### PR TITLE
[api] Move `Esubst` out of API.

### DIFF
--- a/checker/closure.ml
+++ b/checker/closure.ml
@@ -12,6 +12,7 @@ open Names
 open Cic
 open Term
 open Esubst
+open Esubst.Internal
 open Environ
 
 let stats = ref false

--- a/checker/closure.mli
+++ b/checker/closure.mli
@@ -10,6 +10,7 @@
 open Names
 open Cic
 open Esubst
+open Esubst.Internal
 open Environ
 (*i*)
 

--- a/checker/reduction.ml
+++ b/checker/reduction.ml
@@ -11,7 +11,7 @@ open Util
 open Cic
 open Term
 open Closure
-open Esubst
+open Esubst.Internal
 open Environ
 
 let rec is_empty_stack = function

--- a/checker/term.ml
+++ b/checker/term.ml
@@ -11,7 +11,7 @@
 open CErrors
 open Util
 open Names
-open Esubst
+open Esubst.Internal
 
 open Cic
 

--- a/checker/term.mli
+++ b/checker/term.mli
@@ -16,7 +16,7 @@ val noccur_between : int -> int -> constr -> bool
 val noccur_with_meta : int -> int -> constr -> bool
 val map_constr_with_binders :
   ('a -> 'a) -> ('a -> constr -> constr) -> 'a -> constr -> constr
-val exliftn : Esubst.lift -> constr -> constr
+val exliftn : Esubst.Internal.lift -> constr -> constr
 val liftn : int -> int -> constr -> constr
 val lift : int -> constr -> constr
 type info = Closed | Open | Unknown

--- a/engine/universes.ml
+++ b/engine/universes.ml
@@ -885,7 +885,7 @@ let normalize_context_set ctx us algs =
 	 in g) csts g
     in
     let g = Univ.Constraint.fold UGraph.enforce_constraint csts g in
-      UGraph.constraints_of_universes g
+      UGraph.Internal.constraints_of_universes g
   in
   let noneqs =
     Constraint.fold (fun (l,d,r as cstr) noneqs ->

--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -27,6 +27,7 @@ open Constr
 open Vars
 open Environ
 open Esubst
+open Esubst.Internal
 
 let stats = ref false
 let share = ref true

--- a/kernel/cClosure.mli
+++ b/kernel/cClosure.mli
@@ -10,6 +10,7 @@ open Names
 open Constr
 open Environ
 open Esubst
+open Esubst.Internal
 
 (** Flags for profiling reductions. *)
 val stats : bool ref

--- a/kernel/esubst.ml
+++ b/kernel/esubst.ml
@@ -12,6 +12,7 @@
 
 open Util
 
+module Internal = struct
 (*********************)
 (*      Lifting      *)
 (*********************)
@@ -157,3 +158,6 @@ let rec comp mk_cl s1 s2 =
         if k<k'
         then subs_liftn k (comp mk_cl s (subs_liftn (k'-k) s'))
         else subs_liftn k' (comp mk_cl (subs_liftn (k-k') s) s')
+end
+module Public = Internal
+include Public

--- a/kernel/esubst.mli
+++ b/kernel/esubst.mli
@@ -6,6 +6,8 @@
 (*         *       GNU Lesser General Public License Version 2.1        *)
 (************************************************************************)
 
+module Public : sig
+
 (** Explicit substitutions *)
 
 (** {6 Explicit substitutions } *)
@@ -21,6 +23,14 @@ type 'a subs = private
   | CONS of 'a array * 'a subs
   | SHIFT of int * 'a subs
   | LIFT of int * 'a subs
+
+val subs_id : int -> 'a subs
+
+end
+
+include module type of struct include Public end
+
+module Internal : sig
 
 (** Derived constructors granting basic invariants *)
 val subs_id : int -> 'a subs
@@ -66,3 +76,5 @@ val el_liftn : int -> lift -> lift
 val el_lift : lift -> lift
 val reloc_rel : int -> lift -> int
 val is_lift_id : lift -> bool
+
+end

--- a/kernel/mod_typing.ml
+++ b/kernel/mod_typing.ml
@@ -97,7 +97,7 @@ let rec check_with_def env struc (idl,(c,ctx)) mp equiv =
           let subst, ctx = Univ.abstract_universes ctx in
           let c = Vars.subst_univs_level_constr subst c in
           let () =
