### PR TITLE
New version of the selective-unfolding PR

### DIFF
--- a/interp/constrextern.mli
+++ b/interp/constrextern.mli
@@ -80,3 +80,13 @@ val without_specific_symbols : interp_rule list -> ('a -> 'b) -> 'a -> 'b
 
 (** This prints metas as anonymous holes *)
 val with_meta_as_hole : ('a -> 'b) -> 'a -> 'b
+
+(** Fine-grained activation and deactivation of notation printing.
+ *)
+val toggle_scope_printing :
+  scope:Notation_term.scope_name -> activate:bool -> unit
+
+val toggle_notation_printing :
+  ?scope:Notation_term.scope_name -> notation:Constrexpr.notation -> activate:bool -> unit
+
+


### PR DESCRIPTION
This PR is a reimplementation of PR #200. It introduces the possibility to unset the printing of notations in a more fine grained fashion than Unset Printing Notations. One can unfold notations either individually or by scopes.
This is very useful for debugging purposes when having very large notations that should not be unfolded (UTF8 string comes to mind immediately).

It introduces four new commands to activate/deactivate notation either individually or by scope.  Their current syntax (subject to change) is the following:

    Deactivate Notation Scope scope_name.
    Reactivate Notation Scope scope_name.
    Deactivation Notation notation_string [From Scope scope_name].
    Reactivation Notation notation string [From Scope scope_name].

Notation strings are the displayed notations with variables replaced by "_".

I included most of the feedback from PR #200 with the following exceptions:
+ The names of the commands: I agree that @JasonGross 's suggestion is much better but I am not completely sure what @herbelin means by "an ad hoc vernac entry". Does that simply mean adding commands "Set Printing Notation ..." and Co to the command rules?
+ As this only affects the *printing* of notations and not their parsing, I feel like this design really is mostly for debugging and should not be synchronized but feel free to try to make me change my mind
+ There is currently a small bug that seems to make these functions called twice with only one command thus triggering the warnings for already activated/deactivated notations.  I was not able to track it down.