### PR TITLE
Coqlib cleanup [Review PR, not ready for merge yet]

### DIFF
--- a/dev/printers.mllib
+++ b/dev/printers.mllib
@@ -140,6 +140,9 @@ Typeclasses_errors
 Typeclasses
 Detyping
 Indrec
+Declaremods
+Library
+Coqlib
 Program
 Coercion
 Cases

--- a/grammar/q_constr.ml4
+++ b/grammar/q_constr.ml4
@@ -59,10 +59,10 @@ EXTEND
         <:expr< Glob_term.GProd ($dloc$,Anonymous,Decl_kinds.Explicit,$c1$,$c2$) >> ]
     | "75" RIGHTA
       [ "~"; c = constr ->
-        apply_ref <:expr< lazy (get_ref "core.not.type") >> [c] ]
+        apply_ref <:expr< lazy (lib_ref "core.not.type") >> [c] ]
     | "70" RIGHTA
       [ c1 = constr; "="; c2 = NEXT; ":>"; t = NEXT ->
-        apply_ref <:expr< lazy (get_ref "core.eq.type") >> [t;c1;c2] ]
+        apply_ref <:expr< lazy (lib_ref "core.eq.type") >> [t;c1;c2] ]
     | "10" LEFTA
       [ f = constr; args = LIST1 NEXT ->
         let args = mlexpr_of_list (fun x -> x) args in

--- a/grammar/q_constr.ml4
+++ b/grammar/q_constr.ml4
@@ -62,7 +62,7 @@ EXTEND
         apply_ref <:expr< coq_not_ref >> [c] ]
     | "70" RIGHTA
       [ c1 = constr; "="; c2 = NEXT; ":>"; t = NEXT ->
-        apply_ref <:expr< lazy (build_coq_eq_data()).eq >> [t;c1;c2] ]
+        apply_ref <:expr< lazy (get_ref "core.eq.type") >> [t;c1;c2] ]
     | "10" LEFTA
       [ f = constr; args = LIST1 NEXT ->
         let args = mlexpr_of_list (fun x -> x) args in

--- a/grammar/q_constr.ml4
+++ b/grammar/q_constr.ml4
@@ -62,7 +62,7 @@ EXTEND
         apply_ref <:expr< coq_not_ref >> [c] ]
     | "70" RIGHTA
       [ c1 = constr; "="; c2 = NEXT; ":>"; t = NEXT ->
-        apply_ref <:expr< coq_eq_ref >> [t;c1;c2] ]
+        apply_ref <:expr< lazy (build_coq_eq_data()).eq >> [t;c1;c2] ]
     | "10" LEFTA
       [ f = constr; args = LIST1 NEXT ->
         let args = mlexpr_of_list (fun x -> x) args in

--- a/grammar/q_constr.ml4
+++ b/grammar/q_constr.ml4
@@ -59,7 +59,7 @@ EXTEND
         <:expr< Glob_term.GProd ($dloc$,Anonymous,Decl_kinds.Explicit,$c1$,$c2$) >> ]
     | "75" RIGHTA
       [ "~"; c = constr ->
-        apply_ref <:expr< coq_not_ref >> [c] ]
+        apply_ref <:expr< lazy (get_ref "core.not.type") >> [c] ]
     | "70" RIGHTA
       [ c1 = constr; "="; c2 = NEXT; ":>"; t = NEXT ->
         apply_ref <:expr< lazy (get_ref "core.eq.type") >> [t;c1;c2] ]

--- a/interp/coqlib.ml
+++ b/interp/coqlib.ml
@@ -36,18 +36,24 @@ let table : (string * string list * string) array =
    ; "core.True.I",     ["Coq"; "Init"; "Logic"], "I"
 
    ; "core.not.type",   ["Coq"; "Init"; "Logic"], "not"
+
    ; "core.or.type",    ["Coq"; "Init"; "Logic"], "or"
+
    ; "core.and.type",   ["Coq"; "Init"; "Logic"], "and"
+   ; "core.and.ind",    ["Coq"; "Init"; "Logic"], "and_ind"
 
    ; "core.iff.type",   ["Coq"; "Init"; "Logic"], "iff"
    ; "core.iff.proj1",  ["Coq"; "Init"; "Logic"], "proj1"
    ; "core.iff.proj2",  ["Coq"; "Init"; "Logic"], "proj2"
 
-   ; "core.ex.type",    ["Coq"; "Init"; "Specif"], "exist"
+   ; "core.ex.type",    ["Coq"; "Init"; "Logic"], "ex"
+   ; "core.ex.ind",     ["Coq"; "Init"; "Logic"], "ex_ind"
+   ; "core.ex.intro",   ["Coq"; "Init"; "Logic"], "ex_intro"
 
    ; "core.eq.type",    ["Coq"; "Init"; "Logic"], "eq"
    ; "core.eq.refl",    ["Coq"; "Init"; "Logic"], "eq_refl"
    ; "core.eq.ind",     ["Coq"; "Init"; "Logic"], "eq_ind"
+   ; "core.eq.rect",    ["Coq"; "Init"; "Logic"], "eq_rect"
    ; "core.eq.sym",     ["Coq"; "Init"; "Logic"], "eq_sym"
    ; "core.eq.congr",   ["Coq"; "Init"; "Logic"], "f_equal"
    ; "core.eq.trans",   ["Coq"; "Init"; "Logic"], "eq_trans"

--- a/interp/coqlib.ml
+++ b/interp/coqlib.ml
@@ -15,6 +15,16 @@ open Libnames
 open Globnames
 open Nametab
 
+(* Useful for bad^W non-generic tactics *)
+(*
+let _ =
+  let open Pp in
+  Errors.register_handler (function
+    | Nametab.GlobalizationError qid ->
+      (str "GErr at " ++ str (Libnames.string_of_qualid qid))
+    | _ -> raise Unhandled)
+*)
+
 (************************************************************************)
 (* New API *)
 let make_dir l = DirPath.make (List.rev_map Id.of_string l)
@@ -30,7 +40,7 @@ let find_reference locstr dir s =
     anomaly ~label:locstr (str "cannot find " ++ Libnames.pr_path sp)
 
 type mode = Ssr | HoTT | Coq
-let mode = Coq
+let mode = Ssr
 
 let coq = Nameops.coq_string (* "Coq" *)
 

--- a/interp/coqlib.ml
+++ b/interp/coqlib.ml
@@ -159,13 +159,13 @@ let table : (string, global_reference Lazy.t) Hashtbl.t =
   ht
 
 (** Can throw Not_found *)
-let get_ref    s =
+let lib_ref    s =
   (* Format.eprintf "get_ref %s \n%!" s; *)
   try Lazy.force (Hashtbl.find table s)
   with | Not_found ->
     Format.eprintf "not found in table: %s %!" s; raise Not_found
 
-let get_constr s = Universes.constr_of_global (get_ref s)
+let lib_constr s = Universes.constr_of_global (lib_ref s)
 
 (** Replaces a binding ! *)
 let add_ref  s c =
@@ -300,11 +300,11 @@ type coq_sigma_data = {
   typ   : global_reference }
 
 let build_sigma_gen str =
-  { typ   = get_ref ("core." ^ str ^ ".type");
-    elim  = get_ref ("core." ^ str ^ ".rect");
-    intro = get_ref ("core." ^ str ^ ".intro");
-    proj1 = get_ref ("core." ^ str ^ ".proj1");
-    proj2 = get_ref ("core." ^ str ^ ".proj2");
+  { typ   = lib_ref ("core." ^ str ^ ".type");
+    elim  = lib_ref ("core." ^ str ^ ".rect");
+    intro = lib_ref ("core." ^ str ^ ".intro");
+    proj1 = lib_ref ("core." ^ str ^ ".proj1");
+    proj2 = lib_ref ("core." ^ str ^ ".proj2");
   }
 
 let build_prod       () = build_sigma_gen "prod"
@@ -324,12 +324,12 @@ type coq_eq_data = {
 
 let build_eqdata_gen lib str =
   let _ = check_required_library lib in {
-  eq    = get_ref ("core." ^ str ^ ".type");
-  ind   = get_ref ("core." ^ str ^ ".ind");
-  refl  = get_ref ("core." ^ str ^ ".refl");
-  sym   = get_ref ("core." ^ str ^ ".sym");
-  trans = get_ref ("core." ^ str ^ ".trans");
-  congr = get_ref ("core." ^ str ^ ".congr");
+  eq    = lib_ref ("core." ^ str ^ ".type");
+  ind   = lib_ref ("core." ^ str ^ ".ind");
+  refl  = lib_ref ("core." ^ str ^ ".refl");
+  sym   = lib_ref ("core." ^ str ^ ".sym");
+  trans = lib_ref ("core." ^ str ^ ".trans");
+  congr = lib_ref ("core." ^ str ^ ".congr");
   }
 
 let build_coq_eq_data       () = build_eqdata_gen logic_module_name "eq"
@@ -347,9 +347,9 @@ type coq_inversion_data = {
 
 let build_coq_inversion_gen l str =
   List.iter check_required_library l; {
-    inv_eq    = get_ref ("core." ^ str ^ ".type");
-    inv_ind   = get_ref ("core." ^ str ^ ".ind");
-    inv_congr = get_ref ("core." ^ str ^ ".congr_canonical");
+    inv_eq    = lib_ref ("core." ^ str ^ ".type");
+    inv_ind   = lib_ref ("core." ^ str ^ ".ind");
+    inv_congr = lib_ref ("core." ^ str ^ ".congr_canonical");
   }
 
 let build_coq_inversion_eq_data () =
@@ -363,7 +363,7 @@ let build_coq_inversion_eq_true_data () =
 
 let build_coq_inversion_jmeq_data () =
   let _ = check_required_library logic_module_name in {
-  inv_eq    = get_ref "core.jmeq.hom";
-  inv_ind   = get_ref "core.jmeq.ind";
-  inv_congr = get_ref "core.jmeq.congr_canonical"; }
+  inv_eq    = lib_ref "core.jmeq.hom";
+  inv_ind   = lib_ref "core.jmeq.ind";
+  inv_congr = lib_ref "core.jmeq.congr_canonical"; }
 

--- a/interp/coqlib.ml
+++ b/interp/coqlib.ml
@@ -101,10 +101,17 @@ let table : (string * string list * string) array =
    ; "core.bool.andb",      ["Coq"; "Init"; "Datatypes"], "andb"
    ; "core.bool.andb_prop", ["Coq"; "Init"; "Datatypes"], "andb_prop"
    ; "core.bool.andb_true_intro", ["Coq"; "Init"; "Datatypes"], "andb_true_intro"
+   ; "core.bool.orb",       ["Coq"; "Init"; "Datatypes"], "orb"
+   ; "core.bool.xorb",      ["Coq"; "Init"; "Datatypes"], "xorb"
+   ; "core.bool.negb",      ["Coq"; "Init"; "Datatypes"], "negb"
 
    ; "core.eq_true.type",   ["Coq"; "Init"; "Datatypes"], "eq_true"
    ; "core.eq_true.ind",    ["Coq"; "Init"; "Datatypes"], "eq_true_ind"
    ; "core.eq_true.congr",  ["Coq"; "Init"; "Logic"],     "eq_true_congr"
+
+   ; "core.list.type",   ["Coq"; "Init"; "Datatypes"], "list"
+   ; "core.list.nil",    ["Coq"; "Init"; "Datatypes"], "nil"
+   ; "core.list.cons",   ["Coq"; "Init"; "DataTypes"], "cons"
 
   |]
 

--- a/interp/coqlib.ml
+++ b/interp/coqlib.ml
@@ -32,10 +32,6 @@ let find_reference locstr dir s =
     anomaly ~label:locstr (str "cannot find " ++ Libnames.pr_path sp)
 
 let coq_reference locstr dir s = find_reference locstr (coq::dir) s
-let coq_constant locstr dir s = Universes.constr_of_global (coq_reference locstr dir s)
-
-let gen_reference = coq_reference
-let gen_constant = coq_constant
 
 let has_suffix_in_dirs dirs ref =
   let dir = dirpath (path_of_global ref) in
@@ -68,7 +64,6 @@ let gen_reference_in_modules locstr dirs s =
 let gen_constant_in_modules locstr dirs s =
   Universes.constr_of_global (gen_reference_in_modules locstr dirs s)
 
-
 (* For tactics/commands requiring vernacular libraries *)
 
 let check_required_library d =
@@ -92,17 +87,19 @@ let check_required_library d =
 (************************************************************************)
 (* Specific Coq objects *)
 
+let coq_constant locstr dir s = Universes.constr_of_global (coq_reference locstr dir s)
+
 let init_reference dir s =
   let d = "Init"::dir in
-  check_required_library (coq::d); gen_reference "Coqlib" d s
+  check_required_library (coq::d); coq_reference "Coqlib" d s
 
 let init_constant dir s =
   let d = "Init"::dir in
-  check_required_library (coq::d); gen_constant "Coqlib" d s
+  check_required_library (coq::d); coq_constant "Coqlib" d s
 
 let logic_reference dir s =
   let d = "Logic"::dir in
-  check_required_library ("Coq"::d); gen_reference "Coqlib" d s
+  check_required_library ("Coq"::d); coq_reference "Coqlib" d s
 
 let arith_dir = [coq;"Arith"]
 let arith_modules = [arith_dir]
@@ -385,8 +382,8 @@ let build_coq_iff_right_proj () = Lazy.force coq_iff_right_proj
 (* The following is less readable but does not depend on parsing *)
 let coq_eq_ref      = lazy (init_reference ["Logic"] "eq")
 let coq_identity_ref = lazy (init_reference ["Datatypes"] "identity")
-let coq_jmeq_ref     = lazy (gen_reference "Coqlib" ["Logic";"JMeq"] "JMeq")
-let coq_eq_true_ref = lazy (gen_reference "Coqlib" ["Init";"Datatypes"] "eq_true")
+let coq_jmeq_ref     = lazy (coq_reference "Coqlib" ["Logic";"JMeq"] "JMeq")
+let coq_eq_true_ref = lazy (coq_reference "Coqlib" ["Init";"Datatypes"] "eq_true")
 let coq_existS_ref  = lazy (anomaly (Pp.str "use coq_existT_ref"))
 let coq_existT_ref  = lazy (init_reference ["Specif"] "existT")
 let coq_exist_ref  = lazy (init_reference ["Specif"] "exist")

--- a/interp/coqlib.ml
+++ b/interp/coqlib.ml
@@ -127,6 +127,11 @@ let get_ref    s =
 
 let get_constr s = Universes.constr_of_global (get_ref s)
 
+(** Replaces a binding ! *)
+let add_ref  s c =
+  (* Format.eprintf "add_ref_log: %s\n%!" s; *)
+  Hashtbl.add core_table s (Lazy.from_val c)
+
 (************************************************************************)
 (* Generic functions to find Coq objects *)
 
@@ -318,11 +323,21 @@ type coq_inversion_data = {
   inv_congr: global_reference  (* : forall params B (f:t->B) y, eq params y -> f c=f y *)
 }
 
+let build_coq_inversion_gen l str =
+  List.iter check_required_library l; {
+    inv_eq    = get_ref ("core." ^ str ^ ".type");
+    inv_ind   = get_ref ("core." ^ str ^ ".ind");
+    inv_congr = get_ref ("core." ^ str ^ ".congr_canonical");
+  }
+
 let build_coq_inversion_eq_data () =
-  let _     = check_required_library logic_module_name in {
-  inv_eq    = get_ref "core.eq.type";
-  inv_ind   = get_ref "core.eq.ind";
-  inv_congr = get_ref "core.eq.congr_canonical" }
+  build_coq_inversion_gen [logic_module_name] "eq"
+
+let build_coq_inversion_identity_data () =
+  build_coq_inversion_gen [datatypes_module_name; logic_type_module_name] "id"
+
+let build_coq_inversion_eq_true_data () =
+  build_coq_inversion_gen [datatypes_module_name; logic_module_name] "eq_true"
 
 let build_coq_inversion_jmeq_data () =
   let _ = check_required_library logic_module_name in {
@@ -330,17 +345,3 @@ let build_coq_inversion_jmeq_data () =
   inv_ind   = get_ref "core.jmeq.ind";
   inv_congr = get_ref "core.jmeq.congr_canonical"; }
 
-let build_coq_inversion_identity_data () =
-  let _     = check_required_library datatypes_module_name in
-  let _     = check_required_library logic_type_module_name in {
-  inv_eq    = get_ref "core.id.type";
-  inv_ind   = get_ref "core.id.ind";
-  inv_congr = get_ref "core.id.congr_canonical"; }
-
-(* Equality to true *)
-let build_coq_inversion_eq_true_data () =
-  let _ = check_required_library datatypes_module_name in
-  let _ = check_required_library logic_module_name in {
-  inv_eq    = get_ref "core.eq_true.type";
-  inv_ind   = get_ref "core.eq_true.ind";
-  inv_congr = get_ref "core.eq_true.congr"; }

--- a/interp/coqlib.ml
+++ b/interp/coqlib.ml
@@ -64,6 +64,7 @@ let gen_reference_in_modules locstr dirs s =
 let gen_constant_in_modules locstr dirs s =
   Universes.constr_of_global (gen_reference_in_modules locstr dirs s)
 
+
 (* For tactics/commands requiring vernacular libraries *)
 
 let check_required_library d =
@@ -81,8 +82,9 @@ let check_required_library d =
      (Loc.ghost,make_qualid (DirPath.make (List.rev prefix)) m)
 *)
 (* or failing ...*)
+      (Printexc.print_backtrace stderr;
       errorlabstrm "Coqlib.check_required_library"
-        (str "Library " ++ str (DirPath.to_string dir) ++ str " has to be required first.")
+        (str "Library " ++ str (DirPath.to_string dir) ++ str " has to be required first."))
 
 (************************************************************************)
 (* Specific Coq objects *)

--- a/interp/coqlib.ml
+++ b/interp/coqlib.ml
@@ -68,7 +68,7 @@ let table : (string * string list * string) array =
    ; "core.id.congr_canonical",   ["Coq"; "Init"; "Logic_Type"], "identity_congr_canonical_form"
 
    ; "core.prod.type",   ["Coq"; "Init"; "Datatypes"], "prod"
-   ; "core.prod.rect",   ["Coq"; "Init"; "Datatypes"], "prod_rec"
+   ; "core.prod.rect",   ["Coq"; "Init"; "Datatypes"], "prod_rect"
    ; "core.prod.intro",  ["Coq"; "Init"; "Datatypes"], "pair"
    ; "core.prod.proj1",  ["Coq"; "Init"; "Datatypes"], "fst"
    ; "core.prod.proj2",  ["Coq"; "Init"; "Datatypes"], "snd"
@@ -181,12 +181,12 @@ let check_required_library d =
 
 let coq = Nameops.coq_string (* "Coq" *)
 
