### PR TITLE
Guards refine match return predicate arguments

### DIFF
--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -856,17 +856,13 @@ let filter_stack_domain env ci k p stack =
     let (_mib, mip) = lookup_mind_specif env ci.ci_ind in
     let branch_ty = mip.mind_nf_lc.(k) in
     let absctx, result_ty = dest_prod_assum env branch_ty in
-    try
-      let _, args = destApp result_ty in
-      let env = push_rel_context absctx env in
-      let n = List.length absctx in
-      let p = lift n p in
-      let nrealargs = mip.mind_nrealargs in
-      let realargs = Array.sub args (Array.length args - nrealargs) nrealargs in
-      env, n, mkApp (p, realargs)
-    with DestKO ->
-      (* The result type is not an application, so there is no argument! *)
-      env, 0, p in
+    let _, args = decompose_appvect result_ty in
+    let env = push_rel_context absctx env in
+    let n = Context.Rel.length absctx in
+    let p = lift n p in
+    let nrealargs = mip.mind_nrealargs in
+    let realargs = Array.sub args (Array.length args - nrealargs) nrealargs in
+    env, n, mkApp (p, realargs) in
   let absctx, ar = dest_lam_assum env p in
   (* Optimization: if the predicate is not dependent, no restriction is needed
      and we avoid building the recargs tree. *)


### PR DESCRIPTION
Bug 5530 - Fixpoint guard when generalization occurs on strict subterms

The following fixpoint definition now typechecks.

```
Inductive Counter: nat -> Set :=
  Zero: Counter O
| Succ: forall n, Counter n -> Counter (S n).

Fixpoint count2 n (u: Counter n) (v: Counter n) {struct u}: unit :=
  match u with
    Zero => fun _ => tt
  | Succ n u' =>
    fun (v: Counter (S n)) => match v with
      Succ n v' => fun u' => count2 n u' v'
    end u'
  end v.
```