### PR TITLE
Fixing #2881 ("change with" failing in an Ltac definition).

### DIFF
--- a/test-suite/bugs/closed/2881.v
+++ b/test-suite/bugs/closed/2881.v
@@ -1,0 +1,7 @@
+(* About scoping of pattern variables in strict/non-strict mode *)
+
+Ltac eta_red := change (fun a => ?f0 a) with f0.
+Goal forall T1 T2 (f : T1 -> T2), (fun x => f x) = f.
+intros.
+eta_red.
+Abort.


### PR DESCRIPTION
A present for Jason...

The code around internalization/interpretation of pattern remains pretty convulated. How is doing Ltac2 on this matter (`change with`, `match goal`, ...)? Is it worth making Ltac1 improve on pattern interpretation or is Ltac2 ready to take the continuation, and, e.g., to eventually provide support for things such as `replace (S ?x = ?y) with (x = S y)` etc.?

