### PR TITLE
Fix printing of typeclasses eauto debug wrt intro.

### DIFF
--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -1141,7 +1141,8 @@ module Search = struct
                        (true,false,false) info.search_only_classes None decl in
     let ldb = Hint_db.add_list env s hint info.search_hints in
     let info' =
-      { info with search_hints = ldb; last_tac = lazy (str"intro") }
+      { info with search_hints = ldb; last_tac = lazy (str"intro");
+        search_depth = 1 :: 1 :: info.search_depth }
     in kont info'
 
   let intro info kont =


### PR DESCRIPTION
The search depth of `typeclasses eauto` includes the intro steps but they did not seem to increase the depth in debug mode.
This commit fixes this.
Additionally, this semantics will **need to be documented**.
