### PR TITLE
Fix bug #4874

### DIFF
--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -147,17 +147,8 @@ let extern_evar loc n l = CEvar (loc,n,l)
     For instance, in the debugger the tables of global references
     may be inaccurate *)
 
-let safe_shortest_qualid_of_global vars r =
-  try shortest_qualid_of_global vars r
-  with Not_found ->
-    match r with
-    | VarRef v -> make_qualid DirPath.empty v
-    | ConstRef c -> make_qualid DirPath.empty Names.(Label.to_id (con_label c))
-    | IndRef (i,_) | ConstructRef ((i,_),_) ->
-        make_qualid DirPath.empty Names.(Label.to_id (mind_label i))
-
 let default_extern_reference loc vars r =
-  Qualid (loc,safe_shortest_qualid_of_global vars r)
+  Qualid (loc,shortest_qualid_of_global vars r)
 
 let my_extern_reference = ref default_extern_reference
 


### PR DESCRIPTION
[The bug](https://coq.inria.fr/bugs/show_bug.cgi?id=4874) was coming from two problems:

1) The references `Top.M2.t` and `Top.M2.M.t` cannot be found by `Globrevtab.find`.
2) The fallback printer used does not qualify the names at all.

This fixes the second problem. Now, the error message contains the reference names, fully qualified.
This goes back to the behavior of 8.4.

@gares Maybe reverting is too much. Can you explain what this commit was for and if it's still useful?
