### PR TITLE
Allow the user to specify the name to use for the "magic symbol" in extraction

### DIFF
--- a/plugins/extraction/common.ml
+++ b/plugins/extraction/common.ml
@@ -30,14 +30,22 @@ let extraction_magic_name =
   in value
 
 let string_of_id id =
-  let s = Names.Id.to_string id in
+  let s = Unicode.ascii_of_ident (Names.Id.to_string id) in
   let _ =
     try
       Str.search_forward (Str.regexp (Str.quote !extraction_magic_name)) s 0 ;
-      warning_id !extraction_magic_name s
+      if s = !extraction_magic_name then
+        Errors.errorlabstrm "Extraction"
+          (str "You can not have an identifier exactly matching the magic name \
+                for extraction." ++ fnl ()
+           ++ str "The magic name is currently set to '"
+           ++ str !extraction_magic_name ++ str "'." ++ fnl ()
+           ++ str "You can change the magic name using \
+                   'Set Extraction Magic Name \"...\"'.")
+      else warning_id !extraction_magic_name s
     with Not_found -> ()
   in
-  Unicode.ascii_of_ident s
+  s
 
 let is_mp_bound = function MPbound _ -> true | _ -> false
 

--- a/plugins/extraction/common.ml
+++ b/plugins/extraction/common.ml
@@ -17,11 +17,26 @@ open Table
 open Miniml
 open Mlutil
 
+let extraction_magic_name =
+  let value = ref "__" in
+  let _ = Goptions.(declare_string_option
+      { optsync = true
+      ; optdepr = false
+      ; optname = "The name of the \"magic\" symbol used for extracting terms"
+      ; optkey = ["Extraction";"Magic";"Name"]
+      ; optread = (fun () -> !value)
+      ; optwrite = (:=) value
+      })
+  in value
+
 let string_of_id id =
   let s = Names.Id.to_string id in
-  for i = 0 to String.length s - 2 do
-    if s.[i] == '_' && s.[i+1] == '_' then warning_id s
-  done;
+  let _ =
+    try
+      Str.search_forward (Str.regexp (Str.quote !extraction_magic_name)) s 0 ;
+      warning_id !extraction_magic_name s
+    with Not_found -> ()
+  in
   Unicode.ascii_of_ident s
 
 let is_mp_bound = function MPbound _ -> true | _ -> false

--- a/plugins/extraction/common.mli
+++ b/plugins/extraction/common.mli
@@ -16,6 +16,8 @@ open Pp
     blocks are less that a line length. To avoid this awkward situation,
     we attach a big virtual size to [fnl] newlines. *)
 
+val extraction_magic_name : string ref
+
 val fnl : unit -> std_ppcmds
 val fnl2 : unit -> std_ppcmds
 val space_if : bool -> std_ppcmds

--- a/plugins/extraction/haskell.ml
+++ b/plugins/extraction/haskell.ml
@@ -28,7 +28,7 @@ let keywords =
   List.fold_right (fun s -> Id.Set.add (Id.of_string s))
   [ "Any"; "case"; "class"; "data"; "default"; "deriving"; "do"; "else";
     "if"; "import"; "in"; "infix"; "infixl"; "infixr"; "instance";
-    "let"; "module"; "newtype"; "of"; "then"; "type"; "where"; "_"; "__";
+    "let"; "module"; "newtype"; "of"; "then"; "type"; "where"; "_";
     "as"; "qualified"; "hiding" ; "unit" ; "unsafeCoerce" ]
   Id.Set.empty
 
@@ -86,8 +86,8 @@ let preamble mod_name comment used_modules usf =
   ++
   (if not usf.mldummy then mt ()
    else
-     str "__ :: any" ++ fnl () ++
-     str "__ = Prelude.error \"Logical or arity value used\"" ++ fnl2 ())
+     str !extraction_magic_name ++ str " :: any" ++ fnl () ++
+     str !extraction_magic_name ++ str " = Prelude.error \"Logical or arity value used\"" ++ fnl2 ())
 
 let pp_abst = function
   | [] -> (mt ())
