### PR TITLE
[toplevel] Remove exception error printer in favor of feedback printer.

### DIFF
--- a/lib/pp.ml
+++ b/lib/pp.ml
@@ -116,25 +116,6 @@ let strbrk s =
     else if p = n then [] else [str (String.sub s p (n-p))]
   in Ppcmd_glue (aux 0 0)
 
-let pr_loc_pos loc =
-  if Loc.is_ghost loc then (str"<unknown>")
-  else
-    let loc = Loc.unloc loc in
-    int (fst loc) ++ str"-" ++ int (snd loc)
-
-let pr_loc loc =
-  if Loc.is_ghost loc then str"<unknown>" ++ fnl ()
-  else
-    let fname = loc.Loc.fname in
-    if CString.equal fname "" then
-      Loc.(str"Toplevel input, characters " ++ int loc.bp ++
-	   str"-" ++ int loc.ep ++ str":" ++ fnl ())
-    else
-      Loc.(str"File " ++ str "\"" ++ str fname ++ str "\"" ++
-	   str", line " ++ int loc.line_nb ++ str", characters " ++
-	   int (loc.bp-loc.bol_pos) ++ str"-" ++ int (loc.ep-loc.bol_pos) ++
-	   str":" ++ fnl())
-
 let ismt = function | Ppcmd_empty -> true | _ -> false
 
 (* boxing commands *)

--- a/lib/pp.mli
+++ b/lib/pp.mli
@@ -171,7 +171,6 @@ val surround : std_ppcmds -> std_ppcmds
 (** Surround with parenthesis. *)
 
 val pr_vertical_list : ('b -> std_ppcmds) -> 'b list -> std_ppcmds
-val pr_loc : Loc.t -> std_ppcmds
 
 (** {6 Main renderers, to formatter and to string } *)
 

--- a/test-suite/output/ErrorInModule.out
+++ b/test-suite/output/ErrorInModule.out
@@ -1,2 +1,3 @@
 File "stdin", line 3, characters 20-31:
 Error: The reference nonexistent was not found in the current environment.
+

--- a/test-suite/output/ErrorInSection.out
+++ b/test-suite/output/ErrorInSection.out
@@ -1,2 +1,3 @@
 File "stdin", line 3, characters 20-31:
 Error: The reference nonexistent was not found in the current environment.
+

--- a/test-suite/output/qualification.out
+++ b/test-suite/output/qualification.out
@@ -1,3 +1,4 @@
 File "stdin", line 19, characters 0-7:
 Error: Signature components for label test do not match: expected type
 "Top.M2.t = Top.M2.M.t" but found type "Top.M2.t = Top.M2.t".
+

--- a/toplevel/coqloop.mli
+++ b/toplevel/coqloop.mli
@@ -26,12 +26,7 @@ type input_buffer = {
 val top_buffer : input_buffer
 val set_prompt : (unit -> string) -> unit
 
-(** Toplevel error explanation, dealing with locations, Drop, Ctrl-D
-  May raise only the following exceptions: [Drop] and [End_of_input],
-  meaning we get out of the Coq loop. *)
-
-val print_toplevel_error : Exninfo.iexn -> std_ppcmds
-
+(** Toplevel feedback printer. *)
 val coqloop_feed : Feedback.feedback -> unit
 
 (** Parse and execute one vernac command. *)

--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -653,10 +653,10 @@ let init_toplevel arglist =
       flush_all();
       let msg =
         if !batch_mode then mt ()
-        else str "Error during initialization:" ++ fnl ()
+        else str "Error during initialization: " ++ CErrors.iprint any ++ fnl ()
       in
       let is_anomaly e = CErrors.is_anomaly e || not (CErrors.handled e) in
-      fatal_error (msg ++ Coqloop.print_toplevel_error any) (is_anomaly (fst any))
+      fatal_error msg (is_anomaly (fst any))
   end;
   if !batch_mode then begin
     flush_all();

--- a/vernac/topfmt.mli
+++ b/vernac/topfmt.mli
@@ -40,10 +40,9 @@ val get_margin : unit -> int option
 val err_hdr : Pp.std_ppcmds
 val ann_hdr : Pp.std_ppcmds
 
-(** Console display of feedback *)
-val std_logger : ?loc:Loc.t -> Feedback.level -> Pp.std_ppcmds -> unit
-
-val emacs_logger : ?loc:Loc.t -> Feedback.level -> Pp.std_ppcmds -> unit
+(** Console display of feedback, we may add some location information *)
+val std_logger   : ?pre_hdr:Pp.std_ppcmds -> Feedback.level -> Pp.std_ppcmds -> unit
+val emacs_logger : ?pre_hdr:Pp.std_ppcmds -> Feedback.level -> Pp.std_ppcmds -> unit
 
 val init_color_output : unit -> unit
 val clear_styles : unit -> unit


### PR DESCRIPTION
We solve https://coq.inria.fr/bugs/show_bug.cgi?id=4789 by printing
all the errors from the feedback handler, even in the case of coqtop.

All error display is handled by a single, uniform path.

There may be some minor discrepancies with 8.6 as we are uniform now
whereas 8.6 tended to print errors in several ways, but our behavior
is a subset of the 8.6 behavior.

We had to make a choice for `-emacs` error output, which used to vary
too. We have chosen to display error messages as:

```
(location info) option \n
(program caret) option \n
MARKER[254]Error: msgMARKER[255]
```

This commit also fixes:

- https://coq.inria.fr/bugs/show_bug.cgi?id=5418
- https://coq.inria.fr/bugs/show_bug.cgi?id=5429

which were introduced or exposed by #390