### PR TITLE
Purer VM

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -101,7 +101,7 @@ BYTEFLAGS=-thread $(CAMLDEBUG) $(USERFLAGS)
 OPTFLAGS=-thread $(CAMLDEBUGOPT) $(CAMLTIMEPROF) $(USERFLAGS)
 DEPFLAGS= $(LOCALINCLUDES) -I ide -I ide/utils
 
-ifeq ($(shell which codesign > /dev/null && echo $(ARCH)),Darwin)
+ifeq ($(shell which codesign 2>&1 > /dev/null && echo $(ARCH)),Darwin)
 LINKMETADATA=-ccopt "-sectcreate __TEXT __info_plist config/Info-$(notdir $@).plist"
 CODESIGN:=codesign -s -
 else

--- a/kernel/cemitcodes.ml
+++ b/kernel/cemitcodes.ml
@@ -29,10 +29,18 @@ let patch_char4 buff pos c1 c2 c3 c4 =
   String.unsafe_set buff (pos + 2) c3;
   String.unsafe_set buff (pos + 3) c4 
   
-let patch_int buff pos n =
+let patch buff (pos, n) =
   patch_char4 buff pos 
     (Char.unsafe_chr n) (Char.unsafe_chr (n asr 8))  (Char.unsafe_chr (n asr 16))
     (Char.unsafe_chr (n asr 24))
+
+let patch_int buff patches =
+  (* copy code *before* patching because of nested evaluations:
+     the code we are patching might be called (and thus "concurrently" patched)
+     and results in wrong results. Side-effects... *)
+  let buff = String.copy buff in
+  let () = List.iter (fun p -> patch buff p) patches in
+  buff
 
 (* Buffering of bytecode *)
 

--- a/kernel/cemitcodes.ml
+++ b/kernel/cemitcodes.ml
@@ -372,6 +372,8 @@ let to_memory (init_code, fun_code, fv) =
   emit fun_code;
   let code = String.create !out_position in
   String.unsafe_blit !out_buffer 0 code 0 !out_position;
