### PR TITLE
[proof] Removal of global proof state.

### DIFF
--- a/coqpp/coqpp_ast.mli
+++ b/coqpp/coqpp_ast.mli
@@ -103,6 +103,7 @@ type classification =
 
 type vernac_rule = {
   vernac_atts : (string * string) list option;
+  vernac_state: string option;
   vernac_toks : ext_token list;
   vernac_class : code option;
   vernac_depr : bool;

--- a/coqpp/coqpp_lex.mll
+++ b/coqpp/coqpp_lex.mll
@@ -130,6 +130,7 @@ rule extend = parse
 | space { extend lexbuf }
 | '\"' { string lexbuf }
 | '\n' { newline lexbuf; extend lexbuf }
+| "![" { BANGBRACKET }
 | "#[" { HASHBRACKET }
 | '[' { LBRACKET }
 | ']' { RBRACKET }

--- a/coqpp/coqpp_main.ml
+++ b/coqpp/coqpp_main.ml
@@ -347,9 +347,18 @@ let print_atts_right fmt = function
     let nota = match atts with [_] -> "" | _ -> "Attributes.Notations." in
     fprintf fmt "(Attributes.parse %s%a atts)" nota aux atts
 
+let print_body_wrapper fmt r =
+  match r.vernac_state with
+  | Some "proof" ->
+    fprintf fmt "let proof = (%a) ~pstate:st.Vernacstate.proof in { st with Vernacstate.proof }" print_code r.vernac_body
+  | None ->
+    fprintf fmt "let () = %a in st" print_code r.vernac_body
+  | Some x ->
+    fatal ("unsupported state specifier: " ^ x)
+
 let print_body_fun fmt r =
-  fprintf fmt "let coqpp_body %a%a ~st = let () = %a in st in "
-    print_binders r.vernac_toks print_atts_left r.vernac_atts print_code r.vernac_body
+  fprintf fmt "let coqpp_body %a%a ~st = @[%a@] in "
+    print_binders r.vernac_toks print_atts_left r.vernac_atts print_body_wrapper r
 
 let print_body fmt r =
   fprintf fmt "@[(%afun %a~atts@ ~st@ -> coqpp_body %a%a ~st)@]"

--- a/coqpp/coqpp_parse.mly
+++ b/coqpp/coqpp_parse.mly
@@ -65,7 +65,7 @@ let parse_user_entry s sep =
 %token VERNAC TACTIC GRAMMAR EXTEND END DECLARE PLUGIN DEPRECATED ARGUMENT
 %token RAW_PRINTED GLOB_PRINTED
 %token COMMAND CLASSIFIED PRINTED TYPED INTERPRETED GLOBALIZED SUBSTITUTED BY AS
-%token HASHBRACKET LBRACKET RBRACKET PIPE ARROW FUN COMMA EQUAL STAR
+%token BANGBRACKET HASHBRACKET LBRACKET RBRACKET PIPE ARROW FUN COMMA EQUAL STAR
 %token LPAREN RPAREN COLON SEMICOLON
 %token GLOBAL FIRST LAST BEFORE AFTER LEVEL LEFTA RIGHTA NONA
 %token EOF
@@ -209,13 +209,14 @@ vernac_rules:
 ;
 
 vernac_rule:
-| PIPE vernac_attributes_opt LBRACKET ext_tokens RBRACKET rule_deprecation rule_classifier ARROW CODE
+| PIPE vernac_attributes_opt vernac_state_opt LBRACKET ext_tokens RBRACKET rule_deprecation rule_classifier ARROW CODE
   { {
       vernac_atts = $2;
-      vernac_toks = $4;
-      vernac_depr = $6;
-      vernac_class= $7;
-      vernac_body = $9;
+      vernac_state= $3;
+      vernac_toks = $5;
+      vernac_depr = $7;
+      vernac_class= $8;
+      vernac_body = $10;
   } }
 ;
 
@@ -234,6 +235,14 @@ vernac_attribute:
 | qualid_or_ident EQUAL qualid_or_ident { ($1, $3) }
 | qualid_or_ident { ($1, $1) }
 ;
+
+vernac_state_opt:
+| { None }
+| BANGBRACKET vernac_state RBRACKET { Some $2 }
+;
+
+vernac_state:
+| qualid_or_ident { $1 }
 
 rule_deprecation:
 | { false }

--- a/plugins/btauto/refl_btauto.ml
+++ b/plugins/btauto/refl_btauto.ml
@@ -195,7 +195,7 @@ module Btauto = struct
         let assign = List.combine env var in
         let map_msg (key, v) =
           let b = if v then str "true" else str "false" in
-          let sigma, env = Pfedit.get_current_context () in
+          let sigma, env = Tacmach.project gl, Tacmach.pf_env gl in
           let term = Printer.pr_constr_env env sigma key in
           term ++ spc () ++ str ":=" ++ spc () ++ b
         in

--- a/plugins/cc/ccalgo.ml
+++ b/plugins/cc/ccalgo.ml
@@ -27,7 +27,8 @@ let init_size=5
 let cc_verbose=ref false
 
 let print_constr t =
-  let sigma, env = Pfedit.get_current_context () in
+  let env = Global.env () in
+  let sigma = Evd.from_env env in
   Printer.pr_econstr_env env sigma t
 
 let debug x =

--- a/plugins/cc/ccalgo.mli
+++ b/plugins/cc/ccalgo.mli
@@ -255,5 +255,3 @@ val find_contradiction : UF.t ->
   (Names.Id.t * (int * int)) list ->
   (Names.Id.t * (int * int))
 *)
-
-

--- a/plugins/ltac/extraargs.mlg
+++ b/plugins/ltac/extraargs.mlg
@@ -147,8 +147,10 @@ let pr_occurrences = pr_occurrences () () ()
 
 let pr_gen prc _prlc _prtac c = prc c
 
+let gcc () = let env = Global.env () in Evd.from_env env, env
+
 let pr_globc _prc _prlc _prtac (_,glob) =
-  let _, env = Pfedit.get_current_context () in
+  let _, env = gcc () in
   Printer.pr_glob_constr_env env glob
 
 let interp_glob ist gl (t,_) = Tacmach.project gl , (ist,t)

--- a/plugins/ltac/extratactics.mlg
+++ b/plugins/ltac/extratactics.mlg
@@ -910,9 +910,9 @@ END
    the semantics of the LCF-style tactics, hence with the classic tactic
    mode. *)
 VERNAC COMMAND EXTEND GrabEvars
-| [ "Grab" "Existential" "Variables" ]
+| ![ proof ] [ "Grab" "Existential" "Variables" ]
   => { classify_as_proofstep }
-  -> { Proof_global.simple_with_current_proof (fun _ p  -> Proof.V82.grab_evars p) }
+  -> { fun ~pstate -> Option.map (Proof_global.simple_with_current_proof (fun _ p  -> Proof.V82.grab_evars p)) pstate }
 END
 
 (* Shelves all the goals under focus. *)
@@ -942,9 +942,9 @@ END
 
 (* Command to add every unshelved variables to the focus *)
 VERNAC COMMAND EXTEND Unshelve
-| [ "Unshelve" ]
+| ![ proof ] [ "Unshelve" ]
   => { classify_as_proofstep }
-  -> { Proof_global.simple_with_current_proof (fun _ p  -> Proof.unshelve p) }
+  -> { fun ~pstate -> Option.map (Proof_global.simple_with_current_proof (fun _ p  -> Proof.unshelve p)) pstate  }
 END
 
 (* Gives up on the goals under focus: the goals are considered solved,
@@ -1095,8 +1095,8 @@ END
 
 
 VERNAC COMMAND EXTEND OptimizeProof
-| [ "Optimize" "Proof" ] => { classify_as_proofstep } ->
-  { Proof_global.compact_the_proof () }
+| ![ proof ] [ "Optimize" "Proof" ] => { classify_as_proofstep } ->
+  { fun ~pstate -> Option.map Proof_global.compact_the_proof pstate }
 | [ "Optimize" "Heap" ] => { classify_as_proofstep } ->
   { Gc.compact () }
 END

--- a/plugins/ltac/g_auto.mlg
+++ b/plugins/ltac/g_auto.mlg
@@ -61,12 +61,17 @@ let eval_uconstrs ist cs =
   let map c env sigma = c env sigma in
   List.map (fun c -> map (Tacinterp.type_uconstr ~flags ist c)) cs
 
+
+let gcc () = let env = Global.env () in Evd.from_env env, env
+
 let pr_auto_using_raw _ _ _  = Pptactic.pr_auto_using Ppconstr.pr_constr_expr
+
 let pr_auto_using_glob _ _ _ = Pptactic.pr_auto_using (fun (c,_) ->
-    let _, env = Pfedit.get_current_context () in
+    let _, env = gcc () in
     Printer.pr_glob_constr_env env c)
+
 let pr_auto_using _ _ _ = Pptactic.pr_auto_using
-    (let sigma, env = Pfedit.get_current_context () in
+    (let sigma, env = gcc () in
      Printer.pr_closed_glob_env env sigma)
 
 }

--- a/plugins/ltac/g_ltac.mlg
+++ b/plugins/ltac/g_ltac.mlg
@@ -381,9 +381,10 @@ let _ = declare_int_option {
   optwrite = fun n -> print_info_trace := n;
 }
 
-let vernac_solve n info tcom b =
+let vernac_solve ~pstate n info tcom b =
   let open Goal_select in
-  let status = Proof_global.with_current_proof (fun etac p ->
+  Option.map ( fun pstate ->
+  let pstate, status = Proof_global.with_current_proof (fun etac p ->
     let with_end_tac = if b then Some etac else None in
     let global = match n with SelectAll | SelectList _ -> true | _ -> false in
     let info = Option.append info !print_info_trace in
@@ -393,8 +394,9 @@ let vernac_solve n info tcom b =
     (* in case a strict subtree was completed,
        go back to the top of the prooftree *)
     let p = Proof.maximal_unfocus Vernacentries.command_focus p in
-    p,status) in
-    if not status then Feedback.feedback Feedback.AddedAxiom
+    p,status) pstate in
+  if not status then Feedback.feedback Feedback.AddedAxiom;
+  pstate) pstate
 
 let pr_ltac_selector s = Pptactic.pr_goal_selector ~toplevel:true s
 
@@ -441,12 +443,12 @@ let is_explicit_terminator = function TacSolve _ -> true | _ -> false
 }
 
 VERNAC { tactic_mode } EXTEND VernacSolve
-| [ ltac_selector_opt(g) ltac_info_opt(n) tactic(t) ltac_use_default(def) ] =>
+| ![ proof ] [ ltac_selector_opt(g) ltac_info_opt(n) tactic(t) ltac_use_default(def) ] =>
     { classify_as_proofstep } -> {
     let g = Option.default (Goal_select.get_default_goal_selector ()) g in
     vernac_solve g n t def
   }
