### PR TITLE
Repairing `Set Rewriting Schemes`

### DIFF
--- a/test-suite/success/Scheme.v
+++ b/test-suite/success/Scheme.v
@@ -2,3 +2,26 @@
 
 Scheme Induction for eq Sort Prop.
 Check eq_ind_dep.
+
+(* This was broken in v8.5 *)
+
+Set Rewriting Schemes.
+Inductive myeq A (a:A) : A -> Prop := myrefl : myeq A a a.
+Unset Rewriting Schemes.
+
+Check myeq_rect.
+Check myeq_ind.
+Check myeq_rec.
+Check myeq_congr.
+Check myeq_sym_internal.
+Check myeq_rew.
+Check myeq_rew_dep.
+Check myeq_rew_fwd_dep.
+Check myeq_rew_r.
+Check internal_myeq_sym_involutive.
+Check myeq_rew_r_dep.
+Check myeq_rew_fwd_r_dep.
+
+Set Rewriting Schemes.
+Inductive myeq_true : bool -> Prop := myrefl_true : myeq_true true.
+Unset Rewriting Schemes.


### PR DESCRIPTION
This fixes 2 causes of breakage of `Set Rewriting Schemes` in v8.5. I also added a regression test.

One interest of `Set Rewriting Schemes` is that it pre-computes the various schemes `eq_rew_fwd_dep`, `eq_rew_r_dep`, `eq_rew_fwd_r_dep`, etc. which are needed to implement the different variants of `rewrite` (dependent or not, in the context or in the conclusion, left-to-right or right-to-left). Additionally, it works generically, so, in principle, no need to hard-wire `eq` in `rewrite` with these tools. It also works for some non-standard form of equality such as `eq_true`, which `rewrite` knows how to handle actually.

Additionally, `Set Rewriting Schemes` automatically generates proofs of symmetry, proofs of involutivity of symmetry, and proofs of congruence (in some cases).

This is part of a project which I think is important, to build a library of automatically generated mathematical (inductive) schemes (and more generally of mathematical properties, typically characterized as type classes), as currently done in `indrec.ml`, `eqschemes.ml`, `indschemes.ml`, but also in `Equations`, and in other contributions here and there.

The general idea, which is not original, but which I will describe, is typically that each inductive defines a proper name space where to host generically defined properties, (as was discussed already long time ago), say Nat.rec, Nat.ind, Nat.eqb, but virtually also Nat.inj_S, Nat.dec, ... and that for each of these, there is a recipe to build the scheme, and the recipe being applied either automatically, `Set Rewriting Scheme` style, or manually `Scheme Equality` style, or lazily, as with `find_scheme` (which is currently managed as a side effect). This is however a long term project which requires the work of several contributors.