### PR TITLE
[ide] Add route_id parameter to query call.

### DIFF
--- a/API/API.mli
+++ b/API/API.mli
@@ -2266,10 +2266,9 @@ sig
                    | VtQed of vernac_qed_type
                    | VtProofStep of proof_step
                    | VtProofMode of string
-                   | VtQuery of vernac_part_of_script * report_with
+                   | VtQuery of vernac_part_of_script * Feedback.route_id
                    | VtStm of vernac_control * vernac_part_of_script
                    | VtUnknown
-   and report_with = Stateid.t * Feedback.route_id
    and vernac_qed_type = Vernacexpr.vernac_qed_type =
                        | VtKeep
                          | VtKeepAsAxiom

--- a/CHANGES
+++ b/CHANGES
@@ -94,6 +94,12 @@ Build Infrastructure
   access to the same .cmi files. In short, use "make -j && make -j byte"
   instead of "make -j world byte".
 
+XML Protocol
+
+- The `query` call has been modified, now it carries a mandatory
+  "route_id" integer parameter, that associated the result of such
+  query with its generated feedback.
+
 Changes from V8.6beta1 to V8.6
 ==============================
 

--- a/dev/doc/changes.txt
+++ b/dev/doc/changes.txt
@@ -288,6 +288,10 @@ document type". This allows for a more uniform handling of printing
 
 - The legacy `Interp` call has been turned into a noop.
 
+- The `query` call has been modified, now it carries a mandatory
+  "route_id" integer parameter, that associated the result of such
+  query with its generated feedback.
+
 =========================================
 = CHANGES BETWEEN COQ V8.5 AND COQ V8.6 =
 =========================================

--- a/dev/doc/xml-protocol.md
+++ b/dev/doc/xml-protocol.md
@@ -308,14 +308,19 @@ CoqIDE typically sets `force` to `false`.
 
 -------------------------------
 
+### <a name="command-query">**Query(route_id: integer, query: string, stateId: integer)**</a>
 
-### <a name="command-query">**Query(query: string, stateId: integer)**</a>
-In practice, `stateId` is 0, but the effect is to perform the query on the currently-focused state.
+`routeId` can be used to distinguish the result of a particular query,
+`stateId` should be set to the state the query should be run.
+
 ```html
 <call val="Query">
   <pair>
+    <route_id val="${routeId}"/>
+  <pair>
     <string>${query}</string>
     <state_id val="${stateId}"/>
+  </pair>
   </pair>
 </call>
 ```

--- a/ide/coqOps.ml
+++ b/ide/coqOps.ml
@@ -373,7 +373,8 @@ object(self)
       else messages#add s;
     in
     let query =
-      Coq.query (phrase,sid) in
+      let route_id = 0 in
+      Coq.query (route_id,(phrase,sid)) in
     let next = function
     | Fail (_, _, err) -> display_error err; Coq.return ()
     | Good msg -> Coq.return ()
@@ -841,15 +842,14 @@ object(self)
     in
     let try_phrase phrase stop more =
       let action = log "Sending to coq now" in
-      let query = Coq.query (phrase,Stateid.dummy) in
+      let route_id = 0 in
+      let query = Coq.query (route_id,(phrase,Stateid.dummy)) in
       let next = function
       | Fail (_, l, str) -> (* FIXME: check *)
         display_error (l, str);
         messages#add (Pp.str ("Unsuccessfully tried: "^phrase));
         more
-      | Good msg ->
-        messages#add_string msg;
-        stop Tags.Script.processed
+      | Good () -> stop Tags.Script.processed
       in
       Coq.bind (Coq.seq action query) next
     in

--- a/ide/ide_slave.ml
+++ b/ide/ide_slave.ml
@@ -109,9 +109,9 @@ let edit_at id =
  * as not to break the core protocol for this minor change, but it should
  * be removed in the next version of the protocol.
  *)
-let query (s,id) =
+let query (route, (s,id)) =
   let pa = Pcoq.Gram.parsable (Stream.of_string s) in
-  Stm.query ~at:id pa; ""
+  Stm.query ~at:id ~route pa
 
 let annotate phrase =
   let (loc, ast) =

--- a/ide/interface.mli
+++ b/ide/interface.mli
@@ -112,6 +112,7 @@ type coq_info = {
 
 type location = (int * int) option (* start and end of the error *)
 type state_id = Stateid.t
+type route_id = Feedback.route_id
 
 (* Obsolete *)
 type edit_id  = int
@@ -154,8 +155,8 @@ type edit_at_rty = (unit, state_id * (state_id * state_id)) union
     has been deprecated in favor of sending the query answers as
     feedback. It will be removed in a future version of the protocol.
 *)
-type query_sty = string * state_id
-type query_rty = string
+type query_sty = route_id * (string * state_id)
+type query_rty = unit
 
 (** Fetching the list of current goals. Return [None] if no proof is in
     progress, [Some gl] otherwise. *)

