### PR TITLE
Annotate deprecated API

### DIFF
--- a/API/API.mli
+++ b/API/API.mli
@@ -146,6 +146,8 @@ sig
     val canonical : t -> KerName.t
     val user : t -> KerName.t
     val label : t -> Label.t
+    val print : t -> Pp.std_ppcmds
+    val to_string : t -> string
   end
 
   module MutInd :

--- a/checker/include
+++ b/checker/include
@@ -149,12 +149,12 @@ let parse_sp s =
 let parse_kn s =
    let l = List.rev (Str.split(Str.regexp"\\.") s) in
    let dp = make_dirpath(List.map id_of_string(List.tl l)) in
-   make_kn(MPfile dp) empty_dirpath (label_of_id (id_of_string (List.hd l)))
+   make_kn(MPfile dp) DirPath.empty (label_of_id (id_of_string (List.hd l)))
 ;;
 let parse_con s =
    let l = List.rev (Str.split(Str.regexp"\\.") s) in
    let dp = make_dirpath(List.map id_of_string(List.tl l)) in
-   make_con(MPfile dp) empty_dirpath (label_of_id (id_of_string (List.hd l)))
+   Constant.make3 (MPfile dp) DirPath.empty (label_of_id (id_of_string (List.hd l)))
 ;;
 let get_mod dp = 
   lookup_module dp (Safe_typing.get_env())

--- a/dev/top_printers.ml
+++ b/dev/top_printers.ml
@@ -41,11 +41,11 @@ let pplab l = pp (pr_lab l)
 let ppmbid mbid = pp (str (MBId.debug_to_string mbid))
 let ppdir dir = pp (pr_dirpath dir)
 let ppmp mp = pp(str (ModPath.debug_to_string mp))
-let ppcon con = pp(debug_pr_con con)
-let ppproj con = pp(debug_pr_con (Projection.constant con))
+let ppcon con = pp(Constant.debug_print con)
+let ppproj con = pp(Constant.debug_print (Projection.constant con))
 let ppkn kn = pp(str (KerName.to_string kn))
-let ppmind kn = pp(debug_pr_mind kn)
-let ppind (kn,i) = pp(debug_pr_mind kn ++ str"," ++int i)
+let ppmind kn = pp(MutInd.debug_print kn)
+let ppind (kn,i) = pp(MutInd.debug_print kn ++ str"," ++int i)
 let ppsp sp = pp(pr_path sp)
 let ppqualid qid = pp(pr_qualid qid)
 let ppclindex cl = pp(Classops.pr_cl_index cl)
@@ -126,10 +126,10 @@ let ppclosedglobconstridmap x = pp (pr_closed_glob_constr_idmap x)
 let pP s = pp (hov 0 s)
 
 let safe_pr_global = function
-  | ConstRef kn -> pp (str "CONSTREF(" ++ debug_pr_con kn ++ str ")")
-  | IndRef (kn,i) -> pp (str "INDREF(" ++ debug_pr_mind kn ++ str "," ++
+  | ConstRef kn -> pp (str "CONSTREF(" ++ Constant.debug_print kn ++ str ")")
+  | IndRef (kn,i) -> pp (str "INDREF(" ++ MutInd.debug_print kn ++ str "," ++
 			  int i ++ str ")")
-  | ConstructRef ((kn,i),j) -> pp (str "INDREF(" ++ debug_pr_mind kn ++ str "," ++
+  | ConstructRef ((kn,i),j) -> pp (str "INDREF(" ++ MutInd.debug_print kn ++ str "," ++
 				      int i ++ str "," ++ int j ++ str ")")
   | VarRef id -> pp (str "VARREF(" ++ Id.print id ++ str ")")
 
@@ -170,7 +170,7 @@ let ppexistentialfilter filter = match Evd.Filter.repr filter with
 let ppclenv clenv = pp(pr_clenv clenv)
 let ppgoalgoal gl = pp(Goal.pr_goal gl)
 let ppgoal g = pp(Printer.pr_goal g)
-let ppgoalsigma g = pp(Printer.pr_goal g ++ Termops.pr_evar_map None (Refiner.project g))
+let ppgoalsigma g = pp(Printer.pr_goal g ++ Termops.pr_evar_map None g.Evd.sigma)
 let pphintdb db = pp(Hints.pr_hint_db db)
 let ppproofview p =
   let gls,sigma = Proofview.proofview p in
@@ -227,7 +227,7 @@ let ppenv e = pp
 let ppenvwithcst e = pp
   (str "[" ++ pr_named_context_of e Evd.empty ++ str "]" ++ spc() ++
    str "[" ++ pr_rel_context e Evd.empty (rel_context e) ++ str "]" ++ spc() ++
-   str "{" ++ Cmap_env.fold (fun a _ s -> pr_con a ++ spc () ++ s) (Obj.magic e).Pre_env.env_globals.Pre_env.env_constants (mt ()) ++ str "}")
+   str "{" ++ Cmap_env.fold (fun a _ s -> Constant.print a ++ spc () ++ s) (Obj.magic e).Pre_env.env_globals.Pre_env.env_constants (mt ()) ++ str "}")
 
 let pptac = (fun x -> pp(Ltac_plugin.Pptactic.pr_glob_tactic (API.Global.env()) x))
 
@@ -259,13 +259,13 @@ let constr_display csr =
       ^(term_display t)^","^(term_display c)^")"
   | App (c,l) -> "App("^(term_display c)^","^(array_display l)^")\n"
   | Evar (e,l) -> "Evar("^(string_of_existential e)^","^(array_display l)^")"
-  | Const (c,u) -> "Const("^(string_of_con c)^","^(universes_display u)^")"
+  | Const (c,u) -> "Const("^(Constant.to_string c)^","^(universes_display u)^")"
   | Ind ((sp,i),u) ->
-      "MutInd("^(string_of_mind sp)^","^(string_of_int i)^","^(universes_display u)^")"
+      "MutInd("^(MutInd.to_string sp)^","^(string_of_int i)^","^(universes_display u)^")"
   | Construct (((sp,i),j),u) ->
-      "MutConstruct(("^(string_of_mind sp)^","^(string_of_int i)^"),"
+      "MutConstruct(("^(MutInd.to_string sp)^","^(string_of_int i)^"),"
       ^","^(universes_display u)^(string_of_int j)^")"
-  | Proj (p, c) -> "Proj("^(string_of_con (Projection.constant p))^","^term_display c ^")"
+  | Proj (p, c) -> "Proj("^(Constant.to_string (Projection.constant p))^","^term_display c ^")"
   | Case (ci,p,c,bl) ->
       "MutCase(<abs>,"^(term_display p)^","^(term_display c)^","
       ^(array_display bl)^")"
@@ -433,7 +433,7 @@ let print_pure_constr csr =
 	| ("Coq"::_::l) -> l
 	| l             -> l
     in  List.iter (fun x -> print_string x; print_string ".") ls;*)
-      print_string (debug_string_of_mind sp)
+      print_string (MutInd.debug_to_string sp)
   and sp_con_display sp =
 (*    let dir,l = decode_kn sp in
     let ls =
@@ -442,7 +442,7 @@ let print_pure_constr csr =
 	| ("Coq"::_::l) -> l
 	| l             -> l
     in  List.iter (fun x -> print_string x; print_string ".") ls;*)
-      print_string (debug_string_of_con sp)
+      print_string (Constant.debug_to_string sp)
 
   in
     try

--- a/dev/vm_printers.ml
+++ b/dev/vm_printers.ml
@@ -10,11 +10,11 @@ let ppripos (ri,pos) =
   | Reloc_annot a ->
       let sp,i = a.ci.ci_ind in
       print_string
-	("annot : MutInd("^(string_of_mind sp)^","^(string_of_int i)^")\n")
+	("annot : MutInd("^(MutInd.to_string sp)^","^(string_of_int i)^")\n")
   | Reloc_const _ ->
       print_string "structured constant\n"
   | Reloc_getglobal kn ->
-      print_string ("getglob "^(string_of_con kn)^"\n"));
+      print_string ("getglob "^(Constant.to_string kn)^"\n"));
    print_flush ()
 
 let print_vfix () = print_string "vfix"
@@ -32,7 +32,7 @@ let print_idkey idk =
   match idk with
   | ConstKey sp ->
       print_string "Cons(";
-      print_string (string_of_con sp);
+      print_string (Constant.to_string sp);
       print_string ")"
   | VarKey id -> print_string (Id.to_string id)
   | RelKey i -> print_string "~";print_int i
@@ -63,7 +63,7 @@ and ppatom a =
   | Aid idk -> print_idkey idk
   | Atype u -> print_string "Type(...)"
   | Aind(sp,i) ->  print_string "Ind(";
-      print_string (string_of_mind sp);
+      print_string (MutInd.to_string sp);
       print_string ","; print_int i;
       print_string ")"
 

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -306,7 +306,7 @@ let push_rel_decl_to_named_context sigma decl (subst, vsubst, avoid, nc) =
   in
   let extract_if_neq id = function
     | Anonymous -> None
-    | Name id' when id_ord id id' = 0 -> None
+    | Name id' when Id.compare id id' = 0 -> None
     | Name id' -> Some id'
   in
   let na = RelDecl.get_name decl in

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -371,17 +371,17 @@ val key : Id.t -> t -> Evar.t
 end =
 struct
 
-type t = Id.t EvMap.t * existential_key Idmap.t
+type t = Id.t EvMap.t * existential_key Id.Map.t
 
-let empty = (EvMap.empty, Idmap.empty)
+let empty = (EvMap.empty, Id.Map.empty)
 
 let add_name_newly_undefined id evk evi (evtoid, idtoev as names) =
   match id with
   | None -> names
   | Some id ->
-    if Idmap.mem id idtoev then
+    if Id.Map.mem id idtoev then
       user_err  (str "Already an existential evar of name " ++ pr_id id);
-    (EvMap.add evk id evtoid, Idmap.add id evk idtoev)
+    (EvMap.add evk id evtoid, Id.Map.add id evk idtoev)
 
 let add_name_undefined naming evk evi (evtoid,idtoev as evar_names) =
   if EvMap.mem evk evtoid then
@@ -393,15 +393,15 @@ let remove_name_defined evk (evtoid, idtoev as names) =
   let id = try Some (EvMap.find evk evtoid) with Not_found -> None in
   match id with
   | None -> names
-  | Some id -> (EvMap.remove evk evtoid, Idmap.remove id idtoev)
+  | Some id -> (EvMap.remove evk evtoid, Id.Map.remove id idtoev)
 
 let rename evk id (evtoid, idtoev) =
   let id' = try Some (EvMap.find evk evtoid) with Not_found -> None in
   match id' with
-  | None -> (EvMap.add evk id evtoid, Idmap.add id evk idtoev)
+  | None -> (EvMap.add evk id evtoid, Id.Map.add id evk idtoev)
   | Some id' ->
