### PR TITLE
[stm] Make newtip mandatory on Stm.add

### DIFF
--- a/ide/coqOps.ml
+++ b/ide/coqOps.ml
@@ -497,8 +497,11 @@ object(self)
           else if Doc.is_empty document then ()
           else
             try
+              (* Warning, this is specific to the sid generation
+                 strategy of ide_slave *)
+              let st_newer s1 s2 = Stateid.(to_int s1 > to_int s2) in
               match id, Doc.tip document with
-              | id1, id2 when Stateid.newer_than id2 id1 -> ()
+              | id1, id2 when st_newer id2 id1 -> ()
               | _ -> Queue.add msg feedbacks
             with Doc.Empty | Invalid_argument _ -> Queue.add msg feedbacks 
       end;

--- a/lib/stateid.ml
+++ b/lib/stateid.ml
@@ -9,21 +9,13 @@
 type t = int
 let initial = 1
 let dummy = 0
-let fresh, in_range =
-  let cur = ref initial in
-  (fun () -> incr cur; !cur), (fun id -> id >= 0 && id <= !cur)
 let to_string = string_of_int
-let of_int id =
-  (* Coqide too to parse ids too, but cannot check if they are valid.
-   * Hence we check for validity only if we are an ide slave. *)
-  if !Flags.ide_slave then assert (in_range id);
-  id
+let of_int id = id
 let to_int id = id
 let newer_than id1 id2 = id1 > id2
 
 let state_id_info : (t * t) Exninfo.t = Exninfo.make ()
-let add exn ~valid id =
-  Exninfo.add exn state_id_info (valid, id)
+let add exn ~valid id = Exninfo.add exn state_id_info (valid, id)
 let get exn = Exninfo.get exn state_id_info
 
 let equal = Int.equal

--- a/lib/stateid.mli
+++ b/lib/stateid.mli
@@ -16,13 +16,10 @@ module Set : Set.S with type elt = t and type t = Set.Make(Self).t
 
 val initial : t
 val dummy : t
-val fresh : unit -> t
 val to_string : t -> string
 
 val of_int : int -> t
 val to_int : t -> int
-
-val newer_than : t -> t -> bool
 
 (* Attaches to an exception the concerned state id, plus an optional
  * state id that is a valid state id before the error.

--- a/stm/stm.mli
+++ b/stm/stm.mli
@@ -23,15 +23,14 @@ val parse_sentence : Stateid.t -> Pcoq.Gram.coq_parsable ->
 
 exception End_of_input
 
-(* [add ~ontop ?newtip verbose cmd] adds a new command [cmd] ontop of
-   the state [ontop].
+(* [add ?verbose ~ontop ~newtip cmd] adds a new command [cmd] ontop of
+   the state [ontop] with stateid [newtip].
    The [ontop] parameter just asserts that the GUI is on
    sync, but it will eventually call edit_at on the fly if needed.
-   If [newtip] is provided, then the returned state id is guaranteed
-   to be [newtip] *)
-val add : ontop:Stateid.t -> ?newtip:Stateid.t ->
-  bool -> Vernacexpr.vernac_expr Loc.located ->
-  Stateid.t * [ `NewTip | `Unfocus of Stateid.t ]
+*)
+val add : ?verbose:bool -> ontop:Stateid.t -> newtip:Stateid.t ->
+  Vernacexpr.vernac_expr Loc.located ->
+  [ `NewTip | `Unfocus of Stateid.t ]
 
 (* [query at ?report_with cmd] Executes [cmd] at a given state [at],
    throwing away side effects except messages. Feedback will

--- a/toplevel/vernac.ml
+++ b/toplevel/vernac.ml
@@ -116,10 +116,12 @@ let rec interp_vernac sid po (loc,com) =
         load_vernac verbosely sid f
     | v ->
       try
-        let nsid, ntip = Stm.add sid (Flags.is_verbose()) (loc,v) in
+        let newtip = Stateid.(of_int (to_int sid + 1)) in
+        let verbose = Flags.is_verbose () in
+        let focus_st = Stm.add ~verbose ~ontop:sid ~newtip (loc,v) in
 
         (* Main STM interaction *)
-        if ntip <> `NewTip then
+        if focus_st <> `NewTip then
           anomaly (str "vernac.ml: We got an unfocus operation on the toplevel!");
         (* Due to bug #5363 we cannot use observe here as we should,
            it otherwise reveals bugs *)
@@ -132,7 +134,7 @@ let rec interp_vernac sid po (loc,com) =
                          not (Proof_global.there_are_pending_proofs ()) in
 
         if not hide_goals then Feedback.msg_notice (pr_open_cur_subgoals ());
-        nsid
+        newtip
 
       with exn when CErrors.noncritical exn ->
         ignore(Stm.edit_at sid);


### PR DESCRIPTION
We force STM clients to pick the new state in documents. It is their responsibility for the states to be unique. This has significant advantages for IDE clients, as they don't have to wait now.

It also cleanups a bit of code and avoids some weird errors (cf #527, #5101).

Note that the stm still generates internal states in some cases, however, we clean up that part a by ensuring that all the private states are negative, so IDEs can detect when feedback for an internal state is generated.

The XML part of the protocol is not yet implemented, will be rolled with the general version update there.

**Note** this depends on #441, and superseedes #527. Some amount of testing with CoqIDE / PG XML would be welcome.