### PR TITLE
Adding support for coercing ltac variables to list of tactics where relevant

### DIFF
--- a/test-suite/success/ltac.v
+++ b/test-suite/success/ltac.v
@@ -170,6 +170,18 @@ intros.
 revert a b c H.
 Abort.
 
+Module A.
+
+Tactic Notation (at level 4) tactic4(tac) ";" "first" "[" tactic_list_sep(tacl,"|") "]" := tac ; first [ tacl ].
+Tactic Notation (at level 4) tactic4(tac) ";" "first" tactic3(tac') := tac; [ tac' | ..].
+Tactic Notation (at level 4) tactic4(tac) ";" "last" tactic3(tac') := tac; [ .. | tac'].
+
+Goal True.
+idtac; first [exact I].
+Qed.
+
+End A.
+
 (* Used to fail until revision 9280 because of a parasitic App node with
    empty args *)
 


### PR DESCRIPTION
This PR adds support for binding lists of tactics in` Tactic Notation`, which I think is useful until new tactic notation mechanisms are made available.

This small extension allows for instance to define a tactic notation such as:
```coq
Tactic Notation (at level 3) "myfirst" "[" tactic_list_sep(tacl,"|") "]" := first [ tacl ].
```
The feature is of general interest but, in particular, it allows to easily define the (nice and intuitive) `tac; first tac'` and `tac; last tac'` tacticals which can be found in ssreflect:
```coq
Tactic Notation (at level 4) tactic4(tac) ";" "first" "[" tactic_list_sep(tacl,"|") "]" :=
      tac ; first [ tacl ]. (* Needed to factorize the overlapping *)
Tactic Notation (at level 4) tactic4(tac) ";" "first" tactic3(tac') := tac; [ tac' | .. ].
Tactic Notation (at level 4) tactic4(tac) ";" "last" tactic3(tac') := tac; [ .. | tac'].
```
where the first line is unfortunately needed to manually factorize the overlap with the `first [ tac list ]` tactical.




