### PR TITLE
Do dependencies in 1 command per file class.

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -147,8 +147,14 @@ endif
 # For creating the missing .d, make will recursively build things like
 # coqdep_boot (for the .v.d files) or grammar.cma (for .ml4 -> .ml -> .ml.d).
 
+VDFILE := .vfiles
+MLDFILE := .mlfiles
+PLUGMLDFILE := plugins/.mlfiles
+MLLIBDFILE := .mllibfiles
+PLUGMLLIBDFILE := plugins/.mllibfiles
+
 DEPENDENCIES := \
- $(addsuffix .d, $(MLFILES) $(MLIFILES) $(MLLIBFILES) $(MLPACKFILES) $(CFILES) $(VFILES))
+ $(addsuffix .d, $(MLDFILE) $(MLLIBDFILE) $(PLUGMLDFILE) $(PLUGMLLIBDFILE) $(CFILES) $(VDFILE))
 
 -include $(DEPENDENCIES)
 
@@ -189,7 +195,7 @@ TIMER=$(if $(TIMED), $(STDTIME), $(TIMECMD))
 COQOPTS=$(NATIVECOMPUTE)
 BOOTCOQC=$(TIMER) $(COQTOPBEST) -boot $(COQOPTS) -compile
 
-LOCALINCLUDES=$(if $(filter plugins/%,$<),-I lib -I API -open API $(addprefix -I plugins/,$(PLUGINDIRS)),$(addprefix -I ,$(SRCDIRS)))
+LOCALINCLUDES=$(if $(filter plugins/%,$@),-I lib -I API -open API $(addprefix -I plugins/,$(PLUGINDIRS)),$(addprefix -I ,$(SRCDIRS)))
 MLINCLUDES=$(LOCALINCLUDES) -I $(MYCAMLP4LIB)
 
 OCAMLC := $(OCAMLFIND) ocamlc $(CAMLFLAGS)
@@ -197,7 +203,7 @@ OCAMLOPT := $(OCAMLFIND) opt $(CAMLFLAGS)
 
 BYTEFLAGS=$(CAMLDEBUG) $(USERFLAGS)
 OPTFLAGS=$(CAMLDEBUGOPT) $(CAMLTIMEPROF) $(USERFLAGS) $(FLAMBDA_FLAGS)
-DEPFLAGS=$(LOCALINCLUDES)$(if $(filter plugins/%,$<),, -I ide -I ide/utils)
+DEPFLAGS=$(LOCALINCLUDES)$(if $(filter plugins/%,$@),, -I ide -I ide/utils)
 
 # On MacOS, the binaries are signed, except our private ones
 ifeq ($(shell which codesign > /dev/null 2>&1 && echo $(ARCH)),Darwin)
@@ -670,21 +676,24 @@ plugins/%.cmx: plugins/%.ml
 # Ocamldep is now used directly again (thanks to -ml-synonym in OCaml >= 3.12)
 OCAMLDEP = $(OCAMLFIND) ocamldep -slash -ml-synonym .ml4 -ml-synonym .mlpack
 
-%.ml.d: $(D_DEPEND_BEFORE_SRC) %.ml $(D_DEPEND_AFTER_SRC) $(GENFILES)
-	$(SHOW)'OCAMLDEP  $<'
-	$(HIDE)$(OCAMLDEP) $(DEPFLAGS) "$<" $(TOTARGET)
+MAINMLFILES := $(filter-out checker/% plugins/%, $(MLFILES) $(MLIFILES))
+MAINMLLIBFILES := $(filter-out checker/% plugins/%, $(MLLIBFILES) $(MLPACKFILES))
 
