### PR TITLE
Program: cleanup in cases, add options

### DIFF
--- a/doc/refman/Program.tex
+++ b/doc/refman/Program.tex
@@ -63,10 +63,27 @@ will be first rewritten to:
   previous one, an inequality is added in the context of the second
   branch. See for example the definition of {\tt div2} below, where the second
   branch is typed in a context where $\forall p, \_ <> S (S p)$.
-  
+
 \item Coercion. If the object being matched is coercible to an inductive
   type, the corresponding coercion will be automatically inserted. This also
   works with the previous mechanism.
+
+\end{itemize}
+
+There are global options to control the generation of equalities
+and coercions.
+
+\begin{itemize}
+\item {\tt Unset Program Cases}\optindex{Program Cases} This deactivates
+  the special treatment of pattern-matching generating equalities and
+  inequalities when using Program (it is on by default). All
+  pattern-matchings and let-patterns are handled using the standard
+  algorithm of Coq (see Section~\ref{Caseexpr}) when this options is
+  deactivated.
+\item {\tt Unset Program Generalized Coercion}\optindex{Program
+    Generalized Coercion} This deactivates the coercion of general
+  inductive types when using Program (the option is on by default).
+  Coercion of subset types and pairs is still active in this case.
 \end{itemize}
 
 \subsection{Syntactic control over equalities}

--- a/doc/refman/Program.tex
+++ b/doc/refman/Program.tex
@@ -70,19 +70,19 @@ will be first rewritten to:
 
 \end{itemize}
 
-There are global options to control the generation of equalities
+There are options to control the generation of equalities
 and coercions.
 
 \begin{itemize}
 \item {\tt Unset Program Cases}\optindex{Program Cases} This deactivates
   the special treatment of pattern-matching generating equalities and
-  inequalities when using Program (it is on by default). All
+  inequalities when using \Program\ (it is on by default). All
   pattern-matchings and let-patterns are handled using the standard
-  algorithm of Coq (see Section~\ref{Caseexpr}) when this options is
+  algorithm of Coq (see Section~\ref{Mult-match-full}) when this option is
   deactivated.
 \item {\tt Unset Program Generalized Coercion}\optindex{Program
     Generalized Coercion} This deactivates the coercion of general
-  inductive types when using Program (the option is on by default).
+  inductive types when using \Program\ (the option is on by default).
   Coercion of subset types and pairs is still active in this case.
 \end{itemize}
 

--- a/pretyping/cases.mli
+++ b/pretyping/cases.mli
@@ -121,4 +121,3 @@ val prepare_predicate :            Loc.t ->
            Context.Rel.t list ->
            Constr.constr option ->
            'a option -> (Evd.evar_map * Names.name list * Term.constr) list
-

--- a/pretyping/coercion.ml
+++ b/pretyping/coercion.ml
@@ -192,7 +192,7 @@ and coerce loc env evdref (x : Term.constr) (y : Term.constr)
 	  let term = co x in
 	    Typing.e_solve_evars env evdref term)
       in
-	if isEvar c || isEvar c' then
+	if isEvar c || isEvar c' || not (Program.is_program_generalized_coercion ()) then
 	  (* Second-order unification needed. *)
 	  raise NoSubtacCoercion;
 	aux [] typ typ' 0 (fun x -> x)
@@ -280,7 +280,7 @@ and coerce loc env evdref (x : Term.constr) (y : Term.constr)
 		     let c1 = coerce_unify env a a' in
 		     let c2 = coerce_unify env b b' in
 		       match c1, c2 with
-		       None, None -> None
+		       | None, None -> None
 		       | _, _ ->
 			   Some
 			     (fun x ->

--- a/pretyping/program.ml
+++ b/pretyping/program.ml
@@ -70,18 +70,40 @@ let mk_coq_and l =
 
 (* true = transparent by default, false = opaque if possible *)
 let proofs_transparency = ref true
+let program_cases = ref true
+let program_generalized_coercion = ref true
 
 let set_proofs_transparency = (:=) proofs_transparency
 let get_proofs_transparency () = !proofs_transparency
+
+let is_program_generalized_coercion () = !program_generalized_coercion
+let is_program_cases () = !program_cases
 
 open Goptions
 
 let _ =
   declare_bool_option
-    { optsync  = true;
-      optdepr  = false;
-      optname  = "preferred transparency of Program obligations";
-      optkey   = ["Transparent";"Obligations"];
-      optread  = get_proofs_transparency;
-      optwrite = set_proofs_transparency; }
-      
+  { optsync  = true;
+    optdepr  = false;
+    optname  = "preferred transparency of Program obligations";
+    optkey   = ["Transparent";"Obligations"];
+    optread  = get_proofs_transparency;
+    optwrite = set_proofs_transparency; }
+
+let _ =
+  declare_bool_option
+  { optsync  = true;
+    optdepr  = false;
+    optname  = "program cases";
+    optkey   = ["Program";"Cases"];
+    optread  = (fun () -> !program_cases);
+    optwrite = (:=) program_cases }
+
+let _ =
+  declare_bool_option
+  { optsync  = true;
+    optdepr  = false;
+    optname  = "program generalized coercion";
+    optkey   = ["Program";"Generalized";"Coercion"];
+    optread  = (fun () -> !program_generalized_coercion);
+    optwrite = (:=) program_generalized_coercion }

--- a/pretyping/program.mli
+++ b/pretyping/program.mli
@@ -39,3 +39,5 @@ val mk_coq_not : constr -> constr
 val papp : Evd.evar_map ref -> (unit -> global_reference) -> constr array -> constr
 
 val get_proofs_transparency : unit -> bool
+val is_program_cases : unit -> bool
+val is_program_generalized_coercion : unit -> bool


### PR DESCRIPTION
By user request:
- Unset Program Generalized Coercion to avoid coercion of general
  applications.
- Unset Program Cases to deactivate generation equalities and
  disequalities of cases.

Added documentation
