### PR TITLE
Minor patch to build Coq 8.1 on OS X.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1297,9 +1297,17 @@ install-library:
 	cp states/*.coq $(FULLCOQLIB)/states
 	$(MKDIR) $(FULLCOQLIB)/user-contrib
 	cp $(LIBCOQRUN) $(FULLCOQLIB)
-	cp --parents $(CONFIG) $(OBJECTCMI) $(LINKCMO) $(COQIDECMA) $(COQIDECMO:.cmo=.cmi) $(GRAMMARCMA) $(FULLCOQLIB)
+	for f in $(CONFIG) $(OBJECTCMI) $(LINKCMO) $(COQIDECMA) \
+	         $(COQIDECMO:.cmo=.cmi) $(GRAMMARCMA); do \
+	    $(MKDIR) -p $(FULLCOQLIB)/`dirname $$f`; \
+	    cp $$f $(FULLCOQLIB)/`dirname $$f`; \
+	done
 ifeq ($(BEST),opt)
-	cp --parents $(CONFIG:.cmo=.cmx) $(CONFIG:.cmo=.o) $(LINKCMO:.cma=.cmxa) $(LINKCMO:.cma=.a) $(COQIDECMXALL) $(FULLCOQLIB)
+	for f in $(CONFIG:.cmo=.cmx) $(CONFIG:.cmo=.o) $(LINKCMO:.cma=.cmxa) \
+	         $(LINKCMO:.cma=.a) $(COQIDECMXALL); do \
+	    $(MKDIR) -p $(FULLCOQLIB)/`dirname $$f`; \
+	    cp $$f $(FULLCOQLIB)/`dirname $$f`; \
+	done
 endif
 
 install-library-light:


### PR DESCRIPTION
Install of v8.1 fails on OS X because its native `cp` does not support `--parent`.

Replication via opam:

```
opam repo add coq-core-dev https://coq.inria.fr/opam/core-dev 
opam switch install coq8.1 --alias-of 4.02.3
eval $(opam config env --switch coq8.1)
opam install coq.8.1.dev
```
