### PR TITLE
Fixing failing mkdir in test-suite for coq-makefile.

### DIFF
--- a/test-suite/coq-makefile/plugin-reach-outside-API-and-fail/run.sh
+++ b/test-suite/coq-makefile/plugin-reach-outside-API-and-fail/run.sh
@@ -10,7 +10,7 @@ cat > _CoqProject <<EOT
 ./src/test.mli
 EOT
 
-mkdir src
+mkdir -p src
 
 cat > src/test_plugin.mllib <<EOT
 Test

--- a/test-suite/coq-makefile/plugin-reach-outside-API-and-succeed-by-bypassing-the-API/run.sh
+++ b/test-suite/coq-makefile/plugin-reach-outside-API-and-succeed-by-bypassing-the-API/run.sh
@@ -11,7 +11,7 @@ cat > _CoqProject <<EOT
 ./src/test.mli
 EOT
 
-mkdir src
+mkdir -p src
 
 cat > src/test_plugin.mllib <<EOT
 Test


### PR DESCRIPTION
Calling the test a second time after a `make clean` was failing due to an existing `src` directory left by the first call.