### PR TITLE
[ide] Better exn printing. [fixes BZ#5524]

### DIFF
--- a/ide/ide_slave.ml
+++ b/ide/ide_slave.ml
@@ -341,6 +341,7 @@ let about () = {
 }
 
 let handle_exn (e, info) =
+  let (e, info) = ExplainErr.process_vernac_interp_error (e, info) in
   let dummy = Stateid.dummy in
   let loc_of e = match Loc.get_loc e with
     | Some loc -> Some (Loc.unloc loc)


### PR DESCRIPTION
Due to the situation explained in bug 5360, error printing in
ide_slave results in an anomaly. We fix that by properly processing
the error.

This fixes BZ#5524, however BZ#5525 , still applies.