### PR TITLE
Fix test suite on windows (wrt fake_ide and coq-makefile)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ environment:
 install:
 - cmd: '%CYGROOT%\setup-x86_64.exe -qnNdO -R %CYGROOT% -l %CYGCACHE% -s
   %CYGMIRROR% -P rsync -P patch -P diffutils -P curl -P make -P unzip -P git -p m4
-  -P perl -P findutils'
+  -P perl -P findutils -P time'
 - cmd: '%CYGROOT%/bin/bash -l %APPVEYOR_BUILD_FOLDER%/dev/build/windows/appveyor.sh'
 
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,26 @@
+version: '{branch}~{build}'
+clone_depth: 10
+
+platform:
+- x64
+
+image:
+- Visual Studio 2017
+
+environment:
+  CYGROOT: C:\cygwin64
+  CYGMIRROR: http://ftp.inf.tu-dresden.de/software/windows/cygwin32
+  CYGCACHE: C:\cygwin64\var\cache\setup
+  opam_url: https://github.com/fdopen/opam-repository-mingw/releases/download/0.0.0.1/opam64.tar.xz
+
+install:
+- cmd: '%CYGROOT%\setup-x86_64.exe -qnNdO -R %CYGROOT% -l %CYGCACHE% -s
+  %CYGMIRROR% -P rsync -P patch -P diffutils -P curl -P make -P unzip -P git -p m4
+  -P perl -P findutils'
+- cmd: '%CYGROOT%/bin/bash -l %APPVEYOR_BUILD_FOLDER%/dev/build/windows/appveyor.sh'
+
+build_script:
+- cmd: '%CYGROOT%/bin/bash -lc "cd $APPVEYOR_BUILD_FOLDER && ./configure -local && make"'
+
+test_script:
+- cmd: '%CYGROOT%/bin/bash -lc "cd $APPVEYOR_BUILD_FOLDER && make -C test-suite && make validate"'

--- a/dev/build/windows/appveyor.sh
+++ b/dev/build/windows/appveyor.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e -x
+wget $opam_url
+tar -xf opam64.tar.xz
+bash opam64/install.sh
+opam init -a mingw https://github.com/fdopen/opam-repository-mingw.git --comp 4.02.3+mingw64c --switch 4.02.3+mingw64c
+eval $(opam config env)
+opam install -y ocamlfind camlp5

--- a/lib/control.ml
+++ b/lib/control.ml
@@ -48,7 +48,7 @@ let windows_timeout n f e =
   let exited = ref false in
   let thread init =
     while not !killed do
-      let cur = Unix.time () in
+      let cur = Unix.gettimeofday () in
       if float_of_int n <= cur -. init then begin
         interrupt := true;
         exited := true;
@@ -57,12 +57,12 @@ let windows_timeout n f e =
       Thread.delay 0.5
     done
   in
-  let init = Unix.time () in
+  let init = Unix.gettimeofday () in
   let _id = Thread.create thread init in
   try
     let res = f () in
     let () = killed := true in
-    let cur = Unix.time () in
+    let cur = Unix.gettimeofday () in
     (** The thread did not interrupt, but the computation took longer than
         expected. *)
     let () = if float_of_int n <= cur -. init then begin

--- a/lib/minisys.ml
+++ b/lib/minisys.ml
@@ -44,7 +44,11 @@ let ok_dirname f =
 (* Check directory can be opened *)
 
 let exists_dir dir =
-  try Sys.is_directory dir with Sys_error _ -> false
+  let rec strip_trailing_slash dir =
+    let len = String.length dir in
+    if len > 0 && (dir.[len-1] = '/' || dir.[len-1] = '\\')
+    then strip_trailing_slash (String.sub dir 0 (len-1)) else dir in
+  try Sys.is_directory (strip_trailing_slash dir) with Sys_error _ -> false
 
 let apply_subdir f path name =
   (* we avoid all files and subdirs starting by '.' (e.g. .svn) *)

--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -27,8 +27,8 @@
 
 # Default value when called from a freshly compiled Coq, but can be
 # easily overridden
-LIB := $(shell cd ..; pwd)
-BIN := $(LIB)/bin/
+LIB := ..
+BIN := $(shell cd ..; pwd)/bin/
 
 coqtop := $(BIN)coqtop -coqlib $(LIB) -boot -q -batch -test-mode -R prerequisite TestSuite
 coqc := $(BIN)coqc -coqlib $(LIB) -R prerequisite TestSuite

--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -170,6 +170,7 @@ summary.log:
 report: summary.log
 	$(HIDE)./save-logs.sh
 	$(HIDE)if [ -n "${TRAVIS}" ]; then find logs/ -name '*.log' -not -name 'summary.log' -exec 'bash' '-c' 'echo "travis_fold:start:coq.logs.$$(echo '{}' | sed s,/,.,g)"' ';' -exec cat '{}' ';' -exec 'bash' '-c' 'echo "travis_fold:end:coq.logs.$$(echo '{}' | sed s,/,.,g)"' ';'; fi
+	$(HIDE)if [ -n "${APPVEYOR}" ]; then find logs/ -name '*.log' -not -name 'summary.log' -exec 'bash' '-c' 'echo {}' ';' -exec cat '{}' ';' -exec 'bash' '-c' 'echo' ';'; fi
 	$(HIDE)if grep -q -F 'Error!' summary.log ; then echo FAILURES; grep -F 'Error!' summary.log; false; else echo NO FAILURES; fi
 
 #######################################################################

