### PR TITLE
Replacing costly merges in UGraph.

### DIFF
--- a/kernel/uGraph.ml
+++ b/kernel/uGraph.ml
@@ -354,13 +354,15 @@ let get_new_edges g to_merge =
       UMap.empty to_merge
   in
   let ltle =
-    UMap.fold (fun _ n acc ->
-      UMap.merge (fun _ strict1 strict2 ->
-        match strict1, strict2 with
-        | Some true, _ | _, Some true -> Some true
-        | _, _ -> Some false)
-        acc n.ltle)
-      to_merge_lvl UMap.empty
+    let fold _ n acc =
+      let fold u strict acc =
+        if strict then UMap.add u strict acc
+        else if UMap.mem u acc then acc
+        else UMap.add u false acc
+      in
+      UMap.fold fold n.ltle acc
+    in
+    UMap.fold fold to_merge_lvl UMap.empty
   in
   let ltle, _ = clean_ltle g ltle in
   let ltle =


### PR DESCRIPTION
This patch optimizes a common operation used by universe checking, replacing a `Map.merge` by a `Map.fold`. The first operation is costly because it needs to reconstruct the whole merged map everytime, while the other one only depends on the size of the first operand.

Here are the timings.
```
┌────────────────────────┬──────────────────────────┬──────────────────────────────────────┬──────────────────────────────────────┐
│                        │      user time [s]       │              CPU cycles              │           CPU instructions           │
│                        │                          │                                      │                                      │
│           package_name │     NEW     OLD  PDIFF   │           NEW           OLD  PDIFF   │           NEW           OLD  PDIFF   │
├────────────────────────┼──────────────────────────┼──────────────────────────────────────┼──────────────────────────────────────┤
│               coq-iris │  376.26  434.39 -13.38 % │ 1043822274139 1204831656125 -13.36 % │ 1362746426415 1732954962168 -21.36 % │
├────────────────────────┼──────────────────────────┼──────────────────────────────────────┼──────────────────────────────────────┤
│                coq-vst │ 1402.35 1493.02  -6.07 % │ 3895716360171 4147403784552  -6.07 % │ 5674699501284 6263613153899  -9.40 % │
├────────────────────────┼──────────────────────────┼──────────────────────────────────────┼──────────────────────────────────────┤
│ coq-mathcomp-ssreflect │   42.34   42.72  -0.89 % │  115655694216  116156368299  -0.43 % │  149312221327  149370500524  -0.04 % │
├────────────────────────┼──────────────────────────┼──────────────────────────────────────┼──────────────────────────────────────┤
│  coq-mathcomp-solvable │  187.94  189.09  -0.61 % │  522740040309  524864252980  -0.40 % │  764420935259  766694863324  -0.30 % │
├────────────────────────┼──────────────────────────┼──────────────────────────────────────┼──────────────────────────────────────┤
│       coq-fiat-parsers │  525.26  528.43  -0.60 % │ 1434594106396 1443989925785  -0.65 % │ 2043888581027 2056639864348  -0.62 % │
├────────────────────────┼──────────────────────────┼──────────────────────────────────────┼──────────────────────────────────────┤
│              coq-color │  613.16  616.72  -0.58 % │ 1702143265318 1711413630735  -0.54 % │ 2138357550979 2155620387526  -0.80 % │
├────────────────────────┼──────────────────────────┼──────────────────────────────────────┼──────────────────────────────────────┤
│              coq-flocq │   55.16   55.40  -0.43 % │  150881264891  150976065506  -0.06 % │  193327483067  193200211868  +0.07 % │
├────────────────────────┼──────────────────────────┼──────────────────────────────────────┼──────────────────────────────────────┤
│        coq-fiat-crypto │ 1742.16 1749.62  -0.43 % │ 4839742347575 4860337228847  -0.42 % │ 8091450266040 8107338094763  -0.20 % │
├────────────────────────┼──────────────────────────┼──────────────────────────────────────┼──────────────────────────────────────┤
│ coq-mathcomp-odd_order │ 1391.65 1396.55  -0.35 % │ 3878834427291 3883718235196  -0.13 % │ 6817086307559 6826228354568  -0.13 % │
├────────────────────────┼──────────────────────────┼──────────────────────────────────────┼──────────────────────────────────────┤
│ coq-mathcomp-character │  265.53  266.34  -0.30 % │  738031839948  739522338858  -0.20 % │ 1093058607613 1092965657720  +0.01 % │
├────────────────────────┼──────────────────────────┼──────────────────────────────────────┼──────────────────────────────────────┤
│  coq-mathcomp-fingroup │   57.25   57.33  -0.14 % │  157648238777  158141340244  -0.31 % │  222659163643  222637634244  +0.01 % │
├────────────────────────┼──────────────────────────┼──────────────────────────────────────┼──────────────────────────────────────┤
│         coq-coquelicot │   70.80   70.89  -0.13 % │  194434051388  194471814126  -0.02 % │  244523676075  244553351445  -0.01 % │
├────────────────────────┼──────────────────────────┼──────────────────────────────────────┼──────────────────────────────────────┤
│            coq-unimath │ 1244.17 1244.93  -0.06 % │ 3449808440969 3448625553438  +0.03 % │ 5820717659827 5821642053453  -0.02 % │
├────────────────────────┼──────────────────────────┼──────────────────────────────────────┼──────────────────────────────────────┤
│           coq-compcert │  792.40  792.66  -0.03 % │ 2202352305164 2200355239978  +0.09 % │ 3354798796264 3357314558122  -0.07 % │
├────────────────────────┼──────────────────────────┼──────────────────────────────────────┼──────────────────────────────────────┤
│     coq-mathcomp-field │  450.50  450.44  +0.01 % │ 1253603282917 1253554555326  +0.00 % │ 2097339673317 2096687144597  +0.03 % │
├────────────────────────┼──────────────────────────┼──────────────────────────────────────┼──────────────────────────────────────┤
│                 coq-sf │   44.05   43.99  +0.14 % │  119413267872  119920943859  -0.42 % │  155724014490  155841914618  -0.08 % │
├────────────────────────┼──────────────────────────┼──────────────────────────────────────┼──────────────────────────────────────┤
│   coq-mathcomp-algebra │  167.64  167.32  +0.19 % │  465229225405  464657457610  +0.12 % │  665502916391  663851192146  +0.25 % │
├────────────────────────┼──────────────────────────┼──────────────────────────────────────┼──────────────────────────────────────┤
│               coq-hott │  235.95  235.45  +0.21 % │  635493728697  635717129710  -0.04 % │ 1074734625476 1074224023549  +0.05 % │
└────────────────────────┴──────────────────────────┴──────────────────────────────────────┴──────────────────────────────────────┘


PDIFF = proportional difference between measurements done for the NEW and the OLD Coq version
      = (NEW_measurement - OLD_measurement) / OLD_measurement * 100%

NEW = 6795bc07f53a842bcec76ad0329d0b4444a625ab
OLD = beb3acd2fd3831404f0be2da61d3f28e210e8349
```

I had remarked this bottleneck in VST where I was expecting a little gain, but I am genuinely baffled by the gain in speed in Iris.
