### PR TITLE
Fix coqdoc test-suite target on Windows.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,7 @@ test-suite/coq-makefile/plugin-reach-outside-API-and-fail/_CoqProject
 test-suite/coq-makefile/plugin-reach-outside-API-and-succeed-by-bypassing-the-API/_CoqProject
 test-suite/coqdoc/Coqdoc.*
 test-suite/coqdoc/index.html
+test-suite/coqdoc/coqdoc.css
 
 # documentation
 

--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -528,8 +528,8 @@ $(addsuffix .log,$(wildcard coqdoc/*.v)): %.v.log: %.v %.html.out %.tex.out $(PR
 	  f=`basename $*`; \
 	  $(coqdoc) -R . Coqdoc -coqlib http://coq.inria.fr/stdlib --html $$f.v; \
 	  $(coqdoc) -R . Coqdoc -coqlib http://coq.inria.fr/stdlib --latex $$f.v; \
-	  diff -u $$f.html.out Coqdoc.$$f.html 2>&1; R=$$?; times; \
-	  grep -v "^%%" Coqdoc.$$f.tex | diff -u $$f.tex.out - 2>&1; S=$$?; times; \
+	  diff -u --strip-trailing-cr $$f.html.out Coqdoc.$$f.html 2>&1; R=$$?; times; \
+	  grep -v "^%%" Coqdoc.$$f.tex | diff -u --strip-trailing-cr $$f.tex.out - 2>&1; S=$$?; times; \
 	  if [ $$R = 0 -a $$S = 0 ]; then \
 	    echo $(log_success); \
 	    echo "    $<...Ok"; \

--- a/tools/coqdoc/index.ml
+++ b/tools/coqdoc/index.ml
@@ -117,7 +117,7 @@ let find_module m =
   if Hashtbl.mem local_modules m then
     Local
   else
-    try External (Filename.concat (find_external_library m) m)
+    try External (find_external_library m ^ "/" ^ m)
     with Not_found -> Unknown
 
 


### PR DESCRIPTION
Commit 8f12597 introduced new output tests but these were broken on Windows.
This PR hopefully fixes them by using `--strip-trailing-cr` option of `diff`, like in other output tests in the test-suite.
All I can say for sure is that this doesn't break the tests on my machine. However, AppVeyor will have to tell whether this actually fixes the issue.