### PR TITLE
[native comp] Improve error message on linking error.

### DIFF
--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -795,7 +795,10 @@ type compiled_library = {
 type native_library = Nativecode.global list
 
 let get_library_native_symbols senv dir =
-  DPMap.find dir senv.native_symbols
+  try DPMap.find dir senv.native_symbols
+  with Not_found -> Errors.errorlabstrm "get_library_native_symbols"
+                      Pp.((str "Linker error in the native compiler. Are you using Require inside a nested Module declaration?") ++ fnl () ++
+                          (str "This use case is not supported, but disabling the native compiler may help."))
 
 (** FIXME: MS: remove?*)
 let current_modpath senv = senv.modpath


### PR DESCRIPTION
The native compiler doesn't support `Require` inside `Module` sections
in some cases, we improve the error message. See:

https://coq.inria.fr/bugs/show_bug.cgi?id=4335

This patch improves the error message and gives the user some
feedback.

Submitting to v8.5 as a few users affected were indeed in 8.5, but should be merged back to v8.7