### PR TITLE
Disable OSX signing for temporary artifacts.

### DIFF
--- a/dev/build/osx/make-macos-dmg.sh
+++ b/dev/build/osx/make-macos-dmg.sh
@@ -9,14 +9,11 @@ DMGDIR=$PWD/_dmg
 VERSION=$(sed -n -e '/^let coq_version/ s/^[^"]*"\([^"]*\)"$/\1/p' configure.ml)
 APP=bin/CoqIDE_${VERSION}.app
 
-# Create a .app file with CoqIDE
-make -j $NJOBS -l2 $APP
+# Create a .app file with CoqIDE, without signing it
+make PRIVATEBINARIES=$APP -j $NJOBS -l2 $APP
 
 # Add Coq to the .app file
 make OLDROOT=$OUTDIR COQINSTALLPREFIX=$APP/Contents/Resources/ install-coq install-ide-toploop
-
-# Sign the .app file
-codesign -f -s - $APP
 
 # Create the dmg bundle
 mkdir -p $DMGDIR


### PR DESCRIPTION
The OSX binaries were signed twice with a fake identity, leading to some
obscure errors on Travis in some cases.

We disable code signing for Travis artifacts. For released packages,
a proper signing will be applied manually.