### PR TITLE
Deprecate Write/Restore State vernaculars.

### DIFF
--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -925,12 +925,20 @@ let vernac_chdir = function
 (********************)
 (* State management *)
 
+let warn_deprecated_state_vernaculars =
+  CWarnings.create ~name:"deprecated-state-vernaculars" ~category:"deprecated"
+         (fun () ->
+          strbrk "The \"Write State\" and \"Restore State\" commands are deprecated. " ++
+          strbrk "In some cases, Coq will not operate fully correctly when they are used.")
+
 let vernac_write_state file =
+  warn_deprecated_state_vernaculars ();
   Proof_global.discard_all ();
   let file = CUnix.make_suffix file ".coq" in
   States.extern_state file
 
 let vernac_restore_state file =
+  warn_deprecated_state_vernaculars ();
   Proof_global.discard_all ();
   let file = Loadpath.locate_file (CUnix.make_suffix file ".coq") in
   States.intern_state file


### PR DESCRIPTION
As mentioned in the discussion around PR#1088, some parts of Coq's
actual state (e.g. dynlinked code) are not saved, leading to anomalies
with native_compute and other incorrect behaviors.

So we send the user a deprecation warning, and we'll see what to do for
8.8 (keep things as they are, remove the commands or replace them with
an STM-based implementation).