### PR TITLE
Makefiles use $(foo), not $foo, for variables

### DIFF
--- a/configure.ml
+++ b/configure.ml
@@ -861,7 +861,7 @@ let config_runtime () =
     sprintf "-dllib -lcoqrun -dllpath '%s/kernel/byterun'" coqtop
   | _ ->
     let ld="CAML_LD_LIBRARY_PATH" in
-    build_loadpath := sprintf "export %s='%s/kernel/byterun':$%s" ld coqtop ld;
+    build_loadpath := sprintf "export %s:='%s/kernel/byterun':$(%s)" ld coqtop ld;
     sprintf "-dllib -lcoqrun -dllpath '%s'" libdir
 
 let coqrunbyteflags = config_runtime ()


### PR DESCRIPTION
Also, we need :=, so that it's evaluated immediately, rather than becoming a self-recursive variable.  This fixes the "Undefined variable 'C'" error that make keeps spewing.
