### PR TITLE
Add missing label. Fixes broken ref.

### DIFF
--- a/doc/refman/Classes.tex
+++ b/doc/refman/Classes.tex
@@ -380,6 +380,7 @@ use implicit generalization (see \ref{SectionContext}).
 
 \asubsection{\tt typeclasses eauto}
 \tacindex{typeclasses eauto}
+\label{typeclasseseauto}
 
 The {\tt typeclasses eauto} tactic uses a different resolution engine
 than {\tt eauto} and {\tt auto}. The main differences are the following:


### PR DESCRIPTION
##### Motivation for this change
In RefMan-tac.tex, `\ref{typeclasseseauto}` yields:

    ../Reference-Manual.html:10869: Warning, cannot find anchor: typeclasseseauto

and indeed, the reference is ?? in the generated HTML, instead of a link.

##### To note

1. I'm not asking for this to get merged before 8.6beta1. This is a minor fix and it can wait.
2. I am not 100% sure that this is the right way of fixing the problem that I was observing.