### PR TITLE
Makefile : ignore user-contrib in various file searches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ FIND_SKIP_DIRS:='(' \
   -name "$${GIT_DIR}" -o \
   -name '_build' -o \
   -name '_build_ci' -o \
+  -name 'user-contrib' -o \
   -name 'coq-makefile' -o \
   -name '.opamcache' -o \
   -name '.coq-native' \


### PR DESCRIPTION
This is crucial for the search for binary files without known sources (see PR #852) on a "local" build, since `coq_makefile` currently doesn't install in `user-contrib` the ML sources of user plugins.

This could also helps for variables such as `$(EXISTINGML)`.

Btw, there's a discussion to have about the action of `make clean` on `user-contrib` (on a "local" build).
The current behavior is awkward : `*.cm*` files are removed in `user-contrib`, but not the `.vo` files. We probably want `user-contrib` to be fully cleaned. 