### PR TITLE
Some lemmas about dependent equality

### DIFF
--- a/theories/Init/Datatypes.v
+++ b/theories/Init/Datatypes.v
@@ -216,6 +216,14 @@ Definition prod_uncurry (A B C:Type) (f:A * B -> C)
 Definition prod_curry (A B C:Type) (f:A -> B -> C)
   (p:A * B) : C := match p with (x, y) => f x y end.
 
+Import EqNotations.
+
+Lemma rew_pair : forall A (P Q : A->Type) x1 x2 (y1:P x1) (y2:Q x1) (H:x1=x2),
+  (rew H in y1, rew H in y2) = rew [fun x => (P x * Q x)%type] H in (y1,y2).
+Proof.
+  destruct H. reflexivity.
+Defined.
+
 (** Polymorphic lists and some operations *)
 
 Inductive list (A : Type) : Type :=

--- a/theories/Init/Datatypes.v
+++ b/theories/Init/Datatypes.v
@@ -177,11 +177,12 @@ Arguments inr {A B} _ , A [B] _.
     the pair [pair A B a b] of [a] and [b] is abbreviated [(a,b)] *)
 
 Inductive prod (A B:Type) : Type :=
-  pair : A -> B -> prod A B.
+  pair : A -> B -> A * B
+
+where "x * y" := (prod x y) : type_scope.
 
 Add Printing Let prod.
 
-Notation "x * y" := (prod x y) : type_scope.
 Notation "( x , y , .. , z )" := (pair .. (pair x y) .. z) : core_scope.
 
 Arguments pair {A B} _ _.
@@ -189,18 +190,14 @@ Arguments pair {A B} _ _.
 Section projections.
   Context {A : Type} {B : Type}.
 
-  Definition fst (p:A * B) := match p with
-				| (x, y) => x
-                              end.
-  Definition snd (p:A * B) := match p with
-				| (x, y) => y
-                              end.
+  Definition fst (p:A * B) := match p with (x, y) => x end.
+  Definition snd (p:A * B) := match p with (x, y) => y end.
 End projections.
 
 Hint Resolve pair inl inr: core.
 
 Lemma surjective_pairing :
-  forall (A B:Type) (p:A * B), p = pair (fst p) (snd p).
+  forall (A B:Type) (p:A * B), p = (fst p, snd p).
 Proof.
   destruct p; reflexivity.
 Qed.
@@ -213,13 +210,11 @@ Proof.
   rewrite Hfst; rewrite Hsnd; reflexivity.
 Qed.
 
-Definition prod_uncurry (A B C:Type) (f:prod A B -> C)
-  (x:A) (y:B) : C := f (pair x y).
+Definition prod_uncurry (A B C:Type) (f:A * B -> C)
+  (x:A) (y:B) : C := f (x,y).
 
 Definition prod_curry (A B C:Type) (f:A -> B -> C)
-  (p:prod A B) : C := match p with
-                       | pair x y => f x y
-                       end.
+  (p:A * B) : C := match p with (x, y) => f x y end.
 
 (** Polymorphic lists and some operations *)
 
@@ -253,7 +248,6 @@ Definition app (A : Type) : list A -> list A -> list A :=
    | nil => m
    | a :: l1 => a :: app l1 m
   end.
-
 
 Infix "++" := app (right associativity, at level 60) : list_scope.
 

--- a/theories/Init/Logic.v
+++ b/theories/Init/Logic.v
@@ -406,6 +406,19 @@ End EqNotations.
 
 Import EqNotations.
 
+Section equality_dep.
+  Variable A : Type.
+  Variable B : A -> Type.
+  Variable f : forall x, B x.
+  Variables x y : A.
+
+  Theorem f_equal_dep : forall (H: x = y), rew H in f x = f y.
+  Proof.
+    destruct H; reflexivity.
+  Defined.
+
+End equality_dep.
+
 Lemma rew_opp_r : forall A (P:A->Type) (x y:A) (H:x=y) (a:P y), rew H in rew <- H in a = a.
 Proof.
 intros.

--- a/theories/Init/Logic.v
+++ b/theories/Init/Logic.v
@@ -419,6 +419,24 @@ Section equality_dep.
 
 End equality_dep.
 
