### PR TITLE
Deprecate Proof term.

### DIFF
--- a/doc/refman/RefMan-pro.tex
+++ b/doc/refman/RefMan-pro.tex
@@ -102,20 +102,18 @@ memory overflow.
 This command is available in interactive editing proof mode to give up
 the current proof and declare the initial goal as an axiom.
 
-\subsection[\tt Proof {\term}.]{\tt Proof {\term}.\comindex{Proof}
-\label{BeginProof}}
-This command applies in proof editing mode. It is equivalent to {\tt
-  exact {\term}. Qed.} That is, you have to give the full proof in
-one gulp, as a proof term (see Section~\ref{exact}).
-
-\variant {\tt Proof.}
+\subsection[\tt Proof.]{\tt Proof.\comindex{Proof}\label{BeginProof}}
   
-  Is a noop which is useful to delimit the sequence of tactic commands
-  which start a proof, after a {\tt Theorem} command.  It is a good
-  practice to use {\tt Proof.} as an opening parenthesis, closed in
-  the script with a closing {\tt Qed.}
+This command is a noop which is useful to delimit the sequence of tactic commands
+which start a proof, after a {\tt Theorem} command.  It is a good
+practice to use {\tt Proof.} as an opening parenthesis, closed in
+the script with a closing {\tt Qed.}
 
 \SeeAlso {\tt Proof with {\tac}.} in Section~\ref{ProofWith}.
