### PR TITLE
Fix the introduction of SSR refman chapter.

### DIFF
--- a/doc/refman/RefMan-ssr.tex
+++ b/doc/refman/RefMan-ssr.tex
@@ -42,7 +42,7 @@ Proofs written in \ssr{} typically look quite different from the
 ones written using only tactics as per Chapter~\ref{Tactics}.
 We try to summarise here the most ``visible'' ones in order to
 help the reader already accustomed to the tactics described in
-Chapter~\ref{Tactics}to read this chapter.
+Chapter~\ref{Tactics} to read this chapter.
 
 The first difference between the tactics described in this
 chapter and the tactics described in Chapter~\ref{Tactics} is the way
@@ -79,19 +79,19 @@ expansion and partial evaluation participate all to a same concept of
 rewriting a goal in a larger sense. As such, all these functionalities are
 provided by the \ssrC{rewrite} tactic.
 
-\ssrC{} includes a little language of patterns to select subterms in tactics
+\ssr{} includes a little language of patterns to select subterms in tactics
 or tacticals where it matters.  Its most notable application
 is in the \ssrC{rewrite} tactic, where patterns are used to specify
 where the rewriting step has to take place.
 
-Finally, \ssr{} supports the so-called reflection steps, typically
+Finally, \ssr{} supports so-called reflection steps, typically
 allowing to switch back and forth between the computational view and
 logical view of a concept.
 
 To conclude it is worth mentioning that \ssr{} tactics
 can be mixed with non \ssr{} tactics in the same proof,
-or in the same LTac expression.  The few exceptions
-to this statement are described in section~\label{sec:compat}.
+or in the same Ltac expression.  The few exceptions
+to this statement are described in section~\ref{sec:compat}.
 
 \iffalse
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -130,7 +130,7 @@ ProofGeneral provided in the distribution:
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \subsection*{Acknowledgments}
-The authors would like to thank Fr\'ed\'eric Blanqui, Fran\,cois Pottier
+The authors would like to thank Frédéric Blanqui, François Pottier
 and Laurence Rideau for their comments and suggestions.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
I guess I must be the first one who went to https://coq.inria.fr/distrib/V8.7+beta1/refman/Reference-Manual013.html.
The fact that there is no link on the website to the beta version of the reference manual does not help getting feedback.
Let me remark in passing on this specific chapter that the `lstlisting` thingy is a fiasco (probably due to a missing extra stylesheet).