### PR TITLE
Simplify `interp/constrintern.ml:sort_fields`

### DIFF
--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -1001,11 +1001,10 @@ let sort_fields ~complete loc fields completer =
                  begin match proj_kinds with
                     | [] -> anomaly (Pp.str "Number of projections mismatch")
                     | (_, regular) :: proj_kinds ->
+                       (* "regular" is false when the field is defined
+                           by a let-in in the record declaration
+                           (its value is fixed from other fields). *)
                        if first_field && not regular && complete then
-                         (* G.S.: why do we fail only in the
-                            first-field case? I would expect to fail
-                            whenever (not regular && complete), and
-                            skip the fields only when (not complete *)
                          user_err_loc (loc, "", str "No local fields allowed in a record construction.")
                        else if first_field then
                          build_proj_list projs proj_kinds (idx+1) ~acc_first_idx:idx acc

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -1020,7 +1020,6 @@ let sort_fields ~complete loc l completer =
            the constructor *)
         let rec index_fields fields remaining_projs acc =
           match fields with
-            | [] -> acc
             | (field_ref, field_value) :: fields ->
                let field_glob_ref = try global_reference_of_reference field_ref
                with |Not_found ->
@@ -1035,26 +1034,22 @@ let sort_fields ~complete loc l completer =
                       str "This record contains fields of different records.")
                in
                index_fields fields remaining_projs ((field_index, field_value) :: acc)
+            | [] ->
+               (* the order does not matter as we sort them next,
+                  List.rev_* is just for efficiency *)
+               let remaining_fields =
+                 let complete_field (idx, _field_ref) = (idx, completer idx) in
+                 List.rev_map complete_field remaining_projs in
+               List.rev_append remaining_fields acc
         in
-        let unsorted_indexed_pattern =
+        let unsorted_indexed_fields =
           index_fields other_fields proj_list
             [(first_field_index, first_field_value)] in
-        (* we sort them *)
-        let sorted_indexed_pattern =
+        let sorted_indexed_fields =
           let cmp_by_index (i, _) (j, _) = Int.compare i j in
-          List.sort cmp_by_index unsorted_indexed_pattern in
-        (* a function to complete with wildcards *)
-        let rec complete_list n l =
-          if n <= 1 then l else complete_list (n-1) (completer n l) in
-        (* a function to remove indice *)
-        let rec clean_list l i acc =
-          match l with
-            | [] -> complete_list (end_index - i) acc
-            | (k, p)::q-> clean_list q k (p::(complete_list (k - i) acc))
-          in
-        Some (nparams, base_constructor,
-          List.rev (clean_list sorted_indexed_pattern 0 []))
-
+          List.sort cmp_by_index unsorted_indexed_fields in
+        let sorted_fields = List.map snd sorted_indexed_fields in
+        Some (nparams, base_constructor, sorted_fields)
 
 (** {6 Manage multiple aliases} *)
 
@@ -1153,7 +1148,7 @@ let drop_notations_pattern looked_for =
     | CPatAlias (loc, p, id) -> RCPatAlias (loc, in_pat top env p, id)
     | CPatRecord (loc, l) ->
       let sorted_fields =
-	sort_fields ~complete:false loc l (fun _ l -> (CPatAtom (loc, None))::l) in
+	sort_fields ~complete:false loc l (fun _idx -> (CPatAtom (loc, None))) in
       begin match sorted_fields with
 	| None -> RCPatAtom (loc, None)
 	| Some (_, head, pl) ->
@@ -1502,12 +1497,12 @@ let internalize globalenv env allow_patvar lvar c =
 	    (merge_impargs l args) loc
 
     | CRecord (loc, r, fs) ->
-	let cargs =
+	let fields =
 	  sort_fields ~complete:true loc fs
-	    (fun k l -> CHole (loc, Some (Evar_kinds.QuestionMark (Evar_kinds.Define true)), Misctypes.IntroAnonymous, None) :: l)
+	    (fun _idx -> CHole (loc, Some (Evar_kinds.QuestionMark (Evar_kinds.Define true)), Misctypes.IntroAnonymous, None))
 	in
 	begin
