### PR TITLE
Move Software Foundations to allowed failures.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,7 @@ matrix:
 
   allow_failures:
   - env: TEST_TARGET="ci-geocoq TIMED=1"
+  - env: TEST_TARGET="ci-sf TIMED=1"
 
   include:
     # Full Coq test-suite with two compilers


### PR DESCRIPTION
The URL we are testing no longer exists, probably after SF was split in
three volumes. Since we are about to release 8.7+beta1, let's avoid
making the build fails for now.