+Section equality_dep2.
+
+  Variable A A' : Type.
+  Variable B : A -> Type.
+  Variable B' : A' -> Type.
+  Variable f : A -> A'.
+  Variable g : forall a:A, B a -> B' (f a).
+  Variables x y : A.
+
+  Lemma f_equal_dep2 : forall {A A' B B'} (f : A -> A') (g : forall a:A, B a -> B' (f a))
+  {x1 x2 : A} {y1 : B x1} {y2 : B x2} (H : x1 = x2),
+  rew H in y1 = y2 -> rew f_equal f H in g x1 y1 = g x2 y2.
+  Proof.
+    destruct H, 1. reflexivity.
+  Defined.
+
+End equality_dep2.
+
 Lemma rew_opp_r : forall A (P:A->Type) (x y:A) (H:x=y) (a:P y), rew H in rew <- H in a = a.
 Proof.
 intros.
@@ -503,6 +521,42 @@ Theorem eq_trans_assoc : forall A (x y z t:A) (e:x=y) (e':y=z) (e'':z=t),
   eq_trans e (eq_trans e' e'') = eq_trans (eq_trans e e') e''.
 Proof.
   destruct e''; reflexivity.
+Defined.
+
+Theorem rew_map : forall A B (P:B->Type) (f:A->B) x1 x2 (H:x1=x2) (y:P (f x1)),
+  rew [fun x => P (f x)] H in y = rew f_equal f H in y.
+Proof.
+  destruct H; reflexivity.
+Defined.
+
+Theorem eq_trans_map : forall {A B} {x1 x2 x3:A} {y1:B x1} {y2:B x2} {y3:B x3},
+  forall (H1:x1=x2) (H2:x2=x3) (H1': rew H1 in y1 = y2) (H2': rew H2 in y2 = y3),
+  rew eq_trans H1 H2 in y1 = y3.
+Proof.
+  intros. destruct H2. exact (eq_trans H1' H2').
+Defined.
+
+Lemma map_subst : forall {A} {P Q:A->Type} (f : forall x, P x -> Q x) {x y} (H:x=y) (z:P x),
+  rew H in f x z = f y (rew H in z).
+Proof.
+  destruct H. reflexivity.
+Defined.
+
+Lemma map_subst_map : forall {A B} {P:A->Type} {Q:B->Type} (f:A->B) (g : forall x, P x -> Q (f x)),
+  forall {x y} (H:x=y) (z:P x), rew f_equal f H in g x z = g y (rew H in z).
+Proof.
+  destruct H. reflexivity.
+Defined.
+
+Lemma rew_swap : forall A (P:A->Type) x1 x2 (H:x1=x2) (y1:P x1) (y2:P x2), rew H in y1 = y2 -> y1 = rew <- H in y2.
+Proof.
+  destruct H. trivial.
+Defined.
+
+Lemma rew_compose : forall A (P:A->Type) x1 x2 x3 (H1:x1=x2) (H2:x2=x3) (y:P x1),
+  rew H2 in rew H1 in y = rew (eq_trans H1 H2) in y.
+Proof.
+  destruct H2. reflexivity.
 Defined.
 
 (** Extra properties of equality *)


### PR DESCRIPTION
These are various basic lemmas about dependent equality which I needed at some time to work in HoTT.

Of course, this raises a few design issues.
- Some of the `init` library uses letters `a`, `a'` for objects in `A`, other parts use `x` and `y`. Looks like a uniformity is here vain. Any opinion about that?
- I'm dreaming of a standard notation for `existT _ x y`. In an ideal world (which I hope we are step by step preparing) `(x,y)` could just work, but currently, it is not. I know Jason has some notation for `existT`. I decided here to use `{{x,y}}` but, without exporting it, so that it is not too invasive, considering that it remains an unconventional notation.
- Implicit arguments: some existing theorems are missing useful implicit arguments so that they can be used as terms. Shall we give implicit arguments to the new lemmas, even if inconsistent with the existing usage, or not. (One more thing from which a revised library could benefit: better implicit arguments.)




