### PR TITLE
Makefile: install-byte works even if -coqide no

### DIFF
--- a/Makefile.ide
+++ b/Makefile.ide
@@ -127,12 +127,17 @@ ide/%.cmx: ide/%.ml
 ## Install targets
 ####################
 
-.PHONY: install-coqide install-ide-bin install-ide-toploop install-ide-files install-ide-info install-ide-devfiles install-ide-byte
+.PHONY: install-coqide install-ide-bin install-ide-toploop install-ide-files install-ide-info install-ide-devfiles install-ide-byte install-ide-toploop-byte install-coqide-byte
 
 ifeq ($(HASCOQIDE),no)
 install-coqide: install-ide-toploop
 else
 install-coqide: install-ide-bin install-ide-toploop install-ide-files install-ide-info install-ide-devfiles
+endif
+ifeq ($(HASCOQIDE),no)
+install-coqide-byte: install-ide-toploop-byte
+else
+install-coqide-byte: install-ide-toploop-byte install-ide-byte
 endif
 
 # Apparently, coqide.byte is not meant to be installed
@@ -140,8 +145,6 @@ endif
 install-ide-byte:
 	$(MKDIR) $(FULLCOQLIB)
 	$(INSTALLSH) $(FULLCOQLIB) $(IDECMA)
-	$(MKDIR) $(FULLCOQLIB)/toploop
-	$(INSTALLBIN) $(IDETOPLOOPCMA) $(FULLCOQLIB)/toploop/
 
 install-ide-bin:
 	$(MKDIR) $(FULLBINDIR)
@@ -150,6 +153,10 @@ install-ide-bin:
 install-ide-toploop:
 ifeq ($(BEST),opt)
 	$(INSTALLBIN) $(IDETOPLOOPCMA:.cma=.cmxs) $(FULLCOQLIB)/toploop/
+endif
+install-ide-toploop-byte:
+ifneq ($(BEST),opt)
+	$(INSTALLBIN) $(IDETOPLOOPCMA) $(FULLCOQLIB)/toploop/
 endif
 
 install-ide-devfiles:

--- a/Makefile.install
+++ b/Makefile.install
@@ -74,7 +74,7 @@ ifeq ($(BEST),opt)
 	$(INSTALLBIN) $(TOPLOOPCMA:.cma=.cmxs) $(FULLCOQLIB)/toploop/
 endif
 
-install-byte: install-ide-byte
+install-byte: install-coqide-byte
 	$(MKDIR) $(FULLBINDIR)
 	$(INSTALLBIN) $(COQTOPBYTE) $(FULLBINDIR)
 	$(INSTALLBIN) $(TOPLOOPCMA) $(FULLCOQLIB)/toploop/


### PR DESCRIPTION
The current `install-byte` target tries to install `coqide` even if it is not available