### PR TITLE
Refine test for unresolved evars to be less sensitive to unification …

### DIFF
--- a/doc/refman/RefMan-tac.tex
+++ b/doc/refman/RefMan-tac.tex
@@ -313,10 +313,16 @@ Section~\ref{pattern} to transform the goal so that it gets the form
 \item \errindex{Unable to find an instance for the variables
 {\ident} \dots\ {\ident}}
 
-  This occurs when some instantiations of the premises of {\term} are not
-  deducible from the unification. This is the case, for instance, when
-  you want to apply a transitivity property. In this case, you have to
-  use one of the variants below:
+This occurs when some instantiations of the dependent premises of
+{\term} are not deducible from the unification. If a dependent premise
+of the lemma is instantiated by a pre-existing existential variable, or
+a pre-existing existential variable is instantiated by a dependent
+premise variable, it is not considered missing, and the remaining
+undefined existential will remain in the subgoals or on the shelf.
+
+The error will happen, for instance, when you want to apply a
+transitivity property. In this case, you have to use one of the
+variants below:
 
 \end{ErrMsgs}
 

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -663,6 +663,24 @@ let rec advance sigma evk =
       else
         None
 
+let reachable_from_evars current_sigma evars evk =
+  let rec search evk' visited =
+    if Evar.Set.mem evk' visited then visited
+    else
+      let visited = Evar.Set.add evk' visited in
+      match Evd.evar_body (Evd.find current_sigma evk') with
+      | Evd.Evar_empty -> visited
+      | Evd.Evar_defined c ->
+         match Term.kind_of_term c with
+         | Term.Evar (evk',l) -> if Evar.equal evk' evk then raise Exit
+                                else search evk' visited
+         | _ -> visited
+  in
+  try
+    let _ = Evar.Set.fold (fun evk' visited -> search evk' visited) evars Evar.Set.empty in
+    false
+  with Exit -> true
+
 (** The following functions return the set of undefined evars
     contained in the object, the defined evars being traversed.
     This is roughly a combination of the previous functions and

--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -117,6 +117,10 @@ val gather_dependent_evars : evar_map -> evar list -> (Evar.Set.t option) Evar.M
     solved. *)
 val advance : evar_map -> evar -> evar option
 
+(** [reachable_from_evars sigma seeds ev] computes if [ev] is a descendent
+    of an evar of [seeds] by restriction or evar-evar unifications in [sigma]. *)
+val reachable_from_evars : evar_map -> Evar.Set.t -> existential_key -> bool
+
 (** The following functions return the set of undefined evars
     contained in the object, the defined evars being traversed.
     This is roughly a combination of the previous functions and

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -330,10 +330,11 @@ let check_typeclasses_instances_are_solved env current_sigma frozen =
 
 let check_extra_evars_are_solved env current_sigma frozen = match frozen with
 | FrozenId _ -> ()
-| FrozenProgress (lazy (_, pending)) ->
+| FrozenProgress (lazy (frozen, pending)) ->
   Evar.Set.iter
     (fun evk ->
-      if not (Evd.is_defined current_sigma evk) then
+      if not (Evd.is_defined current_sigma evk)
+       && not (Evarutil.reachable_from_evars current_sigma frozen evk) then
         let (loc,k) = evar_source evk current_sigma in
 	match k with
 	| Evar_kinds.ImplicitArg (gr, (i, id), false) -> ()

--- a/tactics/tacticals.ml
+++ b/tactics/tacticals.ml
@@ -467,6 +467,7 @@ module New = struct
   (* Check that holes in arguments have been resolved *)
 
   let check_evars env sigma extsigma origsigma =
+    let origevars = Evar.Map.domain (Evd.undefined_map origsigma) in
     let rec is_undefined_up_to_restriction sigma evk =
       if Evd.mem origsigma evk then None else
       let evi = Evd.find sigma evk in
@@ -482,7 +483,8 @@ module New = struct
     let rest =
       Evd.fold_undefined (fun evk evi acc ->
         match is_undefined_up_to_restriction sigma evk with
-        | Some (evk',evi) -> (evk',evi)::acc
+        | Some (evk',evi) when not (Evarutil.reachable_from_evars sigma origevars evk) ->
+           (evk',evi)::acc
         | _ -> acc)
         extsigma []
     in


### PR DESCRIPTION
…order

evar-evar unifications and restrictions can instantiate pre-existing
evars by new evars but these are not considered fresh
anymore. Similarly, fresh evars can be instantiated by pre-existing
evars and these are not considered fresh either for tactics not
supporting evars.

Add regression tests to the test-suite and a note explaining this in the
reference manual. This should allow closing PR #370 satisfactorily now.