### PR TITLE
Enhance [merge] for Stores used in [Evd.restrict] and evar-evar assig…

### DIFF
--- a/clib/exninfo.ml
+++ b/clib/exninfo.ml
@@ -20,7 +20,7 @@ type info = Store.t
 
 type iexn = exn * info
 
-let make = Store.field
+let make () = Store.field Store.default_merge_field
 let add = Store.set
 let get = Store.get
 let null = Store.empty

--- a/clib/store.ml
+++ b/clib/store.ml
@@ -117,7 +117,7 @@ let field merge =
     let len = Array.length init in
     if i < len then ()
     else begin
-      let arr = allocate (len + 1) in
+      let arr = allocate (len * 2) in
       Array.blit init 0 arr 0 len;
       merge_fns := arr
     end

--- a/clib/store.ml
+++ b/clib/store.ml
@@ -19,13 +19,15 @@
 module type S =
 sig
   type t
+  type 'a merge_field = 'a option -> 'a option -> 'a option
   type 'a field
   val empty : t
   val set : t -> 'a field -> 'a -> t
   val get : t -> 'a field -> 'a option
   val remove : t -> 'a field -> t
   val merge : t -> t -> t
-  val field : unit -> 'a field
+  val field : 'a merge_field -> 'a field
+  val default_merge_field : 'a merge_field
 end
 
 module Make () : S =
@@ -41,9 +43,16 @@ struct
   (** Store are represented as arrays. For small values, which is typicial,
       is slightly quicker than other implementations. *)
 
-type 'a field = int
+  type 'a merge_field = 'a option -> 'a option -> 'a option
+
+  type 'a field = int
 
 let allocate len : t = Array.make len None
+
+let merge_fns = ref (Array.make 10 (Obj.magic (fun _ _ -> None)))
+(** Merge functions are declared for all fields of the store. The merge
+    function array is global for all store objects of this type and grows
+    monotonically with each new field declaration. *)
 
 let empty : t = [||]
 
@@ -74,16 +83,38 @@ let merge (s1 : t) (s2 : t) : t =
   let len2 = Array.length s2 in
   let nlen = if len1 < len2 then len2 else len1 in
   let ans = allocate nlen in
-  (** Important: No more allocation from here. *)
-  Array.blit s2 0 ans 0 len2;
-  for i = 0 to pred len1 do
-    let v = Array.unsafe_get s1 i in
-    match v with
-    | None -> ()
-    | Some _ -> Array.unsafe_set ans i v
+  let merge i x y =
+    let fn = Array.unsafe_get !merge_fns i in
+    let fn : 'a merge_field = Obj.magic fn in
+    fn x y
+  in
+  for i = 0 to pred nlen do
+    let v1 = if i < len1 then Array.unsafe_get s1 i else None in
+    let v2 = if i < len2 then Array.unsafe_get s2 i else None in
+    Array.unsafe_set ans i (merge i v1 v2)
   done;
   ans
 
-let field () = next ()
+let field merge =
+  let i = next () in
+  let () =
+    (** Extend merge array if too small *)
+    let init = !merge_fns in
+    let len = Array.length init in
+    if i < len then ()
+    else begin
+      let arr = allocate (len + 1) in
+      Array.blit init 0 arr 0 len;
+      merge_fns := arr
+    end
+  in
+  Array.set !merge_fns i (Obj.magic merge);
+  i
+
+let default_merge_field x y =
+  match x, y with
+  | None, None -> None
+  | Some _, _ -> x
+  | _, Some _ -> y
 
 end

--- a/clib/store.mli
+++ b/clib/store.mli
@@ -16,6 +16,10 @@ sig
   type t
   (** Type of stores *)
 
+  type 'a merge_field = 'a option -> 'a option -> 'a option
+  (** Type of merging function when merging two stores potentially
+      having values for the same field (used in [merge] only). *)
+
   type 'a field
   (** Type of field of such stores *)
 
@@ -32,10 +36,16 @@ sig
   (** Unset the value of the field *)
 
   val merge : t -> t -> t
-  (** [merge s1 s2] adds all the fields of [s1] into [s2]. *)
+  (** [merge s1 s2] merges the fields of [s1] into [s2].
+      It merges values for the same field according to the [merge] function
+      of the field, called with optional values of [s1] and [s2]. *)
 
-  val field : unit -> 'a field
-  (** Create a new field *)
+  val field : 'a merge_field -> 'a field
+  (** Create a new field with the associated merge function. *)
+
+  val default_merge_field : 'a merge_field
+  (** The default strategy for merge is to always favor the value from
+      [s1] in [merge s1 s2], if present. *)
 
 end
 

