### PR TITLE
Handling evars in the VM

### DIFF
--- a/dev/vm_printers.ml
+++ b/dev/vm_printers.ml
@@ -36,6 +36,10 @@ let print_idkey idk =
       print_string ")"
   | VarKey id -> print_string (Id.to_string id)
   | RelKey i -> print_string "~";print_int i
+  | EvarKey evk ->
+    print_string "Evar(";
+    print_int (Evar.repr evk);
+    print_string ")"
 
 let rec ppzipper z =
   match z with

--- a/kernel/cbytecodes.mli
+++ b/kernel/cbytecodes.mli
@@ -138,6 +138,7 @@ type fv_elem =
   FVnamed of Id.t
 | FVrel of int
 | FVuniv_var of int
+| FVevar of Evar.t
 
 type fv = fv_elem array
 

--- a/kernel/cinstr.mli
+++ b/kernel/cinstr.mli
@@ -20,6 +20,7 @@ type uint =
 and lambda =
   | Lrel          of Name.t * int
   | Lvar          of Id.t
+  | Levar         of Evar.t * lambda array
   | Lprod         of lambda * lambda
   | Llam          of Name.t array * lambda
   | Llet          of Name.t * lambda * lambda

--- a/kernel/csymtable.ml
+++ b/kernel/csymtable.ml
@@ -150,6 +150,7 @@ and slot_for_fv env fv =
         env |> Pre_env.lookup_rel i |> RelDecl.get_value |> fill_fv_cache rv i val_of_rel env_of_rel
       | Some (v, _) -> v
       end
+  | FVevar evk -> val_of_evar evk
   | FVuniv_var idu ->
     assert false
 

--- a/kernel/vars.ml
+++ b/kernel/vars.ml
@@ -310,6 +310,3 @@ let subst_instance_constr subst c =
 let subst_instance_context s ctx = 
   if Univ.Instance.is_empty s then ctx
   else Context.Rel.map (fun x -> subst_instance_constr s x) ctx
-
-type id_key = Constant.t tableKey
-let eq_id_key x y = Names.eq_table_key Constant.equal x y

--- a/kernel/vars.mli
+++ b/kernel/vars.mli
@@ -137,6 +137,3 @@ val subst_univs_level_context : Univ.universe_level_subst -> Context.Rel.t -> Co
 (** Instance substitution for polymorphism. *)
 val subst_instance_constr : Instance.t -> constr -> constr
 val subst_instance_context : Instance.t -> Context.Rel.t -> Context.Rel.t
-
-type id_key = Constant.t tableKey
-val eq_id_key : id_key -> id_key -> bool

--- a/kernel/vconv.ml
+++ b/kernel/vconv.ml
@@ -116,7 +116,7 @@ and conv_atom env pb k a1 stk1 a2 stk2 cu =
 	conv_stack env k stk1 stk2 cu
     else raise NotConvertible
   | Aid ik1, Aid ik2 ->
-    if Vars.eq_id_key ik1 ik2 && compare_stack stk1 stk2 then
+    if Vmvalues.eq_id_key ik1 ik2 && compare_stack stk1 stk2 then
 	conv_stack env k stk1 stk2 cu
       else raise NotConvertible
   | Atype _ , _ | _, Atype _ -> assert false

--- a/kernel/vm.ml
+++ b/kernel/vm.ml
@@ -28,7 +28,6 @@ let popstop_code i =
 
 let stop = popstop_code 0
 
-
 (************************************************)
 (* Abstract machine *****************************)
 (************************************************)
@@ -70,7 +69,6 @@ let apply_varray vf varray =
       interprete (fun_code vf) (fun_val vf) (fun_env vf) (n - 1)
     end
 
-(* Functions over vfun *)
 let mkrel_vstack k arity =
   let max = k + arity - 1 in
   Array.init arity (fun i -> val_of_rel (max - i))

--- a/kernel/vmvalues.mli
+++ b/kernel/vmvalues.mli
@@ -54,8 +54,16 @@ val fun_code : vfun -> tcode
 val fix_code : vfix -> tcode
 val cofix_upd_code : to_update -> tcode
 
+type id_key =
+| ConstKey of Constant.t
+| VarKey of Id.t
+| RelKey of Int.t
+| EvarKey of Evar.t
+
+val eq_id_key : id_key -> id_key -> bool
+
 type atom =
-  | Aid of Vars.id_key
+  | Aid of id_key
   | Aind of inductive
   | Atype of Univ.Universe.t
 
@@ -92,6 +100,7 @@ val val_of_str_const : structured_constant -> values
 val val_of_rel : int -> values
 val val_of_named : Id.t -> values
 val val_of_constant : Constant.t -> values
+val val_of_evar : Evar.t -> values
 val val_of_proj : Constant.t -> values -> values
 val val_of_atom : atom -> values
 

--- a/test-suite/bugs/closed/2850.v
+++ b/test-suite/bugs/closed/2850.v
@@ -1,2 +1,0 @@
-Definition id {A} (x : A) := x.
-Fail Compute id.

--- a/test-suite/success/vm_evars.v
+++ b/test-suite/success/vm_evars.v
@@ -1,0 +1,23 @@
+Fixpoint iter {A} (n : nat) (f : A -> A) (x : A) :=
+match n with
+| 0 => x
+| S n => iter n f (f x)
+end.
+
+Goal nat -> True.
+Proof.
+intros n.
+evar (f : nat -> nat).
+cut (iter 10 f 0 = 0).
+vm_compute.
+intros; constructor.
+instantiate (f := (fun x => x)).
+reflexivity.
+Qed.
+
+Goal exists x, x = 5 + 5.
+Proof.
+  eexists.
+  vm_compute.
+  reflexivity.
+Qed.


### PR DESCRIPTION
This is actually pretty straightforward. We simply treat them as as an application of an atom to its instance,
and in the decompilation phase we reconstruct the instance from the arguments.

This closes #5659.

Note that we could probably do the same in native compilation for the sake of uniformity, but this is left to another PR.