### PR TITLE
Fixing environment in warning "Projection value has no head constant".

### DIFF
--- a/test-suite/output/Warnings.out
+++ b/test-suite/output/Warnings.out
@@ -1,0 +1,3 @@
+File "stdin", line 4, characters 0-22:
+Warning: Projection value has no head constant: fun x : B => x in canonical
+instance a of b, ignoring it. [projection-no-head-constant,typechecker]

--- a/test-suite/output/Warnings.v
+++ b/test-suite/output/Warnings.v
@@ -1,0 +1,5 @@
+(* Term in warning was not printed in the right environment at some time *)
+Record A := { B:Type; b:B->B }.
+Definition a B := {| B:=B; b:=fun x => x |}.
+Canonical Structure a.
+


### PR DESCRIPTION
Hi, I found a UNBOUND_REL in a warning message while working on the ATBR contribution. This PR fixes the computation of the environment for this warning.