### PR TITLE
Interpreting a casted term in the scope bound to its type if any

### DIFF
--- a/doc/changelog/03-notations/6134-master+type-scope-cast.rst
+++ b/doc/changelog/03-notations/6134-master+type-scope-cast.rst
@@ -1,0 +1,10 @@
+- **Changed:**
+  In casts like :g:`term : t` where :g:`t` is bound to some
+  scope :g:`t_scope`, via :cmd:`Bind Scope`, the :g:`term` is now
+  interpreted in scope :g:`t_scope`. In particular when :g:`t`
+  is :g:`Type` the :g:`term` is interpreted in :g:`type_scope`
+  and when :g:`t` is a product the :g:`term` is interpreted
+  in :g:`fun_scope`
+  (`#6134 <https://github.com/coq/coq/pull/6134>`_,
+  fixes `#14959 <https://github.com/coq/coq/issues/14959>`_,
+  by Hugo Herbelin, reviewed by Maxime Dénès, Jim Fehrle, Emilio Gallego, Gaëtan Gilbert, Jason Gross, Pierre-Marie Pédrot, Pierre Roux, Bas Spitters and Théo Zimmermann).

--- a/doc/sphinx/language/core/definitions.rst
+++ b/doc/sphinx/language/core/definitions.rst
@@ -57,6 +57,9 @@ to type check that :n:`@term10` has type :n:`@type` (see :tacn:`native_compute`)
 :n:`@type` without leaving a trace in the produced value.
 This is a :gdef:`volatile cast`.
 
+If a scope is :ref:`bound <LocalInterpretationRulesForNotations>` to
+:n:`@type` then :n:`@term10` is interpreted in that scope.
+
 .. _gallina-definitions:
 
 Top-level definitions

--- a/doc/sphinx/user-extensions/syntax-extensions.rst
+++ b/doc/sphinx/user-extensions/syntax-extensions.rst
@@ -1590,6 +1590,9 @@ Binding types or coercion classes to notation scopes
    then :g:`a` of type :g:`t` in :g:`f t a` is not recognized as an argument to
    be interpreted in scope ``scope``.
 
+   In explicit :ref:`casts <type-cast>` :n:`@term : @coercion_class`, the :n:`term`
+   is interpreted in the :token:`scope_name` associated with :n:`@coercion_class`.
+
    This command supports the :attr:`local`, :attr:`global`,
    :attr:`add_top` and :attr:`add_bottom` attributes.
 
@@ -1651,6 +1654,14 @@ Binding types or coercion classes to notation scopes
       .. coqtop:: all
 
          About f.
+
+      Bindings are also used in casts.
+
+      .. coqtop:: all
+
+         Close Scope F_scope.
+         Check #.
+         Check # : bool.
 
       .. note:: Such stacks of scopes can be handy to share notations
          between multiple types. For instance, the scope ``T_scope``

--- a/interp/constrexpr_ops.ml
+++ b/interp/constrexpr_ops.ml
@@ -684,3 +684,6 @@ let rec coerce_to_cases_pattern_expr c = CAst.map_with_loc (fun ?loc -> function
   | CArray _ ->
     CErrors.user_err ?loc
                       (str "Arrays in patterns not supported.")) c
+
+let isCSort a =
+  match a.CAst.v with Constrexpr.CSort _ -> true | _ -> false

