### PR TITLE
Mini-cleaning around OCaml file names

### DIFF
--- a/tools/coq_makefile.ml
+++ b/tools/coq_makefile.ml
@@ -643,11 +643,15 @@ let subdirs sds =
       section "Subdirectories.";
     List.iter pr_subdir sds
 
+let capitalize_caml_file_name s =
+ assert (String.length s <> 0 && s.[0] >= 'a' && s.[0] <= 'z');
+ String.make 1 (Char.chr (Char.code s.[0] - 32)) ^ String.sub s 1 (String.length s - 1)
+
 let forpacks l =
   let () = if l <> [] then section "Ad-hoc implicit rules for mlpack." in
   List.iter (fun it ->
     let h = Filename.chop_extension it in
-    let pk = String.capitalize (Filename.basename h) in
+    let pk = capitalize_caml_file_name (Filename.basename h) in
     printf "$(addsuffix .cmx,$(filter $(basename $(MLFILES)),$(%s_MLPACK_DEPENDENCIES))): %%.cmx: %%.ml\n" h;
     printf "\t$(SHOW)'CAMLOPT -c -for-pack %s $<'\n" pk;
     printf "\t$(HIDE)$(CAMLOPTC) $(ZDEBUG) $(ZFLAGS) -for-pack %s $<\n\n" pk;

--- a/tools/coqmktop.ml
+++ b/tools/coqmktop.ml
@@ -22,6 +22,10 @@ let split_list =
 
 let (/) = Filename.concat
 
+let capitalize_caml_file_name s =
+  assert (String.length s <> 0 && s.[0] >= 'a' && s.[0] <= 'z');
+  String.make 1 (Char.chr (Char.code s.[0] - 32)) ^ String.sub s 1 (String.length s - 1)
+
 (** Which user files do we support (and propagate to ocamlopt) ?
 *)
 let supported_suffix f = match CUnix.get_extension f with
@@ -39,7 +43,7 @@ let native_suffix f = match CUnix.get_extension f with
 (** Transforms a file name in the corresponding Caml module name.
 *)
 let module_of_file name =
-  String.capitalize
+  capitalize_caml_file_name
     (try Filename.chop_extension name with Invalid_argument _ -> name)
 
 (** Run a command [prog] with arguments [args].
@@ -137,7 +141,7 @@ let core_libs = split_list Tolink.core_libs
 *)
 let files_to_link userfiles =
   let top = if !top then topobjs else [] in
-  let modules = List.map module_of_file (top @ core_objs @ userfiles) in
+  let modules = List.map module_of_file top @ core_objs @ List.map module_of_file userfiles in
   let objs = libobjs @ top @ core_libs in
   let objs' = (if !opt then List.map native_suffix objs else objs) @ userfiles
   in (modules, objs')

--- a/tools/ocamllibdep.mll
+++ b/tools/ocamllibdep.mll
@@ -11,18 +11,25 @@
 
   let syntax_error lexbuf =
     raise (Syntax_error (Lexing.lexeme_start lexbuf, Lexing.lexeme_end lexbuf))
+
+  let capitalize_caml_file_name s =
+    assert (String.length s <> 0 && s.[0] >= 'a' && s.[0] <= 'z');
+    String.make 1 (Char.chr (Char.code s.[0] - 32)) ^ String.sub s 1 (String.length s - 1)
+
+  let uncapitalize_caml_module_name s =
+    assert (String.length s <> 0 && s.[0] >= 'A' && s.[0] <= 'Z');
+    String.make 1 (Char.chr (Char.code s.[0] + 32)) ^ String.sub s 1 (String.length s - 1)
 }
 
 let space = [' ' '\t' '\n' '\r']
-let lowercase = ['a'-'z' '\223'-'\246' '\248'-'\255']
-let uppercase = ['A'-'Z' '\192'-'\214' '\216'-'\222']
-let identchar =
-  ['A'-'Z' 'a'-'z' '_' '\192'-'\214' '\216'-'\246' '\248'-'\255' '\'' '0'-'9']
+let lowercase = ['a'-'z']
+let uppercase = ['A'-'Z']
+let identchar = ['A'-'Z' 'a'-'z' '_' '\'' '0'-'9']
 let caml_up_ident = uppercase identchar*
 let caml_low_ident = lowercase identchar*
 
 rule mllib_list = parse
-  | caml_up_ident { let s = String.uncapitalize (Lexing.lexeme lexbuf)
+  | caml_up_ident { let s = uncapitalize_caml_module_name (Lexing.lexeme lexbuf)
 		in s :: mllib_list lexbuf }
   | "*predef*" { mllib_list lexbuf }
   | space+ { mllib_list lexbuf }
@@ -185,7 +192,7 @@ let mlpack_dependencies () =
   List.iter
     (fun (name,dirname) ->
        let fullname = file_name name dirname in
-       let modname = String.capitalize name in
+       let modname = capitalize_caml_file_name name in
        let deps = traite_fichier_modules fullname ".mlpack" in
        let sdeps = String.concat " " deps in
        let efullname = escape fullname in


### PR DESCRIPTION
Ocaml file names are restricted since 2008 to A..Z followed by a..z0..9'_.

We take this constraint into account in tools manipulating Ocaml file names.

At the same time, this commit makes the compilation independent of String.capitalize, String.uncapitalize, deprecated since ocaml 4.03.0 and liable to disappear in the future.

This is the fourth commit of a split of #628. See the discussion there about the advantages and drawbacks of depending or not from OCaml's `capitalize`. Alternatives are welcome.
