### PR TITLE
Fixing factorization of recursive notations with an atomic separator

### DIFF
--- a/parsing/egramcoq.ml
+++ b/parsing/egramcoq.ml
@@ -259,9 +259,11 @@ let is_binder_level from e = match e with
 | (NumLevel 200, (BorderProd (Right, _) | InternalProd)) -> from = 200
 | _ -> false
 
-let make_sep_rules tkl =
-  let rec mkrule : Tok.t list -> unit rules = function
-  | [] -> Rules ({ norec_rule = Stop }, ignore)
+let make_sep_rules = function
+  | [tk] -> Atoken tk
+  | tkl ->
+  let rec mkrule : Tok.t list -> string rules = function
+  | [] -> Rules ({ norec_rule = Stop }, fun _ -> (* dropped anyway: *) "")
   | tkn :: rem ->
     let Rules ({ norec_rule = r }, f) = mkrule rem in
     let r = { norec_rule = Next (r, Atoken tkn) } in

--- a/test-suite/success/Notations2.v
+++ b/test-suite/success/Notations2.v
@@ -96,3 +96,12 @@ Check fun A (x :prod' bool A) => match x with ##### 0 _ y 0%bool => 2 | _ => 1 e
 
 Notation "'FUNNAT' i => t" := (fun i : nat => i = t) (at level 200).
 Notation "'Funnat' i => t" := (FUNNAT i => t + i%nat) (at level 200).
+
+(* 11. Notations with needed factorization of a recursive pattern *)
+(* See https://github.com/coq/coq/issues/6078#issuecomment-342287412 *)
+Module A.
+Notation "[:: x1 ; .. ; xn & s ]" := (cons x1 .. (cons xn s) ..).
+Notation "[:: x1 ; .. ; xn ]" := (cons x1 .. (cons xn nil) ..).
+Check [:: 1 ; 2 ; 3 ].
+Check [:: 1 ; 2 ; 3 & nil ]. (* was failing *)
+End A.


### PR DESCRIPTION
Hi,

This is a partial fix to one of the Coq/Camlp5 grammar limitations found in math-comp `seq.v` (see discussion at the third paragraph [here](https://github.com/coq/coq/issues/6078#issuecomment-342208528) and an answer [here](https://github.com/coq/coq/issues/6078#issuecomment-342287412)). A reduced instance of the problem is:
```
Notation "[:: x1 # .. # xn & s ]" := (cons x1 .. (cons xn s) ..).
Notation "[:: x1 # .. # xn ]" := (cons x1 .. (cons xn nil) ..).
```
where the two rules are not factorized by camlp5, as shown by:
```
Check [:: 1 # 2 # 3 ]. (* Succeed *)
Check [:: 1 # 2 # 3 & nil ]. (* Fail *)
```
Internally, this is due to the separator `"#"` being represented as a Camlp5 rule `[ () = "#" -> () ]` and the factorization not being done on rules in Camlp5. Even if the rule is here degenerated, a rule contains an arbitrary function so two rules could not be compared easily.

When the separator is a single token, the encoding via a rule is not needed, and the factorization can happen. This is what this PR implements.

In the general case, i.e. when there are several tokens in the separator, the trick does not work. To avoid using a rule, @roglo suggests that we hide the list of tokens behind a new entry name. But I let this to someone wishing to improve his/her Camlp5 kung-fu.

Note in passing that I changed the type of the output of `Atoken` from `string` to `unit`, which seems to be consistent with the fact that a terminal has no information (and returns a `unit`). @ppedrot, I hope I did not misunderstand something.

(Edited for typos.)