### PR TITLE
Moving to GitHub issues.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,13 +4,13 @@ Thank you for your interest in contributing to Coq! There are many ways to contr
 
 ## Bug Reports
 
-Bug reports are enormously useful to identify issues with Coq; we can't fix what we don't know about. Bug reports should all be filed on the [Coq Bugzilla](https://coq.inria.fr/bugs/) (you'll have to make an account). You can file a bug for any of the following:
+Bug reports are enormously useful to identify issues with Coq; we can't fix what we don't know about. To report a bug, please open an issue on the [Coq GitHub repository](https://github.com/coq/coq/issues) (you'll need a GitHub account). You can file a bug for any of the following:
 
 - An anomaly. These are always considered bugs, so Coq will even ask you to file a bug report!
 - An error you didn't expect. If you're not sure whether it's a bug or intentional, feel free to file a bug anyway. We may want to improve the documentation or error message.
 - Missing documentation. It's helpful to track where the documentation should be improved, so please file a bug if you can't find or don't understand some bit of documentation.
 - An error message that wasn't as helpful as you'd like. Bonus points for suggesting what information would have helped you.
-- Bugs in CoqIDE should also be filed on the Bugzilla. Bugs in the Emacs plugin should be filed against [ProofGeneral](https://github.com/ProofGeneral/PG/issues), or against [company-coq](https://github.com/cpitclaudel/company-coq/issues) if they are specific to company-coq features.
+- Bugs in CoqIDE should also be filed on the [GitHub issue tracker](https://github.com/coq/coq/issues). Bugs in the Emacs plugin should be filed against [ProofGeneral](https://github.com/ProofGeneral/PG/issues), or against [company-coq](https://github.com/cpitclaudel/company-coq/issues) if they are specific to company-coq features.
 
 It would help if you search the existing issues before reporting a bug. This can be difficult, so consider it extra credit. We don't mind duplicate bug reports.
 
@@ -40,7 +40,7 @@ Here are a few tags Coq developers may add to your PR and what they mean. In gen
 
 Currently the process for contributing to the documentation is the same as for changing anything else in Coq, so please submit a pull request as described above.
 
-Bugzilla includes a component to mark bugs related to documentation. You can view a list of documentation-related bugs using a [Bugzilla search](https://coq.inria.fr/bugs/buglist.cgi?component=Doc&list_id=455006&product=Coq&resolution=---). Many of these bugs can be fixed by contributing writing, without knowledge of Coq's OCaml source code.
+Our issue tracker includes a flag to mark bugs related to documentation. You can view a list of documentation-related bugs using a [GitHub issue search](https://github.com/coq/coq/pulls?utf8=%E2%9C%93&q=is%3Aopen%20is%3Aissue%20label%3A%22kind%3A%20documentation%22%20). Many of these bugs can be fixed by contributing writing, without knowledge of Coq's OCaml source code.
 
 The sources for the [Coq reference manual](https://coq.inria.fr/distrib/current/refman/) are at [`doc/refman`](/doc/refman). These are written in LaTeX and compiled to HTML with [HeVeA](http://hevea.inria.fr/).
 

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,18 @@
+<!-- Thank you for your contribution.
+     Please complete the following information when reporting a bug. -->
+
+#### Version
+
+<!-- You can get this information by running `coqtop -v`. -->
+
+
+#### Operating system
+
+
+#### Description of the problem
+
+<!-- It is helpful to provide enough information so that we can reproduce the bug.
+     In particular, please include a code example which produces it.
+     If the example is small, you can include it here between ``` ```.
+     Otherwise, please provide a link to a repository, a gist (https://gist.github.com)
+     or drag-and-drop a `.zip` archive. -->

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ For any questions/suggestions about the Coq Club, please write to
 `coq-club-request@inria.fr`.
 
 ## Bugs report
-Send your bug reports by filling a form at [coq.inria.fr/bugs](http://coq.inria.fr/bugs).
+Please report any bug in [our issue tracker](https://github.com/coq/coq/issues).
 
 To be effective, bug reports should mention the OCaml version used
 to compile and run Coq, the Coq version (`coqtop -v`), the configuration


### PR DESCRIPTION
This commit adds an issue template asking for version and OS information
and adapts the contributing guide to the change of bug tracker.