### PR TITLE
Bugzilla migration script.

### DIFF
--- a/dev/tools/bugzilla2github
+++ b/dev/tools/bugzilla2github
@@ -810,24 +810,18 @@ def github_issue_append(issue):
 # Maybe we can generate a backtrace
 def github_issues_add(issues):
     postponed = {}
-    nb_postponed = 0
     id = 1 # No bug id 1 in Coq's Bugzilla
     while True:
         id += 1
         if id in issues:
             issue = issues[id]
         else:
-            if nb_postponed == 0:
+            if len(postponed) == 0:
                 print "Error: No more postponed issues."
                 exit(1)
-            # Certainly not the most efficient way to find the first postponed issue
-            bugzilla_id = 0
-            while True:
-                bugzilla_id += 1
-                if bugzilla_id in postponed:
-                    break
+            # Find the first postponed issue
+            bugzilla_id = sorted(postponed.keys())[0]
             issue = postponed.pop(bugzilla_id)
-            nb_postponed -= 1
         if id > existingIssues and id > bugzillaIssues:
             github_issue = github_get("issues/%d" % id)
         if id <= existingIssues or id <= bugzillaIssues or github_issue:
@@ -839,7 +833,6 @@ def github_issues_add(issues):
             else:
                 print "Issue #%d already exists, postponing..." % id
                 postponed[id] = issue
-                nb_postponed += 1
         else:
             print "Creating issue #%d..." % id
             # Make sure the previous issue already exist

--- a/dev/tools/bugzilla2github
+++ b/dev/tools/bugzilla2github
@@ -35,7 +35,7 @@ existingIssues = 1080
 # Can be used to skip over already imported issues if the script was interrupted.
 # Re-plays everything but without issuing API calls.
 # Room for improvement.
-bugzillaIssues = 2879
+bugzillaIssues = 3274
 force_update = False
 xml_file = "bugzilla.xml"
 github_url = "https://api.github.com"
@@ -420,8 +420,10 @@ def str2str(map, str):
     return map[str]
 
 
-# Could be improved in the following way: if bug was already converted, find what id it has
-# otherwise, use BZ#NNNN syntax instead of #NNNN
+def id_convert(id):
+    global github_owner, github_repo
+    return "[BZ#" + id + "](https://github.com/" + github_owner + "/" + github_repo + "/issues?q=is%3Aissue%20%22Original%20bug%20ID%3A%20BZ%23" + id + "%22)"
+
 def ids_convert(ids):
     ret = []
 
@@ -429,11 +431,18 @@ def ids_convert(ids):
         return ""
     if isinstance(ids, list):
         for id in ids:
-            ret.append("#" + id)
+            ret.append(id_convert(id))
     else:
-        ret.append("#" + ids)
+        ret.append(id_convert(ids))
 
     return ", ".join(ret)
+
+def see_also_convert(see_also):
+    result = re.search('id=(\d+)$', see_also)
+    if not result:
+        return see_also
+    else:
+        return id_convert(result.group(1))
 
 
 def email_convert(email, name):
@@ -522,7 +531,7 @@ def comment_convert(comment, attachments):
     ret.append("")
 
     # Syntax: convert "bug id" to "bug #id"
-    # Same room for improvement here.
+    # We should adapt the same format here as in id_convert
     for i, val in enumerate(ret):
         ret[i] = re.sub(r"(?i)(bug)\s+([0-9]+)", r"\1 #\2", val)
 
@@ -612,10 +621,10 @@ def bug_convert(bug):
     if "see_also" in bug:
         see_also = bug.pop("see_also")
         if isinstance(see_also, basestring):
-            ret["body"].append("See also:     " + see_also)
+            ret["body"].append("See also: " + see_also_convert(see_also))
         else:
             for item in see_also:
-                ret["body"].append("See also:     " + item)
+                ret["body"].append("See also: " + see_also_convert(item))
     ret["body"].append("")
 
     # Put everything together

--- a/dev/tools/bugzilla2github
+++ b/dev/tools/bugzilla2github
@@ -27,15 +27,11 @@
 # Nix users can get the right environment by running:
 # $ nix-shell -p python2 python2Packages.requests
 
-import json, getopt, os, pprint, re, requests, sys, time, xml.etree.ElementTree
+import csv, getopt, json, os, pprint, re, requests, sys, time, xml.etree.ElementTree
 
 # Existing issues means issue numbers already taken on GitHub (by PRs mostly).
 # The script can find these by itself but this will spare API requests.
 existingIssues = 1080
-# Can be used to skip over already imported issues if the script was interrupted.
-# Re-plays everything but without issuing API calls.
-# Room for improvement.
-bugzillaIssues = 3483
 force_update = False
 xml_file = "bugzilla.xml"
 github_url = "https://api.github.com"
@@ -778,9 +774,9 @@ def github_issue_append(bugzilla_id, issue):
     global github_owner, github_repo, github_token
     params = { "access_token": github_token }
     headers = { "Accept": "application/vnd.github.golden-comet-preview+json" }
-    print "\tappending a new issue on GitHub..."
+    print "\timporting BZ#%d on GitHub..." % bugzilla_id
     u = "https://api.github.com/repos/%s/%s/import/issues" % (github_owner, github_repo)
-    comments = issue.pop("comments")
+    comments = issue.pop("comments", [])
     # We can't assign people which are not in the organization / collaborators on the repo
     if github_owner != "coq":
         issue.pop("assignee", None)
@@ -801,7 +797,6 @@ def github_issue_append(bugzilla_id, issue):
         exit(1)
     # The issue_url field of the answer should be of the form .../ISSUE_NUMBER
     # So it's easy to get the issue number, to check that it is what was expected
-    # And even to spare a few get requests to the GitHub API
     result = re.match("https://api.github.com/repos/" + github_owner + "/" + github_repo + "/issues/(\d+)", r.json()["issue_url"])
     if not result:
         print "Error while parsing issue number:\n%s" % r.text
@@ -811,9 +806,6 @@ def github_issue_append(bugzilla_id, issue):
     return issue_number
 
 
-# Room for improvement in this function
-# Maybe we can be more resilient
-# Maybe we can generate a backtrace
 def github_issues_add(issues):
     postponed = {}
     id = 1 # No bug id 1 in Coq's Bugzilla
@@ -833,17 +825,9 @@ def github_issues_add(issues):
             # Find the first postponed issue
             bugzilla_id = sorted(postponed.keys())[0]
             issue = postponed.pop(bugzilla_id)
-        if id > existingIssues and id > bugzillaIssues:
-            github_issue = github_get("issues/%d" % id)
-        if id <= existingIssues or id <= bugzillaIssues or github_issue:
-            # Check if the issue was imported from the Bugzilla
-            if id > existingIssues and id <= bugzillaIssues:
-                print "Issue #%d already imported." % id
-            elif id > existingIssues and ("Original bug ID: BZ#%d\n" % id).lower() in github_issue.json()["body"].lower():
-                print "Issue #%d already imported." % id
-            else:
-                print "Issue #%d already exists, postponing..." % id
-                postponed[id] = issue
+        if id <= existingIssues or github_get("issues/%d" % id):
+            print "Issue #%d already exists, postponing..." % id
+            postponed[bugzilla_id] = issue
         else:
             print "Creating issue #%d..." % id
             # Make sure the previous issue already exist
@@ -887,7 +871,7 @@ def args_parse(argv):
 
 
 def main(argv):
-    global xml_file, github_owner, github_repo
+    global xml_file, github_owner, github_repo, existingIssues
 
     # Parse command line arguments
     args_parse(argv)
@@ -900,11 +884,22 @@ def main(argv):
     xml_root = xml_tree.getroot()
     issues = bugs_convert(xml_root)
 
+    try:
+        with open("bugzilla2github.log", "r") as f:
+            print "===> Skipping already imported issues..."
+            imported_bugs = csv.reader(f)
+            for imported_bug in imported_bugs:
+                issues.pop(int(imported_bug[0]), None)
+                existingIssues = max(existingIssues, int(imported_bug[1]))
+    except IOError:
+        print "===> No log file found. Not skipping any issue."
+
     print "===> Checking all the labels exist on GitHub..."
     github_labels_check(issues)
     print "===> Checking all the assignees exist on GitHub..."
     github_assignees_check(issues)
-    # fake_issue = { "title": "Fake issue", "body": "Fake issue" }
+
+    # fake_issue = { "title": "Fake issue", "body": "Fake issue", "closed": True }
     # for i in xrange(1,existingIssues + 1):
     #     github_issue_append(0, fake_issue)
 

--- a/dev/tools/bugzilla2github
+++ b/dev/tools/bugzilla2github
@@ -571,9 +571,6 @@ def bug_convert(bug):
     ret["title"] = bug.pop("short_desc")
     # Convert creation_ts to created_at
     ret["created_at"] = date_convert(bug.pop("creation_ts"))
-    assignee = str2str(email2login, bug.pop("assigned_to"))
-    if assignee:
-        ret["assignee"] = assignee
     # Convert component to labels
     ret["labels"].extend(str2list(component2labels, bug.pop("component")))
     # Convert bug_status to state
@@ -581,8 +578,13 @@ def bug_convert(bug):
     if ret["closed"]:
         # Convert delta_ts to closed_at
         ret["closed_at"] = date_convert(bug.pop("delta_ts"))
+        bug.pop("assigned_to")
     else:
         bug.pop("delta_ts")
+        # We only assigned open bug reports
+        assignee = str2str(email2login, bug.pop("assigned_to"))
+        if assignee:
+            ret["assignee"] = assignee
     # Convert (optional) keywords to labels
     ret["labels"].extend(str2list(keywords2labels, bug.pop("keywords","")))
     # Convert resolution to labels
@@ -594,7 +596,6 @@ def bug_convert(bug):
 
     # Create the bug description
     ret["body"].append("Original bug ID: BZ#%d" % ret["number"])
-    ret["body"].append("Date: " + ret["created_at"])
     ret["body"].append("From: " + email_convert(bug.pop("reporter"),
                         bug.pop("reporter.name", None)))
     ret["body"].append("Reported version: " + bug.pop("version"))
@@ -770,6 +771,9 @@ def github_issue_append(issue):
     print "\tappending a new issue on GitHub..."
     u = "https://api.github.com/repos/%s/%s/import/issues" % (github_owner, github_repo)
     comments = issue.pop("comments")
