### PR TITLE
Avoid extra failure in the "constructor" tactic (bug #5666).

### DIFF
--- a/test-suite/bugs/closed/5666.v
+++ b/test-suite/bugs/closed/5666.v
@@ -1,0 +1,4 @@
+Inductive foo := Foo : False -> foo.
+Goal foo.
+try (constructor ; fail 0).
+Fail try (constructor ; fail 1).


### PR DESCRIPTION
This changes the implementation of `constructor` from

    constructor 1 + ... + constructor n + fail

to

    constructor 1 + ... + constructor n.