### PR TITLE
Remove a dead exception catching code.

### DIFF
--- a/proofs/pfedit.ml
+++ b/proofs/pfedit.ml
@@ -143,12 +143,7 @@ let solve ?with_end_tac gi info_lvl tac pr =
     in
     (p,status)
   with
-    | Proof_global.NoCurrentProof  -> CErrors.error "No focused proof"
-    | CList.IndexOutOfRange ->
-        match gi with
-	| Vernacexpr.SelectNth i -> let msg = str "No such goal: " ++ int i ++ str "." in
-	                            CErrors.user_err  msg
-        | _ -> assert false
+    Proof_global.NoCurrentProof -> CErrors.error "No focused proof"
 
 let by tac = Proof_global.with_current_proof (fun _ -> solve (Vernacexpr.SelectNth 1) None tac)
 


### PR DESCRIPTION
The code was assuming that `Proofview.tclFOCUS` could raise a `CList.IndexOutOfRange` exception but this isn't the case. The focusing functions already catch this exception and print out an error message.

The exception catching mechanism is there: https://github.com/coq/coq/blob/trunk/engine/proofview.ml#L365