### PR TITLE
Use Travis container-based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 dist: trusty
-sudo: required
+sudo: false
 # Until Ocaml becomes a language, we set a known one.
 language: c
 cache:


### PR DESCRIPTION
It doesn't look like the build needs sudo or setuid, so I'm not sure why it's
using the heavier-weight full VM infrastructure. The one difference I can see
is that `sudo: required` gets VMs with 7.5GB of RAM rather than 4GB (from
https://docs.travis-ci.com/user/ci-environment/#Virtualization-environments).