### PR TITLE
Warning for deprecated: Coercion Local foo := fun x : nat => x

### DIFF
--- a/vernac/locality.ml
+++ b/vernac/locality.ml
@@ -63,6 +63,8 @@ let enforce_locality locality_flag local =
 
 let enforce_locality_exp locality_flag local =
   match locality_flag, local with
+  | None, Some Decl_kinds.Local ->
+     warn_deprecated_local_syntax (); Decl_kinds.Local
   | None, Some local -> local
   | Some b, None -> local_of_bool b
   | None, None -> Decl_kinds.Global


### PR DESCRIPTION
For some reason, the warning was printed only when the body of the
coercion was not provided.

The syntax will go away in 8.8, so it is critical to have this warning
correctly printed.