### PR TITLE
add Show test with -emacs flag for trunk

### DIFF
--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -45,7 +45,7 @@ REDIR := $(if $(VERBOSE),,> /dev/null 2>&1)
 
 # read out an emacs config and look for coq-prog-args; if such exists, return it
 get_coq_prog_args_helper = sed -n s'/^.*coq-prog-args:[[:space:]]*(\([^)]*\)).*/\1/p' $(1)
-get_coq_prog_args = $(strip $(filter-out "-emacs-U" "-emacs",$(shell $(call get_coq_prog_args_helper,$(1)))))
+get_coq_prog_args = $(strip $(shell $(call get_coq_prog_args_helper,$(1)))) 
 SINGLE_QUOTE="
 #" # double up on the quotes, in a comment, to appease the emacs syntax highlighter
 # wrap the arguments in parens, but only if they exist
@@ -490,7 +490,7 @@ coq-makefile/%.log : coq-makefile/%/run.sh
 	$(HIDE)(\
 	  cd coq-makefile/$* && \
 	  ./run.sh 2>&1; \
-       	  if [ $$? = 0 ]; then \
+	if [ $$? = 0 ]; then \
 	    echo $(log_success); \
 	    echo "    $<...Ok"; \
 	  else \

--- a/test-suite/output/Show.out
+++ b/test-suite/output/Show.out
@@ -1,0 +1,12 @@
+3 subgoals (ID 29)
+  
+  H : 0 = 0
+  ============================
+  1 = 1
+
+subgoal 2 (ID 33) is:
+ 1 = S (S m')
+subgoal 3 (ID 20) is:
+ S (S n') = S m
+
+(dependent evars: (printing disabled) )

--- a/test-suite/output/Show.v
+++ b/test-suite/output/Show.v
@@ -1,0 +1,11 @@
+(* -*- mode: coq; coq-prog-args: ("-emacs") -*- *)
+
+(* tests of Show output with -emacs flag to coqtop; see bug 5535 *)
+
+Theorem nums : forall (n m : nat), n = m -> (S n) = (S m).
+Proof.
+  intros.
+  induction n as [| n'].  
+  induction m as [| m'].
+  Show.
+Admitted.


### PR DESCRIPTION
This PR is like #653, which added a Show test using the -emacs flag for v8.6.

The Show output has changed in trunk, so that test would fail if the commit were merged. Instead, this is a new PR where the `.out` reflects the current Show output.

As in #653, the test-suite Makefile no longer filters `-emacs` and `-emacs-U` flags, so that tests can make use of those flags.