### PR TITLE
Report a useful error for dependent induction

### DIFF
--- a/theories/Init/Tactics.v
+++ b/theories/Init/Tactics.v
@@ -236,3 +236,10 @@ Tactic Notation "clear" "dependent" hyp(h) :=
 
 Tactic Notation "revert" "dependent" hyp(h) :=
  generalize dependent h.
+
+(** Provide an error message for dependent induction that reports an import is
+required to use it. Importing Coq.Program.Equality will shadow this notation
+with the actual [dependent induction] tactic. *)
+
+Tactic Notation "dependent" "induction" ident(H) :=
+  fail "To use dependent induction, first [Require Import Coq.Program.Equality.]".


### PR DESCRIPTION
The dependent induction tactic notation is in the standard library but not loaded by default, leading to a parser error message that is confusing and unhelpful. This commit adds a notation for dependent induction to Init that fails and reports `Require Import Coq.Program.Equality.` is required to use `dependent induction`.