### PR TITLE
search: Add a minimal search option

### DIFF
--- a/doc/refman/RefMan-oth.tex
+++ b/doc/refman/RefMan-oth.tex
@@ -910,6 +910,14 @@ This command turns off the normal displaying.
 \subsection[\tt Unset Silent.]{\tt Unset Silent.\optindex{Silent}}
 This command turns the normal display on.
 
+\subsection[\tt Set Search Output Name Only.]{\tt Set Search Output Name Only.\optindex{Search Output Name Only}
+\label{Search-Output-Name-Only}
+\index{Search Output Name Only mode}}
+This command restricts the output of search commands to identifier names; turning it on causes invocations of {\tt Search}, {\tt SearchHead}, {\tt SearchPattern}, {\tt SearchRewrite} etc. to omit types from their output, printing only identifiers.
+
+\subsection[\tt Unset Search Output Name Only.]{\tt Unset Search Output Name Only.\optindex{Search Output Name Only}}
+This command turns type display in search results back on.
+
 \subsection[\tt Set Printing Width {\integer}.]{\tt Set Printing Width {\integer}.\optindex{Printing Width}}
 \label{SetPrintingWidth}
 This command sets which left-aligned part of the width of the screen


### PR DESCRIPTION
This patch adds a `Search Minimal` option. When set, search results only display symbol names, instead of displaying full terms. This is useful when the list of symbols is needed by an external program. I'm using this in particular for my company-coq emacs package (https://github.com/cpitclaudel/company-coq/), where being able to list all symbols efficiently makes it possible to dynamically autocomplete symbol names.

Some numbers:

The output of `SearchPattern _` half as many lines, 8 times less bytes, and 20 times less words when this option is on: 

``` bash
$ ./bin/coqtop -coqlib ./ <<< "SearchPattern _." 2>/dev/null | wc
    714    7365   28693
$ ./bin/coqtop -coqlib ./ <<< "Set Search Minimal. SearchPattern _." 2>/dev/null | wc
    360     364    3602
```

With large libraries loaded the reduction closer to 3 times for lines,  and 5 to 10 times for bytes :

``` bash
$ ./bin/coqtop -coqlib ./ <<< "Require Import OrdersEx. SearchPattern _." 2>/dev/null | wc
  43971  262321 1801983
$ ./bin/coqtop -coqlib ./ <<< "Require Import OrdersEx. Set Search Minimal. SearchPattern _." 2>/dev/null | wc
  14683   14692  334129

$ ./bin/coqtop -coqlib ./ <<< "Require Import ArithRing. SearchPattern _." 2>/dev/null | wc
  20747  136161  860109
$ ./bin/coqtop -coqlib ./ <<< "Require Import ArithRing. Set Search Minimal. SearchPattern _." 2>/dev/null | wc
   6593    6612  142432
```

Search results are also much easier to parse with this patch, making the total speed gains even more significant. Some numbers (after loading `OrdersEx`)

```
Without [Search Minimal]: Loaded 2956 symbols (0.722 seconds)
With [Search Minimal]:    Loaded 2965 symbols (0.047 seconds)
Speedup:                  15.4
```

The patch does not change anything when the option is off.
