### PR TITLE
Iff as a proper connective

### DIFF
--- a/theories/Classes/Init.v
+++ b/theories/Classes/Init.v
@@ -17,7 +17,7 @@
 
 Require Import Coq.Program.Basics.
 
-Typeclasses Opaque id const flip compose arrow impl iff not all.
+Typeclasses Opaque id const flip compose arrow impl not all.
 
 (** Apply using the same opacity information as typeclass proof search. *)
 

--- a/theories/FSets/FMapPositive.v
+++ b/theories/FSets/FMapPositive.v
@@ -1052,7 +1052,6 @@ Module PositiveMap <: S with Module E:=PositiveOrderedTypeBits.
   destruct (IHm2 _ _ H1); clear H1 IHm2.
   split; intros.
   destruct k; unfold In, MapsTo in *; simpl; auto.
-  split; eauto.
   destruct k; unfold In, MapsTo in *; simpl in *.
   eapply H3; eauto.
   eapply H2; eauto.

--- a/theories/FSets/FSetDecide.v
+++ b/theories/FSets/FSetDecide.v
@@ -168,7 +168,7 @@ the above form:
 
     Tactic Notation "push" "not" "using" ident(db) :=
       let dec := solve_decidable using db in
-      unfold not, iff;
+      unfold not;
       repeat (
         match goal with
         | |- context [True -> False] => rewrite not_true_iff
@@ -191,7 +191,7 @@ the above form:
     Tactic Notation
       "push" "not" "in" "*" "|-" "using" ident(db) :=
       let dec := solve_decidable using db in
-      unfold not, iff in * |-;
+      unfold not in * |-;
       repeat (
         match goal with
         | H: context [True -> False] |- _ => rewrite not_true_iff in H
@@ -252,7 +252,7 @@ the above form:
 
     Tactic Notation "pull" "not" "using" ident(db) :=
       let dec := solve_decidable using db in
-      unfold not, iff;
+      unfold not;
       repeat (
         match goal with
         | |- context [True -> False] => rewrite not_true_iff
@@ -278,7 +278,7 @@ the above form:
     Tactic Notation
       "pull" "not" "in" "*" "|-" "using" ident(db) :=
       let dec := solve_decidable using db in
-      unfold not, iff in * |-;
+      unfold not in * |-;
       repeat (
         match goal with
         | H: context [True -> False] |- _ => rewrite not_true_iff in H
@@ -693,8 +693,6 @@ the above form:
       clients of this library).  It's specification is given at
       the top of the file. *)
   Ltac fsetdec :=
-    (** We first unfold any occurrences of [iff]. *)
-    unfold iff in *;
     (** We fold occurrences of [not] because it is better for
         [intros] to leave us with a goal of [~ P] than a goal of
         [False]. *)

--- a/theories/FSets/FSetToFiniteSet.v
+++ b/theories/FSets/FSetToFiniteSet.v
@@ -25,7 +25,7 @@ Module WS_to_Finite_set (U:UsualDecidableType)(M: WSfun U).
 
  Lemma In_In : forall s x, M.In x s <-> In _ (!!s) x.
  Proof.
- unfold In; compute; auto with extcore.
+ unfold In; compute; auto.
  Qed.
 
  Lemma Subset_Included : forall s s',  s[<=]s'  <-> Included _ (!!s) (!!s').

--- a/theories/Init/Logic.v
+++ b/theories/Init/Logic.v
@@ -70,9 +70,10 @@ Arguments or_intror [A B] _, A [B] _.
 
 (** [iff A B], written [A <-> B], expresses the equivalence of [A] and [B] *)
 
-Definition iff (A B:Prop) := (A -> B) /\ (B -> A).
+Inductive iff (A B:Prop) : Prop :=
+  iff_intro : (A -> B) -> (B -> A) -> A <-> B
 
-Notation "A <-> B" := (iff A B) : type_scope.
+where "A <-> B" := (iff A B) : type_scope.
 
 Section Equivalence.
 
@@ -92,8 +93,6 @@ Theorem iff_sym : forall A B:Prop, (A <-> B) -> (B <-> A).
   Qed.
 
 End Equivalence.
-
-Hint Unfold iff: extcore.
 
 (** Backward direction of the equivalences above does not need assumptions *)
 
@@ -193,10 +192,13 @@ Proof.
   + left; right; assumption.
   + right; assumption.
 Qed.
+
 Lemma iff_and : forall A B : Prop, (A <-> B) -> (A -> B) /\ (B -> A).
 Proof.
   intros A B []; split; trivial.
 Qed.
+
+Coercion iff_and : iff >-> and.
 
 Lemma iff_to_and : forall A B : Prop, (A <-> B) <-> (A -> B) /\ (B -> A).
 Proof.

--- a/theories/Init/Logic.v
+++ b/theories/Init/Logic.v
@@ -75,6 +75,8 @@ Inductive iff (A B:Prop) : Prop :=
 
 where "A <-> B" := (iff A B) : type_scope.
 
+Hint Resolve iff_intro : core.
+
 Section Equivalence.
 
 Theorem iff_refl : forall A:Prop, A <-> A.

--- a/theories/MSets/MSetDecide.v
+++ b/theories/MSets/MSetDecide.v
@@ -168,7 +168,7 @@ the above form:
 
     Tactic Notation "push" "not" "using" ident(db) :=
       let dec := solve_decidable using db in
-      unfold not, iff;
+      unfold not;
       repeat (
         match goal with
         | |- context [True -> False] => rewrite not_true_iff
@@ -191,7 +191,7 @@ the above form:
     Tactic Notation
       "push" "not" "in" "*" "|-" "using" ident(db) :=
       let dec := solve_decidable using db in
-      unfold not, iff in * |-;
+      unfold not in * |-;
       repeat (
         match goal with
         | H: context [True -> False] |- _ => rewrite not_true_iff in H
@@ -252,7 +252,7 @@ the above form:
 
     Tactic Notation "pull" "not" "using" ident(db) :=
       let dec := solve_decidable using db in
-      unfold not, iff;
+      unfold not;
       repeat (
         match goal with
         | |- context [True -> False] => rewrite not_true_iff
@@ -278,7 +278,7 @@ the above form:
     Tactic Notation
       "pull" "not" "in" "*" "|-" "using" ident(db) :=
       let dec := solve_decidable using db in
-      unfold not, iff in * |-;
+      unfold not in * |-;
       repeat (
         match goal with
         | H: context [True -> False] |- _ => rewrite not_true_iff in H
@@ -693,8 +693,6 @@ the above form:
       clients of this library).  It's specification is given at
       the top of the file. *)
   Ltac fsetdec :=
-    (** We first unfold any occurrences of [iff]. *)
-    unfold iff in *;
     (** We fold occurrences of [not] because it is better for
         [intros] to leave us with a goal of [~ P] than a goal of
         [False]. *)

--- a/theories/MSets/MSetToFiniteSet.v
+++ b/theories/MSets/MSetToFiniteSet.v
@@ -25,7 +25,7 @@ Module WS_to_Finite_set (U:UsualDecidableType)(M: WSetsOn U).
 
  Lemma In_In : forall s x, M.In x s <-> In _ (!!s) x.
  Proof.
- unfold In; compute; auto with extcore.
+ unfold In; compute; auto.
  Qed.
 
  Lemma Subset_Included : forall s s',  s[<=]s'  <-> Included _ (!!s) (!!s').

--- a/theories/ZArith/Zquot.v
+++ b/theories/ZArith/Zquot.v
@@ -236,7 +236,7 @@ Proof. intros. zero_or_not b. apply Z.mul_quot_ge; auto with zarith. Qed.
     iff the modulo is zero. *)
 
 Lemma Z_quot_exact_full a b : a = b*(a÷b) <-> Z.rem a b = 0.
-Proof. intros. zero_or_not b. intuition. apply Z.quot_exact; auto. Qed.
+Proof. intros. zero_or_not b. apply Z.quot_exact; auto. Qed.
 
 (** A modulo cannot grow beyond its starting point. *)
 


### PR DESCRIPTION
This commit proposes to implement the long-standing request of defining "iff" as a proper connective distinct from "and" and to remove the ad hoc "extcore" hint database whose only purpose was to have "auto" working with "iff" without breaking the compatibility of auto.

So this is late attempt to start on a better basis with iff, but better late than never.

Preserving compatibility with just a flag would be difficult. In a first time, we should test this on a larger set of user developments.

Two kinds of incompatibilities are observable in the standard library:
- using conj for introducing iff while now it is iff_intro ; this is solved by adding a coercion iff -> and
- auto now doing something on a "A <-> B" statement while before it was doing something only when iff was first unfolded (two changes in the standard library, which is not a lot)

Note; The commits should be squashed into one before merging.
