### PR TITLE
Make coqdep find Require commands prefixed by Time

### DIFF
--- a/tools/coqdep_common.ml
+++ b/tools/coqdep_common.ml
@@ -128,7 +128,7 @@ let error_cannot_parse s (i,j) =
 
 let warning_module_notfound f s =
   eprintf "*** Warning: in file %s, library " f;
-  eprintf "%s.v is required and has not been found in loadpath!\n"
+  eprintf "%s.v is required and has not been found in the loadpath!\n"
     (String.concat "." s);
   flush stderr
 

--- a/tools/coqdep_lexer.mll
+++ b/tools/coqdep_lexer.mll
@@ -90,6 +90,8 @@ rule coq_action = parse
       { load_file lexbuf }
   | "Add" space+ "LoadPath" space+
       { add_loadpath lexbuf }
+  | "Time" space+
+      { coq_action lexbuf }
   | space+
       { coq_action lexbuf }
   | "(*"

--- a/tools/coqdep_lexer.mll
+++ b/tools/coqdep_lexer.mll
@@ -50,6 +50,9 @@
   let syntax_error lexbuf =
     raise (Syntax_error (Lexing.lexeme_start lexbuf, Lexing.lexeme_end lexbuf))
 
+  (** This is the prefix that should be pre-prepended to files due to the use
+   ** of [From], i.e. [From Xxx... Require ...]
+   **)
   let from_pre_ident = ref None
 }
 


### PR DESCRIPTION
When running some tests timing import commands I noticed that coqdep does not notice Require commands when they are timed, i.e.

```
Require Foo.
```

is found but

```
Time Require Foo.
```

is not. This very simple patch, fixes this problem.
