### PR TITLE
[plugin] Remove LocalityFixme über hack.

### DIFF
--- a/API/API.mli
+++ b/API/API.mli
@@ -5982,8 +5982,15 @@ sig
 
   type deprecation = bool
 
+  type atts = {
+    loc : Loc.t option;
+    locality : bool option;
+  }
+
   type vernac_command =
-    Genarg.raw_generic_argument list -> Loc.t option -> Vernacstate.t -> Vernacstate.t
+    Genarg.raw_generic_argument list ->
+    atts:atts -> st:Vernacstate.t ->
+    Vernacstate.t
 
   val vinterp_add : deprecation -> Vernacexpr.extend_name -> vernac_command -> unit
 

--- a/API/API.mli
+++ b/API/API.mli
@@ -5837,9 +5837,6 @@ end
 module Locality :
 sig
   val make_section_locality : bool option -> bool
-  module LocalityFixme : sig
-    val consume : unit -> bool option
-  end
   val make_module_locality : bool option -> bool
 end
 

--- a/dev/ci/user-overlays/06197-ejgallego-plugins+remove_locality_hack.sh
+++ b/dev/ci/user-overlays/06197-ejgallego-plugins+remove_locality_hack.sh
@@ -1,0 +1,4 @@
+if [ "$TRAVIS_PULL_REQUEST" = "6197" ] || [ "$TRAVIS_BRANCH" = "plugins+remove_locality_hack" ]; then
+    ltac2_CI_BRANCH=localityfixyou
+    ltac2_CI_GITURL=https://github.com/ejgallego/ltac2.git
+fi

--- a/dev/top_printers.ml
+++ b/dev/top_printers.ml
@@ -509,7 +509,7 @@ let _ =
       (function
          [c] when genarg_tag c = unquote (topwit wit_constr) && true ->
            let c = out_gen (rawwit wit_constr) c in
-           (fun _ st -> in_current_context constr_display c; st)
+           (fun ~atts ~st -> in_current_context constr_display c; st)
        | _ -> failwith "Vernac extension: cannot occur")
   with
     e -> pp (CErrors.print e)
@@ -525,7 +525,7 @@ let _ =
       (function
          [c] when genarg_tag c = unquote (topwit wit_constr) && true ->
            let c = out_gen (rawwit wit_constr) c in
-           (fun _ st -> in_current_context print_pure_constr c; st)
+           (fun ~atts ~st -> in_current_context print_pure_constr c; st)
        | _ -> failwith "Vernac extension: cannot occur")
   with
     e -> pp (CErrors.print e)

--- a/grammar/vernacextend.mlp
+++ b/grammar/vernacextend.mlp
@@ -173,11 +173,11 @@ EXTEND
     [ [ "["; s = STRING; l = LIST0 args; "]";
         d = OPT deprecation; c = OPT classifier; "->"; "["; e = Pcaml.expr; "]" ->
       let () = if s = "" then failwith "Command name is empty." in
-      let b = <:expr< fun loc -> ( let () = $e$ in fun st -> st ) >> in
+      let b = <:expr< fun ~atts ~st -> ( let () = $e$ in st ) >> in
       { r_head = Some s; r_patt = l; r_class = c; r_branch = b; r_depr = d; }
       | "[" ; "-" ; l = LIST1 args ; "]" ;
         d = OPT deprecation; c = OPT classifier; "->"; "["; e = Pcaml.expr; "]" ->
-      let b = <:expr< fun loc -> ( let () = $e$ in fun st -> st ) >> in
+      let b = <:expr< fun ~atts ~st -> ( let () = $e$ in st ) >> in
       { r_head = None; r_patt = l; r_class = c; r_branch = b; r_depr = d; }
     ] ]
   ;

--- a/grammar/vernacextend.mlp
+++ b/grammar/vernacextend.mlp
@@ -136,6 +136,10 @@ EXTEND
         OPT "|"; l = LIST1 rule SEP "|";
         "END" ->
          declare_command loc s c <:expr<None>> l
+      | "VERNAC"; "COMMAND"; "FUNCTIONAL"; "EXTEND"; s = UIDENT; c = OPT classification;
+        OPT "|"; l = LIST1 fun_rule SEP "|";
+        "END" ->
+         declare_command loc s c <:expr<None>> l
       | "VERNAC"; nt = LIDENT ; "EXTEND"; s = UIDENT; c = OPT classification;
         OPT "|"; l = LIST1 rule SEP "|";
         "END" ->
