### PR TITLE
Fix Typo in Doc for `Set Parsing Explicit`

### DIFF
--- a/doc/refman/RefMan-ext.tex
+++ b/doc/refman/RefMan-ext.tex
@@ -1664,7 +1664,7 @@ to be given as if none arguments were implicit. By symmetry, this also
 affects printing. To restore parsing and normal printing of implicit
 arguments, use:
 \begin{quote}
-{\tt Set Parsing Explicit.}
+{\tt Unset Parsing Explicit.}
 \end{quote}
 
 \subsection{Canonical structures


### PR DESCRIPTION
Should be obvious, see diff :-)