### PR TITLE
Fix #4959: Ltac match fails to match Type with Type

### DIFF
--- a/ltac/tacinterp.ml
+++ b/ltac/tacinterp.ml
@@ -1522,7 +1522,7 @@ and interp_match ist lz constr lmr =
     let sigma = project gl in
     let env = Proofview.Goal.env gl in
     let ilr = read_match_rule (extract_ltac_constr_values ist env) ist env sigma lmr in
-    interp_match_successes lz ist (Tactic_matching.match_term env sigma constr ilr)
+    interp_match_successes lz ist (Tactic_matching.match_term env constr ilr)
   end }
 
 (* Interprets the Match Context expressions *)
@@ -1534,7 +1534,7 @@ and interp_match_goal ist lz lr lmr =
       let hyps = if lr then List.rev hyps else hyps in
       let concl = Proofview.Goal.concl gl in
       let ilr = read_match_rule (extract_ltac_constr_values ist env) ist env sigma lmr in
-      interp_match_successes lz ist (Tactic_matching.match_goal env sigma hyps concl ilr)
+      interp_match_successes lz ist (Tactic_matching.match_goal env hyps concl ilr)
     end }
 
 (* Interprets extended tactic generic arguments *)

--- a/plugins/quote/quote.ml
+++ b/plugins/quote/quote.ml
@@ -402,7 +402,10 @@ let quote_terms ivs lc =
       match l with
         | (lhs, rhs)::tail ->
             begin try
-              let s1 = Id.Map.bindings (matches (Global.env ()) Evd.empty rhs c) in
+              let s1 =
+                Id.Map.bindings (let (_sigma,r) (* FIXME *) =
+                                   matches (Global.env ()) Evd.empty rhs c in r)
+              in
               let s2 = List.map (fun (i,c_i) -> (coerce_meta_out i,aux c_i)) s1
 	      in
               Termops.subst_meta s2 lhs

--- a/pretyping/constr_matching.mli
+++ b/pretyping/constr_matching.mli
@@ -30,11 +30,13 @@ type bound_ident_map = Id.t Id.Map.t
    assignment of metavariables; it raises [PatternMatchingFailure] if
    not matchable; bindings are given in increasing order based on the
    numbers given in the pattern *)
-val matches : env -> Evd.evar_map -> constr_pattern -> constr -> patvar_map
+val matches : env -> Evd.evar_map -> constr_pattern -> constr ->
+              Evd.evar_map * patvar_map
 
 (** [matches_head pat c] does the same as [matches pat c] but accepts
     [pat] to match an applicative prefix of [c] *)
-val matches_head : env -> Evd.evar_map -> constr_pattern -> constr -> patvar_map
+val matches_head : env -> Evd.evar_map -> constr_pattern -> constr ->
+                   Evd.evar_map * patvar_map
 
 (** [extended_matches pat c] also returns the names of bound variables
    in [c] that matches the bound variables in [pat]; if several bound
@@ -42,7 +44,7 @@ val matches_head : env -> Evd.evar_map -> constr_pattern -> constr -> patvar_map
    or else the rightmost bound variable, takes precedence *)
 val extended_matches :
   env -> Evd.evar_map -> Tacexpr.binding_bound_vars * constr_pattern ->
-  constr -> bound_ident_map * extended_patvar_map
+  constr -> Evd.evar_map * (bound_ident_map * extended_patvar_map)
 
 (** [is_matching pat c] just tells if [c] matches against [pat] *)
 val is_matching : env -> Evd.evar_map -> constr_pattern -> constr -> bool
@@ -55,12 +57,14 @@ val is_matching_head : env -> Evd.evar_map -> constr_pattern -> constr -> bool
    [(env,sigma)] when constants in pattern are concerned; it raises
    [PatternMatchingFailure] if not matchable; bindings are given in
    increasing order based on the numbers given in the pattern *)
