### PR TITLE
Report the full module path when reporting errors in coqdep

### DIFF
--- a/tools/coqdep_common.ml
+++ b/tools/coqdep_common.ml
@@ -373,6 +373,11 @@ let rec traite_fichier_Coq suffixe verbose f =
                     printf " %s%s" (canonize file_str) suffixe
                   with Not_found ->
 		    if verbose && not (is_in_coqlib ?from str) then
+		      let str =
+			match from with
+			  | None -> str
+			  | Some pth -> pth @ str
+		      in
                       warning_module_notfound f str
        		end) strl
 	  | Declare sl ->


### PR DESCRIPTION
When using 'From' the from module path is not reported in the error message. For example, with the following line:

```
From X.Y Require Import Z.A.
```

`coqdep` will correctly look for `X.Y.Z.A` but will report that it could not find `Z.A`.
