### PR TITLE
Turning the printing primitive projection compatibility flag off by default

### DIFF
--- a/doc/refman/RefMan-ext.tex
+++ b/doc/refman/RefMan-ext.tex
@@ -321,7 +321,7 @@ for the usual defined ones.
 For compatibility, the parameters still appear to the user when printing terms
 even though they are absent in the actual AST manipulated by the kernel. This
 can be changed by unsetting the {\tt Printing Primitive Projection Parameters}
-flag. Further compatibility printing can be deactivated thanks to the
+flag. Further compatibility printing can be activated thanks to the
 {\tt Printing Primitive Projection Compatibility} option which governs the
 printing of pattern-matching over primitive records.
 

--- a/doc/refman/RefMan-ext.tex
+++ b/doc/refman/RefMan-ext.tex
@@ -318,10 +318,10 @@ for the usual defined ones.
   % - [pattern x at n], [rewrite x at n] and in general abstraction and selection
   %   of occurrences may fail due to the disappearance of parameters.
 
-For compatibility, the parameters still appear to the user when printing terms
+The internally omitted parameters can be reconstructed at printing time
 even though they are absent in the actual AST manipulated by the kernel. This
-can be changed by unsetting the {\tt Printing Primitive Projection Parameters}
-flag. Further compatibility printing can be activated thanks to the
+can be obtained by setting the {\tt Printing Primitive Projection Parameters}
+flag. Another compatibility printing can be activated thanks to the
 {\tt Printing Primitive Projection Compatibility} option which governs the
 printing of pattern-matching over primitive records.
 

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -162,7 +162,7 @@ let _ = declare_bool_option
 	    optread  = reverse_matching;
 	    optwrite = (:=) reverse_matching_value }
 
-let print_primproj_params_value = ref true
+let print_primproj_params_value = ref false
 let print_primproj_params () = !print_primproj_params_value
 
 let _ = declare_bool_option

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -173,7 +173,7 @@ let _ = declare_bool_option
 	    optread  = print_primproj_params;
 	    optwrite = (:=) print_primproj_params_value }
 
-let print_primproj_compatibility_value = ref true
+let print_primproj_compatibility_value = ref false
 let print_primproj_compatibility () = !print_primproj_compatibility_value
 
 let _ = declare_bool_option


### PR DESCRIPTION
After discussions with @mattam82 and @ppedrot, here is a trivial PR, so that in, say:
```coq
Set Primitive Projections.
Record prod A B := pair { fst : A; snd : B}.
Eval compute in fun x : prod nat nat => fst _ _ x.
```
one sees the primitive projection and not the counterintuitive `let`-like writing of it.

More generally, here is a summary certified by @mattam82 about the status of the compatibility mode for primitive projections.

Internally, each projection comes in three kernel versions (I use `fst` applied to `t` as example). They are all user-accessible with the same syntax (`Top.fst`):
1. the (applied) folded version `Proj ((Top.fst,false),t)`
  - it reacts to the `delta` flag and unfolds in the folded version; it does not react to `iota`
  - it is always printed `Top.fst`
  - its arguments are recomputed and printed
  - its parameters are taken into account when computing occurrences (e.g. `at 2`) but there is no effect of `simpl`, `change`, `rewrite` etc. in the arguments themselves.
2. the (applied) unfolded version `Proj ((Top.fst,true),t)`
  - it reacts to `iota` if its main argument is a constructor
  - it is printed `let (_,fst) := t in fst` in printing compatibility mode [1]. Otherwise, it is printed `Top.fst nat nat`  in parameter printing mode [2] and with the parameters written `_` otherwise.
  - its parameters are taken into account when computing occurrences (e.g. `at 2`) but there is no effect of `simpl`, `change`, `rewrite` etc. in the arguments.
3. the constant version `Const (Top.fst)`
  - it is used only to represent a non-fully applied projection (decided at interpretation time)
  - it reacts to the `delta` flag and unfolds to the unfolded version; it does not react to `iota`
  - parameters matter when looking for occurrences and they react to action in them.

At interpretation time, if `Top.fst` is fully applied with main argument `t`, it is interpreted as `Proj ((Top.fst,false),t)`, otherwise as a partial application of `Const (Top.fst)`. There is no way to directly mean `Proj ((Top.fst,true),t)`.

At interpretation time, `let (x,y) := t in u` is expanded into `let x := Top.fst _ _ t in let y := Top.snd _ _ t in u` (using the unfolded versions).

So, more generally, I wonder whether we shouldn't have a simplified model, where all the subtleties above are only in compatibility mode, and, where in non-compatibility mode:
- only the strictly primitive `Proj((Top.fst,true),t)` is accepted
- the main argument is mandatory (possibly doing an η-expansion on the fly if partially applied)
- `let (x,y) := t in u` is forbidden
- the parameters are not relevant for counting occurrences nor for actions (`simpl`, `rewrite`, ...) in the parameters.

[1] `Set Printing Primitive Projection Compatibility`
[2] `Set Printing Primitive Projection Parameters.`

Not to forget in passing, a minor bug in compatibility mode: `unfold fst at 1` or `simpl fst` in `fst nat nat x = 0` fails when `fst` is the folded version. But I don't know if it is worth to be fixed since after all this would spread the compatibility mode to yet another part of the system.