### PR TITLE
Use type nonrec in some functor arguments.

### DIFF
--- a/kernel/names.ml
+++ b/kernel/names.ml
@@ -113,8 +113,7 @@ struct
 
   module Self_Hashcons =
     struct
-      type _t = t
-      type t = _t
+      type nonrec t = t
       type u = Id.t -> Id.t
       let hashcons hident = function
         | Name id -> Name (hident id)
@@ -236,8 +235,7 @@ struct
 
   module Self_Hashcons =
     struct
-      type _t = t
-      type t = _t
+      type nonrec t = t
       type u = (Id.t -> Id.t) * (DirPath.t -> DirPath.t)
       let hashcons (hid,hdir) (n,s,dir) = (n,hid s,hdir dir)
       let eq ((n1,s1,dir1) as x) ((n2,s2,dir2) as y) =
@@ -869,8 +867,7 @@ struct
 
   module Self_Hashcons =
     struct
-      type _t = t
-      type t = _t
+      type nonrec t = t
       type u = Constant.t -> Constant.t
       let hashcons hc (c,b) = (hc c,b)
       let eq ((c,b) as x) ((c',b') as y) =

--- a/kernel/univ.ml
+++ b/kernel/univ.ml
@@ -121,8 +121,7 @@ module Level = struct
   (** Hashcons on levels + their hash *)
 
   module Self = struct
-    type _t = t
-    type t = _t
+    type nonrec t = t
     type u = unit
     let eq x y = x.hash == y.hash && RawLevel.hequal x.data y.data
     let hash x = x.hash
@@ -755,8 +754,7 @@ struct
 
   module HInstancestruct =
   struct
-    type _t = t
-    type t = _t
+    type nonrec t = t
     type u = Level.t -> Level.t
 
     let hashcons huniv a = 


### PR DESCRIPTION
`type nonrec` is in ocaml since 4.02.2+dev / +rc1, see https://caml.inria.fr/mantis/view.php?id=6016