### PR TITLE
Fix #4762 (eauto weaker than auto).

### DIFF
--- a/tactics/eauto.ml4
+++ b/tactics/eauto.ml4
@@ -291,7 +291,8 @@ module SearchProblem = struct
       in
       let rec_tacs =
 	let l =
-	  filter_tactics s.tacres (e_possible_resolve s.dblist (List.hd s.localdb) (pf_concl g))
+    let concl = Reductionops.nf_evar (project g)(pf_concl g) in
+	  filter_tactics s.tacres (e_possible_resolve s.dblist (List.hd s.localdb) concl)
 	in
 	List.map
 	  (fun (lgls, cost, pp) ->

--- a/test-suite/bugs/closed/4762.v
+++ b/test-suite/bugs/closed/4762.v
@@ -1,0 +1,24 @@
+Inductive myand (P Q : Prop) := myconj : P -> Q -> myand P Q.
+
+Lemma foo P Q R : R = myand P Q -> P -> Q -> R.
+Proof. intros ->; constructor; auto. Qed.
+
+Hint Extern 0 (myand _ _) => eapply foo; [reflexivity| |] : test1.
+
+Goal forall P Q R : Prop, P -> Q -> R -> myand P (myand Q R).
+Proof.
+  intros.
+  eauto with test1.
+Qed.
+
+Hint Extern 0 =>
+  match goal with
+  | |- myand _ _ => eapply foo; [reflexivity| |]
+  end : test2.
+
+Goal forall P Q R : Prop, P -> Q -> R -> myand P (myand Q R).
+Proof.
+  intros.
+  eauto with test2. (* works *)
+Qed.
+


### PR DESCRIPTION
See [the bug tracker](https://coq.inria.fr/bugs/show_bug.cgi?id=4762) for more information.

Technically this introduces an incompatibility since it allows `eauto` to solve more goals, but it did not seem to break anything in the contribs.
