### PR TITLE
Remove obsolete if_warn flag.

### DIFF
--- a/lib/cWarnings.ml
+++ b/lib/cWarnings.ml
@@ -172,12 +172,10 @@ let rec parse_warnings items =
 (* For compatibility, we accept "none" *)
 let parse_flags s =
   if is_none_keyword s then begin
-      Flags.make_warn false;
       set_all_warnings_status Disabled;
       "none"
     end
   else begin
-      Flags.make_warn true;
       let flags = flags_of_string s in
       let flags = normalize_flags ~silent:true flags in
       parse_warnings flags;

--- a/lib/feedback.ml
+++ b/lib/feedback.ml
@@ -87,8 +87,7 @@ let gen_logger dbg err ?pp_tag ?loc level msg = match level with
   | Debug   -> msgnl_with ?pp_tag !std_ft (make_body dbg  dbg_str ?loc msg)
   | Info    -> msgnl_with ?pp_tag !std_ft (make_body dbg info_str ?loc msg)
   | Notice  -> msgnl_with ?pp_tag !std_ft msg
-  | Warning -> Flags.if_warn (fun () ->
-               msgnl_with ?pp_tag !err_ft (make_body err warn_str ?loc msg)) ()
+  | Warning -> msgnl_with ?pp_tag !err_ft (make_body err warn_str ?loc msg)
   | Error   -> msgnl_with ?pp_tag !err_ft (make_body err  err_str ?loc msg)
 
 (* We provide a generic clear_log_backend callback for backends

--- a/lib/flags.ml
+++ b/lib/flags.ml
@@ -179,10 +179,6 @@ let make_polymorphic_flag b =
 let program_mode = ref false
 let is_program_mode () = !program_mode
 
-let warn = ref true
-let make_warn flag = warn := flag;  ()
-let if_warn f x = if !warn then f x
-
 (* The number of printed hypothesis in a goal *)
 
 let print_hyps_limit = ref (None : int option)

--- a/lib/flags.mli
+++ b/lib/flags.mli
@@ -94,10 +94,6 @@ val is_universe_polymorphism : unit -> bool
 val make_polymorphic_flag : bool -> unit
 val use_polymorphic_flag : unit -> bool
 
-val warn : bool ref
-val make_warn : bool -> unit
-val if_warn : ('a -> unit) -> 'a -> unit
-
 (** Temporarily activate an option (to activate option [o] on [f x y z],
    use [with_option o (f x y) z]) *)
 val with_option : bool ref -> ('a -> 'b) -> 'a -> 'b

--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -34,7 +34,7 @@ let print_header () =
   Feedback.msg_notice (str "Welcome to Coq " ++ str ver ++ str " (" ++ str rev ++ str ")");
   flush_all ()
 
-let warning s = with_option Flags.warn Feedback.msg_warning (strbrk s)
+let warning s = Feedback.msg_warning (strbrk s)
 
 let toploop = ref None
 
@@ -560,7 +560,7 @@ let parse_args arglist =
     |"-output-context" -> output_context := true
     |"-profile-ltac" -> Flags.profile_ltac := true
     |"-q" -> no_load_rc ()
-    |"-quiet"|"-silent" -> Flags.make_silent true; Flags.make_warn false
+    |"-quiet"|"-silent" -> Flags.make_silent true; CWarnings.set_flags "none"
     |"-quick" -> Flags.compilation_mode := BuildVio
     |"-list-tags" -> print_tags := true
     |"-time" -> Flags.time := true


### PR DESCRIPTION
The warning display mechanism should now be controlled by the warnings
flag machinery. In other case that would be a bug or the message should
belong to a different category.