### PR TITLE
Fix: use of + should not affect the failure level.

### DIFF
--- a/tactics/tacticals.ml
+++ b/tactics/tacticals.ml
@@ -326,6 +326,18 @@ module New = struct
       tclUNIT ()
     with e -> tclZERO e
 
+  let catch_error (e, info) =
+    try
+      begin
+	if Logic.catchable_exception e then Control.check_for_interrupt ()
+	else match e with
+	   | Refiner.FailError (0,_) ->
+	      Control.check_for_interrupt ()
+	   | e -> iraise (e, info)
+      end;
+      tclUNIT ()
+    with e -> tclZERO e
+
   (* spiwack: I chose to give the Ltac + the same semantics as
      [Proofview.tclOR], however, for consistency with the or-else
      tactical, we may consider wrapping the first argument with
@@ -336,7 +348,7 @@ module New = struct
       Proofview.tclOR
         t1
         begin fun e ->
-          catch_failerror e <*> t2
+          catch_error e <*> t2
         end
     end
 
@@ -345,7 +357,7 @@ module New = struct
       Proofview.tclOR
         t1
         begin fun e ->
-          catch_failerror e <*> t2 ()
+          catch_error e <*> t2 ()
         end
     end
 


### PR DESCRIPTION
This is a tactic defined in `FSetDecide.v`:

```
Tactic Notation
  "if" tactic(t)
  "then" tactic(t1)
  "else" tactic(t2) :=
  first [ t; first [ t1 | fail 2 ] | t2 ].
```

This tactic has a weird behavior when `t` is multi-success. Example:

```
Goal True.
  if idtac + idtac then exact tt else exact I.
  (* success *)
```

Now, this can be fixed easily by replacing `t` with `once t` but @herbelin and I believe that the problem is actually not in how the tactic is defined but in how `+` and `fail n` interact.

Currently the use of `+` is creating a branching point which means that you need to increase the level of failure for the same effect: here replace `fail 2` with `fail 3`. But then you have the same problem again when you replace `idtac + idtac` with `(idtac + idtac) + idtac`.
- Is there a use case which would justify this behavior? Otherwise, this (dirty) patch fixes it.
- The `catch_error` function is defined on the model of `catch_failerror` (with some code in-lining). It should probably be refactored before being merged.
- Should other functions that `tclOR` and `tclORD` be modified similarly? For instance, `tclIFCATCH`.
- I based on trunk and not on v8.5 because of some problem of compilation on my local machine. But do you agree that this should be fixed in v8.5 too?