-%.mli.d: $(D_DEPEND_BEFORE_SRC) %.mli $(D_DEPEND_AFTER_SRC) $(GENFILES)
-	$(SHOW)'OCAMLDEP  $<'
-	$(HIDE)$(OCAMLDEP) $(DEPFLAGS) "$<" $(TOTARGET)
+$(MLDFILE).d: $(D_DEPEND_BEFORE_SRC) $(MAINMLFILES) $(D_DEPEND_AFTER_SRC) $(GENFILES)
+	$(SHOW)'OCAMLDEP  MLFILES MLIFILES'
+	$(HIDE)$(OCAMLDEP) $(DEPFLAGS) $(MAINMLFILES) $(TOTARGET)
 
-%.mllib.d: $(D_DEPEND_BEFORE_SRC) %.mllib $(D_DEPEND_AFTER_SRC) $(OCAMLLIBDEP) $(GENFILES)
-	$(SHOW)'OCAMLLIBDEP  $<'
-	$(HIDE)$(OCAMLLIBDEP) $(DEPFLAGS) "$<" $(TOTARGET)
+$(MLLIBDFILE).d: $(D_DEPEND_BEFORE_SRC) $(MAINMLLIBFILES) $(D_DEPEND_AFTER_SRC) $(OCAMLLIBDEP) $(GENFILES)
+	$(SHOW)'OCAMLLIBDEP  MLLIBFILES MLPACKFILES'
+	$(HIDE)$(OCAMLLIBDEP) $(DEPFLAGS) $(MAINMLLIBFILES) $(TOTARGET)
 
-%.mlpack.d: $(D_DEPEND_BEFORE_SRC) %.mlpack $(D_DEPEND_AFTER_SRC) $(OCAMLLIBDEP) $(GENFILES)
-	$(SHOW)'OCAMLLIBDEP  $<'
-	$(HIDE)$(OCAMLLIBDEP) $(DEPFLAGS) "$<" $(TOTARGET)
+$(PLUGMLDFILE).d: $(D_DEPEND_BEFORE_SRC) $(filter plugins/%, $(MLFILES) $(MLIFILES)) $(D_DEPEND_AFTER_SRC) $(GENFILES)
+	$(SHOW)'OCAMLDEP  plugins/MLFILES plugins/MLIFILES'
+	$(HIDE)$(OCAMLDEP) $(DEPFLAGS) $(filter plugins/%, $(MLFILES) $(MLIFILES)) $(TOTARGET)
+
+$(PLUGMLLIBDFILE).d: $(D_DEPEND_BEFORE_SRC) $(filter plugins/%, $(MLLIBFILES) $(MLPACKFILES)) $(D_DEPEND_AFTER_SRC) $(OCAMLLIBDEP) $(GENFILES)
+	$(SHOW)'OCAMLLIBDEP  plugins/MLLIBFILES plugins/MLPACKFILES'
+	$(HIDE)$(OCAMLLIBDEP) $(DEPFLAGS) $(filter plugins/%, $(MLLIBFILES) $(MLPACKFILES)) $(TOTARGET)
 
 ###########################################################################
 # Compilation of .v files
@@ -756,9 +765,9 @@ endif
 
 # Dependencies of .v files
 
-%.v.d: $(D_DEPEND_BEFORE_SRC) %.v $(D_DEPEND_AFTER_SRC) $(COQDEPBOOT)
-	$(SHOW)'COQDEP    $<'
-	$(HIDE)$(COQDEPBOOT) -boot $(DYNDEP) "$<" $(TOTARGET)
+$(VDFILE).d: $(D_DEPEND_BEFORE_SRC) $(VFILES) $(D_DEPEND_AFTER_SRC) $(COQDEPBOOT)
+	$(SHOW)'COQDEP    VFILES'
+	$(HIDE)$(COQDEPBOOT) -boot $(DYNDEP) $(VFILES) $(TOTARGET)
 
 ###########################################################################
 

--- a/Makefile.checker
+++ b/Makefile.checker
@@ -26,6 +26,12 @@ CHKLIBS:= -I config -I lib -I checker
 
 # The rules
 
