### PR TITLE
Adding a flag to support different naming modes for evar hypotheses.

### DIFF
--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -30,11 +30,17 @@ val new_evar_from_context :
   ?naming:Misctypes.intro_pattern_naming_expr ->
   ?principal:bool -> types -> evar_map * EConstr.t
 
+type naming_mode =
+  | KeepUserNameAndRenameExistingButSectionNames
+  | KeepUserNameAndRenameExistingEvenSectionNames
+  | KeepExistingNames
+  | FailIfConflict
+
 val new_evar :
   env -> evar_map -> ?src:Evar_kinds.t Loc.located -> ?filter:Filter.t ->
   ?candidates:constr list -> ?store:Store.t ->
   ?naming:Misctypes.intro_pattern_naming_expr ->
-  ?principal:bool -> types -> evar_map * EConstr.t
+  ?principal:bool -> ?hypnaming:naming_mode -> types -> evar_map * EConstr.t
 
 val new_pure_evar :
   named_context_val -> evar_map -> ?src:Evar_kinds.t Loc.located -> ?filter:Filter.t ->
@@ -49,18 +55,20 @@ val e_new_evar :
   env -> evar_map ref -> ?src:Evar_kinds.t Loc.located -> ?filter:Filter.t ->
   ?candidates:constr list -> ?store:Store.t ->
   ?naming:Misctypes.intro_pattern_naming_expr ->
-  ?principal:bool -> types -> constr
+  ?principal:bool -> ?hypnaming:naming_mode -> types -> constr
 
 (** Create a new Type existential variable, as we keep track of 
     them during type-checking and unification. *)
 val new_type_evar :
   env -> evar_map -> ?src:Evar_kinds.t Loc.located -> ?filter:Filter.t ->
-  ?naming:Misctypes.intro_pattern_naming_expr -> ?principal:bool -> rigid ->
+  ?naming:Misctypes.intro_pattern_naming_expr ->
+  ?principal:bool -> ?hypnaming:naming_mode -> rigid ->
   evar_map * (constr * Sorts.t)
 
 val e_new_type_evar : env -> evar_map ref ->
   ?src:Evar_kinds.t Loc.located -> ?filter:Filter.t ->
-  ?naming:Misctypes.intro_pattern_naming_expr -> ?principal:bool -> rigid -> constr * Sorts.t
+  ?naming:Misctypes.intro_pattern_naming_expr ->
+  ?principal:bool -> ?hypnaming:naming_mode -> rigid -> constr * Sorts.t
 
 val new_Type : ?rigid:rigid -> env -> evar_map -> evar_map * constr
 val e_new_Type : ?rigid:rigid -> env -> evar_map ref -> constr
@@ -240,10 +248,11 @@ val csubst_subst : csubst -> constr -> constr
 type ext_named_context =
   csubst * Id.Set.t * named_context
 
-val push_rel_decl_to_named_context :
+val push_rel_decl_to_named_context : ?hypnaming:naming_mode ->
   evar_map -> rel_declaration -> ext_named_context -> ext_named_context
 
-val push_rel_context_to_named_context : Environ.env -> evar_map -> types ->
+val push_rel_context_to_named_context : ?hypnaming:naming_mode ->
+  Environ.env -> evar_map -> types ->
   named_context_val * types * constr list * csubst
 
 val generalize_evar_over_rels : evar_map -> existential -> types * constr list


### PR DESCRIPTION
The question of how to name the hypotheses of the context of an evar is difficult: what to do in case of a clash, what to do in case of an anonymous variable, and the strategy to use may vary depending on needs.

In particular, what motivated me here is the readibility of unification error messages, as in
https://coq.inria.fr/bugs/show_bug.cgi?id=5107, where the message is:

```
The term
 "dlet yss0 := yss in
 let
 '(_, x) as x := xss0 : T * T return (?T@{xss0:=xss; yss0:=yss; xss:=xss0; 
x0:=x} yss0) in
  (x, x) : T * T" has type "?T@{xss0:=xss; yss0:=yss; xss:=xss0; x0:=xss0} yss"
while it is expected to have type "?P xss0".
```

while I would have expected either `@{xss:=xss; yss:=yss; xss0:=xss0; x0:=xss0}` or `@{xss0:=xss0; yss0:=yss0; xss:=xss; x0:=xss}` (knowing that there is a heuristic which avoid printing bindings when the instance has the same name as the hypothesis). Indeed, the mismatch comes from an inconsistency between the renaming done in printing error messages (there, `x:T, x:T` is renamed into `x:T, x0:T`) and the renaming done at evar creation (there, `x:T, x:T` is renamed into `x0:T, x:T`, the latter being motivated by an easier transition for the new "refine").

This commit adds support for different naming strategies, which does not mean that it will be easy to find the right mode for the right purpose, because there are so many places creating evars, but at least, one step is done.

Three modes are currently supported to deal with clashes:
- Failing in case of clash
- Renaming the most recent one (as in up to 8.4)
- Renaming the previous hypothesis of same name

I also made the old mode active by default, but if this PR is ok, then the idea would be that the creation of evars made by `refine` uses the "renaming the previous hypothesis" mode, as it is so in 8.5.
