### PR TITLE
Unifall Episode I: infrastructure

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -42,6 +42,9 @@ Vernacular Commands
 - Nested proofs may be enabled through the option `Nested Proofs Allowed`.
   By default, they are disabled and produce an error. The deprecation
   warning which used to occur when using nested proofs has been removed.
+- New Set Hint Variables/Constants Opaque/Transparent commands for setting
+  globally the opacity flag of variables and constants in hint databases,
+  overwritting the opacity set of the hint database.
 
 Coq binaries and process model
 

--- a/clib/cArray.ml
+++ b/clib/cArray.ml
@@ -280,7 +280,7 @@ let fold_left2_i f a v1 v2 =
   let rec fold a n =
     if n >= lv1 then a else fold (f n a (uget v1 n) (uget v2 n)) (succ n)
   in
-  if Array.length v2 <> lv1 then invalid_arg "Array.fold_left2";
+  if Array.length v2 <> lv1 then invalid_arg "Array.fold_left2_i";
   fold a 0
 
 let fold_left3 f a v1 v2 v3 =
@@ -290,7 +290,7 @@ let fold_left3 f a v1 v2 v3 =
     else fold (f a (uget v1 n) (uget v2 n) (uget v3 n)) (succ n)
   in
   if Array.length v2 <> lv1 || Array.length v3 <> lv1 then
-    invalid_arg "Array.fold_left2";
+    invalid_arg "Array.fold_left3";
   fold a 0
 
 let fold_left4 f a v1 v2 v3 v4 =

--- a/dev/ci/user-overlays/00930-mattam82-unifall-infra.sh
+++ b/dev/ci/user-overlays/00930-mattam82-unifall-infra.sh
@@ -1,0 +1,4 @@
+if [ "$CI_PULL_REQUEST" = "930" ] || [ "$CI_BRANCH" = "unifall-infra" ]; then
+    Equations_CI_BRANCH=coqpr930
+    Equations_CI_GITURL=https://github.com/mattam82/Coq-Equations.git
+fi

--- a/doc/sphinx/proof-engine/tactics.rst
+++ b/doc/sphinx/proof-engine/tactics.rst
@@ -3435,6 +3435,13 @@ The general command to add a hint to some databases :n:`{+ @ident}` is
 
       Declares each :n:`@ident` as a transparent or opaque constant.
 
+   .. cmdv:: Hint %( Variables %| Constants %) %( Transparent %| Opaque %)}
+      :name: Hint ( Variables | Constants )
+
+      This sets the transparency flag used during unification of
+      hints in the database for all constants or all variables,
+      overwritting the existing settings of opacity.
+
    .. cmdv:: Hint Extern @num {? @pattern} => @tactic
       :name: Hint Extern
 

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -426,10 +426,6 @@ let push_rel_context_to_named_context ?hypnaming env sigma typ =
 
 let default_source = Loc.tag @@ Evar_kinds.InternalHole
 
-let restrict_evar evd evk filter ?src candidates =
-  let evd, evk' = Evd.restrict evk filter ?candidates ?src evd in
-  Evd.declare_future_goal evk' evd, evk'
-
 let new_pure_evar_full evd evi =
   let (evd, evk) = Evd.new_evar evd evi in
   let evd = Evd.declare_future_goal evk evd in
@@ -532,10 +528,32 @@ let generalize_evar_over_rels sigma (ev,args) =
 type clear_dependency_error =
 | OccurHypInSimpleClause of Id.t option
 | EvarTypingBreak of existential
+| NoCandidatesLeft of Evar.t
 
 exception ClearDependencyError of Id.t * clear_dependency_error * GlobRef.t option
 
 exception Depends of Id.t
+
+let set_of_evctx l =
+  List.fold_left (fun s decl -> Id.Set.add (NamedDecl.get_id decl) s) Id.Set.empty l
+
+let filter_effective_candidates evd evi filter candidates =
+  let ids = set_of_evctx (Filter.filter_list filter (evar_context evi)) in
+  List.filter (fun a -> Id.Set.subset (collect_vars evd a) ids) candidates
+
+let restrict_evar evd evk filter ?src candidates =
+  let evar_info = Evd.find_undefined evd evk in
+  let candidates = Option.map (filter_effective_candidates evd evar_info filter) candidates in
+  match candidates with
+  | Some [] -> raise (ClearDependencyError (*FIXME*)(Id.of_string "blah", (NoCandidatesLeft evk), None))
+  | _ ->
+     let evd, evk' = Evd.restrict evk filter ?candidates ?src evd in
+     (** Mark new evar as future goal, removing previous one,
+         circumventing Proofview.advance but making Proof.run_tactic catch these. *)
+     let future_goals = Evd.save_future_goals evd in
+     let future_goals = Evd.filter_future_goals (fun evk' -> not (Evar.equal evk evk')) future_goals in
+     let evd = Evd.restore_future_goals evd future_goals in
+     (Evd.declare_future_goal evk' evd, evk')
 
 let rec check_and_clear_in_constr env evdref err ids global c =
   (* returns a new constr where all the evars have been 'cleaned'
@@ -606,7 +624,9 @@ let rec check_and_clear_in_constr env evdref err ids global c =
               let origfilter = Evd.evar_filter evi in
               let filter = Evd.Filter.apply_subfilter origfilter filter in
               let evd = !evdref in
-              let (evd,_) = restrict_evar evd evk filter None in
+              let candidates = Evd.evar_candidates evi in
+              let candidates = Option.map (List.map EConstr.of_constr) candidates in
+              let (evd,_) = restrict_evar evd evk filter candidates in
               evdref := evd;
               Evd.existential_value0 !evdref ev
 

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -510,6 +510,21 @@ let e_new_evar env evdref ?(src=default_source) ?filter ?candidates ?store ?nami
   evdref := evd';
   ev
 
+(* Safe interface to unification problems *)
+type unification_pb = conv_pb * env * EConstr.constr * EConstr.constr
+
+let eq_unification_pb evd (pbty,env,t1,t2) (pbty',env',t1',t2') =
+  pbty == pbty' && env == env' &&
+    EConstr.eq_constr evd t1 t1' &&
+    EConstr.eq_constr evd t2 t2'
+
+let add_unification_pb ?(tail=false) pb evd =
+  let conv_pbs = Evd.conv_pbs evd in
+  if not (List.exists (eq_unification_pb evd pb) conv_pbs) then
+    let (pbty,env,t1,t2) = pb in
+    Evd.add_conv_pb ~tail (pbty,env,t1,t2) evd
+  else evd
+
 (* This assumes an evar with identity instance and generalizes it over only
    the de Bruijn part of the context *)
 let generalize_evar_over_rels sigma (ev,args) =

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -740,6 +740,13 @@ let undefined_evars_of_named_context evd nc =
     nc
     ~init:Evar.Set.empty
 
+let undefined_evars_of_econstr_named_context evd nc =
+  Context.Named.fold_outside
+    (NamedDecl.fold_constr (fun c s -> Evar.Set.union s
+      (undefined_evars_of_term evd c)))
+    nc
+    ~init:Evar.Set.empty
+
 let undefined_evars_of_evar_info evd evi =
   Evar.Set.union (undefined_evars_of_term evd evi.evar_concl)
     (Evar.Set.union

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -431,7 +431,8 @@ let new_pure_evar_full evd evi =
   let evd = Evd.declare_future_goal evk evd in
   (evd, evk)
 
-let new_pure_evar?(src=default_source) ?(filter = Filter.identity) ?candidates ?(store = Store.empty) ?naming ?(principal=false) sign evd typ =
+let new_pure_evar ?(src=default_source) ?(filter = Filter.identity)  ?(abstract_arguments = Abstraction.identity)
+    ?candidates ?(store = Store.empty) ?naming ?(principal=false) sign evd typ =
   let default_naming = IntroAnonymous in
   let naming = Option.default default_naming naming in
   let name = match naming with
@@ -447,6 +448,7 @@ let new_pure_evar?(src=default_source) ?(filter = Filter.identity) ?candidates ?
     evar_concl = typ;
     evar_body = Evar_empty;
     evar_filter = filter;
+    evar_abstract_arguments = abstract_arguments;
     evar_source = src;
     evar_candidates = candidates;
     evar_extra = store; }
@@ -458,11 +460,13 @@ let new_pure_evar?(src=default_source) ?(filter = Filter.identity) ?candidates ?
   in
   (evd, newevk)
 
-let new_evar_instance ?src ?filter ?candidates ?store ?naming ?principal sign evd typ instance =
+let new_evar_instance ?src ?filter ?abstract_arguments ?candidates ?store ?naming
+    ?principal sign evd typ instance =
   let open EConstr in
   assert (not !Flags.debug ||
             List.distinct (ids_of_named_context (named_context_of_val sign)));
-  let (evd, newevk) = new_pure_evar sign evd ?src ?filter ?candidates ?store ?naming ?principal typ in
+  let (evd, newevk) = new_pure_evar sign evd ?src ?filter ?abstract_arguments ?candidates ?store ?naming
+                                    ?principal typ in
   evd, mkEvar (newevk,Array.of_list instance)
 
 let new_evar_from_context ?src ?filter ?candidates ?store ?naming ?principal sign evd typ =
@@ -475,7 +479,7 @@ let new_evar_from_context ?src ?filter ?candidates ?store ?naming ?principal sig
 
 (* [new_evar] declares a new existential in an env env with type typ *)
 (* Converting the env into the sign of the evar to define *)
-let new_evar ?src ?filter ?candidates ?store ?naming ?principal ?hypnaming env evd typ =
+let new_evar ?src ?filter ?abstract_arguments ?candidates ?store ?naming ?principal ?hypnaming env evd typ =
   let sign,typ',instance,subst = push_rel_context_to_named_context ?hypnaming env evd typ in
   let map c = csubst_subst subst c in
   let candidates = Option.map (fun l -> List.map map l) candidates in
@@ -483,7 +487,8 @@ let new_evar ?src ?filter ?candidates ?store ?naming ?principal ?hypnaming env e
     match filter with
     | None -> instance
     | Some filter -> Filter.filter_list filter instance in
-  new_evar_instance sign evd typ' ?src ?filter ?candidates ?store ?naming ?principal instance
+  new_evar_instance sign evd typ' ?src ?filter ?abstract_arguments ?candidates ?store
+                    ?naming ?principal instance
 
 let new_type_evar ?src ?filter ?naming ?principal ?hypnaming env evd rigid =
   let (evd', s) = new_sort_variable rigid evd in

--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -65,9 +65,6 @@ val new_type_evar :
 
 val new_Type : ?rigid:rigid -> env -> evar_map -> evar_map * constr
 
-val restrict_evar : evar_map -> Evar.t -> Filter.t ->
-  ?src:Evar_kinds.t Loc.located -> constr list option -> evar_map * Evar.t
-
 (** Polymorphic constants *)
 
 val new_global : evar_map -> GlobRef.t -> evar_map * constr
@@ -224,8 +221,17 @@ raise OccurHypInSimpleClause if the removal breaks dependencies *)
 type clear_dependency_error =
 | OccurHypInSimpleClause of Id.t option
 | EvarTypingBreak of Constr.existential
+| NoCandidatesLeft of Evar.t
 
 exception ClearDependencyError of Id.t * clear_dependency_error * GlobRef.t option
+
+(** Restrict an undefined evar according to a (sub)filter and candidates.
+    The evar will be defined if there is only one candidate left,
+@raise ClearDependencyError NoCandidatesLeft if the filter turns the candidates
+  into an empty list. *)
+
+val restrict_evar : evar_map -> Evar.t -> Filter.t ->
+  ?src:Evar_kinds.t Loc.located -> constr list option -> evar_map * Evar.t
 
 val clear_hyps_in_evi : env -> evar_map -> named_context_val -> types ->
   Id.Set.t -> evar_map * named_context_val * types

--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -40,14 +40,14 @@ type naming_mode =
 
 val new_evar :
   ?src:Evar_kinds.t Loc.located -> ?filter:Filter.t ->
-  ?candidates:constr list -> ?store:Store.t ->
+  ?abstract_arguments:Abstraction.t -> ?candidates:constr list -> ?store:Store.t ->
   ?naming:intro_pattern_naming_expr ->
   ?principal:bool -> ?hypnaming:naming_mode ->
   env -> evar_map -> types -> evar_map * EConstr.t
 
 val new_pure_evar :
   ?src:Evar_kinds.t Loc.located -> ?filter:Filter.t ->
-  ?candidates:constr list -> ?store:Store.t ->
+  ?abstract_arguments:Abstraction.t -> ?candidates:constr list -> ?store:Store.t ->
   ?naming:intro_pattern_naming_expr ->
   ?principal:bool ->
   named_context_val -> evar_map -> types -> evar_map * Evar.t
@@ -76,7 +76,8 @@ val new_global : evar_map -> GlobRef.t -> evar_map * constr
    of [inst] are typed in the occurrence context and their type (seen
    as a telescope) is [sign] *)
 val new_evar_instance :
-  ?src:Evar_kinds.t Loc.located -> ?filter:Filter.t -> ?candidates:constr list ->
+  ?src:Evar_kinds.t Loc.located -> ?filter:Filter.t ->
+  ?abstract_arguments:Abstraction.t -> ?candidates:constr list ->
   ?store:Store.t -> ?naming:intro_pattern_naming_expr ->
   ?principal:bool ->
  named_context_val -> evar_map -> types ->

--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -122,6 +122,10 @@ val gather_dependent_evars : evar_map -> Evar.t list -> (Evar.Set.t option) Evar
     solved. *)
 val advance : evar_map -> Evar.t -> Evar.t option
 
