### PR TITLE
Adding a tactical `iter` in Ltac

### DIFF
--- a/plugins/ltac/extratactics.ml4
+++ b/plugins/ltac/extratactics.ml4
@@ -1091,6 +1091,26 @@ TACTIC EXTEND decompose
 | [ "decompose" "[" ne_constr_list(l) "]" constr(c) ] -> [ decompose l c ]
 END
 
+let iter ist tac arg =
+  let open Tacinterp in
+  let open Taccoerce in
+  let map tac =
+    Tacticals.New.tclMAP (fun a -> Ftactic.run (interp_app None ist tac [a]) (tactic_of_value ist)) in
+  match Value.to_list arg with
+  | Some l -> map tac l
+  | None ->
+  match Value.to_option arg with
+  | Some (Some v) -> map tac [v]
+  | Some None -> Proofview.tclUNIT ()
+  | None ->
+  match Value.to_pair arg with
+  | Some (a,b) -> map tac [a;b]
+  | None -> Tacticals.New.tclZEROMSG (str "Expecting a pair, list, or option.")
+
+TACTIC EXTEND iter
+| [ "iter" tactic(t) tactic_arg(c) ] -> [ iter ist t c ]
+END
+
 (** library/keys *)
 
 VERNAC COMMAND EXTEND Declare_keys CLASSIFIED AS SIDEFF

--- a/plugins/ltac/extratactics.ml4
+++ b/plugins/ltac/extratactics.ml4
@@ -1108,7 +1108,7 @@ let iter ist tac arg =
   | None -> Tacticals.New.tclZEROMSG (str "Expecting a pair, list, or option.")
 
 TACTIC EXTEND iter
-| [ "iter" tactic(t) tactic_arg(c) ] -> [ iter ist t c ]
+| [ "iter" tactic(t) tactic_as_arg(c) ] -> [ iter ist t c ]
 END
 
 (** library/keys *)

--- a/plugins/ltac/pltac.ml
+++ b/plugins/ltac/pltac.ml
@@ -38,7 +38,7 @@ let clause_dft_concl =
 
 
 (* Main entries for ltac *)
-let tactic_arg = Gram.entry_create "tactic:tactic_arg"
+let tactic_arg = make_gen_entry utactic "tactic_arg"
 let tactic_expr = make_gen_entry utactic "tactic_expr"
 let binder_tactic = make_gen_entry utactic "binder_tactic"
 
@@ -58,6 +58,7 @@ let () =
   register_grammar wit_constr_with_bindings (constr_with_bindings);
   register_grammar wit_bindings (bindings);
   register_grammar wit_tactic (tactic);
+  register_grammar wit_tactic_arg (tactic_arg);
   register_grammar wit_ltac (tactic);
   register_grammar wit_clause_dft_concl (clause_dft_concl);
   register_grammar wit_destruction_arg (destruction_arg);

--- a/plugins/ltac/pltac.ml
+++ b/plugins/ltac/pltac.ml
@@ -59,6 +59,7 @@ let () =
   register_grammar wit_bindings (bindings);
   register_grammar wit_tactic (tactic);
   register_grammar wit_tactic_arg (tactic_arg);
+  register_grammar wit_tactic_as_arg (tactic);
   register_grammar wit_ltac (tactic);
   register_grammar wit_clause_dft_concl (clause_dft_concl);
   register_grammar wit_destruction_arg (destruction_arg);

--- a/plugins/ltac/tacarg.ml
+++ b/plugins/ltac/tacarg.ml
@@ -24,3 +24,6 @@ let wit_ltac = make0 ~dyn:(val_tag (topwit Stdarg.wit_unit)) "ltac"
 
 let wit_destruction_arg =
   make0 "destruction_arg"
+
+let wit_tactic_arg : (raw_tactic_arg, glob_tactic_arg, Val.t) genarg_type =
+  make0 "tactic_arg"

--- a/plugins/ltac/tacarg.ml
+++ b/plugins/ltac/tacarg.ml
@@ -27,3 +27,6 @@ let wit_destruction_arg =
 
 let wit_tactic_arg : (raw_tactic_arg, glob_tactic_arg, Val.t) genarg_type =
   make0 "tactic_arg"
+
+let wit_tactic_as_arg : (raw_tactic_expr, glob_tactic_arg, Val.t) genarg_type =
+  make0 ~dyn:(val_tag (topwit wit_tactic_arg)) "tactic_as_arg"

--- a/plugins/ltac/tacarg.mli
+++ b/plugins/ltac/tacarg.mli
@@ -26,3 +26,5 @@ val wit_destruction_arg :
    delayed_open_constr_with_bindings Tacexpr.destruction_arg) genarg_type
 
 val wit_tactic_arg : (raw_tactic_arg, glob_tactic_arg, Geninterp.Val.t) genarg_type
+
+val wit_tactic_as_arg : (raw_tactic_expr, glob_tactic_arg, Geninterp.Val.t) genarg_type

--- a/plugins/ltac/tacarg.mli
+++ b/plugins/ltac/tacarg.mli
@@ -25,3 +25,4 @@ val wit_destruction_arg :
    glob_constr_and_expr with_bindings Tacexpr.destruction_arg,
    delayed_open_constr_with_bindings Tacexpr.destruction_arg) genarg_type
 
+val wit_tactic_arg : (raw_tactic_arg, glob_tactic_arg, Geninterp.Val.t) genarg_type

--- a/plugins/ltac/tacintern.ml
+++ b/plugins/ltac/tacintern.ml
@@ -807,6 +807,12 @@ let () =
   Genintern.register_intern0 wit_tactic_arg (lift (intern_tacarg true false));
   ()
 
