### PR TITLE
Port Toplevel to the Stm API

### DIFF
--- a/dev/doc/changes.txt
+++ b/dev/doc/changes.txt
@@ -139,6 +139,23 @@ document type". This allows for a more uniform handling of printing
 
    module Tag
 
+** Stm API **
+
+- We have streamlined the `Stm` API, now `add` and `query` take a
+  `coq_parsable` instead a `string` so clients can have more control
+  over their input stream. As a consequence, their types have been
+  modified.
+
+- The main parsing entry point has also been moved to the
+  `Stm`. Parsing is considered a synchronous operation so it will
+  either succeed of emit an exception.
+
+- `Feedback` is now only emitted for asynchronous operations. As a
+  consequence, it always carries a valid stateid and the type has
+  changed to accommodate that.
+
+- A few unused hooks were removed due to cleanups, no clients known.
+
 =========================================
 = CHANGES BETWEEN COQ V8.5 AND COQ V8.6 =
 =========================================

--- a/dev/doc/changes.txt
+++ b/dev/doc/changes.txt
@@ -156,6 +156,19 @@ document type". This allows for a more uniform handling of printing
 
 - A few unused hooks were removed due to cleanups, no clients known.
 
+** Toplevel and Vernacular API **
+
+- The components related to vernacular interpretation have been moved
+  to their own folder `vernac/` whereas toplevel now contains the
+  proper toplevel shell and compiler.
+
+- Coq's toplevel has been ported to directly use the common `Stm`
+  API. The signature of a few functions has changed as a result.
+
+** XML Protocol **
+
+- The legacy `interp` call has been turned into a noop.
+
 =========================================
 = CHANGES BETWEEN COQ V8.5 AND COQ V8.6 =
 =========================================

--- a/dev/doc/changes.txt
+++ b/dev/doc/changes.txt
@@ -148,7 +148,7 @@ document type". This allows for a more uniform handling of printing
 
 - The main parsing entry point has also been moved to the
   `Stm`. Parsing is considered a synchronous operation so it will
-  either succeed of emit an exception.
+  either succeed or raise an exception.
 
 - `Feedback` is now only emitted for asynchronous operations. As a
   consequence, it always carries a valid stateid and the type has
@@ -167,7 +167,7 @@ document type". This allows for a more uniform handling of printing
 
 ** XML Protocol **
 
-- The legacy `interp` call has been turned into a noop.
+- The legacy `Interp` call has been turned into a noop.
 
 =========================================
 = CHANGES BETWEEN COQ V8.5 AND COQ V8.6 =

--- a/ide/coqOps.ml
+++ b/ide/coqOps.ml
@@ -415,11 +415,7 @@ object(self)
     buffer#apply_tag Tags.Script.tooltip ~start ~stop;
     add_tooltip sentence pre post markup
 
-  method private is_dummy_id id =
-    match id with
-    | Edit 0 -> true
-    | State id when Stateid.equal id Stateid.dummy -> true
-    | _ -> false
+  method private is_dummy_id id = Stateid.equal id Stateid.dummy
 
   method private enqueue_feedback msg =
     (* Minilib.log ("Feedback received: " ^ Xml_printer.to_string_fmt (Xmlprotocol.of_feedback msg)); *)
@@ -434,8 +430,7 @@ object(self)
       let sentence =
         let finder _ state_id s =
           match state_id, id with
-          | Some id', State id when Stateid.equal id id' -> Some (state_id, s)
-          | _, Edit id when id = s.edit_id -> Some (state_id, s)
+          | Some id', id when Stateid.equal id id' -> Some (state_id, s)
           | _ -> None in
         try Some (Doc.find_map document finder)
         with Not_found -> None in
@@ -505,8 +500,7 @@ object(self)
           else
             try
               match id, Doc.tip document with
-              | Edit _, _ -> ()
-              | State id1, id2 when Stateid.newer_than id2 id1 -> ()
+              | id1, id2 when Stateid.newer_than id2 id1 -> ()
               | _ -> Queue.add msg feedbacks
             with Doc.Empty | Invalid_argument _ -> Queue.add msg feedbacks 
       end;

--- a/ide/ide_slave.ml
+++ b/ide/ide_slave.ml
@@ -95,7 +95,7 @@ let ide_cmd_checks (loc,ast) =
 (** Interpretation (cf. [Ide_intf.interp]) *)
 
 let add ((s,eid),(sid,verbose)) =