--- a/intf/vernacexpr.ml
+++ b/intf/vernacexpr.ml
@@ -495,10 +495,9 @@ type vernac_type =
   | VtQed of vernac_qed_type
   | VtProofStep of proof_step
   | VtProofMode of string
-  | VtQuery of vernac_part_of_script * report_with
+  | VtQuery of vernac_part_of_script * Feedback.route_id
   | VtStm of vernac_control * vernac_part_of_script
   | VtUnknown
-and report_with = Stateid.t * Feedback.route_id (* feedback on id/route *)
 and vernac_qed_type = VtKeep | VtKeepAsAxiom | VtDrop (* Qed/Admitted, Abort *)
 and vernac_start = string * opacity_guarantee * Id.t list
 and vernac_sideff_type = Id.t list

--- a/stm/stm.mli
+++ b/stm/stm.mli
@@ -34,7 +34,7 @@ val add : ontop:Stateid.t -> ?newtip:Stateid.t ->
    throwing away side effects except messages. Feedback will
    be sent with [report_with], which defaults to the dummy state id *)
 val query :
-  at:Stateid.t -> ?report_with:(Stateid.t * Feedback.route_id) -> Pcoq.Gram.coq_parsable -> unit
+  at:Stateid.t -> route:Feedback.route_id -> Pcoq.Gram.coq_parsable -> unit
 
 (* [edit_at id] is issued to change the editing zone.  [`NewTip] is returned if
    the requested id is the new document tip hence the document portion following

--- a/stm/vernac_classifier.ml
+++ b/stm/vernac_classifier.ml
@@ -30,9 +30,7 @@ let string_of_vernac_type = function
       "ProofStep " ^ string_of_parallel parallel ^
         Option.default "" proof_block_detection
   | VtProofMode s -> "ProofMode " ^ s
-  | VtQuery (b,(id,route)) ->
-      "Query " ^ string_of_in_script b ^ " report " ^ Stateid.to_string id ^
-      " route " ^ string_of_int route
+  | VtQuery (b, route) -> "Query " ^ string_of_in_script b ^ " route " ^ string_of_int route
   | VtStm ((VtJoinDocument|VtWait), b) -> "Stm " ^ string_of_in_script b
   | VtStm (VtBack _, b) -> "Stm Back " ^ string_of_in_script b
 
@@ -92,8 +90,7 @@ let rec classify_vernac e =
     | VernacEndProof _ | VernacExactProof _ -> VtQed VtKeep, VtLater
     (* Query *)
     | VernacShow _ | VernacPrint _ | VernacSearch _ | VernacLocate _
-    | VernacCheckMayEval _ ->
-        VtQuery (true,(Stateid.dummy,Feedback.default_route)), VtLater
+    | VernacCheckMayEval _ -> VtQuery (true,Feedback.default_route), VtLater
     (* ProofStep *)
     | VernacProof _ 
     | VernacFocus _ | VernacUnfocus
@@ -213,7 +210,6 @@ let rec classify_vernac e =
       make_polymorphic res
     else res
 
-let classify_as_query =
-  VtQuery (true,(Stateid.dummy,Feedback.default_route)), VtLater
+let classify_as_query = VtQuery (true,Feedback.default_route), VtLater
 let classify_as_sideeff = VtSideff [], VtLater
 let classify_as_proofstep = VtProofStep { parallel = `No; proof_block_detection = None}, VtLater

--- a/tools/fake_ide.ml
+++ b/tools/fake_ide.ml
@@ -247,16 +247,16 @@ let eval_print l coq =
       let to_id, need_unfocus = get_id id in
       after_edit_at (to_id, need_unfocus) (base_eval_call (edit_at to_id) coq)
   | [ Tok(_,"QUERY"); Top []; Tok(_,phrase) ] ->
-      eval_call (query (phrase,tip_id())) coq
+      eval_call (query (0,(phrase,tip_id()))) coq
   | [ Tok(_,"QUERY"); Top [Tok(_,id)]; Tok(_,phrase) ] ->
       let to_id, _ = get_id id in
-      eval_call (query (phrase, to_id)) coq
+      eval_call (query (0,(phrase, to_id))) coq
   | [ Tok(_,"WAIT") ] ->
       let phrase = "Stm Wait." in
-      eval_call (query (phrase,tip_id())) coq
+      eval_call (query (0,(phrase,tip_id()))) coq
   | [ Tok(_,"JOIN") ] ->
       let phrase = "Stm JoinDocument." in
-      eval_call (query (phrase,tip_id())) coq
+      eval_call (query (0,(phrase,tip_id()))) coq
   | [ Tok(_,"ASSERT"); Tok(_,"TIP"); Tok(_,id) ] ->
       let to_id, _ = get_id id in
       if not(Stateid.equal (Document.tip doc) to_id) then error "Wrong tip"


### PR DESCRIPTION
This is necessary in order for clients to identify the results of
queries. This is a minor breaking change of the protocol, affecting
only this particular call.

This change is necessary in order to fix bug 5417.