### PR TITLE
Addressing BZ#5713 (classical_left/classical_right artificially restricted to a non-empty context).

### DIFF
--- a/test-suite/bugs/closed/5713.v
+++ b/test-suite/bugs/closed/5713.v
@@ -1,0 +1,15 @@
+(* Checking that classical_right/classical_left work in an empty context *)
+
+Require Import Classical.
+
+Parameter A:Prop.
+
+Goal A \/ ~A.
+classical_right.
+assumption.
+Qed.
+
+Goal ~A \/ A.
+classical_left.
+assumption.
+Qed.

--- a/theories/Logic/Classical_Prop.v
+++ b/theories/Logic/Classical_Prop.v
@@ -97,12 +97,12 @@ Proof proof_irrelevance_cci classic.
 (* classical_left  transforms |- A \/ B into ~B |- A *)
 (* classical_right transforms |- A \/ B into ~A |- B *)
 
-Ltac classical_right :=  match goal with
- | _:_ |-?X1 \/ _ => (elim (classic X1);intro;[left;trivial|right])
+Ltac classical_right := match goal with
+|- ?X \/ _ => (elim (classic X);intro;[left;trivial|right])
 end.
 
 Ltac classical_left := match goal with
-| _:_ |- _ \/?X1 => (elim (classic X1);intro;[right;trivial|left])
+|- _ \/ ?X => (elim (classic X);intro;[right;trivial|left])
 end.
 
 Require Export EqdepFacts.


### PR DESCRIPTION
See [BZ#5713](https://coq.inria.fr/bugs/show_bug.cgi?id=5713).

The fix is obvious.