### PR TITLE
Allow interactive editing of Coq.Init.Logic

### DIFF
--- a/theories/Init/Logic.v
+++ b/theories/Init/Logic.v
@@ -553,7 +553,8 @@ Proof.
   intros A P (x & Hp & Huniq); split.
   - intro; exists x; auto.
   - intros (x0 & HPx0 & HQx0) x1 HPx1.
-    replace x1 with x0 by (transitivity x; [symmetry|]; auto).
+    assert (H : x0 = x1) by (transitivity x; [symmetry|]; auto).
+    destruct H.
     assumption.
 Qed.   
 


### PR DESCRIPTION
Without this change, coqtop complains that I need to require
Coq.Init.Logic to use [replace ... with ... by ...].

This is the less objectionable half of #386.