### PR TITLE
Adding a V8.7 compatibility version number.

### DIFF
--- a/doc/stdlib/index-list.html.template
+++ b/doc/stdlib/index-list.html.template
@@ -591,5 +591,6 @@ through the <tt>Require Import</tt> command.</p>
     theories/Compat/AdmitAxiom.v
     theories/Compat/Coq85.v
     theories/Compat/Coq86.v
+    theories/Compat/Coq87.v
   </dd>
 </dl>

--- a/lib/flags.ml
+++ b/lib/flags.ml
@@ -106,7 +106,7 @@ let we_are_parsing = ref false
 (* Current means no particular compatibility consideration.
    For correct comparisons, this constructor should remain the last one. *)
 
-type compat_version = VOld | V8_5 | V8_6 | Current
+type compat_version = VOld | V8_5 | V8_6 | V8_7 | Current
 
 let compat_version = ref Current
 
@@ -120,6 +120,9 @@ let version_compare v1 v2 = match v1, v2 with
   | V8_6, V8_6 -> 0
   | V8_6, _ -> -1
   | _, V8_6 -> 1
+  | V8_7, V8_7 -> 0
+  | V8_7, _ -> -1
+  | _, V8_7 -> 1
   | Current, Current -> 0
 
 let version_strictly_greater v = version_compare !compat_version v > 0
@@ -129,6 +132,7 @@ let pr_version = function
   | VOld -> "old"
   | V8_5 -> "8.5"
   | V8_6 -> "8.6"
+  | V8_7 -> "8.7"
   | Current -> "current"
 
 (* Translate *)

--- a/lib/flags.mli
+++ b/lib/flags.mli
@@ -77,7 +77,7 @@ val raw_print : bool ref
 (* Univ print flag, never set anywere. Maybe should belong to Univ? *)
 val univ_print : bool ref
 
-type compat_version = VOld | V8_5 | V8_6 | Current
+type compat_version = VOld | V8_5 | V8_6 | V8_7 | Current
 val compat_version : compat_version ref
 val version_compare : compat_version -> compat_version -> int
 val version_strictly_greater : compat_version -> bool

--- a/theories/Compat/Coq87.v
+++ b/theories/Compat/Coq87.v
@@ -6,8 +6,4 @@
 (*         *       GNU Lesser General Public License Version 2.1        *)
 (************************************************************************)
 
-(** Compatibility file for making Coq act similar to Coq v8.6 *)
-Require Export Coq.Compat.Coq87.
-
-Require Export Coq.extraction.Extraction.
-Require Export Coq.funind.FunInd.
+(** Compatibility file for making Coq act similar to Coq v8.7 *)

--- a/toplevel/coqinit.ml
+++ b/toplevel/coqinit.ml
@@ -127,7 +127,8 @@ let init_ocaml_path () =
     List.iter add_subdir Coq_config.all_src_dirs
 
 let get_compat_version ?(allow_old = true) = function
-  | "8.7" -> Flags.Current
+  | "8.8" -> Flags.Current
+  | "8.7" -> Flags.V8_7
   | "8.6" -> Flags.V8_6
   | "8.5" -> Flags.V8_5
   | ("8.4" | "8.3" | "8.2" | "8.1" | "8.0") as s ->

--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -209,6 +209,7 @@ let add_compat_require v =
   match v with
   | Flags.V8_5 -> add_require "Coq.Compat.Coq85"
   | Flags.V8_6 -> add_require "Coq.Compat.Coq86"
+  | Flags.V8_7 -> add_require "Coq.Compat.Coq87"
   | Flags.VOld | Flags.Current -> ()
 
 let compile_list = ref ([] : (bool * string) list)


### PR DESCRIPTION
This shifts the list of supported versions from 8.5-8.7 to 8.6-8.8.

BTW, you know how I'm afraid we lose developments by dropping compatibility support for former versions (even if this compatibility support is approximative). Do we have feedback from users about whether they are with us in this direction?