### PR TITLE
Fixing the "beautifier" and checking the parsing-printing reversibility.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,8 @@
 *.v.html
 *.stamp
 *.native
+*.beautified
+*.backup
 revision
 TAGS
 .DS_Store

--- a/Makefile.build
+++ b/Makefile.build
@@ -82,7 +82,7 @@ STDTIME=/usr/bin/time -f "$* (user: %U mem: %M ko)"
 TIMER=$(if $(TIMED), $(STDTIME), $(TIMECMD))
 
 COQOPTS=$(COQ_XML) $(VM) $(NATIVECOMPUTE)
-BOOTCOQC=$(TIMER) $(COQTOPEXE) -boot $(COQOPTS) -compile
+BOOTCOQC=$(TIMER) $(COQTOPEXE) -boot $(COQOPTS) -beautify -compile
 
 # The SHOW and HIDE variables control whether make will echo complete commands 
 # or only abbreviated versions. 
@@ -502,7 +502,7 @@ BEAUTIFIED=$(THEORIESVO) $(PLUGINSVO)
 TOBEAUTIFY=$(BEAUTIFIED:.vo=.v.beautified)
 
 check-beautify: $(TOBEAUTIFY)
-	@echo Upgrading with beautified files
+	@echo Upgrading beautified files
 	$(HIDE)for i in $(TOBEAUTIFY);\
 	do j=`dirname $$i`/`basename $$i .v.beautified`.v;\
 	  mv -f $$j $$j.backup;\

--- a/Makefile.build
+++ b/Makefile.build
@@ -1105,6 +1105,16 @@ dev/%.mllib.d: $(D_DEPEND_BEFORE_SRC) dev/%.mllib $(D_DEPEND_AFTER_SRC) $(OCAMLL
 	$(SHOW)'CCDEP     $<'
 	$(HIDE)$(OCAMLC) -ccopt "-MM -MQ $@ -MQ $(<:.c=.o) -isystem $(CAMLHLIB)" $< $(TOTARGET)
 
+theories/Init/%.v.beautified: theories/Init/%.v $(VO_TOOLS_DEP) | theories/Init/%.v.d
+	$(SHOW)'COQC -beautify -noinit $<'
+	$(HIDE)rm -f theories/Init/$*.glob
+	$(HIDE)$(BOOTCOQC) $< -beautify -noinit -R theories Coq
+
+%.v.beautified: %.v | %.v.d
+	$(SHOW)'COQC -beautify $<'
+	$(HIDE)rm -f $*.glob
+	$(HIDE)$(BOOTCOQC) $< -beautify
+
 ###########################################################################
 # this sets up developper supporting stuff
 ###########################################################################

--- a/Makefile.build
+++ b/Makefile.build
@@ -498,7 +498,7 @@ test-suite: world $(ALLSTDLIB).v
 	$(MAKE) $(MAKE_TSOPTS) all
 	$(MAKE) $(MAKE_TSOPTS) report
 
-BEAUTIFIED=$(THEORIESVO)
+BEAUTIFIED=$(THEORIESVO) $(PLUGINSVO)
 TOBEAUTIFY=$(BEAUTIFIED:.vo=.v.beautified)
 
 check-beautify: $(TOBEAUTIFY)

--- a/Makefile.build
+++ b/Makefile.build
@@ -498,6 +498,25 @@ test-suite: world $(ALLSTDLIB).v
 	$(MAKE) $(MAKE_TSOPTS) all
 	$(MAKE) $(MAKE_TSOPTS) report
 
+BEAUTIFIED=$(THEORIESVO)
+TOBEAUTIFY=$(BEAUTIFIED:.vo=.v.beautified)
+
+check-beautify: $(TOBEAUTIFY)
+	@echo Upgrading with beautified files
+	$(HIDE)for i in $(TOBEAUTIFY);\
+	do j=`dirname $$i`/`basename $$i .v.beautified`.v;\
+	  mv -f $$j $$j.backup;\
+	  if [ $$i -nt $$j ]; then mv -f $$i $$j; fi;\
+	  rm -f "$$j"o;\
+	done
+	@echo Recompiling beautified files
+	$(HIDE)$(MAKE) $(BEAUTIFIED)
+	@echo Restoring initial files
+	$(HIDE)for i in $(TOBEAUTIFY);\
+	do j=`dirname $$i`/`basename $$i .v.beautified`.v;\
+	  mv -f $$j.backup $$j;\
+	done;
+
 ##################################################################
 # partial targets: 1) core ML parts
 ##################################################################
@@ -1110,10 +1129,23 @@ theories/Init/%.v.beautified: theories/Init/%.v $(VO_TOOLS_DEP) | theories/Init/
 	$(HIDE)rm -f theories/Init/$*.glob
 	$(HIDE)$(BOOTCOQC) $< -beautify -noinit -R theories Coq
 
-%.v.beautified: %.v | %.v.d
+%.v.beautified: %.v theories/Init/Prelude.vo $(VO_TOOLS_DEP) | %.v.d
 	$(SHOW)'COQC -beautify $<'
 	$(HIDE)rm -f $*.glob
 	$(HIDE)$(BOOTCOQC) $< -beautify
+
+theories/Init/%.v.backup: theories/Init/%.v.beautified $(VO_TOOLS_DEP) | theories/Init/%.v.d
+	$(SHOW)'COQC -noinit $<'
+	mv -f theories/Init/$*.v theories/Init/$*.v.backup
+	mv -f theories/Init/$*.v.beautified theories/Init/$*.v
+	rm -f theories/Init/$*.vo
+	$(BOOTCOQC) theories/Init/$* -noinit -R theories Coq
+
+%.v.backup: %.v.beautified theories/Init/Prelude.vo $(VO_TOOLS_DEP) | %.v.d
+	$(SHOW)'COQC $<.v.beautified'
+	$(HIDE)mv -f $*.v $*.v.backup
+	$(HIDE)mv -f $*.v.beautified $*.v
+	$(HIDE)$(BOOTCOQC) $*
 
 ###########################################################################
 # this sets up developper supporting stuff

--- a/grammar/q_util.ml4
+++ b/grammar/q_util.ml4
@@ -79,7 +79,8 @@ let rec type_of_user_symbol = function
   ListArgType (type_of_user_symbol s)
 | Uopt s ->
   OptArgType (type_of_user_symbol s)
-| Uentry e | Uentryl (e, _) -> ExtraArgType e
+| Uentry e -> ExtraArgType e
+| Uentryl (e, n) -> ExtraArgType (e ^ string_of_int n)
 
 let coincide s pat off =
   let len = String.length pat in

--- a/interp/constrarg.ml
+++ b/interp/constrarg.ml
@@ -28,6 +28,24 @@ let wit_intro_pattern : (Constrexpr.constr_expr intro_pattern_expr located, glob
 let wit_tactic : (raw_tactic_expr, glob_tactic_expr, Val.t) genarg_type =
   Genarg.make0 "tactic"
 
+let wit_tactic0 : (raw_tactic_expr, glob_tactic_expr, Val.t) genarg_type =
+  Genarg.make0 "tactic0"
+
+let wit_tactic1 : (raw_tactic_expr, glob_tactic_expr, Val.t) genarg_type =
+  Genarg.make0 "tactic1"
+
+let wit_tactic2 : (raw_tactic_expr, glob_tactic_expr, Val.t) genarg_type =
+  Genarg.make0 "tactic2"
+
+let wit_tactic3 : (raw_tactic_expr, glob_tactic_expr, Val.t) genarg_type =
+  Genarg.make0 "tactic3"
+
+let wit_tactic4 : (raw_tactic_expr, glob_tactic_expr, Val.t) genarg_type =
+  Genarg.make0 "tactic4"
+
+let wit_tactic5 : (raw_tactic_expr, glob_tactic_expr, Val.t) genarg_type =
+  Genarg.make0 "tactic5"
+
 let wit_ltac = Genarg.make0 ~dyn:(val_tag (topwit Stdarg.wit_unit)) "ltac"
 
 let wit_ident =

--- a/interp/constrarg.mli
+++ b/interp/constrarg.mli
@@ -71,6 +71,18 @@ val wit_red_expr :
 
 val wit_tactic : (raw_tactic_expr, glob_tactic_expr, Val.t) genarg_type
 
+val wit_tactic0 : (raw_tactic_expr, glob_tactic_expr, Val.t) genarg_type
+
+val wit_tactic1 : (raw_tactic_expr, glob_tactic_expr, Val.t) genarg_type
+
+val wit_tactic2 : (raw_tactic_expr, glob_tactic_expr, Val.t) genarg_type
+
+val wit_tactic3 : (raw_tactic_expr, glob_tactic_expr, Val.t) genarg_type
+
+val wit_tactic4 : (raw_tactic_expr, glob_tactic_expr, Val.t) genarg_type
+
+val wit_tactic5 : (raw_tactic_expr, glob_tactic_expr, Val.t) genarg_type
+
 (** [wit_ltac] is subtly different from [wit_tactic]: they only change for their
     toplevel interpretation. The one of [wit_ltac] forces the tactic and
     discards the result. *)

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -478,7 +478,7 @@ let explicitize loc inctx impl (cf,f) args =
           (is_needed_for_correct_partial_application tail imp) ||
 	  (!print_implicits_defensive &&
 	   is_significant_implicit a &&
-	   not (is_inferable_implicit inctx n imp))
+	   (not (is_inferable_implicit inctx n imp) || !Flags.beautify_file))
 	in
         if visible then
 	  (a,Some (Loc.ghost, ExplByName (name_of_implicit imp))) :: tail

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -1724,7 +1724,7 @@ let internalize globalenv env allow_patvar lvar c =
     in aux 1 l subscopes eargs rargs
 
   and apply_impargs c env imp subscopes l loc = 
-    let imp = select_impargs_size (List.length l) imp in
+    let imp = select_impargs_size (List.length (List.filter (fun (_,x) -> x == None) l)) imp in
     let l = intern_impargs c env imp subscopes l in
       smart_gapp c loc l
 

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -965,7 +965,7 @@ let pr_visibility prglob = function
 (**********************************************************************)
 (* Mapping notations to concrete syntax *)
 
-type unparsing_rule = unparsing list * precedence
+type unparsing_rule = unparsing list * precedence * tolerability option
 type extra_unparsing_rules = (string * string) list
 (* Concrete syntax for symbolic-extension table *)
 let printing_rules =

--- a/interp/notation.mli
+++ b/interp/notation.mli
@@ -194,7 +194,7 @@ val pr_visibility: (glob_constr -> std_ppcmds) -> scope_name option -> std_ppcmd
 (** {6 Printing rules for notations} *)
 
 (** Declare and look for the printing rule for symbolic notations *)
-type unparsing_rule = unparsing list * precedence
+type unparsing_rule = unparsing list * precedence * tolerability option
 type extra_unparsing_rules = (string * string) list
 val declare_notation_printing_rule :
   notation -> extra:extra_unparsing_rules -> unparsing_rule -> unit

--- a/intf/tacexpr.mli
+++ b/intf/tacexpr.mli
@@ -148,7 +148,7 @@ type 'a gen_atomic_tactic_expr =
   | TacMutualFix of Id.t * int * (Id.t * int * 'trm) list
   | TacMutualCofix of Id.t * (Id.t * 'trm) list
   | TacAssert of
-      bool * 'tacexpr option *
+      bool * 'tacexpr option option *
       'dtrm intro_pattern_expr located option * 'trm
   | TacGeneralize of ('trm with_occurrences * Name.t) list
   | TacLetTac of Name.t * 'trm * 'nam clause_expr * letin_flag *

--- a/ltac/extraargs.ml4
+++ b/ltac/extraargs.ml4
@@ -263,7 +263,23 @@ let pr_r_int31_field i31f =
     | Retroknowledge.Int31PhiInv -> str "phi inv"
     | Retroknowledge.Int31Plus -> str "plus"
     | Retroknowledge.Int31Times -> str "times"
-    | _ -> assert false
+    | Retroknowledge.Int31Constructor -> assert false
+    | Retroknowledge.Int31PlusC -> str "plusc"
+    | Retroknowledge.Int31PlusCarryC -> str "pluscarryc"
+    | Retroknowledge.Int31Minus -> str "minus"
+    | Retroknowledge.Int31MinusC -> str "minusc"
+    | Retroknowledge.Int31MinusCarryC -> str "minuscarryc"
+    | Retroknowledge.Int31TimesC -> str "timesc"
+    | Retroknowledge.Int31Div21 -> str "div21"
+    | Retroknowledge.Int31Div -> str "div"
+    | Retroknowledge.Int31Diveucl -> str "diveucl"
+    | Retroknowledge.Int31AddMulDiv -> str "addmuldiv"
+    | Retroknowledge.Int31Compare -> str "compare"
+    | Retroknowledge.Int31Head0 -> str "head0"
+    | Retroknowledge.Int31Tail0 -> str "tail0"
+    | Retroknowledge.Int31Lor -> str "lor"
+    | Retroknowledge.Int31Land -> str "land"
+    | Retroknowledge.Int31Lxor -> str "lxor"
 
 let pr_retroknowledge_field f =
   match f with
@@ -271,7 +287,7 @@ let pr_retroknowledge_field f =
   | Retroknowledge.KNat natf -> pr_r_nat_field () () () natf
   | Retroknowledge.KN nf -> pr_r_n_field () () () nf *)
   | Retroknowledge.KInt31 (group, i31f) -> (pr_r_int31_field i31f) ++
-                                           str "in " ++ str group
+                                           spc () ++ str "in " ++ qs group
 
 VERNAC ARGUMENT EXTEND retroknowledge_nat
 PRINTED BY pr_r_nat_field

--- a/ltac/g_auto.ml4
+++ b/ltac/g_auto.ml4
@@ -50,11 +50,16 @@ let eval_uconstrs ist cs =
   } in
   List.map (fun c -> Pretyping.type_uconstr ~flags ist c) cs
 
-let pr_auto_using _ _ _ = Pptactic.pr_auto_using (fun _ -> mt ())
+let pr_auto_using_raw _ _ _  = Pptactic.pr_auto_using Ppconstr.pr_constr_expr
+let pr_auto_using_glob _ _ _ = Pptactic.pr_auto_using (fun (c,_) -> Printer.pr_glob_constr c)
+let pr_auto_using _ _ _ = Pptactic.pr_auto_using Printer.pr_closed_glob
 
 ARGUMENT EXTEND auto_using
-  TYPED AS uconstr_list
   PRINTED BY pr_auto_using
+  RAW_TYPED AS uconstr_list
+  RAW_PRINTED BY pr_auto_using_raw
+  GLOB_TYPED AS uconstr_list
+  GLOB_PRINTED BY pr_auto_using_glob
 | [ "using" ne_uconstr_list_sep(l, ",") ] -> [ l ]
 | [ ] -> [ [] ]
 END
@@ -191,8 +196,6 @@ ARGUMENT EXTEND hints_path
 | [ hints_path(p) "|" hints_path(q) ] -> [ Hints.PathOr (p, q) ]
 | [ hints_path(p) ";" hints_path(q) ] -> [ Hints.PathSeq (p, q) ]
 END
-
-let pr_hintbases _prc _prlc _prt = Pptactic.pr_hintbases
 
 ARGUMENT EXTEND opthints
   TYPED AS preident_list_opt

--- a/ltac/g_ltac.ml4
+++ b/ltac/g_ltac.ml4
@@ -175,8 +175,7 @@ GEXTEND Gram
   (* Tactic arguments to the right of an application *)
   tactic_arg_compat:
     [ [ a = tactic_arg -> a
-      | r = reference -> Reference r
-      | c = Constr.constr -> ConstrMayEval (ConstrTerm c)
+      | c = Constr.constr -> (match c with CRef (r,None) -> Reference r | c -> ConstrMayEval (ConstrTerm c))
       (* Unambigous entries: tolerated w/o "ltac:" modifier *)
       | "()" -> TacGeneric (genarg_of_unit ()) ] ]
   ;

--- a/ltac/g_rewrite.ml4
+++ b/ltac/g_rewrite.ml4
@@ -187,6 +187,11 @@ let wit_binders =
 
 let binders = Pcoq.create_generic_entry Pcoq.utactic "binders" (Genarg.rawwit wit_binders)
 
+let () =
+  let raw_printer _ _ _ l = Pp.pr_non_empty_arg Ppconstr.pr_binders l in
+  let printer _ _ _ _ = Pp.str "<Unavailable printer for binders>" in
+  Pptactic.declare_extra_genarg_pprule wit_binders raw_printer printer printer
+
 open Pcoq
 
 GEXTEND Gram

--- a/ltac/tacentries.ml
+++ b/ltac/tacentries.ml
@@ -290,15 +290,33 @@ let inTacticGrammar : tactic_grammar_obj -> obj =
        subst_function = subst_tactic_notation;
        classify_function = classify_tactic_notation}
 
+let rec safe_printing_level n prods =
+  match List.last prods with
+  | TacTerm _ -> n
+  | TacNonTerm (_, (nt, sep), _) ->
+     let level = match parse_user_entry nt sep with
+     | Extend.Uentryl ("tactic",n') -> Some n'
+     | Extend.Uentry ("tactic") -> Some 5
+     | Extend.Uentry ("binder_tactic") -> Some 5
+     | _ -> None in
+     match level with
+     | Some n' when n' > n ->
+         msg_warning (strbrk "Notation ends with a tactic at a level "
+           ++ strbrk "higher than the tactic itself. Using this level "
+           ++ strbrk "for ensuring correct parenthesizing when printing.");
+         n'
+     | _ -> n
+
 let cons_production_parameter = function
 | TacTerm _ -> None
 | TacNonTerm (_, _, id) -> Some id
 
 let add_tactic_notation (local,n,prods,e) =
   let ids = List.map_filter cons_production_parameter prods in
+  let printing_level = safe_printing_level n prods in
   let prods = List.map (interp_prod_item n) prods in
   let pprule = {
-    Pptactic.pptac_level = n;
+    Pptactic.pptac_level = printing_level;
     pptac_prods = prods;
   } in
   let tac = Tacintern.glob_tactic_env ids (Global.env()) e in

--- a/ltac/tacintern.ml
+++ b/ltac/tacintern.ml
@@ -795,6 +795,12 @@ let () =
   Genintern.register_intern0 wit_ident intern_ident';
   Genintern.register_intern0 wit_var (lift intern_hyp);
   Genintern.register_intern0 wit_tactic (lift intern_tactic_or_tacarg);
+  Genintern.register_intern0 wit_tactic0 (lift intern_tactic_or_tacarg);
+  Genintern.register_intern0 wit_tactic1 (lift intern_tactic_or_tacarg);
+  Genintern.register_intern0 wit_tactic2 (lift intern_tactic_or_tacarg);
+  Genintern.register_intern0 wit_tactic3 (lift intern_tactic_or_tacarg);
+  Genintern.register_intern0 wit_tactic4 (lift intern_tactic_or_tacarg);
+  Genintern.register_intern0 wit_tactic5 (lift intern_tactic_or_tacarg);
   Genintern.register_intern0 wit_ltac (lift intern_tactic_or_tacarg);
   Genintern.register_intern0 wit_sort (fun ist s -> (ist, s));
   Genintern.register_intern0 wit_quant_hyp (lift intern_quantified_hypothesis);

--- a/ltac/tacintern.ml
+++ b/ltac/tacintern.ml
@@ -498,7 +498,7 @@ let rec intern_atomic lf ist x =
       let f (id,c) = (intern_ident lf ist id,intern_type ist c) in
       TacMutualCofix (intern_ident lf ist id, List.map f l)
   | TacAssert (b,otac,ipat,c) ->
-      TacAssert (b,Option.map (intern_pure_tactic ist) otac,
+      TacAssert (b,Option.map (Option.map (intern_pure_tactic ist)) otac,
                  Option.map (intern_intro_pattern lf ist) ipat,
                  intern_constr_gen false (not (Option.is_empty otac)) ist c)
   | TacGeneralize cl ->

--- a/ltac/tacinterp.ml
+++ b/ltac/tacinterp.ml
@@ -1282,7 +1282,7 @@ and eval_tactic ist tac : unit Proofview.tactic = match tac with
       in
       let tac =
         Ftactic.with_env interp_vars >>= fun (env, lr) ->
-        let name () = Pptactic.pr_alias (fun v -> print_top_val env v) 0 s lr in
+        let name () = Pptactic.pr_alias (fun _ v -> print_top_val env v) 0 s lr in
         Proofview.Trace.name_tactic name (tac lr)
       (* spiwack: this use of name_tactic is not robust to a
          change of implementation of [Ftactic]. In such a situation,
@@ -1304,7 +1304,7 @@ and eval_tactic ist tac : unit Proofview.tactic = match tac with
       let tac = Tacenv.interp_ml_tactic opn in
       let args = Ftactic.List.map_right (fun a -> interp_tacarg ist a) l in
       let tac args =
-        let name () = Pptactic.pr_extend (fun v -> print_top_val () v) 0 opn args in
+        let name () = Pptactic.pr_extend (fun _ v -> print_top_val () v) 0 opn args in
         Proofview.Trace.name_tactic name (catch_error_tac trace (tac args ist))
       in
       Ftactic.run args tac

--- a/ltac/tacinterp.ml
+++ b/ltac/tacinterp.ml
@@ -1766,10 +1766,10 @@ and interp_atomic ist tac : unit Proofview.tactic =
           (if Option.is_empty t then interp_constr else interp_type) ist env sigma c
         in
         let sigma, ipat' = interp_intro_pattern_option ist env sigma ipat in
-        let tac = Option.map (interp_tactic ist) t in
+        let tac = Option.map (Option.map (interp_tactic ist)) t in
         Tacticals.New.tclWITHHOLES false
         (name_atomic ~env
-          (TacAssert(b,Option.map ignore t,ipat,c))
+          (TacAssert(b,Option.map (Option.map ignore) t,ipat,c))
           (Tactics.forward b tac ipat' c)) sigma
       end }
   | TacGeneralize cl ->

--- a/ltac/tacinterp.ml
+++ b/ltac/tacinterp.ml
@@ -2126,6 +2126,30 @@ let () =
   Geninterp.register_interp0 wit_tactic interp
 
 let () =
+  let interp ist tac = Ftactic.return (Value.of_closure ist tac) in
+  Geninterp.register_interp0 wit_tactic0 interp
+
+let () =
+  let interp ist tac = Ftactic.return (Value.of_closure ist tac) in
+  Geninterp.register_interp0 wit_tactic1 interp
+
+let () =
+  let interp ist tac = Ftactic.return (Value.of_closure ist tac) in
+  Geninterp.register_interp0 wit_tactic2 interp
+
+let () =
+  let interp ist tac = Ftactic.return (Value.of_closure ist tac) in
+  Geninterp.register_interp0 wit_tactic3 interp
+
+let () =
+  let interp ist tac = Ftactic.return (Value.of_closure ist tac) in
+  Geninterp.register_interp0 wit_tactic4 interp
+
+let () =
+  let interp ist tac = Ftactic.return (Value.of_closure ist tac) in
+  Geninterp.register_interp0 wit_tactic5 interp
+
+let () =
   let interp ist tac = interp_tactic ist tac >>= fun () -> Ftactic.return () in
   Geninterp.register_interp0 wit_ltac interp
 

--- a/ltac/tacsubst.ml
+++ b/ltac/tacsubst.ml
@@ -151,7 +151,8 @@ let rec subst_atomic subst (t:glob_atomic_tactic_expr) = match t with
   | TacMutualCofix (id,l) ->
       TacMutualCofix (id, List.map (fun (id,c) -> (id,subst_glob_constr subst c)) l)
   | TacAssert (b,otac,na,c) ->
-      TacAssert (b,Option.map (subst_tactic subst) otac,na,subst_glob_constr subst c)
+      TacAssert (b,Option.map (Option.map (subst_tactic subst)) otac,na,
+                 subst_glob_constr subst c)
   | TacGeneralize cl ->
       TacGeneralize (List.map (on_fst (subst_constr_with_occurrences subst))cl)
   | TacLetTac (id,c,clp,b,eqpat) ->

--- a/ltac/tauto.ml
+++ b/ltac/tauto.ml
@@ -99,7 +99,7 @@ let intro = Tactics.intro
 let assert_ ?by c =
   let tac = match by with
   | None -> None
-  | Some tac -> Some (tclCOMPLETE tac)
+  | Some tac -> Some (Some tac)
   in
   Proofview.tclINDEPENDENT (Tactics.forward true tac None c)
 

--- a/parsing/g_tactic.ml4
+++ b/parsing/g_tactic.ml4
@@ -483,10 +483,6 @@ GEXTEND Gram
     [ [ "as"; id = ident -> Names.Name id | -> Names.Anonymous ] ]
   ;
   by_tactic:
-    [ [ "by"; tac = tactic_expr LEVEL "3" -> TacComplete tac
-      | -> TacId [] ] ]
-  ;
-  opt_by_tactic:
     [ [ "by"; tac = tactic_expr LEVEL "3" -> Some tac
     | -> None ] ]
   ;
@@ -621,9 +617,9 @@ GEXTEND Gram
 
       (* Equality and inversion *)
       | IDENT "rewrite"; l = LIST1 oriented_rewriter SEP ",";
-	  cl = clause_dft_concl; t=opt_by_tactic -> TacAtom (!@loc, TacRewrite (false,l,cl,t))
+	  cl = clause_dft_concl; t=by_tactic -> TacAtom (!@loc, TacRewrite (false,l,cl,t))
       | IDENT "erewrite"; l = LIST1 oriented_rewriter SEP ",";
-	  cl = clause_dft_concl; t=opt_by_tactic -> TacAtom (!@loc, TacRewrite (true,l,cl,t))
+	  cl = clause_dft_concl; t=by_tactic -> TacAtom (!@loc, TacRewrite (true,l,cl,t))
       | IDENT "dependent"; k =
 	  [ IDENT "simple"; IDENT "inversion" -> SimpleInversion
 	  | IDENT "inversion" -> FullInversion

--- a/plugins/firstorder/g_ground.ml4
+++ b/plugins/firstorder/g_ground.ml4
@@ -117,9 +117,9 @@ open Pp
 open Genarg
 open Ppconstr
 open Printer
-let pr_firstorder_using_raw _ _ _ l = str "using " ++ prlist_with_sep pr_comma pr_reference l
-let pr_firstorder_using_glob _ _ _ l = str "using " ++ prlist_with_sep pr_comma (pr_or_var (fun x -> (pr_global (snd x)))) l
-let pr_firstorder_using_typed _ _ _ l = str "using " ++ prlist_with_sep pr_comma pr_global l
+let pr_firstorder_using_raw _ _ _ = Pptactic.pr_auto_using pr_reference
+let pr_firstorder_using_glob _ _ _ = Pptactic.pr_auto_using (pr_or_var (fun x -> pr_global (snd x)))
+let pr_firstorder_using_typed _ _ _ = Pptactic.pr_auto_using pr_global
 
 ARGUMENT EXTEND firstorder_using
   PRINTED BY pr_firstorder_using_typed

--- a/plugins/funind/g_indfun.ml4
+++ b/plugins/funind/g_indfun.ml4
@@ -164,6 +164,11 @@ GEXTEND Gram
 
 END
 
+let () =
+  let raw_printer _ _ _ (loc,body) = Ppvernac.pr_rec_definition body in
+  let printer _ _ _ _ = str "<Unavailable printer for rec_definition>" in
+  Pptactic.declare_extra_genarg_pprule wit_function_rec_definition_loc raw_printer printer printer
+
 (* TASSI: n'importe quoi ! *)
 VERNAC COMMAND EXTEND Function
    ["Function" ne_function_rec_definition_loc_list_sep(recsl,"with")]

--- a/plugins/setoid_ring/g_newring.ml4
+++ b/plugins/setoid_ring/g_newring.ml4
@@ -34,7 +34,25 @@ TACTIC EXTEND closed_term
     [ Proofview.V82.tactic (closed_term t l) ]
 END
 
+open Pptactic
+open Ppconstr
+
+let pr_ring_mod = function
+  | Ring_kind (Computational eq_test) -> str "decidable" ++ pr_arg pr_constr_expr eq_test
+  | Ring_kind Abstract ->  str "abstract"
+  | Ring_kind (Morphism morph) -> str "morphism" ++ pr_arg pr_constr_expr morph
+  | Const_tac (CstTac cst_tac) -> str "constants" ++ spc () ++ str "[" ++ pr_raw_tactic cst_tac ++ str "]"
+  | Const_tac (Closed l) -> str "closed" ++ spc () ++ str "[" ++ prlist_with_sep spc pr_reference l ++ str "]"
+  | Pre_tac t -> str "preprocess" ++ spc () ++ str "[" ++ pr_raw_tactic t ++ str "]"
+  | Post_tac t -> str "postprocess" ++ spc () ++ str "[" ++ pr_raw_tactic t ++ str "]"
+  | Setoid(sth,ext) -> str "setoid" ++ pr_arg pr_constr_expr sth ++ pr_arg pr_constr_expr ext
+  | Pow_spec(Closed l,spec) -> str "power_tac" ++ pr_arg pr_constr_expr spec ++ spc () ++ str "[" ++ prlist_with_sep spc pr_reference l ++ str "]"
+  | Pow_spec(CstTac cst_tac,spec) -> str "power_tac" ++ pr_arg pr_constr_expr spec ++ spc () ++ str "[" ++ pr_raw_tactic cst_tac ++ str "]"
+  | Sign_spec t -> str "sign" ++ pr_arg pr_constr_expr t
+  | Div_spec t -> str "div" ++ pr_arg pr_constr_expr t
+
 VERNAC ARGUMENT EXTEND ring_mod
+  PRINTED BY pr_ring_mod
   | [ "decidable" constr(eq_test) ] -> [ Ring_kind(Computational eq_test) ]
   | [ "abstract" ] -> [ Ring_kind Abstract ]
   | [ "morphism" constr(morph) ] -> [ Ring_kind(Morphism morph) ]
@@ -51,7 +69,10 @@ VERNAC ARGUMENT EXTEND ring_mod
   | [ "div" constr(div_spec) ] -> [ Div_spec div_spec ]
 END
 
+let pr_ring_mods l = surround (prlist_with_sep pr_comma pr_ring_mod l)
+
 VERNAC ARGUMENT EXTEND ring_mods
+  PRINTED BY pr_ring_mods
   | [ "(" ne_ring_mod_list_sep(mods, ",") ")" ] -> [ mods ]
 END
 
@@ -75,12 +96,20 @@ TACTIC EXTEND ring_lookup
     [ let (t,lr) = List.sep_last lrt in ring_lookup f lH lr t]
 END
 
+let pr_field_mod = function
+  | Ring_mod m -> pr_ring_mod m
+  | Inject inj -> str "completeness" ++ pr_arg pr_constr_expr inj
+
 VERNAC ARGUMENT EXTEND field_mod
+  PRINTED BY pr_field_mod
   | [ ring_mod(m) ] -> [ Ring_mod m ]
   | [ "completeness" constr(inj) ] -> [ Inject inj ]
 END
 
+let pr_field_mods l = surround (prlist_with_sep pr_comma pr_field_mod l)
+
 VERNAC ARGUMENT EXTEND field_mods
+  PRINTED BY pr_field_mods
   | [ "(" ne_field_mod_list_sep(mods, ",") ")" ] -> [ mods ]
 END
 

--- a/printing/miscprint.ml
+++ b/printing/miscprint.ml
@@ -36,9 +36,16 @@ and pr_or_and_intro_pattern prc = function
   | IntroAndPattern pl ->
       str "(" ++ hv 0 (prlist_with_sep pr_comma (pr_intro_pattern prc) pl) ++ str ")"
   | IntroOrPattern pll ->
-      str "[" ++
-      hv 0 (prlist_with_sep pr_bar (prlist_with_sep spc (pr_intro_pattern prc)) pll)
-      ++ str "]"
+      let n = List.length pll in
+      let pll = Util.List.map_i (fun i l ->
+        if Util.List.is_empty l then
+          if i=1 then if Lexer.is_keyword "[|" then spc () else mt () else
+          if i=n then if Lexer.is_keyword "|]" then spc () else mt () else
+            spc () (* because || is a keyword *)
+        else
+          prlist_with_sep spc (pr_intro_pattern prc) l) 1 pll in
+      str "[" ++ hv 0 (prlist_with_sep (fun () -> str "|") (fun x -> x) pll) ++
+      str "]"
 
 (** Printing of [move_location] *)
 

--- a/printing/miscprint.ml
+++ b/printing/miscprint.ml
@@ -36,16 +36,9 @@ and pr_or_and_intro_pattern prc = function
   | IntroAndPattern pl ->
       str "(" ++ hv 0 (prlist_with_sep pr_comma (pr_intro_pattern prc) pl) ++ str ")"
   | IntroOrPattern pll ->
-      let n = List.length pll in
-      let pll = Util.List.map_i (fun i l ->
-        if Util.List.is_empty l then
-          if i=1 then if Lexer.is_keyword "[|" then spc () else mt () else
-          if i=n then if Lexer.is_keyword "|]" then spc () else mt () else
-            spc () (* because || is a keyword *)
-        else
-          prlist_with_sep spc (pr_intro_pattern prc) l) 1 pll in
-      str "[" ++ hv 0 (prlist_with_sep (fun () -> str "|") (fun x -> x) pll) ++
-      str "]"
+      str "[ " ++
+      hv 0 (prlist_with_sep pr_bar (prlist_with_sep spc (pr_intro_pattern prc)) pll)
+      ++ str " ]"
 
 (** Printing of [move_location] *)
 

--- a/printing/miscprint.ml
+++ b/printing/miscprint.ml
@@ -36,9 +36,9 @@ and pr_or_and_intro_pattern prc = function
   | IntroAndPattern pl ->
       str "(" ++ hv 0 (prlist_with_sep pr_comma (pr_intro_pattern prc) pl) ++ str ")"
   | IntroOrPattern pll ->
-      str "[ " ++
+      str "[" ++
       hv 0 (prlist_with_sep pr_bar (prlist_with_sep spc (pr_intro_pattern prc)) pll)
-      ++ str " ]"
+      ++ str "]"
 
 (** Printing of [move_location] *)
 

--- a/printing/miscprint.ml
+++ b/printing/miscprint.ml
@@ -28,7 +28,7 @@ and pr_intro_pattern_action prc = function
   | IntroInjection pl ->
       str "[=" ++ hv 0 (prlist_with_sep spc (pr_intro_pattern prc) pl) ++
       str "]"
-  | IntroApplyOn (c,pat) -> pr_intro_pattern prc pat ++ str "/" ++ prc c
+  | IntroApplyOn (c,pat) -> pr_intro_pattern prc pat ++ str "%" ++ prc c
   | IntroRewrite true -> str "->"
   | IntroRewrite false -> str "<-"
 

--- a/printing/ppconstr.ml
+++ b/printing/ppconstr.ml
@@ -712,7 +712,7 @@ end) = struct
       Constrextern.extern_glob_constr (Termops.vars_of_env env) r
     else c
 
-  let pr prec c = pr prec (transf (Global.env()) c)
+  let pr prec c = pr prec ((*transf (Global.env())*) c)
 
   let pr_simpleconstr = function
     | CAppExpl (_,(None,f,us),[]) -> str "@" ++ pr_cref f us

--- a/printing/ppconstr.ml
+++ b/printing/ppconstr.ml
@@ -498,6 +498,11 @@ end) = struct
       pr (lapp,L) a  ++
         prlist (fun a -> spc () ++ pr_expl_args pr a) l)
 
+  let pr_record_body_gen pr l =
+    spc () ++
+    prlist_with_sep pr_semicolon
+      (fun (id, c) -> h 1 (pr_reference id ++ spc () ++ str":=" ++ pr ltop c)) l
+
   let pr_forall () = keyword "forall" ++ spc ()
 
   let pr_fun () = keyword "fun" ++ spc ()
@@ -600,10 +605,7 @@ end) = struct
         return (pr_app (pr mt) a l, lapp)
       | CRecord (_,l) ->
         return (
-          hv 0 (str"{|" ++ spc () ++
-                  prlist_with_sep pr_semicolon
-                  (fun (id, c) -> h 1 (pr_reference id ++ spc () ++ str":=" ++ pr spc ltop c)) l
-                ++ str" |}"),
+          hv 0 (str"{|" ++ pr_record_body_gen (pr spc) l ++ str" |}"),
           latom
         )
       | CCases (_,LetPatternStyle,rtntypopt,[c,as_clause,in_clause],[(_,[(loc,[p])],b)]) ->
@@ -735,6 +737,8 @@ end) = struct
   let pr_lconstr_pattern_expr c = !term_pr.pr_lconstr_pattern_expr c
 
   let pr_cases_pattern_expr = pr_patt ltop
+
+  let pr_record_body = pr_record_body_gen pr
 
   let pr_binders = pr_undelimited_binders spc (pr ltop)
 

--- a/printing/ppconstrsig.mli
+++ b/printing/ppconstrsig.mli
@@ -50,6 +50,7 @@ module type Pp = sig
     ('a * Names.Id.t) option * recursion_order_expr ->
     std_ppcmds
 
+  val pr_record_body : (reference * constr_expr) list -> std_ppcmds
   val pr_binders : local_binder list -> std_ppcmds
   val pr_constr_pattern_expr : constr_pattern_expr -> std_ppcmds
   val pr_lconstr_pattern_expr : constr_pattern_expr -> std_ppcmds

--- a/printing/pptactic.ml
+++ b/printing/pptactic.ml
@@ -1160,7 +1160,7 @@ module Make
           | TacNumgoals ->
             keyword "numgoals"
           | (TacCall _|Tacexp _ | TacGeneric _) as a ->
-            keyword "ltac:" ++ pr_tac (latom,E) (TacArg (Loc.ghost,a))
+            keyword "ltac:" ++ surround (pr_tac ltop (TacArg (Loc.ghost,a)))
 
         in pr_tac
 

--- a/printing/pptactic.ml
+++ b/printing/pptactic.ml
@@ -522,8 +522,9 @@ module Make
     | ipat ->
       spc() ++ prc c ++ pr_as_ipat prdc ipat
 
-  let pr_by_tactic prt tac =
-    spc() ++ keyword "by" ++ spc () ++ prt tac
+  let pr_by_tactic prt = function
+    | Some tac -> keyword "by" ++ spc () ++ prt tac
+    | None -> mt()
 
   let pr_hyp_location pr_id = function
     | occs, InHyp -> spc () ++ pr_with_occurrences pr_id occs
@@ -836,7 +837,7 @@ module Make
           hov 1 (
             primitive (if b then "assert" else "enough") ++
               pr_assumption pr.pr_constr pr.pr_dconstr pr.pr_lconstr ipat c ++
-              pr_by_tactic (pr.pr_tactic ltop) tac
+              pr_non_empty_arg (pr_by_tactic (pr.pr_tactic (ltactical,E))) tac
           )
         | TacAssert (_,None,ipat,c) ->
           hov 1 (
@@ -919,7 +920,7 @@ module Make
           )
 
         (* Equality and inversion *)
-        | TacRewrite (ev,l,cl,by) ->
+        | TacRewrite (ev,l,cl,tac) ->
           hov 1 (
             primitive (with_evars ev "rewrite") ++ spc ()
             ++ prlist_with_sep
@@ -929,11 +930,7 @@ module Make
                   pr_with_bindings_arg_full pr.pr_dconstr pr.pr_dconstr c)
               l
             ++ pr_non_empty_arg (pr_clauses (Some true) pr.pr_name) cl
-            ++ (
-              match by with
-                | Some by -> pr_by_tactic (pr.pr_tactic ltop) by
-                | None -> mt()
-            )
+            ++ pr_non_empty_arg (pr_by_tactic (pr.pr_tactic (ltactical,E))) tac
           )
         | TacInversion (DepInversion (k,c,ids),hyp) ->
           hov 1 (

--- a/printing/pptactic.ml
+++ b/printing/pptactic.ml
@@ -878,7 +878,7 @@ module Make
             ++ spc ()
             ++ prlist_with_sep pr_comma (fun ((clear_flag,h),ids,cl) ->
               pr_clear_flag clear_flag (pr_induction_arg pr.pr_dconstr pr.pr_dconstr) h ++
-                pr_with_induction_names pr.pr_dconstr ids ++
+                pr_non_empty_arg (pr_with_induction_names pr.pr_dconstr) ids ++
                 pr_opt (pr_clauses None pr.pr_name) cl) l ++
               pr_opt pr_eliminator el
           )

--- a/printing/pptactic.ml
+++ b/printing/pptactic.ml
@@ -1406,8 +1406,32 @@ let () =
   Genprint.register_print0 Stdarg.wit_string pr_string pr_string pr_string
 
 let () =
-  let printer _ _ prtac = prtac (0, E) in
+  let printer _ _ prtac = prtac (5, E) in
   declare_extra_genarg_pprule wit_tactic printer printer printer
+
+let () =
+  let printer _ _ prtac = prtac (0, E) in
+  declare_extra_genarg_pprule wit_tactic0 printer printer printer
+
+let () =
+  let printer _ _ prtac = prtac (1, E) in
+  declare_extra_genarg_pprule wit_tactic1 printer printer printer
+
+let () =
+  let printer _ _ prtac = prtac (2, E) in
+  declare_extra_genarg_pprule wit_tactic2 printer printer printer
+
+let () =
+  let printer _ _ prtac = prtac (3, E) in
+  declare_extra_genarg_pprule wit_tactic3 printer printer printer
+
+let () =
+  let printer _ _ prtac = prtac (4, E) in
+  declare_extra_genarg_pprule wit_tactic4 printer printer printer
+
+let () =
+  let printer _ _ prtac = prtac (5, E) in
+  declare_extra_genarg_pprule wit_tactic5 printer printer printer
 
 let () =
   let pr_unit _ _ _ () = str "()" in

--- a/printing/pptactic.ml
+++ b/printing/pptactic.ml
@@ -964,6 +964,13 @@ module Make
 
     let make_pr_tac pr strip_prod_binders tag_atom tag =
 
+        let pr_ltac_constr pr = function
+          | TacArg (_,TacGeneric arg)
+          | TacArg (_,Tacexp (TacArg (_,TacGeneric arg))) as u
+              when argument_type_eq (genarg_tag arg) (ArgumentType wit_constr)
+                -> keyword "constr:" ++ surround (pr u)
+          | u -> pr u in
+
         let extract_binders = function
           | Tacexp (TacFun (lvar,body)) -> (lvar,Tacexp body)
           | body -> ([],body) in
@@ -982,9 +989,10 @@ module Make
               let llc = List.map (fun (id,t) -> (id,extract_binders t)) llc in
               v 0
                 (hv 0 (
-                  pr_let_clauses recflag (pr_tac ltop) llc
+                  pr_let_clauses recflag (pr_ltac_constr (pr_tac ltop)) llc
                   ++ spc () ++ keyword "in"
-                 ) ++ fnl () ++ pr_tac (llet,E) u),
+                 ) ++ fnl ()
+                 ++ pr_ltac_constr (pr_tac (llet,E)) u),
               llet
             | TacMatch (lz,t,lrul) ->
               hov 0 (
@@ -992,7 +1000,7 @@ module Make
                 ++ pr_tac ltop t ++ spc () ++ keyword "with"
                 ++ prlist (fun r ->
                   fnl () ++ str "| "
-                  ++ pr_match_rule true (pr_tac ltop) pr.pr_lpattern r
+                  ++ pr_match_rule true (pr_ltac_constr (pr_tac ltop)) pr.pr_lpattern r
                 ) lrul
                 ++ fnl() ++ keyword "end"),
               lmatch
