### PR TITLE
Add -with-file-output flag to coqdep, #5988

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -21,6 +21,13 @@ Tactics
 - Tactic "decide equality" now able to manage constructors which
   contain proofs.
 
+Tools
+
+- The coqdep tool can take the flag "-with-file-output", indicating that
+  that for each .v file on the command line, produce a corresponding .v.d
+  dependency file. Using this flag with multiple files can be much faster
+  than invoking the tool for each file.
+
 Changes from 8.7+beta2 to 8.7.0
 ===============================
 

--- a/man/coqdep.1
+++ b/man/coqdep.1
@@ -1,4 +1,4 @@
-.TH COQ 1 "28 March 1995" "Coq tools"
+.TH COQ 1 "6 November 2017" "Coq tools"
 
 .SH NAME
 coqdep \- Compute inter-module dependencies for Coq and Caml programs
@@ -103,9 +103,11 @@ Skips subdirectory
 Output the given file name ordered by dependencies.
 .TP 
 .B \-boot
-For coq developpers, prints dependencies over coq library files
+For coq developers, prints dependencies over coq library files
 (omitted by default).
-
+.TP
+.B \-with-file-output
+For each file.v on the command line, output a file.v.d dependency file
 
 .SH SEE ALSO
 
@@ -160,6 +162,23 @@ example% coqdep \-I . *.v
 .br
 .ne 7
 .LP
+To output the Coq dependencies directly to files:
+.IP
+.B
+example% coqdep \-I . -with-file-output X.v Y.v Z.v
+.RS
+.sp .5
+.nf
+.fi
+.RE
+.br
+.ne 7
+.LP
+which creates files X.v.d, Y.v.d, and Z.v.d
+.RE
+.br
+.ne 7
+.LP
 With a warning:
 .IP
 .B
@@ -199,5 +218,5 @@ example% coqdep \-c \-I . *.ml
 
 .SH BUGS
 
-Please report any bug to
-.B coq\-bugs@pauillac.inria.fr
+Please report any bugs at
+.B https://www.github.com/coq/coq/issues

--- a/tools/CoqMakefile.in
+++ b/tools/CoqMakefile.in
@@ -363,7 +363,7 @@ post-all::
 	@# Extension point
 .PHONY: post-all
 
-real-all: $(VDFILES) $(VOFILES) $(if $(USEBYTE),bytefiles,optfiles)
+real-all: $(VOFILES) $(if $(USEBYTE),bytefiles,optfiles)
 .PHONY: real-all
 
 real-all.timing.diff: $(VOFILES:.vo=.v.timing.diff)
@@ -533,11 +533,11 @@ clean::
 	$(HIDE)rm -f $(CMOFILES:.cmo=.o)
 	$(HIDE)rm -f $(CMXAFILES:.cmxa=.a)
 	$(HIDE)rm -f $(ALLDFILES)
+	$(HIDE)rm -f .vdfiles
 	$(HIDE)rm -f $(ALLNATIVEFILES)
 	$(HIDE)find . -name .coq-native -type d -empty -delete
 	$(HIDE)rm -f $(VOFILES)
 	$(HIDE)rm -f $(VOFILES:.vo=.vio)
-	$(HIDE)rm -f $(VDFILES) .vdfiles
 	$(HIDE)rm -f $(GFILES)
 	$(HIDE)rm -f $(BEAUTYFILES) $(VFILES:=.old)
 	$(HIDE)rm -f all.ps all-gal.ps all.pdf all-gal.pdf all.glob all-mli.tex

--- a/tools/CoqMakefile.in
+++ b/tools/CoqMakefile.in
@@ -687,6 +687,7 @@ endif
 
 .SECONDARY: $(ALLDFILES)
 
+if_ok = || ( RV=$$?; exit $$RV )
 redir_if_ok = > "$@" || ( RV=$$?; rm -f "$@"; exit $$RV )
 
 $(addsuffix .d,$(MLIFILES)): %.mli.d: %.mli
@@ -709,9 +710,14 @@ $(addsuffix .d,$(MLPACKFILES)): %.mlpack.d: %.mlpack
 	$(SHOW)'COQDEP $<'
 	$(HIDE)$(COQDEP) $(OCAMLLIBS) -c "$<" $(redir_if_ok)
 
