### PR TITLE
Add a [Print Ltacs] vernacular

### DIFF
--- a/doc/refman/RefMan-ltac.tex
+++ b/doc/refman/RefMan-ltac.tex
@@ -1091,6 +1091,8 @@ Defined {\ltac} functions can be displayed using the command
 {\tt Print Ltac {\qualid}.}
 \end{quote}
 
+The command {\tt Print Ltac Signatures\comindex{Print Ltac Signatures}} displays a list of all user-defined tactics, with their arguments.
+
 \section{Debugging {\ltac} tactics}
 
 \subsection[Info trace]{Info trace\comindex{Info}\optindex{Info Level}}

--- a/intf/vernacexpr.mli
+++ b/intf/vernacexpr.mli
@@ -62,6 +62,7 @@ type printable =
   | PrintTypeClasses
   | PrintInstances of reference or_by_notation
   | PrintLtac of reference
+  | PrintLtacSignatures
   | PrintCoercions
   | PrintCoercionPaths of class_rawexpr * class_rawexpr
   | PrintCanonicalConversions

--- a/library/nametab.ml
+++ b/library/nametab.ml
@@ -71,6 +71,7 @@ module type NAMETREE = sig
   val push : visibility -> user_name -> elt -> t -> t
   val locate : qualid -> t -> elt
   val find : user_name -> t -> elt
+  val elements : t -> elt list
   val exists : user_name -> t -> bool
   val user_name : qualid -> t -> user_name
   val shortest_qualid : Id.Set.t -> user_name -> t -> qualid
@@ -192,6 +193,13 @@ let rec search tree = function
 let find_node qid tab =
   let (dir,id) = repr_qualid qid in
     search (Id.Map.find id tab) (DirPath.repr dir)
+
+let elements tab =
+  let f k v acc =
+    match v.path with
+    | Absolute (_, o) | Relative (_, o) -> o :: acc
+    | Nothing                           -> acc
+  in Id.Map.fold_right f tab []
 
 let locate qid tab =
   let o = match find_node qid tab with
@@ -402,6 +410,8 @@ let locate_modtype qid = MPTab.locate qid !the_modtypetab
 let full_name_modtype qid = MPTab.user_name qid !the_modtypetab
 
 let locate_tactic qid = KnTab.locate qid !the_tactictab
+
+let all_tactics () = KnTab.elements !the_tactictab
 
 let locate_dir qid = DirTab.locate qid !the_dirtab
 

--- a/library/nametab.mli
+++ b/library/nametab.mli
@@ -98,6 +98,7 @@ val locate_dir : qualid -> global_dir_reference
 val locate_module : qualid -> module_path
 val locate_section : qualid -> DirPath.t
 val locate_tactic : qualid -> ltac_constant
