### PR TITLE
Add configurable shortcuts for user queries to CoqIDE.

### DIFF
--- a/ide/coqide.ml
+++ b/ide/coqide.ml
@@ -973,7 +973,7 @@ let template_item (text, offset, len, key) =
 (** Create menu items for pairs (query, shortcut key).
     If the shortcut key is not in the range 'a'-'z','A'-'Z', it will be ignored.  *)
 
-let user_queries_items menu_name item_name l modifier =
+let user_queries_items menu_name item_name l =
   let valid_key k = Int.equal (CString.length k) 1 && Util.is_letter k.[0] in
   let mk_item (query, key) =
     let query' =
@@ -983,7 +983,7 @@ let user_queries_items menu_name item_name l modifier =
       else query ^ "."
     in
     let callback = Query.simplequery query' in
-    let accel = if valid_key key then Some (modifier^key) else None in
+    let accel = if valid_key key then Some (prefs.modifier_for_queries^key) else None in
     item (item_name^" "^(no_under query)) ~label:query ?accel ~callback menu_name
   in
   List.iter mk_item l
@@ -1194,17 +1194,21 @@ let build_ui () =
   ];
   alpha_items templates_menu "Template" Coq_commands.commands;
 
-  let qitem s accel = item s ~label:("_"^s) ?accel ~callback:(Query.query s) in
+  let qitem s sc =
+    item s ~label:("_"^s)
+      ~accel:(prefs.modifier_for_queries^sc)
+      ~callback:(Query.query s)
+  in
   menu queries_menu [
     item "Queries" ~label:"_Queries";
-    qitem "Search" (Some "<Ctrl><Shift>K");
-    qitem "Check" (Some "<Ctrl><Shift>C");
-    qitem "Print" (Some "<Ctrl><Shift>P");
-    qitem "About" (Some "<Ctrl><Shift>A");
-    qitem "Locate" (Some "<Ctrl><Shift>L");
-    qitem "Print Assumptions" (Some "<Ctrl><Shift>N");
+    qitem "Search" "K";
+    qitem "Check" "C";
+    qitem "Print" "P";
+    qitem "About" "A";
+    qitem "Locate" "L";
+    qitem "Print Assumptions" "N";
   ];
