### PR TITLE
Make feedback messages associated to a canonical state_id [Under Revision]

### DIFF
--- a/dev/doc/changes.txt
+++ b/dev/doc/changes.txt
@@ -6,6 +6,16 @@
 
 Use Glob_ops.glob_constr_eq instead of Notation_ops.eq_glob_constr.
 
+** Feedback Messages **
+
+The format of feedback messages has been changed. In particular:
+
+- Feedback messages now carry a `state_id` instead of the old `edit_or_state_id`.
+  Thus, feedback always refers to a parseable part of the document.
+  Parsing errors are reported differently, as it was the case before.
+
+- The content of the `Message` feedback is `richpp` instead of a `string`.
+
 ** Logging and Pretty Printing: **
 
 * Printing functions have been removed from `Pp.mli`, which is now a
@@ -59,15 +69,17 @@ val msg_debug   : Pp.std_ppcmds -> unit
 
 ```` ocaml
 val set_feeder : (feedback -> unit) -> unit
-val feedback : ?id:edit_or_state_id -> ?route:route_id -> feedback_content -> unit
-val set_id_for_feedback : ?route:route_id -> edit_or_state_id -> unit
+val feedback : ?id:state_id -> ?route:route_id -> feedback_content -> unit
+val set_id_for_feedback : ?route:route_id -> state_id -> unit
 ````
   Note that `feedback` doesn't take two parameters anymore. After
   refactoring the following function has been removed:
 
 ```` ocaml
-val get_id_for_feedback : unit -> edit_or_state_id * route_id
+val get_id_for_feedback : unit -> state_id * route_id
 ````
+
+** Context interface **
 
 - The interface of the Context module was changed.
   Related types and functions were put in separate submodules.

--- a/ide/coqOps.ml
+++ b/ide/coqOps.ml
@@ -407,10 +407,7 @@ object(self)
     add_tooltip sentence pre post markup
 
   method private is_dummy_id id =
-    match id with
-    | Edit 0 -> true
-    | State id when Stateid.equal id Stateid.dummy -> true
-    | _ -> false
+    Stateid.equal id Stateid.dummy
 
   method private enqueue_feedback msg =
     let id = msg.id in
@@ -424,8 +421,7 @@ object(self)
       let sentence =
         let finder _ state_id s =
           match state_id, id with
-          | Some id', State id when Stateid.equal id id' -> Some (state_id, s)
-          | _, Edit id when id = s.edit_id -> Some (state_id, s)
+          | Some id', id when Stateid.equal id id' -> Some (state_id, s)
           | _ -> None in
         try Some (Doc.find_map document finder)
         with Not_found -> None in
@@ -480,10 +476,8 @@ object(self)
           else if Doc.is_empty document then ()
           else
             try
-              match id, Doc.tip document with
-              | Edit _, _ -> ()
-              | State id1, id2 when Stateid.newer_than id2 id1 -> ()
-              | _ -> Queue.add msg feedbacks
+              if not (Stateid.newer_than (Doc.tip document) id) then
+                Queue.add msg feedbacks
             with Doc.Empty | Invalid_argument _ -> Queue.add msg feedbacks 
       end;
         eat_feedback (n-1)

--- a/ide/xmlprotocol.ml
+++ b/ide/xmlprotocol.ml
@@ -864,8 +864,7 @@ let of_feedback_content = function
   | Message (l,m) -> constructor "feedback_content" "message" [ of_message l m ]
 
 let of_edit_or_state_id = function
-  | Edit id -> ["object","edit"], of_edit_id id
-  | State id -> ["object","state"], of_stateid id
+  | id -> ["object","state"], of_stateid id
 
 let of_feedback msg =
   let content = of_feedback_content msg.contents in
@@ -874,13 +873,9 @@ let of_feedback msg =
   Element ("feedback", obj @ ["route",route], [id;content])
 
 let to_feedback xml = match xml with
-  | Element ("feedback", ["object","edit";"route",route], [id;content]) -> {
-      id = Edit(to_edit_id id);
-      route = int_of_string route;
-      contents = to_feedback_content content }
   | Element ("feedback", ["object","state";"route",route], [id;content]) -> { 
-      id = State(to_stateid id);
-      route = int_of_string route;
+      id       = to_stateid id;
+      route    = int_of_string route;
       contents = to_feedback_content content }
   | x -> raise (Marshal_error("feedback",x))
 

--- a/kernel/term_typing.ml
+++ b/kernel/term_typing.ml
@@ -169,7 +169,7 @@ let hcons_j j =
 let feedback_completion_typecheck =
   let open Feedback in
   Option.iter (fun state_id ->
-      feedback ~id:(State state_id) Feedback.Complete)
+      feedback ~id:state_id Feedback.Complete)
 
 let infer_declaration ~trust env kn dcl =
   match dcl with

