### PR TITLE
Few minor bugs in 8.5

### DIFF
--- a/checker/indtypes.ml
+++ b/checker/indtypes.ml
@@ -292,8 +292,16 @@ let explain_ind_err ntyp env0 nbpar c err =
 	raise (InductiveError
 		 (NotConstructor (env,c',Rel (ntyp+nbpar))))
     | LocalNonPar (n,l) ->
-	raise (InductiveError
-		 (NonPar (env,c',n,Rel (nbpar-n+1), Rel (l+nbpar))))
+        let rec index_nth_hyp pos k = function
+          | (_,Some _,_)::l -> index_nth_hyp (pos + 1) k l
+          | (_,None,_)::l when k = 1 -> pos
+          | (_,None,_)::l -> index_nth_hyp (pos + 1) (k - 1) l
+          | _ -> assert false
+        in 
+        assert (1 <= n && n <= nbpar);
+        let nth_hyp = index_nth_hyp 1 n (List.rev lpar) in
+        raise (InductiveError
+		 (NonPar (env,c',n,Rel (nbpar-nth_hyp+1),Rel (l+nbpar))))
 
 let failwith_non_pos n ntypes c =
   for k = n to n + ntypes - 1 do

--- a/checker/indtypes.ml
+++ b/checker/indtypes.ml
@@ -269,7 +269,7 @@ type ill_formed_ind =
   | LocalNonPos of int
   | LocalNotEnoughArgs of int
   | LocalNotConstructor
-  | LocalNonPar of int * int
+  | LocalNonPar of int * int * int
 
 exception IllFormedInd of ill_formed_ind
 
@@ -291,9 +291,9 @@ let explain_ind_err ntyp env0 nbpar c err =
     | LocalNotConstructor ->
 	raise (InductiveError
 		 (NotConstructor (env,c',Rel (ntyp+nbpar))))
-    | LocalNonPar (n,l) ->
+    | LocalNonPar (n,i,l) ->
 	raise (InductiveError
-		 (NonPar (env,c',n,Rel (nbpar-n+1), Rel (l+nbpar))))
+		 (NonPar (env,c',n,Rel i,Rel (l+nbpar))))
 
 let failwith_non_pos n ntypes c =
   for k = n to n + ntypes - 1 do
@@ -323,7 +323,7 @@ let check_correct_par (env,n,ntypes,_) hyps l largs =
     | _::hyps ->
         match whd_betadeltaiota env lpar.(k) with
 	  | Rel w when w = index -> check (k-1) (index+1) hyps
-	  | _ -> raise (IllFormedInd (LocalNonPar (k+1,l)))
+	  | _ -> raise (IllFormedInd (LocalNonPar (k+1,index,l)))
   in check (nparams-1) (n-nhyps) hyps;
   if not (Array.for_all (noccur_between n ntypes) largs') then
     failwith_non_pos_vect n ntypes largs'

--- a/checker/indtypes.ml
+++ b/checker/indtypes.ml
@@ -292,16 +292,8 @@ let explain_ind_err ntyp env0 nbpar c err =
 	raise (InductiveError
 		 (NotConstructor (env,c',Rel (ntyp+nbpar))))
     | LocalNonPar (n,l) ->
-        let rec index_nth_hyp pos k = function
-          | (_,Some _,_)::l -> index_nth_hyp (pos + 1) k l
-          | (_,None,_)::l when k = 1 -> pos
-          | (_,None,_)::l -> index_nth_hyp (pos + 1) (k - 1) l
-          | _ -> assert false
-        in 
-        assert (1 <= n && n <= nbpar);
-        let nth_hyp = index_nth_hyp 1 n (List.rev lpar) in
-        raise (InductiveError
-		 (NonPar (env,c',n,Rel (nbpar-nth_hyp+1),Rel (l+nbpar))))
+	raise (InductiveError
+		 (NonPar (env,c',n,Rel (nbpar-n+1), Rel (l+nbpar))))
 
 let failwith_non_pos n ntypes c =
   for k = n to n + ntypes - 1 do

--- a/kernel/indtypes.ml
+++ b/kernel/indtypes.ml
@@ -361,7 +361,7 @@ type ill_formed_ind =
   | LocalNonPos of int
   | LocalNotEnoughArgs of int
   | LocalNotConstructor
-  | LocalNonPar of int * int
+  | LocalNonPar of int * int * int
 
 exception IllFormedInd of ill_formed_ind
 
@@ -382,9 +382,9 @@ let explain_ind_err id ntyp env nbpar c nargs err =
     | LocalNotConstructor ->
 	raise (InductiveError
 		 (NotConstructor (env,id,c',mkRel (ntyp+nbpar),nbpar,nargs)))
-    | LocalNonPar (n,l) ->
+    | LocalNonPar (n,i,l) ->
 	raise (InductiveError
-		 (NonPar (env,c',n,mkRel (nbpar-n+1), mkRel (l+nbpar))))
+		 (NonPar (env,c',n,mkRel i, mkRel (l+nbpar))))
 
 let failwith_non_pos n ntypes c =
   for k = n to n + ntypes - 1 do
@@ -413,7 +413,7 @@ let check_correct_par (env,n,ntypes,_) hyps l largs =
     | _::hyps ->
         match kind_of_term (whd_betadeltaiota env lpar.(k)) with
 	  | Rel w when Int.equal w index -> check (k-1) (index+1) hyps
-	  | _ -> raise (IllFormedInd (LocalNonPar (k+1,l)))
+	  | _ -> raise (IllFormedInd (LocalNonPar (k+1, index, l)))
   in check (nparams-1) (n-nhyps) hyps;
   if not (Array.for_all (noccur_between n ntypes) largs') then
     failwith_non_pos_vect n ntypes largs'

--- a/kernel/indtypes.ml
+++ b/kernel/indtypes.ml
@@ -383,16 +383,8 @@ let explain_ind_err id ntyp env nbpar c nargs err =
 	raise (InductiveError
 		 (NotConstructor (env,id,c',mkRel (ntyp+nbpar),nbpar,nargs)))
     | LocalNonPar (n,l) ->
-        let rec index_nth_hyp pos k = function
-          | (_,Some _,_)::l -> index_nth_hyp (pos + 1) k l
-          | (_,None,_)::l when k = 1 -> pos
-          | (_,None,_)::l -> index_nth_hyp (pos + 1) (k - 1) l
-          | _ -> assert false
-        in 
-        assert (1 <= n && n <= nbpar);
-        let nth_hyp = index_nth_hyp 1 n (List.rev lpar) in
 	raise (InductiveError
-		 (NonPar (env,c',n,mkRel (nbpar-nth_hyp+1),mkRel (l+nbpar))))
+		 (NonPar (env,c',n,mkRel (nbpar-n+1), mkRel (l+nbpar))))
 
 let failwith_non_pos n ntypes c =
   for k = n to n + ntypes - 1 do

--- a/kernel/indtypes.ml
+++ b/kernel/indtypes.ml
@@ -383,8 +383,16 @@ let explain_ind_err id ntyp env nbpar c nargs err =
 	raise (InductiveError
 		 (NotConstructor (env,id,c',mkRel (ntyp+nbpar),nbpar,nargs)))
     | LocalNonPar (n,l) ->
+        let rec index_nth_hyp pos k = function
+          | (_,Some _,_)::l -> index_nth_hyp (pos + 1) k l
+          | (_,None,_)::l when k = 1 -> pos
+          | (_,None,_)::l -> index_nth_hyp (pos + 1) (k - 1) l
+          | _ -> assert false
+        in 
+        assert (1 <= n && n <= nbpar);
+        let nth_hyp = index_nth_hyp 1 n (List.rev lpar) in
 	raise (InductiveError
-		 (NonPar (env,c',n,mkRel (nbpar-n+1), mkRel (l+nbpar))))
+		 (NonPar (env,c',n,mkRel (nbpar-nth_hyp+1),mkRel (l+nbpar))))
 
 let failwith_non_pos n ntypes c =
   for k = n to n + ntypes - 1 do

--- a/library/library.ml
+++ b/library/library.ml
@@ -378,7 +378,7 @@ let access_table what tables dp i =
     | Fetched t -> t
     | ToFetch f ->
       let dir_path = Names.DirPath.to_string dp in
-      msg_info (str"Fetching " ++ str what++str" from disk for " ++ str dir_path);
+      Flags.if_verbose msg_info (str"Fetching " ++ str what++str" from disk for " ++ str dir_path);
       let t =
         try fetch_delayed f
         with Faulty f ->

--- a/tools/coq_makefile.ml
+++ b/tools/coq_makefile.ml
@@ -386,12 +386,12 @@ let implicit () =
     print "$(MLLIBFILES:.mllib=.cma): %.cma: | %.mllib\n\t$(CAMLLINK) $(ZDEBUG) $(ZFLAGS) -a -o $@ $^\n\n";
     print "$(MLLIBFILES:.mllib=.cmxa): %.cmxa: | %.mllib\n\t$(CAMLOPTLINK) $(ZDEBUG) $(ZFLAGS) -a -o $@ $^\n\n";
     print "$(addsuffix .d,$(MLLIBFILES)): %.mllib.d: %.mllib\n";
-    print "\t$(COQDEP) $(OCAMLLIBS) \"$<\" > \"$@\" || ( RV=$$?; rm -f \"$@\"; exit $${RV} )\n\n" in
+    print "\t$(COQDEP) $(OCAMLLIBS) -c \"$<\" > \"$@\" || ( RV=$$?; rm -f \"$@\"; exit $${RV} )\n\n" in
   let mlpack_rules () =
     print "$(MLPACKFILES:.mlpack=.cmo): %.cmo: | %.mlpack\n\t$(CAMLLINK) $(ZDEBUG) $(ZFLAGS) -pack -o $@ $^\n\n";
     print "$(MLPACKFILES:.mlpack=.cmx): %.cmx: | %.mlpack\n\t$(CAMLOPTLINK) $(ZDEBUG) $(ZFLAGS) -pack -o $@ $^\n\n";
     print "$(addsuffix .d,$(MLPACKFILES)): %.mlpack.d: %.mlpack\n";
-    print "\t$(COQDEP) $(OCAMLLIBS) \"$<\" > \"$@\" || ( RV=$$?; rm -f \"$@\"; exit $${RV} )\n\n";
+    print "\t$(COQDEP) $(OCAMLLIBS) -c \"$<\" > \"$@\" || ( RV=$$?; rm -f \"$@\"; exit $${RV} )\n\n";
 in
   let v_rules () =
     print "$(VOFILES): %.vo: %.v\n\t$(COQC) $(COQDEBUG) $(COQFLAGS) $*\n\n";

--- a/toplevel/himsg.ml
+++ b/toplevel/himsg.ml
@@ -1086,7 +1086,7 @@ let error_bad_ind_parameters env c n v1 v2  =
   let pv1 = pr_lconstr_env env Evd.empty v1 in
   let pv2 = pr_lconstr_env env Evd.empty v2 in
   str "Last occurrence of " ++ pv2 ++ str " must have " ++ pv1 ++
-  str " as " ++ pr_nth n ++ str " argument in " ++ brk(1,1) ++ pc ++ str "."
+  str " as " ++ pr_nth n ++ str " argument in" ++ brk(1,1) ++ pc ++ str "."
 
 let error_same_names_types id =
   str "The name" ++ spc () ++ pr_id id ++ spc () ++


### PR DESCRIPTION
Prior to commit 964d1b70, the dependency files .mllib.d and .mlpack.d
were generated by a call to coqdep using the argument -c (for ocaml
code). While doing some finetuning of the generation of implicit rules,
this commit removed (I think by mistake) this "-c". And without this
-c argument coqdep output nothing on mllib files leading to incorrect
linking of mllibs.
