### PR TITLE
closing bug 5315

### DIFF
--- a/plugins/funind/functional_principles_proofs.ml
+++ b/plugins/funind/functional_principles_proofs.ml
@@ -821,8 +821,9 @@ let build_proof
 	  | Fix _ | CoFix _ ->
 	      user_err Pp.(str ( "Anonymous local (co)fixpoints are not handled yet"))
 
+
 	  | Proj _ -> user_err Pp.(str "Prod")
-	  | Prod _ -> user_err Pp.(str "Prod")
+	  | Prod _ -> do_finalize dyn_infos g
 	  | LetIn _ ->
 	      let new_infos =
 		{ dyn_infos with

--- a/plugins/funind/glob_termops.ml
+++ b/plugins/funind/glob_termops.ml
@@ -708,9 +708,6 @@ let expand_as =
   in
   expand_as Id.Map.empty
 
-
-
-           
 (* [resolve_and_replace_implicits ?expected_type env sigma rt] solves implicits of [rt] w.r.t. [env] and [sigma] and then replace them by their solution 
  *)
 
@@ -748,6 +745,30 @@ If someone knows how to prevent solved existantial removal in  understand, pleas
            (* we just have to lift the solution in glob_term *)
               Detyping.detype false [] env ctx (EConstr.of_constr (f c))
            | Evar_empty -> rt (* the hole was not solved : we do nothing *)
+       )
+    | (GHole(BinderType na,_,_)) -> (* we only want to deal with implicit arguments *)
+       (
+         let res = 
+           try (* we scan the new evar map to find the evar corresponding to this hole (by looking the source *)
+             Evd.fold (* to simulate an iter *)
+               (fun _ evi _ ->
+                 match evi.evar_source with
+                 | (loc_evi,BinderType na') ->
+                    if Name.equal na na' && rt.CAst.loc = loc_evi  then raise (Found evi)
+                 | _ -> ()
+               )
+               ctx
+               ();
+             (* the hole was not solved : we do nothing *)
+             rt
+           with Found evi -> (* we found the evar corresponding to this hole *)
+                match evi.evar_body with
+                | Evar_defined c ->
+                   (* we just have to lift the solution in glob_term *)
+                   Detyping.detype false [] env ctx (EConstr.of_constr (f c))
+                | Evar_empty -> rt (* the hole was not solved : we d when falseo nothing *)
+         in 
+         res
        )
     | _ -> Glob_ops.map_glob_constr change rt 
   in

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -1136,8 +1136,13 @@ and pretype_type k0 resolve_tc valcon (env : ExtraEnv.t) evdref lvar = function
 		   evd_comb1 (define_evar_as_sort env.ExtraEnv.env) evdref ev
                | _ -> anomaly (Pp.str "Found a type constraint which is not a type.")
            in
-	     { utj_val = v;
-	       utj_type = s }
+           (* Correction of bug #5315 : we need to define an evar for *all* holes *)
+           let evkt = e_new_evar env evdref ~src:(loc, knd) ~naming (mkSort s) in
+           let ev,_ = destEvar !evdref evkt in
+           evdref := Evd.define ev (to_constr !evdref v) !evdref;
+           (* End of correction of bug #5315 *)
+           { utj_val = v;
+	     utj_type = s }
        | None ->
            let env = ltac_interp_name_env k0 lvar env !evdref in
 	   let s = evd_comb0 (new_sort_variable univ_flexible_alg) evdref in

--- a/test-suite/bugs/closed/5315.v
+++ b/test-suite/bugs/closed/5315.v
@@ -1,0 +1,10 @@
+Require Import Recdef.
+
+Function dumb_works (a:nat) {struct a} :=
+  match (fun x => x) a with O => O | S n' => dumb_works n' end.
+
+Function dumb_nope (a:nat) {struct a} :=
+  match (id (fun x => x)) a with O => O | S n' => dumb_nope n' end.
+
+(* This check is just present to ensure Function worked well *)
+Check R_dumb_nope_complete. 


### PR DESCRIPTION
This patch closes [bug 5315](https://coq.inria.fr/bugs/show_bug.cgi?id=5315) and an unreported bug on Function.
@mattam82 @Matafou @maximedenes: The most important change (outside of Function)  is the change in pretyping which is needed in order to typecheck term like f (fun x => ...) for which I need to know the type of x at glob_term level. 
The modification is triggered by Flags.is_function_mode which is itself set to true only during the hole resolution phase of Function so I can see any possible change outside of Function itself in pretyping. 

Any comments is welcome.