### PR TITLE
Fix the way setoid_rewrite handles bindings.

### DIFF
--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -661,7 +661,8 @@ let evar_of_binder holes = function
 | NamedHyp s -> evar_with_name holes s
 | AnonHyp n ->
   try
-    let h = List.nth holes (pred n) in
+    let nondeps = List.filter (fun hole -> not hole.hole_deps) holes in
+    let h = List.nth nondeps (pred n) in
     h.hole_evar
   with e when CErrors.noncritical e ->
     errorlabstrm "" (str "No such binder.")


### PR DESCRIPTION
There is a discrepancy between `rewrite H with (1 := x)` and `setoid_rewrite H with (1 := x)` that was introduced in 8.5: in the former, `x` is used to instantiate the first non-dependent hypothesis of `H`, while in the latter, the first hypothesis (dependent or not) of `H` is instantiated.
Note that in some cases, even `rewrite H with (1 := x)` will change its behaviour, if it switched internally to setoid rewriting.

In 8.4, both expressions behave the same and select the first non-dependent hypothesis, which is also consistent with the way `intros until 1` works.
This 2 lines commit reestablishes the previous behaviour.

I cannot really tell how much breakage this change could occur, but since nobody complained between 8.4 and 8.5, I am guessing not much. Maybe nobody really uses this syntax.