### PR TITLE
patch for printing types of let bindings

### DIFF
--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -695,7 +695,7 @@ and detype_binder (lax,isgoal as flags) bk avoid env sigma na body ty c =
       let c = detype (lax,false) avoid env sigma (Option.get body) in
       (* Heuristic: we display the type if in Prop *)
       let s = try Retyping.get_sort_family_of (snd env) sigma ty with _ when !Flags.in_debugger || !Flags.in_toplevel -> InType (* Can fail because of sigma missing in debugger *) in
-      let t = if s != InProp then None else Some (detype (lax,false) avoid env sigma ty) in
+      let t = if s != InProp  && not !Flags.raw_print then None else Some (detype (lax,false) avoid env sigma ty) in
       GLetIn (dl, na', c, t, r)
 
 let detype_rel_context ?(lax=false) where avoid env sigma sign =


### PR DESCRIPTION
All of this is work was done by @herbelin. Thanks @herbelin.
After applying the patch, I see the types of let bindings. For example:
```
Definition xx :nat := 
let x:=0 in x.

(* Set Printing All in CoqIDE menu *)

Print xx.
(*
xx = let x := O : nat in x
     : nat
*)
```