### PR TITLE
Run non-tactic comands without resilient_command

### DIFF
--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -2136,10 +2136,13 @@ let known_state ?(redefine_qed=false) ~cache id =
 	    if eff then update_global_env ()
           ), (if eff then `Yes else cache), true
       | `Cmd { cast = x; ceff = eff } -> (fun () ->
-            resilient_command reach view.next;
-            vernac_interp id x;
-	    if eff then update_global_env ()
-          ), (if eff then `Yes else cache), true
+          (match !Flags.async_proofs_mode with
+           | Flags.APon | Flags.APonLazy ->
+             resilient_command reach view.next
+           | Flags.APoff -> reach view.next);
+          vernac_interp id x;
+          if eff then update_global_env ()
+        ), (if eff then `Yes else cache), true
       | `Fork ((x,_,_,_), None) -> (fun () ->
             resilient_command reach view.next;
             vernac_interp id x;

--- a/test-suite/output/ErrorInModule.out
+++ b/test-suite/output/ErrorInModule.out
@@ -1,0 +1,2 @@
+File "stdin", line 3, characters 20-31:
+Error: The reference nonexistent was not found in the current environment.

--- a/test-suite/output/ErrorInModule.v
+++ b/test-suite/output/ErrorInModule.v
@@ -1,0 +1,4 @@
+(* -*- mode: coq; coq-prog-args: ("-emacs" "-quick") -*- *)
+Module M.
+  Definition foo := nonexistent.
+End M.

--- a/test-suite/output/ErrorInSection.out
+++ b/test-suite/output/ErrorInSection.out
@@ -1,0 +1,2 @@
+File "stdin", line 3, characters 20-31:
+Error: The reference nonexistent was not found in the current environment.

--- a/test-suite/output/ErrorInSection.v
+++ b/test-suite/output/ErrorInSection.v
@@ -1,0 +1,4 @@
+(* -*- mode: coq; coq-prog-args: ("-emacs" "-quick") -*- *)
+Section S.
+  Definition foo := nonexistent.
+End S.


### PR DESCRIPTION
This is an attempt to fix #5385.