### PR TITLE
Fix #5132: coq_makefile generates incorrect install goal 

### DIFF
--- a/tools/coq_makefile.ml
+++ b/tools/coq_makefile.ml
@@ -676,6 +676,7 @@ let main_targets vfiles (mlifiles,ml4files,mlfiles,mllibfiles,mlpackfiles) other
       print "VO=vo\n";
       print "VOFILES:=$(VFILES:.v=.$(VO))\n";
       classify_files_by_root "VOFILES" l inc;
+      classify_files_by_root "VFILES" l inc;
       print "GLOBFILES:=$(VFILES:.v=.glob)\n";
       print "GFILES:=$(VFILES:.v=.g)\n";
       print "HTMLFILES:=$(VFILES:.v=.html)\n";


### PR DESCRIPTION
Fixes bug #5132 which prevents install of .v files via `make install` target. Here is an example of this problem manifestation: https://github.com/coq-ext-lib/coq-ext-lib/issues/29
