### PR TITLE
Format pairs in pr_depth to get alternating separators, no-thunks version

### DIFF
--- a/checker/check.ml
+++ b/checker/check.ml
@@ -30,7 +30,7 @@ let path_of_dirpath dir =
     | l::dir ->
         {dirpath=List.map Id.to_string dir;basename=Id.to_string l}
 let pr_dirlist dp =
-  prlist_with_sep (fun _ -> str".") str (List.rev dp)
+  prlist_with_sep (str ".") str (List.rev dp)
 let pr_path sp =
   match sp.dirpath with
       [] -> str sp.basename

--- a/checker/check_stat.ml
+++ b/checker/check_stat.ml
@@ -42,7 +42,7 @@ let pr_ax csts =
   if axs = [] then
     str "Axioms: <none>"
   else
-    hv 2 (str "Axioms:" ++ fnl() ++ prlist_with_sep fnl Indtypes.prcon axs)
+    hv 2 (str "Axioms:" ++ fnl() ++ prlist_with_sep (fnl ()) Indtypes.prcon axs)
 
 let print_context env =
   if !output_context then begin

--- a/checker/univ.ml
+++ b/checker/univ.ml
@@ -414,7 +414,7 @@ struct
     | Cons (u, _, Nil) -> Expr.pr u
     | _ -> 
       str "max(" ++ hov 0
-	(prlist_with_sep pr_comma Expr.pr (to_list l)) ++
+	(prlist_with_sep (pr_comma ()) Expr.pr (to_list l)) ++
         str ")"
 
   let level l = match l with

--- a/dev/top_printers.ml
+++ b/dev/top_printers.ml
@@ -76,11 +76,11 @@ let ppfconstr c = ppconstr (CClosure.term_of_fconstr c)
 
 let ppbigint n = pp (str (Bigint.to_string n));;
 
-let prset pr l = str "[" ++ hov 0 (prlist_with_sep spc pr l) ++ str "]"
+let prset pr l = str "[" ++ hov 0 (prlist_with_sep (spc ()) pr l) ++ str "]"
 let ppintset l = pp (prset int (Int.Set.elements l))
 let ppidset l = pp (prset Id.print (Id.Set.elements l))
 
-let prset' pr l = str "[" ++ hov 0 (prlist_with_sep pr_comma pr l) ++ str "]"
+let prset' pr l = str "[" ++ hov 0 (prlist_with_sep (pr_comma ()) pr l) ++ str "]"
 
 let pridmap pr l =
   let pr (id,b) = Id.print id ++ str "=>" ++ pr id b in
@@ -100,7 +100,7 @@ let prididmap = pridmap (fun _ -> Id.print)
 let ppididmap = ppidmap (fun _ -> Id.print)
 
 let prconstrunderbindersidmap = pridmap (fun _ (l,c) ->
-  hov 1 (str"[" ++  prlist_with_sep spc Id.print l ++ str"]")
+  hov 1 (str"[" ++  prlist_with_sep (spc ()) Id.print l ++ str"]")
   ++ str "," ++ spc () ++ Termops.print_constr c)
 
 let ppconstrunderbindersidmap l = pp (prconstrunderbindersidmap l)
@@ -161,12 +161,12 @@ let ppmetas metas = pp(Termops.pr_metaset metas)
 let ppevm evd = pp(Termops.pr_evar_map ~with_univs:!Flags.univ_print (Some 2) evd)
 let ppevmall evd = pp(Termops.pr_evar_map ~with_univs:!Flags.univ_print None evd)
 let pr_existentialset evars =
-  prlist_with_sep spc pr_evar (Evar.Set.elements evars)
+  prlist_with_sep (spc ()) pr_evar (Evar.Set.elements evars)
 let ppexistentialset evars =
   pp (pr_existentialset evars)
 let ppexistentialfilter filter = match Evd.Filter.repr filter with
 | None -> pp (Pp.str "ø")
-| Some f -> pp (prlist_with_sep spc bool f)
+| Some f -> pp (prlist_with_sep (spc ()) bool f)
 let ppclenv clenv = pp(pr_clenv clenv)
 let ppgoalgoal gl = pp(Goal.pr_goal gl)
 let ppgoal g = pp(Printer.pr_goal g)
@@ -188,7 +188,7 @@ let pppftreestate p = pp(print_pftreestate p)
 
 (* let pr_glls glls = *)
 (*   hov 0 (pr_evar_defs (sig_sig glls) ++ fnl () ++ *)
-(*          prlist_with_sep fnl db_pr_goal (sig_it glls)) *)
+(*          prlist_with_sep (fnl ()) db_pr_goal (sig_it glls)) *)
 
 (* let ppsigmagoal g = pp(pr_goal (sig_it g)) *)
 (* let prgls gls = pp(pr_gls gls) *)

--- a/engine/proofview_monad.ml
+++ b/engine/proofview_monad.ml
@@ -125,7 +125,7 @@ module Info = struct
     match brs with
     | [br] -> pr_forest br
     | _ ->
-        let sep () = spc()++str"|"++spc() in
+        let sep = spc()++str"|"++spc() in
         let branches = prlist_with_sep sep pr_forest brs in
         str"[>"++spc()++branches++spc()++str"]"
   and pr_forest = function

--- a/engine/termops.ml
+++ b/engine/termops.ml
@@ -37,7 +37,7 @@ let pr_fix pr_constr ((t,i),(lna,tl,bl)) =
   let fixl = Array.mapi (fun i na -> (na,t.(i),tl.(i),bl.(i))) lna in
   hov 1
       (str"fix " ++ int i ++ spc() ++  str"{" ++
-         v 0 (prlist_with_sep spc (fun (na,i,ty,bd) ->
+         v 0 (prlist_with_sep (spc ()) (fun (na,i,ty,bd) ->
            Name.print na ++ str"/" ++ int i ++ str":" ++ pr_constr ty ++
 	   cut() ++ str":=" ++ pr_constr bd) (Array.to_list fixl)) ++
          str"}")
@@ -69,10 +69,10 @@ let rec pr_constr c = match kind_of_term c with
        pr_constr c)
   | App (c,l) ->  hov 1
       (str"(" ++ pr_constr c ++ spc() ++
-       prlist_with_sep spc pr_constr (Array.to_list l) ++ str")")
+       prlist_with_sep (spc ()) pr_constr (Array.to_list l) ++ str")")
   | Evar (e,l) -> hov 1
       (str"Evar#" ++ int (Evar.repr e) ++ str"{" ++
-       prlist_with_sep spc pr_constr (Array.to_list l) ++str"}")
+       prlist_with_sep (spc ()) pr_constr (Array.to_list l) ++str"}")
   | Const (c,u) -> str"Cst(" ++ pr_puniverses (pr_con c) u ++ str")"
   | Ind ((sp,i),u) -> str"Ind(" ++ pr_puniverses (pr_mind sp ++ str"," ++ int i) u ++ str")"
   | Construct (((sp,i),j),u) ->
@@ -81,14 +81,14 @@ let rec pr_constr c = match kind_of_term c with
   | Case (ci,p,c,bl) -> v 0
       (hv 0 (str"<"++pr_constr p++str">"++ cut() ++ str"Case " ++
              pr_constr c ++ str"of") ++ cut() ++
-       prlist_with_sep (fun _ -> brk(1,2)) pr_constr (Array.to_list bl) ++
+       prlist_with_sep (brk (1,2)) pr_constr (Array.to_list bl) ++
       cut() ++ str"end")
   | Fix f -> pr_fix pr_constr f
   | CoFix(i,(lna,tl,bl)) ->
       let fixl = Array.mapi (fun i na -> (na,tl.(i),bl.(i))) lna in
       hov 1
         (str"cofix " ++ int i ++ spc() ++  str"{" ++
-         v 0 (prlist_with_sep spc (fun (na,ty,bd) ->
+         v 0 (prlist_with_sep (spc ()) (fun (na,ty,bd) ->
            Name.print na ++ str":" ++ pr_constr ty ++
            cut() ++ str":=" ++ pr_constr bd) (Array.to_list fixl)) ++
          str"}")
@@ -216,7 +216,7 @@ let pr_evar_info evi =
       | None -> List.map (fun c -> (c, true)) (evar_context evi)
       | Some filter -> List.combine (evar_context evi) filter
       in
-      prlist_with_sep spc pr_decl (List.rev decls)
+      prlist_with_sep (spc ()) pr_decl (List.rev decls)
     with Invalid_argument _ -> str "Ill-formed filtered context" in
   let pty = print_constr evi.evar_concl in
   let pb =
@@ -228,7 +228,7 @@ let pr_evar_info evi =
     match evi.evar_body, evi.evar_candidates with
       | Evar_empty, Some l ->
            spc () ++ str "{" ++
-           prlist_with_sep (fun () -> str "|") print_constr l ++ str "}"
+           prlist_with_sep (str "|") print_constr l ++ str "}"
       | _ ->
           mt ()
   in
@@ -333,7 +333,7 @@ let pr_evar_constraints sigma pbs =
             | Reduction.CUMUL -> "<=") ++
       spc () ++ print_constr_env env Evd.empty (EConstr.of_constr t2)
   in
-  prlist_with_sep fnl pr_evconstr pbs
+  prlist_with_sep (fnl ()) pr_evconstr pbs
 
 let pr_evar_map_gen with_univs pr_evars sigma =
   let uvs = Evd.evar_universe_context sigma in
@@ -361,7 +361,7 @@ let pr_evar_list sigma l =
        then str " {" ++  pr_existential_key sigma ev ++ str "}"
        else mt ()))
   in
-  h 0 (prlist_with_sep fnl pr l)
+  h 0 (prlist_with_sep (fnl ()) pr l)
 
 let pr_evar_by_depth depth sigma = match depth with
 | None ->

--- a/engine/universes.ml
+++ b/engine/universes.ml
@@ -773,7 +773,7 @@ type constraints_map = (Univ.constraint_type * Univ.LMap.key) list Univ.LMap.t
 let _pr_constraints_map (cmap:constraints_map) =
   LMap.fold (fun l cstrs acc -> 
     Level.pr l ++ str " => " ++ 
-      prlist_with_sep spc (fun (d,r) -> pr_constraint_type d ++ Level.pr r) cstrs ++
+      prlist_with_sep (spc ()) (fun (d,r) -> pr_constraint_type d ++ Level.pr r) cstrs ++
       fnl () ++ acc)
     cmap (mt ())
 

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -260,7 +260,7 @@ let pr_scope_stack = function
   | [] -> str "the empty scope stack"
   | [a] -> str "scope " ++ str a
   | l -> str "scope stack " ++
-      str "[" ++ prlist_with_sep pr_comma str l ++ str "]"
+      str "[" ++ prlist_with_sep (pr_comma ()) str l ++ str "]"
 
 let error_inconsistent_scope ?loc id scopes1 scopes2 =
   user_err ?loc ~hdr:"set_var_scope"

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -837,7 +837,7 @@ let pr_scope_classes sc =
   | _ :: ll ->
     let opt_s = match ll with [] -> mt () | _ -> str "es" in
     hov 0 (str "Bound to class" ++ opt_s ++
-      spc() ++ prlist_with_sep spc pr_scope_class l) ++ fnl()
+      spc() ++ prlist_with_sep (spc ()) pr_scope_class l) ++ fnl()
 
 let pr_notation_info prglob ntn c =
   str "\"" ++ str ntn ++ str "\" := " ++

--- a/kernel/cbytecodes.ml
+++ b/kernel/cbytecodes.ml
@@ -231,16 +231,16 @@ let rec pp_instr i =
       h 1 (str "closurerec " ++
 	     int fv ++ str ", " ++ int init ++
 	     str " types = " ++
-	     prlist_with_sep spc pp_lbl (Array.to_list lblt) ++
+	     prlist_with_sep (spc ()) pp_lbl (Array.to_list lblt) ++
 	     str " bodies = " ++
-	     prlist_with_sep spc pp_lbl (Array.to_list lblb))
+	     prlist_with_sep (spc ()) pp_lbl (Array.to_list lblb))
   | Kclosurecofix (fv,init,lblt,lblb) ->
       h 1 (str "closurecofix " ++
 	     int fv ++ str ", " ++ int init ++
 	     str " types = " ++
-	     prlist_with_sep spc pp_lbl (Array.to_list lblt) ++
+	     prlist_with_sep (spc ()) pp_lbl (Array.to_list lblt) ++
 	     str " bodies = " ++
-	     prlist_with_sep spc pp_lbl (Array.to_list lblb))
+	     prlist_with_sep (spc ()) pp_lbl (Array.to_list lblb))
   | Kgetglobal idu -> str "getglobal " ++ pr_con idu
   | Kconst sc ->
       str "const " ++ pp_struct_const sc
@@ -252,9 +252,9 @@ let rec pp_instr i =
 	pp_lbl lbls ++ str ", " ++ int sz
   | Kswitch(lblc,lblb) ->
       h 1 (str "switch " ++
-	     prlist_with_sep spc pp_lbl (Array.to_list lblc) ++
+	     prlist_with_sep (spc ()) pp_lbl (Array.to_list lblc) ++
 	     str " | " ++
-	     prlist_with_sep spc pp_lbl (Array.to_list lblb))
+	     prlist_with_sep (spc ()) pp_lbl (Array.to_list lblb))
   | Kpushfields n -> str "pushfields " ++ int n
   | Kfield n -> str "field " ++ int n
   | Ksetfield n -> str "set field" ++ int n

--- a/kernel/cbytegen.ml
+++ b/kernel/cbytegen.ml
@@ -934,7 +934,7 @@ let dump_bytecodes init code fvs =
      pp_bytecodes init ++ fnl () ++
      pp_bytecodes code ++ fnl () ++
      str "fv = " ++
-     prlist_with_sep (fun () -> str "; ") pp_fv_elem fvs ++
+     prlist_with_sep (str "; ") pp_fv_elem fvs ++
      fnl ())
 
 let compile fail_on_error ?universes:(universes=0) env c =

--- a/kernel/mod_subst.ml
+++ b/kernel/mod_subst.ml
@@ -108,7 +108,7 @@ let debug_pr_subst sub =
   let f (s1,(s2,s3)) = hov 2 (str s1 ++ spc () ++ str "|-> " ++ str s2 ++
 			      spc () ++ str "[" ++ str s3 ++ str "]")
   in
-  str "{" ++ hov 2 (prlist_with_sep pr_comma f l) ++ str "}"
+  str "{" ++ hov 2 (prlist_with_sep (pr_comma ()) f l) ++ str "}"
 
 (* </debug> *)
 

--- a/kernel/univ.ml
+++ b/kernel/univ.ml
@@ -347,7 +347,7 @@ module LMap = struct
       ext empty
 
   let pr f m =
