### PR TITLE
Remove the -fno-defer-pop cflag

### DIFF
--- a/configure
+++ b/configure
@@ -111,7 +111,7 @@ coq_debug_flag_opt=
 coq_profile_flag=
 coq_annotate_flag=
 best_compiler=opt
-cflags="-fno-defer-pop -Wall -Wno-unused"
+cflags="-Wall -Wno-unused"
 natdynlink=yes
 
 local=false


### PR DESCRIPTION
Now for Coq v8.4.  Any chance this can make it into 8.4pl4?

According to http://caml.inria.fr/mantis/view.php?id=6346, this flag
causes ocamlc to fail on the latest version of xcode, because clang now
errors on -fno-defer-pop. According to the same issue, -fno-defer-pop
is required for computed gotos if you're using gcc 1.xx, but not gcc
3.4.0 nor 4.4.7 (nor presumably other reasonably modern versions of
gcc). I haven't actually tested this, as I don't have a mac, but it's a
relatively small change.

This closes pull request #10.