-  let newid, rc = Stm.add ~ontop:sid verbose ~check:ide_cmd_checks eid s in
+  let newid, rc = Stm.add ~ontop:sid verbose ~check:ide_cmd_checks s in
   let rc = match rc with `NewTip -> CSig.Inl () | `Unfocus id -> CSig.Inr id in
   (* TODO: the "" parameter is a leftover of the times the protocol
    * used to include stderr/stdout output.
@@ -379,7 +379,7 @@ let init =
          let initial_id, _ =
            if not (is_in_load_paths (physical_path_of_string dir)) then
              Stm.add false ~ontop:(Stm.get_current_state ())
-               0 (Printf.sprintf "Add LoadPath \"%s\". " dir)
+               (Printf.sprintf "Add LoadPath \"%s\". " dir)
            else Stm.get_current_state (), `NewTip in
          if Filename.check_suffix file ".v" then
            Stm.set_compilation_hints file;

--- a/ide/ide_slave.ml
+++ b/ide/ide_slave.ml
@@ -466,9 +466,6 @@ let loop () =
   let xml_ic        = Xml_parser.make (Xml_parser.SLexbuf in_lb) in
   let () = Xml_parser.check_eof xml_ic false in
   ignore (Feedback.add_feeder (slave_feeder (!msg_format ()) xml_oc));
-  (* We'll handle goal fetching and display in our own way *)
-  Vernacentries.enable_goal_printing := false;
-  Vernacentries.qed_display_script := false;
   while not !quit do
     try
       let xml_query = Xml_parser.parse xml_ic in

--- a/ide/interface.mli
+++ b/ide/interface.mli
@@ -111,8 +111,10 @@ type coq_info = {
 (** Calls result *)
 
 type location = (int * int) option (* start and end of the error *)
-type state_id = Feedback.state_id
-type edit_id = Feedback.edit_id
+type state_id = Stateid.t
+
+(* Obsolete *)
+type edit_id  = int
 
 (* The fail case carries the current state_id of the prover, the GUI
    should probably retract to that point *)

--- a/ide/xmlprotocol.ml
+++ b/ide/xmlprotocol.ml
@@ -907,9 +907,7 @@ let of_feedback_content = function
         of_string filename ]
   | Message (l,loc,m) -> constructor "feedback_content" "message" [ of_message l loc m ]
 
-let of_edit_or_state_id = function
-  | Edit id -> ["object","edit"], of_edit_id id
-  | State id -> ["object","state"], of_stateid id
+let of_edit_or_state_id id = ["object","state"], of_stateid id
 
 let of_feedback msg =
   let content = of_feedback_content msg.contents in
@@ -921,12 +919,8 @@ let of_feedback msg_fmt =
   msg_format := msg_fmt; of_feedback
 
 let to_feedback xml = match xml with
-  | Element ("feedback", ["object","edit";"route",route], [id;content]) -> {
-      id = Edit(to_edit_id id);
-      route = int_of_string route;
-      contents = to_feedback_content content }
   | Element ("feedback", ["object","state";"route",route], [id;content]) -> { 
-      id = State(to_stateid id);
+      id = to_stateid id;
       route = int_of_string route;
       contents = to_feedback_content content }
   | x -> raise (Marshal_error("feedback",x))

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -85,6 +85,20 @@ let without_specific_symbols l f =
 (**********************************************************************)
 (* Control printing of records *)
 
+(* Set Record Printing flag *)
+let record_print = ref true
+
+let _ =
+  let open Goptions in
+  declare_bool_option
+    { optsync  = true;
+      optdepr  = false;
+      optname  = "record printing";
+      optkey   = ["Printing";"Records"];
+      optread  = (fun () -> !record_print);
+      optwrite = (fun b -> record_print := b) }
+
+
 let is_record indsp =
   try
     let _ = Recordops.lookup_structure indsp in
@@ -658,7 +672,7 @@ let rec extern inctx scopes vars r =
                    ()
                  else if PrintingConstructor.active (fst cstrsp) then
                    raise Exit
-                 else if not !Flags.record_print then
+                 else if not !record_print then
                    raise Exit;
 		 let projs = struc.Recordops.s_PROJ in
 		 let locals = struc.Recordops.s_PROJKIND in

--- a/kernel/term_typing.ml
+++ b/kernel/term_typing.ml
@@ -194,7 +194,7 @@ let rec unzip ctx j =
 let feedback_completion_typecheck =
   let open Feedback in
   Option.iter (fun state_id ->
-      feedback ~id:(State state_id) Feedback.Complete)
+      feedback ~id:state_id Feedback.Complete)
 
 let infer_declaration ~trust env kn dcl =
   match dcl with

--- a/lib/feedback.ml
+++ b/lib/feedback.ml
@@ -15,9 +15,6 @@ type level =
   | Warning
   | Error
 
-type edit_id = int
-type state_id = Stateid.t
-type edit_or_state_id = Edit of edit_id | State of state_id
 type route_id = int
 
 type feedback_content =
@@ -38,9 +35,9 @@ type feedback_content =
   | Message of level * Loc.t option * Pp.std_ppcmds
 
 type feedback = {
-  id : edit_or_state_id;
+  id       : Stateid.t;
+  route    : route_id;
   contents : feedback_content;
-  route : route_id;
 }
 
 let default_route = 0
@@ -56,7 +53,8 @@ let add_feeder =
 
 let del_feeder fid = Hashtbl.remove feeders fid
 
-let feedback_id    = ref (Edit 0)
+let default_route = 0
+let feedback_id    = ref Stateid.dummy
 let feedback_route = ref default_route
 
 let set_id_for_feedback ?(route=default_route) i =

--- a/lib/feedback.mli
+++ b/lib/feedback.mli
@@ -16,11 +16,8 @@ type level =
   | Warning
   | Error
 
-(** Coq "semantic" infos obtained during parsing/execution *)
-type edit_id = int
-type state_id = Stateid.t
-type edit_or_state_id = Edit of edit_id | State of state_id
 
+(** Coq "semantic" infos obtained during execution *)
 type route_id = int
 
 val default_route : route_id
@@ -46,17 +43,16 @@ type feedback_content =
   | Message of level * Loc.t option * Pp.std_ppcmds
 
 type feedback = {
-  id       : edit_or_state_id;  (* The document part concerned *)
-  contents : feedback_content;  (* The payload *)
+  id       : Stateid.t;         (* The document part concerned *)
   route    : route_id;          (* Extra routing info *)
+  contents : feedback_content;  (* The payload *)
 }
 
 (** {6 Feedback sent, even asynchronously, to the user interface} *)
-(* Morally the parser gets a string and an edit_id, and gives back an AST.
- * Feedbacks during the parsing phase are attached to this edit_id.
- * The interpreter assignes an exec_id to the ast, and feedbacks happening
- * during interpretation are attached to the exec_id.
- * Only one among state_id and edit_id can be provided. *)
+
+(* The interpreter assignes an state_id to the ast, and feedbacks happening
+ * during interpretation are attached to it.
+ *)
 
 (** [add_feeder f] adds a feeder listiner [f], returning its id *)
 val add_feeder : (feedback -> unit) -> int
@@ -67,11 +63,10 @@ val del_feeder : int -> unit
 (** [feedback ?id ?route fb] produces feedback fb, with [route] and
     [id] set appropiatedly, if absent, it will use the defaults set by
     [set_id_for_feedback] *)
-val feedback :
-  ?id:edit_or_state_id -> ?route:route_id -> feedback_content -> unit
+val feedback : ?id:Stateid.t -> ?route:route_id -> feedback_content -> unit
 
 (** [set_id_for_feedback route id] Set the defaults for feedback *)
-val set_id_for_feedback : ?route:route_id -> edit_or_state_id -> unit
+val set_id_for_feedback : ?route:route_id -> Stateid.t -> unit
 
 (** {6 output functions}
 

--- a/lib/flags.ml
+++ b/lib/flags.ml
@@ -95,7 +95,6 @@ let time = ref false
 
 let raw_print = ref false
 
-let record_print = ref true
 
 let univ_print = ref false
 
@@ -180,12 +179,6 @@ let is_program_mode () = !program_mode
 let warn = ref true
 let make_warn flag = warn := flag;  ()
 let if_warn f x = if !warn then f x
-
-(* The number of printed hypothesis in a goal *)
-
-let print_hyps_limit = ref (None : int option)
-let set_print_hyps_limit n = print_hyps_limit := n
-let print_hyps_limit () = !print_hyps_limit
 
 (* Flags for external tools *)
 

--- a/lib/flags.ml
+++ b/lib/flags.ml
@@ -86,8 +86,6 @@ let in_toplevel = ref false
 let profile = false
 
 let print_emacs = ref false
-let coqtop_ui = ref false
-
 let xml_export = ref false
 
 let ide_slave = ref false

--- a/lib/flags.mli
+++ b/lib/flags.mli
@@ -46,9 +46,8 @@ val in_toplevel : bool ref
 
 val profile : bool
 
+(* Legacy flags *)
 val print_emacs : bool ref
-val coqtop_ui : bool ref
-
 val xml_export : bool ref
 
 val ide_slave : bool ref

--- a/lib/flags.mli
+++ b/lib/flags.mli
@@ -8,6 +8,8 @@
 
 (** Global options of the system. *)
 
+(** Command-line flags  *)
+
 val boot : bool ref
 val load_init : bool ref
 
@@ -16,8 +18,11 @@ type compilation_mode = BuildVo | BuildVio | Vio2Vo
 val compilation_mode : compilation_mode ref
 val compilation_output_name : string option ref
 
+(* Flag set when the test-suite is called. Its only effect to display
+   verbose information for `Fail` *)
 val test_mode : bool ref
 
+(** Async-related flags *)
 type async_proofs = APoff | APonLazy | APon
 val async_proofs_mode : async_proofs ref
 type cache = Force
@@ -47,18 +52,26 @@ val in_toplevel : bool ref
 val profile : bool
 
 (* Legacy flags *)
+
+(* -emacs option: printing includes emacs tags, will affect stm caching. *)
 val print_emacs : bool ref
+(* -xml option: xml hooks will be called *)
 val xml_export : bool ref
 
+(* -ide_slave: printing will be more verbose, will affect stm caching *)
 val ide_slave : bool ref
 val ideslave_coqtop_flags : string option ref
 
+(* -time option: every command will be wrapped with `Time` *)
 val time : bool ref
 
+(* development flag to detect race conditions, it should go away. *)
 val we_are_parsing : bool ref
 
+(* Set Printing All flag. For some reason it is a global flag *)
 val raw_print : bool ref
-val record_print : bool ref
+
+(* Univ print flag, never set anywere. Maybe should belong to Univ? *)
 val univ_print : bool ref
 
 type compat_version = V8_2 | V8_3 | V8_4 | V8_5 | V8_6 | Current
@@ -68,9 +81,12 @@ val version_strictly_greater : compat_version -> bool
 val version_less_or_equal : compat_version -> bool
 val pr_version : compat_version -> string
 
+(* Beautify command line flags, should move to printing? *)
 val beautify : bool ref
 val beautify_file : bool ref
 
+(* Silent/verbose, both actually controlled by a single flag so they
+   are mutually exclusive *)
 val make_silent : bool -> unit
 val is_silent : unit -> bool
 val is_verbose : unit -> bool
@@ -79,6 +95,7 @@ val verbosely : ('a -> 'b) -> 'a -> 'b
 val if_silent : ('a -> unit) -> 'a -> unit
 val if_verbose : ('a -> unit) -> 'a -> unit
 
+(* Miscellaneus flags for vernac *)
 val make_auto_intros : bool -> unit
 val is_auto_intros : unit -> bool
 
@@ -109,10 +126,6 @@ val without_option : bool ref -> ('a -> 'b) -> 'a -> 'b
 
 (** Temporarily extends the reference to a list *)
 val with_extra_values : 'c list ref -> 'c list -> ('a -> 'b) -> 'a -> 'b
-
-(** If [None], no limit *)
-val set_print_hyps_limit : int option -> unit
-val print_hyps_limit : unit -> int option
 
 (** Options for external tools *)
 

--- a/plugins/ltac/profile_ltac.ml
+++ b/plugins/ltac/profile_ltac.ml
@@ -374,7 +374,7 @@ let data = ref SM.empty
 
 let _ =
   Feedback.(add_feeder (function
-    | { id = State s; contents = Custom (_, "ltacprof_results", xml) } ->
+    | { id = s; contents = Custom (_, "ltacprof_results", xml) } ->
         let results = to_ltacprof_results xml in
         let other_results = (* Multi success can cause this *)
           try SM.find s !data

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -365,8 +365,21 @@ let pr_context_limit_compact ?n env sigma =
 let pr_context_unlimited_compact env sigma =
   pr_context_limit_compact env sigma
 
-let pr_context_of env sigma =
-  match Flags.print_hyps_limit () with
+(* The number of printed hypothesis in a goal *)
+(* If [None], no limit *)
+let print_hyps_limit = ref (None : int option)
+
+let _ =
+  let open Goptions in
+  declare_int_option
+    { optsync  = false;
+      optdepr  = false;
+      optname  = "the hypotheses limit";
+      optkey   = ["Hyps";"Limit"];
+      optread  = (fun () -> !print_hyps_limit);
+      optwrite = (fun x -> print_hyps_limit := x) }
+
+let pr_context_of env sigma = match !print_hyps_limit with
   | None -> hv 0 (pr_context_limit_compact env sigma)
   | Some n -> hv 0 (pr_context_limit_compact ~n env sigma)
 

--- a/stm/asyncTaskQueue.ml
+++ b/stm/asyncTaskQueue.ml
@@ -105,7 +105,7 @@ module Make(T : Task) = struct
 
   let report_status ?(id = !Flags.async_proofs_worker_id) s =
     let open Feedback in
-    feedback ~id:(State Stateid.initial) (WorkerStatus(id, s))
+    feedback ~id:Stateid.initial (WorkerStatus(id, s))
 
   module Worker = Spawn.Sync(struct end)
 

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -29,8 +29,6 @@ let execution_error state_id loc msg =
 
 module Hooks = struct
 
-let process_error, process_error_hook = Hook.make ()
-
 let state_computed, state_computed_hook = Hook.make
  ~default:(fun state_id ~in_cache ->
     feedback ~id:(State state_id) Processed) ()
@@ -63,7 +61,7 @@ let call_process_error_once =
     match Exninfo.get info processed with
     | Some _ -> ei
     | None ->
-        let e, info = call process_error ei in
+        let e, info = ExplainErr.process_vernac_interp_error ei in
         let info = Exninfo.add info processed () in
         e, info
 
@@ -2936,7 +2934,6 @@ let state_computed_hook = Hooks.state_computed_hook
 let state_ready_hook = Hooks.state_ready_hook
 let parse_error_hook = Hooks.parse_error_hook
 let forward_feedback_hook = Hooks.forward_feedback_hook
-let process_error_hook = Hooks.process_error_hook
 let unreachable_state_hook = Hooks.unreachable_state_hook
 let () = Hook.set Obligations.stm_get_fix_exn (fun () -> !State.fix_exn_ref)
 (* vim:set foldmethod=marker: *)

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -52,9 +52,6 @@ let parse_error, parse_error_hook = Hook.make
 let unreachable_state, unreachable_state_hook = Hook.make
  ~default:(fun _ _ -> ()) ()
 
-let tactic_being_run, tactic_being_run_hook = Hook.make
- ~default:(fun _ -> ()) ()
-
 include Hook
 
 (* enables:  Hooks.(call foo args) *)
@@ -2213,10 +2210,8 @@ let known_state ?(redefine_qed=false) ~cache id =
           (fun () ->
             resilient_tactic id cblock (fun () ->
               reach ~cache:`Shallow view.next;
-              Hooks.(call tactic_being_run true); 
               Partac.vernac_interp ~solve ~abstract
-                cancel !Flags.async_proofs_n_tacworkers view.next id x;
-              Hooks.(call tactic_being_run false))
+                cancel !Flags.async_proofs_n_tacworkers view.next id x)
           ), cache, true
       | `Cmd { cast = x; cqueue = `QueryQueue cancel }
         when Flags.async_proofs_is_master () -> (fun () ->
@@ -2226,9 +2221,7 @@ let known_state ?(redefine_qed=false) ~cache id =
       | `Cmd { cast = x; ceff = eff; ctac = true; cblock } -> (fun () ->
             resilient_tactic id cblock (fun () ->
               reach view.next;
-              Hooks.(call tactic_being_run true); 
-              stm_vernac_interp id x;
-              Hooks.(call tactic_being_run false)); 
+              stm_vernac_interp id x);
 	    if eff then update_global_env ()
           ), (if eff then `Yes else cache), true
       | `Cmd { cast = x; ceff = eff } -> (fun () ->
@@ -2946,5 +2939,4 @@ let forward_feedback_hook = Hooks.forward_feedback_hook
 let process_error_hook = Hooks.process_error_hook
 let unreachable_state_hook = Hooks.unreachable_state_hook
 let () = Hook.set Obligations.stm_get_fix_exn (fun () -> !State.fix_exn_ref)
-let tactic_being_run_hook = Hooks.tactic_being_run_hook
 (* vim:set foldmethod=marker: *)

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -6,13 +6,16 @@
 (*         *       GNU Lesser General Public License Version 2.1        *)
 (************************************************************************)
 
+(* enable in case of stm problems  *)
+let stm_debug = false
+
 let stm_pr_err s  = Printf.eprintf "%s] %s\n"     (System.process_id ()) s; flush stderr
 let stm_pp_err pp = Format.eprintf "%s] @[%a@]\n" (System.process_id ()) Pp.pp_with pp; flush stderr
 
-let stm_prerr_endline s = if false then begin stm_pr_err (s ()) end else ()
-let stm_prerr_debug s = if !Flags.debug then begin stm_pr_err (s ()) end else ()
+let stm_prerr_endline s = if stm_debug then begin stm_pr_err (s ()) end else ()
+let stm_pperr_endline s = if stm_debug then begin stm_pp_err (s ()) end else ()
 
-let stm_pperr_endline s = if false then begin stm_pp_err (s ()) end else ()
+let stm_prerr_debug   s = if !Flags.debug then begin stm_pr_err (s ()) end else ()
 
 open Vernacexpr
 open CErrors
@@ -2678,7 +2681,7 @@ let parse_sentence sid pa =
       (str "Currently, the parsing api only supports parsing at the tip of the document." ++ fnl () ++
        str "You wanted to parse at: "  ++ str (Stateid.to_string sid) ++
        str " but the current tip is: " ++ str (Stateid.to_string cur_tip)) ;
-  if not (Stateid.equal sid real_tip) then
+  if not (Stateid.equal sid real_tip) && !Flags.debug && stm_debug then
     Feedback.msg_debug
       (str "Warning, the real tip doesn't match the current tip." ++
        str "You wanted to parse at: "  ++ str (Stateid.to_string sid) ++

--- a/stm/stm.mli
+++ b/stm/stm.mli
@@ -13,8 +13,8 @@ open Loc
 
 (** state-transaction-machine interface *)
 
-(* [add ontop check vebose eid s] adds a new command [s] on the state [ontop]
-   having edit id [eid].  [check] is called on the AST.
+(* [add ontop check vebose eid s] adds a new command [s] on the state [ontop].
+   [check] is called on the AST.
    The [ontop] parameter is just for asserting the GUI is on sync, but
    will eventually call edit_at on the fly if needed.
    The sentence [s] is parsed in the state [ontop].
@@ -23,7 +23,7 @@ open Loc
 val add :
   ontop:Stateid.t -> ?newtip:Stateid.t ->
   ?check:(vernac_expr located -> unit) ->
-  bool -> edit_id -> string ->
+  bool -> string ->
     Stateid.t * [ `NewTip | `Unfocus of Stateid.t ]
 
 (* parses and executes a command at a given state, throws away its side effects
@@ -182,9 +182,8 @@ val register_proof_block_delimiter :
  * the name of the Task(s) above) *)
 
 val state_computed_hook : (Stateid.t -> in_cache:bool -> unit) Hook.t
-val parse_error_hook :
-  (Feedback.edit_or_state_id -> Loc.t -> Pp.std_ppcmds -> unit) Hook.t
 val unreachable_state_hook : (Stateid.t -> Exninfo.iexn -> unit) Hook.t
+
 (* ready means that master has it at hand *)
 val state_ready_hook : (Stateid.t -> unit) Hook.t
 

--- a/stm/stm.mli
+++ b/stm/stm.mli
@@ -30,7 +30,7 @@ exception End_of_input
    If [newtip] is provided, then the returned state id is guaranteed
    to be [newtip] *)
 val add : ontop:Stateid.t -> ?newtip:Stateid.t ->
-  bool -> (Loc.t * Vernacexpr.vernac_expr) ->
+  bool -> Vernacexpr.vernac_expr Loc.located ->
   Stateid.t * [ `NewTip | `Unfocus of Stateid.t ]
 
 (* [query at ?report_with cmd] Executes [cmd] at a given state [at],
@@ -204,13 +204,6 @@ type state = {
 }
 val state_of_id :
   Stateid.t -> [ `Valid of state option | `Expired | `Error of exn ]
