### PR TITLE
Fix Haskell extractions for {Nat,Z}.{div,modulo}

### DIFF
--- a/plugins/extraction/ExtrHaskellNatNum.v
+++ b/plugins/extraction/ExtrHaskellNatNum.v
@@ -11,7 +11,6 @@ Require Import EqNat.
 
 Extract Inlined Constant Nat.add => "(Prelude.+)".
 Extract Inlined Constant Nat.mul => "(Prelude.*)".
-Extract Inlined Constant Nat.div => "Prelude.div".
 Extract Inlined Constant Nat.max => "Prelude.max".
 Extract Inlined Constant Nat.min => "Prelude.min".
 Extract Inlined Constant Init.Nat.add => "(Prelude.+)".
@@ -23,5 +22,8 @@ Extract Inlined Constant EqNat.beq_nat => "(Prelude.==)".
 Extract Inlined Constant EqNat.eq_nat_decide => "(Prelude.==)".
 Extract Inlined Constant Peano_dec.eq_nat_dec => "(Prelude.==)".
 
-Extract Constant pred => "(\n -> Prelude.max 0 (Prelude.pred n))".
-Extract Constant minus => "(\n m -> Prelude.max 0 (n Prelude.- m))".
+Extract Constant Nat.pred => "(\n -> Prelude.max 0 (Prelude.pred n))".
+Extract Constant Nat.sub => "(\n m -> Prelude.max 0 (n Prelude.- m))".
+
+Extract Constant Nat.div => "(\n m -> if m Prelude.== 0 then 0 else Prelude.div n m)".
+Extract Constant Nat.modulo => "(\n m -> if m Prelude.== 0 then 0 else Prelude.mod n m)".

--- a/plugins/extraction/ExtrHaskellZNum.v
+++ b/plugins/extraction/ExtrHaskellZNum.v
@@ -12,8 +12,10 @@ Require Import EqNat.
 Extract Inlined Constant Z.add => "(Prelude.+)".
 Extract Inlined Constant Z.sub => "(Prelude.-)".
 Extract Inlined Constant Z.mul => "(Prelude.*)".
-Extract Inlined Constant Z.div => "Prelude.div".
 Extract Inlined Constant Z.max => "Prelude.max".
 Extract Inlined Constant Z.min => "Prelude.min".
 Extract Inlined Constant Z_ge_lt_dec => "(Prelude.>=)".
 Extract Inlined Constant Z_gt_le_dec => "(Prelude.>)".
+
+Extract Constant Z.div => "(\n m -> if m Prelude.== 0 then 0 else Prelude.div n m)".
+Extract Constant Z.modulo => "(\n m -> if m Prelude.== 0 then 0 else Prelude.mod n m)".


### PR DESCRIPTION
This patch adds a check for divide-by-zero to the extraction of Nat.div and Z.div, and also adds similar extractions (with checks) for Nat.modulo and Z.modulo.
