### PR TITLE
[emacs] [toplevel] Make emacs flag local to the toplevel.

### DIFF
--- a/lib/flags.ml
+++ b/lib/flags.ml
@@ -87,7 +87,6 @@ let in_toplevel = ref false
 
 let profile = false
 
-let print_emacs = ref false
 let xml_export = ref false
 
 let ide_slave = ref false

--- a/lib/flags.mli
+++ b/lib/flags.mli
@@ -13,7 +13,9 @@
 val boot : bool ref
 val load_init : bool ref
 
+(* Will affect STM caching *)
 val batch_mode : bool ref
+
 type compilation_mode = BuildVo | BuildVio | Vio2Vo
 val compilation_mode : compilation_mode ref
 val compilation_output_name : string option ref
@@ -56,8 +58,6 @@ val profile : bool
 
 (* Legacy flags *)
 
-(* -emacs option: printing includes emacs tags, will affect stm caching. *)
-val print_emacs : bool ref
 (* -xml option: xml hooks will be called *)
 val xml_export : bool ref
 

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -26,9 +26,6 @@ module RelDecl = Context.Rel.Declaration
 module NamedDecl = Context.Named.Declaration
 module CompactedDecl = Context.Compacted.Declaration
 
-let emacs_str s =
-  if !Flags.print_emacs then s else ""
-
 let get_current_context () =
   Pfedit.get_current_context ()
 
@@ -656,9 +653,6 @@ let print_dependent_evars gl sigma seeds =
     in
     cut () ++ cut () ++
     str "(dependent evars:" ++ evars ++ str ")"
-    else if !Flags.print_emacs then
-      (* IDEs prefer something dummy instead of nothing *)
-      cut () ++ cut () ++ str "(dependent evars: (printing disabled) )"
     else mt ()
   in
   constraints ++ evars ()

--- a/printing/printer.mli
+++ b/printing/printer.mli
@@ -169,19 +169,6 @@ val pr_ne_evar_set         : std_ppcmds -> std_ppcmds -> evar_map ->
 
 val pr_prim_rule           : prim_rule -> std_ppcmds
 
-(** Emacs/proof general support
-   (emacs_str s) outputs
-    - s if emacs mode,
-    - nothing otherwise.
-    This function was previously used to insert special chars like
-    [(String.make 1 (Char.chr 253))] to parenthesize sub-parts of the
-    proof context for proof by pointing. This part of the code is
-    removed for now because it interacted badly with utf8. We may put
-    it back some day using some xml-like tags instead of special
-    chars. See for example the <prompt> tag in the prompt when in
-    emacs mode. *)
-val emacs_str              : string -> string
-
 (** Backwards compatibility *)
 
 val prterm                 : constr -> std_ppcmds (** = pr_lconstr *)

--- a/proofs/refiner.ml
+++ b/proofs/refiner.ml
@@ -188,8 +188,6 @@ let tclSHOWHYPS (tac : tactic) (goal: Goal.goal Evd.sigma)
       (fun hypl -> List.subtract cmp hypl oldhyps)
       hyps
   in
-  let emacs_str s =
-    if !Flags.print_emacs then s else "" in
   let s = 
     let frst = ref true in
     List.fold_left
@@ -199,9 +197,9 @@ let tclSHOWHYPS (tac : tactic) (goal: Goal.goal Evd.sigma)
 	   "" lh))
     "" newhyps in
   Feedback.msg_notice
-    (str (emacs_str "<infoH>")
+    (str "<infoH>"
       ++  (hov 0 (str s))
-      ++  (str (emacs_str "</infoH>")));
+      ++  (str "</infoH>"));
   tclIDTAC goal;;
 
 

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -66,7 +66,7 @@ end
 
 (* During interactive use we cache more states so that Undoing is fast *)
 let interactive () =
-  if !Flags.ide_slave || !Flags.print_emacs || not !Flags.batch_mode then `Yes
+  if !Flags.ide_slave || not !Flags.batch_mode then `Yes
   else `No
 
 let async_proofs_workers_extra_env = ref [||]
@@ -1094,7 +1094,7 @@ end = struct (* {{{ *)
           VtStm (VtBack oid, true), VtLater
       | VernacBacktrack (id,_,_)
       | VernacBackTo id ->
-          VtStm (VtBack (Stateid.of_int id), not !Flags.print_emacs), VtNow
+          VtStm (VtBack (Stateid.of_int id), not !Flags.batch_mode), VtNow
       | _ -> VtUnknown, VtNow
     with
     | Not_found ->

--- a/test-suite/output/Show.out
+++ b/test-suite/output/Show.out
@@ -8,5 +8,3 @@ subgoal 2 (ID 35) is:
  1 = S (S m')
 subgoal 3 (ID 22) is:
  S (S n') = S m
-
-(dependent evars: (printing disabled) )

--- a/toplevel/coqloop.mli
+++ b/toplevel/coqloop.mli
@@ -8,6 +8,9 @@
 
 (** The Coq toplevel loop. *)
 
+(** -emacs option: printing includes emacs tags. *)
+val print_emacs : bool ref
+
 (** A buffer for the character read from a channel. We store the command
  * entered to be able to report errors without pretty-printing. *)
 

--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -246,21 +246,21 @@ let compile_files () =
 let set_emacs () =
   if not (Option.is_empty !toploop) then
     user_err Pp.(str "Flag -emacs is incompatible with a custom toplevel loop");
-  Flags.print_emacs := true;
+  Coqloop.print_emacs := true;
   Printer.enable_goal_tags_printing := true;
   color := `OFF
 
 (** Options for CoqIDE *)
 
 let set_ideslave () =
-  if !Flags.print_emacs then user_err Pp.(str "Flags -ideslave and -emacs are incompatible");
+  if !Coqloop.print_emacs then user_err Pp.(str "Flags -ideslave and -emacs are incompatible");
   toploop := Some "coqidetop";
   Flags.ide_slave := true
 
 (** Options for slaves *)
 
 let set_toploop name =
-  if !Flags.print_emacs then user_err Pp.(str "Flags -toploop and -emacs are incompatible");
+  if !Coqloop.print_emacs then user_err Pp.(str "Flags -toploop and -emacs are incompatible");
   toploop := Some name
 
 (** GC tweaking *)


### PR DESCRIPTION
We remove the remaining emacs-specific code from the core of Coq, and
instead we put the few necessary functionality in `toplevel/`. The `-emacs` flag is purely a printing flag now.