### PR TITLE
Efficient side-effect abstraction

### DIFF
--- a/test-suite/success/abstract_chain.v
+++ b/test-suite/success/abstract_chain.v
@@ -1,0 +1,43 @@
+Lemma foo1 : nat -> True.
+Proof.
+intros _.
+assert (H : True -> True).
+{ abstract (exact (fun x => x)) using bar. }
+assert (H' : True).
+{ abstract (exact (bar I)) using qux. }
+exact H'.
+Qed.
+
+Lemma foo2 : True.
+Proof.
+assert (H : True -> True).
+{ abstract (exact (fun x => x)) using bar. }
+assert (H' : True).
+{ abstract (exact (bar I)) using qux. }
+assert (H'' : True).
+{ abstract (exact (bar qux)) using quz. }
+exact H''.
+Qed.
+
+Set Universe Polymorphism.
+
+Lemma foo3 : nat -> True.
+Proof.
+intros _.
+assert (H : True -> True).
+{ abstract (exact (fun x => x)) using bar. }
+assert (H' : True).
+{ abstract (exact (bar I)) using qux. }
+exact H'.
+Qed.
+
+Lemma foo4 : True.
+Proof.
+assert (H : True -> True).
+{ abstract (exact (fun x => x)) using bar. }
+assert (H' : True).
+{ abstract (exact (bar I)) using qux. }
+assert (H'' : True).
+{ abstract (exact (bar qux)) using quz. }
+exact H''.
+Qed.


### PR DESCRIPTION
This solves the second part of [bug #5382](https://coq.inria.fr/bugs/show_bug.cgi?id=5382), namely that Qed is slow when the proof contains a lot of abstract.

Essentially, it implements the inlining of side-effects in one pass, instead of as many passes as there are abstracted constants.