-$(addsuffix .d,$(VFILES)): %.v.d: %.v
-	$(SHOW)'COQDEP $<'
-	$(HIDE)$(COQDEP) $(COQLIBS) -dyndep var -c "$<" $(redir_if_ok)
+# .v.d files made from .v files ##############################################
+
+VDFILES=$(addsuffix .d,$(VFILES))
+
+vdfiles: $(VFILES)
+	$(SHOW)'COQDEP $^'
+	$(HIDE)$(COQDEP) $(COQLIBS) -dyndep var -c -with-file-output $^ $(if_ok)
+.PHONY: vdfiles
 
 # Misc ########################################################################
 

--- a/tools/CoqMakefile.in
+++ b/tools/CoqMakefile.in
@@ -687,7 +687,6 @@ endif
 
 .SECONDARY: $(ALLDFILES)
 
-if_ok = || ( RV=$$?; exit $$RV )
 redir_if_ok = > "$@" || ( RV=$$?; rm -f "$@"; exit $$RV )
 
 $(addsuffix .d,$(MLIFILES)): %.mli.d: %.mli
@@ -710,14 +709,13 @@ $(addsuffix .d,$(MLPACKFILES)): %.mlpack.d: %.mlpack
 	$(SHOW)'COQDEP $<'
 	$(HIDE)$(COQDEP) $(OCAMLLIBS) -c "$<" $(redir_if_ok)
 
-# .v.d files made from .v files ##############################################
-
-VDFILES=$(addsuffix .d,$(VFILES))
+# .v.d files made from .v files ###############################################
 
 vdfiles: $(VFILES)
 	$(SHOW)'COQDEP $^'
-	$(HIDE)$(COQDEP) $(COQLIBS) -dyndep var -c -with-file-output $^ $(if_ok)
-.PHONY: vdfiles
+	$(HIDE)$(COQDEP) $(COQLIBS) -dyndep var -c -with-file-output $^
+
+$(addsuffix .d,$(VFILES)): vdfiles
 
 # Misc ########################################################################
 

--- a/tools/CoqMakefile.in
+++ b/tools/CoqMakefile.in
@@ -241,6 +241,7 @@ strip_dotslash = $(patsubst ./%,%,$(1))
 VO = vo
 
 VOFILES = $(VFILES:.v=.$(VO))
+VDFILES = $(addsuffix .d,$(VFILES))
 GLOBFILES = $(VFILES:.v=.glob)
 GFILES = $(VFILES:.v=.g)
 HTMLFILES = $(VFILES:.v=.html)
@@ -362,7 +363,7 @@ post-all::
 	@# Extension point
 .PHONY: post-all
 
-real-all: $(VOFILES) $(if $(USEBYTE),bytefiles,optfiles)
+real-all: $(VDFILES) $(VOFILES) $(if $(USEBYTE),bytefiles,optfiles)
 .PHONY: real-all
 
 real-all.timing.diff: $(VOFILES:.vo=.v.timing.diff)
@@ -536,6 +537,7 @@ clean::
 	$(HIDE)find . -name .coq-native -type d -empty -delete
 	$(HIDE)rm -f $(VOFILES)
 	$(HIDE)rm -f $(VOFILES:.vo=.vio)
+	$(HIDE)rm -f $(VDFILES) .vdfiles
 	$(HIDE)rm -f $(GFILES)
 	$(HIDE)rm -f $(BEAUTYFILES) $(VFILES:=.old)
 	$(HIDE)rm -f all.ps all-gal.ps all.pdf all-gal.pdf all.glob all-mli.tex
@@ -709,13 +711,13 @@ $(addsuffix .d,$(MLPACKFILES)): %.mlpack.d: %.mlpack
 	$(SHOW)'COQDEP $<'
 	$(HIDE)$(COQDEP) $(OCAMLLIBS) -c "$<" $(redir_if_ok)
 
-# .v.d files made from .v files ###############################################
+# timestamp .vdfiles indicates .v.d files already built
 
-vdfiles: $(VFILES)
-	$(SHOW)'COQDEP $^'
-	$(HIDE)$(COQDEP) $(COQLIBS) -dyndep var -c -with-file-output $^
+.vdfiles : $(VFILES)
+	$(SHOW)'COQDEP $(VFILES)'
+	$(HIDE)$(COQDEP) $(COQLIBS) -dyndep var -c -with-file-output $(VFILES) && touch .vdfiles
 
-$(addsuffix .d,$(VFILES)): vdfiles
+$(VDFILES) : .vdfiles
 
 # Misc ########################################################################
 

--- a/tools/coqdep.ml
+++ b/tools/coqdep.ml
@@ -22,6 +22,9 @@ let option_w = ref false
 let option_sort = ref false
 let option_dump = ref None
 