-
-(** read-eval-print loop compatible interface ****************************** **)
-
-(* Adds a new line to the document.  It replaces the core of Vernac.interp.
-   [finish] is called as the last bit of this function if the system
-   is running interactively (-emacs or coqtop). *)
-val interp : bool -> vernac_expr located -> unit
 
 (* Queries for backward compatibility *)
 val current_proof_depth : unit -> int

--- a/stm/stm.mli
+++ b/stm/stm.mli
@@ -209,6 +209,3 @@ val interp : bool -> vernac_expr located -> unit
 (* Queries for backward compatibility *)
 val current_proof_depth : unit -> int
 val get_all_proof_names : unit -> Id.t list
-
-(* Hooks to be set by other Coq components in order to break file cycles *)
-val process_error_hook : Future.fix_exn Hook.t

--- a/stm/stm.mli
+++ b/stm/stm.mli
@@ -187,9 +187,6 @@ val parse_error_hook :
 val unreachable_state_hook : (Stateid.t -> Exninfo.iexn -> unit) Hook.t
 (* ready means that master has it at hand *)
 val state_ready_hook : (Stateid.t -> unit) Hook.t
-(* called with true before and with false after a tactic explicitly
- * in the document is run *)
-val tactic_being_run_hook : (bool -> unit) Hook.t
 
 (* Messages from the workers to the master *)
 val forward_feedback_hook : (Feedback.feedback -> unit) Hook.t

