### PR TITLE
Avoid looping when searching for CoqProject.

### DIFF
--- a/lib/coqProject_file.ml4
+++ b/lib/coqProject_file.ml4
@@ -206,7 +206,7 @@ let rec find_project_file ~from ~projfile_name =
   if Sys.file_exists fname then Some fname
   else
     let newdir = Filename.dirname from in
-    if newdir = "" || newdir = "/" then None
+    if newdir = from then None
     else find_project_file ~from:newdir ~projfile_name
 ;;
 


### PR DESCRIPTION
This could happen with paths on Windows, or even relative paths on all
OSs.

Fixes #5730: CoqIDE becomes unresponsive on file open.