### PR TITLE
Fix bug #4656

### DIFF
--- a/test-suite/bugs/closed/4656.v
+++ b/test-suite/bugs/closed/4656.v
@@ -1,0 +1,4 @@
+(* -*- coq-prog-args: ("-emacs" "-compat" "8.4") -*- *)
+Goal True.
+  constructor 1.
+Qed.

--- a/theories/Compat/Coq84.v
+++ b/theories/Compat/Coq84.v
@@ -22,10 +22,11 @@ Global Set Nonrecursive Elimination Schemes.
 Global Set Universal Lemma Under Conjunction.
 
 (** In 8.4, [constructor (tac)] allowed backtracking across the use of [constructor]; it has been subsumed by [constructor; tac]. *)
+Ltac constructor_84_n n := constructor n.
 Ltac constructor_84_tac tac := once (constructor; tac).
 
 Tactic Notation "constructor" := Coq.Init.Notations.constructor.
-Tactic Notation "constructor" int_or_var(n) := Coq.Init.Notations.constructor n.
+Tactic Notation "constructor" int_or_var(n) := constructor_84_n n.
 Tactic Notation "constructor" "(" tactic(tac) ")" := constructor_84_tac tac.
 
 (** Some tactic notations do not factor well with tactics; we add global parsing entries for some tactics that would otherwise be overwritten by custom variants. See https://coq.inria.fr/bugs/show_bug.cgi?id=4392. *)
@@ -43,7 +44,6 @@ Tactic Notation "left" := left.
 Tactic Notation "eleft" := eleft.
 Tactic Notation "right" := right.
 Tactic Notation "eright" := eright.
-Tactic Notation "constructor" := constructor.
 Tactic Notation "econstructor" := econstructor.
 Tactic Notation "symmetry" := symmetry.
 Tactic Notation "split" := split.


### PR DESCRIPTION
Sorry, I introduced this bug in 4c078b0362542908eb2fe1d63f0d867b339953fd;
Coq.Init.Notations.constructor does not take any arguments.

I've tested this on my machine.

@silene, could you merge this
