### PR TITLE
Fix #5435: [Eval native_compute in] raises anomaly.

### DIFF
--- a/kernel/nativecode.ml
+++ b/kernel/nativecode.ml
@@ -1849,9 +1849,10 @@ and apply_fv env sigma univ (fv_named,fv_rel) auxdefs ml =
 
 and compile_rel env sigma univ auxdefs n =
   let open Context.Rel in
-  let n = length env.env_rel_context - n in
   let open Declaration in
-  match lookup n env.env_rel_context with
+  let decl = lookup n env.env_rel_context in
+  let n = length env.env_rel_context - n in
+  match decl with
   | LocalDef (_,t,_) ->
       let code = lambda_of_constr env sigma t in
       let auxdefs,code = compile_with_fv env sigma univ auxdefs None code in

--- a/test-suite/bugs/closed/5435.v
+++ b/test-suite/bugs/closed/5435.v
@@ -1,0 +1,2 @@
+Definition foo (x : nat) := Eval native_compute in x.
+


### PR DESCRIPTION
Fix bug #5435: [Eval native_compute in] raises anomaly.

Was introduced by the following commit:
```
commit 4f041384cb27f0d24fa14b272884b4b7f69cacbe
Author: Matej Kosik <m4tej.kosik@gmail.com>
Date:   Mon Feb 15 11:55:43 2016 +0100

    CLEANUP: Simplifying the changes done in "kernel/*"
```
Unsoundness seems miraculously avoided by a safeguard I put in nativecode.ml. But other kernel changes in this commit should probably be reviewed carefully.