### PR TITLE
"There are pending proofs" error message now lists the name of the proofs.

### DIFF
--- a/toplevel/vernac.ml
+++ b/toplevel/vernac.ml
@@ -286,7 +286,12 @@ let ensure_exists f =
 let compile verbosely f =
   let check_pending_proofs () =
     let pfs = Proof_global.get_all_proof_names () in
-    if not (List.is_empty pfs) then vernac_error (str "There are pending proofs")
+    if not (List.is_empty pfs) then
+      vernac_error (str "There are pending proofs: "
+                    ++ (pfs
+                        |> List.rev
+                        |> prlist_with_sep pr_comma Names.Id.print)
+                    ++ str ".")
   in
   match !Flags.compilation_mode with
   | BuildVo ->


### PR DESCRIPTION
This closes https://coq.inria.fr/bugs/show_bug.cgi?id=5275

Example: on

```
Lemma a1 : 1 + 1 = 2.
auto.

Lemma a2 : 1 + 2 = 3.

Lemma a3 : 1 + 3 = 4.
  auto.
Qed.
```

it yields: `There are pending proofs: a1, a2.`

There is a regression on this error message: it doesn't start with `Error: ` (normally highlighted in red in my console). But this is not this PR that introduced the problem.