### PR TITLE
Hack to restore printing of glob_constr in debugger.

### DIFF
--- a/printing/printer.mli
+++ b/printing/printer.mli
@@ -81,11 +81,11 @@ val pr_closed_glob         : closed_glob_constr -> Pp.t
 val pr_ljudge_env          : env -> evar_map -> EConstr.unsafe_judgment -> Pp.t * Pp.t
 val pr_ljudge              : EConstr.unsafe_judgment -> Pp.t * Pp.t
 
-val pr_lglob_constr_env      : env -> glob_constr -> Pp.t
-val pr_lglob_constr          : glob_constr -> Pp.t
+val pr_lglob_constr_env      : env -> 'a glob_constr_g -> Pp.t
+val pr_lglob_constr          : 'a glob_constr_g -> Pp.t
 
-val pr_glob_constr_env       : env -> glob_constr -> Pp.t
-val pr_glob_constr           : glob_constr -> Pp.t
+val pr_glob_constr_env       : env -> 'a glob_constr_g -> Pp.t
+val pr_glob_constr           : 'a glob_constr_g -> Pp.t
 
 val pr_lconstr_pattern_env : env -> evar_map -> constr_pattern -> Pp.t
 val pr_lconstr_pattern     : constr_pattern -> Pp.t


### PR DESCRIPTION
Hi,

After the move of (e.g.) `glob_constr` to `[`any `] glob_constr_g`, the printers for `glob_constr` started to become a bit capricious.

The reason is that `pp_glob_constr` is  registered for `glob_constr_r =  [ ``any ] glob_constr_g` while sometimes, the type infered in the code is more general, namely `'a glob_constr_g` which is not recognized as an instance of `glob_constr`.

I tried to generalize the type of `Printer.pr_glob_constr` and co and it seems to fix the problem. The drawback is however that it makes the `API` a bit more technical, in the sense that we have to explain that there is a phantom variable in the type which is here only for internal implementation reasons.

An alternative would be to define a parallel `Printer.pr_debug_glob_constr` of type `'a glob_constr_g` so as to satisfy the need for an API  not made artificially complicated and the need for a debug printer which works.

Any comments, preference?

(In any case, better not to let this stall.)
