### PR TITLE
Fixing an old proof engine bug in collecting evars with cleared context.

### DIFF
--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -153,8 +153,12 @@ let focus i j sp =
   ( { sp with comb = new_comb } , context )
 
 (** [undefined defs l] is the list of goals in [l] which are still
-    unsolved (after advancing cleared goals). *)
-let undefined defs l = CList.map_filter (Evarutil.advance defs) l
+    unsolved (after advancing cleared goals). Note that order matters. *)
+let undefined defs l =
+  List.fold_right (fun evk l ->
+      match Evarutil.advance defs evk with
+      | Some evk -> List.add_set Evar.equal evk l
+      | None -> l) l []
 
 (** Unfocuses a proofview with respect to a context. *)
 let unfocus c sp =

--- a/test-suite/success/unshelve.v
+++ b/test-suite/success/unshelve.v
@@ -9,3 +9,11 @@ unshelve (refine (F _ _ _ _)).
 + exact (@eq_refl bool true).
 + exact (@eq_refl unit tt).
 Qed.
+
+(* This was failing in 8.6, because of ?a:nat being wrongly duplicated *)
+
+Goal (forall a : nat, a = 0 -> True) -> True.
+intros F.
+unshelve (eapply (F _);clear F).
+2:reflexivity.
+Qed.


### PR DESCRIPTION
The function `Proofview.undefined` was collecting twice the evars that had advanced. Consequently, the functions `Proofview.unshelve` and `Proofview.with_shelf` were possibly doing the same. These functions were used in tactic `unshelve` leading to the following (unexpected) duplication of goals:
```coq
Goal (forall a : nat, a = 0 -> True) -> True.
intros F.
unshelve (eapply (F _);clear F).
(* 
3 subgoals
______________________________________(1/3)
nat
______________________________________(2/3)
nat
______________________________________(3/3)
?n = 0
*) 
```
Type classes resolution was also using these functions, so maybe it was impacted too.

This is a bug from at least 8.5.

Note that when both an evar and its restriction are in the `future_goals`, I made that `undefined` keeps the restricted one at the position of the original one, so as to preserve the order at creation time. Maybe a better implementation would be that when an evar is restricted, its restriction is not added to `future_goals`. Then we would have the invariant that `undefined` works on a disjoint list. We could also have that `future_goals` replaces the `existential_key` of the original evars by the `existential_key` of its restriction (but preserving the order), then `advance` may not be needed, perhaps. @mattam82, @aspiwack, @ppedrot, @gares, what do you think? (I'm unsure of what invariants @aspiwack primarily wanted to have.)

[Edited to resolve a confusing sentence.]