### PR TITLE
coqdoc API refactoring

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -262,8 +262,11 @@ DEBUGPRINTERS:=dev/top_printers.cmo dev/vm_printers.cmo dev/printers.cma
 
 COQDEPCMO:=$(COQENVCMO) tools/coqdep_lexer.cmo tools/coqdep_common.cmo tools/coqdep.cmo
 
-COQDOCCMO:=lib/clib.cma $(addprefix tools/coqdoc/, \
-  cdglobals.cmo alpha.cmo index.cmo tokens.cmo output.cmo cpretty.cmo main.cmo )
+COQDOCBACKENDS=$(addsuffix .cmo, out_debug)
+
+COQDOCCMO:=lib/clib.cma $(addprefix tools/coqdoc/, cdglobals.cmo	\
+  alpha.cmo index.cmo tokens.cmo output.cmo cpretty.cmo			\
+  $(COQDOCBACKENDS) main.cmo )
 
 COQMAKEFILECMO:=lib/clib.cma ide/project_file.cmo tools/coq_makefile.cmo
 

--- a/tools/coqdoc/alpha.ml
+++ b/tools/coqdoc/alpha.ml
@@ -22,7 +22,7 @@ let norm_char_latin1 c = match Char.uppercase c with
 let norm_char_utf8 c = Char.uppercase c
 
 let norm_char c =
-  if !utf8 then norm_char_utf8 c else
+  if !utf8   then norm_char_utf8   c else
   if !latin1 then norm_char_latin1 c else
   Char.uppercase c
 

--- a/tools/coqdoc/cdglobals.ml
+++ b/tools/coqdoc/cdglobals.ml
@@ -136,4 +136,3 @@ type coq_module = string
 
 type file =
   | Vernac_file of string * coq_module
-  | Latex_file of string

--- a/tools/coqdoc/cdglobals.ml
+++ b/tools/coqdoc/cdglobals.ml
@@ -10,7 +10,7 @@
 
 (*s Output options *)
 
-type target_language = LaTeX | HTML | TeXmacs | Raw
+type target_language = LaTeX | HTML | TeXmacs | Raw | Debug
 
 let target_language = ref HTML
 

--- a/tools/coqdoc/cdglobals.ml
+++ b/tools/coqdoc/cdglobals.ml
@@ -20,10 +20,7 @@ type output_t =
   | File of string
 
 let output_dir = ref ""
-
-let out_to = ref MultFiles
-
-let out_channel = ref stdout
+let out_to     = ref MultFiles
 
 let ( / ) = Filename.concat
 
@@ -36,13 +33,12 @@ let coqdoc_out f =
   else
     f
 
-let open_out_file f =
-  out_channel :=
-    try open_out (coqdoc_out f)
-    with Sys_error s -> Printf.eprintf "%s\n" s; exit 1
-
-let close_out_file () = close_out !out_channel
-
+let with_outfile file f =
+  try
+    let out = open_out (coqdoc_out file) in
+    f out;
+    close_out out
+  with | Sys_error s -> Printf.eprintf "%s\n" s; exit 1
 
 type glob_source_t =
     | NoGlob
@@ -69,6 +65,8 @@ let normalize_filename f =
   let basename = Filename.basename f in
   let dirname = Filename.dirname f in
   normalize_path dirname, basename
+
+
 
 (** A weaker analog of the function in Envars *)
 

--- a/tools/coqdoc/cdglobals.mli
+++ b/tools/coqdoc/cdglobals.mli
@@ -1,6 +1,6 @@
 (* Global CoqDoc types *)
 
-type target_language = LaTeX | HTML | TeXmacs | Raw
+type target_language = LaTeX | HTML | TeXmacs | Raw | Debug
 
 type output_t = StdOut | MultFiles | File of string
 

--- a/tools/coqdoc/cdglobals.mli
+++ b/tools/coqdoc/cdglobals.mli
@@ -1,0 +1,69 @@
+(* Global CoqDoc types *)
+
+type target_language = LaTeX | HTML | TeXmacs | Raw
+
+type output_t = StdOut | MultFiles | File of string
+
+type glob_source_t = NoGlob | DotGlob | GlobFile of string
+
+type coq_module = string
+type file = Vernac_file of string * coq_module
+
+(* Path handling functions *)
+val normalize_path     : string -> string
+val normalize_filename : string -> string * string
+
+(** [coqdoc_out f] locates output file *)
+val coqdoc_out  : string -> string
+
+(** [with_outfile s f] opens a file named [s] and calls [f out] where
+    [out] is the file descriptor *)
+val with_outfile : string -> (out_channel -> unit) -> unit
+
+(* Global options *)
+val out_to      : output_t ref
+val output_dir  : string ref
+val glob_source : glob_source_t ref
+
+val target_language : target_language ref
+
+(* Index options *)
+val index       : bool ref
+val index_name  : string ref
+val multi_index : bool ref
+val toc         : bool ref
+
+(* Header/Footer *)
+val header_trailer   : bool ref
+val header_file      : string ref
+val header_file_spec : bool ref
+val footer_file      : string ref
+val footer_file_spec : bool ref
+
+val page_title : string ref
+val title : string ref
+
+val quiet          : bool ref
+val light          : bool ref
+val gallina        : bool ref
+val short          : bool ref
+val externals      : bool ref
+val coqlib         : string ref
+val coqlib_path    : string ref
+val raw_comments   : bool ref
+val parse_comments : bool ref
+val plain_comments : bool ref
+val toc_depth      : int option ref
+val lib_name       : string ref
+val lib_subtitles  : bool ref
+val interpolate    : bool ref
+val inline_notmono : bool ref
+
+(* Encoding options *)
+val set_latin1 : unit -> unit
+val set_utf8   : unit -> unit
+
+val charset    : string ref
+val inputenc   : string ref
+val latin1     : bool ref
+val utf8       : bool ref

--- a/tools/coqdoc/cpretty.mli
+++ b/tools/coqdoc/cpretty.mli
@@ -11,7 +11,6 @@ module type S = sig
 module OutB : Output.S
 
 val coq_file        : string -> Cdglobals.coq_module -> unit
-val detect_subtitle : string -> Cdglobals.coq_module -> string option
 
 end
 

--- a/tools/coqdoc/cpretty.mli
+++ b/tools/coqdoc/cpretty.mli
@@ -6,5 +6,13 @@
 (*         *       GNU Lesser General Public License Version 2.1        *)
 (************************************************************************)
 
-val coq_file : string -> Cdglobals.coq_module -> unit
+module type S = sig
+
+module OutB : Output.S
+
+val coq_file        : string -> Cdglobals.coq_module -> unit
 val detect_subtitle : string -> Cdglobals.coq_module -> string option
+
+end
+
+module Make (Out : Output.S) : S with module OutB = Out

--- a/tools/coqdoc/cpretty.mll
+++ b/tools/coqdoc/cpretty.mll
@@ -1235,7 +1235,7 @@ and inf_rules_assumptions indents assumptions = parse
                in
                  (d, Some n))
           with _ -> (dashes_and_name, None)
-            
+
         in
           inf_rules_conclusion indents (List.rev assumptions) 
                                (spaces, dashes, name) [] lexbuf }
