### PR TITLE
2 Typos in 'Add Parametric Morphism' Documentation

### DIFF
--- a/doc/refman/Setoid.tex
+++ b/doc/refman/Setoid.tex
@@ -223,7 +223,7 @@ the following command.
 
 \comindex{Add Parametric Morphism}
 \begin{quote}
-  \texttt{Add Parametric Morphism} ($x_1 : \T_!$) \ldots ($x_k : \T_k$)\\
+  \texttt{Add Parametric Morphism} ($x_1 : \T_1$) \ldots ($x_k : \T_k$) :
   (\textit{f $t_1$ \ldots $t_n$})\\
   \texttt{~with signature} \textit{sig}\\
   \texttt{~as id}.\\


### PR DESCRIPTION
Hi, I noticed a missing colon (and afterwards also a broken index) in the online documentation when comparing the general reference with the examples for 'Add Parametric Morphism'.

I already tested which one (with or without colon) is actually the correct form accepted by the Coq system, and hope this fix will get accepted quickly.