+CHECKMLDFILE := checker/.mlfiles
+CHECKMLLIBFILE := checker/.mllibfiles
+
+CHECKERDEPS := $(addsuffix .d, $(CHECKMLDFILE) $(CHECKMLLIBFILE))
+-include $(CHECKERDEPS)
+
 ifeq ($(BEST),opt)
 $(CHICKEN): checker/check.cmxa checker/main.ml
 	$(SHOW)'OCAMLOPT -o $@'
@@ -49,17 +55,13 @@ checker/check.cmxa: checker/check.mllib | md5chk
 	$(SHOW)'OCAMLOPT -a -o $@'
 	$(HIDE)$(OCAMLOPT) $(CHKLIBS) $(OPTFLAGS) -a -o $@ $(filter-out %.mllib, $^)
 
-checker/%.ml.d: checker/%.ml
-	$(SHOW)'OCAMLDEP  $<'
-	$(HIDE)$(OCAMLFIND) ocamldep -slash $(CHKLIBS) "$<" $(TOTARGET)
+$(CHECKMLDFILE).d: $(filter checker/%, $(MLFILES) $(MLIFILES))
+	$(SHOW)'OCAMLDEP  checker/MLFILES checker/MLIFILES'
+	$(HIDE)$(OCAMLFIND) ocamldep -slash $(CHKLIBS) $(filter checker/%, $(MLFILES) $(MLIFILES)) $(TOTARGET)
 
-checker/%.mli.d: checker/%.mli
-	$(SHOW)'OCAMLDEP  $<'
-	$(HIDE)$(OCAMLFIND) ocamldep -slash $(CHKLIBS) "$<" $(TOTARGET)
-
-checker/%.mllib.d: checker/%.mllib | $(OCAMLLIBDEP)
-	$(SHOW)'OCAMLLIBDEP  $<'
-	$(HIDE)$(OCAMLLIBDEP) $(CHKLIBS) "$<" $(TOTARGET)
+$(CHECKMLLIBFILE).d: $(filter checker/%, $(MLLIBFILES) $(MLPACKFILES)) | $(OCAMLLIBDEP)
+	$(SHOW)'OCAMLLIBDEP  checker/MLLIBFILES checker/MLPACKFILES'
+	$(HIDE)$(OCAMLLIBDEP) $(CHKLIBS) $(filter checker/%, $(MLLIBFILES) $(MLPACKFILES)) $(TOTARGET)
 
 checker/%.cmi: checker/%.mli
 	$(SHOW)'OCAMLC    $<'

--- a/dev/ci/user-overlays/06217-coqdep-at-once.sh
+++ b/dev/ci/user-overlays/06217-coqdep-at-once.sh
@@ -1,0 +1,3 @@
+if [ "$TRAVIS_PULL_REQUEST" = "6217" ] || [ "$TRAVIS_BRANCH" = "coqdep-at-once" ]; then
+    UniMath_CI_GITURL=https://github.com/SkySkimmer/UniMath.git
+fi

--- a/test-suite/coq-makefile/timing/after/time-of-build-after.log.desired
+++ b/test-suite/coq-makefile/timing/after/time-of-build-after.log.desired
@@ -1,7 +1,6 @@
 Makefile:69: warning: undefined variable '*'
 Makefile:204: warning: undefined variable 'DSTROOT'
-COQDEP Fast.v
-COQDEP Slow.v
+COQDEP VFILES
 Makefile:69: warning: undefined variable '*'
 Makefile:204: warning: undefined variable 'DSTROOT'
 Makefile:69: warning: undefined variable '*'

--- a/test-suite/coq-makefile/timing/after/time-of-build-before.log.desired
+++ b/test-suite/coq-makefile/timing/after/time-of-build-before.log.desired
@@ -1,7 +1,6 @@
 Makefile:69: warning: undefined variable '*'
 Makefile:204: warning: undefined variable 'DSTROOT'
