### PR TITLE
A fix for #5390 (a useful error on used introduction names was masked).

### DIFF
--- a/COMPATIBILITY
+++ b/COMPATIBILITY
@@ -1,3 +1,10 @@
+Potential sources of incompatibilities between Coq V8.6 and V8.7
+----------------------------------------------------------------
+
+- Extra superfluous names in introduction patterns may now raise an
+  error rather than a warning when the superfluous name is already in
+  use. The easy fix is to remove the superfluous name.
+
 Potential sources of incompatibilities between Coq V8.5 and V8.6
 ----------------------------------------------------------------
 

--- a/test-suite/output/Tactics.out
+++ b/test-suite/output/Tactics.out
@@ -2,3 +2,7 @@ Ltac f H := split; [ a H | e H ]
 Ltac g := match goal with
           | |- context [ if ?X then _ else _ ] => case X
           end
+The command has indeed failed with message:
+H is already used.
+The command has indeed failed with message:
+H is already used.

--- a/test-suite/output/Tactics.v
+++ b/test-suite/output/Tactics.v
@@ -11,3 +11,13 @@ Print Ltac f.
 
 Ltac g := match goal with |- context [if ?X then _ else _ ] => case X end.
 Print Ltac g.
+
+(* Test an error message (#5390) *)
+Lemma myid (P : Prop) : P <-> P.
+Proof. split; auto. Qed.
+
+Goal True -> (True /\ True) -> True.
+Proof.
+intros H.
+Fail intros [H%myid ?].
+Fail destruct 1 as [H%myid ?].


### PR DESCRIPTION
Don't know if it worth a PR rather than a direct bug fix commit, but since it induced one change in contribs, and also because I suspect some interest in the general issue itself, I put it as a PR.

With the `apply in` introduction pattern, and the backtrack possibly done in `apply` over the components of conjunctions (`descend_in_conjunctions`), the reasons for failing might have
different sources.

We give priority to the detection of used names over other (unification) errors so that an error there is not masked in the backtracking made by `descend_in_conjunctions`.

Of course, the question of what best unification error to give in the presence of backtracking is still open.

The incompatibility in contribs is of the following form:
```coq
Goal forall n m, n+m=0.
intros n [n|m].
```
where, previously there were only a warning on `n` unused, and, now, there is an error on `n` occurring twice.