### PR TITLE
A more explicit algebraic type for evars of kind MatchingVar + a flag suspectingly renamed in a clearer way

### DIFF
--- a/dev/ci/ci-user-overlay.sh
+++ b/dev/ci/ci-user-overlay.sh
@@ -25,10 +25,8 @@ echo $TRAVIS_PULL_REQUEST
 echo $TRAVIS_BRANCH
 echo $TRAVIS_COMMIT
 
-if [ $TRAVIS_PULL_REQUEST == "678" ] || [ $TRAVIS_BRANCH == "coqlib-part-02" ]; then
-
-    mathcomp_CI_BRANCH=coqlib-part-02
-    mathcomp_CI_GITURL=https://github.com/ejgallego/math-comp.git
-
+if [ $TRAVIS_PULL_REQUEST == "590" ] || [ $TRAVIS_BRANCH == "trunk+algebraic-matchingvar" ]; then
+    mathcomp_CI_BRANCH=trunk+pr590-patvar
+    mathcomp_CI_GITURL=https://github.com/herbelin/math-comp.git
 fi
 

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -1751,10 +1751,10 @@ let internalize globalenv env pattern_mode (_, ntnvars as lvar) c =
     (* Parsing pattern variables *)
     | CPatVar n when pattern_mode ->
 	CAst.make ?loc @@
-	GPatVar (true,n)
+	GPatVar (Evar_kinds.SecondOrderPatVar n)
     | CEvar (n, []) when pattern_mode ->
 	CAst.make ?loc @@
-	GPatVar (false,n)
+	GPatVar (Evar_kinds.FirstOrderPatVar n)
     (* end *)
     (* Parsing existential variables *)
     | CEvar (n, l) ->

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -1506,7 +1506,7 @@ let extract_explicit_arg imps args =
 (**********************************************************************)
 (* Main loop                                                          *)
 
-let internalize globalenv env allow_patvar (_, ntnvars as lvar) c =
+let internalize globalenv env pattern_mode (_, ntnvars as lvar) c =
   let rec intern env = CAst.with_loc_val (fun ?loc -> function
     | CRef (ref,us) ->
 	let (c,imp,subscopes,l),_ =
@@ -1749,10 +1749,10 @@ let internalize globalenv env allow_patvar (_, ntnvars as lvar) c =
 	CAst.make ?loc @@
 	GHole (k, naming, solve)
     (* Parsing pattern variables *)
-    | CPatVar n when allow_patvar ->
+    | CPatVar n when pattern_mode ->
 	CAst.make ?loc @@
 	GPatVar (true,n)
-    | CEvar (n, []) when allow_patvar ->
+    | CEvar (n, []) when pattern_mode ->
 	CAst.make ?loc @@
 	GPatVar (false,n)
     (* end *)
@@ -1944,13 +1944,13 @@ let empty_ltac_sign = {
 }
 
 let intern_gen kind env
-               ?(impls=empty_internalization_env) ?(allow_patvar=false) ?(ltacvars=empty_ltac_sign)
+               ?(impls=empty_internalization_env) ?(pattern_mode=false) ?(ltacvars=empty_ltac_sign)
                c =
   let tmp_scope = scope_of_type_kind kind in
   internalize env {ids = extract_ids env; unb = false;
 		         tmp_scope = tmp_scope; scopes = [];
 			 impls = impls}
-    allow_patvar (ltacvars, Id.Map.empty) c
+    pattern_mode (ltacvars, Id.Map.empty) c
 
 let intern_constr env c = intern_gen WithoutTypeConstraint env c
 
@@ -2023,7 +2023,7 @@ let interp_type_evars env evdref ?(impls=empty_internalization_env) c =
 
 let intern_constr_pattern env ?(as_type=false) ?(ltacvars=empty_ltac_sign) c =
   let c = intern_gen (if as_type then IsType else WithoutTypeConstraint)
-            ~allow_patvar:true ~ltacvars env c in
+            ~pattern_mode:true ~ltacvars env c in
   pattern_of_glob_constr c
 
 let interp_notation_constr ?(impls=empty_internalization_env) nenv a =

--- a/interp/constrintern.mli
+++ b/interp/constrintern.mli
@@ -83,7 +83,7 @@ val intern_constr : env -> constr_expr -> glob_constr
 val intern_type : env -> constr_expr -> glob_constr
 
 val intern_gen : typing_constraint -> env ->
-  ?impls:internalization_env -> ?allow_patvar:bool -> ?ltacvars:ltac_sign ->
+  ?impls:internalization_env -> ?pattern_mode:bool -> ?ltacvars:ltac_sign ->
   constr_expr -> glob_constr
 
 val intern_pattern : env -> cases_pattern_expr ->

--- a/intf/evar_kinds.mli
+++ b/intf/evar_kinds.mli
@@ -8,6 +8,7 @@
 
 open Names
 open Globnames
+open Misctypes
 
 (** The kinds of existential variable *)
 
@@ -15,6 +16,8 @@ open Globnames
     defined transparent and expanded in the term? *)
 
 type obligation_definition_status = Define of bool | Expand
+
+type matching_var_kind = FirstOrderPatVar of patvar | SecondOrderPatVar of patvar
 
 type t =
   | ImplicitArg of global_reference * (int * Id.t option)
@@ -27,6 +30,6 @@ type t =
   | TomatchTypeParameter of inductive * int
   | GoalEvar
   | ImpossibleCase
-  | MatchingVar of bool * Id.t
+  | MatchingVar of matching_var_kind
   | VarInstance of Id.t
   | SubEvar of Constr.existential_key

--- a/intf/glob_term.mli
+++ b/intf/glob_term.mli
@@ -39,7 +39,7 @@ type glob_constr_r =
       (** An identifier that cannot be regarded as "GRef".
           Bound variables are typically represented this way. *)
   | GEvar   of existential_name * (Id.t * glob_constr) list
