### PR TITLE
An example showing the benefit of Econstr

### DIFF
--- a/lib/option.ml
+++ b/lib/option.ml
@@ -188,4 +188,14 @@ module List =
 	 |None -> find f t
 	 |x -> x
 
+  let map f l =
+    let rec aux f l = match l with
+    | [] -> []
+    | x :: l ->
+      match f x with
+      | None -> raise Exit
+      | Some y -> y :: aux f l
+    in
+    try Some (aux f l) with Exit -> None
+
 end

--- a/lib/option.ml
+++ b/lib/option.ml
@@ -20,24 +20,24 @@ let has_some = function
   | _ -> true
 
 let is_empty = function
-| None -> true
-| Some _ -> false
+  | None -> true
+  | Some _ -> false
 
 (** Lifting equality onto option types. *)
 let equal f x y = match x, y with
-| None, None -> true
-| Some x, Some y -> f x y
-| _, _ -> false
+  | None, None -> true
+  | Some x, Some y -> f x y
+  | _, _ -> false
 
 let compare f x y = match x, y with
-| None, None -> 0
-| Some x, Some y -> f x y
-| None, Some _ -> -1
-| Some _, None -> 1
+  | None, None -> 0
+  | Some x, Some y -> f x y
+  | None, Some _ -> -1
+  | Some _, None -> 1
 
 let hash f = function
-| None -> 0
-| Some x -> f x
+  | None -> 0
+  | Some x -> f x
 
 exception IsNone
 
@@ -57,12 +57,10 @@ let init b x =
   else
     None
 
-
 (** [flatten x] is [Some y] if [x] is [Some (Some y)] and [None] otherwise. *)
 let flatten = function
   | Some (Some y) -> Some y
   | _ -> None
-
 
 (** [append x y] is the first element of the concatenation of [x] and
     [y] seen as lists. *)
@@ -134,6 +132,7 @@ let cata f a = function
   | Some c -> f c
   | None -> a
 
+
 (** {6 More Specific operations} ***)
 
 (** [default a x] is [y] if [x] is [Some y] and [a] otherwise. *)
@@ -165,7 +164,6 @@ let lift2 f x y =
   | _,_ -> None
 
 
-
 (** {6 Operations with Lists} *)
 
 module List =
@@ -183,10 +181,10 @@ module List =
     | [] -> []
 
   let rec find f = function
-    |[] -> None
-    |h :: t -> match f h with
-	 |None -> find f t
-	 |x -> x
+    | [] -> None
+    | h :: t -> match f h with
+	 | None -> find f t
+	 | x -> x
 
   let map f l =
     let rec aux f l = match l with

--- a/lib/option.mli
+++ b/lib/option.mli
@@ -122,6 +122,9 @@ module List : sig
       [Some y] (in the same order). *)
   val flatten : 'a option list -> 'a list
 
+  (** [List.find f l] is the first [f a] different from [None],
+      scrolling through elements [a] of [l] in left-to-right order;
+      it is [None] if no such element exists. *)
   val find : ('a -> 'b option) -> 'a list -> 'b option
 
   (** [List.map f [a1;...;an]] is the list [Some [b1;...;bn]] if

--- a/lib/option.mli
+++ b/lib/option.mli
@@ -123,4 +123,10 @@ module List : sig
   val flatten : 'a option list -> 'a list
 
   val find : ('a -> 'b option) -> 'a list -> 'b option
+
+  (** [List.map f [a1;...;an]] is the list [Some [b1;...;bn]] if
+      for all i, there is a [bi] such that [f ai] is [Some bi]; it is
+      [None] if, for at least one i, [f ai] is [None]. *)
+  val map : ('a -> 'b option) -> 'a list -> 'b list option
+
 end

--- a/pretyping/evarsolve.ml
+++ b/pretyping/evarsolve.ml
@@ -470,23 +470,13 @@ let free_vars_and_rels_up_alias_expansion sigma aliases c =
 (* Managing pattern-unification *)
 (********************************)
 
-let map_all f l =
-  let rec map_aux f l = match l with
-  | [] -> []
-  | x :: l ->
-    match f x with
-    | None -> raise Exit
-    | Some y -> y :: map_aux f l
-  in
-  try Some (map_aux f l) with Exit -> None
-
 let expand_and_check_vars sigma aliases l =
   let map a = match get_alias_chain_of sigma aliases a with
   | None, [] -> Some a
   | None, a :: _ -> Some a
   | Some _, _ -> None
   in
-  map_all map l
+  Option.List.map map l
 
 let alias_distinct l =
   let rec check (rels, vars) = function
@@ -540,7 +530,7 @@ let is_unification_pattern_meta env evd nb m l t =
   | Rel n -> if n <= nb then Some (RelAlias n) else None
   | _ -> None
   in
-  match map_all map l with
+  match Option.List.map map l with
   | Some l ->
     begin match find_unification_pattern_args env evd l t with
     | Some _ as x when not (dependent evd (mkMeta m) t) -> x
@@ -550,10 +540,10 @@ let is_unification_pattern_meta env evd nb m l t =
     None
 
 let is_unification_pattern_evar env evd (evk,args) l t =
-  match map_all (fun c -> to_alias evd c) l with
+  match Option.List.map (fun c -> to_alias evd c) l with
   | Some l when noccur_evar env evd evk t ->
     let args = remove_instance_local_defs evd evk args in
-    let args = map_all (fun c -> to_alias evd c) args in
+    let args = Option.List.map (fun c -> to_alias evd c) args in
     begin match args with
     | None -> None
     | Some args ->

--- a/test-suite/success/unification.v
+++ b/test-suite/success/unification.v
@@ -188,3 +188,14 @@ Proof.
   apply idpath.
   apply idpath.
 Defined.
+
+(* An example where it is necessary to evar-normalize the instance of
+   an evar to evaluate if it is a pattern *)
+
+Check
+  let a := ?[P] in
+  fun (H : forall y (P : nat -> Prop), y = 0 -> P y)
+      x (p:x=0) =>
+    H ?[y] a p : x = 0.
+(* We have to solve "?P ?y[x] == x = 0" knowing from
+   "p : (x=0) == (?y[x] = 0)" that "?y := x" *)


### PR DESCRIPTION
Adding a test-suite pattern-unification example of the form of those that `Econstr` now fixes once for all.

Seizing also this opportunity to raise a local utility function of general interest in `evarsolve.ml` into a reusable function of our extended `List` library.

In short, a very minor contribution, but which goes in the directions that we are following: more regression tests, valorizing reusable abstractions.
