### PR TITLE
BZ#5716, read flags from project file for Compile Buffer

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -13,6 +13,11 @@ Tactics
   profiling, and "Set NativeCompute Profile Filename" customizes
   the profile filename.
 
+Tools
+
+- In CoqIDE, the "Compile Buffer" command takes account of flags in
+  _CoqProject or other project file.
+
 Changes from 8.6.1 to 8.7+beta
 ==============================
 

--- a/ide/coqide.ml
+++ b/ide/coqide.ml
@@ -439,9 +439,9 @@ let compile sn =
   match sn.fileops#filename with
     |None -> flash_info "Active buffer has no name"
     |Some f ->
-      let (_,args) = make_coqtop_args fn in
-      let cmd = cmd_coqc#get ^ " -I " ^ (Filename.quote (Filename.dirname f))
-	^ (List.fold_left (fun accum arg -> accum ^ " " ^ arg) "" args)
+      let args = Coq.get_arguments sn.coqtop in
+      let cmd = cmd_coqc#get 
+	^ " " ^ String.concat " " args
 	^ " " ^ (Filename.quote f) ^ " 2>&1"
       in
       let buf = Buffer.create 1024 in

--- a/ide/coqide.ml
+++ b/ide/coqide.ml
@@ -439,7 +439,9 @@ let compile sn =
   match sn.fileops#filename with
     |None -> flash_info "Active buffer has no name"
     |Some f ->
+      let (_,args) = make_coqtop_args fn in
       let cmd = cmd_coqc#get ^ " -I " ^ (Filename.quote (Filename.dirname f))
+	^ (List.fold_left (fun accum arg -> accum ^ " " ^ arg) "" args)
 	^ " " ^ (Filename.quote f) ^ " 2>&1"
       in
       let buf = Buffer.create 1024 in


### PR DESCRIPTION
In CoqIDE, the `Compile Buffer` menu item ran `coqc` without using the flags in _CoqProject or other project file. This PR uses `make_coqtop_args` to read those flags, and inserts them into the command line.