@@ -162,13 +166,6 @@ EXTEND
       (which otherwise could have been another argument) is not passed
       to the VernacExtend interpreter function to discriminate between
       the clauses. *)
-
-  (* ejga: Due to the LocalityFixme abomination we cannot eta-expand
-      [e] as we'd like to, so we need to use the below mess with [fun
-      st -> st].
-
-      At some point We should solve the mess and extend
-      vernacextend.mlp with locality info. *)
   rule:
     [ [ "["; s = STRING; l = LIST0 args; "]";
         d = OPT deprecation; c = OPT classifier; "->"; "["; e = Pcaml.expr; "]" ->
@@ -178,6 +175,18 @@ EXTEND
       | "[" ; "-" ; l = LIST1 args ; "]" ;
         d = OPT deprecation; c = OPT classifier; "->"; "["; e = Pcaml.expr; "]" ->
       let b = <:expr< fun ~atts ~st -> ( let () = $e$ in st ) >> in
+      { r_head = None; r_patt = l; r_class = c; r_branch = b; r_depr = d; }
+    ] ]
+  ;
+  fun_rule:
+    [ [ "["; s = STRING; l = LIST0 args; "]";
+        d = OPT deprecation; c = OPT classifier; "->"; "["; e = Pcaml.expr; "]" ->
+      let () = if s = "" then failwith "Command name is empty." in
+      let b = <:expr< $e$ >> in
+      { r_head = Some s; r_patt = l; r_class = c; r_branch = b; r_depr = d; }
+      | "[" ; "-" ; l = LIST1 args ; "]" ;
+        d = OPT deprecation; c = OPT classifier; "->"; "["; e = Pcaml.expr; "]" ->
+      let b = <:expr< $e$ >> in
       { r_head = None; r_patt = l; r_class = c; r_branch = b; r_depr = d; }
     ] ]
   ;

--- a/plugins/firstorder/g_ground.ml4
+++ b/plugins/firstorder/g_ground.ml4
@@ -65,11 +65,14 @@ let default_intuition_tac =
 let (set_default_solver, default_solver, print_default_solver) = 
   Tactic_option.declare_tactic_option ~default:default_intuition_tac "Firstorder default solver"
 
-VERNAC COMMAND EXTEND Firstorder_Set_Solver CLASSIFIED AS SIDEFF
+VERNAC COMMAND FUNCTIONAL EXTEND Firstorder_Set_Solver CLASSIFIED AS SIDEFF
 | [ "Set" "Firstorder" "Solver" tactic(t) ] -> [
-    set_default_solver 
-      (Locality.make_section_locality (Locality.LocalityFixme.consume ()))
-      (Tacintern.glob_tactic t) ]
+    fun ~atts ~st -> let open Vernacinterp in
+      set_default_solver
+        (Locality.make_section_locality atts.locality)
+        (Tacintern.glob_tactic t);
+        st
+  ]
 END
 
 VERNAC COMMAND EXTEND Firstorder_Print_Solver CLASSIFIED AS QUERY

--- a/plugins/ltac/extratactics.ml4
+++ b/plugins/ltac/extratactics.ml4
@@ -319,24 +319,44 @@ let project_hint pri l2r r =
   let info = {Vernacexpr.hint_priority = pri; hint_pattern = None} in
     (info,false,true,Hints.PathAny, Hints.IsGlobRef (Globnames.ConstRef c))
 
-let add_hints_iff l2r lc n bl =
-  let l = Locality.LocalityFixme.consume () in
-  Hints.add_hints (Locality.make_module_locality l) bl
+let add_hints_iff ?locality l2r lc n bl =
+  Hints.add_hints (Locality.make_module_locality locality) bl
     (Hints.HintsResolveEntry (List.map (project_hint n l2r) lc))
 
-VERNAC COMMAND EXTEND HintResolveIffLR CLASSIFIED AS SIDEFF
+VERNAC COMMAND FUNCTIONAL EXTEND HintResolveIffLR CLASSIFIED AS SIDEFF
   [ "Hint" "Resolve" "->" ne_global_list(lc) natural_opt(n)
     ":" preident_list(bl) ] ->
-  [ add_hints_iff true lc n bl ]
+  [ fun ~atts ~st -> begin
+        let open Vernacinterp in
+        add_hints_iff ?locality:atts.locality true lc n bl;
+        st
+      end
+  ]
 | [ "Hint" "Resolve" "->" ne_global_list(lc) natural_opt(n) ] ->
