### PR TITLE
Better editing of the standard library in coqtop/PG

### DIFF
--- a/theories/.dir-locals.el
+++ b/theories/.dir-locals.el
@@ -1,0 +1,4 @@
+((coq-mode . ((eval . (let ((default-directory (locate-dominating-file
+						buffer-file-name ".dir-locals.el")))
+			(setq-local coq-prog-args `("-coqlib" ,(expand-file-name "..") "-R" ,(expand-file-name ".") "Coq"))
+			(setq-local coq-prog-name (expand-file-name "../bin/coqtop")))))))

--- a/theories/Init/_CoqProject
+++ b/theories/Init/_CoqProject
@@ -1,0 +1,2 @@
+-R .. Coq
+-arg -noinit


### PR DESCRIPTION
Change a proof that only compiled non-interactively in `Coq.Init.Logic`, and add `.dir-locals.el` files to set up PG to allow easy editing of the standard library.

@cpitclaudel might have useful comments about the `.dir-locals.el` setup.