### PR TITLE
Univs: fix bug #5365, generation of u+k <= v constraints

### DIFF
--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -809,8 +809,9 @@ let new_sort_variable ?loc ?name rigid d =
 let add_global_univ d u =
   { d with universes = UState.add_global_univ d.universes u }
 
-let make_flexible_variable evd b u =
-  { evd with universes = UState.make_flexible_variable evd.universes b u }
+let make_flexible_variable evd ~algebraic u =
+  { evd with universes =
+      UState.make_flexible_variable evd.universes ~algebraic u }
 
 let make_evar_universe_context e l =
   let uctx = UState.make (Environ.universes e) in

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -526,7 +526,9 @@ val new_sort_variable : ?loc:Loc.t -> ?name:string -> rigid -> evar_map -> evar_
 val add_global_univ : evar_map -> Univ.Level.t -> evar_map
 
 val universe_rigidity : evar_map -> Univ.Level.t -> rigid
-val make_flexible_variable : evar_map -> bool -> Univ.universe_level -> evar_map
+val make_flexible_variable : evar_map -> algebraic:bool -> Univ.universe_level -> evar_map
+(** See [UState.make_flexible_variable] *)
+
 val is_sort_variable : evar_map -> sorts -> Univ.universe_level option 
 (** [is_sort_variable evm s] returns [Some u] or [None] if [s] is 
     not a local sort variable declared in [evm] *)

--- a/engine/uState.mli
+++ b/engine/uState.mli
@@ -92,7 +92,14 @@ val emit_side_effects : Safe_typing.private_constants -> t -> t
 
 val new_univ_variable : ?loc:Loc.t -> rigid -> string option -> t -> t * Univ.Level.t
 val add_global_univ : t -> Univ.Level.t -> t
-val make_flexible_variable : t -> bool -> Univ.Level.t -> t
+
+(** [make_flexible_variable g algebraic l]
+
+  Turn the variable [l] flexible, and algebraic if [algebraic] is true
+  and [l] can be. That is if there are no strict upper constraints on
+  [l] and and it does not appear in the instance of any non-algebraic
+  universe. Otherwise the variable is just made flexible. *)
+val make_flexible_variable : t -> algebraic:bool -> Univ.Level.t -> t
 
 val is_sort_variable : t -> Sorts.t -> Univ.Level.t option
 

--- a/pretyping/evarsolve.ml
+++ b/pretyping/evarsolve.ml
@@ -67,7 +67,7 @@ let refresh_universes ?(status=univ_rigid) ?(onlyalg=false) ?(refreshset=false)
 	       else t
 	    | UnivFlexible alg ->
 	       if onlyalg && alg then
-	         (evdref := Evd.make_flexible_variable !evdref false l; t)
+	         (evdref := Evd.make_flexible_variable !evdref ~algebraic:false l; t)
 	       else t))
     | Sort (Prop Pos as s) when refreshset && not direction ->
        (* Cannot make a universe "lower" than "Set",

--- a/test-suite/bugs/closed/5365.v
+++ b/test-suite/bugs/closed/5365.v
@@ -1,0 +1,13 @@
+
+Inductive TupleT : nat -> Type :=
+| nilT : TupleT 0
+| consT {n} A : (A -> TupleT n) -> TupleT (S n).
+
+Inductive Tuple : forall n, TupleT n -> Type :=
+  nil : Tuple _ nilT
+| cons {n A} (x : A) (F : A -> TupleT n) : Tuple _ (F x) -> Tuple _ (consT A F).
+
+Inductive TupleMap : forall n, TupleT n -> TupleT n -> Type :=
+  tmNil : TupleMap _ nilT nilT
+| tmCons {n} {A B : Type} (F : A -> TupleT n) (G : B -> TupleT n)
+  : (forall x, sigT (fun y => TupleMap _ (F x) (G y))) -> TupleMap _ (consT A F) (consT B G).

--- a/toplevel/command.ml
+++ b/toplevel/command.ml
@@ -427,7 +427,7 @@ let make_conclusion_flexible evdref ty poly =
       | Type u -> 
         (match Univ.universe_level u with
         | Some u -> 
-	  evdref := Evd.make_flexible_variable !evdref true u
+	  evdref := Evd.make_flexible_variable !evdref ~algebraic:true u
 	| None -> ())
       | _ -> ()
   else () 

--- a/toplevel/record.ml
+++ b/toplevel/record.ml
@@ -124,7 +124,7 @@ let typecheck_params_and_fields def id pl t ps nots fs =
 	 | Sort s' -> 
 	    (if poly then
                match Evd.is_sort_variable !evars s' with
-	       | Some l -> evars := Evd.make_flexible_variable !evars true l; 
+	       | Some l -> evars := Evd.make_flexible_variable !evars ~algebraic:true l; 
 	                  sred, true
 	       | None -> s, false
              else s, false)


### PR DESCRIPTION
The twist used to handle template polymorphic inductives making their conclusion always algebraic was a bit too strong, sometimes the universe cannot be made algebraic if there are upper constraints on it (IIRC this used to be checked in the previous implementation as well). Let's see if this breaks anything.
