### PR TITLE
A bug-fix for Bug #4258 (see bug report).

### DIFF
--- a/checker/inductive.ml
+++ b/checker/inductive.ml
@@ -142,53 +142,60 @@ let sort_as_univ = function
 | Prop Null -> Univ.type0m_univ
 | Prop Pos -> Univ.type0_univ
 
+(* cons_subst add the mapping [u |-> su] in subst if [u] is not *)
+(* in the domain or add [u |-> sup x su] if [u] is already mapped *)
+(* to [x]. *)
 let cons_subst u su subst =
-  Univ.LMap.add u su subst
+  try
+    Univ.LMap.add u (Univ.sup (Univ.LMap.find u subst) su) subst
+  with Not_found -> Univ.LMap.add u su subst
 
-let actualize_decl_level env lev t =
-  let sign,s = dest_arity env t in
-  mkArity (sign,lev)
-
-let polymorphism_on_non_applied_parameters = false
+(* remember_subst updates the mapping [u |-> x] by [u |-> sup x u] *)
+(* if it is presents and returns the substitution unchanged if not.*)
+let remember_subst u subst =
+  try
+    let su = Universe.make u in
+    Univ.LMap.add u (Univ.sup (Univ.LMap.find u subst) su) subst
+  with Not_found -> subst
 
 (* Bind expected levels of parameters to actual levels *)
 (* Propagate the new levels in the signature *)