--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -446,7 +446,7 @@ ide : $(patsubst %.fake,%.fake.log,$(wildcard ide/*.fake))
 	@echo "TEST      $<"
 	$(HIDE){ \
 	  echo $(call log_intro,$<); \
-	  $(BIN)fake_ide $< "$(BIN)coqtop -coqlib $(LIB) -boot -async-proofs on -async-proofs-tactic-error-resilience off -async-proofs-command-error-resilience off" 2>&1; \
+	  $(BIN)fake_ide $< "-coqlib $(LIB) -boot -async-proofs on -async-proofs-tactic-error-resilience off -async-proofs-command-error-resilience off" 2>&1; \
 	  if [ $$? = 0 ]; then \
 	    echo $(log_success); \
 	    echo "    $<...Ok"; \

--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -294,7 +294,7 @@ $(addsuffix .log,$(wildcard output/*.v)): %.v.log: %.v %.out $(PREREQUISITELOG)
 	    | grep -v "^<W>" \
 	    | sed 's/File "[^"]*"/File "stdin"/' \
 	    > $$tmpoutput; \
-	  diff -u $*.out $$tmpoutput 2>&1; R=$$?; times; \
+	  diff -u --strip-trailing-cr $*.out $$tmpoutput 2>&1; R=$$?; times; \
 	  if [ $$R = 0 ]; then \
 	    echo $(log_success); \
 	    echo "    $<...Ok"; \
@@ -329,7 +329,7 @@ $(addsuffix .log,$(wildcard output-modulo-time/*.v)): %.v.log: %.v %.out
 		-e 's/\s*[-+]inf\s*//g' \
 		-e 's/^[^a-zA-Z]*//' \
 	       $*.out | sort > $$tmpexpected; \
-	  diff -b -u $$tmpexpected $$tmpoutput 2>&1; R=$$?; times; \
+	  diff  --strip-trailing-cr -b -u $$tmpexpected $$tmpoutput 2>&1; R=$$?; times; \
 	  if [ $$R = 0 ]; then \
 	    echo $(log_success); \
 	    echo "    $<...Ok"; \

--- a/test-suite/coq-makefile/arg/run.sh
+++ b/test-suite/coq-makefile/arg/run.sh
@@ -3,4 +3,5 @@
 . ../template/init.sh
 
 coq_makefile -f _CoqProject -o Makefile
+cat Makefile.conf
 make

--- a/test-suite/coq-makefile/arg/run.sh
+++ b/test-suite/coq-makefile/arg/run.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-#set -x
-set -e
-
 . ../template/init.sh
 
 coq_makefile -f _CoqProject -o Makefile

--- a/test-suite/coq-makefile/compat-subdirs/run.sh
+++ b/test-suite/coq-makefile/compat-subdirs/run.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
 
-#set -x
-set -e
-
 . ../template/init.sh
+
 coq_makefile -f _CoqProject -o Makefile
 make
 exec test -f "subdir/done"

--- a/test-suite/coq-makefile/compat-subdirs/run.sh
+++ b/test-suite/coq-makefile/compat-subdirs/run.sh
@@ -3,5 +3,6 @@
 . ../template/init.sh
 
 coq_makefile -f _CoqProject -o Makefile
+cat Makefile.conf
 make
 exec test -f "subdir/done"

--- a/test-suite/coq-makefile/coqdoc1/run.sh
+++ b/test-suite/coq-makefile/coqdoc1/run.sh
@@ -3,6 +3,7 @@
 . ../template/init.sh
 
 coq_makefile -f _CoqProject -o Makefile
+cat Makefile.conf
 make
 make html mlihtml
 make install DSTROOT="$PWD/tmp"

--- a/test-suite/coq-makefile/coqdoc1/run.sh
+++ b/test-suite/coq-makefile/coqdoc1/run.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-#set -x
-set -e
-
 . ../template/init.sh
 
 coq_makefile -f _CoqProject -o Makefile
@@ -11,7 +8,7 @@ make html mlihtml
 make install DSTROOT="$PWD/tmp"
 make install-doc DSTROOT="$PWD/tmp"
 #make debug
-(for d in `find tmp -name user-contrib`; do pushd $d >/dev/null; find .; popd >/dev/null; done) | sort -u > actual
+(for d in `find tmp -name user-contrib` ; do pushd $d >/dev/null && find . && popd >/dev/null; done) | sort -u > actual
 sort -u > desired <<EOT
 .
 ./test

--- a/test-suite/coq-makefile/coqdoc2/run.sh
+++ b/test-suite/coq-makefile/coqdoc2/run.sh
@@ -3,6 +3,7 @@
 . ../template/init.sh
 
 coq_makefile -f _CoqProject -o Makefile
+cat Makefile.conf
 make
 make html mlihtml
 make install DSTROOT="$PWD/tmp"

--- a/test-suite/coq-makefile/coqdoc2/run.sh
+++ b/test-suite/coq-makefile/coqdoc2/run.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-#set -x
-set -e
-
 . ../template/init.sh
 
 coq_makefile -f _CoqProject -o Makefile
@@ -11,7 +8,7 @@ make html mlihtml
 make install DSTROOT="$PWD/tmp"
 make install-doc DSTROOT="$PWD/tmp"
 #make debug
-(for d in `find tmp -name user-contrib`; do pushd $d >/dev/null; find .; popd >/dev/null; done) | sort -u > actual
+(for d in `find tmp -name user-contrib` ; do pushd $d >/dev/null && find . && popd >/dev/null; done) | sort -u > actual
 sort -u > desired <<EOT
 .
 ./test

--- a/test-suite/coq-makefile/extend-subdirs/run.sh
+++ b/test-suite/coq-makefile/extend-subdirs/run.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-#set -x
-set -e
-
 . ../template/init.sh
 
 coq_makefile -f _CoqProject -o Makefile

--- a/test-suite/coq-makefile/extend-subdirs/run.sh
+++ b/test-suite/coq-makefile/extend-subdirs/run.sh
@@ -3,5 +3,6 @@
 . ../template/init.sh
 
 coq_makefile -f _CoqProject -o Makefile
+cat Makefile.conf
 make
 exec test -f "subdir/done"

--- a/test-suite/coq-makefile/latex1/run.sh
+++ b/test-suite/coq-makefile/latex1/run.sh
@@ -5,6 +5,7 @@ if which pdflatex; then
 . ../template/init.sh
 	
 coq_makefile -f _CoqProject -o Makefile
+cat Makefile.conf
 make
 exec make all.pdf
 

--- a/test-suite/coq-makefile/latex1/run.sh
+++ b/test-suite/coq-makefile/latex1/run.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-#set -x
-set -e
-
 if which pdflatex; then
 
 . ../template/init.sh

--- a/test-suite/coq-makefile/merlin1/run.sh
+++ b/test-suite/coq-makefile/merlin1/run.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-#set -x
-set -e
-
 . ../template/init.sh
 
 coq_makefile -f _CoqProject -o Makefile

--- a/test-suite/coq-makefile/merlin1/run.sh
+++ b/test-suite/coq-makefile/merlin1/run.sh
@@ -3,6 +3,7 @@
 . ../template/init.sh
 
 coq_makefile -f _CoqProject -o Makefile
+cat Makefile.conf
 make .merlin
 cat > desired <<EOT
 B src

--- a/test-suite/coq-makefile/mlpack1/run.sh
+++ b/test-suite/coq-makefile/mlpack1/run.sh
@@ -3,6 +3,7 @@
 . ../template/init.sh
 
 coq_makefile -f _CoqProject -o Makefile
+cat Makefile.conf
 make
 make html mlihtml
 make install DSTROOT="$PWD/tmp"

--- a/test-suite/coq-makefile/mlpack1/run.sh
+++ b/test-suite/coq-makefile/mlpack1/run.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-#set -x
-set -e
-
 . ../template/init.sh
 
 coq_makefile -f _CoqProject -o Makefile
@@ -10,7 +7,7 @@ make
 make html mlihtml
 make install DSTROOT="$PWD/tmp"
 #make debug
-(cd `find tmp -name user-contrib`; find .) | sort > actual
+(cd `find tmp -name user-contrib` && find .) | sort > actual
 sort > desired <<EOT
 .
 ./test

--- a/test-suite/coq-makefile/mlpack2/run.sh
+++ b/test-suite/coq-makefile/mlpack2/run.sh
@@ -3,6 +3,7 @@
 . ../template/init.sh
 
 coq_makefile -f _CoqProject -o Makefile
+cat Makefile.conf
 make
 make html mlihtml
 make install DSTROOT="$PWD/tmp"

--- a/test-suite/coq-makefile/mlpack2/run.sh
+++ b/test-suite/coq-makefile/mlpack2/run.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-#set -x
-set -e
-
 . ../template/init.sh
 
 coq_makefile -f _CoqProject -o Makefile
@@ -10,7 +7,7 @@ make
 make html mlihtml
 make install DSTROOT="$PWD/tmp"
 #make debug
-(cd `find tmp -name user-contrib`; find .) | sort > actual
+(cd `find tmp -name user-contrib` && find .) | sort > actual
 sort > desired <<EOT
 .
 ./test

--- a/test-suite/coq-makefile/multiroot/run.sh
+++ b/test-suite/coq-makefile/multiroot/run.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-#set -x
-set -e
-
 . ../template/init.sh
 
 cp -r theories theories2
@@ -13,7 +10,7 @@ make html mlihtml
 make install DSTROOT="$PWD/tmp"
 make install-doc DSTROOT="$PWD/tmp"
 #make debug
-(for d in `find tmp -name user-contrib`; do pushd $d >/dev/null; find .; popd >/dev/null; done) | sort -u > actual
+(for d in `find tmp -name user-contrib` ; do pushd $d >/dev/null && find . && popd >/dev/null; done) | sort -u > actual
 sort > desired <<EOT
 .
 ./test

--- a/test-suite/coq-makefile/multiroot/run.sh
+++ b/test-suite/coq-makefile/multiroot/run.sh
@@ -5,6 +5,7 @@
 cp -r theories theories2
 mv src/test_plugin.mlpack src/test_plugin.mllib
 coq_makefile -f _CoqProject -o Makefile
+cat Makefile.conf
 make
 make html mlihtml
 make install DSTROOT="$PWD/tmp"

--- a/test-suite/coq-makefile/native1/run.sh
+++ b/test-suite/coq-makefile/native1/run.sh
@@ -6,6 +6,7 @@ if [[ `which ocamlopt` && $NATIVECOMP ]]; then
 . ../template/init.sh
 	
 coq_makefile -f _CoqProject -o Makefile
+cat Makefile.conf
 make
 make html mlihtml
 make install DSTROOT="$PWD/tmp"

--- a/test-suite/coq-makefile/native1/run.sh
+++ b/test-suite/coq-makefile/native1/run.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-#set -x
-set -e
-
 NATIVECOMP=`grep "let no_native_compiler = false" ../../../config/coq_config.ml`||true
 if [[ `which ocamlopt` && $NATIVECOMP ]]; then
 
@@ -13,7 +10,7 @@ make
 make html mlihtml
 make install DSTROOT="$PWD/tmp"
 #make debug
-(cd `find tmp -name user-contrib`; find .) | sort > actual
+(cd `find tmp -name user-contrib` && find .) | sort > actual
 sort > desired <<EOT
 .
 ./test

--- a/test-suite/coq-makefile/only/run.sh
+++ b/test-suite/coq-makefile/only/run.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-#set -x
-set -e
-
 . ../template/init.sh
 
 coq_makefile -f _CoqProject -o Makefile

--- a/test-suite/coq-makefile/only/run.sh
+++ b/test-suite/coq-makefile/only/run.sh
@@ -3,6 +3,7 @@
 . ../template/init.sh
 
 coq_makefile -f _CoqProject -o Makefile
+cat Makefile.conf
 make only TGTS="src/test.cmi src/test_aux.cmi" -j2
 test -f src/test.cmi
 test -f src/test_aux.cmi

--- a/test-suite/coq-makefile/plugin-reach-outside-API-and-fail/run.sh
+++ b/test-suite/coq-makefile/plugin-reach-outside-API-and-fail/run.sh
@@ -27,6 +27,7 @@ let _ = Pre_env.empty_env
 EOT
 
 ${COQBIN}coq_makefile -f _CoqProject -o Makefile
+cat Makefile.conf
 
 if make VERBOSE=1; then
   # make command should have failed (but didn't)

--- a/test-suite/coq-makefile/plugin-reach-outside-API-and-succeed-by-bypassing-the-API/run.sh
+++ b/test-suite/coq-makefile/plugin-reach-outside-API-and-succeed-by-bypassing-the-API/run.sh
@@ -28,5 +28,6 @@ let _ = Pre_env.empty_env
 EOT
 
 ${COQBIN}coq_makefile -f _CoqProject -o Makefile
+cat Makefile.conf
 
 make VERBOSE=1

--- a/test-suite/coq-makefile/plugin1/run.sh
+++ b/test-suite/coq-makefile/plugin1/run.sh
@@ -4,6 +4,7 @@
 
 mv src/test_plugin.mlpack src/test_plugin.mllib
 coq_makefile -f _CoqProject -o Makefile
+cat Makefile.conf
 make
 make html mlihtml
 make install DSTROOT="$PWD/tmp"

--- a/test-suite/coq-makefile/plugin1/run.sh
+++ b/test-suite/coq-makefile/plugin1/run.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-#set -x
-set -e
-
 . ../template/init.sh
 
 mv src/test_plugin.mlpack src/test_plugin.mllib
@@ -11,7 +8,7 @@ make
 make html mlihtml
 make install DSTROOT="$PWD/tmp"
 #make debug
-(cd `find tmp -name user-contrib`; find .) | sort > actual
+(cd `find tmp -name user-contrib` && find .) | sort > actual
 sort > desired <<EOT
 .
 ./test

--- a/test-suite/coq-makefile/plugin2/run.sh
+++ b/test-suite/coq-makefile/plugin2/run.sh
@@ -4,6 +4,7 @@
 
 mv src/test_plugin.mlpack src/test_plugin.mllib
 coq_makefile -f _CoqProject -o Makefile
+cat Makefile.conf
 make
 make html mlihtml
 make install DSTROOT="$PWD/tmp"

--- a/test-suite/coq-makefile/plugin2/run.sh
+++ b/test-suite/coq-makefile/plugin2/run.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-#set -x
-set -e
-
 . ../template/init.sh
 
 mv src/test_plugin.mlpack src/test_plugin.mllib
@@ -11,7 +8,7 @@ make
 make html mlihtml
 make install DSTROOT="$PWD/tmp"
 #make debug
-(cd `find tmp -name user-contrib`; find .) | sort > actual
+(cd `find tmp -name user-contrib` && find .) | sort > actual
 sort > desired <<EOT
 .
 ./test

--- a/test-suite/coq-makefile/plugin3/run.sh
+++ b/test-suite/coq-makefile/plugin3/run.sh
@@ -4,6 +4,7 @@
 
 mv src/test_plugin.mlpack src/test_plugin.mllib
 coq_makefile -f _CoqProject -o Makefile
+cat Makefile.conf
 make
 make html mlihtml
 make install DSTROOT="$PWD/tmp"

--- a/test-suite/coq-makefile/plugin3/run.sh
+++ b/test-suite/coq-makefile/plugin3/run.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-#set -x
-set -e
-
 . ../template/init.sh
 
 mv src/test_plugin.mlpack src/test_plugin.mllib
@@ -11,7 +8,7 @@ make
 make html mlihtml
 make install DSTROOT="$PWD/tmp"
 #make debug
-(cd `find tmp -name user-contrib`; find .) | sort > actual
+(cd `find tmp -name user-contrib` && find .) | sort > actual
 sort > desired <<EOT
 .
 ./test

--- a/test-suite/coq-makefile/template/init.sh
+++ b/test-suite/coq-makefile/template/init.sh
@@ -1,3 +1,5 @@
+set -e
+set -o pipefail
 
 export PATH=$COQBIN:$PATH
 

--- a/test-suite/coq-makefile/uninstall1/run.sh
+++ b/test-suite/coq-makefile/uninstall1/run.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-#set -x
-set -e
-
 . ../template/init.sh
 
 coq_makefile -f _CoqProject -o Makefile
@@ -13,7 +10,7 @@ make install-doc DSTROOT="$PWD/tmp"
 make uninstall DSTROOT="$PWD/tmp"
 make uninstall-doc DSTROOT="$PWD/tmp"
 #make debug
-(for d in `find tmp -name user-contrib`; do pushd $d >/dev/null; find .; popd >/dev/null; done) | sort -u > actual
+(for d in `find tmp -name user-contrib` ; do pushd $d >/dev/null && find . && popd >/dev/null; done) | sort -u > actual
 sort -u > desired <<EOT
 .
 EOT

--- a/test-suite/coq-makefile/uninstall1/run.sh
+++ b/test-suite/coq-makefile/uninstall1/run.sh
@@ -3,6 +3,7 @@
 . ../template/init.sh
 
 coq_makefile -f _CoqProject -o Makefile
+cat Makefile.conf
 make
 make html mlihtml
 make install DSTROOT="$PWD/tmp"

--- a/test-suite/coq-makefile/uninstall2/run.sh
+++ b/test-suite/coq-makefile/uninstall2/run.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-#set -x
-set -e
-
 . ../template/init.sh
 
 coq_makefile -f _CoqProject -o Makefile
@@ -13,7 +10,7 @@ make install-doc DSTROOT="$PWD/tmp"
 make uninstall DSTROOT="$PWD/tmp"
 make uninstall-doc DSTROOT="$PWD/tmp"
 #make debug
-(for d in `find tmp -name user-contrib`; do pushd $d >/dev/null; find .; popd >/dev/null; done) | sort -u > actual
+(for d in `find tmp -name user-contrib` ; do pushd $d >/dev/null && find . && popd >/dev/null; done) | sort -u > actual
 sort -u > desired <<EOT
 .
 EOT

--- a/test-suite/coq-makefile/uninstall2/run.sh
+++ b/test-suite/coq-makefile/uninstall2/run.sh
@@ -3,6 +3,7 @@
 . ../template/init.sh
 
 coq_makefile -f _CoqProject -o Makefile
+cat Makefile.conf
 make
 make html mlihtml
 make install DSTROOT="$PWD/tmp"

--- a/test-suite/coq-makefile/validate1/run.sh
+++ b/test-suite/coq-makefile/validate1/run.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-#set -x
-set -e
-
 . ../template/init.sh
 
 coq_makefile -f _CoqProject -o Makefile

--- a/test-suite/coq-makefile/validate1/run.sh
+++ b/test-suite/coq-makefile/validate1/run.sh
@@ -3,5 +3,6 @@
 . ../template/init.sh
 
 coq_makefile -f _CoqProject -o Makefile
+cat Makefile.conf
 make
 exec make validate

--- a/test-suite/misc/deps-order.sh
+++ b/test-suite/misc/deps-order.sh
@@ -4,7 +4,7 @@
 rm -f misc/deps/lib/*.vo misc/deps/client/*.vo
 tmpoutput=`mktemp /tmp/coqcheck.XXXXXX`
 $coqdep -R misc/deps/lib lib -R misc/deps/client client misc/deps/client/bar.v 2>&1 | head -n 1 > $tmpoutput
-diff -u misc/deps/deps.out $tmpoutput 2>&1
+diff -u --strip-trailing-cr misc/deps/deps.out $tmpoutput 2>&1
 R=$?
 times
 $coqc -R misc/deps/lib lib misc/deps/lib/foo.v 2>&1

--- a/test-suite/success/Hints.v
+++ b/test-suite/success/Hints.v
@@ -37,7 +37,6 @@ Hint Resolve predf | 0 : predconv.
 
 Goal exists n, pred n.
   eexists.
-  Fail Timeout 1 typeclasses eauto with pred.
   Set Typeclasses Filtered Unification.
   Set Typeclasses Debug Verbosity 2.
   (* predf is not tried as it doesn't match the goal *)
@@ -80,8 +79,6 @@ Qed.
 (** The other way around: goal contains redexes instead of instances *)
 Goal exists n, pred (0 + n).
   eexists.
-  (* predf is applied indefinitely *)
-  Fail Timeout 1 typeclasses eauto with pred.
   (* pred0 (pred _) matches the goal *)
   typeclasses eauto with predconv.
 Qed.
@@ -169,8 +166,6 @@ Instance foo f :
   E (id ∘ id ∘ id ∘ id ∘ id ∘ id ∘ id ∘ id ∘ id ∘ id ∘ id ∘ id ∘ id ∘ id ∘ id ∘
      id ∘ id ∘ id ∘ id ∘ id ∘ f ∘ id ∘ id ∘ id ∘ id ∘ id ∘ id ∘ id).
 Proof.
-  Fail Timeout 1 apply _. (* 3.7s *)
-  
 Hint Cut [_* (a_is_b | b_is_c | c_is_d | d_is_e)
                  (a_compose | b_compose | c_compose | d_compose | e_compose)] : typeclass_instances.
 

--- a/tools/CoqMakefile.in
+++ b/tools/CoqMakefile.in
@@ -87,6 +87,9 @@ COQDEP   ?= "$(COQBIN)coqdep"
 GALLINA  ?= "$(COQBIN)gallina"
 COQDOC   ?= "$(COQBIN)coqdoc"
 COQMKTOP ?= "$(COQBIN)coqmktop"
+COQMKFILE ?= "$(COQBIN)coq_makefile"
+
+# Timing scripts
 COQMAKE_ONE_TIME_FILE ?= "$(COQLIB)/tools/make-one-time-file.py"
 COQMAKE_BOTH_TIME_FILES ?= "$(COQLIB)/tools/make-both-time-files.py"
 COQMAKE_BOTH_SINGLE_TIMING_FILES ?= "$(COQLIB)/tools/make-both-single-timing-files.py"
@@ -437,12 +440,12 @@ beautify: $(BEAUTYFILES)
 
 install: install-extra
 	$(HIDE)for f in $(FILESTOINSTALL); do\
-	 df="`$(COQMF_MAKEFILE) -destination-of "$$f" $(COQLIBS)`";\
-	 if [ -z "$$df" ]; then\
+	 df="`$(COQMKFILE) -destination-of "$$f" $(COQLIBS)`";\
+	 if [ "$$?" != "0" -o -z "$$df" ]; then\
 	   echo SKIP "$$f" since it has no logical path;\
 	 else\
-	   install -d "$(DESTDIR)$(COQLIBINSTALL)/$$df"; \
-	   install -m 0644 "$$f" "$(DESTDIR)$(COQLIBINSTALL)/$$df"; \
+	   install -d "$(DESTDIR)$(COQLIBINSTALL)/$$df" &&\
+	   install -m 0644 "$$f" "$(DESTDIR)$(COQLIBINSTALL)/$$df" &&\
 	   echo INSTALL "$$f" "$(DESTDIR)$(COQLIBINSTALL)/$$df";\
 	 fi;\
 	done
@@ -452,12 +455,12 @@ install-extra::
 
 install-byte:
 	$(HIDE)for f in $(BYTEFILESTOINSTALL); do\
-	 df="`$(COQMF_MAKEFILE) -destination-of "$$f" $(COQLIBS)`";\
-	 if [ -z "$$df" ]; then\
+	 df="`$(COQMKFILE) -destination-of "$$f" $(COQLIBS)`";\
+	 if [ "$$?" != "0" -o -z "$$df" ]; then\
 	   echo SKIP "$$f" since it has no logical path;\
 	 else\
-	   install -d "$(DESTDIR)$(COQLIBINSTALL)/$$df"; \
-	   install -m 0644 "$$f" "$(DESTDIR)$(COQLIBINSTALL)/$$df"; \
+	   install -d "$(DESTDIR)$(COQLIBINSTALL)/$$df" &&\
+	   install -m 0644 "$$f" "$(DESTDIR)$(COQLIBINSTALL)/$$df" &&\
 	   echo INSTALL "$$f" "$(DESTDIR)$(COQLIBINSTALL)/$$df";\
 	 fi;\
 	done
@@ -482,11 +485,11 @@ install-doc:: html mlihtml
 uninstall::
 	@# Extension point
 	$(HIDE)for f in $(FILESTOINSTALL); do \
-	 df="`$(COQMF_MAKEFILE) -destination-of "$$f" $(COQLIBS)`";\
-	 instf="$(DESTDIR)$(COQLIBINSTALL)/$$df/`basename $$f`"; \
-	 rm -f "$$instf";\
-	 echo RM "$$instf"; \
-	 rmdir "$(DESTDIR)$(COQLIBINSTALL)/$$df/" || true; \
+	 df="`$(COQMKFILE) -destination-of "$$f" $(COQLIBS)`" &&\
+	 instf="$(DESTDIR)$(COQLIBINSTALL)/$$df/`basename $$f`" &&\
+	 rm -f "$$instf" &&\
+	 echo RM "$$instf" &&\
+	 (rmdir "$(DESTDIR)$(COQLIBINSTALL)/$$df/" || true); \
 	done
 .PHONY: uninstall
 

--- a/tools/CoqMakefile.in
+++ b/tools/CoqMakefile.in
@@ -184,10 +184,6 @@ endif
 
 PP:=-pp '$(CAMLP4O) -I $(CAMLLIB) -I "$(COQLIB)/grammar" compat5.cmo $(CAMLP4EXTEND) $(GRAMMARS) $(CAMLP4OPTIONS) -impl'
 
-COQLIBINSTALL = $(COQLIB)user-contrib
-COQDOCINSTALL = $(DOCDIR)user-contrib
-COQTOPINSTALL = $(COQLIB)toploop
-
 ifneq (,$(TIMING))
 TIMING_ARG=-time
 ifeq (after,$(TIMING))
@@ -207,6 +203,12 @@ endif
 ifneq "$(DSTROOT)" ""
 DESTDIR := $(DSTROOT)
 endif
+
+concat_path = $(if $(1),$(1)/$(subst $(COQMF_WINDRIVE),/,$(2)),$(2))
+
+COQLIBINSTALL = $(call concat_path,$(DESTDIR),$(COQLIB)user-contrib)
+COQDOCINSTALL = $(call concat_path,$(DESTDIR),$(DOCDIR)user-contrib)
+COQTOPINSTALL = $(call concat_path,$(DESTDIR),$(COQLIB)toploop)
 
 # Files #######################################################################
 #
@@ -444,9 +446,9 @@ install: install-extra
 	 if [ "$$?" != "0" -o -z "$$df" ]; then\
 	   echo SKIP "$$f" since it has no logical path;\
 	 else\
-	   install -d "$(DESTDIR)$(COQLIBINSTALL)/$$df" &&\
-	   install -m 0644 "$$f" "$(DESTDIR)$(COQLIBINSTALL)/$$df" &&\
-	   echo INSTALL "$$f" "$(DESTDIR)$(COQLIBINSTALL)/$$df";\
+	   install -d "$(COQLIBINSTALL)/$$df" &&\
+	   install -m 0644 "$$f" "$(COQLIBINSTALL)/$$df" &&\
+	   echo INSTALL "$$f" "$(COQLIBINSTALL)/$$df";\
 	 fi;\
 	done
 install-extra::
@@ -459,24 +461,24 @@ install-byte:
 	 if [ "$$?" != "0" -o -z "$$df" ]; then\
 	   echo SKIP "$$f" since it has no logical path;\
 	 else\
-	   install -d "$(DESTDIR)$(COQLIBINSTALL)/$$df" &&\
-	   install -m 0644 "$$f" "$(DESTDIR)$(COQLIBINSTALL)/$$df" &&\
-	   echo INSTALL "$$f" "$(DESTDIR)$(COQLIBINSTALL)/$$df";\
+	   install -d "$(COQLIBINSTALL)/$$df" &&\
+	   install -m 0644 "$$f" "$(COQLIBINSTALL)/$$df" &&\
+	   echo INSTALL "$$f" "$(COQLIBINSTALL)/$$df";\
 	 fi;\
 	done
 
 install-doc:: html mlihtml
 	@# Extension point
-	$(HIDE)install -d "$(DESTDIR)$(COQDOCINSTALL)/$(INSTALLCOQDOCROOT)/html"
+	$(HIDE)install -d "$(COQDOCINSTALL)/$(INSTALLCOQDOCROOT)/html"
 	$(HIDE)for i in html/*; do \
-	 dest="$(DESTDIR)$(COQDOCINSTALL)/$(INSTALLCOQDOCROOT)/$$i";\
+	 dest="$(COQDOCINSTALL)/$(INSTALLCOQDOCROOT)/$$i";\
 	 install -m 0644 "$$i" "$$dest";\
 	 echo INSTALL "$$i" "$$dest";\
 	done
 	$(HIDE)install -d \
-		"$(DESTDIR)$(COQDOCINSTALL)/$(INSTALLCOQDOCROOT)/mlihtml"
+		"$(COQDOCINSTALL)/$(INSTALLCOQDOCROOT)/mlihtml"
 	$(HIDE)for i in mlihtml/*; do \
-	 dest="$(DESTDIR)$(COQDOCINSTALL)/$(INSTALLCOQDOCROOT)/$$i";\
+	 dest="$(COQDOCINSTALL)/$(INSTALLCOQDOCROOT)/$$i";\
 	 install -m 0644 "$$i" "$$dest";\
 	 echo INSTALL "$$i" "$$dest";\
 	done
@@ -486,20 +488,20 @@ uninstall::
 	@# Extension point
 	$(HIDE)for f in $(FILESTOINSTALL); do \
 	 df="`$(COQMKFILE) -destination-of "$$f" $(COQLIBS)`" &&\
-	 instf="$(DESTDIR)$(COQLIBINSTALL)/$$df/`basename $$f`" &&\
+	 instf="$(COQLIBINSTALL)/$$df/`basename $$f`" &&\
 	 rm -f "$$instf" &&\
 	 echo RM "$$instf" &&\
-	 (rmdir "$(DESTDIR)$(COQLIBINSTALL)/$$df/" || true); \
+	 (rmdir "$(call concat_path,,$(COQLIBINSTALL)/$$df/)" || true); \
 	done
 .PHONY: uninstall
 
 uninstall-doc::
 	@# Extension point
-	$(SHOW)'RM $(DESTDIR)$(COQDOCINSTALL)/$(INSTALLCOQDOCROOT)/html'
-	$(HIDE)rm -rf "$(DESTDIR)$(COQDOCINSTALL)/$(INSTALLCOQDOCROOT)/html"
-	$(SHOW)'RM $(DESTDIR)$(COQDOCINSTALL)/$(INSTALLCOQDOCROOT)/mlihtml'
-	$(HIDE)rm -rf "$(DESTDIR)$(COQDOCINSTALL)/$(INSTALLCOQDOCROOT)/mlihtml"
-	$(HIDE) rmdir "$(DESTDIR)$(COQDOCINSTALL)/$(INSTALLCOQDOCROOT)/" || true
+	$(SHOW)'RM $(COQDOCINSTALL)/$(INSTALLCOQDOCROOT)/html'
+	$(HIDE)rm -rf "$(COQDOCINSTALL)/$(INSTALLCOQDOCROOT)/html"
+	$(SHOW)'RM $(COQDOCINSTALL)/$(INSTALLCOQDOCROOT)/mlihtml'
+	$(HIDE)rm -rf "$(COQDOCINSTALL)/$(INSTALLCOQDOCROOT)/mlihtml"
+	$(HIDE) rmdir "$(COQDOCINSTALL)/$(INSTALLCOQDOCROOT)/" || true
 .PHONY: uninstall-doc
 
 # Cleaning ####################################################################

--- a/tools/coq_makefile.ml
+++ b/tools/coq_makefile.ml
@@ -118,7 +118,7 @@ let makefile_template =
   let template = "/tools/CoqMakefile.in" in
   Coq_config.coqlib ^ template
 
-let quote s = if String.contains s ' ' then "\"" ^ s ^ "\"" else s
+let quote s = if String.contains s ' ' then "'" ^ s ^ "'" else s
 
 let generate_makefile oc conf_file local_file args project =
   let s = read_whole_file makefile_template in

--- a/tools/coq_makefile.ml
+++ b/tools/coq_makefile.ml
@@ -193,12 +193,19 @@ let generate_conf_includes oc { ml_includes; r_includes; q_includes } =
     (S.concat " " (map (fun ({ path },l) -> dash2 "R" path l) r_includes))
 ;;
 
+let windrive s =
+  if Coq_config.arch_is_win32 && Str.(string_match (regexp "^[a-zA-Z]:") s 0)
+  then Str.matched_string s
+  else s
+;;
+
 let generate_conf_coq_config oc args bypass_API =
   section oc "Coq configuration.";
   let src_dirs = if bypass_API
                  then Coq_config.all_src_dirs
                  else Coq_config.api_dirs @ Coq_config.plugins_dirs @ ["-open API"] in
   Envars.print_config ~prefix_var_name:"COQMF_" oc src_dirs;
+  fprintf oc "COQMF_WINDRIVE=%s\n" (windrive Coq_config.coqlib)
 ;;
 
 let generate_conf_files oc

--- a/tools/coq_makefile.ml
+++ b/tools/coq_makefile.ml
@@ -199,7 +199,6 @@ let generate_conf_coq_config oc args bypass_API =
                  then Coq_config.all_src_dirs
                  else Coq_config.api_dirs @ Coq_config.plugins_dirs @ ["-open API"] in
   Envars.print_config ~prefix_var_name:"COQMF_" oc src_dirs;
-  fprintf oc "COQMF_MAKEFILE=%s\n" (quote (List.hd args)); 
 ;;
 
 let generate_conf_files oc

--- a/tools/fake_ide.ml
+++ b/tools/fake_ide.ml
@@ -298,7 +298,8 @@ let main =
        (fun _ -> prerr_endline "Broken Pipe (coqtop died ?)"; exit 1));
   let def_args = ["--xml_format=Ppcmds"; "-ideslave"] in
   let coqtop_name, coqtop_args, input_file = match Sys.argv with
-    | [| _; f |] -> "coqtop", Array.of_list def_args, f
+    | [| _; f |] -> (if Sys.os_type = "Unix" then "coqtop" else "coqtop.exe"),
+                    Array.of_list def_args, f
     | [| _; f; ct |] ->
         let ct = Str.split (Str.regexp " ") ct in
         List.hd ct, Array.of_list (def_args @ List.tl ct), f

--- a/tools/fake_ide.ml
+++ b/tools/fake_ide.ml
@@ -297,12 +297,24 @@ let main =
     (Sys.Signal_handle
        (fun _ -> prerr_endline "Broken Pipe (coqtop died ?)"; exit 1));
   let def_args = ["--xml_format=Ppcmds"; "-ideslave"] in
-  let coqtop_name, coqtop_args, input_file = match Sys.argv with
-    | [| _; f |] -> (if Sys.os_type = "Unix" then "coqtop" else "coqtop.exe"),
-                    Array.of_list def_args, f
+  let coqtop_name = (* from ide/ideutils.ml *)
+    let prog_name = "fake_ide" in
+    let len_prog_name = String.length prog_name in
+    let fake_ide_path = Sys.executable_name in
+    let fake_ide_path_len = String.length fake_ide_path in
+    let pos = fake_ide_path_len - len_prog_name in
+    let rex = Str.regexp_string prog_name in
+    try
+      let i = Str.search_backward rex fake_ide_path pos in
+      String.sub fake_ide_path 0 i ^ "coqtop" ^
+      String.sub fake_ide_path (i + len_prog_name)
+        (fake_ide_path_len - i - len_prog_name) 
+    with Not_found -> assert false in
+  let coqtop_args, input_file = match Sys.argv with
+    | [| _; f |] -> Array.of_list def_args, f
     | [| _; f; ct |] ->
         let ct = Str.split (Str.regexp " ") ct in
-        List.hd ct, Array.of_list (def_args @ List.tl ct), f
+        Array.of_list (def_args @ ct), f
     | _ -> usage () in
   let inc = if input_file = "-" then stdin else open_in input_file in
   let coq =

--- a/tools/fake_ide.ml
+++ b/tools/fake_ide.ml
@@ -293,7 +293,7 @@ let usage () =
 module Coqide = Spawn.Sync(struct end)
 
 let main =
-  Sys.set_signal Sys.sigpipe
+  if Sys.os_type = "Unix" then Sys.set_signal Sys.sigpipe
     (Sys.Signal_handle
        (fun _ -> prerr_endline "Broken Pipe (coqtop died ?)"; exit 1));
   let def_args = ["--xml_format=Ppcmds"; "-ideslave"] in


### PR DESCRIPTION
The PR includes a bunch of commit (by maxime, to be squashed) to add support for windows CI (appveyor) and to fix the test suite (mostly by me).

There is still 1 test failing (misc/deps/deps.out) where I think there i a `\r\n` versus `\n` issue.

  https://ci.appveyor.com/project/gares/coq