### PR TITLE
Fixing the rule for ml4 depencies in coq_makefile

### DIFF
--- a/tools/coq_makefile.ml
+++ b/tools/coq_makefile.ml
@@ -366,7 +366,7 @@ let implicit () =
     print "$(filter-out $(addsuffix .cmx,$(foreach lib,$(MLPACKFILES:.mlpack=_MLPACK_DEPENDENCIES),$($(lib)))),$(ML4FILES:.ml4=.cmx)): %.cmx: %.ml4\n";
     print "\t$(CAMLOPTC) $(ZDEBUG) $(ZFLAGS) $(PP) -impl $<\n\n";
     print "$(addsuffix .d,$(ML4FILES)): %.ml4.d: %.ml4\n";
-    print "\t$(COQDEP) $(OCAMLLIBS) \"$<\" > \"$@\" || ( RV=$$?; rm -f \"$@\"; exit $${RV} )\n\n" in
+    print "\t$(OCAMLDEP) -slash $(OCAMLLIBS) $(PP) -impl \"$<\" > \"$@\" || ( RV=$$?; rm -f \"$@\"; exit $${RV} )\n\n" in
   let ml_rules () =
     print "$(MLFILES:.ml=.cmo): %.cmo: %.ml\n\t$(CAMLC) $(ZDEBUG) $(ZFLAGS) $<\n\n";
     print "$(filter-out $(addsuffix .cmx,$(foreach lib,$(MLPACKFILES:.mlpack=_MLPACK_DEPENDENCIES),$($(lib)))),$(MLFILES:.ml=.cmx)): %.cmx: %.ml\n";


### PR DESCRIPTION
Hello ! 

The tool coq_makefile generates the wrong generic rule to generate dependencies for ml4 files. 

To understand, here is the rule compiling ml4 files : 

``` Makefile
$(ML4FILES:.ml4=.cmo): %.cmo: %.ml4
    $(CAMLC) $(ZDEBUG) $(ZFLAGS) $(PP) -impl $<
```

It does not generate the ml file, but it directly calls the caml compiler with the PP directive to pre-process the file. 
That's why the dependencies induced by ML4 files should be obtained using ocamldep and not coqdep (which could be used to generate the dependencies for processing the ML file but not compiling the CMO). 
That's why I propose to replace : 

``` Makefile
$(addsuffix .d,$(ML4FILES)): %.ml4.d: %.ml4
    $(COQDEP) $(OCAMLLIBS) "$<" > "$@" || ( RV=$$?; rm -f "$@"; exit $${RV} )
```

with: 

``` Makefile
$(addsuffix .d,$(ML4FILES)): %.ml4.d: %.ml4
    $(OCAMLDEP) -slash $(OCAMLLIBS) $(PP) -impl "$<" > "$@" || ( RV=$$?; rm -f "$@"; exit $${RV} )
```
