### PR TITLE
Bug fix : variable capture in ltac code of Nsatz

### DIFF
--- a/plugins/nsatz/Nsatz.v
+++ b/plugins/nsatz/Nsatz.v
@@ -11,9 +11,7 @@
 (commutative ring without zero divisor).
  
 Examples: see test-suite/success/Nsatz.v
-
 Reification is done using type classes, defined in Ncring_tac.v
-
 *)
 
 Require Import List.
@@ -289,6 +287,8 @@ Ltac rev l :=
    | (cons ?x ?l) => let l' := rev l in append1 x l'
   end.
 
+
+
 Ltac nsatz_call_n info nparam p rr lp kont := 
 (*  idtac "Trying power: " rr;*)
   let ll := constr:(PEc info :: PEc nparam :: PEpow p rr :: lp) in
@@ -298,7 +298,9 @@ Ltac nsatz_call_n info nparam p rr lp kont :=
   match goal with
   | |- (?c::PEpow _ ?r::?lq0)::?lci0 = _ -> _ =>
     intros _;
+    let lci := fresh "lci" in
     set (lci:=lci0);
+    let lq := fresh "lq" in
     set (lq:=lq0);
     kont c rr lq lci
   end.
@@ -380,10 +382,13 @@ Ltac nsatz_generic radicalmax info lparam lvar :=
     end in 
 
   SplitPolyList ltac:(fun p lp =>
+    let p21 := fresh "p21" in
+    let lp21 := fresh "lp21" in
     set (p21:=p) ;
     set (lp21:=lp);
-(*    idtac "nparam:"; idtac nparam; idtac "p:"; idtac p; idtac "lp:"; idtac lp; *)
+(*   idtac "nparam:"; idtac nparam; idtac "p:"; idtac p; idtac "lp:"; idtac lp; *)
     nsatz_call radicalmax info nparam p lp ltac:(fun c r lq lci => 
+      let q := fresh "q" in
       set (q := PEmul c (PEpow p21 r)); 
       let Hg := fresh "Hg" in 
       assert (Hg:check lp21 q (lci,lq) = true); 

--- a/plugins/nsatz/utile.ml
+++ b/plugins/nsatz/utile.ml
@@ -11,8 +11,8 @@ let prt0 s = () (* print_string s;flush(stdout)*)
 let prt s =
   if !Flags.debug then (print_string (s^"\n");flush(stdout)) else ()
 
-let info s =
-  Flags.if_verbose prerr_string s
+let info s = 
+  if !Flags.debug then Feedback.msg_debug (Pp.str s)
 
 (* Lists *)
 


### PR DESCRIPTION
changing
set (x := val)
into
let x := fresh "x" in
set (x := val)