+(** when true, .v files will generate .v.d output *)
+let file_output = ref false
+
 let warning_mult suf iter =
   let tab = Hashtbl.create 151 in
   let check f d =
@@ -241,7 +244,7 @@ struct
       else
         let x = NSet.choose rem in
         let rem = NSet.remove x rem in
-        if NSet.mem x seen then 
+        if NSet.mem x seen then
           aux rem seen
         else
           let seen = NSet.add x seen in
@@ -456,6 +459,7 @@ let usage () =
   eprintf "  -suffix s : \n";
   eprintf "  -slash : deprecated, no effect\n";
   eprintf "  -dyndep (opt|byte|both|no|var) : set how dependencies over ML modules are printed";
+  eprintf "  -with-file-output : for each .v file. write dependency output to a .v.d file";
   exit 1
 
 let split_period = Str.split (Str.regexp (Str.quote "."))
@@ -488,6 +492,7 @@ let rec parse = function
   | "-dyndep" :: "byte" :: ll -> option_dynlink := Byte; parse ll
   | "-dyndep" :: "both" :: ll -> option_dynlink := Both; parse ll
   | "-dyndep" :: "var" :: ll -> option_dynlink := Variable; parse ll
+  | "-with-file-output" :: ll -> file_output := true; parse ll
   | ("-h"|"--help"|"-help") :: _ -> usage ()
   | f :: ll -> treat_file None f; parse ll
   | [] -> ()
@@ -524,7 +529,7 @@ let coqdep () =
   warning_mult ".ml" iter_ml_known;
   if !option_sort then begin sort (); exit 0 end;
   if !option_c && not !option_D then mL_dependencies ();
-  if not !option_D then coq_dependencies ();
+  if not !option_D then coq_dependencies !file_output;
   if !option_w || !option_D then declare_dependencies ();
   begin match !option_dump with
   | None -> ()

--- a/tools/coqdep_boot.ml
+++ b/tools/coqdep_boot.ml
@@ -15,6 +15,9 @@ open Coqdep_common
     options (see for instance [option_natdynlk] below).
 *)
 
+(** when true, .v files will generate .v.d output *)
+let file_output = ref false
+  
 let rec parse = function
   | "-dyndep" :: "no" :: ll -> option_dynlink := No; parse ll
   | "-dyndep" :: "opt" :: ll -> option_dynlink := Opt; parse ll
@@ -31,6 +34,7 @@ let rec parse = function
        add_caml_dir r;
        norec_dirs := StrSet.add r !norec_dirs;
        parse ll
+  | "-with-file-output" :: ll -> file_output := true; parse ll
   | f :: ll -> treat_file None f; parse ll
   | [] -> ()
 
@@ -50,4 +54,4 @@ let _ =
     add_rec_dir_import (fun _ -> add_caml_known) "plugins" ["Coq"];
   end;
   if !option_c then mL_dependencies ();
-  coq_dependencies ()
+  coq_dependencies !file_output

--- a/tools/coqdep_common.ml
+++ b/tools/coqdep_common.ml
@@ -483,7 +483,7 @@ let coq_dependencies file_output =
        let (out_fn,out_ch) =
          if file_output then
            (* Coq filename can't begin with _, so can't clash *)
-           Filename.open_temp_file ~temp_dir:(Filename.dirname absname) "_tmp" vd_sfx
+           Filename.open_temp_file ~temp_dir:(Filename.dirname absname) "_coqdeptmp" vd_sfx
          else
            ("" (* dummy, ignored *),stdout)
        in

--- a/tools/coqdep_common.mli
+++ b/tools/coqdep_common.mli
@@ -47,7 +47,7 @@ val file_name : string -> string option -> string
 val escape : string -> string
 val canonize : string -> string
 val mL_dependencies : unit -> unit
-val coq_dependencies : unit -> unit
+val coq_dependencies : bool -> unit
 val suffixes : 'a list -> 'a list list
 val add_known : bool -> string -> string list -> string -> unit
 val add_coqlib_known : bool -> string -> string list -> string -> unit


### PR DESCRIPTION
This flag takes a comma-delimited list of .v files, and for each file, creates the corresponding .v.d file.

Because coqdep does a traversal of `theories` and `plugins` on each invocation, passing many files in a single invocation should be much faster than calling it many times on a single file.

The main documentation for coqdep appears to be in the man page, I added an example there, though there are other things out of date there.