### PR TITLE
After testing it in live, writing metas using an ?INTERNAL#42 style is ugly

### DIFF
--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -464,7 +464,7 @@ and detype_r d flags avoid env sigma t =
           (* Using a dash to be unparsable *)
 	  GEvar (Id.of_string_soft "CONTEXT-HOLE", [])
         else
-	  GEvar (Id.of_string_soft ("INTERNAL#" ^ string_of_int n), [])
+	  GEvar (Id.of_string_soft ("M" ^ string_of_int n), [])
     | Var id ->
 	(try let _ = Global.lookup_named id in GRef (VarRef id, None)
 	 with Not_found -> GVar id)


### PR DESCRIPTION
Printing metas still happens relatively often. From the user point of view, no need to know that it is different from an evar, so the notation `?M42` as it was before is much lighter. As for developers
looking for debugging information, they will easily suspect that it is internally a meta because of the `"M"`.

This reverts "Proposing meta names more distinguishable from evar names than ?M42." (dc5b8f1793c6f7104f0b4762d9887be255709ead) which was a part of #1074.