### PR TITLE
[ci] Test coqchk on the CompCert target.

### DIFF
--- a/dev/ci/ci-compcert.sh
+++ b/dev/ci/ci-compcert.sh
@@ -8,6 +8,4 @@ CompCert_CI_DIR=${CI_BUILD_DIR}/CompCert
 opam install -j ${NJOBS} -y menhir
 git_checkout ${CompCert_CI_BRANCH} ${CompCert_CI_GITURL} ${CompCert_CI_DIR}
 
-# Patch to avoid the upper version limit
-( cd ${CompCert_CI_DIR} && ./configure -ignore-coq-version x86_32-linux && make )
-
+( cd ${CompCert_CI_DIR} && ./configure -ignore-coq-version x86_32-linux && make && make check-proof )


### PR DESCRIPTION
The CompCert makefile has [a target](https://github.com/AbsInt/CompCert/blob/master/Makefile#L280-L285) to (partially) run coqchk.
The limitations should be fixed but in the meantime, it still makes sense to add this target to the Travis tests.
Already tested here: https://travis-ci.org/Zimmi48/coq/builds/240338948