### PR TITLE
Remove a few useless evar-normalizations in printing code.

### DIFF
--- a/ide/ide_slave.ml
+++ b/ide/ide_slave.ml
@@ -177,11 +177,9 @@ let process_goal sigma g =
   let min_env = Environ.reset_context env in
   let id = Goal.uid g in
   let ccl =
-    let norm_constr = Reductionops.nf_evar sigma (Goal.V82.concl sigma g) in
-    pr_goal_concl_style_env env sigma norm_constr
+    pr_goal_concl_style_env env sigma (Goal.V82.concl sigma g)
   in
   let process_hyp d (env,l) =
-    let d = CompactedDecl.map_constr (fun c -> EConstr.Unsafe.to_constr (Reductionops.nf_evar sigma (EConstr.of_constr c))) d in
     let d' = CompactedDecl.to_named_context d in
       (List.fold_right Environ.push_named d' env,
        (pr_compacted_decl env sigma d) :: l) in
@@ -210,7 +208,7 @@ let evars () =
     Stm.finish ();
     let pfts = Proof_global.give_me_the_proof () in
     let { Evd.it = all_goals ; sigma = sigma } = Proof.V82.subgoals pfts in
-    let exl = Evar.Map.bindings (Evarutil.non_instantiated sigma) in
+    let exl = Evar.Map.bindings (Evd.undefined_map sigma) in
     let map_evar ev = { Interface.evar_info = string_of_ppcmds (pr_evar sigma ev); } in
     let el = List.map map_evar exl in
     Some el

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -727,7 +727,7 @@ let default_pr_subgoals ?(pr_first=true)
   match goals with
   | [] ->
       begin
-	let exl = Evarutil.non_instantiated sigma in
+	let exl = Evd.undefined_map sigma in
 	if Evar.Map.is_empty exl then
 	  (str"No more subgoals." ++ print_dependent_evars None sigma seeds)
 	else

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -1460,7 +1460,6 @@ let is_mandatory p comp evd =
 (** In case of unsatisfiable constraints, build a nice error message *)
 
 let error_unresolvable env comp evd =
-  let evd = Evarutil.nf_evar_map_undefined evd in
   let is_part ev = match comp with
   | None -> true
   | Some s -> Evar.Set.mem ev s
@@ -1474,8 +1473,7 @@ let error_unresolvable env comp evd =
     else (found, accu)
    in
   let (_, ev) = Evd.fold_undefined fold evd (true, None) in
-    Pretype_errors.unsatisfiable_constraints
-      (Evarutil.nf_env_evar evd env) evd ev comp
+  Pretype_errors.unsatisfiable_constraints env evd ev comp
 
 (** Check if an evar is concerned by the current resolution attempt,
     (and in particular is in the current component), and also update

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -783,7 +783,7 @@ let pr_constraints printenv env sigma evars cstrs =
 
 let explain_unsatisfiable_constraints env sigma constr comp =
   let (_, constraints) = Evd.extract_all_conv_pbs sigma in
-  let undef = Evd.undefined_map (Evarutil.nf_evar_map_undefined sigma) in
+  let undef = Evd.undefined_map sigma in
   (** Only keep evars that are subject to resolution and members of the given
      component. *)
   let is_kept evk evi = match comp with

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -65,7 +65,7 @@ let show_top_evars () =
   let pfts = Proof_global.give_me_the_proof () in
   let gls = Proof.V82.subgoals pfts in
   let sigma = gls.Evd.sigma in
-  Feedback.msg_notice (pr_evars_int sigma 1 (Evarutil.non_instantiated sigma))
+  Feedback.msg_notice (pr_evars_int sigma 1 (Evd.undefined_map sigma))
 
 let show_universes () =
   let pfts = Proof_global.give_me_the_proof () in


### PR DESCRIPTION
It is a nice companion to #912, as it prevents useless normalizing in CoqIDE printing path as well.