### PR TITLE
coq_makefile: dont show errors from failed (ignored) rmdir

### DIFF
--- a/tools/CoqMakefile.in
+++ b/tools/CoqMakefile.in
@@ -500,7 +500,7 @@ uninstall::
 	 instf="$(COQLIBINSTALL)/$$df/`basename $$f`" &&\
 	 rm -f "$$instf" &&\
 	 echo RM "$$instf" &&\
-	 (rmdir "$(call concat_path,,$(COQLIBINSTALL)/$$df/)" || true); \
+	 (rmdir "$(call concat_path,,$(COQLIBINSTALL)/$$df/)" 2>/dev/null || true); \
 	done
 .PHONY: uninstall
 


### PR DESCRIPTION
Currently, it prints a "failed to remove directory" for every single file. This PR fixes that.

Is submitting the PR against the 8.7 branch the right thing to do?