### PR TITLE
Turning warning for deprecated notations on.

### DIFF
--- a/interp/syntax_def.ml
+++ b/interp/syntax_def.ml
@@ -89,12 +89,11 @@ let pr_compat_warning (kn, def, v) =
     | [], NRef r -> spc () ++ str "is" ++ spc () ++ pr_global_env Id.Set.empty r
     | _ -> strbrk " is a compatibility notation"
   in
-  let since = strbrk " since Coq > " ++ str (Flags.pr_version v) ++ str "." in
-  pr_syndef kn ++ pp_def ++ since
+  pr_syndef kn ++ pp_def ++ str "."
 
 let warn_compatibility_notation =
   CWarnings.(create ~name:"compatibility-notation"
-                    ~category:"deprecated" ~default:Disabled pr_compat_warning)
+                    ~category:"deprecated" ~default:Enabled pr_compat_warning)
 
 let verbose_compat kn def = function
   | Some v when Flags.version_strictly_greater v ->

--- a/plugins/romega/ReflOmegaCore.v
+++ b/plugins/romega/ReflOmegaCore.v
@@ -174,7 +174,7 @@ Module IntProperties (I:Int).
  Definition opp_def := ring.(Ropp_def).
  Definition minus_def := ring.(Rsub_def).
 
- Opaque plus_assoc plus_comm plus_0_l mult_assoc mult_comm mult_1_l
+ Opaque plus_assoc Nat.add_comm plus_0_l mult_assoc mult_comm mult_1_l
   mult_plus_distr_r opp_def minus_def.
 
  (** More facts about [plus] *)

--- a/plugins/setoid_ring/ArithRing.v
+++ b/plugins/setoid_ring/ArithRing.v
@@ -14,7 +14,7 @@ Set Implicit Arguments.
 
 Lemma natSRth : semi_ring_theory O (S O) plus mult (@eq nat).
  Proof.
-  constructor. exact plus_0_l. exact plus_comm. exact plus_assoc.
+  constructor. exact plus_0_l. exact PeanoNat.Nat.add_comm. exact plus_assoc.
   exact mult_1_l. exact mult_0_l. exact mult_comm. exact mult_assoc.
   exact mult_plus_distr_r.
  Qed.

--- a/theories/Arith/Compare.v
+++ b/theories/Arith/Compare.v
@@ -42,10 +42,10 @@ Proof.
   intro H'; lapply (le_lt_or_eq (S m) n); auto with arith.
   induction 1; auto with arith.
   right; exists (n - S (S m)); simpl.
-  rewrite (plus_comm m (n - S (S m))).
+  rewrite (Nat.add_comm m (n - S (S m))).
   rewrite (plus_n_Sm (n - S (S m)) m).
   rewrite (plus_n_Sm (n - S (S m)) (S m)).
-  rewrite (plus_comm (n - S (S m)) (S (S m))); auto with arith.
+  rewrite (Nat.add_comm (n - S (S m)) (S (S m))); auto with arith.
 Qed.
 
 Require Export Wf_nat.

--- a/theories/Arith/Plus.v
+++ b/theories/Arith/Plus.v
@@ -177,7 +177,7 @@ Proof (succ_plus_discr n 3).
 
 (** * Compatibility Hints *)
 
-Hint Immediate plus_comm : arith.
+Hint Immediate Nat.add_comm : arith.
 Hint Resolve plus_assoc plus_assoc_reverse : arith.
 Hint Resolve plus_le_compat_l plus_le_compat_r : arith.
 Hint Resolve le_plus_l le_plus_r le_plus_trans : arith.

--- a/theories/FSets/FSetPositive.v
+++ b/theories/FSets/FSetPositive.v
@@ -784,7 +784,7 @@ Module PositiveSet <: S with Module E:=PositiveOrderedTypeBits.
        rewrite <- plus_n_Sm, Plus.plus_assoc. reflexivity.
       rewrite <- IHl, <- IHr. rewrite Plus.plus_assoc. reflexivity.
 
-    intros. rewrite <- H. simpl. rewrite Plus.plus_comm. reflexivity.
+    intros. rewrite <- H. simpl. rewrite PeanoNat.Nat.add_comm. reflexivity.
   Qed.
 
   (** Specification of [filter] *)

--- a/theories/FSets/FSetProperties.v
+++ b/theories/FSets/FSetProperties.v
@@ -844,7 +844,7 @@ Module WProperties_fun (Import E : DecidableType)(M : WSfun E).
   Proof.
   intros.
   rewrite <- union_inter_cardinal.
