### PR TITLE
Fix ci-fiat-crypto to have a proper lite target

### DIFF
--- a/Makefile.ci
+++ b/Makefile.ci
@@ -7,4 +7,4 @@ CI_TARGETS=ci-all ci-hott ci-math-comp ci-compcert ci-sf ci-cpdt \
 
 # Generic rule, we use make to easy travis integraton with mixed rules
 $(CI_TARGETS): ci-%:
-	./dev/ci/ci-$*.sh
+	+./dev/ci/ci-$*.sh

--- a/dev/ci/ci-bedrock-facade.sh
+++ b/dev/ci/ci-bedrock-facade.sh
@@ -7,4 +7,4 @@ bedrock_facade_CI_DIR=${CI_BUILD_DIR}/bedrock-facade
 
 git_checkout ${bedrock_facade_CI_BRANCH} ${bedrock_facade_CI_GITURL} ${bedrock_facade_CI_DIR}
 
-( cd ${bedrock_facade_CI_DIR} && make -j ${NJOBS} facade )
+( cd ${bedrock_facade_CI_DIR} && make facade )

--- a/dev/ci/ci-bedrock-src.sh
+++ b/dev/ci/ci-bedrock-src.sh
@@ -7,4 +7,4 @@ bedrock_src_CI_DIR=${CI_BUILD_DIR}/bedrock-src
 
 git_checkout ${bedrock_src_CI_BRANCH} ${bedrock_src_CI_GITURL} ${bedrock_src_CI_DIR}
 
-( cd ${bedrock_src_CI_DIR} && make -j ${NJOBS} src )
+( cd ${bedrock_src_CI_DIR} && make src )

--- a/dev/ci/ci-color.sh
+++ b/dev/ci/ci-color.sh
@@ -7,4 +7,4 @@ Color_CI_DIR=${CI_BUILD_DIR}/color
 
 svn checkout ${Color_CI_SVNURL} ${Color_CI_DIR}
 
-( cd ${Color_CI_DIR} && make -j ${NJOBS} )
+( cd ${Color_CI_DIR} && make )

--- a/dev/ci/ci-common.sh
+++ b/dev/ci/ci-common.sh
@@ -59,7 +59,7 @@ install_ssreflect()
     sed -i.bak '/field/d'       Make && \
     sed -i.bak '/fingroup/d'    Make && \
     sed -i.bak '/algebra/d'     Make && \
-    make Makefile.coq && make -f Makefile.coq -j ${NJOBS} all && make install )
+    make Makefile.coq && make -f Makefile.coq all && make install )
 
   echo -en 'travis_fold:end:ssr.install\\r'
 

--- a/dev/ci/ci-compcert.sh
+++ b/dev/ci/ci-compcert.sh
@@ -9,4 +9,4 @@ opam install -j ${NJOBS} -y menhir
 git_checkout ${CompCert_CI_BRANCH} ${CompCert_CI_GITURL} ${CompCert_CI_DIR}
 
 # Patch to avoid the upper version limit
-( cd ${CompCert_CI_DIR} && sed -i.bak 's/8.6)/8.6|trunk)/' configure && ./configure x86_32-linux && make -j ${NJOBS} )
+( cd ${CompCert_CI_DIR} && sed -i.bak 's/8.6)/8.6|trunk)/' configure && ./configure x86_32-linux && make )

--- a/dev/ci/ci-cpdt.sh
+++ b/dev/ci/ci-cpdt.sh
@@ -6,5 +6,5 @@ source ${ci_dir}/ci-common.sh
 wget http://adam.chlipala.net/cpdt/cpdt.tgz
 tar xvfz cpdt.tgz
 
-( cd cpdt && make clean && make -j ${NJOBS} )
+( cd cpdt && make clean && make )
 

--- a/dev/ci/ci-fiat-crypto.sh
+++ b/dev/ci/ci-fiat-crypto.sh
@@ -8,4 +8,4 @@ fiat_crypto_CI_DIR=${CI_BUILD_DIR}/fiat-crypto
 git_checkout ${fiat_crypto_CI_BRANCH} ${fiat_crypto_CI_GITURL} ${fiat_crypto_CI_DIR}
 ( cd ${fiat_crypto_CI_DIR} && git submodule update --init --recursive )
 
-( cd ${fiat_crypto_CI_DIR} && make -j ${NJOBS} lite )
+( cd ${fiat_crypto_CI_DIR} && make lite )