@@ -1002,14 +1010,14 @@ module Make
                 ++ keyword (if lr then "match reverse goal with" else "match goal with")
                 ++ prlist (fun r ->
                   fnl () ++ str "| "
-                  ++ pr_match_rule false (pr_tac ltop) pr.pr_lpattern r
+                  ++ pr_match_rule false (pr_ltac_constr (pr_tac ltop)) pr.pr_lpattern r
                 ) lrul ++ fnl() ++ keyword "end"),
               lmatch
             | TacFun (lvar,body) ->
               hov 2 (
                 keyword "fun"
                 ++ prlist pr_funvar lvar ++ str " =>" ++ spc ()
-                ++ pr_tac (lfun,E) body),
+                ++ pr_ltac_constr (pr_tac (lfun,E)) body),
               lfun
             | TacThens (t,tl) ->
               hov 1 (

--- a/printing/pptactic.ml
+++ b/printing/pptactic.ml
@@ -201,7 +201,7 @@ module Make
     | ConstrContext ((_,id),c) ->
       hov 0
         (keyword "context" ++ spc () ++ pr_id id ++ spc () ++
-           str "[" ++ prlc c ++ str "]")
+           str "[ " ++ prlc c ++ str " ]")
     | ConstrTypeOf c ->
       hov 1 (keyword "type of" ++ spc() ++ prc c)
     | ConstrTerm c when test c ->

--- a/printing/pptactic.ml
+++ b/printing/pptactic.ml
@@ -478,10 +478,9 @@ module Make
 
   let pr_with_induction_names prc = function
     | None, None -> mt ()
-    | Some eqpat, None -> spc () ++ hov 1 (pr_eqn_ipat eqpat)
-    | None, Some ipat -> spc () ++ hov 1 (pr_as_disjunctive_ipat prc ipat)
+    | Some eqpat, None -> hov 1 (pr_eqn_ipat eqpat)
+    | None, Some ipat -> hov 1 (pr_as_disjunctive_ipat prc ipat)
     | Some eqpat, Some ipat ->
-      spc () ++
         hov 1 (pr_as_disjunctive_ipat prc ipat ++ spc () ++ pr_eqn_ipat eqpat)
 
   let pr_as_intro_pattern prc ipat =

--- a/printing/pptactic.ml
+++ b/printing/pptactic.ml
@@ -578,7 +578,7 @@ module Make
     | ElimOnIdent (loc,id) -> pr_with_comments loc (pr_id id)
     | ElimOnAnonHyp n -> int n
 
-  let pr_induction_kind = function
+  let pr_inversion_kind = function
     | SimpleInversion -> primitive "simple inversion"
     | FullInversion -> primitive "inversion"
     | FullInversionClear -> primitive "inversion_clear"
@@ -933,16 +933,16 @@ module Make
           )
         | TacInversion (DepInversion (k,c,ids),hyp) ->
           hov 1 (
-            primitive "dependent " ++ pr_induction_kind k ++ spc ()
+            primitive "dependent " ++ pr_inversion_kind k ++ spc ()
             ++ pr_quantified_hypothesis hyp
             ++ pr_with_inversion_names pr.pr_dconstr ids
             ++ pr_with_constr pr.pr_constr c
           )
         | TacInversion (NonDepInversion (k,cl,ids),hyp) ->
           hov 1 (
-            pr_induction_kind k ++ spc ()
+            pr_inversion_kind k ++ spc ()
             ++ pr_quantified_hypothesis hyp
-            ++ pr_with_inversion_names pr.pr_dconstr ids
+            ++ pr_non_empty_arg (pr_with_inversion_names pr.pr_dconstr) ids
             ++ pr_non_empty_arg (pr_simple_hyp_clause pr.pr_name) cl
           )
         | TacInversion (InversionUsing (c,cl),hyp) ->

--- a/printing/pptactic.ml
+++ b/printing/pptactic.ml
@@ -77,6 +77,17 @@ let declare_extra_genarg_pprule wit f g h =
   let h prc prlc prtac x = h prc prlc prtac (out_gen (topwit wit) x) in
   genarg_pprule := String.Map.add s (f,g,h) !genarg_pprule
 
+let find_extra_genarg_pprule wit =
+  let s = match wit with
+    | ExtraArg s -> ArgT.repr s
+    | _ -> error
+      "Can declare a pretty-printing rule only for extra argument types."
+  in
+  let (f,g,h) = String.Map.find s !genarg_pprule in
+  (fun prc prlc prtac x -> f prc prlc prtac (in_gen (rawwit wit) x)),
+  (fun prc prlc prtac x -> g prc prlc prtac (in_gen (glbwit wit) x)),
+  (fun prc prlc prtac x -> h prc prlc prtac (in_gen (topwit wit) x))
+
 module Make
   (Ppconstr : Ppconstrsig.Pp)
   (Taggers : sig
@@ -304,7 +315,6 @@ module Make
       | ExtraArg s ->
         try pi1 (String.Map.find (ArgT.repr s) !genarg_pprule) prc prlc prtac (in_gen (rawwit wit) x)
         with Not_found -> Genprint.generic_raw_print (in_gen (rawwit wit) x)
-
 
   let rec pr_glb_generic_rec prc prlc prtac prpat (GenArg (Glbwit wit, x)) =
     match wit with

--- a/printing/pptactic.ml
+++ b/printing/pptactic.ml
@@ -257,8 +257,10 @@ module Make
     | NoBindings -> mt ()
 
   let pr_clear_flag clear_flag pp x =
-    (match clear_flag with Some false -> str "!" | Some true -> str ">" | None -> mt())
-    ++ pp x
+    match clear_flag with
+    | Some false -> surround (pp x)
+    | Some true -> str ">" ++ pp x
+    | None -> pp x
 
   let pr_with_bindings prc prlc (c,bl) =
     prc c ++ pr_bindings prc prlc bl

--- a/printing/pptactic.ml
+++ b/printing/pptactic.ml
@@ -352,9 +352,13 @@ module Make
 
   let rec tacarg_using_rule_token pr_gen = function
     | Egramml.GramTerminal s :: l, al -> keyword s :: tacarg_using_rule_token pr_gen (l,al)
-    | Egramml.GramNonTerminal _ :: l, a :: al ->
+    | Egramml.GramNonTerminal (_,Rawwit wit,e) :: l, a :: al ->
+      let lev = match e,wit with
+        | Extend.Aentryl (_,lev), ExtraArg t when ArgT.repr t = "tactic" -> lev
+        | Extend.Aentry _, ExtraArg t when ArgT.repr t = "tactic" -> 5
+        | _ -> 0 in
       let r = tacarg_using_rule_token pr_gen (l,al) in
-      pr_gen a :: r
+      pr_gen (lev,E) a :: r
     | [], [] -> []
     | _ -> failwith "Inconsistent arguments of extended tactic"
 
@@ -387,7 +391,7 @@ module Make
       in
       let args = match l with
         | [] -> mt ()
-        | _ -> spc() ++ pr_sequence pr_gen l
+        | _ -> spc() ++ pr_sequence (pr_gen (1,Any)) l
       in
       str "<" ++ name ++ str ">" ++ args
 
@@ -399,13 +403,13 @@ module Make
       let p = pr_tacarg_using_rule pr_gen (pp.pptac_prods, l) in
       if pp.pptac_level > lev then surround p else p
     with Not_found ->
-      KerName.print key ++ spc() ++ pr_sequence pr_gen l ++ str" (* Generic printer *)"
+      KerName.print key ++ spc() ++ pr_sequence (pr_gen (1,Any)) l ++ str" (* Generic printer *)"
 
   let check_type t arg = match arg with
   | TacGeneric arg -> argument_type_eq t (genarg_tag arg)
   | _ -> argument_type_eq t (ArgumentType wit_tactic)
 
-  let pr_farg prtac arg = prtac (1, Any) (TacArg (Loc.ghost, arg))
+  let pr_farg prtac lev arg = prtac lev (TacArg (Loc.ghost, arg))
 
   let pr_raw_extend_rec prc prlc prtac prpat =
     pr_extend_gen check_type (pr_farg prtac)

--- a/printing/pptactic.mli
+++ b/printing/pptactic.mli
@@ -41,6 +41,12 @@ val declare_extra_genarg_pprule :
   'b glob_extra_genarg_printer ->
   'c extra_genarg_printer -> unit
 
+val find_extra_genarg_pprule :
+  ('a, 'b, 'c) genarg_type ->
+  'a raw_extra_genarg_printer *
+  'b glob_extra_genarg_printer *
+  'c extra_genarg_printer
+
 type grammar_terminals = Tacexpr.raw_tactic_expr Egramml.grammar_prod_item list
 
 type pp_tactic = {

--- a/printing/pptacticsig.mli
+++ b/printing/pptacticsig.mli
@@ -44,9 +44,9 @@ module type Pp = sig
     ml_tactic_entry -> glob_tactic_arg list -> std_ppcmds
 
   val pr_extend :
-    (Val.t -> std_ppcmds) -> int -> ml_tactic_entry -> Val.t list -> std_ppcmds
+    (tolerability -> Val.t -> std_ppcmds) -> int -> ml_tactic_entry -> Val.t list -> std_ppcmds
 
-  val pr_alias : (Val.t -> std_ppcmds) ->
+  val pr_alias : (tolerability -> Val.t -> std_ppcmds) ->
     int -> Names.KerName.t -> Val.t list -> std_ppcmds
 
   val pr_ltac_constant : Nametab.ltac_constant -> std_ppcmds

--- a/printing/ppvernac.ml
+++ b/printing/ppvernac.ml
@@ -1001,7 +1001,7 @@ module Make
           return (
             hov 2
               (keyword "Notation" ++ spc () ++ pr_lident id ++ spc () ++
-                 prlist (fun x -> spc() ++ pr_id x) ids ++ str":=" ++ pr_constrarg c ++
+                 prlist_with_sep spc pr_id ids ++ str":=" ++ pr_constrarg c ++
                  pr_syntax_modifiers
                  (match onlyparsing with None -> [] | Some v -> [SetOnlyParsing v]))
           )

--- a/printing/ppvernac.ml
+++ b/printing/ppvernac.ml
@@ -86,10 +86,6 @@ module Make
   let sep = fun _ -> spc()
   let sep_v2 = fun _ -> str"," ++ spc()
 
-  let pr_ne_sep sep pr = function
-  [] -> mt()
-    | l -> sep() ++ pr l
-
   let pr_set_entry_type = function
     | ETName -> str"ident"
     | ETReference -> str"global"
@@ -271,7 +267,7 @@ module Make
       pr_opt (fun sc -> str ": " ++ str sc) scopt
 
   let pr_binders_arg =
-    pr_ne_sep spc pr_binders
+    pr_non_empty_arg pr_binders
 
   let pr_and_type_binders_arg bl =
     pr_binders_arg bl

--- a/printing/ppvernac.ml
+++ b/printing/ppvernac.ml
@@ -895,9 +895,12 @@ module Make
                  | (_, Anonymous), _ -> mt ()) ++
                 pr_and_type_binders_arg sup ++
                 str":" ++ spc () ++
+                (match bk with Implicit -> str "! " | Explicit -> mt ()) ++
                 pr_constr cl ++ pr_priority pri ++
                 (match props with
-                  | Some (_,p) -> spc () ++ str":=" ++ spc () ++ pr_constr p
+                  | Some (true,CRecord (_,l)) -> spc () ++ str":=" ++ spc () ++ str"{" ++ pr_record_body l ++ str "}"
+                  | Some (true,_) -> assert false
+                  | Some (false,p) -> spc () ++ str":=" ++ spc () ++ pr_constr p
                   | None -> mt()))
           )
 

--- a/printing/ppvernac.ml
+++ b/printing/ppvernac.ml
@@ -518,7 +518,7 @@ module Make
       match v with
         | VernacPolymorphic (poly, v) ->
           let s = if poly then keyword "Polymorphic" else keyword "Monomorphic" in
-          return (s ++ pr_vernac v)
+          return (s ++ spc () ++ pr_vernac v)
         | VernacProgram v ->
           return (keyword "Program" ++ spc() ++ pr_vernac v)
         | VernacLocal (local, v) ->

--- a/printing/ppvernac.ml
+++ b/printing/ppvernac.ml
@@ -1237,13 +1237,13 @@ module Make
       with Failure _ -> str "<error in " ++ str (fst s) ++ str ">" in
     try
       let rl = Egramml.get_extend_vernac_rule s in
-      let rec aux sep rl cl =
+      let rec aux rl cl =
         match rl, cl with
-        | Egramml.GramNonTerminal (_,_,e) :: rl, (GenArg (wit,x)) :: cl -> pr_based_on_grammar (GenArg (wit,x),EntryName e) :: aux sep rl cl
-        | Egramml.GramTerminal s :: rl, cl -> sep() ++ str s :: aux spc rl cl
+        | Egramml.GramNonTerminal (_,_,e) :: rl, (GenArg (wit,x)) :: cl -> pr_based_on_grammar (GenArg (wit,x),EntryName e) :: aux rl cl
+        | Egramml.GramTerminal s :: rl, cl -> str s :: aux rl cl
         | [], [] -> []
         | _ -> assert false in
-      hov 1 (pr_sequence (fun x -> x) (aux mt rl cl))
+      hov 1 (pr_sequence (fun x -> x) (aux rl cl))
     with Not_found ->
       hov 1 (str "TODO(" ++ str (fst s) ++ spc () ++ prlist_with_sep sep pr_based_on_structure cl ++ str ")")
 

--- a/printing/ppvernac.ml
+++ b/printing/ppvernac.ml
@@ -1196,7 +1196,7 @@ module Make
             | Dash n -> str (String.make n '-')
             | Star n -> str (String.make n '*')
             | Plus n -> str (String.make n '+')
-          end ++ spc())
+          end)
         | VernacSubproof None ->
           return (str "{")
         | VernacSubproof (Some i) ->

--- a/printing/ppvernac.ml
+++ b/printing/ppvernac.ml
@@ -230,6 +230,11 @@ module Make
     | NoInline -> str "[no inline]"
     | InlineAt i -> str "[inline at level " ++ int i ++ str "]"
 
+  let pr_assumption_inline = function
+    | DefaultInline -> str "Inline"
+    | NoInline -> mt ()
+    | InlineAt i -> str "Inline(" ++ int i ++ str ")"
+
   let pr_module_ast_inl leading_space pr_c (mast,inl) =
     pr_module_ast leading_space pr_c mast ++ pr_inline inl
 
@@ -737,14 +742,14 @@ module Make
         )
         | VernacExactProof c ->
           return (hov 2 (keyword "Proof" ++ pr_lconstrarg c))
-        | VernacAssumption (stre,_,l) ->
+        | VernacAssumption (stre,t,l) ->
           let n = List.length (List.flatten (List.map fst (List.map snd l))) in
           let pr_params (c, (xl, t)) =
             hov 2 (prlist_with_sep sep pr_plident xl ++ spc() ++
-              (if c then str":>" else str":" ++ spc() ++ pr_lconstr_expr t))
-          in
+              (if c then str":>" else str":" ++ spc() ++ pr_lconstr_expr t)) in
           let assumptions = prlist_with_sep spc (fun p -> hov 1 (str "(" ++ pr_params p ++ str ")")) l in
-          return (hov 2 (pr_assumption_token (n > 1) stre ++ spc() ++ assumptions))
+          return (hov 2 (pr_assumption_token (n > 1) stre ++
+                         pr_non_empty_arg pr_assumption_inline t ++ spc() ++ assumptions))
         | VernacInductive (p,f,l) ->
           let pr_constructor (coe,(id,c)) =
             hov 2 (pr_lident id ++ str" " ++
@@ -930,14 +935,14 @@ module Make
                      pr_lident m ++ b ++
                      pr_of_module_type pr_lconstr tys ++
                      (if List.is_empty bd then mt () else str ":= ") ++
-                     prlist_with_sep (fun () -> str " <+ ")
+                     prlist_with_sep (fun () -> str " <+")
                      (pr_module_ast_inl true pr_lconstr) bd)
           )
         | VernacDeclareModule (export,id,bl,m1) ->
           let b = pr_module_binders bl pr_lconstr in
           return (
             hov 2 (keyword "Declare Module" ++ spc() ++ pr_require_token export ++
-                     pr_lident id ++ b ++
+                     pr_lident id ++ b ++ str " :" ++
                      pr_module_ast_inl true pr_lconstr m1)
           )
         | VernacDeclareModuleType (id,bl,tyl,m) ->
@@ -945,7 +950,7 @@ module Make
           let pr_mt = pr_module_ast_inl true pr_lconstr in
           return (
             hov 2 (keyword "Module Type " ++ pr_lident id ++ b ++
-                     prlist_strict (fun m -> str " <: " ++ pr_mt m) tyl ++
+                     prlist_strict (fun m -> str " <:" ++ pr_mt m) tyl ++
                      (if List.is_empty m then mt () else str ":= ") ++
                      prlist_with_sep (fun () -> str " <+ ") pr_mt m)
           )

--- a/printing/ppvernac.ml
+++ b/printing/ppvernac.ml
@@ -34,6 +34,8 @@ module Make
 
   let keyword s = tag_keyword (str s)
 
+  let pr_constr = pr_constr_expr
+  let pr_lconstr = pr_lconstr_expr
   let pr_spc_lconstr = pr_sep_com spc pr_lconstr_expr
 
   let pr_lident (loc,id) =
@@ -399,835 +401,828 @@ module Make
 (**************************************)
 (* Pretty printer for vernac commands *)
 (**************************************)
-  let make_pr_vernac pr_constr pr_lconstr =
-    let pr_constrarg c = spc () ++ pr_constr c in
-    let pr_lconstrarg c = spc () ++ pr_lconstr c in
-    let pr_intarg n = spc () ++ int n in
-    let pr_oc = function
-    None -> str" :"
-      | Some true -> str" :>"
-      | Some false -> str" :>>"
-    in
-    let pr_record_field ((x, pri), ntn) =
-      let prx = match x with
-        | (oc,AssumExpr (id,t)) ->
-          hov 1 (pr_lname id ++
-                   pr_oc oc ++ spc() ++
-                   pr_lconstr_expr t)
-        | (oc,DefExpr(id,b,opt)) -> (match opt with
-            | Some t ->
-              hov 1 (pr_lname id ++
-                       pr_oc oc ++ spc() ++
-                       pr_lconstr_expr t ++ str" :=" ++ pr_lconstr b)
-            | None ->
-              hov 1 (pr_lname id ++ str" :=" ++ spc() ++
-                       pr_lconstr b)) in
-      let prpri = match pri with None -> mt() | Some i -> str "| " ++ int i in
-      prx ++ prpri ++ prlist (pr_decl_notation pr_constr) ntn
-    in
-    let pr_record_decl b c fs =
-      pr_opt pr_lident c ++ (if c = None then str"{" else str" {") ++
-        hv 0 (prlist_with_sep pr_semicolon pr_record_field fs ++ str"}")
-    in
 
-    let pr_printable = function
-      | PrintFullContext ->
-        keyword "Print All"
-      | PrintSectionContext s ->
-        keyword "Print Section" ++ spc() ++ Libnames.pr_reference s
-      | PrintGrammar ent ->
-        keyword "Print Grammar" ++ spc() ++ str ent
-      | PrintLoadPath dir ->
-        keyword "Print LoadPath" ++ pr_opt pr_dirpath dir
-      | PrintModules ->
-        keyword "Print Modules"
-      | PrintMLLoadPath ->
-        keyword "Print ML Path"
-      | PrintMLModules ->
-        keyword "Print ML Modules"
-      | PrintDebugGC ->
-        keyword "Print ML GC"
-      | PrintGraph ->
-        keyword "Print Graph"
-      | PrintClasses ->
-        keyword "Print Classes"
-      | PrintTypeClasses ->
-        keyword "Print TypeClasses"
-      | PrintInstances qid ->
-        keyword "Print Instances" ++ spc () ++ pr_smart_global qid
-      | PrintCoercions ->
-        keyword "Print Coercions"
-      | PrintCoercionPaths (s,t) ->
-        keyword "Print Coercion Paths" ++ spc()
-        ++ pr_class_rawexpr s ++ spc()
-        ++ pr_class_rawexpr t
-      | PrintCanonicalConversions ->
-        keyword "Print Canonical Structures"
-      | PrintTables ->
-        keyword "Print Tables"
-      | PrintHintGoal ->
-        keyword "Print Hint"
-      | PrintHint qid ->
-        keyword "Print Hint" ++ spc () ++ pr_smart_global qid
-      | PrintHintDb ->
-        keyword "Print Hint *"
-      | PrintHintDbName s ->
-        keyword "Print HintDb" ++ spc () ++ str s
-      | PrintUniverses (b, fopt) ->
-        let cmd =
-          if b then "Print Sorted Universes"
-          else "Print Universes"
-        in
-        keyword cmd ++ pr_opt str fopt
-      | PrintName qid ->
-        keyword "Print" ++ spc()  ++ pr_smart_global qid
-      | PrintModuleType qid ->
-        keyword "Print Module Type" ++ spc() ++ pr_reference qid
-      | PrintModule qid ->
-        keyword "Print Module" ++ spc() ++ pr_reference qid
-      | PrintInspect n ->
-        keyword "Inspect" ++ spc() ++ int n
-      | PrintScopes ->
-        keyword "Print Scopes"
-      | PrintScope s ->
-        keyword "Print Scope" ++ spc() ++ str s
-      | PrintVisibility s ->
-        keyword "Print Visibility" ++ pr_opt str s
-      | PrintAbout (qid,gopt) ->
-         pr_opt (fun g -> int g ++ str ":"++ spc()) gopt
-	 ++ keyword "About" ++ spc()  ++ pr_smart_global qid
-      | PrintImplicit qid ->
-        keyword "Print Implicit" ++ spc()  ++ pr_smart_global qid
-      (* spiwack: command printing all the axioms and section variables used in a
-         term *)
-      | PrintAssumptions (b, t, qid) ->
-        let cmd = match b, t with
-          | true, true -> "Print All Dependencies"
-          | true, false -> "Print Opaque Dependencies"
-          | false, true -> "Print Transparent Dependencies"
-          | false, false -> "Print Assumptions"
-        in
-        keyword cmd ++ spc() ++ pr_smart_global qid
-      | PrintNamespace dp ->
-        keyword "Print Namespace" ++ pr_dirpath dp
-      | PrintStrategy None ->
-        keyword "Print Strategies"
-      | PrintStrategy (Some qid) ->
-        keyword "Print Strategy" ++ pr_smart_global qid
-    in
+  let pr_constrarg c = spc () ++ pr_constr c
+  let pr_lconstrarg c = spc () ++ pr_lconstr c
+  let pr_intarg n = spc () ++ int n
 
-    let pr_using e = str (Proof_using.to_string e) in
+  let pr_oc = function
+    | None -> str" :"
+    | Some true -> str" :>"
+    | Some false -> str" :>>"
 
-    let rec pr_vernac v =
-      let return = Taggers.tag_vernac v in
-      match v with
-        | VernacPolymorphic (poly, v) ->
-          let s = if poly then keyword "Polymorphic" else keyword "Monomorphic" in
-          return (s ++ spc () ++ pr_vernac v)
-        | VernacProgram v ->
-          return (keyword "Program" ++ spc() ++ pr_vernac v)
-        | VernacLocal (local, v) ->
-          return (pr_locality local ++ spc() ++ pr_vernac v)
+  let pr_record_field ((x, pri), ntn) =
+    let prx = match x with
+      | (oc,AssumExpr (id,t)) ->
+        hov 1 (pr_lname id ++
+                 pr_oc oc ++ spc() ++
+                 pr_lconstr_expr t)
+      | (oc,DefExpr(id,b,opt)) -> (match opt with
+          | Some t ->
+            hov 1 (pr_lname id ++
+                     pr_oc oc ++ spc() ++
+                     pr_lconstr_expr t ++ str" :=" ++ pr_lconstr b)
+          | None ->
+            hov 1 (pr_lname id ++ str" :=" ++ spc() ++
+                     pr_lconstr b)) in
+    let prpri = match pri with None -> mt() | Some i -> str "| " ++ int i in
+    prx ++ prpri ++ prlist (pr_decl_notation pr_constr) ntn
 
-        (* Stm *)
-        | VernacStm JoinDocument ->
-          return (keyword "Stm JoinDocument")
-        | VernacStm PrintDag ->
-          return (keyword "Stm PrintDag")
-        | VernacStm Finish ->
-          return (keyword "Stm Finish")
-        | VernacStm Wait ->
-          return (keyword "Stm Wait")
-        | VernacStm (Observe id) ->
-          return (keyword "Stm Observe " ++ str(Stateid.to_string id))
-        | VernacStm (Command v) ->
-          return (keyword "Stm Command " ++ pr_vernac v)
-        | VernacStm (PGLast v) ->
-          return (keyword "Stm PGLast " ++ pr_vernac v)
+  let pr_record_decl b c fs =
+    pr_opt pr_lident c ++ (if c = None then str"{" else str" {") ++
+      hv 0 (prlist_with_sep pr_semicolon pr_record_field fs ++ str"}")
 
