### PR TITLE
Patterns-in-binder syntax tests

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,12 @@
 Changes beyond V8.5
 ===================
 
+Specification language
+
+- Ability to put any pattern in binders, prefixed by quote, e.g.
+  "fun '(a,b) => ...", "λ '(a,(b,c)), ...", "Definition foo '(x,y) := ...".
+  It expands into a "let 'pattern := ..."
+
 Tactics
 
 - Flag "Bracketing Last Introduction Pattern" is now on by default.

--- a/doc/refman/RefMan-gal.tex
+++ b/doc/refman/RefMan-gal.tex
@@ -273,6 +273,7 @@ called \CIC). The formal presentation of {\CIC} is given in Chapter
 {\binder} & ::= &   {\name} & (\ref{Binders}) \\
  & $|$ & {\tt (} \nelist{\name}{} {\tt :} {\term} {\tt )} &\\  
  & $|$ & {\tt (} {\name} {\typecstr} {\tt :=} {\term} {\tt )} &\\
+ & $|$ & {\tt '} {\pattern} &\\
 & & &\\
 {\name} & ::= & {\ident} &\\
  & $|$ & {\tt \_} &\\
@@ -410,7 +411,8 @@ bound variable cannot be synthesized by the system, it can be
 specified with the notation {\tt (}\,{\ident}\,{\tt :}\,{\type}\,{\tt
 )}. There is also a notation for a sequence of binding variables
 sharing the same type: {\tt (}\,{\ident$_1$}\ldots{\ident$_n$}\,{\tt
-:}\,{\type}\,{\tt )}.
+:}\,{\type}\,{\tt )}. A binder can also be any pattern prefixed by a quote,
+e.g. {\tt '(x,y)}.
 
 Some constructions allow the binding of a variable to value. This is
 called a ``let-binder''. The entry {\binder} of the grammar accepts

--- a/interp/constrexpr_ops.ml
+++ b/interp/constrexpr_ops.ml
@@ -272,7 +272,7 @@ let local_binder_loc = function
   | LocalRawAssum ((loc,_)::_,_,t)
   | LocalRawDef ((loc,_),t) -> Loc.merge loc (constr_loc t)
   | LocalRawAssum ([],_,_) -> assert false
-  | LocalPattern (loc,p,ty) -> loc
+  | LocalPattern (loc,_,_) -> loc
 
 let local_binders_loc bll = match bll with
   | [] -> Loc.ghost

--- a/interp/constrexpr_ops.ml
+++ b/interp/constrexpr_ops.ml
@@ -299,7 +299,7 @@ let add_name_in_env env n =
   | Anonymous -> env
   | Name id -> id :: env
 
-let fresh_var_fwd = ref (fun _ _ -> failwith "fresh_var")
+let (fresh_var, fresh_var_hook) = Hook.make ~default:(fun _ _ -> assert false) ()
 
 let expand_pattern_binders mkC bl c =
   let rec loop bl c =
@@ -315,7 +315,7 @@ let expand_pattern_binders mkC bl c =
             let env = List.fold_left add_name_in_env env nl in
             (env, b :: bl, c)
         | LocalPattern (loc, p, ty) ->
-            let ni = !fresh_var_fwd env c in
+            let ni = Hook.get fresh_var env c in
             let id = (loc, Name ni) in
             let b =
               LocalRawAssum

--- a/interp/constrexpr_ops.mli
+++ b/interp/constrexpr_ops.mli
@@ -58,7 +58,7 @@ val mkCLambdaN : Loc.t -> local_binder list -> constr_expr -> constr_expr
 val mkCProdN : Loc.t -> local_binder list -> constr_expr -> constr_expr
 (** Same as [prod_constr_expr], with location *)
 
-val fresh_var_fwd : (Names.Id.t list -> Constrexpr.constr_expr -> Names.Id.t) ref
+val fresh_var_hook : (Names.Id.t list -> Constrexpr.constr_expr -> Names.Id.t) Hook.t
 val expand_pattern_binders :
   (Loc.t -> local_binder list -> constr_expr -> constr_expr) ->
   local_binder list -> constr_expr -> local_binder list * constr_expr

--- a/interp/constrexpr_ops.mli
+++ b/interp/constrexpr_ops.mli
@@ -58,6 +58,11 @@ val mkCLambdaN : Loc.t -> local_binder list -> constr_expr -> constr_expr
 val mkCProdN : Loc.t -> local_binder list -> constr_expr -> constr_expr
 (** Same as [prod_constr_expr], with location *)
 
+val fresh_var_fwd : (Names.Id.t list -> Constrexpr.constr_expr -> Names.Id.t) ref
+val expand_pattern_binders :
+  (Loc.t -> local_binder list -> constr_expr -> constr_expr) ->
+  local_binder list -> constr_expr -> local_binder list * constr_expr
+
 (** {6 Destructors}*)
 
 val coerce_reference_to_id : reference -> Id.t

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -758,6 +758,7 @@ let rec extern inctx scopes vars r =
 	     let listdecl =
 	       Array.mapi (fun i fi ->
                  let (bl,ty,def) = blv.(i), tyv.(i), bv.(i) in
+                 let bl = List.map (fun (p,bk,x,t) -> (Inl p,bk,x,t)) bl in
                  let (assums,ids,bl) = extern_local_binder scopes vars bl in
                  let vars0 = List.fold_right (name_fold Id.Set.add) ids vars in
                  let vars1 = List.fold_right (name_fold Id.Set.add) ids vars' in
@@ -774,7 +775,8 @@ let rec extern inctx scopes vars r =
 	 | GCoFix n ->
 	     let listdecl =
                Array.mapi (fun i fi ->
-                 let (_,ids,bl) = extern_local_binder scopes vars blv.(i) in
+                 let bl = List.map (fun (p,bk,x,t) -> (Inl p,bk,x,t)) blv.(i) in
+                 let (_,ids,bl) = extern_local_binder scopes vars bl in
                  let vars0 = List.fold_right (name_fold Id.Set.add) ids vars in
                  let vars1 = List.fold_right (name_fold Id.Set.add) ids vars' in
 		 ((Loc.ghost, fi),bl,extern_typ scopes vars0 tyv.(i),
@@ -817,13 +819,13 @@ and factorize_lambda inctx scopes vars na bk aty c =
 
 and extern_local_binder scopes vars = function
     [] -> ([],[],[])
-  | (na,bk,Some bd,ty)::l ->
+  | (Inl na,bk,Some bd,ty)::l ->
       let (assums,ids,l) =
         extern_local_binder scopes (name_fold Id.Set.add na vars) l in
       (assums,na::ids,
        LocalRawDef((Loc.ghost,na), extern false scopes vars bd) :: l)
 
-  | (na,bk,None,ty)::l ->
+  | (Inl na,bk,None,ty)::l ->
       let ty = extern_typ scopes vars ty in
       (match extern_local_binder scopes (name_fold Id.Set.add na vars) l with
           (assums,ids,LocalRawAssum(nal,k,ty')::l)
@@ -835,6 +837,14 @@ and extern_local_binder scopes vars = function
         | (assums,ids,l) ->
             (na::assums,na::ids,
              LocalRawAssum([(Loc.ghost,na)],Default bk,ty) :: l))
+
+  | (Inr p,bk,Some bd,ty)::l -> assert false
+
+  | (Inr p,bk,None,ty)::l ->
+      let ty = extern_typ scopes vars ty in
+      let p = extern_cases_pattern vars p in
+      let (assums,ids,l) = extern_local_binder scopes vars l in
+      (assums,ids, LocalPattern(Loc.ghost,p,Some ty) :: l)
 
 and extern_eqn inctx scopes vars (loc,ids,pl,c) =
   (loc,[loc,List.map (extern_cases_pattern_in_scope scopes vars) pl],
@@ -1042,4 +1052,5 @@ let extern_constr_pattern env sigma pat =
 let extern_rel_context where env sigma sign =
   let a = detype_rel_context where [] (names_of_rel_context env,env) sigma sign in
   let vars = vars_of_env env in
+  let a = List.map (fun (p,bk,x,t) -> (Inl p,bk,x,t)) a in
   pi3 (extern_local_binder (None,[]) vars a)

--- a/interp/implicit_quantifiers.ml
+++ b/interp/implicit_quantifiers.ml
@@ -111,6 +111,7 @@ let free_vars_of_binders ?(bound=Id.Set.empty) l (binders : local_binder list) =
 	let l' = free_vars_of_constr_expr c ~bound:bdvars l in
 	  aux (Id.Set.union (ids_of_list bound) bdvars) l' tl
 
+    | LocalPattern _ :: tl -> assert false
     | [] -> bdvars, l
   in aux bound l binders
 

--- a/interp/notation_ops.ml
+++ b/interp/notation_ops.ml
@@ -637,12 +637,12 @@ let glue_letin_with_decls = true
 
 let rec match_iterated_binders islambda decls = function
   | GLambda (_,na,bk,t,b) when islambda ->
-      match_iterated_binders islambda ((na,bk,None,t)::decls) b
+      match_iterated_binders islambda ((Inl na,bk,None,t)::decls) b
   | GProd (_,(Name _ as na),bk,t,b) when not islambda ->
-      match_iterated_binders islambda ((na,bk,None,t)::decls) b
+      match_iterated_binders islambda ((Inl na,bk,None,t)::decls) b
   | GLetIn (loc,na,c,b) when glue_letin_with_decls ->
       match_iterated_binders islambda
-	((na,Explicit (*?*), Some c,GHole(loc,Evar_kinds.BinderType na,Misctypes.IntroAnonymous,None))::decls) b
+	((Inl na,Explicit (*?*), Some c,GHole(loc,Evar_kinds.BinderType na,Misctypes.IntroAnonymous,None))::decls) b
   | b -> (decls,b)
 
 let remove_sigma x (sigmavar,sigmalist,sigmabinders) =
@@ -698,14 +698,27 @@ let rec match_ inner u alp (tmetas,blmetas as metas) sigma a1 a2 =
   | r1, NList (x,_,iter,termin,lassoc) ->
       match_alist (match_hd u alp) metas sigma r1 x iter termin lassoc
 
+  (* "λ p, let 'cp = p in t" -> "λ 'cp, t" *)
+  | GLambda (_,Name p,bk,t1,GCases (_,LetPatternStyle,None,[(GVar(_,e),_)],[(_,_,[cp],t)])),
+    NBinderList (x,_,NLambda (Name id2,_,b2),(NVar v as termin)) when p = e ->
+      let decls = [(Inr cp,bk,None,t1)] in
+      match_in u alp metas (bind_binder sigma x decls) t termin
+
   (* Matching recursive notations for binders: ad hoc cases supporting let-in *)
   | GLambda (_,na1,bk,t1,b1), NBinderList (x,_,NLambda (Name id2,_,b2),termin)->
-      let (decls,b) = match_iterated_binders true [(na1,bk,None,t1)] b1 in
+      let (decls,b) = match_iterated_binders true [(Inl na1,bk,None,t1)] b1 in
       (* TODO: address the possibility that termin is a Lambda itself *)
       match_in u alp metas (bind_binder sigma x decls) b termin
+
+  (* "∀ p, let 'cp = p in t" -> "∀ 'cp, t" *)
+  | GProd (_,Name p,bk,t1,GCases (_,LetPatternStyle,None,[(GVar(_,e),_)],[(_,_,[cp],t)])),
+    NBinderList (x,_,NProd (Name id2,_,b2),(NVar v as termin)) when p = e ->
+      let decls = [(Inr cp,bk,None,t1)] in
+      match_in u alp metas (bind_binder sigma x decls) t termin
+
   | GProd (_,na1,bk,t1,b1), NBinderList (x,_,NProd (Name id2,_,b2),termin)
       when na1 != Anonymous ->
-      let (decls,b) = match_iterated_binders false [(na1,bk,None,t1)] b1 in
+      let (decls,b) = match_iterated_binders false [(Inl na1,bk,None,t1)] b1 in
       (* TODO: address the possibility that termin is a Prod itself *)
       match_in u alp metas (bind_binder sigma x decls) b termin
   (* Matching recursive notations for binders: general case *)
@@ -714,10 +727,10 @@ let rec match_ inner u alp (tmetas,blmetas as metas) sigma a1 a2 =
 
   (* Matching individual binders as part of a recursive pattern *)
   | GLambda (_,na,bk,t,b1), NLambda (Name id,_,b2) when Id.List.mem id blmetas ->
-      match_in u alp metas (bind_binder sigma id [(na,bk,None,t)]) b1 b2
+      match_in u alp metas (bind_binder sigma id [(Inl na,bk,None,t)]) b1 b2
   | GProd (_,na,bk,t,b1), NProd (Name id,_,b2)
       when Id.List.mem id blmetas && na != Anonymous ->
-      match_in u alp metas (bind_binder sigma id [(na,bk,None,t)]) b1 b2
+      match_in u alp metas (bind_binder sigma id [(Inl na,bk,None,t)]) b1 b2
 
   (* Matching compositionally *)
   | GVar (_,id1), NVar id2 when alpha_var id1 id2 alp -> sigma
@@ -801,7 +814,7 @@ let rec match_ inner u alp (tmetas,blmetas as metas) sigma a1 a2 =
       | NHole _ -> sigma
       | NVar id2 -> bind_env alp sigma id2 t1
       | _ -> assert false in
-      match_in u alp metas (bind_binder sigma id [(Name id',Explicit,None,t1)])
+      match_in u alp metas (bind_binder sigma id [(Inl (Name id'),Explicit,None,t1)])
        (mkGApp Loc.ghost b1 (GVar (Loc.ghost,id'))) b2
 
   | (GRec _ | GEvar _), _
@@ -822,6 +835,10 @@ and match_equations u alp metas sigma (_,_,patl1,rhs1) (patl2,rhs2) =
     List.fold_left2 (match_cases_pattern_binders metas)
       (alp,sigma) patl1 patl2 in
   match_in u alp metas sigma rhs1 rhs2
+
+type glob_decl2 =
+    (name, cases_pattern) Util.union * Decl_kinds.binding_kind *
+      glob_constr option * glob_constr
 
 let match_notation_constr u c (metas,pat) =
   let test (_, (_, x)) = match x with NtnTypeBinderList -> false | _ -> true in

--- a/interp/notation_ops.mli
+++ b/interp/notation_ops.mli
@@ -41,9 +41,12 @@ val glob_constr_of_notation_constr : Loc.t -> notation_constr -> glob_constr
 
 exception No_match
 
+type glob_decl2 =
+    (name, cases_pattern) Util.union * Decl_kinds.binding_kind *
+      glob_constr option * glob_constr
 val match_notation_constr : bool -> glob_constr -> interpretation ->
       (glob_constr * subscopes) list * (glob_constr list * subscopes) list *
-      (glob_decl list * subscopes) list
+      (glob_decl2 list * subscopes) list
 
 val match_notation_constr_cases_pattern :
   cases_pattern -> interpretation ->

--- a/interp/topconstr.ml
+++ b/interp/topconstr.ml
@@ -59,6 +59,7 @@ let rec cases_pattern_fold_names f a = function
   | CPatDelimiters (_,_,pat) -> cases_pattern_fold_names f a pat
   | CPatAtom (_,Some (Ident (_,id))) when not (is_constructor id) -> f id a
   | CPatPrim _ | CPatAtom _ -> a
+  | CPatCast _ -> assert false
 
 let ids_of_pattern_list =
   List.fold_left
@@ -92,6 +93,8 @@ let rec fold_local_binders g f n acc b = function
       f n (fold_local_binders g f n' acc b l) t
   | LocalRawDef ((_,na),t)::l ->
       f n (fold_local_binders g f (name_fold g na n) acc b l) t
+  | LocalPattern _::l ->
+      assert false
   | [] ->
       f n acc b
 
@@ -170,6 +173,7 @@ let split_at_annot bl na =
               (List.rev ans, LocalRawAssum (r, k, t) :: rest)
             end
 	| LocalRawDef _ as x :: rest -> aux (x :: acc) rest
+        | LocalPattern _ :: rest -> assert false
 	| [] ->
             user_err_loc(loc,"",
 			 str "No parameter named " ++ Nameops.pr_id id ++ str".")
@@ -191,7 +195,9 @@ let map_local_binders f g e bl =
       LocalRawAssum(nal,k,ty) ->
         (map_binder g e nal, LocalRawAssum(nal,k,f e ty)::bl)
     | LocalRawDef((loc,na),ty) ->
-        (name_fold g na e, LocalRawDef((loc,na),f e ty)::bl) in
+        (name_fold g na e, LocalRawDef((loc,na),f e ty)::bl)
+    | LocalPattern _ ->
+        assert false in
   let (e,rbl) = List.fold_left h (e,[]) bl in
   (e, List.rev rbl)
 

--- a/intf/constrexpr.mli
+++ b/intf/constrexpr.mli
@@ -44,6 +44,8 @@ type raw_cases_pattern_expr =
   | RCPatAtom of Loc.t * Id.t option
   | RCPatOr of Loc.t * raw_cases_pattern_expr list
 
+type instance_expr = Misctypes.glob_level list
+
 type cases_pattern_expr =
   | CPatAlias of Loc.t * cases_pattern_expr * Id.t
   | CPatCstr of Loc.t * reference
@@ -58,14 +60,13 @@ type cases_pattern_expr =
   | CPatPrim of Loc.t * prim_token
   | CPatRecord of Loc.t * (reference * cases_pattern_expr) list
   | CPatDelimiters of Loc.t * string * cases_pattern_expr
+  | CPatCast of Loc.t * cases_pattern_expr * constr_expr
 
 and cases_pattern_notation_substitution =
     cases_pattern_expr list *     (** for constr subterms *)
     cases_pattern_expr list list  (** for recursive notations *)
 
-type instance_expr = Misctypes.glob_level list
-
-type constr_expr =
+and constr_expr =
   | CRef of reference * instance_expr option
   | CFix of Loc.t * Id.t located * fix_expr list
   | CCoFix of Loc.t * Id.t located * cofix_expr list
@@ -124,6 +125,7 @@ and recursion_order_expr =
 and local_binder =
   | LocalRawDef of Name.t located * constr_expr
   | LocalRawAssum of Name.t located list * binder_kind * constr_expr
+  | LocalPattern of Loc.t * cases_pattern_expr * constr_expr option
 
 and constr_notation_substitution =
     constr_expr list *      (** for constr subterms *)

--- a/parsing/g_constr.ml4
+++ b/parsing/g_constr.ml4
@@ -401,6 +401,14 @@ GEXTEND Gram
               CPatPrim (_,Numeral z) when Bigint.is_pos_or_zero z ->
                 CPatNotation(!@loc,"( _ )",([p],[]),[])
             | _ -> p)
+      | "("; p = pattern LEVEL "200"; ":"; ty = lconstr; ")" ->
+          let p =
+            match p with
+              CPatPrim (_,Numeral z) when Bigint.is_pos_or_zero z ->
+                CPatNotation(!@loc,"( _ )",([p],[]),[])
+            | _ -> p
+          in
+	  CPatCast (!@loc, p, ty)
       | n = INT -> CPatPrim (!@loc, Numeral (Bigint.of_string n))
       | s = string -> CPatPrim (!@loc, String s) ] ]
   ;
@@ -476,6 +484,13 @@ GEXTEND Gram
 	  List.map (fun (n, b, t) -> LocalRawAssum ([n], Generalized (Implicit, Explicit, b), t)) tc
       | "`{"; tc = LIST1 typeclass_constraint SEP "," ; "}" ->
 	  List.map (fun (n, b, t) -> LocalRawAssum ([n], Generalized (Implicit, Implicit, b), t)) tc
+      | "'"; p = pattern LEVEL "0" ->
+          let (p, ty) =
+            match p with
+            | CPatCast (_, p, ty) -> (p, Some ty)
+            | _ -> (p, None)
+          in
+          [LocalPattern (!@loc, p, ty)]
     ] ]
   ;
   typeclass_constraint:

--- a/parsing/g_vernac.ml4
+++ b/parsing/g_vernac.ml4
@@ -297,8 +297,14 @@ GEXTEND Gram
           CCast(_,c, CastConv t) -> DefineBody (bl, red, c, Some t)
         | _ -> DefineBody (bl, red, c, None))
     | bl = binders; ":"; t = lconstr; ":="; red = reduce; c = lconstr ->
-        let (bl, c) = expand_pattern_binders mkCLambdaN bl c in
-	DefineBody (bl, red, c, Some t)
+        let ((bl, c), tyo) =
+          if List.exists (function LocalPattern _ -> true | _ -> false) bl
+          then
+            let c = CCast (!@loc, c, CastConv t) in
+            (expand_pattern_binders mkCLambdaN bl c, None)
+          else ((bl, c), Some t)
+        in
+	DefineBody (bl, red, c, tyo)
     | bl = binders; ":"; t = lconstr ->
         ProveBody (bl, t) ] ]
   ;

--- a/parsing/g_vernac.ml4
+++ b/parsing/g_vernac.ml4
@@ -189,7 +189,8 @@ let test_plural_form_types = function
 let fresh_var env c =
   Namegen.next_ident_away (Id.of_string "pat")
     (env @ Id.Set.elements (Topconstr.free_vars_of_constr_expr c))
-let _ = Constrexpr_ops.fresh_var_fwd := fresh_var
+
+let _ = Hook.set Constrexpr_ops.fresh_var_hook fresh_var
 
 (* Gallina declarations *)
 GEXTEND Gram

--- a/parsing/g_vernac.ml4
+++ b/parsing/g_vernac.ml4
@@ -296,6 +296,7 @@ GEXTEND Gram
           CCast(_,c, CastConv t) -> DefineBody (bl, red, c, Some t)
         | _ -> DefineBody (bl, red, c, None))
     | bl = binders; ":"; t = lconstr; ":="; red = reduce; c = lconstr ->
+        let (bl, c) = expand_pattern_binders mkCLambdaN bl c in
 	DefineBody (bl, red, c, Some t)
     | bl = binders; ":"; t = lconstr ->
         ProveBody (bl, t) ] ]

--- a/parsing/g_vernac.ml4
+++ b/parsing/g_vernac.ml4
@@ -186,6 +186,11 @@ let test_plural_form_types = function
    (strbrk "Keywords Implicit Types expect more than one type")
   | _ -> ()
 
+let fresh_var env c =
+  Namegen.next_ident_away (Id.of_string "pat")
+    (env @ Id.Set.elements (Topconstr.free_vars_of_constr_expr c))
+let _ = Constrexpr_ops.fresh_var_fwd := fresh_var
+
 (* Gallina declarations *)
 GEXTEND Gram
   GLOBAL: gallina gallina_ext thm_token def_body of_type_with_opt_coercion
@@ -286,6 +291,7 @@ GEXTEND Gram
   (* Simple definitions *)
   def_body:
     [ [ bl = binders; ":="; red = reduce; c = lconstr ->
+      let (bl, c) = expand_pattern_binders mkCLambdaN bl c in
       (match c with
           CCast(_,c, CastConv t) -> DefineBody (bl, red, c, Some t)
         | _ -> DefineBody (bl, red, c, None))

--- a/plugins/funind/indfun.ml
+++ b/plugins/funind/indfun.ml
@@ -131,6 +131,7 @@ let rec abstract_glob_constr c = function
   | Constrexpr.LocalRawAssum (idl,k,t)::bl ->
       List.fold_right (fun x b -> Constrexpr_ops.mkLambdaC([x],k,t,b)) idl
         (abstract_glob_constr c bl)
+  | Constrexpr.LocalPattern _::bl -> assert false
 
 let interp_casted_constr_with_implicits env sigma impls c  =
   Constrintern.intern_gen Pretyping.WithoutTypeConstraint env ~impls
@@ -213,6 +214,7 @@ let rec local_binders_length = function
   | [] -> 0
   | Constrexpr.LocalRawDef _::bl -> 1 + local_binders_length bl
   | Constrexpr.LocalRawAssum (idl,_,_)::bl -> List.length idl + local_binders_length bl
+  | Constrexpr.LocalPattern _::bl -> assert false
 
 let prepare_body ((name,_,args,types,_),_) rt =
   let n = local_binders_length args in
@@ -859,6 +861,7 @@ let make_graph (f_ref:global_reference) =
 					(fun (loc,n) ->
 					   CRef(Libnames.Ident(loc, Nameops.out_name n),None))
 					nal
+                                  | Constrexpr.LocalPattern _ -> assert false
 			       )
 			       nal_tas
 			    )

--- a/printing/ppconstr.ml
+++ b/printing/ppconstr.ml
@@ -300,6 +300,7 @@ end) = struct
   let begin_of_binder = function
   LocalRawDef((loc,_),_) -> fst (Loc.unloc loc)
     | LocalRawAssum((loc,_)::_,_,_) -> fst (Loc.unloc loc)
+    | LocalPattern(loc,_,_) -> fst (Loc.unloc loc)
     | _ -> assert false
 
   let begin_of_binders = function
@@ -361,6 +362,8 @@ end) = struct
         pr_com_at n ++ kw() ++ pr_binder false pr_c (nal,k,t)
       | LocalRawAssum _ :: _ as bdl ->
         pr_com_at n ++ kw() ++ pr_undelimited_binders sep pr_c bdl
+      | LocalPattern (loc,p,tyo) :: _ ->
+        str "'" ++ pr_patt ltop p
       | _ -> assert false
 
   let pr_binders_gen pr_c sep is_open =

--- a/printing/ppconstr.ml
+++ b/printing/ppconstr.ml
@@ -279,6 +279,8 @@ end) = struct
 
       | CPatDelimiters (_,k,p) ->
         pr_delimiters k (pr_patt mt lsimplepatt p), 1
+      | CPatCast _ ->
+        assert false
     in
     let loc = cases_pattern_expr_loc p in
     pr_with_comments loc
@@ -346,6 +348,8 @@ end) = struct
         | _ -> c, CHole (Loc.ghost, None, Misctypes.IntroAnonymous, None) in
       surround (pr_lname na ++ pr_opt_type pr_c topt ++
                   str":=" ++ cut() ++ pr_c c)
+    | LocalPattern _ ->
+      assert false
 
   let pr_undelimited_binders sep pr_c =
     prlist_with_sep sep (pr_binder_among_many pr_c)
@@ -430,6 +434,7 @@ end) = struct
             let names_of_binder = function
               | LocalRawAssum (nal,_,_) -> nal
               | LocalRawDef (_,_) -> []
+              | LocalPattern _ -> assert false
             in let ids = List.flatten (List.map names_of_binder bl) in
                if List.length ids > 1 then
                  spc() ++ str "{" ++ keyword "struct" ++ spc () ++ pr_id id ++ str"}"

--- a/printing/ppconstr.ml
+++ b/printing/ppconstr.ml
@@ -539,6 +539,21 @@ end) = struct
               str "," ++ pr spc ltop a),
           lprod
         )
