### PR TITLE
Rudimentary support for native_compute profiling, BZ#5170

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -63,6 +63,10 @@ Tactics
   Ltac definition or a Tactic Notation.
 - New option `Set Ltac Batch Debug` on top of `Set Ltac Debug` for
   non-interactive Ltac debug output.
+- On Linux, "native_compute" calls can be profiled using the "perf"
+  utility. The command "Set NativeCompute Profiling" enables
+  profiling, and "Set NativeCompute Profile Filename" customizes
+  the profile filename.
 
 Gallina
 

--- a/doc/refman/RefMan-tac.tex
+++ b/doc/refman/RefMan-tac.tex
@@ -3326,9 +3326,9 @@ evaluating purely computational expressions (i.e. with little dead code).
   \begin{quote}
     {\tt Set NativeCompute Profile Filename \str}
   \end{quote}
-  to specify the profile output; the default is {\tt native\_compute\_profile.data}. If there's an existing file with
-  the specified name, \Coq{} will append a number to it to avoid name collisions. That means you can
-  individually profile multiple uses of {\tt native\_compute} in a script. From the Linux command line, run {\tt perf report} on
+  to specify the profile output; the default is {\tt native\_compute\_profile.data}. The actual filename used 
+  will contain extra characters to avoid overwriting an existing file; that filename is reported to the user. That means
+  you can individually profile multiple uses of {\tt native\_compute} in a script. From the Linux command line, run {\tt perf report} on
   the profile file to see the results. Consult the {\tt perf} documentation for more details.
 
 \end{Variants}

--- a/doc/refman/RefMan-tac.tex
+++ b/doc/refman/RefMan-tac.tex
@@ -3269,7 +3269,7 @@ The call-by-value strategy is the one used in ML languages: the
 arguments of a function call are systematically weakly evaluated
 first. Despite the lazy strategy always performs fewer reductions than
 the call-by-value strategy, the latter is generally more efficient for
-evaluating purely computational expressions (i.e. with few dead code).
+evaluating purely computational expressions (i.e. with little dead code).
 
 \begin{Variants}
 \item {\tt compute} \tacindex{compute}\\
@@ -3316,6 +3316,20 @@ evaluating purely computational expressions (i.e. with few dead code).
   two to five times faster than {\tt vm\_compute}. Note however that the
   compilation cost is higher, so it is worth using only for intensive
   computations.
+
+  On Linux, if you have the {\tt perf} profiler installed, you can profile {\tt native\_compute} evaluations. 
+  The command
+  \begin{quote}
+    {\tt Set Native Compute Profiling}
+  \end{quote}
+  enables profiling. Use the command
+  \begin{quote}
+    {\tt Set NativeCompute Profile Filename \str}
+  \end{quote}
+  to specify the profile output; the default is {\tt native\_compute\_profile.data}. If there's an existing file with
+  the specified name, \Coq{} will append a number to it to avoid name collisions. That means you can
+  individually profile multiple uses of {\tt native\_compute} in a script. From the Linux command line, run {\tt perf report} on
+  the profile file to see the results. Consult the {\tt perf} documentation for more details.
 
 \end{Variants}
 

--- a/kernel/nativeconv.ml
+++ b/kernel/nativeconv.ml
@@ -132,7 +132,7 @@ let native_conv_gen pb sigma env univs t1 t2 =
   let penv = Environ.pre_env env in 
   let ml_filename, prefix = get_ml_filename () in
   let code, upds = mk_conv_code penv sigma prefix t1 t2 in
-  match compile ml_filename code with
+  match compile ml_filename code ~profile:false with
   | (true, fn) ->
       begin
         if !Flags.debug then Feedback.msg_debug (Pp.str "Running test...");

--- a/kernel/nativelib.mli
+++ b/kernel/nativelib.mli
@@ -19,7 +19,7 @@ val load_obj : (string -> unit) ref
 
 val get_ml_filename : unit -> string * string
 
-val compile : string -> global list -> bool * string
+val compile : string -> global list -> profile:bool -> bool * string
 
 val compile_library : Names.dir_path -> global list -> string -> bool
 