-            if not (UGraph.check_subtype (Environ.universes env) uctx ctx) then
+            if not (UGraph.Internal.check_subtype (Environ.universes env) uctx ctx) then
               error_incorrect_with_constraint lab
           in
           (** Terms are compared in a context with De Bruijn universe indices *)

--- a/kernel/nativelambda.ml
+++ b/kernel/nativelambda.ml
@@ -7,7 +7,7 @@
 (************************************************************************)
 open Util
 open Names
-open Esubst
+open Esubst.Internal
 open Constr
 open Declarations
 open Pre_env

--- a/kernel/reduction.ml
+++ b/kernel/reduction.ml
@@ -22,7 +22,7 @@ open Constr
 open Vars
 open Environ
 open CClosure
-open Esubst
+open Esubst.Internal
 open Context.Rel.Declaration
 
 let rec is_empty_stack = function

--- a/kernel/subtyping.ml
+++ b/kernel/subtyping.ml
@@ -94,7 +94,7 @@ let check_conv_error error why cst poly f env a1 a2 =
 let check_polymorphic_instance error env auctx1 auctx2 =
   if not (Univ.AUContext.size auctx1 == Univ.AUContext.size auctx2) then
     error IncompatibleInstances
-  else if not (UGraph.check_subtype (Environ.universes env) auctx2 auctx1) then
+  else if not (UGraph.Internal.check_subtype (Environ.universes env) auctx2 auctx1) then
     error (IncompatibleConstraints auctx1)
   else
     Environ.push_context ~strict:false (Univ.AUContext.repr auctx2) env

--- a/kernel/uGraph.ml
+++ b/kernel/uGraph.ml
@@ -10,6 +10,8 @@ open Pp
 open Util
 open Univ
 
+module Internal = struct
+
 (* Created in Caml by Gérard Huet for CoC 4.8 [Dec 1988] *)
 (* Functional code by Jean-Christophe Filliâtre for Coq V7.0 [1999] *)
 (* Extension with algebraic universes by HH for Coq V7.0 [Sep 2001] *)
@@ -911,3 +913,6 @@ let check_leq =
       CProfile.profile3 check_leq_key check_leq
   else check_leq
 
+end
+
+include Internal

--- a/kernel/uGraph.mli
+++ b/kernel/uGraph.mli
@@ -57,6 +57,8 @@ val empty_universes : t
 
 val sort_universes : t -> t
 
+module Internal : sig
+
 val constraints_of_universes : t -> Constraint.t
 
 val check_subtype : AUContext.t check_function
@@ -70,3 +72,5 @@ val dump_universes :
 
 (** {6 Debugging} *)
 val check_universes_invariants : t -> unit
+
+end

--- a/kernel/vars.ml
+++ b/kernel/vars.ml
@@ -7,7 +7,7 @@
 (************************************************************************)
 
 open Names
-open Esubst
+open Esubst.Internal
 
 module RelDecl = Context.Rel.Declaration
 

--- a/kernel/vars.mli
+++ b/kernel/vars.mli
@@ -33,7 +33,7 @@ val noccur_with_meta : int -> int -> constr -> bool
 (** {6 Relocation and substitution } *)
 
 (** [exliftn el c] lifts [c] with lifting [el] *)
-val exliftn : Esubst.lift -> constr -> constr
+val exliftn : Esubst.Internal.lift -> constr -> constr
 
 (** [liftn n k c] lifts by [n] indexes above or equal to [k] in [c] *)
 val liftn : int -> int -> constr -> constr

--- a/pretyping/cbv.ml
+++ b/pretyping/cbv.ml
@@ -12,6 +12,7 @@ open Constr
 open Vars
 open CClosure
 open Esubst
+open Esubst.Internal
 
 (**** Call by value reduction ****)
 

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -343,7 +343,7 @@ let dump_universes_gen g s =
     end
   in
   try
-    UGraph.dump_universes output_constraint g;
+    UGraph.Internal.dump_universes output_constraint g;
     close ();
     Feedback.msg_info (str "Universes written to file \"" ++ str s ++ str "\".")
   with reraise ->


### PR DESCRIPTION
[api] Move `Esubst` out of API.
We need to determine what part of the API should do in internal.
I'm afraid I am not qualified for that, so comments welcome.

c.f. issue #6008