### PR TITLE
Move linter to allowed failures.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,9 @@ env:
 
 matrix:
 
+  allow_failures:
+    - env: TEST_TARGET="lint"
+
   include:
     - env:
       - TEST_TARGET="lint"


### PR DESCRIPTION
The linter is a nice tool, but I think we may want to make it a "warning",
not a strict failure on Travis.