### PR TITLE
Extra functions exported in EConstr

### DIFF
--- a/engine/eConstr.ml
+++ b/engine/eConstr.ml
@@ -668,6 +668,9 @@ module Vars =
 struct
 exception LocalOccur
 let to_constr = unsafe_to_constr
+let to_rel_decl = unsafe_to_rel_decl
+
+type substl = t list
 
 (** Operations that commute with evar-normalization *)
 let lift n c = of_constr (Vars.lift n (to_constr c))
@@ -676,6 +679,10 @@ let liftn n m c = of_constr (Vars.liftn n m (to_constr c))
 let substnl subst n c = of_constr (Vars.substnl (cast_list unsafe_eq subst) n (to_constr c))
 let substl subst c = of_constr (Vars.substl (cast_list unsafe_eq subst) (to_constr c))
 let subst1 c r = of_constr (Vars.subst1 (to_constr c) (to_constr r))
+
+let substnl_decl subst n d = of_rel_decl (Vars.substnl_decl (cast_list unsafe_eq subst) n (to_rel_decl d))
+let substl_decl subst d = of_rel_decl (Vars.substl_decl (cast_list unsafe_eq subst) (to_rel_decl d))
+let subst1_decl c d = of_rel_decl (Vars.subst1_decl (to_constr c) (to_rel_decl d))
 
 let replace_vars subst c =
   of_constr (Vars.replace_vars (cast_list_snd unsafe_eq subst) (to_constr c))

--- a/engine/eConstr.ml
+++ b/engine/eConstr.ml
@@ -638,6 +638,32 @@ let eq_constr_universes_proj env sigma m n =
     let res = eq_constr' (unsafe_to_constr m) (unsafe_to_constr n) in
     if res then Some !cstrs else None
 
+open Context
+open Environ
+
+let cast_list : type a b. (a,b) eq -> a list -> b list =
+  fun Refl x -> x
+
+let cast_list_snd : type a b. (a,b) eq -> ('c * a) list -> ('c * b) list =
+  fun Refl x -> x
+
+let cast_rel_decl :
+  type a b. (a,b) eq -> (a, a) Rel.Declaration.pt -> (b, b) Rel.Declaration.pt =
+  fun Refl x -> x
+
+let cast_rel_context :
+  type a b. (a,b) eq -> (a, a) Rel.pt -> (b, b) Rel.pt =
+  fun Refl x -> x
+
+let cast_named_decl :
+  type a b. (a,b) eq -> (a, a) Named.Declaration.pt -> (b, b) Named.Declaration.pt =
+  fun Refl x -> x
+
+let cast_named_context :
+  type a b. (a,b) eq -> (a, a) Named.pt -> (b, b) Named.pt =
+  fun Refl x -> x
+
+
 module Vars =
 struct
 exception LocalOccur
@@ -647,13 +673,12 @@ let to_constr = unsafe_to_constr
 let lift n c = of_constr (Vars.lift n (to_constr c))
 let liftn n m c = of_constr (Vars.liftn n m (to_constr c))
 
-let substnl subst n c = of_constr (Vars.substnl (List.map to_constr subst) n (to_constr c))
-let substl subst c = of_constr (Vars.substl (List.map to_constr subst) (to_constr c))
+let substnl subst n c = of_constr (Vars.substnl (cast_list unsafe_eq subst) n (to_constr c))
+let substl subst c = of_constr (Vars.substl (cast_list unsafe_eq subst) (to_constr c))
 let subst1 c r = of_constr (Vars.subst1 (to_constr c) (to_constr r))
 
 let replace_vars subst c =
-  let map (id, c) = (id, to_constr c) in
-  of_constr (Vars.replace_vars (List.map map subst) (to_constr c))
+  of_constr (Vars.replace_vars (cast_list_snd unsafe_eq subst) (to_constr c))
 let substn_vars n subst c = of_constr (Vars.substn_vars n subst (to_constr c))
 let subst_vars subst c = of_constr (Vars.subst_vars subst (to_constr c))
 let subst_var subst c = of_constr (Vars.subst_var subst (to_constr c))
@@ -685,7 +710,8 @@ let closedn sigma n c =
 let closed0 sigma c = closedn sigma 0 c
 
 let subst_of_rel_context_instance ctx subst =
-  List.map of_constr (Vars.subst_of_rel_context_instance (List.map unsafe_to_rel_decl ctx) (List.map to_constr subst))
+  cast_list (sym unsafe_eq)
+    (Vars.subst_of_rel_context_instance (cast_rel_context unsafe_eq ctx) (cast_list unsafe_eq subst))
 
 end
 
