### PR TITLE
In docs, fix command to reset Ltac profiling

### DIFF
--- a/doc/refman/RefMan-ltac.tex
+++ b/doc/refman/RefMan-ltac.tex
@@ -1277,7 +1277,7 @@ Prints the profile
 Prints a profile for all tactics that start with {\qstring}. Append a period (.) to the string if you only want exactly that name.
 
 \begin{quote}
-{\tt Reset Profile}.
+{\tt Reset Ltac Profile}.
 \end{quote}
 Resets the profile, that is, deletes all accumulated information
 


### PR DESCRIPTION
From ltac/profile_ltac_tactics.ml4, it looks like the command to reset Ltac profiling is

  Reset Ltac Profile.

and not

  Reset Profile.
