### PR TITLE
Re-adding explicit dependency of misc universe test into all_stdlib.v.

### DIFF
--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -408,6 +408,11 @@ modules/%.vo: modules/%.v
 
 misc: $(patsubst %.sh,%.log,$(wildcard misc/*.sh))
 
+misc/universes.log: misc/universes/all_stdlib.v
+
+misc/universes/all_stdlib.v:
+	cd .. && $(MAKE) test-suite/$@
+
 $(patsubst %.sh,%.log,$(wildcard misc/*.sh)): %.log: %.sh $(PREREQUISITELOG)
 	@echo "TEST      $<"
 	$(HIDE){ \


### PR DESCRIPTION
Was working when calling test-suite from main Makefile but not when calling directly from the test-suite Makefile.

The dependency was mistakenly dropped in 98a927aef.