### PR TITLE
Avoiding registering files from _build_ci for computing dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,8 @@ FIND_VCS_CLAUSE:='(' \
   -name '.bzr' -o \
   -name 'debian' -o \
   -name "$${GIT_DIR}" -o \
-  -name '_build' \
+  -name '_build' -o \
+  -name '_build_ci' \
 ')' -prune -o
 
 define find


### PR DESCRIPTION
Hi, calling `make` was trying to build `.ml.d` files within `_build_ci` even when simply compiling coq, sometimes failing in producing the `.d` file.

This minor PR proposes to skip `_build_ci`, but I'm not expert, so, experts, please fell free to apply what you think is the appropriate fix.

Actually, this is not unrelated to PR #499 by @matejkosik about the "good" strategy to define _the_ `.v` to compile.