+let () =
+  let intern ist = function
+    | TacArg (_,arg) -> (ist, intern_tacarg true false ist arg)
+    | _ -> user_err (str "Tactic argument expected.") in
+  Genintern.register_intern0 wit_tactic_as_arg intern
+
 (** Substitution for notations containing tactic-in-terms *)
 
 let notation_subst bindings tac =

--- a/plugins/ltac/tacintern.ml
+++ b/plugins/ltac/tacintern.ml
@@ -804,6 +804,7 @@ let () =
   Genintern.register_intern0 wit_bindings (lift intern_bindings);
   Genintern.register_intern0 wit_constr_with_bindings (lift intern_constr_with_bindings);
   Genintern.register_intern0 wit_destruction_arg (lift intern_destruction_arg);
+  Genintern.register_intern0 wit_tactic_arg (lift (intern_tacarg true false));
   ()
 
 (** Substitution for notations containing tactic-in-terms *)

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -2030,6 +2030,7 @@ let () =
   register_interp0 wit_constr_with_bindings interp_constr_with_bindings';
   register_interp0 wit_open_constr_with_bindings interp_open_constr_with_bindings';
   register_interp0 wit_destruction_arg interp_destruction_arg';
+  register_interp0 wit_tactic_arg interp_tacarg;
   ()
 
 let () =

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -2031,6 +2031,7 @@ let () =
   register_interp0 wit_open_constr_with_bindings interp_open_constr_with_bindings';
   register_interp0 wit_destruction_arg interp_destruction_arg';
   register_interp0 wit_tactic_arg interp_tacarg;
+  register_interp0 wit_tactic_as_arg interp_tacarg;
   ()
 
 let () =

--- a/plugins/ltac/tacinterp.mli
+++ b/plugins/ltac/tacinterp.mli
@@ -118,6 +118,14 @@ val interp_tac_gen : value Id.Map.t -> Id.Set.t ->
 
 val interp : raw_tactic_expr -> unit Proofview.tactic
 
+(** Interpret an application *)
+
+val interp_app : Loc.t option -> interp_sign -> Value.t -> Value.t list -> Value.t Ftactic.t
+
+(** Interpret a tactic argument *)
+
+val interp_tacarg : interp_sign -> glob_tactic_arg -> Value.t Ftactic.t
+
 (** Hides interpretation for pretty-print *)
 
 val hide_interp : bool -> raw_tactic_expr -> unit Proofview.tactic option -> unit Proofview.tactic

--- a/plugins/ltac/tacsubst.ml
+++ b/plugins/ltac/tacsubst.ml
@@ -294,6 +294,7 @@ let () =
   Genintern.register_subst0 wit_intro_pattern (fun _ v -> v);
   Genintern.register_subst0 wit_tactic subst_tactic;
   Genintern.register_subst0 wit_ltac subst_tactic;
+  Genintern.register_subst0 wit_tactic_arg subst_tacarg;
   Genintern.register_subst0 wit_constr subst_glob_constr;
   Genintern.register_subst0 wit_clause_dft_concl (fun _ v -> v);
   Genintern.register_subst0 wit_uconstr (fun subst c -> subst_glob_constr subst c);

--- a/plugins/ltac/tacsubst.ml
+++ b/plugins/ltac/tacsubst.ml
@@ -295,6 +295,7 @@ let () =
   Genintern.register_subst0 wit_tactic subst_tactic;
   Genintern.register_subst0 wit_ltac subst_tactic;
   Genintern.register_subst0 wit_tactic_arg subst_tacarg;
+  Genintern.register_subst0 wit_tactic_as_arg subst_tacarg;
   Genintern.register_subst0 wit_constr subst_glob_constr;
   Genintern.register_subst0 wit_clause_dft_concl (fun _ v -> v);
   Genintern.register_subst0 wit_uconstr (fun subst c -> subst_glob_constr subst c);

--- a/test-suite/output/ltac.out
+++ b/test-suite/output/ltac.out
@@ -31,3 +31,7 @@ nat
 nat
 0
 0
+0
+1
+true
+False

--- a/test-suite/output/ltac.v
+++ b/test-suite/output/ltac.v
@@ -57,3 +57,10 @@ match goal with |- ?x*?y => idtac x end.
 match goal with H: context [?x*?y] |- _ => idtac x end.
 match goal with |- context [?x*?y] => idtac x end.
 Abort.
+
+(* Test iter tactical *)
+
+Tactic Notation "iter_message" constr_list(l) := iter (fun x => idtac x) l.
+Goal True.
+iter_message 0 1 true False.
+Abort.


### PR DESCRIPTION
This PR is an experiment in relation with @Armael question on [gitter](https://gitter.im/coq/coq?at=59faf8c52a69af844b3bacec).

It provides an `iter` tactical which works on arguments parsed using the `_list` or `_opt` suffixes, as in, e.g.:
```coq
Tactic Notation "iter_message" constr_list(l) := iter (fun x => idtac x) l.
Goal True.
iter_message 0 1 true False.
```
The behavior seems ok to me (in the ltac habits of ad hoc polymorphism, ad hoc syntax hiding subtleties of the semantics) but I don't know how much it could be promoted. 

Independently of the visible effect of the PR (i.e. of `iter`, which maybe should rather go in a plugin), the PR also exports a bit more of Ltac internals, namely the functions to interpret tactic arguments parsed with either the argument syntax (`constr:(c)` etc.) or the tactic syntax. Not fully clear how good it is to export this, though.