### PR TITLE
Add test-suite cases for bugs fixed in the past few days

### DIFF
--- a/test-suite/bugs/closed/3037.v
+++ b/test-suite/bugs/closed/3037.v
@@ -1,0 +1,11 @@
+(* Anomaly before 4a8950ec7a0d9f2b216e67e69b446c064590a8e9 *)
+
+Require Import Recdef.
+
+Function f_R (a: nat) {wf (fun x y: nat => False)  a}:Prop:=
+  match a:nat with
+    | 0 => True
+    | (S y') => f_R y'
+  end.
+(* Anomaly: File "plugins/funind/recdef.ml", line 916, characters 13-19: Assertion failed.
+Please report. *)

--- a/test-suite/bugs/closed/3164.v
+++ b/test-suite/bugs/closed/3164.v
@@ -1,0 +1,49 @@
+(* Before 31a69c4d0fd7b8325187e8da697a9c283594047d, [case] would stack overflow *)
+Require Import Arith.
+
+Section Acc_generator.
+  Variable A : Type.
+  Variable R : A -> A -> Prop.
+
+  (* *Lazily* add 2^n - 1 Acc_intro on top of wf.
+     Needed for fast reductions using Function and Program Fixpoint
+     and probably using Fix and Fix_F_2
+   *)
+  Fixpoint Acc_intro_generator n (wf : well_founded R)  :=
+    match n with
+        | O => wf
+        | S n => fun x => Acc_intro x (fun y _ => Acc_intro_generator n (Acc_intro_generator n wf) y)
+    end.
+
+
+End Acc_generator.
+
+Definition pred_F : (forall x : nat,
+        (forall y : nat, y < x -> (fun _ : nat => nat) y) ->
+        (fun _ : nat => nat) x).
+Proof.
+  intros x.
+  simpl.
+  case x.
+  exact (fun _ => 0).
+  intros n h.
+  apply (h n).
+  constructor.
+Defined.
+
+Definition my_pred :=  Fix lt_wf (fun _ => nat) pred_F.
+
+
+Lemma my_pred_is_pred : forall x, match my_pred x with | 0 => True | S n => False end.
+Proof.
+  intros x.
+  case x.
+Abort.
+
+Definition my_pred_bad :=  Fix (Acc_intro_generator _ _ 100 lt_wf) (fun _ => nat) pred_F.
+
+Lemma my_pred_is_pred : forall x, match my_pred_bad x with | 0 => True | S n => False end.
+Proof.
+  intros x.
+  Timeout 2 case x.
+Admitted.

--- a/test-suite/bugs/closed/3217.v
+++ b/test-suite/bugs/closed/3217.v
@@ -1,0 +1,36 @@
+(** [Set Implicit Arguments] causes Coq to run out of memory on [Qed] before c3feef4ed5dec126f1144dec91eee9c0f0522a94 *)
+Set Implicit Arguments.
+
+Variable LEM: forall P : Prop, sumbool P (P -> False).
+
+Definition pmap := option (nat -> option nat).
+
+Definition pmplus (oha ohb: pmap) : pmap :=
+ match oha, ohb with
+ | Some ha, Some hb =>
+   if LEM (oha = ohb) then None else None
+ | _, _ => None
+ end.
+
+Definition pmemp: pmap := Some (fun _ => None).
+
+Lemma foo:
+ True ->
+    (pmplus pmemp
+    (pmplus pmemp
+    (pmplus pmemp
+    (pmplus pmemp
+    (pmplus pmemp
+    (pmplus pmemp
+    (pmplus pmemp
+    (pmplus pmemp
+    (pmplus pmemp
+    (pmplus pmemp
+    (pmplus pmemp
+    (pmplus pmemp
+     pmemp))))))))))))
+    =
+    None -> True.
+Proof.
+  auto.
+Timeout 2 Qed.

--- a/test-suite/bugs/closed/3262.v
+++ b/test-suite/bugs/closed/3262.v
@@ -1,0 +1,78 @@
+(* Not having a [return] clause causes the [refine] at the bottom to stack overflow before f65fa9de8a4c9c12d933188a755b51508bd51921 *)
+
+Require Import Coq.Lists.List.
+Require Import Relations RelationClasses.
+
+Set Implicit Arguments.
+Set Strict Implicit.
+Set Asymmetric Patterns.
+
+Section hlist.
+  Context {iT : Type}.
+  Variable F : iT -> Type.
+
+  Inductive hlist : list iT -> Type :=
+  | Hnil  : hlist nil
+  | Hcons : forall l ls, F l -> hlist ls -> hlist (l :: ls).
+
+  Definition hlist_hd {a b} (hl : hlist (a :: b)) : F a :=
+    match hl in hlist x return match x with
+                                 | nil => unit
+                                 | l :: _ => F l
+                               end with
+      | Hnil => tt
+      | Hcons _ _ x _ => x
+    end.
+
+  Definition hlist_tl {a b} (hl : hlist (a :: b)) : hlist b :=
+    match hl in hlist x return match x with
+                                 | nil => unit
+                                 | _ :: ls => hlist ls
+                               end with
+      | Hnil => tt
+      | Hcons _ _ _ x => x
+    end.
+
+  Lemma hlist_eta : forall ls (h : hlist ls),
+    h = match ls as ls return hlist ls -> hlist ls with
+          | nil => fun _ => Hnil
+          | a :: b => fun h => Hcons (hlist_hd h) (hlist_tl h)
+        end h.
+  Proof.
+    intros. destruct h; auto.
+  Qed.
+
+  Variable eqv : forall x, relation (F x).
+
+  Inductive equiv_hlist : forall ls, hlist ls -> hlist ls -> Prop :=
+  | hlist_eqv_nil : equiv_hlist Hnil Hnil
+  | hlist_eqv_cons : forall l ls x y h1 h2, eqv x y -> equiv_hlist h1 h2 ->
+                                            @equiv_hlist (l :: ls) (Hcons x h1) (Hcons y h2).
+
+  Global Instance Reflexive_equiv_hlist (R : forall t, Reflexive (@eqv t)) ls
+  : Reflexive (@equiv_hlist ls).
+  Proof.
+    red. induction x; constructor; auto. reflexivity.
+  Qed.
+
+  Global Instance Transitive_equiv_hlist (R : forall t, Transitive (@eqv t)) ls
+  : Transitive (@equiv_hlist ls).
+  Proof.
+    red. induction 1.
+    { intro; assumption. }
+    { rewrite (hlist_eta z).
+      Timeout 2 Fail refine
+        (fun H =>
+           match H in @equiv_hlist ls X Y
+                 return
+                 (* Uncommenting the following gives an immediate error in 8.4pl3; commented out results in a stack overflow *)
+                 match ls (*as ls return hlist ls -> hlist ls -> Type*) with
+                   | nil => fun _ _ : hlist nil => True
+                   | l :: ls => fun (X Y : hlist (l :: ls)) =>
+                                  equiv_hlist (Hcons x h1) Y
+                 end X Y
+           with
+             | hlist_eqv_nil => I
+             | hlist_eqv_cons l ls x y h1 h2 pf pf' =>
+               _
+           end).


### PR DESCRIPTION
The only way I could figure to test for "not stack overflow" was `Timeout 2` (or there-abouts); I'm not sure if this is permitted in the test-suite.  I've made a separate commit for each test-suite case, so you can merge some of them without others.

The current state of the test suite is:

```
make[3]: Entering directory `/afs/csail.mit.edu/u/j/jgross/coq/test-suite'
make[3]: Leaving directory `/afs/csail.mit.edu/u/j/jgross/coq/test-suite'
make[2]: Leaving directory `/afs/csail.mit.edu/u/j/jgross/coq/test-suite'
if grep -F 'Error!' test-suite/summary.log ; then false; fi
    success/decl_mode.v...Error! (should be accepted)
    success/proof_using.v...Error! (should be accepted)
    failure/subterm2.v...Error! (should be rejected)
    failure/subterm3.v...Error! (should be rejected)
    bugs/closed/1041.v...Error! (bug seems to be opened, please check)
    bugs/closed/2406.v...Error! (bug seems to be opened, please check)
    bugs/closed/3036.v...Error! (bug seems to be opened, please check)
    bugs/closed/3251.v...Error! (bug seems to be opened, please check)
    output/Errors.v...Error! (unexpected output)
    output/Notations.v...Error! (unexpected output)
    output/simpl.v...Error! (unexpected output)
    stm/Nijmegen_QArithSternBrocot_Zaux.v...Error! (should be accepted)
make[1]: *** [test-suite] Error 1
make[1]: Leaving directory `/afs/csail.mit.edu/u/j/jgross/coq'
make: *** [submake] Error 2
```

and for `validate`:

```
Checking library: Coq.Numbers.Cyclic.DoubleCyclic.DoubleCyclic
  checking cst: Coq.Numbers.Cyclic.DoubleCyclic.DoubleCyclic.lor
  checking cst: Coq.Numbers.Cyclic.DoubleCyclic.DoubleCyclic.land
  checking cst: Coq.Numbers.Cyclic.DoubleCyclic.DoubleCyclic.lxor
  checking cst: Coq.Numbers.Cyclic.DoubleCyclic.DoubleCyclic.mk_zn2z_ops
  checking cst: Coq.Numbers.Cyclic.DoubleCyclic.DoubleCyclic.mk_zn2z_ops_karatsuba
  checking cst: Coq.Numbers.Cyclic.DoubleCyclic.DoubleCyclic.spec_ww_add_mul_div
Type error: CantApplyBadType
make[1]: *** [validate] Error 1
```
