### PR TITLE
Fewer stdlib warnings

### DIFF
--- a/plugins/setoid_ring/Ncring_initial.v
+++ b/plugins/setoid_ring/Ncring_initial.v
@@ -78,7 +78,8 @@ Context {R:Type}`{Ring R}.
   | Z0 => 0
   | Zneg p => -(gen_phiPOS p)
   end.
- Notation "[ x ]" := (gen_phiZ x).
+ Local Notation "[ x ]" := (gen_phiZ x) : ZMORPHISM_scope.
+ Local Open Scope ZMORPHISM_scope.
 
  Definition get_signZ z :=
   match z with
@@ -168,7 +169,7 @@ Ltac rsimpl := simpl.
   intros x y; repeat rewrite same_genZ; generalize x y;clear x y.
   induction x;destruct y;simpl;norm.
   apply ARgen_phiPOS_add.
-  apply gen_phiZ1_add_pos_neg. 
+  apply gen_phiZ1_add_pos_neg.
    rewrite gen_phiZ1_add_pos_neg. rewrite ring_add_comm.
 reflexivity.
  rewrite ARgen_phiPOS_add. rewrite ring_opp_add. reflexivity.

--- a/plugins/setoid_ring/Ring_theory.v
+++ b/plugins/setoid_ring/Ring_theory.v
@@ -238,7 +238,8 @@ Section ALMOST_RING.
  Variable req : R -> R -> Prop.
  Notation "0" := rO.  Notation "1" := rI.
  Infix "==" := req. Infix "+" := radd.  Infix "* " := rmul.
- Infix "-" := rsub. Notation "- x" := (ropp x).
+ Infix "-" := rsub : ALMOST_RING0. Notation "- x" := (ropp x) : ALMOST_RING0.
+ Local Open Scope ALMOST_RING0.
 
  (** Leibniz equality leads to a setoid theory and is extensional*)
  Lemma Eqsth : Equivalence (@eq R).
@@ -261,9 +262,10 @@ Section ALMOST_RING.
 
  (** Every semi ring can be seen as an almost ring, by taking :
         -x = x and x - y = x + y *)
- Definition SRopp (x:R) := x. Notation "- x" := (SRopp x).
+ Definition SRopp (x:R) := x. Notation "- x" := (SRopp x) : ALMOST_RING1.
+ Local Open Scope ALMOST_RING1.
 
- Definition SRsub x y := x + -y. Notation "x - y " := (SRsub x y).
+ Definition SRsub x y := x + -y. Notation "x - y " := (SRsub x y) : ALMOST_RING1.
 
  Lemma SRopp_ext : forall x y, x == y -> -x == -y.
  Proof. intros x y H; exact H. Qed.

--- a/theories/Compat/Coq85.v
+++ b/theories/Compat/Coq85.v
@@ -12,6 +12,10 @@
     are likely needed to make them behave like Coq 8.5. *)
 Require Export Coq.Compat.Coq86.
 
+(** We use some deprecated options in this file, so we disable the
+    corresponding warning, to silence the build of this file. *)
+Local Set Warnings "-deprecated-option".
+
 (* In 8.5, "intros [|]", taken e.g. on a goal "A\/B->C", does not
    behave as "intros [H|H]" but leave instead hypotheses quantified in
    the goal, here producing subgoals A->C and B->C. *)


### PR DESCRIPTION
Remaining warnings:

```
COQC      theories/Numbers/Integer/Abstract/ZDivEucl.v
File "./theories/Numbers/Integer/Abstract/ZDivEucl.v", line 33, characters 0-70:
Warning: Notation _ / _ was already used [notation-overridden,parsing]
File "./theories/Numbers/Integer/Abstract/ZDivEucl.v", line 33, characters 0-70:
Warning: Notation _ mod _ was already used [notation-overridden,parsing]
File "./theories/Numbers/Integer/Abstract/ZDivEucl.v", line 40, characters 0-130:
Warning: Notation _ / _ was already used [notation-overridden,parsing]
File "./theories/Numbers/Integer/Abstract/ZDivEucl.v", line 40, characters 0-130:
Warning: Notation _ mod _ was already used [notation-overridden,parsing]
COQC      theories/Arith/PeanoNat.v
File "./theories/Arith/PeanoNat.v", line 23, characters 0-21:
Warning: Notation _ + _ was already used in scope nat_scope
[notation-overridden,parsing]
File "./theories/Arith/PeanoNat.v", line 23, characters 0-21:
Warning: Notation _ * _ was already used in scope nat_scope
[notation-overridden,parsing]
File "./theories/Arith/PeanoNat.v", line 23, characters 0-21:
Warning: Notation _ - _ was already used in scope nat_scope
[notation-overridden,parsing]
```

These are caused by `Import` or `Include`, and so are harder to fix.
