### PR TITLE
Fixing a little parsing bug with level 90 introduced in 3e70ea9c.

### DIFF
--- a/parsing/egramcoq.ml
+++ b/parsing/egramcoq.ml
@@ -34,6 +34,7 @@ let default_levels =
   [200,Extend.RightA,false;
    100,Extend.RightA,false;
    99,Extend.RightA,true;
+   90,Extend.RightA,true;
    10,Extend.RightA,false;
    9,Extend.RightA,false;
    8,Extend.RightA,true;
@@ -44,6 +45,7 @@ let default_pattern_levels =
   [200,Extend.RightA,true;
    100,Extend.RightA,false;
    99,Extend.RightA,true;
+   90,Extend.RightA,true;
    11,Extend.LeftA,false;
    10,Extend.RightA,false;
    1,Extend.LeftA,false;

--- a/parsing/g_constr.ml4
+++ b/parsing/g_constr.ml4
@@ -376,6 +376,7 @@ GEXTEND Gram
     | "100" RIGHTA
       [ p = pattern; "|"; pl = LIST1 pattern SEP "|" -> CAst.make ~loc:!@loc @@ CPatOr (p::pl) ]
     | "99" RIGHTA [ ]
+    | "90" RIGHTA [ ]
     | "11" LEFTA
       [ p = pattern; "as"; id = ident ->
         CAst.make ~loc:!@loc @@ CPatAlias (p, id) ]


### PR DESCRIPTION
Unfortunately, some manual synchronization is needed between the `constr` parser and the table of `constr`/`pattern` levels.

We do this synchronization which was missing in the commit moving `"x -> y"` to a user-level notation.

Symptom was:
```coq
Notation "** x" := (id x) (at level 15).    
Print Grammar constr.
```
which gives
```coq
...
| "30" RIGHTA
  [ SELF; "^"; constr:operconstr LEVEL "30" ]
| "15" RIGHTA
  [ "**"; NEXT ]
| "90" RIGHTA
  [  ]
| "10" LEFTA
  [ SELF; LIST1 constr:appl_arg
 ...
```