-COQDEP Fast.v
-COQDEP Slow.v
+COQDEP VFILES
 Makefile:69: warning: undefined variable '*'
 Makefile:204: warning: undefined variable 'DSTROOT'
 Makefile:69: warning: undefined variable '*'

--- a/tools/CoqMakefile.in
+++ b/tools/CoqMakefile.in
@@ -228,8 +228,9 @@ COQTOPINSTALL = $(call concat_path,$(DESTDIR),$(COQLIB)toploop)
 # We here define a bunch of variables about the files being part of the
 # Coq project in order to ease the writing of build target and build rules
 
+VDFILE := .coqdeps
+
 ALLSRCFILES := \
-	$(VFILES) \
 	$(ML4FILES) \
 	$(MLFILES) \
 	$(MLPACKFILES) \
@@ -307,7 +308,7 @@ else
 DO_NATDYNLINK =
 endif
 
-ALLDFILES = $(addsuffix .d,$(ALLSRCFILES))
+ALLDFILES = $(addsuffix .d,$(ALLSRCFILES) $(VDFILE))
 
 # Compilation targets #########################################################
 
@@ -712,9 +713,9 @@ $(addsuffix .d,$(MLPACKFILES)): %.mlpack.d: %.mlpack
 	$(SHOW)'COQDEP $<'
 	$(HIDE)$(COQDEP) $(OCAMLLIBS) -c "$<" $(redir_if_ok)
 
-$(addsuffix .d,$(VFILES)): %.v.d: %.v
-	$(SHOW)'COQDEP $<'
-	$(HIDE)$(COQDEP) $(COQLIBS) -dyndep var -c "$<" $(redir_if_ok)
+$(VDFILE).d: $(VFILES)
+	$(SHOW)'COQDEP VFILES'
+	$(HIDE)$(COQDEP) $(COQLIBS) -dyndep var -c $(VFILES) $(redir_if_ok)
 
 # Misc ########################################################################
 


### PR DESCRIPTION
coq_makefile produces a Makefile which does `coqdep $(FLAGS) $(VFILES) > .vfiles.d`
Coq's own Makefiles also produce coalesced `.mlfoo.d` ([ml/mli use ocamldep + mllib/mlpack use ocamllibdep] * [checker / plugins / rest use separate flags]). This wasn't done for coq_makefile but could be if there's demand.

Unimath is broken because they check that the order of tag generation is compatible with the dependency order, which they use the v.d files for.

