### PR TITLE
Get all coqdep_boot in one go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -260,6 +260,7 @@ ml4clean:
 
 depclean:
 	find . $(FIND_SKIP_DIRS) '(' -name '*.d' ')' -print | xargs rm -f
+	rm -f .vdfiles
 
 cacheclean:
 	find theories plugins test-suite -name '.*.aux' -delete

--- a/Makefile.build
+++ b/Makefile.build
@@ -753,12 +753,15 @@ endif
 	$(SHOW)PYTHON TIMING-DIFF $<
 	$(HIDE)$(MAKE) --no-print-directory print-pretty-single-time-diff BEFORE=$*.v.before-timing AFTER=$*.v.after-timing TIME_OF_PRETTY_BUILD_FILE="$@"
 
-
 # Dependencies of .v files
 
-%.v.d: $(D_DEPEND_BEFORE_SRC) %.v $(D_DEPEND_AFTER_SRC) $(COQDEPBOOT)
-	$(SHOW)'COQDEP    $<'
-	$(HIDE)$(COQDEPBOOT) -boot $(DYNDEP) "$<" $(TOTARGET)
+# timestamp .vdfiles says all .v.d files built
+.vdfiles: $(COQDEPBOOT) $(VFILES)
+	$(SHOW)'COQDEP $(VFILES)'
+	$(HIDE)$(COQDEPBOOT) -boot $(DYNDEP) -with-file-output $(VFILES) && touch .vdfiles
+
+$(addsuffix .d,$(VFILES)): .vdfiles
+	@true # without something here, falls into catch-all rule below
 
 ###########################################################################
 


### PR DESCRIPTION
When building Coq, use the `-with-file-output` feature of `coqdep_boot` introduced in #6099 to get all `.v.d` files in one go.

On my laptop, that saves around 9 seconds. Not a lot, but many people build Coq many times, so it adds up.

#6099 is not yet merged, so this has to wait on that.