### PR TITLE
Adding a debugging printer for ident maps whose codomain type is unknown

### DIFF
--- a/dev/db
+++ b/dev/db
@@ -68,5 +68,6 @@ install_printer Top_printers.ppist
 install_printer Top_printers.ppconstrunderbindersidmap
 install_printer Top_printers.ppunbound_ltac_var_map
 install_printer Top_printers.ppididmap
+install_printer Top_printers.ppidmapgen
 install_printer Top_printers.ppclosure
 install_printer Top_printers.ppclosedglobconstr

--- a/dev/top_printers.ml
+++ b/dev/top_printers.ml
@@ -85,8 +85,13 @@ let prset' pr l = str "[" ++ hov 0 (prlist_with_sep pr_comma pr l) ++ str "]"
 let pridmap pr l =
   let pr (id,b) = Id.print id ++ str "=>" ++ pr id b in
   prset' pr (Id.Map.fold (fun a b l -> (a,b)::l) l [])
-
 let ppidmap pr l = pp (pridmap pr l)
+
+let pridmapgen l =
+  let dom = Id.Set.elements (Id.Map.domain l) in
+  if dom = [] then str "[]" else
+  str "[domain= " ++ hov 0 (prlist_with_sep spc Id.print dom) ++ str "]"
+let ppidmapgen l = pp (pridmapgen l)
 
 let ppevarsubst = ppidmap (fun id0 -> prset (fun (c,copt,id) ->
   hov 0


### PR DESCRIPTION
This fixes a long-standing problem with printing maps in the debugger.

Actually, ocaml is apparently doing well. If there is a printer for 'a Id.Map.t and another for say Id.t Id.Map.id, it uses the most recent defined existing ones, so, it is apparently not a problem to have overlapping printer.

Example:
```ocaml
let f (a,b) = let f (a,b) = print_int a;;
let g (a,b) = print_int b;;
let h (a,b) = print_int (a+b);;
#install_printer f;;
#install_printer g;;
(1,2);; (* 2 *)
#install_printer f;;
(1,2);; (* 1 *)
("1",2);; (* 2 *)
#install_printer h;;           
(1,2);; (* 3 *)
```