### PR TITLE
Instances should obey universe binders even when defined by tactics.

### DIFF
--- a/test-suite/output/UnivBinders.out
+++ b/test-suite/output/UnivBinders.out
@@ -1,0 +1,6 @@
+bar@{u} = nat
+     : Wrap@{u} Set
+(* u |= Set < u
+         *)
+
+bar is universe polymorphic

--- a/test-suite/output/UnivBinders.v
+++ b/test-suite/output/UnivBinders.v
@@ -1,0 +1,7 @@
+Set Universe Polymorphism.
+Set Printing Universes.
+
+Class Wrap A := wrap : A.
+
+Instance bar@{u} : Wrap@{u} Set. Proof nat.
+Print bar.

--- a/test-suite/success/univnames.v
+++ b/test-suite/success/univnames.v
@@ -21,6 +21,17 @@ Inductive bla@{l k} : Type@{k} := blaI : Type@{l} -> bla.
 Inductive blacopy@{k l} : Type@{k} := blacopyI : Type@{l} -> blacopy.
 
 
+Class Wrap A := wrap : A.
+
+Fail Instance bad@{} : Wrap Type := Type.
+
+Instance bad@{} : Wrap Type.
+Fail Proof Type.
+Abort.
+
+Instance bar@{u} : Wrap@{u} Set. Proof nat.
+
+
 Monomorphic Universe g.
 
 Inductive blacopy'@{l} : Type@{g} := blacopy'I : Type@{l} -> blacopy'.

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -334,7 +334,7 @@ let new_instance ?(abstract=false) ?(global=false) ?(refine= !refine_instance) p
                      the refinement manually.*)
 		let gls = List.rev (Evd.future_goals evm) in
                 let evm = Evd.reset_future_goals evm in
-                Lemmas.start_proof id kind evm termtype
+                Lemmas.start_proof id ?pl kind evm termtype
 		(Lemmas.mk_hook
                   (fun _ -> instance_hook k pri global imps ?hook));
                  (* spiwack: I don't know what to do with the status here. *)


### PR DESCRIPTION
Before this commit, the output test prints `bar@{UnivBinders.4}` (etc) and 
``` coq
Instance bad@{} : Wrap Type.
Proof Type.
```
doesn't fail.

I expect some developments didn't notice that their instance universe binders were lying and will now fail, unless I'm the only one to use them ;). Travis will tell.