### PR TITLE
new options -module-dep and -from for coqdep

### DIFF
--- a/tools/coqdep.ml
+++ b/tools/coqdep.ml
@@ -447,6 +447,8 @@ let usage () =
   eprintf "  -dumpgraphbox f : print a dot dependency graph box in file 'f'\n";
   eprintf "  -exclude-dir dir : skip subdirectories named 'dir' during -R/-Q search\n";
   eprintf "  -coqlib dir : set the coq standard library directory\n";
+  eprintf "  -module-dep mod : only print dependency of module mod\n";
+  eprintf "  -from path : provide a ``From path'' for -module-dep\n";
   eprintf "  -suffix s : \n";
   eprintf "  -slash : deprecated, no effect\n";
   exit 1
@@ -473,6 +475,10 @@ let rec parse = function
   | "-coqlib" :: [] -> usage ()
   | "-suffix" :: s :: ll -> suffixe := s ; parse ll
   | "-suffix" :: [] -> usage ()
+  | "-module-dep" :: m :: ll -> option_mod_dep := Some m; parse ll
+  | "-module-dep" :: [] -> usage ()
+  | "-from" :: f :: ll -> option_from := Some f; parse ll
+  | "-from" :: [] -> usage ()
   | "-slash" :: ll ->
     Printf.eprintf "warning: option -slash has no effect and is deprecated.\n";
     parse ll
@@ -511,6 +517,7 @@ let coqdep () =
   warning_mult ".mli" iter_mli_known;
   warning_mult ".ml" iter_ml_known;
   if !option_sort then begin sort (); exit 0 end;
+  if !option_mod_dep <> None then begin one_module_dependency (); exit 0 end;
   if !option_c && not !option_D then mL_dependencies ();
   if not !option_D then coq_dependencies ();
   if !option_w || !option_D then declare_dependencies ();

--- a/tools/coqdep_common.mli
+++ b/tools/coqdep_common.mli
@@ -21,6 +21,8 @@ val option_noglob : bool ref
 val option_boot : bool ref
 val option_natdynlk : bool ref
 val option_mldep : string option ref
+val option_mod_dep : string option ref
+val option_from : string option ref
 val norec_dirs : StrSet.t ref
 val suffixe : string ref
 type dir = string option
@@ -44,6 +46,7 @@ val file_name : string -> string option -> string
 val escape : string -> string
 val canonize : string -> string
 val mL_dependencies : unit -> unit
+val one_module_dependency : unit -> unit
 val coq_dependencies : unit -> unit
 val suffixes : 'a list -> 'a list list
 val add_known : bool -> string -> string list -> string -> unit


### PR DESCRIPTION
``coqdep -from path -module-dep mod'' computes just the dependency as for ``From path Require mod''. This is very useful for IDE's if they want to trigger a background compilation before processing a require command.

This PR is not complete yet. I created it to get initial feedback and an indication from the Coq team whether this is a useful contribution.

For background compilation, Proof General currently generates a temp file with just one require line for each processed require command. It would be much nicer, if Proof General could ask coqdep directly for the vo dependency.

If the Coq team thinks this is a nice feature to add to coqdep, I will
* add another option for ML dependencies
* add some documentation

The qualified ID processing for -module-dep and -from is very simple, but I believe sufficient. I also considered using coqdep_lexer, but unfortunately none of the existing entries fit. If you think it would be better to use the lexer, I can create a new entry in coqdep_lexer (relying on coq_qual_id_tail) and use that instead of simple_qualid_split.
