### PR TITLE
Scoped options

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -24,6 +24,14 @@ Specification language
   "fun '(a,b) => ...", "λ '(a,(b,c)), ...", "Definition foo '(x,y) := ...".
   It expands into a "let 'pattern := ..."
 
+Vernacular commands
+
+- Setting and unsetting of options without any Local / Global qualifier now
+  survive module closing, and are activated when the corresponding module is
+  imported. An easy transition path is to systematically replace every call to
+  Set / Unset by a corresponding Local Set / Local Unset command, e.g. using
+  a textual replacement tool.
+
 Tactics
 
 - Flag "Bracketing Last Introduction Pattern" is now on by default.

--- a/library/goptions.ml
+++ b/library/goptions.ml
@@ -261,16 +261,23 @@ let declare_option cast uncast append
         match m with
         | OptSet -> write v
         | OptAppend -> write (append (read ()) v) in
-      let load_options i o = cache_options o in
+      let load_options i (_, (l, _, _) as o) = match l with
+      | OptGlobal -> cache_options o
+      | _ -> ()
+      in
+      let open_options i o = if Int.equal i 1 then cache_options o in
       let subst_options (subst,obj) = obj in
       let discharge_options (_,(l,_,_ as o)) =
         match l with OptLocal -> None | _ -> Some o in
-      let classify_options (l,_,_ as o) =
-        match l with OptGlobal -> Substitute o | _ -> Dispose in
+      let classify_options (l,_,_ as o) = match l with
+      | OptGlobal | OptDefault -> Substitute o
+      | OptLocal -> Dispose
+      in
       let options : option_locality * option_mod * _ -> obj =
         declare_object
           { (default_object (nickname key)) with
             load_function = load_options;
+            open_function = open_options;
             cache_function = cache_options;
             subst_function = subst_options;
             discharge_function = discharge_options;

--- a/plugins/extraction/CHANGES
+++ b/plugins/extraction/CHANGES
@@ -210,14 +210,14 @@ http://www.lri.fr/~letouzey/extraction
 
 * Syntax changes, see Documentation for more details: 
 
-Set/Unset Extraction Optimize. 
+Local Set/Unset Extraction Optimize. 
 
 Default is Set. This control all optimizations made on the ML terms 
 (mostly reduction of dummy beta/iota redexes, but also simplications on 
 Cases, etc). Put this option to Unset if you what a ML term as close as 
 possible to the Coq term.
 
-Set/Unset Extraction AutoInline. 
+Local Set/Unset Extraction AutoInline. 
 
 Default in Set, so by default, the extraction mechanism feels free to 
 inline the bodies of some defined constants, according to some heuristics 

--- a/plugins/micromega/Env.v
+++ b/plugins/micromega/Env.v
@@ -13,7 +13,7 @@
 (************************************************************************)
 
 Require Import BinInt List.
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 Local Open Scope positive_scope.
 
 Section S.

--- a/plugins/micromega/EnvRing.v
+++ b/plugins/micromega/EnvRing.v
@@ -10,7 +10,7 @@
    I have modified the code to use binary trees -- logarithmic access.  *)
 
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 Require Import Setoid Morphisms Env BinPos BinNat BinInt.
 Require Export Ring_theory.
 

--- a/plugins/micromega/OrderedRing.v
+++ b/plugins/micromega/OrderedRing.v
@@ -13,7 +13,7 @@ Require Import Ring.
 
 (** Generic properties of ordered rings on a setoid equality *)
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 Module Import OrderedRingSyntax.
 Export RingSyntax.

