### PR TITLE
Fix Bug #5537, goal printed after Print command.

### DIFF
--- a/vernac/vernacprop.ml
+++ b/vernac/vernacprop.ml
@@ -37,7 +37,7 @@ let is_debug cmd = match cmd with
   | VernacSetOption (["Ltac";"Debug"], _) -> true
   | _ -> false
 
-let is_query cmd = match cmd with
+let rec is_query cmd = match cmd with
   | VernacChdir None
   | VernacMemOption _
   | VernacPrintOption _
@@ -46,6 +46,8 @@ let is_query cmd = match cmd with
   | VernacPrint _
   | VernacSearch _
   | VernacLocate _ -> true
+  | VernacTime (_,cmd')
+  | VernacTimeout (_,cmd') -> is_query cmd'
   | _ -> false
 
 let is_undo cmd = match cmd with


### PR DESCRIPTION
After each Vernac command, there's a decision whether to print the current goal. The goal is hidden if, among other things, the predicate `is_query` holds for the command.

The predicate returns `true` for Print commands, and some others. The code had a default match case returning `false`, and that's what was returned for `Timeout` and `Time` commands. I added cases for those two commands that run the `is_query` predicate on the commands they contain.

The alternative would be to consider those one, or both of those commands as queries, regardless of the commands they contain. 

Besides the decision whether to print the goal, the only other place the predicate is used is in `ide/ide_slave.ml` to issue a warning about commands in scripts when using CoqIDE.