### PR TITLE
Fix order of load_printer calls in dev/core.dbg

### DIFF
--- a/dev/core.dbg
+++ b/dev/core.dbg
@@ -14,9 +14,9 @@ load_printer parsing.cma
 load_printer printing.cma
 load_printer tactics.cma
 load_printer vernac.cma
+load_printer highparsing.cma
 load_printer stm.cma
 load_printer toplevel.cma
-load_printer highparsing.cma
 load_printer intf.cma
 load_printer API.cma
 load_printer ltac_plugin.cmo


### PR DESCRIPTION
1c55826018c5f07ee25b5771e59fe0389293cb62 put highparsing before
toplevel.