### PR TITLE
Removing an horribly designed syntax for eauto bfs.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -75,6 +75,14 @@ Tactics
 - Option "Injection On Proofs" was renamed "Keep Proof Equalities". When
   enabled, injection and inversion do not drop equalities between objects
   in Prop. Still disabled by default.
+- Removal of the ancient tactic "new auto".
+- "dfs eauto" and the new tactic "bfs eauto" now rely on the same
+  implemenation as "typeclasses eauto" (and can be used instead of "eauto").
+  "dfs" means depth-first search and "bfs" means breadth-first search
+  (implemented as iterative-deepening). A search-depth and a set of hint
+  bases to use can be specified as with eauto (but the semantics of the
+  search-depth is the one of typeclasses eauto -- intro steps count).
+  These two tactics should be considered experimental until 8.7!
 
 Hints
 

--- a/ltac/g_auto.ml4
+++ b/ltac/g_auto.ml4
@@ -98,38 +98,33 @@ TACTIC EXTEND prolog
     [ Eauto.prolog_tac (eval_uconstrs ist l) n ]
 END
 
-let make_depth n = snd (Eauto.make_dimension n None)
-
 TACTIC EXTEND eauto
-| [ "eauto" int_or_var_opt(n) int_or_var_opt(p) auto_using(lems)
-    hintbases(db) ] ->
-    [ Eauto.gen_eauto (Eauto.make_dimension n p) (eval_uconstrs ist lems) db ]
+| [ "eauto" int_or_var_opt(n) auto_using(lems) hintbases(db) ] ->
+    [ Eauto.gen_eauto (true, Eauto.make_depth n) (eval_uconstrs ist lems) db ]
 END
 
 TACTIC EXTEND new_eauto
 | [ "new" "auto" int_or_var_opt(n) auto_using(lems)
     hintbases(db) ] ->
     [ match db with
-      | None -> Auto.new_full_auto (make_depth n) (eval_uconstrs ist lems)
-      | Some l -> Auto.new_auto (make_depth n) (eval_uconstrs ist lems) l ]
+      | None -> Auto.new_full_auto (Eauto.make_depth n) (eval_uconstrs ist lems)
+      | Some l -> Auto.new_auto (Eauto.make_depth n) (eval_uconstrs ist lems) l ]
 END
 
 TACTIC EXTEND debug_eauto
-| [ "debug" "eauto" int_or_var_opt(n) int_or_var_opt(p) auto_using(lems)
-    hintbases(db) ] ->
-    [ Eauto.gen_eauto ~debug:Debug (Eauto.make_dimension n p) (eval_uconstrs ist lems) db ]
+| [ "debug" "eauto" int_or_var_opt(n) auto_using(lems) hintbases(db) ] ->
+    [ Eauto.gen_eauto ~debug:Debug (true, Eauto.make_depth n) (eval_uconstrs ist lems) db ]
 END
 
 TACTIC EXTEND info_eauto
-| [ "info_eauto" int_or_var_opt(n) int_or_var_opt(p) auto_using(lems)
-    hintbases(db) ] ->
-    [ Eauto.gen_eauto ~debug:Info (Eauto.make_dimension n p) (eval_uconstrs ist lems) db ]
+| [ "info_eauto" int_or_var_opt(n) auto_using(lems) hintbases(db) ] ->
+    [ Eauto.gen_eauto ~debug:Info (true, Eauto.make_depth n) (eval_uconstrs ist lems) db ]
 END
 
 TACTIC EXTEND dfs_eauto
 | [ "dfs" "eauto" int_or_var_opt(p) auto_using(lems)
       hintbases(db) ] ->
-    [ Eauto.gen_eauto (Eauto.make_dimension p None) (eval_uconstrs ist lems) db ]
+    [ Eauto.gen_eauto (true, Eauto.make_depth p) (eval_uconstrs ist lems) db ]
 END
 
 TACTIC EXTEND autounfold

--- a/ltac/g_auto.ml4
+++ b/ltac/g_auto.ml4
@@ -116,7 +116,7 @@ END
 
 (** Typeclasses eauto based tactics *)
 
