### PR TITLE
Update .gitignore with doc/tutorial/Tutorial.v.out

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,7 @@ doc/stdlib/FullLibrary.coqdoc.tex
 doc/stdlib/html/
 doc/stdlib/index-body.html
 doc/stdlib/index-list.html
+doc/tutorial/Tutorial.v.out
 doc/RecTutorial/RecTutorial.html
 doc/RecTutorial/RecTutorial.ps
 dev/ocamldoc/*.html


### PR DESCRIPTION
Assuming #836 was closed because it was a branch on Coq rather than because it was wrong.