### PR TITLE
Fix BZ#5750 (recovering ability to print the hole of a context obtained by ltac pattern-matching)

### DIFF
--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -464,7 +464,7 @@ and detype_r d flags avoid env sigma t =
           (* Using a dash to be unparsable *)
 	  GEvar (Id.of_string_soft "CONTEXT-HOLE", [])
         else
-	  GEvar (Id.of_string_soft ("M" ^ string_of_int n), [])
+	  GEvar (Id.of_string_soft ("INTERNAL#" ^ string_of_int n), [])
     | Var id ->
 	(try let _ = Global.lookup_named id in GRef (VarRef id, None)
 	 with Not_found -> GVar id)

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -460,8 +460,11 @@ and detype_r d flags avoid env sigma t =
 	 in GVar (Id.of_string s))
     | Meta n ->
 	(* Meta in constr are not user-parsable and are mapped to Evar *)
-        (* using numbers to be unparsable *)
-	GEvar (Id.of_string ("M" ^ string_of_int n), [])
+        if n = Constr_matching.special_meta then
+          (* Using a dash to be unparsable *)
+	  GEvar (Id.of_string_soft "CONTEXT-HOLE", [])
+        else
+	  GEvar (Id.of_string_soft ("M" ^ string_of_int n), [])
     | Var id ->
 	(try let _ = Global.lookup_named id in GRef (VarRef id, None)
 	 with Not_found -> GVar id)

--- a/test-suite/bugs/closed/5750.v
+++ b/test-suite/bugs/closed/5750.v
@@ -1,0 +1,3 @@
+(* Check printability of the hole of the context *)
+Goal 0 = 0.
+match goal with |- context c [0] => idtac c end.


### PR DESCRIPTION
This is a possible fix to [BZ#5750](https://coq.inria.fr/bugs/show_bug.cgi?id=5750) (the hole of a context obtained by ltac matching was written `?M-1` in 8.6 but its printing fails in 8.7 beta).

The main fix is to use `is_ident_soft` to prevent the failing. The rest of the commit is to provide something a bit more appealing than `?M-1`. I tentatively adopted `?CONTEXT-HOLE` with a `-` to indicate that it was somehow special.

Another commit rename metas from `?Mxxx` to `?INTERNAL#xxx`. Don't know if it is a good idea. The change might be more disturbing than the attempt to more clearly distinguish Meta from Evar... So, this second commit is mainly for discussion, and I'm not sure that I would otherwise keep it.
