### PR TITLE
Relaxing syntax of parameters in well-formedness of inductive types.

### DIFF
--- a/checker/indtypes.ml
+++ b/checker/indtypes.ml
@@ -321,9 +321,12 @@ let check_correct_par (env,n,ntypes,_) hyps l largs =
     | [] -> ()
     | LocalDef _ :: hyps -> check k (index+1) hyps
     | _::hyps ->
-        match whd_all env lpar.(k) with
-	  | Rel w when w = index -> check (k-1) (index+1) hyps
-	  | _ -> raise (IllFormedInd (LocalNonPar (k+1,index,l)))
+        begin
+          try conv env lpar.(k) (Rel index)
+          with NotConvertible ->
+	     raise (IllFormedInd (LocalNonPar (k+1,index,l)))
+        end;
+        check (k-1) (index+1) hyps
   in check (nparams-1) (n-nhyps) hyps;
   if not (Array.for_all (noccur_between n ntypes) largs') then
     failwith_non_pos_vect n ntypes largs'

--- a/kernel/indtypes.ml
+++ b/kernel/indtypes.ml
@@ -409,14 +409,15 @@ let check_correct_par (env,n,ntypes,_) paramdecls ind_index args =
     | LocalDef _ :: paramdecls ->
       check param_index (paramdecl_index+1) paramdecls
     | _::paramdecls ->
-        match kind_of_term (whd_all env params.(param_index)) with
-	  | Rel w when Int.equal w paramdecl_index ->
-            check (param_index-1) (paramdecl_index+1) paramdecls
-	  | _ ->
+       begin
+         try conv env params.(param_index) (mkRel paramdecl_index)
+         with NotConvertible ->
             let paramdecl_index_in_env = paramdecl_index-n+nparamdecls+1 in
             let err =
               LocalNonPar (param_index+1, paramdecl_index_in_env, ind_index) in
             raise (IllFormedInd err)
+       end;
+       check (param_index-1) (paramdecl_index+1) paramdecls
   in check (nparams-1) (n-nparamdecls) paramdecls;
   if not (Array.for_all (noccur_between n ntypes) realargs) then
     failwith_non_pos_vect n ntypes realargs

--- a/test-suite/output/InitSyntax.out
+++ b/test-suite/output/InitSyntax.out
@@ -1,5 +1,5 @@
 Inductive sig2 (A : Type) (P Q : A -> Prop) : Type :=
-    exist2 : forall x : A, P x -> Q x -> {x : A | P x & Q x}
+    exist2 : forall x : A, P x -> Q x -> {x0 : A | P x0 & Q x0}
 
 For sig2: Argument A is implicit
 For exist2: Argument A is implicit

--- a/test-suite/output/PrintInfos.out
+++ b/test-suite/output/PrintInfos.out
@@ -1,17 +1,17 @@
-existT : forall (A : Type) (P : A -> Type) (x : A), P x -> {x : A & P x}
+existT : forall (A : Type) (P : A -> Type) (x : A), P x -> {x0 : A & P x0}
 
 existT is template universe polymorphic
 Argument A is implicit
 Argument scopes are [type_scope function_scope _ _]
 Expands to: Constructor Coq.Init.Specif.existT
 Inductive sigT (A : Type) (P : A -> Type) : Type :=
-    existT : forall x : A, P x -> {x : A & P x}
+    existT : forall x : A, P x -> {x0 : A & P x0}
 
 For sigT: Argument A is implicit
 For existT: Argument A is implicit
 For sigT: Argument scopes are [type_scope type_scope]
 For existT: Argument scopes are [type_scope function_scope _ _]
-existT : forall (A : Type) (P : A -> Type) (x : A), P x -> {x : A & P x}
+existT : forall (A : Type) (P : A -> Type) (x : A), P x -> {x0 : A & P x0}
 
 Argument A is implicit
 Inductive eq (A : Type) (x : A) : A -> Prop :=  eq_refl : x = x

--- a/theories/Init/Logic.v
+++ b/theories/Init/Logic.v
@@ -245,27 +245,31 @@ Notation "'IF' c1 'then' c2 'else' c3" := (IF_then_else c1 c2 c3)
     is provided too.
 *)
 
