### PR TITLE
Two fixes stm classification

### DIFF
--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -83,7 +83,7 @@ let default_proof_mode () = Proof_global.get_default_proof_mode_name ()
 
 (* Commands piercing opaque *)
 let may_pierce_opaque = function
-  | { expr = VernacPrint (PrintName _) } -> true
+  | { expr = VernacPrint _ } -> true
   | { expr = VernacExtend (("Extraction",_), _) } -> true
   | { expr = VernacExtend (("SeparateExtraction",_), _) } -> true
   | { expr = VernacExtend (("ExtractionLibrary",_), _) } -> true

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -99,7 +99,7 @@ let vernac_interp ?proof id ?route { verbose; loc; expr } =
     | VernacResetName _ | VernacResetInitial | VernacBack _
     | VernacBackTo _ | VernacRestart | VernacUndo _ | VernacUndoTo _
     | VernacBacktrack _ | VernacAbortAll | VernacAbort _ -> true
-    | VernacTime (_,e) | VernacRedirect (_,(_,e)) -> internal_command e
+    | VernacTime (_,e) | VernacTimeout (_,e) | VernacRedirect (_,(_,e)) -> internal_command e
     | _ -> false in
   if internal_command expr then begin
     prerr_endline (fun () -> "ignoring " ^ Pp.string_of_ppcmds(pr_vernac expr))


### PR DESCRIPTION
Two fixes on the classification of commands by the STM (mostly preventive measures), to be reviewed and tested by Enrico.
