### PR TITLE
BZ#5637, look for Obligation num or Next Obligation to start proof for coqwc

### DIFF
--- a/tools/coqwc.mll
+++ b/tools/coqwc.mll
@@ -94,7 +94,7 @@ let rcs = "\036" rcs_keyword [^ '$']* "\036"
 let stars = "(*" '*'* "*)"
 let dot = '.' (' ' | '\t' | '\n' | '\r' | eof)
 let proof_start =
-  "Theorem" | "Lemma" | "Fact" | "Remark" | "Goal" | "Correctness" | "Obligation" | "Next"
+  "Theorem" | "Lemma" | "Fact" | "Remark" | "Goal" | "Correctness" | "Obligation" space+ (['0' - '9'])+ | "Next" space+ "Obligation"
 let def_start =
   "Definition" | "Fixpoint" | "Instance"
 let proof_end =


### PR DESCRIPTION
Instead of looking for isolated keywords `Next` and `Obligation` to start counting proof lines, look for `Next<whitespace>+Obligation` and `Obligation<whitespace>+num`.

With this change, the proof line count for the example in BZ#5637 becomes 0. Replacing the first line with `Next Obligation.` or `Obligation 42.`, the count becomes positive.

The idea that these two constructs can start a proof comes from section 24.2 of the Reference Manual; I hope I've interpreted that correctly.
