### PR TITLE
fix test-suite/coq-makefile/findlib-package on windows after #958

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,5 +22,4 @@ build_script:
 - cmd: '%CYGROOT%/bin/bash -lc "cd $APPVEYOR_BUILD_FOLDER && ./configure -local && make"'
 
 test_script:
-- cmd: '%CYGROOT%/bin/bash -lc "cd $APPVEYOR_BUILD_FOLDER && make -C test-suite all
-  INTERACTIVE= && make validate"'
+- cmd: '%CYGROOT%/bin/bash -lc "cd $APPVEYOR_BUILD_FOLDER && make byte && make -C test-suite all INTERACTIVE= && make validate"'

--- a/test-suite/coq-makefile/findlib-package/findlib/foo/Makefile
+++ b/test-suite/coq-makefile/findlib-package/findlib/foo/Makefile
@@ -1,7 +1,7 @@
 -include ../../Makefile.conf
 
-CO=$(COQMF_OCAMLFIND) opt
-CB=$(COQMF_OCAMLFIND) ocamlc
+CO="$(COQMF_OCAMLFIND)" opt
+CB="$(COQMF_OCAMLFIND)" ocamlc
 
 all:
 	$(CO) -c foolib.ml

--- a/test-suite/coq-makefile/findlib-package/run.sh
+++ b/test-suite/coq-makefile/findlib-package/run.sh
@@ -4,6 +4,11 @@
 
 echo "let () = Foolib.foo ();;" >> src/test_aux.ml
 export OCAMLPATH=$OCAMLPATH:$PWD/findlib
+if which cygpath 2>/dev/null; then
+  # the only way I found to pass OCAMLPATH on win is to have it contain
+  # only one entry
+  export OCAMLPATH=`cygpath -w $PWD/findlib`
+fi
 make -C findlib/foo clean
 coq_makefile -f _CoqProject -o Makefile
 cat Makefile.conf


### PR DESCRIPTION
The issue was not in coq_makefile, but in the test itself that was invoking ocamlfind with no quotes and without putting the contents of OCAMLPATH in windows-friendly format.

Now, the fact that the two major OSs on this planet use different path separators, and that one is an escape character for the shell of the other is, well, ...