### PR TITLE
Add some more entries to .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -12,12 +12,15 @@
 Bruno Barras <bruno.barras@inria.fr>               barras <barras@85f007b7-540e-0410-9357-904b9bb8a0f7>
 Bruno Barras <bruno.barras@inria.fr>               barras-local <barras-local@85f007b7-540e-0410-9357-904b9bb8a0f7>
 Yves Bertot <bertot@gforge>                        bertot <bertot@85f007b7-540e-0410-9357-904b9bb8a0f7>
+Yves Bertot <bertot@gforge>                        Yves Bertot <bertot@inria.fr>
 Frédéric Besson <frederic.besson@inria.fr>         fbesson <fbesson@85f007b7-540e-0410-9357-904b9bb8a0f7>
 Pierre Boutillier <pierre.boutillier@ens-lyon.org> pboutill <pboutill@85f007b7-540e-0410-9357-904b9bb8a0f7>
 Pierre Boutillier <pierre.boutillier@ens-lyon.org> Pierre <pierre.boutillier@ens-lyon.org>
+Pierre Boutillier <pierre.boutillier@ens-lyon.org> Pierre Boutillier <pierre.boutillier@pps.univ-paris-diderot.fr>
 Xavier Clerc <xavier.clerc@inria.fr>               xclerc <xclerc@85f007b7-540e-0410-9357-904b9bb8a0f7>
 Xavier Clerc <xavier.clerc@inria.fr>               xclerc <xavier.clerc@inria.fr>
 Pierre Corbineau <corbinea@gforge>                 corbinea <corbinea@85f007b7-540e-0410-9357-904b9bb8a0f7>
+Pierre Corbineau <corbinea@gforge>                 Pierre Courtieu <pierre.courtieu@cnam.fr>
 Judicaël Courant <courant@gforge>                  courant <courant@85f007b7-540e-0410-9357-904b9bb8a0f7>
 Pierre Courtieu <Pierre.Courtieu@cnam.fr>          courtieu <courtieu@85f007b7-540e-0410-9357-904b9bb8a0f7>
 # uncapitalises the email address:
@@ -30,6 +33,7 @@ Damien Doligez <doligez@gforge>                    doligez <doligez@85f007b7-540
 Jean-Christophe Filliâtre <filliatr@gforge>        filliatr <filliatr@85f007b7-540e-0410-9357-904b9bb8a0f7>
 Julien Forest <julien.forest@ensiie.fr>            jforest <jforest@85f007b7-540e-0410-9357-904b9bb8a0f7>
 Julien Forest <julien.forest@ensiie.fr>            forest <jforest@mourvedre.ensiie.fr>
+Julien Forest <julien.forest@ensiie.fr>            jforest <jforest@thune>
 Stéphane Glondu <steph@glondu.net>                 glondu <glondu@85f007b7-540e-0410-9357-904b9bb8a0f7>
 # corrects accent:
 Stéphane Glondu <steph@glondu.net>                 Stephane Glondu <steph@glondu.net>
@@ -47,6 +51,7 @@ Florent Kirchner <fkirchne@gforge>                 kirchner <kirchner@85f007b7-5
 Pierre Letouzey <pierre.letouzey@inria.fr>         letouzey <letouzey@85f007b7-540e-0410-9357-904b9bb8a0f7>
 Assia Mahboubi <amahboub@gforge>                   amahboub <amahboub@85f007b7-540e-0410-9357-904b9bb8a0f7>
 Evgeny Makarov <emakarov@gforge>                   emakarov <emakarov@85f007b7-540e-0410-9357-904b9bb8a0f7>
+Gregory Malecha <gmalecha@eecs.harvard.edu>        Gregory Malecha <gmalecha@cs.harvard.edu>
 Lionel Elie Mamane <lmamane@gforge>                lmamane <lmamane@85f007b7-540e-0410-9357-904b9bb8a0f7>
 Claude Marché <marche@gforge>                      marche <marche@85f007b7-540e-0410-9357-904b9bb8a0f7>
 Micaela Mayero <mayero@gforge>                     mayero <mayero@85f007b7-540e-0410-9357-904b9bb8a0f7>
@@ -69,8 +74,12 @@ Claudio Sacerdoti Coen <sacerdot@gforge>           sacerdot <sacerdot@85f007b7-5
 Vincent Siles <vsiles@gforge>                      vsiles <vsiles@85f007b7-540e-0410-9357-904b9bb8a0f7>
 Elie Soubiran <soubiran@gforge>                    soubiran <soubiran@85f007b7-540e-0410-9357-904b9bb8a0f7>
 Matthieu Sozeau <mattam@mattam.org>                msozeau <msozeau@85f007b7-540e-0410-9357-904b9bb8a0f7>
+Matthieu Sozeau <mattam@mattam.org>                Matthieu Sozeau <matthieu.sozeau@inria.fr>
 Arnaud Spiwack <arnaud@spiwack.net>                aspiwack <aspiwack@85f007b7-540e-0410-9357-904b9bb8a0f7>
 Enrico Tassi <Enrico.Tassi@inria.fr>               gareuselesinge <gareuselesinge@85f007b7-540e-0410-9357-904b9bb8a0f7>
+# uncapitalizes the email address
+Enrico Tassi <Enrico.Tassi@inria.fr>               Enrico Tassi <Enrico.Tassi@inria.fr>
+Enrico Tassi <Enrico.Tassi@inria.fr>               Enrico Tassi <gares@fettunta.org>
 Laurent Théry <thery@gforge>                       thery <thery@85f007b7-540e-0410-9357-904b9bb8a0f7>
 Benjamin Werner <werner@gforge>                    werner <werner@85f007b7-540e-0410-9357-904b9bb8a0f7>
 


### PR DESCRIPTION
Most of these are deduplicating more email addresses of people already in .mailmap.  The exception is that I've added @gmalecha, and chose which of his two addresses to use by which I had more emails from (both have 1 commit in the repo).
