### PR TITLE
Fixing #5523 (missing support for complex constructions in recursive notations) (bis)

### DIFF
--- a/interp/notation_ops.ml
+++ b/interp/notation_ops.ml
@@ -287,7 +287,7 @@ let compare_recursive_parts found f f' (iterator,subc) =
       | Some _ -> false
       end
   | GLambda (Name x,_,t_x,c), GLambda (Name y,_,t_y,term)
-  | GProd (Name x,_,t_x,c), GProd (Name y,_,t_y,term) ->
+  | GProd (Name x,_,t_x,c), GProd (Name y,_,t_y,term) when not (Id.equal x y) ->
       (* We found a binding position where it differs *)
       begin match !diff with
       | None ->

--- a/pretyping/glob_ops.mli
+++ b/pretyping/glob_ops.mli
@@ -36,6 +36,9 @@ val map_glob_constr_left_to_right :
 
 val warn_variable_collision : ?loc:Loc.t -> Id.t -> unit
 
+val mk_glob_constr_eq : (glob_constr -> glob_constr -> bool) ->
+  glob_constr -> glob_constr -> bool
+
 val fold_glob_constr : ('a -> glob_constr -> 'a) -> 'a -> glob_constr -> 'a
 val fold_glob_constr_with_binders : (Id.t -> 'a -> 'a) -> ('a -> 'b -> glob_constr -> 'b) -> 'a -> 'b -> glob_constr -> 'b
 val iter_glob_constr : (glob_constr -> unit) -> glob_constr -> unit

--- a/test-suite/bugs/closed/5523.v
+++ b/test-suite/bugs/closed/5523.v
@@ -1,0 +1,6 @@
+(* Support for complex constructions in recursive notations, especially "match". *)
+
+Definition Let_In {A P} (x : A) (f : forall a : A, P a) : P x := let y := x in f y.
+Notation "'dlet' x , y := v 'in' ( a , b , .. , c )"
+  := (Let_In v (fun '(x, y) => pair .. (pair a b) .. c))
+       (at level 0).

--- a/test-suite/output/Notations3.out
+++ b/test-suite/output/Notations3.out
@@ -98,5 +98,10 @@ fun n : nat => foo4 n (fun _ y : nat => ETA z : nat, (fun _ : nat => y = 0))
      : nat -> Prop
 tele (t : Type) '(y, z) (x : t0) := tt
      : forall t : Type, nat * nat -> t -> fpack
+[fun x : nat => x + 0;; fun x : nat => x + 1;; fun x : nat => x + 2]
+     : (nat -> nat) *
+       ((nat -> nat) *
+        ((nat -> nat) *
+         ((nat -> nat) * ((nat -> nat) * ((nat -> nat) * (nat -> nat))))))
 foo5 x nat x
      : nat -> nat

--- a/test-suite/output/Notations3.v
+++ b/test-suite/output/Notations3.v
@@ -140,6 +140,12 @@ Notation "'tele' x .. z := b" :=
 
 Check tele (t:Type) '((y,z):nat*nat) (x:t) := tt.
 
+(* Checking that "fun" in a notation does not mixed up with the
+   detection of a recursive binder *)
+
+Notation "[ x ;; .. ;; y ]" := ((x,((fun u => S u), .. (y,(fun u => S u,fun v:nat => v)) ..))).
+Check [ fun x => x+0 ;; fun x => x+1 ;; fun x => x+2 ].
+
 (* Cyprien's part of bug #4765 *)
 
 Notation foo5 x T y := (fun x : T => y).


### PR DESCRIPTION
This is a new copy of #663 which was closed by mistake.