### PR TITLE
Use mega.nz for travis build artifacts.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -273,6 +273,7 @@ ci-fiat-parsers:
   variables:
     <<: *ci-template-vars
     EXTRA_PACKAGES: "python"
+  allow_failure: true
 
 ci-flocq:
   <<: *ci-template

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,21 +28,7 @@ variables:
 
 
 before_script:
-  - ls # figure out if artifacts are around
-  - printenv
-#  - if [ "$COMPILER" = "$COMPILER_32BIT" ]; then sudo dpkg --add-architecture i386; fi
-  - if [ -n "${EXTRA_PACKAGES}" ]; then sudo apt-get update -qq && sudo apt-get install -y -qq ${EXTRA_PACKAGES}; fi
-
-  # setup cache
-  - if [ ! "(" -d .opamcache ")" ]; then mv ~/.opam .opamcache; else mv ~/.opam ~/.opam-old; fi
-  - ln -s $(readlink -f .opamcache) ~/.opam
-
-  - opam switch ${COMPILER}
-  - eval $(opam config env)
-  - opam config list
-  - opam install -j ${NJOBS} -y camlp5.${CAMLP5_VER} ocamlfind ${EXTRA_OPAM}
-  - rm -rf ~/.opam/log/
-  - opam list
+  - dev/ci/setup.sh
 
 # TODO figure out how to build doc for installed coq
 .build-template: &build-template
@@ -50,28 +36,13 @@ before_script:
   artifacts:
     name: "$CI_JOB_NAME"
     paths:
-      - install
+      - coq-install
       - config/Makefile
     expire_in: 1 week
-  script:
-    - set -e
-
-    - echo 'start:coq.config'
-    - ./configure -prefix "$(pwd)/install" ${EXTRA_CONF}
-    - echo 'end:coq.config'
-
-    - echo 'start:coq.build'
-    - make -j ${NJOBS}
-    - echo 'end:coq:build'
-
-    - echo 'start:coq.install'
-    - make install
-    - cp bin/fake_ide install/bin/
-    - echo 'end:coq.install'
-
-    - set +e
+  script: dev/ci/build.sh
   variables: &build-variables
-    EXTRA_CONF: "-native-compiler yes -coqide opt"
+    NATIVE_COMP: "yes"
+    EXTRA_CONF: "-coqide opt"
     EXTRA_PACKAGES: "$COQIDE_PACKAGES"
     EXTRA_OPAM: "$COQIDE_OPAM"
 
@@ -79,30 +50,16 @@ before_script:
   # keep warnings in test stage so we can test things even when warnings occur
   stage: test
   dependencies: []
-  script:
-    - set -e
-
-    - echo 'start:coq.config'
-    - ./configure -local ${EXTRA_CONF}
-    - echo 'end:coq.config'
-
-    - echo 'start:coq.build'
-    - make -j ${NJOBS} coqocaml
-    - echo 'end:coq:build'
-
-    - set +e
+  script: dev/ci/warnings.sh
   variables: &warnings-variables
-    EXTRA_CONF: "-native-compiler yes -coqide opt"
+    NATIVE_COMP: "yes"
+    EXTRA_CONF: "-coqide opt"
     EXTRA_PACKAGES: "$COQIDE_PACKAGES"
     EXTRA_OPAM: "$COQIDE_OPAM"
 
 .test-suite-template: &test-suite-template
   stage: test
-  script:
-    - cd test-suite
-    - make clean
-    # careful with the ending /
-    - make -j ${NJOBS} BIN=$(readlink -f ../install/bin)/ LIB=$(readlink -f ../install/lib/coq)/ all
+  script: dev/ci/test-suite.sh
   artifacts:
     name: "$CI_JOB_NAME.logs"
     when: on_failure
@@ -111,43 +68,20 @@ before_script:
 
 .validate-template: &validate-template
   stage: test
-  script:
-    - cd install
-    - find lib/coq/ -name '*.vo' -print0 > vofiles
-    - for regexp in 's/.vo//' 's:lib/coq/plugins:Coq:' 's:lib/coq/theories:Coq:' 's:/:.:g'; do sed -z -i "$regexp" vofiles; done
-    - xargs -0 --arg-file=vofiles bin/coqchk -boot -silent -o -m -coqlib lib/coq/
+  script: dev/ci/validate.sh
 
 .documentation-template: &documentation-template
   stage: test
