### PR TITLE
Breadth-first eauto, documentation, new tactic

### DIFF
--- a/doc/refman/RefMan-tac.tex
+++ b/doc/refman/RefMan-tac.tex
@@ -3591,19 +3591,11 @@ Note that {\tt ex\_intro} should be declared as a hint.
 \tacindex{bfs\_eauto}
 \label{bfseauto}
  
-This tactic is the same as {\tt eauto}, but it always uses a
-breadth-first search strategy. The options for {\tt bfs\_eauto} are
-the same as for {\tt eauto}, except that it always takes a single
+This tactic is the same as {\tt eauto}, but uses a breadth-first search strategy.
+The options for {\tt bfs\_eauto} are
+the same as for {\tt eauto}, except that it takes exactly one 
 number indicating the search depth limit.
 
-\begin{Variants}
-
-\item {\tt bfs\_eauto \num} \zeroone{{\tt using} \nterm{lemma}$_1$
-  {\tt ,} {\ldots} {\tt ,} \nterm{lemma}$_n$} \zeroone{{\tt with}
-  \ident$_1$ {\ldots} \ident$_n$}
-
-\end{Variants}
-  
 \subsection{\tt autounfold with \ident$_1$ \mbox{\dots} \ident$_n$}
 \tacindex{autounfold}
 \label{autounfold}

--- a/doc/refman/RefMan-tac.tex
+++ b/doc/refman/RefMan-tac.tex
@@ -3575,16 +3575,35 @@ Note that {\tt ex\_intro} should be declared as a hint.
 
 \begin{Variants}
 
-\item {\tt \zeroone{info\_}eauto \zeroone{\num}} \zeroone{{\tt using} \nterm{lemma}$_1$
+\item {\tt \zeroone{info\_}eauto \zeroone{\num} \zeroone{\num}} \zeroone{{\tt using} \nterm{lemma}$_1$
   {\tt ,} {\ldots} {\tt ,} \nterm{lemma}$_n$} \zeroone{{\tt with}
   \ident$_1$ {\ldots} \ident$_n$}
 
-  The various options for eauto are the same as for auto.
+  The various options for eauto are mostly the same as for {\tt auto}. If two numbers are provided,
+  the second number provides a depth limit for breadth-first search, 
+  while the first number is ignored. That usage is deprecated; new code should use {\tt bfs\_eauto}.
 
 \end{Variants}
 
 \SeeAlso Section~\ref{Hints-databases}
 
+\subsection{\tt bfs\_eauto}
+\tacindex{bfs\_eauto}
+\label{bfseauto}
+ 
+This tactic is the same as {\tt eauto}, but it always uses a
+breadth-first search strategy. The options for {\tt bfs\_eauto} are
+the same as for {\tt eauto}, except that it always takes a single
+number indicating the search depth limit.
+
+\begin{Variants}
+
+\item {\tt bfs\_eauto \num} \zeroone{{\tt using} \nterm{lemma}$_1$
+  {\tt ,} {\ldots} {\tt ,} \nterm{lemma}$_n$} \zeroone{{\tt with}
+  \ident$_1$ {\ldots} \ident$_n$}
+
+\end{Variants}
+  
 \subsection{\tt autounfold with \ident$_1$ \mbox{\dots} \ident$_n$}
 \tacindex{autounfold}
 \label{autounfold}

--- a/plugins/ltac/g_auto.ml4
+++ b/plugins/ltac/g_auto.ml4
@@ -133,10 +133,10 @@ TACTIC EXTEND info_eauto
     [ Eauto.gen_eauto ~debug:Info (Eauto.make_dimension n p) (eval_uconstrs ist lems) db ]
 END
 
-TACTIC EXTEND dfs_eauto
-| [ "dfs" "eauto" int_or_var_opt(p) auto_using(lems)
+TACTIC EXTEND bfs_eauto
+| [ "bfs_eauto" int_or_var_opt(p) auto_using(lems)
       hintbases(db) ] ->
-    [ Eauto.gen_eauto (Eauto.make_dimension p None) (eval_uconstrs ist lems) db ]
+    [ Eauto.gen_eauto (Eauto.make_dimension None p) (eval_uconstrs ist lems) db ]
 END
 
 TACTIC EXTEND autounfold


### PR DESCRIPTION
Document existing usage of [eauto] for breadth-first search, indicating it's deprecated.

Add [bfs_eauto]. Remove redundant, undocumented [dfs eauto].