### PR TITLE
Fixing inconsistent associativity of level 10 in the table of levels

### DIFF
--- a/parsing/egramcoq.ml
+++ b/parsing/egramcoq.ml
@@ -35,7 +35,7 @@ let default_levels =
    100,Extend.RightA,false;
    99,Extend.RightA,true;
    90,Extend.RightA,true;
-   10,Extend.RightA,false;
+   10,Extend.LeftA,false;
    9,Extend.RightA,false;
    8,Extend.RightA,true;
    1,Extend.LeftA,false;
@@ -47,7 +47,7 @@ let default_pattern_levels =
    99,Extend.RightA,true;
    90,Extend.RightA,true;
    11,Extend.LeftA,false;
-   10,Extend.RightA,false;
+   10,Extend.LeftA,false;
    1,Extend.LeftA,false;
    0,Extend.RightA,false]
 

--- a/parsing/egramcoq.ml
+++ b/parsing/egramcoq.ml
@@ -46,7 +46,6 @@ let default_pattern_levels =
    100,Extend.RightA,false;
    99,Extend.RightA,true;
    90,Extend.RightA,true;
-   11,Extend.LeftA,false;
    10,Extend.LeftA,false;
    1,Extend.LeftA,false;
    0,Extend.RightA,false]

--- a/parsing/g_constr.ml4
+++ b/parsing/g_constr.ml4
@@ -377,11 +377,10 @@ GEXTEND Gram
       [ p = pattern; "|"; pl = LIST1 pattern SEP "|" -> CAst.make ~loc:!@loc @@ CPatOr (p::pl) ]
     | "99" RIGHTA [ ]
     | "90" RIGHTA [ ]
-    | "11" LEFTA
-      [ p = pattern; "as"; id = ident ->
-        CAst.make ~loc:!@loc @@ CPatAlias (p, id) ]
     | "10" LEFTA
-      [ p = pattern; lp = LIST1 NEXT ->
+      [ p = pattern; "as"; id = ident ->
+        CAst.make ~loc:!@loc @@ CPatAlias (p, id)
+      | p = pattern; lp = LIST1 NEXT ->
         (let open CAst in match p with
 	  | { v = CPatAtom (Some r) } -> CAst.make ~loc:!@loc @@ CPatCstr (r, None, lp)
 	  | { v = CPatCstr (r, None, l2); loc } ->

--- a/parsing/g_constr.ml4
+++ b/parsing/g_constr.ml4
@@ -380,7 +380,7 @@ GEXTEND Gram
     | "11" LEFTA
       [ p = pattern; "as"; id = ident ->
         CAst.make ~loc:!@loc @@ CPatAlias (p, id) ]
-    | "10" RIGHTA
+    | "10" LEFTA
       [ p = pattern; lp = LIST1 NEXT ->
         (let open CAst in match p with
 	  | { v = CPatAtom (Some r) } -> CAst.make ~loc:!@loc @@ CPatCstr (r, None, lp)

--- a/parsing/g_constr.ml4
+++ b/parsing/g_constr.ml4
@@ -391,7 +391,7 @@ GEXTEND Gram
           | _ -> CErrors.user_err
                  ?loc:(cases_pattern_expr_loc p) ~hdr:"compound_pattern"
                  (Pp.str "Such pattern cannot have arguments."))
-      |"@"; r = Prim.reference; lp = LIST0 NEXT ->
+      | "@"; r = Prim.reference; lp = LIST0 NEXT ->
         CAst.make ~loc:!@loc @@ CPatCstr (r, Some lp, []) ]
     | "1" LEFTA
       [ c = pattern; "%"; key=IDENT -> CAst.make ~loc:!@loc @@ CPatDelimiters (key,c) ]

--- a/test-suite/success/Notations.v
+++ b/test-suite/success/Notations.v
@@ -147,3 +147,9 @@ Inductive EQ {A} (x:A) : A -> Prop := REFL : x === x
 
 Fail Check {x@{u},y|x=x}.
 Fail Check {?[n],y|0=0}.
+
+(* Check that 10 is well declared left associative *)
+
+Section C.
+Notation "f $$$ x" := (id f x) (at level 10, left associativity).
+End C.


### PR DESCRIPTION
Thanks to @JasonGross for noticing.

Apparently a long-standing bug, coupled with a `pattern`/`constr` associativity inconsistency introduced while fixing another pattern/constr level inconsistency (bug #4272, 0917ce7c). In particular, the PR also experiments a refined fix to #4272, dropping pattern level 11.

Note that there remain a couple of clumsy things regarding the associativity of levels in `pattern`/`constr`. E.g.:
- Notations are supposed to change both `constr` and `pattern` but there are two distinct level tables. Shouldn't they be shared?
- I did not find a way to control well the associativity of operators because of Camlp5 using heuristics to bypass the levels when no other rules apply (see item 4 [here](https://github.com/coq/coq/wiki/Wishes-for-Camlp5)).
- The check for associativity in `Notation` and `Infix` are a bit loose (sometimes, the associativity is tacitly not used and dropped).
- Probably more...