### PR TITLE
Extra interface to print Gc stats

### DIFF
--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -100,9 +100,21 @@ let output_context = ref false
 let memory_stat = ref false
 
 let print_memory_stat () =
-  if !memory_stat then
+  begin (* -m|--memory from the command-line *)
+    if !memory_stat then
     ppnl
-      (str "total heap size = " ++ int (CObj.heap_size_kb ()) ++ str " kbytes")
+      (str "total heap size = " ++ int (CObj.heap_size_kb ()) ++ str " kbytes");
+  end;
+  begin
+    (* operf-macro interface:
+       https://github.com/OCamlPro/operf-macro *)
+    try
+      let fn = Sys.getenv "OCAML_GC_STATS" in
+      let oc = open_out fn in
+      Gc.print_stat oc;
+      close_out oc
+    with _ -> ()
+  end
 
 let _ = at_exit print_memory_stat
 

--- a/toplevel/usage.ml
+++ b/toplevel/usage.ml
@@ -52,7 +52,7 @@ let print_usage_channel co command =
 \n                         proofs in each fi.vio\
 \n\
 \n  -where                 print Coq's standard library location and exit\
-\n  -config                print Coq's configuration information and exit\
+\n  -config, --config      print Coq's configuration information and exit\
 \n  -v                     print Coq version and exit\
 \n  -list-tags             print highlight color tags known by Coq and exit\
 \n\
@@ -74,8 +74,12 @@ let print_usage_channel co command =
 \n  -indices-matter        levels of indices (and nonuniform parameters) contribute to the level of inductives\
 \n  -type-in-type          disable universe consistency checking\
 \n  -time                  display the time taken by each command\
+\n  -m, --memory           display total heap size at program exit\
+\n                         (use environment variable\
+\n                          OCAML_GC_STATS=\"/tmp/gclog.txt\"\
+\n                          for full Gc stats dump)
 \n  -native-compiler       precompile files for the native_compute machinery\
-\n  -h, -help              print this list of options\
+\n  -h, -help, --help      print this list of options\
 \n";
   List.iter (fun (name, text) ->
     output_string co


### PR DESCRIPTION
When the environment variable `OCAML_GC_STATS` points to a filepath, write Gc stats into it

This interface is promoted by the [https://github.com/OCamlPro/operf-macro](operf-macro tool) which allows to run benchmarks of time and memory usage of various OCaml programs.

Coq already has two ways to get Gc infos:
- the `-m|--memory` command-line flag prints the total heap words allocated
- the `Print Debug Gc` command prints much more information, but in a Coq-implementation-defined format that is not suitable for across-programs comparison (also an environment variable allows to profile Coq runs on any .v, in an non-intrusive way)
