### PR TITLE
[ci] Switch VST back to upstream.

### DIFF
--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -80,7 +80,7 @@
 # VST
 ########################################################################
 : ${VST_CI_BRANCH:=master}
-: ${VST_CI_GITURL:=https://github.com/Zimmi48/VST.git}
+: ${VST_CI_GITURL:=https://github.com/PrincetonUniversity/VST.git}
 
 ########################################################################
 # fiat_parsers


### PR DESCRIPTION
This follows the merge of PrincetonUniversity/VST#110 (thanks @ejgallego for preparing it) and finally closes #5994.