### PR TITLE
Make fiat-parsers allow_failure on gitlab

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -281,6 +281,7 @@ ci-fiat-parsers:
   variables:
     <<: *ci-template-vars
     EXTRA_PACKAGES: "python"
+  allow_failure: true
 
 ci-flocq:
   <<: *ci-template


### PR DESCRIPTION
Following e710306910afc61c9a874e6020bbf35b77ffe4af