### PR TITLE
Better error messages on the CI

### DIFF
--- a/Makefile.ci
+++ b/Makefile.ci
@@ -24,7 +24,4 @@ CI_TARGETS=ci-all \
 
 # Generic rule, we use make to easy travis integraton with mixed rules
 $(CI_TARGETS): ci-%:
-	+./dev/ci/ci-pipe-tee.sh ./dev/ci/ci-$*.sh time-of-build.log
-	echo 'Aggregating timing log...' && echo -en 'travis_fold:start:coq.test.timing\\r'
-	python ./tools/make-one-time-file.py time-of-build.log
-	echo -en 'travis_fold:end:coq.test.timing\\r'
+	+./dev/ci/ci-wrapper.sh ci-$*.sh

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -24,9 +24,7 @@ CI_TARGETS=ci-all \
 
 # Generic rule, we use make to easy travis integraton with mixed rules
 $(CI_TARGETS): ci-%:
-	rm -f ci-$*.ok
-	+(./dev/ci/ci-$*.sh 2>&1 && touch ci-$*.ok) | tee time-of-build.log
+	+./dev/ci/ci-pipe-tee.sh ./dev/ci/ci-$*.sh time-of-build.log
 	echo 'Aggregating timing log...' && echo -en 'travis_fold:start:coq.test.timing\\r'
 	python ./tools/make-one-time-file.py time-of-build.log
 	echo -en 'travis_fold:end:coq.test.timing\\r'
-	rm ci-$*.ok # must not be -f; we're checking to see that it exists

--- a/dev/ci/ci-pipe-tee.sh
+++ b/dev/ci/ci-pipe-tee.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-# Use this script to preserve the exit code of $1 when piping it to
-# `tee $2`.  We have a separate script, because this only works in
-# bash, which we don't require project-wide.
-
-"$1" 2>&1 | tee "$2"
-exit ${PIPESTATUS[0]}

--- a/dev/ci/ci-pipe-tee.sh
+++ b/dev/ci/ci-pipe-tee.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Use this script to preserve the exit code of $1 when piping it to
+# `tee $2`.  We have a separate script, because this only works in
+# bash, which we don't require project-wide.
+
+"$1" 2>&1 | tee "$2"
+exit ${PIPESTATUS[0]}

--- a/dev/ci/ci-wrapper.sh
+++ b/dev/ci/ci-wrapper.sh
@@ -9,7 +9,7 @@ set -eo pipefail
 function travis_fold {
     if [ -n "${TRAVIS}" ];
     then
-	echo -n "travis_fold:$1:$2\\r"
+	echo "travis_fold:$1:$2"
     fi
 }
 

--- a/dev/ci/ci-wrapper.sh
+++ b/dev/ci/ci-wrapper.sh
@@ -19,6 +19,6 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "${DIR}/../.."
 
 "${DIR}/${CI_SCRIPT}" 2>&1 | tee time-of-build.log
-echo 'Aggregating timing log...' && travis_fold 'start' 'coq.test.timing'
+travis_fold 'start' 'coq.test.timing' && echo 'Aggregating timing log...'
 python ./tools/make-one-time-file.py time-of-build.log
 travis_fold 'end' 'coq.test.timing'

--- a/dev/ci/ci-wrapper.sh
+++ b/dev/ci/ci-wrapper.sh
@@ -6,12 +6,19 @@
 
 set -eo pipefail
 
+function travis_fold {
+    if [ -n "${TRAVIS}" ];
+    then
+	echo -n "travis_fold:$1:$2\\r"
+    fi
+}
+
 CI_SCRIPT="$1"
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # assume this script is in dev/ci/, cd to the root Coq directory
 cd "${DIR}/../.."
 
 "${DIR}/${CI_SCRIPT}" 2>&1 | tee time-of-build.log
-echo 'Aggregating timing log...' && echo -en 'travis_fold:start:coq.test.timing\\r'
+echo 'Aggregating timing log...' && travis_fold 'start' 'coq.test.timing'
 python ./tools/make-one-time-file.py time-of-build.log
-echo -en 'travis_fold:end:coq.test.timing\\r'
+travis_fold 'end' 'coq.test.timing'

--- a/dev/ci/ci-wrapper.sh
+++ b/dev/ci/ci-wrapper.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# Use this script to preserve the exit code of $CI_SCRIPT when piping
+# it to `tee time-of-build.log`.  We have a separate script, because
+# this only works in bash, which we don't require project-wide.
+
+set -eo pipefail
+
+CI_SCRIPT="$1"
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+# assume this script is in dev/ci/, cd to the root Coq directory
+cd "${DIR}/../.."
+
+"${DIR}/${CI_SCRIPT}" 2>&1 | tee time-of-build.log
+echo 'Aggregating timing log...' && echo -en 'travis_fold:start:coq.test.timing\\r'
+python ./tools/make-one-time-file.py time-of-build.log
+echo -en 'travis_fold:end:coq.test.timing\\r'


### PR DESCRIPTION
This makes it so that when a ci target fails, we don't get red herring
error messages about .ok files not existing.

Since this requires bash, we make a helper script that invokes bash, so
as to not depend on bash in general.