### PR TITLE
Move evar filters out of evar_info

### DIFF
--- a/API/API.mli
+++ b/API/API.mli
@@ -2215,7 +2215,6 @@ sig
       evar_concl : Constr.t;
       evar_hyps : Environ.named_context_val;
       evar_body : evar_body;
-      evar_filter : Filter.t;
       evar_source : Evar_kinds.t Loc.located;
       evar_candidates : Constr.t list option; (* if not None, list of allowed instances *)
       evar_extra : Store.t
@@ -2225,7 +2224,7 @@ sig
   val evar_body : evar_info -> evar_body
   val evar_context : evar_info -> Context.Named.t
   val instantiate_evar_array : evar_info -> Constr.t -> Constr.t array -> Constr.t
-  val evar_filtered_env : evar_info -> Environ.env
+  val evar_env : evar_info -> Environ.env
   val evar_hyps : evar_info -> Environ.named_context_val
 
   (* ------------------------------------ *)
@@ -2285,7 +2284,6 @@ sig
     val remove : evar_map -> Evar.t -> evar_map
     val fresh_global : ?loc:Loc.t -> ?rigid:rigid -> ?names:Univ.Instance.t -> Environ.env ->
                        evar_map -> Globnames.global_reference -> evar_map * Constr.t
-    val evar_filtered_context : evar_info -> Context.Named.t
     val fresh_inductive_instance : ?loc:Loc.t -> Environ.env -> evar_map -> Names.inductive -> evar_map * Term.pinductive
     val fold_undefined : (Evar.t -> evar_info -> 'a -> 'a) -> evar_map -> 'a -> 'a
 
@@ -2851,14 +2849,14 @@ sig
   val new_global : Evd.evar_map -> Globnames.global_reference -> Evd.evar_map * EConstr.constr
 
   val new_evar :
-    Environ.env -> Evd.evar_map -> ?src:Evar_kinds.t Loc.located -> ?filter:Evd.Filter.t ->
+    Environ.env -> Evd.evar_map -> ?src:Evar_kinds.t Loc.located ->
     ?candidates:EConstr.constr list -> ?store:Evd.Store.t ->
     ?naming:Misctypes.intro_pattern_naming_expr ->
     ?principal:bool -> EConstr.types -> Evd.evar_map * EConstr.constr
 
   val new_evar_instance :
     Environ.named_context_val -> Evd.evar_map -> EConstr.types ->
-    ?src:Evar_kinds.t Loc.located -> ?filter:Evd.Filter.t -> ?candidates:EConstr.constr list ->
+    ?src:Evar_kinds.t Loc.located -> ?candidates:EConstr.constr list ->
     ?store:Evd.Store.t -> ?naming:Misctypes.intro_pattern_naming_expr ->
     ?principal:bool ->
     EConstr.constr list -> Evd.evar_map * EConstr.constr
@@ -2873,12 +2871,12 @@ sig
   exception ClearDependencyError of Names.Id.t * clear_dependency_error
   val undefined_evars_of_term : Evd.evar_map -> EConstr.constr -> Evar.Set.t
   val e_new_evar :
-      Environ.env -> Evd.evar_map ref -> ?src:Evar_kinds.t Loc.located -> ?filter:Evd.Filter.t ->
+      Environ.env -> Evd.evar_map ref -> ?src:Evar_kinds.t Loc.located ->
       ?candidates:EConstr.constr list -> ?store:Evd.Store.t ->
       ?naming:Misctypes.intro_pattern_naming_expr ->
       ?principal:bool -> EConstr.types -> EConstr.constr
   val new_type_evar :
-    Environ.env -> Evd.evar_map -> ?src:Evar_kinds.t Loc.located -> ?filter:Evd.Filter.t ->
+    Environ.env -> Evd.evar_map -> ?src:Evar_kinds.t Loc.located ->
     ?naming:Misctypes.intro_pattern_naming_expr -> ?principal:bool -> Evd.rigid ->
     Evd.evar_map * (EConstr.constr * Sorts.t)
   val nf_evars_universes : Evd.evar_map -> Constr.t -> Constr.t