+Reserved Notation "'exists' x .. y , p"
+  (at level 200, x binder, right associativity,
+   format "'[' 'exists'  '/  ' x  ..  y ,  '/  ' p ']'").
+
 Inductive ex (A:Type) (P:A -> Prop) : Prop :=
-  ex_intro : forall x:A, P x -> ex (A:=A) P.
+  ex_intro : forall x:A, P x -> exists y : A, P y
+ where "'exists' x .. y , p" := (ex (fun x => .. (ex (fun y => p)) ..))
+  : type_scope.
+
+Reserved Notation "'exists2' x , p & q"
+  (at level 200, x ident, p at level 200, right associativity).
 
 Inductive ex2 (A:Type) (P Q:A -> Prop) : Prop :=
-  ex_intro2 : forall x:A, P x -> Q x -> ex2 (A:=A) P Q.
-
-Definition all (A:Type) (P:A -> Prop) := forall x:A, P x.
+  ex_intro2 : forall x:A, P x -> Q x -> exists2 x, P x & Q x
+ where "'exists2' x , p & q" := (ex2 (fun x => p) (fun x => q))
+  : type_scope.
 
 (* Rule order is important to give printing priority to fully typed exists *)
 
-Notation "'exists' x .. y , p" := (ex (fun x => .. (ex (fun y => p)) ..))
-  (at level 200, x binder, right associativity,
-   format "'[' 'exists'  '/  ' x  ..  y ,  '/  ' p ']'")
-  : type_scope.
-
-Notation "'exists2' x , p & q" := (ex2 (fun x => p) (fun x => q))
-  (at level 200, x ident, p at level 200, right associativity) : type_scope.
-Notation "'exists2' x : A , p & q" := (ex2 (A:=A) (fun x => p) (fun x => q))
+Notation "'exists2' x : A , p & q" := (ex2 (A:=A) (fun x:A => p) (fun x:A => q))
   (at level 200, x ident, A at level 200, p at level 200, right associativity,
     format "'[' 'exists2'  '/  ' x  :  A ,  '/  ' '[' p  &  '/' q ']' ']'")
   : type_scope.
+
+Definition all (A:Type) (P:A -> Prop) := forall x:A, P x.
 
 (** Derived rules for universal quantification *)
 

--- a/theories/Init/Specif.v
+++ b/theories/Init/Specif.v
@@ -23,19 +23,24 @@ Require Import Logic.
     of elements of the type [A] which satisfy both [P] and [Q]. *)
 
 Inductive sig (A:Type) (P:A -> Prop) : Type :=
-    exist : forall x:A, P x -> sig P.
+    exist : forall x:A, P x -> { x | P x}
+ where "{ x  |  P }" := (sig (fun x => P)) : type_scope.
 
 Inductive sig2 (A:Type) (P Q:A -> Prop) : Type :=
-    exist2 : forall x:A, P x -> Q x -> sig2 P Q.
+    exist2 : forall x:A, P x -> Q x -> { x | P x & Q x }
+ where "{ x  |  P  & Q }" := (sig2 (fun x => P) (fun x => Q)) : type_scope.
 
 (** [(sigT A P)], or more suggestively [{x:A & (P x)}] is a Sigma-type.
     Similarly for [(sigT2 A P Q)], also written [{x:A & (P x) & (Q x)}]. *)
 
 Inductive sigT (A:Type) (P:A -> Type) : Type :=
-    existT : forall x:A, P x -> sigT P.
+    existT : forall x:A, P x -> { x : A & P x }
+ where "{ x : A & P }" := (sigT (A:=A) (fun x => P)) : type_scope.
 
 Inductive sigT2 (A:Type) (P Q:A -> Type) : Type :=
-    existT2 : forall x:A, P x -> Q x -> sigT2 P Q.
+    existT2 : forall x:A, P x -> Q x -> { x : A & P x & Q x }
+ where "{ x : A & P & Q }" := (sigT2 (A:=A) (fun x => P) (fun x => Q)) :
+  type_scope.
 
 (* Notations *)
 
@@ -44,13 +49,8 @@ Arguments sig2 (A P Q)%type.
 Arguments sigT (A P)%type.
 Arguments sigT2 (A P Q)%type.
 
