### PR TITLE
Report missing tactic arguments in error message

### DIFF
--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -1422,7 +1422,14 @@ and tactic_of_value ist vle =
         extra = TacStore.set ist.extra f_trace []; } in
       let tac = name_if_glob appl (eval_tactic ist t) in
       Profile_ltac.do_profile "tactic_of_value" trace (catch_error_tac trace tac)
-  | (VFun _|VRec _) -> Tacticals.New.tclZEROMSG (str "A fully applied tactic is expected.")
+  | VFun (_, _, _,vars,_) ->
+    let numargs = List.length vars in
+    Tacticals.New.tclZEROMSG
+      (str "A fully applied tactic is expected:" ++ spc() ++ Pp.str "missing " ++
+       Pp.str (String.plural numargs "argument") ++ Pp.str " for " ++
+       Pp.str (String.plural numargs "variable") ++ Pp.str " " ++
+       pr_enum pr_name vars ++ Pp.str ".")
+  | VRec _ -> Tacticals.New.tclZEROMSG (str "A fully applied tactic is expected.")
   else if has_type vle (topwit wit_tactic) then
     let tac = out_gen (topwit wit_tactic) vle in
     tactic_of_value ist tac

--- a/test-suite/output/ltac_missing_args.out
+++ b/test-suite/output/ltac_missing_args.out
@@ -1,0 +1,21 @@
+The command has indeed failed with message:
+Error: A fully applied tactic is expected: missing argument for variable x.
+The command has indeed failed with message:
+Error: A fully applied tactic is expected: missing argument for variable x.
+The command has indeed failed with message:
+Error: A fully applied tactic is expected:
+missing arguments for variables y and _.
+The command has indeed failed with message:
+Error: A fully applied tactic is expected: missing argument for variable x.
+The command has indeed failed with message:
+Error: A fully applied tactic is expected: missing argument for variable x.
+The command has indeed failed with message:
+Error: A fully applied tactic is expected: missing argument for variable _.
+The command has indeed failed with message:
+Error: A fully applied tactic is expected: missing argument for variable _.
+The command has indeed failed with message:
+Error: A fully applied tactic is expected: missing argument for variable _.
+The command has indeed failed with message:
+Error: A fully applied tactic is expected: missing argument for variable x.
+The command has indeed failed with message:
+Error: A fully applied tactic is expected: missing argument for variable x.

--- a/test-suite/output/ltac_missing_args.v
+++ b/test-suite/output/ltac_missing_args.v
@@ -1,0 +1,19 @@
+Ltac foo x := idtac x.
+Ltac bar x := fun y _ => idtac x y.
+Ltac baz := foo.
+Ltac qux := bar.
+Ltac mydo tac := tac ().
+Ltac rec x := rec.
+
+Goal True.
+  Fail foo.
+  Fail bar.
+  Fail bar True.
+  Fail baz.
+  Fail qux.
+  Fail mydo ltac:(fun _ _ => idtac).
+  Fail let tac := (fun _ => idtac) in tac.
+  Fail (fun _ => idtac).
+  Fail rec True.
+  Fail let rec tac x := tac in tac True.
+Abort.


### PR DESCRIPTION
Augments "A fully applied tactic is expected" with the list of missing
arguments to the tactic. Addresses [bug 5344](https://coq.inria.fr/bugs/show_bug.cgi?id=5344).