### PR TITLE
Attempt to improve a bit the "not in its scope" unification error message.

### DIFF
--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -288,12 +288,13 @@ let explain_unification_error env sigma p1 p2 = function
 	strbrk " with term " ++ pr_leconstr_env env sigma rhs ++
         strbrk " that would depend on itself"]
      | NotClean ((evk,args),env,c) ->
-        [str "cannot instantiate " ++ quote (pr_existential_key sigma evk)
-        ++ strbrk " because " ++ pr_leconstr_env env sigma c ++
-	strbrk " is not in its scope" ++
-        (if Array.is_empty args then mt() else
-         strbrk ": available arguments are " ++
-         pr_sequence (pr_leconstr_env env sigma) (List.rev (Array.to_list args)))]
+        let ev = quote (pr_existential_key sigma evk) in
+        [strbrk "unable to get " ++ pr_leconstr_env env sigma c ++
+         strbrk " out of the possible instances available" ++
+         strbrk " at the point of declaration of " ++ ev ++
+         (if Array.is_empty args then mt() else
+          strbrk ", namely: " ++
+          pr_sequence (pr_leconstr_env env sigma) (List.rev (Array.to_list args)))]
      | NotSameArgSize | NotSameHead | NoCanonicalStructure ->
         (* Error speaks from itself *) []
      | ConversionFailed (env,t1,t2) ->


### PR DESCRIPTION
In a situation where one creates an evar `?x`, with existing variables `y1`, ..., `yn`, then introduce a new hypothesis `z`, then try to use this latter hypothesis to instantiate the evar, one typically gets the message
```
cannot instantiate [?x] because "z" is not in its scope: available 
arguments are y1, ..., yn
```
@amahboubi reported once that this message was a bit astruse. For instance, she was proposing something of the following form:
```
z is unknown at the time of the declaration of ?x (known variables are y1, ..., yn)
```
The problem is that the general case is more complex. For instance, one could have a problem `?x@{y1:=y1;...;yn:=yn;w1:=u1;...;wn=un} == t(z)` coming from a configuration such as:
```
fun y1 ... yn => ((fun w1 ... wm => f ?x (fun z => ...)) u1 ... um
```
Would it be possible to have a message as clear as the one above and which handles also the general case?

This PR makes the following proposal:
```
unable to get "t" out of the possible instances available at the point of
declaration of ?x, namely: y1, .., yn, u1, ..., um
```
Even if it is probably an improvement, I'm not fully satisfied, in the sense that we do not get something as nice as in the case where only variables are involved.

Another strategy could be, for instance, to split the part of the instance which is the identity from the part which is non trivial, then to look at whether `t` is a variable or not and to have the following kinds of messages:
```
z is unknown at the time of the declaration of ?x (known variables are y1, ..., yn)
```
or
```
z is unknown at the time of the declaration of ?x (known variables are y1, ..., yn and known instantiations are w1:=u1, ..., .wn:=un)
```
or
```
unable to get "t" out of the possible instances available at the point of declaration of ?x, namely: y1, .., yn, u1, ..., um
```
More generally, the problem is not unrelated to #5788 and #5767. Maybe, `t` should be put in neutral weak-head normal form `E[z]` where `E` is an evaluation context (i.e. stack for those familar with abstract machines) and the message be referring to the head variable `z`. How general such a strategy would be? Can we afford weakly-reducing the term taking the risk of a long computation?
Is there a compromise to find with different messages depending on whether a neutral term has been obtained or not? But the more we try to refine the message, the more we need infrastructure in the unification which at the same time could fix the two aforementioned issues.

So, I don't know what to think and I believe I need help in finding the good compromise. Maybe
```
unable to get "t" out of the knowledge available at the point of
declaration of ?x, namely: y1, .., yn, u1, ..., um
```
so that, in the initial case, it becomes:
```
unable to get "z" out of the knowledge available at the point of
declaration of ?x, namely: y1, .., yn,
```
even if "knowledge" is more about an intuition than about a clearly defined notion. Or
```
unable to get "t" from what is known at the point of
declaration of ?x, namely: y1, .., yn, u1, ..., um
```
but it is also cheating a bit with words.