### PR TITLE
Remove STM vernaculars

### DIFF
--- a/API/API.mli
+++ b/API/API.mli
@@ -3676,7 +3676,7 @@ sig
                    | VtProofStep of proof_step
                    | VtProofMode of string
                    | VtQuery of vernac_part_of_script * Feedback.route_id
-                   | VtStm of vernac_control * vernac_part_of_script
+                   | VtBack of vernac_part_of_script * Stateid.t
                    | VtUnknown
    and vernac_qed_type =
      | VtKeep
@@ -3685,10 +3685,6 @@ sig
    and vernac_start = string * opacity_guarantee * Names.Id.t list
    and vernac_sideff_type = Names.Id.t list
    and vernac_part_of_script = bool
-   and vernac_control =
-     | VtWait
-     | VtJoinDocument
-     | VtBack of Stateid.t
    and opacity_guarantee =
      | GuaranteesOpacity
      | Doesn'tGuaranteeOpacity
@@ -3770,7 +3766,6 @@ sig
   type option_value
   type showable
   type bullet
-  type stm_vernac
   type comment
   type register_kind
   type locatable
@@ -3922,7 +3917,6 @@ sig
   | VernacLocate of locatable
   | VernacRegister of lident * register_kind
   | VernacComments of comment list
-  | VernacStm of stm_vernac
   | VernacGoal of Constrexpr.constr_expr
   | VernacAbort of lident option
   | VernacAbortAll