-  [ add_hints_iff true lc n ["core"] ]
+  [ fun ~atts ~st -> begin
+        let open Vernacinterp in
+        add_hints_iff ?locality:atts.locality true lc n ["core"];
+        st
+      end
+  ]
 END
-VERNAC COMMAND EXTEND HintResolveIffRL CLASSIFIED AS SIDEFF
+
+VERNAC COMMAND FUNCTIONAL EXTEND HintResolveIffRL CLASSIFIED AS SIDEFF
   [ "Hint" "Resolve" "<-" ne_global_list(lc) natural_opt(n)
     ":" preident_list(bl) ] ->
-  [ add_hints_iff false lc n bl ]
+  [ fun ~atts ~st -> begin
+        let open Vernacinterp in
+        add_hints_iff ?locality:atts.locality false lc n bl;
+        st
+      end
+  ]
 | [ "Hint" "Resolve" "<-" ne_global_list(lc) natural_opt(n) ] ->
-  [ add_hints_iff false lc n ["core"] ]
+  [ fun ~atts ~st -> begin
+        let open Vernacinterp in
+        add_hints_iff ?locality:atts.locality false lc n ["core"];
+        st
+      end
+  ]
 END
 
 (**********************************************************************)

--- a/plugins/ltac/g_auto.ml4
+++ b/plugins/ltac/g_auto.ml4
@@ -190,7 +190,7 @@ END
 let pr_hints_path prc prx pry c = Hints.pp_hints_path c
 let pr_pre_hints_path prc prx pry c = Hints.pp_hints_path_gen Libnames.pr_reference c
 let glob_hints_path ist = Hints.glob_hints_path
-							      
+
 ARGUMENT EXTEND hints_path
 PRINTED BY pr_hints_path
 
@@ -214,10 +214,15 @@ ARGUMENT EXTEND opthints
 | [ ] -> [ None ]
 END
 
-VERNAC COMMAND EXTEND HintCut CLASSIFIED AS SIDEFF
+VERNAC COMMAND FUNCTIONAL EXTEND HintCut CLASSIFIED AS SIDEFF
 | [ "Hint" "Cut" "[" hints_path(p) "]" opthints(dbnames) ] -> [
-  let entry = Hints.HintsCutEntry (Hints.glob_hints_path p) in
-    Hints.add_hints (Locality.make_section_locality (Locality.LocalityFixme.consume ()))
-      (match dbnames with None -> ["core"] | Some l -> l) entry ]
+    fun ~atts ~st -> begin
+        let open Vernacinterp in
+        let entry = Hints.HintsCutEntry (Hints.glob_hints_path p) in
+        Hints.add_hints (Locality.make_section_locality atts.locality)
+          (match dbnames with None -> ["core"] | Some l -> l) entry;
+        st
+      end
+ ]
 END
 

--- a/plugins/ltac/g_ltac.ml4
+++ b/plugins/ltac/g_ltac.ml4
@@ -469,13 +469,13 @@ VERNAC ARGUMENT EXTEND ltac_production_item PRINTED BY pr_ltac_production_item
   [ Tacentries.TacNonTerm (Loc.tag ~loc ((Id.to_string nt, None), None)) ]
 END
 
-VERNAC COMMAND EXTEND VernacTacticNotation
+VERNAC COMMAND FUNCTIONAL EXTEND VernacTacticNotation
 | [ "Tactic" "Notation" ltac_tactic_level_opt(n) ne_ltac_production_item_list(r) ":=" tactic(e) ] =>
   [ VtUnknown, VtNow ] ->
