### PR TITLE
Omega and romega know about context definitions (fix old bug 148)

### DIFF
--- a/API/API.mli
+++ b/API/API.mli
@@ -4631,6 +4631,7 @@ sig
     val pf_ids_set_of_hyps : 'a Proofview.Goal.t -> Names.Id.Set.t
     val pf_concl : 'a Proofview.Goal.t -> EConstr.types
     val pf_get_new_id  : Names.Id.t -> 'a Proofview.Goal.t -> Names.Id.t
+    val pf_get_hyp : Names.Id.t -> 'a Proofview.Goal.t -> EConstr.named_declaration
     val pf_get_hyp_typ : Names.Id.t -> 'a Proofview.Goal.t -> EConstr.types
     val pf_get_type_of : 'a Proofview.Goal.t -> EConstr.constr -> EConstr.types
     val pf_global : Names.Id.t -> 'a Proofview.Goal.t -> Globnames.global_reference

--- a/CHANGES
+++ b/CHANGES
@@ -15,6 +15,10 @@ Tactics
 - The tactic "omega" is now aware of the bodies of context variables
   such as "x := 5 : Z" (see bug #148). This could be disabled via
   Unset Omega UseLocalDefs.
+- The tactic "omega" is now aware of the bodies of context variables
+  such as "x := 5 : Z" (see bug #148). This could be disabled via
+  Unset Omega UseLocalDefs.
+- The tactic "romega" is also aware now of the bodies of context variables.
 
 Changes from 8.7+beta1 to 8.7.0
 ===============================

--- a/CHANGES
+++ b/CHANGES
@@ -12,6 +12,9 @@ Tactics
   utility. The command "Set NativeCompute Profiling" enables
   profiling, and "Set NativeCompute Profile Filename" customizes
   the profile filename.
+- The tactic "omega" is now aware of the bodies of context variables
+  such as "x := 5 : Z" (see bug #148). This could be disabled via
+  Unset Omega UseLocalDefs.
 
 Changes from 8.7+beta1 to 8.7.0
 ===============================

--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -127,5 +127,5 @@
 ########################################################################
 # Bignums
 ########################################################################
-: ${bignums_CI_BRANCH:=fix-thunk-printer}
-: ${bignums_CI_GITURL:=https://github.com/ppedrot/bignums.git}
+: ${bignums_CI_BRANCH:=master}
+: ${bignums_CI_GITURL:=https://github.com/coq/bignums}

--- a/plugins/omega/coq_omega.ml
+++ b/plugins/omega/coq_omega.ml
@@ -50,6 +50,7 @@ let display_time_flag = ref false
 let display_system_flag = ref false
 let display_action_flag = ref false
 let old_style_flag = ref false
+let letin_flag = ref true
 
 (* Should we reset all variable labels between two runs of omega ? *)
 
@@ -99,6 +100,14 @@ let _ =
       optkey   = ["Stable";"Omega"];
       optread  = read reset_flag;
       optwrite = write reset_flag }
+
+let _ =
+  declare_bool_option
+    { optdepr  = false;
+      optname  = "Omega takes advantage of context variables with body";
+      optkey   = ["Omega";"UseLocalDefs"];
+      optread  = read letin_flag;
+      optwrite = write letin_flag }
 
 let intref, reset_all_references =
   let refs = ref [] in
@@ -376,16 +385,15 @@ let mk_var v = mkVar (Id.of_string v)
 let mk_plus t1 t2 = mkApp (Lazy.force coq_Zplus, [| t1; t2 |])
 let mk_times t1 t2 = mkApp (Lazy.force coq_Zmult, [| t1; t2 |])
 let mk_minus t1 t2 = mkApp (Lazy.force coq_Zminus, [| t1;t2 |])
-let mk_eq t1 t2 = mkApp (Lazy.force coq_eq,
-			 [| Lazy.force coq_Z; t1; t2 |])
+let mk_gen_eq ty t1 t2 = mkApp (Lazy.force coq_eq, [| ty; t1; t2 |])
+let mk_eq t1 t2 = mk_gen_eq (Lazy.force coq_Z) t1 t2
 let mk_le t1 t2 = mkApp (Lazy.force coq_Zle, [| t1; t2 |])
 let mk_gt t1 t2 = mkApp (Lazy.force coq_Zgt, [| t1; t2 |])
 let mk_inv t = mkApp (Lazy.force coq_Zopp, [| t |])
 let mk_and t1 t2 =  mkApp (Lazy.force coq_and, [| t1; t2 |])
 let mk_or t1 t2 =  mkApp (Lazy.force coq_or, [| t1; t2 |])
 let mk_not t = mkApp (Lazy.force coq_not, [| t |])
-let mk_eq_rel t1 t2 = mkApp (Lazy.force coq_eq,
-			     [| Lazy.force coq_comparison; t1; t2 |])
+let mk_eq_rel t1 t2 = mk_gen_eq (Lazy.force coq_comparison) t1 t2
 let mk_inj t = mkApp (Lazy.force coq_Z_of_nat, [| t |])
 
 let mk_integer n =
@@ -1778,11 +1786,25 @@ let destructure_hyps =
   let type_of = Tacmach.New.pf_unsafe_type_of gl in
   let decidability = decidability gl in
   let pf_nf = pf_nf gl in
-    let rec loop = function
-      | [] -> (tclTHEN nat_inject coq_omega)
-      | decl::lit ->
-          let i = NamedDecl.get_id decl in
-          Proofview.tclEVARMAP >>= fun sigma ->
+  let rec loop = function
+    | [] -> (tclTHEN nat_inject coq_omega)
+    | LocalDef (i,body,typ) :: lit when !letin_flag ->
+       Proofview.tclEVARMAP >>= fun sigma ->
+       begin
+         try
+           match destructurate_type sigma (pf_nf typ) with
+           | Kapp(Nat,_) | Kapp(Z,_) ->
+              let hid = fresh_id Id.Set.empty (add_suffix i "_eqn") gl in
+              let hty = mk_gen_eq typ (mkVar i) body in
+              tclTHEN
+                (assert_by (Name hid) hty reflexivity)
+                (loop (LocalAssum (hid, hty) :: lit))
+           | _ -> loop lit
+         with e when catchable_exception e -> loop lit
+       end
+    | decl :: lit -> (* variable without body (or !letin_flag isn't set) *)
+       let i = NamedDecl.get_id decl in
+       Proofview.tclEVARMAP >>= fun sigma ->
 	  begin try match destructurate_prop sigma (NamedDecl.get_type decl) with
 	  | Kapp(False,[]) -> elim_id i
           | Kapp((Zle|Zge|Zgt|Zlt|Zne),[t1;t2]) -> loop lit

--- a/plugins/romega/const_omega.ml
+++ b/plugins/romega/const_omega.ml
@@ -221,6 +221,7 @@ let mk_N = function
 
 module type Int = sig
   val typ : Term.constr Lazy.t
+  val is_int_typ : [ `NF ] Proofview.Goal.t -> Term.constr -> bool
   val plus : Term.constr Lazy.t
   val mult : Term.constr Lazy.t
   val opp : Term.constr Lazy.t
@@ -287,12 +288,14 @@ let pf_nf gl c =
   EConstr.Unsafe.to_constr
     (Tacmach.New.pf_apply Tacred.simpl gl (EConstr.of_constr c))
 
+let is_int_typ gl t =
+  match destructurate (pf_nf gl t) with
+  | Kapp("Z",[]) -> true
+  | _ -> false
+
 let parse_rel gl t =
   match destructurate t with
-  | Kapp("eq",[typ;t1;t2]) ->
-     (match destructurate (pf_nf gl typ) with
-      | Kapp("Z",[]) -> Req (t1,t2)
-      | _ -> Rother)
+  | Kapp("eq",[typ;t1;t2]) when is_int_typ gl typ -> Req (t1,t2)
   | Kapp("Zne",[t1;t2]) -> Rne (t1,t2)
   | Kapp("Z.le",[t1;t2]) -> Rle (t1,t2)
   | Kapp("Z.lt",[t1;t2]) -> Rlt (t1,t2)

--- a/plugins/romega/const_omega.mli
+++ b/plugins/romega/const_omega.mli
@@ -103,6 +103,8 @@ module type Int =
   sig
     (* the coq type of the numbers *)
     val typ : Term.constr Lazy.t
+    (* Is a constr expands to the type of these numbers *)
+    val is_int_typ : [ `NF ] Proofview.Goal.t -> Term.constr -> bool
     (* the operations on the numbers *)
     val plus : Term.constr Lazy.t
     val mult : Term.constr Lazy.t

--- a/test-suite/bugs/closed/148.v
+++ b/test-suite/bugs/closed/148.v
@@ -1,0 +1,26 @@
+(** Omega is now aware of the bodies of context variables
+    (of type Z or nat). *)
+
+Require Import ZArith Omega.
+Open Scope Z.
+
+Goal let x := 3 in x = 3.
+intros.
+omega.
+Qed.
+
+Open Scope nat.
+
+Goal let x := 2 in x = 2.
+intros.
+omega.
+Qed.
+
+(** NB: this could be disabled for compatibility reasons *)
+
+Unset Omega UseLocalDefs.
+
+Goal let x := 4 in x = 4.
+intros.
+Fail omega.
+Abort.

--- a/test-suite/success/ROmega4.v
+++ b/test-suite/success/ROmega4.v
@@ -1,0 +1,26 @@
+(** ROmega is now aware of the bodies of context variables
+    (of type Z or nat).
+    See also #148 for the corresponding improvement in Omega.
+*)
+
+Require Import ZArith ROmega.
+Open Scope Z.
+
+Goal let x := 3 in x = 3.
+intros.
+romega.
+Qed.
+
+(** Example seen in #4132
+    (actually solvable even if b isn't known to be 5) *)
+
+Lemma foo
+  (x y x' zxy zxy' z : Z)
+  (b := 5)
+  (Ry : - b <= y < b)
+  (Bx : x' <= b)
+  (H : - zxy' <= zxy)
+  (H' : zxy' <= x') : - b <= zxy.
+Proof.
+romega.
+Qed.

--- a/theories/Compat/Coq87.v
+++ b/theories/Compat/Coq87.v
@@ -7,3 +7,11 @@
 (************************************************************************)
 
 (** Compatibility file for making Coq act similar to Coq v8.7 *)
+
+(* In 8.7, omega wasn't taking advantage of local abbreviations,
+   see bug 148 and PR#768. For adjusting this flag, we're forced to
+   first dynlink the omega plugin, but we should avoid doing a full
+   "Require Omega", since it has some undesired effects (at least on hints)
+   and breaks at least fiat-crypto. *)
+Declare ML Module "omega_plugin".
+Unset Omega UseLocalDefs.


### PR DESCRIPTION
When a context variable x is of the form `x := body : Z`, omega and romega are now made aware of this body. Technically, we push an equation `x = body` (either reified or not). For omega, this also works if `x` has type `nat`.

For compatibility, this extra feature of omega could be disabled via `Unset Omega UseLocalDefs`.
    
Caveat : for now, real let-ins deep inside goals or hyps aren't handled, use some "cbv zeta" reduction if you want to get rid of them. And context definitions whose types aren't Z or nat are ignored, some manual "unfold"  are still mandatory if expanding these definitions will help omega.