### PR TITLE
Avoid running interactive tests on Windows.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,4 +23,5 @@ build_script:
 - cmd: '%CYGROOT%/bin/bash -lc "cd $APPVEYOR_BUILD_FOLDER && ./configure -local && make"'
 
 test_script:
-- cmd: '%CYGROOT%/bin/bash -lc "cd $APPVEYOR_BUILD_FOLDER && make -C test-suite && make validate"'
+- cmd: '%CYGROOT%/bin/bash -lc "cd $APPVEYOR_BUILD_FOLDER && make -C test-suite all
+  INTERACTIVE= && make validate"'

--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -85,8 +85,10 @@ COMPLEXITY := $(if $(bogomips),complexity)
 
 BUGS := bugs/opened bugs/closed
 
+INTERACTIVE := interactive
+
 VSUBSYSTEMS := prerequisite success failure $(BUGS) output \
-  output-modulo-time interactive micromega $(COMPLEXITY) modules stm \
+  output-modulo-time $(INTERACTIVE) micromega $(COMPLEXITY) modules stm \
   coqdoc
 
 # All subsystems


### PR DESCRIPTION
This is a temporary workaround, until we fix the underlying issue which
makes coqtop hang on those tests.