### PR TITLE
Range selector

### DIFF
--- a/intf/tacexpr.mli
+++ b/intf/tacexpr.mli
@@ -34,6 +34,13 @@ type clear_flag = bool option (* true = clear hyp, false = keep hyp, None = use 
 
 type debug = Debug | Info | Off (* for trivial / auto / eauto ... *)
 
+type goal_selector =
+  | SelectNth of int
+  | SelectList of (int * int) list
+  | SelectId of Id.t
+  | SelectAll
+  | SelectAllParallel
+
 type 'a core_induction_arg =
   | ElimOnConstr of 'a
   | ElimOnIdent of Id.t located
@@ -290,6 +297,7 @@ and 'a gen_tactic_expr =
       ('p,'a gen_tactic_expr) match_rule list
   | TacFun of 'a gen_tactic_fun_ast
   | TacArg of 'a gen_tactic_arg located
+  | TacSelect of goal_selector * 'a gen_tactic_expr
   (* For ML extensions *)
   | TacML of Loc.t * ml_tactic_name * 'l generic_argument list
   (* For syntax extensions *)

--- a/intf/vernacexpr.mli
+++ b/intf/vernacexpr.mli
@@ -30,6 +30,7 @@ type class_rawexpr = FunClass | SortClass | RefClass of reference or_by_notation
    similar, they do not seem to mean the same thing. *)
 type goal_selector =
   | SelectNth of int
+  | SelectList of (int * int) list
   | SelectId of Id.t
   | SelectAll
   | SelectAllParallel

--- a/intf/vernacexpr.mli
+++ b/intf/vernacexpr.mli
@@ -28,7 +28,7 @@ type class_rawexpr = FunClass | SortClass | RefClass of reference or_by_notation
    to print a goal that is out of focus (or already solved) it doesn't
    make sense to apply a tactic to it. Hence it the types may look very
    similar, they do not seem to mean the same thing. *)
-type goal_selector =
+type goal_selector = Tacexpr.goal_selector =
   | SelectNth of int
   | SelectList of (int * int) list
   | SelectId of Id.t