-  script:
-    - ./configure -prefix "$(pwd)/install" ${EXTRA_CONF}
-    - cp install/lib/coq/tools/coqdoc/coqdoc.sty .
-
-    - INSTALLDIR=$(readlink -f install)
-    - LIB="$INSTALLDIR/lib/coq"
-    # WTF using a newline makes make sigsev
-    # see https://gitlab.com/SkySkimmer/coq/builds/17313312
-    - DOCVFILES=$(find "$LIB/" -name '*.v' -printf "%p ")
-    - DOCLIGHTDIRS="$LIB/theories/Init/ $LIB/theories/Logic/ $LIB/theories/Unicode/ $LIB/theories/Arith/"
-    - DOCLIGHTVOFILES=$(find $DOCLIGHTDIRS -name '*.vo' -printf "%p ")
-
-    - make doc QUICK=true COQDOC_NOBOOT=true COQTEX="$INSTALLDIR/bin/coq-tex" COQDOC="$INSTALLDIR/bin/coqdoc" VFILES="$DOCVFILES" THEORIESLIGHTVO="$DOCLIGHTVOFILES"
-
-    - make install-doc
+  script: dev/ci/documentation.sh
   artifacts:
     name: "$CI_JOB_NAME"
     paths:
-      - install/share/doc
+      - coq-install/share/doc
     expire_in: 1 week
 
 .ci-template: &ci-template
   stage: test
-  script:
-    - set -e
-    - echo 'start:coq.test'
-    - make -f Makefile.ci -j ${NJOBS} ${TEST_TARGET}
-    - echo 'end:coq.test'
-    - set +e
+  script: dev/ci/contrib.sh
   dependencies:
     - build
   variables: &ci-template-vars
@@ -160,7 +94,7 @@ build:
 build:32bit:
   <<: *build-template
   variables:
-    EXTRA_CONF: "-native-compiler yes"
+    NATIVE_COMP: "yes"
     EXTRA_PACKAGES: "gcc-multilib"
     COMPILER: "$COMPILER_32BIT"
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,5 @@
 image: ocaml/opam:ubuntu
 
-# this doesn't seem to work
 cache:
   paths:
     - .opamcache

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,31 +33,6 @@ env:
   - CAMLP5_VER="6.14"
   - NATIVE_COMP="yes"
   # Main test suites
-  matrix:
-  - TEST_TARGET="test-suite" COMPILER="4.02.3+32bit"
-  - TEST_TARGET="validate"                           TW="travis_wait"
-  - TEST_TARGET="validate"   COMPILER="4.02.3+32bit" TW="travis_wait"
-  - TEST_TARGET="ci-bignums"
-  - TEST_TARGET="ci-color"
-  - TEST_TARGET="ci-compcert"
-  - TEST_TARGET="ci-coq-dpdgraph" EXTRA_OPAM="ocamlgraph"
-  - TEST_TARGET="ci-coquelicot"
-  - TEST_TARGET="ci-geocoq"
-  - TEST_TARGET="ci-fiat-crypto"
-  - TEST_TARGET="ci-fiat-parsers"
-  - TEST_TARGET="ci-flocq"
-  - TEST_TARGET="ci-formal-topology"
-  - TEST_TARGET="ci-hott"
-  - TEST_TARGET="ci-iris-coq"
-  - TEST_TARGET="ci-math-classes"
-  - TEST_TARGET="ci-math-comp"
-  - TEST_TARGET="ci-sf"
-  - TEST_TARGET="ci-unimath"
-  - TEST_TARGET="ci-vst"
-  # Not ready yet for 8.7
-  # - TEST_TARGET="ci-cpdt"
-  # - TEST_TARGET="ci-metacoq"
-  # - TEST_TARGET="ci-tlc"
 
 matrix:
 
@@ -67,16 +42,83 @@ matrix:
   - env: TEST_TARGET="ci-fiat-parsers"
 
   include:
