### PR TITLE
Print names of all open blocks

### DIFF
--- a/test-suite/output/UnclosedBlocks.out
+++ b/test-suite/output/UnclosedBlocks.out
@@ -1,0 +1,3 @@
+
+Error: The section Baz, module type Bar and module Foo need to be closed.
+

--- a/test-suite/output/UnclosedBlocks.v
+++ b/test-suite/output/UnclosedBlocks.v
@@ -1,0 +1,8 @@
+(* -*- mode: coq; coq-prog-args: ("-compile" "UnclosedBlocks.v") *)
+Module Foo.
+  Module Closed.
+  End Closed.
+  Module Type Bar.
+    Section Baz.
+      (* end-of-compilation error message reports unclosed sections, blocks, and
+      module types *)


### PR DESCRIPTION
Fixes [bug 5597](https://coq.inria.fr/bugs/show_bug.cgi?id=5597).

If desired, I can improve this patch to print the sequence of open sections/modules/module types.