### PR TITLE
Refining PR#924 (insensitivity of projection heuristics to alphabet).

### DIFF
--- a/test-suite/bugs/closed/6070.v
+++ b/test-suite/bugs/closed/6070.v
@@ -1,0 +1,32 @@
+(* A slight shortening of bug 6078 *)
+
+(* This bug exposed a different behavior of unshelve_unifiable
+   depending on which projection is found in the unification
+   heuristics *)
+
+Axiom flat_type : Type.
+Axiom interp_flat_type : flat_type -> Type.
+Inductive type := Arrow (_ _ : flat_type).
+Definition interp_type (t : type)
+  := interp_flat_type (match t with Arrow s d => s end)
+     -> interp_flat_type (match t with Arrow s d => d end).
+Axiom Expr : type -> Type.
+Axiom Interp : forall {t : type}, Expr t -> interp_type t.
+Axiom Wf : forall {t}, Expr t -> Prop.
+Axiom a : forall f, interp_flat_type f.
+
+Definition packaged_expr_functionP A :=
+  (fun F : Expr A -> Expr A
+   => forall e' v, Interp (F e') v = a (let (_,f) := A in f)).
+Goal forall (f f0 : flat_type)
+            (e : forall _ : Expr (@Arrow f f0),
+                Expr (@Arrow f f0)),
+    @packaged_expr_functionP (@Arrow f f0) e.
+  intros.
+  refine (fun (e0 : Expr (Arrow f f0))
+   => (fun zHwf':True =>
+   (fun v : interp_flat_type f =>
+      ?[G] : ?[U] = ?[V] :> interp_flat_type ?[v])) ?[H]);
+   [ | ].
+   (* Was: Error: Tactic failure: Incorrect number of goals (expected 3 tactics). *)
+Abort.


### PR DESCRIPTION
We refine the criterion for selecting a projection. Before PR#924 it was dependent of the ascii order on names (i.e. morally "random" up to alpha-conversion). After PR#924 it was chronological.

We refine a bit more by giving priority to simple projections when they exist over projections which include an evar instantiation (and which may actually be ill-typed).

This fixes #6070.

While looking at it, I encountered various issues which we may want to consider/check at some time:
- I have a goal `?n` which is not anymore dependent in another goal but on which a constraint remain: should `shelve_unifiable` put it on the shelve or not?
- Updating of conversion problems: pending conversion problems are supposed to be of the form `E[?n] == t` or `E[?n] == E'[?p]` for some evaluation contexts `E` and `E'` and `t` not of the form `E'[?p]`. In particular, if `?n` is instantiated in the former case, the conversion problem is simplifiable (up to the question of whether we may prefer to be lazy on potentially-costly reduction of constants in `t`). Currently, updating the conversion problems when `?n` is instantiated is done in `solve_simple_eqn` but evars can be instantiated at a lower level, directly with `Evd.define`, as e.g. `refine` does. In the latter case, conversion problems are not reconsidered. This should probably be improved.

(Edited for complement of information)