### PR TITLE
Restore safety mechanisms on kernel names.

### DIFF
--- a/kernel/names.ml
+++ b/kernel/names.ml
@@ -49,13 +49,15 @@ struct
 
   let of_string s =
     let () = check_valid s in
+    let s = String.copy s in
     String.hcons s
 
   let of_string_soft s =
     let () = check_valid ~strict:false s in
+    let s = String.copy s in
     String.hcons s
 
-  let to_string id = id
+  let to_string id = String.copy id
 
   let print id = str id
 


### PR DESCRIPTION
As it stands, even with the most recent OCaml compiler (4.05.0), a plugin
that uses only non-buggy non-malicious code can wreak havoc in the kernel
data structures. Until the time the compiler/linker actually enforces the
separation between mutable and immutable strings (at least by giving them
different types in .cmi files), these string copies are to stay.