### PR TITLE
Set detachable windows type hint to dialog.

### DIFF
--- a/ide/wg_Detachable.ml
+++ b/ide/wg_Detachable.ml
@@ -19,7 +19,7 @@ class detachable (obj : ([> Gtk.box] as 'a) Gobject.obj) =
     inherit GPack.box_skel (obj :> Gtk.box Gobject.obj) as super
 
     val but = GButton.button ()
-    val win = GWindow.window ()
+    val win = GWindow.window ~type_hint:`DIALOG ()
     val frame = GBin.frame ~shadow_type:`NONE ()
     val mutable detached = false
     val mutable detached_cb = (fun _ -> ())


### PR DESCRIPTION
Windows such as Search & Replace should be created as dialogs.
For some window manager, such as i3, windows won't be displayed floating by default without this flag.