### PR TITLE
Micro refactoring: use exact_no_check.

### DIFF
--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -1930,9 +1930,7 @@ let exact_check c =
 let cast_no_check cast c =
   Proofview.Goal.enter { enter = begin fun gl ->
     let concl = Proofview.Goal.concl (Proofview.Goal.assume gl) in
-    Refine.refine ~unsafe:true { run = begin fun sigma ->
-      Sigma.here (Term.mkCast (c, cast, concl)) sigma
-    end }
+    exact_no_check (Term.mkCast (c, cast, concl))
   end }
 
 let vm_cast_no_check c = cast_no_check Term.VMcast c
@@ -1968,7 +1966,7 @@ let assumption =
     in
     if is_same_type then
       (Proofview.Unsafe.tclEVARS sigma) <*>
-	Refine.refine ~unsafe:true { run = fun h -> Sigma.here (mkVar (NamedDecl.get_id decl)) h }
+	exact_no_check (mkVar (NamedDecl.get_id decl))
     else arec gl only_eq rest
   in
   let assumption_tac = { enter = begin fun gl ->


### PR DESCRIPTION
This is does not affect the semantics of these functions but it makes them easier to read.
