### PR TITLE
Sort goals by location.

### DIFF
--- a/API/API.mli
+++ b/API/API.mli
@@ -2968,6 +2968,7 @@ sig
   val cycle : int -> unit tactic
   val swap : int -> int -> unit tactic
   val revgoals : unit tactic
+  val sortgoals : ?cmp:(Evd.evar_map -> Evd.evar -> Evd.evar -> int) -> unit -> unit tactic
   val give_up : unit tactic
   val init : Evd.evar_map -> (Environ.env * EConstr.types) list -> entry * proofview
   val shelve : unit tactic

--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -1005,6 +1005,10 @@ let goal_extra evars gl =
   let evi = Evd.find evars gl in
   evi.Evd.evar_extra
 
+let goal_source evars gl =
+  let evi = Evd.find evars gl in
+  evi.Evd.evar_source
+
 
 let catchable_exception = function
   | Logic_monad.Exception _ -> false
@@ -1027,6 +1031,7 @@ module Goal = struct
   let hyps {env} = EConstr.named_context env
   let concl {concl} = concl
   let extra {sigma; self} = goal_extra sigma self
+  let source {sigma; self} = goal_source sigma self
 
   let gmake_with info env sigma goal = 
     { env = Environ.reset_with_named_context (Evd.evar_filtered_hyps info) env ;

--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -776,6 +776,24 @@ let numgoals =
   Comb.get >>= fun comb ->
   return (CList.length comb)
 
+let default_cmp (sigma : Evd.evar_map) (e1 : Evd.evar) (e2 : Evd.evar) : int =
+  let to_pair e =
+    let loc = fst (Evd.evar_source e sigma) in
+    begin match loc with
+    | None -> ()
+    | Some loc ->
+        Feedback.msg_info (str"Loc: " ++ int loc.Loc.line_nb ++
+          str" " ++ int loc.Loc.bp ++ str" " ++ int loc.Loc.ep)
+    end;
+      Option.map Loc.unloc loc
+  in
+    compare (to_pair e1) (to_pair e2)
+
+let sortgoals ?(cmp : Evd.evar_map -> Evd.evar -> Evd.evar -> int = default_cmp) () =
+  let open Proof in
+  InfoL.leaf (Info.Tactic (fun () -> Pp.str"sortgoals")) >>
+  Solution.get >>= fun sigma ->
+  Comb.modify (CList.sort (cmp sigma))
 
 
 (** {7 Access primitives} *)

--- a/engine/proofview.mli
+++ b/engine/proofview.mli
@@ -487,6 +487,7 @@ module Goal : sig
   val env : 'a t -> Environ.env
   val sigma : 'a t -> Evd.evar_map
   val extra : 'a t -> Evd.Store.t
+  val source : 'a t -> Evar_kinds.t Loc.located
 
   (** [nf_enter t] applies the goal-dependent tactic [t] in each goal
       independently, in the manner of {!tclINDEPENDENT} except that

--- a/engine/proofview.mli
+++ b/engine/proofview.mli
@@ -348,6 +348,10 @@ val revgoals : unit tactic
 (** [numgoals] returns the number of goals under focus. *)
 val numgoals : int tactic
 
+(** [sortgoals] sorts the list of focused goals according to
+    some comparison function. *)
+val sortgoals : ?cmp : (Evd.evar_map -> Evd.evar -> Evd.evar -> int) -> unit-> unit tactic
+
 
 (** {7 Access primitives} *)
 

--- a/plugins/ltac/extratactics.ml4
+++ b/plugins/ltac/extratactics.ml4
@@ -1003,6 +1003,11 @@ TACTIC EXTEND revgoals
 | [ "revgoals" ] -> [ Proofview.revgoals ]
 END
 
+(* sorts the list of focused goals according to their location *)
+TACTIC EXTEND sortgoals
+| [ "sortgoals" ] -> [ Proofview.sortgoals () ]
+END
+
 type cmp =
   | Eq
   | Lt | Le

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -196,6 +196,7 @@ let convert_concl ?(check=true) ty k =
   Proofview.Goal.enter begin fun gl ->
     let env = Proofview.Goal.env gl in
     let store = Proofview.Goal.extra gl in
+    let src = Proofview.Goal.source gl in
     let conclty = Proofview.Goal.concl gl in
     Refine.refine ~typecheck:false begin fun sigma ->
       let sigma =
@@ -205,7 +206,7 @@ let convert_concl ?(check=true) ty k =
           if not b then error "Not convertible.";
           sigma
         end else sigma in
-      let (sigma, x) = Evarutil.new_evar env sigma ~principal:true ~store ty in
+      let (sigma, x) = Evarutil.new_evar env sigma ~src ~principal:true ~store ty in
       let ans = if k == DEFAULTcast then x else mkCast(x,k,conclty) in
       (sigma, ans)
     end

--- a/test-suite/output/unifconstraints.out
+++ b/test-suite/output/unifconstraints.out
@@ -2,14 +2,14 @@
 (shelved: 1)
   
   ============================
-  ?Goal 0
+  ?P 0
 
 subgoal 2 is:
- forall n : nat, ?Goal n -> ?Goal (S n)
+ forall n : nat, ?P n -> ?P (S n)
 subgoal 3 is:
  nat
 unification constraint:
- ?Goal ?Goal2 <=
+ ?P ?n <=
    True /\ True /\ True \/
    veeryyyyyyyyyyyyloooooooooooooonggidentifier =
    veeryyyyyyyyyyyyloooooooooooooonggidentifier
@@ -18,14 +18,14 @@ unification constraint:
   
   n, m : nat
   ============================
-  ?Goal@{n:=n; m:=m} 0
+  ?P@{n:=n; m:=m} 0
 
 subgoal 2 is:
- forall n0 : nat, ?Goal@{n:=n; m:=m} n0 -> ?Goal@{n:=n; m:=m} (S n0)
+ forall n0 : nat, ?P@{n:=n; m:=m} n0 -> ?P@{n:=n; m:=m} (S n0)
 subgoal 3 is:
  nat
 unification constraint:
- ?Goal@{n:=n; m:=m} ?Goal2@{n:=n; m:=m} <=
+ ?P@{n:=n; m:=m} ?n@{n:=n; m:=m} <=
    True /\ True /\ True \/
    veeryyyyyyyyyyyyloooooooooooooonggidentifier =
    veeryyyyyyyyyyyyloooooooooooooonggidentifier
@@ -34,15 +34,15 @@ unification constraint:
   
   m : nat
   ============================
-  ?Goal1@{m:=m} 0
+  ?P@{m:=m} 0
 
 subgoal 2 is:
- forall n0 : nat, ?Goal1@{m:=m} n0 -> ?Goal1@{m:=m} (S n0)
+ forall n0 : nat, ?P@{m:=m} n0 -> ?P@{m:=m} (S n0)
 subgoal 3 is:
  nat
 unification constraint:
  
- n, m : nat |- ?Goal1@{m:=m} ?Goal0@{n:=n; m:=m} <=
+ n, m : nat |- ?P@{m:=m} ?n@{n:=n; m:=m} <=
    True /\ True /\ True \/
    veeryyyyyyyyyyyyloooooooooooooonggidentifier =
    veeryyyyyyyyyyyyloooooooooooooonggidentifier
@@ -51,15 +51,15 @@ unification constraint:
   
   m : nat
   ============================
-  ?Goal0@{m:=m} 0
+  ?P@{m:=m} 0
 
 subgoal 2 is:
- forall n0 : nat, ?Goal0@{m:=m} n0 -> ?Goal0@{m:=m} (S n0)
+ forall n0 : nat, ?P@{m:=m} n0 -> ?P@{m:=m} (S n0)
 subgoal 3 is:
  nat
 unification constraint:
  
- n, m : nat |- ?Goal0@{m:=m} ?Goal2@{n:=n} <=
+ n, m : nat |- ?P@{m:=m} ?Goal0@{n:=n} <=
    True /\ True /\ True \/
    veeryyyyyyyyyyyyloooooooooooooonggidentifier =
    veeryyyyyyyyyyyyloooooooooooooonggidentifier


### PR DESCRIPTION
Currently, when writing things like `refine (match x with S n => _ | O => _ end).`, the two generated subgoals are swapped compared to the other provided by the user. The goal of this PR is to remedy this at some point.
(The other goal is to just have the possibility to do that from a plugin.)

I am creating this PR to get a bit of feedback on this matter, since I really don't have a comprehensive understanding of the way evar sources are used. Specifically:
- The first commit fixes the fact that `change` loses the evar source. This might have been intended, especially since it required to change a file in the test-suite, but I don't know.
- The second commit adds a tactic `sortgoals` which will sort the currently focused goals by their location. Note that this does not solve everything, which is the main reason I would like feedback, from @herbelin for instance who seemed interested. Consider the following:

```coq
Inductive foo := A : nat -> foo | B : unit -> foo | C : bool -> foo.

Goal foo -> True.
Proof.
  refine (fun x =>
    match x with
    | C _ | A _ => _
    | B _ => _
   end).
```
Without this PR, the subgoals would be A -> B -> C.
With this PR, by adding `; sortgoals`, the subgoals would be A -> C -> B.
The reason is that the evars corresponding to A and C have the same location. I do not have a satisfying solution to this specific problem yet, but maybe it indicates that this PR is not the right way of addressing the problem. Hence the need for some feedback.