### PR TITLE
Fixing a little location bug with recursive binders

### DIFF
--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -664,11 +664,11 @@ let instantiate_notation_constr loc intern ntnvars subst infos c =
     | NProd (Name id, NHole _, c') when option_mem_assoc id binderopt ->
         let a,letins = snd (Option.get binderopt) in
         let e = make_letins letins (aux subst' infos c') in
-        let (loc,(na,bk,t)) = a in
+        let (_loc,(na,bk,t)) = a in
         CAst.make ?loc @@ GProd (na,bk,t,e)
     | NLambda (Name id,NHole _,c') when option_mem_assoc id binderopt ->
         let a,letins = snd (Option.get binderopt) in
-        let (loc,(na,bk,t)) = a in
+        let (_loc,(na,bk,t)) = a in
         CAst.make ?loc @@ GLambda (na,bk,t,make_letins letins (aux subst' infos c'))
     (* Two special cases to keep binder name synchronous with BinderType *)
     | NProd (na,NHole(Evar_kinds.BinderType na',naming,arg),c')


### PR DESCRIPTION
This fixes the following wrong location of errors:
```coq
> Check 0 + ∀x, x=0.
>            ^
Error: The term "∀ x : nat, x = 0" has type "Prop" while it is expected to have type "nat".
```
now giving
```coq
> Check 0 + ∀x, x=0.
>           ^^^^^^^
Error: The term "∀ x : nat, x = 0" has type "Prop" while it is expected to have type "nat".
```
Note that localisation cannot be perfect anyways, as in the following example, where there is no way to highlight in the original input a syntactically stand-alone subterm where the error occurs.
```coq
> Check forall (y:nat) (x:=0), y.
>       ^^^^^^^^^^^^^^^^^^^^^^^^
Error: In environment
y : nat
The term "let x := 0 in y" has type "nat" which should be Set, Prop or Type.
```

