### PR TITLE
Fix debug trace of typeclasses eauto.

### DIFF
--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -1144,7 +1144,7 @@ module Search = struct
         let res =
           if j = 0 then tclUNIT ()
           else tclDISPATCH
-                 (List.init j (fun j' -> (tac_of gls i (Option.default 0 k + j))))
+                 (List.init j (fun j' -> (tac_of gls i (Option.default 0 k + j'))))
         in
         let finish nestedshelf sigma =
           let filter ev =


### PR DESCRIPTION
Note that this is far from the only bug in the trace.
Here is some code where the difference between the trace before and after this fix can be seen:

```coq
Parameter foo : Prop.
Axiom H : foo -> foo.
Hint Resolve H : foo.
Goal foo.
Typeclasses eauto := debug.
Fail typeclasses eauto 5 with foo.
```