### PR TITLE
Fixing #5522 (anomaly with free vars of pat)

### DIFF
--- a/test-suite/bugs/closed/5522.v
+++ b/test-suite/bugs/closed/5522.v
@@ -1,0 +1,7 @@
+(* Checking support for scope delimiters and as clauses in 'pat
+   applied to notations with binders *)
+
+Notation "'multifun' x .. y 'in' f" := (fun x => .. (fun y => f) .. )
+  (at level 200, x binder, y binder, f at level 200).
+
+Check multifun '((x, y)%core as z) in (x+y,0)=z.

--- a/test-suite/success/Cases.v
+++ b/test-suite/success/Cases.v
@@ -1868,3 +1868,8 @@ Definition transport {A} (P : A->Type) {x y : A} (p : x=y) (u : P x) : P y :=
 Check match eq_refl 0 in _=O return O=O with eq_refl => eq_refl end.
 
 Check match niln in listn O return O=O with niln => eq_refl end.
+
+(* A test about nested "as" clauses *)
+(* (was failing up to May 2017) *)
+
+Check fun x => match x with (y,z) as t as w => (y+z,t) = (0,w) end.


### PR DESCRIPTION
This fixes a case where `'pat` hits a non-implemented case of a function computing free variables of a pattern. We fix it by replacing the partially-implemented function by reusing the result of a call to a pre-existing fully-defined function already able to compute the free variables of a pattern.

This was discussed on Sunday 14 May on gitter. This passes Travis checks. I made a more detailed commit log, following an interaction with @ejgallego.