### PR TITLE
Add exception for invalid state id, handle it in ide_slave loop

### DIFF
--- a/ide/ide_slave.ml
+++ b/ide/ide_slave.ml
@@ -515,7 +515,10 @@ let loop () =
       | Xml_parser.Error (err, loc) ->
         pr_error ("XML syntax error: " ^ Xml_parser.error_msg err)
       | Stateid.Invalid_state_id id ->
-        pr_error ("Invalid state id: " ^ (string_of_int id))
+        let errmsg = "Invalid state id: " ^ (string_of_int id) ^ ", which likely indicates a bug in your Coq client."
+        in
+        pr_error errmsg;
+        Feedback.msg_error (strbrk errmsg)
       | Serialize.Marshal_error (msg,node) ->
         pr_error "Unexpected XML message";
         pr_error ("Expected XML node: " ^ msg);

--- a/ide/ide_slave.ml
+++ b/ide/ide_slave.ml
@@ -514,6 +514,8 @@ let loop () =
         exit 0
       | Xml_parser.Error (err, loc) ->
         pr_error ("XML syntax error: " ^ Xml_parser.error_msg err)
+      | Stateid.Invalid_state_id id ->
+        pr_error ("Invalid state id: " ^ (string_of_int id))
       | Serialize.Marshal_error (msg,node) ->
         pr_error "Unexpected XML message";
         pr_error ("Expected XML node: " ^ msg);

--- a/lib/stateid.ml
+++ b/lib/stateid.ml
@@ -7,6 +7,9 @@
 (************************************************************************)
 
 type t = int
+
+exception Invalid_state_id of int
+
 let initial = 1
 let dummy = 0
 let fresh, in_range =
@@ -16,7 +19,8 @@ let to_string = string_of_int
 let of_int id =
   (* Coqide too to parse ids too, but cannot check if they are valid.
    * Hence we check for validity only if we are an ide slave. *)
-  if !Flags.ide_slave then assert (in_range id);
+  if !Flags.ide_slave && not (in_range id) then 
+    raise (Invalid_state_id id);
   id
 let to_int id = id
 let newer_than id1 id2 = id1 > id2

--- a/lib/stateid.mli
+++ b/lib/stateid.mli
@@ -8,6 +8,8 @@
 
 type t
 
+exception Invalid_state_id of int
+  
 val equal : t -> t -> bool
 val compare : t -> t -> int
 


### PR DESCRIPTION
This is a possible solution to Bug 5101, where coqtop exits on an invalid state id in an `Add` call in the XML protocol.

The exit happens because an `assert` in `to_int` in lib/stateid.ml, where the state id is checked to be in the range of valid state ids.

The change here is to raise an exception indicating the invalid state id, and handle it in the ide_slave main loop. When caught, an error message is printed, as for the other exceptions in the `with` block.

This solution is not entirely satisfactory, since there's no XML `value` response. At least the user has a chance to interrupt Coq and go back to an earlier point in the script, where before Coq just died unexpectedly. There's a feedback sent, so the user knows there's something amiss.