### PR TITLE
[vernac] Uniformize type of vernac interpretation.

### DIFF
--- a/API/API.mli
+++ b/API/API.mli
@@ -6112,6 +6112,7 @@ sig
   type atts = {
     loc : Loc.t option;
     locality : bool option;
+    polymorphic : bool;
   }
 
   type 'a vernac_command = 'a -> atts:atts -> st:Vernacstate.t -> Vernacstate.t

--- a/API/API.mli
+++ b/API/API.mli
@@ -6114,12 +6114,11 @@ sig
     locality : bool option;
   }
 
-  type vernac_command =
-    Genarg.raw_generic_argument list ->
-    atts:atts -> st:Vernacstate.t ->
-    Vernacstate.t
+  type 'a vernac_command = 'a -> atts:atts -> st:Vernacstate.t -> Vernacstate.t
 
-  val vinterp_add : deprecation -> Vernacexpr.extend_name -> vernac_command -> unit
+  type plugin_args = Genarg.raw_generic_argument list
+
+  val vinterp_add : deprecation -> Vernacexpr.extend_name -> plugin_args vernac_command -> unit
 
 end
 

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -1023,7 +1023,7 @@ let stm_vernac_interp ?proof ?route id st { verbose; loc; expr } : Vernacstate.t
   | VernacShow ShowScript -> ShowScript.show_script (); st
   | expr ->
     stm_pperr_endline Pp.(fun () -> str "interpreting " ++ Ppvernac.pr_vernac expr);
-    try Vernacentries.interp ?verbosely:(Some verbose) ?proof st (Loc.tag ?loc expr)
+    try Vernacentries.interp ?verbosely:(Some verbose) ?proof ~st (Loc.tag ?loc expr)
     with e ->
       let e = CErrors.push e in
       Exninfo.iraise Hooks.(call_process_error_once e)

--- a/vernac/vernacentries.mli
+++ b/vernac/vernacentries.mli
@@ -18,7 +18,7 @@ val vernac_require :
 val interp :
   ?verbosely:bool ->
   ?proof:Proof_global.closed_proof ->
-  Vernacstate.t -> Vernacexpr.vernac_expr Loc.located -> Vernacstate.t
+  st:Vernacstate.t -> Vernacexpr.vernac_expr Loc.located -> Vernacstate.t
 
 (** Prepare a "match" template for a given inductive type.
     For each branch of the match, we list the constructor name

--- a/vernac/vernacinterp.ml
+++ b/vernac/vernacinterp.ml
@@ -15,6 +15,7 @@ type deprecation = bool
 type atts = {
   loc : Loc.t option;
   locality : bool option;
+  polymorphic : bool;
 }
 
 type 'a vernac_command = 'a -> atts:atts -> st:Vernacstate.t -> Vernacstate.t

--- a/vernac/vernacinterp.ml
+++ b/vernac/vernacinterp.ml
@@ -17,15 +17,14 @@ type atts = {
   locality : bool option;
 }
 
-type vernac_command =
-  Genarg.raw_generic_argument list ->
-  atts:atts -> st:Vernacstate.t ->
-  Vernacstate.t
+type 'a vernac_command = 'a -> atts:atts -> st:Vernacstate.t -> Vernacstate.t
+
+type plugin_args = Genarg.raw_generic_argument list
 
 (* Table of vernac entries *)
 let vernac_tab =
   (Hashtbl.create 211 :
-    (Vernacexpr.extend_name, deprecation * vernac_command) Hashtbl.t)
+    (Vernacexpr.extend_name, deprecation * plugin_args vernac_command) Hashtbl.t)
 
 let vinterp_add depr s f =
   try
@@ -58,7 +57,7 @@ let warn_deprecated_command =
 
 (* Interpretation of a vernac command *)
 
-let call ?locality ?loc (opn,converted_args) =
+let call opn converted_args ~atts ~st =
   let phase = ref "Looking up command" in
   try
     let depr, callback = vinterp_map opn in
@@ -74,8 +73,7 @@ let call ?locality ?loc (opn,converted_args) =
     phase := "Checking arguments";
     let hunk = callback converted_args in
     phase := "Executing command";
-    let atts = { loc; locality } in
-    hunk ~atts
+    hunk ~atts ~st
   with
     | Drop -> raise Drop
     | reraise ->

--- a/vernac/vernacinterp.mli
+++ b/vernac/vernacinterp.mli
@@ -13,6 +13,7 @@ type deprecation = bool
 type atts = {
   loc : Loc.t option;
   locality : bool option;
+  polymorphic : bool;
 }
 
 type 'a vernac_command = 'a -> atts:atts -> st:Vernacstate.t -> Vernacstate.t

--- a/vernac/vernacinterp.mli
+++ b/vernac/vernacinterp.mli
@@ -15,17 +15,12 @@ type atts = {
   locality : bool option;
 }
 
-type vernac_command =
-  Genarg.raw_generic_argument list ->
-  atts:atts -> st:Vernacstate.t ->
-  Vernacstate.t
+type 'a vernac_command = 'a -> atts:atts -> st:Vernacstate.t -> Vernacstate.t
 
-val vinterp_add : deprecation -> Vernacexpr.extend_name -> vernac_command -> unit
-
-val overwriting_vinterp_add : Vernacexpr.extend_name -> vernac_command -> unit
+type plugin_args = Genarg.raw_generic_argument list
 
 val vinterp_init : unit -> unit
+val vinterp_add : deprecation -> Vernacexpr.extend_name -> plugin_args vernac_command -> unit
+val overwriting_vinterp_add : Vernacexpr.extend_name -> plugin_args vernac_command -> unit
 
-val call : ?locality:bool -> ?loc:Loc.t ->
-  Vernacexpr.extend_name * Genarg.raw_generic_argument list ->
-  st:Vernacstate.t -> Vernacstate.t
+val call : Vernacexpr.extend_name -> plugin_args -> atts:atts -> st:Vernacstate.t -> Vernacstate.t


### PR DESCRIPTION
In particular, we put context in the atts structure, and
generalize the type of the parameters of a vernac, which should
be shared soon by plugins and `Vernacentries`.

I hope this helps people working on "attributes", my motivation
is indeed to have a more robust interpretation.

This PR depends on #6197
