### PR TITLE
Display error messages from coqchk.

### DIFF
--- a/checker/checker.ml
+++ b/checker/checker.ml
@@ -14,6 +14,12 @@ open Flags
 open Names
 open Check
 
+let _ = Feedback.add_feeder
+          (function
+           | { Feedback.contents = Feedback.Message (_,_,msg) } ->
+             Format.eprintf "%a\n%!" pp_with msg
+           | _ -> ())
+
 let () = at_exit flush_all
 
 let chk_pp = Pp.pp_with Format.std_formatter

--- a/lib/feedback.ml
+++ b/lib/feedback.ml
@@ -64,7 +64,9 @@ let feedback ?id ?route what =
      route = Option.default !feedback_route route;
      id    = Option.default !feedback_id id;
   } in
-  Hashtbl.iter (fun _ f -> f m) feeders
+  let at_least_one_sink =
+    Hashtbl.fold (fun _ f _ -> f m; true) feeders false in
+  assert at_least_one_sink
 
 (* Logging messages *)
 let feedback_logger ?loc lvl msg =


### PR DESCRIPTION
This patch also adds an assertion to Feedback so that coqchk silently
validating proofs of False for several months can no longer go unnoticed.