### PR TITLE
Remove most uses of unsafe_type_of as well as a couple of evar leaks.

### DIFF
--- a/API/API.mli
+++ b/API/API.mli
@@ -4953,6 +4953,7 @@ sig
     val pf_apply : (Environ.env -> Evd.evar_map -> 'a) -> 'b Proofview.Goal.t -> 'a
     val project : 'a Proofview.Goal.t -> Evd.evar_map
     val pf_unsafe_type_of : 'a Proofview.Goal.t -> EConstr.constr -> EConstr.types
+    val pf_type_of : 'a Proofview.Goal.t -> EConstr.constr -> Evd.evar_map * EConstr.types
     val of_old : (Goal.goal Evd.sigma -> 'a) -> [ `NF ] Proofview.Goal.t -> 'a
 
     val pf_env : 'a Proofview.Goal.t -> Environ.env

--- a/plugins/cc/ccalgo.ml
+++ b/plugins/cc/ccalgo.ml
@@ -509,7 +509,8 @@ let rec add_term state t=
 	Not_found ->
 	  let b=next uf in
           let trm = constr_of_term t in
-	  let typ = pf_unsafe_type_of state.gls (EConstr.of_constr trm) in
+	  let sigma, typ = pf_type_of state.gls (EConstr.of_constr trm) in
+	  let state = { state with gls = { state.gls with sigma } } in
 	  let typ = canonize_name (project state.gls) typ in
 	  let new_node=
 	    match t with

--- a/plugins/firstorder/instances.ml
+++ b/plugins/firstorder/instances.ml
@@ -102,7 +102,7 @@ let dummy_bvid=Id.of_string "x"
 let mk_open_instance env evmap id idc m t =
   let var_id=
     if id==dummy_id then dummy_bvid else
-      let typ=Typing.unsafe_type_of env evmap idc in
+      let evmap, typ = Typing.type_of env evmap idc in
 	(* since we know we will get a product,
 	   reduction is not too expensive *)
       let (nam,_,_)=destProd evmap (whd_all env evmap typ) in

--- a/plugins/firstorder/sequent.ml
+++ b/plugins/firstorder/sequent.ml
@@ -210,7 +210,7 @@ let extend_with_auto_hints env sigma l seq =
           let (c, _, _) = c in
 	  (try
 	     let (gr, _) = Termops.global_of_constr sigma c in
-	     let typ=(Typing.unsafe_type_of env sigma c) in
+	     let sigma, typ = Typing.type_of env sigma c in
 	       seqref:=add_formula env sigma Hint gr typ !seqref
 	   with Not_found->())
       | _-> () in

--- a/plugins/ltac/extratactics.ml4
+++ b/plugins/ltac/extratactics.ml4
@@ -762,10 +762,11 @@ let refl_equal =
   call it before it is defined. *)
 let  mkCaseEq a  : unit Proofview.tactic =
   Proofview.Goal.enter begin fun gl ->
-    let type_of_a = Tacmach.New.pf_unsafe_type_of gl a in
+    let sigma, t = Tacmach.New.pf_type_of gl a in
+    Proofview.Unsafe.tclEVARS sigma <*>
     Tacticals.New.pf_constr_of_global (delayed_force refl_equal) >>= fun req ->
     Tacticals.New.tclTHENLIST
-         [Tactics.generalize [(mkApp(req, [| type_of_a; a|]))];
+         [Tactics.generalize [(mkApp(req, [| t; a|]))];
           Proofview.Goal.enter begin fun gl ->
             let concl = Proofview.Goal.concl gl in
             let env = Proofview.Goal.env gl in
@@ -819,9 +820,8 @@ let destauto t =
 
 let destauto_in id = 
   Proofview.Goal.enter begin fun gl ->
-  let ctype = Tacmach.New.pf_unsafe_type_of gl (mkVar id) in
-(*  Pp.msgnl (Printer.pr_lconstr (mkVar id)); *)
-(*  Pp.msgnl (Printer.pr_lconstr (ctype)); *)
+  let sigma, ctype = Tacmach.New.pf_type_of gl (mkVar id) in
+  Proofview.Unsafe.tclEVARS sigma <*>
   destauto ctype
   end
 

--- a/plugins/ltac/rewrite.ml
+++ b/plugins/ltac/rewrite.ml
@@ -467,24 +467,24 @@ let rec decompose_app_rel env evd t =
   match EConstr.kind evd t with
   | App (f, [||]) -> assert false
   | App (f, [|arg|]) ->
-    let (f', argl, argr) = decompose_app_rel env evd arg in
-    let ty = Typing.unsafe_type_of env evd argl in
+    let (evd, f', argl, argr) = decompose_app_rel env evd arg in
+    let evd, ty = Typing.type_of env evd argl in
     let f'' = mkLambda (Name default_dependent_ident, ty,
       mkLambda (Name (Id.of_string "y"), lift 1 ty,
         mkApp (lift 2 f, [| mkApp (lift 2 f', [| mkRel 2; mkRel 1 |]) |])))
-    in (f'', argl, argr)
+    in (evd, f'', argl, argr)
   | App (f, args) ->
     let len = Array.length args in
     let fargs = Array.sub args 0 (Array.length args - 2) in
     let rel = mkApp (f, fargs) in
-    rel, args.(len - 2), args.(len - 1)
+    evd, rel, args.(len - 2), args.(len - 1)
   | _ -> error_no_relation ()
 
 let decompose_app_rel env evd t =
-  let (rel, t1, t2) = decompose_app_rel env evd t in
+  let (evd, rel, t1, t2) = decompose_app_rel env evd t in
   let ty = Retyping.get_type_of env evd rel in
   let () = if not (Reductionops.is_arity env evd ty) then error_no_relation () in
-  (rel, t1, t2)
+  (evd, rel, t1, t2)
 
 let decompose_applied_relation env sigma (c,l) =
   let open Context.Rel.Declaration in
@@ -493,7 +493,7 @@ let decompose_applied_relation env sigma (c,l) =
     let sigma, cl = Clenv.make_evar_clause env sigma ty in
     let sigma = Clenv.solve_evar_clause env sigma true cl l in
     let { Clenv.cl_holes = holes; Clenv.cl_concl = t } = cl in
-    let (equiv, c1, c2) = decompose_app_rel env sigma t in
+    let (sigma, equiv, c1, c2) = decompose_app_rel env sigma t in
     let ty1 = Retyping.get_type_of env sigma c1 in
     let ty2 = Retyping.get_type_of env sigma c2 in
     match evd_convertible env sigma ty1 ty2 with
@@ -777,7 +777,8 @@ let resolve_morphism env avoid oldt m ?(fnewt=fun x -> x) args args' (b,cstr) ev
     let morphargs, morphobjs = Array.chop first args in
     let morphargs', morphobjs' = Array.chop first args' in
     let appm = mkApp(m, morphargs) in
-    let appmtype = Typing.unsafe_type_of env (goalevars evars) appm in
+    let sigma, appmtype = Typing.type_of env (goalevars evars) appm in
+    let evars = (sigma, cstrevars evars) in
     let cstrs = List.map 
       (Option.map (fun r -> r.rew_car, get_opt_rew_rel r.rew_prf)) 
       (Array.to_list morphobjs') 
@@ -1897,7 +1898,7 @@ let build_morphism_signature env sigma m =
   let m,ctx = Constrintern.interp_constr env sigma m in
   let m = EConstr.of_constr m in
   let sigma = Evd.from_ctx ctx in
-  let t = Typing.unsafe_type_of env sigma m in
+  let sigma, t = Typing.type_of env sigma m in
   let cstrs =
     let rec aux t =
       match EConstr.kind sigma t with
@@ -1927,7 +1928,7 @@ let build_morphism_signature env sigma m =
 let default_morphism sign m =
   let env = Global.env () in
   let sigma = Evd.from_env env in
-  let t = Typing.unsafe_type_of env sigma m in
+  let sigma, t = Typing.type_of env sigma m in
   let evars, _, sign, cstrs =
     PropGlobal.build_signature (sigma, Evar.Set.empty) env t (fst sign) (snd sign)
   in
@@ -2129,7 +2130,7 @@ let setoid_proof ty fn fallback =
     Proofview.tclORELSE
       begin
         try
-          let rel, _, _ = decompose_app_rel env sigma concl in
+          let sigma, rel, _, _ = decompose_app_rel env sigma concl in
           let (sigma, t) = Typing.type_of env sigma rel in
           let car = snd (List.hd (fst (Reductionops.splay_prod env sigma t))) in
 	    (try init_relation_classes () with _ -> raise Not_found);
@@ -2144,7 +2145,7 @@ let setoid_proof ty fn fallback =
                 | Hipattern.NoEquationFound ->
 	            begin match e with
 	            | (Not_found, _) ->
-	                let rel, _, _ = decompose_app_rel env sigma concl in
+	                let sigma, rel, _, _ = decompose_app_rel env sigma concl in
 		        not_declared env sigma ty rel
 	            | (e, info) -> Proofview.tclZERO ~info e
                     end
@@ -2192,8 +2193,7 @@ let setoid_transitivity c =
 let setoid_symmetry_in id =
   let open Tacmach.New in
   Proofview.Goal.enter begin fun gl ->
-  let sigma = project gl in
-  let ctype = pf_unsafe_type_of gl (mkVar id) in
+  let sigma, ctype = pf_type_of gl (mkVar id) in
   let binders,concl = decompose_prod_assum sigma ctype in
   let (equiv, args) = decompose_app sigma concl in
   let rec split_last_two = function

--- a/pretyping/cases.ml
+++ b/pretyping/cases.ml
@@ -2125,7 +2125,7 @@ let constr_of_pat env evdref arsign pat avoid =
 	let IndType (indf, _) = 
 	  try find_rectype env ( !evdref) (lift (-(List.length realargs)) ty)
 	  with Not_found -> error_case_not_inductive env !evdref
-	    {uj_val = ty; uj_type = Typing.unsafe_type_of env !evdref ty}
+	    {uj_val = ty; uj_type = Typing.e_type_of env evdref ty}
 	in
 	let (ind,u), params = dest_ind_family indf in
 	let params = List.map EConstr.of_constr params in

--- a/pretyping/coercion.ml
+++ b/pretyping/coercion.ml
@@ -295,16 +295,18 @@ and coerce ?loc env evdref (x : EConstr.constr) (y : EConstr.constr)
 		   let evm = !evdref in
 		     (try subco ()
 		      with NoSubtacCoercion ->
-			let typ = Typing.unsafe_type_of env evm c in
-			let typ' = Typing.unsafe_type_of env evm c' in
+			let evm, typ = Typing.type_of env evm c in
+			let evm, typ' = Typing.type_of env evm c' in
+			let () = evdref := evm in
 			  coerce_application typ typ' c c' l l')
 		 else
 		   subco ()
 	   | x, y when EConstr.eq_constr !evdref c c' ->
 	       if Int.equal (Array.length l) (Array.length l') then
 		 let evm =  !evdref in
-		 let lam_type = Typing.unsafe_type_of env evm c in
-		 let lam_type' = Typing.unsafe_type_of env evm c' in
+		 let evm, lam_type = Typing.type_of env evm c in
+		 let evm, lam_type' = Typing.type_of env evm c' in
+                 let () = evdref := evm in
 		   coerce_application lam_type lam_type' c c' l l'
 	       else subco ()
 	   | _ -> subco ())

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -515,7 +515,7 @@ let pretype_ref ?loc evdref env ref us =
   | ref ->
     let evd, c = pretype_global ?loc univ_flexible env !evdref ref us in
     let () = evdref := evd in
-    let ty = unsafe_type_of env.ExtraEnv.env evd c in
+    let ty = e_type_of env.ExtraEnv.env evdref c in
       make_judge c ty
 
 let judge_of_Type ?loc evd s =

--- a/pretyping/tacred.ml
+++ b/pretyping/tacred.ml
@@ -1164,7 +1164,7 @@ let abstract_scheme env sigma (locc,a) (c, sigma) =
 let pattern_occs loccs_trm = begin fun env sigma c ->
   let abstr_trm, sigma = List.fold_right (abstract_scheme env sigma) loccs_trm (c,sigma) in
   try
-    let _ = Typing.unsafe_type_of env sigma abstr_trm in
+    let sigma, _ = Typing.type_of env sigma abstr_trm in
     (sigma, applist(abstr_trm, List.map snd loccs_trm))
   with Type_errors.TypeError (env',t) ->
     raise (ReductionTacticError (InvalidAbstraction (env,sigma,abstr_trm,(env',t))))

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -1245,7 +1245,8 @@ let applyHead env evd n c  =
       apprec (n-1) (mkApp(c,[|evar|])) (subst1 evar c2) evd'
       | _ -> user_err Pp.(str "Apply_Head_Then")
   in
-    apprec n c (Typing.unsafe_type_of env evd c) evd
+    let evd, t = Typing.type_of env evd c in
+    apprec n c t evd
 
 let is_mimick_head sigma ts f =
   match EConstr.kind sigma f with

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -129,7 +129,11 @@ let mk_clenv_from_n gls n (c,cty) =
 
 let mk_clenv_from gls = mk_clenv_from_n gls None
 
-let mk_clenv_type_of gls t = mk_clenv_from gls (t,Tacmach.New.pf_unsafe_type_of gls t)
+let mk_clenv_type_of gls c =
+  let env = Proofview.Goal.env gls in
+  let sigma = Tacmach.New.project gls in
+  let sigma, t = Typing.type_of env sigma c in
+  mk_clenv_from_env env sigma None (c, t)
 
 (******************************************************************)
 

--- a/tactics/autorewrite.ml
+++ b/tactics/autorewrite.ml
@@ -235,9 +235,9 @@ let decompose_applied_relation metas env sigma c ctype left2right =
     in
       try
 	let others,(c1,c2) = split_last_two args in
-	let ty1, ty2 =
-	  Typing.unsafe_type_of env eqclause.evd (EConstr.of_constr c1), Typing.unsafe_type_of env eqclause.evd (EConstr.of_constr c2)
-	in
+	let sigma, ty1 = Typing.type_of env eqclause.evd (EConstr.of_constr c1) in
+	let sigma, ty2 = Typing.type_of env sigma (EConstr.of_constr c2) in
+	let eqclause = { eqclause with evd = sigma } in
 	let ty = EConstr.Unsafe.to_constr ty in
 	let ty1 = EConstr.Unsafe.to_constr ty1 in
 (* 	  if not (evd_convertible env eqclause.evd ty1 ty2) then None *)
@@ -256,7 +256,7 @@ let decompose_applied_relation metas env sigma c ctype left2right =
 	| None -> None
 
 let find_applied_relation ?loc metas env sigma c left2right =
-  let ctype = Typing.unsafe_type_of env sigma (EConstr.of_constr c) in
+  let sigma, ctype = Typing.type_of env sigma (EConstr.of_constr c) in
     match decompose_applied_relation metas env sigma c ctype left2right with
     | Some c -> c
     | None ->

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -1626,11 +1626,15 @@ let is_ground c =
 
 let autoapply c i =
   let open Proofview.Notations in
+  let open Tacmach.New in
   Proofview.Goal.enter begin fun gl ->
+  let env = pf_env gl in
+  let sigma = project gl in
   let flags = auto_unif_flags Evar.Set.empty
     (Hints.Hint_db.transparent_state (Hints.searchtable_map i)) in
-  let cty = Tacmach.New.pf_unsafe_type_of gl c in
-  let ce = mk_clenv_from gl (c,cty) in
+  let sigma, cty = Typing.type_of env sigma c in
+  let ce = mk_clenv_from_env env sigma None (c,cty) in
+    Proofview.Unsafe.tclEVARS sigma <*>
     unify_e_resolve false flags gl
                                  ((c,cty,Univ.ContextSet.empty),0,ce) <*>
       Proofview.tclEVARMAP >>= (fun sigma ->

--- a/tactics/contradiction.ml
+++ b/tactics/contradiction.ml
@@ -112,8 +112,7 @@ let contradiction_term (c,lbind as cl) =
   Proofview.Goal.enter begin fun gl ->
     let sigma = Tacmach.New.project gl in
     let env = Proofview.Goal.env gl in
-    let type_of = Tacmach.New.pf_unsafe_type_of gl in
-    let typ = type_of c in
+    let sigma, typ = Typing.type_of env sigma c in
     let _, ccl = splay_prod env sigma typ in
     if is_empty_type sigma ccl then
       Tacticals.New.tclTHEN

--- a/tactics/eauto.ml
+++ b/tactics/eauto.ml
@@ -31,9 +31,11 @@ let eauto_unif_flags = auto_flags_of_state full_transparent_state
 
 let e_give_exact ?(flags=eauto_unif_flags) c =
   Proofview.Goal.enter begin fun gl ->
-  let t1 = Tacmach.New.pf_unsafe_type_of gl c in
-  let t2 = Tacmach.New.pf_concl (Proofview.Goal.assume gl) in
+  let env = Tacmach.New.pf_env gl in
   let sigma = Tacmach.New.project gl in
+  let sigma, t1 = Typing.type_of env sigma c in
+  let t2 = Tacmach.New.pf_concl (Proofview.Goal.assume gl) in
+  Proofview.Unsafe.tclEVARS sigma <*>
   if occur_existential sigma t1 || occur_existential sigma t2 then
      Tacticals.New.tclTHEN (Clenvtac.unify ~flags t1) (exact_no_check c)
   else exact_check c

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -24,7 +24,6 @@ open Smartlocate
 open Misctypes
 open Termops
 open Inductiveops
-open Typing
 open Decl_kinds
 open Pattern
 open Patternops
@@ -954,7 +953,8 @@ let make_mode ref m =
 let make_trivial env sigma poly ?(name=PathAny) r =
   let c,ctx = fresh_global_or_constr env sigma poly r in
   let sigma = Evd.merge_context_set univ_flexible sigma ctx in
-  let t = hnf_constr env sigma (unsafe_type_of env sigma c) in
+  let sigma, t = Typing.type_of env sigma c in
+  let t = hnf_constr env sigma t in
   let hd = head_constr sigma t in
   let ce = mk_clenv_from_env env sigma None (c,t) in
   (Some hd, { pri=1;

--- a/tactics/hipattern.ml
+++ b/tactics/hipattern.ml
@@ -436,26 +436,26 @@ let find_eq_data sigma eqn = (* fails with PatternMatchingFailure *)
   let hd,u = destInd sigma (fst (destApp sigma eqn)) in
     d,u,k
 
-let extract_eq_args gl = function
+let extract_eq_args env sigma = function
   | MonomorphicLeibnizEq (e1,e2) ->
-      let t = pf_unsafe_type_of gl e1 in (t,e1,e2)
+      let t = Typing.unsafe_type_of env sigma e1 in (t,e1,e2)
   | PolymorphicLeibnizEq (t,e1,e2) -> (t,e1,e2)
   | HeterogenousEq (t1,e1,t2,e2) ->
-      if pf_conv_x gl t1 t2 then (t1,e1,e2)
+      if Reductionops.is_conv env sigma t1 t2 then (t1,e1,e2)
       else raise PatternMatchingFailure
 
-let find_eq_data_decompose gl eqn =
-  let (lbeq,u,eq_args) = find_eq_data (project gl) eqn in
-  (lbeq,u,extract_eq_args gl eq_args)
+let find_eq_data_decompose env sigma eqn =
+  let (lbeq,u,eq_args) = find_eq_data sigma eqn in
+  (lbeq,u,extract_eq_args env sigma eq_args)
 
-let find_this_eq_data_decompose gl eqn =
+let find_this_eq_data_decompose env sigma eqn =
   let (lbeq,u,eq_args) =
     try (*first_match (match_eq eqn) inversible_equalities*)
-      find_eq_data (project gl) eqn
+      find_eq_data sigma eqn
     with PatternMatchingFailure ->
       user_err  (str "No primitive equality found.") in
   let eq_args =
-    try extract_eq_args gl eq_args
+    try extract_eq_args env sigma eq_args
     with PatternMatchingFailure ->
       user_err Pp.(str "Don't know what to do with JMeq on arguments not of same type.") in
   (lbeq,u,eq_args)

--- a/tactics/hipattern.mli
+++ b/tactics/hipattern.mli
@@ -120,11 +120,11 @@ val match_with_equation:
 
 (** Match terms [eq A t u], [identity A t u] or [JMeq A t A u] 
    Returns associated lemmas and [A,t,u] or fails PatternMatchingFailure *)
-val find_eq_data_decompose : 'a Proofview.Goal.t -> constr ->
+val find_eq_data_decompose : Environ.env -> evar_map -> constr ->
       coq_eq_data * EInstance.t * (types * constr * constr)
 
 (** Idem but fails with an error message instead of PatternMatchingFailure *)
-val find_this_eq_data_decompose : 'a Proofview.Goal.t -> constr ->
+val find_this_eq_data_decompose : Environ.env -> evar_map -> constr ->
       coq_eq_data * EInstance.t * (types * constr * constr)
 
 (** A variant that returns more informative structure on the equality found *)

--- a/tactics/inv.ml
+++ b/tactics/inv.ml
@@ -439,8 +439,9 @@ let raw_inversion inv_kind id status names =
     let env = Proofview.Goal.env gl in
     let concl = Proofview.Goal.concl gl in
     let c = mkVar id in
+    let sigma, t = Typing.type_of env sigma c in
     let (ind, t) =
-      try pf_apply Tacred.reduce_to_atomic_ind gl (pf_unsafe_type_of gl c)
+      try Tacred.reduce_to_atomic_ind env sigma t
       with UserError _ ->
         let msg = str "The type of " ++ Id.print id ++ str " is not inductive." in
         CErrors.user_err  msg

--- a/tactics/leminv.ml
+++ b/tactics/leminv.ml
@@ -262,7 +262,8 @@ let add_inversion_lemma_exn na com comsort bool tac =
 let lemInv id c =
   Proofview.Goal.enter begin fun gls ->
   try
-    let clause = mk_clenv_from_env (pf_env gls) (project gls) None (c, pf_unsafe_type_of gls c) in
+    let sigma, t = Typing.type_of (pf_env gls) (project gls) c in
+    let clause = mk_clenv_from_env (pf_env gls) sigma None (c, t) in
     let clause = clenv_constrain_last_binding (EConstr.mkVar id) clause in
     Clenvtac.res_pf clause ~flags:(Unification.elim_flags ()) ~with_evars:false
   with

--- a/vernac/auto_ind_decl.ml
+++ b/vernac/auto_ind_decl.ml
@@ -375,8 +375,7 @@ let do_replace_lb mode lb_scheme_key aavoid narg p q =
       )
   in
   Proofview.Goal.enter begin fun gl ->
-    let type_of_pq = Tacmach.New.pf_unsafe_type_of gl p in
-    let sigma = Tacmach.New.project gl in
+    let sigma, type_of_pq = Tacmach.New.pf_type_of gl p in
     let env = Tacmach.New.pf_env gl in
     let u,v = destruct_ind sigma type_of_pq
     in let lb_type_of_p =
@@ -395,6 +394,7 @@ let do_replace_lb mode lb_scheme_key aavoid narg p q =
           in
           Tacticals.New.tclZEROMSG err_msg
        in
+       Proofview.Unsafe.tclEVARS sigma <*>
        lb_type_of_p >>= fun (lb_type_of_p,eff) ->
        Proofview.tclEVARMAP >>= fun sigma ->
        let lb_args = Array.append (Array.append
@@ -441,8 +441,8 @@ let do_replace_bl mode bl_scheme_key (ind,u as indu) aavoid narg lft rgt =
     match (l1,l2) with
     | (t1::q1,t2::q2) ->
         Proofview.Goal.enter begin fun gl ->
-        let tt1 = Tacmach.New.pf_unsafe_type_of gl t1 in
-        let sigma = Tacmach.New.project gl in
+        let sigma, tt1 = Tacmach.New.pf_type_of gl t1 in
+        Proofview.Unsafe.tclEVARS sigma <*>
         let env = Tacmach.New.pf_env gl in
         if EConstr.eq_constr sigma t1 t2 then aux q1 q2
         else (

--- a/vernac/class.ml
+++ b/vernac/class.ml
@@ -197,9 +197,9 @@ let build_id_coercion idf_opt source poly =
   in
   (* juste pour verification *)
   let _ =
+    let sigma, t = Typing.type_of env sigma (EConstr.of_constr val_f) in
     if not
-      (Reductionops.is_conv_leq env sigma
-	(Typing.unsafe_type_of env sigma (EConstr.of_constr val_f)) (EConstr.of_constr typ_f))
+      (Reductionops.is_conv_leq env sigma t (EConstr.of_constr typ_f))
     then
       user_err  (strbrk
 	"Cannot be defined as coercion (maybe a bad number of arguments).")

--- a/vernac/command.ml
+++ b/vernac/command.ml
@@ -930,7 +930,8 @@ let build_wellfounded (recname,pl,n,bl,arityc,body) poly r measure notation =
   let binders = letbinders @ [arg] in
   let binders_env = push_rel_context binders_rel env in
   let rel, _ = interp_constr_evars_impls env evdref r in
-  let relty = Typing.unsafe_type_of env !evdref rel in
+  let sigma, relty = Typing.type_of env !evdref rel in
+  let () = evdref := sigma in
   let relargty =
     let error () =
       user_err ?loc:(constr_loc r)


### PR DESCRIPTION
This patch replaces a lot of unsafe type checks by their safe version, and it also fixes related evar leaks in the same go. I'm not sure this qualifies for 8.7 inclusion, but it can be considered as a mere bugfix somehow.