### PR TITLE
[warnings] Be consistent on handling "default"

### DIFF
--- a/lib/cWarnings.ml
+++ b/lib/cWarnings.ml
@@ -107,8 +107,13 @@ let parse_flags s =
       Flags.make_warn false;
       set_all_warnings_status Disabled
     end
+  else if CString.equal s "default" then begin
+      Flags.make_warn true;
+      reset_default_warnings ()
+    end
   else begin
       Flags.make_warn true;
+      reset_default_warnings ();
       let reg = Str.regexp "[ ,]+" in
       let items = List.map parse_flag (Str.split reg s) in
       let items = do_all_keyword items in
@@ -117,4 +122,4 @@ let parse_flags s =
     end
 
 let set_flags s =
-  flags := s; reset_default_warnings (); parse_flags s
+  flags := s; parse_flags s


### PR DESCRIPTION
Commit e8b9ee76af721c32b2d5cfcdae4ecbf47b341545 set the warnings default
value to "default", but this was not recognized when setting back the
flags.

[How I come to have to fix this is a long story on the perils of the
 _damn_ static initialization used to build the warnings table.

 Think of a poor Coq IDE, it has no way to retrieve the list of default
 warnings...]