### PR TITLE
Possibility of different warning defaults in compilation and interactive mode

### DIFF
--- a/kernel/names.ml
+++ b/kernel/names.ml
@@ -34,16 +34,8 @@ struct
 
   let hash = String.hash
 
-  let warn_invalid_identifier =
-    CWarnings.create ~name:"invalid-identifier" ~category:"parsing"
-                     ~default:CWarnings.Disabled
-                     (fun s -> str s)
-
-  let check_soft ?(warn = true) x =
-    let iter (fatal, x) =
-      if fatal then CErrors.error x else
-        if warn then warn_invalid_identifier x
-    in
+  let check_soft ?(strict=true) x =
+    let iter (fatal, x) = if fatal || strict then CErrors.error x in
     Option.iter iter (Unicode.ident_refutation x)
 
   let is_valid s = match Unicode.ident_refutation s with
@@ -60,7 +52,7 @@ struct
     String.hcons s
 
   let of_string_soft s =
-    let () = check_soft ~warn:false s in
+    let () = check_soft ~strict:false s in
     String.hcons s
 
   let to_string id = id

--- a/lib/cWarnings.mli
+++ b/lib/cWarnings.mli
@@ -10,7 +10,8 @@ type status = Disabled | Enabled | AsError
 
 val set_current_loc : Loc.t -> unit
 
-val create : name:string -> category:string -> ?default:status ->
+val create : name:string -> category:string ->
+             ?batch_default:status -> ?default:status ->
              ('a -> Pp.std_ppcmds) -> ?loc:Loc.t -> 'a -> unit
 
 val get_flags : unit -> string


### PR DESCRIPTION
This is a modest proposal for clarifying the status of the `invalid-identifier` and for giving the possibility of different default warnings in compilation and interactive mode as motivated in the discussion about generated name warning [#268](https://github.com/coq/coq/pull/268#issuecomment-299456681).