### PR TITLE
Adding a function to be typically used to pass values from an OCaml "when" clause to the r.h.s of the matching clause

### DIFF
--- a/lib/util.ml
+++ b/lib/util.ml
@@ -171,3 +171,12 @@ let open_utf8_file_in fname =
   let s = Bytes.make 3 ' ' in
   if input in_chan s 0 3 < 3 || not (is_bom s) then seek_in in_chan 0;
   in_chan
+
+(** A trick which can typically be used to store on the fly the
+   computation of values in the "when" clause of a "match" then
+   retrieve the evaluated result in the r.h.s of the clause *)
+
+let set_temporary_memory () =
+  let a = ref None in
+  (fun x -> assert (!a = None); a := Some x; x),
+  (fun () -> match !a with Some x -> x | None -> assert false)

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -137,3 +137,8 @@ val sym : ('a, 'b) eq -> ('b, 'a) eq
 
 val open_utf8_file_in : string -> in_channel
 (** Open an utf-8 encoded file and skip the byte-order mark if any. *)
+
+val set_temporary_memory : unit -> ('a -> 'a) * (unit -> 'a)
+(** A trick which can typically be used to store on the fly the
+   computation of values in the "when" clause of a "match" then
+   retrieve the evaluated result in the r.h.s of the clause *)


### PR DESCRIPTION
Who has not wanted to reuse in the right-hand side of an OCaml clause some computation done in a `when` clause?

The attached PR adds a function in `Util` which can be used to memoize on the fly such computation for reuse in the right-hand side.

This is honestly not specially elegant style, or more precisely, I don't find it leading to a very nice syntax. It would certainly be more elegant to have this natively provided in OCaml though I don't know with which intuitive syntax it could be provided (maybe something like `... when expr binding x1 and ... and xn -> ...` for `x1` ... `xn` already in scope?). I would hardly believe that this kind of things has not already been considered.

[Edited for clarification]