### PR TITLE
Backtracking eassumption

### DIFF
--- a/tactics/eauto.ml
+++ b/tactics/eauto.ml
@@ -41,7 +41,13 @@ let assumption id = e_give_exact (mkVar id)
 
 let e_assumption =
   Proofview.Goal.enter { enter = begin fun gl ->
-    Tacticals.New.tclFIRST (List.map assumption (Tacmach.New.pf_ids_of_hyps gl))
+    (if Flags.version_strictly_greater Flags.V8_6 then
+       Tacticals.New.tclANY
+     else
+       Tacticals.New.tclFIRST_ON)
+      ~msg:(str "No such assumption.")
+      assumption
+      (Tacmach.New.pf_ids_of_hyps gl)
   end }
 
 let registered_e_assumption =

--- a/tactics/tacticals.ml
+++ b/tactics/tacticals.ml
@@ -443,6 +443,10 @@ module New = struct
     | [a]   -> tac a (* so that returned failure is the one from last item *)
     | a::tl -> tclORELSE (tac a) (tclFIRST_PROGRESS_ON tac tl)
 
+  let rec tclANY tac = function
+    | [] -> tclZEROMSG (str "No applicable tactic.")
+    | arg :: l -> tclORD (tac arg) (fun () -> tclANY tac l)
+
   let rec tclDO n t =
     if n < 0 then
       tclZEROMSG (str"Wrong argument : Do needs a positive integer.")

--- a/tactics/tacticals.ml
+++ b/tactics/tacticals.ml
@@ -438,6 +438,10 @@ module New = struct
     | [] -> tclZEROMSG (str"No applicable tactic.")
     |  t::rest -> tclORELSE0 t (tclFIRST rest)
 
+  let rec tclFIRST_ON tac = function
+    | [] -> tclZEROMSG (str "No applicable tactic.")
+    | arg :: l -> tclORELSE0 (tac arg) (tclFIRST_ON tac l)
+
   let rec tclFIRST_PROGRESS_ON tac = function
     | []    -> tclFAIL 0 (str "No applicable tactic")
     | [a]   -> tac a (* so that returned failure is the one from last item *)

--- a/tactics/tacticals.ml
+++ b/tactics/tacticals.ml
@@ -438,18 +438,18 @@ module New = struct
     | [] -> tclZEROMSG (str"No applicable tactic.")
     |  t::rest -> tclORELSE0 t (tclFIRST rest)
 
-  let rec tclFIRST_ON tac = function
-    | [] -> tclZEROMSG (str "No applicable tactic.")
-    | arg :: l -> tclORELSE0 (tac arg) (tclFIRST_ON tac l)
+  let rec tclFIRST_ON ?(msg = str "No applicable tactic.") tac = function
+    | [] -> tclZEROMSG msg
+    | arg :: l -> tclORELSE0 (tac arg) (tclFIRST_ON ~msg tac l)
 
   let rec tclFIRST_PROGRESS_ON tac = function
     | []    -> tclFAIL 0 (str "No applicable tactic")
     | [a]   -> tac a (* so that returned failure is the one from last item *)
     | a::tl -> tclORELSE (tac a) (tclFIRST_PROGRESS_ON tac tl)
 
-  let rec tclANY tac = function
-    | [] -> tclZEROMSG (str "No applicable tactic.")
-    | arg :: l -> tclORD (tac arg) (fun () -> tclANY tac l)
+  let rec tclANY ?(msg = str "No applicable tactic.") tac = function
+    | [] -> tclZEROMSG msg
+    | arg :: l -> tclORD (tac arg) (fun () -> tclANY ~msg tac l)
 
   let rec tclDO n t =
     if n < 0 then

--- a/tactics/tacticals.mli
+++ b/tactics/tacticals.mli
@@ -210,6 +210,7 @@ module New : sig
 
   val tclTRY : unit tactic -> unit tactic
   val tclFIRST : unit tactic list -> unit tactic
