### PR TITLE
A refined solution to the beta-iota discrepancies between 8.4 and 8.5/8.6 "refine"

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -18,6 +18,11 @@ Tactics
     missed before because of a missing normalization step. Hopefully this should
     be fairly uncommon.
 - "auto with real" can now discharge comparisons of literals
+- The types of variables in patterns of "match" are now
+  beta-iota-reduced after type-checking. This has an impact on the
+  type of the variables that the tactic "refine" introduces in the
+  context, producing types a priori closer to the expectations.
+
 
 Standard Library
 

--- a/pretyping/cases.ml
+++ b/pretyping/cases.ml
@@ -1245,6 +1245,12 @@ let build_branch initial current realargs deps (realnames,curname) pb arsign eqn
   let typs = List.map2 RelDecl.set_name names cs_args
   in
 
+  (* Beta-iota-normalize types to better compatibility of refine with 8.4 behavior *)
+  (* This is a bit too strong I think, in the sense that what we would *)
+  (* really like is to have beta-iota reduction only at the positions where *)
+  (* parameters are substituted *)
+  let typs = List.map (map_type (nf_betaiota !(pb.evdref))) typs in
+
   (* We build the matrix obtained by expanding the matching on *)
   (* "C x1..xn as x" followed by a residual matching on eqn into *)
   (* a matching on "x1 .. xn eqn" *)

--- a/test-suite/bugs/closed/5219.v
+++ b/test-suite/bugs/closed/5219.v
@@ -1,0 +1,10 @@
+(* Test surgical use of beta-iota in the type of variables coming from
+   pattern-matching for refine *)
+
+Goal forall x : sigT (fun x => x = 1), True.
+  intro x; refine match x with
+                  | existT _ x' e' => _
+                  end.
+  lazymatch goal with
+  | [ H : _ = _ |- _ ] => idtac
+  end.


### PR DESCRIPTION
There is a long story of commits trying to improve the compatibility between 8.4 and 8.5 refine, as discussed in [#346](https://github.com/coq/coq/pull/346).

The current commit tries to identify (one of?) the exact points of divergence between 8.4 and 8.5 refine, namely the beta-iota normalisation done in the types of arguments of constructors in pattern-matching.

For the record, note that for the conclusion of each new goal, there were a nf_betaiota in 8.4 done in function Evarutil.evars_to_metas, so the compatibility expects that such a nf_betaiota on the conclusion of each goal remains.

See also bug report [#5219](https://coq.inria.fr/bugs/show_bug.cgi?id=5219) for elements of discussion.