### PR TITLE
Request a bit more info in ISSUE_TEMPLATE

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -3,7 +3,7 @@
 
 #### Version
 
-<!-- You can get this information by running `coqtop -v`. -->
+<!-- You can get this information by running `coqtop -v`, or `echo | coqtop` if you built from git source. -->
 
 
 #### Operating system


### PR DESCRIPTION
Note that `coqtop -v` is nearly useless when Coq is built from git; this
commit mentions that `echo | coqtop` will give better version info.