### PR TITLE
Use OCaml criteria for infix ops in extraction, #6212

### DIFF
--- a/doc/refman/Extraction.tex
+++ b/doc/refman/Extraction.tex
@@ -391,9 +391,11 @@ Extract Inductive bool => "bool" [ "true" "false" ].
 Extract Inductive sumbool => "bool" [ "true" "false" ].
 \end{coq_example}
 
-\noindent If an inductive constructor or type has arity 2 and the corresponding 
-string is enclosed by parenthesis, then the rest of the string is used
-as infix constructor or type. 
+\noindent When extracting to Ocaml, if an inductive constructor or type
+has arity 2 and the corresponding string is enclosed by parentheses,
+and the string meets Ocaml's lexical criteria for an infix symbol,
+then the rest of the string is used as infix constructor or type.
+
 \begin{coq_example}
 Extract Inductive list => "list" [ "[]" "(::)" ].
 Extract Inductive prod => "(*)"  [ "(,)" ].

--- a/doc/refman/Extraction.tex
+++ b/doc/refman/Extraction.tex
@@ -391,9 +391,9 @@ Extract Inductive bool => "bool" [ "true" "false" ].
 Extract Inductive sumbool => "bool" [ "true" "false" ].
 \end{coq_example}
 
-\noindent When extracting to Ocaml, if an inductive constructor or type
+\noindent When extracting to {\ocaml}, if an inductive constructor or type
 has arity 2 and the corresponding string is enclosed by parentheses,
-and the string meets Ocaml's lexical criteria for an infix symbol,
+and the string meets {\ocaml}'s lexical criteria for an infix symbol,
 then the rest of the string is used as infix constructor or type.
 
 \begin{coq_example}

--- a/plugins/extraction/ocaml.ml
+++ b/plugins/extraction/ocaml.ml
@@ -122,11 +122,13 @@ let is_infix r =
    len >= 3 &&
      (* parenthesized *)
      (s.[0] == '(' && s.[len-1] == ')' &&
+        let inparens = String.trim (String.sub s 1 (len - 2)) in
+        let inparens_len = String.length inparens in
         (* either, begins with infix symbol, any remainder is all operator chars *)
-        (List.mem s.[1] infix_symbols && substring_all_opchars s 2 (len-1))
+        (List.mem inparens.[0] infix_symbols && substring_all_opchars inparens 1 inparens_len)
       ||
         (* or, starts with #, at least one more char, all are operator chars *)
-        (s.[1] == '#' && len >= 4 && substring_all_opchars s 2 (len-1))))
+        (inparens.[0] == '#' && inparens_len >= 2 && substring_all_opchars inparens 1 inparens_len)))
 
 let get_infix r =
   let s = find_custom r in

--- a/plugins/extraction/ocaml.ml
+++ b/plugins/extraction/ocaml.ml
@@ -107,6 +107,11 @@ let infix_symbols =
 let operator_chars =
   [ '!' ; '$' ; '%' ; '&' ; '*' ; '+' ; '-' ; '.' ; '/' ; ':' ; '<' ; '=' ; '>' ; '?' ; '@' ; '^' ; '|' ; '~' ]
 
+(* infix ops in OCaml, but disallowed by preceding grammar *)
+
+let builtin_infixes =
+  [ "::" ; "," ]
+
 let substring_all_opchars s start stop =
   let rec check_char i =
     if i >= stop then true
@@ -120,15 +125,16 @@ let is_infix r =
   (let s = find_custom r in
    let len = String.length s in
    len >= 3 &&
-     (* parenthesized *)
-     (s.[0] == '(' && s.[len-1] == ')' &&
-        let inparens = String.trim (String.sub s 1 (len - 2)) in
-        let inparens_len = String.length inparens in
-        (* either, begins with infix symbol, any remainder is all operator chars *)
-        (List.mem inparens.[0] infix_symbols && substring_all_opchars inparens 1 inparens_len)
-      ||
-        (* or, starts with #, at least one more char, all are operator chars *)
-        (inparens.[0] == '#' && inparens_len >= 2 && substring_all_opchars inparens 1 inparens_len)))
+   (* parenthesized *)
+   (s.[0] == '(' && s.[len-1] == ')' &&
+      let inparens = String.trim (String.sub s 1 (len - 2)) in
+      let inparens_len = String.length inparens in
+      (* either, begins with infix symbol, any remainder is all operator chars *)
+      (List.mem inparens.[0] infix_symbols && substring_all_opchars inparens 1 inparens_len) ||
+      (* or, starts with #, at least one more char, all are operator chars *)
+      (inparens.[0] == '#' && inparens_len >= 2 && substring_all_opchars inparens 1 inparens_len) ||
+      (* or, is an OCaml built-in infix *)
+      (List.mem inparens builtin_infixes)))
 
 let get_infix r =
   let s = find_custom r in

--- a/test-suite/output/Extraction_infix.out
+++ b/test-suite/output/Extraction_infix.out
@@ -1,0 +1,16 @@
+(** val test : foo **)
+
+let test =
+  (fun (b, p) -> bar) (True, False)
+(** val test : foo **)
+
+let test =
+  True@@?False
+(** val test : foo **)
+
+let test =
+  True#^^False
+(** val test : foo **)
+
+let test =
+  True@?:::False

--- a/test-suite/output/Extraction_infix.out
+++ b/test-suite/output/Extraction_infix.out
@@ -14,3 +14,7 @@ let test =
 
 let test =
   True@?:::False
+(** val test : foo **)
+
+let test =
+  True  @?:::  False

--- a/test-suite/output/Extraction_infix.v
+++ b/test-suite/output/Extraction_infix.v
@@ -19,3 +19,8 @@ Extraction test.
 
 Extract Inductive I => "foo" [ "(@?:::)" ].
 Extraction test.
+
+(* allow whitespace around infix operator *)
+
+Extract Inductive I => "foo" [ "(  @?:::  )" ].
+Extraction test.

--- a/test-suite/output/Extraction_infix.v
+++ b/test-suite/output/Extraction_infix.v
@@ -1,0 +1,21 @@
+(* @herbelin's example for issue #6212 *)
+
+Require Import Extraction.
+Inductive I := C : bool -> bool -> I.
+Definition test := C true false.
+
+(* the parentheses around the function wrong signalled an infix operator *)
+
+Extract Inductive I => "foo" [ "(fun (b, p) -> bar)" ].
+Extraction test.
+
+(* some bonafide infix operators *)
+
+Extract Inductive I => "foo" [ "(@@?)" ].
+Extraction test.
+
+Extract Inductive I => "foo" [ "(#^^)" ].
+Extraction test.
+
+Extract Inductive I => "foo" [ "(@?:::)" ].
+Extraction test.


### PR DESCRIPTION
When testing whether a provided Inductive extraction operation should be infix, the extractor looks at OCaml's lexical ciriteria for what should be considered infix. Fixes #6212.