### PR TITLE
intros '(x,y)

### DIFF
--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -2553,10 +2553,15 @@ let intern_gen kind env sigma
     pattern_mode (ltacvars, Id.Map.empty) c
 
 let intern_constr env sigma c = intern_gen WithoutTypeConstraint env sigma c
+
 let intern_type env sigma c = intern_gen IsType env sigma c
-let intern_pattern globalenv patt =
+
+let intern_cases_pattern globalenv patt =
   let env = {pat_ids = None; pat_scopes = (None, [])} in
-  intern_cases_pattern test_kind_tolerant globalenv Id.Map.empty env empty_alias patt
+  let ids,patl = intern_cases_pattern test_kind_tolerant globalenv Id.Map.empty env empty_alias patt in
+  if not (List.for_all (fun (subst,_) -> Id.Map.equal Id.equal Id.Map.empty subst) patl) then
+    user_err ?loc:patt.CAst.loc (str "Unsupported nested \"as\" clause.");
+  ids,List.map snd patl
 
 (*********************************************************************)
 (* Functions to parse and interpret constructions *)

--- a/interp/constrintern.mli
+++ b/interp/constrintern.mli
@@ -85,8 +85,7 @@ val intern_gen : typing_constraint -> env -> evar_map ->
   ?impls:internalization_env -> ?pattern_mode:bool -> ?ltacvars:ltac_sign ->
   constr_expr -> glob_constr
 
-val intern_pattern : env -> cases_pattern_expr ->
-  lident list * (Id.t Id.Map.t * cases_pattern) list
+val intern_cases_pattern : env -> cases_pattern_expr -> lident list * cases_pattern list
 
 val intern_context : env -> bound_univs:UnivNames.universe_binders ->
   internalization_env -> local_binder_expr list -> internalization_env * glob_decl list

--- a/intf/misctypes.ml
+++ b/intf/misctypes.ml
@@ -1,0 +1,139 @@
+(************************************************************************)
+(*  v      *   The Coq Proof Assistant  /  The Coq Development Team     *)
+(* <O___,, *   INRIA - CNRS - LIX - LRI - PPS - Copyright 1999-2017     *)
+(*   \VV/  **************************************************************)
+(*    //   *      This file is distributed under the terms of the       *)
+(*         *       GNU Lesser General Public License Version 2.1        *)
+(************************************************************************)
+
+open Names
+
+(** Basic types used both in [constr_expr] and in [glob_constr] *)
+
+(** Cases pattern variables *)
+
+type patvar = Id.t
+
+(** Introduction patterns *)
+
+type ('constr,'pattern) intro_pattern_expr =
+  | IntroForthcoming of bool
+  | IntroNaming of intro_pattern_naming_expr
+  | IntroAction of ('constr,'pattern) intro_pattern_action_expr
+and intro_pattern_naming_expr =
+  | IntroIdentifier of Id.t
+  | IntroFresh of Id.t
+  | IntroAnonymous
+and ('constr,'pattern) intro_pattern_action_expr =
+  | IntroWildcard
+  | IntroOrAndPattern of ('constr,'pattern) or_and_intro_pattern_expr
+  | IntroInjection of (('constr,'pattern) intro_pattern_expr) Loc.located list
+  | IntroIrrefutablePattern of 'pattern
+  | IntroApplyOn of 'constr Loc.located * ('constr,'pattern) intro_pattern_expr Loc.located
+  | IntroRewrite of bool
+and ('constr,'pattern) or_and_intro_pattern_expr =
+  | IntroOrPattern of (('constr,'pattern) intro_pattern_expr) Loc.located list list
+  | IntroAndPattern of (('constr,'pattern) intro_pattern_expr) Loc.located list
+
+(** Move destination for hypothesis *)
+
+type 'id move_location =
+  | MoveAfter of 'id
+  | MoveBefore of 'id
+  | MoveFirst
+  | MoveLast (** can be seen as "no move" when doing intro *)
+
+(** Sorts *)
+
+type 'a glob_sort_gen =
+  | GProp (** representation of [Prop] literal *)
+  | GSet  (** representation of [Set] literal *)
+  | GType of 'a (** representation of [Type] literal *)
+type sort_info = Name.t Loc.located list
+type level_info = Name.t Loc.located option
+
+type glob_sort = sort_info glob_sort_gen
+type glob_level = level_info glob_sort_gen
+
+(** A synonym of [Evar.t], also defined in Term *)
+
+type existential_key = Evar.t
+
+(** Case style, shared with Term *)
+
+type case_style = Term.case_style =
+  | LetStyle
+  | IfStyle
+  | LetPatternStyle
+  | MatchStyle
+  | RegularStyle (** infer printing form from number of constructor *)
+
+(** Casts *)
+
+type 'a cast_type =
+  | CastConv of 'a
+  | CastVM of 'a
+  | CastCoerce (** Cast to a base type (eg, an underlying inductive type) *)
+  | CastNative of 'a
+
+(** Bindings *)
+
+type quantified_hypothesis = AnonHyp of int | NamedHyp of Id.t
+
+type 'a explicit_bindings = (quantified_hypothesis * 'a) Loc.located list
+
+type 'a bindings =
+  | ImplicitBindings of 'a list
+  | ExplicitBindings of 'a explicit_bindings
+  | NoBindings
+
+type 'a with_bindings = 'a * 'a bindings
+
+
+(** Some utility types for parsing *)
+
+type 'a or_var =
+  | ArgArg of 'a
+  | ArgVar of Names.Id.t Loc.located
+
+type 'a and_short_name = 'a * Id.t Loc.located option
+
+type 'a or_by_notation =
+  | AN of 'a
+  | ByNotation of (string * string option) Loc.located
+
+(* NB: the last string in [ByNotation] is actually a [Notation.delimiters],
+   but this formulation avoids a useless dependency. *)
+
+
+(** Kinds of modules *)
+
+type module_kind = Module | ModType | ModAny
+
+(** Various flags *)
+
+type direction_flag = bool (* true = Left-to-right    false = right-to-right *)
+type evars_flag = bool     (* true = pose evars       false = fail on evars *)
+type rec_flag = bool       (* true = recursive        false = not recursive *)
+type advanced_flag = bool  (* true = advanced         false = basic *)
+type letin_flag = bool     (* true = use local def    false = use Leibniz *)
+type clear_flag = bool option (* true = clear hyp, false = keep hyp, None = use default *)
+
+type multi =
+  | Precisely of int
+  | UpTo of int
+  | RepeatStar
+  | RepeatPlus
+
+type 'a core_destruction_arg =
+  | ElimOnConstr of 'a
+  | ElimOnIdent of Id.t Loc.located
+  | ElimOnAnonHyp of int
+
+type 'a destruction_arg =
+  clear_flag * 'a core_destruction_arg
+
+type inversion_kind =
+  | SimpleInversion
+  | FullInversion
+  | FullInversionClear