-  rewrite Plus.plus_comm.
+  rewrite PeanoNat.Nat.add_comm.
   auto with arith.
   Qed.
 

--- a/theories/MSets/MSetPositive.v
+++ b/theories/MSets/MSetPositive.v
@@ -716,7 +716,7 @@ Module PositiveSet <: S with Module E:=PositiveOrderedTypeBits.
        rewrite <- plus_n_Sm, Plus.plus_assoc. reflexivity.
       rewrite <- IHl, <- IHr. rewrite Plus.plus_assoc. reflexivity.
 
-    intros. rewrite <- H. simpl. rewrite Plus.plus_comm. reflexivity.
+    intros. rewrite <- H. simpl. rewrite PeanoNat.Nat.add_comm. reflexivity.
   Qed.
 
   (** Specification of [filter] *)

--- a/theories/MSets/MSetProperties.v
+++ b/theories/MSets/MSetProperties.v
@@ -853,7 +853,7 @@ Module WPropertiesOn (Import E : DecidableType)(M : WSetsOn E).
   Proof.
   intros.
   rewrite <- union_inter_cardinal.
-  rewrite Plus.plus_comm.
+  rewrite PeanoNat.Nat.add_comm.
   auto with arith.
   Qed.
 

--- a/theories/PArith/BinPos.v
+++ b/theories/PArith/BinPos.v
@@ -1798,7 +1798,7 @@ Proof.
  (* Lt *)
  intros LT LE p Hp1 Hp2. apply IHn; clear IHn; trivial.
  apply le_S_n in LE. eapply Le.le_trans; [|eapply LE].
- rewrite plus_comm, <- plus_n_Sm, <- plus_Sn_m.
+ rewrite PeanoNat.Nat.add_comm, <- plus_n_Sm, <- plus_Sn_m.
  apply plus_le_compat; trivial.
  apply size_nat_monotone, sub_decr, LT.
  apply divide_xO_xI with a; trivial.

--- a/theories/Reals/Binomial.v
+++ b/theories/Reals/Binomial.v
@@ -19,7 +19,7 @@ Proof.
   intros; unfold C; replace (n - (n - i))%nat with i.
   rewrite Rmult_comm.
   reflexivity.
-  apply plus_minus; rewrite plus_comm; apply le_plus_minus; assumption.
+  apply plus_minus; rewrite Nat.add_comm; apply le_plus_minus; assumption.
 Qed.
 
 Lemma pascal_step2 :
@@ -96,7 +96,7 @@ Proof.
   cut ((n - (n - i))%nat = i).
   intro; rewrite H0; reflexivity.
   symmetry ; apply plus_minus.
-  rewrite plus_comm; rewrite le_plus_minus_r.
+  rewrite Nat.add_comm; rewrite le_plus_minus_r.
   reflexivity.
   apply lt_le_weak; assumption.
   apply le_minusni_n; apply lt_le_weak; assumption.

--- a/theories/Reals/RList.v
+++ b/theories/Reals/RList.v
@@ -763,17 +763,17 @@ Proof.
   clear l2 r0 H i H0 H1 H2; induction  l1 as [| r0 l1 Hrecl1].
   reflexivity.
   simpl; assumption.
-  rewrite RList_P23; rewrite plus_comm; simpl; apply lt_n_Sn.
+  rewrite RList_P23; rewrite Nat.add_comm; simpl; apply lt_n_Sn.
   replace (S m - Rlength l1)%nat with (S (S m - S (Rlength l1))).
   rewrite H3; simpl;
     replace (S (Rlength l1)) with (Rlength (cons_Rlist l1 (cons r nil))).
   apply (H (cons_Rlist l1 (cons r nil)) i).
-  rewrite RList_P23; rewrite plus_comm; simpl; rewrite <- H3;
+  rewrite RList_P23; rewrite Nat.add_comm; simpl; rewrite <- H3;
     apply le_n_S; assumption.
   repeat rewrite RList_P23; simpl; rewrite RList_P23 in H1;