--- a/dev/ci/ci-fiat-crypto.sh
+++ b/dev/ci/ci-fiat-crypto.sh
@@ -6,5 +6,6 @@ source ${ci_dir}/ci-common.sh
 fiat_crypto_CI_DIR=${CI_BUILD_DIR}/fiat-crypto
 
 git_checkout ${fiat_crypto_CI_BRANCH} ${fiat_crypto_CI_GITURL} ${fiat_crypto_CI_DIR}
+( cd ${fiat_crypto_CI_DIR} && git submodule update --init --recursive )
 
 ( cd ${fiat_crypto_CI_DIR} && make -j ${NJOBS} lite )

--- a/dev/ci/ci-fiat-parsers.sh
+++ b/dev/ci/ci-fiat-parsers.sh
@@ -7,4 +7,4 @@ fiat_parsers_CI_DIR=${CI_BUILD_DIR}/fiat
 
 git_checkout ${fiat_parsers_CI_BRANCH} ${fiat_parsers_CI_GITURL} ${fiat_parsers_CI_DIR}
 
-( cd ${fiat_parsers_CI_DIR} && make -j ${NJOBS} parsers parsers-examples )
+( cd ${fiat_parsers_CI_DIR} && make parsers parsers-examples )

--- a/dev/ci/ci-formal-topology.sh
+++ b/dev/ci/ci-formal-topology.sh
@@ -13,16 +13,16 @@ formal_topology_CI_DIR=${CI_BUILD_DIR}/formal-topology
 
 git_checkout ${math_classes_CI_BRANCH} ${math_classes_CI_GITURL} ${math_classes_CI_DIR}
 
-( cd ${math_classes_CI_DIR} && make -j ${NJOBS} && make install )
+( cd ${math_classes_CI_DIR} && make && make install )
 
 # Setup Corn
 
 git_checkout ${Corn_CI_BRANCH} ${Corn_CI_GITURL} ${Corn_CI_DIR}
 
-( cd ${Corn_CI_DIR} && make -j ${NJOBS} && make install )
+( cd ${Corn_CI_DIR} && make && make install )
 
 # Setup formal-topology
 
 git_checkout ${formal_topology_CI_BRANCH} ${formal_topology_CI_GITURL} ${formal_topology_CI_DIR}
 
-( cd ${formal_topology_CI_DIR} && make -j ${NJOBS} )
+( cd ${formal_topology_CI_DIR} && make )

--- a/dev/ci/ci-geocoq.sh
+++ b/dev/ci/ci-geocoq.sh
@@ -13,4 +13,4 @@ git_checkout ${GeoCoq_CI_BRANCH} ${GeoCoq_CI_GITURL} ${GeoCoq_CI_DIR}
   sed -i.bak '/Elements\/Book_1\.v/d'                Make && \
   sed -i.bak '/Elements\/Book_3\.v/d'                Make && \
   coq_makefile -f Make -o Makefile                        && \
-  make -j ${NJOBS} )
+  make )

--- a/dev/ci/ci-hott.sh
+++ b/dev/ci/ci-hott.sh
@@ -7,4 +7,4 @@ HoTT_CI_DIR=${CI_BUILD_DIR}/HoTT
 
 git_checkout ${HoTT_CI_BRANCH} ${HoTT_CI_GITURL} ${HoTT_CI_DIR}
 
-( cd ${HoTT_CI_DIR} && ./autogen.sh && ./configure && make -j ${NJOBS} )
+( cd ${HoTT_CI_DIR} && ./autogen.sh && ./configure && make )

--- a/dev/ci/ci-iris-coq.sh
+++ b/dev/ci/ci-iris-coq.sh
@@ -20,7 +20,7 @@ stdpp_CI_COMMIT=${IRIS_DEP[2]}
 
 git_checkout ${stdpp_CI_BRANCH} ${stdpp_CI_GITURL} ${stdpp_CI_DIR} ${stdpp_CI_COMMIT}
 
-( cd ${stdpp_CI_DIR} && make -j ${NJOBS} && make install )
+( cd ${stdpp_CI_DIR} && make && make install )
 
 # Build iris now
-( cd ${Iris_CI_DIR} && make -j ${NJOBS} )
+( cd ${Iris_CI_DIR} && make )

--- a/dev/ci/ci-math-classes.sh
+++ b/dev/ci/ci-math-classes.sh
@@ -11,10 +11,10 @@ Corn_CI_DIR=${CI_BUILD_DIR}/corn
 
 git_checkout ${math_classes_CI_BRANCH} ${math_classes_CI_GITURL} ${math_classes_CI_DIR}
 
-( cd ${math_classes_CI_DIR} && make -j ${NJOBS} && make install )
+( cd ${math_classes_CI_DIR} && make && make install )
 
 # Setup Corn
 
 git_checkout ${Corn_CI_BRANCH} ${Corn_CI_GITURL} ${Corn_CI_DIR}
 
