### PR TITLE
Update .mailmap with a jkloos alias

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -55,6 +55,7 @@ Tom Hutchinson <thutchin@gforge>                   thutchin <thutchin@85f007b7-5
 Cezary Kaliszyk <cek@gforge>                       cek <cek@85f007b7-540e-0410-9357-904b9bb8a0f7>
 Florent Kirchner <fkirchne@gforge>                 fkirchne <fkirchne@85f007b7-540e-0410-9357-904b9bb8a0f7>
 Florent Kirchner <fkirchne@gforge>                 kirchner <kirchner@85f007b7-540e-0410-9357-904b9bb8a0f7>
+Johannes Kloos <jkloos@mpi-sws.org>                jkloos <jkloos@mpi-sws.org>
 Matej Košík <matej.kosik@inria.fr>                 Matej Kosik <m4tej.kosik@gmail.com>
 Matej Košík <matej.kosik@inria.fr>                 Matej Kosik <matej.kosik@inria.fr>
 Marc Lasson <marc.lasson@gmail.com>                mlasson <marc.lasson@gmail.com>


### PR DESCRIPTION
`git shortlog -nse` listed both a `Johannes Kloos <jkloos@mpi-sws.org>` and a `jkloos <jkloos@mpi-sws.org>`, so I merged them.