+val all_tactics : unit -> ltac_constant list
 
 (** These functions globalize user-level references into global
    references, like [locate] and co, but raise a nice error message

--- a/parsing/g_vernac.ml4
+++ b/parsing/g_vernac.ml4
@@ -908,6 +908,7 @@ GEXTEND Gram
       | IDENT "TypeClasses" -> PrintTypeClasses
       | IDENT "Instances"; qid = smart_global -> PrintInstances qid
       | IDENT "Ltac"; qid = global -> PrintLtac qid
+      | IDENT "Ltac"; IDENT "Signatures" -> PrintLtacSignatures
       | IDENT "Coercions" -> PrintCoercions
       | IDENT "Coercion"; IDENT "Paths"; s = class_rawexpr; t = class_rawexpr
          -> PrintCoercionPaths (s,t)

--- a/printing/ppvernac.ml
+++ b/printing/ppvernac.ml
@@ -460,6 +460,8 @@ module Make
         keyword "Print Instances" ++ spc () ++ pr_smart_global qid
       | PrintLtac qid ->
         keyword "Print Ltac" ++ spc() ++ pr_ltac_ref qid
+      | PrintLtacSignatures  ->
+        keyword "Print Ltac Signatures"
       | PrintCoercions ->
         keyword "Print Coercions"
       | PrintCoercionPaths (s,t) ->

--- a/tactics/tacintern.ml
+++ b/tactics/tacintern.ml
@@ -832,6 +832,13 @@ let print_ltac id =
    errorlabstrm "print_ltac"
     (pr_qualid id ++ spc() ++ str "is not a user defined tactic.")
 
+let print_ltac_signatures () =
+  let tacs = Nametab.all_tactics () in
+  let print_one tac =
+    let l,t = split_ltac_fun (Tacenv.interp_ltac tac) in
+    hov 2 (pr_qualid (Nametab.shortest_qualid_of_tactic tac) ++ prlist pr_ltac_fun_arg l) in
+  prlist_with_sep fnl print_one tacs
+
 (** Registering *)
 
 let lift intern = (); fun ist x -> (ist, intern ist x)

--- a/tactics/tacintern.mli
+++ b/tactics/tacintern.mli
@@ -55,6 +55,7 @@ val intern_genarg : glob_sign -> raw_generic_argument -> glob_generic_argument
 
 (** printing *)
 val print_ltac : Libnames.qualid -> std_ppcmds
+val print_ltac_signatures : unit -> std_ppcmds
 
 (** Reduction expressions *)
 

--- a/toplevel/vernacentries.ml
+++ b/toplevel/vernacentries.ml
@@ -1623,6 +1623,7 @@ let vernac_print = function
   | PrintTypeClasses -> msg_notice (Prettyp.print_typeclasses())
   | PrintInstances c -> msg_notice (Prettyp.print_instances (smart_global c))
   | PrintLtac qid -> msg_notice (Tacintern.print_ltac (snd (qualid_of_reference qid)))
+  | PrintLtacSignatures -> msg_notice (Tacintern.print_ltac_signatures ())
   | PrintCoercions -> msg_notice (Prettyp.print_coercions())
   | PrintCoercionPaths (cls,clt) ->
       msg_notice (Prettyp.print_path_between (cl_of_qualid cls) (cl_of_qualid clt))


### PR DESCRIPTION
I quickly mentioned this in the last Coq GT; there does not seem to be a way to print out the signature of all defined tactics. Such a feature would be very convenient in the context of IDEs.

This patch adds a `Print Ltacs` vernacular, which prints out the name and signature of all tactics found in `the_tactictab` in the `Nametab` module. In a clean environment, it looks like this (wrapped for space):

``` bash
$ bin/coqtop -coqlib . <<< "Print Ltacs." 2>/dev/null | tail -n +2 | column -c 120
absurd _0                       eauto                           is_cofix _0
absurd_hyp H                    econstructor                    is_evar _0
admit                           ediscriminate                   is_fix _0
assumption                      eexact _0                       is_ground _0
auto                            einjection                      is_var _0
autounfold_one                  eleft                           lapply _0
autounfoldify _0                elimtype _0                     left
bapply lemma todo               eright                          not_evar _0
case_eq x                       esimplify_eq                    now_show
casetype _0                     esplit                          c
cofix                           etransitivity                   red
compare _0 _1                   exact_no_check _0               reflexivity
compute                         exfalso                         revgoals
congruence                      f_equal                         right
constr_eq _0 _1                 fail                            setoid_etransitivity
constr_eq_nounivs _0 _1         false_hyp H G                   setoid_reflexivity
constructor                     fauto                           setoid_symmetry
contradict H                    find_equiv H                    shelve
contradiction                   firstorder                      shelve_unifiable
convert_concl_no_check _0       fresh                           simpl
cut _0                          gintuition                      simplify_eq
destauto                        give_up                         split
destr_eq H                      has_evar _0                     subst
destruct_all                    hnf                             swap H
t                               idtac                           symmetry
dintuition                      info_eauto                      tauto
discriminate                    injection                       transitivity _0
dtauto                          instantiate                     trivial
eassumption                     intro                           vm_cast_no_check
easy                            intros                          _0
easy'                           intuition
```

This draft implementation is pretty straightforward (I just had to extend `NAMETREE` to add an `elements` function). There are a few problems and limitations:
- When long arguments do not fit on one line, they are pushed to the next line. Is there a way to avoid the automatic line breaking?
- It only prints user-defined tactics (this is consistent with `Print Ltac [blah]`, but this means tactic notations are not listed). Tactics like `instantiate` or `setoid_symmetry` appear, but they seem to just be user-level aliases of plugins:
  
  ``` bash
  $ bin/coqtop -coqlib . <<< "Print Ltac instantiate."
  Coq < Ltac instantiate := instantiate
  ```
- It's not clear that `Print Ltacs` is the right name for this (it was inspired by `Print Coercions`). The feature could leave in the `Search` namespace, but there's not much more to search for than tactic names, so I'm not sure how useful it would be.
- It's not clear (to me) that Nametab is the right way to look for these things; maybe it is not?

Regardless, the prototype works well, and it could open opportunities for really neat in-IDE completion! (if the `Search Output Name Only` patch gets merged, tactics completion will be only type of completion still missing from `company-coq`).