-  | GPatVar of bool * patvar (** Used for patterns only *)
+  | GPatVar of Evar_kinds.matching_var_kind (** Used for patterns only *)
   | GApp    of glob_constr * glob_constr list
   | GLambda of Name.t * binding_kind *  glob_constr * glob_constr
   | GProd   of Name.t * binding_kind * glob_constr * glob_constr

--- a/plugins/funind/indfun.ml
+++ b/plugins/funind/indfun.ml
@@ -142,7 +142,7 @@ let rec abstract_glob_constr c = function
 
 let interp_casted_constr_with_implicits env sigma impls c  =
   Constrintern.intern_gen Pretyping.WithoutTypeConstraint env ~impls
-    ~allow_patvar:false c
+    c
 
 (*
    Construct a fixpoint as a Glob_term

--- a/plugins/ltac/tacintern.ml
+++ b/plugins/ltac/tacintern.ml
@@ -189,7 +189,7 @@ let intern_binding_name ist x =
      and if a term w/o ltac vars, check the name is indeed quantified *)
   x
 
-let intern_constr_gen allow_patvar isarity {ltacvars=lfun; genv=env; extra} c =
+let intern_constr_gen pattern_mode isarity {ltacvars=lfun; genv=env; extra} c =
   let warn = if !strict_check then fun x -> x else Constrintern.for_grammar in
   let scope = if isarity then Pretyping.IsType else Pretyping.WithoutTypeConstraint in
   let ltacvars = {
@@ -198,7 +198,7 @@ let intern_constr_gen allow_patvar isarity {ltacvars=lfun; genv=env; extra} c =
     ltac_extra = extra;
   } in
   let c' =
-    warn (Constrintern.intern_gen scope ~allow_patvar ~ltacvars env) c
+    warn (Constrintern.intern_gen scope ~pattern_mode ~ltacvars env) c
   in
   (c',if !strict_check then None else Some c)
 

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -589,7 +589,7 @@ let interp_uconstr ist env sigma = function
       } in
       { closure ; term =  intern_gen WithoutTypeConstraint ~ltacvars env ce }
 
-let interp_gen kind ist allow_patvar flags env sigma (c,ce) =
+let interp_gen kind ist pattern_mode flags env sigma (c,ce) =
   let constrvars = extract_ltac_constr_context ist env sigma in
   let vars = {
     Pretyping.ltac_constrs = constrvars.typed;
@@ -617,7 +617,7 @@ let interp_gen kind ist allow_patvar flags env sigma (c,ce) =
       } in
       let kind_for_intern =
         match kind with OfType _ -> WithoutTypeConstraint | _ -> kind in
-      intern_gen kind_for_intern ~allow_patvar ~ltacvars env c
+      intern_gen kind_for_intern ~pattern_mode ~ltacvars env c
   in
   (* Jason Gross: To avoid unnecessary modifications to tacinterp, as
       suggested by Arnaud Spiwack, we run push_trace immediately.  We do

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -610,13 +610,13 @@ let rec pretype k0 resolve_tc (tycon : type_constraint) (env : ExtraEnv.t) evdre
       let j = (Retyping.get_judgment_of env.ExtraEnv.env !evdref c) in
 	inh_conv_coerce_to_tycon ?loc env evdref j tycon
 
-  | GPatVar (someta,n) ->
+  | GPatVar kind ->
     let env = ltac_interp_name_env k0 lvar env !evdref in
     let ty =
       match tycon with
       | Some ty -> ty
       | None -> new_type_evar env evdref loc in
-    let k = Evar_kinds.MatchingVar (someta,n) in
+    let k = Evar_kinds.MatchingVar kind in
       { uj_val = e_new_evar env evdref ~src:(loc,k) ty; uj_type = ty }
 
   | GHole (k, naming, None) ->

--- a/tactics/hipattern.ml
+++ b/tactics/hipattern.ml
@@ -260,7 +260,7 @@ let mkGProd id c1 c2 = CAst.make @@
 let mkGArrow c1 c2 = CAst.make @@
   GProd (Anonymous, Explicit, c1, c2)
 let mkGVar id = CAst.make @@ GVar (Id.of_string id)
-let mkGPatVar id = CAst.make @@ GPatVar((false, Id.of_string id))
+let mkGPatVar id = CAst.make @@ GPatVar(Evar_kinds.FirstOrderPatVar (Id.of_string id))
 let mkGRef r = CAst.make @@ GRef (Lazy.force r, None)
 let mkGAppRef r args = mkGApp (mkGRef r) args
 


### PR DESCRIPTION
Hi,

I'm putting here two minor commits that I had developed at the same time as I was working on a fix for bug #5487.

The first one is a renaming of an internal flag of which I found the name a bit confusing.

The second one is a rephrasing of a type formerly encoded as a pair of a boolean and an ident into a more algebraic type, following lines which have been discussed in former WGs, as well as on the PRs site, namely that using explicit algebraic types is generally clearer, and (a priori) more robust, than using encoding with pairs, options, booleans, etc.

I pushed yesterday these commits directly to trunk naively thinking that it would have no consequences, but, unfortunately, the second of these minor "changes" broke plugins.

I don't consider it enough significant to be worth taking the time to adapt plugins. So, I give it as a small and somehow symbolic gift to the community. 

The first one is purely internal, so it might be pushed if someone finds an interest in it.

For the second one, if noone is interested in pursuing such direction of giving priority to algebraic types over encoded types, as @matejkosik did e.g. in `context.ml`, and which I feel is a consensual direction, even to the price of having to adapt plugins, then this PR can be closed.

Happy WE!
