### PR TITLE
Evarunsafe

### DIFF
--- a/kernel/closure.ml
+++ b/kernel/closure.ml
@@ -363,6 +363,7 @@ let set_norm v = v.norm <- Norm
 let is_val v = match v.norm with Norm -> true | _ -> false
 
 let mk_atom c = {norm=Norm;term=FAtom c}
+let mk_red f = {norm=Red;term=f}
 
 (* Could issue a warning if no is still Red, pointing out that we loose
    sharing. *)

--- a/kernel/closure.mli
+++ b/kernel/closure.mli
@@ -164,6 +164,9 @@ val inject : constr -> fconstr
 (** mk_atom: prevents a term from being evaluated *)
 val mk_atom : constr -> fconstr
 
+(** mk_red: makes a reducible term (used in newring) *)
+val mk_red : fterm -> fconstr
+
 val fterm_of : fconstr -> fterm
 val term_of_fconstr : fconstr -> constr
 val destFLambda :


### PR DESCRIPTION
Fix a probably wrong use of Evar.unsafe_of_int, stdlib compiles, to be tested on ring-intensive code.