-let arith_dir     = [ coq; "Arith"   ]
-let arith_modules = [ arith_dir      ]
-let numbers_dir   = [ coq; "Numbers" ]
-let parith_dir    = [ coq; "PArith"  ]
-let narith_dir    = [ coq; "NArith"  ]
-let zarith_dir    = [ coq; "ZArith"  ]
+let arith_dir     = [ coq ; "Arith"   ]
+let arith_modules = [ arith_dir       ]
+let numbers_dir   = [ coq ; "Numbers" ]
+let parith_dir    = [ coq ; "PArith"  ]
+let narith_dir    = [ coq ; "NArith"  ]
+let zarith_dir    = [ coq ; "ZArith"  ]
 
 let zarith_base_modules =
   [ numbers_dir

--- a/interp/coqlib.ml
+++ b/interp/coqlib.ml
@@ -14,7 +14,6 @@ open Term
 open Libnames
 open Globnames
 open Nametab
-open Smartlocate
 
 (************************************************************************)
 (* New API *)
@@ -22,7 +21,7 @@ let make_dir l = DirPath.make (List.rev_map Id.of_string l)
 
 let find_reference locstr dir s =
   let sp = Libnames.make_path (make_dir dir) (Id.of_string s) in
-  try global_of_extended_global (Nametab.extended_global_of_path sp)
+  try Nametab.global_of_path sp
   with Not_found ->
     Format.eprintf "ref not found %s %s\n%!" locstr s;
     Printexc.print_backtrace stderr;
@@ -131,13 +130,12 @@ let has_suffix_in_dirs dirs ref =
   List.exists (fun d -> is_dirpath_prefix_of d dir) dirs
 
 let global_of_extended q =
-  try Some (global_of_extended_global q) with Not_found -> None
+  try Some (Nametab.global_of_path q) with Not_found -> None
 
 let gen_reference_in_modules locstr dirs s =
-  let dirs = List.map make_dir dirs in
-  let qualid = qualid_of_string s in
-  let all = Nametab.locate_extended_all qualid in
-  let all = List.map_filter global_of_extended all in
+  let dirs = List.map make_dir dirs   in
+  let qualid = qualid_of_string s     in
+  let all = Nametab.locate_all qualid in
   let all = List.sort_uniquize RefOrdered_env.compare all in
   let these = List.filter (has_suffix_in_dirs dirs) all in
   match these with

--- a/interp/coqlib.mli
+++ b/interp/coqlib.mli
@@ -55,15 +55,16 @@ val glob_jmeq     : global_reference
 type message = string
 
 val find_reference : message -> string list -> string -> global_reference
-(* This just prefixes with Coq... *)
+
+(** This just prefixes find_reference with Coq... *)
 val coq_reference  : message -> string list -> string -> global_reference
 
 (** For tactics/commands requiring vernacular libraries *)
 val check_required_library : string list -> unit
 
 (** Search in several modules (not prefixed by "Coq") *)
-val gen_constant_in_modules  : string->string list list-> string -> constr
-val gen_reference_in_modules : string->string list list-> string -> global_reference
+val gen_constant_in_modules  : string -> string list list -> string -> constr
+val gen_reference_in_modules : string -> string list list -> string -> global_reference
 
 (* Used in omega: They must query the particular theory *)
 val arith_modules       : string list list
@@ -73,7 +74,7 @@ val init_modules        : string list list
 (** {6 Global references } *)
 
 (** Modules *)
-val prelude_module : DirPath.t
+val prelude_module    : DirPath.t
 
 val logic_module      : DirPath.t
 val logic_module_name : string list

--- a/interp/coqlib.mli
+++ b/interp/coqlib.mli
@@ -18,7 +18,7 @@ open Util
 (** The idea is to migrate to rebindable name-based approach, thus the
     only function this FILE will provide will be:
 
-    [get_ref : string -> global_reference]
+    [lib_ref : string -> global_reference]
 
     such that [find_reference "core.eq.type"]
     returns the proper [global_reference]
@@ -35,8 +35,8 @@ open Util
     This is work in progress, see below.
 *)
 
-val get_ref    : string -> global_reference
-val get_constr : string -> constr
+val lib_ref    : string -> global_reference
+val lib_constr : string -> constr
 
 val add_ref    : string -> global_reference -> unit
 

--- a/interp/coqlib.mli
+++ b/interp/coqlib.mli
@@ -15,6 +15,25 @@ open Util
 (** This module collects the global references, constructions and
     patterns of the standard library used in ocaml files *)
 
+(** The idea is to migrate to rebindable name-based approach, thus the
+    only function this FILE will provide will be:
+
+    [find_reference : string -> global_reference]
+
+    such that [find_reference "core.eq.type"] returns the proper [global_reference]
+
+    [bind_reference : string -> global_reference -> unit]
+
+    will bind a reference.
+
+    A feature based approach would be possible too.
+
+    Contrary to the old approach of raising an anomaly, we expect
+    tactics to gracefully fail in the absence of some primitive.
+
+    This is work in progress, see below.
+*)
+
 (** {6 ... } *)
 (** [find_reference caller_message [dir;subdir;...] s] returns a global
    reference to the name dir.subdir.(...).s; the corresponding module
@@ -25,30 +44,19 @@ open Util
 type message = string
 
 val find_reference : message -> string list -> string -> global_reference
-
-(** [coq_reference caller_message [dir;subdir;...] s] returns a
-   global reference to the name Coq.dir.subdir.(...).s *)
-
-val coq_reference : message -> string list -> string -> global_reference
-
-(** idem but return a term *)
-
-val coq_constant : message -> string list -> string -> constr
-
-(** Synonyms of [coq_constant] and [coq_reference] *)
-
-val gen_constant : message -> string list -> string -> constr
-val gen_reference :  message -> string list -> string -> global_reference
-
-(** Search in several modules (not prefixed by "Coq") *)
-val gen_constant_in_modules : string->string list list-> string -> constr
-val gen_reference_in_modules : string->string list list-> string -> global_reference
-val arith_modules : string list list
-val zarith_base_modules : string list list
-val init_modules : string list list
+(* This just prefixes with Coq... *)
+val coq_reference  : message -> string list -> string -> global_reference
 
 (** For tactics/commands requiring vernacular libraries *)
 val check_required_library : string list -> unit
+
+(** Search in several modules (not prefixed by "Coq") *)
+val gen_constant_in_modules  : string->string list list-> string -> constr
+val gen_reference_in_modules : string->string list list-> string -> global_reference
+
+val arith_modules : string list list
+val zarith_base_modules : string list list
+val init_modules : string list list
 
 (** {6 Global references } *)
 

--- a/interp/coqlib.mli
+++ b/interp/coqlib.mli
@@ -138,6 +138,8 @@ type coq_eq_data = {
 
 val build_coq_eq_data : coq_eq_data delayed
 
+(* val coq_eq_ref : global_reference lazy_t *)
+
 val build_coq_identity_data : coq_eq_data delayed
 val build_coq_jmeq_data : coq_eq_data delayed
 
@@ -190,7 +192,6 @@ val build_coq_or : constr delayed
 (** Existential quantifier *)
 val build_coq_ex : constr delayed
 
-val coq_eq_ref : global_reference lazy_t
 val coq_identity_ref : global_reference lazy_t
 val coq_jmeq_ref : global_reference lazy_t
 val coq_eq_true_ref : global_reference lazy_t

--- a/interp/coqlib.mli
+++ b/interp/coqlib.mli
@@ -38,6 +38,8 @@ open Util
 val get_ref    : string -> global_reference
 val get_constr : string -> constr
 
+val add_ref    : string -> global_reference -> unit
+
 (** Non-lazy, fixed equalities *)
 val glob_eq       : global_reference
 val glob_identity : global_reference

--- a/interp/coqlib.mli
+++ b/interp/coqlib.mli
@@ -62,14 +62,14 @@ val coq_reference  : message -> string list -> string -> global_reference
 (** For tactics/commands requiring vernacular libraries *)
 val check_required_library : string list -> unit
 
-(** Search in several modules (not prefixed by "Coq") *)
-val gen_constant_in_modules  : string -> string list list -> string -> constr
-val gen_reference_in_modules : string -> string list list -> string -> global_reference
-
-(* Used in omega: They must query the particular theory *)
+(** Used in omega/ring: They must query their particular theory XXX PORT to omega.xxx.xxx*)
 val arith_modules       : string list list
 val zarith_base_modules : string list list
 val init_modules        : string list list
+
+(** Search in several modules (not prefixed by "Coq") *)
+val gen_constant_in_modules  : string -> string list list -> string -> constr
+val gen_reference_in_modules : string -> string list list -> string -> global_reference
 
 (** {6 Global references } *)
 

--- a/interp/coqlib.mli
+++ b/interp/coqlib.mli
@@ -18,11 +18,12 @@ open Util
 (** The idea is to migrate to rebindable name-based approach, thus the
     only function this FILE will provide will be:
 
-    [find_reference : string -> global_reference]
+    [get_ref : string -> global_reference]
 
-    such that [find_reference "core.eq.type"] returns the proper [global_reference]
+    such that [find_reference "core.eq.type"]
+    returns the proper [global_reference]
 
-    [bind_reference : string -> global_reference -> unit]
+    [bind_ref : string -> global_reference -> unit]
 
     will bind a reference.
 
@@ -33,6 +34,16 @@ open Util
 
     This is work in progress, see below.
 *)
+
+val get_ref    : string -> global_reference
+val get_constr : string -> constr
+
+(** Non-lazy, fixed equalities *)
+val glob_eq       : global_reference
+val glob_identity : global_reference
+val glob_jmeq     : global_reference
+
+(** The rest below is ready to go... *)
 
 (** {6 ... } *)
 (** [find_reference caller_message [dir;subdir;...] s] returns a global
@@ -54,59 +65,37 @@ val check_required_library : string list -> unit
 val gen_constant_in_modules  : string->string list list-> string -> constr
 val gen_reference_in_modules : string->string list list-> string -> global_reference
 
-val arith_modules : string list list
+(* Used in omega: They must query the particular theory *)
+val arith_modules       : string list list
 val zarith_base_modules : string list list
-val init_modules : string list list
+val init_modules        : string list list
 
 (** {6 Global references } *)
 
 (** Modules *)
 val prelude_module : DirPath.t
 
-val logic_module : DirPath.t
+val logic_module      : DirPath.t
 val logic_module_name : string list
-
 val logic_type_module : DirPath.t
 
-val jmeq_module : DirPath.t
+val jmeq_module      : DirPath.t
 val jmeq_module_name : string list
 
 val datatypes_module_name : string list
 
 (** Natural numbers *)
-val nat_path : full_path
-val glob_nat : global_reference
+val nat_path  : full_path
+val glob_nat  : global_reference
 val path_of_O : constructor
 val path_of_S : constructor
-val glob_O : global_reference
-val glob_S : global_reference
-
-(** Booleans *)
-val glob_bool : global_reference
-val path_of_true : constructor
-val path_of_false : constructor
-val glob_true : global_reference
-val glob_false : global_reference
-
-
-(** Equality *)
-val glob_eq : global_reference
-val glob_identity : global_reference
-val glob_jmeq : global_reference
+val glob_O    : global_reference
+val glob_S    : global_reference
 
 (** {6 ... } *)
 (** Constructions and patterns related to Coq initial state are unknown
-   at compile time. Therefore, we can only provide methods to build
-   them at runtime. This is the purpose of the [constr delayed] and
-   [constr_pattern delayed] types. Objects of this time needs to be
-   forced with [delayed_force] to get the actual constr or pattern 
-   at runtime. *)
-
-type coq_bool_data = {
-  andb : constr;
-  andb_prop : constr;
-  andb_true_intro : constr}
-val build_bool_type : coq_bool_data delayed
+   at compile time.
+  *)
 
 (** {6 For Equality tactics } *)
 type coq_sigma_data = {
@@ -116,17 +105,9 @@ type coq_sigma_data = {
   intro : global_reference;
   typ   : global_reference }
 
-val build_sigma_set : coq_sigma_data delayed
+val build_prod       : coq_sigma_data delayed
 val build_sigma_type : coq_sigma_data delayed
-val build_sigma : coq_sigma_data delayed
-
-(* val build_sigma_type_in : Environ.env -> coq_sigma_data Univ.in_universe_context_set *)
-(* val build_sigma_in : Environ.env -> coq_sigma_data Univ.in_universe_context_set *)
-(* val build_prod_in : Environ.env -> coq_sigma_data Univ.in_universe_context_set *)
-(* val build_coq_eq_data_in : Environ.env -> coq_eq_data Univ.in_universe_context_set *)
-
-(** Non-dependent pairs in Set from Datatypes *)
-val build_prod : coq_sigma_data delayed
+val build_sigma      : coq_sigma_data delayed
 
 type coq_eq_data = {
   eq   : global_reference;
@@ -136,17 +117,9 @@ type coq_eq_data = {
   trans: global_reference;
   congr: global_reference }
 
-val build_coq_eq_data : coq_eq_data delayed
-
-(* val coq_eq_ref : global_reference lazy_t *)
-
+val build_coq_eq_data       : coq_eq_data delayed
 val build_coq_identity_data : coq_eq_data delayed
-val build_coq_jmeq_data : coq_eq_data delayed
-
-val build_coq_eq       : global_reference delayed (** = [(build_coq_eq_data()).eq] *)
-val build_coq_eq_refl  : global_reference delayed (** = [(build_coq_eq_data()).refl] *)
-val build_coq_eq_sym   : global_reference delayed (** = [(build_coq_eq_data()).sym] *)
-val build_coq_f_equal2 : global_reference delayed
+val build_coq_jmeq_data     : coq_eq_data delayed
 
 (** Data needed for discriminate and injection *)
 
@@ -158,50 +131,6 @@ type coq_inversion_data = {
 			 f params = f args *)
 }
 
-val build_coq_inversion_eq_data : coq_inversion_data delayed
+val build_coq_inversion_eq_data       : coq_inversion_data delayed
 val build_coq_inversion_identity_data : coq_inversion_data delayed
-val build_coq_inversion_jmeq_data : coq_inversion_data delayed
-val build_coq_inversion_eq_true_data : coq_inversion_data delayed
-
-(** Specif *)
-val build_coq_sumbool : constr delayed
-
-(** {6 ... } *)
-(** Connectives 
-   The False proposition *)
-val build_coq_False : constr delayed
-
-(** The True proposition and its unique proof *)
-val build_coq_True : constr delayed
-val build_coq_I : constr delayed
-
-(** Negation *)
-val build_coq_not : constr delayed
-
-(** Conjunction *)
-val build_coq_and : constr delayed
-val build_coq_conj : constr delayed
-val build_coq_iff : constr delayed
-
-val build_coq_iff_left_proj : constr delayed
-val build_coq_iff_right_proj : constr delayed
-
-(** Disjunction *)
-val build_coq_or : constr delayed
-
-(** Existential quantifier *)
-val build_coq_ex : constr delayed
-
-val coq_identity_ref : global_reference lazy_t
-val coq_jmeq_ref : global_reference lazy_t
-val coq_eq_true_ref : global_reference lazy_t
-val coq_existS_ref : global_reference lazy_t
-val coq_existT_ref : global_reference lazy_t
-val coq_exist_ref : global_reference lazy_t
-val coq_not_ref : global_reference lazy_t
-val coq_False_ref : global_reference lazy_t
-val coq_sumbool_ref : global_reference lazy_t
-val coq_sig_ref : global_reference lazy_t
-
-val coq_or_ref : global_reference lazy_t
-val coq_iff_ref : global_reference lazy_t
+val build_coq_inversion_jmeq_data     : coq_inversion_data delayed

--- a/interp/coqlib.mli
+++ b/interp/coqlib.mli
@@ -64,11 +64,6 @@ val coq_reference  : message -> string list -> string -> global_reference
 (** For tactics/commands requiring vernacular libraries *)
 val check_required_library : string list -> unit
 
-(** Used in omega/ring: They must query their particular theory XXX PORT to omega.xxx.xxx*)
-val arith_modules       : string list list
-val zarith_base_modules : string list list
-val init_modules        : string list list
-
 (** Search in several modules (not prefixed by "Coq") *)
 val gen_constant_in_modules  : string -> string list list -> string -> constr
 val gen_reference_in_modules : string -> string list list -> string -> global_reference
@@ -77,15 +72,16 @@ val gen_reference_in_modules : string -> string list list -> string -> global_re
 
 (** Modules *)
 val prelude_module    : DirPath.t
+val jmeq_module       : DirPath.t
 
-val logic_module      : DirPath.t
-val logic_module_name : string list
-val logic_type_module : DirPath.t
-
-val jmeq_module      : DirPath.t
-val jmeq_module_name : string list
-
+val logic_module_name     : string list
 val datatypes_module_name : string list
+val jmeq_module_name      : string list
+
+(** Used in omega/ring: XXX: They must query their particular theory omega.obj.prop *)
+val arith_modules       : string list list
+val zarith_base_modules : string list list
+val init_modules        : string list list
 
 (** Natural numbers *)
 val nat_path  : full_path

--- a/interp/interp.mllib
+++ b/interp/interp.mllib
@@ -15,6 +15,5 @@ Implicit_quantifiers
 Constrintern
 Modintern
 Constrextern
-Coqlib
 Discharge
 Declare

--- a/lib/envars.ml
+++ b/lib/envars.ml
@@ -117,8 +117,8 @@ let guess_coqlib fail =
         | None -> coqroot
       in
       if Sys.file_exists (coqlib / prelude) then coqlib
-      else
-        fail "cannot guess a path for Coq libraries; please use -coqlib option")
+      else "")
+        (* fail "cannot guess a path for Coq libraries; please use -coqlib option") *)
 
 (** coqlib is now computed once during coqtop initialization *)
 

--- a/plugins/btauto/refl_btauto.ml
+++ b/plugins/btauto/refl_btauto.ml
@@ -10,9 +10,9 @@ let (===) = Term.eq_constr
 
 
 module CoqList = struct
-  let typ  =  lazy (Coqlib.get_constr "core.list.type")
-  let _nil =  lazy (Coqlib.get_constr "core.list.nil")
-  let _cons = lazy (Coqlib.get_constr "core.list.cons")
+  let typ  =  lazy (Coqlib.lib_constr "core.list.type")
+  let _nil =  lazy (Coqlib.lib_constr "core.list.nil")
+  let _cons = lazy (Coqlib.lib_constr "core.list.cons")
 
   let cons ty h t = lapp _cons [|ty; h ; t|]
   let nil ty = lapp _nil [|ty|]
@@ -24,10 +24,10 @@ module CoqList = struct
 end
 
 module CoqPositive = struct
-  let typ = lazy (Coqlib.get_constr "num.pos.type")
-  let _xH = lazy (Coqlib.get_constr "num.pos.xH")
-  let _xO = lazy (Coqlib.get_constr "num.pos.xO")
-  let _xI = lazy (Coqlib.get_constr "num.pos.xI")
+  let typ = lazy (Coqlib.lib_constr "num.pos.type")
+  let _xH = lazy (Coqlib.lib_constr "num.pos.xH")
+  let _xO = lazy (Coqlib.lib_constr "num.pos.xO")
+  let _xI = lazy (Coqlib.lib_constr "num.pos.xI")
 
   (* A coq nat from an int *)
   let rec of_int n =
@@ -73,14 +73,14 @@ end
 
 module Bool = struct
 
-  let ind    = lazy (Globnames.destIndRef (Coqlib.get_ref "core.bool.type"))
-  let typ    = lazy (Coqlib.get_constr "core.bool.type")
-  let trueb  = lazy (Coqlib.get_constr "core.bool.true")
-  let falseb = lazy (Coqlib.get_constr "core.bool.false")
-  let andb   = lazy (Coqlib.get_constr "core.bool.andb")
-  let orb    = lazy (Coqlib.get_constr "core.bool.orb")
-  let xorb   = lazy (Coqlib.get_constr "core.bool.xorb")
-  let negb   = lazy (Coqlib.get_constr "core.bool.negb")
+  let ind    = lazy (Globnames.destIndRef (Coqlib.lib_ref "core.bool.type"))
+  let typ    = lazy (Coqlib.lib_constr "core.bool.type")
+  let trueb  = lazy (Coqlib.lib_constr "core.bool.true")
+  let falseb = lazy (Coqlib.lib_constr "core.bool.false")
+  let andb   = lazy (Coqlib.lib_constr "core.bool.andb")
+  let orb    = lazy (Coqlib.lib_constr "core.bool.orb")
+  let xorb   = lazy (Coqlib.lib_constr "core.bool.xorb")
+  let negb   = lazy (Coqlib.lib_constr "core.bool.negb")
 
   type t =
   | Var of int
@@ -132,7 +132,7 @@ module Btauto = struct
 
   open Pp
 
-  let eq = lazy (Coqlib.get_constr "core.eq.type")
+  let eq = lazy (Coqlib.lib_constr "core.eq.type")
 
   let get_constant dir s = lazy (Universes.constr_of_global @@ Coqlib.coq_reference contrib_name dir s)
 

--- a/plugins/btauto/refl_btauto.ml
+++ b/plugins/btauto/refl_btauto.ml
@@ -7,7 +7,7 @@ let init_constant dir s =
   in
   find_constant contrib_name dir s
 
-let get_constant dir s = lazy (Coqlib.gen_constant contrib_name dir s)
+let get_constant dir s = lazy (Universes.constr_of_global @@ Coqlib.coq_reference contrib_name dir s)
 
 let get_inductive dir s =
   let glob_ref () = Coqlib.find_reference contrib_name ("Coq" :: dir) s in

--- a/plugins/btauto/refl_btauto.ml
+++ b/plugins/btauto/refl_btauto.ml
@@ -1,18 +1,6 @@
 
 let contrib_name = "btauto"
 
-let init_constant dir s =
-  let find_constant contrib dir s =
-    Universes.constr_of_global (Coqlib.find_reference contrib dir s)
-  in
-  find_constant contrib_name dir s
-
-let get_constant dir s = lazy (Universes.constr_of_global @@ Coqlib.coq_reference contrib_name dir s)
-
-let get_inductive dir s =
-  let glob_ref () = Coqlib.find_reference contrib_name ("Coq" :: dir) s in
-  Lazy.lazy_from_fun (fun () -> Globnames.destIndRef (glob_ref ()))
-
 let decomp_term (c : Term.constr) =
   Term.kind_of_term (Term.strip_outer_cast c)
 
@@ -20,11 +8,11 @@ let lapp c v  = Term.mkApp (Lazy.force c, v)
 
 let (===) = Term.eq_constr
 
+
 module CoqList = struct
-  let path = ["Init"; "Datatypes"]
-  let typ = get_constant path "list"
-  let _nil = get_constant path "nil"
-  let _cons = get_constant path "cons"
+  let typ  =  lazy (Coqlib.get_constr "core.list.type")
+  let _nil =  lazy (Coqlib.get_constr "core.list.nil")
+  let _cons = lazy (Coqlib.get_constr "core.list.cons")
 
   let cons ty h t = lapp _cons [|ty; h ; t|]
   let nil ty = lapp _nil [|ty|]
@@ -36,11 +24,10 @@ module CoqList = struct
 end
 
 module CoqPositive = struct
-  let path = ["Numbers"; "BinNums"]
-  let typ = get_constant path "positive"
-  let _xH = get_constant path "xH"
-  let _xO = get_constant path "xO"
-  let _xI = get_constant path "xI"
+  let typ = lazy (Coqlib.get_constr "num.pos.type")
+  let _xH = lazy (Coqlib.get_constr "num.pos.xH")
+  let _xO = lazy (Coqlib.get_constr "num.pos.xO")
+  let _xI = lazy (Coqlib.get_constr "num.pos.xI")
 
   (* A coq nat from an int *)
   let rec of_int n =
@@ -57,7 +44,7 @@ module Env = struct
   module ConstrHashed = struct
     type t = Term.constr
     let equal = Term.eq_constr
-    let hash = Term.hash_constr
+    let hash  = Term.hash_constr
   end
 
   module ConstrHashtbl = Hashtbl.Make (ConstrHashed)
@@ -86,14 +73,14 @@ end
 
 module Bool = struct
 
-  let typ = get_constant ["Init"; "Datatypes"] "bool"
-  let ind = get_inductive ["Init"; "Datatypes"] "bool"
-  let trueb = get_constant ["Init"; "Datatypes"] "true"
-  let falseb = get_constant ["Init"; "Datatypes"] "false"
-  let andb = get_constant ["Init"; "Datatypes"] "andb"
-  let orb = get_constant ["Init"; "Datatypes"] "orb"
-  let xorb = get_constant ["Init"; "Datatypes"] "xorb"
-  let negb = get_constant ["Init"; "Datatypes"] "negb"
+  let ind    = lazy (Globnames.destIndRef (Coqlib.get_ref "core.bool.type"))
+  let typ    = lazy (Coqlib.get_constr "core.bool.type")
+  let trueb  = lazy (Coqlib.get_constr "core.bool.true")
+  let falseb = lazy (Coqlib.get_constr "core.bool.false")
+  let andb   = lazy (Coqlib.get_constr "core.bool.andb")
+  let orb    = lazy (Coqlib.get_constr "core.bool.orb")
+  let xorb   = lazy (Coqlib.get_constr "core.bool.xorb")
+  let negb   = lazy (Coqlib.get_constr "core.bool.negb")
 
   type t =
   | Var of int
@@ -105,12 +92,12 @@ module Bool = struct
   | Ifb of t * t * t
 
   let quote (env : Env.t) (c : Term.constr) : t =
-    let trueb = Lazy.force trueb in
+    let trueb  = Lazy.force trueb in
     let falseb = Lazy.force falseb in
-    let andb = Lazy.force andb in
-    let orb = Lazy.force orb in
-    let xorb = Lazy.force xorb in
-    let negb = Lazy.force negb in
+    let andb   = Lazy.force andb in
+    let orb    = Lazy.force orb in
+    let xorb   = Lazy.force xorb in
+    let negb   = Lazy.force negb in
 
     let rec aux c = match decomp_term c with
     | Term.App (head, args) ->
@@ -145,7 +132,9 @@ module Btauto = struct
 
   open Pp
 
-  let eq = get_constant ["Init"; "Logic"]  "eq"
+  let eq = lazy (Coqlib.get_constr "core.eq.type")
+
+  let get_constant dir s = lazy (Universes.constr_of_global @@ Coqlib.coq_reference contrib_name dir s)
 
   let f_var = get_constant ["btauto"; "Reflect"] "formula_var"
   let f_btm = get_constant ["btauto"; "Reflect"] "formula_btm"
@@ -156,7 +145,7 @@ module Btauto = struct
   let f_xor = get_constant ["btauto"; "Reflect"] "formula_xor"
   let f_ifb = get_constant ["btauto"; "Reflect"] "formula_ifb"
 
-  let eval = get_constant ["btauto"; "Reflect"] "formula_eval"
+  let eval    = get_constant ["btauto"; "Reflect"] "formula_eval"
   let witness = get_constant ["btauto"; "Reflect"] "boolean_witness"
 
   let soundness = get_constant ["btauto"; "Reflect"] "reduce_poly_of_formula_sound_alt"

--- a/plugins/cc/cctac.ml
+++ b/plugins/cc/cctac.ml
@@ -23,17 +23,15 @@ open Pp
 open Errors
 open Util
 
-let reference dir s = lazy (Coqlib.coq_reference "CC" dir s)
-
-let _f_equal = reference ["Init";"Logic"] "f_equal"
-let _eq_rect = reference ["Init";"Logic"] "eq_rect"
-let _refl_equal = reference ["Init";"Logic"] "eq_refl"
-let _sym_eq = reference ["Init";"Logic"] "eq_sym"
-let _trans_eq = reference ["Init";"Logic"] "eq_trans"
-let _eq = reference ["Init";"Logic"] "eq"
-let _False = reference ["Init";"Logic"] "False"
-let _True = reference ["Init";"Logic"] "True"
-let _I = reference ["Init";"Logic"] "I"
+let _f_equal    = lazy (Coqlib.get_ref "core.eq.congr")
+let _eq_rect    = lazy (Coqlib.get_ref "core.eq.rect")
+let _refl_equal = lazy (Coqlib.get_ref "core.eq.refl")
+let _sym_eq     = lazy (Coqlib.get_ref "core.eq.sym")
+let _trans_eq   = lazy (Coqlib.get_ref "core.eq.trans")
+let _eq         = lazy (Coqlib.get_ref "core.eq.type")
+let _False      = lazy (Coqlib.get_ref "core.False.type")
+let _True       = lazy (Coqlib.get_constr "core.True.type")
+let _I          = lazy (Coqlib.get_constr "core.True.I")
 
 let whd env=
   let infos=Closure.create_clos_infos Closure.betaiotazeta env in
@@ -381,9 +379,9 @@ let discriminate_tac (cstr,u as cstru) p =
     let xid = Tacmach.New.of_old (pf_get_new_id (Id.of_string "X")) gl in
     (* let tid = Tacmach.New.of_old (pf_get_new_id (Id.of_string "t")) gl in *)
     (* let identity=mkLambda(Name xid,outsort,mkLambda(Name tid,mkRel 1,mkRel 1)) in *)
-    let identity = Universes.constr_of_global (Lazy.force _I) in
+    let identity = Lazy.force _I    in
     (* let trivial=pf_unsafe_type_of gls identity in *)
-    let trivial = Universes.constr_of_global (Lazy.force _True) in
+    let trivial  = Lazy.force _True in
     let evm, outtype = Evd.new_sort_variable Evd.univ_flexible (Proofview.Goal.sigma gl) in 
     let outtype = mkSort outtype in
     let pred=mkLambda(Name xid,outtype,mkRel 1) in

--- a/plugins/cc/cctac.ml
+++ b/plugins/cc/cctac.ml
@@ -23,15 +23,15 @@ open Pp
 open Errors
 open Util
 
-let _f_equal    = lazy (Coqlib.get_ref "core.eq.congr")
-let _eq_rect    = lazy (Coqlib.get_ref "core.eq.rect")
-let _refl_equal = lazy (Coqlib.get_ref "core.eq.refl")
-let _sym_eq     = lazy (Coqlib.get_ref "core.eq.sym")
-let _trans_eq   = lazy (Coqlib.get_ref "core.eq.trans")
-let _eq         = lazy (Coqlib.get_ref "core.eq.type")
-let _False      = lazy (Coqlib.get_ref "core.False.type")
-let _True       = lazy (Coqlib.get_constr "core.True.type")
-let _I          = lazy (Coqlib.get_constr "core.True.I")
+let _f_equal    = lazy (Coqlib.lib_ref "core.eq.congr")
+let _eq_rect    = lazy (Coqlib.lib_ref "core.eq.rect")
+let _refl_equal = lazy (Coqlib.lib_ref "core.eq.refl")
+let _sym_eq     = lazy (Coqlib.lib_ref "core.eq.sym")
+let _trans_eq   = lazy (Coqlib.lib_ref "core.eq.trans")
+let _eq         = lazy (Coqlib.lib_ref "core.eq.type")
+let _False      = lazy (Coqlib.lib_ref "core.False.type")
+let _True       = lazy (Coqlib.lib_constr "core.True.type")
+let _I          = lazy (Coqlib.lib_constr "core.True.I")
 
 let whd env=
   let infos=Closure.create_clos_infos Closure.betaiotazeta env in

--- a/plugins/cc/cctac.ml
+++ b/plugins/cc/cctac.ml
@@ -23,7 +23,7 @@ open Pp
 open Errors
 open Util
 
-let reference dir s = lazy (Coqlib.gen_reference "CC" dir s)
+let reference dir s = lazy (Coqlib.coq_reference "CC" dir s)
 
 let _f_equal = reference ["Init";"Logic"] "f_equal"
 let _eq_rect = reference ["Init";"Logic"] "eq_rect"

--- a/plugins/decl_mode/decl_interp.ml
+++ b/plugins/decl_mode/decl_interp.ml
@@ -156,7 +156,7 @@ let special_whd env =
   let infos=Closure.create_clos_infos Closure.betadeltaiota env in
     (fun t -> Closure.whd_val infos (Closure.inject t))
 
-let _eq = lazy (Universes.constr_of_global (Coqlib.glob_eq))
+let _eq = lazy (Coqlib.get_constr "core.eq.type")
 
 let decompose_eq env id =
   let typ = Environ.named_type id env in

--- a/plugins/decl_mode/decl_interp.ml
+++ b/plugins/decl_mode/decl_interp.ml
@@ -156,7 +156,7 @@ let special_whd env =
   let infos=Closure.create_clos_infos Closure.betadeltaiota env in
     (fun t -> Closure.whd_val infos (Closure.inject t))
 
-let _eq = lazy (Coqlib.get_constr "core.eq.type")
+let _eq = lazy (Coqlib.lib_constr "core.eq.type")
 
 let decompose_eq env id =
   let typ = Environ.named_type id env in

--- a/plugins/decl_mode/decl_proof_instr.ml
+++ b/plugins/decl_mode/decl_proof_instr.ml
@@ -281,7 +281,7 @@ let default_justification elems gls=
 
 (* code for conclusion refining *)
 
-let constant dir s = lazy (Coqlib.gen_constant "Declarative" dir s)
+let constant dir s = lazy (Universes.constr_of_global (Coqlib.coq_reference "Declarative" dir s))
 
 let _and       = constant ["Init";"Logic"] "and"
 

--- a/plugins/decl_mode/decl_proof_instr.ml
+++ b/plugins/decl_mode/decl_proof_instr.ml
@@ -283,17 +283,17 @@ let default_justification elems gls=
 
 
 (* iterated equality *)
-let _eq        = lazy (Coqlib.get_constr "core.eq.type")
-let _and       = lazy (Coqlib.get_constr "core.and.type")
-let _and_rect  = lazy (Coqlib.get_constr "core.and.ind")
-let _prod      = lazy (Coqlib.get_constr "core.prod.type")
-let _prod_rect = lazy (Coqlib.get_constr "core.prod.rect")
-let _ex        = lazy (Coqlib.get_constr "core.ex.type")
-let _ex_ind    = lazy (Coqlib.get_constr "core.ex.ind")
-let _sig       = lazy (Coqlib.get_constr "core.sig.type")
-let _sig_rect  = lazy (Coqlib.get_constr "core.sig.rect")
-let _sigT      = lazy (Coqlib.get_constr "core.sigT.type")
-let _sigT_rect = lazy (Coqlib.get_constr "core.sigT.rect")
+let _eq        = lazy (Coqlib.lib_constr "core.eq.type")
+let _and       = lazy (Coqlib.lib_constr "core.and.type")
+let _and_rect  = lazy (Coqlib.lib_constr "core.and.ind")
+let _prod      = lazy (Coqlib.lib_constr "core.prod.type")
+let _prod_rect = lazy (Coqlib.lib_constr "core.prod.rect")
+let _ex        = lazy (Coqlib.lib_constr "core.ex.type")
+let _ex_ind    = lazy (Coqlib.lib_constr "core.ex.ind")
+let _sig       = lazy (Coqlib.lib_constr "core.sig.type")
+let _sig_rect  = lazy (Coqlib.lib_constr "core.sig.rect")
+let _sigT      = lazy (Coqlib.lib_constr "core.sigT.type")
+let _sigT_rect = lazy (Coqlib.lib_constr "core.sigT.rect")
 
 type stackd_elt =
 {se_meta:metavariable;

--- a/plugins/decl_mode/decl_proof_instr.ml
+++ b/plugins/decl_mode/decl_proof_instr.ml
@@ -281,27 +281,19 @@ let default_justification elems gls=
 
 (* code for conclusion refining *)
 
-let constant dir s = lazy (Universes.constr_of_global (Coqlib.coq_reference "Declarative" dir s))
 
-let _and       = constant ["Init";"Logic"] "and"
-
-let _and_rect  = constant ["Init";"Logic"] "and_rect"
-
-let _prod      = constant ["Init";"Datatypes"] "prod"
-
-let _prod_rect = constant ["Init";"Datatypes"] "prod_rect"
-
-let _ex        = constant ["Init";"Logic"] "ex"
-
-let _ex_ind    = constant ["Init";"Logic"] "ex_ind"
-
-let _sig       = constant ["Init";"Specif"] "sig"
-
-let _sig_rect  = constant ["Init";"Specif"] "sig_rect"
-
-let _sigT      = constant ["Init";"Specif"] "sigT"
-
-let _sigT_rect = constant ["Init";"Specif"] "sigT_rect"
+(* iterated equality *)
+let _eq        = lazy (Coqlib.get_constr "core.eq.type")
+let _and       = lazy (Coqlib.get_constr "core.and.type")
+let _and_rect  = lazy (Coqlib.get_constr "core.and.ind")
+let _prod      = lazy (Coqlib.get_constr "core.prod.type")
+let _prod_rect = lazy (Coqlib.get_constr "core.prod.rect")
+let _ex        = lazy (Coqlib.get_constr "core.ex.type")
+let _ex_ind    = lazy (Coqlib.get_constr "core.ex.ind")
+let _sig       = lazy (Coqlib.get_constr "core.sig.type")
+let _sig_rect  = lazy (Coqlib.get_constr "core.sig.rect")
+let _sigT      = lazy (Coqlib.get_constr "core.sigT.type")
+let _sigT_rect = lazy (Coqlib.get_constr "core.sigT.rect")
 
 type stackd_elt =
 {se_meta:metavariable;
@@ -511,9 +503,6 @@ let instr_cut mkstat _thus _then cut gls0 =
       [tclTHEN tcl_erase_info (just_tac _then cut info);
        thus_tac] gls0
 
-
-(* iterated equality *)
-let _eq = lazy (Universes.constr_of_global (Coqlib.glob_eq))
 
 let decompose_eq id gls =
   let typ = pf_get_hyp_typ gls id in

--- a/plugins/firstorder/g_ground.ml4
+++ b/plugins/firstorder/g_ground.ml4
@@ -88,11 +88,11 @@ let gen_ground_tac flag taco ids bases gl=
 
 (* special for compatibility with Intuition
 
-let constant str = Coqlib.gen_constant "User" ["Init";"Logic"] str
+let constant str = Coqlib.get_constr str
 
 let defined_connectives=lazy
-  [[],EvalConstRef (destConst (constant "not"));
-   [],EvalConstRef (destConst (constant "iff"))]
+  [[],EvalConstRef (destConst (constant "core.not.type"));
+   [],EvalConstRef (destConst (constant "core.iff.type"))]
 
 let normalize_evaluables=
   onAllHypsAndConcl

--- a/plugins/firstorder/rules.ml
+++ b/plugins/firstorder/rules.ml
@@ -201,12 +201,11 @@ let ll_forall_tac prod backtrack id continue seq=
 
 (* special for compatibility with old Intuition *)
 
-let constant str = Universes.constr_of_global
-  @@ Coqlib.coq_reference "User" ["Init";"Logic"] str
+let constant str = Coqlib.get_constr str
 
-let defined_connectives=lazy
-  [AllOccurrences,EvalConstRef (fst (destConst (constant "not")));
-   AllOccurrences,EvalConstRef (fst (destConst (constant "iff")))]
+let defined_connectives = lazy
+  [AllOccurrences, EvalConstRef (fst (destConst (constant "core.not.type")));
+   AllOccurrences, EvalConstRef (fst (destConst (constant "core.iff.type")))]
 
 let normalize_evaluables=
   onAllHypsAndConcl

--- a/plugins/firstorder/rules.ml
+++ b/plugins/firstorder/rules.ml
@@ -201,7 +201,7 @@ let ll_forall_tac prod backtrack id continue seq=
 
 (* special for compatibility with old Intuition *)
 
-let constant str = Coqlib.get_constr str
+let constant str = Coqlib.lib_constr str
 
 let defined_connectives = lazy
   [AllOccurrences, EvalConstRef (fst (destConst (constant "core.not.type")));

--- a/plugins/firstorder/rules.ml
+++ b/plugins/firstorder/rules.ml
@@ -201,7 +201,8 @@ let ll_forall_tac prod backtrack id continue seq=
 
 (* special for compatibility with old Intuition *)
 
-let constant str = Coqlib.gen_constant "User" ["Init";"Logic"] str
+let constant str = Universes.constr_of_global
+  @@ Coqlib.coq_reference "User" ["Init";"Logic"] str
 
 let defined_connectives=lazy
   [AllOccurrences,EvalConstRef (fst (destConst (constant "not")));

--- a/plugins/fourier/fourierR.ml
+++ b/plugins/fourier/fourierR.ml
@@ -228,7 +228,7 @@ let ineq1_of_constr (h,t) =
               |_-> raise NoIneq)
           | Ind ((kn,i),_) ->
             if not (eq_gr (IndRef(kn,i))
-                      (Coqlib.build_coq_eq_data()).Coqlib.eq) then raise NoIneq;
+                      (Coqlib.get_ref "core.eq.type")) then raise NoIneq;
             let t0= args.(0) in
             let t1= args.(1) in
             let t2= args.(2) in
@@ -287,10 +287,10 @@ let constant path s = Universes.constr_of_global @@
 
 (* Standard library *)
 open Coqlib
+let coq_eq      = lazy (get_constr "core.eq.type")
 let coq_sym_eqT = lazy (get_ref "core.eq.sym")
 let coq_False   = lazy (get_constr "core.False.type")
 let coq_not     = lazy (get_constr "core.not.type")
-let coq_eq      = lazy (get_constr "core.eq.type")
 
 (* Rdefinitions *)
 let constant_real = constant ["Reals";"Rdefinitions"]

--- a/plugins/fourier/fourierR.ml
+++ b/plugins/fourier/fourierR.ml
@@ -228,7 +228,7 @@ let ineq1_of_constr (h,t) =
               |_-> raise NoIneq)
           | Ind ((kn,i),_) ->
             if not (eq_gr (IndRef(kn,i))
-                      (Coqlib.build_coq_eq_data()).eq) then raise NoIneq;
+                      (Coqlib.build_coq_eq_data()).Coqlib.eq) then raise NoIneq;
             let t0= args.(0) in
             let t1= args.(1) in
             let t2= args.(2) in
@@ -287,10 +287,10 @@ let constant path s = Universes.constr_of_global @@
 
 (* Standard library *)
 open Coqlib
-let coq_sym_eqT = lazy (build_coq_eq_sym ())
-let coq_False = lazy (build_coq_False ())
-let coq_not = lazy (build_coq_not ())
-let coq_eq = lazy (build_coq_eq ())
+let coq_sym_eqT = lazy (get_ref "core.eq.sym")
+let coq_False   = lazy (get_constr "core.False.type")
+let coq_not     = lazy (get_constr "core.not.type")
+let coq_eq      = lazy (get_constr "core.eq.type")
 
 (* Rdefinitions *)
 let constant_real = constant ["Reals";"Rdefinitions"]

--- a/plugins/fourier/fourierR.ml
+++ b/plugins/fourier/fourierR.ml
@@ -281,7 +281,8 @@ let fourier_lineq lineq1 =
 (* Defined constants *)
 
 let get = Lazy.force
-let constant = Coqlib.gen_constant "Fourier"
+let constant path s = Universes.constr_of_global @@
+  Coqlib.coq_reference "Fourier" path s
 
 (* Standard library *)
 open Coqlib

--- a/plugins/fourier/fourierR.ml
+++ b/plugins/fourier/fourierR.ml
@@ -227,7 +227,8 @@ let ineq1_of_constr (h,t) =
 			   hstrict=false}]
               |_-> raise NoIneq)
           | Ind ((kn,i),_) ->
