### PR TITLE
An intropattern-style variant for split

### DIFF
--- a/tactics/hipattern.mli
+++ b/tactics/hipattern.mli
@@ -32,7 +32,7 @@ open Coqlib
    contained in the arguments of the application *)
 
 (** I implemented the following functions which test whether a term [t]
-   is an inductive but non-recursive type, a general conjuction, a
+   is an inductive but non-recursive type, a general conjunction, a
    general disjunction, or a type with no constructors.
 
    They are more general than matching with [or_term], [and_term], etc,

--- a/test-suite/success/intros.v
+++ b/test-suite/success/intros.v
@@ -128,3 +128,10 @@ exact Logic.I.
 Qed.
 
 
+(* Test intro-patterns for splitting *)
+
+Goal (False/\True) <-> False.
+intros [(H,H')|H].
+- exact H.
+- contradiction.
+Qed.


### PR DESCRIPTION
I implemented an idea proposed by Théo which "solves" the issue of having to use two steps for the split and introduction of an "iff" (i.e. "split; [intros H|intros H]", resp "split => [H|H]" for ssreflect afficionados).

The idea is to reuse the [ pat1 | ... | patn ] pattern for splitting:

```
Goal True <-> False.
intros [H|H].
(*
2 subgoals
  
  H : True
  ============================
  False

subgoal 2 is:
 True
*)
```

Of course, this applies only if the goal is not an implication, even after reduction.

We are looking for a nice notation for nested conjunctions, similar to the "( pat1 & ... & patn )" pattern, but for disjunction. Any ideas?