--- a/dev/doc/xml-protocol.md
+++ b/dev/doc/xml-protocol.md
@@ -291,7 +291,10 @@ Pseudocode for listing all of the goals in order: `rev (flat_map fst background)
 
 
 ### <a name="command-status">**Status(force: bool)**</a>
-CoqIDE typically sets `force` to `false`. 
+Returns information about the current proofs. CoqIDE typically sends this
+message with `force = false` after each sentence, and with `force = true` if
+the user wants to force the checking of all proofs (wheels button). In terms of
+the STM API, `force` triggers a `Join`.
 ```html
 <call val="Status"><bool val="${force}"/></call>
 ```

--- a/ide/ide_slave.ml
+++ b/ide/ide_slave.ml
@@ -413,6 +413,7 @@ let eval_call c =
     Interface.quit = (fun () -> quit := true);
     Interface.init = interruptible init;
     Interface.about = interruptible about;
+    Interface.wait = interruptible Stm.wait;
     Interface.interp = interruptible interp;
     Interface.handle_exn = handle_exn;
     Interface.stop_worker = Stm.stop_worker;

--- a/ide/interface.mli
+++ b/ide/interface.mli
@@ -229,6 +229,9 @@ type print_ast_rty = Xml_datatype.xml
 type annotate_sty = string
 type annotate_rty = Xml_datatype.xml
 
+type wait_sty = unit
+type wait_rty = unit
+
 type handler = {
   add         : add_sty         -> add_rty;
   edit_at     : edit_at_sty     -> edit_at_rty;
@@ -248,6 +251,8 @@ type handler = {
   handle_exn  : handle_exn_sty  -> handle_exn_rty;
   init        : init_sty        -> init_rty;
   quit        : quit_sty        -> quit_rty;
+  (* for internal use (fake_id) only, do not use *)
+  wait        : wait_sty        -> wait_rty;
   (* Retrocompatibility stuff *)
   interp      : interp_sty      -> interp_rty;
 }

--- a/ide/xmlprotocol.mli
+++ b/ide/xmlprotocol.mli
@@ -29,6 +29,8 @@ val set_options : set_options_sty -> set_options_rty call
 val quit        : quit_sty        -> quit_rty call
 val init        : init_sty        -> init_rty call
 val stop_worker : stop_worker_sty -> stop_worker_rty call
+(* internal use (fake_ide) only, do not use *)
+val wait        : wait_sty        -> wait_rty call
 (* retrocompatibility *)
 val interp      : interp_sty      -> interp_rty call
 val print_ast   : print_ast_sty   -> print_ast_rty call

--- a/intf/vernacexpr.ml
+++ b/intf/vernacexpr.ml
@@ -280,11 +280,6 @@ type bullet =
     | Star of int
     | Plus of int
 
-(** {6 Types concerning Stm} *)
-type stm_vernac =
-  | JoinDocument
-  | Wait
-
 (** {6 Types concerning the module layer} *)
 
 (** Rigid / flexible module signature *)
@@ -450,10 +445,6 @@ type vernac_expr =
   | VernacRegister of lident * register_kind
   | VernacComments of comment list
 
-  (* Stm backdoor: used in fake_id, will be removed when fake_ide
-     becomes aware of feedback about completed jobs. *)
-  | VernacStm of stm_vernac
-
   (* Proof management *)
   | VernacGoal of constr_expr
   | VernacAbort of lident option
@@ -504,16 +495,12 @@ type vernac_type =
   | VtProofStep of proof_step
   | VtProofMode of string
   | VtQuery of vernac_part_of_script * Feedback.route_id
-  | VtStm of vernac_control * vernac_part_of_script
+  | VtBack of vernac_part_of_script * Stateid.t
   | VtUnknown
 and vernac_qed_type = VtKeep | VtKeepAsAxiom | VtDrop (* Qed/Admitted, Abort *)
 and vernac_start = string * opacity_guarantee * Id.t list
 and vernac_sideff_type = Id.t list
 and vernac_part_of_script = bool
-and vernac_control =
-  | VtWait
-  | VtJoinDocument
-  | VtBack of Stateid.t
 and opacity_guarantee =
   | GuaranteesOpacity (** Only generates opaque terms at [Qed] *)
   | Doesn'tGuaranteeOpacity (** May generate transparent terms even with [Qed].*)

--- a/parsing/g_vernac.ml4
+++ b/parsing/g_vernac.ml4
@@ -75,10 +75,6 @@ GEXTEND Gram
       | IDENT "Local"; v = vernac_poly -> VernacLocal (true, v)
       | IDENT "Global"; v = vernac_poly -> VernacLocal (false, v)
 
-      (* Stm backdoor *)
-      | IDENT "Stm"; IDENT "JoinDocument"; "." -> VernacStm JoinDocument
-      | IDENT "Stm"; IDENT "Wait"; "." -> VernacStm Wait
-
       | v = vernac_poly -> v ]
     ]
   ;

--- a/printing/ppvernac.ml
+++ b/printing/ppvernac.ml
@@ -524,12 +524,6 @@ open Decl_kinds
       | VernacLocal (local, v) ->
         return (pr_locality local ++ spc() ++ pr_vernac_body v)
 
-      (* Stm *)
-      | VernacStm JoinDocument ->
-        return (keyword "Stm JoinDocument")
-      | VernacStm Wait ->
-        return (keyword "Stm Wait")
-
       (* Proof management *)
       | VernacAbortAll ->
         return (keyword "Abort All")

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -2373,6 +2373,7 @@ let finish () =
   | _ -> ()
 
 let wait () =
+  finish ();
   Slaves.wait_all_done ();
   VCS.print ()
 
@@ -2386,7 +2387,6 @@ let rec join_admitted_proofs id =
   | _ -> join_admitted_proofs view.next
 
 let join () =
-  finish ();
   wait ();
   stm_prerr_endline (fun () -> "Joining the environment");
   Global.join_safe_environment ();
@@ -2486,7 +2486,7 @@ let process_transaction ?(newtip=Stateid.fresh ())
       match c with
       (* Joining various parts of the document *)
       | VtStm (VtJoinDocument, b), VtNow -> join (); `Ok
