### PR TITLE
Remove Kjump instruction.

### DIFF
--- a/kernel/cbytecodes.ml
+++ b/kernel/cbytecodes.ml
@@ -66,7 +66,6 @@ type instruction =
   | Kapply of int
   | Kappterm of int * int
   | Kreturn of int
-  | Kjump
   | Krestart
   | Kgrab of int
   | Kgrabrec of int
@@ -222,7 +221,6 @@ let rec pp_instr i =
   | Kappterm(n, m) ->
       str "appterm " ++ int n ++ str ", " ++ int m
   | Kreturn n -> str "return " ++ int n
-  | Kjump -> str "jump"
   | Krestart -> str "restart"
   | Kgrab n -> str "grab " ++ int n
   | Kgrabrec n -> str "grabrec " ++ int n

--- a/kernel/cbytecodes.mli
+++ b/kernel/cbytecodes.mli
@@ -60,7 +60,6 @@ type instruction =
   | Kapply of int                       (** number of arguments (arguments on top of stack) *)
   | Kappterm of int * int               (** number of arguments, slot size *)
   | Kreturn of int                      (** slot size *)
-  | Kjump
   | Krestart
   | Kgrab of int                        (** number of arguments *)
   | Kgrabrec of int                     (** rec arg *)

--- a/kernel/cbytegen.ml
+++ b/kernel/cbytegen.ml
@@ -768,9 +768,9 @@ let rec compile_constr reloc c sz cont =
       let sz_b,branch,is_tailcall =
 	match branch1 with
 	| Kreturn k ->
-	  assert (Int.equal k sz) ;
 	  sz, branch1, true
-	| _ -> sz+3, Kjump, false
+	| Kbranch _ -> sz+3, Kreturn 0, false
+        | _ -> assert false
       in
 
       let c = ref cont in

--- a/kernel/cemitcodes.ml
+++ b/kernel/cemitcodes.ml
@@ -184,8 +184,6 @@ let emit_instr = function
                else (out opAPPTERM; out_int n; out_int sz)
   | Kreturn n ->
       out opRETURN; out_int n
-  | Kjump ->
-      out opRETURN; out_int 0
   | Krestart ->
       out opRESTART
   | Kgrab n ->
@@ -305,8 +303,6 @@ let rec emit insns remaining = match insns with
   | Kpush :: Kconst const :: c ->
       out opPUSHGETGLOBAL; slot_for_const const;
       emit c remaining
-  | Kpop n :: Kjump :: c ->
-      out opRETURN; out_int n; emit c remaining
   | Ksequence(c1,c2)::c ->
       emit c1 (c2::c::remaining)
   (* Default case *)


### PR DESCRIPTION
It was a synonym of Kreturn 0, except for some optimizations.
Note that this change breaks an invariant (see assertion in
cbytegen.ml), but it seems still correct.

This patch was done with Benjamin Grégoire.

This is a small part of the preliminary work on native integers and arrays.