### PR TITLE
Display timing data for fiat-*, bedrock, and HoTT on travis

### DIFF
--- a/dev/ci/ci-bedrock-facade.sh
+++ b/dev/ci/ci-bedrock-facade.sh
@@ -7,4 +7,4 @@ bedrock_facade_CI_DIR=${CI_BUILD_DIR}/bedrock-facade
 
 git_checkout ${bedrock_facade_CI_BRANCH} ${bedrock_facade_CI_GITURL} ${bedrock_facade_CI_DIR}
 
-( cd ${bedrock_facade_CI_DIR} && make -j ${NJOBS} facade )
+( cd ${bedrock_facade_CI_DIR} && ./etc/coq-scripts/timing/make-pretty-timed-or-error.sh -j ${NJOBS} facade )

--- a/dev/ci/ci-bedrock-src.sh
+++ b/dev/ci/ci-bedrock-src.sh
@@ -7,4 +7,4 @@ bedrock_src_CI_DIR=${CI_BUILD_DIR}/bedrock-src
 
 git_checkout ${bedrock_src_CI_BRANCH} ${bedrock_src_CI_GITURL} ${bedrock_src_CI_DIR}
 
-( cd ${bedrock_src_CI_DIR} && make -j ${NJOBS} src )
+( cd ${bedrock_src_CI_DIR} && ./etc/coq-scripts/timing/make-pretty-timed-or-error.sh -j ${NJOBS} src )

--- a/dev/ci/ci-common.sh
+++ b/dev/ci/ci-common.sh
@@ -37,12 +37,15 @@ git_checkout()
   local _DEPTH=$(if [ -z "${4}" ]; then echo "--depth 1"; fi)
 
   mkdir -p ${_DEST}
-  ( cd ${_DEST}                                                && \
-    if [ ! -d .git ] ; then git clone ${_DEPTH} ${_URL} . ; fi && \
-    echo "Checking out ${_DEST}"                               && \
-    git fetch ${_URL} ${_BRANCH}                               && \
-    git checkout ${_COMMIT}                                    && \
-    echo "${_DEST}: `git log -1 --format='%s | %H | %cd | %aN'`" )
+  ( cd ${_DEST}                                                            && \
+    if [ ! -d .git ] ; then git clone --recursive ${_DEPTH} ${_URL} . ; fi && \
+    echo "Checking out ${_DEST}"                                           && \
+    git fetch ${_URL} ${_BRANCH}                                           && \
+    git checkout ${_COMMIT}                                                && \
+    git submodule update --init --recursive                                && \
+    echo "${_DEST}: `git log -1 --format='%s | %H | %cd | %aN'`"           && \
+    git submodule foreach                                                     \
+	'echo "$path: `git log -1 --format="%s | %H | %cd | %aN"`' )
 }
 
 checkout_mathcomp()

--- a/dev/ci/ci-fiat-crypto.sh
+++ b/dev/ci/ci-fiat-crypto.sh
@@ -7,4 +7,4 @@ fiat_crypto_CI_DIR=${CI_BUILD_DIR}/fiat-crypto
 
 git_checkout ${fiat_crypto_CI_BRANCH} ${fiat_crypto_CI_GITURL} ${fiat_crypto_CI_DIR}
 
-( cd ${fiat_crypto_CI_DIR} && make -j ${NJOBS} lite )
+( cd ${fiat_crypto_CI_DIR} && ./etc/coq-scripts/timing/make-pretty-timed-or-error.sh -j ${NJOBS} lite )

--- a/dev/ci/ci-fiat-parsers.sh
+++ b/dev/ci/ci-fiat-parsers.sh
@@ -7,4 +7,4 @@ fiat_parsers_CI_DIR=${CI_BUILD_DIR}/fiat
 
 git_checkout ${fiat_parsers_CI_BRANCH} ${fiat_parsers_CI_GITURL} ${fiat_parsers_CI_DIR}
 
-( cd ${fiat_parsers_CI_DIR} && make -j ${NJOBS} parsers && make -j ${NJOBS} fiat-core )
+( cd ${fiat_parsers_CI_DIR} && ./etc/coq-scripts/timing/make-pretty-timed-or-error.sh -j ${NJOBS} parsers fiat-core )

--- a/dev/ci/ci-hott.sh
+++ b/dev/ci/ci-hott.sh
@@ -7,4 +7,4 @@ HoTT_CI_DIR=${CI_BUILD_DIR}/HoTT
 
 git_checkout ${HoTT_CI_BRANCH} ${HoTT_CI_GITURL} ${HoTT_CI_DIR}
 
-( cd ${HoTT_CI_DIR} && ./autogen.sh && ./configure && make -j ${NJOBS} )
+( cd ${HoTT_CI_DIR} && ./autogen.sh && ./configure && ./etc/coq-scripts/timing/make-pretty-timed-or-error.sh -j ${NJOBS} )


### PR DESCRIPTION
aThis is not as good as having the bench display per-file timing data, but at least it'll give us some sort of per-file timing log for these projects, at almost no cost.