### PR TITLE
Do so that "About" tells if a reference is a coercion.

### DIFF
--- a/printing/prettyp.ml
+++ b/printing/prettyp.ml
@@ -204,6 +204,11 @@ let print_opacity ref =
               str "transparent (with minimal expansion weight)"]
 
 (*******************)
+
+let print_if_is_coercion ref =
+  if Classops.coercion_exists ref then [pr_global ref ++ str " is a coercion"] else []
+
+(*******************)
 (* *)
 
 let print_polymorphism ref =
@@ -257,7 +262,8 @@ let print_name_infos ref =
   type_info_for_implicit @
   print_renames_list (mt()) renames @
   print_impargs_list (mt()) impls @
-  print_argument_scopes (mt()) scopes
+  print_argument_scopes (mt()) scopes @
+  print_if_is_coercion ref
 
 let print_id_args_data test pr id l =
   if List.exists test l then


### PR DESCRIPTION
This is a trivial PR but probably useful.
```coq
Coercion c := Some (A:=bool).
About c.
(*
Argument scope is [bool_scope]
c is a coercion
c is transparent
Expands to: Constant Top.c
*)

```