--- a/plugins/micromega/Refl.v
+++ b/plugins/micromega/Refl.v
@@ -16,7 +16,7 @@
 Require Import List.
 Require Setoid.
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 (* Refl of '->' '/\': basic properties *)
 

--- a/plugins/micromega/RingMicromega.v
+++ b/plugins/micromega/RingMicromega.v
@@ -20,7 +20,7 @@ Require Import Bool.
 Require Import OrderedRing.
 Require Import Refl.
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 Import OrderedRingSyntax.
 

--- a/plugins/micromega/Tauto.v
+++ b/plugins/micromega/Tauto.v
@@ -16,7 +16,7 @@ Require Import List.
 Require Import Refl.
 Require Import Bool.
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 
   Inductive BFormula (A:Type) : Type :=

--- a/plugins/micromega/VarMap.v
+++ b/plugins/micromega/VarMap.v
@@ -16,7 +16,7 @@
 Require Import ZArith.
 Require Import Coq.Arith.Max.
 Require Import List.
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 (* 
  * This adds a Leaf constructor to the varmap data structure (plugins/quote/Quote.v)

--- a/plugins/micromega/ZCoeff.v
+++ b/plugins/micromega/ZCoeff.v
@@ -16,7 +16,7 @@ Require Import Setoid.
 
 Import OrderedRingSyntax.
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 Section InitialMorphism.
 

--- a/plugins/quote/Quote.v
+++ b/plugins/quote/Quote.v
@@ -25,7 +25,7 @@ Declare ML Module "quote_plugin".
 
 ***********************************************************************)
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 Section variables_map.
 
@@ -81,4 +81,4 @@ Qed.
 
 End variables_map.
 
-Unset Implicit Arguments.
+Local Unset Implicit Arguments.

--- a/plugins/romega/ReflOmegaCore.v
+++ b/plugins/romega/ReflOmegaCore.v
@@ -1287,7 +1287,7 @@ Qed.
 
 (* Extraire une hypothèse de la liste *)
 Definition nth_hyps (n : nat) (l : hyps) := nth n l TrueTerm.
-Unset Printing Notations.
+Local Unset Printing Notations.
 Theorem nth_valid :
  forall (ep : list Prop) (e : list int) (i : nat) (l : hyps),
  interp_hyps ep e l -> interp_proposition ep e (nth_hyps i l).

--- a/plugins/setoid_ring/ArithRing.v
+++ b/plugins/setoid_ring/ArithRing.v
@@ -10,7 +10,7 @@ Require Import Mult.
 Require Import BinNat.
 Require Import Nnat.
 Require Export Ring.
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 Lemma natSRth : semi_ring_theory O (S O) plus mult (@eq nat).
  Proof.

--- a/plugins/setoid_ring/BinList.v
+++ b/plugins/setoid_ring/BinList.v
@@ -8,7 +8,7 @@
 
 Require Import BinPos.
 Require Export List.
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 Local Open Scope positive_scope.
 
 Section MakeBinList.

--- a/plugins/setoid_ring/Field_theory.v
+++ b/plugins/setoid_ring/Field_theory.v
@@ -9,7 +9,7 @@
 Require Ring.
 Import Ring_polynom Ring_tac Ring_theory InitialRing Setoid List Morphisms.
 Require Import ZArith_base.
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 (* Set Universe Polymorphism. *)
 
 Section MakeFieldPol.

--- a/plugins/setoid_ring/InitialRing.v
+++ b/plugins/setoid_ring/InitialRing.v
@@ -14,7 +14,7 @@ Require Import Ring_theory.
 Require Import Ring_polynom.
 Import List.
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 (* Set Universe Polymorphism. *)
 
 Import RingSyntax.

--- a/plugins/setoid_ring/NArithRing.v
+++ b/plugins/setoid_ring/NArithRing.v
@@ -10,7 +10,7 @@ Require Export Ring.
 Require Import BinPos BinNat.
 Import InitialRing.
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 Ltac Ncst t :=
   match isNcst t with

--- a/plugins/setoid_ring/Ncring.v
+++ b/plugins/setoid_ring/Ncring.v
@@ -15,7 +15,7 @@ Require Export Morphisms Setoid Bool.
 Require Export ZArith_base.
 Require Export Algebra_syntax.
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 Class Ring_ops(T:Type)
    {ring0:T}

--- a/plugins/setoid_ring/Ncring_initial.v
+++ b/plugins/setoid_ring/Ncring_initial.v
@@ -19,7 +19,7 @@ Require Import Setoid.
 Require Export Ncring.
 Require Export Ncring_polynom.
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 (* An object to return when an expression is not recognized as a constant *)
 Definition NotConstant := false.

--- a/plugins/setoid_ring/Ncring_polynom.v
+++ b/plugins/setoid_ring/Ncring_polynom.v
@@ -8,7 +8,7 @@
 
 (*  A <X1,...,Xn>: non commutative polynomials on a commutative ring A *)
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 Require Import Setoid.
 Require Import BinList.
 Require Import BinPos.

--- a/plugins/setoid_ring/Ncring_tac.v
+++ b/plugins/setoid_ring/Ncring_tac.v
@@ -19,7 +19,7 @@ Require Import Ncring_polynom.
 Require Import Ncring_initial.
 
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 Class nth (R:Type) (t:R) (l:list R) (i:nat).
 
@@ -125,7 +125,7 @@ Definition list_reifyl (R:Type) lexpr lvar lterm
  {_:reifylist (Rr:= Rr) lexpr lvar lterm}
  `{closed (T:=R) lvar}  := (lvar,lexpr).
 
-Unset Implicit Arguments.
+Local Unset Implicit Arguments.
 
 Ltac lterm_goal g :=
   match g with

--- a/plugins/setoid_ring/Ring_polynom.v
+++ b/plugins/setoid_ring/Ring_polynom.v
@@ -7,7 +7,7 @@
 (************************************************************************)
 
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 Require Import Setoid Morphisms. 
 Require Import BinList BinPos BinNat BinInt.
 Require Export Ring_theory.

--- a/plugins/setoid_ring/Ring_tac.v
+++ b/plugins/setoid_ring/Ring_tac.v
@@ -1,4 +1,4 @@
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 Require Import Setoid.
 Require Import BinPos.
 Require Import Ring_polynom.

--- a/plugins/setoid_ring/Ring_theory.v
+++ b/plugins/setoid_ring/Ring_theory.v
@@ -8,7 +8,7 @@
 
 Require Import Setoid Morphisms BinPos BinNat.
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 Module RingSyntax.
 Reserved Notation "x ?=! y" (at level 70, no associativity).

--- a/plugins/setoid_ring/ZArithRing.v
+++ b/plugins/setoid_ring/ZArithRing.v
@@ -12,7 +12,7 @@ Require Import Zpow_def.
 
 Import InitialRing.
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 Ltac Zcst t :=
   match isZcst t with

--- a/test-suite/bugs/closed/3330.v
+++ b/test-suite/bugs/closed/3330.v
@@ -1,7 +1,7 @@
-Unset Strict Universe Declaration.
+Local Unset Strict Universe Declaration.
 Require Import TestSuite.admit.
 (* File reduced by coq-bug-finder from original input, then from 12106 lines to 1070 lines *)
-Set Universe Polymorphism.
+Local Set Universe Polymorphism.
 Definition setleq (A : Type@{i}) (B : Type@{j}) := A : Type@{j}.
 
 Inductive foo : Type@{l} := bar : foo . 
@@ -149,9 +149,9 @@ Module Export HoTT.
 Module Export categories.
 Module Export Category.
 Module Export Core.
-Set Universe Polymorphism.
+Local Set Universe Polymorphism.
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 Delimit Scope morphism_scope with morphism.
 
 Delimit Scope category_scope with category.
@@ -292,9 +292,9 @@ Module Export HoTT.
 Module Export categories.
 Module Export Functor.
 Module Export Core.
-Set Universe Polymorphism.
+Local Set Universe Polymorphism.
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 Delimit Scope functor_scope with functor.
 
 Local Open Scope morphism_scope.
@@ -341,7 +341,7 @@ Module Export HoTT.
 Module Export categories.
 Module Export Category.
 Module Export Morphisms.
-Set Universe Polymorphism.
+Local Set Universe Polymorphism.
 
 Local Open Scope morphism_scope.
 
@@ -379,7 +379,7 @@ Module Export HoTT.
 Module Export categories.
 Module Export Category.
 Module Export Dual.
-Set Universe Polymorphism.
+Local Set Universe Polymorphism.
 
 Local Open Scope morphism_scope.
 
@@ -420,9 +420,9 @@ Module Export categories.
 Module Export Functor.
 Module Export Composition.
 Module Export Core.
-Set Universe Polymorphism.
+Local Set Universe Polymorphism.
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 Local Open Scope morphism_scope.
 
 Section composition.
@@ -486,9 +486,9 @@ Module Export HoTT.
 Module Export categories.
 Module Export Functor.
 Module Export Dual.
-Set Universe Polymorphism.
+Local Set Universe Polymorphism.
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 Section opposite.
 
@@ -522,7 +522,7 @@ Module Export HoTT.
 Module Export categories.
 Module Export Functor.
 Module Export Identity.
-Set Universe Polymorphism.
+Local Set Universe Polymorphism.
 
 Section identity.
 
@@ -553,9 +553,9 @@ Module Export HoTT.
 Module Export categories.
 Module Export NaturalTransformation.
 Module Export Core.
-Set Universe Polymorphism.
+Local Set Universe Polymorphism.
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 Local Open Scope morphism_scope.
 
 Section NaturalTransformation.
@@ -591,7 +591,7 @@ Module Export HoTT.
 Module Export categories.
 Module Export NaturalTransformation.
 Module Export Dual.
-Set Universe Polymorphism.
+Local Set Universe Polymorphism.
 
 Section opposite.
 
@@ -627,7 +627,7 @@ Module Export Category.
 Module Export Strict.
 
 Export Category.Core.
-Set Universe Polymorphism.
+Local Set Universe Polymorphism.
 
 End Strict.
 
@@ -643,7 +643,7 @@ Module Export HoTT.
 Module Export categories.
 Module Export Category.
 Module Export Prod.
-Set Universe Polymorphism.
+Local Set Universe Polymorphism.
 
 Local Open Scope morphism_scope.
 
@@ -679,9 +679,9 @@ End HoTT.
 
 Module Functor.
 Module Export Prod.
-Set Universe Polymorphism.
+Local Set Universe Polymorphism.
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 Local Open Scope morphism_scope.
 
 Section proj.
@@ -750,9 +750,9 @@ Module categories.
 Module Export NaturalTransformation.
 Module Export Composition.
 Module Export Core.
-Set Universe Polymorphism.
+Local Set Universe Polymorphism.
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 Local Open Scope path_scope.
 
 Local Open Scope morphism_scope.
@@ -805,7 +805,7 @@ End NaturalTransformation.
 
 End categories.
 
-Set Universe Polymorphism.
+Local Set Universe Polymorphism.
 
 Section path_natural_transformation.
 
@@ -849,9 +849,9 @@ Ltac path_natural_transformation :=
          end.
 
 Module Export Identity.
-Set Universe Polymorphism.
+Local Set Universe Polymorphism.
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 Local Open Scope morphism_scope.
 
 Local Open Scope path_scope.
@@ -909,7 +909,7 @@ End Identity.
 
 Module Export Laws.
 Import HoTT_DOT_categories_DOT_NaturalTransformation_DOT_Composition_DOT_Core.HoTT.categories.
-Set Universe Polymorphism.
+Local Set Universe Polymorphism.
 
 Local Open Scope natural_transformation_scope.
 Section natural_transformation_identity.
@@ -958,7 +958,7 @@ End Laws.
 Module Export FunctorCategory.
 Module Export Core.
 Import HoTT_DOT_categories_DOT_NaturalTransformation_DOT_Composition_DOT_Core.HoTT.categories.
-Set Universe Polymorphism.
+Local Set Universe Polymorphism.
 
 Section functor_category.
 
@@ -987,9 +987,9 @@ End Core.
 End FunctorCategory.
 
 Module Export Morphisms.
-Set Universe Polymorphism.
+Local Set Universe Polymorphism.
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 Definition NaturalIsomorphism `{Funext} (C D : PreCategory) F G :=
   @Isomorphic (C -> D) F G.
@@ -1007,7 +1007,7 @@ Global Existing Instance iss.
 End HSet.
 
 Module Export Core.
-Set Universe Polymorphism.
+Local Set Universe Polymorphism.
 
 Notation cat_of obj :=
   (@Build_PreCategory obj
@@ -1020,7 +1020,7 @@ Notation cat_of obj :=
                       _).
 
 Definition set_cat `{Funext} : PreCategory := cat_of hSet.
-Set Universe Polymorphism.
+Local Set Universe Polymorphism.
 
 Local Open Scope morphism_scope.
 
@@ -1051,13 +1051,13 @@ Section hom_functor.
     simpl; admit.
   Defined.
 End hom_functor.
-Set Universe Polymorphism.
+Local Set Universe Polymorphism.
 
 Import Category.Dual Functor.Dual.
 Import Category.Prod Functor.Prod.
 Import Functor.Composition.Core.
 Import Functor.Identity.
-Set Universe Polymorphism.
+Local Set Universe Polymorphism.
 
 Local Open Scope functor_scope.
 Local Open Scope natural_transformation_scope.

--- a/test-suite/bugs/closed/4089.v
+++ b/test-suite/bugs/closed/4089.v
@@ -1,4 +1,4 @@
-Unset Strict Universe Declaration.
+Local Unset Strict Universe Declaration.
 Require Import TestSuite.admit.
 (* -*- mode: coq; coq-prog-args: ("-emacs" "-indices-matter") -*- *)
 (* File reduced by coq-bug-finder from original input, then from 6522 lines to 318 lines, then from 1139 lines to 361 lines *)
@@ -9,7 +9,7 @@ Open Scope type_scope.
 Global Set Universe Polymorphism.
 Module Export Datatypes.
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 Record prod (A B : Type) := pair { fst : A ; snd : B }.
 
@@ -19,7 +19,7 @@ Notation "( x , y , .. , z )" := (pair .. (pair x y) .. z) : core_scope.
 End Datatypes.
 Module Export Specif.
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 Record sig {A} (P : A -> Type) := exist { proj1_sig : A ; proj2_sig : P proj1_sig }.
 

--- a/test-suite/bugs/closed/4527.v
+++ b/test-suite/bugs/closed/4527.v
@@ -20,7 +20,7 @@ Inductive True : Type :=
   I : True.
 Module Export Datatypes.
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 Notation nat := Coq.Init.Datatypes.nat.
 Notation S := Coq.Init.Datatypes.S.
 
@@ -33,7 +33,7 @@ Open Scope nat_scope.
 End Datatypes.
 Module Export Specif.
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 Record sig {A} (P : A -> Type) := exist { proj1_sig : A ; proj2_sig : P 
 proj1_sig }.

--- a/test-suite/bugs/closed/4533.v
+++ b/test-suite/bugs/closed/4533.v
@@ -14,7 +14,7 @@ Global Set Universe Polymorphism.
 Global Set Primitive Projections.
 Notation "A -> B" := (forall (_ : A), B) : type_scope.
 Module Export Datatypes.
-  Set Implicit Arguments.
+  Local Set Implicit Arguments.
   Notation nat := Coq.Init.Datatypes.nat.
   Notation S := Coq.Init.Datatypes.S.
   Record prod (A B : Type) := pair { fst : A ; snd : B }.
@@ -23,7 +23,7 @@ Module Export Datatypes.
   Open Scope nat_scope.
 End Datatypes.
 Module Export Specif.
-  Set Implicit Arguments.
+  Local Set Implicit Arguments.
   Record sig {A} (P : A -> Type) := exist { proj1_sig : A ; proj2_sig : P 
 proj1_sig }.
   Notation sigT := sig (only parsing).

--- a/test-suite/bugs/closed/4544.v
+++ b/test-suite/bugs/closed/4544.v
@@ -26,7 +26,7 @@ Record prod (A B : Type) := pair { fst : A ; snd : B }.
 Notation "x * y" := (prod x y) : type_scope.
 Module Export Specif.
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 Record sig {A} (P : A -> Type) := exist { proj1_sig : A ; proj2_sig : P proj1_sig }.
 Arguments proj1_sig {A P} _ / .

--- a/theories/Arith/PeanoNat.v
+++ b/theories/Arith/PeanoNat.v
@@ -24,7 +24,7 @@ Include Coq.Init.Nat.
 
 (** When including property functors, inline t eq zero one two lt le succ *)
 
-Set Inline Level 50.
+Local Set Inline Level 50.
 
 (** All operations are well-defined (trivial here since eq is Leibniz) *)
 

--- a/theories/Arith/Wf_nat.v
+++ b/theories/Arith/Wf_nat.v
@@ -205,7 +205,7 @@ Qed.
 (** A constructive proof that any non empty decidable subset of
     natural numbers has a least element *)
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 Require Import Le.
 Require Import Compare_dec.
@@ -235,6 +235,6 @@ Proof.
    intros n' (HPn',Hn'); apply Nat.le_antisymm; auto.
 Qed.
 
-Unset Implicit Arguments.
+Local Unset Implicit Arguments.
 
 Notation iter_nat n A f x := (nat_rect (fun _ => A) x (fun _ => f) n) (only parsing).

--- a/theories/Bool/DecBool.v
+++ b/theories/Bool/DecBool.v
@@ -6,7 +6,7 @@
 (*         *       GNU Lesser General Public License Version 2.1        *)
 (************************************************************************)
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 Definition ifdec (A B:Prop) (C:Type) (H:{A} + {B}) (x y:C) : C :=
   if H then x else y.
@@ -28,4 +28,4 @@ Proof.
   intro; absurd A; trivial.
 Qed.
 
-Unset Implicit Arguments.
+Local Unset Implicit Arguments.

--- a/theories/Classes/CEquivalence.v
+++ b/theories/Classes/CEquivalence.v
@@ -20,8 +20,8 @@ Require Import Relation_Definitions.
 Require Export Coq.Classes.CRelationClasses.
 Require Import Coq.Classes.CMorphisms.
 
-Set Implicit Arguments.
-Unset Strict Implicit.
+Local Set Implicit Arguments.
+Local Unset Strict Implicit.
 
 Generalizable Variables A R eqA B S eqB.
 Local Obligation Tactic := try solve [simpl_crelation].

--- a/theories/Classes/CMorphisms.v
+++ b/theories/Classes/CMorphisms.v
@@ -20,7 +20,7 @@ Require Export Coq.Classes.CRelationClasses.
 Generalizable Variables A eqA B C D R RA RB RC m f x y.
 Local Obligation Tactic := simpl_crelation.
 
-Set Universe Polymorphism.
+Local Set Universe Polymorphism.
 
 (** * Morphisms.
 
@@ -266,7 +266,7 @@ Section GenericInstances.
     transitivity (y x0)...
   Qed.
 
-  Unset Strict Universe Declaration.
+  Local Unset Strict Universe Declaration.
   
   (** The complement of a crelation conserves its proper elements. *)
  

--- a/theories/Classes/CRelationClasses.v
+++ b/theories/Classes/CRelationClasses.v
@@ -21,7 +21,7 @@ Require Import Coq.Program.Tactics.
 
 Generalizable Variables A B C D R S T U l eqA eqB eqC eqD.
 
-Set Universe Polymorphism.
+Local Set Universe Polymorphism.
 
 Definition crelation (A : Type) := A -> A -> Type.
 
@@ -215,7 +215,7 @@ Hint Extern 4 (subrelation (flip _) _) =>
 
 Hint Resolve irreflexivity : ord.
 
-Unset Implicit Arguments.
+Local Unset Implicit Arguments.
 
 (** A HintDb for crelations. *)
 
@@ -306,7 +306,7 @@ Section Binary.
   
   (** Relation equivalence is an equivalence, and subrelation defines a partial order. *)
   
-  Set Automatic Introduction.
+  Local Set Automatic Introduction.
   
   Global Instance relation_equivalence_equivalence :
     Equivalence relation_equivalence.

--- a/theories/Classes/Equivalence.v
+++ b/theories/Classes/Equivalence.v
@@ -20,8 +20,8 @@ Require Import Relation_Definitions.
 Require Export Coq.Classes.RelationClasses.
 Require Import Coq.Classes.Morphisms.
 
-Set Implicit Arguments.
-Unset Strict Implicit.
+Local Set Implicit Arguments.
+Local Unset Strict Implicit.
 
 Generalizable Variables A R eqA B S eqB.
 Local Obligation Tactic := try solve [simpl_relation].

--- a/theories/Classes/RelationClasses.v
+++ b/theories/Classes/RelationClasses.v
@@ -215,7 +215,7 @@ Arguments Antisymmetric A eqA {_} _.
 
 Hint Resolve irreflexivity : ord.
 
-Unset Implicit Arguments.
+Local Unset Implicit Arguments.
 
 (** A HintDb for relations. *)
 
@@ -434,7 +434,7 @@ Section Binary.
   
   (** Relation equivalence is an equivalence, and subrelation defines a partial order. *)
   
-  Set Automatic Introduction.
+  Local Set Automatic Introduction.
   
   Global Instance relation_equivalence_equivalence :
     Equivalence relation_equivalence.

--- a/theories/Classes/SetoidClass.v
+++ b/theories/Classes/SetoidClass.v
@@ -12,8 +12,8 @@
    Institution: LRI, CNRS UMR 8623 - University Paris Sud
 *)
 
-Set Implicit Arguments.
-Unset Strict Implicit.
+Local Set Implicit Arguments.
+Local Unset Strict Implicit.
 
 Generalizable Variables A.
 

--- a/theories/Classes/SetoidDec.v
+++ b/theories/Classes/SetoidDec.v
@@ -13,8 +13,8 @@
    Institution: LRI, CNRS UMR 8623 - University Paris Sud
 *)
 
-Set Implicit Arguments.
-Unset Strict Implicit.
+Local Set Implicit Arguments.
+Local Unset Strict Implicit.
 
 Generalizable Variables A B .
 

--- a/theories/Classes/SetoidTactics.v
+++ b/theories/Classes/SetoidTactics.v
@@ -21,8 +21,8 @@ Generalizable Variables A R.
 
 Export ProperNotations.
 
-Set Implicit Arguments.
-Unset Strict Implicit.
+Local Set Implicit Arguments.
+Local Unset Strict Implicit.
 
 (** Default relation on a given support. Can be used by tactics
    to find a sensible default relation on any carrier. Users can

--- a/theories/Compat/Coq84.v
+++ b/theories/Compat/Coq84.v
@@ -82,4 +82,4 @@ Notation "[ x ; .. ; y ]" := (VectorDef.cons _ x _ .. (VectorDef.cons _ y _ (nil
 
 (** In 8.4, the statement of admitted lemmas did not depend on the section
     variables. *)
-Unset Keep Admitted Variables.
+Local Unset Keep Admitted Variables.

--- a/theories/FSets/FMapAVL.v
+++ b/theories/FSets/FMapAVL.v
@@ -18,8 +18,8 @@
 
 Require Import FMapInterface FMapList ZArith Int.
 
-Set Implicit Arguments.
-Unset Strict Implicit.
+Local Set Implicit Arguments.
+Local Unset Strict Implicit.
 
 (** Notations and helper lemma about pairs *)
 

--- a/theories/FSets/FMapFacts.v
+++ b/theories/FSets/FMapFacts.v
@@ -15,8 +15,8 @@
 
 Require Import Bool DecidableType DecidableTypeEx OrderedType Morphisms.
 Require Export FMapInterface.
-Set Implicit Arguments.
-Unset Strict Implicit.
+Local Set Implicit Arguments.
+Local Unset Strict Implicit.
 
 Hint Extern 1 (Equivalence _) => constructor; congruence.
 

--- a/theories/FSets/FMapFullAVL.v
+++ b/theories/FSets/FMapFullAVL.v
@@ -27,8 +27,8 @@
 
 Require Import Recdef FMapInterface FMapList ZArith Int FMapAVL ROmega.
 
-Set Implicit Arguments.
-Unset Strict Implicit.
+Local Set Implicit Arguments.
+Local Unset Strict Implicit.
 
 Module AvlProofs (Import I:Int)(X: OrderedType).
 Module Import Raw := Raw I X.

--- a/theories/FSets/FMapInterface.v
+++ b/theories/FSets/FMapInterface.v
@@ -11,8 +11,8 @@
 (** This file proposes interfaces for finite maps *)
 
 Require Export Bool DecidableType OrderedType.
-Set Implicit Arguments.
-Unset Strict Implicit.
+Local Set Implicit Arguments.
+Local Unset Strict Implicit.
 
 (** When compared with Ocaml Map, this signature has been split in
     several parts :

--- a/theories/FSets/FMapList.v
+++ b/theories/FSets/FMapList.v
@@ -14,8 +14,8 @@
 
 Require Import FMapInterface.
 
-Set Implicit Arguments.
-Unset Strict Implicit.
+Local Set Implicit Arguments.
+Local Unset Strict Implicit.
 
 Module Raw (X:OrderedType).
 

--- a/theories/FSets/FMapPositive.v
+++ b/theories/FSets/FMapPositive.v
@@ -10,7 +10,7 @@
 
 Require Import Bool OrderedType ZArith OrderedType OrderedTypeEx FMapInterface.
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 Local Open Scope positive_scope.
 Local Unset Elimination Schemes.
 

--- a/theories/FSets/FMapWeakList.v
+++ b/theories/FSets/FMapWeakList.v
@@ -13,8 +13,8 @@
 
 Require Import FMapInterface.
 
-Set Implicit Arguments.
-Unset Strict Implicit.
+Local Set Implicit Arguments.
+Local Unset Strict Implicit.
 
 Module Raw (X:DecidableType).
 

--- a/theories/FSets/FSetAVL.v
+++ b/theories/FSets/FSetAVL.v
@@ -33,8 +33,8 @@
 
 Require Import FSetInterface ZArith Int.
 
-Set Implicit Arguments.
-Unset Strict Implicit.
+Local Set Implicit Arguments.
+Local Unset Strict Implicit.
 
 (** This is just a compatibility layer, the real implementation
     is now in [MSetAVL] *)

--- a/theories/FSets/FSetBridge.v
+++ b/theories/FSets/FSetBridge.v
@@ -12,9 +12,9 @@
     to/from non-dependent set signature. *)
 
 Require Export FSetInterface.
-Set Implicit Arguments.
-Unset Strict Implicit.
-Set Firstorder Depth 2.
+Local Set Implicit Arguments.
+Local Unset Strict Implicit.
+Local Set Firstorder Depth 2.
 
 (** * From non-dependent signature [S] to dependent signature [Sdep]. *)
 

--- a/theories/FSets/FSetCompat.v
+++ b/theories/FSets/FSetCompat.v
@@ -9,8 +9,8 @@
 (** * Compatibility functors between FSetInterface and MSetInterface. *)
 
 Require Import FSetInterface FSetFacts MSetInterface MSetFacts.
-Set Implicit Arguments.
-Unset Strict Implicit.
+Local Set Implicit Arguments.
+Local Unset Strict Implicit.
 
 (** * From new Weak Sets to old ones *)
 

--- a/theories/FSets/FSetFacts.v
+++ b/theories/FSets/FSetFacts.v
@@ -16,8 +16,8 @@
 
 Require Import DecidableTypeEx.
 Require Export FSetInterface.
-Set Implicit Arguments.
-Unset Strict Implicit.
+Local Set Implicit Arguments.
+Local Unset Strict Implicit.
 
 (** First, a functor for Weak Sets in functorial version. *)
 

--- a/theories/FSets/FSetInterface.v
+++ b/theories/FSets/FSetInterface.v
@@ -27,8 +27,8 @@
 *)
 
 Require Export Bool OrderedType DecidableType.
-Set Implicit Arguments.
-Unset Strict Implicit.
+Local Set Implicit Arguments.
+Local Unset Strict Implicit.
 
 (** * Non-dependent signatures
 

--- a/theories/FSets/FSetList.v
+++ b/theories/FSets/FSetList.v
@@ -12,8 +12,8 @@
     interface [FSetInterface.S] using strictly ordered list. *)
 
 Require Export FSetInterface.
-Set Implicit Arguments.
-Unset Strict Implicit.
+Local Set Implicit Arguments.
+Local Unset Strict Implicit.
 
 (** This is just a compatibility layer, the real implementation
     is now in [MSetList] *)

--- a/theories/FSets/FSetPositive.v
+++ b/theories/FSets/FSetPositive.v
@@ -18,7 +18,7 @@
 
 Require Import Bool BinPos OrderedType OrderedTypeEx FSetInterface.
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 Local Open Scope lazy_bool_scope.
 Local Open Scope positive_scope.
 Local Unset Elimination Schemes.

--- a/theories/FSets/FSetProperties.v
+++ b/theories/FSets/FSetProperties.v
@@ -16,8 +16,8 @@
 
 Require Export FSetInterface.
 Require Import DecidableTypeEx FSetFacts FSetDecide.
-Set Implicit Arguments.
-Unset Strict Implicit.
+Local Set Implicit Arguments.
+Local Unset Strict Implicit.
 
 Hint Unfold transpose compat_op Proper respectful.
 Hint Extern 1 (Equivalence _) => constructor; congruence.

--- a/theories/FSets/FSetWeakList.v
+++ b/theories/FSets/FSetWeakList.v
@@ -12,8 +12,8 @@
     interface [FSetInterface.WS] using lists without redundancy. *)
 
 Require Import FSetInterface.
-Set Implicit Arguments.
-Unset Strict Implicit.
+Local Set Implicit Arguments.
+Local Unset Strict Implicit.
 
 (** This is just a compatibility layer, the real implementation
     is now in [MSetWeakList] *)

--- a/theories/Init/Datatypes.v
+++ b/theories/Init/Datatypes.v
@@ -6,7 +6,7 @@
 (*         *       GNU Lesser General Public License Version 2.1        *)
 (************************************************************************)
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 Require Import Notations.
 Require Import Logic.

--- a/theories/Init/Logic.v
+++ b/theories/Init/Logic.v
@@ -6,7 +6,7 @@
 (*         *       GNU Lesser General Public License Version 2.1        *)
 (************************************************************************)
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 Require Export Notations.
 

--- a/theories/Init/Logic_Type.v
+++ b/theories/Init/Logic_Type.v
@@ -9,7 +9,7 @@
 (** This module defines type constructors for types in [Type]
     ([Datatypes.v] and [Logic.v] defined them for types in [Set]) *)
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 Require Import Datatypes.
 Require Export Logic.

--- a/theories/Init/Specif.v
+++ b/theories/Init/Specif.v
@@ -8,8 +8,8 @@
 
 (** Basic specifications : sets that may contain logical information *)
 
-Set Implicit Arguments.
-Set Reversible Pattern Implicit.
+Local Set Implicit Arguments.
+Local Set Reversible Pattern Implicit.
 
 Require Import Notations.
 Require Import Datatypes.

--- a/theories/Init/Tactics.v
+++ b/theories/Init/Tactics.v
@@ -195,7 +195,7 @@ Ltac now_show c := change c.
 
 (** Support for rewriting decidability statements *)
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 Lemma decide_left : forall (C:Prop) (decide:{C}+{~C}),
   C -> forall P:{C}+{~C}->Prop, (forall H:C, P (left _ H)) -> P decide.

--- a/theories/Init/Wf.v
+++ b/theories/Init/Wf.v
@@ -11,7 +11,7 @@
     - well-founded induction
     from a well-founded ordering on a given set *)
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 Require Import Notations.
 Require Import Logic.

--- a/theories/Lists/List.v
+++ b/theories/Lists/List.v
@@ -9,7 +9,7 @@
 Require Setoid.
 Require Import PeanoNat Le Gt Minus Bool Lt.
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 (* Set Universe Polymorphism. *)
 
 (******************************************************************)

--- a/theories/Lists/ListDec.v
+++ b/theories/Lists/ListDec.v
@@ -9,7 +9,7 @@
 (** Decidability results about lists *)
 
 Require Import List Decidable.
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 Definition decidable_eq A := forall x y:A, decidable (x=y).
 

--- a/theories/Lists/ListSet.v
+++ b/theories/Lists/ListSet.v
@@ -16,7 +16,7 @@
 
 Require Import List.
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 Section first_definitions.
 
@@ -495,4 +495,4 @@ Section other_definitions.
 
 End other_definitions.
 
-Unset Implicit Arguments.
+Local Unset Implicit Arguments.

--- a/theories/Lists/SetoidList.v
+++ b/theories/Lists/SetoidList.v
@@ -9,8 +9,8 @@
 Require Export List.
 Require Export Sorted.
 Require Export Setoid Basics Morphisms.
-Set Implicit Arguments.
-Unset Strict Implicit.
+Local Set Implicit Arguments.
+Local Unset Strict Implicit.
 (* Set Universe Polymorphism. *)
 (** * Logical relations over lists with respect to a setoid equality
       or ordering. *)

--- a/theories/Lists/SetoidPermutation.v
+++ b/theories/Lists/SetoidPermutation.v
@@ -9,8 +9,8 @@
 Require Import Permutation SetoidList.
 (* Set Universe Polymorphism. *)
 
-Set Implicit Arguments.
-Unset Strict Implicit.
+Local Set Implicit Arguments.
+Local Unset Strict Implicit.
 
 (** Permutations of list modulo a setoid equality. *)
 

--- a/theories/Lists/Streams.v
+++ b/theories/Lists/Streams.v
@@ -6,7 +6,7 @@
 (*         *       GNU Lesser General Public License Version 2.1        *)
 (************************************************************************)
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 (** Streams *)
 
@@ -243,4 +243,4 @@ Qed.
 
 End Zip.
 
-Unset Implicit Arguments.
+Local Unset Implicit Arguments.

--- a/theories/Logic/Berardi.v
+++ b/theories/Logic/Berardi.v
@@ -24,7 +24,7 @@
 }
 >> *)
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 Section Berardis_paradox.
 

--- a/theories/Logic/ChoiceFacts.v
+++ b/theories/Logic/ChoiceFacts.v
@@ -88,7 +88,7 @@ Type Theories, Mathematical Logic Quarterly, volume 39, 1993.
 intentional type theory, Journal of Symbolic Logic 70(2):488-514, 2005.
 *)
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 Local Unset Intuition Negation Unfolding.
 
 (**********************************************************************)

--- a/theories/Logic/ClassicalChoice.v
+++ b/theories/Logic/ClassicalChoice.v
@@ -24,7 +24,7 @@ Require Export ClassicalUniqueChoice.
 Require Export RelationalChoice.
 Require Import ChoiceFacts.
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 Definition subset (U:Type) (P Q:U->Prop) : Prop := forall x, P x -> Q x.
 

--- a/theories/Logic/ClassicalDescription.v
+++ b/theories/Logic/ClassicalDescription.v
@@ -14,7 +14,7 @@
     computable functions. It conflicts with the impredicativity of
     [Set] *)
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 Require Export Classical.   (* Axiomatize classical reasoning *)
 Require Export Description. (* Axiomatize constructive form of Church's iota *)
@@ -79,7 +79,7 @@ Qed.
 
 (** Compatibility lemmas *)
 
-Unset Implicit Arguments.
+Local Unset Implicit Arguments.
 
 Definition dependent_description := dependent_unique_choice.
 Definition description := unique_choice.

--- a/theories/Logic/ClassicalEpsilon.v
+++ b/theories/Logic/ClassicalEpsilon.v
@@ -18,7 +18,7 @@
 Require Export Classical.
 Require Import ChoiceFacts.
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 Axiom constructive_indefinite_description :
   forall (A : Type) (P : A->Prop),

--- a/theories/Logic/Description.v
+++ b/theories/Logic/Description.v
@@ -12,7 +12,7 @@
 
 Require Import ChoiceFacts.
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 Axiom constructive_definite_description :
   forall (A : Type) (P : A->Prop),

--- a/theories/Logic/Epsilon.v
+++ b/theories/Logic/Epsilon.v
@@ -11,7 +11,7 @@
 
 Require Import ChoiceFacts.
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 (** Hilbert's epsilon: operator and specification in one statement *)
 

--- a/theories/Logic/EqdepFacts.v
+++ b/theories/Logic/EqdepFacts.v
@@ -166,7 +166,7 @@ Qed.
 
 (** Dependent equality is equivalent to a dependent pair of equalities *)
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 Lemma eq_sigT_sig_eq : forall X P (x1 x2:X) H1 H2, existT P x1 H1 = existT P x2 H2 <->
                                                    {H:x1=x2 | rew H in H1 = H2}.
@@ -221,7 +221,7 @@ Proof.
   reflexivity.
 Defined.
 
-Unset Implicit Arguments.
+Local Unset Implicit Arguments.
 
 (** Exported hints *)
 

--- a/theories/Logic/Eqdep_dec.v
+++ b/theories/Logic/Eqdep_dec.v
@@ -34,7 +34,7 @@ Table of contents:
 (************************************************************************)
 (** * Streicher's K and injectivity of dependent pair hold on decidable types *)
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 (* Set Universe Polymorphism. *)
 
 Section EqdepDec.
@@ -194,7 +194,7 @@ Theorem UIP_dec :
     forall (x y:A) (p1 p2:x = y), p1 = p2.
 Proof (fun A eq_dec => eq_dep_eq__UIP A (eq_dep_eq_dec eq_dec)).
 
-Unset Implicit Arguments.
+Local Unset Implicit Arguments.
 
 (************************************************************************)
 (** ** Definition of the functor that builds properties of dependent equalities on decidable sets in Type *)

--- a/theories/Logic/ExtensionalityFacts.v
+++ b/theories/Logic/ExtensionalityFacts.v
@@ -27,7 +27,7 @@ Table of contents
 
 *)
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 (**********************************************************************)
 (** * Definitions *)

--- a/theories/Logic/FinFun.v
+++ b/theories/Logic/FinFun.v
@@ -12,7 +12,7 @@
     f injective <-> f bijective <-> f surjective. *)
 
 Require Import List Compare_dec EqNat Decidable ListDec. Require Fin.
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 (** General definitions *)
 

--- a/theories/Logic/Hurkens.v
+++ b/theories/Logic/Hurkens.v
@@ -74,7 +74,7 @@
 *)
 
 
-Set Universe Polymorphism.
+Local Set Universe Polymorphism.
 
 (* begin show *)
 
@@ -631,7 +631,7 @@ End NoRetractFromTypeToProp.
 
 Module TypeNeqSmallType.
 
-Unset Universe Polymorphism.
+Local Unset Universe Polymorphism.
 
 Section Paradox.
 

--- a/theories/Logic/IndefiniteDescription.v
+++ b/theories/Logic/IndefiniteDescription.v
@@ -14,7 +14,7 @@
 
 Require Import ChoiceFacts.
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 Axiom constructive_indefinite_description :
   forall (A : Type) (P : A->Prop),

--- a/theories/Logic/JMeq.v
+++ b/theories/Logic/JMeq.v
@@ -15,14 +15,14 @@
 
 *)
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
-Unset Elimination Schemes.
+Local Unset Elimination Schemes.
 
 Inductive JMeq (A:Type) (x:A) : forall B:Type, B -> Prop :=
     JMeq_refl : JMeq x x.
 
-Set Elimination Schemes.
+Local Set Elimination Schemes.
 
 Arguments JMeq_refl {A x} , [A] x.
 

--- a/theories/MSets/MSetAVL.v
+++ b/theories/MSets/MSetAVL.v
@@ -33,8 +33,8 @@
 
 Require Import MSetInterface MSetGenTree BinInt Int.
 
-Set Implicit Arguments.
-Unset Strict Implicit.
+Local Set Implicit Arguments.
+Local Unset Strict Implicit.
 (* for nicer extraction, we create inductive principles
    only when needed *)
 Local Unset Elimination Schemes.

--- a/theories/MSets/MSetFacts.v
+++ b/theories/MSets/MSetFacts.v
@@ -16,8 +16,8 @@
 
 Require Import DecidableTypeEx.
 Require Export MSetInterface.
-Set Implicit Arguments.
-Unset Strict Implicit.
+Local Set Implicit Arguments.
+Local Unset Strict Implicit.
 
 (** First, a functor for Weak Sets in functorial version. *)
 

--- a/theories/MSets/MSetInterface.v
+++ b/theories/MSets/MSetInterface.v
@@ -29,8 +29,8 @@
 
 Require Export Bool SetoidList RelationClasses Morphisms
  RelationPairs Equalities Orders OrdersFacts.
-Set Implicit Arguments.
-Unset Strict Implicit.
+Local Set Implicit Arguments.
+Local Unset Strict Implicit.
 
 Module Type TypElt.
  Parameters t elt : Type.

--- a/theories/MSets/MSetList.v
+++ b/theories/MSets/MSetList.v
@@ -12,8 +12,8 @@
     interface [MSetInterface.S] using strictly ordered list. *)
 
 Require Export MSetInterface OrdersFacts OrdersLists.
-Set Implicit Arguments.
-Unset Strict Implicit.
+Local Set Implicit Arguments.
+Local Unset Strict Implicit.
 
 (** * Functions over lists
 

--- a/theories/MSets/MSetPositive.v
+++ b/theories/MSets/MSetPositive.v
@@ -18,7 +18,7 @@
 
 Require Import Bool BinPos Orders OrdersEx MSetInterface.
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 Local Open Scope lazy_bool_scope.
 Local Open Scope positive_scope.
 Local Unset Elimination Schemes.

--- a/theories/MSets/MSetProperties.v
+++ b/theories/MSets/MSetProperties.v
@@ -16,8 +16,8 @@
 
 Require Export MSetInterface.
 Require Import DecidableTypeEx OrdersLists MSetFacts MSetDecide.
-Set Implicit Arguments.
-Unset Strict Implicit.
+Local Set Implicit Arguments.
+Local Unset Strict Implicit.
 
 Hint Unfold transpose.
 

--- a/theories/MSets/MSetWeakList.v
+++ b/theories/MSets/MSetWeakList.v
@@ -12,8 +12,8 @@
     interface [MSetWeakInterface.S] using lists without redundancy. *)
 
 Require Import MSetInterface.
-Set Implicit Arguments.
-Unset Strict Implicit.
+Local Set Implicit Arguments.
+Local Unset Strict Implicit.
 
 (** * Functions over lists
 

--- a/theories/NArith/BinNat.v
+++ b/theories/NArith/BinNat.v
@@ -38,7 +38,7 @@ Include BinNatDef.N.
 
 (** When including property functors, only inline t eq zero one two *)
 
-Set Inline Level 30.
+Local Set Inline Level 30.
 
 (** Logical predicates *)
 

--- a/theories/Numbers/BinNums.v
+++ b/theories/Numbers/BinNums.v
@@ -8,7 +8,7 @@
 
 (** * Binary Numerical Datatypes *)
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 Declare ML Module "z_syntax_plugin".
 

--- a/theories/Numbers/Cyclic/Abstract/CyclicAxioms.v
+++ b/theories/Numbers/Cyclic/Abstract/CyclicAxioms.v
@@ -13,7 +13,7 @@
 (** This file specifies how to represent [Z/nZ] when [n=2^d],
     [d] being the number of digits of these bounded integers. *)
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 Require Import ZArith.
 Require Import Znumtheory.

--- a/theories/Numbers/Cyclic/DoubleCyclic/DoubleAdd.v
+++ b/theories/Numbers/Cyclic/DoubleCyclic/DoubleAdd.v
@@ -8,7 +8,7 @@
 (*            Benjamin Gregoire, Laurent Thery, INRIA, 2007             *)
 (************************************************************************)
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 Require Import ZArith.
 Require Import BigNumPrelude.

--- a/theories/Numbers/Cyclic/DoubleCyclic/DoubleBase.v
+++ b/theories/Numbers/Cyclic/DoubleCyclic/DoubleBase.v
@@ -8,7 +8,7 @@
 (*            Benjamin Gregoire, Laurent Thery, INRIA, 2007             *)
 (************************************************************************)
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 Require Import ZArith Ndigits.
 Require Import BigNumPrelude.

--- a/theories/Numbers/Cyclic/DoubleCyclic/DoubleCyclic.v
+++ b/theories/Numbers/Cyclic/DoubleCyclic/DoubleCyclic.v
@@ -8,7 +8,7 @@
 (*            Benjamin Gregoire, Laurent Thery, INRIA, 2007             *)
 (************************************************************************)
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 Require Import ZArith.
 Require Import BigNumPrelude.

--- a/theories/Numbers/Cyclic/DoubleCyclic/DoubleDiv.v
+++ b/theories/Numbers/Cyclic/DoubleCyclic/DoubleDiv.v
@@ -8,7 +8,7 @@
 (*         Benjamin Gregoire, Laurent Thery, INRIA, 2007                *)
 (************************************************************************)
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 Require Import ZArith.
 Require Import BigNumPrelude.

--- a/theories/Numbers/Cyclic/DoubleCyclic/DoubleDivn1.v
+++ b/theories/Numbers/Cyclic/DoubleCyclic/DoubleDivn1.v
@@ -8,7 +8,7 @@
 (*            Benjamin Gregoire, Laurent Thery, INRIA, 2007             *)
 (************************************************************************)
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 Require Import ZArith Ndigits.
 Require Import BigNumPrelude.

--- a/theories/Numbers/Cyclic/DoubleCyclic/DoubleLift.v
+++ b/theories/Numbers/Cyclic/DoubleCyclic/DoubleLift.v
@@ -8,7 +8,7 @@
 (*            Benjamin Gregoire, Laurent Thery, INRIA, 2007             *)
 (************************************************************************)
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 Require Import ZArith.
 Require Import BigNumPrelude.

--- a/theories/Numbers/Cyclic/DoubleCyclic/DoubleMul.v
+++ b/theories/Numbers/Cyclic/DoubleCyclic/DoubleMul.v
@@ -8,7 +8,7 @@
 (*            Benjamin Gregoire, Laurent Thery, INRIA, 2007             *)
 (************************************************************************)
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 Require Import ZArith.
 Require Import BigNumPrelude.

--- a/theories/Numbers/Cyclic/DoubleCyclic/DoubleSqrt.v
+++ b/theories/Numbers/Cyclic/DoubleCyclic/DoubleSqrt.v
@@ -8,7 +8,7 @@
 (*            Benjamin Gregoire, Laurent Thery, INRIA, 2007             *)
 (************************************************************************)
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 Require Import ZArith.
 Require Import BigNumPrelude.

--- a/theories/Numbers/Cyclic/DoubleCyclic/DoubleSub.v
+++ b/theories/Numbers/Cyclic/DoubleCyclic/DoubleSub.v
@@ -9,7 +9,7 @@
 (*            Benjamin Gregoire, Laurent Thery, INRIA, 2007             *)
 (************************************************************************)
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 Require Import ZArith.
 Require Import BigNumPrelude.

--- a/theories/Numbers/Cyclic/DoubleCyclic/DoubleType.v
+++ b/theories/Numbers/Cyclic/DoubleCyclic/DoubleType.v
@@ -8,7 +8,7 @@
 (*            Benjamin Gregoire, Laurent Thery, INRIA, 2007             *)
 (************************************************************************)
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 Require Import ZArith.
 Local Open Scope Z_scope.

--- a/theories/Numbers/Cyclic/ZModulo/ZModulo.v
+++ b/theories/Numbers/Cyclic/ZModulo/ZModulo.v
@@ -13,7 +13,7 @@
   the efficient arbitrary precision numbers, it provides a simple
   implementation of CyclicAxioms, hence ensuring its coherence. *)
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 Require Import Bool.
 Require Import ZArith.

--- a/theories/Numbers/NumPrelude.v
+++ b/theories/Numbers/NumPrelude.v
@@ -10,7 +10,7 @@
 
 Require Export Setoid Morphisms Morphisms_Prop.
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 (* The following tactic uses solve_proper to solve the goals
 relating to well-definedness that are produced by applying induction.

--- a/theories/PArith/BinPos.v
+++ b/theories/PArith/BinPos.v
@@ -38,7 +38,7 @@ Include BinPosDef.Pos.
 
 (** In functor applications that follow, we only inline t and eq *)
 
-Set Inline Level 30.
+Local Set Inline Level 30.
 
 (** * Logical Predicates *)
 

--- a/theories/PArith/BinPosDef.v
+++ b/theories/PArith/BinPosDef.v
@@ -375,7 +375,7 @@ Fixpoint gcdn (n : nat) (a b : positive) : positive :=
 Definition gcd (a b : positive) := gcdn (size_nat a + size_nat b)%nat a b.
 
 (** Generalized Gcd, also computing the division of a and b by the gcd *)
-Set Printing Universes.
+Local Set Printing Universes.
 Fixpoint ggcdn (n : nat) (a b : positive) : (positive*(positive*positive)) :=
   match n with
     | O => (1,(a,b))

--- a/theories/Program/Utils.v
+++ b/theories/Program/Utils.v
@@ -10,7 +10,7 @@
 
 Require Export Coq.Program.Tactics.
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 (** A simpler notation for subsets defined on a cartesian product. *)
 

--- a/theories/Program/Wf.v
+++ b/theories/Program/Wf.v
@@ -71,7 +71,7 @@ End Well_founded.
 
 Extraction Inline Fix_F_sub Fix_sub.
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 (** Reasoning about well-founded fixpoints on measures. *)
 

--- a/theories/Reals/RiemannInt.v
+++ b/theories/Reals/RiemannInt.v
@@ -15,7 +15,7 @@ Require Import RiemannInt_SF.
 Require Import Max.
 Local Open Scope R_scope.
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 (********************************************)
 (**           Riemann's Integral            *)

--- a/theories/Reals/RiemannInt_SF.v
+++ b/theories/Reals/RiemannInt_SF.v
@@ -12,7 +12,7 @@ Require Import Ranalysis_reg.
 Require Import Classical_Prop.
 Local Open Scope R_scope.
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 (*****************************************************)
 (** * Each bounded subset of N has a maximal element *)

--- a/theories/Reals/Rsigma.v
+++ b/theories/Reals/Rsigma.v
@@ -13,7 +13,7 @@ Require Import PartSum.
 Require Import Omega.
 Local Open Scope R_scope.
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 Section Sigma.
 

--- a/theories/Reals/SeqProp.v
+++ b/theories/Reals/SeqProp.v
@@ -150,7 +150,7 @@ Definition sequence_lb (Un:nat -> R) (pr:has_lb Un)
 (* Compatibility *)
 Notation sequence_majorant := sequence_ub (only parsing).
 Notation sequence_minorant := sequence_lb (only parsing).
-Unset Standard Proposition Elimination Names.
+Local Unset Standard Proposition Elimination Names.
 Lemma Wn_decreasing :
   forall (Un:nat -> R) (pr:has_ub Un), Un_decreasing (sequence_ub Un pr).
 Proof.

--- a/theories/Sets/Multiset.v
+++ b/theories/Sets/Multiset.v
@@ -10,7 +10,7 @@
 
 Require Import Permut Setoid.
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 Section multiset_defs.
 
@@ -185,7 +185,7 @@ i*)
 
 End multiset_defs.
 
-Unset Implicit Arguments.
+Local Unset Implicit Arguments.
 
 Hint Unfold meq multiplicity: v62 datatypes.
 Hint Resolve munion_empty_right munion_comm munion_ass meq_left meq_right

--- a/theories/Sets/Uniset.v
+++ b/theories/Sets/Uniset.v
@@ -13,7 +13,7 @@
 
 Require Import Bool.
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 Section defs.
 
@@ -210,4 +210,4 @@ i*)
 
 End defs.
 
-Unset Implicit Arguments.
+Local Unset Implicit Arguments.

--- a/theories/Sorting/PermutEq.v
+++ b/theories/Sorting/PermutEq.v
@@ -8,7 +8,7 @@
 
 Require Import Relations Setoid SetoidList List Multiset PermutSetoid Permutation Omega.
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 (** This file is similar to [PermutSetoid], except that the equality used here
     is Coq usual one instead of a setoid equality. In particular, we can then

--- a/theories/Sorting/PermutSetoid.v
+++ b/theories/Sorting/PermutSetoid.v
@@ -23,7 +23,7 @@ Require Import Omega Relations Multiset SetoidList.
     that [List.Permutation] and [permutation] are equivalent in this context.
 *)
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 Local Notation "[ ]" := nil.
 Local Notation "[ a ; .. ; b ]" := (a :: .. (b :: []) ..).

--- a/theories/Sorting/Permutation.v
+++ b/theories/Sorting/Permutation.v
@@ -15,7 +15,7 @@
 
 Require Import List Setoid Compare_dec Morphisms FinFun.
 Import ListNotations. (* For notations [] and [a;b;c] *)
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 (* Set Universe Polymorphism. *)
 
 Section Permutation.

--- a/theories/Sorting/Sorted.v
+++ b/theories/Sorting/Sorted.v
@@ -24,7 +24,7 @@ Require Import List Relations Relations_1.
 
 (** Preambule *)
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 Local Notation "[ ]" := nil (at level 0).
 Local Notation "[ a ; .. ; b ]" := (a :: .. (b :: []) ..) (at level 0).
 Arguments Transitive [U] R.

--- a/theories/Structures/DecidableType.v
+++ b/theories/Structures/DecidableType.v
@@ -9,8 +9,8 @@
 Require Export SetoidList.
 Require Equalities.
 
-Set Implicit Arguments.
-Unset Strict Implicit.
+Local Set Implicit Arguments.
+Local Unset Strict Implicit.
 
 (** NB: This file is here only for compatibility with earlier version of
     [FSets] and [FMap]. Please use [Structures/Equalities.v] directly now. *)

--- a/theories/Structures/DecidableTypeEx.v
+++ b/theories/Structures/DecidableTypeEx.v
@@ -7,8 +7,8 @@
 (***********************************************************************)
 
 Require Import DecidableType OrderedType OrderedTypeEx.
-Set Implicit Arguments.
-Unset Strict Implicit.
+Local Set Implicit Arguments.
+Local Unset Strict Implicit.
 
 (** NB: This file is here only for compatibility with earlier version of
     [FSets] and [FMap]. Please use [Structures/Equalities.v] directly now. *)

--- a/theories/Structures/Equalities.v
+++ b/theories/Structures/Equalities.v
@@ -9,8 +9,8 @@
 Require Export RelationClasses.
 Require Import Bool Morphisms Setoid.
 
-Set Implicit Arguments.
-Unset Strict Implicit.
+Local Set Implicit Arguments.
+Local Unset Strict Implicit.
 
 (** Structure with nothing inside.
     Used to force a module type T into a module via Nop <+ T. (HACK!) *)

--- a/theories/Structures/EqualitiesFacts.v
+++ b/theories/Structures/EqualitiesFacts.v
@@ -8,7 +8,7 @@
 
 Require Import Equalities Bool SetoidList RelationPairs.
 
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 (** * Keys and datas used in the future MMaps *)
 

--- a/theories/Structures/OrderedType.v
+++ b/theories/Structures/OrderedType.v
@@ -7,8 +7,8 @@
 (***********************************************************************)
 
 Require Export SetoidList Morphisms OrdersTac.
-Set Implicit Arguments.
-Unset Strict Implicit.
+Local Set Implicit Arguments.
+Local Unset Strict Implicit.
 
 (** NB: This file is here only for compatibility with earlier version of
      [FSets] and [FMap]. Please use [Structures/Orders.v] directly now. *)

--- a/theories/Structures/Orders.v
+++ b/theories/Structures/Orders.v
@@ -7,8 +7,8 @@
 (***********************************************************************)
 
 Require Export Relations Morphisms Setoid Equalities.
-Set Implicit Arguments.
-Unset Strict Implicit.
+Local Set Implicit Arguments.
+Local Unset Strict Implicit.
 
 (** * Ordered types *)
 

--- a/theories/Structures/OrdersAlt.v
+++ b/theories/Structures/OrdersAlt.v
@@ -12,7 +12,7 @@
  *              91405 Orsay, France *)
 
 Require Import OrderedType Orders.
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 (** * Some alternative (but equivalent) presentations for an Ordered Type
    inferface. *)

--- a/theories/Structures/OrdersFacts.v
+++ b/theories/Structures/OrdersFacts.v
@@ -9,8 +9,8 @@
 Require Import Bool Basics OrdersTac.
 Require Export Orders.
 
-Set Implicit Arguments.
-Unset Strict Implicit.
+Local Set Implicit Arguments.
+Local Unset Strict Implicit.
 
 (** * Properties of [compare] *)
 
@@ -260,7 +260,7 @@ Qed.
 
 End OrderedTypeRev.
 
-Unset Implicit Arguments.
+Local Unset Implicit Arguments.
 
 (** * Order relations derived from a [compare] function.
 

--- a/theories/Structures/OrdersLists.v
+++ b/theories/Structures/OrdersLists.v
@@ -8,8 +8,8 @@
 
 Require Export RelationPairs SetoidList Orders EqualitiesFacts.
 
-Set Implicit Arguments.
-Unset Strict Implicit.
+Local Set Implicit Arguments.
+Local Unset Strict Implicit.
 
 (** * Specialization of results about lists modulo. *)
 

--- a/theories/Structures/OrdersTac.v
+++ b/theories/Structures/OrdersTac.v
@@ -7,7 +7,7 @@
 (***********************************************************************)
 
 Require Import Setoid Morphisms Basics Equalities Orders.
-Set Implicit Arguments.
+Local Set Implicit Arguments.
 
 (** * The order tactic *)
 

--- a/theories/ZArith/BinInt.v
+++ b/theories/ZArith/BinInt.v
@@ -38,7 +38,7 @@ Include BinIntDef.Z.
 
 (** When including property functors, only inline t eq zero one two *)
 
-Set Inline Level 30.
+Local Set Inline Level 30.
 
 (** * Logic Predicates *)
 


### PR DESCRIPTION
Before this patch, Set and Local Set behaved the same outside of a section,
i.e. they disappeared at module closing. Now, setting an option without a
qualifier allows to activate it whenever the module it lives in is imported.
This is a much saner behaviour that allows to scope options properly.

Fixing the Coq source files was a mere matter of systematically replacing
every Set / Unset invokations by a corresponding Local Set / Unset command.
