### PR TITLE
Timorous fix of bug #5598 on global existing class in sections

### DIFF
--- a/plugins/ltac/g_class.ml4
+++ b/plugins/ltac/g_class.ml4
@@ -21,7 +21,7 @@ let set_transparency cl b =
   List.iter (fun r ->
     let gr = Smartlocate.global_with_alias r in
     let ev = Tacred.evaluable_of_global_reference (Global.env ()) gr in
-      Classes.set_typeclass_transparency ev false b) cl
+      Classes.set_typeclass_transparency ev (Locality.make_section_locality None) b) cl
 
 VERNAC COMMAND EXTEND Typeclasses_Unfold_Settings CLASSIFIED AS SIDEFF
 | [ "Typeclasses" "Transparent" reference_list(cl) ] -> [

--- a/pretyping/typeclasses.ml
+++ b/pretyping/typeclasses.ml
@@ -98,6 +98,8 @@ let new_instance cl info glob poly impl =
     if glob then Some (Lib.sections_depth ())
     else None
   in
+  if match global with Some n -> n>0 && isVarRef impl | _ -> false then
+    CErrors.user_err (Pp.str "Cannot set Global an instance referring to a section variable.");
     { is_class = cl.cl_impl;
       is_info = info ;
       is_global = global ;
@@ -358,6 +360,7 @@ let discharge_instance (_, (action, inst)) =
   match inst.is_global with
   | None -> None
   | Some n ->
+    assert (not (isVarRef inst.is_impl));
     Some (action,
     { inst with 
       is_global = Some (pred n);

--- a/test-suite/bugs/closed/5598.v
+++ b/test-suite/bugs/closed/5598.v
@@ -1,0 +1,8 @@
+(* Checking when discharge of an existing class is possible *)
+Section foo.
+  Context {T} (a : T) (b : T).
+  Let k := eq_refl a.
+  Existing Class eq.
+  Fail Global Existing Instance k.
+  Existing Instance k.
+End foo.

--- a/vernac/obligations.ml
+++ b/vernac/obligations.ml
@@ -660,7 +660,7 @@ let declare_obligation prg obl body ty uctx =
       let constant = Declare.declare_constant obl.obl_name ~local:true
 	(DefinitionEntry ce,IsProof Property)
       in
-	if not opaque then add_hint false prg constant;
+	if not opaque then add_hint (Locality.make_section_locality None) prg constant;
 	definition_message obl.obl_name;
 	true, { obl with obl_body =
 	    if poly then


### PR DESCRIPTION
I had started to try to fix #5598 but I'm unsure of the intended design. That would be good if @mattam82 should tell more about what is expected.

I simply errored on a `Global` on a section-variable instance. But we could have had a warning, we could have had the discharge working up to the point the section variable exactly disappears (in case of nested Section), etc.

I also started a [branch](http://github.com/herbelin/github-coq/tree/trunk+wip-supporting-discharging-hints) which supports the `Global` flag in sections for hints, but, similarly, I'm unsure of the expected design. So, not being a heavy users of hints, I prefer to let it to specialists, or, at least to first hear from them.

As for now, in the current PR, I made two modifications preparing the possibility of discharge of hints in the future (`Typeclasses Opaque`, `Typeclasses Tranparent`, and the obligation mechanism were adding hints with the global flag on in sections, even though this flag was later on ignored by hints).
