### PR TITLE
Remove the -fno-defer-pop cflag

### DIFF
--- a/configure.ml
+++ b/configure.ml
@@ -384,7 +384,7 @@ let coq_annotate_flag =
   then if program_in_path "ocamlmerlin" then "-bin-annot" else "-dtypes"
   else ""
 
-let cflags = "-fno-defer-pop -Wall -Wno-unused"
+let cflags = "-Wall -Wno-unused"
 
 
 (** * Architecture *)


### PR DESCRIPTION
According to http://caml.inria.fr/mantis/view.php?id=6346, this flag
causes ocamlc to fail on the latest version of xcode, because clang now
errors on -fno-defer-pop.  According to the same issue, -fno-defer-pop
is required for computed gotos if you're using gcc 1.xx, but not gcc
3.4.0 nor 4.4.7 (nor presumably other reasonably modern versions of
gcc).  I haven't actually tested this, as I don't have a mac, but it's a
relatively small change.
