### PR TITLE
Don't require printing-only notation to be productive

### DIFF
--- a/parsing/g_prim.ml4
+++ b/parsing/g_prim.ml4
@@ -34,7 +34,7 @@ GEXTEND Gram
   GLOBAL:
     bigint natural integer identref name ident var preident
     fullyqualid qualid reference dirpath ne_lstring
-    ne_string string pattern_ident pattern_identref by_notation smart_global;
+    ne_string string lstring pattern_ident pattern_identref by_notation smart_global;
   preident:
     [ [ s = IDENT -> s ] ]
   ;
@@ -105,6 +105,9 @@ GEXTEND Gram
   ;
   string:
     [ [ s = STRING -> s ] ]
+  ;
+  lstring:
+    [ [ s = string -> (!@loc, s) ] ]
   ;
   integer:
     [ [ i = INT      -> my_int_of_string (!@loc) i

--- a/parsing/g_vernac.ml4
+++ b/parsing/g_vernac.ml4
@@ -1122,7 +1122,7 @@ GEXTEND Gram
 	 idl = LIST0 ident; ":="; c = constr; b = only_parsing ->
            VernacSyntacticDefinition
 	     (id,(idl,c),local,b)
-     | IDENT "Notation"; local = obsolete_locality; s = ne_lstring; ":=";
+     | IDENT "Notation"; local = obsolete_locality; s = lstring; ":=";
 	 c = constr;
          modl = [ "("; l = LIST1 syntax_modifier SEP ","; ")" -> l | -> [] ];
 	 sc = OPT [ ":"; sc = IDENT -> sc ] ->

--- a/parsing/pcoq.ml
+++ b/parsing/pcoq.ml
@@ -267,6 +267,7 @@ module Prim =
     let integer = gec_gen "integer"
     let bigint = Gram.entry_create "Prim.bigint"
     let string = gec_gen "string"
+    let lstring = Gram.entry_create "Prim.lstring"
     let reference = make_gen_entry uprim "reference"
     let by_notation = Gram.entry_create "by_notation"
     let smart_global = Gram.entry_create "smart_global"

--- a/parsing/pcoq.mli
+++ b/parsing/pcoq.mli
@@ -137,6 +137,7 @@ module Prim :
     val bigint : Bigint.bigint Gram.entry
     val integer : int Gram.entry
     val string : string Gram.entry
+    val lstring : string located Gram.entry
     val qualid : qualid located Gram.entry
     val fullyqualid : Id.t list located Gram.entry
     val reference : reference Gram.entry

--- a/test-suite/success/Notations.v
+++ b/test-suite/success/Notations.v
@@ -132,3 +132,6 @@ Qed.
 (* Check that we can have notations without any symbol iff they are "only printing". *)
 Fail Notation "" := (@nil).
 Notation "" := (@nil) (only printing).
+
+(* Check that a notation cannot be neither parsing nor printing. *)
+Fail Notation "'foobarkeyword'" := (@nil) (only parsing, only printing).

--- a/test-suite/success/Notations.v
+++ b/test-suite/success/Notations.v
@@ -128,3 +128,7 @@ Notation " |- {{ a }} b" := (a=b) (no associativity, at level 10).
 Goal True.
 {{ exact I. }}
 Qed.
+
+(* Check that we can have notations without any symbol iff they are "only printing". *)
+Fail Notation "" := (@nil).
+Notation "" := (@nil) (only printing).

--- a/toplevel/metasyntax.ml
+++ b/toplevel/metasyntax.ml
@@ -984,6 +984,7 @@ let remove_curly_brackets l =
 
 let compute_syntax_data df modifiers =
   let (assoc,n,etyps,onlyparse,onlyprint,compat,fmt,extra) = interp_modifiers modifiers in
+  if onlyprint && onlyparse then error "A notation cannot be both 'only printing' and 'only parsing'.";
   let assoc = match assoc with None -> (* default *) Some NonA | a -> a in
   let toks = split_notation_string df in
   let (recvars,mainvars,symbols) = analyze_notation_tokens toks in

--- a/toplevel/metasyntax.ml
+++ b/toplevel/metasyntax.ml
@@ -903,8 +903,8 @@ let find_precedence lev etyps symbols =
   let first_symbol =
     let rec aux = function
       | Break _ :: t -> aux t
-      | h :: t -> h
-      | [] -> assert false (* rule is known to be productive *) in
+      | h :: t -> Some h
+      | [] -> None in
     aux symbols in
   let last_is_terminal () =
     let rec aux b = function
@@ -914,7 +914,8 @@ let find_precedence lev etyps symbols =
       | [] -> b in
     aux false symbols in
   match first_symbol with
-  | NonTerminal x ->
+  | None -> [],0
+  | Some (NonTerminal x) ->
       (try match List.assoc x etyps with
 	| ETConstr _ ->
 	    error "The level of the leftmost non-terminal cannot be changed."
@@ -937,11 +938,11 @@ let find_precedence lev etyps symbols =
 	if Option.is_empty lev then
 	  error "A left-recursive notation must have an explicit level."
 	else [],Option.get lev)
-  | Terminal _ when last_is_terminal () ->
+  | Some (Terminal _) when last_is_terminal () ->
       if Option.is_empty lev then
 	([Feedback.msg_info ?loc:None ,strbrk "Setting notation at level 0."], 0)
       else [],Option.get lev
-  | _ ->
+  | Some _ ->
       if Option.is_empty lev then error "Cannot determine the level.";
       [],Option.get lev
 
@@ -991,7 +992,7 @@ let compute_syntax_data df modifiers =
   let symbols' = remove_curly_brackets symbols in
   let need_squash = not (List.equal Notation.symbol_eq symbols symbols') in
   let ntn_for_grammar = make_notation_key symbols' in
-  check_rule_productivity symbols';
+  if not onlyprint then check_rule_productivity symbols';
   let msgs,n = find_precedence n etyps symbols' in
   let innerlevel = NumLevel 200 in
   let typs =


### PR DESCRIPTION
This fixes #5256. While I was at it, I also added an error message for notations that are marked both "only printing" and "only parsing"... that combination just makes no sense.

Note that I have no idea what I am doing here. I have zero experience in OCaml and camlp{4,5}, and only very little experience in SML. I changed things until they compiled, and copy-pasted from the surrounding where necessary (e.g. to add the `lstring` thing).

Also, there should probably be tests, both for new things that are accepted and for things that are rejected. Do I just have to drop some file(s) somewhere -- and what would be the right place?
