### PR TITLE
tclDISPATCH: more informative error message

### DIFF
--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -423,11 +423,11 @@ let tclFOCUSID id t =
 
 exception SizeMismatch of int*int
 let _ = CErrors.register_handler begin function
-  | SizeMismatch (i,_) ->
+  | SizeMismatch (i,j) ->
       let open Pp in
       let errmsg =
         str"Incorrect number of goals" ++ spc() ++
-        str"(expected "++int i++str(String.plural i " tactic") ++ str")."
+        str"(expected "++int i++str(String.plural i " tactic") ++ str", was given "++ int j++str")."
       in
       CErrors.user_err  errmsg
   | _ -> raise CErrors.Unhandled


### PR DESCRIPTION
"expected _n_ tactics" -> "exected _n_ tactics, was given _k_".

Also affect other similar tacticals from `Proofview`.

I used that for debugging once, I thought I might as well propose it for
mergeing.