+      | CLambdaN
+          (_,
+           [([(_,Name n)],_,_)],
+           CCases
+             (_,LetPatternStyle,None,[(CRef(Ident(_,m),None),None,None)],
+              [(_,[(_,[p])],e)]))
+          when
+            Id.equal m n &&
+            not (Id.Set.mem n (Topconstr.free_vars_of_constr_expr e)) ->
+        return (
+          hov 0 (
+            keyword "fun" ++ spc () ++ str "'" ++ pr_patt ltop p ++ spc () ++
+            str "=>" ++ pr spc ltop e),
+          llambda
+        )
       | CLambdaN _ ->
         let (bl,a) = extract_lam_binders a in
         return (

--- a/printing/ppconstr.ml
+++ b/printing/ppconstr.ml
@@ -530,6 +530,21 @@ end) = struct
                    (pr_cofixdecl (pr mt) (pr_dangling_with_for mt pr)) (snd id) cofix),
           lfix
         )
+      | CProdN
+          (_,
+           [([(_,Name n)],_,_)],
+           CCases
+             (_,LetPatternStyle,None,[(CRef(Ident(_,m),None),None,None)],
+              [(_,[(_,[p])],a)]))
+          when
+            Id.equal m n &&
+            not (Id.Set.mem n (Topconstr.free_vars_of_constr_expr a)) ->
+        return (
+          hov 0 (
+            keyword "forall" ++ spc () ++ str "'" ++ pr_patt ltop p ++
+            str "," ++ pr spc ltop a),
+          llambda
+        )
       | CProdN _ ->
         let (bl,a) = extract_prod_binders a in
         return (
@@ -544,14 +559,14 @@ end) = struct
            [([(_,Name n)],_,_)],
            CCases
              (_,LetPatternStyle,None,[(CRef(Ident(_,m),None),None,None)],
-              [(_,[(_,[p])],e)]))
+              [(_,[(_,[p])],a)]))
           when
             Id.equal m n &&
