### PR TITLE
Backport fix to bug 5641 in v8.7

### DIFF
--- a/kernel/term_typing.ml
+++ b/kernel/term_typing.ml
@@ -466,7 +466,7 @@ let constant_entry_of_side_effect cb u =
     match cb.const_universes with
     | Monomorphic_const ctx -> false, ctx
     | Polymorphic_const auctx -> 
-      true, Univ.instantiate_univ_context auctx
+      true, Univ.AUContext.repr auctx
   in
   let pt =
     match cb.const_body, u with

--- a/kernel/univ.ml
+++ b/kernel/univ.ml
@@ -1031,7 +1031,14 @@ end
 type universe_context = UContext.t
 let hcons_universe_context = UContext.hcons
 
-module AUContext = UContext
+module AUContext =
+struct
+  include UContext
+
+  let repr (inst, cst) =
+    (Array.mapi (fun i l -> Level.var i) inst, cst)
+
+end
 
 type abstract_universe_context = AUContext.t
 let hcons_abstract_universe_context = AUContext.hcons

--- a/kernel/univ.mli
+++ b/kernel/univ.mli
@@ -328,6 +328,8 @@ sig
   (** Keeps the order of the instances *)
   val union : t -> t -> t
 
+  val repr : t -> UContext.t
+
 end
 
 type abstract_universe_context = AUContext.t

--- a/test-suite/bugs/closed/5641.v
+++ b/test-suite/bugs/closed/5641.v
@@ -1,0 +1,6 @@
+Set Universe Polymorphism.
+
+Definition foo@{i j} (A : Type@{i}) : Type@{j}.
+Proof.
+abstract (exact ltac:(abstract (exact A))).
+Defined.


### PR DESCRIPTION
This PR cherry-picks commit c401fc9 from #870 which fixed https://coq.inria.fr/bug/5641.
I'm creating this PR mostly to have a record that this bug was fixed in 8.7.

@ppedrot Next time you identify what can be considered as an independent bug fix, please make a separate PR for it. That will ease the process.