### PR TITLE
Experiment in bindings sumbool and sumor to sum

### DIFF
--- a/plugins/romega/ReflOmegaCore.v
+++ b/plugins/romega/ReflOmegaCore.v
@@ -378,7 +378,7 @@ Module IntProperties (I:Int).
  destruct compare; intuition.
  Qed.
 
- Lemma lt_eq_lt_dec : forall n m, { n<m }+{ n=m }+{ m<n }.
+ Lemma lt_eq_lt_dec : forall n m, (n<m)+(n=m)+(m<n).
  Proof.
   intros.
   generalize (compare_Lt n m)(compare_Eq n m)(compare_Gt n m).

--- a/theories/Arith/Compare_dec.v
+++ b/theories/Arith/Compare_dec.v
@@ -12,19 +12,19 @@ Local Open Scope nat_scope.
 
 Implicit Types m n x y : nat.
 
-Definition zerop n : {n = 0} + {0 < n}.
+Definition zerop n : (n = 0) + (0 < n).
 Proof.
   destruct n; auto with arith.
 Defined.
 
-Definition lt_eq_lt_dec n m : {n < m} + {n = m} + {m < n}.
+Definition lt_eq_lt_dec n m : (n < m) + (n = m) + (m < n).
 Proof.
   induction n in m |- *; destruct m; auto with arith.
   destruct (IHn m) as [H|H]; auto with arith.
   destruct H; auto with arith.
 Defined.
 
-Definition gt_eq_gt_dec n m : {m > n} + {n = m} + {n > m}.
+Definition gt_eq_gt_dec n m : (m > n) + (n = m) + (n > m).
 Proof.
   now apply lt_eq_lt_dec.
 Defined.
@@ -53,7 +53,7 @@ Proof.
   exact (le_lt_dec n m).
 Defined.
 
-Definition le_lt_eq_dec n m : n <= m -> {n < m} + {n = m}.
+Definition le_lt_eq_dec n m : n <= m -> (n < m) + (n = m).
 Proof.
   intros; destruct (lt_eq_lt_dec n m); auto with arith.
   intros; absurd (m < n); auto with arith.
@@ -181,9 +181,9 @@ Qed.
 
 Definition nat_compare_alt (n m:nat) :=
   match lt_eq_lt_dec n m with
-    | inleft (left _) => Lt
-    | inleft (right _) => Eq
-    | inright _ => Gt
+    | inl (inl _) => Lt
+    | inl (inr _) => Eq
+    | inr _ => Gt
   end.
 
 Lemma nat_compare_equiv n m : (n ?= m) = nat_compare_alt n m.

--- a/theories/Arith/Peano_dec.v
+++ b/theories/Arith/Peano_dec.v
@@ -12,7 +12,7 @@ Local Open Scope nat_scope.
 
 Implicit Types m n x y : nat.
 
-Theorem O_or_S n : {m : nat | S m = n} + {0 = n}.
+Theorem O_or_S n : {m : nat | S m = n} + (0 = n).
 Proof.
   induction n.
   - now right.

--- a/theories/FSets/FSetBridge.v
+++ b/theories/FSets/FSetBridge.v
@@ -243,14 +243,14 @@ Module DepOfNodep (Import M: S) <: Sdep with Module E := M.E.
   Qed.
 
   Definition choose_aux: forall s : t,
-    { x : elt | M.choose s = Some x } + { M.choose s = None }.
+    { x : elt | M.choose s = Some x } + (M.choose s = None).
   Proof.
    intros.
    destruct (M.choose s); [left | right]; auto.
    exists e; auto.
   Qed.
 
-  Definition choose : forall s : t, {x : elt | In x s} + {Empty s}.
+  Definition choose : forall s : t, {x : elt | In x s} + (Empty s).
   Proof.
    intros; destruct (choose_aux s) as [(x,Hx)|H].
    left; exists x; apply choose_1; auto.
@@ -303,7 +303,7 @@ Module DepOfNodep (Import M: S) <: Sdep with Module E := M.E.
 
   Definition min_elt :
     forall s : t,
-    {x : elt | In x s /\ For_all (fun y => ~ E.lt y x) s} + {Empty s}.
+    {x : elt | In x s /\ For_all (fun y => ~ E.lt y x) s} + (Empty s).
   Proof.
     intros;
      generalize (min_elt_1 (s:=s)) (min_elt_2 (s:=s)) (min_elt_3 (s:=s)).
@@ -313,7 +313,7 @@ Module DepOfNodep (Import M: S) <: Sdep with Module E := M.E.
 
   Definition max_elt :
     forall s : t,
-    {x : elt | In x s /\ For_all (fun y => ~ E.lt x y) s} + {Empty s}.
+    {x : elt | In x s /\ For_all (fun y => ~ E.lt x y) s} + (Empty s).
   Proof.
     intros;
      generalize (max_elt_1 (s:=s)) (max_elt_2 (s:=s)) (max_elt_3 (s:=s)).

--- a/theories/FSets/FSetInterface.v
+++ b/theories/FSets/FSetInterface.v
@@ -484,14 +484,14 @@ Module Type Sdep.
   Parameter
     min_elt :
       forall s : t,
