### PR TITLE
dev/tool/anomaly-traces-parser.el

### DIFF
--- a/dev/README
+++ b/dev/README
@@ -45,3 +45,6 @@ Makefile.subdir: makefile dedicated to intensive work in a given subdirectory
 Makefile.devel: utilities to automatically launch coq in various states
 Makefile.common: used by other Makefiles
 objects.el: various development utilities at emacs level
+anomaly-traces-parser.el: a .emacs-ready elisp snippet to parse
+  location of Anomaly backtraces and jump to them conveniently from
+  the Emacs *compilation* output.

--- a/dev/tools/anomaly-traces-parser.el
+++ b/dev/tools/anomaly-traces-parser.el
@@ -1,0 +1,28 @@
+;; This Elisp snippet adds a regexp parser for the format of Anomaly
+;; backtraces (coqc -bt ...), to the error parser of the Compilation
+;; mode (C-c C-c: "Compile command: ..."). Once the
+;; coq-change-error-alist-for-backtraces function has run, file
+;; locations in traces are recognized and can be jumped from easily
+;; from the *compilation* buffer.
+
+;; You can just copy everything below to your .emacs and this will be
+;; enabled from any compilation command launched from an OCaml file.
+
+(defun coq-change-error-alist-for-backtraces ()
+  "Hook to change the compilation-error-regexp-alist variable, to
+   search the coq backtraces for error locations"
+  (interactive)
+  (add-to-list
+   'compilation-error-regexp-alist-alist
+   '(coq-backtrace
+     "^ *\\(?:raise\\|frame\\) @ file \\(\"?\\)\\([^,\" \n\t<>]+\\)\\1,\
+      lines? \\([0-9]+\\)-?\\([0-9]+\\)?\\(?:$\\|,\
+      \\(?: characters? \\([0-9]+\\)-?\\([0-9]+\\)?:?\\)?\\)"
+     2 (3 . 4) (5 . 6)))
+  (add-to-list 'compilation-error-regexp-alist 'coq-backtrace))
+
+;; this Anomaly parser should be available when one is hacking
+;; on the *OCaml* code of Coq (adding bugs), so we enable it
+;; through the OCaml mode hooks.
+(add-hook 'caml-mode-hook 'coq-change-error-alist-for-backtraces)
+(add-hook 'tuareg-mode-hook 'coq-change-error-alist-for-backtraces)


### PR DESCRIPTION
An .emacs-ready elisp snippet to parse location of Anomaly backtraces
and jump to them conveniently from the Emacs `*compilation*` output.
