### PR TITLE
Remove dependency of test-suite on git (fix #5725).

### DIFF
--- a/test-suite/coq-makefile/plugin-reach-outside-API-and-fail/run.sh
+++ b/test-suite/coq-makefile/plugin-reach-outside-API-and-fail/run.sh
@@ -2,8 +2,6 @@
 
 set -e
 
-git clean -dfx
-
 cat > _CoqProject <<EOT
 -I src/
 

--- a/test-suite/coq-makefile/plugin-reach-outside-API-and-succeed-by-bypassing-the-API/run.sh
+++ b/test-suite/coq-makefile/plugin-reach-outside-API-and-succeed-by-bypassing-the-API/run.sh
@@ -2,8 +2,6 @@
 
 set -e
 
-git clean -dfx
-
 cat > _CoqProject <<EOT
 -bypass-API
 -I src/


### PR DESCRIPTION
The two lines that this commit remove are spurious as a `git clean -dfx || true`
is already performed in `test-suite/coq-makefile/template/init.sh`.
While this resolves the accidental dependency on git, I am still unhappy with
this call of `git clean -dfx`.