### PR TITLE
Fix a printing typo in LtacProf

### DIFF
--- a/ltac/profile_ltac.ml
+++ b/ltac/profile_ltac.ml
@@ -219,7 +219,8 @@ let rec list_iter_is_last f = function
 let header =
   str " tactic                                    self  total   calls       max" ++
   fnl () ++
-  str "────────────────────────────────────────┴──────┴──────┴───────┴─────────┘"
+  str "────────────────────────────────────────┴──────┴──────┴───────┴─────────┘" ++
+  fnl ()
 
 let rec print_node all_total indent prefix (s, n) =
   let e = n.entry in

--- a/ltac/profile_ltac.ml
+++ b/ltac/profile_ltac.ml
@@ -231,6 +231,7 @@ let rec print_node all_total indent prefix (s, n) =
     ++ padl 8 (string_of_int e.ncalls)
     ++ padl 10 (format_sec (e.max_total))
   ) ++
+  fnl () ++
   print_table all_total indent false n.children
 
 and print_table all_total indent first_level table =


### PR DESCRIPTION
Introduced by b21fefc0ec0aab2560d0b654f1a1f4203898388b, which made the printout look like:

```
total time:      1.052s
 tactic                                    self  total   calls       max
────────────────────────────────────────┴──────┴──────┴───────┴─────────┘─slow ----------------------------------   1.9%
100.0%       1    1.052s
─aaa -----------------------------------  32.3%  98.1%   10000    0.004s
─Coq.Init.Prelude.firstorder_#_#_4B9F515  20.9%  20.9%   10000    0.004s
─Coq.Init.Prelude.congruence_4B9F5155 --  14.1%  14.1%   10000    0.004s
─Coq.Init.Notations.auto_#_#_#_4C69D514   12.9%  12.9%   10000    0.004s
─Coq.Init.Notations.discriminate_4C69D55   7.2%   7.2%   10000    0.004s
─reflexivity ---------------------------   5.7%   5.7%   10000    0.004s
─Coq.Init.Notations.contradiction_#_4C69   4.9%   4.9%   10000    0.004s
 tactic                                    self  total   calls       max
────────────────────────────────────────┴──────┴──────┴───────┴─────────┘─slow ----------------------------------   1.9%
100.0%       1    1.052s
└aaa -----------------------------------  32.3%  98.1%   10000    0.004s ├─Coq.Init.Prelude.firstorder_#_#_4B9F5  20.9%  20.9%
10000    0.004s
 ├─Coq.Init.Prelude.congruence_4B9F5155   14.1%  14.1%   10000    0.004s
 ├─Coq.Init.Notations.auto_#_#_#_4C69D51  12.9%  12.9%   10000    0.004s
 ├─Coq.Init.Notations.discriminate_4C69D   7.2%   7.2%   10000    0.004s
 ├─reflexivity -------------------------   5.7%   5.7%   10000    0.004s
 └─Coq.Init.Notations.contradiction_#_4C   4.9%   4.9%   10000    0.004s
```

when it should look like

```
total time:      0.776s

 tactic                                    self  total   calls       max
────────────────────────────────────────┴──────┴──────┴───────┴─────────┘
─slow ----------------------------------   3.1% 100.0%       1    0.776s
─aaa -----------------------------------  62.4%  96.9%   10000    0.008s
─auto with * ---------------------------  13.9%  13.9%   10000    0.004s
─auto ----------------------------------  13.4%  13.4%   10000    0.008s
─reflexivity ---------------------------   7.2%   7.2%   10000    0.004s

 tactic                                    self  total   calls       max
────────────────────────────────────────┴──────┴──────┴───────┴─────────┘
─slow ----------------------------------   3.1% 100.0%       1    0.776s
└aaa -----------------------------------  62.4%  96.9%   10000    0.008s
 ├─auto with * -------------------------  13.9%  13.9%   10000    0.004s
 ├─auto --------------------------------  13.4%  13.4%   10000    0.008s
 └─reflexivity -------------------------   7.2%   7.2%   10000    0.004s
```
