### PR TITLE
An attempt to fix issue #5771 (error color hidden by warning color in coqide).

### DIFF
--- a/ide/tags.ml
+++ b/ide/tags.ml
@@ -17,32 +17,20 @@ module Script =
 struct
   (* More recently defined tags have highest priority in case of overlapping *)
   let table = GText.tag_table ()
-  let comment = make_tag table ~name:"comment" []
   let warning = make_tag table ~name:"warning" [`UNDERLINE `SINGLE; `FOREGROUND "blue"]
   let error = make_tag table ~name:"error" [`UNDERLINE `SINGLE]
   let error_bg = make_tag table ~name:"error_bg" []
   let to_process = make_tag table ~name:"to_process" []
   let processed = make_tag table ~name:"processed" []
-  let incomplete = make_tag table ~name:"incomplete" [
-          `BACKGROUND_STIPPLE_SET true;
-  ]
+  let incomplete = make_tag table ~name:"incomplete" [`BACKGROUND_STIPPLE_SET true]
   let unjustified = make_tag table ~name:"unjustified" [`BACKGROUND "gold"]
-  let found = make_tag table ~name:"found" [`BACKGROUND "blue"; `FOREGROUND "white"]
-  let sentence = make_tag table ~name:"sentence" []
   let tooltip = make_tag table ~name:"tooltip" [] (* debug:`BACKGROUND "blue" *)
-
   let ephemere =
     [error; warning; error_bg; tooltip; processed; to_process; incomplete; unjustified]
-
-  let all =
-    comment :: found :: sentence :: ephemere
-
-  let edit_zone =
-    let t = make_tag table ~name:"edit_zone" [`UNDERLINE `SINGLE] in
-    t#set_priority (List.length all);
-    t
-  let all = edit_zone :: all
-  
+  let comment = make_tag table ~name:"comment" []
+  let sentence = make_tag table ~name:"sentence" []
+  let edit_zone = make_tag table ~name:"edit_zone" [`UNDERLINE `SINGLE] (* for debugging *)
+  let all = edit_zone :: comment :: sentence :: ephemere
 end
 module Proof =
 struct

--- a/ide/tags.ml
+++ b/ide/tags.ml
@@ -15,10 +15,11 @@ let make_tag (tt:GText.tag_table) ~name prop =
 
 module Script =
 struct
+  (* More recently defined tags have highest priority in case of overlapping *)
   let table = GText.tag_table ()
   let comment = make_tag table ~name:"comment" []
-  let error = make_tag table ~name:"error" [`UNDERLINE `SINGLE]
   let warning = make_tag table ~name:"warning" [`UNDERLINE `SINGLE; `FOREGROUND "blue"]
+  let error = make_tag table ~name:"error" [`UNDERLINE `SINGLE]
   let error_bg = make_tag table ~name:"error_bg" []
   let to_process = make_tag table ~name:"to_process" []
   let processed = make_tag table ~name:"processed" []

--- a/ide/tags.mli
+++ b/ide/tags.mli
@@ -17,7 +17,6 @@ sig
   val processed : GText.tag
   val incomplete : GText.tag
   val unjustified : GText.tag
-  val found : GText.tag
   val sentence : GText.tag
   val tooltip : GText.tag
   val edit_zone : GText.tag (* for debugging *)


### PR DESCRIPTION
We change the relative priority of errors and warnings, so that the error color (namely red) takes precedence.

It is unsure that it is universally the best choice. If the location of the error is finer than the one of the warning, it is better. In the other way round, it might be less good, e.g. if understanding the
warning helps to understand the error.

Maybe the best policy would be to test the relative locations of the warning and error, determining which one is included in the other?

Anyway, trying to consider the error as more important, at the current time.

Any recommendation from a UI expert welcome.

Further edit: I added a commit intended to simplify a bit the code declaring tags for the script winows. This should be reviewed carefully by the UI experts, including checking the order of priorities.