### PR TITLE
[travis] Add webhook to Gitter.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -123,3 +123,12 @@ script:
 - echo 'Running tests...' && echo -en 'travis_fold:start:coq.test\\r'
 - ${TW} make -j ${NJOBS} ${TEST_TARGET}
 - echo -en 'travis_fold:end:coq.test\\r'
+
+# Testing Gitter webhook
+notifications:
+  webhooks:
+    urls:
+      - https://webhooks.gitter.im/e/3cdabdec318214c7cd63
+    on_success: change  # options: [always|never|change] default: always
+    on_failure: always  # options: [always|never|change] default: always
+    on_start: never     # options: [always|never|change] default: always


### PR DESCRIPTION
This is to add notifications for Travis jobs in the left panel of coq/coq Gitter chat room (where the GitHub notifications currently appear).
Parameters can be later adjusted.
Also there is the risk that it also sends notifications when pushing to forks, but I guess we'll see with experience.
I based it on trunk. Let me know if this is OK.