### PR TITLE
Add coqc -time to Coq 8.4

### DIFF
--- a/scripts/coqc.ml
+++ b/scripts/coqc.ml
@@ -139,7 +139,7 @@ let parse_args () =
     | "-R" :: s :: "-as" :: [] -> usage ()
     | "-R" :: s :: t :: rem -> parse (cfiles,t::s::"-R"::args) rem
 
-    | ("-notactics"|"-debug"|"-nolib"|"-boot"
+    | ("-notactics"|"-debug"|"-nolib"|"-boot"|"-time"
       |"-batch"|"-nois"|"-noglob"|"-no-glob"
       |"-q"|"-full"|"-profile"|"-just-parsing"|"-echo" |"-unsafe"|"-quiet"
       |"-silent"|"-m"|"-xml"|"-v7"|"-v8"|"-beautify"|"-strict-implicit"

--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -240,6 +240,8 @@ let parse_args arglist =
 
     | "-debug" :: rem -> set_debug (); parse rem
 
+    | "-time" :: rem -> Vernac.time := true; parse rem
+
     | "-compat" :: v :: rem ->
         Flags.compat_version := get_compat_version v; parse rem
     | "-compat" :: []       -> usage ()

--- a/toplevel/usage.ml
+++ b/toplevel/usage.ml
@@ -71,6 +71,7 @@ let print_usage_channel co command =
 \n                         stdout (if unset)\
 \n  -quality               improve the legibility of the proof terms produced by\
 \n                         some tactics\
+\n  -time                  display the time taken by each command\
 \n  -h, --help             print this list of options\
 \n"
 

--- a/toplevel/vernac.mli
+++ b/toplevel/vernac.mli
@@ -44,3 +44,6 @@ val load_vernac : bool -> string -> unit
 (** Compile a vernac file, verbosely or not (f is assumed without .v suffix) *)
 
 val compile : bool -> string -> unit
+
+(** Should we display timings for each command ? *)
+val time : bool ref


### PR DESCRIPTION
This cherry-picks the commit that adds -time.  I have tested this, and it compiles and works as expected.

This would be very useful to me while waiting for 8.5 to come out (or on various projects that won't upgrade to 8.4 for a while) to run my bug-finder code more effectively and quickly, as well as to make timing annotations on files.