@@ -1301,7 +1301,7 @@ and st_subtitle = parse
 {
   let coq_file f m =
     reset ();
-    let c = open_in f in
+    let c  = open_in f in
     let lb = from_channel c in
       (Index.current_library := m;
        OutB.initialize ();

--- a/tools/coqdoc/cpretty.mll
+++ b/tools/coqdoc/cpretty.mll
@@ -12,6 +12,20 @@
   open Printf
   open Lexing
 
+  module type S = sig
+
+  module OutB : Output.S
+
+  val coq_file        : string -> Cdglobals.coq_module -> unit
+  val detect_subtitle : string -> Cdglobals.coq_module -> string option
+
+  end
+
+  (* Output Back End *)
+  module Make (Out : Output.S) = struct
+
+  module OutB = Out
+
   (* A list function we need *)
   let rec take n ls =
     if n = 0 then [] else
@@ -75,8 +89,8 @@
     let stop_env () = if !r then stop (); r := false in
       (fun x -> !r), start_env, stop_env
       
-  let in_emph, start_emph, stop_emph = in_env Output.start_emph Output.stop_emph
-  let in_quote, start_quote, stop_quote = in_env Output.start_quote Output.stop_quote
+  let in_emph, start_emph, stop_emph = in_env OutB.start_emph OutB.stop_emph
+  let in_quote, start_quote, stop_quote = in_env OutB.start_quote OutB.stop_quote
 
   let url_buffer = Buffer.create 40
   let url_name_buffer = Buffer.create 40
@@ -241,9 +255,9 @@
 
   let output_indented_keyword s lexbuf =
     let nbsp,isp = count_spaces s in
-    Output.indentation nbsp;
+    OutB.indentation nbsp;
     let s = String.sub s isp (String.length s - isp) in
-    Output.keyword s (lexeme_start lexbuf + isp)
+    OutB.keyword s (lexeme_start lexbuf + isp)
 
 }
 
@@ -441,16 +455,16 @@ let end_verb = "(*" space* "end" space+ "verb" space* "*)"
 rule coq_bol = parse
   | space* nl+
       { if not (!in_proof <> None && (!Cdglobals.gallina || !Cdglobals.light))
-        then Output.empty_line_of_code ();
+        then OutB.empty_line_of_code ();
         coq_bol lexbuf }
   | space* "(**" space_nl
-      { Output.end_coq (); Output.start_doc ();
+      { OutB.end_coq (); OutB.start_doc ();
 	let eol = doc_bol lexbuf in
-	  Output.end_doc (); Output.start_coq ();
+	  OutB.end_doc (); OutB.start_coq ();
 	  if eol then coq_bol lexbuf else coq lexbuf }
   | space* "Comments" space_nl
-      { Output.end_coq (); Output.start_doc (); comments lexbuf; Output.end_doc ();
-	Output.start_coq (); coq lexbuf }
+      { OutB.end_coq (); OutB.start_doc (); comments lexbuf; OutB.end_doc ();
+	OutB.start_coq (); coq lexbuf }
   | space* begin_hide
       { skip_hide lexbuf; coq_bol lexbuf }
   | space* begin_show
@@ -538,8 +552,8 @@ rule coq_bol = parse
 	if !Cdglobals.parse_comments then begin
 	  let s = lexeme lexbuf in
 	  let nbsp,isp = count_spaces s in
-	    Output.indentation nbsp;
-	    Output.start_comment ();
+	    OutB.indentation nbsp;
+	    OutB.start_comment ();
 	end;
 	let eol = comment lexbuf in
 	  if eol then coq_bol lexbuf else coq lexbuf }
@@ -558,19 +572,19 @@ rule coq_bol = parse
 
 and coq = parse
   | nl
-      { if not (!in_proof <> None && !Cdglobals.gallina) then Output.line_break(); coq_bol lexbuf }
+      { if not (!in_proof <> None && !Cdglobals.gallina) then OutB.line_break(); coq_bol lexbuf }
   | "(**" space_nl
-      { Output.end_coq (); Output.start_doc ();
+      { OutB.end_coq (); OutB.start_doc ();
 	let eol = doc_bol lexbuf in
-	  Output.end_doc (); Output.start_coq ();
+	  OutB.end_doc (); OutB.start_coq ();
 	  if eol then coq_bol lexbuf else coq lexbuf }
   | "(*"
       { comment_level := 1;
 	if !Cdglobals.parse_comments then begin
 	  let s = lexeme lexbuf in
 	  let nbsp,isp = count_spaces s in
-	    Output.indentation nbsp;
-	    Output.start_comment ();
+	    OutB.indentation nbsp;
+	    OutB.start_comment ();
 	end;
 	let eol = comment lexbuf in
 	  if eol then coq_bol lexbuf
@@ -583,10 +597,10 @@ and coq = parse
 	  let s = lexeme lexbuf in
 	  let nlsp,s = remove_newline s in
 	  let nbsp,isp = count_spaces s in
-	  Output.indentation nbsp;
+	  OutB.indentation nbsp;
 	  let loc = lexeme_start lexbuf + isp + nlsp in
-	  Output.sublexer ']' loc;
-	  Output.sublexer ']' (loc+1);
+	  OutB.sublexer ']' loc;
+	  OutB.sublexer ']' (loc+1);
 	  coq lexbuf
 	end }
   | eof
@@ -600,7 +614,7 @@ and coq = parse
 	    end
 	  else
 	    begin
-	      Output.ident s None;
+	      OutB.ident s None;
 	      let eol=body lexbuf in
 		if eol then coq_bol lexbuf else coq lexbuf
 	    end }
@@ -623,27 +637,27 @@ and coq = parse
 	else
 	  let eol = skip_to_dot lexbuf in
 	    if !in_proof <> Some true && eol then
-	      Output.line_break ();
+	      OutB.line_break ();
 	    eol
       in
 	in_proof := None;
 	if eol then coq_bol lexbuf else coq lexbuf }
   | gallina_kw
       { let s = lexeme lexbuf in
-	  Output.ident s None;
+	  OutB.ident s None;
 	let eol = body lexbuf in
 	  if eol then coq_bol lexbuf else coq lexbuf }
   | notation_kw
       { let s = lexeme lexbuf in
-	Output.ident s None;
+	OutB.ident s None;
 	let eol= start_notation_string lexbuf in
 	if eol then coq_bol lexbuf else coq lexbuf }
   | prog_kw
       { let s = lexeme lexbuf in
-	  Output.ident s None;
+	  OutB.ident s None;
 	let eol = body lexbuf in
 	  if eol then coq_bol lexbuf else coq lexbuf }
-  | space+ { Output.char ' '; coq lexbuf }
+  | space+ { OutB.char ' '; coq lexbuf }
   | eof
       { () }
   | _ {	let eol =
@@ -664,7 +678,7 @@ and doc_bol = parse
              (subtitle (Output.get_module false) s) then
             ()
           else
-            Output.section lev (fun () -> ignore (doc None (from_string s)));
+            OutB.section lev (fun () -> ignore (doc None (from_string s)));
 	    if eol then doc_bol lexbuf else doc None lexbuf }
   | space_nl* '-'+
       { let buf' = lexeme lexbuf in
@@ -678,18 +692,18 @@ and doc_bol = parse
         in
           match check_start_list line with
           | Neither -> backtrack_past_newline lexbuf; doc None lexbuf
-          | List n -> Output.paragraph ();
-                      Output.item 1; doc (Some [n]) lexbuf
-          | Rule -> Output.rule (); doc None lexbuf
+          | List n -> OutB.paragraph ();
+                      OutB.item 1; doc (Some [n]) lexbuf
+          | Rule -> OutB.rule (); doc None lexbuf
       }
   | space* nl+
-      { Output.paragraph (); doc_bol lexbuf }
+      { OutB.paragraph (); doc_bol lexbuf }
   | "<<" space*
-      { Output.start_verbatim false; verbatim false lexbuf; doc_bol lexbuf }
+      { OutB.start_verbatim false; verbatim false lexbuf; doc_bol lexbuf }
   | eof
       { true }
   | '_'
