### PR TITLE
Give andb_prop a simpler proof

### DIFF
--- a/theories/Init/Datatypes.v
+++ b/theories/Init/Datatypes.v
@@ -65,7 +65,7 @@ Infix "&&" := andb : bool_scope.
 
 Lemma andb_prop : forall a b:bool, andb a b = true -> a = true /\ b = true.
 Proof.
-  destruct a; destruct b; intros; split; try (reflexivity || discriminate).
+  destruct a, b; repeat split; assumption.
 Qed.
 Hint Resolve andb_prop: bool.
 


### PR DESCRIPTION
No need to use `discriminate`.  This is the hopefully uncontroversial part of https://github.com/coq/coq/pull/401.