### PR TITLE
Fix nsatz not recognizing real literals.

### DIFF
--- a/plugins/nsatz/Nsatz.v
+++ b/plugins/nsatz/Nsatz.v
@@ -462,6 +462,11 @@ try (try apply Rsth;
 exact Rplus_opp_r.
 Defined.
 
+Class can_compute_Z (z : Z) := dummy_can_compute_Z : True.
+Hint Extern 0 (can_compute_Z ?v) =>
+  match isZcst v with true => exact I end : typeclass_instances.
+Instance reify_IZR z lvar {_ : can_compute_Z z} : reify (PEc z) lvar (IZR z).
+
 Lemma R_one_zero: 1%R <> 0%R.
 discrR.
 Qed.


### PR DESCRIPTION
While trivial, this fix is not completely satisfactory, thus I am submitting it as a pull request. It is meant to solve the issue @herbelin reported on coqdev.

The main issue with the fix is that `nsatz` now fails on `IZR n = IZR n` while it was working in 8.6. I have no idea how to modify a typeclass-based reification so that it accepts reifying `IZR 42` but it refuses reifying `IZR not_42`.