### PR TITLE
Prevent pretyping from checking well-guardedness unnecessarily.

### DIFF
--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -73,14 +73,9 @@ let search_guard loc env possible_indexes fixdefs =
   (* We treat it separately in order to get proper error msg. *)
   let is_singleton = function [_] -> true | _ -> false in
   if List.for_all is_singleton possible_indexes then
-    let indexes = Array.of_list (List.map List.hd possible_indexes) in
-    let fix = ((indexes, 0),fixdefs) in
-    (try check_fix env fix
-     with reraise ->
-       let (e, info) = Errors.push reraise in
-       let info = Loc.add_loc info loc in
-       iraise (e, info));
-    indexes
+    (* in this case, errors are delegated to the kernel, which will
+       check well-guardedness if required. *)
+    Array.of_list (List.map List.hd possible_indexes)
   else
     (* we now search recursively among all combinations *)
     (try


### PR DESCRIPTION
Patch extracted from #79. I committed the patch there because it significantly simplified the implementation of #79, but it's not really logically connected, so it should be discussed/integrated separately.

The `search_guard` function is called to infer the recursive argument of fixpoints. For each potential argument, it tests whether it is called structurally, calling the kernel test. When a single argument is available either because `{struct x}` was specified, or because there is a single inductive argument, the kernel test is performed, despite the fact that the kernel will do it later, and the kernel error is reraised.

I believe this test is unnecessary. Even if it weakens the pretyper a bit, since the pretyper can produced ill-typed terms, it doesn't affect the pretyper's ability to find a type since I don't believe the pretyper does (or should) rely on this test to create backtracking point.

So, as I see it, it's a matter of making a test that will necessarily be made a second time, without even a different error message in case of failure. But, as I mentioned above, there can be arguments otherwise. Thoughts?