-  [
-    let l = Locality.LocalityFixme.consume () in
-    let n = Option.default 0 n in
-    Tacentries.add_tactic_notation (Locality.make_module_locality l) n r e
+  [ fun ~atts ~st -> let open Vernacinterp in
+      let n = Option.default 0 n in
+      Tacentries.add_tactic_notation (Locality.make_module_locality atts.locality) n r e;
+      st
   ]
 END
 
@@ -512,15 +512,15 @@ PRINTED BY pr_tacdef_body
 | [ tacdef_body(t) ] -> [ t ]
 END
 
-VERNAC COMMAND EXTEND VernacDeclareTacticDefinition
+VERNAC COMMAND FUNCTIONAL EXTEND VernacDeclareTacticDefinition
 | [ "Ltac" ne_ltac_tacdef_body_list_sep(l, "with") ] => [
     VtSideff (List.map (function
       | TacticDefinition ((_,r),_) -> r
       | TacticRedefinition (Ident (_,r),_) -> r
       | TacticRedefinition (Qualid (_,q),_) -> snd(repr_qualid q)) l), VtLater
-  ] -> [
-    let lc = Locality.LocalityFixme.consume () in
-    Tacentries.register_ltac (Locality.make_module_locality lc) l
+  ] -> [ fun ~atts ~st -> let open Vernacinterp in
+           Tacentries.register_ltac (Locality.make_module_locality atts.locality) l;
+           st
   ]
 END
 

--- a/plugins/ltac/g_obligations.ml4
+++ b/plugins/ltac/g_obligations.ml4
@@ -123,11 +123,15 @@ VERNAC COMMAND EXTEND Admit_Obligations CLASSIFIED AS SIDEFF
 | [ "Admit" "Obligations" ] -> [ admit_obligations None ]
 END
 
-VERNAC COMMAND EXTEND Set_Solver CLASSIFIED AS SIDEFF
+VERNAC COMMAND FUNCTIONAL EXTEND Set_Solver CLASSIFIED AS SIDEFF
 | [ "Obligation" "Tactic" ":=" tactic(t) ] -> [
-    set_default_tactic
-      (Locality.make_section_locality (Locality.LocalityFixme.consume ()))
-      (Tacintern.glob_tactic t) ]
+    fun ~atts ~st -> begin
+        let open Vernacinterp in
+        set_default_tactic
+          (Locality.make_section_locality atts.locality)
+          (Tacintern.glob_tactic t);
+        st
+      end]
 END
 
 open Pp

--- a/plugins/ltac/g_rewrite.ml4
+++ b/plugins/ltac/g_rewrite.ml4
@@ -243,22 +243,37 @@ VERNAC COMMAND EXTEND AddParametricRelation3 CLASSIFIED AS SIDEFF
       [ declare_relation ~binders:b a aeq n None None (Some lemma3) ]
 END
 
-VERNAC COMMAND EXTEND AddSetoid1 CLASSIFIED AS SIDEFF
+VERNAC COMMAND FUNCTIONAL EXTEND AddSetoid1 CLASSIFIED AS SIDEFF
    [ "Add" "Setoid" constr(a) constr(aeq) constr(t) "as" ident(n) ] ->
-     [ add_setoid (not (Locality.make_section_locality (Locality.LocalityFixme.consume ()))) [] a aeq t n ]
+     [ fun ~atts ~st -> let open Vernacinterp in
+         add_setoid (not (Locality.make_section_locality atts.locality)) [] a aeq t n;
+         st
+     ]
   | [ "Add" "Parametric" "Setoid" binders(binders) ":" constr(a) constr(aeq) constr(t) "as" ident(n) ] ->
-     [  add_setoid (not (Locality.make_section_locality (Locality.LocalityFixme.consume ()))) binders a aeq t n ]
+     [ fun ~atts ~st -> let open Vernacinterp in
+         add_setoid (not (Locality.make_section_locality atts.locality)) binders a aeq t n;
+         st
+     ]
   | [ "Add" "Morphism" constr(m) ":" ident(n) ]
     (* This command may or may not open a goal *)
     => [ Vernacexpr.VtUnknown, Vernacexpr.VtNow ]
-    -> [ add_morphism_infer (not (Locality.make_section_locality (Locality.LocalityFixme.consume ()))) m n ]
+    -> [ fun ~atts ~st -> let open Vernacinterp in
+           add_morphism_infer (not (Locality.make_section_locality atts.locality)) m n;
+           st
+       ]
   | [ "Add" "Morphism" constr(m) "with" "signature" lconstr(s) "as" ident(n) ]
     => [ Vernacexpr.(VtStartProof("Classic",GuaranteesOpacity,[n]), VtLater) ]
-    -> [ add_morphism (not (Locality.make_section_locality (Locality.LocalityFixme.consume ()))) [] m s n ]
+    -> [ fun ~atts ~st -> let open Vernacinterp in
+           add_morphism (not (Locality.make_section_locality atts.locality)) [] m s n;
+           st
+       ]
   | [ "Add" "Parametric" "Morphism" binders(binders) ":" constr(m)
         "with" "signature" lconstr(s) "as" ident(n) ]
     => [ Vernacexpr.(VtStartProof("Classic",GuaranteesOpacity,[n]), VtLater) ]
