### PR TITLE
Remove unused feedback_content: Goals

### DIFF
--- a/ide/xmlprotocol.ml
+++ b/ide/xmlprotocol.ml
@@ -816,7 +816,6 @@ let to_feedback_content = do_match "feedback_content" (fun s a -> match s,a with
   | "workerstatus", [ns] ->
        let n, s = to_pair to_string to_string ns in
        WorkerStatus(n,s)
-  | "goals", [loc;s] -> Goals (to_loc loc, to_string s)
   | "custom", [loc;name;x]-> Custom (to_loc loc, to_string name, x)
   | "filedependency", [from; dep] ->
       FileDependency (to_option to_string from, to_string dep)
@@ -849,8 +848,6 @@ let of_feedback_content = function
   | WorkerStatus(n,s) ->
       constructor "feedback_content" "workerstatus"
         [of_pair of_string of_string (n,s)]
-  | Goals (loc,s) ->
-      constructor "feedback_content" "goals" [of_loc loc;of_string s]
   | Custom (loc, name, x) ->
       constructor "feedback_content" "custom" [of_loc loc; of_string name; x]
   | FileDependency (from, depends_on) ->

--- a/lib/feedback.ml
+++ b/lib/feedback.ml
@@ -27,7 +27,6 @@ type feedback_content =
   | ProcessingIn of string
   | InProgress of int
   | WorkerStatus of string * string
-  | Goals of Loc.t * string
   | AddedAxiom
   | GlobRef of Loc.t * string * string * string * string
   | GlobDef of Loc.t * string * string * string

--- a/lib/feedback.mli
+++ b/lib/feedback.mli
@@ -36,7 +36,6 @@ type feedback_content =
   | InProgress of int
   | WorkerStatus of string * string
   (* Generally useful metadata *)
-  | Goals of Loc.t * string
   | AddedAxiom
   | GlobRef of Loc.t * string * string * string * string
   | GlobDef of Loc.t * string * string * string


### PR DESCRIPTION
`Goals` was introduced by 2a805fd99b96746dbfe381d64cd7eaba84fdca79 to support `Flags.feedback_goals`, which was removed 2 years ago by 10af47a5790987ee5211bac88c3a16396f30bcb0. No code uses `Goals` anymore.