### PR TITLE
Fixing an extra bug with pattern_of_constr

### DIFF
--- a/pretyping/patternops.ml
+++ b/pretyping/patternops.ml
@@ -155,14 +155,15 @@ let pattern_of_constr env sigma t =
     | Construct (sp,u) -> PRef (canonical_gr (ConstructRef sp))
     | Proj (p, c) -> 
       pattern_of_constr env (EConstr.Unsafe.to_constr (Retyping.expand_projection env sigma p (EConstr.of_constr c) []))
-    | Evar (evk,ctxt) ->
+    | Evar (evk,ctxt as ev) ->
       (match snd (Evd.evar_source evk sigma) with
       | Evar_kinds.MatchingVar (b,id) ->
         assert (not b); PMeta (Some id)
       | Evar_kinds.GoalEvar | Evar_kinds.VarInstance _ ->
         (* These are the two evar kinds used for existing goals *)
         (* see Proofview.mark_in_evm *)
-	PEvar (evk,Array.map (pattern_of_constr env) ctxt)
+         if Evd.is_defined sigma evk then pattern_of_constr env (Evd.existential_value sigma ev)
+         else PEvar (evk,Array.map (pattern_of_constr env) ctxt)
       | _ -> 
 	 PMeta None)
     | Case (ci,p,a,br) ->

--- a/test-suite/success/change.v
+++ b/test-suite/success/change.v
@@ -59,3 +59,12 @@ unfold x.
 (* check that n in 0+n is not interpreted as the n from "fun n" *)
 change n with (0+n).
 Abort.
+
+(* Check non-collision of non-normalized defined evars with pattern variables *)
+
+Goal exists x, 1=1 -> x=1/\x=1.
+eexists ?[n]; intros; split.
+eassumption.
+match goal with |- ?x=1 => change (x=1) with (0+x=1) end.
+match goal with |- 0+1=1 => trivial end.
+Qed.


### PR DESCRIPTION
While matching a term against a pattern (in `constr_matching.ml`), the preexisting evars of the goal appearing in the pattern must be expanded at the time of producing the pattern (in `pattern_of_constr`). We need to do it manually since we start from a `Constr.constr` whose defined evars are not necessarily expanded.

Short example showing the problem:
```coq
Goal exists x, 1=1 -> x=1/\x=1.
eexists ?[n]; intros; split. eassumption.
(* Goal is displayed `1=1` but, internally, it is `?n=1` with `?n` known to be `1` *)
match goal with |- ?x=1 => change (x=1) with (0+x=1) end.
```
Goal matching binds `?x` to `?n` but we need to expand `?n` so that the pattern for `change` is `1=1` and not `?n=1` (there is no such notion of `EPattern` view at patterns like there is a `EConstr` view at terms).

Bug detected by the failure of contribution propcalc, after fix to bug [#5487](https://coq.inria.fr/bugs/show_bug.cgi?id=5487) was committed in #597.