### PR TITLE
[v8.6] Display timing data on v8.6 travis

### DIFF
--- a/dev/ci/ci-bedrock-facade.sh
+++ b/dev/ci/ci-bedrock-facade.sh
@@ -6,5 +6,6 @@ source ${ci_dir}/ci-common.sh
 bedrock_facade_CI_DIR=${CI_BUILD_DIR}/bedrock-facade
 
 git_checkout ${bedrock_facade_CI_BRANCH} ${bedrock_facade_CI_GITURL} ${bedrock_facade_CI_DIR}
+( cd ${bedrock_facade_CI_DIR} && git submodule update --init --recursive )
 
-( cd ${bedrock_facade_CI_DIR} && make facade )
+( cd ${bedrock_facade_CI_DIR} && (make facade TIMED=1 2>&1 | tee time-of-build.log; exit ${PIPESTATUS[0]}) && python ./etc/coq-scripts/timing/make-one-time-file.py time-of-build.log time-of-build-pretty.log && cat time-of-build-pretty.log )

--- a/dev/ci/ci-bedrock-src.sh
+++ b/dev/ci/ci-bedrock-src.sh
@@ -6,5 +6,6 @@ source ${ci_dir}/ci-common.sh
 bedrock_src_CI_DIR=${CI_BUILD_DIR}/bedrock-src
 
 git_checkout ${bedrock_src_CI_BRANCH} ${bedrock_src_CI_GITURL} ${bedrock_src_CI_DIR}
+( cd ${bedrock_src_CI_DIR} && git submodule update --init --recursive )
 
-( cd ${bedrock_src_CI_DIR} && make src )
+( cd ${bedrock_src_CI_DIR} && (make src TIMED=1 2>&1 | tee time-of-build.log; exit ${PIPESTATUS[0]}) && python ./etc/coq-scripts/timing/make-one-time-file.py time-of-build.log time-of-build-pretty.log && cat time-of-build-pretty.log )

--- a/dev/ci/ci-fiat-crypto.sh
+++ b/dev/ci/ci-fiat-crypto.sh
@@ -8,4 +8,4 @@ fiat_crypto_CI_DIR=${CI_BUILD_DIR}/fiat-crypto
 git_checkout ${fiat_crypto_CI_BRANCH} ${fiat_crypto_CI_GITURL} ${fiat_crypto_CI_DIR}
 ( cd ${fiat_crypto_CI_DIR} && git submodule update --init --recursive )
 
-( cd ${fiat_crypto_CI_DIR} && make lite )
+( cd ${fiat_crypto_CI_DIR} && (make lite TIMED=1 2>&1 | tee time-of-build.log; exit ${PIPESTATUS[0]}) && python ./etc/coq-scripts/timing/make-one-time-file.py time-of-build.log time-of-build-pretty.log && cat time-of-build-pretty.log )

--- a/dev/ci/ci-fiat-parsers.sh
+++ b/dev/ci/ci-fiat-parsers.sh
@@ -6,5 +6,6 @@ source ${ci_dir}/ci-common.sh
 fiat_parsers_CI_DIR=${CI_BUILD_DIR}/fiat
 
 git_checkout ${fiat_parsers_CI_BRANCH} ${fiat_parsers_CI_GITURL} ${fiat_parsers_CI_DIR}
+( cd ${fiat_parsers_CI_DIR} && git submodule update --init --recursive )
 
-( cd ${fiat_parsers_CI_DIR} && make parsers parsers-examples )
+( cd ${fiat_parsers_CI_DIR} && (make parsers parsers-examples TIMED=1 2>&1 | tee time-of-build.log; exit ${PIPESTATUS[0]}) && python ./etc/coq-scripts/timing/make-one-time-file.py time-of-build.log time-of-build-pretty.log && cat time-of-build-pretty.log )

--- a/dev/ci/ci-hott.sh
+++ b/dev/ci/ci-hott.sh
@@ -6,5 +6,6 @@ source ${ci_dir}/ci-common.sh
 HoTT_CI_DIR=${CI_BUILD_DIR}/HoTT
 
 git_checkout ${HoTT_CI_BRANCH} ${HoTT_CI_GITURL} ${HoTT_CI_DIR}
+( cd ${HoTT_CI_DIR} && git submodule update --init --recursive )
 
-( cd ${HoTT_CI_DIR} && ./autogen.sh && ./configure && make )
+( cd ${HoTT_CI_DIR} && ./autogen.sh && ./configure && (make TIMED=1 2>&1 | tee time-of-build.log; exit ${PIPESTATUS[0]}) && python ./etc/coq-scripts/timing/make-one-time-file.py time-of-build.log time-of-build-pretty.log && cat time-of-build-pretty.log )


### PR DESCRIPTION
This is especially useful for failures in fiat-crypto, though I went ahead and added timing data for the other projects that support it in v8.6 (fiat, bedrock, HoTT).

It's not clear to me whether this should be merged before or after 8.6.1; certainly 98386c3 doesn't belong in trunk, assuming we can get #745 (and #746, which is only about the ci) into 8.7.
