### PR TITLE
Clean 'with Definition' implementation.

### DIFF
--- a/kernel/declareops.ml
+++ b/kernel/declareops.ml
@@ -67,37 +67,6 @@ let type_of_constant cb =
       if t' == t then x else RegularArity t'
   | TemplateArity _ as x -> x
 
-let constraints_of_constant otab cb =
-  match cb.const_universes with
-  | Polymorphic_const ctx -> 
-    Univ.UContext.constraints (Univ.instantiate_univ_context ctx)
-  | Monomorphic_const ctx -> 
-    Univ.Constraint.union 
-      (Univ.UContext.constraints ctx)
-      (match cb.const_body with
-       | Undef _ -> Univ.empty_constraint
-       | Def c -> Univ.empty_constraint
-       | OpaqueDef o ->
-         Univ.ContextSet.constraints (Opaqueproof.force_constraints otab o))
-
-let universes_of_constant otab cb = 
-  match cb.const_body with
-  | Undef _ | Def _ ->
-    begin
-      match cb.const_universes with
-      | Monomorphic_const ctx -> ctx
-      | Polymorphic_const ctx -> Univ.instantiate_univ_context ctx
-    end
-  | OpaqueDef o -> 
-    let body_uctxs = Opaqueproof.force_constraints otab o in
-    match cb.const_universes with
-    | Monomorphic_const ctx ->
-      let uctxs = Univ.ContextSet.of_context ctx in
-      Univ.ContextSet.to_context (Univ.ContextSet.union body_uctxs uctxs)
-    | Polymorphic_const ctx ->
-      assert(Univ.ContextSet.is_empty body_uctxs);
-      Univ.instantiate_univ_context ctx
-
 let universes_of_polymorphic_constant otab cb = 
   match cb.const_universes with
   | Monomorphic_const _ -> Univ.UContext.empty

--- a/kernel/declareops.mli
+++ b/kernel/declareops.mli
@@ -39,10 +39,6 @@ val constant_is_polymorphic : constant_body -> bool
 val body_of_constant :
   Opaqueproof.opaquetab -> constant_body -> Term.constr option
 val type_of_constant : constant_body -> constant_type
-val constraints_of_constant :
-  Opaqueproof.opaquetab -> constant_body -> Univ.constraints
-val universes_of_constant :
-  Opaqueproof.opaquetab -> constant_body -> Univ.universe_context
 
 (** Return the universe context, in case the definition is polymorphic, otherwise
     the context is empty. *)

--- a/kernel/subtyping.ml
+++ b/kernel/subtyping.ml
@@ -358,40 +358,17 @@ let check_constant cst env mp1 l info1 cb2 spec2 subst1 subst2 =
 	      let c2 = Mod_subst.force_constr lc2 in
 	      check_conv NotConvertibleBodyField cst poly u infer_conv env' c1 c2))
    | IndType ((kn,i),mind1) ->
-       ignore (CErrors.user_err Pp.(str @@
+       CErrors.user_err Pp.(str @@
        "The kernel does not recognize yet that a parameter can be " ^
        "instantiated by an inductive type. Hint: you can rename the " ^
        "inductive type and give a definition to map the old name to the new " ^
-       "name."));
-      let () = assert (List.is_empty mind1.mind_hyps && List.is_empty cb2.const_hyps) in
-      if Declareops.constant_has_body cb2 then error DefinitionFieldExpected;
-      let u1 = inductive_polymorphic_instance mind1 in
-      let arity1,cst1 = constrained_type_of_inductive env 
-	((mind1,mind1.mind_packets.(i)),u1) in
-      let cst2 = assert false in
-(*       let cst2 = *)
-(*         Declareops.constraints_of_constant (Environ.opaque_tables env) cb2 in  *)
-      let typ2 = Typeops.type_of_constant_type env cb2.const_type in
-      let cst = Constraint.union cst (Constraint.union cst1 cst2) in
-      let error = NotConvertibleTypeField (env, arity1, typ2) in
-       check_conv error cst false Univ.Instance.empty infer_conv_leq env arity1 typ2
-   | IndConstr (((kn,i),j) as cstr,mind1) ->
-      ignore (CErrors.user_err Pp.(str @@
+       "name.")
+   | IndConstr (((kn,i),j),mind1) ->
+      CErrors.user_err Pp.(str @@
        "The kernel does not recognize yet that a parameter can be " ^
        "instantiated by a constructor. Hint: you can rename the " ^
        "constructor and give a definition to map the old name to the new " ^
-       "name."));
-      let () = assert (List.is_empty mind1.mind_hyps && List.is_empty cb2.const_hyps) in
-      if Declareops.constant_has_body cb2 then error DefinitionFieldExpected;
-      let u1 = inductive_polymorphic_instance mind1 in
-      let ty1,cst1 = constrained_type_of_constructor (cstr,u1) (mind1,mind1.mind_packets.(i)) in
-      let cst2 = assert false in
-(*       let cst2 = *)
-(*         Declareops.constraints_of_constant (Environ.opaque_tables env) cb2 in *)
-      let ty2 = Typeops.type_of_constant_type env cb2.const_type in
-      let cst = Constraint.union cst (Constraint.union cst1 cst2) in
-      let error = NotConvertibleTypeField (env, ty1, ty2) in
-       check_conv error cst false Univ.Instance.empty infer_conv env ty1 ty2
+       "name.")
 
 let rec check_modules cst env msb1 msb2 subst1 subst2 =
   let mty1 = module_type_of_module msb1 in

