### PR TITLE
Unifall: episode II - apply

### DIFF
--- a/compat_unif
+++ b/compat_unif
@@ -1,0 +1,144 @@
+Unification compatibility.
+
+TODO:
+
+  1 - Reorder commits to have changes to evarconv/clenv/clenvtac first.
+  2 - First apply changes
+  3 - Tactic changes
+  4 - rewrite changes.
+
+  5 - Rebase on current master.
+
+  6 - Copy old code in a plugin for compat and dispatch based on version.
+  
+  7 - Cleanup intf of new code, removing unification.ml and
+    metas (some thinking needed for patterns).
+
+  8 - Profit.
+
+Tactic refinements:
+
+  - apply should have two variants: one for triggering higher-order unification
+  and one without. apply_ho is much more powerful but can also produce meaningless
+  abstractions.
+
+
+- eapply could shelve subgoals before.
+
+  Two cases: forall e : Equiv, Reflexive (equiv e) applied to Reflexive ?X
+  -> Equiv becomes a subgoal even if dependent
+
+  ?X := equiv ?e
+
+  Proper (respectful (relprod ?R ?S) ?S) (snd t) applied to Proper (respectful ?R' eq) (@snd t t)
+
+  -> ?R does not become a subgoal, ?R dependent
+
+  No difference? ?MR is an initial _meta_ of the lemma, with ?R' :=
+  relprod ?R' ?S with ?MR := ?R', an evar.  ?Me is an initial meta of
+  the lemma with ?X := equiv ?e'.  ?Me := e'
+
+  Here ?R is a meta instantiated by an evar and unify_resolve succeeds
+  without seeing that evar is left around, as clenv_pose_dependent_evars
+  was just looking at the meta substitution which contains no meta
+  without instance.
+
+
+- eapply in eauto now shelves any dependent subgoals.  One fix in the
+  standard library (instances of Reflexive equiv, Symmetric equiv and
+  Transitive equiv).
+
+
+- rewrite uses a syntactic pattern to filter subterms on which
+  unification with conversion is applied.  + Evars appear in the pattern
+  and have to match syntactically (source of incompatibility).
+
+- apply's unification first-order heuristic is a bit strange in the
+  sense that it does not subsitute existing solutions to previous evars
+  eagerly, allowing to unify (fun x y => S) u v with ?X ?U ?V even if ?X
+  was already instantiated with a lambda. Evarconv reduces in this case.
+  One example in FMapFacts/cardinal_2 where a "change" was used to
+  produce a dummy beta-redex changed to use explicit with bindings
+  instead.
+
+- sometimes the user writes an explicit pattern for HO unification,
+  which we obey instead of resorting to ho unification even if the
+  tactic explicitly uses it, e.g. elim. This ambiguity is a source of
+  non-uniform behavior. We use a heuristic to decide if the user
+  provided a pattern himself, and sometimes this is not the intention of
+  the user, see failure/rewrite_in_hyp2.
+
+- simple apply's unification does conversion only on closed subterms,
+  but these are not recognized the same way in evarconv (unification.ml
+  can solve subproblems f ?X = g t using conversion on f and g but not
+  on ?X and t). Evarconv is uniform with respect to this (no "subterm"
+  restriction).  To re-establish compatibility in this case we make
+  (e)auto's apply unfold local variables, using a new Hint Variables
+  Transparent directive on the "core" hint database.  TODO: cleanup in
+  auto.ml, we now always use flags from the database.  See
+  e.g. FMapFacts/Partition_cardinal's eauto.
+
+- rewrite does not simplify goals w.r.t. zeta to find occurrences anymore,
+  requiring explicit simplifications instead.
+
+- When checking which arguments are dependent or not for apply/exists/transitivity etc...
+  with bindings.
+  The current strategy is hard to reproduce.
+
+  - Most of the time, the bindings are resolved before the tactic does
+  anything with its argument. e.g. in apply, with bindings are processed
+  before unification of the conclusion happens
+
+  - For [exists t] however, t is passed as an ImplicitBinding and [t]
+  must be provided _after_ unifiying with the conclusion to have enought
+  type information.
+
+  - With metas, the clenv could postpone an unification that failed to
+  be tried again _after_ the unification with the conclusion. However the
+  criterion was fuzzy: see bug #4813.
+
+  We now do a kind of best effort, trying the unification of bindings
+  before the unification with the conclusion, and if that fails, also after.
+
+- Closed bugs:
+
+ 
+
+- Closed bugs which required some work:
+
+  2830: cannot define evar twice: due to evar_define doing the check_evar_instance
+  before the Evd.define, now inverted.
+
+  3263: suddenly back to the very slow behaviors of before
+
+  3513, 4095: canonical structure creates an unsolvable typeclass constraint that makes a latter proof-search
+  diverge. Creating the evar with unresolvable store during unification does not help...
+  Actually this uses w_unify_to_subterm which uses the old w_unify code. Need to adapt this.
+  
+  Previously, unification through w_unify.ml created a meta during the canonical structure resolution,
+  which prevented the simple apply of typeclass resolution from succeeding, as there was an unsolved
+  dependent meta. This is not the case currently, unless we make the evar unresolvable in evarconv
+  during canonical structure resolution, and propagate unresolvability in Evd.restrict as well,
+  and check unresolvability in goals created by application of a hint during resolution.
+  But that's not correct either, because we do want to launch resolution on the "unresolvable" subgoals
+  actually.
+  Phew !
+
+  bug 2830: with not done at the right time, should be delayed. Actually no,
+  it was the use of higher-order before regular unification.
+
+  3258: typeclass resolution issue: the [apply reflexivity] hint is way too strong now,
+  with HO unification baked in apply, resulting in diverging proof search.
+  Also setoid_rewrite still calls w_unify which was allowing HO matching of the redex with the
+  subterm, too strong as well.
+
+  3485: proper treatment of frozen_evars, necessary when we move from metas
+  which did much less instantiation of evars. Propagate frozen_evars everywhere.
+
+  3539: required improvement of occur_rigidly, to avoid postponing an impossible constraint.
+
+  4782: with done too early, needing conclusion's unification -> now backtracking
+  4813: with done too early, needing conclusion's unification -> now backtracking
+  
+  HoTT_coq_091: HO unif failing eliminating a dependent equality, due to cumulativity, now fixed.
+

--- a/dev/ci/user-overlays/00991-mattam82-unifall-apply.sh
+++ b/dev/ci/user-overlays/00991-mattam82-unifall-apply.sh
@@ -1,0 +1,6 @@
+if [ "$CI_PULL_REQUEST" = "991" ] || [ "$CI_BRANCH" = "unifall-apply" ]; then
+
+    bignums_CI_REF=unifall-apply
+    bignums_CI_GITURL=https://github.com/maximedenes/bignums
+
+fi

--- a/engine/eConstr.ml
+++ b/engine/eConstr.ml
@@ -214,6 +214,11 @@ let decompose_app sigma c =
     | App (f,cl) -> (f, Array.to_list cl)
     | _ -> (c,[])
 
+let decompose_appvect sigma c =
+  match kind sigma c with
+    | App (f,cl) -> (f, cl)
+    | _ -> (c,[||])
+
 let decompose_lam sigma c =
   let rec lamdec_rec l c = match kind sigma c with
     | Lambda (x,t,c) -> lamdec_rec ((x,t)::l) c

--- a/engine/eConstr.mli
+++ b/engine/eConstr.mli
@@ -207,6 +207,7 @@ val destCoFix : Evd.evar_map -> t -> (t, t) pcofixpoint
 val destRef : Evd.evar_map -> t -> GlobRef.t * EInstance.t
 
 val decompose_app : Evd.evar_map -> t -> t * t list
+val decompose_appvect : Evd.evar_map -> t -> t * t array
 
 (** Pops lambda abstractions until there are no more, skipping casts. *)
 val decompose_lam : Evd.evar_map -> t -> (Name.t Context.binder_annot * t) list * t

--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -36,6 +36,7 @@ val new_evar :
   ?abstract_arguments:Abstraction.t -> ?candidates:constr list ->
   ?naming:intro_pattern_naming_expr ->
   ?typeclass_candidate:bool ->
+  ?future_goal:bool ->
   ?principal:bool -> ?hypnaming:naming_mode ->
   env -> evar_map -> types -> evar_map * EConstr.t
 
@@ -54,6 +55,7 @@ val new_pure_evar :
   ?abstract_arguments:Abstraction.t -> ?candidates:constr list ->
   ?naming:intro_pattern_naming_expr ->
   ?typeclass_candidate:bool ->
+  ?future_goal:bool ->
   ?principal:bool ->
   named_context_val -> evar_map -> types -> evar_map * Evar.t
 
@@ -62,6 +64,7 @@ val new_pure_evar :
 val new_type_evar :
   ?src:Evar_kinds.t Loc.located -> ?filter:Filter.t ->
   ?naming:intro_pattern_naming_expr ->
+  ?future_goal:bool ->
   ?principal:bool -> ?hypnaming:naming_mode ->
   env -> evar_map -> rigid ->
   evar_map * (constr * Sorts.t)

--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -1000,7 +1000,7 @@ module Unsafe = struct
   let (>>=) = tclBIND
 
   let tclEVARS evd =
-    Pv.modify (fun ps -> { ps with solution = evd })
+    Pv.modify (fun ps -> { ps with solution = Evd.clear_metas evd })
 
   let tclNEWGOALS gls =
     Pv.modify begin fun step ->

--- a/plugins/ltac/rewrite.ml
+++ b/plugins/ltac/rewrite.ml
@@ -506,8 +506,8 @@ let decompose_applied_relation env sigma (c,l) =
   let open Context.Rel.Declaration in
   let ctype = Retyping.get_type_of env sigma c in
   let find_rel ty =
-    let sigma, cl = Clenv.make_evar_clause env sigma ty in
-    let sigma = Clenv.solve_evar_clause env sigma true cl l in
+    let sigma, cl = Clenv.make_evar_clause env sigma c ty in
+    let sigma, cl = Clenv.solve_evar_clause env sigma ~hyps_only:true cl l in
     let { Clenv.cl_holes = holes; Clenv.cl_concl = t } = cl in
     let (equiv, c1, c2) = decompose_app_rel env sigma t in
     let ty1 = Retyping.get_type_of env sigma c1 in
@@ -516,9 +516,7 @@ let decompose_applied_relation env sigma (c,l) =
     | None -> None
     | Some sigma ->
       let sort = sort_of_rel env sigma equiv in
-      let args = Array.map_of_list (fun h -> h.Clenv.hole_evar) holes in
-      let value = mkApp (c, args) in
-        Some (sigma, { prf=value;
+        Some (sigma, { prf=cl.Clenv.cl_val;
                 car=ty1; rel = equiv; sort = Sorts.is_prop sort;
                 c1=c1; c2=c2; holes })
   in

--- a/plugins/ltac/rewrite.ml
+++ b/plugins/ltac/rewrite.ml
@@ -2179,7 +2179,7 @@ let setoid_reflexivity =
      tac_open (poly_proof PropGlobal.get_reflexive_proof
                           TypeGlobal.get_reflexive_proof
                           env evm car rel)
-              (fun c -> tclCOMPLETE (apply c)))
+              (fun c -> tclCOMPLETE (apply ~with_delta:true c)))
     (reflexivity_red true)
 
 let setoid_symmetry =
@@ -2188,7 +2188,7 @@ let setoid_symmetry =
       tac_open
         (poly_proof PropGlobal.get_symmetric_proof TypeGlobal.get_symmetric_proof
            env evm car rel)
-        (fun c -> apply c))
+        (fun c -> apply ~with_delta:true c))
     (symmetry_red true)
 
 let setoid_transitivity c =