--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -22,13 +22,13 @@ val mk_new_meta : unit -> constr
 
 (** {6 Creating a fresh evar given their type and context} *)
 val new_evar :
-  env -> evar_map -> ?src:Evar_kinds.t Loc.located -> ?filter:Filter.t ->
+  env -> evar_map -> ?src:Evar_kinds.t Loc.located ->
   ?candidates:constr list -> ?store:Store.t ->
   ?naming:Misctypes.intro_pattern_naming_expr ->
   ?principal:bool -> types -> evar_map * EConstr.t
 
 val new_pure_evar :
-  named_context_val -> evar_map -> ?src:Evar_kinds.t Loc.located -> ?filter:Filter.t ->
+  named_context_val -> evar_map -> ?src:Evar_kinds.t Loc.located ->
   ?candidates:constr list -> ?store:Store.t ->
   ?naming:Misctypes.intro_pattern_naming_expr ->
   ?principal:bool -> types -> evar_map * evar
@@ -37,7 +37,7 @@ val new_pure_evar_full : evar_map -> evar_info -> evar_map * evar
 
 (** the same with side-effects *)
 val e_new_evar :
-  env -> evar_map ref -> ?src:Evar_kinds.t Loc.located -> ?filter:Filter.t ->
+  env -> evar_map ref -> ?src:Evar_kinds.t Loc.located ->
   ?candidates:constr list -> ?store:Store.t ->
   ?naming:Misctypes.intro_pattern_naming_expr ->
   ?principal:bool -> types -> constr
@@ -45,12 +45,12 @@ val e_new_evar :
 (** Create a new Type existential variable, as we keep track of 
     them during type-checking and unification. *)
 val new_type_evar :
-  env -> evar_map -> ?src:Evar_kinds.t Loc.located -> ?filter:Filter.t ->
+  env -> evar_map -> ?src:Evar_kinds.t Loc.located ->
   ?naming:Misctypes.intro_pattern_naming_expr -> ?principal:bool -> rigid ->
   evar_map * (constr * sorts)
 
 val e_new_type_evar : env -> evar_map ref ->
-  ?src:Evar_kinds.t Loc.located -> ?filter:Filter.t ->
+  ?src:Evar_kinds.t Loc.located ->
   ?naming:Misctypes.intro_pattern_naming_expr -> ?principal:bool -> rigid -> constr * sorts
 
 val new_Type : ?rigid:rigid -> env -> evar_map -> evar_map * constr
@@ -72,7 +72,7 @@ val e_new_global : evar_map ref -> Globnames.global_reference -> constr
    as a telescope) is [sign] *)
 val new_evar_instance :
  named_context_val -> evar_map -> types -> 