-      {x : elt | In x s /\ For_all (fun y => ~ E.lt y x) s} + {Empty s}.
+      {x : elt | In x s /\ For_all (fun y => ~ E.lt y x) s} + (Empty s).
 
   Parameter
     max_elt :
       forall s : t,
-      {x : elt | In x s /\ For_all (fun y => ~ E.lt x y) s} + {Empty s}.
+      {x : elt | In x s /\ For_all (fun y => ~ E.lt x y) s} + (Empty s).
 
-  Parameter choose : forall s : t, {x : elt | In x s} + {Empty s}.
+  Parameter choose : forall s : t, {x : elt | In x s} + (Empty s).
 
   (** The [choose_3] specification of [S] cannot be packed
         in the dependent version of [choose], so we leave it separate. *)

--- a/theories/Init/Specif.v
+++ b/theories/Init/Specif.v
@@ -193,28 +193,24 @@ Definition sigT2_of_sig2 (A : Type) (P Q : A -> Prop) (X : sig2 P Q) : sigT2 P Q
 (** [sumbool] is a boolean type equipped with the justification of
     their value *)
 
-Inductive sumbool (A B:Prop) : Set :=
-  | left : A -> {A} + {B}
-  | right : B -> {A} + {B}
- where "{ A } + { B }" := (sumbool A B) : type_scope.
-
-Add Printing If sumbool.
-
-Arguments left {A B} _, [A] B _.
-Arguments right {A B} _ , A [B] _.
+Notation sumbool := sum (compat "8.6").
+Notation left := inl (compat "8.6").
+Notation right := inr (compat "8.6").
+Notation "{ A } + { B }" := (sum A B) (only parsing, compat "8.6") : type_scope.
+Notation sumbool_rect := sum_rect (compat "8.6").
+Notation sumbool_rec := sum_rec (compat "8.6").
+Notation sumbool_ind := sum_ind (compat "8.6").
 
 (** [sumor] is an option type equipped with the justification of why
     it may not be a regular value *)
 
-Inductive sumor (A:Type) (B:Prop) : Type :=
-  | inleft : A -> A + {B}
-  | inright : B -> A + {B}
- where "A + { B }" := (sumor A B) : type_scope.
-
-Add Printing If sumor.
-
-Arguments inleft {A B} _ , [A] B _.
-Arguments inright {A B} _ , A [B] _.
+Notation sumor := sum (compat "8.6").
+Notation inleft := inl (compat "8.6").
+Notation inright := inr (compat "8.6").
+Notation "A + { B }" := (sum A B) (only parsing, compat "8.6") : type_scope.
+Notation sumor_rect := sum_rect (compat "8.6").
+Notation sumor_rec := sum_rec (compat "8.6").
+Notation sumor_ind := sum_ind (compat "8.6").
 
 (* Unset Universe Polymorphism. *)
 

--- a/theories/Lists/List.v
+++ b/theories/Lists/List.v
@@ -80,7 +80,7 @@ Section Facts.
 
   (** Destruction *)
 
-  Theorem destruct_list : forall l : list A, {x:A & {tl:list A | l = x::tl}}+{l = []}.
+  Theorem destruct_list : forall l : list A, {x:A & {tl:list A | l = x::tl}} + (l = []).
   Proof.
     induction l as [|a tail].
     right; reflexivity.

--- a/theories/NArith/BinNat.v
+++ b/theories/NArith/BinNat.v
@@ -90,7 +90,7 @@ Defined.
 
 (** Discrimination principle *)
 
-Definition discr n : { p:positive | n = pos p } + { n = 0 }.
+Definition discr n : { p:positive | n = pos p } + (n = 0).
 Proof.
  destruct n; auto.
  left; exists p; auto.

--- a/theories/NArith/Ndigits.v
+++ b/theories/NArith/Ndigits.v
@@ -474,7 +474,7 @@ Proof.
 Qed.
 
 Lemma Nless_total :
