### PR TITLE
Prevent unsafe overwriting of Required modules by toplevel library.

### DIFF
--- a/library/declaremods.ml
+++ b/library/declaremods.ml
@@ -894,7 +894,8 @@ let get_library_native_symbols dir =
 let start_library dir =
   let mp = Global.start_library dir in
   openmod_info := default_module_info;
-  Lib.start_compilation dir mp;
+  let prefix = Lib.start_compilation dir mp in
+  Nametab.push_dir (Nametab.Until 1) (fst prefix) (DirOpenModule prefix);
   Lib.add_frozen_state ()
 
 let end_library ?except dir =

--- a/library/lib.ml
+++ b/library/lib.ml
@@ -315,7 +315,8 @@ let start_compilation s mp =
   let prefix = s, (mp, Names.DirPath.empty) in
   let () = add_anonymous_entry (CompilingLibrary prefix) in
   comp_name := Some s;
-  path_prefix := prefix
+  path_prefix := prefix;
+  prefix
 
 let end_compilation_checks dir =
   let _ =

--- a/library/lib.mli
+++ b/library/lib.mli
@@ -127,7 +127,7 @@ val end_modtype :
 
 (** {6 Compilation units } *)
 
-val start_compilation : Names.DirPath.t -> Names.module_path -> unit
+val start_compilation : Names.DirPath.t -> Names.module_path -> Libnames.object_prefix
 val end_compilation_checks : Names.DirPath.t -> Libnames.object_name
 val end_compilation :
   Libnames.object_name-> Libnames.object_prefix * library_segment


### PR DESCRIPTION
In coqtop, one could do for instance:

Require Import Top. (\* Where Top contains a Definition b := true *)
Lemma bE : b = true. Proof. reflexivity. Qed.

Definition b := false.

Lemma bad : False. Proof. generalize bE; compute; discriminate. Qed.

That proof could however not be saved because of the circular dependency check.

As a stopgap, we register the toplevel library in the Nametab. This way, this
proof of false is prevented in the same way as is a similar one with a library
whose logical name is A.B and another library whose logical name is A and which
contains a module B.

A better long term fix for these issues would not rely on Nametab, which is
effectively in the TCB today.