-            not (Id.Set.mem n (Topconstr.free_vars_of_constr_expr e)) ->
+            not (Id.Set.mem n (Topconstr.free_vars_of_constr_expr a)) ->
         return (
           hov 0 (
-            keyword "fun" ++ spc () ++ str "'" ++ pr_patt ltop p ++ spc () ++
-            str "=>" ++ pr spc ltop e),
+            keyword "fun" ++ spc () ++ str "'" ++ pr_patt ltop p ++
+            pr_fun_sep ++ pr spc ltop a),
           llambda
         )
       | CLambdaN _ ->

--- a/printing/ppconstr.ml
+++ b/printing/ppconstr.ml
@@ -511,8 +511,14 @@ end) = struct
       | _ ->
         pr sep inherited a
 
+let obj_string x =
+  if Obj.is_block (Obj.repr x) then
+    "tag = " ^ string_of_int (Obj.tag (Obj.repr x))
+  else "int_val = " ^ string_of_int (Obj.magic x)
+
   let pr pr sep inherited a =
     let return (cmds, prec) = (tag_constr_expr a cmds, prec) in
+let _ = Printf.eprintf "pr a=%s\n%!" (obj_string a) in
     let (strm, prec) = match a with
       | CRef (r, us) ->
         return (pr_cref r us, latom)
