### PR TITLE
Fix GeoCoq CI and remove it from allowed failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,9 +62,6 @@ env:
 
 matrix:
 
-  allow_failures:
-  - env: TEST_TARGET="ci-geocoq TIMED=1"
-
   include:
     # Full Coq test-suite with two compilers
     - env:

--- a/dev/ci/ci-geocoq.sh
+++ b/dev/ci/ci-geocoq.sh
@@ -8,9 +8,5 @@ GeoCoq_CI_DIR=${CI_BUILD_DIR}/GeoCoq
 git_checkout ${GeoCoq_CI_BRANCH} ${GeoCoq_CI_GITURL} ${GeoCoq_CI_DIR}
 
 ( cd ${GeoCoq_CI_DIR}                                     && \
-  ./configure.sh                                          && \
-  sed -i.bak '/Ch16_coordinates_with_functions\.v/d' Make && \
-  sed -i.bak '/Elements\/Book_1\.v/d'                Make && \
-  sed -i.bak '/Elements\/Book_3\.v/d'                Make && \
-  coq_makefile -f Make -o Makefile                        && \
+  ./configure-ci.sh                                       && \
   make )


### PR DESCRIPTION
The shared `configure-ci.sh` script proposed in GeoCoq/GeoCoq#7 means that we are testing the exact same files in Coq CI as in GeoCoq CI.