### PR TITLE
[stm] First step to move interpretation of Undo commands out of the classifier.

### DIFF
--- a/API/API.mli
+++ b/API/API.mli
@@ -3713,7 +3713,6 @@ sig
                    | VtProofStep of proof_step
                    | VtProofMode of string
                    | VtQuery of vernac_part_of_script * Feedback.route_id
-                   | VtBack of vernac_part_of_script * Stateid.t
                    | VtMeta
                    | VtUnknown
    and vernac_qed_type =

--- a/API/API.mli
+++ b/API/API.mli
@@ -3714,6 +3714,7 @@ sig
                    | VtProofMode of string
                    | VtQuery of vernac_part_of_script * Feedback.route_id
                    | VtBack of vernac_part_of_script * Stateid.t
+                   | VtMeta
                    | VtUnknown
    and vernac_qed_type =
      | VtKeep

--- a/intf/vernacexpr.ml
+++ b/intf/vernacexpr.ml
@@ -502,7 +502,6 @@ type vernac_type =
   | VtProofStep of proof_step
   | VtProofMode of string
   | VtQuery of vernac_part_of_script * Feedback.route_id
-  | VtBack of vernac_part_of_script * Stateid.t
   | VtMeta
   | VtUnknown
 and vernac_qed_type = VtKeep | VtKeepAsAxiom | VtDrop (* Qed/Admitted, Abort *)

--- a/intf/vernacexpr.ml
+++ b/intf/vernacexpr.ml
@@ -503,6 +503,7 @@ type vernac_type =
   | VtProofMode of string
   | VtQuery of vernac_part_of_script * Feedback.route_id
   | VtBack of vernac_part_of_script * Stateid.t
+  | VtMeta
   | VtUnknown
 and vernac_qed_type = VtKeep | VtKeepAsAxiom | VtDrop (* Qed/Admitted, Abort *)
 and vernac_start = string * opacity_guarantee * Id.t list

--- a/stm/vernac_classifier.ml
+++ b/stm/vernac_classifier.ml
@@ -31,7 +31,6 @@ let string_of_vernac_type = function
         Option.default "" proof_block_detection
   | VtProofMode s -> "ProofMode " ^ s
   | VtQuery (b, route) -> "Query " ^ string_of_in_script b ^ " route " ^ string_of_int route
-  | VtBack (b, _) -> "Stm Back " ^ string_of_in_script b
   | VtMeta -> "Meta "
 
 let string_of_vernac_when = function
@@ -73,7 +72,7 @@ let rec classify_vernac e =
     | VernacFail e -> (* Fail Qed or Fail Lemma must not join/fork the DAG *)
         (match classify_vernac e with
         | ( VtQuery _ | VtProofStep _ | VtSideff _
-          | VtBack _ | VtProofMode _ | VtMeta), _ as x -> x
+          | VtProofMode _ | VtMeta), _ as x -> x
         | VtQed _, _ ->
             VtProofStep { parallel = `No; proof_block_detection = None },
             VtNow

--- a/stm/vernac_classifier.mli
+++ b/stm/vernac_classifier.mli
@@ -18,9 +18,6 @@ val classify_vernac : vernac_expr -> vernac_classification
 val declare_vernac_classifier :
   Vernacexpr.extend_name -> (raw_generic_argument list -> unit -> vernac_classification) -> unit
 
-(** Set by Stm *)
-val set_undo_classifier : (vernac_expr -> vernac_classification) -> unit
-
 (** Standard constant classifiers *)
 val classify_as_query : vernac_classification
 val classify_as_sideeff : vernac_classification

--- a/toplevel/vernac.ml
+++ b/toplevel/vernac.ml
@@ -119,7 +119,7 @@ let rec interp_vernac ~check ~interactive doc sid (loc,com) =
 
       (* XXX: We need to run this before add as the classification is
          highly dynamic and depends on the structure of the
-         document. Hopefully this is fixed when VtBack can be removed
+         document. Hopefully this is fixed when VtMeta can be removed
          and Undo etc... are just interpreted regularly. *)
 
       (* XXX: The classifier can emit warnings so we need to guard
@@ -127,7 +127,7 @@ let rec interp_vernac ~check ~interactive doc sid (loc,com) =
       let wflags = CWarnings.get_flags () in
       CWarnings.set_flags "none";
       let is_proof_step = match fst (Vernac_classifier.classify_vernac v) with
-        | VtProofStep _ | VtBack (_, _) | VtStartProof _ -> true
+        | VtProofStep _ | VtMeta | VtStartProof _ -> true
         | _ -> false
       in
       CWarnings.set_flags wflags;


### PR DESCRIPTION
The vernacular classifier has a current special case for "Undo" like
commands, as it needs access to the document structure in order to
produce the proper "VtBack" classification, however the classifier is
defined before the document is.

We introduce a new delegation status `VtMeta` that allows us to
interpreted such commands outside the classifier itself.