### PR TITLE
Making coq_makefile usage consistent with what it claims + possibly fixing printing errors (was: Removing failure of coq_makefile on no arguments)

### DIFF
--- a/tools/coq_makefile.ml
+++ b/tools/coq_makefile.ml
@@ -27,16 +27,8 @@ let rec print_prefix_list sep = function
   | x :: l -> print sep; print x; print_prefix_list sep l
   | [] -> ()
 
-let usage () =
-  output_string stderr "Usage summary:\
-\n\
-\ncoq_makefile .... [file.v] ... [file.ml[i4]?] ... [file.ml{lib,pack}]\
-\n  ... [any] ... [-extra[-phony] result dependencies command]\
-\n  ... [-I dir] ... [-R physicalpath logicalpath]\
-\n  ... [-Q physicalpath logicalpath] ... [VARIABLE = value]\
-\n  ...  [-arg opt] ... [-opt|-byte] [-no-install] [-f file] [-o file]\
-\n  [-h] [--help]\
-\n\
+let usage_common () =
+  output_string stderr "\
 \n[file.v]: Coq file to be compiled\
 \n[file.ml[i4]?]: Objective Caml file to be compiled\
 \n[file.ml{lib,pack}]: ocamlbuild file that describes a Objective Caml\
@@ -65,10 +57,29 @@ let usage () =
 \n[-install opt]: where opt is \"user\" to force install into user directory,\
 \n  \"none\" to build a makefile with no install target or\
 \n  \"global\" to force install in $COQLIB directory\
+\n[-bypass-API]: when compiling plugins, bypass Coq API\
+\n"
+
+let usage_coq_project () =
+  output_string stderr "Available arguments:";
+  usage_common ();
+  exit 1
+
+let usage_coq_makefile () =
+  output_string stderr "Usage summary:\
+\n\
+\ncoq_makefile .... [file.v] ... [file.ml[i4]?] ... [file.ml{lib,pack}]\
+\n  ... [any] ... [-extra[-phony] result dependencies command]\
+\n  ... [-I dir] ... [-R physicalpath logicalpath]\
+\n  ... [-Q physicalpath logicalpath] ... [VARIABLE = value]\
+\n  ...  [-arg opt] ... [-opt|-byte] [-no-install] [-f file] [-o file]\
+\n  [-h] [--help]\
+\n";
+  usage_common ();
+  output_string stderr "\
 \n[-f file]: take the contents of file as arguments\
 \n[-o file]: output should go in file file (recommended)\
 \n	Output file outside the current directory is forbidden.\
-\n[-bypass-API]: when compiling plugins, bypass Coq API\
 \n[-h]: print this usage summary\
 \n[--help]: equivalent to [-h]\n";
   exit 1
@@ -391,7 +402,7 @@ let _ =
 
   let project = 
     try cmdline_args_to_project ~curdir:Filename.current_dir_name args
-    with Parsing_error s -> prerr_endline s; usage () in
+    with Parsing_error s -> prerr_endline s; usage_coq_project () in
 
   if only_destination <> None then begin
     destination_of project (Option.get only_destination);

--- a/tools/coq_makefile.ml
+++ b/tools/coq_makefile.ml
@@ -391,6 +391,7 @@ let share_prefix s1 s2 =
   | _ -> false
 
 let _ =
+  let _fhandle = Feedback.(add_feeder (console_feedback_listener Format.err_formatter)) in
   let prog, args =
     let args = Array.to_list Sys.argv in
     let prog = List.hd args in

--- a/tools/coq_makefile.ml
+++ b/tools/coq_makefile.ml
@@ -66,7 +66,7 @@ let usage () =
 \n  \"none\" to build a makefile with no install target or\
 \n  \"global\" to force install in $COQLIB directory\
 \n[-f file]: take the contents of file as arguments\
-\n[-o file]: output should go in file file\
+\n[-o file]: output should go in file file (recommended)\
 \n	Output file outside the current directory is forbidden.\
 \n[-bypass-API]: when compiling plugins, bypass Coq API\
 \n[-h]: print this usage summary\
@@ -381,7 +381,6 @@ let share_prefix s1 s2 =
 
 let _ =
   let prog, args =
-    if Array.length Sys.argv = 1 then usage ();
     let args = Array.to_list Sys.argv in
     let prog = List.hd args in
     prog, List.tl args in


### PR DESCRIPTION
This is "brocante" day... cleaning the open branches I have, I found this minor fix to `coq_makefile`, whose usage says that all arguments are optional, but which in practice expects at least one argument.

I solved the inconsistency by accepting no arguments. One could have also fixed it by changing the usage. Don't know what the `coq_makefile` experts would prefer.