-Notation "{ x  |  P }" := (sig (fun x => P)) : type_scope.
-Notation "{ x  |  P  & Q }" := (sig2 (fun x => P) (fun x => Q)) : type_scope.
 Notation "{ x : A  |  P }" := (sig (A:=A) (fun x => P)) : type_scope.
 Notation "{ x : A  |  P  & Q }" := (sig2 (A:=A) (fun x => P) (fun x => Q)) :
-  type_scope.
-Notation "{ x : A  & P }" := (sigT (A:=A) (fun x => P)) : type_scope.
-Notation "{ x : A  & P  & Q }" := (sigT2 (A:=A) (fun x => P) (fun x => Q)) :
   type_scope.
 
 Add Printing Let sig.

--- a/theories/Init/Specif.v
+++ b/theories/Init/Specif.v
@@ -72,11 +72,11 @@ Section Subset_projections.
   Variable A : Type.
   Variable P : A -> Prop.
 
-  Definition proj1_sig (e:sig P) := match e with
+  Definition proj1_sig (e : {x|P x}) := match e with
                                     | exist _ a b => a
                                     end.
 
-  Definition proj2_sig (e:sig P) :=
+  Definition proj2_sig (e : {x|P x}) :=
     match e return P (proj1_sig e) with
     | exist _ a b => b
     end.
@@ -92,7 +92,7 @@ End Subset_projections.
     [proj1_sig] of a coerced [X : sig2 P Q] will unify with [let (a,
     _, _) := X in a] *)
 
-Definition sig_of_sig2 (A : Type) (P Q : A -> Prop) (X : sig2 P Q) : sig P
+Definition sig_of_sig2 (A : Type) (P Q : A -> Prop) (X : {x|P x & Q x}) : {x|P x}
   := exist P
            (let (a, _, _) := X in a)
            (let (x, p, _) as s return (P (let (a, _, _) := s in a)) := X in p).
@@ -111,7 +111,7 @@ Section Subset_projections2.
   Variable A : Type.
   Variables P Q : A -> Prop.
 
-  Definition proj3_sig (e : sig2 P Q) :=
+  Definition proj3_sig (e : {x|P x & Q x}) :=
     let (a, b, c) return Q (proj1_sig (sig_of_sig2 e)) := e in c.
 
 End Subset_projections2.
@@ -131,11 +131,11 @@ Section Projections.
   Variable A : Type.
   Variable P : A -> Type.
 
-  Definition projT1 (x:sigT P) : A := match x with
+  Definition projT1 (x : {x:A & P x}) : A := match x with
                                       | existT _ a _ => a
                                       end.
 
-  Definition projT2 (x:sigT P) : P (projT1 x) :=
+  Definition projT2 (x : {x:A & P x}) : P (projT1 x) :=
     match x return P (projT1 x) with
     | existT _ _ h => h
     end.
@@ -150,7 +150,7 @@ End Projections.
     [projT1] of a coerced [X : sigT2 P Q] will unify with [let (a,
     _, _) := X in a] *)
 
-Definition sigT_of_sigT2 (A : Type) (P Q : A -> Type) (X : sigT2 P Q) : sigT P
+Definition sigT_of_sigT2 (A : Type) (P Q : A -> Type) (X : {x:A & P x & Q x}) : {x:A & P x}
   := existT P
             (let (a, _, _) := X in a)
             (let (x, p, _) as s return (P (let (a, _, _) := s in a)) := X in p).
@@ -169,25 +169,25 @@ Section Projections2.
   Variable A : Type.
   Variables P Q : A -> Type.
 
-  Definition projT3 (e : sigT2 P Q) :=
+  Definition projT3 (e : {x:A & P x & Q x}) :=
     let (a, b, c) return Q (projT1 (sigT_of_sigT2 e)) := e in c.
 
 End Projections2.
 
 (** [sigT] of a predicate is equivalent to [sig] *)
 
-Definition sig_of_sigT (A : Type) (P : A -> Prop) (X : sigT P) : sig P
+Definition sig_of_sigT (A : Type) (P : A -> Prop) (X : {x:A & P x}) : {x:A | P x}
   := exist P (projT1 X) (projT2 X).
 
-Definition sigT_of_sig (A : Type) (P : A -> Prop) (X : sig P) : sigT P
+Definition sigT_of_sig (A : Type) (P : A -> Prop) (X : {x:A | P x}) : {x:A & P x}
   := existT P (proj1_sig X) (proj2_sig X).
 
 (** [sigT2] of a predicate is equivalent to [sig2] *)
 
