### PR TITLE
Fix BZ#5687: Coqtop died badly modal message box from CoqIDE.

### DIFF
--- a/ide/coq.mli
+++ b/ide/coq.mli
@@ -170,3 +170,4 @@ val check_connection : string list -> unit
     may terminate coqide in case of trouble *)
 
 val interrupter : (int -> unit) ref
+val save_all : (unit -> unit) ref

--- a/ide/coqide.ml
+++ b/ide/coqide.ml
@@ -284,6 +284,8 @@ let saveall _ =
       | Some f -> ignore (sn.fileops#save f))
     notebook#pages
 
+let () = Coq.save_all := saveall
+
 let revert_all _ =
   List.iter
     (fun sn -> if sn.fileops#changed_on_disk then sn.fileops#revert)


### PR DESCRIPTION
We let the user choose the most appropriate action to do if coqtop decides
to go berserk.

Fixes #5687.