-      { if !Cdglobals.plain_comments then Output.char '_' else start_emph ();
+      { if !Cdglobals.plain_comments then OutB.char '_' else start_emph ();
         doc None lexbuf }
   | _
       { backtrack lexbuf; doc None lexbuf }
@@ -700,23 +714,23 @@ and doc_list_bol indents = parse
       { let (n_spaces,_) = count_spaces (lexeme lexbuf) in
         match find_level indents n_spaces with
         | Before -> backtrack lexbuf; doc_bol lexbuf
-        | StartLevel n -> Output.item n; doc (Some (take n indents)) lexbuf
+        | StartLevel n -> OutB.item n; doc (Some (take n indents)) lexbuf
         | InLevel (n,true) ->
             let items = List.length indents in
-              Output.item (items+1);
+              OutB.item (items+1);
               doc (Some (List.append indents [n_spaces])) lexbuf
         | InLevel (_,false) ->
             backtrack lexbuf; doc_bol lexbuf
       }
   | "<<" space*
-      { Output.start_verbatim false;
+      { OutB.start_verbatim false;
         verbatim false lexbuf;
         doc_list_bol indents lexbuf }
   | "[[" nl
       { formatted := true;
-        Output.start_inline_coq_block ();
+        OutB.start_inline_coq_block ();
         ignore(body_bol lexbuf);
-        Output.end_inline_coq_block ();
+        OutB.end_inline_coq_block ();
         formatted := false;
         doc_list_bol indents lexbuf }
   | "[[[" nl
@@ -724,7 +738,7 @@ and doc_list_bol indents = parse
   | space* nl space* '-'
       { (* Like in the doc_bol production, these two productions
            exist only to deal properly with whitespace *)
-        Output.paragraph ();
+        OutB.paragraph ();
         backtrack_past_newline lexbuf;
         doc_list_bol indents lexbuf }
   | space* nl space* _
@@ -740,19 +754,19 @@ and doc_list_bol indents = parse
         let (n_spaces,_) = count_spaces buf in
         match find_level indents n_spaces with
         | InLevel _ ->
-            Output.paragraph ();
+            OutB.paragraph ();
             backtrack_past_newline lexbuf;
             doc_list_bol indents lexbuf
         | StartLevel n ->
             if n = 1 then
               begin
-                Output.stop_item ();
+                OutB.stop_item ();
                 backtrack_past_newline lexbuf;
                 doc_bol lexbuf
               end
             else
               begin
-                Output.paragraph ();
+                OutB.paragraph ();
                 backtrack_past_newline lexbuf;
                 doc_list_bol indents lexbuf
               end
@@ -762,8 +776,8 @@ and doc_list_bol indents = parse
            a paragraph for the empty line, rewind to whatever's just
            after the newline, then toss over to doc_bol for whatever
            comes next. *)
-            Output.stop_item ();
-            Output.paragraph ();
+            OutB.stop_item ();
+            OutB.paragraph ();
             backtrack_past_newline lexbuf;
             doc_bol lexbuf
 
@@ -771,17 +785,17 @@ and doc_list_bol indents = parse
   | space* _
       { let (n_spaces,_) = count_spaces (lexeme lexbuf) in
         match find_level indents n_spaces with
-        | Before -> Output.stop_item (); backtrack lexbuf;
+        | Before -> OutB.stop_item (); backtrack lexbuf;
                     doc_bol lexbuf
         | StartLevel n ->
             (if n = 1 then
-               Output.stop_item ()
+               OutB.stop_item ()
              else
-               Output.reach_item_level (n-1));
+               OutB.reach_item_level (n-1));
             backtrack lexbuf;
             doc (Some (take (n-1) indents)) lexbuf
         | InLevel (n,_) ->
-            Output.reach_item_level n;
+            OutB.reach_item_level n;
             backtrack lexbuf;
             doc (Some (take n indents)) lexbuf
       }
@@ -789,17 +803,17 @@ and doc_list_bol indents = parse
 (*s Scanning documentation elsewhere *)
 and doc indents = parse
   | nl