@@ -539,6 +545,7 @@ end) = struct
           when
             Id.equal m n &&
             not (Id.Set.mem n (Topconstr.free_vars_of_constr_expr a)) ->
+let _ = Printf.eprintf "*** CProdN oui\n%!" in
         return (
           hov 0 (
             keyword "forall" ++ spc () ++ str "'" ++ pr_patt ltop p ++
@@ -546,6 +553,7 @@ end) = struct
           llambda
         )
       | CProdN _ ->
+let _ = Printf.eprintf "*** CProdN non\n%!" in
         let (bl,a) = extract_prod_binders a in
         return (
           hov 0 (
@@ -712,6 +720,7 @@ end) = struct
       | CNotation (_,"( _ )",([t],[],[])) ->
         return (pr (fun()->str"(") (max_int,L) t ++ str")", latom)
       | CNotation (_,s,env) ->
+let _ = Printf.eprintf "*** CNotation \"%s\"\n%!" s in
         pr_notation (pr mt) (pr_binders_gen (pr mt ltop)) s env
       | CGeneralization (_,bk,ak,c) ->
         return (pr_generalization bk ak (pr mt ltop c), latom)

--- a/printing/ppconstr.ml
+++ b/printing/ppconstr.ml
@@ -511,14 +511,8 @@ end) = struct
       | _ ->
         pr sep inherited a
 
