### PR TITLE
Missing optimization when Kernel Term Sharing is disabled.

### DIFF
--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -1000,7 +1000,7 @@ let rec kl info m =
   if is_val m then (incr prune; term_of_fconstr m)
   else
     let (nm,s) = kni info m [] in
-    let _ = fapp_stack(nm,s) in (* to unlock Zupdates! *)
+    let () = if !share then ignore (fapp_stack (nm, s)) in (* to unlock Zupdates! *)
     zip_term (kl info) (norm_head info nm) s
 
 (* no redex: go up for atoms and already normalized terms, go down
@@ -1050,7 +1050,7 @@ let inject c = mk_clos (subs_id 0) c
 
 let whd_stack infos m stk =
   let k = kni infos m stk in
-  let _ = fapp_stack k in (* to unlock Zupdates! *)
+  let () = if !share then ignore (fapp_stack k) in (* to unlock Zupdates! *)
   k
 
 (* cache of constants: the body is computed only when needed. *)


### PR DESCRIPTION
This patch adds a missing optimization in the kernel. When reducing terms without Kernel Term Sharing set, we don't have to perfom in-place updates because we actually know that there is none on the stack.

This is somewhat critical in UniMath which abuses the flag. I ran the bench three times on it and got the following results:
```
┌──────────────┬─────────────────────────┬─────────────────────────────────────┬─────────────────────────────────────┐
│              │      user time [s]      │             CPU cycles              │          CPU instructions           │
│              │                         │                                     │                                     │
│ package_name │     NEW     OLD PDIFF   │           NEW           OLD PDIFF   │           NEW           OLD PDIFF   │
├──────────────┼─────────────────────────┼─────────────────────────────────────┼─────────────────────────────────────┤
│  coq-unimath │ 1130.24 1247.54 -9.40 % │ 3132128571062 3456741122915 -9.39 % │ 5332501952654 5812131583426 -8.25 % │
└──────────────┴─────────────────────────┴─────────────────────────────────────┴─────────────────────────────────────┘
```
Note that I did not bench the other packages because several seemed to be half-broken by the merge of EConstr, and furthermore this optimization is irrelevant to them.
 