-      { Output.char '\n';
+      { OutB.char '\n';
         match indents with
         | Some ls -> doc_list_bol ls lexbuf
         | None -> doc_bol lexbuf }
   | "[[" nl
       { if !Cdglobals.plain_comments
-        then (Output.char '['; Output.char '['; doc indents lexbuf)
+        then (OutB.char '['; OutB.char '['; doc indents lexbuf)
         else (formatted := true;
-              Output.start_inline_coq_block ();
+              OutB.start_inline_coq_block ();
 	      let eol = body_bol lexbuf in
-	        Output.end_inline_coq_block (); formatted := false;
+	        OutB.end_inline_coq_block (); formatted := false;
 	        if eol then
 		  match indents with
 		  | Some ls -> doc_list_bol ls lexbuf
@@ -808,12 +822,12 @@ and doc indents = parse
   | "[[[" nl
       { inf_rules indents lexbuf }
   | "[]"
-      { Output.proofbox (); doc indents lexbuf }
+      { OutB.proofbox (); doc indents lexbuf }
   | "{{" { url lexbuf; doc indents lexbuf }
   | "["
-      { if !Cdglobals.plain_comments then Output.char '['
-        else (brackets := 1;  Output.start_inline_coq (); escaped_coq lexbuf;
-              Output.end_inline_coq ()); doc indents lexbuf }
+      { if !Cdglobals.plain_comments then OutB.char '['
+        else (brackets := 1;  OutB.start_inline_coq (); escaped_coq lexbuf;
+              OutB.end_inline_coq ()); doc indents lexbuf }
   | "(*"
       { backtrack lexbuf ;
         let bol_parse = match indents with
@@ -825,14 +839,14 @@ and doc indents = parse
       }
   | '*'* "*)" space_nl* "(**"
       {(match indents with
-        | Some _ -> Output.stop_item ()
+        | Some _ -> OutB.stop_item ()
         | None -> ());
        (* this says - if there is a blank line between the two comments,
           insert one in the output too *)
        let lines = List.length (Str.split_delim (Str.regexp "['\n']") 
                                                 (lexeme lexbuf))
        in 
-         if lines > 2 then Output.paragraph ();
+         if lines > 2 then OutB.paragraph ();
        doc_bol lexbuf
       }
   | '*'* "*)" space* nl
@@ -840,40 +854,40 @@ and doc indents = parse
   | '*'* "*)"
       { false }
   | "$"
-      { if !Cdglobals.plain_comments then Output.char '$'
-        else (Output.start_latex_math (); escaped_math_latex lexbuf);
+      { if !Cdglobals.plain_comments then OutB.char '$'
+        else (OutB.start_latex_math (); escaped_math_latex lexbuf);
         doc indents lexbuf }
   | "$$"
-      { if !Cdglobals.plain_comments then Output.char '$';
-        Output.char '$'; doc indents lexbuf }
+      { if !Cdglobals.plain_comments then OutB.char '$';
+        OutB.char '$'; doc indents lexbuf }
   | "%"
-      { if !Cdglobals.plain_comments then Output.char '%'
+      { if !Cdglobals.plain_comments then OutB.char '%'
         else escaped_latex lexbuf; doc indents lexbuf }
   | "%%"
-      { if !Cdglobals.plain_comments then Output.char '%';
-        Output.char '%'; doc indents lexbuf }
+      { if !Cdglobals.plain_comments then OutB.char '%';
+        OutB.char '%'; doc indents lexbuf }
   | "#"
-      { if !Cdglobals.plain_comments then Output.char '#'
+      { if !Cdglobals.plain_comments then OutB.char '#'
         else escaped_html lexbuf; doc indents lexbuf }
   | "##"
-      { if !Cdglobals.plain_comments then Output.char '#';
-        Output.char '#'; doc indents lexbuf }
+      { if !Cdglobals.plain_comments then OutB.char '#';
+        OutB.char '#'; doc indents lexbuf }
   | nonidentchar '_' nonidentchar
-      { List.iter (fun x -> Output.char (lexeme_char lexbuf x)) [0;1;2];
+      { List.iter (fun x -> OutB.char (lexeme_char lexbuf x)) [0;1;2];
         doc indents lexbuf}
   | nonidentchar '_'
-      { Output.char (lexeme_char lexbuf 0);
-        if !Cdglobals.plain_comments then Output.char '_' else  start_emph () ;
+      { OutB.char (lexeme_char lexbuf 0);
+        if !Cdglobals.plain_comments then OutB.char '_' else  start_emph () ;
         doc indents lexbuf }
   | '_' nonidentchar
-      { if !Cdglobals.plain_comments then Output.char '_' else stop_emph () ;
-        Output.char (lexeme_char lexbuf 1);
+      { if !Cdglobals.plain_comments then OutB.char '_' else stop_emph () ;
+        OutB.char (lexeme_char lexbuf 1);
         doc indents lexbuf }
   | "<<" space*
-      { Output.start_verbatim true; verbatim true lexbuf; doc_bol lexbuf }
+      { OutB.start_verbatim true; verbatim true lexbuf; doc_bol lexbuf }
   | '"'
       { if !Cdglobals.plain_comments 
-	then Output.char '"' 
+	then OutB.char '"' 
 	else if in_quote ()
 	then stop_quote () 
 	else start_quote ();
@@ -881,50 +895,50 @@ and doc indents = parse
   | eof
       { false }
   | _
-      { Output.char (lexeme_char lexbuf 0); doc indents lexbuf }
+      { OutB.char (lexeme_char lexbuf 0); doc indents lexbuf }
 
 (*s Various escapings *)
 
 and escaped_math_latex = parse
-  | "$" { Output.stop_latex_math () }
-  | eof { Output.stop_latex_math () }
+  | "$" { OutB.stop_latex_math () }
+  | eof { OutB.stop_latex_math () }
   | "*)"
-        { Output.stop_latex_math (); backtrack lexbuf }
-  | _   { Output.latex_char (lexeme_char lexbuf 0); escaped_math_latex lexbuf }
+        { OutB.stop_latex_math (); backtrack lexbuf }
+  | _   { OutB.latex_char (lexeme_char lexbuf 0); escaped_math_latex lexbuf }
 
 and escaped_latex = parse
   | "%" { () }
   | eof { () }
   | "*)"
         { backtrack lexbuf }
-  | _   { Output.latex_char (lexeme_char lexbuf 0); escaped_latex lexbuf }
+  | _   { OutB.latex_char (lexeme_char lexbuf 0); escaped_latex lexbuf }
 
 and escaped_html = parse
   | "#" { () }
   | "&#"
-        { Output.html_char '&'; Output.html_char '#'; escaped_html lexbuf }
+        { OutB.html_char '&'; OutB.html_char '#'; escaped_html lexbuf }
   | "##"
-        { Output.html_char '#'; escaped_html lexbuf }
+        { OutB.html_char '#'; escaped_html lexbuf }
   | eof { () }
   | "*)"
         { backtrack lexbuf }
-  | _   { Output.html_char (lexeme_char lexbuf 0); escaped_html lexbuf }
+  | _   { OutB.html_char (lexeme_char lexbuf 0); escaped_html lexbuf }
 
 and verbatim inline = parse
-  | nl ">>" space* nl { Output.verbatim_char inline '\n'; Output.stop_verbatim inline }
-  | nl ">>" { Output.verbatim_char inline '\n'; Output.stop_verbatim inline }
-  | ">>" { Output.stop_verbatim inline }
-  | "*)" { Output.stop_verbatim inline; backtrack lexbuf }
-  | eof { Output.stop_verbatim inline }
-  | _ { Output.verbatim_char inline (lexeme_char lexbuf 0); verbatim inline lexbuf }
+  | nl ">>" space* nl { OutB.verbatim_char inline '\n'; OutB.stop_verbatim inline }
+  | nl ">>" { OutB.verbatim_char inline '\n'; OutB.stop_verbatim inline }
+  | ">>" { OutB.stop_verbatim inline }
+  | "*)" { OutB.stop_verbatim inline; backtrack lexbuf }
+  | eof { OutB.stop_verbatim inline }
+  | _ { OutB.verbatim_char inline (lexeme_char lexbuf 0); verbatim inline lexbuf }
 
 and url = parse
-  | "}}" { Output.url (Buffer.contents url_buffer) None; Buffer.clear url_buffer }
+  | "}}" { OutB.url (Buffer.contents url_buffer) None; Buffer.clear url_buffer }
   | "}" { url_name lexbuf }
   | _ { Buffer.add_char url_buffer (lexeme_char lexbuf 0); url lexbuf }
 
 and url_name = parse
-  | "}" { Output.url (Buffer.contents url_buffer) (Some (Buffer.contents url_name_buffer));
+  | "}" { OutB.url (Buffer.contents url_buffer) (Some (Buffer.contents url_name_buffer));
 	  Buffer.clear url_buffer; Buffer.clear url_name_buffer }
   | _ { Buffer.add_char url_name_buffer (lexeme_char lexbuf 0); url_name lexbuf }
 
@@ -934,11 +948,11 @@ and escaped_coq = parse
   | "]"
       { decr brackets;
 	if !brackets > 0 then
-	  (Output.sublexer_in_doc ']'; escaped_coq lexbuf)
+	  (OutB.sublexer_in_doc ']'; escaped_coq lexbuf)
 	else Tokens.flush_sublexer () }
   | "["
       { incr brackets;
-        Output.sublexer_in_doc '['; escaped_coq lexbuf }
+        OutB.sublexer_in_doc '['; escaped_coq lexbuf }
   | "(*"
       { Tokens.flush_sublexer (); comment_level := 1;
         ignore (comment lexbuf); escaped_coq lexbuf }
@@ -948,26 +962,26 @@ and escaped_coq = parse
       { Tokens.flush_sublexer () }
   | (identifier '.')* identifier
       { Tokens.flush_sublexer();
-        Output.ident (lexeme lexbuf) None;
+        OutB.ident (lexeme lexbuf) None;
         escaped_coq lexbuf }
   | space_nl*
       { let str = lexeme lexbuf in
           Tokens.flush_sublexer();
           (if !Cdglobals.inline_notmono then () 
-                                        else Output.end_inline_coq ()); 
-          String.iter Output.char str; 
+                                        else OutB.end_inline_coq ()); 
+          String.iter OutB.char str; 
           (if !Cdglobals.inline_notmono then () 
-                                        else Output.start_inline_coq ());
+                                        else OutB.start_inline_coq ());
           escaped_coq lexbuf }
   | _ 
-      { Output.sublexer_in_doc (lexeme_char lexbuf 0);
+      { OutB.sublexer_in_doc (lexeme_char lexbuf 0);
         escaped_coq lexbuf }
 
 (*s Coq "Comments" command. *)
 
 and comments = parse
   | space_nl+
-      { Output.char ' '; comments lexbuf }
+      { OutB.char ' '; comments lexbuf }
   | '"' [^ '"']* '"'
       { let s = lexeme lexbuf in
 	let s = String.sub s 1 (String.length s - 2) in
@@ -979,72 +993,72 @@ and comments = parse
   | eof
       { () }
   | _
-      { Output.char (lexeme_char lexbuf 0); comments lexbuf }
+      { OutB.char (lexeme_char lexbuf 0); comments lexbuf }
 
 (*s Skip comments *)
 
 and comment = parse
   | "(*" { incr comment_level;
-	   if !Cdglobals.parse_comments then Output.start_comment ();
+	   if !Cdglobals.parse_comments then OutB.start_comment ();
 	   comment lexbuf }
   | "*)" space* nl {
       if !Cdglobals.parse_comments then
-	(Output.end_comment (); Output.line_break ());
+	(OutB.end_comment (); OutB.line_break ());
       decr comment_level; if !comment_level > 0 then comment lexbuf else true }
   | "*)" {
-      if !Cdglobals.parse_comments then (Output.end_comment ());
+      if !Cdglobals.parse_comments then (OutB.end_comment ());
       decr comment_level; if !comment_level > 0 then comment lexbuf else false }
   | "[" {
       if !Cdglobals.parse_comments then
-	if !Cdglobals.plain_comments then Output.char '['
-        else (brackets := 1; Output.start_inline_coq ();
-              escaped_coq lexbuf; Output.end_inline_coq ());
+	if !Cdglobals.plain_comments then OutB.char '['
+        else (brackets := 1; OutB.start_inline_coq ();
+              escaped_coq lexbuf; OutB.end_inline_coq ());
       comment lexbuf }
   | "[[" nl {
       if !Cdglobals.parse_comments then
-        if !Cdglobals.plain_comments then (Output.char '['; Output.char '[')
+        if !Cdglobals.plain_comments then (OutB.char '['; OutB.char '[')
         else (formatted := true;
-              Output.start_inline_coq_block ();
+              OutB.start_inline_coq_block ();
               let _ = body_bol lexbuf in
-                Output.end_inline_coq_block (); formatted := false);
+                OutB.end_inline_coq_block (); formatted := false);
       comment lexbuf}
   | "$"
       { if !Cdglobals.parse_comments then
-          if !Cdglobals.plain_comments then Output.char '$'
-          else (Output.start_latex_math (); escaped_math_latex lexbuf);
+          if !Cdglobals.plain_comments then OutB.char '$'
+          else (OutB.start_latex_math (); escaped_math_latex lexbuf);
         comment lexbuf }
   | "$$"
       { if !Cdglobals.parse_comments
         then
-          (if !Cdglobals.plain_comments then Output.char '$'; Output.char '$');
+          (if !Cdglobals.plain_comments then OutB.char '$'; OutB.char '$');
         doc None lexbuf }
   | "%"
       { if !Cdglobals.parse_comments
           then
-            if !Cdglobals.plain_comments then Output.char '%'
+            if !Cdglobals.plain_comments then OutB.char '%'
             else escaped_latex lexbuf; comment lexbuf }
   | "%%"
       { if !Cdglobals.parse_comments
         then
-          (if !Cdglobals.plain_comments then Output.char '%'; Output.char '%');
+          (if !Cdglobals.plain_comments then OutB.char '%'; OutB.char '%');
         comment lexbuf }
   | "#"
       { if !Cdglobals.parse_comments
         then
-          if !Cdglobals.plain_comments then Output.char '$'
+          if !Cdglobals.plain_comments then OutB.char '$'
           else escaped_html lexbuf; comment lexbuf }
   | "##"
       { if !Cdglobals.parse_comments
         then
-          (if !Cdglobals.plain_comments then Output.char '#'; Output.char '#');
+          (if !Cdglobals.plain_comments then OutB.char '#'; OutB.char '#');
         comment lexbuf }
   | eof  { false }
   | space+ { if !Cdglobals.parse_comments
-             then Output.indentation (fst (count_spaces (lexeme lexbuf)));
+             then OutB.indentation (fst (count_spaces (lexeme lexbuf)));
              comment lexbuf }
   | nl   { if !Cdglobals.parse_comments
-           then Output.line_break (); comment lexbuf }
-  | _    { if !Cdglobals.parse_comments then Output.char (lexeme_char lexbuf 0);
+           then OutB.line_break (); comment lexbuf }
+  | _    { if !Cdglobals.parse_comments then OutB.char (lexeme_char lexbuf 0);
            comment lexbuf }
 
 and skip_to_dot = parse
@@ -1055,11 +1069,11 @@ and skip_to_dot = parse
 
 and body_bol = parse
   | space+
-      { Output.indentation (fst (count_spaces (lexeme lexbuf))); body lexbuf }
-  | _ { backtrack lexbuf; Output.indentation 0; body lexbuf }
+      { OutB.indentation (fst (count_spaces (lexeme lexbuf))); body lexbuf }
+  | _ { backtrack lexbuf; OutB.indentation 0; body lexbuf }
 
 and body = parse
-  | nl {Tokens.flush_sublexer(); Output.line_break(); Lexing.new_line lexbuf; body_bol lexbuf}
+  | nl {Tokens.flush_sublexer(); OutB.line_break(); Lexing.new_line lexbuf; body_bol lexbuf}
   | nl+ space* "]]" space* nl
       { Tokens.flush_sublexer();
         if not !formatted then
@@ -1068,14 +1082,14 @@ and body = parse
             let nlsp,s = remove_newline s in
             let _,isp = count_spaces s in
             let loc = lexeme_start lexbuf + nlsp + isp in
-            Output.sublexer ']' loc;
-            Output.sublexer ']' (loc+1);
+            OutB.sublexer ']' loc;
+            OutB.sublexer ']' (loc+1);
             Tokens.flush_sublexer();
             body lexbuf
           end
         else
           begin
-            Output.paragraph ();
+            OutB.paragraph ();
             true
           end }
   | "]]" space* nl
@@ -1083,23 +1097,23 @@ and body = parse
         if not !formatted then
           begin
 	    let loc = lexeme_start lexbuf in
-	    Output.sublexer ']' loc;
-	    Output.sublexer ']' (loc+1);
+	    OutB.sublexer ']' loc;
+	    OutB.sublexer ']' (loc+1);
 	    Tokens.flush_sublexer();
-	    Output.line_break();
+	    OutB.line_break();
             body lexbuf
           end
         else
           begin
-            Output.paragraph ();
+            OutB.paragraph ();
             true
           end }
   | eof { Tokens.flush_sublexer(); false }
   | '.' space* nl | '.' space* eof
-	{ Tokens.flush_sublexer(); Output.char '.'; Output.line_break();
+	{ Tokens.flush_sublexer(); OutB.char '.'; OutB.line_break();
 	  if not !formatted then true else body_bol lexbuf }
   | '.' space* nl "]]" space* nl
-	{ Tokens.flush_sublexer(); Output.char '.';
+	{ Tokens.flush_sublexer(); OutB.char '.';
         if not !formatted then
           begin
             eprintf "Error: stray ]] at %d\n"  (lexeme_start lexbuf);
@@ -1108,52 +1122,52 @@ and body = parse
           end
 	  else
           begin
-            Output.paragraph ();
+            OutB.paragraph ();
             true
           end
       }
   | '.' space+
-        { Tokens.flush_sublexer(); Output.char '.'; Output.char ' ';
+        { Tokens.flush_sublexer(); OutB.char '.'; OutB.char ' ';
 	  if not !formatted then false else body lexbuf }
   | "(**" space_nl
-      { Tokens.flush_sublexer(); Output.end_coq (); Output.start_doc ();
+      { Tokens.flush_sublexer(); OutB.end_coq (); OutB.start_doc ();
 	let eol = doc_bol lexbuf in
-	  Output.end_doc (); Output.start_coq ();
+	  OutB.end_doc (); OutB.start_coq ();
 	  if eol then body_bol lexbuf else body lexbuf }
   | "(*" { Tokens.flush_sublexer(); comment_level := 1;
-	   if !Cdglobals.parse_comments then Output.start_comment ();
+	   if !Cdglobals.parse_comments then OutB.start_comment ();
 	   let eol = comment lexbuf in
 	     if eol
-	     then begin if not !Cdglobals.parse_comments then Output.line_break(); body_bol lexbuf end
+	     then begin if not !Cdglobals.parse_comments then OutB.line_break(); body_bol lexbuf end
 	     else body lexbuf }
   | "where" 
       { Tokens.flush_sublexer();
-        Output.ident (lexeme lexbuf) None;
+        OutB.ident (lexeme lexbuf) None;
 	start_notation_string lexbuf }
   | identifier
       { Tokens.flush_sublexer();
-        Output.ident (lexeme lexbuf) (Some (lexeme_start lexbuf));
+        OutB.ident (lexeme lexbuf) (Some (lexeme_start lexbuf));
 	body lexbuf }
   | ".."
-      { Tokens.flush_sublexer(); Output.char '.'; Output.char '.';
+      { Tokens.flush_sublexer(); OutB.char '.'; OutB.char '.';
         body lexbuf }
   | '"'
-      { Tokens.flush_sublexer(); Output.char '"';
+      { Tokens.flush_sublexer(); OutB.char '"';
         string lexbuf;
         body lexbuf }
   | space
-      { Tokens.flush_sublexer(); Output.char (lexeme_char lexbuf 0);
+      { Tokens.flush_sublexer(); OutB.char (lexeme_char lexbuf 0);
         body lexbuf }
 
   | _ { let c = lexeme_char lexbuf 0 in
-	Output.sublexer c (lexeme_start lexbuf);
+	OutB.sublexer c (lexeme_start lexbuf);
         body lexbuf }
 
 and start_notation_string = parse
-  | space { Tokens.flush_sublexer(); Output.char (lexeme_char lexbuf 0);
+  | space { Tokens.flush_sublexer(); OutB.char (lexeme_char lexbuf 0);
 	    start_notation_string lexbuf }
   | '"' (* a true notation *)
-      { Output.sublexer '"' (lexeme_start lexbuf);
+      { OutB.sublexer '"' (lexeme_start lexbuf);
         notation_string lexbuf;
 	body lexbuf }
   | _ (* an abbreviation *)
@@ -1161,18 +1175,18 @@ and start_notation_string = parse
 
 and notation_string = parse
   | "\"\""
-      { Output.char '"'; Output.char '"'; (* Unlikely! *)
+      { OutB.char '"'; OutB.char '"'; (* Unlikely! *)
         notation_string lexbuf }
   | '"'
-      { Tokens.flush_sublexer(); Output.char '"' }
+      { Tokens.flush_sublexer(); OutB.char '"' }
   | _ { let c = lexeme_char lexbuf 0 in
-        Output.sublexer c (lexeme_start lexbuf);
+        OutB.sublexer c (lexeme_start lexbuf);
         notation_string lexbuf }
 
 and string = parse
-  | "\"\"" { Output.char '"'; Output.char '"'; string lexbuf }
-  | '"'    { Output.char '"' }
-  | _      { let c = lexeme_char lexbuf 0 in Output.char c; string lexbuf }
+  | "\"\"" { OutB.char '"'; OutB.char '"'; string lexbuf }
+  | '"'    { OutB.char '"' }
+  | _      { let c = lexeme_char lexbuf 0 in OutB.char c; string lexbuf }
 
 and skip_hide = parse
   | eof | end_hide { () }
@@ -1241,7 +1255,7 @@ and inf_rules_assumptions indents assumptions = parse
 and inf_rules_conclusion indents assumptions middle conclusions = parse
   | space* nl | space* "]]]" nl (* end of conclusions. *)
       { backtrack lexbuf;
-        Output.inf_rule assumptions middle (List.rev conclusions);
+        OutB.inf_rule assumptions middle (List.rev conclusions);
         inf_rules indents lexbuf }
   | space* [^ '\n']+ nl (* this is a line in the conclusion *)
       { let line = lexeme lexbuf in
@@ -1290,9 +1304,9 @@ and st_subtitle = parse
     let c = open_in f in
     let lb = from_channel c in
       (Index.current_library := m;
-       Output.initialize ();
-       Output.start_module ();
-       Output.start_coq (); coq_bol lb; Output.end_coq ();
+       OutB.initialize ();
+       OutB.start_module ();
+       OutB.start_coq (); coq_bol lb; OutB.end_coq ();
        close_in c)
 
   let detect_subtitle f m =
@@ -1301,4 +1315,6 @@ and st_subtitle = parse
     let sub = st_start m lb in
       close_in c;
       sub
+
+  end
 }

--- a/tools/coqdoc/main.ml
+++ b/tools/coqdoc/main.ml
@@ -28,6 +28,7 @@ let usage () =
   prerr_endline "  --latex              produce a LaTeX document";
   prerr_endline "  --texmacs            produce a TeXmacs document";
   prerr_endline "  --raw                produce a text document";
+  prerr_endline "  --backend=debug      produce a debug document";
   prerr_endline "  --dvi                output the DVI";
   prerr_endline "  --ps                 output the PostScript";
   prerr_endline "  --pdf                output the Pdf";
@@ -91,8 +92,10 @@ let banner () =
 let target_full_name f =
   match !Cdglobals.target_language with
     | HTML  -> f ^ ".html"
+    | TeXmacs
+    | LaTeX -> f ^ ".tex"
     | Raw   -> f ^ ".txt"
-    | _     -> f ^ ".tex"
+    | Debug -> f ^ ".txt"
 
 (*s \textbf{Separation of files.} Files given on the command line are
     separated according to their type, which is determined by their
@@ -253,6 +256,8 @@ let parse () =
 	Cdglobals.target_language := TeXmacs; parse_rec rem
     | ("-raw" | "--raw") :: rem ->
 	Cdglobals.target_language := Raw; parse_rec rem
+    | ("--backend=debug") :: rem ->
+	Cdglobals.target_language := Debug; parse_rec rem
     | ("-charset" | "--charset") :: s :: rem ->
 	Cdglobals.charset := s; parse_rec rem
     | ("-charset" | "--charset") :: [] ->
@@ -417,6 +422,7 @@ let output_factory tl =
   | HTML      -> (module Html    : S)
   | TeXmacs   -> (module TeXmacs : S)
   | Raw       -> (module Raw     : S)
+  | Debug     -> (module Out_debug.Debug : S)
 
 (*s Functions for generating output files *)
 

--- a/tools/coqdoc/out_debug.ml
+++ b/tools/coqdoc/out_debug.ml
@@ -1,0 +1,143 @@
+(************************************************************************)
+(*  v      *   The Coq Proof Assistant  /  The Coq Development Team     *)
+(* <O___,, *   INRIA - CNRS - LIX - LRI - PPS - Copyright 1999-2015     *)
+(*   \VV/  **************************************************************)
+(*    //   *      This file is distributed under the terms of the       *)
+(*         *       GNU Lesser General Public License Version 2.1        *)
+(************************************************************************)
+
+open Cdglobals
+open Index
+open Output
+
+open Format
+
+(* Function to Print index entries *)
+let pp_idxo fmt idx = match idx with
+  (* refs:  Index.index_entry: the index type of the token (if any) *)
+  | Some refs -> fprintf fmt ""
+  | None      -> fprintf fmt ""
+
+module Debug : S = struct
+
+  let oc = ref (formatter_of_out_channel stdout)
+
+  let printf        s = fprintf !oc s
+  let output_char   c = printf "%c" c
+  let output_string s = printf "%s" s
+
+  let cur_mod = ref ""
+
+  let output_sublexer_string esc sym idx s =
+    let s_esc = if esc then "e" else "" in
+    let s_sym = if esc then "S" else "" in
+    let s_tot = if esc || sym then "<" ^ s_esc ^ s_sym ^ ">" else "" in
+    fprintf !oc "%s%s" s_tot s
+
+  let appendix ~toc ~index ~split_index ~standalone =
+    printf "#appendix [toc: %B|idx: %B|splt: %B|std: %B]@\n"
+      toc index split_index standalone
+
+  let push_in_preamble s = printf "#preamble: %s@\n" s
+
+  let support_files = []
+
+  let start_file out ~toc ~index ~split_index ~standalone =
+    oc := formatter_of_out_channel out;
+    Tokens.token_tree := ref Tokens.empty_ttree;
+    Tokens.outfun     := output_sublexer_string;
+    printf "#start_file [toc: %B|idx: %B|splt: %B|std: %B]@\n"
+      toc index split_index standalone
+
+  let end_file () =
+    printf "#end_file@\n%!"
+
+  let start_module coq_mod =
+    cur_mod := coq_mod;
+    printf "#start_module: %s/%s@\n" !lib_name coq_mod
+
+  let indentation n = for _i = 1 to n do printf "␣" done
+
+  let line_break         () = printf "¶@\n"
+  let empty_line_of_code () = printf "⏎@\n"
+
+  let nbsp () = printf "<␣>"
+
+  let char                   = output_char
+  let verbatim_char inline c = printf "`%c`" c
+  let hard_verbatim_char     = output_char
+
+  let latex_char   s = printf "[!%c]" s
+  let latex_string s = printf "[\\%s]" s
+
+  let html_char   c = printf "<h>%c" c
+  let html_string s = printf "<h>%s" s
+
+  let start_latex_math () = printf "#begin_math@\n"
+  let stop_latex_math  () = printf "#end_math@\n"
+
+  let start_quote () = printf "#start_quote@\n"
+  let stop_quote  () = printf "#stop_quote@\n"
+
+  let start_verbatim inline =
+    if inline then printf "<tt>"
+    else printf "<pre>"
+
+  let stop_verbatim inline =
+    if inline then printf "</tt>"
+    else printf "</pre>\n"
+
+  let url addr name =
+    printf "<a href=\"%s\">%s</a>" addr
+      (match name with
+       | Some n -> n
+       | None -> addr)
+
+  let sublexer c loc =
+    let tag = try Some (Index.find !cur_mod loc) with Not_found -> None
+    in Tokens.output_tagged_symbol_char tag c
+
+  let sublexer_in_doc c = Tokens.output_tagged_symbol_char None c
+
+  let keyword s loc = printf "<k>%s" s
+  let ident   s loc = printf "<i>%s" s
+  let proofbox ()   = printf "#proofbox "
+
+  let reach_item_level n = printf "#reach-item-level: %d@\n" n
+
+  let item n       = printf "#start-item: %d@\n" n
+  let stop_item () = printf "#stop-item@\n"
+
+  let start_coq () = printf "#start-coq@\n"
+  let end_coq   () = printf "#end-coq@\n"
+
+  let start_doc () = printf "#start-doc@\n"
+  let end_doc   () = printf "#end-doc@\n"
+
+  let start_emph () = printf "<em>"
+  let stop_emph  () = printf "</em>"
+
+  let start_comment () = printf "#start_comment@\n"
+  let end_comment   () = printf "#end_comment@\n"
+
+  let start_code () = printf "#start_code@\n"
+  let end_code   () = printf "#end_code@\n"
+
+  let start_inline_coq () = printf "#start-inline-coq@\n"
+  let end_inline_coq   () = printf "#end-inline-coq@\n"
+
+  let start_inline_coq_block () = printf "#start-inline-coq-block@\n"
+  let end_inline_coq_block   () = printf "#end-inline-coq-block@\n"
+
+  let paragraph () = printf "#par@\n"
+
+  let inf_rule _ _ _ = printf "#inf_rule @\n"
+
+  let section lev f =
+    printf "#start-sec-%d: " lev;
+    f ();
+    printf "#end-sec-%d@\n" lev
+
+  let rule () = printf "<hr/>\n"
+
+end

--- a/tools/coqdoc/out_debug.ml
+++ b/tools/coqdoc/out_debug.ml
@@ -120,9 +120,6 @@ module Debug : S = struct
   let start_comment () = printf "#start_comment@\n"
   let end_comment   () = printf "#end_comment@\n"
 
-  let start_code () = printf "#start_code@\n"
-  let end_code   () = printf "#end_code@\n"
-
   let start_inline_coq () = printf "#start-inline-coq@\n"
   let end_inline_coq   () = printf "#end-inline-coq@\n"
 

--- a/tools/coqdoc/out_debug.mli
+++ b/tools/coqdoc/out_debug.mli
@@ -1,0 +1,9 @@
+(************************************************************************)
+(*  v      *   The Coq Proof Assistant  /  The Coq Development Team     *)
+(* <O___,, *   INRIA - CNRS - LIX - LRI - PPS - Copyright 1999-2015     *)
+(*   \VV/  **************************************************************)
+(*    //   *      This file is distributed under the terms of the       *)
+(*         *       GNU Lesser General Public License Version 2.1        *)
+(************************************************************************)
+
+module Debug : Output.S

--- a/tools/coqdoc/output.ml
+++ b/tools/coqdoc/output.ml
@@ -196,9 +196,6 @@ val end_comment : unit -> unit
 val start_coq : unit -> unit
 val end_coq : unit -> unit
 
-val start_code : unit -> unit
-val end_code : unit -> unit
-
 val start_inline_coq : unit -> unit
 val end_inline_coq : unit -> unit
 
@@ -598,10 +595,6 @@ module Latex : S = struct
 
   let end_coq () = printf "\\end{coqdoccode}\n"
 
-  let start_code () = end_doc (); start_coq ()
-
-  let end_code () = end_coq (); start_doc ()
-
   let section_kind = function
     | 1 -> "\\section{"
     | 2 -> "\\subsection{"
@@ -890,10 +883,6 @@ module Html : S = struct
   let start_comment () = printf "<span class=\"comment\">(*"
 
   let end_comment () = printf "*)</span>"
-
-  let start_code () = end_doc (); start_coq ()
-
-  let end_code () = end_coq (); start_doc ()
 
   let start_inline_coq () = 
     if !inline_notmono then printf "<span class=\"inlinecodenm\">"
@@ -1236,9 +1225,6 @@ module TeXmacs : S = struct
   let start_comment () = ()
   let end_comment () = ()
 
-  let start_code () = in_doc := true; printf "<\\code>\n"
-  let end_code () = in_doc := false; printf "\n</code>"
-
   let section_kind = function
     | 1 -> "section"
     | 2 -> "subsection"
@@ -1362,9 +1348,6 @@ module Raw : S = struct
 
   let start_coq () = ()
   let end_coq () = ()
-
-  let start_code () = end_doc (); start_coq ()
-  let end_code () = end_coq (); start_doc ()
 
   let section_kind =
     function

--- a/tools/coqdoc/output.ml
+++ b/tools/coqdoc/output.ml
@@ -11,14 +11,12 @@ open Index
 
 (*s Low level output *)
 
-let output_char c = Pervasives.output_char !out_channel c
-
+let output_char   c = Pervasives.output_char !out_channel c
 let output_string s = Pervasives.output_string !out_channel s
 
 let printf s = Printf.fprintf !out_channel s
 
 let sprintf = Printf.sprintf
-
 
 (*s Coq keywords *)
 
@@ -185,10 +183,10 @@ module type S = sig
 
 val initialize : unit -> unit
 
+val push_in_preamble : string -> unit
+
 val header : unit -> unit
 val trailer : unit -> unit
-
-val push_in_preamble : string -> unit
 
 val start_module : unit -> unit
 
@@ -232,7 +230,6 @@ val keyword : string -> loc -> unit
 val ident : string -> loc option -> unit
 val sublexer : char -> loc -> unit
 val sublexer_in_doc : char -> unit
-val initialize : unit -> unit
 
 val proofbox : unit -> unit
 
@@ -1334,11 +1331,3 @@ module Raw : S = struct
   let make_toc () = ()
 
 end
-
-(*s Generic output *)
-
-let output_factory tl = match tl with
-  | LaTeX   -> (module Latex   : S)
-  | HTML    -> (module Html    : S)
-  | TeXmacs -> (module TeXmacs : S)
-  | Raw     -> (module Raw     : S)

--- a/tools/coqdoc/output.ml
+++ b/tools/coqdoc/output.ml
@@ -185,6 +185,8 @@ val initialize : unit -> unit
 
 val push_in_preamble : string -> unit
 
+val support_files : string list
+
 val header : unit -> unit
 val trailer : unit -> unit
 
@@ -340,6 +342,8 @@ module Latex : S = struct
     end
 
   let push_in_preamble s = Queue.add s preamble
+
+  let support_files = ["coqdoc.sty"]
 
   (*s Latex low-level translation *)
 
@@ -674,6 +678,8 @@ module Html : S = struct
       end
 
   let push_in_preamble _ = ()
+
+  let support_files = ["coqdoc.css"]
 
   let start_module () =
     let ln = !lib_name in
@@ -1082,6 +1088,8 @@ module TeXmacs : S = struct
 
   let push_in_preamble _ = ()
 
+  let support_files = []
+
   let nbsp () = output_char ' '
 
   let char_true c = match c with
@@ -1231,6 +1239,8 @@ module Raw : S = struct
   let trailer () = ()
 
   let push_in_preamble _ = ()
+
+  let support_files = []
 
   let nbsp () = output_char ' '
 

--- a/tools/coqdoc/output.mli
+++ b/tools/coqdoc/output.mli
@@ -9,13 +9,17 @@
 open Cdglobals
 open Index
 
-val initialize : unit -> unit
-
-val add_printing_token : string -> string option * string option -> unit
+(* Common primitives *)
+val add_printing_token    : string -> string option * string option -> unit
 val remove_printing_token : string -> unit
 
-val set_module : coq_module -> string option -> unit
 val get_module : bool -> string
+val set_module : coq_module -> string option -> unit
+
+(* Backend printer *)
+module type S = sig
+
+val initialize : unit -> unit
 
 val header : unit -> unit
 val trailer : unit -> unit
@@ -104,3 +108,8 @@ val inf_rule :  (int * string) list
 val make_multi_index : unit -> unit
 val make_index : unit -> unit
 val make_toc : unit -> unit
+
+end
+
+(*s Create an output backend *)
+val output_factory : target_language -> (module S)

--- a/tools/coqdoc/output.mli
+++ b/tools/coqdoc/output.mli
@@ -87,9 +87,11 @@ val reach_item_level : int -> unit
 val rule : unit -> unit
 
 val nbsp : unit -> unit
-val char : char -> unit
+
+val char    : char -> unit
 val keyword : string -> loc -> unit
-val ident : string -> loc option -> unit
+val ident   : string -> loc option -> unit
+
 val sublexer : char -> loc -> unit
 val sublexer_in_doc : char -> unit
 
@@ -97,8 +99,10 @@ val proofbox : unit -> unit
 
 val latex_char : char -> unit
 val latex_string : string -> unit
+
 val html_char : char -> unit
 val html_string : string -> unit
+
 val verbatim_char : bool -> char -> unit
 val hard_verbatim_char : char -> unit
 

--- a/tools/coqdoc/output.mli
+++ b/tools/coqdoc/output.mli
@@ -35,6 +35,8 @@ val initialize : unit -> unit
 
 val push_in_preamble : string -> unit
 
+val support_files : string list
+
 val header : unit -> unit
 val trailer : unit -> unit
 

--- a/tools/coqdoc/output.mli
+++ b/tools/coqdoc/output.mli
@@ -14,10 +14,6 @@ val add_printing_token    : string -> string option * string option -> unit
 val remove_printing_token : string -> unit
 
 (* This interface should be improved. *)
-val current_module : (string * string option) ref
-val get_module : bool -> string
-val set_module : coq_module -> string option -> unit
-
 type toc_entry =
   | Toc_library of string * string option
   | Toc_section of int * (unit -> unit) * string
@@ -31,17 +27,31 @@ val is_tactic  : string -> bool
 (* Backend printer *)
 module type S = sig
 
-val initialize : unit -> unit
-
+(** XXX move to start_file  *)
 val push_in_preamble : string -> unit
 
-val support_files : string list
+(** [support_files] List of support files to be copied along the output. *)
+val support_files    : string list
 
-val header : unit -> unit
-val trailer : unit -> unit
+(** [appendix toc index split_index standalone] Backend-specific
+    function that outputs additional files. *)
+val appendix : toc:bool -> index:bool -> split_index:bool -> standalone:bool -> unit
 
-val start_module : unit -> unit
+(** [start_file out toc index split_index standalone] Start a logical
+    output file to channel [out] [toc], [index], and [standalone]
+    control whether the backend will generate a TOC, index, and
+    header/trailers for the file.
+*)
+val start_file : out_channel -> toc:bool -> index:bool ->
+                 split_index:bool -> standalone:bool -> unit
 
+(** [end_file] Ends the file *)
+val end_file : unit -> unit
+
+(** [start_module mod] Starts a coq module. *)
+val start_module : coq_module -> unit
+
+(** [start_doc] Moves the backend to "document" mode. *)
 val start_doc : unit -> unit
 val end_doc : unit -> unit
 
@@ -117,10 +127,6 @@ val inf_rule :  (int * string) list
              -> (int * string * (string option))
              -> (int * string) list
              -> unit
-
-val make_multi_index : unit -> unit
-val make_index : unit -> unit
-val make_toc   : unit -> unit
 
 end
 

--- a/tools/coqdoc/output.mli
+++ b/tools/coqdoc/output.mli
@@ -9,22 +9,34 @@
 open Cdglobals
 open Index
 
-(* Common primitives *)
+(* Common primitives: should be moved to out_common? *)
 val add_printing_token    : string -> string option * string option -> unit
 val remove_printing_token : string -> unit
 
+(* This interface should be improved. *)
+val current_module : (string * string option) ref
 val get_module : bool -> string
 val set_module : coq_module -> string option -> unit
+
+type toc_entry =
+  | Toc_library of string * string option
+  | Toc_section of int * (unit -> unit) * string
+
+val add_toc_entry : toc_entry -> unit
+val toc_q : toc_entry Queue.t
+
+val is_keyword : string -> bool
+val is_tactic  : string -> bool
 
 (* Backend printer *)
 module type S = sig
 
 val initialize : unit -> unit
 
+val push_in_preamble : string -> unit
+
 val header : unit -> unit
 val trailer : unit -> unit
-
-val push_in_preamble : string -> unit
 
 val start_module : unit -> unit
 
@@ -68,7 +80,6 @@ val keyword : string -> loc -> unit
 val ident : string -> loc option -> unit
 val sublexer : char -> loc -> unit
 val sublexer_in_doc : char -> unit
-val initialize : unit -> unit
 
 val proofbox : unit -> unit
 
@@ -101,15 +112,17 @@ val url : string -> string option -> unit
    something smart we can just format the rule verbatim like the user did
 *)
 val inf_rule :  (int * string) list
-             -> (int * string * (string option)) 
+             -> (int * string * (string option))
              -> (int * string) list
              -> unit
 
 val make_multi_index : unit -> unit
 val make_index : unit -> unit
-val make_toc : unit -> unit
+val make_toc   : unit -> unit
 
 end
 
-(*s Create an output backend *)
-val output_factory : target_language -> (module S)
+module Latex   : S
+module Html    : S
+module TeXmacs : S
+module Raw     : S

--- a/tools/coqdoc/output.mli
+++ b/tools/coqdoc/output.mli
@@ -64,9 +64,6 @@ val end_comment : unit -> unit
 val start_coq : unit -> unit
 val end_coq : unit -> unit
 
-val start_code : unit -> unit
-val end_code : unit -> unit
-
 val start_inline_coq : unit -> unit
 val end_inline_coq : unit -> unit
 


### PR DESCRIPTION
This pull request introduces a cleanup in coqdoc; backends are mostly untouched, see the log for more details.

Please review.

Tested with Coq documentation, seems to be OK; SF and CPDT seem also OK, that is, they
exhibit the same artifacts in vanilla v8.5 vs the refactored version.