--- a/interp/constrexpr_ops.mli
+++ b/interp/constrexpr_ops.mli
@@ -113,6 +113,8 @@ val map_constr_expr_with_binders :
   (Id.t -> 'a -> 'a) -> ('a -> constr_expr -> constr_expr) ->
       'a -> constr_expr -> constr_expr
 
+(** {6 Miscellaneous}*)
+
 val replace_vars_constr_expr :
   Id.t Id.Map.t -> constr_expr -> constr_expr
 
@@ -126,6 +128,8 @@ val split_at_annot : local_binder_expr list -> lident option -> local_binder_exp
 
 val ntn_loc : ?loc:Loc.t -> constr_notation_substitution -> notation -> (int * int) list
 val patntn_loc : ?loc:Loc.t -> cases_pattern_notation_substitution -> notation -> (int * int) list
+
+val isCSort : constr_expr -> bool
 
 (** For cases pattern parsing errors *)
 val error_invalid_pattern_notation : ?loc:Loc.t -> unit -> 'a

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -1062,7 +1062,9 @@ let rec extern inctx ?impargs scopes vars r =
   | GGenarg arg -> CGenargGlob arg
 
   | GCast (c, k, c') ->
-    CCast (sub_extern true scopes vars c, k, extern_typ scopes vars c')
+    let c' = extern_typ scopes vars c' in
+    let c = if isCSort c' then extern_typ scopes vars c else sub_extern true scopes vars c in
+    CCast (c, k, c')
 
   | GInt i ->
      extern_prim_token_delimiter_if_required

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -1062,8 +1062,9 @@ let rec extern inctx ?impargs scopes vars r =
   | GGenarg arg -> CGenargGlob arg
 
   | GCast (c, k, c') ->
+    let scl = Notation.compute_glob_type_scope c' in
     let c' = extern_typ scopes vars c' in
-    let c = if isCSort c' then extern_typ scopes vars c else sub_extern true scopes vars c in
+    let c = extern true (fst scopes,(scl, snd (snd scopes))) vars c in
     CCast (c, k, c')
 
   | GInt i ->

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -594,11 +594,11 @@ let intern_letin_binder intern ntnvars env (({loc;v=na} as locna),def,ty) =
    (na,term,ty))
 
 let intern_cases_pattern_as_binder intern test_kind ntnvars env bk (CAst.{v=p;loc} as pv) =
-  let p,t = match p with
-  | CPatCast (p, t) -> (p, Some t)
-  | _ -> (pv, None) in
+  let p,t,tmp_scope = match p with
+  | CPatCast (p, t) -> (p, Some t, (* Redone later, not nice: *) Notation.compute_glob_type_scope (intern (set_type_scope env) t))
+  | _ -> (pv, None, []) in
   let il,disjpat =
-    let (il, subst_disjpat) = !intern_cases_pattern_fwd test_kind ntnvars (env_for_pattern (reset_tmp_scope env)) p in
+    let (il, subst_disjpat) = !intern_cases_pattern_fwd test_kind ntnvars (env_for_pattern {env with tmp_scope}) p in
     let substl,disjpat = List.split subst_disjpat in
     if not (List.for_all (fun subst -> Id.Map.equal Id.equal subst Id.Map.empty) substl) then
       user_err ?loc (str "Unsupported nested \"as\" clause.");

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -2390,9 +2390,12 @@ let internalize globalenv env pattern_mode (_, ntnvars as lvar) c =
         DAst.make ?loc @@
         GSort (intern_sort ~local_univs:env.local_univs s)
     | CCast (c1, k, c2) ->
-        let c1 = if isCSort c2 then intern_type env c1 else intern env c1 in
+        let c2 = intern_type (slide_binders env) c2 in
+        let sc = Notation.compute_glob_type_scope c2 in
+        let env' = {env with tmp_scope = sc @ env.tmp_scope} in
+        let c1 = intern env' c1 in
         DAst.make ?loc @@
-        GCast (c1, k, intern_type (slide_binders env) c2)
+        GCast (c1, k, c2)
     | CArray(u,t,def,ty) ->
       DAst.make ?loc @@ GArray(intern_instance ~local_univs:env.local_univs u, Array.map (intern env) t, intern env def, intern env ty)
     )

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -2390,8 +2390,9 @@ let internalize globalenv env pattern_mode (_, ntnvars as lvar) c =
         DAst.make ?loc @@
         GSort (intern_sort ~local_univs:env.local_univs s)
     | CCast (c1, k, c2) ->
+        let c1 = if isCSort c2 then intern_type env c1 else intern env c1 in
         DAst.make ?loc @@
-        GCast (intern env c1, k, intern_type (slide_binders env) c2)
+        GCast (c1, k, intern_type (slide_binders env) c2)
     | CArray(u,t,def,ty) ->
       DAst.make ?loc @@ GArray(intern_instance ~local_univs:env.local_univs u, Array.map (intern env) t, intern env def, intern env ty)
     )

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -1841,6 +1841,9 @@ let compute_type_scope env sigma t =
 let current_type_scope_names () =
    find_scope_class_opt !scope_class_map (Some CL_SORT)
 
+let compute_glob_type_scope t =
+  find_scope_class_opt !scope_class_map (try Some (find_class_glob_type t) with Not_found -> None)
+
 let scope_class_of_class (x : cl_typ) : scope_class =
   x
 

--- a/interp/notation.mli
+++ b/interp/notation.mli
@@ -308,6 +308,7 @@ val declare_ref_arguments_scope : GlobRef.t -> unit
 
 val compute_arguments_scope : Environ.env -> Evd.evar_map -> EConstr.types -> scope_name list list
 val compute_type_scope : Environ.env -> Evd.evar_map -> EConstr.types -> scope_name list
+val compute_glob_type_scope : 'a Glob_term.glob_constr_g -> scope_name list
 
 (** Get the current scopes bound to Sortclass *)
 val current_type_scope_names : unit -> scope_name list

--- a/pretyping/coercionops.ml
+++ b/pretyping/coercionops.ml
@@ -176,6 +176,17 @@ let find_class_type env sigma t =
     | Sort _ -> CL_SORT, EInstance.empty, []
     |  _ -> raise Not_found
 
+let class_of_global_reference = function
+  | GlobRef.VarRef id -> CL_SECVAR id
+  | GlobRef.ConstRef kn -> CL_CONST kn
+  | GlobRef.IndRef ind -> CL_IND ind
+  | GlobRef.ConstructRef _ -> raise Not_found
+
+let find_class_glob_type c = match DAst.get c with
+  | Glob_term.GRef (ref,_) -> class_of_global_reference ref
+  | Glob_term.GProd _ -> CL_FUN
+  | Glob_term.GSort _ -> CL_SORT
+  |  _ -> raise Not_found
 
 let subst_cl_typ env subst ct = match ct with
     CL_SORT

--- a/pretyping/coercionops.mli
+++ b/pretyping/coercionops.mli
@@ -61,6 +61,8 @@ val class_nparams : cl_typ -> int
     its universe instance and its arguments *)
 val find_class_type : env -> evar_map -> types -> cl_typ * EInstance.t * constr list
 
+val find_class_glob_type : 'a Glob_term.glob_constr_g -> cl_typ
+
 (** raises [Not_found] if not convertible to a class *)
 val class_of : env -> evar_map -> types -> types * cl_typ
 

--- a/test-suite/output/NNumberSyntax.out
+++ b/test-suite/output/NNumberSyntax.out
@@ -20,67 +20,67 @@ fun x : positive => (N.pos x~0 + 0)%N
      : N
 N.of_nat 0 = 0%N
      : Prop
-0%N : N
+0%N
      : N
-1%N : N
+1%N
      : N
-2%N : N
+2%N
      : N
-255%N : N
+255%N
      : N
-255%N : N
+255%N
      : N
-0%N : N
+0%N
      : N
-1%N : N
+1%N
      : N
-2%N : N
+2%N
      : N
-255%N : N
+255%N
      : N
-255%N : N
-     : N
-0x2a
-     : N
-0x0
+255%N
      : N
 0x2a
      : N
 0x0
      : N
-0x0 : N
+0x2a
      : N
-0x1 : N
+0x0
      : N
-0x2 : N
+0x0
      : N
-0xff : N
+0x1
      : N
-0xff : N
+0x2
      : N
-0x0 : N
+0xff
      : N
-0x0 : N
+0xff
      : N
-0x1 : N
+0x0
      : N
-0x2 : N
+0x0
      : N
-0xff : N
+0x1
      : N
-0xff : N
+0x2
      : N
-0x0 : N
+0xff
      : N
-0x0 : N
+0xff
      : N
-0x1 : N
+0x0
      : N
-0x2 : N
+0x0
      : N
-0xff : N
+0x1
      : N
-0xff : N
+0x2
+     : N
+0xff
+     : N
+0xff
      : N
 (0 + N.of_nat 11)%N
      : N

--- a/test-suite/output/NNumberSyntax.v
+++ b/test-suite/output/NNumberSyntax.v
@@ -10,16 +10,16 @@ Check (fun x : positive => (Npos (xO x) + 0)%N).
 Check (N.of_nat 0 + 1)%N.
 Check (0 + N.of_nat (0 + 0))%N.
 Check (N.of_nat 0 = 0%N).
-Check 0x00%N : N.
-Check 0x01%N : N.
-Check 0x02%N : N.
-Check 0xff%N : N.
-Check 0xFF%N : N.
-Check 0x00%xN : N.
-Check 0x01%xN : N.
-Check 0x02%xN : N.
-Check 0xff%xN : N.
-Check 0xFF%xN : N.
+Check 0x00%N.
+Check 0x01%N.
+Check 0x02%N.
+Check 0xff%N.
+Check 0xFF%N.
+Check 0x00%xN.
+Check 0x01%xN.
+Check 0x02%xN.
+Check 0xff%xN.
+Check 0xFF%xN.
 
 (* Check hexadecimal printing *)
 Open Scope hex_N_scope.
@@ -27,23 +27,23 @@ Check 42%N.
 Check 0%N.
 Check 42%xN.
 Check 0%xN.
-Check 0x00%N : N.
-Check 0x01%N : N.
-Check 0x02%N : N.
-Check 0xff%N : N.
-Check 0xFF%N : N.
-Check 0x0%xN : N.
-Check 0x00%xN : N.
-Check 0x01%xN : N.
-Check 0x02%xN : N.
-Check 0xff%xN : N.
-Check 0xFF%xN : N.
-Check 0x0 : N.
-Check 0x00 : N.
-Check 0x01 : N.
-Check 0x02 : N.
-Check 0xff : N.
-Check 0xFF : N.
+Check 0x00%N.
+Check 0x01%N.
+Check 0x02%N.
+Check 0xff%N.
+Check 0xFF%N.
+Check 0x0%xN.
+Check 0x00%xN.
+Check 0x01%xN.
+Check 0x02%xN.
+Check 0xff%xN.
+Check 0xFF%xN.
+Check 0x0.
+Check 0x00.
+Check 0x01.
+Check 0x02.
+Check 0xff.
+Check 0xFF.
 Close Scope hex_N_scope.
 
 Require Import Arith.

--- a/test-suite/output/PosSyntax.out
+++ b/test-suite/output/PosSyntax.out
@@ -29,21 +29,21 @@ Cannot interpret this number as a value of type positive
 File "./output/PosSyntax.v", line 15, characters 11-15:
 The command has indeed failed with message:
 Cannot interpret this number as a value of type positive
-1%positive : positive
+1%positive
      : positive
-2%positive : positive
+2%positive
      : positive
-255%positive : positive
+255%positive
      : positive
-255%positive : positive
+255%positive
      : positive
-1%positive : positive
+1%positive
      : positive
-2%positive : positive
+2%positive
      : positive
-255%positive : positive
+255%positive
      : positive
-255%positive : positive
+255%positive
      : positive
 0x2a
      : positive
@@ -55,13 +55,13 @@ Cannot interpret this number as a value of type positive
 File "./output/PosSyntax.v", line 30, characters 11-15:
 The command has indeed failed with message:
 Cannot interpret this number as a value of type positive
-0x1 : positive
+0x1
      : positive
-0x2 : positive
+0x2
      : positive
-0xff : positive
+0xff
      : positive
-0xff : positive
+0xff
      : positive
 File "./output/PosSyntax.v", line 35, characters 11-14:
 The command has indeed failed with message:
@@ -69,13 +69,13 @@ Cannot interpret this number as a value of type positive
 File "./output/PosSyntax.v", line 36, characters 11-15:
 The command has indeed failed with message:
 Cannot interpret this number as a value of type positive
-0x1 : positive
+0x1
      : positive
-0x2 : positive
+0x2
      : positive
-0xff : positive
+0xff
      : positive
-0xff : positive
+0xff
      : positive
 File "./output/PosSyntax.v", line 41, characters 11-14:
 The command has indeed failed with message:
@@ -83,13 +83,13 @@ Cannot interpret this number as a value of type positive
 File "./output/PosSyntax.v", line 42, characters 11-15:
 The command has indeed failed with message:
 Cannot interpret this number as a value of type positive
-0x1 : positive
+0x1
      : positive
-0x2 : positive
+0x2
      : positive
-0xff : positive
+0xff
      : positive
-0xff : positive
+0xff
      : positive
 (1 + Pos.of_nat 11)%positive
      : positive

--- a/test-suite/output/PosSyntax.v
+++ b/test-suite/output/PosSyntax.v
@@ -10,40 +10,40 @@ Check (fun x : positive => (xO x + 1)%positive).
 Check (Pos.of_nat 0 + 1)%positive.
 Check (1 + Pos.of_nat (0 + 0))%positive.
 Check (Pos.of_nat 1 = 1%positive).
-Fail Check 0%positive : positive.
-Fail Check 0x0%positive : positive.
-Fail Check 0x00%positive : positive.
-Check 0x01%positive : positive.
-Check 0x02%positive : positive.
-Check 0xff%positive : positive.
-Check 0xFF%positive : positive.
-Check 0x01%xpositive : positive.
-Check 0x02%xpositive : positive.
-Check 0xff%xpositive : positive.
-Check 0xFF%xpositive : positive.
+Fail Check 0%positive.
+Fail Check 0x0%positive.
+Fail Check 0x00%positive.
+Check 0x01%positive.
+Check 0x02%positive.
+Check 0xff%positive.
+Check 0xFF%positive.
+Check 0x01%xpositive.
+Check 0x02%xpositive.
+Check 0xff%xpositive.
+Check 0xFF%xpositive.
 
 (* Check hexadecimal printing *)
 Open Scope hex_positive_scope.
 Check 42%positive.
 Check 1%positive.
-Fail Check 0x0%positive : positive.
-Fail Check 0x00%positive : positive.
-Check 0x01%positive : positive.
-Check 0x02%positive : positive.
-Check 0xff%positive : positive.
-Check 0xFF%positive : positive.
-Fail Check 0x0 : positive.
-Fail Check 0x00 : positive.
-Check 0x01 : positive.
-Check 0x02 : positive.
-Check 0xff : positive.
-Check 0xFF : positive.
-Fail Check 0x0%xpositive : positive.
-Fail Check 0x00%xpositive : positive.
-Check 0x01%xpositive : positive.
-Check 0x02%xpositive : positive.
-Check 0xff%xpositive : positive.
-Check 0xFF%xpositive : positive.
+Fail Check 0x0%positive.
+Fail Check 0x00%positive.
+Check 0x01%positive.
+Check 0x02%positive.
+Check 0xff%positive.
+Check 0xFF%positive.
+Fail Check 0x0.
+Fail Check 0x00.
+Check 0x01.
+Check 0x02.
+Check 0xff.
+Check 0xFF.
+Fail Check 0x0%xpositive.
+Fail Check 0x00%xpositive.
+Check 0x01%xpositive.
+Check 0x02%xpositive.
+Check 0xff%xpositive.
+Check 0xFF%xpositive.
 Close Scope hex_positive_scope.
 
 Require Import Arith.

--- a/test-suite/output/TermSyntax.out
+++ b/test-suite/output/TermSyntax.out
@@ -1,2 +1,6 @@
 nat * nat : Type
      : Type
+0 * 0 : nat
+     : nat
+0 * 0 : Z
+     : Z

--- a/test-suite/output/TermSyntax.out
+++ b/test-suite/output/TermSyntax.out
@@ -4,3 +4,8 @@ nat * nat : Type
      : nat
 0 * 0 : Z
      : Z
+File "./output/TermSyntax.v", line 11, characters 16-21:
+The command has indeed failed with message:
+Unknown interpretation for notation "{ _ ; _ }".
+λ '(exist _ x _), x
+     : b → bool

--- a/test-suite/output/TermSyntax.out
+++ b/test-suite/output/TermSyntax.out
@@ -1,0 +1,2 @@
+nat * nat : Type
+     : Type

--- a/test-suite/output/TermSyntax.v
+++ b/test-suite/output/TermSyntax.v
@@ -1,0 +1,2 @@
+(* Check Type cast setting type_scope *)
+Check nat * nat : Type.

--- a/test-suite/output/TermSyntax.v
+++ b/test-suite/output/TermSyntax.v
@@ -3,3 +3,11 @@ Check nat * nat : Type.
 Check 0 * 0 : nat.
 Require Import ZArith.
 Check 0 * 0 : Z.
+
+Declare Scope b_scope.
+Definition b := {x:bool|x=true}.
+Notation "{ x ; y }" := (exist _ x y) : b_scope.
+Require Import Utf8.
+Fail Check λ '({x;y}:b), x.
+Bind Scope b_scope with b.
+Check λ '({x;y}:b), x.

--- a/test-suite/output/TermSyntax.v
+++ b/test-suite/output/TermSyntax.v
@@ -1,2 +1,5 @@
-(* Check Type cast setting type_scope *)
+(* Check cast setting scopes *)
 Check nat * nat : Type.
+Check 0 * 0 : nat.
+Require Import ZArith.
+Check 0 * 0 : Z.

--- a/test-suite/output/ZNumberSyntax.out
+++ b/test-suite/output/ZNumberSyntax.out
@@ -24,59 +24,53 @@ fun x : positive => (- Z.pos x~0 + 0)%Z
      : Z
 Z.of_nat 0 = 0%Z
      : Prop
-0%Z : Z
+0%Z
      : Z
-0%Z : Z
+0%Z
      : Z
-1%Z : Z
+1%Z
      : Z
-2%Z : Z
+2%Z
      : Z
-255%Z : Z
+255%Z
      : Z
-255%Z : Z
+255%Z
      : Z
-(- 0)%Z : Z
+(- 0)%Z
      : Z
-(- 0)%Z : Z
+(- 0)%Z
      : Z
-(-1)%Z : Z
+(-1)%Z
      : Z
-(-2)%Z : Z
+(-2)%Z
      : Z
-(-255)%Z : Z
+(-255)%Z
      : Z
-(-255)%Z : Z
+(-255)%Z
      : Z
-0%Z : Z
+0%Z
      : Z
-0%Z : Z
+0%Z
      : Z
-1%Z : Z
+1%Z
      : Z
-2%Z : Z
+2%Z
      : Z
-255%Z : Z
+255%Z
      : Z
-255%Z : Z
+255%Z
      : Z
-(- 0)%Z : Z
+(- 0)%Z
      : Z
-(- 0)%Z : Z
+(- 0)%Z
      : Z
-(-1)%Z : Z
+(-1)%Z
      : Z
-(-2)%Z : Z
+(-2)%Z
      : Z
-(-255)%Z : Z
+(-255)%Z
      : Z
-(-255)%Z : Z
-     : Z
-0x2a
-     : Z
--0x2a
-     : Z
-0x0
+(-255)%Z
      : Z
 0x2a
      : Z
@@ -84,65 +78,71 @@ Z.of_nat 0 = 0%Z
      : Z
 0x0
      : Z
-0x0 : Z
+0x2a
      : Z
-0x0 : Z
+-0x2a
      : Z
-0x1 : Z
+0x0
      : Z
-0x2 : Z
+0x0
      : Z
-0xff : Z
+0x0
      : Z
-0xff : Z
+0x1
      : Z
-(- 0)%Z : Z
+0x2
      : Z
-(- 0)%Z : Z
+0xff
      : Z
--0x1 : Z
+0xff
      : Z
--0x2 : Z
+(- 0)%Z
      : Z
--0xff : Z
+(- 0)%Z
      : Z
--0xff : Z
+-0x1
      : Z
-0x0 : Z
+-0x2
      : Z
-0x0 : Z
+-0xff
      : Z
-0x1 : Z
+-0xff
      : Z
-0x2 : Z
+0x0
      : Z
-0xff : Z
+0x0
      : Z
-0xff : Z
+0x1
      : Z
-0x0 : Z
+0x2
      : Z
-0x0 : Z
+0xff
      : Z
-0x1 : Z
+0xff
      : Z
-0x2 : Z
+0x0
      : Z
-0xff : Z
+0x0
      : Z
-0xff : Z
+0x1
      : Z
-(- 0)%Z : Z
+0x2
      : Z
-(- 0)%Z : Z
+0xff
      : Z
--0x1 : Z
+0xff
      : Z
--0x2 : Z
+(- 0)%Z
      : Z
--0xff : Z
+(- 0)%Z
      : Z
--0xff : Z
+-0x1
+     : Z
+-0x2
+     : Z
+-0xff
+     : Z
+-0xff
      : Z
 (0 + Z.of_nat 11)%Z
      : Z

--- a/test-suite/output/ZNumberSyntax.v
+++ b/test-suite/output/ZNumberSyntax.v
@@ -12,30 +12,30 @@ Check (fun x : positive => (- Zpos (xO x) + 0)%Z).
 Check (Z.of_nat 0 + 1)%Z.
 Check (0 + Z.of_nat (0 + 0))%Z.
 Check (Z.of_nat 0 = 0%Z).
-Check 0x0%Z : Z.
-Check 0x00%Z : Z.
-Check 0x01%Z : Z.
-Check 0x02%Z : Z.
-Check 0xff%Z : Z.
-Check 0xFF%Z : Z.
-Check (-0x0)%Z : Z.
-Check (-0x00)%Z : Z.
-Check (-0x01)%Z : Z.
-Check (-0x02)%Z : Z.
-Check (-0xff)%Z : Z.
-Check (-0xFF)%Z : Z.
-Check 0x0%xZ : Z.
-Check 0x00%xZ : Z.
-Check 0x01%xZ : Z.
-Check 0x02%xZ : Z.
-Check 0xff%xZ : Z.
-Check 0xFF%xZ : Z.
-Check (-0x0)%xZ%Z : Z.
-Check (-0x00)%xZ%Z : Z.
-Check (-0x01)%xZ : Z.
-Check (-0x02)%xZ : Z.
-Check (-0xff)%xZ : Z.
-Check (-0xFF)%xZ : Z.
+Check 0x0%Z.
+Check 0x00%Z.
+Check 0x01%Z.
+Check 0x02%Z.
+Check 0xff%Z.
+Check 0xFF%Z.
+Check (-0x0)%Z.
+Check (-0x00)%Z.
+Check (-0x01)%Z.
+Check (-0x02)%Z.
+Check (-0xff)%Z.
+Check (-0xFF)%Z.
+Check 0x0%xZ.
+Check 0x00%xZ.
+Check 0x01%xZ.
+Check 0x02%xZ.
+Check 0xff%xZ.
+Check 0xFF%xZ.
+Check (-0x0)%xZ%Z.
+Check (-0x00)%xZ%Z.
+Check (-0x01)%xZ.
+Check (-0x02)%xZ.
+Check (-0xff)%xZ.
+Check (-0xFF)%xZ.
 
 (* Check hexadecimal printing *)
 Open Scope hex_Z_scope.
@@ -45,36 +45,36 @@ Check 0%Z.
 Check 42%xZ.
 Check (-42)%xZ.
 Check 0%xZ.
-Check 0x0%Z : Z.
-Check 0x00%Z : Z.
-Check 0x01%Z : Z.
-Check 0x02%Z : Z.
-Check 0xff%Z : Z.
-Check 0xFF%Z : Z.
-Check (-0x0)%Z : Z.
-Check (-0x00)%Z : Z.
-Check (-0x01)%Z : Z.
-Check (-0x02)%Z : Z.
-Check (-0xff)%Z : Z.
-Check (-0xFF)%Z : Z.
-Check 0x0 : Z.
-Check 0x00 : Z.
-Check 0x01 : Z.
-Check 0x02 : Z.
-Check 0xff : Z.
-Check 0xFF : Z.
-Check 0x0%xZ : Z.
-Check 0x00%xZ : Z.
-Check 0x01%xZ : Z.
-Check 0x02%xZ : Z.
-Check 0xff%xZ : Z.
-Check 0xFF%xZ : Z.
-Check (-0x0)%xZ%Z : Z.
-Check (-0x00)%xZ%Z : Z.
-Check (-0x01)%xZ : Z.
-Check (-0x02)%xZ : Z.
-Check (-0xff)%xZ : Z.
-Check (-0xFF)%xZ : Z.
+Check 0x0%Z.
+Check 0x00%Z.
+Check 0x01%Z.
+Check 0x02%Z.
+Check 0xff%Z.
+Check 0xFF%Z.
+Check (-0x0)%Z.
+Check (-0x00)%Z.
+Check (-0x01)%Z.
+Check (-0x02)%Z.
+Check (-0xff)%Z.
+Check (-0xFF)%Z.
+Check 0x0.
+Check 0x00.
+Check 0x01.
+Check 0x02.
+Check 0xff.
+Check 0xFF.
+Check 0x0%xZ.
+Check 0x00%xZ.
+Check 0x01%xZ.
+Check 0x02%xZ.
+Check 0xff%xZ.
+Check 0xFF%xZ.
+Check (-0x0)%xZ%Z.
+Check (-0x00)%xZ%Z.
+Check (-0x01)%xZ.
+Check (-0x02)%xZ.
+Check (-0xff)%xZ.
+Check (-0xFF)%xZ.
 Close Scope hex_Z_scope.
 
 (* Submitted by Pierre Casteran *)

--- a/theories/ssr/ssreflect.v
+++ b/theories/ssr/ssreflect.v
@@ -101,7 +101,6 @@ Export SsrSyntax.
 Local Notation CoqGenericIf c vT vF := (if c then vT else vF) (only parsing).
 Local Notation CoqGenericDependentIf c x R vT vF :=
   (if c as x return R then vT else vF) (only parsing).
-Local Notation CoqCast x T := (x : T) (only parsing).
 
 (** Reserve notation that introduced in this file. **)
 Reserved Notation "'if' c 'then' vT 'else' vF" (at level 200,
@@ -110,9 +109,6 @@ Reserved Notation "'if' c 'return' R 'then' vT 'else' vF" (at level 200,
   c, R, vT, vF at level 200).
 Reserved Notation "'if' c 'as' x 'return' R 'then' vT 'else' vF" (at level 200,
   c, R, vT, vF at level 200, x name).
-
-Reserved Notation "T : 'Type'" (at level 100, format "T  :  'Type'").
-Reserved Notation "P : 'Prop'" (at level 100, format "P  :  'Prop'").
 
 Reserved Notation "[ 'the' sT 'of' v 'by' f ]" (at level 0,
   format "[ 'the'  sT  'of'  v  'by'  f ]").
@@ -181,14 +177,6 @@ Open Scope boolean_if_scope.
 Declare Scope form_scope.
 Delimit Scope form_scope with FORM.
 Open Scope form_scope.
-
-(**
- Allow the casual use of notations like nat * nat for explicit Type
- declarations. Note that (nat * nat : Type) is NOT equivalent to
- (nat * nat)%%type, whose inferred type is legacy type "Set".                **)
-Notation "T : 'Type'" := (CoqCast T%type Type) (only parsing) : core_scope.
-(**  Allow similarly Prop annotation for, e.g., rewrite multirules. **)
-Notation "P : 'Prop'" := (CoqCast P%type Prop) (only parsing) : core_scope.
 
 (**  Constants for abstract: and #[#: name #]# intro pattern  **)
 Definition abstract_lock := unit.


### PR DESCRIPTION
This is a proposal in relation to the discussion at #6078.

It proceeds in several steps depending on taste:
- setting `type_scope` when casted by a sort
- removal of the then-redundant vernac-level notation casts in `ssreflect.v`
- interpreting any term casted with a type bound to a scope in this scope
- a start at interpreting any pattern casted with a type bound to a scope in this scope, as also discussed at #6078.

There are more to do about the last step but that will become easier in the context of the more regular parsing of patterns in #982.

Note 1: I have a terminology question: how to call the `bind` in `Option`? In which order should be its arguments? (I tentatively called it `compose`.)
Note 2 : This PR depends on #6133 (replaced by #18031) and ~#982 (merged)~ shall depend on it for interpreting casts in 
patterns.

Fixes: #14959 

#### Overlays (to be merged before the current PR)

- [x] https://github.com/coq-community/corn/pull/199
- [x] https://github.com/coq-community/math-classes/pull/118