### PR TITLE
A fix to #5220 ("destruct"'s section variable test too approximative).

### DIFF
--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -4356,6 +4356,16 @@ let has_generic_occurrences_but_goal cls id env ccl =
   (* TODO: whd_evar of goal *)
   (cls.concl_occs != NoOccurrences || not (occur_var env id ccl))
 
+let look_like_section_variable env sigma id =
+  try
+    let d = Context.Named.lookup id (Global.named_context ()) in
+    let d' = Context.Named.lookup id (named_context env) in
+    is_conv env sigma (get_type d) (get_type d')
+    && Option.equal (is_conv env sigma) (get_value d) (get_value d')
+  with
+    | Not_found -> false
+    | e when noncritical e -> false
+
 let induction_gen clear_flag isrec with_evars elim
     ((_pending,(c,lbind)),(eqname,names) as arg) cls =
   let inhyps = match cls with
@@ -4368,7 +4378,7 @@ let induction_gen clear_flag isrec with_evars elim
   let cls = Option.default allHypsAndConcl cls in
   let t = typ_of env sigma c in
   let is_arg_pure_hyp =
-    isVar c && not (mem_named_context_val (destVar c) (Global.named_context_val ()))
+    isVar c && not (look_like_section_variable env (Sigma.to_evar_map sigma) (destVar c))
     && lbind == NoBindings && not with_evars && Option.is_empty eqname
     && clear_flag == None
     && has_generic_occurrences_but_goal cls (destVar c) env ccl in

--- a/test-suite/bugs/closed/5220.v
+++ b/test-suite/bugs/closed/5220.v
@@ -1,0 +1,12 @@
+(* Check that destruct does not use only the name to tell that a goal
+   variable is a section variable *)
+
+Section foo.
+Context (H : True).
+
+Lemma bar : True \/ True -> True.
+Proof.
+  (* Does not remove H : True \/ True *)
+  clear H. intros H. destruct H as [H'|H'].
+  Fail Check H.
+Abort.


### PR DESCRIPTION
This is a proposal to at least fix #5220, even if the general problem of confusion of a section variable with a goal variable is more complex.

The fix is just to make a more robust check for section variables (using also the type, not only the name), even if it is well-known that Coq is missing the ability to trace which goal variables originate from section variables, independently of their name and type.

There is a risk of incompatibilities and I started a test.