+  (** Later uses of this string are all purely functional *)
+  let code = CString.hcons code in
   let reloc = List.rev !reloc_info in
   Array.iter (fun lbl ->
     (match lbl with

--- a/kernel/cemitcodes.mli
+++ b/kernel/cemitcodes.mli
@@ -13,11 +13,9 @@ val subst_patch : Mod_subst.substitution -> patch -> patch
 
 type emitcodes
 
-val copy : emitcodes -> emitcodes
-
 val length : emitcodes -> int
 
-val patch_int : emitcodes -> (*pos*)int -> int -> unit
+val patch_int : emitcodes -> ((*pos*)int * int) list -> emitcodes
 
 type to_patch = emitcodes * (patch list) * fv
 

--- a/kernel/csymtable.ml
+++ b/kernel/csymtable.ml
@@ -193,19 +193,13 @@ and slot_for_fv env fv =
       end
 
 and eval_to_patch env (buff,pl,fv) =
-  (* copy code *before* patching because of nested evaluations:
-     the code we are patching might be called (and thus "concurrently" patched)
-     and results in wrong results. Side-effects... *)
-  let buff = Cemitcodes.copy buff in
   let patch = function
-    | Reloc_annot a, pos -> patch_int buff pos (slot_for_annot a)
-    | Reloc_const sc, pos -> patch_int buff pos (slot_for_str_cst sc)
-    | Reloc_getglobal kn, pos ->
-(*      Pp.msgnl (str"patching global: "++str(debug_string_of_con kn));*)
-	patch_int buff pos (slot_for_getglobal env kn);
-(*      Pp.msgnl (str"patch done: "++str(debug_string_of_con kn))*)
+    | Reloc_annot a, pos -> (pos, slot_for_annot a)
+    | Reloc_const sc, pos -> (pos, slot_for_str_cst sc)
+    | Reloc_getglobal kn, pos -> (pos, slot_for_getglobal env kn)
   in
-  List.iter patch pl;
+  let patches = List.map_left patch pl in
+  let buff = patch_int buff patches in
   let vm_env = Array.map (slot_for_fv env) fv in
   let tc = tcode_of_code buff (length buff) in
 (*Pp.msgnl (str"execute code");*)

--- a/test-suite/output/Notations.out
+++ b/test-suite/output/Notations.out
@@ -70,7 +70,7 @@ FST (0; 1)
      : Z
 Nil
      : forall A : Type, list A
-NIL:list nat
+NIL : list nat
      : list nat
 (false && I 3)%bool /\ I 6
      : Prop
@@ -78,7 +78,7 @@ NIL:list nat
      : Z * Z * Z * (Z * Z * Z)
 [|0 * (1, 2, 3); (4, 5, 6) * false|]
      : Z * Z * (Z * Z) * (Z * Z) * (Z * bool * (Z * bool) * (Z * bool))
-fun f : Z -> Z -> Z -> Z => {|f; 0; 1; 2|}:Z
+fun f : Z -> Z -> Z -> Z => {|f; 0; 1; 2|} : Z
      : (Z -> Z -> Z -> Z) -> Z
 Init.Nat.add
      : nat -> nat -> nat

--- a/test-suite/output/inference.out
+++ b/test-suite/output/inference.out
@@ -6,12 +6,12 @@ fun e : option L => match e with
      : option L -> option L
 fun (m n p : nat) (H : S m <= S n + p) => le_S_n m (n + p) H
      : forall m n p : nat, S m <= S n + p -> m <= n + p
-fun n : nat => let x := A n in ?y ?y0:T n
+fun n : nat => let x := A n in ?y ?y0 : T n
      : forall n : nat, T n
 where
 ?y : [n : nat  x := A n : T n |- ?T0 -> T n] 
 ?y0 : [n : nat  x := A n : T n |- ?T0] 
-fun n : nat => ?y ?y0:T n
+fun n : nat => ?y ?y0 : T n
      : forall n : nat, T n
 where
 ?y : [n : nat |- ?T0 -> T n] 

--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -649,7 +649,79 @@ let init arglist =
 
 let init_toplevel = init
 
+module Foo =
+struct
+open Memprof
+open Printexc
+
+type sampleTree =
+    STC of sample list * int * (raw_backtrace_slot, sampleTree) Hashtbl.t
+
+let add_sampleTree (s:sample) (t:sampleTree) : sampleTree =
+  let rec aux idx (STC (sl, n, sth)) =
+    if idx >= Printexc.raw_backtrace_length s.callstack then
+      STC(s::sl, n+s.occurences, sth)
+    else
+      let li = Printexc.get_raw_backtrace_slot s.callstack idx in
+      let child =
+        try Hashtbl.find sth li
+        with Not_found -> STC ([], 0, Hashtbl.create 3)
+      in
+      Hashtbl.replace sth li (aux (idx+1) child);
+      STC(sl, n+s.occurences, sth)
+  in
+  aux 1 t
+
+type sortedSampleTree =
+    SSTC of sample list * int * (raw_backtrace_slot * sortedSampleTree) list
+
+let rec sort_sampleTree (t:sampleTree) : sortedSampleTree =
+  let STC (sl, n, sth) = t in
+  SSTC (sl, n,
+        List.sort (fun (_, SSTC (_, n1, _)) (_, SSTC (_, n2, _)) -> n2 - n1)
+          (Hashtbl.fold (fun li st lst -> (li, sort_sampleTree st)::lst) sth []))
+
+let print chan (SSTC (_, n, tl)) =
+  let rec aux indent =
+    List.iter (fun (li, SSTC (sl, n, tl)) ->
+      begin match Printexc.Slot.location (convert_raw_backtrace_slot li) with
+      | Some { filename; line_number; start_char; end_char } ->
+          Printf.fprintf chan "%7d | %s%s:%d %d-%d" n indent filename line_number start_char end_char
+      | None ->
+          Printf.fprintf chan "%7d | %s?" n indent
+      end;
+      (match sl with
+      | _ :: _ ->
+          let mean =
+            (List.fold_left (+.) 0. (List.map (fun x -> float_of_int x.size) sl)) /.
+            (float_of_int (List.length sl))
+          in
+          Printf.fprintf chan " mean size=%f\n" mean
+      | [] -> Printf.fprintf chan "\n");
+      aux (indent^"  ") tl)
+  in
+  Printf.fprintf chan "%7d | Total samples\n" n;
+  aux "" tl
+
+let dump () =
+  sort_sampleTree
+    (Array.fold_left (fun st s -> add_sampleTree s st) (STC ([], 0, Hashtbl.create 3))
+       (Memprof.dump_samples ()))
+end
+
+let () =
+  let count = ref 0 in
+  let signal _ =
+    let () = incr count in
+    let f = Printf.sprintf "%i.%i" (Unix.getpid ()) !count in
+    let chan = open_out f in
+    let () = try Foo.print chan (Foo.dump ()) with _ -> () in
+    close_out chan
+  in
+  Sys.set_signal Sys.sigusr1 (Sys.Signal_handle signal)
+
 let start () =
+  let () = Memprof.(set_ctrl { lambda = 0.001; dumpped_callstack_size = 5; }) in
   let () = init_toplevel (List.tl (Array.to_list Sys.argv)) in
   (* In batch mode, Coqtop has already exited at this point. In interactive one,
      dump glob is nothing but garbage ...  *)


### PR DESCRIPTION
1. We expose a pure interface to patch the bytecode produced by the VM
2. We exploit the ensured purity to hashcons all bytecodes in the term declarations.
