### PR TITLE
Increase travis wait for GeoCoq

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ env:
   - TEST_TARGET="ci-compcert"
   - TEST_TARGET="ci-coquelicot"
   - TEST_TARGET="ci-cpdt"
-  - TEST_TARGET="ci-geocoq"
+  - TEST_TARGET="ci-geocoq" TW="travis_wait"
   - TEST_TARGET="ci-fiat-crypto"
   - TEST_TARGET="ci-fiat-parsers"
   - TEST_TARGET="ci-flocq"

--- a/dev/ci/ci-geocoq.sh
+++ b/dev/ci/ci-geocoq.sh
@@ -11,6 +11,5 @@ git_checkout ${GeoCoq_CI_BRANCH} ${GeoCoq_CI_GITURL} GeoCoq
 
 ( cd GeoCoq                                               && \
   ./configure.sh                                          && \
-  sed -i.bak '/Ch16_coordinates_with_functions\.v/d' Make && \
   coq_makefile -f Make -o Makefile                        && \
   make -j ${NJOBS} )


### PR DESCRIPTION
Rather than not build the slow Ch16_coordinates_with_functions.v file,
increase the travis wait time (from 10 to 20 minutes). See
https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received.