### PR TITLE
Fix a refine anomaly "Evar defined twice".

### DIFF
--- a/proofs/refine.ml
+++ b/proofs/refine.ml
@@ -102,7 +102,12 @@ let generic_refine ~typecheck f gl =
   in
   (** Proceed to the refinement *)
   let c = EConstr.Unsafe.to_constr c in
-  let sigma = match evkmain with
+  let sigma = match Proofview.Unsafe.advance sigma self with
+  | None ->
+    (** Nothing to do, the goal has been solved by side-effect *)
+    sigma
+  | Some self ->
+    match evkmain with
     | None -> Evd.define self c sigma
     | Some evk ->
         let id = Evd.evar_ident self sigma in


### PR DESCRIPTION
Because the argument given to refine may mess with the evarmap, the goal being
refined can be solved by side-effect after the term filler is computed. If this
happens, we simply don't perform the refining operation.