-Definition sig2_of_sigT2 (A : Type) (P Q : A -> Prop) (X : sigT2 P Q) : sig2 P Q
+Definition sig2_of_sigT2 (A : Type) (P Q : A -> Prop) (X : {x:A & P x & Q x}) : {x:A | P x & Q x}
   := exist2 P Q (projT1 (sigT_of_sigT2 X)) (projT2 (sigT_of_sigT2 X)) (projT3 X).
 
-Definition sigT2_of_sig2 (A : Type) (P Q : A -> Prop) (X : sig2 P Q) : sigT2 P Q
+Definition sigT2_of_sig2 (A : Type) (P Q : A -> Prop) (X : {x:A | P x & Q x}) : {x:A & P x & Q x}
   := existT2 P Q (proj1_sig (sig_of_sig2 X)) (proj2_sig (sig_of_sig2 X)) (proj3_sig X).
 
 (** η Principles *)

--- a/theories/Init/Specif.v
+++ b/theories/Init/Specif.v
@@ -72,11 +72,11 @@ Section Subset_projections.
   Variable A : Type.
   Variable P : A -> Prop.
 
-  Definition proj1_sig (e : {x|P x}) := match e with
+  Definition proj1_sig (e:sig P) := match e with
                                     | exist _ a b => a
                                     end.
 
-  Definition proj2_sig (e : {x|P x}) :=
+  Definition proj2_sig (e:sig P) :=
     match e return P (proj1_sig e) with
     | exist _ a b => b
     end.
@@ -92,7 +92,7 @@ End Subset_projections.
     [proj1_sig] of a coerced [X : sig2 P Q] will unify with [let (a,
     _, _) := X in a] *)
 
-Definition sig_of_sig2 (A : Type) (P Q : A -> Prop) (X : {x|P x & Q x}) : {x|P x}
+Definition sig_of_sig2 (A : Type) (P Q : A -> Prop) (X : sig2 P Q) : sig P
   := exist P
            (let (a, _, _) := X in a)
            (let (x, p, _) as s return (P (let (a, _, _) := s in a)) := X in p).
@@ -111,7 +111,7 @@ Section Subset_projections2.
   Variable A : Type.
   Variables P Q : A -> Prop.
 
-  Definition proj3_sig (e : {x|P x & Q x}) :=
+  Definition proj3_sig (e : sig2 P Q) :=
     let (a, b, c) return Q (proj1_sig (sig_of_sig2 e)) := e in c.
 
 End Subset_projections2.
@@ -131,11 +131,11 @@ Section Projections.
   Variable A : Type.
   Variable P : A -> Type.
 
-  Definition projT1 (x : {x:A & P x}) : A := match x with
+  Definition projT1 (x:sigT P) : A := match x with
                                       | existT _ a _ => a
                                       end.
 
-  Definition projT2 (x : {x:A & P x}) : P (projT1 x) :=
+  Definition projT2 (x:sigT P) : P (projT1 x) :=
     match x return P (projT1 x) with
     | existT _ _ h => h
     end.
@@ -150,7 +150,7 @@ End Projections.
     [projT1] of a coerced [X : sigT2 P Q] will unify with [let (a,
     _, _) := X in a] *)
 
-Definition sigT_of_sigT2 (A : Type) (P Q : A -> Type) (X : {x:A & P x & Q x}) : {x:A & P x}
+Definition sigT_of_sigT2 (A : Type) (P Q : A -> Type) (X : sigT2 P Q) : sigT P
   := existT P
             (let (a, _, _) := X in a)
             (let (x, p, _) as s return (P (let (a, _, _) := s in a)) := X in p).
@@ -169,25 +169,25 @@ Section Projections2.
   Variable A : Type.
   Variables P Q : A -> Type.
 
-  Definition projT3 (e : {x:A & P x & Q x}) :=
+  Definition projT3 (e : sigT2 P Q) :=
     let (a, b, c) return Q (projT1 (sigT_of_sigT2 e)) := e in c.
 
 End Projections2.
 
 (** [sigT] of a predicate is equivalent to [sig] *)
 