@@ -727,25 +753,6 @@ let mkNamedLambda_or_LetIn decl c =
 
 let it_mkProd_or_LetIn t ctx = List.fold_left (fun c d -> mkProd_or_LetIn d c) t ctx
 let it_mkLambda_or_LetIn t ctx = List.fold_left (fun c d -> mkLambda_or_LetIn d c) t ctx
-
-open Context
-open Environ
-
-let cast_rel_decl :
-  type a b. (a,b) eq -> (a, a) Rel.Declaration.pt -> (b, b) Rel.Declaration.pt =
-  fun Refl x -> x
-
-let cast_rel_context :
-  type a b. (a,b) eq -> (a, a) Rel.pt -> (b, b) Rel.pt =
-  fun Refl x -> x
-
-let cast_named_decl :
-  type a b. (a,b) eq -> (a, a) Named.Declaration.pt -> (b, b) Named.Declaration.pt =
-  fun Refl x -> x
-
-let cast_named_context :
-  type a b. (a,b) eq -> (a, a) Named.pt -> (b, b) Named.pt =
-  fun Refl x -> x
 
 let push_rel d e = push_rel (cast_rel_decl unsafe_eq d) e
 let push_rel_context d e = push_rel_context (cast_rel_context unsafe_eq d) e

--- a/engine/eConstr.ml
+++ b/engine/eConstr.ml
@@ -731,8 +731,6 @@ let it_mkLambda_or_LetIn t ctx = List.fold_left (fun c d -> mkLambda_or_LetIn d 
 open Context
 open Environ
 
-let sym : type a b. (a, b) eq -> (b, a) eq = fun Refl -> Refl
-
 let cast_rel_decl :
   type a b. (a,b) eq -> (a, a) Rel.Declaration.pt -> (b, b) Rel.Declaration.pt =
   fun Refl x -> x

--- a/engine/eConstr.mli
+++ b/engine/eConstr.mli
@@ -205,11 +205,20 @@ val fold : Evd.evar_map -> ('a -> t -> 'a) -> 'a -> t -> 'a
 
 module Vars :
 sig
+
+(** See vars.mli for the documentation of the functions below *)
+
+type substl = t list
+
 val lift : int -> t -> t
 val liftn : int -> int -> t -> t
-val substnl : t list -> int -> t -> t
-val substl : t list -> t -> t
+val substnl : substl -> int -> t -> t
+val substl : substl -> t -> t
 val subst1 : t -> t -> t
+
+val substnl_decl : substl -> int -> rel_declaration -> rel_declaration
+val substl_decl : substl -> rel_declaration -> rel_declaration
+val subst1_decl : t -> rel_declaration -> rel_declaration
 
 val replace_vars : (Id.t * t) list -> t -> t
 val substn_vars : int -> Id.t list -> t -> t

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -136,6 +136,8 @@ type ('a, 'b) union = ('a, 'b) CSig.union = Inl of 'a | Inr of 'b
 type 'a until = 'a CSig.until = Stop of 'a | Cont of 'a
 type ('a, 'b) eq = ('a, 'b) CSig.eq = Refl : ('a, 'a) eq
 
+let sym : type a b. (a, b) eq -> (b, a) eq = fun Refl -> Refl
+
 module Union =
 struct
   let map f g = function

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -133,5 +133,7 @@ type 'a until = 'a CSig.until = Stop of 'a | Cont of 'a
 
 type ('a, 'b) eq = ('a, 'b) CSig.eq = Refl : ('a, 'a) eq
 
+val sym : ('a, 'b) eq -> ('b, 'a) eq
+
 val open_utf8_file_in : string -> in_channel
 (** Open an utf-8 encoded file and skip the byte-order mark if any. *)


### PR DESCRIPTION
These are a few extra functions on `EConstr` which were useful to port `aac-tactics`. Not a big deal.

The most difficult part was about dealing with a hash table indexed on `Constr.constr` (I renounced to make a module dependent on a sigma and kept the table on `Constr.constr`).

The table is used for reification. So, this is another instance of the need to provide general-purpose primitives to reify expressions up to some equality on atoms (to my knowledge, it does not really exist, right? or is there already some work done in this direction?).

PS added afterwards: Opening `EConstr` exports a module `Vars` which hides the module provided by `vars.mli`. I could not find how to get access to it after `EConstr` is open.