### PR TITLE
Printing of unification constraints

### DIFF
--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -471,7 +471,38 @@ let default_pr_subgoal n sigma =
 
 let pr_internal_existential_key ev = str (string_of_existential ev)
 
-let emacs_print_dependent_evars sigma seeds =
+let print_evar_constraints gl sigma cstrs =
+  let pr_env =
+    match gl with
+    | None -> fun e' -> pr_context_of e' sigma
+    | Some g ->
+       let env = Goal.V82.env sigma g in fun e' ->
+       begin
+         if Context.Named.equal (named_context env) (named_context e') then
+           if Context.Rel.equal (rel_context env) (rel_context e') then mt ()
+           else pr_rel_context_of e' sigma ++ str " |-" ++ spc ()
+         else pr_context_of e' sigma ++ str " |-" ++ spc ()
+       end
+  in
+  let pr_evconstr (pbty,env,t1,t2) =
+    let t1 = Evarutil.nf_evar sigma t1
+    and t2 = Evarutil.nf_evar sigma t2 in
+    str" " ++
+      hov 2 (pr_env env ++ pr_lconstr_env env sigma t1 ++ spc () ++
+             str (match pbty with
+                  | Reduction.CONV -> "=="
+                  | Reduction.CUMUL -> "<=") ++
+             spc () ++ pr_lconstr_env env sigma t2)
+  in
+  prlist_with_sep fnl pr_evconstr cstrs
+
+let print_dependent_evars gl sigma seeds =
+  let constraints =
+    let _, cstrs = Evd.extract_all_conv_pbs sigma in
+    if List.is_empty cstrs then mt ()
+    else fnl () ++ str (String.plural (List.length cstrs) "unification constraint")
+         ++ str":" ++ fnl () ++ hov 0 (print_evar_constraints gl sigma cstrs)
+  in
   let evars () =
     let evars = Evarutil.gather_dependent_evars sigma seeds in
     let evars =
@@ -489,7 +520,7 @@ let emacs_print_dependent_evars sigma seeds =
     fnl () ++
     str "(dependent evars:" ++ evars ++ str ")" ++ fnl ()
   in
-  delayed_emacs_cmd evars
+  constraints ++ delayed_emacs_cmd evars
 
 (* Print open subgoals. Checks for uninstantiated existential variables *)
 (* spiwack: [seeds] is for printing dependent evars in emacs mode. *)
@@ -557,12 +588,12 @@ let default_pr_subgoals ?(pr_first=true) close_cmd sigma seeds shelf stack goals
 	let exl = Evarutil.non_instantiated sigma in
 	if Evar.Map.is_empty exl then
 	  (str"No more subgoals."
-	   ++ emacs_print_dependent_evars sigma seeds)
+	   ++ print_dependent_evars None sigma seeds)
 	else
 	  let pei = pr_evars_int sigma 1 exl in
 	  (str "No more subgoals, but there are non-instantiated existential variables:"
 	   ++ fnl () ++ (hov 0 pei)
-	   ++ emacs_print_dependent_evars sigma seeds ++ fnl () ++
+	   ++ print_dependent_evars None sigma seeds ++ fnl () ++
            str "You can use Grab Existential Variables.")
       end
   | [g] when not !Flags.print_emacs && pr_first ->
@@ -570,7 +601,7 @@ let default_pr_subgoals ?(pr_first=true) close_cmd sigma seeds shelf stack goals
       v 0 (
 	str "1" ++ focused_if_needed ++ str"subgoal" ++ print_extra
         ++ pr_goal_tag g ++ pr_goal_name sigma g ++ cut () ++ pg
-	++ emacs_print_dependent_evars sigma seeds
+	++ print_dependent_evars (Some g) sigma seeds
       )
   | g1::rest ->
       let goals = print_multiple_goals g1 rest in
@@ -582,7 +613,7 @@ let default_pr_subgoals ?(pr_first=true) close_cmd sigma seeds shelf stack goals
         ++ pr_goal_tag g1
         ++ pr_goal_name sigma g1 ++ cut ()
 	++ goals
-	++ emacs_print_dependent_evars sigma seeds
+	++ print_dependent_evars (Some g1) sigma seeds
       )
 
 (**********************************************************************)

