### PR TITLE
Bug fix (coq_makefile): Adding unix.cma and threads.cma dependencies for...

### DIFF
--- a/tools/coq_makefile.ml
+++ b/tools/coq_makefile.ml
@@ -454,11 +454,11 @@ let variables is_install opt (args,defs) =
     print "CAMLOPTLINK?=$(OCAMLOPT) -rectypes -thread\n";
     print "GRAMMARS?=grammar.cma\n";
     print "ifeq ($(CAMLP4),camlp5)
-CAMLP4EXTEND=pa_extend.cmo q_MLast.cmo pa_macro.cmo
+CAMLP4EXTEND=pa_extend.cmo q_MLast.cmo pa_macro.cmo unix.cma threads.cma
 else
 CAMLP4EXTEND=
 endif\n";
-    print "PP?=-pp '$(CAMLP4O) -I $(CAMLLIB) $(COQSRCLIBS) compat5.cmo \\
+    print "PP?=-pp '$(CAMLP4O) -I $(CAMLLIB) -I $(CAMLLIB)threads/ $(COQSRCLIBS) compat5.cmo \\
   $(CAMLP4EXTEND) $(GRAMMARS) $(CAMLP4OPTIONS) -impl'\n\n";
     end;
     match is_install with


### PR DESCRIPTION
... grammar in campl4

The calls to camlp4 generated by coq_makefile where bugged since grammar.cma depends on threads.
This should fix it. 

I had to add the option "-I $(CAMLLIB)threads/" to the loadpath of camlp4 (of course it relies on the "unix" threads to be present in ocaml distribution). It should work for windows too, but I haven't checked it. 