-        (* Proof management *)
-        | VernacAbortAll ->
-          return (keyword "Abort All")
-        | VernacRestart ->
-          return (keyword "Restart")
-        | VernacUnfocus ->
-          return (keyword "Unfocus")
-        | VernacUnfocused ->
-          return (keyword "Unfocused")
-        | VernacGoal c ->
-          return (keyword "Goal" ++ pr_lconstrarg c)
-        | VernacAbort id ->
-          return (keyword "Abort" ++ pr_opt pr_lident id)
-        | VernacUndo i ->
-          return (
-            if Int.equal i 1 then keyword "Undo" else keyword "Undo" ++ pr_intarg i
-          )
-        | VernacUndoTo i ->
-          return (keyword "Undo" ++ spc() ++ keyword "To" ++ pr_intarg i)
-        | VernacBacktrack (i,j,k) ->
-          return (keyword "Backtrack" ++  spc() ++ prlist_with_sep sep int [i;j;k])
-        | VernacFocus i ->
-          return (keyword "Focus" ++ pr_opt int i)
-        | VernacShow s ->
-          let pr_goal_reference = function
-            | OpenSubgoals -> mt ()
-            | NthGoal n -> spc () ++ int n
-            | GoalId id -> spc () ++ pr_id id
-            | GoalUid n -> spc () ++ str n in
-          let pr_showable = function
-            | ShowGoal n -> keyword "Show" ++ pr_goal_reference n
-            | ShowGoalImplicitly n -> keyword "Show Implicit Arguments" ++ pr_opt int n
-            | ShowProof -> keyword "Show Proof"
-            | ShowNode -> keyword "Show Node"
-            | ShowScript -> keyword "Show Script"
-            | ShowExistentials -> keyword "Show Existentials"
-            | ShowUniverses -> keyword "Show Universes"
-            | ShowTree -> keyword "Show Tree"
-            | ShowProofNames -> keyword "Show Conjectures"
-            | ShowIntros b -> keyword "Show " ++ (if b then keyword "Intros" else keyword "Intro")
-            | ShowMatch id -> keyword "Show Match " ++ pr_lident id
-            | ShowThesis -> keyword "Show Thesis"
-          in
-          return (pr_showable s)
-        | VernacCheckGuard ->
-          return (keyword "Guarded")
+  let pr_printable = function
+    | PrintFullContext ->
+      keyword "Print All"
+    | PrintSectionContext s ->
+      keyword "Print Section" ++ spc() ++ Libnames.pr_reference s
+    | PrintGrammar ent ->
+      keyword "Print Grammar" ++ spc() ++ str ent
+    | PrintLoadPath dir ->
+      keyword "Print LoadPath" ++ pr_opt pr_dirpath dir
+    | PrintModules ->
+      keyword "Print Modules"
+    | PrintMLLoadPath ->
+      keyword "Print ML Path"
+    | PrintMLModules ->
+      keyword "Print ML Modules"
+    | PrintDebugGC ->
+      keyword "Print ML GC"
+    | PrintGraph ->
+      keyword "Print Graph"
+    | PrintClasses ->
+      keyword "Print Classes"
+    | PrintTypeClasses ->
+      keyword "Print TypeClasses"
+    | PrintInstances qid ->
+      keyword "Print Instances" ++ spc () ++ pr_smart_global qid
+    | PrintCoercions ->
+      keyword "Print Coercions"
+    | PrintCoercionPaths (s,t) ->
+      keyword "Print Coercion Paths" ++ spc()
+      ++ pr_class_rawexpr s ++ spc()
+      ++ pr_class_rawexpr t
+    | PrintCanonicalConversions ->
+      keyword "Print Canonical Structures"
+    | PrintTables ->
+      keyword "Print Tables"
+    | PrintHintGoal ->
+      keyword "Print Hint"
+    | PrintHint qid ->
+      keyword "Print Hint" ++ spc () ++ pr_smart_global qid
+    | PrintHintDb ->
+      keyword "Print Hint *"
+    | PrintHintDbName s ->
+      keyword "Print HintDb" ++ spc () ++ str s
+    | PrintUniverses (b, fopt) ->
+      let cmd =
+        if b then "Print Sorted Universes"
+        else "Print Universes"
+      in
+      keyword cmd ++ pr_opt str fopt
+    | PrintName qid ->
+      keyword "Print" ++ spc()  ++ pr_smart_global qid
+    | PrintModuleType qid ->
+      keyword "Print Module Type" ++ spc() ++ pr_reference qid
+    | PrintModule qid ->
+      keyword "Print Module" ++ spc() ++ pr_reference qid
+    | PrintInspect n ->
+      keyword "Inspect" ++ spc() ++ int n
+    | PrintScopes ->
+      keyword "Print Scopes"
+    | PrintScope s ->
+      keyword "Print Scope" ++ spc() ++ str s
+    | PrintVisibility s ->
+      keyword "Print Visibility" ++ pr_opt str s
+    | PrintAbout (qid,gopt) ->
+       pr_opt (fun g -> int g ++ str ":"++ spc()) gopt
+       ++ keyword "About" ++ spc()  ++ pr_smart_global qid
+    | PrintImplicit qid ->
+      keyword "Print Implicit" ++ spc()  ++ pr_smart_global qid
+    (* spiwack: command printing all the axioms and section variables used in a
+       term *)
+    | PrintAssumptions (b, t, qid) ->
+      let cmd = match b, t with
+        | true, true -> "Print All Dependencies"
+        | true, false -> "Print Opaque Dependencies"
+        | false, true -> "Print Transparent Dependencies"
+        | false, false -> "Print Assumptions"
+      in
+      keyword cmd ++ spc() ++ pr_smart_global qid
+    | PrintNamespace dp ->
+      keyword "Print Namespace" ++ pr_dirpath dp
+    | PrintStrategy None ->
+      keyword "Print Strategies"
+    | PrintStrategy (Some qid) ->
+      keyword "Print Strategy" ++ pr_smart_global qid
 
-      (* Resetting *)
-        | VernacResetName id ->
-          return (keyword "Reset" ++ spc() ++ pr_lident id)
-        | VernacResetInitial ->
-          return (keyword "Reset Initial")
-        | VernacBack i ->
-          return (
-            if Int.equal i 1 then keyword "Back" else keyword "Back" ++ pr_intarg i
-          )
-        | VernacBackTo i ->
-          return (keyword "BackTo" ++ pr_intarg i)
+  let pr_using e = str (Proof_using.to_string e)
 
-      (* State management *)
-        | VernacWriteState s ->
-          return (keyword "Write State" ++ spc () ++ qs s)
-        | VernacRestoreState s ->
-          return  (keyword "Restore State" ++ spc() ++ qs s)
+  let rec pr_vernac_body v =
+    let return = Taggers.tag_vernac v in
+    match v with
+      | VernacPolymorphic (poly, v) ->
+        let s = if poly then keyword "Polymorphic" else keyword "Monomorphic" in
+        return (s ++ spc () ++ pr_vernac_body v)
+      | VernacProgram v ->
+        return (keyword "Program" ++ spc() ++ pr_vernac_body v)
+      | VernacLocal (local, v) ->
+        return (pr_locality local ++ spc() ++ pr_vernac_body v)
 
-      (* Control *)
-        | VernacLoad (f,s) ->
-          return (
-            keyword "Load"
-            ++ if f then
-                (spc() ++ keyword "Verbose" ++ spc())
-              else
-                spc() ++ qs s
-          )
-        | VernacTime (_,v) ->
-          return (keyword "Time" ++ spc() ++ pr_vernac v)
-        | VernacRedirect (s, (_,v)) ->
-          return (keyword "Redirect" ++ spc() ++ qs s ++ spc() ++ pr_vernac v)
-        | VernacTimeout(n,v) ->
-          return (keyword "Timeout " ++ int n ++ spc() ++ pr_vernac v)
-        | VernacFail v ->
-          return (keyword "Fail" ++ spc() ++ pr_vernac v)
-        | VernacError _ ->
-          return (keyword "No-parsing-rule for VernacError")
+      (* Stm *)
+      | VernacStm JoinDocument ->
+        return (keyword "Stm JoinDocument")
+      | VernacStm PrintDag ->
+        return (keyword "Stm PrintDag")
+      | VernacStm Finish ->
+        return (keyword "Stm Finish")
+      | VernacStm Wait ->
+        return (keyword "Stm Wait")
+      | VernacStm (Observe id) ->
+        return (keyword "Stm Observe " ++ str(Stateid.to_string id))
+      | VernacStm (Command v) ->
+        return (keyword "Stm Command " ++ pr_vernac_body v)
+      | VernacStm (PGLast v) ->
+        return (keyword "Stm PGLast " ++ pr_vernac_body v)
 