-let rec make_subst env = function
-  | (_,Some _,_ as t)::sign, exp, args ->
-      let ctx,subst = make_subst env (sign, exp, args) in
-      t::ctx, subst
-  | d::sign, None::exp, args ->
-      let args = match args with _::args -> args | [] -> [] in
-      let ctx,subst = make_subst env (sign, exp, args) in
-      d::ctx, subst
-  | d::sign, Some u::exp, a::args ->
-      (* We recover the level of the argument, but we don't change the *)
-      (* level in the corresponding type in the arity; this level in the *)
-      (* arity is a global level which, at typing time, will be enforce *)
-      (* to be greater than the level of the argument; this is probably *)
-      (* a useless extra constraint *)
-      let s = sort_as_univ (snd (dest_arity env a)) in
-      let ctx,subst = make_subst env (sign, exp, args) in
-      d::ctx, cons_subst u s subst
-  | (na,None,t as d)::sign, Some u::exp, [] ->
-      (* No more argument here: we instantiate the type with a fresh level *)
-      (* which is first propagated to the corresponding premise in the arity *)
-      (* (actualize_decl_level), then to the conclusion of the arity (via *)
-      (* the substitution) *)
-      let ctx,subst = make_subst env (sign, exp, []) in
-	d::ctx, subst
-  | sign, [], _ ->
-      (* Uniform parameters are exhausted *)
-      sign,Univ.LMap.empty
-  | [], _, _ ->
-      assert false
-
+let rec make_subst env =
+  let rec make subst = function
+    | (_,Some _,_ as t)::sign, exp, args ->
+        make subst (sign, exp, args)
+    | d::sign, None::exp, args ->
+        let args = match args with _::args -> args | [] -> [] in
+        make subst (sign, exp, args)
+    | d::sign, Some u::exp, a::args ->
+        (* We recover the level of the argument, but we don't change the *)
+        (* level in the corresponding type in the arity; this level in the *)
+        (* arity is a global level which, at typing time, will be enforce *)
+        (* to be greater than the level of the argument; this is probably *)
+        (* a useless extra constraint *)
+        let s = sort_as_univ (snd (dest_arity env a)) in
+        make (cons_subst u s subst) (sign, exp, args)
+    | (na,None,t as d)::sign, Some u::exp, [] ->
+        (* No more argument here: we add the remaining universes to the *)
+        (* substitution (when [u] is distinct from all other universes in the *)
+        (* template, it is identity substitution  otherwise (ie. when u is *)
+        (* already in the domain of the substitution) [remember_subst] will *)
+        (* update its image [x] by [sup x u] in order not to forget the *)
+        (* dependency in [u] that remains to be fullfilled. *)
+        make (remember_subst u subst) (sign, exp, [])
+    | sign, [], _ ->
+        (* Uniform parameters are exhausted *)
+        subst
+    | [], _, _ ->
+        assert false
+  in
+  make Univ.LMap.empty
 
 exception SingletonInductiveBecomesProp of Id.t
 
 let instantiate_universes env ctx ar argsorts =
   let args = Array.to_list argsorts in
-  let ctx,subst = make_subst env (ctx,ar.template_param_levels,args) in
+  let subst = make_subst env (ctx,ar.template_param_levels,args) in
   let level = Univ.subst_univs_universe (Univ.make_subst subst) ar.template_level in
   let ty =
     (* Singleton type not containing types are interpretable in Prop *)

--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -134,46 +134,60 @@ let sort_as_univ = function
 
 (* Template polymorphism *)
 
+(* cons_subst add the mapping [u |-> su] in subst if [u] is not *)
+(* in the domain or add [u |-> sup x su] if [u] is already mapped *)
+(* to [x]. *)
 let cons_subst u su subst =
-  Univ.LMap.add u su subst
+  try
+    Univ.LMap.add u (Univ.sup (Univ.LMap.find u subst) su) subst
+  with Not_found -> Univ.LMap.add u su subst
+
+(* remember_subst updates the mapping [u |-> x] by [u |-> sup x u] *)
+(* if it is presents and returns the substitution unchanged if not.*)
+let remember_subst u subst =
+  try
+    let su = Universe.make u in
+    Univ.LMap.add u (Univ.sup (Univ.LMap.find u subst) su) subst
+  with Not_found -> subst
 
 (* Bind expected levels of parameters to actual levels *)
 (* Propagate the new levels in the signature *)
-let rec make_subst env = function
-  | (_,Some _,_ as t)::sign, exp, args ->
-      let ctx,subst = make_subst env (sign, exp, args) in
-      t::ctx, subst
-  | d::sign, None::exp, args ->
-      let args = match args with _::args -> args | [] -> [] in
-      let ctx,subst = make_subst env (sign, exp, args) in
-      d::ctx, subst
-  | d::sign, Some u::exp, a::args ->
-      (* We recover the level of the argument, but we don't change the *)
-      (* level in the corresponding type in the arity; this level in the *)
-      (* arity is a global level which, at typing time, will be enforce *)
-      (* to be greater than the level of the argument; this is probably *)
-      (* a useless extra constraint *)
-      let s = sort_as_univ (snd (dest_arity env (Lazy.force a))) in
-      let ctx,subst = make_subst env (sign, exp, args) in
-      d::ctx, cons_subst u s subst
-  | (na,None,t as d)::sign, Some u::exp, [] ->
-      (* No more argument here: we instantiate the type with a fresh level *)
-      (* which is first propagated to the corresponding premise in the arity *)
-      (* (actualize_decl_level), then to the conclusion of the arity (via *)
-      (* the substitution) *)
-      let ctx,subst = make_subst env (sign, exp, []) in
-	d::ctx, subst
-  | sign, [], _ ->
-      (* Uniform parameters are exhausted *)
-      sign, Univ.LMap.empty
-  | [], _, _ ->
-      assert false
+let rec make_subst env =
+  let rec make subst = function
+    | (_,Some _,_ as t)::sign, exp, args ->
+        make subst (sign, exp, args)
+    | d::sign, None::exp, args ->
+        let args = match args with _::args -> args | [] -> [] in
+        make subst (sign, exp, args)
+    | d::sign, Some u::exp, a::args ->
+        (* We recover the level of the argument, but we don't change the *)
+        (* level in the corresponding type in the arity; this level in the *)
+        (* arity is a global level which, at typing time, will be enforce *)
+        (* to be greater than the level of the argument; this is probably *)
+        (* a useless extra constraint *)
+        let s = sort_as_univ (snd (dest_arity env (Lazy.force a))) in
+        make (cons_subst u s subst) (sign, exp, args)
+    | (na,None,t as d)::sign, Some u::exp, [] ->
+        (* No more argument here: we add the remaining universes to the *)
+        (* substitution (when [u] is distinct from all other universes in the *)
+        (* template, it is identity substitution  otherwise (ie. when u is *)
+        (* already in the domain of the substitution) [remember_subst] will *)
+        (* update its image [x] by [sup x u] in order not to forget the *)
+        (* dependency in [u] that remains to be fullfilled. *)
+        make (remember_subst u subst) (sign, exp, [])
+    | sign, [], _ ->
+        (* Uniform parameters are exhausted *)
+        subst
+    | [], _, _ ->
+        assert false
+  in
+  make Univ.LMap.empty
 
 exception SingletonInductiveBecomesProp of Id.t
 
 let instantiate_universes env ctx ar argsorts =
   let args = Array.to_list argsorts in
-  let ctx,subst = make_subst env (ctx,ar.template_param_levels,args) in
+  let subst = make_subst env (ctx,ar.template_param_levels,args) in
   let level = Univ.subst_univs_universe (Univ.make_subst subst) ar.template_level in
   let ty =
     (* Singleton type not containing types are interpretable in Prop *)


### PR DESCRIPTION
```
(* There is a bug in the implementation of template polymorphism in presence of aliasing in the 8.5 branch. *)
Inductive box (A : Type@{T}) (B : Type@{T}) (C : Type@{T}) := 
  close_box : A -> B -> C -> box A B C.
(* Remember, the notation @{T} means that the sorts of A, B and C are of the same level. 
   That's "aliasing". And template polymorphism is the part of the kernel which recognizes 
   that list of proposition is a proposition (eg. list True lives in Prop), a list of nat 
   is in set, and more generally a list of type whose sort is of level l lives in the sort
   of level l. *)

(* Applied to propositional parameters this inductive lives in Prop. 
   So far so good. *)
Check (box True True True). 
(* But when you instantiate it with types of different sorts, it starts smelling fishy. *)
Check (box True unit unit). (* Prop *)  
Check (box unit True unit). (* Set *)
Check (box unit unit True). (* Set *)
(* It happens that only the first parameters is used by the template mechanism and 
   the others are discarded. So you have a way to inject higher universes into 
   smaller ones. Not good. *)
Definition star := box True True.
Check star. (* Type -> Prop *)
Definition open {A} (b : star A) : A := 
  match b with 
    close_box _ _ _ _ _ a => a
  end.
Definition close {A} (a : A) : star A := close_box True True A I I a.
(* Using, this you can embed any derivation of the naive type theory (the "type-in-type"
   version of CIC) by using the following translation : 
      | x | = close x
      | fun x : A => M | = fun x : open |A| => |M|
      | M N | = open |M| (open |N|)
      | Type | = close Prop
      | forall x:A, B | = close (forall x : open |A|, open |B|)

    This translation preserves typing : 
           M : A                in type in type
   ------------------------- 
     |M| : star (open |A|)      in coq 8.5 (beta)

  From a closed proof p of False (forall X:Type, X) in type-in-type, you obtain 
  a proof "open |p|" of "open |forall X : Type, X|"  which is convertible to 
  "forall X:Prop, X". I join to this bug report a translation of Hurken's formulation 
  of Girard's paradox for the pleasure of writing a diverging term. 
 *)

(* The bug. *)
(* To understand where is the bug, one should notice that the fact that there is 
   an odd number of parameters in the inductive is important. *)

(* For instance, the following inductive is safe : *)
Inductive bibox (A : Type@{T}) (B : Type@{T}) := 
  close_bibox : A -> B -> bibox A B.
Check (bibox True True). (* Type *)
Check (bibox True unit). (* Type *)
Check (bibox unit True). (* Type *)
(* Indeed, when the inductive bibox is registered, the system notices the aliasing 
   and declare that both A and B are not contributing to template polymorphism. 
   They are declared as "template-monomorph parameters" (yes, I made that up). *)
(* The code responsible to decide if a parameter contributes to template polymorphism
   is the function "param_ccls" in kernel/indtypes.ml:

let param_ccls params =
  let has_some_univ u = function
    | Some v when Univ.Level.equal u v -> true
    | _ -> false
  in
  let remove_some_univ u = function
    | Some v when Univ.Level.equal u v -> None
    | x -> x
  in
  let fold l (_, b, p) = match b with
  | None ->
    (* Parameter contributes to polymorphism only if explicit Type *)
    let c = strip_prod_assum p in
    (* Add Type levels to the ordered list of parameters contributing to *)
    (* polymorphism unless there is aliasing (i.e. non distinct levels) *)
    begin match kind_of_term c with
    | Sort (Type u) ->
      (match Univ.Universe.level u with
      | Some u ->
          if List.exists (has_some_univ u) l then
           None :: List.map (remove_some_univ u) l
          else
          Some u :: l
      | None -> None :: l)
    | _ ->
      None :: l
    end
  | _ -> l
  in
    List.fold_left fold [] params

  It takes as argument the list of parameters. Applied to box parameters
  [Type_i; Type_i; Type_i] it will return [Some i; None; None]
  and applied to bibox parameters [Type_i; Type_i] it will return [None; None].
  The function basically removes pairs of identical elements in a list
  when it wants to removes all elements occurring strictly more than once.
  A quick fix would be : 

(* Returns the list [x_1, ..., x_n] of levels contributing to template polymorphism.
   The elements x_k is None if the k-th parameter (starting from the most recent) is
   not contributing or is Some u_k if its level is u_k and is contributing. *)
let param_ccls params =
   let contributing_universes =
    let fold acc = function (_, None, p) -> 
        (let c = strip_prod_assum p in
        match kind_of_term c with
          | Sort (Type u) -> Univ.Universe.level u
          | _ -> None) :: acc
      | _ -> acc 
    in
    List.fold_left fold [] params
  in
  let nelem x s = try Univ.LMap.find x s with Not_found -> 0 in
  let multiset_add x s = try
       Univ.LMap.add x ((Univ.LMap.find x s) + 1) s
     with Not_found -> Univ.LMap.add x 1 s
  in 
  let fold s = function 
    Some l -> multiset_add l s
  | None -> s
  in 
  (* Collect all contributing levels *)
  let occurring_levels = 
   List.fold_left fold Univ.LMap.empty contributing_universes 
  in 
  (* Removes all sorts occurring strictly more than once *)
  let contributing_universes = 
    List.map 
      (function Some l as x when nelem l occurring_levels <= 1 -> x | _ -> None) 
      contributing_universes
  in 
  List.rev contributing_universes

   This fix is in the "spirit" of what the original implementation wanted to do. 
   After this fix, theses checks :  
     Check (box True unit unit). 
     Check (box unit True unit). 
     Check (box unit unit True). 
   All returns Type. 

   I would be very sad if this fix actually ends up in the next version of Coq. 
   Indeed, I think (and I may be wrong) that we should used this opportunity to 
   increase (I hope not too much) the expressiveness of template polymorphism 
   by not giving up on aliased parameters.

   My idea would be to typecheck fully-instanciated inductives by substituting 
   aliased sorts by the sup of all the levels of the arguments.
   That way, box True True True would be sup(Prop, Prop, Prop) = Prop, 
             box unit True unit would be sup(Set, Prop, Set) = Set
   and more generally box A B C would typechecks as 
             sup(Type_i, Type_j, Type_k) = Type_{sup (i,j,k)}
   where Type_i, Type_j, and Type_k are the sorts of respectivelly A, B, and C.
   Of course, we would need to do something special in the case the inductive
   is not fully-instanciated by "remembering" in the sup the level that may
   be substituted later. So (box True unit) would be of level 
   sup(Prop, Set, Type_T) where T is the level of parameters of box. 
   Again, I think this is what we want but there may be something that I've not 
   thought of which could lead to another inconsistency. 

   Since this is the solution I would like to be implemented, concurrently with
   this bug report I'm submitting a new pull-request for this solution.
   It consists of a simplification of "param_ccls":

(* Returns the list [x_1, ..., x_n] of levels contributing to template polymorphism.
   The elements x_k is None if the k-th parameter (starting from the most recent) is
   not contributing or is Some u_k if the corresponding universes is u_k and is 
   contributing. A parameter is contributing iff it is an arity of sort Type 
   (and not Set or Prop). *)
let param_ccls params =
  let fold acc = function (_, None, p) -> 
      (let c = strip_prod_assum p in
      match kind_of_term c with
        | Sort (Type u) -> Univ.Universe.level u
        | _ -> None) :: acc
    | _ -> acc 
  in
  List.fold_left fold [] params

   Together with a modification of the susbtitution function make_subst in the 
   module "kernel/inductive.ml" responsible for typing inductives. 
   Here is the original code: 

(* Template polymorphism *)

let cons_subst u su subst =
  Univ.LMap.add u su subst

(* Bind expected levels of parameters to actual levels *)
(* Propagate the new levels in the signature *)
let rec make_subst env = function
  | (_,Some _,_ as t)::sign, exp, args ->
      let ctx,subst = make_subst env (sign, exp, args) in
      t::ctx, subst
  | d::sign, None::exp, args ->
      let args = match args with _::args -> args | [] -> [] in
      let ctx,subst = make_subst env (sign, exp, args) in
      d::ctx, subst
  | d::sign, Some u::exp, a::args ->
      (* We recover the level of the argument, but we don't change the *)
      (* level in the corresponding type in the arity; this level in the *)
      (* arity is a global level which, at typing time, will be enforce *)
      (* to be greater than the level of the argument; this is probably *)
      (* a useless extra constraint *)
      let s = sort_as_univ (snd (dest_arity env (Lazy.force a))) in
      let ctx,subst = make_subst env (sign, exp, args) in
      d::ctx, cons_subst u s subst
  | (na,None,t as d)::sign, Some u::exp, [] ->
      (* No more argument here: we instantiate the type with a fresh level *)
      (* which is first propagated to the corresponding premise in the arity *)
      (* (actualize_decl_level), then to the conclusion of the arity (via *)
      (* the substitution) *)
      let ctx,subst = make_subst env (sign, exp, []) in
        d::ctx, subst
  | sign, [], _ ->
      (* Uniform parameters are exhausted *)
      sign, Univ.LMap.empty
  | [], _, _ ->
      assert false  

Note that there are two minors issues:
 1. the first projection of the result is always equal to the first 
projection of the input (sign/ctx), 
 2. the second comment in the body of make_subst is outdated. 

I propose to substitute this code by : 
(* Template polymorphism *)

(* cons_subst add the mapping [u |-> su] in subst if [u] is not *)
(* in the domain or add [u |-> sup x su] if [u] is already mapped *)
(* to [x]. *)
let cons_subst u su subst =
  try 
    Univ.LMap.add u (Univ.sup (Univ.LMap.find u subst) su) subst
  with Not_found -> Univ.LMap.add u su subst

(* remember_subst updates the mapping [u |-> x] by [u |-> sup x u] *)
(* if it is presents and returns the substitution unchanged if not.*)
let remember_subst u subst = 
  try
    let su = Universe.make u in
    Univ.LMap.add u (Univ.sup (Univ.LMap.find u subst) su) subst
  with Not_found -> subst

(* Bind expected levels of parameters to actual levels *)
(* Propagate the new levels in the signature *)
let rec make_subst env =
  let rec make subst = function
    | (_,Some _,_ as t)::sign, exp, args ->  
        make subst (sign, exp, args)
    | d::sign, None::exp, args ->
        let args = match args with _::args -> args | [] -> [] in
        make subst (sign, exp, args) 
    | d::sign, Some u::exp, a::args ->
        (* We recover the level of the argument, but we don't change the *)
        (* level in the corresponding type in the arity; this level in the *)
        (* arity is a global level which, at typing time, will be enforce *)
        (* to be greater than the level of the argument; this is probably *)
        (* a useless extra constraint *)
        let s = sort_as_univ (snd (dest_arity env (Lazy.force a))) in
        make (cons_subst u s subst) (sign, exp, args)
    | (na,None,t as d)::sign, Some u::exp, [] ->
        (* No more argument here: we add the remaining universes to the *)
        (* substitution (when [u] is distinct from all other universes in the *)
        (* template, it is identity substitution  otherwise (ie. when u is *)
        (* already in the domain of the substitution) [remember_subst] will *)
        (* update its image [x] by [sup x u] in order not to forget the *)
        (* dependency in [u] that remains to be fullfilled. *)
        make (remember_subst u subst) (sign, exp, []) 
    | sign, [], _ ->
        (* Uniform parameters are exhausted *)
        subst
    | [], _, _ ->
        assert false
  in
  make Univ.LMap.empty

I updated the implementation of cons_subst to cope with aliasing and add the 
function remember_subst used in the branch that deals with inductives which 
are not fully-instantiated. I removed the first component of the result 
(the signature) since it was useless. Finally, I made the function tail 
recursive not to improve perfs but because I needed the substitution to 
be built the other way around. 

That should work. 

By the way, this fix is important for my parametricity plugin because aliasing 
occurrs naturally when computing relations for inductive types. 
Eg, the inductive *)
   Inductive inhab (X : Type) := witness : X -> inhab X.
(* induces the following relation : *)
   Inductive inhab_R (X1 : Type@{T}) (X2 : Type@{T}) (X_R : X1 -> X2 -> Type@{T}) : inhab X1 -> inhab X2 -> Type
    := witness_R : forall x1 x2, X_R x1 x2 -> inhab_R X1 X2 X_R (witness X1 x1) (witness X2 x2).
(* When one "translates" the translation of [inhab True] living in Prop is [inhab_R True True True_R] where 
   True_R is *)
Inductive True_R : True -> True -> Prop :=
   I_R : True_R I I. 
(* Then, the following check *)
Check (inhab_R True True True_R). 
(* should return inhab True -> inhab True -> Prop and not inhab True -> inhab True -> Type. *)
(* Of course, I could try to get around this by not sharing universes in translations, but it 
   would mean a lot of painful work to handle the universes constaints of copies of old universes. *)
```
