### PR TITLE
Adding and fixing links in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,17 @@ mathematical definitions, executable algorithms and theorems together with an
 environment for semi-interactive development of machine-checked proofs.
 
 ## Installation
-See the file `INSTALL` for installation procedure.
+Go to the [download page](https://coq.inria.fr/download) for Windows and MacOS packages;
+read the [help page](https://coq.inria.fr/opam/www/using.html) on how to install Coq with OPAM;
+or refer to the [`INSTALL` file](/INSTALL) for the procedure to install from source.
 
 ## Documentation
 The documentation is part of the archive in directory doc. The
 documentation of the last released version is available on the Coq
-web site at [coq.inria.fr/doc](http://coq.inria.fr/doc).
+web site at [coq.inria.fr/documentation](http://coq.inria.fr/documentation).
 
 ## Changes
-There is a file named `CHANGES` that explains the differences and the
+There is a file named [`CHANGES`](/CHANGES) that explains the differences and the
 incompatibilities since last versions. If you upgrade Coq, please read
 it carefully.
 


### PR DESCRIPTION
Mostly this takes advantage of Markdown to have clickable links to referred files in the repository.

This also updates the link to the documentation: it was [coq.inria.fr/doc](http://coq.inria.fr/doc) which redirects to the refman. The correct link to the documentation page is [coq.inria.fr/documentation](http://coq.inria.fr/documentation). If the purpose was to link directly to the refman, then it should be announced as "reference manual" not "documentation".

This also adds some links to install using provided packages or OPAM. In particular, the help page for OPAM is very hard to find. Having it mentioned in the README should correct part of this problem.

TODO in the future (not in this PR):
- add an introduction to the developer's documentation and link to it from the README;
- add a CONTRIBUTING file and link to it from the README.