-    # Full Coq test-suite with two compilers
     - env:
-      - TEST_TARGET="test-suite"
-      - EXTRA_CONF="-coqide opt -with-doc yes"
-      - EXTRA_OPAM="lablgtk-extras hevea"
+      - TEST_TARGET="install"
+      - EXTRA_CONF="-coqide opt"
+      - EXTRA_OPAM="lablgtk-extras"
+      script: dev/ci/build.sh
+      stage: build
       addons:
-        apt:
+        apt: &coqide-apt
           sources:
           - avsm
-          packages: &extra-packages
+          packages:
+          - opam
+          - aspcud
+          - libgtk2.0-dev
+          - libgtksourceview2.0-dev
+
+    - env:
+      - TEST_TARGET="install"
+      - COMPILER="4.02.3+32bit"
+      script: dev/ci/build.sh
+      stage: build
+
+    - env:
+      - TEST_TARGET="install"
+      - COMPILER="4.04.1"
+      - CAMLP5_VER="6.17"
+      - EXTRA_CONF="-coqide opt"
+      - EXTRA_OPAM="lablgtk-extras"
+      script: dev/ci/build.sh
+      stage: build
+      addons:
+        apt: *coqide-apt
+
+    - env: TEST_TARGET="test-suite"
+      script: dev/ci/test-suite.sh
+      stage: test
+    - env: TEST_TARGET="test-suite" COMPILER="4.02.3+32bit"
+      script: dev/ci/test-suite.sh
+    - env: TEST_TARGET="test-suite" COMPILER="4.04.1" CAMLP5_VER="6.17"
+      script: dev/ci/test-suite.sh
+
+    - env: TEST_TARGET="validate"                             TW="travis_wait"
+      script: dev/ci/validate.sh
+    - env: TEST_TARGET="validate"   COMPILER="4.02.3+32bit"   TW="travis_wait"
+      script: dev/ci/validate.sh
+
+    - env: TEST_TARGET="ci-bignums"
+    - env: TEST_TARGET="ci-color"
+    - env: TEST_TARGET="ci-compcert"
+    - env: TEST_TARGET="ci-coq-dpdgraph" EXTRA_OPAM="ocamlgraph"
+    - env: TEST_TARGET="ci-coquelicot"
+    - env: TEST_TARGET="ci-geocoq"
+    - env: TEST_TARGET="ci-fiat-crypto"
+    - env: TEST_TARGET="ci-fiat-parsers"
+    - env: TEST_TARGET="ci-flocq"
+    - env: TEST_TARGET="ci-formal-topology"
+    - env: TEST_TARGET="ci-hott"
+    - env: TEST_TARGET="ci-iris-coq"
+    - env: TEST_TARGET="ci-math-classes"
+    - env: TEST_TARGET="ci-math-comp"
+    - env: TEST_TARGET="ci-sf"
+    - env: TEST_TARGET="ci-unimath"
+    - env: TEST_TARGET="ci-vst"
+      # Not ready yet for 8.7
+      # - TEST_TARGET="ci-cpdt"
+      # - TEST_TARGET="ci-metacoq"
+      # - TEST_TARGET="ci-tlc"
+
+    - env:
+      - TEST_TARGET="documentation"
+      - EXTRA_OPAM="hevea"
+      script: dev/ci/documentation.sh
+      addons:
+        apt: &extra-apt
+          sources:
+          - avsm
+          packages:
           - opam
           - aspcud
           - libgtk2.0-dev
@@ -94,47 +136,36 @@ matrix:
           - tipa
 
     - env:
-      - TEST_TARGET="test-suite"
+      - TEST_TARGET="documentation"
       - COMPILER="4.04.1"
       - CAMLP5_VER="6.17"
-      - EXTRA_CONF="-coqide opt -with-doc yes"
-      - EXTRA_OPAM="lablgtk-extras hevea"
+      - EXTRA_OPAM="hevea"
+      script: dev/ci/documentation.sh
       addons:
