### PR TITLE
Fixing an inconsistency between configure and configure.ml

### DIFF
--- a/configure
+++ b/configure
@@ -3,7 +3,7 @@
 ## This micro-configure shell script is here only to
 ## launch the real configuration via ocaml
 
-cmd=ocaml
+ocaml=ocaml
 script=./configure.ml
 
 if [ ! -f $script ]; then
@@ -16,10 +16,11 @@ fi
 ## Parse the args, only looking for -camldir
 ## We avoid using shift to keep "$@" intact
 
+cmd=$ocaml
 last=
 for i; do
    case $last in
-       -camldir|--camldir) cmd="$i/ocaml"; break;;
+       -camldir) cmd="$i/$ocaml"; break;;
    esac
    last=$i
 done

--- a/configure.ml
+++ b/configure.ml
@@ -349,6 +349,8 @@ let args_options = Arg.align [
     " URL of the coq website";
   "-force-caml-version", Arg.Set Prefs.force_caml_version,
     " Force OCaml version";
+  "-camldir", Arg.String (fun _ -> ()),
+    "<dir> Specifies path to ocaml for running configure script";
 ]
 
 let parse_args () =


### PR DESCRIPTION
This is a fix to configure with option -camldir (first commit of a split of #628).