### PR TITLE
Update debugging

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ If you want to minimize your bug (or help minimize someone else's) for more extr
 
 If you want to contribute a bug fix or feature yourself, pull requests on the [GitHub repository](https://github.com/coq/coq) are the way to contribute directly to the Coq implementation. We recommend you create a fork of the repository on GitHub and push your changes to a new "topic branch" in that fork. From there you can follow the [GitHub pull request documentation](https://help.github.com/articles/about-pull-requests/) to get your changes reviewed and pulled into the Coq source repository.
 
-Documentation for getting started with the Coq sources is located in various files in [`dev/doc`](/dev/doc) (for example, [debugging.txt](/dev/doc/debugging.txt)). For further help with the Coq sources, feel free to join the [Coq Gitter chat](https://gitter.im/coq/coq) and ask questions.
+Documentation for getting started with the Coq sources is located in various files in [`dev/doc`](/dev/doc) (for example, [debugging.md](/dev/doc/debugging.md)). For further help with the Coq sources, feel free to join the [Coq Gitter chat](https://gitter.im/coq/coq) and ask questions.
 
 Please make pull requests against the `master` branch.
 

--- a/dev/doc/debugging.md
+++ b/dev/doc/debugging.md
@@ -65,14 +65,14 @@ Global gprof-based profiling
 Per function profiling
 ======================
 
-   1. To profile function foo in file bar.ml, add the following lines, just
-      after the definition of the function:
+   To profile function foo in file bar.ml, add the following lines, just
+   after the definition of the function:
 
      let fookey = Profile.declare_profile "foo";;
      let foo a b c = Profile.profile3 fookey foo a b c;;
 
-     where foo is assumed to have three arguments (adapt using
-     Profile.profile1, Profile. profile2, etc).
+   where foo is assumed to have three arguments (adapt using
+   Profile.profile1, Profile. profile2, etc).
 
-     This has the effect to cumulate the time passed in foo under a
-     line of name "foo" which is displayed at the time coqtop exits.
+   This has the effect to cumulate the time passed in foo under a
+   line of name "foo" which is displayed at the time coqtop exits.

--- a/dev/doc/debugging.md
+++ b/dev/doc/debugging.md
@@ -25,8 +25,9 @@ Debugging from Coq toplevel using Caml trace mechanism
 Debugging from Caml debugger
 ============================
 
-   Needs tuareg mode in Emacs
-   Coq must be configured with -debug and -local (./configure -debug -local)
+   Requires [Tuareg mode](https://github.com/ocaml/tuareg) in Emacs.\
+   Coq must be configured with `-local` (`./configure -local`) and the
+   byte-code version of `coqtop` must have been generated with `make byte`.
 
    1. M-x camldebug
    2. give the binary name bin/coqtop.byte


### PR DESCRIPTION
Each time I change a file in `dev/doc` I try to see if I can move it to Markdown.
For this one it was easy (see first commit).
The second commit is the adaptation that I actually wanted to make (remove mention of `-debug` option and mention `make byte` since it is not called when doing just `make` anymore).

TODO: fix link in `CONTRIBUTING.md` if #961 is merged before.