### PR TITLE
Fix bug 5550: "typeclasses eauto with" does not work with section variables.

### DIFF
--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -593,6 +593,7 @@ let make_hints g st only_classes sign =
     List.fold_left
       (fun hints hyp ->
         let consider =
+          not only_classes ||
           let open Context.Named.Declaration in
           try let t = Global.lookup_named (get_id hyp) |> get_type in
               (* Section variable, reindex only if the type changed *)

--- a/test-suite/bugs/closed/5550.v
+++ b/test-suite/bugs/closed/5550.v
@@ -1,0 +1,10 @@
+Section foo.
+
+  Variable bar : Prop.
+  Variable H : bar.
+
+  Goal bar.
+    typeclasses eauto with foobar.
+  Qed.
+
+End foo.


### PR DESCRIPTION
https://coq.inria.fr/bugs/show_bug.cgi?id=5550

Requesting a review from @mattam82