### PR TITLE
Primitive Ltac definitions for first and solve

### DIFF
--- a/doc/refman/RefMan-ltac.tex
+++ b/doc/refman/RefMan-ltac.tex
@@ -522,6 +522,19 @@ to have \emph{at least} one success.
 
 \ErrMsg \errindex{No applicable tactic}
 
+\variant {\tt first {\tacexpr}}
+
+This is an Ltac alias that gives a primitive access to the {\tt first} tactical
+as a Ltac definition without going through a parsing rule. It expects to be
+given a list of tactics through a {\tt Tactic Notation}, allowing to write
+notations of the following form.
+
+\Example
+
+\begin{quote}
+{\tt Tactic Notation "{foo}" tactic\_list(tacs) := first tacs.}
+\end{quote}
+
 \subsubsection[Left-biased branching]{Left-biased branching\tacindex{$\mid\mid$}
 \index{Tacticals!orelse@{\tt $\mid\mid$}}}
 
@@ -599,6 +612,11 @@ independently, if it doesn't solve the goal then it tries to apply
 $v_2$ and so on. It fails if there is no solving tactic.
 
 \ErrMsg \errindex{Cannot solve the goal}
+
+\variant {\tt solve {\tacexpr}}
+
+This is an Ltac alias that gives a primitive access to the {\tt solve} tactical.
+See the {\tt first} tactical for more information.
 
 \subsubsection[Identity]{Identity\label{ltac:idtac}\tacindex{idtac}
 \index{Tacticals!idtac@{\tt idtac}}}


### PR DESCRIPTION
This PR adds a Ltac definition to access the `first` and `solve` tacticals without having to go through a built-in notation. These functions accept a list of tactics as arguments, which allows to define tactic notations manipulating such data structures. Typical use:
```
Tactic Notation "foo" tactic_list(tacs) := first tacs.
```
 As of today there is no other way than notations to create lists in Ltac, so the use case is pretty well delimited but exists nonetheless. It is the proper way to implement the PR #470, as it does not change the Ltac runtime at all.
