### PR TITLE
Add build_coq_or to API.Coqlib

### DIFF
--- a/API/API.mli
+++ b/API/API.mli
@@ -2107,6 +2107,7 @@ sig
   val coq_not_ref : Globnames.global_reference lazy_t
   val coq_or_ref : Globnames.global_reference lazy_t
   val build_coq_and : Globnames.global_reference Util.delayed
+  val build_coq_or : Globnames.global_reference Util.delayed
   val build_coq_I : Globnames.global_reference Util.delayed
   val coq_reference : string -> string list -> string -> Globnames.global_reference
 end


### PR DESCRIPTION
Module `Coqlib` as exported via `API` provides the logical constants `build_coq_False`, `build_coq_True`, `build_coq_and`, `build_coq_not` but not `build_coq_or`.

I created this PR with the intention that someone takes a look which constants Coqlib is intended to provide. I think `build_coq_or` is a logical addition, but there might be other candidates (`build_coq_ex`, etc).

For reference, it is my understanding from reading the sources of the `FunInd` plugin that `or` (or for that matter, any constant from Init) can be obtained via 
```
let coq_init_constant s =
  Universes.constr_of_global @@
    Coqlib.gen_reference_in_modules "YourPluginNameHere" Coqlib.init_modules s

let coq_or = coq_init_constant "or"
```