### PR TITLE
Fixing restriction of existential variables regarding evar_store

### DIFF
--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -659,8 +659,7 @@ let restrict evk filter ?candidates ?src evd =
   let evar_info' =
     { evar_info with evar_filter = filter;
       evar_candidates = candidates;
-      evar_source = (match src with None -> evar_info.evar_source | Some src -> src);
-      evar_extra = Store.empty } in
+      evar_source = (match src with None -> evar_info.evar_source | Some src -> src) } in
   let last_mods = match evd.conv_pbs with
   | [] ->  evd.last_mods
   | _ -> Evar.Set.add evk evd.last_mods in


### PR DESCRIPTION
This is part of @mattam82 's #611, what seems to be a bug in `Evd.restrict`, which does not propagate the field storing extra information. I had this in my stack of pending works. I did not spend time at finding a counter-example but there is no reason a restricted evar should drop its extra field, so this a priori prevent potential bugs.