### PR TITLE
Add HashConsing option

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -13,6 +13,12 @@ Tactics
   profiling, and "Set NativeCompute Profile Filename" customizes
   the profile filename.
 
+Vernacular Commands
+
+- The option HashConsing can be Unset to disable hash-consing in the
+  Coq implementation. In many cases, that can speed up Qed, Defined,
+  and End section commands, at the cost of greater memory usage.
+
 Changes from 8.6.1 to 8.7+beta
 ==============================
 

--- a/doc/refman/RefMan-oth.tex
+++ b/doc/refman/RefMan-oth.tex
@@ -1000,6 +1000,19 @@ line when {\tt -emacs} is passed.
 %\subsection{\tt Abstraction ...}
 %Not yet documented.
 
+\section{Controlling Coq's internal representation of terms}
+\label{Controlling_internal_representations}
+\optindex{HashConsing}
+
+Internally, by default, {\Coq} uses a technique called
+``hash-consing'' to use a single representative for terms considered
+identical, reducing memory consumption. Finding the representative can take
+a lot of time, though, particularly for the commands {\tt Qed},
+{\tt Defined}, and for {\tt End} that closes a section.  The command
+{\tt Unset HashConsing} can be used to disable this technique, at the
+expense of greater memory usage. The command {\tt Set HashConsing} re-enables
+hash-consing.
+
 \section{Controlling the reduction strategies and the conversion algorithm}
 \label{Controlling_reduction_strategy}
 

--- a/lib/hashcons.mli
+++ b/lib/hashcons.mli
@@ -8,6 +8,12 @@
 
 (** Generic hash-consing. *)
 
+(** flag to enable, disable hash-consing, with getter and setter *)
+
+val hashconsing_enabled : bool ref
+val get_hashconsing_enabled : unit -> bool
+val set_hashconsing_enabled : bool -> unit
+
 (** {6 Hashconsing functorial interface} *)
 
 module type HashconsedType =

--- a/lib/hashset.ml
+++ b/lib/hashset.ml
@@ -175,6 +175,8 @@ module Make (E : EqType) =
     loop 0
 
   let find_or h t d ifnotfound =
+(*    let cs = Printexc.get_callstack () in
+      let cs_str = Printexc.raw_backtrace_to_string cs in *)
     let index = get_index t h in
     let bucket = t.table.(index) in
     let hashes = t.hashes.(index) in

--- a/lib/hashset.ml
+++ b/lib/hashset.ml
@@ -175,8 +175,6 @@ module Make (E : EqType) =
     loop 0
 
   let find_or h t d ifnotfound =
-(*    let cs = Printexc.get_callstack () in
-      let cs_str = Printexc.raw_backtrace_to_string cs in *)
     let index = get_index t h in
     let bucket = t.table.(index) in
     let hashes = t.hashes.(index) in

--- a/test-suite/success/HashConsing.v
+++ b/test-suite/success/HashConsing.v
@@ -1,0 +1,15 @@
+(* make sure HashConsing option can be Set and Unset *)
+
+Unset HashConsing.
+Theorem foo : forall x : nat, x = x.
+Proof.
+  trivial.
+Qed.
+
+Set HashConsing.
+Theorem bar : forall x : nat, x = x.
+Proof.
+  apply foo.
+Qed.
+
+

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1473,6 +1473,14 @@ let _ =
       optread  = Nativenorm.get_profiling_enabled;
       optwrite = Nativenorm.set_profiling_enabled }
 
+let _ = 
+  declare_bool_option
+    { optdepr  = false;
+      optname  = "use hash-consing of terms";
+      optkey   = ["HashConsing"];
+      optread  = Hashcons.get_hashconsing_enabled;
+      optwrite = Hashcons.set_hashconsing_enabled }
+    
 let vernac_set_strategy locality l =
   let local = make_locality locality in
   let glob_ref r =


### PR DESCRIPTION
This PR creates a new boolean option `HashConsing`. If you run `Unset HashConsing`, the hash-conser doesn't bother to find a representative. You can run `Set HashConsing` to re-enable hash-consing.

On the slow Nsatz example in the MIT slow-code Wiki, if hash-consing is disabled, the time for the final `Qed` goes from 60 sec to 18 sec, and the final `End` section goes from 78 sec to 38 sec.


