### PR TITLE
Adding 3 Arith/QArith lemmas that I found useful

### DIFF
--- a/theories/Arith/PeanoNat.v
+++ b/theories/Arith/PeanoNat.v
@@ -172,6 +172,17 @@ Proof.
  apply leb_le.
 Qed.
 
+
+Lemma leb_not_le n m : (n <=? m) = false -> n > m.
+Proof.
+  revert m; induction n; destruct m; simpl; intros H_nm.
+  - congruence.
+  - congruence.
+  - apply lt_succ_r, le_0_n.
+  - specialize (IHn _ H_nm).
+    now apply lt_succ_r in IHn.
+Qed.
+
 (** ** Decidability of equality over [nat]. *)
 
 Lemma eq_dec : forall n m : nat, {n = m} + {n <> m}.

--- a/theories/Arith/PeanoNat.v
+++ b/theories/Arith/PeanoNat.v
@@ -172,11 +172,6 @@ Proof.
  apply leb_le.
 Qed.
 
-Lemma leb_not_le n m : (n <=? m) = false <-> ~n <= m.
-Proof.
-  now rewrite <- leb_le, <- not_true_iff_false.
-Qed.
-
 (** ** Decidability of equality over [nat]. *)
 
 Lemma eq_dec : forall n m : nat, {n = m} + {n <> m}.

--- a/theories/Arith/PeanoNat.v
+++ b/theories/Arith/PeanoNat.v
@@ -172,15 +172,9 @@ Proof.
  apply leb_le.
 Qed.
 
-
-Lemma leb_not_le n m : (n <=? m) = false -> n > m.
+Lemma leb_not_le n m : (n <=? m) = false <-> ~n <= m.
 Proof.
-  revert m; induction n; destruct m; simpl; intros H_nm.
-  - congruence.
-  - congruence.
-  - apply lt_succ_r, le_0_n.
-  - specialize (IHn _ H_nm).
-    now apply lt_succ_r in IHn.
+  now rewrite <- leb_le, <- not_true_iff_false.
 Qed.
 
 (** ** Decidability of equality over [nat]. *)

--- a/theories/QArith/QArith_base.v
+++ b/theories/QArith/QArith_base.v
@@ -188,7 +188,7 @@ Qed.
 
 Lemma Qeq_bool_trans x y z: Qeq_bool x y = true -> Qeq_bool y z = true -> Qeq_bool x z = true.
 Proof.
-  rewrite !Qeq_bool_iff. apply Qeq_trans.
+  rewrite !Qeq_bool_iff; apply Qeq_trans.
 Qed.
 
 Hint Resolve Qnot_eq_sym : qarith.

--- a/theories/QArith/QArith_base.v
+++ b/theories/QArith/QArith_base.v
@@ -171,6 +171,19 @@ Proof.
  auto with qarith.
 Qed.
 
+Lemma Qeq_bool_sym x y: Qeq_bool x y = Qeq_bool y x.
+Proof.
+  case_eq (Qeq_bool x y); intros H_eq_xy.
+  - unfold Qeq_bool in *.
+    rewrite <- Zeq_is_eq_bool in H_eq_xy.
+    rewrite H_eq_xy; symmetry.
+    rewrite <- Zeq_is_eq_bool; auto.
+  - apply Zeq_bool_neq in H_eq_xy.
+    case_eq (Qeq_bool y x); intros H_eq_yx.
+    + apply Zeq_is_eq_bool in H_eq_yx; congruence.
+    + auto.
+Qed.
+
 Hint Resolve Qnot_eq_sym : qarith.
 
 (** * Addition, multiplication and opposite *)

--- a/theories/QArith/QArith_base.v
+++ b/theories/QArith/QArith_base.v
@@ -176,19 +176,19 @@ Proof.
  apply eq_true_iff_eq. rewrite !Qeq_bool_iff. now symmetry.
 Qed.
 
-Lemma Qeq_bool_refl x: is_true (Qeq_bool x x).
+Lemma Qeq_bool_refl x: Qeq_bool x x = true.
 Proof.
-  unfold is_true. rewrite Qeq_bool_iff. now reflexivity.
+  rewrite Qeq_bool_iff. now reflexivity.
 Qed.
 