--- a/lib/feedback.ml
+++ b/lib/feedback.ml
@@ -15,10 +15,9 @@ type level =
   | Warning
   | Error
 
-type edit_id = int
-type state_id = Stateid.t
-type edit_or_state_id = Edit of edit_id | State of state_id
+type edit_id  = int
 type route_id = int
+type state_id = Stateid.t
 
 type feedback_content =
   | Processed
@@ -40,9 +39,9 @@ type feedback_content =
   | Message of level * Richpp.richpp
 
 type feedback = {
-  id : edit_or_state_id;
+  id       : state_id;
   contents : feedback_content;
-  route : route_id;
+  route    : route_id;
 }
 
 let default_route = 0
@@ -127,7 +126,7 @@ let msg_debug   x = !logger (Debug "_") x
 let feeder = ref ignore
 let set_feeder f = feeder := f
 
-let feedback_id    = ref (Edit 0)
+let feedback_id    = ref Stateid.initial
 let feedback_route = ref default_route
 
 let set_id_for_feedback ?(route=default_route) i =

--- a/lib/feedback.mli
+++ b/lib/feedback.mli
@@ -18,11 +18,9 @@ type level =
 
 
 (** Coq "semantic" infos obtained during parsing/execution *)
-type edit_id = int
-type state_id = Stateid.t
-type edit_or_state_id = Edit of edit_id | State of state_id
-
+type edit_id  = int
 type route_id = int
+type state_id = Stateid.t
 
 val default_route : route_id
 
@@ -49,7 +47,7 @@ type feedback_content =
   | Message of level * Richpp.richpp
 
 type feedback = {
-  id       : edit_or_state_id;  (* The document part concerned *)
+  id       : state_id;          (* The document part concerned *)
   contents : feedback_content;  (* The payload *)
   route    : route_id;          (* Extra routing info *)
 }
@@ -91,10 +89,10 @@ val set_feeder : (feedback -> unit) -> unit
     [id] set appropiatedly, if absent, it will use the defaults set by
     [set_id_for_feedback] *)
 val feedback :
-  ?id:edit_or_state_id -> ?route:route_id -> feedback_content -> unit
+  ?id:state_id -> ?route:route_id -> feedback_content -> unit
 
 (** [set_id_for_feedback route id] Set the defaults for feedback *)
-val set_id_for_feedback : ?route:route_id -> edit_or_state_id -> unit
+val set_id_for_feedback : ?route:route_id -> state_id -> unit
 
 (** [with_output_to_file file f x] executes [f x] with logging
     redirected to a file [file] *)

--- a/stm/asyncTaskQueue.ml
+++ b/stm/asyncTaskQueue.ml
@@ -105,7 +105,7 @@ module Make(T : Task) = struct
 
   let report_status ?(id = !Flags.async_proofs_worker_id) s =
     let open Feedback in
-    feedback ~id:(State Stateid.initial) (WorkerStatus(id, s))
+    feedback ~id:Stateid.initial (WorkerStatus(id, s))
 
   module Worker = Spawn.Sync(struct end)
 

--- a/stm/stm.mli
+++ b/stm/stm.mli
@@ -183,7 +183,7 @@ val register_proof_block_delimiter :
 
 val state_computed_hook : (Stateid.t -> in_cache:bool -> unit) Hook.t
 val parse_error_hook :
-  (Feedback.edit_or_state_id -> Loc.t -> Pp.std_ppcmds -> unit) Hook.t
+  (Feedback.state_id -> Feedback.edit_id -> Loc.t -> Pp.std_ppcmds -> unit) Hook.t
 val execution_error_hook : (Stateid.t -> Loc.t -> Pp.std_ppcmds -> unit) Hook.t
 val unreachable_state_hook : (Stateid.t -> Exninfo.iexn -> unit) Hook.t
 (* ready means that master has it at hand *)


### PR DESCRIPTION
This is the first of a series of pull requests trying to streamline the
construction of full documents using the Stm by IDE/SerAPI.

Currently, `feedback` carries an `edit_or_state_id`, but the `edit_id`
case is used once (to report parsing errors) and indeed that case is
handled specifically in CoqIDE and PIDEtop by catching the exception.

For IDEs and SerAPI, it makes more sense to always map feedback messages
to already "added" parts of the document, simplifying message handling,
and treat document building failure as a different case.

This patch removes `edit_id` from feedback messages. Tested CoqIDE,
seems unaffected, PIDE should work fine too (but I lack eclipse).

No changes to the protocol format. No more `ErrorMsg` will be generated
on parse error, consumers can still emit a custom error by catching the
exception (as they do now) or by hooking into `Stm.parse_error_hook`
