### PR TITLE
[ci] VST is now built with IGNORECOQVERSION=true.

### DIFF
--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -79,8 +79,8 @@
 ########################################################################
 # VST
 ########################################################################
-: ${VST_CI_BRANCH:=less_init_plugins}
-: ${VST_CI_GITURL:=https://github.com/letouzey/VST.git}
+: ${VST_CI_BRANCH:=master}
+: ${VST_CI_GITURL:=https://github.com/Zimmi48/VST.git}
 
 ########################################################################
 # fiat_parsers

--- a/dev/ci/ci-vst.sh
+++ b/dev/ci/ci-vst.sh
@@ -10,4 +10,4 @@ git_checkout ${VST_CI_BRANCH} ${VST_CI_GITURL} ${VST_CI_DIR}
 
 # Targets are: msl veric floyd
 # Patch to avoid the upper version limit
-( cd ${VST_CI_DIR} && sed -i.bak 's/8.6$/8.6 or-else trunk/' Makefile && make )
+( cd ${VST_CI_DIR} && make IGNORECOQVERSION=true )


### PR DESCRIPTION
This should fix VST on Travis after PrincetonUniversity/VST#79.