### PR TITLE
An experiment in locally setting an option in a tactic (and a fix to #5281)

### DIFF
--- a/engine/proofview.mli
+++ b/engine/proofview.mli
@@ -393,6 +393,10 @@ val tclTIMEOUT : int -> 'a tactic -> 'a tactic
     identifying annotation if present *)
 val tclTIME : string option -> 'a tactic -> 'a tactic
 
+(** [tclOPTION o v t] sets option o to value v while executing t *)
+val tclWITHOPTION : Goptions.option_name ->
+  Goptions.option_value -> 'a tactic -> 'a tactic
+
 (** {7 Unsafe primitives} *)
 
 (** The primitives in the [Unsafe] module should be avoided as much as

--- a/library/goptions.mli
+++ b/library/goptions.mli
@@ -175,6 +175,14 @@ type option_value =
   | StringValue of string
   | StringOptValue of string option
 
+
+(* For use in tactics: to be used in pairs *)
+type previous_option_value
+val override_option_value    : option_name -> option_value -> previous_option_value
+val restore_option_value : option_name -> previous_option_value -> unit
+
+val with_option_value : option_name -> option_value -> ('a -> 'b) -> 'a -> 'b
+
 (** Summary of an option status *)
 type option_state = {
   opt_sync  : bool;

--- a/tactics/eqdecide.ml
+++ b/tactics/eqdecide.ml
@@ -74,7 +74,11 @@ let mkBranches c1 c2 =
 
 let discrHyp id =
   let c = { delayed = fun env sigma -> Sigma.here (Term.mkVar id, NoBindings) sigma } in
-  let tac c = Equality.discr_tac false (Some (None, ElimOnConstr c)) in
+  let tac c =
+    Proofview.tclWITHOPTION
+      Equality.keep_proof_equalities_for_injection_name
+      (Goptions.BoolValue true)
+      (Equality.discr_tac false (Some (None, ElimOnConstr c))) in
   Tacticals.New.tclDELAYEDWITHHOLES false c tac
 
 let solveNoteqBranch side =
@@ -122,7 +126,11 @@ let eqCase tac =
 
 let injHyp id =
   let c = { delayed = fun env sigma -> Sigma.here (Term.mkVar id, NoBindings) sigma } in
-  let tac c = Equality.injClause None false (Some (None, ElimOnConstr c)) in
+  let tac c =
+    Proofview.tclWITHOPTION
+      Equality.keep_proof_equalities_for_injection_name
+      (Goptions.BoolValue true)
+      (Equality.injClause None false (Some (None, ElimOnConstr c))) in
   Tacticals.New.tclDELAYEDWITHHOLES false c tac
 
 let diseqCase hyps eqonleft =

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -704,12 +704,14 @@ exception DiscrFound of
 
 let keep_proof_equalities_for_injection = ref false
 
+let keep_proof_equalities_for_injection_name = ["Keep";"Proof";"Equalities"]
+
 let _ =
   declare_bool_option
     { optsync  = true;
       optdepr  = false;
       optname  = "injection on prop arguments";
-      optkey   = ["Keep";"Proof";"Equalities"];
+      optkey   = keep_proof_equalities_for_injection_name;
       optread  = (fun () -> !keep_proof_equalities_for_injection) ;
       optwrite = (fun b -> keep_proof_equalities_for_injection := b) }
 

--- a/tactics/equality.mli
+++ b/tactics/equality.mli
@@ -82,6 +82,8 @@ val injConcl     : unit Proofview.tactic
 val simpleInjClause : evars_flag ->
   constr with_bindings destruction_arg option -> unit Proofview.tactic
 
+val keep_proof_equalities_for_injection_name : Goptions.option_name
+
 val dEq : evars_flag -> constr with_bindings destruction_arg option -> unit Proofview.tactic
 val dEqThen : evars_flag -> (clear_flag -> constr -> int -> unit Proofview.tactic) -> constr with_bindings destruction_arg option -> unit Proofview.tactic
 

--- a/test-suite/bugs/closed/5281.v
+++ b/test-suite/bugs/closed/5281.v
@@ -1,0 +1,6 @@
+Inductive A (T : Prop) := B (_ : T).
+Scheme Equality for A.
+
+Goal forall (T:Prop), (forall x y : T, {x=y}+{x<>y}) -> forall x y : A T, {x=y}+{x<>y}.
+decide equality.
+Qed.

--- a/vernac/auto_ind_decl.ml
+++ b/vernac/auto_ind_decl.ml
@@ -95,6 +95,18 @@ let destruct_on_using c id =
 let destruct_on_as c l =
   destruct false None c (Some (dl,l)) None
 
+let my_discr_tac =
+  Proofview.tclWITHOPTION
+    Equality.keep_proof_equalities_for_injection_name
+    (Goptions.BoolValue true)
+    (Equality.discr_tac false None)
+
+let my_inj_tac x =
+  Proofview.tclWITHOPTION
+    Equality.keep_proof_equalities_for_injection_name
+    (Goptions.BoolValue true)
+    (Equality.inj None false None (mkVar x,NoBindings))
+
 (* reconstruct the inductive with the correct deBruijn indexes *)
 let mkFullInd (ind,u) n =
   let mib = Global.lookup_mind (fst ind) in
@@ -592,7 +604,7 @@ let compute_bl_tact mode bl_scheme_key ind lnamesparrec nparrec =
                      intro_using freshz;
                      intros;
                      Tacticals.New.tclTRY (
-                      Tacticals.New.tclORELSE reflexivity (Equality.discr_tac false None)
+                      Tacticals.New.tclORELSE reflexivity my_discr_tac
                      );
                      simpl_in_hyp (freshz,Locus.InHyp);
 (*
@@ -736,9 +748,9 @@ let compute_lb_tact mode lb_scheme_key ind lnamesparrec nparrec =
                      intro_using freshz;
                      intros;
                      Tacticals.New.tclTRY (
-                      Tacticals.New.tclORELSE reflexivity (Equality.discr_tac false None)
+                      Tacticals.New.tclORELSE reflexivity my_discr_tac
                      );
-                     Equality.inj None false None (mkVar freshz,NoBindings);
+                     my_inj_tac freshz;
 		     intros; simpl_in_concl;
                      Auto.default_auto;
                      Tacticals.New.tclREPEAT (
@@ -933,7 +945,7 @@ let compute_dec_tact ind lnamesparrec nparrec =
                                 NoBindings
                               )
                               true;
-              Equality.discr_tac false None
+              my_discr_tac
 	    ]
             end }
 	  ]


### PR DESCRIPTION
This PR provides a tactical Proofview.tclWITHOPTION for locally setting an option while calling a tactic.

It uses a Proofview.tclIO tactical which follows the same pattern as tclTIME (because of the abstraction of the monad, we cannot just activate/deactivate the option while calling `tac : unit tactic`; we need to set the option at the time it is run - or at least I did not know how to do differently).

As an application, we set `Keep Proof Equalities` while calling `injection` and `discriminate` from `decide equality` and `Scheme Equality` which allows them to work better in general (for instance it fixes Jason's bug #5281 about decision of equality for `Inductive A (T : Prop) := B (_ : T).`).

No concrete syntax is given yet for letting it being used user-side but this would be possible eventually.