### PR TITLE
An adaptation of ssreflect's => to Coq introduction pattern model

### DIFF
--- a/parsing/g_tactic.ml4
+++ b/parsing/g_tactic.ml4
@@ -216,7 +216,7 @@ let merge_occurrences loc cl = function
 GEXTEND Gram
   GLOBAL: simple_tactic constr_with_bindings quantified_hypothesis
   bindings red_expr int_or_var open_constr uconstr
-  simple_intropattern clause_dft_concl hypident;
+  simple_intropattern intropatterns ne_intropatterns clause_dft_concl hypident;
 
   int_or_var:
     [ [ n = integer  -> ArgArg n

--- a/parsing/pcoq.ml
+++ b/parsing/pcoq.ml
@@ -382,6 +382,10 @@ module Tactic =
     let red_expr = make_gen_entry utactic (rawwit wit_red_expr) "red_expr"
     let simple_intropattern =
       make_gen_entry utactic (rawwit wit_intro_pattern) "simple_intropattern"
+    let intropatterns =
+      make_gen_entry utactic (rawwit (wit_list wit_intro_pattern)) "intropatterns"
+    let ne_intropatterns =
+      make_gen_entry utactic (rawwit (wit_list wit_intro_pattern)) "ne_intropatterns"
     let clause_dft_concl = 
       make_gen_entry utactic (rawwit wit_clause_dft_concl) "clause"
 

--- a/parsing/pcoq.mli
+++ b/parsing/pcoq.mli
@@ -231,6 +231,8 @@ module Tactic :
     val red_expr : raw_red_expr Gram.entry
     val simple_tactic : raw_tactic_expr Gram.entry
     val simple_intropattern : constr_expr intro_pattern_expr located Gram.entry
+    val intropatterns : constr_expr intro_pattern_expr located list Gram.entry
+    val ne_intropatterns : constr_expr intro_pattern_expr located list Gram.entry
     val clause_dft_concl : Names.Id.t Loc.located Locus.clause_expr Gram.entry
     val tactic_arg : raw_tactic_arg Gram.entry
     val tactic_expr : raw_tactic_expr Gram.entry

--- a/test-suite/success/intros.v
+++ b/test-suite/success/intros.v
@@ -97,4 +97,12 @@ Goal forall x, (True -> x=0) -> 0=x.
 intros x ->.
 - reflexivity.
 - exact I.
+
+(* Testing ==> *)
+
+Goal forall x, x=0 -> x=0.
+intro x.
+elim x ==> [> | * IH] H.
+- exact H.
+- exact H.
 Qed.


### PR DESCRIPTION
This commit is proposing a (claimed more general, more robust, more flexible, more universal) variant of ssreflect's => (noted ==>) for abbreviating either

intros intropatterns 

or

[> intros intropatterns1 | .. | intros intropatternsn ]

and more generally sequences of those as well as combinations based on the other notational variants of "[> ...]" (e.g. "==> H [> .. | H'] H'' [ | n ] [> H'' .. ] , etc.)

As a consequence of being based on "intros" (where "intros" without arguments means "idtac", not "intros **"), "==>" is structured, robust wrt side conditions and flexible wrt the number of names given in "destruct" or "injection" patterns.

The ssreflect's context-dependent overloading between initial [...] as either an overloaded destructor/dispatcher or a dispatcher is solved by using Arnaud's "[> ... ]" for the second case. As a consequence it is a universal tactical.

Like "[> ...]", "==>" can be used to start a line, thus saving an "intros" keyword.
