### PR TITLE
Make "simpl nomatch" forbid Fix and CoFix constructs too.

### DIFF
--- a/pretyping/tacred.ml
+++ b/pretyping/tacred.ml
@@ -770,7 +770,7 @@ and whd_simpl_stack env sigma =
              let rec is_case x = match kind_of_term x with
                | Lambda (_,_, x) | LetIn (_,_,_, x) | Cast (x, _,_) -> is_case x
                | App (hd, _) -> is_case hd
-               | Case _ -> true
+               | Case _ | Fix _ | CoFix _ -> true
                | _ -> false in
                if nocase && is_case hd then raise Redelimination
                else s''


### PR DESCRIPTION
Definitions marked as "simpl nomatch" cannot be simplified to a term
starting with

  fun x => match ...

but they can be simplified to a term starting with

  fix foo x := match ...

which is just as ugly. This commit fixes this discrepancy. Actually, it
goes a bit further by always forbidding Fix and CoFix constructs.