### PR TITLE
Prepare De Bruijn universe abstractions, Spin-off: Checker

### DIFF
--- a/checker/mod_checking.ml
+++ b/checker/mod_checking.ml
@@ -26,22 +26,21 @@ let refresh_arity ar =
 
 let check_constant_declaration env kn cb =
   Feedback.msg_notice (str "  checking cst:" ++ prcon kn);
-  let env', u =
+  (** [env'] contains De Bruijn universe variables *)
+  let env' =
     match cb.const_universes with
-    | Monomorphic_const ctx -> push_context ~strict:true ctx env, Univ.Instance.empty
+    | Monomorphic_const ctx -> push_context ~strict:true ctx env
     | Polymorphic_const auctx ->
-      let ctx = Univ.instantiate_univ_context auctx in
-      push_context ~strict:false ctx env, Univ.UContext.instance ctx
+      let ctx = Univ.AUContext.repr auctx in
+      push_context ~strict:false ctx env
   in
   let envty, ty = 
     match cb.const_type with
       RegularArity ty ->
-        let ty = subst_instance_constr u ty in
         let ty', cu = refresh_arity ty in
         let envty = push_context_set cu env' in
         let _ = infer_type envty ty' in envty, ty
     | TemplateArity(ctxt,par) ->
-        assert(Univ.Instance.is_empty u);
         let _ = check_ctxt env' ctxt in
         check_polymorphic_arity env' ctxt par;
 	env', it_mkProd_or_LetIn (Sort(Type par.template_level)) ctxt 
@@ -49,7 +48,6 @@ let check_constant_declaration env kn cb =
   let () = 
     match body_of_constant cb with
     | Some bd ->
-      let bd = subst_instance_constr u bd in
       (match cb.const_proj with 
       | None -> let j = infer envty bd in
 		  conv_leq envty j ty

--- a/checker/term.ml
+++ b/checker/term.ml
@@ -447,37 +447,3 @@ let subst_instance_constr subst c =
 let subst_instance_context s ctx = 
   if Univ.Instance.is_empty s then ctx
   else map_rel_context (fun x -> subst_instance_constr s x) ctx
-
-let subst_univs_level_constr subst c =
-  if Univ.is_empty_level_subst subst then c
-  else 
-    let f = Univ.Instance.subst_fn (Univ.subst_univs_level_level subst) in
-    let changed = ref false in
-    let rec aux t = 
-      match t with
-      | Const (c, u) -> 
-	if Univ.Instance.is_empty u then t
-	else 
-          let u' = f u in 
-	    if u' == u then t
-	    else (changed := true; Const (c, u'))
-      | Ind (i, u) ->
-	if Univ.Instance.is_empty u then t
-	else 
-	  let u' = f u in 
-	    if u' == u then t
-	    else (changed := true; Ind (i, u'))
-      | Construct (c, u) ->
-	if Univ.Instance.is_empty u then t
-	else 
-          let u' = f u in 
-	    if u' == u then t
-	    else (changed := true; Construct (c, u'))
-      | Sort (Type u) -> 
-         let u' = Univ.subst_univs_level_universe subst u in
-	   if u' == u then t else 
-	     (changed := true; Sort (sort_of_univ u'))
-      | _ -> map_constr aux t
-    in
-    let c' = aux c in
-      if !changed then c' else c

--- a/checker/term.mli
+++ b/checker/term.mli
@@ -57,4 +57,3 @@ val eq_constr : constr -> constr -> bool
 (** Instance substitution for polymorphism. *)
 val subst_instance_constr : Univ.universe_instance -> constr -> constr
 val subst_instance_context : Univ.universe_instance -> rel_context -> rel_context
-val subst_univs_level_constr : Univ.universe_level_subst -> constr -> constr

--- a/checker/univ.mli
+++ b/checker/univ.mli
@@ -18,6 +18,8 @@ sig
   (** Create a new universe level from a unique identifier and an associated
       module path. *)
 
+  val var : int -> t
+
   val pr : t -> Pp.std_ppcmds
   (** Pretty-printing *)
   
@@ -179,6 +181,8 @@ sig
   val length : t -> int
   (** Compute the length of the instance  *)
 
+  val of_array : Level.t array -> t
+
   val append : t -> t -> t
   (** Append two universe instances *)
 end
@@ -208,7 +212,6 @@ module AUContext :
 sig
   type t
 
-  val instance : t -> Instance.t
   val size : t -> int
 
   val instantiate : Instance.t -> t -> Constraint.t
@@ -217,27 +220,6 @@ sig
 end
 
 type abstract_universe_context = AUContext.t
-
-module CumulativityInfo :
-sig
-  type t
-
-  val make : universe_context * universe_context -> t
-
-  val empty : t
-
-  val univ_context : t -> universe_context
-  val subtyp_context : t -> universe_context
-
-  val from_universe_context : universe_context -> universe_instance -> t
-
-  val subtyping_other_instance : t -> universe_instance
-  
-  val subtyping_susbst : t -> universe_level_subst
-
-end
-
-type cumulativity_info = CumulativityInfo.t
 
 module ACumulativityInfo :
 sig
@@ -283,10 +265,6 @@ val subst_instance_universe : universe_instance -> universe -> universe
 
 (* val make_instance_subst : universe_instance -> universe_level_subst *)
 (* val make_inverse_instance_subst : universe_instance -> universe_level_subst *)
-
-(** Get the instantiated graph. *)
-val instantiate_univ_context : abstract_universe_context -> universe_context
-val instantiate_cumulativity_info : abstract_cumulativity_info -> cumulativity_info
 
 (** Build the relative instance corresponding to the context *)
 val make_abstract_instance : abstract_universe_context -> universe_instance


### PR DESCRIPTION
This patch fixes the checker w.r.t. wrongly used abstract universe contexts.

It seems we were not testing the checker on cumulative inductive types,
because judging from the code, it would just have exploded in anomalies.
Before this patch, the checker was mixing De Bruijn indices with named
variables, resulting in ill-formed universe contexts used throughout the
checking of cumulative inductive types.

This patch also gets rid of a lot of now dead code, and removes abstraction
breaking code from the checker.