-let typeclasses_eauto depth dbnames =
+let typeclasses_eauto ~dfs depth dbnames =
   let db_list =
     match dbnames with
     | None -> Hints.current_pure_db ()
@@ -130,13 +130,19 @@ let typeclasses_eauto depth dbnames =
   Tacticals.New.tclTRY
     (Class_tactics.Search.eauto_tac
        ~only_classes:false
+       ~dfs
        ~depth:(Some depth)
        ~dep:true
        db_list)
 
 TACTIC EXTEND dfs_eauto
 | [ "dfs" "eauto" int_or_var_opt(depth) hintbases(db) ] ->
-   [ typeclasses_eauto depth db ]
+   [ typeclasses_eauto ~dfs:true depth db ]
+END
+
+TACTIC EXTEND bfs_eauto
+| [ "bfs" "eauto" int_or_var_opt(depth) hintbases(db) ] ->
+   [ typeclasses_eauto ~dfs:false depth db ]
 END
 
 TACTIC EXTEND autounfold

--- a/ltac/g_auto.ml4
+++ b/ltac/g_auto.ml4
@@ -103,14 +103,6 @@ TACTIC EXTEND eauto
     [ Eauto.gen_eauto (true, Eauto.make_depth n) (eval_uconstrs ist lems) db ]
 END
 
-TACTIC EXTEND new_eauto
-| [ "new" "auto" int_or_var_opt(n) auto_using(lems)
-    hintbases(db) ] ->
-    [ match db with
-      | None -> Auto.new_full_auto (Eauto.make_depth n) (eval_uconstrs ist lems)
-      | Some l -> Auto.new_auto (Eauto.make_depth n) (eval_uconstrs ist lems) l ]
-END
-
 TACTIC EXTEND debug_eauto
 | [ "debug" "eauto" int_or_var_opt(n) auto_using(lems) hintbases(db) ] ->
     [ Eauto.gen_eauto ~debug:Debug (true, Eauto.make_depth n) (eval_uconstrs ist lems) db ]
@@ -119,12 +111,6 @@ END
 TACTIC EXTEND info_eauto
 | [ "info_eauto" int_or_var_opt(n) auto_using(lems) hintbases(db) ] ->
     [ Eauto.gen_eauto ~debug:Info (true, Eauto.make_depth n) (eval_uconstrs ist lems) db ]
-END
-
-TACTIC EXTEND dfs_eauto
-| [ "dfs" "eauto" int_or_var_opt(p) auto_using(lems)
-      hintbases(db) ] ->
-    [ Eauto.gen_eauto (true, Eauto.make_depth p) (eval_uconstrs ist lems) db ]
 END
 
 TACTIC EXTEND autounfold

--- a/ltac/g_auto.ml4
+++ b/ltac/g_auto.ml4
@@ -100,17 +100,17 @@ END
 
 TACTIC EXTEND eauto
 | [ "eauto" int_or_var_opt(n) auto_using(lems) hintbases(db) ] ->
-    [ Eauto.gen_eauto (true, Eauto.make_depth n) (eval_uconstrs ist lems) db ]
+    [ Eauto.gen_eauto ?depth:n (eval_uconstrs ist lems) db ]
 END
 
 TACTIC EXTEND debug_eauto
 | [ "debug" "eauto" int_or_var_opt(n) auto_using(lems) hintbases(db) ] ->
-    [ Eauto.gen_eauto ~debug:Debug (true, Eauto.make_depth n) (eval_uconstrs ist lems) db ]
+    [ Eauto.gen_eauto ~debug:Debug ?depth:n (eval_uconstrs ist lems) db ]
 END
 
 TACTIC EXTEND info_eauto
 | [ "info_eauto" int_or_var_opt(n) auto_using(lems) hintbases(db) ] ->
-    [ Eauto.gen_eauto ~debug:Info (true, Eauto.make_depth n) (eval_uconstrs ist lems) db ]
+    [ Eauto.gen_eauto ~debug:Info ?depth:n (eval_uconstrs ist lems) db ]
 END
 
 TACTIC EXTEND autounfold