-    h 0 (prlist_with_sep fnl (fun (u, v) ->
+    h 0 (prlist_with_sep (fnl ()) (fun (u, v) ->
       Level.pr u ++ f v) (bindings m))
 end
 
@@ -355,7 +355,7 @@ module LSet = struct
   include LMap.Set
 
   let pr prl s =
-    str"{" ++ prlist_with_sep spc prl (elements s) ++ str"}"
+    str"{" ++ prlist_with_sep (spc ()) prl (elements s) ++ str"}"
 
   let of_array l =
     Array.fold_left (fun acc x -> add x acc) empty l
@@ -552,14 +552,14 @@ struct
     | Cons (u, _, Nil) -> Expr.pr u
     | _ -> 
       str "max(" ++ hov 0
-	(prlist_with_sep pr_comma Expr.pr (to_list l)) ++
+	(prlist_with_sep (pr_comma ()) Expr.pr (to_list l)) ++
         str ")"
 
   let pr_with f l = match l with
     | Cons (u, _, Nil) -> Expr.pr_with f u
     | _ -> 
       str "max(" ++ hov 0
-	(prlist_with_sep pr_comma (Expr.pr_with f) (to_list l)) ++
+	(prlist_with_sep (pr_comma ()) (Expr.pr_with f) (to_list l)) ++
         str ")"
 
   let is_level l = match l with

--- a/lib/cErrors.ml
+++ b/lib/cErrors.ml
@@ -86,7 +86,7 @@ let print_backtrace e = match Backtrace.get_backtrace e with
 | Some bt ->
   let bt = Backtrace.repr bt in
   let pr_frame f = str (Backtrace.print_frame f) in
-  let bt = prlist_with_sep fnl pr_frame bt in
+  let bt = prlist_with_sep (fnl ()) pr_frame bt in
   fnl () ++ hov 0 bt
 
 let print_anomaly askreport e =

--- a/lib/pp.mli
+++ b/lib/pp.mli
@@ -143,9 +143,10 @@ val prlist_strict :  ('a -> std_ppcmds) -> 'a list -> std_ppcmds
 (** Same as [prlist], but strict. *)
 
 val prlist_with_sep :
-   (unit -> std_ppcmds) -> ('a -> std_ppcmds) -> 'a list -> std_ppcmds
+   std_ppcmds -> ('a -> std_ppcmds) -> 'a list -> std_ppcmds
 (** [prlist_with_sep sep pr [a ; ... ; c]] outputs
-    [pr a ++ sep() ++ ... ++ sep() ++ pr c]. *)
+    [pr a ++ sep ++ ... ++ sep ++ pr c]. 
+*)
 
 val prvect : ('a -> std_ppcmds) -> 'a array -> std_ppcmds
 (** As [prlist], but on arrays. *)

--- a/lib/system.ml
+++ b/lib/system.ml
@@ -91,7 +91,7 @@ let warn_ambiguous_file_name =
   CWarnings.create ~name:"ambiguous-file-name" ~category:"filesystem"
     (fun (filename,l,f) -> str filename ++ str " has been found in" ++ spc () ++
                 hov 0 (str "[ " ++
-                         hv 0 (prlist_with_sep (fun () -> str " " ++ pr_semicolon())
+                         hv 0 (prlist_with_sep (str " " ++ pr_semicolon())
                                                (fun (lpe,_) -> str lpe) l)
                        ++ str " ];") ++ fnl () ++
                 str "loading " ++ str f)

--- a/library/coqlib.ml
+++ b/library/coqlib.ml
@@ -52,14 +52,14 @@ let gen_reference_in_modules locstr dirs s =
     | [] ->
 	anomaly ~label:locstr (str "cannot find " ++ str s ++
 	str " in module" ++ str (if List.length dirs > 1 then "s " else " ") ++
-	prlist_with_sep pr_comma pr_dirpath dirs ++ str ".")
+	prlist_with_sep (pr_comma ()) pr_dirpath dirs ++ str ".")
     | l ->
       anomaly ~label:locstr
 	(str "ambiguous name " ++ str s ++ str " can represent " ++
-	   prlist_with_sep pr_comma
+	   prlist_with_sep (pr_comma ())
 	   (fun x -> Libnames.pr_path (Nametab.path_of_global x)) l ++
 	   str " in module" ++ str (if List.length dirs > 1 then "s " else " ") ++
-	   prlist_with_sep pr_comma pr_dirpath dirs ++ str ".")
+	   prlist_with_sep (pr_comma ()) pr_dirpath dirs ++ str ".")
 
 (* For tactics/commands requiring vernacular libraries *)
 

--- a/library/declare.ml
+++ b/library/declare.ml
@@ -422,7 +422,7 @@ let fixpoint_message indexes l =
       (match indexes with
 	 | Some [|i|] -> str " (decreasing on "++pr_rank i++str " argument)"
 	 | _ -> mt ())
-  | l -> hov 0 (prlist_with_sep pr_comma pr_id l ++
+  | l -> hov 0 (prlist_with_sep (pr_comma ()) pr_id l ++
 		  spc () ++ str "are recursively defined" ++
 		  match indexes with
 		    | Some a -> spc () ++ str "(decreasing respectively on " ++
@@ -434,7 +434,7 @@ let cofixpoint_message l =
   Flags.if_verbose Feedback.msg_info (match l with
   | [] -> anomaly (Pp.str "No corecursive definition.")
   | [id] -> pr_id id ++ str " is corecursively defined"
-  | l -> hov 0 (prlist_with_sep pr_comma pr_id l ++
+  | l -> hov 0 (prlist_with_sep (pr_comma ()) pr_id l ++
                     spc () ++ str "are corecursively defined"))
 
 let recursive_message isfix i l =

--- a/library/keys.ml
+++ b/library/keys.ml
@@ -153,7 +153,7 @@ let pr_key pr_global = function
   | KRel -> str"Rel"
 
 let pr_keyset pr_global v = 
-  prlist_with_sep spc (pr_key pr_global) (Keyset.elements v)
+  prlist_with_sep (spc ()) (pr_key pr_global) (Keyset.elements v)
 
 let pr_mapping pr_global k v = 
   pr_key pr_global k ++ str" <-> " ++ pr_keyset pr_global v

--- a/plugins/cc/ccproof.ml
+++ b/plugins/cc/ccproof.ml
@@ -130,7 +130,7 @@ and constr_proof uf i ipac=
       
 and path_proof uf i l=
   debug (fun () -> str "path_proof " ++ pr_idx_term uf i ++ brk (1,20) ++ str "{" ++
-	   (prlist_with_sep (fun () -> str ",") (fun ((_,j),_) -> int j) l) ++ str "}");
+	   (prlist_with_sep (str ",") (fun ((_,j),_) -> int j) l) ++ str "}");
   match l with
   | [] -> prefl (term uf i)
   | x::q->ptrans (path_proof uf (snd (fst x)) q) (edge_proof uf x)

--- a/plugins/cc/cctac.ml
+++ b/plugins/cc/cctac.ml
@@ -455,7 +455,7 @@ let cc_tactic depth additionnal_terms =
 		 begin
 		   str "\"congruence with (" ++
 		     prlist_with_sep
-		     (fun () -> str ")" ++ spc () ++ str "(")
+		     (str ")" ++ spc () ++ str "(")
 		     pr_missing
 		     terms_to_complete ++
 		     str ")\","

--- a/plugins/extraction/common.ml
+++ b/plugins/extraction/common.ml
@@ -36,7 +36,7 @@ let pp_par par st = if par then str "(" ++ st ++ str ")" else st
 
 let pp_apply st par args = match args with
   | [] -> st
-  | _  -> hov 2 (pp_par par (st ++ spc () ++ prlist_with_sep spc identity args))
+  | _  -> hov 2 (pp_par par (st ++ spc () ++ prlist_with_sep (spc ()) identity args))
 
 (** Same as [pp_apply], but with also protection of the head by parenthesis *)
 
@@ -46,23 +46,23 @@ let pp_apply2 st par args =
 
 let pr_binding = function
   | [] -> mt ()
-  | l  -> str " " ++ prlist_with_sep (fun () -> str " ") Id.print l
+  | l  -> str " " ++ prlist_with_sep (str " ") Id.print l
 
 let pp_tuple_light f = function
   | [] -> mt ()
   | [x] -> f true x
   | l ->
-      pp_par true (prlist_with_sep (fun () -> str "," ++ spc ()) (f false) l)
+      pp_par true (prlist_with_sep (str "," ++ spc ()) (f false) l)
 
 let pp_tuple f = function
   | [] -> mt ()
   | [x] -> f x
-  | l -> pp_par true (prlist_with_sep (fun () -> str "," ++ spc ()) f l)
+  | l -> pp_par true (prlist_with_sep (str "," ++ spc ()) f l)
 
 let pp_boxed_tuple f = function
   | [] -> mt ()
   | [x] -> f x
-  | l -> pp_par true (hov 0 (prlist_with_sep (fun () -> str "," ++ spc ()) f l))
+  | l -> pp_par true (hov 0 (prlist_with_sep (str "," ++ spc ()) f l))
 
 (** By default, in module Format, you can do horizontal placing of blocks
     even if they include newlines, as long as the number of chars in the

--- a/plugins/extraction/extract_env.ml
+++ b/plugins/extraction/extract_env.ml
@@ -494,7 +494,7 @@ let get_comment () =
   if String.is_empty s then None
   else
     let split_comment = Str.split (Str.regexp "[ \t\n]+") s in
-    Some (prlist_with_sep spc str split_comment)
+    Some (prlist_with_sep (spc ()) str split_comment)
 
 let print_structure_to_file (fn,si,mo) dry struc =
   Buffer.clear buf;

--- a/plugins/extraction/haskell.ml
+++ b/plugins/extraction/haskell.ml
@@ -93,7 +93,7 @@ let preamble mod_name comment used_modules usf =
 let pp_abst = function
   | [] -> (mt ())
   | l  -> (str "\\" ++
-             prlist_with_sep (fun () -> (str " ")) Id.print l ++
+             prlist_with_sep (str " ") Id.print l ++
              str " ->" ++ spc ())
 
 (*s The pretty-printer for haskell syntax *)
@@ -118,7 +118,7 @@ let rec pp_type par vl t =
     | Tglob (r,l) ->
 	  pp_par par
 	    (pp_global Type r ++ spc () ++
-	     prlist_with_sep spc (pp_type true vl) l)
+	     prlist_with_sep (spc ()) (pp_type true vl) l)
     | Tarr (t1,t2) ->
 	pp_par par
 	  (pp_rec true t1 ++ spc () ++ str "->" ++ spc () ++ pp_rec false t2)
@@ -179,7 +179,7 @@ let rec pp_expr par env args =
 	    pp_par par (pp_global Cons r ++ spc () ++ pp_expr true env [] a)
 	  | _ ->
 	    pp_par par (pp_global Cons r ++ spc () ++
-			prlist_with_sep spc (pp_expr true env []) a)
+			prlist_with_sep (spc ()) (pp_expr true env []) a)
 	end
     | MLtuple l ->
         assert (List.is_empty args);
@@ -219,7 +219,7 @@ let rec pp_expr par env args =
 
 and pp_cons_pat par r ppl =
   pp_par par
-    (pp_global Cons r ++ space_if (not (List.is_empty ppl)) ++ prlist_with_sep spc identity ppl)
+    (pp_global Cons r ++ space_if (not (List.is_empty ppl)) ++ prlist_with_sep (spc ()) identity ppl)
 
 and pp_gen_pat par ids env = function
   | Pcons (r,l) -> pp_cons_pat par r (List.map (pp_gen_pat true ids env) l)
@@ -274,7 +274,7 @@ let pp_singleton kn packet =
   let name = pp_global Type (IndRef (kn,0)) in
   let l = rename_tvars keywords packet.ip_vars in
   hov 2 (str "type " ++ name ++ spc () ++
-	 prlist_with_sep spc Id.print l ++
+	 prlist_with_sep (spc ()) Id.print l ++
 	 (if not (List.is_empty l) then str " " else mt ()) ++ str "=" ++ spc () ++
 	 pp_type false l (List.hd packet.ip_types.(0)) ++ fnl () ++
 	 pp_comment (str "singleton inductive, whose constructor was " ++
@@ -288,7 +288,7 @@ let pp_one_ind ip pl cv =
        | [] -> (mt ())
        | _  -> (str " " ++
       	       	prlist_with_sep
-		  (fun () -> (str " ")) (pp_type true pl) l))
+		  (str " ") (pp_type true pl) l))
   in
   str (if Array.is_empty cv then "type " else "data ") ++
   pp_global Type (IndRef ip) ++

--- a/plugins/extraction/json.ml
+++ b/plugins/extraction/json.ml
@@ -28,7 +28,7 @@ let json_dict_one (k, v) =
 
 let json_dict_open l =
   str ("{") ++ fnl () ++
-  str ("  ") ++ hov 0 (prlist_with_sep pr_comma json_dict_one l)
+  str ("  ") ++ hov 0 (prlist_with_sep (pr_comma ()) json_dict_one l)
 
 let json_dict l =
   json_dict_open l ++ fnl () ++
@@ -36,7 +36,7 @@ let json_dict l =
 
 let json_list l =
   str ("[") ++ fnl () ++
-  str ("  ") ++ hov 0 (prlist_with_sep pr_comma (fun x -> x) l) ++ fnl () ++
+  str ("  ") ++ hov 0 (prlist_with_sep (pr_comma ()) (fun x -> x) l) ++ fnl () ++
   str ("]")
 
 let json_listarr a =
@@ -251,13 +251,13 @@ and pp_module_expr = function
 let pp_struct mls =
   let pp_sel (mp,sel) =
     push_visible mp [];
-    let p = prlist_with_sep pr_comma identity
+    let p = prlist_with_sep (pr_comma ()) identity
       (List.concat (List.map pp_structure_elem sel)) in
     pop_visible (); p
   in
   str "," ++ fnl () ++
   str "  " ++ qs "declarations" ++ str ": [" ++ fnl () ++
-  str "    " ++ hov 0 (prlist_with_sep pr_comma pp_sel mls) ++ fnl () ++
+  str "    " ++ hov 0 (prlist_with_sep (pr_comma ()) pp_sel mls) ++ fnl () ++
   str "  ]" ++ fnl () ++
   str "}" ++ fnl ()
 

--- a/plugins/extraction/ocaml.ml
+++ b/plugins/extraction/ocaml.ml
@@ -29,7 +29,7 @@ let pp_tvar id = str ("'" ^ Id.to_string id)
 let pp_abst = function
   | [] -> mt ()
   | l  ->
-      str "fun " ++ prlist_with_sep (fun () -> str " ") Id.print l ++
+      str "fun " ++ prlist_with_sep (str " ") Id.print l ++
       str " ->" ++ spc ()
 
 let pp_parameters l =
@@ -313,7 +313,7 @@ and pp_record_proj par env typ t pv args =
 
 and pp_record_pat (fields, args) =
    str "{ " ++
-   prlist_with_sep (fun () -> str ";" ++ spc ())
+   prlist_with_sep (str ";" ++ spc ())
      (fun (f,a) -> f ++ str " =" ++ spc () ++ a)
      (List.combine fields args) ++
    str " }"
@@ -444,7 +444,7 @@ let pp_one_ind prefix ip_equiv pl name cnames ctyps =
     hov 3 (str "| " ++ cnames.(i) ++
 	   (if List.is_empty typs then mt () else str " of ") ++
 	   prlist_with_sep
-	    (fun () -> spc () ++ str "* ") (pp_type true pl) typs)
+	    (spc () ++ str "* ") (pp_type true pl) typs)
   in
   pp_parameters pl ++ str prefix ++ name ++
   pp_equiv pl name ip_equiv ++ str " =" ++
@@ -474,7 +474,7 @@ let pp_record kn fields ip_equiv packet =
   let pl = rename_tvars keywords packet.ip_vars in
   str "type " ++ pp_parameters pl ++ name ++
   pp_equiv pl name ip_equiv ++ str " = { "++
-  hov 0 (prlist_with_sep (fun () -> str ";" ++ spc ())
+  hov 0 (prlist_with_sep (str ";" ++ spc ())
 	   (fun (p,t) -> p ++ str " : " ++ pp_type true pl t) l)
   ++ str " }"
 
@@ -628,7 +628,7 @@ and pp_module_type params = function
       str "sig" ++ fnl () ++
       (if List.is_empty l then mt ()
        else
-         v 1 (str " " ++ prlist_with_sep cut2 identity l) ++ fnl ())
+         v 1 (str " " ++ prlist_with_sep (cut2 ()) identity l) ++ fnl ())
       ++ str "end"
   | MTwith(mt,ML_With_type(idl,vl,typ)) ->
       let ids = pp_parameters (rename_tvars keywords vl) in
@@ -706,7 +706,7 @@ and pp_module_expr params = function
       str "struct" ++ fnl () ++
       (if List.is_empty l then mt ()
        else
-         v 1 (str " " ++ prlist_with_sep cut2 identity l) ++ fnl ())
+         v 1 (str " " ++ prlist_with_sep (cut2 ()) identity l) ++ fnl ())
       ++ str "end"
 
 let rec prlist_sep_nonempty sep f = function

--- a/plugins/extraction/scheme.ml
+++ b/plugins/extraction/scheme.ml
@@ -49,7 +49,7 @@ let pp_abst st = function
   | [] -> assert false
   | [id] -> paren (str "lambda " ++ paren (pr_id id) ++ spc () ++ st)
   | l -> paren
-	(str "lambdas " ++ paren (prlist_with_sep spc pr_id l) ++ spc () ++ st)
+	(str "lambdas " ++ paren (prlist_with_sep (spc ()) pr_id l) ++ spc () ++ st)
 
 let pp_apply st _ = function
   | [] -> st
@@ -94,7 +94,7 @@ let rec pp_expr env args =
 	  str "`" ++
 	  paren (pp_global Cons r ++
 		 (if List.is_empty args' then mt () else spc ()) ++
-		 prlist_with_sep spc (pp_cons_args env) args')
+		 prlist_with_sep (spc ()) (pp_cons_args env) args')
 	in
 	if is_coinductive r then paren (str "delay " ++ st) else st
     | MLtuple _ -> user_err Pp.(str "Cannot handle tuples in Scheme yet.")
@@ -133,7 +133,7 @@ and pp_cons_args env = function
   | MLcons (_,r,args) when is_coinductive r ->
       paren (pp_global Cons r ++
 	     (if List.is_empty args then mt () else spc ()) ++
-	     prlist_with_sep spc (pp_cons_args env) args)
+	     prlist_with_sep (spc ()) (pp_cons_args env) args)
   | e -> str "," ++ pp_expr env [] e
 
 and pp_one_pat env (ids,p,t) =
@@ -145,7 +145,7 @@ and pp_one_pat env (ids,p,t) =
   let ids,env' = push_vars (List.rev_map id_of_mlid ids) env in
   let args =
     if List.is_empty ids then mt ()
-    else (str " " ++ prlist_with_sep spc pr_id (List.rev ids))
+    else (str " " ++ prlist_with_sep (spc ()) pr_id (List.rev ids))
   in
   (pp_global Cons r ++ args), (pp_expr env' [] t)
 

--- a/plugins/extraction/table.ml
+++ b/plugins/extraction/table.ml
@@ -306,7 +306,7 @@ let warn_extraction_axiom_to_realize =
          (fun axioms ->
           let s = if Int.equal (List.length axioms) 1 then "axiom" else "axioms" in
           strbrk ("The following "^s^" must be realized in the extracted code:")
-                   ++ hov 1 (spc () ++ prlist_with_sep spc safe_pr_global axioms)
+                   ++ hov 1 (spc () ++ prlist_with_sep (spc ()) safe_pr_global axioms)
                    ++ str "." ++ fnl ())
 
 let warn_extraction_logical_axiom =
@@ -316,7 +316,7 @@ let warn_extraction_logical_axiom =
             if Int.equal (List.length axioms) 1 then "axiom was" else "axioms were"
           in
           (strbrk ("The following logical "^s^" encountered:") ++
-             hov 1 (spc () ++ prlist_with_sep spc safe_pr_global axioms ++ str ".\n")
+             hov 1 (spc () ++ prlist_with_sep (spc ()) safe_pr_global axioms ++ str ".\n")
            ++ strbrk "Having invalid logical axiom in the environment when extracting"
            ++ spc () ++ strbrk "may lead to incorrect or non-terminating ML terms." ++
              fnl ()))
@@ -346,7 +346,7 @@ let warn_extraction_opaque_as_axiom =
 let warning_opaques accessed =
   let opaques = Refset'.elements !opaques in
   if not (List.is_empty opaques) then
-    let lst = hov 1 (spc () ++ prlist_with_sep spc safe_pr_global opaques) in
+    let lst = hov 1 (spc () ++ prlist_with_sep (spc ()) safe_pr_global opaques) in
     if accessed then warn_extraction_opaque_accessed lst
     else warn_extraction_opaque_as_axiom lst
 
@@ -800,7 +800,7 @@ let extraction_blacklist l =
 (* Printing part *)
 
 let print_extraction_blacklist () =
-  prlist_with_sep fnl Id.print (Id.Set.elements !blacklist_table)
+  prlist_with_sep (fnl ()) Id.print (Id.Set.elements !blacklist_table)
 
 (* Reset part *)
 

--- a/plugins/funind/functional_principles_proofs.ml
+++ b/plugins/funind/functional_principles_proofs.ml
@@ -1127,11 +1127,11 @@ let prove_princ_for_struct (evd:Evd.evar_map ref) interactive_proof fun_num fnam
 	)
     in
     observe (str "full_params := " ++
-	       prlist_with_sep spc (RelDecl.get_name %> Nameops.Name.get_id %> Ppconstr.pr_id)
+	       prlist_with_sep (spc ()) (RelDecl.get_name %> Nameops.Name.get_id %> Ppconstr.pr_id)
 	       full_params
 	    );
     observe (str "princ_params := " ++
-	       prlist_with_sep spc (RelDecl.get_name %> Nameops.Name.get_id %> Ppconstr.pr_id)
+	       prlist_with_sep (spc ()) (RelDecl.get_name %> Nameops.Name.get_id %> Ppconstr.pr_id)
 	       princ_params
 	    );
     observe (str "fbody_with_full_params := " ++
@@ -1308,8 +1308,8 @@ let prove_princ_for_struct (evd:Evd.evar_map ref) interactive_proof fun_num fnam
 			 dyn_infos)
 		     in
 (* 		     observe (str "branches := " ++ *)
-(* 				prlist_with_sep spc (fun decl -> Ppconstr.pr_id (id_of_decl decl)) princ_info.branches ++  fnl () ++ *)
-(* 			   str "args := " ++ prlist_with_sep spc Ppconstr.pr_id  args_id *)
+(* 				prlist_with_sep (spc ()) (fun decl -> Ppconstr.pr_id (id_of_decl decl)) princ_info.branches ++  fnl () ++ *)
+(* 			   str "args := " ++ prlist_with_sep (spc ()) Ppconstr.pr_id  args_id *)
 
 (* 			   ); *)
 		     (* observe_tac "instancing" *) (instanciate_hyps_with_args prove_tac
@@ -1682,11 +1682,11 @@ let prove_principle_for_gen
 	 let pte_info =
 	   { proving_tac =
 	       (fun eqs ->
-(* 		  msgnl (str "tcc_list := "++ prlist_with_sep spc Ppconstr.pr_id  !tcc_list); *)
-(* 		  msgnl (str "princ_info.args := "++ prlist_with_sep spc Ppconstr.pr_id  (List.map  (fun (na,_,_) -> (Nameops.Name.get_id na)) princ_info.args)); *)
-(* 		  msgnl (str "princ_info.params := "++ prlist_with_sep spc Ppconstr.pr_id  (List.map  (fun (na,_,_) -> (Nameops.Name.get_id na)) princ_info.params)); *)
+(* 		  msgnl (str "tcc_list := "++ prlist_with_sep (spc ()) Ppconstr.pr_id  !tcc_list); *)
+(* 		  msgnl (str "princ_info.args := "++ prlist_with_sep (spc ()) Ppconstr.pr_id  (List.map  (fun (na,_,_) -> (Nameops.Name.get_id na)) princ_info.args)); *)
+(* 		  msgnl (str "princ_info.params := "++ prlist_with_sep (spc ()) Ppconstr.pr_id  (List.map  (fun (na,_,_) -> (Nameops.Name.get_id na)) princ_info.params)); *)
 (* 		  msgnl (str "acc_rec_arg_id := "++  Ppconstr.pr_id acc_rec_arg_id); *)
-(* 		  msgnl (str "eqs := "++ prlist_with_sep spc Ppconstr.pr_id  eqs); *)
+(* 		  msgnl (str "eqs := "++ prlist_with_sep (spc ()) Ppconstr.pr_id  eqs); *)
 
 		  (* observe_tac "new_prove_with_tcc"  *)
 		    (new_prove_with_tcc

--- a/plugins/funind/g_indfun.ml4
+++ b/plugins/funind/g_indfun.ml4
@@ -105,7 +105,7 @@ TACTIC EXTEND snewfunind
 END
 
 
-let pr_constr_comma_sequence prc _ _ = prlist_with_sep pr_comma prc
+let pr_constr_comma_sequence prc _ _ = prlist_with_sep (pr_comma ()) prc
 
 ARGUMENT EXTEND constr_comma_sequence'
   TYPED AS constr_list

--- a/plugins/funind/indfun.ml
+++ b/plugins/funind/indfun.ml
@@ -318,10 +318,10 @@ let warning_error names e =
   in
   match e with
     | Building_graph e ->
-       let names = prlist_with_sep (fun _ -> str","++spc ()) Ppconstr.pr_id names in
+       let names = prlist_with_sep (str "," ++ spc ()) Ppconstr.pr_id names in
        warn_cannot_define_graph (names,e_explain e)
     | Defining_principle e ->
-       let names = prlist_with_sep (fun _ -> str","++spc ()) Ppconstr.pr_id names in
+       let names = prlist_with_sep (str "," ++ spc ()) Ppconstr.pr_id names in
        warn_cannot_define_principle (names,e_explain e)
     | _ -> raise e
 
@@ -336,7 +336,7 @@ let error_error names e =
     | Building_graph e ->
 	user_err 
 	  (str "Cannot define graph(s) for " ++
-	     h 1 (prlist_with_sep (fun _ -> str","++spc ()) Ppconstr.pr_id names) ++
+	     h 1 (prlist_with_sep (str "," ++ spc ()) Ppconstr.pr_id names) ++
 	     e_explain e)
     | _ -> raise e
 

--- a/plugins/funind/indfun_common.ml
+++ b/plugins/funind/indfun_common.ml
@@ -354,7 +354,7 @@ let pr_info f_info =
 
 let pr_table tb =
   let l = Cmap_env.fold (fun k v acc -> v::acc) tb [] in
-  Pp.prlist_with_sep fnl pr_info l
+  Pp.prlist_with_sep (fnl ()) pr_info l
 
 let in_Function : function_info -> Libobject.obj =
   Libobject.declare_object

--- a/plugins/ltac/g_ltac.ml4
+++ b/plugins/ltac/g_ltac.ml4
@@ -397,7 +397,7 @@ let pr_range_selector (i, j) =
 
 let pr_ltac_selector = function
 | SelectNth i -> int i ++ str ":"
-| SelectList l -> str "[" ++ prlist_with_sep (fun () -> str ", ") pr_range_selector l ++
+| SelectList l -> str "[" ++ prlist_with_sep (str ", ") pr_range_selector l ++
     str "]" ++ str ":"
 | SelectId id -> str "[" ++ Id.print id ++ str "]" ++ str ":"
 | SelectAll -> str "all" ++ str ":"

--- a/plugins/ltac/pptactic.ml
+++ b/plugins/ltac/pptactic.ml
@@ -284,7 +284,7 @@ type 'a extra_genarg_printer =
   | Extend.Ulist1sep (s, sep) | Extend.Ulist0sep (s, sep) ->
     begin match get_list arg with
     | None -> str "ltac:(" ++ prtac (1, Any) arg ++ str ")"
-    | Some l -> prlist_with_sep (fun () -> str sep) (pr_any_arg prtac s) l
+    | Some l -> prlist_with_sep (str sep) (pr_any_arg prtac s) l
     end
   | Extend.Uopt s ->
     begin match get_opt arg with
@@ -416,7 +416,7 @@ type 'a extra_genarg_printer =
 
   let pr_simple_hyp_clause pr_id = function
     | [] -> mt ()
-    | l -> pr_in (spc () ++ prlist_with_sep spc pr_id l)
+    | l -> pr_in (spc () ++ prlist_with_sep (spc ()) pr_id l)
 
   let pr_in_hyp_as prc pr_id = function
     | None -> mt ()
@@ -428,10 +428,10 @@ type 'a extra_genarg_printer =
     | { onhyps=None; concl_occs=occs } ->
       (pr_with_occurrences (fun () -> str "*") (occs,()))
     | { onhyps=Some l; concl_occs=NoOccurrences } ->
-      prlist_with_sep (fun () -> str ", ") (pr_hyp_location pr_id) l
+      prlist_with_sep (str ", ") (pr_hyp_location pr_id) l
     | { onhyps=Some l; concl_occs=occs } ->
       let pr_occs = pr_with_occurrences (fun () -> str" |- *") (occs,()) in
-      (prlist_with_sep (fun () -> str", ") (pr_hyp_location pr_id) l ++ pr_occs)
+      (prlist_with_sep (str ", ") (pr_hyp_location pr_id) l ++ pr_occs)
 
   let pr_clauses default_is_concl pr_id = function
     | { onhyps=Some []; concl_occs=occs }
@@ -449,7 +449,7 @@ type 'a extra_genarg_printer =
         | _ -> pr_with_occurrences (fun () -> str" |- *") (occs,())
       in
       pr_in
-        (prlist_with_sep (fun () -> str",")
+        (prlist_with_sep (str ",")
            (fun id -> spc () ++ pr_hyp_location pr_id id) l ++ pr_occs)
 
   let pr_orient b = if b then mt () else str "<- "
@@ -480,7 +480,7 @@ type 'a extra_genarg_printer =
 
   let pr_goal_selector = function
     | SelectNth i -> int i ++ str ":"
-    | SelectList l -> str "[" ++ prlist_with_sep (fun () -> str ", ") pr_range_selector l ++
+    | SelectList l -> str "[" ++ prlist_with_sep (str ", ") pr_range_selector l ++
         str "]" ++ str ":"
     | SelectId id -> str "[" ++ Id.print id ++ str "]" ++ str ":"
     | SelectAll -> str "all" ++ str ":"
@@ -512,14 +512,14 @@ type 'a extra_genarg_printer =
         spc () ++ str "=>" ++ brk (1,4) ++ pr t
     (*
       | Pat (rl,mp,t) ->
-      hv 0 (prlist_with_sep pr_comma (pr_match_hyps pr_pat) rl ++
+      hv 0 (prlist_with_sep (pr_comma ()) (pr_match_hyps pr_pat) rl ++
       (if rl <> [] then spc () else mt ()) ++
       hov 0 (str "|-" ++ spc () ++ pr_match_pattern pr_pat mp ++ spc () ++
       str "=>" ++ brk (1,4) ++ pr t))
     *)
     | Pat (rl,mp,t) ->
       hov 0 (
-        hv 0 (prlist_with_sep pr_comma (pr_match_hyps pr_pat) rl) ++
+        hv 0 (prlist_with_sep (pr_comma ()) (pr_match_hyps pr_pat) rl) ++
           (if not (List.is_empty rl) then spc () else mt ()) ++
           hov 0 (
             str "|-" ++ spc () ++ pr_match_pattern pr_pat mp ++ spc () ++
@@ -541,12 +541,12 @@ type 'a extra_genarg_printer =
 
   let pr_seq_body pr tl =
     hv 0 (str "[ " ++
-            prlist_with_sep (fun () -> spc () ++ str "| ") pr tl ++
+            prlist_with_sep (spc () ++ str "| ") pr tl ++
             str " ]")
 
   let pr_dispatch pr tl =
     hv 0 (str "[>" ++
-            prlist_with_sep (fun () -> spc () ++ str "| ") pr tl ++
+            prlist_with_sep (spc () ++ str "| ") pr tl ++
             str " ]")
 
   let pr_opt_tactic pr = function
@@ -575,7 +575,7 @@ type 'a extra_genarg_printer =
 
   let pr_auto_using prc = function
     | [] -> mt ()
-    | l -> hov 2 (keyword "using" ++ spc () ++ prlist_with_sep pr_comma prc l)
+    | l -> hov 2 (keyword "using" ++ spc () ++ prlist_with_sep (pr_comma ()) prc l)
 
   let pr_then () = str ";"
 
@@ -640,9 +640,9 @@ type 'a extra_genarg_printer =
 
       let pr_binder_fix (nal,t) =
         (*  match t with
-            | CHole _ -> spc() ++ prlist_with_sep spc (pr_lname) nal
+            | CHole _ -> spc() ++ prlist_with_sep (spc ()) (pr_lname) nal
             | _ ->*)
-        let s = prlist_with_sep spc pr_lname nal ++ str ":" ++ pr.pr_lconstr t in
+        let s = prlist_with_sep (spc ()) pr_lname nal ++ str ":" ++ pr.pr_lconstr t in
         spc() ++ hov 1 (str"(" ++ s ++ str")") in
 
       let pr_fix_tac (id,n,c) =
@@ -699,12 +699,12 @@ type 'a extra_genarg_printer =
           pr_atom0 t
         | TacIntroPattern (ev,(_::_ as p)) ->
            hov 1 (primitive (if ev then "eintros" else "intros") ++ spc () ++
-                    prlist_with_sep spc (Miscprint.pr_intro_pattern pr.pr_dconstr) p)
+                    prlist_with_sep (spc ()) (Miscprint.pr_intro_pattern pr.pr_dconstr) p)
         | TacApply (a,ev,cb,inhyp) ->
           hov 1 (
             (if a then mt() else primitive "simple ") ++
               primitive (with_evars ev "apply") ++ spc () ++
-              prlist_with_sep pr_comma pr_with_bindings_arg cb ++
+              prlist_with_sep (pr_comma ()) pr_with_bindings_arg cb ++
               pr_non_empty_arg (pr_in_hyp_as pr.pr_dconstr pr.pr_name) inhyp
           )
         | TacElim (ev,cb,cbo) ->
@@ -717,11 +717,11 @@ type 'a extra_genarg_printer =
         | TacMutualFix (id,n,l) ->
           hov 1 (
             primitive "fix" ++ spc () ++ pr_id id ++ pr_intarg n ++ spc()
-            ++ keyword "with" ++ spc () ++ prlist_with_sep spc pr_fix_tac l)
+            ++ keyword "with" ++ spc () ++ prlist_with_sep (spc ()) pr_fix_tac l)
         | TacMutualCofix (id,l) ->
           hov 1 (
             primitive "cofix" ++ spc () ++ pr_id id ++ spc()
-            ++ keyword "with" ++ spc () ++ prlist_with_sep spc pr_cofix_tac l
+            ++ keyword "with" ++ spc () ++ prlist_with_sep (spc ()) pr_cofix_tac l
           )
         | TacAssert (ev,b,Some tac,ipat,c) ->
           hov 1 (
@@ -737,7 +737,7 @@ type 'a extra_genarg_printer =
         | TacGeneralize l ->
           hov 1 (
             primitive "generalize" ++ spc ()
-            ++ prlist_with_sep pr_comma (fun (cl,na) ->
+            ++ prlist_with_sep (pr_comma ()) (fun (cl,na) ->
               pr_with_occurrences pr.pr_constr cl ++ pr_as_name na)
               l
           )
@@ -766,7 +766,7 @@ type 'a extra_genarg_printer =
           hov 1 (
             primitive (with_evars ev (if isrec then "induction" else "destruct"))
             ++ spc ()
-            ++ prlist_with_sep pr_comma (fun (h,ids,cl) ->
+            ++ prlist_with_sep (pr_comma ()) (fun (h,ids,cl) ->
               pr_destruction_arg pr.pr_dconstr pr.pr_dconstr h ++
                 pr_non_empty_arg (pr_with_induction_names pr.pr_dconstr) ids ++
                 pr_opt (pr_clauses None pr.pr_name) cl) l ++
@@ -797,7 +797,7 @@ type 'a extra_genarg_printer =
           hov 1 (
             primitive (with_evars ev "rewrite") ++ spc ()
             ++ prlist_with_sep
-              (fun () -> str ","++spc())
+              (str "," ++ spc ())
               (fun (b,m,c) ->
                 pr_orient b ++ pr_multi m ++
                   pr_with_bindings_arg_full pr.pr_dconstr pr.pr_dconstr c)
@@ -1009,7 +1009,7 @@ type 'a extra_genarg_printer =
             | TacArg(_,TacCall(loc,(f,l))) ->
               pr_with_comments ?loc (hov 1 (
                 pr.pr_reference f ++ spc ()
-                ++ prlist_with_sep spc pr_tacarg l)),
+                ++ prlist_with_sep (spc ()) pr_tacarg l)),
               lcall
             | TacArg (_,a) ->
               pr_tacarg a, latom

--- a/plugins/ltac/tacentries.ml
+++ b/plugins/ltac/tacentries.ml
@@ -507,7 +507,7 @@ let print_ltacs () =
     let pr_ltac_fun_arg n = spc () ++ Name.print n in
     hov 2 (pr_qualid qid ++ prlist pr_ltac_fun_arg l)
   in
-  Feedback.msg_notice (prlist_with_sep fnl pr_entry entries)
+  Feedback.msg_notice (prlist_with_sep (fnl ()) pr_entry entries)
 
 (** Grammar *)
 

--- a/plugins/ltac/tacintern.ml
+++ b/plugins/ltac/tacintern.ml
@@ -734,7 +734,7 @@ let print_ltac id =
   let redefined = match mods with
   | [] -> mt ()
   | mods ->
-    let redef = prlist_with_sep fnl pr_qualid mods in
+    let redef = prlist_with_sep (fnl ()) pr_qualid mods in
     fnl () ++ str "Redefined by:" ++ fnl () ++ redef
   in
   let l,t = split_ltac_fun tac.Tacenv.tac_body in

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -102,7 +102,7 @@ let pr_generic arg =
     str"<" ++ Val.pr tag ++ str ":(" ++ Pptactic.pr_value Pptactic.ltop arg ++ str ")>"
 let pr_appl h vs =
   Pptactic.pr_ltac_constant  h ++ spc () ++
-  Pp.prlist_with_sep spc pr_generic vs
+  Pp.prlist_with_sep (spc ()) pr_generic vs
 let rec name_with_list appl t =
   match appl with
   | [] -> t
@@ -253,7 +253,7 @@ let pr_value env v =
 
 let pr_closure env ist body =
   let pp_body = Pptactic.pr_glob_tactic env body in
-  let pr_sep () = fnl () in
+  let pr_sep = fnl () in
   let pr_iarg (id, arg) =
     let arg = pr_argument_type arg in
     hov 0 (Id.print id ++ spc () ++ str ":" ++ spc () ++ arg)
@@ -861,7 +861,7 @@ let rec message_of_value v =
   else match Value.to_list v with
   | Some l ->
     Ftactic.List.map message_of_value l >>= fun l ->
-    Ftactic.return (prlist_with_sep spc (fun x -> x) l)
+    Ftactic.return (prlist_with_sep (spc ()) (fun x -> x) l)
   | None ->
     let tag = pr_argument_type v in
     Ftactic.return (str "<" ++ tag ++ str ">") (** TODO *)
@@ -878,7 +878,7 @@ let interp_message_token ist = function
 let interp_message ist l =
   let open Ftactic in
   Ftactic.List.map (interp_message_token ist) l >>= fun l ->
-  Ftactic.return (prlist_with_sep spc (fun x -> x) l)
+  Ftactic.return (prlist_with_sep (spc ()) (fun x -> x) l)
 
 let rec interp_intro_pattern ist env sigma = function
   | loc, IntroAction pat ->

--- a/plugins/ltac/tactic_debug.ml
+++ b/plugins/ltac/tactic_debug.ml
@@ -368,7 +368,7 @@ let explain_ltac_call_trace last trace loc =
       quote (Printer.pr_glob_constr_env (Global.env()) c) ++
         (if not (Id.Map.is_empty vars) then
           strbrk " (with " ++
-            prlist_with_sep pr_comma
+            prlist_with_sep (pr_comma ())
             (fun (id,c) ->
                 Id.print id ++ str ":=" ++ Printer.pr_lconstr_under_binders c)
             (List.rev (Id.Map.bindings vars)) ++ str ")"

--- a/plugins/setoid_ring/g_newring.ml4
+++ b/plugins/setoid_ring/g_newring.ml4
@@ -44,11 +44,11 @@ let pr_ring_mod = function
   | Ring_kind Abstract ->  str "abstract"
   | Ring_kind (Morphism morph) -> str "morphism" ++ pr_arg pr_constr_expr morph
   | Const_tac (CstTac cst_tac) -> str "constants" ++ spc () ++ str "[" ++ pr_raw_tactic cst_tac ++ str "]"
-  | Const_tac (Closed l) -> str "closed" ++ spc () ++ str "[" ++ prlist_with_sep spc pr_reference l ++ str "]"
+  | Const_tac (Closed l) -> str "closed" ++ spc () ++ str "[" ++ prlist_with_sep (spc ()) pr_reference l ++ str "]"
   | Pre_tac t -> str "preprocess" ++ spc () ++ str "[" ++ pr_raw_tactic t ++ str "]"
   | Post_tac t -> str "postprocess" ++ spc () ++ str "[" ++ pr_raw_tactic t ++ str "]"
   | Setoid(sth,ext) -> str "setoid" ++ pr_arg pr_constr_expr sth ++ pr_arg pr_constr_expr ext
-  | Pow_spec(Closed l,spec) -> str "power_tac" ++ pr_arg pr_constr_expr spec ++ spc () ++ str "[" ++ prlist_with_sep spc pr_reference l ++ str "]"
+  | Pow_spec(Closed l,spec) -> str "power_tac" ++ pr_arg pr_constr_expr spec ++ spc () ++ str "[" ++ prlist_with_sep (spc ()) pr_reference l ++ str "]"
   | Pow_spec(CstTac cst_tac,spec) -> str "power_tac" ++ pr_arg pr_constr_expr spec ++ spc () ++ str "[" ++ pr_raw_tactic cst_tac ++ str "]"
   | Sign_spec t -> str "sign" ++ pr_arg pr_constr_expr t
   | Div_spec t -> str "div" ++ pr_arg pr_constr_expr t
@@ -71,7 +71,7 @@ VERNAC ARGUMENT EXTEND ring_mod
   | [ "div" constr(div_spec) ] -> [ Div_spec div_spec ]
 END
 
-let pr_ring_mods l = surround (prlist_with_sep pr_comma pr_ring_mod l)
+let pr_ring_mods l = surround (prlist_with_sep (pr_comma ()) pr_ring_mod l)
 
 VERNAC ARGUMENT EXTEND ring_mods
   PRINTED BY pr_ring_mods
@@ -106,7 +106,7 @@ VERNAC ARGUMENT EXTEND field_mod
   | [ "completeness" constr(inj) ] -> [ Inject inj ]
 END
 
-let pr_field_mods l = surround (prlist_with_sep pr_comma pr_field_mod l)
+let pr_field_mods l = surround (prlist_with_sep (pr_comma ()) pr_field_mod l)
 
 VERNAC ARGUMENT EXTEND field_mods
   PRINTED BY pr_field_mods

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -564,7 +564,7 @@ let pf_abs_evars_pirrel gl (sigma, c0) =
   let evlist = put [] c0 in
   if evlist = [] then 0, c0 else
   let pr_constr t = Printer.pr_econstr (Reductionops.nf_beta (project gl) (EConstr.of_constr t)) in
-  pp(lazy(str"evlist=" ++ pr_list (fun () -> str";")
+  pp(lazy(str"evlist=" ++ pr_list (str ";")
     (fun (k,_) -> str(Evd.string_of_existential k)) evlist));
   let evplist = 
     let depev = List.fold_left (fun evs (_,(_,t,_)) -> 

--- a/plugins/ssr/ssrparser.ml4
+++ b/plugins/ssr/ssrparser.ml4
@@ -174,7 +174,7 @@ ARGUMENT EXTEND ssrhoi_id TYPED AS ssrhoirep PRINTED BY pr_ssrhoi
 END
 
 
-let pr_hyps = pr_list pr_spc pr_hyp
+let pr_hyps = pr_list (pr_spc ()) pr_hyp
 let pr_ssrhyps _ _ _ = pr_hyps
 
 ARGUMENT EXTEND ssrhyps TYPED AS ssrhyp list PRINTED BY pr_ssrhyps
@@ -482,7 +482,7 @@ END
 
 (* Views *)
 
-let pr_view = pr_list mt (fun c -> str "/" ++ pr_term c)
+let pr_view = pr_list (mt ()) (fun c -> str "/" ++ pr_term c)
 
 let pr_ssrview _ _ _ = pr_view
 
@@ -546,11 +546,11 @@ let rec pr_ipat p =
   | IPatAnon One -> str "?"
   | IPatView v -> pr_view v
   | IPatNoop -> str "-"
-  | IPatNewHidden l -> str "[:" ++ pr_list spc pr_id l ++ str "]"
+  | IPatNewHidden l -> str "[:" ++ pr_list (spc ()) pr_id l ++ str "]"
 (* TODO  | IPatAnon Temporary -> str "+" *)
 
-and pr_iorpat iorpat = pr_list pr_bar pr_ipats iorpat
-and pr_ipats ipats = pr_list spc pr_ipat ipats
+and pr_iorpat iorpat = pr_list (pr_bar ()) pr_ipats iorpat
+and pr_ipats ipats = pr_list (spc ()) pr_ipat ipats
 
 let wit_ssripatrep = add_genarg "ssripatrep" pr_ipat
 
@@ -952,7 +952,7 @@ let pr_clseq = function
   | InAllHyps       -> str "* |-"
 
 let wit_ssrclseq = add_genarg "ssrclseq" pr_clseq
-let pr_clausehyps = pr_list pr_spc pr_wgen
+let pr_clausehyps = pr_list (pr_spc ()) pr_wgen
 let pr_ssrclausehyps _ _ _ = pr_clausehyps
 
 ARGUMENT EXTEND ssrclausehyps 
@@ -995,7 +995,7 @@ let pr_binder prl = function
   | Bvar x ->
     pr_name x
   | Bdecl (xs, t) ->
-    str "(" ++ pr_list pr_spc pr_name xs ++ str " : " ++ prl t ++ str ")"
+    str "(" ++ pr_list (pr_spc ()) pr_name xs ++ str " : " ++ prl t ++ str ")"
   | Bdef (x, None, v) ->
     str "(" ++ pr_name x ++ str " := " ++ prl v ++ str ")"
   | Bdef (x, Some t, v) ->
@@ -1127,7 +1127,7 @@ let pr_gen_fwd prval prc prlc fk (bs, c) =
   | FwdHint (s,_), _ ->  prc (s ^ "(* typeof *)")
   | FwdHave, [Bcast t] -> str ":" ++ spc () ++ prlc t ++ prc " :="
   | _, [] -> prc " :="
-  | _, _ -> spc () ++ pr_list spc (pr_binder prlc) bs ++ prc " :="
+  | _, _ -> spc () ++ pr_list (spc ()) (pr_binder prlc) bs ++ prc " :="
 
 let pr_fwd_guarded prval prval' = function
 | (fk, h), (_, (_, Some c)) ->
@@ -1703,7 +1703,7 @@ let has_occ ((_, occ), _) = occ <> None
 let gens_sep = function [], [] -> mt | _ -> spc
 
 let pr_dgens pr_gen (gensl, clr) =
-  let prgens s gens = str s ++ pr_list spc pr_gen gens in
+  let prgens s gens = str s ++ pr_list (spc ()) pr_gen gens in
   let prdeps deps = prgens ": " deps ++ spc () ++ str "/" in
   match gensl with
   | [deps; []] -> prdeps deps ++ pr_clear pr_spc clr
@@ -2107,7 +2107,7 @@ END
 
 (* type ssrrwargs = ssrrwarg list *)
 
-let pr_ssrrwargs _ _ _ rwargs = pr_list spc pr_rwarg rwargs
+let pr_ssrrwargs _ _ _ rwargs = pr_list (spc ()) pr_rwarg rwargs
 
 ARGUMENT EXTEND ssrrwargs TYPED AS ssrrwarg list PRINTED BY pr_ssrrwargs
   | [ "YouShouldNotTypeThis" ] -> [ anomaly "Grammar placeholder match" ]
@@ -2155,7 +2155,7 @@ ARGUMENT EXTEND ssrunlockarg TYPED AS ssrocc * ssrterm
   | [  ssrterm(t) ] -> [ None, t ]
 END
 
-let pr_ssrunlockargs _ _ _ args = pr_list spc pr_unlockarg args
+let pr_ssrunlockargs _ _ _ args = pr_list (spc ()) pr_unlockarg args
 
 ARGUMENT EXTEND ssrunlockargs TYPED AS ssrunlockarg list
   PRINTED BY pr_ssrunlockargs
@@ -2261,7 +2261,7 @@ END
 (* type ssrwlogfwd = ssrwgen list * ssrfwd *)
 
 let pr_ssrwlogfwd _ _ _ (gens, t) =
-  str ":" ++ pr_list mt pr_wgen gens ++ spc() ++ pr_fwd t
+  str ":" ++ pr_list (mt ()) pr_wgen gens ++ spc() ++ pr_fwd t
 
 ARGUMENT EXTEND ssrwlogfwd TYPED AS ssrwgen list * ssrfwd
                          PRINTED BY pr_ssrwlogfwd

--- a/plugins/ssr/ssrprinters.ml
+++ b/plugins/ssr/ssrprinters.ml
@@ -67,8 +67,8 @@ let pr_term (k, c) = pr_guarded (guard_term k) pr_glob_constr_and_expr c
 let pr_hyp (SsrHyp (_, id)) = Id.print id
 
 let pr_occ = function
-  | Some (true, occ) -> str "{-" ++ pr_list pr_spc int occ ++ str "}"
-  | Some (false, occ) -> str "{+" ++ pr_list pr_spc int occ ++ str "}"
+  | Some (true, occ) -> str "{-" ++ pr_list (pr_spc ()) int occ ++ str "}"
+  | Some (false, occ) -> str "{+" ++ pr_list (pr_spc ()) int occ ++ str "}"
   | None -> str "{}"
 
 (* 0 cost pp function. Active only if Debug Ssreflect is Set *)

--- a/plugins/ssr/ssrprinters.mli
+++ b/plugins/ssr/ssrprinters.mli
@@ -17,7 +17,7 @@ val pp_term :
 val pr_spc : unit -> Pp.std_ppcmds
 val pr_bar : unit -> Pp.std_ppcmds
 val pr_list : 
-  (unit -> Pp.std_ppcmds) -> ('a -> Pp.std_ppcmds) -> 'a list -> Pp.std_ppcmds
+  Pp.std_ppcmds -> ('a -> Pp.std_ppcmds) -> 'a list -> Pp.std_ppcmds
 
 val pp_concat :
   Pp.std_ppcmds ->

--- a/plugins/ssr/ssrvernac.ml4
+++ b/plugins/ssr/ssrvernac.ml4
@@ -218,7 +218,7 @@ let interp_search_notation ?loc tag okey =
   let pr_ntn ntn = str "(" ++ str ntn ++ str ")" in
   let pr_and_list pr = function
     | [x] -> pr x
-    | x :: lx -> pr_list pr_comma pr lx ++ pr_comma () ++ str "and " ++ pr x
+    | x :: lx -> pr_list (pr_comma ()) pr lx ++ pr_comma () ++ str "and " ++ pr x
     | [] -> mt () in
   let pr_sc sc = str (if sc = "" then "independently" else sc) in
   let pr_scs = function
@@ -309,7 +309,7 @@ END
 
 let pr_ssr_search_arg _ _ _ =
   let pr_item (b, p) = str (if b then "-" else "") ++ pr_search_item p in
-  pr_list spc pr_item
+  pr_list (spc ()) pr_item
 
 ARGUMENT EXTEND ssr_search_arg TYPED AS (bool * ssr_searchitem) list
   PRINTED BY pr_ssr_search_arg
@@ -409,7 +409,7 @@ let pr_modloc (b, m) = if b then str "-" ++ pr_reference m else pr_reference m
 let wit_ssrmodloc = add_genarg "ssrmodloc" pr_modloc
 
 let pr_ssr_modlocs _ _ _ ml =
-  if ml = [] then str "" else spc () ++ str "in " ++ pr_list spc pr_modloc ml
+  if ml = [] then str "" else spc () ++ str "in " ++ pr_list (spc ()) pr_modloc ml
 
 ARGUMENT EXTEND ssr_modlocs TYPED AS ssrmodloc list PRINTED BY pr_ssr_modlocs
   | [ ] -> [ [] ]
@@ -517,7 +517,7 @@ END
 
 let print_view_hints i =
   let pp_viewname = str "Hint View" ++ pr_viewpos i ++ str " " in
-  let pp_hints = pr_list spc pr_rawhintref Ssrview.viewtab.(i) in
+  let pp_hints = pr_list (spc ()) pr_rawhintref Ssrview.viewtab.(i) in
   Feedback.msg_info  (pp_viewname ++ hov 0 pp_hints ++ Pp.cut ())
 
 VERNAC COMMAND EXTEND PrintView CLASSIFIED AS QUERY

--- a/plugins/ssrmatching/ssrmatching.ml4
+++ b/plugins/ssrmatching/ssrmatching.ml4
@@ -1073,7 +1073,7 @@ let thin id sigma goal =
     sigma
 
 let pr_ist { lfun= lfun } =
-  prlist_with_sep spc
+  prlist_with_sep (spc ())
     (fun (id, Geninterp.Val.Dyn(ty,_)) ->
         pr_id id ++ str":" ++ Geninterp.Val.pr ty) (Id.Map.bindings lfun)
 

--- a/pretyping/classops.ml
+++ b/pretyping/classops.ml
@@ -332,7 +332,7 @@ let print_path x = !path_printer x
 
 let message_ambig l =
   (str"Ambiguous paths:" ++ spc () ++
-   prlist_with_sep fnl (fun ijp -> print_path ijp) l)
+   prlist_with_sep (fnl ()) (fun ijp -> print_path ijp) l)
 
 (* add_coercion_in_graph : coe_index * cl_index * cl_index -> unit
                          coercion,source,target *)

--- a/pretyping/find_subterm.ml
+++ b/pretyping/find_subterm.ml
@@ -27,7 +27,7 @@ type occurrence_error =
 let explain_invalid_occurrence l =
   let l = List.sort_uniquize Int.compare l in
   str ("Invalid occurrence " ^ String.plural (List.length l) "number" ^": ")
-  ++ prlist_with_sep spc int l ++ str "."
+  ++ prlist_with_sep (spc ()) int l ++ str "."
 
 let explain_incorrect_in_value_occurrence id =
   pr_id id ++ str " has no value."

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -259,7 +259,7 @@ module Cst_stack = struct
   let pr l =
     let open Pp in
     let p_c c = Termops.print_constr c in
-    prlist_with_sep pr_semicolon
+    prlist_with_sep (pr_semicolon ())
       (fun (c,params,args) ->
 	hov 1 (str"(" ++ p_c c ++ str ")" ++ spc () ++ pr_sequence p_c params ++ spc () ++ str "(args:" ++
 		 pr_sequence (fun (i,el) -> prvect_with_sep spc p_c (Array.sub el i (Array.length el - i))) args ++
@@ -365,13 +365,13 @@ struct
     | Cst (mem,curr,remains,params,cst_l) ->
       str "ZCst(" ++ pr_cst_member pr_c mem ++ pr_comma () ++ int curr
       ++ pr_comma () ++
-	prlist_with_sep pr_semicolon int remains ++
+	prlist_with_sep (pr_semicolon ()) int remains ++
 	pr_comma () ++ pr pr_c params ++ str ")"
     | Shift i -> str "ZShift(" ++ int i ++ str ")"
     | Update t -> str "ZUpdate(" ++ pr_c t ++ str ")"
   and pr pr_c l =
     let open Pp in
-    prlist_with_sep pr_semicolon (fun x -> hov 1 (pr_member pr_c x)) l
+    prlist_with_sep (pr_semicolon ()) (fun x -> hov 1 (pr_member pr_c x)) l
 
   and pr_cst_member pr_c c =
     let open Pp in

--- a/printing/miscprint.ml
+++ b/printing/miscprint.ml
@@ -26,7 +26,7 @@ and pr_intro_pattern_action prc = function
   | IntroWildcard -> str "_"
   | IntroOrAndPattern pll -> pr_or_and_intro_pattern prc pll
   | IntroInjection pl ->
-      str "[=" ++ hv 0 (prlist_with_sep spc (pr_intro_pattern prc) pl) ++
+      str "[=" ++ hv 0 (prlist_with_sep (spc ()) (pr_intro_pattern prc) pl) ++
       str "]"
   | IntroApplyOn ((_,c),pat) -> pr_intro_pattern prc pat ++ str "%" ++ prc c
   | IntroRewrite true -> str "->"
@@ -34,10 +34,10 @@ and pr_intro_pattern_action prc = function
 
 and pr_or_and_intro_pattern prc = function
   | IntroAndPattern pl ->
-      str "(" ++ hv 0 (prlist_with_sep pr_comma (pr_intro_pattern prc) pl) ++ str ")"
+      str "(" ++ hv 0 (prlist_with_sep (pr_comma ()) (pr_intro_pattern prc) pl) ++ str ")"
   | IntroOrPattern pll ->
       str "[" ++
-      hv 0 (prlist_with_sep pr_bar (prlist_with_sep spc (pr_intro_pattern prc)) pll)
+      hv 0 (prlist_with_sep (pr_bar ()) (prlist_with_sep (spc ()) (pr_intro_pattern prc)) pll)
       ++ str "]"
 
 (** Printing of [move_location] *)
@@ -64,9 +64,9 @@ let pr_bindings prc prlc = function
 
 let pr_bindings_no_with prc prlc = function
   | ImplicitBindings l ->
-    brk (0,1) ++ prlist_with_sep spc prc l
+    brk (0,1) ++ prlist_with_sep (spc ()) prc l
   | ExplicitBindings l ->
-    brk (0,1) ++ prlist_with_sep spc (fun b -> str"(" ++ pr_binding prlc b ++ str")") l
+    brk (0,1) ++ prlist_with_sep (spc ()) (fun b -> str"(" ++ pr_binding prlc b ++ str")") l
   | NoBindings -> mt ()
 
 let pr_with_bindings prc prlc (c,bl) =

--- a/printing/ppconstr.ml
+++ b/printing/ppconstr.ml
@@ -103,7 +103,7 @@ let tag_var = tag Tag.variable
         return unp pp1 pp2
       | UnpListMetaVar (_, prec, sl) as unp :: l ->
         let cl = pop envlist in
-        let pp1 = prlist_with_sep (fun () -> aux sl) (pr (n,prec)) cl in
+        let pp1 = prlist_with_sep (aux sl) (pr (n,prec)) cl in
         let pp2 = aux l in
         return unp pp1 pp2
       | UnpBinderListMetaVar (_, isopen, sl) as unp :: l ->
@@ -152,7 +152,7 @@ let tag_var = tag Tag.variable
   let pr_univ l =
     match l with
       | [_,x] -> Name.print x
-      | l -> str"max(" ++ prlist_with_sep (fun () -> str",") (fun x -> Name.print (snd x)) l ++ str")"
+      | l -> str"max(" ++ prlist_with_sep (str ",") (fun x -> Name.print (snd x)) l ++ str")"
 
   let pr_univ_annot pr x = str "@{" ++ pr x ++ str "}"
 
@@ -195,7 +195,7 @@ let tag_var = tag Tag.variable
         | None -> tag_type (str "Type"))
 
   let pr_universe_instance l =
-    pr_opt_no_spc (pr_univ_annot (prlist_with_sep spc pr_glob_sort_instance)) l
+    pr_opt_no_spc (pr_univ_annot (prlist_with_sep (spc ()) pr_glob_sort_instance)) l
 
   let pr_reference = function
   | Qualid (_, qid) -> pr_qualid qid
@@ -241,7 +241,7 @@ let tag_var = tag Tag.variable
           | [] -> mt()
           | l ->
             let f (id,c) = pr_id id ++ str ":=" ++ pr ltop c in
-            str"@{" ++ hov 0 (prlist_with_sep pr_semicolon f (List.rev l)) ++ str"}"))
+            str"@{" ++ hov 0 (prlist_with_sep (pr_semicolon ()) f (List.rev l)) ++ str"}"))
 
   let las = lapp
   let lpator = 100
@@ -253,7 +253,7 @@ let tag_var = tag Tag.variable
         let pp (c, p) =
           pr_reference c ++ spc() ++ str ":=" ++ pr_patt spc (lpatrec, Any) p
         in
-        str "{| " ++ prlist_with_sep pr_semicolon pp l ++ str " |}", lpatrec
+        str "{| " ++ prlist_with_sep (pr_semicolon ()) pp l ++ str " |}", lpatrec
 
       | CPatAlias (p, id) ->
         pr_patt mt (las,E) p ++ str " as " ++ pr_id id, las
@@ -278,7 +278,7 @@ let tag_var = tag Tag.variable
         pr_reference r, latom
 
       | CPatOr pl ->
-        hov 0 (prlist_with_sep pr_bar (pr_patt spc (lpator,L)) pl), lpator
+        hov 0 (prlist_with_sep (pr_bar ()) (pr_patt spc (lpator,L)) pl), lpator
 
       | CPatNotation ("( _ )",([p],[]),[]) ->
         pr_patt (fun()->str"(") (max_int,E) p ++ str")", latom
@@ -307,7 +307,7 @@ let tag_var = tag Tag.variable
     spc() ++ hov 4
       (pr_with_comments ?loc
          (str "| " ++
-            hov 0 (prlist_with_sep pr_bar (prlist_with_sep sep_v (pr_patt ltop)) pl
+            hov 0 (prlist_with_sep (pr_bar ()) (prlist_with_sep (sep_v ()) (pr_patt ltop)) pl
                    ++ str " =>") ++
             pr_sep_com spc (pr ltop) rhs))
 
@@ -350,10 +350,10 @@ let tag_var = tag Tag.variable
       | Default b ->
         match t with
           | { CAst.v = CHole (_,Misctypes.IntroAnonymous,_) } ->
-            let s = prlist_with_sep spc pr_lname nal in
+            let s = prlist_with_sep (spc ()) pr_lname nal in
             hov 1 (surround_implicit b s)
           | _ ->
-            let s = prlist_with_sep spc pr_lname nal ++ str " : " ++ pr t in
+            let s = prlist_with_sep (spc ()) pr_lname nal ++ str " : " ++ pr t in
             hov 1 (if many then surround_impl b s else surround_implicit b s)
 
   let pr_binder_among_many pr_c = function
@@ -372,7 +372,7 @@ let tag_var = tag Tag.variable
           str "'" ++ surround (p ++ spc () ++ str ":" ++ ws 1 ++ pr_c ty)
 
   let pr_undelimited_binders sep pr_c =
-    prlist_with_sep sep (pr_binder_among_many pr_c)
+    prlist_with_sep (sep ()) (pr_binder_among_many pr_c)
 
   let pr_delimited_binders kw sep pr_c bl =
     let n = begin_of_binders bl in
@@ -488,7 +488,7 @@ let tag_var = tag Tag.variable
     | [] -> anomaly (Pp.str "(co)fixpoint with no definition.")
     | [d1] -> pr_decl false d1
     | dl ->
-      prlist_with_sep (fun () -> fnl() ++ keyword "with" ++ spc ())
+      prlist_with_sep (fnl () ++ keyword "with" ++ spc ())
         (pr_decl true) dl ++
         fnl() ++ keyword "for" ++ spc () ++ pr_id id
 
@@ -532,7 +532,7 @@ let tag_var = tag Tag.variable
 
   let pr_record_body_gen pr l =
     spc () ++
-    prlist_with_sep pr_semicolon
+    prlist_with_sep (pr_semicolon ())
       (fun (id, c) -> h 1 (pr_reference id ++ spc () ++ str":=" ++ pr ltop c)) l
 
   let pr_forall n = keyword "forall" ++ pr_com_at n ++ spc ()
@@ -658,7 +658,7 @@ let tag_var = tag Tag.variable
           v 0
             (hv 0 (keyword "match" ++ brk (1,2) ++
                      hov 0 (
-                       prlist_with_sep sep_v
+                       prlist_with_sep (sep_v ())
                          (pr_case_item (pr_dangling_with_for mt pr)) c
                        ++ pr_case_type (pr_dangling_with_for mt pr) rtntypopt) ++
                      spc () ++ keyword "with") ++
@@ -671,7 +671,7 @@ let tag_var = tag Tag.variable
           hv 0 (
             hov 2 (keyword "let" ++ spc () ++
               hov 1 (str "(" ++
-                       prlist_with_sep sep_v pr_lname nal ++
+                       prlist_with_sep (sep_v ()) pr_lname nal ++
                        str ")" ++
                        pr_simple_return_type (pr mt) na po ++ str " :=") ++
                        pr spc ltop c

--- a/printing/pputils.ml
+++ b/printing/pputils.ml
@@ -37,10 +37,10 @@ let pr_with_occurrences pr keyword (occs,c) =
       failwith "pr_with_occurrences: no occurrences"
     | OnlyOccurrences nl ->
       hov 1 (pr c ++ spc () ++ keyword "at" ++ spc () ++
-                hov 0 (prlist_with_sep spc (pr_or_var int) nl))
+                hov 0 (prlist_with_sep (spc ()) (pr_or_var int) nl))
     | AllOccurrencesBut nl ->
       hov 1 (pr c ++ spc () ++ keyword "at" ++ str" - " ++
-                hov 0 (prlist_with_sep spc (pr_or_var int) nl))
+                hov 0 (prlist_with_sep (spc ()) (pr_or_var int) nl))
 
 exception ComplexRedFlag
 
@@ -50,7 +50,7 @@ let pr_short_red_flag pr r =
   else if List.is_empty r.rConst then
     if r.rDelta then mt () else raise ComplexRedFlag
   else (if r.rDelta then str "-" else mt ()) ++
-          hov 0 (str "[" ++ prlist_with_sep spc pr r.rConst ++ str "]")
+          hov 0 (str "[" ++ prlist_with_sep (spc ()) pr r.rConst ++ str "]")
 
 let pr_red_flag pr r =
   try pr_short_red_flag pr r
@@ -66,7 +66,7 @@ let pr_red_flag pr r =
           else mt ()
         else
           pr_arg str "delta " ++ (if r.rDelta then str "-" else mt ()) ++
-            hov 0 (str "[" ++ prlist_with_sep spc pr r.rConst ++ str "]"))
+            hov 0 (str "[" ++ prlist_with_sep (spc ()) pr r.rConst ++ str "]"))
 
 let pr_union pr1 pr2 = function
   | Inl a -> pr1 a
@@ -89,11 +89,11 @@ let pr_red_expr (pr_constr,pr_lconstr,pr_ref,pr_pattern) keyword = function
     hov 1 (keyword "cbn" ++ pr_red_flag pr_ref f)
   | Unfold l ->
     hov 1 (keyword "unfold" ++ spc() ++
-              prlist_with_sep pr_comma (pr_with_occurrences pr_ref keyword) l)
+              prlist_with_sep (pr_comma ()) (pr_with_occurrences pr_ref keyword) l)
   | Fold l -> hov 1 (keyword "fold" ++ prlist (pr_arg pr_constr) l)
   | Pattern l ->
     hov 1 (keyword "pattern" ++
-              pr_arg (prlist_with_sep pr_comma (pr_with_occurrences pr_constr keyword)) l)
+              pr_arg (prlist_with_sep (pr_comma ()) (pr_with_occurrences pr_constr keyword)) l)
 
   | Red true ->
     CErrors.user_err Pp.(str "Shouldn't be accessible from user.")

--- a/printing/ppvernac.ml
+++ b/printing/ppvernac.ml
@@ -40,7 +40,7 @@ open Decl_kinds
   let pr_plident (lid, l) =
     pr_lident lid ++
     (match l with
-     | Some l -> prlist_with_sep spc pr_lident l
+     | Some l -> prlist_with_sep (spc ()) pr_lident l
      | None -> mt())
     
   let string_of_fqid fqid =
@@ -74,8 +74,8 @@ open Decl_kinds
 
   let pr_gen t = Pputils.pr_raw_generic (Global.env ()) t
 
-  let sep = fun _ -> spc()
-  let sep_v2 = fun _ -> str"," ++ spc()
+  let sep = spc ()
+  let sep_v2 = str "," ++ spc()
 
   let pr_set_entry_type = function
     | ETName -> str"ident"
@@ -112,7 +112,7 @@ open Decl_kinds
       | SearchPattern c -> keyword "SearchPattern" ++ spc() ++ pr_p c ++ pr_in_out_modules b
       | SearchRewrite c -> keyword "SearchRewrite" ++ spc() ++ pr_p c ++ pr_in_out_modules b
       | SearchAbout sl ->
-	 keyword "Search" ++ spc() ++ prlist_with_sep spc pr_search_about sl ++ pr_in_out_modules b
+	 keyword "Search" ++ spc() ++ prlist_with_sep (spc ()) pr_search_about sl ++ pr_in_out_modules b
 
   let pr_locality local = if local then keyword "Local" else keyword "Global"
 
@@ -128,7 +128,7 @@ open Decl_kinds
     | StringRefValue s -> qs s
 
   let pr_printoption table b =
-    prlist_with_sep spc str table ++
+    prlist_with_sep (spc ()) str table ++
       pr_opt (prlist_with_sep sep pr_option_ref_value) b
 
   let pr_set_option a b =
@@ -182,10 +182,10 @@ open Decl_kinds
           keyword "Mode"
           ++ spc ()
           ++ pr_reference m ++ spc() ++
-            prlist_with_sep spc pr_hint_mode l
+            prlist_with_sep (spc ()) pr_hint_mode l
         | HintsConstructors c ->
           keyword "Constructors"
-          ++ spc() ++ prlist_with_sep spc pr_reference c
+          ++ spc() ++ prlist_with_sep (spc ()) pr_reference c
         | HintsExtern (n,c,tac) ->
           let pat = match c with None -> mt () | Some pat -> pr_pat pat in
           keyword "Extern" ++ spc() ++ int n ++ spc() ++ pat ++ str" =>" ++
@@ -246,7 +246,7 @@ open Decl_kinds
     let m = pr_module_ast true pr_c mty in
     spc() ++
       hov 1 (str"(" ++ pr_require_token export ++
-               prlist_with_sep spc pr_lident idl ++ str":" ++ m ++ str")")
+               prlist_with_sep (spc ()) pr_lident idl ++ str":" ++ m ++ str")")
 
   let pr_module_binders l pr_c =
     prlist_strict (pr_module_vardecls pr_c) l
@@ -339,7 +339,7 @@ open Decl_kinds
     match factorize l with
       | [p] -> pr_params pr_c p
       | l ->
-        prlist_with_sep spc
+        prlist_with_sep (spc ())
           (fun p -> hov 1 (str "(" ++ pr_params pr_c p ++ str ")")) l
 
 (*
@@ -374,7 +374,7 @@ open Decl_kinds
   let pr_univs pl =
     match pl with
     | None -> mt ()
-    | Some pl -> str"@{" ++ prlist_with_sep spc pr_lident pl ++ str"}"
+    | Some pl -> str"@{" ++ prlist_with_sep (spc ()) pr_lident pl ++ str"}"
 
   let pr_rec_definition ((((loc,id),pl),ro,bl,type_,def),ntn) =
     let pr_pure_lconstr c = Flags.without_option Flags.beautify pr_lconstr c in
@@ -424,7 +424,7 @@ open Decl_kinds
 
   let pr_record_decl b c fs =
     pr_opt pr_lident c ++ (if c = None then str"{" else str" {") ++
-      hv 0 (prlist_with_sep pr_semicolon pr_record_field fs ++ str"}")
+      hv 0 (prlist_with_sep (pr_semicolon ()) pr_record_field fs ++ str"}")
 
   let pr_printable = function
     | PrintFullContext ->
@@ -627,7 +627,7 @@ open Decl_kinds
       | VernacBindScope (sc,cll) ->
         return (
           keyword "Bind Scope" ++ spc () ++ str sc ++
-            spc() ++ keyword "with" ++ spc () ++ prlist_with_sep spc pr_class_rawexpr cll
+            spc() ++ keyword "with" ++ spc () ++ prlist_with_sep (spc ()) pr_class_rawexpr cll
         )
       | VernacArgumentsScope (q,scl) ->
         let pr_opt_scope = function
@@ -714,7 +714,7 @@ open Decl_kinds
               | Opaque None -> keyword "Qed"
               | Opaque (Some l) ->
                   keyword "Qed" ++ spc() ++ str"export" ++
-                    prlist_with_sep (fun () -> str", ") pr_lident l)
+                    prlist_with_sep (str ", ") pr_lident l)
           | Some id -> (if opac <> Transparent then keyword "Save" else keyword "Defined") ++ spc() ++ pr_lident id
       )
       | VernacExactProof c ->
@@ -724,7 +724,7 @@ open Decl_kinds
         let pr_params (c, (xl, t)) =
           hov 2 (prlist_with_sep sep pr_plident xl ++ spc() ++
             (if c then str":>" else str":" ++ spc() ++ pr_lconstr_expr t)) in
-        let assumptions = prlist_with_sep spc (fun p -> hov 1 (str "(" ++ pr_params p ++ str ")")) l in
+        let assumptions = prlist_with_sep (spc ()) (fun p -> hov 1 (str "(" ++ pr_params p ++ str ")")) l in
         return (hov 2 (pr_assumption_token (n > 1) stre ++
                        pr_non_empty_arg pr_assumption_inline t ++ spc() ++ assumptions))
       | VernacInductive (cum, p,f,l) ->
@@ -739,7 +739,7 @@ open Decl_kinds
             let fst_sep = match l with [_] -> "   " | _ -> " | " in
             pr_com_at (begin_of_inductive l) ++
               fnl() ++ str fst_sep ++
-              prlist_with_sep (fun _ -> fnl() ++ str" | ") pr_constructor l
+              prlist_with_sep (fnl () ++ str" | ") pr_constructor l
           | RecordDecl (c,fs) ->
             pr_record_decl b c fs
         in
@@ -777,7 +777,7 @@ open Decl_kinds
         in
         return (
           hov 0 (str local ++ keyword "Fixpoint" ++ spc () ++
-                   prlist_with_sep (fun _ -> fnl () ++ keyword "with"
+                   prlist_with_sep (fnl () ++ keyword "with"
                      ++ spc ()) pr_rec_definition recs)
         )
 
@@ -795,23 +795,23 @@ open Decl_kinds
         in
         return (
           hov 0 (local ++ keyword "CoFixpoint" ++ spc() ++
-                   prlist_with_sep (fun _ -> fnl() ++ keyword "with" ++ spc ()) pr_onecorec corecs)
+                   prlist_with_sep (fnl () ++ keyword "with" ++ spc ()) pr_onecorec corecs)
         )
       | VernacScheme l ->
         return (
           hov 2 (keyword "Scheme" ++ spc() ++
-                   prlist_with_sep (fun _ -> fnl() ++ keyword "with" ++ spc ()) pr_onescheme l)
+                   prlist_with_sep (fnl () ++ keyword "with" ++ spc ()) pr_onescheme l)
         )
       | VernacCombinedScheme (id, l) ->
         return (
           hov 2 (keyword "Combined Scheme" ++ spc() ++
                    pr_lident id ++ spc() ++ keyword "from" ++ spc() ++
-                   prlist_with_sep (fun _ -> fnl() ++ str", ") pr_lident l)
+                   prlist_with_sep (fnl () ++ str", ") pr_lident l)
         )
       | VernacUniverse v ->
         return (
           hov 2 (keyword "Universe" ++ spc () ++
-                   prlist_with_sep (fun _ -> str",") pr_lident v)
+                   prlist_with_sep (str ",") pr_lident v)
         )
       | VernacConstraint v ->
         let pr_uconstraint (l, d, r) =
@@ -820,7 +820,7 @@ open Decl_kinds
         in
         return (
           hov 2 (keyword "Constraint" ++ spc () ++
-                   prlist_with_sep (fun _ -> str",") pr_uconstraint v)
+                   prlist_with_sep (str ",") pr_uconstraint v)
         )
 
       (* Gallina extensions *)
@@ -897,7 +897,7 @@ open Decl_kinds
          return (
           hov 1 (keyword "Existing" ++ spc () ++
                    keyword(String.plural (List.length insts) "Instance") ++
-                 spc () ++ prlist_with_sep (fun () -> str", ") pr_inst insts)
+                 spc () ++ prlist_with_sep (str ", ") pr_inst insts)
         )
 
       | VernacDeclareClass id ->
@@ -913,7 +913,7 @@ open Decl_kinds
                    pr_lident m ++ b ++
                    pr_of_module_type pr_lconstr tys ++
                    (if List.is_empty bd then mt () else str ":= ") ++
-                   prlist_with_sep (fun () -> str " <+")
+                   prlist_with_sep (str " <+")
                    (pr_module_ast_inl true pr_lconstr) bd)
         )
       | VernacDeclareModule (export,id,bl,m1) ->
@@ -930,13 +930,13 @@ open Decl_kinds
           hov 2 (keyword "Module Type " ++ pr_lident id ++ b ++
                    prlist_strict (fun m -> str " <:" ++ pr_mt m) tyl ++
                    (if List.is_empty m then mt () else str ":= ") ++
-                   prlist_with_sep (fun () -> str " <+ ") pr_mt m)
+                   prlist_with_sep (str " <+ ") pr_mt m)
         )
       | VernacInclude (mexprs) ->
         let pr_m = pr_module_ast_inl false pr_lconstr in
         return (
           hov 2 (keyword "Include" ++ spc() ++
-                   prlist_with_sep (fun () -> str " <+ ") pr_m mexprs)
+                   prlist_with_sep (str " <+ ") pr_m mexprs)
         )
       (* Solving *)
       | VernacSolveExistential (i,c) ->
