### PR TITLE
Change wrong bullet message.

### DIFF
--- a/proofs/proof_global.ml
+++ b/proofs/proof_global.ml
@@ -516,7 +516,7 @@ module Bullet = struct
       | NeedClosingBrace -> str"Try unfocusing with \"}\"."
       | NoBulletInUse -> assert false (* This should never raise an error. *)
       | ProofFinished -> str"No more subgoals."
-      | Suggest b -> str"Bullet " ++ pr_bullet b ++ str" is mandatory here."
+      | Suggest b -> str"Expecting " ++ pr_bullet b ++ str"."
       | Unfinished b -> str"Current bullet " ++ pr_bullet b ++ str" is not finished."
 
     exception FailedBullet of t * suggestion
@@ -525,7 +525,7 @@ module Bullet = struct
       CErrors.register_handler
 	(function
 	| FailedBullet (b,sugg) ->
-	  let prefix = str"Wrong bullet " ++ pr_bullet b ++ str" : " in
+	  let prefix = str"Wrong bullet " ++ pr_bullet b ++ str": " in
 	  CErrors.user_err ~hdr:"Focus" (prefix ++ suggest_on_error sugg)
 	| _ -> raise CErrors.Unhandled)
 


### PR DESCRIPTION
Remove a space before colon.
Remove the use of term mandatory
(this closes https://coq.inria.fr/bugs/show_bug.cgi?id=3994).