### PR TITLE
Revert "Switch Travis to OSX 10.12 and Xcode 8.3.3."

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -136,7 +136,6 @@ matrix:
           packages: *coqide-packages
 
     - os: osx
-      osx_image: xcode8.3
       env:
       - TEST_TARGET="test-suite"
       - COMPILER="4.02.3"
@@ -149,7 +148,6 @@ matrix:
 
     - if: NOT type IS pull_request
       os: osx
-      osx_image: xcode8.3
       env:
       - TEST_TARGET=""
       - COMPILER="4.02.3"


### PR DESCRIPTION
This reverts commit 587e556a909fcd2e1507a9230d9cdaffa3f9394e from PR #1024.
This commit did not solve any issue at the time it was merged but made the macOS package we produce compatible only with macOS 10.12 and later.

Small note: thanks to the "Trigger build" feature of Travis, I was able to trigger a [new macOS packaging build for V8.7+beta2](https://travis-ci.org/coq/coq/builds/284445710), with a [fixed configuration](https://travis-ci.org/coq/coq/jobs/284445711/config). Hugo confirmed that the package worked on a version of macOS earlier to 10.12, so I replaced the one we distribute at https://github.com/coq/coq/releases/tag/V8.7%2Bbeta2. @maximedenes you might want to update the copy at https://coq.inria.fr/distrib/V8.7+beta2/files/ accordingly.

We might also want to revert the other commit in #1024, which is making the build log too verbose to be shown on Travis.