### PR TITLE
Restoring test on ident validity while browsing directory structure.

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -430,14 +430,18 @@ tools: $(TOOLS) $(OCAMLLIBDEP) $(COQDEPBOOT)
 
 # Remember to update the dependencies below when you add files!
 
-COQDEPBOOTSRC := lib/minisys.cmo \
- lib/segmenttree.cmo lib/unicodetable.cmo lib/unicode.cmo \
+COQDEPBOOTSRC := \
+ lib/segmenttree.cmo lib/unicodetable.cmo lib/unicode.cmo lib/minisys.cmo \
  tools/coqdep_lexer.cmo tools/coqdep_common.cmo tools/coqdep_boot.cmo
 
 lib/segmenttree.cmo : lib/segmenttree.cmi
 lib/segmenttree.cmx : lib/segmenttree.cmi
-lib/unicode.cmo : lib/unicodetable.cmo lib/segmenttree.cmi lib/unicode.cmi
-lib/unicode.cmx : lib/unicodetable.cmx lib/segmenttree.cmx lib/unicode.cmi
+lib/unicodetable.cmo : lib/segmenttree.cmo
+lib/unicodetable.cmx : lib/segmenttree.cmx
+lib/unicode.cmo : lib/unicodetable.cmo lib/unicode.cmi
+lib/unicode.cmx : lib/unicodetable.cmx lib/unicode.cmi
+lib/minisys.cmo : lib/unicode.cmo
+lib/minisys.cmx : lib/unicode.cmx
 tools/coqdep_lexer.cmo : lib/unicode.cmi tools/coqdep_lexer.cmi
 tools/coqdep_lexer.cmx : lib/unicode.cmx tools/coqdep_lexer.cmi
 tools/coqdep_common.cmo : lib/minisys.cmo tools/coqdep_lexer.cmi tools/coqdep_common.cmi
@@ -455,8 +459,8 @@ $(OCAMLLIBDEP): $(call bestobj, tools/ocamllibdep.cmo)
 
 # The full coqdep (unused by this build, but distributed by make install)
 
-COQDEPCMO:=lib/clib.cma lib/cErrors.cmo lib/cWarnings.cmo lib/minisys.cmo \
-  lib/segmenttree.cmo lib/unicodetable.cmo lib/unicode.cmo \
+COQDEPCMO:=lib/clib.cma lib/cErrors.cmo lib/cWarnings.cmo \
+  lib/segmenttree.cmo lib/unicodetable.cmo lib/unicode.cmo lib/minisys.cmo \
   lib/system.cmo tools/coqdep_lexer.cmo tools/coqdep_common.cmo \
   tools/coqdep.cmo
 

--- a/lib/segmenttree.ml
+++ b/lib/segmenttree.ml
@@ -1,3 +1,11 @@
+(************************************************************************)
+(*  v      *   The Coq Proof Assistant  /  The Coq Development Team     *)
+(* <O___,, *   INRIA - CNRS - LIX - LRI - PPS - Copyright 1999-2017     *)
+(*   \VV/  **************************************************************)
+(*    //   *      This file is distributed under the terms of the       *)
+(*         *       GNU Lesser General Public License Version 2.1        *)
+(************************************************************************)
+
 (** This module is a very simple implementation of "segment trees".
 
     A segment tree of type ['a t] represents a mapping from a union of

--- a/lib/segmenttree.mli
+++ b/lib/segmenttree.mli
@@ -1,3 +1,11 @@
+(************************************************************************)
+(*  v      *   The Coq Proof Assistant  /  The Coq Development Team     *)
+(* <O___,, *   INRIA - CNRS - LIX - LRI - PPS - Copyright 1999-2017     *)
+(*   \VV/  **************************************************************)
+(*    //   *      This file is distributed under the terms of the       *)
+(*         *       GNU Lesser General Public License Version 2.1        *)
+(************************************************************************)
+
 (** This module is a very simple implementation of "segment trees".
 
     A segment tree of type ['a t] represents a mapping from a union of


### PR DESCRIPTION
The test was abandoned at the time of merging subdirectory browsing between `coqdep` and `coqtop`, and to limit at the same time the dependency of `coqdep` in files such as `unicode.cmo`.

But checking ident validity speeds up browsing in arbitrary non-Coq-specific directory structures and we restore it for this reason.

(One could also consider that browsing arbitrary directory structures is not intended, but in practice this may happen, as e.g. reported in [BZ#5734](https://coq.inria.fr/bugs/show_bug.cgi?id=5734).)

@letouzey, I know that you care about minimal dependencies for `coqdep`.

Is it ok for you that we make `coqdep` aware of the exact (UTF-8) syntax of module names? Otherwise we can also consider that users are not supposed to do `Add LoadPath` on non-Coq related directory structure and that the regression in efficiency of `Add LoadPath` between 8.5 and 8.6 is not a problem. Or, we can have different ocaml code to locate modules in `coqdep` and `coqtop` (but with the risk of inconsistencies as we had).

Note that the question is also about whether we want `coqdep` to be aware of the exact (UTF-8) syntax of library names (see commit e88dfed in PR#1041). (Though here, I could not understand if there were a global agreement on supporting arbitrary letters in library names, as we do for modules in general, rather than just ascii letters.)
