### PR TITLE
Fix BZ#5697: Congruence does not work with primitive projections

### DIFF
--- a/plugins/cc/cctac.ml
+++ b/plugins/cc/cctac.ml
@@ -84,7 +84,8 @@ let rec decompose_term env sigma t=
     | Proj (p, c) -> 
 	let canon_const kn = Constant.make1 (Constant.canonical kn) in 
 	let p' = Projection.map canon_const p in
-	(Appli (Symb (Term.mkConst (Projection.constant p')), decompose_term env sigma c))
+	let c = Retyping.expand_projection env sigma p' c [] in
+	decompose_term env sigma c
     | _ ->
        let t = Termops.strip_outer_cast sigma t in
        if closed0 sigma t then Symb (EConstr.to_constr sigma t) else raise Not_found

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -922,7 +922,8 @@ let build_selector env sigma dirn c ind special default =
   let brl =
     List.map build_branch(List.interval 1 (Array.length mip.mind_consnames)) in
   let ci = make_case_info env ind RegularStyle in
-  mkCase (ci, p, c, Array.of_list brl)
+  let ans = Inductiveops.make_case_or_project env sigma indf ci p c (Array.of_list brl) in
+  ans
 
 let build_coq_False () = pf_constr_of_global (build_coq_False ())
 let build_coq_True () = pf_constr_of_global (build_coq_True ())

--- a/test-suite/bugs/closed/5697.v
+++ b/test-suite/bugs/closed/5697.v
@@ -1,0 +1,10 @@
+Set Primitive Projections.
+
+Record foo : Type := Foo { foo_car: nat }.
+
+Goal forall x y : nat, x <> y -> Foo x <> Foo y.
+Proof.
+intros.
+intros H'.
+congruence.
+Qed.

--- a/test-suite/bugs/closed/5697.v
+++ b/test-suite/bugs/closed/5697.v
@@ -8,3 +8,12 @@ intros.
 intros H'.
 congruence.
 Qed.
+
+Record bar (A : Type) : Type := Bar { bar_car: A }.
+
+Goal forall x y : nat, x <> y -> Bar nat x <> Bar nat y.
+Proof.
+intros.
+intros H'.
+congruence.
+Qed.


### PR DESCRIPTION
See [BZ#5697](https://coq.inria.fr/bugs/show_bug.cgi?id=5697).

The code generating the projection was unconditionally generating pattern-matchings, although this is incorrect for primitive records.

We also fix a bug that was lurking around in congruence, which would have caused it to fail on primitive projections with parameters.