--- a/clib/store.mli
+++ b/clib/store.mli
@@ -16,7 +16,11 @@ sig
   type t
   (** Type of stores *)
 
-  type 'a merge_field = 'a option -> 'a option -> 'a option
+  type 'a merge_arg =
+    | One of 'a
+    | Both of 'a * 'a
+
+  type 'a merge_field = 'a merge_arg -> 'a option
   (** Type of merging function when merging two stores potentially
       having values for the same field (used in [merge] only). *)
 

--- a/dev/ci/user-overlays/00661-mattam82-evarstore.sh
+++ b/dev/ci/user-overlays/00661-mattam82-evarstore.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+if [ "$CI_PULL_REQUEST" = "661" ] || [ "$CI_BRANCH" = "evarstore" ]; then
+    ltac2_CI_REF=evarstore
+    ltac2_CI_GITURL=https://github.com/mattam82/ltac2
+fi

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -634,7 +634,13 @@ let evar_source evk d = (find d evk).evar_source
 let evar_ident evk evd = EvNames.ident evk evd.evar_names
 let evar_key id evd = EvNames.key id evd.evar_names
 
-let restricted = Store.field ()
+
+(** This will be called in evar-evar unifications to set the restricted flag
+    of the defined evar, given the restricted flag of the "to be defined" evar first.
+    Only defined evars can have the restricted flag, so this returns None. *)
+let merge_restricted x y = None
+
+let restricted = Store.field merge_restricted
 
 let define_aux ?dorestrict def undef evk body =
   let oldinfo =

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -638,7 +638,7 @@ let evar_key id evd = EvNames.key id evd.evar_names
 (** This will be called in evar-evar unifications to set the restricted flag
     of the defined evar, given the restricted flag of the "to be defined" evar first.
     Only defined evars can have the restricted flag, so this returns None. *)
-let merge_restricted x y = None
+let merge_restricted xy = None
 
 let restricted = Store.field merge_restricted
 

--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -60,15 +60,15 @@ type telescope =
   | TNil of Evd.evar_map
   | TCons of Environ.env * Evd.evar_map * EConstr.types * (Evd.evar_map -> EConstr.constr -> telescope)
 
-(** This will be called in evar-evar unifications to set the resolvable flag
-    of the undefined evar, given the resolvable flag of the "to be defined" evar first.
-    If one of those is marked [resolvable] then the undefined evar becomes resolvable. *)
-let merge_typeclass_unresolvable x y =
-  match x, y with
-  | None, None -> None
-  | Some _, None -> y
-  | None, Some _ -> x
-  | Some _, Some _ -> x
+(** This will be called in evar-evar unifications to set the resolvable
+    flag of the undefined evar, given the resolvable flag of the "to be
+    defined" evar first.  If at least one of those is not marked
+    [unresolvable] then the undefined evar becomes resolvable. *)
+let merge_typeclass_unresolvable xy =
+  let open Evd.Store in
+  match xy with
+  | One () -> None
+  | Both (x, y) -> Some x
 
 let typeclass_unresolvable = Evd.Store.field merge_typeclass_unresolvable
 
@@ -778,7 +778,7 @@ let mark_in_evm ~goal evd content =
   in
   let info = match get_typeclass_unresolvable info.Evd.evar_extra with
   | None -> { info with Evd.evar_extra = set_typeclass_unresolvable info.Evd.evar_extra }
-  | Some _ -> info
+  | Some () -> info
   in
   Evd.add evd content info
 

--- a/engine/proofview.mli
+++ b/engine/proofview.mli
@@ -463,6 +463,9 @@ module Unsafe : sig
   (** Make an evar unresolvable for type classes. *)
   val mark_as_unresolvable : proofview -> Evar.t -> proofview
 
