### PR TITLE
Fix compilation by using strict mode of camlp5.

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -149,7 +149,7 @@ endef
 # Camlp5 settings
 
 CAMLP4DEPS:=grammar/compat5.cmo grammar/grammar.cma
-CAMLP4USE=pa_extend.cmo q_MLast.cmo pa_macro.cmo -D$(CAMLVERSION)
+CAMLP4USE=pa_extend.cmo q_MLast.cmo pa_macro.cmo -D$(CAMLVERSION) -mode S
 
 PR_O := $(if $(READABLE_ML4),pr_o.cmo,pr_dump.cmo)
 


### PR DESCRIPTION
Until now, camlp5 was used with the default mode (set at compile time).
But since the camlp4 compatibility removal, the strict mode is required.
This is a bit puzzling and maybe others will have something to say or better to propose.