-let obj_string x =
-  if Obj.is_block (Obj.repr x) then
-    "tag = " ^ string_of_int (Obj.tag (Obj.repr x))
-  else "int_val = " ^ string_of_int (Obj.magic x)
-
   let pr pr sep inherited a =
     let return (cmds, prec) = (tag_constr_expr a cmds, prec) in
-let _ = Printf.eprintf "pr a=%s\n%!" (obj_string a) in
     let (strm, prec) = match a with
       | CRef (r, us) ->
         return (pr_cref r us, latom)
@@ -545,7 +539,6 @@ let _ = Printf.eprintf "pr a=%s\n%!" (obj_string a) in
           when
             Id.equal m n &&
             not (Id.Set.mem n (Topconstr.free_vars_of_constr_expr a)) ->
-let _ = Printf.eprintf "*** CProdN oui\n%!" in
         return (
           hov 0 (
             keyword "forall" ++ spc () ++ str "'" ++ pr_patt ltop p ++
@@ -553,7 +546,6 @@ let _ = Printf.eprintf "*** CProdN oui\n%!" in
           llambda
         )
       | CProdN _ ->
-let _ = Printf.eprintf "*** CProdN non\n%!" in
         let (bl,a) = extract_prod_binders a in
         return (
           hov 0 (
@@ -720,7 +712,6 @@ let _ = Printf.eprintf "*** CProdN non\n%!" in
       | CNotation (_,"( _ )",([t],[],[])) ->
         return (pr (fun()->str"(") (max_int,L) t ++ str")", latom)
       | CNotation (_,s,env) ->
-let _ = Printf.eprintf "*** CNotation \"%s\"\n%!" s in
         pr_notation (pr mt) (pr_binders_gen (pr mt ltop)) s env
       | CGeneralization (_,bk,ak,c) ->
         return (pr_generalization bk ak (pr mt ltop c), latom)

--- a/stm/texmacspp.ml
+++ b/stm/texmacspp.ml
@@ -237,6 +237,8 @@ and pp_local_binder lb = (* don't know what it is for now *)
       let ppl =
         List.map (fun (loc, nam) -> (xmlCst (string_of_name nam) loc)) namll in
       xmlTyped (ppl @ [pp_expr ce])
+  | LocalPattern _ ->
+      assert false
 and pp_local_decl_expr lde = (* don't know what it is for now *)
   match lde with
   | AssumExpr (_, ce) -> pp_expr ce
@@ -344,6 +346,7 @@ and pp_cases_pattern_expr cpe =
       xmlApply loc
         (xmlOperator "delimiter" ~attr:["name", delim] loc ::
           [pp_cases_pattern_expr cpe])
+  | CPatCast _ -> assert false
 and pp_case_expr (e, name, pat) =
   match name, pat with
   | None, None -> xmlScrutinee [pp_expr e]

--- a/test-suite/output/Binder.out
+++ b/test-suite/output/Binder.out
@@ -1,0 +1,8 @@
+foo = fun '(x, y) => x + y
+     : nat * nat -> nat
+forall '(a, b), a /\ b
+     : Prop
+foo = λ '(x, y), x + y
+     : nat * nat → nat
+∀ '(a, b), a ∧ b
+     : Prop

--- a/test-suite/output/Binder.v
+++ b/test-suite/output/Binder.v
@@ -1,0 +1,7 @@
+Definition foo '(x,y) := x + y.
+Print foo.
+Check forall '(a,b), a /\ b.
+
+Require Import Utf8.
+Print foo.
+Check forall '(a,b), a /\ b.

--- a/test-suite/output/PatternsInBinders.out
+++ b/test-suite/output/PatternsInBinders.out
@@ -1,0 +1,31 @@
+swap = fun '(x, y) => (y, x)
+     : A * B -> B * A
+fun '(x, y) => (y, x)
+     : A * B -> B * A
+forall '(x, y), swap (x, y) = (y, x)
+     : Prop
+proj_informative = fun 'exist _ x _ => x : A
+     : {x : A | P x} -> A
+foo = fun 'Bar n b tt p => if b then n + p else n - p
+     : Foo -> nat
+baz = 
+fun 'Bar n1 _ tt p1 => fun 'Bar _ _ tt _ => n1 + p1
+     : Foo -> Foo -> nat
+λ '(x, y), (y, x)
+     : A * B → B * A
+∀ '(x, y), swap (x, y) = (y, x)
+     : Prop
+swap = 
+fun (A B : Type) (pat : A * B) => let '(x, y) := pat in (y, x)
+     : forall A B : Type, A * B -> B * A
+
+Arguments A, B are implicit and maximally inserted
+Argument scopes are [type_scope type_scope _]
+forall (A B : Type) (pat : A * B), let '(x, y) := pat in swap (x, y) = (y, x)
+     : Prop
+exists pat : A * A, let '(x, y) := pat in swap (x, y) = (y, x)
+     : Prop
+both_z = 
+fun pat : nat * nat =>
+let '(n, p) as pat0 := pat return (F pat0) in (Z n, Z p) : F (n, p)
+     : forall pat : nat * nat, F pat

--- a/test-suite/output/PatternsInBinders.v
+++ b/test-suite/output/PatternsInBinders.v
@@ -1,0 +1,54 @@
+(** The purpose of this file is to test printing of the destructive
+    patterns used in binders ([fun] and [forall]). *)
+
+Parameters (A B : Type) (P:A->Prop).
+
+Definition swap '((x,y) : A*B) := (y,x).
+Print swap.
+
+Check fun '((x,y) : A*B) => (y,x).
+
+Check forall '(x,y), swap (x,y) = (y,x).
+
+Definition proj_informative '(exist _ x _ : { x:A | P x }) : A := x.
+Print proj_informative.
+
+Inductive Foo := Bar : nat -> bool -> unit -> nat -> Foo.
+Definition foo '(Bar n b tt p) :=
+  if b then n+p else n-p.
+Print foo.
+
+Definition baz '(Bar n1 b1 tt p1) '(Bar n2 b2 tt p2) := n1+p1.
+Print baz.
+
+(** Some test involving unicode noations. *)
+Module WithUnicode.
+
+  Require Import Coq.Unicode.Utf8.
+
+  Check λ '((x,y) : A*B),  (y,x).
+  Check ∀ '(x,y), swap (x,y) = (y,x).
+
+End WithUnicode.
+
+
+(** * Suboptimal printing *)
+
+(** These tests show examples which expose the [let] introduced by
+    the pattern notation in binders. *)
+
+Module Suboptimal.
+
+Definition swap {A B} '((x,y) : A*B) := (y,x).
+Print swap.
+
+Check forall (A B:Type) '((x,y) : A*B), swap (x,y) = (y,x).
+
+Check exists '((x,y):A*A), swap (x,y) = (y,x).
+
+Inductive Fin (n:nat) := Z : Fin n.
+Definition F '(n,p) : Type := (Fin n * Fin p)%type.
+Definition both_z '(n,p) : F (n,p) := (Z _,Z _).
+Print both_z.
+
+End Suboptimal.

--- a/test-suite/success/PatternsInBinders.v
+++ b/test-suite/success/PatternsInBinders.v
@@ -1,0 +1,67 @@
+(** The purpose of this file is to test functional properties of the
+    destructive patterns used in binders ([fun] and [forall]). *)
+
+
+Definition swap {A B} '((x,y) : A*B) := (y,x).
+
+(** Tests the use of patterns in [fun] and [Definition] *)
+Section TestFun.
+
+  Variables A B : Type.
+
+  Goal forall (x:A) (y:B), swap (x,y) = (y,x).
+  Proof. reflexivity. Qed.
+
+  Goal forall u:A*B, swap (swap u) = u.
+  Proof. destruct u. reflexivity. Qed.
+
+  Goal @swap A B = fun '(x,y) => (y,x).
+  Proof. reflexivity. Qed.
+
+End TestFun.
+
+
+(** Tests the use of patterns in [forall] *)
+Section TestForall.
+
+  Variables A B : Type.
+
+  Goal forall '((x,y) : A*B), swap (x,y) = (y,x).
+  Proof. intros [x y]. reflexivity. Qed.
+
+  Goal forall x0:A, exists '((x,y) : A*A), swap (x,y) = (x,y).
+  Proof.
+    intros x0.
+    exists (x0,x0).
+    reflexivity.
+  Qed.
+
+End TestForall.
+
+
+
+(** Tests the use of patterns in dependent definitions. *)
+
+Section TestDependent.
+
+  Inductive Fin (n:nat) := Z : Fin n.
+
+  Definition F '(n,p) : Type := (Fin n * Fin p)%type.
+
+  Definition both_z '(n,p) : F (n,p) := (Z _,Z _).
+
+End TestDependent.
+
+
+(** Tests with a few other types just to make sure parsing is
+    robust. *)
+Section TestExtra.
+
+  Definition proj_informative {A P} '(exist _ x _ : { x:A | P x }) : A := x.
+
+  Inductive Foo := Bar : nat -> bool -> unit -> nat -> Foo.
+
+  Definition foo '(Bar n b tt p) :=
+    if b then n+p else n-p.
+
+End TestExtra.

--- a/toplevel/command.ml
+++ b/toplevel/command.ml
@@ -541,6 +541,7 @@ let check_param = function
 | LocalRawDef (na, _) -> check_named na
 | LocalRawAssum (nas, Default _, _) -> List.iter check_named nas
 | LocalRawAssum (nas, Generalized _, _) -> ()
+| LocalPattern _ -> assert false
 
 let interp_mutual_inductive (paramsl,indl) notations poly prv finite =
   check_all_names_different indl;

--- a/toplevel/record.ml
+++ b/toplevel/record.ml
@@ -102,7 +102,8 @@ let typecheck_params_and_fields def id pl t ps nots fs =
     in
       List.iter 
 	(function LocalRawDef (b, _) -> error default_binder_kind b
-	   | LocalRawAssum (ls, bk, ce) -> List.iter (error bk) ls) ps
+	   | LocalRawAssum (ls, bk, ce) -> List.iter (error bk) ls
+           | LocalPattern _ -> assert false) ps
   in 
   let impls_env, ((env1,newps), imps) = interp_context_evars env0 evars ps in
   let t', template = match t with 


### PR DESCRIPTION
Followup of (and dependent on) #142. Only my commits are actually part of the PR, the rest is from #142. This should be rebased and tested again when #142 is merged.

Tests files to check non-regression of the syntax. The `ouput/` test checks printing, but since printing is not perfect yet, it may be subject to changes in the near future (any work against the printing of this feature should be checked and the output file modified accordingly).
