### PR TITLE
Port the [reduce] tactics to the new tactics engine.

### DIFF
--- a/plugins/funind/functional_principles_proofs.ml
+++ b/plugins/funind/functional_principles_proofs.ml
@@ -371,12 +371,12 @@ let isLetIn t =
     | _ -> false
 
 
-let h_reduce_with_zeta =
-  reduce
+let h_reduce_with_zeta l =
+  Proofview.V82.of_tactic (reduce
     (Genredexpr.Cbv
        {Redops.all_flags
 	with Genredexpr.rDelta = false;
-       })
+       }) l)
 
 
 
@@ -707,7 +707,7 @@ let build_proof
 		    [
 		      Simple.generalize (term_eq::(List.map mkVar dyn_infos.rec_hyps));
 		      thin dyn_infos.rec_hyps;
-		      pattern_option [Locus.AllOccurrencesBut [1],t] None;
+		      Proofview.V82.of_tactic (pattern_option [Locus.AllOccurrencesBut [1],t] None);
 		      (fun g -> observe_tac "toto" (
 			 tclTHENSEQ [Proofview.V82.of_tactic (Simple.case t);
 				     (fun g' ->

--- a/plugins/funind/indfun.ml
+++ b/plugins/funind/indfun.ml
@@ -113,7 +113,7 @@ let functional_induction with_clean c princl pat =
 	in
 	Tacticals.tclTHEN
 	  (Tacticals.tclMAP (fun id -> Tacticals.tclTRY (Proofview.V82.of_tactic (Equality.subst_gen (do_rewrite_dependent ()) [id]))) idl )
-	  (Tactics.reduce flag Locusops.allHypsAndConcl)
+	  (Proofview.V82.of_tactic (Tactics.reduce flag Locusops.allHypsAndConcl))
 	  g
       else Tacticals.tclIDTAC g
     in

--- a/plugins/funind/invfun.ml
+++ b/plugins/funind/invfun.ml
@@ -362,14 +362,14 @@ let prove_fun_correct evd functional_induction funs_constr graphs_constr schemes
 	    (* unfolding of all the defined variables introduced by this branch *)
 	    (* observe_tac "unfolding" pre_tac; *)
 	    (* $zeta$ normalizing of the conclusion *)
-	    reduce
+	    Proofview.V82.of_tactic (reduce
 	      (Genredexpr.Cbv
 		 { Redops.all_flags with
 		     Genredexpr.rDelta = false ;
 		     Genredexpr.rConst = []
 		 }
 	      )
-	      Locusops.onConcl;
+	      Locusops.onConcl);
 	    observe_tac ("toto ") tclIDTAC;
     
 	    (* introducing the the result of the graph and the equality hypothesis *)
@@ -531,12 +531,12 @@ and intros_with_rewrite_aux : tactic =
 		      ] g
 		  | LetIn _ ->
 		      tclTHENSEQ[
-			reduce
+			Proofview.V82.of_tactic (reduce
 			  (Genredexpr.Cbv
 			     {Redops.all_flags
 			      with Genredexpr.rDelta = false;
 			     })
-			  Locusops.onConcl
+			  Locusops.onConcl)
 			;
 			intros_with_rewrite
 		      ] g
@@ -546,12 +546,12 @@ and intros_with_rewrite_aux : tactic =
 	      end
 	  | LetIn _ ->
 	      tclTHENSEQ[
-		reduce
+		Proofview.V82.of_tactic (reduce
 		  (Genredexpr.Cbv
 		     {Redops.all_flags
 		      with Genredexpr.rDelta = false;
 		     })
-		  Locusops.onConcl
+		  Locusops.onConcl)
 		;
 		intros_with_rewrite
 	      ] g
@@ -691,12 +691,12 @@ let prove_fun_complete funcs graphs schemes lemmas_types_infos i : tactic =
 	  Proofview.V82.of_tactic (Equality.rewriteLR (mkConst eq_lemma));
 	  (* Don't forget to $\zeta$ normlize the term since the principles
              have been $\zeta$-normalized *)
-	  reduce
+	  Proofview.V82.of_tactic (reduce
 	    (Genredexpr.Cbv
 	       {Redops.all_flags
 		with Genredexpr.rDelta = false;
 	       })
-	    Locusops.onConcl
+	    Locusops.onConcl)
 	  ;
 	  Simple.generalize (List.map mkVar ids);
 	  thin ids

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -157,11 +157,11 @@ let rec n_x_id ids n =
 
 
 let simpl_iter clause =
-  reduce
+  Proofview.V82.of_tactic (reduce
     (Lazy
        {rBeta=true;rIota=true;rZeta= true; rDelta=false;
         rConst = [ EvalConstRef (const_of_ref (delayed_force iter_ref))]})
-    clause
+    clause)
 
 (* Others ugly things ... *)
 let (value_f:constr list -> global_reference -> constr) =

--- a/proofs/logic.mli
+++ b/proofs/logic.mli
@@ -16,6 +16,9 @@ open Proof_type
 
 val with_check    : tactic -> tactic
 
+(** This flag is exported for compatibility reasons. Do not use it directly. *)
+val check : bool ref
+
 (** [without_check] respectively means:\\
   [Intro]: no check that the name does not exist\\
   [Intro_after]: no check that the name does not exist and that variables in

--- a/proofs/proofview.ml
+++ b/proofs/proofview.ml
@@ -1210,4 +1210,14 @@ module V82 = struct
     with e when catchable_exception e ->
       let (e, info) = Errors.push e in tclZERO ~info e
 
+  (** Compatibility version of [with_check]. This adds a [tclONCE] around [t]. *)
+  let with_check t =
+    let get = tclLIFT (NonLogical.make (fun () -> !Logic.check)) in
+    let set x = tclLIFT (NonLogical.make (fun () -> Logic.check := x)) in
+    let open Notations in
+      get >>= fun old ->
+      set true <*>
+      tclIFCATCH (tclONCE t)
+        (fun res -> set old <*> tclUNIT res)
+        (fun (e, info) -> set old <*> tclZERO ~info:info e)
 end

--- a/proofs/proofview.mli
+++ b/proofs/proofview.mli
@@ -582,4 +582,7 @@ module V82 : sig
   (* transforms every Ocaml (catchable) exception into a failure in
      the monad. *)
   val wrap_exceptions : (unit -> 'a tactic) -> 'a tactic
+
+  (** Compatibility version of [with_check]. This adds a [tclONCE] around [t]. *)
+val with_check : 'a tactic -> 'a tactic
 end

--- a/tactics/auto.ml
+++ b/tactics/auto.ml
@@ -370,10 +370,11 @@ and tac_of_hint dbg db_list local_db concl (flags, ({pat=p; code=t;poly=poly})) 
 	   with "debug auto" we don't display the details of inner trivial *)
         (trivial_fail_db (no_dbg ()) (not (Option.is_empty flags)) db_list local_db)
     | Unfold_nth c ->
-      Proofview.V82.tactic (fun gl ->
-       if exists_evaluable_reference (pf_env gl) c then
-	 tclPROGRESS (reduce (Unfold [AllOccurrences,c]) Locusops.onConcl) gl
-       else tclFAIL 0 (str"Unbound reference") gl)
+        Proofview.Goal.enter begin fun gl ->
+          if exists_evaluable_reference (Proofview.Goal.env gl) c then
+            Proofview.tclPROGRESS (reduce (Unfold [AllOccurrences,c]) Locusops.onConcl)
+          else Tacticals.New.tclFAIL 0 (str"Unbound reference")
+        end
     | Extern tacast -> 
       conclPattern concl p tacast
   in

--- a/tactics/eauto.ml4
+++ b/tactics/eauto.ml4
@@ -179,7 +179,7 @@ and e_my_find_search db_list local_db hdc concl =
         | Res_pf_THEN_trivial_fail (term,cl) ->
           Tacticals.New.tclTHEN (Proofview.V82.tactic (unify_e_resolve poly st (term,cl)))
             (e_trivial_fail_db db_list local_db)
-        | Unfold_nth c -> Proofview.V82.tactic (reduce (Unfold [AllOccurrences,c]) onConcl)
+        | Unfold_nth c -> reduce (Unfold [AllOccurrences,c]) onConcl
         | Extern tacast -> conclPattern concl p tacast
        in
        let tac = run_hint t tac in

--- a/tactics/tactics.mli
+++ b/tactics/tactics.mli
@@ -157,8 +157,8 @@ val unfold_option     :
 val change            :
   constr_pattern option -> change_arg -> clause -> tactic
 val pattern_option    :
-  (occurrences * constr) list -> goal_location -> tactic
-val reduce            : red_expr -> clause -> tactic
+  (occurrences * constr) list -> goal_location -> unit Proofview.tactic
+val reduce            : red_expr -> clause -> unit Proofview.tactic
 val unfold_constr     : global_reference -> tactic
 
 (** {6 Modification of the local context. } *)


### PR DESCRIPTION
Some part of [reduce] wasn't yet in the monad, now it is, allowing for all the fanciness.
This change might break some plugins because the type of [reduce] inevitably changed, but not in a bad way, it is just a matter of interface.

Now that I have done it once, I should be able to port more tactics into the monad.

Comments are welcome of course.