-    rewrite plus_comm in H1; simpl in H1; rewrite (plus_comm (Rlength l1));
-      simpl; rewrite plus_comm; apply H1.
-  rewrite RList_P23; rewrite plus_comm; reflexivity.
+    rewrite Nat.add_comm in H1; simpl in H1; rewrite (Nat.add_comm (Rlength l1));
+      simpl; rewrite Nat.add_comm; apply H1.
+  rewrite RList_P23; rewrite Nat.add_comm; reflexivity.
   change (S (m - Rlength l1) = (S m - Rlength l1)%nat);
     apply minus_Sn_m; assumption.
   replace (cons r r0) with (cons_Rlist (cons r nil) r0);

--- a/theories/Reals/Rfunctions.v
+++ b/theories/Reals/Rfunctions.v
@@ -149,7 +149,7 @@ Proof.
   apply Rlt_pow_R1; auto with arith.
   apply plus_lt_reg_l with (p := n); auto with arith.
   rewrite le_plus_minus_r; auto with arith; rewrite <- plus_n_O; auto.
-  rewrite plus_comm; auto with arith.
+  rewrite Nat.add_comm; auto with arith.
 Qed.
 Hint Resolve Rlt_pow: real.
 
@@ -475,7 +475,7 @@ Proof.
   apply Rmult_le_compat_l.
   apply pow_le; left; apply Rlt_le_trans with 1; [ apply Rlt_0_1 | assumption ].
   apply pow_R1_Rle; assumption.
-  rewrite plus_comm.
+  rewrite Nat.add_comm.
   symmetry ; apply le_plus_minus; assumption.
 Qed.
 
@@ -602,12 +602,12 @@ Proof.
  - rewrite Pos2Nat.inj_sub by trivial.
    rewrite Pos2Nat.inj_lt in H.
    rewrite (pow_RN_plus x _ (Pos.to_nat n)) by auto with real.
-   rewrite plus_comm, le_plus_minus_r by auto with real.
+   rewrite Nat.add_comm, le_plus_minus_r by auto with real.
    rewrite Rinv_mult_distr, Rinv_involutive; auto with real.
  - rewrite Pos2Nat.inj_sub by trivial.
    rewrite Pos2Nat.inj_lt in H.
    rewrite (pow_RN_plus x _ (Pos.to_nat m)) by auto with real.
-   rewrite plus_comm, le_plus_minus_r by auto with real.
+   rewrite Nat.add_comm, le_plus_minus_r by auto with real.
    reflexivity.
 Qed.
 

--- a/theories/Sorting/PermutSetoid.v
+++ b/theories/Sorting/PermutSetoid.v
@@ -198,7 +198,7 @@ Proof.
   do 2 rewrite list_contents_app.
   simpl.
   intros; apply plus_reg_l with (multiplicity (list_contents l) a).
-  rewrite plus_comm; rewrite H; rewrite plus_comm.
+  rewrite Nat.add_comm; rewrite H; rewrite Nat.add_comm.
   trivial.
 Qed.
 
@@ -231,8 +231,8 @@ Proof.
   rewrite list_contents_app in *; simpl in *.
   apply plus_reg_l with (if eqA_dec a a0 then 1 else 0).
   rewrite H; clear H.
-  symmetry; rewrite plus_comm, <- ! plus_assoc; f_equal.
-  rewrite plus_comm.
+  symmetry; rewrite Nat.add_comm, <- ! plus_assoc; f_equal.
+  rewrite Nat.add_comm.
   destruct (eqA_dec a a0) as [Ha|Ha]; rewrite Heq in Ha;
     decide (eqA_dec b a0) with Ha; reflexivity.
 Qed.

--- a/theories/Strings/String.v
+++ b/theories/Strings/String.v
@@ -108,7 +108,7 @@ Theorem append_correct2 :
  get n s2 = get (n + length s1) (s1 ++ s2).
 Proof.
 intros s1; elim s1; simpl; auto.
-intros s2 n; rewrite plus_comm; simpl; auto.
+intros s2 n; rewrite Nat.add_comm; simpl; auto.
 intros a s1' Rec s2 n; case n; simpl; auto.
 generalize (Rec s2 0); simpl; auto. intros.
 rewrite <- Plus.plus_Snm_nSm; auto.

--- a/theories/Vectors/Fin.v
+++ b/theories/Vectors/Fin.v
@@ -196,7 +196,7 @@ induction o ; simpl.
 
 - rewrite R_sanity. rewrite IHo.
   rewrite Plus.plus_assoc. destruct (to_nat o); simpl; rewrite Mult.mult_succ_r.
