### PR TITLE
Workaround bug 5156 in the standard library

### DIFF
--- a/theories/Classes/CRelationClasses.v
+++ b/theories/Classes/CRelationClasses.v
@@ -222,7 +222,14 @@ Unset Implicit Arguments.
 Ltac solve_crelation :=
   match goal with
   | [ |- ?R ?x ?x ] => reflexivity
-  | [ H : ?R ?x ?y |- ?R ?y ?x ] => symmetry ; exact H
+  (* use separate pattern matches as a workaround for bug
+  https://coq.inria.fr/bugs/show_bug.cgi?id=5156 (this tactic applies frequently
+  even in developments that don't actively use CRelationClasses due to
+  [intuition]'s use of [auto with *]) *)
+  | [ |- ?R ?y ?x ] =>
+    match goal with
+    | [ H : R y x |- _ ] => symmetry ; exact H
+    end
   end.
 
 Hint Extern 4 => solve_crelation : crelations.


### PR DESCRIPTION
Any development that `Require`'d CRelationClasses had a non-linear pattern matching extern hint that could be used by `intuition` due to `auto with *`. Re-writing the tactic to remove the non-linear pattern match avoids triggering [bug 5156](https://coq.inria.fr/bugs/show_bug.cgi?id=5156).

This is a temporary solution; the underlying bug should be fixed and then this workaround can be reverted.