### PR TITLE
Remove the Existential command.

### DIFF
--- a/API/API.mli
+++ b/API/API.mli
@@ -2416,7 +2416,6 @@ sig
   | VernacDeclareModuleType of lident *
       module_binder list * module_ast_inl list * module_ast_inl list
   | VernacInclude of module_ast_inl list
-  | VernacSolveExistential of int * Constrexpr.constr_expr
   | VernacAddLoadPath of bool * string * Names.DirPath.t option
   | VernacRemoveLoadPath of string
   | VernacAddMLPath of bool * string

--- a/doc/refman/RefMan-pro.tex
+++ b/doc/refman/RefMan-pro.tex
@@ -241,22 +241,6 @@ proof was edited.
 
 \end{Variants}
 
-%%%%
-\subsection[\tt Existential {\num} := {\term}.]{\tt Existential  {\num} := {\term}.\comindex{Existential}
-\label{Existential}}
-
-This command instantiates an existential variable. {\tt \num}
-is an index in the list of uninstantiated existential variables
-displayed by {\tt Show Existentials} (described in Section~\ref{Show}).
-
-This command is intended to be used to instantiate existential
-variables when the proof is completed but some uninstantiated
-existential variables remain. To instantiate existential variables
-during proof edition, you should use the tactic {\tt instantiate}.
-
-\SeeAlso {\tt instantiate (\num:= \term).} in Section~\ref{instantiate}.
-\SeeAlso {\tt Grab Existential Variables.} below.
-
 \subsection[\tt Grab Existential Variables.]{\tt Grab Existential Variables.\comindex{Grab Existential Variables}
 \label{GrabEvars}}
 

--- a/intf/vernacexpr.ml
+++ b/intf/vernacexpr.ml
@@ -383,10 +383,6 @@ type vernac_expr =
       module_binder list * module_ast_inl list * module_ast_inl list
   | VernacInclude of module_ast_inl list
 
-  (* Solving *)
-
-  | VernacSolveExistential of int * constr_expr
-
   (* Auxiliary file and library management *)
   | VernacAddLoadPath of rec_flag * string * DirPath.t option
   | VernacRemoveLoadPath of string

--- a/parsing/g_proofs.ml4
+++ b/parsing/g_proofs.ml4
@@ -42,8 +42,6 @@ GEXTEND Gram
       | IDENT "Abort" -> VernacAbort None
       | IDENT "Abort"; IDENT "All" -> VernacAbortAll
       | IDENT "Abort"; id = identref -> VernacAbort (Some id)
-      | IDENT "Existential"; n = natural; c = constr_body ->
-	  VernacSolveExistential (n,c)
       | IDENT "Admitted" -> VernacEndProof Admitted
       | IDENT "Qed" -> VernacEndProof (Proved (Opaque None,None))
       | IDENT "Qed"; IDENT "exporting"; l = LIST0 identref SEP "," ->

--- a/printing/ppvernac.ml
+++ b/printing/ppvernac.ml
@@ -932,9 +932,6 @@ open Decl_kinds
           hov 2 (keyword "Include" ++ spc() ++
                    prlist_with_sep (fun () -> str " <+ ") pr_m mexprs)
         )
-      (* Solving *)
-      | VernacSolveExistential (i,c) ->
-        return (keyword "Existential" ++ spc () ++ int i ++ pr_lconstrarg c)
 
       (* Auxiliary file and library management *)
       | VernacAddLoadPath (fl,s,d) ->

--- a/proofs/pfedit.ml
+++ b/proofs/pfedit.ml
@@ -122,9 +122,6 @@ let solve ?with_end_tac gi info_lvl tac pr =
 
 let by tac = Proof_global.with_current_proof (fun _ -> solve (Vernacexpr.SelectNth 1) None tac)
 
-let instantiate_nth_evar_com n com = 
-  Proof_global.simple_with_current_proof (fun _ p -> Proof.V82.instantiate_evar n com p)
-
 
 (**********************************************************************)
 (* Shortcut to build a term using tactics *)

--- a/proofs/pfedit.mli
+++ b/proofs/pfedit.mli
@@ -83,13 +83,6 @@ val solve : ?with_end_tac:unit Proofview.tactic ->
 
 val by : unit Proofview.tactic -> bool
 
-(** [instantiate_nth_evar_com n c] instantiate the [n]th undefined
-   existential variable of the current focused proof by [c] or raises a
-   UserError if no proof is focused or if there is no such [n]th
-   existential variable *)
-
-val instantiate_nth_evar_com : int -> Constrexpr.constr_expr -> unit
-
 (** [build_by_tactic typ tac] returns a term of type [typ] by calling
     [tac]. The return boolean, if [false] indicates the use of an unsafe
     tactic. *)