-    now rewrite (Plus.plus_comm n).
+    now rewrite (PeanoNat.Nat.add_comm n).
 Qed.
 
 Fixpoint eqb {m n} (p : t m) (q : t n) :=

--- a/theories/ZArith/Zgcd_alt.v
+++ b/theories/ZArith/Zgcd_alt.v
@@ -217,7 +217,7 @@ Open Scope Z_scope.
    intros _.
    induction p; [ | | compute; auto ];
     simpl Zgcd_bound in *;
-    rewrite plus_comm; simpl plus;
+    rewrite Nat.add_comm; simpl plus;
     set (n:= (Pos.size_nat p+Pos.size_nat p)%nat) in *; simpl;
     assert (n <> O) by (unfold n; destruct p; simpl; auto).
 
@@ -250,7 +250,7 @@ Open Scope Z_scope.
   simpl Zgcd_bound in *.
   remember (Pos.size_nat a+Pos.size_nat a)%nat as m.
   assert (1 < m)%nat.
-  { rewrite Heqm; destruct a; simpl; rewrite 1?plus_comm;
+  { rewrite Heqm; destruct a; simpl; rewrite 1?Nat.add_comm;
     auto with arith. }
   destruct m as [ |m]; [inversion H0; auto| ].
   destruct n as [ |n]; [inversion H; auto| ].


### PR DESCRIPTION
With this PR, the warning for compatibility notations is turned on, which is I believe the expected behavior.

If I remember correctly, it was left off because of a pending discussion at the [deprecation PR](https://github.com/coq/coq/pull/375#issuecomment-289011574).

I believe we should decide something for the questionable aliases without preventing the deprecated warning being activated, since, in most of the cases, this warning seems justified:
- use of qualification (apparently a general agreement these days to put the concept name in the base name and the structure name in the qualified part of the name)
- consistent terminoly (`mul`/`add`/`sub`, rather than the inconsistent `mult`/`plus`/`minus`; always `succ` rather than `S` or `succ`)
- standard algebraic names when they exist (e.g. `le_0_l` rather than `le_0_n`)

Are there other questionable names than the one mentioned by @maximedenes and involving `diag` (standing for a statement which refers to the same variable on both side of a relation)? I list those here, if ever some good idea emerges:
```
Lemma minus_diag_reverse n : 0 = n - n.
Lemma orb_diag : forall b, b || b = b.
Lemma andb_diag : forall b, b && b = b.
Lemma add_diag p : p + p = p~0.
Lemma sub_mask_add_diag_l p q : sub_mask (p+q) p = IsPos q.
Lemma sub_mask_add_diag_r p q : sub_mask p (p+q) = IsNeg.
Lemma lt_succ_diag_r p : p < succ p.
Lemma lt_add_diag_r p q : p < p + q.
Lemma sub_diag p : p-p = 1.
Lemma Rminus_diag_eq : forall r1 r2, r1 = r2 -> r1 - r2 = 0.
Lemma Rminus_diag_uniq : forall r1 r2, r1 - r2 = 0 -> r1 = r2.
Lemma Rminus_diag_uniq_sym : forall r1 r2, r2 - r1 = 0 -> r1 = r2.
Lemma pos_sub_diag p : pos_sub p p = 0.
Lemma add_opp_diag_r n : n + - n = 0.
Lemma add_diag n : n + n = 2 * n.
Lemma Zminus_diag_reverse : forall n, 0 = n-n.
Lemma Zplus_diag_eq_mult_2 n : n + n = n * 2.
Lemma Qcplus_diag x : (x + x)%Qc = (2 * x)%Qc.
Lemma Qp_minus_diag x : (x - x)%Qp = None.
Lemma gcd_diag_nonneg : forall n, 0<=n -> gcd n n == n.
Lemma gcd_mul_diag_l : forall n m, 0<=n -> gcd n (n*m) == n.
Theorem sub_mask_diag p : sub_mask p p = IsNul.
Theorem lt_succ_diag_r : forall n, n < S n.
Theorem le_succ_diag_r : forall n, n <= S n.
Theorem neq_succ_diag_l : forall n, S n ~= n.
Theorem neq_succ_diag_r : forall n, n ~= S n.
Theorem nlt_succ_diag_l : forall n, ~ S n < n.
Theorem nle_succ_diag_l : forall n, ~ S n <= n.
```
Note by the way that `diag` is also common in `CoRN` and `MathClasses`.

(Also removing writing "since Coq > Old" in the warning.)