### PR TITLE
Make a test for coq_makefile portable.

### DIFF
--- a/test-suite/coq-makefile/template/init.sh
+++ b/test-suite/coq-makefile/template/init.sh
@@ -2,6 +2,7 @@ set -e
 set -o pipefail
 
 export PATH=$COQBIN:$PATH
+export LC_ALL=C
 
 rm -rf theories src Makefile Makefile.conf tmp
 git clean -dfx || true


### PR DESCRIPTION
The validity of this test depended on Makefile issueing warnings in English.
We simply force the global language of the shell to be C.