-    -> [ add_morphism (not (Locality.make_section_locality (Locality.LocalityFixme.consume ()))) binders m s n ]
+    -> [ fun ~atts ~st -> let open Vernacinterp in
+           add_morphism (not (Locality.make_section_locality atts.locality)) binders m s n;
+           st
+       ]
 END
 
 TACTIC EXTEND setoid_symmetry

--- a/plugins/ltac/rewrite.ml
+++ b/plugins/ltac/rewrite.ml
@@ -1800,9 +1800,9 @@ let declare_instance_trans global binders a aeq n lemma =
   in anew_instance global binders instance
        [(Ident (Loc.tag @@ Id.of_string "transitivity"),lemma)]
 
-let declare_relation ?(binders=[]) a aeq n refl symm trans =
+let declare_relation ?locality ?(binders=[]) a aeq n refl symm trans =
   init_setoid ();
-  let global = not (Locality.make_section_locality (Locality.LocalityFixme.consume ())) in
+  let global = not (Locality.make_section_locality locality) in
   let instance = declare_instance a aeq (add_suffix n "_relation") "Coq.Classes.RelationClasses.RewriteRelation"
   in ignore(anew_instance global binders instance []);
   match (refl,symm,trans) with

--- a/plugins/ltac/rewrite.mli
+++ b/plugins/ltac/rewrite.mli
@@ -75,7 +75,7 @@ val cl_rewrite_clause :
 val is_applied_rewrite_relation :
   env -> evar_map -> rel_context -> constr -> types option
 
-val declare_relation :
+val declare_relation : ?locality:bool ->
   ?binders:local_binder_expr list -> constr_expr -> constr_expr -> Id.t ->
   constr_expr option -> constr_expr option -> constr_expr option -> unit
 

--- a/plugins/ssr/ssrvernac.ml4
+++ b/plugins/ssr/ssrvernac.ml4
@@ -158,11 +158,14 @@ let declare_one_prenex_implicit locality f =
   | impls ->
     Impargs.declare_manual_implicits locality fref ~enriching:false [impls]
 
-VERNAC COMMAND EXTEND Ssrpreneximplicits CLASSIFIED AS SIDEFF
+VERNAC COMMAND FUNCTIONAL EXTEND Ssrpreneximplicits CLASSIFIED AS SIDEFF
   | [ "Prenex" "Implicits" ne_global_list(fl) ]
-  -> [ let locality =
-         Locality.make_section_locality (Locality.LocalityFixme.consume ()) in
-       List.iter (declare_one_prenex_implicit locality) fl ]
+  -> [ fun ~atts ~st ->
+         let open Vernacinterp in
+         let locality = Locality.make_section_locality atts.locality in
+         List.iter (declare_one_prenex_implicit locality) fl;
+         st
+     ]
 END
 
 (* Vernac grammar visibility patch *)

--- a/vernac/locality.ml
+++ b/vernac/locality.ml
@@ -6,21 +6,11 @@
 (*         *       GNU Lesser General Public License Version 2.1        *)
 (************************************************************************)
 
-open Pp
-
 (** * Managing locality *)
 
 let local_of_bool = function
   | true -> Decl_kinds.Local
   | false -> Decl_kinds.Global
-
-let check_locality locality_flag =
-  match locality_flag with
-  | Some b ->
-    let s = if b then "Local" else "Global" in
-    CErrors.user_err ~hdr:"Locality.check_locality"
-      (str "This command does not support the \"" ++ str s ++ str "\" prefix.")
-  | None -> ()
 
 (** Extracting the locality flag *)
 
@@ -95,13 +85,3 @@ let make_module_locality = function
 
 let enforce_module_locality locality_flag local =
   make_module_locality (enforce_locality_full locality_flag local)
-
-module LocalityFixme = struct
-  let locality = ref None
-  let set l = locality := l
-  let consume () =
-    let l = !locality in
-    locality := None;
-    l
-  let assert_consumed () = check_locality !locality
-end

--- a/vernac/locality.mli
+++ b/vernac/locality.mli
@@ -41,11 +41,3 @@ val enforce_section_locality : bool option -> bool -> bool
 
 val make_module_locality : bool option -> bool
 val enforce_module_locality : bool option -> bool -> bool
-
-(* This is the old imperative interface that is still used for
- * VernacExtend vernaculars.  Time permitting this could be trashed too *)
-module LocalityFixme : sig
-  val set : bool option -> unit
-  val consume : unit -> bool option
-  val assert_consumed : unit -> unit
-end

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -2078,7 +2078,7 @@ let interp ?proof ?loc locality poly st c =
   (* Extensions *)
   | VernacExtend (opn,args) ->
     (* XXX: Here we are returning the state! :) *)
