### PR TITLE
A possible fix to a dependency computation problem with .c files under MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,12 +63,16 @@ define findx
  $(shell find . $(FIND_VCS_CLAUSE) '(' -name $(1) ')' -exec $(2) {} \; | sed 's|^\./||')
 endef
 
+define finddir
+ $(shell find $(1) $(FIND_VCS_CLAUSE) '(' -name $(2) ')' -print | sed 's|^\./||')
+endef
+
 ## Files in the source tree
 
 LEXFILES := $(call find, '*.mll')
 export MLLIBFILES := $(call find, '*.mllib') $(call find, '*.mlpack')
 export ML4FILES := $(call find, '*.ml4')
-export CFILES := $(call find, '*.c')
+export CFILES := $(call finddir, 'kernel/byterun', '*.c')
 
 # NB: The lists of currently existing .ml and .mli files will change
 # before and after a build or a make clean. Hence we do not export

--- a/Makefile.build
+++ b/Makefile.build
@@ -238,7 +238,7 @@ kernel/copcodes.ml: kernel/byterun/coq_instruct.h
 	$(SHOW)'CCDEP	$<'
 	$(HIDE)echo "$@ $(@:.c.d=.o): $(@:.c.d=.c)" > $@
 
-%.c.d: $(D_DEPEND_BEFORE_SRC) %.c $(D_DEPEND_AFTER_SRC) $(GENHFILES)
+kernel/byterun/%.c.d: $(D_DEPEND_BEFORE_SRC) kernel/byterun/%.c $(D_DEPEND_AFTER_SRC) $(GENHFILES)
 	$(SHOW)'CCDEP     $<'
 	$(HIDE)$(OCAMLC) -ccopt "-MM -MQ $@ -MQ $(<:.c=.o) -isystem $(CAMLHLIB)" $< $(TOTARGET)
 


### PR DESCRIPTION
Under MacOS X, "cc" issues a warning on "#include <windows.h>" and the .c.d file is not generated (so that the warning and failure is repeated at each new call to "make").

(Note however that under linux, the .c.d is generated, without a warning.)

I don't know if this is the intended way to fix this, but this commit at least proposes a fix to avoid the warning (the fix is to not compile the .c.d files in dev/build/windows).