-( cd ${Corn_CI_DIR} && make -j ${NJOBS} )
+( cd ${Corn_CI_DIR} && make )

--- a/dev/ci/ci-math-comp.sh
+++ b/dev/ci/ci-math-comp.sh
@@ -12,4 +12,4 @@ checkout_mathcomp ${mathcomp_CI_DIR}
 ( cd ${mathcomp_CI_DIR}/mathcomp                  && \
   sed -i.bak '/PFsection/d'                  Make && \
   sed -i.bak '/stripped_odd_order_theorem/d' Make && \
-  make Makefile.coq && make -f Makefile.coq -j ${NJOBS} all )
+  make Makefile.coq && make -f Makefile.coq all )

--- a/dev/ci/ci-metacoq.sh
+++ b/dev/ci/ci-metacoq.sh
@@ -10,10 +10,10 @@ metacoq_CI_DIR=${CI_BUILD_DIR}/MetaCoq
 
 git_checkout ${unicoq_CI_BRANCH} ${unicoq_CI_GITURL} ${unicoq_CI_DIR}
 
-( cd ${unicoq_CI_DIR} && coq_makefile -f Make -o Makefile && make -j ${NJOBS} && make install )
+( cd ${unicoq_CI_DIR} && coq_makefile -f Make -o Makefile && make && make install )
 
 # Setup MetaCoq
 
 git_checkout ${metacoq_CI_BRANCH} ${metacoq_CI_GITURL} ${metacoq_CI_DIR}
 
-( cd ${metacoq_CI_DIR} && coq_makefile -f _CoqProject -o Makefile && make -j ${NJOBS} )
+( cd ${metacoq_CI_DIR} && coq_makefile -f _CoqProject -o Makefile && make )

--- a/dev/ci/ci-sf.sh
+++ b/dev/ci/ci-sf.sh
@@ -7,6 +7,6 @@ source ${ci_dir}/ci-common.sh
 wget ${sf_CI_TARURL}
 tar xvfz sf.tgz
 
-( cd sf && sed -i.bak 's/(K,N)/((K,N))/' LibTactics.v && make clean && make -j ${NJOBS} )
+( cd sf && sed -i.bak 's/(K,N)/((K,N))/' LibTactics.v && make clean && make )
 
 

--- a/dev/ci/ci-template.sh
+++ b/dev/ci/ci-template.sh
@@ -9,4 +9,4 @@ Template_CI_DIR=${CI_BUILD_DIR}/Template
 
 git_checkout ${Template_CI_BRANCH} ${Template_CI_GITURL} ${Template_CI_DIR}
 
-( cd ${Template_CI_DIR} && make -j ${NJOBS} )
+( cd ${Template_CI_DIR} && make )

--- a/dev/ci/ci-tlc.sh
+++ b/dev/ci/ci-tlc.sh
@@ -7,4 +7,4 @@ tlc_CI_DIR=${CI_BUILD_DIR}/tlc
 
 git_checkout ${tlc_CI_BRANCH} ${tlc_CI_GITURL} ${tlc_CI_DIR}
 
-( cd ${tlc_CI_DIR} && make -j ${NJOBS} )
+( cd ${tlc_CI_DIR} && make )

--- a/dev/ci/ci-unimath.sh
+++ b/dev/ci/ci-unimath.sh
@@ -10,5 +10,5 @@ git_checkout ${UniMath_CI_BRANCH} ${UniMath_CI_GITURL} ${UniMath_CI_DIR}
 ( cd ${UniMath_CI_DIR}                        && \
   sed -i.bak '/Folds/d'              Makefile && \
   sed -i.bak '/HomologicalAlgebra/d' Makefile && \
-  make -j ${NJOBS} BUILD_COQ=no )
+  make BUILD_COQ=no )
 

--- a/dev/ci/ci-vst.sh
+++ b/dev/ci/ci-vst.sh
@@ -10,4 +10,4 @@ git_checkout ${VST_CI_BRANCH} ${VST_CI_GITURL} ${VST_CI_DIR}
 
 # Targets are: msl veric floyd
 # Patch to avoid the upper version limit
-( cd ${VST_CI_DIR} && sed -i.bak 's/8.6$/8.6 or-else trunk/' Makefile && make -j ${NJOBS} )
+( cd ${VST_CI_DIR} && sed -i.bak 's/8.6$/8.6 or-else trunk/' Makefile && make )


### PR DESCRIPTION
The lite target depends on having the submodule cloned to generate the
list of files to not build.

(Hopefully; I'm not 100% certain this will fix things.)