### PR TITLE
Add configurable shortcuts for user queries to CoqIDE.

### DIFF
--- a/ide/coqide.ml
+++ b/ide/coqide.ml
@@ -919,7 +919,7 @@ let template_item (text, offset, len, key) =
 (** Create menu items for pairs (query, shortcut key).
     If the shortcut key is not in the range 'a'-'z','A'-'Z', it will be ignored.  *)
 
-let user_queries_items menu_name item_name l modifier =
+let user_queries_items menu_name item_name l =
   let valid_key k = Int.equal (CString.length k) 1 && Util.is_letter k.[0] in
   let mk_item (query, key) =
     let query' =
@@ -929,7 +929,7 @@ let user_queries_items menu_name item_name l modifier =
       else query ^ "."
     in
     let callback = Query.simplequery query' in
-    let accel = if valid_key key then Some (modifier^key) else None in
+    let accel = if valid_key key then Some (modifier_for_queries#get^key) else None in
     item (item_name^" "^(no_under query)) ~label:query ?accel ~callback menu_name
   in
   List.iter mk_item l
@@ -1123,17 +1123,21 @@ let build_ui () =
   ];
   alpha_items templates_menu "Template" Coq_commands.commands;
 
-  let qitem s accel = item s ~label:("_"^s) ?accel ~callback:(Query.query s) in
+  let qitem s sc =
+    item s ~label:("_"^s)
+      ~accel:(modifier_for_queries#get^sc)
+      ~callback:(Query.query s)
+  in
   menu queries_menu [
     item "Queries" ~label:"_Queries";
-    qitem "Search" (Some "<Ctrl><Shift>K");
-    qitem "Check" (Some "<Ctrl><Shift>C");
-    qitem "Print" (Some "<Ctrl><Shift>P");
-    qitem "About" (Some "<Ctrl><Shift>A");
-    qitem "Locate" (Some "<Ctrl><Shift>L");
-    qitem "Print Assumptions" (Some "<Ctrl><Shift>N");
+    qitem "Search" "K";
+    qitem "Check" "C";
+    qitem "Print" "P";
+    qitem "About" "A";
+    qitem "Locate" "L";
+    qitem "Print Assumptions" "N";
   ];
-  user_queries_items queries_menu "Query" user_queries#get "<Ctrl><Shift>";
+  user_queries_items queries_menu "Query" user_queries#get;
 
   menu tools_menu [
     item "Tools" ~label:"_Tools";

--- a/ide/coqide.ml
+++ b/ide/coqide.ml
@@ -1132,7 +1132,6 @@ let build_ui () =
     qitem "About" (Some "<Ctrl><Shift>A");
     qitem "Locate" (Some "<Ctrl><Shift>L");
     qitem "Print Assumptions" (Some "<Ctrl><Shift>N");
-    qitem "Show Proof" (Some "<Ctrl><Shift>R");
   ];
   user_queries_items queries_menu "Query" user_queries#get "<Ctrl><Shift>";
 

--- a/ide/coqide.ml
+++ b/ide/coqide.ml
@@ -916,20 +916,12 @@ let template_item (text, offset, len, key) =
   in
   item name ~label ~callback:(cb_on_current_term callback) ~accel:(modifier^key)
 
-(** Create menu items for pairs (query, shortcut key).
-    If the shortcut key is not in the range 'a'-'z','A'-'Z', it will be ignored.  *)
-
+(** Create menu items for pairs (query, shortcut key). *)
 let user_queries_items menu_name item_name l =
-  let valid_key k = Int.equal (CString.length k) 1 && Util.is_letter k.[0] in
   let mk_item (query, key) =
-    let query' =
-      let last = CString.length query - 1 in
-      if query.[last] = '.'
-      then query
-      else query ^ "."
-    in
-    let callback = Query.simplequery query' in
-    let accel = if valid_key key then Some (modifier_for_queries#get^key) else None in
+    let callback = Query.simplequery (query ^ ".") in
+    let accel = if not (CString.is_empty key) then
+      Some (modifier_for_queries#get^key) else None in
     item (item_name^" "^(no_under query)) ~label:query ?accel ~callback menu_name
   in
   List.iter mk_item l

--- a/ide/coqide.ml
+++ b/ide/coqide.ml
@@ -677,18 +677,27 @@ let searchabout sn =
 
 let searchabout () = on_current_term searchabout
 
+let doquery query sn =
+  sn.messages#clear;
+  Coq.try_grab sn.coqtop (sn.coqops#raw_coq_query query) ignore
+
+let showproof () =
+  let query = "Show Proof." in
+  on_current_term (doquery query)
+
 let otherquery command sn =
   let word = get_current_word sn in
   if word <> "" then
     let query = command ^ " " ^ word ^ "." in
-    sn.messages#clear;
-    Coq.try_grab sn.coqtop (sn.coqops#raw_coq_query query) ignore
+    doquery query sn
 
 let otherquery command = cb_on_current_term (otherquery command)
 
 let query command _ =
   if command = "Search" || command = "SearchAbout"
   then searchabout ()
+  else if command = "Show Proof"
+  then showproof ()
   else otherquery command ()
 
 end
@@ -1109,6 +1118,7 @@ let build_ui () =
     qitem "About" (Some "<Ctrl><Shift>A");
     qitem "Locate" (Some "<Ctrl><Shift>L");
     qitem "Print Assumptions" (Some "<Ctrl><Shift>N");
+    qitem "Show Proof" (Some "<Ctrl><Shift>R");
   ];
 
   menu tools_menu [

--- a/ide/coqide.ml
+++ b/ide/coqide.ml
@@ -681,10 +681,6 @@ let doquery query sn =
   sn.messages#clear;
   Coq.try_grab sn.coqtop (sn.coqops#raw_coq_query query) ignore
 
-let showproof () =
-  let query = "Show Proof." in
-  on_current_term (doquery query)
-
 let otherquery command sn =
   let word = get_current_word sn in
   if word <> "" then
@@ -696,9 +692,9 @@ let otherquery command = cb_on_current_term (otherquery command)
 let query command _ =
   if command = "Search" || command = "SearchAbout"
   then searchabout ()
-  else if command = "Show Proof"
-  then showproof ()
   else otherquery command ()
+
+let simplequery query = cb_on_current_term (doquery query)
 
 end
 
@@ -868,12 +864,12 @@ let toggle_items menu_name l =
   in
   List.iter f l
 
+let no_under = Util.String.map (fun x -> if x = '_' then '-' else x)
+
 (** Create alphabetical menu items with elements in sub-items.
     [l] is a list of lists, one per initial letter *)
 
 let alpha_items menu_name item_name l =
-  let no_under = Util.String.map (fun x -> if x = '_' then '-' else x)
-  in
   let mk_item text =
     let text' =
       let last = String.length text - 1 in
@@ -919,6 +915,24 @@ let template_item (text, offset, len, key) =
     end
   in
   item name ~label ~callback:(cb_on_current_term callback) ~accel:(modifier^key)
+
+(** Create menu items for pairs (query, shortcut key).
+    If the shortcut key is not in the range 'a'-'z','A'-'Z', it will be ignored.  *)
+
+let user_queries_items menu_name item_name l modifier =
+  let valid_key k = Int.equal (CString.length k) 1 && Util.is_letter k.[0] in
+  let mk_item (query, key) =
+    let query' =
+      let last = CString.length query - 1 in
+      if query.[last] = '.'
+      then query
+      else query ^ "."
+    in
+    let callback = Query.simplequery query' in
+    let accel = if valid_key key then Some (modifier^key) else None in
+    item (item_name^" "^(no_under query)) ~label:query ?accel ~callback menu_name
+  in
+  List.iter mk_item l
 
 let emit_to_focus window sgn =
   let focussed_widget = GtkWindow.Window.get_focus window#as_window in
@@ -1120,6 +1134,7 @@ let build_ui () =
     qitem "Print Assumptions" (Some "<Ctrl><Shift>N");
     qitem "Show Proof" (Some "<Ctrl><Shift>R");
   ];
+  user_queries_items queries_menu "Query" user_queries#get "<Ctrl><Shift>";
 
   menu tools_menu [
     item "Tools" ~label:"_Tools";

--- a/ide/coqide_ui.ml
+++ b/ide/coqide_ui.ml
@@ -119,6 +119,7 @@ let init () =
     <menuitem action='About' />
     <menuitem action='Locate' />
     <menuitem action='Print Assumptions' />
+    <menuitem action='Show Proof' />
   </menu>
   <menu name='Tools' action='Tools'>
     <menuitem action='Comment' />

--- a/ide/coqide_ui.ml
+++ b/ide/coqide_ui.ml
@@ -18,6 +18,15 @@ let list_items menu li =
   let () = List.iter (fun b -> Buffer.add_buffer res_buf (tactic_item b)) li in
   res_buf
 
+let list_queries menu li =
+  let res_buf = Buffer.create 500 in
+  let query_item (q, _) =
+    let s = "<menuitem action='"^menu^" "^(no_under q)^"' />\n" in
+    Buffer.add_string res_buf s
+  in
+  let () = List.iter query_item li in
+  res_buf
+
 let init () =
   let theui = Printf.sprintf "<ui>
 <menubar name='CoqIde MenuBar'>
@@ -119,7 +128,8 @@ let init () =
     <menuitem action='About' />
     <menuitem action='Locate' />
     <menuitem action='Print Assumptions' />
-    <menuitem action='Show Proof' />
+    <separator />
+    %s
   </menu>
   <menu name='Tools' action='Tools'>
     <menuitem action='Comment' />
@@ -163,5 +173,6 @@ let init () =
     (if Coq_config.gtk_platform <> `QUARTZ then "<menuitem action='Quit' />" else "")
     (Buffer.contents (list_items "Tactic" Coq_commands.tactics))
     (Buffer.contents (list_items "Template" Coq_commands.commands))
+    (Buffer.contents (list_queries "Query" Preferences.user_queries#get))
  in
   ignore (ui_m#add_ui_from_string theui);

--- a/ide/coqide_ui.ml
+++ b/ide/coqide_ui.ml
@@ -173,6 +173,6 @@ let init () =
     (if Coq_config.gtk_platform <> `QUARTZ then "<menuitem action='Quit' />" else "")
     (Buffer.contents (list_items "Tactic" Coq_commands.tactics))
     (Buffer.contents (list_items "Template" Coq_commands.commands))
-    (Buffer.contents (list_queries "Query" Preferences.user_queries#get))
+    (Buffer.contents (list_queries "User-Query" Preferences.user_queries#get))
  in
   ignore (ui_m#add_ui_from_string theui);

--- a/ide/preferences.ml
+++ b/ide/preferences.ml
@@ -938,8 +938,6 @@ let configure ?(apply=(fun () -> ())) () =
     in
     let q = input_string "User query" "Your query" in
     let k = input_string "Shortcut key" "Shortcut (a single letter)" in
-    let last = CString.length q - 1 in
-    let q = if last > 0 && q.[last] = '.' then CString.sub q 0 last else q in
     let q = CString.map (fun c -> if c = '$' then ' ' else c) q in
     (* Anything that is not a simple letter will be ignored. *)
     let k =
@@ -952,8 +950,8 @@ let configure ?(apply=(fun () -> ())) () =
   let user_queries =
     list
       ~f:user_queries#set
-      (* Disallow same key or empty query. *)
-      ~eq:(fun (q1, k1) (q2, k2) -> k1 = k2 || q1 = "" || q2 = "")
+      (* Disallow same query, key or empty query. *)
+      ~eq:(fun (q1, k1) (q2, k2) -> k1 = k2 || q1 = "" || q2 = "" || q1 = q2)
       ~add:add_user_query
       ~titles:["User query"; "Shortcut key"]
       "User queries"

--- a/ide/preferences.ml
+++ b/ide/preferences.ml
@@ -322,6 +322,7 @@ let _ = attach_modifiers modifier_for_navigation "<Actions>/Navigation/"
 let _ = attach_modifiers modifier_for_templates "<Actions>/Templates/"
 let _ = attach_modifiers modifier_for_tactics "<Actions>/Tactics/"
 let _ = attach_modifiers modifier_for_display "<Actions>/View/"
+let _ = attach_modifiers modifier_for_queries "<Actions>/Queries/"
 
 let modifiers_valid =
   new preference ~name:["modifiers_valid"] ~init:"<Alt><Control><Shift>" ~repr:Repr.(string)
@@ -938,7 +939,8 @@ let configure ?(apply=(fun () -> ())) () =
     let q = input_string "User query" "Your query" in
     let k = input_string "Shortcut key" "Shortcut (a single letter)" in
     let last = CString.length q - 1 in
-    let q =  if q.[last] = '.' then CString.sub q 0 last else q in
+    let q = if last > 0 && q.[last] = '.' then CString.sub q 0 last else q in
+    let q = CString.map (fun c -> if c = '$' then ' ' else c) q in
     (* Anything that is not a simple letter will be ignored. *)
     let k =
       if Int.equal (CString.length k) 1 && Util.is_letter k.[0] then k
@@ -950,7 +952,8 @@ let configure ?(apply=(fun () -> ())) () =
   let user_queries =
     list
       ~f:user_queries#set
-      ~eq:(fun (_, k1) (_, k2) -> k1 = k2) (* Disallow same key. *)
+      (* Disallow same key or empty query. *)
+      ~eq:(fun (q1, k1) (q2, k2) -> k1 = k2 || q1 = "" || q2 = "")
       ~add:add_user_query
       ~titles:["User query"; "Shortcut key"]
       "User queries"

--- a/ide/preferences.ml
+++ b/ide/preferences.ml
@@ -924,8 +924,13 @@ let configure ?(apply=(fun () -> ())) () =
               vertical_tabs;opposite_tabs] in
 
   let edit_user_query (q, k) =
-    let q = Configwin_ihm.edit_string "User query" q in
-    let k = Configwin_ihm.edit_string "Shortcut key" k in
+    let input_string l s v =
+      match GToolbox.input_string ~title:l ~text:s v with
+      | None -> s
+      | Some s -> s
+    in
+    let q = input_string "User query" q "Your query" in
+    let k = input_string "Shortcut key" k "Shortcut (a single letter)" in
       q, k
   in
 

--- a/ide/preferences.ml
+++ b/ide/preferences.ml
@@ -976,11 +976,10 @@ let configure ?(apply=(fun () -> ())) () =
 	     [automatic_tactics]);
      Section("Shortcuts", Some `PREFERENCES,
 	     [modifiers_valid; modifier_for_tactics;
-	      modifier_for_templates; modifier_for_display; modifier_for_navigation]);
+        modifier_for_templates; modifier_for_display; modifier_for_navigation;
+        user_queries]);
      Section("Misc", Some `ADD,
-       misc);
-     Section("User queries", None,
-       [user_queries])]
+       misc)]
   in
 (*
   Format.printf "before edit: current.text_font = %s@." (Pango.Font.to_string current.text_font);

--- a/ide/preferences.ml
+++ b/ide/preferences.ml
@@ -315,6 +315,9 @@ let modifier_for_tactics =
 let modifier_for_display =
   new preference ~name:["modifier_for_display"] ~init:"<Alt><Shift>" ~repr:Repr.(string)
 
+let modifier_for_queries =
+  new preference ~name:["modifier_for_queries"] ~init:"<Control><Shift>" ~repr:Repr.(string)
+
 let _ = attach_modifiers modifier_for_navigation "<Actions>/Navigation/"
 let _ = attach_modifiers modifier_for_templates "<Actions>/Templates/"
 let _ = attach_modifiers modifier_for_tactics "<Actions>/Tactics/"
@@ -852,6 +855,9 @@ let configure ?(apply=(fun () -> ())) () =
   let modifier_for_display =
     pmodifiers "Modifiers for View Menu" modifier_for_display
   in
+  let modifier_for_queries =
+    pmodifiers "Modifiers for Queries Menu" modifier_for_queries
+  in
   let modifiers_valid =
     pmodifiers ~all:true "Allowed modifiers" modifiers_valid
   in
@@ -977,7 +983,7 @@ let configure ?(apply=(fun () -> ())) () =
      Section("Shortcuts", Some `PREFERENCES,
 	     [modifiers_valid; modifier_for_tactics;
         modifier_for_templates; modifier_for_display; modifier_for_navigation;
-        user_queries]);
+        modifier_for_queries; user_queries]);
      Section("Misc", Some `ADD,
        misc)]
   in

--- a/ide/preferences.mli
+++ b/ide/preferences.mli
@@ -65,6 +65,7 @@ val modifier_for_navigation : string preference
 val modifier_for_templates : string preference
 val modifier_for_tactics : string preference
 val modifier_for_display : string preference
+val modifier_for_queries : string preference
 val modifiers_valid : string preference
 val cmd_browse : string preference
 val cmd_editor : string preference

--- a/ide/preferences.mli
+++ b/ide/preferences.mli
@@ -95,6 +95,7 @@ val spaces_instead_of_tabs : bool preference
 val tab_length : int preference
 val highlight_current_line : bool preference
 val nanoPG : bool preference
+val user_queries : (string * string) list preference
 
 val save_pref : unit -> unit
 val load_pref : unit -> unit


### PR DESCRIPTION
Same as #67, but now on trunk.

It also allows to have queries that end with "...", meaning that the query takes an argument (just like Print or Check).

The modification of the Queries menu still require a restart, and after some time trying to deal with it, I think I will probably need some pointers. (@ppedrot for instance?)
The problem is to dynamically remove and add menu items.
