### PR TITLE
Fix newlines in printout of LtacProf

### DIFF
--- a/ltac/profile_ltac.ml
+++ b/ltac/profile_ltac.ml
@@ -160,6 +160,7 @@ let rec print_node ~filter all_total indent prefix (s, e) =
     ++ padl 8 (string_of_int e.ncalls)
     ++ padl 10 (format_sec (e.max_total))
   ) ++
+  fnl () ++
   print_table ~filter all_total indent false e.children
 
 and print_table ~filter all_total indent first_level table =
@@ -179,7 +180,7 @@ and print_table ~filter all_total indent first_level table =
      let sep1 = if first_level then "─" else if is_last then " └─" else " ├─" in
      print_node ~filter all_total (indent ^ sep0) (indent ^ sep1)
     in
-    prlist_with_sep fnl (fun pr -> pr) (list_iter_is_last iter ls)
+    prlist (fun pr -> pr) (list_iter_is_last iter ls)
 
 let to_string ~filter node =
   let tree = node.children in
@@ -223,7 +224,6 @@ let to_string ~filter node =
     fnl () ++
     header ++
     print_table ~filter all_total "" true flat_tree ++
-    fnl () ++
     fnl () ++
     header ++
     print_table ~filter all_total "" true tree


### PR DESCRIPTION
Previously, newlines were missing if a node had no children.

I tested this change elsewhere, but have since lost the diff, so I'm relying on CI to make sure that I haven't made any typos that make things not build.
