### PR TITLE
Fix copyright info in reference manual.

### DIFF
--- a/doc/common/styles/html/coqremote/cover.html
+++ b/doc/common/styles/html/coqremote/cover.html
@@ -52,20 +52,7 @@
 <h2 style="text-align:center; font-size: 150%">The Coq Development Team</h2>
 <br /><br /><br />
 
-<div style="text-align: left; font-size: 80%; text-indent: 0pt">
-<ul style="list-style: none; margin-left: 0pt">
-  <li>V7.x © INRIA 1999-2004</li>
-  <li>V8.0 © INRIA 2004-2008</li>
-  <li>V8.1 © INRIA 2006-2011</li>
-  <li>V8.2 © INRIA 2008-2011</li>
-  <li>V8.3 © INRIA 2010-2011</li>
-  <li>V8.4 © INRIA 2012-2014</li>
-  <li>V8.5 © INRIA 2015-2016</li>
-  <li>V8.6 © INRIA 2016</li>
-</ul>
-
-<p style="text-indent:0pt">This research was partly supported by IST
-  working group ``Types''</p>
+<p style="text-indent:0pt">Copyright © INRIA 1999-2017</p>
 
 <p style="text-indent:0pt">This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at <a href="http://www.opencontent.org/openpub">http://www.opencontent.org/openpub</a>). Options A and B are not elected.</p>
 

--- a/doc/common/styles/html/simple/cover.html
+++ b/doc/common/styles/html/simple/cover.html
@@ -30,20 +30,7 @@
 <br /><br /><br />
 
 
-<div style="text-align: left; font-size: 80%; text-indent: 0pt">
-<ul style="list-style: none; margin-left: 0pt">
-  <li>V7.x © INRIA 1999-2004</li>
-  <li>V8.0 © INRIA 2004-2008</li>
-  <li>V8.1 © INRIA 2006-2011</li>
-  <li>V8.2 © INRIA 2008-2011</li>
-  <li>V8.3 © INRIA 2010-2011</li>
-  <li>V8.4 © INRIA 2012-2014</li>
-  <li>V8.5 © INRIA 2015-2016</li>
-  <li>V8.6 © INRIA 2016</li>
-</ul>
-
-<p style="text-indent:0pt">This research was partly supported by IST
-  working group ``Types''</p>
+<p style="text-indent:0pt">Copyright © INRIA 1999-2017</p>
 
 <p style="text-indent: 0pt">This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at <a href="http://www.opencontent.org/openpub">http://www.opencontent.org/openpub</a>). Options A and B are not elected.</p>
 


### PR DESCRIPTION
Also simplifies the way it is presented (no need to be overly precise).