### PR TITLE
An attempt to fix a failure of test deps-checksum.sh fails with make -j4

### DIFF
--- a/test-suite/misc/deps-checksum.sh
+++ b/test-suite/misc/deps-checksum.sh
@@ -1,4 +1,4 @@
-rm -f misc/deps/*/*.vo
+rm -f misc/deps/A/*.vo misc/deps/B/*.vo
 $coqc -R misc/deps/A A misc/deps/A/A.v
 $coqc -R misc/deps/B A misc/deps/B/A.v
 $coqc -R misc/deps/B A misc/deps/B/B.v

--- a/test-suite/misc/deps-order.sh
+++ b/test-suite/misc/deps-order.sh
@@ -1,7 +1,7 @@
 # Check that both coqdep and coqtop/coqc supports -R
 # Check that both coqdep and coqtop/coqc takes the later -R
 # See bugs 2242, 2337, 2339
-rm -f misc/deps/*/*.vo
+rm -f misc/deps/lib/*.vo misc/deps/client/*.vo
 tmpoutput=`mktemp /tmp/coqcheck.XXXXXX`
 $coqdep -R misc/deps/lib lib -R misc/deps/client client misc/deps/client/bar.v 2>&1 | head -n 1 > $tmpoutput
 diff -u misc/deps/deps.out $tmpoutput 2>&1


### PR DESCRIPTION
I observed that, often, the test `deps-checksum.sh` fails with `make -j4`. Apparently, this is because the file `misc/deps/A/A.vo` is not yet ready while calling the main file `misc/deps/checksum.v`.

This is a patch which seems to empirically works. There may be better solutions though to guarantee the dependency...