### PR TITLE
Change the order of arguments of fig2dev.

### DIFF
--- a/Makefile.doc
+++ b/Makefile.doc
@@ -61,7 +61,7 @@ endif
 	(cd `dirname $<`; $(DVIPS) -q -o `basename $@` `basename $<`)
 
 %.png: %.fig
-	$(FIG2DEV) -m 2 -L png $< $@
+	$(FIG2DEV) -L png -m 2 $< $@
 
 %.pdf: %.fig
 	$(FIG2DEV) -L pdftex $< $@


### PR DESCRIPTION
For some reason, with my version of transfig (which seems to be the latest),
the order of arguments of the fig2dev command matters: `-L png` must come
before `-m 2`. I suppose that this fix shouldn't break things for others.
