### PR TITLE
new quick2vo target: like vio2vo, but smarter

### DIFF
--- a/test-suite/coq-makefile/quick2vo/_CoqProject
+++ b/test-suite/coq-makefile/quick2vo/_CoqProject
@@ -1,0 +1,10 @@
+-R src test
+-R theories test
+-I src
+
+src/test_plugin.mlpack
+src/test.ml4
+src/test.mli
+src/test_aux.ml
+src/test_aux.mli
+theories/test.v

--- a/test-suite/coq-makefile/quick2vo/run.sh
+++ b/test-suite/coq-makefile/quick2vo/run.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
+a=`uname`
 
 . ../template/init.sh
 
 coq_makefile -f _CoqProject -o Makefile
-cat Makefile.conf
-make quick2vo J=2
-test -f theories/test.vo
-make validate
+# vio2vo is broken on Windows (#6720)
+if [ "$a" = "Darwin" -o "$a" = "Linux" ]; then
+    make quick2vo J=2
+    test -f theories/test.vo
+    make validate
+fi

--- a/test-suite/coq-makefile/quick2vo/run.sh
+++ b/test-suite/coq-makefile/quick2vo/run.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+. ../template/init.sh
+
+coq_makefile -f _CoqProject -o Makefile
+cat Makefile.conf
+make quick2vo J=2
+test -f theories/test.vo
+make validate

--- a/test-suite/coq-makefile/vio2vo/_CoqProject
+++ b/test-suite/coq-makefile/vio2vo/_CoqProject
@@ -1,0 +1,10 @@
+-R src test
+-R theories test
+-I src
+
+src/test_plugin.mlpack
+src/test.ml4
+src/test.mli
+src/test_aux.ml
+src/test_aux.mli
+theories/test.v

--- a/test-suite/coq-makefile/vio2vo/run.sh
+++ b/test-suite/coq-makefile/vio2vo/run.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+. ../template/init.sh
+
+coq_makefile -f _CoqProject -o Makefile
+cat Makefile.conf
+make quick
+make vio2vo J=2
+test -f theories/test.vo
+make validate

--- a/test-suite/coq-makefile/vio2vo/run.sh
+++ b/test-suite/coq-makefile/vio2vo/run.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
+a=`uname`
 
 . ../template/init.sh
 
 coq_makefile -f _CoqProject -o Makefile
-cat Makefile.conf
 make quick
-make vio2vo J=2
-test -f theories/test.vo
-make validate
+# vio2vo is broken on Windows (#6720)
+if [ "$a" = "Darwin" -o "$a" = "Linux" ]; then
+    make vio2vo J=2
+    test -f theories/test.vo
+    make validate
+fi

--- a/tools/CoqMakefile.in
+++ b/tools/CoqMakefile.in
@@ -381,7 +381,7 @@ bytefiles: $(CMOFILES) $(CMAFILES)
 optfiles: $(if $(DO_NATDYNLINK),$(CMXSFILES))
 .PHONY: optfiles
 
-# FIXME, see Ralph's bugreport
+# FIXME, see Ralf's bugreport
 quick: $(VOFILES:.vo=.vio)
 .PHONY: quick
 
@@ -389,6 +389,18 @@ vio2vo:
 	$(TIMER) $(COQC) $(COQDEBUG) $(COQFLAGS) \
 		-schedule-vio2vo $(J) $(VOFILES:%.vo=%.vio)
 .PHONY: vio2vo
+
+quick2vo:
+	$(HIDE)make -j $(J) quick
+	$(HIDE)VIOFILES=$$(for vofile in $(VOFILES); do \
+	  viofile="$$(echo "$$vofile" | sed "s/\.vo$$/.vio/")"; \
+	  if [ "$$vofile" -ot "$$viofile" -o ! -e "$$vofile" ]; then printf "$$viofile "; fi; \
+	done); \
+	echo "VIO2VO: $$VIOFILES"; \
+	if [ -n "$$VIOFILES" ]; then \
+	  $(TIMER) $(COQC) $(COQDEBUG) $(COQFLAGS) -schedule-vio2vo $(J) $$VIOFILES; \
+	fi
+.PHONY: quick2vo
 
 checkproofs:
 	$(TIMER) $(COQC) $(COQDEBUG) $(COQFLAGS) \


### PR DESCRIPTION
This adds a new target to do both `make quick` and `make vio2vo`, and to only `vio2vo` those files where the `vio` is newer than the `vo`.

For now, I did not touch the existing target to (a) keep compatibility -- I have no idea why this was even split into two different goals, so I don't feel like I can make the decision to remove that split -- and (b) because this is not working perfectly due to <https://coq.inria.fr/bugs/show_bug.cgi?id=5223>. That problem in principle also exists with the existing target, but there one can work around it my deleting all `*.vo` files -- due to how naive `vio2vo` is, this dosn't actually cost any time. It re-does all the work all the time anyway.

Btw, I have no idea which bugreport that comment is referring to... or maybe this is not my name misspelled, but referring to someone else?

I think a better approach, while still mostly keeping compatibility, would be to make `vio2vo` smart about timestamps as well, and to have `quick2vo` just call `quick` and then `vio2vo` -- but again, I didn't know why things work the way they work, so I didn't want to change them.

---

Recursively calling `make` is not nice. The problem with adding the `.vio` files as dependencies like for `make quick` is that one would have to do `make quick2vo -j8 J=8` -- this looks somewhat silly. The right fix for this is for Coq's `-schedule-vio2vo` to gain support for talking with make's jobserver, so that its parallelism is controlled by make.