### PR TITLE
[ltac] Remove Deprecated `Add Morphism` form.

### DIFF
--- a/doc/refman/Setoid.tex
+++ b/doc/refman/Setoid.tex
@@ -588,31 +588,6 @@ where \textit{Aeq} is a congruence relation without parameters,
 symmetry and transitivity lemmas). Notice that the syntax is not completely
 backward compatible since the identifier was not required.
 
-\comindex{Add Morphism}
-\begin{quote}
-  \texttt{Add Morphism} \textit{f}:\textit{ident}.\\
-  Proof.\\
-  \ldots\\
-  Qed.
-\end{quote}
-
-The latter command also is restricted to the declaration of morphisms without
-parameters. It is not fully backward compatible since the property the user
-is asked to prove is slightly different: for $n$-ary morphisms the hypotheses
-of the property are permuted; moreover, when the morphism returns a
-proposition, the property is now stated using a bi-implication in place of
-a simple implication. In practice, porting an old development to the new
-semantics is usually quite simple.
-
-Notice that several limitations of the old implementation have been lifted.
-In particular, it is now possible to declare several relations with the
-same carrier and several signatures for the same morphism. Moreover, it is
-now also possible to declare several morphisms having the same signature.
-Finally, the replace and rewrite tactics can be used to replace terms in
-contexts that were refused by the old implementation. As discussed in
-the next section, the semantics of the new \texttt{setoid\_rewrite}
-command differs slightly from the old one and \texttt{rewrite}.
-
 \asection{Extensions}
 \subsection{Rewriting under binders}
 

--- a/plugins/ltac/g_rewrite.ml4
+++ b/plugins/ltac/g_rewrite.ml4
@@ -252,13 +252,6 @@ VERNAC COMMAND FUNCTIONAL EXTEND AddSetoid1 CLASSIFIED AS SIDEFF
          add_setoid (not (Locality.make_section_locality atts.locality)) binders a aeq t n;
          st
      ]
-  | [ "Add" "Morphism" constr(m) ":" ident(n) ]
-    (* This command may or may not open a goal *)
-    => [ Vernacexpr.VtUnknown, Vernacexpr.VtNow ]
-    -> [ fun ~atts ~st -> let open Vernacinterp in
-           add_morphism_infer (not (Locality.make_section_locality atts.locality)) m n;
-           st
-       ]
   | [ "Add" "Morphism" constr(m) "with" "signature" lconstr(s) "as" ident(n) ]
     => [ Vernacexpr.(VtStartProof("Classic",GuaranteesOpacity,[n]), VtLater) ]
     -> [ fun ~atts ~st -> let open Vernacinterp in

--- a/plugins/ltac/rewrite.mli
+++ b/plugins/ltac/rewrite.mli
@@ -83,8 +83,6 @@ val add_setoid :
   bool -> local_binder_expr list -> constr_expr -> constr_expr -> constr_expr ->
   Id.t -> unit
 
-val add_morphism_infer : bool -> constr_expr -> Id.t -> unit
-
 val add_morphism :
   bool -> local_binder_expr list -> constr_expr -> constr_expr -> Id.t -> unit
 


### PR DESCRIPTION
We remove deprecated form `Add Morphism op : id`.

The reason is that this is one of the few commands to require
"dynamic" classification; c.f. #459 #566 #1095, which is quite
problematic.

Another option to keep the command would be to require that it always
starts a proof; however, as the command is marked as deprecated we try
its removal with the consequent cleanup.

Note that the documentation marks the command as always starting a
proof, however I deduced from the classifier history that this is not
correct.