### PR TITLE
Change OCAMLRUNPARAM warning to mention OCaml 4.06

### DIFF
--- a/dev/doc/debugging.md
+++ b/dev/doc/debugging.md
@@ -54,9 +54,10 @@ Debugging from Caml debugger
      of each of error* functions or anomaly* functions in lib/util.ml
    - If "source db" fails, do a "make printers" and try again (it should build
      top_printers.cmo and the core cma files).
-   - If you have the OCAMLRUNPARAM environment variable set, Coq may hang on
-     startup when run from the debugger. If this happens, unset the variable,
-     re-start Emacs, and run the debugger again.
+   - If you build Coq with an OCaml version earlier than 4.06, and have the 
+     OCAMLRUNPARAM environment variable set, Coq may hang on startup when run 
+     from the debugger. If this happens, unset the variable, re-start Emacs, and 
+     run the debugger again.
 
 Global gprof-based profiling
 ============================


### PR DESCRIPTION
This is a re-submit (and update) of #1098, because git did not do what I expected, creating a mess.

The update is that instead of removing the warning, we mention that OCaml 4.06 avoids the problem. We can mention that, because #6045 will allow Coq to be built with 4.06.

I'm not putting the "independent fix needed" label, because 4.06 has been released now.
