### PR TITLE
[dev] Remove deprecation warning from `base_include`

### DIFF
--- a/dev/base_include
+++ b/dev/base_include
@@ -231,7 +231,7 @@ let pf_e gl s =
 let _ = Flags.in_debugger := false
 let _ = Flags.in_toplevel := true
 let _ = Constrextern.set_extern_reference
-  (fun ?loc _ r -> Libnames.Qualid (loc,Nametab.shortest_qualid_of_global Idset.empty r));;
+  (fun ?loc _ r -> Libnames.Qualid (loc,Nametab.shortest_qualid_of_global Id.Set.empty r));;
 
 let go () = Coqloop.loop Option.(get !Coqtop.drop_last_doc)
 


### PR DESCRIPTION
The warning created problems as OCaml restored the color printing tags
when printing it, so users doing `Drop` and then `go ()` got color
printing back after the warning.

We should guard the console on `Drop` better, but this requires some
(much needed) refactoring work in the toplevel.