-    if Idmap.mem id idtoev then anomaly (str "Evar name already in use.");
-    (EvMap.update evk id evtoid (* overwrite old name *), Idmap.add id evk (Idmap.remove id' idtoev))
+    if Id.Map.mem id idtoev then anomaly (str "Evar name already in use.");
+    (EvMap.update evk id evtoid (* overwrite old name *), Id.Map.add id evk (Id.Map.remove id' idtoev))
 
 let reassign_name_defined evk evk' (evtoid, idtoev as names) =
   let id = try Some (EvMap.find evk evtoid) with Not_found -> None in
@@ -409,13 +409,13 @@ let reassign_name_defined evk evk' (evtoid, idtoev as names) =
   | None -> names (** evk' must not be defined *)
   | Some id ->
     (EvMap.add evk' id (EvMap.remove evk evtoid),
-    Idmap.add id evk' (Idmap.remove id idtoev))
+    Id.Map.add id evk' (Id.Map.remove id idtoev))
 
 let ident evk (evtoid, _) =
   try Some (EvMap.find evk evtoid) with Not_found -> None
 
 let key id (_, idtoev) =
-  Idmap.find id idtoev
+  Id.Map.find id idtoev
 
 end
 

--- a/engine/namegen.ml
+++ b/engine/namegen.ml
@@ -59,9 +59,9 @@ let is_imported_ref = function
   | VarRef _ -> false
   | IndRef (kn,_)
   | ConstructRef ((kn,_),_) ->
-      let (mp,_,_) = repr_mind kn in is_imported_modpath mp
+      let (mp,_,_) = MutInd.repr3 kn in is_imported_modpath mp
   | ConstRef kn ->
-      let (mp,_,_) = repr_con kn in is_imported_modpath mp
+      let (mp,_,_) = Constant.repr3 kn in is_imported_modpath mp
 
 let is_global id =
   try
@@ -97,7 +97,7 @@ let head_name sigma c = (* Find the head constant of a constr if any *)
     match EConstr.kind sigma c with
     | Prod (_,_,c) | Lambda (_,_,c) | LetIn (_,_,_,c)
     | Cast (c,_,_) | App (c,_) -> hdrec c
-    | Proj (kn,_) -> Some (Label.to_id (con_label (Projection.constant kn)))
+    | Proj (kn,_) -> Some (Label.to_id (Constant.label (Projection.constant kn)))
     | Const _ | Ind _ | Construct _ | Var _ as c ->
 	Some (basename_of_global (global_of_constr c))
     | Fix ((_,i),(lna,_,_)) | CoFix (i,(lna,_,_)) ->
@@ -118,8 +118,8 @@ let hdchar env sigma c =
     match EConstr.kind sigma c with
     | Prod (_,_,c) | Lambda (_,_,c) | LetIn (_,_,_,c) -> hdrec (k+1) c
     | Cast (c,_,_) | App (c,_) -> hdrec k c
-    | Proj (kn,_) -> lowercase_first_char (Label.to_id (con_label (Projection.constant kn)))
-    | Const (kn,_) -> lowercase_first_char (Label.to_id (con_label kn))
+    | Proj (kn,_) -> lowercase_first_char (Label.to_id (Constant.label (Projection.constant kn)))
+    | Const (kn,_) -> lowercase_first_char (Label.to_id (Constant.label kn))
     | Ind (x,_) -> lowercase_first_char (basename_of_global (IndRef x))
     | Construct (x,_) -> lowercase_first_char (basename_of_global (ConstructRef x))
     | Var id  -> lowercase_first_char id

--- a/engine/namegen.mli
+++ b/engine/namegen.mli
@@ -38,7 +38,9 @@ val mkLambda_name : env -> evar_map -> Name.t * types * constr -> constr
 
 (** Deprecated synonyms of [mkProd_name] and [mkLambda_name] *)
 val prod_name : env -> evar_map -> Name.t * types * types -> types
+[@@ocaml.deprecated]
 val lambda_name : env -> evar_map -> Name.t * types * constr -> constr
+[@@ocaml.deprecated]
 
 val prod_create : env -> evar_map -> types * types -> constr
 val lambda_create : env -> evar_map -> types * constr -> constr

--- a/engine/proofview.mli
+++ b/engine/proofview.mli
@@ -548,6 +548,7 @@ val tclLIFT : 'a NonLogical.t -> 'a tactic
 module V82 : sig
   type tac = Evar.t Evd.sigma -> Evar.t list Evd.sigma
   val tactic : tac -> unit tactic
+  [@@ocaml.deprecated]
 
   (* normalises the evars in the goals, and stores the result in
      solution. *)
@@ -573,6 +574,7 @@ module V82 : sig
      should be avoided as much as possible.  It should work as
      expected for a tactic obtained from {!V82.tactic} though. *)
   val of_tactic : 'a tactic -> tac
+  [@@ocaml.deprecated]
 
   (* marks as unsafe if the argument is [false] *)
   val put_status : bool -> unit tactic

--- a/engine/termops.ml
+++ b/engine/termops.ml
@@ -31,8 +31,6 @@ let pr_sort_family = function
   | InProp -> (str "Prop")
   | InType -> (str "Type")
 
-let pr_con sp = str(string_of_con sp)
-
 let pr_fix pr_constr ((t,i),(lna,tl,bl)) =
   let fixl = Array.mapi (fun i na -> (na,t.(i),tl.(i),bl.(i))) lna in
   hov 1
@@ -73,11 +71,11 @@ let rec pr_constr c = match kind_of_term c with
   | Evar (e,l) -> hov 1
       (str"Evar#" ++ int (Evar.repr e) ++ str"{" ++
        prlist_with_sep spc pr_constr (Array.to_list l) ++str"}")
-  | Const (c,u) -> str"Cst(" ++ pr_puniverses (pr_con c) u ++ str")"
-  | Ind ((sp,i),u) -> str"Ind(" ++ pr_puniverses (pr_mind sp ++ str"," ++ int i) u ++ str")"
+  | Const (c,u) -> str"Cst(" ++ pr_puniverses (Constant.print c) u ++ str")"
+  | Ind ((sp,i),u) -> str"Ind(" ++ pr_puniverses (MutInd.print sp ++ str"," ++ int i) u ++ str")"
   | Construct (((sp,i),j),u) ->
-      str"Constr(" ++ pr_puniverses (pr_mind sp ++ str"," ++ int i ++ str"," ++ int j) u ++ str")"
-  | Proj (p,c) -> str"Proj(" ++ pr_con (Projection.constant p) ++ str"," ++ bool (Projection.unfolded p) ++ pr_constr c ++ str")"
+      str"Constr(" ++ pr_puniverses (MutInd.print sp ++ str"," ++ int i ++ str"," ++ int j) u ++ str")"
+  | Proj (p,c) -> str"Proj(" ++ Constant.print (Projection.constant p) ++ str"," ++ bool (Projection.unfolded p) ++ pr_constr c ++ str")"
   | Case (ci,p,c,bl) -> v 0
       (hv 0 (str"<"++pr_constr p++str">"++ cut() ++ str"Case " ++
              pr_constr c ++ str"of") ++ cut() ++

--- a/engine/universes.ml
+++ b/engine/universes.ml
@@ -238,7 +238,7 @@ let compare_head_gen_proj env equ eqs eqc' m n =
   | Proj (p, c), App (f, args)
   | App (f, args), Proj (p, c) -> 
       (match kind_of_term f with
-      | Const (p', u) when eq_constant (Projection.constant p) p' -> 
+      | Const (p', u) when Constant.equal (Projection.constant p) p' -> 
           let pb = Environ.lookup_projection p env in
           let npars = pb.Declarations.proj_npars in
 	  if Array.length args == npars + 1 then

--- a/ide/ide_slave.ml
+++ b/ide/ide_slave.ml
@@ -173,11 +173,12 @@ let concl_next_tac sigma concl =
   ])
 
 let process_goal sigma g =
-  let env = Goal.V82.env sigma g in
+  let evi = Evd.find sigma g in
+  let env = Evd.evar_env evi in
   let min_env = Environ.reset_context env in
   let id = Goal.uid g in
   let ccl =
-    let norm_constr = Reductionops.nf_evar sigma (Goal.V82.concl sigma g) in
+    let norm_constr = Reductionops.nf_evar sigma (EConstr.of_constr (Evd.evar_concl evi)) in
     pr_goal_concl_style_env env sigma norm_constr
   in
   let process_hyp d (env,l) =
@@ -223,7 +224,8 @@ let hints () =
     match all_goals with
     | [] -> None
     | g :: _ ->
-      let env = Goal.V82.env sigma g in
+      let evi = Evd.find sigma g in
+      let env = Evd.evar_env evi in
       let hint_goal = concl_next_tac sigma g in
       let get_hint_hyp env d accu = hyp_next_tac sigma env d :: accu in
       let hint_hyps = List.rev (Environ.fold_named_context get_hint_hyp env ~init: []) in

--- a/interp/dumpglob.ml
+++ b/interp/dumpglob.ml
@@ -231,7 +231,7 @@ let add_glob ?loc ref =
     add_glob_gen ?loc sp lib_dp ty
 
 let mp_of_kn kn =
-  let mp,sec,l = Names.repr_kn kn in
+  let mp,sec,l = Names.KerName.repr kn in
     Names.MPdot (mp,l)
 
 let add_glob_kn ?loc kn =

--- a/kernel/cbytecodes.ml
+++ b/kernel/cbytecodes.ml
@@ -193,7 +193,7 @@ let pp_sort s =
 
 let rec pp_struct_const = function
   | Const_sorts s -> pp_sort s
-  | Const_ind (mind, i) -> pr_mind mind ++ str"#" ++ int i
+  | Const_ind (mind, i) -> MutInd.print mind ++ str"#" ++ int i
   | Const_proj p -> Constant.print p
   | Const_b0 i -> int i
   | Const_bn (i,t) ->
@@ -241,7 +241,7 @@ let rec pp_instr i =
 	     prlist_with_sep spc pp_lbl (Array.to_list lblt) ++
 	     str " bodies = " ++
 	     prlist_with_sep spc pp_lbl (Array.to_list lblb))
-  | Kgetglobal idu -> str "getglobal " ++ pr_con idu
+  | Kgetglobal idu -> str "getglobal " ++ Constant.print idu
   | Kconst sc ->
       str "const " ++ pp_struct_const sc
   | Kmakeblock(n, m) ->

--- a/kernel/cbytegen.ml
+++ b/kernel/cbytegen.ml
@@ -998,7 +998,7 @@ let compile_constant_body fail_on_error env univs = function
       match kind_of_term body with
 	| Const (kn',u) when is_univ_copy instance_size u ->
 	    (* we use the canonical name of the constant*)
-	    let con= constant_of_kn (canonical_con kn') in
+	    let con= Constant.make1 (Constant.canonical kn') in
 	      Some (BCalias (get_alias env con))
 	| _ ->
 	    let res = compile fail_on_error ~universes:instance_size env body in
@@ -1006,7 +1006,7 @@ let compile_constant_body fail_on_error env univs = function
 
 (* Shortcut of the previous function used during module strengthening *)
 
-let compile_alias kn = BCalias (constant_of_kn (canonical_con kn))
+let compile_alias kn = BCalias (Constant.make1 (Constant.canonical kn))
 
 (* spiwack: additional function which allow different part of compilation of the
       31-bit integers *)

--- a/kernel/constr.ml
+++ b/kernel/constr.ml
@@ -520,7 +520,7 @@ let compare_head_gen_leq_with kind1 kind2 eq_universes leq_sorts eq leq t1 t2 =
         eq c1 c2 && Array.equal_norefl eq l1 l2
   | Proj (p1,c1), Proj (p2,c2) -> Projection.equal p1 p2 && eq c1 c2
   | Evar (e1,l1), Evar (e2,l2) -> Evar.equal e1 e2 && Array.equal eq l1 l2
-  | Const (c1,u1), Const (c2,u2) -> eq_constant c1 c2 && eq_universes true u1 u2
+  | Const (c1,u1), Const (c2,u2) -> Constant.equal c1 c2 && eq_universes true u1 u2
   | Ind (c1,u1), Ind (c2,u2) -> eq_ind c1 c2 && eq_universes false u1 u2
   | Construct (c1,u1), Construct (c2,u2) -> eq_constructor c1 c2 && eq_universes false u1 u2
   | Case (_,p1,c1,bl1), Case (_,p2,c2,bl2) ->
@@ -681,7 +681,7 @@ let constr_ord_int f t1 t2 =
     | Proj (p1,c1), Proj (p2,c2) -> (Projection.compare =? f) p1 p2 c1 c2
     | Evar (e1,l1), Evar (e2,l2) ->
         (Evar.compare =? (Array.compare f)) e1 e2 l1 l2
-    | Const (c1,u1), Const (c2,u2) -> con_ord c1 c2
+    | Const (c1,u1), Const (c2,u2) -> Constant.CanOrd.compare c1 c2
     | Ind (ind1, u1), Ind (ind2, u2) -> ind_ord ind1 ind2
     | Construct (ct1,u1), Construct (ct2,u2) -> constructor_ord ct1 ct2
     | Case (_,p1,c1,bl1), Case (_,p2,c2,bl2) ->

--- a/kernel/cooking.ml
+++ b/kernel/cooking.ml
@@ -29,12 +29,12 @@ let pop_dirpath p = match DirPath.repr p with
   | _::l -> DirPath.make l
 
 let pop_mind kn =
-  let (mp,dir,l) = Names.repr_mind kn in
-  Names.make_mind mp (pop_dirpath dir) l
+  let (mp,dir,l) = Names.MutInd.repr3 kn in
+  Names.MutInd.make3 mp (pop_dirpath dir) l
 
 let pop_con con =
-  let (mp,dir,l) = Names.repr_con con in
-  Names.make_con mp (pop_dirpath dir) l
+  let (mp,dir,l) = Names.Constant.repr3 con in
+  Names.Constant.make3 mp (pop_dirpath dir) l
 
 type my_global_reference =
   | ConstRef of constant

--- a/kernel/csymtable.ml
+++ b/kernel/csymtable.ml
@@ -68,7 +68,7 @@ let rec eq_structured_constant c1 c2 = match c1, c2 with
 | Const_bn (t1, a1), Const_bn (t2, a2) ->
   Int.equal t1 t2 && Array.equal eq_structured_constant a1 a2
 | Const_bn _, _ -> false
-| Const_univ_level l1 , Const_univ_level l2 -> Univ.eq_levels l1 l2
+| Const_univ_level l1 , Const_univ_level l2 -> Univ.Level.equal l1 l2
 | Const_univ_level _ , _ -> false
 | Const_type u1 , Const_type u2 -> Univ.Universe.equal u1 u2
 | Const_type _ , _ -> false

--- a/kernel/declareops.ml
+++ b/kernel/declareops.ml
@@ -287,9 +287,9 @@ let hcons_mind mib =
 (** {6 Stm machinery } *)
 
 let string_of_side_effect { Entries.eff } = match eff with
-  | Entries.SEsubproof (c,_,_) -> "P(" ^ Names.string_of_con c ^ ")"
+  | Entries.SEsubproof (c,_,_) -> "P(" ^ Names.Constant.to_string c ^ ")"
   | Entries.SEscheme (cl,_) ->
-      "S(" ^ String.concat ", " (List.map (fun (_,c,_,_) -> Names.string_of_con c) cl) ^ ")"
+      "S(" ^ String.concat ", " (List.map (fun (_,c,_,_) -> Names.Constant.to_string c) cl) ^ ")"
 
 (** Hashconsing of modules *)
 

--- a/kernel/indtypes.ml
+++ b/kernel/indtypes.ml
@@ -787,7 +787,7 @@ exception UndefinableExpansion
     a substitution of the form [params, x : ind params] *)
 let compute_projections ((kn, _ as ind), u as indu) n x nparamargs params
     mind_consnrealdecls mind_consnrealargs paramslet ctx =
-  let mp, dp, l = repr_mind kn in
+  let mp, dp, l = MutInd.repr3 kn in
   (** We build a substitution smashing the lets in the record parameters so
       that typechecking projections requires just a substitution and not
       matching with a parameter context. *)

--- a/kernel/mod_subst.ml
+++ b/kernel/mod_subst.ml
@@ -76,21 +76,21 @@ let is_empty_subst = Umap.is_empty
 let string_of_hint = function
   | Inline (_,Some _) -> "inline(Some _)"
   | Inline _ -> "inline()"
-  | Equiv kn -> string_of_kn kn
+  | Equiv kn -> KerName.to_string kn
 
 let debug_string_of_delta resolve =
   let kn_to_string kn hint l =
-    (string_of_kn kn ^ "=>" ^ string_of_hint hint) :: l
+    (KerName.to_string kn ^ "=>" ^ string_of_hint hint) :: l
   in
   let mp_to_string mp mp' l =
-    (string_of_mp mp ^ "=>" ^ string_of_mp mp') :: l
+    (ModPath.to_string mp ^ "=>" ^ ModPath.to_string mp') :: l
   in
   let l = Deltamap.fold mp_to_string kn_to_string resolve [] in
   String.concat ", " (List.rev l)
 
 let list_contents sub =
-  let one_pair (mp,reso) = (string_of_mp mp,debug_string_of_delta reso) in
-  let mp_one_pair mp0 p l = (string_of_mp mp0, one_pair p)::l in
+  let one_pair (mp,reso) = (ModPath.to_string mp,debug_string_of_delta reso) in
+  let mp_one_pair mp0 p l = (ModPath.to_string mp0, one_pair p)::l in
   let mbi_one_pair mbi p l = (MBId.debug_to_string mbi, one_pair p)::l in
   Umap.fold mp_one_pair mbi_one_pair sub []
 
@@ -117,7 +117,7 @@ let debug_pr_subst sub =
 let add_inline_delta_resolver kn (lev,oc) = Deltamap.add_kn kn (Inline (lev,oc))
 
 let add_kn_delta_resolver kn kn' =
-  assert (Label.equal (label kn) (label kn'));
+  assert (Label.equal (KerName.label kn) (KerName.label kn'));
   Deltamap.add_kn kn (Equiv kn')
 
 let add_mp_delta_resolver mp1 mp2 = Deltamap.add_mp mp1 mp2
@@ -165,12 +165,12 @@ let solve_delta_kn resolve kn =
       | Inline (lev, Some c) ->	raise (Change_equiv_to_inline (lev,c))
       | Inline (_, None) -> raise Not_found
   with Not_found ->
-    let mp,dir,l = repr_kn kn in
+    let mp,dir,l = KerName.repr kn in
     let new_mp = find_prefix resolve mp in
     if mp == new_mp then
       kn
     else
-      make_kn new_mp dir l
+      KerName.make new_mp dir l
 
 let kn_of_delta resolve kn =
   try solve_delta_kn resolve kn
@@ -242,18 +242,18 @@ let subst_mp sub mp =
   | Some (mp',_) -> mp'
 
 let subst_kn_delta sub kn =
- let mp,dir,l = repr_kn kn in
+ let mp,dir,l = KerName.repr kn in
   match subst_mp0 sub mp with
      Some (mp',resolve) ->
-      solve_delta_kn resolve (make_kn mp' dir l)
+      solve_delta_kn resolve (KerName.make mp' dir l)
    | None -> kn
 
 
 let subst_kn sub kn =
- let mp,dir,l = repr_kn kn in
+ let mp,dir,l = KerName.repr kn in
   match subst_mp0 sub mp with
      Some (mp',_) ->
-      (make_kn mp' dir l)
+      (KerName.make mp' dir l)
    | None -> kn
 
 exception No_subst
@@ -419,7 +419,7 @@ let subst_mps sub c =
 
 let rec replace_mp_in_mp mpfrom mpto mp =
   match mp with
-    | _ when mp_eq mp mpfrom -> mpto
+    | _ when ModPath.equal mp mpfrom -> mpto
     | MPdot (mp1,l) ->
 	let mp1' = replace_mp_in_mp mpfrom mpto mp1 in
 	  if mp1 == mp1' then mp
@@ -427,14 +427,14 @@ let rec replace_mp_in_mp mpfrom mpto mp =
     | _ -> mp
 
 let replace_mp_in_kn mpfrom mpto kn =
- let mp,dir,l = repr_kn kn in
+ let mp,dir,l = KerName.repr kn in
   let mp'' = replace_mp_in_mp mpfrom mpto mp in
     if mp==mp'' then kn
-    else make_kn mp'' dir l
+    else KerName.make mp'' dir l
 
 let rec mp_in_mp mp mp1 =
   match mp1 with
-    | _ when mp_eq mp1 mp -> true
+    | _ when ModPath.equal mp1 mp -> true
     | MPdot (mp2,l) -> mp_in_mp mp mp2
     | _ -> false
 
@@ -446,7 +446,7 @@ let subset_prefixed_by mp resolver =
     match hint with
       | Inline _ -> rslv
       | Equiv _ ->
-	if mp_in_mp mp (modpath kn) then Deltamap.add_kn kn hint rslv else rslv
+	if mp_in_mp mp (KerName.modpath kn) then Deltamap.add_kn kn hint rslv else rslv
   in
   Deltamap.fold mp_prefix kn_prefix resolver empty_delta_resolver
 
@@ -515,7 +515,7 @@ let add_delta_resolver resolver1 resolver2 =
 
 let substition_prefixed_by k mp subst =
   let mp_prefixmp kmp (mp_to,reso) sub =
-    if mp_in_mp mp kmp && not (mp_eq mp kmp) then
+    if mp_in_mp mp kmp && not (ModPath.equal mp kmp) then
       let new_key = replace_mp_in_mp mp k kmp in
       Umap.add_mp new_key (mp_to,reso) sub
     else sub

--- a/kernel/modops.ml
+++ b/kernel/modops.ml
@@ -399,8 +399,8 @@ let inline_delta_resolver env inl mp mbid mtb delta =
 	      let constr = Mod_subst.force_constr body in
 	      add_inline_delta_resolver kn (lev, Some constr) l
 	with Not_found ->
-	  error_no_such_label_sub (con_label con)
-	    (string_of_mp (con_modpath con))
+	  error_no_such_label_sub (Constant.label con)
+	    (ModPath.to_string (Constant.modpath con))
   in
   make_inline delta constants
 

--- a/kernel/names.mli
+++ b/kernel/names.mli
@@ -549,24 +549,31 @@ type identifier = Id.t
 (** @deprecated Alias for [Id.t] *)
 
 val string_of_id : identifier -> string
+[@@ocaml.deprecated]
 (** @deprecated Same as [Id.to_string]. *)
 
 val id_of_string : string -> identifier
+[@@ocaml.deprecated]
 (** @deprecated Same as [Id.of_string]. *)
 
 val id_ord : identifier -> identifier -> int
+[@@ocaml.deprecated]
 (** @deprecated Same as [Id.compare]. *)
 
 val id_eq : identifier -> identifier -> bool
+[@@ocaml.deprecated]
 (** @deprecated Same as [Id.equal]. *)
 
 module Idset  : Set.S with type elt = identifier and type t = Id.Set.t
+[@@ocaml.deprecated]
 (** @deprecated Same as [Id.Set]. *)
 
 module Idpred : Predicate.S with type elt = identifier and type t = Id.Pred.t
+[@@ocaml.deprecated]
 (** @deprecated Same as [Id.Pred]. *)
 
 module Idmap : module type of Id.Map
+[@@ocaml.deprecated]
 (** @deprecated Same as [Id.Map]. *)
 
 (** {5 Directory paths} *)
@@ -575,27 +582,35 @@ type dir_path = DirPath.t
 (** @deprecated Alias for [DirPath.t]. *)
 
 val dir_path_ord : dir_path -> dir_path -> int
+[@@ocaml.deprecated]
 (** @deprecated Same as [DirPath.compare]. *)
 
 val dir_path_eq : dir_path -> dir_path -> bool
+[@@ocaml.deprecated]
 (** @deprecated Same as [DirPath.equal]. *)
 
 val make_dirpath : module_ident list -> dir_path
+[@@ocaml.deprecated]
 (** @deprecated Same as [DirPath.make]. *)
 
 val repr_dirpath : dir_path -> module_ident list
+[@@ocaml.deprecated]
 (** @deprecated Same as [DirPath.repr]. *)
 
 val empty_dirpath : dir_path
+[@@ocaml.deprecated]
 (** @deprecated Same as [DirPath.empty]. *)
 
 val is_empty_dirpath : dir_path -> bool
+[@@ocaml.deprecated]
 (** @deprecated Same as [DirPath.is_empty]. *)
 
 val string_of_dirpath : dir_path -> string
+[@@ocaml.deprecated]
 (** @deprecated Same as [DirPath.to_string]. *)
 
 val initial_dir : DirPath.t
+[@@ocaml.deprecated]
 (** @deprecated Same as [DirPath.initial]. *)
 
 (** {5 Labels} *)
@@ -604,21 +619,27 @@ type label = Label.t
 (** Alias type *)
 
 val mk_label : string -> label
+[@@ocaml.deprecated]
 (** @deprecated Same as [Label.make]. *)
 
 val string_of_label : label -> string
+[@@ocaml.deprecated]
 (** @deprecated Same as [Label.to_string]. *)
 
 val pr_label : label -> Pp.std_ppcmds
+[@@ocaml.deprecated]
 (** @deprecated Same as [Label.print]. *)
 
 val label_of_id : Id.t -> label
+[@@ocaml.deprecated]
 (** @deprecated Same as [Label.of_id]. *)
 
 val id_of_label : label -> Id.t
+[@@ocaml.deprecated]
 (** @deprecated Same as [Label.to_id]. *)
 
 val eq_label : label -> label -> bool
+[@@ocaml.deprecated]
 (** @deprecated Same as [Label.equal]. *)
 
 (** {5 Unique bound module names} *)
@@ -627,29 +648,37 @@ type mod_bound_id = MBId.t
 (** Alias type. *)
 
 val mod_bound_id_ord : mod_bound_id -> mod_bound_id -> int
+[@@ocaml.deprecated]
 (** @deprecated Same as [MBId.compare]. *)
 
 val mod_bound_id_eq : mod_bound_id -> mod_bound_id -> bool
+[@@ocaml.deprecated]
 (** @deprecated Same as [MBId.equal]. *)
 
 val make_mbid : DirPath.t -> Id.t -> mod_bound_id
+[@@ocaml.deprecated]
 (** @deprecated Same as [MBId.make]. *)
 
 val repr_mbid : mod_bound_id -> int * Id.t * DirPath.t
+[@@ocaml.deprecated]
 (** @deprecated Same as [MBId.repr]. *)
 
 val id_of_mbid : mod_bound_id -> Id.t
+[@@ocaml.deprecated]
 (** @deprecated Same as [MBId.to_id]. *)
 
 val string_of_mbid : mod_bound_id -> string
+[@@ocaml.deprecated]
 (** @deprecated Same as [MBId.to_string]. *)
 
 val debug_string_of_mbid : mod_bound_id -> string
+[@@ocaml.deprecated]
 (** @deprecated Same as [MBId.debug_to_string]. *)
 
 (** {5 Names} *)
 
 val name_eq : name -> name -> bool
+[@@ocaml.deprecated]
 (** @deprecated Same as [Name.equal]. *)
 
 (** {5 Module paths} *)
@@ -661,18 +690,23 @@ type module_path = ModPath.t =
 (** @deprecated Alias type *)
 
 val mp_ord : module_path -> module_path -> int
+[@@ocaml.deprecated]
 (** @deprecated Same as [ModPath.compare]. *)
 
 val mp_eq : module_path -> module_path -> bool
+[@@ocaml.deprecated]
 (** @deprecated Same as [ModPath.equal]. *)
 
 val check_bound_mp : module_path -> bool
+[@@ocaml.deprecated]
 (** @deprecated Same as [ModPath.is_bound]. *)
 
 val string_of_mp : module_path -> string
+[@@ocaml.deprecated]
 (** @deprecated Same as [ModPath.to_string]. *)
 
 val initial_path : module_path
+[@@ocaml.deprecated]
 (** @deprecated Same as [ModPath.initial]. *)
 
 (** {5 Kernel names} *)
@@ -681,24 +715,31 @@ type kernel_name = KerName.t
 (** @deprecated Alias type *)
 
 val make_kn : ModPath.t -> DirPath.t -> Label.t -> kernel_name
+[@@ocaml.deprecated]
 (** @deprecated Same as [KerName.make]. *)
 
 val repr_kn : kernel_name -> module_path * DirPath.t * Label.t
+[@@ocaml.deprecated]
 (** @deprecated Same as [KerName.repr]. *)
 
 val modpath : kernel_name -> module_path
+[@@ocaml.deprecated]
 (** @deprecated Same as [KerName.modpath]. *)
 
 val label : kernel_name -> Label.t
+[@@ocaml.deprecated]
 (** @deprecated Same as [KerName.label]. *)
 
 val string_of_kn : kernel_name -> string
+[@@ocaml.deprecated]
 (** @deprecated Same as [KerName.to_string]. *)
 
 val pr_kn : kernel_name -> Pp.std_ppcmds
+[@@ocaml.deprecated]
 (** @deprecated Same as [KerName.print]. *)
 
 val kn_ord : kernel_name -> kernel_name -> int
+[@@ocaml.deprecated]
 (** @deprecated Same as [KerName.compare]. *)
 
 (** {5 Constant names} *)
@@ -738,51 +779,67 @@ end
 type projection = Projection.t
 
 val constant_of_kn_equiv : KerName.t -> KerName.t -> constant
+[@@ocaml.deprecated]
 (** @deprecated Same as [Constant.make] *)
 
 val constant_of_kn : KerName.t -> constant
+[@@ocaml.deprecated]
 (** @deprecated Same as [Constant.make1] *)
 
 val make_con : ModPath.t -> DirPath.t -> Label.t -> constant
+[@@ocaml.deprecated]
 (** @deprecated Same as [Constant.make3] *)
 
 val repr_con : constant -> ModPath.t * DirPath.t * Label.t
+[@@ocaml.deprecated]
 (** @deprecated Same as [Constant.repr3] *)
 
 val user_con : constant -> KerName.t
+[@@ocaml.deprecated]
 (** @deprecated Same as [Constant.user] *)
 
 val canonical_con : constant -> KerName.t
+[@@ocaml.deprecated]
 (** @deprecated Same as [Constant.canonical] *)
 
 val con_modpath : constant -> ModPath.t
+[@@ocaml.deprecated]
 (** @deprecated Same as [Constant.modpath] *)
 
 val con_label : constant -> Label.t
+[@@ocaml.deprecated]
 (** @deprecated Same as [Constant.label] *)
 
 val eq_constant : constant -> constant -> bool
+[@@ocaml.deprecated]
 (** @deprecated Same as [Constant.equal] *)
 
 val con_ord : constant -> constant -> int
+[@@ocaml.deprecated]
 (** @deprecated Same as [Constant.CanOrd.compare] *)
 
 val con_user_ord : constant -> constant -> int
+[@@ocaml.deprecated]
 (** @deprecated Same as [Constant.UserOrd.compare] *)
 
 val con_with_label : constant -> Label.t -> constant
+[@@ocaml.deprecated]
 (** @deprecated Same as [Constant.change_label] *)
 
 val string_of_con : constant -> string
+[@@ocaml.deprecated]
 (** @deprecated Same as [Constant.to_string] *)
 
 val pr_con : constant -> Pp.std_ppcmds
+[@@ocaml.deprecated]
 (** @deprecated Same as [Constant.print] *)
 
 val debug_pr_con : constant -> Pp.std_ppcmds
+[@@ocaml.deprecated]
 (** @deprecated Same as [Constant.debug_print] *)
 
 val debug_string_of_con : constant -> string
+[@@ocaml.deprecated]
 (** @deprecated Same as [Constant.debug_to_string] *)
 
 (** {5 Mutual Inductive names} *)
@@ -791,46 +848,61 @@ type mutual_inductive = MutInd.t
 (** @deprecated Alias type *)
 
 val mind_of_kn : KerName.t -> mutual_inductive
+[@@ocaml.deprecated]
 (** @deprecated Same as [MutInd.make1] *)
 
 val mind_of_kn_equiv : KerName.t -> KerName.t -> mutual_inductive
+[@@ocaml.deprecated]
 (** @deprecated Same as [MutInd.make] *)
 
 val make_mind : ModPath.t -> DirPath.t -> Label.t -> mutual_inductive
+[@@ocaml.deprecated]
 (** @deprecated Same as [MutInd.make3] *)
 
 val user_mind : mutual_inductive -> KerName.t
+[@@ocaml.deprecated]
 (** @deprecated Same as [MutInd.user] *)
 
 val canonical_mind : mutual_inductive -> KerName.t
+[@@ocaml.deprecated]
 (** @deprecated Same as [MutInd.canonical] *)
 
 val repr_mind : mutual_inductive -> ModPath.t * DirPath.t * Label.t
+[@@ocaml.deprecated]
 (** @deprecated Same as [MutInd.repr3] *)
 
 val eq_mind : mutual_inductive -> mutual_inductive -> bool
+[@@ocaml.deprecated]
 (** @deprecated Same as [MutInd.equal] *)
 
 val mind_ord : mutual_inductive -> mutual_inductive -> int
+[@@ocaml.deprecated]
 (** @deprecated Same as [MutInd.CanOrd.compare] *)
 
 val mind_user_ord : mutual_inductive -> mutual_inductive -> int
+[@@ocaml.deprecated]
 (** @deprecated Same as [MutInd.UserOrd.compare] *)
 
 val mind_label : mutual_inductive -> Label.t
+[@@ocaml.deprecated]
 (** @deprecated Same as [MutInd.label] *)
 
 val mind_modpath : mutual_inductive -> ModPath.t
+[@@ocaml.deprecated]
 (** @deprecated Same as [MutInd.modpath] *)
 
 val string_of_mind : mutual_inductive -> string
+[@@ocaml.deprecated]
 (** @deprecated Same as [MutInd.to_string] *)
 
 val pr_mind : mutual_inductive -> Pp.std_ppcmds
+[@@ocaml.deprecated]
 (** @deprecated Same as [MutInd.print] *)
 
 val debug_pr_mind : mutual_inductive -> Pp.std_ppcmds
+[@@ocaml.deprecated]
 (** @deprecated Same as [MutInd.debug_print] *)
 
 val debug_string_of_mind : mutual_inductive -> string
+[@@ocaml.deprecated]
 (** @deprecated Same as [MutInd.debug_to_string] *)

--- a/kernel/nativecode.ml
+++ b/kernel/nativecode.ml
@@ -1504,7 +1504,7 @@ let string_of_dirpath = function
 (* OCaml as a module identifier.                                           *)
 let string_of_dirpath s = "N"^string_of_dirpath s
 
-let mod_uid_of_dirpath dir = string_of_dirpath (repr_dirpath dir)
+let mod_uid_of_dirpath dir = string_of_dirpath (DirPath.repr dir)
 
 let link_info_of_dirpath dir =
   Linked (mod_uid_of_dirpath dir ^ ".")
@@ -1523,19 +1523,19 @@ let string_of_label_def l =
 let rec list_of_mp acc = function
   | MPdot (mp,l) -> list_of_mp (string_of_label l::acc) mp
   | MPfile dp ->
-      let dp = repr_dirpath dp in
+      let dp = DirPath.repr dp in
       string_of_dirpath dp :: acc
-  | MPbound mbid -> ("X"^string_of_id (id_of_mbid mbid))::acc
+  | MPbound mbid -> ("X"^string_of_id (MBId.to_id mbid))::acc
 
 let list_of_mp mp = list_of_mp [] mp
 
 let string_of_kn kn =
-  let (mp,dp,l) = repr_kn kn in
+  let (mp,dp,l) = KerName.repr kn in
   let mp = list_of_mp mp in
   String.concat "_" mp ^ "_" ^ string_of_label l
 
-let string_of_con c = string_of_kn (user_con c)
-let string_of_mind mind = string_of_kn (user_mind mind)
+let string_of_con c = string_of_kn (Constant.user c)
+let string_of_mind mind = string_of_kn (MutInd.user mind)
 
 let string_of_gname g =
   match g with
@@ -1721,7 +1721,7 @@ let pp_mllam fmt l =
     | Mk_cofix(start) -> Format.fprintf fmt "mk_cofix_accu %i" start
     | Mk_rel i -> Format.fprintf fmt "mk_rel_accu %i" i
     | Mk_var id ->
-        Format.fprintf fmt "mk_var_accu (Names.id_of_string \"%s\")" (string_of_id id)
+        Format.fprintf fmt "mk_var_accu (Names.Id.of_string \"%s\")" (string_of_id id)
     | Mk_proj -> Format.fprintf fmt "mk_proj_accu"
     | Is_accu -> Format.fprintf fmt "is_accu"
     | Is_int -> Format.fprintf fmt "is_int"
@@ -1877,7 +1877,7 @@ let compile_constant env sigma prefix ~interactive con cb =
         if interactive then LinkedInteractive prefix
         else Linked prefix
       in
-      let l = con_label con in
+      let l = Constant.label con in
       let auxdefs,code =
 	if no_univs then compile_with_fv env sigma None [] (Some l) code
 	else
@@ -1955,8 +1955,8 @@ let is_code_loaded ~interactive name =
       if is_loaded_native_file s then true
       else (name := NotLinked; false)
 
-let param_name = Name (id_of_string "params")
-let arg_name = Name (id_of_string "arg")
+let param_name = Name (Id.of_string "params")
+let arg_name = Name (Id.of_string "arg")
 
 let compile_mind prefix ~interactive mb mind stack =
   let u = Declareops.inductive_polymorphic_context mb in

--- a/kernel/nativelibrary.ml
+++ b/kernel/nativelibrary.ml
@@ -26,7 +26,7 @@ let rec translate_mod prefix mp env mod_expr acc =
 and translate_field prefix mp env acc (l,x) =
   match x with
   | SFBconst cb ->
-     let con = make_con mp empty_dirpath l in
+     let con = Constant.make3 mp DirPath.empty l in
      (if !Flags.debug then
 	let msg = Printf.sprintf "Compiling constant %s..." (Constant.to_string con) in
 	Feedback.msg_debug (Pp.str msg));

--- a/kernel/reduction.ml
+++ b/kernel/reduction.ml
@@ -239,7 +239,7 @@ let compare_stacks f fmind lft1 stk1 lft2 stk2 cuniv =
             | (Zlapp a1,Zlapp a2) -> 
 	       Array.fold_right2 f a1 a2 cu1
 	    | (Zlproj (c1,l1),Zlproj (c2,l2)) -> 
-	      if not (eq_constant c1 c2) then 
+	      if not (Constant.equal c1 c2) then 
 		raise NotConvertible
 	      else cu1
             | (Zlfix(fx1,a1),Zlfix(fx2,a2)) ->

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -143,7 +143,7 @@ let rec library_dp_of_senv senv =
 
 let empty_environment =
   { env = Environ.empty_env;
-    modpath = initial_path;
+    modpath = ModPath.initial;
     modvariant = NONE;
     modresolver = Mod_subst.empty_delta_resolver;
     paramresolver = Mod_subst.empty_delta_resolver;
@@ -160,7 +160,7 @@ let empty_environment =
 
 let is_initial senv =
   match senv.revstruct, senv.modvariant with
-  | [], NONE -> ModPath.equal senv.modpath initial_path
+  | [], NONE -> ModPath.equal senv.modpath ModPath.initial
   | _ -> false
 
 let delta_of_senv senv = senv.modresolver,senv.paramresolver
@@ -521,7 +521,7 @@ let add_constant_aux no_section senv (kn, cb) =
   let senv'' = match cb.const_body with
     | Undef (Some lev) ->
       update_resolver
-        (Mod_subst.add_inline_delta_resolver (user_con kn) (lev,None)) senv'
+        (Mod_subst.add_inline_delta_resolver (Constant.user kn) (lev,None)) senv'
     | _ -> senv'
   in
   senv''
@@ -535,7 +535,7 @@ let export_private_constants ~in_section ce senv =
   (ce, exported), senv
 
 let add_constant dir l decl senv =
-  let kn = make_con senv.modpath dir l in
+  let kn = Constant.make3 senv.modpath dir l in
   let no_section = DirPath.is_empty dir in
   let senv =
     let cb = 
@@ -562,7 +562,7 @@ let check_mind mie lab =
 
 let add_mind dir l mie senv =
   let () = check_mind mie l in
-  let kn = make_mind senv.modpath dir l in
+  let kn = MutInd.make3 senv.modpath dir l in
   let mib = Term_typing.translate_mind senv.env kn mie in
   let mib =
     match mib.mind_hyps with [] -> Declareops.hcons_mind mib | _ -> mib

--- a/kernel/subtyping.ml
+++ b/kernel/subtyping.ml
@@ -63,11 +63,11 @@ let empty_labmap = { objs = Label.Map.empty; mods = Label.Map.empty }
 
 let get_obj mp map l =
   try Label.Map.find l map.objs
-  with Not_found -> error_no_such_label_sub l (string_of_mp mp)
+  with Not_found -> error_no_such_label_sub l (ModPath.to_string mp)
 
 let get_mod mp map l =
   try Label.Map.find l map.mods
-  with Not_found -> error_no_such_label_sub l (string_of_mp mp)
+  with Not_found -> error_no_such_label_sub l (ModPath.to_string mp)
 
 let make_labmap mp list =
   let add_one (l,e) map =
@@ -181,7 +181,7 @@ let check_inductive cst env mp1 l info1 mp2 mib2 spec2 subst1 subst2 reso1 reso2
       let cst = check_inductive_type cst p2.mind_typename ty1 ty2 in
 	cst
   in
-  let mind = mind_of_kn kn1 in
+  let mind = MutInd.make1 kn1 in
   let check_cons_types i cst p1 p2 =
     Array.fold_left3
       (fun cst id t1 t2 -> check_conv (NotConvertibleConstructorField id) cst

--- a/kernel/term.mli
+++ b/kernel/term.mli
@@ -157,6 +157,7 @@ val destApp : constr -> constr * constr array
 
 (** Obsolete synonym of destApp *)
 val destApplication : constr -> constr * constr array
+[@@ocaml.deprecated]
 
 (** Decompose any term as an applicative term; the list of args can be empty *)
 val decompose_app : constr -> constr * constr list

--- a/kernel/term_typing.ml
+++ b/kernel/term_typing.ml
@@ -388,10 +388,10 @@ let build_constant_declaration kn env result =
     let mk_set l = List.fold_right Id.Set.add (List.map NamedDecl.get_id l) Id.Set.empty in
     let inferred_set, declared_set = mk_set inferred, mk_set declared in
     if not (Id.Set.subset inferred_set declared_set) then
-      let l = Id.Set.elements (Idset.diff inferred_set declared_set) in
+      let l = Id.Set.elements (Id.Set.diff inferred_set declared_set) in
       let n = List.length l in
-      let declared_vars = Pp.pr_sequence Id.print (Idset.elements declared_set) in
-      let inferred_vars = Pp.pr_sequence Id.print (Idset.elements inferred_set) in
+      let declared_vars = Pp.pr_sequence Id.print (Id.Set.elements declared_set) in
+      let inferred_vars = Pp.pr_sequence Id.print (Id.Set.elements inferred_set) in
       let missing_vars  = Pp.pr_sequence Id.print (List.rev l) in
       user_err Pp.(prlist str
          ["The following section "; (String.plural n "variable"); " ";
@@ -417,7 +417,7 @@ let build_constant_declaration kn env result =
            we must look at the body NOW, if any *)
         let ids_typ = global_vars_set env typ in
         let ids_def = match def with
-        | Undef _ -> Idset.empty
+        | Undef _ -> Id.Set.empty
         | Def cs -> global_vars_set env (Mod_subst.force_constr cs)
         | OpaqueDef lc ->
             let vars =
@@ -432,7 +432,7 @@ let build_constant_declaration kn env result =
               record_aux env ids_typ vars expr;
             vars
         in
-        keep_hyps env (Idset.union ids_typ ids_def), def
+        keep_hyps env (Id.Set.union ids_typ ids_def), def
     | None ->
         if !Flags.compilation_mode = Flags.BuildVo then
           record_aux env Id.Set.empty Id.Set.empty "";
@@ -445,14 +445,14 @@ let build_constant_declaration kn env result =
         | Def cs as x ->
             let ids_typ = global_vars_set env typ in
             let ids_def = global_vars_set env (Mod_subst.force_constr cs) in
-            let inferred = keep_hyps env (Idset.union ids_typ ids_def) in
+            let inferred = keep_hyps env (Id.Set.union ids_typ ids_def) in
             check declared inferred;
             x
         | OpaqueDef lc -> (* In this case we can postpone the check *)
             OpaqueDef (Opaqueproof.iter_direct_opaque (fun c ->
               let ids_typ = global_vars_set env typ in
               let ids_def = global_vars_set env c in
-              let inferred = keep_hyps env (Idset.union ids_typ ids_def) in
+              let inferred = keep_hyps env (Id.Set.union ids_typ ids_def) in
               check declared inferred) lc) in
   let univs = result.cook_universes in
   let tps = 

--- a/kernel/typeops.ml
+++ b/kernel/typeops.ml
@@ -294,7 +294,7 @@ let type_of_projection env p c ct =
     try find_rectype env ct
     with Not_found -> error_case_not_inductive env (make_judge c ct)
   in
-  assert(eq_mind pb.proj_ind (fst ind));
+  assert(MutInd.equal pb.proj_ind (fst ind));
   let ty = Vars.subst_instance_constr u pb.Declarations.proj_type in
   substl (c :: List.rev args) ty
       

--- a/kernel/univ.mli
+++ b/kernel/univ.mli
@@ -491,10 +491,13 @@ val hcons_abstract_cumulativity_info : abstract_cumulativity_info -> abstract_cu
 
 (* deprecated: use qualified names instead *)
 val compare_levels : universe_level -> universe_level -> int
+[@@ocaml.deprecated]
 val eq_levels : universe_level -> universe_level -> bool
+[@@ocaml.deprecated]
 
 (** deprecated: Equality of formal universe expressions. *)
 val equal_universes : universe -> universe -> bool
+[@@ocaml.deprecated]
 
 (** Universes of constraints *)
 val universes_of_constraints : constraints -> universe_set

--- a/kernel/vm.ml
+++ b/kernel/vm.ml
@@ -654,10 +654,10 @@ let apply_whd k whd =
 let rec pr_atom a =
   Pp.(match a with
   | Aid c -> str "Aid(" ++ (match c with
-                            | ConstKey c -> Names.pr_con c
+                            | ConstKey c -> Names.Constant.print c
 			    | RelKey i -> str "#" ++ int i
 			    | _ -> str "...") ++ str ")"
-  | Aind (mi,i) -> str "Aind(" ++ Names.pr_mind mi ++ str "#" ++ int i ++ str ")"
+  | Aind (mi,i) -> str "Aind(" ++ Names.MutInd.print mi ++ str "#" ++ int i ++ str ")"
   | Atype _ -> str "Atype(")
 and pr_whd w =
   Pp.(match w with
@@ -679,4 +679,4 @@ and pr_zipper z =
   | Zapp args -> str "Zapp(len = " ++ int (nargs args) ++ str ")"
   | Zfix (f,args) -> str "Zfix(..., len=" ++ int (nargs args) ++ str ")"
   | Zswitch s -> str "Zswitch(...)"
-  | Zproj c -> str "Zproj(" ++ Names.pr_con c ++ str ")")
+  | Zproj c -> str "Zproj(" ++ Names.Constant.print c ++ str ")")

--- a/lib/rtree.mli
+++ b/lib/rtree.mli
@@ -81,4 +81,5 @@ val smartmap : ('a -> 'a) -> 'a t -> 'a t
 val pp_tree : ('a -> Pp.std_ppcmds) -> 'a t -> Pp.std_ppcmds
 
 val eq_rtree : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
+[@@ocaml.deprecated]
 (** @deprecated Same as [Rtree.equal] *)

--- a/library/declaremods.ml
+++ b/library/declaremods.ml
@@ -147,7 +147,7 @@ module ModObjs :
 *)
 
 let mp_of_kn kn =
-  let mp,sec,l = repr_kn kn in
+  let mp,sec,l = KerName.repr kn in
   assert (DirPath.is_empty sec);
   MPdot (mp,l)
 
@@ -978,7 +978,7 @@ let debug_print_modtab _ =
     | l -> str "[." ++ int (List.length l) ++ str ".]"
   in
   let pr_modinfo mp (prefix,substobjs,keepobjs) s =
-    s ++ str (string_of_mp mp) ++ (spc ())
+    s ++ str (ModPath.to_string mp) ++ (spc ())
     ++ (pr_seg (Lib.segment_of_objects prefix (substobjs@keepobjs)))
   in
   let modules = MPmap.fold pr_modinfo (ModObjs.all ()) (mt ()) in

--- a/library/global.ml
+++ b/library/global.ml
@@ -233,11 +233,11 @@ let universes_of_global gr =
 
 (** Global universe names *)
 type universe_names = 
-  (polymorphic * Univ.universe_level) Idmap.t * Id.t Univ.LMap.t
+  (polymorphic * Univ.universe_level) Id.Map.t * Id.t Univ.LMap.t
 
 let global_universes =
   Summary.ref ~name:"Global universe names"
-  ((Idmap.empty, Univ.LMap.empty) : universe_names)
+  ((Id.Map.empty, Univ.LMap.empty) : universe_names)
 
 let global_universe_names () = !global_universes
 let set_global_universe_names s = global_universes := s

--- a/library/global.mli
+++ b/library/global.mli
@@ -104,7 +104,7 @@ val body_of_constant_body : Declarations.constant_body -> (Term.constr * Univ.AU
 
 (** Global universe name <-> level mapping *)
 type universe_names = 
-  (Decl_kinds.polymorphic * Univ.universe_level) Idmap.t * Id.t Univ.LMap.t
+  (Decl_kinds.polymorphic * Univ.universe_level) Id.Map.t * Id.t Univ.LMap.t
 
 val global_universe_names : unit -> universe_names
 val set_global_universe_names : universe_names -> unit

--- a/library/globnames.ml
+++ b/library/globnames.ml
@@ -26,7 +26,7 @@ let isConstructRef = function ConstructRef _ -> true | _ -> false
 
 let eq_gr gr1 gr2 =
   gr1 == gr2 || match gr1,gr2 with
-    | ConstRef con1, ConstRef con2 -> eq_constant con1 con2
+    | ConstRef con1, ConstRef con2 -> Constant.equal con1 con2
     | IndRef kn1, IndRef kn2 -> eq_ind kn1 kn2
     | ConstructRef kn1, ConstructRef kn2 -> eq_constructor kn1 kn2
     | VarRef v1, VarRef v2 -> Id.equal v1 v2
@@ -67,9 +67,9 @@ let subst_global subst ref = match ref with
 	if c'==c then ref,t else ConstructRef c', t
 
 let canonical_gr = function
-  | ConstRef con -> ConstRef(constant_of_kn(canonical_con con))
-  | IndRef (kn,i) -> IndRef(mind_of_kn(canonical_mind kn),i)
-  | ConstructRef ((kn,i),j )-> ConstructRef((mind_of_kn(canonical_mind kn),i),j)
+  | ConstRef con -> ConstRef(Constant.make1(Constant.canonical con))
+  | IndRef (kn,i) -> IndRef(MutInd.make1(MutInd.canonical kn),i)
+  | ConstructRef ((kn,i),j )-> ConstructRef((MutInd.make1(MutInd.canonical kn),i),j)
   | VarRef id -> VarRef id
 
 let global_of_constr c = match kind_of_term c with
@@ -81,10 +81,10 @@ let global_of_constr c = match kind_of_term c with
 
 let is_global c t =
   match c, kind_of_term t with
-  | ConstRef c, Const (c', _) -> eq_constant c c'
+  | ConstRef c, Const (c', _) -> Constant.equal c c'
   | IndRef i, Ind (i', _) -> eq_ind i i'
   | ConstructRef i, Construct (i', _) -> eq_constructor i i'
-  | VarRef id, Var id' -> id_eq id id'
+  | VarRef id, Var id' -> Id.equal id id'
   | _ -> false
 
 let printable_constr_of_global = function
@@ -180,7 +180,7 @@ module ExtRefOrdered = struct
     if x == y then 0
     else match x, y with
       | TrueGlobal rx, TrueGlobal ry -> RefOrdered_env.compare rx ry
-      | SynDef knx, SynDef kny -> kn_ord knx kny
+      | SynDef knx, SynDef kny -> KerName.compare knx kny
       | TrueGlobal _, SynDef _ -> -1
       | SynDef _, TrueGlobal _ -> 1
 
@@ -215,12 +215,12 @@ let decode_mind kn =
 	  id::(DirPath.repr dp)
     | MPdot(mp,l) -> (Label.to_id l)::(dir_of_mp mp)
   in
-  let mp,sec_dir,l = repr_mind kn in
+  let mp,sec_dir,l = MutInd.repr3 kn in
   check_empty_section sec_dir;
   (DirPath.make (dir_of_mp mp)),Label.to_id l
 
 let decode_con kn =
-  let mp,sec_dir,l = repr_con kn in
+  let mp,sec_dir,l = Constant.repr3 kn in
   check_empty_section sec_dir;
   match mp with
     | MPfile dir -> (dir,Label.to_id l)
@@ -231,12 +231,12 @@ let decode_con kn =
     user and canonical kernel names must be equal. *)
 
 let pop_con con =
-  let (mp,dir,l) = repr_con con in
-  Names.make_con mp (pop_dirpath dir) l
+  let (mp,dir,l) = Constant.repr3 con in
+  Names.Constant.make3 mp (pop_dirpath dir) l
 
 let pop_kn kn =
-  let (mp,dir,l) = repr_mind kn in
-  Names.make_mind mp (pop_dirpath dir) l
+  let (mp,dir,l) = MutInd.repr3 kn in
+  Names.MutInd.make3 mp (pop_dirpath dir) l
 
 let pop_global_reference = function
   | ConstRef con -> ConstRef (pop_con con)

--- a/library/globnames.mli
+++ b/library/globnames.mli
@@ -47,6 +47,7 @@ val global_of_constr : constr -> global_reference
 
 (** Obsolete synonyms for constr_of_global and global_of_constr *)
 val reference_of_constr : constr -> global_reference
+[@@ocaml.deprecated]
 
 module RefOrdered : sig
   type t = global_reference

--- a/library/heads.ml
+++ b/library/heads.ml
@@ -156,7 +156,7 @@ let cache_head o =
 let subst_head_approximation subst = function
   | RigidHead (RigidParameter cst) as k ->
       let cst,c = subst_con_kn subst cst in
-      if isConst c && eq_constant (fst (destConst c)) cst then
+      if isConst c && Constant.equal (fst (destConst c)) cst then
         (* A change of the prefix of the constant *)
         k
       else

--- a/library/libnames.ml
+++ b/library/libnames.ml
@@ -159,7 +159,7 @@ type object_name = full_path * kernel_name
 type object_prefix = DirPath.t * (module_path * DirPath.t)
 
 let make_oname (dirpath,(mp,dir)) id =
-  make_path dirpath id, make_kn mp dir (Label.of_id id)
+  make_path dirpath id, KerName.make mp dir (Label.of_id id)
 
 (* to this type are mapped DirPath.t's in the nametab *)
 type global_dir_reference =
@@ -173,7 +173,7 @@ type global_dir_reference =
 let eq_op (d1, (mp1, p1)) (d2, (mp2, p2)) =
   DirPath.equal d1 d2 &&
   DirPath.equal p1 p2 &&
-  mp_eq mp1 mp2
+  ModPath.equal mp1 mp2
 
 let eq_global_dir_reference r1 r2 = match r1, r2 with
 | DirOpenModule op1, DirOpenModule op2 -> eq_op op1 op2

--- a/library/libnames.mli
+++ b/library/libnames.mli
@@ -131,4 +131,6 @@ val join_reference : reference -> reference -> reference
 (** Deprecated synonyms *)
 
 val make_short_qualid : Id.t -> qualid (** = qualid_of_ident *)
+[@@ocaml.deprecated]
 val qualid_of_sp : full_path -> qualid (** = qualid_of_path *)
+[@@ocaml.deprecated]

--- a/library/nametab.mli
+++ b/library/nametab.mli
@@ -125,8 +125,10 @@ val exists_cci : full_path -> bool
 val exists_modtype : full_path -> bool
 val exists_dir : DirPath.t -> bool
 val exists_section : DirPath.t -> bool (** deprecated synonym of [exists_dir] *)
+[@@ocaml.deprecated]
 val exists_module : DirPath.t -> bool (** deprecated synonym of [exists_dir] *)
-val exists_tactic : full_path -> bool (** deprecated synonym of [exists_dir] *)
+[@@ocaml.deprecated]
+val exists_tactic : full_path -> bool
 
 (** {6 These functions locate qualids into full user names } *)
 

--- a/plugins/funind/functional_principles_proofs.ml
+++ b/plugins/funind/functional_principles_proofs.ml
@@ -18,6 +18,9 @@ open Context.Rel.Declaration
 
 module RelDecl = Context.Rel.Declaration
 
+(** Deactivate deprecated warning *)
+[@@@ocaml.warning "-3"]
+
 (* let msgnl = Pp.msgnl *)
 
 (*

--- a/plugins/funind/functional_principles_types.ml
+++ b/plugins/funind/functional_principles_types.ml
@@ -15,6 +15,9 @@ open Misctypes
 
 module RelDecl = Context.Rel.Declaration
 
+(** Deactivate deprecated warning *)
+[@@@ocaml.warning "-3"]
+
 exception Toberemoved_with_rel of int*constr
 exception Toberemoved
 

--- a/plugins/funind/functional_principles_types.ml
+++ b/plugins/funind/functional_principles_types.ml
@@ -340,7 +340,7 @@ let generate_functional_principle (evd: Evd.evar_map ref)
     fun  new_principle_type _ _  -> 
     if Option.is_empty sorts
     then
-      (*     let id_of_f = Label.to_id (con_label f) in *)
+      (*     let id_of_f = Label.to_id (Constant.label f) in *)
       let register_with_sort fam_sort =
 	let evd' = Evd.from_env (Global.env ()) in
 	let evd',s = Evd.fresh_sort_in_family env evd' fam_sort in

--- a/plugins/funind/glob_term_to_relation.ml
+++ b/plugins/funind/glob_term_to_relation.ml
@@ -15,6 +15,9 @@ open Misctypes
 module RelDecl = Context.Rel.Declaration
 module NamedDecl = Context.Named.Declaration
 
+(** Deactivate deprecated warning *)
+[@@@ocaml.warning "-3"]
+
 let observe strm =
   if do_observe ()
   then Feedback.msg_debug strm

--- a/plugins/funind/glob_termops.ml
+++ b/plugins/funind/glob_termops.ml
@@ -6,6 +6,9 @@ open Names
 open Decl_kinds
 open Misctypes
 
+(** Deactivate deprecated warning *)
+[@@@ocaml.warning "-3"]
+
 (*
    Some basic functions to rebuild glob_constr
    In each of them the location is Loc.ghost

--- a/plugins/funind/indfun.ml
+++ b/plugins/funind/indfun.ml
@@ -14,6 +14,9 @@ open Decl_kinds
 
 module RelDecl = Context.Rel.Declaration
 
+(** Deactivate deprecated warning *)
+[@@@ocaml.warning "-3"]
+
 let is_rec_info sigma scheme_info =
   let test_branche min acc decl =
     acc || (

--- a/plugins/funind/indfun_common.ml
+++ b/plugins/funind/indfun_common.ml
@@ -3,6 +3,10 @@ open Pp
 open Libnames
 open Globnames
 open Refiner
+
+(** Deactivate deprecated warning *)
+[@@@ocaml.warning "-3"]
+
 let mk_prefix pre id = Id.of_string (pre^(Id.to_string id))
 let mk_rel_id = mk_prefix "R_"
 let mk_correct_id id = Nameops.add_suffix (mk_rel_id id) "_correct"

--- a/plugins/funind/invfun.ml
+++ b/plugins/funind/invfun.ml
@@ -26,6 +26,9 @@ open Context.Rel.Declaration
 
 module RelDecl = Context.Rel.Declaration
 
+(** Deactivate deprecated warning *)
+[@@@ocaml.warning "-3"]
+
 (* The local debugging mechanism *)
 (* let msgnl = Pp.msgnl *)
 

--- a/plugins/funind/merge.ml
+++ b/plugins/funind/merge.ml
@@ -27,6 +27,9 @@ open Context.Rel.Declaration
 
 module RelDecl = Context.Rel.Declaration
 
+(** Deactivate deprecated warning *)
+[@@@ocaml.warning "-3"]
+
 (** {1 Utilities}  *)
 
 (** {2 Useful operations on constr and glob_constr} *)

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -45,6 +45,9 @@ open Eauto
 open Indfun_common
 open Context.Rel.Declaration
 
+(** Deactivate deprecated warning *)
+[@@@ocaml.warning "-3"]
+
 (* Ugly things which should not be here *)
 
 let coq_constant m s = EConstr.of_constr @@ Universes.constr_of_global @@

--- a/pretyping/classops.ml
+++ b/pretyping/classops.ml
@@ -60,8 +60,8 @@ let coe_info_typ_equal c1 c2 =
 
 let cl_typ_ord t1 t2 = match t1, t2 with
   | CL_SECVAR v1, CL_SECVAR v2 -> Id.compare v1 v2
-  | CL_CONST c1, CL_CONST c2 -> con_ord c1 c2
-  | CL_PROJ c1, CL_PROJ c2 -> con_ord c1 c2
+  | CL_CONST c1, CL_CONST c2 -> Constant.CanOrd.compare c1 c2
+  | CL_PROJ c1, CL_PROJ c2 -> Constant.CanOrd.compare c1 c2
   | CL_IND i1, CL_IND i2 -> ind_ord i1 i2
   | _ -> Pervasives.compare t1 t2 (** OK *)
 

--- a/pretyping/constr_matching.ml
+++ b/pretyping/constr_matching.ml
@@ -204,8 +204,8 @@ let matches_core env sigma convert allow_partial_app allow_bound_rels
   let open EConstr in
   let convref ref c = 
     match ref, EConstr.kind sigma c with
-    | VarRef id, Var id' -> Names.id_eq id id'
-    | ConstRef c, Const (c',_) -> Names.eq_constant c c'
+    | VarRef id, Var id' -> Names.Id.equal id id'
+    | ConstRef c, Const (c',_) -> Names.Constant.equal c c'
     | IndRef i, Ind (i', _) -> Names.eq_ind i i'
     | ConstructRef c, Construct (c',u) -> Names.eq_constructor c c'
     | _, _ -> 
@@ -277,7 +277,7 @@ let matches_core env sigma convert allow_partial_app allow_bound_rels
 	   
       | PApp (c1,arg1), App (c2,arg2) ->
 	(match c1, EConstr.kind sigma c2 with
-	| PRef (ConstRef r), Proj (pr,c) when not (eq_constant r (Projection.constant pr))
+	| PRef (ConstRef r), Proj (pr,c) when not (Constant.equal r (Projection.constant pr))
 	    || Projection.unfolded pr ->
 	  raise PatternMatchingFailure
 	| PProj (pr1,c1), Proj (pr,c) ->
@@ -294,7 +294,7 @@ let matches_core env sigma convert allow_partial_app allow_bound_rels
           with Invalid_argument _ -> raise PatternMatchingFailure)
 	  
       | PApp (PRef (ConstRef c1), _), Proj (pr, c2) 
-	when Projection.unfolded pr || not (eq_constant c1 (Projection.constant pr)) -> 
+	when Projection.unfolded pr || not (Constant.equal c1 (Projection.constant pr)) -> 
 	raise PatternMatchingFailure
 	
       | PApp (c, args), Proj (pr, c2) ->

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -291,7 +291,7 @@ let ise_stack2 no_app env evd f sk1 sk2 =
         | UnifFailure _ as x -> fail x)
       | UnifFailure _ as x -> fail x)
     | Stack.Proj (n1,a1,p1,_)::q1, Stack.Proj (n2,a2,p2,_)::q2 ->
-       if eq_constant (Projection.constant p1) (Projection.constant p2)
+       if Constant.equal (Projection.constant p1) (Projection.constant p2)
        then ise_stack2 true i q1 q2
        else fail (UnifFailure (i, NotSameHead))
     | Stack.Fix (((li1, i1),(_,tys1,bds1 as recdef1)),a1,_)::q1,
@@ -335,7 +335,7 @@ let exact_ise_stack2 env evd f sk1 sk2 =
 	  (fun i -> ise_stack2 i a1 a2)]
       else UnifFailure (i,NotSameHead)
     | Stack.Proj (n1,a1,p1,_)::q1, Stack.Proj (n2,a2,p2,_)::q2 ->
-       if eq_constant (Projection.constant p1) (Projection.constant p2)
+       if Constant.equal (Projection.constant p1) (Projection.constant p2)
        then ise_stack2 i q1 q2
        else (UnifFailure (i, NotSameHead))
     | Stack.Update _ :: _, _ | Stack.Shift _ :: _, _
@@ -765,7 +765,7 @@ and evar_eqappr_x ?(rhs_is_already_stuck = false) ts env evd pbty
 	    ise_try evd [f1; f2]
 	      
 	(* Catch the p.c ~= p c' cases *)
-	| Proj (p,c), Const (p',u) when eq_constant (Projection.constant p) p' ->
+	| Proj (p,c), Const (p',u) when Constant.equal (Projection.constant p) p' ->
 	  let res = 
 	    try Some (destApp evd (Retyping.expand_projection env evd p c []))
 	    with Retyping.RetypeError _ -> None
@@ -776,7 +776,7 @@ and evar_eqappr_x ?(rhs_is_already_stuck = false) ts env evd pbty
 		(appr2,csts2)
 	    | None -> UnifFailure (evd,NotSameHead))
 	      
-	| Const (p,u), Proj (p',c') when eq_constant p (Projection.constant p') ->
+	| Const (p,u), Proj (p',c') when Constant.equal p (Projection.constant p') ->
 	  let res = 
 	    try Some (destApp evd (Retyping.expand_projection env evd p' c' []))
 	    with Retyping.RetypeError _ -> None

--- a/pretyping/evarconv.mli
+++ b/pretyping/evarconv.mli
@@ -36,6 +36,7 @@ val e_cumul : env -> ?ts:transparent_state -> evar_map ref -> constr -> constr -
 val solve_unif_constraints_with_heuristics : env -> ?ts:transparent_state -> evar_map -> evar_map
 
 val consider_remaining_unif_problems : env -> ?ts:transparent_state -> evar_map -> evar_map
+[@@ocaml.deprecated]
 (** @deprecated Alias for [solve_unif_constraints_with_heuristics] *)
 
 (** Check all pending unification problems are solved and raise an

--- a/pretyping/evarsolve.ml
+++ b/pretyping/evarsolve.ml
@@ -1001,7 +1001,7 @@ let closure_of_filter evd evk = function
   | Some filter ->
   let evi = Evd.find_undefined evd evk in
   let vars = collect_vars evd (EConstr.of_constr (evar_concl evi)) in
-  let test b decl = b || Idset.mem (get_id decl) vars ||
+  let test b decl = b || Id.Set.mem (get_id decl) vars ||
                     match decl with
                     | LocalAssum _ ->
                        false
@@ -1550,19 +1550,19 @@ let rec invert_definition conv_algo choose env evd pbty (evk,argsv as ev) rhs =
   let rhs = whd_beta evd rhs (* heuristic *) in
   let fast rhs = 
     let filter_ctxt = evar_filtered_context evi in
-    let names = ref Idset.empty in
+    let names = ref Id.Set.empty in
     let rec is_id_subst ctxt s =
       match ctxt, s with
       | (decl :: ctxt'), (c :: s') ->
         let id = get_id decl in
-        names := Idset.add id !names;
+        names := Id.Set.add id !names;
         isVarId evd id c && is_id_subst ctxt' s'
       | [], [] -> true
       | _ -> false 
     in
       is_id_subst filter_ctxt (Array.to_list argsv) &&
       closed0 evd rhs &&
-      Idset.subset (collect_vars evd rhs) !names 
+      Id.Set.subset (collect_vars evd rhs) !names 
   in
   let body =
     if fast rhs then EConstr.of_constr (EConstr.to_constr evd rhs) (** FIXME? *)

--- a/pretyping/evarsolve.mli
+++ b/pretyping/evarsolve.mli
@@ -62,6 +62,7 @@ val solve_simple_eqn : conv_fun -> ?choose:bool -> env ->  evar_map ->
 val reconsider_unif_constraints : conv_fun -> evar_map -> unification_result
 
 val reconsider_conv_pbs : conv_fun -> evar_map -> unification_result
+[@@ocaml.deprecated]
 (** @deprecated Alias for [reconsider_unif_constraints] *)
 
 val is_unification_pattern_evar : env -> evar_map -> existential -> constr list ->

--- a/pretyping/indrec.ml
+++ b/pretyping/indrec.ml
@@ -566,7 +566,7 @@ let build_mutual_induction_scheme env sigma = function
     	(List.map
 	   (function ((mind',u'),dep',s') ->
 	      let (sp',_) = mind' in
-	      if eq_mind sp sp' then
+	      if MutInd.equal sp sp' then
                 let (mibi',mipi') = lookup_mind_specif env mind' in
 		((mind',u'),mibi',mipi',dep',s')
 	      else
@@ -605,7 +605,7 @@ let lookup_eliminator ind_sp s =
   (* Try first to get an eliminator defined in the same section as the *)
   (* inductive type *)
   try
-    let cst =Global.constant_of_delta_kn (make_kn mp dp (Label.of_id id)) in
+    let cst =Global.constant_of_delta_kn (KerName.make mp dp (Label.of_id id)) in
     let _ = Global.lookup_constant cst in
       ConstRef cst
   with Not_found ->

--- a/pretyping/nativenorm.ml
+++ b/pretyping/nativenorm.ml
@@ -39,7 +39,7 @@ let invert_tag cst tag reloc_tbl =
 let decompose_prod env t =
   let (name,dom,codom as res) = destProd (whd_all env t) in
   match name with
-  | Anonymous -> (Name (id_of_string "x"),dom,codom)
+  | Anonymous -> (Name (Id.of_string "x"),dom,codom)
   | _ -> res
 
 let app_type env c =
@@ -310,7 +310,7 @@ and nf_atom_type env sigma atom =
       mkCase(ci, p, a, branchs), tcase 
   | Afix(tt,ft,rp,s) ->
       let tt = Array.map (fun t -> nf_type env sigma t) tt in
-      let name = Array.map (fun _ -> (Name (id_of_string "Ffix"))) tt in
+      let name = Array.map (fun _ -> (Name (Id.of_string "Ffix"))) tt in
       let lvl = nb_rel env in
       let nbfix = Array.length ft in
       let fargs = mk_rels_accu lvl (Array.length ft) in
@@ -323,7 +323,7 @@ and nf_atom_type env sigma atom =
       mkFix((rp,s),(name,tt,ft)), tt.(s)
   | Acofix(tt,ft,s,_) | Acofixe(tt,ft,s,_) ->
       let tt = Array.map (nf_type env sigma) tt in
-      let name = Array.map (fun _ -> (Name (id_of_string "Fcofix"))) tt in
+      let name = Array.map (fun _ -> (Name (Id.of_string "Fcofix"))) tt in
       let lvl = nb_rel env in
       let fargs = mk_rels_accu lvl (Array.length ft) in
       let env = push_rec_types (name,tt,[||]) env in
@@ -365,7 +365,7 @@ and  nf_predicate env sigma ind mip params v pT =
   | Vfun f, _ -> 
       let k = nb_rel env in
       let vb = f (mk_rel_accu k) in
-      let name = Name (id_of_string "c") in
+      let name = Name (Id.of_string "c") in
       let n = mip.mind_nrealargs in
       let rargs = Array.init n (fun i -> mkRel (n-i)) in
       let params = if Int.equal n 0 then params else Array.map (lift n) params in

--- a/pretyping/patternops.ml
+++ b/pretyping/patternops.ml
@@ -149,7 +149,7 @@ let pattern_of_constr env sigma t =
          with
          | Some n -> PSoApp (n,Array.to_list (Array.map (pattern_of_constr env) a))
          | None -> PApp (pattern_of_constr env f,Array.map (pattern_of_constr env) a))
-    | Const (sp,u)  -> PRef (ConstRef (constant_of_kn(canonical_con sp)))
+    | Const (sp,u)  -> PRef (ConstRef (Constant.make1(Constant.canonical sp)))
     | Ind (sp,u)    -> PRef (canonical_gr (IndRef sp))
     | Construct (sp,u) -> PRef (canonical_gr (ConstructRef sp))
     | Proj (p, c) -> 

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -203,7 +203,7 @@ let interp_universe_level_name ~anon_rigidity evd (loc, s) =
        with Not_found ->
 	 try
 	   let id = try Id.of_string s with _ -> raise Not_found in
-           evd, snd (Idmap.find id names)
+           evd, snd (Id.Map.find id names)
 	 with Not_found ->
 	   if not (is_strict_universe_declarations ()) then
   	     new_univ_level_variable ?loc ~name:s univ_rigid evd

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -358,7 +358,7 @@ struct
        ++ str ")"
     | Proj (n,m,p,cst) ->
       str "ZProj(" ++ int n ++ pr_comma () ++ int m ++
-	pr_comma () ++ pr_con (Projection.constant p) ++ str ")"
+	pr_comma () ++ Constant.print (Projection.constant p) ++ str ")"
     | Fix (f,args,cst) ->
        str "ZFix(" ++ Termops.pr_fix pr_c f
        ++ pr_comma () ++ pr pr_c args ++ str ")"

--- a/pretyping/tacred.ml
+++ b/pretyping/tacred.ml
@@ -81,7 +81,7 @@ type evaluable_reference =
   | EvalEvar of EConstr.existential
 
 let evaluable_reference_eq sigma r1 r2 = match r1, r2 with
-| EvalConst c1, EvalConst c2 -> eq_constant c1 c2
+| EvalConst c1, EvalConst c2 -> Constant.equal c1 c2
 | EvalVar id1, EvalVar id2 -> Id.equal id1 id2
 | EvalRel i1, EvalRel i2 -> Int.equal i1 i2
 | EvalEvar (e1, ctx1), EvalEvar (e2, ctx2) ->
@@ -240,7 +240,7 @@ let invert_name labs l na0 env sigma ref = function
 	  | EvalRel _ | EvalEvar _ -> None
 	  | EvalVar id' -> Some (EvalVar id)
 	  | EvalConst kn ->
-	      Some (EvalConst (con_with_label kn (Label.of_id id))) in
+	      Some (EvalConst (Constant.change_label kn (Label.of_id id))) in
 	match refi with
 	  | None -> None
 	  | Some ref ->
@@ -521,7 +521,7 @@ let reduce_mind_case_use_function func env sigma mia =
 		       the block was indeed initially built as a global
 		       definition *)
                     let (kn, u) = destConst sigma func in
-                    let kn = con_with_label kn (Label.of_id id) in
+                    let kn = Constant.change_label kn (Label.of_id id) in
                     let cst = (kn, EInstance.kind sigma u) in
 		    try match constant_opt_value_in env cst with
 		      | None -> None
@@ -938,7 +938,7 @@ let whd_simpl_orelse_delta_but_fix env sigma c =
       | CoFix _ | Fix _ -> s'
       | Proj (p,t) when
 	  (match EConstr.kind sigma constr with
-	  | Const (c', _) -> eq_constant (Projection.constant p) c'
+	  | Const (c', _) -> Constant.equal (Projection.constant p) c'
 	  | _ -> false) ->
 	let pb = Environ.lookup_projection p env in
 	  if List.length stack <= pb.Declarations.proj_npars then
@@ -1044,8 +1044,8 @@ let contextually byhead occs f env sigma t =
 
 let match_constr_evaluable_ref sigma c evref = 
   match EConstr.kind sigma c, evref with
-  | Const (c,u), EvalConstRef c' when eq_constant c c' -> Some u
-  | Var id, EvalVarRef id' when id_eq id id' -> Some EInstance.empty
+  | Const (c,u), EvalConstRef c' when Constant.equal c c' -> Some u
+  | Var id, EvalVarRef id' when Id.equal id id' -> Some EInstance.empty
   | _, _ -> None
 
 let substlin env sigma evalref n (nowhere_except_in,locs) c =

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -42,6 +42,9 @@ type subst0 =
 module RelDecl = Context.Rel.Declaration
 module NamedDecl = Context.Named.Declaration
 
+(** Deactivate deprecated warning *)
+[@@@ocaml.warning "-3"]
+
 let keyed_unification = ref (false)
 let _ = Goptions.declare_bool_option {
   Goptions.optdepr = false;

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -553,10 +553,10 @@ let oracle_order env cf1 cf2 =
       | Some k2 ->
 	match k1, k2 with
 	| IsProj (p, _), IsKey (ConstKey (p',_)) 
-	  when eq_constant (Projection.constant p) p' -> 
+	  when Constant.equal (Projection.constant p) p' -> 
 	  Some (not (Projection.unfolded p))
 	| IsKey (ConstKey (p,_)), IsProj (p', _) 
-	  when eq_constant p (Projection.constant p') -> 
+	  when Constant.equal p (Projection.constant p') -> 
 	  Some (Projection.unfolded p')
 	| _ ->
           Some (Conv_oracle.oracle_order (fun x -> x)
@@ -783,7 +783,7 @@ let rec unify_0_with_initial_metas (sigma,ms,es as subst : subst0) conv_at_top e
 	| _, LetIn (_,a,_,c) -> unirec_rec curenvnb pb opt substn cM (subst1 a c)
 
 	(** Fast path for projections. *)
-	| Proj (p1,c1), Proj (p2,c2) when eq_constant
+	| Proj (p1,c1), Proj (p2,c2) when Constant.equal
 	    (Projection.constant p1) (Projection.constant p2) ->
 	  (try unify_same_proj curenvnb cv_pb {opt with at_top = true}
 	       substn c1 c2

--- a/printing/prettyp.ml
+++ b/printing/prettyp.ml
@@ -586,14 +586,14 @@ let gallina_print_leaf_entry with_values ((sp,kn as oname),lobj) =
              constraints *)
 	  (try Some(print_named_decl (basename sp)) with Not_found -> None)
       | (_,"CONSTANT") ->
-	  Some (print_constant with_values sep (constant_of_kn kn))
+	  Some (print_constant with_values sep (Constant.make1 kn))
       | (_,"INDUCTIVE") ->
-	  Some (gallina_print_inductive (mind_of_kn kn))
+	  Some (gallina_print_inductive (MutInd.make1 kn))
       | (_,"MODULE") ->
-	  let (mp,_,l) = repr_kn kn in
+	  let (mp,_,l) = KerName.repr kn in
 	    Some (print_module with_values (MPdot (mp,l)))
       | (_,"MODULE TYPE") ->
-	  let (mp,_,l) = repr_kn kn in
+	  let (mp,_,l) = KerName.repr kn in
 	  Some (print_modtype (MPdot (mp,l)))
       | (_,("AUTOHINT"|"GRAMMAR"|"SYNTAXCONSTANT"|"PPSYNTAX"|"TOKEN"|"CLASS"|
 	    "COERCION"|"REQUIRE"|"END-SECTION"|"STRUCTURE")) -> None
@@ -713,12 +713,12 @@ let print_full_pure_context () =
 	    str "." ++ fnl () ++ fnl ()
       | "MODULE" ->
 	  (* TODO: make it reparsable *)
-	  let (mp,_,l) = repr_kn kn in
+	  let (mp,_,l) = KerName.repr kn in
 	  print_module true (MPdot (mp,l)) ++ str "." ++ fnl () ++ fnl ()
       | "MODULE TYPE" ->
 	  (* TODO: make it reparsable *)
 	  (* TODO: make it reparsable *)
-	  let (mp,_,l) = repr_kn kn in
+	  let (mp,_,l) = KerName.repr kn in
 	  print_modtype (MPdot (mp,l)) ++ str "." ++ fnl () ++ fnl ()
       | _ -> mt () in
       prec rest ++ pp

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -16,7 +16,6 @@ open Globnames
 open Nametab
 open Evd
 open Proof_type
-open Refiner
 open Constrextern
 open Ppconstr
 open Declarations
@@ -478,10 +477,11 @@ let pr_transparent_state (ids, csts) =
 	str"CONSTANTS: " ++ pr_cpred csts ++ fnl ())
 
 (* display complete goal *)
-let default_pr_goal gs =
-  let (g,sigma) = Goal.V82.nf_evar (project gs) (sig_it gs) in
-  let env = Goal.V82.env sigma g in
-  let concl = Goal.V82.concl sigma g in
+let default_pr_goal sigma evk =
+  let evi = Evd.find sigma evk in
+  let evi = Evarutil.nf_evar_info sigma evi in
+  let env = evar_env evi in
+  let concl = EConstr.of_constr (evar_concl evi) in
   let goal =
     pr_context_of env sigma ++ cut () ++
       str "============================" ++ cut ()  ++
@@ -498,17 +498,18 @@ let pr_goal_name sigma g =
   if should_gname() then str " " ++ Pp.surround (pr_existential_key sigma g)
   else mt ()
 
-let pr_goal_header nme sigma g =
-  let (g,sigma) = Goal.V82.nf_evar sigma g in
-  str "subgoal " ++ nme ++ (if should_tag() then pr_goal_tag g else str"")
-  ++ (if should_gname() then str " " ++ Pp.surround (pr_existential_key sigma g) else mt ())  
+let pr_goal_header nme sigma evk =
+  str "subgoal " ++ nme ++ (if should_tag() then pr_goal_tag evk else str"")
+  ++ (if should_gname() then str " " ++ Pp.surround (pr_existential_key sigma evk) else mt ())  
 
 (* display the conclusion of a goal *)
-let pr_concl n sigma g =
-  let (g,sigma) = Goal.V82.nf_evar sigma g in
-  let env = Goal.V82.env sigma g in
-  let pc = pr_goal_concl_style_env env sigma (Goal.V82.concl sigma g) in
-  let header = pr_goal_header (int n) sigma g in
+let pr_concl n sigma evk =
+  let evi = Evd.find sigma evk in
+  let evi = Evarutil.nf_evar_info sigma evi in
+  let env = evar_env evi in
+  let concl = EConstr.of_constr (evar_concl evi) in
+  let pc = pr_goal_concl_style_env env sigma concl in
+  let header = pr_goal_header (int n) sigma evk in
   header ++ str " is:" ++ cut () ++ str" "  ++ pc
 
 (* display evar type: a context and a type *)
@@ -564,7 +565,7 @@ let pr_ne_evar_set hd tl sigma l =
     mt ()
 
 let pr_selected_subgoal name sigma g =
-  let pg = default_pr_goal { sigma=sigma ; it=g; } in
+  let pg = default_pr_goal sigma g in
   let header = pr_goal_header name sigma g in
   v 0 (header ++ str " is:" ++ cut () ++ pg)
 
@@ -581,12 +582,13 @@ let default_pr_subgoal n sigma =
 
 let pr_internal_existential_key ev = str (string_of_existential ev)
 
-let print_evar_constraints gl sigma =
+let print_evar_constraints sigma evk =
   let pr_env =
-    match gl with
+    match evk with
     | None -> fun e' -> pr_context_of e' sigma
     | Some g ->
-       let env = Goal.V82.env sigma g in fun e' ->
+       let evi = Evd.find sigma g in
+       let env = evar_env evi in fun e' ->
        begin
          if Context.Named.equal Constr.equal (named_context env) (named_context e') then
            if Context.Rel.equal Constr.equal (rel_context env) (rel_context e') then mt ()
@@ -642,7 +644,7 @@ let _ =
       optwrite = (fun v -> should_print_dependent_evars := v) }
 
 let print_dependent_evars gl sigma seeds =
-  let constraints = print_evar_constraints gl sigma in
+  let constraints = print_evar_constraints sigma gl in
   let evars () =
     if !should_print_dependent_evars then
       let evars = Evarutil.gather_dependent_evars sigma seeds in
@@ -712,7 +714,7 @@ let default_pr_subgoals ?(pr_first=true)
   in
   let print_multiple_goals g l =
     if pr_first then
-      default_pr_goal { it = g ; sigma = sigma; }
+      default_pr_goal sigma g
       ++ (if l=[] then mt () else cut ())
       ++ pr_rec 2 l
     else 
@@ -766,7 +768,7 @@ type printer_pr = {
 let default_printer_pr = {
  pr_subgoals = default_pr_subgoals;
  pr_subgoal  = default_pr_subgoal;
- pr_goal     = default_pr_goal;
+ pr_goal     = (fun g -> default_pr_goal g.sigma g.it);
 }
 
 let printer_pr = ref default_printer_pr

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -886,11 +886,11 @@ struct
   let compare_axiom x y =
     match x,y with
     | Constant k1 , Constant k2 ->
-        con_ord k1 k2
+        Constant.CanOrd.compare k1 k2
     | Positive m1 , Positive m2 ->
         MutInd.CanOrd.compare m1 m2
     | Guarded k1 , Guarded k2 ->
-        con_ord k1 k2
+        Constant.CanOrd.compare k1 k2
     | _ , Constant _ -> 1
     | _ , Positive _ -> 1
     | _ -> -1
@@ -903,10 +903,10 @@ struct
     | Axiom (k1,_) , Axiom (k2, _) -> compare_axiom k1 k2
     | Axiom _ , _ -> -1
     | _ , Axiom _ -> 1
-    | Opaque k1 , Opaque k2 -> con_ord k1 k2
+    | Opaque k1 , Opaque k2 -> Constant.CanOrd.compare k1 k2
     | Opaque _ , _ -> -1
     | _ , Opaque _ -> 1
-    | Transparent k1 , Transparent k2 -> con_ord k1 k2
+    | Transparent k1 , Transparent k2 -> Constant.CanOrd.compare k1 k2
 end
 
 module ContextObjectSet = Set.Make (OrderedContextObject)
@@ -920,8 +920,8 @@ let pr_assumptionset env s =
     let safe_pr_constant env kn =
       try pr_constant env kn
       with Not_found ->
-	let mp,_,lab = repr_con kn in
-        str (string_of_mp mp) ++ str "." ++ pr_label lab
+	let mp,_,lab = Constant.repr3 kn in
+        str (ModPath.to_string mp) ++ str "." ++ Label.print lab
     in
     let safe_pr_ltype typ =
       try str " : " ++ pr_ltype typ
@@ -955,7 +955,7 @@ let pr_assumptionset env s =
         let ax = pr_axiom env axiom typ ++
           cut() ++
           prlist_with_sep cut (fun (lbl, ctx, ty) ->
-            str " used in " ++ pr_label lbl ++
+            str " used in " ++ Label.print lbl ++
             str " to prove:" ++ safe_pr_ltype_relctx (ctx,ty))
           l in
         (v, ax :: a, o, tr)

--- a/printing/printmod.ml
+++ b/printing/printmod.ml
@@ -61,7 +61,7 @@ let keyword s = tag_keyword (str s)
 let get_new_id locals id =
   let rec get_id l id =
     let dir = DirPath.make [id] in
-      if not (Nametab.exists_module dir) then
+      if not (Nametab.exists_dir dir) then
 	id
       else
 	get_id (id::l) (Namegen.next_ident_away id l)
@@ -300,7 +300,7 @@ let nametab_register_modparam mbid mtb =
       id
 
 let print_body is_impl env mp (l,body) =
-  let name = pr_label l in
+  let name = Label.print l in
   hov 2 (match body with
     | SFBmodule _ -> keyword "Module" ++ spc () ++ name
     | SFBmodtype _ -> keyword "Module Type" ++ spc () ++ name

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -26,6 +26,9 @@ open Evarutil
 open Unification
 open Misctypes
 
+(** Deactivate deprecated warning *)
+[@@@ocaml.warning "-3"]
+
 (******************************************************************)
 (* Clausal environments *)
 

--- a/proofs/clenvtac.ml
+++ b/proofs/clenvtac.ml
@@ -18,6 +18,9 @@ open Reduction
 open Tacmach
 open Clenv
 
+(** Deactivate deprecated warning *)
+[@@@ocaml.warning "-3"]
+
 (* This function put casts around metavariables whose type could not be
  * infered by the refiner, that is head of applications, predicates and
  * subject of Cases.

--- a/proofs/goal.mli
+++ b/proofs/goal.mli
@@ -75,3 +75,4 @@ module V82 : sig
   val abstract_type : Evd.evar_map -> goal -> EConstr.types 
 
 end
+[@@ocaml.deprecated]

--- a/proofs/logic.ml
+++ b/proofs/logic.ml
@@ -26,6 +26,9 @@ open Context.Named.Declaration
 
 module NamedDecl = Context.Named.Declaration
 
+(** Deactivate deprecated warning *)
+[@@@ocaml.warning "-3"]
+
 type refiner_error =
 
   (* Errors raised by the refiner *)

--- a/proofs/logic.mli
+++ b/proofs/logic.mli
@@ -17,6 +17,7 @@ open Proof_type
    argument; works by side-effect *)
 
 val with_check    : tactic -> tactic
+[@@ocaml.deprecated]
 
 (** [without_check] respectively means:\\
   [Intro]: no check that the name does not exist\\
@@ -31,6 +32,7 @@ val with_check    : tactic -> tactic
 (** The primitive refiner. *)
 
 val prim_refiner : prim_rule -> evar_map -> goal -> goal list * evar_map
+[@@ocaml.deprecated]
 
 
 (** {6 Refiner errors. } *)

--- a/proofs/pfedit.ml
+++ b/proofs/pfedit.ml
@@ -53,12 +53,13 @@ let get_nth_V82_goal i =
   let p = Proof_global.give_me_the_proof () in
   let { it=goals ; sigma = sigma; } = Proof.V82.subgoals p in
   try
-          { it=(List.nth goals (i-1)) ; sigma=sigma; }
+    (sigma, List.nth goals (i - 1))
   with Failure _ -> raise NoSuchGoal
 
 let get_goal_context_gen i =
-  let { it=goal ; sigma=sigma; } =  get_nth_V82_goal i in
-  (sigma, Refiner.pf_env { it=goal ; sigma=sigma; })
+  let (sigma, goal) =  get_nth_V82_goal i in
+  let evi = Evd.find sigma goal in
+  (sigma, Evd.evar_env evi)
 
 let get_goal_context i =
   try get_goal_context_gen i

--- a/proofs/refiner.ml
+++ b/proofs/refiner.ml
@@ -15,6 +15,9 @@ open Logic
 
 module NamedDecl = Context.Named.Declaration
 
+(** Deactivate deprecated warning *)
+[@@@ocaml.warning "-3"]
+
 let sig_it x = x.it
 let project x = x.sigma
 

--- a/proofs/refiner.mli
+++ b/proofs/refiner.mli
@@ -15,63 +15,86 @@ open EConstr
 (** The refiner (handles primitive rules and high-level tactics). *)
 
 val sig_it  : 'a sigma -> 'a
+[@@ocaml.deprecated]
 val project : 'a sigma -> evar_map
+[@@ocaml.deprecated]
 
 val pf_env  : goal sigma -> Environ.env
+[@@ocaml.deprecated]
 val pf_hyps : goal sigma -> named_context
+[@@ocaml.deprecated]
 
 val unpackage : 'a sigma -> evar_map ref * 'a
+[@@ocaml.deprecated]
 val repackage : evar_map ref -> 'a -> 'a sigma
+[@@ocaml.deprecated]
 val apply_sig_tac :
   evar_map ref -> (goal sigma -> goal list sigma) -> goal -> goal list
+[@@ocaml.deprecated]
 
 val refiner : rule -> tactic
+[@@ocaml.deprecated]
 
 (** {6 Tacticals. } *)
 
 (** [tclIDTAC] is the identity tactic without message printing*)
 val tclIDTAC          : tactic
+[@@ocaml.deprecated]
 val tclIDTAC_MESSAGE  : Pp.std_ppcmds -> tactic
+[@@ocaml.deprecated]
 
 (** [tclEVARS sigma] changes the current evar map *)
 val tclEVARS : evar_map -> tactic
+[@@ocaml.deprecated]
 val tclEVARUNIVCONTEXT : Evd.evar_universe_context -> tactic
+[@@ocaml.deprecated]
 
 val tclPUSHCONTEXT : Evd.rigid -> Univ.universe_context_set -> tactic -> tactic
+[@@ocaml.deprecated]
 val tclPUSHEVARUNIVCONTEXT : Evd.evar_universe_context -> tactic
+[@@ocaml.deprecated]
 
 val tclPUSHCONSTRAINTS : Univ.constraints -> tactic
+[@@ocaml.deprecated]
 
 (** [tclTHEN tac1 tac2 gls] applies the tactic [tac1] to [gls] and applies
    [tac2] to every resulting subgoals *)
 val tclTHEN          : tactic -> tactic -> tactic
+[@@ocaml.deprecated]
 
 (** [tclTHENLIST [t1;..;tn]] applies [t1] THEN [t2] ... THEN [tn]. More
    convenient than [tclTHEN] when [n] is large *)
 val tclTHENLIST      : tactic list -> tactic
+[@@ocaml.deprecated]
 
 (** [tclMAP f [x1..xn]] builds [(f x1);(f x2);...(f xn)] *)
 val tclMAP           : ('a -> tactic) -> 'a list -> tactic
+[@@ocaml.deprecated]
 
 (** [tclTHEN_i tac1 tac2 gls] applies the tactic [tac1] to [gls] and applies
    [(tac2 i)] to the [i]{^ th} resulting subgoal (starting from 1) *)
 val tclTHEN_i        : tactic -> (int -> tactic) -> tactic
+[@@ocaml.deprecated]
 
 (** [tclTHENLAST tac1 tac2 gls] applies the tactic [tac1] to [gls] and [tac2]
    to the last resulting subgoal (previously called [tclTHENL]) *)
 val tclTHENLAST         : tactic -> tactic -> tactic
+[@@ocaml.deprecated]
 
 (** [tclTHENFIRST tac1 tac2 gls] applies the tactic [tac1] to [gls] and [tac2]
    to the first resulting subgoal *)
 val tclTHENFIRST         : tactic -> tactic -> tactic
+[@@ocaml.deprecated]
 
 (** [tclTHENS tac1 [|t1 ; ... ; tn|] gls] applies the tactic [tac1] to
    [gls] and applies [t1],..., [tn] to the [n] resulting subgoals. Raises
    an error if the number of resulting subgoals is not [n] *)
 val tclTHENSV         : tactic -> tactic array -> tactic
+[@@ocaml.deprecated]
 
 (** Same with a list of tactics *)
 val tclTHENS         : tactic -> tactic list -> tactic
+[@@ocaml.deprecated]
 
 (** [tclTHENS3PARTS tac1 [|t1 ; ... ; tn|] tac2 [|t'1 ; ... ; t'm|] gls]
    applies the tactic [tac1] to [gls] then, applies [t1], ..., [tn] to
@@ -79,25 +102,30 @@ val tclTHENS         : tactic -> tactic list -> tactic
    subgoals and [tac2] to the rest of the subgoals in the middle. Raises an
    error if the number of resulting subgoals is strictly less than [n+m] *)
 val tclTHENS3PARTS     : tactic -> tactic array -> tactic -> tactic array -> tactic
+[@@ocaml.deprecated]
 
 (** [tclTHENSLASTn tac1 [t1 ; ... ; tn] tac2 gls] applies [t1],...,[tn] on the
    last [n] resulting subgoals and [tac2] on the remaining first subgoals *)
 val tclTHENSLASTn     : tactic -> tactic -> tactic array -> tactic
+[@@ocaml.deprecated]
 
 (** [tclTHENSFIRSTn tac1 [t1 ; ... ; tn] tac2 gls] first applies [tac1], then
    applies [t1],...,[tn] on the first [n] resulting subgoals and
    [tac2] for the remaining last subgoals (previously called tclTHENST) *)
 val tclTHENSFIRSTn : tactic -> tactic array -> tactic -> tactic
+[@@ocaml.deprecated]
 
 (** [tclTHENLASTn tac1 [t1 ; ... ; tn] gls] first applies [tac1] then,
    applies [t1],...,[tn] on the last [n] resulting subgoals and leaves
    unchanged the other subgoals *)
 val tclTHENLASTn    : tactic -> tactic array -> tactic
+[@@ocaml.deprecated]
 
 (** [tclTHENFIRSTn tac1 [t1 ; ... ; tn] gls] first applies [tac1] then,
    applies [t1],...,[tn] on the first [n] resulting subgoals and leaves
    unchanged the other subgoals (previously called [tclTHENSI]) *)
 val tclTHENFIRSTn   : tactic -> tactic array -> tactic
+[@@ocaml.deprecated]
 
 (** A special exception for levels for the Fail tactic *)
 exception FailError of int * Pp.std_ppcmds Lazy.t
@@ -107,30 +135,47 @@ exception FailError of int * Pp.std_ppcmds Lazy.t
 val catch_failerror  : Exninfo.iexn -> unit
 
 val tclORELSE0       : tactic -> tactic -> tactic
+[@@ocaml.deprecated]
 val tclORELSE        : tactic -> tactic -> tactic
+[@@ocaml.deprecated]
 val tclREPEAT        : tactic -> tactic
+[@@ocaml.deprecated]
 val tclREPEAT_MAIN   : tactic -> tactic
+[@@ocaml.deprecated]
 val tclFIRST         : tactic list -> tactic
+[@@ocaml.deprecated]
 val tclSOLVE         : tactic list -> tactic
+[@@ocaml.deprecated]
 val tclTRY           : tactic -> tactic
+[@@ocaml.deprecated]
 val tclTHENTRY       : tactic -> tactic -> tactic
+[@@ocaml.deprecated]
 val tclCOMPLETE      : tactic -> tactic
+[@@ocaml.deprecated]
 val tclAT_LEAST_ONCE : tactic -> tactic
+[@@ocaml.deprecated]
 val tclFAIL          : int -> Pp.std_ppcmds -> tactic
+[@@ocaml.deprecated]
 val tclFAIL_lazy     : int -> Pp.std_ppcmds Lazy.t -> tactic
+[@@ocaml.deprecated]
 val tclDO            : int -> tactic -> tactic
 val tclPROGRESS      : tactic -> tactic
+[@@ocaml.deprecated]
 val tclSHOWHYPS      : tactic -> tactic
 
 (** [tclIFTHENELSE tac1 tac2 tac3 gls] first applies [tac1] to [gls] then,
    if it succeeds, applies [tac2] to the resulting subgoals,
    and if not applies [tac3] to the initial goal [gls] *)
 val tclIFTHENELSE    : tactic -> tactic -> tactic -> tactic
+[@@ocaml.deprecated]
 val tclIFTHENSELSE   : tactic -> tactic list -> tactic ->tactic
+[@@ocaml.deprecated]
 val tclIFTHENSVELSE   : tactic -> tactic array -> tactic ->tactic
+[@@ocaml.deprecated]
 
 (** [tclIFTHENTRYELSEMUST tac1 tac2 gls] applies [tac1] then [tac2]. If [tac1]
    has been successful, then [tac2] may fail. Otherwise, [tac2] must succeed.
    Equivalent to [(tac1;try tac2)||tac2] *)
 
 val tclIFTHENTRYELSEMUST : tactic -> tactic -> tactic
+[@@ocaml.deprecated]

--- a/proofs/tacmach.ml
+++ b/proofs/tacmach.ml
@@ -22,6 +22,10 @@ open Context.Named.Declaration
 
 module NamedDecl = Context.Named.Declaration
 
+(** Deactivate deprecated warning. TODO: move deprecated code to a proper
+    module, and move this attribute inside. *)
+[@@@ocaml.warning "-3"]
+
 let re_sig it  gc = { it = it; sigma = gc; }
 
 (**************************************************************)

--- a/proofs/tacmach.mli
+++ b/proofs/tacmach.mli
@@ -18,84 +18,133 @@ open Locus
 
 (** Operations for handling terms under a local typing context. *)
 
-type 'a sigma   = 'a Evd.sigma;;
-type tactic     = Proof_type.tactic;;
+type 'a sigma   = 'a Evd.sigma
+[@@ocaml.deprecated]
+type tactic     = Proof_type.tactic
+[@@ocaml.deprecated]
 
 val sig_it  : 'a sigma   -> 'a
+[@@ocaml.deprecated]
 val project : goal sigma -> evar_map
+[@@ocaml.deprecated]
 
 val re_sig : 'a -> evar_map -> 'a sigma
+[@@ocaml.deprecated]
 
 val unpackage : 'a sigma -> evar_map ref * 'a
+[@@ocaml.deprecated]
 val repackage : evar_map ref -> 'a -> 'a sigma
+[@@ocaml.deprecated]
 val apply_sig_tac :
   evar_map ref -> (goal sigma -> (goal list) sigma) -> goal -> (goal list)
+[@@ocaml.deprecated]
 
 val pf_concl              : goal sigma -> types
+[@@ocaml.deprecated]
 val pf_env                : goal sigma -> env
+[@@ocaml.deprecated]
 val pf_hyps               : goal sigma -> named_context
+[@@ocaml.deprecated]
 (*i val pf_untyped_hyps       : goal sigma -> (Id.t * constr) list i*)
 val pf_hyps_types         : goal sigma -> (Id.t * types) list
+[@@ocaml.deprecated]
 val pf_nth_hyp_id         : goal sigma -> int -> Id.t
+[@@ocaml.deprecated]
 val pf_last_hyp           : goal sigma -> named_declaration
+[@@ocaml.deprecated]
 val pf_ids_of_hyps        : goal sigma -> Id.t list
+[@@ocaml.deprecated]
 val pf_global             : goal sigma -> Id.t -> constr
+[@@ocaml.deprecated]
 val pf_unsafe_type_of            : goal sigma -> constr -> types
+[@@ocaml.deprecated]
 val pf_type_of            : goal sigma -> constr -> evar_map * types
+[@@ocaml.deprecated]
 val pf_hnf_type_of        : goal sigma -> constr -> types
+[@@ocaml.deprecated]
 
 val pf_get_hyp            : goal sigma -> Id.t -> named_declaration
+[@@ocaml.deprecated]
 val pf_get_hyp_typ        : goal sigma -> Id.t -> types
+[@@ocaml.deprecated]
 
 val pf_get_new_id  : Id.t      -> goal sigma -> Id.t
+[@@ocaml.deprecated]
 val pf_get_new_ids : Id.t list -> goal sigma -> Id.t list
+[@@ocaml.deprecated]
 
 val pf_reduction_of_red_expr : goal sigma -> red_expr -> constr -> evar_map * constr
+[@@ocaml.deprecated]
 
 
 val pf_apply : (env -> evar_map -> 'a) -> goal sigma -> 'a
+[@@ocaml.deprecated]
 val pf_eapply : (env -> evar_map -> 'a -> evar_map * 'b) -> 
   goal sigma -> 'a -> goal sigma * 'b
+[@@ocaml.deprecated]
 val pf_reduce :
   (env -> evar_map -> constr -> constr) ->
   goal sigma -> constr -> constr
+[@@ocaml.deprecated]
 val pf_e_reduce :
   (env -> evar_map -> constr -> evar_map * constr) ->
   goal sigma -> constr -> evar_map * constr
+[@@ocaml.deprecated]
 
 val pf_whd_all       : goal sigma -> constr -> constr
+[@@ocaml.deprecated]
 val pf_hnf_constr              : goal sigma -> constr -> constr
+[@@ocaml.deprecated]
 val pf_nf                      : goal sigma -> constr -> constr
+[@@ocaml.deprecated]
 val pf_nf_betaiota             : goal sigma -> constr -> constr
+[@@ocaml.deprecated]
 val pf_reduce_to_quantified_ind : goal sigma -> types -> (inductive * EInstance.t) * types
+[@@ocaml.deprecated]
 val pf_reduce_to_atomic_ind     : goal sigma -> types -> (inductive * EInstance.t) * types
+[@@ocaml.deprecated]
 val pf_compute                 : goal sigma -> constr -> constr
+[@@ocaml.deprecated]
 val pf_unfoldn    : (occurrences * evaluable_global_reference) list
   -> goal sigma -> constr -> constr
+[@@ocaml.deprecated]
 
 val pf_const_value : goal sigma -> pconstant -> constr
+[@@ocaml.deprecated]
 val pf_conv_x      : goal sigma -> constr -> constr -> bool
+[@@ocaml.deprecated]
 val pf_conv_x_leq  : goal sigma -> constr -> constr -> bool
+[@@ocaml.deprecated]
 
 val pf_matches     : goal sigma -> constr_pattern -> constr -> patvar_map
+[@@ocaml.deprecated]
 val pf_is_matching : goal sigma -> constr_pattern -> constr -> bool
+[@@ocaml.deprecated]
 
 
 (** {6 The most primitive tactics. } *)
 
 val refiner                   : rule -> tactic
+[@@ocaml.deprecated]
 val internal_cut_no_check     : bool -> Id.t -> types -> tactic
+[@@ocaml.deprecated]
 val refine_no_check           : constr -> tactic
+[@@ocaml.deprecated]
 
 (** {6 The most primitive tactics with consistency and type checking } *)
 
 val internal_cut     : bool -> Id.t -> types -> tactic
+[@@ocaml.deprecated]
 val internal_cut_rev : bool -> Id.t -> types -> tactic
+[@@ocaml.deprecated]
 val refine           : constr -> tactic
+[@@ocaml.deprecated]
 
 (** {6 Pretty-printing functions (debug only). } *)
 val pr_gls    : goal sigma -> Pp.std_ppcmds
+[@@ocaml.deprecated]
 val pr_glls   : goal list sigma -> Pp.std_ppcmds
+[@@ocaml.deprecated]
 
 (* Variants of [Tacmach] functions built with the new proof engine *)
 module New : sig

--- a/proofs/tacmach.mli
+++ b/proofs/tacmach.mli
@@ -16,6 +16,9 @@ open Redexpr
 open Pattern
 open Locus
 
+(** Deactivate deprecated warning *)
+[@@@ocaml.warning "-3"]
+
 (** Operations for handling terms under a local typing context. *)
 
 type 'a sigma   = 'a Evd.sigma

--- a/proofs/tacmach.mli
+++ b/proofs/tacmach.mli
@@ -129,7 +129,7 @@ val refiner                   : rule -> tactic
 val internal_cut_no_check     : bool -> Id.t -> types -> tactic
 [@@ocaml.deprecated]
 val refine_no_check           : constr -> tactic
-[@@ocaml.deprecated]
+[@@ocaml.deprecated "See dev/doc/proof-engine.md."]
 
 (** {6 The most primitive tactics with consistency and type checking } *)
 
@@ -138,7 +138,7 @@ val internal_cut     : bool -> Id.t -> types -> tactic
 val internal_cut_rev : bool -> Id.t -> types -> tactic
 [@@ocaml.deprecated]
 val refine           : constr -> tactic
-[@@ocaml.deprecated]
+[@@ocaml.deprecated "See dev/doc/proof-engine.md."]
 
 (** {6 Pretty-printing functions (debug only). } *)
 val pr_gls    : goal sigma -> Pp.std_ppcmds

--- a/tactics/auto.ml
+++ b/tactics/auto.ml
@@ -21,6 +21,9 @@ open Locus
 open Proofview.Notations
 open Hints
 
+(** Deactivate deprecated warning *)
+[@@@ocaml.warning "-3"]
+
 (**************************************************************************)
 (*                           Automatic tactics                            *)
 (**************************************************************************)

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -619,6 +619,9 @@ let make_hints g st only_classes sign =
 (** <= 8.5 resolution *)
 module V85 = struct
 
+  (** Deactivate deprecated warning *)
+  [@@@ocaml.warning "-3"]
+
   type autoinfo = { hints : hint_db; is_evar: existential_key option;
                     only_classes: bool; unique : bool;
                     auto_depth: int list; auto_last_tac: std_ppcmds Lazy.t;

--- a/tactics/eauto.ml
+++ b/tactics/eauto.ml
@@ -442,7 +442,7 @@ let autounfolds db occs cls gl =
     in
     let (ids, csts) = Hint_db.unfolds db in
     let hyps = pf_ids_of_hyps gl in
-    let ids = Idset.filter (fun id -> List.mem id hyps) ids in
+    let ids = Id.Set.filter (fun id -> List.mem id hyps) ids in
       Cset.fold (fun cst -> cons (AllOccurrences, EvalConstRef cst)) csts
 	(Id.Set.fold (fun id -> cons (AllOccurrences, EvalVarRef id)) ids [])) db)
   in Proofview.V82.of_tactic (unfold_option unfolds cls) gl

--- a/tactics/eauto.ml
+++ b/tactics/eauto.ml
@@ -27,6 +27,9 @@ open Locusops
 open Hints
 open Proofview.Notations
 
+(** Deactivate deprecated warning *)
+[@@@ocaml.warning "-3"]
+
 let eauto_unif_flags = auto_flags_of_state full_transparent_state
 
 let e_give_exact ?(flags=eauto_unif_flags) c =

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -364,16 +364,16 @@ let find_elim hdcncl lft2rgt dep cls ot gl =
         | Some true, None
         | Some false, Some _ ->
 	  let c1 = destConstRef pr1 in 
-	  let mp,dp,l = repr_con (constant_of_kn (canonical_con c1)) in 
+	  let mp,dp,l = Constant.repr3 (Constant.make1 (Constant.canonical c1)) in 
 	  let l' = Label.of_id (add_suffix (Label.to_id l) "_r")  in 
-	  let c1' = Global.constant_of_delta_kn (make_kn mp dp l') in
+	  let c1' = Global.constant_of_delta_kn (KerName.make mp dp l') in
 	  begin 
 	    try 
 	      let _ = Global.lookup_constant c1' in
 		c1'
 	    with Not_found -> 
 	      user_err ~hdr:"Equality.find_elim"
-                (str "Cannot find rewrite principle " ++ pr_label l' ++ str ".")
+                (str "Cannot find rewrite principle " ++ Label.print l' ++ str ".")
 	  end
 	| _ -> destConstRef pr1
         end

--- a/tactics/tacticals.ml
+++ b/tactics/tacticals.ml
@@ -20,6 +20,10 @@ open Tactypes
 
 module NamedDecl = Context.Named.Declaration
 
+(** Deactivate deprecated warning. TODO: move deprecated code to a proper
+    module, and move this attribute inside. *)
+[@@@ocaml.warning "-3"]
+
 (************************************************************************)
 (* Tacticals re-exported from the Refiner module                        *)
 (************************************************************************)

--- a/tactics/tacticals.ml
+++ b/tactics/tacticals.ml
@@ -626,8 +626,8 @@ module New = struct
       | _ ->
 	  let name_elim =
 	    match EConstr.kind sigma elim with
-	    | Const (kn, _) -> string_of_con kn
-	    | Var id -> string_of_id id
+	    | Const (kn, _) -> Constant.to_string kn
+	    | Var id -> Id.to_string id
 	    | _ -> "\b"
 	  in
 	  user_err ~hdr:"Tacticals.general_elim_then_using"

--- a/tactics/tacticals.mli
+++ b/tactics/tacticals.mli
@@ -16,6 +16,10 @@ open Locus
 open Misctypes
 open Tactypes
 
+(** Deactivate deprecated warning. TODO: move deprecated code to a proper
+    module, and move this attribute inside. *)
+[@@@ocaml.warning "-3"]
+
 (** Tacticals i.e. functions from tactics to tactics. *)
 
 val tclIDTAC         : tactic

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -912,14 +912,14 @@ let unfold_constr = function
    iteration of [find_name] above. As [default_id] checks the sort of
    the type to build hyp names, we maintain an environment to be able
    to type dependent hyps. *)
-let find_intro_names ctxt gl =
+let find_intro_names env sigma ctxt =
   let _, res = List.fold_right
     (fun decl acc ->
       let env,idl = acc in
-      let name = fresh_id idl (default_id env gl.sigma decl) gl in
+      let name = fresh_id_in_env idl (default_id env sigma decl) env in
       let newenv = push_rel decl env in
       (newenv,(name::idl)))
-    ctxt (pf_env gl , []) in
+    ctxt (env, []) in
   List.rev res
 
 let build_intro_tac id dest tac = match dest with

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -516,7 +516,7 @@ let mutual_fix f n rest j = Proofview.Goal.enter begin fun gl ->
   | (f, n, ar) :: oth ->
     let open Context.Named.Declaration in
     let (sp', u')  = check_mutind env sigma n ar in
-    if not (eq_mind sp sp') then
+    if not (MutInd.equal sp sp') then
       error "Fixpoints should be on the same mutual inductive declaration.";
     if mem_named_context_val f sign then
       user_err ~hdr:"Logic.prim_refiner"
@@ -1329,7 +1329,7 @@ let enforce_prop_bound_names rename tac =
                 (* "very_standard" says that we should have "H" names only, but
                    this would break compatibility even more... *)
                 let s = match Namegen.head_name sigma t with
-                  | Some id when not very_standard -> string_of_id id
+                  | Some id when not very_standard -> Id.to_string id
                   | _ -> "" in
                 Name (add_suffix Namegen.default_prop_ident s)
               else

--- a/tactics/tactics.mli
+++ b/tactics/tactics.mli
@@ -51,7 +51,7 @@ val convert_leq     : constr -> constr -> unit Proofview.tactic
 
 val fresh_id_in_env : Id.t list -> Id.t -> env -> Id.t
 val fresh_id : Id.t list -> Id.t -> goal sigma -> Id.t
-val find_intro_names : rel_context -> goal sigma -> Id.t list
+val find_intro_names : env -> evar_map -> rel_context -> Id.t list
 
 val intro                : unit Proofview.tactic
 val introf               : unit Proofview.tactic

--- a/vernac/assumptions.ml
+++ b/vernac/assumptions.ml
@@ -89,7 +89,7 @@ and fields_of_mp mp =
   let mb = lookup_module_in_impl mp in
   let fields,inner_mp,subs = fields_of_mb empty_subst mb [] in
   let subs =
-    if mp_eq inner_mp mp then subs
+    if ModPath.equal inner_mp mp then subs
     else add_mp inner_mp mp mb.mod_delta subs
   in
   Modops.subst_structure subs fields
@@ -118,7 +118,7 @@ and fields_of_expression x = fields_of_functor fields_of_expr x
 
 let lookup_constant_in_impl cst fallback =
   try
-    let mp,dp,lab = repr_kn (canonical_con cst) in
+    let mp,dp,lab = KerName.repr (Constant.canonical cst) in
     let fields = memoize_fields_of_mp mp in
     (* A module found this way is necessarily closed, in particular
        our constant cannot be in an opened section : *)
@@ -131,7 +131,7 @@ let lookup_constant_in_impl cst fallback =
        - The label has not been found in the structure. This is an error *)
     match fallback with
       | Some cb -> cb
-      | None -> anomaly (str "Print Assumption: unknown constant " ++ pr_con cst ++ str ".")
+      | None -> anomaly (str "Print Assumption: unknown constant " ++ Constant.print cst ++ str ".")
 
 let lookup_constant cst =
   try
@@ -142,7 +142,7 @@ let lookup_constant cst =
 
 let lookup_mind_in_impl mind =
   try
-    let mp,dp,lab = repr_kn (canonical_mind mind) in
+    let mp,dp,lab = KerName.repr (MutInd.canonical mind) in
     let fields = memoize_fields_of_mp mp in
       search_mind_label lab fields
   with Not_found ->
@@ -156,9 +156,9 @@ let lookup_mind mind =
     traversed objects *)
 
 let label_of = function
-  | ConstRef kn -> pi3 (repr_con kn)
+  | ConstRef kn -> pi3 (Constant.repr3 kn)
   | IndRef (kn,_)
-  | ConstructRef ((kn,_),_) -> pi3 (repr_mind kn)
+  | ConstructRef ((kn,_),_) -> pi3 (MutInd.repr3 kn)
   | VarRef id -> Label.of_id id
 
 let fold_constr_with_full_binders g f n acc c =

--- a/vernac/auto_ind_decl.ml
+++ b/vernac/auto_ind_decl.ml
@@ -181,7 +181,7 @@ let build_beq_scheme mode kn =
 	match EConstr.kind sigma c with
         | Rel x -> mkRel (x-nlist+ndx), Safe_typing.empty_private_constants
         | Var x ->
-          let eid = id_of_string ("eq_"^(string_of_id x)) in
+          let eid = Id.of_string ("eq_"^(Id.to_string x)) in
           let () =
             try ignore (Environ.lookup_named eid env)
             with Not_found -> raise (ParameterWithoutEquality (VarRef x))
@@ -190,7 +190,7 @@ let build_beq_scheme mode kn =
         | Cast (x,_,_) -> aux (EConstr.applist (x,a))
         | App _ -> assert false
         | Ind ((kn',i as ind'),u) (*FIXME: universes *) -> 
-            if eq_mind kn kn' then mkRel(eqA-nlist-i+nb_ind-1), Safe_typing.empty_private_constants
+            if MutInd.equal kn kn' then mkRel(eqA-nlist-i+nb_ind-1), Safe_typing.empty_private_constants
             else begin
               try
                 let eq, eff =
@@ -358,8 +358,8 @@ let do_replace_lb mode lb_scheme_key aavoid narg p q =
       (* if this happen then the args have to be already declared as a
               Parameter*)
       (
-        let mp,dir,lbl = repr_con (fst (destConst sigma v)) in
-          mkConst (make_con mp dir (mk_label (
+        let mp,dir,lbl = Constant.repr3 (fst (destConst sigma v)) in
+          mkConst (Constant.make3 mp dir (Label.make (
           if Int.equal offset 1 then ("eq_"^(Label.to_string lbl))
                        else ((Label.to_string lbl)^"_lb")
         )))
@@ -419,8 +419,8 @@ let do_replace_bl mode bl_scheme_key (ind,u as indu) aavoid narg lft rgt =
       (* if this happen then the args have to be already declared as a
          Parameter*)
       (
-        let mp,dir,lbl = repr_con (fst (destConst sigma v)) in
-          mkConst (make_con mp dir (mk_label (
+        let mp,dir,lbl = Constant.repr3 (fst (destConst sigma v)) in
+          mkConst (Constant.make3 mp dir (Label.make (
           if Int.equal offset 1 then ("eq_"^(Label.to_string lbl))
                        else ((Label.to_string lbl)^"_bl")
         )))
@@ -495,7 +495,7 @@ let do_replace_bl mode bl_scheme_key (ind,u as indu) aavoid narg lft rgt =
         with DestKO -> Tacticals.New.tclZEROMSG (str "The expected type is an inductive one.")
       end
   end >>= fun (sp2,i2) ->
-  if not (eq_mind sp1 sp2) || not (Int.equal i1 i2)
+  if not (MutInd.equal sp1 sp2) || not (Int.equal i1 i2)
   then Tacticals.New.tclZEROMSG (str "Eq should be on the same type")
   else aux (Array.to_list ca1) (Array.to_list ca2)
 
@@ -522,7 +522,7 @@ let eqI ind l =
   and e, eff = 
     try let c, eff = find_scheme beq_scheme_kind ind in mkConst c, eff 
     with Not_found -> user_err ~hdr:"AutoIndDecl.eqI"
-      (str "The boolean equality on " ++ pr_mind (fst ind) ++ str " is needed.");
+      (str "The boolean equality on " ++ MutInd.print (fst ind) ++ str " is needed.");
   in (if Array.equal Term.eq_constr eA [||] then e else mkApp(e,eA)), eff
 
 (**********************************************************************)

--- a/vernac/class.ml
+++ b/vernac/class.ml
@@ -173,8 +173,8 @@ let get_strength stre ref cls clt =
 let ident_key_of_class = function
   | CL_FUN -> "Funclass"
   | CL_SORT -> "Sortclass"
-  | CL_CONST sp | CL_PROJ sp -> Label.to_string (con_label sp)
-  | CL_IND (sp,_) -> Label.to_string (mind_label sp)
+  | CL_CONST sp | CL_PROJ sp -> Label.to_string (Constant.label sp)
+  | CL_IND (sp,_) -> Label.to_string (MutInd.label sp)
   | CL_SECVAR id -> Id.to_string id
 
 (* Identity coercion *)

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -98,7 +98,7 @@ let type_ctx_instance evars env ctx inst subst =
 
 let id_of_class cl =
   match cl.cl_impl with
-    | ConstRef kn -> let _,_,l = repr_con kn in Label.to_id l
+    | ConstRef kn -> let _,_,l = Constant.repr3 kn in Label.to_id l
     | IndRef (kn,i) ->
 	let mip = (Environ.lookup_mind kn (Global.env ())).Declarations.mind_packets in
 	  mip.(0).Declarations.mind_typename

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -913,11 +913,11 @@ let explain_not_match_error = function
       quote (Univ.pr_constraints (Termops.pr_evd_level Evd.empty) cst)
 
 let explain_signature_mismatch l spec why =
-  str "Signature components for label " ++ pr_label l ++
+  str "Signature components for label " ++ Label.print l ++
   str " do not match:" ++ spc () ++ explain_not_match_error why ++ str "."
 
 let explain_label_already_declared l =
-  str "The label " ++ pr_label l ++ str " is already declared."
+  str "The label " ++ Label.print l ++ str " is already declared."
 
 let explain_application_to_not_path _ =
   strbrk "A module cannot be applied to another module application or " ++
@@ -947,11 +947,11 @@ let explain_not_equal_module_paths mp1 mp2 =
   str "Non equal modules."
 
 let explain_no_such_label l =
-  str "No such label " ++ pr_label l ++ str "."
+  str "No such label " ++ Label.print l ++ str "."
 
 let explain_incompatible_labels l l' =
   str "Opening and closing labels are not the same: " ++
-  pr_label l ++ str " <> " ++ pr_label l' ++ str "!"
+  Label.print l ++ str " <> " ++ Label.print l' ++ str "!"
 
 let explain_not_a_module s =
   quote (str s) ++ str " is not a module."
@@ -960,19 +960,19 @@ let explain_not_a_module_type s =
   quote (str s) ++ str " is not a module type."
 
 let explain_not_a_constant l =
-  quote (pr_label l) ++ str " is not a constant."
+  quote (Label.print l) ++ str " is not a constant."
 
 let explain_incorrect_label_constraint l =
   str "Incorrect constraint for label " ++
-  quote (pr_label l) ++ str "."
+  quote (Label.print l) ++ str "."
 
 let explain_generative_module_expected l =
-  str "The module " ++ pr_label l ++ str " is not generative." ++
+  str "The module " ++ Label.print l ++ str " is not generative." ++
   strbrk " Only components of generative modules can be changed" ++
   strbrk " using the \"with\" construct."
 
 let explain_label_missing l s =
-  str "The field " ++ pr_label l ++ str " is missing in "
+  str "The field " ++ Label.print l ++ str " is missing in "
   ++ str s ++ str "."
 
 let explain_include_restricted_functor mp =

--- a/vernac/indschemes.ml
+++ b/vernac/indschemes.ml
@@ -409,7 +409,7 @@ let do_mutual_induction_scheme lnamedepindsort =
 let get_common_underlying_mutual_inductive = function
   | [] -> assert false
   | (id,(mind,i as ind))::l as all ->
-      match List.filter (fun (_,(mind',_)) -> not (eq_mind mind mind')) l with
+      match List.filter (fun (_,(mind',_)) -> not (MutInd.equal mind mind')) l with
       | (_,ind')::_ ->
 	  raise (RecursionSchemeError (NotMutualInScheme (ind,ind')))
       | [] ->

--- a/vernac/lemmas.ml
+++ b/vernac/lemmas.ml
@@ -117,7 +117,7 @@ let find_mutually_recursive_statements thms =
             [] in
       ind_hyps,ind_ccl) thms in
     let inds_hyps,ind_ccls = List.split inds in
-    let of_same_mutind ((kn,_),_,_) = function ((kn',_),_,_) -> eq_mind kn kn' in
+    let of_same_mutind ((kn,_),_,_) = function ((kn',_),_,_) -> MutInd.equal kn kn' in
     (* Check if all conclusions are coinductive in the same type *)
     (* (degenerated cartesian product since there is at most one coind ccl) *)
     let same_indccl =
@@ -505,7 +505,7 @@ let save_proof ?proof = function
                   let env = Global.env () in
                   let ids_typ = Environ.global_vars_set env typ in
                   let ids_def = Environ.global_vars_set env pproof in
-                  Some (Environ.keep_hyps env (Idset.union ids_typ ids_def))
+                  Some (Environ.keep_hyps env (Id.Set.union ids_typ ids_def))
               | _ -> None in
 	    let names = Proof_global.get_universe_binders () in
             let evd = Evd.from_ctx universes in

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -251,7 +251,7 @@ let print_namespace ns =
   let print_list pr l = prlist_with_sep (fun () -> str".") pr l in
   let print_kn kn =
     (* spiwack: I'm ignoring the dirpath, is that bad? *)
-    let (mp,_,lbl) = Names.repr_kn kn in
+    let (mp,_,lbl) = Names.KerName.repr kn in
     let qn = (qualified_minus (List.length ns) mp)@[Names.Label.to_id lbl] in
     print_list pr_id qn
   in
@@ -266,8 +266,8 @@ let print_namespace ns =
   let constants = (Environ.pre_env (Global.env ())).Pre_env.env_globals.Pre_env.env_constants in
   let constants_in_namespace =
     Cmap_env.fold (fun c (body,_) acc ->
-      let kn = user_con c in
-      if matches (modpath kn) then
+      let kn = Constant.user c in
+      if matches (KerName.modpath kn) then
         acc++fnl()++hov 2 (print_constant kn body)
       else
         acc


### PR DESCRIPTION
This branch leverages the OCaml 4.02 attribute mechanism in order to output deprecated warnings. The immediate observation following this is that there is a lot of tidying work left... In order not to produce too many false positives, I deactivated the deprecation warning in legacy files.

In a subsequent PR we'll eliminate trivial deprecation warnings, e.g. by replacing all old Names definitions.