### PR TITLE
Avoid reinstalling some Cygwin dependencies on AppVeyor.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,8 +15,7 @@ environment:
 
 install:
 - cmd: '%CYGROOT%\setup-x86_64.exe -qnNdO -R %CYGROOT% -l %CYGCACHE% -s
-  %CYGMIRROR% -P rsync -P patch -P diffutils -P curl -P make -P unzip -P git -p m4
-  -P perl -P findutils -P time'
+  %CYGMIRROR% -P rsync -P patch -P diffutils -P make -P unzip -P m4 -P findutils -P time'
 - cmd: '%CYGROOT%/bin/bash -l %APPVEYOR_BUILD_FOLDER%/dev/build/windows/appveyor.sh'
 
 build_script:


### PR DESCRIPTION
For some reason, OPAM was not happy after we reinstalled curl.