### PR TITLE
[toplevel] Remove the feedback printer only on exit.

### DIFF
--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -92,11 +92,11 @@ let console_toploop_run () =
     Dumpglob.noglob ()
   end;
   Coqloop.loop();
-  (* We remove the feeder but it could be ok not to do so *)
-  Feedback.del_feeder tl_feed;
   (* Initialise and launch the Ocaml toplevel *)
   Coqinit.init_ocaml_path();
-  Mltop.ocaml_toploop()
+  Mltop.ocaml_toploop();
+  (* We let the feeder in place for users of Drop *)
+  Feedback.del_feeder tl_feed
 
 let toploop_run = ref console_toploop_run
 


### PR DESCRIPTION
This fixes the bug in `Drop` reported by @mattam82: after performing a `Drop`, the feeder was lost and no further message from Coq was printed.