### PR TITLE
Selective unfolding

### DIFF
--- a/doc/refman/RefMan-syn.tex
+++ b/doc/refman/RefMan-syn.tex
@@ -321,6 +321,20 @@ Sometimes, a notation is expected only for the parser.
 To do so, the option {\em only parsing} is allowed in the list of modifiers of
 \texttt{Notation}.
 
+\paragraph{Deactivating some printing notations}
+In addition \verb=Unset Printing Notations=, it is possible to deactivate notations in a more fine-grain way, either individually or by scopes, using the following syntax:
+\begin{quote}
+  Deactivate Notation "expression" From Scope {\scope}.
+  Reactivate Notation "expression" From Scope {\scope}.
+
+  Deactivate Notation Scope {\scope}.
+  Reactivate Notation Scope {\scope}.
+\end{quote}
+where "expression" represents the notation with variables replaced by underscores.
+\begin{coq_example*}
+Deactivate Notation "_ + _" From Scope nat_scope.
+\end{coq_example*}
+
 \subsection{The \texttt{Infix} command
 \comindex{Infix}}
 

--- a/ide/texmacspp.ml
+++ b/ide/texmacspp.ml
@@ -513,6 +513,15 @@ let rec tmpp v loc =
       xmlScope loc "delimit" name ~attr:["delimiter",tag] []
   | VernacDelimiters (name,None) ->
       xmlScope loc "undelimit" name ~attr:[] []
+  | VernacNotationActivation (Some name,_,true) ->
+      xmlScope loc "activate" name ~attr:[] []
+  | VernacNotationActivation (Some name,_,false) ->
+      xmlScope loc "deactivate" name ~attr:[] []
+  | VernacNotationActivation (None,Some name,true) ->
+      xmlScope loc "activate" name ~attr:[] []
+  | VernacNotationActivation (None,Some name,false) ->
+      xmlScope loc "deactivate" name ~attr:[] []
+  | VernacNotationActivation (None,None,_) -> assert false
   | VernacInfix (_,((_,name),sml),ce,sn) ->
       let attrs = List.flatten (List.map attribute_of_syntax_modifier sml) in
       let sc_attr =

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -90,9 +90,9 @@ let show_scope scopt =
   | Some sc -> spc () ++ str "in scope" ++ spc () ++ str sc
 
 let deactivate_notation_printing ntn scopt =
