### PR TITLE
[travis] Use the lite target for fiat-crypto

### DIFF
--- a/dev/ci/ci-fiat-crypto.sh
+++ b/dev/ci/ci-fiat-crypto.sh
@@ -7,4 +7,4 @@ fiat_crypto_CI_DIR=${CI_BUILD_DIR}/fiat-crypto
 
 git_checkout ${fiat_crypto_CI_BRANCH} ${fiat_crypto_CI_GITURL} ${fiat_crypto_CI_DIR}
 
-( cd ${fiat_crypto_CI_DIR} && make -j ${NJOBS} )
+( cd ${fiat_crypto_CI_DIR} && make -j ${NJOBS} lite )


### PR DESCRIPTION
This improves build time for fiat-crypto, hopefully saving us from failure by timeout.

If #476 is merged, this may not be needed, as it seems to decrease the build time by a couple of minutes which could just work.