### PR TITLE
Add an option to disallow shelved goals to remain in 8.7

### DIFF
--- a/doc/refman/Classes.tex
+++ b/doc/refman/Classes.tex
@@ -395,12 +395,16 @@ than {\tt eauto} and {\tt auto}. The main differences are the following:
   and will try to solve \emph{only} typeclass goals. If some subgoal of
   a hint/instance is non-dependent and not of class type, that hint
   application will fail. Dependent subgoals are automatically shelved
-  and \emph{must be} resolved entirely when the other typeclass subgoals
-  are resolved or the proof search will fail \emph{globally},
+  and, according to the value of the {\tt Typeclasses Allow Shelved}
+  flag, \emph{must be} resolved entirely when the other typeclass
+  subgoals are resolved or the proof search will fail \emph{globally},
   \emph{without} the possibility to find another complete solution with
-  no shelved subgoals.
+  no shelved subgoals. If the {\tt Typeclasses Allow Shelved} option is
+  \emph{on}, resolution does not care about shelved subgoals which might
+  appear at any point. This might result in resolutions that leave
+  dangling evars, as in \Coq{} 8.5.
 
-  \emph{Note: } As of Coq 8.6, {\tt all:once (typeclasses eauto)}
+  \emph{Note: } As of \Coq{} 8.6, {\tt all:once (typeclasses eauto)}
   faithfully mimicks what happens during typeclass resolution when it is
   called during refinement/type-inference. It might move to {\tt
     all:typeclasses eauto} in future versions when the refinement engine
@@ -469,6 +473,15 @@ subgoals, meaning that subgoals which are depended on by other subgoals
 come first, while the non-dependent subgoals were put before the
 dependent ones previously (Coq v8.5 and below). This can result in quite
 different performance behaviors of proof search.
+
+\subsection{\tt Set Typeclasses Allow Shelved}
+\optindex{Typeclasses Allow Shelved}
+
+This option (on by default in 8.6) governs the treatment of shelved
+goals during typeclass resolution (and {\tt typeclasses eauto} calls).
+If unset, shelved goals created during resolution must be solved at the
+end of it and cannot escape. Otherwise shelved goals are considered
+postponed and can remain at the end of resolution.
 
 \subsection{\tt Set Typeclasses Filtered Unification}
 \optindex{Typeclasses Filtered Unification}

--- a/tactics/class_tactics.mli
+++ b/tactics/class_tactics.mli
@@ -24,7 +24,8 @@ type search_strategy = Dfs | Bfs
 
 val set_typeclasses_strategy : search_strategy -> unit
 
-val typeclasses_eauto : ?only_classes:bool -> ?st:transparent_state -> ?strategy:search_strategy ->
+val typeclasses_eauto : ?allow_shelved:bool -> ?only_classes:bool ->
+			?st:transparent_state -> ?strategy:search_strategy ->
                         depth:(Int.t option) ->
                         Hints.hint_db_name list -> unit Proofview.tactic
 
@@ -41,6 +42,8 @@ module Search : sig
     ?st:Names.transparent_state ->
     (** The transparent_state used when working with local hypotheses  *)
     ?unique:bool ->
+    (** Should we allow shelved subgoals to remain (by default a global option) *)
+    ?allow_shelved:bool ->
     (** Should we force a unique solution *)
     only_classes:bool ->
     (** Should non-class goals be shelved and resolved at the end *)

