### PR TITLE
[ci] Remove deploy to GitHub of OS X package.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -173,14 +173,6 @@ matrix:
         skip_cleanup: true
         on:
           all_branches: true
-      - provider: releases
-        api_key:
-          secure: "Z/ewvydCLXEhlBBtQGYm2nZ8o+2RP+MwA5uEDuu6mEpZttUZAYaoHivChxADLXz8LNKvUloIeBeIL/PrLk6QnhSur/s2iEYHssrnl99SkAPtoWggyfsdacuKLMkpLoZGOBIEYKPuXuEZyqvugSUO42rSya1zdjcnXc4l+E/bXMc="
-        file: _build/*.dmg
-        skip_cleanup: true
-        on:
-          tags: true
-          repo: coq/coq
 
 before_install:
 - if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then echo "Tested commit (followed by parent commits):"; git log -1; for commit in `git log -1 --format="%P"`; do echo; git log -1 $commit; done; fi


### PR DESCRIPTION
This is inconvenient because it can only be tested on tags and it didn't work for V8.7+beta1.