--- a/test-suite/output/unifconstraints.out
+++ b/test-suite/output/unifconstraints.out
@@ -1,0 +1,83 @@
+3 focused subgoals
+(shelved: 1)
+  
+  ============================
+  ?Goal 0
+
+subgoal 2 is:
+ forall n : nat, ?Goal n -> ?Goal (S n)
+subgoal 3 is:
+ nat
+unification constraints:
+ ?Goal ?Goal2 <=
+   True /\ True /\ True \/
+   veeryyyyyyyyyyyyloooooooooooooonggidentifier =
+   veeryyyyyyyyyyyyloooooooooooooonggidentifier
+ ?Goal ?Goal2 <=
+   True /\ True /\ True \/
+   veeryyyyyyyyyyyyloooooooooooooonggidentifier =
+   veeryyyyyyyyyyyyloooooooooooooonggidentifier
+3 focused subgoals
+(shelved: 1)
+  
+  n, m : nat
+  ============================
+  ?Goal@{n:=n; m:=m} 0
+
+subgoal 2 is:
+ forall n0 : nat, ?Goal@{n:=n; m:=m} n0 -> ?Goal@{n:=n; m:=m} (S n0)
+subgoal 3 is:
+ nat
+unification constraints:
+ ?Goal@{n:=n; m:=m} ?Goal2@{n:=n; m:=m} <=
+   True /\ True /\ True \/
+   veeryyyyyyyyyyyyloooooooooooooonggidentifier =
+   veeryyyyyyyyyyyyloooooooooooooonggidentifier
+ ?Goal@{n:=n; m:=m} ?Goal2@{n:=n; m:=m} <=
+   True /\ True /\ True \/
+   veeryyyyyyyyyyyyloooooooooooooonggidentifier =
+   veeryyyyyyyyyyyyloooooooooooooonggidentifier
+3 focused subgoals
+(shelved: 1)
+  
+  m : nat
+  ============================
+  ?Goal1@{m:=m} 0
+
+subgoal 2 is:
+ forall n0 : nat, ?Goal1@{m:=m} n0 -> ?Goal1@{m:=m} (S n0)
+subgoal 3 is:
+ nat
+unification constraints:
+ 
+ n, m : nat |- ?Goal1@{m:=m} ?Goal0@{n:=n; m:=m} <=
+   True /\ True /\ True \/
+   veeryyyyyyyyyyyyloooooooooooooonggidentifier =
+   veeryyyyyyyyyyyyloooooooooooooonggidentifier
+ 
+ n, m : nat |- ?Goal1@{m:=m} ?Goal0@{n:=n; m:=m} <=
+   True /\ True /\ True \/
+   veeryyyyyyyyyyyyloooooooooooooonggidentifier =
+   veeryyyyyyyyyyyyloooooooooooooonggidentifier
+3 focused subgoals
+(shelved: 1)
+  
+  m : nat
+  ============================
+  ?Goal0@{m:=m} 0
+
+subgoal 2 is:
+ forall n0 : nat, ?Goal0@{m:=m} n0 -> ?Goal0@{m:=m} (S n0)
+subgoal 3 is:
+ nat
+unification constraints:
+ 
+ n, m : nat |- ?Goal0@{m:=m} ?Goal2@{n:=n} <=
+   True /\ True /\ True \/
+   veeryyyyyyyyyyyyloooooooooooooonggidentifier =
+   veeryyyyyyyyyyyyloooooooooooooonggidentifier
+ 
+ n, m : nat |- ?Goal0@{m:=m} ?Goal2@{n:=n} <=
+   True /\ True /\ True \/
+   veeryyyyyyyyyyyyloooooooooooooonggidentifier =
+   veeryyyyyyyyyyyyloooooooooooooonggidentifier

--- a/test-suite/output/unifconstraints.v
+++ b/test-suite/output/unifconstraints.v
@@ -1,0 +1,21 @@
+(* Set Printing Existential Instances. *)
+Axiom veeryyyyyyyyyyyyloooooooooooooonggidentifier : nat.
+Goal True /\ True /\ True \/
+             veeryyyyyyyyyyyyloooooooooooooonggidentifier =
+             veeryyyyyyyyyyyyloooooooooooooonggidentifier.
+  refine (nat_rect _ _ _ _).
+  Show.
+Admitted.
+
+Set Printing Existential Instances.
+Goal forall n m : nat, True /\ True /\ True \/
+                        veeryyyyyyyyyyyyloooooooooooooonggidentifier =
+                        veeryyyyyyyyyyyyloooooooooooooonggidentifier.
+  intros.
+  refine (nat_rect _ _ _ _).
+  Show.
+  clear n. 
+  Show.
+  3:clear m.
+  Show.
+Admitted.


### PR DESCRIPTION
Add an option (by default activated except in <= 8.5 compatibility mode) to print pending unification constraints in proof mode, which allows in particular to understand error messages mentioning them better.