--- a/pretyping/nativenorm.ml
+++ b/pretyping/nativenorm.ml
@@ -436,11 +436,10 @@ let evars_of_evar_map sigma =
     Nativelambda.evars_metas = Evd.meta_type sigma }
 
 (* fork perf process, return profiler's process id *)
-let start_profiler_linux () =
+let start_profiler_linux profile_fn =
   let coq_pid = Unix.getpid () in (* pass pid of running coqtop *)
   (* we don't want to see perf's console output *)
   let dev_null = Unix.descr_of_out_channel (open_out_bin "/dev/null") in
-  let profile_fn = get_available_profile_filename () in
   let _ = Feedback.msg_info (Pp.str ("Profiling to file " ^ profile_fn)) in
   let perf = "perf" in
   let profiler_pid = 
@@ -468,8 +467,9 @@ let stop_profiler_linux m_pid =
   | None -> ()
 
 let start_profiler () =
+  let profile_fn = get_available_profile_filename () in
   match profiler_platform () with
-    "Unix (Linux)" -> start_profiler_linux ()
+    "Unix (Linux)" -> start_profiler_linux profile_fn
   | _ ->
      let _ = Feedback.msg_info
        (Pp.str (Format.sprintf "Native_compute profiling not supported on the platform: %s"

--- a/pretyping/nativenorm.ml
+++ b/pretyping/nativenorm.ml
@@ -54,8 +54,17 @@ let get_available_profile_filename () =
   let profile_filename = get_profile_filename () in
   let dir = Filename.dirname profile_filename in 
   let base = Filename.basename profile_filename in 
-  let ext = Filename.extension base in 
-  let name = Filename.remove_extension base in 
+  (* starting with OCaml 4.04, could use Filename.remove_extension and Filename.extension, which
+     gets rid of need for exception-handling here
+  *)
+  let (name,ext) =
+    try
+      let nm = Filename.chop_extension base in
+      let nm_len = String.length nm in
+      let ex = String.sub base nm_len (String.length base - nm_len) in
+      (nm,ex)
+    with Invalid_argument _ -> (base,"")
+  in
   try 
     (* unlikely race: fn deleted, another process uses fn *)
     Filename.temp_file ~temp_dir:dir (name ^ "_") ext

--- a/pretyping/nativenorm.mli
+++ b/pretyping/nativenorm.mli
@@ -12,6 +12,13 @@ open Evd
 
 (** This module implements normalization by evaluation to OCaml code *)
 
+val get_profile_filename : unit -> string
+val set_profile_filename : string -> unit
+
+val get_profiling_enabled : unit -> bool
+val set_profiling_enabled : bool -> unit
+
+
 val native_norm : env -> evar_map -> constr -> types -> constr
 
 (** Conversion with inference of universe constraints *)

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1457,6 +1457,22 @@ let _ =
       optread  = CWarnings.get_flags;
       optwrite = CWarnings.set_flags }
 
+let _ =
+  declare_string_option 
+    { optdepr  = false;
+      optname  = "native_compute profiler output";
+      optkey   = ["NativeCompute"; "Profile"; "Filename"];
+      optread  = Nativenorm.get_profile_filename;
+      optwrite = Nativenorm.set_profile_filename }
+
+let _ =
+  declare_bool_option
+    { optdepr  = false;
+      optname  = "enable native compute profiling";
+      optkey   = ["NativeCompute"; "Profiling"];
+      optread  = Nativenorm.get_profiling_enabled;
+      optwrite = Nativenorm.set_profiling_enabled }
+
 let vernac_set_strategy locality l =
   let local = make_locality locality in
   let glob_ref r =


### PR DESCRIPTION
This is a proof of concept for profiling `native_compute` on Linux, rough-around-the-edges.

How to use it:
 ```
  Set NativeCompute Profiling.
  Set NativeCompute Profile Filename "filename-probably-with-a-directory".
  Eval native_compute in your-expression-here.
```
Specifying the filename is optional, the default is "native_compute_profile.data" (though I'm not sure where it will be placed).

The setup assumes you have `perf` installed (and I think it needs to be in the default PATH).

After running the line with `native_compute`, you should be able to run `perf report` on the profile output from a shell. On my Linux box, running Mint 18, I used the command:
```
  perf report -g fractal,callee --no-children -f -i the-profile-file
```
The `-f` flag is because `perf` creates the file with funny permissions on my machine, maybe it behaves differently elsewhere. 

I ran an example from Xavier Leroy:
```
Require Import ZArith.
Open Scope Z_scope.

Fixpoint fib (n: nat) : Z :=
  match n with 0%nat => 1 | 1%nat => 1 | S (S n2 as n1) => fib n1 + fib n2 end.
Eval native_compute in (fib 42%nat).
```
and I can see lots of stuff from `ZArith` and `PArith` at the top of the profile.