--- a/toplevel/coqinit.ml
+++ b/toplevel/coqinit.ml
@@ -27,12 +27,12 @@ let set_rcfile s = rcfile := s; rcfile_specified := true
 let load_rc = ref true
 let no_load_rc () = load_rc := false
 
-let load_rcfile() =
+let load_rcfile sid =
   if !load_rc then
     try
       if !rcfile_specified then
         if CUnix.file_readable_p !rcfile then
-          Vernac.load_vernac false !rcfile
+          Vernac.load_vernac false sid !rcfile
         else raise (Sys_error ("Cannot read rcfile: "^ !rcfile))
       else
 	try
@@ -43,8 +43,8 @@ let load_rcfile() =
 	    Envars.home ~warn / "."^rcdefaultname^"."^Coq_config.version;
 	    Envars.home ~warn / "."^rcdefaultname
 	  ] in
-          Vernac.load_vernac false inferedrc
-	with Not_found -> ()
+          Vernac.load_vernac false sid inferedrc
+	with Not_found -> sid
 	(*
 	Flags.if_verbose
 	  mSGNL (str ("No coqrc or coqrc."^Coq_config.version^
@@ -55,7 +55,8 @@ let load_rcfile() =
       let () = Feedback.msg_info (str"Load of rcfile failed.") in
       iraise reraise
   else
-    Flags.if_verbose Feedback.msg_info (str"Skipping rcfile loading.")
+    (Flags.if_verbose Feedback.msg_info (str"Skipping rcfile loading.");
+     sid)
 
 (* Recursively puts dir in the LoadPath if -nois was not passed *)
 let add_stdlib_path ~unix_path ~coq_root ~with_ml =

--- a/toplevel/coqloop.ml
+++ b/toplevel/coqloop.ml
@@ -345,7 +345,6 @@ let loop_flush_all () =
 
 let rec loop () =
   Sys.catch_break true;
-  if !Flags.print_emacs then Vernacentries.qed_display_script := false;
   try
     reset_input_buffer stdin top_buffer;
     (* Be careful to keep this loop tail-recursive *)

--- a/toplevel/coqloop.mli
+++ b/toplevel/coqloop.mli
@@ -31,7 +31,7 @@ val coqloop_feed : Feedback.feedback -> unit
 
 (** Parse and execute one vernac command. *)
 
-val do_vernac : unit -> unit
+val do_vernac : Stateid.t -> Stateid.t
 
 (** Main entry point of Coq: read and execute vernac commands. *)
 

--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -8,11 +8,8 @@
 
 open Pp
 open CErrors
-open Util
 open Flags
-open Names
 open Libnames
-open States
 open Coqinit
 
 let () = at_exit flush_all
@@ -133,10 +130,10 @@ let engage () =
 
 let set_batch_mode () = batch_mode := true
 
-let toplevel_default_name = DirPath.make [Id.of_string "Top"]
+let toplevel_default_name = Names.(DirPath.make [Id.of_string "Top"])
 let toplevel_name = ref toplevel_default_name
 let set_toplevel_name dir =
-  if DirPath.is_empty dir then error "Need a non empty toplevel module name";
+  if Names.DirPath.is_empty dir then error "Need a non empty toplevel module name";
   toplevel_name := dir
 
 let remove_top_ml () = Mltop.remove ()
@@ -150,9 +147,9 @@ let set_inputstate s =
   warn_deprecated_inputstate ();
   inputstate:=s
 let inputstate () =
-  if not (String.is_empty !inputstate) then
+  if not (CString.is_empty !inputstate) then
     let fname = Loadpath.locate_file (CUnix.make_suffix !inputstate ".coq") in
-    intern_state fname
+    States.intern_state fname
 
 let warn_deprecated_outputstate =
   CWarnings.create ~name:"deprecated-outputstate" ~category:"deprecated"
@@ -164,9 +161,9 @@ let set_outputstate s =
   warn_deprecated_outputstate ();
   outputstate:=s
 let outputstate () =
-  if not (String.is_empty !outputstate) then
+  if not (CString.is_empty !outputstate) then
     let fname = CUnix.make_suffix !outputstate ".coq" in
-    extern_state fname
+    States.extern_state fname
 
 let set_include d p implicit =
   let p = dirpath_of_string p in
@@ -379,7 +376,7 @@ let get_host_port opt s =
 let get_error_resilience opt = function
   | "on" | "all" | "yes" -> `All
   | "off" | "no" -> `None
-  | s -> `Only (String.split ',' s)
+  | s -> `Only (CString.split ',' s)
 
 let get_task_list s = List.map int_of_string (Str.split (Str.regexp ",") s)
 
@@ -624,7 +621,7 @@ let init_toplevel arglist =
       init_load_path ();
       Option.iter Mltop.load_ml_object_raw !toploop;
       let extras = !toploop_init extras in
-      if not (List.is_empty extras) then begin
+      if not (CList.is_empty extras) then begin
         prerr_endline ("Don't know what to do with "^String.concat " " extras);
         prerr_endline "See -help for the list of supported options";
         exit 1
@@ -633,7 +630,7 @@ let init_toplevel arglist =
       inputstate ();
       Mltop.init_known_plugins ();
       engage ();
-      if (not !batch_mode || List.is_empty !compile_list)
+      if (not !batch_mode || CList.is_empty !compile_list)
          && Global.env_is_initial ()
       then Declaremods.start_library !toplevel_name;
       init_library_roots ();

--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -250,7 +250,6 @@ let set_emacs () =
   if not (Option.is_empty !toploop) then
     error "Flag -emacs is incompatible with a custom toplevel loop";
   Flags.print_emacs := true;
-  Vernacentries.qed_display_script := false;
   color := `OFF
 
 (** Options for CoqIDE *)

--- a/toplevel/vernac.ml
+++ b/toplevel/vernac.ml
@@ -347,6 +347,3 @@ let compile v f =
   ignore(CoqworkmgrApi.get 1);
   compile v f;
   CoqworkmgrApi.giveback 1
-
-let () = Hook.set Stm.process_error_hook
-  ExplainErr.process_vernac_interp_error

--- a/toplevel/vernac.ml
+++ b/toplevel/vernac.ml
@@ -13,111 +13,30 @@ open CErrors
 open Util
 open Flags
 open Vernacexpr
+open Vernacprop
 
 (* The functions in this module may raise (unexplainable!) exceptions.
    Use the module Coqtoplevel, which catches these exceptions
    (the exceptions are explained only at the toplevel). *)
 
-let user_error loc s = CErrors.user_err ~loc (str s)
-
-(* Navigation commands are allowed in a coqtop session but not in a .v file *)
-
-let rec is_navigation_vernac = function
-  | VernacResetInitial
-  | VernacResetName _
-  | VernacBacktrack _
-  | VernacBackTo _
-  | VernacBack _
-  | VernacStm _ -> true
-  | VernacRedirect (_, (_,c))
-  | VernacTime (_,c) ->
-      is_navigation_vernac c (* Time Back* is harmless *)
-  | c -> is_deep_navigation_vernac c
-
-and is_deep_navigation_vernac = function
-  | VernacTimeout (_,c) | VernacFail c -> is_navigation_vernac c
-  | _ -> false
-
-(* NB: Reset is now allowed again as asked by A. Chlipala *)
-
-let is_reset = function
-  | VernacResetInitial | VernacResetName _ -> true
-  | _ -> false
-
-let checknav_simple loc cmd =
+let checknav_simple (loc, cmd) =
   if is_navigation_vernac cmd && not (is_reset cmd) then
-    user_error loc "Navigation commands forbidden in files."
+    CErrors.user_err ~loc (str "Navigation commands forbidden in files.")
 
-let checknav_deep loc ast =
+let checknav_deep (loc, ast) =
   if is_deep_navigation_vernac ast then
-    user_error loc "Navigation commands forbidden in nested commands."
-
-(* When doing Load on a file, two behaviors are possible:
-
-   - either the history stack is grown by only one command,
-     the "Load" itself. This is mandatory for command-counting
-     interfaces (CoqIDE).
-
-   - either each individual sub-commands in the file is added
-     to the history stack. This allows commands like Show Script
-     to work across the loaded file boundary (cf. bug #2820).
-
-   The best of the two could probably be combined someday,
-   in the meanwhile we use a flag. *)
-
-let atomic_load = ref true
-
-let _ =
-  Goptions.declare_bool_option
-    { Goptions.optsync  = true;
-      Goptions.optdepr  = false;
-      Goptions.optname  = "atomic registration of commands in a Load";
-      Goptions.optkey   = ["Atomic";"Load"];
-      Goptions.optread  = (fun () -> !atomic_load);
-      Goptions.optwrite = ((:=) atomic_load) }
+    CErrors.user_err ~loc (str "Navigation commands forbidden in nested commands.")
 
 let disable_drop = function
   | Drop -> CErrors.error "Drop is forbidden."
   | e -> e
 
-(* Opening and closing a channel. Open it twice when verbose: the first
-   channel is used to read the commands, and the second one to print them.
-   Note: we could use only one thanks to seek_in, but seeking on and on in
-   the file we parse seems a bit risky to me.  B.B.  *)
-
-let open_file_twice_if verbosely longfname =
-  let in_chan = open_utf8_file_in longfname in
-  let verb_ch =
-    if verbosely then Some (open_utf8_file_in longfname) else None in
-  let po = Pcoq.Gram.parsable ~file:longfname (Stream.of_channel in_chan) in
-  (in_chan, longfname, (po, verb_ch))
-
-let close_input in_chan (_,verb) =
-  try
-    close_in in_chan;
-    match verb with
-      | Some verb_ch -> close_in verb_ch
-      | _ -> ()
-  with e when CErrors.noncritical e -> ()
-
-let verbose_phrase verbch loc =
-  let loc = Loc.unloc loc in
-  match verbch with
-    | Some ch ->
-	let len = snd loc - fst loc in
-	let s = Bytes.create len in
-        seek_in ch (fst loc);
-        really_input ch s 0 len;
-        Feedback.msg_notice (str (Bytes.to_string s))
-    | None -> ()
-
-exception End_of_input
-
-let parse_sentence = Flags.with_option Flags.we_are_parsing
-  (fun (po, verbch) ->
-  match Pcoq.Gram.entry_parse Pcoq.main_entry po with
-    | Some (loc,_ as com) -> verbose_phrase verbch loc; com
-    | None -> raise End_of_input)
+(* Echo from a buffer based on position.
+   XXX: Should move to utility file. *)
+let vernac_echo loc in_chan = let open Loc in
+  let len = loc.ep - loc.bp in
+  seek_in in_chan loc.bp;
+  Feedback.msg_notice @@ str @@ really_input_string in_chan len
 
 (* vernac parses the given stream, executes interpfun on the syntax tree it
  * parses, and is verbose on "primitives" commands if verbosely is true *)
@@ -184,20 +103,43 @@ let print_cmd_header loc com =
   Pp.pp_with !Topfmt.std_ft (pp_cmd_header loc com);
   Format.pp_print_flush !Topfmt.std_ft ()
 
-let rec interp_vernac po chan_beautify checknav (loc,com) =
+let pr_open_cur_subgoals () =
+  try Printer.pr_open_subgoals ()
+  with Proof_global.NoCurrentProof -> Pp.str ""
+
+let rec interp_vernac sid po (loc,com) =
   let interp = function
     | VernacLoad (verbosely, fname) ->
 	let fname = Envars.expand_path_macros ~warn:(fun x -> Feedback.msg_warning (str x)) fname in
         let fname = CUnix.make_suffix fname ".v" in
         let f = Loadpath.locate_file fname in
-        load_vernac verbosely f
+        load_vernac verbosely sid f
+    | v ->
+      try
+        let nsid, ntip = Stm.add sid (Flags.is_verbose()) (loc,v) in
 
-    | v -> Stm.interp (Flags.is_verbose()) (loc,v)
+        (* Main STM interaction *)
+        if ntip <> `NewTip then
+          anomaly (str "vernac.ml: We got an unfocus operation on the toplevel!");
+        (* Due to bug #5363 we cannot use observe here as we should,
+           it otherwise reveals bugs *)
+        (* Stm.observe nsid; *)
+        Stm.finish ();
+
+        (* We could use a more refined criteria depending on the
+           vernac. For now we imitate the old approach. *)
+        let print_goals = not (!Flags.batch_mode || is_query v) in
+
+        if print_goals then Feedback.msg_notice (pr_open_cur_subgoals ());
+        nsid
+
+      with exn when CErrors.noncritical exn ->
+        ignore(Stm.edit_at sid);
+        raise exn
   in
     try
-      checknav loc com;
-      if !beautify then pr_new_syntax po chan_beautify loc (Some com);
-      (* XXX: This is not 100% correct if called from an IDE context *)
+      (* The -time option is only supported from console-based
+         clients due to the way it prints. *)
       if !Flags.time then print_cmd_header loc com;
       let com = if !Flags.time then VernacTime (loc,com) else com in
       interp com
@@ -208,26 +150,39 @@ let rec interp_vernac po chan_beautify checknav (loc,com) =
       else iraise (reraise, info)
 
 (* Load a vernac file. CErrors are annotated with file and location *)
-and load_vernac verbosely file =
+and load_vernac verbosely sid file =
   let chan_beautify =
     if !Flags.beautify_file then open_out (file^beautify_suffix) else stdout in
-  let (in_chan, fname, input) = open_file_twice_if verbosely file in
+  let in_chan = open_utf8_file_in file in
+  let in_echo = if verbosely then Some (open_utf8_file_in file) else None in
+  let in_pa   = Pcoq.Gram.parsable ~file (Stream.of_channel in_chan) in
+  let rsid = ref sid in
   try
     (* we go out of the following infinite loop when a End_of_input is
      * raised, which means that we raised the end of the file being loaded *)
     while true do
-      let loc_ast = Flags.silently parse_sentence input in
-      CWarnings.set_current_loc (fst loc_ast);
-      Flags.silently (interp_vernac (fst input) chan_beautify checknav_simple) loc_ast;
-    done
+      let loc, ast = Stm.parse_sentence !rsid in_pa in
+
+      (* Printing of vernacs *)
+      if !beautify then pr_new_syntax in_pa chan_beautify loc (Some ast);
+      Option.iter (vernac_echo loc) in_echo;
+
+      checknav_simple (loc, ast);
+      let nsid = Flags.silently (interp_vernac !rsid in_pa) (loc, ast) in
+      rsid := nsid
+    done;
+    !rsid
   with any ->   (* whatever the exception *)
     let (e, info) = CErrors.push any in
-    close_input in_chan input;    (* we must close the file first *)
+    close_in in_chan;
+    Option.iter close_in in_echo;
     match e with
-      | End_of_input ->
+      | Stm.End_of_input ->
+          (* Is this called so comments at EOF are printed? *)
           if !beautify then
-            pr_new_syntax (fst input) chan_beautify (Loc.make_loc (max_int,max_int)) None;
+            pr_new_syntax in_pa chan_beautify (Loc.make_loc (max_int,max_int)) None;
           if !Flags.beautify_file then close_out chan_beautify;
+          !rsid
       | reraise ->
          if !Flags.beautify_file then close_out chan_beautify;
 	 iraise (disable_drop e, info)
@@ -239,7 +194,9 @@ and load_vernac verbosely file =
    of a new state label). An example of state-preserving command is one coming
    from the query panel of Coqide. *)
 
-let process_expr po loc_ast = interp_vernac po stdout checknav_deep loc_ast
+let process_expr sid po loc_ast =
+  checknav_deep loc_ast;
+  interp_vernac sid po loc_ast
 
 (* XML output hooks *)
 let (f_xml_start_library, xml_start_library) = Hook.make ~default:ignore ()
@@ -308,7 +265,7 @@ let compile verbosely f =
       Dumpglob.dump_string ("F" ^ Names.DirPath.to_string ldir ^ "\n");
       if !Flags.xml_export then Hook.get f_xml_start_library ();
       let wall_clock1 = Unix.gettimeofday () in
-      let _ = load_vernac verbosely long_f_dot_v in
+      let _ = load_vernac verbosely (Stm.get_current_state ()) long_f_dot_v in
       Stm.join ();
       let wall_clock2 = Unix.gettimeofday () in
       check_pending_proofs ();
@@ -328,7 +285,7 @@ let compile verbosely f =
       let ldir = Flags.verbosely Library.start_library long_f_dot_vio in
       Dumpglob.noglob ();
       Stm.set_compilation_hints long_f_dot_vio;
-      let _ = load_vernac verbosely long_f_dot_v in
+      let _ = load_vernac verbosely (Stm.get_current_state ()) long_f_dot_v in
       Stm.finish ();
       check_pending_proofs ();
       Stm.snapshot_vio ldir long_f_dot_vio;

--- a/toplevel/vernac.mli
+++ b/toplevel/vernac.mli
@@ -8,30 +8,16 @@
 
 (** Parsing of vernacular. *)
 
-(** Read a vernac command on the specified input (parse only).
-   Raises [End_of_file] if EOF (or Ctrl-D) is reached. *)
-
-val parse_sentence : Pcoq.Gram.coq_parsable * in_channel option ->
- Loc.t * Vernacexpr.vernac_expr
-
 (** Reads and executes vernac commands from a stream. *)
+val process_expr : Stateid.t -> Pcoq.Gram.coq_parsable -> Vernacexpr.vernac_expr Loc.located -> Stateid.t
 
-exception End_of_input
+(** [load_vernac echo sid file] Loads [file] on top of [sid], will
+    echo the commands if [echo] is set. *)
+val load_vernac : bool -> Stateid.t -> string -> Stateid.t
 
-val process_expr : Pcoq.Gram.coq_parsable -> Loc.t * Vernacexpr.vernac_expr -> unit
+(** Compile a vernac file, (f is assumed without .v suffix) *)
+val compile : bool -> string -> unit
 
 (** Set XML hooks *)
 val xml_start_library : (unit -> unit) Hook.t
 val xml_end_library   : (unit -> unit) Hook.t
-
-(** Load a vernac file, verbosely or not. Errors are annotated with file
-   and location *)
-
-val load_vernac : bool -> string -> unit
-
-
-(** Compile a vernac file, verbosely or not (f is assumed without .v suffix) *)
-
-val compile : bool -> string -> unit
-
-val is_navigation_vernac : Vernacexpr.vernac_expr -> bool

--- a/vernac/vernac.mllib
+++ b/vernac/vernac.mllib
@@ -1,3 +1,4 @@
+Vernacprop
 Lemmas
 Himsg
 ExplainErr

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -84,24 +84,10 @@ let show_universes () =
     Feedback.msg_notice (Evd.pr_evar_universe_context (Evd.evar_universe_context sigma));
     Feedback.msg_notice (str"Normalized constraints: " ++ Univ.pr_universe_context_set (Evd.pr_evd_level sigma) ctx)
 
-let show_prooftree () =
-  (* Spiwack: proof tree is currently not working *)
-  ()
+(* Spiwack: proof tree is currently not working *)
+let show_prooftree () = ()
 
-let enable_goal_printing = ref true
-
-let print_subgoals () =
-  if !enable_goal_printing && is_verbose ()
-  then begin
-    Feedback.msg_notice (pr_open_subgoals ())
-  end
-
-let try_print_subgoals () =
-  try print_subgoals () with Proof_global.NoCurrentProof | UserError _ -> ()
-
-
-  (* Simulate the Intro(s) tactic *)
-
+(* Simulate the Intro(s) tactic *)
 let show_intro all =
   let pf = get_pftreestate() in
   let {Evd.it=gls ; sigma=sigma; } = Proof.V82.subgoals pf in
@@ -510,8 +496,6 @@ let vernac_start_proof locality p kind l lettop =
       user_err ~hdr:"Vernacentries.StartProof"
 	(str "Let declarations can only be used in proof editing mode.");
   start_proof_and_print (local, p, Proof kind) l no_hook
-
-let qed_display_script = ref true
 
 let vernac_end_proof ?proof = function
   | Admitted          -> save_proof ?proof Admitted

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1362,15 +1362,6 @@ let _ =
   declare_bool_option
     { optsync  = true;
       optdepr  = false;
-      optname  = "record printing";
-      optkey   = ["Printing";"Records"];
-      optread  = (fun () -> !Flags.record_print);
-      optwrite = (fun b -> Flags.record_print := b) }
-
-let _ =
-  declare_bool_option
-    { optsync  = true;
-      optdepr  = false;
       optname  = "use of the program extension";
       optkey   = ["Program";"Mode"];
       optread  = (fun () -> !Flags.program_mode);
@@ -1416,15 +1407,6 @@ let _ =
       optkey   = ["Undo"];
       optread  = (fun _ -> None);
       optwrite = (fun _ -> ()) }
-
-let _ =
-  declare_int_option
-    { optsync  = false;
-      optdepr  = false;
-      optname  = "the hypotheses limit";
-      optkey   = ["Hyps";"Limit"];
-      optread  = Flags.print_hyps_limit;
-      optwrite = Flags.set_print_hyps_limit }
 
 let _ =
   declare_int_option

--- a/vernac/vernacentries.mli
+++ b/vernac/vernacentries.mli
@@ -11,41 +11,14 @@ open Misctypes
 val dump_global : Libnames.reference or_by_notation -> unit
 
 (** Vernacular entries *)
-
-val show_prooftree : unit -> unit
-
-val show_node : unit -> unit
-
 val vernac_require :
   Libnames.reference option -> bool option -> Libnames.reference list -> unit
 
-(** This function can be used by any command that want to observe terms
-   in the context of the current goal *)
-val get_current_context_of_args : int option -> Evd.evar_map * Environ.env
-
 (** The main interpretation function of vernacular expressions *)
-val interp : 
+val interp :
   ?verbosely:bool ->
   ?proof:Proof_global.closed_proof ->
     Loc.t * Vernacexpr.vernac_expr -> unit
-
-(** Print subgoals when the verbose flag is on.
-    Meant to be used inside vernac commands from plugins. *)
-
-val print_subgoals : unit -> unit
-val try_print_subgoals : unit -> unit
-
-(** The printing of goals via [print_subgoals] or during
-    [interp] can be controlled by the following flag.
-    Used for instance by coqide, since it has its own
-    goal-fetching mechanism. *)
-
-val enable_goal_printing : bool ref
-
-(** Should Qed try to display the proof script ?
-    True by default, but false in ProofGeneral and coqIDE *)
-
-val qed_display_script : bool ref
 
 (** Prepare a "match" template for a given inductive type.
     For each branch of the match, we list the constructor name
@@ -54,9 +27,6 @@ val qed_display_script : bool ref
     a known inductive type. *)
 
 val make_cases : string -> string list list
-
-val vernac_end_proof :
-  ?proof:Proof_global.closed_proof -> Vernacexpr.proof_end -> unit
 
 val with_fail : bool -> (unit -> unit) -> unit
 

--- a/vernac/vernacprop.ml
+++ b/vernac/vernacprop.ml
@@ -1,0 +1,53 @@
+(************************************************************************)
+(*  v      *   The Coq Proof Assistant  /  The Coq Development Team     *)
+(* <O___,, *   INRIA - CNRS - LIX - LRI - PPS - Copyright 1999-2016     *)
+(*   \VV/  **************************************************************)
+(*    //   *      This file is distributed under the terms of the       *)
+(*         *       GNU Lesser General Public License Version 2.1        *)
+(************************************************************************)
+
+(* We define some high-level properties of vernacular commands, used
+   mainly by the UI components *)
+
+open Vernacexpr
+
+(* Navigation commands are allowed in a coqtop session but not in a .v file *)
+let rec is_navigation_vernac = function
+  | VernacResetInitial
+  | VernacResetName _
+  | VernacBacktrack _
+  | VernacBackTo _
+  | VernacBack _
+  | VernacStm _ -> true
+  | VernacRedirect (_, (_,c))
+  | VernacTime (_,c) ->
+      is_navigation_vernac c (* Time Back* is harmless *)
+  | c -> is_deep_navigation_vernac c
+
+and is_deep_navigation_vernac = function
+  | VernacTimeout (_,c) | VernacFail c -> is_navigation_vernac c
+  | _ -> false
+
+(* NB: Reset is now allowed again as asked by A. Chlipala *)
+let is_reset = function
+  | VernacResetInitial | VernacResetName _ -> true
+  | _ -> false
+
+let is_debug cmd = match cmd with
+  | VernacSetOption (["Ltac";"Debug"], _) -> true
+  | _ -> false
+
+let is_query cmd = match cmd with
+  | VernacChdir None
+  | VernacMemOption _
+  | VernacPrintOption _
+  | VernacCheckMayEval _
+  | VernacGlobalCheck _
+  | VernacPrint _
+  | VernacSearch _
+  | VernacLocate _ -> true
+  | _ -> false
+
+let is_undo cmd = match cmd with
+  | VernacUndo _ | VernacUndoTo _ -> true
+  | _ -> false

--- a/vernac/vernacprop.mli
+++ b/vernac/vernacprop.mli
@@ -6,23 +6,14 @@
 (*         *       GNU Lesser General Public License Version 2.1        *)
 (************************************************************************)
 
-(** Initialization. *)
+(* We define some high-level properties of vernacular commands, used
+   mainly by the UI components *)
 
-val set_debug : unit -> unit
+open Vernacexpr
 
-val set_rcfile : string -> unit
-
-val no_load_rc : unit -> unit
-val load_rcfile : Stateid.t -> Stateid.t
-
-val push_include : string -> Names.DirPath.t -> bool -> unit
-(** [push_include phys_path log_path implicit] *)
-
-val push_ml_include : string -> unit
-
-val init_load_path : unit -> unit
-val init_library_roots : unit -> unit
-
-val init_ocaml_path : unit -> unit
-
-val get_compat_version : string -> Flags.compat_version
+val is_navigation_vernac : vernac_expr -> bool
+val is_deep_navigation_vernac : vernac_expr -> bool
+val is_reset : vernac_expr -> bool
+val is_query : vernac_expr -> bool
+val is_debug : vernac_expr -> bool
+val is_undo : vernac_expr -> bool


### PR DESCRIPTION
As discussed with Enrico, we extend the Stm API to decouple parsing from document building, and we port the toplevel to the new API removing quite a bit of redundancy. A few minor cleanups happen in the way.

This greatly helps clients willing to do whole-document parsing, among other things. pidecoq was ported without problems that I could spot.

The PR is ready to merge, and it supersedes #203 and #204 .