### PR TITLE
Autolink to Github PRs from Bugzilla

### DIFF
--- a/dev/Bugzilla_Coq_autolink.user.js
+++ b/dev/Bugzilla_Coq_autolink.user.js
@@ -1,0 +1,25 @@
+﻿// ==UserScript==
+// @name        Bugzilla Coq autolink
+// @namespace   CoqScript
+// @include     https://coq.inria.fr/bugs/*
+// @description Makes #XXXX into links to Github Coq PRs
+// @version     1
+// @grant       none
+// ==/UserScript==
+
+var regex = /#(\d+)/g;
+var substr = '<a href="https://github.com/coq/coq/pull/$1">$&</a>';
+
+function doNode(node)
+{
+    node.innerHTML = node.innerHTML.replace(regex,substr);
+}
+
+var comments = document.getElementsByClassName("bz_comment_table")[0];
+var pars = comments.getElementsByClassName("bz_comment_text");
+
+for(var j=0; j<pars.length; j++)
+{
+    doNode(pars[j]);
+}
+


### PR DESCRIPTION
This PR complements #1104. If installed, entering `#nnnn` in a Bugzilla comment automatically links to the relevant PR in Github.

I'm not adding any documentation in this PR, but if `dev/README` is updated, it should mention the two `.js` scripts.
