### PR TITLE
Print Warnings feature.

### DIFF
--- a/intf/vernacexpr.mli
+++ b/intf/vernacexpr.mli
@@ -75,6 +75,9 @@ type printable =
   | PrintImplicit of reference or_by_notation
   | PrintAssumptions of bool * bool * reference or_by_notation
   | PrintStrategy of reference or_by_notation option
+  | PrintWarnings
+  | PrintCategoryWarnings of string
+  | PrintWarning of string
 
 type search_about_item =
   | SearchSubPattern of constr_pattern_expr

--- a/lib/cWarnings.mli
+++ b/lib/cWarnings.mli
@@ -8,6 +8,13 @@
 
 type status = Disabled | Enabled | AsError
 
+type t = {
+  name : string;
+  default : status;
+  category : string;
+  status : status;
+}
+
 val set_current_loc : Loc.t -> unit
 
 val create : name:string -> category:string -> ?default:status ->
@@ -19,3 +26,7 @@ val set_flags : string -> unit
 (** Cleans up a user provided warnings status string, e.g. removing unknown
     warnings (in which case a warning is emitted) or subsumed warnings . *)
 val normalize_flags_string : string -> string
+
+val get_categories : unit -> string list
+val get_category_warnings : string -> t list
+val get_warning : string -> t

--- a/parsing/g_vernac.ml4
+++ b/parsing/g_vernac.ml4
@@ -984,7 +984,10 @@ GEXTEND Gram
       | IDENT "Transparent"; IDENT "Dependencies"; qid = smart_global -> PrintAssumptions (false, true, qid)
       | IDENT "All"; IDENT "Dependencies"; qid = smart_global -> PrintAssumptions (true, true, qid)
       | IDENT "Strategy"; qid = smart_global -> PrintStrategy (Some qid)
-      | IDENT "Strategies" -> PrintStrategy None ] ]
+      | IDENT "Strategies" -> PrintStrategy None
+      | IDENT "Warnings" -> PrintWarnings
+      | IDENT "Category"; IDENT "Warnings"; s = STRING -> PrintCategoryWarnings(s)
+      | IDENT "Warning"; s = STRING -> PrintWarning(s) ] ]
   ;
   class_rawexpr:
     [ [ IDENT "Funclass" -> FunClass

--- a/printing/ppvernac.ml
+++ b/printing/ppvernac.ml
@@ -522,6 +522,13 @@ module Make
       keyword "Print Strategies"
     | PrintStrategy (Some qid) ->
       keyword "Print Strategy" ++ pr_smart_global qid
+    | PrintWarnings ->
+       keyword "Print Warnings"
+    | PrintCategoryWarnings(s) ->
+       keyword "Print Category Warnings" ++ spc () ++ str s
+    | PrintWarning(s) ->
+       keyword "Print Warning" ++ spc () ++ str s
+
 
   let pr_using e = str (Proof_using.to_string e)
 

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -9,6 +9,7 @@
 (* Concrete syntax of the mathematical vernacular MV V2.6 *)
 
 open Pp
+open CWarnings
 open CErrors
 open Util
 open Flags
@@ -322,6 +323,23 @@ let print_strategy r =
     in
     let lvl = get_strategy oracle key in
     Feedback.msg_notice (pr_strategy (r, lvl))
+
+let pr_warning w =
+  let pr_status = function
+  | AsError -> str "error"
+  | Disabled -> str "disabled"
+  | Enabled -> str "enabled"
+  in
+  hov 0 (str w.CWarnings.name ++ spc () ++ pr_status w.status ++ spc () ++
+    str "(default: " ++ pr_status w.default ++ str ")")
+
+let pr_category_warnings category =
+  let warnings = get_category_warnings category in
+  let warnings = pr_vertical_list pr_warning warnings in
+  hov 1 (str category ++ str":" ++ fnl () ++ warnings) ++ fnl ()
+
+let pr_warnings () =
+  pr_vertical_list pr_category_warnings (get_categories ())
 
 let dump_universes_gen g s =
   let output = open_out s in
@@ -1707,6 +1725,9 @@ let vernac_print = let open Feedback in function
 	Assumptions.assumptions st ~add_opaque:o ~add_transparent:t gr cstr in
       msg_notice (Printer.pr_assumptionset (Global.env ()) nassums)
   | PrintStrategy r -> print_strategy r
+  | PrintWarnings -> Feedback.msg_notice (pr_warnings ())
+  | PrintCategoryWarnings c -> Feedback.msg_notice (pr_category_warnings c)
+  | PrintWarning w -> Feedback.msg_notice (pr_warning (get_warning w))
 
 let global_module r =
   let (loc,qid) = qualid_of_reference r in


### PR DESCRIPTION
This commit introduces three toplevel commands:
- Print Warning "warning".
- Print Category Warnings "category".
- Print Warnings.

It is a reimplementation of PR #354, that separates printing concerns
from the warnings API.