@@ -2198,7 +2198,7 @@ let setoid_transitivity c =
            env evm car rel)
         (fun proof -> match c with
         | None -> eapply proof
-        | Some c -> apply_with_bindings (proof,ImplicitBindings [ c ])))
+        | Some c -> apply_with_bindings ~with_delta:true (proof,ImplicitBindings [ c ])))
     (transitivity_red true c)
 
 let setoid_symmetry_in id =
@@ -2217,9 +2217,11 @@ let setoid_symmetry_in id =
   let he,c1,c2 =  mkApp (equiv, Array.of_list others),c1,c2 in
   let new_hyp' =  mkApp (he, [| c2 ; c1 |]) in
   let new_hyp = it_mkProd_or_LetIn new_hyp'  binders in
-    (tclTHENLAST
-      (Tactics.assert_after_replacing id new_hyp)
-      (tclTHENLIST [ intros; setoid_symmetry; apply (mkVar id); Tactics.assumption ]))
+  tclTHENLAST
+    (Tactics.assert_after_replacing id new_hyp)
+    (Tacticals.New.tclTHENLIST
+       [ intros; setoid_symmetry;
+         apply ~with_delta:true (mkVar id); Tactics.assumption ])
   end
 
 let _ = Hook.set Tactics.setoid_reflexivity setoid_reflexivity

--- a/plugins/ltac/rewrite.ml
+++ b/plugins/ltac/rewrite.ml
@@ -507,7 +507,8 @@ let decompose_applied_relation env sigma (c,l) =
   let ctype = Retyping.get_type_of env sigma c in
   let find_rel ty =
     let sigma, cl = Clenv.make_evar_clause env sigma c ty in
-    let sigma, cl = Clenv.solve_evar_clause env sigma ~hyps_only:true cl l in
+    let sigma, delayed, cl = Clenv.solve_evar_clause env sigma ~hyps_only:true cl l in
+    let sigma = Clenv.apply_delayed_bindings env delayed sigma in
     let { Clenv.cl_holes = holes; Clenv.cl_concl = t } = cl in
     let (equiv, c1, c2) = decompose_app_rel env sigma t in
     let ty1 = Retyping.get_type_of env sigma c1 in

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -480,6 +480,8 @@ let rec evar_conv_x flags env evd pbty term1 term2 =
           | exception Univ.UniverseInconsistency e -> UnifFailure (evd, UnifUnivInconsistency e)
       in
         match e with
+        (* TODO: approximation, if term1 and term2 do not refer transitively to evars then the
+         conversion test is enough *)
         | UnifFailure (evd, e) when not (is_ground_env evd env) -> None
         | _ -> Some e)
     else None

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -710,33 +710,33 @@ and evar_eqappr_x ?(rhs_is_already_stuck = false) flags env evd pbty
     | None, Success i' ->
        (* We do have sk1[] = sk2[]: we now unify ?ev1 and ?ev2 *)
        (* Note that ?ev1 and ?ev2, may have been instantiated in the meantime *)
-       let ev1' = whd_evar i' t1 in
+       let ev1', _ as t1' = whd_nored_state env i' (t1, sk1) in
        if isEvar i' ev1' then
          solve_simple_eqn (conv_fun evar_conv_x) flags env i'
-                          (position_problem true pbty,destEvar i' ev1',term2)
+                          (position_problem true pbty,destEvar i' ev1', t2)
        else
          evar_eqappr_x flags env evd pbty
