### PR TITLE
Fixing bug #5671 (tactic specialize unclean wrt Metas).

### DIFF
--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -2979,7 +2979,7 @@ let specialize (c,lbind) ipat =
           sigma,hd'
         | _ ,_ -> assert false in
       let sigma,hd = rebuild_lambdas sigma (List.rev lprod) [] c_hd tstack in
-      sigma, hd
+      Evd.clear_metas sigma, hd
   in
   let typ = Retyping.get_type_of env sigma term in
   let tac =

--- a/test-suite/bugs/closed/5671.v
+++ b/test-suite/bugs/closed/5671.v
@@ -1,0 +1,7 @@
+(* Fixing Meta-unclean specialize *)
+
+Require Import Setoid.
+Axiom a : forall x, x=0 -> True.
+Lemma lem (x y1 y2:nat) (H:x=0) (H0:eq y1 y2) : y1 = y2.
+specialize a with (1:=H). clear H x. intros _.
+setoid_rewrite H0.


### PR DESCRIPTION
Still continuing porting a 8.4 contrib (actually, @barras' set-theoretic model). I fell on a surprising bug:
```coq
Require Import Setoid.
Axiom a : forall x, x=0 -> True.
Lemma lem (x y1 y2:nat) (H:x=0) (H0:eq y1 y2) : y1 = y2.
specialize a with (1:=H). clear H x. intros _.
setoid_rewrite H0.
(* Anomaly "variable x unbound." Please report at http://coq.inria.fr/bugs/. *)
```
This is a fix for the bug, which is also reported as [5671](https://coq.inria.fr/bugs/show_bug.cgi?id=5671).