### PR TITLE
Some factorizations of ltac interpretation functions between ssreflect and coq code

### DIFF
--- a/dev/ci/ci-user-overlay.sh
+++ b/dev/ci/ci-user-overlay.sh
@@ -25,10 +25,8 @@ echo $TRAVIS_PULL_REQUEST
 echo $TRAVIS_BRANCH
 echo $TRAVIS_COMMIT
 
-if [ $TRAVIS_PULL_REQUEST == "678" ] || [ $TRAVIS_BRANCH == "coqlib-part-02" ]; then
-
-    mathcomp_CI_BRANCH=coqlib-part-02
-    mathcomp_CI_GITURL=https://github.com/ejgallego/math-comp.git
-
+if [ $TRAVIS_PULL_REQUEST == "600" ] || [ $TRAVIS_BRANCH == "trunk+some-factorizations-with-ssreflect" ]; then
+    mathcomp_CI_BRANCH=trunk+interp_closed_glob_constr
+    mathcomp_CI_GITURL=https://github.com/herbelin/math-comp.git
 fi
 

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -577,57 +577,47 @@ let extract_ltac_constr_context ist env sigma =
 
 (** Significantly simpler than [interp_constr], to interpret an
     untyped constr, it suffices to adjoin a closure environment. *)
-let interp_uconstr ist env sigma = function
-  | (term,None) ->
-      { closure = extract_ltac_constr_context ist env sigma; term }
-  | (_,Some ce) ->
-      let ( {typed ; untyped } as closure) = extract_ltac_constr_context ist env sigma in
-      let ltacvars = {
-        Constrintern.ltac_vars = Id.(Set.union (Map.domain typed) (Map.domain untyped));
-        ltac_bound = Id.Map.domain ist.lfun;
-        ltac_extra = Genintern.Store.empty;
-      } in
-      { closure ; term =  intern_gen WithoutTypeConstraint ~ltacvars env ce }
-
-let interp_gen kind ist allow_patvar flags env sigma (c,ce) =
-  let constrvars = extract_ltac_constr_context ist env sigma in
-  let vars = {
-    Pretyping.ltac_constrs = constrvars.typed;
-    Pretyping.ltac_uconstrs = constrvars.untyped;
-    Pretyping.ltac_idents = constrvars.idents;
-    Pretyping.ltac_genargs = ist.lfun;
-  } in
-  let c = match ce with
-  | None -> c
-    (* If at toplevel (ce<>None), the error can be due to an incorrect
-       context at globalization time: we retype with the now known
-       intros/lettac/inversion hypothesis names *)
-  | Some c ->
+let interp_glob_closure ist env sigma ?(kind=WithoutTypeConstraint) ?(allow_patvar=false) (term,term_expr_opt) =
+  let closure = extract_ltac_constr_context ist env sigma in
+  match term_expr_opt with
+  | None -> { closure ; term }
+  | Some term_expr ->
+     (* If at toplevel (term_expr_opt<>None), the error can be due to
+       an incorrect context at globalization time: we retype with the
+       now known intros/lettac/inversion hypothesis names *)
       let constr_context =
         Id.Set.union
-          (Id.Map.domain constrvars.typed)
-       (Id.Set.union
-          (Id.Map.domain constrvars.untyped)
-          (Id.Map.domain constrvars.idents))
+          (Id.Map.domain closure.typed)
+          (Id.Map.domain closure.untyped)
       in
       let ltacvars = {
         ltac_vars = constr_context;
         ltac_bound = Id.Map.domain ist.lfun;
         ltac_extra = Genintern.Store.empty;
       } in
-      let kind_for_intern =
-        match kind with OfType _ -> WithoutTypeConstraint | _ -> kind in
-      intern_gen kind_for_intern ~allow_patvar ~ltacvars env c
-  in
+      { closure ; term = intern_gen kind ~allow_patvar ~ltacvars env term_expr }
+
+let interp_uconstr ist env sigma c = interp_glob_closure ist env sigma c
+
+let interp_gen kind ist allow_patvar flags env sigma c =
+  let kind_for_intern = match kind with OfType _ -> WithoutTypeConstraint | _ -> kind in
+  let { closure = constrvars ; term } =
+    interp_glob_closure ist env sigma ~kind:kind_for_intern ~allow_patvar c in
+  let vars = {
+    Pretyping.ltac_constrs = constrvars.typed;
+    Pretyping.ltac_uconstrs = constrvars.untyped;
+    Pretyping.ltac_idents = constrvars.idents;
+    Pretyping.ltac_genargs = ist.lfun;
+  } in
   (* Jason Gross: To avoid unnecessary modifications to tacinterp, as
       suggested by Arnaud Spiwack, we run push_trace immediately.  We do
       this with the kludge of an empty proofview, and rely on the
       invariant that running the tactic returned by push_trace does
       not modify sigma. *)
   let (_, dummy_proofview) = Proofview.init sigma [] in
-  let (trace,_,_,_) = Proofview.apply env (push_trace (loc_of_glob_constr c,LtacConstrInterp (c,vars)) ist) dummy_proofview in
+  let (trace,_,_,_) = Proofview.apply env (push_trace (loc_of_glob_constr term,LtacConstrInterp (term,vars)) ist) dummy_proofview in
   let (evd,c) =