--- a/kernel/subtyping.ml
+++ b/kernel/subtyping.ml
@@ -368,8 +368,9 @@ let check_constant cst env mp1 l info1 cb2 spec2 subst1 subst2 =
       let u1 = inductive_polymorphic_instance mind1 in
       let arity1,cst1 = constrained_type_of_inductive env 
 	((mind1,mind1.mind_packets.(i)),u1) in
-      let cst2 =
-        Declareops.constraints_of_constant (Environ.opaque_tables env) cb2 in 
+      let cst2 = assert false in
+(*       let cst2 = *)
+(*         Declareops.constraints_of_constant (Environ.opaque_tables env) cb2 in  *)
       let typ2 = Typeops.type_of_constant_type env cb2.const_type in
       let cst = Constraint.union cst (Constraint.union cst1 cst2) in
       let error = NotConvertibleTypeField (env, arity1, typ2) in
@@ -384,8 +385,9 @@ let check_constant cst env mp1 l info1 cb2 spec2 subst1 subst2 =
       if Declareops.constant_has_body cb2 then error DefinitionFieldExpected;
       let u1 = inductive_polymorphic_instance mind1 in
       let ty1,cst1 = constrained_type_of_constructor (cstr,u1) (mind1,mind1.mind_packets.(i)) in
-      let cst2 =
-        Declareops.constraints_of_constant (Environ.opaque_tables env) cb2 in
+      let cst2 = assert false in
+(*       let cst2 = *)
+(*         Declareops.constraints_of_constant (Environ.opaque_tables env) cb2 in *)
       let ty2 = Typeops.type_of_constant_type env cb2.const_type in
       let cst = Constraint.union cst (Constraint.union cst1 cst2) in
       let error = NotConvertibleTypeField (env, ty1, ty2) in

--- a/library/global.ml
+++ b/library/global.ml
@@ -124,10 +124,6 @@ let exists_objlabel id = Safe_typing.exists_objlabel id (safe_env ())
 let opaque_tables () = Environ.opaque_tables (env ())
 let body_of_constant_body cb = Declareops.body_of_constant (opaque_tables ()) cb
 let body_of_constant cst = body_of_constant_body (lookup_constant cst)
-let constraints_of_constant_body cb =
-  Declareops.constraints_of_constant (opaque_tables ()) cb
-let universes_of_constant_body cb =
-  Declareops.universes_of_constant (opaque_tables ()) cb
 
 (** Operations on kernel names *)
 

--- a/library/global.mli
+++ b/library/global.mli
@@ -91,10 +91,6 @@ val mind_of_delta_kn : kernel_name -> mutual_inductive
 val opaque_tables : unit -> Opaqueproof.opaquetab
 val body_of_constant : constant -> Term.constr option
 val body_of_constant_body : Declarations.constant_body -> Term.constr option
-val constraints_of_constant_body :
-  Declarations.constant_body -> Univ.constraints
-val universes_of_constant_body :
-  Declarations.constant_body -> Univ.universe_context
 
 (** Global universe name <-> level mapping *)
 type universe_names = 


### PR DESCRIPTION
Do not add original constraints to the environment in 'with Definition' check.

This was useless, because immediate constraints are assumed to already be in
the current environment, while deferred constraints are useless for the
conversion check of the definition types, as they only appear in the opaque
body.

This also clarifies a bit what is going on in the typing of module constraints
w.r.t. global universes.

Also removed error-prone, suspicious functions from the kernel.