+    # We can't assign people which are not in the organization / collaborators on the repo
+    if github_owner != "coq":
+        issue.pop("assignee", None)
     r = requests.post(u, params = params, headers = headers,
                       data = json.dumps({ "issue": issue, "comments": comments }))
     if not r:
@@ -888,7 +892,6 @@ def main(argv):
     github_labels_check(issues)
     print "===> Checking all the assignees exist on GitHub..."
     github_assignees_check(issues)
-
     # fake_issue = { "title": "Fake issue", "body": "Fake issue" }
     # for i in xrange(1,existingIssues + 1):
     #     github_issue_append(fake_issue)

--- a/dev/tools/bugzilla2github
+++ b/dev/tools/bugzilla2github
@@ -1,0 +1,921 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+#
+# Bugzilla XML File to GitHub Issues Converter
+# by Andriy Berestovskyy (https://github.com/semihalf-berestovskyy-andriy/tools/)
+# Adapted for the Coq bug tracker migration by Théo Zimmermann
+# This script is licensed under the Apache 2.0 license.
+#
+# How to use the script:
+# 1. Generate a GitHub access token:
+#    - on GitHub select "Settings"
+#    - select "Personal access tokens"
+#    - click "Generate new token"
+#    - type a token description, i.e. "bugzilla2github"
+#    - select "public_repo" to access just public repositories
+#    - save the generated token into the migration script
+# 2. Export Bugzilla issues into an XML file:
+#    - go to https://coq.inria.fr/bugs/buglist.cgi?bug_status=UNCONFIRMED&bug_status=NEW&bug_status=ASSIGNED&bug_status=REOPENED&bug_status=RESOLVED&bug_status=VERIFIED&bug_status=CLOSED&limit=0&order=bug_id&query_format=advanced&resolution=---&resolution=FIXED&resolution=INVALID&resolution=WONTFIX&resolution=DUPLICATE&resolution=WORKSFORME&resolution=MOVED
+#    - at the very end click the XML icon
+#    - save the XML into a file: bugzilla.xml
+# 3. Run the migration script and check all the warnings:
+#    bugzilla2github -x bugzilla.xml -o berestovskyy -r test -t beefbeefbeef
+# 4. Run the migration script again and force the updates:
+#    bugzilla2github -x bugzilla.xml -o berestovskyy -r test -t beefbeefbeef -f
+#
+# The script depends on the requests package.
+# Nix users can get the right environment by running:
+# $ nix-shell -p python2 python2Packages.requests
+
+import json, getopt, os, pprint, re, requests, sys, time, xml.etree.ElementTree
+
+# Existing issues means issue numbers already taken on GitHub (by PRs mostly).
+# The script can find these by itself but this will spare API requests.
+existingIssues = 1148
+# Can be used to skip over already imported issues if the script was interrupted.
+# Re-plays everything but without issuing API calls.
+# Room for improvement.
+bugzillaIssues = 0
+force_update = False
+# Avoid @-mentioning users during the tests.
+test = True
+xml_file = "bugzilla.xml"
+github_url = "https://api.github.com"
+github_owner = ""
+github_repo = ""
+github_token = ""
+
+reload(sys)
+sys.setdefaultencoding('utf-8')
+
+email2login = {
+    "__name__": "email to GitHub login",
+    "aa755@cs.cornell.edu": "aa755",
+    "abhishek.anand.iitg@gmail.com": "aa755",
+    "adam@chlipala.net": "achlipala-biz",
+    "adamc@cs.berkeley.edu": "achlipala-biz",
+    "adamc@hcoop.net": "achlipala-biz",
+    "adam.koprowski@gmail.com": "akoprow",
+    "akhirsch@gwmail.gwu.edu": "akhirsch",
+    "alan.schmitt@inria.fr": "brabalan",
+    "alexandre.pilkiewicz+bug-coq@polytechnique.org": "pilki",
+    "amintimany@gmail.com": "amintimany",
+    "anders@anderslundstedt.se": "anderslundstedt",
+    "andersk@mit.edu": "andersk",
+    "andreser-coqbugs@mit.edu": "andres-erbsen",
+    "Andrej.Bauer@andrej.com": "andrejbauer",
+    "andrew.mccreight@yale.edu": "amccreight",
+    "mccreigh@pdx.edu": "amccreight",
+    "anne.pacalet@sophia.inria.fr": "anne-pacalet",
+    "appel@princeton.edu": "andrew-appel",
+    "armael.gueneau@inria.fr": "Armael",
+    "arnaud.spiwack@gmail.com": "aspiwack",
+    "arthur.aa@gmail.com": "arthuraa",
+    "arthur.chargueraud@ens-lyon.fr": "charguer",
+    "arthur.chargueraud@inria.fr": "charguer",
+    "aspiwack@lix.polytechnique.fr": "aspiwack",
+    "assia.mahboubi@sophia.inria.fr": "amahboubi",
+    "assia.mahboubi@inria.fr": "amahboubi",
+    "asr@eafit.edu.co": "asr",
+    "asyabergal@gmail.com": "asya-bergal",
+    "baydemir@cis.upenn.edu": "brianaydemir2",
+    "bcpierce@cis.upenn.edu": "bcpierce00",
+    "bernhardschommer@gmail.com": "bschommer",
+    "blanqui@loria.fr": "fblanqui",
+    "boris@yakobowski.org": "yakobowski",
+    "Bruno.Barras@trusted-logic.fr": "barras",
+    "bruno.barras@inria.fr": "barras",
+    "bzapf@online.de": "bastiaanzapf",
+    "catalin.hritcu@inria.fr": "catalin-hritcu",
+    "chantal.keller@wanadoo.fr": "ckeller",
+    "ch.martin+coq@gmail.com": "chris-martin",
+    "christoph.senjak@ifi.lmu.de": "dasuxullebt",
+    "clement.pit@gmail.com": "cpitclaudel",
+    "cohen@crans.org": "CohenCyril",
+    "constantine.plotnikov@gmail.com": "const",
+    "coqbugs@contacts.eelis.net": "Eelis",
+    "coq-bugs@contacts.eelis.net": "Eelis",
+    "coq-bugs@jbapple.com": "jbapple",
+    "coq@robbertkrebbers.nl": "robbertkrebbers",
+    "coq@yforster.de": "yforster",
+    "cyprien.mangin@m4x.org": "cmangin",
+    "daniel.de_rauglaudre@inria.fr": "roglo",
+    "David.Monniaux@ens.fr": "monniaux",
+    "David.Nowak@lsv.ens-cachan.fr": "davidnowak",
+    "david.nowak@univ-lille1.fr": "davidnowak",
+    "denis.redozubov@gmail.com": "dredozubov",
+    "dfoxfranke@gmail.com": "dfoxfranke",
+    "dfu@college.harvard.edu": "DanFu09",
+    "dirk.pattinson@anu.edu.au": "dirk-pattinson",
+    "didickman@gmail.com": "didickman",
+    "dmz@mit.edu": "daniel-ziegler",
+    "drg@uiuc.edu": "DanGrayson",
+    "e@x80.org": "ejgallego",
+    "elazarg@gmail.com": "elazarg",
+    "enrico.tassi@inria.fr": "gares",
+    "erik@martin-dorel.org": "erikmd",
+    "eternaleye+coq@gmail.com": "eternaleye",
+    "ezyang@mit.edu": "ezyang",
+    "fdhzs2010@hotmail.com": "HuStmpHrrr",
+    "fdsteffahn@gmail.com": "staffehn",
+    "filliatr@lri.fr": "backtracking",
+    "Florent.Hivert@univ-mlv.fr": "hivert",
+    "forest@ensiie.fr": "forestjulien",
+    "francois.garillot@ens.fr": "huitseeker",
+    "francois.garillot@inria.fr": "huitseeker",
+    "francois.pottier@inria.fr": "fpottier",
+    "frederic.besson@inria.fr": "fajb",
+    "frederic.blanqui@inria.fr": "fblanqui",
+    "frederic.peschanski@lip6.fr": "fredokun",
+    "frederic.tuong@inria.fr": "tuong",
+    "gaetan.gilbert@ens-lyon.fr": "SkySkimmer",
+    "gaetan.gilbert@skyskimmer.net": "SkySkimmer",
+    "gabriel.scherer@gmail.com": "gasche",
+    "gares@fettunta.org": "gares",
+    "gdsfh1@gmail.com": "gdsfh",
+    "georges.gonthier@inria.fr": "ggonthier",
+    "gmalecha@gmail.com": "gmalecha",
+    "gmalecha@eecs.harvard.edu": "gmalecha",
+    "greenrd@greenrd.org": "greenrd",
+    "guillaume.allais@ens-lyon.org": "gallais",
+    "guillaume.bury@gmail.com": "gbury",
+    "guillaume.melquiond@inria.fr": "silene",
+    "guillaume.melquiond@ens-lyon.fr": "silene",
+    "Guillaume.Rousse@inria.fr": "guillomovitch",
+    "hendrik@askra.de": "hendriktews",
+    "Hugo.Herbelin@inria.fr": "herbelin",
+    "herbelin@pauillac.inria.fr": "herbelin",
+    "igorjirkov@gmail.com": "sayon",
+    "ikdc-coqbugs@mit.edu": "ichung",
+    "i.sergey@ucl.ac.uk": "ilyasergey",
+    "itz@speakeasy.org": "nobrowser",
+    "jade.philipoom@gmail.com": "jadephilipoom",
+    "janno@mpi-sws.org": "Janno",
+    "jasongross9+bugzilla@gmail.com": "JasonGross",
+    "jasperh@cs.washington.edu": "jashug",
+    "Jean-Christophe.Filliatre@lri.fr": "backtracking",
+    "jean-christophe.lechenet@cea.fr": "eponier",
+    "jebe@itu.dk": "jesper-bengtson",
+    "jelle@defekt.nl": "wires",
+    "jeremie.koenig@gmail.com": "jeremie-koenig",
+    "jk@jk.fr.eu.org": "jeremie-koenig",
+    "jlottes@gmail.com": "jlottes",
+    "jonikelee@gmail.com": "jonleivent",
+    "johnw@newartisans.com": "jwiegley",
+    "jourgun@gmail.com": "jhjourdan",
+    "juhani.bonsdorff@gmail.com": "JBons",
+    "Julien.Narboux@inria.fr": "jnarboux",
+    "julien@narboux.fr": "jnarboux",
+    "Julien.Signoles@wanadoo.fr": "signoles",
+    "julien.tesson@lacl.fr": "picojulien",
+    "signoles@edcsm.jussieu.fr": "signoles",
+    "Julien.Signoles@lri.fr": "signoles",
+    "kzi@cs.uni.wroc.pl": "klara-zielinska",
+    "lai.zhangsheng@gmail.com": "zunction",
+    "Lars.Rasmusson@sics.se": "larsr",
+    "lazyswamp@gmail.com": "kwanghoon",
+    "letouzey@lri.fr": "letouzey",
+    "Letouzey@pauillac.inria.fr": "letouzey",
+    "letouzey@math.lmu.de": "letouzey",
+    "lionel.rieg@ens-lyon.org": "Lionel-Rieg",
+    "lolisa@marisa.moe": "MarisaKirisame",
+    "magaud@dpt-info.u-strasbg.fr": "magaud",
+    "magaud@unistra.fr": "magaud",
+    "marc.lasson@gmail.com": "mlasson",
+    "maggesi@math.unice.fr": "maggesi",
+    "matej.kosik@inria.fr": "matejkosik",
+    "mattator@gmail.com": "teto",
+    "matthieu.sozeau@inria.fr": "mattam82",
+    "mail@maximedenes.fr": "maximedenes",
+    "mdoerri@cs.jhu.edu": "doerrie",
+    "mhelvens@gmail.com": "mhelvens",
+    "michael.soegtrop@intel.com": "MSoegtropIMC",
+    "nadeem@acm.org": "nadeemabdulhamid",
+    "naesten@gmail.com": "SamB",
+    "nathan.collins@gmail.com": "ntc2",
+    "nickolai@csail.mit.edu": "zeldovich",
+    "Nicolas.Magaud@sophia.inria.fr": "magaud",
+    "noury@lri.fr": "NicolasOury",
+    "pauliankline@gmail.com": "paul-kline",
+    "pierre.boutillier@inria.fr": "pirbo",
+    "Pierre.Courtieu@sophia.inria.fr": "Matafou",
+    "Pierre.Courtieu@univ-orleans.fr": "Matafou",
+    "Pierre.Courtieu@cnam.fr": "Matafou",
+    "Pierre.Courtieu@gmail.com": "Matafou",
+    "pierre.cregut@orange-ftgroup.com": "pierrecregut",
+    "pierre.cregut@rd.francetelecom.fr": "pierrecregut",
+    "pierre.cregut@rd.francetelecom.com": "pierrecregut",
+    "pierre.letouzey@inria.fr": "letouzey",
+    "pierre-marie.pedrot@ens-lyon.org": "ppedrot",
+    "pierre.roux@ens-lyon.org": "proux01",
+    "porton@narod.ru": "vporton",
+    "post+coq@ralfj.de": "RalfJung",
+    "ppk@cse.iitk.ac.in": "piyush-kurur",
+    "psteck@mit.edu": "pstecker",
+    "public@clarus.me": "clarus",
+    "roconn@mcmaster.ca": "roconnor",
+    "roconnor@cs.ru.nl": "roconnor",
+    "roconnor@theorem.ca": "roconnor",
+    "r.oconnor@cs.ru.nl": "roconnor",
+    "rr@cs.st-andrews.ac.uk": "robrwo",
+    "saemi472@gmail.com": "samuelgruetter",
+    "sakaguchi@coins.tsukuba.ac.jp": "pi8027",
+    "sherman@csail.mit.edu": "bmsherman",
+    "schneck@math.berkeley.edu": "tupelo-schneck",
+    "shulman@sandiego.edu": "mikeshulman",
+    "sebastien.briais@epfl.ch": "sbriais",
+    "siegebell@gmail.com": "siegebell",
+    "siegebell+bugzilla@gmail.com": "siegebell",
+    "sigurd.schneider@cs.uni-saarland.de": "sigurdschneider",
+    "sliverdragon37@gmail.com": "sliverdragon37",
+    "simon.boulier@ens-rennes.fr": "SimonBoulier",
+    "shlomif@gmail.com": "shlomif",
+    "shlomif@iglu.org.il": "shlomif",
+    "spitters@cs.ru.nl": "spitters",
+    "spitters@cs.kun.nl": "spitters",
+    "stefanor@cox.net": "sorear",
+    "steph@glondu.net": "glondu",
+    "stevez@cis.upenn.edu": "Zdancewic",
+    "sullivan.kevinj@gmail.com": "kevinsullivan",
+    "Sylvain.Boulme@lip6.fr": "boulme",
+    "Sylvain.Boulme@imag.fr": "boulme",
+    "tabareau@pps.jussieu.fr": "tabareau",
+    "tadeuzagallo@gmail.com": "tadeuzagallo",
+    "tassi@cs.unibo.it": "gares",
+    "tchajed@mit.edu": "tchajed",
+    "thery@sophia.inria.fr": "thery",
+    "theo.belaire@gmail.com": "tbelaire",
+    "theo.winterhalter@gmail.com": "TheoWinterhalter",
+    "theo.zimmermann@univ-paris-diderot.fr": "Zimmi48",
+    "thierry.martinez@inria.fr": "thierry-martinez",
+    "thomas.braibant@gmail.com": "braibant",
+    "tom.prince@ualberta.net": "tomprince",
+    "treinen@debian.org": "treinen",
+    "t.tebbi@gmail.com": "tebbi",
+    "valentin.robert.42@gmail.com": "Ptival",
+    "vsiles@lix.polytechnique.fr": "vsiles",
+    "vzaliva@cmu.edu": "vzaliva",
+    "vincent.laporte@gmail.com": "vgbl",
+    "wangpeng@csail.mit.edu": "wangpengmit",
+    "westbrook@galois.com": "eddywestbrook",
+    "xavier.clerc@inria.fr": "xclerc",
+    "Xavier.Leroy@inria.fr": "xavierleroy",
+    "yann.regis-gianas@pps.jussieu.fr": "yurug",
+    "yannick.zakowski@irisa.fr": "YaZko",
+    "yrg@pps.jussieu.fr": "yurug",
+    "Yves.Bertot@sophia.inria.fr": "ybertot",
+    "Yves.Bertot@pauillac.inria.fr": "ybertot",
+    "Yves.Bertot@inria.fr": "ybertot",
+}
+status2state = {
+    "__name__": "status to GitHub state",
+    "NEW": "open",
+    "UNCONFIRMED": "open",
+    "CONFIRMED": "open",
+    "VERIFIED": "open",
+    "ASSIGNED": "open",
+    "IN_PROGRESS": "open",
+    "RESOLVED": "closed",
+    "CLOSED": "closed",
+    "REOPENED": "open",
+}
+component2labels = {
+    "__name__": "component to GitHub labels",
+    "Main": [],
+    "Checker": ["component: checker"],
+    "Doc": ["kind: documentation"],
+    "Extraction": ["component: extraction"],
+    "Funind": ["component: funind"],
+    "IDE": ["component: IDE"],
+    "Installation": [ "component: installation" ],
+    "Kernel": ["component: kernel"],
+    "Ltac": ["component: ltac"],
+    "Modules": ["component: modules"],
+    "Native compiler": ["component: native compiler"],
+    "Notations": ["component: notations"],
+    "Program": ["component: program"],
+    "SSReflect": ["component: ssreflect"],
+    "Stdlib": ["component: stdlib"],
+    "STM": ["component: STM"],
+    "Tactics": ["component: tactics"],
+    "Tools": ["component: tools"],
+    "Typeclasses": ["component: typeclasses"],
+    "VM": ["component: VM"],
+    "Website": ["component: website"],
+}
+keywords2labels = {
+    "__name__": "keywords to GitHub labels",
+    "compatibility": ["kind: compatibility"],
+    "performance": ["kind: performance"],
+    "performance, regression":  ["kind: performance", "kind: regression"],
+    "regression": ["kind: regression"],
+}
+resolution2labels = {
+    "__name__": "resolution to GitHub labels",
+    "FIXED": [],
+    "DUPLICATE": ["resolved: duplicate"],
+    "INVALID": ["resolved: invalid"],
+    "MOVED": ["resolved: closed"],
+    "WONTFIX": ["resolved: won't fix"],
+    "WORKSFORME": ["resolved: works for me"],
+}
+op_sys2labels = {
+    "__name__": "Operating System to GitHub labels",
+    "Mac OS": [ "platform: OS X" ],
+    "Windows": [ "platform: Windows" ],
+    "Linux": [],
+    "Other": [],
+    "All": []
+}
+bug_unused_fields = [
+    "actual_time",
+    "attachment.isobsolete",
+    "attachment.ispatch",
+    "attachment.isprivate",
+    "bug_file_loc",
+    "cclist_accessible",
+    "classification",
+    "classification_id",
+    "comment_sort_order",
+    "deadline",
+    "estimated_time",
+    "everconfirmed",
+    "long_desc.isprivate",
+    "priority",
+    "product",
+    "remaining_time",
+    "reporter_accessible",
+    "rep_platform",
+    "bug_severity",
+    "target_milestone",
+    "token",
+]
+comment_unused_fields = [
+    "commentid",
+    "comment_count",
+    "attachid",
+    "work_time",
+]
+attachment_unused_fields = [
+    "attacher",
+    "attacher.name",
+    "date",
+    "delta_ts",
+    "token",
+]
+
+def usage():
+    print "Bugzilla XML file to GitHub Issues Converter"
+    print "Usage: %s [-h] [-f]\n" \
+        "\t[-x <src XML file>]\n" \
+        "\t[-o <dst GitHub owner>] [-r <dst repo>] [-t <dst access token>]\n" \
+            % os.path.basename(__file__)
+    print "Example:"
+    print "\t%s -h" % os.path.basename(__file__)
+    print "\t%s -x bugzilla.xml -o dst_login -r dst_repo -t dst_token" \
+            % os.path.basename(__file__)
+    exit(1)
+
+
+def XML2dict(parent):
+    ret = {}
+
+    for key in parent:
+        # TODO: debug
+        # print len(key), key.tag, key.attrib, key.text
+        if len(key) > 0:
+            val = XML2dict(key)
+        else:
+            val = key.text
+        if key.text:
+            if key.tag not in ret:
+                ret[key.tag] = val
+            else:
+                if isinstance(ret[key.tag], list):
+                    ret[key.tag].append(val)
+                else:
+                    ret[key.tag] = [ret[key.tag], val]
+        # Parse attributes
+        for name, val in key.items():
+            ret["%s.%s" % (key.tag, name)] = val
+
+    return ret
+
+
+def str2list(map, str):
+    if str not in map:
+        print "WARNING: unable to convert %s: %s" % (map["__name__"], str)
+        # Suppress further reports
+        map[str] = []
+
+    return map[str]
+
+
+def str2str(map, str):
+    if str not in map:
+        print "WARNING: unable to convert %s: %s" % (map["__name__"], str)
+        # Suppress further reports
+        map[str] = None
+
+    return map[str]
+
+
+# Could be improved in the following way: if bug was already converted, find what id it has
+# otherwise, use BZ#NNNN syntax instead of #NNNN
+def ids_convert(ids):
+    ret = []
+
+    if not ids:
+        return ""
+    if isinstance(ids, list):
+        for id in ids:
+            ret.append("#" + id)
+    else:
+        ret.append("#" + ids)
+
+    return ", ".join(ret)
+
+
+def email_convert(email, name):
+    ret = str2str(email2login, email)
+    if ret:
+        if test:
+            # Add space to avoid notifying people during tests
+            return "@ " + ret
+        else:
+            return "@" + ret
+    else:
+        if name and not name.find("@") >= 0:
+            return "%s &lt;<%s>&gt;" % (name, email)
+        else:
+            return email
+
+
+def emails_convert(emails):
+    ret = []
+    if isinstance(emails, list):
+        for email in emails:
+            ret.append(email_convert(email, None))
+    else:
+        ret.append(email_convert(emails, None))
+
+    return ret
+
+
+def fields_ignore(obj, fields):
+    # Ignore some Bugzilla fields
+    for field in fields:
+        obj.pop(field, None)
+    if test:
+        obj.pop("assigned_to", None)
+        obj.pop("assigned_to.name", None)
+
+
+def fields_dump(obj):
+    # Make sure we have converted all the fields
+    for key, val in obj.items():
+        print " " * 8 + "%s[%d] = %s" % (key, len(val), val)
+
+
+def attachment_convert(idx, attach):
+    ret = []
+
+    id = attach.pop("attachid")
+    ret.append("> Attached file: [%s](https://coq.inria.fr/bugfiles/attachment.cgi?id=%s) (%s, %s bytes)" % (attach.pop("filename"), id, attach.pop("type"), attach.pop("size")))
+    if "desc" in attach:
+        ret.append("> Description:   " + attach.pop("desc"))
+
+    # Ignore some fields
+    global attachment_unused_fields
+    fields_ignore(attach, attachment_unused_fields)
+    # Make sure we have converted all the fields
+    if attach:
+        print "WARNING: unconverted attachment fields:"
+        fields_dump(attach)
+
+    idx[id] = "\n".join(ret)
+
+def attachments_convert(attachments):
+    ret = {}
+    if isinstance(attachments, list):
+        for attachment in attachments:
+            attachment_convert(ret, attachment)
+    else:
+        attachment_convert(ret, attachments)
+
+    return ret
+
+
+def comment_convert(comment, attachments):
+    ret = []
+
+    ret.append("### " + email_convert(comment.pop("who"), comment.pop("who.name", None)) + " on " + comment.pop("bug_when"))
+    ret.append("")
+    ret.append(comment.pop("thetext", "").replace("@", "@ "))
+    # Add space after @ to avoid spurious GitHub-mentions
+    ret.append("")
+    # Convert attachments if any
+    if "attachid" in comment:
+        attachid = comment.pop("attachid")
+        if attachid in attachments:
+            ret.append(attachments.pop(attachid))
+            ret.append("")
+    ret.append("")
+
+    # Syntax: convert "bug id" to "bug #id"
+    # Same room for improvement here.
+    for i, val in enumerate(ret):
+        ret[i] = re.sub(r"(?i)(bug)\s+([0-9]+)", r"\1 #\2", val)
+
+    # Ignore some comment fields
+    global comment_unused_fields
+    fields_ignore(comment, comment_unused_fields)
+    # Make sure we have converted all the fields
+    if comment:
+        print "WARNING: unconverted comment fields:"
+        fields_dump(comment)
+
+    return "\n".join(ret)
+
+
+def comments_convert(comments, attachments):
+    ret = []
+    if isinstance(comments, list):
+        for comment in comments:
+            ret.append(comment_convert(comment, attachments))
+    else:
+        ret.append(comment_convert(comments, attachments))
+
+    return ret
+
+
+def bug_convert(bug):
+    ret = {}
+    ret["body"] = []
+    ret["body"].append("Note: the issue was created automatically with %s tool"
+                        % os.path.basename(__file__))
+    ret["body"].append("")
+    ret["labels"] = []
+    ret["assignees"] = []
+    ret["comments"] = []
+    attachments = {}
+
+    # Convert bug_id to number
+    ret["number"] = int(bug.pop("bug_id"))
+    # Convert attachments if any
+    if "attachment" in bug:
+        attachments = attachments_convert(bug.pop("attachment"))
+    # Convert long_desc and attachment to comments
+    ret["comments"].extend(comments_convert(bug.pop("long_desc"), attachments))
+    # Convert short_desc to title
+    ret["title"] = bug.pop("short_desc")
+    # Convert creation_ts to created_at
+    ret["created_at"] = bug.pop("creation_ts")
+    # Convert delta_ts to updated_at
+    ret["updated_at"] = bug.pop("delta_ts")
+    # Convert reporter to user login
+    ret["user.login"] = email_convert(bug.pop("reporter"),
+                        bug.pop("reporter.name", None))
+    # Convert assigned_to to assignees (disabled during tests)
+    if not test:
+        ret["assignees"].append(email_convert(bug.pop("assigned_to"),
+                                              bug.pop("assigned_to.name", None)))
+    # Convert component to labels
+    ret["labels"].extend(str2list(component2labels, bug.pop("component")))
+    # Convert bug_status to state
+    ret["state"] = str2str(status2state, bug.pop("bug_status"))
+    # Convert (optional) keywords to labels
+    ret["labels"].extend(str2list(keywords2labels, bug.pop("keywords","")))
+    # Convert resolution to labels
+    if "resolution" in bug:
+        ret["labels"].extend(str2list(resolution2labels, bug.pop("resolution")))
+    # Convert op_sys to labels
+    if "op_sys" in bug:
+        ret["labels"].extend(str2list(op_sys2labels, bug.pop("op_sys")))
+    # Convert version to version
+    ret["version"] = bug.pop("version")
+
+    # Create the bug description
+    ret["body"].append("Original bug ID: BZ#%d" % ret["number"])
+    ret["body"].append("Date: " + ret["created_at"])
+    ret["body"].append("From: " + ret["user.login"])
+    ret["body"].append("Reported version: " + ret["version"])
+    if "cc" in bug:
+        ret["body"].append("CC:   " + ", ".join(emails_convert(bug.pop("cc"))))
+    # Extra information
+    ret["body"].append("")
+    if "dup_id" in bug:
+        ret["body"].append("Duplicates:   " + ids_convert(bug.pop("dup_id")))
+    if "dependson" in bug:
+        ret["body"].append("Depends on:   " + ids_convert(bug.pop("dependson")))
+    if "blocked" in bug:
+        ret["body"].append("Blocker for:  " + ids_convert(bug.pop("blocked")))
+    if "see_also" in bug:
+        see_also = bug.pop("see_also")
+        if isinstance(see_also, basestring):
+            ret["body"].append("See also:     " + see_also)
+        else:
+            for item in see_also:
+                ret["body"].append("See also:     " + item)
+    ret["body"].append("Last updated: " + ret["updated_at"])
+    ret["body"].append("")
+
+    # Put everything together
+    ret["body"] = "\n".join(ret["body"]) + "\n\n" + "\n".join(ret["comments"])
+    ret["assignees"] = [a[1:] for a in ret["assignees"] if a[0] == "@"]
+
+    # Ignore some bug fields
+    global bug_unused_fields
+    fields_ignore(bug, bug_unused_fields)
+    # Make sure we have converted all the fields
+    if bug:
+        print "WARNING: unconverted bug fields:"
+        fields_dump(bug)
+
+    # Make sure we have converted all the attachments
+    if attachments:
+        print "WARNING: unconverted attachments:"
+        fields_dump(attachments)
+
+    return ret
+
+
+def bugs_convert(xml_root):
+    issues = {}
+    for xml_bug in xml_root.iter("bug"):
+        bug = XML2dict(xml_bug)
+        issue = bug_convert(bug)
+        # Check for duplicates
+        id = issue["number"]
+        if id in issues:
+            print("Error checking for duplicates: bug #%d is duplicated in the '%s'"
+                            % (id, xml_file))
+        issues[id] = issue
+
+    return issues
+
+
+def github_get(url, avs = {}):
+    global xml_file, github_url, github_owner, github_repo, github_token
+
+    if url[0] == "/":
+        u = "%s%s" % (github_url, url)
+    elif url.startswith("https://"):
+        u = url
+    elif url.startswith("http://"):
+        u = url
+    else:
+        u = "%s/repos/%s/%s/%s" % (github_url, github_owner, github_repo, url)
+
+    # TODO: debug
+    # print "GET: " + u
+
+    avs["access_token"] = github_token
+    return requests.get(u, params = avs)
+
+
+def github_post(url, avs = {}, fields = []):
+    global force_update
+    global xml_file, github_url, github_owner, github_repo, github_token
+
+    if url[0] == "/":
+        u = "%s%s" % (github_url, url)
+    else:
+        u = "%s/repos/%s/%s/%s" % (github_url, github_owner, github_repo, url)
+
+    d = {}
+    # Copy fields into the data
+    for field in fields:
+        if field not in avs:
+            print "Error posting filed %s to %s" % (field, url)
+            exit(1)
+        d[field] = avs[field]
+
+    # TODO: debug
+    # print "POST: " + u
+    # print "DATA: " + json.dumps(d)
+
+    if force_update:
+        return requests.post(u, params = { "access_token": github_token },
+                                data = json.dumps(d))
+    else:
+        if not github_post.warn:
+            print "Skipping POST... (use -f to force updates)"
+            github_post.warn = True
+        return True
+
+github_post.warn = False
+
+
+def github_label_create(label):
+    if not github_get("labels/" + label):
+        print "\tcreating label '%s' on GitHub..." % label
+        r = github_post("labels", {
+            "name": label,
+            "color": "0"*6,
+        }, ["name", "color"])
+        if not r:
+            print "Error creating label %s: %s" % (label, r.headers)
+            exit(1)
+
+
+def github_labels_check(issues):
+    global force_update
+
+    labels_set = set()
+    for id in issues:
+        for label in issues[id]["labels"]:
+            labels_set.add(label)
+
+    for label in labels_set:
+        if github_get("labels/" + label):
+            print "\tlabel '%s' exists on GitHub" % label
+        else:
+            if force_update:
+                github_label_create(label)
+            else:
+                print "WARNING: label '%s' does not exist on GitHub" % label
+
+
+def github_assignees_check(issues):
+    a_set = set()
+    for id in issues:
+        for assignee in issues[id]["assignees"]:
+            a_set.add(assignee)
+
+    for assignee in a_set:
+        if not github_get("/users/" + assignee):
+            print "Error checking user '%s' on GitHub" % assignee
+            exit(1)
+        else:
+            print "Assignee '%s' exists" % assignee
+
+
+def github_issue_exist(number):
+    if github_get("issues/%d" % number):
+        return True
+    else:
+        return False
+
+
+def github_issue_get(number):
+    req = github_get("issues/%d" % number)
+    if not req:
+        print "Error getting GitHub issue #%d: %s" % (number, req.headers)
+        exit(1)
+
+    return req.json()
+
+
+def github_issue_update(issue):
+    id = issue["number"]
+
+    print "\tupdating issue #%d on GitHub..." % id
+    r = github_post("issues/%d" % id, issue,
+            ["title", "body", "state", "labels", "assignees"])
+    if not r:
+        print "Error updating issue #%d on GitHub:\n%s" % (id, r.headers)
+        exit(1)
+
+
+def github_issue_append(issue):
+    print "\tappending a new issue on GitHub..."
+    r = github_post("issues", issue, ["title", "body", "labels", "assignees"])
+    while not r:
+        print "Error appending an issue on GitHub... trying again in 5 minutes.\n"
+        time.sleep(5*60)
+        r = github_post("issues", issue, ["title", "body", "labels", "assignees"])
+    return r
+
+
+def issue_renumber(orig_issue, new_id):
+    orig_issue["orig_number"] = orig_issue["number"]
+    orig_issue["number"] = new_id
+
+# Room for improvement in this function
+# Maybe we can be more resilient
+# Maybe we can generate a backtrace
+def github_issues_add(issues):
+    postponed = {}
+    nb_postponed = 0
+    id = 1 # No bug id 1 in Coq's Bugzilla
+    while True:
+        id += 1
+        if id in issues:
+            issue = issues[id]
+        else:
+            if nb_postponed == 0:
+                print "Error: No more postponed issues."
+                exit(1)
+            # Certainly not the most efficient way to find the first postponed issue
+            bugzilla_id = 0
+            while True:
+                bugzilla_id += 1
+                if bugzilla_id in postponed:
+                    break
+            issue = postponed.pop(bugzilla_id)
+            nb_postponed -= 1
+            issue_renumber(issue, id)
+        if id > existingIssues and id > bugzillaIssues:
+            github_issue = github_get("issues/%d" % id)
+        if id <= existingIssues or id <= bugzillaIssues or github_issue:
+            # Check if the issue was imported from the Bugzilla
+            if id > existingIssues and id <= bugzillaIssues:
+                print "Issue #%d already imported, doing nothing..." % id
+            elif id > existingIssues and ("Original bug ID: BZ#%d\n" % id).lower() in github_issue.json()["body"].lower():
+                print "Issue #%d already imported, updating..." % id
+                github_issue_update(issue)
+            else:
+                print "Issue #%d already exists, postponing..." % id
+                postponed[id] = issue
+                nb_postponed += 1
+        else:
+            print "Creating issue #%d..." % id
+            # Make sure the previous issue already exist
+            if force_update and id > 1 and not github_issue_exist(id - 1):
+                print "Error adding issue #%d on GitHub: previous issue does not exists" \
+                        % id
+                exit(1)
+            req = github_issue_append(issue)
+            if force_update:
+                new_issue = github_get(req.headers["location"]).json()
+                # Sometimes this fails, so we try again
+                if not "number" in new_issue:
+                    print "Something went wrong, trying again in 5 seconds."
+                    time.sleep(5)
+                    new_issue = github_get(req.headers["location"]).json()
+                if new_issue["number"] != id:
+                    print "Error adding issue #%d: assigned unexpected issue id #%d" \
+                        % (id, new_issue["number"])
+                    exit(1)
+                # Update issue state
+                if issue["state"] != "open":
+                    github_issue_update(issue)
+    print "Done adding with %d issues postponed." % nb_postponed
+
+    return postponed
+
+
+def args_parse(argv):
+    global force_update
+    global xml_file, github_owner, github_repo, github_token
+
+    try:
+        opts, args = getopt.getopt(argv,"hfo:r:t:x:")
+    except getopt.GetoptError:
+        usage()
+    for opt, arg in opts:
+        if opt == '-h':
+            usage()
+        elif opt == "-f":
+            print "WARNING: the repo will be UPDATED! No backups, no undos!"
+            print "Press Ctrl+C within next 5 seconds to cancel the update:"
+            time.sleep(5)
+            force_update = True
+        elif opt == "-o":
+            github_owner = arg
+        elif opt == "-r":
+            github_repo = arg
+        elif opt == "-t":
+            github_token = arg
+        elif opt == "-x":
+            xml_file = arg
+
+    # Check the arguments
+    if (not xml_file or not github_owner or not github_repo or not github_token):
+        print("Error parsing arguments: "
+                "please specify XML file, GitHub owner, repo and token")
+        usage()
+
+
+def main(argv):
+    global xml_file, github_owner, github_repo
+
+    # Parse command line arguments
+    args_parse(argv)
+    print "===> Converting Bugzilla reports to GitHub Issues..."
+    print "\tSource XML file:    %s" % xml_file
+    print "\tDest. GitHub owner: %s" % github_owner
+    print "\tDest. GitHub repo:  %s" % github_repo
+
+    xml_tree = xml.etree.ElementTree.parse(xml_file)
+    xml_root = xml_tree.getroot()
+    issues = bugs_convert(xml_root)
+
+    print "===> Checking all the labels exist on GitHub..."
+    github_labels_check(issues)
+    print "===> Checking all the assignees exist on GitHub..."
+    github_assignees_check(issues)
+
+    #if test:
+    #    fake_issue = { "title": "Fake issue", "body": "", "labels": [], "assignees": [] }
+    #    for i in xrange(1,existingIssues + 1):
+    #        github_issue_append(fake_issue)
+
+    print "===> Adding Bugzilla reports on GitHub..."
+    postponed = github_issues_add(issues)
+    print "===> All done."
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/dev/tools/bugzilla2github
+++ b/dev/tools/bugzilla2github
@@ -171,6 +171,7 @@ email2login = {
     "kzi@cs.uni.wroc.pl": "klara-zielinska",
     "lai.zhangsheng@gmail.com": "zunction",
     "Lars.Rasmusson@sics.se": "larsr",
+    "laurent.pubs@free.Fr": "olaure01",
     "lazyswamp@gmail.com": "kwanghoon",
     "letouzey@lri.fr": "letouzey",
     "Letouzey@pauillac.inria.fr": "letouzey",

--- a/dev/tools/bugzilla2github
+++ b/dev/tools/bugzilla2github
@@ -31,14 +31,12 @@ import json, getopt, os, pprint, re, requests, sys, time, xml.etree.ElementTree
 
 # Existing issues means issue numbers already taken on GitHub (by PRs mostly).
 # The script can find these by itself but this will spare API requests.
-existingIssues = 1149
+existingIssues = 1080
 # Can be used to skip over already imported issues if the script was interrupted.
 # Re-plays everything but without issuing API calls.
 # Room for improvement.
-bugzillaIssues = 0
+bugzillaIssues = 2879
 force_update = False
-# Avoid @-mentioning users during the tests.
-test = True
 xml_file = "bugzilla.xml"
 github_url = "https://api.github.com"
 github_owner = ""
@@ -212,7 +210,7 @@ email2login = {
     "porton@narod.ru": "vporton",
     "post+coq@ralfj.de": "RalfJung",
     "ppk@cse.iitk.ac.in": "piyush-kurur",
-    "psteck@mit.edu": "pstecker",
+    "psteck@mit.edu": "psteckler",
     "public@clarus.me": "clarus",
     "roconn@mcmaster.ca": "roconnor",
     "roconnor@cs.ru.nl": "roconnor",
@@ -270,15 +268,15 @@ email2login = {
 }
 status2state = {
     "__name__": "status to GitHub state",
-    "NEW": "open",
-    "UNCONFIRMED": "open",
-    "CONFIRMED": "open",
-    "VERIFIED": "open",
-    "ASSIGNED": "open",
-    "IN_PROGRESS": "open",
-    "RESOLVED": "closed",
-    "CLOSED": "closed",
-    "REOPENED": "open",
+    "NEW": False,
+    "UNCONFIRMED": False,
+    "CONFIRMED": False,
+    "VERIFIED": False,
+    "ASSIGNED": False,
+    "IN_PROGRESS": False,
+    "RESOLVED": True,
+    "CLOSED": True,
+    "REOPENED": False,
 }
 component2labels = {
     "__name__": "component to GitHub labels",
@@ -330,6 +328,7 @@ op_sys2labels = {
 }
 bug_unused_fields = [
     "actual_time",
+    "assigned_to.name",
     "attachment.isobsolete",
     "attachment.ispatch",
     "attachment.isprivate",
@@ -440,11 +439,7 @@ def ids_convert(ids):
 def email_convert(email, name):
     ret = str2str(email2login, email)
     if ret:
-        if test:
-            # Add space to avoid notifying people during tests
-            return "@ " + ret
-        else:
-            return "@" + ret
+        return "@" + ret
     else:
         if name and not name.find("@") >= 0:
             return "%s &lt;<%s>&gt;" % (name, email)
@@ -467,10 +462,6 @@ def fields_ignore(obj, fields):
     # Ignore some Bugzilla fields
     for field in fields:
         obj.pop(field, None)
-    if test:
-        obj.pop("assigned_to", None)
-        obj.pop("assigned_to.name", None)
-
 
 def fields_dump(obj):
     # Make sure we have converted all the fields
@@ -506,14 +497,21 @@ def attachments_convert(attachments):
 
     return ret
 
+def date_convert(date):
+    result = re.match(r'(\d\d\d\d-\d\d-\d\d) (\d\d:\d\d:\d\d) \+(\d\d)(\d\d)', date)
+    if not result:
+        print("Date %s was not converted!" % date)
+        exit(1)
+    return "{a}T{b}+{c}:{d}".format(a = result.group(1), b = result.group(2),
+                                    c = result.group(3), d = result.group(4))
+
 
 def comment_convert(comment, attachments):
     ret = []
 
-    ret.append("### " + email_convert(comment.pop("who"), comment.pop("who.name", None)) + " on " + comment.pop("bug_when"))
+    ret.append("Comment author: " + email_convert(comment.pop("who"), comment.pop("who.name", None)))
     ret.append("")
     ret.append(comment.pop("thetext", "").replace("@", "@ "))
-    # Add space after @ to avoid spurious GitHub-mentions
     ret.append("")
     # Convert attachments if any
     if "attachid" in comment:
@@ -528,6 +526,8 @@ def comment_convert(comment, attachments):
     for i, val in enumerate(ret):
         ret[i] = re.sub(r"(?i)(bug)\s+([0-9]+)", r"\1 #\2", val)
 
+    created_at = date_convert(comment.pop("bug_when"))
+
     # Ignore some comment fields
     global comment_unused_fields
     fields_ignore(comment, comment_unused_fields)
@@ -536,7 +536,7 @@ def comment_convert(comment, attachments):
         print "WARNING: unconverted comment fields:"
         fields_dump(comment)
 
-    return "\n".join(ret)
+    return { "body": "\n".join(ret), "created_at": created_at }
 
 
 def comments_convert(comments, attachments):
@@ -557,7 +557,6 @@ def bug_convert(bug):
                         % os.path.basename(__file__))
     ret["body"].append("")
     ret["labels"] = []
-    ret["assignees"] = []
     ret["comments"] = []
     attachments = {}
 
@@ -571,20 +570,19 @@ def bug_convert(bug):
     # Convert short_desc to title
     ret["title"] = bug.pop("short_desc")
     # Convert creation_ts to created_at
-    ret["created_at"] = bug.pop("creation_ts")
-    # Convert delta_ts to updated_at
-    ret["updated_at"] = bug.pop("delta_ts")
-    # Convert reporter to user login
-    ret["user.login"] = email_convert(bug.pop("reporter"),
-                        bug.pop("reporter.name", None))
-    # Convert assigned_to to assignees (disabled during tests)
-    if not test:
-        ret["assignees"].append(email_convert(bug.pop("assigned_to"),
-                                              bug.pop("assigned_to.name", None)))
+    ret["created_at"] = date_convert(bug.pop("creation_ts"))
+    assignee = str2str(email2login, bug.pop("assigned_to"))
+    if assignee:
+        ret["assignee"] = assignee
     # Convert component to labels
     ret["labels"].extend(str2list(component2labels, bug.pop("component")))
     # Convert bug_status to state
-    ret["state"] = str2str(status2state, bug.pop("bug_status"))
+    ret["closed"] = str2str(status2state, bug.pop("bug_status"))
+    if ret["closed"]:
+        # Convert delta_ts to closed_at
+        ret["closed_at"] = date_convert(bug.pop("delta_ts"))
+    else:
+        bug.pop("delta_ts")
     # Convert (optional) keywords to labels
     ret["labels"].extend(str2list(keywords2labels, bug.pop("keywords","")))
     # Convert resolution to labels
@@ -593,14 +591,13 @@ def bug_convert(bug):
     # Convert op_sys to labels
     if "op_sys" in bug:
         ret["labels"].extend(str2list(op_sys2labels, bug.pop("op_sys")))
-    # Convert version to version
-    ret["version"] = bug.pop("version")
 
     # Create the bug description
     ret["body"].append("Original bug ID: BZ#%d" % ret["number"])
     ret["body"].append("Date: " + ret["created_at"])
-    ret["body"].append("From: " + ret["user.login"])
-    ret["body"].append("Reported version: " + ret["version"])
+    ret["body"].append("From: " + email_convert(bug.pop("reporter"),
+                        bug.pop("reporter.name", None)))
+    ret["body"].append("Reported version: " + bug.pop("version"))
     if "cc" in bug:
         ret["body"].append("CC:   " + ", ".join(emails_convert(bug.pop("cc"))))
     # Extra information
@@ -618,12 +615,10 @@ def bug_convert(bug):
         else:
             for item in see_also:
                 ret["body"].append("See also:     " + item)
-    ret["body"].append("Last updated: " + ret["updated_at"])
     ret["body"].append("")
 
     # Put everything together
-    ret["body"] = "\n".join(ret["body"]) + "\n\n" + "\n".join(ret["comments"])
-    ret["assignees"] = [a[1:] for a in ret["assignees"] if a[0] == "@"]
+    ret["body"] = "\n".join(ret["body"])
 
     # Ignore some bug fields
     global bug_unused_fields
@@ -647,7 +642,7 @@ def bugs_convert(xml_root):
         bug = XML2dict(xml_bug)
         issue = bug_convert(bug)
         # Check for duplicates
-        id = issue["number"]
+        id = issue.pop("number")
         if id in issues:
             print("Error checking for duplicates: bug #%d is duplicated in the '%s'"
                             % (id, xml_file))
@@ -741,8 +736,8 @@ def github_labels_check(issues):
 def github_assignees_check(issues):
     a_set = set()
     for id in issues:
-        for assignee in issues[id]["assignees"]:
-            a_set.add(assignee)
+        if "assignee" in issues[id]:
+            a_set.add(issues[id]["assignee"])
 
     for assignee in a_set:
         if not github_get("/users/" + assignee):
@@ -768,30 +763,33 @@ def github_issue_get(number):
     return req.json()
 
 
-def github_issue_update(issue):
-    id = issue["number"]
-
-    print "\tupdating issue #%d on GitHub..." % id
-    r = github_post("issues/%d" % id, issue,
-            ["title", "body", "state", "labels", "assignees"])
-    if not r:
-        print "Error updating issue #%d on GitHub:\n%s" % (id, r.headers)
-        exit(1)
-
-
 def github_issue_append(issue):
+    global github_owner, github_repo, github_token
+    params = { "access_token": github_token }
+    headers = { "Accept": "application/vnd.github.golden-comet-preview+json" }
     print "\tappending a new issue on GitHub..."
-    r = github_post("issues", issue, ["title", "body", "labels", "assignees"])
-    while not r:
-        print "Error appending an issue on GitHub... trying again in 5 minutes.\n"
-        time.sleep(5*60)
-        r = github_post("issues", issue, ["title", "body", "labels", "assignees"])
+    u = "https://api.github.com/repos/%s/%s/import/issues" % (github_owner, github_repo)
+    comments = issue.pop("comments")
+    r = requests.post(u, params = params, headers = headers,
+                      data = json.dumps({ "issue": issue, "comments": comments }))
+    if not r:
+        print "Error importing issue on GitHub:\n%s" % r.text
+        exit(1)
+    u = r.json()["url"]
+    wait = 1
+    r = False
+    while not r or r.json()["status"] == "pending":
+        time.sleep(wait)
+        wait = 2 * wait
+        r = requests.get(u, params = params, headers = headers)
+    if not r.json()["status"] == "imported":
+        print "Error importing issue on GitHub:\n%s" % r.text
+        exit(1)
+    # The issue_url field of the answer should be of the form .../ISSUE_NUMBER
+    # So it's easy to get the issue number, to check that it is what was expected
+    # And even to spare a few get requests to the GitHub API
     return r
 
-
-def issue_renumber(orig_issue, new_id):
-    orig_issue["orig_number"] = orig_issue["number"]
-    orig_issue["number"] = new_id
 
 # Room for improvement in this function
 # Maybe we can be more resilient
@@ -816,16 +814,14 @@ def github_issues_add(issues):
                     break
             issue = postponed.pop(bugzilla_id)
             nb_postponed -= 1
-            issue_renumber(issue, id)
         if id > existingIssues and id > bugzillaIssues:
             github_issue = github_get("issues/%d" % id)
         if id <= existingIssues or id <= bugzillaIssues or github_issue:
             # Check if the issue was imported from the Bugzilla
             if id > existingIssues and id <= bugzillaIssues:
-                print "Issue #%d already imported, doing nothing..." % id
+                print "Issue #%d already imported." % id
             elif id > existingIssues and ("Original bug ID: BZ#%d\n" % id).lower() in github_issue.json()["body"].lower():
-                print "Issue #%d already imported, updating..." % id
-                github_issue_update(issue)
+                print "Issue #%d already imported." % id
             else:
                 print "Issue #%d already exists, postponing..." % id
                 postponed[id] = issue
@@ -837,22 +833,7 @@ def github_issues_add(issues):
                 print "Error adding issue #%d on GitHub: previous issue does not exists" \
                         % id
                 exit(1)
-            req = github_issue_append(issue)
-            if force_update:
-                new_issue = github_get(req.headers["location"]).json()
-                # Sometimes this fails, so we try again
-                if not "number" in new_issue:
-                    print "Something went wrong, trying again in 5 seconds."
-                    time.sleep(5)
-                    new_issue = github_get(req.headers["location"]).json()
-                if new_issue["number"] != id:
-                    print "Error adding issue #%d: assigned unexpected issue id #%d" \
-                        % (id, new_issue["number"])
-                    exit(1)
-                # Update issue state
-                if issue["state"] != "open":
-                    github_issue_update(issue)
-    print "Done adding with %d issues postponed." % nb_postponed
+            github_issue_append(issue)
 
     return postponed
 
@@ -908,10 +889,9 @@ def main(argv):
     print "===> Checking all the assignees exist on GitHub..."
     github_assignees_check(issues)
 
-    #if test:
-    #    fake_issue = { "title": "Fake issue", "body": "", "labels": [], "assignees": [] }
-    #    for i in xrange(1,existingIssues + 1):
-    #        github_issue_append(fake_issue)
+    # fake_issue = { "title": "Fake issue", "body": "Fake issue" }
+    # for i in xrange(1,existingIssues + 1):
+    #     github_issue_append(fake_issue)
 
     print "===> Adding Bugzilla reports on GitHub..."
     postponed = github_issues_add(issues)

--- a/dev/tools/bugzilla2github
+++ b/dev/tools/bugzilla2github
@@ -904,7 +904,10 @@ def main(argv):
         result = re.search("Original bug ID: BZ#(\d+)", github_issue.json()["body"])
         if result:
             print "Indeed, this was the case."
-            issues.pop(int(result.group(1)), None)
+            bugzilla_id = int(result.group(1))
+            issues.pop(bugzilla_id, None)
+            with open("bugzilla2github.log", "a") as f:
+                f.write("%d, %d\n" % (bugzilla_id, existingIssues + 1))
 
     print "===> Checking all the labels exist on GitHub..."
     github_labels_check(issues)

--- a/dev/tools/bugzilla2github
+++ b/dev/tools/bugzilla2github
@@ -460,7 +460,8 @@ def emails_convert(emails):
     ret = []
     if isinstance(emails, list):
         for email in emails:
-            ret.append(email_convert(email, None))
+            if email != "coq-bugs-redist@lists.gforge.inria.fr":
+                ret.append(email_convert(email, None))
     else:
         ret.append(email_convert(emails, None))
 

--- a/dev/tools/bugzilla2github
+++ b/dev/tools/bugzilla2github
@@ -890,7 +890,16 @@ def main(argv):
         print "===> No log file found. Not skipping any issue."
 
     print "===> Checking last existing issue actually exists."
-    github_issue_exist(existingIssues)
+    if not github_issue_exist(existingIssues):
+        print "    Last existing issue doesn't actually exist. Aborting!"
+        exit(1)
+    print "===> Checking whether the following issue was created but not saved."
+    github_issue = github_get("issues/%d" % (existingIssues + 1))
+    if github_issue:
+        result = re.search("Original bug ID: BZ#(\d+)", github_issue.json()["body"])
+        if result:
+            print "    Indeed, this was the case."
+            issues.pop(int(result.group(1)), None)
 
     print "===> Checking all the labels exist on GitHub..."
     github_labels_check(issues)

--- a/dev/tools/bugzilla2github
+++ b/dev/tools/bugzilla2github
@@ -421,6 +421,9 @@ def id_convert(id):
     global github_owner, github_repo
     return "[BZ#" + id + "](https://github.com/" + github_owner + "/" + github_repo + "/issues?q=is%3Aissue%20%22Original%20bug%20ID%3A%20BZ%23" + id + "%22)"
 
+def id_convert_from_match(match):
+    return id_convert(match.group(1))
+
 def ids_convert(ids):
     ret = []
 
@@ -531,10 +534,9 @@ def comment_convert(comment, attachments):
             ret.append("")
     ret.append("")
 
-    # Syntax: convert "bug id" to "bug #id"
-    # We should adapt the same format here as in id_convert
+    # Syntax: convert "bug id" to "BZ#id"
     for i, val in enumerate(ret):
-        ret[i] = re.sub(r"(?i)(bug)\s+([0-9]+)", r"\1 #\2", val)
+        ret[i] = re.sub(r"(?i)(?:bug(?:\s+report)?\s+|feature wish\s+|\#)([0-9]+)", id_convert_from_match, val)
 
     created_at = date_convert(comment.pop("bug_when"))
 

--- a/dev/tools/bugzilla2github
+++ b/dev/tools/bugzilla2github
@@ -35,7 +35,7 @@ existingIssues = 1080
 # Can be used to skip over already imported issues if the script was interrupted.
 # Re-plays everything but without issuing API calls.
 # Room for improvement.
-bugzillaIssues = 3274
+bugzillaIssues = 3483
 force_update = False
 xml_file = "bugzilla.xml"
 github_url = "https://api.github.com"
@@ -774,7 +774,7 @@ def github_issue_get(number):
     return req.json()
 
 
-def github_issue_append(issue):
+def github_issue_append(bugzilla_id, issue):
     global github_owner, github_repo, github_token
     params = { "access_token": github_token }
     headers = { "Accept": "application/vnd.github.golden-comet-preview+json" }
@@ -802,7 +802,13 @@ def github_issue_append(issue):
     # The issue_url field of the answer should be of the form .../ISSUE_NUMBER
     # So it's easy to get the issue number, to check that it is what was expected
     # And even to spare a few get requests to the GitHub API
-    return r
+    result = re.match("https://api.github.com/repos/" + github_owner + "/" + github_repo + "/issues/(\d+)", r.json()["issue_url"])
+    if not result:
+        print "Error while parsing issue number:\n%s" % r.text
+    issue_number = result.group(1)
+    with open("bugzilla2github.log", "a") as f:
+        f.write("%d, %s\n" % (bugzilla_id, issue_number))
+    return issue_number
 
 
 # Room for improvement in this function
@@ -814,6 +820,7 @@ def github_issues_add(issues):
     while True:
         id += 1
         if id in issues:
+            bugzilla_id = id
             issue = issues[id]
         else:
             if len(postponed) == 0:
@@ -840,7 +847,7 @@ def github_issues_add(issues):
                 print "Error adding issue #%d on GitHub: previous issue does not exists" \
                         % id
                 exit(1)
-            github_issue_append(issue)
+            github_issue_append(bugzilla_id, issue)
 
     return postponed
 
@@ -897,7 +904,7 @@ def main(argv):
     github_assignees_check(issues)
     # fake_issue = { "title": "Fake issue", "body": "Fake issue" }
     # for i in xrange(1,existingIssues + 1):
-    #     github_issue_append(fake_issue)
+    #     github_issue_append(0, fake_issue)
 
     print "===> Adding Bugzilla reports on GitHub..."
     postponed = github_issues_add(issues)

--- a/dev/tools/bugzilla2github
+++ b/dev/tools/bugzilla2github
@@ -422,7 +422,7 @@ def id_convert(id):
     return "[BZ#" + id + "](https://github.com/" + github_owner + "/" + github_repo + "/issues?q=is%3Aissue%20%22Original%20bug%20ID%3A%20BZ%23" + id + "%22)"
 
 def id_convert_from_match(match):
-    return id_convert(match.group(1))
+    return re.sub(r'\#', "", match.group(1)) + id_convert(match.group(2))
 
 def ids_convert(ids):
     ret = []
@@ -537,7 +537,7 @@ def comment_convert(comment, attachments):
     # Syntax: convert "bug id" to "BZ#id"
     for i, val in enumerate(ret):
         val = re.sub(r"\(In reply to comment \#\d+\)","", val)
-        ret[i] = re.sub(r"(?i)(?:bug(?:\s+report)?\s+|feature wish\s+|\s\#)(\d\d?\d?\d?)", id_convert_from_match, val)
+        ret[i] = re.sub(r"(?i)(bug(?:\s+report)?\s+|feature wish\s+|\s\#)(\d\d?\d?\d?)", id_convert_from_match, val)
 
     created_at = date_convert(comment.pop("bug_when"))
 

--- a/dev/tools/bugzilla2github
+++ b/dev/tools/bugzilla2github
@@ -882,7 +882,8 @@ def main(argv):
 
     try:
         with open("bugzilla2github.log", "r") as f:
-            print "===> Skipping already imported issues..."
+            print "===> Skipping already imported issues (WARNING: this shouldn't happen when you run this script for the first time)..."
+            time.sleep(5)
             imported_bugs = csv.reader(f)
             for imported_bug in imported_bugs:
                 issues.pop(int(imported_bug[0]), None)
@@ -892,14 +893,14 @@ def main(argv):
 
     print "===> Checking last existing issue actually exists."
     if not github_issue_exist(existingIssues):
-        print "    Last existing issue doesn't actually exist. Aborting!"
+        print "Last existing issue doesn't actually exist. Aborting!"
         exit(1)
     print "===> Checking whether the following issue was created but not saved."
     github_issue = github_get("issues/%d" % (existingIssues + 1))
     if github_issue:
         result = re.search("Original bug ID: BZ#(\d+)", github_issue.json()["body"])
         if result:
-            print "    Indeed, this was the case."
+            print "Indeed, this was the case."
             issues.pop(int(result.group(1)), None)
 
     print "===> Checking all the labels exist on GitHub..."

--- a/dev/tools/bugzilla2github
+++ b/dev/tools/bugzilla2github
@@ -521,7 +521,7 @@ def comment_convert(comment, attachments):
         ret.append("Comment author: "
                    + email_convert(comment.pop("who"), comment.pop("who.name", None)))
         ret.append("")
-    ret.append(comment.pop("thetext", "").replace("@", "@ "))
+    ret.append(comment.pop("thetext", "*No description provided.*").replace("@", "@ "))
     ret.append("")
     # Convert attachments if any
     if "attachid" in comment:
@@ -782,6 +782,7 @@ def github_issue_append(bugzilla_id, issue):
                       data = json.dumps({ "issue": issue, "comments": comments }))
     if not r:
         print "Error importing issue on GitHub:\n%s" % r.text
+        print "For the record, here was the request:\n%s" % json.dumps({ "issue": issue, "comments": comments })
         exit(1)
     u = r.json()["url"]
     wait = 1

--- a/dev/tools/bugzilla2github
+++ b/dev/tools/bugzilla2github
@@ -335,6 +335,7 @@ bug_unused_fields = [
     "classification_id",
     "comment_sort_order",
     "deadline",
+    "delta_ts",
     "estimated_time",
     "everconfirmed",
     "long_desc.isprivate",
@@ -584,16 +585,10 @@ def bug_convert(bug):
     ret["labels"].extend(str2list(component2labels, bug.pop("component")))
     # Convert bug_status to state
     ret["closed"] = str2str(status2state, bug.pop("bug_status"))
-    if ret["closed"]:
-        # Convert delta_ts to closed_at
-        ret["closed_at"] = date_convert(bug.pop("delta_ts"))
-        bug.pop("assigned_to")
-    else:
-        bug.pop("delta_ts")
-        # We only assigned open bug reports
-        assignee = str2str(email2login, bug.pop("assigned_to"))
-        if assignee:
-            ret["assignee"] = assignee
+    # We only assign open bug reports
+    assignee = str2str(email2login, bug.pop("assigned_to"))
+    if not ret["closed"] and assignee:
+        ret["assignee"] = assignee
     # Convert (optional) keywords to labels
     ret["labels"].extend(str2list(keywords2labels, bug.pop("keywords","")))
     # Convert resolution to labels

--- a/dev/tools/bugzilla2github
+++ b/dev/tools/bugzilla2github
@@ -31,7 +31,7 @@ import csv, getopt, json, os, pprint, re, requests, sys, time, xml.etree.Element
 
 # Existing issues means issue numbers already taken on GitHub (by PRs mostly).
 # The script can find these by itself but this will spare API requests.
-existingIssues = 1080
+existingIssues = 1155
 force_update = False
 xml_file = "bugzilla.xml"
 github_url = "https://api.github.com"
@@ -536,7 +536,8 @@ def comment_convert(comment, attachments):
 
     # Syntax: convert "bug id" to "BZ#id"
     for i, val in enumerate(ret):
-        ret[i] = re.sub(r"(?i)(?:bug(?:\s+report)?\s+|feature wish\s+|\#)([0-9]+)", id_convert_from_match, val)
+        val = re.sub(r"\(In reply to comment \#\d+\)","", val)
+        ret[i] = re.sub(r"(?i)(?:bug(?:\s+report)?\s+|feature wish\s+|\s\#)(\d\d?\d?\d?)", id_convert_from_match, val)
 
     created_at = date_convert(comment.pop("bug_when"))
 

--- a/dev/tools/bugzilla2github
+++ b/dev/tools/bugzilla2github
@@ -31,7 +31,7 @@ import json, getopt, os, pprint, re, requests, sys, time, xml.etree.ElementTree
 
 # Existing issues means issue numbers already taken on GitHub (by PRs mostly).
 # The script can find these by itself but this will spare API requests.
-existingIssues = 1148
+existingIssues = 1149
 # Can be used to skip over already imported issues if the script was interrupted.
 # Re-plays everything but without issuing API calls.
 # Room for improvement.
@@ -188,6 +188,7 @@ email2login = {
     "matthieu.sozeau@inria.fr": "mattam82",
     "mail@maximedenes.fr": "maximedenes",
     "mdoerri@cs.jhu.edu": "doerrie",
+    "mdvrc27au2@snkmail.com": "bluelightning32",
     "mhelvens@gmail.com": "mhelvens",
     "michael.soegtrop@intel.com": "MSoegtropIMC",
     "nadeem@acm.org": "nadeemabdulhamid",

--- a/dev/tools/bugzilla2github
+++ b/dev/tools/bugzilla2github
@@ -593,6 +593,10 @@ def bug_convert(bug):
     assignee = str2str(email2login, bug.pop("assigned_to"))
     if not ret["closed"] and assignee:
         ret["assignee"] = assignee
+    # Approximate closing date with last update date
+    updated_at = bug.pop("delta_ts")
+    if ret["closed"]:
+        ret["closed_at"] = date_convert(updated_at)
     # Convert (optional) keywords to labels
     ret["labels"].extend(str2list(keywords2labels, bug.pop("keywords","")))
     # Convert resolution to labels

--- a/dev/tools/bugzilla2github
+++ b/dev/tools/bugzilla2github
@@ -824,8 +824,12 @@ def github_issues_add(issues):
             issue = issues[id]
         else:
             if len(postponed) == 0:
-                print "Error: No more postponed issues."
-                exit(1)
+                if len(issues) == 0:
+                    print "===> All done."
+                    exit(0)
+                else:
+                    print "Error: No more postponed issues."
+                    exit(1)
             # Find the first postponed issue
             bugzilla_id = sorted(postponed.keys())[0]
             issue = postponed.pop(bugzilla_id)
@@ -848,8 +852,6 @@ def github_issues_add(issues):
                         % id
                 exit(1)
             github_issue_append(bugzilla_id, issue)
-
-    return postponed
 
 
 def args_parse(argv):
@@ -907,8 +909,7 @@ def main(argv):
     #     github_issue_append(0, fake_issue)
 
     print "===> Adding Bugzilla reports on GitHub..."
-    postponed = github_issues_add(issues)
-    print "===> All done."
+    github_issues_add(issues)
 
 
 if __name__ == "__main__":

--- a/dev/tools/bugzilla2github
+++ b/dev/tools/bugzilla2github
@@ -311,7 +311,7 @@ resolution2labels = {
     "FIXED": [],
     "DUPLICATE": ["resolved: duplicate"],
     "INVALID": ["resolved: invalid"],
-    "MOVED": ["resolved: closed"],
+    "MOVED": ["resolved: moved"],
     "WONTFIX": ["resolved: won't fix"],
     "WORKSFORME": ["resolved: works for me"],
 }

--- a/dev/tools/bugzilla2github
+++ b/dev/tools/bugzilla2github
@@ -348,7 +348,6 @@ bug_unused_fields = [
     "token",
 ]
 comment_unused_fields = [
-    "commentid",
     "comment_count",
     "attachid",
     "work_time",
@@ -515,8 +514,12 @@ def date_convert(date):
 def comment_convert(comment, attachments):
     ret = []
 
-    ret.append("Comment author: " + email_convert(comment.pop("who"), comment.pop("who.name", None)))
-    ret.append("")
+    id = int(comment.pop("commentid"))
+
+    if id >= 1658:
+        ret.append("Comment author: "
+                   + email_convert(comment.pop("who"), comment.pop("who.name", None)))
+        ret.append("")
     ret.append(comment.pop("thetext", "").replace("@", "@ "))
     ret.append("")
     # Convert attachments if any
@@ -808,34 +811,31 @@ def github_issue_append(bugzilla_id, issue):
 
 def github_issues_add(issues):
     postponed = {}
-    id = 1 # No bug id 1 in Coq's Bugzilla
+    id = 0
     while True:
         id += 1
-        if id in issues:
-            bugzilla_id = id
-            issue = issues[id]
-        else:
-            if len(postponed) == 0:
-                if len(issues) == 0:
-                    print "===> All done."
-                    exit(0)
-                else:
-                    print "Error: No more postponed issues."
-                    exit(1)
-            # Find the first postponed issue
-            bugzilla_id = sorted(postponed.keys())[0]
-            issue = postponed.pop(bugzilla_id)
         if id <= existingIssues or github_get("issues/%d" % id):
-            print "Issue #%d already exists, postponing..." % id
-            postponed[bugzilla_id] = issue
+            if id in issues:
+                print "Issue #%d already exists, postponing..." % id
+                postponed[id] = issues.pop(id)
         else:
-            print "Creating issue #%d..." % id
-            # Make sure the previous issue already exist
-            if force_update and id > 1 and not github_issue_exist(id - 1):
-                print "Error adding issue #%d on GitHub: previous issue does not exists" \
-                        % id
-                exit(1)
-            github_issue_append(bugzilla_id, issue)
+            if id in issues:
+                bugzilla_id = id
+                issue = issues.pop(id)
+            else:
+                if len(postponed) == 0:
+                    if len(issues) == 0:
+                        print "===> All done."
+                        exit(0)
+                    else:
+                        print "Error: No more postponed issues."
+                        exit(1)
+                # Find the first postponed issue
+                bugzilla_id = sorted(postponed.keys())[0]
+                issue = postponed.pop(bugzilla_id)
+            if force_update:
+                print "Creating issue #%d..." % id
+                github_issue_append(bugzilla_id, issue)
 
 
 def args_parse(argv):
@@ -893,6 +893,9 @@ def main(argv):
                 existingIssues = max(existingIssues, int(imported_bug[1]))
     except IOError:
         print "===> No log file found. Not skipping any issue."
+
+    print "===> Checking last existing issue actually exists."
+    github_issue_exist(existingIssues)
 
     print "===> Checking all the labels exist on GitHub..."
     github_labels_check(issues)


### PR DESCRIPTION
I'm sharing this script in a pull request mainly to get feedback and contributions for improvement, especially from Python-experts (e.g. @JasonGross).

As the comments in the script tell, this is an adaptation of an existing script initially found by @silene.
As I explained during the WG, one of the core feature of this script is that it preserves the bug IDs of as many bugs as possible (and it postpones the others). The main change I made was to accept non-continuous Bugzilla IDs and use postponed bug reports to fill the holes.

The most bothering aspect when using this script in practice is that after adding exactly 300 new issues, GitHub will prevent any more addition for 30 minutes (BTW it does prevent me to submit this PR, not just to open issues through the API). (The original script was certainly used on a much smaller scale and I had to adapt the script so that it tries again after some time elapsed.) Adding 300 issues takes about 13 minutes, so completing the migration will take around 12 hours. While this is not impracticable, a shorter migration period would be better. I'm thus going to write to GitHub support to see whether they can lift this restriction temporarily.

Other details in the script could be further improved, for instance, the migration from JitterBug to Bugzilla incorrectly marked all the comments pre-dating the migration as coming from the original reporter.
See an example here: https://github.com/Zimmi48/bugzilla-test-2/issues/1306
The first reply is wrongly attributed, but further replies are correctly attributed. So the migration date was sometime between 2007-01-23 and 2007-07-20. One improvement could be to detect comments before the migration date and print them differently. (BTW this means that Bugzilla will have lasted more than 10 years!)

Other possible improvements: save a trace of the migration (what new IDs were given to postponed bugs). This could be used to put correct cross-references between an issue and the previous issues it refers to. In the opposite direction it's much harder, but given how GitHub automatically puts a link to other issues where a given issue was mentioned, we could decide to only copy references to previous issues (and let GitHub handle the rest). (Most cross-references should be both ways.)

Finally, I adapted the function `github_issues_add` a bit stupidly. It works but it could probably be prettified and made a bit smarter.

If you have a patch improving this script, feel free to push directly to this branch, or submit a PR on my fork if you're not sure.