+  (** An [Evd.evar_extra] field for unresolvability of an evar *)
+  val typeclass_unresolvable : unit Evd.Store.field
+
   (** [advance sigma g] returns [Some g'] if [g'] is undefined and is
       the current avatar of [g] (for instance [g] was changed by [clear]
       into [g']). It returns [None] if [g] has been (partially)
@@ -474,9 +477,6 @@ module Unsafe : sig
       defined *)
   val undefined : Evd.evar_map -> Proofview_monad.goal_with_state list ->
     Proofview_monad.goal_with_state list
-
-  val typeclass_resolvable : unit Evd.Store.field
-
 end
 
 (** This module gives access to the innards of the monad. Its use is

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -127,10 +127,10 @@ let name_vfun appl vle =
 
 module TacStore = Geninterp.TacStore
 
-let f_avoid_ids : Id.Set.t TacStore.field = TacStore.field ()
+let f_avoid_ids : Id.Set.t TacStore.field = TacStore.field TacStore.default_merge_field
 (* ids inherited from the call context (needed to get fresh ids) *)
-let f_debug : debug_info TacStore.field = TacStore.field ()
-let f_trace : ltac_trace TacStore.field = TacStore.field ()
+let f_debug : debug_info TacStore.field = TacStore.field TacStore.default_merge_field
+let f_trace : ltac_trace TacStore.field = TacStore.field TacStore.default_merge_field
 
 (* Signature for interpretation: val_interp and interpretation functions *)
 type interp_sign = Geninterp.interp_sign = {

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -1529,8 +1529,9 @@ end
 
 module MakeState(S : StateType) = struct
 
+(** State is kept during merges of evars *)
 let state_field : S.state Proofview_monad.StateStore.field =
-  Proofview_monad.StateStore.field ()
+  Proofview_monad.StateStore.field Proofview_monad.StateStore.default_merge_field
 
 (* FIXME: should not inject fresh_state, but initialize it at the beginning *)
 let lift_upd_state upd s =

--- a/pretyping/evarsolve.ml
+++ b/pretyping/evarsolve.ml
@@ -1265,14 +1265,7 @@ let solve_evar_evar_l2r force f g env evd aliases pbty ev1 (evk2,_ as ev2) =
 let opp_problem = function None -> None | Some b -> Some (not b)
 
 (** Support for program obligations: during merges of evars, the obligation flag is kept *)
-let merge_obligation x y =
-  match x, y with
-  | Some _, None -> x
-  | None, Some _ -> y
-  | Some _, Some _ -> x
-  | None, None -> x
-
-let obligation = Evd.Store.field merge_obligation
+let obligation = Evd.Store.field Evd.Store.default_merge_field
 
 let obligation_store = Evd.Store.set Evd.Store.empty obligation ()
 

--- a/pretyping/evarsolve.ml
+++ b/pretyping/evarsolve.ml
@@ -1240,33 +1240,51 @@ let check_evar_instance evd evk1 body conv_algo =
   | Success evd -> evd
   | UnifFailure _ -> raise (IllTypedInstance (evenv,ty, evi.evar_concl))
 
-let update_evar_source ev1 ev2 evd =
-  let loc, evs2 = evar_source ev2 evd in
-  match evs2 with
-  | (Evar_kinds.QuestionMark _ | Evar_kinds.ImplicitArg (_, _, false)) ->
-     let evi = Evd.find evd ev1 in
-     Evd.add evd ev1 {evi with evar_source = loc, evs2}
-  | _ -> evd
-  
+let update_evar_info ev1 ev2 evd =
+  let evi = find evd ev2 in
+  let loc, evs2 = evi.evar_source in
+  let evi = Evd.find evd ev1 in
+  let evi' =
+    match evs2 with
+    | (Evar_kinds.QuestionMark _ | Evar_kinds.ImplicitArg (_, _, false)) ->
+       {evi with evar_source = loc, evs2}
+    | _ -> evi
+  in
+  let evi' = { evi with evar_extra = Evd.Store.merge evi.evar_extra evi'.evar_extra } in
+  Evd.add evd ev1 evi'
+
 let solve_evar_evar_l2r force f g env evd aliases pbty ev1 (evk2,_ as ev2) =
   try
     let evd,body = project_evar_on_evar force g env evd aliases 0 pbty ev1 ev2 in
     let evd' = Evd.define evk2 body evd in
-    let evd' = update_evar_source (fst (destEvar evd body)) evk2 evd' in
+    let evd' = update_evar_info (fst (destEvar evd body)) evk2 evd' in
       check_evar_instance evd' evk2 body g
   with EvarSolvedOnTheFly (evd,c) ->
     f env evd pbty ev2 c
 
 let opp_problem = function None -> None | Some b -> Some (not b)
 
+(** Support for program obligations: during merges of evars, the obligation flag is kept *)
+let merge_obligation x y =
+  match x, y with
+  | Some _, None -> x
+  | None, Some _ -> y
+  | Some _, Some _ -> x
+  | None, None -> x
+
+let obligation = Evd.Store.field merge_obligation
+
+let obligation_store = Evd.Store.set Evd.Store.empty obligation ()
+
+let is_obligation store = not (Option.is_empty (Evd.Store.get store obligation))
+
 let preferred_orientation evd evk1 evk2 =
-  let _,src1 = (Evd.find_undefined evd evk1).evar_source in
-  let _,src2 = (Evd.find_undefined evd evk2).evar_source in
+  let extra1 = (Evd.find_undefined evd evk1).evar_extra in
+  let extra2 = (Evd.find_undefined evd evk2).evar_extra in
   (* This is a heuristic useful for program to work *)
-  match src1,src2 with
-  | (Evar_kinds.QuestionMark _ | Evar_kinds.ImplicitArg (_, _, false)) , _ -> true
-  | _, (Evar_kinds.QuestionMark _ | Evar_kinds.ImplicitArg (_, _, false)) -> false
-  | _ -> true
+  if is_obligation extra1 then true
+  else if is_obligation extra2 then false
+  else true
 
 let solve_evar_evar_aux force f g env evd pbty (evk1,args1 as ev1) (evk2,args2 as ev2) =
   let aliases = make_alias_map env evd in

--- a/pretyping/evarsolve.mli
+++ b/pretyping/evarsolve.mli
@@ -86,3 +86,7 @@ val remove_instance_local_defs :
 
 val get_type_of_refresh : 
   ?polyprop:bool -> ?lax:bool -> env -> evar_map -> constr -> evar_map * types
+
+(** Support for program obligations *)
+
+val obligation_store : Evd.Store.t

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -89,7 +89,7 @@ let push_rel_context sigma ctx env = {
 
 let lookup_named id env = lookup_named id env.env
 
-let e_new_evar env evdref ?src ?naming typ =
+let e_new_evar env evdref ?src ?naming ?store typ =
   let open Context.Named.Declaration in
   let inst_vars = List.map (get_id %> mkVar) (named_context env.env) in
   let inst_rels = List.rev (rel_list 0 (nb_rel env.env)) in
@@ -98,7 +98,7 @@ let e_new_evar env evdref ?src ?naming typ =
   let instance = inst_rels @ inst_vars in
   let sign = val_of_named_context nc in
   let sigma = !evdref in
-  let (sigma, e) = new_evar_instance sign sigma typ' ?src ?naming instance in
+  let (sigma, e) = new_evar_instance sign sigma typ' ?src ?naming ?store instance in
   evdref := sigma;
   e
 
@@ -629,8 +629,16 @@ let rec pretype k0 resolve_tc (tycon : type_constraint) (env : ExtraEnv.t) evdre
         match tycon with
         | Some ty -> ty
         | None ->
-          new_type_evar env evdref loc in
-        { uj_val = e_new_evar env evdref ~src:(loc,k) ~naming ty; uj_type = ty }
+           new_type_evar env evdref loc in
+      let store =
+        if Flags.is_program_mode () then
+          match k with
+          | Evar_kinds.QuestionMark _
+          | Evar_kinds.ImplicitArg (_, _, false) -> Evarsolve.obligation_store
+          | _ -> Evd.Store.empty
+        else Evd.Store.empty
+      in
+        { uj_val = e_new_evar env evdref ~src:(loc,k) ~naming ~store ty; uj_type = ty }
 
   | GHole (k, _naming, Some arg) ->
       let env = ltac_interp_name_env k0 lvar env !evdref in

--- a/pretyping/typeclasses.ml
+++ b/pretyping/typeclasses.ml
@@ -504,15 +504,15 @@ let is_instance = function
    Nota: we will only check the resolvability status of undefined evars.
  *)
 
-let resolvable = Proofview.Unsafe.typeclass_resolvable
+let unresolvable = Proofview.Unsafe.typeclass_unresolvable
 
 let set_resolvable s b =
-  if b then Store.remove s resolvable
-  else Store.set s resolvable ()
+  if b then Store.remove s unresolvable
+  else Store.set s unresolvable ()
 
 let is_resolvable evi =
   assert (match evi.evar_body with Evar_empty -> true | _ -> false);
-  Option.is_empty (Store.get evi.evar_extra resolvable)
+  Option.is_empty (Store.get evi.evar_extra unresolvable)
 
 let mark_resolvability_undef b evi =
   if is_resolvable evi == (b : bool) then evi

--- a/vernac/egramcoq.ml
+++ b/vernac/egramcoq.ml
@@ -517,7 +517,7 @@ let extend_constr state forpat ng =
   in
   List.fold_left fold ([], state) ng.notgram_prods
 
-let constr_levels = GramState.field ()
+let constr_levels = GramState.field GramState.default_merge_field
 
 let extend_constr_notation ng state =
   let levels = match GramState.get state constr_levels with


### PR DESCRIPTION
…nments

Now restricted evars inherit the store of their parent, and when
solving evar-evar problems the undefined evars gets a [merge]d store.
The merge functions are stored in a separate array, and can be called
on empty values for the field.

This is used for the "unresolvable" flag of evars (renamed accordingly) and the "obligation" status of evars. Not sure this can apply to names of evars similarly.