@@ -146,7 +146,10 @@ let rec pp_expr par env args =
 	let id = get_db_name n env in
         (* Try to survive to the occurrence of a Dummy rel.
            TODO: we should get rid of this hack (cf. #592) *)
-        let id = if Id.equal id dummy_name then Id.of_string "__" else id in
+        let id =
+          if Id.equal id dummy_name then
+            Id.of_string !extraction_magic_name
+          else id in
         apply (pr_id id)
     | MLapp (f,args') ->
 	let stl = List.map (pp_expr true env []) args' in
@@ -210,8 +213,8 @@ let rec pp_expr par env args =
     | MLdummy k ->
         (* An [MLdummy] may be applied, but I don't really care. *)
         (match msg_of_implicit k with
-         | "" -> str "__"
-         | s -> str "__" ++ spc () ++ pp_bracket_comment (str s))
+         | "" -> str !extraction_magic_name
+         | s -> str !extraction_magic_name ++ spc () ++ pp_bracket_comment (str s))
     | MLmagic a ->
 	pp_apply (str "unsafeCoerce") par (pp_expr true env [] a :: args)
     | MLaxiom -> pp_par par (str "Prelude.error \"AXIOM TO BE REALIZED\"")

--- a/plugins/extraction/ocaml.ml
+++ b/plugins/extraction/ocaml.ml
@@ -20,7 +20,6 @@ open Mlutil
 open Modutil
 open Common
 
-
 (*s Some utility functions. *)
 
 let pp_tvar id = str ("'" ^ Id.to_string id)
@@ -69,11 +68,14 @@ let pp_header_comment = function
 let then_nl pp = if Pp.is_empty pp then mt () else pp ++ fnl ()
 
 let pp_tdummy usf =
-  if usf.tdummy || usf.tunknown then str "type __ = Obj.t" ++ fnl () else mt ()
+  if usf.tdummy || usf.tunknown then
+    str "type " ++ str !extraction_magic_name ++ str " = Obj.t" ++ fnl ()
+  else mt ()
 
 let pp_mldummy usf =
   if usf.mldummy then
-    str "let __ = let rec f _ = Obj.repr f in Obj.repr f" ++ fnl ()
+    str "let " ++ str !extraction_magic_name ++
+    str " = let rec f _ = Obj.repr f in Obj.repr f" ++ fnl ()
   else mt ()
 
 let preamble _ comment used_modules usf =
@@ -142,8 +144,8 @@ let pp_type par vl t =
     | Tarr (t1,t2) ->
 	pp_par par
 	  (pp_rec true t1 ++ spc () ++ str "->" ++ spc () ++ pp_rec false t2)
-    | Tdummy _ -> str "__"
-    | Tunknown -> str "__"
+    | Tdummy _ -> str !extraction_magic_name
+    | Tunknown -> str !extraction_magic_name
   in
   hov 0 (pp_rec par t)
 

--- a/plugins/extraction/scheme.ml
+++ b/plugins/extraction/scheme.ml
@@ -23,7 +23,7 @@ let keywords =
   List.fold_right (fun s -> Id.Set.add (Id.of_string s))
     [ "define"; "let"; "lambda"; "lambdas"; "match";
       "apply"; "car"; "cdr";
-      "error"; "delay"; "force"; "_"; "__"]
+      "error"; "delay"; "force"; "_"]
     Id.Set.empty
 
 let pp_comment s = str";; "++h 0 s++fnl ()
@@ -37,7 +37,10 @@ let preamble _ comment _ usf =
   str ";; This extracted scheme code relies on some additional macros\n" ++
   str ";; available at http://www.pps.univ-paris-diderot.fr/~letouzey/scheme\n" ++
   str "(load \"macros_extr.scm\")\n\n" ++
-  (if usf.mldummy then str "(define __ (lambda (_) __))\n\n" else mt ())
+  (if usf.mldummy then
+     str "(define " ++ str !extraction_magic_name ++ str " (lambda (_) " ++
+     str !extraction_magic_name ++ str "))\n\n"
+   else mt ())
 
 let pr_id id =
   let s = Id.to_string id in
@@ -127,7 +130,8 @@ let rec pp_expr env args =
 	(* An [MLexn] may be applied, but I don't really care. *)
 	paren (str "error" ++ spc () ++ qs s)
     | MLdummy _ ->
-	str "__" (* An [MLdummy] may be applied, but I don't really care. *)
+      (* An [MLdummy] may be applied, but I don't really care. *)
+      str !extraction_magic_name
     | MLmagic a ->
 	pp_expr env args a
     | MLaxiom -> paren (str "error \"AXIOM TO BE REALIZED\"")

--- a/plugins/extraction/table.ml
+++ b/plugins/extraction/table.ml
@@ -367,9 +367,10 @@ let check_inside_section () =
     err (str "You can't do that within a section." ++ fnl () ++
 	 str "Close it and try again.")
 
-let warning_id s =
-  msg_warning (str ("The identifier "^s^
-		    " contains __ which is reserved for the extraction"))
+let warning_id bad s =
+  msg_warning (str "The identifier " ++ str s ++
+               str " contains " ++ str bad ++
+               str " which is reserved for the extraction")
 
 let error_constant r =
   err (safe_pr_global r ++ str " is not a constant.")
@@ -413,11 +414,15 @@ let error_not_visible r =
 
 let error_MPfile_as_mod mp b =
   let s1 = if b then "asked" else "required" in
-  let s2 = if b then "extract some objects of this module or\n" else "" in
-  err (str ("Extraction of file "^(raw_string_of_modfile mp)^
-	    ".v as a module is "^s1^".\n"^
-	    "Monolithic Extraction cannot deal with this situation.\n"^
-	    "Please "^s2^"use (Recursive) Extraction Library instead.\n"))
+  let s2 = if b then str "extract some objects of this module or" ++ fnl ()
+           else spc ()
+  in
+  err (   str "Extraction of file" ++ spc () ++ str (raw_string_of_modfile mp)
+       ++ str ".v as a module is " ++ str s1 ++ str "." ++ fnl ()
+       ++ str "Monolithic Extraction cannot deal with this situation."
+       ++ fnl ()
+       ++ str "Please " ++ s2 ++ str "use (Recursive) Extraction Library instead."
+       ++ fnl ())
 
 let argnames_of_global r =
   let typ = Global.type_of_global_unsafe r in

--- a/plugins/extraction/table.mli
+++ b/plugins/extraction/table.mli
@@ -23,7 +23,7 @@ val warning_axioms : unit -> unit
 val warning_opaques : bool -> unit
 val warning_both_mod_and_cst :
  qualid -> module_path -> global_reference -> unit
-val warning_id : string -> unit
+val warning_id : string -> string -> unit
 val error_axiom_scheme : global_reference -> int -> 'a
 val error_constant : global_reference -> 'a
 val error_inductive : global_reference -> 'a


### PR DESCRIPTION
Currently, extraction extracts certain terms to a "magic" symbol __. This produces a lot of warnings when code uses identifiers that mention this symbol. This patch allows the user to pick this name using:

Set Extraction Magic Name "...".

There is currently no checking on the string. If it clashes with a reserved word then you will likely get an error when compiling the code but you could get incorrect results.
