### PR TITLE
A stronger progress tactical

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -55,6 +55,8 @@ Tactics
   "Structural Injection". In this case, hypotheses are also put in the
   context in the natural left-to-right order and the hypothesis on
   which injection applies is cleared.
+- Add a "strong_progress" tactical which will fail if the initial
+  goals are a subset of the final goals.
 
 Hints
 

--- a/doc/refman/RefMan-ltac.tex
+++ b/doc/refman/RefMan-ltac.tex
@@ -472,6 +472,17 @@ is raised.
 
 \ErrMsg \errindex{Failed to progress}
 
+\begin{Variants}
+  \item {\tt strong_progress} {\tacexpr}
+
+    It has the same behaviour as {\tt progress} {\tacexpr} except that
+    the criterion to assess progress is more stringent: a tactic $t$
+    is considered to have strongly progressed if the set of focused
+    goals before $t$ was applied is a subset of the focused goals
+    after $t$ is done.
+
+\end{Variants}
+
 \subsubsection[Backtracking branching]{Backtracking branching\tacindex{$+$}
 \index{Tacticals!or@{\tt $+$}}}
 

--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -1009,6 +1009,11 @@ module Goal = struct
 
   let raw_concl { concl=concl } = concl
 
+  let equal gl1 gl2 =
+    let eq_hyps = CList.equal Context.Named.Declaration.equal in
+    let eq_concl = Constr.equal in
+    eq_concl (concl gl1) (concl gl2) && eq_hyps (hyps gl1) (hyps gl2)
+
 
   let gmake_with info env sigma goal = 
     { env = Environ.reset_with_named_context (Evd.evar_filtered_hyps info) env ;

--- a/engine/proofview.mli
+++ b/engine/proofview.mli
@@ -483,6 +483,13 @@ module Goal : sig
   val sigma : ('a, 'r) t -> 'r Sigma.t
   val extra : ('a, 'r) t -> Evd.Store.t
 
+  (** {equal} compares two goals extensionally ({i i.e.} compares the
+      (normalised) hypotheses and conclusions of the goals). The goals
+      need not be in the same [evar_map], however when evars are
+      compared it will be supposed that they have a coherent typing
+      context in both [evar_map]. *)
+  val equal : ([`NF], 'r) t -> ([`NF], 's) t -> bool
+
   (** Returns the goal's conclusion even if the goal is not
       normalised. *)
   val raw_concl : ('a, 'r) t -> Term.constr


### PR DESCRIPTION
This PR adds a flavour of progress which detects that all the initial goals still appear as subgoals. As discussed in #1766.

This new `strong_progress` tactical is much slower than progress. It also has the property that `strong_progress (swap 1 2)` will always fail. So it's not a drop-in replacement for replace. It is meant to be used, for instance, as part of automation to cut useless branches.

Questions:
- Is `extractactics.ml4` the right place for such new tacticals? (@ppedrot?)
- The CHANGES doesn't distinguish 8.6 commits and post-8.6 commits. We may want to address that before merging this PR.

(cc @maximedenes )
