### PR TITLE
Fixing BZ#5765 (an anomaly with 'pat in the parameters of an inductive definition)

### DIFF
--- a/test-suite/bugs/closed/5765.v
+++ b/test-suite/bugs/closed/5765.v
@@ -1,0 +1,3 @@
+(* 'pat binder not (yet?) allowed in parameters of inductive types *)
+
+Fail Inductive X '(a,b) := x.

--- a/vernac/command.ml
+++ b/vernac/command.ml
@@ -518,7 +518,8 @@ let check_param = function
 | CLocalDef (na, _, _) -> check_named na
 | CLocalAssum (nas, Default _, _) -> List.iter check_named nas
 | CLocalAssum (nas, Generalized _, _) -> ()
-| CLocalPattern _ -> assert false
+| CLocalPattern (loc,_) ->
+    Loc.raise ?loc (Stream.Error "pattern with quote not allowed here.")
 
 let interp_mutual_inductive (paramsl,indl) notations cum poly prv finite =
   check_all_names_different indl;


### PR DESCRIPTION
Obvious fix: to replace the `assert false` by a proper error message.