### PR TITLE
[travis] Display info on tested commit for PR builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -145,6 +145,9 @@ matrix:
       - brew update
       - brew install opam
 
+before_install:
+- if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then echo "Tested commit (followed by parent commits):"; git log -1; for commit in `git log -1 --format="%P"`; do echo; git log -1 $commit; done; fi
+
 install:
 - opam init -j ${NJOBS} --compiler=${COMPILER} -n -y
 - eval $(opam config env)


### PR DESCRIPTION
This is made necessary by the fact that the displayed commit in the header of the build can be outdated if the build was restarted or took a long time to start. Sometimes, it is so old that the link to GitHub is a 404.

For instance, in [this build](https://travis-ci.org/coq/coq/jobs/252059019) the commit displayed in the header correspond to the [merge commit that triggered the build](https://github.com/coq/coq/commit/0e0697bf38190ae831720bc43b2b1405fc52117d). But it was restarted after master was updated and the actual commit that was tested is https://github.com/coq/coq/commit/214b10c22.

It is unfortunate that Travis uses the following commands for fetching the latest merge commit:

```
git clone --depth=50 https://github.com/coq/coq.git coq/coq
cd coq/coq
git fetch origin +refs/pull/868/merge:
git checkout -qf FETCH_HEAD
```

If the `-q` option wasn't used, this PR wouldn't be necessary because the tested commit would be printed at checkout time.