### PR TITLE
Fix for bug #4784

### DIFF
--- a/checker/check_stat.ml
+++ b/checker/check_stat.ml
@@ -18,7 +18,7 @@ let print_memory_stat () =
   if !memory_stat then begin
     Format.printf "total heap size = %d kbytes\n" (CObj.heap_size_kb ());
     Format.print_newline();
-    flush_all()
+    Format.print_flush()
   end
 
 let output_context = ref false

--- a/lib/errors.ml
+++ b/lib/errors.ml
@@ -144,5 +144,5 @@ let handled e =
 let fatal_error info anomaly =
   let msg = info ++ fnl () in
   pp_with ~pp_tag:Ppstyle.pp_tag !Pp_control.err_ft msg;
-  flush_all ();
+  Format.pp_print_flush !Pp_control.err_ft ();
   exit (if anomaly then 129 else 1)

--- a/toplevel/coqloop.ml
+++ b/toplevel/coqloop.ml
@@ -345,13 +345,21 @@ let feed_emacs = function
   | _  -> ()
 *)
 
+(* Flush in a compatible order with 8.5 *)
+(* This mimics the semantics of the old Pp.flush_all *)
+let loop_flush_all () =
+  Pervasives.flush stderr;
+  Pervasives.flush stdout;
+  Format.pp_print_flush !Pp_control.std_ft ();
+  Format.pp_print_flush !Pp_control.err_ft ()
+
 let rec loop () =
   Sys.catch_break true;
   if !Flags.print_emacs then Vernacentries.qed_display_script := false;
   Flags.coqtop_ui := true;
   try
     reset_input_buffer stdin top_buffer;
-    while true do do_vernac(); flush_all() done
+    while true do do_vernac(); loop_flush_all () done
   with
     | Errors.Drop -> ()
     | Errors.Quit -> exit 0

--- a/toplevel/coqloop.ml
+++ b/toplevel/coqloop.ml
@@ -328,7 +328,7 @@ let do_vernac () =
         Format.set_formatter_out_channel stdout;
         let msg = print_toplevel_error any ++ fnl () in
         pp_with ~pp_tag:Ppstyle.pp_tag !Pp_control.std_ft msg;
-        flush_all ()
+        Format.pp_print_flush !Pp_control.std_ft ()
 
 (** Main coq loop : read vernacular expressions until Drop is entered.
     Ctrl-C is handled internally as Sys.Break instead of aborting Coq.


### PR DESCRIPTION
We revert to the old flushing strategy in the toplevel.

PR #179 introduced a different flushing in toplevel, but now a new
line is produced when Set Printing Width is large and proof general complains.

IMO, this is a pitfall of the current setup, in particular, it is using
format without enclosing expressions in top-level boxes, which results
in undefined behavior and fragile printing such as this bug shows.

Test suite passes.