-        apt:
-          sources:
-          - avsm
-          packages: *extra-packages
+        apt: *extra-apt
 
     # Ocaml warnings with two compilers
     - env:
       - TEST_TARGET="coqocaml"
       - EXTRA_CONF="-coqide opt -warn-error"
-      - EXTRA_OPAM="lablgtk-extras hevea"
+      - EXTRA_OPAM="lablgtk-extras"
       # dummy target
       - BUILD_TARGET="clean"
+      script: dev/ci/warnings.sh
       addons:
-        apt:
-          sources:
-          - avsm
-          packages: &coqide-packages
-          - opam
-          - aspcud
-          - libgtk2.0-dev
-          - libgtksourceview2.0-dev
+        apt: *coqide-apt
 
     - env:
       - TEST_TARGET="coqocaml"
       - COMPILER="4.04.1"
       - CAMLP5_VER="6.17"
       - EXTRA_CONF="-coqide opt -warn-error"
-      - EXTRA_OPAM="lablgtk-extras hevea"
+      - EXTRA_OPAM="lablgtk-extras"
       # dummy target
       - BUILD_TARGET="clean"
+      script: dev/ci/warnings.sh
       addons:
-        apt:
-          sources:
-          - avsm
-          packages: *coqide-packages
+        apt: *coqide-apt
 
     - os: osx
       env:
@@ -142,32 +173,15 @@ matrix:
       - COMPILER="system"
       - CAMLP5_VER="6.17"
       - NATIVE_COMP="no"
+      script: dev/ci/test-suite.sh
       before_install:
       - brew update
       - brew install opam
 
-install:
-- opam init -j ${NJOBS} --compiler=${COMPILER} -n -y
-- eval $(opam config env)
-- opam config list
-- opam install -j ${NJOBS} -y camlp5.${CAMLP5_VER} ocamlfind ${EXTRA_OPAM}
-- opam list
+install: dev/ci/setup.sh
 
 script:
-
-- set -e
-- echo 'Configuring Coq...' && echo -en 'travis_fold:start:coq.config\\r'
-- ./configure -local -native-compiler ${NATIVE_COMP} ${EXTRA_CONF}
-- echo -en 'travis_fold:end:coq.config\\r'
-
-- echo 'Building Coq...' && echo -en 'travis_fold:start:coq.build\\r'
-- make -j ${NJOBS}
-- echo -en 'travis_fold:end:coq.build\\r'
-
-- echo 'Running tests...' && echo -en 'travis_fold:start:coq.test\\r'
-- ${TW} make -j ${NJOBS} ${TEST_TARGET}
-- echo -en 'travis_fold:end:coq.test\\r'
-- set +e
+- ${TW} dev/ci/contrib.sh
 
 # Testing Gitter webhook
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,14 @@ matrix:
   - env: TEST_TARGET="ci-fiat-parsers"
 
   include:
+    # cleanup any old files on mega
+    # if mega doesn't work on PRs consider making it branch only (if possible)
+    - env:
+      - TEST_TARGET="cleanup"
+      script: dev/ci/travis-cleanup.sh
+      install: true
+      stage: cleanup
+
     - env:
       - TEST_TARGET="install"
       - EXTRA_CONF="-coqide opt"

--- a/.travis.yml
+++ b/.travis.yml
@@ -173,6 +173,9 @@ matrix:
       - COMPILER="system"
       - CAMLP5_VER="6.17"
       - NATIVE_COMP="no"
+      # disable mega on osx
+      - MEGANAME=""
+      - MEGAPASS=""
       script: dev/ci/test-suite.sh
       before_install:
       - brew update

--- a/README.ci.md
+++ b/README.ci.md
@@ -82,23 +82,47 @@ corresponding GitLab CI variables.
 Travis specific information
 ===========================
 