-            if not (eq_gr (IndRef(kn,i)) Coqlib.glob_eq) then raise NoIneq;
+            if not (eq_gr (IndRef(kn,i))
+                      (Coqlib.build_coq_eq_data()).eq) then raise NoIneq;
             let t0= args.(0) in
             let t1= args.(1) in
             let t2= args.(2) in

--- a/plugins/fourier/fourierR.ml
+++ b/plugins/fourier/fourierR.ml
@@ -228,7 +228,7 @@ let ineq1_of_constr (h,t) =
               |_-> raise NoIneq)
           | Ind ((kn,i),_) ->
             if not (eq_gr (IndRef(kn,i))
-                      (Coqlib.get_ref "core.eq.type")) then raise NoIneq;
+                      (Coqlib.lib_ref "core.eq.type")) then raise NoIneq;
             let t0= args.(0) in
             let t1= args.(1) in
             let t2= args.(2) in
@@ -287,10 +287,10 @@ let constant path s = Universes.constr_of_global @@
 
 (* Standard library *)
 open Coqlib
-let coq_eq      = lazy (get_constr "core.eq.type")
-let coq_sym_eqT = lazy (get_ref "core.eq.sym")
-let coq_False   = lazy (get_constr "core.False.type")
-let coq_not     = lazy (get_constr "core.not.type")
+let coq_eq      = lazy (lib_constr "core.eq.type")
+let coq_sym_eqT = lazy (lib_ref "core.eq.sym")
+let coq_False   = lazy (lib_constr "core.False.type")
+let coq_not     = lazy (lib_constr "core.not.type")
 
 (* Rdefinitions *)
 let constant_real = constant ["Reals";"Rdefinitions"]

--- a/plugins/funind/functional_principles_proofs.ml
+++ b/plugins/funind/functional_principles_proofs.ml
@@ -406,9 +406,9 @@ let rewrite_until_var arg_num eq_ids : tactic =
 
 let rec_pte_id = Id.of_string "Hrec"
 let clean_hyp_with_heq ptes_infos eq_hyps hyp_id env sigma =
-  let coq_False = Coqlib.build_coq_False () in
-  let coq_True = Coqlib.build_coq_True () in
-  let coq_I = Coqlib.build_coq_I () in
+  let coq_False = Coqlib.get_constr "core.False.type" in
+  let coq_True  = Coqlib.get_constr "core.True.type"  in
+  let coq_I     = Coqlib.get_constr "core.True.I"     in
   let rec scan_type  context type_of_hyp : tactic =
     if isLetIn type_of_hyp then
       let real_type_of_hyp = it_mkProd_or_LetIn type_of_hyp context in

--- a/plugins/funind/functional_principles_proofs.ml
+++ b/plugins/funind/functional_principles_proofs.ml
@@ -406,9 +406,9 @@ let rewrite_until_var arg_num eq_ids : tactic =
 
 let rec_pte_id = Id.of_string "Hrec"
 let clean_hyp_with_heq ptes_infos eq_hyps hyp_id env sigma =
-  let coq_False = Coqlib.get_constr "core.False.type" in
-  let coq_True  = Coqlib.get_constr "core.True.type"  in
-  let coq_I     = Coqlib.get_constr "core.True.I"     in
+  let coq_False = Coqlib.lib_constr "core.False.type" in
+  let coq_True  = Coqlib.lib_constr "core.True.type"  in
+  let coq_I     = Coqlib.lib_constr "core.True.I"     in
   let rec scan_type  context type_of_hyp : tactic =
     if isLetIn type_of_hyp then
       let real_type_of_hyp = it_mkProd_or_LetIn type_of_hyp context in

--- a/plugins/funind/glob_term_to_relation.ml
+++ b/plugins/funind/glob_term_to_relation.ml
@@ -908,7 +908,7 @@ let rec rebuild_cons env nb_args relname args crossed_types depth rt =
 			assert false
 		end
 	    | GApp(loc1,GRef(loc2,eq_as_ref,_),[ty;GVar(loc3,id);rt])
-		when Globnames.eq_gr eq_as_ref (Lazy.force Coqlib.coq_eq_ref)  && n == Anonymous
+		when Globnames.eq_gr eq_as_ref (Coqlib.build_coq_eq_data()).eq  && n == Anonymous
 		  ->
 		begin
 		  try
@@ -1027,7 +1027,7 @@ let rec rebuild_cons env nb_args relname args crossed_types depth rt =
 		     else new_b, Id.Set.add id id_to_exclude
 		  *)
 	    | GApp(loc1,GRef(loc2,eq_as_ref,_),[ty;rt1;rt2])
-		when Globnames.eq_gr eq_as_ref (Lazy.force Coqlib.coq_eq_ref) && n == Anonymous
+		when Globnames.eq_gr eq_as_ref (Coqlib.build_coq_eq_data()).eq && n == Anonymous
 		  ->
 	      begin
 		try 

--- a/plugins/funind/glob_term_to_relation.ml
+++ b/plugins/funind/glob_term_to_relation.ml
@@ -908,7 +908,7 @@ let rec rebuild_cons env nb_args relname args crossed_types depth rt =
 			assert false
 		end
 	    | GApp(loc1,GRef(loc2,eq_as_ref,_),[ty;GVar(loc3,id);rt])
-		when Globnames.eq_gr eq_as_ref (Coqlib.build_coq_eq_data()).Coqlib.eq  && n == Anonymous
+		when Globnames.eq_gr eq_as_ref (Coqlib.get_ref "core.eq.type")  && n == Anonymous
 		  ->
 		begin
 		  try
@@ -1027,7 +1027,7 @@ let rec rebuild_cons env nb_args relname args crossed_types depth rt =
 		     else new_b, Id.Set.add id id_to_exclude
 		  *)
 	    | GApp(loc1,GRef(loc2,eq_as_ref,_),[ty;rt1;rt2])
