### PR TITLE
Shorten the .gitattributes file.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,3 @@
-.dir-locals.el export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
 .mailmap export-ignore
-TODO export-ignore


### PR DESCRIPTION
`.dir-locals.el` can be useful for users of the tarballs as well (as remarked today on Gitter) and TODO doesn't exist anymore.
The `.gitattributes` file is now reduced to very git specific stuff.