### PR TITLE
Add [opam update] and online repository to gitlab CI script.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,6 +40,11 @@ before_script:
   - if [ ! "(" -d .opamcache ")" ]; then mv ~/.opam .opamcache; else mv ~/.opam ~/.opam-old; fi
   - ln -s $(readlink -f .opamcache) ~/.opam
 
+  # the default repo in this docker image is a local directory
+  # at the time of 4aaeb8abf it lagged behind the official
+  # repository such that camlp5 7.01 was not available
+  - opam repository set-url default https://opam.ocaml.org
+  - opam update
   - opam switch ${COMPILER}
   - eval $(opam config env)
   - opam config list


### PR DESCRIPTION
This allows it to find out about new packages / compilers without
having to invalidate cache somehow.
Additionally the latest camlp5 (7.01) is not in the local repository
for some reason.