### PR TITLE
Ref. Man.: Updating the current official writing of OCaml; updating Camlp4->Camlp5.

### DIFF
--- a/doc/common/macros.tex
+++ b/doc/common/macros.tex
@@ -94,8 +94,8 @@
 \newcommand{\gallina}{\textsc{Gallina}}
 \newcommand{\Gallina}{\textsc{Gallina}}
 \newcommand{\CoqIDE}{\textsc{CoqIDE}}
-\newcommand{\ocaml}{\textsc{Objective Caml}}
-\newcommand{\camlpppp}{\textsc{Camlp4}}
+\newcommand{\ocaml}{\textsc{OCaml}}
+\newcommand{\camlpppp}{\textsc{Camlp5}}
 \newcommand{\emacs}{\textsc{GNU Emacs}}
 \newcommand{\ProofGeneral}{\textsc{Proof General}}
 \newcommand{\CIC}{\textsc{Cic}}


### PR DESCRIPTION
A minor PR, which was lost in the forest of #982 commits. All is in the title.

Depending on the status of the move to sphinx, this is at least relevant for 8.7.1 I guess.