### PR TITLE
Pin math-comp to 1.6.1 in v8.6 branch.

### DIFF
--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -8,7 +8,8 @@
 # MathComp
 ########################################################################
 : ${mathcomp_CI_BRANCH:=master}
-: ${mathcomp_CI_GITURL:=https://github.com/math-comp/math-comp.git}
+: ${mathcomp_CI_GITURL:=https://github.com/Zimmi48/math-comp.git}
+# Until MathComp gets fixed for Coq 8.6.
 
 ########################################################################
 # UniMath


### PR DESCRIPTION
Since the SSR merge, the master branch of math-comp isn't compatible with Coq 8.6 anymore.
This should fix the Travis targets depending on it by pinning the 1.6.1 version instead of using
the development version.

Note to @gares @maximedenes: an alternative solution would be for math-comp to maintain compatibility with 8.6 by using the old SSR files in case Coq version is < 8.7 (but I suppose you discussed the options already).