### PR TITLE
Nix file

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,64 @@
+# How to use?
+
+# If you have Nix installed, you can get in an environment with everything
+# needed to compile Coq and CoqIDE by running:
+# $ nix-shell
+# at the root of the Coq repository.
+
+# How to tweak default arguments?
+
+# nix-shell supports the --arg option (see Nix doc) that allows you for
+# instance to do this:
+# $ nix-shell --arg ocamlPackages "(import <nixpkgs> {}).ocamlPackages_latest" --arg buildIde false
+
+# You can also compile Coq and "install" it by running:
+# $ make clean # (only needed if you have left-over compilation files)
+# $ nix-build
+# at the root of the Coq repository.
+# nix-build also supports the --arg option, so you will be able to do:
+# $ nix-build --arg doCheck false
+# if you want to speed up things by not running the test-suite.
+# Once the build is finished, you will find, in the current directory,
+# a symlink to where Coq was installed.
+
+{ pkgs ? (import <nixpkgs> {}), ocamlPackages ? pkgs.ocamlPackages,
+  buildIde ? true, doCheck ? true }:
+
+with pkgs;
+
+stdenv.mkDerivation rec {
+
+  name = "coq";
+
+  buildInputs = (with ocamlPackages; [
+
+    # Coq dependencies
+    ocaml
+    findlib
+    camlp5_strict
+
+  ]) ++ (if buildIde then [
+
+    # CoqIDE dependencies
+    ocamlPackages.lablgtk
+
+  ] else []) ++ (if doCheck then [
+
+    # Test-suite dependencies
+    python
+    rsync
+    which
+
+  ] else []);
+
+  src =
+    if lib.inNixShell then null
+    else
+      with builtins; filterSource
+        (path: _: !elem (baseNameOf path) [".git" "result" "bin"]) ./.;
+
+  prefixKey = "-prefix ";
+
+  inherit doCheck;
+
+}

--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -174,7 +174,7 @@ summary.log:
 # if not on travis we can get the log files (they're just there for a
 # local build, and downloadable on GitLab)
 report: summary.log
-	$(HIDE)./save-logs.sh
+	$(HIDE)bash save-logs.sh
 	$(HIDE)if [ -n "${TRAVIS}" ]; then find logs/ -name '*.log' -not -name 'summary.log' -exec 'bash' '-c' 'echo "travis_fold:start:coq.logs.$$(echo '{}' | sed s,/,.,g)"' ';' -exec cat '{}' ';' -exec 'bash' '-c' 'echo "travis_fold:end:coq.logs.$$(echo '{}' | sed s,/,.,g)"' ';'; fi
 	$(HIDE)if [ -n "${APPVEYOR}" ]; then find logs/ -name '*.log' -not -name 'summary.log' -exec 'bash' '-c' 'echo {}' ';' -exec cat '{}' ';' -exec 'bash' '-c' 'echo' ';'; fi
 	$(HIDE)if grep -q -F 'Error!' summary.log ; then echo FAILURES; grep -F 'Error!' summary.log; false; else echo NO FAILURES; fi
@@ -528,7 +528,7 @@ coq-makefile/%.log : coq-makefile/%/run.sh
 	$(HIDE)(\
 	  export COQBIN=$(BIN);\
 	  cd coq-makefile/$* && \
-	  ./run.sh 2>&1; \
+	  bash run.sh 2>&1; \
 	if [ $$? = 0 ]; then \
 	    echo $(log_success); \
 	    echo "    $<...Ok"; \

--- a/test-suite/coq-makefile/plugin-reach-outside-API-and-fail/run.sh
+++ b/test-suite/coq-makefile/plugin-reach-outside-API-and-fail/run.sh
@@ -2,8 +2,6 @@
 
 set -e
 
-git clean -dfx
-
 cat > _CoqProject <<EOT
 -I src/
 

--- a/test-suite/coq-makefile/plugin-reach-outside-API-and-succeed-by-bypassing-the-API/run.sh
+++ b/test-suite/coq-makefile/plugin-reach-outside-API-and-succeed-by-bypassing-the-API/run.sh
@@ -2,8 +2,6 @@
 
 set -e
 
-git clean -dfx
-
 cat > _CoqProject <<EOT
 -bypass-API
 -I src/


### PR DESCRIPTION
This introduces a `default.nix` file at the root of the Coq repository.
This file is supposed to allow Nix users to easily get into a shell with all the required dependencies to compile Coq, and also provide a way to build Coq. It could also be used to simplify the Coq derivation in nixpkgs (in particular I looked at https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/science/logic/coq/default.nix and retained some of it but not all; it seems to me that a lot of stuff over there, such as the configure options is outdated).

I thought that this was the right time to share this since there are now several Nix users among the Coq developers (@maximedenes @aspiwack @cmangin and @ejgallego is testing it) and among users (I will only cite maintainers of nixpkgs @vbgl and @jwiegley). I request feedback from all the experienced Nix users.

I encourage reviewers and curious minds to read the comments at the top of the file to get an idea of how it's supposed to work.

If you want to test this file with `nix-build`, I recommend `make clean && nix-build --arg doCheck false` because the test-suite is currently failing because of #5975 (the test-suite is failing when `./configure` is not called with `-local`).