### PR TITLE
When Travis build starts, test most recent merge of PR in base branch.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -156,6 +156,7 @@ install:
 script:
 
 - set -e
+- if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then echo "Fetching the most recent merge of PR ${TRAVIS_PULL_REQUEST} in ${TRAVIS_BRANCH}..." && git fetch origin +refs/pull/${TRAVIS_PULL_REQUEST}/merge && git checkout --detach FETCH_HEAD; fi
 - echo 'Configuring Coq...' && echo -en 'travis_fold:start:coq.config\\r'
 - ./configure -local -native-compiler ${NATIVE_COMP} ${EXTRA_CONF}
 - echo -en 'travis_fold:end:coq.config\\r'


### PR DESCRIPTION
Currently, whenever someone opens a PR, or pushes to it, or closes/reopens a PR to trigger a build, a merge is done automatically by GitHub between the base branch and the PR branch. Then a Travis build is added to the queue, and in busy periods it can take hours or days before the build actually starts.

- If in the meantime a breaking change that required overlays for plugins has been merged, the build can fail for an apparently very strange reason: the developments we test are targeting trunk, but the merge point is lagging behind.

- If in the meantime a conflicting change has been merged, then Travis will still run the build even if it now needs rebasing. (Wasting build time for everyone.)

- If the PR badly interacts with a change that has been merged, but the two did not conflict, there is the risk of merging a seemingly good PR only to see it create problems in trunk. (I don't think this has happened yet.)

This PR brings a change to the Travis configuration which has the following effect:
Whenever the build of a PR starts, the tip of the base branch is fetched and merged with the PR branch, so that we test an up-to-date version.
Of course, this may create failures due to merge conflict but these only indicate that the PR needs rebasing.
We do the merge as soon as possible in the build process so as to waste as little build time as possible in case of a merge conflict (typically 2 minutes for each build, which correspond to the download of Ubuntu packages).

Note that this does not affect the build of branches outside of PRs, so everyone can continue to test their own versions in their forks.