### PR TITLE
Less allocations in Detyping

### DIFF
--- a/engine/termops.ml
+++ b/engine/termops.ml
@@ -994,12 +994,14 @@ let rec strip_outer_cast sigma c = match EConstr.kind sigma c with
 (* flattens application lists throwing casts in-between *)
 let collapse_appl sigma c = match EConstr.kind sigma c with
   | App (f,cl) ->
+    if EConstr.isCast sigma f then
       let rec collapse_rec f cl2 =
         match EConstr.kind sigma (strip_outer_cast sigma f) with
         | App (g,cl1) -> collapse_rec g (Array.append cl1 cl2)
         | _ -> EConstr.mkApp (f,cl2)
       in
       collapse_rec f cl
+    else c
   | _ -> c
 
 (* First utilities for avoiding telescope computation for subst_term *)

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -475,8 +475,8 @@ let rec detype flags avoid env sigma t = CAst.make @@
  	  GApp (f',args''@args')
  	| _ -> GApp (f',args')
       in
-	mkapp (detype flags avoid env sigma f)
-	  (Array.map_to_list (detype flags avoid env sigma) args)
+      mkapp (detype flags avoid env sigma f)
+        (detype_array flags avoid env sigma args)
     | Const (sp,u) -> GRef (ConstRef sp, detype_instance sigma u)
     | Proj (p,c) ->
       let noparams () = 
@@ -693,6 +693,13 @@ and detype_binder (lax,isgoal as flags) bk avoid env sigma na body ty c =
       let s = try Retyping.get_sort_family_of (snd env) sigma ty with _ when !Flags.in_debugger || !Flags.in_toplevel -> InType (* Can fail because of sigma missing in debugger *) in
       let t = if s != InProp  && not !Flags.raw_print then None else Some (detype (lax,false) avoid env sigma ty) in
       GLetIn (na', c, t, r)
+
+and detype_array flags avoid env sigma args =
+  let ans = ref [] in
+  for i = Array.length args - 1 downto 0 do
+    ans := detype flags avoid env sigma args.(i) :: !ans;
+  done;
+  !ans
 
 let detype_rel_context ?(lax=false) where avoid env sigma sign =
   let where = Option.map (fun c -> EConstr.it_mkLambda_or_LetIn c sign) where in

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -694,6 +694,8 @@ and detype_binder (lax,isgoal as flags) bk avoid env sigma na body ty c =
       let t = if s != InProp  && not !Flags.raw_print then None else Some (detype (lax,false) avoid env sigma ty) in
       GLetIn (na', c, t, r)
 
+(** We use a dedicated function here to prevent overallocation from
+    Array.map_to_list. *)
 and detype_array flags avoid env sigma args =
   let ans = ref [] in
   for i = Array.length args - 1 downto 0 do


### PR DESCRIPTION
This PR mitigates [BZ#5561](https://coq.inria.fr/bugs/show_bug.cgi?id=5661).

The detyper was indeed allocating twice as much memory as needed for application nodes, and it was also reallocating because of a dubious, most-of-the-time identity transformation. The provided example stills dies with a OOM, but it should do so less quickly, and we've probably reaped a few more printable big terms.

The underlying issue is still there though. To solve it, we would need to perform detyping and externalization at once, allowing not to generate glob_terms that won't ever be displayed to the user.