### PR TITLE
[ide] Temporary fix to avoid race condition.

### DIFF
--- a/ide/wg_MessageView.ml
+++ b/ide/wg_MessageView.ml
@@ -123,6 +123,9 @@ let message_view () : message_view =
   end
   in
   (* Is there a better way to connect the signal ? *)
-  let w_cb (_ : Gtk.rectangle) = mv#refresh false in
-  ignore (view#misc#connect#size_allocate ~callback:w_cb);
+  (* Disable dynamic resizing for 8.7 due to the above redraw race-condition. *)
+  if false then begin
+    let w_cb (_ : Gtk.rectangle) = mv#refresh false in
+    ignore (view#misc#connect#size_allocate ~callback:w_cb)
+  end;
   mv

--- a/ide/wg_ProofView.ml
+++ b/ide/wg_ProofView.ml
@@ -240,6 +240,9 @@ let proof_view () =
   in
   (* Is there a better way to connect the signal ? *)
   (* Can this be done in the object constructor? *)
-  let w_cb _ = pf#refresh ~force:false in
-  ignore (view#misc#connect#size_allocate ~callback:w_cb);
+  (* Disable dynamic resizing for 8.7 due to the above redraw race-condition. *)
+  if false then begin
+    let w_cb _ = pf#refresh ~force:false in
+    ignore (view#misc#connect#size_allocate ~callback:w_cb)
+  end;
   pf


### PR DESCRIPTION
The dynamic resizing code still has a race condition that produces an
infinite redrawing under certain conditions.

While we investigate the bug more calmly, we disable dynamic resizing
for 8.7.