### PR TITLE
[notation] Allow to retrieve notations with defined printing rules.

### DIFF
--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -1011,6 +1011,9 @@ let find_notation_parsing_rules ntn =
   try pi3 (String.Map.find ntn !notation_rules)
   with Not_found -> anomaly (str "No parsing rule found for " ++ str ntn)
 
+let get_defined_notations () =
+  String.Set.elements @@ String.Map.domain !notation_rules
+
 let add_notation_extra_printing_rule ntn k v =
   try
     notation_rules :=

--- a/interp/notation.mli
+++ b/interp/notation.mli
@@ -203,6 +203,9 @@ val find_notation_extra_printing_rules : notation -> extra_unparsing_rules
 val find_notation_parsing_rules : notation -> notation_grammar
 val add_notation_extra_printing_rule : notation -> string -> string -> unit
 
+(** Returns notations with defined parsing/printing rules *)
+val get_defined_notations : unit -> notation list
+
 (** Rem: printing rules for primitive token are canonical *)
 
 val with_notation_protection : ('a -> 'b) -> 'a -> 'b


### PR DESCRIPTION
The ML side lacks a method to query Coq for notations with defined
printing rules. This commit adds a method
`get_defined_printing_notations` to that purpose.
(Suggestions on the naming welcome).

This is very useful for instance in SerAPI. However, note that I believe
that in the medium-term, the `Notation` interface needs a bit of
refactoring to allow programmatic access and manipulation of notations.
