### PR TITLE
The "on_last_hyp" tactic now behaves as it should.

### DIFF
--- a/theories/Program/Tactics.v
+++ b/theories/Program/Tactics.v
@@ -41,7 +41,7 @@ Ltac do_nat n tac :=
 (** Do something on the last hypothesis, or fail *)
 
 Ltac on_last_hyp tac :=
-  match goal with [ H : _ |- _ ] => first [ tac H | fail 1 ] end.
+  lazymatch goal with [ H : _ |- _ ] => tac H end.
 
 (** Destructs one pair, without care regarding naming. *)
 


### PR DESCRIPTION
The behavior of "on_last_hyp" was to execute "tac" on the first hypothesis on which it doesn't fail. Instead, it should fail if it cannot apply to the first hypothesis found. 