-  user_queries_items queries_menu "Query" prefs.user_queries "<Ctrl><Shift>";
+  user_queries_items queries_menu "Query" prefs.user_queries;
 
   menu tools_menu [
     item "Tools" ~label:"_Tools";

--- a/ide/coqide.ml
+++ b/ide/coqide.ml
@@ -696,8 +696,6 @@ let otherquery command = cb_on_current_term (otherquery command)
 let query command _ =
   if command = "Search" || command = "SearchAbout"
   then searchabout ()
-  else if command = "Show Proof"
-  then showproof ()
   else otherquery command ()
 
 let simplequery query = cb_on_current_term (doquery query)

--- a/ide/coqide.ml
+++ b/ide/coqide.ml
@@ -681,18 +681,27 @@ let searchabout sn =
 
 let searchabout () = on_current_term searchabout
 
+let doquery query sn =
+  sn.messages#clear;
+  Coq.try_grab sn.coqtop (sn.coqops#raw_coq_query query) ignore
+
+let showproof () =
+  let query = "Show Proof." in
+  on_current_term (doquery query)
+
 let otherquery command sn =
   let word = get_current_word sn in
   if word <> "" then
     let query = command ^ " " ^ word ^ "." in
-    sn.messages#clear;
-    Coq.try_grab sn.coqtop (sn.coqops#raw_coq_query query) ignore
+    doquery query sn
 
 let otherquery command = cb_on_current_term (otherquery command)
 
 let query command _ =
   if command = "Search" || command = "SearchAbout"
   then searchabout ()
+  else if command = "Show Proof"
+  then showproof ()
   else otherquery command ()
 
 end
@@ -1180,6 +1189,7 @@ let build_ui () =
     qitem "About" (Some "<Ctrl><Shift>A");
     qitem "Locate" (Some "<Ctrl><Shift>L");
     qitem "Print Assumptions" (Some "<Ctrl><Shift>N");
+    qitem "Show Proof" (Some "<Ctrl><Shift>R");
   ];
 
   menu tools_menu [

--- a/ide/coqide.ml
+++ b/ide/coqide.ml
@@ -1203,7 +1203,6 @@ let build_ui () =
     qitem "About" (Some "<Ctrl><Shift>A");
     qitem "Locate" (Some "<Ctrl><Shift>L");
     qitem "Print Assumptions" (Some "<Ctrl><Shift>N");
-    qitem "Show Proof" (Some "<Ctrl><Shift>R");
   ];
   user_queries_items queries_menu "Query" prefs.user_queries "<Ctrl><Shift>";
 

--- a/ide/coqide_ui.ml
+++ b/ide/coqide_ui.ml
@@ -119,6 +119,7 @@ let init () =
     <menuitem action='About' />
     <menuitem action='Locate' />
     <menuitem action='Print Assumptions' />
+    <menuitem action='Show Proof' />
   </menu>
   <menu name='Tools' action='Tools'>
     <menuitem action='Comment' />

--- a/ide/coqide_ui.ml
+++ b/ide/coqide_ui.ml
@@ -18,6 +18,15 @@ let list_items menu li =
   let () = List.iter (fun b -> Buffer.add_buffer res_buf (tactic_item b)) li in
   res_buf
 
+let list_queries menu li =
+  let res_buf = Buffer.create 500 in
+  let query_item (q, _) =
+    let s = "<menuitem action='"^menu^" "^(no_under q)^"' />\n" in
+    Buffer.add_string res_buf s
+  in
+  let () = List.iter query_item li in
+  res_buf
+
 let init () =
   let theui = Printf.sprintf "<ui>
 <menubar name='CoqIde MenuBar'>
@@ -119,7 +128,8 @@ let init () =
     <menuitem action='About' />
     <menuitem action='Locate' />
     <menuitem action='Print Assumptions' />
-    <menuitem action='Show Proof' />
+    <separator />
+    %s
   </menu>
   <menu name='Tools' action='Tools'>
     <menuitem action='Comment' />
@@ -163,5 +173,6 @@ let init () =
     (if Coq_config.gtk_platform <> `QUARTZ then "<menuitem action='Quit' />" else "")
     (Buffer.contents (list_items "Tactic" Coq_commands.tactics))
     (Buffer.contents (list_items "Template" Coq_commands.commands))
+    (Buffer.contents (list_queries "Query" Preferences.current.user_queries))
  in
   ignore (ui_m#add_ui_from_string theui);

--- a/ide/coqide_ui.ml
+++ b/ide/coqide_ui.ml
@@ -173,6 +173,6 @@ let init () =
     (if Coq_config.gtk_platform <> `QUARTZ then "<menuitem action='Quit' />" else "")
     (Buffer.contents (list_items "Tactic" Coq_commands.tactics))
     (Buffer.contents (list_items "Template" Coq_commands.commands))
-    (Buffer.contents (list_queries "Query" Preferences.current.user_queries))
+    (Buffer.contents (list_queries "Query" Preferences.current.Preferences.user_queries))
  in
   ignore (ui_m#add_ui_from_string theui);

--- a/ide/preferences.ml
+++ b/ide/preferences.ml
@@ -847,8 +847,13 @@ let configure ?(apply=(fun () -> ())) () =
               vertical_tabs;opposite_tabs] in
 
   let edit_user_query (q, k) =
-    let q = Configwin_ihm.edit_string "User query" q in
-    let k = Configwin_ihm.edit_string "Shortcut key" k in
+    let input_string l s v =
+      match GToolbox.input_string ~title:l ~text:s v with
+      | None -> s
+      | Some s -> s
+    in
+    let q = input_string "User query" q "Your query" in
+    let k = input_string "Shortcut key" k "Shortcut (a single letter)" in
       q, k
   in
 

--- a/ide/preferences.ml
+++ b/ide/preferences.ml
@@ -116,6 +116,7 @@ type pref =
       mutable modifier_for_templates : string;
       mutable modifier_for_tactics : string;
       mutable modifier_for_display : string;
+      mutable modifier_for_queries : string;
       mutable modifiers_valid : string;
 
       mutable cmd_browse : string;
@@ -196,6 +197,7 @@ let current = {
     modifier_for_templates = "<Control><Shift>";
     modifier_for_tactics = "<Control><Alt>";
     modifier_for_display = "<Alt><Shift>";
+    modifier_for_queries = "<Control><Shift>";
     modifiers_valid = "<Alt><Control><Shift>";
 
 
@@ -281,6 +283,7 @@ let save_pref () =
     add "modifier_for_templates" [p.modifier_for_templates] ++
     add "modifier_for_tactics" [p.modifier_for_tactics] ++
     add "modifier_for_display" [p.modifier_for_display] ++
+    add "modifier_for_queries" [p.modifier_for_queries] ++
     add "modifiers_valid" [p.modifiers_valid] ++
     add "cmd_browse" [p.cmd_browse] ++
     add "cmd_editor" [p.cmd_editor] ++
@@ -362,6 +365,8 @@ let load_pref () =
       (fun v -> np.modifier_for_tactics <- v);
     set_hd "modifier_for_display"
       (fun v -> np.modifier_for_display <- v);
+    set_hd "modifier_for_queries"
+      (fun v -> np.modifier_for_queries <- v);
     set_hd "modifiers_valid"
       (fun v ->
 	np.modifiers_valid <- v);
@@ -758,6 +763,14 @@ let configure ?(apply=(fun () -> ())) () =
       "Modifiers for View Menu"
       (str_to_mod_list current.modifier_for_display)
   in
+  let modifier_for_queries =
+    modifiers
+      ~allow:the_valid_mod
+      ~f:(fun l -> current.modifier_for_queries <- mod_list_to_str l)
+      ~help:help_string
+      "Modifiers for Queries Menu"
+      (str_to_mod_list current.modifier_for_queries)
+  in
   let modifiers_valid =
     modifiers
       ~f:(fun l ->
@@ -897,8 +910,8 @@ let configure ?(apply=(fun () -> ())) () =
 	     [automatic_tactics]);
      Section("Shortcuts", Some `PREFERENCES,
 	     [modifiers_valid; modifier_for_tactics;
-        modifier_for_templates; modifier_for_display; modifier_for_navigation; modifier_notice;
-        user_queries]);
+        modifier_for_templates; modifier_for_display; modifier_for_navigation;
+        modifier_for_queries; user_queries; modifier_notice]);
      Section("Misc", Some `ADD,
        misc)]
   in

--- a/ide/preferences.ml
+++ b/ide/preferences.ml
@@ -897,11 +897,10 @@ let configure ?(apply=(fun () -> ())) () =
 	     [automatic_tactics]);
      Section("Shortcuts", Some `PREFERENCES,
 	     [modifiers_valid; modifier_for_tactics;
-	      modifier_for_templates; modifier_for_display; modifier_for_navigation; modifier_notice]);
+        modifier_for_templates; modifier_for_display; modifier_for_navigation; modifier_notice;
+        user_queries]);
      Section("Misc", Some `ADD,
-       misc);
-     Section("User queries", None,
-       [user_queries])]
+       misc)]
   in
 (*
   Format.printf "before edit: current.text_font = %s@." (Pango.Font.to_string current.text_font);

--- a/ide/preferences.mli
+++ b/ide/preferences.mli
@@ -43,6 +43,7 @@ type pref =
       mutable modifier_for_templates : string;
       mutable modifier_for_tactics : string;
       mutable modifier_for_display : string;
+      mutable modifier_for_queries : string;
       mutable modifiers_valid : string;
 
       mutable cmd_browse : string;

--- a/ide/preferences.mli
+++ b/ide/preferences.mli
@@ -86,6 +86,8 @@ type pref =
 
       mutable nanoPG : bool;
 
+      mutable user_queries : (string * string) list;
+
     }
 
 val save_pref : unit -> unit


### PR DESCRIPTION
I find myself typing "Show Proof." a lot sometimes, and was wondering why there wasn't a shortcut for that. Maybe there is a reason?
Anyway, if there is none, here is a patch that adds this.