@@ -978,7 +978,7 @@ open Decl_kinds
       | VernacRemoveHints (dbnames, ids) ->
         return (
           hov 1 (keyword "Remove Hints" ++ spc () ++
-                   prlist_with_sep spc (fun r -> pr_id (coerce_reference_to_id r)) ids ++
+                   prlist_with_sep (spc ()) (fun r -> pr_id (coerce_reference_to_id r)) ids ++
                    pr_opt_hintbases dbnames)
         )
       | VernacHints (_, dbnames,h) ->
@@ -987,7 +987,7 @@ open Decl_kinds
         return (
           hov 2
             (keyword "Notation" ++ spc () ++ pr_lident id ++ spc () ++
-               prlist_with_sep spc pr_id ids ++ str":=" ++ pr_constrarg c ++
+               prlist_with_sep (spc ()) pr_id ids ++ str":=" ++ pr_constrarg c ++
                pr_syntax_modifiers
                (match compat with
                 | None -> []
@@ -1002,7 +1002,7 @@ open Decl_kinds
         return (
           hov 1 (keyword "Implicit Arguments" ++ spc () ++
                    spc() ++ pr_smart_global q ++ spc() ++
-                   prlist_with_sep spc (fun imps ->
+                   prlist_with_sep (spc ()) (fun imps ->
                      str"[" ++ prlist_with_sep sep pr_explanation imps ++ str"]")
                    impls)
         )
@@ -1037,7 +1037,7 @@ open Decl_kinds
                   prlist (fun l -> str"," ++ print_implicits l) more_implicits
                 else (mt ()) ++
                 (if not (List.is_empty mods) then str" : " else str"") ++
-                  prlist_with_sep (fun () -> str", " ++ spc()) (function
+                  prlist_with_sep ( str ", " ++ spc()) (function
                     | `ReductionDontExposeCase -> keyword "simpl nomatch"
                     | `ReductionNeverUnfold -> keyword "simpl never"
                     | `DefaultImplicits -> keyword "default implicits"
@@ -1063,7 +1063,7 @@ open Decl_kinds
                 | Some [] -> str "s all"
                 | Some idl ->
                   str (if List.length idl > 1 then "s " else " ") ++
-                    prlist_with_sep spc pr_lident idl)
+                    prlist_with_sep (spc ()) pr_lident idl)
           ))
       | VernacSetOpacity(k,l) when Conv_oracle.is_transparent k ->
         return (

--- a/printing/prettyp.ml
+++ b/printing/prettyp.ml
@@ -54,7 +54,7 @@ let gallina_print_modtype = print_modtype
 
 let print_closed_sections = ref false
 
-let pr_infos_list l = v 0 (prlist_with_sep cut (fun x -> x) l)
+let pr_infos_list l = v 0 (prlist_with_sep (cut ()) (fun x -> x) l)
 
 let with_line_skip l = if List.is_empty l then mt() else fnl() ++ fnl () ++ pr_infos_list l
 
@@ -98,7 +98,7 @@ let print_impargs_by_name max = function
   | impls ->
      let n = List.length impls in
      [hov 0 (str (String.plural n "Argument") ++ spc() ++
-      prlist_with_sep pr_comma pr_impl_name impls ++ spc() ++
+      prlist_with_sep (pr_comma ()) pr_impl_name impls ++ spc() ++
       str (String.conjugate_verb_to_be n) ++ str" implicit" ++
       (if max then strbrk " and maximally inserted" else mt()))]
 
@@ -117,14 +117,14 @@ let print_impargs_list prefix l =
 	List.map (fun pp -> add_colon prefix ++ pp)
 	  (print_one_impargs_list imps)
     | Some (n1,n2) ->
-       [v 2 (prlist_with_sep cut (fun x -> x)
+       [v 2 (prlist_with_sep (cut ()) (fun x -> x)
 	 [(if ismt prefix then str "When" else prefix ++ str ", when") ++
 	   str " applied to " ++
 	   (if Int.equal n1 n2 then int_or_no n2 else
 	    if Int.equal n1 0 then str "no more than " ++ int n2
 	    else int n1 ++ str " to " ++ int_or_no n2) ++
 	    str (String.plural n2 " argument") ++ str ":";
-          v 0 (prlist_with_sep cut (fun x -> x)
+          v 0 (prlist_with_sep (cut ()) (fun x -> x)
 	    (if List.exists is_status_implicit imps
 	    then print_one_impargs_list imps
 	    else [str "No implicit arguments"]))])]) l)
@@ -132,7 +132,7 @@ let print_impargs_list prefix l =
 let print_renames_list prefix l =
   if List.is_empty l then [] else
   [add_colon prefix ++ str "Arguments are renamed to " ++
-    hv 2 (prlist_with_sep pr_comma (fun x -> x) (List.map Name.print l))]
+    hv 2 (prlist_with_sep (pr_comma ()) (fun x -> x) (List.map Name.print l))]
 
 let need_expansion impl ref =
   let typ = Global.type_of_global_unsafe ref in
@@ -420,7 +420,7 @@ let print_located_qualid name flags ref =
 	else
 	  str "No " ++ str name ++ str " of suffix" ++ spc () ++ pr_qualid qid
     | l ->
-	prlist_with_sep fnl
+	prlist_with_sep (fnl ())
 	(fun (o,oqid) ->
 	  hov 2 (pr_located_qualid o ++
 	  (if not (qualid_eq oqid qid) then
@@ -819,14 +819,14 @@ let print_class i =
 
 let print_path ((i,j),p) =
   hov 2 (
-    str"[" ++ hov 0 (prlist_with_sep pr_semicolon print_coercion_value p) ++
+    str"[" ++ hov 0 (prlist_with_sep (pr_semicolon ()) print_coercion_value p) ++
     str"] : ") ++
   print_class i ++ str" >-> " ++ print_class j
 
 let _ = Classops.install_path_printer print_path
 
 let print_graph () =
-  prlist_with_sep fnl print_path (inheritance_graph())
+  prlist_with_sep (fnl ()) print_path (inheritance_graph())
 
 let print_classes () =
   pr_sequence pr_class (classes())
@@ -855,7 +855,7 @@ let print_path_between cls clt =
   print_path ((i,j),p)
 
 let print_canonical_projections () =
-  prlist_with_sep fnl
+  prlist_with_sep (fnl ())
     (fun ((r1,r2),o) -> pr_cs_pattern r2 ++
     str " <- " ++
     pr_global r1 ++ str " ( " ++ pr_lconstr o.o_DEF ++ str " )")
@@ -873,7 +873,7 @@ let pr_typeclass env t =
 
 let print_typeclasses () =
   let env = Global.env () in
-    prlist_with_sep fnl (pr_typeclass env) (typeclasses ())
+    prlist_with_sep (fnl ()) (pr_typeclass env) (typeclasses ())
 
 let pr_instance env i =
   (*   gallina_print_constant_with_infos i.is_impl *)
@@ -887,9 +887,9 @@ let pr_instance env i =
 let print_all_instances () =
   let env = Global.env () in
   let inst = all_instances () in
-    prlist_with_sep fnl (pr_instance env) inst
+    prlist_with_sep (fnl ()) (pr_instance env) inst
 
 let print_instances r =
   let env = Global.env () in
   let inst = instances r in
-    prlist_with_sep fnl (pr_instance env) inst
+    prlist_with_sep (fnl ()) (pr_instance env) inst

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -321,7 +321,7 @@ let pr_compacted_decl env sigma decl =
        let pb = if isCast c then surround pb else pb in
        ids, (str" := " ++ pb ++ cut ()), typ
   in
-  let pids = prlist_with_sep pr_comma pr_id ids in
+  let pids = prlist_with_sep (pr_comma ()) pr_id ids in
   let pt = pr_ltype_env env sigma typ in
   let ptyp = (str" : " ++ pt) in
   hov 0 (pids ++ pbody ++ ptyp)
@@ -353,7 +353,7 @@ let pr_rel_decl env sigma decl =
 let pr_named_context_of env sigma =
   let make_decl_list env d pps = pr_named_decl env sigma d :: pps in
   let psl = List.rev (fold_named_context make_decl_list env ~init:[]) in
-  hv 0 (prlist_with_sep (fun _ -> ws 2) (fun x -> x) psl)
+  hv 0 (prlist_with_sep (ws 2) (fun x -> x) psl)
 
 let pr_var_list_decl env sigma decl =
   hov 0 (pr_compacted_decl env sigma decl)
@@ -463,7 +463,7 @@ let pr_context_of env sigma = match !print_hyps_limit with
 (* display goal parts (Proof mode) *)
 
 let pr_predicate pr_elt (b, elts) =
-  let pr_elts = prlist_with_sep spc pr_elt elts in
+  let pr_elts = prlist_with_sep (spc ()) pr_elt elts in
     if b then
       str"all" ++
 	(if List.is_empty elts then mt () else str" except: " ++ pr_elts)
@@ -522,14 +522,14 @@ let pr_evgl_sign sigma evi =
   let ids = List.rev_map NamedDecl.get_id l in
   let warn =
     if List.is_empty ids then mt () else
-      (str "(" ++ prlist_with_sep pr_comma pr_id ids ++ str " cannot be used)")
+      (str "(" ++ prlist_with_sep (pr_comma ()) pr_id ids ++ str " cannot be used)")
   in
   let pc = pr_lconstr_env env sigma evi.evar_concl in
   let candidates =
     match evi.evar_body, evi.evar_candidates with
     | Evar_empty, Some l ->
        spc () ++ str "= {" ++
-         prlist_with_sep (fun () -> str "|") (pr_lconstr_env env sigma) l ++ str "}"
+         prlist_with_sep (str "|") (pr_lconstr_env env sigma) l ++ str "}"
     | _ ->
        mt ()
   in
@@ -621,7 +621,7 @@ let print_evar_constraints gl sigma =
     let _, cstrs = Evd.extract_all_conv_pbs sigma in
     if List.is_empty cstrs then mt ()
     else fnl () ++ str (String.plural (List.length cstrs) "unification constraint")
-         ++ str":" ++ fnl () ++ hov 0 (prlist_with_sep fnl pr_evconstr cstrs)
+         ++ str":" ++ fnl () ++ hov 0 (prlist_with_sep (fnl ()) pr_evconstr cstrs)
   in
   let candidates, ppcandidates = Evd.fold_undefined pr_candidate sigma (0,mt ()) in
   constraints ++
@@ -954,7 +954,7 @@ let pr_assumptionset env s =
       | Axiom (axiom,l) ->
         let ax = pr_axiom env axiom typ ++
           cut() ++
-          prlist_with_sep cut (fun (lbl, ctx, ty) ->
+          prlist_with_sep (cut ()) (fun (lbl, ctx, ty) ->
             str " used in " ++ pr_label lbl ++
             str " to prove:" ++ safe_pr_ltype_relctx (ctx,ty))
           l in
@@ -984,7 +984,7 @@ let pr_assumptionset env s =
     | l ->
       let section =
         title ++ fnl () ++
-        v 0 (prlist_with_sep fnl (fun s -> s) l) in
+        v 0 (prlist_with_sep (fnl ()) (fun s -> s) l) in
       Some section
     in
     let assums = [
@@ -994,7 +994,7 @@ let pr_assumptionset env s =
       opt_list (str "Opaque constants:") opaque;
       opt_list (str "Theory:") theory;
     ] in
-    prlist_with_sep fnl (fun x -> x) (Option.List.flatten assums)
+    prlist_with_sep (fnl ()) (fun x -> x) (Option.List.flatten assums)
 
 let xor a b = 
   (a && not b) || (not a && b)

--- a/printing/printmod.ml
+++ b/printing/printmod.ml
@@ -78,7 +78,7 @@ let print_params env sigma params =
 
 let print_constructors envpar sigma names types =
   let pc =
-    prlist_with_sep (fun () -> brk(1,0) ++ str "| ")
+    prlist_with_sep (brk (1,0) ++ str "| ")
       (fun (id,c) -> pr_id id ++ str " : " ++ Printer.pr_lconstr_env envpar sigma c)
       (Array.to_list (Array.map2 (fun n t -> (n,t)) names types))
   in
@@ -125,7 +125,7 @@ let print_mutual_inductive env mind mib =
            (Declareops.inductive_is_polymorphic mib) 
            (Declareops.inductive_is_cumulative mib) ++
          def keyword ++ spc () ++
-         prlist_with_sep (fun () -> fnl () ++ str"  with ")
+         prlist_with_sep (fnl () ++ str "  with ")
            (print_one_inductive env sigma mib) inds ++
          match mib.mind_universes with
          | Monomorphic_ind _ | Polymorphic_ind _ -> str ""
@@ -181,7 +181,7 @@ let print_record env mind mib =
       str ":= " ++ pr_id mip.mind_consnames.(0)) ++
     brk(1,2) ++
     hv 2 (str "{ " ++
-      prlist_with_sep (fun () -> str ";" ++ brk(2,0))
+      prlist_with_sep (str ";" ++ brk (2,0))
         (fun (id,b,c) ->
           pr_id id ++ str (if b then " : " else " := ") ++
           Printer.pr_lconstr_env envpar sigma c) fields) ++ str" }" ++
@@ -333,7 +333,7 @@ let print_body is_impl env mp (l,body) =
 	keyword ++ spc () ++ name)
 
 let print_struct is_impl env mp struc =
-  prlist_with_sep spc (print_body is_impl env mp) struc
+  prlist_with_sep (spc ()) (print_body is_impl env mp) struc
 
 let print_structure is_type env mp locals struc =
   let env' = Option.map
@@ -356,7 +356,7 @@ let rec print_typ_expr env mp locals mty =
       let fapp = List.hd lapp in
       let mapp = List.tl lapp in
       hov 3 (str"(" ++ (print_kn locals fapp) ++ spc () ++
-		 prlist_with_sep spc (print_modpath locals) mapp ++ str")")
+		 prlist_with_sep (spc ()) (print_modpath locals) mapp ++ str")")
   | MEwith(me,WithDef(idl,(c, _)))->
       let env' = None in (* TODO: build a proper environment if env <> None *)
       let s = String.concat "." (List.map Id.to_string idl) in
@@ -374,7 +374,7 @@ let print_mod_expr env mp locals = function
   | MEapply _ as me ->
       let lapp = flatten_app me [] in
       hov 3
-        (str"(" ++ prlist_with_sep spc (print_modpath locals) lapp ++ str")")
+        (str"(" ++ prlist_with_sep (spc ()) (print_modpath locals) lapp ++ str")")
   | MEwith _ -> assert false (* No 'with' syntax for modules *)
 
 let rec print_functor fty fatom is_type env mp locals = function

--- a/proofs/proof.ml
+++ b/proofs/proof.ml
@@ -375,7 +375,7 @@ let unshelve p =
 let pr_proof p =
   let p = map_structured_proof p (fun _sigma g -> g) in
   Pp.(
-    let pr_goal_list = prlist_with_sep spc Goal.pr_goal in
+    let pr_goal_list = prlist_with_sep (spc ()) Goal.pr_goal in
     let rec aux acc = function
       | [] -> acc
       | (before,after)::stack ->

--- a/proofs/proof_global.ml
+++ b/proofs/proof_global.ml
@@ -676,7 +676,7 @@ let pr_goal_selector = function
   | Vernacexpr.SelectNth i -> int i
   | Vernacexpr.SelectList l ->
      str "["
-     ++ prlist_with_sep pr_comma pr_range_selector l
+     ++ prlist_with_sep (pr_comma ()) pr_range_selector l
      ++ str "]"
   | Vernacexpr.SelectId id -> Id.print id
 

--- a/proofs/proof_using.ml
+++ b/proofs/proof_using.ml
@@ -113,7 +113,7 @@ let suggest_Proof_using name env vars ids_typ context_ids =
     let wrap ppcmds =
       if parens && S.cardinal s > 1 then str "(" ++ ppcmds ++ str ")"
       else ppcmds in
-    wrap (prlist_with_sep (fun _ -> str" ") Id.print (S.elements s)) in
+    wrap (prlist_with_sep (str " ") Id.print (S.elements s)) in
   let used = S.union vars ids_typ in
   let needed = minimize_hyps env (remove_ids_and_lets env used ids_typ) in
   let all_needed = really_needed env needed in
@@ -136,8 +136,8 @@ let suggest_Proof_using name env vars ids_typ context_ids =
     str"The proof of "++ str name ++ spc() ++
     str "should start with one of the following commands:"++spc()++
     v 0 (
-    prlist_with_sep cut (fun x->str"Proof using " ++x++ str". ") !valid_exprs));
-  string_of_ppcmds (prlist_with_sep (fun _ -> str";")  (fun x->x) !valid_exprs)
+    prlist_with_sep (cut ()) (fun x->str"Proof using " ++x++ str". ") !valid_exprs));
+  string_of_ppcmds (prlist_with_sep (str ";") (fun x->x) !valid_exprs)
 ;;
 
 let value = ref false

--- a/proofs/tacmach.ml
+++ b/proofs/tacmach.ml
@@ -150,7 +150,7 @@ let pr_gls gls =
 
 let pr_glls glls =
   hov 0 (pr_evar_map (Some 2) (sig_sig glls) ++ fnl () ++
-         prlist_with_sep fnl (db_pr_goal (project glls)) (sig_it glls))
+         prlist_with_sep (fnl ()) (db_pr_goal (project glls)) (sig_it glls))
 
 (* Variants of [Tacmach] functions built with the new proof engine *)
 module New = struct

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -940,7 +940,7 @@ let show_script ?proof () =
       List.fold_left indent_script_item ((1,[]),false,[],[]) cmds
     in
     let indented_cmds = List.rev (indented_cmds) in
-    msg_notice Pp.(v 0 (prlist_with_sep fnl (fun x -> x) indented_cmds))
+    msg_notice Pp.(v 0 (prlist_with_sep (fnl ()) (fun x -> x) indented_cmds))
   with Vcs_aux.Expired -> ()
 
 end

--- a/tactics/auto.ml
+++ b/tactics/auto.ml
@@ -260,7 +260,7 @@ let pr_info_atom (d,pp) =
 
 let pr_info_trace = function
   | (Info,_,{contents=(d,Some pp)::l}) ->
-      Feedback.msg_info (prlist_with_sep fnl pr_info_atom (cleanup_info_trace d [(d,pp)] l))
+      Feedback.msg_info (prlist_with_sep (fnl ()) pr_info_atom (cleanup_info_trace d [(d,pp)] l))
   | _ -> ()
 
 let pr_info_nop = function

--- a/tactics/autorewrite.ml
+++ b/tactics/autorewrite.ml
@@ -75,7 +75,7 @@ let find_matches bas pat =
 
 let print_rewrite_hintdb bas =
   (str "Database " ++ str bas ++ fnl () ++
-	   prlist_with_sep fnl
+	   prlist_with_sep (fnl ())
 	   (fun h ->
 	     str (if h.rew_l2r then "rewrite -> " else "rewrite <- ") ++
 	       Printer.pr_lconstr h.rew_lemma ++ str " of type " ++ Printer.pr_lconstr h.rew_type ++

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -1479,7 +1479,7 @@ let pr_hint_db db =
   let pr_mode = prvect_with_sep spc pp_hint_mode in
   let pr_modes l = 
     if List.is_empty l then mt ()
-    else str" (modes " ++ prlist_with_sep pr_comma pr_mode l ++ str")"
+    else str" (modes " ++ prlist_with_sep (pr_comma ()) pr_mode l ++ str")"
   in
   let content =
     let fold head modes hintlist accu =

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -3078,7 +3078,7 @@ let warn_unused_intro_pattern =
   CWarnings.create ~name:"unused-intro-pattern" ~category:"tactics"
          (fun names ->
           strbrk"Unused introduction " ++ str (String.plural (List.length names) "pattern")
-          ++ str": " ++ prlist_with_sep spc 
+          ++ str": " ++ prlist_with_sep (spc ())
          (Miscprint.pr_intro_pattern 
 	 (fun c -> Printer.pr_econstr (snd (c (Global.env()) Evd.empty)))) names)
 

--- a/test-suite/output/TypeclassDebug.out
+++ b/test-suite/output/TypeclassDebug.out
@@ -1,0 +1,18 @@
+Debug: 1: looking for foo without backtracking
+Debug: 1.1: simple apply H on foo, 1 subgoal(s)
+Debug: 1.1-2 : foo
+Debug: 1.1-2: looking for foo without backtracking
+Debug: 1.1-2.1: simple apply H on foo, 1 subgoal(s)
+Debug: 1.1-2.1-2 : foo
+Debug: 1.1-2.1-2: looking for foo without backtracking
+Debug: 1.1-2.1-2.1: simple apply H on foo, 1 subgoal(s)
+Debug: 1.1-2.1-2.1-2 : foo
+Debug: 1.1-2.1-2.1-2: looking for foo without backtracking
+Debug: 1.1-2.1-2.1-2.1: simple apply H on foo, 1 subgoal(s)
+Debug: 1.1-2.1-2.1-2.1-2 : foo
+Debug: 1.1-2.1-2.1-2.1-2: looking for foo without backtracking
+Debug: 1.1-2.1-2.1-2.1-2.1: simple apply H on foo, 1 subgoal(s)
+Debug: 1.1-2.1-2.1-2.1-2.1-2 : foo
+The command has indeed failed with message:
+Ltac call to "typeclasses eauto (int_or_var_opt) with (ne_preident_list)" failed.
+Tactic failure: Proof search reached its limit.

--- a/test-suite/output/TypeclassDebug.v
+++ b/test-suite/output/TypeclassDebug.v
@@ -1,0 +1,8 @@
+(* show alternating separators in typeclass debug output; see discussion in PR #868 *)
+
+Parameter foo : Prop.
+Axiom H : foo -> foo.
+Hint Resolve H : foo.
+Goal foo.
+Typeclasses eauto := debug.
+Fail typeclasses eauto 5 with foo.

--- a/toplevel/vernac.ml
+++ b/toplevel/vernac.ml
@@ -290,7 +290,7 @@ let compile verbosely f =
       vernac_error (str "There are pending proofs: "
                     ++ (pfs
                         |> List.rev
-                        |> prlist_with_sep pr_comma Names.Id.print)
+                        |> prlist_with_sep (pr_comma ()) Names.Id.print)
                     ++ str ".")
   in
   match !Flags.compilation_mode with

--- a/vernac/command.ml
+++ b/vernac/command.ml
@@ -330,7 +330,7 @@ let minductive_message warn = function
   | []  -> user_err Pp.(str "No inductive definition.")
   | [x] -> (pr_id x ++ str " is defined" ++ 
 	    if warn then str " as a non-primitive record" else mt())
-  | l   -> hov 0  (prlist_with_sep pr_comma pr_id l ++
+  | l   -> hov 0  (prlist_with_sep (pr_comma ()) pr_id l ++
 		     spc () ++ str "are defined")
 
 let check_all_names_different indl =

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -338,7 +338,7 @@ let explain_unification_error env sigma p1 p2 = function
      match aux p1 p2 e with
      | [] -> mt ()
      | l -> spc () ++ str "(" ++
-            prlist_with_sep pr_semicolon (fun x -> x) l ++ str ")"
+            prlist_with_sep (pr_semicolon ()) (fun x -> x) l ++ str ")"
 
 let explain_actual_type env sigma j t reason =
   let env = make_all_name_different env sigma in
@@ -1059,7 +1059,7 @@ let explain_refiner_bad_type arg ty conclty =
 let explain_refiner_unresolved_bindings l =
   str "Unable to find an instance for the " ++
   str (String.plural (List.length l) "variable") ++ spc () ++
-  prlist_with_sep pr_comma Name.print l ++ str"."
+  prlist_with_sep (pr_comma ()) Name.print l ++ str"."
 
 let explain_refiner_cannot_apply t harg =
   str "In refiner, a term of type" ++ brk(1,1) ++
@@ -1153,7 +1153,7 @@ let error_same_names_constructors id =
 let error_same_names_overlap idl =
   strbrk "The following names are used both as type names and constructor " ++
   str "names:" ++ spc () ++
-  prlist_with_sep pr_comma pr_id idl ++ str "."
+  prlist_with_sep (pr_comma ()) pr_id idl ++ str "."
 
 let error_not_an_arity env c =
   str "The type" ++ spc () ++ pr_lconstr_env env Evd.empty c ++ spc () ++
@@ -1256,7 +1256,7 @@ let explain_unused_clause env pats =
 let explain_non_exhaustive env pats =
   str "Non exhaustive pattern-matching: no clause found for " ++
   str (String.plural (List.length pats) "pattern") ++
-  spc () ++ hov 0 (prlist_with_sep pr_comma pr_cases_pattern pats)
+  spc () ++ hov 0 (prlist_with_sep (pr_comma ()) pr_cases_pattern pats)
 
 let explain_cannot_infer_predicate env sigma typs =
   let inj c = EConstr.to_constr sigma c in
@@ -1267,7 +1267,7 @@ let explain_cannot_infer_predicate env sigma typs =
     str "For " ++ pr_lconstr_env env sigma cstr ++ str ": " ++ pr_lconstr_env env sigma typ
   in
   str "Unable to unify the types found in the branches:" ++
-  spc () ++ hov 0 (prlist_with_sep fnl pr_branch typs)
+  spc () ++ hov 0 (prlist_with_sep (fnl ()) pr_branch typs)
 
 let explain_pattern_matching_error env sigma = function
   | BadPattern (c,t) ->

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -399,7 +399,7 @@ let check_open_binder isopen sl m =
   if isopen && not (List.is_empty sl) then
     user_err  (str "as " ++ pr_id m ++
       str " is a non-closed binder, no such \"" ++
-      prlist_with_sep spc pr_token sl
+      prlist_with_sep (spc ()) pr_token sl
       ++ strbrk "\" is allowed to occur.")
 
 (* Heuristics for building default printing rules *)
@@ -689,7 +689,7 @@ let pr_arg_level from = function
 
 let pr_level ntn (from,args) =
   str "at level " ++ int from ++ spc () ++ str "with arguments" ++ spc() ++
-  prlist_with_sep pr_comma (pr_arg_level from) args
+  prlist_with_sep (pr_comma ()) (pr_arg_level from) args
 
 let error_incompatible_level ntn oldprec prec =
   user_err 

--- a/vernac/mltop.ml
+++ b/vernac/mltop.ml
@@ -416,7 +416,7 @@ let declare_ml_modules local l =
 let print_ml_path () =
   let l = !coq_mlpath_copy in
   str"ML Load Path:" ++ fnl () ++ str"  " ++
-          hv 0 (prlist_with_sep fnl str l)
+          hv 0 (prlist_with_sep (fnl ()) str l)
 
 (* Printing of loaded ML modules *)
 

--- a/vernac/obligations.ml
+++ b/vernac/obligations.ml
@@ -446,7 +446,7 @@ let close sec =
     let keys = map_keys !from_prg in
       user_err ~hdr:"Program" 
 	(str "Unsolved obligations when closing " ++ str sec ++ str":" ++ spc () ++
-	   prlist_with_sep spc (fun x -> Nameops.pr_id x) keys ++
+	   prlist_with_sep (spc ()) (fun x -> Nameops.pr_id x) keys ++
 	   (str (if Int.equal (List.length keys) 1 then " has " else " have ") ++
 	      str "unsolved obligations"))
 
@@ -726,7 +726,7 @@ let get_prog name =
 	       | _ ->
                 let progs = Id.Set.elements (ProgMap.domain prg_infos) in
                 let prog = List.hd progs in
-                let progs = prlist_with_sep pr_comma Nameops.pr_id progs in
+                let progs = prlist_with_sep (pr_comma ()) Nameops.pr_id progs in
                 user_err 
                   (str "More than one program with unsolved obligations: " ++ progs
                   ++ str "; use the \"of\" clause to specify, as in \"Obligation 1 of " ++ Nameops.pr_id prog ++ str "\""))

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -194,7 +194,7 @@ let warning_or_error coe indsp err =
 	let s,have = if List.length projs > 1 then "s","were" else "","was" in
         (pr_id fi ++
 	   strbrk" cannot be defined because the projection" ++ str s ++ spc () ++
-           prlist_with_sep pr_comma pr_id projs ++ spc () ++ str have ++
+           prlist_with_sep (pr_comma ()) pr_id projs ++ spc () ++ str have ++
 	   strbrk " not defined.")
     | BadTypedProj (fi,ctx,te) ->
 	match te with

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -58,7 +58,7 @@ let show_proof () =
   (* spiwack: this would probably be cooler with a bit of polishing. *)
   let p = Proof_global.give_me_the_proof () in
   let pprf = Proof.partial_proof p in
-  Feedback.msg_notice (Pp.prlist_with_sep Pp.fnl Printer.pr_econstr pprf)
+  Feedback.msg_notice (Pp.prlist_with_sep (Pp.fnl ()) Printer.pr_econstr pprf)
 
 let show_top_evars () =
   (* spiwack: new as of Feb. 2010: shows goal evars in addition to non-goal evars. *)
@@ -85,7 +85,7 @@ let show_intro all =
     let l,_= decompose_prod_assum sigma (Termops.strip_outer_cast sigma (pf_concl gl)) in
     if all then
       let lid = Tactics.find_intro_names l gl in
-      Feedback.msg_notice (hov 0 (prlist_with_sep  spc pr_id lid))
+      Feedback.msg_notice (hov 0 (prlist_with_sep (spc ()) pr_id lid))
     else if not (List.is_empty l) then
       let n = List.last l in
       Feedback.msg_notice (pr_id (List.hd (Tactics.find_intro_names [n] gl)))
@@ -146,10 +146,10 @@ let show_match id =
     with Not_found -> user_err Pp.(str "Unknown inductive type.")
   in
   let pr_branch l =
-    str "| " ++ hov 1 (prlist_with_sep spc str l) ++ str " =>"
+    str "| " ++ hov 1 (prlist_with_sep (spc ()) str l) ++ str " =>"
   in
   Feedback.msg_notice (v 1 (str "match # with" ++ fnl () ++
-	    prlist_with_sep fnl pr_branch patterns ++ fnl () ++ str "end" ++ fnl ()))
+	    prlist_with_sep (fnl ()) pr_branch patterns ++ fnl () ++ str "end" ++ fnl ()))
 
 (* "Print" commands *)
 
@@ -167,7 +167,7 @@ let print_loadpath dir =
     List.filter filter l
   in
   str "Logical Path / Physical path:" ++ fnl () ++
-    prlist_with_sep fnl print_path_entry l
+    prlist_with_sep (fnl ()) print_path_entry l
 
 let print_modules () =
   let opened = Library.opened_libraries ()
@@ -248,7 +248,7 @@ let print_namespace ns =
     in
     snd (Util.List.chop n (List.rev (list_of_modulepath mp)))
   in
-  let print_list pr l = prlist_with_sep (fun () -> str".") pr l in
+  let print_list pr l = prlist_with_sep (str ".") pr l in
   let print_kn kn =
     (* spiwack: I'm ignoring the dirpath, is that bad? *)
     let (mp,_,lbl) = Names.repr_kn kn in
@@ -296,12 +296,12 @@ let print_strategy r =
     let var_msg =
       if List.is_empty var_lvl then mt ()
       else str "Variable strategies" ++ fnl () ++
-        hov 0 (prlist_with_sep fnl pr_strategy var_lvl) ++ fnl ()
+        hov 0 (prlist_with_sep (fnl ()) pr_strategy var_lvl) ++ fnl ()
     in
     let cst_msg =
       if List.is_empty cst_lvl then mt ()
       else str "Constant strategies" ++ fnl () ++
-        hov 0 (prlist_with_sep fnl pr_strategy cst_lvl)
+        hov 0 (prlist_with_sep (fnl ()) pr_strategy cst_lvl)
     in
     Feedback.msg_notice (var_msg ++ cst_msg)
   | Some r ->
@@ -1002,12 +1002,12 @@ let vernac_arguments locality reference args more_implicits nargs_for_red flags 
   let err_extra_args names =
     user_err ~hdr:"vernac_declare_arguments"
                  (strbrk "Extra arguments: " ++
-                    prlist_with_sep pr_comma Name.print names ++ str ".")
+                    prlist_with_sep (pr_comma ()) Name.print names ++ str ".")
   in
   let err_missing_args names =
     user_err ~hdr:"vernac_declare_arguments"
                  (strbrk "The following arguments are not declared: " ++
-                    prlist_with_sep pr_comma Name.print names ++ str ".")
+                    prlist_with_sep (pr_comma ()) Name.print names ++ str ".")
   in
 
   let rec check_extra_args extra_args =
@@ -1099,7 +1099,7 @@ let vernac_arguments locality reference args more_implicits nargs_for_red flags 
     List.duplicates Name.equal (List.filter ((!=) Anonymous) names)
   in
   if not (List.is_empty duplicate_names) then begin
-    let duplicates = prlist_with_sep pr_comma Name.print duplicate_names in
+    let duplicates = prlist_with_sep (pr_comma ()) Name.print duplicate_names in
     user_err (strbrk "Some argument names are duplicated: " ++ duplicates)
   end;
 


### PR DESCRIPTION
This is the same as #869, except that instead of memoizing thunks in `prlist_sep_lastsep`, callers (direct or indirect) pass values instead of thunks.