### PR TITLE
Moving --print-version to -print-version for consistency.

### DIFF
--- a/tools/coqc.ml
+++ b/tools/coqc.ml
@@ -86,7 +86,7 @@ let parse_args () =
         Envars.print_config stdout Coq_config.all_src_dirs;
         exit 0
       
-    |"--print-version" :: _ ->
+    | ("-print-version" | "--print-version") :: _ ->
         Usage.machine_readable_version 0
 
 (* Options for coqtop : a) options with 0 argument *)

--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -584,7 +584,7 @@ let parse_args arglist =
     |"-type-in-type" -> set_type_in_type ()
     |"-unicode" -> add_require "Utf8_core"
     |"-v"|"--version" -> Usage.version (exitcode ())
-    |"--print-version" -> Usage.machine_readable_version (exitcode ())
+    |"-print-version"|"--print-version" -> Usage.machine_readable_version (exitcode ())
     |"-where" -> print_where := true
     |"-xml" -> Flags.xml_export := true
 

--- a/toplevel/usage.ml
+++ b/toplevel/usage.ml
@@ -57,7 +57,7 @@ let print_usage_channel co command =
 \n  -where                 print Coq's standard library location and exit\
 \n  -config, --config      print Coq's configuration information and exit\
 \n  -v, --version          print Coq version and exit\
-\n  --print-version        print Coq version in easy to parse format and exit\
+\n  -print-version         print Coq version in easy to parse format and exit\
 \n  -list-tags             print highlight color tags known by Coq and exit\
 \n\
 \n  -quiet                 unset display of extra information (implies -w \"-all\")\


### PR DESCRIPTION
This a "fix" to the new `--print-version` option of 8.7. It makes it a `-print-version` option for consistency with the naming convention adopted for the rest of the options.

Not that I don't like GNU's double-hyphen convention. I would be satisfied with consistently providing a `--` alternative to all long-style options to `coqtop`/`coqc`.