### PR TITLE
Allow stream parsing from the Stm. [Under revision]

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -38,4 +38,4 @@ B tools/coqdoc
 S dev
 B dev
 
-PKG threads.posix
+PKG threads threads.posix

--- a/dev/doc/changes.txt
+++ b/dev/doc/changes.txt
@@ -62,6 +62,14 @@ FCofix. Similarly, rIota was replaced by rMatch, rFix and rCofix.
 
 Use Glob_ops.glob_constr_eq instead of Notation_ops.eq_glob_constr.
 
+** Stm **
+
+- `Stm.add` and `Stm.query` now take a `Pcoq.Gram.parsable` instead of
+  a `string`, giving more control over the input to the caller.
+
+- `Stm.add` return type is extended to include the location of the end
+  of the parsed sentence.
+
 ** Logging and Pretty Printing: **
 
 * Printing functions have been removed from `Pp.mli`, which is now a


### PR DESCRIPTION
**[NOTE: PR under revision]**

This patch proposes two changes to the `Stm.add` interface in order to help with whole document parsing (such as the one attempted in SerAPI):
- `Stm.add` now takes a `Pcoq.Gram.parsable` instead of a `string`.
- `Stm.add` now returns the location of the end of the parsed sentence.

Both features allow for easier and more accurate document building by repeated calls to `Stm.add`.
