### PR TITLE
Two fixes about zify (bugs #5336 and #5439)

### DIFF
--- a/plugins/omega/PreOmega.v
+++ b/plugins/omega/PreOmega.v
@@ -264,8 +264,8 @@ Ltac zify_positive_op :=
   | |- context [ Zpos (Pos.max ?a ?b) ] => rewrite (Pos2Z.inj_max a b)
 
   (* Pos.sub -> Z.max 1 (Z.sub ... ...) *)
-  | H : context [ Zpos (Pos.sub ?a ?b) ] |- _ => rewrite (Pos2Z.inj_sub a b) in H
-  | |- context [ Zpos (Pos.sub ?a ?b) ] => rewrite (Pos2Z.inj_sub a b)
+  | H : context [ Zpos (Pos.sub ?a ?b) ] |- _ => rewrite (Pos2Z.inj_sub_max a b) in H
+  | |- context [ Zpos (Pos.sub ?a ?b) ] => rewrite (Pos2Z.inj_sub_max a b)
 
   (* Pos.succ -> Z.succ *)
   | H : context [ Zpos (Pos.succ ?a) ] |- _ => rewrite (Pos2Z.inj_succ a) in H


### PR DESCRIPTION
The first bug was just a typo.
The second fix (some "compute" instead of "simpl" in zify) should also be pretty safe.
