### PR TITLE
[pp] Fix bug 4842 (Time prints in multiple lines)

### DIFF
--- a/lib/system.ml
+++ b/lib/system.ml
@@ -293,20 +293,20 @@ let fmt_time_difference (startreal,ustart,sstart) (stopreal,ustop,sstop) =
   real (round (sstop -. sstart)) ++ str "s" ++
   str ")"
 
-let with_time time f x =
+let with_time ?(hdr = mt()) time f x =
   let tstart = get_time() in
   let msg = if time then "" else "Finished transaction in " in
   try
     let y = f x in
     let tend = get_time() in
     let msg2 = if time then "" else " (successful)" in
-    Feedback.msg_info (str msg ++ fmt_time_difference tstart tend ++ str msg2);
+    Feedback.msg_info (hdr ++ str msg ++ fmt_time_difference tstart tend ++ str msg2);
     y
   with e ->
     let tend = get_time() in
     let msg = if time then "" else "Finished failing transaction in " in
     let msg2 = if time then "" else " (failure)" in
-    Feedback.msg_info (str msg ++ fmt_time_difference tstart tend ++ str msg2);
+    Feedback.msg_info (hdr ++ str msg ++ fmt_time_difference tstart tend ++ str msg2);
     raise e
 
 let process_id () =

--- a/lib/system.mli
+++ b/lib/system.mli
@@ -103,7 +103,7 @@ val get_time : unit -> time
 val time_difference : time -> time -> float (** in seconds *)
 val fmt_time_difference : time -> time -> Pp.std_ppcmds
 
-val with_time : bool -> ('a -> 'b) -> 'a -> 'b
+val with_time : ?hdr:Pp.std_ppcmds -> bool -> ('a -> 'b) -> 'a -> 'b
 
 (** {6 Name of current process.} *)
 val process_id : unit -> string

--- a/toplevel/vernac.ml
+++ b/toplevel/vernac.ml
@@ -155,30 +155,6 @@ let restore_translator_coqdoc (ch,cl,cs,coqdocstate) =
   CLexer.restore_com_state cs;
   CLexer.restore_location_table coqdocstate
 
-(* For coqtop -time, we display the position in the file,
-   and a glimpse of the executed command *)
-
-let display_cmd_header loc com =
-  let shorten s = try (String.sub s 0 30)^"..." with _ -> s in
-  let noblank s =
-    for i = 0 to String.length s - 1 do
-      match s.[i] with
-	| ' ' | '\n' | '\t' | '\r' -> s.[i] <- '~'
-	| _ -> ()
-    done;
-    s
-  in
-  let (start,stop) = Loc.unloc loc in
-  let safe_pr_vernac x =
-    try Ppvernac.pr_vernac x
-    with e -> str (Printexc.to_string e) in
-  let cmd = noblank (shorten (string_of_ppcmds (safe_pr_vernac com)))
-  in
-  Feedback.msg_notice
-    (str "Chars " ++ int start ++ str " - " ++ int stop ++
-     str " [" ++ str cmd ++ str "] ")
-
-
 let rec vernac_com checknav (loc,com) =
   let interp = function
     | VernacLoad (verbosely, fname) ->
@@ -208,7 +184,6 @@ let rec vernac_com checknav (loc,com) =
     try
       checknav loc com;
       if do_beautify () then pr_new_syntax loc (Some com);
-      if !Flags.time then display_cmd_header loc com;
       let com = if !Flags.time then VernacTime (loc,com) else com in
       let a = CLexer.com_state () in
       interp com;


### PR DESCRIPTION
This commit proposes a fix for
https://coq.inria.fr/bugs/show_bug.cgi?id=4842

Here, we face a bit of a dilemma: we need to choose between sending the
time report to the user in one or two messages.

In the one message approach, we send the whole report once the command
has been completed. In the two messages approach, we send one message at
the start and one at completion. However, in the second approach, we
lose some control of the formatting.

I've opted to send just one message for timing event: I think it is a
better choice for the IDEs, and it is the easiest path to preserve
output compatibility this late in the release process.

However, note that having a finer control over messages layout could
make sense, but IMVHO in order to achieve a satisfactory implementation
we would need to implement `pp_stdcmds` serialization first.
