### PR TITLE
[toplevel] Export the last document seen after `Drop`.

### DIFF
--- a/dev/base_include
+++ b/dev/base_include
@@ -233,8 +233,7 @@ let _ = Flags.in_toplevel := true
 let _ = Constrextern.set_extern_reference
   (fun ?loc _ r -> Libnames.Qualid (loc,Nametab.shortest_qualid_of_global Idset.empty r));;
 
-open Coqloop
-let go = loop
+let go () = Coqloop.loop Option.(get !Coqtop.drop_last_doc)
 
 let _ =
  print_string

--- a/toplevel/coqloop.ml
+++ b/toplevel/coqloop.ml
@@ -350,7 +350,7 @@ let rec loop doc =
        not possible due exceptions. *)
     in vernac_loop doc (Stm.get_current_state ~doc)
   with
-    | CErrors.Drop -> ()
+    | CErrors.Drop -> doc
     | CErrors.Quit -> exit 0
     | any ->
       Feedback.msg_error (str "Anomaly: main loop exited with exception: " ++

--- a/toplevel/coqloop.mli
+++ b/toplevel/coqloop.mli
@@ -36,4 +36,4 @@ val do_vernac : Stm.doc -> Stateid.t -> Stm.doc * Stateid.t
 
 (** Main entry point of Coq: read and execute vernac commands. *)
 
-val loop : Stm.doc -> unit
+val loop : Stm.doc -> Stm.doc

--- a/toplevel/coqtop.mli
+++ b/toplevel/coqtop.mli
@@ -15,6 +15,9 @@ val init_toplevel : string list -> (Stm.doc * Stateid.t) option
 
 val start : unit -> unit
 
+(* Last document seen after `Drop` *)
+val drop_last_doc : Stm.doc option ref
+
 (* For other toploops *)
 val toploop_init : (string list -> string list) ref
 val toploop_run : (Stm.doc -> unit) ref


### PR DESCRIPTION
After `Drop`, `Coqtop.drop_last_doc` will contain the current document
used by `Coqloop`. This is useful for people wanting to restart Coq
after a `Drop`.