-      | VtStm (VtWait, b),         VtNow -> finish (); wait (); `Ok
+      | VtStm (VtWait, b),         VtNow -> wait (); `Ok
       | VtStm ((VtJoinDocument|VtWait),_), VtLater ->
           anomaly(str"classifier: join actions cannot be classified as VtLater.")
 

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -1049,7 +1049,7 @@ end = struct (* {{{ *)
     try
       match v with
       | VernacResetInitial ->
-          VtStm (VtBack Stateid.initial, true), VtNow
+          VtBack (true, Stateid.initial), VtNow
       | VernacResetName (_,name) ->
           let id = VCS.get_branch_pos (VCS.current_branch ()) in
           (try
@@ -1057,20 +1057,20 @@ end = struct (* {{{ *)
               fold_until (fun b (id,_,label,_,_) ->
                 if b then `Stop id else `Cont (List.mem name label))
               false id in
-            VtStm (VtBack oid, true), VtNow
+            VtBack (true, oid), VtNow
           with Not_found ->
-            VtStm (VtBack id, true), VtNow)
+            VtBack (true, id), VtNow)
       | VernacBack n ->
           let id = VCS.get_branch_pos (VCS.current_branch ()) in
           let oid = fold_until (fun n (id,_,_,_,_) ->
             if Int.equal n 0 then `Stop id else `Cont (n-1)) n id in
-          VtStm (VtBack oid, true), VtNow
+          VtBack (true, oid), VtNow
       | VernacUndo n ->
           let id = VCS.get_branch_pos (VCS.current_branch ()) in
           let oid = fold_until (fun n (id,_,_,tactic,undo) ->
             let value = (if tactic then 1 else 0) - undo in
             if Int.equal n 0 then `Stop id else `Cont (n-value)) n id in
-          VtStm (VtBack oid, true), VtLater
+          VtBack (true, oid), VtLater
       | VernacUndoTo _
       | VernacRestart as e ->
           let m = match e with VernacUndoTo m -> m | _ -> 0 in
@@ -1087,16 +1087,16 @@ end = struct (* {{{ *)
             0 id in
           let oid = fold_until (fun n (id,_,_,_,_) ->
             if Int.equal n 0 then `Stop id else `Cont (n-1)) (n-m-1) id in
-          VtStm (VtBack oid, true), VtLater
+          VtBack (true, oid), VtLater
       | VernacAbortAll ->
           let id = VCS.get_branch_pos (VCS.current_branch ()) in
           let oid = fold_until (fun () (id,vcs,_,_,_) ->
             match Vcs_.branches vcs with [_] -> `Stop id | _ -> `Cont ())
             () id in
-          VtStm (VtBack oid, true), VtLater
+          VtBack (true, oid), VtLater
       | VernacBacktrack (id,_,_)
       | VernacBackTo id ->
-          VtStm (VtBack (Stateid.of_int id), not !Flags.batch_mode), VtNow
+          VtBack (not !Flags.batch_mode, Stateid.of_int id), VtNow
       | _ -> VtUnknown, VtNow
     with
     | Not_found ->
@@ -2484,14 +2484,8 @@ let process_transaction ?(newtip=Stateid.fresh ())
       stm_prerr_endline (fun () ->
         "  classified as: " ^ string_of_vernac_classification c);
       match c with
-      (* Joining various parts of the document *)
-      | VtStm (VtJoinDocument, b), VtNow -> join (); `Ok
-      | VtStm (VtWait, b),         VtNow -> wait (); `Ok
-      | VtStm ((VtJoinDocument|VtWait),_), VtLater ->
-          anomaly(str"classifier: join actions cannot be classified as VtLater.")
-
       (* Back *)
-      | VtStm (VtBack oid, true), w ->
+      | VtBack (true, oid), w ->
           let id = VCS.new_node ~id:newtip () in
           let { mine; others } = Backtrack.branches_of oid in
           let valid = VCS.get_branch_pos head in
@@ -2510,12 +2504,12 @@ let process_transaction ?(newtip=Stateid.fresh ())
           VCS.checkout_shallowest_proof_branch ();
           VCS.commit id (Alias (oid,x));
           Backtrack.record (); if w == VtNow then finish (); `Ok
-      | VtStm (VtBack id, false), VtNow ->
+      | VtBack (false, id), VtNow ->
           stm_prerr_endline (fun () -> "undo to state " ^ Stateid.to_string id);
           Backtrack.backto id;
           VCS.checkout_shallowest_proof_branch ();
           Reach.known_state ~cache:(interactive ()) id; `Ok
-      | VtStm (VtBack id, false), VtLater ->
+      | VtBack (false, id), VtLater ->
           anomaly(str"classifier: VtBack + VtLater must imply part_of_script.")
 
       (* Query *)
@@ -2779,8 +2773,8 @@ let query ~at ~route s =
     let clas = classify_vernac ast in
     let aast = { verbose = true; indentation; strlen; loc; expr = ast } in
     match clas with
-    | VtStm (w,_), _ ->
-       ignore(process_transaction aast (VtStm (w,false), VtNow))
+    | VtBack (_,id), _ -> (* TODO: can this still happen ? *)
+       ignore(process_transaction aast (VtBack (false,id), VtNow))
     | _ ->
        ignore(process_transaction aast (VtQuery (false, route), VtNow)))
   s

--- a/stm/stm.mli
+++ b/stm/stm.mli
@@ -51,6 +51,9 @@ val edit_at : Stateid.t -> [ `NewTip | `Focus of focus ]
 (* Evaluates the tip of the current branch *)
 val finish : unit -> unit
 
+(* Internal use (fake_ide) only, do not use *)
+val wait : unit -> unit
+
 val observe : Stateid.t -> unit
 
 val stop_worker : string -> unit

--- a/tools/fake_ide.ml
+++ b/tools/fake_ide.ml
@@ -252,11 +252,9 @@ let eval_print l coq =
       let to_id, _ = get_id id in
       eval_call (query (0,(phrase, to_id))) coq
   | [ Tok(_,"WAIT") ] ->
-      let phrase = "Stm Wait." in
-      eval_call (query (0,(phrase,tip_id()))) coq
+      eval_call (wait ()) coq
   | [ Tok(_,"JOIN") ] ->
-      let phrase = "Stm JoinDocument." in
-      eval_call (query (0,(phrase,tip_id()))) coq
+      eval_call (status true) coq
   | [ Tok(_,"ASSERT"); Tok(_,"TIP"); Tok(_,id) ] ->
       let to_id, _ = get_id id in
       if not(Stateid.equal (Document.tip doc) to_id) then error "Wrong tip"

--- a/toplevel/vernac.ml
+++ b/toplevel/vernac.ml
@@ -134,7 +134,7 @@ let rec interp_vernac sid (loc,com) =
          document. Hopefully this is fixed when VtBack can be removed
          and Undo etc... are just interpreted regularly. *)
       let is_proof_step = match fst (Vernac_classifier.classify_vernac v) with
-        | VtProofStep _ | VtStm (VtBack _, _) | VtStartProof _ -> true
+        | VtProofStep _ | VtBack (_, _) | VtStartProof _ -> true
         | _ -> false
       in
 

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1924,7 +1924,6 @@ let interp ?proof ?loc locality poly c =
   | VernacTime _ -> assert false
   | VernacRedirect _ -> assert false
   | VernacTimeout _ -> assert false
-  | VernacStm _ -> assert false
 
   (* The STM should handle that, but LOAD bypasses the STM... *)
   | VernacAbortAll    -> CErrors.user_err  (str "AbortAll cannot be used through the Load command")
@@ -2184,10 +2183,6 @@ let with_fail b f =
 let interp ?(verbosely=true) ?proof (loc,c) =
   let orig_program_mode = Flags.is_program_mode () in
   let rec aux ?locality ?polymorphism isprogcmd = function
-
-    (* This assert case will be removed when fake_ide can understand
-       completion feedback *)
-    | VernacStm _ -> assert false (* Done by Stm *)
 
     | VernacProgram c when not isprogcmd -> aux ?locality ?polymorphism true c
     | VernacProgram _ -> user_err Pp.(str "Program mode specified twice")

--- a/vernac/vernacprop.ml
+++ b/vernac/vernacprop.ml
@@ -17,8 +17,7 @@ let rec is_navigation_vernac = function
   | VernacResetName _
   | VernacBacktrack _
   | VernacBackTo _
-  | VernacBack _
-  | VernacStm _ -> true
+  | VernacBack _ -> true
   | VernacRedirect (_, (_,c))
   | VernacTime (_,c) ->
       is_navigation_vernac c (* Time Back* is harmless *)


### PR DESCRIPTION
We add support for Wait in the XML protocol and `fake_ide`, then remove the STM vernaculars which have become unnecessary.

This is still preliminary work for a larger vernac cleanup.