--- a/test-suite/bugs/closed/5198.v
+++ b/test-suite/bugs/closed/5198.v
@@ -1,0 +1,42 @@
+(* -*- mode: coq; coq-prog-args: ("-emacs" "-boot" "-nois") -*- *)
+(* File reduced by coq-bug-finder from original input, then from 286 lines to 
+27 lines, then from 224 lines to 53 lines, then from 218 lines to 56 lines, 
+then from 269 lines to 180 lines, then from 132 lines to 48 lines, then from 
+253 lines to 65 lines, then from 79 lines to 65 lines *)
+(* coqc version 8.6.0 (November 2016) compiled on Nov 12 2016 14:43:52 with 
+OCaml 4.02.3
+   coqtop version jgross-Leopard-WS:/home/jgross/Downloads/coq/coq-v8.6,v8.6 
+(7e992fa784ee6fa48af8a2e461385c094985587d) *)
+Axiom admit : forall {T}, T.
+Set Printing Implicit.
+Inductive nat := O | S (_ : nat).
+Axiom f : forall (_ _ : nat), nat.
+Class ZLikeOps (e : nat)
+  := { LargeT : Type ; SmallT : Type ; CarryAdd : forall (_ _ : LargeT), LargeT 
+}.
+Class BarrettParameters :=
+  { b : nat ; k : nat ; ops : ZLikeOps (f b k) }.
+
+Axiom barrett_reduce_function_bundled : forall {params : BarrettParameters}
+                                               (_ : @LargeT _ (@ops params)),
+    @SmallT _ (@ops params).
+
+Instance ZZLikeOps e : ZLikeOps (f (S O) e)
+  := {| LargeT := nat ; SmallT := nat ; CarryAdd x y := y |}.
+
+Definition SRep := nat.
+Local Instance x86_25519_Barrett : BarrettParameters
+  := { b := S O ; k := O ; ops := ZZLikeOps O }.
+Definition SRepAdd : forall (_ _ : SRep), SRep
+  := let v := (fun x y => barrett_reduce_function_bundled (CarryAdd x y)) in
+     (fun x y : SRep => v x y).
+
+Definition SRepAdd'  : forall (_ _ : SRep), SRep
+  := fun x y : SRep => barrett_reduce_function_bundled (CarryAdd x y). 
+(* Error:
+In environment
+x : SRep
+y : SRep
+The term "x" has type "SRep" while it is expected to have type
+ "@LargeT ?e ?ZLikeOps".
+ *)

--- a/test-suite/success/Hints.v
+++ b/test-suite/success/Hints.v
@@ -27,6 +27,7 @@ Parameter f : nat -> nat.
 Parameter predf : forall n, pred n -> pred (f n).
 
 (* No conversion on let-bound variables and constants in pred (the default) *)
+
 Hint Resolve pred0 | 1 (pred _) : pred.
 Hint Resolve predf | 0 : pred.
 
@@ -57,9 +58,11 @@ Create HintDb pred2conv discriminated.
 Hint Resolve pred0 : pred2conv.
 Hint Resolve predconv | 1 (pred (S _)) : pred2conv.
 
-Goal pred 3.
+Definition g := f.
+
+Goal pred (g 0).
   Fail typeclasses eauto with pred2.
-  typeclasses eauto with pred2conv.
+  typeclasses eauto with predconv.
 Abort.
 
 Set Typeclasses Filtered Unification.

--- a/test-suite/success/HintsForward.v
+++ b/test-suite/success/HintsForward.v
@@ -1,0 +1,17 @@
+
+Parameter pred : nat -> Prop.
+Parameter pred0 : pred 0.
+Parameter f : nat -> nat.
+Parameter predf : forall n, pred n -> pred (f n).
+
+Parameter pred2 : nat -> Prop.
+Lemma foo n : pred n -> pred (S n).
+Admitted.
+
+Hint Extern 0 => match goal with [ H : pred ?n |- _ ] => pose (foo n H) end : bla.
+
+Hint Extern 100000 => shelve : bla.
+
+Goal pred 0 -> True.
+  intros.
+  unshelve typeclasses eauto 4 with bla.


### PR DESCRIPTION
This provides one way to fix 5198 and leaves the control of shelving/unshelving to the user (e.g. using unshelve tac; fail disallows remaining shelved goals in tac). I put an example of what one can do with this answering Michael Soegstrup's question on coq-club as well. Obviously this is experimental.