### PR TITLE
Adding a test case as requested in bug 5205.

### DIFF
--- a/test-suite/bugs/closed/5205.v
+++ b/test-suite/bugs/closed/5205.v
@@ -1,0 +1,6 @@
+Definition foo (n : nat) (m : nat) : nat := m.
+
+Arguments foo {_} _, _ _.
+
+Check foo 1 1.
+Check foo (n:=1) 1.


### PR DESCRIPTION
This test case fails in Coq < 8.6 as reported in https://coq.inria.fr/bugs/show_bug.cgi?id=5205.