### PR TITLE
A variant of Refine.refine which assumes one goal under focus and which may return a non-trivial value

### DIFF
--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -387,16 +387,19 @@ let push_rel_context_to_named_context env typ =
   (* compute the instances relative to the named context and rel_context *)
   let open Context.Named.Declaration in
   let ids = List.map get_id (named_context env) in
-  let avoid = List.fold_right Id.Set.add ids Id.Set.empty in
   let inst_vars = List.map mkVar ids in
-  let inst_rels = List.rev (rel_list 0 (nb_rel env)) in
-  (* move the rel context to a named context and extend the named instance *)
-  (* with vars of the rel context *)
-  (* We do keep the instances corresponding to local definition (see above) *)
-  let (subst, vsubst, _, env) =
-    Context.Rel.fold_outside push_rel_decl_to_named_context
-      (rel_context env) ~init:(empty_csubst, [], avoid, named_context env) in
-  (val_of_named_context env, subst2 subst vsubst typ, inst_rels@inst_vars, subst, vsubst)
+  if List.is_empty (Environ.rel_context env) then
+    (named_context_val env, typ, inst_vars, empty_csubst, [])
+  else
+    let avoid = List.fold_right Id.Set.add ids Id.Set.empty in
+    let inst_rels = List.rev (rel_list 0 (nb_rel env)) in
+    (* move the rel context to a named context and extend the named instance *)
+    (* with vars of the rel context *)
+    (* We do keep the instances corresponding to local definition (see above) *)
+    let (subst, vsubst, _, env) =
+      Context.Rel.fold_outside push_rel_decl_to_named_context
+        (rel_context env) ~init:(empty_csubst, [], avoid, named_context env) in
+    (val_of_named_context env, subst2 subst vsubst typ, inst_rels@inst_vars, subst, vsubst)
 
 (*------------------------------------*
  * Entry points to define new evars   *

--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -1058,6 +1058,19 @@ module Goal = struct
     end
     end
 
+  let enter_one f =
+    let open Proof in
+    Comb.get >>= function
+    | [goal] -> begin
+       Env.get >>= fun env ->
+       tclEVARMAP >>= fun sigma ->
+       try f.enter (gmake env sigma goal)
+       with e when catchable_exception e ->
+         let (e, info) = CErrors.push e in
+         tclZERO ~info e
+      end
+    | _ -> tclZERO (CErrors.errorlabstrm "" (str "More than one subgoal"))
+
   type ('a, 'b) s_enter =
     { s_enter : 'r. ('a, 'r) t -> ('b, 'r) Sigma.sigma }
 

--- a/engine/proofview.mli
+++ b/engine/proofview.mli
@@ -499,6 +499,10 @@ module Goal : sig
   (** Like {!nf_enter}, but does not normalize the goal beforehand. *)
   val enter : ([ `LZ ], unit tactic) enter -> unit tactic
 
+  (** Like {!enter}, but assumes exactly one goal under focus, raising *)
+  (** an error otherwise. *)
+  val enter_one : ([ `LZ ], 'a tactic) enter -> 'a tactic
+
   type ('a, 'b) s_enter =
     { s_enter : 'r. ('a, 'r) t -> ('b, 'r) Sigma.sigma }
 

--- a/ide/coqOps.ml
+++ b/ide/coqOps.ml
@@ -561,13 +561,19 @@ object(self)
       condition returns true; it is fed with the number of phrases read and the
       iters enclosing the current sentence. *)
   method private fill_command_queue until queue =
+    let topstack =
+      if Doc.focused document then fst (Doc.context document) else [] in
     let rec loop n iter =
       match Sentence.find buffer iter with
       | None -> ()
       | Some (start, stop) ->
         if until n start stop then begin
           ()
-        end else if stop#backward_char#has_tag Tags.Script.processed then begin
+        end else if
+          List.exists (fun (_, s) ->
+            start#equal (buffer#get_iter_at_mark s.start) &&
+            stop#equal (buffer#get_iter_at_mark s.stop)) topstack
+        then begin
           Queue.push (`Skip (start, stop)) queue;
           loop n stop
         end else begin

--- a/ide/ide_slave.ml
+++ b/ide/ide_slave.ml
@@ -499,7 +499,7 @@ let loop () =
   let xml_ic = Xml_parser.make (Xml_parser.SLexbuf in_lb) in
   let () = Xml_parser.check_eof xml_ic false in
   Feedback.set_logger (slave_logger xml_oc);
-  Feedback.set_feeder (slave_feeder xml_oc);
+  Feedback.add_feeder (slave_feeder xml_oc);
   (* We'll handle goal fetching and display in our own way *)
   Vernacentries.enable_goal_printing := false;
   Vernacentries.qed_display_script := false;

--- a/ide/xml_printer.ml
+++ b/ide/xml_printer.ml
@@ -17,65 +17,65 @@ type t = target
 let make x = x
 
 let buffer_pcdata tmp text =
-  let output = Buffer.add_string tmp in
-  let output' = Buffer.add_char tmp in
+  let puts = Buffer.add_string tmp in
+  let putc = Buffer.add_char tmp in
   let l = String.length text in
   for p = 0 to l-1 do
     match text.[p] with
-      | ' ' -> output "&nbsp;";
-      | '>' -> output "&gt;"
-      | '<' -> output "&lt;"
+      | ' ' -> puts "&nbsp;";
+      | '>' -> puts "&gt;"
+      | '<' -> puts "&lt;"
       | '&' ->
         if p < l - 1 && text.[p + 1] = '#' then
-          output' '&'
+          putc '&'
         else
-          output "&amp;"
-      | '\'' -> output "&apos;"
-      | '"' -> output "&quot;"
-      | c -> output' c
+          puts "&amp;"
+      | '\'' -> puts "&apos;"
+      | '"' -> puts "&quot;"
+      | c -> putc c
   done
 
 let buffer_attr tmp (n,v) =
-  let output = Buffer.add_string tmp in
-  let output' = Buffer.add_char tmp in
-  output' ' ';
-  output n;
-  output "=\"";
+  let puts = Buffer.add_string tmp in
+  let putc = Buffer.add_char tmp in
+  putc ' ';
+  puts n;
+  puts "=\"";
   let l = String.length v in
   for p = 0 to l - 1 do
     match v.[p] with
-      | '\\' -> output "\\\\"
-      | '"' -> output "\\\""
-      | '<' -> output "&lt;"
-      | '&' -> output "&amp;"
-      | c -> output' c
+      | '\\' -> puts "\\\\"
+      | '"' -> puts "\\\""
+      | '<' -> puts "&lt;"
+      | '&' -> puts "&amp;"
+      | c -> putc c
   done;
-  output' '"'
+  putc '"'
 
 let to_buffer tmp x =
   let pcdata = ref false in
-  let output = Buffer.add_string tmp in
-  let output' = Buffer.add_char tmp in
+  let puts = Buffer.add_string tmp in
+  let putc = Buffer.add_char tmp in
   let rec loop = function
     | Element (tag,alist,[]) ->
-      output' '<';
-      output tag;
+      putc '<';
+      puts tag;
       List.iter (buffer_attr tmp) alist;
-      output "/>";
+      puts "/>";
       pcdata := false;
     | Element (tag,alist,l) ->
-      output' '<';
-      output tag;
+      putc '<';
+      puts tag;
       List.iter (buffer_attr tmp) alist;
-      output' '>';
+      putc '>';
       pcdata := false;
       List.iter loop l;
-      output "</";
-      output tag;
-      output' '>';
+      puts "</";
+      puts tag;
+      putc '>';
       pcdata := false;
     | PCData text ->
-      if !pcdata then output' ' ';
+      if !pcdata then putc ' ';
       buffer_pcdata tmp text;
       pcdata := true;
   in
@@ -93,42 +93,42 @@ let to_string x =
 
 let to_string_fmt x =
   let tmp = Buffer.create 200 in
-  let output = Buffer.add_string tmp in
-  let output' = Buffer.add_char tmp in
+  let puts = Buffer.add_string tmp in
+  let putc = Buffer.add_char tmp in
   let rec loop ?(newl=false) tab = function
     | Element (tag, alist, []) ->
-      output tab;
-      output' '<';
-      output tag;
+      puts tab;
+      putc '<';
+      puts tag;
       List.iter (buffer_attr tmp) alist;
-      output "/>";
-      if newl then output' '\n';
+      puts "/>";
+      if newl then putc '\n';
     | Element (tag, alist, [PCData text]) ->
-      output tab;
-      output' '<';
-      output tag;
+      puts tab;
+      putc '<';
+      puts tag;
       List.iter (buffer_attr tmp) alist;
-      output ">";
+      puts ">";
       buffer_pcdata tmp text;
-      output "</";
-      output tag;
-      output' '>';
-      if newl then output' '\n';
+      puts "</";
+      puts tag;
+      putc '>';
+      if newl then putc '\n';
     | Element (tag, alist, l) ->
-      output tab;
-      output' '<';
-      output tag;
+      puts tab;
+      putc '<';
+      puts tag;
       List.iter (buffer_attr tmp) alist;
-      output ">\n";
+      puts ">\n";
       List.iter (loop ~newl:true (tab^"  ")) l;
-      output tab;
-      output "</";
-      output tag;
-      output' '>';
-      if newl then output' '\n';
+      puts tab;
+      puts "</";
+      puts tag;
+      putc '>';
+      if newl then putc '\n';
     | PCData text ->
       buffer_pcdata tmp text;
-      if newl then output' '\n';
+      if newl then putc '\n';
   in
   loop "" x;
   Buffer.contents tmp

--- a/kernel/csymtable.ml
+++ b/kernel/csymtable.ml
@@ -219,17 +219,9 @@ and eval_to_patch env (buff,pl,fv) =
   eval_tcode tc vm_env
 
 and val_of_constr env c =
-  let (_,fun_code,_ as ccfv) =
-    try match compile true env c with
-	| Some v -> v
-	| None -> assert false
-    with reraise ->
-      let reraise = CErrors.push reraise in
-      let () = print_string "can not compile \n" in
-      let () = Format.print_flush () in
-      iraise reraise
-  in
-  eval_to_patch env (to_memory ccfv)
+  match compile true env c with
+  | Some v -> eval_to_patch env (to_memory v)
+  | None -> assert false
 
 let set_transparent_const kn = () (* !?! *)
 let set_opaque_const kn = () (* !?! *)

--- a/lib/feedback.ml
+++ b/lib/feedback.ml
@@ -125,8 +125,8 @@ let msg_error   ?loc x = !logger ?loc Error x
 let msg_debug   ?loc x = !logger ?loc Debug x
 
 (** Feeders *)
-let feeder = ref ignore
-let set_feeder f = feeder := f
+let feeders = ref []
+let add_feeder f = feeders := f :: !feeders
 
 let feedback_id    = ref (Edit 0)
 let feedback_route = ref default_route
@@ -135,11 +135,12 @@ let set_id_for_feedback ?(route=default_route) i =
   feedback_id := i; feedback_route := route
 
 let feedback ?id ?route what =
-  !feeder {
+  let m = {
      contents = what;
      route = Option.default !feedback_route route;
      id    = Option.default !feedback_id id;
-  }
+  } in
+  List.iter (fun f -> f m) !feeders
 
 let feedback_logger ?loc lvl msg =
   feedback ~route:!feedback_route ~id:!feedback_id

--- a/lib/feedback.mli
+++ b/lib/feedback.mli
@@ -83,8 +83,8 @@ val feedback_logger : logger
 val emacs_logger    : logger
 
 
-(** [set_feeder] A feeder processes the feedback, [ignore] by default *)
-val set_feeder : (feedback -> unit) -> unit
+(** [add_feeder] feeders observe the feedback *)
+val add_feeder : (feedback -> unit) -> unit
 
 (** [feedback ?id ?route fb] produces feedback fb, with [route] and
     [id] set appropiatedly, if absent, it will use the defaults set by

--- a/library/summary.mli
+++ b/library/summary.mli
@@ -42,6 +42,17 @@ val declare_summary : string -> 'a summary_declaration -> unit
 
 val ref : ?freeze:(marshallable -> 'a -> 'a) -> name:string -> 'a -> 'a ref
 
+(* As [ref] but the value is local to a process, i.e. not sent to, say, proof
+ * workers.  It is useful to implement a local cache for example. *)
+module Local : sig
+
+  type 'a local_ref
+  val ref : ?freeze:('a -> 'a) -> name:string -> 'a -> 'a local_ref
+  val (:=) : 'a local_ref -> 'a -> unit
+  val (!) : 'a local_ref -> 'a
+
+end
+
 (** Special name for the summary of ML modules.  This summary entry is
     special because its unfreeze may load ML code and hence add summary
     entries.  Thus is has to be recognizable, and handled appropriately *)

--- a/ltac/profile_ltac.ml
+++ b/ltac/profile_ltac.ml
@@ -11,6 +11,8 @@ open Pp
 open Printer
 open Util
 
+module M = CString.Map
+
 (** [is_profiling] and the profiling info ([stack]) should be synchronized with
     the document; the rest of the ref cells are either local to individual
     tactic invocations, or global flags, and need not be synchronized, since no
@@ -20,10 +22,6 @@ let is_profiling = Flags.profile_ltac
 
 let set_profiling b = is_profiling := b
 let get_profiling () = !is_profiling
-
-let new_call = ref false
-let entered_call () = new_call := true
-let is_new_call () = let b = !new_call in new_call := false; b
 
 (** LtacProf cannot yet handle backtracking into multi-success tactics.
     To properly support this, we'd have to somehow recreate our location in the
@@ -35,7 +33,7 @@ let encountered_multi_success_backtracking = ref false
 let warn_profile_backtracking =
   CWarnings.create ~name:"profile-backtracking" ~category:"ltac"
     (fun () -> strbrk "Ltac Profiler cannot yet handle backtracking \
-            into multi-success tactics; profiling results may be wildly inaccurate.")
+       into multi-success tactics; profiling results may be wildly inaccurate.")
 
 let warn_encountered_multi_success_backtracking () =
   if !encountered_multi_success_backtracking then
@@ -48,92 +46,199 @@ let encounter_multi_success_backtracking () =
     warn_encountered_multi_success_backtracking ()
   end
 
-type entry = {
-  mutable total : float;
-  mutable local : float;
-  mutable ncalls : int;
-  mutable max_total : float
-}
 
-let empty_entry () = { total = 0.; local = 0.; ncalls = 0; max_total = 0. }
-
-let add_entry e add_total { total; local; ncalls; max_total } =
-  if add_total then e.total <- e.total +. total;
-  e.local <- e.local +. local;
-  e.ncalls <- e.ncalls + ncalls;
-  if add_total then e.max_total <- max e.max_total max_total
+(* *************** tree data structure for profiling ****************** *)
 
 type treenode = {
-  entry : entry;
-  children : (string, treenode) Hashtbl.t
+  name : M.key;
+  total : float;
+  local : float;
+  ncalls : int;
+  max_total : float;
+  children : treenode M.t
 }
 
-let empty_treenode n = { entry = empty_entry (); children = Hashtbl.create n }
+let empty_treenode name = {
+  name;
+  total = 0.0;
+  local = 0.0;
+  ncalls = 0;
+  max_total = 0.0;
+  children = M.empty;
+}
 
-(** Tobias Tebbi wrote some tricky code involving mutation. Rather than
-    rewriting it in a functional style, we simply freeze the state when we need
-    to by issuing a deep copy of the profiling data. *)
-(** TODO: rewrite me in purely functional style *)
-let deepcopy_entry { total; local; ncalls; max_total } =
-  { total; local; ncalls; max_total }
+let root = "root"
 
-let rec deepcopy_treenode { entry; children } =
-  let children' = Hashtbl.create (Hashtbl.length children) in
-  let iter key subtree = Hashtbl.add children' key (deepcopy_treenode subtree) in
-  let () = Hashtbl.iter iter children in
-  { entry = deepcopy_entry entry; children = children' }
+module Local = Summary.Local
 
-let stack =
-  let freeze _ = List.map deepcopy_treenode in
-  Summary.ref ~freeze [empty_treenode 20] ~name:"LtacProf-stack"
+let stack = Local.ref ~name:"LtacProf-stack" [empty_treenode root]
 
-let on_stack = Hashtbl.create 5
+let reset_profile () =
+  Local.(stack := [empty_treenode root]);
+  encountered_multi_success_backtracking := false
 
-let get_node c table =
-  try Hashtbl.find table c
+(* ************** XML Serialization  ********************* *)
+
+let rec of_ltacprof_tactic (name, t) =
+  assert (String.equal name t.name);
+  let open Xml_datatype in
+  let total = string_of_float t.total in
+  let local = string_of_float t.local in
+  let ncalls = string_of_int t.ncalls in
+  let max_total = string_of_float t.max_total in
+  let children = List.map of_ltacprof_tactic (M.bindings t.children) in
+  Element ("ltacprof_tactic",
+    [ ("name", name); ("total",total); ("local",local);
+      ("ncalls",ncalls); ("max_total",max_total)],
+    children)
+
+let of_ltacprof_results t =
+  let open Xml_datatype in
+  assert(String.equal t.name root);
+  let children = List.map of_ltacprof_tactic (M.bindings t.children) in
+  Element ("ltacprof", [("total_time", string_of_float t.total)], children)
+
+let rec to_ltacprof_tactic m xml =
+  let open Xml_datatype in
+  match xml with
+  | Element ("ltacprof_tactic",
+     [("name", name); ("total",total); ("local",local);
+      ("ncalls",ncalls); ("max_total",max_total)], xs) ->
+      let node = {
+         name;
+         total = float_of_string total;
+         local = float_of_string local;
+         ncalls = int_of_string ncalls;
+         max_total = float_of_string max_total;
+         children = List.fold_left to_ltacprof_tactic M.empty xs;
+       } in
+      M.add name node m
+  | _ -> CErrors.anomaly Pp.(str "Malformed ltacprof_tactic XML")
+
+let to_ltacprof_results xml =
+  let open Xml_datatype in
+  match xml with
+  | Element ("ltacprof", [("total_time", t)], xs) ->
+     { name = root;
+       total = float_of_string t;
+       ncalls = 0;
+       max_total = 0.0;
+       local = 0.0;
+       children = List.fold_left to_ltacprof_tactic M.empty xs }
+  | _ -> CErrors.anomaly Pp.(str "Malformed ltacprof XML")
+
+let feedback_results results =
+  Feedback.(feedback 
+    (Custom (Loc.dummy_loc, "ltacprof_results", of_ltacprof_results results)))
+
+(* ************** pretty printing ************************************* *)
+
+let format_sec x = (Printf.sprintf "%.3fs" x)
+let format_ratio x = (Printf.sprintf "%.1f%%" (100. *. x))
+let padl n s = ws (max 0 (n - utf8_length s)) ++ str s
+let padr n s = str s ++ ws (max 0 (n - utf8_length s))
+let padr_with c n s =
+  let ulength = utf8_length s in
+  str (utf8_sub s 0 n) ++ str (String.make (max 0 (n - ulength)) c)
+
+let rec list_iter_is_last f = function
+  | []      -> []
+  | [x]     -> [f true x]
+  | x :: xs -> f false x :: list_iter_is_last f xs
+
+let header =
+  str " tactic                                    local  total   calls       max" ++
+  fnl () ++
+  str "────────────────────────────────────────┴──────┴──────┴───────┴─────────┘" ++
+  fnl ()
+
+let rec print_node ~filter all_total indent prefix (s, e) =
+  h 0 (
+    padr_with '-' 40 (prefix ^ s ^ " ")
+    ++ padl 7 (format_ratio (e.local /. all_total))
+    ++ padl 7 (format_ratio (e.total /. all_total))
+    ++ padl 8 (string_of_int e.ncalls)
+    ++ padl 10 (format_sec (e.max_total))
+  ) ++
+  print_table ~filter all_total indent false e.children
+
+and print_table ~filter all_total indent first_level table =
+  let fold _ n l =
+    let s, total = n.name, n.total in
+    if filter s then (s, n) :: l else l in
+  let ls = M.fold fold table [] in
+  match ls with
+  | [s, n] when not first_level ->
+     print_node ~filter all_total indent (indent ^ "└") (s, n)
+  | _ ->
+    let ls =
+      List.sort (fun (_, { total = s1 }) (_, { total = s2}) ->
+                   compare s2 s1) ls in
+    let iter is_last =
+     let sep0 = if first_level then "" else if is_last then "  " else " │" in
+     let sep1 = if first_level then "─" else if is_last then " └─" else " ├─" in
+     print_node ~filter all_total (indent ^ sep0) (indent ^ sep1)
+    in
+    prlist_with_sep fnl (fun pr -> pr) (list_iter_is_last iter ls)
+
+let to_string ~filter node =
+  let tree = node.children in
+  let all_total = node.total in
+  let flat_tree =
+    let global = ref M.empty in
+    let find_tactic tname l =
+      try M.find tname !global
+      with Not_found ->
+        let e = empty_treenode tname in
+        global := M.add tname e !global;
+        e in
+    let add_tactic tname stats = global := M.add tname stats !global in
+    let sum_stats add_total
+      { name; total = t1; local = l1; ncalls = n1; max_total = m1 }
+      {       total = t2; local = l2; ncalls = n2; max_total = m2 } = {
+          name;
+          total = if add_total then t1 +. t2 else t1;
+          local = l1 +. l2;
+          ncalls = n1 + n2;
+          max_total = if add_total then max m1 m2 else m1;
+          children = M.empty;
+      } in
+    let rec cumulate table =
+      let iter _ ({ name; children } as statistics) =
+        if filter name then begin
+          let stats' = find_tactic name global in
+          add_tactic name (sum_stats true stats' statistics);
+        end;
+        cumulate children
+      in
+      M.iter iter table
+    in
+    cumulate tree;
+    !global
+  in
+  warn_encountered_multi_success_backtracking ();
+  let msg =
+    h 0 (str "total time: " ++ padl 11 (format_sec (all_total))) ++
+    fnl () ++
+    header ++
+    print_table ~filter all_total "" true flat_tree ++
+    fnl () ++
+    header ++
+    print_table ~filter all_total "" true tree
+  in
+  msg
+
+(* ******************** profiling code ************************************** *)
+
+let get_child name node =
+  try node, M.find name node.children
   with Not_found ->
-    let new_node = empty_treenode 5 in
-    Hashtbl.add table c new_node;
-    new_node
-
-let rec add_node node node' =
-  add_entry node.entry true node'.entry;
-  Hashtbl.iter
-    (fun s node' -> add_node (get_node s node.children) node')
-    node'.children
+    let new_node = empty_treenode name in
+    { node with children = M.add name new_node node.children }, new_node
 
 let time () =
   let times = Unix.times () in
   times.Unix.tms_utime +. times.Unix.tms_stime
-
-(*
-let msgnl_with fmt strm = msg_with fmt (strm ++ fnl ())
-let msgnl          strm = msgnl_with !Pp_control.std_ft strm
-
-let rec print_treenode indent (tn : treenode) =
-  msgnl (str (indent^"{ entry = {"));
-  Feedback.msg_notice (str (indent^"total = "));
-  msgnl (str (indent^(string_of_float (tn.entry.total))));
-  Feedback.msg_notice (str (indent^"local = "));
-  msgnl (str (indent^(string_of_float tn.entry.local)));
-  Feedback.msg_notice (str (indent^"ncalls = "));
-  msgnl (str (indent^(string_of_int tn.entry.ncalls)));
-  Feedback.msg_notice (str (indent^"max_total = "));
-  msgnl (str (indent^(string_of_float tn.entry.max_total)));
-  msgnl (str (indent^"}"));
-  msgnl (str (indent^"children = {"));
-  Hashtbl.iter
-    (fun s node ->
-      msgnl (str (indent^" "^s^" |-> "));
-      print_treenode (indent^"  ") node
-    )
-    tn.children;
-  msgnl (str (indent^"} }"))
-
-let rec print_stack (st : treenode list) = match st with
-| [] -> msgnl (str "[]")
-| x :: xs -> print_treenode "" x; msgnl (str ("::")); print_stack xs
-*)
 
 let string_of_call ck =
   let s =
@@ -155,17 +260,66 @@ let string_of_call ck =
   let s = try String.sub s 0 (CString.string_index_from s 0 "(*") with Not_found -> s in
   CString.strip s
 
-let exit_tactic start_time add_total c = match !stack with
-| [] | [_] ->
-  (* oops, our stack is invalid *)
-  encounter_multi_success_backtracking ()
-| node :: (parent :: _ as stack') ->
-  stack := stack';
-  if add_total then Hashtbl.remove on_stack (string_of_call c);
+let rec merge_sub_tree name tree acc =
+  try
+    let t = M.find name acc in
+    let t = {
+      name;
+      total = t.total +. tree.total;
+      ncalls = t.ncalls + tree.ncalls;
+      local = t.local +. tree.local;
+      max_total = max t.max_total tree.max_total;
+      children = M.fold merge_sub_tree tree.children t.children;
+    } in
+    M.add name t acc
+  with Not_found -> M.add name tree acc
+
+let merge_roots t1 t2 =
+  assert(String.equal t1.name t2.name);
+  { name = t1.name;
+    ncalls = t1.ncalls + t2.ncalls;
+    local = t1.local +. t2.local;
+    total = t1.total +. t2.total;
+    max_total = max t1.max_total t2.max_total;
+    children =
+      M.fold merge_sub_tree t2.children t1.children }
+
+let exit_tactic start_time c =
   let diff = time () -. start_time in
-  parent.entry.local <- parent.entry.local -. diff;
-  let node' = { total = diff; local = diff; ncalls = 1; max_total = diff } in
-  add_entry node.entry add_total node'
+  match Local.(!stack) with
+  | [] | [_] ->
+    (* oops, our stack is invalid *)
+    encounter_multi_success_backtracking ();
+    reset_profile ()
+  | node :: (parent :: rest) ->
+    let name = string_of_call c in
+    if not (String.equal name node.name) then
+      (* oops, our stack is invalid *)
+      encounter_multi_success_backtracking ();
+    let node = { node with
+      total = node.total +. diff;
+      local = node.local +. diff;
+      ncalls = node.ncalls + 1;
+      max_total = max node.max_total diff;
+    } in
+    let parent =
+      if String.equal parent.name node.name then
+        (* we coalesce the rec-call *)
+        merge_roots
+          { parent with children = M.remove node.name parent.children }
+          node
+      else
+        (* we graft the subtree *)
+        { parent with
+           local = parent.local -. diff;
+           children = M.add node.name node parent.children } in
+    Local.(stack := parent :: rest);
+    (* Calls are over, we reset the stack and send back data *)
+    if rest == [] && get_profiling () then begin
+      assert(String.equal root parent.name);
+      reset_profile ();
+      feedback_results parent
+    end
 
 let tclFINALLY tac (finally : unit Proofview.tactic) =
   let open Proofview.Notations in
@@ -177,181 +331,56 @@ let tclFINALLY tac (finally : unit Proofview.tactic) =
 let do_profile s call_trace tac =
   let open Proofview.Notations in
   Proofview.tclLIFT (Proofview.NonLogical.make (fun () ->
-  if !is_profiling && is_new_call () then
-    match call_trace with
-      | (_, c) :: _ ->
-        let s = string_of_call c in
-        let parent = List.hd !stack in
-        let node, add_total = try Hashtbl.find on_stack s, false
-                              with Not_found ->
-                                   let node = get_node s parent.children in
-                                   Hashtbl.add on_stack s node;
-                                   node, true
-        in
-        if not add_total && node = List.hd !stack then None else (
-          stack := node :: !stack;
-          let start_time = time () in
-          Some (start_time, add_total)
-        )
-      | [] -> None
+  if !is_profiling then
+    match call_trace, Local.(!stack) with
+      | (_, c) :: _, parent :: rest ->
+        let name = string_of_call c in
+        let parent, node = get_child name parent in
+        Local.(stack := node :: parent :: rest);
+        Some (time ())
+      | _ -> None
   else None)) >>= function
-  | Some (start_time, add_total) ->
+  | Some start_time ->
     tclFINALLY
       tac
       (Proofview.tclLIFT (Proofview.NonLogical.make (fun () ->
         (match call_trace with
-        | (_, c) :: _ ->
-          exit_tactic start_time add_total c
+        | (_, c) :: _ -> exit_tactic start_time c
         | [] -> ()))))
   | None -> tac
 
+(* ************** Accumulation of data from workers ************************* *)
 
+let get_local_profiling_results () = List.hd Local.(!stack)
 
-let format_sec x = (Printf.sprintf "%.3fs" x)
-let format_ratio x = (Printf.sprintf "%.1f%%" (100. *. x))
-let padl n s = ws (max 0 (n - utf8_length s)) ++ str s
-let padr n s = str s ++ ws (max 0 (n - utf8_length s))
-let padr_with c n s =
-  let ulength = utf8_length s in
-  str (utf8_sub s 0 n) ++ str (String.make (max 0 (n - ulength)) c)
+module SM = Map.Make(Stateid.Self)
 
-let rec list_iter_is_last f = function
-  | []      -> []
-  | [x]     -> [f true x]
-  | x :: xs -> f false x :: list_iter_is_last f xs
+let data = ref SM.empty
 
-let header =
-  str " tactic                                    self  total   calls       max" ++
-  fnl () ++
-  str "────────────────────────────────────────┴──────┴──────┴───────┴─────────┘" ++
-  fnl ()
+let _ =
+  Feedback.(add_feeder (function
+    | { id = State s; contents = Custom (_, "ltacprof_results", xml) } ->
+        let results = to_ltacprof_results xml in
+        let other_results = (* Multi success can cause this *)
+          try SM.find s !data
+          with Not_found -> empty_treenode root in
+        data := SM.add s (merge_roots results other_results) !data
+    | _ -> ()))
 
-let rec print_node all_total indent prefix (s, n) =
-  let e = n.entry in
-  h 0 (
-    padr_with '-' 40 (prefix ^ s ^ " ")
-    ++ padl 7 (format_ratio (e.local /. all_total))
-    ++ padl 7 (format_ratio (e.total /. all_total))
-    ++ padl 8 (string_of_int e.ncalls)
-    ++ padl 10 (format_sec (e.max_total))
-  ) ++
-  print_table all_total indent false n.children
+(* ******************** *)
 
-and print_table all_total indent first_level table =
-  let fold s n l = if n.entry.total /. all_total < 0.02 then l else (s, n) :: l in
-  let ls = Hashtbl.fold fold table [] in
-  match ls with
-  | [s, n] when not first_level ->
-     print_node all_total indent (indent ^ "└") (s, n)
-  | _ ->
-    let ls = List.sort (fun (_, n1) (_, n2) -> compare n2.entry.total n1.entry.total) ls in
-    let iter is_last =
-      let sep0 = if first_level then "" else if is_last then "  " else " │" in
-      let sep1 = if first_level then "─" else if is_last then " └─" else " ├─" in
-      print_node all_total (indent ^ sep0) (indent ^ sep1)
-    in
-    prlist_with_sep fnl (fun pr -> pr) (list_iter_is_last iter ls)
+let print_results_filter ~filter =
+  let valid id _ = Stm.state_of_id id <> `Expired in
+  data := SM.filter valid !data;
+  let results = SM.fold (fun _ -> merge_roots) !data (empty_treenode root) in
+  Feedback.msg_notice (to_string ~filter results)
+;;
 
-let get_results_string () =
-  let tree = (List.hd !stack).children in
-  let all_total = -. (List.hd !stack).entry.local in
-  let global = Hashtbl.create 20 in
-  let rec cumulate table =
-    let iter s node =
-      let node' = get_node s global in
-      add_entry node'.entry true node.entry;
-      cumulate node.children
-    in
-    Hashtbl.iter iter table
-  in
-  cumulate tree;
-  warn_encountered_multi_success_backtracking ();
-  let msg =
-    h 0 (str "total time: " ++ padl 11 (format_sec (all_total))) ++
-    fnl () ++
-    header ++
-    print_table all_total "" true global ++
-    fnl () ++
-    header ++
-    print_table all_total "" true tree
-  in
-  msg
-
-
-type ltacprof_entry = {total : float; self : float; num_calls : int; max_total : float}
-type ltacprof_tactic = {name: string; statistics : ltacprof_entry; tactics : ltacprof_tactic list}
-type ltacprof_results = {total_time : float; tactics : ltacprof_tactic list}
-
-let to_ltacprof_entry (e: entry) : ltacprof_entry =
-  {total=e.total; self=e.local; num_calls=e.ncalls; max_total=e.max_total}
-
-let rec to_ltacprof_tactic (name: string) (t: treenode) : ltacprof_tactic =
-  { name = name; statistics = to_ltacprof_entry t.entry; tactics = to_ltacprof_treenode t.children }
-and to_ltacprof_treenode (table: (string, treenode) Hashtbl.t) : ltacprof_tactic list =
-  Hashtbl.fold (fun name' t' c -> to_ltacprof_tactic name' t'::c) table []
-
-let get_profiling_results() : ltacprof_results =
-  let tree = List.hd !stack in
-  { total_time = -. tree.entry.local; tactics = to_ltacprof_treenode tree.children }
-
-let rec of_ltacprof_tactic t =
-  let open Xml_datatype in
-  let total = string_of_float t.statistics.total in
-  let self = string_of_float t.statistics.self in
-  let num_calls = string_of_int t.statistics.num_calls in
-  let max_total = string_of_float t.statistics.max_total in
-  let children = List.map of_ltacprof_tactic t.tactics in
-  Element ("ltacprof_tactic", [("name", t.name); ("total",total); ("self",self); ("num_calls",num_calls); ("max_total",max_total)], children)
-
-let rec of_ltacprof_results t =
-  let open Xml_datatype in
-  let children = List.map of_ltacprof_tactic t.tactics in
-  Element ("ltacprof", [("total_time", string_of_float t.total_time)], children)
-
-
-let get_profile_xml() =
-  of_ltacprof_results (get_profiling_results())
-
-let print_results () =
-  Feedback.msg_notice (get_results_string());
-  Feedback.feedback (Feedback.Custom (Loc.dummy_loc, "ltacprof_results", get_profile_xml()))
-
-  (* FOR DEBUGGING *)
-  (* ;
-     msgnl (str"");
-     print_stack (!stack)
-  *)
+let print_results () = print_results_filter ~filter:(fun _ -> true)
 
 let print_results_tactic tactic =
-  let tree = (List.hd !stack).children in
-  let table_tactic = Hashtbl.create 20 in
-  let rec cumulate table =
-    let iter s node =
-      if String.sub (s ^ ".") 0 (min (1 + String.length s) (String.length tactic)) = tactic
-      then add_node (get_node s table_tactic) node
-      else cumulate node.children
-    in
-    Hashtbl.iter iter table
-  in
-  cumulate tree;
-  let all_total = -. (List.hd !stack).entry.local in
-  let tactic_total =
-    Hashtbl.fold
-      (fun _ node all_total -> node.entry.total +. all_total)
-      table_tactic 0. in
-  warn_encountered_multi_success_backtracking ();
-  let msg =
-    h 0 (str"total time:           " ++ padl 11 (format_sec (all_total))) ++
-    h 0 (str"time spent in tactic: " ++ padl 11 (format_sec (tactic_total))) ++
-    fnl () ++
-    header ++
-    print_table tactic_total "" true table_tactic
-  in
-  Feedback.msg_notice msg
-
-let reset_profile () =
-  stack := [empty_treenode 20];
-  encountered_multi_success_backtracking := false
+  print_results_filter ~filter:(fun s ->
+    String.(equal tactic (sub (s ^ ".") 0 (min (1+length s) (length tactic)))))
 
 let do_print_results_at_close () = if get_profiling () then print_results ()
 

--- a/ltac/profile_ltac.mli
+++ b/ltac/profile_ltac.mli
@@ -8,13 +8,11 @@
 
 (** Ltac profiling primitives *)
 
-val do_profile : string -> ('a * Tacexpr.ltac_call_kind) list -> 'b Proofview.tactic -> 'b Proofview.tactic
+val do_profile :
+  string -> ('a * Tacexpr.ltac_call_kind) list ->
+    'b Proofview.tactic -> 'b Proofview.tactic
 
 val set_profiling : bool -> unit
-
-val get_profiling : unit -> bool
-
-val entered_call : unit -> unit
 
 val print_results : unit -> unit
 
@@ -30,24 +28,20 @@ val do_print_results_at_close : unit -> unit
  * statistics of the two invocations combined, and also combined over all
  * invocations of 'aaa'.
  * total:     time spent running this tactic and its subtactics (seconds)
- * self:      time spent running this tactic, minus its subtactics (seconds)
- * num_calls: the number of invocations of this tactic that have been made
+ * local:      time spent running this tactic, minus its subtactics (seconds)
+ * ncalls: the number of invocations of this tactic that have been made
  * max_total: the greatest running time of a single invocation (seconds)
  *)
-type ltacprof_entry = {total : float; self : float; num_calls : int; max_total : float}
-(* A profiling entry for a tactic and the tactics that it called
- * name:       name of the tactic
- * statistics: profiling data collected
- * tactics:    profiling results for each tactic that this tactic invoked;
- *             multiple invocations of the same sub-tactic are combined together.
- *)
-type ltacprof_tactic = {name: string; statistics : ltacprof_entry; tactics : ltacprof_tactic list}
-(* The full results of profiling
- * total_time: time spent running tactics (seconds)
- * tactics:    the tactics that have been invoked since profiling was started or reset
- *)
-type ltacprof_results = {total_time : float; tactics : ltacprof_tactic list}
+type treenode = {
+  name : CString.Map.key;
+  total : float;
+  local : float;
+  ncalls : int;
+  max_total : float;
+  children : treenode CString.Map.t
+}
 
-(* Returns the profiling results for the currently-focused state. *)
-val get_profiling_results : unit -> ltacprof_results
+(* Returns the profiling results known by the current process *)
+val get_local_profiling_results : unit -> treenode
+val feedback_results : treenode -> unit
 

--- a/ltac/tacinterp.ml
+++ b/ltac/tacinterp.ml
@@ -289,7 +289,7 @@ let constr_of_id env id =
 (* Some of the code further down depends on the fact that push_trace does not modify sigma (the evar map) *)
 let push_trace call ist = match TacStore.get ist.extra f_trace with
 | None -> Proofview.tclUNIT [call]
-| Some trace -> Proofview.tclLIFT (Proofview.NonLogical.make Profile_ltac.entered_call) <*> Proofview.tclUNIT (call :: trace)
+| Some trace -> Proofview.tclUNIT (call :: trace)
 
 let propagate_trace ist loc id v =
   let v = Value.normalize v in

--- a/parsing/pcoq.ml
+++ b/parsing/pcoq.ml
@@ -132,13 +132,13 @@ let grammar_delete e reinit (pos,rls) =
 let grammar_extend e reinit ext =
   let ext = of_coq_extend_statement ext in
   let undo () = grammar_delete e reinit ext in
-  let redo () = camlp4_verbose (maybe_uncurry (G.extend e)) ext in
+  let redo () = camlp4_verbosity false (maybe_uncurry (G.extend e)) ext in
   camlp4_state := ByEXTEND (undo, redo) :: !camlp4_state;
   redo ()
 
 let grammar_extend_sync e reinit ext =
   camlp4_state := ByGrammar (ExtendRule (e, reinit, ext)) :: !camlp4_state;
-  camlp4_verbose (maybe_uncurry (G.extend e)) (of_coq_extend_statement ext)
+  camlp4_verbosity false (maybe_uncurry (G.extend e)) (of_coq_extend_statement ext)
 
 (** The apparent parser of Coq; encapsulate G to keep track
     of the extensions. *)

--- a/proofs/refine.mli
+++ b/proofs/refine.mli
@@ -30,6 +30,9 @@ val refine : ?unsafe:bool -> Constr.t Sigma.run -> unit tactic
     tactic failures. If [unsafe] is [false] (default is [true]) [t] is
     type-checked beforehand. *)
 
+val refine_one : ?unsafe:bool -> ('a * Constr.t) Sigma.run -> 'a tactic
+(** A generalization of [refine] which assumes exactly one goal under focus *)
+
 (** {7 Helper functions} *)
 
 val with_type : Environ.env -> Evd.evar_map ->

--- a/tactics/eauto.ml
+++ b/tactics/eauto.ml
@@ -29,9 +29,9 @@ open Proofview.Notations
 let eauto_unif_flags = auto_flags_of_state full_transparent_state
 
 let e_give_exact ?(flags=eauto_unif_flags) c =
-  Proofview.Goal.nf_enter { enter = begin fun gl ->
+  Proofview.Goal.enter { enter = begin fun gl ->
   let t1 = Tacmach.New.pf_unsafe_type_of gl c in
-  let t2 = Tacmach.New.pf_concl gl in
+  let t2 = Tacmach.New.pf_concl (Proofview.Goal.assume gl) in
   if occur_existential t1 || occur_existential t2 then
      Tacticals.New.tclTHEN (Clenvtac.unify ~flags t1) (exact_no_check c)
   else exact_check c


### PR DESCRIPTION
This is a follow-up of the discussion on 2 Sep 2016 on coqdev. Taking it as an exercice, assuming that others could be also interested in the exercice, this commit is proposing

val enter_one : ([ `LZ ], 'a tactic) enter -> 'a tactic
val refine_one : ?unsafe:bool -> ('a \* Constr.t) Sigma.run -> 'a tactic

It looked to me that assuming one goal under focus was more natural than not assuming it and explicitly selecting one goal. In particular, if we are in the scope of an enter (or more precisely of an iter_goal), then there is already exactly one goal under focus, and we don't need to dispatch.

This fits my need but it is of course not exclusive of the other propositions.
