### PR TITLE
A small bug in 8.6's configure + a small cleaning of tools relatively to ocaml file names 

### DIFF
--- a/configure
+++ b/configure
@@ -27,7 +27,7 @@ done
 
 ## We check that $cmd is ok before the real exec $cmd
 
-`$cmd -version > /dev/null 2>&1` && exec $cmd $script "$@"
+`$cmd -version > /dev/null 2>&1` && exec $cmd -w "-3" $script "$@"
 
 ## If we're still here, something is wrong with $cmd
 

--- a/configure
+++ b/configure
@@ -3,7 +3,7 @@
 ## This micro-configure shell script is here only to
 ## launch the real configuration via ocaml
 
-cmd=ocaml
+ocaml=ocaml
 script=./configure.ml
 
 if [ ! -f $script ]; then
@@ -16,10 +16,11 @@ fi
 ## Parse the args, only looking for -camldir
 ## We avoid using shift to keep "$@" intact
 
+cmd=$ocaml
 last=
 for i; do
    case $last in
-       -camldir|--camldir) cmd="$i/ocaml"; break;;
+       -camldir) cmd="$i/$ocaml"; break;;
    esac
    last=$i
 done

--- a/configure.ml
+++ b/configure.ml
@@ -512,6 +512,8 @@ let camltag = match caml_version_list with
   | x::y::_ -> "OCAML"^x^y
   | _ -> assert false
 
+let coq_warn_flag =
+  if caml_version_nums > [4;2;3] then "-w -3-52-56" else ""
 
 (** * CamlpX configuration *)
 
@@ -1130,7 +1132,7 @@ let write_makefile f =
   pr "CAMLHLIB=%S\n\n" camllib;
   pr "# Caml link command and Caml make top command\n";
   pr "# Caml flags\n";
-  pr "CAMLFLAGS=-rectypes %s\n" coq_annotate_flag;
+  pr "CAMLFLAGS=-rectypes %s %s\n" coq_annotate_flag coq_warn_flag;
   pr "# User compilation flag\n";
   pr "USERFLAGS=\n\n";
   pr "# Flags for GCC\n";

--- a/configure.ml
+++ b/configure.ml
@@ -349,6 +349,8 @@ let args_options = Arg.align [
     " URL of the coq website";
   "-force-caml-version", Arg.Set Prefs.force_caml_version,
     " Force OCaml version";
+  "-camldir", Arg.String (fun _ -> ()),
+    "<dir> Specifies path to ocaml for running configure script";
 ]
 
 let parse_args () =

--- a/tools/coq_makefile.ml
+++ b/tools/coq_makefile.ml
@@ -643,11 +643,15 @@ let subdirs sds =
       section "Subdirectories.";
     List.iter pr_subdir sds
 