-    let _st : Vernacstate.t = Vernacinterp.call ?locality ?loc (opn,args) st in
+    let _st : Vernacstate.t = Vernacinterp.call ?locality ?loc (opn,args) ~st in
     ()
 
 (* Vernaculars that take a locality flag *)

--- a/vernac/vernacinterp.ml
+++ b/vernac/vernacinterp.ml
@@ -11,8 +11,16 @@ open Pp
 open CErrors
 
 type deprecation = bool
-type vernac_command = Genarg.raw_generic_argument list -> Loc.t option ->
-  Vernacstate.t -> Vernacstate.t
+
+type atts = {
+  loc : Loc.t option;
+  locality : bool option;
+}
+
+type vernac_command =
+  Genarg.raw_generic_argument list ->
+  atts:atts -> st:Vernacstate.t ->
+  Vernacstate.t
 
 (* Table of vernac entries *)
 let vernac_tab =
@@ -67,7 +75,8 @@ let call ?locality ?loc (opn,converted_args) =
     let hunk = callback converted_args in
     phase := "Executing command";
     Locality.LocalityFixme.set locality;
-    let res = hunk loc in
+    let atts = { loc; locality } in
+    let res = hunk ~atts in
     Locality.LocalityFixme.assert_consumed ();
     res
   with

--- a/vernac/vernacinterp.ml
+++ b/vernac/vernacinterp.ml
@@ -74,11 +74,8 @@ let call ?locality ?loc (opn,converted_args) =
     phase := "Checking arguments";
     let hunk = callback converted_args in
     phase := "Executing command";
-    Locality.LocalityFixme.set locality;
     let atts = { loc; locality } in
-    let res = hunk ~atts in
-    Locality.LocalityFixme.assert_consumed ();
-    res
+    hunk ~atts
   with
     | Drop -> raise Drop
     | reraise ->

--- a/vernac/vernacinterp.mli
+++ b/vernac/vernacinterp.mli
@@ -10,8 +10,15 @@
 
 type deprecation = bool
 
-type vernac_command = Genarg.raw_generic_argument list -> Loc.t option ->
-  Vernacstate.t -> Vernacstate.t
+type atts = {
+  loc : Loc.t option;
+  locality : bool option;
+}
+
+type vernac_command =
+  Genarg.raw_generic_argument list ->
+  atts:atts -> st:Vernacstate.t ->
+  Vernacstate.t
 
 val vinterp_add : deprecation -> Vernacexpr.extend_name -> vernac_command -> unit
 
@@ -21,4 +28,4 @@ val vinterp_init : unit -> unit
 
 val call : ?locality:bool -> ?loc:Loc.t ->
   Vernacexpr.extend_name * Genarg.raw_generic_argument list ->
-  Vernacstate.t -> Vernacstate.t
+  st:Vernacstate.t -> Vernacstate.t

--- a/vernac/vernacstate.ml
+++ b/vernac/vernacstate.ml
@@ -6,7 +6,7 @@
 (*         *       GNU Lesser General Public License Version 2.1        *)
 (************************************************************************)
 
-type t = { (* TODO: inline records in OCaml 4.03 *)
+type t = {
   system  : States.state;        (* summary + libstack *)
   proof   : Proof_global.state;  (* proof state *)
   shallow : bool                 (* is the state trimmed down (libstack) *)

--- a/vernac/vernacstate.mli
+++ b/vernac/vernacstate.mli
@@ -6,7 +6,7 @@
 (*         *       GNU Lesser General Public License Version 2.1        *)
 (************************************************************************)
 
-type t = { (* TODO: inline records in OCaml 4.03 *)
+type t = {
   system  : States.state;        (* summary + libstack *)
   proof   : Proof_global.state;  (* proof state *)
   shallow : bool                 (* is the state trimmed down (libstack) *)


### PR DESCRIPTION
To that extent we introduce a new prototype vernacular extension
macro `VERNAC COMMAND FUNCTIONAL EXTEND` that will take a
function with the proper parameters and attributes, where we
start to encapsulate modifiers to vernac commands.

This is a continuation of #6183 and another step towards a more
functional interpretation of commands, and needs of course more
refinement, in particular we should move `vernac_command` to its
own file and make `Vernacentries` consistent wrt it.