--- a/intf/tactypes.ml
+++ b/intf/tactypes.ml
@@ -1,0 +1,36 @@
+(************************************************************************)
+(*  v      *   The Coq Proof Assistant  /  The Coq Development Team     *)
+(* <O___,, *   INRIA - CNRS - LIX - LRI - PPS - Copyright 1999-2017     *)
+(*   \VV/  **************************************************************)
+(*    //   *      This file is distributed under the terms of the       *)
+(*         *       GNU Lesser General Public License Version 2.1        *)
+(************************************************************************)
+
+(** Tactic-related types that are not totally Ltac specific and still used in
+    lower API. It's not clear whether this is a temporary API or if this is
+    meant to stay. *)
+
+open Loc
+open Names
+open Constrexpr
+open Pattern
+open Misctypes
+open Glob_term
+
+(** In globalize tactics, we need to keep the initial [constr_expr] to recompute
+   in the environment by the effective calls to Intro, Inversion, etc
+   The [constr_expr] field is [None] in TacDef though *)
+type glob_constr_and_expr = Glob_term.glob_constr * constr_expr option
+type glob_constr_pattern_and_expr = Id.Set.t * glob_constr_and_expr * constr_pattern
+
+type 'a delayed_open = Environ.env -> Evd.evar_map -> Evd.evar_map * 'a
+
+type delayed_open_constr = EConstr.constr delayed_open
+type delayed_open_constr_with_bindings = EConstr.constr with_bindings delayed_open
+
+type glob_cases_pattern = Id.t list * cases_pattern list
+
+type intro_pattern = (delayed_open_constr,glob_cases_pattern) intro_pattern_expr located
+type intro_patterns = (delayed_open_constr,glob_cases_pattern) intro_pattern_expr located list
+type or_and_intro_pattern = (delayed_open_constr,glob_cases_pattern) or_and_intro_pattern_expr located
+type intro_pattern_naming = intro_pattern_naming_expr located

--- a/plugins/ltac/g_tactic.ml4
+++ b/plugins/ltac/g_tactic.ml4
@@ -1,0 +1,683 @@
+(************************************************************************)
+(*  v      *   The Coq Proof Assistant  /  The Coq Development Team     *)
+(* <O___,, *   INRIA - CNRS - LIX - LRI - PPS - Copyright 1999-2017     *)
+(*   \VV/  **************************************************************)
+(*    //   *      This file is distributed under the terms of the       *)
+(*         *       GNU Lesser General Public License Version 2.1        *)
+(************************************************************************)
+
+open Pp
+open CErrors
+open Util
+open Tacexpr
+open Genredexpr
+open Constrexpr
+open Libnames
+open Tok
+open Misctypes
+open Locus
+open Decl_kinds
+
+open Pcoq
+
+
+let all_with delta = Redops.make_red_flag [FBeta;FMatch;FFix;FCofix;FZeta;delta]
+
+let tactic_kw = [ "->"; "<-" ; "by" ]
+let _ = List.iter CLexer.add_keyword tactic_kw
+
+let err () = raise Stream.Failure
+
+(* Hack to parse "(x:=t)" as an explicit argument without conflicts with the *)
+(* admissible notation "(x t)" *)
+let test_lpar_id_coloneq =
+  Gram.Entry.of_parser "lpar_id_coloneq"
+    (fun strm ->
+      match stream_nth 0 strm with
+        | KEYWORD "(" ->
+            (match stream_nth 1 strm with
+              | IDENT _ ->
+                  (match stream_nth 2 strm with
+	            | KEYWORD ":=" -> ()
+	            | _ -> err ())
+	      | _ -> err ())
+	| _ -> err ())
+
+(* Hack to recognize "(x)" *)
+let test_lpar_id_rpar =
+  Gram.Entry.of_parser "lpar_id_coloneq"
+    (fun strm ->
+      match stream_nth 0 strm with
+        | KEYWORD "(" ->
+            (match stream_nth 1 strm with
+              | IDENT _ ->
+                  (match stream_nth 2 strm with
+	            | KEYWORD ")" -> ()
+	            | _ -> err ())
+	      | _ -> err ())
+	| _ -> err ())
+
+(* idem for (x:=t) and (1:=t) *)
+let test_lpar_idnum_coloneq =
+  Gram.Entry.of_parser "test_lpar_idnum_coloneq"
+    (fun strm ->
+      match stream_nth 0 strm with
+        | KEYWORD "(" ->
+            (match stream_nth 1 strm with
+              | IDENT _ | INT _ ->
+                  (match stream_nth 2 strm with
+                    | KEYWORD ":=" -> ()
+                    | _ -> err ())
+              | _ -> err ())
+        | _ -> err ())
+
+(* idem for (x:t) *)
+open Extraargs
+
+(* idem for (x1..xn:t) [n^2 complexity but exceptional use] *)
+let check_for_coloneq =
+  Gram.Entry.of_parser "lpar_id_colon"
+    (fun strm ->
+      let rec skip_to_rpar p n =
+	match List.last (Stream.npeek n strm) with
+        | KEYWORD "(" -> skip_to_rpar (p+1) (n+1)
+        | KEYWORD ")" -> if Int.equal p 0 then n+1 else skip_to_rpar (p-1) (n+1)
+	| KEYWORD "." -> err ()
+	| _ -> skip_to_rpar p (n+1) in
+      let rec skip_names n =
+	match List.last (Stream.npeek n strm) with
+        | IDENT _ | KEYWORD "_" -> skip_names (n+1)
+	| KEYWORD ":" -> skip_to_rpar 0 (n+1) (* skip a constr *)
+	| _ -> err () in
+      let rec skip_binders n =
+	match List.last (Stream.npeek n strm) with
+        | KEYWORD "(" -> skip_binders (skip_names (n+1))
+        | IDENT _ | KEYWORD "_" -> skip_binders (n+1)
+	| KEYWORD ":=" -> ()
+	| _ -> err () in
+      match stream_nth 0 strm with
+      | KEYWORD "(" -> skip_binders 2
+      | _ -> err ())
+
+let lookup_at_as_comma =
+  Gram.Entry.of_parser "lookup_at_as_comma"
+    (fun strm ->
+      match stream_nth 0 strm with
+	| KEYWORD (","|"at"|"as") -> ()
+	| _ -> err ())
+
+open Constr
+open Prim
+open Pltac
+
+let mk_fix_tac (loc,id,bl,ann,ty) =
+  let n =
+    match bl,ann with
+        [([_],_,_)], None -> 1
+      | _, Some x ->
+          let ids = List.map snd (List.flatten (List.map pi1 bl)) in
+          (try List.index Names.Name.equal (snd x) ids
+          with Not_found -> user_err Pp.(str "No such fix variable."))
+      | _ -> user_err Pp.(str "Cannot guess decreasing argument of fix.") in
+  (id,n, CAst.make ~loc @@ CProdN(bl,ty))
+
+let mk_cofix_tac (loc,id,bl,ann,ty) =
+  let _ = Option.map (fun (aloc,_) ->
+    user_err ~loc:aloc
+      ~hdr:"Constr:mk_cofix_tac"
+      (Pp.str"Annotation forbidden in cofix expression.")) ann in
+  (id,CAst.make ~loc @@ CProdN(bl,ty))
+
+(* Functions overloaded by quotifier *)
+let destruction_arg_of_constr (c,lbind as clbind) = match lbind with
+  | NoBindings ->
+    begin
+      try ElimOnIdent (Constrexpr_ops.constr_loc c,snd(Constrexpr_ops.coerce_to_id c))
+      with e when CErrors.noncritical e -> ElimOnConstr clbind
+    end
+  | _ -> ElimOnConstr clbind
+
+let mkNumeral n = Numeral (string_of_int (abs n), 0<=n)
+
+let mkTacCase with_evar = function
+  | [(clear,ElimOnConstr cl),(None,None),None],None ->
+      TacCase (with_evar,(clear,cl))
+  (* Reinterpret numbers as a notation for terms *)
+  | [(clear,ElimOnAnonHyp n),(None,None),None],None ->
+      TacCase (with_evar,
+        (clear,(CAst.make @@ CPrim (mkNumeral n),
+         NoBindings)))
+  (* Reinterpret ident as notations for variables in the context *)
+  (* because we don't know if they are quantified or not *)
+  | [(clear,ElimOnIdent id),(None,None),None],None ->
+      TacCase (with_evar,(clear,(CAst.make @@ CRef (Ident id,None),NoBindings)))
+  | ic ->
+      if List.exists (function ((_, ElimOnAnonHyp _),_,_) -> true | _ -> false) (fst ic)
+      then
+	user_err Pp.(str "Use of numbers as direct arguments of 'case' is not supported.");
+      TacInductionDestruct (false,with_evar,ic)
+
+let rec mkCLambdaN_simple_loc ?loc bll c =
+  match bll with
+  | ((loc1,_)::_ as idl,bk,t) :: bll ->
+      CAst.make ?loc @@ CLambdaN ([idl,bk,t],mkCLambdaN_simple_loc ?loc:(Loc.merge_opt loc1 loc) bll c)
+  | ([],_,_) :: bll -> mkCLambdaN_simple_loc ?loc bll c
+  | [] -> c
+
+let mkCLambdaN_simple bl c = match bl with
+  | [] -> c
+  | h :: _ ->
+    let loc = Loc.merge_opt (fst (List.hd (pi1 h))) (Constrexpr_ops.constr_loc c) in
+    mkCLambdaN_simple_loc ?loc bl c
+
+let loc_of_ne_list l = Loc.merge_opt (fst (List.hd l)) (fst (List.last l))
+
+let map_int_or_var f = function
+  | ArgArg x -> ArgArg (f x)
+  | ArgVar _ as y -> y
+
+let all_concl_occs_clause = { onhyps=Some[]; concl_occs=AllOccurrences }
+
+let merge_occurrences loc cl = function
+  | None ->
+      if Locusops.clause_with_generic_occurrences cl then (None, cl)
+      else
+	user_err ~loc  (str "Found an \"at\" clause without \"with\" clause.")
+  | Some (occs, p) ->
+    let ans = match occs with
+    | AllOccurrences -> cl
+    | _ ->
+      begin match cl with
+      | { onhyps = Some []; concl_occs = AllOccurrences } ->
+        { onhyps = Some []; concl_occs = occs }
+      | { onhyps = Some [(AllOccurrences, id), l]; concl_occs = NoOccurrences } ->
+        { cl with onhyps = Some [(occs, id), l] }
+      | _ ->
+        if Locusops.clause_with_generic_occurrences cl then
+          user_err ~loc  (str "Unable to interpret the \"at\" clause; move it in the \"in\" clause.")
+        else
+          user_err ~loc  (str "Cannot use clause \"at\" twice.")
+      end
+    in
+    (Some p, ans)
+
+let warn_deprecated_eqn_syntax =
+  CWarnings.create ~name:"deprecated-eqn-syntax" ~category:"deprecated"
+         (fun arg -> strbrk (Printf.sprintf "Syntax \"_eqn:%s\" is deprecated. Please use \"eqn:%s\" instead." arg arg))
+
+(* Auxiliary grammar rules *)
+
+open Vernac_
+
+GEXTEND Gram
+  GLOBAL: simple_tactic constr_with_bindings quantified_hypothesis
+  bindings red_expr int_or_var open_constr uconstr
+  simple_intropattern in_clause clause_dft_concl hypident destruction_arg;
+
+  int_or_var:
+    [ [ n = integer  -> ArgArg n
+      | id = identref -> ArgVar id ] ]
+  ;
+  nat_or_var:
+    [ [ n = natural  -> ArgArg n
+      | id = identref -> ArgVar id ] ]
+  ;
+  (* An identifier or a quotation meta-variable *)
+  id_or_meta:
+    [ [ id = identref -> id ] ]
+  ;
+  open_constr:
+    [ [ c = constr -> c ] ]
+  ;
+  uconstr:
+    [ [ c = constr -> c ] ]
+  ;
+  destruction_arg:
+    [ [ n = natural -> (None,ElimOnAnonHyp n)
+      | test_lpar_id_rpar; c = constr_with_bindings ->
+        (Some false,destruction_arg_of_constr c)
+      | c = constr_with_bindings_arg -> on_snd destruction_arg_of_constr c
+    ] ]
+  ;
+  constr_with_bindings_arg:
+    [ [ ">"; c = constr_with_bindings -> (Some true,c)
+      | c = constr_with_bindings -> (None,c) ] ]
+  ;
+  quantified_hypothesis:
+    [ [ id = ident -> NamedHyp id
+      | n = natural -> AnonHyp n ] ]
+  ;
+  conversion:
+    [ [ c = constr -> (None, c)
+      | c1 = constr; "with"; c2 = constr -> (Some (AllOccurrences,c1),c2)
+      | c1 = constr; "at"; occs = occs_nums; "with"; c2 = constr ->
+          (Some (occs,c1), c2) ] ]
+  ;
+  occs_nums:
+    [ [ nl = LIST1 nat_or_var -> OnlyOccurrences nl
+      | "-"; n = nat_or_var; nl = LIST0 int_or_var ->
+	  (* have used int_or_var instead of nat_or_var for compatibility *)
+	   AllOccurrencesBut (List.map (map_int_or_var abs) (n::nl)) ] ]
+  ;
+  occs:
+    [ [ "at"; occs = occs_nums -> occs | -> AllOccurrences ] ]
+  ;
+  pattern_occ:
+    [ [ c = constr; nl = occs -> (nl,c) ] ]
+  ;
+  ref_or_pattern_occ:
+    (* If a string, it is interpreted as a ref
+       (anyway a Coq string does not reduce) *)
+    [ [ c = smart_global; nl = occs -> nl,Inl c
+      | c = constr; nl = occs -> nl,Inr c ] ]
+  ;
+  unfold_occ:
+    [ [ c = smart_global; nl = occs -> (nl,c) ] ]
+  ;
+  intropatterns:
+    [ [ l = LIST0 nonsimple_intropattern -> l ]]
+  ;
+  ne_intropatterns:
+    [ [ l = LIST1 nonsimple_intropattern -> l ]]
+  ;
+  or_and_intropattern:
+    [ [ "["; tc = LIST1 intropatterns SEP "|"; "]" -> IntroOrPattern tc
+      | "()" -> IntroAndPattern []
+      | "("; si = simple_intropattern; ")" -> IntroAndPattern [si]
+      | "("; si = simple_intropattern; ",";
+             tc = LIST1 simple_intropattern SEP "," ; ")" ->
+             IntroAndPattern (si::tc)
+      | "("; si = simple_intropattern; "&";
+	     tc = LIST1 simple_intropattern SEP "&" ; ")" ->
+	  (* (A & B & C) is translated into (A,(B,C)) *)
+	  let rec pairify = function
+	    | ([]|[_]|[_;_]) as l -> l
+	    | t::q -> [t; Loc.tag ?loc:(loc_of_ne_list q) (IntroAction (IntroOrAndPattern (IntroAndPattern (pairify q))))]
+	  in IntroAndPattern (pairify (si::tc)) ] ]
+  ;
+  equality_intropattern:
+    [ [ "->" -> IntroRewrite true
+      | "<-" -> IntroRewrite false
+      | "[="; tc = intropatterns; "]" -> IntroInjection tc ] ]
+  ;
+  naming_intropattern:
+    [ [ prefix = pattern_ident -> IntroFresh prefix
+      | "?" -> IntroAnonymous
+      | id = ident -> IntroIdentifier id ] ]
+  ;
+  nonsimple_intropattern:
+    [ [ l = simple_intropattern -> l
+      | "*"  -> Loc.tag ~loc:!@loc @@ IntroForthcoming true
+      | "**" -> Loc.tag ~loc:!@loc @@ IntroForthcoming false ]]
+  ;
+  simple_intropattern:
+    [ [ pat = simple_intropattern_closed;
+        l = LIST0 ["%"; c = operconstr LEVEL "0" -> c] ->
+          let loc0,pat = pat in
+          let f c pat =
+            let loc1 = Constrexpr_ops.constr_loc c in
+            let loc = Loc.merge_opt loc0 loc1 in
+            IntroAction (IntroApplyOn ((loc1,c),(loc,pat))) in
+          Loc.tag ~loc:!@loc @@ List.fold_right f l pat ] ]
+  ;
+  simple_intropattern_closed:
+    [ [ pat = or_and_intropattern   -> Loc.tag ~loc:!@loc @@ IntroAction (IntroOrAndPattern pat)
+      | "'"; pat = pattern -> Loc.tag ~loc:!@loc @@ IntroAction (IntroIrrefutablePattern pat)
+      | pat = equality_intropattern -> Loc.tag ~loc:!@loc @@ IntroAction pat
+      | "_" -> Loc.tag ~loc:!@loc @@ IntroAction IntroWildcard 
+      | pat = naming_intropattern -> Loc.tag ~loc:!@loc @@ IntroNaming pat ] ]
+  ;
+  simple_binding:
+    [ [ "("; id = ident; ":="; c = lconstr; ")" -> Loc.tag ~loc:!@loc (NamedHyp id, c)
+      | "("; n = natural; ":="; c = lconstr; ")" -> Loc.tag ~loc:!@loc (AnonHyp n, c) ] ]
+  ;
+  bindings:
+    [ [ test_lpar_idnum_coloneq; bl = LIST1 simple_binding ->
+          ExplicitBindings bl
+      | bl = LIST1 constr -> ImplicitBindings bl ] ]
+  ;
+  constr_with_bindings:
+    [ [ c = constr; l = with_bindings -> (c, l) ] ]
+  ;
+  with_bindings:
+    [ [ "with"; bl = bindings -> bl | -> NoBindings ] ]
+  ;
+  red_flags:
+    [ [ IDENT "beta" -> [FBeta]
+      | IDENT "iota" -> [FMatch;FFix;FCofix]
+      | IDENT "match" -> [FMatch]
+      | IDENT "fix" -> [FFix]
+      | IDENT "cofix" -> [FCofix]
+      | IDENT "zeta" -> [FZeta]
+      | IDENT "delta"; d = delta_flag -> [d]
+    ] ]
+  ;
+  delta_flag:
+    [ [ "-"; "["; idl = LIST1 smart_global; "]" -> FDeltaBut idl
+      | "["; idl = LIST1 smart_global; "]" -> FConst idl
+      | -> FDeltaBut []
+    ] ]
+  ;
+  strategy_flag:
+    [ [ s = LIST1 red_flags -> Redops.make_red_flag (List.flatten s)
+      | d = delta_flag -> all_with d
+    ] ]
+  ;
+  red_expr:
+    [ [ IDENT "red" -> Red false
+      | IDENT "hnf" -> Hnf
+      | IDENT "simpl"; d = delta_flag; po = OPT ref_or_pattern_occ -> Simpl (all_with d,po)
+      | IDENT "cbv"; s = strategy_flag -> Cbv s
+      | IDENT "cbn"; s = strategy_flag -> Cbn s
+      | IDENT "lazy"; s = strategy_flag -> Lazy s
+      | IDENT "compute"; delta = delta_flag -> Cbv (all_with delta)
+      | IDENT "vm_compute"; po = OPT ref_or_pattern_occ -> CbvVm po
+      | IDENT "native_compute"; po = OPT ref_or_pattern_occ -> CbvNative po
+      | IDENT "unfold"; ul = LIST1 unfold_occ SEP "," -> Unfold ul
+      | IDENT "fold"; cl = LIST1 constr -> Fold cl
+      | IDENT "pattern"; pl = LIST1 pattern_occ SEP"," -> Pattern pl
+      | s = IDENT -> ExtraRedExpr s ] ]
+  ;
+  hypident:
+    [ [ id = id_or_meta ->
+          id,InHyp
+      | "("; IDENT "type"; IDENT "of"; id = id_or_meta; ")" ->
+	  id,InHypTypeOnly
+      | "("; IDENT "value"; IDENT "of"; id = id_or_meta; ")" ->
+	  id,InHypValueOnly
+    ] ]
+  ;
+  hypident_occ:
+    [ [ (id,l)=hypident; occs=occs -> ((occs,id),l) ] ]
+  ;
+  in_clause:
+    [ [ "*"; occs=occs ->
+          {onhyps=None; concl_occs=occs}
+      | "*"; "|-"; occs=concl_occ ->
+          {onhyps=None; concl_occs=occs}
+      | hl=LIST0 hypident_occ SEP","; "|-"; occs=concl_occ ->
+          {onhyps=Some hl; concl_occs=occs}
+      | hl=LIST0 hypident_occ SEP"," ->
+          {onhyps=Some hl; concl_occs=NoOccurrences} ] ]
+  ;
+  clause_dft_concl:
+    [ [ "in"; cl = in_clause -> cl
+      | occs=occs -> {onhyps=Some[]; concl_occs=occs}
+      | -> all_concl_occs_clause ] ]
+  ;
+  clause_dft_all:
+    [ [ "in"; cl = in_clause -> cl
+      | -> {onhyps=None; concl_occs=AllOccurrences} ] ]
+  ;
+  opt_clause:
+    [ [ "in"; cl = in_clause -> Some cl
+      | "at"; occs = occs_nums -> Some {onhyps=Some[]; concl_occs=occs}
+      | -> None ] ]
+  ;
+  concl_occ:
+    [ [ "*"; occs = occs -> occs
+      | -> NoOccurrences ] ]
+  ;
+  in_hyp_list:
+    [ [ "in"; idl = LIST1 id_or_meta -> idl
+      | -> [] ] ]
+  ;
+  in_hyp_as:
+    [ [ "in"; id = id_or_meta; ipat = as_ipat -> Some (id,ipat)
+      | -> None ] ]
+  ;
+  orient:
+    [ [ "->" -> true
+      | "<-" -> false
+      | -> true ]]
+  ;
+  simple_binder:
+    [ [ na=name -> ([na],Default Explicit, CAst.make ~loc:!@loc @@ CHole (Some (Evar_kinds.BinderType (snd na)), IntroAnonymous, None))
+      | "("; nal=LIST1 name; ":"; c=lconstr; ")" -> (nal,Default Explicit,c)
+    ] ]
+  ;
+  fixdecl:
+    [ [ "("; id = ident; bl=LIST0 simple_binder; ann=fixannot;
+        ":"; ty=lconstr; ")" -> (!@loc, id, bl, ann, ty) ] ]
+  ;
+  fixannot:
+    [ [ "{"; IDENT "struct"; id=name; "}" -> Some id
+      | -> None ] ]
+  ;
+  cofixdecl:
+    [ [ "("; id = ident; bl=LIST0 simple_binder; ":"; ty=lconstr; ")" ->
+        (!@loc, id, bl, None, ty) ] ]
+  ;
+  bindings_with_parameters:
+    [ [ check_for_coloneq; "(";  id = ident; bl = LIST0 simple_binder;
+        ":="; c = lconstr; ")" -> (id, mkCLambdaN_simple bl c) ] ]
+  ;
+  eliminator:
+    [ [ "using"; el = constr_with_bindings -> el ] ]
+  ;
+  as_ipat:
+    [ [ "as"; ipat = simple_intropattern -> Some ipat
+      | -> None ] ]
+  ;
+  or_and_intropattern_loc:
+    [ [ ipat = or_and_intropattern -> ArgArg (Loc.tag ~loc:!@loc ipat)
+      | locid = identref -> ArgVar locid ] ]
+  ;
+  as_or_and_ipat:
+    [ [ "as"; ipat = or_and_intropattern_loc -> Some ipat
+      | -> None ] ]
+  ;
+  eqn_ipat:
+    [ [ IDENT "eqn"; ":"; pat = naming_intropattern -> Some (Loc.tag ~loc:!@loc pat)
+      | IDENT "_eqn"; ":"; pat = naming_intropattern ->
+         let loc = !@loc in
+	 warn_deprecated_eqn_syntax ~loc "H"; Some (Loc.tag ~loc pat)
+      | IDENT "_eqn" ->
+         let loc = !@loc in
+	 warn_deprecated_eqn_syntax ~loc "?"; Some (Loc.tag ~loc IntroAnonymous)
+      | -> None ] ]
+  ;
+  as_name:
+    [ [ "as"; id = ident ->Names.Name.Name id | -> Names.Name.Anonymous ] ]
+  ;
+  by_tactic:
+    [ [ "by"; tac = tactic_expr LEVEL "3" -> Some tac
+    | -> None ] ]
+  ;
+  rewriter :
+    [ [ "!"; c = constr_with_bindings_arg -> (RepeatPlus,c)
+      | ["?"| LEFTQMARK]; c = constr_with_bindings_arg -> (RepeatStar,c)
+      | n = natural; "!"; c = constr_with_bindings_arg -> (Precisely n,c)
+      |	n = natural; ["?" | LEFTQMARK]; c = constr_with_bindings_arg -> (UpTo n,c)
+      | n = natural; c = constr_with_bindings_arg -> (Precisely n,c)
+      | c = constr_with_bindings_arg -> (Precisely 1, c)
+      ] ]
+  ;
+  oriented_rewriter :
+    [ [ b = orient; p = rewriter -> let (m,c) = p in (b,m,c) ] ]
+  ;
+  induction_clause:
+    [ [ c = destruction_arg; pat = as_or_and_ipat; eq = eqn_ipat;
+        cl = opt_clause -> (c,(eq,pat),cl) ] ]
+  ;
+  induction_clause_list:
+    [ [ ic = LIST1 induction_clause SEP ","; el = OPT eliminator;
+        cl_tolerance = opt_clause ->
+        (* Condition for accepting "in" at the end by compatibility *)
+        match ic,el,cl_tolerance with
+        | [c,pat,None],Some _,Some _ -> ([c,pat,cl_tolerance],el)
+        | _,_,Some _ -> err ()
+        | _,_,None -> (ic,el) ]]
+  ;
+  simple_tactic:
+    [ [
+      (* Basic tactics *)
+        IDENT "intros"; pl = ne_intropatterns ->
+          TacAtom (Loc.tag ~loc:!@loc @@ TacIntroPattern (false,pl))
+      | IDENT "intros" ->
+          TacAtom (Loc.tag ~loc:!@loc @@ TacIntroPattern (false,[Loc.tag ~loc:!@loc @@IntroForthcoming false]))
+      | IDENT "eintros"; pl = ne_intropatterns ->
+          TacAtom (Loc.tag ~loc:!@loc @@ TacIntroPattern (true,pl))
+
+      | IDENT "apply"; cl = LIST1 constr_with_bindings_arg SEP ",";
+          inhyp = in_hyp_as -> TacAtom (Loc.tag ~loc:!@loc @@ TacApply (true,false,cl,inhyp))
+      | IDENT "eapply"; cl = LIST1 constr_with_bindings_arg SEP ",";
+          inhyp = in_hyp_as -> TacAtom (Loc.tag ~loc:!@loc @@ TacApply (true,true,cl,inhyp))
+      | IDENT "simple"; IDENT "apply";
+          cl = LIST1 constr_with_bindings_arg SEP ",";
+          inhyp = in_hyp_as -> TacAtom (Loc.tag ~loc:!@loc @@ TacApply (false,false,cl,inhyp))
+      | IDENT "simple"; IDENT "eapply";
+          cl = LIST1 constr_with_bindings_arg SEP",";
+          inhyp = in_hyp_as -> TacAtom (Loc.tag ~loc:!@loc @@ TacApply (false,true,cl,inhyp))
+      | IDENT "elim"; cl = constr_with_bindings_arg; el = OPT eliminator ->
+          TacAtom (Loc.tag ~loc:!@loc @@ TacElim (false,cl,el))
+      | IDENT "eelim"; cl = constr_with_bindings_arg; el = OPT eliminator ->
+          TacAtom (Loc.tag ~loc:!@loc @@ TacElim (true,cl,el))
+      | IDENT "case"; icl = induction_clause_list -> TacAtom (Loc.tag ~loc:!@loc @@ mkTacCase false icl)
+      | IDENT "ecase"; icl = induction_clause_list -> TacAtom (Loc.tag ~loc:!@loc @@ mkTacCase true icl)
+      | "fix"; id = ident; n = natural; "with"; fd = LIST1 fixdecl ->
+	  TacAtom (Loc.tag ~loc:!@loc @@ TacMutualFix (id,n,List.map mk_fix_tac fd))
+      | "cofix"; id = ident; "with"; fd = LIST1 cofixdecl ->
+	  TacAtom (Loc.tag ~loc:!@loc @@ TacMutualCofix (id,List.map mk_cofix_tac fd))
+
+      | IDENT "pose"; (id,b) = bindings_with_parameters ->
+	  TacAtom (Loc.tag ~loc:!@loc @@ TacLetTac (false,Names.Name.Name id,b,Locusops.nowhere,true,None))
+      | IDENT "pose"; b = constr; na = as_name ->
+	  TacAtom (Loc.tag ~loc:!@loc @@ TacLetTac (false,na,b,Locusops.nowhere,true,None))
+      | IDENT "epose"; (id,b) = bindings_with_parameters ->
+	  TacAtom (Loc.tag ~loc:!@loc @@ TacLetTac (true,Names.Name id,b,Locusops.nowhere,true,None))
+      | IDENT "epose"; b = constr; na = as_name ->
+	  TacAtom (Loc.tag ~loc:!@loc @@ TacLetTac (true,na,b,Locusops.nowhere,true,None))
+      | IDENT "set"; (id,c) = bindings_with_parameters; p = clause_dft_concl ->
+	  TacAtom (Loc.tag ~loc:!@loc @@ TacLetTac (false,Names.Name.Name id,c,p,true,None))
+      | IDENT "set"; c = constr; na = as_name; p = clause_dft_concl ->
+          TacAtom (Loc.tag ~loc:!@loc @@ TacLetTac (false,na,c,p,true,None))
+      | IDENT "eset"; (id,c) = bindings_with_parameters; p = clause_dft_concl ->
+	  TacAtom (Loc.tag ~loc:!@loc @@ TacLetTac (true,Names.Name id,c,p,true,None))
+      | IDENT "eset"; c = constr; na = as_name; p = clause_dft_concl ->
+          TacAtom (Loc.tag ~loc:!@loc @@ TacLetTac (true,na,c,p,true,None))
+      | IDENT "remember"; c = constr; na = as_name; e = eqn_ipat;
+          p = clause_dft_all ->
+          TacAtom (Loc.tag ~loc:!@loc @@ TacLetTac (false,na,c,p,false,e))
+      | IDENT "eremember"; c = constr; na = as_name; e = eqn_ipat;
+          p = clause_dft_all ->
+          TacAtom (Loc.tag ~loc:!@loc @@ TacLetTac (true,na,c,p,false,e))
+
+      (* Alternative syntax for "pose proof c as id" *)
+      | IDENT "assert"; test_lpar_id_coloneq; "("; (loc,id) = identref; ":=";
+	  c = lconstr; ")" ->
+	  TacAtom (Loc.tag ~loc:!@loc @@ TacAssert (false,true,None,Some (Loc.tag ~loc:!@loc @@ IntroNaming (IntroIdentifier id)),c))
+      | IDENT "eassert"; test_lpar_id_coloneq; "("; (loc,id) = identref; ":=";
+	  c = lconstr; ")" ->
+	  TacAtom (Loc.tag ~loc:!@loc @@ TacAssert (true,true,None,Some (Loc.tag ~loc:!@loc @@ IntroNaming (IntroIdentifier id)),c))
+
+      (* Alternative syntax for "assert c as id by tac" *)
+      | IDENT "assert"; test_lpar_id_colon; "("; (loc,id) = identref; ":";
+	  c = lconstr; ")"; tac=by_tactic ->
+	  TacAtom (Loc.tag ~loc:!@loc @@ TacAssert (false,true,Some tac,Some (Loc.tag ~loc:!@loc @@ IntroNaming (IntroIdentifier id)),c))
+      | IDENT "eassert"; test_lpar_id_colon; "("; (loc,id) = identref; ":";
+	  c = lconstr; ")"; tac=by_tactic ->
+	  TacAtom (Loc.tag ~loc:!@loc @@ TacAssert (true,true,Some tac,Some (Loc.tag ~loc:!@loc @@ IntroNaming (IntroIdentifier id)),c))
+
+      (* Alternative syntax for "enough c as id by tac" *)
+      | IDENT "enough"; test_lpar_id_colon; "("; (loc,id) = identref; ":";
+	  c = lconstr; ")"; tac=by_tactic ->
+	  TacAtom (Loc.tag ~loc:!@loc @@ TacAssert (false,false,Some tac,Some (Loc.tag ~loc:!@loc @@ IntroNaming (IntroIdentifier id)),c))
+      | IDENT "eenough"; test_lpar_id_colon; "("; (loc,id) = identref; ":";
+	  c = lconstr; ")"; tac=by_tactic ->
+	  TacAtom (Loc.tag ~loc:!@loc @@ TacAssert (true,false,Some tac,Some (Loc.tag ~loc:!@loc @@ IntroNaming (IntroIdentifier id)),c))
+
+      | IDENT "assert"; c = constr; ipat = as_ipat; tac = by_tactic ->
+	  TacAtom (Loc.tag ~loc:!@loc @@ TacAssert (false,true,Some tac,ipat,c))
+      | IDENT "eassert"; c = constr; ipat = as_ipat; tac = by_tactic ->
+	  TacAtom (Loc.tag ~loc:!@loc @@ TacAssert (true,true,Some tac,ipat,c))
+      | IDENT "pose"; IDENT "proof"; c = lconstr; ipat = as_ipat ->
+	  TacAtom (Loc.tag ~loc:!@loc @@ TacAssert (false,true,None,ipat,c))
+      | IDENT "epose"; IDENT "proof"; c = lconstr; ipat = as_ipat ->
+	  TacAtom (Loc.tag ~loc:!@loc @@ TacAssert (true,true,None,ipat,c))
+      | IDENT "enough"; c = constr; ipat = as_ipat; tac = by_tactic ->
+	  TacAtom (Loc.tag ~loc:!@loc @@ TacAssert (false,false,Some tac,ipat,c))
+      | IDENT "eenough"; c = constr; ipat = as_ipat; tac = by_tactic ->
+	  TacAtom (Loc.tag ~loc:!@loc @@ TacAssert (true,false,Some tac,ipat,c))
+
+      | IDENT "generalize"; c = constr ->
+	  TacAtom (Loc.tag ~loc:!@loc @@ TacGeneralize [((AllOccurrences,c),Names.Name.Anonymous)])
+      | IDENT "generalize"; c = constr; l = LIST1 constr ->
+	  let gen_everywhere c = ((AllOccurrences,c),Names.Name.Anonymous) in
+          TacAtom (Loc.tag ~loc:!@loc @@ TacGeneralize (List.map gen_everywhere (c::l)))
+      | IDENT "generalize"; c = constr; lookup_at_as_comma; nl = occs;
+          na = as_name;
+          l = LIST0 [","; c = pattern_occ; na = as_name -> (c,na)] ->
+          TacAtom (Loc.tag ~loc:!@loc @@ TacGeneralize (((nl,c),na)::l))
+
+      (* Derived basic tactics *)
+      | IDENT "induction"; ic = induction_clause_list ->
+	  TacAtom (Loc.tag ~loc:!@loc @@ TacInductionDestruct (true,false,ic))
+      | IDENT "einduction"; ic = induction_clause_list ->
+	  TacAtom (Loc.tag ~loc:!@loc @@ TacInductionDestruct(true,true,ic))
+      | IDENT "destruct"; icl = induction_clause_list ->
+	  TacAtom (Loc.tag ~loc:!@loc @@ TacInductionDestruct(false,false,icl))
+      | IDENT "edestruct";  icl = induction_clause_list ->
+	  TacAtom (Loc.tag ~loc:!@loc @@ TacInductionDestruct(false,true,icl))
+
+      (* Equality and inversion *)
+      | IDENT "rewrite"; l = LIST1 oriented_rewriter SEP ",";
+	  cl = clause_dft_concl; t=by_tactic -> TacAtom (Loc.tag ~loc:!@loc @@ TacRewrite (false,l,cl,t))
+      | IDENT "erewrite"; l = LIST1 oriented_rewriter SEP ",";
+	  cl = clause_dft_concl; t=by_tactic -> TacAtom (Loc.tag ~loc:!@loc @@ TacRewrite (true,l,cl,t))
+      | IDENT "dependent"; k =
+	  [ IDENT "simple"; IDENT "inversion" -> SimpleInversion
+	  | IDENT "inversion" -> FullInversion
+	  | IDENT "inversion_clear" -> FullInversionClear ];
+	  hyp = quantified_hypothesis;
+	  ids = as_or_and_ipat; co = OPT ["with"; c = constr -> c] ->
+	    TacAtom (Loc.tag ~loc:!@loc @@ TacInversion (DepInversion (k,co,ids),hyp))
+      | IDENT "simple"; IDENT "inversion";
+	  hyp = quantified_hypothesis; ids = as_or_and_ipat;
+	  cl = in_hyp_list ->
+	    TacAtom (Loc.tag ~loc:!@loc @@ TacInversion (NonDepInversion (SimpleInversion, cl, ids), hyp))
+      | IDENT "inversion";
+	  hyp = quantified_hypothesis; ids = as_or_and_ipat;
+	  cl = in_hyp_list ->
+	    TacAtom (Loc.tag ~loc:!@loc @@ TacInversion (NonDepInversion (FullInversion, cl, ids), hyp))
+      | IDENT "inversion_clear";
+	  hyp = quantified_hypothesis; ids = as_or_and_ipat;
+	  cl = in_hyp_list ->
+	    TacAtom (Loc.tag ~loc:!@loc @@ TacInversion (NonDepInversion (FullInversionClear, cl, ids), hyp))
+      | IDENT "inversion"; hyp = quantified_hypothesis;
+	  "using"; c = constr; cl = in_hyp_list ->
+	    TacAtom (Loc.tag ~loc:!@loc @@ TacInversion (InversionUsing (c,cl), hyp))
+
+      (* Conversion *)
+      | IDENT "red"; cl = clause_dft_concl ->
+          TacAtom (Loc.tag ~loc:!@loc @@ TacReduce (Red false, cl))
+      | IDENT "hnf"; cl = clause_dft_concl ->
+          TacAtom (Loc.tag ~loc:!@loc @@ TacReduce (Hnf, cl))
+      | IDENT "simpl"; d = delta_flag; po = OPT ref_or_pattern_occ; cl = clause_dft_concl ->
+          TacAtom (Loc.tag ~loc:!@loc @@ TacReduce (Simpl (all_with d, po), cl))
+      | IDENT "cbv"; s = strategy_flag; cl = clause_dft_concl ->
+          TacAtom (Loc.tag ~loc:!@loc @@ TacReduce (Cbv s, cl))
+      | IDENT "cbn"; s = strategy_flag; cl = clause_dft_concl ->
+          TacAtom (Loc.tag ~loc:!@loc @@ TacReduce (Cbn s, cl))
+      | IDENT "lazy"; s = strategy_flag; cl = clause_dft_concl ->
+          TacAtom (Loc.tag ~loc:!@loc @@ TacReduce (Lazy s, cl))
+      | IDENT "compute"; delta = delta_flag; cl = clause_dft_concl ->
+          TacAtom (Loc.tag ~loc:!@loc @@ TacReduce (Cbv (all_with delta), cl))
+      | IDENT "vm_compute"; po = OPT ref_or_pattern_occ; cl = clause_dft_concl ->
+          TacAtom (Loc.tag ~loc:!@loc @@ TacReduce (CbvVm po, cl))
+      | IDENT "native_compute"; po = OPT ref_or_pattern_occ; cl = clause_dft_concl ->
+          TacAtom (Loc.tag ~loc:!@loc @@ TacReduce (CbvNative po, cl))
+      | IDENT "unfold"; ul = LIST1 unfold_occ SEP ","; cl = clause_dft_concl ->
+          TacAtom (Loc.tag ~loc:!@loc @@ TacReduce (Unfold ul, cl))
+      | IDENT "fold"; l = LIST1 constr; cl = clause_dft_concl ->
+          TacAtom (Loc.tag ~loc:!@loc @@ TacReduce (Fold l, cl))
+      | IDENT "pattern"; pl = LIST1 pattern_occ SEP","; cl = clause_dft_concl ->
+          TacAtom (Loc.tag ~loc:!@loc @@ TacReduce (Pattern pl, cl))
+
+      (* Change ne doit pas s'appliquer dans un Definition t := Eval ... *)
+      | IDENT "change"; (oc,c) = conversion; cl = clause_dft_concl ->
+	  let p,cl = merge_occurrences (!@loc) cl oc in
+	  TacAtom (Loc.tag ~loc:!@loc @@ TacChange (p,c,cl))
+    ] ]
+  ;
+END;;

--- a/plugins/ltac/pltac.mli
+++ b/plugins/ltac/pltac.mli
@@ -29,7 +29,7 @@ val destruction_arg : constr_expr with_bindings Tactics.destruction_arg Entry.t
 val int_or_var : int Locus.or_var Entry.t
 val nat_or_var : int Locus.or_var Entry.t
 val simple_tactic : raw_tactic_expr Entry.t
-val simple_intropattern : constr_expr intro_pattern_expr CAst.t Entry.t
+val simple_intropattern : (constr_expr,cases_pattern_expr) intro_pattern_expr CAst.t Entry.t
 val in_clause : Names.lident Locus.clause_expr Entry.t
 val clause_dft_concl : Names.lident Locus.clause_expr Entry.t
 val tactic_value : raw_tactic_arg Entry.t

--- a/plugins/ltac/tacarg.mli
+++ b/plugins/ltac/tacarg.mli
@@ -17,12 +17,12 @@ open Tacexpr
 
 (** Tactic related witnesses, could also live in tactics/ if other users *)
 (* To keep after deprecation phase but it will get a different parsing semantics in pltac.ml *)
-val wit_intropattern : (constr_expr intro_pattern_expr CAst.t, glob_constr_and_expr intro_pattern_expr CAst.t, intro_pattern) genarg_type
+val wit_intropattern : ((constr_expr,cases_pattern_expr) intro_pattern_expr CAst.t, (glob_constr_and_expr,glob_cases_pattern) intro_pattern_expr CAst.t, intro_pattern) genarg_type
 [@@ocaml.deprecated "Use wit_simple_intropattern"]
 
-val wit_simple_intropattern : (constr_expr intro_pattern_expr CAst.t, glob_constr_and_expr intro_pattern_expr CAst.t, intro_pattern) genarg_type
+val wit_simple_intropattern : ((constr_expr,cases_pattern_expr) intro_pattern_expr CAst.t, (glob_constr_and_expr,glob_cases_pattern) intro_pattern_expr CAst.t, intro_pattern) genarg_type
 
-val wit_intro_pattern : (constr_expr intro_pattern_expr CAst.t, glob_constr_and_expr intro_pattern_expr CAst.t, intro_pattern) genarg_type
+val wit_intro_pattern : ((constr_expr,cases_pattern_expr) intro_pattern_expr CAst.t, (glob_constr_and_expr,glob_cases_pattern) intro_pattern_expr CAst.t, intro_pattern) genarg_type
 
 val wit_quant_hyp : quantified_hypothesis uniform_genarg_type
 

--- a/plugins/ltac/taccoerce.mli
+++ b/plugins/ltac/taccoerce.mli
@@ -55,7 +55,7 @@ val coerce_var_to_ident : bool -> Environ.env -> Evd.evar_map -> Value.t -> Id.t
 
 val coerce_to_ident_not_fresh : Evd.evar_map -> Value.t -> Id.t
 
-val coerce_to_intro_pattern : Evd.evar_map -> Value.t -> delayed_open_constr intro_pattern_expr
+val coerce_to_intro_pattern : Evd.evar_map -> Value.t -> (Tactypes.delayed_open_constr,Tactypes.glob_cases_pattern) intro_pattern_expr
 
 val coerce_to_intro_pattern_naming :
   Evd.evar_map -> Value.t -> Namegen.intro_pattern_naming_expr

--- a/plugins/ltac/tacexpr.ml
+++ b/plugins/ltac/tacexpr.ml
@@ -36,11 +36,11 @@ type letin_flag = bool     (* true = use local def    false = use Leibniz *)
 type clear_flag = bool option (* true = clear hyp, false = keep hyp, None = use default *)
 type check_flag = bool     (* true = check    false = do not check *)
 
-type ('c,'d,'id) inversion_strength =
+type ('c,'d,'e,'id) inversion_strength =
   | NonDepInversion of
-      Inv.inversion_kind * 'id list * 'd or_and_intro_pattern_expr CAst.t or_var option
+      Inv.inversion_kind * 'id list * ('d,'e) or_and_intro_pattern_expr CAst.t or_var option
   | DepInversion of
-      Inv.inversion_kind * 'c option * 'd or_and_intro_pattern_expr CAst.t or_var option
+      Inv.inversion_kind * 'c option * ('d,'e) or_and_intro_pattern_expr CAst.t or_var option
   | InversionUsing of 'c * 'id list
 
 type ('a,'b) location = HypLocation of 'a | ConclLocation of 'b
@@ -50,14 +50,14 @@ type 'id message_token =
   | MsgInt of int
   | MsgIdent of 'id
 
-type ('dconstr,'id) induction_clause =
+type ('dconstr,'dpattern,'id) induction_clause =
     'dconstr with_bindings Tactics.destruction_arg *
     (Namegen.intro_pattern_naming_expr CAst.t option (* eqn:... *)
-    * 'dconstr or_and_intro_pattern_expr CAst.t or_var option) (* as ... *)
+    * ('dconstr,'dpattern) or_and_intro_pattern_expr CAst.t or_var option) (* as ... *)
     * 'id clause_expr option (* in ... *)
 
-type ('constr,'dconstr,'id) induction_clause_list =
-    ('dconstr,'id) induction_clause list
+type ('constr,'dconstr,'dpattern,'id) induction_clause_list =
+    ('dconstr,'dpattern,'id) induction_clause list
     * 'constr with_bindings option (* using ... *)
 
 type 'a with_bindings_arg = clear_flag * 'a with_bindings
@@ -97,32 +97,32 @@ type ml_tactic_entry = {
 type open_constr_expr = unit * constr_expr
 type open_glob_constr = unit * Genintern.glob_constr_and_expr
 
-type intro_pattern = delayed_open_constr intro_pattern_expr CAst.t
-type intro_patterns = delayed_open_constr intro_pattern_expr CAst.t list
-type or_and_intro_pattern = delayed_open_constr or_and_intro_pattern_expr CAst.t
+type intro_pattern = (delayed_open_constr,Tactypes.glob_cases_pattern) intro_pattern_expr CAst.t
+type intro_patterns = (delayed_open_constr,Tactypes.glob_cases_pattern) intro_pattern_expr CAst.t list
+type or_and_intro_pattern = (delayed_open_constr,Tactypes.glob_cases_pattern) or_and_intro_pattern_expr CAst.t
 type intro_pattern_naming = Namegen.intro_pattern_naming_expr CAst.t
 
 (** Generic expressions for atomic tactics *)
 
 type 'a gen_atomic_tactic_expr =
   (* Basic tactics *)
-  | TacIntroPattern of evars_flag * 'dtrm intro_pattern_expr CAst.t list
+  | TacIntroPattern of evars_flag * ('dtrm,'dpat) intro_pattern_expr CAst.t list
   | TacApply of advanced_flag * evars_flag * 'trm with_bindings_arg list *
-      ('nam * 'dtrm intro_pattern_expr CAst.t option) list
+      ('nam * ('dtrm,'dpat) intro_pattern_expr CAst.t option) list
   | TacElim of evars_flag * 'trm with_bindings_arg * 'trm with_bindings option
   | TacCase of evars_flag * 'trm with_bindings_arg
   | TacMutualFix of Id.t * int * (Id.t * int * 'trm) list
   | TacMutualCofix of Id.t * (Id.t * 'trm) list
   | TacAssert of
       evars_flag * bool * 'tacexpr option option *
-      'dtrm intro_pattern_expr CAst.t option * 'trm
+      ('dtrm,'dpat) intro_pattern_expr CAst.t option * 'trm
   | TacGeneralize of ('trm with_occurrences * Name.t) list
   | TacLetTac of evars_flag * Name.t * 'trm * 'nam clause_expr * letin_flag *
       Namegen.intro_pattern_naming_expr CAst.t option
 
   (* Derived basic tactics *)
   | TacInductionDestruct of
-      rec_flag * evars_flag * ('trm,'dtrm,'nam) induction_clause_list
+      rec_flag * evars_flag * ('trm,'dtrm,'dpat,'nam) induction_clause_list
 
   (* Conversion *)
   | TacReduce of ('trm,'cst,'pat) red_expr_gen * 'nam clause_expr
@@ -138,12 +138,13 @@ type 'a gen_atomic_tactic_expr =
          uninterpreted, it works fine here too, and avoid more
          disruption of this file. *)
       'tacexpr option
-  | TacInversion of ('trm,'dtrm,'nam) inversion_strength * quantified_hypothesis
+  | TacInversion of ('trm,'dtrm,'dpat,'nam) inversion_strength * quantified_hypothesis
 
 constraint 'a = <
     term:'trm;
     dterm: 'dtrm;
     pattern:'pat;
+    dpattern:'dpat;
     constant:'cst;
     reference:'ref;
     name:'nam;
@@ -167,6 +168,7 @@ constraint 'a = <
     term:'trm;
     dterm: 'dtrm;
     pattern:'pat;
+    dpattern:'dpat;
     constant:'cst;
     reference:'ref;
     name:'nam;
@@ -244,6 +246,7 @@ constraint 'a = <
     term:'t;
     dterm: 'dtrm;
     pattern:'p;
+    dpattern:'dpat;
     constant:'c;
     reference:'r;
     name:'n;
@@ -257,6 +260,7 @@ constraint 'a = <
     term:'t;
     dterm: 'dtrm;
     pattern:'p;
+    dpattern:'dpat;
     constant:'c;
     reference:'r;
     name:'n;
@@ -271,6 +275,7 @@ constraint 'a = <
     term:'t;
     dterm: 'dtrm;
     pattern:'p;
+    dpattern:'dpat;
     constant:'c;
     reference:'r;
     name:'n;
@@ -282,6 +287,7 @@ constraint 'a = <
 
 type g_trm = Genintern.glob_constr_and_expr
 type g_pat = Genintern.glob_constr_pattern_and_expr
+type g_dpat = Tactypes.glob_cases_pattern
 type g_cst = Tacred.evaluable_global_reference Genredexpr.and_short_name or_var
 type g_ref = ltac_constant located or_var
 type g_nam = lident
@@ -290,6 +296,7 @@ type g_dispatch =  <
     term:g_trm;
     dterm:g_trm;
     pattern:g_pat;
+    dpattern:g_dpat;
     constant:g_cst;
     reference:g_ref;
     name:g_nam;
@@ -308,6 +315,7 @@ type glob_tactic_arg =
 
 (** Raw tactics *)
 
+type r_dpat = Constrexpr.cases_pattern_expr
 type r_ref = qualid
 type r_nam = lident
 type r_lev = rlevel
@@ -316,6 +324,7 @@ type r_dispatch =  <
     term:r_trm;
     dterm:r_trm;
     pattern:r_pat;
+    dpattern:r_dpat;
     constant:r_cst;
     reference:r_ref;
     name:r_nam;
@@ -344,6 +353,7 @@ type t_dispatch =  <
     term:t_trm;
     dterm:g_trm;
     pattern:t_pat;
+    dpattern:g_dpat;
     constant:t_cst;
     reference:t_ref;
     name:t_nam;

--- a/plugins/ltac/tacintern.ml
+++ b/plugins/ltac/tacintern.ml
@@ -267,6 +267,8 @@ and intern_intro_pattern_action lf ist = function
     IntroOrAndPattern (intern_or_and_intro_pattern lf ist l)
   | IntroInjection l ->
     IntroInjection (List.map (intern_intro_pattern lf ist) l)
+  | IntroIrrefutablePattern pat ->
+     IntroIrrefutablePattern (Constrintern.intern_cases_pattern ist.genv pat)
   | IntroWildcard | IntroRewrite _ as x -> x
   | IntroApplyOn ({loc;v=c},pat) ->
     IntroApplyOn (make ?loc @@ intern_constr ist c, intern_intro_pattern lf ist pat)

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -503,6 +503,7 @@ let rec intropattern_ids accu {loc;v=pat} = match pat with
       List.fold_left intropattern_ids accu (List.flatten ll)
   | IntroAction (IntroInjection l) ->
       List.fold_left intropattern_ids accu l
+  | IntroAction (IntroIrrefutablePattern (ids,pat)) -> List.fold_right (fun CAst.{v} ids -> Id.Set.add v ids) ids Id.Set.empty
   | IntroAction (IntroApplyOn ({v=c},pat)) -> intropattern_ids accu pat
   | IntroNaming (IntroAnonymous | IntroFresh _)
   | IntroAction (IntroWildcard | IntroRewrite _)
@@ -870,6 +871,8 @@ and interp_intro_pattern_action ist env sigma = function
   | IntroInjection l ->
       let l = interp_intro_pattern_list_as_list ist env sigma l in
       IntroInjection l
+  | IntroIrrefutablePattern pat ->
+      IntroIrrefutablePattern pat
   | IntroApplyOn ({loc;v=c},ipat) ->
       let c env sigma = interp_open_constr ist env sigma c in
       let ipat = interp_intro_pattern ist env sigma ipat in

--- a/plugins/ltac/tacinterp.mli
+++ b/plugins/ltac/tacinterp.mli
@@ -148,7 +148,7 @@ val interp_int_or_var : interp_sign -> int Locus.or_var -> int
 val interp_ident : interp_sign -> Environ.env -> Evd.evar_map -> Id.t -> Id.t
 
 val interp_intro_pattern : interp_sign -> Environ.env -> Evd.evar_map ->
-  glob_constr_and_expr intro_pattern_expr CAst.t -> intro_pattern
+  (glob_constr_and_expr,Tactypes.glob_cases_pattern) intro_pattern_expr CAst.t -> intro_pattern
 
 val default_ist : unit -> Geninterp.interp_sign
 (** Empty ist with debug set on the current value. *)

--- a/plugins/ltac/tacsubst.ml
+++ b/plugins/ltac/tacsubst.ml
@@ -59,6 +59,7 @@ and subst_intro_pattern_action subst = let open CAst in function
   | IntroOrAndPattern l ->
       IntroOrAndPattern (subst_intro_or_and_pattern subst l)
   | IntroInjection l -> IntroInjection (List.map (subst_intro_pattern subst) l)
+  | IntroIrrefutablePattern pat -> IntroIrrefutablePattern pat
   | IntroWildcard | IntroRewrite _ as x -> x
 
 and subst_intro_or_and_pattern subst = function

--- a/plugins/ssr/ssrparser.ml4
+++ b/plugins/ssr/ssrparser.ml4
@@ -1,0 +1,2353 @@
+(************************************************************************)
+(*  v      *   The Coq Proof Assistant  /  The Coq Development Team     *)
+(* <O___,, *   INRIA - CNRS - LIX - LRI - PPS - Copyright 1999-2017     *)
+(*   \VV/  **************************************************************)
+(*    //   *      This file is distributed under the terms of the       *)
+(*         *       GNU Lesser General Public License Version 2.1        *)
+(************************************************************************)
+
+(* This file is (C) Copyright 2006-2015 Microsoft Corporation and Inria. *)
+
+open Names
+open Pp
+open Pcoq
+open Ltac_plugin
+open Genarg
+open Stdarg
+open Tacarg
+open Term
+open Libnames
+open Tactics
+open Tacticals
+open Tacmach
+open Glob_term
+open Util
+open Tacexpr
+open Tacinterp
+open Pltac
+open Extraargs
+open Ppconstr
+open Printer
+
+open Misctypes
+open Decl_kinds
+open Constrexpr
+open Constrexpr_ops
+
+open Ssrprinters
+open Ssrcommon
+open Ssrtacticals
+open Ssrbwd
+open Ssrequality
+open Ssrelim
+
+(** Ssreflect load check. *)
+
+(* To allow ssrcoq to be fully compatible with the "plain" Coq, we only *)
+(* turn on its incompatible features (the new rewrite syntax, and the   *)
+(* reserved identifiers) when the theory library (ssreflect.v) has      *)
+(* has actually been required, or is being defined. Because this check  *)
+(* needs to be done often (for each identifier lookup), we implement    *)
+(* some caching, repeating the test only when the environment changes.  *)
+(*   We check for protect_term because it is the first constant loaded; *)
+(* ssr_have would ultimately be a better choice.                        *)
+let ssr_loaded = Summary.ref ~name:"SSR:loaded" false
+let is_ssr_loaded () =
+  !ssr_loaded ||
+  (if CLexer.is_keyword "SsrSyntax_is_Imported" then ssr_loaded:=true;
+   !ssr_loaded)
+
+DECLARE PLUGIN "ssreflect_plugin"
+(* Defining grammar rules with "xx" in it automatically declares keywords too,
+ * we thus save the lexer to restore it at the end of the file *)
+let frozen_lexer = CLexer.get_keyword_state () ;;
+
+let tacltop = (5,Ppextend.E)
+
+let pr_ssrtacarg _ _ prt = prt tacltop
+ARGUMENT EXTEND ssrtacarg TYPED AS tactic PRINTED BY pr_ssrtacarg
+| [ "YouShouldNotTypeThis" ] -> [ CErrors.anomaly (Pp.str "Grammar placeholder match") ]
+END
+GEXTEND Gram
+  GLOBAL: ssrtacarg;
+  ssrtacarg: [[ tac = tactic_expr LEVEL "5" -> tac ]];
+END
+
+(* Lexically closed tactic for tacticals. *)
+let pr_ssrtclarg _ _ prt tac = prt tacltop tac
+ARGUMENT EXTEND ssrtclarg TYPED AS ssrtacarg
+    PRINTED BY pr_ssrtclarg
+| [ ssrtacarg(tac) ] -> [ tac ]
+END
+
+open Genarg
+
+(** Adding a new uninterpreted generic argument type *)
+let add_genarg tag pr =
+  let wit = Genarg.make0 tag in
+  let tag = Geninterp.Val.create tag in
+  let glob ist x = (ist, x) in
+  let subst _ x = x in
+  let interp ist x = Ftactic.return (Geninterp.Val.Dyn (tag, x)) in
+  let gen_pr _ _ _ = pr in
+  let () = Genintern.register_intern0 wit glob in
+  let () = Genintern.register_subst0 wit subst in
+  let () = Geninterp.register_interp0 wit interp in
+  let () = Geninterp.register_val0 wit (Some (Geninterp.Val.Base tag)) in
+  Pptactic.declare_extra_genarg_pprule wit gen_pr gen_pr gen_pr;
+  wit
+
+(** Primitive parsing to avoid syntax conflicts with basic tactics. *)
+
+let accept_before_syms syms strm =
+  match Util.stream_nth 1 strm with
+  | Tok.KEYWORD sym when List.mem sym syms -> ()
+  | _ -> raise Stream.Failure
+
+let accept_before_syms_or_any_id syms strm =
+  match Util.stream_nth 1 strm with
+  | Tok.KEYWORD sym when List.mem sym syms -> ()
+  | Tok.IDENT _ -> ()
+  | _ -> raise Stream.Failure
+
+let accept_before_syms_or_ids syms ids strm =
+  match Util.stream_nth 1 strm with
+  | Tok.KEYWORD sym when List.mem sym syms -> ()
+  | Tok.IDENT id when List.mem id ids -> ()
+  | _ -> raise Stream.Failure
+
+open Ssrast
+let pr_id = Ppconstr.pr_id
+let pr_name = function Name id -> pr_id id | Anonymous -> str "_"
+let pr_spc () = str " "
+let pr_bar () = Pp.cut() ++ str "|"
+let pr_list = prlist_with_sep
+
+(**************************** ssrhyp **************************************) 
+
+let pr_ssrhyp _ _ _ = pr_hyp
+
+let wit_ssrhyprep = add_genarg "ssrhyprep" pr_hyp
+
+let intern_hyp ist (SsrHyp (loc, id) as hyp) =
+  let _ = Tacintern.intern_genarg ist (in_gen (rawwit wit_var) (loc, id)) in
+  if not_section_id id then hyp else
+  hyp_err ?loc "Can't clear section hypothesis " id
+
+open Pcoq.Prim
+
+ARGUMENT EXTEND ssrhyp TYPED AS ssrhyprep PRINTED BY pr_ssrhyp
+                       INTERPRETED BY interp_hyp
+                       GLOBALIZED BY intern_hyp
+  | [ ident(id) ] -> [ SsrHyp (Loc.tag ~loc id) ]
+END
+
+
+let pr_hoi = hoik pr_hyp
+let pr_ssrhoi _ _ _ = pr_hoi
+
+let wit_ssrhoirep = add_genarg "ssrhoirep" pr_hoi
+
+let intern_ssrhoi ist = function
+  | Hyp h -> Hyp (intern_hyp ist h)
+  | Id (SsrHyp (_, id)) as hyp ->
+    let _ = Tacintern.intern_genarg ist (in_gen (rawwit wit_ident) id) in
+    hyp
+
+let interp_ssrhoi ist gl = function
+  | Hyp h -> let s, h' = interp_hyp ist gl h in s, Hyp h'
+  | Id (SsrHyp (loc, id)) ->
+    let s, id' = interp_wit wit_ident ist gl id in
+    s, Id (SsrHyp (loc, id'))
+
+ARGUMENT EXTEND ssrhoi_hyp TYPED AS ssrhoirep PRINTED BY pr_ssrhoi
+                       INTERPRETED BY interp_ssrhoi
+                       GLOBALIZED BY intern_ssrhoi
+  | [ ident(id) ] -> [ Hyp (SsrHyp(Loc.tag ~loc id)) ]
+END
+ARGUMENT EXTEND ssrhoi_id TYPED AS ssrhoirep PRINTED BY pr_ssrhoi
+                       INTERPRETED BY interp_ssrhoi
+                       GLOBALIZED BY intern_ssrhoi
+  | [ ident(id) ] -> [ Id (SsrHyp(Loc.tag ~loc id)) ]
+END
+
+
+let pr_hyps = pr_list pr_spc pr_hyp
+let pr_ssrhyps _ _ _ = pr_hyps
+
+ARGUMENT EXTEND ssrhyps TYPED AS ssrhyp list PRINTED BY pr_ssrhyps
+                        INTERPRETED BY interp_hyps
+  | [ ssrhyp_list(hyps) ] -> [ check_hyps_uniq [] hyps; hyps ]
+END
+
+(** Rewriting direction *)
+
+
+let pr_dir = function L2R -> str "->" | R2L -> str "<-"
+let pr_rwdir = function L2R -> mt() | R2L -> str "-"
+
+let wit_ssrdir = add_genarg "ssrdir" pr_dir
+
+(** Simpl switch *)
+
+
+let pr_simpl = function
+  | Simpl -1 -> str "/="
+  | Cut -1 -> str "//"
+  | Simpl n -> str "/" ++ int n ++ str "="
+  | Cut n -> str "/" ++ int n ++ str"/"
+  | SimplCut (-1,-1) -> str "//="
+  | SimplCut (n,-1) -> str "/" ++ int n ++ str "/="
+  | SimplCut (-1,n) -> str "//" ++ int n ++ str "="
+  | SimplCut (n,m) -> str "/" ++ int n ++ str "/" ++ int m ++ str "="
+  | Nop -> mt ()
+
+let pr_ssrsimpl _ _ _ = pr_simpl
+
+let wit_ssrsimplrep = add_genarg "ssrsimplrep" pr_simpl
+
+let test_ssrslashnum b1 b2 strm =
+  match Util.stream_nth 0 strm with
+  | Tok.KEYWORD "/" ->
+      (match Util.stream_nth 1 strm with
+      | Tok.INT _ when b1 ->
+         (match Util.stream_nth 2 strm with
+         | Tok.KEYWORD "=" | Tok.KEYWORD "/=" when not b2 -> ()
+         | Tok.KEYWORD "/" ->
+             if not b2 then () else begin
+               match Util.stream_nth 3 strm with
+               | Tok.INT _ -> ()
+               | _ -> raise Stream.Failure
+             end
+         | _ -> raise Stream.Failure)
+      | Tok.KEYWORD "/" when not b1 ->
+         (match Util.stream_nth 2 strm with
+         | Tok.KEYWORD "=" when not b2 -> ()
+         | Tok.INT _ when b2 ->
+           (match Util.stream_nth 3 strm with
+           | Tok.KEYWORD "=" -> ()
+           | _ -> raise Stream.Failure)
+         | _ when not b2 -> ()
+         | _ -> raise Stream.Failure)
+      | Tok.KEYWORD "=" when not b1 && not b2 -> ()
+      | _ -> raise Stream.Failure)
+  | Tok.KEYWORD "//" when not b1 ->
+         (match Util.stream_nth 1 strm with
+         | Tok.KEYWORD "=" when not b2 -> ()
+         | Tok.INT _ when b2 ->
+           (match Util.stream_nth 2 strm with
+           | Tok.KEYWORD "=" -> ()
+           | _ -> raise Stream.Failure)
+         | _ when not b2 -> ()
+         | _ -> raise Stream.Failure)
+  | _ -> raise Stream.Failure
+
+let test_ssrslashnum10 = test_ssrslashnum true false
+let test_ssrslashnum11 = test_ssrslashnum true true
+let test_ssrslashnum01 = test_ssrslashnum false true
+let test_ssrslashnum00 = test_ssrslashnum false false
+
+let negate_parser f x =
+  let rc = try Some (f x) with Stream.Failure -> None in
+  match rc with
+  | None -> ()
+  | Some _ -> raise Stream.Failure 
+
+let test_not_ssrslashnum =
+  Pcoq.Gram.Entry.of_parser
+    "test_not_ssrslashnum" (negate_parser test_ssrslashnum10)
+let test_ssrslashnum00 =
+  Pcoq.Gram.Entry.of_parser "test_ssrslashnum01" test_ssrslashnum00
+let test_ssrslashnum10 =
+  Pcoq.Gram.Entry.of_parser "test_ssrslashnum10" test_ssrslashnum10
+let test_ssrslashnum11 =
+  Pcoq.Gram.Entry.of_parser "test_ssrslashnum11" test_ssrslashnum11
+let test_ssrslashnum01 =
+  Pcoq.Gram.Entry.of_parser "test_ssrslashnum01" test_ssrslashnum01
+
+
+ARGUMENT EXTEND ssrsimpl_ne TYPED AS ssrsimplrep PRINTED BY pr_ssrsimpl
+| [ "//=" ] -> [ SimplCut (~-1,~-1) ]
+| [ "/=" ] -> [ Simpl ~-1 ]
+END
+
+Pcoq.(Prim.(
+GEXTEND Gram
+  GLOBAL: ssrsimpl_ne;
+  ssrsimpl_ne: [
+    [ test_ssrslashnum11; "/"; n = natural; "/"; m = natural; "=" -> SimplCut(n,m)
+    | test_ssrslashnum10; "/"; n = natural; "/" -> Cut n 
+    | test_ssrslashnum10; "/"; n = natural; "=" -> Simpl n 
+    | test_ssrslashnum10; "/"; n = natural; "/=" -> SimplCut (n,~-1) 
+    | test_ssrslashnum10; "/"; n = natural; "/"; "=" -> SimplCut (n,~-1) 
+    | test_ssrslashnum01; "//"; m = natural; "=" -> SimplCut (~-1,m)
+    | test_ssrslashnum00; "//" -> Cut ~-1
+    ]];
+
+END
+))
+
+ARGUMENT EXTEND ssrsimpl TYPED AS ssrsimplrep PRINTED BY pr_ssrsimpl
+| [ ssrsimpl_ne(sim) ] -> [ sim ]
+| [ ] -> [ Nop ]
+END
+
+let pr_clear_ne clr = str "{" ++ pr_hyps clr ++ str "}"
+let pr_clear sep clr = if clr = [] then mt () else sep () ++ pr_clear_ne clr
+
+let pr_ssrclear _ _ _ = pr_clear mt
+
+ARGUMENT EXTEND ssrclear_ne TYPED AS ssrhyps PRINTED BY pr_ssrclear
+| [ "{" ne_ssrhyp_list(clr) "}" ] -> [ check_hyps_uniq [] clr; clr ]
+END
+
+ARGUMENT EXTEND ssrclear TYPED AS ssrclear_ne PRINTED BY pr_ssrclear
+| [ ssrclear_ne(clr) ] -> [ clr ]
+| [ ] -> [ [] ]
+END
+
+(** Indexes *)
+
+(* Since SSR indexes are always positive numbers, we use the 0 value *)
+(* to encode an omitted index. We reuse the in or_var type, but we   *)
+(* supply our own interpretation function, which checks for non      *)
+(* positive values, and allows the use of constr numerals, so that   *)
+(* e.g., "let n := eval compute in (1 + 3) in (do n!clear)" works.   *)
+
+
+let pr_index = function
+  | Misctypes.ArgVar (_, id) -> pr_id id
+  | Misctypes.ArgArg n when n > 0 -> int n
+  | _ -> mt ()
+let pr_ssrindex _ _ _ = pr_index
+
+let noindex = Misctypes.ArgArg 0
+
+let check_index ?loc i =
+  if i > 0 then i else CErrors.user_err ?loc (str"Index not positive")
+let mk_index ?loc = function
+  | Misctypes.ArgArg i -> Misctypes.ArgArg (check_index ?loc i)
+  | iv -> iv
+
+let interp_index ist gl idx =
+  Tacmach.project gl, 
+  match idx with
+  | Misctypes.ArgArg _ -> idx
+  | Misctypes.ArgVar (loc, id) ->
+    let i =
+      try
+        let v = Id.Map.find id ist.Tacinterp.lfun in
+        begin match Tacinterp.Value.to_int v with
+        | Some i -> i
+        | None ->
+        begin match Tacinterp.Value.to_constr v with
+        | Some c ->
+          let rc = Detyping.detype false [] (pf_env gl) (project gl) c in
+          begin match Notation.uninterp_prim_token rc with
+          | _, Constrexpr.Numeral (s,b) ->
+             let n = int_of_string s in if b then n else -n
+          | _ -> raise Not_found
+          end
+        | None -> raise Not_found
+        end end
+    with _ -> CErrors.user_err ?loc (str"Index not a number") in
+    Misctypes.ArgArg (check_index ?loc i)
+
+open Pltac
+
+ARGUMENT EXTEND ssrindex TYPED AS ssrindex PRINTED BY pr_ssrindex
+  INTERPRETED BY interp_index
+| [ int_or_var(i) ] -> [ mk_index ~loc i ]
+END
+
+
+(** Occurrence switch *)
+
+(* The standard syntax of complemented occurrence lists involves a single *)
+(* initial "-", e.g., {-1 3 5}. An initial                                *)
+(* "+" may be used to indicate positive occurrences (the default). The    *)
+(* "+" is optional, except if the list of occurrences starts with a       *)
+(* variable or is empty (to avoid confusion with a clear switch). The     *)
+(* empty positive switch "{+}" selects no occurrences, while the empty    *)
+(* negative switch "{-}" selects all occurrences explicitly; this is the  *)
+(* default, but "{-}" prevents the implicit clear, and can be used to     *)
+(* force dependent elimination -- see ndefectelimtac below.               *)
+
+
+let pr_ssrocc _ _ _ = pr_occ
+
+open Pcoq.Prim
+
+ARGUMENT EXTEND ssrocc TYPED AS (bool * int list) option PRINTED BY pr_ssrocc
+| [ natural(n) natural_list(occ) ] -> [
+     Some (false, List.map (check_index ~loc) (n::occ)) ]
+| [ "-" natural_list(occ) ]     -> [ Some (true, occ) ]
+| [ "+" natural_list(occ) ]     -> [ Some (false, occ) ]
+END
+
+
+(* modality *)
+
+
+let pr_mmod = function May -> str "?" | Must -> str "!" | Once -> mt ()
+
+let wit_ssrmmod = add_genarg "ssrmmod" pr_mmod
+let ssrmmod = Pcoq.create_generic_entry Pcoq.utactic "ssrmmod" (Genarg.rawwit wit_ssrmmod);;
+
+GEXTEND Gram
+  GLOBAL: ssrmmod;
+  ssrmmod: [[ "!" -> Must | LEFTQMARK -> May | "?" -> May]];
+END
+
+(** Rewrite multiplier: !n ?n *)
+
+let pr_mult (n, m) =
+  if n > 0 && m <> Once then int n ++ pr_mmod m else pr_mmod m
+
+let pr_ssrmult _ _ _ = pr_mult
+
+ARGUMENT EXTEND ssrmult_ne TYPED AS int * ssrmmod PRINTED BY pr_ssrmult
+  | [ natural(n) ssrmmod(m) ] -> [ check_index ~loc n, m ]
+  | [ ssrmmod(m) ]            -> [ notimes, m ]
+END
+
+ARGUMENT EXTEND ssrmult TYPED AS ssrmult_ne PRINTED BY pr_ssrmult
+  | [ ssrmult_ne(m) ] -> [ m ]
+  | [ ] -> [ nomult ]
+END
+
+(** Discharge occ switch (combined occurrence / clear switch *)
+
+let pr_docc = function
+  | None, occ -> pr_occ occ
+  | Some clr, _ -> pr_clear mt clr
+
+let pr_ssrdocc _ _ _ = pr_docc
+
+ARGUMENT EXTEND ssrdocc TYPED AS ssrclear option * ssrocc PRINTED BY pr_ssrdocc
+| [ "{" ne_ssrhyp_list(clr) "}" ] -> [ mkclr clr ]
+| [ "{" ssrocc(occ) "}" ] -> [ mkocc occ ]
+END
+
+(* kinds of terms *)
+
+let input_ssrtermkind strm = match Util.stream_nth 0 strm with
+  | Tok.KEYWORD "(" -> xInParens
+  | Tok.KEYWORD "@" -> xWithAt
+  | _ -> xNoFlag
+
+let ssrtermkind = Pcoq.Gram.Entry.of_parser "ssrtermkind" input_ssrtermkind
+
+(* terms *)
+
+(** Terms parsing. ********************************************************)
+
+let interp_constr = interp_wit wit_constr
+
+(* Because we allow wildcards in term references, we need to stage the *)
+(* interpretation of terms so that it occurs at the right time during  *)
+(* the execution of the tactic (e.g., so that we don't report an error *)
+(* for a term that isn't actually used in the execution).              *)
+(*   The term representation tracks whether the concrete initial term  *)
+(* started with an opening paren, which might avoid a conflict between *)
+(* the ssrreflect term syntax and Gallina notation.                    *)
+
+(* terms *)
+let pr_ssrterm _ _ _ = pr_term
+let force_term ist gl (_, c) = interp_constr ist gl c
+let glob_ssrterm gs = function
+  | k, (_, Some c) -> k, Tacintern.intern_constr gs c
+  | ct -> ct
+let subst_ssrterm s (k, c) = k, Tacsubst.subst_glob_constr_and_expr s c
+let interp_ssrterm _ gl t = Tacmach.project gl, t
+
+open Pcoq.Constr
+
+ARGUMENT EXTEND ssrterm
+     PRINTED BY pr_ssrterm
+     INTERPRETED BY interp_ssrterm
+     GLOBALIZED BY glob_ssrterm SUBSTITUTED BY subst_ssrterm
+     RAW_PRINTED BY pr_ssrterm
+     GLOB_PRINTED BY pr_ssrterm
+| [ "YouShouldNotTypeThis" constr(c) ] -> [ mk_lterm c ]
+END
+
+
+GEXTEND Gram
+  GLOBAL: ssrterm;
+  ssrterm: [[ k = ssrtermkind; c = Pcoq.Constr.constr -> mk_term k c ]];
+END
+
+(* Views *)
+
+let pr_view = pr_list mt (fun c -> str "/" ++ pr_term c)
+
+let pr_ssrview _ _ _ = pr_view
+
+ARGUMENT EXTEND ssrview TYPED AS ssrterm list
+   PRINTED BY pr_ssrview
+| [ "YouShouldNotTypeThis" ] -> [ [] ]
+END
+
+Pcoq.(
+GEXTEND Gram
+  GLOBAL: ssrview;
+  ssrview: [
+    [  test_not_ssrslashnum; "/"; c = Pcoq.Constr.constr -> [mk_term xNoFlag c]
+    |  test_not_ssrslashnum; "/"; c = Pcoq.Constr.constr; w = ssrview ->
+                    (mk_term xNoFlag c) :: w ]];
+END
+)
+
+(* }}} *)
+ 
+(* ipats *)
+
+
+let remove_loc = snd
+
+let ipat_of_intro_pattern p = Misctypes.(
+  let rec ipat_of_intro_pattern = function
+    | IntroNaming (IntroIdentifier id) -> IPatId id
+    | IntroAction IntroWildcard -> IPatAnon Drop
+    | IntroAction (IntroOrAndPattern (IntroOrPattern iorpat)) ->
+      IPatCase 
+       (List.map (List.map ipat_of_intro_pattern) 
+ 	 (List.map (List.map remove_loc) iorpat))
+    | IntroAction (IntroOrAndPattern (IntroAndPattern iandpat)) ->
+      IPatCase 
+       [List.map ipat_of_intro_pattern (List.map remove_loc iandpat)]
+    | IntroNaming IntroAnonymous -> IPatAnon One
+    | IntroAction (IntroRewrite b) -> IPatRewrite (allocc, if b then L2R else R2L)
+    | IntroNaming (IntroFresh id) -> IPatAnon One
+    | IntroAction (IntroApplyOn _) -> (* to do *) CErrors.user_err (Pp.str "TO DO")
+    | IntroAction (IntroInjection ips) ->
+        IPatInj [List.map ipat_of_intro_pattern (List.map remove_loc ips)]
+    | IntroAction (IntroIrrefutablePattern _) ->
+        assert false
+    | IntroForthcoming _ ->
+        (* Unable to determine which kind of ipat interp_introid could
+         * return [HH] *)
+        assert false
+  in
+  ipat_of_intro_pattern p
+)
+
+let rec pr_ipat p =
+  match p with
+  | IPatId id -> pr_id id
+  | IPatSimpl sim -> pr_simpl sim
+  | IPatClear clr -> pr_clear mt clr
+  | IPatCase iorpat -> hov 1 (str "[" ++ pr_iorpat iorpat ++ str "]")
+  | IPatInj iorpat -> hov 1 (str "[=" ++ pr_iorpat iorpat ++ str "]")
+  | IPatRewrite (occ, dir) -> pr_occ occ ++ pr_dir dir
+  | IPatAnon All -> str "*"
+  | IPatAnon Drop -> str "_"
+  | IPatAnon One -> str "?"
+  | IPatView v -> pr_view v
+  | IPatNoop -> str "-"
+  | IPatNewHidden l -> str "[:" ++ pr_list spc pr_id l ++ str "]"
+(* TODO  | IPatAnon Temporary -> str "+" *)
+
+and pr_iorpat iorpat = pr_list pr_bar pr_ipats iorpat
+and pr_ipats ipats = pr_list spc pr_ipat ipats
+
+let wit_ssripatrep = add_genarg "ssripatrep" pr_ipat
+
+let pr_ssripat _ _ _ = pr_ipat
+let pr_ssripats _ _ _ = pr_ipats
+let pr_ssriorpat _ _ _ = pr_iorpat
+
+let intern_ipat ist ipat =
+  let rec check_pat = function
+  | IPatClear clr -> ignore (List.map (intern_hyp ist) clr)
+  | IPatCase iorpat -> List.iter (List.iter check_pat) iorpat
+  | IPatInj iorpat -> List.iter (List.iter check_pat) iorpat
+  | _ -> () in
+  check_pat ipat; ipat
+
+let intern_ipats ist = List.map (intern_ipat ist)
+
+let interp_intro_pattern = interp_wit wit_intro_pattern
+
+let interp_introid ist gl id = Misctypes.(
+ try IntroNaming (IntroIdentifier (hyp_id (snd (interp_hyp ist gl (SsrHyp (Loc.tag id))))))
+ with _ -> snd(snd (interp_intro_pattern ist gl (Loc.tag @@ IntroNaming (IntroIdentifier id))))
+)
+
+let rec add_intro_pattern_hyps (loc, ipat) hyps = Misctypes.(
+  match ipat with
+  | IntroNaming (IntroIdentifier id) ->
+    if not_section_id id then SsrHyp (loc, id) :: hyps else
+    hyp_err ?loc "Can't delete section hypothesis " id
+  | IntroAction IntroWildcard -> hyps
+  | IntroAction (IntroOrAndPattern (IntroOrPattern iorpat)) ->
+     List.fold_right (List.fold_right add_intro_pattern_hyps) iorpat hyps
+  | IntroAction (IntroOrAndPattern (IntroAndPattern iandpat)) ->
+    List.fold_right add_intro_pattern_hyps iandpat hyps
+  | IntroNaming IntroAnonymous -> []
+  | IntroNaming (IntroFresh _) -> []
+  | IntroAction (IntroRewrite _) -> hyps
+  | IntroAction (IntroInjection ips) -> List.fold_right add_intro_pattern_hyps ips hyps
+  | IntroAction (IntroIrrefutablePattern (ids,_)) -> assert false
+  | IntroAction (IntroApplyOn (c,pat)) -> add_intro_pattern_hyps pat hyps
+  | IntroForthcoming _ -> 
+    (* As in ipat_of_intro_pattern, was unable to determine which kind
+      of ipat interp_introid could return [HH] *) assert false
+)
+
+(* MD: what does this do? *)
+let interp_ipat ist gl = Misctypes.(
+  let ltacvar id = Id.Map.mem id ist.Tacinterp.lfun in
+  let rec interp = function
+  | IPatId id when ltacvar id ->
+    ipat_of_intro_pattern (interp_introid ist gl id)
+  | IPatClear clr ->
+    let add_hyps (SsrHyp (loc, id) as hyp) hyps =
+      if not (ltacvar id) then hyp :: hyps else
+      add_intro_pattern_hyps (loc, (interp_introid ist gl id)) hyps in
+    let clr' = List.fold_right add_hyps clr [] in
+    check_hyps_uniq [] clr'; IPatClear clr'
+  | IPatCase(iorpat) ->
+      IPatCase(List.map (List.map interp) iorpat)
+  | IPatInj iorpat -> IPatInj (List.map (List.map interp) iorpat)
+  | IPatNewHidden l ->
+      IPatNewHidden
+        (List.map (function
+           | IntroNaming (IntroIdentifier id) -> id
+           | _ -> assert false)
+        (List.map (interp_introid ist gl) l))
+  | ipat -> ipat in
+  interp
+)
+
+let interp_ipats ist gl l = project gl, List.map (interp_ipat ist gl) l
+
+let pushIPatRewrite = function
+  | pats :: orpat -> (IPatRewrite (allocc, L2R) :: pats) :: orpat
+  | [] -> []
+
+let pushIPatNoop = function
+  | pats :: orpat -> (IPatNoop :: pats) :: orpat
+  | [] -> []
+
+ARGUMENT EXTEND ssripat TYPED AS ssripatrep list PRINTED BY pr_ssripats
+  INTERPRETED BY interp_ipats
+  GLOBALIZED BY intern_ipats
+  | [ "_" ] -> [ [IPatAnon Drop] ]
+  | [ "*" ] -> [ [IPatAnon All] ]
+             (*
+  | [ "^" "*" ] -> [ [IPatFastMode] ]
+  | [ "^" "_" ] -> [ [IPatSeed `Wild] ]
+  | [ "^_" ] -> [ [IPatSeed `Wild] ]
+  | [ "^" "?" ] -> [ [IPatSeed `Anon] ]
+  | [ "^?" ] -> [ [IPatSeed `Anon] ]
+  | [ "^" ident(id) ] -> [ [IPatSeed (`Id(id,`Pre))] ]
+  | [ "^" "~" ident(id) ] -> [ [IPatSeed (`Id(id,`Post))] ]
+  | [ "^~" ident(id) ] -> [ [IPatSeed (`Id(id,`Post))] ]
+              *)
+  | [ ident(id) ] -> [ [IPatId id] ]
+  | [ "?" ] -> [ [IPatAnon One] ]
+(* TODO  | [ "+" ] -> [ [IPatAnon Temporary] ] *)
+  | [ ssrsimpl_ne(sim) ] -> [ [IPatSimpl sim] ]
+  | [ ssrdocc(occ) "->" ] -> [ match occ with
+      | None, occ -> [IPatRewrite (occ, L2R)]
+      | Some clr, _ -> [IPatClear clr; IPatRewrite (allocc, L2R)]]
+  | [ ssrdocc(occ) "<-" ] -> [ match occ with
+      | None, occ ->  [IPatRewrite (occ, R2L)]
+      | Some clr, _ -> [IPatClear clr; IPatRewrite (allocc, R2L)]]
+  | [ ssrdocc(occ) ] -> [ match occ with
+      | Some cl, _ -> check_hyps_uniq [] cl; [IPatClear cl]
+      | _ -> CErrors.user_err ~loc (str"Only identifiers are allowed here")]
+  | [ "->" ] -> [ [IPatRewrite (allocc, L2R)] ]
+  | [ "<-" ] -> [ [IPatRewrite (allocc, R2L)] ]
+  | [ "-" ] -> [ [IPatNoop] ]
+  | [ "-/" "=" ] -> [ [IPatNoop;IPatSimpl(Simpl ~-1)] ]
+  | [ "-/=" ] -> [ [IPatNoop;IPatSimpl(Simpl ~-1)] ]
+  | [ "-/" "/" ] -> [ [IPatNoop;IPatSimpl(Cut ~-1)] ]
+  | [ "-//" ] -> [ [IPatNoop;IPatSimpl(Cut ~-1)] ]
+  | [ "-/" integer(n) "/" ] -> [ [IPatNoop;IPatSimpl(Cut n)] ]
+  | [ "-/" "/=" ] -> [ [IPatNoop;IPatSimpl(SimplCut (~-1,~-1))] ]
+  | [ "-//" "=" ] -> [ [IPatNoop;IPatSimpl(SimplCut (~-1,~-1))] ]
+  | [ "-//=" ] -> [ [IPatNoop;IPatSimpl(SimplCut (~-1,~-1))] ]
+  | [ "-/" integer(n) "/=" ] -> [ [IPatNoop;IPatSimpl(SimplCut (n,~-1))] ]
+  | [ "-/" integer(n) "/" integer (m) "=" ] ->
+      [ [IPatNoop;IPatSimpl(SimplCut(n,m))] ]
+  | [ ssrview(v) ] -> [ [IPatView v] ]
+  | [ "[" ":" ident_list(idl) "]" ] -> [ [IPatNewHidden idl] ]
+  | [ "[:" ident_list(idl) "]" ] -> [ [IPatNewHidden idl] ]
+END
+
+ARGUMENT EXTEND ssripats TYPED AS ssripat PRINTED BY pr_ssripats
+  | [ ssripat(i) ssripats(tl) ] -> [ i @ tl ]
+  | [ ] -> [ [] ]
+END
+
+ARGUMENT EXTEND ssriorpat TYPED AS ssripat list PRINTED BY pr_ssriorpat
+| [ ssripats(pats) "|" ssriorpat(orpat) ] -> [ pats :: orpat ]
+| [ ssripats(pats) "|-" ">" ssriorpat(orpat) ] -> [ pats :: pushIPatRewrite orpat ]
+| [ ssripats(pats) "|-" ssriorpat(orpat) ] -> [ pats :: pushIPatNoop orpat ]
+| [ ssripats(pats) "|->" ssriorpat(orpat) ] -> [ pats :: pushIPatRewrite orpat ]
+| [ ssripats(pats) "||" ssriorpat(orpat) ] -> [ pats :: [] :: orpat ]
+| [ ssripats(pats) "|||" ssriorpat(orpat) ] -> [ pats :: [] :: [] :: orpat ]
+| [ ssripats(pats) "||||" ssriorpat(orpat) ] -> [ [pats; []; []; []] @ orpat ]
+| [ ssripats(pats) ] -> [ [pats] ]
+END
+
+let reject_ssrhid strm =
+  match Util.stream_nth 0 strm with
+  | Tok.KEYWORD "[" ->
+      (match Util.stream_nth 1 strm with
+      | Tok.KEYWORD ":" -> raise Stream.Failure
+      | _ -> ())
+  | _ -> ()
+
+let test_nohidden = Pcoq.Gram.Entry.of_parser "test_ssrhid" reject_ssrhid
+
+ARGUMENT EXTEND ssrcpat TYPED AS ssripatrep PRINTED BY pr_ssripat
+  | [ "YouShouldNotTypeThis" ssriorpat(x) ] -> [ IPatCase(x) ]
+END
+
+Pcoq.(
+GEXTEND Gram
+  GLOBAL: ssrcpat;
+  ssrcpat: [
+   [ test_nohidden; "["; iorpat = ssriorpat; "]" ->
+(*      check_no_inner_seed !@loc false iorpat;
+      IPatCase (understand_case_type iorpat) *)
+      IPatCase iorpat
+   | test_nohidden; "[="; iorpat = ssriorpat; "]" ->
+(*      check_no_inner_seed !@loc false iorpat; *)
+      IPatInj iorpat ]];
+END
+);;
+
+Pcoq.(
+GEXTEND Gram
+  GLOBAL: ssripat;
+  ssripat: [[ pat = ssrcpat -> [pat] ]];
+END
+)
+
+ARGUMENT EXTEND ssripats_ne TYPED AS ssripat PRINTED BY pr_ssripats
+  | [ ssripat(i) ssripats(tl) ] -> [ i @ tl ]
+                                     END
+
+(* subsets of patterns *)
+
+(* TODO: review what this function does, it looks suspicious *)
+let check_ssrhpats loc w_binders ipats =
+  let err_loc s = CErrors.user_err ~loc ~hdr:"ssreflect" s in
+  let clr, ipats =
+    let rec aux clr = function
+      | IPatClear cl :: tl -> aux (clr @ cl) tl
+(*      | IPatSimpl (cl, sim) :: tl -> clr @ cl, IPatSimpl ([], sim) :: tl *)
+      | tl -> clr, tl
+    in aux [] ipats in
+  let simpl, ipats = 
+    match List.rev ipats with
+    | IPatSimpl _ as s :: tl -> [s], List.rev tl
+    | _ -> [],  ipats in
+  if simpl <> [] && not w_binders then
+    err_loc (str "No s-item allowed here: " ++ pr_ipats simpl);
+  let ipat, binders =
+    let rec loop ipat = function
+      | [] -> ipat, []
+      | ( IPatId _| IPatAnon _| IPatCase _| IPatRewrite _ as i) :: tl -> 
+        if w_binders then
+          if simpl <> [] && tl <> [] then 
+            err_loc(str"binders XOR s-item allowed here: "++pr_ipats(tl@simpl))
+          else if not (List.for_all (function IPatId _ -> true | _ -> false) tl)
+          then err_loc (str "Only binders allowed here: " ++ pr_ipats tl)
+          else ipat @ [i], tl
+        else
+          if tl = [] then  ipat @ [i], []
+          else err_loc (str "No binder or s-item allowed here: " ++ pr_ipats tl)
+      | hd :: tl -> loop (ipat @ [hd]) tl
+    in loop [] ipats in
+  ((clr, ipat), binders), simpl
+
+let pr_hpats (((clr, ipat), binders), simpl) =
+   pr_clear mt clr ++ pr_ipats ipat ++ pr_ipats binders ++ pr_ipats simpl
+let pr_ssrhpats _ _ _ = pr_hpats
+let pr_ssrhpats_wtransp _ _ _ (_, x) = pr_hpats x
+
+ARGUMENT EXTEND ssrhpats TYPED AS ((ssrclear * ssripat) * ssripat) * ssripat
+PRINTED BY pr_ssrhpats
+  | [ ssripats(i) ] -> [ check_ssrhpats loc true i ]
+END
+
+ARGUMENT EXTEND ssrhpats_wtransp
+  TYPED AS bool * (((ssrclear * ssripats) * ssripats) * ssripats)
+  PRINTED BY pr_ssrhpats_wtransp
+  | [ ssripats(i) ] -> [ false,check_ssrhpats loc true i ]
+  | [ ssripats(i) "@" ssripats(j) ] -> [ true,check_ssrhpats loc true (i @ j) ]
+END
+
+ARGUMENT EXTEND ssrhpats_nobs 
+TYPED AS ((ssrclear * ssripats) * ssripats) * ssripats PRINTED BY pr_ssrhpats
+  | [ ssripats(i) ] -> [ check_ssrhpats loc false i ]
+END
+
+ARGUMENT EXTEND ssrrpat TYPED AS ssripatrep PRINTED BY pr_ssripat
+  | [ "->" ] -> [ IPatRewrite (allocc, L2R) ]
+  | [ "<-" ] -> [ IPatRewrite (allocc, R2L) ]
+END
+
+let pr_intros sep intrs =
+  if intrs = [] then mt() else sep () ++ str "=>" ++ pr_ipats intrs
+let pr_ssrintros _ _ _ = pr_intros mt
+
+ARGUMENT EXTEND ssrintros_ne TYPED AS ssripat
+ PRINTED BY pr_ssrintros
+  | [ "=>" ssripats_ne(pats) ] -> [ pats ]
+(*  TODO | [ "=>" ">" ssripats_ne(pats) ] -> [ IPatFastMode :: pats ]
+  | [ "=>>" ssripats_ne(pats) ] -> [ IPatFastMode :: pats ] *)
+END
+
+ARGUMENT EXTEND ssrintros TYPED AS ssrintros_ne PRINTED BY pr_ssrintros
+  | [ ssrintros_ne(intrs) ] -> [ intrs ]
+  | [ ] -> [ [] ]
+END
+
+let pr_ssrintrosarg _ _ prt (tac, ipats) =
+  prt tacltop tac ++ pr_intros spc ipats
+
+ARGUMENT EXTEND ssrintrosarg TYPED AS tactic * ssrintros
+   PRINTED BY pr_ssrintrosarg
+| [ "YouShouldNotTypeThis" ssrtacarg(arg) ssrintros_ne(ipats) ] -> [ arg, ipats ]
+END
+
+TACTIC EXTEND ssrtclintros
+| [ "YouShouldNotTypeThis" ssrintrosarg(arg) ] ->
+  [ let tac, intros = arg in
+    Proofview.V82.tactic (Ssripats.tclINTROS ist (fun ist -> ssrevaltac ist tac) intros) ]
+    END
+
+(** Defined identifier *)
+let pr_ssrfwdid id = pr_spc () ++ pr_id id
+
+let pr_ssrfwdidx _ _ _ = pr_ssrfwdid
+
+(* We use a primitive parser for the head identifier of forward *)
+(* tactis to avoid syntactic conflicts with basic Coq tactics. *)
+ARGUMENT EXTEND ssrfwdid TYPED AS ident PRINTED BY pr_ssrfwdidx
+  | [ "YouShouldNotTypeThis" ] -> [ anomaly "Grammar placeholder match" ]
+END
+
+let accept_ssrfwdid strm =
+  match stream_nth 0 strm with
+  | Tok.IDENT id -> accept_before_syms_or_any_id [":"; ":="; "("] strm
+  | _ -> raise Stream.Failure
+
+
+let test_ssrfwdid = Gram.Entry.of_parser "test_ssrfwdid" accept_ssrfwdid
+
+GEXTEND Gram
+  GLOBAL: ssrfwdid;
+  ssrfwdid: [[ test_ssrfwdid; id = Prim.ident -> id ]];
+  END
+
+  
+(* by *)
+(** Tactical arguments. *)
+
+(* We have four kinds: simple tactics, [|]-bracketed lists, hints, and swaps *)
+(* The latter two are used in forward-chaining tactics (have, suffice, wlog) *)
+(* and subgoal reordering tacticals (; first & ; last), respectively.        *)
+
+
+let pr_ortacs prt = 
+  let rec pr_rec = function
+  | [None]           -> spc() ++ str "|" ++ spc()
+  | None :: tacs     -> spc() ++ str "|" ++ pr_rec tacs
+  | Some tac :: tacs -> spc() ++ str "| " ++ prt tacltop tac ++  pr_rec tacs
+  | []                -> mt() in
+  function
+  | [None]           -> spc()
+  | None :: tacs     -> pr_rec tacs
+  | Some tac :: tacs -> prt tacltop tac ++ pr_rec tacs
+  | []                -> mt()
+let pr_ssrortacs _ _ = pr_ortacs
+
+ARGUMENT EXTEND ssrortacs TYPED AS tactic option list PRINTED BY pr_ssrortacs
+| [ ssrtacarg(tac) "|" ssrortacs(tacs) ] -> [ Some tac :: tacs ]
+| [ ssrtacarg(tac) "|" ] -> [ [Some tac; None] ]
+| [ ssrtacarg(tac) ] -> [ [Some tac] ]
+| [ "|" ssrortacs(tacs) ] -> [ None :: tacs ]
+| [ "|" ] -> [ [None; None] ]
+END
+
+let pr_hintarg prt = function
+  | true, tacs -> hv 0 (str "[ " ++ pr_ortacs prt tacs ++ str " ]")
+  | false, [Some tac] -> prt tacltop tac
+  | _, _ -> mt()
+
+let pr_ssrhintarg _ _ = pr_hintarg
+
+
+ARGUMENT EXTEND ssrhintarg TYPED AS bool * ssrortacs PRINTED BY pr_ssrhintarg
+| [ "[" "]" ] -> [ nullhint ]
+| [ "[" ssrortacs(tacs) "]" ] -> [ mk_orhint tacs ]
+| [ ssrtacarg(arg) ] -> [ mk_hint arg ]
+END
+
+ARGUMENT EXTEND ssrortacarg TYPED AS ssrhintarg PRINTED BY pr_ssrhintarg
+| [ "[" ssrortacs(tacs) "]" ] -> [ mk_orhint tacs ]
+END
+
+
+let pr_hint prt arg =
+  if arg = nohint then mt() else str "by " ++ pr_hintarg prt arg
+let pr_ssrhint _ _ = pr_hint
+
+ARGUMENT EXTEND ssrhint TYPED AS ssrhintarg PRINTED BY pr_ssrhint
+| [ ]                       -> [ nohint ]
+END
+(** The "in" pseudo-tactical {{{ **********************************************)
+
+(* We can't make "in" into a general tactical because this would create a  *)
+(* crippling conflict with the ltac let .. in construct. Hence, we add     *)
+(* explicitly an "in" suffix to all the extended tactics for which it is   *)
+(* relevant (including move, case, elim) and to the extended do tactical   *)
+(* below, which yields a general-purpose "in" of the form do [...] in ...  *)
+
+(* This tactical needs to come before the intro tactics because the latter *)
+(* must take precautions in order not to interfere with the discharged     *)
+(* assumptions. This is especially difficult for discharged "let"s, which  *)
+(* the default simpl and unfold tactics would erase blindly.               *)
+
+open Ssrmatching_plugin.Ssrmatching
+
+let pr_wgen = function 
+  | (clr, Some((id,k),None)) -> spc() ++ pr_clear mt clr ++ str k ++ pr_hoi id
+  | (clr, Some((id,k),Some p)) ->
+      spc() ++ pr_clear mt clr ++ str"(" ++ str k ++ pr_hoi id ++ str ":=" ++
+        pr_cpattern p ++ str ")"
+  | (clr, None) -> spc () ++ pr_clear mt clr
+let pr_ssrwgen _ _ _ = pr_wgen
+
+(* no globwith for char *)
+ARGUMENT EXTEND ssrwgen
+  TYPED AS ssrclear * ((ssrhoi_hyp * string) * cpattern option) option
+  PRINTED BY pr_ssrwgen
+| [ ssrclear_ne(clr) ] -> [ clr, None ]
+| [ ssrhoi_hyp(hyp) ] -> [ [], Some((hyp, " "), None) ]
+| [ "@" ssrhoi_hyp(hyp) ] -> [ [], Some((hyp, "@"), None) ]
+| [ "(" ssrhoi_id(id) ":=" lcpattern(p) ")" ] ->
+  [ [], Some ((id," "),Some p) ]
+| [ "(" ssrhoi_id(id) ")" ] -> [ [], Some ((id,"("), None) ]
+| [ "(@" ssrhoi_id(id) ":=" lcpattern(p) ")" ] ->
+  [ [], Some ((id,"@"),Some p) ]
+| [ "(" "@" ssrhoi_id(id) ":=" lcpattern(p) ")" ] ->
+  [ [], Some ((id,"@"),Some p) ]
+END
+
+let pr_clseq = function
+  | InGoal | InHyps -> mt ()
+  | InSeqGoal       -> str "|- *"
+  | InHypsSeqGoal   -> str " |- *"
+  | InHypsGoal      -> str " *"
+  | InAll           -> str "*"
+  | InHypsSeq       -> str " |-"
+  | InAllHyps       -> str "* |-"
+
+let wit_ssrclseq = add_genarg "ssrclseq" pr_clseq
+let pr_clausehyps = pr_list pr_spc pr_wgen
+let pr_ssrclausehyps _ _ _ = pr_clausehyps
+
+ARGUMENT EXTEND ssrclausehyps 
+TYPED AS ssrwgen list PRINTED BY pr_ssrclausehyps
+| [ ssrwgen(hyp) "," ssrclausehyps(hyps) ] -> [ hyp :: hyps ]
+| [ ssrwgen(hyp) ssrclausehyps(hyps) ] -> [ hyp :: hyps ]
+| [ ssrwgen(hyp) ] -> [ [hyp] ]
+END
+
+(* type ssrclauses = ssrahyps * ssrclseq *)
+
+let pr_clauses (hyps, clseq) = 
+  if clseq = InGoal then mt ()
+  else str "in " ++ pr_clausehyps hyps ++ pr_clseq clseq
+let pr_ssrclauses _ _ _ = pr_clauses
+
+ARGUMENT EXTEND ssrclauses TYPED AS ssrwgen list * ssrclseq
+    PRINTED BY pr_ssrclauses
+  | [ "in" ssrclausehyps(hyps) "|-" "*" ] -> [ hyps, InHypsSeqGoal ]
+  | [ "in" ssrclausehyps(hyps) "|-" ]     -> [ hyps, InHypsSeq ]
+  | [ "in" ssrclausehyps(hyps) "*" ]      -> [ hyps, InHypsGoal ]
+  | [ "in" ssrclausehyps(hyps) ]          -> [ hyps, InHyps ]
+  | [ "in" "|-" "*" ]                     -> [ [], InSeqGoal ]
+  | [ "in" "*" ]                          -> [ [], InAll ]
+  | [ "in" "*" "|-" ]                     -> [ [], InAllHyps ]
+  | [ ]                                   -> [ [], InGoal ]
+END
+
+
+
+
+(** Definition value formatting *)
+
+(* We use an intermediate structure to correctly render the binder list  *)
+(* abbreviations. We use a list of hints to extract the binders and      *)
+(* base term from a term, for the two first levels of representation of  *)
+(* of constr terms.                                                      *)
+
+let pr_binder prl = function
+  | Bvar x ->
+    pr_name x
+  | Bdecl (xs, t) ->
+    str "(" ++ pr_list pr_spc pr_name xs ++ str " : " ++ prl t ++ str ")"
+  | Bdef (x, None, v) ->
+    str "(" ++ pr_name x ++ str " := " ++ prl v ++ str ")"
+  | Bdef (x, Some t, v) ->
+    str "(" ++ pr_name x ++ str " : " ++ prl t ++
+                            str " := " ++ prl v ++ str ")"
+  | Bstruct x ->
+    str "{struct " ++ pr_name x ++ str "}"
+  | Bcast t ->
+    str ": " ++ prl t
+
+let rec mkBstruct i = function
+  | Bvar x :: b ->
+    if i = 0 then [Bstruct x] else mkBstruct (i - 1) b
+  | Bdecl (xs, _) :: b ->
+    let i' = i - List.length xs in
+    if i' < 0 then [Bstruct (List.nth xs i)] else mkBstruct i' b
+  | _ :: b -> mkBstruct i b
+  | [] -> []
+
+let rec format_local_binders h0 bl0 = match h0, bl0 with
+  | BFvar :: h, CLocalAssum ([_, x], _,  _) :: bl ->
+    Bvar x :: format_local_binders h bl
+  | BFdecl _ :: h, CLocalAssum (lxs, _, t) :: bl ->
+    Bdecl (List.map snd lxs, t) :: format_local_binders h bl
+  | BFdef :: h, CLocalDef ((_, x), v, oty) :: bl ->
+    Bdef (x, oty, v) :: format_local_binders h bl
+  | _ -> []
+  
+let rec format_constr_expr h0 c0 = let open CAst in match h0, c0 with
+  | BFvar :: h, { v = CLambdaN ([[_, x], _, _], c) } ->
+    let bs, c' = format_constr_expr h c in
+    Bvar x :: bs, c'
+  | BFdecl _:: h, { v = CLambdaN ([lxs, _, t], c) } ->
+    let bs, c' = format_constr_expr h c in
+    Bdecl (List.map snd lxs, t) :: bs, c'
+  | BFdef :: h, { v = CLetIn((_, x), v, oty, c) } ->
+    let bs, c' = format_constr_expr h c in
+    Bdef (x, oty, v) :: bs, c'
+  | [BFcast], { v = CCast (c, CastConv t) } ->
+    [Bcast t], c
+  | BFrec (has_str, has_cast) :: h, 
+    { v = CFix ( _, [_, (Some locn, CStructRec), bl, t, c]) } ->
+    let bs = format_local_binders h bl in
+    let bstr = if has_str then [Bstruct (Name (snd locn))] else [] in
+    bs @ bstr @ (if has_cast then [Bcast t] else []), c 
+  | BFrec (_, has_cast) :: h, { v = CCoFix ( _, [_, bl, t, c]) } ->
+    format_local_binders h bl @ (if has_cast then [Bcast t] else []), c
+  | _, c ->
+    [], c
+
+let rec format_glob_decl h0 d0 = match h0, d0 with
+  | BFvar :: h, (x, _, None, _) :: d ->
+    Bvar x :: format_glob_decl h d
+  | BFdecl 1 :: h,  (x, _, None, t) :: d ->
+    Bdecl ([x], t) :: format_glob_decl h d
+  | BFdecl n :: h, (x, _, None, t) :: d when n > 1 ->
+    begin match format_glob_decl (BFdecl (n - 1) :: h) d with
+    | Bdecl (xs, _) :: bs -> Bdecl (x :: xs, t) :: bs
+    | bs -> Bdecl ([x], t) :: bs
+    end
+  | BFdef :: h, (x, _, Some v, _)  :: d ->
+    Bdef (x, None, v) :: format_glob_decl h d
+  | _, (x, _, None, t) :: d ->
+    Bdecl ([x], t) :: format_glob_decl [] d
+  | _, (x, _, Some v, _) :: d ->
+     Bdef (x, None, v) :: format_glob_decl [] d
+  | _, [] -> []
+
+let rec format_glob_constr h0 c0 = let open CAst in match h0, c0 with
+  | BFvar :: h, { v = GLambda (x, _, _, c) } ->
+    let bs, c' = format_glob_constr h c in
+    Bvar x :: bs, c'
+  | BFdecl 1 :: h, { v = GLambda (x, _, t, c) } ->
+    let bs, c' = format_glob_constr h c in
+    Bdecl ([x], t) :: bs, c'
+  | BFdecl n :: h, { v = GLambda (x, _, t, c) } when n > 1 ->
+    begin match format_glob_constr (BFdecl (n - 1) :: h) c with
+    | Bdecl (xs, _) :: bs, c' -> Bdecl (x :: xs, t) :: bs, c'
+    | _ -> [Bdecl ([x], t)], c
+    end
+  | BFdef :: h, { v = GLetIn(x, v, oty, c) } ->
+    let bs, c' = format_glob_constr h c in
+    Bdef (x, oty, v) :: bs, c'
+  | [BFcast], { v = GCast (c, CastConv t) } ->
+    [Bcast t], c
+  | BFrec (has_str, has_cast) :: h, { v = GRec (f, _, bl, t, c) }
+      when Array.length c = 1 ->
+    let bs = format_glob_decl h bl.(0) in
+    let bstr = match has_str, f with
+    | true, GFix ([|Some i, GStructRec|], _) -> mkBstruct i bs
+    | _ -> [] in
+    bs @ bstr @ (if has_cast then [Bcast t.(0)] else []), c.(0)
+  | _, c ->
+    [], c
+
+(** Forward chaining argument *)
+
+(* There are three kinds of forward definitions:           *)
+(*   - Hint: type only, cast to Type, may have proof hint. *)
+(*   - Have: type option + value, no space before type     *)
+(*   - Pose: binders + value, space before binders.        *)
+
+let pr_fwdkind = function
+  | FwdHint (s,_) -> str (s ^ " ") | _ -> str " :=" ++ spc ()
+let pr_fwdfmt (fk, _ : ssrfwdfmt) = pr_fwdkind fk
+
+let wit_ssrfwdfmt = add_genarg "ssrfwdfmt" pr_fwdfmt
+
+(* type ssrfwd = ssrfwdfmt * ssrterm *)
+
+let mkFwdVal fk c = ((fk, []), mk_term xNoFlag c)
+let mkssrFwdVal fk c = ((fk, []), (c,None))
+let dC t = CastConv t
+
+let mkFwdCast fk ?loc t c = ((fk, [BFcast]), mk_term ' ' (CAst.make ?loc @@ CCast (c, dC t)))
+let mkssrFwdCast fk loc t c = ((fk, [BFcast]), (c, Some t))
+
+let mkFwdHint s t =
+  let loc =  Constrexpr_ops.constr_loc t in
+  mkFwdCast (FwdHint (s,false)) ?loc t (mkCHole loc)
+let mkFwdHintNoTC s t =
+  let loc =  Constrexpr_ops.constr_loc t in
+  mkFwdCast (FwdHint (s,true)) ?loc t (mkCHole loc)
+
+let pr_gen_fwd prval prc prlc fk (bs, c) =
+  let prc s = str s ++ spc () ++ prval prc prlc c in
+  match fk, bs with
+  | FwdHint (s,_), [Bcast t] -> str s ++ spc () ++ prlc t
+  | FwdHint (s,_), _ ->  prc (s ^ "(* typeof *)")
+  | FwdHave, [Bcast t] -> str ":" ++ spc () ++ prlc t ++ prc " :="
+  | _, [] -> prc " :="
+  | _, _ -> spc () ++ pr_list spc (pr_binder prlc) bs ++ prc " :="
+
+let pr_fwd_guarded prval prval' = function
+| (fk, h), (_, (_, Some c)) ->
+  pr_gen_fwd prval pr_constr_expr prl_constr_expr fk (format_constr_expr h c)
+| (fk, h), (_, (c, None)) ->
+  pr_gen_fwd prval' pr_glob_constr prl_glob_constr fk (format_glob_constr h c)
+
+let pr_unguarded prc prlc = prlc
+
+let pr_fwd = pr_fwd_guarded pr_unguarded pr_unguarded
+let pr_ssrfwd _ _ _ = pr_fwd
+ 
+ARGUMENT EXTEND ssrfwd TYPED AS (ssrfwdfmt * ssrterm) PRINTED BY pr_ssrfwd
+  | [ ":=" lconstr(c) ] -> [ mkFwdVal FwdPose c ]
+  | [ ":" lconstr (t) ":=" lconstr(c) ] -> [ mkFwdCast FwdPose ~loc t c ]
+END
+
+(** Independent parsing for binders *)
+
+(* The pose, pose fix, and pose cofix tactics use these internally to  *)
+(* parse argument fragments.                                           *)
+
+let pr_ssrbvar prc _ _ v = prc v
+
+ARGUMENT EXTEND ssrbvar TYPED AS constr PRINTED BY pr_ssrbvar
+| [ ident(id) ] -> [ mkCVar ~loc id ]
+| [ "_" ] -> [ mkCHole (Some loc) ]
+END
+
+let bvar_lname = let open CAst in function
+  | { v = CRef (Ident (loc, id), _) } -> Loc.tag ?loc @@ Name id
+  | { loc = loc } -> Loc.tag ?loc Anonymous
+
+let pr_ssrbinder prc _ _ (_, c) = prc c
+
+ARGUMENT EXTEND ssrbinder TYPED AS ssrfwdfmt * constr PRINTED BY pr_ssrbinder
+ | [ ssrbvar(bv) ] ->
+   [ let xloc, _ as x = bvar_lname bv in
+     (FwdPose, [BFvar]),
+     CAst.make ~loc @@ CLambdaN ([[x],Default Explicit,mkCHole xloc],mkCHole (Some loc)) ]
+ | [ "(" ssrbvar(bv) ")" ] ->
+   [ let xloc, _ as x = bvar_lname bv in
+     (FwdPose, [BFvar]),
+     CAst.make ~loc @@ CLambdaN ([[x],Default Explicit,mkCHole xloc],mkCHole (Some loc)) ]
+ | [ "(" ssrbvar(bv) ":" lconstr(t) ")" ] ->
+   [ let x = bvar_lname bv in
+     (FwdPose, [BFdecl 1]),
+     CAst.make ~loc @@ CLambdaN ([[x], Default Explicit, t], mkCHole (Some loc)) ]
+ | [ "(" ssrbvar(bv) ne_ssrbvar_list(bvs) ":" lconstr(t) ")" ] ->
+   [ let xs = List.map bvar_lname (bv :: bvs) in
+     let n = List.length xs in
+     (FwdPose, [BFdecl n]),
+     CAst.make ~loc @@ CLambdaN ([xs, Default Explicit, t], mkCHole (Some loc)) ]
+ | [ "(" ssrbvar(id) ":" lconstr(t) ":=" lconstr(v) ")" ] ->
+   [ (FwdPose,[BFdef]), CAst.make ~loc @@ CLetIn (bvar_lname id, v, Some t, mkCHole (Some loc)) ]
+ | [ "(" ssrbvar(id) ":=" lconstr(v) ")" ] ->
+   [ (FwdPose,[BFdef]), CAst.make ~loc @@ CLetIn (bvar_lname id, v, None, mkCHole (Some loc)) ]
+     END
+
+GEXTEND Gram
+  GLOBAL: ssrbinder;
+  ssrbinder: [
+  [  ["of" | "&"]; c = operconstr LEVEL "99" ->
+     let loc = !@loc in
+     (FwdPose, [BFvar]),
+     CAst.make ~loc @@ CLambdaN ([[Loc.tag ~loc Anonymous],Default Explicit,c],mkCHole (Some loc)) ]
+  ];
+END
+
+let rec binders_fmts = function
+  | ((_, h), _) :: bs -> h @ binders_fmts bs
+  | _ -> []
+
+let push_binders c2 bs =
+  let loc2 = constr_loc c2 in let mkloc loc1 = Loc.merge_opt loc1 loc2 in
+  let open CAst in
+  let rec loop ty c = function
+  | (_, { loc = loc1; v = CLambdaN (b, _) } ) :: bs when ty ->
+      CAst.make ?loc:(mkloc loc1) @@ CProdN (b, loop ty c bs)
+  | (_, { loc = loc1; v = CLambdaN (b, _) } ) :: bs ->
+      CAst.make ?loc:(mkloc loc1) @@ CLambdaN (b, loop ty c bs)
+  | (_, { loc = loc1; v = CLetIn (x, v, oty, _) } ) :: bs ->
+      CAst.make ?loc:(mkloc loc1) @@ CLetIn (x, v, oty, loop ty c bs)
+  | [] -> c
+  | _ -> anomaly "binder not a lambda nor a let in" in
+  match c2 with
+  | { loc; v = CCast (ct, CastConv cty) } ->
+      CAst.make ?loc @@ (CCast (loop false ct bs, CastConv (loop true cty bs)))
+  | ct -> loop false ct bs
+
+let rec fix_binders = let open CAst in function
+  | (_, { v = CLambdaN ([xs, _, t], _) } ) :: bs ->
+      CLocalAssum (xs, Default Explicit, t) :: fix_binders bs
+  | (_, { v = CLetIn (x, v, oty, _) } ) :: bs ->
+    CLocalDef (x, v, oty) :: fix_binders bs
+  | _ -> []
+
+let pr_ssrstruct _ _ _ = function
+  | Some id -> str "{struct " ++ pr_id id ++ str "}"
+  | None -> mt ()
+
+ARGUMENT EXTEND ssrstruct TYPED AS ident option PRINTED BY pr_ssrstruct
+| [ "{" "struct" ident(id) "}" ] -> [ Some id ]
+| [ ] -> [ None ]
+END
+
+(** The "pose" tactic *)
+
+(* The plain pose form. *)
+
+let bind_fwd bs = function
+  | (fk, h), (ck, (rc, Some c)) ->
+    (fk,binders_fmts bs @ h), (ck,(rc,Some (push_binders c bs)))
+  | fwd -> fwd
+
+ARGUMENT EXTEND ssrposefwd TYPED AS ssrfwd PRINTED BY pr_ssrfwd
+  | [ ssrbinder_list(bs) ssrfwd(fwd) ] -> [ bind_fwd bs fwd ]
+END
+
+(* The pose fix form. *)
+
+let pr_ssrfixfwd _ _ _ (id, fwd) = str " fix " ++ pr_id id ++ pr_fwd fwd
+
+let bvar_locid = function
+  | { CAst.v = CRef (Ident (loc, id), _) } -> loc, id
+  | _ -> CErrors.user_err (Pp.str "Missing identifier after \"(co)fix\"")
+
+
+ARGUMENT EXTEND ssrfixfwd TYPED AS ident * ssrfwd PRINTED BY pr_ssrfixfwd
+  | [ "fix" ssrbvar(bv) ssrbinder_list(bs) ssrstruct(sid) ssrfwd(fwd) ] ->
+    [ let (_, id) as lid = bvar_locid bv in
+      let (fk, h), (ck, (rc, oc)) = fwd in
+      let c = Option.get oc in
+      let has_cast, t', c' = match format_constr_expr h c with
+      | [Bcast t'], c' -> true, t', c'
+      | _ -> false, mkCHole (constr_loc c), c in
+      let lb = fix_binders bs in
+      let has_struct, i =
+        let rec loop = function
+          (l', Name id') :: _ when Option.equal Id.equal sid (Some id') -> true, (l', id')
+          | [l', Name id'] when sid = None -> false, (l', id')
+          | _ :: bn -> loop bn
+          | [] -> CErrors.user_err (Pp.str "Bad structural argument") in
+        loop (names_of_local_assums lb) in
+      let h' = BFrec (has_struct, has_cast) :: binders_fmts bs in
+      let fix = CAst.make ~loc @@ CFix (lid, [lid, (Some i, CStructRec), lb, t', c']) in
+      id, ((fk, h'), (ck, (rc, Some fix))) ]
+END
+
+
+(* The pose cofix form. *)
+
+let pr_ssrcofixfwd _ _ _ (id, fwd) = str " cofix " ++ pr_id id ++ pr_fwd fwd
+
+ARGUMENT EXTEND ssrcofixfwd TYPED AS ssrfixfwd PRINTED BY pr_ssrcofixfwd
+  | [ "cofix" ssrbvar(bv) ssrbinder_list(bs) ssrfwd(fwd) ] ->
+    [ let _, id as lid = bvar_locid bv in
+      let (fk, h), (ck, (rc, oc)) = fwd in
+      let c = Option.get oc in
+      let has_cast, t', c' = match format_constr_expr h c with
+      | [Bcast t'], c' -> true, t', c'
+      | _ -> false, mkCHole (constr_loc c), c in
+      let h' = BFrec (false, has_cast) :: binders_fmts bs in
+      let cofix = CAst.make ~loc @@ CCoFix (lid, [lid, fix_binders bs, t', c']) in
+      id, ((fk, h'), (ck, (rc, Some cofix)))
+    ]
+END
+
+(* This does not print the type, it should be fixed... *)
+let pr_ssrsetfwd _ _ _ (((fk,_),(t,_)), docc) =
+  pr_gen_fwd (fun _ _ -> pr_cpattern)
+    (fun _ -> mt()) (fun _ -> mt()) fk ([Bcast ()],t)
+
+ARGUMENT EXTEND ssrsetfwd
+TYPED AS (ssrfwdfmt * (lcpattern * ssrterm option)) * ssrdocc
+PRINTED BY pr_ssrsetfwd
+| [ ":" lconstr(t) ":=" "{" ssrocc(occ) "}" cpattern(c) ] ->
+  [ mkssrFwdCast FwdPose loc (mk_lterm t) c, mkocc occ ]
+| [ ":" lconstr(t) ":=" lcpattern(c) ] ->
+  [ mkssrFwdCast FwdPose loc (mk_lterm t) c, nodocc ]
+| [ ":=" "{" ssrocc(occ) "}" cpattern(c) ] ->
+  [ mkssrFwdVal FwdPose c, mkocc occ ]
+| [ ":=" lcpattern(c) ] -> [ mkssrFwdVal FwdPose c, nodocc ]
+END
+
+
+let pr_ssrhavefwd _ _ prt (fwd, hint) = pr_fwd fwd ++ pr_hint prt hint
+
+ARGUMENT EXTEND ssrhavefwd TYPED AS ssrfwd * ssrhint PRINTED BY pr_ssrhavefwd
+| [ ":" lconstr(t) ssrhint(hint) ] -> [ mkFwdHint ":" t, hint ]
+| [ ":" lconstr(t) ":=" lconstr(c) ] -> [ mkFwdCast FwdHave ~loc t c, nohint ]
+| [ ":" lconstr(t) ":=" ] -> [ mkFwdHintNoTC ":" t, nohint ]
+| [ ":=" lconstr(c) ] -> [ mkFwdVal FwdHave c, nohint ]
+END
+
+let intro_id_to_binder = List.map (function 
+  | IPatId id ->
+      let xloc, _ as x = bvar_lname (mkCVar id) in
+      (FwdPose, [BFvar]),
+        CAst.make @@ CLambdaN ([[x], Default Explicit, mkCHole xloc],
+          mkCHole None)
+  | _ -> anomaly "non-id accepted as binder")
+
+let binder_to_intro_id = CAst.(List.map (function
+  | (FwdPose, [BFvar]), { v = CLambdaN ([ids,_,_],_) }
+  | (FwdPose, [BFdecl _]), { v = CLambdaN ([ids,_,_],_) } ->
+      List.map (function (_, Name id) -> IPatId id | _ -> IPatAnon One) ids
+  | (FwdPose, [BFdef]), { v = CLetIn ((_,Name id),_,_,_) } -> [IPatId id]
+  | (FwdPose, [BFdef]), { v = CLetIn ((_,Anonymous),_,_,_) } -> [IPatAnon One]
+  | _ -> anomaly "ssrbinder is not a binder"))
+
+let pr_ssrhavefwdwbinders _ _ prt (tr,((hpats, (fwd, hint)))) =
+  pr_hpats hpats ++ pr_fwd fwd ++ pr_hint prt hint
+
+ARGUMENT EXTEND ssrhavefwdwbinders
+  TYPED AS bool * (ssrhpats * (ssrfwd * ssrhint))
+  PRINTED BY pr_ssrhavefwdwbinders
+| [ ssrhpats_wtransp(trpats) ssrbinder_list(bs) ssrhavefwd(fwd) ] ->
+  [ let tr, pats = trpats in
+    let ((clr, pats), binders), simpl = pats in
+    let allbs = intro_id_to_binder binders @ bs in
+    let allbinders = binders @ List.flatten (binder_to_intro_id bs) in
+    let hint = bind_fwd allbs (fst fwd), snd fwd in
+    tr, ((((clr, pats), allbinders), simpl), hint) ]
+END
+
+
+let pr_ssrdoarg prc _ prt (((n, m), tac), clauses) =
+  pr_index n ++ pr_mmod m ++ pr_hintarg prt tac ++ pr_clauses clauses
+
+ARGUMENT EXTEND ssrdoarg
+  TYPED AS ((ssrindex * ssrmmod) * ssrhintarg) * ssrclauses
+  PRINTED BY pr_ssrdoarg
+| [ "YouShouldNotTypeThis" ] -> [ anomaly "Grammar placeholder match" ]
+END
+
+(* type ssrseqarg = ssrindex * (ssrtacarg * ssrtac option) *)
+
+let pr_seqtacarg prt = function
+  | (is_first, []), _ -> str (if is_first then "first" else "last")
+  | tac, Some dtac ->
+    hv 0 (pr_hintarg prt tac ++ spc() ++ str "|| " ++ prt tacltop dtac)
+  | tac, _ -> pr_hintarg prt tac
+
+let pr_ssrseqarg _ _ prt = function
+  | ArgArg 0, tac -> pr_seqtacarg prt tac
+  | i, tac -> pr_index i ++ str " " ++ pr_seqtacarg prt tac
+
+(* We must parse the index separately to resolve the conflict with *)
+(* an unindexed tactic.                                            *)
+ARGUMENT EXTEND ssrseqarg TYPED AS ssrindex * (ssrhintarg * tactic option)
+                          PRINTED BY pr_ssrseqarg
+| [ "YouShouldNotTypeThis" ] -> [ anomaly "Grammar placeholder match" ]
+END
+
+let sq_brace_tacnames =
+   ["first"; "solve"; "do"; "rewrite"; "have"; "suffices"; "wlog"]
+   (* "by" is a keyword *)
+let accept_ssrseqvar strm =
+  match stream_nth 0 strm with
+  | Tok.IDENT id when not (List.mem id sq_brace_tacnames) ->
+     accept_before_syms_or_ids ["["] ["first";"last"] strm
+  | _ -> raise Stream.Failure
+
+let test_ssrseqvar = Gram.Entry.of_parser "test_ssrseqvar" accept_ssrseqvar
+
+let swaptacarg (loc, b) = (b, []), Some (TacId [])
+
+let check_seqtacarg dir arg = match snd arg, dir with
+  | ((true, []), Some (TacAtom (loc, _))), L2R ->
+    CErrors.user_err ?loc (str "expected \"last\"")
+  | ((false, []), Some (TacAtom (loc, _))), R2L ->
+    CErrors.user_err ?loc (str "expected \"first\"")
+  | _, _ -> arg
+
+let ssrorelse = Gram.entry_create "ssrorelse"
+GEXTEND Gram
+  GLOBAL: ssrorelse ssrseqarg;
+  ssrseqidx: [
+    [ test_ssrseqvar; id = Prim.ident -> ArgVar (Loc.tag ~loc:!@loc id)
+    | n = Prim.natural -> ArgArg (check_index ~loc:!@loc n)
+    ] ];
+  ssrswap: [[ IDENT "first" -> !@loc, true | IDENT "last" -> !@loc, false ]];
+  ssrorelse: [[ "||"; tac = tactic_expr LEVEL "2" -> tac ]];
+  ssrseqarg: [
+    [ arg = ssrswap -> noindex, swaptacarg arg
+    | i = ssrseqidx; tac = ssrortacarg; def = OPT ssrorelse -> i, (tac, def)
+    | i = ssrseqidx; arg = ssrswap -> i, swaptacarg arg
+    | tac = tactic_expr LEVEL "3" -> noindex, (mk_hint tac, None)
+    ] ];
+END
+
+let tactic_expr = Pltac.tactic_expr
+
+(** 1. Utilities *)
+
+(** Tactic-level diagnosis *)
+
+(* debug *)
+
+(* Let's play with the new proof engine API *)
+let old_tac = Proofview.V82.tactic
+
+
+(** Name generation {{{ *******************************************************)
+
+(* Since Coq now does repeated internal checks of its external lexical *)
+(* rules, we now need to carve ssreflect reserved identifiers out of   *)
+(* out of the user namespace. We use identifiers of the form _id_ for  *)
+(* this purpose, e.g., we "anonymize" an identifier id as _id_, adding *)
+(* an extra leading _ if this might clash with an internal identifier. *)
+(*    We check for ssreflect identifiers in the ident grammar rule;    *)
+(* when the ssreflect Module is present this is normally an error,     *)
+(* but we provide a compatibility flag to reduce this to a warning.    *)
+
+let ssr_reserved_ids = Summary.ref ~name:"SSR:idents" true
+
+let _ =
+  Goptions.declare_bool_option
+    { Goptions.optname  = "ssreflect identifiers";
+      Goptions.optkey   = ["SsrIdents"];
+      Goptions.optdepr  = false;
+      Goptions.optread  = (fun _ -> !ssr_reserved_ids);
+      Goptions.optwrite = (fun b -> ssr_reserved_ids := b)
+    }
+
+let is_ssr_reserved s =
+  let n = String.length s in n > 2 && s.[0] = '_' && s.[n - 1] = '_'
+
+let ssr_id_of_string loc s =
+  if is_ssr_reserved s && is_ssr_loaded () then begin
+    if !ssr_reserved_ids then
+      CErrors.user_err ~loc (str ("The identifier " ^ s ^ " is reserved."))
+    else if is_internal_name s then
+      Feedback.msg_warning (str ("Conflict between " ^ s ^ " and ssreflect internal names."))
+    else Feedback.msg_warning (str (
+     "The name " ^ s ^ " fits the _xxx_ format used for anonymous variables.\n"
+  ^ "Scripts with explicit references to anonymous variables are fragile."))
+    end; Id.of_string s
+
+let ssr_null_entry = Gram.Entry.of_parser "ssr_null" (fun _ -> ())
+
+let (!@) = Pcoq.to_coqloc
+
+GEXTEND Gram 
+  GLOBAL: Prim.ident;
+  Prim.ident: [[ s = IDENT; ssr_null_entry -> ssr_id_of_string !@loc s ]];
+END
+
+let perm_tag = "_perm_Hyp_"
+let _ = add_internal_name (is_tagged perm_tag)
+  
+(* }}} *)
+
+(* We must not anonymize context names discharged by the "in" tactical. *)
+
+(** Tactical extensions. {{{ **************************************************)
+
+(* The TACTIC EXTEND facility can't be used for defining new user   *)
+(* tacticals, because:                                              *)
+(*  - the concrete syntax must start with a fixed string            *)
+(*   We use the following workaround:                               *)
+(*  - We use the (unparsable) "YouShouldNotTypeThis"  token for tacticals that      *)
+(*    don't start with a token, then redefine the grammar and       *)
+(*    printer using GEXTEND and set_pr_ssrtac, respectively.        *)
+
+type ssrargfmt = ArgSsr of string | ArgSep of string
+
+let ssrtac_name name = {
+  mltac_plugin = "ssreflect_plugin";
+  mltac_tactic = "ssr" ^ name;
+}
+
+let ssrtac_entry name n = {
+  mltac_name = ssrtac_name name; 
+  mltac_index = n;
+}
+
+let set_pr_ssrtac name prec afmt = (* FIXME *) () (*
+  let fmt = List.map (function
+    | ArgSep s -> Egramml.GramTerminal s
+    | ArgSsr s -> Egramml.GramTerminal s
+    | ArgCoq at -> Egramml.GramTerminal "COQ_ARG") afmt in
+  let tacname = ssrtac_name name in () *)
+
+let ssrtac_atom ?loc name args = TacML (Loc.tag ?loc (ssrtac_entry name 0, args))
+let ssrtac_expr ?loc name args = ssrtac_atom ?loc name args
+
+let tclintros_expr ?loc tac ipats =
+  let args = [Tacexpr.TacGeneric (in_gen (rawwit wit_ssrintrosarg) (tac, ipats))] in
+  ssrtac_expr ?loc "tclintros" args
+
+GEXTEND Gram
+  GLOBAL: tactic_expr;
+  tactic_expr: LEVEL "1" [ RIGHTA
+    [ tac = tactic_expr; intros = ssrintros_ne -> tclintros_expr ~loc:!@loc tac intros
+    ] ];
+END
+
+(* }}} *)
+
+
+(** Bracketing tactical *)
+
+(* The tactic pretty-printer doesn't know that some extended tactics *)
+(* are actually tacticals. To prevent it from improperly removing    *)
+(* parentheses we override the parsing rule for bracketed tactic     *)
+(* expressions so that the pretty-print always reflects the input.   *)
+(* (Removing user-specified parentheses is dubious anyway).          *)
+
+GEXTEND Gram
+  GLOBAL: tactic_expr;
+  ssrparentacarg: [[ "("; tac = tactic_expr; ")" -> Loc.tag ~loc:!@loc (Tacexp tac) ]];
+  tactic_expr: LEVEL "0" [[ arg = ssrparentacarg -> TacArg arg ]];
+END
+
+(** The internal "done" and "ssrautoprop" tactics. *)
+
+(* For additional flexibility, "done" and "ssrautoprop" are  *)
+(* defined in Ltac.                                          *)
+(* Although we provide a default definition in ssreflect,    *)
+(* we look up the definition dynamically at each call point, *)
+(* to allow for user extensions. "ssrautoprop" defaults to   *)
+(* trivial.                                                  *)
+
+let ssrautoprop gl =
+  try 
+    let tacname = 
+      try Nametab.locate_tactic (qualid_of_ident (Id.of_string "ssrautoprop"))
+      with Not_found -> Nametab.locate_tactic (ssrqid "ssrautoprop") in
+    let tacexpr = Loc.tag @@ Tacexpr.Reference (ArgArg (Loc.tag @@ tacname)) in
+    Proofview.V82.of_tactic (eval_tactic (Tacexpr.TacArg tacexpr)) gl
+  with Not_found -> Proofview.V82.of_tactic (Auto.full_trivial []) gl
+
+let () = ssrautoprop_tac := ssrautoprop
+
+let tclBY tac = tclTHEN tac (donetac ~-1)
+
+(** Tactical arguments. *)
+
+(* We have four kinds: simple tactics, [|]-bracketed lists, hints, and swaps *)
+(* The latter two are used in forward-chaining tactics (have, suffice, wlog) *)
+(* and subgoal reordering tacticals (; first & ; last), respectively.        *)
+
+(* Force use of the tactic_expr parsing entry, to rule out tick marks. *)
+
+(** The "by" tactical. *)
+
+
+open Ssrfwd
+
+TACTIC EXTEND ssrtclby
+| [ "by" ssrhintarg(tac) ] -> [ Proofview.V82.tactic (hinttac ist true tac) ]
+END
+
+(* }}} *)
+(* We can't parse "by" in ARGUMENT EXTEND because it will only be made *)
+(* into a keyword in ssreflect.v; so we anticipate this in GEXTEND.    *)
+
+GEXTEND Gram
+  GLOBAL: ssrhint simple_tactic;
+  ssrhint: [[ "by"; arg = ssrhintarg -> arg ]];
+END
+
+open Ssripats
+
+(** The "do" tactical. ********************************************************)
+
+(*
+type ssrdoarg = ((ssrindex * ssrmmod) * ssrhint) * ssrclauses
+*)
+TACTIC EXTEND ssrtcldo
+| [ "YouShouldNotTypeThis" "do" ssrdoarg(arg) ] -> [ Proofview.V82.tactic (ssrdotac ist arg) ]
+END
+set_pr_ssrtac "tcldo" 3 [ArgSep "do "; ArgSsr "doarg"]
+
+let ssrdotac_expr ?loc n m tac clauses =
+  let arg = ((n, m), tac), clauses in
+  ssrtac_expr ?loc "tcldo" [Tacexpr.TacGeneric (in_gen (rawwit wit_ssrdoarg) arg)]
+
+GEXTEND Gram
+  GLOBAL: tactic_expr;
+  ssrdotac: [
+    [ tac = tactic_expr LEVEL "3" -> mk_hint tac
+    | tacs = ssrortacarg -> tacs
+  ] ];
+  tactic_expr: LEVEL "3" [ RIGHTA
+    [ IDENT "do"; m = ssrmmod; tac = ssrdotac; clauses = ssrclauses ->
+      ssrdotac_expr ~loc:!@loc noindex m tac clauses
+    | IDENT "do"; tac = ssrortacarg; clauses = ssrclauses ->
+      ssrdotac_expr ~loc:!@loc noindex Once tac clauses
+    | IDENT "do"; n = int_or_var; m = ssrmmod;
+                  tac = ssrdotac; clauses = ssrclauses ->
+      ssrdotac_expr ~loc:!@loc (mk_index ~loc:!@loc n) m tac clauses
+    ] ];
+END
+(* }}} *)
+
+
+(* We can't actually parse the direction separately because this   *)
+(* would introduce conflicts with the basic ltac syntax.           *)
+let pr_ssrseqdir _ _ _ = function
+  | L2R -> str ";" ++ spc () ++ str "first "
+  | R2L -> str ";" ++ spc () ++ str "last "
+
+ARGUMENT EXTEND ssrseqdir TYPED AS ssrdir PRINTED BY pr_ssrseqdir
+| [ "YouShouldNotTypeThis" ] -> [ anomaly "Grammar placeholder match" ]
+END
+
+TACTIC EXTEND ssrtclseq
+| [ "YouShouldNotTypeThis" ssrtclarg(tac) ssrseqdir(dir) ssrseqarg(arg) ] ->
+  [ Proofview.V82.tactic (tclSEQAT ist tac dir arg) ]
+END
+set_pr_ssrtac "tclseq" 5 [ArgSsr "tclarg"; ArgSsr "seqdir"; ArgSsr "seqarg"]
+
+let tclseq_expr ?loc tac dir arg =
+  let arg1 = in_gen (rawwit wit_ssrtclarg) tac in
+  let arg2 = in_gen (rawwit wit_ssrseqdir) dir in
+  let arg3 = in_gen (rawwit wit_ssrseqarg) (check_seqtacarg dir arg) in
+  ssrtac_expr ?loc "tclseq" (List.map (fun x -> Tacexpr.TacGeneric x) [arg1; arg2; arg3])
+
+GEXTEND Gram
+  GLOBAL: tactic_expr;
+  ssr_first: [
+    [ tac = ssr_first; ipats = ssrintros_ne -> tclintros_expr ~loc:!@loc tac ipats
+    | "["; tacl = LIST0 tactic_expr SEP "|"; "]" -> TacFirst tacl
+    ] ];
+  ssr_first_else: [
+    [ tac1 = ssr_first; tac2 = ssrorelse -> TacOrelse (tac1, tac2)
+    | tac = ssr_first -> tac ]];
+  tactic_expr: LEVEL "4" [ LEFTA
+    [ tac1 = tactic_expr; ";"; IDENT "first"; tac2 = ssr_first_else ->
+      TacThen (tac1, tac2)
+    | tac = tactic_expr; ";"; IDENT "first"; arg = ssrseqarg ->
+      tclseq_expr ~loc:!@loc tac L2R arg
+    | tac = tactic_expr; ";"; IDENT "last"; arg = ssrseqarg ->
+      tclseq_expr ~loc:!@loc tac R2L arg
+    ] ];
+END
+(* }}} *)
+
+(** 5. Bookkeeping tactics (clear, move, case, elim) *)
+
+(** Generalization (discharge) item *)
+
+(* An item is a switch + term pair.                                     *)
+
+(* type ssrgen = ssrdocc * ssrterm *)
+
+let pr_gen (docc, dt) = pr_docc docc ++ pr_cpattern dt
+
+let pr_ssrgen _ _ _ = pr_gen
+
+ARGUMENT EXTEND ssrgen TYPED AS ssrdocc * cpattern PRINTED BY pr_ssrgen
+| [ ssrdocc(docc) cpattern(dt) ] -> [ docc, dt ]
+| [ cpattern(dt) ] -> [ nodocc, dt ]
+END
+
+let has_occ ((_, occ), _) = occ <> None
+
+(** Generalization (discharge) sequence *)
+
+(* A discharge sequence is represented as a list of up to two   *)
+(* lists of d-items, plus an ident list set (the possibly empty *)
+(* final clear switch). The main list is empty iff the command  *)
+(* is defective, and has length two if there is a sequence of   *)
+(* dependent terms (and in that case it is the first of the two *)
+(* lists). Thus, the first of the two lists is never empty.     *)
+
+(* type ssrgens = ssrgen list *)
+(* type ssrdgens = ssrgens list * ssrclear *)
+
+let gens_sep = function [], [] -> mt | _ -> spc
+
+let pr_dgens pr_gen (gensl, clr) =
+  let prgens s gens = str s ++ pr_list spc pr_gen gens in
+  let prdeps deps = prgens ": " deps ++ spc () ++ str "/" in
+  match gensl with
+  | [deps; []] -> prdeps deps ++ pr_clear pr_spc clr
+  | [deps; gens] -> prdeps deps ++ prgens " " gens ++ pr_clear spc clr
+  | [gens] -> prgens ": " gens ++ pr_clear spc clr
+  | _ -> pr_clear pr_spc clr
+
+let pr_ssrdgens _ _ _ = pr_dgens pr_gen
+
+let cons_gen gen = function
+  | gens :: gensl, clr -> (gen :: gens) :: gensl, clr
+  | _ -> anomaly "missing gen list"
+
+let cons_dep (gensl, clr) =
+  if List.length gensl = 1 then ([] :: gensl, clr) else
+  CErrors.user_err (Pp.str "multiple dependents switches '/'")
+
+ARGUMENT EXTEND ssrdgens_tl TYPED AS ssrgen list list * ssrclear
+                            PRINTED BY pr_ssrdgens
+| [ "{" ne_ssrhyp_list(clr) "}" cpattern(dt) ssrdgens_tl(dgens) ] ->
+  [ cons_gen (mkclr clr, dt) dgens ]
+| [ "{" ne_ssrhyp_list(clr) "}" ] ->
+  [ [[]], clr ]
+| [ "{" ssrocc(occ) "}" cpattern(dt) ssrdgens_tl(dgens) ] ->
+  [ cons_gen (mkocc occ, dt) dgens ]
+| [ "/" ssrdgens_tl(dgens) ] ->
+  [ cons_dep dgens ]
+| [ cpattern(dt) ssrdgens_tl(dgens) ] ->
+  [ cons_gen (nodocc, dt) dgens ]
+| [ ] ->
+  [ [[]], [] ]
+END
+
+ARGUMENT EXTEND ssrdgens TYPED AS ssrdgens_tl PRINTED BY pr_ssrdgens
+| [ ":" ssrgen(gen) ssrdgens_tl(dgens) ] -> [ cons_gen gen dgens ]
+END
+
+(** Equations *)
+
+(* argument *)
+
+let pr_eqid = function Some pat -> str " " ++ pr_ipat pat | None -> mt ()
+let pr_ssreqid _ _ _ = pr_eqid
+
+(* We must use primitive parsing here to avoid conflicts with the  *)
+(* basic move, case, and elim tactics.                             *)
+ARGUMENT EXTEND ssreqid TYPED AS ssripatrep option PRINTED BY pr_ssreqid
+| [ "YouShouldNotTypeThis" ] -> [ anomaly "Grammar placeholder match" ]
+END
+
+let accept_ssreqid strm =
+  match Util.stream_nth 0 strm with
+  | Tok.IDENT _ -> accept_before_syms [":"] strm
+  | Tok.KEYWORD ":" -> ()
+  | Tok.KEYWORD pat when List.mem pat ["_"; "?"; "->"; "<-"] ->
+                      accept_before_syms [":"] strm
+  | _ -> raise Stream.Failure
+
+let test_ssreqid = Gram.Entry.of_parser "test_ssreqid" accept_ssreqid
+
+GEXTEND Gram
+  GLOBAL: ssreqid;
+  ssreqpat: [
+    [ id = Prim.ident -> IPatId id
+    | "_" -> IPatAnon Drop
+    | "?" -> IPatAnon One
+    | occ = ssrdocc; "->" -> (match occ with
+      | None, occ -> IPatRewrite (occ, L2R)
+      | _ -> CErrors.user_err ~loc:!@loc (str"Only occurrences are allowed here"))
+    | occ = ssrdocc; "<-" -> (match occ with
+      | None, occ ->  IPatRewrite (occ, R2L)
+      | _ -> CErrors.user_err ~loc:!@loc (str "Only occurrences are allowed here"))
+    | "->" -> IPatRewrite (allocc, L2R)
+    | "<-" -> IPatRewrite (allocc, R2L)
+    ]];
+  ssreqid: [
+    [ test_ssreqid; pat = ssreqpat -> Some pat
+    | test_ssreqid -> None
+    ]];
+END
+
+(** Bookkeeping (discharge-intro) argument *)
+
+(* Since all bookkeeping ssr commands have the same discharge-intro    *)
+(* argument format we use a single grammar entry point to parse them.  *)
+(* the entry point parses only non-empty arguments to avoid conflicts  *)
+(* with the basic Coq tactics.                                         *)
+
+(* type ssrarg = ssrview * (ssreqid * (ssrdgens * ssripats)) *)
+
+let pr_ssrarg _ _ _ (view, (eqid, (dgens, ipats))) =
+  let pri = pr_intros (gens_sep dgens) in
+  pr_view view ++ pr_eqid eqid ++ pr_dgens pr_gen dgens ++ pri ipats
+
+ARGUMENT EXTEND ssrarg TYPED AS ssrview * (ssreqid * (ssrdgens * ssrintros))
+   PRINTED BY pr_ssrarg
+| [ ssrview(view) ssreqid(eqid) ssrdgens(dgens) ssrintros(ipats) ] ->
+  [ view, (eqid, (dgens, ipats)) ]
+| [ ssrview(view) ssrclear(clr) ssrintros(ipats) ] ->
+  [ view, (None, (([], clr), ipats)) ]
+| [ ssreqid(eqid) ssrdgens(dgens) ssrintros(ipats) ] ->
+  [ [], (eqid, (dgens, ipats)) ]
+| [ ssrclear_ne(clr) ssrintros(ipats) ] ->
+  [ [], (None, (([], clr), ipats)) ]
+| [ ssrintros_ne(ipats) ] ->
+  [ [], (None, (([], []), ipats)) ]
+END
+
+(** The "clear" tactic *)
+
+(* We just add a numeric version that clears the n top assumptions. *)
+
+let poptac ist n = introstac ~ist (List.init n (fun _ -> IPatAnon Drop))
+
+TACTIC EXTEND ssrclear
+  | [ "clear" natural(n) ] -> [ Proofview.V82.tactic (poptac ist n) ]
+END
+
+(** The "move" tactic *)
+
+(* TODO: review this, in particular the => _ and => [] cases *)
+let rec improper_intros = function
+  | IPatSimpl _ :: ipats -> improper_intros ipats
+  | (IPatId _ | IPatAnon _ | IPatCase _) :: _ -> false
+  | _ -> true (* FIXME *)
+
+let check_movearg = function
+  | view, (eqid, _) when view <> [] && eqid <> None ->
+    CErrors.user_err (Pp.str "incompatible view and equation in move tactic")
+  | view, (_, (([gen :: _], _), _)) when view <> [] && has_occ gen ->
+    CErrors.user_err (Pp.str "incompatible view and occurrence switch in move tactic")
+  | _, (_, ((dgens, _), _)) when List.length dgens > 1 ->
+    CErrors.user_err (Pp.str "dependents switch `/' in move tactic")
+  | _, (eqid, (_, ipats)) when eqid <> None && improper_intros ipats ->
+    CErrors.user_err (Pp.str "no proper intro pattern for equation in move tactic")
+  | arg -> arg
+
+ARGUMENT EXTEND ssrmovearg TYPED AS ssrarg PRINTED BY pr_ssrarg
+| [ ssrarg(arg) ] -> [ check_movearg arg ]
+END
+
+
+
+TACTIC EXTEND ssrmove
+| [ "move" ssrmovearg(arg) ssrrpat(pat) ] ->
+  [ Proofview.V82.tactic (tclTHEN (ssrmovetac ist arg) (introstac ~ist [pat])) ]
+| [ "move" ssrmovearg(arg) ssrclauses(clauses) ] ->
+  [ Proofview.V82.tactic (tclCLAUSES ist (ssrmovetac ist arg) clauses) ]
+| [ "move" ssrrpat(pat) ] -> [ Proofview.V82.tactic (introstac ~ist [pat]) ]
+| [ "move" ] -> [ Proofview.V82.tactic (movehnftac) ]
+END
+
+let check_casearg = function
+| view, (_, (([_; gen :: _], _), _)) when view <> [] && has_occ gen ->
+  CErrors.user_err (Pp.str "incompatible view and occurrence switch in dependent case tactic")
+| arg -> arg
+
+ARGUMENT EXTEND ssrcasearg TYPED AS ssrarg PRINTED BY pr_ssrarg
+| [ ssrarg(arg) ] -> [ check_casearg arg ]
+END
+
+
+TACTIC EXTEND ssrcase
+| [ "case" ssrcasearg(arg) ssrclauses(clauses) ] ->
+  [ old_tac (tclCLAUSES ist (ssrcasetac ist arg) clauses) ]
+| [ "case" ] -> [ old_tac (with_fresh_ctx (with_top (ssrscasetac false))) ]
+END
+
+(** The "elim" tactic *)
+
+(* Elim views are elimination lemmas, so the eliminated term is not addded *)
+(* to the dependent terms as for "case", unless it actually occurs in the  *)
+(* goal, the "all occurrences" {+} switch is used, or the equation switch  *)
+(* is used and there are no dependents.                                    *)
+
+let ssrelimtac ist (view, (eqid, (dgens, ipats))) =
+  let ndefectelimtac view eqid ipats deps gen ist gl =
+    let elim = match view with [v] -> Some (snd(force_term ist gl v)) | _ -> None in
+    ssrelim ~ist deps (`EGen gen) ?elim eqid (elim_intro_tac ipats) gl
+  in
+  with_dgens dgens (ndefectelimtac view eqid ipats) ist 
+
+TACTIC EXTEND ssrelim
+| [ "elim" ssrarg(arg) ssrclauses(clauses) ] ->
+  [ old_tac (tclCLAUSES ist (ssrelimtac ist arg) clauses) ]
+| [ "elim" ] -> [ old_tac (with_fresh_ctx (with_top elimtac)) ]
+END
+
+(** 6. Backward chaining tactics: apply, exact, congr. *)
+
+(** The "apply" tactic *)
+
+let pr_agen (docc, dt) = pr_docc docc ++ pr_term dt
+let pr_ssragen _ _ _ = pr_agen
+let pr_ssragens _ _ _ = pr_dgens pr_agen
+
+ARGUMENT EXTEND ssragen TYPED AS ssrdocc * ssrterm PRINTED BY pr_ssragen
+| [ "{" ne_ssrhyp_list(clr) "}" ssrterm(dt) ] -> [ mkclr clr, dt ]
+| [ ssrterm(dt) ] -> [ nodocc, dt ]
+END
+
+ARGUMENT EXTEND ssragens TYPED AS ssragen list list * ssrclear 
+PRINTED BY pr_ssragens
+| [ "{" ne_ssrhyp_list(clr) "}" ssrterm(dt) ssragens(agens) ] ->
+  [ cons_gen (mkclr clr, dt) agens ]
+| [ "{" ne_ssrhyp_list(clr) "}" ] -> [ [[]], clr]
+| [ ssrterm(dt) ssragens(agens) ] ->
+  [ cons_gen (nodocc, dt) agens ]
+| [ ] -> [ [[]], [] ]
+END
+
+let mk_applyarg views agens intros = views, (None, (agens, intros))
+
+let pr_ssraarg _ _ _ (view, (eqid, (dgens, ipats))) =
+  let pri = pr_intros (gens_sep dgens) in
+  pr_view view ++ pr_eqid eqid ++ pr_dgens pr_agen dgens ++ pri ipats
+
+ARGUMENT EXTEND ssrapplyarg 
+TYPED AS ssrview * (ssreqid * (ssragens * ssrintros))
+PRINTED BY pr_ssraarg
+| [ ":" ssragen(gen) ssragens(dgens) ssrintros(intros) ] ->
+  [ mk_applyarg [] (cons_gen gen dgens) intros ]
+| [ ssrclear_ne(clr) ssrintros(intros) ] ->
+  [ mk_applyarg [] ([], clr) intros ]
+| [ ssrintros_ne(intros) ] ->
+  [ mk_applyarg [] ([], []) intros ]
+| [ ssrview(view) ":" ssragen(gen) ssragens(dgens) ssrintros(intros) ] ->
+  [ mk_applyarg view (cons_gen gen dgens) intros ]
+| [ ssrview(view) ssrclear(clr) ssrintros(intros) ] ->
+  [ mk_applyarg view ([], clr) intros ]
+    END
+
+TACTIC EXTEND ssrapply
+| [ "apply" ssrapplyarg(arg) ] -> [ Proofview.V82.tactic (ssrapplytac ist arg) ]
+| [ "apply" ] -> [ Proofview.V82.tactic apply_top_tac ]
+END
+
+(** The "exact" tactic *)
+
+let mk_exactarg views dgens = mk_applyarg views dgens []
+
+ARGUMENT EXTEND ssrexactarg TYPED AS ssrapplyarg PRINTED BY pr_ssraarg
+| [ ":" ssragen(gen) ssragens(dgens) ] ->
+  [ mk_exactarg [] (cons_gen gen dgens) ]
+| [ ssrview(view) ssrclear(clr) ] ->
+  [ mk_exactarg view ([], clr) ]
+| [ ssrclear_ne(clr) ] ->
+  [ mk_exactarg [] ([], clr) ]
+END
+
+let vmexacttac pf =
+  Proofview.Goal.nf_enter begin fun gl ->
+  exact_no_check (EConstr.mkCast (pf, VMcast, Tacmach.New.pf_concl gl))
+  end
+
+TACTIC EXTEND ssrexact
+| [ "exact" ssrexactarg(arg) ] -> [ Proofview.V82.tactic (tclBY (ssrapplytac ist arg)) ]
+| [ "exact" ] -> [ Proofview.V82.tactic (tclORELSE (donetac ~-1) (tclBY apply_top_tac)) ]
+| [ "exact" "<:" lconstr(pf) ] -> [ vmexacttac pf ]
+END
+
+(** The "congr" tactic *)
+
+(* type ssrcongrarg = open_constr * (int * constr) *)
+
+let pr_ssrcongrarg _ _ _ ((n, f), dgens) =
+  (if n <= 0 then mt () else str " " ++ int n) ++
+  str " " ++ pr_term f ++ pr_dgens pr_gen dgens
+
+ARGUMENT EXTEND ssrcongrarg TYPED AS (int * ssrterm) * ssrdgens
+  PRINTED BY pr_ssrcongrarg
+| [ natural(n) constr(c) ssrdgens(dgens) ] -> [ (n, mk_term xNoFlag c), dgens ]
+| [ natural(n) constr(c) ] -> [ (n, mk_term xNoFlag c),([[]],[]) ]
+| [ constr(c) ssrdgens(dgens) ] -> [ (0, mk_term xNoFlag c), dgens ]
+| [ constr(c) ] -> [ (0, mk_term xNoFlag c), ([[]],[]) ]
+END
+
+
+
+TACTIC EXTEND ssrcongr
+| [ "congr" ssrcongrarg(arg) ] ->
+[ let arg, dgens = arg in
+  Proofview.V82.tactic begin
+    match dgens with
+    | [gens], clr -> tclTHEN (genstac (gens,clr) ist) (newssrcongrtac arg ist)
+    | _ -> errorstrm (str"Dependent family abstractions not allowed in congr")
+  end]
+END
+
+(** 7. Rewriting tactics (rewrite, unlock) *)
+
+(** Coq rewrite compatibility flag *)
+
+(** Rewrite clear/occ switches *)
+
+let pr_rwocc = function
+  | None, None -> mt ()
+  | None, occ -> pr_occ occ
+  | Some clr,  _ ->  pr_clear_ne clr
+
+let pr_ssrrwocc _ _ _ = pr_rwocc
+
+ARGUMENT EXTEND ssrrwocc TYPED AS ssrdocc PRINTED BY pr_ssrrwocc
+| [ "{" ssrhyp_list(clr) "}" ] -> [ mkclr clr ]
+| [ "{" ssrocc(occ) "}" ] -> [ mkocc occ ]
+| [ ] -> [ noclr ]
+END
+
+(** Rewrite rules *)
+
+let pr_rwkind = function
+  | RWred s -> pr_simpl s
+  | RWdef -> str "/"
+  | RWeq -> mt ()
+
+let wit_ssrrwkind = add_genarg "ssrrwkind" pr_rwkind
+
+let pr_rule = function
+  | RWred s, _ -> pr_simpl s
+  | RWdef, r-> str "/" ++ pr_term r
+  | RWeq, r -> pr_term r
+
+let pr_ssrrule _ _ _ = pr_rule
+
+let noruleterm loc = mk_term xNoFlag (mkCProp loc)
+
+ARGUMENT EXTEND ssrrule_ne TYPED AS ssrrwkind * ssrterm PRINTED BY pr_ssrrule
+  | [ "YouShouldNotTypeThis" ] -> [ anomaly "Grammar placeholder match" ]
+END
+
+GEXTEND Gram
+  GLOBAL: ssrrule_ne;
+  ssrrule_ne : [
+    [ test_not_ssrslashnum; x =
+        [ "/"; t = ssrterm -> RWdef, t
+        | t = ssrterm -> RWeq, t 
+        | s = ssrsimpl_ne -> RWred s, noruleterm (Some !@loc)
+        ] -> x
+    | s = ssrsimpl_ne -> RWred s, noruleterm (Some !@loc)
+  ]];
+END
+
+ARGUMENT EXTEND ssrrule TYPED AS ssrrule_ne PRINTED BY pr_ssrrule
+  | [ ssrrule_ne(r) ] -> [ r ]
+  | [ ] -> [ RWred Nop, noruleterm (Some loc) ]
+END
+
+(** Rewrite arguments *)
+
+let pr_option f = function None -> mt() | Some x -> f x
+let pr_pattern_squarep= pr_option (fun r -> str "[" ++ pr_rpattern r ++ str "]")
+let pr_ssrpattern_squarep _ _ _ = pr_pattern_squarep
+let pr_rwarg ((d, m), ((docc, rx), r)) =
+  pr_rwdir d ++ pr_mult m ++ pr_rwocc docc ++ pr_pattern_squarep rx ++ pr_rule r
+
+let pr_ssrrwarg _ _ _ = pr_rwarg
+
+ARGUMENT EXTEND ssrpattern_squarep
+TYPED AS rpattern option PRINTED BY pr_ssrpattern_squarep
+  | [ "[" rpattern(rdx) "]" ] -> [ Some rdx ]
+  | [ ] -> [ None ]
+END
+
+ARGUMENT EXTEND ssrpattern_ne_squarep
+TYPED AS rpattern option PRINTED BY pr_ssrpattern_squarep
+  | [ "[" rpattern(rdx) "]" ] -> [ Some rdx ]
+END
+
+
+ARGUMENT EXTEND ssrrwarg
+  TYPED AS (ssrdir * ssrmult) * ((ssrdocc * rpattern option) * ssrrule)
+  PRINTED BY pr_ssrrwarg
+  | [ "-" ssrmult(m) ssrrwocc(docc) ssrpattern_squarep(rx) ssrrule_ne(r) ] ->
+    [ mk_rwarg (R2L, m) (docc, rx) r ]
+  | [ "-/" ssrterm(t) ] ->     (* just in case '-/' should become a token *)
+    [ mk_rwarg (R2L, nomult) norwocc (RWdef, t) ]
+  | [ ssrmult_ne(m) ssrrwocc(docc) ssrpattern_squarep(rx) ssrrule_ne(r) ] ->
+    [ mk_rwarg (L2R, m) (docc, rx) r ]
+  | [ "{" ne_ssrhyp_list(clr) "}" ssrpattern_ne_squarep(rx) ssrrule_ne(r) ] ->
+    [ mk_rwarg norwmult (mkclr clr, rx) r ]
+  | [ "{" ne_ssrhyp_list(clr) "}" ssrrule(r) ] ->
+    [ mk_rwarg norwmult (mkclr clr, None) r ]
+  | [ "{" ssrocc(occ) "}" ssrpattern_squarep(rx) ssrrule_ne(r) ] ->
+    [ mk_rwarg norwmult (mkocc occ, rx) r ]
+  | [ "{" "}" ssrpattern_squarep(rx) ssrrule_ne(r) ] ->
+    [ mk_rwarg norwmult (nodocc, rx) r ]
+  | [ ssrpattern_ne_squarep(rx) ssrrule_ne(r) ] ->
+    [ mk_rwarg norwmult (noclr, rx) r ]
+  | [ ssrrule_ne(r) ] ->
+    [ mk_rwarg norwmult norwocc r ]
+END
+
+TACTIC EXTEND ssrinstofruleL2R
+| [ "ssrinstancesofruleL2R" ssrterm(arg) ] -> [ Proofview.V82.tactic (ssrinstancesofrule ist L2R arg) ]
+END
+TACTIC EXTEND ssrinstofruleR2L
+| [ "ssrinstancesofruleR2L" ssrterm(arg) ] -> [ Proofview.V82.tactic (ssrinstancesofrule ist R2L arg) ]
+END
+
+(** Rewrite argument sequence *)
+
+(* type ssrrwargs = ssrrwarg list *)
+
+let pr_ssrrwargs _ _ _ rwargs = pr_list spc pr_rwarg rwargs
+
+ARGUMENT EXTEND ssrrwargs TYPED AS ssrrwarg list PRINTED BY pr_ssrrwargs
+  | [ "YouShouldNotTypeThis" ] -> [ anomaly "Grammar placeholder match" ]
+END
+
+let ssr_rw_syntax = Summary.ref ~name:"SSR:rewrite" true
+
+let _ =
+  Goptions.declare_bool_option
+    { Goptions.optname  = "ssreflect rewrite";
+      Goptions.optkey   = ["SsrRewrite"];
+      Goptions.optread  = (fun _ -> !ssr_rw_syntax);
+      Goptions.optdepr  = false;
+      Goptions.optwrite = (fun b -> ssr_rw_syntax := b) }
+
+let test_ssr_rw_syntax =
+  let test strm  =
+    if not !ssr_rw_syntax then raise Stream.Failure else
+    if is_ssr_loaded () then () else
+    match Util.stream_nth 0 strm with
+    | Tok.KEYWORD key when List.mem key.[0] ['{'; '['; '/'] -> ()
+    | _ -> raise Stream.Failure in
+  Gram.Entry.of_parser "test_ssr_rw_syntax" test
+
+GEXTEND Gram
+  GLOBAL: ssrrwargs;
+  ssrrwargs: [[ test_ssr_rw_syntax; a = LIST1 ssrrwarg -> a ]];
+END
+
+(** The "rewrite" tactic *)
+
+TACTIC EXTEND ssrrewrite
+  | [ "rewrite" ssrrwargs(args) ssrclauses(clauses) ] ->
+    [ Proofview.V82.tactic (tclCLAUSES ist (ssrrewritetac ist args) clauses) ]
+END
+
+(** The "unlock" tactic *)
+
+let pr_unlockarg (occ, t) = pr_occ occ ++ pr_term t
+let pr_ssrunlockarg _ _ _ = pr_unlockarg
+
+ARGUMENT EXTEND ssrunlockarg TYPED AS ssrocc * ssrterm
+  PRINTED BY pr_ssrunlockarg
+  | [  "{" ssrocc(occ) "}" ssrterm(t) ] -> [ occ, t ]
+  | [  ssrterm(t) ] -> [ None, t ]
+END
+
+let pr_ssrunlockargs _ _ _ args = pr_list spc pr_unlockarg args
+
+ARGUMENT EXTEND ssrunlockargs TYPED AS ssrunlockarg list
+  PRINTED BY pr_ssrunlockargs
+  | [  ssrunlockarg_list(args) ] -> [ args ]
+END
+
+TACTIC EXTEND ssrunlock
+  | [ "unlock" ssrunlockargs(args) ssrclauses(clauses) ] ->
+[  Proofview.V82.tactic (tclCLAUSES ist (unlocktac ist args) clauses) ]
+END
+
+(** 8. Forward chaining tactics (pose, set, have, suffice, wlog) *)
+
+
+TACTIC EXTEND ssrpose
+| [ "pose" ssrfixfwd(ffwd) ] -> [ Proofview.V82.tactic (ssrposetac ist ffwd) ]
+| [ "pose" ssrcofixfwd(ffwd) ] -> [ Proofview.V82.tactic (ssrposetac ist ffwd) ]
+| [ "pose" ssrfwdid(id) ssrposefwd(fwd) ] -> [ Proofview.V82.tactic (ssrposetac ist (id, fwd)) ]
+END
+
+(** The "set" tactic *)
+
+(* type ssrsetfwd = ssrfwd * ssrdocc *)
+
+TACTIC EXTEND ssrset
+| [ "set" ssrfwdid(id) ssrsetfwd(fwd) ssrclauses(clauses) ] ->
+  [ Proofview.V82.tactic (tclCLAUSES ist (ssrsettac ist id fwd) clauses) ]
+END
+
+(** The "have" tactic *)
+
+(* type ssrhavefwd = ssrfwd * ssrhint *)
+
+
+(* Pltac. *)
+
+(* The standard TACTIC EXTEND does not work for abstract *)
+GEXTEND Gram
+  GLOBAL: tactic_expr;
+  tactic_expr: LEVEL "3"
+    [ RIGHTA [ IDENT "abstract"; gens = ssrdgens ->
+               ssrtac_expr ~loc:!@loc "abstract"
+                [Tacexpr.TacGeneric (Genarg.in_gen (Genarg.rawwit wit_ssrdgens) gens)] ]];
+END
+TACTIC EXTEND ssrabstract
+| [ "abstract" ssrdgens(gens) ] -> [
+    if List.length (fst gens) <> 1 then
+      errorstrm (str"dependents switches '/' not allowed here");
+    Proofview.V82.tactic (ssrabstract ist gens) ]
+END
+
+TACTIC EXTEND ssrhave
+| [ "have" ssrhavefwdwbinders(fwd) ] ->
+  [ Proofview.V82.tactic (havetac ist fwd false false) ]
+END
+
+TACTIC EXTEND ssrhavesuff
+| [ "have" "suff" ssrhpats_nobs(pats) ssrhavefwd(fwd) ] ->
+  [ Proofview.V82.tactic (havetac ist (false,(pats,fwd)) true false) ]
+END
+
+TACTIC EXTEND ssrhavesuffices
+| [ "have" "suffices" ssrhpats_nobs(pats) ssrhavefwd(fwd) ] ->
+  [ Proofview.V82.tactic (havetac ist (false,(pats,fwd)) true false) ]
+END
+
+TACTIC EXTEND ssrsuffhave
+| [ "suff" "have" ssrhpats_nobs(pats) ssrhavefwd(fwd) ] ->
+  [ Proofview.V82.tactic (havetac ist (false,(pats,fwd)) true true) ]
+END
+
+TACTIC EXTEND ssrsufficeshave
+| [ "suffices" "have" ssrhpats_nobs(pats) ssrhavefwd(fwd) ] ->
+  [ Proofview.V82.tactic (havetac ist (false,(pats,fwd)) true true) ]
+END
+
+(** The "suffice" tactic *)
+
+let pr_ssrsufffwdwbinders _ _ prt (hpats, (fwd, hint)) =
+  pr_hpats hpats ++ pr_fwd fwd ++ pr_hint prt hint
+
+ARGUMENT EXTEND ssrsufffwd
+  TYPED AS ssrhpats * (ssrfwd * ssrhint) PRINTED BY pr_ssrsufffwdwbinders
+| [ ssrhpats(pats) ssrbinder_list(bs)  ":" lconstr(t) ssrhint(hint) ] ->
+  [ let ((clr, pats), binders), simpl = pats in
+    let allbs = intro_id_to_binder binders @ bs in
+    let allbinders = binders @ List.flatten (binder_to_intro_id bs) in
+    let fwd = mkFwdHint ":" t in
+    (((clr, pats), allbinders), simpl), (bind_fwd allbs fwd, hint) ]
+END
+
+
+TACTIC EXTEND ssrsuff
+| [ "suff" ssrsufffwd(fwd) ] -> [ Proofview.V82.tactic (sufftac ist fwd) ]
+END
+
+TACTIC EXTEND ssrsuffices
+| [ "suffices" ssrsufffwd(fwd) ] -> [ Proofview.V82.tactic (sufftac ist fwd) ]
+END
+
+(** The "wlog" (Without Loss Of Generality) tactic *)
+
+(* type ssrwlogfwd = ssrwgen list * ssrfwd *)
+
+let pr_ssrwlogfwd _ _ _ (gens, t) =
+  str ":" ++ pr_list mt pr_wgen gens ++ spc() ++ pr_fwd t
+
+ARGUMENT EXTEND ssrwlogfwd TYPED AS ssrwgen list * ssrfwd
+                         PRINTED BY pr_ssrwlogfwd
+| [ ":" ssrwgen_list(gens) "/" lconstr(t) ] -> [ gens, mkFwdHint "/" t]
+END
+
+        
+TACTIC EXTEND ssrwlog
+| [ "wlog" ssrhpats_nobs(pats) ssrwlogfwd(fwd) ssrhint(hint) ] ->
+  [ Proofview.V82.tactic (wlogtac ist pats fwd hint false `NoGen) ]
+END
+
+TACTIC EXTEND ssrwlogs
+| [ "wlog" "suff" ssrhpats_nobs(pats) ssrwlogfwd(fwd) ssrhint(hint) ] ->
+  [ Proofview.V82.tactic (wlogtac ist pats fwd hint true `NoGen) ]
+END
+
+TACTIC EXTEND ssrwlogss
+| [ "wlog" "suffices" ssrhpats_nobs(pats) ssrwlogfwd(fwd) ssrhint(hint) ]->
+  [ Proofview.V82.tactic (wlogtac ist pats fwd hint true `NoGen) ]
+END
+
+TACTIC EXTEND ssrwithoutloss
+| [ "without" "loss" ssrhpats_nobs(pats) ssrwlogfwd(fwd) ssrhint(hint) ] ->
+  [ Proofview.V82.tactic (wlogtac ist pats fwd hint false `NoGen) ]
+END
+
+TACTIC EXTEND ssrwithoutlosss
+| [ "without" "loss" "suff" 
+    ssrhpats_nobs(pats) ssrwlogfwd(fwd) ssrhint(hint) ] ->
+  [ Proofview.V82.tactic (wlogtac ist pats fwd hint true `NoGen) ]
+END
+
+TACTIC EXTEND ssrwithoutlossss
+| [ "without" "loss" "suffices" 
+    ssrhpats_nobs(pats) ssrwlogfwd(fwd) ssrhint(hint) ]->
+  [ Proofview.V82.tactic (wlogtac ist pats fwd hint true `NoGen) ]
+END
+
+(* Generally have *)
+let pr_idcomma _ _ _ = function
+  | None -> mt()
+  | Some None -> str"_, "
+  | Some (Some id) -> pr_id id ++ str", "
+
+ARGUMENT EXTEND ssr_idcomma TYPED AS ident option option PRINTED BY pr_idcomma
+  | [ ] -> [ None ]
+END
+
+let accept_idcomma strm =
+  match stream_nth 0 strm with
+  | Tok.IDENT _ | Tok.KEYWORD "_" -> accept_before_syms [","] strm
+  | _ -> raise Stream.Failure
+
+let test_idcomma = Gram.Entry.of_parser "test_idcomma" accept_idcomma
+
+GEXTEND Gram
+  GLOBAL: ssr_idcomma;
+  ssr_idcomma: [ [ test_idcomma; 
+    ip = [ id = IDENT -> Some (Id.of_string id) | "_" -> None ]; "," ->
+    Some ip
+  ] ];
+END
+
+let augment_preclr clr1 (((clr0, x),y),z) = (((clr1 @ clr0, x),y),z)
+
+TACTIC EXTEND ssrgenhave
+| [ "gen" "have" ssrclear(clr)
+    ssr_idcomma(id) ssrhpats_nobs(pats) ssrwlogfwd(fwd) ssrhint(hint) ] ->
+  [ let pats = augment_preclr clr pats in
+    Proofview.V82.tactic (wlogtac ist pats fwd hint false (`Gen id)) ]
+END
+
+TACTIC EXTEND ssrgenhave2
+| [ "generally" "have" ssrclear(clr)
+    ssr_idcomma(id) ssrhpats_nobs(pats) ssrwlogfwd(fwd) ssrhint(hint) ] ->
+  [ let pats = augment_preclr clr pats in
+    Proofview.V82.tactic (wlogtac ist pats fwd hint false (`Gen id)) ]
+END
+
+(* We wipe out all the keywords generated by the grammar rules we defined. *)
+(* The user is supposed to Require Import ssreflect or Require ssreflect   *)
+(* and Import ssreflect.SsrSyntax to obtain these keywords and as a         *)
+(* consequence the extended ssreflect grammar.                             *)
+let () = CLexer.set_keyword_state frozen_lexer ;;
+
+
+(* vim: set filetype=ocaml foldmethod=marker: *)

--- a/plugins/ssr/ssrparser.mlg
+++ b/plugins/ssr/ssrparser.mlg
@@ -637,6 +637,7 @@ let ipat_of_intro_pattern p = Tactypes.(
     | IntroAction (IntroApplyOn _) -> (* to do *) CErrors.user_err (Pp.str "TO DO")
     | IntroAction (IntroInjection ips) ->
         IPatInj [List.map ipat_of_intro_pattern (List.map remove_loc ips)]
+    | IntroAction (IntroIrrefutablePattern _) -> failwith "TODO"
     | IntroForthcoming _ ->
         (* Unable to determine which kind of ipat interp_introid could
          * return [HH] *)
@@ -701,6 +702,7 @@ let rec add_intro_pattern_hyps ipat hyps =
   | IntroNaming (IntroFresh _) -> []
   | IntroAction (IntroRewrite _) -> hyps
   | IntroAction (IntroInjection ips) -> List.fold_right add_intro_pattern_hyps ips hyps
+  | IntroAction (IntroIrrefutablePattern _) -> failwith "TODO"
   | IntroAction (IntroApplyOn (c,pat)) -> add_intro_pattern_hyps pat hyps
   | IntroForthcoming _ ->
     (* As in ipat_of_intro_pattern, was unable to determine which kind

--- a/pretyping/glob_ops.mli
+++ b/pretyping/glob_ops.mli
@@ -28,7 +28,7 @@ val cases_pattern_eq : 'a cases_pattern_g -> 'a cases_pattern_g -> bool
 exception ComplexSort
 val glob_sort_family : glob_sort -> Sorts.family
 
-val alias_of_pat : 'a cases_pattern_g -> Name.t
+val alias_of_pat : cases_pattern -> Name.t
 
 val set_pat_alias : Id.t -> 'a cases_pattern_g -> 'a cases_pattern_g
 

--- a/proofs/miscprint.ml
+++ b/proofs/miscprint.ml
@@ -14,33 +14,34 @@ open Tactypes
 
 (** Printing of [intro_pattern] *)
 
-let rec pr_intro_pattern prc {CAst.v=pat} = match pat with
+let rec pr_intro_pattern prc prpat {CAst.v=pat} = match pat with
   | IntroForthcoming true -> str "*"
   | IntroForthcoming false -> str "**"
   | IntroNaming p -> pr_intro_pattern_naming p
-  | IntroAction p -> pr_intro_pattern_action prc p
+  | IntroAction p -> pr_intro_pattern_action prc prpat p
 
 and pr_intro_pattern_naming = let open Namegen in function
   | IntroIdentifier id -> Id.print id
   | IntroFresh id -> str "?" ++ Id.print id
   | IntroAnonymous -> str "?"
 
-and pr_intro_pattern_action prc = function
+and pr_intro_pattern_action prc prpat = function
   | IntroWildcard -> str "_"
-  | IntroOrAndPattern pll -> pr_or_and_intro_pattern prc pll
+  | IntroOrAndPattern pll -> pr_or_and_intro_pattern prc prpat pll
   | IntroInjection pl ->
-      str "[=" ++ hv 0 (prlist_with_sep spc (pr_intro_pattern prc) pl) ++
+      str "[=" ++ hv 0 (prlist_with_sep spc (pr_intro_pattern prc prpat) pl) ++
       str "]"
-  | IntroApplyOn ({CAst.v=c},pat) -> pr_intro_pattern prc pat ++ str "%" ++ prc c
+  | IntroIrrefutablePattern cases_patttern -> prpat cases_patttern
+  | IntroApplyOn ({CAst.v=c},pat) -> pr_intro_pattern prc prpat pat ++ str "%" ++ prc c
   | IntroRewrite true -> str "->"
   | IntroRewrite false -> str "<-"
 
-and pr_or_and_intro_pattern prc = function
+and pr_or_and_intro_pattern prc prpat = function
   | IntroAndPattern pl ->
-      str "(" ++ hv 0 (prlist_with_sep pr_comma (pr_intro_pattern prc) pl) ++ str ")"
+      str "(" ++ hv 0 (prlist_with_sep pr_comma (pr_intro_pattern prc prpat) pl) ++ str ")"
   | IntroOrPattern pll ->
       str "[" ++
-      hv 0 (prlist_with_sep pr_bar (prlist_with_sep spc (pr_intro_pattern prc)) pll)
+      hv 0 (prlist_with_sep pr_bar (prlist_with_sep spc (pr_intro_pattern prc prpat)) pll)
       ++ str "]"
 
 (** Printing of bindings *)

--- a/proofs/miscprint.mli
+++ b/proofs/miscprint.mli
@@ -13,10 +13,10 @@ open Tactypes
 (** Printing of [intro_pattern] *)
 
 val pr_intro_pattern :
-  ('a -> Pp.t) -> 'a intro_pattern_expr CAst.t -> Pp.t
+  ('a -> Pp.t) -> ('b -> Pp.t) -> ('a,'b) intro_pattern_expr CAst.t -> Pp.t
 
 val pr_or_and_intro_pattern :
-  ('a -> Pp.t) -> 'a or_and_intro_pattern_expr -> Pp.t
+  ('a -> Pp.t) -> ('b -> Pp.t) -> ('a,'b) or_and_intro_pattern_expr -> Pp.t
 
 val pr_intro_pattern_naming : Namegen.intro_pattern_naming_expr -> Pp.t
 

--- a/proofs/tactypes.ml
+++ b/proofs/tactypes.ml
@@ -16,19 +16,20 @@ open Names
 
 (** Introduction patterns *)
 
-type 'constr intro_pattern_expr =
+type ('constr,'pattern) intro_pattern_expr =
   | IntroForthcoming of bool
   | IntroNaming of Namegen.intro_pattern_naming_expr
-  | IntroAction of 'constr intro_pattern_action_expr
-and 'constr intro_pattern_action_expr =
+  | IntroAction of ('constr,'pattern) intro_pattern_action_expr
+and ('constr,'pattern) intro_pattern_action_expr =
   | IntroWildcard
-  | IntroOrAndPattern of 'constr or_and_intro_pattern_expr
-  | IntroInjection of ('constr intro_pattern_expr) CAst.t list
-  | IntroApplyOn of 'constr CAst.t * 'constr intro_pattern_expr CAst.t
+  | IntroOrAndPattern of ('constr,'pattern) or_and_intro_pattern_expr
+  | IntroInjection of (('constr,'pattern) intro_pattern_expr) CAst.t list
+  | IntroIrrefutablePattern of 'pattern
+  | IntroApplyOn of 'constr CAst.t * ('constr,'pattern) intro_pattern_expr CAst.t
   | IntroRewrite of bool
-and 'constr or_and_intro_pattern_expr =
-  | IntroOrPattern of ('constr intro_pattern_expr) CAst.t list list
-  | IntroAndPattern of ('constr intro_pattern_expr) CAst.t list
+and ('constr,'pattern) or_and_intro_pattern_expr =
+  | IntroOrPattern of (('constr,'pattern) intro_pattern_expr) CAst.t list list
+  | IntroAndPattern of (('constr,'pattern) intro_pattern_expr) CAst.t list
 
 (** Bindings *)
 
@@ -48,7 +49,9 @@ type 'a delayed_open = Environ.env -> Evd.evar_map -> Evd.evar_map * 'a
 type delayed_open_constr = EConstr.constr delayed_open
 type delayed_open_constr_with_bindings = EConstr.constr with_bindings delayed_open
 
-type intro_pattern = delayed_open_constr intro_pattern_expr CAst.t
-type intro_patterns = delayed_open_constr intro_pattern_expr CAst.t list
-type or_and_intro_pattern = delayed_open_constr or_and_intro_pattern_expr CAst.t
+type glob_cases_pattern = lident list * Glob_term.cases_pattern list
+
+type intro_pattern = (delayed_open_constr,glob_cases_pattern) intro_pattern_expr CAst.t
+type intro_patterns = (delayed_open_constr,glob_cases_pattern) intro_pattern_expr CAst.t list
+type or_and_intro_pattern = (delayed_open_constr,glob_cases_pattern) or_and_intro_pattern_expr CAst.t
 type intro_pattern_naming = Namegen.intro_pattern_naming_expr CAst.t

--- a/tactics/inv.ml
+++ b/tactics/inv.ml
@@ -303,7 +303,7 @@ let error_too_many_names pats =
     str "Unexpected " ++
     str (String.plural (List.length pats) "introduction pattern") ++
     str ": " ++ pr_enum (Miscprint.pr_intro_pattern
-                           (fun c -> Printer.pr_econstr_env env sigma (snd (c env (Evd.from_env env))))) pats ++
+                           (fun c -> Printer.pr_econstr_env env sigma (snd (c env (Evd.from_env env)))) (fun (_,c) -> prlist_with_sep pr_spcbar Printer.pr_cases_pattern c)) pats ++
     str ".")
 
 let get_names (allow_conj,issimple) ({CAst.loc;v=pat} as x) = match pat with
@@ -326,6 +326,8 @@ let get_names (allow_conj,issimple) ({CAst.loc;v=pat} as x) = match pat with
         user_err Pp.(str"Nested conjunctive patterns not allowed for inversion equations.")
   | IntroAction (IntroInjection l) ->
       user_err Pp.(str "Injection patterns not allowed for inversion equations.")
+  | IntroAction (IntroIrrefutablePattern _) ->
+      user_err Pp.(str "Kind of patterns not allowed for inversion equations.")
   | IntroAction (IntroOrAndPattern (IntroOrPattern _)) ->
       user_err Pp.(str "Disjunctive patterns not allowed for inversion equations.")
   | IntroAction (IntroApplyOn (c,pat)) ->

--- a/tactics/tacticals.mli
+++ b/tactics/tacticals.mli
@@ -244,13 +244,13 @@ val tclSELECT : ?nosuchgoal:'a tactic -> Goal_select.t -> 'a tactic -> 'a tactic
    error message if |pats| <> |branchsign|; extends them if no pattern is given
    for let-ins in the case of a conjunctive pattern *)
 val get_and_check_or_and_pattern :
-  ?loc:Loc.t -> delayed_open_constr or_and_intro_pattern_expr ->
+  ?loc:Loc.t -> (delayed_open_constr,Tactypes.glob_cases_pattern) or_and_intro_pattern_expr ->
   bool list array -> intro_patterns array
 
 (** Tolerate "[]" to mean a disjunctive pattern of any length *)
 val fix_empty_or_and_pattern : int ->
-  delayed_open_constr or_and_intro_pattern_expr ->
-  delayed_open_constr or_and_intro_pattern_expr
+  (delayed_open_constr,Tactypes.glob_cases_pattern) or_and_intro_pattern_expr ->
+  (delayed_open_constr,Tactypes.glob_cases_pattern) or_and_intro_pattern_expr
 
 val compute_constructor_signatures : Environ.env -> rec_flag:bool -> inductive * 'a -> bool list array
 

--- a/tactics/tactics.mli
+++ b/tactics/tactics.mli
@@ -124,7 +124,7 @@ val intro_patterns_to : evars_flag -> Id.t Logic.move_location -> intro_patterns
   unit Proofview.tactic
 val intro_patterns_bound_to : evars_flag -> int -> Id.t Logic.move_location -> intro_patterns ->
   unit Proofview.tactic
-val intro_pattern_to : evars_flag -> Id.t Logic.move_location -> delayed_open_constr intro_pattern_expr ->
+val intro_pattern_to : evars_flag -> Id.t Logic.move_location -> (delayed_open_constr,Tactypes.glob_cases_pattern) intro_pattern_expr ->
   unit Proofview.tactic
 
 (** Implements user-level "intros", with [] standing for "**" *)


### PR DESCRIPTION
Hi, the idea of an introduction pattern following the `'pat`-style quantification is in the air for some time. This PR is proposing a (very) raw first proof of concept.

Basic example of use:
```coq
Goal forall '(x,y,z), x+y=z.
intros '(x,y,z).
(* x, y, z : nat |- x + y = z *)

Goal forall z, fst z + snd z = 0.
intros '(x,y).
(* x, y : nat |- fst (x, y) + snd (x, y) = 0 *)
```
Of course, one could already imagine further extensions such as, say, `intros '[0 | 1 => tac | _ => auto]`, etc. It seems that there is an avenue for cool things to do around this kind of feature.

It is unclear what is the best way to implement it. At the current time, I went the shortest way just to understand the feasibility (even if there is a huge boilerplate due to the addition of an extra parameter to the type of introduction patterns; probably worth a discussion with @ppedrot on the future of the `tacexpr` code).

I also wondered whether `refine` could have been of some use in this kind of situation. Maybe, but it would first need some improvements of `'pat`, since e.g. `refine (fun '(x,y,z) => _)` currently produces a bit of junk and breaks the left-to-right order: `pat : nat * nat * nat  p : nat * nat  z, x, y : nat |- x + y = z`.

SSReflect developers, would you be interested in discussing at how to get such kind of feature for SSReflect introduction patterns too?