### PR TITLE
Adding support for recursive notations of the form "x , .. , y , z".

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,10 @@
+To be inserted at the proper place:
+
+Notations
+
+- Recursive notations with the recursive pattern repeating on the
+  right (e.g. "( x ; .. ; y ; z )") now supported.
+
 Changes beyond V8.6
 ===================
 

--- a/intf/notation_term.ml
+++ b/intf/notation_term.ml
@@ -83,9 +83,10 @@ type notation_interp_env = {
 type grammar_constr_prod_item =
   | GramConstrTerminal of Tok.t
   | GramConstrNonTerminal of Extend.constr_prod_entry_key * Id.t option
-  | GramConstrListMark of int * bool
+  | GramConstrListMark of int * bool * int
     (* tells action rule to make a list of the n previous parsed items;
-       concat with last parsed list if true *)
+       concat with last parsed list when true; additionally release
+       the p last items as if they were parsed autonomously *)
 
 type notation_grammar = {
   notgram_level : int;

--- a/parsing/egramcoq.ml
+++ b/parsing/egramcoq.ml
@@ -354,7 +354,7 @@ type (_, _) ty_symbol =
 type ('self, _, 'r) ty_rule =
 | TyStop : ('self, 'r, 'r) ty_rule
 | TyNext : ('self, 'a, 'r) ty_rule * ('self, 'b) ty_symbol -> ('self, 'b -> 'a, 'r) ty_rule
-| TyMark : int * bool * ('self, 'a, 'r) ty_rule -> ('self, 'a, 'r) ty_rule
+| TyMark : int * bool * int * ('self, 'a, 'r) ty_rule -> ('self, 'a, 'r) ty_rule
 
 type 'r gen_eval = Loc.t -> 'r env -> 'r
 
@@ -368,18 +368,27 @@ let rec ty_eval : type s a. (s, a, Loc.t -> s) ty_rule -> s gen_eval -> s env ->
 | TyNext (rem, TyNonTerm (forpat, e, _, true)) ->
   fun f env v ->
     ty_eval rem f (push_item forpat e env v)
-| TyMark (n, b, rem) ->
+| TyMark (n, b, p, rem) ->
   fun f env ->
     let heads, constrs = List.chop n env.constrs in
-    let constrlists =
-      if b then (heads @ List.hd env.constrlists) :: List.tl env.constrlists
-      else heads :: env.constrlists
+    let constrlists, constrs =
+      if b then
+         (* We rearrange constrs = c1..cn rem and constrlists = [d1..dr e1..ep] rem' into
+            constrs = e1..ep rem and constrlists [c1..cn d1..dr] rem' *)
+         let constrlist = List.hd env.constrlists in
+         let constrlist, tail = List.chop (List.length constrlist - p) constrlist in
+         (heads @ constrlist) :: List.tl env.constrlists, tail @ constrs
+      else
+         (* We rearrange constrs = c1..cn e1..ep rem into
+            constrs = e1..ep rem and add a constr list [c1..cn] *)
+        let constrlist, tail = List.chop (n - p) heads in
+        constrlist :: env.constrlists, tail @ constrs
     in
     ty_eval rem f { env with constrs; constrlists; } 
 
 let rec ty_erase : type s a r. (s, a, r) ty_rule -> (s, a, r) Extend.rule = function
 | TyStop -> Stop
-| TyMark (_, _, r) -> ty_erase r
+| TyMark (_, _, _, r) -> ty_erase r
 | TyNext (rem, TyTerm tok) -> Next (ty_erase rem, Atoken tok)
 | TyNext (rem, TyNonTerm (_, _, s, _)) -> Next (ty_erase rem, s)
 
@@ -398,9 +407,9 @@ let make_ty_rule assoc from forpat prods =
     let s = symbol_of_entry assoc from e in
     let bind = match var with None -> false | Some _ -> true in
     AnyTyRule (TyNext (r, TyNonTerm (forpat, e, s, bind)))
-  | GramConstrListMark (n, b) :: rem ->
+  | GramConstrListMark (n, b, p) :: rem ->
     let AnyTyRule r = make_ty_rule rem in
-    AnyTyRule (TyMark (n, b, r))
+    AnyTyRule (TyMark (n, b, p, r))
   in
   make_ty_rule (List.rev prods)
 

--- a/test-suite/output/Notations3.out
+++ b/test-suite/output/Notations3.out
@@ -109,3 +109,9 @@ fun x : ?A => x === x
      : forall x : ?A, x = x
 where
 ?A : [x : ?A |- Type] (x cannot be used)
+{0, 1}
+     : nat * nat
+{0, 1, 2}
+     : nat * (nat * nat)
+{0, 1, 2, 3}
+     : nat * (nat * (nat * nat))

--- a/test-suite/output/Notations3.v
+++ b/test-suite/output/Notations3.v
@@ -160,3 +160,11 @@ End Bug4765.
 
 Notation "x === x" := (eq_refl x) (only printing, at level 10).
 Check (fun x => eq_refl x).
+
+(**********************************************************************)
+(* Test recursive notations with the recursive pattern repeated on the right *)
+
+Notation "{ x , .. , y , z }" := (pair x .. (pair y z) ..).
+Check {0,1}.
+Check {0,1,2}.
+Check {0,1,2,3}.


### PR DESCRIPTION
This adds support for recursive notations whose recursive pattern is repeated on the right, as e.g. in the tempting:
```coq
Notation "( x ; .. ; y ; z )" := (existT _ x .. (existT _ y z) ..).
```
See code for details on the trick used to turn "( x ; .. ; y ; z )" into the camlp5 left-factorized "( x ; y ; .. ; z )".