-		when Globnames.eq_gr eq_as_ref (Coqlib.build_coq_eq_data()).Coqlib.eq && n == Anonymous
+		when Globnames.eq_gr eq_as_ref (Coqlib.get_ref "core.eq.type") && n == Anonymous
 		  ->
 	      begin
 		try 

--- a/plugins/funind/glob_term_to_relation.ml
+++ b/plugins/funind/glob_term_to_relation.ml
@@ -244,11 +244,8 @@ let mk_result ctxt value avoid =
   Some functions to deal with overlapping patterns
 **************************************************)
 
-let coq_True_ref =
-  lazy  (Coqlib.coq_reference "" ["Init";"Logic"] "True")
-
-let coq_False_ref =
-  lazy  (Coqlib.coq_reference "" ["Init";"Logic"] "False")
+let coq_True_ref  = lazy (Coqlib.get_ref "core.True.type")
+let coq_False_ref = lazy (Coqlib.get_ref "core.False.type")
 
 (*
   [make_discr_match_el \[e1,...en\]] builds match e1,...,en with

--- a/plugins/funind/glob_term_to_relation.ml
+++ b/plugins/funind/glob_term_to_relation.ml
@@ -908,7 +908,7 @@ let rec rebuild_cons env nb_args relname args crossed_types depth rt =
 			assert false
 		end
 	    | GApp(loc1,GRef(loc2,eq_as_ref,_),[ty;GVar(loc3,id);rt])
-		when Globnames.eq_gr eq_as_ref (Coqlib.build_coq_eq_data()).eq  && n == Anonymous
+		when Globnames.eq_gr eq_as_ref (Coqlib.build_coq_eq_data()).Coqlib.eq  && n == Anonymous
 		  ->
 		begin
 		  try
@@ -1027,7 +1027,7 @@ let rec rebuild_cons env nb_args relname args crossed_types depth rt =
 		     else new_b, Id.Set.add id id_to_exclude
 		  *)
 	    | GApp(loc1,GRef(loc2,eq_as_ref,_),[ty;rt1;rt2])
-		when Globnames.eq_gr eq_as_ref (Coqlib.build_coq_eq_data()).eq && n == Anonymous
+		when Globnames.eq_gr eq_as_ref (Coqlib.build_coq_eq_data()).Coqlib.eq && n == Anonymous
 		  ->
 	      begin
 		try 

--- a/plugins/funind/glob_term_to_relation.ml
+++ b/plugins/funind/glob_term_to_relation.ml
@@ -245,10 +245,10 @@ let mk_result ctxt value avoid =
 **************************************************)
 
 let coq_True_ref =
-  lazy  (Coqlib.gen_reference "" ["Init";"Logic"] "True")
+  lazy  (Coqlib.coq_reference "" ["Init";"Logic"] "True")
 
 let coq_False_ref =
-  lazy  (Coqlib.gen_reference "" ["Init";"Logic"] "False")
+  lazy  (Coqlib.coq_reference "" ["Init";"Logic"] "False")
 
 (*
   [make_discr_match_el \[e1,...en\]] builds match e1,...,en with

--- a/plugins/funind/glob_term_to_relation.ml
+++ b/plugins/funind/glob_term_to_relation.ml
@@ -244,8 +244,8 @@ let mk_result ctxt value avoid =
   Some functions to deal with overlapping patterns
 **************************************************)
 
-let coq_True_ref  = lazy (Coqlib.get_ref "core.True.type")
-let coq_False_ref = lazy (Coqlib.get_ref "core.False.type")
+let coq_True_ref  = lazy (Coqlib.lib_ref "core.True.type")
+let coq_False_ref = lazy (Coqlib.lib_ref "core.False.type")
 
 (*
   [make_discr_match_el \[e1,...en\]] builds match e1,...,en with
@@ -905,7 +905,7 @@ let rec rebuild_cons env nb_args relname args crossed_types depth rt =
 			assert false
 		end
 	    | GApp(loc1,GRef(loc2,eq_as_ref,_),[ty;GVar(loc3,id);rt])
-		when Globnames.eq_gr eq_as_ref (Coqlib.get_ref "core.eq.type")  && n == Anonymous
+		when Globnames.eq_gr eq_as_ref (Coqlib.lib_ref "core.eq.type")  && n == Anonymous
 		  ->
 		begin
 		  try
@@ -1024,7 +1024,7 @@ let rec rebuild_cons env nb_args relname args crossed_types depth rt =
 		     else new_b, Id.Set.add id id_to_exclude
 		  *)
 	    | GApp(loc1,GRef(loc2,eq_as_ref,_),[ty;rt1;rt2])
-		when Globnames.eq_gr eq_as_ref (Coqlib.get_ref "core.eq.type") && n == Anonymous
+		when Globnames.eq_gr eq_as_ref (Coqlib.lib_ref "core.eq.type") && n == Anonymous
 		  ->
 	      begin
 		try 

--- a/plugins/funind/glob_termops.ml
+++ b/plugins/funind/glob_termops.ml
@@ -95,7 +95,7 @@ let glob_decompose_app =
 
 (* [glob_make_eq t1 t2] build the glob_constr corresponding to [t2 = t1] *)
 let glob_make_eq ?(typ= mkGHole ()) t1 t2  =
-  mkGApp(mkGRef (Lazy.force Coqlib.coq_eq_ref),[typ;t2;t1])
+  mkGApp(mkGRef ((Coqlib.build_coq_eq_data()).eq),[typ;t2;t1])
 
 (* [glob_make_neq t1 t2] build the glob_constr corresponding to [t1 <> t2] *)
 let glob_make_neq t1 t2 =

--- a/plugins/funind/glob_termops.ml
+++ b/plugins/funind/glob_termops.ml
@@ -95,14 +95,14 @@ let glob_decompose_app =
 
 (* [glob_make_eq t1 t2] build the glob_constr corresponding to [t2 = t1] *)
 let glob_make_eq ?(typ= mkGHole ()) t1 t2  =
-  mkGApp(mkGRef ((Coqlib.build_coq_eq_data()).eq),[typ;t2;t1])
+  mkGApp(mkGRef ((Coqlib.build_coq_eq_data()).Coqlib.eq),[typ;t2;t1])
 
 (* [glob_make_neq t1 t2] build the glob_constr corresponding to [t1 <> t2] *)
 let glob_make_neq t1 t2 =
-  mkGApp(mkGRef (Lazy.force Coqlib.coq_not_ref),[glob_make_eq t1 t2])
+  mkGApp(mkGRef (Coqlib.get_ref "core.not.type"), [glob_make_eq t1 t2])
 
 (* [glob_make_or P1 P2] build the glob_constr corresponding to [P1 \/ P2] *)