Fix #5988, see benchmark https://ci.inria.fr/coq/view/benchmarking/job/benchmark-part-of-the-branch/241/console (with caveat that coqdep might still be doing inefficient things ofc)
```
┌──────────────────────────┬──────────────────────────┬───────────────────────────────────────┬────────────────────────────────────────┬─────────────────────────┬─────────────────┐
│                          │      user time [s]       │              CPU cycles               │            CPU instructions            │  max resident mem [KB]  │   mem faults    │
│                          │                          │                                       │                                        │                         │                 │
│             package_name │     NEW     OLD  PDIFF   │           NEW            OLD  PDIFF   │            NEW            OLD  PDIFF   │     NEW     OLD PDIFF   │ NEW OLD PDIFF   │
├──────────────────────────┼──────────────────────────┼───────────────────────────────────────┼────────────────────────────────────────┼─────────────────────────┼─────────────────┤
│            coq-fiat-core │  100.60  119.70 -15.96 % │  279032379770   315751328583 -11.63 % │   363445071048   424116612776 -14.31 % │  502232  502572 -0.07 % │  15   0  +nan % │
├──────────────────────────┼──────────────────────────┼───────────────────────────────────────┼────────────────────────────────────────┼─────────────────────────┼─────────────────┤
│          coq-fiat-crypto │ 3356.62 3716.68  -9.69 % │ 9355596792764 10341719205058  -9.54 % │ 15836566246788 17539300025959  -9.71 % │ 3282944 3282676 +0.01 % │   0   0  +nan % │
├──────────────────────────┼──────────────────────────┼───────────────────────────────────────┼────────────────────────────────────────┼─────────────────────────┼─────────────────┤
│         coq-fiat-parsers │  651.73  675.51  -3.52 % │ 1821538306849  1867845688099  -2.48 % │  2966511358622  3029504433708  -2.08 % │ 3535648 3534884 +0.02 % │   0   0  +nan % │
├──────────────────────────┼──────────────────────────┼───────────────────────────────────────┼────────────────────────────────────────┼─────────────────────────┼─────────────────┤
│   coq-mathcomp-odd_order │ 1362.21 1382.99  -1.50 % │ 3792155295519  3855828453697  -1.65 % │  6704276847509  6703997409949  +0.00 % │ 1121452 1109976 +1.03 % │   0   0  +nan % │
├──────────────────────────┼──────────────────────────┼───────────────────────────────────────┼────────────────────────────────────────┼─────────────────────────┼─────────────────┤
│               coq-geocoq │ 3056.72 3098.26  -1.34 % │ 8530157579011  8645086519808  -1.33 % │ 14290179855016 14317259972179  -0.19 % │ 1216268 1250012 -2.70 % │   0   0  +nan % │
├──────────────────────────┼──────────────────────────┼───────────────────────────────────────┼────────────────────────────────────────┼─────────────────────────┼─────────────────┤
│               coq-sf-vfa │   18.56   18.74  -0.96 % │   51833037991    51992857232  -0.31 % │    70938041264    71003227643  -0.09 % │  537372  537420 -0.01 % │   0   0  +nan % │
├──────────────────────────┼──────────────────────────┼───────────────────────────────────────┼────────────────────────────────────────┼─────────────────────────┼─────────────────┤
│    coq-mathcomp-fingroup │   59.07   59.64  -0.96 % │  163187831745   164356618411  -0.71 % │   229166960267   229639694955  -0.21 % │  530916  531244 -0.06 % │   0   0  +nan % │
├──────────────────────────┼──────────────────────────┼───────────────────────────────────────┼────────────────────────────────────────┼─────────────────────────┼─────────────────┤
│   coq-mathcomp-character │  267.10  269.26  -0.80 % │  742950126451   748274284417  -0.71 % │  1100695927681  1100851669853  -0.01 % │  981588  981696 -0.01 % │   0   0  +nan % │
├──────────────────────────┼──────────────────────────┼───────────────────────────────────────┼────────────────────────────────────────┼─────────────────────────┼─────────────────┤
│   coq-mathcomp-ssreflect │   38.05   38.34  -0.76 % │  105250679200   105625546166  -0.35 % │   130829168640   131452165963  -0.47 % │  477592  477404 +0.04 % │   0   0  +nan % │
├──────────────────────────┼──────────────────────────┼───────────────────────────────────────┼────────────────────────────────────────┼─────────────────────────┼─────────────────┤
│                coq-color │  566.43  570.58  -0.73 % │ 1586302193738  1595581304010  -0.58 % │  2004234150999  2015849829353  -0.58 % │ 1488188 1487940 +0.02 % │   0   0  +nan % │
├──────────────────────────┼──────────────────────────┼───────────────────────────────────────┼────────────────────────────────────────┼─────────────────────────┼─────────────────┤
│       coq-mathcomp-field │  448.65  451.86  -0.71 % │ 1247819523502  1258024855141  -0.81 % │  2095874074865  2096406956637  -0.03 % │  729044  728224 +0.11 % │   0   0  +nan % │
├──────────────────────────┼──────────────────────────┼───────────────────────────────────────┼────────────────────────────────────────┼─────────────────────────┼─────────────────┤
│     coq-mathcomp-algebra │  168.54  169.29  -0.44 % │  468733459198   471154710670  -0.51 % │   668518826832   668781608887  -0.04 % │  590200  590224 -0.00 % │   0   0  +nan % │
├──────────────────────────┼──────────────────────────┼───────────────────────────────────────┼────────────────────────────────────────┼─────────────────────────┼─────────────────┤
│ coq-mathcomp-real_closed │  166.24  166.94  -0.42 % │  462229342259   464153163350  -0.41 % │   711970726247   712398950777  -0.06 % │  731516  732284 -0.10 % │   0   0  +nan % │
├──────────────────────────┼──────────────────────────┼───────────────────────────────────────┼────────────────────────────────────────┼─────────────────────────┼─────────────────┤
│                  coq-vst │ 2177.01 2185.99  -0.41 % │ 6071022822166  6093105493201  -0.36 % │  8896882744656  8891900364981  +0.06 % │ 1951524 1951828 -0.02 % │   0   0  +nan % │
├──────────────────────────┼──────────────────────────┼───────────────────────────────────────┼────────────────────────────────────────┼─────────────────────────┼─────────────────┤
│    coq-mathcomp-solvable │  189.20  189.92  -0.38 % │  525885860360   528263563838  -0.45 % │   768026202487   768220029033  -0.03 % │  715068  714936 +0.02 % │   0   0  +nan % │
├──────────────────────────┼──────────────────────────┼───────────────────────────────────────┼────────────────────────────────────────┼─────────────────────────┼─────────────────┤
│           coq-coquelicot │   74.66   74.73  -0.09 % │  205598006569   205687035528  -0.04 % │   258842413511   258920649977  -0.03 % │  659968  660056 -0.01 % │   0   0  +nan % │
├──────────────────────────┼──────────────────────────┼───────────────────────────────────────┼────────────────────────────────────────┼─────────────────────────┼─────────────────┤
│               coq-sf-plf │   41.84   41.87  -0.07 % │  116552940203   116460303871  +0.08 % │   153002937171   153055790679  -0.03 % │  510672  510680 -0.00 % │   0   0  +nan % │
├──────────────────────────┼──────────────────────────┼───────────────────────────────────────┼────────────────────────────────────────┼─────────────────────────┼─────────────────┤
│              coq-bignums │   75.00   75.04  -0.05 % │  207726428237   208795928383  -0.51 % │   284421738640   285375454180  -0.33 % │  535420  535280 +0.03 % │  24   0  +nan % │
├──────────────────────────┼──────────────────────────┼───────────────────────────────────────┼────────────────────────────────────────┼─────────────────────────┼─────────────────┤
│                coq-flocq │   58.04   57.95  +0.16 % │  159054344225   158975740972  +0.05 % │   205329186602   205373779533  -0.02 % │  643768  643876 -0.02 % │ 161   0  +nan % │
├──────────────────────────┼──────────────────────────┼───────────────────────────────────────┼────────────────────────────────────────┼─────────────────────────┼─────────────────┤
│             coq-compcert │  802.95  801.36  +0.20 % │ 2239706838770  2234838124321  +0.22 % │  3413311591191  3415512000564  -0.06 % │ 1387948 1387876 +0.01 % │   0   0  +nan % │
├──────────────────────────┼──────────────────────────┼───────────────────────────────────────┼────────────────────────────────────────┼─────────────────────────┼─────────────────┤
│      coq-formal-topology │   33.84   33.66  +0.53 % │   93397098561    94179630472  -0.83 % │   125100821458   126873449235  -1.40 % │  482640  482564 +0.02 % │   0   0  +nan % │
├──────────────────────────┼──────────────────────────┼───────────────────────────────────────┼────────────────────────────────────────┼─────────────────────────┼─────────────────┤
│                coq-sf-lf │   15.54   15.43  +0.71 % │   42429693854    42418332415  +0.03 % │    59550787458    59568498344  -0.03 % │  419096  419124 -0.01 % │   0   0  +nan % │
└──────────────────────────┴──────────────────────────┴───────────────────────────────────────┴────────────────────────────────────────┴─────────────────────────┴─────────────────┘
```