-val matches_conv : env -> Evd.evar_map -> constr_pattern -> constr -> patvar_map
+val matches_conv : env -> Evd.evar_map -> constr_pattern -> constr ->
+                   Evd.evar_map * patvar_map
 
 (** The type of subterm matching results: a substitution + a context
    (whose hole is denoted here with [special_meta]) *)
 type matching_result =
     { m_sub : bound_ident_map * patvar_map;
+      m_evarmap : Evd.evar_map;
       m_ctx : constr }
 
 (** [match_subterm n pat c] returns the substitution and the context

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -1228,6 +1228,7 @@ let solve_unconstrained_impossible_cases env evd =
   Evd.fold_undefined (fun evk ev_info evd' ->
     match ev_info.evar_source with
     | loc,Evar_kinds.ImpossibleCase ->
+       (* Why does this ad-hoc code have to be here instead of cases.ml? *)
       let j, ctx = coq_unit_judge () in
       let evd' = Evd.merge_context_set Evd.univ_flexible_alg ~loc evd' ctx in
       let ty = j_type j in

--- a/pretyping/tacred.ml
+++ b/pretyping/tacred.ml
@@ -984,7 +984,7 @@ let e_contextually byhead (occs,c) f = { e_redfun = begin fun env sigma t ->
     if nowhere_except_in && (!pos > maxocc) then (* Shortcut *) t
     else
     try
-      let subst =
+      let (_sigma,subst) = (* FIXME *)
         if byhead then matches_head env sigma c t 
 	else Constr_matching.matches env sigma c t in
       let ok =

--- a/proofs/tacmach.mli
+++ b/proofs/tacmach.mli
@@ -77,7 +77,7 @@ val pf_const_value : goal sigma -> pconstant -> constr
 val pf_conv_x      : goal sigma -> constr -> constr -> bool
 val pf_conv_x_leq  : goal sigma -> constr -> constr -> bool
 
-val pf_matches     : goal sigma -> constr_pattern -> constr -> patvar_map
+val pf_matches     : goal sigma -> constr_pattern -> constr -> evar_map * patvar_map
 val pf_is_matching : goal sigma -> constr_pattern -> constr -> bool
 
 
@@ -129,7 +129,7 @@ module New : sig
   val pf_whd_all : ('a, 'r) Proofview.Goal.t -> constr -> constr
   val pf_compute : ('a, 'r) Proofview.Goal.t -> constr -> constr
 
-  val pf_matches : ('a, 'r) Proofview.Goal.t -> constr_pattern -> constr -> patvar_map
+  val pf_matches : ('a, 'r) Proofview.Goal.t -> constr_pattern -> constr -> evar_map * patvar_map
 
   val pf_nf_evar : ('a, 'r) Proofview.Goal.t -> constr -> constr
 

--- a/tactics/auto.ml
+++ b/tactics/auto.ml
@@ -136,8 +136,11 @@ let conclPattern concl pat tac =
     | None -> Proofview.tclUNIT Id.Map.empty
     | Some pat ->
 	try
-	  Proofview.tclUNIT (Constr_matching.matches env sigma pat concl)
-	with Constr_matching.PatternMatchingFailure ->
+          let (_sigma, matches) = (* FIXME *)
+            Constr_matching.matches env sigma pat concl
+          in
+          Proofview.tclUNIT matches
+        with Constr_matching.PatternMatchingFailure ->
           Tacticals.New.tclZEROMSG (str "conclPattern")
   in
   Proofview.Goal.enter { enter = begin fun gl ->

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -1436,6 +1436,11 @@ let initial_select_evars filter =
     Typeclasses.is_class_evar evd evi
 
 let resolve_typeclass_evars debug depth unique env evd filter split fail =
+  (* This looks a bit fishy. Why do we consider the whole set of pending
+  unification problems, and yet keep going if we fail to solve them?
+  [consider_remaining_unif_problems] without the try-with or [reconsider_conv_pbs]
+  would be more natural.
+  *)
   let evd =
     try Evarconv.consider_remaining_unif_problems
       ~ts:(Typeclasses.classes_transparent_state ()) env evd

--- a/tactics/tactic_matching.mli
+++ b/tactics/tactic_matching.mli
@@ -24,25 +24,21 @@ type 'a t = {
 }
 
 
-(** [match_term env sigma term rules] matches the term [term] with the
-    set of matching rules [rules]. The environment [env] and the
-    evar_map [sigma] are not currently used, but avoid code
-    duplication. *)
+(** [match_term env sigma term rules] matches the term [term] with the set of
+    matching rules [rules]. The environment [env] is not currently used, but
+    avoids code duplication. *)
 val match_term :
   Environ.env ->
-  Evd.evar_map ->
   Term.constr ->
   (Tacexpr.binding_bound_vars * Pattern.constr_pattern, Tacexpr.glob_tactic_expr) Tacexpr.match_rule list ->
   Tacexpr.glob_tactic_expr t Proofview.tactic
 
-(** [match_goal env sigma hyps concl rules] matches the goal
-    [hyps|-concl] with the set of matching rules [rules]. The
-    environment [env] and the evar_map [sigma] are used to check
-    convertibility for pattern variables shared between hypothesis
-    patterns or the conclusion pattern. *)
+(** [match_goal env sigma hyps concl rules] matches the goal [hyps|-concl] with
+    the set of matching rules [rules]. The environment [env] and the current
+    evar_map are used to check convertibility for pattern variables shared
+    between hypothesis patterns or the conclusion pattern. *)
 val match_goal:
   Environ.env ->
-  Evd.evar_map ->
   Context.Named.t ->
   Term.constr ->
   (Tacexpr.binding_bound_vars * Pattern.constr_pattern, Tacexpr.glob_tactic_expr) Tacexpr.match_rule list ->

--- a/test-suite/bugs/closed/4959.v
+++ b/test-suite/bugs/closed/4959.v
@@ -1,0 +1,10 @@
+Goal True.
+let T1 := constr:(Type) in
+let T2 := constr:(Type) in
+let X := constr:((T1, T2)) in
+match X with (?A, ?A) => idtac end.
+Abort.
+
+Goal (Type * Type).
+match goal with |- (?A * ?A)%type => refine ((Type, Type) : (A * A)) end.
+Qed.

--- a/test-suite/bugs/closed/HoTT_coq_052.v
+++ b/test-suite/bugs/closed/HoTT_coq_052.v
@@ -1,5 +1,5 @@
 Goal Type = Type.
-  Fail match goal with |- ?x = ?x => idtac end.
+  match goal with |- ?x = ?x => idtac end.
 Abort.
 
 Goal Prop.


### PR DESCRIPTION
Non-linear Ltac pattern matching can now produce universe constraints.
Previously, it was comparing universes up to syntactic equality, which
is too restrictive.

However, this fix removes an optimization in tacting_matching,
where functions taking an env and an evar_map were specialized using
a first class functor, instead of threading explicitely data that did
not change. This fix requires the evar_map to change when evaluating the
pattern matching, so I had to remove it from the functor, and we are now
creating more closures.

Disclaimer: I had essentially no idea of what I was doing while writing this patch, due to my limited knowledge of these parts of the system. So this PR needs to be thoroughly reviewed. My main concern is the performance impact, and it is hard for me to tell if I could do the same change in a more efficient way.

I tried it on contribs and it breaks only one plugin in rational, in an expected way.