--- a/plugins/funind/functional_principles_proofs.ml
+++ b/plugins/funind/functional_principles_proofs.ml
@@ -1405,7 +1405,7 @@ let prove_with_tcc tcc_lemma_constr eqs : tactic =
 (* 		 let ids = List.filter (fun id -> not (List.mem id ids)) ids' in  *)
 (* 		 rewrite *)
 (* 	      ) *)
-	      Proofview.V82.of_tactic (Eauto.gen_eauto (false,5) [] (Some []))
+	      Proofview.V82.of_tactic (Eauto.gen_eauto ~dfs:false ~depth:5 [] (Some []))
 	    ]
 	    gls
 

--- a/tactics/auto.ml
+++ b/tactics/auto.ml
@@ -514,8 +514,6 @@ let delta_auto =
 
 let auto ?(debug=Off) n = delta_auto debug false n
 
-let new_auto ?(debug=Off) n = delta_auto debug true n
-
 let default_auto = auto !default_search_depth [] []
 
 let delta_full_auto ?(debug=Off) mod_delta n lems =
@@ -530,7 +528,6 @@ let delta_full_auto ?(debug=Off) mod_delta n lems =
   end }
 
 let full_auto ?(debug=Off) n = delta_full_auto ~debug false n
-let new_full_auto ?(debug=Off) n = delta_full_auto ~debug true n
 
 let default_full_auto = full_auto !default_search_depth []
 

--- a/tactics/auto.mli
+++ b/tactics/auto.mli
@@ -42,19 +42,11 @@ val auto : ?debug:Tacexpr.debug ->
 
 (** Auto with more delta. *)
 
-val new_auto : ?debug:Tacexpr.debug ->
-  int -> Tacexpr.delayed_open_constr list -> hint_db_name list -> unit Proofview.tactic
-
 (** auto with default search depth and with the hint database "core" *)
 val default_auto : unit Proofview.tactic
 
 (** auto with all hint databases except the "v62" compatibility database *)
 val full_auto : ?debug:Tacexpr.debug ->
-  int -> Tacexpr.delayed_open_constr list -> unit Proofview.tactic
-
-(** auto with all hint databases except the "v62" compatibility database
-   and doing delta *)
-val new_full_auto : ?debug:Tacexpr.debug ->
   int -> Tacexpr.delayed_open_constr list -> unit Proofview.tactic
 
 (** auto with default search depth and with all hint databases

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -1202,10 +1202,15 @@ module Search = struct
                                    | (e,ie) -> Proofview.tclZERO ~info:ie e)
     in aux 1
 
-  let eauto_tac ?(st=full_transparent_state) ~only_classes ~depth ~dep hints =
+  let eauto_tac ?(st=full_transparent_state) ~only_classes ?dfs ~depth ~dep hints =
     let tac =
       let search = search_tac ~st only_classes dep hints in
-      if get_typeclasses_iterative_deepening () then
+      let bfs =
+        match dfs with
+        | None -> get_typeclasses_iterative_deepening ()
+        | Some v -> v
+      in
+      if bfs then
         match depth with
         | None -> fix_iterative search
         | Some l -> fix_iterative_limit l search

--- a/tactics/class_tactics.mli
+++ b/tactics/class_tactics.mli
@@ -38,6 +38,9 @@ module Search : sig
     (** The transparent_state used when working with local hypotheses  *)
     only_classes:bool ->
     (** Should non-class goals be shelved and resolved at the end *)
+    ?dfs:bool ->
+    (** Is a traversing-strategy specified?
+        If yes, true means dfs, false means bfs, i.e iterative deepening *)
     depth:Int.t option ->
     (** Bounded or unbounded search *)
     dep:bool ->

--- a/tactics/eauto.ml
+++ b/tactics/eauto.ml
@@ -423,10 +423,6 @@ let make_depth = function
   | None -> !default_search_depth
   | Some d -> d
 
-let make_dimension n = function
-  | None -> (true,make_depth n)
-  | Some d -> (false,d)
-
 let cons a l = a :: l
 
 let autounfolds db occs cls gl =