-    catch_error trace (understand_ltac flags env sigma vars kind) c
+    catch_error trace (understand_ltac flags env sigma vars kind) term
   in
   (* spiwack: to avoid unnecessary modifications of tacinterp, as this
      function already use effect, I call [run] hoping it doesn't mess

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -673,10 +673,10 @@ let pure_open_constr_flags = {
 
 (* Interprets an open constr *)
 let interp_open_constr ?(expected_type=WithoutTypeConstraint) ist env sigma c =
-  let flags =
-    if expected_type == WithoutTypeConstraint then open_constr_no_classes_flags ()
-    else open_constr_use_classes_flags () in
-  interp_gen expected_type ist false flags env sigma c
+  interp_gen expected_type ist false (open_constr_no_classes_flags ()) env sigma c
+
+let interp_open_constr_with_classes ?(expected_type=WithoutTypeConstraint) ist env sigma c =
+  interp_gen expected_type ist false (open_constr_use_classes_flags ()) env sigma c
 
 let interp_pure_open_constr ist =
   interp_gen WithoutTypeConstraint ist false pure_open_constr_flags

--- a/plugins/ltac/tacinterp.mli
+++ b/plugins/ltac/tacinterp.mli
@@ -72,11 +72,18 @@ val interp_redexp : Environ.env -> Evd.evar_map -> raw_red_expr -> Evd.evar_map 
 val interp_hyp : interp_sign -> Environ.env -> Evd.evar_map ->
   Id.t Loc.located -> Id.t
 
+val interp_glob_closure : interp_sign -> Environ.env -> Evd.evar_map ->
+  ?kind:Pretyping.typing_constraint -> ?allow_patvar:bool -> glob_constr_and_expr ->
+  Glob_term.closed_glob_constr
+
+val interp_uconstr : interp_sign -> Environ.env -> Evd.evar_map ->
+  glob_constr_and_expr -> Glob_term.closed_glob_constr
+
 val interp_constr_gen : Pretyping.typing_constraint -> interp_sign ->
   Environ.env -> Evd.evar_map -> glob_constr_and_expr -> Evd.evar_map * constr
 
 val interp_bindings : interp_sign -> Environ.env -> Evd.evar_map ->
- glob_constr_and_expr bindings -> Evd.evar_map * constr bindings
+  glob_constr_and_expr bindings -> Evd.evar_map * constr bindings
 
 val interp_open_constr : ?expected_type:Pretyping.typing_constraint ->
   interp_sign -> Environ.env -> Evd.evar_map ->

--- a/plugins/ltac/tacinterp.mli
+++ b/plugins/ltac/tacinterp.mli
@@ -78,6 +78,14 @@ val interp_constr_gen : Pretyping.typing_constraint -> interp_sign ->
 val interp_bindings : interp_sign -> Environ.env -> Evd.evar_map ->
  glob_constr_and_expr bindings -> Evd.evar_map * constr bindings
 
+val interp_open_constr : ?expected_type:Pretyping.typing_constraint ->
+  interp_sign -> Environ.env -> Evd.evar_map ->
+  glob_constr_and_expr -> Evd.evar_map * EConstr.constr
+
+val interp_open_constr_with_classes : ?expected_type:Pretyping.typing_constraint ->
+  interp_sign -> Environ.env -> Evd.evar_map ->
+  glob_constr_and_expr -> Evd.evar_map * EConstr.constr
+
 val interp_open_constr_with_bindings : interp_sign -> Environ.env -> Evd.evar_map ->
   glob_constr_and_expr with_bindings -> Evd.evar_map * EConstr.constr with_bindings
 

--- a/test-suite/success/Scopes.v
+++ b/test-suite/success/Scopes.v
@@ -20,3 +20,9 @@ Inductive U := A.
 Bind Scope u with U.
 Notation "'ε'" := A : u.
 Definition c := ε : U.
+
+(* Check activation of type scope for tactics such as assert *)
+
+Goal True.
+assert (nat * nat).
+


### PR DESCRIPTION
I'm obviously not the only one to have observed that ssreflect has dependences in pretty low-level interfaces of Coq. For instance, I recently fall recently on a dependence in `Pretyping.empty_lvar` which broke a PR because `empty_lvar` moved to `Glob_term`.

This commit is an experiment in trying to share abstractions between ssreflect and Coq, namely here `Ssreflect.interp_open_constr` (which actually exists in Coq but is not exported) and `interp_uconstr` not exported either but used in `Ssreflect.interp_refine`. By sharing these abstractions, we also reduce the need for low-level details, as said above.

In the move, I realized various inconsistent behaviors:
- ltac variables bound to a name were discarded by interp_uconstr but not by interp_gen. I could not find an example where it matters, but I'm not 100% sure it does not matter, and maybe it is the interp_gen behavior which is expected.
- ssreflect does not seem to support the "Declare Implicit Tactic" command. Is it intended. It seems to me that it costs nothing to support it. Users who are not interested will not use it. Uses who are interested in both "Declare Implicit Tactic" and the ssreflect tactics might be frustrated not to be able to have both at the same time. Even though "Declare Implicit Tactic" might be later subsumed as was discussed a couple of months ago.  With my proposal, ssreflect would smoothly support "Declare Implicit Tactic".
- ssreflect did not seem to support uconstr ltac variables. With my factorization, ssreflect should support directly the recent uconstr feature (though I did not test).

So, more factoring between ssreflect and Coq code, so as to simplify interfacing and ensuring a greater consistency of behavior. Any opinion about going in this direction?
