### PR TITLE
Fix bug #5486, don't reverse ids in tuples 

### DIFF
--- a/pretyping/patternops.ml
+++ b/pretyping/patternops.ml
@@ -360,9 +360,9 @@ let rec pat_of_raw metas vars = function
       PIf (pat_of_raw metas vars c,
            pat_of_raw metas vars b1,pat_of_raw metas vars b2)
   | GLetTuple (loc,nal,(_,None),b,c) ->
-      let mkGLambda c na =
+      let mkGLambda na c =
 	GLambda (loc,na,Explicit,GHole (loc,Evar_kinds.InternalHole, IntroAnonymous, None),c) in
-      let c = List.fold_left mkGLambda c nal in
+      let c = List.fold_right mkGLambda nal c in
       let cip =
 	{ cip_style = LetStyle;
 	  cip_ind = None;

--- a/test-suite/bugs/closed/5486.v
+++ b/test-suite/bugs/closed/5486.v
@@ -1,0 +1,15 @@
+Axiom proof_admitted : False.
+Tactic Notation "admit" := abstract case proof_admitted.
+Goal forall (T : Type) (p : prod (prod T T) bool) (Fm : Set) (f : Fm) (k :
+									 forall _ : T, Fm),
+    @eq Fm
+	(k
+	   match p return T with
+	   | pair p0 swap => fst p0
+	   end) f.
+  intros.
+  (* next statement failed in Bug 5486 *)
+  match goal with
+  | [ |- ?f (let (a, b) := ?d in @?e a b) = ?rhs ]
+    => pose (let (a, b) := d in e a b) as t0
+  end.


### PR DESCRIPTION
A fold-left over the tuple ids was reversing them, changed to a fold-right.

The test suite file contains Jason's original long example (with the Fail removed). By hand, I verified that the other examples mentioned in the bug report by Samuel Gruetter and Guillaume Melquiond also work after this patch.