-| [ "par" ":" ltac_info_opt(n) tactic(t) ltac_use_default(def) ] =>
+| ![ proof ] [ "par" ":" ltac_info_opt(n) tactic(t) ltac_use_default(def) ] =>
     {
       let anon_abstracting_tac = is_anonymous_abstract t in
       let solving_tac = is_explicit_terminator t in

--- a/plugins/ltac/g_obligations.mlg
+++ b/plugins/ltac/g_obligations.mlg
@@ -80,8 +80,9 @@ GRAMMAR EXTEND Gram
 
 open Obligations
 
-let obligation obl tac = with_tac (fun t -> Obligations.obligation obl t) tac
-let next_obligation obl tac = with_tac (fun t -> Obligations.next_obligation obl t) tac
+(* XXX: Proof_global.t *)
+let obligation obl tac = with_tac (fun t -> ignore(Obligations.obligation obl t)) tac
+let next_obligation obl tac = with_tac (fun t -> ignore(Obligations.next_obligation obl t)) tac
 
 let classify_obbl _ = Vernacextend.(VtStartProof ("Classic",Doesn'tGuaranteeOpacity,[]), VtLater)
 

--- a/plugins/ltac/g_rewrite.mlg
+++ b/plugins/ltac/g_rewrite.mlg
@@ -40,11 +40,13 @@ type constr_expr_with_bindings = constr_expr with_bindings
 type glob_constr_with_bindings = Tacexpr.glob_constr_and_expr with_bindings
 type glob_constr_with_bindings_sign = interp_sign * Tacexpr.glob_constr_and_expr with_bindings
 
+let gcc () = let env = Global.env () in Evd.from_env env, env
+
 let pr_glob_constr_with_bindings_sign _ _ _ (ge : glob_constr_with_bindings_sign) =
-  let _, env = Pfedit.get_current_context () in
+  let _, env = gcc () in
   Printer.pr_glob_constr_env env (fst (fst (snd ge)))
 let pr_glob_constr_with_bindings _ _ _ (ge : glob_constr_with_bindings) =
-  let _, env = Pfedit.get_current_context () in
+  let _, env = gcc () in
   Printer.pr_glob_constr_env env (fst (fst ge))
 let pr_constr_expr_with_bindings prc _ _ (ge : constr_expr_with_bindings) = prc (fst ge)
 let interp_glob_constr_with_bindings ist gl c = Tacmach.project gl , (ist, c)
@@ -281,18 +283,18 @@ VERNAC COMMAND EXTEND AddSetoid1 CLASSIFIED AS SIDEFF
     (* This command may or may not open a goal *)
     => { VtUnknown, VtNow }
     -> {
-           add_morphism_infer atts m n;
+           (* add_morphism_infer atts m n; *) ()
        }
   | #[ atts = rewrite_attributes; ] [ "Add" "Morphism" constr(m) "with" "signature" lconstr(s) "as" ident(n) ]
     => { VtStartProof("Classic",GuaranteesOpacity,[n]), VtLater }
     -> {
-           add_morphism atts [] m s n;
+           (* add_morphism atts [] m s n; *) ()
        }
   | #[ atts = rewrite_attributes; ] [ "Add" "Parametric" "Morphism" binders(binders) ":" constr(m)
         "with" "signature" lconstr(s) "as" ident(n) ]
     => { VtStartProof("Classic",GuaranteesOpacity,[n]), VtLater }
     -> {
-           add_morphism atts binders m s n;
+          (* add_morphism atts binders m s n; *) ()
        }
 END
 
@@ -312,6 +314,6 @@ END
 
 VERNAC COMMAND EXTEND PrintRewriteHintDb CLASSIFIED AS QUERY
 | [ "Print" "Rewrite" "HintDb" preident(s) ] ->
-  { let sigma, env = Pfedit.get_current_context () in
+  { let sigma, env = gcc () in
     Feedback.msg_notice (Autorewrite.print_rewrite_hintdb env sigma s) }
 END

--- a/plugins/ltac/pptactic.ml
+++ b/plugins/ltac/pptactic.ml
@@ -1303,13 +1303,12 @@ let lift_top f a = Genprint.TopPrinterBasic (fun () -> f a)
 let register_basic_print0 wit f g h =
   Genprint.register_print0 wit (lift f) (lift g) (lift_top h)
 
-
 let pr_glob_constr_pptac c =
-  let _, env = Pfedit.get_current_context () in
+  let env = Global.env () in
   pr_glob_constr_env env c
 
 let pr_lglob_constr_pptac c =
-  let _, env = Pfedit.get_current_context () in
+  let env = Global.env () in
   pr_lglob_constr_env env c
 
 let () =

--- a/plugins/ltac/rewrite.mli
+++ b/plugins/ltac/rewrite.mli
@@ -88,7 +88,7 @@ val add_setoid :
   rewrite_attributes -> local_binder_expr list -> constr_expr -> constr_expr -> constr_expr ->
   Id.t -> unit
 
-val add_morphism_infer : rewrite_attributes -> constr_expr -> Id.t -> unit
+val add_morphism_infer : ?ontop:Proof_global.t -> rewrite_attributes -> constr_expr -> Id.t -> Proof_global.t option
 
 val add_morphism :
   rewrite_attributes -> local_binder_expr list -> constr_expr -> constr_expr -> Id.t -> unit

--- a/plugins/ltac/tactic_debug.ml
+++ b/plugins/ltac/tactic_debug.ml
@@ -15,6 +15,8 @@ open Tacexpr
 
 let (ltac_trace_info : ltac_trace Exninfo.t) = Exninfo.make ()
 
+let get_current_context () = let env = Global.env () in Evd.from_env env, env
+
 let prtac x =
   Pptactic.pr_glob_tactic (Global.env()) x
 let prmatchpatt env sigma hyp =
@@ -22,7 +24,7 @@ let prmatchpatt env sigma hyp =
 let prmatchrl rl =
   Pptactic.pr_match_rule false (Pptactic.pr_glob_tactic (Global.env()))
     (fun (_,p) ->
-       let sigma, env = Pfedit.get_current_context () in
+       let sigma, env = get_current_context () in
        Printer.pr_constr_pattern_env env sigma p) rl
 
 (* This module intends to be a beginning of debugger for tactic expressions.
@@ -372,7 +374,7 @@ let explain_ltac_call_trace last trace loc =
           strbrk " (with " ++
             prlist_with_sep pr_comma
             (fun (id,c) ->
-              let sigma, env = Pfedit.get_current_context () in
+              let sigma, env = get_current_context () in
               Id.print id ++ str ":=" ++ Printer.pr_lconstr_under_binders_env env sigma c)
             (List.rev (Id.Map.bindings vars)) ++ str ")"
         else mt())

--- a/plugins/syntax/numeral.ml
+++ b/plugins/syntax/numeral.ml
@@ -59,7 +59,9 @@ let locate_int () =
     int = locate_ind q_int }
 
 let has_type f ty =
-  let (sigma, env) = Pfedit.get_current_context () in
+  (* This shouldn't take the context from the proof *)
+  let env = Global.env () in
+  let sigma = Evd.from_env env in
   let c = mkCastC (mkRefC f, Glob_term.CastConv ty) in
   try let _ = Constrintern.interp_constr env sigma c in true
   with Pretype_errors.PretypeError _ -> false

--- a/printing/proof_diffs.ml
+++ b/printing/proof_diffs.ml
@@ -532,7 +532,7 @@ let match_goals ot nt =
 
 let get_proof_context (p : Proof.t) =
   let goals, _, _, _, sigma = Proof.proof p in
-  sigma, Refiner.pf_env { it = List.(hd goals); sigma }
+  sigma, Refiner.pf_env { Evd.it = List.(hd goals); sigma }
 
 let to_constr pf =
   let open CAst in

--- a/printing/proof_diffs.ml
+++ b/printing/proof_diffs.ml
@@ -530,13 +530,16 @@ let match_goals ot nt =
   | None -> ());
   !nevar_to_oevar
 
+let get_proof_context (p : Proof.t) =
+  let goals, _, _, _, sigma = Proof.proof p in
+  sigma, Refiner.pf_env { it = List.(hd goals); sigma }
 
-let to_constr p =
+let to_constr pf =
   let open CAst in
-  let pprf = Proof.partial_proof p in
+  let pprf = Proof.partial_proof pf in
   (* pprf generally has only one element, but it may have more in the derive plugin *)
   let t = List.hd pprf in
-  let sigma, env = Pfedit.get_current_context ~p () in
+  let sigma, env = get_proof_context pf in
   let x = Constrextern.extern_constr false env sigma t in  (* todo: right options?? *)
   x.v
 

--- a/proofs/pfedit.mli
+++ b/proofs/pfedit.mli
@@ -16,34 +16,32 @@ open Environ
 open Decl_kinds
 
 (** {6 ... } *)
+
 (** [get_goal_context n] returns the context of the [n]th subgoal of
    the current focused proof or raises a [UserError] if there is no
    focused proof or if there is no more subgoals *)
 
-val get_goal_context : int -> Evd.evar_map * env
+val get_goal_context : Proof_global.t -> int -> Evd.evar_map * env
 
 (** [get_current_goal_context ()] works as [get_goal_context 1] *)
-
-val get_current_goal_context : unit -> Evd.evar_map * env
+val get_current_goal_context : Proof_global.t -> Evd.evar_map * env
 
 (** [get_current_context ()] returns the context of the
   current focused goal. If there is no focused goal but there
   is a proof in progress, it returns the corresponding evar_map.
   If there is no pending proof then it returns the current global
   environment and empty evar_map. *)
-
-val get_current_context : ?p:Proof.t -> unit -> Evd.evar_map * env
+val get_current_context : Proof_global.t -> Evd.evar_map * env
 
 (** [current_proof_statement] *)
 
 val current_proof_statement :
-  unit -> Id.t * goal_kind * EConstr.types
+  Proof_global.t -> Id.t * goal_kind * EConstr.types
 
 (** {6 ... } *)
 
 (** [solve (SelectNth n) tac] applies tactic [tac] to the [n]th
-    subgoal of the current focused proof or raises a [UserError] if no
-    proof is focused or if there is no [n]th subgoal. [solve SelectAll
+    subgoal of the current focused proof. [solve SelectAll
     tac] applies [tac] to all subgoals. *)
 
 val solve : ?with_end_tac:unit Proofview.tactic ->
@@ -51,11 +49,10 @@ val solve : ?with_end_tac:unit Proofview.tactic ->
       Proof.t -> Proof.t * bool
 
 (** [by tac] applies tactic [tac] to the 1st subgoal of the current
-    focused proof or raises a UserError if there is no focused proof or
-    if there is no more subgoals.
+    focused proof.
     Returns [false] if an unsafe tactic has been used. *)
 
-val by : unit Proofview.tactic -> bool
+val by : unit Proofview.tactic -> Proof_global.t -> Proof_global.t * bool
 
 (** Option telling if unification heuristics should be used. *)
 val use_unification_heuristics : unit -> bool
@@ -65,7 +62,7 @@ val use_unification_heuristics : unit -> bool
    UserError if no proof is focused or if there is no such [n]th
    existential variable *)
 
-val instantiate_nth_evar_com : int -> Constrexpr.constr_expr -> unit
+val instantiate_nth_evar_com : int -> Constrexpr.constr_expr -> Proof_global.t -> Proof_global.t
 
 (** [build_by_tactic typ tac] returns a term of type [typ] by calling
     [tac]. The return boolean, if [false] indicates the use of an unsafe

--- a/proofs/proof_global.mli
+++ b/proofs/proof_global.mli
@@ -14,22 +14,14 @@
 
 type t
 
-val there_are_pending_proofs : unit -> bool
-val check_no_pending_proof : unit -> unit
+val get_current_proof_name : t -> Names.Id.t
+val get_all_proof_names : t -> Names.Id.t list
 
-val get_current_proof_name : unit -> Names.Id.t
-val get_all_proof_names : unit -> Names.Id.t list
+val discard : Names.lident -> t -> t option
+val discard_current : t -> t option
 
-val discard : Names.lident -> unit
-val discard_current : unit -> unit
-val discard_all : unit -> unit
-
-val give_me_the_proof_opt : unit -> Proof.t option
-exception NoCurrentProof
-val give_me_the_proof : unit -> Proof.t
-(** @raise NoCurrentProof when outside proof mode. *)
-
-val compact_the_proof : unit -> unit
+val give_me_the_proof : t -> Proof.t
+val compact_the_proof : t -> t
 
 (** When a proof is closed, it is reified into a [proof_object], where
     [id] is the name of the proof, [entries] the list of the proof terms
@@ -60,7 +52,7 @@ type closed_proof = proof_object * proof_terminator
 val make_terminator : (proof_ending -> unit) -> proof_terminator
 val apply_terminator : proof_terminator -> proof_ending -> unit
 
-(** [start_proof id str pl goals terminator] starts a proof of name
+(** [start_proof ?ontop id str pl goals terminator] starts a proof of name
    [id] with goals [goals] (a list of pairs of environment and
    conclusion); [str] describes what kind of theorem/definition this
    is; [terminator] is used at the end of the proof to close the proof
@@ -68,25 +60,25 @@ val apply_terminator : proof_terminator -> proof_ending -> unit
    morphism). The proof is started in the evar map [sigma] (which can
    typically contain universe constraints), and with universe bindings
    pl. *)
-val start_proof :
+val start_proof : ?ontop:t ->
   Evd.evar_map -> Names.Id.t -> ?pl:UState.universe_decl ->
   Decl_kinds.goal_kind -> (Environ.env * EConstr.types) list  ->
-    proof_terminator -> unit
+    proof_terminator -> t
 
 (** Like [start_proof] except that there may be dependencies between
     initial goals. *)
-val start_dependent_proof :
+val start_dependent_proof : ?ontop:t ->
   Names.Id.t -> ?pl:UState.universe_decl -> Decl_kinds.goal_kind ->
-  Proofview.telescope -> proof_terminator -> unit
+  Proofview.telescope -> proof_terminator -> t
 
 (** Update the proofs global environment after a side-effecting command
   (e.g. a sublemma definition) has been run inside it. Assumes
   there_are_pending_proofs. *)
-val update_global_env : unit -> unit
+val update_global_env : t -> t
 
 (* Takes a function to add to the exceptions data relative to the
    state in which the proof was built *)
-val close_proof : keep_body_ucst_separate:bool -> Future.fix_exn -> closed_proof
+val close_proof : keep_body_ucst_separate:bool -> Future.fix_exn -> t -> closed_proof
 
 (* Intermediate step necessary to delegate the future.
  * Both access the current proof state. The former is supposed to be
@@ -96,50 +88,44 @@ type closed_proof_output = (Constr.t * Safe_typing.private_constants) list * USt
 
 (* If allow_partial is set (default no) then an incomplete proof
  * is allowed (no error), and a warn is given if the proof is complete. *)
-val return_proof : ?allow_partial:bool -> unit -> closed_proof_output
-val close_future_proof : feedback_id:Stateid.t ->
+val return_proof : ?allow_partial:bool -> t -> closed_proof_output
+val close_future_proof : feedback_id:Stateid.t -> t ->
   closed_proof_output Future.computation -> closed_proof
 
 (** Gets the current terminator without checking that the proof has
     been completed. Useful for the likes of [Admitted]. *)
-val get_terminator : unit -> proof_terminator
-val set_terminator : proof_terminator -> unit
-
-exception NoSuchProof
-
-val get_open_goals : unit -> int
+val get_terminator : t -> proof_terminator
+val set_terminator : proof_terminator -> t -> t
+val get_open_goals : t -> int
 
 (** Runs a tactic on the current proof. Raises [NoCurrentProof] is there is
     no current proof.
     The return boolean is set to [false] if an unsafe tactic has been used. *)
 val with_current_proof :
-  (unit Proofview.tactic -> Proof.t -> Proof.t * 'a) -> 'a
+  (unit Proofview.tactic -> Proof.t -> Proof.t * 'a) -> t -> t * 'a
 val simple_with_current_proof :
-  (unit Proofview.tactic -> Proof.t -> Proof.t) -> unit
+  (unit Proofview.tactic -> Proof.t -> Proof.t) -> t -> t
 
 (** Sets the tactic to be used when a tactic line is closed with [...] *)
-val set_endline_tactic : Genarg.glob_generic_argument -> unit
+val set_endline_tactic : Genarg.glob_generic_argument -> t -> t
 
 (** Sets the section variables assumed by the proof, returns its closure
  * (w.r.t. type dependencies and let-ins covered by it) + a list of
  * ids to be cleared *)
-val set_used_variables :
-  Names.Id.t list -> Constr.named_context * Names.lident list
-val get_used_variables : unit -> Constr.named_context option
+val set_used_variables : t ->
+  Names.Id.t list -> Constr.named_context * Names.lident list * t
+
+val get_used_variables : t -> Constr.named_context option
 
 (** Get the universe declaration associated to the current proof. *)
-val get_universe_decl : unit -> UState.universe_decl
+val get_universe_decl : t -> UState.universe_decl
 
 module V82 : sig
-  val get_current_initial_conclusions : unit -> Names.Id.t *(EConstr.types list *
-  Decl_kinds.goal_kind)
+  val get_current_initial_conclusions : t -> Names.Id.t * (EConstr.types list * Decl_kinds.goal_kind)
 end
 
-val freeze : marshallable:[`Yes | `No | `Shallow] -> t
-val unfreeze : t -> unit
 val proof_of_state : t -> Proof.t
 val copy_terminators : src:t -> tgt:t -> t
-
 
 (**********************************************************)
 (* Proof Mode API                                         *)
@@ -150,7 +136,7 @@ val copy_terminators : src:t -> tgt:t -> t
 (** Type of proof modes :
     - A name
     - A function [set] to set it *from standard mode*
-    - A function [reset] to reset the *standard mode* from it 
+    - A function [reset] to reset the *standard mode* from it
 
 *)
 type proof_mode_name = string
@@ -173,7 +159,7 @@ val get_default_proof_mode_name : unit -> proof_mode_name
 
 (** [set_proof_mode] sets the proof mode to be used after it's called. It is
     typically called by the Proof Mode command. *)
-val set_proof_mode : proof_mode_name -> unit
+val set_proof_mode : proof_mode_name -> t -> t
 [@@ocaml.deprecated "the current proof mode API is deprecated, use with care, see PR #459 and #566 "]
 
 val activate_proof_mode : proof_mode_name -> unit

--- a/stm/proofBlockDelimiter.ml
+++ b/stm/proofBlockDelimiter.ml
@@ -49,7 +49,7 @@ let is_focused_goal_simple ~doc id =
   match state_of_id ~doc id with
   | `Expired | `Error _ | `Valid None -> `Not
   | `Valid (Some { Vernacstate.proof }) ->
-       let proof = Proof_global.proof_of_state proof in
+       let proof = Proof_global.proof_of_state Option.(get proof) in
        let focused, r1, r2, r3, sigma = Proof.proof proof in
        let rest = List.(flatten (map (fun (x,y) -> x @ y) r1)) @ r2 @ r3 in
        if List.for_all (fun x -> simple_goal sigma x rest) focused

--- a/tactics/abstract.ml
+++ b/tactics/abstract.ml
@@ -176,12 +176,15 @@ let abstract_subproof ~opaque id gk tac =
 let anon_id = Id.of_string "anonymous"
 
 let name_op_to_name name_op object_kind suffix =
-  let open Proof_global in
+  (* let open Proof_global in *)
   let default_gk = (Global, false, object_kind) in
+  let name, gk = None, default_gk in
+(* XXX: FIXME Proof_global.t
   let name, gk = match Proof_global.V82.get_current_initial_conclusions () with
   | (id, (_, gk)) -> Some id, gk
   | exception NoCurrentProof -> None, default_gk
   in
+  *)
   match name_op with
   | Some s -> s, gk
   | None ->

--- a/tactics/auto.ml
+++ b/tactics/auto.ml
@@ -395,8 +395,9 @@ and tac_of_hint dbg db_list local_db concl (flags, ({pat=p; code=t;poly=poly;db=
     | None -> mt ()
     | Some n -> str " (in " ++ str n ++ str ")"
     in
-    let sigma, env = Pfedit.get_current_context () in
-    pr_hint env sigma t ++ origin
+    (* XXX: Fix tclLOG *)
+    let env = Global.env () in
+    pr_hint env Evd.(from_env env) t ++ origin
   in
   tclLOG dbg pr_hint (run_hint t tactic)
 

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -1514,9 +1514,9 @@ let pr_hint_term env sigma cl =
     (str "No hint applicable for current goal")
 
 (* print all hints that apply to the concl of the current goal *)
-let pr_applicable_hint () =
+let pr_applicable_hint pf =
   let env = Global.env () in
-  let pts = Proof_global.give_me_the_proof () in
+  let pts = Proof_global.give_me_the_proof pf in
   let glss,_,_,_,sigma = Proof.proof pts in
   match glss with
   | [] -> CErrors.user_err Pp.(str "No focused goal.")

--- a/tactics/hints.mli
+++ b/tactics/hints.mli
@@ -294,7 +294,7 @@ val wrap_hint_warning_fun : env -> evar_map ->
 (** Printing  hints *)
 
 val pr_searchtable : env -> evar_map -> Pp.t
-val pr_applicable_hint : unit -> Pp.t
+val pr_applicable_hint : Proof_global.t -> Pp.t
 val pr_hint_ref : env -> evar_map -> GlobRef.t -> Pp.t
 val pr_hint_db_by_name : env -> evar_map -> hint_db_name -> Pp.t
 val pr_hint_db_env : env -> evar_map -> Hint_db.t -> Pp.t

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -891,9 +891,10 @@ let reduce redexp cl =
     let pr = (pr_econstr_env, pr_leconstr_env, pr_evaluable_reference, pr_constr_pattern_env) in
     Pp.(hov 2 (Pputils.pr_red_expr_env env sigma pr str redexp))
   in
+  (* XXX: Fix trace *)
   let trace () =
-    let sigma, env = Pfedit.get_current_context () in
-    trace env sigma
+    let env = Global.env () in
+    trace env Evd.(from_env env)
   in
   Proofview.Trace.name_tactic trace begin
   Proofview.Goal.enter begin fun gl ->

--- a/toplevel/coqloop.mli
+++ b/toplevel/coqloop.mli
@@ -14,7 +14,7 @@
  * entered to be able to report errors without pretty-printing. *)
 
 type input_buffer = {
-  mutable prompt : Stm.doc -> string;
+  mutable prompt : Vernac.State.t -> string;
   mutable str : Bytes.t; (** buffer of already read characters *)
   mutable len : int;    (** number of chars in the buffer *)
   mutable bols : int list; (** offsets in str of begining of lines *)

--- a/toplevel/vernac.ml
+++ b/toplevel/vernac.ml
@@ -75,7 +75,7 @@ module State = struct
   type t = {
     doc : Stm.doc;
     sid : Stateid.t;
-    proof : Proof.t option;
+    proof : Proof_global.t option;
     time : bool;
   }
 
@@ -101,8 +101,12 @@ let interp_vernac ~check ~interactive ~state ({CAst.loc;_} as com) =
          it otherwise reveals bugs *)
       (* Stm.observe nsid; *)
       let ndoc = if check then Stm.finish ~doc else doc in
-      let new_proof = Proof_global.give_me_the_proof_opt () in
-      { state with doc = ndoc; sid = nsid; proof = new_proof; }
+      let proof =
+        match Stm.state_of_id ~doc:state.doc state.sid with
+        | `Valid ( Some { Vernacstate.proof } ) -> proof
+        | _ -> None
+      in
+      { state with doc = ndoc; sid = nsid; proof; }
     with reraise ->
       (* XXX: In non-interactive mode edit_at seems to do very weird
          things, so we better avoid it while we investigate *)

--- a/toplevel/vernac.mli
+++ b/toplevel/vernac.mli
@@ -14,7 +14,7 @@ module State : sig
   type t = {
     doc : Stm.doc;
     sid : Stateid.t;
-    proof : Proof.t option;
+    proof : Proof_global.t option;
     time : bool;
   }
 

--- a/vernac/classes.mli
+++ b/vernac/classes.mli
@@ -40,6 +40,7 @@ val declare_instance_constant :
   unit
 
 val new_instance :
+  ?ontop:Proof_global.t ->
   ?abstract:bool -> (** Not abstract by default. *)
   ?global:bool -> (** Not global by default. *)
   ?refine:bool -> (** Allow refinement *)
@@ -52,7 +53,8 @@ val new_instance :
   ?tac:unit Proofview.tactic  ->
   ?hook:(GlobRef.t -> unit) ->
   Hints.hint_info_expr ->
-  Id.t
+  (* May open a proof *)
+  Id.t * Proof_global.t option
 
 (** Setting opacity *)
 

--- a/vernac/comAssumption.ml
+++ b/vernac/comAssumption.ml
@@ -8,7 +8,7 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-open Pp
+(* open Pp *)
 open CErrors
 open Util
 open Vars
@@ -52,11 +52,12 @@ match local with
   let decl = (Lib.cwd(), SectionLocalAssum ((c,ctx),p,impl), IsAssumption kind) in
   let _ = declare_variable ident decl in
   let () = assumption_message ident in
-  let () =
-    if not !Flags.quiet && Proof_global.there_are_pending_proofs () then
-    Feedback.msg_info (str"Variable" ++ spc () ++ Id.print ident ++
-    strbrk " is not visible from current goals")
-  in
+  (* XXX *)
+  (* let () =
+   *   if not !Flags.quiet && Proof_global.there_are_pending_proofs () then
+   *   Feedback.msg_info (str"Variable" ++ spc () ++ Id.print ident ++
+   *   strbrk " is not visible from current goals")
+   * in *)
   let r = VarRef ident in
   let () = Typeclasses.declare_instance None true r in
   let () = if is_coe then Class.try_add_new_coercion r ~local:true false in

--- a/vernac/comFixpoint.ml
+++ b/vernac/comFixpoint.ml
@@ -250,7 +250,8 @@ let interp_fixpoint ~cofix l ntns =
   let uctx,fix = ground_fixpoint env evd fix in
   (fix,pl,uctx,info)
 
-let declare_fixpoint local poly ((fixnames,fixdefs,fixtypes),pl,ctx,fiximps) indexes ntns =
+let declare_fixpoint ?ontop local poly ((fixnames,fixdefs,fixtypes),pl,ctx,fiximps) indexes ntns =
+  let pstate =
   if List.exists Option.is_empty fixdefs then
     (* Some bodies to define by proof *)
     let thms =
@@ -260,8 +261,9 @@ let declare_fixpoint local poly ((fixnames,fixdefs,fixtypes),pl,ctx,fiximps) ind
       Some (List.map (Option.cata (EConstr.of_constr %> Tactics.exact_no_check) Tacticals.New.tclIDTAC)
         fixdefs) in
     let evd = Evd.from_ctx ctx in
-    Lemmas.start_proof_with_initialization (local,poly,DefinitionBody Fixpoint)
-      evd pl (Some(false,indexes,init_tac)) thms None (Lemmas.mk_hook (fun _ _ -> ()))
+    Some
+    (Lemmas.start_proof_with_initialization (local,poly,DefinitionBody Fixpoint)
+      evd pl (Some(false,indexes,init_tac)) thms None (Lemmas.mk_hook (fun _ _ -> ())))
   else begin
     (* We shortcut the proof process *)
     let fixdefs = List.map Option.get fixdefs in
@@ -281,11 +283,14 @@ let declare_fixpoint local poly ((fixnames,fixdefs,fixtypes),pl,ctx,fiximps) ind
               fixnames fixdecls fixtypes fiximps);
     (* Declare the recursive definitions *)
     fixpoint_message (Some indexes) fixnames;
-  end;
+    None
+  end in
   (* Declare notations *)
-  List.iter (Metasyntax.add_notation_interpretation (Global.env())) ntns
+  List.iter (Metasyntax.add_notation_interpretation (Global.env())) ntns;
+  pstate
 
-let declare_cofixpoint local poly ((fixnames,fixdefs,fixtypes),pl,ctx,fiximps) ntns =
+let declare_cofixpoint ?ontop local poly ((fixnames,fixdefs,fixtypes),pl,ctx,fiximps) ntns =
+  let pstate =
   if List.exists Option.is_empty fixdefs then
     (* Some bodies to define by proof *)
     let thms =
@@ -295,8 +300,8 @@ let declare_cofixpoint local poly ((fixnames,fixdefs,fixtypes),pl,ctx,fiximps) n
       Some (List.map (Option.cata (EConstr.of_constr %> Tactics.exact_no_check) Tacticals.New.tclIDTAC)
         fixdefs) in
     let evd = Evd.from_ctx ctx in
-      Lemmas.start_proof_with_initialization (Global,poly, DefinitionBody CoFixpoint)
-      evd pl (Some(true,[],init_tac)) thms None (Lemmas.mk_hook (fun _ _ -> ()))
+    Some (Lemmas.start_proof_with_initialization ?ontop (Global,poly, DefinitionBody CoFixpoint)
+            evd pl (Some(true,[],init_tac)) thms None (Lemmas.mk_hook (fun _ _ -> ())))
   else begin
     (* We shortcut the proof process *)
     let fixdefs = List.map Option.get fixdefs in
@@ -312,10 +317,12 @@ let declare_cofixpoint local poly ((fixnames,fixdefs,fixtypes),pl,ctx,fiximps) n
     ignore (List.map4 (DeclareDef.declare_fix (local, poly, CoFixpoint) pl ctx)
               fixnames fixdecls fixtypes fiximps);
     (* Declare the recursive definitions *)
-    cofixpoint_message fixnames
-  end;
+    cofixpoint_message fixnames;
+    None
+  end in
   (* Declare notations *)
-  List.iter (Metasyntax.add_notation_interpretation (Global.env())) ntns
+  List.iter (Metasyntax.add_notation_interpretation (Global.env())) ntns;
+  pstate
 
 let extract_decreasing_argument limit = function
   | (na,CStructRec) -> na
@@ -343,16 +350,18 @@ let check_safe () =
   let flags = Environ.typing_flags (Global.env ()) in
   flags.check_universes && flags.check_guarded
 
-let do_fixpoint local poly l =
+let do_fixpoint ?ontop local poly l =
   let fixl, ntns = extract_fixpoint_components true l in
   let (_, _, _, info as fix) = interp_fixpoint ~cofix:false fixl ntns in
   let possible_indexes =
     List.map compute_possible_guardness_evidences info in
-  declare_fixpoint local poly fix possible_indexes ntns;
-  if not (check_safe ()) then Feedback.feedback Feedback.AddedAxiom else ()
+  let pstate = declare_fixpoint ?ontop local poly fix possible_indexes ntns in
+  if not (check_safe ()) then Feedback.feedback Feedback.AddedAxiom else ();
+  pstate
 
-let do_cofixpoint local poly l =
+let do_cofixpoint ?ontop local poly l =
   let fixl,ntns = extract_cofixpoint_components l in
   let cofix = interp_fixpoint ~cofix:true fixl ntns in
-  declare_cofixpoint local poly cofix ntns;
-  if not (check_safe ()) then Feedback.feedback Feedback.AddedAxiom else ()
+  let pstate = declare_cofixpoint ?ontop local poly cofix ntns in
+  if not (check_safe ()) then Feedback.feedback Feedback.AddedAxiom else ();
+  pstate

--- a/vernac/comFixpoint.mli
+++ b/vernac/comFixpoint.mli
@@ -19,12 +19,14 @@ open Vernacexpr
 (** Entry points for the vernacular commands Fixpoint and CoFixpoint *)
 
 val do_fixpoint :
+  ?ontop:Proof_global.t ->
   (* When [false], assume guarded. *)
-  locality -> polymorphic -> (fixpoint_expr * decl_notation list) list -> unit
+  locality -> polymorphic -> (fixpoint_expr * decl_notation list) list -> Proof_global.t option
 
 val do_cofixpoint :
+  ?ontop:Proof_global.t ->
   (* When [false], assume guarded. *)
-  locality -> polymorphic -> (cofixpoint_expr * decl_notation list) list -> unit
+  locality -> polymorphic -> (cofixpoint_expr * decl_notation list) list -> Proof_global.t option
 
 (************************************************************************)
 (** Internal API  *)
@@ -80,15 +82,20 @@ val interp_fixpoint :
 (** Registering fixpoints and cofixpoints in the environment *)
 (** [Not used so far] *)
 val declare_fixpoint :
+  ?ontop:Proof_global.t ->
   locality -> polymorphic ->
   recursive_preentry * UState.universe_decl * UState.t *
   (Constr.rel_context * Impargs.manual_implicits * int option) list ->
-  Proof_global.lemma_possible_guards -> decl_notation list -> unit
+  Proof_global.lemma_possible_guards -> decl_notation list ->
+  Proof_global.t option
 
-val declare_cofixpoint : locality -> polymorphic ->
+val declare_cofixpoint :
+  ?ontop:Proof_global.t ->
+  locality -> polymorphic ->
   recursive_preentry * UState.universe_decl * UState.t *
   (Constr.rel_context * Impargs.manual_implicits * int option) list ->
-  decl_notation list -> unit
+  decl_notation list ->
+  Proof_global.t option
 
 (** Very private function, do not use *)
 val compute_possible_guardness_evidences :

--- a/vernac/declareDef.ml
+++ b/vernac/declareDef.ml
@@ -14,11 +14,13 @@ open Entries
 open Globnames
 open Impargs
 
+(*
 let warn_definition_not_visible =
   CWarnings.create ~name:"definition-not-visible" ~category:"implicits"
     Pp.(fun ident ->
         strbrk "Section definition " ++
         Names.Id.print ident ++ strbrk " is not visible from current goals")
+*)
 
 let warn_local_declaration =
   CWarnings.create ~name:"local-declaration" ~category:"scope"
@@ -38,7 +40,8 @@ let declare_definition ident (local, p, k) ce pl imps hook =
   let gr = match local with
   | Discharge when Lib.sections_are_opened () ->
       let _ = declare_variable ident (Lib.cwd(), SectionLocalDef ce, IsDefinition k) in
-      let () = if Proof_global.there_are_pending_proofs () then warn_definition_not_visible ident in
+      (* XXX *)
+      (* let () = if Proof_global.there_are_pending_proofs () then warn_definition_not_visible ident in *)
       VarRef ident
   | Discharge | Local | Global ->
       let local = get_locality ident ~kind:"definition" local in

--- a/vernac/lemmas.mli
+++ b/vernac/lemmas.mli
@@ -15,29 +15,29 @@ type declaration_hook
 val mk_hook : (Decl_kinds.locality -> GlobRef.t -> unit) -> declaration_hook
 val call_hook : Future.fix_exn -> declaration_hook -> Decl_kinds.locality -> GlobRef.t -> unit
 
-val start_proof : Id.t -> ?pl:UState.universe_decl -> goal_kind -> Evd.evar_map ->
+val start_proof : ?ontop:Proof_global.t -> Id.t -> ?pl:UState.universe_decl -> goal_kind -> Evd.evar_map ->
   ?terminator:(Proof_global.lemma_possible_guards -> declaration_hook -> Proof_global.proof_terminator) ->
   ?sign:Environ.named_context_val -> EConstr.types ->
   ?compute_guard:Proof_global.lemma_possible_guards ->
-  declaration_hook -> unit
+   declaration_hook -> Proof_global.t
 
-val start_proof_univs : Id.t -> ?pl:UState.universe_decl -> goal_kind -> Evd.evar_map ->
+val start_proof_univs : ?ontop:Proof_global.t -> Id.t -> ?pl:UState.universe_decl -> goal_kind -> Evd.evar_map ->
   ?terminator:(Proof_global.lemma_possible_guards -> (UState.t option -> declaration_hook) -> Proof_global.proof_terminator) ->
   ?sign:Environ.named_context_val -> EConstr.types ->
   ?compute_guard:Proof_global.lemma_possible_guards ->
-  (UState.t option -> declaration_hook) -> unit
+  (UState.t option -> declaration_hook) -> Proof_global.t
 
-val start_proof_com :
+val start_proof_com : ?ontop:Proof_global.t ->
   ?inference_hook:Pretyping.inference_hook ->
   goal_kind -> Vernacexpr.proof_expr list ->
-  declaration_hook -> unit
+  declaration_hook -> Proof_global.t
 
-val start_proof_with_initialization :
+val start_proof_with_initialization : ?ontop:Proof_global.t ->
   goal_kind -> Evd.evar_map -> UState.universe_decl ->
   (bool * Proof_global.lemma_possible_guards * unit Proofview.tactic list option) option ->
   (Id.t (* name of thm *) *
      (EConstr.types (* type of thm *) * (Name.t list (* names to pre-introduce *) * Impargs.manual_explicitation list))) list
-  -> int list option -> declaration_hook -> unit
+  -> int list option -> declaration_hook -> Proof_global.t
 
 val universe_proof_terminator :
   Proof_global.lemma_possible_guards ->
@@ -48,7 +48,7 @@ val standard_proof_terminator :
   Proof_global.lemma_possible_guards -> declaration_hook ->
     Proof_global.proof_terminator
 
-val fresh_name_for_anonymous_theorem : unit -> Id.t
+val fresh_name_for_anonymous_theorem : pstate:Proof_global.t option -> Id.t
 
 (* Prepare global named context for proof session: remove proofs of
    opaque section definitions and remove vm-compiled code *)
@@ -57,4 +57,4 @@ val initialize_named_context_for_proof : unit -> Environ.named_context_val
 
 (** {6 ... } *)
 
-val save_proof : ?proof:Proof_global.closed_proof -> Vernacexpr.proof_end -> unit
+val save_proof : ?proof:Proof_global.closed_proof -> pstate:Proof_global.t -> Vernacexpr.proof_end -> Proof_global.t option

--- a/vernac/obligations.ml
+++ b/vernac/obligations.ml
@@ -963,7 +963,7 @@ in
       ignore (auto (Some prg.prg_name) None deps)
   end
 
-let rec solve_obligation prg num tac =
+let rec solve_obligation ?ontop prg num tac =
   let user_num = succ num in
   let obls, rem = prg.prg_obligations in
   let obl = obls.(num) in
@@ -984,18 +984,19 @@ let rec solve_obligation prg num tac =
     Proof_global.make_terminator
       (obligation_terminator prg.prg_name num guard hook auto) in
   let hook ctx = Lemmas.mk_hook (obligation_hook prg obl num auto ctx) in
-  let () = Lemmas.start_proof_univs ~sign:prg.prg_sign obl.obl_name kind evd (EConstr.of_constr obl.obl_type) ~terminator hook in
+  let pstate = Lemmas.start_proof_univs ?ontop ~sign:prg.prg_sign obl.obl_name kind evd (EConstr.of_constr obl.obl_type) ~terminator hook in
   let _ = Pfedit.by !default_tactic in
-  Option.iter (fun tac -> Proof_global.set_endline_tactic tac) tac
+  let pstate = Option.cata (fun tac -> Proof_global.set_endline_tactic tac pstate) pstate tac in
+  pstate
 
-and obligation (user_num, name, typ) tac =
+and obligation ?ontop (user_num, name, typ) tac =
   let num = pred user_num in
   let prg = get_prog_err name in
   let obls, rem = prg.prg_obligations in
     if num >= 0 && num < Array.length obls then
       let obl = obls.(num) in
 	match obl.obl_body with
-	    None -> solve_obligation prg num tac
+	    None -> solve_obligation ?ontop prg num tac
 	  | Some r -> error "Obligation already solved"
     else error (sprintf "Unknown obligation number %i" (succ num))
 
@@ -1195,7 +1196,7 @@ let admit_obligations n =
     let prg = get_prog_err n in
     admit_prog prg
 
-let next_obligation n tac =
+let next_obligation ?ontop n tac =
   let prg = match n with
   | None -> get_any_prog_err ()
   | Some _ -> get_prog_err n
@@ -1206,7 +1207,7 @@ let next_obligation n tac =
   | Some i -> i
   | None -> anomaly (Pp.str "Could not find a solvable obligation.")
   in
-  solve_obligation prg i tac
+  solve_obligation ?ontop prg i tac
 
 let init_program () =
   Coqlib.check_required_library Coqlib.datatypes_module_name;

--- a/vernac/obligations.mli
+++ b/vernac/obligations.mli
@@ -84,10 +84,10 @@ val add_mutual_definitions :
   notations ->
   fixpoint_kind -> unit
 
-val obligation : int * Names.Id.t option * Constrexpr.constr_expr option ->
-  Genarg.glob_generic_argument option -> unit
+val obligation : ?ontop:Proof_global.t -> int * Names.Id.t option * Constrexpr.constr_expr option ->
+  Genarg.glob_generic_argument option -> Proof_global.t
 
-val next_obligation : Names.Id.t option -> Genarg.glob_generic_argument option -> unit
+val next_obligation : ?ontop:Proof_global.t -> Names.Id.t option -> Genarg.glob_generic_argument option -> Proof_global.t
 
 val solve_obligations : Names.Id.t option -> unit Proofview.tactic option -> progress
 (* Number of remaining obligations to be solved for this program *)

--- a/vernac/search.ml
+++ b/vernac/search.ml
@@ -59,11 +59,16 @@ let iter_constructors indsp u fn env nconstr =
 let iter_named_context_name_type f =
   List.iter (fun decl -> f (NamedDecl.get_id decl) (NamedDecl.get_type decl))
 
+let get_current_or_goal_context ~pstate glnum =
+  match pstate with
+  | None -> let env = Global.env () in Evd.(from_env env, env)
+  | Some p -> Pfedit.get_goal_context p glnum
+
 (* General search over hypothesis of a goal *)
-let iter_hypothesis glnum (fn : GlobRef.t -> env -> constr -> unit) =
+let iter_hypothesis ~pstate glnum (fn : GlobRef.t -> env -> constr -> unit) =
   let env = Global.env () in
   let iter_hyp idh typ = fn (VarRef idh) env typ in
-  let evmap,e = Pfedit.get_goal_context glnum in
+  let evmap,e = get_current_or_goal_context ~pstate glnum in
   let pfctxt = named_context e in
   iter_named_context_name_type iter_hyp pfctxt
 
@@ -99,10 +104,10 @@ let iter_declarations (fn : GlobRef.t -> env -> constr -> unit) =
   try Declaremods.iter_all_segments iter_obj
   with Not_found -> ()
 
-let generic_search glnumopt fn =
+let generic_search ~pstate glnumopt fn =
   (match glnumopt with
   | None -> ()
-  | Some glnum ->  iter_hypothesis glnum fn);
+  | Some glnum -> iter_hypothesis ~pstate glnum fn);
   iter_declarations fn
 
 (** This module defines a preference on constrs in the form of a
@@ -221,7 +226,7 @@ let search_about_filter query gr env typ = match query with
 
 (** SearchPattern *)
 
-let search_pattern gopt pat mods pr_search =
+let search_pattern ~pstate gopt pat mods pr_search =
   let blacklist_filter = blacklist_filter_aux () in
   let filter ref env typ =
     module_filter mods ref env typ &&
@@ -231,7 +236,7 @@ let search_pattern gopt pat mods pr_search =
   let iter ref env typ =
     if filter ref env typ then pr_search ref env typ
   in
-  generic_search gopt iter
+  generic_search ~pstate gopt iter
 
 (** SearchRewrite *)
 
@@ -243,7 +248,7 @@ let rewrite_pat1 pat =
 let rewrite_pat2 pat =
   PApp (PRef (eq ()), [| PMeta None; PMeta None; pat |])
 
-let search_rewrite gopt pat mods pr_search =
+let search_rewrite ~pstate gopt pat mods pr_search =
   let pat1 = rewrite_pat1 pat in
   let pat2 = rewrite_pat2 pat in
   let blacklist_filter = blacklist_filter_aux () in
@@ -256,11 +261,11 @@ let search_rewrite gopt pat mods pr_search =
   let iter ref env typ =
     if filter ref env typ then pr_search ref env typ
   in
-  generic_search gopt iter
+  generic_search ~pstate gopt iter
 
 (** Search *)
 
-let search_by_head gopt pat mods pr_search =
+let search_by_head ~pstate gopt pat mods pr_search =
   let blacklist_filter = blacklist_filter_aux () in
   let filter ref env typ =
     module_filter mods ref env typ &&
@@ -270,11 +275,11 @@ let search_by_head gopt pat mods pr_search =
   let iter ref env typ =
     if filter ref env typ then pr_search ref env typ
   in
-  generic_search gopt iter
+  generic_search ~pstate gopt iter
 
 (** SearchAbout *)
 
-let search_about gopt items mods pr_search =
+let search_about ~pstate gopt items mods pr_search =
   let blacklist_filter = blacklist_filter_aux () in
   let filter ref env typ =
     let eqb b1 b2 = if b1 then b2 else not b2 in
@@ -286,7 +291,7 @@ let search_about gopt items mods pr_search =
   let iter ref env typ =
     if filter ref env typ then pr_search ref env typ
   in
-  generic_search gopt iter
+  generic_search ~pstate gopt iter
 
 type search_constraint =
   | Name_Pattern of Str.regexp
@@ -301,7 +306,7 @@ type 'a coq_object = {
   coq_object_object : 'a;
 }
 
-let interface_search =
+let interface_search ~pstate =
   let rec extract_flags name tpe subtpe mods blacklist = function
   | [] -> (name, tpe, subtpe, mods, blacklist)
   | (Name_Pattern regexp, b) :: l ->
@@ -371,7 +376,7 @@ let interface_search =
   let iter ref env typ =
     if filter_function ref env typ then print_function ref env typ
   in
-  let () = generic_search glnum iter in
+  let () = generic_search ~pstate glnum iter in
   !ans
 
 let blacklist_filter ref env typ =

--- a/vernac/search.mli
+++ b/vernac/search.mli
@@ -39,13 +39,13 @@ val search_about_filter : glob_search_about_item -> filter_function
 goal and the global environment for things matching [pattern] and
 satisfying module exclude/include clauses of [modinout]. *)
 
-val search_by_head : int option -> constr_pattern -> DirPath.t list * bool
+val search_by_head : pstate:(Proof_global.t option) -> int option -> constr_pattern -> DirPath.t list * bool
                   -> display_function -> unit
-val search_rewrite : int option -> constr_pattern -> DirPath.t list * bool
+val search_rewrite : pstate:(Proof_global.t option) -> int option -> constr_pattern -> DirPath.t list * bool
                   -> display_function -> unit
-val search_pattern : int option -> constr_pattern -> DirPath.t list * bool
+val search_pattern : pstate:(Proof_global.t option)-> int option -> constr_pattern -> DirPath.t list * bool
                   -> display_function -> unit
-val search_about   : int option -> (bool * glob_search_about_item) list
+val search_about   : pstate:(Proof_global.t option)-> int option -> (bool * glob_search_about_item) list
                   -> DirPath.t list * bool -> display_function -> unit
 
 type search_constraint =
@@ -66,12 +66,12 @@ type 'a coq_object = {
   coq_object_object : 'a;
 }
 
-val interface_search : ?glnum:int -> (search_constraint * bool) list ->
+val interface_search : pstate:(Proof_global.t option) -> ?glnum:int -> (search_constraint * bool) list ->
   constr coq_object list
 
 (** {6 Generic search function} *)
 
-val generic_search : int option -> display_function -> unit
+val generic_search : pstate:(Proof_global.t option) -> int option -> display_function -> unit
 (** This function iterates over all hypothesis of the goal numbered
     [glnum] (if present) and all known declarations. *)
 

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -44,6 +44,28 @@ let vernac_pperr_endline pp =
 
 (* Misc *)
 
+let there_are_pending_proofs ~pstate =
+  not Option.(is_empty pstate)
+
+let check_no_pending_proof ~pstate =
+  if there_are_pending_proofs ~pstate then
+    user_err Pp.(str "Command not supported with open proofs.")
+
+let vernac_require_open_proof ~pstate f =
+  match pstate with
+  | Some pstate -> f ~pstate
+  | None -> user_err Pp.(str "Command not supported with open proofs.")
+
+let get_current_or_global_context ~pstate =
+  match pstate with
+  | None -> let env = Global.env () in Evd.(from_env env, env)
+  | Some p -> Pfedit.get_current_context p
+
+let get_current_or_goal_context ~pstate glnum =
+  match pstate with
+  | None -> let env = Global.env () in Evd.(from_env env, env)
+  | Some p -> Pfedit.get_goal_context p glnum
+
 let cl_of_qualid = function
   | FunClass -> Classops.CL_FUN
   | SortClass -> Classops.CL_SORT
@@ -55,30 +77,30 @@ let scope_class_of_qualid qid =
 (*******************)
 (* "Show" commands *)
 
-let show_proof () =
+let show_proof ~pstate =
   (* spiwack: this would probably be cooler with a bit of polishing. *)
-  let p = Proof_global.give_me_the_proof () in
-  let sigma, env = Pfedit.get_current_context () in
+  let p = Proof_global.give_me_the_proof pstate in
+  let sigma, env = Pfedit.get_current_context pstate in
   let pprf = Proof.partial_proof p in
   Pp.prlist_with_sep Pp.fnl (Printer.pr_econstr_env env sigma) pprf
 
-let show_top_evars () =
+let show_top_evars ~pstate =
   (* spiwack: new as of Feb. 2010: shows goal evars in addition to non-goal evars. *)
-  let pfts = Proof_global.give_me_the_proof () in
+  let pfts = Proof_global.give_me_the_proof pstate in
   let gls,_,shelf,givenup,sigma = Proof.proof pfts in
   pr_evars_int sigma ~shelf ~givenup 1 (Evd.undefined_map sigma)
 
-let show_universes () =
-  let pfts = Proof_global.give_me_the_proof () in
+let show_universes ~pstate =
+  let pfts = Proof_global.give_me_the_proof pstate in
   let gls,_,_,_,sigma = Proof.proof pfts in
   let ctx = Evd.universe_context_set (Evd.minimize_universes sigma) in
   Termops.pr_evar_universe_context (Evd.evar_universe_context sigma) ++ fnl () ++
   str "Normalized constraints: " ++ Univ.pr_universe_context_set (Termops.pr_evd_level sigma) ctx
 
 (* Simulate the Intro(s) tactic *)
-let show_intro all =
+let show_intro ~pstate all =
   let open EConstr in
-  let pf = Proof_global.give_me_the_proof() in
+  let pf = Proof_global.give_me_the_proof pstate in
   let gls,_,_,_,sigma = Proof.proof pf in
   if not (List.is_empty gls) then begin
     let gl = {Evd.it=List.hd gls ; sigma = sigma; } in
@@ -206,7 +228,7 @@ let print_modtype qid =
     with Not_found ->
       user_err (str"Unknown Module Type or Module " ++ pr_qualid qid)
 
-let print_namespace ns =
+let print_namespace ~pstate ns =
   let ns = List.rev (Names.DirPath.repr ns) in
   (* [match_dirpath], [match_modulpath] are helpers for [matches]
      which checks whether a constant is in the namespace [ns]. *)
@@ -254,10 +276,10 @@ let print_namespace ns =
     let qn = (qualified_minus (List.length ns) mp)@[Names.Label.to_id lbl] in
     print_list Id.print qn
   in
-  let print_constant k body =
+  let print_constant ~pstate k body =
     (* FIXME: universes *)
     let t = body.Declarations.const_type in
-    let sigma, env = Pfedit.get_current_context () in
+    let sigma, env = get_current_or_global_context ~pstate in
     print_kn k ++ str":" ++ spc() ++ Printer.pr_type_env env sigma t
   in
   let matches mp = match match_modulepath ns mp with
@@ -267,7 +289,7 @@ let print_namespace ns =
     Environ.fold_constants (fun c body acc ->
         let kn = Constant.user c in
         if matches (KerName.modpath kn)
-        then acc++fnl()++hov 2 (print_constant kn body)
+        then acc++fnl()++hov 2 (print_constant ~pstate kn body)
         else acc)
       (Global.env ()) (str"")
   in
@@ -475,7 +497,7 @@ let vernac_custom_entry ~module_local s =
 (***********)
 (* Gallina *)
 
-let start_proof_and_print k l hook =
+let start_proof_and_print ~pstate k l hook =
   let inference_hook =
     if Flags.is_program_mode () then
       let hook env sigma ev =
@@ -497,7 +519,7 @@ let start_proof_and_print k l hook =
       in Some hook
     else None
   in
-  start_proof_com ?inference_hook k l hook
+  start_proof_com ?ontop:pstate ?inference_hook k l hook
 
 let no_hook = Lemmas.mk_hook (fun _ _ -> ())
 
@@ -510,7 +532,7 @@ let vernac_definition_hook p = function
   Class.add_subclass_hook p
 | _ -> no_hook
 
-let vernac_definition ~atts discharge kind ({loc;v=id}, pl) def =
+let vernac_definition ~pstate ~atts discharge kind ({loc;v=id}, pl) def =
   let atts = attributes_of_flags atts in
   let local = enforce_locality_exp atts.locality discharge in
   let hook = vernac_definition_hook atts.polymorphic kind in
@@ -525,39 +547,42 @@ let vernac_definition ~atts discharge kind ({loc;v=id}, pl) def =
   let program_mode = Flags.is_program_mode () in
   let name =
     match id with
-    | Anonymous -> fresh_name_for_anonymous_theorem ()
+    | Anonymous -> fresh_name_for_anonymous_theorem ~pstate
     | Name n -> n
   in
   (match def with
     | ProveBody (bl,t) ->   (* local binders, typ *)
-      start_proof_and_print (local, atts.polymorphic, DefinitionBody kind)
-        [(CAst.make ?loc name, pl), (bl, t)] hook
+      Some (start_proof_and_print ~pstate (local, atts.polymorphic, DefinitionBody kind)
+              [(CAst.make ?loc name, pl), (bl, t)] hook)
     | DefineBody (bl,red_option,c,typ_opt) ->
       let red_option = match red_option with
-          | None -> None
-          | Some r ->
-            let sigma, env = Pfedit.get_current_context () in
-            Some (snd (Hook.get f_interp_redexp env sigma r)) in
+        | None -> None
+        | Some r ->
+          let sigma, env = get_current_or_global_context ~pstate in
+          Some (snd (Hook.get f_interp_redexp env sigma r)) in
       ComDefinition.do_definition ~program_mode name
-        (local, atts.polymorphic, kind) pl bl red_option c typ_opt hook)
+        (local, atts.polymorphic, kind) pl bl red_option c typ_opt hook;
+      None
+  )
 
-let vernac_start_proof ~atts kind l =
+let vernac_start_proof ~pstate ~atts kind l =
   let atts = attributes_of_flags atts in
   let local = enforce_locality_exp atts.locality NoDischarge in
   if Dumpglob.dump () then
     List.iter (fun ((id, _), _) -> Dumpglob.dump_definition id false "prf") l;
-  start_proof_and_print (local, atts.polymorphic, Proof kind) l no_hook
+  Some (start_proof_and_print ~pstate (local, atts.polymorphic, Proof kind) l no_hook)
 
-let vernac_end_proof ?proof = function
-  | Admitted          -> save_proof ?proof Admitted
-  | Proved (_,_) as e -> save_proof ?proof e
+let vernac_end_proof ~pstate ?proof = function
+  | Admitted          -> save_proof ~pstate ?proof Admitted
+  | Proved (_,_) as e -> save_proof ~pstate ?proof e
 
-let vernac_exact_proof c =
+let vernac_exact_proof ~pstate c =
   (* spiwack: for simplicity I do not enforce that "Proof proof_term" is
      called only at the begining of a proof. *)
-  let status = Pfedit.by (Tactics.exact_proof c) in
-  save_proof (Vernacexpr.(Proved(Proof_global.Opaque,None)));
-  if not status then Feedback.feedback Feedback.AddedAxiom
+  let pstate, status = Pfedit.by (Tactics.exact_proof c) pstate in
+  let pstate = save_proof ~pstate (Vernacexpr.(Proved(Proof_global.Opaque,None))) in
+  if not status then Feedback.feedback Feedback.AddedAxiom;
+  pstate
 
 let vernac_assumption ~atts discharge kind l nl =
   let atts = attributes_of_flags atts in
@@ -725,28 +750,28 @@ let vernac_inductive ~atts cum lo finite indl =
       in vernac_record cum (Class true) atts.polymorphic finite [id, bl, c, None, [f]]
     *)
 
-let vernac_fixpoint ~atts discharge l =
+let vernac_fixpoint ~atts discharge l : Proof_global.t option =
   let atts = attributes_of_flags atts in
   let local = enforce_locality_exp atts.locality discharge in
   if Dumpglob.dump () then
     List.iter (fun (((lid,_), _, _, _, _), _) -> Dumpglob.dump_definition lid false "def") l;
   (* XXX: Switch to the attribute system and match on ~atts *)
   let do_fixpoint = if Flags.is_program_mode () then
-      ComProgramFixpoint.do_fixpoint
+      fun local sign l -> ComProgramFixpoint.do_fixpoint local sign l; None
     else
-      ComFixpoint.do_fixpoint
+      ComFixpoint.do_fixpoint ?ontop:None
   in
   do_fixpoint local atts.polymorphic l
 
-let vernac_cofixpoint ~atts discharge l =
+let vernac_cofixpoint ~atts discharge l : Proof_global.t option =
   let atts = attributes_of_flags atts in
   let local = enforce_locality_exp atts.locality discharge in
   if Dumpglob.dump () then
     List.iter (fun (((lid,_), _, _, _), _) -> Dumpglob.dump_definition lid false "def") l;
   let do_cofixpoint = if Flags.is_program_mode () then
-      ComProgramFixpoint.do_cofixpoint
+      fun local sign l -> ComProgramFixpoint.do_cofixpoint local sign l; None
     else
-      ComFixpoint.do_cofixpoint
+      ComFixpoint.do_cofixpoint ?ontop:None
   in
   do_cofixpoint local atts.polymorphic l
 
@@ -804,14 +829,14 @@ let vernac_declare_module export {loc;v=id} binders_ast mty_ast =
   Flags.if_verbose Feedback.msg_info (str "Module " ++ Id.print id ++ str " is declared");
   Option.iter (fun export -> vernac_import export [qualid_of_ident id]) export
 
-let vernac_define_module export {loc;v=id} (binders_ast : module_binder list) mty_ast_o mexpr_ast_l =
+let vernac_define_module ~pstate export {loc;v=id} (binders_ast : module_binder list) mty_ast_o mexpr_ast_l =
   (* We check the state of the system (in section, in module type)
      and what module information is supplied *)
   if Lib.sections_are_opened () then
     user_err Pp.(str "Modules and Module Types are not allowed inside sections.");
   match mexpr_ast_l with
     | [] ->
-       Proof_global.check_no_pending_proof ();
+       check_no_pending_proof ~pstate;
        let binders_ast,argsexport =
         List.fold_right
          (fun (export,idl,ty) (args,argsexport) ->
@@ -851,13 +876,13 @@ let vernac_end_module export {loc;v=id} =
   Flags.if_verbose Feedback.msg_info (str "Module " ++ Id.print id ++ str " is defined");
   Option.iter (fun export -> vernac_import export [qualid_of_ident ?loc id]) export
 
-let vernac_declare_module_type {loc;v=id} binders_ast mty_sign mty_ast_l =
+let vernac_declare_module_type ~pstate {loc;v=id} binders_ast mty_sign mty_ast_l =
   if Lib.sections_are_opened () then
     user_err Pp.(str "Modules and Module Types are not allowed inside sections.");
 
   match mty_ast_l with
     | [] ->
-       Proof_global.check_no_pending_proof ();
+       check_no_pending_proof ~pstate;
        let binders_ast,argsexport =
 	 List.fold_right
          (fun (export,idl,ty) (args,argsexport) ->
@@ -904,8 +929,8 @@ let vernac_include l =
 
 (* Sections *)
 
-let vernac_begin_section ({v=id} as lid) =
-  Proof_global.check_no_pending_proof ();
+let vernac_begin_section ~pstate ({v=id} as lid) =
+  check_no_pending_proof ~pstate;
   Dumpglob.dump_definition lid true "sec";
   Lib.open_section id
 
@@ -918,8 +943,8 @@ let vernac_name_sec_hyp {v=id} set = Proof_using.name_set id set
 
 (* Dispatcher of the "End" command *)
 
-let vernac_end_segment ({v=id} as lid) =
-  Proof_global.check_no_pending_proof ();
+let vernac_end_segment ~pstate ({v=id} as lid) =
+  check_no_pending_proof ~pstate;
   match Lib.find_opening_node id with
   | Lib.OpenedModule (false,export,_,_) -> vernac_end_module export lid
   | Lib.OpenedModule (true,_,_,_) -> vernac_end_modtype lid
@@ -1008,20 +1033,18 @@ let focus_command_cond = Proof.no_cond command_focus
      there are no more goals to solve. It cannot be a tactic since
      all tactics fail if there are no further goals to prove. *)
 
-let vernac_solve_existential = Pfedit.instantiate_nth_evar_com
+let vernac_solve_existential ~pstate i e = Pfedit.instantiate_nth_evar_com i e pstate
 
-let vernac_set_end_tac tac =
+let vernac_set_end_tac ~pstate tac =
   let env = Genintern.empty_glob_sign (Global.env ()) in
   let _, tac = Genintern.generic_intern env tac in
-  if not (Proof_global.there_are_pending_proofs ()) then
-    user_err Pp.(str "Unknown command of the non proof-editing mode.");
-  Proof_global.set_endline_tactic tac
-    (* TO DO verifier s'il faut pas mettre exist s | TacId s ici*)
+  (* TO DO verifier s'il faut pas mettre exist s | TacId s ici*)
+  Proof_global.set_endline_tactic tac pstate
 
-let vernac_set_used_variables e =
+let vernac_set_used_variables ~(pstate : Proof_global.t) e : Proof_global.t =
   let env = Global.env () in
   let tys =
-    List.map snd (Proof.initial_goals (Proof_global.give_me_the_proof ())) in
+    List.map snd Proof.(initial_goals Proof_global.(give_me_the_proof pstate)) in
   let tys = List.map EConstr.Unsafe.to_constr tys in
   let l = Proof_using.process_expr env e tys in
   let vars = Environ.named_context env in
@@ -1030,14 +1053,14 @@ let vernac_set_used_variables e =
       user_err ~hdr:"vernac_set_used_variables"
         (str "Unknown variable: " ++ Id.print id))
     l;
-  let _, to_clear = Proof_global.set_used_variables l in
+  let _, to_clear, pstate = Proof_global.set_used_variables pstate l in
   let to_clear = List.map (fun x -> x.CAst.v) to_clear in
-  Proof_global.with_current_proof begin fun _ p ->
+  fst @@ Proof_global.with_current_proof begin fun _ p ->
     if List.is_empty to_clear then (p, ())
     else
       let tac = Tactics.clear to_clear in
       fst (Pfedit.solve Goal_select.SelectAll None tac p), ()
-  end
+  end pstate
 
 (*****************************)
 (* Auxiliary file management *)
@@ -1082,12 +1105,10 @@ let vernac_chdir = function
 (* State management *)
 
 let vernac_write_state file =
-  Proof_global.discard_all ();
   let file = CUnix.make_suffix file ".coq" in
   States.extern_state file
 
 let vernac_restore_state file =
-  Proof_global.discard_all ();
   let file = Loadpath.locate_file (CUnix.make_suffix file ".coq") in
   States.intern_state file
 
@@ -1734,9 +1755,9 @@ let vernac_print_option key =
   try print_option_value key
   with Not_found -> error_undeclared_key key
 
-let get_current_context_of_args = function
-  | Some n -> Pfedit.get_goal_context n
-  | None -> Pfedit.get_current_context ()
+let get_current_context_of_args ~pstate = function
+  | Some n -> Pfedit.get_goal_context pstate n
+  | None -> Pfedit.get_current_context pstate
 
 let query_command_selector ?loc = function
   | None -> None
@@ -1744,9 +1765,9 @@ let query_command_selector ?loc = function
   | _ -> user_err ?loc ~hdr:"query_command_selector"
       (str "Query commands only support the single numbered goal selector.")
 
-let vernac_check_may_eval ~atts redexp glopt rc =
+let vernac_check_may_eval ~pstate ~atts redexp glopt rc =
   let glopt = query_command_selector glopt in
-  let (sigma, env) = get_current_context_of_args glopt in
+  let (sigma, env) = get_current_context_of_args ~pstate glopt in
   let sigma, c = interp_open_constr env sigma rc in
   let sigma = Evarconv.solve_unif_constraints_with_heuristics env sigma in
   Evarconv.check_problems_are_solved env sigma;
@@ -1800,27 +1821,29 @@ let vernac_global_check c =
   pr_universe_ctx_set sigma uctx
 
 
-let get_nth_goal n =
-  let pf = Proof_global.give_me_the_proof() in
+let get_nth_goal ~pstate n =
+  let pf = Proof_global.give_me_the_proof pstate in
   let gls,_,_,_,sigma = Proof.proof pf in
   let gl = {Evd.it=List.nth gls (n-1) ; sigma = sigma; } in
   gl
 
 exception NoHyp
+
 (* Printing "About" information of a hypothesis of the current goal.
    We only print the type and a small statement to this comes from the
    goal. Precondition: there must be at least one current goal. *)
-let print_about_hyp_globs ?loc ref_or_by_not udecl glopt =
+let print_about_hyp_globs ~(pstate : Proof_global.t option) ?loc ref_or_by_not udecl glopt =
   let open Context.Named.Declaration in
   try
+    let pstate = Option.get pstate in
     (* FIXME error on non None udecl if we find the hyp. *)
     let glnumopt = query_command_selector ?loc glopt in
     let gl,id =
       match glnumopt, ref_or_by_not.v with
       | None,AN qid when qualid_is_ident qid -> (* goal number not given, catch any failure *)
-         (try get_nth_goal 1, qualid_basename qid with _ -> raise NoHyp)
+         (try get_nth_goal ~pstate 1, qualid_basename qid with _ -> raise NoHyp)
       | Some n,AN qid when qualid_is_ident qid ->  (* goal number given, catch if wong *)
-         (try get_nth_goal n, qualid_basename qid
+         (try get_nth_goal ~pstate n, qualid_basename qid
 	  with
 	    Failure _ -> user_err ?loc ~hdr:"print_about_hyp_globs"
                           (str "No such goal: " ++ int n ++ str "."))
@@ -1830,15 +1853,16 @@ let print_about_hyp_globs ?loc ref_or_by_not udecl glopt =
     let natureofid = match decl with
                      | LocalAssum _ -> "Hypothesis"
                      | LocalDef (_,bdy,_) ->"Constant (let in)" in
-    let sigma, env = Pfedit.get_current_context () in
+    let sigma, env = Pfedit.get_current_context pstate in
     v 0 (Id.print id ++ str":" ++ pr_econstr_env env sigma (NamedDecl.get_type decl) ++ fnl() ++ fnl()
 	 ++ str natureofid ++ str " of the goal context.")
   with (* fallback to globals *)
     | NoHyp | Not_found ->
-    let sigma, env = Pfedit.get_current_context () in
+    let sigma, env = get_current_or_global_context ~pstate in
     print_about env sigma ref_or_by_not udecl
 
-let vernac_print ~atts env sigma =
+let vernac_print ~(pstate : Proof_global.t option) ~atts =
+  let sigma, env = get_current_or_global_context ~pstate in
   function
   | PrintTables -> print_tables ()
   | PrintFullContext-> print_full_context_typ env sigma
@@ -1849,7 +1873,7 @@ let vernac_print ~atts env sigma =
   | PrintModules -> print_modules ()
   | PrintModule qid -> print_module qid
   | PrintModuleType qid -> print_modtype qid
-  | PrintNamespace ns -> print_namespace ns
+  | PrintNamespace ns -> print_namespace ~pstate ns
   | PrintMLLoadPath -> Mltop.print_ml_path ()
   | PrintMLModules -> Mltop.print_ml_modules ()
   | PrintDebugGC -> Mltop.print_gc ()
@@ -1866,7 +1890,13 @@ let vernac_print ~atts env sigma =
   | PrintCanonicalConversions -> Prettyp.print_canonical_projections env sigma
   | PrintUniverses (sort, subgraph, dst) -> print_universes ~sort ~subgraph dst
   | PrintHint r -> Hints.pr_hint_ref env sigma (smart_global r)
-  | PrintHintGoal -> Hints.pr_applicable_hint ()
+  | PrintHintGoal ->
+     begin match pstate with
+     | Some pstate ->
+        Hints.pr_applicable_hint pstate
+     | None ->
+        str "No proof in progress"
+     end
   | PrintHintDbName s -> Hints.pr_hint_db_by_name env sigma s
   | PrintHintDb -> Hints.pr_searchtable env sigma
   | PrintScopes ->
@@ -1876,7 +1906,7 @@ let vernac_print ~atts env sigma =
   | PrintVisibility s ->
     Notation.pr_visibility (Constrextern.without_symbols (pr_lglob_constr_env env)) s
   | PrintAbout (ref_or_by_not,udecl,glnumopt) ->
-    print_about_hyp_globs ref_or_by_not udecl glnumopt
+    print_about_hyp_globs ~pstate ref_or_by_not udecl glnumopt
   | PrintImplicit qid ->
     dump_global qid;
     print_impargs qid
@@ -1941,16 +1971,16 @@ let _ =
       optread  = (fun () -> !search_output_name_only);
       optwrite = (:=) search_output_name_only }
 
-let vernac_search ~atts s gopt r =
+let vernac_search ~pstate ~atts s gopt r =
   let gopt = query_command_selector gopt in
   let r = interp_search_restriction r in
   let env,gopt =
     match gopt with | None ->
       (* 1st goal by default if it exists, otherwise no goal at all *)
-      (try snd (Pfedit.get_goal_context 1) , Some 1
+      (try snd (get_current_or_goal_context ~pstate 1) , Some 1
        with _ -> Global.env (),None)
     (* if goal selector is given and wrong, then let exceptions be raised. *)
-    | Some g -> snd (Pfedit.get_goal_context g) , Some g
+    | Some g -> snd (get_current_or_goal_context ~pstate g) , Some g
   in
   let get_pattern c = snd (intern_constr_pattern env Evd.(from_env env) c) in
   let pr_search ref env c =
@@ -1965,21 +1995,21 @@ let vernac_search ~atts s gopt r =
   in
   match s with
   | SearchPattern c ->
-      (Search.search_pattern gopt (get_pattern c) r |> Search.prioritize_search) pr_search
+      (Search.search_pattern ~pstate gopt (get_pattern c) r |> Search.prioritize_search) pr_search
   | SearchRewrite c ->
-      (Search.search_rewrite gopt (get_pattern c) r |> Search.prioritize_search) pr_search
+      (Search.search_rewrite ~pstate gopt (get_pattern c) r |> Search.prioritize_search) pr_search
   | SearchHead c ->
-      (Search.search_by_head gopt (get_pattern c) r |> Search.prioritize_search) pr_search
+      (Search.search_by_head ~pstate gopt (get_pattern c) r |> Search.prioritize_search) pr_search
   | SearchAbout sl ->
-      (Search.search_about gopt (List.map (on_snd (interp_search_about_item env Evd.(from_env env))) sl) r |>
+      (Search.search_about ~pstate gopt (List.map (on_snd (interp_search_about_item env Evd.(from_env env))) sl) r |>
        Search.prioritize_search) pr_search
 
-let vernac_locate = function
+let vernac_locate ~pstate = function
   | LocateAny {v=AN qid}  -> print_located_qualid qid
   | LocateTerm {v=AN qid} -> print_located_term qid
   | LocateAny {v=ByNotation (ntn, sc)} (** TODO : handle Ltac notations *)
   | LocateTerm {v=ByNotation (ntn, sc)} ->
-    let _, env = Pfedit.get_current_context () in
+    let _, env = get_current_or_global_context ~pstate in
     Notation.locate_notation
       (Constrextern.without_symbols (pr_lglob_constr_env env)) ntn sc
   | LocateLibrary qid -> print_located_library qid
@@ -1987,9 +2017,9 @@ let vernac_locate = function
   | LocateOther (s, qid) -> print_located_other s qid
   | LocateFile f -> locate_file f
 
-let vernac_register qid r =
-  let gr = Smartlocate.global_with_alias qid in
- if Proof_global.there_are_pending_proofs () then
+let vernac_register ~pstate id r =
+  let gr = Smartlocate.global_with_alias id in
+  if there_are_pending_proofs ~pstate then
     user_err Pp.(str "Cannot register a primitive while in proof editing mode.");
   match r with
   | RegisterInline ->
@@ -2023,8 +2053,8 @@ let vernac_unfocus () =
     (fun _ p -> Proof.unfocus command_focus p ())
 
 (* Checks that a proof is fully unfocused. Raises an error if not. *)
-let vernac_unfocused () =
-  let p = Proof_global.give_me_the_proof () in
+let vernac_unfocused ~pstate =
+  let p = Proof_global.give_me_the_proof pstate in
   if Proof.unfocused p then
     str"The proof is indeed fully unfocused."
   else
@@ -2054,25 +2084,25 @@ let vernac_bullet (bullet : Proof_bullet.t) =
   Proof_global.simple_with_current_proof (fun _ p ->
     Proof_bullet.put p bullet)
 
-let vernac_show = function
+let vernac_show ~pstate = function
   | ShowScript -> assert false  (* Only the stm knows the script *)
   | ShowGoal goalref ->
-    let proof = Proof_global.give_me_the_proof () in
+    let proof = Proof_global.give_me_the_proof pstate in
     begin match goalref with
     | OpenSubgoals -> pr_open_subgoals ~proof
     | NthGoal n -> pr_nth_open_subgoal ~proof n
     | GoalId id -> pr_goal_by_id ~proof id
     end
-  | ShowProof -> show_proof ()
-  | ShowExistentials -> show_top_evars ()
-  | ShowUniverses -> show_universes ()
+  | ShowProof -> show_proof ~pstate
+  | ShowExistentials -> show_top_evars ~pstate
+  | ShowUniverses -> show_universes ~pstate
   | ShowProofNames ->
-    pr_sequence Id.print (Proof_global.get_all_proof_names())
-  | ShowIntros all -> show_intro all
+    pr_sequence Id.print (Proof_global.get_all_proof_names pstate)
+  | ShowIntros all -> show_intro ~pstate all
   | ShowMatch id -> show_match id
 
-let vernac_check_guard () =
-  let pts = Proof_global.give_me_the_proof () in
+let vernac_check_guard ~pstate =
+  let pts = Proof_global.give_me_the_proof pstate in
   let pfterm = List.hd (Proof.partial_proof pts) in
   let message =
     try
@@ -2091,13 +2121,14 @@ exception End_of_input
    the way the proof mode is set there makes the task non trivial
    without a considerable amount of refactoring.
  *)
-let vernac_load interp fname =
-  if Proof_global.there_are_pending_proofs () then
+let vernac_load ~st interp fname =
+  let pstate = st.Vernacstate.proof in
+  if there_are_pending_proofs ~pstate then
     CErrors.user_err Pp.(str "Load is not supported inside proofs.");
-  let interp x =
+  let interp ~st x =
     let proof_mode = Proof_global.get_default_proof_mode_name () [@ocaml.warning "-3"] in
     Proof_global.activate_proof_mode proof_mode [@ocaml.warning "-3"];
-    interp x in
+    interp ~st x in
   let parse_sentence = Flags.with_option Flags.we_are_parsing
     (fun po ->
     match Pcoq.Entry.parse Pvernac.main_entry po with
@@ -2110,13 +2141,20 @@ let vernac_load interp fname =
     let longfname = Loadpath.locate_file fname in
     let in_chan = open_utf8_file_in longfname in
     Pcoq.Parsable.make ~file:(Loc.InFile longfname) (Stream.of_channel in_chan) in
-  begin
-    try while true do interp (snd (parse_sentence input)) done
-    with End_of_input -> ()
-  end;
+  let rec load_loop ~st =
+    try
+      let pstate = interp ~st (snd (parse_sentence input)) in
+      let st = { st with Vernacstate.proof = pstate } in
+      load_loop ~st
+    with
+      End_of_input ->
+      pstate
+  in
+  let pstate = load_loop ~st in
   (* If Load left a proof open, we fail too. *)
-  if Proof_global.there_are_pending_proofs () then
-    CErrors.user_err Pp.(str "Files processed by Load cannot leave open proofs.")
+  if there_are_pending_proofs ~pstate then
+    CErrors.user_err Pp.(str "Files processed by Load cannot leave open proofs.");
+  pstate
 
 let with_locality ~atts f =
   let local = Attributes.(parse locality atts) in
@@ -2136,7 +2174,8 @@ let with_module_locality ~atts f =
  * is the outdated/deprecated "Local" attribute of some vernacular commands
  * still parsed as the obsolete_locality grammar entry for retrocompatibility.
  * loc is the Loc.t of the vernacular command being interpreted. *)
-let interp ?proof ~atts ~st c =
+let interp ?proof ~atts ~st c : Proof_global.t option =
+  let pstate = st.Vernacstate.proof in
   vernac_pperr_endline (fun () -> str "interpreting: " ++ Ppvernac.pr_vernac_expr c);
   match c with
 
@@ -2160,143 +2199,304 @@ let interp ?proof ~atts ~st c =
 
   (* Syntax *)
   | VernacSyntaxExtension (infix, sl) ->
-      with_module_locality ~atts vernac_syntax_extension infix sl
-  | VernacDeclareScope sc -> with_module_locality ~atts vernac_declare_scope sc
-  | VernacDelimiters (sc,lr) -> with_module_locality ~atts vernac_delimiters sc lr
-  | VernacBindScope (sc,rl) -> with_module_locality ~atts vernac_bind_scope sc rl
-  | VernacOpenCloseScope (b, s) -> with_section_locality ~atts vernac_open_close_scope (b,s)
-  | VernacInfix (mv,qid,sc) -> with_module_locality ~atts vernac_infix mv qid sc
-  | VernacNotation (c,infpl,sc) -> with_module_locality ~atts vernac_notation c infpl sc
+    with_module_locality ~atts vernac_syntax_extension infix sl;
+    pstate
+  | VernacDeclareScope sc ->
+    with_module_locality ~atts vernac_declare_scope sc;
+    pstate
+  | VernacDelimiters (sc,lr) ->
+    with_module_locality ~atts vernac_delimiters sc lr;
+    pstate
+  | VernacBindScope (sc,rl) ->
+    with_module_locality ~atts vernac_bind_scope sc rl;
+    pstate
+  | VernacOpenCloseScope (b, s) ->
+    with_section_locality ~atts vernac_open_close_scope (b,s);
+    pstate
+  | VernacInfix (mv,qid,sc) ->
+    with_module_locality ~atts vernac_infix mv qid sc;
+    pstate
+  | VernacNotation (c,infpl,sc) ->
+    with_module_locality ~atts vernac_notation c infpl sc;
+    pstate
   | VernacNotationAddFormat(n,k,v) ->
     unsupported_attributes atts;
-    Metasyntax.add_notation_extra_printing_rule n k v
+    Metasyntax.add_notation_extra_printing_rule n k v;
+    pstate
   | VernacDeclareCustomEntry s ->
-      with_module_locality ~atts vernac_custom_entry s
+    with_module_locality ~atts vernac_custom_entry s;
+    pstate
 
   (* Gallina *)
   | VernacDefinition ((discharge,kind),lid,d) ->
-      vernac_definition ~atts discharge kind lid d
-  | VernacStartTheoremProof (k,l) -> vernac_start_proof ~atts k l
-  | VernacEndProof e -> unsupported_attributes atts; vernac_end_proof ?proof e
-  | VernacExactProof c -> unsupported_attributes atts; vernac_exact_proof c
+    let _ = vernac_definition ~atts discharge kind lid d in
+    pstate
+  | VernacStartTheoremProof (k,l) ->
+    let _ = vernac_start_proof ~atts k l in
+    pstate
+  | VernacEndProof e ->
+    unsupported_attributes atts;
+    vernac_require_open_proof ~pstate (vernac_end_proof ?proof e)
+  | VernacExactProof c ->
+    unsupported_attributes atts;
+    vernac_require_open_proof ~pstate (vernac_exact_proof c)
   | VernacAssumption ((discharge,kind),nl,l) ->
-      vernac_assumption ~atts discharge kind l nl
-  | VernacInductive (cum, priv, finite, l) -> vernac_inductive ~atts cum priv finite l
-  | VernacFixpoint (discharge, l) -> vernac_fixpoint ~atts discharge l
-  | VernacCoFixpoint (discharge, l) -> vernac_cofixpoint ~atts discharge l
-  | VernacScheme l -> unsupported_attributes atts; vernac_scheme l
-  | VernacCombinedScheme (id, l) -> unsupported_attributes atts; vernac_combined_scheme id l
-  | VernacUniverse l -> vernac_universe ~poly:(only_polymorphism atts) l
-  | VernacConstraint l -> vernac_constraint ~poly:(only_polymorphism atts) l
+    vernac_assumption ~atts discharge kind l nl;
+    pstate
+  | VernacInductive (cum, priv, finite, l) ->
+    vernac_inductive ~atts cum priv finite l;
+    pstate
+  | VernacFixpoint (discharge, l) ->
+    vernac_fixpoint ~atts discharge l
+  | VernacCoFixpoint (discharge, l) ->
+    vernac_cofixpoint ~atts discharge l
+  | VernacScheme l ->
+    unsupported_attributes atts;
+    vernac_scheme l;
+    pstate
+  | VernacCombinedScheme (id, l) ->
+    unsupported_attributes atts;
+    vernac_combined_scheme id l;
+    pstate
+  | VernacUniverse l ->
+    vernac_universe ~poly:(only_polymorphism atts) l;
+    pstate
+  | VernacConstraint l ->
+    vernac_constraint ~poly:(only_polymorphism atts) l;
+    pstate
 
   (* Modules *)
   | VernacDeclareModule (export,lid,bl,mtyo) ->
-      unsupported_attributes atts; vernac_declare_module export lid bl mtyo
+    unsupported_attributes atts;
+    vernac_declare_module export lid bl mtyo;
+    pstate
   | VernacDefineModule (export,lid,bl,mtys,mexprl) ->
-      unsupported_attributes atts; vernac_define_module export lid bl mtys mexprl
+    unsupported_attributes atts;
+    vernac_define_module ~pstate export lid bl mtys mexprl;
+    pstate
   | VernacDeclareModuleType (lid,bl,mtys,mtyo) ->
-      unsupported_attributes atts; vernac_declare_module_type lid bl mtys mtyo
+    unsupported_attributes atts;
+    vernac_declare_module_type ~pstate lid bl mtys mtyo;
+    pstate
   | VernacInclude in_asts ->
-      unsupported_attributes atts; vernac_include in_asts
+    unsupported_attributes atts;
+    vernac_include in_asts;
+    pstate
   (* Gallina extensions *)
-  | VernacBeginSection lid -> unsupported_attributes atts; vernac_begin_section lid
+  | VernacBeginSection lid ->
+    unsupported_attributes atts;
+    vernac_begin_section ~pstate lid;
+    pstate
 
-  | VernacEndSegment lid -> unsupported_attributes atts; vernac_end_segment lid
+  | VernacEndSegment lid ->
+    unsupported_attributes atts;
+    vernac_end_segment ~pstate lid;
+    pstate
 
-  | VernacNameSectionHypSet (lid, set) -> unsupported_attributes atts; vernac_name_sec_hyp lid set
+  | VernacNameSectionHypSet (lid, set) ->
+    unsupported_attributes atts;
+    vernac_name_sec_hyp lid set;
+    pstate
 
-  | VernacRequire (from, export, qidl) -> unsupported_attributes atts; vernac_require from export qidl
-  | VernacImport (export,qidl) -> unsupported_attributes atts; vernac_import export qidl
-  | VernacCanonical qid -> unsupported_attributes atts; vernac_canonical qid
-  | VernacCoercion (r,s,t) -> vernac_coercion ~atts r s t
+  | VernacRequire (from, export, qidl) ->
+    unsupported_attributes atts;
+    vernac_require from export qidl;
+    pstate
+  | VernacImport (export,qidl) ->
+    unsupported_attributes atts;
+    vernac_import export qidl;
+    pstate
+  | VernacCanonical qid ->
+    unsupported_attributes atts;
+    vernac_canonical qid;
+    pstate
+  | VernacCoercion (r,s,t) ->
+    vernac_coercion ~atts r s t;
+    pstate
   | VernacIdentityCoercion ({v=id},s,t) ->
-      vernac_identity_coercion ~atts id s t
+    vernac_identity_coercion ~atts id s t;
+    pstate
 
   (* Type classes *)
   | VernacInstance (abst, sup, inst, props, info) ->
-      vernac_instance ~atts abst sup inst props info
-  | VernacContext sup -> vernac_context ~poly:(only_polymorphism atts) sup
-  | VernacDeclareInstances insts -> with_section_locality ~atts vernac_declare_instances insts
-  | VernacDeclareClass id -> unsupported_attributes atts; vernac_declare_class id
+    vernac_instance ~atts abst sup inst props info;
+    pstate
+  | VernacContext sup ->
+    vernac_context ~poly:(only_polymorphism atts) sup;
+    pstate
+  | VernacDeclareInstances insts ->
+    with_section_locality ~atts vernac_declare_instances insts;
+    pstate
+  | VernacDeclareClass id ->
+    unsupported_attributes atts;
+    vernac_declare_class id;
+    pstate
 
   (* Solving *)
-  | VernacSolveExistential (n,c) -> unsupported_attributes atts; vernac_solve_existential n c
+  | VernacSolveExistential (n,c) ->
+    unsupported_attributes atts;
+    Some (vernac_require_open_proof ~pstate (vernac_solve_existential n c))
 
   (* Auxiliary file and library management *)
-  | VernacAddLoadPath (isrec,s,alias) -> unsupported_attributes atts; vernac_add_loadpath isrec s alias
-  | VernacRemoveLoadPath s -> unsupported_attributes atts; vernac_remove_loadpath s
-  | VernacAddMLPath (isrec,s) -> unsupported_attributes atts; vernac_add_ml_path isrec s
-  | VernacDeclareMLModule l -> with_locality ~atts vernac_declare_ml_module l
-  | VernacChdir s -> unsupported_attributes atts; vernac_chdir s
+  | VernacAddLoadPath (isrec,s,alias) ->
+    unsupported_attributes atts;
+    vernac_add_loadpath isrec s alias;
+    pstate
+  | VernacRemoveLoadPath s ->
+    unsupported_attributes atts;
+    vernac_remove_loadpath s;
+    pstate
+  | VernacAddMLPath (isrec,s) ->
+    unsupported_attributes atts;
+    vernac_add_ml_path isrec s;
+    pstate
+  | VernacDeclareMLModule l ->
+    with_locality ~atts vernac_declare_ml_module l;
+    pstate
+  | VernacChdir s ->
+    unsupported_attributes atts;
+    vernac_chdir s;
+    pstate
 
   (* State management *)
-  | VernacWriteState s -> unsupported_attributes atts; vernac_write_state s
-  | VernacRestoreState s -> unsupported_attributes atts; vernac_restore_state s
+  | VernacWriteState s ->
+    unsupported_attributes atts;
+    vernac_write_state s;
+    pstate
+  | VernacRestoreState s ->
+    unsupported_attributes atts;
+    vernac_restore_state s;
+    pstate
 
   (* Commands *)
   | VernacCreateHintDb (dbname,b) ->
-    with_module_locality ~atts vernac_create_hintdb dbname b
+    with_module_locality ~atts vernac_create_hintdb dbname b;
+    pstate
   | VernacRemoveHints (dbnames,ids) ->
-    with_module_locality ~atts vernac_remove_hints dbnames ids
+    with_module_locality ~atts vernac_remove_hints dbnames ids;
+    pstate
   | VernacHints (dbnames,hints) ->
-      vernac_hints ~atts dbnames hints
+    vernac_hints ~atts dbnames hints;
+    pstate
   | VernacSyntacticDefinition (id,c,b) ->
-      with_module_locality ~atts vernac_syntactic_definition id c b
+    with_module_locality ~atts vernac_syntactic_definition id c b;
+    pstate
   | VernacArguments (qid, args, more_implicits, nargs, flags) ->
-      with_section_locality ~atts vernac_arguments qid args more_implicits nargs flags
-  | VernacReserve bl -> unsupported_attributes atts; vernac_reserve bl
-  | VernacGeneralizable gen -> with_locality ~atts vernac_generalizable gen
-  | VernacSetOpacity qidl -> with_locality ~atts vernac_set_opacity qidl
-  | VernacSetStrategy l -> with_locality ~atts vernac_set_strategy l
-  | VernacSetOption (export, key,v) -> vernac_set_option ~local:(only_locality atts) export key v
-  | VernacUnsetOption (export, key) -> vernac_unset_option ~local:(only_locality atts) export key
-  | VernacRemoveOption (key,v) -> unsupported_attributes atts; vernac_remove_option key v
-  | VernacAddOption (key,v) -> unsupported_attributes atts; vernac_add_option key v
-  | VernacMemOption (key,v) -> unsupported_attributes atts; vernac_mem_option key v
-  | VernacPrintOption key -> unsupported_attributes atts; vernac_print_option key
+    with_section_locality ~atts vernac_arguments qid args more_implicits nargs flags;
+    pstate
+  | VernacReserve bl ->
+    unsupported_attributes atts;
+    vernac_reserve bl;
+    pstate
+  | VernacGeneralizable gen ->
+    with_locality ~atts vernac_generalizable gen;
+    pstate
+  | VernacSetOpacity qidl ->
+    with_locality ~atts vernac_set_opacity qidl;
+    pstate
+  | VernacSetStrategy l ->
+    with_locality ~atts vernac_set_strategy l;
+    pstate
+  | VernacSetOption (export, key,v) ->
+    vernac_set_option ~local:(only_locality atts) export key v;
+    pstate
+  | VernacUnsetOption (export, key) ->
+    vernac_unset_option ~local:(only_locality atts) export key;
+    pstate
+  | VernacRemoveOption (key,v) ->
+    unsupported_attributes atts;
+    vernac_remove_option key v;
+    pstate
+  | VernacAddOption (key,v) ->
+    unsupported_attributes atts;
+    vernac_add_option key v;
+    pstate
+  | VernacMemOption (key,v) ->
+    unsupported_attributes atts;
+    vernac_mem_option key v;
+    pstate
+  | VernacPrintOption key ->
+    unsupported_attributes atts;
+    vernac_print_option key;
+    pstate
   | VernacCheckMayEval (r,g,c) ->
-    Feedback.msg_notice @@ vernac_check_may_eval ~atts r g c
-  | VernacDeclareReduction (s,r) -> with_locality ~atts vernac_declare_reduction s r
+    Feedback.msg_notice @@
+      vernac_require_open_proof ~pstate (vernac_check_may_eval ~atts r g c);
+    pstate
+  | VernacDeclareReduction (s,r) ->
+    with_locality ~atts vernac_declare_reduction s r;
+    pstate
   | VernacGlobalCheck c ->
     unsupported_attributes atts;
-    Feedback.msg_notice @@ vernac_global_check c
+    Feedback.msg_notice @@ vernac_global_check c;
+    pstate
   | VernacPrint p ->
-    let sigma, env = Pfedit.get_current_context () in
-    Feedback.msg_notice @@ vernac_print ~atts env sigma p
-  | VernacSearch (s,g,r) -> unsupported_attributes atts; vernac_search ~atts s g r
+    Feedback.msg_notice @@ vernac_print ~pstate ~atts p;
+    pstate
+  | VernacSearch (s,g,r) ->
+    unsupported_attributes atts;
+    vernac_search ~pstate ~atts s g r;
+    pstate
   | VernacLocate l -> unsupported_attributes atts;
-    Feedback.msg_notice @@ vernac_locate l
-  | VernacRegister (qid, r) -> unsupported_attributes atts; vernac_register qid r
-  | VernacComments l -> unsupported_attributes atts;
-    Flags.if_verbose Feedback.msg_info (str "Comments ok\n")
+    Feedback.msg_notice @@ vernac_locate ~pstate l;
+    pstate
+  | VernacRegister (qid, r) ->
+    unsupported_attributes atts;
+    vernac_register ~pstate qid r;
+    pstate
+  | VernacComments l ->
+    unsupported_attributes atts;
+    Flags.if_verbose Feedback.msg_info (str "Comments ok\n");
+    pstate
 
   (* Proof management *)
-  | VernacFocus n -> unsupported_attributes atts; vernac_focus n
-  | VernacUnfocus -> unsupported_attributes atts; vernac_unfocus ()
-  | VernacUnfocused -> unsupported_attributes atts;
-    Feedback.msg_notice @@ vernac_unfocused ()
-  | VernacBullet b -> unsupported_attributes atts; vernac_bullet b
-  | VernacSubproof n -> unsupported_attributes atts; vernac_subproof n
-  | VernacEndSubproof -> unsupported_attributes atts; vernac_end_subproof ()
-  | VernacShow s -> unsupported_attributes atts;
-    Feedback.msg_notice @@ vernac_show s
-  | VernacCheckGuard -> unsupported_attributes atts;
-    Feedback.msg_notice @@ vernac_check_guard ()
-  | VernacProof (tac, using) -> unsupported_attributes atts;
+  | VernacFocus n ->
+    unsupported_attributes atts;
+    Option.map (vernac_focus n) pstate
+  | VernacUnfocus ->
+    unsupported_attributes atts;
+    Option.map (vernac_unfocus ()) pstate
+  | VernacUnfocused ->
+    unsupported_attributes atts;
+    Option.iter (fun pstate -> Feedback.msg_notice @@ vernac_unfocused ~pstate) pstate;
+    pstate
+  | VernacBullet b ->
+    unsupported_attributes atts;
+    Option.map (vernac_bullet b) pstate
+  | VernacSubproof n ->
+    unsupported_attributes atts;
+    Option.map (vernac_subproof n) pstate
+  | VernacEndSubproof ->
+    unsupported_attributes atts;
+    Option.map (vernac_end_subproof ()) pstate
+  | VernacShow s ->
+    unsupported_attributes atts;
+    Option.iter (fun pstate -> Feedback.msg_notice @@ vernac_show ~pstate s) pstate;
+    pstate
+  | VernacCheckGuard ->
+    unsupported_attributes atts;
+    Feedback.msg_notice @@
+      vernac_require_open_proof ~pstate (vernac_check_guard);
+    pstate
+  | VernacProof (tac, using) ->
+    unsupported_attributes atts;
     let using = Option.append using (Proof_using.get_default_proof_using ()) in
     let tacs = if Option.is_empty tac then "tac:no" else "tac:yes" in
     let usings = if Option.is_empty using then "using:no" else "using:yes" in
     Aux_file.record_in_aux_at "VernacProof" (tacs^" "^usings);
-    Option.iter vernac_set_end_tac tac;
-    Option.iter vernac_set_used_variables using
+    let pstate =
+      vernac_require_open_proof ~pstate (fun ~pstate ->
+          let pstate = Option.cata (vernac_set_end_tac ~pstate) pstate tac in
+          Option.cata (vernac_set_used_variables ~pstate) pstate using)
+    in Some pstate
   | VernacProofMode mn -> unsupported_attributes atts;
-    Proof_global.set_proof_mode mn [@ocaml.warning "-3"]
+    Option.map (Proof_global.set_proof_mode mn) pstate [@ocaml.warning "-3"]
 
   (* Extensions *)
   | VernacExtend (opn,args) ->
     (* XXX: Here we are returning the state! :) *)
-    let _st : Vernacstate.t = Vernacextend.call ~atts opn args ~st in
-    ()
+    let st : Vernacstate.t = Vernacextend.call ~atts opn args ~st in
+    st.Vernacstate.proof
 
 (** A global default timeout, controlled by option "Set Default Timeout n".
     Use "Unset Default Timeout" to deactivate it (or set it to 0). *)
@@ -2316,12 +2516,18 @@ let _ =
 
 let current_timeout = ref None
 
-let vernac_timeout f =
+let vernac_timeout (f : 'a -> 'b) (x : 'a) : 'b =
   match !current_timeout, !default_timeout with
-    | Some n, _ | None, Some n ->
-      let f () = f (); current_timeout := None in
-      Control.timeout n f () Timeout
-    | None, None -> f ()
+    | Some n, _
+    | None, Some n ->
+      let f v =
+        let res = f v in
+        current_timeout := None;
+        res
+      in
+      Control.timeout n f x Timeout
+    | None, None ->
+      f x
 
 let restore_timeout () = current_timeout := None
 
@@ -2335,14 +2541,14 @@ exception HasFailed of Pp.t
 
 (* XXX STATE: this type hints that restoring the state should be the
    caller's responsibility *)
-let with_fail st b f =
+let with_fail ~st b f =
   if not b
   then f ()
   else begin try
       (* If the command actually works, ignore its effects on the state.
        * Note that error has to be printed in the right state, hence
        * within the purified function *)
-      try f (); raise HasNotFailed
+      try ignore (f ()); raise HasNotFailed
       with
       | HasNotFailed as e -> raise e
       | e ->
@@ -2359,30 +2565,32 @@ let with_fail st b f =
           user_err ~hdr:"Fail" (str "The command has not failed!")
       | HasFailed msg ->
           if not !Flags.quiet || !Flags.test_mode then Feedback.msg_info
-            (str "The command has indeed failed with message:" ++ fnl () ++ msg)
+            (str "The command has indeed failed with message:" ++ fnl () ++ msg);
+          st.Vernacstate.proof
       | _ -> assert false
   end
 
-let interp ?(verbosely=true) ?proof ~st {CAst.loc;v=c} =
+let interp ?(verbosely=true) ?proof ~st {CAst.loc;v=c} : Proof_global.t option =
   let orig_program_mode = Flags.is_program_mode () in
-  let rec control = function
+  let rec control ~st = function
   | VernacExpr (atts, v) ->
-    aux ~atts v
-  | VernacFail v -> with_fail st true (fun () -> control v)
+    aux ~atts ~st v
+  | VernacFail v ->
+    with_fail ~st true (fun () -> control ~st v)
   | VernacTimeout (n,v) ->
     current_timeout := Some n;
-    control v
+    control ~st v
   | VernacRedirect (s, {v}) ->
-    Topfmt.with_output_to_file s control v
+    Topfmt.with_output_to_file s (control ~st) v
   | VernacTime (batch, {v}) ->
-    System.with_time ~batch control v;
+    System.with_time ~batch (control ~st) v;
 
-  and aux ~atts : _ -> unit =
+  and aux ~atts ~st : _ -> Proof_global.t option =
     function
 
     | VernacLoad (_,fname) ->
       unsupported_attributes atts;
-      vernac_load control fname
+      vernac_load ~st control fname
 
     | c ->
       let program = let open Attributes in
@@ -2392,37 +2600,40 @@ let interp ?(verbosely=true) ?proof ~st {CAst.loc;v=c} =
          just parsing them to do our option magic. *)
       Option.iter Obligations.set_program_mode program;
       try
-        vernac_timeout begin fun () ->
-          if verbosely
-          then Flags.verbosely (interp ?proof ~atts ~st) c
-          else Flags.silently  (interp ?proof ~atts ~st) c;
+        vernac_timeout begin fun st ->
+          let pstate : Proof_global.t option =
+            if verbosely
+            then Flags.verbosely (interp ?proof ~atts ~st) c
+            else Flags.silently  (interp ?proof ~atts ~st) c
+          in
           (* If the command is `(Un)Set Program Mode` or `(Un)Set Universe Polymorphism`,
              we should not restore the previous state of the flag... *)
           if Option.has_some program then
             Flags.program_mode := orig_program_mode;
-          end
-        with
-        | reraise when
-              (match reraise with
-              | Timeout -> true
-              | e -> CErrors.noncritical e)
-          ->
-            let e = CErrors.push reraise in
-            let e = locate_if_not_already ?loc e in
-            let () = restore_timeout () in
-            Flags.program_mode := orig_program_mode;
-            iraise e
+          pstate
+          end st
+      with
+      | reraise when
+          (match reraise with
+           | Timeout -> true
+           | e -> CErrors.noncritical e)
+        ->
+        let e = CErrors.push reraise in
+        let e = locate_if_not_already ?loc e in
+        let () = restore_timeout () in
+        Flags.program_mode := orig_program_mode;
+        iraise e
   in
   if verbosely
-  then Flags.verbosely control c
-  else control  c
+  then Flags.verbosely (control ~st) c
+  else (control ~st) c
 
 (* Be careful with the cache here in case of an exception. *)
 let interp ?verbosely ?proof ~st cmd =
   Vernacstate.unfreeze_interp_state st;
   try
-    interp ?verbosely ?proof ~st cmd;
-    Vernacstate.freeze_interp_state `No
+    let pstate = interp ?verbosely ?proof ~st cmd in
+    Vernacstate.freeze_interp_state ~pstate `No
   with exn ->
     let exn = CErrors.push exn in
     Vernacstate.invalidate_cache ();

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -2536,47 +2536,13 @@ let locate_if_not_already ?loc (e, info) =
   | None   -> (e, Option.cata (Loc.add_loc info) info loc)
   | Some l -> (e, info)
 
-exception HasNotFailed
-exception HasFailed of Pp.t
-
-(* XXX STATE: this type hints that restoring the state should be the
-   caller's responsibility *)
-let with_fail ~st b f =
-  if not b
-  then f ()
-  else begin try
-      (* If the command actually works, ignore its effects on the state.
-       * Note that error has to be printed in the right state, hence
-       * within the purified function *)
-      try ignore (f ()); raise HasNotFailed
-      with
-      | HasNotFailed as e -> raise e
-      | e ->
-        let e = CErrors.push e in
-        raise (HasFailed (CErrors.iprint
-                            (ExplainErr.process_vernac_interp_error ~allow_uncaught:false e)))
-    with e when CErrors.noncritical e ->
-      (* Restore the previous state XXX Careful here with the cache! *)
-      Vernacstate.invalidate_cache ();
-      Vernacstate.unfreeze_interp_state st;
-      let (e, _) = CErrors.push e in
-      match e with
-      | HasNotFailed ->
-          user_err ~hdr:"Fail" (str "The command has not failed!")
-      | HasFailed msg ->
-          if not !Flags.quiet || !Flags.test_mode then Feedback.msg_info
-            (str "The command has indeed failed with message:" ++ fnl () ++ msg);
-          st.Vernacstate.proof
-      | _ -> assert false
-  end
-
 let interp ?(verbosely=true) ?proof ~st {CAst.loc;v=c} : Proof_global.t option =
   let orig_program_mode = Flags.is_program_mode () in
   let rec control ~st = function
   | VernacExpr (atts, v) ->
     aux ~atts ~st v
   | VernacFail v ->
-    with_fail ~st true (fun () -> control ~st v)
+    Vernacstate.with_fail ~st (fun () -> control ~st v)
   | VernacTimeout (n,v) ->
     current_timeout := Some n;
     control ~st v

--- a/vernac/vernacentries.mli
+++ b/vernac/vernacentries.mli
@@ -30,7 +30,7 @@ val make_cases : string -> string list list
 
 (* XXX STATE: this type hints that restoring the state should be the
    caller's responsibility *)
-val with_fail : Vernacstate.t -> bool -> (unit -> unit) -> unit
+val with_fail : st:Vernacstate.t -> bool -> (unit -> Proof_global.t option) -> Proof_global.t option
 
 val command_focus : unit Proof.focus_kind
 

--- a/vernac/vernacentries.mli
+++ b/vernac/vernacentries.mli
@@ -28,10 +28,6 @@ val interp :
 
 val make_cases : string -> string list list
 
-(* XXX STATE: this type hints that restoring the state should be the
-   caller's responsibility *)
-val with_fail : st:Vernacstate.t -> bool -> (unit -> Proof_global.t option) -> Proof_global.t option
-
 val command_focus : unit Proof.focus_kind
 
 val interp_redexp_hook : (Environ.env -> Evd.evar_map -> Genredexpr.raw_red_expr ->

--- a/vernac/vernacstate.ml
+++ b/vernac/vernacstate.ml
@@ -15,11 +15,9 @@ type t = {
 }
 
 let s_cache = ref None
-let s_proof = ref None
 
 let invalidate_cache () =
-  s_cache := None;
-  s_proof := None
+  s_cache := None
 
 let update_cache rf v =
   rf := Some v; v
@@ -40,3 +38,122 @@ let freeze_interp_state ~pstate marshallable =
 
 let unfreeze_interp_state { system } =
   do_if_not_cached s_cache States.unfreeze system
+
+exception HasNotFailed
+exception HasFailed of Pp.t
+
+(* XXX STATE: this type hints that restoring the state should be the
+   caller's responsibility *)
+let with_fail ~st f =
+  try
+    (* If the command actually works, ignore its effects on the state.
+     * Note that error has to be printed in the right state, hence
+     * within the purified function *)
+    try
+      ignore (f ());
+      raise HasNotFailed
+    with
+    | HasNotFailed as e -> raise e
+    | e ->
+      let e = CErrors.push e in
+      raise (HasFailed
+               (CErrors.iprint
+                  (ExplainErr.process_vernac_interp_error ~allow_uncaught:false e)))
+  with e when CErrors.noncritical e ->
+    (* Restore the previous state XXX Careful here with the cache! *)
+    invalidate_cache ();
+    unfreeze_interp_state st;
+    let (e, _) = CErrors.push e in
+    match e with
+    | HasNotFailed ->
+      CErrors.user_err ~hdr:"Fail" Pp.(str "The command has not failed!")
+    | HasFailed msg ->
+      if not !Flags.quiet || !Flags.test_mode then Feedback.msg_info
+          Pp.(str "The command has indeed failed with message:" ++ fnl () ++ msg);
+      st.proof
+    | _ -> assert false
+
+module StmCompat = struct
+
+  let p_state = ref None
+
+  let freeze marshallable =
+  { system = update_cache s_cache (States.freeze ~marshallable);
+    proof  = !p_state;
+    shallow = marshallable = `Shallow }
+
+  let unfreeze { system ; proof } =
+    do_if_not_cached s_cache States.unfreeze system;
+    p_state := proof
+
+  let with_fail ~(st : t) f =
+    let f () = f (); !p_state in
+    p_state := with_fail ~st f
+
+  exception NoCurrentProof
+
+  let there_are_pending_proofs () =
+    not Option.(is_empty !p_state)
+
+  let get_open_goals () =
+    Option.cata Proof_global.get_open_goals 0 !p_state
+
+  let set_terminator t =
+    p_state := Option.map Proof_global.(set_terminator t) !p_state
+
+  let give_me_the_proof () =
+    match !p_state with
+    | Some pstate -> Proof_global.give_me_the_proof pstate
+    | None -> raise NoCurrentProof
+
+  let get_current_proof_name () =
+    match !p_state with
+    | Some pstate -> Proof_global.get_current_proof_name pstate
+    | None -> raise NoCurrentProof
+
+  let simple_with_current_proof f =
+    p_state :=
+      match !p_state with
+      | Some pstate -> Some (Proof_global.simple_with_current_proof f pstate)
+      | None -> raise NoCurrentProof
+
+  let with_current_proof f =
+    let ps, ret =
+      match !p_state with
+      | Some pstate -> Proof_global.with_current_proof f pstate
+      | None -> raise NoCurrentProof
+    in
+    p_state := Some ps; ret
+
+  let install_state st = p_state := Some st
+
+  let return_proof ?allow_partial () =
+    match !p_state with
+    | Some pstate ->
+      Proof_global.return_proof ?allow_partial pstate
+    | None -> raise NoCurrentProof
+
+  let close_future_proof ~feedback_id f =
+    match !p_state with
+    | Some pstate ->
+      Proof_global.close_future_proof ~feedback_id pstate f
+    | None -> raise NoCurrentProof
+
+  let close_proof ~keep_body_ucst_separate f =
+    match !p_state with
+    | Some pstate ->
+      Proof_global.close_proof ~keep_body_ucst_separate f pstate
+    | None -> raise NoCurrentProof
+
+  let discard_all () = ()
+  let update_global_env () = ()
+
+  let get_current_context () =
+    match !p_state with
+    | Some pstate ->
+      Pfedit.get_current_context pstate
+    | None ->
+      let env = Global.env () in
+      Evd.from_env env, env
+
+end

--- a/vernac/vernacstate.ml
+++ b/vernac/vernacstate.ml
@@ -9,9 +9,9 @@
 (************************************************************************)
 
 type t = {
-  system  : States.state;        (* summary + libstack *)
-  proof   : Proof_global.t;      (* proof state *)
-  shallow : bool                 (* is the state trimmed down (libstack) *)
+  system  : States.state;          (* summary + libstack *)
+  proof   : Proof_global.t option; (* proof state *)
+  shallow : bool                   (* is the state trimmed down (libstack) *)
 }
 
 let s_cache = ref None
@@ -33,11 +33,10 @@ let do_if_not_cached rf f v =
   | Some _ ->
     ()
 
-let freeze_interp_state marshallable =
+let freeze_interp_state ~pstate marshallable =
   { system = update_cache s_cache (States.freeze ~marshallable);
-    proof  = update_cache s_proof (Proof_global.freeze ~marshallable);
+    proof  = pstate;
     shallow = marshallable = `Shallow }
 
-let unfreeze_interp_state { system; proof } =
-  do_if_not_cached s_cache States.unfreeze system;
-  do_if_not_cached s_proof Proof_global.unfreeze proof
+let unfreeze_interp_state { system } =
+  do_if_not_cached s_cache States.unfreeze system

--- a/vernac/vernacstate.mli
+++ b/vernac/vernacstate.mli
@@ -9,12 +9,12 @@
 (************************************************************************)
 
 type t = {
-  system  : States.state;        (* summary + libstack *)
-  proof   : Proof_global.t;      (* proof state *)
-  shallow : bool                 (* is the state trimmed down (libstack) *)
+  system  : States.state;          (* summary + libstack *)
+  proof   : Proof_global.t option; (* proof state *)
+  shallow : bool                   (* is the state trimmed down (libstack) *)
 }
 
-val freeze_interp_state : Summary.marshallable -> t
+val freeze_interp_state : pstate:Proof_global.t option -> Summary.marshallable -> t
 val unfreeze_interp_state : t -> unit
 
 (* WARNING: Do not use, it will go away in future releases *)

--- a/vernac/vernacstate.mli
+++ b/vernac/vernacstate.mli
@@ -19,3 +19,47 @@ val unfreeze_interp_state : t -> unit
 
 (* WARNING: Do not use, it will go away in future releases *)
 val invalidate_cache : unit -> unit
+
+(* XXX STATE: this type hints that restoring the state should be the
+   caller's responsibility *)
+val with_fail : st:t -> (unit -> Proof_global.t option) -> Proof_global.t option
+
+module StmCompat : sig
+
+  val freeze : Summary.marshallable -> t
+  val unfreeze : t -> unit
+
+  val with_fail : st:t -> (unit -> unit) -> unit
+
+  open Proof_global
+  exception NoCurrentProof
+
+  val there_are_pending_proofs : unit -> bool
+  val get_open_goals : unit -> int
+
+  val set_terminator : proof_terminator -> unit
+  val give_me_the_proof : unit -> Proof.t
+  val get_current_proof_name : unit -> Names.Id.t
+
+  val simple_with_current_proof :
+      (unit Proofview.tactic -> Proof.t -> Proof.t) -> unit
+
+  val with_current_proof :
+      (unit Proofview.tactic -> Proof.t -> Proof.t * 'a) -> 'a
+
+  val install_state : t -> unit
+
+  val return_proof : ?allow_partial:bool -> unit -> closed_proof_output
+
+  val close_future_proof :
+    feedback_id:Stateid.t ->
+    closed_proof_output Future.computation -> closed_proof
+
+  val close_proof : keep_body_ucst_separate:bool -> Future.fix_exn -> closed_proof
+
+  val discard_all : unit -> unit
+  val update_global_env : unit -> unit
+
+  val get_current_context : unit -> Evd.evar_map * Environ.env
+
+end


### PR DESCRIPTION
Currently, proofs are stored in a global variable in `Proof_global`,
which is then kept in sync with the `Stm` notion of proof for each
particular state.

In this commit, we make some partial progress towards removal of such
global state in favor of a functional handling of the proof state. For
now, we deprecate functions accessing the global proof state to get an
idea of the remaining work.

Completing this work seems doable for 8.8, however the question on
compatibility should be addressed. There are 3 possible choices:

- Deprecate all the interfaces, but remove the global proof state in
  8.9 . This implies having Coq use some of the bad interfaces itself.

- Hard removal of the impure interfaces.

- Removal of the global proof state, keep the deprecated interfaces
  and install a private compatibility hook for the STM to update the
  proof state while the transition happens.

I think the best option is 2, even if a bit painful. 1 has a big risk
of delaying work and so the work may never happen. 3 is a bit of a
hack and IMO the advantages are not so clear.

EDIT: this depends on #7196.