### PR TITLE
[toplevel] Fix printing of parsing errors + corner case.

### DIFF
--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -649,7 +649,7 @@ let init_toplevel arglist =
       let any = CErrors.push any in
       flush_all();
       let msg =
-        if !batch_mode then mt ()
+        if !batch_mode && not Stateid.(equal (Stm.get_current_state ()) dummy) then mt ()
         else str "Error during initialization: " ++ CErrors.iprint any ++ fnl ()
       in
       let is_anomaly e = CErrors.is_anomaly e || not (CErrors.handled e) in


### PR DESCRIPTION
PR #441 and #530 had an interesting interaction creating two bugs:

- #441 stopped emitting feedback for the parser, however #530 changed
  the mechanism to print parser errors to the feedback, thus when the
  two patches were applied, parsing errors were not printed in
  batch_mode.

- Additionally, #530 contains an error: prior to `Stm.init` we must
  take care of exceptions `require ()`/etc... otherwise they won't get
  printed.