### PR TITLE
Update Coq84.v

### DIFF
--- a/theories/Compat/Coq84.v
+++ b/theories/Compat/Coq84.v
@@ -18,16 +18,11 @@ Global Set Asymmetric Patterns.
 (** See bug 3545 *)
 Global Set Universal Lemma Under Conjunction.
 
-(** In 8.5, [refine] leaves over dependent subgoals. *)
-Tactic Notation "refine" uconstr(term) := refine term; shelve_unifiable.
-
 (** In 8.4, [constructor (tac)] allowed backtracking across the use of [constructor]; it has been subsumed by [constructor; tac]. *)
-Ltac constructor_84 := constructor.
-Ltac constructor_84_n n := constructor n.
 Ltac constructor_84_tac tac := once (constructor; tac).
 
-Tactic Notation "constructor" := constructor_84.
-Tactic Notation "constructor" int_or_var(n) := constructor_84_n n.
+Tactic Notation "constructor" := Coq.Init.Notations.constructor.
+Tactic Notation "constructor" int_or_var(n) := Coq.Init.Notations.constructor n.
 Tactic Notation "constructor" "(" tactic(tac) ")" := constructor_84_tac tac.
 
 (** Some tactic notations do not factor well with tactics; we add global parsing entries for some tactics that would otherwise be overwritten by custom variants. See https://coq.inria.fr/bugs/show_bug.cgi?id=4392. *)


### PR DESCRIPTION
We no longer need to redefine `refine` (it now shelves by default).  Also clean up `constructor` a bit.