-	  match cargs with
+	  match fields with
 	    | None -> user_err_loc (loc, "intern", str"No constructor inference.")
 	    | Some (n, constrname, args) ->
 		let pars = List.make n (CHole (loc, None, Misctypes.IntroAnonymous, None)) in

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -958,52 +958,64 @@ let sort_fields ~complete loc l completer =
      when pattern-matching, the list of fields may be partial. *)
   match l with
     | [] -> None
-    | (refer, value)::rem ->
-        let (nparams,          (* the number of parameters *)
-             base_constructor, (* the reference constructor of the record *)
-             (max,             (* number of params *)
-              (first_index,    (* index of the first field of the record *)
-               list_proj)))    (* list of projections *)
+    | (first_field_ref, first_field_value):: other_fields ->
+        let env_error_msg = "Environment corruption for records." in
+        let first_field_glob_ref =
+          try global_reference_of_reference first_field_ref
+          with Not_found -> anomaly (Pp.str env_error_msg) in
+        let record =
+          try Recordops.find_projection first_field_glob_ref
+          with Not_found ->
+            user_err_loc (loc_of_reference first_field_ref, "intern",
+                          pr_reference first_field_ref ++ str": Not a projection")
+        in
+        (* the number of parameters *)
+        let nparams = record.Recordops.s_EXPECTEDPARAM in
+        (* the reference constructor of the record *)
+        let base_constructor =
+          let global_record_id = ConstructRef record.Recordops.s_CONST in
+          try Qualid (loc, shortest_qualid_of_global Id.Set.empty global_record_id)
+          with Not_found -> anomaly (Pp.str env_error_msg) in
+        let (end_index,    (* one past the last field index *)
+             first_field_index,  (* index of the first field of the record *)
+             proj_list)    (* list of projections *)
           =
-          let record =
-            try Recordops.find_projection
-              (global_reference_of_reference refer)
-            with Not_found ->
-              user_err_loc (loc_of_reference refer, "intern", pr_reference refer ++ str": Not a projection")
-            in
-          (* elimination of the first field from the projections *)
-          let rec build_patt l m i acc =
-            match l with
-              | [] -> (i, acc)
-              | (Some name) :: b ->
-                 begin match m with
+          (* elimitate the first field from the projections,
+             but keep its index *)
+          let rec build_proj_list projs proj_kinds idx ~acc_first_idx acc =
+            match projs with
+              | [] -> (idx, acc_first_idx, acc)
+              | (Some name) :: projs ->
+                 let field_glob_ref = ConstRef name in
+                 let first_field = eq_gr field_glob_ref first_field_glob_ref in
+                 begin match proj_kinds with
                     | [] -> anomaly (Pp.str "Number of projections mismatch")
