### PR TITLE
coqtop -help: don't die if coqlib can't be found

### DIFF
--- a/toplevel/usage.ml
+++ b/toplevel/usage.ml
@@ -30,6 +30,7 @@ let print_usage_channel co command =
 \n  -R dir coqdir          recursively map physical dir to logical coqdir\
 \n  -Q dir coqdir          map physical dir to logical coqdir\
 \n  -top coqdir            set the toplevel name to be coqdir instead of Top\
+\n  -coqlib dir            set the coq standard library directory\
 \n  -exclude-dir f         exclude subdirectories named f for option -R\
 \n\
 \n  -noinit                start without loading the Init library\


### PR DESCRIPTION
There's a comment which says "We no longer use [Arg.parse], in order to use share [Usage.print_usage] between coqtop and coqc." dating from 76b16e44285d06236b9c00e24659138c376d54f3
I don't understand why Arg.parse couldn't share common parts between them, and it would avoid forgetting option in the usage like -coqlib.