-  (* match scopt with (\* ensures that the scope exists *\) *)
-  (* | Some sc -> ignore (find_scope sc) *)
-  (* | None -> (); *)
+  match scopt with (* ensures that the scope exists *)
+  | Some sc -> ignore (find_scope sc)
+  | None -> ();
   (* match availability_of_notation (scopt, ntn) (scopt, []) with *)
   (* | None -> user_err_loc (Loc.ghost, "", str "Notation" ++ spc () ++ str ntn *)
   (*                                        ++ spc () ++ str "does not exist" *)
@@ -100,7 +100,7 @@ let deactivate_notation_printing ntn scopt =
   (* | Some _ -> *)
      let nr = NotationRule (scopt, ntn) in
      if List.mem nr !print_non_active_notations then
-       Pp.msg_warning (str "Notation " ++ spc () ++ str ntn ++ spc ()
+       Pp.msg_warning (str "Notation" ++ spc () ++ str ntn ++ spc ()
                        ++ str "is already inactive" ++ show_scope scopt ++ str ".")
      else print_non_active_notations := nr :: !print_non_active_notations
 
@@ -111,8 +111,8 @@ let reactivate_notation_printing ntn scopt =
       (fun x -> x = (NotationRule (scopt, ntn)))
       !print_non_active_notations
   with Not_found ->
-    Pp.msg_warning (str "Notation " ++ str ntn ++ str " is already activated"
-                    ++ show_scope scopt ++ str ".")
+    Pp.msg_warning (str "Notation" ++ spc () ++ str ntn ++ spc ()
+                    ++ str "is already activated" ++ show_scope scopt ++ str ".")
 
 let show_printing_inactive_notations () =
   let _ = Pp.msg_notice (str "Inactive notations:") in

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -90,9 +90,9 @@ let show_scope scopt =
   | Some sc -> spc () ++ str "in scope" ++ spc () ++ str sc
 
 let deactivate_notation_printing ntn scopt =
-  match scopt with (* ensures that the scope exists *)
-  | Some sc -> ignore (find_scope sc)
-  | None -> ();
+  (* match scopt with (\* ensures that the scope exists *\) *)
+  (* | Some sc -> ignore (find_scope sc) *)
+  (* | None -> (); *)
   (* match availability_of_notation (scopt, ntn) (scopt, []) with *)
   (* | None -> user_err_loc (Loc.ghost, "", str "Notation" ++ spc () ++ str ntn *)
   (*                                        ++ spc () ++ str "does not exist" *)

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -93,11 +93,11 @@ let deactivate_notation_printing ntn scopt =
   (* match scopt with (\* ensures that the scope exists *\) *)
   (* | Some sc -> ignore (find_scope sc) *)
   (* | None -> (); *)
-  (* match availability_of_notation (scopt, ntn) (scopt, []) with *)
-  (* | None -> user_err_loc (Loc.ghost, "", str "Notation" ++ spc () ++ str ntn *)
-  (*                                        ++ spc () ++ str "does not exist" *)
-  (*                                        ++ show_scope scopt ++ str ".") *)
-  (* | Some _ -> *)
+  match availability_of_notation (scopt, ntn) (scopt, []) with
+  | None -> user_err_loc (Loc.ghost, "", str "Notation" ++ spc () ++ str ntn
+                                         ++ spc () ++ str "does not exist"
+                                         ++ show_scope scopt ++ str ".")
+  | Some _ ->
      let nr = NotationRule (scopt, ntn) in
      if List.mem nr !print_non_active_notations then
        Pp.msg_warning (str "Notation" ++ spc () ++ str ntn ++ spc ()

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -100,7 +100,7 @@ let deactivate_notation_printing ntn scopt =
   | Some _ ->
      let nr = NotationRule (scopt, ntn) in
      if List.mem nr !print_non_active_notations then
-       Pp.msg_warning (str "Notation" ++ spc () ++ str ntn ++ spc ()
+       Feedback.msg_warning (str "Notation" ++ spc () ++ str ntn ++ spc ()
                        ++ str "is already inactive" ++ show_scope scopt ++ str ".")
      else print_non_active_notations := nr :: !print_non_active_notations
 
@@ -111,14 +111,14 @@ let reactivate_notation_printing ntn scopt =
       (fun x -> x = (NotationRule (scopt, ntn)))
       !print_non_active_notations
   with Not_found ->
-    Pp.msg_warning (str "Notation" ++ spc () ++ str ntn ++ spc ()
+    Feedback.msg_warning (str "Notation" ++ spc () ++ str ntn ++ spc ()
                     ++ str "is already activated" ++ show_scope scopt ++ str ".")
 
 let show_printing_inactive_notations () =
-  let _ = Pp.msg_notice (str "Inactive notations:") in
+  let _ = Feedback.msg_notice (str "Inactive notations:") in
   List.iter
     (function
-    | NotationRule (scopt, ntn) -> Pp.msg_notice (str ntn ++ show_scope scopt)
+    | NotationRule (scopt, ntn) -> Feedback.msg_notice (str ntn ++ show_scope scopt)
     | SynDefRule _ -> ())
     !print_non_active_notations
 
@@ -497,7 +497,7 @@ let is_projection nargs = function
 	 else None
      with Not_found -> None)
   | _ -> None
-	
+
 let is_hole = function CHole _ | CEvar _ -> true | _ -> false
 
 let is_significant_implicit a =

--- a/interp/constrextern.mli
+++ b/interp/constrextern.mli
@@ -76,7 +76,12 @@ val with_universes : ('a -> 'b) -> 'a -> 'b
 val without_symbols : ('a -> 'b) -> 'a -> 'b
 
 (** This suppresses printing of specific notations only *)
+val deactivate_notation_printing : notation -> scope_name option -> unit
+val reactivate_notation_printing : notation -> scope_name option -> unit
 val without_specific_symbols : interp_rule list -> ('a -> 'b) -> 'a -> 'b
+
+(** This prints all notations with inactive printing *)
+val show_printing_inactive_notations : unit -> unit
 
 (** This prints metas as anonymous holes *)
 val with_meta_as_hole : ('a -> 'b) -> 'a -> 'b

--- a/interp/constrextern.mli
+++ b/interp/constrextern.mli
@@ -76,8 +76,10 @@ val with_universes : ('a -> 'b) -> 'a -> 'b
 val without_symbols : ('a -> 'b) -> 'a -> 'b
 
 (** This suppresses printing of specific notations only *)
-val deactivate_notation_printing : notation -> scope_name option -> unit
-val reactivate_notation_printing : notation -> scope_name option -> unit
+val deactivate_single_notation_printing : notation -> scope_name option -> unit
+val reactivate_single_notation_printing : notation -> scope_name option -> unit
+val deactivate_notation_scope_printing : scope_name -> unit
+val reactivate_notation_scope_printing : scope_name -> unit
 val without_specific_symbols : interp_rule list -> ('a -> 'b) -> 'a -> 'b
 
 (** This prints all notations with inactive printing *)

--- a/interp/notation.mli
+++ b/interp/notation.mli
@@ -124,9 +124,9 @@ val uninterp_notations : glob_constr -> notation_rule list
 val uninterp_cases_pattern_notations : cases_pattern -> notation_rule list
 val uninterp_ind_pattern_notations : inductive -> notation_rule list
 
-(** Test if a notation is available in the scopes 
-   context [scopes]; if available, the result is not None; the first 
-   argument is itself not None if a delimiters is needed *)
+(** Test if a notation is available in the scopes context [scopes];
+    if available, the result is not None;
+    the first argument is itself not None if delimiters are needed *)
 val availability_of_notation : scope_name option * notation -> local_scopes ->
   (scope_name option * delimiters option) option
 

--- a/intf/vernacexpr.mli
+++ b/intf/vernacexpr.mli
@@ -297,6 +297,7 @@ type vernac_expr =
       obsolete_locality * constr_expr * (lstring * syntax_modifier list) *
       scope_name option
   | VernacNotationAddFormat of string * string * string
+  | VernacNotationActivation of string option * scope_name option * bool
 
   (* Gallina *)
   | VernacDefinition of

--- a/parsing/g_vernac.ml4
+++ b/parsing/g_vernac.ml4
@@ -1022,6 +1022,19 @@ GEXTEND Gram
      | IDENT "Undelimit"; IDENT "Scope"; sc = IDENT ->
 	 VernacDelimiters (sc, None)
 
+     | IDENT "Reactivate"; IDENT "Notation"; IDENT "Scope"; sc = IDENT ->
+	 VernacNotationActivation (None, Some sc, true)
+     | IDENT "Deactivate"; IDENT "Notation"; IDENT "Scope"; sc = IDENT ->
+	 VernacNotationActivation (None, Some sc, false)
+     | IDENT "Reactivate"; IDENT "Notation"; ntn = STRING ->
+	 VernacNotationActivation (Some ntn, None, true)
+     | IDENT "Deactivate"; IDENT "Notation"; ntn = STRING ->
+	 VernacNotationActivation (Some ntn, None, false)
+     | IDENT "Reactivate"; IDENT "Notation"; ntn = STRING; IDENT "From"; IDENT "Scope"; sc = IDENT ->
+	 VernacNotationActivation (Some ntn, Some sc, true)
+     | IDENT "Deactivate"; IDENT "Notation"; ntn = STRING; IDENT "From"; IDENT "Scope"; sc = IDENT ->
+	 VernacNotationActivation (Some ntn, Some sc, false)
+
      | IDENT "Bind"; IDENT "Scope"; sc = IDENT; "with";
        refl = LIST1 class_rawexpr -> VernacBindScope (sc,refl)
 

--- a/printing/ppvernac.ml
+++ b/printing/ppvernac.ml
@@ -634,6 +634,33 @@ module Make
           return (
             keyword "Undelimit Scope" ++ spc () ++ str sc
           )
+        | VernacNotationActivation (None,Some sc,true) ->
+          return (
+            keyword "Activate Notation Scope" ++ spc () ++ str sc
+          )
+        | VernacNotationActivation (None,Some sc,false) ->
+          return (
+            keyword "Deactivate Notation Scope" ++ spc () ++ str sc
+          )
+        | VernacNotationActivation (Some ntn,None,true) ->
+          return (
+            keyword "Activate Notation" ++ spc () ++ str ntn
+          )
+        | VernacNotationActivation (Some ntn,None,false) ->
+          return (
+            keyword "Deactivate Notation" ++ spc () ++ str ntn
+          )
+        | VernacNotationActivation (Some ntn,Some sc,true) ->
+          return (
+            keyword "Activate Notation" ++ spc () ++ str ntn ++
+            keyword "From Scope" ++ spc () ++ str sc
+          )
+        | VernacNotationActivation (Some ntn,Some sc,false) ->
+          return (
+            keyword "Deactivate Notation" ++ spc () ++ str ntn ++
+            keyword "From Scope" ++ spc () ++ str sc
+          )
+        | VernacNotationActivation (None,None,_) -> assert false
         | VernacBindScope (sc,cll) ->
           return (
             keyword "Bind Scope" ++ spc () ++ str sc ++

--- a/stm/vernac_classifier.ml
+++ b/stm/vernac_classifier.ml
@@ -188,7 +188,7 @@ let rec classify_vernac e =
     (* These commands alter the parser *)
     | VernacOpenCloseScope _ | VernacDelimiters _ | VernacBindScope _
     | VernacInfix _ | VernacNotation _ | VernacNotationAddFormat _
-    | VernacSyntaxExtension _ 
+    | VernacSyntaxExtension _ | VernacNotationActivation _
     | VernacSyntacticDefinition _
     | VernacRequire _ | VernacImport _ | VernacInclude _
     | VernacDeclareMLModule _

--- a/toplevel/metasyntax.ml
+++ b/toplevel/metasyntax.ml
@@ -1223,11 +1223,20 @@ let add_notation local c ((loc,df),modifiers) sc =
   Dumpglob.dump_notation (loc,df') sc true
 
 let add_notation_extra_printing_rule df k v =
-  let notk = 
+  let notk =
     let dfs = split_notation_string df in
     let _,_, symbs = analyze_notation_tokens dfs in
     make_notation_key symbs in
   Notation.add_notation_extra_printing_rule notk k v
+
+let deactivate_single_notation_printing ntn sc =
+  Constrextern.deactivate_single_notation_printing ntn sc
+let reactivate_single_notation_printing ntn sc =
+  Constrextern.reactivate_single_notation_printing ntn sc
+let deactivate_notation_scope_printing sc =
+  Constrextern.deactivate_notation_scope_printing sc
+let reactivate_notation_scope_printing sc =
+  Constrextern.reactivate_notation_scope_printing sc
 
 (* Infix notations *)
 

--- a/toplevel/metasyntax.mli
+++ b/toplevel/metasyntax.mli
@@ -27,6 +27,13 @@ val add_notation_extra_printing_rule : string -> string -> string -> unit
 
 (** Declaring delimiter keys and default scopes *)
 
+val deactivate_single_notation_printing : string -> scope_name option -> unit
+val reactivate_single_notation_printing : string -> scope_name option -> unit
+val deactivate_notation_scope_printing : scope_name -> unit
+val reactivate_notation_scope_printing : scope_name -> unit
+
+(** Declaring delimiter keys and default scopes *)
+
 val add_delimiters : scope_name -> string -> unit
 val remove_delimiters : scope_name -> unit
 val add_class_scope : scope_name -> scope_class list -> unit

--- a/toplevel/vernacentries.ml
+++ b/toplevel/vernacentries.ml
@@ -412,6 +412,7 @@ let dump_global r =
     let gr = Smartlocate.smart_global r in
     Dumpglob.add_glob (Constrarg.loc_of_or_by_notation loc_of_reference r) gr
   with e when Errors.noncritical e -> ()
+
 (**********)
 (* Syntax *)
 
@@ -441,6 +442,14 @@ let vernac_infix locality local =
 let vernac_notation locality local =
   let local = enforce_module_locality locality local in
   Metasyntax.add_notation local
+
+let vernac_notation_activation ntn sc b =
+  match ntn, sc, b with
+  | Some ntn, scopt, true -> Metasyntax.reactivate_single_notation_printing ntn scopt
+  | Some ntn, scopt, false -> Metasyntax.deactivate_single_notation_printing ntn scopt
+  | None, Some sc, true -> Metasyntax.reactivate_notation_scope_printing sc
+  | None, Some sc, false -> Metasyntax.deactivate_notation_scope_printing sc
+  | None, None, _ -> assert false
 
 (***********)
 (* Gallina *)
@@ -1748,6 +1757,7 @@ let interp ?proof ~loc locality poly c =
   | VernacSyntaxExtension (local,sl) ->
       vernac_syntax_extension locality local sl
   | VernacDelimiters (sc,lr) -> vernac_delimiters sc lr
+  | VernacNotationActivation (ntn, sc, b) -> vernac_notation_activation ntn sc b
   | VernacBindScope (sc,rl) -> vernac_bind_scope sc rl
   | VernacOpenCloseScope (local, s) -> vernac_open_close_scope locality local s
   | VernacArgumentsScope (qid,scl) -> vernac_arguments_scope locality qid scl


### PR DESCRIPTION
This PR introduces the possibility to unset the printing of notations in a more fine grained fashion than Unset Printing Notations. One can unfold notations either individually or by scopes.
It is a project I started at the coding sprint last year and I finished it in the train coming back from this year's.
This is very useful for debugging purposes when having very large notations that should not be unfolded (UTF8 string comes to mind immediately).

It introduces four new commands:
- Deactivate Notation Scope scope_name.
- Reactivate Notation Scope scope_name.
- Deactivation Notation notation_string [From Scope scope_name].
- Reactivation Notation notation string [From Scope scope_name].

Notation strings are the displayed notations with variables replaced by "_".

I agree the names are not so great and could be improved (Hugo suggested "Unset Printing Notation Scope <scope_name>" if i remember correctly).
