### PR TITLE
TimeFileMaker.py: Allow trailing spaces

### DIFF
--- a/tools/TimeFileMaker.py
+++ b/tools/TimeFileMaker.py
@@ -28,10 +28,10 @@ def get_times(file_name):
     else:
         with open(file_name, 'r') as f:
             lines = f.read()
-    reg = re.compile(r'^([^\s]+) \([^\)]*?user: ([0-9\.]+)[^\)]*?\)$', re.MULTILINE)
+    reg = re.compile(r'^([^\s]+) \([^\)]*?user: ([0-9\.]+)[^\)]*?\)\s*$', re.MULTILINE)
     times = reg.findall(lines)
     if all(time in ('0.00', '0.01') for name, time in times):
-        reg = re.compile(r'^([^\s]*) \([^\)]*?real: ([0-9\.]+)[^\)]*?\)$', re.MULTILINE)
+        reg = re.compile(r'^([^\s]*) \([^\)]*?real: ([0-9\.]+)[^\)]*?\)\s*$', re.MULTILINE)
         times = reg.findall(lines)
     if all(STRIP_REG.search(name.strip()) for name, time in times):
         times = tuple((STRIP_REG.sub(STRIP_REP, name.strip()), time) for name, time in times)


### PR DESCRIPTION
This allows the timing aggregation scripts to handle logs from Travis,
which, for some reason, seems to insert trailing spaces.