### PR TITLE
[travis] [External CI] [geocoq] don't build slow file

### DIFF
--- a/dev/ci/ci-geocoq.sh
+++ b/dev/ci/ci-geocoq.sh
@@ -9,4 +9,8 @@ GeoCoq_CI_GITURL=https://github.com/GeoCoq/GeoCoq.git
 
 git clone --depth 1 -b ${GeoCoq_CI_BRANCH} ${GeoCoq_CI_GITURL}
 
-( cd GeoCoq && ./configure.sh && make -j ${NJOBS} )
+( cd GeoCoq                                               && \
+  ./configure.sh                                          && \
+  sed -i.bak '/Ch16_coordinates_with_functions\.v/d' Make && \
+  coq_makefile -f Make -o Makefile                        && \
+  make -j ${NJOBS} )


### PR DESCRIPTION
Unfortunately `Ch16_coordinates_with_functions.v` takes alone ~15
minutes in my computer, which is too much for Travis. Pity, because it was a nice use case.

This fixes a timeout on the CI server