### PR TITLE
Fix BZ#5785 (make install -j broken)

### DIFF
--- a/Makefile.ide
+++ b/Makefile.ide
@@ -153,10 +153,12 @@ install-ide-bin:
 
 install-ide-toploop:
 ifeq ($(BEST),opt)
+	$(MKDIR) $(FULLCOQLIB)/toploop/
 	$(INSTALLBIN) $(IDETOPLOOPCMA:.cma=.cmxs) $(FULLCOQLIB)/toploop/
 endif
 install-ide-toploop-byte:
 ifneq ($(BEST),opt)
+	$(MKDIR) $(FULLCOQLIB)/toploop/
 	$(INSTALLBIN) $(IDETOPLOOPCMA) $(FULLCOQLIB)/toploop/
 endif
 

--- a/Makefile.install
+++ b/Makefile.install
@@ -77,6 +77,7 @@ endif
 install-byte: install-coqide-byte
 	$(MKDIR) $(FULLBINDIR)
 	$(INSTALLBIN) $(COQTOPBYTE) $(FULLBINDIR)
+	$(MKDIR) $(FULLCOQLIB)/toploop
 	$(INSTALLBIN) $(TOPLOOPCMA) $(FULLCOQLIB)/toploop/
 	$(INSTALLSH) $(FULLCOQLIB) $(LINKCMO) $(PLUGINS)
 ifndef CUSTOM


### PR DESCRIPTION
This adds back `$(MKDIR) $(FULLCOQLIB)/toploop`, which was lost between
8.6 and 8.7.

This should be backported to 8.7.