### PR TITLE
Make [proj1] and [proj2] transparent

### DIFF
--- a/theories/Init/Logic.v
+++ b/theories/Init/Logic.v
@@ -45,15 +45,13 @@ Section Conjunction.
 
   Variables A B : Prop.
 
-  Theorem proj1 : A /\ B -> A.
-  Proof.
-    destruct 1; trivial.
-  Qed.
+  Definition proj1 (p : A /\ B) : A := match p with
+                                       | conj a b => a
+				       end.
 
-  Theorem proj2 : A /\ B -> B.
-  Proof.
-    destruct 1; trivial.
-  Qed.
+  Definition proj2 (p : A /\ B) : B := match p with
+                                       | conj a b => b
+				       end.
 
 End Conjunction.
 


### PR DESCRIPTION
These are projections from an inductive datatype, and there is
essentially only one way to define them.  It's annoying to not be able
to use [proj1] and [proj2] when defining terms which take in
conjunctions and need to compute away.

(cc @herbelin @ppedrot )

(Requesting 8.7 inclusion)