### PR TITLE
Fix ocamldebug hang, BZ#5688

### DIFF
--- a/lib/profile.ml
+++ b/lib/profile.ml
@@ -33,7 +33,7 @@ let get_alloc_overhead =
   (* measurements; with two measures the risk decreases *)
   min (mark2 -. mark1) (mark3 -. mark2)
 
-let last_alloc = ref 0.0 (* set by init_profile () *)
+let last_alloc = ref (get_alloc ()) (* set again by init_profile () *)
 
 let spent_alloc () =
   let now = get_alloc () in


### PR DESCRIPTION
I'm not sure exactly why this eliminates the ocamldebug hanging problem when you try to debug coqtop.byte.

But the assignment to `last_alloc` in `init_profile` at the module top level (rather than inside a function) seemed to be the critical bit. So, I just initialized `last_alloc` to the same thing, and voila, ocamldebug works again on coqtop.byte.