--- a/tactics/eauto.ml
+++ b/tactics/eauto.ml
@@ -415,13 +415,9 @@ let full_eauto ?(debug=Off) n lems gl =
   let db_list = List.map searchtable_map (String.Set.elements dbnames) in
   tclTRY (e_search_auto debug n lems db_list) gl
 
-let gen_eauto ?(debug=Off) np lems = function
-  | None -> Proofview.V82.tactic (full_eauto ~debug np lems)
-  | Some l -> Proofview.V82.tactic (eauto ~debug np lems l)
-
-let make_depth = function
-  | None -> !default_search_depth
-  | Some d -> d
+let gen_eauto ?(debug=Off) ?(dfs=true) ?(depth=(!default_search_depth)) lems = function
+  | None -> Proofview.V82.tactic (full_eauto ~debug (dfs, depth) lems)
+  | Some l -> Proofview.V82.tactic (eauto ~debug (dfs, depth) lems l)
 
 let cons a l = a :: l
 

--- a/tactics/eauto.mli
+++ b/tactics/eauto.mli
@@ -30,4 +30,4 @@ val autounfold : hint_db_name list -> Locus.clause -> unit Proofview.tactic
 val autounfold_tac : hint_db_name list option -> Locus.clause -> unit Proofview.tactic
 val autounfold_one : hint_db_name list -> Locus.hyp_location option -> unit Proofview.tactic
 
-val make_dimension : int option -> int option -> bool * int
+val make_depth : int option -> int

--- a/tactics/eauto.mli
+++ b/tactics/eauto.mli
@@ -18,7 +18,8 @@ val e_give_exact : ?flags:Unification.unify_flags -> constr -> unit Proofview.ta
 
 val prolog_tac : Tacexpr.delayed_open_constr list -> int -> unit Proofview.tactic
 
-val gen_eauto : ?debug:Tacexpr.debug -> bool * int -> Tacexpr.delayed_open_constr list ->
+val gen_eauto :
+  ?debug:Tacexpr.debug -> ?dfs:bool -> ?depth:int -> Tacexpr.delayed_open_constr list ->
   hint_db_name list option -> unit Proofview.tactic
 
 val eauto_with_bases :
@@ -30,4 +31,3 @@ val autounfold : hint_db_name list -> Locus.clause -> unit Proofview.tactic
 val autounfold_tac : hint_db_name list option -> Locus.clause -> unit Proofview.tactic
 val autounfold_one : hint_db_name list -> Locus.hyp_location option -> unit Proofview.tactic
 
-val make_depth : int option -> int


### PR DESCRIPTION
Before this commit, it was possible to use `eauto 4 3` to call `eauto` in breadth-first search with depth 3 (`4` being a completely dummy argument).
This horrible syntax does not seem to be documented anywhere, not even in CHANGES so there is nothing against removing it.
It is not used in the stdlib.
A grep on coq-contribs seems to indicate that it is not used there either but to be sure, I am also running https://ci.inria.fr/coq/view/coq-contribs/job/coq-contribs/521/console.

NB: this syntax has existed at least since 2002 when .ml4 files were introduced. I did not manage to trace it back earlier but it probably wasn't invented then.

When we are at it, shouldn't we also remove `dfs eauto` (which does nothing more than `eauto`, is undocumented and not used in either the stdlib or the contribs) or provide a new `bfs eauto`? I am a bit skeptical about the second option however because no one is asking for it. People who want more control on `eauto` are already using `typeclasses eauto` anyway and the latter is going to replace the former eventually.
If we decide not to provide any way to call `eauto` in breadth-first search mode (as is the case currently, except for this syntax that _I hope_ no one knew about), maybe we could clean `eauto` from this possibility (to shorten the code).

What is `new auto`? It is undocumented as well and I couldn't find any use in the contribs or the stdlib.

Finally, while this patch strives to be minimal, I would have additionally replaced the use of `Eauto.make_depth` with an optional argument in `Eauto.gen_eauto`. Should I do it or, since this tactic is doomed anyway, I shouldn't worry about it?
