### PR TITLE
Fix #5380: Default colors for CoqIDE are actually applied.

### DIFF
--- a/ide/preferences.ml
+++ b/ide/preferences.ml
@@ -407,11 +407,15 @@ let opposite_tabs =
 let background_color =
   new preference ~name:["background_color"] ~init:"cornsilk" ~repr:Repr.(string)
 
+let attach_tag (pref : string preference) (tag : GText.tag) f =
+  tag#set_property (f pref#get);
+  pref#connect#changed (fun c -> tag#set_property (f c))
+
 let attach_bg (pref : string preference) (tag : GText.tag) =
-  pref#connect#changed (fun c -> tag#set_property (`BACKGROUND c))
+  attach_tag pref tag (fun c -> `BACKGROUND c)
 
 let attach_fg (pref : string preference) (tag : GText.tag) =
-  pref#connect#changed (fun c -> tag#set_property (`FOREGROUND c))
+  attach_tag pref tag (fun c -> `FOREGROUND c)
 
 let processing_color =
   new preference ~name:["processing_color"] ~init:"light blue" ~repr:Repr.(string)


### PR DESCRIPTION
When a configuration line for a tag color was absent, its value was not set to the actual default value, because the preference field was not actually "changed".

See [bug 5380](https://coq.inria.fr/bugs/show_bug.cgi?id=5380) for instance.

If you are aware of any other configuration field whose default is not taken into account the first time you run CoqIDE, please let me know, I will try to take a look at it.