### PR TITLE
Mini fix at improving the cannot unify error message

### DIFF
--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -300,6 +300,8 @@ let explain_unification_error env sigma p1 p2 = function
      | NotSameArgSize | NotSameHead | NoCanonicalStructure ->
         (* Error speaks from itself *) []
      | ConversionFailed (env,t1,t2) ->
+        let t1 = Reductionops.nf_betaiota sigma t1 in
+        let t2 = Reductionops.nf_betaiota sigma t2 in
         if EConstr.eq_constr sigma t1 p1 && EConstr.eq_constr sigma t2 p2 then [] else
         let env = make_all_name_different env sigma in
         let t1 = Evarutil.nf_evar sigma t1 in


### PR DESCRIPTION
In the `term bla has type bli while it is expected to have type blu (cannot unify bli' and blu')` message, sometimes `bli'` or `blu'` only differs from `bli` and `blu` by βɩ-reduction. We add βɩ-reduction on `bli'` and `blu'` (as it was already the case for `bli` and `blu`) so that the test checking whether `bli` and `bli'` as well as `blu` and `blu'` are the same works well and prevents writing a redundant `cannot unify` parenthesis as expected.

In a second commit we remove all `nf_evars` of `Himsg` which have become useless after the move to `EConstr`.