### PR TITLE
coq_makefile: "-open API" is not a directory (fixup 41489a97)

### DIFF
--- a/tools/coq_makefile.ml
+++ b/tools/coq_makefile.ml
@@ -203,7 +203,7 @@ let generate_conf_coq_config oc args bypass_API =
   section oc "Coq configuration.";
   let src_dirs = if bypass_API
                  then Coq_config.all_src_dirs
-                 else Coq_config.api_dirs @ Coq_config.plugins_dirs @ ["-open API"] in
+                 else Coq_config.api_dirs @ Coq_config.plugins_dirs in
   Envars.print_config ~prefix_var_name:"COQMF_" oc src_dirs;
   fprintf oc "COQMF_WINDRIVE=%s\n" (windrive Coq_config.coqlib)
 ;;


### PR DESCRIPTION
It did not blow up because the makefile would prefix `-I coqpath/` resulting in `-I coqpath/-open -I coqpath/API` and `ocamlc` does not complain if you pass `-I nonexistent`