-Travis rebuilds all of Coq's executables and stdlib for each job. Coq
-is built with `./configure -local`, then used for the job's test.
+Travis by default (and always on pull requests between different
+repositories) will rebuild all of Coq's executables and stdlib for
+each job, installed at prefix "$CI_INSTALL".
+
+You can set your repository to share builds between jobs
+through [mega.nz](https://mega.nz) (using the [megatools](https://megatools.megous.com/) CLI). You will need to
+sign up to Mega (free accounts get 10GB of storage), then in the
+travis settings of your repository add the following secret variables:
+- MEGANAME with the email you used for Mega
+- MEGAPASS with your Mega password
+
+At every build, a job will run to remove all artifacts except those
+from the last few runs. See [dev/ci/travis-cleanup.sh](dev/ci/travis-cleanup.sh) for the
+exact number of old artifacts it retains. It should be at least 2 in
+order to avoid interfering with a parallel build.
+
+Unlike GitLab only the Coq build is uploaded.
+
+Using Mega is not possible for pull requests at this time (except for
+intra repository pull requests), as travis secret variables are not
+available there.
 
 GitLab specific information
 ===========================
 
 GitLab is set up to use the "build artifact" feature to avoid
 rebuilding Coq. In one job, Coq is built with `./configure -prefix
-install` and `make install` is run, then the `install` directory
+coq-install` and `make install` is run, then the `install` directory
 persists to and is used by the next jobs.
+
+As an exception to the above, jobs testing that compilation triggers
+no Ocaml warnings build Coq in parallel with other tests.
 
 Artifacts can also be downloaded from the GitLab repository.
 Currently, available artifacts are:
 - the Coq executables and stdlib, in three copies varying in
   architecture and Ocaml version used to build Coq.
 - the Coq documentation, in two different copies varying in the OCaml
-  version used to build Coq
+  version used to build Coq.
+- if the test suite failed, its logs.
 
-As an exception to the above, jobs testing that compilation triggers
-no Ocaml warnings build Coq in parallel with other tests.
+Artifacts are retained one week then deleted, except for test suite
+logs which are retained indefinitely. You can go to the job's page and
+click a button to keep a specific artifact around longer.

--- a/dev/ci/build.sh
+++ b/dev/ci/build.sh
@@ -16,3 +16,5 @@ fold-start "Installing..." "coq.install"
 make install
 cp bin/fake_ide "$CI_INSTALL"/bin
 fold-end "Installation done." "coq.install"
+
+save-artifact-coq

--- a/dev/ci/build.sh
+++ b/dev/ci/build.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -ex
+
+source dev/ci/exports.sh
+
+fold-start "Configuring..." "coq.config"
+./configure -prefix "$CI_INSTALL" -native-compiler ${NATIVE_COMP} ${EXTRA_CONF}
+fold-end "Configuration done." "coq.config"
+
+fold-start "Building..." "coq.build"
+make -j ${NJOBS}
+fold-end "Build done." "coq.build"
+
+fold-start "Installing..." "coq.install"
+make install
+cp bin/fake_ide "$CI_INSTALL"/bin
+fold-end "Installation done." "coq.install"

--- a/dev/ci/ci-common.sh
+++ b/dev/ci/ci-common.sh
@@ -2,12 +2,7 @@
 
 set -xe
 
-if [ -n "${GITLAB_CI}" ];
-then
-    export COQBIN=`pwd`/install/bin
-else
-    export COQBIN=`pwd`/bin
-fi
+export COQBIN="$CI_INSTALL/bin"
 export PATH="$COQBIN:$PATH"
 
 # Coq's tools need an ending slash :S, we should fix them.

--- a/dev/ci/contrib.sh
+++ b/dev/ci/contrib.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -ex
+
+source dev/ci/exports.sh
+
+get-artifact-coq-with-fallback
+
+# considering this just calls one of the ci-* scripts maybe we should skip the Makefile?
+fold-start "Starting tests..." "coq.test"
+make -f Makefile.ci -j ${NJOBS} ${TEST_TARGET}
+fold-end "Tests done." "coq.test"

--- a/dev/ci/documentation.sh
+++ b/dev/ci/documentation.sh
@@ -6,6 +6,8 @@ source dev/ci/exports.sh
 
 get-artifact-coq-with-fallback
 
+fold-start "Building documentation..." "coq.doc"
+
 ./configure -prefix "$CI_INSTALL" ${EXTRA_CONF}
 cp "$CI_INSTALL/lib/coq/tools/coqdoc/coqdoc.sty" .
 
@@ -19,3 +21,5 @@ DOCLIGHTVOFILES=$(find $DOCLIGHTDIRS -name '*.vo' -printf "%p ")
 make doc QUICK=true COQDOC_NOBOOT=true COQTEX="$CI_INSTALL/bin/coq-tex" COQDOC="$CI_INSTALL/bin/coqdoc" VFILES="$DOCVFILES" THEORIESLIGHTVO="$DOCLIGHTVOFILES"
 
 make install-doc
+
+fold-end "Documentation built." "coq.doc"

--- a/dev/ci/documentation.sh
+++ b/dev/ci/documentation.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -ex
+
+source dev/ci/exports.sh
+
+get-artifact-coq-with-fallback
+
+./configure -prefix "$CI_INSTALL" ${EXTRA_CONF}
+cp "$CI_INSTALL/lib/coq/tools/coqdoc/coqdoc.sty" .
+
+LIB="$CI_INSTALL/lib/coq"
+# WTF using a newline makes make sigsev
+# see https://gitlab.com/SkySkimmer/coq/builds/17313312
+DOCVFILES=$(find "$LIB/" -name '*.v' -printf "%p ")
+DOCLIGHTDIRS="$LIB/theories/Init/ $LIB/theories/Logic/ $LIB/theories/Unicode/ $LIB/theories/Arith/"
+DOCLIGHTVOFILES=$(find $DOCLIGHTDIRS -name '*.vo' -printf "%p ")
+
+make doc QUICK=true COQDOC_NOBOOT=true COQTEX="$CI_INSTALL/bin/coq-tex" COQDOC="$CI_INSTALL/bin/coqdoc" VFILES="$DOCVFILES" THEORIESLIGHTVO="$DOCLIGHTVOFILES"
+
+make install-doc

--- a/dev/ci/exports.sh
+++ b/dev/ci/exports.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -ex
+# TODO figure out how to cleanly combine this with ci-common
+
+eval $(opam config env)
+
+ls -a
+printenv
+
+if [ -n "${GITLAB_CI}" ];
+then
+    source dev/ci/gitlab-exports.sh
+elif [ -n "${TRAVIS}" ];
+then
+    source dev/ci/travis-exports.sh
+else
+    >&2 echo "Unknown CI kind."
+    printenv
+    exit 1
+fi
+
+export CI_INSTALL="$(pwd)/coq-install"

--- a/dev/ci/gitlab-exports.sh
+++ b/dev/ci/gitlab-exports.sh
@@ -15,3 +15,7 @@ function fold-end {
 function get-artifact-coq-with-fallback {
     :
 }
+
+function save-artifact-coq {
+    :
+}

--- a/dev/ci/gitlab-exports.sh
+++ b/dev/ci/gitlab-exports.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# gitlab doesn't have folding
+function fold-start {
+    echo "$1"
+    echo "start:$2"
+}
+
+function fold-end {
+    echo "$1"
+    echo "end:$2"
+}
+
+# dummy since gitlab always has artifacts
+function get-artifact-coq-with-fallback {
+    :
+}

--- a/dev/ci/gitlab-setup.sh
+++ b/dev/ci/gitlab-setup.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# setup gitlab only things
+
+set -ex
+
+# travis uses the apt addon
+# gitlab has a docker image with opam preloaded so doesn't always need to install things
+if [ -n "${EXTRA_PACKAGES}" ];
+then
+    sudo apt-get update -qq
+    sudo apt-get install -y -qq ${EXTRA_PACKAGES}
+fi
+
+# gitlab can only cache subdirectories
+if [ ! "(" -f .opamcache/config ")" ];
+then mv ~/.opam .opamcache
+else mv ~/.opam ~/.opam-old # faster than [rm -rf] (?)
+fi
+ln -s $(readlink -f .opamcache) ~/.opam
+
+# since opam comes with docker we con't start the same as travis
+opam switch -j ${NJOBS} ${COMPILER}

--- a/dev/ci/setup.sh
+++ b/dev/ci/setup.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# setup common ci things
+
+set -ex
+
+if [ -n "${GITLAB_CI}" ];
+then
+    source dev/ci/gitlab-setup.sh
+elif [ -n "${TRAVIS}" ];
+then
+    source dev/ci/travis-setup.sh
+else
+    >&2 echo "Unknown CI kind."
+    printenv
+    exit 1
+fi
+
+eval $(opam config env)
+
+ls
+printenv
+
+opam config list
+
+opam install -j ${NJOBS} -y camlp5.${CAMLP5_VER} ocamlfind ${EXTRA_OPAM}
+rm -rf ~/.opam/log/
+
+opam list

--- a/dev/ci/test-suite.sh
+++ b/dev/ci/test-suite.sh
@@ -6,8 +6,10 @@ source dev/ci/exports.sh
 
 get-artifact-coq-with-fallback
 
+fold-start "Running test suite..." "coq.tests"
 cd test-suite
 make clean
 
 # careful with the ending /
 make -j ${NJOBS} BIN="$CI_INSTALL/bin/" LIB="$CI_INSTALL/lib/coq/" all
+fold-end "Test suite done." "coq.tests"

--- a/dev/ci/test-suite.sh
+++ b/dev/ci/test-suite.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -ex
+
+source dev/ci/exports.sh
+
+get-artifact-coq-with-fallback
+
+cd test-suite
+make clean
+
+# careful with the ending /
+make -j ${NJOBS} BIN="$CI_INSTALL/bin/" LIB="$CI_INSTALL/lib/coq/" all

--- a/dev/ci/travis-cleanup.sh
+++ b/dev/ci/travis-cleanup.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set +x
+if [ -n "${MEGANAME}" ];
+then
+    echo "[Login]" > ~/.megarc
+    echo "Username = $MEGANAME" >> ~/.megarc
+    echo "Password = $MEGAPASS" >> ~/.megarc
+else
+    exit 0
+fi
+
+set -ex
+
+source dev/ci/travis-exports.sh
+
+setup-mega
+
+megals /Root/ | grep Coq-travis > megafiles
+
+# grab the build numbers of uploaded files, uniquify, remove newest 2
+cat megafiles | sed -r 's:/Root/Coq-travis-.*-([0-9]+).zip:\1:g' | sort -ru | awk 'NR>2' > megajobs
+
+for i in $(cat megajobs);
+do
+    for f in $(cat megafiles | grep $i);
+    do
+        megarm "$f"
+    done
+done

--- a/dev/ci/travis-exports.sh
+++ b/dev/ci/travis-exports.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+if [ -f ~/.megarc ];
+then
+    HASMEGA=true
+else
+    HASMEGA=false
+fi
+
 function fold-start {
     echo -en "travis_fold:start:$2\\r"
     echo "$1"
@@ -10,6 +17,48 @@ function fold-end {
     echo "$1"
 }
 
+# CONSIDER this is fast so maybe we should always do it instead of
+# having it in the middle of the build
+function setup-mega {
+    fold-start "Installing megatools..." "mega.install"
+
+    wget http://megatools.megous.com/builds/megatools-1.9.97.tar.gz
+    zcat megatools-1.9.97.tar.gz > megatools-1.9.97.tar
+    tar -xf megatools-1.9.97.tar
+    pushd megatools-1.9.97
+    ./configure
+    make
+    sudo make install
+    popd
+
+    fold-end "megatools installed." "mega.install"
+}
+
 function get-artifact-coq-with-fallback {
-    dev/ci/build.sh
+    if $HASMEGA;
+    then
+        setup-mega
+
+        fold-start "Getting Coq from mega..." "mega.get"
+        FILE="Coq-travis-${COMPILER}-${TRAVIS_BUILD_ID}.zip"
+        megaget "/Root/$FILE"
+        unzip "$FILE"
+        fold-end "Coq received." "mega.get"
+    else
+        dev/ci/build.sh
+    fi
+}
+
+function save-artifact-coq {
+    if $HASMEGA;
+    then
+        setup-mega
+
+        FILE="Coq-travis-${COMPILER}-${TRAVIS_BUILD_ID}.zip"
+
+        # do not use "$CI_INSTALL" here, we need a relative path
+        zip -r "$FILE" coq-install config/Makefile
+
+        megaput "$FILE"
+    fi
 }

--- a/dev/ci/travis-exports.sh
+++ b/dev/ci/travis-exports.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+function fold-start {
+    echo -en "travis_fold:start:$2\\r"
+    echo "$1"
+}
+
+function fold-end {
+    echo -en "travis_fold:end:$2\\r"
+    echo "$1"
+}
+
+function get-artifact-coq-with-fallback {
+    dev/ci/build.sh
+}

--- a/dev/ci/travis-setup.sh
+++ b/dev/ci/travis-setup.sh
@@ -2,6 +2,14 @@
 
 # setup travis only things
 
+set +x
+if [ -n "${MEGANAME}" ];
+then
+    echo "[Login]" > ~/.megarc
+    echo "Username = $MEGANAME" >> ~/.megarc
+    echo "Password = $MEGAPASS" >> ~/.megarc
+fi
+
 set -ex
 
 opam init -j ${NJOBS} --compiler=${COMPILER} -n -y

--- a/dev/ci/travis-setup.sh
+++ b/dev/ci/travis-setup.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# setup travis only things
+
+set -ex
+
+opam init -j ${NJOBS} --compiler=${COMPILER} -n -y

--- a/dev/ci/validate.sh
+++ b/dev/ci/validate.sh
@@ -6,6 +6,7 @@ source dev/ci/exports.sh
 
 get-artifact-coq-with-fallback
 
+fold-start "Validating library..." "coq.validate"
 cd "$CI_INSTALL"
 find lib/coq/ -name '*.vo' -print0 > vofiles
 for regexp in 's/.vo//' 's:lib/coq/plugins:Coq:' 's:lib/coq/theories:Coq:' 's:/:.:g';
@@ -13,3 +14,4 @@ do
     sed -z -i "$regexp" vofiles
 done
 xargs -0 --arg-file=vofiles bin/coqchk -boot -silent -o -m -coqlib lib/coq/
+fold-end "Library validated." "coq.validate"

--- a/dev/ci/validate.sh
+++ b/dev/ci/validate.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -ex
+
+source dev/ci/exports.sh
+
+get-artifact-coq-with-fallback
+
+cd "$CI_INSTALL"
+find lib/coq/ -name '*.vo' -print0 > vofiles
+for regexp in 's/.vo//' 's:lib/coq/plugins:Coq:' 's:lib/coq/theories:Coq:' 's:/:.:g';
+do
+    sed -z -i "$regexp" vofiles
+done
+xargs -0 --arg-file=vofiles bin/coqchk -boot -silent -o -m -coqlib lib/coq/

--- a/dev/ci/warnings.sh
+++ b/dev/ci/warnings.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -ex
+
+source dev/ci/exports.sh
+
+fold-start "Configuring..." "coq.config"
+./configure -local -native-compiler ${NATIVE_COMP} ${EXTRA_CONF}
+fold-end "Configuration done." "coq.config"
+
+fold-start "Building..." "coq.build"
+make -j ${NJOBS} coqocaml
+fold-end "Build done." "coq.build"


### PR DESCRIPTION
Scripts are now shared between travis and gitlab (except for the OSX brew step).

Using secret variables `MEGANAME` and `MEGAPASS` you can explain to travis how to login to a mega.nz account. Then when gitlab would get a build artifact travis will download it from mega.
If you don't set the secret variables, or if you're on a PR like here, travis will have to rebuild at each job like before, except now there are more jobs.
**This may result in overall slowdown for Coq, so I don't know whether this PR should be merged.** 

The following are more minor issues:

There is also a cleanup job at the beginning of each build: if travis has access to mega it will delete all but the last 2 builds. I'm not sure if this is the right way to do this, maybe we should just let people delete their builds manually / with their own non travis cron jobs? Or have some `MEGARETAIN` secret variable?

This isn't robust to restarting builds as travis keeps the same build number (which we use to access the right artifact) as far as I can tell. I could add something which tests whether the file exists and deletes it but I'm not sure if this is the right solution. Restarting individual build stage jobs while test stage jobs are running is fundamentally broken, so don't do that.