### PR TITLE
Add Equations to CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -284,6 +284,9 @@ ci-coquelicot:
     <<: *ci-template-vars
     EXTRA_PACKAGES: "$TIMING_PACKAGES autoconf"
 
+ci-equations:
+  <<: *ci-template
+
 ci-geocoq:
   <<: *ci-template
   allow_failure: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,7 @@ env:
   - TEST_TARGET="ci-compcert TIMED=1"
   - TEST_TARGET="ci-coq-dpdgraph" EXTRA_OPAM="ocamlgraph"
   - TEST_TARGET="ci-coquelicot TIMED=1"
+  - TEST_TARGET="ci-equations TIMED=1"
   - TEST_TARGET="ci-geocoq TIMED=1"
   - TEST_TARGET="ci-fiat-crypto TIMED=1"
   - TEST_TARGET="ci-fiat-parsers TIMED=1"

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -5,6 +5,7 @@ CI_TARGETS=ci-all \
     ci-coq-dpdgraph \
     ci-coquelicot \
     ci-cpdt \
+    ci-equations \
     ci-fiat-crypto \
     ci-fiat-parsers \
     ci-flocq \

--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -135,3 +135,9 @@
 ########################################################################
 : ${bignums_CI_BRANCH:=master}
 : ${bignums_CI_GITURL:=https://github.com/coq/bignums.git}
+
+########################################################################
+# Equations
+########################################################################
+: ${Equations_CI_BRANCH:=8.8+alpha}
+: ${Equations_CI_GITURL:=https://github.com/mattam82/Coq-Equations.git}

--- a/dev/ci/ci-equations.sh
+++ b/dev/ci/ci-equations.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+ci_dir="$(dirname "$0")"
+source ${ci_dir}/ci-common.sh
+
+Equations_CI_DIR=${CI_BUILD_DIR}/Equations
+
+git_checkout ${Equations_CI_BRANCH} ${Equations_CI_GITURL} ${Equations_CI_DIR}
+
+( cd ${Equations_CI_DIR} && coq_makefile -f _CoqProject -o Makefile && make -j ${NJOBS} && make -j ${NJOBS} test-suite && make -j ${NJOBS} examples && make install)


### PR DESCRIPTION
Title says it all, this adds the 8.8+alpha branch of Equations (following Coq's master branch) to the CI targets. Compilation generates quite a few deprecation warnings I plan to fix soon, it's not a showstopper I hope?