### PR TITLE
Deprecate options that were introduced for compatibility with 8.5.

### DIFF
--- a/doc/refman/Classes.tex
+++ b/doc/refman/Classes.tex
@@ -486,15 +486,17 @@ where there is a hole in that place.
 
 \subsection{\tt Set Typeclasses Legacy Resolution}
 \optindex{Typeclasses Legacy Resolution}
+\emph{Deprecated since 8.7}
 
 This option (off by default) uses the 8.5 implementation of resolution.
 Use for compatibility purposes only (porting and debugging).
 
 \subsection{\tt Set Typeclasses Module Eta}
 \optindex{Typeclasses Modulo Eta}
+\emph{Deprecated since 8.7}
 
 This option allows eta-conversion for functions and records during
-unification of type-classes. This option is now unsupported in 8.6 with
+unification of type-classes. This option is unsupported since 8.6 with
 {\tt Typeclasses Filtered Unification} set, but still affects the
 default unification strategy, and the one used in {\tt Legacy
   Resolution} mode. It is \emph{unset} by default. If {\tt Typeclasses
@@ -505,7 +507,7 @@ pattern-matching is not up-to eta.
 \subsection{\tt Set Typeclasses Limit Intros}
 \optindex{Typeclasses Limit Intros}
 
-This option (on by default in Coq 8.6 and below) controls the ability to
+This option (on by default) controls the ability to
 apply hints while avoiding (functional) eta-expansions in the generated
 proof term. It does so by allowing hints that conclude in a product to
 apply to a goal with a matching product directly, avoiding an

--- a/doc/refman/Program.tex
+++ b/doc/refman/Program.tex
@@ -278,7 +278,8 @@ tactic is replaced by the default one if not specified.
   as implicit arguments of the special constant
   \texttt{Program.Tactics.obligation}.
 \item {\tt Set Shrink Obligations}\optindex{Shrink Obligations}
-  Control whether obligations should have their
+\emph{Deprecated since 8.7}
+  This option (on by default) controls whether obligations should have their
   context minimized to the set of variables used in the proof of the
   obligation, to avoid unnecessary dependencies.
 \end{itemize}

--- a/doc/refman/RefMan-ltac.tex
+++ b/doc/refman/RefMan-ltac.tex
@@ -1131,8 +1131,9 @@ on. This can be obtained thanks to the option below.
 \optindex{Shrink Abstract}
 {\tt Set Shrink Abstract}
 \end{quote}
+\emph{Deprecated since 8.7}
 
-When set, all lemmas generated through \texttt{abstract {\tacexpr}}
+When set (default), all lemmas generated through \texttt{abstract {\tacexpr}}
 and \texttt{transparent\_abstract {\tacexpr}} are quantified only over the
 variables that appear in the term constructed by \texttt{\tacexpr}.
 

--- a/doc/refman/RefMan-tac.tex
+++ b/doc/refman/RefMan-tac.tex
@@ -3485,6 +3485,7 @@ reduced to \texttt{S t}.
 \optindex{Refolding Reduction}
 {\tt Refolding Reduction}
 \end{quote}
+\emph{Deprecated since 8.7}
 
 This option (off by default) controls the use of the refolding strategy
 of {\tt cbn} while doing reductions in unification, type inference and

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -29,7 +29,7 @@ exception Elimconst
 
 let refolding_in_reduction = ref false
 let _ = Goptions.declare_bool_option {
-  Goptions.optdepr = false;
+  Goptions.optdepr = true; (* remove in 8.8 *)
   Goptions.optname =
     "Perform refolding of fixpoints/constants like cbn during reductions";
   Goptions.optkey = ["Refolding";"Reduction"];

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -92,7 +92,7 @@ open Goptions
 
 let _ =
   declare_bool_option
-    { optdepr  = true;
+    { optdepr  = true; (* remove in 8.8 *)
       optname  = "do typeclass search modulo eta conversion";
       optkey   = ["Typeclasses";"Modulo";"Eta"];
       optread  = get_typeclasses_modulo_eta;
@@ -125,7 +125,7 @@ let _ =
 
 let _ =
   declare_bool_option
-    { optdepr  = false;
+    { optdepr  = true; (* remove in 8.8 *)
       optname  = "compat";
       optkey   = ["Typeclasses";"Legacy";"Resolution"];
       optread  = get_typeclasses_legacy_resolution;

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -80,15 +80,15 @@ let _ =
       optread  = (fun () -> !Flags.tactic_context_compat) ;
       optwrite = (fun b -> Flags.tactic_context_compat := b) }
 
-let apply_solve_class_goals = ref (false)
-let _ = Goptions.declare_bool_option {
-  Goptions.optdepr = true;
-  Goptions.optname =
-    "Perform typeclass resolution on apply-generated subgoals.";
-  Goptions.optkey = ["Typeclass";"Resolution";"After";"Apply"];
-  Goptions.optread = (fun () -> !apply_solve_class_goals);
-  Goptions.optwrite = (fun a -> apply_solve_class_goals:=a);
-}
+let apply_solve_class_goals = ref false
+
+let _ =
+  declare_bool_option
+    { optdepr = true; (* remove in 8.8 *)
+      optname = "Perform typeclass resolution on apply-generated subgoals.";
+      optkey = ["Typeclass";"Resolution";"After";"Apply"];
+      optread = (fun () -> !apply_solve_class_goals);
+      optwrite = (fun a -> apply_solve_class_goals := a); }
 
 let clear_hyp_by_default = ref false
 
@@ -124,7 +124,7 @@ let shrink_abstract = ref true
 
 let _ =
   declare_bool_option
-    { optdepr  = true;
+    { optdepr  = true; (* remove in 8.8 *)
       optname  = "shrinking of abstracted proofs";
       optkey   = ["Shrink"; "Abstract"];
       optread  = (fun () -> !shrink_abstract) ;

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -143,7 +143,7 @@ let use_bracketing_last_or_and_intro_pattern () =
 
 let _ =
   declare_bool_option
-    { optdepr  = true; (* remove in 8.8 *)
+    { optdepr  = false;
       optname  = "bracketing last or-and introduction pattern";
       optkey   = ["Bracketing";"Last";"Introduction";"Pattern"];
       optread  = (fun () -> !bracketing_last_or_and_intro_pattern);

--- a/test-suite/output/inference.v
+++ b/test-suite/output/inference.v
@@ -14,6 +14,7 @@ Definition P (e:option L) :=
 Print P.
 
 (* Check that plus is folded even if reduction is involved *)
+Set Warnings Append "-deprecated-option".
 Set Refolding Reduction.
 Check (fun m n p (H : S m <= (S n) + p) => le_S_n _ _ H).
 

--- a/vernac/obligations.ml
+++ b/vernac/obligations.ml
@@ -350,7 +350,7 @@ let get_shrink_obligations () = !shrink_obligations
 
 let _ =
   declare_bool_option
-    { optdepr  = true;
+    { optdepr  = true; (* remove in 8.8 *)
       optname  = "Shrinking of Program obligations";
       optkey   = ["Shrink";"Obligations"];
       optread  = get_shrink_obligations;


### PR DESCRIPTION
I ignore if the following was an oversight from @silene in his #375 PR or if there was a reason for not deprecating these options in 8.7. So I'm asking for a green light by @silene and also by @mattam82 who is concerned by most of the options I'm deprecating here.

The idea is that if we don't deprecate these options in 8.7, then the removal of the `-compat 8.5` option in 8.8 isn't going to bring much clean-up. I'm particularly interested in getting rid of the legacy `typeclasses eauto` implementation.

This closes [bug 5633](https://coq.inria.fr/bugs/show_bug.cgi?id=5633).