### PR TITLE
Implement open recursion in the pretyper

### DIFF
--- a/pretyping/pretyping.mli
+++ b/pretyping/pretyping.mli
@@ -147,6 +147,7 @@ type pretyper = {
   pretype_cast : pretyper -> glob_constr * glob_constr cast_type -> unsafe_judgment pretype_fun;
   pretype_int : pretyper -> Uint63.t -> unsafe_judgment pretype_fun;
   pretype_float : pretyper -> Float64.t -> unsafe_judgment pretype_fun;
+  pretype_type : pretyper -> glob_constr -> unsafe_type_judgment pretype_fun;
 }
 (** Type of pretyping algorithms in open-recursion style. A typical way to
     implement a pretyping variant is to inherit from some pretyper using


### PR DESCRIPTION
This PR is a proof-of-concept of an open-ended implementation of the pretyper. It doesn't do much apart from moving code around and exporting the behaviour of the pretyper node-wise. Yet, this allows to provide a good example of the usefulness of such a presentation, as the horrendous code used for Ltac variable handling in pretyping is now moved back to the Ltac plugin (and is thus Ltac specific).

It is mainly for discussion purposes, I don't think it is mergeable as-is (is it?). Also, the type of open-ended pretypers is not the most generic one. Ideally, one should be parametric over the type of environments, requiring a well-delimited API like e.g. `push_rel` and `to_env`. In particular, this would allow to push back the `ltac_var_map` type to Ltac as well, although this type has currently complex interactions with the binder-capture feature of Ltac.

While we're at it, at some point the pretyper should also be put in the monad. Even though this is fairly orthogonal to this PR, it will change the API quite a lot, so it may be a good idea to conflate both processes nonetheless.
