### PR TITLE
Mark "Set Tactic Compat Context" as deprecated.

### DIFF
--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -74,7 +74,7 @@ let _ =
 
 let _ =
   declare_bool_option
-    { optdepr  = false;
+    { optdepr  = true; (* remove in 8.8 *)
       optname  = "trigger bugged context matching compatibility";
       optkey   = ["Tactic";"Compat";"Context"];
       optread  = (fun () -> !Flags.tactic_context_compat) ;


### PR DESCRIPTION
It was introduced in 8.5 for compatibility with a 8.4 bug.