### PR TITLE
Fix OS X Travis by pinning OCaml version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -139,8 +139,7 @@ matrix:
     - os: osx
       env:
       - TEST_TARGET="test-suite"
-      - COMPILER="system"
-      - CAMLP5_VER="6.17"
+      - COMPILER="4.02.3"
       - NATIVE_COMP="no"
       before_install:
       - brew update


### PR DESCRIPTION
Currently the Travis OS X job is broken because brew installs OCaml 4.04.2 but Camlp5 6.17 requires OCaml <= 4.04.1. This fixes the issue by pinning the OCaml version we test to 4.02.3, as in most other jobs (this also means that we can use the default version of Camlp5, as in most other jobs).