+let capitalize_caml_file_name s =
+ assert (String.length s <> 0 && s.[0] >= 'a' && s.[0] <= 'z');
+ String.make 1 (Char.chr (Char.code s.[0] - 32)) ^ String.sub s 1 (String.length s - 1)
+
 let forpacks l =
   let () = if l <> [] then section "Ad-hoc implicit rules for mlpack." in
   List.iter (fun it ->
     let h = Filename.chop_extension it in
-    let pk = String.capitalize (Filename.basename h) in
+    let pk = capitalize_caml_file_name (Filename.basename h) in
     printf "$(addsuffix .cmx,$(filter $(basename $(MLFILES)),$(%s_MLPACK_DEPENDENCIES))): %%.cmx: %%.ml\n" h;
     printf "\t$(SHOW)'CAMLOPT -c -for-pack %s $<'\n" pk;
     printf "\t$(HIDE)$(CAMLOPTC) $(ZDEBUG) $(ZFLAGS) -for-pack %s $<\n\n" pk;

--- a/tools/coqmktop.ml
+++ b/tools/coqmktop.ml
@@ -22,6 +22,10 @@ let split_list =
 
 let (/) = Filename.concat
 
+let capitalize_caml_file_name s =
+  assert (String.length s <> 0 && s.[0] >= 'a' && s.[0] <= 'z');
+  String.make 1 (Char.chr (Char.code s.[0] - 32)) ^ String.sub s 1 (String.length s - 1)
+
 (** Which user files do we support (and propagate to ocamlopt) ?
 *)
 let supported_suffix f = match CUnix.get_extension f with
@@ -39,7 +43,7 @@ let native_suffix f = match CUnix.get_extension f with
 (** Transforms a file name in the corresponding Caml module name.
 *)
 let module_of_file name =
-  String.capitalize
+  capitalize_caml_file_name
     (try Filename.chop_extension name with Invalid_argument _ -> name)
 
 (** Run a command [prog] with arguments [args].
@@ -137,7 +141,7 @@ let core_libs = split_list Tolink.core_libs
 *)
 let files_to_link userfiles =
   let top = if !top then topobjs else [] in
-  let modules = List.map module_of_file (top @ core_objs @ userfiles) in
+  let modules = List.map module_of_file top @ core_objs @ List.map module_of_file userfiles in
   let objs = libobjs @ top @ core_libs in
   let objs' = (if !opt then List.map native_suffix objs else objs) @ userfiles
   in (modules, objs')

--- a/tools/ocamllibdep.mll
+++ b/tools/ocamllibdep.mll
@@ -11,18 +11,25 @@
 
   let syntax_error lexbuf =
     raise (Syntax_error (Lexing.lexeme_start lexbuf, Lexing.lexeme_end lexbuf))
+
+  let capitalize_caml_file_name s =
+    assert (String.length s <> 0 && s.[0] >= 'a' && s.[0] <= 'z');
+    String.make 1 (Char.chr (Char.code s.[0] - 32)) ^ String.sub s 1 (String.length s - 1)
+
+  let uncapitalize_caml_module_name s =
+    assert (String.length s <> 0 && s.[0] >= 'A' && s.[0] <= 'Z');
+    String.make 1 (Char.chr (Char.code s.[0] + 32)) ^ String.sub s 1 (String.length s - 1)
 }
 
 let space = [' ' '\t' '\n' '\r']
-let lowercase = ['a'-'z' '\223'-'\246' '\248'-'\255']
-let uppercase = ['A'-'Z' '\192'-'\214' '\216'-'\222']
-let identchar =
-  ['A'-'Z' 'a'-'z' '_' '\192'-'\214' '\216'-'\246' '\248'-'\255' '\'' '0'-'9']
+let lowercase = ['a'-'z']
+let uppercase = ['A'-'Z']
+let identchar = ['A'-'Z' 'a'-'z' '_' '\'' '0'-'9']
 let caml_up_ident = uppercase identchar*
 let caml_low_ident = lowercase identchar*
 
 rule mllib_list = parse
-  | caml_up_ident { let s = String.uncapitalize (Lexing.lexeme lexbuf)
+  | caml_up_ident { let s = uncapitalize_caml_module_name (Lexing.lexeme lexbuf)
 		in s :: mllib_list lexbuf }
   | "*predef*" { mllib_list lexbuf }
   | space+ { mllib_list lexbuf }
@@ -185,7 +192,7 @@ let mlpack_dependencies () =
   List.iter
     (fun (name,dirname) ->
        let fullname = file_name name dirname in
-       let modname = String.capitalize name in
+       let modname = capitalize_caml_file_name name in
        let deps = traite_fichier_modules fullname ".mlpack" in
        let sdeps = String.concat " " deps in
        let efullname = escape fullname in


### PR DESCRIPTION
This PR first fixes a small bug of `configure` with non-existing option `-camldir`.

It then cleans the manipulation of ocaml fine names in `coq_makefile`, `coqdep`, `coqmktop`, especially regarding the conversion file name <-> module name. It fixes the syntax of modules names and gets rid of `String.capitalize` and `String.uncapitalize` (not that their use is incorrect in this context, but to avoid the warning it generates with recent versions of ocaml).

In between, it also backborts from trunk some deactivation of warnings that ocaml 4.01.0 does not know but that later versions of ocaml might report (supposingly mergeable easily).