+
+\subsection[\tt Proof {\term}.]{\tt Proof {\term}.}
+This command is deprecated and will be removed in the next version of Coq.
+You should use the equivalent form {\tt Proof. exact {\term}. Qed.} instead.
 
 \subsection[{\tt Proof using} {\ident$_1$} {\ldots} {\ident$_n$}{\tt .}]
 {{\tt Proof using} {\ident$_1$} {\ldots} {\ident$_n$}{\tt .}

--- a/plugins/micromega/OrderedRing.v
+++ b/plugins/micromega/OrderedRing.v
@@ -178,22 +178,22 @@ Qed.
 (* Relations *)
 
 Theorem Rle_refl : forall n : R, n <= n.
-Proof sor.(SORle_refl).
+Proof. exact sor.(SORle_refl). Qed.
 
 Theorem Rle_antisymm : forall n m : R, n <= m -> m <= n -> n == m.
-Proof sor.(SORle_antisymm).
+Proof. exact sor.(SORle_antisymm). Qed.
 
 Theorem Rle_trans : forall n m p : R, n <= m -> m <= p -> n <= p.
-Proof sor.(SORle_trans).
+Proof. exact sor.(SORle_trans). Qed.
 
 Theorem Rlt_trichotomy : forall n m : R,  n < m \/ n == m \/ m < n.
-Proof sor.(SORlt_trichotomy).
+Proof. exact sor.(SORlt_trichotomy). Qed.
 
 Theorem Rlt_le_neq : forall n m : R, n < m <-> n <= m /\ n ~= m.
-Proof sor.(SORlt_le_neq).
+Proof. exact sor.(SORlt_le_neq). Qed.
 
 Theorem Rneq_0_1 : 0 ~= 1.
-Proof sor.(SORneq_0_1).
+Proof. exact sor.(SORneq_0_1). Qed.
 
 Theorem Req_em : forall n m : R, n == m \/ n ~= m.
 Proof.
@@ -373,7 +373,7 @@ Qed.
 (* Times and order *)
 
 Theorem Rtimes_pos_pos : forall n m : R, 0 < n -> 0 < m -> 0 < n * m.
-Proof sor.(SORtimes_pos_pos).
+Proof. exact sor.(SORtimes_pos_pos). Qed.
 
 Theorem Rtimes_nonneg_nonneg : forall n m : R, 0 <= n -> 0 <= m -> 0 <= n * m.
 Proof.

--- a/plugins/setoid_ring/InitialRing.v
+++ b/plugins/setoid_ring/InitialRing.v
@@ -25,10 +25,10 @@ Definition NotConstant := false.
 (** Z is a ring and a setoid*)
 
 Lemma Zsth : Setoid_Theory Z (@eq Z).
-Proof (Eqsth Z).
+Proof. exact (Eqsth Z). Qed.
 
 Lemma Zeqe : ring_eq_ext Z.add Z.mul Z.opp (@eq Z).
-Proof (Eq_ext Z.add Z.mul Z.opp).
+Proof. exact (Eq_ext Z.add Z.mul Z.opp). Qed.
 
 Lemma Zth : ring_theory Z0 (Zpos xH) Z.add Z.mul Z.sub Z.opp (@eq Z).
 Proof.
@@ -221,10 +221,10 @@ End ZMORPHISM.
 
 (** N is a semi-ring and a setoid*)
 Lemma Nsth : Setoid_Theory N (@eq N).
-Proof (Eqsth N).
+Proof. exact (Eqsth N). Qed.
 
 Lemma Nseqe : sring_eq_ext N.add N.mul (@eq N).
-Proof (Eq_s_ext N.add N.mul).
+Proof. exact (Eq_s_ext N.add N.mul). Qed.
 
 Lemma Nth : semi_ring_theory 0%N 1%N N.add N.mul (@eq N).
 Proof.
@@ -237,11 +237,11 @@ Definition Nsub := SRsub N.add.
 Definition Nopp := (@SRopp N).
 
 Lemma Neqe : ring_eq_ext N.add N.mul Nopp (@eq N).
-Proof (SReqe_Reqe Nseqe).
+Proof. exact (SReqe_Reqe Nseqe). Qed.
 
 Lemma Nath :
  almost_ring_theory 0%N 1%N N.add N.mul Nsub Nopp (@eq N).
-Proof (SRth_ARth Nsth Nth).
+Proof. exact (SRth_ARth Nsth Nth). Qed.
 
 Lemma Neqb_ok : forall x y, N.eqb x y = true -> x = y.
 Proof. exact (fun x y => proj1 (N.eqb_eq x y)). Qed.

--- a/plugins/setoid_ring/RealField.v
+++ b/plugins/setoid_ring/RealField.v
@@ -104,7 +104,9 @@ Lemma Zeq_bool_complete : forall x y,
   InitialRing.gen_phiZ 0%R 1%R Rplus Rmult Ropp x =
   InitialRing.gen_phiZ 0%R 1%R Rplus Rmult Ropp y ->
   Zeq_bool x y = true.
-Proof gen_phiZ_complete Rset Rext Rfield Rgen_phiPOS_not_0.
+Proof.
+  exact (gen_phiZ_complete Rset Rext Rfield Rgen_phiPOS_not_0).
+Qed.
 
 Lemma Rdef_pow_add : forall (x:R) (n m:nat), pow x  (n + m) = pow x n * pow x m.
 Proof.

--- a/plugins/setoid_ring/Ring_theory.v
+++ b/plugins/setoid_ring/Ring_theory.v
@@ -285,11 +285,13 @@ Section ALMOST_RING.
  Proof. reflexivity. Qed.
 
  Lemma SRth_ARth : almost_ring_theory 0 1 radd rmul SRsub SRopp req.
- Proof (mk_art 0 1 radd rmul SRsub SRopp req
-    (SRadd_0_l SRth) (SRadd_comm SRth) (SRadd_assoc SRth)
-    (SRmul_1_l SRth) (SRmul_0_l SRth)
-    (SRmul_comm SRth) (SRmul_assoc SRth) (SRdistr_l SRth)
-    SRopp_mul_l SRopp_add SRsub_def).
+ Proof.
+   exact (mk_art 0 1 radd rmul SRsub SRopp req
+            (SRadd_0_l SRth) (SRadd_comm SRth) (SRadd_assoc SRth)
+            (SRmul_1_l SRth) (SRmul_0_l SRth)
+            (SRmul_comm SRth) (SRmul_assoc SRth) (SRdistr_l SRth)
+            SRopp_mul_l SRopp_add SRsub_def).
+ Qed.
 
  (** Identity morphism for semi-ring equipped with their almost-ring structure*)
  Variable reqb : R->R->bool.
@@ -377,11 +379,12 @@ Section ALMOST_RING.
   rewrite ((Radd_comm Rth) x); now apply (Radd_0_l Rth).
  Qed.
 
- Lemma  Rth_ARth : almost_ring_theory 0 1 radd rmul rsub ropp req.
- Proof
-  (mk_art 0 1 radd rmul rsub ropp req (Radd_0_l Rth) (Radd_comm Rth) (Radd_assoc Rth)
-    (Rmul_1_l Rth) Rmul_0_l (Rmul_comm Rth) (Rmul_assoc Rth) (Rdistr_l Rth)
-    Ropp_mul_l Ropp_add (Rsub_def Rth)).
+ Lemma Rth_ARth : almost_ring_theory 0 1 radd rmul rsub ropp req.
+ Proof.
+   exact (mk_art 0 1 radd rmul rsub ropp req (Radd_0_l Rth) (Radd_comm Rth) (Radd_assoc Rth)
+            (Rmul_1_l Rth) Rmul_0_l (Rmul_comm Rth) (Rmul_assoc Rth) (Rdistr_l Rth)
+            Ropp_mul_l Ropp_add (Rsub_def Rth)).
+ Qed.
 
  (** Every semi morphism between two rings is a morphism*)
  Variable C : Type.
@@ -423,11 +426,12 @@ Section ALMOST_RING.
  Lemma Smorph_morph :
    ring_morph 0 1 radd rmul rsub ropp req
      cO cI cadd cmul csub copp ceqb phi.
- Proof
-  (mkmorph 0 1 radd rmul rsub ropp req cO cI cadd cmul csub copp ceqb phi
-        (Smorph0 Smorph) (Smorph1 Smorph)
-         (Smorph_add Smorph) Smorph_sub (Smorph_mul Smorph) Smorph_opp
-         (Smorph_eq Smorph)).
+ Proof.
+   exact (mkmorph 0 1 radd rmul rsub ropp req cO cI cadd cmul csub copp ceqb phi
+            (Smorph0 Smorph) (Smorph1 Smorph)
+            (Smorph_add Smorph) Smorph_sub (Smorph_mul Smorph) Smorph_opp
+            (Smorph_eq Smorph)).
+ Qed.
 
  End RING.
 

--- a/test-suite/output/PrintAssumptions.v
+++ b/test-suite/output/PrintAssumptions.v
@@ -64,11 +64,11 @@ Print Assumptions AddCommExt_Transparent.add_comm_ext.
 
 Lemma add1_comm_ext_opaque :
   (fun x => x + 1) = (fun x => 1 + x).
-Proof (AddCommExt_Opaque.add_comm_ext 1).
+Proof. exact (AddCommExt_Opaque.add_comm_ext 1). Qed.
 
 Lemma add1_comm_ext_transparent :
   (fun x => x + 1) = (fun x => 1 + x).
-Proof (AddCommExt_Transparent.add_comm_ext 1).
+Proof. exact (AddCommExt_Transparent.add_comm_ext 1). Qed.
 
 Print Assumptions add1_comm_ext_opaque.
 (* Should answer: extensionality *)
@@ -90,7 +90,7 @@ End false_positive.
 
 Lemma comm_plus5 : forall x,
   x + 5 = 5 + x.
-Proof (false_positive.add_comm 5).
+Proof. exact (false_positive.add_comm 5). Qed.
 
 Print Assumptions comm_plus5.
 (* Should answer : Closed under the global context *)

--- a/test-suite/output/UnivBinders.v
+++ b/test-suite/output/UnivBinders.v
@@ -3,5 +3,5 @@ Set Printing Universes.
 
 Class Wrap A := wrap : A.
 
-Instance bar@{u} : Wrap@{u} Set. Proof nat.
+Instance bar@{u} : Wrap@{u} Set. Proof. exact nat. Qed.
 Print bar.

--- a/theories/Arith/Between.v
+++ b/theories/Arith/Between.v
@@ -59,7 +59,7 @@ Section Between.
   Qed.
 
   Lemma exists_lt : forall k l, exists_between k l -> k < l.
-  Proof exists_le_S.
+  Proof. exact (exists_le_S). Qed.
   Hint Immediate exists_le_S exists_lt: arith.
 
   Lemma exists_S_le : forall k l, exists_between k (S l) -> k <= l.

--- a/theories/Arith/Compare.v
+++ b/theories/Arith/Compare.v
@@ -23,15 +23,15 @@ Definition le_or_le_S := le_le_S_dec.
 Definition Pcompare := gt_eq_gt_dec.
 
 Lemma le_dec : forall n m, {n <= m} + {m <= n}.
-Proof le_ge_dec.
+Proof. exact (le_ge_dec). Qed.
 
 Definition lt_or_eq n m := {m > n} + {n = m}.
 
 Lemma le_decide : forall n m, n <= m -> lt_or_eq n m.
-Proof le_lt_eq_dec.
+Proof. exact (le_lt_eq_dec). Qed.
 
 Lemma le_le_S_eq : forall n m, n <= m -> S n <= m \/ n = m.
-Proof le_lt_or_eq.
+Proof. exact (le_lt_or_eq). Qed.
 
 (* By special request of G. Kahn - Used in Group Theory *)
 Lemma discrete_nat :

--- a/theories/Arith/Div2.v
+++ b/theories/Arith/Div2.v
@@ -120,16 +120,16 @@ Qed.
 (** Specializations *)
 
 Lemma even_double n : even n -> n = double (div2 n).
-Proof proj1 (proj1 (even_odd_double n)).
+Proof. exact (proj1 (proj1 (even_odd_double n))). Qed.
 
 Lemma double_even n : n = double (div2 n) -> even n.
-Proof proj2 (proj1 (even_odd_double n)).
+Proof. exact (proj2 (proj1 (even_odd_double n))). Qed.
 
 Lemma odd_double n : odd n -> n = S (double (div2 n)).
-Proof proj1 (proj2 (even_odd_double n)).
+Proof. exact (proj1 (proj2 (even_odd_double n))). Qed.
 
 Lemma double_odd n : n = S (double (div2 n)) -> odd n.
-Proof proj2 (proj2 (even_odd_double n)).
+Proof. exact (proj2 (proj2 (even_odd_double n))). Qed.
 
 Hint Resolve even_double double_even odd_double double_odd: arith.
 

--- a/theories/Arith/Gt.v
+++ b/theories/Arith/Gt.v
@@ -23,10 +23,10 @@ Local Open Scope nat_scope.
 (** * Order and successor *)
 
 Theorem gt_Sn_O n : S n > 0.
-Proof Nat.lt_0_succ _.
+Proof. exact (Nat.lt_0_succ _). Qed.
 
 Theorem gt_Sn_n n : S n > n.
-Proof Nat.lt_succ_diag_r _.
+Proof. exact (Nat.lt_succ_diag_r _). Qed.
 
 Theorem gt_n_S n m : n > m -> S n > S m.
 Proof.
@@ -51,12 +51,12 @@ Qed.
 (** * Irreflexivity *)
 
 Lemma gt_irrefl n : ~ n > n.
-Proof Nat.lt_irrefl _.
+Proof. exact (Nat.lt_irrefl _). Qed.
 
 (** * Asymmetry *)
 
 Lemma gt_asym n m : n > m -> ~ m > n.
-Proof Nat.lt_asymm _ _.
+Proof. exact (Nat.lt_asymm _ _). Qed.
 
 (** * Relating strict and large orders *)
 

--- a/theories/Arith/Le.v
+++ b/theories/Arith/Le.v
@@ -48,16 +48,16 @@ Qed.
 (** See also [Nat.succ_le_mono]. *)
 
 Theorem le_n_S : forall n m, n <= m -> S n <= S m.
-Proof Peano.le_n_S.
+Proof. exact (Peano.le_n_S). Qed.
 
 Theorem le_S_n : forall n m, S n <= S m -> n <= m.
-Proof Peano.le_S_n.
+Proof. exact (Peano.le_S_n). Qed.
 
 Notation le_n_Sn := Nat.le_succ_diag_r (compat "8.4"). (* n <= S n *)
 Notation le_Sn_n := Nat.nle_succ_diag_l (compat "8.4"). (* ~ S n <= n *)
 
 Theorem le_Sn_le : forall n m, S n <= m -> n <= m.
-Proof Nat.lt_le_incl.
+Proof. exact (Nat.lt_le_incl). Qed.
 
 Hint Resolve le_0_n le_Sn_0: arith.
 Hint Resolve le_n_S le_n_Sn le_Sn_n : arith.

--- a/theories/Arith/Plus.v
+++ b/theories/Arith/Plus.v
@@ -166,13 +166,13 @@ Proof.
 Qed.
 
 Lemma n_SSn n : n <> S (S n).
-Proof (succ_plus_discr n 1).
+Proof. exact (succ_plus_discr n 1). Qed.
 
 Lemma n_SSSn n : n <> S (S (S n)).
-Proof (succ_plus_discr n 2).
+Proof. exact (succ_plus_discr n 2). Qed.
 
 Lemma n_SSSSn n : n <> S (S (S (S n))).
-Proof (succ_plus_discr n 3).
+Proof. exact (succ_plus_discr n 3). Qed.
 
 
 (** * Compatibility Hints *)

--- a/theories/Arith/Wf_nat.v
+++ b/theories/Arith/Wf_nat.v
@@ -143,7 +143,7 @@ Defined.
 
 Lemma gt_wf_ind :
   forall n (P:nat -> Prop), (forall n, (forall m, n > m -> P m) -> P n) -> P n.
-Proof lt_wf_ind.
+Proof. exact (lt_wf_ind). Qed.
 
 Lemma lt_wf_double_rec :
  forall P:nat -> nat -> Set,

--- a/theories/Logic/Classical_Prop.v
+++ b/theories/Logic/Classical_Prop.v
@@ -92,7 +92,7 @@ tauto.
 Qed.
 
 Lemma proof_irrelevance : forall (P:Prop) (p1 p2:P), p1 = p2.
-Proof proof_irrelevance_cci classic.
+Proof. exact (proof_irrelevance_cci classic). Qed.
 
 (* classical_left  transforms |- A \/ B into ~B |- A *)
 (* classical_right transforms |- A \/ B into ~A |- B *)

--- a/theories/Logic/EqdepFacts.v
+++ b/theories/Logic/EqdepFacts.v
@@ -66,7 +66,7 @@ Section Dependent_Equality.
   Hint Constructors eq_dep: core.
 
   Lemma eq_dep_refl : forall (p:U) (x:P p), eq_dep p x p x.
-  Proof eq_dep_intro.
+  Proof. exact eq_dep_intro. Qed.
 
   Lemma eq_dep_sym :
     forall (p q:U) (x:P p) (y:P q), eq_dep p x q y -> eq_dep q y p x.
@@ -277,8 +277,10 @@ Section Equivalences.
   Qed.
   Lemma eq_rect_eq__eq_dep1_eq :
     Eq_rect_eq -> forall (P:U->Type) (p:U) (x y:P p), eq_dep1 p x p y -> x = y.
-  Proof (fun eq_rect_eq P p y x =>
-           @eq_rect_eq_on__eq_dep1_eq_on p P x (eq_rect_eq p P x) y).
+  Proof.
+    exact (fun eq_rect_eq P p y x =>
+             @eq_rect_eq_on__eq_dep1_eq_on p P x (eq_rect_eq p P x) y).
+  Qed.
 
   Lemma eq_rect_eq_on__eq_dep_eq_on (p : U) (P : U -> Type) (x : P p) :
     Eq_rect_eq_on p P x -> Eq_dep_eq_on P p x.
@@ -288,8 +290,10 @@ Section Equivalences.
     apply eq_dep_sym in H; apply eq_dep_dep1; trivial.
   Qed.
   Lemma eq_rect_eq__eq_dep_eq : Eq_rect_eq -> Eq_dep_eq.
-  Proof (fun eq_rect_eq P p x y =>
-           @eq_rect_eq_on__eq_dep_eq_on p P x (eq_rect_eq p P x) y).
+  Proof.
+    exact (fun eq_rect_eq P p x y =>
+             @eq_rect_eq_on__eq_dep_eq_on p P x (eq_rect_eq p P x) y).
+  Qed.
 
   (** Uniqueness of Identity Proofs (UIP) is a consequence of *)
   (** Injectivity of Dependent Equality *)
@@ -304,8 +308,10 @@ Section Equivalences.
     apply eq_dep_intro.
   Qed.
   Lemma eq_dep_eq__UIP : Eq_dep_eq -> UIP_.
-  Proof (fun eq_dep_eq x y p1 =>
-           @eq_dep_eq_on__UIP_on x y p1 (eq_dep_eq _ _ _)).
+  Proof.
+    exact (fun eq_dep_eq x y p1 =>
+             @eq_dep_eq_on__UIP_on x y p1 (eq_dep_eq _ _ _)).
+  Qed.
 
   (** Uniqueness of Reflexive Identity Proofs is a direct instance of UIP *)
 
@@ -315,8 +321,10 @@ Section Equivalences.
     intro UIP; red; intros; symmetry; apply UIP.
   Qed.
   Lemma UIP__UIP_refl : UIP_ -> UIP_refl_.
-  Proof (fun UIP x p =>
-           @UIP_on__UIP_refl_on x (UIP x x eq_refl) p).
+  Proof.
+    exact (fun UIP x p =>
+             @UIP_on__UIP_refl_on x (UIP x x eq_refl) p).
+  Qed.
 
   (** Streicher's axiom K is a direct consequence of Uniqueness of
       Reflexive Identity Proofs *)
@@ -327,8 +335,10 @@ Section Equivalences.
     intro UIP_refl; red; intros; rewrite UIP_refl; assumption.
   Qed.
   Lemma UIP_refl__Streicher_K : UIP_refl_ -> Streicher_K_.
-  Proof (fun UIP_refl x P =>
-           @UIP_refl_on__Streicher_K_on x P (UIP_refl x)).
+  Proof.
+    exact (fun UIP_refl x P =>
+             @UIP_refl_on__Streicher_K_on x P (UIP_refl x)).
+  Qed.
 
   (** We finally recover from K the Invariance by Substitution of
       Reflexive Equality Proofs *)
@@ -342,8 +352,10 @@ Section Equivalences.
     reflexivity.
   Qed.
   Lemma Streicher_K__eq_rect_eq : Streicher_K_ -> Eq_rect_eq.
-  Proof (fun Streicher_K p P x =>
-           @Streicher_K_on__eq_rect_eq_on p P x (Streicher_K p _)).
+  Proof.
+    exact (fun Streicher_K p P x =>
+             @Streicher_K_on__eq_rect_eq_on p P x (Streicher_K p _)).
+  Qed.
 
 (** Remark: It is reasonable to think that [eq_rect_eq] is strictly
     stronger than [eq_rec_eq] (which is [eq_rect_eq] restricted on [Set]):
@@ -383,8 +395,10 @@ Proof.
     destruct z. destruct (UIP _ _). reflexivity.
 Qed.
 Theorem UIP_shift : forall U, UIP_refl_ U -> forall x:U, UIP_refl_ (x = x).
-Proof (fun U UIP_refl x =>
-         @UIP_shift_on U x (UIP_refl x)).
+Proof.
+  exact (fun U UIP_refl x =>
+           @UIP_shift_on U x (UIP_refl x)).
+Qed.
 
 Section Corollaries.
 
@@ -406,8 +420,10 @@ Section Corollaries.
    assumption.
  Qed.
  Lemma eq_dep_eq__inj_pair2 : Eq_dep_eq U -> Inj_dep_pair.
- Proof (fun eq_dep_eq P p x =>
-          @eq_dep_eq_on__inj_pair2_on P p x (eq_dep_eq P p x)).
+ Proof.
+   exact (fun eq_dep_eq P p x =>
+            @eq_dep_eq_on__inj_pair2_on P p x (eq_dep_eq P p x)).
+ Qed.
 
 End Corollaries.
 
@@ -437,34 +453,34 @@ Module EqdepTheory (M:EqdepElimination).
 
 Lemma eq_rect_eq :
   forall (p:U) (Q:U -> Type) (x:Q p) (h:p = p), x = eq_rect p Q x p h.
-Proof M.eq_rect_eq U.
+Proof. exact (M.eq_rect_eq U). Qed.
 
 Lemma eq_rec_eq :
   forall (p:U) (Q:U -> Set) (x:Q p) (h:p = p), x = eq_rec p Q x p h.
-Proof (fun p Q => M.eq_rect_eq U p Q).
+Proof. exact (fun p Q => M.eq_rect_eq U p Q). Qed.
 
 (** Injectivity of Dependent Equality *)
 
 Lemma eq_dep_eq : forall (P:U->Type) (p:U) (x y:P p), eq_dep p x p y -> x = y.
-Proof (eq_rect_eq__eq_dep_eq U eq_rect_eq).
+Proof. exact (eq_rect_eq__eq_dep_eq U eq_rect_eq). Qed.
 
 (** Uniqueness of Identity Proofs (UIP) is a consequence of *)
 (** Injectivity of Dependent Equality *)
 
 Lemma UIP : forall (x y:U) (p1 p2:x = y), p1 = p2.
-Proof (eq_dep_eq__UIP U eq_dep_eq).
+Proof. exact (eq_dep_eq__UIP U eq_dep_eq). Qed.
 
 (** Uniqueness of Reflexive Identity Proofs is a direct instance of UIP *)
 
 Lemma UIP_refl : forall (x:U) (p:x = x), p = eq_refl x.
-Proof (UIP__UIP_refl U UIP).
+Proof. exact (UIP__UIP_refl U UIP). Qed.
 
 (** Streicher's axiom K is a direct consequence of Uniqueness of
     Reflexive Identity Proofs *)
 
 Lemma Streicher_K :
   forall (x:U) (P:x = x -> Prop), P (eq_refl x) -> forall p:x = x, P p.
-Proof (UIP_refl__Streicher_K U UIP_refl).
+Proof. exact (UIP_refl__Streicher_K U UIP_refl). Qed.
 
 End Axioms.
 
@@ -473,7 +489,7 @@ End Axioms.
 Lemma inj_pair2 :
  forall (U:Type) (P:U -> Type) (p:U) (x y:P p),
    existT P p x = existT P p y -> x = y.
-Proof (fun U => eq_dep_eq__inj_pair2 U (eq_dep_eq U)).
+Proof. exact (fun U => eq_dep_eq__inj_pair2 U (eq_dep_eq U)). Qed.
 
 Notation inj_pairT2 := inj_pair2.
 

--- a/theories/Logic/Eqdep_dec.v
+++ b/theories/Logic/Eqdep_dec.v
@@ -140,16 +140,16 @@ End EqdepDec.
 
 Theorem eq_proofs_unicity A (eq_dec : forall x y : A, x = y \/ x <> y) (x : A)
 : forall (y:A) (p1 p2:x = y), p1 = p2.
-Proof (@eq_proofs_unicity_on A x (eq_dec x)).
+Proof. exact (@eq_proofs_unicity_on A x (eq_dec x)). Qed.
 
 Theorem K_dec A (eq_dec : forall x y : A, x = y \/ x <> y) (x : A)
 : forall P:x = x -> Prop, P (eq_refl x) -> forall p:x = x, P p.
-Proof (@K_dec_on A x (eq_dec x)).
+Proof. exact (@K_dec_on A x (eq_dec x)). Qed.
 
 Theorem inj_right_pair A (eq_dec : forall x y : A, x = y \/ x <> y) (x : A)
 : forall (P:A -> Prop) (y y':P x),
     ex_intro P x y = ex_intro P x y' -> y = y'.
-Proof (@inj_right_pair_on A x (eq_dec x)).
+Proof. exact (@inj_right_pair_on A x (eq_dec x)). Qed.
 
 Require Import EqdepFacts.
 
@@ -169,7 +169,7 @@ Theorem K_dec_set :
   forall A:Set,
     (forall x y:A, {x = y} + {x <> y}) ->
     forall (x:A) (P:x = x -> Prop), P (eq_refl x) -> forall p:x = x, P p.
-Proof fun A => K_dec_type (A:=A).
+Proof. exact (fun A => K_dec_type (A:=A)). Qed.
 
 (** We deduce the [eq_rect_eq] axiom for (decidable) types *)
 Theorem eq_rect_eq_dec :
@@ -186,13 +186,13 @@ Theorem eq_dep_eq_dec :
   forall A:Type,
     (forall x y:A, {x = y} + {x <> y}) ->
      forall (P:A->Type) (p:A) (x y:P p), eq_dep A P p x p y -> x = y.
-Proof (fun A eq_dec => eq_rect_eq__eq_dep_eq A (eq_rect_eq_dec eq_dec)).
+Proof. exact (fun A eq_dec => eq_rect_eq__eq_dep_eq A (eq_rect_eq_dec eq_dec)). Qed.
 
 Theorem UIP_dec :
   forall (A:Type),
     (forall x y:A, {x = y} + {x <> y}) ->
     forall (x y:A) (p1 p2:x = y), p1 = p2.
-Proof (fun A eq_dec => eq_dep_eq__UIP A (eq_dep_eq_dec eq_dec)).
+Proof. exact (fun A eq_dec => eq_dep_eq__UIP A (eq_dep_eq_dec eq_dec)). Qed.
 
 Unset Implicit Arguments.
 
@@ -219,36 +219,36 @@ Module DecidableEqDep (M:DecidableType).
 
   Lemma eq_rect_eq :
     forall (p:U) (Q:U -> Type) (x:Q p) (h:p = p), x = eq_rect p Q x p h.
-  Proof eq_rect_eq_dec eq_dec.
+  Proof. exact (eq_rect_eq_dec eq_dec). Qed.
 
   (** Injectivity of Dependent Equality *)
 
   Theorem eq_dep_eq :
     forall (P:U->Type) (p:U) (x y:P p), eq_dep U P p x p y -> x = y.
-  Proof (eq_rect_eq__eq_dep_eq U eq_rect_eq).
+  Proof. exact (eq_rect_eq__eq_dep_eq U eq_rect_eq). Qed.
 
   (** Uniqueness of Identity Proofs (UIP) *)
 
   Lemma UIP : forall (x y:U) (p1 p2:x = y), p1 = p2.
-  Proof (eq_dep_eq__UIP U eq_dep_eq).
+  Proof. exact (eq_dep_eq__UIP U eq_dep_eq). Qed.
 
   (** Uniqueness of Reflexive Identity Proofs *)
 
   Lemma UIP_refl : forall (x:U) (p:x = x), p = eq_refl x.
-  Proof (UIP__UIP_refl U UIP).
+  Proof. exact (UIP__UIP_refl U UIP). Qed.
 
   (** Streicher's axiom K *)
 
   Lemma Streicher_K :
     forall (x:U) (P:x = x -> Prop), P (eq_refl x) -> forall p:x = x, P p.
-  Proof (K_dec_type eq_dec).
+  Proof. exact (K_dec_type eq_dec). Qed.
 
   (** Injectivity of equality on dependent pairs in [Type] *)
 
   Lemma inj_pairT2 :
     forall (P:U -> Type) (p:U) (x y:P p),
       existT P p x = existT P p y -> x = y.
-  Proof eq_dep_eq__inj_pairT2 U eq_dep_eq.
+  Proof. exact (eq_dep_eq__inj_pairT2 U eq_dep_eq). Qed.
 
   (** Proof-irrelevance on subsets of decidable sets *)
 
@@ -288,43 +288,43 @@ Module DecidableEqDepSet (M:DecidableSet).
 
   Lemma eq_rect_eq :
     forall (p:U) (Q:U -> Type) (x:Q p) (h:p = p), x = eq_rect p Q x p h.
-  Proof eq_rect_eq_dec eq_dec.
+  Proof. exact (eq_rect_eq_dec eq_dec). Qed.
 
   (** Injectivity of Dependent Equality *)
 
   Theorem eq_dep_eq :
     forall (P:U->Type) (p:U) (x y:P p), eq_dep U P p x p y -> x = y.
-  Proof (eq_rect_eq__eq_dep_eq U eq_rect_eq).
+  Proof. exact (eq_rect_eq__eq_dep_eq U eq_rect_eq). Qed.
 
   (** Uniqueness of Identity Proofs (UIP) *)
 
   Lemma UIP : forall (x y:U) (p1 p2:x = y), p1 = p2.
-  Proof (eq_dep_eq__UIP U eq_dep_eq).
+  Proof. exact (eq_dep_eq__UIP U eq_dep_eq). Qed.
 
   (** Uniqueness of Reflexive Identity Proofs *)
 
   Lemma UIP_refl : forall (x:U) (p:x = x), p = eq_refl x.
-  Proof (UIP__UIP_refl U UIP).
+  Proof. exact (UIP__UIP_refl U UIP). Qed.
 
   (** Streicher's axiom K *)
 
   Lemma Streicher_K :
     forall (x:U) (P:x = x -> Prop), P (eq_refl x) -> forall p:x = x, P p.
-  Proof (K_dec_type eq_dec).
+  Proof. exact (K_dec_type eq_dec). Qed.
 
   (** Proof-irrelevance on subsets of decidable sets *)
 
   Lemma inj_pairP2 :
     forall (P:U -> Prop) (x:U) (p q:P x),
       ex_intro P x p = ex_intro P x q -> p = q.
-  Proof N.inj_pairP2.
+  Proof. exact (N.inj_pairP2). Qed.
 
   (** Injectivity of equality on dependent pairs in [Type] *)
 
   Lemma inj_pair2 :
     forall (P:U -> Type) (p:U) (x y:P p),
       existT P p x = existT P p y -> x = y.
-  Proof eq_dep_eq__inj_pair2 U N.eq_dep_eq.
+  Proof. exact (eq_dep_eq__inj_pair2 U N.eq_dep_eq). Qed.
 
   (** Injectivity of equality on dependent pairs with second component
       in [Type] *)

--- a/theories/NArith/BinNat.v
+++ b/theories/NArith/BinNat.v
@@ -1050,15 +1050,15 @@ Notation Ngt_Nlt := N.gt_lt (compat "8.3").
     (to preserve scopes for instance) *)
 
 Lemma Nplus_reg_l n m p : n + m = n + p -> m = p.
-Proof (proj1 (N.add_cancel_l m p n)).
+Proof. exact (proj1 (N.add_cancel_l m p n)). Qed.
 Lemma Nmult_Sn_m n m : N.succ n * m = m + n * m.
-Proof (eq_trans (N.mul_succ_l n m) (N.add_comm _ _)).
+Proof. exact (eq_trans (N.mul_succ_l n m) (N.add_comm _ _)). Qed.
 Lemma Nmult_plus_distr_l n m p : p * (n + m) = p * n + p * m.
-Proof (N.mul_add_distr_l p n m).
+Proof. exact (N.mul_add_distr_l p n m). Qed.
 Lemma Nmult_reg_r n m p : p <> 0 -> n * p = m * p -> n = m.
-Proof (fun H => proj1 (N.mul_cancel_r n m p H)).
+Proof. exact (fun H => proj1 (N.mul_cancel_r n m p H)). Qed.
 Lemma Ncompare_antisym n m : CompOpp (n ?= m) = (m ?= n).
-Proof (eq_sym (N.compare_antisym n m)).
+Proof. exact (eq_sym (N.compare_antisym n m)). Qed.
 
 Definition N_ind_double a P f0 f2 fS2 := N.binary_ind P f0 f2 fS2 a.
 Definition N_rec_double a P f0 f2 fS2 := N.binary_rec P f0 f2 fS2 a.

--- a/theories/Numbers/NatInt/NZOrder.v
+++ b/theories/Numbers/NatInt/NZOrder.v
@@ -559,14 +559,14 @@ Theorem order_induction_0 :
   (forall n, 0 <= n -> A n -> A (S n)) ->
   (forall n, n < 0  -> A (S n) -> A n) ->
     forall n, A n.
-Proof (order_induction 0).
+Proof. exact (order_induction 0). Qed.
 
 Theorem order_induction'_0 :
   A 0 ->
   (forall n, 0 <= n -> A n -> A (S n)) ->
   (forall n, n <= 0 -> A n -> A (P n)) ->
     forall n, A n.
-Proof (order_induction' 0).
+Proof. exact (order_induction' 0). Qed.
 
 (** Elimintation principle for < *)
 

--- a/theories/PArith/BinPos.v
+++ b/theories/PArith/BinPos.v
@@ -2086,17 +2086,17 @@ Proof. apply Pos.eqb_eq. Qed.
 Lemma Pcompare_eq_Gt p q : (p ?= q) = Gt <-> p > q.
 Proof. reflexivity. Qed.
 Lemma Pplus_one_succ_r p : Pos.succ p = p + 1.
-Proof (eq_sym (Pos.add_1_r p)).
+Proof. exact (eq_sym (Pos.add_1_r p)). Qed.
 Lemma Pplus_one_succ_l p : Pos.succ p = 1 + p.
-Proof (eq_sym (Pos.add_1_l p)).
+Proof. exact (eq_sym (Pos.add_1_l p)). Qed.
 Lemma Pcompare_refl p : Pos.compare_cont Eq p p = Eq.
-Proof (Pos.compare_cont_refl p Eq).
+Proof. exact (Pos.compare_cont_refl p Eq). Qed.
 Lemma Pcompare_Eq_eq : forall p q, Pos.compare_cont Eq p q = Eq -> p = q.
-Proof Pos.compare_eq.
+Proof. exact (Pos.compare_eq). Qed.
 Lemma ZC4 p q : Pos.compare_cont Eq p q = CompOpp (Pos.compare_cont Eq q p).
-Proof (Pos.compare_antisym q p).
+Proof. exact (Pos.compare_antisym q p). Qed.
 Lemma Ppred_minus p : Pos.pred p = p - 1.
-Proof (eq_sym (Pos.sub_1_r p)).
+Proof. exact (eq_sym (Pos.sub_1_r p)). Qed.
 
 Lemma Pminus_mask_Gt p q :
   p > q ->

--- a/theories/PArith/Pnat.v
+++ b/theories/PArith/Pnat.v
@@ -416,23 +416,23 @@ Notation pred_o_P_of_succ_nat_o_nat_of_P_eq_id := Pos2SuccNat.pred_id (compat "8
 Lemma nat_of_P_minus_morphism p q :
  Pos.compare_cont Eq p q = Gt ->
   Pos.to_nat (p - q) = Pos.to_nat p - Pos.to_nat q.
-Proof (fun H => Pos2Nat.inj_sub p q (Pos.gt_lt _ _ H)).
+Proof. exact (fun H => Pos2Nat.inj_sub p q (Pos.gt_lt _ _ H)). Qed.
 
 Lemma nat_of_P_lt_Lt_compare_morphism p q :
  Pos.compare_cont Eq p q = Lt -> Pos.to_nat p < Pos.to_nat q.
-Proof (proj1 (Pos2Nat.inj_lt p q)).
+Proof. exact (proj1 (Pos2Nat.inj_lt p q)). Qed.
 
 Lemma nat_of_P_gt_Gt_compare_morphism p q :
  Pos.compare_cont Eq p q = Gt -> Pos.to_nat p > Pos.to_nat q.
-Proof (proj1 (Pos2Nat.inj_gt p q)).
+Proof. exact (proj1 (Pos2Nat.inj_gt p q)). Qed.
 
 Lemma nat_of_P_lt_Lt_compare_complement_morphism p q :
  Pos.to_nat p < Pos.to_nat q -> Pos.compare_cont Eq p q = Lt.
-Proof (proj2 (Pos2Nat.inj_lt p q)).
+Proof. exact (proj2 (Pos2Nat.inj_lt p q)). Qed.
 
 Definition nat_of_P_gt_Gt_compare_complement_morphism p q :
  Pos.to_nat p > Pos.to_nat q -> Pos.compare_cont Eq p q = Gt.
-Proof (proj2 (Pos2Nat.inj_gt p q)).
+Proof. exact (proj2 (Pos2Nat.inj_gt p q)). Qed.
 
 (** Old intermediate results about [Pmult_nat] *)
 

--- a/theories/Reals/RIneq.v
+++ b/theories/Reals/RIneq.v
@@ -1277,7 +1277,7 @@ Lemma Rmult_lt_0_compat : forall r1 r2, 0 < r1 -> 0 < r2 -> 0 < r1 * r2.
 Proof. intros; replace 0 with (0 * r2); auto with real. Qed.
 
 Lemma Rmult_gt_0_compat : forall r1 r2, r1 > 0 -> r2 > 0 -> r1 * r2 > 0.
-Proof Rmult_lt_0_compat.
+Proof. exact (Rmult_lt_0_compat). Qed.
 
 (** *** Contravariant compatibility *)
 

--- a/theories/ZArith/BinInt.v
+++ b/theories/ZArith/BinInt.v
@@ -1671,62 +1671,62 @@ Notation SYM2 lem := (fun n m => eq_sym (lem n m)).
 Notation SYM3 lem := (fun n m p => eq_sym (lem n m p)).
 
 Lemma Zplus_assoc_reverse : forall n m p, n+m+p = n+(m+p).
-Proof (SYM3 Z.add_assoc).
+Proof. exact (SYM3 Z.add_assoc). Qed.
 Lemma Zplus_succ_r_reverse : forall n m, Z.succ (n+m) = n+Z.succ m.
-Proof (SYM2 Z.add_succ_r).
+Proof. exact (SYM2 Z.add_succ_r). Qed.
 Notation Zplus_succ_r := Zplus_succ_r_reverse (only parsing).
 Lemma Zplus_0_r_reverse : forall n, n = n + 0.
-Proof (SYM1 Z.add_0_r).
+Proof. exact (SYM1 Z.add_0_r). Qed.
 Lemma Zplus_eq_compat : forall n m p q, n=m -> p=q -> n+p=m+q.
-Proof (f_equal2 Z.add).
+Proof. exact (f_equal2 Z.add). Qed.
 Lemma Zsucc_pred : forall n, n = Z.succ (Z.pred n).
-Proof (SYM1 Z.succ_pred).
+Proof. exact (SYM1 Z.succ_pred). Qed.
 Lemma Zpred_succ : forall n, n = Z.pred (Z.succ n).
-Proof (SYM1 Z.pred_succ).
+Proof. exact (SYM1 Z.pred_succ). Qed.
 Lemma Zsucc_eq_compat : forall n m, n = m -> Z.succ n = Z.succ m.
-Proof (f_equal Z.succ).
+Proof. exact (f_equal Z.succ). Qed.
 Lemma Zminus_0_l_reverse : forall n, n = n - 0.
-Proof (SYM1 Z.sub_0_r).
+Proof. exact (SYM1 Z.sub_0_r). Qed.
 Lemma Zminus_diag_reverse : forall n, 0 = n-n.
-Proof (SYM1 Z.sub_diag).
+Proof. exact (SYM1 Z.sub_diag). Qed.
 Lemma Zminus_succ_l : forall n m, Z.succ (n - m) = Z.succ n - m.
-Proof (SYM2 Z.sub_succ_l).
+Proof. exact (SYM2 Z.sub_succ_l). Qed.
 Lemma Zplus_minus_eq : forall n m p, n = m + p -> p = n - m.
 Proof. intros. now apply Z.add_move_l. Qed.
 Lemma Zplus_minus : forall n m, n + (m - n) = m.
-Proof (fun n m => eq_trans (Z.add_comm n (m-n)) (Z.sub_add n m)).
+Proof. exact (fun n m => eq_trans (Z.add_comm n (m-n)) (Z.sub_add n m)). Qed.
 Lemma Zminus_plus_simpl_l : forall n m p, p + n - (p + m) = n - m.
-Proof (fun n m p => Z.add_add_simpl_l_l p n m).
+Proof. exact (fun n m p => Z.add_add_simpl_l_l p n m). Qed.
 Lemma Zminus_plus_simpl_l_reverse : forall n m p, n - m = p + n - (p + m).
-Proof (SYM3 Zminus_plus_simpl_l).
+Proof. exact (SYM3 Zminus_plus_simpl_l). Qed.
 Lemma Zminus_plus_simpl_r : forall n m p, n + p - (m + p) = n - m.
-Proof (fun n m p => Z.add_add_simpl_r_r n p m).
+Proof. exact (fun n m p => Z.add_add_simpl_r_r n p m). Qed.
 Lemma Zeq_minus : forall n m, n = m -> n - m = 0.
-Proof (fun n m => proj2 (Z.sub_move_0_r n m)).
+Proof. exact (fun n m => proj2 (Z.sub_move_0_r n m)). Qed.
 Lemma Zminus_eq : forall n m, n - m = 0 -> n = m.
-Proof (fun n m => proj1 (Z.sub_move_0_r n m)).
+Proof. exact (fun n m => proj1 (Z.sub_move_0_r n m)). Qed.
 Lemma Zmult_0_r_reverse : forall n, 0 = n * 0.
-Proof (SYM1 Z.mul_0_r).
+Proof. exact (SYM1 Z.mul_0_r). Qed.
 Lemma Zmult_assoc_reverse : forall n m p, n * m * p = n * (m * p).
-Proof (SYM3 Z.mul_assoc).
+Proof. exact (SYM3 Z.mul_assoc). Qed.
 Lemma Zmult_integral : forall n m, n * m = 0 -> n = 0 \/ m = 0.
-Proof (fun n m => proj1 (Z.mul_eq_0 n m)).
+Proof. exact (fun n m => proj1 (Z.mul_eq_0 n m)). Qed.
 Lemma Zmult_integral_l : forall n m, n <> 0 -> m * n = 0 -> m = 0.
-Proof (fun n m H H' => Z.mul_eq_0_l m n H' H).
+Proof. exact (fun n m H H' => Z.mul_eq_0_l m n H' H). Qed.
 Lemma Zopp_mult_distr_l : forall n m, - (n * m) = - n * m.
-Proof (SYM2 Z.mul_opp_l).
+Proof. exact (SYM2 Z.mul_opp_l). Qed.
 Lemma Zopp_mult_distr_r : forall n m, - (n * m) = n * - m.
-Proof (SYM2 Z.mul_opp_r).
+Proof. exact (SYM2 Z.mul_opp_r). Qed.
 Lemma Zmult_minus_distr_l : forall n m p, p * (n - m) = p * n - p * m.
-Proof (fun n m p => Z.mul_sub_distr_l p n m).
+Proof. exact (fun n m p => Z.mul_sub_distr_l p n m). Qed.
 Lemma Zmult_succ_r_reverse : forall n m, n * m + n = n * Z.succ m.
-Proof (SYM2 Z.mul_succ_r).
+Proof. exact (SYM2 Z.mul_succ_r). Qed.
 Lemma Zmult_succ_l_reverse : forall n m, n * m + m = Z.succ n * m.
-Proof (SYM2 Z.mul_succ_l).
+Proof. exact (SYM2 Z.mul_succ_l). Qed.
 Lemma Zpos_eq : forall p q, p = q -> Z.pos p = Z.pos q.
 Proof. congruence. Qed.
 Lemma Zpos_eq_iff : forall p q, p = q <-> Z.pos p = Z.pos q.
-Proof (fun p q => iff_sym (Pos2Z.inj_iff p q)).
+Proof. exact (fun p q => iff_sym (Pos2Z.inj_iff p q)). Qed.
 
 Hint Immediate Zsucc_pred: zarith.
 

--- a/theories/ZArith/ZArith_dec.v
+++ b/theories/ZArith/ZArith_dec.v
@@ -194,8 +194,8 @@ Proof.
 Defined.
 
 Corollary Z_notzerop : forall (x:Z), {x <> 0} + {x = 0}.
-Proof (fun x => sumbool_not _ _ (Z_zerop x)).
+Proof. exact (fun x => sumbool_not _ _ (Z_zerop x)). Qed.
 
 Corollary Z_noteq_dec : forall (x y:Z), {x <> y} + {x = y}.
-Proof (fun x y => sumbool_not _ _ (Z.eq_dec x y)).
+Proof. exact (fun x y => sumbool_not _ _ (Z.eq_dec x y)). Qed.
 (* end hide *)

--- a/theories/ZArith/Zcompare.v
+++ b/theories/ZArith/Zcompare.v
@@ -23,16 +23,16 @@ Local Open Scope Z_scope.
 (** * Comparison on integers *)
 
 Lemma Zcompare_Gt_Lt_antisym : forall n m:Z, (n ?= m) = Gt <-> (m ?= n) = Lt.
-Proof Z.gt_lt_iff.
+Proof. exact (Z.gt_lt_iff). Qed.
 
 Lemma Zcompare_antisym n m : CompOpp (n ?= m) = (m ?= n).
-Proof eq_sym (Z.compare_antisym n m).
+Proof. exact (eq_sym (Z.compare_antisym n m)). Qed.
 
 (** * Transitivity of comparison *)
 
 Lemma Zcompare_Lt_trans :
   forall n m p:Z, (n ?= m) = Lt -> (m ?= p) = Lt -> (n ?= p) = Lt.
-Proof Z.lt_trans.
+Proof. exact (Z.lt_trans). Qed.
 
 Lemma Zcompare_Gt_trans :
   forall n m p:Z, (n ?= m) = Gt -> (m ?= p) = Gt -> (n ?= p) = Gt.

--- a/theories/ZArith/Zdiv.v
+++ b/theories/ZArith/Zdiv.v
@@ -98,10 +98,10 @@ Proof.
 Qed.
 
 Lemma Z_mod_lt a b : b > 0 -> 0 <= a mod b < b.
-Proof (fun Hb => Z.mod_pos_bound a b (Z.gt_lt _ _ Hb)).
+Proof. exact (fun Hb => Z.mod_pos_bound a b (Z.gt_lt _ _ Hb)). Qed.
 
 Lemma Z_mod_neg a b : b < 0 -> b < a mod b <= 0.
-Proof (Z.mod_neg_bound a b).
+Proof. exact (Z.mod_neg_bound a b). Qed.
 
 Lemma Z_div_mod_eq a b : b > 0 -> a = b*(a/b) + (a mod b).
 Proof.
@@ -144,12 +144,12 @@ Theorem Zdiv_mod_unique_2 :
  forall b q1 q2 r1 r2:Z,
   Remainder r1 b -> Remainder r2 b ->
   b*q1+r1 = b*q2+r2 -> q1=q2 /\ r1=r2.
-Proof Z.div_mod_unique.
+Proof. exact (Z.div_mod_unique). Qed.
 
 Theorem Zdiv_unique_full:
  forall a b q r, Remainder r b ->
    a = b*q + r -> q = a/b.
-Proof Z.div_unique.
+Proof. exact (Z.div_unique). Qed.
 
 Theorem Zdiv_unique:
  forall a b q r, 0 <= r < b ->
@@ -159,7 +159,7 @@ Proof. intros; eapply Zdiv_unique_full; eauto. Qed.
 Theorem Zmod_unique_full:
  forall a b q r, Remainder r b ->
   a = b*q + r ->  r = a mod b.
-Proof Z.mod_unique.
+Proof. exact (Z.mod_unique). Qed.
 
 Theorem Zmod_unique:
  forall a b q r, 0 <= r < b ->
@@ -203,13 +203,13 @@ Hint Resolve Zmod_0_l Zmod_0_r Zdiv_0_l Zdiv_0_r Zdiv_1_r Zmod_1_r
  : zarith.
 
 Lemma Zdiv_1_l: forall a, 1 < a -> 1/a = 0.
-Proof Z.div_1_l.
+Proof. exact (Z.div_1_l). Qed.
 
 Lemma Zmod_1_l: forall a, 1 < a ->  1 mod a = 1.
-Proof Z.mod_1_l.
+Proof. exact (Z.mod_1_l). Qed.
 
 Lemma Z_div_same_full : forall a:Z, a<>0 -> a/a = 1.
-Proof Z.div_same.
+Proof. exact (Z.div_same). Qed.
 
 Lemma Z_mod_same_full : forall a, a mod a = 0.
 Proof. intros. zero_or_not a. apply Z.mod_same; auto. Qed.
@@ -218,7 +218,7 @@ Lemma Z_mod_mult : forall a b, (a*b) mod b = 0.
 Proof. intros. zero_or_not b. apply Z.mod_mul. auto. Qed.
 
 Lemma Z_div_mult_full : forall a b:Z, b <> 0 -> (a*b)/b = a.
-Proof Z.div_mul.
+Proof. exact (Z.div_mul). Qed.
 
 (** * Order results about Z.modulo and Z.div *)
 
@@ -241,12 +241,12 @@ Proof. intros. apply Z.div_lt; auto with zarith. Qed.
 (** A division of a small number by a bigger one yields zero. *)
 
 Theorem Zdiv_small: forall a b, 0 <= a < b -> a/b = 0.
-Proof Z.div_small.
+Proof. exact (Z.div_small). Qed.
 
 (** Same situation, in term of modulo: *)
 
 Theorem Zmod_small: forall a n, 0 <= a < n -> a mod n = a.
-Proof Z.mod_small.
+Proof. exact (Z.mod_small). Qed.
 
 (** [Z.ge] is compatible with a positive division. *)
 
@@ -313,10 +313,10 @@ Lemma Z_mod_plus_full : forall a b c:Z, (a + b * c) mod c = a mod c.
 Proof. intros. zero_or_not c. apply Z.mod_add; auto. Qed.
 
 Lemma Z_div_plus_full : forall a b c:Z, c <> 0 -> (a + b * c) / c = a / c + b.
-Proof Z.div_add.
+Proof. exact (Z.div_add). Qed.
 
 Theorem Z_div_plus_full_l: forall a b c : Z, b <> 0 -> (a * b + c) / b = a + c / b.
-Proof Z.div_add_l.
+Proof. exact (Z.div_add_l). Qed.
 
 (** [Z.opp] and [Z.div], [Z.modulo].
     Due to the choice of convention for our Euclidean division,
@@ -527,7 +527,7 @@ Qed.
 (** Particular case : dividing by 2 is related with parity *)
 
 Lemma Zdiv2_div : forall a, Z.div2 a = a/2.
-Proof Z.div2_div.
+Proof. exact (Z.div2_div). Qed.
 
 Lemma Zmod_odd : forall a, a mod 2 = if Z.odd a then 1 else 0.
 Proof.

--- a/theories/ZArith/Zeven.v
+++ b/theories/ZArith/Zeven.v
@@ -51,10 +51,10 @@ Proof.
 Qed.
 
 Theorem Zeven_ex_iff n : Zeven n <-> exists m, n = 2*m.
-Proof (Zeven_equiv n).
+Proof. exact (Zeven_equiv n). Qed.
 
 Theorem Zodd_ex_iff n : Zodd n <-> exists m, n = 2*m + 1.
-Proof (Zodd_equiv n).
+Proof. exact (Zodd_equiv n). Qed.
 
 (** Boolean tests of parity (now in BinInt.Z) *)
 
@@ -145,7 +145,7 @@ Notation Zquot2 := Z.quot2 (compat "8.3").
 (** Properties of [Z.div2] *)
 
 Lemma Zdiv2_odd_eqn n : n = 2*(Z.div2 n) + if Z.odd n then 1 else 0.
-Proof (Z.div2_odd n).
+Proof. exact (Z.div2_odd n). Qed.
 
 Lemma Zeven_div2 n : Zeven n -> n = 2 * Z.div2 n.
 Proof.

--- a/theories/ZArith/Znat.v
+++ b/theories/ZArith/Znat.v
@@ -939,7 +939,7 @@ Lemma inj_neq n m : neq n m -> Zne (Z.of_nat n) (Z.of_nat m).
 Proof. intros H H'. now apply H, Nat2Z.inj. Qed.
 
 Lemma Zpos_P_of_succ_nat n : Zpos (Pos.of_succ_nat n) = Z.succ (Z.of_nat n).
-Proof (Nat2Z.inj_succ n).
+Proof. exact (Nat2Z.inj_succ n). Qed.
 
 (** For these one, used in omega, a Definition is necessary *)
 

--- a/theories/ZArith/Zpow_facts.v
+++ b/theories/ZArith/Zpow_facts.v
@@ -18,7 +18,7 @@ Local Open Scope Z_scope.
     primality. *)
 
 Lemma Zpower_pos_1_r x : Z.pow_pos x 1 = x.
-Proof (Z.pow_1_r x).
+Proof. exact (Z.pow_1_r x). Qed.
 
 Lemma Zpower_pos_1_l p : Z.pow_pos 1 p = 1.
 Proof. now apply (Z.pow_1_l (Zpos p)). Qed.

--- a/theories/ZArith/Zpower.v
+++ b/theories/ZArith/Zpower.v
@@ -198,7 +198,7 @@ Section Powers_of_2.
   Qed.
 
   Lemma two_p_correct x : two_p x = 2^x.
-  Proof (two_p_equiv x).
+  Proof. exact (two_p_equiv x). Qed.
 
   Theorem two_p_is_exp x y :
     0 <= x -> 0 <= y -> two_p (x + y) = two_p x * two_p y.

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -503,12 +503,22 @@ let vernac_end_proof ?proof = function
   | Admitted          -> save_proof ?proof Admitted
   | Proved (_,_) as e -> save_proof ?proof e
 
+
+(* This is deprecated *)
+
 let vernac_exact_proof c =
   (* spiwack: for simplicity I do not enforce that "Proof proof_term" is
      called only at the begining of a proof. *)
   let status = Pfedit.by (Tactics.exact_proof c) in
   save_proof (Vernacexpr.(Proved(Opaque None,None)));
   if not status then Feedback.feedback Feedback.AddedAxiom
+
+let warn_deprecated_exact_proof =
+  CWarnings.create ~name:"deprecated-exact-proof" ~category:"deprecated"
+                   (fun c -> Pp.(
+                      str "This syntax is deprecated. Use \"Proof. exact "
+                      ++ Ppconstr.pr_constr_expr c
+                      ++ str ". Qed.\" instead."))
 
 let vernac_assumption locality poly (local, kind) l nl =
   let local = enforce_locality_exp locality local in
@@ -1935,7 +1945,8 @@ let interp ?proof ?loc locality poly c =
   | VernacDefinition (k,lid,d) -> vernac_definition locality poly k lid d
   | VernacStartTheoremProof (k,l) -> vernac_start_proof locality poly k l
   | VernacEndProof e -> vernac_end_proof ?proof e
-  | VernacExactProof c -> vernac_exact_proof c
+  | VernacExactProof c ->
+     warn_deprecated_exact_proof ?loc c; vernac_exact_proof c
   | VernacAssumption (stre,nl,l) -> vernac_assumption locality poly stre l nl
   | VernacInductive (cum, priv,finite,l) -> vernac_inductive cum poly priv finite l
   | VernacFixpoint (local, l) -> vernac_fixpoint locality poly local l


### PR DESCRIPTION
As suggested by @ejgallego after discussion, we deprecate this syntax in 8.7 so as to be able to remove it in 8.8. This syntax has many open bugs (see e.g. [bug 5592](https://coq.inria.fr/bugs/show_bug.cgi?id=5592)).

The biggest part of this PR was to remove all uses of this syntax in the standard library (because we don't want to warn about something that we are using all over the place). Most of this removal was done with `sed` while multi-line cases were removed by hand with the help of `-w "+deprecated-exact-proof"`. (BTW I would have expected `-warn-error` to turn Coq warnings into errors as well but this is not the case AFAICS).

FTR I want to work at providing an alternative of the form `Lemma :=` but this deprecation doesn't need to wait for this alternative because there already is a forward-backward compatible alternative in the form of `Proof. exact term. Qed.`

This somewhat closes the discussion started at #412.