### PR TITLE
For BZ#5688, mention hanging issue in ocamldebug and workaround

### DIFF
--- a/dev/doc/debugging.txt
+++ b/dev/doc/debugging.txt
@@ -53,6 +53,9 @@ Debugging from Caml debugger
      of each of error* functions or anomaly* functions in lib/util.ml
    - If "source db" fails, do a "make printers" and try again (it should build
      top_printers.cmo and the core cma files).
+   - If you have the OCAMLRUNPARAM environment variable set, Coq may hang on
+     startup when run from the debugger. If this happens, unset the variable,
+     re-start Emacs, and run the debugger again.
 
 Global gprof-based profiling
 ============================


### PR DESCRIPTION
It looks like #977 is not going to get merged. 

This PR adds advice in `debugging.txt` on how to avoid the hanging issue in ocamldebug.