-  ?src:Evar_kinds.t Loc.located -> ?filter:Filter.t -> ?candidates:constr list ->
+  ?src:Evar_kinds.t Loc.located -> ?candidates:constr list ->
   ?store:Store.t -> ?naming:Misctypes.intro_pattern_naming_expr ->
   ?principal:bool ->
   constr list -> evar_map * constr

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -96,10 +96,6 @@ type evar_info = {
   (** Context of the evar. *)
   evar_body : evar_body;
   (** Optional content of the evar. *)
-  evar_filter : Filter.t;
-  (** Boolean mask over {!evar_hyps}. Should have the same length.
-      When filtered out, the corresponding variable is not allowed to occur
-      in the solution *)
   evar_source : Evar_kinds.t located;
   (** Information about the evar. *)
   evar_candidates : constr list option;
@@ -111,16 +107,14 @@ type evar_info = {
 val make_evar : named_context_val -> types -> evar_info
 val evar_concl : evar_info -> constr
 val evar_context : evar_info -> Context.Named.t
-val evar_filtered_context : evar_info -> Context.Named.t
 val evar_hyps : evar_info -> named_context_val
-val evar_filtered_hyps : evar_info -> named_context_val
 val evar_body : evar_info -> evar_body
-val evar_filter : evar_info -> Filter.t
 val evar_env :  evar_info -> env
-val evar_filtered_env :  evar_info -> env
 
 val map_evar_body : (constr -> constr) -> evar_body -> evar_body
 val map_evar_info : (constr -> constr) -> evar_info -> evar_info
+
+val filter_evar_hyps : Filter.t -> named_context_val -> named_context_val
 
 (** {6 Unification state} **)
 
@@ -425,7 +419,7 @@ val evars_of_term : constr -> Evar.Set.t
 
 val evars_of_named_context : Context.Named.t -> Evar.Set.t
 
-val evars_of_filtered_evar_info : evar_info -> Evar.Set.t
+val evars_of_evar_info : evar_info -> Evar.Set.t
 
 (** Metas *)
 val meta_list : evar_map -> (metavariable * clbinding) list

--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -635,7 +635,7 @@ let shelve_goals l =
     [evi]. Note: since we want to use it on goals, the body is actually
     supposed to be empty. *)
 let contained_in_info sigma e evi =
-  Evar.Set.mem e (Evd.evars_of_filtered_evar_info (Evarutil.nf_evar_info sigma evi))
+  Evar.Set.mem e (Evd.evars_of_evar_info (Evarutil.nf_evar_info sigma evi))
 
 (** [depends_on sigma src tgt] checks whether the goal [src] appears
     as an existential variable in the definition of the goal [tgt] in
@@ -989,7 +989,7 @@ let (>>=) = tclBIND
 
 let goal_env evars gl =
   let evi = Evd.find evars gl in
-  Evd.evar_filtered_env evi
+  Evd.evar_env evi
 
 let goal_nf_evar sigma gl =
   let evi = Evd.find sigma gl in
@@ -1025,7 +1025,7 @@ module Goal = struct
   let extra {sigma; self} = goal_extra sigma self
 
   let gmake_with info env sigma goal = 
-    { env = Environ.reset_with_named_context (Evd.evar_filtered_hyps info) env ;
+    { env = Environ.reset_with_named_context (Evd.evar_hyps info) env ;
       sigma = sigma ;
       concl = EConstr.of_constr (Evd.evar_concl info);
       self = goal }

--- a/engine/termops.ml
+++ b/engine/termops.ml
@@ -173,13 +173,13 @@ let pr_meta_map evd =
   in
   prlist pr_meta_binding (meta_list evd)
 
-let pr_decl (decl,ok) =
+let pr_decl decl =
   let open NamedDecl in
   let print_constr = print_kconstr in
   match decl with
-  | LocalAssum (id,_) -> if ok then pr_id id else (str "{" ++ pr_id id ++ str "}")
-  | LocalDef (id,c,_) -> str (if ok then "(" else "{") ++ pr_id id ++ str ":=" ++
-                           print_constr c ++ str (if ok then ")" else "}")
+  | LocalAssum (id,_) -> pr_id id
+  | LocalDef (id,c,_) -> str "(" ++ pr_id id ++ str ":=" ++
+                           print_constr c ++ str ")"
 
 let pr_evar_source = function
   | Evar_kinds.NamedHole id -> pr_id id
@@ -211,13 +211,8 @@ let pr_evar_info evi =
   let open Evd in
   let print_constr = print_kconstr in
   let phyps =
-    try
-      let decls = match Filter.repr (evar_filter evi) with
-      | None -> List.map (fun c -> (c, true)) (evar_context evi)
-      | Some filter -> List.combine (evar_context evi) filter
-      in
-      prlist_with_sep spc pr_decl (List.rev decls)
-    with Invalid_argument _ -> str "Ill-formed filtered context" in
+    prlist_with_sep spc pr_decl (List.rev (evar_context evi))
+  in
   let pty = print_constr evi.evar_concl in
   let pb =
     match evi.evar_body with

--- a/plugins/ltac/evar_tactics.ml
+++ b/plugins/ltac/evar_tactics.ml
@@ -24,7 +24,7 @@ module NamedDecl = Context.Named.Declaration
 
 let instantiate_evar evk (ist,rawc) sigma =
   let evi = Evd.find sigma evk in
-  let filtered = Evd.evar_filtered_env evi in
+  let filtered = Evd.evar_env evi in
   let constrvars = Tacinterp.extract_ltac_constr_values ist filtered in
   let lvar = {
     Glob_term.ltac_constrs = constrvars;

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -483,7 +483,7 @@ let pf_abs_evars2 gl rigid (sigma, c0) =
   let nenv = env_size (pf_env gl) in
   let abs_evar n k =
     let evi = Evd.find sigma k in
-    let dc = CList.firstn n (evar_filtered_context evi) in
+    let dc = CList.firstn n (evar_context evi) in
     let abs_dc c = function
     | NamedDecl.LocalDef (x,b,t) -> mkNamedLetIn x b t (mkArrow t c)
     | NamedDecl.LocalAssum (x,t) -> mkNamedProd x t c in
@@ -543,7 +543,7 @@ let pf_abs_evars_pirrel gl (sigma, c0) =
   let nenv = env_size (pf_env gl) in
   let abs_evar n k =
     let evi = Evd.find sigma k in
-    let dc = CList.firstn n (evar_filtered_context evi) in
+    let dc = CList.firstn n (evar_context evi) in
     let abs_dc c = function
     | NamedDecl.LocalDef (x,b,t) -> mkNamedLetIn x b t (mkArrow t c)
     | NamedDecl.LocalAssum (x,t) -> mkNamedProd x t c in

--- a/plugins/ssrmatching/ssrmatching.ml4
+++ b/plugins/ssrmatching/ssrmatching.ml4
@@ -435,7 +435,7 @@ let evars_for_FO ~hack env sigma0 (ise0:evar_map) c0 =
     with NotInstantiatedEvar ->
     if Evd.mem sigma0 k then map_constr put c else
     let evi = Evd.find !sigma k in
-    let dc = List.firstn (max 0 (Array.length a - nenv)) (evar_filtered_context evi) in
+    let dc = List.firstn (max 0 (Array.length a - nenv)) (evar_context evi) in
     let abs_dc (d, c) = function
     | Context.Named.Declaration.LocalDef (x, b, t) ->
         d, mkNamedLetIn x (put b) (put t) c

--- a/pretyping/cases.ml
+++ b/pretyping/cases.ml
@@ -1706,10 +1706,11 @@ let abstract_tycon ?loc env evdref subst tycon extenv t =
       let named_filter =
 	List.map (fun d -> local_occur_var !evdref (NamedDecl.get_id d) u)
 	  (named_context extenv) in
-      let filter = Filter.make (rel_filter @ named_filter) in
       let candidates = u :: List.map mkRel vl in
-      let ev = e_new_evar extenv evdref ~src ~filter ~candidates ty in
-      lift k ev
+      let filter = Filter.make (rel_filter @ named_filter) in
+      let ev = e_new_evar extenv evdref ~src ~candidates ty in
+      let evd, ev' = restrict_applied_evar !evdref (destEvar !evdref ev) (Some filter) NoUpdate in
+      evdref := evd; lift k (mkEvar ev')
   in
   aux (0,extenv,subst0) t0
 

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -1110,7 +1110,7 @@ let apply_on_subterm env evdref f c t =
     else
       match EConstr.kind !evdref t with
       | Evar (evk,args) ->
-          let ctx = evar_filtered_context (Evd.find_undefined !evdref evk) in
+          let ctx = evar_context (Evd.find_undefined !evdref evk) in
           let g decl a = if is_local_assum decl then applyrec acc a else a in
           mkEvar (evk, Array.of_list (List.map2 g ctx (Array.to_list args)))
       | _ ->
@@ -1168,9 +1168,9 @@ exception TypingFailed of evar_map
 let second_order_matching ts env_rhs evd (evk,args) argoccs rhs =
   try
   let evi = Evd.find_undefined evd evk in
-  let env_evar = evar_filtered_env evi in
+  let env_evar = evar_env evi in
   let sign = named_context_val env_evar in
-  let ctxt = evar_filtered_context evi in
+  let ctxt = evar_context evi in
   let instance = List.map mkVar (List.map NamedDecl.get_id ctxt) in
 
   let rec make_subst = function
@@ -1199,9 +1199,10 @@ let second_order_matching ts env_rhs evd (evk,args) argoccs rhs =
         | Some _ -> user_err Pp.(str "Selection of specific occurrences not supported")
         | None ->
         let evty = set_holes evdref cty subst in
+        let sign = Evd.filter_evar_hyps filter sign in
         let instance = Filter.filter_list filter instance in
         let evd = !evdref in
-        let (evd, ev) = new_evar_instance sign evd evty ~filter instance in
+        let (evd, ev) = new_evar_instance sign evd evty instance in
         evdref := evd;
         evsref := (fst (destEvar !evdref ev),evty)::!evsref;
         ev in

--- a/pretyping/evardefine.ml
+++ b/pretyping/evardefine.ml
@@ -75,20 +75,17 @@ let define_pure_evar_as_product evd evk =
   let id = next_ident_away idx (ids_of_named_context (evar_context evi)) in
   let concl = Reductionops.whd_all evenv evd (EConstr.of_constr evi.evar_concl) in
   let s = destSort evd concl in
-  let evd1,(dom,u1) =
-    new_type_evar evenv evd univ_flexible_alg ~filter:(evar_filter evi)
-  in
+  let evd1,(dom,u1) = new_type_evar evenv evd univ_flexible_alg in
   let evd2,rng =
     let newenv = push_named (LocalAssum (id, dom)) evenv in
     let src = evar_source evk evd1 in
-    let filter = Filter.extend 1 (evar_filter evi) in
       if is_prop_sort (ESorts.kind evd1 s) then
        (* Impredicative product, conclusion must fall in [Prop]. *)
-        new_evar newenv evd1 concl ~src ~filter
+        new_evar newenv evd1 concl ~src
       else
 	let status = univ_flexible_alg in
 	let evd3, (rng, srng) =
-          new_type_evar newenv evd1 status ~src ~filter
+          new_type_evar newenv evd1 status ~src
         in
 	let prods = Univ.sup (univ_of_sort u1) (univ_of_sort srng) in
 	let evd3 = Evd.set_leq_sort evenv evd3 (Type prods) (ESorts.kind evd1 s) in
@@ -131,9 +128,8 @@ let define_pure_evar_as_lambda env evd evk =
   let id =
     next_name_away_with_default_using_types "x" na avoid (Reductionops.whd_evar evd dom) in
   let newenv = push_named (LocalAssum (id, dom)) evenv in
-  let filter = Filter.extend 1 (evar_filter evi) in
   let src = evar_source evk evd1 in
-  let evd2,body = new_evar newenv evd1 ~src (subst1 (mkVar id) rng) ~filter in
+  let evd2,body = new_evar newenv evd1 ~src (subst1 (mkVar id) rng) in
   let lam = mkLambda (Name id, dom, subst_var id body) in
   Evd.define evk (EConstr.Unsafe.to_constr lam) evd2, lam
 

--- a/pretyping/evarsolve.mli
+++ b/pretyping/evarsolve.mli
@@ -25,6 +25,17 @@ val is_success : unification_result -> bool
    their representative that is most ancient in the context *)
 val expand_vars_in_term : env -> evar_map -> constr -> constr
 
+
+type 'a update =
+| UpdateWith of 'a
+| NoUpdate
+
+val restrict_applied_evar : 
+  Evd.evar_map ->
+  Evd.evar * 'a array ->
+  Evd.Filter.t option ->
+  EConstr.constr list update -> Evd.evar_map * (Evd.evar * 'a array)
+
 (** [evar_define choose env ev c] try to instantiate [ev] with [c] (typed in [env]),
    possibly solving related unification problems, possibly leaving open
    some problems that cannot be solved in a unique way (except if choose is
@@ -85,3 +96,10 @@ val remove_instance_local_defs :
 
 val get_type_of_refresh : 
   ?polyprop:bool -> ?lax:bool -> env -> evar_map -> constr -> evar_map * types
+
+val recheck_applications :            (Environ.env ->
+            Evd.evar_map ->
+            Reduction.conv_pb ->
+            EConstr.types -> EConstr.constr -> unification_result) ->
+           Environ.env -> Evd.evar_map ref -> EConstr.constr -> unit
+

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -378,7 +378,7 @@ let adjust_evar_source evdref na c =
      begin match evi.evar_source with
      | loc, Evar_kinds.QuestionMark (b,Anonymous) ->
         let src = (loc,Evar_kinds.QuestionMark (b,na)) in
-        let (evd, evk') = restrict_evar !evdref evk (evar_filter evi) ~src None in
+        let (evd, evk') = restrict_evar !evdref evk Filter.identity ~src None in
         evdref := evd;
         mkEvar (evk',args)
      | _ -> c
@@ -595,7 +595,7 @@ let rec pretype k0 resolve_tc (tycon : type_constraint) (env : ExtraEnv.t) evdre
         try Evd.evar_key id !evdref
         with Not_found ->
           user_err ?loc  (str "Unknown existential variable.") in
-      let hyps = evar_filtered_context (Evd.find !evdref evk) in
+      let hyps = evar_context (Evd.find !evdref evk) in
       let args = pretype_instance k0 resolve_tc env evdref lvar loc hyps evk inst in
       let c = mkEvar (evk, args) in
       let j = (Retyping.get_judgment_of env.ExtraEnv.env !evdref c) in

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -515,15 +515,6 @@ let pr_concl n sigma g =
 let pr_evgl_sign sigma evi =
   let env = evar_env evi in
   let ps = pr_named_context_of env sigma in
-  let _, l = match Filter.repr (evar_filter evi) with
-  | None -> [], []
-  | Some f -> List.filter2 (fun b c -> not b) f (evar_context evi)
-  in
-  let ids = List.rev_map NamedDecl.get_id l in
-  let warn =
-    if List.is_empty ids then mt () else
-      (str "(" ++ prlist_with_sep pr_comma pr_id ids ++ str " cannot be used)")
-  in
   let pc = pr_lconstr_env env sigma evi.evar_concl in
   let candidates =
     match evi.evar_body, evi.evar_candidates with
@@ -534,7 +525,7 @@ let pr_evgl_sign sigma evi =
        mt ()
   in
   hov 0 (str"[" ++ ps ++ spc () ++ str"|- "  ++ pc ++ str"]" ++
-           candidates ++ spc () ++ warn)
+           candidates ++ spc ())
 
 (* Print an existential variable *)
 

--- a/proofs/evar_refiner.ml
+++ b/proofs/evar_refiner.ml
@@ -44,7 +44,7 @@ let define_and_solve_constraints evk c env evd =
 let w_refine (evk,evi) (ltac_var,rawc) sigma =
   if Evd.is_defined sigma evk then
     user_err Pp.(str "Instantiate called on already-defined evar");
-  let env = Evd.evar_filtered_env evi in
+  let env = Evd.evar_env evi in
   let sigma',typed_c =
     let flags = {
       Pretyping.use_typeclasses = true;

--- a/proofs/goal.ml
+++ b/proofs/goal.ml
@@ -31,12 +31,12 @@ module V82 = struct
   (* Old style env primitive *)
   let env evars gl =
     let evi = Evd.find evars gl in
-    Evd.evar_filtered_env evi
+    Evd.evar_env evi
 
   (* Old style hyps primitive *)
   let hyps evars gl =
     let evi = Evd.find evars gl in
-    Evd.evar_filtered_hyps evi
+    Evd.evar_hyps evi
 
   (* same as [hyps], but ensures that existential variables are
      normalised. *)
@@ -65,7 +65,6 @@ module V82 = struct
     let prev_principal_goal = Evd.principal_future_goal evars in
     let evi = { Evd.evar_hyps = hyps;
 		Evd.evar_concl = concl;
-		Evd.evar_filter = Evd.Filter.identity;
 		Evd.evar_body = Evd.Evar_empty;
 		Evd.evar_source = (Loc.tag Evar_kinds.GoalEvar);
 		Evd.evar_candidates = None;
@@ -123,10 +122,8 @@ module V82 = struct
     let hyps = evi.Evd.evar_hyps in
     let new_hyps =
       List.fold_right Environ.push_named_context_val extra_hyps hyps in
-    let filter = evi.Evd.evar_filter in
-    let new_filter = Evd.Filter.extend (List.length extra_hyps) filter in
     let new_evi =
-      { evi with Evd.evar_hyps = new_hyps; Evd.evar_filter = new_filter } in
+      { evi with Evd.evar_hyps = new_hyps } in
     let new_evi = Typeclasses.mark_unresolvable new_evi in
     let (sigma, evk) = Evarutil.new_pure_evar_full Evd.empty new_evi in
     { Evd.it = evk ; sigma = sigma; }

--- a/proofs/proof.ml
+++ b/proofs/proof.ml
@@ -426,7 +426,7 @@ module V82 = struct
         else
           CList.nth evl (n-1)
       in
-      let env = Evd.evar_filtered_env evi in
+      let env = Evd.evar_env evi in
       let rawc = Constrintern.intern_constr env com in
       let ltac_vars = Glob_ops.empty_lvar in
       let sigma = Evar_refiner.w_refine (evk, evi) (ltac_vars, rawc) sigma in

--- a/stm/proofBlockDelimiter.ml
+++ b/stm/proofBlockDelimiter.ml
@@ -40,7 +40,7 @@ let simple_goal sigma g gs =
   let open Evarutil in
   let evi = Evd.find sigma g in
   Set.is_empty (evars_of_term evi.evar_concl) &&
-  Set.is_empty (evars_of_filtered_evar_info (nf_evar_info sigma evi)) &&
+  Set.is_empty (evars_of_evar_info (nf_evar_info sigma evi)) &&
   not (List.exists (Proofview.depends_on sigma g) gs)
 
 let is_focused_goal_simple id =

--- a/test-suite/output/Existentials.out
+++ b/test-suite/output/Existentials.out
@@ -1,4 +1,3 @@
 Existential 1 = ?Goal : [p : nat  q := S p : nat  n : nat  m : nat |- ?y = m] 
-Existential 2 =
-?y : [p : nat  q := S p : nat  n : nat  m : nat |- nat] (p, q cannot be used)
+Existential 2 = ?y : [n : nat  m : nat |- nat] 
 Existential 3 = ?Goal0 : [q : nat  n : nat  m : nat |- n = ?y] 

--- a/test-suite/output/Notations.out
+++ b/test-suite/output/Notations.out
@@ -117,8 +117,7 @@ fun x : list ?T => match x with
                    end
      : list ?T -> option (list ?T)
 where
-?T : [x : list ?T  x1 : list ?T  x0 := x1 : list ?T |- Type] (x, x1,
-     x0 cannot be used)
+?T : [ |- Type] 
 s
      : s
 10

--- a/test-suite/output/Notations3.out
+++ b/test-suite/output/Notations3.out
@@ -108,4 +108,4 @@ foo5 x nat x
 fun x : ?A => x === x
      : forall x : ?A, x = x
 where
-?A : [x : ?A |- Type] (x cannot be used)
+?A : [ |- Type] 

--- a/theories/Vectors/VectorDef.v
+++ b/theories/Vectors/VectorDef.v
@@ -36,7 +36,6 @@ Local Notation "h :: t" := (cons _ h _ t) (at level 60, right associativity).
 Section SCHEMES.
 
 (** An induction scheme for non-empty vectors *)
-
 Definition rectS {A} (P:forall {n}, t A (S n) -> Type)
  (bas: forall a: A, P (a :: []))
  (rect: forall a {n} (v: t A (S n)), P v -> P (a :: v)) :=

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -585,7 +585,7 @@ let rec explain_evar_kind env sigma evk ty = function
 let explain_typeclass_resolution env sigma evi k =
   match Typeclasses.class_of_constr sigma (EConstr.of_constr evi.evar_concl) with
   | Some _ ->
-    let env = Evd.evar_filtered_env evi in
+    let env = Evd.evar_env evi in
       fnl () ++ str "Could not find an instance for " ++
       pr_lconstr_env env sigma evi.evar_concl ++
       pr_trailing_ne_context_of env sigma
@@ -602,7 +602,7 @@ let explain_placeholder_kind env sigma c e =
 
 let explain_unsolvable_implicit env sigma evk explain =
   let evi = Evarutil.nf_evar_info sigma (Evd.find_undefined sigma evk) in
-  let env = Evd.evar_filtered_env evi in
+  let env = Evd.evar_env evi in
   let type_of_hole = pr_lconstr_env env sigma evi.evar_concl in
   let pe = pr_trailing_ne_context_of env sigma in
   strbrk "Cannot infer " ++

--- a/vernac/obligations.ml
+++ b/vernac/obligations.ml
@@ -152,7 +152,7 @@ let evar_dependencies evm oev =
   let one_step deps =
     Evar.Set.fold (fun ev s ->
       let evi = Evd.find evm ev in
-      let deps' = evars_of_filtered_evar_info evi in
+      let deps' = evars_of_evar_info evi in
       if Evar.Set.mem oev deps' then
 	invalid_arg ("Ill-formed evar map: cycle detected for evar " ^ string_of_existential oev)
       else Evar.Set.union deps' s)
@@ -208,7 +208,7 @@ let eterm_obligations env name evm fs ?status t ty =
     (* Remove existential variables in types and build the corresponding products *)
     List.fold_right
       (fun (id, (n, nstr), ev) l ->
-	 let hyps = Evd.evar_filtered_context ev in
+	 let hyps = Evd.evar_context ev in
 	 let hyps = trunc_named_context nc_len hyps in
 	 let evtyp, deps, transp = etype_of_evar l hyps ev.evar_concl in
 	 let evtyp, hyps, chop =

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -445,7 +445,7 @@ let start_proof_and_print k l hook =
       let hook env sigma ev =
         let tac = !Obligations.default_tactic in
         let evi = Evd.find sigma ev in
-        let env = Evd.evar_filtered_env evi in
+        let env = Evd.evar_env evi in
         try
           let concl = Evarutil.nf_evars_universes sigma evi.Evd.evar_concl in
           let concl = EConstr.of_constr concl in


### PR DESCRIPTION
This is a tentative to simplify the API by doing immediate restrictions of evars instead of carrying an evar filter along, and seeing if it has performance impact. Filters are still used to perform restrictions. It should maintain correctness however I cannot figure out what to do in cases.ml to avoid making bugs/opened/3166 not fail earlier than expected, that's the only bug I introduced (apparently). It looks like "ill-typed" filters, i.e. filtering variables which can still appear in the evars' conclusion is used essentially. In this case, the vars appearing in the conclusion sometimes expand to variables that stay in the restricted evar, sometimes not, leading to really ill-scoped evars. Probably @herbelin can help :)