### PR TITLE
[readlink -f] doesn't work on OSX

### DIFF
--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -27,8 +27,8 @@
 
 # Default value when called from a freshly compiled Coq, but can be
 # easily overridden
-BIN := $(shell cd ..; readlink -f bin)/
 LIB := $(shell cd ..; pwd)
+BIN := $(LIB)/bin/
 
 coqtop := $(BIN)coqtop -coqlib $(LIB) -boot -q -batch -test-mode -R prerequisite TestSuite
 coqc := $(BIN)coqc -coqlib $(LIB) -R prerequisite TestSuite


### PR DESCRIPTION
We only want an absolute path, no need to follow symlinks.

Issue brought up by @herbelin at https://github.com/coq/coq/pull/248#issuecomment-304872856