--- a/proofs/proof.ml
+++ b/proofs/proof.ml
@@ -410,34 +410,4 @@ module V82 = struct
       raise UnfinishedProof
     else
       { p with proofview = Proofview.V82.grab p.proofview }
-
-
-  (* Main component of vernac command Existential *)
-  let instantiate_evar n com pr =
-    let tac =
-      Proofview.tclBIND Proofview.tclEVARMAP begin fun sigma ->
-      let (evk, evi) =
-        let evl = Evarutil.non_instantiated sigma in
-        let evl = Evar.Map.bindings evl in
-        if (n <= 0) then
-          CErrors.user_err Pp.(str "incorrect existential variable index")
-        else if CList.length evl < n then
-          CErrors.user_err Pp.(str "not so many uninstantiated existential variables")
-        else
-          CList.nth evl (n-1)
-      in
-      let env = Evd.evar_filtered_env evi in
-      let rawc = Constrintern.intern_constr env com in
-      let ltac_vars = Glob_ops.empty_lvar in
-      let sigma = Evar_refiner.w_refine (evk, evi) (ltac_vars, rawc) sigma in
-      Proofview.Unsafe.tclEVARS sigma
-    end in
-    let ((), proofview, _, _) = Proofview.apply (Global.env ()) tac pr.proofview in
-    let shelf =
-      List.filter begin fun g ->
-        Evd.is_undefined (Proofview.return proofview) g
-      end pr.shelf
-    in
-    { pr with proofview ; shelf }
-
 end

--- a/proofs/proof.mli
+++ b/proofs/proof.mli
@@ -200,6 +200,4 @@ module V82 : sig
      Raises [UnfinishedProof] if there are still unsolved goals. *)
   val grab_evars : proof -> proof
 
-  (* Implements the Existential command *)
-  val instantiate_evar : int -> Constrexpr.constr_expr -> proof -> proof
 end

--- a/stm/vernac_classifier.ml
+++ b/stm/vernac_classifier.ml
@@ -100,8 +100,6 @@ let rec classify_vernac e =
     | VernacSubproof _
     | VernacCheckGuard
     | VernacUnfocused
-    | VernacSolveExistential _ ->
-        VtProofStep { parallel = `No; proof_block_detection = None }, VtLater
     | VernacBullet _ ->
         VtProofStep { parallel = `No; proof_block_detection = Some "bullet" },
         VtLater

--- a/test-suite/success/apply.v
+++ b/test-suite/success/apply.v
@@ -393,10 +393,10 @@ Qed.
    the subsequent "assumption" failed. *)
 
 Goal exists f:nat->nat, forall x y, x = y -> f x = f y.
-intros; eexists; intros.
+intros; eexists ?[f]; intros.
 simple eapply (@f_equal nat).
 assumption.
-Existential 1 := fun x => x.
+[f]: exact (fun x => x). (* Adapted after the removal of Existential *)
 Qed.
 
 (* The following worked in 8.2 but was not accepted from r12229 to
@@ -405,9 +405,9 @@ Qed.
    assumption. *)
 
 Goal exists f:nat->nat, forall x y, x = y -> f x = f y.
-intros; eexists; intros.
+intros; eexists ?[f]; intros.
 eauto.
-Existential 1 := fun x => x.
+[f]: exact (fun x => x). (* Adapted after the removal of Existential *)
 Qed.
 
 (* The following was accepted before r12612 but is still not accepted in r12658

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -844,8 +844,6 @@ let focus_command_cond = Proof.no_cond command_focus
      there are no more goals to solve. It cannot be a tactic since
      all tactics fail if there are no further goals to prove. *)
 
-let vernac_solve_existential = Pfedit.instantiate_nth_evar_com
-
 let vernac_set_end_tac tac =
   let env = Genintern.empty_glob_sign (Global.env ()) in
   let _, tac = Genintern.generic_intern env tac in
@@ -1982,9 +1980,6 @@ let interp ?proof ?loc locality poly c =
   | VernacContext sup -> vernac_context poly sup
   | VernacDeclareInstances insts -> vernac_declare_instances locality insts
   | VernacDeclareClass id -> vernac_declare_class id
-
-  (* Solving *)
-  | VernacSolveExistential (n,c) -> vernac_solve_existential n c
 
   (* Auxiliary file and library management *)
   | VernacAddLoadPath (isrec,s,alias) -> vernac_add_loadpath isrec s alias


### PR DESCRIPTION
My experiments show that this command isn't used in any development we test on Travis.
There are alternatives:
- bad alternative (but can be useful in the middle of a proof): `Grab Existential Variables`
- good alternative: use a named evar and a named-goal selector: `[e]: exact foo`
If this is approved (for 8.8), I'll make a PR on 8.7 to add a deprecation notice and information about the alternatives.