### PR TITLE
Export Nat in NPeano.v

### DIFF
--- a/theories/Numbers/Natural/Peano/NPeano.v
+++ b/theories/Numbers/Natural/Peano/NPeano.v
@@ -12,4 +12,4 @@ Require Import PeanoNat NAxioms.
 
 (** * [PeanoNat.Nat] already implements [NAxiomSig] *)
 
-Module Nat <: NAxiomsSig := Nat.
+Module Export Nat <: NAxiomsSig := Nat.


### PR DESCRIPTION
I believe this restores compatibility (with Coq 8.4) of things like

``` coq
Require Import NPeano.
Check (_ mod _).
```

after 8836eae5d52fbbadf7722548052da3f7ceb5b260.
