### PR TITLE
A cleaning step in using heuristics for inference of the return clause

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -83,7 +83,7 @@ Focusing
   e.g. `[x]: {` will focus on a goal (existential variable) named `x`.
   As usual, unfocus with `}` once the sub-goal is fully solved.
 
-Specification language
+Specification language, type inference
 
 - A fix to unification (which was sensitive to the ascii name of
   variables) may occasionally change type inference in incompatible
@@ -93,6 +93,11 @@ Specification language
   variables which are bound to local definitions might exceptionally
   induce an overhead if the cost of checking the conversion of the
   corresponding definitions is additionally high (PR #8215).
+
+- A few improvements in inference of the return clause of "match" can
+  exceptionally introduce incompatibilities (PR #262). This can be
+  solved by writing an explicit "return" clause, sometimes even simply
+  an explicit "return _" clause.
 
 Standard Library
 

--- a/pretyping/cases.ml
+++ b/pretyping/cases.ml
@@ -1996,10 +1996,7 @@ let prepare_predicate_from_arsign_tycon env sigma loc tomatchs arsign c =
  * type and 1 assumption for each term not _syntactically_ in an
  * inductive type.
 
- * Each matched terms are independently considered dependent or not.
-
- * A type constraint but no annotation case: we try to specialize the
- * tycon to make the predicate if it is not closed.
+ * Each matched term is independently considered dependent or not.
  *)
 
 exception LocalOccur
@@ -2031,15 +2028,14 @@ let prepare_predicate ?loc typing_fun env sigma tomatchs arsign tycon pred =
     | None, Some t when not (noccur_with_meta sigma 0 max_int t) ->
 	(* If the tycon is not closed w.r.t real variables, we try *)
         (* two different strategies *)
-       (* First strategy: we abstract the tycon wrt to the dependencies *)
-         let sigma, t = refresh_tycon sigma t in
-         let p1 =
+        (* First strategy: we build an "inversion" predicate *)
+        let sigma1,pred1 = build_inversion_problem loc env sigma tomatchs t in
+        (* Optional second strategy: we abstract the tycon wrt to the dependencies *)
+        let p2 =
           prepare_predicate_from_arsign_tycon env sigma loc tomatchs arsign t in
-	(* Second strategy: we build an "inversion" predicate *)
-	let sigma2,pred2 = build_inversion_problem loc env sigma tomatchs t in
-	(match p1 with
-         | Some (sigma1,pred1,arsign) -> [sigma1, pred1, arsign; sigma2, pred2, arsign]
-         | None -> [sigma2, pred2, arsign])
+        (match p2 with
+         | Some (sigma2,pred2,arsign) -> [sigma1, pred1, arsign; sigma2, pred2, arsign]
+         | None -> [sigma1, pred1, arsign])
     | None, _ ->
 	(* No dependent type constraint, or no constraints at all: *)
 	(* we use two strategies *)
@@ -2052,7 +2048,7 @@ let prepare_predicate ?loc typing_fun env sigma tomatchs arsign tycon pred =
 	in
         (* First strategy: we build an "inversion" predicate *)
 	let sigma1,pred1 = build_inversion_problem loc env sigma tomatchs t in
-	(* Second strategy: we directly use the evar as a non dependent pred *)
+        (* Second strategy: we use the evar or tycon as a non dependent pred *)
         let pred2 = lift (List.length (List.flatten arsign)) t in
         [sigma1, pred1, arsign; sigma, pred2, arsign]
     (* Some type annotation *)

--- a/test-suite/output/Cases.out
+++ b/test-suite/output/Cases.out
@@ -64,14 +64,9 @@ In environment
 texpDenote : forall t : type, texp t -> typeDenote t
 t : type
 e : texp t
-t1 : type
-t2 : type
-t0 : type
-b : tbinop t1 t2 t0
-e1 : texp t1
-e2 : texp t2
-The term "0" has type "nat" while it is expected to have type
- "typeDenote t0".
+n : nat
+The term "n" has type "nat" while it is expected to have type
+ "typeDenote ?t@{t1:=Nat}".
 fun '{{n, m, _}} => n + m
      : J -> nat
 fun '{{n, m, p}} => n + m + p

--- a/test-suite/success/Case13.v
+++ b/test-suite/success/Case13.v
@@ -113,3 +113,15 @@ Check fun z P Q (y:K true z) (H1 H2:P y) (f:forall y z, P y -> Q y z) =>
         | F  => f y true H1
         | G b => f y b H2
         end.
+
+(* Check use of the maximal-dependency-in-variable strategy for "Var"
+   variables *)
+
+Goal forall z P Q (y:K true z) (H1 H2:P y) (f:forall y z, P y -> Q y z), Q y z.
+intros z P Q y H1 H2 f.
+Show.
+refine (match y with
+        | F  => f y true H1
+        | G b => f y b H2
+        end).
+Qed.

--- a/test-suite/success/Case13.v
+++ b/test-suite/success/Case13.v
@@ -87,3 +87,17 @@ Check fun (x : E) => match x with c => e c end.
 Inductive C' : bool -> Set := c' : C' true.
 Inductive E' (b : bool) : Set := e' :> C' b -> E' b.
 Check fun (x : E' true) => match x with c' => e' true c' end.
+
+(* Check use of the no-dependency strategy when a type constraint is
+   given (and when the "inversion-and-dependencies-as-evars" strategy
+   is not strong enough because of a constructor with a type whose
+   pattern structure is not refined enough for it to be captured by
+   the inversion predicate) *)
+
+Inductive K : bool -> bool -> Type := F : K true true | G x : K x x.
+
+Check fun z P Q (y:K true z) (H1 H2:P y) (f:forall y, P y -> Q y z) =>
+        match y with
+        | F  => f y H1
+        | G _ => f y H2
+        end : Q y z.

--- a/test-suite/success/Case13.v
+++ b/test-suite/success/Case13.v
@@ -101,3 +101,15 @@ Check fun z P Q (y:K true z) (H1 H2:P y) (f:forall y, P y -> Q y z) =>
         | F  => f y H1
         | G _ => f y H2
         end : Q y z.
+
+(* Check use of the maximal-dependency-in-variable strategy even when
+   no explicit type constraint is given (and when the
+   "inversion-and-dependencies-as-evars" strategy is not strong enough
+   because of a constructor with a type whose pattern structure is not
+   refined enough for it to be captured by the inversion predicate) *)
+
+Check fun z P Q (y:K true z) (H1 H2:P y) (f:forall y z, P y -> Q y z) =>
+        match y with
+        | F  => f y true H1
+        | G b => f y b H2
+        end.


### PR DESCRIPTION
This started when Jason noticed on coq-club that "refine (fun H1 => match H1 with eq_refl => _ end)" was not using "small inversion" while "intro H1; refine (match H1 with eq_refl => _ end)" was.

I then took time to clean the organization of the three heuristics used for inference of the return clause, resulting in the attached 4 commits, progressively unifying the use of heuristics, depending on whether there is a type constraint or not, on whether this type constraint is referring to variables by rels or vars, trying the heuristics in the same order in each situation.

Details are in the commit logs.

It seems ok to me for 8.6 in the sense that it is cleaning an existing framework. No effect on the contribs tested by the jenkins system even though there is a small semantic change: when there is a type constraint with contains "rel" variables, priority was given to abstracting this type constraint over these "rel" variables without inverting even if using a "small inversion" was relevant (as in Jason's example). Now, "small inversion" is always tried first. 8.7 could be considered too if needed, though I would advocate for a quick integration to limit merging issues.