-      (* Syntax *)
-        | VernacOpenCloseScope (_,(opening,sc)) ->
-          return (
-            keyword (if opening then "Open " else "Close ") ++
-              keyword "Scope" ++ spc() ++ str sc
-          )
-        | VernacDelimiters (sc,Some key) ->
-          return (
-            keyword "Delimit Scope" ++ spc () ++ str sc ++
-              spc() ++ keyword "with" ++ spc () ++ str key
-          )
-        | VernacDelimiters (sc, None) ->
-          return (
-            keyword "Undelimit Scope" ++ spc () ++ str sc
-          )
-        | VernacBindScope (sc,cll) ->
-          return (
-            keyword "Bind Scope" ++ spc () ++ str sc ++
-              spc() ++ keyword "with" ++ spc () ++ prlist_with_sep spc pr_class_rawexpr cll
-          )
-        | VernacArgumentsScope (q,scl) ->
-          let pr_opt_scope = function
-            | None -> str"_"
-            | Some sc -> str sc
-          in
-          return (
-            keyword "Arguments Scope"
-            ++ spc() ++ pr_smart_global q
-            ++ spc() ++ str"[" ++ prlist_with_sep sep pr_opt_scope scl ++ str"]"
-          )
-        | VernacInfix (_,((_,s),mv),q,sn) -> (* A Verifier *)
-          return (
-            hov 0 (hov 0 (keyword "Infix "
-                          ++ qs s ++ str " :=" ++ pr_constrarg q) ++
-                     pr_syntax_modifiers mv ++
-                     (match sn with
-                       | None -> mt()
-                       | Some sc -> spc() ++ str":" ++ spc() ++ str sc))
-          )
-        | VernacNotation (_,c,((_,s),l),opt) ->
-          return (
-            hov 2 (keyword "Notation" ++ spc() ++ qs s ++
-                     str " :=" ++ Flags.without_option Flags.beautify_file pr_constrarg c ++ pr_syntax_modifiers l ++
-                     (match opt with
-                       | None -> mt()
-                       | Some sc -> str" :" ++ spc() ++ str sc))
-          )
-        | VernacSyntaxExtension (_,(s,l)) ->
-          return (
-            keyword "Reserved Notation" ++ spc() ++ pr_located qs s ++
-              pr_syntax_modifiers l
-          )
-        | VernacNotationAddFormat(s,k,v) ->
-          return (
-            keyword "Format Notation " ++ qs s ++ spc () ++ qs k ++ spc() ++ qs v
-          )
-
-        (* Gallina *)
-        | VernacDefinition (d,id,b) -> (* A verifier... *)
-          let pr_def_token (l,dk) =
-            let l = match l with Some x -> x | None -> Decl_kinds.Global in
-            keyword (Kindops.string_of_definition_kind (l,false,dk))
-          in
-          let pr_reduce = function
-            | None -> mt()
-            | Some r ->
-              keyword "Eval" ++ spc() ++
-                pr_red_expr (pr_constr, pr_lconstr, pr_smart_global, pr_constr) r ++
-                keyword " in" ++ spc()
-          in
-          let pr_def_body = function
-            | DefineBody (bl,red,body,d) ->
-              let ty = match d with
-                | None -> mt()
-                | Some ty -> spc() ++ str":" ++ pr_spc_lconstr ty
-              in
-              (pr_binders_arg bl,ty,Some (pr_reduce red ++ pr_lconstr body))
-            | ProveBody (bl,t) ->
-              (pr_binders_arg bl, str" :" ++ pr_spc_lconstr t, None) in
-          let (binds,typ,c) = pr_def_body b in
-          return (
-            hov 2 (
-              pr_def_token d ++ spc()
-              ++ pr_plident id ++ binds ++ typ
-              ++ (match c with
-                | None -> mt()
-                | Some cc -> str" :=" ++ spc() ++ cc))
-          )
-
-        | VernacStartTheoremProof (ki,l,_) ->
-          return (
-            hov 1 (pr_statement (pr_thm_token ki) (List.hd l) ++
-                     prlist (pr_statement (spc () ++ keyword "with")) (List.tl l))
-          )
-
-        | VernacEndProof Admitted ->
-          return (keyword "Admitted")
-
-        | VernacEndProof (Proved (opac,o)) -> return (
-          match o with
-            | None -> (match opac with
-                | Transparent -> keyword "Defined"
-                | Opaque None -> keyword "Qed"
-                | Opaque (Some l) ->
-                    keyword "Qed" ++ spc() ++ str"export" ++
-                      prlist_with_sep (fun () -> str", ") pr_lident l)
-            | Some (id,th) -> (match th with
-                | None -> (if opac <> Transparent then keyword "Save" else keyword "Defined") ++ spc() ++ pr_lident id
-                | Some tok -> keyword "Save" ++ spc() ++ pr_thm_token tok ++ spc() ++ pr_lident id)
+      (* Proof management *)
+      | VernacAbortAll ->
+        return (keyword "Abort All")
+      | VernacRestart ->
+        return (keyword "Restart")
+      | VernacUnfocus ->
+        return (keyword "Unfocus")
+      | VernacUnfocused ->
+        return (keyword "Unfocused")
+      | VernacGoal c ->
+        return (keyword "Goal" ++ pr_lconstrarg c)
+      | VernacAbort id ->
+        return (keyword "Abort" ++ pr_opt pr_lident id)
+      | VernacUndo i ->
+        return (
+          if Int.equal i 1 then keyword "Undo" else keyword "Undo" ++ pr_intarg i
         )
-        | VernacExactProof c ->
-          return (hov 2 (keyword "Proof" ++ pr_lconstrarg c))
-        | VernacAssumption (stre,t,l) ->
-          let n = List.length (List.flatten (List.map fst (List.map snd l))) in
-          let pr_params (c, (xl, t)) =
-            hov 2 (prlist_with_sep sep pr_plident xl ++ spc() ++
-              (if c then str":>" else str":" ++ spc() ++ pr_lconstr_expr t)) in
-          let assumptions = prlist_with_sep spc (fun p -> hov 1 (str "(" ++ pr_params p ++ str ")")) l in
-          return (hov 2 (pr_assumption_token (n > 1) stre ++
-                         pr_non_empty_arg pr_assumption_inline t ++ spc() ++ assumptions))
-        | VernacInductive (p,f,l) ->
-          let pr_constructor (coe,(id,c)) =
-            hov 2 (pr_lident id ++ str" " ++
-                     (if coe then str":>" else str":") ++
-                     Flags.without_option Flags.beautify_file pr_spc_lconstr c)
-          in
-          let pr_constructor_list b l = match l with
-            | Constructors [] -> mt()
-            | Constructors l ->
-              let fst_sep = match l with [_] -> "   " | _ -> " | " in
-              pr_com_at (begin_of_inductive l) ++
-                fnl() ++ str fst_sep ++
-                prlist_with_sep (fun _ -> fnl() ++ str" | ") pr_constructor l
-            | RecordDecl (c,fs) ->
-              pr_record_decl b c fs
-          in
-          let pr_oneind key (((coe,(id,pl)),indpar,s,k,lc),ntn) =
-            hov 0 (
-              str key ++ spc() ++
-                (if coe then str"> " else str"") ++ pr_lident id ++ pr_univs pl ++
-                pr_and_type_binders_arg indpar ++
-                pr_opt (fun s -> str":" ++ spc() ++ pr_lconstr_expr s) s ++
-                str" :=") ++ pr_constructor_list k lc ++
+      | VernacUndoTo i ->
+        return (keyword "Undo" ++ spc() ++ keyword "To" ++ pr_intarg i)
+      | VernacBacktrack (i,j,k) ->
+        return (keyword "Backtrack" ++  spc() ++ prlist_with_sep sep int [i;j;k])
+      | VernacFocus i ->
+        return (keyword "Focus" ++ pr_opt int i)
+      | VernacShow s ->
+        let pr_goal_reference = function
+          | OpenSubgoals -> mt ()
+          | NthGoal n -> spc () ++ int n
+          | GoalId id -> spc () ++ pr_id id
+          | GoalUid n -> spc () ++ str n in
+        let pr_showable = function
+          | ShowGoal n -> keyword "Show" ++ pr_goal_reference n
+          | ShowGoalImplicitly n -> keyword "Show Implicit Arguments" ++ pr_opt int n
+          | ShowProof -> keyword "Show Proof"
+          | ShowNode -> keyword "Show Node"
+          | ShowScript -> keyword "Show Script"
+          | ShowExistentials -> keyword "Show Existentials"
+          | ShowUniverses -> keyword "Show Universes"
+          | ShowTree -> keyword "Show Tree"
+          | ShowProofNames -> keyword "Show Conjectures"
+          | ShowIntros b -> keyword "Show " ++ (if b then keyword "Intros" else keyword "Intro")
+          | ShowMatch id -> keyword "Show Match " ++ pr_lident id
+          | ShowThesis -> keyword "Show Thesis"
+        in
+        return (pr_showable s)
+      | VernacCheckGuard ->
+        return (keyword "Guarded")
+
+    (* Resetting *)
+      | VernacResetName id ->
+        return (keyword "Reset" ++ spc() ++ pr_lident id)
+      | VernacResetInitial ->
+        return (keyword "Reset Initial")
+      | VernacBack i ->
+        return (
+          if Int.equal i 1 then keyword "Back" else keyword "Back" ++ pr_intarg i
+        )
+      | VernacBackTo i ->
+        return (keyword "BackTo" ++ pr_intarg i)
+
+    (* State management *)
+      | VernacWriteState s ->
+        return (keyword "Write State" ++ spc () ++ qs s)
+      | VernacRestoreState s ->
+        return  (keyword "Restore State" ++ spc() ++ qs s)
+
+    (* Control *)
+      | VernacLoad (f,s) ->
+        return (
+          keyword "Load"
+          ++ if f then
+              (spc() ++ keyword "Verbose" ++ spc())
+            else
+              spc() ++ qs s
+        )
+      | VernacTime (_,v) ->
+        return (keyword "Time" ++ spc() ++ pr_vernac_body v)
+      | VernacRedirect (s, (_,v)) ->
+        return (keyword "Redirect" ++ spc() ++ qs s ++ spc() ++ pr_vernac_body v)
+      | VernacTimeout(n,v) ->
+        return (keyword "Timeout " ++ int n ++ spc() ++ pr_vernac_body v)
+      | VernacFail v ->
+        return (keyword "Fail" ++ spc() ++ pr_vernac_body v)
+      | VernacError _ ->
+        return (keyword "No-parsing-rule for VernacError")
+
+    (* Syntax *)
+      | VernacOpenCloseScope (_,(opening,sc)) ->
+        return (
+          keyword (if opening then "Open " else "Close ") ++
+            keyword "Scope" ++ spc() ++ str sc
+        )
+      | VernacDelimiters (sc,Some key) ->
+        return (
+          keyword "Delimit Scope" ++ spc () ++ str sc ++
+            spc() ++ keyword "with" ++ spc () ++ str key
+        )
+      | VernacDelimiters (sc, None) ->
+        return (
+          keyword "Undelimit Scope" ++ spc () ++ str sc
+        )
+      | VernacBindScope (sc,cll) ->
+        return (
+          keyword "Bind Scope" ++ spc () ++ str sc ++
+            spc() ++ keyword "with" ++ spc () ++ prlist_with_sep spc pr_class_rawexpr cll
+        )
+      | VernacArgumentsScope (q,scl) ->
+        let pr_opt_scope = function
+          | None -> str"_"
+          | Some sc -> str sc
+        in
+        return (
+          keyword "Arguments Scope"
+          ++ spc() ++ pr_smart_global q
+          ++ spc() ++ str"[" ++ prlist_with_sep sep pr_opt_scope scl ++ str"]"
+        )
+      | VernacInfix (_,((_,s),mv),q,sn) -> (* A Verifier *)
+        return (
+          hov 0 (hov 0 (keyword "Infix "
+                        ++ qs s ++ str " :=" ++ pr_constrarg q) ++
+                   pr_syntax_modifiers mv ++
+                   (match sn with
+                     | None -> mt()
+                     | Some sc -> spc() ++ str":" ++ spc() ++ str sc))
+        )
+      | VernacNotation (_,c,((_,s),l),opt) ->
+        return (
+          hov 2 (keyword "Notation" ++ spc() ++ qs s ++
+                   str " :=" ++ Flags.without_option Flags.beautify_file pr_constrarg c ++ pr_syntax_modifiers l ++
+                   (match opt with
+                     | None -> mt()
+                     | Some sc -> str" :" ++ spc() ++ str sc))
+        )
+      | VernacSyntaxExtension (_,(s,l)) ->
+        return (
+          keyword "Reserved Notation" ++ spc() ++ pr_located qs s ++
+            pr_syntax_modifiers l
+        )
+      | VernacNotationAddFormat(s,k,v) ->
+        return (
+          keyword "Format Notation " ++ qs s ++ spc () ++ qs k ++ spc() ++ qs v
+        )
+
+      (* Gallina *)
+      | VernacDefinition (d,id,b) -> (* A verifier... *)
+        let pr_def_token (l,dk) =
+          let l = match l with Some x -> x | None -> Decl_kinds.Global in
+          keyword (Kindops.string_of_definition_kind (l,false,dk))
+        in
+        let pr_reduce = function
+          | None -> mt()
+          | Some r ->
+            keyword "Eval" ++ spc() ++
+              pr_red_expr (pr_constr, pr_lconstr, pr_smart_global, pr_constr) r ++
+              keyword " in" ++ spc()
+        in
+        let pr_def_body = function
+          | DefineBody (bl,red,body,d) ->
+            let ty = match d with
+              | None -> mt()
+              | Some ty -> spc() ++ str":" ++ pr_spc_lconstr ty
+            in
+            (pr_binders_arg bl,ty,Some (pr_reduce red ++ pr_lconstr body))
+          | ProveBody (bl,t) ->
+            (pr_binders_arg bl, str" :" ++ pr_spc_lconstr t, None) in
+        let (binds,typ,c) = pr_def_body b in
+        return (
+          hov 2 (
+            pr_def_token d ++ spc()
+            ++ pr_plident id ++ binds ++ typ
+            ++ (match c with
+              | None -> mt()
+              | Some cc -> str" :=" ++ spc() ++ cc))
+        )
+
+      | VernacStartTheoremProof (ki,l,_) ->
+        return (
+          hov 1 (pr_statement (pr_thm_token ki) (List.hd l) ++
+                   prlist (pr_statement (spc () ++ keyword "with")) (List.tl l))
+        )
+
+      | VernacEndProof Admitted ->
+        return (keyword "Admitted")
+
+      | VernacEndProof (Proved (opac,o)) -> return (
+        match o with
+          | None -> (match opac with
+              | Transparent -> keyword "Defined"
+              | Opaque None -> keyword "Qed"
+              | Opaque (Some l) ->
+                  keyword "Qed" ++ spc() ++ str"export" ++
+                    prlist_with_sep (fun () -> str", ") pr_lident l)
+          | Some (id,th) -> (match th with
+              | None -> (if opac <> Transparent then keyword "Save" else keyword "Defined") ++ spc() ++ pr_lident id
+              | Some tok -> keyword "Save" ++ spc() ++ pr_thm_token tok ++ spc() ++ pr_lident id)
+      )
+      | VernacExactProof c ->
+        return (hov 2 (keyword "Proof" ++ pr_lconstrarg c))
+      | VernacAssumption (stre,t,l) ->
+        let n = List.length (List.flatten (List.map fst (List.map snd l))) in
+        let pr_params (c, (xl, t)) =
+          hov 2 (prlist_with_sep sep pr_plident xl ++ spc() ++
+            (if c then str":>" else str":" ++ spc() ++ pr_lconstr_expr t)) in
+        let assumptions = prlist_with_sep spc (fun p -> hov 1 (str "(" ++ pr_params p ++ str ")")) l in
+        return (hov 2 (pr_assumption_token (n > 1) stre ++
+                       pr_non_empty_arg pr_assumption_inline t ++ spc() ++ assumptions))
+      | VernacInductive (p,f,l) ->
+        let pr_constructor (coe,(id,c)) =
+          hov 2 (pr_lident id ++ str" " ++
+                   (if coe then str":>" else str":") ++
+                   Flags.without_option Flags.beautify_file pr_spc_lconstr c)
+        in
+        let pr_constructor_list b l = match l with
+          | Constructors [] -> mt()
+          | Constructors l ->
+            let fst_sep = match l with [_] -> "   " | _ -> " | " in
+            pr_com_at (begin_of_inductive l) ++
+              fnl() ++ str fst_sep ++
+              prlist_with_sep (fun _ -> fnl() ++ str" | ") pr_constructor l
+          | RecordDecl (c,fs) ->
+            pr_record_decl b c fs
+        in
+        let pr_oneind key (((coe,(id,pl)),indpar,s,k,lc),ntn) =
+          hov 0 (
+            str key ++ spc() ++
+              (if coe then str"> " else str"") ++ pr_lident id ++ pr_univs pl ++
+              pr_and_type_binders_arg indpar ++
+              pr_opt (fun s -> str":" ++ spc() ++ pr_lconstr_expr s) s ++
+              str" :=") ++ pr_constructor_list k lc ++
+            prlist (pr_decl_notation pr_constr) ntn
+        in
+        let key =
+          let (_,_,_,k,_),_ = List.hd l in
+          match k with Record -> "Record" | Structure -> "Structure"
+            | Inductive_kw -> "Inductive" | CoInductive -> "CoInductive"
+            | Class _ -> "Class" | Variant -> "Variant"
+        in
+        return (
+          hov 1 (pr_oneind key (List.hd l)) ++
+            (prlist (fun ind -> fnl() ++ hov 1 (pr_oneind "with" ind)) (List.tl l))
+        )
+
+      | VernacFixpoint (local, recs) ->
+        let local = match local with
+          | Some Discharge -> "Let "
+          | Some Local -> "Local "
+          | None | Some Global -> ""
+        in
+        let pr_pure_lconstr c =
+          Flags.without_option Flags.beautify_file pr_lconstr c in
+        let pr_onerec = function
+          | (((loc,id),pl),ro,bl,type_,def),ntn ->
+            let annot = pr_guard_annot pr_lconstr_expr bl ro in
+            pr_id id ++ pr_univs pl ++ pr_binders_arg bl ++ annot
+            ++ pr_type_option (fun c -> spc() ++ pr_lconstr_expr c) type_
+            ++ pr_opt (fun def -> str":=" ++ brk(1,2) ++ pr_pure_lconstr def) def ++
               prlist (pr_decl_notation pr_constr) ntn
-          in
-          let key =
-            let (_,_,_,k,_),_ = List.hd l in
-            match k with Record -> "Record" | Structure -> "Structure"
-              | Inductive_kw -> "Inductive" | CoInductive -> "CoInductive"
-              | Class _ -> "Class" | Variant -> "Variant"
-          in
-          return (
-            hov 1 (pr_oneind key (List.hd l)) ++
-              (prlist (fun ind -> fnl() ++ hov 1 (pr_oneind "with" ind)) (List.tl l))
-          )
+        in
+        return (
+          hov 0 (str local ++ keyword "Fixpoint" ++ spc () ++
+                   prlist_with_sep (fun _ -> fnl () ++ keyword "with" ++ spc ()) pr_onerec recs)
+        )
 
-        | VernacFixpoint (local, recs) ->
-          let local = match local with
-            | Some Discharge -> "Let "
-            | Some Local -> "Local "
-            | None | Some Global -> ""
-          in
-          let pr_pure_lconstr c =
-            Flags.without_option Flags.beautify_file pr_lconstr c in
-          let pr_onerec = function
-            | (((loc,id),pl),ro,bl,type_,def),ntn ->
-              let annot = pr_guard_annot pr_lconstr_expr bl ro in
-              pr_id id ++ pr_univs pl ++ pr_binders_arg bl ++ annot
-              ++ pr_type_option (fun c -> spc() ++ pr_lconstr_expr c) type_
-              ++ pr_opt (fun def -> str":=" ++ brk(1,2) ++ pr_pure_lconstr def) def ++
-                prlist (pr_decl_notation pr_constr) ntn
-          in
-          return (
-            hov 0 (str local ++ keyword "Fixpoint" ++ spc () ++
-                     prlist_with_sep (fun _ -> fnl () ++ keyword "with" ++ spc ()) pr_onerec recs)
-          )
+      | VernacCoFixpoint (local, corecs) ->
+        let local = match local with
+          | Some Discharge -> keyword "Let" ++ spc ()
+          | Some Local -> keyword "Local" ++ spc ()
+          | None | Some Global -> str ""
+        in
+        let pr_onecorec ((((loc,id),pl),bl,c,def),ntn) =
+          pr_id id ++ pr_univs pl ++ spc() ++ pr_binders bl ++ spc() ++ str":" ++
+            spc() ++ pr_lconstr_expr c ++
+            pr_opt (fun def -> str":=" ++ brk(1,2) ++ pr_lconstr def) def ++
+            prlist (pr_decl_notation pr_constr) ntn
+        in
+        return (
+          hov 0 (local ++ keyword "CoFixpoint" ++ spc() ++
+                   prlist_with_sep (fun _ -> fnl() ++ keyword "with" ++ spc ()) pr_onecorec corecs)
+        )
+      | VernacScheme l ->
+        return (
+          hov 2 (keyword "Scheme" ++ spc() ++
+                   prlist_with_sep (fun _ -> fnl() ++ keyword "with" ++ spc ()) pr_onescheme l)
+        )
+      | VernacCombinedScheme (id, l) ->
+        return (
+          hov 2 (keyword "Combined Scheme" ++ spc() ++
+                   pr_lident id ++ spc() ++ keyword "from" ++ spc() ++
+                   prlist_with_sep (fun _ -> fnl() ++ str", ") pr_lident l)
+        )
+      | VernacUniverse v ->
+        return (
+          hov 2 (keyword "Universe" ++ spc () ++
+                   prlist_with_sep (fun _ -> str",") pr_lident v)
+        )
+      | VernacConstraint v ->
+        let pr_uconstraint (l, d, r) =
+          pr_lident l ++ spc () ++ Univ.pr_constraint_type d ++ spc () ++ pr_lident r
+        in
+        return (
+          hov 2 (keyword "Constraint" ++ spc () ++
+                   prlist_with_sep (fun _ -> str",") pr_uconstraint v)
+        )
 
-        | VernacCoFixpoint (local, corecs) ->
-          let local = match local with
-            | Some Discharge -> keyword "Let" ++ spc ()
-            | Some Local -> keyword "Local" ++ spc ()
-            | None | Some Global -> str ""
-          in
-          let pr_onecorec ((((loc,id),pl),bl,c,def),ntn) =
-            pr_id id ++ pr_univs pl ++ spc() ++ pr_binders bl ++ spc() ++ str":" ++
-              spc() ++ pr_lconstr_expr c ++
-              pr_opt (fun def -> str":=" ++ brk(1,2) ++ pr_lconstr def) def ++
-              prlist (pr_decl_notation pr_constr) ntn
-          in
-          return (
-            hov 0 (local ++ keyword "CoFixpoint" ++ spc() ++
-                     prlist_with_sep (fun _ -> fnl() ++ keyword "with" ++ spc ()) pr_onecorec corecs)
-          )
-        | VernacScheme l ->
-          return (
-            hov 2 (keyword "Scheme" ++ spc() ++
-                     prlist_with_sep (fun _ -> fnl() ++ keyword "with" ++ spc ()) pr_onescheme l)
-          )
-        | VernacCombinedScheme (id, l) ->
-          return (
-            hov 2 (keyword "Combined Scheme" ++ spc() ++
-                     pr_lident id ++ spc() ++ keyword "from" ++ spc() ++
-                     prlist_with_sep (fun _ -> fnl() ++ str", ") pr_lident l)
-          )
-        | VernacUniverse v ->
-          return (
-            hov 2 (keyword "Universe" ++ spc () ++
-                     prlist_with_sep (fun _ -> str",") pr_lident v)
-          )
-        | VernacConstraint v ->
-          let pr_uconstraint (l, d, r) =
-            pr_lident l ++ spc () ++ Univ.pr_constraint_type d ++ spc () ++ pr_lident r
-          in
-          return (
-            hov 2 (keyword "Constraint" ++ spc () ++
-                     prlist_with_sep (fun _ -> str",") pr_uconstraint v)
-          )
+      (* Gallina extensions *)
+      | VernacBeginSection id ->
+        return (hov 2 (keyword "Section" ++ spc () ++ pr_lident id))
+      | VernacEndSegment id ->
+        return (hov 2 (keyword "End" ++ spc() ++ pr_lident id))
+      | VernacNameSectionHypSet (id,set) ->
+        return (hov 2 (keyword "Package" ++ spc() ++ pr_lident id ++ spc()++
+        str ":="++spc()++pr_using set))
+      | VernacRequire (from, exp, l) ->
+        let from = match from with
+        | None -> mt ()
+        | Some r -> keyword "From" ++ spc () ++ pr_module r ++ spc ()
+        in
+        return (
+          hov 2
+            (from ++ keyword "Require" ++ spc() ++ pr_require_token exp ++
+               prlist_with_sep sep pr_module l)
+        )
+      | VernacImport (f,l) ->
+        return (
+          (if f then keyword "Export" else keyword "Import") ++ spc() ++
+            prlist_with_sep sep pr_import_module l
+        )
+      | VernacCanonical q ->
+        return (
+          keyword "Canonical Structure" ++ spc() ++ pr_smart_global q
+        )
+      | VernacCoercion (_,id,c1,c2) ->
+        return (
+          hov 1 (
+            keyword "Coercion" ++ spc() ++
+              pr_smart_global id ++ spc() ++ str":" ++ spc() ++ pr_class_rawexpr c1 ++
+              spc() ++ str">->" ++ spc() ++ pr_class_rawexpr c2)
+        )
+      | VernacIdentityCoercion (_,id,c1,c2) ->
+        return (
+          hov 1 (
+            keyword "Identity Coercion" ++ spc() ++ pr_lident id ++
+              spc() ++ str":" ++ spc() ++ pr_class_rawexpr c1 ++ spc() ++ str">->" ++
+              spc() ++ pr_class_rawexpr c2)
+        )
 
-        (* Gallina extensions *)
-        | VernacBeginSection id ->
-          return (hov 2 (keyword "Section" ++ spc () ++ pr_lident id))
-        | VernacEndSegment id ->
-          return (hov 2 (keyword "End" ++ spc() ++ pr_lident id))
-        | VernacNameSectionHypSet (id,set) ->
-          return (hov 2 (keyword "Package" ++ spc() ++ pr_lident id ++ spc()++
-          str ":="++spc()++pr_using set))
-        | VernacRequire (from, exp, l) ->
-          let from = match from with
-          | None -> mt ()
-          | Some r -> keyword "From" ++ spc () ++ pr_module r ++ spc ()
-          in
-          return (
-            hov 2
-              (from ++ keyword "Require" ++ spc() ++ pr_require_token exp ++
-                 prlist_with_sep sep pr_module l)
-          )
-        | VernacImport (f,l) ->
-          return (
-            (if f then keyword "Export" else keyword "Import") ++ spc() ++
-              prlist_with_sep sep pr_import_module l
-          )
-        | VernacCanonical q ->
-          return (
-            keyword "Canonical Structure" ++ spc() ++ pr_smart_global q
-          )
-        | VernacCoercion (_,id,c1,c2) ->
-          return (
-            hov 1 (
-              keyword "Coercion" ++ spc() ++
-                pr_smart_global id ++ spc() ++ str":" ++ spc() ++ pr_class_rawexpr c1 ++
-                spc() ++ str">->" ++ spc() ++ pr_class_rawexpr c2)
-          )
-        | VernacIdentityCoercion (_,id,c1,c2) ->
-          return (
-            hov 1 (
-              keyword "Identity Coercion" ++ spc() ++ pr_lident id ++
-                spc() ++ str":" ++ spc() ++ pr_class_rawexpr c1 ++ spc() ++ str">->" ++
-                spc() ++ pr_class_rawexpr c2)
-          )
+      | VernacInstance (abst, sup, (instid, bk, cl), props, pri) ->
+        return (
+          hov 1 (
+            (if abst then keyword "Declare" ++ spc () else mt ()) ++
+              keyword "Instance" ++
+              (match instid with
+      	 | (loc, Name id), l -> spc () ++ pr_plident ((loc, id),l) ++ spc () 
+               | (_, Anonymous), _ -> mt ()) ++
+              pr_and_type_binders_arg sup ++
+              str":" ++ spc () ++
+              (match bk with Implicit -> str "! " | Explicit -> mt ()) ++
+              pr_constr cl ++ pr_priority pri ++
+              (match props with
+                | Some (true,CRecord (_,l)) -> spc () ++ str":=" ++ spc () ++ str"{" ++ pr_record_body l ++ str "}"
+                | Some (true,_) -> assert false
+                | Some (false,p) -> spc () ++ str":=" ++ spc () ++ pr_constr p
+                | None -> mt()))
+        )
 
-        | VernacInstance (abst, sup, (instid, bk, cl), props, pri) ->
-          return (
-            hov 1 (
-              (if abst then keyword "Declare" ++ spc () else mt ()) ++
-                keyword "Instance" ++
-                (match instid with
-		 | (loc, Name id), l -> spc () ++ pr_plident ((loc, id),l) ++ spc () 
-                 | (_, Anonymous), _ -> mt ()) ++
-                pr_and_type_binders_arg sup ++
-                str":" ++ spc () ++
-                (match bk with Implicit -> str "! " | Explicit -> mt ()) ++
-                pr_constr cl ++ pr_priority pri ++
-                (match props with
-                  | Some (true,CRecord (_,l)) -> spc () ++ str":=" ++ spc () ++ str"{" ++ pr_record_body l ++ str "}"
-                  | Some (true,_) -> assert false
-                  | Some (false,p) -> spc () ++ str":=" ++ spc () ++ pr_constr p
-                  | None -> mt()))
-          )
+      | VernacContext l ->
+        return (
+          hov 1 (
+            keyword "Context" ++ spc () ++ pr_and_type_binders_arg l)
+        )
 
-        | VernacContext l ->
-          return (
-            hov 1 (
-              keyword "Context" ++ spc () ++ pr_and_type_binders_arg l)
-          )
+      | VernacDeclareInstances (ids, pri) ->
+        return (
+          hov 1 (keyword "Existing" ++ spc () ++
+                   keyword(String.plural (List.length ids) "Instance") ++
+                   spc () ++ prlist_with_sep spc pr_reference ids ++ pr_priority pri)
+        )
 
-        | VernacDeclareInstances (ids, pri) ->
-          return (
-            hov 1 (keyword "Existing" ++ spc () ++
-                     keyword(String.plural (List.length ids) "Instance") ++
-                     spc () ++ prlist_with_sep spc pr_reference ids ++ pr_priority pri)
-          )
+      | VernacDeclareClass id ->
+        return (
+          hov 1 (keyword "Existing" ++ spc () ++ keyword "Class" ++ spc () ++ pr_reference id)
+        )
 
-        | VernacDeclareClass id ->
-          return (
-            hov 1 (keyword "Existing" ++ spc () ++ keyword "Class" ++ spc () ++ pr_reference id)
-          )
+      (* Modules and Module Types *)
+      | VernacDefineModule (export,m,bl,tys,bd) ->
+        let b = pr_module_binders bl pr_lconstr in
+        return (
+          hov 2 (keyword "Module" ++ spc() ++ pr_require_token export ++
+                   pr_lident m ++ b ++
+                   pr_of_module_type pr_lconstr tys ++
+                   (if List.is_empty bd then mt () else str ":= ") ++
+                   prlist_with_sep (fun () -> str " <+")
+                   (pr_module_ast_inl true pr_lconstr) bd)
+        )
+      | VernacDeclareModule (export,id,bl,m1) ->
+        let b = pr_module_binders bl pr_lconstr in
+        return (
+          hov 2 (keyword "Declare Module" ++ spc() ++ pr_require_token export ++
+                   pr_lident id ++ b ++ str " :" ++
+                   pr_module_ast_inl true pr_lconstr m1)
+        )
+      | VernacDeclareModuleType (id,bl,tyl,m) ->
+        let b = pr_module_binders bl pr_lconstr in
+        let pr_mt = pr_module_ast_inl true pr_lconstr in
+        return (
+          hov 2 (keyword "Module Type " ++ pr_lident id ++ b ++
+                   prlist_strict (fun m -> str " <:" ++ pr_mt m) tyl ++
+                   (if List.is_empty m then mt () else str ":= ") ++
+                   prlist_with_sep (fun () -> str " <+ ") pr_mt m)
+        )
+      | VernacInclude (mexprs) ->
+        let pr_m = pr_module_ast_inl false pr_lconstr in
+        return (
+          hov 2 (keyword "Include" ++ spc() ++
+                   prlist_with_sep (fun () -> str " <+ ") pr_m mexprs)
+        )
+      (* Solving *)
+      | VernacSolveExistential (i,c) ->
+        return (keyword "Existential" ++ spc () ++ int i ++ pr_lconstrarg c)
 
-        (* Modules and Module Types *)
-        | VernacDefineModule (export,m,bl,tys,bd) ->
-          let b = pr_module_binders bl pr_lconstr in
-          return (
-            hov 2 (keyword "Module" ++ spc() ++ pr_require_token export ++
-                     pr_lident m ++ b ++
-                     pr_of_module_type pr_lconstr tys ++
-                     (if List.is_empty bd then mt () else str ":= ") ++
-                     prlist_with_sep (fun () -> str " <+")
-                     (pr_module_ast_inl true pr_lconstr) bd)
-          )
-        | VernacDeclareModule (export,id,bl,m1) ->
-          let b = pr_module_binders bl pr_lconstr in
-          return (
-            hov 2 (keyword "Declare Module" ++ spc() ++ pr_require_token export ++
-                     pr_lident id ++ b ++ str " :" ++
-                     pr_module_ast_inl true pr_lconstr m1)
-          )
-        | VernacDeclareModuleType (id,bl,tyl,m) ->
-          let b = pr_module_binders bl pr_lconstr in
-          let pr_mt = pr_module_ast_inl true pr_lconstr in
-          return (
-            hov 2 (keyword "Module Type " ++ pr_lident id ++ b ++
-                     prlist_strict (fun m -> str " <:" ++ pr_mt m) tyl ++
-                     (if List.is_empty m then mt () else str ":= ") ++
-                     prlist_with_sep (fun () -> str " <+ ") pr_mt m)
-          )
-        | VernacInclude (mexprs) ->
-          let pr_m = pr_module_ast_inl false pr_lconstr in
-          return (
-            hov 2 (keyword "Include" ++ spc() ++
-                     prlist_with_sep (fun () -> str " <+ ") pr_m mexprs)
-          )
-        (* Solving *)
-        | VernacSolveExistential (i,c) ->
-          return (keyword "Existential" ++ spc () ++ int i ++ pr_lconstrarg c)
+      (* Auxiliary file and library management *)
+      | VernacAddLoadPath (fl,s,d) ->
+        return (
+          hov 2
+            (keyword "Add" ++
+               (if fl then spc () ++ keyword "Rec" ++ spc () else spc()) ++
+               keyword "LoadPath" ++ spc() ++ qs s ++
+               (match d with
+                 | None -> mt()
+                 | Some dir -> spc() ++ keyword "as" ++ spc() ++ pr_dirpath dir))
+        )
+      | VernacRemoveLoadPath s ->
+        return (keyword "Remove LoadPath" ++ qs s)
+      | VernacAddMLPath (fl,s) ->
+        return (
+          keyword "Add"
+          ++ (if fl then spc () ++ keyword "Rec" ++ spc () else spc())
+          ++ keyword "ML Path"
+          ++ qs s
+        )
+      | VernacDeclareMLModule (l) ->
+        return (
+          hov 2 (keyword "Declare ML Module" ++ spc() ++ prlist_with_sep sep qs l)
+        )
+      | VernacChdir s ->
+        return (keyword "Cd" ++ pr_opt qs s)
 
-        (* Auxiliary file and library management *)
-        | VernacAddLoadPath (fl,s,d) ->
-          return (
-            hov 2
-              (keyword "Add" ++
-                 (if fl then spc () ++ keyword "Rec" ++ spc () else spc()) ++
-                 keyword "LoadPath" ++ spc() ++ qs s ++
-                 (match d with
-                   | None -> mt()
-                   | Some dir -> spc() ++ keyword "as" ++ spc() ++ pr_dirpath dir))
-          )
-        | VernacRemoveLoadPath s ->
-          return (keyword "Remove LoadPath" ++ qs s)
-        | VernacAddMLPath (fl,s) ->
-          return (
-            keyword "Add"
-            ++ (if fl then spc () ++ keyword "Rec" ++ spc () else spc())
-            ++ keyword "ML Path"
-            ++ qs s
-          )
-        | VernacDeclareMLModule (l) ->
-          return (
-            hov 2 (keyword "Declare ML Module" ++ spc() ++ prlist_with_sep sep qs l)
-          )
-        | VernacChdir s ->
-          return (keyword "Cd" ++ pr_opt qs s)
+      (* Commands *)
+      | VernacCreateHintDb (dbname,b) ->
+        return (
+          hov 1 (keyword "Create HintDb" ++ spc () ++
+                   str dbname ++ (if b then str" discriminated" else mt ()))
+        )
+      | VernacRemoveHints (dbnames, ids) ->
+        return (
+          hov 1 (keyword "Remove Hints" ++ spc () ++
+                   prlist_with_sep spc (fun r -> pr_id (coerce_reference_to_id r)) ids ++
+                   pr_opt_hintbases dbnames)
+        )
+      | VernacHints (_, dbnames,h) ->
+        return (pr_hints dbnames h pr_constr pr_constr_pattern_expr)
+      | VernacSyntacticDefinition (id,(ids,c),_,onlyparsing) ->
+        return (
+          hov 2
+            (keyword "Notation" ++ spc () ++ pr_lident id ++ spc () ++
+               prlist_with_sep spc pr_id ids ++ str":=" ++ pr_constrarg c ++
+               pr_syntax_modifiers
+               (match onlyparsing with None -> [] | Some v -> [SetOnlyParsing v]))
+        )
+      | VernacDeclareImplicits (q,[]) ->
+        return (
+          hov 2 (keyword "Implicit Arguments" ++ spc() ++ pr_smart_global q)
+        )
+      | VernacDeclareImplicits (q,impls) ->
+        return (
+          hov 1 (keyword "Implicit Arguments" ++ spc () ++
+                   spc() ++ pr_smart_global q ++ spc() ++
+                   prlist_with_sep spc (fun imps ->
+                     str"[" ++ prlist_with_sep sep pr_explanation imps ++ str"]")
+                   impls)
+        )
+      | VernacArguments (q, impl, nargs, mods) ->
+        return (
+          hov 2 (
+            keyword "Arguments" ++ spc() ++
+              pr_smart_global q ++
+              let pr_s = function None -> str"" | Some (_,s) -> str "%" ++ str s in
+              let pr_if b x = if b then x else str "" in
+              let pr_br imp max x = match imp, max with
+                | true, false -> str "[" ++ x ++ str "]"
+                | true, true -> str "{" ++ x ++ str "}"
+                | _ -> x in
+              let rec aux n l =
+                match n, l with
+                  | 0, l -> spc () ++ str"/" ++ aux ~-1 l
+                  | _, [] -> mt()
+                  | n, (id,k,s,imp,max) :: tl ->
+                    spc() ++ pr_br imp max (pr_if k (str"!") ++ pr_name id ++ pr_s s) ++
+                      aux (n-1) tl in
+              prlist_with_sep (fun () -> str", ") (aux nargs) impl ++
+                (if not (List.is_empty mods) then str" : " else str"") ++
+                  prlist_with_sep (fun () -> str", " ++ spc()) (function
+                    | `ReductionDontExposeCase -> keyword "simpl nomatch"
+                    | `ReductionNeverUnfold -> keyword "simpl never"
+                    | `DefaultImplicits -> keyword "default implicits"
+                    | `Rename -> keyword "rename"
+                    | `Assert -> keyword "assert"
+                    | `ExtraScopes -> keyword "extra scopes"
+                    | `ClearImplicits -> keyword "clear implicits"
+                    | `ClearScopes -> keyword "clear scopes")
+                  mods)
+        )
+      | VernacReserve bl ->
+        let n = List.length (List.flatten (List.map fst bl)) in
+        return (
+          hov 2 (tag_keyword (str"Implicit Type" ++ str (if n > 1 then "s " else " "))
+                 ++ pr_ne_params_list pr_lconstr_expr (List.map (fun sb -> false,sb) bl))
+        )
+      | VernacGeneralizable g ->
+        return (
+          hov 1 (tag_keyword (
+            str"Generalizable Variable" ++
+              match g with
+                | None -> str "s none"
+                | Some [] -> str "s all"
+                | Some idl ->
+                  str (if List.length idl > 1 then "s " else " ") ++
+                    prlist_with_sep spc pr_lident idl)
+          ))
+      | VernacSetOpacity(k,l) when Conv_oracle.is_transparent k ->
+        return (
+          hov 1 (keyword "Transparent" ++
+                   spc() ++ prlist_with_sep sep pr_smart_global l)
+        )
+      | VernacSetOpacity(Conv_oracle.Opaque,l) ->
+        return (
+          hov 1 (keyword "Opaque" ++
+                   spc() ++ prlist_with_sep sep pr_smart_global l)
+        )
+      | VernacSetOpacity _ ->
+        return (
+          Errors.anomaly (keyword "VernacSetOpacity used to set something else")
+        )
+      | VernacSetStrategy l ->
+        let pr_lev = function
+          | Conv_oracle.Opaque -> keyword "opaque"
+          | Conv_oracle.Expand -> keyword "expand"
+          | l when Conv_oracle.is_transparent l -> keyword "transparent"
+          | Conv_oracle.Level n -> int n
+        in
+        let pr_line (l,q) =
+          hov 2 (pr_lev l ++ spc() ++
+                   str"[" ++ prlist_with_sep sep pr_smart_global q ++ str"]")
+        in
+        return (
+          hov 1 (keyword "Strategy" ++ spc() ++
+                   hv 0 (prlist_with_sep sep pr_line l))
+        )
+      | VernacUnsetOption (na) ->
+        return (
+          hov 1 (keyword "Unset" ++ spc() ++ pr_printoption na None)
+        )
+      | VernacSetOption (na,v) ->
+        return (
+          hov 2 (keyword "Set" ++ spc() ++ pr_set_option na v)
+        )
+      | VernacAddOption (na,l) ->
+        return (
+          hov 2 (keyword "Add" ++ spc() ++ pr_printoption na (Some l))
+        )
+      | VernacRemoveOption (na,l) ->
+        return (
+          hov 2 (keyword "Remove" ++ spc() ++ pr_printoption na (Some l))
+        )
+      | VernacMemOption (na,l) ->
+        return (
+          hov 2 (keyword "Test" ++ spc() ++ pr_printoption na (Some l))
+        )
+      | VernacPrintOption na ->
+        return (
+          hov 2 (keyword "Test" ++ spc() ++ pr_printoption na None)
+        )
+      | VernacCheckMayEval (r,io,c) ->
+        let pr_mayeval r c = match r with
+          | Some r0 ->
+            hov 2 (keyword "Eval" ++ spc() ++
+                     pr_red_expr (pr_constr,pr_lconstr,pr_smart_global, pr_constr) r0 ++
+                     spc() ++ keyword "in" ++ spc () ++ pr_lconstr c)
+          | None -> hov 2 (keyword "Check" ++ spc() ++ pr_lconstr c)
+        in
+        let pr_i = match io with None -> mt () | Some i -> int i ++ str ": " in
+        return (pr_i ++ pr_mayeval r c)
+      | VernacGlobalCheck c ->
+        return (hov 2 (keyword "Type" ++ pr_constrarg c))
+      | VernacDeclareReduction (s,r) ->
+        return (
+          keyword "Declare Reduction" ++ spc () ++ str s ++ str " := " ++
+            pr_red_expr (pr_constr,pr_lconstr,pr_smart_global, pr_constr) r
+        )
+      | VernacPrint p ->
+        return (pr_printable p)
+      | VernacSearch (sea,g,sea_r) ->
+        return (pr_search sea g sea_r pr_constr_pattern_expr)
+      | VernacLocate loc ->
+        let pr_locate =function
+          | LocateAny qid -> pr_smart_global qid
+          | LocateTerm qid -> keyword "Term" ++ spc() ++ pr_smart_global qid
+          | LocateFile f -> keyword "File" ++ spc() ++ qs f
+          | LocateLibrary qid -> keyword "Library" ++ spc () ++ pr_module qid
+          | LocateModule qid -> keyword "Module" ++ spc () ++ pr_module qid
+          | LocateTactic qid -> keyword "Ltac" ++ spc () ++ pr_ltac_ref qid
+        in
+        return (keyword "Locate" ++ spc() ++ pr_locate loc)
+      | VernacRegister (id, RegisterInline) ->
+        return (
+          hov 2
+            (keyword "Register Inline" ++ spc() ++ pr_lident id)
+        )
+      | VernacComments l ->
+        return (
+          hov 2
+            (keyword "Comments" ++ spc()
+             ++ prlist_with_sep sep (pr_comment pr_constr) l)
+        )
 
-        (* Commands *)
-        | VernacCreateHintDb (dbname,b) ->
-          return (
-            hov 1 (keyword "Create HintDb" ++ spc () ++
-                     str dbname ++ (if b then str" discriminated" else mt ()))
-          )
-        | VernacRemoveHints (dbnames, ids) ->
-          return (
-            hov 1 (keyword "Remove Hints" ++ spc () ++
-                     prlist_with_sep spc (fun r -> pr_id (coerce_reference_to_id r)) ids ++
-                     pr_opt_hintbases dbnames)
-          )
-        | VernacHints (_, dbnames,h) ->
-          return (pr_hints dbnames h pr_constr pr_constr_pattern_expr)
-        | VernacSyntacticDefinition (id,(ids,c),_,onlyparsing) ->
-          return (
-            hov 2
-              (keyword "Notation" ++ spc () ++ pr_lident id ++ spc () ++
-                 prlist_with_sep spc pr_id ids ++ str":=" ++ pr_constrarg c ++
-                 pr_syntax_modifiers
-                 (match onlyparsing with None -> [] | Some v -> [SetOnlyParsing v]))
-          )
-        | VernacDeclareImplicits (q,[]) ->
-          return (
-            hov 2 (keyword "Implicit Arguments" ++ spc() ++ pr_smart_global q)
-          )
-        | VernacDeclareImplicits (q,impls) ->
-          return (
-            hov 1 (keyword "Implicit Arguments" ++ spc () ++
-                     spc() ++ pr_smart_global q ++ spc() ++
-                     prlist_with_sep spc (fun imps ->
-                       str"[" ++ prlist_with_sep sep pr_explanation imps ++ str"]")
-                     impls)
-          )
-        | VernacArguments (q, impl, nargs, mods) ->
-          return (
-            hov 2 (
-              keyword "Arguments" ++ spc() ++
-                pr_smart_global q ++
-                let pr_s = function None -> str"" | Some (_,s) -> str "%" ++ str s in
-                let pr_if b x = if b then x else str "" in
-                let pr_br imp max x = match imp, max with
-                  | true, false -> str "[" ++ x ++ str "]"
-                  | true, true -> str "{" ++ x ++ str "}"
-                  | _ -> x in
-                let rec aux n l =
-                  match n, l with
-                    | 0, l -> spc () ++ str"/" ++ aux ~-1 l
-                    | _, [] -> mt()
-                    | n, (id,k,s,imp,max) :: tl ->
-                      spc() ++ pr_br imp max (pr_if k (str"!") ++ pr_name id ++ pr_s s) ++
-                        aux (n-1) tl in
-                prlist_with_sep (fun () -> str", ") (aux nargs) impl ++
-                  (if not (List.is_empty mods) then str" : " else str"") ++
-                    prlist_with_sep (fun () -> str", " ++ spc()) (function
-                      | `ReductionDontExposeCase -> keyword "simpl nomatch"
-                      | `ReductionNeverUnfold -> keyword "simpl never"
-                      | `DefaultImplicits -> keyword "default implicits"
-                      | `Rename -> keyword "rename"
-                      | `Assert -> keyword "assert"
-                      | `ExtraScopes -> keyword "extra scopes"
-                      | `ClearImplicits -> keyword "clear implicits"
-                      | `ClearScopes -> keyword "clear scopes")
-                    mods)
-          )
-        | VernacReserve bl ->
-          let n = List.length (List.flatten (List.map fst bl)) in
-          return (
-            hov 2 (tag_keyword (str"Implicit Type" ++ str (if n > 1 then "s " else " "))
-                   ++ pr_ne_params_list pr_lconstr_expr (List.map (fun sb -> false,sb) bl))
-          )
-        | VernacGeneralizable g ->
-          return (
-            hov 1 (tag_keyword (
-              str"Generalizable Variable" ++
-                match g with
-                  | None -> str "s none"
-                  | Some [] -> str "s all"
-                  | Some idl ->
-                    str (if List.length idl > 1 then "s " else " ") ++
-                      prlist_with_sep spc pr_lident idl)
-            ))
-        | VernacSetOpacity(k,l) when Conv_oracle.is_transparent k ->
-          return (
-            hov 1 (keyword "Transparent" ++
-                     spc() ++ prlist_with_sep sep pr_smart_global l)
-          )
-        | VernacSetOpacity(Conv_oracle.Opaque,l) ->
-          return (
-            hov 1 (keyword "Opaque" ++
-                     spc() ++ prlist_with_sep sep pr_smart_global l)
-          )
-        | VernacSetOpacity _ ->
-          return (
-            Errors.anomaly (keyword "VernacSetOpacity used to set something else")
-          )
-        | VernacSetStrategy l ->
-          let pr_lev = function
-            | Conv_oracle.Opaque -> keyword "opaque"
-            | Conv_oracle.Expand -> keyword "expand"
-            | l when Conv_oracle.is_transparent l -> keyword "transparent"
-            | Conv_oracle.Level n -> int n
-          in
-          let pr_line (l,q) =
-            hov 2 (pr_lev l ++ spc() ++
-                     str"[" ++ prlist_with_sep sep pr_smart_global q ++ str"]")
-          in
-          return (
-            hov 1 (keyword "Strategy" ++ spc() ++
-                     hv 0 (prlist_with_sep sep pr_line l))
-          )
-        | VernacUnsetOption (na) ->
-          return (
-            hov 1 (keyword "Unset" ++ spc() ++ pr_printoption na None)
-          )
-        | VernacSetOption (na,v) ->
-          return (
-            hov 2 (keyword "Set" ++ spc() ++ pr_set_option na v)
-          )
-        | VernacAddOption (na,l) ->
-          return (
-            hov 2 (keyword "Add" ++ spc() ++ pr_printoption na (Some l))
-          )
-        | VernacRemoveOption (na,l) ->
-          return (
-            hov 2 (keyword "Remove" ++ spc() ++ pr_printoption na (Some l))
-          )
-        | VernacMemOption (na,l) ->
-          return (
-            hov 2 (keyword "Test" ++ spc() ++ pr_printoption na (Some l))
-          )
-        | VernacPrintOption na ->
-          return (
-            hov 2 (keyword "Test" ++ spc() ++ pr_printoption na None)
-          )
-        | VernacCheckMayEval (r,io,c) ->
-          let pr_mayeval r c = match r with
-            | Some r0 ->
-              hov 2 (keyword "Eval" ++ spc() ++
-                       pr_red_expr (pr_constr,pr_lconstr,pr_smart_global, pr_constr) r0 ++
-                       spc() ++ keyword "in" ++ spc () ++ pr_lconstr c)
-            | None -> hov 2 (keyword "Check" ++ spc() ++ pr_lconstr c)
-          in
-          let pr_i = match io with None -> mt () | Some i -> int i ++ str ": " in
-          return (pr_i ++ pr_mayeval r c)
-        | VernacGlobalCheck c ->
-          return (hov 2 (keyword "Type" ++ pr_constrarg c))
-        | VernacDeclareReduction (s,r) ->
-          return (
-            keyword "Declare Reduction" ++ spc () ++ str s ++ str " := " ++
-              pr_red_expr (pr_constr,pr_lconstr,pr_smart_global, pr_constr) r
-          )
-        | VernacPrint p ->
-          return (pr_printable p)
-        | VernacSearch (sea,g,sea_r) ->
-          return (pr_search sea g sea_r pr_constr_pattern_expr)
-        | VernacLocate loc ->
-          let pr_locate =function
-            | LocateAny qid -> pr_smart_global qid
-            | LocateTerm qid -> keyword "Term" ++ spc() ++ pr_smart_global qid
-            | LocateFile f -> keyword "File" ++ spc() ++ qs f
-            | LocateLibrary qid -> keyword "Library" ++ spc () ++ pr_module qid
-            | LocateModule qid -> keyword "Module" ++ spc () ++ pr_module qid
-            | LocateTactic qid -> keyword "Ltac" ++ spc () ++ pr_ltac_ref qid
-          in
-          return (keyword "Locate" ++ spc() ++ pr_locate loc)
-        | VernacRegister (id, RegisterInline) ->
-          return (
-            hov 2
-              (keyword "Register Inline" ++ spc() ++ pr_lident id)
-          )
-        | VernacComments l ->
-          return (
-            hov 2
-              (keyword "Comments" ++ spc()
-               ++ prlist_with_sep sep (pr_comment pr_constr) l)
-          )
+      (* Toplevel control *)
+      | VernacToplevelControl exn ->
+        return (pr_topcmd exn)
 
-        (* Toplevel control *)
-        | VernacToplevelControl exn ->
-          return (pr_topcmd exn)
+      (* For extension *)
+      | VernacExtend (s,c) ->
+        return (pr_extend s c)
+      | VernacProof (None, None) ->
+        return (keyword "Proof")
+      | VernacProof (None, Some e) ->
+        return (keyword "Proof " ++ spc () ++
+            keyword "using" ++ spc() ++ pr_using e)
+      | VernacProof (Some te, None) ->
+        return (keyword "Proof with" ++ spc() ++ pr_raw_tactic te)
+      | VernacProof (Some te, Some e) ->
+        return (
+          keyword "Proof" ++ spc () ++
+            keyword "using" ++ spc() ++ pr_using e ++ spc() ++
+            keyword "with" ++ spc() ++pr_raw_tactic te
+        )
+      | VernacProofMode s ->
+        return (keyword "Proof Mode" ++ str s)
+      | VernacBullet b ->
+        return (begin match b with
+          | Dash n -> str (String.make n '-')
+          | Star n -> str (String.make n '*')
+          | Plus n -> str (String.make n '+')
+        end)
+      | VernacSubproof None ->
+        return (str "{")
+      | VernacSubproof (Some i) ->
+        return (keyword "BeginSubproof" ++ spc () ++ int i)
+      | VernacEndSubproof ->
+        return (str "}")
 
-        (* For extension *)
-        | VernacExtend (s,c) ->
-          return (pr_extend s c)
-        | VernacProof (None, None) ->
-          return (keyword "Proof")
-        | VernacProof (None, Some e) ->
-          return (keyword "Proof " ++ spc () ++
-              keyword "using" ++ spc() ++ pr_using e)
-        | VernacProof (Some te, None) ->
-          return (keyword "Proof with" ++ spc() ++ pr_raw_tactic te)
-        | VernacProof (Some te, Some e) ->
-          return (
-            keyword "Proof" ++ spc () ++
-              keyword "using" ++ spc() ++ pr_using e ++ spc() ++
-              keyword "with" ++ spc() ++pr_raw_tactic te
-          )
-        | VernacProofMode s ->
-          return (keyword "Proof Mode" ++ str s)
-        | VernacBullet b ->
-          return (begin match b with
-            | Dash n -> str (String.make n '-')
-            | Star n -> str (String.make n '*')
-            | Plus n -> str (String.make n '+')
-          end)
-        | VernacSubproof None ->
-          return (str "{")
-        | VernacSubproof (Some i) ->
-          return (keyword "BeginSubproof" ++ spc () ++ int i)
-        | VernacEndSubproof ->
-          return (str "}")
+  and pr_extend s cl =
+    let pr_arg a =
+      try pr_gen a
+      with Failure _ -> str "<error in " ++ str (fst s) ++ str ">" in
+    try
+      let rl = Egramml.get_extend_vernac_rule s in
+      let rec aux rl cl =
+        match rl, cl with
+        | Egramml.GramNonTerminal _ :: rl, arg :: cl -> pr_arg arg :: aux rl cl
+        | Egramml.GramTerminal s :: rl, cl -> str s :: aux rl cl
+        | [], [] -> []
+        | _ -> assert false in
+      hov 1 (pr_sequence (fun x -> x) (aux rl cl))
+    with Not_found ->
+      hov 1 (str "TODO(" ++ str (fst s) ++ spc () ++ prlist_with_sep sep pr_arg cl ++ str ")")
 
-    and pr_extend s cl =
-      let pr_arg a =
-        try pr_gen a
-        with Failure _ -> str "<error in " ++ str (fst s) ++ str ">" in
-      try
-        let rl = Egramml.get_extend_vernac_rule s in
-        let rec aux rl cl =
-          match rl, cl with
-          | Egramml.GramNonTerminal _ :: rl, arg :: cl -> pr_arg arg :: aux rl cl
-          | Egramml.GramTerminal s :: rl, cl -> str s :: aux rl cl
-          | [], [] -> []
-          | _ -> assert false in
-        hov 1 (pr_sequence (fun x -> x) (aux rl cl))
-      with Not_found ->
-        hov 1 (str "TODO(" ++ str (fst s) ++ spc () ++ prlist_with_sep sep pr_arg cl ++ str ")")
-
-    in pr_vernac
-
-  let pr_vernac_body v = make_pr_vernac pr_constr_expr pr_lconstr_expr v
-
-  let pr_vernac v = make_pr_vernac pr_constr_expr pr_lconstr_expr v ++ sep_end v
-
-  let pr_vernac x =
-    try pr_vernac x
+  let pr_vernac v =
+    try pr_vernac_body v ++ sep_end v
     with e -> Errors.print e
 
 end

--- a/printing/ppvernac.ml
+++ b/printing/ppvernac.ml
@@ -21,7 +21,7 @@ open Decl_kinds
 
 module Make
   (Ppconstr : Ppconstrsig.Pp)
-  (Pptactic : Pptacticsig.Pp)
+  (Pptacticsig : Pptacticsig.Pp)
   (Taggers  : sig
     val tag_keyword : std_ppcmds -> std_ppcmds
     val tag_vernac  : vernac_expr -> std_ppcmds -> std_ppcmds
@@ -30,7 +30,7 @@ module Make
 
   open Taggers
   open Ppconstr
-  open Pptactic
+  open Pptacticsig
 
   let keyword s = tag_keyword (str s)
 
@@ -81,10 +81,38 @@ module Make
     | VernacEndSubproof -> str""
     | _ -> str"."
 
-  let pr_gen t = pr_raw_generic (Global.env ()) t
-
   let sep = fun _ -> spc()
   let sep_v2 = fun _ -> str"," ++ spc()
+
+  open Genarg
+
+  type 'c entry_name = EntryName : ('c, 'a) Extend.symbol -> 'c entry_name
+
+  let hov_if_not_empty n p = if Pp.ismt p then p else hov n p
+
+  let rec pr_gen = function
+    | GenArg (Rawwit (ListArg wit), x), EntryName (Alist1 e) ->
+        let map x = pr_gen (GenArg (rawwit wit, x), EntryName e) in
+        hov_if_not_empty 0 (pr_sequence map x)
+    | GenArg (Rawwit (ListArg wit), x), EntryName (Alist0 e) ->
+        let map x = pr_gen (GenArg (rawwit wit, x), EntryName e) in
+        hov_if_not_empty 0 (pr_sequence map x)
+    | GenArg (Rawwit (ListArg wit), x), EntryName (Alist1sep (e,sep)) ->
+        let map x = pr_gen (GenArg (rawwit wit, x), EntryName e) in
+        hov_if_not_empty 0 (prlist_with_sep (fun () -> spc() ++ str sep ++ spc()) map x)
+    | GenArg (Rawwit (ListArg wit), x), EntryName (Alist0sep (e,sep)) ->
+        let map x = pr_gen (GenArg (rawwit wit, x), EntryName e) in
+        hov_if_not_empty 0 (prlist_with_sep (fun () -> spc() ++ str sep ++ spc()) map x)
+    | GenArg (Rawwit (OptArg wit), x), EntryName (Aopt e) ->
+        let ans = match x with
+          | None -> mt ()
+          | Some x -> pr_gen (GenArg (rawwit wit, x), EntryName e) in
+        hov_if_not_empty 0 ans
+    | GenArg (Rawwit (PairArg (wit1, wit2)), _), _ -> error "Pair of entries not implemented."
+    | GenArg (Rawwit (ExtraArg s as wit), x), e ->
+        (try pi1 (Pptactic.find_extra_genarg_pprule wit) pr_constr_expr pr_lconstr_expr (fun _ -> pr_raw_tactic) x
+        with Not_found -> Genprint.generic_raw_print (in_gen (rawwit wit) x))
+    | _, _ -> assert false
 
   let pr_set_entry_type = function
     | ETName -> str"ident"
@@ -1201,20 +1229,23 @@ module Make
         return (str "}")
 
   and pr_extend s cl =
-    let pr_arg a =
+    let pr_based_on_grammar a =
       try pr_gen a
+      with Failure _ -> str "<error in " ++ str (fst s) ++ str ">" in
+    let pr_based_on_structure a =
+      try Pptactic.pr_raw_generic (Global.env ()) a
       with Failure _ -> str "<error in " ++ str (fst s) ++ str ">" in
     try
       let rl = Egramml.get_extend_vernac_rule s in
-      let rec aux rl cl =
+      let rec aux sep rl cl =
         match rl, cl with
-        | Egramml.GramNonTerminal _ :: rl, arg :: cl -> pr_arg arg :: aux rl cl
-        | Egramml.GramTerminal s :: rl, cl -> str s :: aux rl cl
+        | Egramml.GramNonTerminal (_,_,e) :: rl, (GenArg (wit,x)) :: cl -> pr_based_on_grammar (GenArg (wit,x),EntryName e) :: aux sep rl cl
+        | Egramml.GramTerminal s :: rl, cl -> sep() ++ str s :: aux spc rl cl
         | [], [] -> []
         | _ -> assert false in
-      hov 1 (pr_sequence (fun x -> x) (aux rl cl))
+      hov 1 (pr_sequence (fun x -> x) (aux mt rl cl))
     with Not_found ->
-      hov 1 (str "TODO(" ++ str (fst s) ++ spc () ++ prlist_with_sep sep pr_arg cl ++ str ")")
+      hov 1 (str "TODO(" ++ str (fst s) ++ spc () ++ prlist_with_sep sep pr_based_on_structure cl ++ str ")")
 
   let pr_vernac v =
     try pr_vernac_body v ++ sep_end v

--- a/printing/ppvernac.ml
+++ b/printing/ppvernac.ml
@@ -665,16 +665,8 @@ module Make
                        | Some sc -> spc() ++ str":" ++ spc() ++ str sc))
           )
         | VernacNotation (_,c,((_,s),l),opt) ->
