### PR TITLE
Fix specialized extraction of [ascii] characters into Haskell [Char]s

### DIFF
--- a/plugins/extraction/common.ml
+++ b/plugins/extraction/common.ml
@@ -628,7 +628,7 @@ let check_extract_ascii () =
   try
     let char_type = match lang () with
       | Ocaml -> "char"
-      | Haskell -> "Char"
+      | Haskell -> "Prelude.Char"
       | _ -> raise Not_found
     in
     String.equal (find_custom (IndRef (ind_ascii, 0))) (char_type)


### PR DESCRIPTION
The extraction machinery has specialized support for extracting [ascii]
characters into native characters in the target language, as opposed
to using an explicit constructor from 8 boolean bits.  This works by
hard-coding the name of the character type in the target language.
Unfortunately, the hard-coded type for Haskell was "Char", not the
fully-qualified "Prelude.Char".  As a result, it was impossible to
extract characters into Haskell without getting type errors about "Char".
This patch changes this hard-coded name to "Prelude.Char".
