### PR TITLE
Cache evar dependencies, take 2 

### DIFF
--- a/API/API.mli
+++ b/API/API.mli
@@ -2218,6 +2218,7 @@ sig
       evar_filter : Filter.t;
       evar_source : Evar_kinds.t Loc.located;
       evar_candidates : Constr.t list option; (* if not None, list of allowed instances *)
+      evar_dependency_cache : Evar.Set.t option;
       evar_extra : Store.t
     }
 

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -692,7 +692,9 @@ let cache_undefined_evars_of_evar_info ev evd evi =
     (Evar.Set.union
        (match evi.evar_body with
 	 | Evar_empty -> Evar.Set.empty
-	 | Evar_defined b -> undefined_evars_of_term evd (EConstr.of_constr b))
+	 | Evar_defined b ->
+	    (* we assume ev is undefined, so body should not be defined *)
+	    assert false)
        (undefined_evars_of_named_context evd
           (named_context_of_val evi.evar_hyps)))
   in

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -692,9 +692,7 @@ let cache_undefined_evars_of_evar_info ev evd evi =
     (Evar.Set.union
        (match evi.evar_body with
 	 | Evar_empty -> Evar.Set.empty
-	 | Evar_defined b ->
-	    (* we assume ev is undefined, so body should not be defined *)
-	    assert false)
+	 | Evar_defined b -> undefined_evars_of_term evd (EConstr.of_constr b))
        (undefined_evars_of_named_context evd
           (named_context_of_val evi.evar_hyps)))
   in

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -396,6 +396,7 @@ let new_pure_evar sign evd ?(src=default_source) ?(filter = Filter.identity) ?ca
     evar_filter = filter;
     evar_source = src;
     evar_candidates = candidates;
+    evar_dependency_cache = None;
     evar_extra = store; }
   in
   let (evd, newevk) = Evd.new_evar evd ?name evi in
@@ -684,15 +685,37 @@ let undefined_evars_of_named_context evd nc =
     nc
     ~init:Evar.Set.empty
 
-let undefined_evars_of_evar_info evd evi =
+(* compute undefined evars, cache results *) 
+let cache_undefined_evars_of_evar_info ev evd evi =
+  let deps =
   Evar.Set.union (undefined_evars_of_term evd (EConstr.of_constr evi.evar_concl))
     (Evar.Set.union
        (match evi.evar_body with
 	 | Evar_empty -> Evar.Set.empty
 	 | Evar_defined b -> undefined_evars_of_term evd (EConstr.of_constr b))
        (undefined_evars_of_named_context evd
-	  (named_context_of_val evi.evar_hyps)))
+          (named_context_of_val evi.evar_hyps)))
+  in
+  let evi' = { evi with evar_dependency_cache = Some deps } in
+  let evd' = Evd.update_undefined evd ev evi' in
+  (evi',evd')
 
+(* get undefined evars, from cache if possible *)
+let undefined_evars_of_evar_info ev evd evi =
+  let (evi_with_cache,evd_with_cache) =
+    match evi.evar_dependency_cache with
+    | None -> (* initially populate dependency cache *)
+       cache_undefined_evars_of_evar_info ev evd evi
+  | Some cache -> (* update dependency cache *)
+     (* some evars may have become defined, so repopulate cache *)
+     let cache_invalid = Evar.Set.exists (fun evar -> Evd.is_defined evd evar) cache in
+     if cache_invalid then
+       cache_undefined_evars_of_evar_info ev evd evi
+     else (evi,evd)
+  in
+  (* invariant: always have a cache here *)
+  (Option.get evi_with_cache.evar_dependency_cache,evd_with_cache)
+    
 (* spiwack: this is a more complete version of
    {!Termops.occur_evar}. The latter does not look recursively into an
    [evar_map]. If unification only need to check superficially, tactics

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -713,7 +713,8 @@ let undefined_evars_of_evar_info ev evd evi =
      let cache_invalid = Evar.Set.exists (fun evar -> Evd.is_defined evd evar) cache in
      if cache_invalid then
        cache_undefined_evars_of_evar_info ev evd evi
-     else (evi,evd)
+     else (* cache hit *)
+       (evi,evd)
   in
   (* invariant: always have a cache here *)
   (Option.get evi_with_cache.evar_dependency_cache,evd_with_cache)

--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -124,7 +124,7 @@ val advance : evar_map -> evar -> evar option
 
 val undefined_evars_of_term : evar_map -> constr -> Evar.Set.t
 val undefined_evars_of_named_context : evar_map -> Context.Named.t -> Evar.Set.t
-val undefined_evars_of_evar_info : evar_map -> evar_info -> Evar.Set.t
+val undefined_evars_of_evar_info : evar -> evar_map -> evar_info -> Evar.Set.t * evar_map
 
 (** [occur_evar_upto sigma k c] returns [true] if [k] appears in
     [c]. It looks up recursively in [sigma] for the value of existential

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -142,6 +142,7 @@ type evar_info = {
   evar_filter : Filter.t;
   evar_source : Evar_kinds.t Loc.located;
   evar_candidates : constr list option; (* if not None, list of allowed instances *)
+  evar_dependency_cache : Evar.Set.t option;
   evar_extra : Store.t }
 
 let make_evar hyps ccl = {
@@ -151,6 +152,7 @@ let make_evar hyps ccl = {
   evar_filter = Filter.identity;
   evar_source = Loc.tag @@ Evar_kinds.InternalHole;
   evar_candidates = None;
+  evar_dependency_cache = None;
   evar_extra = Store.empty
 }
 
@@ -494,6 +496,8 @@ let find_undefined d e = EvMap.find e d.undf_evars
 let mem d e = EvMap.mem e d.undf_evars || EvMap.mem e d.defn_evars
 
 let undefined_map d = d.undf_evars
+
+let update_undefined d e evi = { d with undf_evars = EvMap.add e evi d.undf_evars }
 
 let drop_all_defined d = { d with defn_evars = EvMap.empty }
 

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -644,7 +644,8 @@ let define_aux def undef evk body =
         anomaly ~label:"Evd.define" (Pp.str "cannot define undeclared evar.")
   in
   let () = assert (oldinfo.evar_body == Evar_empty) in
-  let newinfo = { oldinfo with evar_body = Evar_defined body } in
+  (* flush the dependency cache to free memory *)
+  let newinfo = { oldinfo with evar_body = Evar_defined body; evar_dependency_cache = None } in
   EvMap.add evk newinfo def, EvMap.remove evk undef
 
 (* define the existential of section path sp as the constr body *)

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -194,7 +194,9 @@ val define : evar -> constr -> evar_map -> evar_map
       {- The evar is already present in the evarmap.}
       {- The evar is not defined in the evarmap yet.}
       {- All the evars present in the constr should be present in the evar map.}
-    } *)
+    } 
+    The dependency cache for the evar is flushed.
+*)
 
 val cmap : (constr -> constr) -> evar_map -> evar_map
 (** Map the function on all terms in the evar map. *)

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -104,6 +104,8 @@ type evar_info = {
   (** Information about the evar. *)
   evar_candidates : constr list option;
   (** List of possible solutions when known that it is a finite list *)
+  evar_dependency_cache : Evar.Set.t option;
+  (** Set of undefined evars that this evar depends on *)
   evar_extra : Store.t
   (** Extra store, used for clever hacks. *)
 }