-          let ps =
-            let n = String.length s in
-            if n > 2 && s.[0] == '\'' && s.[n-1] == '\''
-            then
-              let s' = String.sub s 1 (n-2) in
-              if String.contains s' '\'' then qs s else str s'
-            else qs s
-          in
           return (
-            hov 2 (keyword "Notation" ++ spc() ++ ps ++
+            hov 2 (keyword "Notation" ++ spc() ++ qs s ++
                      str " :=" ++ Flags.without_option Flags.beautify_file pr_constrarg c ++ pr_syntax_modifiers l ++
                      (match opt with
                        | None -> mt()

--- a/printing/ppvernac.ml
+++ b/printing/ppvernac.ml
@@ -1036,7 +1036,7 @@ module Make
                       spc() ++ pr_br imp max (pr_if k (str"!") ++ pr_name id ++ pr_s s) ++
                         aux (n-1) tl in
                 prlist_with_sep (fun () -> str", ") (aux nargs) impl ++
-                  if not (List.is_empty mods) then str" : " else str"" ++
+                  (if not (List.is_empty mods) then str" : " else str"") ++
                     prlist_with_sep (fun () -> str", " ++ spc()) (function
                       | `ReductionDontExposeCase -> keyword "simpl nomatch"
                       | `ReductionNeverUnfold -> keyword "simpl never"

--- a/printing/ppvernac.ml
+++ b/printing/ppvernac.ml
@@ -381,6 +381,14 @@ module Make
     | None -> mt ()
     | Some pl -> str"@{" ++ prlist_with_sep spc pr_lident pl ++ str"}"
 
+  let pr_rec_definition ((((loc,id),pl),ro,bl,type_,def),ntn) =
+    let pr_pure_lconstr c = Flags.without_option Flags.beautify_file pr_lconstr c in
+    let annot = pr_guard_annot pr_lconstr_expr bl ro in
+    pr_id id ++ pr_univs pl ++ pr_binders_arg bl ++ annot
+    ++ pr_type_option (fun c -> spc() ++ pr_lconstr_expr c) type_
+    ++ pr_opt (fun def -> str":=" ++ brk(1,2) ++ pr_pure_lconstr def) def
+    ++ prlist (pr_decl_notation pr_constr) ntn
+
   let pr_statement head (idpl,(bl,c,guard)) =
     assert (not (Option.is_empty idpl));
     let id, pl = Option.get idpl in
@@ -789,19 +797,10 @@ module Make
           | Some Local -> "Local "
           | None | Some Global -> ""
         in
-        let pr_pure_lconstr c =
-          Flags.without_option Flags.beautify_file pr_lconstr c in
-        let pr_onerec = function
-          | (((loc,id),pl),ro,bl,type_,def),ntn ->
-            let annot = pr_guard_annot pr_lconstr_expr bl ro in
-            pr_id id ++ pr_univs pl ++ pr_binders_arg bl ++ annot
-            ++ pr_type_option (fun c -> spc() ++ pr_lconstr_expr c) type_
-            ++ pr_opt (fun def -> str":=" ++ brk(1,2) ++ pr_pure_lconstr def) def ++
-              prlist (pr_decl_notation pr_constr) ntn
-        in
         return (
           hov 0 (str local ++ keyword "Fixpoint" ++ spc () ++
-                   prlist_with_sep (fun _ -> fnl () ++ keyword "with" ++ spc ()) pr_onerec recs)
+                   prlist_with_sep (fun _ -> fnl () ++ keyword "with"
+                     ++ spc ()) pr_rec_definition recs)
         )
 
       | VernacCoFixpoint (local, corecs) ->

--- a/printing/ppvernac.ml
+++ b/printing/ppvernac.ml
@@ -259,7 +259,8 @@ module Make
     | _ as c -> brk(0,2) ++ str" :" ++ pr_c c
 
   let pr_decl_notation prc ((loc,ntn),c,scopt) =
-    fnl () ++ keyword "where " ++ qs ntn ++ str " := " ++ prc c ++
+    fnl () ++ keyword "where " ++ qs ntn ++ str " := "
+    ++ Flags.without_option Flags.beautify_file prc c ++
       pr_opt (fun sc -> str ": " ++ str sc) scopt
 
   let pr_binders_arg =
@@ -674,7 +675,7 @@ module Make
           in
           return (
             hov 2 (keyword "Notation" ++ spc() ++ ps ++
-                     str " :=" ++ pr_constrarg c ++ pr_syntax_modifiers l ++
+                     str " :=" ++ Flags.without_option Flags.beautify_file pr_constrarg c ++ pr_syntax_modifiers l ++
                      (match opt with
                        | None -> mt()
                        | Some sc -> str" :" ++ spc() ++ str sc))
@@ -756,7 +757,7 @@ module Make
           let pr_constructor (coe,(id,c)) =
             hov 2 (pr_lident id ++ str" " ++
                      (if coe then str":>" else str":") ++
-                     pr_spc_lconstr c)
+                     Flags.without_option Flags.beautify_file pr_spc_lconstr c)
           in
           let pr_constructor_list b l = match l with
             | Constructors [] -> mt()
@@ -794,12 +795,14 @@ module Make
             | Some Local -> "Local "
             | None | Some Global -> ""
           in
+          let pr_pure_lconstr c =
+            Flags.without_option Flags.beautify_file pr_lconstr c in
           let pr_onerec = function
             | (((loc,id),pl),ro,bl,type_,def),ntn ->
               let annot = pr_guard_annot pr_lconstr_expr bl ro in
               pr_id id ++ pr_univs pl ++ pr_binders_arg bl ++ annot
               ++ pr_type_option (fun c -> spc() ++ pr_lconstr_expr c) type_
-              ++ pr_opt (fun def -> str":=" ++ brk(1,2) ++ pr_lconstr def) def ++
+              ++ pr_opt (fun def -> str":=" ++ brk(1,2) ++ pr_pure_lconstr def) def ++
                 prlist (pr_decl_notation pr_constr) ntn
           in
           return (

--- a/printing/ppvernacsig.mli
+++ b/printing/ppvernacsig.mli
@@ -8,6 +8,9 @@
 
 module type Pp = sig
 
+  (** Prints a fixpoint body *)
+  val pr_rec_definition : (Vernacexpr.fixpoint_expr * Vernacexpr.decl_notation list) -> Pp.std_ppcmds
+
   (** Prints a vernac expression *)
   val pr_vernac_body : Vernacexpr.vernac_expr -> Pp.std_ppcmds
 

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -8,8 +8,8 @@
 
 let pr_err s = Printf.eprintf "%s] %s\n" (System.process_id ()) s; flush stderr
 
-let prerr_endline s = if false then begin pr_err s end else ()
-let prerr_debug s = if !Flags.debug then begin pr_err s end else ()
+let prerr_endline s = if false then begin pr_err (s ()) end else ()
+let prerr_debug s = if !Flags.debug then begin pr_err (s ()) end else ()
 
 open Vernacexpr
 open Errors
@@ -104,11 +104,11 @@ let vernac_interp ?proof id ?route { verbose; loc; expr } =
     | VernacTime (_,e) | VernacRedirect (_,(_,e)) -> internal_command e
     | _ -> false in
   if internal_command expr then begin
-    prerr_endline ("ignoring " ^ string_of_ppcmds(pr_vernac expr))
+    prerr_endline (fun () -> "ignoring " ^ string_of_ppcmds(pr_vernac expr))
   end else begin
     set_id_for_feedback ?route (Feedback.State id);
     Aux_file.record_in_aux_set_at loc;
-    prerr_endline ("interpreting " ^ string_of_ppcmds(pr_vernac expr));
+    prerr_endline (fun () -> "interpreting " ^ string_of_ppcmds(pr_vernac expr));
     try Hooks.(call interp ?verbosely:(Some verbose) ?proof (loc, expr))
     with e ->
       let e = Errors.push e in
@@ -478,7 +478,7 @@ end = struct (* {{{ *)
         let branch, mode = match Vcs_aux.find_proof_at_depth !vcs pl with
           | h, { Vcs_.kind = `Proof (m, _) } -> h, m | _ -> assert false in
         checkout branch;
-        prerr_endline ("mode:" ^ mode);
+        prerr_endline (fun () -> "mode:" ^ mode);
         Proof_global.activate_proof_mode mode
       with Failure _ ->
         checkout Branch.master;
@@ -743,7 +743,7 @@ end = struct (* {{{ *)
     if is_cached id && not redefine then
       anomaly (str"defining state "++str str_id++str" twice");
     try
-      prerr_endline("defining "^str_id^" (cache="^
+      prerr_endline (fun () -> "defining "^str_id^" (cache="^
         if cache = `Yes then "Y)" else if cache = `Shallow then "S)" else "N)");
       let good_id = match safe_id with None -> !cur_id | Some id -> id in
       fix_exn_ref := exn_on id ~valid:good_id;
@@ -751,7 +751,7 @@ end = struct (* {{{ *)
       fix_exn_ref := (fun x -> x);
       if cache = `Yes then freeze `No id
       else if cache = `Shallow then freeze `Shallow id;
-      prerr_endline ("setting cur id to "^str_id);
+      prerr_endline (fun () -> "setting cur id to "^str_id);
       cur_id := id;
       if feedback_processed then
         Hooks.(call state_computed id ~in_cache:false);
@@ -1133,8 +1133,8 @@ end = struct (* {{{ *)
           | Some (safe, err) -> err, safe
           | None -> Stateid.dummy, Stateid.dummy in
         let e_msg = iprint (e, info) in
-        prerr_endline "failed with the following exception:";
-        prerr_endline (string_of_ppcmds e_msg);
+        prerr_endline (fun () -> "failed with the following exception:");
+        prerr_endline (fun () -> string_of_ppcmds e_msg);
         let e_safe_states = List.filter State.is_cached my_states in
         RespError { e_error_at; e_safe_id; e_msg; e_safe_states }
   
@@ -1400,7 +1400,7 @@ end = struct (* {{{ *)
              | Some (ReqBuildProof (r, b, _)) -> Some(r, b)
              | _ -> None)
         tasks in
-    prerr_endline (Printf.sprintf "dumping %d tasks\n" (List.length reqs));
+    prerr_endline (fun () -> Printf.sprintf "dumping %d tasks\n" (List.length reqs));
     reqs
 
   let reset_task_queue () = TaskQueue.clear (Option.get !queue)
@@ -1568,7 +1568,7 @@ end = struct (* {{{ *)
             with Not_found -> Errors.anomaly(str"Partac: wrong focus") in
           if Future.is_over f then
             let pt, uc = Future.join f in
-            prerr_endline (string_of_ppcmds(hov 0 (
+            prerr_endline (fun () -> string_of_ppcmds(hov 0 (
               str"g=" ++ str gid ++ spc () ++
               str"t=" ++ (Printer.pr_constr pt) ++ spc () ++
               str"uc=" ++ Evd.pr_evar_universe_context uc)));
@@ -1680,7 +1680,7 @@ let delegate name =
               || !Flags.async_proofs_full
  
 let collect_proof keep cur hd brkind id =
- prerr_endline ("Collecting proof ending at "^Stateid.to_string id);
+ prerr_endline (fun () -> "Collecting proof ending at "^Stateid.to_string id);
  let no_name = "" in
  let name = function
    | [] -> no_name
@@ -1781,7 +1781,7 @@ let string_of_reason = function
   | `NoPU_NoHint_NoES -> "no 'Proof using..', no .aux file, inside a section"
   | `Unknown -> "unsupported case"
 
-let log_string s = prerr_debug ("STM: " ^ s)
+let log_string s = prerr_debug (fun () -> "STM: " ^ s)
 let log_processing_async id name = log_string Printf.(sprintf
   "%s: proof %s: asynch" (Stateid.to_string id) name
 )
@@ -1803,17 +1803,17 @@ let known_state ?(redefine_qed=false) ~cache id =
     Summary.unfreeze_summary s; Lib.unfreeze l; update_global_env ()
   in
   let rec pure_cherry_pick_non_pstate id = Future.purify (fun id ->
-    prerr_endline ("cherry-pick non pstate " ^ Stateid.to_string id);
+    prerr_endline (fun () -> "cherry-pick non pstate " ^ Stateid.to_string id);
     reach id;
     cherry_pick_non_pstate ()) id
 
   (* traverses the dag backward from nodes being already calculated *)
   and reach ?(redefine_qed=false) ?(cache=cache) id =
-    prerr_endline ("reaching: " ^ Stateid.to_string id);
+    prerr_endline (fun () -> "reaching: " ^ Stateid.to_string id);
     if not redefine_qed && State.is_cached ~cache id then begin
       State.install_cached id;
       Hooks.(call state_computed id ~in_cache:true);
-      prerr_endline ("reached (cache)")
+      prerr_endline (fun () -> "reached (cache)")
     end else
     let step, cache_step, feedback_processed =
       let view = VCS.visit id in
@@ -1951,7 +1951,7 @@ let known_state ?(redefine_qed=false) ~cache id =
       else cache_step in
     State.define
       ~cache:cache_step ~redefine:redefine_qed ~feedback_processed step id;
-    prerr_endline ("reached: "^ Stateid.to_string id) in
+    prerr_endline (fun () -> "reached: "^ Stateid.to_string id) in
   reach ~redefine_qed id
 
 end (* }}} *)
@@ -1966,7 +1966,7 @@ let init () =
   Backtrack.record ();
   Slaves.init ();
   if Flags.async_proofs_is_master () then begin
-    prerr_endline "Initializing workers";
+    prerr_endline (fun () -> "Initializing workers");
     Query.init ();
     let opts = match !Flags.async_proofs_private_flags with
       | None -> []
@@ -2018,9 +2018,9 @@ let rec join_admitted_proofs id =
 let join () =
   finish ();
   wait ();
-  prerr_endline "Joining the environment";
+  prerr_endline (fun () -> "Joining the environment");
   Global.join_safe_environment ();
-  prerr_endline "Joining Admitted proofs";
+  prerr_endline (fun () -> "Joining Admitted proofs");
   join_admitted_proofs (VCS.get_branch_pos (VCS.current_branch ()));
   VCS.print ();
   VCS.print ()
@@ -2096,7 +2096,7 @@ let handle_failure (e, info) vcs tty =
       anomaly(str"error with no safe_id attached:" ++ spc() ++
         Errors.iprint_no_report (e, info))
   | Some (safe_id, id) ->
-      prerr_endline ("Failed at state " ^ Stateid.to_string id);
+      prerr_endline (fun () -> "Failed at state " ^ Stateid.to_string id);
       VCS.restore vcs;
       if tty && interactive () = `Yes then begin
         (* We stay on a valid state *)
@@ -2121,13 +2121,13 @@ let process_transaction ?(newtip=Stateid.fresh ()) ~tty verbose c (loc, expr) =
   let warn_if_pos a b =
     if b then msg_warning(pr_ast a ++ str" should not be part of a script") in
   let v, x = expr, { verbose = verbose; loc; expr } in
-  prerr_endline ("{{{ processing: "^ string_of_ppcmds (pr_ast x));
+  prerr_endline (fun () -> "{{{ processing: "^ string_of_ppcmds (pr_ast x));
   let vcs = VCS.backup () in
   try
     let head = VCS.current_branch () in
     VCS.checkout head;
     let rc = begin
-      prerr_endline ("  classified as: " ^ string_of_vernac_classification c);
+      prerr_endline (fun () -> "  classified as: " ^ string_of_vernac_classification c);
       match c with
       (* PG stuff *)    
       | VtStm(VtPG,false), VtNow -> vernac_interp Stateid.dummy x; `Ok
@@ -2163,7 +2163,7 @@ let process_transaction ?(newtip=Stateid.fresh ()) ~tty verbose c (loc, expr) =
           VCS.commit id (Alias (oid,x));
           Backtrack.record (); if w == VtNow then finish (); `Ok
       | VtStm (VtBack id, false), VtNow ->
-          prerr_endline ("undo to state " ^ Stateid.to_string id);
+          prerr_endline (fun () -> "undo to state " ^ Stateid.to_string id);
           Backtrack.backto id;
           VCS.checkout_shallowest_proof_branch ();
           Reach.known_state ~cache:(interactive ()) id; `Ok
@@ -2298,7 +2298,7 @@ let process_transaction ?(newtip=Stateid.fresh ()) ~tty verbose c (loc, expr) =
               expr = VernacShow (ShowGoal OpenSubgoals) }
       | _ -> ()
     end;
-    prerr_endline "processed }}}";
+    prerr_endline (fun () -> "processed }}}");
     VCS.print ();
     rc
   with e ->
@@ -2476,7 +2476,7 @@ let edit_at id =
         anomaly (str ("edit_at "^Stateid.to_string id^": ") ++
           Errors.print_no_report e)
     | Some (_, id) ->
-        prerr_endline ("Failed at state " ^ Stateid.to_string id);
+        prerr_endline (fun () -> "Failed at state " ^ Stateid.to_string id);
         VCS.restore vcs;
         VCS.print ();
         iraise (e, info)

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -2551,6 +2551,9 @@ let forward b usetac ipat c =
 	(Proofview.V82.tactic (exact_no_check c))
       end }
   | Some tac ->
+      let tac = match tac with
+        | None -> Tacticals.New.tclIDTAC
+        | Some tac -> Tacticals.New.tclCOMPLETE tac in
       if b then
         Tacticals.New.tclTHENFIRST (assert_as b None ipat c) tac
       else
@@ -2558,8 +2561,8 @@ let forward b usetac ipat c =
           (assert_as b None ipat c) [||] tac [|Tacticals.New.tclIDTAC|]
 
 let pose_proof na c = forward true None (ipat_of_name na) c
-let assert_by na t tac = forward true (Some tac) (ipat_of_name na) t
-let enough_by na t tac = forward false (Some tac) (ipat_of_name na) t
+let assert_by na t tac = forward true (Some (Some tac)) (ipat_of_name na) t
+let enough_by na t tac = forward false (Some (Some tac)) (ipat_of_name na) t
 
 (***************************)
 (*  Generalization tactics *)

--- a/tactics/tactics.mli
+++ b/tactics/tactics.mli
@@ -365,7 +365,7 @@ val pose_proof : Name.t -> constr ->
 
 (** Common entry point for user-level "assert", "enough" and "pose proof" *)
 
-val forward   : bool -> unit Proofview.tactic option ->
+val forward   : bool -> unit Proofview.tactic option option ->
   intro_pattern option -> constr -> unit Proofview.tactic
 
 (** Implements the tactic cut, actually a modus ponens rule *)

--- a/test-suite/output/Notations2.out
+++ b/test-suite/output/Notations2.out
@@ -50,3 +50,7 @@ end
      : nat -> nat
 # _ : nat => 2
      : nat -> nat
+fun x : nat => (## x) + x
+     : nat -> nat
+fun x : nat => ## x + x
+     : nat -> nat

--- a/test-suite/output/Notations2.v
+++ b/test-suite/output/Notations2.v
@@ -98,3 +98,10 @@ Notation "#  x : T => t" := (fun x : T => t)
 
 Check # x : nat => x.
 Check # _ : nat => 2.
+
+(* Check printing of notations that have arguments at higher level
+   than the notation itself *)
+
+Notation "## a" := (S a) (at level 0, a at level 100).
+Check fun x => (S x) + x.
+Check fun x => S (x + x).

--- a/theories/Init/Specif.v
+++ b/theories/Init/Specif.v
@@ -9,6 +9,7 @@
 (** Basic specifications : sets that may contain logical information *)
 
 Set Implicit Arguments.
+Set Reversible Pattern Implicit.
 
 Require Import Notations.
 Require Import Datatypes.

--- a/theories/Lists/List.v
+++ b/theories/Lists/List.v
@@ -26,83 +26,83 @@ In a special module to avoid conflicts. *)
 Module ListNotations.
 Notation " [ ] " := nil (format "[ ]") : list_scope.
 Notation " [ x ] " := (cons x nil) : list_scope.
-Notation " [ x ; y ; .. ; z ] " :=  (cons x (cons y .. (cons z nil) ..)) : list_scope.
+Notation " [ x ; y ; .. ; z ] " := (cons x (cons y .. (cons z nil) ..)) :
+  list_scope.
 End ListNotations.
 
 Import ListNotations.
 
 Section Lists.
 
-  Variable A : Type.
+  Variable (A : Type).
 
   (** Head and tail *)
 
-  Definition hd (default:A) (l:list A) :=
+  Definition hd (default : A) (l : list A) :=
     match l with
-      | [] => default
-      | x :: _ => x
+    | [] => default
+    | x :: _ => x
     end.
 
-  Definition hd_error (l:list A) :=
+  Definition hd_error (l : list A) :=
     match l with
-      | [] => None
-      | x :: _ => Some x
+    | [] => None
+    | x :: _ => Some x
     end.
 
-  Definition tl (l:list A) :=
-    match l with
-      | [] => nil
-      | a :: m => m
-    end.
+  Definition tl (l : list A) := match l with
+                                | [] => nil
+                                | a :: m => m
+                                end.
 
   (** The [In] predicate *)
-  Fixpoint In (a:A) (l:list A) : Prop :=
+  Fixpoint In (a : A) (l : list A) : Prop :=
     match l with
-      | [] => False
-      | b :: m => b = a \/ In a m
+    | [] => False
+    | b :: m => b = a \/ In a m
     end.
 
 End Lists.
 
 Section Facts.
 
-  Variable A : Type.
+  Variable (A : Type).
 
 
   (** *** Generic facts *)
 
   (** Discrimination *)
-  Theorem nil_cons : forall (x:A) (l:list A), [] <> x :: l.
+  Theorem nil_cons : forall (x : A) (l : list A), [] <> x :: l.
   Proof.
-    intros; discriminate.
+    intros **; discriminate.
   Qed.
 
 
   (** Destruction *)
 
-  Theorem destruct_list : forall l : list A, {x:A & {tl:list A | l = x::tl}}+{l = []}.
+  Theorem destruct_list :
+    forall l : list A, {x : A & {tl : list A | l = x :: tl}} + {l = []}.
   Proof.
-    induction l as [|a tail].
+    induction l as [| a tail].
     right; reflexivity.
-    left; exists a, tail; reflexivity.
+    left; exists a; exists tail; reflexivity.
   Qed.
 
-  Lemma hd_error_tl_repr : forall l (a:A) r,
-    hd_error l = Some a /\ tl l = r <-> l = a :: r.
-  Proof. destruct l as [|x xs].
+  Lemma hd_error_tl_repr :
+    forall l (a : A) r, hd_error l = Some a /\ tl l = r <-> l = a :: r.
+  Proof. destruct l as [| x xs].
     - unfold hd_error, tl; intros a r. split; firstorder discriminate.
-    - intros. simpl. split.
+    - intros **. simpl. split.
       * intros (H1, H2). inversion H1. rewrite H2. reflexivity.
       * inversion 1. subst. auto.
   Qed.
 
-  Lemma hd_error_some_nil : forall l (a:A), hd_error l = Some a -> l <> nil.
-  Proof. unfold hd_error. destruct l; now discriminate. Qed.
+  Lemma hd_error_some_nil : forall l (a : A), hd_error l = Some a -> l <> nil.
+  Proof. unfold hd_error. destruct l; (now (discriminate)). Qed.
 
-  Theorem length_zero_iff_nil (l : list A):
-    length l = 0 <-> l=[].
+  Theorem length_zero_iff_nil (l : list A) : length l = 0 <-> l = [].
   Proof.
-    split; [now destruct l | now intros ->].
+    split; [ now (destruct l) | now (intros ->) ].
   Qed.
 
   (** *** Head and tail *)
@@ -112,9 +112,10 @@ Section Facts.
     simpl; reflexivity.
   Qed.
 
-  Theorem hd_error_cons : forall (l : list A) (x : A), hd_error (x::l) = Some x.
+  Theorem hd_error_cons :
+    forall (l : list A) (x : A), hd_error (x :: l) = Some x.
   Proof.
-    intros; simpl; reflexivity.
+    intros **; simpl; reflexivity.
   Qed.
 
 
@@ -125,46 +126,48 @@ Section Facts.
 
   (** Characterization of [In] *)
 
-  Theorem in_eq : forall (a:A) (l:list A), In a (a :: l).
+  Theorem in_eq : forall (a : A) (l : list A), In a (a :: l).
   Proof.
     simpl; auto.
   Qed.
 
-  Theorem in_cons : forall (a b:A) (l:list A), In b l -> In b (a :: l).
+  Theorem in_cons : forall (a b : A) (l : list A), In b l -> In b (a :: l).
   Proof.
     simpl; auto.
   Qed.
 
-  Theorem not_in_cons (x a : A) (l : list A):
-    ~ In x (a::l) <-> x<>a /\ ~ In x l.
+  Theorem not_in_cons (x a : A) (l : list A) :
+    ~ In x (a :: l) <-> x <> a /\ ~ In x l.
   Proof.
     simpl. intuition.
   Qed.
 
-  Theorem in_nil : forall a:A, ~ In a [].
+  Theorem in_nil : forall a : A, ~ In a [].
   Proof.
     unfold not; intros a H; inversion_clear H.
   Qed.
 
-  Theorem in_split : forall x (l:list A), In x l -> exists l1 l2, l = l1++x::l2.
+  Theorem in_split :
+    forall x (l : list A), In x l -> exists l1 l2, l = l1 ++ x :: l2.
   Proof.
   induction l; simpl; destruct 1.
   subst a; auto.
-  exists [], l; auto.
-  destruct (IHl H) as (l1,(l2,H0)).
-  exists (a::l1), l2; simpl. apply f_equal. auto.
+  exists []; exists l; auto.
+  destruct (IHl H) as (l1, (l2, H0)).
+  exists (a :: l1); exists l2; simpl. apply f_equal. auto.
   Qed.
 
   (** Inversion *)
-  Lemma in_inv : forall (a b:A) (l:list A), In b (a :: l) -> a = b \/ In b l.
+  Lemma in_inv :
+    forall (a b : A) (l : list A), In b (a :: l) -> a = b \/ In b l.
   Proof.
     intros a b l H; inversion_clear H; auto.
   Qed.
 
   (** Decidability of [In] *)
   Theorem in_dec :
-    (forall x y:A, {x = y} + {x <> y}) ->
-    forall (a:A) (l:list A), {In a l} + {~ In a l}.
+    (forall x y : A, {x = y} + {x <> y}) ->
+    forall (a : A) (l : list A), {In a l} + {~ In a l}.
   Proof.
     intro H; induction l as [| a0 l IHl].
     right; apply in_nil.
@@ -179,41 +182,42 @@ Section Facts.
   (**************************)
 
   (** Discrimination *)
-  Theorem app_cons_not_nil : forall (x y:list A) (a:A), [] <> x ++ a :: y.
+  Theorem app_cons_not_nil : forall (x y : list A) (a : A), [] <> x ++ a :: y.
   Proof.
     unfold not.
-    destruct x as [| a l]; simpl; intros.
+    destruct x as [| a l]; simpl; intros **.
     discriminate H.
     discriminate H.
   Qed.
 
 
   (** Concat with [nil] *)
-  Theorem app_nil_l : forall l:list A, [] ++ l = l.
+  Theorem app_nil_l : forall l : list A, [] ++ l = l.
   Proof.
     reflexivity.
   Qed.
 
-  Theorem app_nil_r : forall l:list A, l ++ [] = l.
+  Theorem app_nil_r : forall l : list A, l ++ [] = l.
   Proof. 
     induction l; simpl; f_equal; auto.
   Qed.
 
   (* begin hide *)
   (* Deprecated *)
-  Theorem app_nil_end : forall (l:list A), l = l ++ [].
+  Theorem app_nil_end : forall l : list A, l = l ++ [].
   Proof. symmetry; apply app_nil_r. Qed.
   (* end hide *)
 
   (** [app] is associative *)
-  Theorem app_assoc : forall l m n:list A, l ++ m ++ n = (l ++ m) ++ n.
+  Theorem app_assoc : forall l m n : list A, l ++ m ++ n = (l ++ m) ++ n.
   Proof.
     intros l m n; induction l; simpl; f_equal; auto.
   Qed.
 
   (* begin hide *)
   (* Deprecated *)
-  Theorem app_assoc_reverse : forall l m n:list A, (l ++ m) ++ n = l ++ m ++ n.
+  Theorem app_assoc_reverse :
+    forall l m n : list A, (l ++ m) ++ n = l ++ m ++ n.
   Proof.
      auto using app_assoc.
   Qed.
@@ -221,14 +225,16 @@ Section Facts.
   (* end hide *)
 
   (** [app] commutes with [cons] *)
-  Theorem app_comm_cons : forall (x y:list A) (a:A), a :: (x ++ y) = (a :: x) ++ y.
+  Theorem app_comm_cons :
+    forall (x y : list A) (a : A), a :: x ++ y = (a :: x) ++ y.
   Proof.
     auto.
   Qed.
 
   (** Facts deduced from the result of a concatenation *)
 
-  Theorem app_eq_nil : forall l l':list A, l ++ l' = [] -> l = [] /\ l' = [].
+  Theorem app_eq_nil :
+    forall l l' : list A, l ++ l' = [] -> l = [] /\ l' = [].
   Proof.
     destruct l as [| x l]; destruct l' as [| y l']; simpl; auto.
     intro; discriminate.
@@ -236,18 +242,19 @@ Section Facts.
   Qed.
 
   Theorem app_eq_unit :
-    forall (x y:list A) (a:A),
-      x ++ y = [a] -> x = [] /\ y = [a] \/ x = [a] /\ y = [].
+    forall (x y : list A) (a : A),
+    x ++ y = [a] -> x = [] /\ y = [a] \/ x = [a] /\ y = [].
   Proof.
-    destruct x as [| a l]; [ destruct y as [| a l] | destruct y as [| a0 l0] ];
-      simpl.
+    destruct x as [| a l];
+     [ destruct y as [| a l] | destruct y as [| a0 l0] ]; 
+     simpl.
     intros a H; discriminate H.
     left; split; auto.
     right; split; auto.
     generalize H.
     generalize (app_nil_r l); intros E.
-    rewrite -> E; auto.
-    intros.
+    rewrite E; auto.
+    intros **.
     injection H.
     intro.
     assert ([] = l ++ a0 :: l0) by auto.
@@ -255,11 +262,11 @@ Section Facts.
   Qed.
 
   Lemma app_inj_tail :
-    forall (x y:list A) (a b:A), x ++ [a] = y ++ [b] -> x = y /\ a = b.
+    forall (x y : list A) (a b : A), x ++ [a] = y ++ [b] -> x = y /\ a = b.
   Proof.
     induction x as [| x l IHl];
-      [ destruct y as [| a l] | destruct y as [| a l0] ];
-      simpl; auto.
+     [ destruct y as [| a l] | destruct y as [| a l0] ]; 
+     simpl; auto.
     - intros a b H.
       injection H.
       auto.
@@ -272,19 +279,21 @@ Section Facts.
       apply app_cons_not_nil in H as [].
     - intros a0 b H.
       injection H as <- H0.
-      destruct (IHl l0 a0 b H0) as (<-,<-).
+      destruct (IHl l0 a0 b H0) as (<-, <-).
       split; auto.
   Qed.
 
 
   (** Compatibility with other operations *)
 
-  Lemma app_length : forall l l' : list A, length (l++l') = length l + length l'.
+  Lemma app_length :
+    forall l l' : list A, length (l ++ l') = length l + length l'.
   Proof.
     induction l; simpl; auto.
   Qed.
 
-  Lemma in_app_or : forall (l m:list A) (a:A), In a (l ++ m) -> In a l \/ In a m.
+  Lemma in_app_or :
+    forall (l m : list A) (a : A), In a (l ++ m) -> In a l \/ In a m.
   Proof.
     intros l m a.
     elim l; simpl; auto.
@@ -296,7 +305,8 @@ Section Facts.
     elim (H H1); auto.
   Qed.
 
-  Lemma in_or_app : forall (l m:list A) (a:A), In a l \/ In a m -> In a (l ++ m).
+  Lemma in_or_app :
+    forall (l m : list A) (a : A), In a l \/ In a m -> In a (l ++ m).
   Proof.
     intros l m a.
     elim l; simpl; intro H.
@@ -312,30 +322,29 @@ Section Facts.
     elim H2; auto.
   Qed.
 
-  Lemma in_app_iff : forall l l' (a:A), In a (l++l') <-> In a l \/ In a l'.
+  Lemma in_app_iff :
+    forall l l' (a : A), In a (l ++ l') <-> In a l \/ In a l'.
   Proof.
     split; auto using in_app_or, in_or_app.
   Qed.
 
-  Lemma app_inv_head:
-   forall l l1 l2 : list A, l ++ l1 = l ++ l2 -> l1 = l2.
+  Lemma app_inv_head : forall l l1 l2 : list A, l ++ l1 = l ++ l2 -> l1 = l2.
   Proof.
     induction l; simpl; auto; injection 1; auto.
   Qed.
 
-  Lemma app_inv_tail:
-    forall l l1 l2 : list A, l1 ++ l = l2 ++ l -> l1 = l2.
+  Lemma app_inv_tail : forall l l1 l2 : list A, l1 ++ l = l2 ++ l -> l1 = l2.
   Proof.
     intros l l1 l2; revert l1 l2 l.
-    induction l1 as [ | x1 l1]; destruct l2 as [ | x2 l2];
-     simpl; auto; intros l H.
+    induction l1 as [| x1 l1]; destruct l2 as [| x2 l2]; simpl; auto;
+     intros l H.
     absurd (length (x2 :: l2 ++ l) <= length l).
     simpl; rewrite app_length; auto with arith.
     rewrite <- H; auto with arith.
     absurd (length (x1 :: l1 ++ l) <= length l).
     simpl; rewrite app_length; auto with arith.
     rewrite H; auto with arith.
-    injection H; clear H; intros; f_equal; eauto.
+    injection H; clear H; intros **; f_equal; eauto.
   Qed.
 
 End Facts.
@@ -354,68 +363,70 @@ Hint Resolve in_eq in_cons in_inv in_nil in_app_or in_or_app: datatypes v62.
 
 Section Elts.
 
-  Variable A : Type.
+  Variable (A : Type).
 
   (*****************************)
   (** ** Nth element of a list *)
   (*****************************)
 
-  Fixpoint nth (n:nat) (l:list A) (default:A) {struct l} : A :=
+  Fixpoint nth (n : nat) (l : list A) (default : A) {struct l} : A :=
     match n, l with
-      | O, x :: l' => x
-      | O, other => default
-      | S m, [] => default
-      | S m, x :: t => nth m t default
+    | O, x :: l' => x
+    | O, other => default
+    | S m, [] => default
+    | S m, x :: t => nth m t default
     end.
 
-  Fixpoint nth_ok (n:nat) (l:list A) (default:A) {struct l} : bool :=
+  Fixpoint nth_ok (n : nat) (l : list A) (default : A) {struct l} : bool :=
     match n, l with
-      | O, x :: l' => true
-      | O, other => false
-      | S m, [] => false
-      | S m, x :: t => nth_ok m t default
+    | O, x :: l' => true
+    | O, other => false
+    | S m, [] => false
+    | S m, x :: t => nth_ok m t default
     end.
 
   Lemma nth_in_or_default :
-    forall (n:nat) (l:list A) (d:A), {In (nth n l d) l} + {nth n l d = d}.
+    forall (n : nat) (l : list A) (d : A),
+    {In (nth n l d) l} + {nth n l d = d}.
   Proof.
     intros n l d; revert n; induction l.
     - right; destruct n; trivial.
-    - intros [|n]; simpl.
+    - intros [| n]; simpl.
       * left; auto.
       * destruct (IHl n); auto.
   Qed.
 
   Lemma nth_S_cons :
-    forall (n:nat) (l:list A) (d a:A),
-      In (nth n l d) l -> In (nth (S n) (a :: l) d) (a :: l).
+    forall (n : nat) (l : list A) (d a : A),
+    In (nth n l d) l -> In (nth (S n) (a :: l) d) (a :: l).
   Proof.
     simpl; auto.
   Qed.
 
-  Fixpoint nth_error (l:list A) (n:nat) {struct n} : option A :=
+  Fixpoint nth_error (l : list A) (n : nat) {struct n} : 
+  option A :=
     match n, l with
-      | O, x :: _ => Some x
-      | S n, _ :: l => nth_error l n
-      | _, _ => None
+    | O, x :: _ => Some x
+    | S n, _ :: l => nth_error l n
+    | _, _ => None
     end.
 
-  Definition nth_default (default:A) (l:list A) (n:nat) : A :=
+  Definition nth_default (default : A) (l : list A) 
+    (n : nat) : A :=
     match nth_error l n with
-      | Some x => x
-      | None => default
+    | Some x => x
+    | None => default
     end.
 
-  Lemma nth_default_eq :
-    forall n l (d:A), nth_default d l n = nth n l d.
+  Lemma nth_default_eq : forall n l (d : A), nth_default d l n = nth n l d.
   Proof.
-    unfold nth_default; induction n; intros [ | ] ?; simpl; auto.
+    unfold nth_default; induction n; intros [| ] ?; simpl; auto.
   Qed.
 
   (** Results about [nth] *)
 
   Lemma nth_In :
-    forall (n:nat) (l:list A) (d:A), n < length l -> In (nth n l d) l.
+    forall (n : nat) (l : list A) (d : A), n < length l -> In (nth n l d) l.
   Proof.
     unfold lt; induction n as [| n hn]; simpl.
     - destruct l; simpl; [ inversion 2 | auto ].
@@ -424,74 +435,74 @@ Section Elts.
       * intros d ie; right; apply hn; auto with arith.
   Qed.
 
-  Lemma In_nth l x d : In x l ->
-    exists n, n < length l /\ nth n l d = x.
+  Lemma In_nth l x d : In x l -> exists n, n < length l /\ nth n l d = x.
   Proof.
-    induction l as [|a l IH].
+    induction l as [| a l IH].
     - easy.
-    - intros [H|H].
+    - intros [H| H].
       * subst; exists 0; simpl; auto with arith.
-      * destruct (IH H) as (n & Hn & Hn').
+      * destruct (IH H) as (n, (Hn, Hn')).
         exists (S n); simpl; auto with arith.
   Qed.
 
   Lemma nth_overflow : forall l n d, length l <= n -> nth n l d = d.
   Proof.
-    induction l; destruct n; simpl; intros; auto.
+    induction l; destruct n; simpl; intros **; auto.
     - inversion H.
     - apply IHl; auto with arith.
   Qed.
 
-  Lemma nth_indep :
-    forall l n d d', n < length l -> nth n l d = nth n l d'.
+  Lemma nth_indep : forall l n d d', n < length l -> nth n l d = nth n l d'.
   Proof.
     induction l.
     - inversion 1.
-    - intros [|n] d d'; simpl; auto with arith.
+    - intros [| n] d d'; simpl; auto with arith.
   Qed.
 
   Lemma app_nth1 :
-    forall l l' d n, n < length l -> nth n (l++l') d = nth n l d.
+    forall l l' d n, n < length l -> nth n (l ++ l') d = nth n l d.
   Proof.
     induction l.
     - inversion 1.
-    - intros l' d [|n]; simpl; auto with arith.
+    - intros l' d [| n]; simpl; auto with arith.
   Qed.
 
   Lemma app_nth2 :
-    forall l l' d n, n >= length l -> nth n (l++l') d = nth (n-length l) l' d.
+    forall l l' d n,
+    n >= length l -> nth n (l ++ l') d = nth (n - length l) l' d.
   Proof.
-    induction l; intros l' d [|n]; auto.
+    induction l; intros l' d [| n]; auto.
     - inversion 1.
-    - intros; simpl; rewrite IHl; auto with arith.
+    - intros **; simpl; rewrite IHl; auto with arith.
   Qed.
 
-  Lemma nth_split n l d : n < length l ->
+  Lemma nth_split n l d :
+    n < length l ->
     exists l1, exists l2, l = l1 ++ nth n l d :: l2 /\ length l1 = n.
   Proof.
     revert l.
-    induction n as [|n IH]; intros [|a l] H; try easy.
-    - exists nil; exists l; now simpl.
-    - destruct (IH l) as (l1 & l2 & Hl & Hl1); auto with arith.
-      exists (a::l1); exists l2; simpl; split; now f_equal.
+    induction n as [| n IH]; intros [| a l] H; try easy.
+    - exists nil; exists l; (now (simpl)).
+    - destruct (IH l) as (l1, (l2, (Hl, Hl1))); auto with arith.
+      exists (a :: l1); exists l2; simpl; split; (now f_equal).
   Qed.
 
   (** Results about [nth_error] *)
 
   Lemma nth_error_In l n x : nth_error l n = Some x -> In x l.
   Proof.
-    revert n. induction l as [|a l IH]; intros [|n]; simpl; try easy.
+    revert n. induction l as [| a l IH]; intros [| n]; simpl; try easy.
     - injection 1; auto.
     - eauto.
   Qed.
 
   Lemma In_nth_error l x : In x l -> exists n, nth_error l n = Some x.
   Proof.
-    induction l as [|a l IH].
+    induction l as [| a l IH].
     - easy.
-    - intros [H|H].
+    - intros [H| H].
       * subst; exists 0; simpl; auto with arith.
-      * destruct (IH H) as (n,Hn).
+      * destruct (IH H) as (n, Hn).
         exists (S n); simpl; auto with arith.
   Qed.
 
@@ -500,42 +511,43 @@ Section Elts.
     revert n. induction l; destruct n; simpl.
     - split; auto.
     - split; auto with arith.
-    - split; now auto with arith.
+    - split; (now (auto with arith)).
     - rewrite IHl; split; auto with arith.
   Qed.
 
   Lemma nth_error_Some l n : nth_error l n <> None <-> n < length l.
   Proof.
    revert n. induction l; destruct n; simpl.
-    - split; [now destruct 1 | inversion 1].
-    - split; [now destruct 1 | inversion 1].
-    - split; now auto with arith.
+    - split; [ now (destruct 1) | inversion 1 ].
+    - split; [ now (destruct 1) | inversion 1 ].
+    - split; (now (auto with arith)).
     - rewrite IHl; split; auto with arith.
   Qed.
 
-  Lemma nth_error_split l n a : nth_error l n = Some a ->
+  Lemma nth_error_split l n a :
+    nth_error l n = Some a ->
     exists l1, exists l2, l = l1 ++ a :: l2 /\ length l1 = n.
   Proof.
     revert l.
-    induction n as [|n IH]; intros [|x l] H; simpl in *; try easy.
-    - exists nil; exists l. injection H; clear H; intros; now subst.
-    - destruct (IH _ H) as (l1 & l2 & H1 & H2).
-      exists (x::l1); exists l2; simpl; split; now f_equal.
+    induction n as [| n IH]; intros [| x l] H; simpl in *; try easy.
+    - exists nil; exists l. injection H; clear H; intros **; (now (subst)).
+    - destruct (IH _ H) as (l1, (l2, (H1, H2))).
+      exists (x :: l1); exists l2; simpl; split; (now f_equal).
   Qed.
 
-  Lemma nth_error_app1 l l' n : n < length l ->
-    nth_error (l++l') n = nth_error l n.
+  Lemma nth_error_app1 l l' n :
+    n < length l -> nth_error (l ++ l') n = nth_error l n.
   Proof.
     revert l.
-    induction n; intros [|a l] H; auto; try solve [inversion H].
+    induction n; intros [| a l] H; auto; try (solve [ inversion H ]).
     simpl in *. apply IHn. auto with arith.
   Qed.
 
-  Lemma nth_error_app2 l l' n : length l <= n ->
-    nth_error (l++l') n = nth_error l' (n-length l).
+  Lemma nth_error_app2 l l' n :
+    length l <= n -> nth_error (l ++ l') n = nth_error l' (n - length l).
   Proof.
     revert l.
-    induction n; intros [|a l] H; auto; try solve [inversion H].
+    induction n; intros [| a l] H; auto; try (solve [ inversion H ]).
     simpl in *. apply IHn. auto with arith.
   Qed.
 
@@ -543,18 +555,18 @@ Section Elts.
   (** ** Remove    *)
   (*****************)
 
-  Hypothesis eq_dec : forall x y : A, {x = y}+{x <> y}.
+  Hypothesis (eq_dec : forall x y : A, {x = y} + {x <> y}).
 
   Fixpoint remove (x : A) (l : list A) : list A :=
     match l with
-      | [] => []
-      | y::tl => if (eq_dec x y) then remove x tl else y::(remove x tl)
+    | [] => []
+    | y :: tl => if eq_dec x y then remove x tl else y :: remove x tl
     end.
 
   Theorem remove_In : forall (l : list A) (x : A), ~ In x (remove x l).
   Proof.
-    induction l as [|x l]; auto.
-    intro y; simpl; destruct (eq_dec y x) as [yeqx | yneqx].
+    induction l as [| x l]; auto.
+    intro y; simpl; destruct (eq_dec y x) as [yeqx| yneqx].
     apply IHl.
     unfold not; intro HF; simpl in HF; destruct HF; auto.
     apply (IHl y); assumption.
@@ -568,20 +580,20 @@ Section Elts.
   (** [last l d] returns the last element of the list [l],
     or the default value [d] if [l] is empty. *)
 
-  Fixpoint last (l:list A) (d:A) : A :=
-  match l with
+  Fixpoint last (l : list A) (d : A) : A :=
+    match l with
     | [] => d
     | [a] => a
     | a :: l => last l d
-  end.
+    end.
 
   (** [removelast l] remove the last element of [l] *)
 
-  Fixpoint removelast (l:list A) : list A :=
+  Fixpoint removelast (l : list A) : list A :=
     match l with
-      | [] =>  []
-      | [a] => []
-      | a :: l => a :: removelast l
+    | [] => []
+    | [a] => []
+    | a :: l => a :: removelast l
     end.
 
   Lemma app_removelast_last :
@@ -591,34 +603,34 @@ Section Elts.
     destruct 1; auto.
     intros d _.
     destruct l; auto.
-    pattern (a0::l) at 1; rewrite IHl with d; auto; discriminate.
+    pattern (a0 :: l) at 1; rewrite IHl with d; auto; discriminate.
   Qed.
 
   Lemma exists_last :
-    forall l, l <> [] -> { l' : (list A) & { a : A | l = l' ++ [a]}}.
+    forall l, l <> [] -> {l' : list A & {a : A | l = l' ++ [a]}}.
   Proof.
     induction l.
     destruct 1; auto.
     intros _.
     destruct l.
-    exists [], a; auto.
-    destruct IHl as [l' (a',H)]; try discriminate.
+    exists []; exists a; auto.
+    destruct IHl as [l' (a', H)]; try discriminate.
     rewrite H.
-    exists (a::l'), a'; auto.
+    exists (a :: l'); exists a'; auto.
   Qed.
 
   Lemma removelast_app :
-    forall l l', l' <> [] -> removelast (l++l') = l ++ removelast l'.
+    forall l l', l' <> [] -> removelast (l ++ l') = l ++ removelast l'.
   Proof.
     induction l.
     simpl; auto.
-    simpl; intros.
-    assert (l++l' <> []).
+    simpl; intros **.
+    assert (l ++ l' <> []).
     destruct l.
     simpl; auto.
     simpl; discriminate.
     specialize (IHl l' H).
-    destruct (l++l'); [elim H0; auto|f_equal; auto].
+    destruct (l ++ l'); [ elim H0; auto | f_equal; auto ].
   Qed.
 
 
@@ -628,23 +640,21 @@ Section Elts.
 
   Fixpoint count_occ (l : list A) (x : A) : nat :=
     match l with
-      | [] => 0
-      | y :: tl =>
-        let n := count_occ tl x in
-        if eq_dec y x then S n else n
+    | [] => 0
+    | y :: tl => let n := count_occ tl x in if eq_dec y x then S n else n
     end.
 
   (** Compatibility of count_occ with operations on list *)
   Theorem count_occ_In l x : In x l <-> count_occ l x > 0.
   Proof.
-    induction l as [|y l]; simpl.
-    - split; [destruct 1 | apply gt_irrefl].
-    - destruct eq_dec as [->|Hneq]; rewrite IHl; intuition.
+    induction l as [| y l]; simpl.
+    - split; [ destruct 1 | apply gt_irrefl ].
+    - destruct eq_dec as [->| Hneq]; rewrite IHl; intuition.
   Qed.
 
   Theorem count_occ_not_In l x : ~ In x l <-> count_occ l x = 0.
   Proof.
-    rewrite count_occ_In. unfold gt. now rewrite Nat.nlt_ge, Nat.le_0_r.
+    rewrite count_occ_In. unfold gt. now (rewrite Nat.nlt_ge, Nat.le_0_r).
   Qed.
 
   Lemma count_occ_nil x : count_occ [] x = 0.
@@ -652,26 +662,25 @@ Section Elts.
     reflexivity.
   Qed.
 
-  Theorem count_occ_inv_nil l :
-    (forall x:A, count_occ l x = 0) <-> l = [].
+  Theorem count_occ_inv_nil l : (forall x : A, count_occ l x = 0) <-> l = [].
   Proof.
     split.
-    - induction l as [|x l]; trivial.
+    - induction l as [| x l]; trivial.
       intros H. specialize (H x). simpl in H.
-      destruct eq_dec as [_|NEQ]; [discriminate|now elim NEQ].
-    - now intros ->.
+      destruct eq_dec as [_| NEQ]; [ discriminate | now (elim NEQ) ].
+    - now (intros ->).
   Qed.
 
   Lemma count_occ_cons_eq l x y :
-    x = y -> count_occ (x::l) y = S (count_occ l y).
+    x = y -> count_occ (x :: l) y = S (count_occ l y).
   Proof.
-    intros H. simpl. now destruct (eq_dec x y).
+    intros H. simpl. now (destruct (eq_dec x y)).
   Qed.
 
   Lemma count_occ_cons_neq l x y :
-    x <> y -> count_occ (x::l) y = count_occ l y.
+    x <> y -> count_occ (x :: l) y = count_occ l y.
   Proof.
-    intros H. simpl. now destruct (eq_dec x y).
+    intros H. simpl. now (destruct (eq_dec x y)).
   Qed.
 
 End Elts.
@@ -682,19 +691,19 @@ End Elts.
 
 Section ListOps.
 
-  Variable A : Type.
+  Variable (A : Type).
 
   (*************************)
   (** ** Reverse           *)
   (*************************)
 
-  Fixpoint rev (l:list A) : list A :=
+  Fixpoint rev (l : list A) : list A :=
     match l with
-      | [] => []
-      | x :: l' => rev l' ++ [x]
+    | [] => []
+    | x :: l' => rev l' ++ [x]
     end.
 
-  Lemma rev_app_distr : forall x y:list A, rev (x ++ y) = rev y ++ rev x.
+  Lemma rev_app_distr : forall x y : list A, rev (x ++ y) = rev y ++ rev x.
   Proof.
     induction x as [| a l IHl].
     destruct y as [| a l].
@@ -710,13 +719,13 @@ Section ListOps.
     rewrite app_assoc; trivial.
   Qed.
 
-  Remark rev_unit : forall (l:list A) (a:A), rev (l ++ [a]) = a :: rev l.
+  Remark rev_unit : forall (l : list A) (a : A), rev (l ++ [a]) = a :: rev l.
   Proof.
-    intros.
+    intros **.
     apply (rev_app_distr l [a]); simpl; auto.
   Qed.
 
-  Lemma rev_involutive : forall l:list A, rev (rev l) = l.
+  Lemma rev_involutive : forall l : list A, rev (rev l) = l.
   Proof.
     induction l as [| a l IHl].
     simpl; auto.
@@ -733,7 +742,7 @@ Section ListOps.
   Proof.
     induction l.
     simpl; intuition.
-    intros.
+    intros **.
     simpl.
     intuition.
     subst.
@@ -744,19 +753,19 @@ Section ListOps.
 
   Lemma rev_length : forall l, length (rev l) = length l.
   Proof.
-    induction l;simpl; auto.
+    induction l; simpl; auto.
     rewrite app_length.
     rewrite IHl.
     simpl.
     elim (length l); simpl; auto.
   Qed.
 
-  Lemma rev_nth : forall l d n,  n < length l ->
-    nth n (rev l) d = nth (length l - S n) l d.
+  Lemma rev_nth :
+    forall l d n, n < length l -> nth n (rev l) d = nth (length l - S n) l d.
   Proof.
     induction l.
-    intros; inversion H.
-    intros.
+    intros **; inversion H.
+    intros **.
     simpl in H.
     simpl (rev (a :: l)).
     simpl (length (a :: l) - S n).
@@ -769,30 +778,30 @@ Section ListOps.
     rewrite (minus_plus_simpl_l_reverse (length l) n 1).
     replace (1 + length l) with (S (length l)); auto with arith.
     rewrite <- minus_Sn_m; auto with arith.
-    apply IHl ; auto with arith.
+    apply IHl; auto with arith.
     rewrite rev_length; auto.
   Qed.
 
 
   (**  An alternative tail-recursive definition for reverse *)
 
-  Fixpoint rev_append (l l': list A) : list A :=
+  Fixpoint rev_append (l l' : list A) : list A :=
     match l with
-      | [] => l'
-      | a::l => rev_append l (a::l')
+    | [] => l'
+    | a :: l => rev_append l (a :: l')
     end.
 
   Definition rev' l : list A := rev_append l [].
 
   Lemma rev_append_rev : forall l l', rev_append l l' = rev l ++ l'.
   Proof.
-    induction l; simpl; auto; intros.
+    induction l; simpl; auto; intros **.
     rewrite <- app_assoc; firstorder.
   Qed.
 
   Lemma rev_alt : forall l, rev l = rev_append l [].
   Proof.
-    intros; rewrite rev_append_rev.
+    intros **; rewrite rev_append_rev.
     rewrite app_nil_r; trivial.
   Qed.
 
@@ -804,27 +813,28 @@ Section ListOps.
   Section Reverse_Induction.
 
     Lemma rev_list_ind :
-      forall P:list A-> Prop,
-	P [] ->
-	(forall (a:A) (l:list A), P (rev l) -> P (rev (a :: l))) ->
-	forall l:list A, P (rev l).
+      forall P : list A -> Prop,
+      P [] ->
+      (forall (a : A) (l : list A), P (rev l) -> P (rev (a :: l))) ->
+      forall l : list A, P (rev l).
     Proof.
       induction l; auto.
     Qed.
 
     Theorem rev_ind :
-      forall P:list A -> Prop,
-	P [] ->
-	(forall (x:A) (l:list A), P l -> P (l ++ [x])) -> forall l:list A, P l.
+      forall P : list A -> Prop,
+      P [] ->
+      (forall (x : A) (l : list A), P l -> P (l ++ [x])) ->
+      forall l : list A, P l.
     Proof.
-      intros.
+      intros **.
       generalize (rev_involutive l).
       intros E; rewrite <- E.
       apply (rev_list_ind P).
       auto.
 
       simpl.
-      intros.
+      intros **.
       apply (H0 a (rev l0)).
       auto.
     Qed.
@@ -836,10 +846,10 @@ Section ListOps.
   (*************************)
 
   Fixpoint concat (l : list (list A)) : list A :=
-  match l with
-  | nil => nil
-  | cons x l => x ++ concat l
-  end.
+    match l with
+    | nil => nil
+    | cons x l => x ++ concat l
+    end.
 
   Lemma concat_nil : concat nil = nil.
   Proof.
@@ -853,7 +863,7 @@ Section ListOps.
 
   Lemma concat_app : forall l1 l2, concat (l1 ++ l2) = concat l1 ++ concat l2.
   Proof.
-  intros l1; induction l1 as [|x l1 IH]; intros l2; simpl.
+  intros l1; induction l1 as [| x l1 IH]; intros l2; simpl.
   + reflexivity.
   + rewrite IH; apply app_assoc.
   Qed.
@@ -862,9 +872,9 @@ Section ListOps.
   (** ** Decidable equality on lists *)
   (***********************************)
 
-  Hypothesis eq_dec : forall (x y : A), {x = y}+{x <> y}.
+  Hypothesis (eq_dec : forall x y : A, {x = y} + {x <> y}).
 
-  Lemma list_eq_dec : forall l l':list A, {l = l'} + {l <> l'}.
+  Lemma list_eq_dec : forall l l' : list A, {l = l'} + {l <> l'}.
   Proof. decide equality. Defined.
 
 End ListOps.
@@ -879,28 +889,28 @@ End ListOps.
 
 Section Map.
   Variables (A : Type) (B : Type).
-  Variable f : A -> B.
+  Variable (f : A -> B).
 
-  Fixpoint map (l:list A) : list B :=
+  Fixpoint map (l : list A) : list B :=
     match l with
-      | [] => []
-      | a :: t => (f a) :: (map t)
+    | [] => []
+    | a :: t => f a :: map t
     end.
 
-  Lemma map_cons (x:A)(l:list A) : map (x::l) = (f x) :: (map l).
+  Lemma map_cons (x : A) (l : list A) : map (x :: l) = f x :: map l.
   Proof.
     reflexivity.
   Qed.
 
-  Lemma in_map :
-    forall (l:list A) (x:A), In x l -> In (f x) (map l).
+  Lemma in_map : forall (l : list A) (x : A), In x l -> In (f x) (map l).
   Proof.
-    induction l; firstorder (subst; auto).
+    induction l; firstorder subst; auto.
   Qed.
 
-  Lemma in_map_iff : forall l y, In y (map l) <-> exists x, f x = y /\ In x l.
+  Lemma in_map_iff :
+    forall l y, In y (map l) <-> (exists x, f x = y /\ In x l).
   Proof.
-    induction l; firstorder (subst; auto).
+    induction l; firstorder subst; auto.
   Qed.
 
   Lemma map_length : forall l, length (map l) = length l.
@@ -908,23 +918,21 @@ Section Map.
     induction l; simpl; auto.
   Qed.
 
-  Lemma map_nth : forall l d n,
-    nth n (map l) (f d) = f (nth n l d).
+  Lemma map_nth : forall l d n, nth n (map l) (f d) = f (nth n l d).
   Proof.
     induction l; simpl map; destruct n; firstorder.
   Qed.
 
-  Lemma map_nth_error : forall n l d,
-    nth_error l n = Some d -> nth_error (map l) n = Some (f d).
+  Lemma map_nth_error :
+    forall n l d, nth_error l n = Some d -> nth_error (map l) n = Some (f d).
   Proof.
-    induction n; intros [ | ] ? Heq; simpl in *; inversion Heq; auto.
+    induction n; intros [| ] ? Heq; simpl in *; inversion Heq; auto.
   Qed.
 
-  Lemma map_app : forall l l',
-    map (l++l') = (map l)++(map l').
+  Lemma map_app : forall l l', map (l ++ l') = map l ++ map l'.
   Proof.
     induction l; simpl; auto.
-    intros; rewrite IHl; auto.
+    intros **; rewrite IHl; auto.
   Qed.
 
   Lemma map_rev : forall l, map (rev l) = rev (map l).
@@ -941,17 +949,17 @@ Section Map.
 
   (** [map] and count of occurrences *)
 
-  Hypothesis decA: forall x1 x2 : A, {x1 = x2} + {x1 <> x2}.
-  Hypothesis decB: forall y1 y2 : B, {y1 = y2} + {y1 <> y2}.
-  Hypothesis Hfinjective: forall x1 x2: A, (f x1) = (f x2) -> x1 = x2.
+  Hypothesis (decA : forall x1 x2 : A, {x1 = x2} + {x1 <> x2}).
+  Hypothesis (decB : forall y1 y2 : B, {y1 = y2} + {y1 <> y2}).
+  Hypothesis (Hfinjective : forall x1 x2 : A, f x1 = f x2 -> x1 = x2).
 
-  Theorem count_occ_map x l:
+  Theorem count_occ_map x l :
     count_occ decA l x = count_occ decB (map l) (f x).
   Proof.
     revert x. induction l as [| a l' Hrec]; intro x; simpl.
     - reflexivity.
     - specialize (Hrec x).
-      destruct (decA a x) as [H1|H1], (decB (f a) (f x)) as [H2|H2].
+      destruct (decA a x) as [H1| H1], (decB (f a) (f x)) as [H2| H2].
       * rewrite Hrec. reflexivity.
       * contradiction H2. rewrite H1. reflexivity.
       * specialize (Hfinjective H2). contradiction H1.
@@ -960,55 +968,57 @@ Section Map.
 
   (** [flat_map] *)
 
-  Definition flat_map (f:A -> list B) :=
-    fix flat_map (l:list A) : list B :=
-    match l with
+  Definition flat_map (f : A -> list B) :=
+    fix flat_map (l : list A) : list B :=
+      match l with
       | nil => nil
-      | cons x t => (f x)++(flat_map t)
-    end.
+      | cons x t => f x ++ flat_map t
+      end.
 
-  Lemma in_flat_map : forall (f:A->list B)(l:list A)(y:B),
-    In y (flat_map f l) <-> exists x, In x l /\ In y (f x).
-  Proof using A B.
+  Lemma in_flat_map :
+    forall (f : A -> list B) (l : list A) (y : B),
+    In y (flat_map f l) <-> (exists x, In x l /\ In y (f x)).
+  Proof  using ((B) + (A)).
     clear Hfinjective.
-    induction l; simpl; split; intros.
+    induction l; simpl; split; intros **.
     contradiction.
-    destruct H as (x,(H,_)); contradiction.
+    destruct H as (x, (H, _)); contradiction.
     destruct (in_app_or _ _ _ H).
     exists a; auto.
-    destruct (IHl y) as (H1,_); destruct (H1 H0) as (x,(H2,H3)).
+    destruct (IHl y) as (H1, _); destruct (H1 H0) as (x, (H2, H3)).
     exists x; auto.
     apply in_or_app.
-    destruct H as (x,(H0,H1)); destruct H0.
+    destruct H as (x, (H0, H1)); destruct H0.
     subst; auto.
-    right; destruct (IHl y) as (_,H2); apply H2.
+    right; destruct (IHl y) as (_, H2); apply H2.
     exists x; auto.
   Qed.
 
 End Map.
 
-Lemma flat_map_concat_map : forall A B (f : A -> list B) l,
-  flat_map f l = concat (map f l).
+Lemma flat_map_concat_map :
+  forall A B (f : A -> list B) l, flat_map f l = concat (map f l).
 Proof.
-intros A B f l; induction l as [|x l IH]; simpl.
+intros A B f l; induction l as [| x l IH]; simpl.
 + reflexivity.
 + rewrite IH; reflexivity.
 Qed.
 
-Lemma concat_map : forall A B (f : A -> B) l, map f (concat l) = concat (map (map f) l).
+Lemma concat_map :
+  forall A B (f : A -> B) l, map f (concat l) = concat (map (map f) l).
 Proof.
-intros A B f l; induction l as [|x l IH]; simpl.
+intros A B f l; induction l as [| x l IH]; simpl.
 + reflexivity.
 + rewrite map_app, IH; reflexivity.
 Qed.
 
-Lemma map_id : forall (A :Type) (l : list A),
-  map (fun x => x) l = l.
+Lemma map_id : forall (A : Type) (l : list A), map (fun x => x) l = l.
 Proof.
   induction l; simpl; auto; rewrite IHl; auto.
 Qed.
 
-Lemma map_map : forall (A B C:Type)(f:A->B)(g:B->C) l,
+Lemma map_map :
+  forall (A B C : Type) (f : A -> B) (g : B -> C) l,
   map g (map f l) = map (fun x => g (f x)) l.
 Proof.
   induction l; simpl; auto.
@@ -1016,16 +1026,18 @@ Proof.
 Qed.
 
 Lemma map_ext_in :
-  forall (A B : Type)(f g:A->B) l, (forall a, In a l -> f a = g a) -> map f l = map g l.
+  forall (A B : Type) (f g : A -> B) l,
+  (forall a, In a l -> f a = g a) -> map f l = map g l.
 Proof.
   induction l; simpl; auto.
-  intros; rewrite H by intuition; rewrite IHl; auto.
+  intros **; rewrite H by intuition; rewrite IHl; auto.
 Qed.
 
 Lemma map_ext :
-  forall (A B : Type)(f g:A->B), (forall a, f a = g a) -> forall l, map f l = map g l.
+  forall (A B : Type) (f g : A -> B),
+  (forall a, f a = g a) -> forall l, map f l = map g l.
 Proof.
-  intros; apply map_ext_in; auto.
+  intros **; apply map_ext_in; auto.
 Qed.
 
 
@@ -1035,20 +1047,21 @@ Qed.
 
 Section Fold_Left_Recursor.
   Variables (A : Type) (B : Type).
-  Variable f : A -> B -> A.
+  Variable (f : A -> B -> A).
 
-  Fixpoint fold_left (l:list B) (a0:A) : A :=
+  Fixpoint fold_left (l : list B) (a0 : A) : A :=
     match l with
-      | nil => a0
-      | cons b t => fold_left t (f a0 b)
+    | nil => a0
+    | cons b t => fold_left t (f a0 b)
     end.
 
-  Lemma fold_left_app : forall (l l':list B)(i:A),
-    fold_left (l++l') i = fold_left l' (fold_left l i).
+  Lemma fold_left_app :
+    forall (l l' : list B) (i : A),
+    fold_left (l ++ l') i = fold_left l' (fold_left l i).
   Proof.
     induction l.
     simpl; auto.
-    intros.
+    intros **.
     simpl.
     auto.
   Qed.
@@ -1056,12 +1069,13 @@ Section Fold_Left_Recursor.
 End Fold_Left_Recursor.
 
 Lemma fold_left_length :
-  forall (A:Type)(l:list A), fold_left (fun x _ => S x) l 0 = length l.
+  forall (A : Type) (l : list A), fold_left (fun x _ => S x) l 0 = length l.
 Proof.
   intros A l.
-  enough (H : forall n, fold_left (fun x _ => S x) l n = n + length l) by exact (H 0).
+  enough (H : forall n, fold_left (fun x _ => S x) l n = n + length l) by
+   exact (H 0).
   induction l; simpl; auto.
-  intros; rewrite IHl.
+  intros **; rewrite IHl.
   simpl; auto with arith.
 Qed.
 
@@ -1071,32 +1085,34 @@ Qed.
 
 Section Fold_Right_Recursor.
   Variables (A : Type) (B : Type).
-  Variable f : B -> A -> A.
-  Variable a0 : A.
+  Variable (f : B -> A -> A).
+  Variable (a0 : A).
 
-  Fixpoint fold_right (l:list B) : A :=
+  Fixpoint fold_right (l : list B) : A :=
     match l with
-      | nil => a0
-      | cons b t => f b (fold_right t)
+    | nil => a0
+    | cons b t => f b (fold_right t)
     end.
 
 End Fold_Right_Recursor.
 
-  Lemma fold_right_app : forall (A B:Type)(f:A->B->B) l l' i,
-    fold_right f i (l++l') = fold_right f (fold_right f i l') l.
+  Lemma fold_right_app :
+    forall (A B : Type) (f : A -> B -> B) l l' i,
+    fold_right f i (l ++ l') = fold_right f (fold_right f i l') l.
   Proof.
     induction l.
     simpl; auto.
-    simpl; intros.
+    simpl; intros **.
     f_equal; auto.
   Qed.
 
-  Lemma fold_left_rev_right : forall (A B:Type)(f:A->B->B) l i,
+  Lemma fold_left_rev_right :
+    forall (A B : Type) (f : A -> B -> B) l i,
     fold_right f i (rev l) = fold_left (fun x y => f y x) l i.
   Proof.
     induction l.
     simpl; auto.
-    intros.
+    intros **.
     simpl.
     rewrite fold_right_app; simpl; auto.
   Qed.
@@ -1104,25 +1120,27 @@ End Fold_Right_Recursor.
   Theorem fold_symmetric :
     forall (A : Type) (f : A -> A -> A),
     (forall x y z : A, f x (f y z) = f (f x y) z) ->
-    forall (a0 : A), (forall y : A, f a0 y = f y a0) ->
-    forall (l : list A), fold_left f l a0 = fold_right f a0 l.
+    forall a0 : A,
+    (forall y : A, f a0 y = f y a0) ->
+    forall l : list A, fold_left f l a0 = fold_right f a0 l.
   Proof.
     intros A f assoc a0 comma0 l.
-    induction l as [ | a1 l ]; [ simpl; reflexivity | ].
-    simpl. rewrite <- IHl. clear IHl. revert a1. induction l; [ auto | ].
+    induction l as [| a1 l]; [ simpl; reflexivity |  ].
+    simpl. rewrite <- IHl. clear IHl. revert a1. induction l; [ auto |  ].
     simpl. intro. rewrite <- assoc. rewrite IHl. rewrite IHl. auto.
   Qed.
 
   (** [(list_power x y)] is [y^x], or the set of sequences of elts of [y]
       indexed by elts of [x], sorted in lexicographic order. *)
 
-  Fixpoint list_power (A B:Type)(l:list A) (l':list B) :
-    list (list (A * B)) :=
+  Fixpoint list_power (A B : Type) (l : list A) (l' : list B) :
+  list (list (A * B)) :=
     match l with
-      | nil => cons nil nil
-      | cons x t =>
-	flat_map (fun f:list (A * B) => map (fun y:B => cons (x, y) f) l')
-        (list_power t l')
+    | nil => cons nil nil
+    | cons x t =>
+        flat_map
+          (fun f : list (A * B) => map (fun y : B => cons (x, y) f) l')
+          (list_power t l')
     end.
 
 
@@ -1131,20 +1149,20 @@ End Fold_Right_Recursor.
   (*************************************)
 
   Section Bool.
-    Variable A : Type.
-    Variable f : A -> bool.
+    Variable (A : Type).
+    Variable (f : A -> bool).
 
   (** find whether a boolean function can be satisfied by an
        elements of the list. *)
 
-    Fixpoint existsb (l:list A) : bool :=
+    Fixpoint existsb (l : list A) : bool :=
       match l with
-	| nil => false
-	| a::l => f a || existsb l
+      | nil => false
+      | a :: l => f a || existsb l
       end.
 
     Lemma existsb_exists :
-      forall l, existsb l = true <-> exists x, In x l /\ f x = true.
+      forall l, existsb l = true <-> (exists x, In x l /\ f x = true).
     Proof.
       induction l; simpl; intuition.
       inversion H.
@@ -1155,32 +1173,33 @@ End Fold_Right_Recursor.
       rewrite H2; auto.
     Qed.
 
-    Lemma existsb_nth : forall l n d, n < length l ->
-      existsb l = false -> f (nth n l d) = false.
+    Lemma existsb_nth :
+      forall l n d,
+      n < length l -> existsb l = false -> f (nth n l d) = false.
     Proof.
       induction l.
       inversion 1.
-      simpl; intros.
+      simpl; intros **.
       destruct (orb_false_elim _ _ H0); clear H0; auto.
-      destruct n ; auto.
+      destruct n; auto.
       rewrite IHl; auto with arith.
     Qed.
 
-    Lemma existsb_app : forall l1 l2,
-      existsb (l1++l2) = existsb l1 || existsb l2.
+    Lemma existsb_app :
+      forall l1 l2, existsb (l1 ++ l2) = existsb l1 || existsb l2.
     Proof.
       induction l1; intros l2; simpl.
-        solve[auto].
-      case (f a); simpl; solve[auto].
+        solve [ auto ].
+      case (f a); simpl; (solve [ auto ]).
     Qed.
 
   (** find whether a boolean function is satisfied by
     all the elements of a list. *)
 
-    Fixpoint forallb (l:list A) : bool :=
+    Fixpoint forallb (l : list A) : bool :=
       match l with
-	| nil => true
-	| a::l => f a && forallb l
+      | nil => true
+      | a :: l => f a && forallb l
       end.
 
     Lemma forallb_forall :
@@ -1196,39 +1215,39 @@ End Fold_Right_Recursor.
     Qed.
 
     Lemma forallb_app :
-      forall l1 l2, forallb (l1++l2) = forallb l1 && forallb l2.
+      forall l1 l2, forallb (l1 ++ l2) = forallb l1 && forallb l2.
     Proof.
       induction l1; simpl.
-        solve[auto].
-      case (f a); simpl; solve[auto].
+        solve [ auto ].
+      case (f a); simpl; (solve [ auto ]).
     Qed.
   (** [filter] *)
 
-    Fixpoint filter (l:list A) : list A :=
+    Fixpoint filter (l : list A) : list A :=
       match l with
-	| nil => nil
-	| x :: l => if f x then x::(filter l) else filter l
+      | nil => nil
+      | x :: l => if f x then x :: filter l else filter l
       end.
 
     Lemma filter_In : forall x l, In x (filter l) <-> In x l /\ f x = true.
     Proof.
       induction l; simpl.
       intuition.
-      intros.
-      case_eq (f a); intros; simpl; intuition congruence.
+      intros **.
+      case_eq (f a); intros **; simpl; (intuition (congruence)).
     Qed.
 
   (** [find] *)
 
-    Fixpoint find (l:list A) : option A :=
+    Fixpoint find (l : list A) : option A :=
       match l with
-	| nil => None
-	| x :: tl => if f x then Some x else find tl
+      | nil => None
+      | x :: tl => if f x then Some x else find tl
       end.
 
     Lemma find_some l x : find l = Some x -> In x l /\ f x = true.
     Proof.
-     induction l as [|a l IH]; simpl; [easy| ].
+     induction l as [| a l IH]; simpl; [ easy |  ].
      case_eq (f a); intros Ha Eq.
      * injection Eq as ->; auto.
      * destruct (IH Eq); auto.
@@ -1236,59 +1255,55 @@ End Fold_Right_Recursor.
 
     Lemma find_none l : find l = None -> forall x, In x l -> f x = false.
     Proof.
-     induction l as [|a l IH]; simpl; [easy|].
-     case_eq (f a); intros Ha Eq x IN; [easy|].
-     destruct IN as [<-|IN]; auto.
+     induction l as [| a l IH]; simpl; [ easy |  ].
+     case_eq (f a); intros Ha Eq x IN; [ easy |  ].
+     destruct IN as [<-| IN]; auto.
     Qed.
 
   (** [partition] *)
 
-    Fixpoint partition (l:list A) : list A * list A :=
+    Fixpoint partition (l : list A) : list A * list A :=
       match l with
-	| nil => (nil, nil)
-	| x :: tl => let (g,d) := partition tl in
-	  if f x then (x::g,d) else (g,x::d)
+      | nil => (nil, nil)
+      | x :: tl =>
+          let (g, d) := partition tl in
+          if f x then (x :: g, d) else (g, x :: d)
       end.
 
-  Theorem partition_cons1 a l l1 l2:
+  Theorem partition_cons1 a l l1 l2 :
     partition l = (l1, l2) ->
-    f a = true ->
-    partition (a::l) = (a::l1, l2).
+    f a = true -> partition (a :: l) = (a :: l1, l2).
   Proof.
-    simpl. now intros -> ->.
+    simpl. now (intros -> ->).
   Qed.
 
-  Theorem partition_cons2 a l l1 l2:
+  Theorem partition_cons2 a l l1 l2 :
     partition l = (l1, l2) ->
-    f a=false ->
-    partition (a::l) = (l1, a::l2).
+    f a = false -> partition (a :: l) = (l1, a :: l2).
   Proof.
-    simpl. now intros -> ->.
+    simpl. now (intros -> ->).
   Qed.
 
-  Theorem partition_length l l1 l2:
-    partition l = (l1, l2) ->
-    length l = length l1 + length l2.
+  Theorem partition_length l l1 l2 :
+    partition l = (l1, l2) -> length l = length l1 + length l2.
   Proof.
-    revert l1 l2. induction l as [ | a l' Hrec]; intros l1 l2.
-    - now intros [= <- <- ].
-    - simpl. destruct (f a), (partition l') as (left, right);
-      intros [= <- <- ]; simpl; rewrite (Hrec left right); auto.
+    revert l1 l2. induction l as [| a l' Hrec]; intros l1 l2.
+    - now (intros [=<- <-]).
+    - simpl. destruct (f a), (partition l') as (left, right); intros [=<- <-]; simpl;
+  rewrite (Hrec left right); auto.
   Qed.
 
-  Theorem partition_inv_nil (l : list A):
-    partition l = ([], []) <-> l = [].
+  Theorem partition_inv_nil (l : list A) : partition l = ([], []) <-> l = [].
   Proof.
     split.
-    - destruct l as [|a l' _].
+    - destruct l as [| a l' _].
       * intuition.
-      * simpl. destruct (f a), (partition l'); now intros [= -> ->].
-    - now intros ->.
+      * simpl. destruct (f a), (partition l'); (now (intros [=-> ->])).
+    - now (intros ->).
   Qed.
 
-  Theorem elements_in_partition l l1 l2:
-    partition l = (l1, l2) ->
-    forall x:A, In x l <-> In x l1 \/ In x l2.
+  Theorem elements_in_partition l l1 l2 :
+    partition l = (l1, l2) -> forall x : A, In x l <-> In x l1 \/ In x l2.
   Proof.
     revert l1 l2. induction l as [| a l' Hrec]; simpl; intros l1 l2 Eq x.
     - injection Eq as <- <-. tauto.
@@ -1311,34 +1326,39 @@ End Fold_Right_Recursor.
 
   (** [split] derives two lists from a list of pairs *)
 
-    Fixpoint split (l:list (A*B)) : list A * list B :=
+    Fixpoint split (l : list (A * B)) : list A * list B :=
       match l with
-	| [] => ([], [])
-	| (x,y) :: tl => let (left,right) := split tl in (x::left, y::right)
+      | [] => ([], [])
+      | (x, y) :: tl =>
+          let (left, right) := split tl in (x :: left, y :: right)
       end.
 
-    Lemma in_split_l : forall (l:list (A*B))(p:A*B),
+    Lemma in_split_l :
+      forall (l : list (A * B)) (p : A * B),
       In p l -> In (fst p) (fst (split l)).
     Proof.
-      induction l; simpl; intros; auto.
+      induction l; simpl; intros **; auto.
       destruct p; destruct a; destruct (split l); simpl in *.
       destruct H.
       injection H; auto.
-      right; apply (IHl (a0,b) H).
+      right; apply (IHl (a0, b) H).
     Qed.
 
-    Lemma in_split_r : forall (l:list (A*B))(p:A*B),
+    Lemma in_split_r :
+      forall (l : list (A * B)) (p : A * B),
       In p l -> In (snd p) (snd (split l)).
     Proof.
-      induction l; simpl; intros; auto.
+      induction l; simpl; intros **; auto.
       destruct p; destruct a; destruct (split l); simpl in *.
       destruct H.
       injection H; auto.
-      right; apply (IHl (a0,b) H).
+      right; apply (IHl (a0, b) H).
     Qed.
 
-    Lemma split_nth : forall (l:list (A*B))(n:nat)(d:A*B),
-      nth n l d = (nth n (fst (split l)) (fst d), nth n (snd (split l)) (snd d)).
+    Lemma split_nth :
+      forall (l : list (A * B)) (n : nat) (d : A * B),
+      nth n l d =
+      (nth n (fst (split l)) (fst d), nth n (snd (split l)) (snd d)).
     Proof.
       induction l.
       destruct n; destruct d; simpl; auto.
@@ -1348,15 +1368,15 @@ End Fold_Right_Recursor.
       apply IHl.
     Qed.
 
-    Lemma split_length_l : forall (l:list (A*B)),
-      length (fst (split l)) = length l.
+    Lemma split_length_l :
+      forall l : list (A * B), length (fst (split l)) = length l.
     Proof.
       induction l; simpl; auto.
       destruct a; destruct (split l); simpl; auto.
     Qed.
 
-    Lemma split_length_r : forall (l:list (A*B)),
-      length (snd (split l)) = length l.
+    Lemma split_length_r :
+      forall l : list (A * B), length (snd (split l)) = length l.
     Proof.
       induction l; simpl; auto.
       destruct a; destruct (split l); simpl; auto.
@@ -1366,14 +1386,15 @@ End Fold_Right_Recursor.
       Lists given to [combine] are meant to be of same length.
       If not, [combine] stops on the shorter list *)
 
-    Fixpoint combine (l : list A) (l' : list B) : list (A*B) :=
-      match l,l' with
-	| x::tl, y::tl' => (x,y)::(combine tl tl')
-	| _, _ => nil
+    Fixpoint combine (l : list A) (l' : list B) : 
+    list (A * B) :=
+      match l, l' with
+      | x :: tl, y :: tl' => (x, y) :: combine tl tl'
+      | _, _ => nil
       end.
 
-    Lemma split_combine : forall (l: list (A*B)),
-      let (l1,l2) := split l in combine l1 l2 = l.
+    Lemma split_combine :
+      forall l : list (A * B), let (l1, l2) := split l in combine l1 l2 = l.
     Proof.
       induction l.
       simpl; auto.
@@ -1382,38 +1403,42 @@ End Fold_Right_Recursor.
       f_equal; auto.
     Qed.
 
-    Lemma combine_split : forall (l:list A)(l':list B), length l = length l' ->
-      split (combine l l') = (l,l').
+    Lemma combine_split :
+      forall (l : list A) (l' : list B),
+      length l = length l' -> split (combine l l') = (l, l').
     Proof.
-      induction l; destruct l'; simpl; intros; auto; try discriminate.
-      injection H; clear H; intros.
+      induction l; destruct l'; simpl; intros **; auto; try discriminate.
+      injection H; clear H; intros **.
       rewrite IHl; auto.
     Qed.
 
-    Lemma in_combine_l : forall (l:list A)(l':list B)(x:A)(y:B),
-      In (x,y) (combine l l') -> In x l.
+    Lemma in_combine_l :
+      forall (l : list A) (l' : list B) (x : A) (y : B),
+      In (x, y) (combine l l') -> In x l.
     Proof.
       induction l.
       simpl; auto.
-      destruct l'; simpl; auto; intros.
+      destruct l'; simpl; auto; intros **.
       contradiction.
       destruct H.
       injection H; auto.
       right; apply IHl with l' y; auto.
     Qed.
 
-    Lemma in_combine_r : forall (l:list A)(l':list B)(x:A)(y:B),
-      In (x,y) (combine l l') -> In y l'.
+    Lemma in_combine_r :
+      forall (l : list A) (l' : list B) (x : A) (y : B),
+      In (x, y) (combine l l') -> In y l'.
     Proof.
       induction l.
-      simpl; intros; contradiction.
-      destruct l'; simpl; auto; intros.
+      simpl; intros **; contradiction.
+      destruct l'; simpl; auto; intros **.
       destruct H.
       injection H; auto.
       right; apply IHl with x; auto.
     Qed.
 
-    Lemma combine_length : forall (l:list A)(l':list B),
+    Lemma combine_length :
+      forall (l : list A) (l' : list B),
       length (combine l l') = min (length l) (length l').
     Proof.
       induction l.
@@ -1421,11 +1446,12 @@ End Fold_Right_Recursor.
       destruct l'; simpl; auto.
     Qed.
 
-    Lemma combine_nth : forall (l:list A)(l':list B)(n:nat)(x:A)(y:B),
+    Lemma combine_nth :
+      forall (l : list A) (l' : list B) (n : nat) (x : A) (y : B),
       length l = length l' ->
-      nth n (combine l l') (x,y) = (nth n l x, nth n l' y).
+      nth n (combine l l') (x, y) = (nth n l x, nth n l' y).
     Proof.
-      induction l; destruct l'; intros; try discriminate.
+      induction l; destruct l'; intros **; try discriminate.
       destruct n; simpl; auto.
       destruct n; simpl in *; auto.
     Qed.
@@ -1434,52 +1460,53 @@ End Fold_Right_Recursor.
      [combine], it adds every possible pairs, not only those at the
      same position. *)
 
-    Fixpoint list_prod (l:list A) (l':list B) :
-      list (A * B) :=
+    Fixpoint list_prod (l : list A) (l' : list B) : 
+    list (A * B) :=
       match l with
-	| nil => nil
-	| cons x t => (map (fun y:B => (x, y)) l')++(list_prod t l')
+      | nil => nil
+      | cons x t => map (fun y : B => (x, y)) l' ++ list_prod t l'
       end.
 
     Lemma in_prod_aux :
-      forall (x:A) (y:B) (l:list B),
-	In y l -> In (x, y) (map (fun y0:B => (x, y0)) l).
+      forall (x : A) (y : B) (l : list B),
+      In y l -> In (x, y) (map (fun y0 : B => (x, y0)) l).
     Proof.
       induction l;
-	[ simpl; auto
-	  | simpl; destruct 1 as [H1| ];
-	    [ left; rewrite H1; trivial | right; auto ] ].
+       [ simpl; auto
+       | simpl; destruct 1 as [H1| ];
+          [ left; rewrite H1; trivial | right; auto ] ].
     Qed.
 
     Lemma in_prod :
-      forall (l:list A) (l':list B) (x:A) (y:B),
-	In x l -> In y l' -> In (x, y) (list_prod l l').
+      forall (l : list A) (l' : list B) (x : A) (y : B),
+      In x l -> In y l' -> In (x, y) (list_prod l l').
     Proof.
       induction l;
-	[ simpl; tauto
-	  | simpl; intros; apply in_or_app; destruct H;
-	    [ left; rewrite H; apply in_prod_aux; assumption | right; auto ] ].
+       [ simpl; tauto
+       | simpl; intros **; apply in_or_app; destruct H;
+          [ left; rewrite H; apply in_prod_aux; assumption | right; auto ] ].
     Qed.
 
     Lemma in_prod_iff :
-      forall (l:list A)(l':list B)(x:A)(y:B),
-	In (x,y) (list_prod l l') <-> In x l /\ In y l'.
+      forall (l : list A) (l' : list B) (x : A) (y : B),
+      In (x, y) (list_prod l l') <-> In x l /\ In y l'.
     Proof.
-      split; [ | intros; apply in_prod; intuition ].
-      induction l; simpl; intros.
+      split; [  | intros **; apply in_prod; intuition ].
+      induction l; simpl; intros **.
       intuition.
       destruct (in_app_or _ _ _ H); clear H.
-      destruct (in_map_iff (fun y : B => (a, y)) l' (x,y)) as (H1,_).
-      destruct (H1 H0) as (z,(H2,H3)); clear H0 H1.
-      injection H2; clear H2; intros; subst; intuition.
+      destruct (in_map_iff (fun y : B => (a, y)) l' (x, y)) as (H1, _).
+      destruct (H1 H0) as (z, (H2, H3)); clear H0 H1.
+      injection H2; clear H2; intros **; subst; intuition.
       intuition.
     Qed.
 
-    Lemma prod_length : forall (l:list A)(l':list B),
-      length (list_prod l l') = (length l) * (length l').
+    Lemma prod_length :
+      forall (l : list A) (l' : list B),
+      length (list_prod l l') = length l * length l'.
     Proof.
       induction l; simpl; auto.
-      intros.
+      intros **.
       rewrite app_length.
       rewrite map_length.
       auto.
@@ -1501,12 +1528,12 @@ End Fold_Right_Recursor.
 (******************************)
 
 Section length_order.
-  Variable A : Type.
+  Variable (A : Type).
 
-  Definition lel (l m:list A) := length l <= length m.
+  Definition lel (l m : list A) := length l <= length m.
 
-  Variables a b : A.
-  Variables l m n : list A.
+  Variables (a b : A).
+  Variables (l m n : list A).
 
   Lemma lel_refl : lel l l.
   Proof.
@@ -1515,7 +1542,7 @@ Section length_order.
 
   Lemma lel_trans : lel l m -> lel m n -> lel l n.
   Proof.
-    unfold lel; intros.
+    unfold lel; intros **.
     now_show (length l <= length n).
     apply le_trans with (length m); auto with arith.
   Qed.
@@ -1535,7 +1562,7 @@ Section length_order.
     unfold lel; simpl; auto with arith.
   Qed.
 
-  Lemma lel_nil : forall l':list A, lel l' nil -> nil = l'.
+  Lemma lel_nil : forall l' : list A, lel l' nil -> nil = l'.
   Proof.
     intro l'; elim l'; auto with arith.
     intros a' y H H0.
@@ -1554,42 +1581,42 @@ Hint Resolve lel_refl lel_cons_cons lel_cons lel_nil lel_nil nil_cons:
 
 Section SetIncl.
 
-  Variable A : Type.
+  Variable (A : Type).
 
-  Definition incl (l m:list A) := forall a:A, In a l -> In a m.
+  Definition incl (l m : list A) := forall a : A, In a l -> In a m.
   Hint Unfold incl.
 
-  Lemma incl_refl : forall l:list A, incl l l.
+  Lemma incl_refl : forall l : list A, incl l l.
   Proof.
     auto.
   Qed.
   Hint Resolve incl_refl.
 
-  Lemma incl_tl : forall (a:A) (l m:list A), incl l m -> incl l (a :: m).
+  Lemma incl_tl : forall (a : A) (l m : list A), incl l m -> incl l (a :: m).
   Proof.
     auto with datatypes.
   Qed.
   Hint Immediate incl_tl.
 
-  Lemma incl_tran : forall l m n:list A, incl l m -> incl m n -> incl l n.
+  Lemma incl_tran : forall l m n : list A, incl l m -> incl m n -> incl l n.
   Proof.
     auto.
   Qed.
 
-  Lemma incl_appl : forall l m n:list A, incl l n -> incl l (n ++ m).
+  Lemma incl_appl : forall l m n : list A, incl l n -> incl l (n ++ m).
   Proof.
     auto with datatypes.
   Qed.
   Hint Immediate incl_appl.
 
-  Lemma incl_appr : forall l m n:list A, incl l n -> incl l (m ++ n).
+  Lemma incl_appr : forall l m n : list A, incl l n -> incl l (m ++ n).
   Proof.
     auto with datatypes.
   Qed.
   Hint Immediate incl_appr.
 
   Lemma incl_cons :
-    forall (a:A) (l m:list A), In a m -> incl l m -> incl (a :: l) m.
+    forall (a : A) (l m : list A), In a m -> incl l m -> incl (a :: l) m.
   Proof.
     unfold incl; simpl; intros a l m H H0 a0 H1.
     now_show (In a0 m).
@@ -1603,7 +1630,8 @@ Section SetIncl.
   Qed.
   Hint Resolve incl_cons.
 
-  Lemma incl_app : forall l m n:list A, incl l n -> incl m n -> incl (l ++ m) n.
+  Lemma incl_app :
+    forall l m n : list A, incl l n -> incl m n -> incl (l ++ m) n.
   Proof.
     unfold incl; simpl; intros l m n H H0 a H1.
     now_show (In a n).
@@ -1623,98 +1651,96 @@ Hint Resolve incl_refl incl_tl incl_tran incl_appl incl_appr incl_cons
 
 Section Cutting.
 
-  Variable A : Type.
+  Variable (A : Type).
 
-  Fixpoint firstn (n:nat)(l:list A) : list A :=
+  Fixpoint firstn (n : nat) (l : list A) : list A :=
     match n with
-      | 0 => nil
-      | S n => match l with
-		 | nil => nil
-		 | a::l => a::(firstn n l)
-	       end
+    | 0 => nil
+    | S n => match l with
+             | nil => nil
+             | a :: l => a :: firstn n l
+             end
     end.
 
-  Lemma firstn_nil n: firstn n [] = [].
-  Proof. induction n; now simpl. Qed.
+  Lemma firstn_nil n : firstn n [] = [].
+  Proof. induction n; (now (simpl)). Qed.
 
-  Lemma firstn_cons n a l: firstn (S n) (a::l) = a :: (firstn n l).
-  Proof. now simpl. Qed.
+  Lemma firstn_cons n a l : firstn (S n) (a :: l) = a :: firstn n l.
+  Proof. now (simpl). Qed.
 
-  Lemma firstn_all l: firstn (length l) l = l.
-  Proof. induction l as [| ? ? H]; simpl; [reflexivity | now rewrite H]. Qed.
+  Lemma firstn_all l : firstn (length l) l = l.
+  Proof. induction l as [| ? ? H]; simpl; [ reflexivity | now (rewrite H) ]. Qed.
 
-  Lemma firstn_all2 n: forall (l:list A), (length l) <= n -> firstn n l = l.
-  Proof. induction n as [|k iHk].
-    - intro. inversion 1 as [H1|?].
-      rewrite (length_zero_iff_nil l) in H1. subst. now simpl.
-    - destruct l as [|x xs]; simpl.
+  Lemma firstn_all2 n : forall l : list A, length l <= n -> firstn n l = l.
+  Proof. induction n as [| k iHk].
+    - intro. inversion 1as [H1| ?].
+      rewrite (length_zero_iff_nil l) in H1. subst. now (simpl).
+    - destruct l as [| x xs]; simpl.
       * now reflexivity.
       * simpl. intro H. apply Peano.le_S_n in H. f_equal. apply iHk, H.
   Qed.
 
-  Lemma firstn_O l: firstn 0 l = [].
-  Proof. now simpl. Qed.
+  Lemma firstn_O l : firstn 0 l = [].
+  Proof. now (simpl). Qed.
 
-  Lemma firstn_le_length n: forall l:list A, length (firstn n l) <= n.
+  Lemma firstn_le_length n : forall l : list A, length (firstn n l) <= n.
   Proof.
-    induction n as [|k iHk]; simpl; [auto | destruct l as [|x xs]; simpl].
+    induction n as [| k iHk]; simpl; [ auto | destruct l as [| x xs]; simpl ].
     - auto with arith.
     - apply Peano.le_n_S, iHk.
   Qed.
 
-  Lemma firstn_length_le: forall l:list A, forall n:nat,
-    n <= length l -> length (firstn n l) = n.
-  Proof. induction l as [|x xs Hrec].
-    - simpl. intros n H. apply le_n_0_eq in H. rewrite <- H. now simpl.
+  Lemma firstn_length_le :
+    forall (l : list A) (n : nat), n <= length l -> length (firstn n l) = n.
+  Proof. induction l as [| x xs Hrec].
+    - simpl. intros n H. apply le_n_0_eq in H. rewrite <- H. now (simpl).
     - destruct n.
-      * now simpl.
-      * simpl. intro H. apply le_S_n in H. now rewrite (Hrec n H).
+      * now (simpl).
+      * simpl. intro H. apply le_S_n in H. now (rewrite (Hrec n H)).
   Qed.
 
-  Lemma firstn_app n:
+  Lemma firstn_app n :
     forall l1 l2,
-    firstn n (l1 ++ l2) = (firstn n l1) ++ (firstn (n - length l1) l2).
-  Proof. induction n as [|k iHk]; intros l1 l2.
-    - now simpl.
-    - destruct l1 as [|x xs].
-      * unfold firstn at 2, length. now rewrite 2!app_nil_l, <- minus_n_O.
+    firstn n (l1 ++ l2) = firstn n l1 ++ firstn (n - length l1) l2.
+  Proof. induction n as [| k iHk]; intros l1 l2.
+    - now (simpl).
+    - destruct l1 as [| x xs].
+      * unfold firstn at 2, length. now (rewrite 2!app_nil_l, <- minus_n_O).
       * rewrite <- app_comm_cons. simpl. f_equal. apply iHk.
   Qed.
 
-  Lemma firstn_app_2 n:
-    forall l1 l2,
-    firstn ((length l1) + n) (l1 ++ l2) = l1 ++ firstn n l2.
-  Proof. induction n as [| k iHk];intros l1 l2.
+  Lemma firstn_app_2 n :
+    forall l1 l2, firstn (length l1 + n) (l1 ++ l2) = l1 ++ firstn n l2.
+  Proof. induction n as [| k iHk]; intros l1 l2.
     - unfold firstn at 2. rewrite <- plus_n_O, app_nil_r.
       rewrite firstn_app. rewrite <- minus_diag_reverse.
       unfold firstn at 2. rewrite app_nil_r. apply firstn_all.
-    - destruct l2 as [|x xs].
+    - destruct l2 as [| x xs].
       * simpl. rewrite app_nil_r. apply firstn_all2. auto with arith.
-      * rewrite firstn_app. assert (H0 : (length l1 + S k - length l1) = S k).
+      * rewrite firstn_app. assert (H0 : length l1 + S k - length l1 = S k).
         auto with arith.
-        rewrite H0, firstn_all2; [reflexivity | auto with arith].
+        rewrite H0, firstn_all2; [ reflexivity | auto with arith ].
   Qed.
 
-  Lemma firstn_firstn:
-    forall l:list A,
-    forall i j : nat,
+  Lemma firstn_firstn :
+    forall (l : list A) (i j : nat),
     firstn i (firstn j l) = firstn (min i j) l.
-  Proof. induction l as [|x xs Hl].
-    - intros. simpl. now rewrite ?firstn_nil.
+  Proof. induction l as [| x xs Hl].
+    - intros **. simpl. now (rewrite ?firstn_nil).
     - destruct i.
-      * intro. now simpl.
+      * intro. now (simpl).
       * destruct j.
-        + now simpl.
+        + now (simpl).
         + simpl. f_equal. apply Hl.
   Qed.
 
-  Fixpoint skipn (n:nat)(l:list A) : list A :=
+  Fixpoint skipn (n : nat) (l : list A) : list A :=
     match n with
-      | 0 => l
-      | S n => match l with
-		 | nil => nil
-		 | a::l => skipn n l
-	       end
+    | 0 => l
+    | S n => match l with
+             | nil => nil
+             | a :: l => skipn n l
+             end
     end.
 
   Lemma firstn_skipn : forall n l, firstn n l ++ skipn n l = l.
@@ -1730,17 +1756,17 @@ Section Cutting.
     induction n; destruct l; simpl; auto.
   Qed.
 
-   Lemma removelast_firstn : forall n l, n < length l ->
-     removelast (firstn (S n) l) = firstn n l.
+   Lemma removelast_firstn :
+     forall n l, n < length l -> removelast (firstn (S n) l) = firstn n l.
    Proof.
      induction n; destruct l.
      simpl; auto.
      simpl; auto.
      simpl; auto.
-     intros.
+     intros **.
      simpl in H.
-     change (firstn (S (S n)) (a::l)) with ((a::nil)++firstn (S n) l).
-     change (firstn (S n) (a::l)) with (a::firstn n l).
+     change (firstn (S (S n)) (a :: l)) with ((a :: nil) ++ firstn (S n) l).
+     change (firstn (S n) (a :: l)) with (a :: firstn n l).
      rewrite removelast_app.
      rewrite IHn; auto with arith.
 
@@ -1749,16 +1775,16 @@ Section Cutting.
      inversion_clear H0.
    Qed.
 
-   Lemma firstn_removelast : forall n l, n < length l ->
-     firstn n (removelast l) = firstn n l.
+   Lemma firstn_removelast :
+     forall n l, n < length l -> firstn n (removelast l) = firstn n l.
    Proof.
      induction n; destruct l.
      simpl; auto.
      simpl; auto.
      simpl; auto.
-     intros.
+     intros **.
      simpl in H.
-     change (removelast (a :: l)) with (removelast ((a::nil)++l)).
+     change (removelast (a :: l)) with (removelast ((a :: nil) ++ l)).
      rewrite removelast_app.
      simpl; f_equal; auto with arith.
      intro H0; rewrite H0 in H; inversion_clear H; inversion_clear H1.
@@ -1772,32 +1798,31 @@ End Cutting.
 
 Section Add.
 
-  Variable A : Type.
+  Variable (A : Type).
 
   (* [Add a l l'] means that [l'] is exactly [l], with [a] added
      once somewhere *)
-  Inductive Add (a:A) : list A -> list A -> Prop :=
-    | Add_head l : Add a l (a::l)
-    | Add_cons x l l' : Add a l l' -> Add a (x::l) (x::l').
+  Inductive Add (a : A) : list A -> list A -> Prop :=
+    | Add_head : forall l, Add a l (a :: l)
+    | Add_cons : forall x l l', Add a l l' -> Add a (x :: l) (x :: l').
 
-  Lemma Add_app a l1 l2 : Add a (l1++l2) (l1++a::l2).
+  Lemma Add_app a l1 l2 : Add a (l1 ++ l2) (l1 ++ a :: l2).
   Proof.
-   induction l1; simpl; now constructor.
+   induction l1; simpl; (now (constructor)).
   Qed.
 
   Lemma Add_split a l l' :
-    Add a l l' -> exists l1 l2, l = l1++l2 /\ l' = l1++a::l2.
+    Add a l l' -> exists l1 l2, l = l1 ++ l2 /\ l' = l1 ++ a :: l2.
   Proof.
    induction 1.
    - exists nil; exists l; split; trivial.
-   - destruct IHAdd as (l1 & l2 & Hl & Hl').
-     exists (x::l1); exists l2; split; simpl; f_equal; trivial.
+   - destruct IHAdd as (l1, (l2, (Hl, Hl'))).
+     exists (x :: l1); exists l2; split; simpl; f_equal; trivial.
   Qed.
 
-  Lemma Add_in a l l' : Add a l l' ->
-   forall x, In x l' <-> In x (a::l).
+  Lemma Add_in a l l' : Add a l l' -> forall x, In x l' <-> In x (a :: l).
   Proof.
-   induction 1; intros; simpl in *; rewrite ?IHAdd; tauto.
+   induction 1; intros **; simpl in *; rewrite ?IHAdd; tauto.
   Qed.
 
   Lemma Add_length a l l' : Add a l l' -> length l' = S (length l).
@@ -1807,17 +1832,17 @@ Section Add.
 
   Lemma Add_inv a l : In a l -> exists l', Add a l' l.
   Proof.
-   intro Ha. destruct (in_split _ _ Ha) as (l1 & l2 & ->).
+   intro Ha. destruct (in_split _ _ Ha) as (l1, (l2, ->)).
    exists (l1 ++ l2). apply Add_app.
   Qed.
 
   Lemma incl_Add_inv a l u v :
-    ~In a l -> incl (a::l) v -> Add a u v -> incl l u.
+    ~ In a l -> incl (a :: l) v -> Add a u v -> incl l u.
   Proof.
    intros Ha H AD y Hy.
-   assert (Hy' : In y (a::u)).
+   assert (Hy' : In y (a :: u)).
    { rewrite <- (Add_in AD). apply H; simpl; auto. }
-   destruct Hy'; [ subst; now elim Ha | trivial ].
+   destruct Hy'; [ subst; (now (elim Ha)) | trivial ].
   Qed.
 
 End Add.
@@ -1828,111 +1853,110 @@ End Add.
 
 Section ReDun.
 
-  Variable A : Type.
+  Variable (A : Type).
 
   Inductive NoDup : list A -> Prop :=
     | NoDup_nil : NoDup nil
-    | NoDup_cons : forall x l, ~ In x l -> NoDup l -> NoDup (x::l).
+    | NoDup_cons : forall x l, ~ In x l -> NoDup l -> NoDup (x :: l).
 
-  Lemma NoDup_Add a l l' : Add a l l' -> (NoDup l' <-> NoDup l /\ ~In a l).
+  Lemma NoDup_Add a l l' : Add a l l' -> NoDup l' <-> NoDup l /\ ~ In a l.
   Proof.
-   induction 1 as [l|x l l' AD IH].
-   - split; [ inversion_clear 1; now split | now constructor ].
+   induction 1 as [l| x l l' AD IH].
+   - split; [ inversion_clear 1; (now split) | now (constructor) ].
    - split.
      + inversion_clear 1. rewrite IH in *. rewrite (Add_in AD) in *.
        simpl in *; split; try constructor; intuition.
-     + intros (N,IN). inversion_clear N. constructor.
+     + intros (N, IN). inversion_clear N. constructor.
        * rewrite (Add_in AD); simpl in *; intuition.
        * apply IH. split; trivial. simpl in *; intuition.
   Qed.
 
   Lemma NoDup_remove l l' a :
-    NoDup (l++a::l') -> NoDup (l++l') /\ ~In a (l++l').
+    NoDup (l ++ a :: l') -> NoDup (l ++ l') /\ ~ In a (l ++ l').
   Proof.
   apply NoDup_Add. apply Add_app.
   Qed.
 
-  Lemma NoDup_remove_1 l l' a : NoDup (l++a::l') -> NoDup (l++l').
+  Lemma NoDup_remove_1 l l' a : NoDup (l ++ a :: l') -> NoDup (l ++ l').
   Proof.
-  intros. now apply NoDup_remove with a.
+  intros **. now (apply NoDup_remove with a).
   Qed.
 
-  Lemma NoDup_remove_2 l l' a : NoDup (l++a::l') -> ~In a (l++l').
+  Lemma NoDup_remove_2 l l' a : NoDup (l ++ a :: l') -> ~ In a (l ++ l').
   Proof.
-  intros. now apply NoDup_remove.
+  intros **. now (apply NoDup_remove).
   Qed.
 
-  Theorem NoDup_cons_iff a l:
-    NoDup (a::l) <-> ~ In a l /\ NoDup l.
+  Theorem NoDup_cons_iff a l : NoDup (a :: l) <-> ~ In a l /\ NoDup l.
   Proof.
     split.
     + inversion_clear 1. now split.
-    + now constructor.
+    + now (constructor).
   Qed.
 
   (** Effective computation of a list without duplicates *)
 
-  Hypothesis decA: forall x y : A, {x = y} + {x <> y}.
+  Hypothesis (decA : forall x y : A, {x = y} + {x <> y}).
 
   Fixpoint nodup (l : list A) : list A :=
     match l with
-      | [] => []
-      | x::xs => if in_dec decA x xs then nodup xs else x::(nodup xs)
+    | [] => []
+    | x :: xs => if in_dec decA x xs then nodup xs else x :: nodup xs
     end.
 
   Lemma nodup_In l x : In x (nodup l) <-> In x l.
   Proof.
-    induction l as [|a l' Hrec]; simpl.
+    induction l as [| a l' Hrec]; simpl.
     - reflexivity.
     - destruct (in_dec decA a l'); simpl; rewrite Hrec.
-      * intuition; now subst.
+      * intuition; (now (subst)).
       * reflexivity.
   Qed.
 
-  Lemma NoDup_nodup l: NoDup (nodup l).
+  Lemma NoDup_nodup l : NoDup (nodup l).
   Proof.
-    induction l as [|a l' Hrec]; simpl.
+    induction l as [| a l' Hrec]; simpl.
     - constructor.
     - destruct (in_dec decA a l'); simpl.
       * assumption.
-      * constructor; [ now rewrite nodup_In | assumption].
+      * constructor; [ now (rewrite nodup_In) | assumption ].
   Qed.
 
   Lemma nodup_inv k l a : nodup k = a :: l -> ~ In a l.
   Proof.
     intros H.
-    assert (H' : NoDup (a::l)).
+    assert (H' : NoDup (a :: l)).
     { rewrite <- H. apply NoDup_nodup. }
-    now inversion_clear H'.
+    now (inversion_clear H').
   Qed.
 
-  Theorem NoDup_count_occ l:
-    NoDup l <-> (forall x:A, count_occ decA l x <= 1).
+  Theorem NoDup_count_occ l :
+    NoDup l <-> (forall x : A, count_occ decA l x <= 1).
   Proof.
     induction l as [| a l' Hrec].
     - simpl; split; auto. constructor.
     - rewrite NoDup_cons_iff, Hrec, (count_occ_not_In decA). clear Hrec. split.
       + intros (Ha, H) x. simpl. destruct (decA a x); auto.
-        subst; now rewrite Ha.
+        subst; (now (rewrite Ha)).
       + split.
         * specialize (H a). rewrite count_occ_cons_eq in H; trivial.
-          now inversion H.
+          now (inversion H).
         * intros x. specialize (H x). simpl in *. destruct (decA a x); auto.
-          now apply Nat.lt_le_incl.
+          now (apply Nat.lt_le_incl).
   Qed.
 
-  Theorem NoDup_count_occ' l:
-    NoDup l <-> (forall x:A, In x l -> count_occ decA l x = 1).
+  Theorem NoDup_count_occ' l :
+    NoDup l <-> (forall x : A, In x l -> count_occ decA l x = 1).
   Proof.
     rewrite NoDup_count_occ.
     setoid_rewrite (count_occ_In decA). unfold gt, lt in *.
-    split; intros H x; specialize (H x);
-    set (n := count_occ decA l x) in *; clearbody n.
+    split; intros H x; specialize (H x); set (n := count_occ decA l x) in *;
+     clearbody n.
     (* the rest would be solved by omega if we had it here... *)
-    - now apply Nat.le_antisymm.
+    - now (apply Nat.le_antisymm).
     - destruct (Nat.le_gt_cases 1 n); trivial.
       + rewrite H; trivial.
-      + now apply Nat.lt_le_incl.
+      + now (apply Nat.lt_le_incl).
   Qed.
 
   (** Alternative characterisations of being without duplicates,
@@ -1940,18 +1964,18 @@ Section ReDun.
 
   Lemma NoDup_nth_error l :
     NoDup l <->
-    (forall i j, i<length l -> nth_error l i = nth_error l j -> i = j).
+    (forall i j, i < length l -> nth_error l i = nth_error l j -> i = j).
   Proof.
     split.
-    { intros H; induction H as [|a l Hal Hl IH]; intros i j Hi E.
+    { intros H; induction H as [| a l Hal Hl IH]; intros i j Hi E.
       - inversion Hi.
       - destruct i, j; simpl in *; auto.
         * elim Hal. eapply nth_error_In; eauto.
         * elim Hal. eapply nth_error_In; eauto.
         * f_equal. apply IH; auto with arith. }
-    { induction l as [|a l]; intros H; constructor.
-      * intro Ha. apply In_nth_error in Ha. destruct Ha as (n,Hn).
-        assert (n < length l) by (now rewrite <- nth_error_Some, Hn).
+    { induction l as [| a l]; intros H; constructor.
+      * intro Ha. apply In_nth_error in Ha. destruct Ha as (n, Hn).
+        assert (n < length l) by (now (rewrite <- nth_error_Some, Hn)).
         specialize (H 0 (S n)). simpl in H. discriminate H; auto with arith.
       * apply IHl.
         intros i j Hi E. apply eq_add_S, H; simpl; auto with arith. }
@@ -1959,18 +1983,18 @@ Section ReDun.
 
   Lemma NoDup_nth l d :
     NoDup l <->
-    (forall i j, i<length l -> j<length l ->
-       nth i l d = nth j l d -> i = j).
+    (forall i j,
+     i < length l -> j < length l -> nth i l d = nth j l d -> i = j).
   Proof.
     split.
-    { intros H; induction H as [|a l Hal Hl IH]; intros i j Hi Hj E.
+    { intros H; induction H as [| a l Hal Hl IH]; intros i j Hi Hj E.
       - inversion Hi.
       - destruct i, j; simpl in *; auto.
         * elim Hal. subst a. apply nth_In; auto with arith.
         * elim Hal. subst a. apply nth_In; auto with arith.
         * f_equal. apply IH; auto with arith. }
-    { induction l as [|a l]; intros H; constructor.
-      * intro Ha. eapply In_nth in Ha. destruct Ha as (n & Hn & Hn').
+    { induction l as [| a l]; intros H; constructor.
+      * intro Ha. eapply In_nth in Ha. destruct Ha as (n, (Hn, Hn')).
         specialize (H 0 (S n)). simpl in H. discriminate H; eauto with arith.
       * apply IHl.
         intros i j Hi Hj E. apply eq_add_S, H; simpl; auto with arith. }
@@ -1981,26 +2005,26 @@ Section ReDun.
   Lemma NoDup_incl_length l l' :
     NoDup l -> incl l l' -> length l <= length l'.
   Proof.
-   intros N. revert l'. induction N as [|a l Hal N IH]; simpl.
+   intros N. revert l'. induction N as [| a l Hal N IH]; simpl.
    - auto with arith.
    - intros l' H.
      destruct (Add_inv a l') as (l'', AD). { apply H; simpl; auto. }
      rewrite (Add_length AD). apply le_n_S. apply IH.
-     now apply incl_Add_inv with a l'.
+     now (apply incl_Add_inv with a l').
   Qed.
 
   Lemma NoDup_length_incl l l' :
     NoDup l -> length l' <= length l -> incl l l' -> incl l' l.
   Proof.
-   intros N. revert l'. induction N as [|a l Hal N IH].
+   intros N. revert l'. induction N as [| a l Hal N IH].
    - destruct l'; easy.
    - intros l' E H x Hx.
      destruct (Add_inv a l') as (l'', AD). { apply H; simpl; auto. }
      rewrite (Add_in AD) in Hx. simpl in Hx.
-     destruct Hx as [Hx|Hx]; [left; trivial|right].
+     destruct Hx as [Hx| Hx]; [ left; trivial | right ].
      revert x Hx. apply (IH l''); trivial.
-     * apply le_S_n. now rewrite <- (Add_length AD).
-     * now apply incl_Add_inv with a l'.
+     * apply le_S_n. now (rewrite <- (Add_length AD)).
+     * now (apply incl_Add_inv with a l').
   Qed.
 
 End ReDun.
@@ -2010,10 +2034,10 @@ End ReDun.
 (** NB: the reciprocal result holds only for injective functions,
     see FinFun.v *)
 
-Lemma NoDup_map_inv A B (f:A->B) l : NoDup (map f l) -> NoDup l.
+Lemma NoDup_map_inv A B (f : A -> B) l : NoDup (map f l) -> NoDup l.
 Proof.
  induction l; simpl; inversion_clear 1; subst; constructor; auto.
- intro H. now apply (in_map f) in H.
+ intro H. now (apply (in_map f) in H).
 Qed.
 
 (***********************************)
@@ -2025,10 +2049,10 @@ Section NatSeq.
   (** [seq] computes the sequence of [len] contiguous integers
       that starts at [start]. For instance, [seq 2 3] is [2::3::4::nil]. *)
 
-  Fixpoint seq (start len:nat) : list nat :=
+  Fixpoint seq (start len : nat) : list nat :=
     match len with
-      | 0 => nil
-      | S len => start :: seq (S start) len
+    | 0 => nil
+    | S len => start :: seq (S start) len
     end.
 
   Lemma seq_length : forall len start, length (seq start len) = len.
@@ -2036,41 +2060,41 @@ Section NatSeq.
     induction len; simpl; auto.
   Qed.
 
-  Lemma seq_nth : forall len start n d,
-    n < len -> nth n (seq start len) d = start+n.
+  Lemma seq_nth :
+    forall len start n d, n < len -> nth n (seq start len) d = start + n.
   Proof.
-    induction len; intros.
+    induction len; intros **.
     inversion H.
     simpl seq.
     destruct n; simpl.
     auto with arith.
-    rewrite IHlen;simpl; auto with arith.
+    rewrite IHlen; simpl; auto with arith.
   Qed.
 
-  Lemma seq_shift : forall len start,
-    map S (seq start len) = seq (S start) len.
+  Lemma seq_shift :
+    forall len start, map S (seq start len) = seq (S start) len.
   Proof.
     induction len; simpl; auto.
-    intros.
+    intros **.
     rewrite IHlen.
     auto with arith.
   Qed.
 
   Lemma in_seq len start n :
-    In n (seq start len) <-> start <= n < start+len.
+    In n (seq start len) <-> start <= n < start + len.
   Proof.
-   revert start. induction len; simpl; intros.
-   - rewrite <- plus_n_O. split;[easy|].
-     intros (H,H'). apply (Lt.lt_irrefl _ (Lt.le_lt_trans _ _ _ H H')).
+   revert start. induction len; simpl; intros **.
+   - rewrite <- plus_n_O. split; [ easy |  ].
+     intros (H, H'). apply (Lt.lt_irrefl _ (Lt.le_lt_trans _ _ _ H H')).
    - rewrite IHlen, <- plus_n_Sm; simpl; split.
-     * intros [H|H]; subst; intuition auto with arith.
-     * intros (H,H'). destruct (Lt.le_lt_or_eq _ _ H); intuition.
+     * intros [H| H]; subst; (intuition (auto with arith)).
+     * intros (H, H'). destruct (Lt.le_lt_or_eq _ _ H); intuition.
   Qed.
 
   Lemma seq_NoDup len start : NoDup (seq start len).
   Proof.
    revert start; induction len; simpl; constructor; trivial.
-   rewrite in_seq. intros (H,_). apply (Lt.lt_irrefl _ H).
+   rewrite in_seq. intros (H, _). apply (Lt.lt_irrefl _ H).
   Qed.
 
 End NatSeq.
@@ -2079,20 +2103,19 @@ Section Exists_Forall.
 
   (** * Existential and universal predicates over lists *)
 
-  Variable A:Type.
+  Variable (A : Type).
 
   Section One_predicate.
 
-    Variable P:A->Prop.
+    Variable (P : A -> Prop).
 
     Inductive Exists : list A -> Prop :=
-      | Exists_cons_hd : forall x l, P x -> Exists (x::l)
-      | Exists_cons_tl : forall x l, Exists l -> Exists (x::l).
+      | Exists_cons_hd : forall x l, P x -> Exists (x :: l)
+      | Exists_cons_tl : forall x l, Exists l -> Exists (x :: l).
 
     Hint Constructors Exists.
 
-    Lemma Exists_exists (l:list A) :
-      Exists l <-> (exists x, In x l /\ P x).
+    Lemma Exists_exists (l : list A) : Exists l <-> (exists x, In x l /\ P x).
     Proof.
       split.
       - induction 1; firstorder.
@@ -2102,97 +2125,95 @@ Section Exists_Forall.
     Lemma Exists_nil : Exists nil <-> False.
     Proof. split; inversion 1. Qed.
 
-    Lemma Exists_cons x l:
-      Exists (x::l) <-> P x \/ Exists l.
+    Lemma Exists_cons x l : Exists (x :: l) <-> P x \/ Exists l.
     Proof. split; inversion 1; auto. Qed.
 
-    Lemma Exists_dec l:
-      (forall x:A, {P x} + { ~ P x }) ->
-      {Exists l} + {~ Exists l}.
+    Lemma Exists_dec l :
+      (forall x : A, {P x} + {~ P x}) -> {Exists l} + {~ Exists l}.
     Proof.
-      intro Pdec. induction l as [|a l' Hrec].
-      - right. now rewrite Exists_nil.
-      - destruct Hrec as [Hl'|Hl'].
-        * left. now apply Exists_cons_tl.
-        * destruct (Pdec a) as [Ha|Ha].
-          + left. now apply Exists_cons_hd.
-          + right. now inversion_clear 1.
+      intro Pdec. induction l as [| a l' Hrec].
+      - right. now (rewrite Exists_nil).
+      - destruct Hrec as [Hl'| Hl'].
+        * left. now (apply Exists_cons_tl).
+        * destruct (Pdec a) as [Ha| Ha].
+          + left. now (apply Exists_cons_hd).
+          + right. now (inversion_clear 1).
     Qed.
 
     Inductive Forall : list A -> Prop :=
       | Forall_nil : Forall nil
-      | Forall_cons : forall x l, P x -> Forall l -> Forall (x::l).
+      | Forall_cons : forall x l, P x -> Forall l -> Forall (x :: l).
 
     Hint Constructors Forall.
 
-    Lemma Forall_forall (l:list A):
-      Forall l <-> (forall x, In x l -> P x).
+    Lemma Forall_forall (l : list A) : Forall l <-> (forall x, In x l -> P x).
     Proof.
       split.
       - induction 1; firstorder; subst; auto.
       - induction l; firstorder.
     Qed.
 
-    Lemma Forall_inv : forall (a:A) l, Forall (a :: l) -> P a.
+    Lemma Forall_inv : forall (a : A) l, Forall (a :: l) -> P a.
     Proof.
-      intros; inversion H; trivial.
+      intros **; inversion H; trivial.
     Qed.
 
-    Lemma Forall_rect : forall (Q : list A -> Type),
+    Lemma Forall_rect :
+      forall Q : list A -> Type,
       Q [] -> (forall b l, P b -> Q (b :: l)) -> forall l, Forall l -> Q l.
     Proof.
-      intros Q H H'; induction l; intro; [|eapply H', Forall_inv]; eassumption.
+      intros Q H H'; induction l; intro; [  | eapply H', Forall_inv ];
+       eassumption.
     Qed.
 
     Lemma Forall_dec :
-      (forall x:A, {P x} + { ~ P x }) ->
-      forall l:list A, {Forall l} + {~ Forall l}.
+      (forall x : A, {P x} + {~ P x}) ->
+      forall l : list A, {Forall l} + {~ Forall l}.
     Proof.
-      intro Pdec. induction l as [|a l' Hrec].
+      intro Pdec. induction l as [| a l' Hrec].
       - left. apply Forall_nil.
-      - destruct Hrec as [Hl'|Hl'].
-        + destruct (Pdec a) as [Ha|Ha].
-          * left. now apply Forall_cons.
-          * right. now inversion_clear 1.
-        + right. now inversion_clear 1.
+      - destruct Hrec as [Hl'| Hl'].
+        + destruct (Pdec a) as [Ha| Ha].
+          * left. now (apply Forall_cons).
+          * right. now (inversion_clear 1).
+        + right. now (inversion_clear 1).
     Qed.
 
   End One_predicate.
 
-  Lemma Forall_Exists_neg (P:A->Prop)(l:list A) :
-   Forall (fun x => ~ P x) l <-> ~(Exists P l).
+  Lemma Forall_Exists_neg (P : A -> Prop) (l : list A) :
+    Forall (fun x => ~ P x) l <-> ~ Exists P l.
   Proof.
    rewrite Forall_forall, Exists_exists. firstorder.
   Qed.
 
-  Lemma Exists_Forall_neg (P:A->Prop)(l:list A) :
-    (forall x, P x \/ ~P x) ->
-    Exists (fun x => ~ P x) l <-> ~(Forall P l).
+  Lemma Exists_Forall_neg (P : A -> Prop) (l : list A) :
+    (forall x, P x \/ ~ P x) -> Exists (fun x => ~ P x) l <-> ~ Forall P l.
   Proof.
    intro Dec.
    split.
    - rewrite Forall_forall, Exists_exists; firstorder.
    - intros NF.
-     induction l as [|a l IH].
+     induction l as [| a l IH].
      + destruct NF. constructor.
-     + destruct (Dec a) as [Ha|Ha].
-       * apply Exists_cons_tl, IH. contradict NF. now constructor.
-       * now apply Exists_cons_hd.
+     + destruct (Dec a) as [Ha| Ha].
+       * apply Exists_cons_tl, IH. contradict NF. now (constructor).
+       * now (apply Exists_cons_hd).
   Qed.
 
-  Lemma Forall_Exists_dec (P:A->Prop) :
-    (forall x:A, {P x} + { ~ P x }) ->
-    forall l:list A,
-    {Forall P l} + {Exists (fun x => ~ P x) l}.
+  Lemma Forall_Exists_dec (P : A -> Prop) :
+    (forall x : A, {P x} + {~ P x}) ->
+    forall l : list A, {Forall P l} + {Exists (fun x => ~ P x) l}.
   Proof.
     intros Pdec l.
-    destruct (Forall_dec P Pdec l); [left|right]; trivial.
+    destruct (Forall_dec P Pdec l); [ left | right ]; trivial.
     apply Exists_Forall_neg; trivial.
-    intro x. destruct (Pdec x); [now left|now right].
+    intro x. destruct (Pdec x); [ now left | now right ].
   Qed.
 
-  Lemma Forall_impl : forall (P Q : A -> Prop), (forall a, P a -> Q a) ->
-    forall l, Forall P l -> Forall Q l.
+  Lemma Forall_impl :
+    forall P Q : A -> Prop,
+    (forall a, P a -> Q a) -> forall l, Forall P l -> Forall Q l.
   Proof.
     intros P Q H l. rewrite !Forall_forall. firstorder.
   Qed.
@@ -2206,45 +2227,48 @@ Section Forall2.
 
   (** [Forall2]: stating that elements of two lists are pairwise related. *)
 
-  Variables A B : Type.
-  Variable R : A -> B -> Prop.
+  Variables (A B : Type).
+  Variable (R : A -> B -> Prop).
 
   Inductive Forall2 : list A -> list B -> Prop :=
     | Forall2_nil : Forall2 [] []
-    | Forall2_cons : forall x y l l',
-      R x y -> Forall2 l l' -> Forall2 (x::l) (y::l').
+    | Forall2_cons :
+        forall x y l l', R x y -> Forall2 l l' -> Forall2 (x :: l) (y :: l').
 
   Hint Constructors Forall2.
 
   Theorem Forall2_refl : Forall2 [] [].
-  Proof. intros; apply Forall2_nil. Qed.
+  Proof. intros **; apply Forall2_nil. Qed.
 
-  Theorem Forall2_app_inv_l : forall l1 l2 l',
+  Theorem Forall2_app_inv_l :
+    forall l1 l2 l',
     Forall2 (l1 ++ l2) l' ->
     exists l1' l2', Forall2 l1 l1' /\ Forall2 l2 l2' /\ l' = l1' ++ l2'.
   Proof.
-    induction l1; intros.
-      exists [], l'; auto.
+    induction l1; intros **.
+      exists []; exists l'; auto.
       simpl in H; inversion H; subst; clear H.
-      apply IHl1 in H4 as (l1' & l2' & Hl1 & Hl2 & ->).
-      exists (y::l1'), l2'; simpl; auto.
+      apply IHl1 in H4 as (l1', (l2', (Hl1, (Hl2, ->)))).
+      exists (y :: l1'); exists l2'; simpl; auto.
   Qed.
 
-  Theorem Forall2_app_inv_r : forall l1' l2' l,
+  Theorem Forall2_app_inv_r :
+    forall l1' l2' l,
     Forall2 l (l1' ++ l2') ->
     exists l1 l2, Forall2 l1 l1' /\ Forall2 l2 l2' /\ l = l1 ++ l2.
   Proof.
-    induction l1'; intros.
-      exists [], l; auto.
+    induction l1'; intros **.
+      exists []; exists l; auto.
       simpl in H; inversion H; subst; clear H.
-      apply IHl1' in H4 as (l1 & l2 & Hl1 & Hl2 & ->).
-      exists (x::l1), l2; simpl; auto.
+      apply IHl1' in H4 as (l1, (l2, (Hl1, (Hl2, ->)))).
+      exists (x :: l1); exists l2; simpl; auto.
   Qed.
 
-  Theorem Forall2_app : forall l1 l2 l1' l2',
+  Theorem Forall2_app :
+    forall l1 l2 l1' l2',
     Forall2 l1 l1' -> Forall2 l2 l2' -> Forall2 (l1 ++ l2) (l1' ++ l2').
   Proof.
-    intros. induction l1 in l1', H, H0 |- *; inversion H; subst; simpl; auto.
+    intros **. induction l1 in l1', H, H0 |- *; inversion H; subst; simpl; auto.
   Qed.
 End Forall2.
 
@@ -2255,25 +2279,26 @@ Section ForallPairs.
   (** [ForallPairs] : specifies that a certain relation should
     always hold when inspecting all possible pairs of elements of a list. *)
 
-  Variable A : Type.
-  Variable R : A -> A -> Prop.
+  Variable (A : Type).
+  Variable (R : A -> A -> Prop).
 
-  Definition ForallPairs l :=
-    forall a b, In a l -> In b l -> R a b.
+  Definition ForallPairs l := forall a b, In a l -> In b l -> R a b.
 
   (** [ForallOrdPairs] : we still check a relation over all pairs
      of elements of a list, but now the order of elements matters. *)
 
   Inductive ForallOrdPairs : list A -> Prop :=
     | FOP_nil : ForallOrdPairs nil
-    | FOP_cons : forall a l,
-      Forall (R a) l -> ForallOrdPairs l -> ForallOrdPairs (a::l).
+    | FOP_cons :
+        forall a l,
+        Forall (R a) l -> ForallOrdPairs l -> ForallOrdPairs (a :: l).
 
   Hint Constructors ForallOrdPairs.
 
-  Lemma ForallOrdPairs_In : forall l,
+  Lemma ForallOrdPairs_In :
+    forall l,
     ForallOrdPairs l ->
-    forall x y, In x l -> In y l -> x=y \/ R x y \/ R y x.
+    forall x y, In x l -> In y l -> x = y \/ R x y \/ R y x.
   Proof.
     induction 1.
     inversion 1.
@@ -2285,12 +2310,12 @@ Section ForallPairs.
   (** [ForallPairs] implies [ForallOrdPairs]. The reverse implication is true
     only when [R] is symmetric and reflexive. *)
 
-  Lemma ForallPairs_ForallOrdPairs l: ForallPairs l -> ForallOrdPairs l.
+  Lemma ForallPairs_ForallOrdPairs l : ForallPairs l -> ForallOrdPairs l.
   Proof.
     induction l; auto. intros H.
     constructor.
-    apply <- Forall_forall. intros; apply H; simpl; auto.
-    apply IHl. red; intros; apply H; simpl; auto.
+    apply <- Forall_forall. intros **; apply H; simpl; auto.
+    apply IHl. red; intros **; apply H; simpl; auto.
   Qed.
 
   Lemma ForallOrdPairs_ForallPairs :
@@ -2305,22 +2330,24 @@ End ForallPairs.
 
 (** * Inversion of predicates over lists based on head symbol *)
 
-Ltac is_list_constr c :=
- match c with
+Ltac
+ is_list_constr c :=
+  match c with
   | nil => idtac
-  | (_::_) => idtac
+  | _ :: _ => idtac
   | _ => fail
- end.
+  end.
 
-Ltac invlist f :=
- match goal with
+Ltac
+ invlist f :=
+  match goal with
   | H:f ?l |- _ => is_list_constr l; inversion_clear H; invlist f
   | H:f _ ?l |- _ => is_list_constr l; inversion_clear H; invlist f
   | H:f _ _ ?l |- _ => is_list_constr l; inversion_clear H; invlist f
   | H:f _ _ _ ?l |- _ => is_list_constr l; inversion_clear H; invlist f
   | H:f _ _ _ _ ?l |- _ => is_list_constr l; inversion_clear H; invlist f
   | _ => idtac
- end.
+  end.
 
 
 
@@ -2328,15 +2355,15 @@ Ltac invlist f :=
 
 
 Hint Rewrite
-  rev_involutive (* rev (rev l) = l *)
-  rev_unit (* rev (l ++ a :: nil) = a :: rev l *)
-  map_nth (* nth n (map f l) (f d) = f (nth n l d) *)
-  map_length (* length (map f l) = length l *)
-  seq_length (* length (seq start len) = len *)
-  app_length (* length (l ++ l') = length l + length l' *)
-  rev_length (* length (rev l) = length l *)
-  app_nil_r (* l ++ nil = l *)
-  : list.
+ rev_involutive (* rev (rev l) = l *)
+ rev_unit (* rev (l ++ a :: nil) = a :: rev l *)
+ map_nth (* nth n (map f l) (f d) = f (nth n l d) *)
+ map_length (* length (map f l) = length l *)
+ seq_length (* length (seq start len) = len *)
+ app_length (* length (l ++ l') = length l + length l' *)
+ rev_length (* length (rev l) = length l *)
+ app_nil_r (* l ++ nil = l *)
+ : list.
 
 Ltac simpl_list := autorewrite with list.
 Ltac ssimpl_list := autorewrite with list using simpl.
@@ -2366,28 +2393,26 @@ Notation rev_acc := rev_append (only parsing).
 Notation rev_acc_rev := rev_append_rev (only parsing).
 Notation AllS := Forall (only parsing). (* was formerly in TheoryList *)
 
-Hint Resolve app_nil_end : datatypes v62.
+Hint Resolve app_nil_end: datatypes v62.
 (* end hide *)
 
 Section Repeat.
 
-  Variable A : Type.
-  Fixpoint repeat (x : A) (n: nat ) :=
+  Variable (A : Type).
+  Fixpoint repeat (x : A) (n : nat) :=
     match n with
-      | O => []
-      | S k => x::(repeat x k)
+    | O => []
+    | S k => x :: repeat x k
     end.
 
-  Theorem repeat_length x n:
-    length (repeat x n) = n.
+  Theorem repeat_length x n : length (repeat x n) = n.
   Proof.
     induction n as [| k Hrec]; simpl; rewrite ?Hrec; reflexivity.
   Qed.
 
-  Theorem repeat_spec n x y:
-    In y (repeat x n) -> y=x.
+  Theorem repeat_spec n x y : In y (repeat x n) -> y = x.
   Proof.
-    induction n as [|k Hrec]; simpl; destruct 1; auto.
+    induction n as [| k Hrec]; simpl; destruct 1; auto.
   Qed.
 
 End Repeat.

--- a/theories/MSets/MSetGenTree.v
+++ b/theories/MSets/MSetGenTree.v
@@ -983,7 +983,7 @@ Proof.
  apply (StrictOrder_Irreflexive (elements s2)); auto.
  intros s1 s2 s3 (s1' & s2' & B1 & B2 & E1 & E2 & L12)
                  (s2'' & s3' & B2' & B3 & E2' & E3 & L23).
- exists s1', s3'; do 4 (split; trivial).
+ exists s1'; exists s3'; do 4 (split; trivial).
  assert (eqlistA X.eq (elements s2') (elements s2'')).
   apply SortA_equivlistA_eqlistA with (ltA:=X.lt); auto with *.
   rewrite <- eq_Leq. transitivity s2; auto. symmetry; auto.
@@ -995,11 +995,11 @@ Instance lt_compat : Proper (eq==>eq==>iff) lt.
 Proof.
  intros s1 s2 E12 s3 s4 E34. split.
  intros (s1' & s3' & B1 & B3 & E1 & E3 & LT).
- exists s1', s3'; do 2 (split; trivial).
+ exists s1'; exists s3'; do 2 (split; trivial).
   split. transitivity s1; auto. symmetry; auto.
   split; auto. transitivity s3; auto. symmetry; auto.
  intros (s1' & s3' & B1 & B3 & E1 & E3 & LT).
- exists s1', s3'; do 2 (split; trivial).
+ exists s1'; exists s3'; do 2 (split; trivial).
   split. transitivity s2; auto.
   split; auto. transitivity s4; auto.
 Qed.
@@ -1079,8 +1079,8 @@ Proof.
  intros.
  destruct (compare_Cmp s1 s2); constructor.
  rewrite eq_Leq; auto.
- intros; exists s1, s2; repeat split; auto.
- intros; exists s2, s1; repeat split; auto.
+ intros; exists s1; exists s2; repeat split; auto.
+ intros; exists s2; exists s1; repeat split; auto.
 Qed.
 
 

--- a/theories/MSets/MSetList.v
+++ b/theories/MSets/MSetList.v
@@ -795,7 +795,7 @@ Module MakeRaw (X: OrderedType) <: RawSets X.
   apply (StrictOrder_Irreflexive s2); auto.
   intros s1 s2 s3 (s1' & s2' & B1 & B2 & E1 & E2 & L12)
                   (s2'' & s3' & B2' & B3 & E2' & E3 & L23).
-  exists s1', s3'.
+  exists s1'; exists s3'.
   repeat rewrite <- isok_iff in *.
   do 4 (split; trivial).
   assert (eqlistA X.eq s2' s2'').
@@ -809,11 +809,11 @@ Module MakeRaw (X: OrderedType) <: RawSets X.
   Proof.
   intros s1 s2 E12 s3 s4 E34. split.
   intros (s1' & s3' & B1 & B3 & E1 & E3 & LT).
-  exists s1', s3'; do 2 (split; trivial).
+  exists s1'; exists s3'; do 2 (split; trivial).
    split. transitivity s1; auto. symmetry; auto.
    split; auto. transitivity s3; auto. symmetry; auto.
   intros (s1' & s3' & B1 & B3 & E1 & E3 & LT).
-  exists s1', s3'; do 2 (split; trivial).
+  exists s1'; exists s3'; do 2 (split; trivial).
    split. transitivity s2; auto.
    split; auto. transitivity s4; auto.
   Qed.
@@ -829,8 +829,8 @@ Module MakeRaw (X: OrderedType) <: RawSets X.
   Proof.
   intros s s' Hs Hs'.
   destruct (compare_spec_aux s s'); constructor; auto.
-  exists s, s'; repeat split; auto using @ok.
-  exists s', s; repeat split; auto using @ok.
+  exists s; exists s'; repeat split; auto using @ok.
+  exists s'; exists s; repeat split; auto using @ok.
   Qed.
 
 End MakeRaw.

--- a/theories/Numbers/Natural/BigN/NMake_gen.ml
+++ b/theories/Numbers/Natural/BigN/NMake_gen.ml
@@ -147,7 +147,7 @@ pr
   pr " Local Notation Size := (SizePlus O).";
   pr "";
 
-  pr " Tactic Notation \"do_size\" tactic(t) := do %i t." (size+1);
+  pr " Tactic Notation (at level 3) \"do_size\" tactic3(t) := do %i t." (size+1);
   pr "";
 
   pr " Definition dom_t n := match n with";

--- a/theories/Reals/PSeries_reg.v
+++ b/theories/Reals/PSeries_reg.v
@@ -54,7 +54,7 @@ rewrite Rplus_comm; apply Rplus_lt_compat_l, Rmult_lt_compat_r.
 apply Rlt_trans with z; assumption.
 destruct (boule_of_interval _ _ cmp) as [c [r [P1 P2]]].
 assert (0 < /2) by (apply Rinv_0_lt_compat, Rlt_0_2).
-exists c, r; split.
+exists c; exists r; split.
  destruct h; unfold Boule; simpl; apply Rabs_def1.
   apply Rplus_lt_reg_l with c; rewrite P2;
   replace (c + (z - c)) with (z * / 2 + z * / 2) by field.

--- a/theories/Relations/Operators_Properties.v
+++ b/theories/Relations/Operators_Properties.v
@@ -36,7 +36,7 @@ Section Properties.
   Section Clos_Refl_Trans.
 
     Local Notation "R *" := (clos_refl_trans R)
-      (at level 8, left associativity, format "R *").
+      (at level 8, no associativity, format "R *").
 
     (** Correctness of the reflexive-transitive closure operator *)
 

--- a/theories/Structures/EqualitiesFacts.v
+++ b/theories/Structures/EqualitiesFacts.v
@@ -110,7 +110,7 @@ Module KeyDecidableType(D:DecidableType).
   unfold In, MapsTo.
   setoid_rewrite Exists_exists; setoid_rewrite InA_alt.
   firstorder.
-  exists (snd x), x; auto.
+  exists (snd x); exists x; auto.
  Qed.
 
  Lemma In_nil {elt} k : In k (@nil (key*elt)) <-> False.

--- a/toplevel/metasyntax.ml
+++ b/toplevel/metasyntax.ml
@@ -479,6 +479,14 @@ let make_hunks etyps symbols from =
 
   in make symbols
 
+let rec trailing_precedence etyps from = function
+  | [] -> assert false
+  | [NonTerminal id|SProdList (id,_)] ->
+     let typ = List.assoc id etyps in
+     Some (precedence_of_entry_type from typ)
+  | [Terminal _|Break _] -> None
+  | _ :: l -> trailing_precedence etyps from l
+
 (* Build default printing rules from explicit format *)
 
 let error_format () = error "The format does not match the notation."
@@ -672,7 +680,7 @@ type syntax_extension = {
   synext_level : Notation.level;
   synext_notation : notation;
   synext_notgram : notation_grammar;
-  synext_unparsing : unparsing list;
+  synext_unparsing : unparsing_rule;
   synext_extra : (string * string) list;
 }
 
@@ -691,7 +699,7 @@ let cache_one_syntax_extension se =
     Egramcoq.extend_constr_grammar prec se.synext_notgram;
     (* Declare the printing rule *)
     Notation.declare_notation_printing_rule ntn
-      ~extra:se.synext_extra (se.synext_unparsing, fst prec)
+      ~extra:se.synext_extra se.synext_unparsing
 
 let cache_syntax_extension (_, (_, sy)) =
   List.iter cache_one_syntax_extension sy
@@ -1051,7 +1059,7 @@ exception NoSyntaxRule
 let recover_syntax ntn =
   try
     let prec = Notation.level_of_notation ntn in
-    let pp_rule,_ = Notation.find_notation_printing_rule ntn in
+    let pp_rule= Notation.find_notation_printing_rule ntn in
     let pp_extra_rules = Notation.find_notation_extra_printing_rules ntn in
     let pa_rule = Egramcoq.recover_constr_grammar ntn prec in
     { synext_level = prec;
@@ -1085,14 +1093,16 @@ let make_pa_rule i_typs (n,typs,symbols,_) ntn =
     notgram_prods = prod;
     notgram_typs = i_typs; }
 
-let make_pp_rule (n,typs,symbols,fmt) =
-  match fmt with
+let make_pp_rule (n,typs,symbols,fmt) (lev,_) =
+  let unp = match fmt with
   | None -> [UnpBox (PpHOVB 0, make_hunks typs symbols n)]
-  | Some fmt -> hunks_of_format (n, List.split typs) (symbols, parse_format fmt)
+  | Some fmt -> hunks_of_format (n, List.split typs) (symbols, parse_format fmt) in
+  let trailingprec = trailing_precedence typs lev symbols in
+  (unp, lev, trailingprec)
 
 let make_syntax_rules (i_typs,ntn,prec,need_squash,sy_data) extra =
   let pa_rule = make_pa_rule i_typs sy_data ntn in
-  let pp_rule = make_pp_rule sy_data in
+  let pp_rule = make_pp_rule sy_data prec in
   let sy = {
     synext_level = prec;
     synext_notation = ntn;

--- a/toplevel/vernac.ml
+++ b/toplevel/vernac.ml
@@ -229,7 +229,9 @@ let rec vernac_com verbose checknav (loc,com) =
       if do_beautify () then pr_new_syntax loc (Some com);
       if !Flags.time then display_cmd_header loc com;
       let com = if !Flags.time then VernacTime (loc,com) else com in
-      interp com
+      let a = Lexer.com_state () in
+      interp com;
+      Lexer.restore_com_state a
     with reraise ->
       let (reraise, info) = Errors.push reraise in
       Format.set_formatter_out_channel stdout;


### PR DESCRIPTION
This sequence of commit is restoring a minimal effective form of the "beautifier".
- It adds a target for checking the reparsability of the result of "beautification" (make check-beautify).
- It fixes a number of parsing bugs, printing bugs or library's fragile notations found while reparsing the result of beautification.

The infrastructure for re-printing documents can be used for various purposes such as:
- documentation: it was used by Yann in his unfinished new coqdoc;
- upgrading: by automatically applying translations so that a file works from a version to another;
- beautification: changing notations globally in a development;
- correctness: by testing the reversibility of the term and tactic printers;
- debugging: by providing a printer usable for debugging.

The "fixing" commits are ready to be committed.

One commit is a workaround in the library to remember that a list has to be printed with a separator (where to put this information? it is not in the generic_argument, but since generic, there is no printer rules associated to it). Another commit is a workaround until when to print "constr:" or "ltac:" is stabilized.  ltac code. These are temporary commits waiting for a stable solution.

If no objections, my proposal is to commit all the fixes, and when the printing of ltac stabilize, to add the new target for checking the reversibility of printing/parsing and, then, to have it checked by the Jenkins tools.

Note that the current approach does not re-interpret terms before displaying. It only checks the string->constr_expr->string reversibility. A complementary approach would be to check the
string->constr->string reversibility.
