### PR TITLE
Revert "Add debug output to brew update."

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -143,7 +143,7 @@ matrix:
       - NATIVE_COMP="no"
       - COQ_DEST="-local"
       before_install:
-      - brew update --debug --verbose
+      - brew update
       - brew install opam gnu-time
 
     - if: NOT (type = pull_request)
@@ -157,7 +157,7 @@ matrix:
       - EXTRA_CONF="-coqide opt -warn-error"
       - EXTRA_OPAM="lablgtk-extras"
       before_install:
-      - brew update --debug --verbose
+      - brew update
       - brew install opam gnu-time gtk+ expat gtksourceview libxml2 gdk-pixbuf python3
       - pip3 install macpack
       before_deploy:


### PR DESCRIPTION
This reverts commit c7465d2ecb69e64613dd38b262f5e78ecad99de1 which is the second part of #1024 (whose first part was already reverted in #1134).
This verbosity level is making the Travis log too long to be displayed while bringing no apparent benefit.