-Lemma Qeq_bool_sym x y: is_true (Qeq_bool x y) -> is_true (Qeq_bool y x).
+Lemma Qeq_bool_sym x y: Qeq_bool x y = true -> Qeq_bool y x = true.
 Proof.
-  unfold is_true. rewrite !Qeq_bool_iff. now symmetry.
+  rewrite !Qeq_bool_iff. now symmetry.
 Qed.
 
-Lemma Qeq_bool_trans x y z: is_true (Qeq_bool x y) -> is_true (Qeq_bool y z) -> is_true (Qeq_bool x z).
+Lemma Qeq_bool_trans x y z: Qeq_bool x y = true -> Qeq_bool y z = true -> Qeq_bool x z = true.
 Proof.
-  unfold is_true. rewrite !Qeq_bool_iff. apply Qeq_trans.
+  rewrite !Qeq_bool_iff. apply Qeq_trans.
 Qed.
 
 Hint Resolve Qnot_eq_sym : qarith.

--- a/theories/QArith/QArith_base.v
+++ b/theories/QArith/QArith_base.v
@@ -176,6 +176,21 @@ Proof.
  apply eq_true_iff_eq. rewrite !Qeq_bool_iff. now symmetry.
 Qed.
 
+Lemma Qeq_bool_refl x: is_true (Qeq_bool x x).
+Proof.
+  unfold is_true. rewrite Qeq_bool_iff. now reflexivity.
+Qed.
+
+Lemma Qeq_bool_sym x y: is_true (Qeq_bool x y) -> is_true (Qeq_bool y x).
+Proof.
+  unfold is_true. rewrite !Qeq_bool_iff. now symmetry.
+Qed.
+
+Lemma Qeq_bool_trans x y z: is_true (Qeq_bool x y) -> is_true (Qeq_bool y z) -> is_true (Qeq_bool x z).
+Proof.
+  unfold is_true. rewrite !Qeq_bool_iff. apply Qeq_trans.
+Qed.
+
 Hint Resolve Qnot_eq_sym : qarith.
 
 (** * Addition, multiplication and opposite *)

--- a/theories/QArith/QArith_base.v
+++ b/theories/QArith/QArith_base.v
@@ -171,17 +171,9 @@ Proof.
  auto with qarith.
 Qed.
 
-Lemma Qeq_bool_sym x y: Qeq_bool x y = Qeq_bool y x.
+Lemma Qeq_bool_comm x y: Qeq_bool x y = Qeq_bool y x.
 Proof.
-  case_eq (Qeq_bool x y); intros H_eq_xy.
-  - unfold Qeq_bool in *.
-    rewrite <- Zeq_is_eq_bool in H_eq_xy.
-    rewrite H_eq_xy; symmetry.
-    rewrite <- Zeq_is_eq_bool; auto.
-  - apply Zeq_bool_neq in H_eq_xy.
-    case_eq (Qeq_bool y x); intros H_eq_yx.
-    + apply Zeq_is_eq_bool in H_eq_yx; congruence.
-    + auto.
+ apply eq_true_iff_eq. rewrite !Qeq_bool_iff. now symmetry.
 Qed.
 
 Hint Resolve Qnot_eq_sym : qarith.

--- a/theories/QArith/Qabs.v
+++ b/theories/QArith/Qabs.v
@@ -100,6 +100,13 @@ rewrite Z.abs_mul.
 reflexivity.
 Qed.
 
+Lemma Qabs_Qinv : forall q, Qabs (/ q) == / (Qabs q).
+Proof.
+  intros [n d]; simpl.
+  unfold Qinv.
+  case_eq n; intros; simpl in *; apply Qeq_refl.
+Qed.
+  
 Lemma Qabs_Qminus x y: Qabs (x - y) = Qabs (y - x).
 Proof.
  unfold Qminus, Qopp. simpl.


### PR DESCRIPTION
During a few Coq proofs, I needed the following lemmas:
```coq
Lemma leb_not_le n m : (n <=? m) = false -> n > m.
Lemma Qabs_Qinv : forall q, Qabs (/ q) == / (Qabs q).
Lemma Qeq_bool_sym x y: Qeq_bool x y = Qeq_bool y x.
```

It may be interesting to add them to Coq theories?