### PR TITLE
Add option index entry for NativeCompute Profiling

### DIFF
--- a/doc/refman/RefMan-tac.tex
+++ b/doc/refman/RefMan-tac.tex
@@ -3309,7 +3309,7 @@ evaluating purely computational expressions (i.e. with little dead code).
   fine-tuned. It is specially interesting for full evaluation of algebraic
   objects. This includes the case of reflection-based tactics.
 
-\item {\tt native\_compute} \tacindex{native\_compute}
+\item {\tt native\_compute} \tacindex{native\_compute} \optindex{NativeCompute Profiling}
 
   This tactic evaluates the goal by compilation to \ocaml{} as described in
   \cite{FullReduction}. If \Coq{} is running in native code, it can be typically


### PR DESCRIPTION
PR #950 did not add a Vernacular Option Index entry for `NativeCompute Profiling`, so here it is.