### PR TITLE
Turning clearing of unused section variables on.

### DIFF
--- a/proofs/proof_global.ml
+++ b/proofs/proof_global.ml
@@ -265,7 +265,7 @@ let start_dependent_proof id ?pl str goals terminator =
 let get_used_variables () = (cur_pstate ()).section_vars
 let get_universe_binders () = (cur_pstate ()).universe_binders
 
-let proof_using_auto_clear = ref false
+let proof_using_auto_clear = ref true
 let _ = Goptions.declare_bool_option
     { Goptions.optdepr  = false;
       Goptions.optname  = "Proof using Clear Unused";

--- a/theories/Lists/List.v
+++ b/theories/Lists/List.v
@@ -970,7 +970,6 @@ Section Map.
   Lemma in_flat_map : forall (f:A->list B)(l:list A)(y:B),
     In y (flat_map f l) <-> exists x, In x l /\ In y (f x).
   Proof using A B.
-    clear Hfinjective.
     induction l; simpl; split; intros.
     contradiction.
     destruct H as (x,(H,_)); contradiction.


### PR DESCRIPTION
By default, option `Proof Using Clear Unused` is off. This PR proposes to turn it on by default as this looks to me like the intuitive expectation (even if source of incompatibilities, which I suspect was the reason for having it off).

This depends on #882 for the existence of version number 8.7 (so that the option is on only from 8.8).