### PR TITLE
In Array.smartmap, read and write from same array

### DIFF
--- a/lib/cArray.ml
+++ b/lib/cArray.ml
@@ -331,7 +331,7 @@ let smartmap f (ar : 'a array) =
     Array.unsafe_set ans !i v;
     incr i;
     while !i < len do
-      let v = Array.unsafe_get ar !i in
+      let v = Array.unsafe_get ans !i in
       let v' = f v in
       if v != v' then Array.unsafe_set ans !i v';
       incr i

--- a/lib/cArray.ml
+++ b/lib/cArray.ml
@@ -514,7 +514,7 @@ struct
       Array.unsafe_set ans !i v;
       incr i;
       while !i < len do
-        let v = Array.unsafe_get ar !i in
+        let v = Array.unsafe_get ans !i in
         let v' = f arg v in
         if v != v' then Array.unsafe_set ans !i v';
         incr i


### PR DESCRIPTION
`Array.smartmap` is a time-sink in the Kami project.

The array `ans` is a copy of the input array `ar`. In the second `while` loop, writes are to `ans`, while reads are from `ar`. Since `ans` is a copy, reads from it should yield the same values. If we read and write using the same array, we might get better memory locality.

While I don't expect this change to be a big win, it might be worth seeing what pendulum does.
