### PR TITLE
Fixing #5487 (v8.5 regression on ltac-matching expressions with evars).

### DIFF
--- a/pretyping/constr_matching.ml
+++ b/pretyping/constr_matching.ml
@@ -347,6 +347,9 @@ let matches_core env sigma convert allow_partial_app allow_bound_rels
 
       |	PFix c1, Fix _ when eq_constr (mkFix c1) cT -> subst
       |	PCoFix c1, CoFix _ when eq_constr (mkCoFix c1) cT -> subst
+      | PEvar (c1,args1), Evar (c2,args2) when c1 = c2 ->
+         Array.fold_left2 (sorec ctx env) subst args1 args2
+
       | _ -> raise PatternMatchingFailure
 
   in

--- a/pretyping/patternops.ml
+++ b/pretyping/patternops.ml
@@ -160,7 +160,9 @@ let pattern_of_constr env sigma t =
 	let ty = Evarutil.nf_evar sigma (existential_type sigma ev) in
 	let () = ignore (pattern_of_constr env ty) in
         assert (not b); PMeta (Some id)
-      | Evar_kinds.GoalEvar -> 
+      | Evar_kinds.GoalEvar | Evar_kinds.VarInstance _ ->
+        (* These are the two evar kinds used for existing goals *)
+        (* see Proofview.mark_in_evm *)
 	PEvar (evk,Array.map (pattern_of_constr env) ctxt)
       | _ -> 
 	let ty = Evarutil.nf_evar sigma (existential_type sigma ev) in

--- a/test-suite/bugs/closed/5487.v
+++ b/test-suite/bugs/closed/5487.v
@@ -1,0 +1,9 @@
+(* Was a collision between an ltac pattern variable and an evar *)
+
+Goal forall n, exists m, n = m :> nat.
+Proof.
+  eexists.
+  Fail match goal with
+  | [ |- ?x = ?y ]
+    => match x with y => idtac end
+  end.

--- a/test-suite/success/ltac.v
+++ b/test-suite/success/ltac.v
@@ -317,3 +317,16 @@ let T := constr:(fun a b : nat => a) in
   end.
 exact (eq_refl n).
 Qed.
+
+(* A variant of #2602 which was wrongly succeeding because "a", bound to
+   "?m", was then internally turned into a "_" in the second matching *)
+
+Goal exists m, S m > 0.
+eexists.
+Fail match goal with
+ | |- context [ S ?a ] =>
+     match goal with
+       | |- S a > a => idtac
+     end
+end.
+Abort.


### PR DESCRIPTION
Wondering what to do with #5487 after the emotion that its badly-checked commit created, I'm finally leaning to submit it as a PR, letting future knows if this is the right decision to take or not. I have virtually many things to say about the bug and about what it relates to, but I don't want to clutter the PR system excessively, so I shall just say that the fix is made much simpler (and less ambitious) than discussed on Gitter on Wednesday 26 April as I renounced to seize the opportunity of the bug to clarify the two interpretation paths from text to `CEvar` to `constr_pattern` (where `?x` means a pattern variable) and from text to `CEvar` to `glob_constr` (where `?x` means an evar). 