### PR TITLE
Bug #5535, test for Show with -emacs

### DIFF
--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -44,7 +44,7 @@ REDIR := $(if $(VERBOSE),,> /dev/null 2>&1)
 
 # read out an emacs config and look for coq-prog-args; if such exists, return it
 get_coq_prog_args_helper = sed -n s'/^.*coq-prog-args:[[:space:]]*(\([^)]*\)).*/\1/p' $(1)
-get_coq_prog_args = $(strip $(filter-out "-emacs-U" "-emacs",$(shell $(call get_coq_prog_args_helper,$(1)))))
+get_coq_prog_args = $(strip $(shell $(call get_coq_prog_args_helper,$(1))))
 SINGLE_QUOTE="
 #" # double up on the quotes, in a comment, to appease the emacs syntax highlighter
 # wrap the arguments in parens, but only if they exist

--- a/test-suite/output/Show.out
+++ b/test-suite/output/Show.out
@@ -1,0 +1,12 @@
+3 subgoals, subgoal 1 (ID 29)
+  
+  H : 0 = 0
+  ============================
+  1 = 1
+
+subgoal 2 (ID 33) is:
+ 1 = S (S m')
+subgoal 3 (ID 20) is:
+ S (S n') = S m
+(dependent evars: (printing disabled) )
+

--- a/test-suite/output/Show.v
+++ b/test-suite/output/Show.v
@@ -1,0 +1,11 @@
+(* -*- mode: coq; coq-prog-args: ("-emacs") -*- *)
+
+(* tests of Show output with -emacs flag to coqtop; see bug 5535 *)
+
+Theorem nums : forall (n m : nat), n = m -> (S n) = (S m).
+Proof.
+  intros.
+  induction n as [| n'].  
+  induction m as [| m'].
+  Show.
+Admitted.


### PR DESCRIPTION
The output of Show has sometimes been incorrect with the -emacs flag for Proof General. This is a test case that checks Show output with a goal and multiple subgoals.

We had been filtering out the -emacs flag in the test-suite, so in the old days, that flag had no effect. All uses of that flag in the test suite were removed in PR #589. I removed that filtering in the test-suite Makefile, to enable this particular test (and new tests, if created). 