### PR TITLE
Fix printing anomaly in conv

### DIFF
--- a/lib/cErrors.ml
+++ b/lib/cErrors.ml
@@ -91,7 +91,7 @@ let print_backtrace e = match Backtrace.get_backtrace e with
 
 let print_anomaly askreport e =
   if askreport then
-    hov 0 (str "Anomaly" ++ spc () ++ quote (raw_anomaly e) ++ spc ()) ++
+    hov 0 (str "Anomaly" ++ spc () ++ quote (raw_anomaly e)) ++ spc () ++
     hov 0 (str "Please report at " ++ str Coq_config.wwwbugtracker ++ str ".")
   else
     hov 0 (raw_anomaly e)

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -1314,7 +1314,9 @@ let pb_equal = function
   | Reduction.CONV -> Reduction.CONV
 
 let report_anomaly e =
-  let e = UserError (None, Pp.(str "Conversion test raised an anomaly" ++ print e)) in
+  let msg = Pp.(str "Conversion test raised an anomaly:" ++
+                spc () ++ CErrors.print e) in
+  let e = UserError (None,msg) in
   let e = CErrors.push e in
   iraise e
 


### PR DESCRIPTION
This fixes (or more precisely improves) an ill-formatted error message as shown in this [comment](https://github.com/coq/coq/issues/6106#issue-271852409) at PR #6106.

The new proposed message is:
```
Error:
Ltac call to "case (ssrcasearg) (ssrclauses)" failed.
Conversion test raised an anomaly: Universe Top.3 undefined.
```

Note: I removed the "please report" since this anomaly is (on purpose) turned into an error (wouldn't it be left as an anomaly if it was to be reported?). (edited: removal cancelled)

In passing: fixing an apparently misplaced `spc` in the please report message, hoping I'm not breaking other intended behavior.