### PR TITLE
Re-enable checker error messages

### DIFF
--- a/checker/checker.ml
+++ b/checker/checker.ml
@@ -380,8 +380,10 @@ let init_feedback_listener () =
   let pp_loc fmt loc = let open Loc in match loc with
     | None     -> fprintf fmt ""
     | Some loc ->
-      fprintf fmt "File \"%s\", line %d, characters %d-%d:@\n"
-        loc.fname loc.line_nb (loc.bp-loc.bol_pos) (loc.ep-loc.bol_pos) in
+      let where =
+        match loc.fname with InFile f -> f | ToplevelInput -> "Toplevel input" in
+      fprintf fmt "\"%s\", line %d, characters %d-%d:@\n"
+        where loc.line_nb (loc.bp-loc.bol_pos) (loc.ep-loc.bol_pos) in
   let checker_feed (fb : Feedback.feedback) = let open Feedback in
   match fb.contents with
   | Processed   -> ()

--- a/checker/mod_checking.ml
+++ b/checker/mod_checking.ml
@@ -25,7 +25,7 @@ let refresh_arity ar =
     | _ -> ar, Univ.ContextSet.empty
 
 let check_constant_declaration env kn cb =
-  Feedback.msg_notice (str "  checking cst:" ++ prcon kn);
+  Flags.if_verbose Feedback.msg_notice (str "  checking cst:" ++ prcon kn);
   (** [env'] contains De Bruijn universe variables *)
   let env' =
     match cb.const_universes with


### PR DESCRIPTION
Supersedes (and contains #901). I plan to add some (trivial) functional tests for the checker, but given how critical this bug is, we may want to merge this first.

#1066 is also very related but contains an assertion that I think should be replaced by tests (but not there yet)