@@ -212,8 +214,11 @@ val add_constraints : evar_map -> Univ.constraints -> evar_map
 val undefined_map : evar_map -> evar_info Evar.Map.t
 (** Access the undefined evar mapping directly. *)
 
+val update_undefined : evar_map -> evar -> evar_info -> evar_map
+(** replace (or add) the evar info for an undefined evar *)
+  
 val drop_all_defined : evar_map -> evar_map
-
+  
 (** {6 Instantiating partial terms} *)
 
 exception NotInstantiatedEvar

--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -635,13 +635,7 @@ let shelve_goals l =
     [evi]. Note: since we want to use it on goals, the body is actually
     supposed to be empty. *)
 let contained_in_info sigma e evi =
-  let es =
-    match evi.Evd.evar_body with
-    | Evd.Evar_empty ->
-       fst (Evarutil.undefined_evars_of_evar_info e sigma evi)
-    | Evd.Evar_defined _ ->
-       Evd.evars_of_filtered_evar_info (Evarutil.nf_evar_info sigma evi)
-  in
+  let (es,_) = Evarutil.undefined_evars_of_evar_info e sigma evi in
   Evar.Set.mem e es
     
 (** [depends_on sigma src tgt] checks whether the goal [src] appears

--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -635,8 +635,15 @@ let shelve_goals l =
     [evi]. Note: since we want to use it on goals, the body is actually
     supposed to be empty. *)
 let contained_in_info sigma e evi =
-  Evar.Set.mem e (Evd.evars_of_filtered_evar_info (Evarutil.nf_evar_info sigma evi))
-
+  let es =
+    match evi.Evd.evar_body with
+    | Evd.Evar_empty ->
+       fst (Evarutil.undefined_evars_of_evar_info e sigma evi)
+    | Evd.Evar_defined _ ->
+       Evd.evars_of_filtered_evar_info (Evarutil.nf_evar_info sigma evi)
+  in
+  Evar.Set.mem e es
+    
 (** [depends_on sigma src tgt] checks whether the goal [src] appears
     as an existential variable in the definition of the goal [tgt] in
     [sigma]. *)

--- a/proofs/goal.ml
+++ b/proofs/goal.ml
@@ -69,6 +69,7 @@ module V82 = struct
 		Evd.evar_body = Evd.Evar_empty;
 		Evd.evar_source = (Loc.tag Evar_kinds.GoalEvar);
 		Evd.evar_candidates = None;
+		Evd.evar_dependency_cache = None;
 		Evd.evar_extra = extra }
     in
     let evi = Typeclasses.mark_unresolvable evi in


### PR DESCRIPTION
This is a second whack at caching sets of evars. It's the same as #949, except we also try to use the cache in `Proofview.contained_in_info`. There we distinguish the cases for `evi.evar_body`, otherwise we get failures building the library (hope that's right).

Let's see if this gives us any performance boost.