--- a/lib/cList.ml
+++ b/lib/cList.ml
@@ -47,6 +47,8 @@ sig
     ('a -> 'b -> 'c -> 'd -> 'e) -> 'a list -> 'b list -> 'c list -> 'd list -> 'e list
   val filteri :
     (int -> 'a -> bool) -> 'a list -> 'a list
+  val partitioni :
+    (int -> 'a -> bool) -> 'a list -> 'a list * 'a list
   val smartfilter : ('a -> bool) -> 'a list -> 'a list
   val index : 'a eq -> 'a -> 'a list -> int
   val index0 : 'a eq -> 'a -> 'a list -> int
@@ -471,6 +473,15 @@ let filteri p =
     | x::l -> let l' = filter_i_rec (succ i) l in if p i x then x::l' else l'
   in
   filter_i_rec 0
+
+let partitioni p =
+  let rec aux i = function
+    | [] -> [], []
+    | x :: l ->
+        let (l1, l2) = aux (succ i) l in
+        if p i x then (x :: l1, l2)
+        else (l1, x :: l2)
+  in aux 0
 
 let rec sep_last = function
   | [] -> failwith "sep_last"

--- a/lib/cList.mli
+++ b/lib/cList.mli
@@ -89,6 +89,7 @@ sig
   val map4 : ('a -> 'b -> 'c -> 'd -> 'e) -> 'a list -> 'b list -> 'c list ->
     'd list -> 'e list
   val filteri : (int -> 'a -> bool) -> 'a list -> 'a list
+  val partitioni : (int -> 'a -> bool) -> 'a list -> 'a list * 'a list
 
   val smartfilter : ('a -> bool) -> 'a list -> 'a list
   (** [smartfilter f [a1...an] = List.filter f [a1...an]] but if for all i

--- a/parsing/g_ltac.ml4
+++ b/parsing/g_ltac.ml4
@@ -278,7 +278,6 @@ GEXTEND Gram
   selector:
     [ [ l = range_selector_or_nth; ":" -> l
       | "?"; "["; id = ident; "]"; ":" -> SelectId id
-      | IDENT "all" ; ":" -> SelectAll
-      | IDENT "par" ; ":" -> SelectAllParallel ] ]
+      | IDENT "all" ; ":" -> SelectAll ] ]
   ;
   END

--- a/parsing/g_ltac.ml4
+++ b/parsing/g_ltac.ml4
@@ -277,7 +277,6 @@ GEXTEND Gram
 
   selector:
     [ [ l = range_selector_or_nth; ":" -> l
-      | "?"; "["; id = ident; "]"; ":" -> SelectId id
       | IDENT "all" ; ":" -> SelectAll ] ]
   ;
   END

--- a/parsing/g_ltac.ml4
+++ b/parsing/g_ltac.ml4
@@ -33,7 +33,7 @@ let genarg_of_ipattern pat = in_gen (rawwit Constrarg.wit_intro_pattern) pat
 
 GEXTEND Gram
   GLOBAL: tactic tacdef_body tactic_expr binder_tactic tactic_arg
-          constr_may_eval constr_eval;
+          constr_may_eval constr_eval selector;
 
   tactic_then_last:
     [ [ "|"; lta = LIST0 OPT tactic_expr SEP "|" ->
@@ -79,7 +79,8 @@ GEXTEND Gram
 (*To do: put Abstract in Refiner*)
       | IDENT "abstract"; tc = NEXT -> TacAbstract (tc,None)
       | IDENT "abstract"; tc = NEXT; "using";  s = ident ->
-          TacAbstract (tc,Some s) ]
+          TacAbstract (tc,Some s)
+      | sel = selector; ta = tactic_expr -> TacSelect (sel, ta) ]
 (*End of To do*)
     | "2" RIGHTA
       [ ta0 = tactic_expr; "+"; ta1 = binder_tactic -> TacOr (ta0,ta1)
@@ -256,5 +257,28 @@ GEXTEND Gram
   ;
   tactic:
     [ [ tac = tactic_expr -> tac ] ]
+  ;
+
+  range_selector:
+    [ [ n = natural ; "-" ; m = natural -> (n, m)
+      | n = natural -> (n, n) ] ]
+  ;
+
+  (* We unfold a range selectors list once so that we can make a special case
+   * for a unique SelectNth selector. *)
+  range_selector_or_nth:
+    [ [ n = natural ; "-" ; m = natural;
+        l = OPT [","; l = LIST1 range_selector SEP "," -> l] ->
+          SelectList ((n, m) :: Option.default [] l)
+      | n = natural;
+        l = OPT [","; l = LIST1 range_selector SEP "," -> l] ->
+          Option.cata (fun l -> SelectList ((n, n) :: l)) (SelectNth n) l ] ]
+  ;
+
+  selector:
+    [ [ l = range_selector_or_nth; ":" -> l
+      | "?"; "["; id = ident; "]"; ":" -> SelectId id
+      | IDENT "all" ; ":" -> SelectAll
+      | IDENT "par" ; ":" -> SelectAllParallel ] ]
   ;
   END

--- a/parsing/g_vernac.ml4
+++ b/parsing/g_vernac.ml4
@@ -143,10 +143,20 @@ GEXTEND Gram
       | n = natural -> (n, n) ] ]
   ;
 
+  (* We unfold a range selectors list once so that we can make a special case
+   * for a unique SelectNth selector. *)
+  range_selector_or_nth:
+    [ [ n = natural ; "-" ; m = natural;
+        l = OPT [","; l = LIST1 range_selector SEP "," -> l] ->
+          SelectList ((n, m) :: Option.default [] l)
+      | n = natural;
+        l = OPT [","; l = LIST1 range_selector SEP "," -> l] ->
+          Option.cata (fun l -> SelectList ((n, n) :: l)) (SelectNth n) l ] ]
+  ;
+
   selector:
-    [ [ n=natural; ":" -> SelectNth n
+    [ [ l = range_selector_or_nth; ":" -> l
       | test_bracket_ident; "["; id = ident; "]"; ":" -> SelectId id
-      | "[" ; l = LIST1 range_selector SEP "," ; "]" ; ":" -> SelectList l
       | IDENT "all" ; ":" -> SelectAll
       | IDENT "par" ; ":" -> SelectAllParallel ] ]
   ;

--- a/parsing/g_vernac.ml4
+++ b/parsing/g_vernac.ml4
@@ -127,8 +127,13 @@ GEXTEND Gram
     [ [ c = subgoal_command -> c None] ]
   ;
 
+  vernac_selector:
+    [ [ s = Tactic.selector -> s
+      | IDENT "par" ; ":" -> Tacexpr.SelectAllParallel ] ]
+  ;
+
   tactic_mode:
-  [ [ gln = OPT Tactic.selector;
+  [ [ gln = OPT vernac_selector;
       tac = subgoal_command -> tac gln ] ]
   ;
 

--- a/parsing/g_vernac.ml4
+++ b/parsing/g_vernac.ml4
@@ -71,6 +71,17 @@ let make_bullet s =
   | '*' -> Star n
   | _ -> assert false
 
+(* Hack to parse "[ id" without dropping [ *)
+let test_bracket_ident =
+  Gram.Entry.of_parser "test_bracket_ident"
+    (fun strm ->
+      match get_tok (stream_nth 0 strm) with
+        | KEYWORD "[" ->
+            (match get_tok (stream_nth 1 strm) with
+              | IDENT _ -> ()
+              | _ -> raise Stream.Failure)
+        | _ -> raise Stream.Failure)
+
 let default_command_entry =
   Gram.Entry.of_parser "command_entry"
     (fun strm -> Gram.parse_tokens_after_filter (get_command_entry ()) strm)
@@ -129,7 +140,8 @@ GEXTEND Gram
 
   vernac_selector:
     [ [ s = Tactic.selector -> s
-      | IDENT "par" ; ":" -> Tacexpr.SelectAllParallel ] ]
+      | test_bracket_ident ; "["; id = ident; "]"; ":" -> SelectId id
+      | IDENT "par" ; ":" -> SelectAllParallel ] ]
   ;
 
   tactic_mode:

--- a/parsing/g_vernac.ml4
+++ b/parsing/g_vernac.ml4
@@ -138,9 +138,15 @@ GEXTEND Gram
     [ [ c = subgoal_command -> c None] ]
   ;
 
+  range_selector:
+    [ [ n = natural ; "-" ; m = natural -> (n, m)
+      | n = natural -> (n, n) ] ]
+  ;
+
   selector:
     [ [ n=natural; ":" -> SelectNth n
       | test_bracket_ident; "["; id = ident; "]"; ":" -> SelectId id
+      | "[" ; l = LIST1 range_selector SEP "," ; "]" ; ":" -> SelectList l
       | IDENT "all" ; ":" -> SelectAll
       | IDENT "par" ; ":" -> SelectAllParallel ] ]
   ;

--- a/parsing/pcoq.ml4
+++ b/parsing/pcoq.ml4
@@ -404,6 +404,9 @@ module Tactic =
     (* For Ltac definition *)
     let tacdef_body = Gram.entry_create "tactic:tacdef_body"
 
+    (* For goal selector *)
+    let selector = Gram.entry_create "tactic:selector"
+
   end
 
 module Vernac_ =

--- a/parsing/pcoq.mli
+++ b/parsing/pcoq.mli
@@ -232,6 +232,7 @@ module Tactic :
     val tactic : raw_tactic_expr Gram.entry
     val tactic_eoi : raw_tactic_expr Gram.entry
     val tacdef_body : (reference * bool * raw_tactic_expr) Gram.entry
+    val selector : goal_selector Gram.entry
   end
 
 module Vernac_ :

--- a/printing/ppvernac.ml
+++ b/printing/ppvernac.ml
@@ -995,7 +995,9 @@ module Make
         in
         let pr_goal_selector = function
           | SelectNth i -> int i ++ str":"
-          | SelectList l -> prlist_with_sep (fun () -> str ", ") pr_range_selector l
+          | SelectList l ->
+              str"[" ++ prlist_with_sep (fun () -> str ", ") pr_range_selector l ++
+              str"]" ++ str":"
           | SelectId id -> pr_id id ++ str":"
           | SelectAll -> str"all" ++ str":"
           | SelectAllParallel -> str"par"

--- a/printing/ppvernac.ml
+++ b/printing/ppvernac.ml
@@ -990,7 +990,7 @@ module Make
         (* Solving *)
       | VernacSolve (i,info,tac,deftac) ->
         let pr_range_selector (i, j) =
-          if i = j then int i
+          if Int.equal i j then int i
           else int i ++ str"-" ++ int j
         in
         let pr_goal_selector = function

--- a/printing/ppvernac.ml
+++ b/printing/ppvernac.ml
@@ -989,8 +989,13 @@ module Make
           )
         (* Solving *)
       | VernacSolve (i,info,tac,deftac) ->
+        let pr_range_selector (i, j) =
+          if i = j then int i
+          else int i ++ str"-" ++ int j
+        in
         let pr_goal_selector = function
           | SelectNth i -> int i ++ str":"
+          | SelectList l -> prlist_with_sep (fun () -> str ", ") pr_range_selector l
           | SelectId id -> pr_id id ++ str":"
           | SelectAll -> str"all" ++ str":"
           | SelectAllParallel -> str"par"

--- a/proofs/pfedit.ml
+++ b/proofs/pfedit.ml
@@ -115,6 +115,7 @@ let solve ?with_end_tac gi info_lvl tac pr =
     in
     let tac = match gi with
       | Vernacexpr.SelectNth i -> Proofview.tclFOCUS i i tac
+      | Vernacexpr.SelectList l -> Proofview.tclFOCUSLIST l tac
       | Vernacexpr.SelectId id -> Proofview.tclFOCUSID id tac
       | Vernacexpr.SelectAll -> tac
       | Vernacexpr.SelectAllParallel ->

--- a/proofs/proof_global.ml
+++ b/proofs/proof_global.ml
@@ -657,9 +657,15 @@ let _ =
 let default_goal_selector = ref (Vernacexpr.SelectNth 1)
 let get_default_goal_selector () = !default_goal_selector
 
+let print_range_selector (i, j) =
+  if i = j then string_of_int i
+  else string_of_int i ^ "-" ^ string_of_int j
+
 let print_goal_selector = function
   | Vernacexpr.SelectAll -> "all"
   | Vernacexpr.SelectNth i -> string_of_int i
+  | Vernacexpr.SelectList l -> "[" ^
+      String.concat ", " (List.map print_range_selector l) ^ "]"
   | Vernacexpr.SelectId id -> Id.to_string id
   | Vernacexpr.SelectAllParallel -> "par"
 

--- a/proofs/proofview.ml
+++ b/proofs/proofview.ml
@@ -403,6 +403,8 @@ let tclFOCUSLIST l t =
     match l with
       | [] -> tclZERO (NoSuchGoals 0)
       | (mi, _) :: _ ->
+          (* [CList.goto] returns a zipper, so that
+             [(rev left) @ sub_right = comb]. *)
           let left, sub_right = CList.goto (mi-1) comb in
           let p x _ = CList.exists (fun (i, j) -> i <= x +mi && x + mi <= j) l in
           let sub, right = CList.partitioni p sub_right in

--- a/proofs/proofview.ml
+++ b/proofs/proofview.ml
@@ -404,10 +404,8 @@ let tclFOCUSLIST l t =
       | [] -> tclZERO (NoSuchGoals 0)
       | (mi, _) :: _ ->
           let left, sub_right = CList.goto (mi-1) comb in
-          let p x = CList.exists (fun (i, j) -> i <= x && x <= j) l in
-          (* Since there is no [CList.partitioni], we do it manually. *)
-          let sub = CList.filteri (fun x _ -> p (x + mi)) sub_right in
-          let right = CList.filteri (fun x _ -> not (p (x + mi))) sub_right in
+          let p x _ = CList.exists (fun (i, j) -> i <= x +mi && x + mi <= j) l in
+          let sub, right = CList.partitioni p sub_right in
           let mj = mi - 1 + CList.length sub in
             Comb.set (CList.rev_append left (sub @ right)) >>
             tclFOCUS mi mj t

--- a/proofs/proofview.ml
+++ b/proofs/proofview.ml
@@ -396,17 +396,16 @@ let tclFOCUSLIST l t =
       else Some ((max i 1), (min j n))
     in
     let l = CList.map_filter sanitize l in
-    (* Sort the list to get the left-most goal to focus. This goal won't
-       move, and we will then place all the other goals to focus to the
-       right. *)
-    let l = CList.sort compare l in
     match l with
       | [] -> tclZERO (NoSuchGoals 0)
       | (mi, _) :: _ ->
+          (* Get the left-most goal to focus. This goal won't move, and we
+             will then place all the other goals to focus to the right. *)
+          let mi = CList.fold_left (fun m (i, _) -> min m i) mi l in
           (* [CList.goto] returns a zipper, so that
              [(rev left) @ sub_right = comb]. *)
           let left, sub_right = CList.goto (mi-1) comb in
-          let p x _ = CList.exists (fun (i, j) -> i <= x +mi && x + mi <= j) l in
+          let p x _ = CList.exists (fun (i, j) -> i <= x + mi && x + mi <= j) l in
           let sub, right = CList.partitioni p sub_right in
           let mj = mi - 1 + CList.length sub in
             Comb.set (CList.rev_append left (sub @ right)) >>

--- a/proofs/proofview.mli
+++ b/proofs/proofview.mli
@@ -240,7 +240,7 @@ val set_nosuchgoals_hook: (int -> string option) -> unit
 val tclFOCUS : int -> int -> 'a tactic -> 'a tactic
 
 (** [tclFOCUSLIST li t] applies [t] on the list of focused goals
-    described by [li]. Each element of [li] is a pair [(i, j)] denothing
+    described by [li]. Each element of [li] is a pair [(i, j)] denoting
     the goals numbered from [i] to [j] (inclusive, starting from 1).
     It will try to apply [t] to all the valid goals in any of these
     intervals. If the set of such goals is not a single range, then it

--- a/proofs/proofview.mli
+++ b/proofs/proofview.mli
@@ -239,6 +239,16 @@ val set_nosuchgoals_hook: (int -> string option) -> unit
 
 val tclFOCUS : int -> int -> 'a tactic -> 'a tactic
 
+(** [tclFOCUSLIST li t] applies [t] on the list of focused goals
+    described by [li]. Each element of [li] is a pair [(i, j)] denothing
+    the goals numbered from [i] to [j] (inclusive, starting from 1).
+    It will try to apply [t] to all the valid goals in any of these
+    intervals. If the set of such goals is not a single range, then it
+    will move goals such that it is a single range. (So, for
+    instance, [[1, 3-5]; idtac.] is not the identity.)
+    If the set of such goals is empty, it will fail. *)
+val tclFOCUSLIST : (int * int) list -> 'a tactic -> 'a tactic
+
 (** [tclFOCUSID x t] applies [t] on a (single) focused goal like
     {!tclFOCUS}. The goal is found by its name rather than its
     number.*)

--- a/tactics/tacintern.ml
+++ b/tactics/tacintern.ml
@@ -660,6 +660,8 @@ and intern_tactic_seq onlytac ist = function
   | TacSolve l -> ist.ltacvars, TacSolve (List.map (intern_pure_tactic ist) l)
   | TacComplete tac -> ist.ltacvars, TacComplete (intern_pure_tactic ist tac)
   | TacArg (loc,a) -> ist.ltacvars, intern_tactic_as_arg loc onlytac ist a
+  | TacSelect (sel, tac) ->
+      ist.ltacvars, TacSelect (sel, intern_pure_tactic ist tac)
 
   (* For extensions *)
   | TacAlias (loc,s,l) ->

--- a/tactics/tacinterp.ml
+++ b/tactics/tacinterp.ml
@@ -1202,6 +1202,7 @@ and eval_tactic ist tac : unit Proofview.tactic = match tac with
            strbrk "There is an \"Info\" command to replace it." ++fnl () ++
 	   strbrk "Some specific verbose tactics may also exist, such as info_eauto.");
       eval_tactic ist tac
+  | TacSelect (sel, tac) -> Tacticals.New.tclSELECT sel (interp_tactic ist tac)
   (* For extensions *)
   | TacAlias (loc,s,l) ->
       let body = Tacenv.interp_alias s in

--- a/tactics/tacticals.ml
+++ b/tactics/tacticals.ml
@@ -463,6 +463,15 @@ module New = struct
   let tclPROGRESS t =
     Proofview.tclINDEPENDENT (Proofview.tclPROGRESS t)
 
+  (* Select a subset of the goals *)
+  let tclSELECT = function
+    | Tacexpr.SelectNth i -> Proofview.tclFOCUS i i
+    | Tacexpr.SelectList l -> Proofview.tclFOCUSLIST l
+    | Tacexpr.SelectId id -> Proofview.tclFOCUSID id
+    | Tacexpr.SelectAll -> fun tac -> tac
+    | Tacexpr.SelectAllParallel -> fun _ ->
+        tclZEROMSG (str"Parallel selector cannot be used inside a tactic.")
+
   (* Check that holes in arguments have been resolved *)
 
   let check_evars env sigma extsigma origsigma =

--- a/tactics/tacticals.mli
+++ b/tactics/tacticals.mli
@@ -218,6 +218,7 @@ module New : sig
   val tclCOMPLETE : 'a tactic -> 'a tactic
   val tclSOLVE : unit tactic list -> unit tactic
   val tclPROGRESS : unit tactic -> unit tactic
+  val tclSELECT : goal_selector -> 'a tactic -> 'a tactic
   val tclWITHHOLES : bool -> 'a tactic -> Evd.evar_map -> 'a tactic
 
   val tclTIMEOUT : int -> unit tactic -> unit tactic

--- a/test-suite/success/destruct.v
+++ b/test-suite/success/destruct.v
@@ -106,7 +106,7 @@ Goal exists x, S 0 = S x.
 eexists ?[x].
 destruct (S _). (* Incompatible occurrences but takes the first one since Oct 2014 *)
 change (0 = S ?x).
-?[x]: exact 0. (* Incidentally test applying a tactic to a goal on the shelve *)
+[x]: exact 0. (* Incidentally test applying a tactic to a goal on the shelve *)
 Abort.
 
 Goal exists n p:nat, (S n,S n) = (S p,S p) /\ p = n.

--- a/test-suite/success/destruct.v
+++ b/test-suite/success/destruct.v
@@ -106,7 +106,7 @@ Goal exists x, S 0 = S x.
 eexists ?[x].
 destruct (S _). (* Incompatible occurrences but takes the first one since Oct 2014 *)
 change (0 = S ?x).
-[x]: exact 0. (* Incidentally test applying a tactic to a goal on the shelve *)
+?[x]: exact 0. (* Incidentally test applying a tactic to a goal on the shelve *)
 Abort.
 
 Goal exists n p:nat, (S n,S n) = (S p,S p) /\ p = n.

--- a/test-suite/success/goal_selector.v
+++ b/test-suite/success/goal_selector.v
@@ -51,5 +51,5 @@ Qed.
 
 Goal True -> exists (x : Prop), x.
 Proof.
-  intro H; eexists ?[x]; ?[x]: exact True; assumption.
+  intro H; eexists ?[x]. [x]: exact True. 1: assumption.
 Qed.

--- a/test-suite/success/goal_selector.v
+++ b/test-suite/success/goal_selector.v
@@ -1,0 +1,33 @@
+Inductive two : bool -> Prop :=
+| Zero : two false
+| One : two true.
+
+Ltac dup :=
+  let H := fresh in assert (forall (P : Prop), P -> P -> P) as H by (intros; trivial);
+  apply H; clear H.
+
+Lemma transform : two false <-> two true.
+Proof. split; intros _; constructor. Qed.
+
+Goal two false /\ two true /\ two false /\ two true /\ two true /\ two true.
+Proof.
+  do 2 dup.
+  - repeat split.
+    [2, 4-99, 100-3]:idtac.
+    [2-5]:exact One.
+    par:exact Zero.
+  - repeat split.
+    [3-6]:swap 1 4.
+    [1-5]:swap 1 5.
+    [0-4]:exact One.
+    all:exact Zero.
+  - repeat split.
+    [1, 3]:exact Zero.
+    [1, 2, 3, 4]: exact One.
+  - repeat split.
+    all:apply transform.
+    [2, 4, 6]:apply transform.
+    all:apply transform.
+    [1-5]:apply transform.
+    [1-6]:exact One.
+Qed.

--- a/test-suite/success/goal_selector.v
+++ b/test-suite/success/goal_selector.v
@@ -13,21 +13,29 @@ Goal two false /\ two true /\ two false /\ two true /\ two true /\ two true.
 Proof.
   do 2 dup.
   - repeat split.
-    [2, 4-99, 100-3]:idtac.
-    [2-5]:exact One.
+    2, 4-99, 100-3:idtac.
+    2-5:exact One.
     par:exact Zero.
   - repeat split.
-    [3-6]:swap 1 4.
-    [1-5]:swap 1 5.
-    [0-4]:exact One.
+    3-6:swap 1 4.
+    1-5:swap 1 5.
+    0-4:exact One.
     all:exact Zero.
   - repeat split.
-    [1, 3]:exact Zero.
-    [1, 2, 3, 4]: exact One.
+    1, 3:exact Zero.
+    1, 2, 3, 4: exact One.
   - repeat split.
     all:apply transform.
-    [2, 4, 6]:apply transform.
+    2, 4, 6:apply transform.
     all:apply transform.
-    [1-5]:apply transform.
-    [1-6]:exact One.
+    1-5:apply transform.
+    1-6:exact One.
+Qed.
+
+Goal True -> True.
+Proof.
+  intros y.
+  Fail 1-1:let x := y in idtac x.
+  1:let x := y in idtac x.
+  exact I.
 Qed.

--- a/test-suite/success/goal_selector.v
+++ b/test-suite/success/goal_selector.v
@@ -34,8 +34,22 @@ Qed.
 
 Goal True -> True.
 Proof.
-  intros y.
+  intros y; 1-2 : repeat idtac.
+  1-1:match goal with y : _ |- _ => let x := y in idtac x end.
   Fail 1-1:let x := y in idtac x.
   1:let x := y in idtac x.
   exact I.
+Qed.
+
+Goal True /\ (True /\ True).
+Proof.
+  dup.
+  - split; 2: (split; exact I).
+    exact I.
+  - split; 2: split; exact I.
+Qed.
+
+Goal True -> exists (x : Prop), x.
+Proof.
+  intro H; eexists ?[x]; ?[x]: exact True; assumption.
 Qed.

--- a/toplevel/vernacentries.ml
+++ b/toplevel/vernacentries.ml
@@ -842,7 +842,7 @@ let vernac_solve n info tcom b =
     error "Unknown command of the non proof-editing mode.";
   let status = Proof_global.with_current_proof (fun etac p ->
     let with_end_tac = if b then Some etac else None in
-    let global = match n with SelectAll -> true | _ -> false in
+    let global = match n with SelectAll | SelectList _ -> true | _ -> false in
     let info = Option.append info !print_info_trace in
     let (p,status) =
       solve n info (Tacinterp.hide_interp global tcom None) ?with_end_tac p


### PR DESCRIPTION
This patch adds range selectors for tactics.
You can write "[1, 3-5]: tac." to apply the tactic "tac" to the goals numbered 1, 3, 4 and 5.