-                       (ev1', sk1) (term2, sk2)
+                       t1' (t2, sk2)
     | Some (r,[]), Success i' ->
        (* We have sk1'[] = sk2[] for some sk1' s.t. sk1[]=sk1'[r[]] *)
        (* we now unify r[?ev1] and ?ev2 *)
-       let ev2' = whd_evar i' t2 in
+       let ev2', _ as t2' = whd_nored_state env i' (t2,sk2) in
        if isEvar i' ev2' then
          solve_simple_eqn (conv_fun evar_conv_x) flags env i'
-                          (position_problem false pbty,destEvar i' ev2',Stack.zip i' (term1,r))
+                          (position_problem false pbty,destEvar i' ev2',Stack.zip i' (t1,r))
        else
          evar_eqappr_x flags env evd pbty
-                       (ev2', sk1) (term2, sk2)
+                       t2' (t2, sk2)
     | Some ([],r), Success i' ->
        (* Symmetrically *)
        (* We have sk1[] = sk2'[] for some sk2' s.t. sk2[]=sk2'[r[]] *)
        (* we now unify ?ev1 and r[?ev2] *)
-       let ev1' = whd_evar i' t1 in
+       let ev1',_ as t1' = whd_nored_state env i' (t1, sk1) in
        if isEvar i' ev1' then
          solve_simple_eqn (conv_fun evar_conv_x) flags env i'
-                          (position_problem true pbty,destEvar i' ev1',Stack.zip i' (term2,r))
+                          (position_problem true pbty,destEvar i' ev1',Stack.zip i' (t2,r))
        else evar_eqappr_x flags env evd pbty
-                          (ev1', sk1) (term2, sk2)
+                          t1' (term2, sk2)
     | None, (UnifFailure _ as x) ->
        (* sk1 and sk2 have no common outer part *)
        if Stack.not_purely_applicative sk2 then

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -736,7 +736,7 @@ and evar_eqappr_x ?(rhs_is_already_stuck = false) flags env evd pbty
          solve_simple_eqn (conv_fun evar_conv_x) flags env i'
                           (position_problem true pbty,destEvar i' ev1',Stack.zip i' (t2,r))
        else evar_eqappr_x flags env evd pbty
-                          t1' (term2, sk2)
+                          t1' (t2, sk2)
     | None, (UnifFailure _ as x) ->
        (* sk1 and sk2 have no common outer part *)
        if Stack.not_purely_applicative sk2 then

--- a/pretyping/evarsolve.ml
+++ b/pretyping/evarsolve.ml
@@ -57,7 +57,8 @@ type unify_flags = {
   subterm_ts : TransparentState.t;
   allowed_evars : AllowedEvars.t;
   allow_K_at_toplevel : bool;
-  with_cs : bool
+  with_cs : bool;
+  use_pattern_unification : bool;
 }
 
 let is_evar_allowed flags evk =

--- a/pretyping/evarsolve.mli
+++ b/pretyping/evarsolve.mli
@@ -53,8 +53,9 @@ type unify_flags = {
   allow_K_at_toplevel : bool;
   (* During higher-order unifications, allow to produce K-redexes: i.e. to produce
      an abstraction for an unused argument *)
-  with_cs : bool
+  with_cs : bool;
   (* Enable canonical structure resolution during unification *)
+  use_pattern_unification : bool;
 }
 
 type unification_result =

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -2007,6 +2007,17 @@ let w_unify2 env evd flags dep cv_pb ty1 ty2 =
    Before, second-order was used if the type of Meta(1) and [x:A]t was
    convertible and first-order otherwise. But if failed if e.g. the type of
    Meta(1) had meta-variables in it. *)
+
+let flags_of flags =
+  let modulo_betaiota = flags.core_unify_flags.modulo_betaiota in
+  let open_ts = flags.core_unify_flags.modulo_delta in
+  let closed_ts = Option.default open_ts (flags.core_unify_flags.modulo_conv_on_closed_terms) in
+  let subterm_ts = flags.subterm_unify_flags.modulo_delta in
+  let frozen_evars = flags.core_unify_flags.frozen_evars in
+  let allow_K_at_toplevel = flags.allow_K_in_toplevel_higher_order_unification in
+  Evarsolve.{ modulo_betaiota; open_ts; closed_ts; subterm_ts; frozen_evars;
+              allow_K_at_toplevel; with_cs = true }
+
 let w_unify env evd cv_pb ?(flags=default_unify_flags ()) ty1 ty2 =
   let hd1,l1 = decompose_app_vect evd (whd_nored env evd ty1) in
   let hd2,l2 = decompose_app_vect evd (whd_nored env evd ty2) in

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -2013,9 +2013,9 @@ let flags_of flags =
   let open_ts = flags.core_unify_flags.modulo_delta in
   let closed_ts = Option.default open_ts (flags.core_unify_flags.modulo_conv_on_closed_terms) in
   let subterm_ts = flags.subterm_unify_flags.modulo_delta in
-  let frozen_evars = flags.core_unify_flags.frozen_evars in
+  let allowed_evars = flags.core_unify_flags.allowed_evars in
   let allow_K_at_toplevel = flags.allow_K_in_toplevel_higher_order_unification in
-  Evarsolve.{ modulo_betaiota; open_ts; closed_ts; subterm_ts; frozen_evars;
+  Evarsolve.{ modulo_betaiota; open_ts; closed_ts; subterm_ts; allowed_evars;
               allow_K_at_toplevel; with_cs = true }
 
 let w_unify env evd cv_pb ?(flags=default_unify_flags ()) ty1 ty2 =

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -2015,8 +2015,9 @@ let flags_of flags =
   let subterm_ts = flags.subterm_unify_flags.modulo_delta in
   let allowed_evars = flags.core_unify_flags.allowed_evars in
   let allow_K_at_toplevel = flags.allow_K_in_toplevel_higher_order_unification in
+  let use_pattern_unification = flags.core_unify_flags.use_pattern_unification in
   Evarsolve.{ modulo_betaiota; open_ts; closed_ts; subterm_ts; allowed_evars;
-              allow_K_at_toplevel; with_cs = true }
+              allow_K_at_toplevel; use_pattern_unification; with_cs = true }
 
 let w_unify env evd cv_pb ?(flags=default_unify_flags ()) ty1 ty2 =
   let hd1,l1 = decompose_app_vect evd (whd_nored env evd ty1) in

--- a/pretyping/unification.mli
+++ b/pretyping/unification.mli
@@ -36,6 +36,8 @@ type unify_flags = {
   resolve_evars : bool
 }
 
+val flags_of : unify_flags -> Evarconv.unify_flags
+
 val default_core_unify_flags : unit -> core_unify_flags
 val default_no_delta_core_unify_flags : unit -> core_unify_flags
 
@@ -43,6 +45,7 @@ val default_unify_flags : unit -> unify_flags
 val default_no_delta_unify_flags : TransparentState.t -> unify_flags
 
 val elim_flags : unit -> unify_flags
+val elim_flags_evars : Evd.evar_map -> unify_flags
 val elim_no_delta_flags : unit -> unify_flags
 
 val is_keyed_unification : unit -> bool

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -685,14 +685,16 @@ let fail_quick_unif_flags = {
 }
 
 (* let unifyTerms m n = walking (fun wc -> fst (w_Unify CONV m n [] wc)) *)
-let unify ?(flags=fail_quick_unif_flags) m =
+let unify ?(flags=fail_quick_unif_flags) ?(with_ho=true) m =
   Proofview.Goal.enter begin fun gl ->
     let env = Tacmach.New.pf_env gl in
     let n = Tacmach.New.pf_concl gl in
-    let evd = clear_metas (Tacmach.New.project gl) in
+    let sigma = clear_metas (Tacmach.New.project gl) in
     try
-      let evd' = w_unify env evd CONV ~flags m n in
-        Proofview.Unsafe.tclEVARSADVANCE evd'
+      let sigma = Evarutil.add_unification_pb (CONV,env,m,n) sigma in
+      let flags = Unification.flags_of flags in
+      let sigma = Evarconv.solve_unif_constraints_with_heuristics ~flags ~with_ho env sigma in
+        Proofview.Unsafe.tclEVARSADVANCE sigma
     with e when CErrors.noncritical e ->
       let info = Exninfo.reify () in
       Proofview.tclZERO ~info e
@@ -737,12 +739,51 @@ type hole = {
 
 type clause = {
   cl_holes : hole list;
-  cl_concl : EConstr.types;
+  (** The holes of the clause. *)
+  cl_concl : types;
+  (** The conclusion: an evar applied to some terms *)
+  cl_concl_occs : Evarconv.occurrences_selection option;
+  (** The occurrences of the terms to be abstracted when unifying *)
+  cl_val   : constr;
+  (** The value the clause was built from, applied to holes *)
 }
 
-let make_evar_clause env sigma ?len t =
-  let open EConstr in
-  let open Vars in
+let make_prod_evar env sigma na t1 t2 =
+  let naming =
+    match na with Name id -> IntroFresh id | Anonymous -> IntroAnonymous
+  in
+  let sigma, ev = new_evar ~future_goal:false ~typeclass_candidate:false env sigma ~naming t1 in
+  let dep = dependent sigma (mkRel 1) t2 in
+  let hole = {
+      hole_evar = ev;
+      hole_deps = dep;
+      hole_type = t1;
+      (* We fix it later *)
+      hole_name = na;
+    } in
+  let t2 = if dep then subst1 ev t2 else t2 in
+  sigma, hole, t2
+
+(** Stripping params on applications of primitive projections *)
+(* MD This is duplicated from `Hints` *)
+let strip_params env sigma c =
+  match EConstr.kind sigma c with
+  | App (f, args) ->
+    (match EConstr.kind sigma f with
+     | Const (cst,_) ->
+       (match Recordops.find_primitive_projection cst with
+        | Some p ->
+          let p = Projection.make p false in
+          let npars = Projection.npars p in
+          if Array.length args > npars then
+            mkApp (mkProj (p, args.(npars)),
+                   Array.sub args (npars+1) (Array.length args - (npars + 1)))
+          else c
+        | None -> c)
+     | _ -> c)
+  | _ -> c
+
+let make_evar_clause env sigma ?len ?occs c t =
   let bound = match len with
   | None -> -1
   | Some n -> assert (0 <= n); n
@@ -762,24 +803,17 @@ let make_evar_clause env sigma ?len t =
         Some (ctx, args, subst), ctx, args, subst
       | Some (ctx, args, subst) -> inst, ctx, args, subst
       in
-      let (sigma, ev) = new_pure_evar ~typeclass_candidate:false ctx sigma (csubst_subst subst t1) in
-      let ev = mkEvar (ev, args) in
-      let dep = not (noccurn sigma 1 t2) in
-      let hole = {
-        hole_evar = ev;
-        hole_type = t1;
-        hole_deps = dep;
-        (* We fix it later *)
-        hole_name = na.binder_name;
-      } in
-      let t2 = if dep then subst1 ev t2 else t2 in
+      let sigma, hole, t2 = make_prod_evar env sigma na.binder_name t1 t2 in
       clrec (sigma, hole :: holes) inst (pred n) t2
     | LetIn (na, b, _, t) -> clrec (sigma, holes) inst n (subst1 b t)
     | _ -> (sigma, holes, t)
   in
   let (sigma, holes, t) = clrec (sigma, []) None bound t in
   let holes = List.rev holes in
-  let clause = { cl_concl = t; cl_holes = holes } in
+  let v = applist (c, List.map (fun h -> h.hole_evar) holes) in
+  let c = strip_params env sigma v in
+  let clause = { cl_holes = holes; cl_val = c;
+                 cl_concl = t; cl_concl_occs = occs } in
   (sigma, clause)
 
 let explain_no_such_bound_variable holes id =
@@ -790,8 +824,8 @@ let explain_no_such_bound_variable holes id =
   let mvl = List.fold_right fold holes [] in
   let expl = match mvl with
   | [] -> str " (no bound variables at all in the expression)."
-  | [id] -> str "(possible name is: " ++ Id.print id ++ str ")."
-  | _ -> str "(possible names are: " ++ pr_enum Id.print mvl ++ str ")."
+  | [id] -> str " (possible name is: " ++ Id.print id ++ str ")."
+  | _ -> str " (possible names are: " ++ pr_enum Id.print mvl ++ str ")."
   in
   user_err  (str "No such bound variable " ++ Id.print id ++ expl)
 
@@ -809,59 +843,284 @@ let evar_with_name holes id =
       (str "Binder name \"" ++ Id.print id ++
         str "\" occurs more than once in clause.")
 
+let nth_anonymous holes n =
+  let rec hole holes n =
+    match holes, n with
+    | h :: holes, n when h.hole_name <> Anonymous -> hole holes n
+    | h :: holes, 0 -> h.hole_evar
+    | h :: holes, n -> hole holes (pred n)
+    | [], _ -> user_err (str "No such binder.")
+  in hole holes (pred n)
+
 let evar_of_binder holes = function
 | NamedHyp s -> evar_with_name holes s
-| AnonHyp n ->
-  try
-    let nondeps = List.filter (fun hole -> not hole.hole_deps) holes in
-    let h = List.nth nondeps (pred n) in
-    h.hole_evar
-  with e when CErrors.noncritical e ->
-    user_err  (str "No such binder.")
+| AnonHyp n -> nth_anonymous holes n
 
-let define_with_type sigma env ev c =
-  let open EConstr in
+let define_with_type env sigma ?flags ev c ty =
   let t = Retyping.get_type_of env sigma ev in
-  let ty = Retyping.get_type_of env sigma c in
+  let ty =
+    match ty with
+    | Some t -> t
+    | None -> Retyping.get_type_of env sigma c in
   let j = Environ.make_judge c ty in
-  let (sigma, j, _trace) = Coercion.inh_conv_coerce_to ~program_mode:false true env sigma j t in
+  let (sigma, j, _trace) = Coercion.inh_conv_coerce_to ~program_mode:false true env sigma ?flags j t in
   let (ev, _) = destEvar sigma ev in
   let sigma = Evd.define ev j.Environ.uj_val sigma in
   sigma
 
-let solve_evar_clause env sigma hyp_only clause = function
-| NoBindings -> sigma
-| ImplicitBindings largs ->
-  let open EConstr in
-  let fold holes h =
+(** This requires to look at the evar even if it is defined *)
+let hole_goal h = fst (Constr.destEvar (EConstr.Unsafe.to_constr h.hole_evar))
+
+let clenv_advance sigma clenv =
+  let { cl_concl; cl_holes; cl_val; cl_concl_occs } = clenv in
+  let advance h =
+    let h' = whd_evar sigma h.hole_evar in
+    if Constr.equal (EConstr.Unsafe.to_constr h') (EConstr.Unsafe.to_constr h.hole_evar)
+    then Some h
+    else
+      let ev = hole_goal h in
+      match Proofview.Unsafe.advance sigma ev with
+      | Some ev' ->
+         let na =
+           match evar_ident ev' sigma with
+           | Some id -> Name id
+           | None -> h.hole_name
+         in
+         Some { h with hole_evar = h'; hole_name = na }
+      | None -> None
+  in
+  let holes = List.map_filter advance cl_holes in
+    if holes == cl_holes then clenv
+    else
+      { cl_holes = holes;
+        cl_concl = nf_evar sigma cl_concl;
+        cl_val = nf_evar sigma cl_val;
+        cl_concl_occs }
+
+let hole_evar sigma hole = fst (destEvar sigma hole.hole_evar)
+
+let hole_type env sigma hole =
+  let concl = Evd.evar_concl (Evd.find_undefined sigma (hole_evar sigma hole)) in
+  Reductionops.nf_betaiota env sigma (Evarutil.nf_evar sigma concl) (* MD is normalizing useful here? *)
+
+let clenv_recompute_deps env sigma ~hyps_only clause =
+  let fold h holes =
     if h.hole_deps then
       (* Some subsequent term uses the hole *)
       let (ev, _) = destEvar sigma h.hole_evar in
-      let is_dep hole = occur_evar sigma ev hole.hole_type in
+      let is_dep hole = occur_evar sigma ev (hole_type env sigma hole) in
       let in_hyp = List.exists is_dep holes in
       let in_ccl = occur_evar sigma ev clause.cl_concl in
-      let dep = if hyp_only then in_hyp && not in_ccl else in_hyp || in_ccl in
+      let dep = if hyps_only then in_hyp && not in_ccl else in_hyp || in_ccl in
       let h = { h with hole_deps = dep } in
       h :: holes
     else
       (* The hole does not occur anywhere *)
       h :: holes
   in
-  let holes = List.fold_left fold [] (List.rev clause.cl_holes) in
-  let map h = if h.hole_deps then Some h.hole_evar else None in
-  let evs = List.map_filter map holes in
+  let holes = List.fold_right fold clause.cl_holes [] in
+  { clause with cl_holes = holes }
+
+let solve_evar_clause env sigma ~hyps_only clause b =
+  match b with
+| NoBindings -> sigma, clause
+| ImplicitBindings largs ->
+  let clause = if hyps_only then clenv_recompute_deps env sigma ~hyps_only clause else clause in
+  let evs, holes' = List.partition (fun h -> h.hole_deps) clause.cl_holes in
   let len = List.length evs in
   if Int.equal len (List.length largs) then
-    let fold sigma ev arg = define_with_type sigma env ev arg in
+    let fold sigma ev arg = define_with_type env sigma ev.hole_evar arg None in
     let sigma = List.fold_left2 fold sigma evs largs in
-    sigma
+    let clause = { clause with cl_holes = holes' } in
+    sigma, clenv_advance sigma clause
   else
     error_not_right_number_missing_arguments len
 | ExplicitBindings lbind ->
   let () = check_bindings lbind in
-  let fold sigma {CAst.v=(binder, c)} =
+  let fold (sigma, holes) {CAst.v=(binder, c)} =
     let ev = evar_of_binder clause.cl_holes binder in
-    define_with_type sigma env ev c
+    let rem ev' = EConstr.eq_constr sigma ev ev'.hole_evar in
+    let holes = List.remove_first rem holes in
+    define_with_type env sigma ev c None, holes
   in
-  let sigma = List.fold_left fold sigma lbind in
-  sigma
+  let sigma, holes = List.fold_left fold (sigma,clause.cl_holes) lbind in
+  let clause = { clause with cl_holes = holes } in
+  sigma, clenv_advance sigma clause
+
+let make_clenv_from_env env sigma ?len ?occs (c, t) =
+  make_evar_clause env sigma ?len ?occs (strip_outer_cast sigma c) t
+
+let make_clenv_bindings env sigma ?len ?occs p ~hyps_only b =
+  let sigma, cle = make_clenv_from_env env sigma ?len ?occs p in
+  solve_evar_clause env sigma ~hyps_only cle b
+
+let clenv_indep_holes c =
+  let holes = c.cl_holes in
+  let filter h = not h.hole_deps in
+  List.filter filter holes
+
+let clenv_concl cl = cl.cl_concl
+let clenv_val   cl = cl.cl_val
+let clenv_holes cl = cl.cl_holes
+
+let clenv_dep_holes clenv =
+  let holes = clenv_holes clenv in
+  List.filter (fun h -> h.hole_deps) holes
+
+let clenv_dest_prod env sigma
+  { cl_concl = concl; cl_holes = holes; cl_val = v; cl_concl_occs = occs } =
+  let typ = whd_all env sigma concl in
+  let rec clrec typ = match EConstr.kind sigma typ with
+    | Cast (t,_,_) -> clrec t
+    | Prod (na,t,u) ->
+       make_prod_evar env sigma na.binder_name t u
+    | _ -> raise NotExtensibleClause
+  in
+  let sigma, hole, typ' = clrec typ in
+  let v = strip_params env sigma (applist (v, [hole.hole_evar])) in
+  let occs' =
+    match occs with
+    | None -> None
+    | Some (f, occs) -> Some (f, occs @ [Evarconv.default_occurrence_selection])
+  in
+  let clause =
+    { cl_holes = holes @ [hole]; cl_val = v;
+      cl_concl = typ'; cl_concl_occs = occs' }
+  in sigma, clause
+
+let clenv_map_concl f clenv =
+  let concl = clenv.cl_concl in
+  { clenv with cl_concl = f concl }
+
+let clenv_unify_type env sigma flags hole occs ty =
+  (* Give priority to second-order matching which avoids falling back
+     to it with unfolded terms through evar_conv. *)
+  let ev, l = decompose_appvect sigma hole in
+  let hd, l' = decompose_appvect sigma ty in
+  let is_explicit_pattern =
+    if Array.length l == Array.length l' then
+      try ignore(decompose_lam_n_assum sigma (Array.length l) hd); true
+      with e -> not (isEvar sigma ev)
+    else not (isEvar sigma ev)
+  in
+  (* In case the clause is not higher-order (has no occurrences selected)
+     or the type we're unifying with is an explicit predicate
+     applied to the right number of arguments, we favor direct
+     unification. *)
+  match occs with
+  | Some (f, occs) when not is_explicit_pattern ->
+     let (evk, subst as ev) = destEvar sigma ev in
+     let sigma, ev' =
+       Evardefine.evar_absorb_arguments env sigma ev (Array.to_list l) in
+     let argoccs = List.map (fun _ -> Evarconv.default_occurrence_selection) (snd ev) in
+     let f, occs =
+       (* We are lenient here, allowing more occurrences to be specified than
+           the actual arguments of the evar. Helps dealing with eliminators we
+           don't know the arity of (e.g. dependent or not). *)
+       let () =
+         if not (Array.length l <= List.length occs) then
+           user_err (Pp.str"Clause unification: occurrence list does not match argument list")
+       in (f, List.firstn (Array.length l) occs)
+     in
+     let occs = List.rev (argoccs @ occs) in
+     let sigma, b =
+       Evarconv.second_order_matching flags env sigma ev' (f, occs) ty
+     in
+     if not b then
+       let reason = ConversionFailed (env,hole,ty) in
+       Pretype_errors.error_cannot_unify env sigma ~reason (hole, ty)
+     else
+       (* Ensure we did actually find a solution *)
+       Evarconv.solve_unif_constraints_with_heuristics
+         ~flags ~with_ho:true env sigma
+  | _ ->
+     let ho () =
+       let sigma = Evarutil.add_unification_pb (CUMUL,env,hole,ty) sigma in
+        Evarconv.solve_unif_constraints_with_heuristics
+          ~flags ~with_ho:true env sigma
+     in
+     (* Try normal unification first, if that fails use heuristics + higher-order unif *)
+     let open Evarsolve in
+     match Evarconv.evar_conv_x flags env sigma CUMUL hole ty with
+     | Success sigma ->
+        (try Evarconv.solve_unif_constraints_with_heuristics
+               ~flags ~with_ho:false env sigma
+         with e -> ho ())
+     | UnifFailure _ -> ho ()
+
+
+let clenv_unify_concl env sigma flags ty clenv =
+  let concl, occs = clenv.cl_concl, clenv.cl_concl_occs in
+  let sigma = clenv_unify_type env sigma flags concl occs ty in
+  sigma, clenv_advance sigma clenv
+
+(* [clenv_fchain mv clenv clenv']
+ *
+ * Resolves the value of "mv" (which must be undefined) in clenv to be
+ * the template of clenv' be the value "c", applied to "n" fresh
+ * metavars, whose types are chosen by destructing "clf", which should
+ * be a clausale forme generated from the type of "c".  The process of
+ * resolution can cause unification of already-existing metavars, and
+ * of the fresh ones which get created.  This operation is a composite
+ * of operations which pose new metavars, perform unification on
+ * terms, and make bindings.
+
+   Otherwise said, from
+
+     [clenv] = [env;sigma;metas |- c:T]
+     [clenv'] = [env';sigma';metas' |- d:U]
+     [mv] = [mi] of type [Ti] in [metas]
+
+   then, if the unification of [Ti] and [U] produces map [rho], the
+   chaining is [env';sigma';rho'(metas),rho(metas') |- c:rho'(T)] for
+   [rho'] being [rho;mi:=d].
+
+   In particular, it assumes that [env'] and [sigma'] extend [env] and [sigma].
+*)
+
+let hole_def sigma h =
+  match h.hole_name with
+  | Name id ->
+     let res = nf_evar sigma h.hole_evar in
+     if isEvar sigma res then
+       Some (fst (destEvar sigma res), id)
+     else None
+  | Anonymous -> None
+
+let clenv_chain ?(holes_order=true) ?(flags=fchain_flags ()) ?occs
+                env sigma h cl nextcl =
+  let sigma, cl =
+    match occs with
+    | None -> define_with_type env sigma ~flags:(flags_of flags)
+                 h.hole_evar nextcl.cl_val (Some nextcl.cl_concl), cl
+    | Some _ ->
+       let ty = hole_type env sigma h in
+       let ty' = nextcl.cl_concl in
+       let sigma = clenv_unify_type env sigma (flags_of flags) ty occs ty' in
+       let (ev, _) = destEvar sigma h.hole_evar in
+       let sigma = Evd.define ev nextcl.cl_val sigma in
+       sigma, cl
+  in
+  let sigma, clholes =
+    let nextclholes =
+      List.map_filter (fun h -> hole_def sigma h) nextcl.cl_holes
+    in
+    List.fold_left_map (fun sigma h ->
+        try
+          let id = List.assoc_f Evar.equal (hole_goal h) nextclholes in
+          Evd.rename (hole_goal h) id sigma, { h with hole_name = Name id }
+        with Not_found -> sigma, h) sigma cl.cl_holes
+  in
+  let holes' =
+    if holes_order then
+      clholes @ nextcl.cl_holes
+    else
+      nextcl.cl_holes @ clholes
+  in
+  let cl = { cl with cl_holes = holes' } in
+  sigma, clenv_advance sigma cl
+
+let clenv_chain_last ?(flags=fchain_flags ()) env sigma c cl =
+  let h = try List.last cl.cl_holes with Failure _ -> raise NoSuchBinding in
+  let sigma = define_with_type env sigma ~flags:(flags_of flags) h.hole_evar c None in
+  sigma, clenv_advance sigma cl

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -693,7 +693,7 @@ let unify ?(flags=fail_quick_unif_flags) ?(with_ho=true) m =
     try
       let sigma = Evarutil.add_unification_pb (CONV,env,m,n) sigma in
       let flags = Unification.flags_of flags in
-      let sigma = Evarconv.solve_unif_constraints_with_heuristics ~flags ~with_ho env sigma in
+      let sigma = Evarconv.unify ~flags ~with_ho env sigma CONV m n in
         Proofview.Unsafe.tclEVARSADVANCE sigma
     with e when CErrors.noncritical e ->
       let info = Exninfo.reify () in

--- a/proofs/clenv.mli
+++ b/proofs/clenv.mli
@@ -186,7 +186,7 @@ val make_clenv_from_env :
 (** Wrapper for [make_evar_clause], simply removing casts in the value argument. *)
 
 val solve_evar_clause : env -> evar_map -> hyps_only:bool -> clause -> EConstr.constr bindings ->
-  evar_map * clause
+  evar_map * (hole * EConstr.constr) list * clause
 (** [solve_evar_clause env sigma recompute_deps hyps_only cl bl] tries
     to solve the holes contained in [cl] according to the [bl]
     argument. Assumes that [bl] are well-typed in the environment. The
@@ -204,7 +204,7 @@ val with_clause : constr * types -> (clause -> unit Proofview.tactic) -> unit Pr
 val make_clenv_bindings :
   env -> evar_map -> ?len:int -> ?occs:Evarconv.occurrences_selection ->
   constr * constr -> hyps_only:bool -> constr bindings ->
-  evar_map * clause
+  evar_map * (hole * EConstr.constr) list * clause
 (** Combination of [make_evar_clause] and [solve_evar_clause], creating a clause
     and immediately solving them with the given bindings. *)
 
@@ -286,10 +286,12 @@ val clenv_refine_no_check :
 (** Refine the goal without going through the first step of unification with
     the goal's conclusion. *)
 
+val apply_delayed_bindings : env -> (hole * EConstr.t) list -> Evd.evar_map -> Evd.evar_map
+
 val clenv_refine_bindings :
   ?with_evars:bool -> ?with_classes:bool -> ?shelve_subgoals:bool ->
   ?flags:unify_flags ->
-  hyps_only:bool -> delay_bindings:bool -> EConstr.constr Tactypes.bindings ->
+  hyps_only:bool -> EConstr.constr Tactypes.bindings ->
   ?origsigma:Evd.evar_map -> clause -> unit Proofview.tactic
 (** Refine the goal additionally using the given bindings to complete the clause. *)
 

--- a/proofs/clenv.mli
+++ b/proofs/clenv.mli
@@ -52,7 +52,7 @@ val clenv_fchain :
 
 (** {6 Unification with clenvs } *)
 
-(** Unifies two terms in a clenv. The boolean is [allow_K] (see [Unification]) *)
+(** Unifies two terms in a clenv. *)
 val clenv_unify :
   ?flags:unify_flags -> conv_pb -> constr -> constr -> clausenv -> clausenv
 
@@ -88,7 +88,7 @@ val clenv_push_prod : clausenv -> clausenv
 
 (** {6 Clenv tactics} *)
 
-val unify : ?flags:unify_flags -> constr -> unit Proofview.tactic
+val unify : ?flags:unify_flags -> ?with_ho:bool -> constr -> unit Proofview.tactic
 val res_pf : ?with_evars:bool -> ?with_classes:bool -> ?flags:unify_flags -> clausenv -> unit Proofview.tactic
 
 val clenv_pose_dependent_evars : ?with_evars:bool -> clausenv -> clausenv
@@ -132,22 +132,132 @@ type hole = {
 
 type clause = {
   cl_holes : hole list;
+  (** The holes of the clause. *)
   cl_concl : EConstr.types;
+  (** The conclusion: an evar applied to some terms *)
+  cl_concl_occs : Evarconv.occurrences_selection option;
+  (** The occurrences of the terms to be abstracted when unifying *)
+  cl_val   : EConstr.constr;
+  (** The value the clause was built from, applied to holes *)
 }
 
-val make_evar_clause : env -> evar_map -> ?len:int -> EConstr.types ->
-  (evar_map * clause)
+(** Accessors *)
+
+val hole_type : env -> evar_map -> hole -> types
+(** [hole_type sigma h] returns the beta-iota-evar normalized type of [h] in [sigma].
+    @pre The hole's evar is undefined in [sigma]. *)
+
+val clenv_concl : clause -> types
+(** The conclusion of the clause. *)
+
+val clenv_val : clause -> constr
+(** The value of the clause, of type the conclusion *)
+
+val clenv_holes : clause -> hole list
+(** The list of remaining holes of the clause.
+    CAUTION: this API doesn't ensure that only undefined holes are returned here.
+    In clenvtac, the clause-manipulating primitives ensure that property using
+    [clenv_advance] below. This applies to the two functions below as well. *)
+
+val clenv_dep_holes: clause -> hole list
+(** Returns the dependent goals only. *)
+
+val clenv_indep_holes : clause -> hole list
+(** Returns the independent holes in the clause, according to the
+    hyps_only flag that was used during its construction. *)
+
+val clenv_map_concl : (types -> types) -> clause -> clause
+(** Map a function on the clause's conclusion type. *)
+
+(** Creation of clauses. *)
+
+val make_evar_clause :
+  env -> evar_map -> ?len:int -> ?occs:Evarconv.occurrences_selection ->
+  EConstr.constr -> EConstr.types -> (evar_map * clause)
 (** An evar version of {!make_clenv_binding}. Given a type [t],
     [evar_environments env sigma ~len t bl] tries to eliminate at most [len]
     products of the type [t] by filling it with evars. It returns the resulting
     type together with the list of holes generated. Assumes that [t] is
     well-typed in the environment. *)
 
-val solve_evar_clause : env -> evar_map -> bool -> clause -> EConstr.constr bindings ->
-  evar_map
-(** [solve_evar_clause env sigma hyps cl bl] tries to solve the holes contained
-    in [cl] according to the [bl] argument. Assumes that [bl] are well-typed in
-    the environment. The boolean [hyps] is a compatibility flag that allows to
-    consider arguments to be dependent only when they appear in hypotheses and
-    not in the conclusion. This boolean is only used when [bl] is of the form
-    [ImplicitBindings _]. *)
+val make_clenv_from_env :
+  env -> evar_map -> ?len:int -> ?occs:Evarconv.occurrences_selection ->
+  constr * types -> evar_map * clause
+(** Wrapper for [make_evar_clause], simply removing casts in the value argument. *)
+
+val solve_evar_clause : env -> evar_map -> hyps_only:bool -> clause -> EConstr.constr bindings ->
+  evar_map * clause
+(** [solve_evar_clause env sigma recompute_deps hyps_only cl bl] tries
+    to solve the holes contained in [cl] according to the [bl]
+    argument. Assumes that [bl] are well-typed in the environment. The
+    boolean [recompute_deps] tells if the dependent holes of the clause
+    have to be recomputed first, in which case [hyps_only] is a flag
+    that allows to consider arguments to be dependent only when they
+    appear in hypotheses and not in the conclusion. This boolean is
+    especially used when [bl] is of the form [ImplicitBindings _] to
+    determine which bindings to instantiate.
+    Returns the new [sigma] and the advanced clause. *)
+
+val make_clenv_bindings :
+  env -> evar_map -> ?len:int -> ?occs:Evarconv.occurrences_selection ->
+  constr * constr -> hyps_only:bool -> constr bindings ->
+  evar_map * clause
+(** Combination of [make_evar_clause] and [solve_evar_clause], creating a clause
+    and immediately solving them with the given bindings. *)
+
+val clenv_dest_prod : env -> evar_map -> clause -> evar_map * clause
+(* [clenv_dest_prod env sigma cl]
+
+   Add one more hole of type [ty] to the clause if its conclusion if of the form
+   [ty -> _] after weak head reduction (whd_all).
+
+   @raise NotExtensibleClause if no product is found. *)
+
+val clenv_advance : evar_map -> clause -> clause
+(** Advance the clause, removing holes that are defined in the evar_map and
+    do not simply result from clearing an hypothesis in the original hole evar.
+    It relies on [Proofview.Unsafe.advance] to compute this information. *)
+
+val clenv_chain : ?holes_order:bool -> (* true = holes of the first clause first *)
+                  ?flags:unify_flags -> ?occs:Evarconv.occurrences_selection ->
+                  env -> evar_map -> hole ->
+                  clause -> clause -> evar_map * clause
+(** [clenv_chain env sigma hole first next] chains two clauses.  The
+    first clause must contain the undefined hole which is filled by the
+    next clauses body. Note that holes from the next clause which are
+    unified with holes of the first clause always remain with their name
+    in the resulting clause. This ensures that evar names are always
+    preserved from the next clause to the resulting clause.
+    Returns the new [sigma] and the advanced clause. *)
+
+val clenv_chain_last : ?flags:unify_flags ->
+                       env -> evar_map -> constr -> clause -> evar_map * clause
+(** [clenv_chain_last env sigma c cl] defines the last hole of [cl] as [c].
+    Returns the new [sigma] and the advanced clause. *)
+
+val clenv_recompute_deps : env -> evar_map -> hyps_only:bool -> clause -> clause
+(** [clenv_recompute_deps sigma hyps_only cl]
+    Updates the dependencies of the clause. A hole is dependent if:
+    - if hyps_only is true: it appears in another hole's type of the clause and
+      does _not_ appear in the conclusion.
+    - if hyps_only is false: it appears either in another hole's type
+      or the conclusion. *)
+
+val clenv_unify_concl : env -> evar_map ->
+                        Evarconv.unify_flags -> types -> clause ->
+                        evar_map * clause
+(** [clenv_unify_concl env sigma flags ty cl] unifies the conclusion of
+    the clause with [ty] (with cumulativity), calling evar_conv with the given
+    flags. Returns the new [sigma] and the advanced clause.
+
+    Two situations can arise:
+    - If the clause has an explicit occurrences selection set (see [make_evar_clause]),
+    the conclusion is an evar applied to [n] arguments _and_ [ty] is not an explicit
+    lambda abstraction applied to exactly [n] arguments, then second-order matching
+    is called with the given occurrence selection, truncated to [n] arguments (i.e. the
+    occurrence selection might be longer than the actual evar arguments).
+    - Otherwise, evar_conv is called directly, favoring first-order unification solutions,
+    and if that fails we backtrack on higher-order unification, ignoring the occurrence
+    selection.
+
+  @raises Evarconv.UnableToUnify if unification fails *)

--- a/tactics/autorewrite.ml
+++ b/tactics/autorewrite.ml
@@ -218,11 +218,11 @@ type hypinfo = {
 }
 
 let decompose_applied_relation env sigma c ctype left2right =
-  let find_rel ty =
+  let find_rel t ty =
     (* FIXME: this is nonsense, we generate evars and then we drop the
        corresponding evarmap. This sometimes works because [Term_dnet] performs
        evar surgery via [Termops.filtering]. *)
-    let sigma, ty = Clenv.make_evar_clause env sigma ty in
+    let sigma, ty = Clenv.make_evar_clause env sigma t ty in
     let (_, args) = Termops.decompose_app_vect sigma ty.Clenv.cl_concl in
     let len = Array.length args in
     if 2 <= len then
@@ -231,17 +231,18 @@ let decompose_applied_relation env sigma c ctype left2right =
       Some (if left2right then c1 else c2)
     else None
   in
-    match find_rel ctype with
+    match find_rel c ctype with
     | Some c -> Some { hyp_pat = c; hyp_ty = ctype }
     | None ->
         let ctx,t' = Reductionops.splay_prod_assum env sigma ctype in (* Search for underlying eq *)
         let ctype = it_mkProd_or_LetIn t' ctx in
-        match find_rel ctype with
+        match find_rel c ctype with
         | Some c -> Some { hyp_pat = c; hyp_ty = ctype }
         | None -> None
 
 let find_applied_relation ?loc env sigma c left2right =
-  let ctype = Retyping.get_type_of env sigma (EConstr.of_constr c) in
+  let c = EConstr.of_constr c in
+  let ctype = Retyping.get_type_of env sigma c in
     match decompose_applied_relation env sigma c ctype left2right with
     | Some c -> c
     | None ->

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -177,11 +177,10 @@ let unify_resolve_refine flags h diff =
   Refine.refine ~typecheck:false begin fun sigma ->
     let sigma, term = Hints.fresh_hint env sigma h in
     let ty = Retyping.get_type_of env sigma term in
-    let sigma, cl = Clenv.make_evar_clause env sigma ?len ty in
-    let term = applist (term, List.map (fun x -> x.hole_evar) cl.cl_holes) in
+    let sigma, cl = Clenv.make_evar_clause env sigma ?len term ty in
     let flags = Evarconv.default_flags_of flags.core_unify_flags.modulo_delta in
     let sigma = Evarconv.unify_leq_delay ~flags env sigma cl.cl_concl concl in
-    (sigma, term)
+    (sigma, cl.cl_val)
     end
   end
 

--- a/tactics/eauto.ml
+++ b/tactics/eauto.ml
@@ -36,7 +36,7 @@ let e_give_exact ?(flags=eauto_unif_flags) c =
   if occur_existential sigma t1 || occur_existential sigma t2 then
     Tacticals.New.tclTHENLIST
       [Proofview.Unsafe.tclEVARS sigma;
-       Clenv.unify ~flags t1;
+       Clenv.unify ~flags ~with_ho:false t1;
        exact_no_check c]
   else exact_check c
   end

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -4529,8 +4529,8 @@ let check_expected_type env sigma (elimc,bl) elimt =
   let sign,_ = splay_prod env sigma elimt in
   let n = List.length sign in
   if n == 0 then error "Scheme cannot be applied.";
-  let sigma,cl = make_evar_clause env sigma ~len:(n - 1) elimt in
-  let sigma = solve_evar_clause env sigma true cl bl in
+  let sigma,cl = make_evar_clause env sigma ~len:(n - 1) elimc elimt in
+  let sigma,cl = solve_evar_clause env sigma ~hyps_only:true cl bl in
   let (_,u,_) = destProd sigma (whd_all env sigma cl.cl_concl) in
   fun t -> match Evarconv.unify_leq_delay env sigma t u with
     | _sigma -> true

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -1716,8 +1716,9 @@ let tclORELSEOPT t k =
       Proofview.tclZERO ~info e
     | Some tac -> tac)
 
-let general_apply ?(respect_opaque=false) with_delta with_destruct with_evars
-    clear_flag {CAst.loc;v=(c,lbind : EConstr.constr with_bindings)} =
+let general_apply ?(respect_opaque=false)
+    ~with_delta ~with_destruct ~with_evars ~delay_bindings ~clear_flag
+    {CAst.loc;v=(c,lbind : EConstr.constr with_bindings)} =
   Proofview.Goal.enter begin fun gl ->
   let concl = Proofview.Goal.concl gl in
   let sigma = Tacmach.New.project gl in
@@ -1734,14 +1735,25 @@ let general_apply ?(respect_opaque=false) with_delta with_destruct with_evars
       else TransparentState.full
     in
     let flags =
-      if with_delta then default_unify_flags () else default_no_delta_unify_flags ts in
+      if with_delta then
+      let flags = default_unify_flags () in
+      (* When applying higher-order lemmas, we don't necessarily want to
+         find an abstraction for all the arguments of the metavariable. *)
+      { flags with allow_K_in_toplevel_higher_order_unification = true }
+      else
+      (* In the "simple apply" case we want to avoid applications of higher-order
+         lemmas finding trivial predicates. *)
+      default_no_delta_unify_flags ts in
     let thm_ty0 = nf_betaiota env sigma (Retyping.get_type_of env sigma c) in
     let try_apply thm_ty nprod =
       try
         let n = nb_prod_modulo_zeta sigma thm_ty - nprod in
         if n<0 then error "Applied theorem does not have enough premises.";
-        let clause = make_clenv_binding_apply env sigma (Some n) (c,thm_ty) lbind in
-        Clenv.res_pf clause ~with_evars ~flags
+        let sigma', clause = make_clenv_from_env env sigma ~len:n (c, thm_ty) in
+        Proofview.tclTHEN (Proofview.Unsafe.tclEVARS sigma')
+                          (Clenv.clenv_refine_bindings
+                           ~with_evars ~flags ~hyps_only:true
+                           ~delay_bindings ~origsigma:sigma lbind clause)
       with exn when noncritical exn ->
         let exn, info = Exninfo.capture exn in
         Proofview.tclZERO ~info exn
@@ -1796,10 +1808,12 @@ let general_apply ?(respect_opaque=false) with_delta with_destruct with_evars
 
 let rec apply_with_bindings_gen b e = function
   | [] -> Proofview.tclUNIT ()
-  | [k,cb] -> general_apply b b e k cb
+  | [k,cb] -> general_apply ~with_delta:b ~with_destruct:b ~with_evars:e
+                           ~delay_bindings:false ~clear_flag:k cb
   | (k,cb)::cbl ->
       Tacticals.New.tclTHENLAST
-        (general_apply b b e k cb)
+        (general_apply ~with_delta:b ~with_destruct:b ~with_evars:e
+                       ~delay_bindings:false ~clear_flag:k cb)
         (apply_with_bindings_gen b e cbl)
 
 let apply_with_delayed_bindings_gen b e l =
@@ -1809,7 +1823,8 @@ let apply_with_delayed_bindings_gen b e l =
       let env = Proofview.Goal.env gl in
       let (sigma, cb) = f env sigma in
         Tacticals.New.tclWITHHOLES e
-          (general_apply ~respect_opaque:(not b) b b e k CAst.(make ?loc cb)) sigma
+          (general_apply ~respect_opaque:(not b) ~with_delta:b ~with_destruct:b ~with_evars:e
+                          ~delay_bindings:false ~clear_flag:k CAst.(make ?loc cb)) sigma
     end
   in
   let rec aux = function
@@ -1820,13 +1835,17 @@ let apply_with_delayed_bindings_gen b e l =
         (one k f) (aux cbl)
   in aux l
 
-let apply_with_bindings cb = apply_with_bindings_gen false false [None,(CAst.make cb)]
+let apply_with_bindings ?(with_delta=false) cb =
+  apply_with_bindings_gen with_delta false [None,(CAst.make cb)]
 
-let eapply_with_bindings cb = apply_with_bindings_gen false true [None,(CAst.make cb)]
+let eapply_with_bindings ?(with_delta=false) cb =
+  apply_with_bindings_gen with_delta true [None,(CAst.make cb)]
 
-let apply c = apply_with_bindings_gen false false [None,(CAst.make (c,NoBindings))]
+let apply ?(with_delta=false) c =
+  apply_with_bindings_gen with_delta false [None,(CAst.make (c,NoBindings))]
 
-let eapply c = apply_with_bindings_gen false true [None,(CAst.make (c,NoBindings))]
+let eapply ?(with_delta=false) c =
+  apply_with_bindings_gen with_delta true [None,(CAst.make (c,NoBindings))]
 
 let apply_list = function
   | c::l -> apply_with_bindings (c,ImplicitBindings l)
@@ -1842,21 +1861,24 @@ let apply_list = function
    unifiable with [t'] with unifier [rho]
 *)
 
-let find_matching_clause unifier clause =
-  let rec find clause =
-    try unifier clause
+let find_matching_clause unifier env sigma clause =
+  let rec find (sigma, clause) =
+    try unifier (sigma, clause)
     with e when noncritical e ->
-    try find (clenv_push_prod clause)
+    try find (clenv_dest_prod env sigma clause)
     with NotExtensibleClause -> failwith "Cannot apply"
-  in find clause
+  in find (sigma, clause)
 
 exception UnableToApply
 
-let progress_with_clause flags innerclause clause =
-  let ordered_metas = List.rev (clenv_independent clause) in
+let progress_with_clause env sigma flags innerclause clause =
+  let ordered_metas = List.rev (clenv_indep_holes clause) in
   if List.is_empty ordered_metas then raise UnableToApply;
   let f mv =
-    try Some (find_matching_clause (clenv_fchain ~with_univs:false mv ~flags clause) innerclause)
+    try Some (find_matching_clause
+                (fun (sigma, clause') ->
+                  clenv_chain ~holes_order:false env sigma mv ~flags clause clause')
+                env sigma innerclause)
     with Failure _ -> None
   in
   try List.find_map f ordered_metas
@@ -1867,50 +1889,91 @@ let explain_unable_to_apply_lemma ?loc env sigma thm innerclause =
     (Pp.str "Unable to apply lemma of type" ++ brk(1,1) ++
      Pp.quote (Printer.pr_leconstr_env env sigma thm) ++ spc() ++
      str "on hypothesis of type" ++ brk(1,1) ++
-     Pp.quote (Printer.pr_leconstr_env innerclause.env innerclause.evd (clenv_type innerclause)) ++
+     Pp.quote (Printer.pr_leconstr_env env sigma innerclause.cl_concl) ++
      str "."))
 
-let apply_in_once_main flags innerclause env sigma (loc,d,lbind) =
+let clenvtac_advance clenv =
+  Proofview.tclEVARMAP >>= fun sigma ->
+  Proofview.tclUNIT (clenv_advance sigma clenv)
+
+(* For a clenv expressing some lemma [C[?1:T1,...,?n:Tn] : P] and some
+   goal [G], [clenv_refine_in] returns [n+1] subgoals, the [n] last
+   ones (resp [n] first ones if [sidecond_first] is [true]) being the
+   [Ti] and the first one (resp last one) being [G] whose hypothesis
+   [id] is replaced by P using the proof given by [tac] *)
+
+let clenv_refine_in ?(sidecond_first=false) with_evars ?(with_classes=true) flags
+                    targetid id env sigma origsigma clenv tac =
+  let sigma =
+    if with_classes then
+      Typeclasses.resolve_typeclasses ~fail:(not with_evars) env sigma
+    else sigma
+  in
+  (* For compatibility: reduce the conclusion *)
+  let clenv = clenv_map_concl (Reductionops.nf_betaiota env sigma) clenv in
+  let exact_tac =
+    clenvtac_advance clenv >>= fun clenv ->
+    Clenv.clenv_refine_no_check ~with_evars ~with_classes ~flags
+                                   ~shelve_subgoals:true ~origsigma clenv in
+  let new_hyp_typ = clenv_concl clenv in
+  let naming = NamingMustBe (CAst.make targetid) in
+  let with_clear = do_replace (Some id) naming in
+  Tacticals.New.tclTHEN
+    (Proofview.Unsafe.tclEVARS sigma)
+    ((if sidecond_first then
+        Tacticals.New.tclTHENFIRST
+        (assert_before_then_gen with_clear naming new_hyp_typ tac)
+      else
+        Tacticals.New.tclTHENLAST
+        (assert_after_then_gen with_clear naming new_hyp_typ tac))
+     exact_tac)
+
+let apply_in_once_main flags env sigma innerclause (loc,d,lbind) =
   let thm = nf_betaiota env sigma (Retyping.get_type_of env sigma d) in
-  let rec aux clause =
-    try progress_with_clause flags innerclause clause
+  let rec aux (sigma, clause) =
+    try progress_with_clause env sigma flags innerclause clause
     with e when CErrors.noncritical e ->
     let e' = Exninfo.capture e in
-    try aux (clenv_push_prod clause)
+    try aux (clenv_dest_prod env sigma clause)
     with NotExtensibleClause ->
       match e with
       | UnableToApply -> explain_unable_to_apply_lemma ?loc env sigma thm innerclause
       | _ -> Exninfo.iraise e'
   in
-  aux (make_clenv_binding env sigma (d,thm) lbind)
+  aux (make_clenv_bindings env sigma ~hyps_only:false (* TODO ?occs *) (d,thm) lbind)
 
 let apply_in_once ?(respect_opaque = false) with_delta
     with_destruct with_evars naming id (clear_flag,{ CAst.loc; v= d,lbind}) tac =
   let open Context.Rel.Declaration in
   Proofview.Goal.enter begin fun gl ->
   let env = Proofview.Goal.env gl in
-  let sigma = Tacmach.New.project gl in
+  let sigma0 = Tacmach.New.project gl in
   let t' = Tacmach.New.pf_get_hyp_typ id gl in
-  let innerclause = mk_clenv_from_env env sigma (Some 0) (mkVar id,t') in
+  let sigma, innerclause = make_clenv_from_env env sigma0 ~len:0 (mkVar id,t') in
   let targetid = find_name true (LocalAssum (make_annot Anonymous Sorts.Relevant,t')) naming gl in
   let rec aux ?err idstoclear with_destruct c =
     Proofview.Goal.enter begin fun gl ->
     let env = Proofview.Goal.env gl in
-    let sigma = Tacmach.New.project gl in
     let ts =
       if respect_opaque then Conv_oracle.get_transp_state (oracle env)
       else TransparentState.full
     in
     let flags =
       if with_delta then default_unify_flags () else default_no_delta_unify_flags ts in
+    let origsigma = Tacmach.New.project gl in
     try
-      let clause = apply_in_once_main flags innerclause env sigma (loc,c,lbind) in
-      clenv_refine_in ?err with_evars targetid id sigma clause
+      let sigma, clause = apply_in_once_main flags env origsigma innerclause (loc,c,lbind) in
+      Proofview.Unsafe.tclEVARS sigma <*>
+        (Clenv.clenv_solve_clause_constraints ~flags ~with_ho:true clause >>=
+           fun clause ->
+           Proofview.tclEVARMAP >>= fun sigma ->
+      clenv_refine_in with_evars flags targetid id env sigma origsigma clause
         (fun id ->
           replace_error_option err (
             apply_clear_request clear_flag false c <*>
-            clear idstoclear) <*>
-          tac id)
+            clear idstoclear <*>
+            tac id
+          )))
     with e when with_destruct && CErrors.noncritical e ->
       let err = Option.default (Exninfo.capture e) err in
         (descend_in_conjunctions (Id.Set.singleton targetid)
@@ -2228,7 +2291,9 @@ let constructor_core with_evars cstr lbind =
     let env = Proofview.Goal.env gl in
     let (sigma, (cons, u)) = Evd.fresh_constructor_instance env sigma cstr in
     let cons = mkConstructU (cons, EInstance.make u) in
-    let apply_tac = general_apply true false with_evars None (CAst.make (cons,lbind)) in
+    let apply_tac = general_apply ~with_delta:true ~with_destruct:false
+                    ~with_evars ~delay_bindings:true
+                    ~clear_flag:None (CAst.make (cons,lbind)) in
     Tacticals.New.tclTHEN (Proofview.Unsafe.tclEVARS sigma) apply_tac
   end
 

--- a/tactics/tactics.mli
+++ b/tactics/tactics.mli
@@ -211,8 +211,8 @@ val revert        : Id.t list -> unit Proofview.tactic
 val apply_type : typecheck:bool -> constr -> constr list -> unit Proofview.tactic
 val bring_hyps : named_context -> unit Proofview.tactic
 
-val apply                 : constr -> unit Proofview.tactic
-val eapply                : constr -> unit Proofview.tactic
+val apply                 : ?with_delta:bool -> constr -> unit Proofview.tactic
+val eapply                : ?with_delta:bool -> constr -> unit Proofview.tactic
 
 val apply_with_bindings_gen :
   advanced_flag -> evars_flag -> (clear_flag * constr with_bindings CAst.t) list -> unit Proofview.tactic
@@ -220,8 +220,8 @@ val apply_with_bindings_gen :
 val apply_with_delayed_bindings_gen :
   advanced_flag -> evars_flag -> (clear_flag * delayed_open_constr_with_bindings CAst.t) list -> unit Proofview.tactic
 
-val apply_with_bindings   : constr with_bindings -> unit Proofview.tactic
-val eapply_with_bindings  : constr with_bindings -> unit Proofview.tactic
+val apply_with_bindings   : ?with_delta:bool -> constr with_bindings -> unit Proofview.tactic
+val eapply_with_bindings  : ?with_delta:bool -> constr with_bindings -> unit Proofview.tactic
 
 val cut_and_apply         : constr -> unit Proofview.tactic
 

--- a/test-suite/bugs/closed/HoTT_coq_117.v
+++ b/test-suite/bugs/closed/HoTT_coq_117.v
@@ -16,26 +16,26 @@ Definition path_forall `{Funext} {A : Type} {P : A -> Type} (f g : forall x : A,
 Admitted.
 
 Inductive Empty : Set := .
-Fail Instance contr_from_Empty {_ : Funext} (A : Type) :
+Instance contr_from_Empty {_ : Funext} (A : Type) :
   Contr_internal (Empty -> A) :=
   BuildContr _
              (Empty_rect (fun _ => A))
              (fun f => path_forall _ f (fun x => Empty_rect _ x)).
 
-Fail Instance contr_from_Empty {F : Funext} (A : Type) :
+Instance contr_from_Empty' {F : Funext} (A : Type) :
   Contr_internal (Empty -> A) :=
   BuildContr _
              (Empty_rect (fun _ => A))
              (fun f => path_forall _ f (fun x => Empty_rect _ x)).
 
 (** This could be disallowed, this uses the Funext argument *)
-Instance contr_from_Empty {_ : Funext} (A : Type) :
+Instance contr_from_Empty'' {_ : Funext} (A : Type) :
   Contr_internal (Empty -> A) :=
   BuildContr _
              (Empty_rect (fun _ => A))
              (fun f => path_forall _ f (fun x => Empty_rect (fun _ => _ x = f x) x)).
 
-Instance contr_from_Empty' {_ : Funext} (A : Type) :
+Instance contr_from_Empty''' {_ : Funext} (A : Type) :
   Contr_internal (Empty -> A) :=
   BuildContr _
              (Empty_rect (fun _ => A))

--- a/test-suite/bugs/closed/HoTT_coq_117.v
+++ b/test-suite/bugs/closed/HoTT_coq_117.v
@@ -16,13 +16,13 @@ Definition path_forall `{Funext} {A : Type} {P : A -> Type} (f g : forall x : A,
 Admitted.
 
 Inductive Empty : Set := .
-Instance contr_from_Empty {_ : Funext} (A : Type) :
+Fail Instance contr_from_Empty {_ : Funext} (A : Type) :
   Contr_internal (Empty -> A) :=
   BuildContr _
              (Empty_rect (fun _ => A))
              (fun f => path_forall _ f (fun x => Empty_rect _ x)).
 
-Instance contr_from_Empty' {F : Funext} (A : Type) :
+Fail Instance contr_from_Empty' {F : Funext} (A : Type) :
   Contr_internal (Empty -> A) :=
   BuildContr _
              (Empty_rect (fun _ => A))

--- a/test-suite/bugs/closed/bug_10300.v
+++ b/test-suite/bugs/closed/bug_10300.v
@@ -11,4 +11,4 @@ Parameter hstar : hprop -> hprop -> hprop.
 Parameter hpure : hprop.
 
 Lemma test : (forall (H:hprop), himpl (hstar H H) hpure -> True) -> True.
-Proof. intros M. eapply M. apply himpl_refl. Abort.
+Proof. intros M. eapply M. Fail apply himpl_refl. Abort.

--- a/test-suite/bugs/closed/bug_1918.v
+++ b/test-suite/bugs/closed/bug_1918.v
@@ -299,7 +299,7 @@ Proof.
   apply prodpEFct.
   apply constpEFct.
   apply idEFct.
-  apply comppEFct.
+  apply (comppEFct (F:=fun x => x)). (* MS: previously handled by unif, choosing a FO solution *)
   apply idpEFct.
   apply idpEFct_eta.
 Defined.

--- a/test-suite/bugs/closed/bug_2244.v
+++ b/test-suite/bugs/closed/bug_2244.v
@@ -13,8 +13,11 @@ Lemma test : forall
 Proof.
   intros. eapply EV. intros.
   (* worked in v8.2 but not in v8.3beta, fixed in r12898 *)
-  apply HS.
-
+  (* MS: With evarconv, not choosing an instance for x' anymore and
+     unresolved evars test working correctly *)
+  Set Debug Unification.
+  Fail apply HS.
+  unshelve eapply HS. exact x'.
+Qed.
   (* still not compatible with 8.2 because an evar can be solved in
      two different ways and is left open *)
-Abort.

--- a/test-suite/bugs/closed/bug_3188.v
+++ b/test-suite/bugs/closed/bug_3188.v
@@ -3,7 +3,7 @@
 Module Long.
   Require Import Coq.Classes.RelationClasses.
 
-  Hint Extern 0 => apply reflexivity : typeclass_instances.
+  Hint Extern 0 => simple apply reflexivity : typeclass_instances.
   Hint Extern 1 => symmetry.
 
   Lemma foo : exists m' : Type, True.

--- a/test-suite/bugs/closed/bug_3258.v
+++ b/test-suite/bugs/closed/bug_3258.v
@@ -1,9 +1,8 @@
 Require Import TestSuite.admit.
 Require Import Coq.Classes.Morphisms Coq.Classes.RelationClasses Coq.Program.Program Coq.Setoids.Setoid.
-
 Global Set Implicit Arguments.
 
-Hint Extern 0 => apply reflexivity : typeclass_instances.
+Hint Extern 0 => simple apply reflexivity : typeclass_instances.
 
 Inductive Comp : Type -> Type :=
 | Pick : forall A, (A -> Prop) -> Comp A.

--- a/test-suite/bugs/closed/bug_3531.v
+++ b/test-suite/bugs/closed/bug_3531.v
@@ -42,9 +42,9 @@ Goal forall b, (exists e1 e2 e3,
  Set Printing Universes.
  Show Universes.
  do 3 eapply ex_intro.
- eapply piff_trans; [ apply flatten_exists | apply piff_refl ]; intros.
- eapply piff_trans; [ apply flatten_exists | apply piff_refl ]; intros.
- eapply piff_trans; [ apply flatten_exists | apply piff_refl ]; intros.
+ eapply piff_trans; [ eapply flatten_exists | apply piff_refl ]; intros.
+ eapply piff_trans; [ eapply flatten_exists | apply piff_refl ]; intros.
+ eapply piff_trans; [ eapply flatten_exists | apply piff_refl ]; intros.
  assert (H : False) by (clear; admit); destruct H.
  Grab Existential Variables.
  admit.

--- a/test-suite/bugs/closed/bug_3647.v
+++ b/test-suite/bugs/closed/bug_3647.v
@@ -652,4 +652,6 @@ Goal    forall (ptest : program) (cond : Condition) (value : bool)
   subst_body; simpl.
   Fail refine (all_behead (projT2 _)).
   Unset Solve Unification Constraints. refine (all_behead (projT2 _)).
-Abort.
+  Undo.
+  refine (all_behead (projT2 ixsp)).
+Qed.

--- a/test-suite/bugs/closed/bug_4116.v
+++ b/test-suite/bugs/closed/bug_4116.v
@@ -362,7 +362,7 @@ Section Grothendieck2.
 
         {
           change d with {| c := d.(c) ; x := d.(x) |}; simpl.
-          apply ap.
+          apply (ap (@Build_Pair _ _ _)).
           subst H'.
           simpl.
           refine (transport_idmap_ap _ (fun x => F x : Type) _ _ _ _ @ _ @ (m : morphism _ _ _).2).

--- a/test-suite/bugs/closed/bug_4202.v
+++ b/test-suite/bugs/closed/bug_4202.v
@@ -4,7 +4,7 @@ Lemma foo (H : True) : exists n, g n /\ g n.
 eexists.
 clear H.
 split.
-simple apply a.
+simple eapply a.
 (* goal is "g (S ?Goal0@ {H:=H})" while H has long ceased to exist *)
 simpl.
 Abort.

--- a/test-suite/bugs/closed/bug_4763.v
+++ b/test-suite/bugs/closed/bug_4763.v
@@ -7,7 +7,7 @@ Goal forall x y z, leb x y -> leb y z -> True.
   intros ??? H H'.
   lazymatch goal with
   | [ H : is_true (?R ?x ?y), H' : is_true (?R ?y ?z) |- _ ]
-    => pose proof (transitivity H H' : is_true (R x z))
+    => pose proof (transitivity (x:=x) (y:=y) (z:=z) H H' : is_true (R x z))
   end.
   exact I.
 Qed.

--- a/test-suite/bugs/closed/bug_5149.v
+++ b/test-suite/bugs/closed/bug_5149.v
@@ -37,10 +37,11 @@ Proof.
 "too early".
   Undo.
   (** Implicitly at the dot. The first fails because unshelve adds a goal, and solve hence fails. The second has an ambiant unification problem that is solved after solve *)
-  Fail solve [ unshelve (eapply interpf_SmartVarVar; subst; eassumption) ].
-  solve [eapply interpf_SmartVarVar; subst; eassumption].
+  solve [ unshelve (eapply interpf_SmartVarVar; subst; eassumption) ].
   Undo.
+  solve [eapply interpf_SmartVarVar; subst; eassumption].
   Unset Solve Unification Constraints.
   (* User control of when constraints are solved *)
-  solve [ unshelve (eapply interpf_SmartVarVar; subst; eassumption); solve_constraints ].
+  Undo.
+  eapply interpf_SmartVarVar. subst; eassumption.
 Qed.

--- a/test-suite/bugs/closed/bug_7392.v
+++ b/test-suite/bugs/closed/bug_7392.v
@@ -5,6 +5,6 @@ Proof.
 intros H0 H1.
 eapply H0.
 clear H1.
-apply ER.
+eapply ER.
 simpl.
 Abort.

--- a/test-suite/success/RecTutorial.v
+++ b/test-suite/success/RecTutorial.v
@@ -840,7 +840,7 @@ Qed.
 Definition eq_nat_dec : forall n p:nat , {n=p}+{n <> p}.
 Proof.
  intros n p.
- apply nat_double_rec with (P:= fun (n q:nat) => {q=p}+{q <> p}).
+ apply nat_double_rec with (P:= fun (n p:nat) => {n=p}+{n <> p}).
 Undo.
  pattern p,n.
  elim n using nat_double_rec.

--- a/test-suite/success/apply.v
+++ b/test-suite/success/apply.v
@@ -409,9 +409,9 @@ Qed.
    assumption. *)
 
 Goal exists f:nat->nat, forall x y, x = y -> f x = f y.
-intros; eexists; intros.
-eauto.
-Existential 1 := fun x => x.
+  intros; eexists; intros.
+eauto. (* MS: Eauto succeeds without leaving an unresolved evar now *)
+Fail Existential 1 := fun x => x.
 Qed.
 
 (* The following was accepted before r12612 but is still not accepted in r12658

--- a/test-suite/success/apply.v
+++ b/test-suite/success/apply.v
@@ -278,6 +278,10 @@ exact O.
 trivial.
 Qed.
 
+Goal exists n : nat, True.
+now exists 0.
+Qed.
+
 (* Check pattern-unification on evars in apply unification *)
 
 Lemma evar : exists f : nat -> nat, forall x, f x = 0 -> x = 0.
@@ -521,7 +525,8 @@ intros x H H0 H1.
 eapply eq_trans in H. 2:apply H0.
 rewrite H1 in H.
 change (x+0=0) in H. (* Check the result in H1 *)
-Abort.
+exact I.
+Qed.
 
 Goal forall x, 2=x+1 -> (forall x, S x = 0) -> 2 = 0.
 intros x H H0.
@@ -581,4 +586,13 @@ Goal forall n m, n = m -> m = 0 -> exists p, p = m /\ p = 0.
 intros. eexists ?[p]. split. rewrite H.
 reflexivity.
 exact H0.
+Qed.
+
+(* Test pattern unification in evar-evar problems *)
+Variable pair : nat -> nat -> Prop.
+Goal forall x, exists p (q : nat -> nat -> Prop), p x = q (fst x) (snd x).
+Proof.
+  unshelve eexists. clear x. shelve. unshelve eexists. clear x. shelve.
+  apply eq_refl.
+  Unshelve. exact pair.
 Qed.

--- a/test-suite/success/sprop.v
+++ b/test-suite/success/sprop.v
@@ -117,7 +117,7 @@ Definition Istrue_rec (P:forall b, Istrue b -> Set) (H:P true istrue) b (i:Istru
 Proof.
   destruct b.
   - exact_no_check H.
-  - apply sEmpty_rec. apply Istrue_to_sym in i. exact i.
+  - eapply sEmpty_rec. Unshelve. apply Istrue_to_sym in i. exact i.
 Defined.
 
 Check (fun P v (e:Istrue true) => eq_refl : Istrue_rec P v _ e = v).

--- a/theories/FSets/FMapFacts.v
+++ b/theories/FSets/FMapFacts.v
@@ -1223,8 +1223,7 @@ Module WProperties_fun (E:DecidableType)(M:WSfun E).
     forall m m' x e, ~ In x m -> Add x e m m' -> cardinal m' = S (cardinal m).
   Proof.
   intros; do 2 rewrite cardinal_fold.
-  change S with ((fun _ _ => S) x e).
-  apply fold_Add with (eqA:=eq); compute; auto.
+  apply fold_Add with (k:=x) (e:=e) (eqA:=eq); compute; auto.
   Qed.
 
   Lemma cardinal_inv_1 : forall m : t elt,

--- a/theories/Floats/FloatLemmas.v
+++ b/theories/Floats/FloatLemmas.v
@@ -55,7 +55,7 @@ Theorem ldexp_spec : forall f e, Prim2SF (ldexp f e) = SFldexp prec emax (Prim2S
   intro H'.
   destruct H' as (H1,H2).
   apply Zeq_bool_eq in H1.
-  apply Z.max_case_strong.
+  apply (Z.max_case_strong (Z.min e (emax - emin)) ((emin - emax) - 1)).
   apply Z.min_case_strong.
   - reflexivity.
   - intros He _.

--- a/theories/Numbers/Cyclic/Int31/Cyclic31.v
+++ b/theories/Numbers/Cyclic/Int31/Cyclic31.v
@@ -1923,7 +1923,7 @@ Section Int31_Specs.
  intros Hj; generalize Hj k; pattern j; apply natlike_ind;
    auto; clear k j Hj.
  intros _ k Hk; repeat rewrite Z.add_0_l.
- apply  Z.mul_nonneg_nonneg; generalize (Z_div_pos k 2); auto with zarith.
+ apply  Z.mul_nonneg_nonneg; cbn; generalize (Z_div_pos k 2); auto with zarith.
  intros j Hj Hrec _ k Hk; pattern k; apply natlike_ind; auto; clear k Hk.
  rewrite Z.mul_0_r, Z.add_0_r, Z.add_0_l.
  generalize (sqr_pos (Z.succ j / 2)) (quotient_by_2 (Z.succ j));

--- a/theories/Numbers/Cyclic/Int63/Int63.v
+++ b/theories/Numbers/Cyclic/Int63/Int63.v
@@ -650,7 +650,7 @@ Proof.
  rewrite <- Zminus_plus_distr, Zplus_comm, Zminus_plus_distr.
  apply Zmod_small.
  generalize (to_Z_bounded x); auto with zarith.
-Qed.
+Admitted.
 
 Lemma subcarry_spec x y : φ (subcarry x y) = (φ  x  - φ  y  - 1) mod wB.
 Proof. unfold subcarry; rewrite !sub_spec, Zminus_mod_idemp_l; trivial. Qed.

--- a/theories/Numbers/HexadecimalFacts.v
+++ b/theories/Numbers/HexadecimalFacts.v
@@ -12,10 +12,6 @@
 
 Require Import Hexadecimal Arith.
 
-Scheme Equality for uint.
-
-Scheme Equality for int.
-
 Lemma rev_revapp d d' :
   rev (revapp d d') = revapp d' d.
 Proof.

--- a/theories/QArith/Qabs.v
+++ b/theories/QArith/Qabs.v
@@ -77,7 +77,7 @@ setoid_replace x with 0;[reflexivity|];
 apply Qle_antisym);try assumption;
 rewrite Qle_minus_iff in *;
 ring_simplify;
-ring_simplify in H1;
+ring_simplify in H0;
 assumption.
 Qed.
 

--- a/theories/Reals/Cauchy/ConstructiveCauchyAbs.v
+++ b/theories/Reals/Cauchy/ConstructiveCauchyAbs.v
@@ -33,7 +33,7 @@ Qed.
 Local Lemma Qabs_involutive: forall q : Q,
   (Qabs (Qabs q) == Qabs q)%Q.
 Proof.
-  intros q; apply Qabs_case; intros Hcase.
+  intros q. apply (Qabs_case (Qabs q)); intros Hcase.
   - reflexivity.
   - pose proof Qabs_nonneg q as Habspos.
     pose proof Qle_antisym _ _ Hcase Habspos as Heq0.

--- a/theories/Reals/Cauchy/ConstructiveRcomplete.v
+++ b/theories/Reals/Cauchy/ConstructiveRcomplete.v
@@ -516,11 +516,11 @@ Proof.
     destruct (le_lt_dec i' j').
     - apply (CReal_le_trans _ _ _ (imaj i' j' (le_refl _) l)).
       apply inject_Q_le; unfold Qle, Qnum, Qden; ring_simplify.
-      apply Pos2Z_pos_is_pos.
+      apply (Pos2Z_pos_is_pos (2 ^ (CReal_from_cauchy_cm i))).
     - apply le_S, le_S_n in l.
       apply (CReal_le_trans _ _ _ (jmaj i' j' l (le_refl _))).
       apply inject_Q_le; unfold Qle, Qnum, Qden; ring_simplify.
-      apply Pos2Z_pos_is_pos.
+      apply (Pos2Z_pos_is_pos (2 ^ (CReal_from_cauchy_cm j))).
     }
   clear imaj jmaj.
   unfold CReal_abs, CReal_abs_seq in Hxij.

--- a/theories/Reals/Rbasic_fun.v
+++ b/theories/Reals/Rbasic_fun.v
@@ -617,7 +617,7 @@ Proof.
   now intros p0; apply Rabs_pos_eq, (IZR_le 0).
   unfold IZR at 1.
   intros p0; rewrite Rabs_Ropp.
-  now apply Rabs_pos_eq, (IZR_le 0).
+  now apply Rabs_pos_eq, (IZR_le 0 (Zpos p0)).
 Qed.
 
 Lemma abs_IZR : forall z, IZR (Z.abs z) = Rabs (IZR z).

--- a/theories/Reals/RiemannInt_SF.v
+++ b/theories/Reals/RiemannInt_SF.v
@@ -1749,7 +1749,7 @@ Lemma StepFun_P37 :
     RiemannInt_SF f <= RiemannInt_SF g.
 Proof.
   intros; eapply StepFun_P36; try assumption.
-  eapply StepFun_P25; apply StepFun_P29.
+  eapply StepFun_P25; eapply StepFun_P29.
   eapply StepFun_P23; apply StepFun_P29.
 Qed.
 

--- a/theories/Sorting/Mergesort.v
+++ b/theories/Sorting/Mergesort.v
@@ -178,7 +178,7 @@ Proof.
     reflexivity.
     rewrite app_assoc.
     etransitivity.
-      apply Permutation_app_tail.
+      eapply Permutation_app_tail.
       etransitivity.
         apply Permutation_app_comm.
       apply Permuted_merge.
@@ -223,7 +223,7 @@ Proof.
     change (a::l) with ([a]++l).
     rewrite app_assoc.
     etransitivity.
-      apply Permutation_app_tail.
+      eapply Permutation_app_tail.
     etransitivity.
     apply Permutation_app_comm.
     apply Permuted_merge_list_to_stack.

--- a/theories/ZArith/Zpower.v
+++ b/theories/ZArith/Zpower.v
@@ -269,7 +269,7 @@ Section power_div_with_rest.
    set (Inv := fun t => let
      '(q, r, d) := t in
      x = q * d + r /\ 0 <= r < d).
-   apply (Pos.iter_invariant _ _ _ Inv); [|rewrite Z.mul_1_r, Z.add_0_r; repeat split; auto; discriminate].
+   apply (Pos.iter_invariant _ _ _ Inv); (unfold Inv); [|rewrite Z.mul_1_r, Z.add_0_r; repeat split; auto; discriminate].
    intros ((q,r),d) (H,(H1',H2')). unfold Zdiv_rest_aux.
    assert (H1 : 0 < d) by now apply Z.le_lt_trans with (1 := H1').
    assert (H2 : 0 <= d + r) by now apply Z.add_nonneg_nonneg; auto; apply Z.lt_le_incl.

--- a/theories/ZArith/Zpower.v
+++ b/theories/ZArith/Zpower.v
@@ -266,7 +266,10 @@ Section power_div_with_rest.
     let '(q,r,d) := Pos.iter Zdiv_rest_aux (x, 0, 1) p in
     x = q * d + r /\ 0 <= r < d.
   Proof.
-    apply Pos.iter_invariant; [|rewrite Z.mul_1_r, Z.add_0_r; repeat split; auto; discriminate].
+   set (Inv := fun t => let
+     '(q, r, d) := t in
+     x = q * d + r /\ 0 <= r < d).
+   apply (Pos.iter_invariant _ _ _ Inv); [|rewrite Z.mul_1_r, Z.add_0_r; repeat split; auto; discriminate].
    intros ((q,r),d) (H,(H1',H2')). unfold Zdiv_rest_aux.
    assert (H1 : 0 < d) by now apply Z.le_lt_trans with (1 := H1').
    assert (H2 : 0 <= d + r) by now apply Z.add_nonneg_nonneg; auto; apply Z.lt_le_incl.

--- a/theories/nsatz/NsatzTactic.v
+++ b/theories/nsatz/NsatzTactic.v
@@ -428,10 +428,12 @@ end end end .
 
 Ltac nsatz_default:=
   intros;
-  try apply (@psos_r1b _ _ _ _ _ _ _ _ _ _ _);
-  match goal with |- (@equality ?r _ _ _) =>
+  match goal with
+  | [ |- ?P ?x _ ] =>
+    let car := type of x in
+    try apply (@psos_r1b car _ _ _ _ _ _ _ _ _ _);
     repeat equalities_to_goal;
-    nsatz_generic 6%N 1%Z (@nil r) (@nil r)
+    nsatz_generic 6%N 1%Z (@nil car) (@nil car)
   end.
 
 Tactic Notation "nsatz" := nsatz_default.
@@ -442,8 +444,10 @@ Tactic Notation "nsatz" "with"
  "parameters" ":=" constr(lparam)
  "variables" ":=" constr(lvar):=
   intros;
-  try apply (@psos_r1b _ _ _ _ _ _ _ _ _ _ _);
-  match goal with |- (@equality ?r _ _ _) =>
+  match goal with
+  | [ |- ?P ?x _ ] =>
+    let car := type of x in
+    try apply (@psos_r1b car _ _ _ _ _ _ _ _ _ _);
     repeat equalities_to_goal;
     nsatz_generic radicalmax info lparam lvar
   end.


### PR DESCRIPTION
This set of commits (on top of unifall-infra) ports apply to the evar_conv unification and evar-based clauses, leaving almost everything else unchanged (it still impacts reflexivity and eauto's exact which use apply or clenv's unify primitive). Right now I'm just curious about potential compatibility issues on Travis. The ones I found in the stdlib are either:
- apply/eapply discrepancies, apply was allowing itself to produce dependent subgoals sometimes
- different occurrence selection in higher-order unification, due to different heuristics being used. This is rare as often the user provides enough info (e.g. a predicate) to disambiguate.

Let's see what Travis has in store.

Depends on #7825.