### PR TITLE
Add an is_cofix tactic

### DIFF
--- a/tactics/extratactics.ml4
+++ b/tactics/extratactics.ml4
@@ -831,6 +831,13 @@ TACTIC EXTEND is_fix
     | _ -> Tacticals.New.tclFAIL 0 (Pp.str "not a fix definition") ]
 END;;
 
+TACTIC EXTEND is_cofix
+| [ "is_cofix" constr(x) ] ->
+  [ match kind_of_term x with
+    | CoFix _ -> Proofview.tclUNIT ()
+    | _ -> Tacticals.New.tclFAIL 0 (Pp.str "not a cofix definition") ]
+END;;
+
 (* Command to grab the evars left unresolved at the end of a proof. *)
 (* spiwack: I put it in extratactics because it is somewhat tied with
    the semantics of the LCF-style tactics, hence with the classic tactic


### PR DESCRIPTION
Should we also add is_\* tactics for other things?  is_rel, is_meta,
is_sort, is_cast, is_prod, is_lambda, is_letin, is_app, is_const,
is_ind, is_constructor, is_case, is_proj?

If you prefer patches that don't remove trailing spaces, I can edit this patch to do that.
