### PR TITLE
Revert the LtacProf tactic table header

### DIFF
--- a/ltac/profile_ltac.ml
+++ b/ltac/profile_ltac.ml
@@ -147,7 +147,7 @@ let rec list_iter_is_last f = function
   | x :: xs -> f false x :: list_iter_is_last f xs
 
 let header =
-  str "                                   tactic  local  total   calls       max" ++
+  str " tactic                                   local  total   calls       max " ++
   fnl () ++
   str "────────────────────────────────────────┴──────┴──────┴───────┴─────────┘" ++
   fnl ()


### PR DESCRIPTION
This removes a space (making the final letter of the right-aligned columns line come right before the vertical separators, rather than overlapping them), and left-aligns "tactic", as it was in Tobias' original code, which I think is easier to read.  (This way, the alignment of the headers matches the alignment of the entries.)

@gares 
