### PR TITLE
Remove VernacError

### DIFF
--- a/ide/texmacspp.ml
+++ b/ide/texmacspp.ml
@@ -504,7 +504,6 @@ let rec tmpp v loc =
       xmlApply loc (Element("timeout",["val",string_of_int s],[]) ::
                     [tmpp e loc])
   | VernacFail e -> xmlApply loc (Element("fail",[],[]) :: [tmpp e loc])
-  | VernacError _ -> xmlWithLoc loc "error" [] []
 
   (* Syntax *)
   | VernacSyntaxExtension (_, ((_, name), sml)) ->

--- a/intf/vernacexpr.mli
+++ b/intf/vernacexpr.mli
@@ -71,7 +71,7 @@ type printable =
   | PrintScopes
   | PrintScope of string
   | PrintVisibility of string option
-  | PrintAbout of reference or_by_notation*int option
+  | PrintAbout of reference or_by_notation * goal_selector option
   | PrintImplicit of reference or_by_notation
   | PrintAssumptions of bool * bool * reference or_by_notation
   | PrintStrategy of reference or_by_notation option
@@ -316,7 +316,6 @@ type vernac_expr =
   | VernacRedirect of string * vernac_expr located
   | VernacTimeout of int * vernac_expr
   | VernacFail of vernac_expr
-  | VernacError of exn (* always fails *)
 
   (* Syntax *)
   | VernacSyntaxExtension of
@@ -436,11 +435,11 @@ type vernac_expr =
   | VernacRemoveOption of Goptions.option_name * option_ref_value list
   | VernacMemOption of Goptions.option_name * option_ref_value list
   | VernacPrintOption of Goptions.option_name
-  | VernacCheckMayEval of Genredexpr.raw_red_expr option * int option * constr_expr
+  | VernacCheckMayEval of Genredexpr.raw_red_expr option * goal_selector option * constr_expr
   | VernacGlobalCheck of constr_expr
   | VernacDeclareReduction of string * Genredexpr.raw_red_expr
   | VernacPrint of printable
-  | VernacSearch of searchable * int option * search_restriction
+  | VernacSearch of searchable * goal_selector option * search_restriction
   | VernacLocate of locatable
   | VernacRegister of lident * register_kind
   | VernacComments of comment list

--- a/plugins/ltac/g_ltac.ml4
+++ b/plugins/ltac/g_ltac.ml4
@@ -335,7 +335,7 @@ GEXTEND Gram
     |   IDENT "all"; ":" -> SelectAll ] ]
   ;
   tactic_mode:
-    [ [ g = OPT toplevel_selector; tac = G_vernac.subgoal_command -> tac g ] ]
+    [ [ g = OPT toplevel_selector; tac = G_vernac.query_command -> tac g ] ]
   ;
   command:
     [ [ IDENT "Proof"; "with"; ta = Pltac.tactic; 

--- a/printing/ppvernac.ml
+++ b/printing/ppvernac.ml
@@ -107,7 +107,7 @@ open Decl_kinds
         | SearchString (s,sc) -> qs s ++ pr_opt (fun sc -> str "%" ++ str sc) sc
 
   let pr_search a gopt b pr_p =
-    pr_opt (fun g -> int g ++ str ":"++ spc()) gopt
+    pr_opt (fun g -> Proof_global.pr_goal_selector g ++ str ":"++ spc()) gopt
     ++
       match a with
       | SearchHead c -> keyword "SearchHead" ++ spc() ++ pr_p c ++ pr_in_out_modules b
@@ -497,7 +497,7 @@ open Decl_kinds
     | PrintVisibility s ->
       keyword "Print Visibility" ++ pr_opt str s
     | PrintAbout (qid,gopt) ->
-       pr_opt (fun g -> int g ++ str ":"++ spc()) gopt
+       pr_opt (fun g -> Proof_global.pr_goal_selector g ++ str ":"++ spc()) gopt
        ++ keyword "About" ++ spc()  ++ pr_smart_global qid
     | PrintImplicit qid ->
       keyword "Print Implicit" ++ spc()  ++ pr_smart_global qid
@@ -619,8 +619,6 @@ open Decl_kinds
         return (keyword "Timeout " ++ int n ++ spc() ++ pr_vernac_body v)
       | VernacFail v ->
         return (keyword "Fail" ++ spc() ++ pr_vernac_body v)
-      | VernacError _ ->
-        return (keyword "No-parsing-rule for VernacError")
 
     (* Syntax *)
       | VernacOpenCloseScope (_,(opening,sc)) ->
@@ -1140,7 +1138,8 @@ open Decl_kinds
                      spc() ++ keyword "in" ++ spc () ++ pr_lconstr c)
           | None -> hov 2 (keyword "Check" ++ spc() ++ pr_lconstr c)
         in
-        let pr_i = match io with None -> mt () | Some i -> int i ++ str ": " in
+        let pr_i = match io with None -> mt ()
+                               | Some i -> Proof_global.pr_goal_selector i ++ str ": " in
         return (pr_i ++ pr_mayeval r c)
       | VernacGlobalCheck c ->
         return (hov 2 (keyword "Type" ++ pr_constrarg c))

--- a/proofs/proof_global.ml
+++ b/proofs/proof_global.ml
@@ -671,16 +671,18 @@ let _ =
 let default_goal_selector = ref (Vernacexpr.SelectNth 1)
 let get_default_goal_selector () = !default_goal_selector
 
-let print_range_selector (i, j) =
-  if i = j then string_of_int i
-  else string_of_int i ^ "-" ^ string_of_int j
+let pr_range_selector (i, j) =
+  if i = j then int i
+  else int i ++ str "-" ++ int j
 
-let print_goal_selector = function
-  | Vernacexpr.SelectAll -> "all"
-  | Vernacexpr.SelectNth i -> string_of_int i
-  | Vernacexpr.SelectList l -> "[" ^
-      String.concat ", " (List.map print_range_selector l) ^ "]"
-  | Vernacexpr.SelectId id -> Id.to_string id
+let pr_goal_selector = function
+  | Vernacexpr.SelectAll -> str "all"
+  | Vernacexpr.SelectNth i -> int i
+  | Vernacexpr.SelectList l ->
+     str "["
+     ++ prlist_with_sep pr_comma pr_range_selector l
+     ++ str "]"
+  | Vernacexpr.SelectId id -> Id.print id
 
 let parse_goal_selector = function
   | "all" -> Vernacexpr.SelectAll
@@ -699,7 +701,10 @@ let _ =
                                   optdepr = false;
                                   optname = "default goal selector" ;
                                   optkey = ["Default";"Goal";"Selector"] ;
-                                  optread = begin fun () -> print_goal_selector !default_goal_selector end;
+                                  optread = begin fun () ->
+                                            string_of_ppcmds
+                                              (pr_goal_selector !default_goal_selector)
+                                            end;
                                   optwrite = begin fun n ->
                                     default_goal_selector := parse_goal_selector n
                                   end

--- a/proofs/proof_global.mli
+++ b/proofs/proof_global.mli
@@ -198,6 +198,7 @@ end
 (*                                                        *)
 (**********************************************************)
 
+val pr_goal_selector : Vernacexpr.goal_selector -> Pp.std_ppcmds
 val get_default_goal_selector : unit -> Vernacexpr.goal_selector
 
 module V82 : sig

--- a/stm/vernac_classifier.ml
+++ b/stm/vernac_classifier.ml
@@ -202,8 +202,7 @@ let rec classify_vernac e =
     (* What are these? *)
     | VernacToplevelControl _
     | VernacRestoreState _
-    | VernacWriteState _
-    | VernacError _ -> VtUnknown, VtNow
+    | VernacWriteState _ -> VtUnknown, VtNow
     (* Plugins should classify their commands *)
     | VernacExtend (s,l) ->
         try List.assoc s !classifiers l ()

--- a/test-suite/output/Search.out
+++ b/test-suite/output/Search.out
@@ -98,6 +98,14 @@ h: n <> newdef n
 h': newdef n <> n
 h: n <> newdef n
 h: n <> newdef n
+h: n <> newdef n
+h': newdef n <> n
+The command has indeed failed with message:
+No such goal.
+The command has indeed failed with message:
+Query commands only support the single numbered goal selector.
+The command has indeed failed with message:
+Query commands only support the single numbered goal selector.
 h: P n
 h': ~ P n
 h: P n

--- a/test-suite/output/Search.v
+++ b/test-suite/output/Search.v
@@ -10,11 +10,19 @@ Search (@eq _ _ _) true -false "prop" -"intro".  (* andb_prop *)
 Definition newdef := fun x:nat => x.
 
 Goal forall n:nat, n <> newdef n -> newdef n <> n -> False.
-  intros n h h'.
+  cut False.
+  intros _ n h h'.
   Search n.                             (* search hypothesis *)
   Search newdef.                        (* search hypothesis *)
   Search ( _ <> newdef _).              (* search hypothesis, pattern *)
   Search ( _ <> newdef _) -"h'".        (* search hypothesis, pattern *)
+
+  1:Search newdef.
+  2:Search newdef.
+
+  Fail 3:Search newdef.
+  Fail 1-2:Search newdef.
+  Fail all:Search newdef.
 Abort.
 
 Goal forall n (P:nat -> Prop), P n -> ~P n -> False.


### PR DESCRIPTION
This is an attempt to do better than #556. It doesn't work as both
```
Goal True.
Check _.
```
and
```
Goal True.
1:Check _.
```
error with `The reference Check was not found in the current environment.`

I'm making this PR in the hope that someone else will know what I'm missing.