### PR TITLE
Fix #5708, simpl/cbn with simpl never projection, primitive or not

### DIFF
--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -933,13 +933,13 @@ let rec whd_state_gen ?csts ~refold ~tactic_mode flags env sigma =
          if not tactic_mode then
            let stack' = (c, Stack.Proj (p, Cst_stack.empty (*cst_l*)) :: stack) in
 	     whrec Cst_stack.empty stack'
-         else match ReductionBehaviour.get (Globnames.ConstRef (Projection.constant p)) with
-	 | None ->
+         else match Projection.unfolded p, ReductionBehaviour.get (Globnames.ConstRef (Projection.constant p)) with
+         | true, _ | _, None ->
            let stack' = (c, Stack.Proj (p, cst_l) :: stack) in
-	   let stack'', csts = whrec Cst_stack.empty stack' in
+           let stack'', csts = whrec Cst_stack.empty stack' in
 	     if equal_stacks sigma stack' stack'' then fold ()
 	     else stack'', csts
-	 | Some (recargs, nargs, flags) ->
+	 | false, Some (recargs, nargs, flags) ->
 	   if (List.mem `ReductionNeverUnfold flags
 	       || (nargs > 0 && Stack.args_size stack < (nargs - (npars + 1))))
 	   then fold ()

--- a/test-suite/bugs/closed/5708.v
+++ b/test-suite/bugs/closed/5708.v
@@ -1,0 +1,72 @@
+Module WithoutProj.
+Record foo := Foo {
+  foo_car : Type;
+  foo_op : foo_car -> foo_car -> foo_car
+}.
+Arguments foo_op : simpl never.
+
+Definition nat_foo := Foo nat plus.
+
+Goal match foo_op nat_foo 10 10 with 0 => True | _ => False end.
+  simpl. 
+  match goal with
+    |- match foo_op nat_foo 10 10 with
+       | 0 => True
+       | S _ => False
+       end => idtac
+  end.
+  unfold foo_op; simpl.
+  match goal with
+    |- False => idtac
+  end.
+  Undo 2.
+  cbn.
+  match goal with
+    |- match foo_op nat_foo 10 10 with
+       | 0 => True
+       | S _ => False
+       end => idtac
+  end.
+  unfold foo_op; cbn.
+  match goal with
+    |- False => idtac
+  end.
+Abort.
+End WithoutProj.
+
+Set Primitive Projections.
+Module WithProj.
+Record foo := Foo {
+  foo_car : Type;
+  foo_op : foo_car -> foo_car -> foo_car
+}.
+Arguments foo_op : simpl never.
+
+Definition nat_foo := Foo nat plus.
+
+Goal match foo_op nat_foo 10 10 with 0 => True | _ => False end.
+  simpl. 
+  match goal with
+    |- match foo_op nat_foo 10 10 with
+       | 0 => True
+       | S _ => False
+       end => idtac
+  end.
+  unfold foo_op; simpl.
+  match goal with
+    |- False => idtac
+  end.
+  Undo 2.
+  cbn.
+  match goal with
+    |- match foo_op nat_foo 10 10 with
+       | 0 => True
+       | S _ => False
+       end => idtac
+  end.
+  unfold foo_op; cbn.
+  match goal with
+    |- False => idtac
+  end.
+Abort.
+End WithProj.


### PR DESCRIPTION
Implement a consistent behavior between primitive and non-primitive projections for the simpl never flag, in both simpl and cbn.