### PR TITLE
Fix ci-bignums.sh "missing ]" error.

### DIFF
--- a/dev/ci/ci-bignums.sh
+++ b/dev/ci/ci-bignums.sh
@@ -4,7 +4,7 @@ ci_dir="$(dirname "$0")"
 
 # This script could be included inside other ones
 # Let's avoid to source ci-common twice in this case
-if [ -z "${CI_BUILD_DIR}"];
+if [ -z "${CI_BUILD_DIR}" ];
 then
     source ${ci_dir}/ci-common.sh
 fi


### PR DESCRIPTION
It made the test always fail so ci-common was always sourced. It's not
quite idempotent as it adds COQBIN to PATH but it didn't lead to CI failure.