### PR TITLE
[v8.7-only] Undeprecate Add Setoid.

### DIFF
--- a/plugins/ltac/rewrite.ml
+++ b/plugins/ltac/rewrite.ml
@@ -1935,12 +1935,7 @@ let default_morphism sign m =
   let evars, mor = resolve_one_typeclass env (goalevars evars) morph in
     mor, proper_projection sigma mor morph
 
-let warn_add_setoid_deprecated =
-  CWarnings.create ~name:"add-setoid" ~category:"deprecated" (fun () ->
-      Pp.(str "Add Setoid is deprecated, please use Add Parametric Relation."))
-
 let add_setoid global binders a aeq t n =
-  warn_add_setoid_deprecated ?loc:a.CAst.loc ();
   init_setoid ();
   let _lemma_refl = declare_instance_refl global binders a aeq n (mkappc "Seq_refl" [a;aeq;t]) in
   let _lemma_sym = declare_instance_sym global binders a aeq n (mkappc "Seq_sym" [a;aeq;t]) in


### PR DESCRIPTION
This partially reverts commit 798a39b7128132a87e21db4540faed5d7f924779.
The reason to go back on this deprecation is that uses of this command
had not been removed from the stdlib which was now emitting deprecation
warnings.