### PR TITLE
Add lia.cache to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ myocamlbuild_config.ml
 config/Makefile
 config/coq_config.ml
 dev/ocamldebug-coq
+lia.cache
 plugins/micromega/csdpcert
 kernel/byterun/dllcoqrun.so
 coqdoc.sty


### PR DESCRIPTION
It is generated if we call `make test-suite` from top-level, I believe.
