### PR TITLE
Using msg_info for info_e/auto?

### DIFF
--- a/tactics/auto.ml
+++ b/tactics/auto.ml
@@ -254,19 +254,19 @@ let pr_info_atom (d,pp) =
 
 let pr_info_trace = function
   | (Info,_,{contents=(d,Some pp)::l}) ->
-      msg_debug (prlist_with_sep fnl pr_info_atom (cleanup_info_trace d [(d,pp)] l))
+      msg_info (prlist_with_sep fnl pr_info_atom (cleanup_info_trace d [(d,pp)] l))
   | _ -> ()
 
 let pr_info_nop = function
-  | (Info,_,_) -> msg_debug (str "idtac.")
+  | (Info,_,_) -> msg_info (str "idtac.")
   | _ -> ()
 
 let pr_dbg_header = function
   | (Off,_,_) -> ()
   | (Debug,0,_) -> msg_debug (str "(* debug trivial : *)")
   | (Debug,_,_) -> msg_debug (str "(* debug auto : *)")
-  | (Info,0,_) -> msg_debug (str "(* info trivial : *)")
-  | (Info,_,_) -> msg_debug (str "(* info auto : *)")
+  | (Info,0,_) -> msg_info (str "(* info trivial : *)")
+  | (Info,_,_) -> msg_info (str "(* info auto : *)")
 
 let tclTRY_dbg d tac =
   let delay f = Proofview.tclUNIT () >>= fun () -> f () in

--- a/tactics/eauto.ml4
+++ b/tactics/eauto.ml4
@@ -355,13 +355,13 @@ let mk_eauto_dbg d =
   else Off
 
 let pr_info_nop = function
-  | Info -> msg_debug (str "idtac.")
+  | Info -> msg_info (str "idtac.")
   | _ -> ()
 
 let pr_dbg_header = function
   | Off -> ()
   | Debug -> msg_debug (str "(* debug eauto : *)")
-  | Info -> msg_debug (str "(* info eauto : *)")
+  | Info -> msg_info (str "(* info eauto : *)")
 
 let pr_info dbg s =
   if dbg != Info then ()
@@ -372,7 +372,7 @@ let pr_info dbg s =
 	| State sp ->
 	  let mindepth = loop sp in
 	  let indent = String.make (mindepth - sp.depth) ' ' in
-	  msg_debug (str indent ++ Lazy.force s.last_tactic ++ str ".");
+	  msg_info (str indent ++ Lazy.force s.last_tactic ++ str ".");
 	  mindepth
     in
     ignore (loop s)


### PR DESCRIPTION
Hi, I struggled a bit with the output of `info_auto` a few days ago. The current situation for `info_auto`, `info_eauto`, `debug auto` and `debug auto` is of the following form:

```
Goal (True -> True) \/ False.
info_auto.
Debug: (* info auto: *)
Debug:  simple apply or_introl (in core).
  intro.
  assumption.

Undo.
debug auto.
Debug: (* debug auto: *)
Debug: * assumption. (*fail*)
Debug: * intro. (*fail*)
Debug: * simple apply or_intror (in core). (*success*)
Debug: ** assumption. (*fail*)
Debug: ** intro. (*fail*)
Debug: * simple apply or_introl (in core). (*success*)
Debug: ** assumption. (*fail*)
Debug: ** intro. (*success*)
Debug: ** assumption. (*success*)

Undo.
info_eauto.
Debug: (* info eauto: *)
Debug: simple apply or_introl.
Debug:  intro.
Debug:  exact H.

Undo.
debug eauto.
Debug: (* debug eauto: *)
Debug: 1 depth=5 
Debug: 1.1 depth=4 simple apply or_intror
Debug: 1.2 depth=4 simple apply or_introl
Debug: 1.2.1 depth=4 intro
Debug: 1.2.1.1 depth=4 exact H
```

Simple user-level questions in passing: which of `msg_info` and `msg_debug` is the most relevant to be used for the output of `info_auto`, `info_eauto`, `debug auto` and of `debug eauto` respectively? Otherwise said, what is the intended purpose of `msg_info` and `msg_debug` in general? For instance, should `Set Ltac Debug` uses `msg_debug`, or is it `debug_auto` which should stop to use `msg_debug`?

Should we unify the display of `info_auto` and the one of `info_eauto`, as well as the one of `debug_auto` and the one of `debug_eauto`? Is there one better?

More generally, are there obstacles to merge the code of `auto` and `eauto`, reasons not to merge them?

In any case, by default, I'm proposing at the current time the minimalistic attached PR for at least unifying the output of `info_auto` and `info_eauto`.
