### PR TITLE
Print name of (first of block) inductive with cumulativity info.

### DIFF
--- a/dev/top_printers.ml
+++ b/dev/top_printers.ml
@@ -213,8 +213,10 @@ let ppuniverseconstraints c = pp (Universes.Constraints.pr c)
 let ppuniverse_context_future c = 
   let ctx = Future.force c in
     ppuniverse_context ctx
-let ppcumulativity_info c = pp (Univ.pr_cumulativity_info Univ.Level.pr c)
-let ppabstract_cumulativity_info c = pp (Univ.pr_abstract_cumulativity_info Univ.Level.pr c)
+let ppcumulativity_info c = pp (Univ.pr_cumulativity_info Univ.Level.pr
+                                  (Names.Id.of_string_soft "~") c)
+let ppabstract_cumulativity_info c =
+  pp (Univ.pr_abstract_cumulativity_info Univ.Level.pr (Id.of_string_soft "~") c)
 let ppuniverses u = pp (UGraph.pr_universes Level.pr u)
 let ppnamedcontextval e =
   pp (pr_named_context (Global.env ()) Evd.empty (named_context_of_val e))

--- a/kernel/univ.ml
+++ b/kernel/univ.ml
@@ -951,11 +951,12 @@ struct
     (Instance.of_array (Array.sub (Instance.to_array ctx) 0 halflen),
      Instance.of_array (Array.sub (Instance.to_array ctx) halflen halflen))
 
-  let pr prl (univcst, subtypcst) =
+  let pr prl id (univcst, subtypcst) =
     if UContext.is_empty univcst then mt() else
       let (ctx, ctx') = halve_context (UContext.instance subtypcst) in
       (UContext.pr prl univcst) ++ fnl () ++ fnl () ++
-        h 0 (str "~@{" ++ Instance.pr prl ctx ++ str "} <= ~@{" ++ Instance.pr prl ctx' ++ str "} iff ")
+      h 0 (Names.Id.print id ++ str "@{" ++ Instance.pr prl ctx ++ str "} <= " ++
+           Names.Id.print id ++ str "@{" ++ Instance.pr prl ctx' ++ str "} iff ")
          ++ fnl () ++ h 0 (v 0 (Constraint.pr prl (UContext.constraints subtypcst)))
 
   let hcons (univcst, subtypcst) =

--- a/kernel/univ.mli
+++ b/kernel/univ.mli
@@ -467,9 +467,9 @@ val make_abstract_instance : abstract_universe_context -> universe_instance
 val pr_constraint_type : constraint_type -> Pp.t
 val pr_constraints : (Level.t -> Pp.t) -> constraints -> Pp.t
 val pr_universe_context : (Level.t -> Pp.t) -> universe_context -> Pp.t
-val pr_cumulativity_info : (Level.t -> Pp.t) -> cumulativity_info -> Pp.t
+val pr_cumulativity_info : (Level.t -> Pp.t) -> Names.Id.t -> cumulativity_info -> Pp.t
 val pr_abstract_universe_context : (Level.t -> Pp.t) -> abstract_universe_context -> Pp.t
-val pr_abstract_cumulativity_info : (Level.t -> Pp.t) -> abstract_cumulativity_info -> Pp.t
+val pr_abstract_cumulativity_info : (Level.t -> Pp.t) -> Names.Id.t -> abstract_cumulativity_info -> Pp.t
 val pr_universe_context_set : (Level.t -> Pp.t) -> universe_context_set -> Pp.t
 val explain_universe_inconsistency : (Level.t -> Pp.t) -> 
   univ_inconsistency -> Pp.t

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -266,11 +266,11 @@ let pr_universe_ctx sigma c =
   else
     mt()
 
-let pr_cumulativity_info sigma cumi =
+let pr_cumulativity_info sigma id cumi =
   if !Detyping.print_universes 
   && not (Univ.UContext.is_empty (Univ.CumulativityInfo.univ_context cumi)) then
     fnl()++pr_in_comment (fun uii -> v 0 
-      (Univ.pr_cumulativity_info (Termops.pr_evd_level sigma) uii)) cumi
+      (Univ.pr_cumulativity_info (Termops.pr_evd_level sigma) id uii)) cumi
   else
     mt()
 

--- a/printing/printer.mli
+++ b/printing/printer.mli
@@ -103,7 +103,7 @@ val pr_polymorphic         : bool -> Pp.t
 val pr_cumulative          : bool -> bool -> Pp.t
 val pr_universe_instance   : evar_map -> Univ.universe_context -> Pp.t
 val pr_universe_ctx        : evar_map -> Univ.universe_context -> Pp.t
-val pr_cumulativity_info   : evar_map -> Univ.cumulativity_info -> Pp.t
+val pr_cumulativity_info   : evar_map -> Names.Id.t -> Univ.cumulativity_info -> Pp.t
 
 (** Printing global references using names as short as possible *)
 

--- a/printing/printmod.ml
+++ b/printing/printmod.ml
@@ -145,7 +145,7 @@ let print_mutual_inductive env mind mib =
          | Monomorphic_ind _ | Polymorphic_ind _ -> str ""
          | Cumulative_ind cumi ->
            Printer.pr_cumulativity_info
-             sigma (instantiate_cumulativity_info cumi))
+             sigma (mib.mind_packets.(0).mind_typename) (instantiate_cumulativity_info cumi))
 
 let get_fields =
   let rec prodec_rec l subst c =
@@ -203,7 +203,7 @@ let print_record env mind mib =
     | Monomorphic_ind _ | Polymorphic_ind _ -> str ""
     | Cumulative_ind cumi ->
       Printer.pr_cumulativity_info
-        sigma (instantiate_cumulativity_info cumi)
+        sigma mip.mind_typename (instantiate_cumulativity_info cumi)
   )
 
 let pr_mutual_inductive_body env mind mib =

--- a/test-suite/output/UnivBinders.out
+++ b/test-suite/output/UnivBinders.out
@@ -10,3 +10,12 @@ Type@{Top.8} -> Type@{v} -> Type@{u}
 (* u Top.8 v |=  *)
 
 foo is universe polymorphic
+Cumulative Record TypBox : Type@{i+1} := Build_TypBox
+  { unbox : Type@{i} }
+(* i |= 
+   
+   TypBox@{i} <= TypBox@{Top.12} iff 
+   i <= Top.12
+    *)
+
+For Build_TypBox: Argument scope is [type_scope]

--- a/test-suite/output/UnivBinders.v
+++ b/test-suite/output/UnivBinders.v
@@ -11,3 +11,7 @@ Print bar.
    order of appearance. *)
 Definition foo@{u +} := Type -> Type@{v} -> Type@{u}.
 Print foo.
+
+Cumulative Record TypBox@{i} := { unbox : Type@{i} }.
+
+Print TypBox.


### PR DESCRIPTION
This replaces printing "~@{bla} <= ~@{bli}" by "Ind@{bla} <= Ind@{bli}".

I feel like this is easier to read but maybe it's confusing for mutual inductives (where only the name of the first one is printed) or if the inductive has arguments.