### PR TITLE
Removing default evar-normalization for ARGUMENT EXTEND.

### DIFF
--- a/grammar/argextend.mlp
+++ b/grammar/argextend.mlp
@@ -137,7 +137,8 @@ let declare_tactic_argument loc s (typ, f, g, h) cl =
       let typ = match globtyp with None -> ExtraArgType s | Some typ -> typ in
       <:expr<
         let f = $lid:f$ in
-        fun ist v -> Ftactic.nf_enter (fun gl ->
+        fun ist v -> Ftactic.enter (fun gl ->
+          let gl = Proofview.Goal.assume gl in
           let (sigma, v) = Tacmach.New.of_old (fun gl -> f ist gl v) gl in
           let v = Geninterp.Val.inject (Geninterp.val_tag $make_topwit loc typ$) v in
           Proofview.tclTHEN (Proofview.Unsafe.tclEVARS sigma) (Ftactic.return v)

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -2000,7 +2000,7 @@ let lift f = (); fun ist x -> Ftactic.enter begin fun gl ->
   Ftactic.return (f ist env sigma x)
 end
 
-let lifts f = (); fun ist x -> Ftactic.nf_enter begin fun gl ->
+let lifts f = (); fun ist x -> Ftactic.enter begin fun gl ->
   let env = Proofview.Goal.env gl in
   let sigma = Proofview.Goal.sigma gl in
   let (sigma, v) = f ist env sigma x in


### PR DESCRIPTION
This fixes bug 5650: evar (x : Prop) should not be slow.

Should be backported to 8.7 as well.