### PR TITLE
Add the "not a keyword" modifier to notations

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -46,6 +46,11 @@ solved by the automatic tactic.
 - Documented the Hint Cut command that allows control of the
   proof-search during typeclass resolution (see reference manual).
 
+Notations
+
+- Added a new modifier: "ident" not a keyword which specifies the quoted
+identifier to be parsed as an identifier and not as a keyword.
+
 API
 
 - Some functions from pretyping/typing.ml and their derivatives were potential

--- a/doc/refman/RefMan-syn.tex
+++ b/doc/refman/RefMan-syn.tex
@@ -480,7 +480,8 @@ Locate "exists _ .. _ , _".
   & $|$ & {\ident} {\tt global} \\
   & $|$ & {\ident} {\tt bigint} \\
   & $|$ & {\tt only parsing} \\
-  & $|$ & {\tt format} {\str} 
+  & $|$ & {\tt format} {\str} \\
+  & $|$ & {\str} {\tt not a keyword}
 \end{tabular}
 \end{centerframe}
 \end{small}
@@ -631,6 +632,42 @@ Notation "'mylet' f x .. y :=  t 'in' u":=
   (let f := fun x => .. (fun y => t) .. in u)
   (x closed binder, y closed binder, at level 200, right associativity).
 \end{coq_example*}
+
+\subsection{Notes on keywords}
+
+When an identifier is used in a notation (such identifiers are surrounded by
+simple quotes), {\Coq} may decide heuristically to turn it into a keyword.
+This heuristic has good properties except for some cases. For instance, if
+you want to define the following notation:
+\begin{coq_example*}
+Notation "'intro' x" := (fun x => x) (at level 99).
+
+Goal forall (p : Prop), p = p.
+Proof.
+\end{coq_example*}
+\begin{coq_example}
+  intro.
+\end{coq_example}
+% (********** The above produces **********)
+% (**** Syntax error: illegal begin of vernac:tactic_command. ********)
+\begin{coq_eval}
+Abort.
+Reset Initial.
+\end{coq_eval}
+
+you cannot use the {\tt intro} tactic anymore. Even if you delimit the scope of
+the notation the problem remains because {\tt intro} is parsed as a keyword and
+not as an identifier.
+
+As simple fix is to add the following modifier to the notation:
+\begin{coq_example*}
+Notation "'intro' x" := (fun x => x) (at level 99, "intro" not a keyword).
+\end{coq_example*}
+
+then, the {\tt intro} tactic can be used as specified above without any
+problems.
+
+\Rem This feature is available only since Coq 8.5.
 
 \subsection{Summary}
 

--- a/intf/vernacexpr.mli
+++ b/intf/vernacexpr.mli
@@ -215,6 +215,7 @@ type syntax_modifier =
   | SetEntryType of string * Extend.simple_constr_prod_entry_key
   | SetOnlyParsing of Flags.compat_version
   | SetFormat of string * string located
+  | SetNotAKeyword of string
 
 type proof_end =
   | Admitted

--- a/parsing/g_vernac.ml4
+++ b/parsing/g_vernac.ml4
@@ -1156,6 +1156,8 @@ GEXTEND Gram
         lev = level -> SetItemLevel (x::l,lev)
       | x = IDENT; "at"; lev = level -> SetItemLevel ([x],lev)
       | x = IDENT; typ = syntax_extension_type -> SetEntryType (x,typ)
+      | str = STRING; IDENT "not"; IDENT "a"; IDENT "keyword" ->
+          SetNotAKeyword str
     ] ]
   ;
   syntax_extension_type:

--- a/printing/ppvernac.ml
+++ b/printing/ppvernac.ml
@@ -379,6 +379,7 @@ module Make
     | SetOnlyParsing v -> keyword("compat \"" ^ Flags.pr_version v ^ "\"")
     | SetFormat("text",s) -> keyword "format " ++ pr_located qs s
     | SetFormat(k,s) -> keyword "format " ++ qs k ++ spc() ++ pr_located qs s
+    | SetNotAKeyword s -> qs s ++ spc() ++ keyword "not a keyword"
 
   let pr_syntax_modifiers = function
     | [] -> mt()

--- a/stm/texmacspp.ml
+++ b/stm/texmacspp.ml
@@ -195,6 +195,8 @@ match sm with
   | SetFormat (system, (loc, s)) ->
       let start, stop = unlock loc in
       ["format-"^system, s; "begin", start; "end", stop]
+  | SetNotAKeyword str ->
+      ["not-a-keyword", str]
 
 let string_of_assumption_kind l a many =
   match l, a, many with


### PR DESCRIPTION
This PR adds a new modifier to notations.
It allows to write such code:

``` coq
Notation "'intro'" := (1 + 1).

Goal forall (n : Prop), n = n.
Proof.
  intro.
  reflexivity.
Qed.
```

which is impossible so far because `intro` becomes a keyword when we define the notation and Ltac is looking for an identifier for each tactics.
We can fix this using this PR by just adding a modifier to the notation as follow:

``` coq
Notation "'intro'" := (1 + 1) ("intro" not a keyword).
```
