### PR TITLE
coq_makefile: build .cma for each .mlpack

### DIFF
--- a/test-suite/coq-makefile/coqdoc1/run.sh
+++ b/test-suite/coq-makefile/coqdoc1/run.sh
@@ -15,6 +15,7 @@ make install-doc DSTROOT="$PWD/tmp"
 sort -u > desired <<EOT
 .
 ./test
+./test/test_plugin.cma
 ./test/test_plugin.cmi
 ./test/test_plugin.cmo
 ./test/test_plugin.cmx

--- a/test-suite/coq-makefile/coqdoc2/run.sh
+++ b/test-suite/coq-makefile/coqdoc2/run.sh
@@ -15,6 +15,7 @@ make install-doc DSTROOT="$PWD/tmp"
 sort -u > desired <<EOT
 .
 ./test
+./test/test_plugin.cma
 ./test/test_plugin.cmi
 ./test/test_plugin.cmo
 ./test/test_plugin.cmx

--- a/test-suite/coq-makefile/mlpack1/run.sh
+++ b/test-suite/coq-makefile/mlpack1/run.sh
@@ -15,6 +15,7 @@ sort > desired <<EOT
 .
 ./test
 ./test/test.glob
+./test/test_plugin.cma
 ./test/test_plugin.cmi
 ./test/test_plugin.cmo
 ./test/test_plugin.cmx

--- a/test-suite/coq-makefile/mlpack2/run.sh
+++ b/test-suite/coq-makefile/mlpack2/run.sh
@@ -15,6 +15,7 @@ sort > desired <<EOT
 .
 ./test
 ./test/test.glob
+./test/test_plugin.cma
 ./test/test_plugin.cmi
 ./test/test_plugin.cmo
 ./test/test_plugin.cmx

--- a/test-suite/coq-makefile/native1/run.sh
+++ b/test-suite/coq-makefile/native1/run.sh
@@ -17,6 +17,7 @@ sort > desired <<EOT
 .
 ./test
 ./test/test.glob
+./test/test_plugin.cma
 ./test/test_plugin.cmi
 ./test/test_plugin.cmo
 ./test/test_plugin.cmx

--- a/tools/CoqMakefile.in
+++ b/tools/CoqMakefile.in
@@ -184,7 +184,7 @@ CMOFILES = \
 	$(MLPACKFILES:.mlpack=.cmo)
 CMXFILES = $(CMOFILES:.cmo=.cmx)
 OFILES = $(CMXFILES:.cmx=.o)
-CMAFILES = $(MLLIBFILES:.mllib=.cma)
+CMAFILES = $(MLLIBFILES:.mllib=.cma) $(MLPACKFILES:.mlpack=.cma)
 CMXAFILES = $(CMAFILES:.cma=.cmxa)
 CMIFILES = \
 	$(CMOFILES:.cmo=.cmi) \
@@ -473,6 +473,10 @@ $(MLLIBFILES:.mllib=.cmxa): %.cmxa: | %.mllib
 $(MLPACKFILES:.mlpack=.cmxs): %.cmxs: %.cmx
 	$(SHOW)'CAMLOPT -shared -o $@'
 	$(HIDE)$(CAMLOPTLINK) $(CAMLDEBUG) $(CAMLFLAGS) -shared -o $@ $<
+
+$(MLPACKFILES:.mlpack=.cma): %.cma: %.cmo | %.mlpack
+	$(SHOW)'CAMLC -a -o $@'
+	$(HIDE)$(CAMLLINK) $(CAMLDEBUG) $(CAMLFLAGS) -a -o $@ $^
 
 $(MLPACKFILES:.mlpack=.cmo): %.cmo: | %.mlpack
 	$(SHOW)'CAMLC -pack -o $@'


### PR DESCRIPTION
It used to generate only .cmo (the packed one).
While this works if the plugin has no external dependencies,
it does not if it does.

The bug affected only bytecode builds