### PR TITLE
eauto based on the typeclasses eauto implementation

### DIFF
--- a/engine/proofview.mli
+++ b/engine/proofview.mli
@@ -289,6 +289,7 @@ val tclTRYFOCUS : int -> int -> unit tactic -> unit tactic
 exception SizeMismatch of int*int
 val tclDISPATCH : unit tactic list -> unit tactic
 val tclDISPATCHL : 'a tactic list -> 'a list tactic
+val tclFOLD : ('a -> 'a tactic) -> 'a -> 'a tactic
 
 (** [tclEXTEND b r e] is a variant of {!tclDISPATCH}, where the [r]
     tactic is "repeated" enough time such that every goal has a tactic

--- a/plugins/ltac/g_auto.ml4
+++ b/plugins/ltac/g_auto.ml4
@@ -111,9 +111,15 @@ END
 let make_depth n = snd (Eauto.make_dimension n None)
 
 TACTIC EXTEND eauto
-| [ "eauto" int_or_var_opt(n) int_or_var_opt(p) auto_using(lems)
+| [ "eauto" int_or_var_opt(depth) int_or_var_opt(p) auto_using(lems)
     hintbases(db) ] ->
-    [ Eauto.gen_eauto (Eauto.make_dimension n p) (eval_uconstrs ist lems) db ]
+    [
+      if Option.has_some p then
+        (* TODO: Should print a deprecation warning *)
+        Eauto.gen_eauto (Eauto.make_dimension depth p) (eval_uconstrs ist lems) db
+      else
+        Class_tactics.eauto ~depth ~strategy:Class_tactics.Dfs (eval_uconstrs ist lems) db
+    ]
 END
 
 TACTIC EXTEND new_eauto

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -601,12 +601,13 @@ let make_resolve_hyp env sigma ~mode st pri decl =
                else false
   in
   let is_class = iscl env cty in
-  let keep = not mode.only_classes || is_class in
-    if keep then
+  if mode.only_classes && not is_class then []
+  else
       let c = mkVar id in
       let name = PathHints [VarRef id] in
       let hints =
-        if is_class then
+        if mode.only_classes then
+          (* Given the previous test, cty must be a class. *)
           let hints = build_subclasses ~check:false env sigma (VarRef id) empty_hint_info in
             (List.map_append
              (fun (path,info,c) ->
@@ -627,7 +628,6 @@ let make_resolve_hyp env sigma ~mode st pri decl =
          [ make_exact_entry ~name env sigma ~compat:mode.compat pri false
          ; make_apply_entry ~name env sigma (mode.evars,mode.hnf,false) pri false ]
         )
-    else []
 
 let make_hints ~mode g st sign =
   let hintlist =

--- a/tactics/class_tactics.mli
+++ b/tactics/class_tactics.mli
@@ -29,6 +29,11 @@ val typeclasses_eauto : ?only_classes:bool -> ?st:transparent_state -> ?strategy
                         depth:(Int.t option) ->
                         Hints.hint_db_name list -> unit Proofview.tactic
 
+val eauto :
+  ?strategy:search_strategy -> ?evars:bool -> ?max_cost:int ->
+  depth:(Int.t option) -> Tactypes.delayed_open_constr list ->
+  Hints.hint_db_name list option -> unit Proofview.tactic
+
 val head_of_constr : Id.t -> constr -> unit Proofview.tactic
 
 val not_evar : constr -> unit Proofview.tactic
@@ -37,6 +42,7 @@ val is_ground : constr -> unit Proofview.tactic
 
 val autoapply : constr -> Hints.hint_db_name -> unit Proofview.tactic
 
+(*
 module Search : sig
   val eauto_tac :
     ?st:Names.transparent_state ->
@@ -56,3 +62,4 @@ module Search : sig
     (** The list of hint databases to use *)
     unit Proofview.tactic
 end
+*)

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -786,7 +786,15 @@ let secvars_of_constr env sigma c =
 let secvars_of_global env gr =
   secvars_of_idset (vars_of_global_reference env gr)
 
-let make_exact_entry env sigma info poly ?(name=PathAny) (c, cty, ctx) =
+let make_exact_entry_compat env sigma info poly ?(name=PathAny) (c, cty, ctx) =
+  let secvars = secvars_of_constr env sigma c in
+  let cty = strip_outer_cast sigma cty in
+  let pri = match info.hint_priority with None -> 0 | Some p -> p in
+  (None, { pri; poly; pat = None; name; db = None; secvars;
+           code = with_uid (Give_exact (c, cty, ctx)); })
+
+let make_exact_entry env sigma ?(compat=false) info poly ?(name=PathAny) (c, cty, ctx) =
+  if compat then make_exact_entry_compat env sigma info poly ~name (c, cty, ctx) else
   let secvars = secvars_of_constr env sigma c in
   let cty = strip_outer_cast sigma cty in
     match EConstr.kind sigma cty with

--- a/tactics/hints.mli
+++ b/tactics/hints.mli
@@ -194,7 +194,7 @@ val prepare_hint : bool (* Check no remaining evars *) ->
    [hint_pattern] is the hint's desired pattern, it is inferred if not specified
 *)
 
-val make_exact_entry : env -> evar_map -> hint_info -> polymorphic -> ?name:hints_path_atom ->
+val make_exact_entry : env -> evar_map -> ?compat:bool -> hint_info -> polymorphic -> ?name:hints_path_atom ->
   (constr * types * Univ.ContextSet.t) -> hint_entry
 
 (** [make_apply_entry (eapply,hnf,verbose) info (c,cty,ctx))].

--- a/test-suite/bugs/closed/6198.v
+++ b/test-suite/bugs/closed/6198.v
@@ -1,0 +1,22 @@
+Theorem inj_proj : forall A B (p1 p2:A*B),
+    fst p1 = fst p2 ->
+    snd p1 = snd p2 ->
+    p1 = p2.
+Proof.
+  destruct p1, p2; simpl; intros; congruence.
+Qed.
+
+Hint Resolve inj_proj.
+
+Definition state := (nat * nat)%type.
+
+Theorem surjective_pairing : forall (p:state) a b,
+    fst p = a ->
+    snd p = b ->
+    p = (a, b).
+Proof.
+  intros.
+  Fail simple apply inj_proj.
+  Fail solve [ eauto ].
+  Fail solve [ eauto using inj_proj ].
+Abort.

--- a/test-suite/bugs/opened/6544.v
+++ b/test-suite/bugs/opened/6544.v
@@ -1,0 +1,20 @@
+Hint Resolve plus_n_O | 0 (?X = ?X + 0).
+Hint Extern 0 (?X = ?X + 0) => simple apply plus_n_O.
+
+Goal forall n, n = n + (0 + 0).
+  intros n.
+  solve [auto].
+  Undo.
+  solve [eauto].          (* can be solved because we have `plus_n_O` hint *)
+  Undo.
+  Remove Hints plus_n_O : core.
+  Fail solve [auto].
+  Fail solve [eauto].     (* fails as expected *)
+  Hint Extern 0 (?X = ?X + 0) => simple apply plus_n_O.
+  Fail solve [auto].
+  Fail solve [eauto].     (* I'd expect this to work, since the following works *)
+  Hint Resolve plus_n_O | 0 (?X = ?X + 0).
+  solve [auto].
+  Undo.
+  solve [eauto].
+Qed.


### PR DESCRIPTION
This PR plugs the `eauto` tactic to a new implementation based on the one of `typeclasses eauto` in `class_tactics.ml`.

~~The issue preventing to replace `eauto` is the search-depth semantics. I fail to see how to imitate the current search-depth semantics of `eauto` (threading the decrease of the depth among sub-goals) within the tactic engine (see #5555).~~
EDIT: (almost) addressed

I have also tried to see if I could replace `auto` but I encountered at least two issues: obligation solving becoming more powerful; immediate hints failing when they would succeed with the original `auto`.

Similarly, I tried to see if I could replace `trivial` but it was too powerful, due to some discrepancy with `eauto`. Here is an example showing the difference of power between `trivial` and `eauto` in 8.6:

```coq
Require Import BinInt BinNat.
Lemma foo (n m : Z) (p p0 : positive)
  (H : forall p q : positive, Z.abs_N (Z.pos p ÷ Z.pos q) = (N.pos p / N.pos q)%N) :
  Z.abs_N (Z.pos p ÷ Z.pos p0) = (Z.abs_N (Z.pos p) / Z.abs_N (Z.pos p0))%N.
Proof.
  debug trivial with nocore. (* assumption. (*fail*) intro. (*fail*) simple apply H. (*fail*) *)
  info_eauto 1 with nocore. (* simple apply H. *)
Qed.
```

~~FTR 107f835 is a cherry-pick of e6c41b9 which was merged into v8.6 (this branch should be rebased once v8.6 is merged into trunk).~~
EDIT: Done.

~~9ab3d55 is an independent (small) refactoring which could be moved out of this PR.~~
EDIT: I dropped this one because if conflicts with #638.

~~Also, @mattam82 do you agree with 083ee07? I am betting that there was a missing `if only_classes` test there. If that's correct, it could be made into an independent bug-fix. Although I haven't identified a bug that it could trigger (but I haven't looked, maybe one could cook such a bug).~~
EDIT: See #6841.