+  val tclANY : ('a -> unit tactic) -> 'a list -> unit tactic
   val tclIFTHENELSE : unit tactic -> unit tactic -> unit tactic -> unit tactic
   val tclIFTHENSVELSE : unit tactic -> unit tactic array -> unit tactic -> unit tactic
   val tclIFTHENTRYELSEMUST : unit tactic -> unit tactic -> unit tactic

--- a/tactics/tacticals.mli
+++ b/tactics/tacticals.mli
@@ -210,6 +210,7 @@ module New : sig
 
   val tclTRY : unit tactic -> unit tactic
   val tclFIRST : unit tactic list -> unit tactic
+  val tclFIRST_ON : ('a -> unit tactic) -> 'a list -> unit tactic
   val tclANY : ('a -> unit tactic) -> 'a list -> unit tactic
   val tclIFTHENELSE : unit tactic -> unit tactic -> unit tactic -> unit tactic
   val tclIFTHENSVELSE : unit tactic -> unit tactic array -> unit tactic -> unit tactic

--- a/tactics/tacticals.mli
+++ b/tactics/tacticals.mli
@@ -210,8 +210,10 @@ module New : sig
 
   val tclTRY : unit tactic -> unit tactic
   val tclFIRST : unit tactic list -> unit tactic
-  val tclFIRST_ON : ('a -> unit tactic) -> 'a list -> unit tactic
-  val tclANY : ('a -> unit tactic) -> 'a list -> unit tactic
+  val tclFIRST_ON :
+    ?msg:Pp.std_ppcmds -> ('a -> unit tactic) -> 'a list -> unit tactic
+  val tclANY :
+    ?msg:Pp.std_ppcmds -> ('a -> unit tactic) -> 'a list -> unit tactic
   val tclIFTHENELSE : unit tactic -> unit tactic -> unit tactic -> unit tactic
   val tclIFTHENSVELSE : unit tactic -> unit tactic array -> unit tactic -> unit tactic
   val tclIFTHENTRYELSEMUST : unit tactic -> unit tactic -> unit tactic

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -2201,11 +2201,6 @@ let one_constructor i lbind = constructor_tac false None i lbind
    Should be generalize in Constructor (Fun c : I -> tactic)
  *)
 
-let rec tclANY tac = function
-| [] -> Tacticals.New.tclZEROMSG (str "No applicable tactic.")
-| arg :: l ->
-  Tacticals.New.tclORD (tac arg) (fun () -> tclANY tac l)
-
 let any_constructor with_evars tacopt =
   let t = match tacopt with None -> Proofview.tclUNIT () | Some t -> t in
   let tac i = Tacticals.New.tclTHEN (constructor_tac with_evars None i NoBindings) t in
@@ -2218,7 +2213,7 @@ let any_constructor with_evars tacopt =
     let nconstr =
       Array.length (snd (Global.lookup_inductive (fst mind))).mind_consnames in
     if Int.equal nconstr 0 then error "The type has no constructors.";
-    tclANY tac (List.interval 1 nconstr)
+    Tacticals.New.tclANY tac (List.interval 1 nconstr)
  end }
 
 let left_with_bindings  with_evars = constructor_tac with_evars (Some 2) 1

--- a/test-suite/failure/backtracking_eassumption.v
+++ b/test-suite/failure/backtracking_eassumption.v
@@ -1,0 +1,8 @@
+(* -*- coq-prog-args: ("-emacs" "-compat" "8.6") -*- *)
+(* Cf pull request #287 *)
+
+Require Import Arith.
+
+Goal forall n m p, p <> 0 -> n <> 0 -> m <> 0 -> n * p = m * p -> n = m.
+  intros.
+  Fail eapply Nat.mul_cancel_r; eassumption.

--- a/test-suite/success/backtracking_eassumption.v
+++ b/test-suite/success/backtracking_eassumption.v
@@ -1,0 +1,8 @@
+(* Cf pull request #287 *)
+
+Require Import Arith.
+
+Goal forall n m p, p <> 0 -> n <> 0 -> m <> 0 -> n * p = m * p -> n = m.
+  intros.
+  eapply Nat.mul_cancel_r; eassumption.
+Qed.


### PR DESCRIPTION
This pull request changes the behavior of `eassumption` to allow it to have multiple successes. The goal here is to be able to do `eapply my_theorem; eassumption` where `eapply` will generate several subgoals, the first one having several candidate solutions (but only one will allow the other subgoals to be solved).

The two first commits can be considered independently:
- The first one is a micro refactoring that has nothing to do with the actual topic here but clarifies the code in `tactics.ml` a little bit. Maybe it could be merged separately.
- The second one adds a compatibility flag for 8.6 (since this pull request should go to 8.7).

Then, there is the actual change and the last commit makes sure that the behavior does not change if there is a compatibility flag.

I tested this pull request against coq-contribs on Jenkins and the only two failures I get are the ones reported earlier by @matej-kosik.
