### PR TITLE
Allow using cumulativity without forcing strict constraints.

### DIFF
--- a/dev/top_printers.mli
+++ b/dev/top_printers.mli
@@ -85,7 +85,7 @@ val ppclosedglobconstr : Ltac_pretype.closed_glob_constr -> unit
 val ppclosedglobconstridmap :
   Ltac_pretype.closed_glob_constr Names.Id.Map.t -> unit
 
-val ppglobal : Globnames.global_reference -> unit
+val ppglobal : Names.global_reference -> unit
 
 val ppconst :
   Names.KerName.t * (Constr.constr, 'a) Environ.punsafe_judgment -> unit

--- a/engine/eConstr.mli
+++ b/engine/eConstr.mli
@@ -284,9 +284,9 @@ val map_rel_context_in_env :
 (* XXX Missing Sigma proxy *)
 val fresh_global :
   ?loc:Loc.t -> ?rigid:Evd.rigid -> ?names:Univ.Instance.t -> Environ.env ->
-  Evd.evar_map -> Globnames.global_reference -> Evd.evar_map * t
+  Evd.evar_map -> global_reference -> Evd.evar_map * t
 
-val is_global : Evd.evar_map -> Globnames.global_reference -> t -> bool
+val is_global : Evd.evar_map -> global_reference -> t -> bool
 
 (** {5 Extra} *)
 

--- a/engine/eConstr.mli
+++ b/engine/eConstr.mli
@@ -191,11 +191,22 @@ val whd_evar : Evd.evar_map -> constr -> constr
 
 (** {6 Equality} *)
 
+val cmp_inductives : Reduction.conv_pb -> Declarations.mutual_inductive_body * int ->
+  Int.t -> Univ.Instance.t -> Univ.Instance.t ->
+  Universes.Constraints.t -> Universes.Constraints.t
+
+val cmp_constructors : Declarations.mutual_inductive_body * int * int ->
+  Int.t -> Univ.Instance.t -> Univ.Instance.t ->
+  Universes.Constraints.t -> Universes.Constraints.t
+
 val eq_constr : Evd.evar_map -> t -> t -> bool
 val eq_constr_nounivs : Evd.evar_map -> t -> t -> bool
-val eq_constr_universes : Evd.evar_map -> t -> t -> Universes.Constraints.t option
-val leq_constr_universes : Evd.evar_map -> t -> t -> Universes.Constraints.t option
+val eq_constr_universes : Environ.env -> Evd.evar_map -> t -> t -> Universes.Constraints.t option
+val leq_constr_universes : Environ.env -> Evd.evar_map -> t -> t -> Universes.Constraints.t option
+
+(** [eq_constr_universes_proj] can equate projections and their eta-expanded constant form. *)
 val eq_constr_universes_proj : Environ.env -> Evd.evar_map -> t -> t -> Universes.Constraints.t option
+
 val compare_constr : Evd.evar_map -> (t -> t -> bool) -> t -> t -> bool
 
 (** {6 Iterators} *)

--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -68,8 +68,8 @@ val restrict_evar : evar_map -> Evar.t -> Filter.t ->
 
 (** Polymorphic constants *)
 
-val new_global : evar_map -> Globnames.global_reference -> evar_map * constr
-val e_new_global : evar_map ref -> Globnames.global_reference -> constr
+val new_global : evar_map -> global_reference -> evar_map * constr
+val e_new_global : evar_map ref -> global_reference -> constr
 
 (** Create a fresh evar in a context different from its definition context:
    [new_evar_instance sign evd ty inst] creates a new evar of context

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -596,7 +596,7 @@ val fresh_inductive_instance : ?loc:Loc.t -> env -> evar_map -> inductive -> eva
 val fresh_constructor_instance : ?loc:Loc.t -> env -> evar_map -> constructor -> evar_map * pconstructor
 
 val fresh_global : ?loc:Loc.t -> ?rigid:rigid -> ?names:Univ.Instance.t -> env ->
-  evar_map -> Globnames.global_reference -> evar_map * constr
+  evar_map -> global_reference -> evar_map * constr
 
 (********************************************************************)
 (* constr with holes and pending resolution of classes, conversion  *)

--- a/engine/termops.ml
+++ b/engine/termops.ml
@@ -913,12 +913,9 @@ let vars_of_global_reference env gr =
 (* Tests whether [m] is a subterm of [t]:
    [m] is appropriately lifted through abstractions of [t] *)
 
-let dependent_main noevar univs sigma m t =
+let dependent_main noevar sigma m t =
   let open EConstr in
-  let eqc x y =
-    if univs then not (Option.is_empty (eq_constr_universes sigma x y))
-    else eq_constr_nounivs sigma x y
-  in
+  let eqc x y = eq_constr_nounivs sigma x y in
   let rec deprec m t =
     if eqc m t then
       raise Occur
@@ -935,11 +932,8 @@ let dependent_main noevar univs sigma m t =
   in
   try deprec m t; false with Occur -> true
 
-let dependent sigma c t = dependent_main false false sigma c t
-let dependent_no_evar sigma c t = dependent_main true false sigma c t
-
-let dependent_univs sigma c t = dependent_main false true sigma c t
-let dependent_univs_no_evar sigma c t = dependent_main true true sigma c t
+let dependent sigma c t = dependent_main false sigma c t
+let dependent_no_evar sigma c t = dependent_main true sigma c t
 
 let dependent_in_decl sigma a decl =
   let open NamedDecl in

--- a/engine/termops.mli
+++ b/engine/termops.mli
@@ -105,8 +105,6 @@ val free_rels : Evd.evar_map -> constr -> Int.Set.t
 (** [dependent m t] tests whether [m] is a subterm of [t] *)
 val dependent : Evd.evar_map -> constr -> constr -> bool
 val dependent_no_evar : Evd.evar_map -> constr -> constr -> bool
-val dependent_univs : Evd.evar_map -> constr -> constr -> bool
-val dependent_univs_no_evar : Evd.evar_map -> constr -> constr -> bool
 val dependent_in_decl : Evd.evar_map -> constr -> named_declaration -> bool
 val count_occurrences : Evd.evar_map -> constr -> constr -> int
 val collect_metas : Evd.evar_map -> constr -> int list

--- a/engine/termops.mli
+++ b/engine/termops.mli
@@ -109,7 +109,7 @@ val dependent_in_decl : Evd.evar_map -> constr -> named_declaration -> bool
 val count_occurrences : Evd.evar_map -> constr -> constr -> int
 val collect_metas : Evd.evar_map -> constr -> int list
 val collect_vars : Evd.evar_map -> constr -> Id.Set.t (** for visible vars only *)
-val vars_of_global_reference : env -> Globnames.global_reference -> Id.Set.t
+val vars_of_global_reference : env -> global_reference -> Id.Set.t
 val occur_term : Evd.evar_map -> constr -> constr -> bool (** Synonymous of dependent *)
 [@@ocaml.deprecated "alias of Termops.dependent"]
 
@@ -258,7 +258,7 @@ val clear_named_body : Id.t -> env -> env
 val global_vars : env -> Evd.evar_map -> constr -> Id.t list
 val global_vars_set : env -> Evd.evar_map -> constr -> Id.Set.t
 val global_vars_set_of_decl : env -> Evd.evar_map -> named_declaration -> Id.Set.t
-val global_app_of_constr : Evd.evar_map -> constr -> (Globnames.global_reference * EInstance.t) * constr option
+val global_app_of_constr : Evd.evar_map -> constr -> (global_reference * EInstance.t) * constr option
 
 (** Gives an ordered list of hypotheses, closed by dependencies,
    containing a given set *)
@@ -267,9 +267,9 @@ val dependency_closure : env -> Evd.evar_map -> named_context -> Id.Set.t -> Id.
 (** Test if an identifier is the basename of a global reference *)
 val is_section_variable : Id.t -> bool
 
-val global_of_constr : Evd.evar_map -> constr -> Globnames.global_reference * EInstance.t
+val global_of_constr : Evd.evar_map -> constr -> global_reference * EInstance.t
 
-val is_global : Evd.evar_map -> Globnames.global_reference -> constr -> bool
+val is_global : Evd.evar_map -> global_reference -> constr -> bool
 
 val isGlobalRef : Evd.evar_map -> constr -> bool
 

--- a/engine/universes.ml
+++ b/engine/universes.ml
@@ -69,7 +69,7 @@ let subst_ubinder (subst,(ref,l as orig)) =
 let discharge_ubinder (_,(ref,l)) =
   Some (Lib.discharge_global ref, l)
 
-let ubinder_obj : Globnames.global_reference * universe_binders -> Libobject.obj =
+let ubinder_obj : Names.global_reference * universe_binders -> Libobject.obj =
   let open Libobject in
   declare_object { (default_object "universe binder") with
     cache_function = cache_ubinder;

--- a/engine/universes.mli
+++ b/engine/universes.mli
@@ -92,6 +92,8 @@ val enforce_eq_instances_univs : bool -> Instance.t universe_constraint_function
 
 val to_constraints : UGraph.t -> Constraints.t -> Constraint.t
 
+val of_constraints : bool -> Constraint.t -> Constraints.t
+
 (** [eq_constr_univs_infer_With kind1 kind2 univs m n] is a variant of
     {!eq_constr_univs_infer} taking kind-of-term functions, to expose
     subterms of [m] and [n], arguments. *)
@@ -99,10 +101,6 @@ val eq_constr_univs_infer_with :
   (constr -> (constr, types, Sorts.t, Univ.Instance.t) kind_of_term) ->
   (constr -> (constr, types, Sorts.t, Univ.Instance.t) kind_of_term) ->
   UGraph.t -> 'a constraint_accumulator -> constr -> constr -> 'a -> 'a option
-
-(** [eq_constr_universes a b] [true, c] if [a] equals [b] modulo alpha, casts,
-    application grouping and the universe constraints in [c]. *)
-val eq_constr_universes_proj : env -> constr -> constr -> bool universe_constrained
 
 (** Build a fresh instance for a given context, its associated substitution and 
     the instantiated constraints. *)

--- a/engine/universes.mli
+++ b/engine/universes.mli
@@ -32,8 +32,8 @@ type universe_binders = Univ.Level.t Names.Id.Map.t
 
 val empty_binders : universe_binders
 
-val register_universe_binders : Globnames.global_reference -> universe_binders -> unit
-val universe_binders_of_global : Globnames.global_reference -> universe_binders
+val register_universe_binders : global_reference -> universe_binders -> unit
+val universe_binders_of_global : global_reference -> universe_binders
 
 type univ_name_list = Name.t Loc.located list
 
@@ -43,7 +43,7 @@ type univ_name_list = Name.t Loc.located list
     May error if the lengths mismatch.
 
     Otherwise return [universe_binders_of_global ref]. *)
-val universe_binders_with_opt_names : Globnames.global_reference ->
+val universe_binders_with_opt_names : global_reference ->
   Univ.Level.t list -> univ_name_list option -> universe_binders
 
 (** The global universe counter *)
@@ -120,7 +120,7 @@ val fresh_inductive_instance : env -> inductive ->
 val fresh_constructor_instance : env -> constructor ->
   pconstructor in_universe_context_set
 
-val fresh_global_instance : ?names:Univ.Instance.t -> env -> Globnames.global_reference -> 
+val fresh_global_instance : ?names:Univ.Instance.t -> env -> global_reference ->
   constr in_universe_context_set
 
 val fresh_global_or_constr_instance : env -> Globnames.global_reference_or_constr -> 
@@ -132,9 +132,9 @@ val fresh_universe_context_set_instance : ContextSet.t ->
   universe_level_subst * ContextSet.t
 
 (** Raises [Not_found] if not a global reference. *)
-val global_of_constr : constr -> Globnames.global_reference puniverses
+val global_of_constr : constr -> global_reference puniverses
 
-val constr_of_global_univ : Globnames.global_reference puniverses -> constr
+val constr_of_global_univ : global_reference puniverses -> constr
 
 val extend_context : 'a in_universe_context_set -> ContextSet.t -> 
   'a in_universe_context_set
@@ -193,16 +193,15 @@ val normalize_universe_subst : universe_subst ref ->
     the constraints should be properly added to an evd. 
     See Evd.fresh_global, Evarutil.new_global, and pf_constr_of_global for
     the proper way to get a fresh copy of a global reference. *)
-val constr_of_global : Globnames.global_reference -> constr
+val constr_of_global : global_reference -> constr
 
-(** ** DEPRECATED ** synonym of [constr_of_global] *)
-val constr_of_reference : Globnames.global_reference -> constr
+val constr_of_reference : global_reference -> constr
 [@@ocaml.deprecated "synonym of [constr_of_global]"]
 
 (** Returns the type of the global reference, by creating a fresh instance of polymorphic 
     references and computing their instantiated universe context. (side-effect on the
     universe counter, use with care). *)
-val type_of_global : Globnames.global_reference -> types in_universe_context_set
+val type_of_global : global_reference -> types in_universe_context_set
 
 (** Full universes substitutions into terms *)
 

--- a/interp/constrextern.mli
+++ b/interp/constrextern.mli
@@ -11,7 +11,6 @@ open Termops
 open EConstr
 open Environ
 open Libnames
-open Globnames
 open Glob_term
 open Pattern
 open Constrexpr

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -930,7 +930,7 @@ let interp_reference vars r =
 (** Private internalization patterns *)
 type 'a raw_cases_pattern_expr_r =
   | RCPatAlias of 'a raw_cases_pattern_expr * Id.t
-  | RCPatCstr  of Globnames.global_reference
+  | RCPatCstr  of Names.global_reference
     * 'a raw_cases_pattern_expr list * 'a raw_cases_pattern_expr list
   (** [RCPatCstr (loc, c, l1, l2)] represents ((@c l1) l2) *)
   | RCPatAtom  of Id.t option

--- a/interp/constrintern.mli
+++ b/interp/constrintern.mli
@@ -11,7 +11,6 @@ open Constr
 open Evd
 open Environ
 open Libnames
-open Globnames
 open Glob_term
 open Pattern
 open Constrexpr
@@ -174,11 +173,11 @@ val interp_context_evars :
 (** Locating references of constructions, possibly via a syntactic definition 
    (these functions do not modify the glob file) *)
 
-val locate_reference :  Libnames.qualid -> Globnames.global_reference
+val locate_reference :  Libnames.qualid -> global_reference
 val is_global : Id.t -> bool
-val construct_reference : ('c, 't) Context.Named.pt -> Id.t -> Globnames.global_reference
-val global_reference : Id.t -> Globnames.global_reference
-val global_reference_in_absolute_module : DirPath.t -> Id.t -> Globnames.global_reference
+val construct_reference : ('c, 't) Context.Named.pt -> Id.t -> global_reference
+val global_reference : Id.t -> global_reference
+val global_reference_in_absolute_module : DirPath.t -> Id.t -> global_reference
 
 (** Interprets a term as the left-hand side of a notation. The returned map is
     guaranteed to have the same domain as the input one. *)

--- a/interp/declare.mli
+++ b/interp/declare.mli
@@ -81,7 +81,7 @@ val recursive_message : bool (** true = fixpoint *) ->
 val exists_name : Id.t -> bool
 
 (** Global universe contexts, names and constraints *)
-val declare_univ_binders : Globnames.global_reference -> Universes.universe_binders -> unit
+val declare_univ_binders : Names.global_reference -> Universes.universe_binders -> unit
 
 val declare_universe_context : polymorphic -> Univ.ContextSet.t -> unit
 

--- a/interp/dumpglob.mli
+++ b/interp/dumpglob.mli
@@ -22,7 +22,7 @@ val feedback_glob : unit -> unit
 val pause : unit -> unit
 val continue : unit -> unit
 
-val add_glob : ?loc:Loc.t -> Globnames.global_reference -> unit
+val add_glob : ?loc:Loc.t -> Names.global_reference -> unit
 val add_glob_kn : ?loc:Loc.t -> Names.KerName.t -> unit
 
 val dump_definition : Names.Id.t Loc.located -> bool -> string -> unit
@@ -41,4 +41,4 @@ val dump_constraint :
 
 val dump_string : string -> unit
 
-val type_of_global_ref : Globnames.global_reference -> string 
+val type_of_global_ref : Names.global_reference -> string

--- a/interp/impargs.ml
+++ b/interp/impargs.ml
@@ -484,7 +484,7 @@ type implicit_discharge_request =
   | ImplLocal
   | ImplConstant of Constant.t * implicits_flags
   | ImplMutualInductive of MutInd.t * implicits_flags
-  | ImplInteractive of global_reference * implicits_flags *
+  | ImplInteractive of Names.global_reference * implicits_flags *
       implicit_interactive_request
 
 let implicits_table = Summary.ref Refmap.empty ~name:"implicits"
@@ -605,7 +605,7 @@ let classify_implicits (req,_ as obj) = match req with
 
 type implicits_obj =
     implicit_discharge_request *
-      (global_reference * implicits_list list) list
+      (Names.global_reference * implicits_list list) list
 
 let inImplicits : implicits_obj -> obj =
   declare_object {(default_object "IMPLICITS") with

--- a/interp/impargs.mli
+++ b/interp/impargs.mli
@@ -8,7 +8,6 @@
 
 open Names
 open Constr
-open Globnames
 open Environ
 
 (** {6 Implicit Arguments } *)

--- a/interp/implicit_quantifiers.mli
+++ b/interp/implicit_quantifiers.mli
@@ -11,7 +11,6 @@ open Names
 open Glob_term
 open Constrexpr
 open Libnames
-open Globnames
 
 val declare_generalizable : Vernacexpr.locality_flag -> (Id.t located) list option -> unit
 

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -240,7 +240,7 @@ type interp_rule =
    according to the key of the pattern (adapted from Chet Murthy by HH) *)
 
 type key =
-  | RefKey of global_reference
+  | RefKey of Names.global_reference
   | Oth
 
 let key_compare k1 k2 = match k1, k2 with
@@ -772,7 +772,7 @@ let rebuild_arguments_scope (req,r,n,l,_) =
 	(req,r,0,l1@l,cls1)
 
 type arguments_scope_obj =
-    arguments_scope_discharge_request * global_reference *
+    arguments_scope_discharge_request * Names.global_reference *
     (* Used to communicate information from discharge to rebuild *)
     (* set to 0 otherwise *) int *
     scope_name option list * scope_class option list

--- a/interp/notation.mli
+++ b/interp/notation.mli
@@ -9,7 +9,6 @@
 open Bigint
 open Names
 open Libnames
-open Globnames
 open Constrexpr
 open Glob_term
 open Notation_term
@@ -89,7 +88,7 @@ val declare_string_interpreter : scope_name -> required_module ->
 val interp_prim_token : ?loc:Loc.t -> prim_token -> local_scopes ->
   glob_constr * (notation_location * scope_name option)
 (* This function returns a glob_const representing a pattern *)
-val interp_prim_token_cases_pattern_expr : ?loc:Loc.t -> (global_reference -> unit) -> prim_token ->
+val interp_prim_token_cases_pattern_expr : ?loc:Loc.t -> (Names.global_reference -> unit) -> prim_token ->
   local_scopes -> glob_constr * (notation_location * scope_name option)
 
 (** Return the primitive token associated to a [term]/[cases_pattern];
@@ -141,8 +140,8 @@ val level_of_notation : notation -> level (** raise [Not_found] if no level *)
 
 (** {6 Miscellaneous} *)
 
-val interp_notation_as_global_reference : ?loc:Loc.t -> (global_reference -> bool) ->
-      notation -> delimiters option -> global_reference
+val interp_notation_as_global_reference : ?loc:Loc.t -> (Names.global_reference -> bool) ->
+      notation -> delimiters option -> Names.global_reference
 
 (** Checks for already existing notations *)
 val exists_notation_in_scope : scope_name option -> notation ->
@@ -150,9 +149,9 @@ val exists_notation_in_scope : scope_name option -> notation ->
 
 (** Declares and looks for scopes associated to arguments of a global ref *)
 val declare_arguments_scope :
-  bool (** true=local *) -> global_reference -> scope_name option list -> unit
+  bool (** true=local *) -> Names.global_reference -> scope_name option list -> unit
 
-val find_arguments_scope : global_reference -> scope_name option list
+val find_arguments_scope : Names.global_reference -> scope_name option list
 
 type scope_class
 
@@ -163,7 +162,7 @@ val subst_scope_class :
   Mod_subst.substitution -> scope_class -> scope_class option
 
 val declare_scope_class : scope_name -> scope_class -> unit
-val declare_ref_arguments_scope : global_reference -> unit
+val declare_ref_arguments_scope : Names.global_reference -> unit
 
 val compute_arguments_scope : Constr.types -> scope_name option list
 val compute_type_scope : Constr.types -> scope_name option

--- a/interp/reserve.ml
+++ b/interp/reserve.ml
@@ -20,7 +20,7 @@ open Notation_ops
 open Globnames
 
 type key =
-  | RefKey of global_reference
+  | RefKey of Names.global_reference
   | Oth
 
 (** TODO: share code from Notation *)

--- a/interp/smartlocate.mli
+++ b/interp/smartlocate.mli
@@ -7,9 +7,9 @@
 (************************************************************************)
 
 open Loc
-open Names
 open Libnames
 open Globnames
+open Names
 open Misctypes
 
 (** [locate_global_with_alias] locates global reference possibly following

--- a/interp/stdarg.mli
+++ b/interp/stdarg.mli
@@ -12,7 +12,6 @@ open Loc
 open Names
 open EConstr
 open Libnames
-open Globnames
 open Genredexpr
 open Pattern
 open Constrexpr

--- a/intf/evar_kinds.ml
+++ b/intf/evar_kinds.ml
@@ -7,7 +7,6 @@
 (************************************************************************)
 
 open Names
-open Globnames
 open Misctypes
 
 (** The kinds of existential variable *)

--- a/intf/glob_term.ml
+++ b/intf/glob_term.ml
@@ -15,7 +15,6 @@
    arguments and pattern-matching compilation are not. *)
 
 open Names
-open Globnames
 open Decl_kinds
 open Misctypes
 

--- a/intf/notation_term.ml
+++ b/intf/notation_term.ml
@@ -7,7 +7,6 @@
 (************************************************************************)
 
 open Names
-open Globnames
 open Misctypes
 open Glob_term
 

--- a/intf/pattern.ml
+++ b/intf/pattern.ml
@@ -7,7 +7,6 @@
 (************************************************************************)
 
 open Names
-open Globnames
 open Constr
 open Misctypes
 

--- a/kernel/constr.mli
+++ b/kernel/constr.mli
@@ -406,13 +406,18 @@ val iter_with_binders :
 
 val compare_head : (constr -> constr -> bool) -> constr -> constr -> bool
 
-(** [compare_head_gen u s f c1 c2] compare [c1] and [c2] using [f] to compare
-   the immediate subterms of [c1] of [c2] if needed, [u] to compare universe
-   instances (the first boolean tells if they belong to a Constant.t), [s] to 
-   compare sorts; Cast's, binders name and Cases annotations are not taken 
-    into account *)
+(** Convert a global reference applied to 2 instances. The int says
+   how many arguments are given (as we can only use cumulativity for
+   fully applied inductives/constructors) .*)
+type instance_compare_fn = global_reference -> int ->
+  Univ.Instance.t -> Univ.Instance.t -> bool
 
-val compare_head_gen : (bool -> Univ.Instance.t -> Univ.Instance.t -> bool) ->
+(** [compare_head_gen u s f c1 c2] compare [c1] and [c2] using [f] to
+   compare the immediate subterms of [c1] of [c2] if needed, [u] to
+   compare universe instances, [s] to compare sorts; Cast's, binders
+   name and Cases annotations are not taken into account *)
+
+val compare_head_gen : instance_compare_fn ->
   (Sorts.t -> Sorts.t -> bool) ->
   (constr -> constr -> bool) ->
   constr -> constr -> bool
@@ -420,7 +425,7 @@ val compare_head_gen : (bool -> Univ.Instance.t -> Univ.Instance.t -> bool) ->
 val compare_head_gen_leq_with :
   (constr -> (constr, types, Sorts.t, Univ.Instance.t) kind_of_term) ->
   (constr -> (constr, types, Sorts.t, Univ.Instance.t) kind_of_term) ->
-  (bool -> Univ.Instance.t -> Univ.Instance.t -> bool) ->
+  instance_compare_fn ->
   (Sorts.t -> Sorts.t -> bool) ->
   (constr -> constr -> bool) ->
   (constr -> constr -> bool) ->
@@ -433,7 +438,7 @@ val compare_head_gen_leq_with :
 val compare_head_gen_with :
   (constr -> (constr, types, Sorts.t, Univ.Instance.t) kind_of_term) ->
   (constr -> (constr, types, Sorts.t, Univ.Instance.t) kind_of_term) ->
-  (bool -> Univ.Instance.t -> Univ.Instance.t -> bool) ->
+  instance_compare_fn ->
   (Sorts.t -> Sorts.t -> bool) ->
   (constr -> constr -> bool) ->
   constr -> constr -> bool
@@ -445,7 +450,7 @@ val compare_head_gen_with :
     [s] to compare sorts for for subtyping; Cast's, binders name and
     Cases annotations are not taken into account *)
 
-val compare_head_gen_leq : (bool -> Univ.Instance.t -> Univ.Instance.t -> bool) ->
+val compare_head_gen_leq : instance_compare_fn ->
   (Sorts.t -> Sorts.t -> bool) ->
   (constr -> constr -> bool) ->
   (constr -> constr -> bool) ->

--- a/kernel/names.ml
+++ b/kernel/names.ml
@@ -699,6 +699,12 @@ end
 module Constrmap = Map.Make(ConstructorOrdered)
 module Constrmap_env = Map.Make(ConstructorOrdered_env)
 
+type global_reference =
+  | VarRef of variable           (** A reference to the section-context. *)
+  | ConstRef of Constant.t       (** A reference to the environment. *)
+  | IndRef of inductive          (** A reference to an inductive type. *)
+  | ConstructRef of constructor  (** A reference to a constructor of an inductive type. *)
+
 (* Better to have it here that in closure, since used in grammar.cma *)
 type evaluable_global_reference =
   | EvalVarRef of Id.t

--- a/kernel/names.mli
+++ b/kernel/names.mli
@@ -498,6 +498,13 @@ val constructor_user_hash : constructor -> int
 val constructor_syntactic_ord : constructor -> constructor -> int
 val constructor_syntactic_hash : constructor -> int
 
+(** {6 Global reference is a kernel side type for all references together } *)
+type global_reference =
+  | VarRef of variable           (** A reference to the section-context. *)
+  | ConstRef of Constant.t       (** A reference to the environment. *)
+  | IndRef of inductive          (** A reference to an inductive type. *)
+  | ConstructRef of constructor  (** A reference to a constructor of an inductive type. *)
+
 (** Better to have it here that in Closure, since required in grammar.cma *)
 type evaluable_global_reference =
   | EvalVarRef of Id.t

--- a/library/coqlib.ml
+++ b/library/coqlib.ml
@@ -9,9 +9,9 @@
 open CErrors
 open Util
 open Pp
-open Names
 open Libnames
 open Globnames
+open Names
 open Nametab
 
 let coq = Libnames.coq_string (* "Coq" *)

--- a/library/coqlib.mli
+++ b/library/coqlib.mli
@@ -8,7 +8,6 @@
 
 open Names
 open Libnames
-open Globnames
 open Util
 
 (** This module collects the global references, constructions and

--- a/library/global.mli
+++ b/library/global.mli
@@ -121,26 +121,26 @@ val env_of_context : Environ.named_context_val -> Environ.env
 val join_safe_environment : ?except:Future.UUIDSet.t -> unit -> unit
 val is_joined_environment : unit -> bool
 
-val is_polymorphic : Globnames.global_reference -> bool
-val is_template_polymorphic : Globnames.global_reference -> bool
-val is_type_in_type : Globnames.global_reference -> bool
+val is_polymorphic : global_reference -> bool
+val is_template_polymorphic : global_reference -> bool
+val is_type_in_type : global_reference -> bool
 
 val constr_of_global_in_context : Environ.env ->
-  Globnames.global_reference -> Constr.types * Univ.AUContext.t
+  global_reference -> Constr.types * Univ.AUContext.t
 (** Returns the type of the constant in its local universe
     context. The type should not be used without pushing it's universe
     context in the environmnent of usage. For non-universe-polymorphic
     constants, it does not matter. *)
 
 val type_of_global_in_context : Environ.env -> 
-  Globnames.global_reference -> Constr.types * Univ.AUContext.t
+  global_reference -> Constr.types * Univ.AUContext.t
 (** Returns the type of the constant in its local universe
     context. The type should not be used without pushing it's universe
     context in the environmnent of usage. For non-universe-polymorphic
     constants, it does not matter. *)
 
 (** Returns the universe context of the global reference (whatever its polymorphic status is). *)
-val universes_of_global : Globnames.global_reference -> Univ.AUContext.t
+val universes_of_global : global_reference -> Univ.AUContext.t
 
 (** {6 Retroknowledge } *)
 

--- a/library/globnames.ml
+++ b/library/globnames.ml
@@ -13,7 +13,7 @@ open Mod_subst
 open Libnames
 
 (*s Global reference is a kernel side type for all references together *)
-type global_reference =
+type global_reference = Names.global_reference =
   | VarRef of variable           (** A reference to the section-context. *)
   | ConstRef of Constant.t       (** A reference to the environment. *)
   | IndRef of inductive          (** A reference to an inductive type. *)

--- a/library/globnames.mli
+++ b/library/globnames.mli
@@ -11,13 +11,6 @@ open Names
 open Constr
 open Mod_subst
 
-(** {6 Global reference is a kernel side type for all references together } *)
-type global_reference = Names.global_reference =
-  | VarRef of variable           (** A reference to the section-context. *)
-  | ConstRef of Constant.t       (** A reference to the environment. *)
-  | IndRef of inductive          (** A reference to an inductive type. *)
-  | ConstructRef of constructor  (** A reference to a constructor of an inductive type. *)
-
 val isVarRef : global_reference -> bool
 val isConstRef : global_reference -> bool
 val isIndRef : global_reference -> bool
@@ -102,3 +95,11 @@ val decode_con : Constant.t -> DirPath.t * Id.t
 val pop_con : Constant.t -> Constant.t
 val pop_kn : MutInd.t-> MutInd.t
 val pop_global_reference : global_reference -> global_reference
+
+(** {6 Global reference is a kernel side type for all references together } *)
+type global_reference = Names.global_reference =
+  | VarRef of variable           (** A reference to the section-context. *)
+  | ConstRef of Constant.t       (** A reference to the environment. *)
+  | IndRef of inductive          (** A reference to an inductive type. *)
+  | ConstructRef of constructor  (** A reference to a constructor of an inductive type. *)
+[@@ocaml.deprecated "Alias of Names.global_reference"]

--- a/library/globnames.mli
+++ b/library/globnames.mli
@@ -12,7 +12,7 @@ open Constr
 open Mod_subst
 
 (** {6 Global reference is a kernel side type for all references together } *)
-type global_reference =
+type global_reference = Names.global_reference =
   | VarRef of variable           (** A reference to the section-context. *)
   | ConstRef of Constant.t       (** A reference to the environment. *)
   | IndRef of inductive          (** A reference to an inductive type. *)

--- a/library/keys.ml
+++ b/library/keys.ml
@@ -13,7 +13,7 @@ open Term
 open Libobject
 
 type key =
-  | KGlob of global_reference
+  | KGlob of Names.global_reference
   | KLam
   | KLet
   | KProd

--- a/library/keys.mli
+++ b/library/keys.mli
@@ -6,8 +6,6 @@
 (*         *       GNU Lesser General Public License Version 2.1        *)
 (************************************************************************)
 
-open Globnames
-
 type key
 
 val declare_equiv_keys : key -> key -> unit
@@ -19,5 +17,5 @@ val equiv_keys : key -> key -> bool
 val constr_key : ('a -> ('a, 't, 'u, 'i) Constr.kind_of_term) -> 'a -> key option
 (** Compute the head key of a term. *)
 
-val pr_keys : (global_reference -> Pp.t) -> Pp.t
+val pr_keys : (Names.global_reference -> Pp.t) -> Pp.t
 (** Pretty-print the mapping *)

--- a/library/lib.mli
+++ b/library/lib.mli
@@ -134,7 +134,7 @@ val library_dp : unit -> Names.DirPath.t
 (** Extract the library part of a name even if in a section *)
 val dp_of_mp : Names.ModPath.t -> Names.DirPath.t
 val split_modpath : Names.ModPath.t -> Names.DirPath.t * Names.Id.t list
-val library_part :  Globnames.global_reference -> Names.DirPath.t
+val library_part :  Names.global_reference -> Names.DirPath.t
 
 (** {6 Sections } *)
 
@@ -167,12 +167,12 @@ val named_of_variable_context : variable_context -> Context.Named.t
 
 val section_segment_of_constant : Names.Constant.t -> abstr_info
 val section_segment_of_mutual_inductive: Names.MutInd.t -> abstr_info
-val section_segment_of_reference : Globnames.global_reference -> abstr_info
+val section_segment_of_reference : Names.global_reference -> abstr_info
 
-val variable_section_segment_of_reference : Globnames.global_reference -> variable_context
+val variable_section_segment_of_reference : Names.global_reference -> variable_context
 
-val section_instance : Globnames.global_reference -> Univ.Instance.t * Names.Id.t array
-val is_in_section : Globnames.global_reference -> bool
+val section_instance : Names.global_reference -> Univ.Instance.t * Names.Id.t array
+val is_in_section : Names.global_reference -> bool
 
 val add_section_variable : Names.Id.t -> Decl_kinds.binding_kind -> Decl_kinds.polymorphic -> Univ.ContextSet.t -> unit
 val add_section_context : Univ.ContextSet.t -> unit
@@ -186,7 +186,7 @@ val replacement_context : unit -> Opaqueproof.work_list
 
 val discharge_kn :  Names.MutInd.t -> Names.MutInd.t
 val discharge_con : Names.Constant.t -> Names.Constant.t
-val discharge_global : Globnames.global_reference -> Globnames.global_reference
+val discharge_global : Names.global_reference -> Names.global_reference
 val discharge_inductive : Names.inductive -> Names.inductive
 val discharge_abstract_universe_context :
   abstr_info -> Univ.AUContext.t -> Univ.universe_level_subst * Univ.AUContext.t

--- a/library/nametab.mli
+++ b/library/nametab.mli
@@ -6,9 +6,9 @@
 (*         *       GNU Lesser General Public License Version 2.1        *)
 (************************************************************************)
 
+open Globnames
 open Names
 open Libnames
-open Globnames
 
 (** This module contains the tables for globalization. *)
 

--- a/plugins/extraction/common.mli
+++ b/plugins/extraction/common.mli
@@ -7,7 +7,6 @@
 (************************************************************************)
 
 open Names
-open Globnames
 open Miniml
 
 (** By default, in module Format, you can do horizontal placing of blocks

--- a/plugins/extraction/extract_env.ml
+++ b/plugins/extraction/extract_env.ml
@@ -77,7 +77,7 @@ module type VISIT = sig
 
   (* Add reference / ... in the visit lists.
      These functions silently add the mp of their arg in the mp list *)
-  val add_ref : global_reference -> unit
+  val add_ref : Names.global_reference -> unit
   val add_kn : KerName.t -> unit
   val add_decl_deps : ml_decl -> unit
   val add_spec_deps : ml_spec -> unit

--- a/plugins/extraction/extract_env.mli
+++ b/plugins/extraction/extract_env.mli
@@ -10,7 +10,6 @@
 
 open Names
 open Libnames
-open Globnames
 
 val simple_extraction : reference -> unit
 val full_extraction : string option -> reference list -> unit

--- a/plugins/extraction/miniml.mli
+++ b/plugins/extraction/miniml.mli
@@ -9,7 +9,6 @@
 (*s Target language for extraction: a core ML called MiniML. *)
 
 open Names
-open Globnames
 
 (* The [signature] type is used to know how many arguments a CIC
    object expects, and what these arguments will become in the ML

--- a/plugins/extraction/mlutil.ml
+++ b/plugins/extraction/mlutil.ml
@@ -268,7 +268,7 @@ let rec var2var' = function
   | Tglob (r,l) -> Tglob (r, List.map var2var' l)
   | a -> a
 
-type abbrev_map = global_reference -> ml_type option
+type abbrev_map = Names.global_reference -> ml_type option
 
 (*s Delta-reduction of type constants everywhere in a ML type [t].
    [env] is a function of type [ml_type_env]. *)

--- a/plugins/extraction/mlutil.mli
+++ b/plugins/extraction/mlutil.mli
@@ -7,7 +7,6 @@
 (************************************************************************)
 
 open Names
-open Globnames
 open Miniml
 open Table
 

--- a/plugins/extraction/modutil.ml
+++ b/plugins/extraction/modutil.ml
@@ -8,7 +8,6 @@
 
 open Names
 open ModPath
-open Globnames
 open CErrors
 open Util
 open Miniml

--- a/plugins/extraction/modutil.mli
+++ b/plugins/extraction/modutil.mli
@@ -7,7 +7,6 @@
 (************************************************************************)
 
 open Names
-open Globnames
 open Miniml
 
 (*s Functions upon ML modules. *)

--- a/plugins/extraction/table.ml
+++ b/plugins/extraction/table.ml
@@ -651,7 +651,7 @@ let add_inline_entries b l =
 
 (* Registration of operations for rollback. *)
 
-let inline_extraction : bool * global_reference list -> obj =
+let inline_extraction : bool * Names.global_reference list -> obj =
   declare_object
     {(default_object "Extraction Inline") with
        cache_function = (fun (_,(b,l)) -> add_inline_entries b l);
@@ -735,7 +735,7 @@ let add_implicits r l =
 
 (* Registration of operations for rollback. *)
 
-let implicit_extraction : global_reference * int_or_id list -> obj =
+let implicit_extraction : Names.global_reference * int_or_id list -> obj =
   declare_object
     {(default_object "Extraction Implicit") with
        cache_function = (fun (_,(r,l)) -> add_implicits r l);
@@ -856,7 +856,7 @@ let find_custom_match pv =
 
 (* Registration of operations for rollback. *)
 
-let in_customs : global_reference * string list * string -> obj =
+let in_customs : Names.global_reference * string list * string -> obj =
   declare_object
     {(default_object "ML extractions") with
        cache_function = (fun (_,(r,ids,s)) -> add_custom r ids s);
@@ -866,7 +866,7 @@ let in_customs : global_reference * string list * string -> obj =
         (fun (s,(r,ids,str)) -> (fst (subst_global s r), ids, str))
     }
 
-let in_custom_matchs : global_reference * string -> obj =
+let in_custom_matchs : Names.global_reference * string -> obj =
   declare_object
     {(default_object "ML extractions custom matchs") with
        cache_function = (fun (_,(r,s)) -> add_custom_match r s);

--- a/plugins/extraction/table.mli
+++ b/plugins/extraction/table.mli
@@ -8,7 +8,6 @@
 
 open Names
 open Libnames
-open Globnames
 open Miniml
 open Declarations
 

--- a/plugins/firstorder/formula.ml
+++ b/plugins/firstorder/formula.ml
@@ -14,7 +14,6 @@ open Vars
 open Termops
 open Util
 open Declarations
-open Globnames
 
 module RelDecl = Context.Rel.Declaration
 

--- a/plugins/firstorder/formula.mli
+++ b/plugins/firstorder/formula.mli
@@ -6,9 +6,9 @@
 (*         *       GNU Lesser General Public License Version 2.1        *)
 (************************************************************************)
 
+open Names
 open Constr
 open EConstr
-open Globnames
 
 val qflag : bool ref
 

--- a/plugins/firstorder/instances.ml
+++ b/plugins/firstorder/instances.ml
@@ -41,7 +41,7 @@ let compare_gr id1 id2 =
 
 module OrderedInstance=
 struct
-  type t=instance * Globnames.global_reference
+  type t=instance * global_reference
   let compare (inst1,id1) (inst2,id2)=
     (compare_instance =? compare_gr) inst2 inst1 id2 id1
     (* we want a __decreasing__ total order *)

--- a/plugins/firstorder/instances.mli
+++ b/plugins/firstorder/instances.mli
@@ -6,13 +6,12 @@
 (*         *       GNU Lesser General Public License Version 2.1        *)
 (************************************************************************)
 
-open Globnames
 open Rules
 
 val collect_quantified : Evd.evar_map -> Sequent.t -> Formula.t list * Sequent.t
 
 val give_instances : Evd.evar_map -> Formula.t list -> Sequent.t ->
-  (Unify.instance * global_reference) list
+  (Unify.instance * Names.global_reference) list
 
 val quantified_tac : Formula.t list -> seqtac with_backtracking
 

--- a/plugins/firstorder/rules.ml
+++ b/plugins/firstorder/rules.ml
@@ -18,7 +18,6 @@ open Proofview.Notations
 open Termops
 open Formula
 open Sequent
-open Globnames
 open Locus
 
 module NamedDecl = Context.Named.Declaration

--- a/plugins/firstorder/rules.mli
+++ b/plugins/firstorder/rules.mli
@@ -9,7 +9,6 @@
 open Names
 open Constr
 open EConstr
-open Globnames
 
 type tactic = unit Proofview.tactic
 

--- a/plugins/firstorder/sequent.ml
+++ b/plugins/firstorder/sequent.ml
@@ -54,7 +54,7 @@ struct
 	(priority e1.pat) - (priority e2.pat)
 end
 
-type h_item = global_reference * (int*Constr.t) option
+type h_item = Names.global_reference * (int*Constr.t) option
 
 module Hitem=
 struct
@@ -95,7 +95,7 @@ module HP=Heap.Functional(OrderedFormula)
 
 type t=
     {redexes:HP.t;
-     context:(global_reference list) CM.t;
+     context:(Names.global_reference list) CM.t;
      latoms:constr list;
      gl:types;
      glatom:constr option;

--- a/plugins/firstorder/sequent.mli
+++ b/plugins/firstorder/sequent.mli
@@ -8,7 +8,7 @@
 
 open EConstr
 open Formula
-open Globnames
+open Names
 
 module CM: CSig.MapS with type key=Constr.t
 

--- a/plugins/funind/glob_termops.mli
+++ b/plugins/funind/glob_termops.mli
@@ -13,7 +13,7 @@ val pattern_to_term : cases_pattern -> glob_constr
    Some basic functions to rebuild glob_constr
    In each of them the location is Util.Loc.ghost
 *)
-val mkGRef : Globnames.global_reference -> glob_constr
+val mkGRef : global_reference -> glob_constr
 val mkGVar : Id.t -> glob_constr
 val mkGApp  : glob_constr*(glob_constr list) -> glob_constr
 val mkGLambda : Name.t * glob_constr * glob_constr -> glob_constr

--- a/plugins/funind/indfun.ml
+++ b/plugins/funind/indfun.ml
@@ -7,7 +7,6 @@ open EConstr
 open Pp
 open Indfun_common
 open Libnames
-open Globnames
 open Glob_term
 open Declarations
 open Misctypes

--- a/plugins/funind/indfun.mli
+++ b/plugins/funind/indfun.mli
@@ -18,4 +18,4 @@ val functional_induction :
   Goal.goal Evd.sigma -> Goal.goal list Evd.sigma
 
 
-val make_graph :  Globnames.global_reference -> unit
+val make_graph :  Names.global_reference -> unit

--- a/plugins/funind/indfun_common.mli
+++ b/plugins/funind/indfun_common.mli
@@ -41,7 +41,7 @@ val chop_rprod_n : int -> Glob_term.glob_constr ->
 val def_of_const : Constr.t -> Constr.t
 val eq : EConstr.constr Lazy.t
 val refl_equal : EConstr.constr Lazy.t
-val const_of_id: Id.t ->  Globnames.global_reference(* constantyes *)
+val const_of_id: Id.t ->  Names.global_reference(* constantyes *)
 val jmeq : unit -> EConstr.constr
 val jmeq_refl : unit -> EConstr.constr
 
@@ -107,11 +107,11 @@ val h_intros: Names.Id.t list -> Tacmach.tactic
 val h_id :  Names.Id.t
 val hrec_id :  Names.Id.t
 val acc_inv_id :  EConstr.constr Util.delayed
-val ltof_ref : Globnames.global_reference Util.delayed
+val ltof_ref : Names.global_reference Util.delayed
 val well_founded_ltof : EConstr.constr Util.delayed
 val acc_rel : EConstr.constr Util.delayed
 val well_founded : EConstr.constr Util.delayed
-val evaluable_of_global_reference : Globnames.global_reference -> Names.evaluable_global_reference
+val evaluable_of_global_reference : Names.global_reference -> Names.evaluable_global_reference
 val list_rewrite : bool -> (EConstr.constr*bool) list -> Tacmach.tactic
 
 val decompose_lam_n : Evd.evar_map -> int -> EConstr.t ->

--- a/plugins/funind/invfun.mli
+++ b/plugins/funind/invfun.mli
@@ -8,7 +8,7 @@
 
 val invfun :
   Misctypes.quantified_hypothesis ->
-  Globnames.global_reference option ->
+  Names.global_reference option ->
   Evar.t Evd.sigma -> Evar.t list Evd.sigma
 val derive_correctness :
   (Evd.evar_map ref ->

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -18,7 +18,6 @@ open Entries
 open Pp
 open Names
 open Libnames
-open Globnames
 open Nameops
 open CErrors
 open Util
@@ -204,7 +203,7 @@ let (value_f: Constr.t list -> global_reference -> Constr.t) =
 	(RegularStyle,None,
 	 [DAst.make @@ GApp(DAst.make @@ GRef(fterm,None), List.rev_map (fun x_id -> DAst.make @@ GVar x_id) rev_x_id_l),
 	  (Anonymous,None)],
-	 [Loc.tag ([v_id], [DAst.make @@ PatCstr ((destIndRef (delayed_force coq_sig_ref),1),
+         [Loc.tag ([v_id], [DAst.make @@ PatCstr ((Globnames.destIndRef (delayed_force coq_sig_ref),1),
 			   [DAst.make @@ PatVar(Name v_id); DAst.make @@ PatVar Anonymous],
                            Anonymous)],
 	    DAst.make @@ GVar v_id)])

--- a/plugins/ltac/extratactics.ml4
+++ b/plugins/ltac/extratactics.ml4
@@ -856,8 +856,9 @@ END
 
 let eq_constr x y = 
   Proofview.Goal.enter begin fun gl ->
+    let env = Tacmach.New.pf_env gl in
     let evd = Tacmach.New.project gl in
-      match EConstr.eq_constr_universes evd x y with
+      match EConstr.eq_constr_universes env evd x y with
       | Some _ -> Proofview.tclUNIT () 
       | None -> Tacticals.New.tclFAIL 0 (str "Not equal")
   end

--- a/plugins/ltac/taccoerce.mli
+++ b/plugins/ltac/taccoerce.mli
@@ -77,7 +77,7 @@ val coerce_to_hyp : Environ.env -> Evd.evar_map -> Value.t -> Id.t
 
 val coerce_to_hyp_list : Environ.env -> Evd.evar_map -> Value.t -> Id.t list
 
-val coerce_to_reference : Environ.env -> Evd.evar_map -> Value.t -> Globnames.global_reference
+val coerce_to_reference : Environ.env -> Evd.evar_map -> Value.t -> global_reference
 
 val coerce_to_quantified_hypothesis : Evd.evar_map -> Value.t -> quantified_hypothesis
 

--- a/plugins/setoid_ring/newring.mli
+++ b/plugins/setoid_ring/newring.mli
@@ -9,7 +9,6 @@
 open Names
 open EConstr
 open Libnames
-open Globnames
 open Constrexpr
 open Newring_ast
 

--- a/plugins/ssr/ssrcommon.mli
+++ b/plugins/ssr/ssrcommon.mli
@@ -206,7 +206,7 @@ val pf_mkprod :
            EConstr.t -> Goal.goal Evd.sigma * EConstr.types
 
 val mkSsrRRef : string -> Glob_term.glob_constr * 'a option
-val mkSsrRef : string -> Globnames.global_reference
+val mkSsrRef : string -> global_reference
 val mkSsrConst : 
            string ->
            env -> evar_map -> evar_map * EConstr.t
@@ -218,7 +218,7 @@ val new_wild_id : tac_ctx -> Names.Id.t * tac_ctx
 
 
 val pf_fresh_global :
-           Globnames.global_reference ->
+           global_reference ->
            Goal.goal Evd.sigma ->
            Constr.constr * Goal.goal Evd.sigma
 

--- a/pretyping/arguments_renaming.ml
+++ b/pretyping/arguments_renaming.ml
@@ -24,7 +24,7 @@ let name_table =
 
 type req =
   | ReqLocal
-  | ReqGlobal of global_reference * Name.t list
+  | ReqGlobal of Names.global_reference * Name.t list
 
 let load_rename_args _ (_, (_, (r, names))) =
   name_table := Refmap.add r names !name_table

--- a/pretyping/arguments_renaming.mli
+++ b/pretyping/arguments_renaming.mli
@@ -7,7 +7,6 @@
 (************************************************************************)
 
 open Names
-open Globnames
 open Environ
 open Constr
 

--- a/pretyping/classops.ml
+++ b/pretyping/classops.ml
@@ -35,7 +35,7 @@ type cl_info_typ = {
   cl_param : int
 }
 
-type coe_typ = global_reference
+type coe_typ = Names.global_reference
 
 module CoeTypMap = Refmap_env
 

--- a/pretyping/classops.mli
+++ b/pretyping/classops.mli
@@ -34,7 +34,7 @@ type cl_info_typ = {
   cl_param : int }
 
 (** This is the type of coercion kinds *)
-type coe_typ = Globnames.global_reference
+type coe_typ = global_reference
 
 (** This is the type of infos for declared coercions *)
 type coe_info_typ

--- a/pretyping/evarsolve.ml
+++ b/pretyping/evarsolve.ml
@@ -1335,7 +1335,7 @@ type conv_fun_bool =
 
 let solve_refl ?(can_drop=false) conv_algo env evd pbty evk argsv1 argsv2 =
   let evdref = ref evd in
-  let eq_constr c1 c2 = match EConstr.eq_constr_universes !evdref c1 c2 with
+  let eq_constr c1 c2 = match EConstr.eq_constr_universes env !evdref c1 c2 with
   | None -> false
   | Some cstr ->
     try ignore (Evd.add_universe_constraints !evdref cstr); true

--- a/pretyping/indrec.mli
+++ b/pretyping/indrec.mli
@@ -59,7 +59,7 @@ val weaken_sort_scheme : env -> evar_map -> bool -> Sorts.t -> int -> constr -> 
 
 (** Recursor names utilities *)
 
-val lookup_eliminator : inductive -> Sorts.family -> Globnames.global_reference
+val lookup_eliminator : inductive -> Sorts.family -> Names.global_reference
 val elimination_suffix : Sorts.family -> string
 val make_elimination_ident : Id.t -> Sorts.family -> Id.t
 

--- a/pretyping/patternops.mli
+++ b/pretyping/patternops.mli
@@ -7,7 +7,6 @@
 (************************************************************************)
 
 open EConstr
-open Globnames
 open Glob_term
 open Mod_subst
 open Misctypes
@@ -30,12 +29,12 @@ exception BoundPattern
    type [t] or raises [BoundPattern] (even if a sort); it raises an anomaly
    if [t] is an abstraction *)
 
-val head_pattern_bound : constr_pattern -> global_reference
+val head_pattern_bound : constr_pattern -> Names.global_reference
 
 (** [head_of_constr_reference c] assumes [r] denotes a reference and
    returns its label; raises an anomaly otherwise *)
 
-val head_of_constr_reference : Evd.evar_map -> constr -> global_reference
+val head_of_constr_reference : Evd.evar_map -> constr -> Names.global_reference
 
 (** [pattern_of_constr c] translates a term [c] with metavariables into
    a pattern; currently, no destructor (Cases, Fix, Cofix) and no

--- a/pretyping/program.mli
+++ b/pretyping/program.mli
@@ -7,7 +7,7 @@
 (************************************************************************)
 
 open EConstr
-open Globnames
+open Names
 
 (** A bunch of Coq constants used by Progam *)
 

--- a/pretyping/recordops.ml
+++ b/pretyping/recordops.ml
@@ -142,7 +142,7 @@ type obj_typ = {
   o_TCOMPS : constr list } (* ordered *)
 
 type cs_pattern =
-    Const_cs of global_reference
+    Const_cs of Names.global_reference
   | Prod_cs
   | Sort_cs of Sorts.family
   | Default_cs

--- a/pretyping/recordops.mli
+++ b/pretyping/recordops.mli
@@ -8,7 +8,6 @@
 
 open Names
 open Constr
-open Globnames
 
 (** Operations concerning records and canonical structures *)
 

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -105,7 +105,7 @@ module ReductionBehaviour = struct
   type flag = [ `ReductionDontExposeCase | `ReductionNeverUnfold ]
   type req =
     | ReqLocal
-    | ReqGlobal of global_reference * (int list * int * flag list)
+    | ReqGlobal of Names.global_reference * (int list * int * flag list)
 
   let load _ (_,(_,(r, b))) =
     table := Refmap.add r b !table

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -709,7 +709,7 @@ let magicaly_constant_of_fixbody env sigma reference bd = function
       match constant_opt_value_in env (cst,u) with
       | None -> bd
       | Some t ->
-        let csts = EConstr.eq_constr_universes sigma (EConstr.of_constr t) bd in
+        let csts = EConstr.eq_constr_universes env sigma (EConstr.of_constr t) bd in
         begin match csts with
         | Some csts ->
           let subst = Universes.Constraints.fold (fun (l,d,r) acc ->
@@ -1343,9 +1343,9 @@ let infer_conv_gen conv_fun ?(catch_incon=true) ?(pb=Reduction.CUMUL)
     let b, sigma = 
       let ans =
 	if pb == Reduction.CUMUL then 
-	  EConstr.leq_constr_universes sigma x y
+          EConstr.leq_constr_universes env sigma x y
 	else
-	  EConstr.eq_constr_universes sigma x y
+          EConstr.eq_constr_universes env sigma x y
       in
       let ans = match ans with
       | None -> None

--- a/pretyping/reductionops.mli
+++ b/pretyping/reductionops.mli
@@ -23,10 +23,10 @@ module ReductionBehaviour : sig
 
 (** [set is_local ref (recargs, nargs, flags)] *)
   val set :
-    bool -> Globnames.global_reference -> (int list * int * flag list) -> unit
+    bool -> global_reference -> (int list * int * flag list) -> unit
   val get :
-    Globnames.global_reference -> (int list * int * flag list) option
-  val print : Globnames.global_reference -> Pp.t
+    global_reference -> (int list * int * flag list) option
+  val print : global_reference -> Pp.t
 end
 
 (** Option telling if reduction should use the refolding machinery of cbn
@@ -44,7 +44,7 @@ val declare_reduction_effect : effect_name ->
   (Environ.env -> Evd.evar_map -> Constr.constr -> unit) -> unit
 
 (* [set_reduction_effect cst name] declares effect [name] to be called when [cst] is found *)
-val set_reduction_effect : Globnames.global_reference -> effect_name -> unit
+val set_reduction_effect : global_reference -> effect_name -> unit
 
 (* [effect_hook env sigma key term] apply effect associated to [key] on [term] *)
 val reduction_effect_hook : Environ.env -> Evd.evar_map -> Constr.constr ->

--- a/pretyping/tacred.mli
+++ b/pretyping/tacred.mli
@@ -12,7 +12,6 @@ open Evd
 open EConstr
 open Reductionops
 open Pattern
-open Globnames
 open Locus
 open Univ
 open Ltac_pretype
@@ -28,13 +27,13 @@ exception ReductionTacticError of reduction_tactic_error
 
 val is_evaluable : Environ.env -> evaluable_global_reference -> bool
 
-val error_not_evaluable : Globnames.global_reference -> 'a
+val error_not_evaluable : Names.global_reference -> 'a
 
 val evaluable_of_global_reference :
-  Environ.env -> Globnames.global_reference -> evaluable_global_reference
+  Environ.env -> Names.global_reference -> evaluable_global_reference
 
 val global_of_evaluable_reference :
-  evaluable_global_reference -> Globnames.global_reference
+  evaluable_global_reference -> Names.global_reference
 
 exception Redelimination
 
@@ -86,10 +85,10 @@ val reduce_to_quantified_ind : env ->  evar_map -> types -> (inductive * EInstan
 (** [reduce_to_quantified_ref env sigma ref t] try to put [t] in the form
    [t'=(x1:A1)..(xn:An)(ref args)] and fails with user error if not possible *)
 val reduce_to_quantified_ref :
-  env ->  evar_map -> global_reference -> types -> types
+  env ->  evar_map -> Names.global_reference -> types -> types
 
 val reduce_to_atomic_ref :
-  env ->  evar_map -> global_reference -> types -> types
+  env ->  evar_map -> Names.global_reference -> types -> types
 
 val find_hnf_rectype : 
   env ->  evar_map -> types -> (inductive * EInstance.t) * constr list

--- a/pretyping/typeclasses.ml
+++ b/pretyping/typeclasses.ml
@@ -62,10 +62,10 @@ type typeclass = {
   cl_univs : Univ.AUContext.t;
 
   (* The class implementation *)
-  cl_impl : global_reference;
+  cl_impl : Names.global_reference;
 
   (* Context in which the definitions are typed. Includes both typeclass parameters and superclasses. *)
-  cl_context : global_reference option list * Context.Rel.t;
+  cl_context : Names.global_reference option list * Context.Rel.t;
 
   (* Context of definitions and properties on defs, will not be shared *)
   cl_props : Context.Rel.t;
@@ -82,12 +82,12 @@ type typeclass = {
 type typeclasses = typeclass Refmap.t
 
 type instance = {
-  is_class: global_reference;
+  is_class: Names.global_reference;
   is_info: Vernacexpr.hint_info_expr;
   (* Sections where the instance should be redeclared,
      None for discard, Some 0 for none. *)
   is_global: int option;
-  is_impl: global_reference;
+  is_impl: Names.global_reference;
 }
 
 type instances = (instance Refmap.t) Refmap.t

--- a/pretyping/typeclasses.mli
+++ b/pretyping/typeclasses.mli
@@ -7,7 +7,6 @@
 (************************************************************************)
 
 open Names
-open Globnames
 open Constr
 open Evd
 open Environ
@@ -115,10 +114,10 @@ val classes_transparent_state_hook : (unit -> transparent_state) Hook.t
 val classes_transparent_state : unit -> transparent_state
 
 val add_instance_hint_hook : 
-  (global_reference_or_constr -> global_reference list ->
+  (Globnames.global_reference_or_constr -> global_reference list ->
    bool (* local? *) -> Vernacexpr.hint_info_expr -> Decl_kinds.polymorphic -> unit) Hook.t
 val remove_instance_hint_hook : (global_reference -> unit) Hook.t
-val add_instance_hint : global_reference_or_constr -> global_reference list -> 
+val add_instance_hint : Globnames.global_reference_or_constr -> global_reference list ->
   bool -> Vernacexpr.hint_info_expr -> Decl_kinds.polymorphic -> unit
 val remove_instance_hint : global_reference -> unit
 

--- a/pretyping/typeclasses_errors.ml
+++ b/pretyping/typeclasses_errors.ml
@@ -11,14 +11,13 @@ open Names
 open EConstr
 open Environ
 open Constrexpr
-open Globnames
 (*i*)
 
 type contexts = Parameters | Properties
 
 type typeclass_error =
     | NotAClass of constr
-    | UnboundMethod of global_reference * Id.t Loc.located (* Class name, method *)
+    | UnboundMethod of Names.global_reference * Id.t Loc.located (* Class name, method *)
     | MismatchedContextInstance of contexts * constr_expr list * Context.Rel.t (* found, expected *)
 
 exception TypeClassError of env * typeclass_error

--- a/pretyping/typeclasses_errors.mli
+++ b/pretyping/typeclasses_errors.mli
@@ -11,7 +11,6 @@ open Names
 open EConstr
 open Environ
 open Constrexpr
-open Globnames
 
 type contexts = Parameters | Properties
 

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -582,10 +582,10 @@ let force_eqs c =
 	Universes.Constraints.add c' acc) 
     c Universes.Constraints.empty
 
-let constr_cmp pb sigma flags t u =
+let constr_cmp pb env sigma flags t u =
   let cstrs =
-    if pb == Reduction.CONV then EConstr.eq_constr_universes sigma t u
-    else EConstr.leq_constr_universes sigma t u
+    if pb == Reduction.CONV then EConstr.eq_constr_universes env sigma t u
+    else EConstr.leq_constr_universes env sigma t u
   in 
   match cstrs with
   | Some cstrs ->
@@ -750,7 +750,7 @@ let rec unify_0_with_initial_metas (sigma,ms,es as subst : subst0) conv_at_top e
 	| Evar (evk,_ as ev), Evar (evk',_)
             when not (Evar.Set.mem evk flags.frozen_evars)
               && Evar.equal evk evk' ->
-            let sigma',b = constr_cmp cv_pb sigma flags cM cN in
+            let sigma',b = constr_cmp cv_pb env sigma flags cM cN in
             if b then
 	      sigma',metasubst,evarsubst
             else
@@ -932,7 +932,7 @@ let rec unify_0_with_initial_metas (sigma,ms,es as subst : subst0) conv_at_top e
   and unify_not_same_head curenvnb pb opt (sigma, metas, evars as substn : subst0) cM cN =
     try canonical_projections curenvnb pb opt cM cN substn
     with ex when precatchable_exception ex ->
-    let sigma', b = constr_cmp cv_pb sigma flags cM cN in
+    let sigma', b = constr_cmp cv_pb env sigma flags cM cN in
       if b then (sigma', metas, evars)
       else
 	try reduce curenvnb pb opt substn cM cN
@@ -1101,7 +1101,7 @@ let rec unify_0_with_initial_metas (sigma,ms,es as subst : subst0) conv_at_top e
     else 
       let sigma, b = match flags.modulo_conv_on_closed_terms with
 	| Some convflags -> infer_conv ~pb:cv_pb ~ts:convflags env sigma m n
-	| _ -> constr_cmp cv_pb sigma flags m n in
+        | _ -> constr_cmp cv_pb env sigma flags m n in
 	if b then Some sigma
 	else if (match flags.modulo_conv_on_closed_terms, flags.modulo_delta with
         | Some (cv_id, cv_k), (dl_id, dl_k) ->

--- a/printing/prettyp.ml
+++ b/printing/prettyp.ml
@@ -325,7 +325,7 @@ type 'a locatable_info = {
 type locatable = Locatable : 'a locatable_info -> locatable
 
 type logical_name =
-  | Term of global_reference
+  | Term of Names.global_reference
   | Dir of global_dir_reference
   | Syntactic of KerName.t
   | ModuleType of ModPath.t

--- a/printing/prettyp.mli
+++ b/printing/prettyp.mli
@@ -10,7 +10,6 @@ open Names
 open Environ
 open Reductionops
 open Libnames
-open Globnames
 open Misctypes
 open Evd
 

--- a/printing/printer.mli
+++ b/printing/printer.mli
@@ -7,7 +7,6 @@
 (************************************************************************)
 
 open Names
-open Globnames
 open Constr
 open Environ
 open Pattern

--- a/proofs/tacmach.mli
+++ b/proofs/tacmach.mli
@@ -93,7 +93,7 @@ val pr_glls   : goal list sigma -> Pp.t
 (* Variants of [Tacmach] functions built with the new proof engine *)
 module New : sig
   val pf_apply : (env -> evar_map -> 'a) -> 'b Proofview.Goal.t -> 'a
-  val pf_global : Id.t -> 'a Proofview.Goal.t -> Globnames.global_reference
+  val pf_global : Id.t -> 'a Proofview.Goal.t -> Names.global_reference
   (** FIXME: encapsulate the level in an existential type. *)
   val of_old : (Proof_type.goal Evd.sigma -> 'a) -> [ `NF ] Proofview.Goal.t -> 'a
 

--- a/tactics/btermdn.ml
+++ b/tactics/btermdn.ml
@@ -11,7 +11,6 @@ open Term
 open EConstr
 open Names
 open Pattern
-open Globnames
 
 (* Discrimination nets with bounded depth.
    See the module dn.ml for further explanations.
@@ -26,7 +25,7 @@ type term_label =
 | SortLabel
 
 let compare_term_label t1 t2 = match t1, t2 with
-| GRLabel gr1, GRLabel gr2 -> RefOrdered.compare gr1 gr2
+| GRLabel gr1, GRLabel gr2 -> Globnames.RefOrdered.compare gr1 gr2
 | _ -> Pervasives.compare t1 t2 (** OK *)
 
 type 'res lookup_res = 'res Dn.lookup_res = Label of 'res | Nothing | Everything

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -622,7 +622,7 @@ module V85 = struct
   type autoinfo = { hints : hint_db; is_evar: existential_key option;
                     only_classes: bool; unique : bool;
                     auto_depth: int list; auto_last_tac: Pp.t Lazy.t;
-                    auto_path : global_reference option list;
+                    auto_path : Names.global_reference option list;
                     auto_cut : hints_path }
   type autogoal = goal * autoinfo
   type failure = NotApplicable | ReachedLimit

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -113,7 +113,7 @@ type 'a hints_path_atom_gen =
   (* For forward hints, their names is the list of projections *)
   | PathAny
 
-type hints_path_atom = global_reference hints_path_atom_gen
+type hints_path_atom = Names.global_reference hints_path_atom_gen
 
 type 'a hints_path_gen =
   | PathAtom of 'a hints_path_atom_gen
@@ -124,10 +124,10 @@ type 'a hints_path_gen =
   | PathEpsilon
 
 type pre_hints_path = Libnames.reference hints_path_gen
-type hints_path = global_reference hints_path_gen
+type hints_path = Names.global_reference hints_path_gen
 
 type hint_term =
-  | IsGlobRef of global_reference
+  | IsGlobRef of Names.global_reference
   | IsConstr of constr * Univ.ContextSet.t
 
 type 'a with_uid = {
@@ -151,7 +151,7 @@ type 'a with_metadata = {
 
 type full_hint = hint with_metadata
 
-type hint_entry = global_reference option * 
+type hint_entry = Names.global_reference option *
   raw_hint hint_ast with_uid with_metadata
 
 type import_level = [ `LAX | `WARN | `STRICT ]
@@ -472,28 +472,28 @@ module Hint_db :
 sig
 type t
 val empty : ?name:hint_db_name -> transparent_state -> bool -> t
-val find : global_reference -> t -> search_entry
+val find : Names.global_reference -> t -> search_entry
 val map_none : secvars:Id.Pred.t -> t -> full_hint list
-val map_all : secvars:Id.Pred.t -> global_reference -> t -> full_hint list
+val map_all : secvars:Id.Pred.t -> Names.global_reference -> t -> full_hint list
 val map_existential : evar_map -> secvars:Id.Pred.t ->
-		      (global_reference * constr array) -> constr -> t -> full_hint list
+                      (Names.global_reference * constr array) -> constr -> t -> full_hint list
 val map_eauto : evar_map -> secvars:Id.Pred.t ->
-		(global_reference * constr array) -> constr -> t -> full_hint list
+                (Names.global_reference * constr array) -> constr -> t -> full_hint list
 val map_auto : evar_map -> secvars:Id.Pred.t ->
-	       (global_reference * constr array) -> constr -> t -> full_hint list
+               (Names.global_reference * constr array) -> constr -> t -> full_hint list
 val add_one : env -> evar_map -> hint_entry -> t -> t
 val add_list : env -> evar_map -> hint_entry list -> t -> t
-val remove_one : global_reference -> t -> t
-val remove_list : global_reference list -> t -> t
-val iter : (global_reference option -> hint_mode array list -> full_hint list -> unit) -> t -> unit
+val remove_one : Names.global_reference -> t -> t
+val remove_list : Names.global_reference list -> t -> t
+val iter : (Names.global_reference option -> hint_mode array list -> full_hint list -> unit) -> t -> unit
 val use_dn : t -> bool
 val transparent_state : t -> transparent_state
 val set_transparent_state : t -> transparent_state -> t
 val add_cut : hints_path -> t -> t
-val add_mode : global_reference -> hint_mode array -> t -> t
+val add_mode : Names.global_reference -> hint_mode array -> t -> t
 val cut : t -> hints_path
 val unfolds : t -> Id.Set.t * Cset.t
-val fold : (global_reference option -> hint_mode array list -> full_hint list -> 'a -> 'a) ->
+val fold : (Names.global_reference option -> hint_mode array list -> full_hint list -> 'a -> 'a) ->
   t -> 'a -> 'a
 
 end =
@@ -508,7 +508,7 @@ struct
     hintdb_map : search_entry Constr_map.t;
     (* A list of unindexed entries starting with an unfoldable constant
        or with no associated pattern. *)
-    hintdb_nopat : (global_reference option * stored_data) list;
+    hintdb_nopat : (Names.global_reference option * stored_data) list;
     hintdb_name : string option;
   }
 
@@ -1013,9 +1013,9 @@ type hint_action =
   | CreateDB of bool * transparent_state
   | AddTransparency of evaluable_global_reference list * bool
   | AddHints of hint_entry list
-  | RemoveHints of global_reference list
+  | RemoveHints of Names.global_reference list
   | AddCut of hints_path
-  | AddMode of global_reference * hint_mode array
+  | AddMode of Names.global_reference * hint_mode array
 
 let add_cut dbname path =
   let db = get_db dbname in
@@ -1224,7 +1224,7 @@ type hints_entry =
   | HintsCutEntry of hints_path
   | HintsUnfoldEntry of evaluable_global_reference list
   | HintsTransparencyEntry of evaluable_global_reference list * bool
-  | HintsModeEntry of global_reference * hint_mode list
+  | HintsModeEntry of Names.global_reference * hint_mode list
   | HintsExternEntry of hint_info * Genarg.glob_generic_argument
 
 let default_prepare_hint_ident = Id.of_string "H"

--- a/tactics/hints.mli
+++ b/tactics/hints.mli
@@ -10,7 +10,6 @@ open Util
 open Names
 open EConstr
 open Environ
-open Globnames
 open Decl_kinds
 open Evd
 open Misctypes
@@ -89,9 +88,9 @@ val pp_hints_path_atom : ('a -> Pp.t) -> 'a hints_path_atom_gen -> Pp.t
 val pp_hints_path : hints_path -> Pp.t
 val pp_hint_mode : hint_mode -> Pp.t
 val glob_hints_path_atom :
-  Libnames.reference hints_path_atom_gen -> Globnames.global_reference hints_path_atom_gen
+  Libnames.reference hints_path_atom_gen -> global_reference hints_path_atom_gen
 val glob_hints_path :
-  Libnames.reference hints_path_gen -> Globnames.global_reference hints_path_gen
+  Libnames.reference hints_path_gen -> global_reference hints_path_gen
 
 module Hint_db :
   sig

--- a/tactics/hipattern.mli
+++ b/tactics/hipattern.mli
@@ -142,7 +142,7 @@ val is_matching_sigma : Environ.env -> evar_map -> constr -> bool
 
 (** Match a decidable equality judgement (e.g [{t=u:>T}+{~t=u}]), returns
    [t,u,T] and a boolean telling if equality is on the left side *)
-val match_eqdec : Environ.env -> evar_map -> constr -> bool * Globnames.global_reference * constr * constr * constr
+val match_eqdec : Environ.env -> evar_map -> constr -> bool * Names.global_reference * constr * constr * constr
 
 (** Match a negation *)
 val is_matching_not : Environ.env -> evar_map -> constr -> bool

--- a/tactics/tacticals.mli
+++ b/tactics/tacticals.mli
@@ -133,7 +133,7 @@ val elimination_sort_of_hyp  : Id.t -> goal sigma -> Sorts.family
 val elimination_sort_of_clause : Id.t option -> goal sigma -> Sorts.family
 
 val pf_with_evars :  (goal sigma -> Evd.evar_map * 'a) -> ('a -> tactic) -> tactic
-val pf_constr_of_global : Globnames.global_reference -> (constr -> tactic) -> tactic
+val pf_constr_of_global : Names.global_reference -> (constr -> tactic) -> tactic
 
 (** Tacticals defined directly in term of Proofview *)
 
@@ -263,5 +263,5 @@ module New : sig
   val elim_on_ba : (branch_assumptions -> unit Proofview.tactic) -> branch_args  -> unit Proofview.tactic
   val case_on_ba : (branch_assumptions -> unit Proofview.tactic) -> branch_args  -> unit Proofview.tactic
 
-  val pf_constr_of_global : Globnames.global_reference -> constr Proofview.tactic
+  val pf_constr_of_global : Names.global_reference -> constr Proofview.tactic
 end

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -3496,7 +3496,7 @@ let cook_sign hyp0_opt inhyps indvars env sigma =
 type elim_scheme = {
   elimc: constr with_bindings option;
   elimt: types;
-  indref: global_reference option;
+  indref: Names.global_reference option;
   params: rel_context;      (* (prm1,tprm1);(prm2,tprm2)...(prmp,tprmp) *)
   nparams: int;               (* number of parameters *)
   predicates: rel_context;  (* (Qq, (Tq_1 -> Tq_2 ->...-> Tq_nq)), (Q1,...) *)

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -4933,9 +4933,9 @@ let intros_transitivity  n  = Tacticals.New.tclTHEN intros (transitivity_gen n)
    is solved by tac *)
 
 (** d1 is the section variable in the global context, d2 in the goal context *)
-let interpretable_as_section_decl evd d1 d2 =
+let interpretable_as_section_decl env evd d1 d2 =
   let open Context.Named.Declaration in
-  let e_eq_constr_univs sigma c1 c2 = match eq_constr_universes !sigma c1 c2 with
+  let e_eq_constr_univs sigma c1 c2 = match eq_constr_universes env !sigma c1 c2 with
   | None -> false
   | Some cstr ->
     try ignore (Evd.add_universe_constraints !sigma cstr); true
@@ -4999,6 +4999,7 @@ let cache_term_by_tactic_then ~opaque ?(goal_type=None) id gk tac tacK =
   let open Tacmach.New in
   let open Proofview.Notations in
   Proofview.Goal.enter begin fun gl ->
+  let env = Proofview.Goal.env gl in
   let sigma = Proofview.Goal.sigma gl in
   let current_sign = Global.named_context_val ()
   and global_sign = Proofview.Goal.hyps gl in
@@ -5008,7 +5009,7 @@ let cache_term_by_tactic_then ~opaque ?(goal_type=None) id gk tac tacK =
       (fun d (s1,s2) ->
         let id = NamedDecl.get_id d in
 	if mem_named_context_val id current_sign &&
-          interpretable_as_section_decl evdref (lookup_named_val id current_sign) d
+          interpretable_as_section_decl env evdref (lookup_named_val id current_sign) d
         then (s1,push_named_context_val d s2)
 	else (Context.Named.add d s1,s2))
       global_sign (Context.Named.empty, empty_named_context_val) in

--- a/tactics/tactics.mli
+++ b/tactics/tactics.mli
@@ -15,7 +15,6 @@ open Proof_type
 open Evd
 open Clenv
 open Redexpr
-open Globnames
 open Pattern
 open Unification
 open Misctypes

--- a/tactics/term_dnet.ml
+++ b/tactics/term_dnet.ml
@@ -35,7 +35,7 @@ struct
   type 't t =
     | DRel
     | DSort
-    | DRef    of global_reference
+    | DRef    of Names.global_reference
     | DCtx    of 't * 't (* (binding list, subterm) = Prods and LetIns *)
     | DLambda of 't * 't
     | DApp    of 't * 't (* binary app *)

--- a/test-suite/bugs/closed/6661.v
+++ b/test-suite/bugs/closed/6661.v
@@ -1,0 +1,259 @@
+(* -*- mode: coq; coq-prog-args: ("-noinit" "-indices-matter" "-w" "-notation-overridden,-deprecated-option") -*- *)
+(*
+    The Coq Proof Assistant, version 8.7.1 (January 2018)
+    compiled on Jan 21 2018 15:02:24 with OCaml 4.06.0
+    from commit 391bb5e196901a3a9426295125b8d1c700ab6992
+ *)
+
+
+Require Export Coq.Init.Notations.
+Notation "'∏'  x .. y , P" := (forall x, .. (forall y, P) ..)
+  (at level 200, x binder, y binder, right associativity) : type_scope.
+Notation "'λ' x .. y , t" := (fun x => .. (fun y => t) ..)
+  (at level 200, x binder, y binder, right associativity).
+Notation "A -> B" := (forall (_ : A), B) : type_scope.
+Reserved Notation "p @ q" (at level 60, right associativity).
+Reserved Notation "! p " (at level 50).
+
+Monomorphic Universe uu.
+Monomorphic Universe uu0.
+Monomorphic Universe uu1.
+Constraint uu0 < uu1.
+
+Global Set Universe Polymorphism.
+Global Set Polymorphic Inductive Cumulativity.
+Global Unset Universe Minimization ToSet.
+
+Notation UU  := Type (only parsing).
+Notation UU0 := Type@{uu0} (only parsing).
+
+Global Set Printing Universes.
+
+ Inductive unit : UU0 := tt : unit.
+
+Inductive paths@{i} {A:Type@{i}} (a:A) : A -> Type@{i} := idpath : paths a a.
+Hint Resolve idpath : core .
+Notation "a = b" := (paths a b) (at level 70, no associativity) : type_scope.
+
+Set Primitive Projections.
+Set Nonrecursive Elimination Schemes.
+
+Record total2@{i} { T: Type@{i} } ( P: T -> Type@{i} ) : Type@{i}
+  := tpair { pr1 : T; pr2 : P pr1 }.
+
+Arguments tpair {_} _ _ _.
+Arguments pr1 {_ _} _.
+Arguments pr2 {_ _} _.
+
+Notation "'∑'  x .. y , P" := (total2 (λ x, .. (total2 (λ y, P)) ..))
+  (at level 200, x binder, y binder, right associativity) : type_scope.
+
+Definition foo (X:Type) (xy : @total2 X (λ _, X)) : X.
+  induction xy as [x y].
+  exact x.
+Defined.
+
+Unset Automatic Introduction.
+
+Definition idfun (T : UU) := λ t:T, t.
+
+Definition pathscomp0 {X : UU} {a b c : X} (e1 : a = b) (e2 : b = c) : a = c.
+Proof.
+  intros. induction e1. exact e2.
+Defined.
+
+Hint Resolve @pathscomp0 : pathshints.
+
+Notation "p @ q" := (pathscomp0 p q).
+
+Definition pathsinv0 {X : UU} {a b : X} (e : a = b) : b = a.
+Proof.
+  intros. induction e. exact (idpath _).
+Defined.
+
+Notation "! p " := (pathsinv0 p).
+
+Definition maponpaths {T1 T2 : UU} (f : T1 -> T2) {t1 t2 : T1}
+           (e: t1 = t2) : f t1 = f t2.
+Proof.
+  intros. induction e. exact (idpath _).
+Defined.
+
+Definition map_on_two_paths {X Y Z : UU} (f : X -> Y -> Z) {x x' y y'} (ex : x = x') (ey: y = y') :
+  f x y = f x' y'.
+Proof.
+  intros. induction ex. induction ey. exact (idpath _).
+Defined.
+
+
+Definition maponpathscomp0 {X Y : UU} {x1 x2 x3 : X}
+           (f : X -> Y) (e1 : x1 = x2) (e2 : x2 = x3) :
+  maponpaths f (e1 @ e2) = maponpaths f e1 @ maponpaths f e2.
+Proof.
+  intros. induction e1. induction e2. exact (idpath _).
+Defined.
+
+Definition maponpathsinv0 {X Y : UU} (f : X -> Y)
+           {x1 x2 : X} (e : x1 = x2) : maponpaths f (! e) = ! (maponpaths f e).
+Proof.
+  intros. induction e. exact (idpath _).
+Defined.
+
+
+
+Definition constr1 {X : UU} (P : X -> UU) {x x' : X} (e : x = x') :
+  ∑ (f : P x -> P x'),
+  ∑ (ee : ∏ p : P x, tpair _ x p = tpair _ x' (f p)),
+  ∏ (pp : P x), maponpaths pr1 (ee pp) = e.
+Proof.
+  intros. induction e.
+  split with (idfun (P x)).
+  split with (λ p, idpath _).
+  unfold maponpaths. simpl.
+  intro. exact (idpath _).
+Defined.
+
+Definition transportf@{i} {X : Type@{i}} (P : X -> Type@{i}) {x x' : X}
+           (e : x = x') : P x -> P x' := pr1 (constr1 P e).
+
+Lemma two_arg_paths_f@{i} {A : Type@{i}} {B : A -> Type@{i}} {C:Type@{i}} {f : ∏ a, B a -> C} {a1 b1 a2 b2}
+      (p : a1 = a2) (q : transportf B p b1 = b2) : f a1 b1 = f a2 b2.
+Proof.
+  intros. induction p. induction q. exact (idpath _).
+Defined.
+
+Definition iscontr@{i} (T:Type@{i}) : Type@{i} := ∑ cntr:T, ∏ t:T, t=cntr.
+
+Lemma proofirrelevancecontr {X : UU} (is : iscontr X) (x x' : X) : x = x'.
+Proof.
+  intros.
+  induction is as [y fe].
+  exact (fe x @ !(fe x')).
+Defined.
+
+
+Definition hfiber@{i} {X Y : Type@{i}} (f : X -> Y) (y : Y) : Type@{i} := total2 (λ x, f x = y).
+
+Definition hfiberpair {X Y : UU} (f : X -> Y) {y : Y}
+           (x : X) (e : f x = y) : hfiber f y :=
+  tpair _ x e.
+
+Definition coconustot (T : UU) (t : T) := ∑ t' : T, t' = t.
+
+Definition coconustotpair (T : UU) {t t' : T} (e: t' = t) : coconustot T t
+  := tpair _ t' e.
+
+Lemma connectedcoconustot {T : UU} {t : T} (c1 c2 : coconustot T t) : c1 = c2.
+Proof.
+  intros.
+  induction c1 as [x0 x].
+  induction x.
+  induction c2 as [x1 y].
+  induction y.
+  exact (idpath _).
+Defined.
+
+Definition isweq@{i} {X Y : Type@{i}} (f : X -> Y) : Type@{i} :=
+  ∏ y : Y, iscontr (hfiber f y).
+
+Lemma isProofIrrelevantUnit : ∏ x x' : unit, x = x'.
+Proof.
+  intros. induction x. induction x'. exact (idpath _).
+Defined.
+
+Lemma unitl0 : tt = tt -> coconustot _ tt.
+Proof.
+  intros e. exact (coconustotpair unit e).
+Defined.
+
+Lemma unitl1: coconustot _ tt -> tt = tt.
+Proof.
+  intro cp. induction cp as [x t]. induction x. exact t.
+Defined.
+
+Lemma unitl2: ∏ e : tt = tt, unitl1 (unitl0 e) = e.
+Proof.
+  intros. unfold unitl0. simpl. exact (idpath _).
+Defined.
+
+Lemma unitl3: ∏ e : tt = tt, e = idpath tt.
+Proof.
+  intros.
+
+  assert (e0 : unitl0 (idpath tt) = unitl0 e).
+  { simple refine (connectedcoconustot _ _). }
+
+  set (e1 := maponpaths unitl1 e0).
+
+  exact (! (unitl2 e) @ (! e1) @ (unitl2 (idpath _))).
+Defined.
+
+Theorem iscontrpathsinunit (x x' : unit) : iscontr (x = x').
+Proof.
+  intros.
+  split with (isProofIrrelevantUnit x x').
+  intros e'.
+  induction x.
+  induction x'.
+  simpl.
+  apply unitl3.
+Qed.
+
+Lemma ifcontrthenunitl0 (e1 e2 : tt = tt) : e1 = e2.
+Proof.
+  intros.
+  simple refine (proofirrelevancecontr _ _ _).
+  exact (iscontrpathsinunit tt tt).
+Qed.
+
+Section isweqcontrtounit.
+
+  Universe i.
+
+  (* To see the bug, run it both with and without this constraint: *)
+
+  (* Constraint uu0 < i. *)
+
+  (* Without this constraint, we get i = uu0 in the next definition *)
+  Lemma isweqcontrtounit@{} {T : Type@{i}} (is : iscontr@{i} T) : isweq@{i} (λ _:T, tt).
+  Proof.
+    intros. intro y. induction y.
+    induction is as [c h].
+    split with (hfiberpair@{i i i} _ c (idpath tt)).
+    intros ha.
+    induction ha as [x e].
+    simple refine (two_arg_paths_f (h x) _).
+    simple refine (ifcontrthenunitl0 _ _).
+  Defined.
+
+  (*
+     Explanation of the bug:
+
+     With the constraint uu0 < i above we get:
+
+            |= uu0 <= bug.3
+               uu0 <= i
+               uu1 <= i
+               i <= bug.3
+
+     from this print statement: *)
+
+         Print isweqcontrtounit.
+
+  (*
+
+     Without the constraint uu0 < i above we get:
+
+            |= i <= bug.3
+               uu0 = i
+
+     Since uu0 = i is not inferred when we impose the constraint uu0 < i,
+     it is invalid to infer it when we don't.
+
+   *)
+
+  Context (X : Type@{uu1}).
+
+  Check (@isweqcontrtounit X). (* detect a universe inconsistency *)
+
+End isweqcontrtounit.

--- a/test-suite/coqchk/cumulativity.v
+++ b/test-suite/coqchk/cumulativity.v
@@ -25,7 +25,7 @@ Section ListLower.
 
 End ListLower.
 
-Lemma LowerL_Lem@{i j} (A : Type@{j}) (l : List@{i} A) : l = LowerL l.
+Lemma LowerL_Lem@{i j|j<i+} (A : Type@{j}) (l : List@{i} A) : l = LowerL l.
 Proof. reflexivity. Qed.
 (*
 I disable these tests because cqochk can't process them when compiled with

--- a/test-suite/success/cumulativity.v
+++ b/test-suite/success/cumulativity.v
@@ -10,40 +10,16 @@ Set Printing Universes.
 
 Inductive List (A: Type) := nil | cons : A -> List A -> List A.
 
-Section ListLift.
-  Universe i j.
-
-  Constraint i < j.
-
-  Definition LiftL {A} : List@{i} A -> List@{j} A := fun x => x.
-
-End ListLift.
+Definition LiftL@{k i j|k <= i, k <= j} {A:Type@{k}} : List@{i} A -> List@{j} A := fun x => x.
 
 Lemma LiftL_Lem A (l : List A) : l = LiftL l.
 Proof. reflexivity. Qed.
 
-Section ListLower.
-  Universe i j.
-
-  Constraint i < j.
-
-  Definition LowerL {A : Type@{i}} : List@{j} A -> List@{i} A := fun x => x.
-
-End ListLower.
-
-Lemma LowerL_Lem@{i j} (A : Type@{j}) (l : List@{i} A) : l = LowerL l.
-Proof. reflexivity. Qed.
-
 Inductive Tp := tp : Type -> Tp.
 
-Section TpLift.
-  Universe i j.
+Definition LiftTp@{i j|i <= j} : Tp@{i} -> Tp@{j} := fun x => x.
 
-  Constraint i < j.
-
-  Definition LiftTp : Tp@{i} -> Tp@{j} := fun x => x.
-
-End TpLift.
+Fail Definition LowerTp@{i j|j < i} : Tp@{i} -> Tp@{j} := fun x => x.
 
 Record Tp' := { tp' : Tp }.
 
@@ -51,21 +27,11 @@ Definition CTp := Tp.
 (* here we have to reduce a constant to infer the correct subtyping. *)
 Record Tp'' := { tp'' : CTp }.
 
-Definition LiftTp'@{i j|i < j} : Tp'@{i} -> Tp'@{j} := fun x => x.
-Definition LiftTp''@{i j|i < j} : Tp''@{i} -> Tp''@{j} := fun x => x.
+Definition LiftTp'@{i j|i <= j} : Tp'@{i} -> Tp'@{j} := fun x => x.
+Definition LiftTp''@{i j|i <= j} : Tp''@{i} -> Tp''@{j} := fun x => x.
 
 Lemma LiftC_Lem (t : Tp) : LiftTp t = t.
 Proof. reflexivity. Qed.
-
-Section TpLower.
-  Universe i j.
-
-  Constraint i < j.
-
-  Fail Definition LowerTp : Tp@{j} -> Tp@{i} := fun x => x.
-
-End TpLower.
-
 
 Section subtyping_test.
   Universe i j.
@@ -82,14 +48,8 @@ Record B (X : A) : Type := { b : X; }.
 NonCumulative Inductive NCList (A: Type)
   := ncnil | nccons : A -> NCList A -> NCList A.
 
-Section NCListLift.
-  Universe i j.
-
-  Constraint i < j.
-
-  Fail Definition LiftNCL {A} : NCList@{i} A -> NCList@{j} A := fun x => x.
-
-End NCListLift.
+Fail Definition LiftNCL@{k i j|k <= i, k <= j} {A:Type@{k}}
+  : NCList@{i} A -> NCList@{j} A := fun x => x.
 
 Inductive eq@{i} {A : Type@{i}} (x : A) : A -> Type@{i} := eq_refl : eq x x.
 
@@ -114,7 +74,7 @@ Fail Definition arrow_lift@{i i' j j' | i' < i, j < j'}
   : Arrow@{i j} -> Arrow@{i' j'}
   := fun x => x.
 
-Definition arrow_lift@{i i' j j' | i' = i, j < j'}
+Definition arrow_lift@{i i' j j' | i' = i, j <= j'}
   : Arrow@{i j} -> Arrow@{i' j'}
   := fun x => x.
 

--- a/vernac/assumptions.mli
+++ b/vernac/assumptions.mli
@@ -28,4 +28,4 @@ val traverse :
    {!traverse} also applies. *)
 val assumptions :
   ?add_opaque:bool -> ?add_transparent:bool -> transparent_state ->
-     global_reference -> constr -> types ContextObjectMap.t
+     Names.global_reference -> constr -> types ContextObjectMap.t

--- a/vernac/auto_ind_decl.ml
+++ b/vernac/auto_ind_decl.ml
@@ -18,7 +18,6 @@ open Vars
 open Termops
 open Declarations
 open Names
-open Globnames
 open Inductiveops
 open Tactics
 open Ind_tables
@@ -633,7 +632,7 @@ repeat ( apply andb_prop in z;let z1:= fresh "Z" in destruct z as [z1 z]).
                         | App (c,ca) -> (
                           match EConstr.kind sigma c with
                           | Ind (indeq, u) ->
-                              if eq_gr (IndRef indeq) Coqlib.glob_eq
+                              if Globnames.eq_gr (IndRef indeq) Coqlib.glob_eq
                               then
                                 Tacticals.New.tclTHEN
                                   (do_replace_bl mode bl_scheme_key ind

--- a/vernac/auto_ind_decl.mli
+++ b/vernac/auto_ind_decl.mli
@@ -21,7 +21,7 @@ exception EqUnknown of string
 exception UndefinedCst of string
 exception InductiveWithProduct
 exception InductiveWithSort
-exception ParameterWithoutEquality of Globnames.global_reference
+exception ParameterWithoutEquality of global_reference
 exception NonSingletonProp of inductive
 exception DecidabilityMutualNotSupported
 exception NoDecidabilityCoInductive

--- a/vernac/class.ml
+++ b/vernac/class.ml
@@ -18,7 +18,6 @@ open Entries
 open Environ
 open Classops
 open Declare
-open Globnames
 open Nametab
 open Decl_kinds
 

--- a/vernac/class.mli
+++ b/vernac/class.mli
@@ -8,7 +8,6 @@
 
 open Names
 open Classops
-open Globnames
 
 (** Classes and coercions. *)
 

--- a/vernac/classes.mli
+++ b/vernac/classes.mli
@@ -28,7 +28,7 @@ val declare_instance_constant :
   Vernacexpr.hint_info_expr -> (** priority *)
   bool -> (** globality *)
   Impargs.manual_explicitation list -> (** implicits *)
-  ?hook:(Globnames.global_reference -> unit) ->
+  ?hook:(global_reference -> unit) ->
   Id.t -> (** name *)
   Univdecls.universe_decl ->
   bool -> (* polymorphic *)
@@ -48,7 +48,7 @@ val new_instance :
   (bool * constr_expr) option ->
   ?generalize:bool ->
   ?tac:unit Proofview.tactic  ->
-  ?hook:(Globnames.global_reference -> unit) ->
+  ?hook:(global_reference -> unit) ->
   Vernacexpr.hint_info_expr ->
   Id.t
 

--- a/vernac/comAssumption.mli
+++ b/vernac/comAssumption.mli
@@ -9,7 +9,6 @@
 open Names
 open Constr
 open Entries
-open Globnames
 open Vernacexpr
 open Constrexpr
 open Decl_kinds

--- a/vernac/declareDef.mli
+++ b/vernac/declareDef.mli
@@ -13,10 +13,10 @@ val get_locality : Id.t -> kind:string -> Decl_kinds.locality -> bool
 
 val declare_definition : Id.t -> definition_kind ->
   Safe_typing.private_constants Entries.definition_entry -> Universes.universe_binders -> Impargs.manual_implicits ->
-    Globnames.global_reference Lemmas.declaration_hook -> Globnames.global_reference
+    global_reference Lemmas.declaration_hook -> global_reference
 
 val declare_fix : ?opaque:bool -> definition_kind ->
   Universes.universe_binders -> Entries.constant_universes_entry ->
   Id.t -> Safe_typing.private_constants Entries.proof_output ->
   Constr.types -> Impargs.manual_implicits ->
-  Globnames.global_reference
+  global_reference

--- a/vernac/lemmas.ml
+++ b/vernac/lemmas.ml
@@ -32,7 +32,7 @@ open Impargs
 module RelDecl = Context.Rel.Declaration
 module NamedDecl = Context.Named.Declaration
 
-type 'a declaration_hook = Decl_kinds.locality -> Globnames.global_reference -> 'a
+type 'a declaration_hook = Decl_kinds.locality -> Names.global_reference -> 'a
 let mk_hook hook = hook
 let call_hook fix_exn hook l c =
   try hook l c

--- a/vernac/lemmas.mli
+++ b/vernac/lemmas.mli
@@ -11,10 +11,10 @@ open Decl_kinds
 
 type 'a declaration_hook
 val mk_hook :
-  (Decl_kinds.locality -> Globnames.global_reference -> 'a) -> 'a declaration_hook
+  (Decl_kinds.locality -> global_reference -> 'a) -> 'a declaration_hook
 
 val call_hook :
-  Future.fix_exn -> 'a declaration_hook -> Decl_kinds.locality -> Globnames.global_reference -> 'a
+  Future.fix_exn -> 'a declaration_hook -> Decl_kinds.locality -> global_reference -> 'a
 
 (** A hook start_proof calls on the type of the definition being started *)
 val set_start_hook : (EConstr.types -> unit) -> unit

--- a/vernac/obligations.ml
+++ b/vernac/obligations.ml
@@ -1,5 +1,4 @@
 open Printf
-open Globnames
 open Libobject
 open Entries
 open Decl_kinds

--- a/vernac/obligations.mli
+++ b/vernac/obligations.mli
@@ -10,7 +10,6 @@ open Environ
 open Constr
 open Evd
 open Names
-open Globnames
 
 (* This is a hack to make it possible for Obligations to craft a Qed
  * behind the scenes.  The fix_exn the Stm attaches to the Future proof

--- a/vernac/record.mli
+++ b/vernac/record.mli
@@ -9,7 +9,6 @@
 open Names
 open Vernacexpr
 open Constrexpr
-open Globnames
 
 val primitive_flag : bool ref
 

--- a/vernac/search.ml
+++ b/vernac/search.ml
@@ -15,7 +15,6 @@ open Libobject
 open Environ
 open Pattern
 open Libnames
-open Globnames
 open Nametab
 
 module NamedDecl = Context.Named.Declaration
@@ -116,7 +115,7 @@ module ConstrPriority = struct
   (* The priority is memoised here. Because of the very localised use
      of this module, it is not worth it making a convenient interface. *)
   type t =
-    Globnames.global_reference * Environ.env * Constr.t * priority
+    global_reference * Environ.env * Constr.t * priority
   and priority = int
 
   module ConstrSet = CSet.Make(Constr)

--- a/vernac/search.mli
+++ b/vernac/search.mli
@@ -10,7 +10,6 @@ open Names
 open Constr
 open Environ
 open Pattern
-open Globnames
 
 (** {6 Search facilities. } *)
 


### PR DESCRIPTION
Previously `fun x : Ind@{i} => x : Ind@{j}` with Ind some cumulative
inductive would try to generate a constraint `i = j` and use
cumulativity only if this resulted in an inconsistency. This is
confusingly different from the behaviour with `Type` and means
cumulativity can only be used to lift between universes related by
strict inequalities. (This isn't a kernel restriction so there might
be some workaround to send the kernel the right constraints, but
not in a nice way.)

See modified test for more details of what is now possible.

Technical notes:

When universe constraints were inferred by comparing the shape of
terms without reduction, cumulativity was not used and so too-strict
equality constraints were generated. Then in order to use cumulativity
we had to make this comparison fail to fall back to full conversion.

This commit gives enough information to the universe comparison
functions in Constr.compare_head_gen* to use cumulativity. 

The code in EConstr can probably be factored with similar code in
Reduction (see eg 990f725) but I don't have the energy right now.
See also misc added TODOs.

Also note in Constr.compare_head_gen_leq_with some possibly evar
sensitivity if given `App (?X, args)` with `?X` defined as it got matched
with `Cast` without calling `kind` again.

Fixes #6661.

Now depends on #6128.