### PR TITLE
fix Emacs compiler warning on '(lambda...)

### DIFF
--- a/tools/gallina-db.el
+++ b/tools/gallina-db.el
@@ -163,7 +163,7 @@ for DB structure."
 
 (defun coq-sort-menu-entries (menu)
   (sort menu 
-	'(lambda (x y) (string< 
+	(lambda (x y) (string< 
 			(downcase (elt x 0)) 
 			(downcase (elt y 0))))))
 


### PR DESCRIPTION
lambda is self-quoting, see elisp manual, section 12.7 Anonymous Functions