### PR TITLE
Fix typo in documentation for identity

### DIFF
--- a/theories/Init/Datatypes.v
+++ b/theories/Init/Datatypes.v
@@ -336,7 +336,7 @@ Proof. intros. apply CompareSpec2Type; assumption. Defined.
 
 (** [identity A a] is the family of datatypes on [A] whose sole non-empty
     member is the singleton datatype [identity A a a] whose
-    sole inhabitant is denoted [refl_identity A a] *)
+    sole inhabitant is denoted [identity_refl A a] *)
 
 Inductive identity (A:Type) (a:A) : A -> Type :=
   identity_refl : identity a a.


### PR DESCRIPTION
Fixes Coq [bug 5635](https://coq.inria.fr/bugs/show_bug.cgi?id=5635).