- forall a a', {Nless a a' = true} + {Nless a' a = true} + {a = a'}.
+ forall a a', (Nless a a' = true) + (Nless a' a = true) + (a = a').
 Proof.
   induction a using N.binary_rec; intro a'.
   - case_eq (Nless N0 a') ; intros Heqb.

--- a/theories/QArith/QArith_base.v
+++ b/theories/QArith/QArith_base.v
@@ -657,7 +657,7 @@ Hint Resolve Qle_not_lt Qlt_not_le Qnot_le_lt Qnot_lt_le
 
 (** Some decidability results about orders. *)
 
-Lemma Q_dec : forall x y, {x<y} + {y<x} + {x==y}.
+Lemma Q_dec : forall x y, (x<y) + (y<x) + (x==y).
 Proof.
   unfold Qlt, Qle, Qeq; intros.
   exact (Z_dec' (Qnum x * QDen y) (Qnum y * QDen x)).

--- a/theories/QArith/Qcanon.v
+++ b/theories/QArith/Qcanon.v
@@ -394,7 +394,7 @@ Qed.
 
 (** Some decidability results about orders. *)
 
-Lemma Qc_dec : forall x y, {x<y} + {y<x} + {x=y}.
+Lemma Qc_dec : forall x y, (x<y) + (y<x) + (x=y).
 Proof.
   unfold Qclt, Qcle; intros.
   destruct (Q_dec x y) as [H|H].

--- a/theories/Reals/Raxioms.v
+++ b/theories/Reals/Raxioms.v
@@ -79,7 +79,7 @@ Hint Resolve Rmult_plus_distr_l: real v62.
 (*********************************************************)
 
 (**********)
-Axiom total_order_T : forall r1 r2:R, {r1 < r2} + {r1 = r2} + {r1 > r2}.
+Axiom total_order_T : forall r1 r2:R, (r1 < r2) + (r1 = r2) + (r1 > r2).
 
 (*********************************************************)
 (** **   Lower                                           *)

--- a/theories/Reals/Rlogic.v
+++ b/theories/Reals/Rlogic.v
@@ -25,7 +25,7 @@ Section Arithmetical_dec.
 Variable P : nat -> Prop.
 Hypothesis HP : forall n, {P n} + {~P n}.
 
-Lemma sig_forall_dec : {n | ~P n} + {forall n, P n}.
+Lemma sig_forall_dec : {n | ~P n} + (forall n, P n).
 Proof.
 assert (Hi: (forall n, 0 < INR n + 1)%R).
   intros n.

--- a/theories/Vectors/Fin.v
+++ b/theories/Vectors/Fin.v
@@ -78,7 +78,7 @@ Fixpoint to_nat {m} (n : t m) : {i | i < m} :=
 
 (** [of_nat p n] answers the p{^ th} element of [fin n] if p < n or a proof of
 p >= n else *)
-Fixpoint of_nat (p n : nat) : (t n) + { exists m, p = n + m } :=
+Fixpoint of_nat (p n : nat) : (t n) + exists m, p = n + m :=
   match n with
    |0 => inright _ (ex_intro _ p eq_refl)
    |S n' => match p with

--- a/theories/ZArith/ZArith_dec.v
+++ b/theories/ZArith/ZArith_dec.v
@@ -15,7 +15,7 @@ Local Open Scope Z_scope.
 
 (* begin hide *)
 (* Trivial, to deprecate? *)
-Lemma Dcompare_inf : forall r:comparison, {r = Eq} + {r = Lt} + {r = Gt}.
+Lemma Dcompare_inf : forall r:comparison, (r = Eq) + (r = Lt) + (r = Gt).
 Proof.
   induction r; auto.
 Defined.
@@ -155,7 +155,7 @@ Proof.
   assumption.
 Defined.
 
-Lemma Z_dec : forall n m:Z, {n < m} + {n > m} + {n = m}.
+Lemma Z_dec : forall n m:Z, (n < m) + (n > m) + (n = m).
 Proof.
   intros x y.
   case (Z_lt_ge_dec x y).
@@ -179,7 +179,7 @@ Proof.
 Defined.
 
 
-Lemma Z_dec' : forall n m:Z, {n < m} + {m < n} + {n = m}.
+Lemma Z_dec' : forall n m:Z, (n < m) + (m < n) + (n = m).
 Proof.
   intros x y.
   case (Z.eq_dec x y); intro H;

--- a/theories/ZArith/Zorder.v
+++ b/theories/ZArith/Zorder.v
@@ -24,7 +24,7 @@ Local Open Scope Z_scope.
 
 (** * Trichotomy *)
 
-Theorem Ztrichotomy_inf n m : {n < m} + {n = m} + {n > m}.
+Theorem Ztrichotomy_inf n m : (n < m) + (n = m) + (n > m).
 Proof.
   unfold ">", "<". generalize (Z.compare_eq n m).
   destruct (n ?= m); [ left; right | left; left | right]; auto.


### PR DESCRIPTION
PMP asked whether `sumor` could not be bound to `sum`, thanks to cumulativity. The same question actually holds for `sumbool`.

The first of this commit defines `sumor` and `sumbool` as aliases for `sum`, as well as `inleft` and `left` (resp. `inright` and `right`) as aliases for `inl` (resp. `inr`), as well as 
`_ + { _ }` and `{ _ } + { _ }` as aliases for `_ + _` (in type_scope).

This has the advantages to free both the space of names and the space of notations, offering rooms for new notations based on curly brackets such as a `{ x .. y | P }` (see #142), or a `{ x , .. , y  }` notation.

It does not seem that this would impact extraction. Is that correct?

On the other side, the `{ ... } + { ... }` and `{ ... } + { ... } + { ... }` notations are somehow strongly tied to some popular style of specifications in Coq. This has also to be considered.

Among side-effects, `{ A } + { B }` would then typically be printed `A + B`, or `(A + B)%type`, which is not necessarily more readable, due in the first case to the overloading with + on numbers and in the second case to the cumbersome `%type` annotation.

The second commit is removing uses of `sumor` in the standard library.

Test-suite is not updated, replacing `sumbool` by `sum` is generally not done (when not part of a ternary sum).
