### PR TITLE
[stm] Remove Opacity Information from Theorem and Definition start.

### DIFF
--- a/API/API.mli
+++ b/API/API.mli
@@ -3719,12 +3719,9 @@ sig
      | VtKeep
      | VtKeepAsAxiom
      | VtDrop
-   and vernac_start = string * opacity_guarantee * Names.Id.t list
+   and vernac_start = string * Names.Id.t list
    and vernac_sideff_type = Names.Id.t list
    and vernac_part_of_script = bool
-   and opacity_guarantee =
-     | GuaranteesOpacity
-     | Doesn'tGuaranteeOpacity
    and proof_step = {
      parallel : [ `Yes of solving_tac * anon_abstracting_tac | `No ];
      proof_block_detection : proof_block_name option

--- a/intf/vernacexpr.ml
+++ b/intf/vernacexpr.ml
@@ -504,12 +504,9 @@ type vernac_type =
   | VtBack of vernac_part_of_script * Stateid.t
   | VtUnknown
 and vernac_qed_type = VtKeep | VtKeepAsAxiom | VtDrop (* Qed/Admitted, Abort *)
-and vernac_start = string * opacity_guarantee * Id.t list
+and vernac_start = string * Id.t list
 and vernac_sideff_type = Id.t list
 and vernac_part_of_script = bool
-and opacity_guarantee =
-  | GuaranteesOpacity (** Only generates opaque terms at [Qed] *)
-  | Doesn'tGuaranteeOpacity (** May generate transparent terms even with [Qed].*)
 and proof_step = { (* TODO: inline with OCaml 4.03 *)
   parallel : [ `Yes of solving_tac * anon_abstracting_tac | `No ];
   proof_block_detection : proof_block_name option

--- a/plugins/derive/g_derive.ml4
+++ b/plugins/derive/g_derive.ml4
@@ -12,7 +12,7 @@ open Stdarg
 
 DECLARE PLUGIN "derive_plugin"
 
-let classify_derive_command _ = Vernacexpr.(VtStartProof ("Classic",Doesn'tGuaranteeOpacity,[]),VtLater)
+let classify_derive_command _ = Vernacexpr.(VtStartProof ("Classic",[]),VtLater)
 
 VERNAC COMMAND EXTEND Derive CLASSIFIED BY classify_derive_command
 | [ "Derive" ident(f) "SuchThat" constr(suchthat) "As" ident(lemma) ] ->

--- a/plugins/funind/g_indfun.ml4
+++ b/plugins/funind/g_indfun.ml4
@@ -158,7 +158,7 @@ VERNAC COMMAND EXTEND Function
              (Vernacexpr.VernacFixpoint(None, List.map snd recsl))
          with
          | Vernacexpr.VtSideff ids, _ when hard ->
-             Vernacexpr.(VtStartProof ("Classic", GuaranteesOpacity, ids), VtLater)
+             Vernacexpr.(VtStartProof ("Classic", ids), VtLater)
          | x -> x ]
     -> [ do_generate_principle false (List.map snd recsl) ]
 END

--- a/plugins/ltac/g_obligations.ml4
+++ b/plugins/ltac/g_obligations.ml4
@@ -79,7 +79,7 @@ open Obligations
 let obligation obl tac = with_tac (fun t -> Obligations.obligation obl t) tac
 let next_obligation obl tac = with_tac (fun t -> Obligations.next_obligation obl t) tac
 
-let classify_obbl _ = Vernacexpr.(VtStartProof ("Classic",Doesn'tGuaranteeOpacity,[]), VtLater)
+let classify_obbl _ = Vernacexpr.(VtStartProof ("Classic",[]), VtLater)
 
 VERNAC COMMAND EXTEND Obligations CLASSIFIED BY classify_obbl
 | [ "Obligation" integer(num) "of" ident(name) ":" lglob(t) withtac(tac) ] ->

--- a/plugins/ltac/g_rewrite.ml4
+++ b/plugins/ltac/g_rewrite.ml4
@@ -250,11 +250,11 @@ VERNAC COMMAND EXTEND AddSetoid1 CLASSIFIED AS SIDEFF
     => [ Vernacexpr.VtUnknown, Vernacexpr.VtNow ]
     -> [ add_morphism_infer (not (Locality.make_section_locality (Locality.LocalityFixme.consume ()))) m n ]
   | [ "Add" "Morphism" constr(m) "with" "signature" lconstr(s) "as" ident(n) ]
-    => [ Vernacexpr.(VtStartProof("Classic",GuaranteesOpacity,[n]), VtLater) ]
+    => [ Vernacexpr.(VtStartProof("Classic",[n]), VtLater) ]
     -> [ add_morphism (not (Locality.make_section_locality (Locality.LocalityFixme.consume ()))) [] m s n ]
   | [ "Add" "Parametric" "Morphism" binders(binders) ":" constr(m)
         "with" "signature" lconstr(s) "as" ident(n) ]
-    => [ Vernacexpr.(VtStartProof("Classic",GuaranteesOpacity,[n]), VtLater) ]
+    => [ Vernacexpr.(VtStartProof("Classic",[n]), VtLater) ]
     -> [ add_morphism (not (Locality.make_section_locality (Locality.LocalityFixme.consume ()))) binders m s n ]
 END
 

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -114,7 +114,7 @@ type cmd_t = {
            | `TacQueue of solving_tac * anon_abstracting_tac * cancel_switch
            | `QueryQueue of cancel_switch
            | `SkipQueue ] }
-type fork_t = aast * Vcs_.Branch.t * Vernacexpr.opacity_guarantee * Names.Id.t list
+type fork_t = aast * Vcs_.Branch.t * Names.Id.t list
 type qed_t = {
   qast : aast;
   keep : vernac_qed_type;
@@ -348,7 +348,7 @@ end = struct (* {{{ *)
     let fname =
       "stm_" ^ Str.global_replace (Str.regexp " ") "_" (System.process_id ()) in
     let string_of_transaction = function
-      | Cmd { cast = t } | Fork (t, _,_,_) ->
+      | Cmd { cast = t } | Fork (t,_,_) ->
           (try Pp.string_of_ppcmds (pr_ast t) with _ -> "ERR")
       | Sideff (ReplayCommand t) ->
           sprintf "Sideff(%s)"
@@ -960,7 +960,7 @@ let get_script prf =
        Stateid.equal id Stateid.dummy then acc else
     let view = VCS.visit id in
     match view.step with
-    | `Fork((_,_,_,ns), _) when test ns -> acc
+    | `Fork((_,_,ns), _) when test ns -> acc
     | `Qed (qed, proof) -> find [qed.qast.expr, (VCS.get_info id).n_goals] proof
     | `Sideff (ReplayCommand x,_) ->
          find ((x.expr, (VCS.get_info id).n_goals)::acc) view.next
@@ -1083,7 +1083,7 @@ end = struct (* {{{ *)
         let ids, tactic, undo =
           if id = Stateid.initial || id = Stateid.dummy then [],false,0 else
           match VCS.visit id with
-          | { step = `Fork ((_,_,_,l),_) } -> l, false,0
+          | { step = `Fork ((_,_,l),_) } -> l, false,0
           | { step = `Cmd { cids = l; ctac } } -> l, ctac,0
           | { step = `Alias (_,{ expr = VernacUndo n}) } -> [], false, n
           | _ -> [],false,0 in
@@ -1594,7 +1594,7 @@ end = struct (* {{{ *)
       | Some (_, cur) ->
           match VCS.visit cur with
           | { step = `Cmd { cast = { loc } } }
-          | { step = `Fork (( { loc }, _, _, _), _) } 
+          | { step = `Fork (( { loc }, _, _), _) } 
           | { step = `Qed ( { qast = { loc } }, _) } 
           | { step = `Sideff (ReplayCommand { loc }, _) } ->
               let start, stop = Option.cata Loc.unloc (0,0) loc in
@@ -2066,15 +2066,13 @@ let collect_proof keep cur hd brkind id =
     | `Sideff (ReplayCommand x,_) -> collect (Some (id,x)) (id::accn) view.next
     (* An Alias could jump everywhere... we hope we can ignore it*)
     | `Alias _ -> `Sync (no_name,`Alias)
-    | `Fork((_,_,_,_::_::_), _) ->
+    | `Fork((_,_,_::_::_), _) ->
         `Sync (no_name,`MutualProofs)
-    | `Fork((_,_,Doesn'tGuaranteeOpacity,_), _) ->
-        `Sync (no_name,`Doesn'tGuaranteeOpacity)
-    | `Fork((_,hd',GuaranteesOpacity,ids), _) when has_proof_using last ->
+    | `Fork((_,hd',ids), _) when has_proof_using last ->
         assert (VCS.Branch.equal hd hd' || VCS.Branch.equal hd VCS.edit_branch);
         let name = name ids in
         `ASync (parent last,accn,name,delegate name)
-    | `Fork((_, hd', GuaranteesOpacity, ids), _) when
+    | `Fork((_, hd', ids), _) when
        has_proof_no_using last && not (State.is_cached_and_valid (parent last)) &&
        VCS.is_vio_doc () ->
         assert (VCS.Branch.equal hd hd'||VCS.Branch.equal hd VCS.edit_branch);
@@ -2086,7 +2084,7 @@ let collect_proof keep cur hd brkind id =
         with Not_found ->
           let name = name ids in
           `MaybeASync (parent last, accn, name, delegate name))
-    | `Fork((_, hd', GuaranteesOpacity, ids), _) ->
+    | `Fork((_, hd', ids), _) ->
         assert (VCS.Branch.equal hd hd' || VCS.Branch.equal hd VCS.edit_branch);
         let name = name ids in
         `MaybeASync (parent last, accn, name, delegate name)
@@ -2262,12 +2260,12 @@ let known_state ?(redefine_qed=false) ~cache id =
           stm_vernac_interp id x;
           if eff then update_global_env ()
         ), (if eff then `Yes else cache), true
-      | `Fork ((x,_,_,_), None) -> (fun () ->
+      | `Fork ((x,_,_), None) -> (fun () ->
             resilient_command reach view.next;
             stm_vernac_interp id x;
             wall_clock_last_fork := Unix.gettimeofday ()
           ), `Yes, true
-      | `Fork ((x,_,_,_), Some prev) -> (fun () -> (* nested proof *)
+      | `Fork ((x,_,_), Some prev) -> (fun () -> (* nested proof *)
             reach ~cache:`Shallow prev;
             reach view.next;
             (try stm_vernac_interp id x;
@@ -2647,16 +2645,16 @@ let process_transaction ?(newtip=Stateid.fresh ())
           anomaly(str"classifier: VtQuery + VtLater must imply part_of_script.")
 
       (* Proof *)
-      | VtStartProof (mode, guarantee, names), w ->
+      | VtStartProof (mode, names), w ->
           let id = VCS.new_node ~id:newtip () in
           let bname = VCS.mk_branch_name x in
           VCS.checkout VCS.Branch.master;
           if VCS.Branch.equal head VCS.Branch.master then begin
-            VCS.commit id (Fork (x, bname, guarantee, names));
+            VCS.commit id (Fork (x, bname, names));
             VCS.branch bname (`Proof (mode, VCS.proof_nesting () + 1))
           end else begin
             VCS.branch bname (`Proof (mode, VCS.proof_nesting () + 1));
-            VCS.merge id ~ours:(Fork (x, bname, guarantee, names)) head
+            VCS.merge id ~ours:(Fork (x, bname, names)) head
           end;
           Proof_global.activate_proof_mode mode [@ocaml.warning "-3"];
           Backtrack.record (); if w == VtNow then ignore(finish ~doc:dummy_doc); `Ok
@@ -2731,12 +2729,7 @@ let process_transaction ?(newtip=Stateid.fresh ())
             if not in_proof && Proof_global.there_are_pending_proofs () then
             begin
               let bname = VCS.mk_branch_name x in
-              let rec opacity_of_produced_term = function
-                (* This AST is ambiguous, hence we check it dynamically *)
-                | VernacInstance (false, _,_ , None, _) -> GuaranteesOpacity
-                | VernacLocal (_,e) -> opacity_of_produced_term e
-                | _ -> Doesn'tGuaranteeOpacity in
-              VCS.commit id (Fork (x,bname,opacity_of_produced_term x.expr,[]));
+              VCS.commit id (Fork (x,bname,[]));
               let proof_mode = default_proof_mode () in
               VCS.branch bname (`Proof (proof_mode, VCS.proof_nesting () + 1));
               Proof_global.activate_proof_mode proof_mode [@ocaml.warning "-3"];
@@ -2766,7 +2759,7 @@ let process_transaction ?(newtip=Stateid.fresh ())
 let get_ast ~doc id =
   match VCS.visit id with
   | { step = `Cmd { cast = { loc; expr } } }
-  | { step = `Fork (({ loc; expr }, _, _, _), _) } 
+  | { step = `Fork (({ loc; expr }, _, _), _) } 
   | { step = `Qed ({ qast = { loc; expr } }, _) } ->
          Some (Loc.tag ?loc expr)
   | _ -> None

--- a/stm/vernac_classifier.ml
+++ b/stm/vernac_classifier.ml
@@ -47,12 +47,6 @@ let declare_vernac_classifier
 =
   classifiers := !classifiers @ [s,f]
 
-let make_polymorphic (a, b as x) =
-  match a with
-  | VtStartProof (x, _, ids) ->
-      VtStartProof (x, Doesn'tGuaranteeOpacity, ids), b
-  | _ -> x
-
 let undo_classifier = ref (fun _ -> assert false)
 let set_undo_classifier f = undo_classifier := f
 
@@ -66,10 +60,7 @@ let rec classify_vernac e =
     (* Nested vernac exprs *)
     | VernacProgram e -> classify_vernac e
     | VernacLocal (_,e) -> classify_vernac e
-    | VernacPolymorphic (b, e) -> 
-      if b || Flags.is_universe_polymorphism () (* Ok or not? *) then
-	make_polymorphic (classify_vernac e)
-      else classify_vernac e
+    | VernacPolymorphic (b, e) -> classify_vernac e
     | VernacTimeout (_,e) -> classify_vernac e
     | VernacTime (_,e) | VernacRedirect (_, (_,e)) -> classify_vernac e
     | VernacFail e -> (* Fail Qed or Fail Lemma must not join/fork the DAG *)
@@ -108,32 +99,32 @@ let rec classify_vernac e =
     (* StartProof *)
     | VernacDefinition (
        (Some Decl_kinds.Discharge,Decl_kinds.Definition),((_,i),_),ProveBody _) ->
-        VtStartProof(default_proof_mode (),Doesn'tGuaranteeOpacity,[i]), VtLater
+        VtStartProof(default_proof_mode (),[i]), VtLater
     | VernacDefinition (_,((_,i),_),ProveBody _) ->
-        VtStartProof(default_proof_mode (),GuaranteesOpacity,[i]), VtLater
+        VtStartProof(default_proof_mode (),[i]), VtLater
     | VernacStartTheoremProof (_,l) ->
-        let ids = 
+        let ids =
           CList.map_filter (function (Some ((_,i),pl), _) -> Some i | _ -> None) l in
-        VtStartProof (default_proof_mode (),GuaranteesOpacity,ids), VtLater
-    | VernacGoal _ -> VtStartProof (default_proof_mode (),GuaranteesOpacity,[]), VtLater
+        VtStartProof (default_proof_mode (),ids), VtLater
+    | VernacGoal _ -> VtStartProof (default_proof_mode (),[]), VtLater
     | VernacFixpoint (_,l) ->
         let ids, open_proof =
           List.fold_left (fun (l,b) ((((_,id),_),_,_,_,p),_) ->
             id::l, b || p = None) ([],false) l in
         if open_proof
-        then VtStartProof (default_proof_mode (),GuaranteesOpacity,ids), VtLater
+        then VtStartProof (default_proof_mode (),ids), VtLater
         else VtSideff ids, VtLater
     | VernacCoFixpoint (_,l) ->
         let ids, open_proof =
           List.fold_left (fun (l,b) ((((_,id),_),_,_,p),_) ->
             id::l, b || p = None) ([],false) l in
         if open_proof
-        then VtStartProof (default_proof_mode (),GuaranteesOpacity,ids), VtLater
+        then VtStartProof (default_proof_mode (),ids), VtLater
         else VtSideff ids, VtLater
     (* Sideff: apply to all open branches. usually run on master only *)
     | VernacAssumption (_,_,l) ->
         let ids = List.flatten (List.map (fun (_,(l,_)) -> List.map (fun (id, _) -> snd id) l) l) in
-        VtSideff ids, VtLater    
+        VtSideff ids, VtLater
     | VernacDefinition (_,((_,id),_),DefineBody _) -> VtSideff [id], VtLater
     | VernacInductive (_, _,_,l) ->
         let ids = List.map (fun (((_,((_,id),_)),_,_,_,cl),_) -> id :: match cl with
@@ -201,10 +192,7 @@ let rec classify_vernac e =
         try List.assoc s !classifiers l ()
         with Not_found -> anomaly(str"No classifier for"++spc()++str (fst s)++str".")
   in
-  let res = static_classifier e in
-    if Flags.is_universe_polymorphism () then
-      make_polymorphic res
-    else res
+  static_classifier e
 
 let classify_as_query = VtQuery (true,Feedback.default_route), VtLater
 let classify_as_sideeff = VtSideff [], VtLater


### PR DESCRIPTION
This information was introduced in db65876 and IMHO was wrongly used all the way around.

It seems that some features of the proof layer and the document/STM ought to be better integrated; in particular as discussed in #682 we may want to revert eef907e and in fact go back to a design where the proof terms a proof is allowed to produce correspond to the information stored in `VtStartProof`.

I agree with the spirit of db65876 in the sense that the current static analysis is tied to document
traversal and this is inflexible in some scenarios; however we may want to be more regular at the vernac level too.

This PR is more a RFC than a request for immediate merge, and it depends on #1089 