### PR TITLE
Remove deprecated options of ./configure in 8.8

### DIFF
--- a/configure.ml
+++ b/configure.ml
@@ -300,27 +300,17 @@ let args_options = Arg.align [
     "<dir> Where to install doc files";
   "-emacslib", arg_string_option Prefs.emacslib,
     "<dir> Where to install emacs files";
-  "-emacs", Arg.String (fun s ->
-      prerr_endline "Warning: -emacs option is deprecated. Use -emacslib instead.";
-      Prefs.emacslib := Some s),
-    "<dir> Deprecated: same as -emacslib";
   "-coqdocdir", arg_string_option Prefs.coqdocdir,
     "<dir> Where to install Coqdoc style files";
   "-ocamlfind", arg_string_option Prefs.ocamlfindcmd,
     "<dir> Specifies the ocamlfind command to use";
   "-lablgtkdir", arg_string_option Prefs.lablgtkdir,
     "<dir> Specifies the path to the Lablgtk library";
-  "-usecamlp5", Arg.Unit (fun () ->
-      prerr_endline "Warning: -usecamlp5 option is deprecated. Camlp5 is already a required dependency."),
-    " Deprecated: Camlp5 is a required dependency (Camlp4 is not supported anymore)";
   "-camlp5dir",
     Arg.String (fun s -> Prefs.camlp5dir:=Some s),
     "<dir> Specifies where is the Camlp5 library and tells to use it";
   "-arch", arg_string_option Prefs.arch,
     "<arch> Specifies the architecture";
-  "-opt", Arg.Unit (fun () ->
-      prerr_endline "Warning: -opt option is deprecated. Native OCaml executables are detected automatically."),
-    " Deprecated: native OCaml executables detected automatically";
   "-natdynlink", arg_bool Prefs.natdynlink,
     "(yes|no) Use dynamic loading of native code or not";
   "-coqide", Arg.String (fun s -> Prefs.coqide := Some (get_ide s)),
@@ -329,33 +319,18 @@ let args_options = Arg.align [
     " Do not try to build CoqIDE MacOS integration";
   "-browser", arg_string_option Prefs.browser,
     "<command> Use <command> to open URL %s";
-  "-nodoc", Arg.Unit (fun () ->
-      prerr_endline "Warning: -nodoc option is deprecated. Use -with-doc no instead.";
-      Prefs.withdoc := false),
-    " Deprecated: use -with-doc no instead";
   "-with-doc", arg_bool Prefs.withdoc,
     "(yes|no) Compile the documentation or not";
   "-with-geoproof", arg_bool Prefs.geoproof,
     "(yes|no) Use Geoproof binding or not";
   "-byte-only", Arg.Set Prefs.byteonly,
     " Compiles only bytecode version of Coq";
-  "-byteonly", Arg.Unit (fun () ->
-      prerr_endline "Warning: -byteonly option is deprecated. Use -byte-only instead.";
-      Prefs.byteonly := true),
-    " Deprecated: use -byte-only instead";
-  "-debug", Arg.Unit (fun () ->
-      prerr_endline "Warning: -debug option is deprecated. Coq is compiled in debug mode by default.";
-      Prefs.debug := true),
-    " Deprecated: Coq is compiled in debug mode by default";
   "-nodebug", Arg.Clear Prefs.debug,
     " Do not add debugging information in the Coq executables";
   "-profile", Arg.Set Prefs.profile,
     " Add profiling information in the Coq executables";
   "-annotate", Arg.Set Prefs.annotate,
     " Dumps ml annotation files while compiling Coq";
-  "-makecmd", Arg.String (fun _ ->
-      prerr_endline "Warning: -makecmd option is deprecated and doesn't have any effect."),
-    "<command> Deprecated";
   "-native-compiler", arg_bool Prefs.nativecompiler,
     "(yes|no) Compilation to native code for conversion and normalization";
   "-coqwebsite", Arg.Set_string Prefs.coqwebsite,


### PR DESCRIPTION
This depends upon #749.
Please add the 8.8 milestone to this (not to be merged before the branching).