### PR TITLE
Make `ErrorMsg` carry a richpp.

### DIFF
--- a/dev/doc/changes.txt
+++ b/dev/doc/changes.txt
@@ -41,6 +41,13 @@ val emacs_logger    : logger
 val feedback_logger : logger
 ````
 
+* Changes in the feedback type:
+
+  - `Feedback.MsgError` now carries a richpp document instead of a
+    string.
+
+  - `Feedback.level = Debug` has lost its unused argument.
+
 * We now provide several loggers, `log_via_feedback` is removed in
   favor of `set_logger feedback_logger`. Output functions are:
 

--- a/ide/coqOps.ml
+++ b/ide/coqOps.ml
@@ -463,9 +463,9 @@ object(self)
       | ErrorMsg(loc, msg), Some (id,sentence) ->
           log "ErrorMsg" id;
           remove_flag sentence `PROCESSING;
-          add_flag sentence (`ERROR (loc, msg));
+          add_flag sentence (`ERROR (loc, Richpp.raw_print msg));
           self#mark_as_needed sentence;
-          self#attach_tooltip sentence loc msg;
+          self#attach_tooltip sentence loc (Richpp.raw_print msg);
           if not (Loc.is_ghost loc) then
             self#position_error_tag_at_sentence sentence (Some (Loc.unloc loc))
       | InProgress n, _ ->

--- a/ide/xmlprotocol.ml
+++ b/ide/xmlprotocol.ml
@@ -769,15 +769,15 @@ let document to_string_fmt =
 open Feedback
 
 let of_message_level = function
-  | Debug s ->
-      Serialize.constructor "message_level" "debug" [Xml_datatype.PCData s]
+  | Debug ->
+      Serialize.constructor "message_level" "debug" []
   | Info -> Serialize.constructor "message_level" "info" []
   | Notice -> Serialize.constructor "message_level" "notice" []
   | Warning -> Serialize.constructor "message_level" "warning" []
   | Error -> Serialize.constructor "message_level" "error" []
 let to_message_level =
   Serialize.do_match "message_level" (fun s args -> match s with
-  | "debug" -> Debug (Serialize.raw_string args)
+  | "debug" -> Debug
   | "info" -> Info
   | "notice" -> Notice
   | "warning" -> Warning

--- a/ide/xmlprotocol.ml
+++ b/ide/xmlprotocol.ml
@@ -809,7 +809,7 @@ let to_feedback_content = do_match "feedback_content" (fun s a -> match s,a with
          to_string modpath, to_string ident, to_string ty)
   | "globdef", [loc; ident; secpath; ty] ->
        GlobDef(to_loc loc, to_string ident, to_string secpath, to_string ty)
-  | "errormsg", [loc;  s] -> ErrorMsg (to_loc loc, to_string s)
+  | "errormsg", [loc;  s] -> ErrorMsg (to_loc loc, to_richpp s)
   | "inprogress", [n] -> InProgress (to_int n)
   | "workerstatus", [ns] ->
        let n, s = to_pair to_string to_string ns in
@@ -844,7 +844,7 @@ let of_feedback_content = function
         of_string secpath;
         of_string ty ]
   | ErrorMsg(loc, s) ->
-      constructor "feedback_content" "errormsg" [of_loc loc; of_string s]
+      constructor "feedback_content" "errormsg" [of_loc loc; of_richpp s]
   | InProgress n -> constructor "feedback_content" "inprogress" [of_int n]
   | WorkerStatus(n,s) ->
       constructor "feedback_content" "workerstatus"

--- a/lib/feedback.ml
+++ b/lib/feedback.ml
@@ -9,7 +9,7 @@
 open Xml_datatype
 
 type level =
-  | Debug of string
+  | Debug
   | Info
   | Notice
   | Warning
@@ -85,7 +85,7 @@ let make_body quoter info s = quoter (hov 0 (info ++ s))
 
 (* Generic logger *)
 let gen_logger dbg err level msg = match level with
-  | Debug _ -> msgnl (make_body dbg  dbg_str msg)
+  | Debug   -> msgnl (make_body dbg  dbg_str msg)
   | Info    -> msgnl (make_body dbg info_str msg)
   | Notice  -> msgnl msg
   | Warning -> Flags.if_warn (fun () ->
@@ -99,7 +99,7 @@ let std_logger   = gen_logger (fun x -> x) (fun x -> x)
 let color_terminal_logger level strm =
   let msg = Ppstyle.color_msg in
   match level with
-  | Debug _ -> msg ~header:("Debug", Ppstyle.debug_tag) !std_ft strm
+  | Debug   -> msg ~header:("Debug", Ppstyle.debug_tag) !std_ft strm
   | Info    -> msg !std_ft strm
   | Notice  -> msg !std_ft strm
   | Warning ->
@@ -121,7 +121,7 @@ let msg_info    x = !logger Info x
 let msg_notice  x = !logger Notice x
 let msg_warning x = !logger Warning x
 let msg_error   x = !logger Error x
-let msg_debug   x = !logger (Debug "_") x
+let msg_debug   x = !logger Debug x
 
 (** Feeders *)
 let feeder = ref ignore
@@ -148,7 +148,7 @@ let feedback_logger lvl msg =
 let ft_logger old_logger ft level mesg =
   let id x = x in
   match level with
-  | Debug _ -> msgnl_with ft (make_body id  dbg_str mesg)
+  | Debug   -> msgnl_with ft (make_body id  dbg_str mesg)
   | Info    -> msgnl_with ft (make_body id info_str mesg)
   | Notice  -> msgnl_with ft mesg
   | Warning -> old_logger level mesg

--- a/lib/feedback.ml
+++ b/lib/feedback.ml
@@ -24,7 +24,7 @@ type feedback_content =
   | Processed
   | Incomplete
   | Complete
-  | ErrorMsg of Loc.t * string
+  | ErrorMsg of Loc.t * Richpp.richpp
   | ProcessingIn of string
   | InProgress of int
   | WorkerStatus of string * string

--- a/lib/feedback.mli
+++ b/lib/feedback.mli
@@ -10,7 +10,7 @@ open Xml_datatype
 
 (* Old plain messages (used to be in Pp) *)
 type level =
-  | Debug of string
+  | Debug
   | Info
   | Notice
   | Warning

--- a/lib/feedback.mli
+++ b/lib/feedback.mli
@@ -31,7 +31,7 @@ type feedback_content =
   | Processed
   | Incomplete
   | Complete
-  | ErrorMsg of Loc.t * string
+  | ErrorMsg of Loc.t * Richpp.richpp
   (* STM optional data *)
   | ProcessingIn of string
   | InProgress of int

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -11,6 +11,9 @@ let pr_err s = Printf.eprintf "%s] %s\n" (System.process_id ()) s; flush stderr
 let prerr_endline s = if false then begin pr_err (s ()) end else ()
 let prerr_debug s = if !Flags.debug then begin pr_err (s ()) end else ()
 
+(* XXX: Ppvernac alias of Richpp!! See PR#185 *)
+let to_richpp = Richpp.richpp_of_pp
+
 open Vernacexpr
 open Errors
 open Pp
@@ -40,11 +43,11 @@ let forward_feedback, forward_feedback_hook = Hook.make
 
 let parse_error, parse_error_hook = Hook.make
  ~default:(fun id loc msg ->
-        feedback ~id (ErrorMsg (loc, Pp.string_of_ppcmds msg))) ()
+        feedback ~id (ErrorMsg (loc, to_richpp msg))) ()
 
 let execution_error, execution_error_hook = Hook.make
  ~default:(fun state_id loc msg ->
-    feedback ~id:(State state_id) (ErrorMsg (loc, Pp.string_of_ppcmds msg))) ()
+    feedback ~id:(State state_id) (ErrorMsg (loc, to_richpp msg))) ()
 
 let unreachable_state, unreachable_state_hook = Hook.make
  ~default:(fun _ _ -> ()) ()
@@ -1842,7 +1845,7 @@ end = struct (* {{{ *)
       feedback ~id:(State r_for) Processed
     with e when Errors.noncritical e ->
       let e = Errors.push e in
-      let msg = string_of_ppcmds (iprint e) in
+      let msg = to_richpp (iprint e) in
       feedback ~id:(State r_for) (ErrorMsg (Loc.ghost, msg))
     
   let name_of_task { t_what } = string_of_ppcmds (pr_ast t_what)


### PR DESCRIPTION
This was requested by IDE people, so they can better tag terms in error
messages.

However, it is my opinion that we should really get rid of ErrorMsg
altogether and extend the Message type.

(Or move ErrorMsg to a general purpose, ExtMessage type).

I also clean up an unused `Debug` tag. I can see the intended use case but IMHO it should be done otherwise.
