### PR TITLE
Fail on deprecated warning even for Ocaml > 4.02.3

### DIFF
--- a/configure
+++ b/configure
@@ -26,7 +26,7 @@ done
 
 ## We check that $cmd is ok before the real exec $cmd
 
-`$cmd -version > /dev/null 2>&1` && exec $cmd -w "-3" $script "$@"
+`$cmd -version > /dev/null 2>&1` && exec $cmd $script "$@"
 
 ## If we're still here, something is wrong with $cmd
 

--- a/configure.ml
+++ b/configure.ml
@@ -515,7 +515,6 @@ let camltag = match caml_version_list with
   | _ -> assert false
 
 (** Explanation of disabled warnings:
-    3: deprecated warning (not error for non minimum supported ocaml)
     4: fragile pattern matching: too common in the code and too annoying to avoid in general
     9: missing fields in a record pattern: too common in the code and not worth the bother
     27: innocuous unused variable: innocuous
@@ -533,7 +532,7 @@ let coq_warn_flags =
     if !Prefs.warn_error
     then "-warn-error +a"
          ^ (if caml_version_nums > [4;2;3]
-            then "-3-56"
+            then "-56"
             else "")
     else ""
   in

--- a/configure.ml
+++ b/configure.ml
@@ -598,9 +598,11 @@ let config_camlpX () =
     let camlp5mod = "gramlib" in
     let camlp5libdir, camlp5o = check_camlp5 (camlp5mod^".cma") in
     let camlp5_version = check_camlp5_version camlp5o in
-    "camlp5", camlp5o, Filename.dirname camlp5o, camlp5libdir, camlp5mod, camlp5_version
+    "camlp5", "Camlp5", camlp5o, Filename.dirname camlp5o, camlp5libdir, camlp5mod, camlp5_version
 
-let camlpX, camlpXo, camlpXbindir, fullcamlpXlibdir, camlpXmod, camlpX_version = config_camlpX ()
+let camlpX, capitalized_camlpX, camlpXo,
+    camlpXbindir, fullcamlpXlibdir,
+    camlpXmod, camlpX_version = config_camlpX ()
 
 let shorten_camllib s =
   if starts_with s (camllib^"/") then
@@ -959,9 +961,9 @@ let print_summary () =
   pr "  OCaml version               : %s\n" caml_version;
   pr "  OCaml binaries in           : %s\n" camlbin;
   pr "  OCaml library in            : %s\n" camllib;
-  pr "  %s version              : %s\n"     (String.capitalize camlpX) camlpX_version;
-  pr "  %s binaries in          : %s\n"     (String.capitalize camlpX) camlpXbindir;
-  pr "  %s library in           : %s\n"     (String.capitalize camlpX) camlpXlibdir;
+  pr "  %s version              : %s\n"     capitalized_camlpX camlpX_version;
+  pr "  %s binaries in          : %s\n"     capitalized_camlpX camlpXbindir;
+  pr "  %s library in           : %s\n"     capitalized_camlpX camlpXlibdir;
   if best_compiler = "opt" then
     pr "  Native dynamic link support : %B\n" hasnatdynlink;
   if coqide <> "no" then

--- a/ide/preferences.ml
+++ b/ide/preferences.ml
@@ -643,6 +643,10 @@ let pmodifiers ?(all = false) name p = modifiers
   name
   (str_to_mod_list p#get)
 
+[@@@ocaml.warning "-3"]       (* String.uppercase_ascii since 4.03.0 GPR#124 *)
+let uppercase = String.uppercase
+[@@@ocaml.warning "+3"]
+
 let configure ?(apply=(fun () -> ())) () =
   let cmd_coqtop =
     string
@@ -969,7 +973,7 @@ let configure ?(apply=(fun () -> ())) () =
     let k =
       if Int.equal (CString.length k) 1 && Util.is_letter k.[0] then k
       else "" in
-    let k = CString.uppercase k in
+    let k = uppercase k in
       [q, k]
   in
 

--- a/ide/xml_lexer.mll
+++ b/ide/xml_lexer.mll
@@ -83,6 +83,9 @@ let error lexbuf e =
         last_pos := lexeme_start lexbuf;
         raise (Error e)
 
+[@@@ocaml.warning "-3"]       (* String.lowercase_ascii since 4.03.0 GPR#124 *)
+let lowercase = String.lowercase
+[@@@ocaml.warning "+3"]
 }
 
 let newline = ['\n']
@@ -219,7 +222,7 @@ and entity = parse
                 {
                         let ident = lexeme lexbuf in
                         try
-                                Hashtbl.find idents (String.lowercase ident)
+                                Hashtbl.find idents (lowercase ident)
                         with
                                 Not_found -> "&" ^ ident
                 }

--- a/lib/cString.ml
+++ b/lib/cString.ml
@@ -11,7 +11,9 @@ module type S = module type of String
 module type ExtS =
 sig
   include S
+  [@@@ocaml.warning "-3"]     (* [@@noalloc] since 4.03.0 GPR#240 *)
   external equal : string -> string -> bool = "caml_string_equal" "noalloc"
+  [@@@ocaml.warning "+3"]
   val hash : string -> int
   val is_empty : string -> bool
   val explode : string -> string list
@@ -33,7 +35,9 @@ end
 
 include String
 
+[@@@ocaml.warning "-3"]     (* [@@noalloc] since 4.03.0 GPR#240 *)
 external equal : string -> string -> bool = "caml_string_equal" "noalloc"
+[@@@ocaml.warning "+3"]
 
 let rec hash len s i accu =
   if i = len then accu

--- a/lib/cString.mli
+++ b/lib/cString.mli
@@ -14,7 +14,10 @@ sig
   include S
   (** We include the standard library *)
 
+  [@@@ocaml.warning "-3"]     (* [@@noalloc] since 4.03.0 GPR#240 *)
   external equal : string -> string -> bool = "caml_string_equal" "noalloc"
+  [@@@ocaml.warning "+3"]
+
   (** Equality on strings *)
 
   val hash : string -> int

--- a/lib/hashcons.ml
+++ b/lib/hashcons.ml
@@ -130,7 +130,11 @@ module Hstring = Make(
     type t = string
     type u = unit
     let hashcons () s =(* incr accesstr;*) s
+
+    [@@@ocaml.warning "-3"]     (* [@@noalloc] since 4.03.0 GPR#240 *)
     external eq : string -> string -> bool = "caml_string_equal" "noalloc"
+    [@@@ocaml.warning "+3"]
+
     (** Copy from CString *)
     let rec hash len s i accu =
       if i = len then accu

--- a/plugins/extraction/common.ml
+++ b/plugins/extraction/common.ml
@@ -109,12 +109,17 @@ let pseudo_qualify = qualify "__"
 let is_upper s = match s.[0] with 'A' .. 'Z' -> true | _ -> false
 let is_lower s = match s.[0] with 'a' .. 'z' | '_' -> true | _ -> false
 
-let lowercase_id id = Id.of_string (String.uncapitalize (ascii_of_id id))
+[@@@ocaml.warning "-3"]       (* String.(un)capitalize_ascii since 4.03.0 GPR#124 *)
+let capitalize = String.capitalize
+let uncapitalize = String.uncapitalize
+[@@@ocaml.warning "+3"]
+
+let lowercase_id id = Id.of_string (uncapitalize (ascii_of_id id))
 let uppercase_id id =
   let s = ascii_of_id id in
   assert (not (String.is_empty s));
   if s.[0] == '_' then Id.of_string ("Coq_"^s)
-  else Id.of_string (String.capitalize s)
+  else Id.of_string (capitalize s)
 
 type kind = Term | Type | Cons | Mod
 

--- a/plugins/extraction/haskell.ml
+++ b/plugins/extraction/haskell.ml
@@ -20,9 +20,10 @@ open Mlutil
 open Common
 
 (*s Haskell renaming issues. *)
-
+[@@@ocaml.warning "-3"]       (* String.(un)capitalize_ascii since 4.03.0 GPR#124 *)
 let pr_lower_id id = str (String.uncapitalize (Id.to_string id))
 let pr_upper_id id = str (String.capitalize (Id.to_string id))
+[@@@ocaml.warning "+3"]
 
 let keywords =
   List.fold_right (fun s -> Id.Set.add (Id.of_string s))

--- a/plugins/extraction/table.ml
+++ b/plugins/extraction/table.ml
@@ -20,6 +20,11 @@ open Util
 open Pp
 open Miniml
 
+[@@@ocaml.warning "-3"]       (* String.capitalize_ascii since 4.03.0 GPR#124 *)
+let capitalize = String.capitalize
+[@@@ocaml.warning "+3"]
+
+
 (** Sets and maps for [global_reference] that use the "user" [kernel_name]
     instead of the canonical one *)
 
@@ -55,7 +60,7 @@ let is_modfile = function
   | _ -> false
 
 let raw_string_of_modfile = function
-  | MPfile f -> String.capitalize (Id.to_string (List.hd (DirPath.repr f)))
+  | MPfile f -> capitalize (Id.to_string (List.hd (DirPath.repr f)))
   | _ -> assert false
 
 let is_toplevel mp =
@@ -772,7 +777,7 @@ let file_of_modfile mp =
 
 let add_blacklist_entries l =
   blacklist_table :=
-    List.fold_right (fun s -> Id.Set.add (Id.of_string (String.capitalize s)))
+    List.fold_right (fun s -> Id.Set.add (Id.of_string (capitalize s)))
       l !blacklist_table
 
 (* Registration of operations for rollback. *)

--- a/tools/coqdep_common.ml
+++ b/tools/coqdep_common.ml
@@ -36,6 +36,10 @@ let norec_dirs = ref StrSet.empty
 
 let suffixe = ref ".vo"
 
+[@@@ocaml.warning "-3"]       (* String.capitalize_ascii since 4.03.0 GPR#124 *)
+let capitalize = String.capitalize
+[@@@ocaml.warning "+3"]
+
 type dir = string option
 
 (** [get_extension f l] checks whether [f] has one of the extensions
@@ -455,7 +459,7 @@ let mL_dependencies () =
        printf "%s_MLPACK_DEPENDENCIES:=%s\n" efullname (String.concat " " dep);
        printf "%s.cmo:$(addsuffix .cmo,$(%s_MLPACK_DEPENDENCIES))\n" efullname efullname;
        printf "%s.cmx:$(addsuffix .cmx,$(%s_MLPACK_DEPENDENCIES))\n" efullname efullname;
-       let efullname_capital = String.capitalize (Filename.basename efullname) in
+       let efullname_capital = capitalize (Filename.basename efullname) in
        List.iter (fun dep ->
          printf "%s.cmx : FOR_PACK=-for-pack %s\n" dep efullname_capital)
          dep;

--- a/tools/coqdep_lexer.mll
+++ b/tools/coqdep_lexer.mll
@@ -39,6 +39,10 @@
 
   let syntax_error lexbuf =
     raise (Syntax_error (Lexing.lexeme_start lexbuf, Lexing.lexeme_end lexbuf))
+
+  [@@@ocaml.warning "-3"]       (* String.uncapitalize_ascii since 4.03.0 GPR#124 *)
+  let uncapitalize = String.uncapitalize
+  [@@@ocaml.warning "+3"]
 }
 
 let space = [' ' '\t' '\n' '\r']
@@ -154,7 +158,7 @@ and caml_action = parse
   | space +
       { caml_action lexbuf }
   | "open" space* (caml_up_ident as id)
-        { Use_module (String.uncapitalize id) }
+        { Use_module (uncapitalize id) }
   | "module" space+ caml_up_ident
         { caml_action lexbuf }
   | caml_low_ident { caml_action lexbuf }
@@ -321,12 +325,12 @@ and modules mllist = parse
 
 and qual_id ml_module_name = parse
   | '.' [^ '.' '(' '[']
-      { Use_module (String.uncapitalize ml_module_name) }
+      { Use_module (uncapitalize ml_module_name) }
   | eof { raise Fin_fichier }
   | _ { caml_action lexbuf }
 
 and mllib_list = parse
-  | caml_up_ident { let s = String.uncapitalize (Lexing.lexeme lexbuf)
+  | caml_up_ident { let s = uncapitalize (Lexing.lexeme lexbuf)
 		in s :: mllib_list lexbuf }
   | "*predef*" { mllib_list lexbuf }
   | space+ { mllib_list lexbuf }

--- a/tools/coqdoc/alpha.ml
+++ b/tools/coqdoc/alpha.ml
@@ -8,7 +8,11 @@
 
 open Cdglobals
 
-let norm_char_latin1 c = match Char.uppercase c with
+[@@@ocaml.warning "-3"]       (* Char.uppercase_ascii since 4.03.0 GPR#124 *)
+let uppercase = Char.uppercase
+[@@@ocaml.warning "+3"]
+
+let norm_char_latin1 c = match uppercase c with
   | '\192'..'\198' -> 'A'
   | '\199' -> 'C'
   | '\200'..'\203' -> 'E'
@@ -19,12 +23,12 @@ let norm_char_latin1 c = match Char.uppercase c with
   | '\221' -> 'Y'
   | c -> c
 
-let norm_char_utf8 c = Char.uppercase c
+let norm_char_utf8 c = uppercase c
 
 let norm_char c =
   if !utf8 then norm_char_utf8 c else
   if !latin1 then norm_char_latin1 c else
-  Char.uppercase c
+  uppercase c
 
 let norm_string = String.map (fun s -> norm_char s)
 

--- a/tools/coqdoc/index.ml
+++ b/tools/coqdoc/index.ml
@@ -155,10 +155,14 @@ let sort_entries el =
 
 let display_letter c = if c = '*' then "other" else String.make 1 c
 
+[@@@ocaml.warning "-3"]       (* String.lowercase_ascii since 4.03.0 GPR#124 *)
+let lowercase = String.lowercase
+[@@@ocaml.warning "+3"]
+
 let type_name = function
   | Library ->
       let ln = !lib_name in
-        if ln <> "" then String.lowercase ln else "library"
+        if ln <> "" then lowercase ln else "library"
   | Module -> "module"
   | Definition -> "definition"
   | Inductive -> "inductive"

--- a/tools/coqdoc/output.ml
+++ b/tools/coqdoc/output.ml
@@ -19,6 +19,10 @@ let printf s = Printf.fprintf !out_channel s
 
 let sprintf = Printf.sprintf
 
+[@@@ocaml.warning "-3"]       (* String.{capitalize,lowercase}_ascii since 4.03.0 GPR#124 *)
+let capitalize = String.capitalize
+let lowercase = String.lowercase
+[@@@ocaml.warning "+3"]
 
 (*s Coq keywords *)
 
@@ -846,7 +850,7 @@ module Html = struct
 	if t = Library then
          let ln = !lib_name in
            if ln <> "" then
-	       "[" ^ String.lowercase ln ^ "]", m ^ ".html", t
+	       "[" ^ lowercase ln ^ "]", m ^ ".html", t
            else
 	       "[library]", m ^ ".html", t
 	else
@@ -864,7 +868,7 @@ module Html = struct
 
   (* Impression de la table d'index *)
   let print_index_table_item i =
-    printf "<tr>\n<td>%s Index</td>\n" (String.capitalize i.idx_name);
+    printf "<tr>\n<td>%s Index</td>\n" (capitalize i.idx_name);
     List.iter
       (fun (c,l) ->
 	 if l <> [] then
@@ -912,7 +916,7 @@ module Html = struct
     let print_table () = print_index_table all_index in
     let print_one_index i =
       if i.idx_size > 0 then begin
-	printf "<hr/>\n<h1>%s Index</h1>\n" (String.capitalize i.idx_name);
+	printf "<hr/>\n<h1>%s Index</h1>\n" (capitalize i.idx_name);
 	all_letters i
       end
     in

--- a/tools/coqmktop.ml
+++ b/tools/coqmktop.ml
@@ -20,6 +20,10 @@ let split_list =
   let spaces = Str.regexp "[ \t\n]+" in
   fun str -> Str.split spaces str
 
+[@@@ocaml.warning "-3"]       (* String.uncapitalize_ascii since 4.03.0 GPR#124 *)
+let capitalize = String.capitalize
+[@@@ocaml.warning "+3"]
+
 let (/) = Filename.concat
 
 (** Which user files do we support (and propagate to ocamlopt) ?
@@ -39,8 +43,7 @@ let native_suffix f = match CUnix.get_extension f with
 (** Transforms a file name in the corresponding Caml module name.
 *)
 let module_of_file name =
-  String.capitalize
-    (try Filename.chop_extension name with Invalid_argument _ -> name)
+  capitalize (try Filename.chop_extension name with Invalid_argument _ -> name)
 
 (** Run a command [prog] with arguments [args].
     We do not use [Sys.command] anymore, see comment in [CUnix.sys_command].

--- a/tools/ocamllibdep.mll
+++ b/tools/ocamllibdep.mll
@@ -11,6 +11,12 @@
 
   let syntax_error lexbuf =
     raise (Syntax_error (Lexing.lexeme_start lexbuf, Lexing.lexeme_end lexbuf))
+
+  [@@@ocaml.warning "-3"]       (* String.(un)capitalize_ascii since 4.03.0 GPR#124 *)
+  let uncapitalize = String.uncapitalize
+
+  let capitalize = String.capitalize
+  [@@@ocaml.warning "+3"]
 }
 
 let space = [' ' '\t' '\n' '\r']
@@ -22,7 +28,7 @@ let caml_up_ident = uppercase identchar*
 let caml_low_ident = lowercase identchar*
 
 rule mllib_list = parse
-  | caml_up_ident { let s = String.uncapitalize (Lexing.lexeme lexbuf)
+  | caml_up_ident { let s = uncapitalize (Lexing.lexeme lexbuf)
 		in s :: mllib_list lexbuf }
   | "*predef*" { mllib_list lexbuf }
   | space+ { mllib_list lexbuf }
@@ -185,7 +191,7 @@ let mlpack_dependencies () =
   List.iter
     (fun (name,dirname) ->
        let fullname = file_name name dirname in
-       let modname = String.capitalize name in
+       let modname = capitalize name in
        let deps = traite_fichier_modules fullname ".mlpack" in
        let sdeps = String.concat " " deps in
        let efullname = escape fullname in


### PR DESCRIPTION
Deprecations which can't be fixed in 4.02.3 are locally wrapped with [@@@ocaml.warning "-3"]. The only ones encountered are
- capitalize to capitalize_ascii and variants. Changing to ascii would break coqdoc -latin1 and maybe other things though. This is related to #628.
- external "noalloc" to external [@@noalloc].