-                    | (_, regular)::tm ->
-                       begin match global_reference_of_reference refer with
-                       | ConstRef name' when eq_constant name name' ->
-                         if not regular && complete then
-                           user_err_loc (loc, "", str "No local fields allowed in a record construction.")
-                         else build_patt b tm (i + 1) (i, snd acc) (* we found it *)
-                       | _ ->
-                          build_patt b tm
-                            (if not regular && complete then i else i + 1)
-                            (if not regular && complete then acc
-                             else fst acc, (i, ConstRef name) :: snd acc)
-                       end
+                    | (_, regular) :: proj_kinds ->
+                       if first_field && not regular && complete then
+                         (* G.S.: why do we fail only in the
+                            first-field case? I would expect to fail
+                            whenever (not regular && complete), and
+                            skip the fields only when (not complete *)
+                         user_err_loc (loc, "", str "No local fields allowed in a record construction.")
+                       else if first_field then
+                         build_proj_list projs proj_kinds (idx+1) ~acc_first_idx:idx acc
+                       else if not regular && complete then
+                         (* skip non-regular fields *)
+                         build_proj_list projs proj_kinds idx ~acc_first_idx acc
+                       else
+                         build_proj_list projs proj_kinds (idx+1) ~acc_first_idx
+                                         ((idx, field_glob_ref) :: acc)
                  end
-              | None :: b-> (* we don't want anonymous fields *)
+              | None :: projs ->
                  if complete then
+                   (* we don't want anonymous fields *)
                    user_err_loc (loc, "", str "This record contains anonymous fields.")
-                 else build_patt b m (i+1) acc
-                   (* anonymous arguments don't appear in m *)
+                 else
+                   (* anonymous arguments don't appear in proj_kinds *)
+                   build_proj_list projs proj_kinds (idx+1) ~acc_first_idx acc
           in
-          let ind = record.Recordops.s_CONST in
-          try (* insertion of Constextern.reference_global *)
-            (record.Recordops.s_EXPECTEDPARAM,
-             Qualid (loc, shortest_qualid_of_global Id.Set.empty (ConstructRef ind)),
-             build_patt record.Recordops.s_PROJ record.Recordops.s_PROJKIND 1 (0,[]))
-          with Not_found -> anomaly (Pp.str "Environment corruption for records.")
-          in
+          build_proj_list record.Recordops.s_PROJ record.Recordops.s_PROJKIND 1 ~acc_first_idx:0 []
+        in
         (* now we want to have all fields of the pattern indexed by their place in
            the constructor *)
         let rec sf patts accpatt =
@@ -1029,7 +1041,7 @@ let sort_fields ~complete loc l completer =
                let (index, projs) = add_patt (snd accpatt) [] in
                  sf q ((index, patt)::fst accpatt, projs) in
         let (unsorted_indexed_pattern, remainings) =
-          sf rem ([first_index, value], list_proj) in
+          sf other_fields ([first_field_index, first_field_value], proj_list) in
         (* we sort them *)
         let sorted_indexed_pattern =
           let cmp_by_index (i, _) (j, _) = Int.compare i j in
@@ -1040,7 +1052,7 @@ let sort_fields ~complete loc l completer =
         (* a function to remove indice *)
         let rec clean_list l i acc =
           match l with
-            | [] -> complete_list (max - i) acc
+            | [] -> complete_list (end_index - i) acc
             | (k, p)::q-> clean_list q k (p::(complete_list (k - i) acc))
           in
         Some (nparams, base_constructor,

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -952,11 +952,21 @@ let find_pattern_variable = function
   | Ident (loc,id) -> id
   | Qualid (loc,_) as x -> raise (InternalizationError(loc,NotAConstructor x))
 
-let sort_fields ~complete loc l completer =
-  (* the 'complete' parameter is true when we require that all the
-     record fields be provided -- when building a new record value;
-     when pattern-matching, the list of fields may be partial. *)
-  match l with
+(** [sort_fields ~complete loc fields completer] expects a list
+    [fields] of field assignments [f = e1; g = e2; ...], where [f, g]
+    are fields of a record and [e1] are "values" (either terms, when
+    interning a record construction, or patterns, when intering record
+    pattern-matching). It will sort the fields according to the record
+    declaration order (which is important when type-checking them in
+    presence of dependencies between fields). If the parameter
+    [complete] is true, we require the assignment to be complete: all
+    the fields of the record must be present in the
+    assignment. Otherwise the record assignment may be partial
+    (in a pattern, we may match on some fields only), and we call the
+    function [completer] to fill the missing fields; the returned
+    field assignment list is always complete. *)
+let sort_fields ~complete loc fields completer =
+  match fields with
     | [] -> None
     | (first_field_ref, first_field_value):: other_fields ->
         let env_error_msg = "Environment corruption for records." in
@@ -1016,13 +1026,13 @@ let sort_fields ~complete loc l completer =
           in
           build_proj_list record.Recordops.s_PROJ record.Recordops.s_PROJKIND 1 ~acc_first_idx:0 []
         in
-        (* now we want to have all fields of the pattern indexed by their place in
+        (* now we want to have all fields assignments indexed by their place in
            the constructor *)
         let rec index_fields fields remaining_projs acc =
           match fields with
             | (field_ref, field_value) :: fields ->
                let field_glob_ref = try global_reference_of_reference field_ref
-               with |Not_found ->
+               with Not_found ->
                  user_err_loc (loc_of_reference field_ref, "intern",
                                str "The field \"" ++ pr_reference field_ref ++ str "\" does not exist.") in
                let remaining_projs, (field_index, _) =

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -952,8 +952,10 @@ let find_pattern_variable = function
   | Ident (loc,id) -> id
   | Qualid (loc,_) as x -> raise (InternalizationError(loc,NotAConstructor x))
 
-let sort_fields mode loc l completer =
-(*mode=false if pattern and true if constructor*)
+let sort_fields ~complete loc l completer =
+  (* the 'complete' parameter is true when we require that all the
+     record fields be provided -- when building a new record value;
+     when pattern-matching, the list of fields may be partial. *)
   match l with
     | [] -> None
     | (refer, value)::rem ->
@@ -973,27 +975,28 @@ let sort_fields mode loc l completer =
 	  let rec build_patt l m i acc =
 	    match l with
 	      | [] -> (i, acc)
-	      | (Some name) :: b->
-		 (match m with
+	      | (Some name) :: b ->
+		 begin match m with
 		    | [] -> anomaly (Pp.str "Number of projections mismatch")
 		    | (_, regular)::tm ->
-		       let boolean = not regular in
                        begin match global_reference_of_reference refer with
 		       | ConstRef name' when eq_constant name name' ->
-			 if boolean && mode then
-			   user_err_loc (loc, "", str"No local fields allowed in a record construction.")
+			 if not regular && complete then
+			   user_err_loc (loc, "", str "No local fields allowed in a record construction.")
 			 else build_patt b tm (i + 1) (i, snd acc) (* we found it *)
                        | _ ->
-			  build_patt b tm (if boolean&&mode then i else i + 1)
-			    (if boolean && mode then acc
+			  build_patt b tm
+			    (if not regular && complete then i else i + 1)
+			    (if not regular && complete then acc
 			     else fst acc, (i, ConstRef name) :: snd acc)
-                       end)
+		       end
+		 end
 	      | None :: b-> (* we don't want anonymous fields *)
-		 if mode then
+		 if complete then
 		   user_err_loc (loc, "", str "This record contains anonymous fields.")
 		 else build_patt b m (i+1) acc
 		   (* anonymous arguments don't appear in m *)
-	    in
+	  in
 	  let ind = record.Recordops.s_CONST in
 	  try (* insertion of Constextern.reference_global *)
 	    (record.Recordops.s_EXPECTEDPARAM,
@@ -1029,7 +1032,8 @@ let sort_fields mode loc l completer =
 	  sf rem ([first_index, value], list_proj) in
 	(* we sort them *)
 	let sorted_indexed_pattern =
-	  List.sort (fun (i, _) (j, _) -> compare i j) unsorted_indexed_pattern in
+          let cmp_by_index (i, _) (j, _) = Int.compare i j in
+	  List.sort cmp_by_index unsorted_indexed_pattern in
 	(* a function to complete with wildcards *)
 	let rec complete_list n l =
 	  if n <= 1 then l else complete_list (n-1) (completer n l) in
@@ -1139,7 +1143,7 @@ let drop_notations_pattern looked_for =
     | CPatAlias (loc, p, id) -> RCPatAlias (loc, in_pat top env p, id)
     | CPatRecord (loc, l) ->
       let sorted_fields =
-	sort_fields false loc l (fun _ l -> (CPatAtom (loc, None))::l) in
+	sort_fields ~complete:false loc l (fun _ l -> (CPatAtom (loc, None))::l) in
       begin match sorted_fields with
 	| None -> RCPatAtom (loc, None)
 	| Some (_, head, pl) ->
@@ -1487,9 +1491,9 @@ let internalize globalenv env allow_patvar lvar c =
           apply_impargs c env impargs args_scopes 
 	    (merge_impargs l args) loc
 
-    | CRecord (loc, _, fs) ->
+    | CRecord (loc, r, fs) ->
 	let cargs =
-	  sort_fields true loc fs
+	  sort_fields ~complete:true loc fs
 	    (fun k l -> CHole (loc, Some (Evar_kinds.QuestionMark (Evar_kinds.Define true)), Misctypes.IntroAnonymous, None) :: l)
 	in
 	begin

--- a/lib/cList.ml
+++ b/lib/cList.ml
@@ -61,6 +61,7 @@ sig
   val except : 'a eq -> 'a -> 'a list -> 'a list
   val remove : 'a eq -> 'a -> 'a list -> 'a list
   val remove_first : ('a -> bool) -> 'a list -> 'a list
+  val extract_first : ('a -> bool) -> 'a list -> 'a list * 'a
   val insert : ('a -> 'a -> bool) -> 'a -> 'a list -> 'a list
   val for_all2eq : ('a -> 'b -> bool) -> 'a list -> 'b list -> bool
   val sep_last : 'a list -> 'a * 'a list
@@ -444,6 +445,14 @@ let rec remove_first p = function
   | b::l when p b -> l
   | b::l -> b::remove_first p l
   | [] -> raise Not_found
+
+let extract_first p li =
+  let rec loop rev_left = function
+    | [] -> raise Not_found
+    | x::right ->
+       if p x then List.rev_append rev_left right, x
+       else loop (x :: rev_left) right
+  in loop [] li
 
 let insert p v l =
   let rec insrec = function

--- a/lib/cList.mli
+++ b/lib/cList.mli
@@ -119,6 +119,10 @@ sig
   val remove_first : ('a -> bool) -> 'a list -> 'a list
   (** Remove the first element satisfying a predicate, or raise [Not_found] *)
 
+  val extract_first : ('a -> bool) -> 'a list -> 'a list * 'a
+  (** Remove and return the first element satisfying a predicate,
+      or raise [Not_found] *)
+
   val insert : ('a -> 'a -> bool) -> 'a -> 'a list -> 'a list
   (** Insert at the (first) position so that if the list is ordered wrt to the
       total order given as argument, the order is preserved *)

--- a/parsing/g_constr.ml4
+++ b/parsing/g_constr.ml4
@@ -225,8 +225,8 @@ GEXTEND Gram
   ;
   record_declaration:
     [ [ fs = LIST0 record_field_declaration SEP ";" -> CRecord (!@loc, None, fs)
-(*       | c = lconstr; "with"; fs = LIST1 record_field_declaration SEP ";" -> *)
-(* 	  CRecord (!@loc, Some c, fs) *)
+      | "as"; c = lconstr; "with"; fs = LIST1 record_field_declaration SEP ";" ->
+	  CRecord (!@loc, Some c, fs)
     ] ]
   ;
   record_field_declaration:


### PR DESCRIPTION
Background: at the end of the Coq Coding Sprint, I decided that a feature that would be within reach (unlike `fun <pattern> =>`...) would be the ability to define records by reusing fields of an existing records, that is `{| r with f1 = ...; f2 = ... |}`.

The function to use for this purpose is `sort_fields` in `interp/constrintern.ml`. Unfortunately it is undocumented and its code was unclear enough that I could not understand what it does. (There was a boolean argument named `mode` and a local variable named `boolean`, for example.)

The current pull-request brings zero new feature, but is a series of simplification and changes to the code of `sort_fields` that allowed me to understand its semantics, culminating in a documentation comment. I suspect the code changes along the way could also help future readers, which is why I didn't just include the comment in the pull request.

Note 1: it's quite hard to review all changes at once, because there are a many simultaneous changes going on. I would recommend looking at the commits one by one, I tried to make them as atomic as reasonably possible.

Note 2: there is a question in a commend prefixed by `(* G.S.:`, if someone can answer it I think inline comments would be a good place to discuss it, otherwise I'll just remove the comment.

```
                         (* G.S.: why do we fail only in the
                            first-field case? I would expect to fail
                            whenever (not regular && complete), and
                            skip the fields only when (not complete *)
```

Note 3: now that I do understand what the function does, I suspect there should be a more direct way to implement it (than the inherently quadratic processing being performed here), but I resisted the temptation to do it. My point was just to make the existing implementation clearer.

Note 4: I did a couple mistakes during my changes, and observed that Coq immediately fails to build `theories/Logic/ExtensionalityFacts.vo`. I therefore suspect that Coq breaks in obvious way when this function is bugged, which gives me confidence that the new implementation is as bug-free as the previous one.

Note 5: I was a bit frightened when I discovered that `make test-suite` fails miserably in my feature branch, but then found out that it already fails on `trunk` with the same failures (included below), so I guess that is ok.

```
    success/decl_mode2.v...Error! (should be accepted)
    bugs/opened/3948.v...Error! (bug seems to be closed, please check)
    bugs/opened/4214.v...Error! (bug seems to be closed, please check)
    output/inference.v...Error! (unexpected output)
    output/Notations.v...Error! (unexpected output)
```
