### PR TITLE
[lib] Remove obsolete state-management function add_frozen_state

### DIFF
--- a/API/API.mli
+++ b/API/API.mli
@@ -2634,7 +2634,6 @@ module Lib : sig
             | ClosedModule  of library_segment
             | OpenedSection of Libnames.object_prefix * Summary.frozen
             | ClosedSection of library_segment
-            | FrozenState of Summary.frozen
 
    and library_segment = (Libnames.object_name * node) list
 

--- a/library/declaremods.ml
+++ b/library/declaremods.ml
@@ -589,7 +589,6 @@ let start_module interp_modast export id args res fs =
   openmod_info := { cur_typ = res_entry_o; cur_typs = subtyps };
   let prefix = Lib.start_module export id mp fs in
   Nametab.push_dir (Nametab.Until 1) (fst prefix) (DirOpenModule prefix);
-  Lib.add_frozen_state ();
   if_xml (Hook.get f_xml_start_module) mp;
   mp
 
@@ -629,7 +628,6 @@ let end_module () =
   assert (eq_full_path (fst newoname) (fst oldoname));
   assert (ModPath.equal (mp_of_kn (snd newoname)) mp);
 
-  Lib.add_frozen_state () (* to prevent recaching *);
   if_xml (Hook.get f_xml_end_module) mp;
   mp
 
@@ -701,7 +699,6 @@ let start_modtype interp_modast id args mtys fs =
   openmodtype_info := sub_mty_l;
   let prefix = Lib.start_modtype id mp fs in
   Nametab.push_dir (Nametab.Until 1) (fst prefix) (DirOpenModtype prefix);
-  Lib.add_frozen_state ();
   if_xml (Hook.get f_xml_start_module_type) mp;
   mp
 
@@ -719,7 +716,6 @@ let end_modtype () =
   assert (eq_full_path (fst oname) (fst oldoname));
   assert (ModPath.equal (mp_of_kn (snd oname)) mp);
 
-  Lib.add_frozen_state ()(* to prevent recaching *);
   if_xml (Hook.get f_xml_end_module_type) mp;
   mp
 
@@ -894,8 +890,7 @@ let get_library_native_symbols dir =
 let start_library dir =
   let mp = Global.start_library dir in
   openmod_info := default_module_info;
-  Lib.start_compilation dir mp;
-  Lib.add_frozen_state ()
+  Lib.start_compilation dir mp
 
 let end_library_hook = ref ignore
 let append_end_library_hook f =

--- a/library/lib.mli
+++ b/library/lib.mli
@@ -23,7 +23,6 @@ type node =
   | ClosedModule  of library_segment
   | OpenedSection of Libnames.object_prefix * Summary.frozen
   | ClosedSection of library_segment
-  | FrozenState of Summary.frozen
 
 and library_segment = (Libnames.object_name * node) list
 
@@ -60,8 +59,6 @@ val pull_to_head : Libnames.object_name -> unit
 (** this operation adds all objects with the same name and calls [load_object]
    for each of them *)
 val add_leaves : Names.Id.t -> Libobject.obj list -> Libnames.object_name
-
-val add_frozen_state : unit -> unit
 
 (** {6 ... } *)
 
@@ -122,8 +119,6 @@ val end_modtype :
   unit ->
   Libnames.object_name * Libnames.object_prefix *
     Summary.frozen * library_segment
-
-(** [Lib.add_frozen_state] must be called after each of the above functions *)
 
 (** {6 Compilation units } *)
 

--- a/library/library.ml
+++ b/library/library.ml
@@ -575,7 +575,7 @@ let require_library_from_dirpath modrefl export =
     else
       add_anonymous_leaf (in_require (needed,modrefl,export));
     if !Flags.xml_export then List.iter (Hook.get f_xml_require) modrefl;
-  add_frozen_state ()
+  ()
 
 (* the function called by Vernacentries.vernac_import *)
 

--- a/printing/prettyp.ml
+++ b/printing/prettyp.ml
@@ -587,8 +587,6 @@ let gallina_print_library_entry with_values ent =
 	Some (str " >>>>>>> Module " ++ pr_name oname)
     | (oname,Lib.ClosedModule _) ->
         Some (str " >>>>>>> Closed Module " ++ pr_name oname)
-    | (_,Lib.FrozenState _) ->
-	None
 
 let gallina_print_context with_values =
   let rec prec n = function

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -639,8 +639,7 @@ let vernac_constraint loc poly l =
 (* Modules            *)
 
 let vernac_import export refl =
-  Library.import_module export (List.map qualid_of_reference refl);
-  Lib.add_frozen_state ()
+  Library.import_module export (List.map qualid_of_reference refl)
 
 let vernac_declare_module export (loc, id) binders_ast mty_ast =
   (* We check the state of the system (in section, in module type)


### PR DESCRIPTION
AFAICS this function predates modern state-handling; nowadays
summaries are stored by the STM and nobody were using this
information.