### PR TITLE
8.6+travis osx package

### DIFF
--- a/.bintray.json
+++ b/.bintray.json
@@ -1,0 +1,20 @@
+{
+    "package": {
+        "name": "coq",
+        "repo": "coq",
+        "subject": "coq"
+    },
+
+    "version": {
+        "name": "8.6.1~pre"
+    },
+
+    "files":
+        [
+        {"includePattern": "_build/(.*\\.dmg)", "uploadPattern": "$1",
+         "matrixParams": {
+             "override": 1 }
+        }
+        ],
+    "publish": true
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ env:
   - NJOBS=2
   # system is == 4.02.3
   - COMPILER="system"
+  - NATIVE_COMP="yes"
+  - COQ_DEST="-local"
   # Main test suites
   matrix:
   - TEST_TARGET="test-suite" COMPILER="4.02.3+32bit"
@@ -106,6 +108,30 @@ matrix:
           - transfig
           - imagemagick
 
+    - os: osx
+      env:
+      - TEST_TARGET=""
+      - COMPILER="4.02.3"
+      - NATIVE_COMP="no"
+      - COQ_DEST="-prefix ${PWD}/_install"
+      - EXTRA_CONF="-coqide opt"
+      - EXTRA_OPAM="lablgtk-extras"
+      before_install:
+      - brew update
+      - brew install opam gtk+ expat gtksourceview libxml2 gdk-pixbuf python3
+      - pip3 install macpack
+      before_deploy:
+        - dev/build/osx/make-macos-dmg.sh
+      deploy:
+        provider: bintray
+        user: maximedenes
+        file: .bintray.json
+        key:
+          secure: "AUJJuMuzOSpyKX+2nZ2XEdQ0G2kgPcfSsnHoY8YCi/SxzNckVLfUegweHfkNG0oeMhyjCHn588IZ7Op67A5NADYxaU2R2cpAt8hN1SFo/7Wj5Sv1qM/hVwOFPQ4iDv5iHJIONaiHUY1dy1JRHPJrsJ+sBrcDLgVlI3rKcNWMNEA="
+        skip_cleanup: true
+        on:
+          all_branches: true
+
 install:
 - opam init -j ${NJOBS} --compiler=${COMPILER} -n -y
 - eval $(opam config env)
@@ -116,7 +142,7 @@ install:
 script:
 
 - echo 'Configuring Coq...' && echo -en 'travis_fold:start:coq.config\\r'
-- ./configure -local -usecamlp5 -native-compiler yes ${EXTRA_CONF}
+- ./configure ${COQ_DEST} -native-compiler ${NATIVE_COMP} ${EXTRA_CONF}
 - echo -en 'travis_fold:end:coq.config\\r'
 
 - echo 'Building Coq...' && echo -en 'travis_fold:start:coq.build\\r'

--- a/.travis.yml
+++ b/.travis.yml
@@ -110,6 +110,15 @@ matrix:
 
     - os: osx
       env:
+      - TEST_TARGET="test-suite"
+      - COMPILER="4.02.3"
+      - NATIVE_COMP="no"
+      before_install:
+      - brew update
+      - brew install opam
+
+    - os: osx
+      env:
       - TEST_TARGET=""
       - COMPILER="4.02.3"
       - NATIVE_COMP="no"

--- a/Makefile.ide
+++ b/Makefile.ide
@@ -55,7 +55,8 @@ IDEFILES=$(wildcard ide/*.lang) ide/coq_style.xml ide/coq.png ide/MacOS/default_
 GTKSHARE=$(shell pkg-config --variable=prefix gtk+-2.0)/share
 GTKBIN=$(shell pkg-config --variable=prefix gtk+-2.0)/bin
 GTKLIBS=$(shell pkg-config --variable=libdir gtk+-2.0)
-
+PIXBUFBIN=$(shell pkg-config --variable=prefix gdk-pixbuf-2.0)/bin
+SOURCEVIEWSHARE=$(shell pkg-config --variable=prefix gtksourceview-2.0)/share
 
 ###########################################################################
 # CoqIde special targets
@@ -176,15 +177,14 @@ $(COQIDEAPP)/Contents/Resources/share: $(COQIDEAPP)/Contents
 	$(MKDIR) $@/coq/
 	$(INSTALLLIB) ide/coq.png ide/*.lang ide/coq_style.xml $@/coq/
 	$(MKDIR) $@/gtksourceview-2.0/{language-specs,styles}
-	$(INSTALLLIB) "$(GTKSHARE)/"gtksourceview-2.0/language-specs/{def.lang,language2.rng} $@/gtksourceview-2.0/language-specs/
-	$(INSTALLLIB) "$(GTKSHARE)/"gtksourceview-2.0/styles/{styles.rng,classic.xml} $@/gtksourceview-2.0/styles/
+	$(INSTALLLIB) "$(SOURCEVIEWSHARE)/"gtksourceview-2.0/language-specs/{def.lang,language2.rng} $@/gtksourceview-2.0/language-specs/
+	$(INSTALLLIB) "$(SOURCEVIEWSHARE)/"gtksourceview-2.0/styles/{styles.rng,classic.xml} $@/gtksourceview-2.0/styles/
 	cp -R "$(GTKSHARE)/"locale $@
-	cp -R "$(GTKSHARE)/"icons $@
 	cp -R "$(GTKSHARE)/"themes $@
 
 $(COQIDEAPP)/Contents/Resources/loaders: $(COQIDEAPP)/Contents
 	$(MKDIR) $@
-	$(INSTALLLIB) $$("$(GTKBIN)/gdk-pixbuf-query-loaders" | sed -n -e '5 s!.*= \(.*\)$$!\1!p')/libpixbufloader-png.so $@
+	$(INSTALLLIB) $$("$(PIXBUFBIN)/gdk-pixbuf-query-loaders" | sed -n -e '5 s!.*= \(.*\)$$!\1!p')/libpixbufloader-png.so $@
 
 $(COQIDEAPP)/Contents/Resources/immodules: $(COQIDEAPP)/Contents
 	$(MKDIR) $@
@@ -195,7 +195,7 @@ $(COQIDEAPP)/Contents/Resources/etc: $(COQIDEAPP)/Contents/Resources/lib
 	$(MKDIR) $@/xdg/coq
 	$(INSTALLLIB) ide/MacOS/default_accel_map $@/xdg/coq/coqide.keys
 	$(MKDIR) $@/gtk-2.0
-	{ "$(GTKBIN)/gdk-pixbuf-query-loaders" $@/../loaders/*.so |\
+	{ "$(PIXBUFBIN)/gdk-pixbuf-query-loaders" $@/../loaders/*.so |\
 	 sed -e "s!/.*\(/loaders/.*.so\)!@executable_path/../Resources/\1!"; } \
 	> $@/gtk-2.0/gdk-pixbuf.loaders
 	{ "$(GTKBIN)/gtk-query-immodules-2.0" $@/../immodules/*.so |\
@@ -207,32 +207,11 @@ $(COQIDEAPP)/Contents/Resources/etc: $(COQIDEAPP)/Contents/Resources/lib
 
 $(COQIDEAPP)/Contents/Resources/lib: $(COQIDEAPP)/Contents/Resources/immodules $(COQIDEAPP)/Contents/Resources/loaders $(COQIDEAPP)/Contents $(COQIDEINAPP)
 	$(MKDIR) $@
-	$(INSTALLLIB) $(GTKLIBS)/charset.alias $@/
-	$(MKDIR) $@/pango/1.8.0/modules
-	$(INSTALLLIB) "$(GTKLIBS)/pango/1.8.0/modules/"*.so $@/pango/1.8.0/modules/
-	{ "$(GTKBIN)/pango-querymodules" $@/pango/1.8.0/modules/*.so |\
-	 sed -e "s!/.*\(/pango/1.8.0/modules/.*.so\)!@executable_path/../Resources/lib\1!"; } \
-	> $@/pango/1.8.0/modules.cache
-
-	for i in $$(otool -L $(COQIDEINAPP) |sed -n -e "\@$(GTKLIBS)@ s/[^/]*\(\/[^ ]*\) .*$$/\1/p"); \
-	    do cp $$i $@/; \
-	    ide/MacOS/relatify_with-respect-to_.sh $@/$$(basename $$i) $(GTKLIBS) $@; \
+	macpack -d ../Resources/lib $(COQIDEINAPP)
+	for i in $@/../loaders/*.so $@/../immodules/*.so; \
+	do \
+	  macpack -d ../lib $$i; \
 	done
-	for i in $@/../loaders/*.so $@/../immodules/*.so $@/pango/1.8.0/modules/*.so; \
-	    do \
-		for j in $$(otool -L $$i | sed -n -e "\@$(GTKLIBS)@ s/[^/]*\(\/[^ ]*\) .*$$/\1/p"); \
-		do cp $$j $@/; ide/MacOS/relatify_with-respect-to_.sh $@/$$(basename $$j) $(GTKLIBS) $@; done; \
-		ide/MacOS/relatify_with-respect-to_.sh $$i $(GTKLIBS) $@; \
-	    done
-	EXTRAWORK=1; \
-	while [ $${EXTRAWORK} -eq 1 ]; \
-	do EXTRAWORK=0; \
-	    for i in $@/*.dylib; \
-	    do for j in $$(otool -L $$i | sed -n -e "\@$(GTKLIBS)@ s/[^/]*\(\/[^ ]*\) .*$$/\1/p"); \
-		do EXTRAWORK=1; cp $$j $@/; ide/MacOS/relatify_with-respect-to_.sh $@/$$(basename $$j) $(GTKLIBS) $@; done; \
-	    done; \
-	done
-	ide/MacOS/relatify_with-respect-to_.sh $(COQIDEINAPP) $(GTKLIBS) $@
 
 $(COQIDEAPP)/Contents/Resources:$(COQIDEAPP)/Contents/Resources/etc $(COQIDEAPP)/Contents/Resources/share
 	$(INSTALLLIB) ide/MacOS/*.icns $@

--- a/dev/build/osx/make-macos-dmg.sh
+++ b/dev/build/osx/make-macos-dmg.sh
@@ -4,19 +4,13 @@
 set -e
 
 # Configuration setup
-eval `opam config env`
-make distclean
 OUTDIR=$PWD/_install
 DMGDIR=$PWD/_dmg
-./configure -debug -prefix $OUTDIR -native-compiler no
 VERSION=$(sed -n -e '/^let coq_version/ s/^[^"]*"\([^"]*\)"$/\1/p' configure.ml)
 APP=bin/CoqIDE_${VERSION}.app
 
 # Create a .app file with CoqIDE
-~/.local/bin/jhbuild run make -j -l2 $APP
-
-# Build Coq and run test-suite
-make && make check
+make -j $NJOBS -l2 $APP
 
 # Add Coq to the .app file
 make OLDROOT=$OUTDIR COQINSTALLPREFIX=$APP/Contents/Resources/ install-coq install-ide-toploop
@@ -29,7 +23,9 @@ mkdir -p $DMGDIR
 ln -sf /Applications $DMGDIR/Applications
 cp -r $APP $DMGDIR
 
-# Temporary countermeasure to hdiutil error 5341
-head -c9703424 /dev/urandom > $DMGDIR/.padding
+mkdir -p _build
 
-hdiutil create -imagekey zlib-level=9 -volname CoqIDE_$VERSION -srcfolder $DMGDIR -ov -format UDZO CoqIDE_$VERSION.dmg
+# Temporary countermeasure to hdiutil error 5341
+# head -c9703424 /dev/urandom > $DMGDIR/.padding
+
+hdiutil create -imagekey zlib-level=9 -volname CoqIDE_$VERSION -srcfolder $DMGDIR -ov -format UDZO _build/CoqIDE_$VERSION.dmg


### PR DESCRIPTION
This makes 8.6 generate the OSX package using Travis and bintray. It also runs the test-suite on OSX, but separately due to timeouts.