### PR TITLE
Fix BZ#5245 hnf on projections with simpl never flag

### DIFF
--- a/pretyping/tacred.ml
+++ b/pretyping/tacred.ml
@@ -557,6 +557,12 @@ let match_eval_ref_value env sigma constr stack =
       Some (EConstr.of_constr (constant_value_in env (sp, u)))
     else
       None
+  | Proj (p, c) when not (Projection.unfolded p) ->
+     reduction_effect_hook env sigma (EConstr.to_constr sigma constr)
+        (lazy (EConstr.to_constr sigma (applist (constr,stack))));
+     if is_evaluable env (EvalConstRef (Projection.constant p)) then
+       Some (mkProj (Projection.unfold p, c))
+     else None
   | Var id when is_evaluable env (EvalVarRef id) -> 
      env |> lookup_named id |> NamedDecl.get_value
   | Rel n ->

--- a/test-suite/bugs/closed/5245.v
+++ b/test-suite/bugs/closed/5245.v
@@ -1,0 +1,18 @@
+Set Primitive Projections.
+
+Record foo := Foo {
+  foo_car : Type;
+  foo_rel : foo_car -> foo_car -> Prop
+}.
+Arguments foo_rel : simpl never.
+
+Definition foo_fun {A B} := Foo (A -> B) (fun f g => forall x, f x = g x).
+
+Goal @foo_rel foo_fun (fun x : nat => x) (fun x => x).
+Proof.
+intros x; exact eq_refl.
+Undo.
+progress hnf; intros; exact eq_refl.
+Undo.
+unfold foo_rel. intros x. exact eq_refl.
+Qed.


### PR DESCRIPTION
This was an omission in match_eval_ref_value, whose purpose is to do one-step unfolding of head constants, which didn't turn folded projections to unfolded ones (the first obey the "simpl never" flag while the later are treated like a match expression).