+(** [reachable_from_evars sigma seeds evs] computes if one of [evs] is a descendent
+    of an evar of [seeds] by restriction or evar-evar unifications in [sigma]. *)
+val reachable_from_evars : evar_map -> Evar.Set.t -> Evar.Set.t -> bool
+
 (** The following functions return the set of undefined evars
     contained in the object, the defined evars being traversed.
     This is roughly a combination of the previous functions and
@@ -240,6 +244,10 @@ exception ClearDependencyError of Id.t * clear_dependency_error * GlobRef.t opti
 
 val restrict_evar : evar_map -> Evar.t -> Filter.t ->
   ?src:Evar_kinds.t Loc.located -> constr list option -> evar_map * Evar.t
+
+(** Marks an evar that has been defined by another evar by projection.
+    Used to handle checking of created goals correctly. *)
+val evar_evar_solution : bool Store.field
 
 val clear_hyps_in_evi : env -> evar_map -> named_context_val -> types ->
   Id.Set.t -> evar_map * named_context_val * types

--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -132,6 +132,7 @@ val advance : evar_map -> Evar.t -> Evar.t option
 
 val undefined_evars_of_term : evar_map -> constr -> Evar.Set.t
 val undefined_evars_of_named_context : evar_map -> Context.Named.t -> Evar.Set.t
+val undefined_evars_of_econstr_named_context : evar_map -> EConstr.named_context -> Evar.Set.t
 val undefined_evars_of_evar_info : evar_map -> evar_info -> Evar.Set.t
 
 type undefined_evars_cache

--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -215,6 +215,14 @@ val compare_cumulative_instances : Reduction.conv_pb -> Univ.Variance.t array ->
 val compare_constructor_instances : evar_map ->
   Univ.Instance.t -> Univ.Instance.t -> evar_map
 
+(** {6 Unification problems} *)
+type unification_pb = conv_pb * env * constr * constr
+
+(** [add_unification_pb ?tail pb sigma]
+    Add a unification problem [pb] to [sigma], if not already present.
+    Put it at the end of the list if [tail] is true, by default it is false. *)
+val add_unification_pb : ?tail:bool -> unification_pb -> evar_map -> evar_map
+
 (** {6 Removing hyps in evars'context}
 raise OccurHypInSimpleClause if the removal breaks dependencies *)
 

--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -42,26 +42,26 @@ val new_evar :
   ?src:Evar_kinds.t Loc.located -> ?filter:Filter.t ->
   ?abstract_arguments:Abstraction.t -> ?candidates:constr list -> ?store:Store.t ->
   ?naming:intro_pattern_naming_expr ->
-  ?principal:bool -> ?hypnaming:naming_mode ->
+  ?future_goal:bool -> ?principal:bool -> ?hypnaming:naming_mode ->
   env -> evar_map -> types -> evar_map * EConstr.t
 
 val new_pure_evar :
   ?src:Evar_kinds.t Loc.located -> ?filter:Filter.t ->
   ?abstract_arguments:Abstraction.t -> ?candidates:constr list -> ?store:Store.t ->
   ?naming:intro_pattern_naming_expr ->
-  ?principal:bool ->
+  ?future_goal:bool -> ?principal:bool ->
   named_context_val -> evar_map -> types -> evar_map * Evar.t
-
-val new_pure_evar_full : evar_map -> evar_info -> evar_map * Evar.t
 
 (** Create a new Type existential variable, as we keep track of 
     them during type-checking and unification. *)
 val new_type_evar :
   ?src:Evar_kinds.t Loc.located -> ?filter:Filter.t ->
-  ?naming:intro_pattern_naming_expr ->
+  ?naming:intro_pattern_naming_expr -> ?future_goal:bool ->
   ?principal:bool -> ?hypnaming:naming_mode ->
   env -> evar_map -> rigid ->
   evar_map * (constr * Sorts.t)
+
+val new_pure_evar_full : evar_map -> evar_info -> evar_map * Evar.t
 
 val new_Type : ?rigid:rigid -> env -> evar_map -> evar_map * constr
 
@@ -79,7 +79,7 @@ val new_evar_instance :
   ?src:Evar_kinds.t Loc.located -> ?filter:Filter.t ->
   ?abstract_arguments:Abstraction.t -> ?candidates:constr list ->
   ?store:Store.t -> ?naming:intro_pattern_naming_expr ->
-  ?principal:bool ->
+  ?future_goal:bool -> ?principal:bool ->
  named_context_val -> evar_map -> types ->
   constr list -> evar_map * constr
 
@@ -288,13 +288,13 @@ val e_new_evar :
   env -> evar_map ref -> ?src:Evar_kinds.t Loc.located -> ?filter:Filter.t ->
   ?candidates:constr list -> ?store:Store.t ->
   ?naming:intro_pattern_naming_expr ->
-  ?principal:bool -> ?hypnaming:naming_mode -> types -> constr
+  ?future_goal:bool -> ?principal:bool -> ?hypnaming:naming_mode -> types -> constr
 [@@ocaml.deprecated "Use [Evarutil.new_evar]"]
 
 val e_new_type_evar : env -> evar_map ref ->
   ?src:Evar_kinds.t Loc.located -> ?filter:Filter.t ->
   ?naming:intro_pattern_naming_expr ->
-  ?principal:bool -> ?hypnaming:naming_mode -> rigid -> constr * Sorts.t
+  ?future_goal:bool -> ?principal:bool -> ?hypnaming:naming_mode -> rigid -> constr * Sorts.t
 [@@ocaml.deprecated "Use [Evarutil.new_type_evar]"]
 
 val e_new_Type : ?rigid:rigid -> env -> evar_map ref -> constr

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -171,6 +171,8 @@ let evar_context evi = named_context_of_val evi.evar_hyps
 let evar_filtered_context evi =
   Filter.filter_list (evar_filter evi) (evar_context evi)
 
+let evar_candidates evi = evi.evar_candidates
+
 let evar_hyps evi = evi.evar_hyps
 
 let evar_filtered_hyps evi = match Filter.repr (evar_filter evi) with
@@ -620,6 +622,7 @@ let merge_universe_context evd uctx' =
 let set_universe_context evd uctx' =
   { evd with universes = uctx' }
 
+(* TODO: make unique *)
 let add_conv_pb ?(tail=false) pb d =
   (** MS: we have duplicates here, why? *)
   if tail then {d with conv_pbs = d.conv_pbs @ [pb]}

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -622,11 +622,11 @@ let merge_universe_context evd uctx' =
 let set_universe_context evd uctx' =
   { evd with universes = uctx' }
 
-(* TODO: make unique *)
 let add_conv_pb ?(tail=false) pb d =
-  (** MS: we have duplicates here, why? *)
   if tail then {d with conv_pbs = d.conv_pbs @ [pb]}
   else {d with conv_pbs = pb::d.conv_pbs}
+
+let conv_pbs d = d.conv_pbs
 
 let evar_source evk d = (find d evk).evar_source
 

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -126,6 +126,15 @@ struct
 
 end
 
+module Abstraction = struct
+
+  type t = bool list
+
+  let identity = []
+
+  let abstract_last l = true :: l
+end
+
 (* The kinds of existential variables are now defined in [Evar_kinds] *)
 
 (* The type of mappings for existential variables *)
@@ -143,6 +152,7 @@ type evar_info = {
   evar_hyps : named_context_val;
   evar_body : evar_body;
   evar_filter : Filter.t;
+  evar_abstract_arguments : Abstraction.t;
   evar_source : Evar_kinds.t Loc.located;
   evar_candidates : constr list option; (* if not None, list of allowed instances *)
   evar_extra : Store.t }
@@ -152,6 +162,7 @@ let make_evar hyps ccl = {
   evar_hyps = hyps;
   evar_body = Evar_empty;
   evar_filter = Filter.identity;
+  evar_abstract_arguments = Abstraction.identity;
   evar_source = Loc.tag @@ Evar_kinds.InternalHole;
   evar_candidates = None;
   evar_extra = Store.empty

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -77,6 +77,14 @@ sig
 
 end
 
+module Abstraction : sig
+  type t = bool list
+
+  val identity : t
+
+  val abstract_last : t -> t
+end
+
 (** {6 Evar infos} *)
 
 type evar_body =
@@ -98,6 +106,10 @@ type evar_info = {
   (** Boolean mask over {!evar_hyps}. Should have the same length.
       When filtered out, the corresponding variable is not allowed to occur
       in the solution *)
+  evar_abstract_arguments : Abstraction.t;
+  (** Boolean information over {!evar_hyps}, telling if an hypothesis instance
+      can be immitated or should stay abstract in HO unification problems
+      and inversion (see [second_order_matching_with_args] for its use). *)
   evar_source : Evar_kinds.t located;
   (** Information about the evar. *)
   evar_candidates : econstr list option;

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -441,7 +441,11 @@ type clbinding =
 (** Unification constraints *)
 type conv_pb = Reduction.conv_pb
 type evar_constraint = conv_pb * env * econstr * econstr
+
+(** The following two functions are for internal use only,
+    see [Evarutil.add_unification_pb] for a safe interface. *)
 val add_conv_pb : ?tail:bool -> evar_constraint -> evar_map -> evar_map
+val conv_pbs : evar_map -> evar_constraint list
 
 val extract_changed_conv_pbs : evar_map ->
       (Evar.Set.t -> evar_constraint -> bool) ->

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -113,6 +113,7 @@ val evar_filtered_context : evar_info -> (econstr, etypes) Context.Named.pt
 val evar_hyps : evar_info -> named_context_val
 val evar_filtered_hyps : evar_info -> named_context_val
 val evar_body : evar_info -> evar_body
+val evar_candidates : evar_info -> constr list option
 val evar_filter : evar_info -> Filter.t
 val evar_env :  evar_info -> env
 val evar_filtered_env :  evar_info -> env
@@ -243,7 +244,8 @@ val evars_reset_evd  : ?with_conv_pbs:bool -> ?with_univs:bool ->
 val restrict : Evar.t-> Filter.t -> ?candidates:econstr list ->
   ?src:Evar_kinds.t located -> evar_map -> evar_map * Evar.t
 (** Restrict an undefined evar into a new evar by filtering context and
-    possibly limiting the instances to a set of candidates *)
+    possibly limiting the instances to a set of candidates (candidates
+    are filtered according to the filter) *)
 
 val is_restricted_evar : evar_info -> Evar.t option
 (** Tell if an evar comes from restriction of another evar, and if yes, which *)

--- a/kernel/term.mli
+++ b/kernel/term.mli
@@ -132,6 +132,7 @@ val decompose_prod_assum : types -> Context.Rel.t * types
 val decompose_lam_assum : constr -> Context.Rel.t * constr
 
 (** Idem but extract the first [n] premisses, counting let-ins. *)
+(** MS: name mismatch here, should be decls not assum *)
 val decompose_prod_n_assum : int -> types -> Context.Rel.t * types
 
 (** Idem for lambdas, _not_ counting let-ins *)

--- a/plugins/ltac/extratactics.ml4
+++ b/plugins/ltac/extratactics.ml4
@@ -293,7 +293,7 @@ open Vars
 
 let constr_flags () = {
   Pretyping.use_typeclasses = true;
-  Pretyping.solve_unification_constraints = true;
+  Pretyping.solve_unification_constraints = Pfedit.use_unification_heuristics ();
   Pretyping.use_hook = Pfedit.solve_by_implicit_tactic ();
   Pretyping.fail_evar = false;
   Pretyping.expand_evars = true }

--- a/plugins/ltac/tacintern.ml
+++ b/plugins/ltac/tacintern.ml
@@ -536,7 +536,7 @@ let rec intern_atomic lf ist x =
       | _ -> false
       in
       let is_onconcl = match cl.concl_occs with
-      | AllOccurrences | NoOccurrences -> true
+      | AtLeastOneOccurrence | AllOccurrences | NoOccurrences -> true
       | _ -> false
       in
       TacChange (None,

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -1745,7 +1745,7 @@ and interp_atomic ist tac : unit Proofview.tactic =
           | _ -> false
         in
         let is_onconcl = match cl.concl_occs with
-          | AllOccurrences | NoOccurrences -> true
+          | AtLeastOneOccurrence | AllOccurrences | NoOccurrences -> true
           | _ -> false
         in
         let c_interp patvars sigma =

--- a/pretyping/coercion.mli
+++ b/pretyping/coercion.mli
@@ -46,10 +46,12 @@ val inh_coerce_to_prod : ?loc:Loc.t ->
     applicable. resolve_tc=false disables resolving type classes (as the last
     resort before failing) *)
 val inh_conv_coerce_to : ?loc:Loc.t -> bool ->
-  env -> evar_map -> unsafe_judgment -> types -> evar_map * unsafe_judgment
+  env -> evar_map -> ?flags:Evarconv.unify_flags ->
+  unsafe_judgment -> types -> evar_map * unsafe_judgment
 
 val inh_conv_coerce_rigid_to : ?loc:Loc.t -> bool ->
-  env -> evar_map -> unsafe_judgment -> types -> evar_map * unsafe_judgment
+  env -> evar_map -> ?flags:Evarconv.unify_flags ->
+  unsafe_judgment -> types -> evar_map * unsafe_judgment
 
 (** [inh_conv_coerces_to loc env isevars t t'] checks if an object of type [t]
     is coercible to an object of type [t'] adding evar constraints if needed;

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -1141,7 +1141,7 @@ let second_order_matching ts env_rhs evd (evk,args) argoccs rhs =
   | (id,_,c,cty,evsref,filter,occs)::subst ->
       let set_var k =
         match occs with
-        | Some Locus.AllOccurrences -> mkVar id
+        | Some (Locus.AtLeastOneOccurrence | Locus.AllOccurrences) -> mkVar id
         | Some _ -> user_err Pp.(str "Selection of specific occurrences not supported")
         | None ->
         let evty = set_holes evdref cty subst in

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -25,13 +25,27 @@ open Evardefine
 open Evarsolve
 open Evd
 open Pretype_errors
-open Context.Named.Declaration
 
 module RelDecl = Context.Rel.Declaration
 module NamedDecl = Context.Named.Declaration
 
-type unify_fun = transparent_state ->
+type unify_flags = Evarsolve.unify_flags
+
+type unify_fun = unify_flags ->
   env -> evar_map -> conv_pb -> EConstr.constr -> EConstr.constr -> Evarsolve.unification_result
+
+let default_transparent_state env = full_transparent_state
+(* Conv_oracle.get_transp_state (Environ.oracle env) *)
+
+let default_flags_of ?(subterm_ts=empty_transparent_state) ts =
+  { modulo_betaiota = true;
+    open_ts = ts; closed_ts = ts; subterm_ts;
+    frozen_evars = Evar.Set.empty; with_cs = true;
+    allow_K_at_toplevel = true }
+
+let default_flags env =
+  let ts = default_transparent_state env in
+  default_flags_of ts
 
 let debug_unification = ref (false)
 let _ = Goptions.declare_bool_option {
@@ -41,6 +55,16 @@ let _ = Goptions.declare_bool_option {
   Goptions.optkey = ["Debug";"Unification"];
   Goptions.optread = (fun () -> !debug_unification);
   Goptions.optwrite = (fun a -> debug_unification:=a);
+}
+
+let debug_ho_unification = ref (false)
+let _ = Goptions.declare_bool_option {
+  Goptions.optdepr = false;
+  Goptions.optname =
+    "Print debug information for the higer-order unification algorithm";
+  Goptions.optkey = ["Debug";"HO"; "Unification"];
+  Goptions.optread = (fun () -> !debug_ho_unification);
+  Goptions.optwrite = (fun a -> debug_ho_unification:=a);
 }
 
 (*******************************************)
@@ -103,28 +127,48 @@ type flex_kind_of_term =
   | MaybeFlexible of EConstr.t (* reducible but not necessarily reduced *)
   | Flexible of EConstr.existential
 
-let flex_kind_of_term ts env evd c sk =
+let is_frozen flags (evk, _) = Evar.Set.mem evk flags.frozen_evars
+
+let flex_kind_of_term flags env evd c sk =
   match EConstr.kind evd c with
     | LetIn _ | Rel _ | Const _ | Var _ | Proj _ ->
-      Option.cata (fun x -> MaybeFlexible x) Rigid (eval_flexible_term ts env evd c)
-    | Lambda _ when not (Option.is_empty (Stack.decomp sk)) -> MaybeFlexible c
-    | Evar ev -> Flexible ev
+      Option.cata (fun x -> MaybeFlexible x) Rigid (eval_flexible_term flags.open_ts env evd c)
+    | Lambda _ when not (Option.is_empty (Stack.decomp sk)) ->
+       if flags.modulo_betaiota then MaybeFlexible c
+       else Rigid
+    | Evar ev ->
+       if is_frozen flags ev then Rigid
+       else Flexible ev
     | Lambda _ | Prod _ | Sort _ | Ind _ | Construct _ | CoFix _ -> Rigid
     | Meta _ -> Rigid
     | Fix _ -> Rigid (* happens when the fixpoint is partially applied *)
     | Cast _ | App _ | Case _ -> assert false
 
-let apprec_nohdbeta ts env evd c =
+let apprec_nohdbeta flags env evd c =
   let (t,sk as appr) = Reductionops.whd_nored_state evd (c, []) in
-  if Stack.not_purely_applicative sk
+  if flags.modulo_betaiota && Stack.not_purely_applicative sk
   then Stack.zip evd (fst (whd_betaiota_deltazeta_for_iota_state
-		   ts env evd Cst_stack.empty appr))
+                   flags.open_ts env evd Cst_stack.empty appr))
   else c
 
 let position_problem l2r = function
   | CONV -> None
   | CUMUL -> Some l2r
 
+(* [occur_rigidly ev evd t] tests if the evar ev occurs in a rigid
+   context in t
+
+  That function should be an over approximation of occur-check, it can
+  return true even if the occur-check would fail on the normal form, as
+  otherwise we will postpone unsolvable constraints while maybe a
+  reduction would have allowed unification (see bug 3539 for example).
+
+  The boolean indicates if the term is a rigid head. For applications,
+  this means than an occurrence of the evar in arguments should be looked
+  at to find an occur-check.
+
+  TODO: replace with a test on the normal form and evaluate performance.
+ *)
 let occur_rigidly (evk,_ as ev) evd t =
   let rec aux t =
     match EConstr.kind evd t with
@@ -133,7 +177,8 @@ let occur_rigidly (evk,_ as ev) evd t =
     | Proj (p, c) -> not (aux c)
     | Evar (evk',_) -> if Evar.equal evk evk' then raise Occur else false
     | Cast (p, _, _) -> aux p
-    | Lambda _ | LetIn _ -> false
+    | Lambda (na, t, b) -> aux b
+    | LetIn (na, _, _, b) -> aux b
     | Const _ -> false
     | Prod (_, b, t) -> ignore(aux b || aux t); true
     | Rel _ | Var _ -> false
@@ -357,7 +402,15 @@ let compare_cumulative_instances evd variances u u' =
     Success evd
   | Inr p -> UnifFailure (evd, UnifUnivInconsistency p)
 
-let rec evar_conv_x ts env evd pbty term1 term2 =
+let conv_fun f flags on_types =
+  let typefn env evd pbty term1 term2 =
+    f { (default_flags env) with with_cs = flags.with_cs } env evd pbty term1 term2
+  in
+  let termfn env evd pbty term1 term2 =
+    f flags env evd pbty term1 term2
+  in if on_types then typefn else termfn
+
+let rec evar_conv_x flags env evd pbty term1 term2 =
   let term1 = whd_head_evar evd term1 in
   let term2 = whd_head_evar evd term2 in
   (* Maybe convertible but since reducing can erase evars which [evar_apprec]
@@ -366,7 +419,7 @@ let rec evar_conv_x ts env evd pbty term1 term2 =
   let ground_test =
     if is_ground_term evd term1 && is_ground_term evd term2 then (
       let e =
-          match infer_conv ~catch_incon:false ~pb:pbty ~ts:(fst ts) env evd term1 term2 with
+          match infer_conv ~catch_incon:false ~pb:pbty ~ts:flags.closed_ts env evd term1 term2 with
           | Some evd -> Success evd
           | None -> UnifFailure (evd, ConversionFailed (env,term1,term2))
           | exception Univ.UniverseInconsistency e -> UnifFailure (evd, UnifUnivInconsistency e)
@@ -381,30 +434,30 @@ let rec evar_conv_x ts env evd pbty term1 term2 =
     | None ->
       (* Until pattern-unification is used consistently, use nohdbeta to not
 	   destroy beta-redexes that can be used for 1st-order unification *)
-        let term1 = apprec_nohdbeta (fst ts) env evd term1 in
-        let term2 = apprec_nohdbeta (fst ts) env evd term2 in
+        let term1 = apprec_nohdbeta flags env evd term1 in
+        let term2 = apprec_nohdbeta flags env evd term2 in
 	let default () = 
-          evar_eqappr_x ts env evd pbty
+          evar_eqappr_x flags env evd pbty
             (whd_nored_state evd (term1,Stack.empty), Cst_stack.empty)
             (whd_nored_state evd (term2,Stack.empty), Cst_stack.empty)
 	in
           begin match EConstr.kind evd term1, EConstr.kind evd term2 with
-          | Evar ev, _ when Evd.is_undefined evd (fst ev) ->
-            (match solve_simple_eqn (evar_conv_x ts) env evd
-              (position_problem true pbty,ev, term2) with
+          | Evar ev, _ when Evd.is_undefined evd (fst ev) && not (is_frozen flags ev) ->
+            (match solve_simple_eqn flags (conv_fun evar_conv_x flags) env evd
+              (position_problem true pbty,ev,term2) with
 	      | UnifFailure (_,OccurCheck _) -> 
 		(* Eta-expansion might apply *) default ()
 	      | x -> x)
-          | _, Evar ev when Evd.is_undefined evd (fst ev) ->
-            (match solve_simple_eqn (evar_conv_x ts) env evd
-              (position_problem false pbty,ev, term1) with
+          | _, Evar ev when Evd.is_undefined evd (fst ev) && not (is_frozen flags ev) ->
+            (match solve_simple_eqn flags (conv_fun evar_conv_x flags) env evd
+              (position_problem false pbty,ev,term1) with
 	      | UnifFailure (_, OccurCheck _) ->
 		(* Eta-expansion might apply *) default () 
 	      | x -> x)
           | _ -> default ()
         end
 
-and evar_eqappr_x ?(rhs_is_already_stuck = false) ts env evd pbty
+and evar_eqappr_x ?(rhs_is_already_stuck = false) flags env evd pbty
     ((term1,sk1 as appr1),csts1) ((term2,sk2 as appr2),csts2) =
   let quick_fail i = (* not costly, loses info *)
     UnifFailure (i, NotSameHead)
@@ -415,18 +468,18 @@ and evar_eqappr_x ?(rhs_is_already_stuck = false) ts env evd pbty
       | Some l1' -> (* Miller-Pfenning's patterns unification *)
 	let t2 = tM in
 	let t2 = solve_pattern_eqn env evd l1' t2 in
-	  solve_simple_eqn (evar_conv_x ts) env evd
+          solve_simple_eqn flags (conv_fun evar_conv_x flags) env evd
 	    (position_problem on_left pbty,ev,t2) 
   in
   let consume_stack on_left (termF,skF) (termO,skO) evd =
     let switch f a b = if on_left then f a b else f b a in
     let not_only_app = Stack.not_purely_applicative skO in
-    match switch (ise_stack2 not_only_app env evd (evar_conv_x ts)) skF skO with
+    match switch (ise_stack2 not_only_app env evd (evar_conv_x flags)) skF skO with
       |Some (l,r), Success i' when on_left && (not_only_app || List.is_empty l) ->
-	switch (evar_conv_x ts env i' pbty) (Stack.zip evd (termF,l)) (Stack.zip evd (termO,r))
+        switch (evar_conv_x flags env i' pbty) (Stack.zip evd (termF,l)) (Stack.zip evd (termO,r))
       |Some (r,l), Success i' when not on_left && (not_only_app || List.is_empty l) ->
-	switch (evar_conv_x ts env i' pbty) (Stack.zip evd (termF,l)) (Stack.zip evd (termO,r))
-      |None, Success i' -> switch (evar_conv_x ts env i' pbty) termF termO
+        switch (evar_conv_x flags env i' pbty) (Stack.zip evd (termF,l)) (Stack.zip evd (termO,r))
+      |None, Success i' -> switch (evar_conv_x flags env i' pbty) termF termO
       |_, (UnifFailure _ as x) -> x
       |Some _, _ -> UnifFailure (evd,NotSameArgSize) in
   let eta env evd onleft sk term sk' term' =
@@ -435,12 +488,12 @@ and evar_eqappr_x ?(rhs_is_already_stuck = false) ts env evd pbty
     let c = nf_evar evd c1 in
     let env' = push_rel (RelDecl.LocalAssum (na,c)) env in
     let out1 = whd_betaiota_deltazeta_for_iota_state
-      (fst ts) env' evd Cst_stack.empty (c'1, Stack.empty) in
+      flags.open_ts env' evd Cst_stack.empty (c'1, Stack.empty) in
     let out2 = whd_nored_state evd
       (lift 1 (Stack.zip evd (term', sk')), Stack.append_app [|EConstr.mkRel 1|] Stack.empty),
       Cst_stack.empty in
-    if onleft then evar_eqappr_x ts env' evd CONV out1 out2
-    else evar_eqappr_x ts env' evd CONV out2 out1
+    if onleft then evar_eqappr_x flags env' evd CONV out1 out2
+    else evar_eqappr_x flags env' evd CONV out2 out1
   in
   let rigids env evd sk term sk' term' =
     let check_strict evd u u' =
@@ -498,12 +551,16 @@ and evar_eqappr_x ?(rhs_is_already_stuck = false) ts env evd pbty
     ise_and evd [(fun i ->
                 try compare_heads i
                 with Univ.UniverseInconsistency p -> UnifFailure (i, UnifUnivInconsistency p));
-                 (fun i -> exact_ise_stack2 env i (evar_conv_x ts) sk sk')]
+                 (fun i -> exact_ise_stack2 env i (evar_conv_x flags) sk sk')]
   in
-  let flex_maybeflex on_left ev ((termF,skF as apprF),cstsF) ((termM, skM as apprM),cstsM) vM =
+  let consume on_left (_, skF as apprF) (_,skM as apprM) i =
+    if not (Stack.is_empty skF && Stack.is_empty skM) then
+      consume_stack on_left apprF apprM i
+    else quick_fail i
+  in
+  let miller on_left ev (termF,skF as apprF) (termM, skM as apprM) i =
     let switch f a b = if on_left then f a b else f b a in
     let not_only_app = Stack.not_purely_applicative skM in
-    let f1 i =
       match Stack.list_of_app_stack skF with
       | None -> quick_fail evd
       | Some lF -> 
@@ -512,17 +569,17 @@ and evar_eqappr_x ?(rhs_is_already_stuck = false) ts env evd pbty
 	    (fun () -> if not_only_app then (* Postpone the use of an heuristic *)
               switch (fun x y -> Success (Evarutil.add_unification_pb (pbty,env,x,y) i)) (Stack.zip evd apprF) tM
 	    else quick_fail i)
-	  ev lF tM i
-    and consume (termF,skF as apprF) (termM,skM as apprM) i = 
-      if not (Stack.is_empty skF && Stack.is_empty skM) then
-        consume_stack on_left apprF apprM i
-      else quick_fail i
-    and delta i =
-      switch (evar_eqappr_x ts env i pbty) (apprF,cstsF)
-	     (whd_betaiota_deltazeta_for_iota_state
-  	        (fst ts) env i cstsM (vM,skM))
+            ev lF tM i
+  in
+  let flex_maybeflex on_left ev ((termF,skF as apprF),cstsF) ((termM, skM as apprM),cstsM) vM =
+    let switch f a b = if on_left then f a b else f b a in
+    let delta i =
+      switch (evar_eqappr_x flags env i pbty) (apprF,cstsF)
+        (whd_betaiota_deltazeta_for_iota_state flags.open_ts env i cstsM (vM,skM))
     in    
-    let default i = ise_try i [f1; consume apprF apprM; delta]
+    let default i = ise_try i [miller on_left ev apprF apprM;
+                               consume on_left apprF apprM;
+                               delta]
     in
       match EConstr.kind evd termM with
       | Proj (p, c) when not (Stack.is_empty skF) ->
@@ -537,13 +594,13 @@ and evar_eqappr_x ?(rhs_is_already_stuck = false) ts env evd pbty
 		try 
 		  let termM' = Retyping.expand_projection env evd p c [] in
 		  let apprM', cstsM' = 
-		    whd_betaiota_deltazeta_for_iota_state
-		      (fst ts) env evd cstsM (termM',skM)
+                    whd_betaiota_deltazeta_for_iota_state flags.open_ts env evd cstsM (termM',skM)
 		  in
 		  let delta' i = 
-		    switch (evar_eqappr_x ts env i pbty) (apprF,cstsF) (apprM',cstsM') 
+                    switch (evar_eqappr_x flags env i pbty) (apprF,cstsF) (apprM',cstsM')
 		  in
-		    fun i -> ise_try i [f1; consume apprF apprM'; delta']
+                  fun i -> ise_try i [miller on_left ev apprF apprM';
+                                   consume on_left apprF apprM'; delta']
 		with Retyping.RetypeError _ ->
 		(* Happens thanks to w_unify building ill-typed terms *) 
 		  default
@@ -551,13 +608,77 @@ and evar_eqappr_x ?(rhs_is_already_stuck = false) ts env evd pbty
 	  end
       | _ -> default evd
   in
-  let flex_rigid on_left ev (termF, skF as apprF) (termR, skR as apprR) =
+  let rec first_order flexrigid env i t1 t2 sk1 sk2 =
+    (* Try first-order unification *)
+    match ise_stack2 false env i (evar_conv_x flags) sk1 sk2 with
+    | None, Success i' ->
+       (* We do have sk1[] = sk2[]: we now unify ?ev1 and ?ev2 *)
+       (* Note that ?ev1 and ?ev2, may have been instantiated in the meantime *)
+       let ev1' = whd_evar i' t1 in
+       if isEvar i' ev1' then
+         solve_simple_eqn flags (conv_fun evar_conv_x flags) env i'
+                          (position_problem true pbty,destEvar i' ev1',term2)
+       else
+         evar_eqappr_x flags env evd pbty
+                       ((ev1', sk1), csts1) ((term2, sk2), csts2)
+    | Some (r,[]), Success i' ->
+       (* We have sk1'[] = sk2[] for some sk1' s.t. sk1[]=sk1'[r[]] *)
+       (* we now unify r[?ev1] and ?ev2 *)
+       let ev2' = whd_evar i' t2 in
+       if isEvar i' ev2' then
+         solve_simple_eqn flags (conv_fun evar_conv_x flags) env i'
+                          (position_problem false pbty,destEvar i' ev2',Stack.zip i' (term1,r))
+       else
+         evar_eqappr_x flags env evd pbty
+                       ((ev2', sk1), csts1) ((term2, sk2), csts2)
+    | Some ([],r), Success i' ->
+       (* Symmetrically *)
+       (* We have sk1[] = sk2'[] for some sk2' s.t. sk2[]=sk2'[r[]] *)
+       (* we now unify ?ev1 and r[?ev2] *)
+       let ev1' = whd_evar i' t1 in
+       if isEvar i' ev1' then
+         solve_simple_eqn flags (conv_fun evar_conv_x flags) env i'
+                          (position_problem true pbty,destEvar i' ev1',Stack.zip i' (term2,r))
+       else evar_eqappr_x flags env evd pbty
+                          ((ev1', sk1), csts1) ((term2, sk2), csts2)
+    | None, (UnifFailure _ as x) ->
+       (* sk1 and sk2 have no common outer part *)
+       if flexrigid then x else
+       if Stack.not_purely_applicative sk2 then
+         (* Ad hoc compatibility with 8.4 which treated non-app as rigid *)
+         flex_rigid true (destEvar evd t1) appr1 appr2
+       else
+         if Stack.not_purely_applicative sk1 then
+           (* Ad hoc compatibility with 8.4 which treated non-app as rigid *)
+           flex_rigid false (destEvar evd t2) appr2 appr1
+         else
+           (* We could instead try Miller unification, then
+              postpone to see if other equations help, as in:
+              [Check fun a b : unit => (eqᵣefl : _ a = _ a b)] *)
+           x
+    | Some _, Success _ ->
+       if flexrigid then UnifFailure (i, NotSameArgSize) else
+       (* sk1 and sk2 have a common outer part *)
+       if Stack.not_purely_applicative sk2 then
+         (* Ad hoc compatibility with 8.4 which treated non-app as rigid *)
+         flex_rigid true (destEvar evd t1) appr1 appr2
+       else
+         if Stack.not_purely_applicative sk1 then
+           (* Ad hoc compatibility with 8.4 which treated non-app as rigid *)
+           flex_rigid false (destEvar evd t2) appr2 appr1
+         else
+           (* We could instead try Miller unification, then
+              postpone to see if other equations help, as in:
+              [Check fun a b c : unit => (eqᵣefl : _ a b = _ c a b)] *)
+           UnifFailure (i,NotSameArgSize)
+    | _, _ -> anomaly (Pp.str "Unexpected result from ise_stack2.")
+  and flex_rigid on_left ev (termF, skF as apprF) (termR, skR as apprR) =
     let switch f a b = if on_left then f a b else f b a in
     let eta evd =
       match EConstr.kind evd termR with
       | Lambda _ when (* if ever problem is ill-typed: *) List.is_empty skR ->
          eta env evd false skR termR skF termF
-      | Construct u -> eta_constructor ts env evd skR u skF termF
+      | Construct u -> eta_constructor flags env evd skR u skF termF
       | _ -> UnifFailure (evd,NotSameHead)
     in
     match Stack.list_of_app_stack skF with
@@ -569,6 +690,7 @@ and evar_eqappr_x ?(rhs_is_already_stuck = false) ts env evd pbty
 	    (fun () ->
 	      ise_try evd 
 	        [eta;(* Postpone the use of an heuristic *)
+                 (* (fun i -> first_order true env i termF termR skF skR); *)
 		 (fun i -> 
 		   if not (occur_rigidly ev i tR) then
                      let i,tF =
@@ -588,86 +710,28 @@ and evar_eqappr_x ?(rhs_is_already_stuck = false) ts env evd pbty
   (* Evar must be undefined since we have flushed evars *)
   let () = if !debug_unification then
 	     let open Pp in
-	     Feedback.msg_notice (v 0 (pr_state appr1 ++ cut () ++ pr_state appr2 ++ cut ())) in
-  match (flex_kind_of_term (fst ts) env evd term1 sk1, 
-	 flex_kind_of_term (fst ts) env evd term2 sk2) with
-    | Flexible (sp1,al1 as ev1), Flexible (sp2,al2 as ev2) ->
+             Feedback.msg_notice (v 0 (pr_state appr1 ++ cut () ++ pr_state appr2 ++ cut ())
+                 ++ fnl ()) in
+  match (flex_kind_of_term flags env evd term1 sk1,
+         flex_kind_of_term flags env evd term2 sk2) with
+    | Flexible (sp1,al1), Flexible (sp2,al2) ->
         (* sk1[?ev1] =? sk2[?ev2] *)
-	let f1 i =
-          (* Try first-order unification *)
-	  match ise_stack2 false env i (evar_conv_x ts) sk1 sk2 with
-	  | None, Success i' ->
-            (* We do have sk1[] = sk2[]: we now unify ?ev1 and ?ev2 *)
-            (* Note that ?ev1 and ?ev2, may have been instantiated in the meantime *)
-	    let ev1' = whd_evar i' (mkEvar ev1) in
-	      if isEvar i' ev1' then
-		solve_simple_eqn (evar_conv_x ts) env i'
-		  (position_problem true pbty,destEvar i' ev1', term2)
-	      else 
-		evar_eqappr_x ts env evd pbty 
-		  ((ev1', sk1), csts1) ((term2, sk2), csts2)
-	  | Some (r,[]), Success i' ->
-            (* We have sk1'[] = sk2[] for some sk1' s.t. sk1[]=sk1'[r[]] *)
-            (* we now unify r[?ev1] and ?ev2 *)
-	    let ev2' = whd_evar i' (mkEvar ev2) in
-	      if isEvar i' ev2' then
-		solve_simple_eqn (evar_conv_x ts) env i'
-		  (position_problem false pbty,destEvar i' ev2',Stack.zip evd (term1,r))
-	      else 
-		evar_eqappr_x ts env evd pbty 
-		  ((ev2', sk1), csts1) ((term2, sk2), csts2)
-	  | Some ([],r), Success i' ->
-            (* Symmetrically *)
-            (* We have sk1[] = sk2'[] for some sk2' s.t. sk2[]=sk2'[r[]] *)
-            (* we now unify ?ev1 and r[?ev2] *)
-	    let ev1' = whd_evar i' (mkEvar ev1) in
-	      if isEvar i' ev1' then
-		solve_simple_eqn (evar_conv_x ts) env i'
-	          (position_problem true pbty,destEvar i' ev1',Stack.zip evd (term2,r))
-	      else evar_eqappr_x ts env evd pbty 
-		((ev1', sk1), csts1) ((term2, sk2), csts2)
-	  | None, (UnifFailure _ as x) ->
-             (* sk1 and sk2 have no common outer part *)
-             if Stack.not_purely_applicative sk2 then
-               (* Ad hoc compatibility with 8.4 which treated non-app as rigid *)
-               flex_rigid true ev1 appr1 appr2
-             else
-             if Stack.not_purely_applicative sk1 then
-               (* Ad hoc compatibility with 8.4 which treated non-app as rigid *)
-               flex_rigid false ev2 appr2 appr1
-             else
-               (* We could instead try Miller unification, then
-                  postpone to see if other equations help, as in:
-                  [Check fun a b : unit => (eqᵣefl : _ a = _ a b)] *)
-               x
-	  | Some _, Success _ ->
-             (* sk1 and sk2 have a common outer part *)
-             if Stack.not_purely_applicative sk2 then
-               (* Ad hoc compatibility with 8.4 which treated non-app as rigid *)
-               flex_rigid true ev1 appr1 appr2
-             else
-             if Stack.not_purely_applicative sk1 then
-               (* Ad hoc compatibility with 8.4 which treated non-app as rigid *)
-               flex_rigid false ev2 appr2 appr1
-             else
-               (* We could instead try Miller unification, then
-                  postpone to see if other equations help, as in:
-                  [Check fun a b c : unit => (eqᵣefl : _ a b = _ c a b)] *)
-               UnifFailure (i,NotSameArgSize)
-          | _, _ -> anomaly (Pp.str "Unexpected result from ise_stack2.")
-
+        let f1 i = first_order false env i term1 term2 sk1 sk2
 	and f2 i =
           if Evar.equal sp1 sp2 then
-	    match ise_stack2 false env i (evar_conv_x ts) sk1 sk2 with
+            match ise_stack2 false env i (evar_conv_x flags) sk1 sk2 with
 	    |None, Success i' ->
-              Success (solve_refl (fun env i pbty a1 a2 ->
-                is_success (evar_conv_x ts env i pbty a1 a2))
+              Success (solve_refl flags (fun p env i pbty a1 a2 ->
+                let flags = if p then default_flags env else flags in
+                is_success (evar_conv_x flags env i pbty a1 a2))
                 env i' (position_problem true pbty) sp1 al1 al2)
 	    |_, (UnifFailure _ as x) -> x
             |Some _, _ -> UnifFailure (i,NotSameArgSize)
           else UnifFailure (i,NotSameHead)
-	in
-	ise_try evd [f1; f2]
+        and f3 i = miller true (sp1,al1) appr1 appr2 i
+        and f4 i = miller false (sp2,al2) appr2 appr1 i
+        and f5 i = consume true appr1 appr2 i in
+        ise_try evd [f1; f2; f3; f4; f5]
 
     | Flexible ev1, MaybeFlexible v2 ->
       flex_maybeflex true ev1 (appr1,csts1) (appr2,csts2) v2
@@ -681,19 +745,19 @@ and evar_eqappr_x ?(rhs_is_already_stuck = false) ts env evd pbty
         let f1 i = (* FO *)
           ise_and i
             [(fun i -> ise_try i
-               [(fun i -> evar_conv_x ts env i CUMUL t1 t2);
-                (fun i -> evar_conv_x ts env i CUMUL t2 t1)]);
-             (fun i -> evar_conv_x ts env i CONV b1 b2);
+               [(fun i -> evar_conv_x flags env i CUMUL t1 t2);
+                (fun i -> evar_conv_x flags env i CUMUL t2 t1)]);
+             (fun i -> evar_conv_x flags env i CONV b1 b2);
 	     (fun i ->
 	       let b = nf_evar i b1 in
 	       let t = nf_evar i t1 in
                let na = Nameops.Name.pick na1 na2 in
-	       evar_conv_x ts (push_rel (RelDecl.LocalDef (na,b,t)) env) i pbty c'1 c'2);
-	     (fun i -> exact_ise_stack2 env i (evar_conv_x ts) sk1 sk2)]
+               evar_conv_x flags (push_rel (RelDecl.LocalDef (na,b,t)) env) i pbty c'1 c'2);
+             (fun i -> exact_ise_stack2 env i (evar_conv_x flags) sk1 sk2)]
 	and f2 i =
-          let out1 = whd_betaiota_deltazeta_for_iota_state (fst ts) env i csts1 (v1,sk1)
-          and out2 = whd_betaiota_deltazeta_for_iota_state (fst ts) env i csts2 (v2,sk2)
-	  in evar_eqappr_x ts env i pbty out1 out2
+          let out1 = whd_betaiota_deltazeta_for_iota_state flags.open_ts env i csts1 (v1,sk1)
+          and out2 = whd_betaiota_deltazeta_for_iota_state flags.open_ts env i csts2 (v2,sk2)
+          in evar_eqappr_x flags env i pbty out1 out2
 	in
 	ise_try evd [f1; f2]
 
@@ -701,12 +765,12 @@ and evar_eqappr_x ?(rhs_is_already_stuck = false) ts env evd pbty
 	  when Constant.equal (Projection.constant p) (Projection.constant p') ->
 	  let f1 i = 
 	    ise_and i 
-	    [(fun i -> evar_conv_x ts env i CONV c c');
-	     (fun i -> exact_ise_stack2 env i (evar_conv_x ts) sk1 sk2)]
+            [(fun i -> evar_conv_x flags env i CONV c c');
+             (fun i -> exact_ise_stack2 env i (evar_conv_x flags) sk1 sk2)]
 	  and f2 i =
-            let out1 = whd_betaiota_deltazeta_for_iota_state (fst ts) env i csts1 (v1,sk1)
-            and out2 = whd_betaiota_deltazeta_for_iota_state (fst ts) env i csts2 (v2,sk2)
-	    in evar_eqappr_x ts env i pbty out1 out2
+            let out1 = whd_betaiota_deltazeta_for_iota_state flags.open_ts env i csts1 (v1,sk1)
+            and out2 = whd_betaiota_deltazeta_for_iota_state flags.open_ts env i csts2 (v2,sk2)
+            in evar_eqappr_x flags env i pbty out1 out2
 	  in
 	    ise_try evd [f1; f2]
 	      
@@ -718,7 +782,7 @@ and evar_eqappr_x ?(rhs_is_already_stuck = false) ts env evd pbty
 	  in
 	    (match res with 
 	    | Some (f1,args1) -> 
-	      evar_eqappr_x ts env evd pbty ((f1,Stack.append_app args1 sk1),csts1) 
+              evar_eqappr_x flags env evd pbty ((f1,Stack.append_app args1 sk1),csts1)
 		(appr2,csts2)
 	    | None -> UnifFailure (evd,NotSameHead))
 	      
@@ -729,7 +793,7 @@ and evar_eqappr_x ?(rhs_is_already_stuck = false) ts env evd pbty
 	  in 
 	    (match res with
 	    | Some (f2,args2) ->
-	      evar_eqappr_x ts env evd pbty (appr1,csts1) ((f2,Stack.append_app args2 sk2),csts2)
+              evar_eqappr_x flags env evd pbty (appr1,csts1) ((f2,Stack.append_app args2 sk2),csts2)
 	    | None -> UnifFailure (evd,NotSameHead))
 	      
 	| _, _ ->
@@ -746,13 +810,13 @@ and evar_eqappr_x ?(rhs_is_already_stuck = false) ts env evd pbty
 		try Success (Evd.add_universe_constraints i univs)
 		with UniversesDiffer -> UnifFailure (i,NotSameHead)
 		| Univ.UniverseInconsistency p -> UnifFailure (i, UnifUnivInconsistency p));
-			 (fun i -> exact_ise_stack2 env i (evar_conv_x ts) sk1 sk2)]
+                         (fun i -> exact_ise_stack2 env i (evar_conv_x flags) sk1 sk2)]
           | None ->
             UnifFailure (i,NotSameHead)
 	and f2 i =
 	  (try 
-	     if not (snd ts) then raise Not_found
-	     else conv_record ts env i
+             if not flags.with_cs then raise Not_found
+             else conv_record flags env i
                (try check_conv_record env i appr1 appr2
 		with Not_found -> check_conv_record env i appr2 appr1)
            with Not_found -> UnifFailure (i,NoCanonicalStructure))
@@ -770,7 +834,7 @@ and evar_eqappr_x ?(rhs_is_already_stuck = false) ts env evd pbty
             | Lambda _ -> assert (match args with [] -> true | _ -> false); true
             | LetIn (_,b,_,c) -> is_unnamed
 	     (fst (whd_betaiota_deltazeta_for_iota_state
-		      (fst ts) env i Cst_stack.empty (subst1 b c, args)))
+                      flags.open_ts env i Cst_stack.empty (subst1 b c, args)))
 	    | Fix _ -> true (* Partially applied fix can be the result of a whd call *)
 	    | Proj (p, _) -> Projection.unfolded p || Stack.not_purely_applicative args
             | Case _ | App _| Cast _ -> assert false in
@@ -778,20 +842,20 @@ and evar_eqappr_x ?(rhs_is_already_stuck = false) ts env evd pbty
 	    let applicative_stack = fst (Stack.strip_app sk2) in
 	    is_unnamed
 	      (fst (whd_betaiota_deltazeta_for_iota_state
-		      (fst ts) env i Cst_stack.empty (v2, applicative_stack))) in
+                      flags.open_ts env i Cst_stack.empty (v2, applicative_stack))) in
           let rhs_is_already_stuck =
             rhs_is_already_stuck || rhs_is_stuck_and_unnamed () in
 
 	  if (EConstr.isLambda i term1 || rhs_is_already_stuck)
 	    && (not (Stack.not_purely_applicative sk1)) then
-	    evar_eqappr_x ~rhs_is_already_stuck ts env i pbty
+            evar_eqappr_x ~rhs_is_already_stuck flags env i pbty
 	      (whd_betaiota_deltazeta_for_iota_state
-		 (fst ts) env i (Cst_stack.add_cst term1 csts1) (v1,sk1))
+                 flags.open_ts env i (Cst_stack.add_cst term1 csts1) (v1,sk1))
 	      (appr2,csts2)
 	  else
-	    evar_eqappr_x ts env i pbty (appr1,csts1)
+            evar_eqappr_x flags env i pbty (appr1,csts1)
 	      (whd_betaiota_deltazeta_for_iota_state
-		 (fst ts) env i (Cst_stack.add_cst term2 csts2) (v2,sk2))
+                 flags.open_ts env i (Cst_stack.add_cst term2 csts2) (v2,sk2))
 	in
 	ise_try evd [f1; f2; f3]
     end
@@ -799,13 +863,14 @@ and evar_eqappr_x ?(rhs_is_already_stuck = false) ts env evd pbty
     | Rigid, Rigid when EConstr.isLambda evd term1 && EConstr.isLambda evd term2 ->
         let (na1,c1,c'1) = EConstr.destLambda evd term1 in
         let (na2,c2,c'2) = EConstr.destLambda evd term2 in
-        assert app_empty;
         ise_and evd
-          [(fun i -> evar_conv_x ts env i CONV c1 c2);
+          [(fun i -> evar_conv_x flags env i CONV c1 c2);
            (fun i ->
 	     let c = nf_evar i c1 in
              let na = Nameops.Name.pick na1 na2 in
-	     evar_conv_x ts (push_rel (RelDecl.LocalAssum (na,c)) env) i CONV c'1 c'2)]
+             evar_conv_x flags (push_rel (RelDecl.LocalAssum (na,c)) env) i CONV c'1 c'2);
+           (** When in modulo_betaiota = false case, lambda's are not reduced *)
+           (fun i -> exact_ise_stack2 env i (evar_conv_x flags) sk1 sk2)]
 
     | Flexible ev1, Rigid -> flex_rigid true ev1 appr1 appr2
     | Rigid, Flexible ev2 -> flex_rigid false ev2 appr2 appr1
@@ -813,13 +878,13 @@ and evar_eqappr_x ?(rhs_is_already_stuck = false) ts env evd pbty
     | MaybeFlexible v1, Rigid ->
 	let f3 i =
 	  (try 
-	     if not (snd ts) then raise Not_found
-	     else conv_record ts env i (check_conv_record env i appr1 appr2)
+             if not flags.with_cs then raise Not_found
+             else conv_record flags env i (check_conv_record env i appr1 appr2)
            with Not_found -> UnifFailure (i,NoCanonicalStructure))
 	and f4 i =
-	  evar_eqappr_x ts env i pbty
+          evar_eqappr_x flags env i pbty
 	    (whd_betaiota_deltazeta_for_iota_state
-	       (fst ts) env i (Cst_stack.add_cst term1 csts1) (v1,sk1))
+               flags.open_ts env i (Cst_stack.add_cst term1 csts1) (v1,sk1))
 	    (appr2,csts2)
 	in
 	  ise_try evd [f3; f4]
@@ -827,13 +892,13 @@ and evar_eqappr_x ?(rhs_is_already_stuck = false) ts env evd pbty
     | Rigid, MaybeFlexible v2 ->
 	let f3 i =
 	  (try
-	     if not (snd ts) then raise Not_found
-	     else conv_record ts env i (check_conv_record env i appr2 appr1)
+             if not flags.with_cs then raise Not_found
+             else conv_record flags env i (check_conv_record env i appr2 appr1)
            with Not_found -> UnifFailure (i,NoCanonicalStructure))
 	and f4 i =
-	  evar_eqappr_x ts env i pbty (appr1,csts1)
+          evar_eqappr_x flags env i pbty (appr1,csts1)
 	    (whd_betaiota_deltazeta_for_iota_state
-	       (fst ts) env i (Cst_stack.add_cst term2 csts2) (v2,sk2))
+               flags.open_ts env i (Cst_stack.add_cst term2 csts2) (v2,sk2))
 	in
 	  ise_try evd [f3; f4]
 
@@ -862,72 +927,84 @@ and evar_eqappr_x ?(rhs_is_already_stuck = false) ts env evd pbty
 
 	| Prod (n1,c1,c'1), Prod (n2,c2,c'2) when app_empty ->
             ise_and evd
-              [(fun i -> evar_conv_x ts env i CONV c1 c2);
+              [(fun i -> evar_conv_x flags env i CONV c1 c2);
                (fun i ->
  	         let c = nf_evar i c1 in
                  let na = Nameops.Name.pick n1 n2 in
-	         evar_conv_x ts (push_rel (RelDecl.LocalAssum (na,c)) env) i pbty c'1 c'2)]
+                 evar_conv_x flags (push_rel (RelDecl.LocalAssum (na,c)) env) i pbty c'1 c'2)]
 
 	| Rel x1, Rel x2 ->
 	    if Int.equal x1 x2 then
-              exact_ise_stack2 env evd (evar_conv_x ts) sk1 sk2
+              exact_ise_stack2 env evd (evar_conv_x flags) sk1 sk2
             else UnifFailure (evd,NotSameHead)
 
 	| Var var1, Var var2 ->
 	    if Id.equal var1 var2 then
-              exact_ise_stack2 env evd (evar_conv_x ts) sk1 sk2
+              exact_ise_stack2 env evd (evar_conv_x flags) sk1 sk2
             else UnifFailure (evd,NotSameHead)
 
 	| Const _, Const _
 	| Ind _, Ind _ 
 	| Construct _, Construct _ ->
-	  rigids env evd sk1 term1 sk2 term2
+           rigids env evd sk1 term1 sk2 term2
+
+        | Evar (sp1,al1), Evar (sp2,al2) -> (** Frozen evars *)
+          if Evar.equal sp1 sp2 then
+            match ise_stack2 false env evd (evar_conv_x flags) sk1 sk2 with
+            |None, Success i' ->
+              (** FIXME: solve_refl can restrict the evar, do we want to allow that? *)
+              Success (solve_refl flags (fun p env i pbty a1 a2 ->
+                let flags = if p then default_flags env else flags in
+                is_success (evar_conv_x flags env i pbty a1 a2))
+                env i' (position_problem true pbty) sp1 al1 al2)
+            |_, (UnifFailure _ as x) -> x
+            |Some _, _ -> UnifFailure (evd,NotSameArgSize)
+          else UnifFailure (evd,NotSameHead)
 
 	| Construct u, _ ->
-	  eta_constructor ts env evd sk1 u sk2 term2
+          eta_constructor flags env evd sk1 u sk2 term2
 	    
 	| _, Construct u ->
-	  eta_constructor ts env evd sk2 u sk1 term1
+          eta_constructor flags env evd sk2 u sk1 term1
 
 	| Fix ((li1, i1),(_,tys1,bds1 as recdef1)), Fix ((li2, i2),(_,tys2,bds2)) -> (* Partially applied fixs *)
 	  if Int.equal i1 i2 && Array.equal Int.equal li1 li2 then
             ise_and evd [
-	      (fun i -> ise_array2 i (fun i' -> evar_conv_x ts env i' CONV) tys1 tys2);
-	      (fun i -> ise_array2 i (fun i' -> evar_conv_x ts (push_rec_types recdef1 env) i' CONV) bds1 bds2);
-	      (fun i -> exact_ise_stack2 env i (evar_conv_x ts) sk1 sk2)]
+              (fun i -> ise_array2 i (fun i' -> evar_conv_x flags env i' CONV) tys1 tys2);
+              (fun i -> ise_array2 i (fun i' -> evar_conv_x flags (push_rec_types recdef1 env) i' CONV) bds1 bds2);
+              (fun i -> exact_ise_stack2 env i (evar_conv_x flags) sk1 sk2)]
 	  else UnifFailure (evd, NotSameHead)
 
 	| CoFix (i1,(_,tys1,bds1 as recdef1)), CoFix (i2,(_,tys2,bds2)) ->
             if Int.equal i1 i2  then
               ise_and evd
                 [(fun i -> ise_array2 i
-                    (fun i -> evar_conv_x ts env i CONV) tys1 tys2);
+                    (fun i -> evar_conv_x flags env i CONV) tys1 tys2);
                  (fun i -> ise_array2 i
-		     (fun i -> evar_conv_x ts (push_rec_types recdef1 env) i CONV)
+                     (fun i -> evar_conv_x flags (push_rec_types recdef1 env) i CONV)
 		     bds1 bds2);
                  (fun i -> exact_ise_stack2 env i
-                     (evar_conv_x ts) sk1 sk2)]
+                     (evar_conv_x flags) sk1 sk2)]
             else UnifFailure (evd,NotSameHead)
 
 	| (Meta _, _) | (_, Meta _) ->
-	  begin match ise_stack2 true env evd (evar_conv_x ts) sk1 sk2 with
+          begin match ise_stack2 true env evd (evar_conv_x flags) sk1 sk2 with
 	  |_, (UnifFailure _ as x) -> x
-	  |None, Success i' -> evar_conv_x ts env i' CONV term1 term2
-	  |Some (sk1',sk2'), Success i' -> evar_conv_x ts env i' CONV (Stack.zip i' (term1,sk1')) (Stack.zip i' (term2,sk2'))
+          |None, Success i' -> evar_conv_x flags env i' CONV term1 term2
+          |Some (sk1',sk2'), Success i' -> evar_conv_x flags env i' CONV (Stack.zip i' (term1,sk1')) (Stack.zip i' (term2,sk2'))
 	  end
 
-	| (Ind _ | Sort _ | Prod _ | CoFix _ | Fix _ | Rel _ | Var _ | Const _), _ ->
+        | (Ind _ | Sort _ | Prod _ | CoFix _ | Fix _ | Rel _ | Var _ | Const _ | Evar _ | Lambda _), _ ->
 	  UnifFailure (evd,NotSameHead)
-	| _, (Ind _ | Sort _ | Prod _ | CoFix _ | Fix _ | Rel _ | Var _ | Const _) ->
+        | _, (Ind _ | Sort _ | Prod _ | CoFix _ | Fix _ | Rel _ | Var _ | Const _ | Evar _ | Lambda _) ->
 	  UnifFailure (evd,NotSameHead)
-
-	| (App _ | Cast _ | Case _ | Proj _), _ -> assert false
-	| (LetIn _| Evar _), _ -> assert false
-	| (Lambda _), _ -> assert false
-
+        | Case _, _ -> UnifFailure (evd,NotSameHead)
+        | Proj _, _ -> UnifFailure (evd,NotSameHead)
+        | (App _ | Cast _), _ -> assert false
+        | LetIn _, _ -> assert false
       end
 
-and conv_record trs env evd (ctx,(h,h2),c,bs,(params,params1),(us,us2),(sk1,sk2),c1,(n,t2)) =
+and conv_record flags env evd (ctx,(h,h2),c,bs,(params,params1),(us,us2),(sk1,sk2),c1,(n,t2)) =
   (* Tries to unify the states
 
         (proji params1 c1 | sk1)   =   (proji params2 (c (?xs:bs)) | sk2)
@@ -958,7 +1035,7 @@ and conv_record trs env evd (ctx,(h,h2),c,bs,(params,params1),(us,us2),(sk1,sk2)
 	(fun (i,ks,m,test) b ->
 	  if match n with Some n -> Int.equal m n | None -> false then
 	    let ty = Retyping.get_type_of env i t2 in
-	    let test i = evar_conv_x trs env i CUMUL ty (substl ks b) in
+            let test i = evar_conv_x flags env i CUMUL ty (substl ks b) in
 	      (i,t2::ks, m-1, test)
 	  else
 	    let dloc = Loc.tag Evar_kinds.InternalHole in
@@ -970,20 +1047,20 @@ and conv_record trs env evd (ctx,(h,h2),c,bs,(params,params1),(us,us2),(sk1,sk2)
     ise_and evd'
       [(fun i ->
 	exact_ise_stack2 env i
-          (fun env' i' cpb x1 x -> evar_conv_x trs env' i' cpb x1 (substl ks x))
+          (fun env' i' cpb x1 x -> evar_conv_x flags env' i' cpb x1 (substl ks x))
           params1 params);
        (fun i ->
 	 exact_ise_stack2 env i
-           (fun env' i' cpb u1 u -> evar_conv_x trs env' i' cpb u1 (substl ks u))
+           (fun env' i' cpb u1 u -> evar_conv_x flags env' i' cpb u1 (substl ks u))
            us2 us);
-       (fun i -> evar_conv_x trs env i CONV c1 app);
-       (fun i -> exact_ise_stack2 env i (evar_conv_x trs) sk1 sk2);
+       (fun i -> evar_conv_x flags env i CONV c1 app);
+       (fun i -> exact_ise_stack2 env i (evar_conv_x flags) sk1 sk2);
        test;
-       (fun i -> evar_conv_x trs env i CONV h2
+       (fun i -> evar_conv_x flags env i CONV h2
 	 (fst (decompose_app_vect i (substl ks h))))]
   else UnifFailure(evd,(*dummy*)NotSameHead)
 
-and eta_constructor ts env evd sk1 ((ind, i), u) sk2 term2 =
+and eta_constructor flags env evd sk1 ((ind, i), u) sk2 term2 =
   let mib = lookup_mind (fst ind) env in
     match mib.Declarations.mind_record with
     | Some (Some (id, projs, pbs)) when mib.Declarations.mind_finite == Declarations.BiFinite ->
@@ -994,15 +1071,15 @@ and eta_constructor ts env evd sk1 ((ind, i), u) sk2 term2 =
 	     let term = Stack.zip evd (term2,sk2) in 
 	       List.map (fun p -> EConstr.mkProj (Projection.make p false, term)) (Array.to_list projs)
 	   in
-	     exact_ise_stack2 env evd (evar_conv_x (fst ts, false)) l1' 
+             exact_ise_stack2 env evd (evar_conv_x { flags with with_cs = false}) l1'
 	       (Stack.append_app_list l2' Stack.empty)
-	 with 
+         with
 	 | Invalid_argument _ ->
 	   (* Stack.tail: partially applied constructor *)
 	   UnifFailure(evd,NotSameHead))
     | _ -> UnifFailure (evd,NotSameHead)
 
-let evar_conv_x ts = evar_conv_x (ts, true)
+let evar_conv_x flags = evar_conv_x flags
 
 (* Profiling *)
 let evar_conv_x =
@@ -1013,25 +1090,26 @@ let evar_conv_x =
 
 let evar_conv_hook_get, evar_conv_hook_set = Hook.make ~default:evar_conv_x ()
 
-let evar_conv_x ts = Hook.get evar_conv_hook_get ts
+let evar_conv_x flags = Hook.get evar_conv_hook_get flags
 
 let set_evar_conv f = Hook.set evar_conv_hook_set f
 
 
 (* We assume here |l1| <= |l2| *)
 
-let first_order_unification ts env evd (ev1,l1) (term2,l2) =
+let first_order_unification flags env evd (ev1,l1) (term2,l2) =
   let (deb2,rest2) = Array.chop (Array.length l2-Array.length l1) l2 in
   ise_and evd
     (* First compare extra args for better failure message *)
-    [(fun i -> ise_array2 i (fun i -> evar_conv_x ts env i CONV) rest2 l1);
+    [(fun i -> ise_array2 i (fun i -> evar_conv_x flags env i CONV) rest2 l1);
     (fun i ->
       (* Then instantiate evar unless already done by unifying args *)
       let t2 = mkApp(term2,deb2) in
       if is_defined i (fst ev1) then
-	evar_conv_x ts env i CONV t2 (mkEvar ev1)
+        evar_conv_x flags env i CONV t2 (mkEvar ev1)
       else
-	solve_simple_eqn ~choose:true (evar_conv_x ts) env i (None,ev1,t2))]
+        solve_simple_eqn ~choose:true ~imitate_defs:false
+                         flags (conv_fun evar_conv_x flags) env i (None,ev1,t2))]
 
 let choose_less_dependent_instance evk evd term args =
   let evi = Evd.find_undefined evd evk in
@@ -1041,7 +1119,7 @@ let choose_less_dependent_instance evk evd term args =
   | [] -> None
   | (id, _) :: _ -> Some (Evd.define evk (mkVar id) evd)
 
-let apply_on_subterm env evdref f c t =
+(*let apply_on_subterm env evdref f c t =
   let rec applyrec (env,(k,c) as acc) t =
     (* By using eq_constr, we make an approximation, for instance, we *)
     (* could also be interested in finding a term u convertible to t *)
@@ -1063,6 +1141,57 @@ let apply_on_subterm env evdref f c t =
         map_constr_with_binders_left_to_right !evdref
 	  (fun d (env,(k,c)) -> (push_rel d env, (k+1,lift 1 c)))
 	  applyrec acc t
+ *)
+
+type occurrence_match_test =
+  env -> evar_map -> constr ->
+  env -> evar_map -> int -> constr -> constr -> bool * evar_map
+
+type prefer_abstraction = bool
+
+type occurrence_selection =
+  | AtOccurrences of Locus.occurrences
+  | Unspecified of prefer_abstraction
+
+type occurrences_selection =
+  occurrence_match_test * occurrence_selection list
+
+let default_occurrence_selection = Unspecified false
+
+let default_occurrence_test ~frozen_evars ts _ origsigma _ env sigma _ c pat =
+  let flags = { (default_flags_of ~subterm_ts:ts ts) with frozen_evars } in
+  match evar_conv_x flags env sigma CONV c pat with
+  | Success sigma -> true, sigma
+  | UnifFailure _ -> false, sigma
+
+let default_occurrences_selection ?(frozen_evars=Evar.Set.empty) ts n =
+  (default_occurrence_test ~frozen_evars ts,
+   List.init n (fun _ -> default_occurrence_selection))
+
+let apply_on_subterm env evdref fixedref f test c t =
+  let test = test env !evdref c in
+  let prc env = print_constr_env env !evdref in
+  let rec applyrec (env,(k,c) as acc) t =
+    if Evar.Set.exists (fun fixed -> occur_evar !evdref fixed t) !fixedref then
+      match EConstr.kind !evdref t with
+      | Evar (ev, args) when Evar.Set.mem ev !fixedref -> t
+      | _ -> map_constr_with_binders_left_to_right !evdref
+              (fun d (env,(k,c)) -> (push_rel d env, (k+1,lift 1 c)))
+              applyrec acc t
+    else
+    (if !debug_ho_unification then
+     Feedback.msg_debug Pp.(str"Testing " ++ prc env c ++ str" against " ++ prc env t);
+     let b, evd =
+        try test env !evdref k c t
+        with e when CErrors.noncritical e -> assert false in
+     if b then (evdref := evd;
+                if !debug_ho_unification then Feedback.msg_debug (Pp.str "succeeded");
+                f k t)
+     else (
+       if !debug_ho_unification then Feedback.msg_debug (Pp.str "failed");
+       map_constr_with_binders_left_to_right !evdref
+        (fun d (env,(k,c)) -> (push_rel d env, (k+1,lift 1 c)))
+        applyrec acc t))
   in
   applyrec (env,(0,c)) t
 
@@ -1109,85 +1238,209 @@ let set_solve_evars f = solve_evars := f
  * proposition from Dan Grayson]
  *)
 
+let check_selected_occs env sigma c occ occs =
+  let notfound =
+    match occs with
+    | AtOccurrences occs ->
+       (match occs with
+       | Locus.AtLeastOneOccurrence -> occ == 1
+       | Locus.AllOccurrences -> false
+       | Locus.AllOccurrencesBut l -> List.last l > occ
+       | Locus.OnlyOccurrences l -> List.last l > occ
+       | Locus.NoOccurrences -> false)
+    | Unspecified abstract -> false
+  in if notfound then
+     raise (PretypeError (env,sigma,NoOccurrenceFound (c,None)))
+     else ()
+
 exception TypingFailed of evar_map
 
-let second_order_matching ts env_rhs evd (evk,args) argoccs rhs =
+let set_of_evctx l =
+  List.fold_left (fun s decl -> Id.Set.add (NamedDecl.get_id decl) s) Id.Set.empty l
+
+(** Weaken the existentials so that they can be typed in sign and raise
+    an error if the term otherwise mentions variables not bound in sign. *)
+let thin_evars env sigma sign c =
+  let evdref = ref sigma in
+  let ctx = set_of_evctx sign in
+  let rec applyrec (env,acc) t =
+    match kind sigma t with
+    | Evar (ev, args) ->
+       let evi = Evd.find_undefined sigma ev in
+       let filter = Array.map (fun c -> Id.Set.subset (collect_vars sigma c) ctx) args in
+       let filter = Filter.make (Array.to_list filter) in
+       let candidates = Option.map (List.map EConstr.of_constr) (evar_candidates evi) in
+       let evd, ev = restrict_evar !evdref ev filter candidates in
+       evdref := evd; whd_evar !evdref t
+    | Var id ->
+       if not (Id.Set.mem id ctx) then raise (TypingFailed sigma)
+       else t
+    | _ ->
+       map_constr_with_binders_left_to_right !evdref
+        (fun d (env,acc) -> (push_rel d env, acc+1))
+        applyrec (env,acc) t
+  in
+  let c' = applyrec (env,0) c in
+  (!evdref, c')
+
+let second_order_matching flags env_rhs evd (evk,args) (test,argoccs) rhs =
   try
   let evi = Evd.find_undefined evd evk in
+  let evi = nf_evar_info evd evi in
+  let env_evar_unf = evar_env evi in
   let env_evar = evar_filtered_env evi in
   let sign = named_context_val env_evar in
   let ctxt = evar_filtered_context evi in
-  let instance = List.map mkVar (List.map NamedDecl.get_id ctxt) in
-
+  if !debug_ho_unification then
+    (Feedback.msg_debug Pp.(str"env rhs: " ++ print_env env_rhs);
+     Feedback.msg_debug Pp.(str"env evars: " ++ print_env env_evar));
+  let args = Array.map (nf_evar evd) args in
+  let vars = List.map NamedDecl.get_id ctxt in
+  let argsubst = List.map2 (fun id c -> (id, c)) vars (Array.to_list args) in
+  let instance = List.map mkVar vars in
+  let rhs = nf_evar evd rhs in
+  if not (noccur_evar env_rhs evd evk rhs) then raise (TypingFailed evd);
+  (** Ensure that any progress made by Typing.e_solve_evars will not contradict
+      the solution we are trying to build here by adding the problem as a constraint. *)
+  let evd = Evarutil.add_unification_pb (CONV,env_rhs,mkEvar (evk,args),rhs) evd in
+  let evdref = ref evd in
+  let prc env c = print_constr_env env !evdref c in
   let rec make_subst = function
   | decl'::ctxt', c::l, occs::occsl when isVarId evd (NamedDecl.get_id decl') c ->
       begin match occs with
-      | Some _ ->
-        user_err Pp.(str "Cannot force abstraction on identity instance.")
-      | None ->
+      | AtOccurrences loc when not (Locusops.is_all_occurrences loc) ->
+      user_err Pp.(str "Cannot force abstraction on identity instance.")
+      | _ ->
         make_subst (ctxt',l,occsl)
       end
   | decl'::ctxt', c::l, occs::occsl ->
       let id = NamedDecl.get_id decl' in
       let t = NamedDecl.get_type decl' in
       let evs = ref [] in
-      let ty = Retyping.get_type_of env_rhs evd c in
-      let filter' = filter_possible_projections evd c ty ctxt args in
+      let c = nf_evar evd c in
+      (* ty is in env_rhs now *)
+      let ty = replace_vars argsubst t in
+      let filter' = filter_possible_projections !evdref c (nf_evar evd ty) ctxt args in
       (id,t,c,ty,evs,Filter.make filter',occs) :: make_subst (ctxt',l,occsl)
   | _, _, [] -> []
-  | _ -> anomaly (Pp.str "Signature or instance are shorter than the occurrences list.") in
-
-  let rec set_holes evdref rhs = function
-  | (id,_,c,cty,evsref,filter,occs)::subst ->
-      let set_var k =
-        match occs with
-        | Some (Locus.AtLeastOneOccurrence | Locus.AllOccurrences) -> mkVar id
-        | Some _ -> user_err Pp.(str "Selection of specific occurrences not supported")
-        | None ->
-        let evty = set_holes evdref cty subst in
+  | _ -> anomaly (Pp.str "Signature or instance are shorter than the occurrences list") in
+  let fixed = ref Evar.Set.empty in
+  let rec set_holes env_rhs evdref rhs = function
+  | (id,idty,c,cty,evsref,filter,occs)::subst ->
+     let c = nf_evar !evdref c in
+     if !debug_ho_unification then
+       Feedback.msg_debug Pp.(str"set holes for: " ++
+                                prc env_rhs (mkVar id) ++ spc () ++
+                                prc env_rhs c ++ str" in " ++
+                                prc env_rhs rhs);
+     let occ = ref 1 in
+     let set_var k inst =
+       let oc = !occ in
+       if !debug_ho_unification then
+       (Feedback.msg_debug Pp.(str"Found one occurrence");
+        Feedback.msg_debug Pp.(str"cty: " ++ prc env_rhs c));
+       incr occ;
+       match occs with
+       | AtOccurrences occs ->
+          if Locusops.is_selected oc occs then mkVar id
+          else inst
+       | Unspecified prefer_abstraction ->
+          let evty = set_holes env_rhs evdref cty subst in
+          let evty = nf_evar !evdref evty in
+        if !debug_ho_unification then
+          Feedback.msg_debug Pp.(str"abstracting one occurrence " ++ prc env_rhs inst ++
+                                   str" of type: " ++ prc env_evar evty ++
+                                   str " for " ++ prc env_rhs c);
         let instance = Filter.filter_list filter instance in
-        let evd = !evdref in
+        (** Allow any type lower than the variable's type as the
+            abstracted subterm might have a smaller type, which could be
+            crucial to make the surrounding context typecheck. *)
+        let evd, evty =
+          if isArity !evdref evty then
+            refresh_universes ~status:Evd.univ_flexible (Some true)
+                              env_evar_unf !evdref evty
+          else !evdref, evty in
         let (evd, ev) = new_evar_instance sign evd evty ~filter instance in
+        let evk = fst (destEvar !evdref ev) in
         evdref := evd;
-        evsref := (fst (destEvar !evdref ev),evty)::!evsref;
-        ev in
-      set_holes evdref (apply_on_subterm env_rhs evdref set_var c rhs) subst
+        evsref := (evk,evty,inst,prefer_abstraction)::!evsref;
+        fixed := Evar.Set.add evk !fixed;
+        ev
+     in
+     let rhs' = apply_on_subterm env_rhs evdref fixed set_var test c rhs in
+     if !debug_ho_unification then
+       Feedback.msg_debug Pp.(str"abstracted: " ++ prc env_rhs rhs');
+     let () =
+       check_selected_occs env_rhs !evdref c !occ occs
+     in set_holes (push_named (Context.Named.Declaration.LocalAssum (id,idty)) env_rhs)
+                  evdref rhs' subst
   | [] -> rhs in
 
   let subst = make_subst (ctxt,Array.to_list args,argoccs) in
 
-  let evd, rhs =
-    let evdref = ref evd in
-    let rhs = set_holes evdref rhs subst in
-    !evdref, rhs
-  in
-
+  let rhs' = set_holes env_rhs evdref rhs subst in
+  let evd = !evdref in
+  let rhs' = nf_evar evd rhs' in
+  (** Thin evars making the term typable in env_evar *)
+  let evd, rhs' = thin_evars env_evar evd ctxt rhs' in
   (* We instantiate the evars of which the value is forced by typing *)
-  let evd,rhs =
-    try !solve_evars env_evar evd rhs
+  if !debug_ho_unification then
+    (Feedback.msg_debug Pp.(str"solve_evars on: " ++ prc env_evar rhs');
+     Feedback.msg_debug Pp.(str"evars: " ++ pr_evar_map (Some 0) evd));
+  let evd,rhs' =
+    try !solve_evars env_evar evd rhs'
     with e when Pretype_errors.precatchable_exception e ->
       (* Could not revert all subterms *)
-      raise (TypingFailed evd) in
+      raise (TypingFailed !evdref) in
+  let rhs' = nf_evar evd rhs' in
+  (* We instantiate the evars of which the value is forced by typing *)
+  if !debug_ho_unification then
+    (Feedback.msg_debug Pp.(str"after solve_evars: " ++ prc env_evar rhs');
+     Feedback.msg_debug Pp.(str"evars: " ++ pr_evar_map (Some 0) evd));
 
   let rec abstract_free_holes evd = function
-  | (id,idty,c,_,evsref,_,_)::l ->
+   | (id,idty,c,cty,evsref,_,_)::l ->
+     let c = nf_evar evd c in
+     if !debug_ho_unification then
+       Feedback.msg_debug Pp.(str"abstracting: " ++
+                                prc env_rhs (mkVar id) ++ spc () ++
+                                prc env_rhs c);
       let rec force_instantiation evd = function
-      | (evk,evty)::evs ->
-          let evd =
+      | (evk,evty,inst,abstract)::evs ->
+         let evk = Option.default evk (Evarutil.advance evd evk) in
+         let evd =
             if is_undefined evd evk then
-              (* We force abstraction over this unconstrained occurrence *)
+              (* We try abstraction or concretisation for *)
+              (* this unconstrained occurrence *)
               (* and we use typing to propagate this instantiation *)
-              (* This is an arbitrary choice *)
-              let evd = Evd.define evk (mkVar id) evd in
-              match evar_conv_x ts env_evar evd CUMUL idty evty with
-              | UnifFailure _ -> user_err Pp.(str "Cannot find an instance")
-              | Success evd ->
-              match reconsider_unif_constraints (evar_conv_x ts) evd with
-              | UnifFailure _ -> user_err Pp.(str "Cannot find an instance")
-              | Success evd ->
-              evd
+              (* We avoid making an arbitrary choice by leaving candidates *)
+              (* if both can work *)
+              let evi = Evd.find_undefined evd evk in
+              let vid = mkVar id in
+              let candidates = [inst; vid] in
+              try
+                let evd, ev = Evarutil.restrict_evar evd evk (Evd.evar_filter evi) (Some candidates) in
+                let evi = Evd.find evd ev in
+                (match evar_candidates evi with
+                 | Some [t] ->
+                    if not (noccur_evar env_rhs evd ev (EConstr.of_constr t)) then
+                      raise (TypingFailed evd);
+                    let evd = Evd.define ev (EConstr.of_constr t) evd in
+                    check_evar_instance evd ev (EConstr.of_constr t) (conv_fun evar_conv_x flags)
+                 | Some l when abstract && List.exists (fun c -> isVarId evd id (EConstr.of_constr c)) l ->
+                    let evd = Evd.define ev vid evd in
+                    check_evar_instance evd ev vid (conv_fun evar_conv_x flags)
+                 | _ -> evd)
+              with e -> user_err (Pp.str "Cannot find an instance")
             else
-              evd
+              ((if !debug_ho_unification then
+                  let evi = Evd.find evd evk in
+                  let env = Evd.evar_env evi in
+                  Feedback.msg_debug Pp.(str"evar is defined: " ++
+                     int (Evar.repr evk) ++ spc () ++
+                     prc env (match evar_body evi with Evar_defined c -> c
+                                                     | Evar_empty -> assert false)));
+               evd)
           in
           force_instantiation evd evs
       | [] ->
@@ -1195,31 +1448,81 @@ let second_order_matching ts env_rhs evd (evk,args) argoccs rhs =
       in
       force_instantiation evd !evsref
   | [] ->
-    let evd = 
-      try Evarsolve.check_evar_instance evd evk rhs
-	    (evar_conv_x full_transparent_state)
-      with IllTypedInstance _ -> raise (TypingFailed evd)
-    in
-      Evd.define evk rhs evd
+     if Evd.is_defined evd evk then
+       (** Can happen due to dependencies: instantiating evars in the arguments of evk might
+           instantiate evk itself. *)
+       (if !debug_ho_unification then
+          begin
+            let evi = Evd.find evd evk in
+            let evenv = evar_env evi in
+            let body = match evar_body evi with Evar_empty -> assert false | Evar_defined c -> c in
+            Feedback.msg_debug Pp.(str"evar was defined already as: " ++ prc evenv body)
+          end;
+        evd)
+     else
+       let evd =
+         try
+           let evi = Evd.find_undefined evd evk in
+           let evenv = evar_env evi in
+           let evdref = ref evd in
+           let rhs' = nf_evar !evdref rhs' in
+           if !debug_ho_unification then
+             Feedback.msg_debug Pp.(str"abstracted type before second solve_evars: " ++
+                                      prc evenv rhs');
+           (** solve_evars is not commuting with nf_evar, because restricting
+               an evar might provide a more specific type. *)
+           let evd, _ = !solve_evars evenv evd rhs' in
+           evdref := evd;
+           (* Feedback.msg_debug Pp.(str"evenv: " ++ print_named_context evenv); *)
+           if !debug_ho_unification then
+             Feedback.msg_debug Pp.(str"abstracted type: " ++ prc evenv (nf_evar !evdref rhs'));
+           Evarsolve.check_evar_instance !evdref evk rhs'
+                                         (conv_fun evar_conv_x (default_flags_of full_transparent_state))
+         with IllTypedInstance _ -> raise (TypingFailed evd)
+       in
+      Evd.define evk rhs' evd
   in
-  abstract_free_holes evd subst, true
+  let evd = abstract_free_holes evd subst in
+  evd, true
   with TypingFailed evd -> evd, false
 
-let second_order_matching_with_args ts env evd pbty ev l t =
-(*
-  let evd,ev = evar_absorb_arguments env evd ev l in
-  let argoccs = Array.map_to_list (fun _ -> None) (snd ev) in
-  let evd, b = second_order_matching ts env evd ev argoccs t in
-  if b then Success evd
-  else UnifFailure (evd, ConversionFailed (env,mkApp(mkEvar ev,l),t))
-  if b then Success evd else
- *)
-  let pb = (pbty,env,mkApp(mkEvar ev,l),t) in
-  UnifFailure (evd, CannotSolveConstraint (pb,ProblemBeyondCapabilities))
+let default_evar_selection flags evd (ev,args) =
+  let evi = Evd.find_undefined evd ev in
+  let rec aux args abs =
+    match args, abs with
+    | _ :: args, a :: abs ->
+       let spec = if not flags.allow_K_at_toplevel then
+                    AtOccurrences (if a then Locus.AtLeastOneOccurrence else Locus.AllOccurrences)
+                  else Unspecified a in
+       spec :: aux args abs
+    | l, [] -> List.map (fun _ -> default_occurrence_selection) l
+    | [], _ :: _ -> assert false
+  in aux (Array.to_list args) evi.evar_abstract_arguments
 
-let apply_conversion_problem_heuristic ts env evd pbty t1 t2 =
-  let t1 = apprec_nohdbeta ts env evd (whd_head_evar evd t1) in
-  let t2 = apprec_nohdbeta ts env evd (whd_head_evar evd t2) in
+let second_order_matching_with_args flags env evd with_ho pbty ev l t =
+  if with_ho then
+    let evd,ev = evar_absorb_arguments env evd ev (Array.to_list l) in
+    let argoccs = default_evar_selection flags evd ev in
+    let test = default_occurrence_test ~frozen_evars:flags.frozen_evars flags.subterm_ts in
+    let evd, b =
+      try second_order_matching flags env evd ev (test,argoccs) t
+      with PretypeError (_, _, NoOccurrenceFound _) -> evd, false
+    in
+    if b then Success evd
+    else
+      UnifFailure (evd, ConversionFailed (env,mkApp(mkEvar ev,l),t))
+  else
+    let pb = (pbty,env,mkApp(mkEvar ev,l),t) in
+    UnifFailure (evd, CannotSolveConstraint (pb,ProblemBeyondCapabilities))
+
+let is_beyond_capabilities = function
+  | CannotSolveConstraint (pb,ProblemBeyondCapabilities) -> true
+  | _ -> false
+
+(* TODO frozen *)
+let apply_conversion_problem_heuristic flags env evd with_ho pbty t1 t2 =
+  let t1 = apprec_nohdbeta flags env evd (whd_head_evar evd t1) in
+  let t2 = apprec_nohdbeta flags env evd (whd_head_evar evd t2) in
   let (term1,l1 as appr1) = try destApp evd t1 with DestKO -> (t1, [||]) in
   let (term2,l2 as appr2) = try destApp evd t2 with DestKO -> (t2, [||]) in
   let () = if !debug_unification then
@@ -1249,36 +1552,38 @@ let apply_conversion_problem_heuristic ts env evd pbty t1 t2 =
          let reason = ProblemBeyondCapabilities in
          UnifFailure (evd, CannotSolveConstraint ((pbty,env,t1,t2),reason)))
   | Evar (evk1,args1), Evar (evk2,args2) when Evar.equal evk1 evk2 ->
-      let f env evd pbty x y = is_fconv ~reds:ts pbty env evd x y in
-      Success (solve_refl ~can_drop:true f env evd
+     let f ontype env evd pbty x y =
+       let reds = if ontype then full_transparent_state else flags.open_ts in
+       is_fconv ~reds pbty env evd x y in
+      Success (solve_refl ~can_drop:true flags f env evd
                  (position_problem true pbty) evk1 args1 args2)
   | Evar ev1, Evar ev2 when app_empty ->
       Success (solve_evar_evar ~force:true
-        (evar_define (evar_conv_x ts) ~choose:true) (evar_conv_x ts) env evd
+        flags (evar_define flags (conv_fun evar_conv_x flags) ~choose:true) (conv_fun evar_conv_x flags) env evd
         (position_problem true pbty) ev1 ev2)
   | Evar ev1,_ when Array.length l1 <= Array.length l2 ->
       (* On "?n t1 .. tn = u u1 .. u(n+p)", try first-order unification *)
       (* and otherwise second-order matching *)
       ise_try evd
-        [(fun evd -> first_order_unification ts env evd (ev1,l1) appr2);
+        [(fun evd -> first_order_unification flags env evd (ev1,l1) appr2);
          (fun evd ->
-           second_order_matching_with_args ts env evd pbty ev1 l1 t2)]
+           second_order_matching_with_args flags env evd with_ho pbty ev1 l1 t2)]
   | _,Evar ev2 when Array.length l2 <= Array.length l1 ->
       (* On "u u1 .. u(n+p) = ?n t1 .. tn", try first-order unification *)
       (* and otherwise second-order matching *)
       ise_try evd
-        [(fun evd -> first_order_unification ts env evd (ev2,l2) appr1);
+        [(fun evd -> first_order_unification flags env evd (ev2,l2) appr1);
          (fun evd ->
-           second_order_matching_with_args ts env evd pbty ev2 l2 t1)]
+           second_order_matching_with_args flags env evd with_ho pbty ev2 l2 t1)]
   | Evar ev1,_ ->
       (* Try second-order pattern-matching *)
-      second_order_matching_with_args ts env evd pbty ev1 l1 t2
+      second_order_matching_with_args flags env evd with_ho pbty ev1 l1 t2
   | _,Evar ev2 ->
       (* Try second-order pattern-matching *)
-      second_order_matching_with_args ts env evd pbty ev2 l2 t1
+      second_order_matching_with_args flags env evd with_ho pbty ev2 l2 t1
   | _ ->
       (* Some head evar have been instantiated, or unknown kind of problem *)
-      evar_conv_x ts env evd pbty t1 t2
+      evar_conv_x flags env evd pbty t1 t2
 
 let error_cannot_unify env evd pb ?reason t1 t2 =
   Pretype_errors.error_cannot_unify
@@ -1307,7 +1612,7 @@ let max_undefined_with_candidates evd =
   with MaxUndefined ans ->
     Some ans
 
-let rec solve_unconstrained_evars_with_candidates ts evd =
+let rec solve_unconstrained_evars_with_candidates flags evd =
   (* max_undefined is supposed to return the most recent, hence
      possibly most dependent evar *)
   match max_undefined_with_candidates evd with
@@ -1317,11 +1622,11 @@ let rec solve_unconstrained_evars_with_candidates ts evd =
       | [] -> user_err Pp.(str "Unsolvable existential variables.")
       | a::l ->
           try
-            let conv_algo = evar_conv_x ts in
+            let conv_algo = conv_fun evar_conv_x flags in
             let evd = check_evar_instance evd evk a conv_algo in
             let evd = Evd.define evk a evd in
             match reconsider_unif_constraints conv_algo evd with
-            | Success evd -> solve_unconstrained_evars_with_candidates ts evd
+            | Success evd -> solve_unconstrained_evars_with_candidates flags evd
             | UnifFailure _ -> aux l
           with
           | IllTypedInstance _ -> aux l
@@ -1329,7 +1634,7 @@ let rec solve_unconstrained_evars_with_candidates ts evd =
       (* List.rev is there to favor most dependent solutions *)
       (* and favor progress when used with the refine tactics *)
       let evd = aux (List.rev l) in
-      solve_unconstrained_evars_with_candidates ts evd
+      solve_unconstrained_evars_with_candidates flags evd
 
 let solve_unconstrained_impossible_cases env evd =
   Evd.fold_undefined (fun evk ev_info evd' ->
@@ -1338,35 +1643,41 @@ let solve_unconstrained_impossible_cases env evd =
       let j, ctx = coq_unit_judge () in
       let evd' = Evd.merge_context_set Evd.univ_flexible_alg ?loc evd' ctx in
       let ty = j_type j in
-      let conv_algo = evar_conv_x full_transparent_state in
+      let conv_algo = conv_fun evar_conv_x (default_flags env) in
       let evd' = check_evar_instance evd' evk ty conv_algo in
         Evd.define evk ty evd'
     | _ -> evd') evd evd
 
 let solve_unif_constraints_with_heuristics env
-    ?(ts=Conv_oracle.get_transp_state (Environ.oracle env)) evd =
-  let evd = solve_unconstrained_evars_with_candidates ts evd in
+    ?(flags=default_flags env) ?(with_ho=false) evd =
+  let evd = solve_unconstrained_evars_with_candidates flags evd in
   let rec aux evd pbs progress stuck =
     match pbs with
     | (pbty,env,t1,t2 as pb) :: pbs ->
-        (match apply_conversion_problem_heuristic ts env evd pbty t1 t2 with
+        (match apply_conversion_problem_heuristic flags env evd with_ho pbty t1 t2 with
 	| Success evd' ->
-	    let (evd', rest) = extract_all_conv_pbs evd' in
-            begin match rest with
+           let evd' = solve_unconstrained_evars_with_candidates flags evd' in
+           let (evd', rest) = extract_all_conv_pbs evd' in
+           begin match rest with
             | [] -> aux evd' pbs true stuck
-            | _ -> (* Unification got actually stuck, postpone *)
-	      aux evd pbs progress (pb :: stuck)
+            | l ->
+               (* Unification got actually stuck, postpone *)
+               let reason = CannotSolveConstraint (pb,ProblemBeyondCapabilities) in
+               aux evd pbs progress ((pb, reason):: stuck)
             end
         | UnifFailure (evd,reason) ->
-           error_cannot_unify env evd pb ~reason t1 t2)
+           if is_beyond_capabilities reason then
+             aux evd pbs progress ((pb,reason) :: stuck)
+           else aux evd [] false ((pb,reason) :: stuck))
     | _ -> 
-	if progress then aux evd stuck false []
+        if progress then aux evd (List.map fst stuck) false []
 	else 
 	  match stuck with
 	  | [] -> (* We're finished *) evd
-	  | (pbty,env,t1,t2 as pb) :: _ ->
-             (* There remains stuck problems *)
-             error_cannot_unify env evd pb t1 t2
+          | ((pbty,env,t1,t2 as pb), reason) :: _ ->
+              (* There remains stuck problems *)
+              Pretype_errors.error_cannot_unify ?loc:(loc_of_conv_pb evd pb)
+                env evd ~reason (t1, t2)
   in
   let (evd,pbs) = extract_all_conv_pbs evd in
   let heuristic_solved_evd = aux evd pbs false [] in
@@ -1379,16 +1690,15 @@ let consider_remaining_unif_problems = solve_unif_constraints_with_heuristics
 
 exception UnableToUnify of evar_map * unification_error
 
-let default_transparent_state env = full_transparent_state
-(* Conv_oracle.get_transp_state (Environ.oracle env) *)
-
 let the_conv_x env ?(ts=default_transparent_state env) t1 t2 evd =
-  match evar_conv_x ts env evd CONV  t1 t2 with
+  let flags = default_flags_of ts in
+  match evar_conv_x flags env evd CONV  t1 t2 with
   | Success evd' -> evd'
   | UnifFailure (evd',e) -> raise (UnableToUnify (evd',e))
 
 let the_conv_x_leq env ?(ts=default_transparent_state env) t1 t2 evd =
-  match evar_conv_x ts env evd CUMUL t1 t2 with
+  let flags = default_flags_of ts in
+  match evar_conv_x flags env evd CUMUL t1 t2 with
   | Success evd' -> evd'
   | UnifFailure (evd',e) -> raise (UnableToUnify (evd',e))
 
@@ -1397,17 +1707,39 @@ let make_opt = function
   | UnifFailure _ -> None
 
 let conv env ?(ts=default_transparent_state env) evd t1 t2 =
-  make_opt(evar_conv_x ts env evd CONV t1 t2)
+  let flags = default_flags_of ts in
+  make_opt(evar_conv_x flags env evd CONV t1 t2)
 
 let cumul env ?(ts=default_transparent_state env) evd t1 t2 =
-  make_opt(evar_conv_x ts env evd CUMUL t1 t2)
+  let flags = default_flags_of ts in
+  make_opt(evar_conv_x flags env evd CUMUL t1 t2)
 
 let e_conv env ?(ts=default_transparent_state env) evdref t1 t2 =
-  match evar_conv_x ts env !evdref CONV t1 t2 with
+  let flags = default_flags_of ts in
+  match evar_conv_x flags env !evdref CONV t1 t2 with
   | Success evd' -> evdref := evd'; true
   | _ -> false
 
 let e_cumul env ?(ts=default_transparent_state env) evdref t1 t2 =
-  match evar_conv_x ts env !evdref CUMUL t1 t2 with
+  let flags = default_flags_of ts in
+  match evar_conv_x flags env !evdref CUMUL t1 t2 with
   | Success evd' -> evdref := evd'; true
   | _ -> false
+
+let unify flags env evd t1 t2 =
+  match evar_conv_x flags env evd CONV t1 t2 with
+  | Success evd' -> evd'
+  | UnifFailure (evd',e) -> raise (UnableToUnify (evd',e))
+
+let unify_leq flags env evd t1 t2 =
+  match evar_conv_x flags env evd CUMUL t1 t2 with
+  | Success evd' -> evd'
+  | UnifFailure (evd',e) -> raise (UnableToUnify (evd',e))
+
+let unify_with_heuristics flags ~with_ho env evd cv_pb ty1 ty2 =
+  let res = evar_conv_x flags env evd cv_pb ty1 ty2 in
+  match res with
+  | Success evd ->
+     solve_unif_constraints_with_heuristics ~flags ~with_ho env evd
+  | UnifFailure (evd, reason) ->
+     raise (PretypeError (env, evd, CannotUnify (ty1, ty2, Some reason)))

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -424,7 +424,9 @@ let rec evar_conv_x flags env evd pbty term1 term2 =
           | None -> UnifFailure (evd, ConversionFailed (env,term1,term2))
           | exception Univ.UniverseInconsistency e -> UnifFailure (evd, UnifUnivInconsistency e)
       in
-	match e with
+        match e with
+        (** TODO: approximation, if term1 and term2 do not refer transitively to evars then the
+         conversion test is enough *)
 	| UnifFailure (evd, e) when not (is_ground_env evd env) -> None
 	| _ -> Some e)
     else None

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -510,7 +510,7 @@ and evar_eqappr_x ?(rhs_is_already_stuck = false) ts env evd pbty
         let tM = Stack.zip evd apprM in
 	  miller_pfenning on_left
 	    (fun () -> if not_only_app then (* Postpone the use of an heuristic *)
-	      switch (fun x y -> Success (add_conv_pb (pbty,env,x,y) i)) (Stack.zip evd apprF) tM
+              switch (fun x y -> Success (Evarutil.add_unification_pb (pbty,env,x,y) i)) (Stack.zip evd apprF) tM
 	    else quick_fail i)
 	  ev lF tM i
     and consume (termF,skF as apprF) (termM,skM as apprM) i = 
@@ -578,7 +578,7 @@ and evar_eqappr_x ?(rhs_is_already_stuck = false) ts env evd pbty
                          i,mkEvar ev
                        else
                          i,Stack.zip evd apprF in
-		     switch (fun x y -> Success (add_conv_pb (pbty,env,x,y) i))
+                     switch (fun x y -> Success (Evarutil.add_unification_pb (pbty,env,x,y) i))
 	               tF tR
 		   else
                      UnifFailure (evd,OccurCheck (fst ev,tR)))])

--- a/pretyping/evarconv.mli
+++ b/pretyping/evarconv.mli
@@ -17,13 +17,31 @@ open Locus
 
 (** {4 Unification for type inference. } *)
 
+type unify_flags = Evarsolve.unify_flags
+
+(** The default subterm transparent state is no unfoldings *)
+val default_flags_of : ?subterm_ts:transparent_state -> transparent_state -> unify_flags
+
+type unify_fun = unify_flags ->
+  env -> evar_map -> conv_pb -> constr -> constr -> Evarsolve.unification_result
+
+val conv_fun : unify_fun -> unify_flags -> Evarsolve.conv_fun
+
 exception UnableToUnify of evar_map * Pretype_errors.unification_error
 
 (** {6 Main unification algorithm for type inference. } *)
 
-(** returns exception NotUnifiable with best known evar_map if not unifiable *)
+(** returns exception UnableToUnify with best known evar_map if not unifiable *)
 val the_conv_x     : env -> ?ts:transparent_state -> constr -> constr -> evar_map -> evar_map
 val the_conv_x_leq : env -> ?ts:transparent_state -> constr -> constr -> evar_map -> evar_map
+
+(** Allows to pass arbitrary flags to the unifier *)
+val unify : unify_flags -> env -> evar_map -> constr -> constr -> evar_map
+val unify_leq : unify_flags -> env -> evar_map -> constr -> constr -> evar_map
+
+(** @raises a PretypeError if it cannot unify *)
+val unify_with_heuristics : unify_flags -> with_ho:bool ->
+                            env -> evar_map -> conv_pb -> constr -> constr -> evar_map
 
 (** The same function resolving evars by side-effect and
    catching the exception *)
@@ -36,14 +54,17 @@ val e_cumul : env -> ?ts:transparent_state -> evar_map ref -> constr -> constr -
 val conv : env -> ?ts:transparent_state -> evar_map -> constr -> constr -> evar_map option
 val cumul : env -> ?ts:transparent_state -> evar_map -> constr -> constr -> evar_map option
 
+
 (** {6 Unification heuristics. } *)
 
 (** Try heuristics to solve pending unification problems and to solve
     evars with candidates *)
 
-val solve_unif_constraints_with_heuristics : env -> ?ts:transparent_state -> evar_map -> evar_map
+val solve_unif_constraints_with_heuristics :
+  env -> ?flags:unify_flags -> ?with_ho:bool -> evar_map -> evar_map
 
-val consider_remaining_unif_problems : env -> ?ts:transparent_state -> evar_map -> evar_map
+val consider_remaining_unif_problems :
+  env -> ?flags:unify_flags -> ?with_ho:bool -> evar_map -> evar_map
 [@@ocaml.deprecated "Alias for [solve_unif_constraints_with_heuristics]"]
 
 (** Check all pending unification problems are solved and raise an
@@ -64,15 +85,38 @@ val check_conv_record : env -> evar_map ->
 (** Try to solve problems of the form ?x[args] = c by second-order
     matching, using typing to select occurrences *)
 
-val second_order_matching : transparent_state -> env -> evar_map ->
-  EConstr.existential -> occurrences option list -> constr -> evar_map * bool
+type occurrence_match_test =
+  env -> evar_map -> constr -> (* Used to precompute the local tests *)
+  env -> evar_map -> int -> constr -> constr -> bool * evar_map
+
+(** When given the choice of abstracting an occurrence or leaving it,
+    force abstration. *)
+type prefer_abstraction = bool
+
+type occurrence_selection =
+  | AtOccurrences of occurrences
+  | Unspecified of prefer_abstraction
+
+(** By default, unspecified, not preferring abstraction.
+    This provides the most general solutions. *)
+val default_occurrence_selection : occurrence_selection
+
+type occurrences_selection =
+  occurrence_match_test * occurrence_selection list
+
+val default_occurrence_test : frozen_evars:Evar.Set.t -> transparent_state -> occurrence_match_test
+
+(** [default_occurrence_selection n]
+    Gives the default test and occurrences for [n] arguments *)
+val default_occurrences_selection : ?frozen_evars:Evar.Set.t (* By default, none *) ->
+                                    transparent_state -> int -> occurrences_selection
+
+val second_order_matching : unify_flags -> env -> evar_map ->
+  existential -> occurrences_selection -> constr -> evar_map * bool
 
 (** Declare function to enforce evars resolution by using typing constraints *)
 
 val set_solve_evars : (env -> evar_map -> constr -> evar_map * constr) -> unit
-
-type unify_fun = transparent_state ->
-  env -> evar_map -> conv_pb -> constr -> constr -> Evarsolve.unification_result
 
 (** Override default [evar_conv_x] algorithm. *)
 val set_evar_conv : unify_fun -> unit
@@ -82,7 +126,7 @@ val evar_conv_x : unify_fun
 
 (**/**)
 (* For debugging *)
-val evar_eqappr_x : ?rhs_is_already_stuck:bool -> transparent_state * bool ->
+val evar_eqappr_x : ?rhs_is_already_stuck:bool -> unify_flags ->
   env -> evar_map ->
     conv_pb -> state * Cst_stack.t -> state * Cst_stack.t ->
       Evarsolve.unification_result

--- a/pretyping/evardefine.ml
+++ b/pretyping/evardefine.ml
@@ -139,7 +139,8 @@ let define_pure_evar_as_lambda env evd evk =
   let newenv = push_named (LocalAssum (id, dom)) evenv in
   let filter = Filter.extend 1 (evar_filter evi) in
   let src = subterm_source evk ~where:Body (evar_source evk evd1) in
-  let evd2,body = new_evar newenv evd1 ~src (subst1 (mkVar id) rng) ~filter in
+  let abstract_arguments = Abstraction.abstract_last evi.evar_abstract_arguments in
+  let evd2,body = new_evar newenv evd1 ~src (subst1 (mkVar id) rng) ~filter ~abstract_arguments in
   let lam = mkLambda (Name id, dom, subst_var id body) in
   Evd.define evk lam evd2, lam
 

--- a/pretyping/evarsolve.ml
+++ b/pretyping/evarsolve.ml
@@ -1252,6 +1252,8 @@ let solve_evar_evar_l2r force f g env evd aliases pbty ev1 (evk2,_ as ev2) =
   try
     let evd,body = project_evar_on_evar force g env evd aliases 0 pbty ev1 ev2 in
     let evd' = Evd.define evk2 body evd in
+    let evi = Evd.find evd' evk2 in
+    let evd' = Evd.add evd' evk2 {evi with evar_extra = Store.set evi.evar_extra Evarutil.evar_evar_solution true} in
     let evd' = update_evar_source (fst (destEvar evd body)) evk2 evd' in
       check_evar_instance evd' evk2 body g
   with EvarSolvedOnTheFly (evd,c) ->

--- a/pretyping/evarsolve.mli
+++ b/pretyping/evarsolve.mli
@@ -16,6 +16,15 @@ type alias
 
 val of_alias : alias -> EConstr.t
 
+type unify_flags = {
+  modulo_betaiota : bool;
+  open_ts : Names.transparent_state;
+  closed_ts : Names.transparent_state;
+  subterm_ts : Names.transparent_state;
+  frozen_evars : Evar.Set.t;
+  allow_K_at_toplevel : bool;
+  with_cs : bool}
+
 type unification_result =
   | Success of evar_map
   | UnifFailure of evar_map * Pretype_errors.unification_error
@@ -31,14 +40,16 @@ val expand_vars_in_term : env -> evar_map -> constr -> constr
    some problems that cannot be solved in a unique way (except if choose is
    true); fails if the instance is not valid for the given [ev] *)
 
-type conv_fun =
-  env ->  evar_map -> conv_pb -> constr -> constr -> unification_result
+type types_or_terms = bool
 
-type conv_fun_bool =
+type conv_fun = types_or_terms ->
+  env -> evar_map -> conv_pb -> constr -> constr -> unification_result
+
+type conv_fun_bool = types_or_terms ->
   env ->  evar_map -> conv_pb -> constr -> constr -> bool
 
-val evar_define : conv_fun -> ?choose:bool -> env -> evar_map -> 
-  bool option -> existential -> constr -> evar_map
+val evar_define : unify_flags -> conv_fun -> ?choose:bool -> ?imitate_defs:bool ->
+  env -> evar_map -> bool option -> existential -> constr -> evar_map
 
 val refresh_universes :
   ?status:Evd.rigid ->
@@ -49,15 +60,15 @@ val refresh_universes :
   bool option (* direction: true for levels lower than the existing levels *) ->
   env -> evar_map -> types -> evar_map * types
 
-val solve_refl : ?can_drop:bool -> conv_fun_bool -> env ->  evar_map ->
+val solve_refl : ?can_drop:bool -> unify_flags -> conv_fun_bool -> env ->  evar_map ->
   bool option -> Evar.t -> constr array -> constr array -> evar_map
 
-val solve_evar_evar : ?force:bool ->
+val solve_evar_evar : ?force:bool -> unify_flags ->
   (env -> evar_map -> bool option -> existential -> constr -> evar_map) ->
   conv_fun ->
   env ->  evar_map -> bool option -> existential -> existential -> evar_map
 
-val solve_simple_eqn : conv_fun -> ?choose:bool -> env ->  evar_map ->
+val solve_simple_eqn : unify_flags -> conv_fun -> ?choose:bool -> ?imitate_defs:bool -> env ->  evar_map ->
   bool option * existential * constr -> unification_result
 
 val reconsider_unif_constraints : conv_fun -> evar_map -> unification_result

--- a/pretyping/find_subterm.ml
+++ b/pretyping/find_subterm.ml
@@ -125,7 +125,7 @@ let replace_term_occ_gen_modulo sigma occs like_first test bywhat cl occ t =
          end;
          add_subst t subst; incr pos;
          (* Check nested matching subterms *)
-         if occs != Locus.AllOccurrences && occs != Locus.NoOccurrences then
+         if not (Locusops.is_all_occurrences occs) && occs != Locus.NoOccurrences then
            begin nested := true; ignore (subst_below k t); nested := false end;
          (* Do the effective substitution *)
          Vars.lift k (bywhat ()))

--- a/pretyping/locus.ml
+++ b/pretyping/locus.ml
@@ -20,6 +20,7 @@ type 'a or_var =
 
 type 'a occurrences_gen =
   | AllOccurrences
+  | AtLeastOneOccurrence
   | AllOccurrencesBut of 'a list (** non-empty *)
   | NoOccurrences
   | OnlyOccurrences of 'a list (** non-empty *)

--- a/pretyping/locusops.mli
+++ b/pretyping/locusops.mli
@@ -21,6 +21,8 @@ val convert_occs : occurrences -> bool * int list
 
 val is_selected : int -> occurrences -> bool
 
+val is_all_occurrences : 'a occurrences_gen -> bool
+
 (** Usual clauses *)
 
 val allHypsAndConcl : 'a clause_expr

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -316,7 +316,7 @@ let apply_inference_hook hook evdref frozen = match frozen with
 let apply_heuristics env evdref fail_evar =
   (* Resolve eagerly, potentially making wrong choices *)
   try evdref := solve_unif_constraints_with_heuristics
-	~ts:(Typeclasses.classes_transparent_state ()) env !evdref
+        ~flags:(default_flags_of (Typeclasses.classes_transparent_state ())) env !evdref
   with e when CErrors.noncritical e ->
     let e = CErrors.push e in if fail_evar then iraise e
 
@@ -395,7 +395,7 @@ let adjust_evar_source evdref na c =
 let inh_conv_coerce_to_tycon ?loc resolve_tc env evdref j = function
   | None -> j
   | Some t ->
-      evd_comb2 (Coercion.inh_conv_coerce_to ?loc resolve_tc env.ExtraEnv.env) evdref j t
+      evd_comb2 (fun evd uj -> Coercion.inh_conv_coerce_to ?loc resolve_tc env.ExtraEnv.env evd uj) evdref j t
 
 let check_instance loc subst = function
   | [] -> ()

--- a/pretyping/tacred.ml
+++ b/pretyping/tacred.ml
@@ -1110,6 +1110,7 @@ let unfoldoccs env sigma (occs,name) c =
     | AllOccurrences -> unfold env sigma name c
     | OnlyOccurrences l -> unfo true l
     | AllOccurrencesBut l -> unfo false l
+    | AtLeastOneOccurrence -> unfo false []
 
 (* Unfold reduction tactic: *)
 let unfoldn loccname env sigma c =

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -1653,7 +1653,7 @@ let make_abstraction_core name (test,out) env sigma c ty occs check_occs concl =
     match occurrences_of_hyp hyp occs with
     | NoOccurrences, InHyp ->
         (push_named_context_val d sign,depdecls)
-    | AllOccurrences, InHyp as occ ->
+    | (AllOccurrences | AtLeastOneOccurrence), InHyp as occ ->
         let occ = if likefirst then LikeFirst else AtOccs occ in
         let newdecl = replace_term_occ_decl_modulo sigma occ test mkvarid d in
         if Context.Named.Declaration.equal (EConstr.eq_constr sigma) d newdecl

--- a/printing/pputils.ml
+++ b/printing/pputils.ml
@@ -45,8 +45,8 @@ let pr_or_var pr = function
 
 let pr_with_occurrences pr keyword (occs,c) =
   match occs with
-    | AllOccurrences ->
-      pr c
+    | AtLeastOneOccurrence -> hov 1 (pr c ++ spc () ++ keyword "at" ++ str" +")
+    | AllOccurrences -> pr c
     | NoOccurrences ->
       failwith "pr_with_occurrences: no occurrences"
     | OnlyOccurrences nl ->

--- a/proofs/clenvtac.ml
+++ b/proofs/clenvtac.ml
@@ -87,7 +87,7 @@ let clenv_refine ?(with_evars=false) ?(with_classes=true) clenv =
       let evd' =
         if has_typeclass then
           Typeclasses.resolve_typeclasses ~fast_path:false ~filter:Typeclasses.all_evars
-          ~fail:(not with_evars) clenv.env clenv.evd
+          ~fail:(not with_evars) ~split:false clenv.env clenv.evd
         else clenv.evd
       in
       if has_resolvable then

--- a/proofs/evar_refiner.ml
+++ b/proofs/evar_refiner.ml
@@ -38,7 +38,7 @@ let define_and_solve_constraints evk c env evd =
   match
     List.fold_left
       (fun p (pbty,env,t1,t2) -> match p with
-        | Success evd -> Evarconv.evar_conv_x full_transparent_state env evd pbty t1 t2
+        | Success evd -> Evarconv.evar_conv_x (Evarconv.default_flags_of full_transparent_state) env evd pbty t1 t2
 	| UnifFailure _ as x -> x) (Success evd)
       pbs
   with

--- a/proofs/goal.ml
+++ b/proofs/goal.ml
@@ -65,6 +65,7 @@ module V82 = struct
     let evi = { Evd.evar_hyps = hyps;
 		Evd.evar_concl = concl;
 		Evd.evar_filter = Evd.Filter.identity;
+                Evd.evar_abstract_arguments = Evd.Abstraction.identity;
 		Evd.evar_body = Evd.Evar_empty;
 		Evd.evar_source = (Loc.tag Evar_kinds.GoalEvar);
 		Evd.evar_candidates = None;

--- a/proofs/pfedit.mli
+++ b/proofs/pfedit.mli
@@ -85,6 +85,9 @@ val solve : ?with_end_tac:unit Proofview.tactic ->
 
 val by : unit Proofview.tactic -> bool
 
+(** Option telling if unification heuristics should be used. *)
+val use_unification_heuristics : unit -> bool
+
 (** [instantiate_nth_evar_com n c] instantiate the [n]th undefined
    existential variable of the current focused proof by [c] or raises a
    UserError if no proof is focused or if there is no such [n]th

--- a/proofs/tacmach.ml
+++ b/proofs/tacmach.ml
@@ -227,4 +227,10 @@ module New = struct
 
   let pf_nf_evar gl t = nf_evar (project gl) t
 
+  let pf_undefined_evars gl =
+    let sigma = Proofview.Goal.sigma gl in
+    let hyps = Proofview.Goal.hyps gl in
+    let concl = Proofview.Goal.concl gl in
+    Evar.Set.union (Evarutil.undefined_evars_of_econstr_named_context sigma hyps)
+      (Evarutil.undefined_evars_of_term sigma concl)
 end

--- a/proofs/tacmach.mli
+++ b/proofs/tacmach.mli
@@ -139,4 +139,5 @@ module New : sig
 
   val pf_nf_evar : Proofview.Goal.t -> constr -> constr
 
+  val pf_undefined_evars : Proofview.Goal.t -> Evar.Set.t
 end

--- a/tactics/autorewrite.ml
+++ b/tactics/autorewrite.ml
@@ -145,7 +145,7 @@ let gen_auto_multi_rewrite conds tac_main lbas cl =
   let try_do_hyps treat_id l =
     autorewrite_multi_in ~conds (List.map treat_id l) tac_main lbas
   in
-  if cl.concl_occs != AllOccurrences &&
+  if not (Locusops.is_all_occurrences cl.concl_occs) &&
      cl.concl_occs != NoOccurrences
   then
     Tacticals.New.tclZEROMSG (str"The \"at\" syntax isn't available yet for the autorewrite tactic.")

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -1136,7 +1136,7 @@ let initial_select_evars filter =
 let resolve_typeclass_evars debug depth unique env evd filter split fail =
   let evd =
     try Evarconv.solve_unif_constraints_with_heuristics
-      ~ts:(Typeclasses.classes_transparent_state ()) env evd
+      ~flags:(Evarconv.default_flags_of (Typeclasses.classes_transparent_state ())) env evd
     with e when CErrors.noncritical e -> evd
   in
     resolve_all_evars debug depth unique env

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -165,12 +165,18 @@ type hint_mode =
   | ModeNoHeadEvar (* No evar at the head *)
   | ModeOutput (* Anything *)
 
+
+type 'a hints_transparency_target =
+  | HintsVariables
+  | HintsConstants
+  | HintsReferences of 'a list
+
 type hints_expr =
   | HintsResolve of (hint_info_expr * bool * reference_or_constr) list
   | HintsResolveIFF of bool * reference list * int option
   | HintsImmediate of reference_or_constr list
   | HintsUnfold of reference list
-  | HintsTransparency of reference list * bool
+  | HintsTransparency of reference hints_transparency_target * bool
   | HintsMode of reference * hint_mode list
   | HintsConstructors of reference list
   | HintsExtern of int * Constrexpr.constr_expr option * Genarg.raw_generic_argument
@@ -1014,15 +1020,19 @@ let add_hint dbname hintlist =
   let db' = Hint_db.add_list env sigma hintlist db in
     searchtable_add (dbname,db')
 
-let add_transparency dbname grs b =
+let add_transparency dbname target b =
   let db = get_db dbname in
-  let st = Hint_db.transparent_state db in
+  let (ids, csts as st) = Hint_db.transparent_state db in
   let st' =
-    List.fold_left (fun (ids, csts) gr ->
-      match gr with
-      | EvalConstRef c -> (ids, (if b then Cpred.add else Cpred.remove) c csts)
-      | EvalVarRef v -> (if b then Id.Pred.add else Id.Pred.remove) v ids, csts)
-      st grs
+    match target with
+    | HintsVariables -> (if b then Id.Pred.full else Id.Pred.empty), csts
+    | HintsConstants -> ids, if b then Cpred.full else Cpred.empty
+    | HintsReferences grs ->
+       List.fold_left (fun (ids, csts) gr ->
+       match gr with
+       | EvalConstRef c -> (ids, (if b then Cpred.add else Cpred.remove) c csts)
+       | EvalVarRef v -> (if b then Id.Pred.add else Id.Pred.remove) v ids, csts)
+                      st grs
   in searchtable_add (dbname, Hint_db.set_transparent_state db st')
 
 let remove_hint dbname grs =
@@ -1032,7 +1042,7 @@ let remove_hint dbname grs =
 
 type hint_action =
   | CreateDB of bool * transparent_state
-  | AddTransparency of evaluable_global_reference list * bool
+  | AddTransparency of evaluable_global_reference hints_transparency_target * bool
   | AddHints of hint_entry list
   | RemoveHints of GlobRef.t list
   | AddCut of hints_path
@@ -1122,9 +1132,17 @@ let subst_autohint (subst, obj) =
   in
   let action = match obj.hint_action with
     | CreateDB _ -> obj.hint_action
-    | AddTransparency (grs, b) ->
-      let grs' = List.Smart.map (subst_evaluable_reference subst) grs in
-      if grs == grs' then obj.hint_action else AddTransparency (grs', b)
+    | AddTransparency (target, b) ->
+      let target' =
+        match target with
+        | HintsVariables -> target
+        | HintsConstants -> target
+        | HintsReferences grs ->
+          let grs' = List.Smart.map (subst_evaluable_reference subst) grs in
+          if grs == grs' then target
+          else HintsReferences grs'
+      in
+      if target' == target then obj.hint_action else AddTransparency (target', b)
     | AddHints hintlist ->
       let hintlist' = List.Smart.map subst_hint hintlist in
       if hintlist' == hintlist then obj.hint_action else AddHints hintlist'
@@ -1244,7 +1262,7 @@ type hints_entry =
   | HintsImmediateEntry of (hints_path_atom * polymorphic * hint_term) list
   | HintsCutEntry of hints_path
   | HintsUnfoldEntry of evaluable_global_reference list
-  | HintsTransparencyEntry of evaluable_global_reference list * bool
+  | HintsTransparencyEntry of evaluable_global_reference hints_transparency_target * bool
   | HintsModeEntry of GlobRef.t * hint_mode list
   | HintsExternEntry of hint_info * Genarg.glob_generic_argument
 
@@ -1347,14 +1365,19 @@ let interp_hints poly =
     let info = { info with hint_pattern = Option.map fp info.hint_pattern } in
       (info, poly, b, path, gr)
   in
+  let ft = function
+    | HintsVariables -> HintsVariables
+    | HintsConstants -> HintsConstants
+    | HintsReferences lhints -> HintsReferences (List.map fr lhints)
+  in
+  let fp = Constrintern.intern_constr_pattern (Global.env()) in
   match h with
   | HintsResolve lhints -> HintsResolveEntry (List.map fres lhints)
   | HintsResolveIFF (l2r, lc, n) ->
     HintsResolveEntry (List.map (project_hint ~poly n l2r) lc)
   | HintsImmediate lhints -> HintsImmediateEntry (List.map fi lhints)
   | HintsUnfold lhints -> HintsUnfoldEntry (List.map fr lhints)
-  | HintsTransparency (lhints, b) ->
-      HintsTransparencyEntry (List.map fr lhints, b)
+  | HintsTransparency (t, b) -> HintsTransparencyEntry (ft t, b)
   | HintsMode (r, l) -> HintsModeEntry (fref r, l)
   | HintsConstructors lqid ->
       let constr_hints_of_ind qid =
@@ -1369,7 +1392,7 @@ let interp_hints poly =
 			PathHints [gr], IsGlobRef gr)
       in HintsResolveEntry (List.flatten (List.map constr_hints_of_ind lqid))
   | HintsExtern (pri, patcom, tacexp) ->
-      let pat =	Option.map fp patcom in
+      let pat =	Option.map (fp sigma) patcom in
       let l = match pat with None -> [] | Some (l, _) -> l in
       let ltacvars = List.fold_left (fun accu x -> Id.Set.add x accu) Id.Set.empty l in
       let env = Genintern.({ (empty_glob_sign env) with ltacvars }) in

--- a/tactics/hints.mli
+++ b/tactics/hints.mli
@@ -81,12 +81,17 @@ type hint_mode =
   | ModeNoHeadEvar (* No evar at the head *)
   | ModeOutput (* Anything *)
 
+type 'a hints_transparency_target =
+  | HintsVariables
+  | HintsConstants
+  | HintsReferences of 'a list
+
 type hints_expr =
   | HintsResolve of (hint_info_expr * bool * reference_or_constr) list
   | HintsResolveIFF of bool * Libnames.reference list * int option
   | HintsImmediate of reference_or_constr list
   | HintsUnfold of Libnames.reference list
-  | HintsTransparency of Libnames.reference list * bool
+  | HintsTransparency of Libnames.reference hints_transparency_target * bool
   | HintsMode of Libnames.reference * hint_mode list
   | HintsConstructors of Libnames.reference list
   | HintsExtern of int * Constrexpr.constr_expr option * Genarg.raw_generic_argument
@@ -173,7 +178,7 @@ type hints_entry =
   | HintsImmediateEntry of (hints_path_atom * polymorphic * hint_term) list
   | HintsCutEntry of hints_path
   | HintsUnfoldEntry of evaluable_global_reference list
-  | HintsTransparencyEntry of evaluable_global_reference list * bool
+  | HintsTransparencyEntry of evaluable_global_reference hints_transparency_target * bool
   | HintsModeEntry of GlobRef.t * hint_mode list
   | HintsExternEntry of hint_info * Genarg.glob_generic_argument
 

--- a/tactics/tacticals.ml
+++ b/tactics/tacticals.ml
@@ -501,6 +501,7 @@ module New = struct
   (* Check that holes in arguments have been resolved *)
 
   let check_evars env sigma extsigma origsigma =
+    let origevars = Evar.Map.domain (Evd.undefined_map origsigma) in
     let rec is_undefined_up_to_restriction sigma evk =
       if Evd.mem origsigma evk then None else
       let evi = Evd.find sigma evk in
@@ -516,7 +517,10 @@ module New = struct
     let rest =
       Evd.fold_undefined (fun evk evi acc ->
         match is_undefined_up_to_restriction sigma evk with
-        | Some (evk',evi) -> (evk',evi)::acc
+        | Some (evk',evi) when not (Evd.mem origsigma evk)
+                            && not (Evarutil.reachable_from_evars sigma origevars
+                                      (Evar.Set.singleton evk)) ->
+           (evk',evi)::acc
         | _ -> acc)
         extsigma []
     in

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -212,6 +212,9 @@ let clear_dependency_msg env sigma id err inglobal =
       str "Cannot remove " ++ Id.print id ++
       strbrk " without breaking the typing of " ++
       Printer.pr_existential env sigma ev ++ str"."
+  | Evarutil.NoCandidatesLeft ev ->
+      str "Cannot remove " ++ Id.print id ++ str " as it would leave the existential " ++
+      Printer.pr_existential_key sigma ev ++ str" without candidates."
 
 let error_clear_dependency env sigma id err inglobal =
   user_err (clear_dependency_msg env sigma id err inglobal)
@@ -228,6 +231,9 @@ let replacing_dependency_msg env sigma id err inglobal =
       str "Cannot change " ++ Id.print id ++
       strbrk " without breaking the typing of " ++
       Printer.pr_existential env sigma ev ++ str"."
+  | Evarutil.NoCandidatesLeft ev ->
+      str "Cannot change " ++ Id.print id ++ str " as it would leave the existential " ++
+      Printer.pr_existential_key sigma ev ++ str" without candidates."
 
 let error_replacing_dependency env sigma id err inglobal =
   user_err (replacing_dependency_msg env sigma id err inglobal)

--- a/test-suite/success/Hints.v
+++ b/test-suite/success/Hints.v
@@ -169,7 +169,7 @@ Proof.
 Hint Cut [_* (a_is_b | b_is_c | c_is_d | d_is_e)
                  (a_compose | b_compose | c_compose | d_compose | e_compose)] : typeclass_instances.
 
-  Timeout 1 Fail apply _. (* 0.06s *)
+Timeout 1 Fail apply _. (* 0.06s *)
 Abort.
 End HintCut.
 

--- a/theories/Init/Logic.v
+++ b/theories/Init/Logic.v
@@ -29,6 +29,13 @@ Definition not (A:Prop) := A -> False.
 
 Notation "~ x" := (not x) : type_scope.
 
+(** Create the "core" hint database, and set its transparent state for
+  variables and constants explicitely. *)
+
+Create HintDb core.
+Hint Variables Opaque : core.
+Hint Constants Opaque : core.
+
 Hint Unfold not: core.
 
   (** [and A B], written [A /\ B], is the conjunction of [A] and [B]

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -42,7 +42,7 @@ let typeclasses_db = "typeclass_instances"
 
 let set_typeclass_transparency c local b = 
   Hints.add_hints ~local [typeclasses_db]
-    (Hints.HintsTransparencyEntry ([c], b))
+    (Hints.HintsTransparencyEntry (Vernacexpr.HintsReferences [c], b))
     
 let _ =
   Hook.set Typeclasses.add_instance_hint_hook

--- a/vernac/g_proofs.ml4
+++ b/vernac/g_proofs.ml4
@@ -113,8 +113,12 @@ GEXTEND Gram
       | IDENT "Resolve"; "<-"; lc = LIST1 global; n = OPT natural ->
           HintsResolveIFF (false, lc, n)
       | IDENT "Immediate"; lc = LIST1 reference_or_constr -> HintsImmediate lc
-      | IDENT "Transparent"; lc = LIST1 global -> HintsTransparency (lc, true)
-      | IDENT "Opaque"; lc = LIST1 global -> HintsTransparency (lc, false)
+      | IDENT "Variables"; IDENT "Transparent" -> HintsTransparency (HintsVariables, true)
+      | IDENT "Variables"; IDENT "Opaque" -> HintsTransparency (HintsVariables, false)
+      | IDENT "Constants"; IDENT "Transparent" -> HintsTransparency (HintsConstants, true)
+      | IDENT "Constants"; IDENT "Opaque" -> HintsTransparency (HintsConstants, false)
+      | IDENT "Transparent"; lc = LIST1 global -> HintsTransparency (HintsReferences lc, true)
+      | IDENT "Opaque"; lc = LIST1 global -> HintsTransparency (HintsReferences lc, false)
       | IDENT "Mode"; l = global; m = mode -> HintsMode (l, m)
       | IDENT "Unfold"; lqid = LIST1 global -> HintsUnfold lqid
       | IDENT "Constructors"; lc = LIST1 global -> HintsConstructors lc ] ]

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -211,7 +211,10 @@ open Pputils
         | HintsTransparency (l, b) ->
           keyword (if b then "Transparent" else "Opaque")
           ++ spc ()
-          ++ prlist_with_sep sep pr_reference l
+          ++ (match l with
+              | HintsVariables -> keyword "Variables"
+              | HintsConstants -> keyword "Constants"
+              | HintsReferences l -> prlist_with_sep sep pr_reference l)
         | HintsMode (m, l) ->
           keyword "Mode"
           ++ spc ()

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -121,12 +121,17 @@ type 'a hint_info_gen = 'a Typeclasses.hint_info_gen =
 type hint_info_expr = Hints.hint_info_expr
 [@@ocaml.deprecated "Please use [Hints.hint_info_expr]"]
 
+type 'a hints_transparency_target = 'a Hints.hints_transparency_target =
+  | HintsVariables
+  | HintsConstants
+  | HintsReferences of 'a list
+
 type hints_expr = Hints.hints_expr =
   | HintsResolve of (Hints.hint_info_expr * bool * Hints.reference_or_constr) list
   | HintsResolveIFF of bool * reference list * int option
   | HintsImmediate of Hints.reference_or_constr list
   | HintsUnfold of reference list
-  | HintsTransparency of reference list * bool
+  | HintsTransparency of reference hints_transparency_target * bool
   | HintsMode of reference * Hints.hint_mode list
   | HintsConstructors of reference list
   | HintsExtern of int * constr_expr option * Genarg.raw_generic_argument


### PR DESCRIPTION
Following @ppedrot , I'm in for a trilogy (at least!). This PR implements the infrastructure needed by the unifall changes, preparing to switch tactics to the evarconv and second_order_matching algorithms. It stands alone as an addition to the current tactics, mainly improving evarconv and second_order_matching, adding an Abstraction field to evars and a ?future_goal to Evd.new_evar* functions for handling the future_goal tag in evar-based Clenvs correctly. Hopefully this part will have no impact on compatibility at all. The commits may need reworking and separation, I'm making this first big PR to evaluate any unforeseen impact.