### PR TITLE
Add -no-print-dependent-evars

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -57,6 +57,9 @@ Tools
 - coqc accepts a -o option to specify the output file name
 - coqtop accepts --print-version to print Coq and OCaml versions in
   easy to parse format
+- Setting [Printing Dependent Evars Line] can be unset to disable the
+  computation associated with printing the "dependent evars: " line in
+  -emacs mode
 
 Changes from V8.5pl1 to V8.5pl2
 ===============================
@@ -499,8 +502,8 @@ Tactics
 - When given a reference as argument, simpl, vm_compute and
   native_compute now strictly interpret it as the head of a pattern
   starting with this reference.
-- The "change p with c" tactic semantics changed, now type-checking 
-  "c" at each matching occurrence "t" of the pattern "p", and 
+- The "change p with c" tactic semantics changed, now type-checking
+  "c" at each matching occurrence "t" of the pattern "p", and
   converting "t" with "c".
 - Now "appcontext" and "context" behave the same. The old buggy behavior of
   "context" can be retrieved at parse time by setting the

--- a/doc/refman/RefMan-oth.tex
+++ b/doc/refman/RefMan-oth.tex
@@ -947,6 +947,14 @@ time of writing this documentation, the default value is 50).
 \subsection[\tt Test Printing Depth.]{\tt Test Printing Depth.\optindex{Printing Depth}}
 This command displays the current nesting depth used for display.
 
+\subsection[\tt Set Printing Dependent Evars Line.]{\tt Set Printing Dependent Evars Line.\optindex{Printing Dependent Evars Line}}
+This command enables the printing of the ``{\tt (dependent evars: \ldots)}''
+line when {\tt -emacs} is passed.
+
+\subsection[\tt Unset Printing Dependent Evars Line.]{\tt Unset Printing Dependent Evars Line.\optindex{Printing Dependent Evars Line}}
+This command disables the printing of the ``{\tt (dependent evars: \ldots)}''
+line when {\tt -emacs} is passed.
+
 %\subsection{\tt Abstraction ...}
 %Not yet documented.
 


### PR DESCRIPTION
This allows a work-around for bug #4819,
https://coq.inria.fr/bugs/show_bug.cgi?id=4819.  Undocumented, because this is just for smooth interactivity with Coq in PG until the new protocol lands.
