### PR TITLE
Add tactics [test] and [not]

### DIFF
--- a/test-suite/success/ltac_init_tactics_not.v
+++ b/test-suite/success/ltac_init_tactics_not.v
@@ -1,0 +1,21 @@
+Require Import Coq.Init.Tactics.
+
+Goal Set.
+Proof.
+  not fail.
+  not not idtac.
+  not fail 0.
+  not fail 1.
+  not fail 2.
+  (** Would be nice if we could get [not fail 3] to pass *)
+  try ((not fail 3); fail 1).
+  not not admit.
+  not not test admit.
+  not progress test admit.
+  (* test grouping *)
+  not (not idtac; fail).
+  assert True.
+  all:not fail.
+  2:not fail.
+  all:admit.
+Defined.

--- a/test-suite/success/ltac_init_tactics_test.v
+++ b/test-suite/success/ltac_init_tactics_test.v
@@ -1,0 +1,25 @@
+Require Import Coq.Init.Tactics.
+
+Goal Set.
+Proof.
+  test idtac.
+  test try fail.
+  test admit.
+  test match goal with |- Set => idtac end.
+  test (idtac; match goal with |- Set => idtac end).
+  (* test grouping *)
+  first [ (test idtac; fail); fail 1 | idtac ].
+  try test fail.
+  try test test fail.
+  test test idtac.
+  test test admit.
+  Fail test fail.
+  test (idtac; []).
+  test (assert True; [|]).
+  try ((test fail 1); fail 1).
+  assert True.
+  all:test idtac.
+  all:test admit.
+  2:test admit.
+  all:admit.
+Defined.

--- a/theories/Init/Tactics.v
+++ b/theories/Init/Tactics.v
@@ -240,3 +240,13 @@ Tactic Notation "clear" "dependent" hyp(h) :=
 
 Tactic Notation "revert" "dependent" hyp(h) :=
  generalize dependent h.
+
+(** Test if a tactic succeeds, but always roll-back the results. *)
+Ltac pre_test tac :=
+  try (first [ tac | fail 2 tac "does not succeed" ]; fail tac "succeeds"; [](* test for [t] solved all goals *)).
+(* We must handle level 1 failure separately. *)
+Tactic Notation "test" tactic3(tac) :=
+  pre_test tac; pre_test ltac:(try tac).
+
+(** [not tac] is equivalent to [fail tac "succeeds"] if [tac] succeeds, and is equivalent to [idtac] if [tac] fails at levels 0, 1, or 2. *)
+Tactic Notation "not" tactic3(tac) := try ((test tac); fail 1 tac "succeeds").


### PR DESCRIPTION
These are generally useful low-level tactics for doing tests in ltac,
which seem like they might be useful in the standard library.

I don't know how they fare with regard to multi-goal tactic invocations,
because I don't know the syntax for that.  (There should probably be
backwards compatibility checks in the test-suite, though.)

Are there simpler ways to code these tactics that pass all the tests I
gave?  Should these actually be coded in ml?