-Definition sig_of_sigT (A : Type) (P : A -> Prop) (X : {x:A & P x}) : {x:A | P x}
+Definition sig_of_sigT (A : Type) (P : A -> Prop) (X : sigT P) : sig P
   := exist P (projT1 X) (projT2 X).
 
-Definition sigT_of_sig (A : Type) (P : A -> Prop) (X : {x:A | P x}) : {x:A & P x}
+Definition sigT_of_sig (A : Type) (P : A -> Prop) (X : sig P) : sigT P
   := existT P (proj1_sig X) (proj2_sig X).
 
 (** [sigT2] of a predicate is equivalent to [sig2] *)
 
-Definition sig2_of_sigT2 (A : Type) (P Q : A -> Prop) (X : {x:A & P x & Q x}) : {x:A | P x & Q x}
+Definition sig2_of_sigT2 (A : Type) (P Q : A -> Prop) (X : sigT2 P Q) : sig2 P Q
   := exist2 P Q (projT1 (sigT_of_sigT2 X)) (projT2 (sigT_of_sigT2 X)) (projT3 X).
 
-Definition sigT2_of_sig2 (A : Type) (P Q : A -> Prop) (X : {x:A | P x & Q x}) : {x:A & P x & Q x}
+Definition sigT2_of_sig2 (A : Type) (P Q : A -> Prop) (X : sig2 P Q) : sigT2 P Q
   := existT2 P Q (proj1_sig (sig_of_sig2 X)) (proj2_sig (sig_of_sig2 X)) (proj3_sig X).
 
 (** η Principles *)

--- a/theories/Logic/FunctionalExtensionality.v
+++ b/theories/Logic/FunctionalExtensionality.v
@@ -144,7 +144,7 @@ Tactic Notation "extensionality" ident(x) :=
     until finding an equality statement *)
 (* Note that you can write [Ltac extensionality_in_checker tac ::= tac tt.] to get a more informative error message. *)
 Ltac extensionality_in_checker tac :=
-  first [ tac tt | fail 1 "Anomaly: Unexpected error in extensionality tactic.  Please report." ].
+  first [ tac tt | fail 1 "Anomaly: Unexpected error in extensionality tactic.  Please report" ].
 Tactic Notation "extensionality" "in" hyp(H) :=
   let rec check_is_extensional_equality H :=
       lazymatch type of H with
@@ -186,7 +186,9 @@ Tactic Notation "extensionality" "in" hyp(H) :=
       | forall a : ?A, _
         => let Ha := fresh in
            let ret := constr:(fun a : A => match H a with Ha => ltac:(let v := lift_sig_extensionality Ha in exact v) end) in
-           lazymatch type of ret with
+           let t := type of ret in
+           let t := eval lazy beta in t in
+           lazymatch t with
            | forall a : ?A, sig (fun b : ?B => @?f a b = @?g a b)
              => eta_contract (exist (fun b : (forall a : A, B) => (fun a : A => f a (b a)) = (fun a : A => g a (b a)))
                                     (fun a : A => proj1_sig (ret a))


### PR DESCRIPTION
The main part of this PR is to do that parameters are considered up to conversion rather than syntactically being variables in the definition of an inductive type. This allows for instance to support the following:

```coq
Inductive sig {A:Type} (P:A -> Prop) : Type :=
    exist : forall x:A, P x -> { x : A | P x }
where "{ x : A |  P }" := (sig (fun x : A => P)) : type_scope.
```
where the parameter P appears not as a variable but as an eta-expanded variable.

The rest of the PR is more about raising questions.

The PR contains also a commit experimenting defining `ex`, `sig`, `sigT`, `ex2`, `sig2`, `sigT2` jointly with their notation. This is not anodyne, as it introduces an η-expansion which has an effect on how the type of the constructor is printed, and which also has an effect on pattern-matching on the type of such a constructor, what raises question on how robust is the system wrt such trivial conversion.

The PR contains also a commit proposing to replace the use of `sig`, `sigT`, `sig2`, `sigT2` which were not using a notation in `Specif.v` by using the notations (in relation with the discussion at PR #385). Again, this means changing the type of the corresponding functions by addding an η-expansion (is this an extra argument to tell that substitution of terms creating βɩ-redexes should maybe reduce those redexes on the fly?).

The PR also contains two fixes already committed in branch 8.5 (so, to be eventually absorbed when merging v8.5).