### PR TITLE
funind: Ignore missing info for current function

### DIFF
--- a/plugins/funind/functional_principles_proofs.ml
+++ b/plugins/funind/functional_principles_proofs.ml
@@ -1233,7 +1233,7 @@ let prove_princ_for_struct (evd:Evd.evar_map ref) interactive_proof fun_num fnam
 	    else
 	      Proofview.V82.of_tactic (Tactics.mutual_fix this_fix_info.name (this_fix_info.idx + 1)
 		other_fix_infos 0)
-	| _ -> anomaly (Pp.str "Not a valid information")
+	| _,[] -> tclIDTAC
     in
     let first_tac : tactic = (* every operations until fix creations *)
       tclTHENSEQ

--- a/test-suite/bugs/opened/5372.v
+++ b/test-suite/bugs/opened/5372.v
@@ -1,0 +1,7 @@
+(* coq bug 5372: https://coq.inria.fr/bugs/show_bug.cgi?id=5372 *)
+Function odd (n:nat) :=
+  match n with
+  | 0 => false
+  | S n => true
+  end
+with even (n:nat) := false.


### PR DESCRIPTION
Fixes [Coq bug \#5372](https://coq.inria.fr/bugs/show_bug.cgi?id=5372).

I have no idea if this is the right fix, and the funind plugin is too complicated for me to figure out. However, this anomaly only covers a case where there is some pre_info and no info. Extrapolating from the case where info is non-nil, `mk_fixes` would have created a mutual fix. Without something in info this is impossible. If there is no pre_info or info, then this code does nothing (returns `tclIDTAC`) (not sure how that's triggered...) but for some reason it had an anomaly if pre_info is non-nil, even though `pre_info` should be irrelevant without something in `this_fix_info`. My hypothesis is that this code doesn't correctly handle the case of non-mutually dependent fixpoints and this is a perfectly valid info for that case.

This is all speculation, but it would be great if someone who knows this code could either confirm this is a fix, provide a counter-example for better test coverage, or find some better way to handle mutual fixpoints without actual dependency.