-let glob_make_or t1 t2 = mkGApp (mkGRef(Lazy.force Coqlib.coq_or_ref),[t1;t2])
+let glob_make_or t1 t2 = mkGApp (mkGRef(Coqlib.get_ref "core.or.type"),[t1;t2])
 
 (* [glob_make_or_list [P1;...;Pn]] build the glob_constr corresponding
    to [P1 \/ ( .... \/ Pn)]

--- a/plugins/funind/glob_termops.ml
+++ b/plugins/funind/glob_termops.ml
@@ -95,7 +95,7 @@ let glob_decompose_app =
 
 (* [glob_make_eq t1 t2] build the glob_constr corresponding to [t2 = t1] *)
 let glob_make_eq ?(typ= mkGHole ()) t1 t2  =
-  mkGApp(mkGRef ((Coqlib.build_coq_eq_data()).Coqlib.eq),[typ;t2;t1])
+  mkGApp(mkGRef (Coqlib.get_ref "core.eq.type"), [typ; t2; t1])
 
 (* [glob_make_neq t1 t2] build the glob_constr corresponding to [t1 <> t2] *)
 let glob_make_neq t1 t2 =

--- a/plugins/funind/glob_termops.ml
+++ b/plugins/funind/glob_termops.ml
@@ -95,14 +95,14 @@ let glob_decompose_app =
 
 (* [glob_make_eq t1 t2] build the glob_constr corresponding to [t2 = t1] *)
 let glob_make_eq ?(typ= mkGHole ()) t1 t2  =
-  mkGApp(mkGRef (Coqlib.get_ref "core.eq.type"), [typ; t2; t1])
+  mkGApp(mkGRef (Coqlib.lib_ref "core.eq.type"), [typ; t2; t1])
 
 (* [glob_make_neq t1 t2] build the glob_constr corresponding to [t1 <> t2] *)
 let glob_make_neq t1 t2 =
-  mkGApp(mkGRef (Coqlib.get_ref "core.not.type"), [glob_make_eq t1 t2])
+  mkGApp(mkGRef (Coqlib.lib_ref "core.not.type"), [glob_make_eq t1 t2])
 
 (* [glob_make_or P1 P2] build the glob_constr corresponding to [P1 \/ P2] *)
-let glob_make_or t1 t2 = mkGApp (mkGRef(Coqlib.get_ref "core.or.type"),[t1;t2])
+let glob_make_or t1 t2 = mkGApp (mkGRef(Coqlib.lib_ref "core.or.type"),[t1;t2])
 
 (* [glob_make_or_list [P1;...;Pn]] build the glob_constr corresponding
    to [P1 \/ ( .... \/ Pn)]

--- a/plugins/funind/indfun_common.ml
+++ b/plugins/funind/indfun_common.ml
@@ -475,13 +475,15 @@ exception ToShow of exn
 let jmeq () =
   try
     Coqlib.check_required_library Coqlib.jmeq_module_name;
-    Coqlib.gen_constant "Function" ["Logic";"JMeq"] "JMeq"
+    Universes.constr_of_global @@
+      Coqlib.coq_reference "Function" ["Logic";"JMeq"] "JMeq"
   with e when Errors.noncritical e -> raise (ToShow e)
 
 let jmeq_refl () =
   try
     Coqlib.check_required_library Coqlib.jmeq_module_name;
-    Coqlib.gen_constant "Function" ["Logic";"JMeq"] "JMeq_refl"
+    Universes.constr_of_global @@
+      Coqlib.coq_reference "Function" ["Logic";"JMeq"] "JMeq_refl"
   with e when Errors.noncritical e -> raise (ToShow e)
 
 let h_intros l =
@@ -492,7 +494,10 @@ let hrec_id = Id.of_string "hrec"
 let well_founded = function () -> (coq_constant "well_founded")
 let acc_rel = function () -> (coq_constant "Acc")
 let acc_inv_id = function () -> (coq_constant "Acc_inv")
-let well_founded_ltof = function () ->  (Coqlib.coq_constant "" ["Arith";"Wf_nat"] "well_founded_ltof")
+
+let well_founded_ltof () = Universes.constr_of_global @@
+    Coqlib.coq_reference "" ["Arith";"Wf_nat"] "well_founded_ltof"
+
 let ltof_ref = function  () -> (find_reference ["Coq";"Arith";"Wf_nat"] "ltof")
 
 let evaluable_of_global_reference r = (* Tacred.evaluable_of_global_reference (Global.env ()) *)

--- a/plugins/funind/indfun_common.ml
+++ b/plugins/funind/indfun_common.ml
@@ -475,13 +475,13 @@ exception ToShow of exn
 let jmeq () =
   try
     Coqlib.check_required_library Coqlib.jmeq_module_name;
-    Coqlib.get_constr "core.jmeq.type"
+    Coqlib.lib_constr "core.jmeq.type"
   with e when Errors.noncritical e -> raise (ToShow e)
 
 let jmeq_refl () =
   try
     Coqlib.check_required_library Coqlib.jmeq_module_name;
-    Coqlib.get_constr "core.jmeq.refl"
+    Coqlib.lib_constr "core.jmeq.refl"
   with e when Errors.noncritical e -> raise (ToShow e)
 
 let h_intros l =

--- a/plugins/funind/indfun_common.ml
+++ b/plugins/funind/indfun_common.ml
@@ -475,15 +475,13 @@ exception ToShow of exn
 let jmeq () =
   try
     Coqlib.check_required_library Coqlib.jmeq_module_name;
-    Universes.constr_of_global @@
-      Coqlib.coq_reference "Function" ["Logic";"JMeq"] "JMeq"
+    Coqlib.get_constr "core.jmeq.type"
   with e when Errors.noncritical e -> raise (ToShow e)
 
 let jmeq_refl () =
   try
     Coqlib.check_required_library Coqlib.jmeq_module_name;
-    Universes.constr_of_global @@
-      Coqlib.coq_reference "Function" ["Logic";"JMeq"] "JMeq_refl"
+    Coqlib.get_constr "core.jmeq.refl"
   with e when Errors.noncritical e -> raise (ToShow e)
 
 let h_intros l =

--- a/plugins/funind/invfun.ml
+++ b/plugins/funind/invfun.ml
@@ -101,15 +101,13 @@ let nf_zeta =
 
 
 let make_eq () =
-  try
-    Universes.constr_of_global (Coqlib.build_coq_eq ())
-  with _ -> assert false 
-let make_eq_refl () =
-  try
-    Universes.constr_of_global (Coqlib.build_coq_eq_refl ())
+  try Coqlib.get_constr "core.eq.type"
   with _ -> assert false
 
-	  
+let make_eq_refl () =
+  try Coqlib.get_constr "core.eq.refl"
+  with _ -> assert false
+
 (* [generate_type g_to_f f graph i] build the completeness (resp. correctness) lemma type if [g_to_f = true]
    (resp. g_to_f = false) where [graph]  is the graph of [f] and is the [i]th function in the block.
 
@@ -522,7 +520,7 @@ and intros_with_rewrite_aux : tactic =
 			    intros_with_rewrite
 			  ] g
 			end
-		  | Ind _ when eq_constr t (Coqlib.build_coq_False ()) ->
+		  | Ind _ when eq_constr t (Coqlib.get_constr "core.False.type") ->
 		      Proofview.V82.of_tactic Tauto.tauto g
 		  | Case(_,_,v,_) ->
 		      tclTHENSEQ[

--- a/plugins/funind/invfun.ml
+++ b/plugins/funind/invfun.ml
@@ -101,11 +101,11 @@ let nf_zeta =
 
 
 let make_eq () =
-  try Coqlib.get_constr "core.eq.type"
+  try Coqlib.lib_constr "core.eq.type"
   with _ -> assert false
 
 let make_eq_refl () =
-  try Coqlib.get_constr "core.eq.refl"
+  try Coqlib.lib_constr "core.eq.refl"
   with _ -> assert false
 
 (* [generate_type g_to_f f graph i] build the completeness (resp. correctness) lemma type if [g_to_f = true]
@@ -520,7 +520,7 @@ and intros_with_rewrite_aux : tactic =
 			    intros_with_rewrite
 			  ] g
 			end
-		  | Ind _ when eq_constr t (Coqlib.get_constr "core.False.type") ->
+		  | Ind _ when eq_constr t (Coqlib.lib_constr "core.False.type") ->
 		      Proofview.V82.of_tactic Tauto.tauto g
 		  | Case(_,_,v,_) ->
 		      tclTHENSEQ[

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -43,8 +43,8 @@ open Indfun_common
 
 (* Ugly things which should not be here *)
 
-let coq_constant m s =
-  Coqlib.coq_constant "RecursiveDefinition" m s
+let coq_constant m s = Universes.constr_of_global @@
+  Coqlib.coq_reference "RecursiveDefinition" m s
 
 let arith_Nat = ["Arith";"PeanoNat";"Nat"]
 let arith_Lt = ["Arith";"Lt"]

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -1199,7 +1199,7 @@ let get_current_subgoals_types () =
     sigma, List.map (Goal.V82.abstract_type sigma) sgs
 
 let build_and_l l =
-  let and_constr =  Coqlib.build_coq_and () in
+  let and_constr =  Coqlib.get_constr "core.and.type" in
   let conj_constr = coq_conj () in
   let mk_and p1 p2 =
     Term.mkApp(and_constr,[|p1;p2|]) in

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -133,6 +133,7 @@ let iter_ref () =
   try find_reference ["Recdef"] "iter" 
   with Not_found -> error "module Recdef not loaded"
 let iter = function () -> (constr_of_global (delayed_force iter_ref))
+
 let eq = function () -> (coq_init_constant "eq")
 let le_lt_SS = function () -> (constant ["Recdef"] "le_lt_SS")
 let le_lt_n_Sm = function () -> (coq_constant arith_Lt "le_lt_n_Sm")

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -1200,7 +1200,7 @@ let get_current_subgoals_types () =
     sigma, List.map (Goal.V82.abstract_type sigma) sgs
 
 let build_and_l l =
-  let and_constr =  Coqlib.get_constr "core.and.type" in
+  let and_constr =  Coqlib.lib_constr "core.and.type" in
   let conj_constr = coq_conj () in
   let mk_and p1 p2 =
     Term.mkApp(and_constr,[|p1;p2|]) in

--- a/plugins/nsatz/nsatz.ml4
+++ b/plugins/nsatz/nsatz.ml4
@@ -152,8 +152,10 @@ let mul = function
 
 let unconstr = mkRel 1
 
-let tpexpr =
-  lazy (gen_constant "CC" ["setoid_ring";"Ring_polynom"] "PExpr")
+let gen_constant msg path s = Universes.constr_of_global @@
+  coq_reference msg path s
+
+let tpexpr  = lazy (gen_constant "CC" ["setoid_ring";"Ring_polynom"] "PExpr")
 let ttconst = lazy (gen_constant "CC" ["setoid_ring";"Ring_polynom"] "PEc")
 let ttvar = lazy (gen_constant "CC" ["setoid_ring";"Ring_polynom"] "PEX")
 let ttadd = lazy (gen_constant "CC" ["setoid_ring";"Ring_polynom"] "PEadd")

--- a/plugins/omega/coq_omega.ml
+++ b/plugins/omega/coq_omega.ml
@@ -361,21 +361,21 @@ let sp_Zle = lazy (evaluable_ref_of_constr "Z.le" coq_Zle)
 let sp_Zgt = lazy (evaluable_ref_of_constr "Z.gt" coq_Zgt)
 let sp_Zge = lazy (evaluable_ref_of_constr "Z.ge" coq_Zge)
 let sp_Zlt = lazy (evaluable_ref_of_constr "Z.lt" coq_Zlt)
-let sp_not = lazy (evaluable_ref_of_constr "not" (lazy (get_constr "core.not.type")))
+let sp_not = lazy (evaluable_ref_of_constr "not" (lazy (lib_constr "core.not.type")))
 
 let mk_var v = mkVar (Id.of_string v)
 let mk_plus t1 t2 = mkApp (Lazy.force coq_Zplus, [| t1; t2 |])
 let mk_times t1 t2 = mkApp (Lazy.force coq_Zmult, [| t1; t2 |])
 let mk_minus t1 t2 = mkApp (Lazy.force coq_Zminus, [| t1;t2 |])
-let mk_eq t1 t2  = mkApp (get_constr "core.eq.type",
+let mk_eq t1 t2  = mkApp (lib_constr "core.eq.type",
 			 [| Lazy.force coq_Z; t1; t2 |])
 let mk_le  t1 t2 = mkApp (Lazy.force coq_Zle, [| t1; t2 |])
 let mk_gt  t1 t2 = mkApp (Lazy.force coq_Zgt, [| t1; t2 |])
 let mk_inv t     = mkApp (Lazy.force coq_Zopp, [| t |])
-let mk_and t1 t2 = mkApp (get_constr "core.and.type", [| t1; t2 |])
-let mk_or  t1 t2 = mkApp (get_constr "core.or.type" , [| t1; t2 |])
-let mk_not t     = mkApp (get_constr "core.not.type", [| t |])
-let mk_eq_rel t1 t2 = mkApp (get_constr "core.eq.type",
+let mk_and t1 t2 = mkApp (lib_constr "core.and.type", [| t1; t2 |])
+let mk_or  t1 t2 = mkApp (lib_constr "core.or.type" , [| t1; t2 |])
+let mk_not t     = mkApp (lib_constr "core.not.type", [| t |])
+let mk_eq_rel t1 t2 = mkApp (lib_constr "core.eq.type",
 			     [| Lazy.force coq_comparison; t1; t2 |])
 let mk_inj t = mkApp (Lazy.force coq_Z_of_nat, [| t |])
 
@@ -420,19 +420,19 @@ type result =
 let destructurate_prop t =
   let c, args = decompose_app t in
   match kind_of_term c, args with
-    | _, [_;_;_] when is_global (get_ref "core.eq.type") c -> Kapp (Eq,args)
+    | _, [_;_;_] when is_global (lib_ref "core.eq.type") c -> Kapp (Eq,args)
     | _, [_;_] when eq_constr c (Lazy.force coq_neq) -> Kapp (Neq,args)
     | _, [_;_] when eq_constr c (Lazy.force coq_Zne) -> Kapp (Zne,args)
     | _, [_;_] when eq_constr c (Lazy.force coq_Zle) -> Kapp (Zle,args)
     | _, [_;_] when eq_constr c (Lazy.force coq_Zlt) -> Kapp (Zlt,args)
     | _, [_;_] when eq_constr c (Lazy.force coq_Zge) -> Kapp (Zge,args)
     | _, [_;_] when eq_constr c (Lazy.force coq_Zgt) -> Kapp (Zgt,args)
-    | _, [_;_] when eq_constr c (get_constr "core.and.type")   -> Kapp (And,args)
-    | _, [_;_] when eq_constr c (get_constr "core.or.type")    -> Kapp (Or,args)
-    | _, [_;_] when eq_constr c (get_constr "core.iff.type")   -> Kapp (Iff, args)
-    | _, [_]   when eq_constr c (get_constr "core.not.type")   -> Kapp (Not,args)
-    | _, []    when eq_constr c (get_constr "core.False.type") -> Kapp (False,args)
-    | _, []    when eq_constr c (get_constr "core.True.type")  -> Kapp (True,args)
+    | _, [_;_] when eq_constr c (lib_constr "core.and.type")   -> Kapp (And,args)
+    | _, [_;_] when eq_constr c (lib_constr "core.or.type")    -> Kapp (Or,args)
+    | _, [_;_] when eq_constr c (lib_constr "core.iff.type")   -> Kapp (Iff, args)
+    | _, [_]   when eq_constr c (lib_constr "core.not.type")   -> Kapp (Not,args)
+    | _, []    when eq_constr c (lib_constr "core.False.type") -> Kapp (False,args)
+    | _, []    when eq_constr c (lib_constr "core.True.type")  -> Kapp (True,args)
     | _, [_;_] when eq_constr c (Lazy.force coq_le) -> Kapp (Le,args)
     | _, [_;_] when eq_constr c (Lazy.force coq_lt) -> Kapp (Lt,args)
     | _, [_;_] when eq_constr c (Lazy.force coq_ge) -> Kapp (Ge,args)
@@ -1082,7 +1082,7 @@ let replay_history tactic_normalisation =
 	  let p_initial = [P_APP 2;P_TYPE] in
 	  let tac = shuffle_cancel p_initial e1.body in
 	  let solve_le =
-            let not_sup_sup = mkApp (get_constr "core.eq.type",
+            let not_sup_sup = mkApp (lib_constr "core.eq.type",
 				     [|
 					Lazy.force coq_comparison;
 					Lazy.force coq_Gt;
@@ -1242,7 +1242,7 @@ let replay_history tactic_normalisation =
 	  and eq2 = val_of(decompile orig) in
 	  let vid = unintern_id v in
 	  let theorem =
-            mkApp (get_constr "core.ex.type", [|
+            mkApp (lib_constr "core.ex.type", [|
 		      Lazy.force coq_Z;
 		      mkLambda
 			(Name vid,
@@ -1850,7 +1850,7 @@ let destructure_goal =
                 (Proofview.V82.tactic (Tactics.refine
 		                         (mkApp (Lazy.force coq_dec_not_not, [| t; dec; mkNewMeta () |]))))
 	        intro
-	    with Undecidable -> Tactics.elim_type (get_constr "core.False.type")
+	    with Undecidable -> Tactics.elim_type (lib_constr "core.False.type")
 	  in
 	  Tacticals.New.tclTHEN goal_tac destructure_hyps
     in

--- a/plugins/quote/quote.ml
+++ b/plugins/quote/quote.ml
@@ -115,7 +115,9 @@ open Tacmach
   We do that lazily, because this code can be linked before
   the constants are loaded in the environment *)
 
-let constant dir s = Coqlib.gen_constant "Quote" ("quote"::dir) s
+let constant dir s =
+  Universes.constr_of_global @@
+    Coqlib.coq_reference "Quote" ("quote"::dir) s
 
 let coq_Empty_vm = lazy (constant ["Quote"] "Empty_vm")
 let coq_Node_vm = lazy (constant ["Quote"] "Node_vm")

--- a/plugins/romega/const_omega.ml
+++ b/plugins/romega/const_omega.ml
@@ -212,7 +212,7 @@ let rec mk_nat = function
 
 let mkListConst c = 
   let r = 
-    Coqlib.gen_reference "" ["Init";"Datatypes"] c
+    Coqlib.coq_reference "" ["Init";"Datatypes"] c
   in 
   let inst = 
     if Global.is_polymorphic r then fun u -> Univ.Instance.of_array [|u|]

--- a/plugins/rtauto/refl_tauto.ml
+++ b/plugins/rtauto/refl_tauto.ml
@@ -20,9 +20,6 @@ let step_count = ref 0
 
 let node_count = ref 0
 
-let logic_constant s = Universes.constr_of_global @@
-  Coqlib.coq_reference "refl_tauto" ["Init";"Logic"] s
-
 let li_False = lazy (destInd (Coqlib.get_constr "core.False.type"))
 let li_and   = lazy (destInd (Coqlib.get_constr "core.and.type"))
 let li_or    = lazy (destInd (Coqlib.get_constr "core.or.type"))

--- a/plugins/rtauto/refl_tauto.ml
+++ b/plugins/rtauto/refl_tauto.ml
@@ -20,28 +20,28 @@ let step_count = ref 0
 
 let node_count = ref 0
 
-let logic_constant =
-  Coqlib.gen_constant "refl_tauto" ["Init";"Logic"]
+let logic_constant s = Universes.constr_of_global @@
+  Coqlib.coq_reference "refl_tauto" ["Init";"Logic"] s
 
 let li_False = lazy (destInd (logic_constant "False"))
-let li_and = lazy (destInd (logic_constant "and"))
-let li_or =  lazy (destInd (logic_constant "or"))
+let li_and   = lazy (destInd (logic_constant "and"))
+let li_or    = lazy (destInd (logic_constant "or"))
 
-let pos_constant =
-  Coqlib.gen_constant "refl_tauto" ["Numbers";"BinNums"]
+let pos_constant s = Universes.constr_of_global @@
+  Coqlib.coq_reference "refl_tauto" ["Numbers";"BinNums"] s
 
 let l_xI = lazy (pos_constant "xI")
 let l_xO = lazy (pos_constant "xO")
 let l_xH = lazy (pos_constant "xH")
 
-let store_constant =
-  Coqlib.gen_constant "refl_tauto" ["rtauto";"Bintree"]
+let store_constant s = Universes.constr_of_global @@
+  Coqlib.coq_reference "refl_tauto" ["rtauto";"Bintree"] s
 
 let l_empty = lazy (store_constant "empty")
 let l_push = lazy (store_constant "push")
 
-let constant=
-  Coqlib.gen_constant "refl_tauto" ["rtauto";"Rtauto"]
+let constant s = Universes.constr_of_global @@
+  Coqlib.coq_reference "refl_tauto" ["rtauto";"Rtauto"] s
 
 let l_Reflect = lazy (constant "Reflect")
 

--- a/plugins/rtauto/refl_tauto.ml
+++ b/plugins/rtauto/refl_tauto.ml
@@ -20,9 +20,9 @@ let step_count = ref 0
 
 let node_count = ref 0
 
-let li_False = lazy (destInd (Coqlib.get_constr "core.False.type"))
-let li_and   = lazy (destInd (Coqlib.get_constr "core.and.type"))
-let li_or    = lazy (destInd (Coqlib.get_constr "core.or.type"))
+let li_False = lazy (destInd (Coqlib.lib_constr "core.False.type"))
+let li_and   = lazy (destInd (Coqlib.lib_constr "core.and.type"))
+let li_or    = lazy (destInd (Coqlib.lib_constr "core.or.type"))
 
 let pos_constant s = Universes.constr_of_global @@
   Coqlib.coq_reference "refl_tauto" ["Numbers";"BinNums"] s

--- a/plugins/rtauto/refl_tauto.ml
+++ b/plugins/rtauto/refl_tauto.ml
@@ -23,9 +23,9 @@ let node_count = ref 0
 let logic_constant s = Universes.constr_of_global @@
   Coqlib.coq_reference "refl_tauto" ["Init";"Logic"] s
 
-let li_False = lazy (destInd (logic_constant "False"))
-let li_and   = lazy (destInd (logic_constant "and"))
-let li_or    = lazy (destInd (logic_constant "or"))
+let li_False = lazy (destInd (Coqlib.get_constr "core.False.type"))
+let li_and   = lazy (destInd (Coqlib.get_constr "core.and.type"))
+let li_or    = lazy (destInd (Coqlib.get_constr "core.or.type"))
 
 let pos_constant s = Universes.constr_of_global @@
   Coqlib.coq_reference "refl_tauto" ["Numbers";"BinNums"] s

--- a/plugins/setoid_ring/newring.ml4
+++ b/plugins/setoid_ring/newring.ml4
@@ -288,7 +288,7 @@ let znew_ring_path =
 let zltac s =
   lazy(make_kn (MPfile znew_ring_path) DirPath.empty (Label.make s))
 
-let mk_cst l s = lazy (Coqlib.gen_reference "newring" l s);;
+let mk_cst l s = lazy (Coqlib.coq_reference "newring" l s);;
 let pol_cst s = mk_cst [plugin_dir;"Ring_polynom"] s ;;
 
 (* Ring theory *)

--- a/plugins/setoid_ring/newring.ml4
+++ b/plugins/setoid_ring/newring.ml4
@@ -1008,7 +1008,7 @@ let ftheory_to_obj : field_info -> obj =
 let field_equality evd r inv req =
   match kind_of_term req with
     | App (f, [| _ |]) when eq_constr_nounivs f (Lazy.force coq_eq) ->
-        mkApp(Coqlib.get_constr "core.eq.congr", [|r;r;inv|])
+        mkApp(Coqlib.lib_constr "core.eq.congr", [|r;r;inv|])
     | _ ->
 	let _setoid = setoid_of_relation (Global.env ()) evd r req in
 	let signature = [Some (r,Some req)],Some(r,Some req) in

--- a/plugins/setoid_ring/newring.ml4
+++ b/plugins/setoid_ring/newring.ml4
@@ -1008,7 +1008,7 @@ let ftheory_to_obj : field_info -> obj =
 let field_equality evd r inv req =
   match kind_of_term req with
     | App (f, [| _ |]) when eq_constr_nounivs f (Lazy.force coq_eq) ->
-        mkApp(Universes.constr_of_global (Coqlib.build_coq_eq_data()).congr,[|r;r;inv|])
+        mkApp(Coqlib.get_constr "core.eq.congr", [|r;r;inv|])
     | _ ->
 	let _setoid = setoid_of_relation (Global.env ()) evd r req in
 	let signature = [Some (r,Some req)],Some(r,Some req) in

--- a/plugins/syntax/ascii_syntax.ml
+++ b/plugins/syntax/ascii_syntax.ml
@@ -33,8 +33,8 @@ let glob_Ascii = lazy (make_reference "Ascii")
 
 open Lazy
 
-let glob_true  () = get_ref "core.bool.true"
-let glob_false () = get_ref "core.bool.false"
+let glob_true  () = lib_ref "core.bool.true"
+let glob_false () = lib_ref "core.bool.false"
 
 let interp_ascii dloc p =
   let rec aux n p =

--- a/plugins/syntax/ascii_syntax.ml
+++ b/plugins/syntax/ascii_syntax.ml
@@ -33,11 +33,14 @@ let glob_Ascii = lazy (make_reference "Ascii")
 
 open Lazy
 
+let glob_true  () = get_ref "core.bool.true"
+let glob_false () = get_ref "core.bool.false"
+
 let interp_ascii dloc p =
   let rec aux n p =
      if Int.equal n 0 then [] else
      let mp = p mod 2 in
-     GRef (dloc,(if Int.equal mp 0 then glob_false else glob_true),None)
+     GRef (dloc,(if Int.equal mp 0 then glob_false () else glob_true () ), None)
      :: (aux (n-1) (p/2)) in
   GApp (dloc,GRef(dloc,force glob_Ascii,None), aux 8 p)
 
@@ -55,8 +58,8 @@ let interp_ascii_string dloc s =
 let uninterp_ascii r =
   let rec uninterp_bool_list n = function
     | [] when Int.equal n 0 -> 0
-    | GRef (_,k,_)::l when Globnames.eq_gr k glob_true  -> 1+2*(uninterp_bool_list (n-1)  l)
-    | GRef (_,k,_)::l when Globnames.eq_gr k glob_false -> 2*(uninterp_bool_list (n-1) l)
+    | GRef (_,k,_)::l when Globnames.eq_gr k (glob_true  ()) -> 1+2*(uninterp_bool_list (n-1)  l)
+    | GRef (_,k,_)::l when Globnames.eq_gr k (glob_false ()) -> 2*(uninterp_bool_list (n-1) l)
     | _ -> raise Non_closed_ascii in
   try
     let aux = function

--- a/pretyping/pretyping.mllib
+++ b/pretyping/pretyping.mllib
@@ -25,6 +25,7 @@ Tacred
 Typeclasses_errors
 Typeclasses
 Classops
+Coqlib
 Program
 Coercion
 Detyping

--- a/pretyping/program.ml
+++ b/pretyping/program.ml
@@ -12,31 +12,31 @@ open Util
 open Names
 open Term
 
-let sig_typ   () = Coqlib.get_ref "core.sig.type"
-let sig_intro () = Coqlib.get_ref "core.sig.intro"
-let sig_proj1 () = Coqlib.get_ref "core.sig.proj1"
-let sig_proj2 () = Coqlib.get_ref "core.sig.proj2"
+let sig_typ   () = Coqlib.lib_ref "core.sig.type"
+let sig_intro () = Coqlib.lib_ref "core.sig.intro"
+let sig_proj1 () = Coqlib.lib_ref "core.sig.proj1"
+let sig_proj2 () = Coqlib.lib_ref "core.sig.proj2"
 
-let sigT_typ   () = Coqlib.get_ref "core.sigT.type"
-let sigT_intro () = Coqlib.get_ref "core.sigT.intro"
-let sigT_proj1 () = Coqlib.get_ref "core.sigT.proj2"
-let sigT_proj2 () = Coqlib.get_ref "core.sigT.proj2"
+let sigT_typ   () = Coqlib.lib_ref "core.sigT.type"
+let sigT_intro () = Coqlib.lib_ref "core.sigT.intro"
+let sigT_proj1 () = Coqlib.lib_ref "core.sigT.proj2"
+let sigT_proj2 () = Coqlib.lib_ref "core.sigT.proj2"
 
-let prod_typ   () = Coqlib.get_ref "core.prod.type"
-let prod_intro () = Coqlib.get_ref "core.prod.intro"
-let prod_proj1 () = Coqlib.get_ref "core.prod.proj1"
-let prod_proj2 () = Coqlib.get_ref "core.prod.proj2"
+let prod_typ   () = Coqlib.lib_ref "core.prod.type"
+let prod_intro () = Coqlib.lib_ref "core.prod.intro"
+let prod_proj1 () = Coqlib.lib_ref "core.prod.proj1"
+let prod_proj2 () = Coqlib.lib_ref "core.prod.proj2"
 
-let coq_eq_ind      () = Coqlib.get_ref "core.eq.type"
-let coq_eq_refl     () = Coqlib.get_ref "core.eq.refl"
-let coq_eq_refl_ref () = Coqlib.get_ref "core.eq.refl"
-let coq_eq_rect     () = Coqlib.get_ref "core.eq.rect"
+let coq_eq_ind      () = Coqlib.lib_ref "core.eq.type"
+let coq_eq_refl     () = Coqlib.lib_ref "core.eq.refl"
+let coq_eq_refl_ref () = Coqlib.lib_ref "core.eq.refl"
+let coq_eq_rect     () = Coqlib.lib_ref "core.eq.rect"
 
-let coq_JMeq_ind  () = Coqlib.get_ref "core.jmeq.type"
-let coq_JMeq_refl () = Coqlib.get_ref "core.jmeq.refl"
+let coq_JMeq_ind  () = Coqlib.lib_ref "core.jmeq.type"
+let coq_JMeq_refl () = Coqlib.lib_ref "core.jmeq.refl"
 
-let coq_not () = Coqlib.get_constr "core.not.type"
-let coq_and () = Coqlib.get_constr "core.and.type"
+let coq_not () = Coqlib.lib_constr "core.not.type"
+let coq_and () = Coqlib.lib_constr "core.and.type"
 
 let unsafe_fold_right f = function
     hd :: tl -> List.fold_right f tl hd

--- a/pretyping/program.ml
+++ b/pretyping/program.ml
@@ -12,54 +12,41 @@ open Util
 open Names
 open Term
 
-let make_dir l = DirPath.make (List.rev_map Id.of_string l)
+let sig_typ   () = Coqlib.get_ref "core.sig.type"
+let sig_intro () = Coqlib.get_ref "core.sig.intro"
+let sig_proj1 () = Coqlib.get_ref "core.sig.proj1"
+let sig_proj2 () = Coqlib.get_ref "core.sig.proj2"
 
-let find_reference locstr dir s =
-  let sp = Libnames.make_path (make_dir dir) (Id.of_string s) in
-  try Nametab.global_of_path sp
-  with Not_found ->
-    anomaly ~label:locstr (Pp.str "cannot find" ++ spc () ++ Libnames.pr_path sp)
+let sigT_typ   () = Coqlib.get_ref "core.sigT.type"
+let sigT_intro () = Coqlib.get_ref "core.sigT.intro"
+let sigT_proj1 () = Coqlib.get_ref "core.sigT.proj2"
+let sigT_proj2 () = Coqlib.get_ref "core.sigT.proj2"
 
-let coq_reference locstr dir s = find_reference locstr ("Coq"::dir) s
-let coq_constant locstr dir s = Universes.constr_of_global (coq_reference locstr dir s)
+let prod_typ   () = Coqlib.get_ref "core.prod.type"
+let prod_intro () = Coqlib.get_ref "core.prod.intro"
+let prod_proj1 () = Coqlib.get_ref "core.prod.proj1"
+let prod_proj2 () = Coqlib.get_ref "core.prod.proj2"
 
-let init_constant dir s () = coq_constant "Program" dir s
-let init_reference dir s () = coq_reference "Program" dir s
+let coq_eq_ind      () = Coqlib.get_ref "core.eq.type"
+let coq_eq_refl     () = Coqlib.get_ref "core.eq.refl"
+let coq_eq_refl_ref () = Coqlib.get_ref "core.eq.refl"
+let coq_eq_rect     () = Coqlib.get_ref "core.eq.rect"
 
-let papp evdref r args = 
-  let gr = delayed_force r in
-    mkApp (Evarutil.e_new_global evdref gr, args)
+let coq_JMeq_ind  () = Coqlib.get_ref "core.jmeq.type"
+let coq_JMeq_refl () = Coqlib.get_ref "core.jmeq.refl"
 
-let sig_typ = init_reference ["Init"; "Specif"] "sig"
-let sig_intro = init_reference ["Init"; "Specif"] "exist"
-let sig_proj1 = init_reference ["Init"; "Specif"] "proj1_sig"
-
-let sigT_typ = init_reference ["Init"; "Specif"] "sigT"
-let sigT_intro = init_reference ["Init"; "Specif"] "existT"
-let sigT_proj1 = init_reference ["Init"; "Specif"] "projT1"
-let sigT_proj2 = init_reference ["Init"; "Specif"] "projT2"
-
-let prod_typ = init_reference ["Init"; "Datatypes"] "prod"
-let prod_intro = init_reference ["Init"; "Datatypes"] "pair"
-let prod_proj1 = init_reference ["Init"; "Datatypes"] "fst"
-let prod_proj2 = init_reference ["Init"; "Datatypes"] "snd"
-
-let coq_eq_ind = init_reference ["Init"; "Logic"] "eq"
-let coq_eq_refl = init_reference ["Init"; "Logic"] "eq_refl"
-let coq_eq_refl_ref = init_reference ["Init"; "Logic"] "eq_refl"
-let coq_eq_rect = init_reference ["Init"; "Logic"] "eq_rect"
-
-let coq_JMeq_ind = init_reference ["Logic";"JMeq"] "JMeq"
-let coq_JMeq_refl = init_reference ["Logic";"JMeq"] "JMeq_refl"
-
-let coq_not = init_constant ["Init";"Logic"] "not"
-let coq_and = init_constant ["Init";"Logic"] "and"
-
-let mk_coq_not x = mkApp (delayed_force coq_not, [| x |])
+let coq_not () = Coqlib.get_constr "core.not.type"
+let coq_and () = Coqlib.get_constr "core.and.type"
 
 let unsafe_fold_right f = function
     hd :: tl -> List.fold_right f tl hd
   | [] -> invalid_arg "unsafe_fold_right"
+
+let mk_coq_not x = mkApp (delayed_force coq_not, [| x |])
+
+let papp evdref r args =
+  let gr = delayed_force r in
+    mkApp (Evarutil.e_new_global evdref gr, args)
 
 let mk_coq_and l =
   let and_typ = delayed_force coq_and in

--- a/pretyping/program.mli
+++ b/pretyping/program.mli
@@ -11,20 +11,20 @@ open Globnames
 
 (** A bunch of Coq constants used by Progam *)
 
-val sig_typ : unit -> global_reference
-val sig_intro : unit -> global_reference
-val sig_proj1 : unit -> global_reference
-val sigT_typ : unit -> global_reference
+val sig_typ    : unit -> global_reference
+val sig_intro  : unit -> global_reference
+val sig_proj1  : unit -> global_reference
+val sigT_typ   : unit -> global_reference
 val sigT_intro : unit -> global_reference
 val sigT_proj1 : unit -> global_reference
 val sigT_proj2 : unit -> global_reference
 
-val prod_typ : unit -> global_reference
+val prod_typ   : unit -> global_reference
 val prod_intro : unit -> global_reference
 val prod_proj1 : unit -> global_reference
 val prod_proj2 : unit -> global_reference
 
-val coq_eq_ind : unit -> global_reference
+val coq_eq_ind  : unit -> global_reference
 val coq_eq_refl : unit -> global_reference
 val coq_eq_refl_ref : unit -> global_reference
 val coq_eq_rect : unit -> global_reference

--- a/tactics/contradiction.ml
+++ b/tactics/contradiction.ml
@@ -18,7 +18,7 @@ open Misctypes
 
 let mk_absurd_proof t =
   let id = Namegen.default_dependent_ident in
-  mkLambda (Names.Name id,mkApp(get_constr "core.not.type",[|t|]),
+  mkLambda (Names.Name id,mkApp(lib_constr "core.not.type",[|t|]),
     mkLambda (Names.Name id,t,mkApp (mkRel 2,[|mkRel 1|])))
 
 let absurd c =
@@ -30,7 +30,7 @@ let absurd c =
     let t = j.Environ.utj_val in
     Tacticals.New.tclTHENLIST [
       Proofview.Unsafe.tclEVARS sigma;
-      elim_type (get_constr "core.False.type");
+      elim_type (lib_constr "core.False.type");
       Simple.apply (mk_absurd_proof t)
     ]
   end

--- a/tactics/contradiction.ml
+++ b/tactics/contradiction.ml
@@ -18,7 +18,7 @@ open Misctypes
 
 let mk_absurd_proof t =
   let id = Namegen.default_dependent_ident in
-  mkLambda (Names.Name id,mkApp(build_coq_not (),[|t|]),
+  mkLambda (Names.Name id,mkApp(get_constr "core.not.type",[|t|]),
     mkLambda (Names.Name id,t,mkApp (mkRel 2,[|mkRel 1|])))
 
 let absurd c =
@@ -30,7 +30,7 @@ let absurd c =
     let t = j.Environ.utj_val in
     Tacticals.New.tclTHENLIST [
       Proofview.Unsafe.tclEVARS sigma;
-      elim_type (build_coq_False ());
+      elim_type (get_constr "core.False.type");
       Simple.apply (mk_absurd_proof t)
     ]
   end

--- a/tactics/eqdecide.ml
+++ b/tactics/eqdecide.ml
@@ -81,11 +81,11 @@ let solveNoteqBranch side =
 (* Constructs the type {c1=c2}+{~c1=c2} *)
 
 let make_eq () =
-(*FIXME*) Universes.constr_of_global (Coqlib.build_coq_eq ())
+(*FIXME*) Coqlib.get_constr "core.eq.type"
 
 let mkDecideEqGoal eqonleft op rectype c1 c2 =
   let equality    = mkApp(make_eq(), [|rectype; c1; c2|]) in
-  let disequality = mkApp(build_coq_not (), [|equality|]) in
+  let disequality = mkApp(get_constr "core.not.type", [|equality|]) in
   if eqonleft then mkApp(op, [|equality; disequality |])
   else mkApp(op, [|disequality; equality |])
 
@@ -101,7 +101,7 @@ let mkGenDecideEqGoal rectype g =
   and yname    = next_ident_away idy hypnames in
   (mkNamedProd xname rectype
      (mkNamedProd yname rectype
-        (mkDecideEqGoal true (build_coq_sumbool ())
+        (mkDecideEqGoal true (get_constr "core.sumbool.type")
           rectype (mkVar xname) (mkVar yname))))
 
 let rec rewrite_and_clear hyps = match hyps with
@@ -218,7 +218,7 @@ let decideEquality rectype =
 let compare c1 c2 =
   Proofview.Goal.enter begin fun gl ->
   let rectype = pf_unsafe_type_of gl c1 in
-  let decide = mkDecideEqGoal true (build_coq_sumbool ()) rectype c1 c2 in
+  let decide = mkDecideEqGoal true (get_constr "core.sumbool.type") rectype c1 c2 in
   (tclTHENS (cut decide)
             [(tclTHEN  intro
              (tclTHEN (onLastHyp simplest_case) clear_last));

--- a/tactics/eqdecide.ml
+++ b/tactics/eqdecide.ml
@@ -81,11 +81,11 @@ let solveNoteqBranch side =
 (* Constructs the type {c1=c2}+{~c1=c2} *)
 
 let make_eq () =
-(*FIXME*) Coqlib.get_constr "core.eq.type"
+(*FIXME*) Coqlib.lib_constr "core.eq.type"
 
 let mkDecideEqGoal eqonleft op rectype c1 c2 =
   let equality    = mkApp(make_eq(), [|rectype; c1; c2|]) in
-  let disequality = mkApp(get_constr "core.not.type", [|equality|]) in
+  let disequality = mkApp(lib_constr "core.not.type", [|equality|]) in
   if eqonleft then mkApp(op, [|equality; disequality |])
   else mkApp(op, [|disequality; equality |])
 
@@ -101,7 +101,7 @@ let mkGenDecideEqGoal rectype g =
   and yname    = next_ident_away idy hypnames in
   (mkNamedProd xname rectype
      (mkNamedProd yname rectype
-        (mkDecideEqGoal true (get_constr "core.sumbool.type")
+        (mkDecideEqGoal true (lib_constr "core.sumbool.type")
           rectype (mkVar xname) (mkVar yname))))
 
 let rec rewrite_and_clear hyps = match hyps with
@@ -218,7 +218,7 @@ let decideEquality rectype =
 let compare c1 c2 =
   Proofview.Goal.enter begin fun gl ->
   let rectype = pf_unsafe_type_of gl c1 in
-  let decide = mkDecideEqGoal true (get_constr "core.sumbool.type") rectype c1 c2 in
+  let decide = mkDecideEqGoal true (lib_constr "core.sumbool.type") rectype c1 c2 in
   (tclTHENS (cut decide)
             [(tclTHEN  intro
              (tclTHEN (onLastHyp simplest_case) clear_last));

--- a/tactics/eqschemes.ml
+++ b/tactics/eqschemes.ml
@@ -80,7 +80,7 @@ let my_it_mkLambda_or_LetIn_name s c =
 
 let get_coq_eq ctx =
   try
-    let eq = Globnames.destIndRef Coqlib.glob_eq in
+    let eq = Globnames.destIndRef (Coqlib.lib_ref "core.eq.type") in
     (* Do not force the lazy if they are not defined *)
     let eq, ctx = with_context_set ctx 
       (Universes.fresh_inductive_instance (Global.env ()) eq) in

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -321,12 +321,15 @@ let jmeq_same_dom gl = function
 
 let find_elim hdcncl lft2rgt dep cls ot gl =
   (* XXX: Must make the use of jmeq optional *)
-  let eq_ref = lib_ref "core.eq.type"   in
+  (* let eq_ref = lib_ref "core.eq.type"   in *)
   (* let jm_ref = get_ref "core.jmeq.type" in *)
-  let jm_ref = Coqlib.glob_jmeq         in
-  let inccl  = Option.is_empty cls      in
-  if (is_global eq_ref hdcncl ||
-      (is_global jm_ref hdcncl &&
+  (* let jm_ref = Coqlib.glob_jmeq         in *)
+  (* let inccl  = Option.is_empty cls      in *)
+  (* if (is_global eq_ref hdcncl || *)
+  (*     (is_global jm_ref hdcncl && *)
+  let inccl = Option.is_empty cls in
+  if (is_global Coqlib.glob_eq hdcncl ||
+      (is_global Coqlib.glob_jmeq hdcncl &&
 	 jmeq_same_dom gl ot)) && not dep
     || Flags.version_less_or_equal Flags.V8_2
   then

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -320,9 +320,13 @@ let jmeq_same_dom gl = function
    eliminate lbeq on sort_of_gl. *)
 
 let find_elim hdcncl lft2rgt dep cls ot gl =
-  let inccl = Option.is_empty cls in
-  if (is_global Coqlib.glob_eq hdcncl ||
-      (is_global Coqlib.glob_jmeq hdcncl &&
+  (* XXX: Must make the use of jmeq optional *)
+  let eq_ref = get_ref "core.eq.type"   in
+  (* let jm_ref = get_ref "core.jmeq.type" in *)
+  let jm_ref = Coqlib.glob_jmeq         in
+  let inccl  = Option.is_empty cls      in
+  if (is_global eq_ref hdcncl ||
+      (is_global jm_ref hdcncl &&
 	 jmeq_same_dom gl ot)) && not dep
     || Flags.version_less_or_equal Flags.V8_2
   then
@@ -1629,8 +1633,10 @@ let unfold_body x =
   end
 
 let restrict_to_eq_and_identity eq = (* compatibility *)
-  if not (is_global glob_eq eq) &&
-    not (is_global glob_identity eq) 
+  let eq_ref = get_ref "core.eq.type"   in
+  let id_ref = get_ref "core.id.type"   in
+  if not (is_global eq_ref eq) &&
+    not (is_global id_ref eq)
   then raise Constr_matching.PatternMatchingFailure
 
 exception FoundHyp of (Id.t * constr * bool)

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -612,8 +612,8 @@ let replace_using_leibniz clause c1 c2 l2r unsafe try_prove_eq_opt =
   | None ->
     tclFAIL 0 (str"Terms do not have convertible types.")
   | Some evd ->
-    let e = build_coq_eq () in
-    let sym = build_coq_eq_sym () in
+    let e   = get_ref "core.eq.type" in
+    let sym = get_ref "core.eq.sym"  in
     Tacticals.New.pf_constr_of_global sym (fun sym ->
     Tacticals.New.pf_constr_of_global e (fun e ->
     let eq = applist (e, [t1;c1;c2]) in
@@ -875,7 +875,9 @@ let construct_discriminator env sigma dirn c sort =
   let (indp,_) = dest_ind_family indf in
   let ind, _ = check_privacy env indp in
   let (mib,mip) = lookup_mind_specif env ind in
-  let (true_0,false_0,sort_0) = build_coq_True(),build_coq_False(),Prop Null in
+  let true_0  = get_constr "core.True.type"  in
+  let false_0 = get_constr "core.False.type" in
+  let sort_0  = Prop Null                    in
   let deparsign = make_arity_signature env true indf in
   let p = it_mkLambda_or_LetIn (mkSort sort_0) deparsign in
   let cstrs = get_constructors env indf in
@@ -893,7 +895,7 @@ let rec build_discriminator env sigma dirn c sort = function
       let (cnum_nlams,cnum_env,kont) = descend_then env sigma c cnum in
       let newc = mkRel(cnum_nlams-argnum) in
       let subval = build_discriminator cnum_env sigma dirn newc sort l  in
-      kont subval (build_coq_False (),mkSort (Prop Null))
+      kont subval (get_constr "core.False.type", mkSort (Prop Null))
 
 (* Note: discrimination could be more clever: if some elimination is
    not allowed because of a large impredicative constructor in the
@@ -936,8 +938,8 @@ let ind_scheme_of_eq lbeq =
 
 
 let discrimination_pf env sigma e (t,t1,t2) discriminator lbeq =
-  let i            = build_coq_I () in
-  let absurd_term  = build_coq_False () in
+  let i            = get_constr "core.True.I"     in
+  let absurd_term  = get_constr "core.False.type" in
   let eq_elim, eff = ind_scheme_of_eq lbeq in
   let sigma, eq_elim = Evd.fresh_global (Global.env ()) sigma eq_elim in
     sigma, (applist (eq_elim, [t;t1;mkNamedLambda e t discriminator;i;t2]), absurd_term),

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -1288,16 +1288,16 @@ let inject_if_homogenous_dependent_pair ty =
   try
     let eq,u,(t,t1,t2) = find_this_eq_data_decompose gl ty in
     (* fetch the informations of the  pair *)
-    let ceq = Universes.constr_of_global Coqlib.glob_eq in
-    let sigTconstr () = (Coqlib.build_sigma_type()).Coqlib.typ in
-    let existTconstr () = (Coqlib.build_sigma_type()).Coqlib.intro in
+    let ceq          = Coqlib.get_constr "core.eq.type"    in
+    let sigTconstr   = Coqlib.get_ref    "core.sigT.type"  in
+    let existTconstr = Coqlib.get_ref    "core.sigT.intro" in
     (* check whether the equality deals with dep pairs or not *)
     let eqTypeDest = fst (decompose_app t) in
-    if not (Globnames.is_global (sigTconstr()) eqTypeDest) then raise Exit;
+    if not (Globnames.is_global sigTconstr eqTypeDest) then raise Exit;
     let hd1,ar1 = decompose_app_vect t1 and
         hd2,ar2 = decompose_app_vect t2 in
-    if not (Globnames.is_global (existTconstr()) hd1) then raise Exit;
-    if not (Globnames.is_global (existTconstr()) hd2) then raise Exit;
+    if not (Globnames.is_global existTconstr hd1) then raise Exit;
+    if not (Globnames.is_global existTconstr hd2) then raise Exit;
     let ind,_ = try pf_apply find_mrectype gl ar1.(0) with Not_found -> raise Exit in
     (* check if the user has declared the dec principle *)
     (* and compare the fst arguments of the dep pair *)

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -321,7 +321,7 @@ let jmeq_same_dom gl = function
 
 let find_elim hdcncl lft2rgt dep cls ot gl =
   (* XXX: Must make the use of jmeq optional *)
-  let eq_ref = get_ref "core.eq.type"   in
+  let eq_ref = lib_ref "core.eq.type"   in
   (* let jm_ref = get_ref "core.jmeq.type" in *)
   let jm_ref = Coqlib.glob_jmeq         in
   let inccl  = Option.is_empty cls      in
@@ -616,8 +616,8 @@ let replace_using_leibniz clause c1 c2 l2r unsafe try_prove_eq_opt =
   | None ->
     tclFAIL 0 (str"Terms do not have convertible types.")
   | Some evd ->
-    let e   = get_ref "core.eq.type" in
-    let sym = get_ref "core.eq.sym"  in
+    let e   = lib_ref "core.eq.type" in
+    let sym = lib_ref "core.eq.sym"  in
     Tacticals.New.pf_constr_of_global sym (fun sym ->
     Tacticals.New.pf_constr_of_global e (fun e ->
     let eq = applist (e, [t1;c1;c2]) in
@@ -879,8 +879,8 @@ let construct_discriminator env sigma dirn c sort =
   let (indp,_) = dest_ind_family indf in
   let ind, _ = check_privacy env indp in
   let (mib,mip) = lookup_mind_specif env ind in
-  let true_0  = get_constr "core.True.type"  in
-  let false_0 = get_constr "core.False.type" in
+  let true_0  = lib_constr "core.True.type"  in
+  let false_0 = lib_constr "core.False.type" in
   let sort_0  = Prop Null                    in
   let deparsign = make_arity_signature env true indf in
   let p = it_mkLambda_or_LetIn (mkSort sort_0) deparsign in
@@ -899,7 +899,7 @@ let rec build_discriminator env sigma dirn c sort = function
       let (cnum_nlams,cnum_env,kont) = descend_then env sigma c cnum in
       let newc = mkRel(cnum_nlams-argnum) in
       let subval = build_discriminator cnum_env sigma dirn newc sort l  in
-      kont subval (get_constr "core.False.type", mkSort (Prop Null))
+      kont subval (lib_constr "core.False.type", mkSort (Prop Null))
 
 (* Note: discrimination could be more clever: if some elimination is
    not allowed because of a large impredicative constructor in the
@@ -942,8 +942,8 @@ let ind_scheme_of_eq lbeq =
 
 
 let discrimination_pf env sigma e (t,t1,t2) discriminator lbeq =
-  let i            = get_constr "core.True.I"     in
-  let absurd_term  = get_constr "core.False.type" in
+  let i            = lib_constr "core.True.I"     in
+  let absurd_term  = lib_constr "core.False.type" in
   let eq_elim, eff = ind_scheme_of_eq lbeq in
   let sigma, eq_elim = Evd.fresh_global (Global.env ()) sigma eq_elim in
     sigma, (applist (eq_elim, [t;t1;mkNamedLambda e t discriminator;i;t2]), absurd_term),
@@ -1288,9 +1288,9 @@ let inject_if_homogenous_dependent_pair ty =
   try
     let eq,u,(t,t1,t2) = find_this_eq_data_decompose gl ty in
     (* fetch the informations of the  pair *)
-    let ceq          = Coqlib.get_constr "core.eq.type"    in
-    let sigTconstr   = Coqlib.get_ref    "core.sigT.type"  in
-    let existTconstr = Coqlib.get_ref    "core.sigT.intro" in
+    let ceq          = Coqlib.lib_constr "core.eq.type"    in
+    let sigTconstr   = Coqlib.lib_ref    "core.sigT.type"  in
+    let existTconstr = Coqlib.lib_ref    "core.sigT.intro" in
     (* check whether the equality deals with dep pairs or not *)
     let eqTypeDest = fst (decompose_app t) in
     if not (Globnames.is_global sigTconstr eqTypeDest) then raise Exit;
@@ -1633,8 +1633,8 @@ let unfold_body x =
   end
 
 let restrict_to_eq_and_identity eq = (* compatibility *)
-  let eq_ref = get_ref "core.eq.type"   in
-  let id_ref = get_ref "core.id.type"   in
+  let eq_ref = lib_ref "core.eq.type"   in
+  let id_ref = lib_ref "core.id.type"   in
   if not (is_global eq_ref eq) &&
     not (is_global id_ref eq)
   then raise Constr_matching.PatternMatchingFailure

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -1301,8 +1301,8 @@ let inject_if_homogenous_dependent_pair ty =
       pf_apply is_conv gl ar1.(2) ar2.(2)) then raise Exit;
     Coqlib.check_required_library ["Coq";"Logic";"Eqdep_dec"];
     let new_eq_args = [|pf_unsafe_type_of gl ar1.(3);ar1.(3);ar2.(3)|] in
-    let inj2 = Coqlib.coq_constant "inj_pair2_eq_dec is missing"
-      ["Logic";"Eqdep_dec"] "inj_pair2_eq_dec" in
+    let inj2 = Universes.constr_of_global @@
+      Coqlib.coq_reference "inj_pair2_eq_dec is missing" ["Logic";"Eqdep_dec"] "inj_pair2_eq_dec" in
     let c, eff = find_scheme (!eq_dec_scheme_kind_name()) (Univ.out_punivs ind) in
     (* cut with the good equality and prove the requested goal *)
     tclTHENLIST

--- a/tactics/extratactics.ml4
+++ b/tactics/extratactics.ml4
@@ -306,13 +306,12 @@ let project_hint pri l2r r =
   let sigma, c = Evd.fresh_global env sigma gr in
   let t = Retyping.get_type_of env sigma c in
   let t =
-    Tacred.reduce_to_quantified_ref env sigma (Lazy.force coq_iff_ref) t in
+    Tacred.reduce_to_quantified_ref env sigma (get_ref "core.iff.type") t in
   let sign,ccl = decompose_prod_assum t in
   let (a,b) = match snd (decompose_app ccl) with
     | [a;b] -> (a,b)
     | _ -> assert false in
-  let p =
-    if l2r then build_coq_iff_left_proj () else build_coq_iff_right_proj () in
+  let p = get_constr (if l2r then "core.iff.proj1" else "core.iff.proj2") in
   let c = Reductionops.whd_beta Evd.empty (mkApp (c,Termops.extended_rel_vect 0 sign)) in
   let c = it_mkLambda_or_LetIn
     (mkApp (p,[|mkArrow a (lift 1 b);mkArrow b (lift 1 a);c|])) sign in

--- a/tactics/extratactics.ml4
+++ b/tactics/extratactics.ml4
@@ -306,12 +306,12 @@ let project_hint pri l2r r =
   let sigma, c = Evd.fresh_global env sigma gr in
   let t = Retyping.get_type_of env sigma c in
   let t =
-    Tacred.reduce_to_quantified_ref env sigma (get_ref "core.iff.type") t in
+    Tacred.reduce_to_quantified_ref env sigma (lib_ref "core.iff.type") t in
   let sign,ccl = decompose_prod_assum t in
   let (a,b) = match snd (decompose_app ccl) with
     | [a;b] -> (a,b)
     | _ -> assert false in
-  let p = get_constr (if l2r then "core.iff.proj1" else "core.iff.proj2") in
+  let p = lib_constr (if l2r then "core.iff.proj1" else "core.iff.proj2") in
   let c = Reductionops.whd_beta Evd.empty (mkApp (c,Termops.extended_rel_vect 0 sign)) in
   let c = it_mkLambda_or_LetIn
     (mkApp (p,[|mkArrow a (lift 1 b);mkArrow b (lift 1 a);c|])) sign in

--- a/tactics/hipattern.ml4
+++ b/tactics/hipattern.ml4
@@ -378,7 +378,7 @@ let rec first_match matcher = function
 
 (* Patterns "(eq ?1 ?2 ?3)" and "(identity ?1 ?2 ?3)" *)
 let coq_eq_pattern_gen eq = lazy PATTERN [ %eq ?X1 ?X2 ?X3 ]
-let coq_eq_pattern = coq_eq_pattern_gen coq_eq_ref
+let coq_eq_pattern = coq_eq_pattern_gen (lazy (build_coq_eq_data()).eq)
 let coq_identity_pattern = coq_eq_pattern_gen coq_identity_ref
 let coq_jmeq_pattern = lazy PATTERN [ %coq_jmeq_ref ?X1 ?X2 ?X3 ?X4 ]
 

--- a/tactics/hipattern.ml4
+++ b/tactics/hipattern.ml4
@@ -249,17 +249,23 @@ let is_matching x y = is_matching (Global.env ()) Evd.empty x y
 let matches x y = matches (Global.env ()) Evd.empty x y
 
 let match_with_equation t =
+  let eq_ref = get_ref "core.eq.type"   in
+  (* let id_ref = get_ref "core.id.type"   in *)
+  (* let jm_ref = get_ref "core.jmeq.type" in *)
+  (* XXX: This must be generalized no to depend on identity or jmeq *)
+  let id_ref = glob_identity            in
+  let jm_ref = glob_jmeq                in
   if not (isApp t) then raise NoEquationFound;
   let (hdapp,args) = destApp t in
   match kind_of_term hdapp with
   | Ind (ind,u) ->
-      if eq_gr (IndRef ind) glob_eq then
+      if eq_gr (IndRef ind) eq_ref then
 	Some (build_coq_eq_data()),hdapp,
 	PolymorphicLeibnizEq(args.(0),args.(1),args.(2))
-      else if eq_gr (IndRef ind) glob_identity then
+      else if eq_gr (IndRef ind) id_ref then
 	Some (build_coq_identity_data()),hdapp,
 	PolymorphicLeibnizEq(args.(0),args.(1),args.(2))
-      else if eq_gr (IndRef ind) glob_jmeq then
+      else if eq_gr (IndRef ind) jm_ref then
 	Some (build_coq_jmeq_data()),hdapp,
 	HeterogenousEq(args.(0),args.(1),args.(2),args.(3))
       else

--- a/tactics/hipattern.ml4
+++ b/tactics/hipattern.ml4
@@ -249,7 +249,7 @@ let is_matching x y = is_matching (Global.env ()) Evd.empty x y
 let matches x y = matches (Global.env ()) Evd.empty x y
 
 let match_with_equation t =
-  let eq_ref = get_ref "core.eq.type"   in
+  let eq_ref = lib_ref "core.eq.type"   in
   (* let id_ref = get_ref "core.id.type"   in *)
   (* let jm_ref = get_ref "core.jmeq.type" in *)
   (* XXX: This must be generalized no to depend on identity or jmeq *)
@@ -384,9 +384,9 @@ let rec first_match matcher = function
 
 (* Patterns "(eq ?1 ?2 ?3)" and "(identity ?1 ?2 ?3)" *)
 let coq_eq_pattern_gen eq = lazy PATTERN [ %eq ?X1 ?X2 ?X3 ]
-let coq_eq_pattern        = coq_eq_pattern_gen (lazy (get_ref "core.eq.type"))
-let coq_identity_pattern  = coq_eq_pattern_gen (lazy (get_ref "core.id.type"))
-let jmeq_pat              = lazy (get_ref "core.jmeq.type")
+let coq_eq_pattern        = coq_eq_pattern_gen (lazy (lib_ref "core.eq.type"))
+let coq_identity_pattern  = coq_eq_pattern_gen (lazy (lib_ref "core.id.type"))
+let jmeq_pat              = lazy (lib_ref "core.jmeq.type")
 let coq_jmeq_pattern      = lazy PATTERN [ %jmeq_pat ?X1 ?X2 ?X3 ?X4 ]
 
 let match_eq eqn eq_pat =
@@ -457,9 +457,9 @@ let dest_nf_eq gls eqn =
 
 let match_sigma ex =
   match kind_of_term ex with
-  | App (f, [| a; p; car; cdr |]) when is_global (get_ref "core.sig.intro") f ->
+  | App (f, [| a; p; car; cdr |]) when is_global (lib_ref "core.sig.intro") f ->
     build_sigma (), (snd (destConstruct f), a, p, car, cdr)
-  | App (f, [| a; p; car; cdr |]) when is_global (get_ref "core.sigT.intro") f ->
+  | App (f, [| a; p; car; cdr |]) when is_global (lib_ref "core.sigT.intro") f ->
     build_sigma_type (), (snd (destConstruct f), a, p, car, cdr)
   | _ -> raise PatternMatchingFailure
 
@@ -467,7 +467,7 @@ let find_sigma_data_decompose ex = (* fails with PatternMatchingFailure *)
   match_sigma ex
 
 (* Pattern "(sig ?1 ?2)" *)
-let coq_sig_ref = lazy (get_ref "core.sig.type")
+let coq_sig_ref = lazy (lib_ref "core.sig.type")
 let coq_sig_pattern = lazy PATTERN [ %coq_sig_ref ?X1 ?X2 ]
 
 let match_sigma t =
@@ -484,9 +484,9 @@ let is_matching_sigma t = is_matching (Lazy.force coq_sig_pattern) t
 (* Pattern "{<?1>x=y}+{~(<?1>x=y)}" *)
 (* i.e. "(sumbool (eq ?1 x y) ~(eq ?1 x y))" *)
 
-let coq_or_ref      = lazy (get_ref "core.or.type")
-let coq_not_ref     = lazy (get_ref "core.not.type")
-let coq_sumbool_ref = lazy (get_ref "core.sumbool.type")
+let coq_or_ref      = lazy (lib_ref "core.or.type")
+let coq_not_ref     = lazy (lib_ref "core.not.type")
+let coq_sumbool_ref = lazy (lib_ref "core.sumbool.type")
 
 let coq_eqdec_inf_pattern =
  lazy PATTERN [ { ?X2 = ?X3 :> ?X1 } + { ~ ?X2 = ?X3 :> ?X1 } ]
@@ -521,7 +521,7 @@ let match_eqdec t =
 (* Patterns "~ ?" and "? -> False" *)
 let coq_not_pattern = lazy PATTERN [ ~ _ ]
 
-let coq_False_ref = lazy (get_ref "core.False.type")
+let coq_False_ref = lazy (lib_ref "core.False.type")
 let coq_imp_False_pattern = lazy PATTERN [ _ -> %coq_False_ref ]
 
 let is_matching_not t = is_matching (Lazy.force coq_not_pattern) t

--- a/tactics/hipattern.ml4
+++ b/tactics/hipattern.ml4
@@ -384,9 +384,9 @@ let rec first_match matcher = function
 
 (* Patterns "(eq ?1 ?2 ?3)" and "(identity ?1 ?2 ?3)" *)
 let coq_eq_pattern_gen eq = lazy PATTERN [ %eq ?X1 ?X2 ?X3 ]
-let coq_eq_pattern        = coq_eq_pattern_gen (lazy (build_coq_eq_data()).eq)
-let coq_identity_pattern  = coq_eq_pattern_gen (lazy (build_coq_identity_data()).eq)
-let jmeq_pat = lazy (build_coq_jmeq_data()).eq
+let coq_eq_pattern        = coq_eq_pattern_gen (lazy (get_ref "core.eq.type"))
+let coq_identity_pattern  = coq_eq_pattern_gen (lazy (get_ref "core.id.type"))
+let jmeq_pat              = lazy (get_ref "core.jmeq.type")
 let coq_jmeq_pattern      = lazy PATTERN [ %jmeq_pat ?X1 ?X2 ?X3 ?X4 ]
 
 let match_eq eqn eq_pat =

--- a/tactics/rewrite.ml
+++ b/tactics/rewrite.ml
@@ -55,7 +55,7 @@ let make_dir l = DirPath.make (List.rev_map Id.of_string l)
 let try_find_global_reference dir s =
   let sp = Libnames.make_path (make_dir ("Coq"::dir)) (Id.of_string s) in
     try Nametab.global_of_path sp
-    with Not_found -> 
+    with Not_found ->
       anomaly (str "Global reference " ++ str s ++ str " not found in generalized rewriting")
 
 let find_reference dir s =

--- a/tactics/rewrite.ml
+++ b/tactics/rewrite.ml
@@ -66,7 +66,7 @@ type evars = evar_map * Evar.Set.t (* goal evars, constraint evars *)
 
 let find_global dir s =
   let gr = lazy (try_find_global_reference dir s) in
-    fun (evd,cstrs) -> 
+    fun (evd,cstrs) ->
       let evd, c = Evarutil.new_global evd (Lazy.force gr) in
 	(evd, cstrs), c
 
@@ -74,13 +74,13 @@ let find_global dir s =
 
 (** Global constants. *)
 
-let coq_eq_ref = find_reference ["Init"; "Logic"] "eq"
-let coq_eq = find_global ["Init"; "Logic"] "eq"
-let coq_f_equal = find_global ["Init"; "Logic"] "f_equal"
-let coq_all = find_global ["Init"; "Logic"] "all"
-let impl = find_global ["Program"; "Basics"] "impl"
+let coq_eq_ref  = find_reference ["Init"; "Logic"] "eq"
+let coq_eq      = find_global    ["Init"; "Logic"] "eq"
+let coq_f_equal = find_global    ["Init"; "Logic"] "f_equal"
+let coq_all     = find_global    ["Init"; "Logic"] "all"
+let impl        = find_global    ["Program"; "Basics"] "impl"
 
-(** Bookkeeping which evars are constraints so that we can 
+(** Bookkeeping which evars are constraints so that we can
     remove them at the end of the tactic. *)
 
 let goalevars evars = fst evars
@@ -138,7 +138,7 @@ end) = struct
 
   let reflexive_type = find_global relation_classes "Reflexive"
   let reflexive_proof = find_global relation_classes "reflexivity"
-    
+
   let symmetric_type = find_global relation_classes "Symmetric"
   let symmetric_proof = find_global relation_classes "symmetry"
 
@@ -723,9 +723,9 @@ let default_flags = { under_lambdas = true; on_morphisms = true; }
 let get_opt_rew_rel = function RewPrf (rel, prf) -> Some rel | _ -> None
 
 let make_eq () =
-(*FIXME*) Universes.constr_of_global (Coqlib.build_coq_eq ())
+(*FIXME*) Coqlib.get_constr "core.eq.type"
 let make_eq_refl () =
-(*FIXME*) Universes.constr_of_global (Coqlib.build_coq_eq_refl ())
+(*FIXME*) Coqlib.get_constr "core.eq.refl"
 
 let get_rew_prf r = match r.rew_prf with
   | RewPrf (rel, prf) -> rel, prf 

--- a/tactics/rewrite.ml
+++ b/tactics/rewrite.ml
@@ -723,9 +723,9 @@ let default_flags = { under_lambdas = true; on_morphisms = true; }
 let get_opt_rew_rel = function RewPrf (rel, prf) -> Some rel | _ -> None
 
 let make_eq () =
-(*FIXME*) Coqlib.get_constr "core.eq.type"
+(*FIXME*) Coqlib.lib_constr "core.eq.type"
 let make_eq_refl () =
-(*FIXME*) Coqlib.get_constr "core.eq.refl"
+(*FIXME*) Coqlib.lib_constr "core.eq.refl"
 
 let get_rew_prf r = match r.rew_prf with
   | RewPrf (rel, prf) -> rel, prf 

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -3151,25 +3151,11 @@ let error_ind_scheme s =
   let s = if not (String.is_empty s) then s^" " else s in
   errorlabstrm "Tactics" (str "Cannot recognize " ++ str s ++ str "an induction scheme.")
 
-let coq_eq      = lazy (get_constr "core.eq.type")
-let coq_eq_refl = lazy (get_constr "core.eq.refl")
+let mkEq t x y = mkApp (get_constr "core.eq.type", [| t; x; y |])
+let mkRefl t x = mkApp (get_constr "core.eq.refl", [| t; x |])
 
-let coq_heq      = lazy (Universes.constr_of_global (Coqlib.coq_reference "mkHEq" ["Logic";"JMeq"] "JMeq"))
-let coq_heq_refl = lazy (Universes.constr_of_global (Coqlib.coq_reference "mkHEq" ["Logic";"JMeq"] "JMeq_refl"))
-
-let mkEq t x y =
-  mkApp (Lazy.force coq_eq, [| t; x; y |])
-
-let mkRefl t x =
-  mkApp (Lazy.force coq_eq_refl, [| t; x |])
-
-let mkHEq t x u y =
-  mkApp (Lazy.force coq_heq,
-	[| t; x; u; y |])
-
-let mkHRefl t x =
-  mkApp (Lazy.force coq_heq_refl,
-	[| t; x |])
+let mkHEq t x u y = mkApp (get_constr "core.jmeq.type", [| t; x; u; y |])
+let mkHRefl t x   = mkApp (get_constr "core.jmeq.refl",	[| t; x |])
 
 let lift_togethern n l =
   let l', _ =
@@ -3417,17 +3403,17 @@ let specialize_eqs id gl =
     match kind_of_term ty with
     | Prod (na, t, b) ->
 	(match kind_of_term t with
-	| App (eq, [| eqty; x; y |]) when Term.eq_constr (Lazy.force coq_eq) eq ->
+	| App (eq, [| eqty; x; y |]) when Term.eq_constr (get_constr "core.eq.type") eq ->
 	    let c = if noccur_between 1 (List.length ctx) x then y else x in
-	    let pt = mkApp (Lazy.force coq_eq, [| eqty; c; c |]) in
-	    let p = mkApp (Lazy.force coq_eq_refl, [| eqty; c |]) in
+	    let pt = mkEq eqty c c  in
+	    let p  = mkRefl eqty c  in
 	      if unif (push_rel_context ctx env) evars pt t then
 		aux true ctx (mkApp (acc, [| p |])) (subst1 p b)
 	      else acc, in_eqs, ctx, ty
-	| App (heq, [| eqty; x; eqty'; y |]) when Term.eq_constr heq (Lazy.force coq_heq) ->
+	| App (heq, [| eqty; x; eqty'; y |]) when Term.eq_constr heq (get_constr "core.jmeq.type") ->
 	    let eqt, c = if noccur_between 1 (List.length ctx) x then eqty', y else eqty, x in
-	    let pt = mkApp (Lazy.force coq_heq, [| eqt; c; eqt; c |]) in
-	    let p = mkApp (Lazy.force coq_heq_refl, [| eqt; c |]) in
+	    let pt = mkHEq eqt c eqt c in
+	    let p  = mkHRefl eqt c     in
 	      if unif (push_rel_context ctx env) evars pt t then
 		aux true ctx (mkApp (acc, [| p |])) (subst1 p b)
 	      else acc, in_eqs, ctx, ty

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -3151,12 +3151,10 @@ let error_ind_scheme s =
   let s = if not (String.is_empty s) then s^" " else s in
   errorlabstrm "Tactics" (str "Cannot recognize " ++ str s ++ str "an induction scheme.")
 
-let glob = Universes.constr_of_global
+let coq_eq      = lazy (get_constr "core.eq.type")
+let coq_eq_refl = lazy (get_constr "core.eq.refl")
 
-let coq_eq      = lazy (glob (Coqlib.build_coq_eq ()))
-let coq_eq_refl = lazy (glob (Coqlib.build_coq_eq_refl ()))
-
-let coq_heq      = lazy (Universes.constr_of_global (Coqlib.coq_reference"mkHEq" ["Logic";"JMeq"] "JMeq"))
+let coq_heq      = lazy (Universes.constr_of_global (Coqlib.coq_reference "mkHEq" ["Logic";"JMeq"] "JMeq"))
 let coq_heq_refl = lazy (Universes.constr_of_global (Coqlib.coq_reference "mkHEq" ["Logic";"JMeq"] "JMeq_refl"))
 
 let mkEq t x y =

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -3153,12 +3153,11 @@ let error_ind_scheme s =
 
 let glob = Universes.constr_of_global
 
-let coq_eq = lazy (glob (Coqlib.build_coq_eq ()))
+let coq_eq      = lazy (glob (Coqlib.build_coq_eq ()))
 let coq_eq_refl = lazy (glob (Coqlib.build_coq_eq_refl ()))
 
-let coq_heq = lazy (Coqlib.coq_constant "mkHEq" ["Logic";"JMeq"] "JMeq")
-let coq_heq_refl = lazy (Coqlib.coq_constant "mkHEq" ["Logic";"JMeq"] "JMeq_refl")
-
+let coq_heq      = lazy (Universes.constr_of_global (Coqlib.coq_reference"mkHEq" ["Logic";"JMeq"] "JMeq"))
+let coq_heq_refl = lazy (Universes.constr_of_global (Coqlib.coq_reference "mkHEq" ["Logic";"JMeq"] "JMeq_refl"))
 
 let mkEq t x y =
   mkApp (Lazy.force coq_eq, [| t; x; y |])

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -3151,11 +3151,11 @@ let error_ind_scheme s =
   let s = if not (String.is_empty s) then s^" " else s in
   errorlabstrm "Tactics" (str "Cannot recognize " ++ str s ++ str "an induction scheme.")
 
-let mkEq t x y = mkApp (get_constr "core.eq.type", [| t; x; y |])
-let mkRefl t x = mkApp (get_constr "core.eq.refl", [| t; x |])
+let mkEq t x y = mkApp (lib_constr "core.eq.type", [| t; x; y |])
+let mkRefl t x = mkApp (lib_constr "core.eq.refl", [| t; x |])
 
-let mkHEq t x u y = mkApp (get_constr "core.jmeq.type", [| t; x; u; y |])
-let mkHRefl t x   = mkApp (get_constr "core.jmeq.refl",	[| t; x |])
+let mkHEq t x u y = mkApp (lib_constr "core.jmeq.type", [| t; x; u; y |])
+let mkHRefl t x   = mkApp (lib_constr "core.jmeq.refl",	[| t; x |])
 
 let lift_togethern n l =
   let l', _ =
@@ -3403,14 +3403,14 @@ let specialize_eqs id gl =
     match kind_of_term ty with
     | Prod (na, t, b) ->
 	(match kind_of_term t with
-	| App (eq, [| eqty; x; y |]) when Term.eq_constr (get_constr "core.eq.type") eq ->
+	| App (eq, [| eqty; x; y |]) when Term.eq_constr (lib_constr "core.eq.type") eq ->
 	    let c = if noccur_between 1 (List.length ctx) x then y else x in
 	    let pt = mkEq eqty c c  in
 	    let p  = mkRefl eqty c  in
 	      if unif (push_rel_context ctx env) evars pt t then
 		aux true ctx (mkApp (acc, [| p |])) (subst1 p b)
 	      else acc, in_eqs, ctx, ty
-	| App (heq, [| eqty; x; eqty'; y |]) when Term.eq_constr heq (get_constr "core.jmeq.type") ->
+	| App (heq, [| eqty; x; eqty'; y |]) when Term.eq_constr heq (lib_constr "core.jmeq.type") ->
 	    let eqt, c = if noccur_between 1 (List.length ctx) x then eqty', y else eqty, x in
 	    let pt = mkHEq eqt c eqt c in
 	    let p  = mkHRefl eqt c     in

--- a/tactics/tauto.ml4
+++ b/tactics/tauto.ml4
@@ -201,7 +201,7 @@ let not_dep_intros ist =
   <:tactic<
   repeat match goal with
   | |- (forall (_: ?X1), ?X2) => intro
-  | |- (Coq.Init.Logic.not _) => unfold Coq.Init.Logic.not at 1; intro
+  | |- (init.not _) => unfold init.not at 1; intro
   end >>
 
 let axioms flags ist =
@@ -224,13 +224,14 @@ let simplif flags ist =
   and t_is_disj = tacticIn (is_disj flags)
   and t_not_dep_intros = tacticIn not_dep_intros in
   let c1 = constructor 1 in
+
   <:tactic<
     $t_not_dep_intros;
     repeat
        (match reverse goal with
         | id: ?X1 |- _ => $t_is_conj; elim id; do 2 intro; clear id
-        | id: (Coq.Init.Logic.iff _ _) |- _ => elim id; do 2 intro; clear id
-        | id: (Coq.Init.Logic.not _) |- _ => red in id
+        | id: (init.iff _ _) |- _ => elim id; do 2 intro; clear id
+        | id: (init.not _) |- _ => red in id
         | id: ?X1 |- _ => $t_is_disj; elim id; intro; clear id
         | id0: (forall (_: ?X1), ?X2), id1: ?X1|- _ =>
 	    (* generalize (id0 id1); intro; clear id0 does not work
@@ -246,7 +247,7 @@ let simplif flags ist =
         | id: forall (_ : ?X1), ?X2|- _ =>
           $t_flatten_contravariant_conj
 	  (* moved from "id:(?A/\?B)->?X2|-" to "?A->?B->?X2|-" *)
-        | id: forall (_: Coq.Init.Logic.iff ?X1 ?X2), ?X3|- _ =>
+        | id: forall (_: init.iff ?X1 ?X2), ?X3|- _ =>
           assert (forall (_: forall _:X1, X2), forall (_: forall _: X2, X1), X3)
 	    by (do 2 intro; apply id; split; assumption);
             clear id
@@ -254,8 +255,8 @@ let simplif flags ist =
           $t_flatten_contravariant_disj
 	  (* moved from "id:(?A\/?B)->?X2|-" to "?A->?X2,?B->?X2|-" *)
         | |- ?X1 => $t_is_conj; split
-        | |- (Coq.Init.Logic.iff _ _) => split
-        | |- (Coq.Init.Logic.not _) => red
+        | |- (init.iff _ _) => split
+        | |- (init.not _) => red
         end;
         $t_not_dep_intros) >>
 
@@ -295,9 +296,9 @@ let rec tauto_intuit flags t_reduce solver =
 
 let reduction_not_iff _ist =
   match !negation_unfolding, unfold_iff () with
-    | true, true -> <:tactic< unfold Coq.Init.Logic.not, Coq.Init.Logic.iff in * >>
-    | true, false -> <:tactic< unfold Coq.Init.Logic.not in * >>
-    | false, true -> <:tactic< unfold Coq.Init.Logic.iff in * >>
+    | true, true -> <:tactic< unfold init.not, init.iff in * >>
+    | true, false -> <:tactic< unfold init.not in * >>
+    | false, true -> <:tactic< unfold init.iff in * >>
     | false, false -> <:tactic< idtac >>
 
 let t_reduction_not_iff = tacticIn reduction_not_iff

--- a/tactics/tauto.ml4
+++ b/tactics/tauto.ml4
@@ -201,7 +201,7 @@ let not_dep_intros ist =
   <:tactic<
   repeat match goal with
   | |- (forall (_: ?X1), ?X2) => intro
-  | |- (init.not _) => unfold init.not at 1; intro
+  | |- (not _) => unfold not at 1; intro
   end >>
 
 let axioms flags ist =
@@ -230,8 +230,8 @@ let simplif flags ist =
     repeat
        (match reverse goal with
         | id: ?X1 |- _ => $t_is_conj; elim id; do 2 intro; clear id
-        | id: (init.iff _ _) |- _ => elim id; do 2 intro; clear id
-        | id: (init.not _) |- _ => red in id
+        | id: (iff _ _) |- _ => elim id; do 2 intro; clear id
+        | id: (not _) |- _ => red in id
         | id: ?X1 |- _ => $t_is_disj; elim id; intro; clear id
         | id0: (forall (_: ?X1), ?X2), id1: ?X1|- _ =>
 	    (* generalize (id0 id1); intro; clear id0 does not work
@@ -247,7 +247,7 @@ let simplif flags ist =
         | id: forall (_ : ?X1), ?X2|- _ =>
           $t_flatten_contravariant_conj
 	  (* moved from "id:(?A/\?B)->?X2|-" to "?A->?B->?X2|-" *)
-        | id: forall (_: init.iff ?X1 ?X2), ?X3|- _ =>
+        | id: forall (_: iff ?X1 ?X2), ?X3|- _ =>
           assert (forall (_: forall _:X1, X2), forall (_: forall _: X2, X1), X3)
 	    by (do 2 intro; apply id; split; assumption);
             clear id
@@ -255,8 +255,8 @@ let simplif flags ist =
           $t_flatten_contravariant_disj
 	  (* moved from "id:(?A\/?B)->?X2|-" to "?A->?X2,?B->?X2|-" *)
         | |- ?X1 => $t_is_conj; split
-        | |- (init.iff _ _) => split
-        | |- (init.not _) => red
+        | |- (iff _ _) => split
+        | |- (not _) => red
         end;
         $t_not_dep_intros) >>
 
@@ -296,9 +296,9 @@ let rec tauto_intuit flags t_reduce solver =
 
 let reduction_not_iff _ist =
   match !negation_unfolding, unfold_iff () with
-    | true, true -> <:tactic< unfold init.not, init.iff in * >>
-    | true, false -> <:tactic< unfold init.not in * >>
-    | false, true -> <:tactic< unfold init.iff in * >>
+    | true, true -> <:tactic< unfold not, iff in * >>
+    | true, false -> <:tactic< unfold not in * >>
+    | false, true -> <:tactic< unfold iff in * >>
     | false, false -> <:tactic< idtac >>
 
 let t_reduction_not_iff = tacticIn reduction_not_iff

--- a/toplevel/auto_ind_decl.ml
+++ b/toplevel/auto_ind_decl.ml
@@ -594,7 +594,7 @@ repeat ( apply andb_prop in z;let z1:= fresh "Z" in destruct z as [z1 z]).
                         | App (c,ca) -> (
                           match (kind_of_term c) with
                           | Ind (indeq, u) ->
-                              if eq_gr (IndRef indeq) Coqlib.glob_eq
+                              if eq_gr (IndRef indeq) (Coqlib.lib_ref "core.eq.type")
                               then
                                 Tacticals.New.tclTHEN
                                   (do_replace_bl mode bl_scheme_key ind

--- a/toplevel/auto_ind_decl.ml
+++ b/toplevel/auto_ind_decl.ml
@@ -59,28 +59,18 @@ exception DecidabilityMutualNotSupported
 
 let dl = Loc.ghost
 
-let constr_of_global g = lazy (Universes.constr_of_global g)
-
 (* Some pre declaration of constant we are going to use *)
-let bb = constr_of_global Coqlib.glob_bool
+let andb_prop       () = Coqlib.get_constr "core.bool.andb_prop"
+let andb_true_intro () = Coqlib.get_constr "core.bool.andb_true_intro"
+let bb              () = Coqlib.get_constr "core.bool.type"
+let tt              () = Coqlib.get_constr "core.bool.true"
+let ff              () = Coqlib.get_constr "core.bool.false"
+let eq              () = Coqlib.get_constr "core.eq.type"
 
-let andb_prop = fun _ -> (Coqlib.build_bool_type()).Coqlib.andb_prop
+let sumbool () = Coqlib.get_constr "core.sumbool.type"
+let andb    () = Coqlib.get_constr "core.bool.andb"
 
-let andb_true_intro = fun _ ->
-    (Coqlib.build_bool_type()).Coqlib.andb_true_intro
-
-let tt = constr_of_global Coqlib.glob_true
-
-let ff = constr_of_global Coqlib.glob_false
-
-let eq = constr_of_global Coqlib.glob_eq
-
-let sumbool = Coqlib.build_coq_sumbool
-
-let andb = fun _ -> (Coqlib.build_bool_type()).Coqlib.andb
-
-let induct_on c = induction false None c None None
-
+let induct_on  c = induction false None c None None
 let destruct_on c = destruct false None c None None
 
 let destruct_on_using c id =
@@ -106,7 +96,7 @@ let mkFullInd (ind,u) n =
     else mkIndU (ind,u)
 
 let check_bool_is_defined () =
-  try let _ = Global.type_of_global_unsafe Coqlib.glob_bool in ()
+  try let _ = Global.type_of_global_unsafe (Coqlib.get_ref "core.bool.type") in ()
   with e when Errors.noncritical e -> raise (UndefinedCst "bool")
 
 let beq_scheme_kind_aux = ref (fun _ -> failwith "Undefined")
@@ -142,7 +132,7 @@ let build_beq_scheme mode kn =
       let eqs_typ = List.map (fun aa ->
                                 let a = lift !lift_cnt aa in
                                   incr lift_cnt;
-                                  myArrow a (myArrow a (Lazy.force bb))
+                                  myArrow a (myArrow a (bb ()))
                              ) ext_rel_list in
 
         let eq_input = List.fold_left2
@@ -225,7 +215,7 @@ let build_beq_scheme mode kn =
      List.fold_left (fun a b -> mkLambda(Anonymous,b,a))
       (mkLambda (Anonymous,
                  mkFullInd ind (n+3+(List.length rettyp_l)+nb_ind-1),
-                 (Lazy.force bb)))
+                 (bb ())))
       (List.rev rettyp_l) in
   (* make_one_eq *)
   (* do the [| C1 ... =>  match Y with ... end
@@ -236,17 +226,17 @@ let build_beq_scheme mode kn =
       extended_rel_list (n+nb_ind-1) mib.mind_params_ctxt)) in
     let constrsi = constrs (3+nparrec) in
     let n = Array.length constrsi in
-    let ar = Array.make n (Lazy.force ff) in
+    let ar = Array.make n (ff ()) in
     let eff = ref Safe_typing.empty_private_constants in
 	for i=0 to n-1 do
 	  let nb_cstr_args = List.length constrsi.(i).cs_args in
-	  let ar2 = Array.make n (Lazy.force ff) in
+	  let ar2 = Array.make n (ff ()) in
           let constrsj = constrs (3+nparrec+nb_cstr_args) in
 	    for j=0 to n-1 do
 	      if Int.equal i j then
 		ar2.(j) <- let cc = (match nb_cstr_args with
-                    | 0 -> Lazy.force tt
-                    | _ -> let eqs = Array.make nb_cstr_args (Lazy.force tt) in
+                    | 0 -> tt ()
+                    | _ -> let eqs = Array.make nb_cstr_args (tt ()) in
                       for ndx = 0 to nb_cstr_args-1 do
                         let _,_,cc = List.nth constrsi.(i).cs_args ndx in
                           let eqA, eff' = compute_A_equality rel_list
@@ -271,7 +261,7 @@ let build_beq_scheme mode kn =
                     (constrsj.(j).cs_args)
 		)
 	      else ar2.(j) <- (List.fold_left (fun a (p,q,r) ->
-			mkLambda (p,r,a)) (Lazy.force ff) (constrsj.(j).cs_args) )
+			mkLambda (p,r,a)) (ff ()) (constrsj.(j).cs_args) )
 	    done;
 
 	  ar.(i) <- (List.fold_left (fun a (p,q,r) -> mkLambda (p,r,a))
@@ -292,7 +282,7 @@ let build_beq_scheme mode kn =
     for i=0 to (nb_ind-1) do
         names.(i) <- Name (Id.of_string (rec_name i));
 	types.(i) <- mkArrow (mkFullInd ((kn,i),u) 0)
-                     (mkArrow (mkFullInd ((kn,i),u) 1) (Lazy.force bb));
+                     (mkArrow (mkFullInd ((kn,i),u) 1) (bb ()));
         let c, eff' = make_one_eq i in
         cores.(i) <- c;
         eff := Safe_typing.concat_private eff' !eff
@@ -522,15 +512,15 @@ let compute_bl_goal ind lnamesparrec nparrec =
         mkNamedProd x (mkVar s) (
             mkNamedProd y (mkVar s) (
               mkArrow
-               ( mkApp(Lazy.force eq,[|(Lazy.force bb);mkApp(mkVar seq,[|mkVar x;mkVar y|]);(Lazy.force tt)|]))
-               ( mkApp(Lazy.force eq,[|mkVar s;mkVar x;mkVar y|]))
+               ( mkApp(eq (),[|bb (); mkApp(mkVar seq,[|mkVar x;mkVar y|]);tt () |]))
+               ( mkApp(eq (),[|mkVar s;mkVar x;mkVar y|]))
           ))
         ) list_id in
       let bl_input = List.fold_left2 ( fun a (s,_,sbl,_) b ->
         mkNamedProd sbl b a
       ) c (List.rev list_id) (List.rev bl_typ) in
       let eqs_typ = List.map (fun (s,_,_,_) ->
-          mkProd(Anonymous,mkVar s,mkProd(Anonymous,mkVar s,(Lazy.force bb)))
+          mkProd(Anonymous,mkVar s,mkProd(Anonymous,mkVar s,(bb ())))
           ) list_id in
       let eq_input = List.fold_left2 ( fun a (s,seq,_,_) b ->
         mkNamedProd seq b a
@@ -546,8 +536,8 @@ let compute_bl_goal ind lnamesparrec nparrec =
         mkNamedProd n (mkFullInd (ind,u) nparrec) (
           mkNamedProd m (mkFullInd (ind,u) (nparrec+1)) (
             mkArrow
-              (mkApp(Lazy.force eq,[|(Lazy.force bb);mkApp(eqI,[|mkVar n;mkVar m|]);(Lazy.force tt)|]))
-              (mkApp(Lazy.force eq,[|mkFullInd (ind,u) (nparrec+3);mkVar n;mkVar m|]))
+              (mkApp(eq (),[|bb ();mkApp(eqI,[|mkVar n;mkVar m|]);tt ()|]))
+              (mkApp(eq (),[|mkFullInd (ind,u) (nparrec+3);mkVar n;mkVar m|]))
         ))), eff
 
 let compute_bl_tact mode bl_scheme_key ind lnamesparrec nparrec =
@@ -656,7 +646,7 @@ let _ = bl_scheme_kind_aux := fun () -> bl_scheme_kind
 
 let compute_lb_goal ind lnamesparrec nparrec =
   let list_id = list_id lnamesparrec in
-  let eq = Lazy.force eq and tt = Lazy.force tt and bb = Lazy.force bb in
+  let eq = eq () and tt = tt () and bb = bb () in
   let eqI, eff = eqI ind lnamesparrec in
     let create_input c =
       let x = Id.of_string "x" and
@@ -778,13 +768,13 @@ let _ = lb_scheme_kind_aux := fun () -> lb_scheme_kind
 (* Decidable equality *)
 
 let check_not_is_defined () =
-  try ignore (Coqlib.build_coq_not ())
+  try ignore (Coqlib.get_constr "core.not.type")
   with e when Errors.noncritical e -> raise (UndefinedCst "not")
 
 (* {n=m}+{n<>m}  part  *)
 let compute_dec_goal ind lnamesparrec nparrec =
   check_not_is_defined ();
-  let eq = Lazy.force eq and tt = Lazy.force tt and bb = Lazy.force bb in
+  let eq = eq () and tt = tt () and bb = bb () in
   let list_id = list_id lnamesparrec in
     let create_input c =
       let x = Id.of_string "x" and
@@ -829,14 +819,14 @@ let compute_dec_goal ind lnamesparrec nparrec =
         create_input (
           mkNamedProd n (mkFullInd ind (2*nparrec)) (
             mkNamedProd m (mkFullInd ind (2*nparrec+1)) (
-              mkApp(sumbool(),[|eqnm;mkApp (Coqlib.build_coq_not(),[|eqnm|])|])
+              mkApp(sumbool(), [|eqnm;mkApp (Coqlib.get_constr "core.not.type",[|eqnm|])|])
           )
         )
       )
 
 let compute_dec_tact ind lnamesparrec nparrec =
-  let eq = Lazy.force eq and tt = Lazy.force tt 
-  and ff = Lazy.force ff and bb = Lazy.force bb in
+  let eq = eq () and tt = tt ()
+  and ff = ff () and bb = bb () in
   let list_id = list_id lnamesparrec in
   let eqI, eff = eqI ind lnamesparrec in
   let avoid = ref [] in
@@ -901,7 +891,7 @@ let compute_dec_tact ind lnamesparrec nparrec =
             let freshH3 = fresh_id (Id.of_string "H") gl in
             Tacticals.New.tclTHENLIST [
 	      simplest_right ;
-              Proofview.V82.tactic (unfold_constr (Lazy.force Coqlib.coq_not_ref));
+              Proofview.V82.tactic (unfold_constr (Coqlib.get_ref "core.not.type"));
               intro;
               Equality.subst_all ();
               assert_by (Name freshH3)

--- a/toplevel/auto_ind_decl.ml
+++ b/toplevel/auto_ind_decl.ml
@@ -60,15 +60,15 @@ exception DecidabilityMutualNotSupported
 let dl = Loc.ghost
 
 (* Some pre declaration of constant we are going to use *)
-let andb_prop       () = Coqlib.get_constr "core.bool.andb_prop"
-let andb_true_intro () = Coqlib.get_constr "core.bool.andb_true_intro"
-let bb              () = Coqlib.get_constr "core.bool.type"
-let tt              () = Coqlib.get_constr "core.bool.true"
-let ff              () = Coqlib.get_constr "core.bool.false"
-let eq              () = Coqlib.get_constr "core.eq.type"
+let andb_prop       () = Coqlib.lib_constr "core.bool.andb_prop"
+let andb_true_intro () = Coqlib.lib_constr "core.bool.andb_true_intro"
+let bb              () = Coqlib.lib_constr "core.bool.type"
+let tt              () = Coqlib.lib_constr "core.bool.true"
+let ff              () = Coqlib.lib_constr "core.bool.false"
+let eq              () = Coqlib.lib_constr "core.eq.type"
 
-let sumbool () = Coqlib.get_constr "core.sumbool.type"
-let andb    () = Coqlib.get_constr "core.bool.andb"
+let sumbool () = Coqlib.lib_constr "core.sumbool.type"
+let andb    () = Coqlib.lib_constr "core.bool.andb"
 
 let induct_on  c = induction false None c None None
 let destruct_on c = destruct false None c None None
@@ -96,7 +96,7 @@ let mkFullInd (ind,u) n =
     else mkIndU (ind,u)
 
 let check_bool_is_defined () =
-  try let _ = Global.type_of_global_unsafe (Coqlib.get_ref "core.bool.type") in ()
+  try let _ = Global.type_of_global_unsafe (Coqlib.lib_ref "core.bool.type") in ()
   with e when Errors.noncritical e -> raise (UndefinedCst "bool")
 
 let beq_scheme_kind_aux = ref (fun _ -> failwith "Undefined")
@@ -768,7 +768,7 @@ let _ = lb_scheme_kind_aux := fun () -> lb_scheme_kind
 (* Decidable equality *)
 
 let check_not_is_defined () =
-  try ignore (Coqlib.get_constr "core.not.type")
+  try ignore (Coqlib.lib_constr "core.not.type")
   with e when Errors.noncritical e -> raise (UndefinedCst "not")
 
 (* {n=m}+{n<>m}  part  *)
@@ -819,7 +819,7 @@ let compute_dec_goal ind lnamesparrec nparrec =
         create_input (
           mkNamedProd n (mkFullInd ind (2*nparrec)) (
             mkNamedProd m (mkFullInd ind (2*nparrec+1)) (
-              mkApp(sumbool(), [|eqnm;mkApp (Coqlib.get_constr "core.not.type",[|eqnm|])|])
+              mkApp(sumbool(), [|eqnm;mkApp (Coqlib.lib_constr "core.not.type",[|eqnm|])|])
           )
         )
       )
@@ -891,7 +891,7 @@ let compute_dec_tact ind lnamesparrec nparrec =
             let freshH3 = fresh_id (Id.of_string "H") gl in
             Tacticals.New.tclTHENLIST [
 	      simplest_right ;
-              Proofview.V82.tactic (unfold_constr (Coqlib.get_ref "core.not.type"));
+              Proofview.V82.tactic (unfold_constr (Coqlib.lib_ref "core.not.type"));
               intro;
               Equality.subst_all ();
               assert_by (Name freshH3)

--- a/toplevel/command.ml
+++ b/toplevel/command.ml
@@ -860,8 +860,9 @@ let subtac_dir = [contrib_name]
 let fixsub_module = subtac_dir @ ["Wf"]
 let tactics_module = subtac_dir @ ["Tactics"]
 
-let init_reference dir s () = Coqlib.gen_reference "Command" dir s
-let init_constant dir s () = Coqlib.gen_constant "Command" dir s
+let init_reference dir s () = Coqlib.coq_reference "Command" dir s
+let init_constant  dir s () = Universes.constr_of_global (Coqlib.coq_reference "Command" dir s)
+
 let make_ref l s = init_reference l s
 let fix_proto = init_constant tactics_module "fix_proto"
 let fix_sub_ref = make_ref fixsub_module "Fix_sub"

--- a/toplevel/command.ml
+++ b/toplevel/command.ml
@@ -882,8 +882,8 @@ let rec telescope = function
 	List.fold_left
 	  (fun (ty, tys, (k, constr)) (n, b, t) ->
 	    let pred = mkLambda (n, t, ty) in
-	    let ty    = get_constr "core.sigT.type"  in
-	    let intro = get_constr "core.sigT.intro" in
+	    let ty    = lib_constr "core.sigT.type"  in
+	    let intro = lib_constr "core.sigT.intro" in
 	    let sigty = mkApp (ty, [|t; pred|]) in
 	    let intro = mkApp (intro, [|lift k t; lift k pred; mkRel k; constr|]) in
 	      (sigty, pred :: tys, (succ k, intro)))
@@ -891,8 +891,8 @@ let rec telescope = function
       in
       let (last, subst) = List.fold_right2
 	(fun pred (n, b, t) (prev, subst) ->
-	  let p1 = get_constr "core.sigT.proj1" in
-	  let p2 = get_constr "core.sigT.proj2" in
+	  let p1 = lib_constr "core.sigT.proj1" in
+	  let p2 = lib_constr "core.sigT.proj2" in
 	  let proj1 = applistc p1 [t; pred; prev] in
 	  let proj2 = applistc p2 [t; pred; prev] in
 	    (lift 1 proj2, (n, Some proj1, t) :: subst))

--- a/toplevel/command.ml
+++ b/toplevel/command.ml
@@ -871,8 +871,6 @@ let well_founded = init_constant ["Init"; "Wf"] "well_founded"
 let mkSubset name typ prop =
   mkApp (Universes.constr_of_global (delayed_force build_sigma).typ,
 	 [| typ; mkLambda (name, typ, prop) |])
-let sigT = Lazy.lazy_from_fun build_sigma_type
-
 let make_qref s = Qualid (Loc.ghost, qualid_of_string s)
 let lt_ref = make_qref "Init.Peano.lt"
 
@@ -884,8 +882,8 @@ let rec telescope = function
 	List.fold_left
 	  (fun (ty, tys, (k, constr)) (n, b, t) ->
 	    let pred = mkLambda (n, t, ty) in
-	    let ty = Universes.constr_of_global (Lazy.force sigT).typ in
-	    let intro = Universes.constr_of_global (Lazy.force sigT).intro in
+	    let ty    = get_constr "core.sigT.type"  in
+	    let intro = get_constr "core.sigT.intro" in
 	    let sigty = mkApp (ty, [|t; pred|]) in
 	    let intro = mkApp (intro, [|lift k t; lift k pred; mkRel k; constr|]) in
 	      (sigty, pred :: tys, (succ k, intro)))
@@ -893,8 +891,8 @@ let rec telescope = function
       in
       let (last, subst) = List.fold_right2
 	(fun pred (n, b, t) (prev, subst) ->
-	  let p1 = Universes.constr_of_global (Lazy.force sigT).proj1 in
-	  let p2 = Universes.constr_of_global (Lazy.force sigT).proj2 in
+	  let p1 = get_constr "core.sigT.proj1" in
+	  let p2 = get_constr "core.sigT.proj2" in
 	  let proj1 = applistc p1 [t; pred; prev] in
 	  let proj2 = applistc p2 [t; pred; prev] in
 	    (lift 1 proj2, (n, Some proj1, t) :: subst))

--- a/toplevel/indschemes.ml
+++ b/toplevel/indschemes.ml
@@ -456,7 +456,8 @@ let build_combined_scheme env schemes =
   let ctx, ind, nargs = find_inductive t in
   (* Number of clauses, including the predicates quantification *)
   let prods = nb_prod t - (nargs + 1) in
-  let coqand = Coqlib.build_coq_and () and coqconj = Coqlib.build_coq_conj () in
+  let coqand  = Coqlib.get_constr "core.and.type"
+  and coqconj = Coqlib.get_constr "core.and.conj" in
   let relargs = rel_vect 0 prods in
   let concls = List.rev_map
     (fun (cst, t) -> (* FIXME *)

--- a/toplevel/indschemes.ml
+++ b/toplevel/indschemes.ml
@@ -456,8 +456,8 @@ let build_combined_scheme env schemes =
   let ctx, ind, nargs = find_inductive t in
   (* Number of clauses, including the predicates quantification *)
   let prods = nb_prod t - (nargs + 1) in
-  let coqand  = Coqlib.get_constr "core.and.type"
-  and coqconj = Coqlib.get_constr "core.and.conj" in
+  let coqand  = Coqlib.lib_constr "core.and.type"
+  and coqconj = Coqlib.lib_constr "core.and.conj" in
   let relargs = rel_vect 0 prods in
   let concls = List.rev_map
     (fun (cst, t) -> (* FIXME *)

--- a/toplevel/obligations.ml
+++ b/toplevel/obligations.ml
@@ -265,7 +265,7 @@ let eterm_obligations env name evm fs ?status t ty =
 let tactics_module = ["Program";"Tactics"]
 let safe_init_constant md name () =
   Coqlib.check_required_library ("Coq"::md);
-  Coqlib.gen_constant "Obligations" md name
+  Universes.constr_of_global (Coqlib.coq_reference "Obligations" md name)
 let hide_obligation = safe_init_constant tactics_module "obligation"
 
 let pperror cmd = Errors.errorlabstrm "Program" cmd

--- a/toplevel/search.ml
+++ b/toplevel/search.ml
@@ -172,13 +172,13 @@ let search_pattern gopt pat mods =
 
 (** SearchRewrite *)
 
-let eq = Coqlib.glob_eq
+let eq () = Coqlib.lib_ref "core.eq.type"
 
 let rewrite_pat1 pat =
-  PApp (PRef eq, [| PMeta None; pat; PMeta None |])
+  PApp (PRef (eq ()), [| PMeta None; pat; PMeta None |])
 
 let rewrite_pat2 pat =
-  PApp (PRef eq, [| PMeta None; PMeta None; pat |])
+  PApp (PRef (eq ()), [| PMeta None; PMeta None; pat |])
 
 let search_rewrite gopt pat mods =
   let pat1 = rewrite_pat1 pat in


### PR DESCRIPTION
# Patch description and motivation:

This patch modifies the API for requesting library-defined symbols from the ML side. It enables the use of Coq without its standard library.

Currently, ML code wanting to access to library-defined constants use [Coqlib.find_reference module id] to get a reference to a symbol in .v files.

IMO, the current API to map library-provided symbols has a few weak points:
- It is closely tied to file-system layout.
- It uses non-deterministic search sometimes.
- It doesn't handle optional dependencies well (Anomalies...)
- The rules for symbol lifetime are not very clear (Lazy vs delayed)
- It provides redundant entry points.
- It provides "hardcoded constants".
- The symbol namespace is not easily discoverable/extensible.
- It is not easy for plugin/library writers to extend the global namespace in such a way that other plugins can rely on it.
# Current changes/Status.

The current patch introduces a new API to access library-defined symbols.

It is pretty much work in progress and not ready to be merged yet; with some caveats, it enables the compilation of HoTT and math-comp without the standard library [1].

The main change is a modification of the coqlib API such that objects are referenced now using a "domain.object.property".

The new functions are:

``` ocaml
val lib_ref    : string -> global_reference
val add_ref    : string -> global_reference -> unit
```

Example namespaces are:

```
  "core.eq.type"   -> reference to current eq type
  "core.bool.type" -> reference to current bool type
  "core.bool.true" -> reference to true constructor

  "omega.bool.type" -> plugin-specific namespace, omega may want to
                       allow rebinding of bool, etc...
```

Static references are not allowed, as they depend on which libraries are loaded.

The contract for callers of `lib_ref` is pretty liberal. Users _must_ handle Not_found gracefully; also, the result of `lib_ref` will be altered by library loading, thus each time a current reference is desired `lib_ref` must be called again.

Plugins are free to cache references, but they are then responsible of managing reference lifetime.

The main parts of Coq have been ported to the new API. Coq stdlib, math-comp and HoTT work, but a flag is still needed to tweak a couple of settings.

In order to remove the flag, a new vernacular is necessary:

``` coq
Declare Lib Object "dom.obj.prop" name.
```

Then, libraries could rebind references and the rest of hardcoded paths in `coqlib.ml` would go away.

Most of the test suite passes, [a few tests fails given that I won't port all the plugins until I get some feedback].

Most of the patch is pretty straightforward; the kernel is not affected. There are a couple of delicate things thou:
- Coqlib has been moved to pretyping now. This is needed as program.ml was requesting access to library-defined symbols.
  I don't have a particular opinion on this.
- The old coqlib was using smartlocate, but as a consequence of the above change, reference finding had to be moved back to using Nametab. I don't know what the impact of this change is.
- hipattern and equality.ml want to use "globals", that is uninitialized references to library symbols. You can see the two particular places by doing "git grep glob_jmeq".
  The logic here is delicate and I'd need a bit of help to understand what would be the right choice.
# TODO:

Apart from checking if people would be OK with this change, there are
still quite a few things to do:
- Removal of glob_\* in coqlib:
  - the last uses are in hipattern.ml and equality.ml, but they are a bit tricky and require having a good understanding of the logic.
- Implement the Declare Lib Object vernacular.
- Port the syntax plugins
- removal of *_module exports in coqlib.ml
- removal of the rest of exports from coqlib.
- Finish porting all other plugins.
  - In particular Tauto.v depends on Coq.Init.Logic.{iff,not}.

[1] See:
- https://github.com/ejgallego/HoTT/tree/no-stdlib
- https://github.com/ejgallego/math-comp/tree/no-stdlib
