### PR TITLE
[ci] [vst] Shorten compilation time to avoid Travis timeouts.

### DIFF
--- a/dev/ci/ci-vst.sh
+++ b/dev/ci/ci-vst.sh
@@ -8,6 +8,6 @@ VST_CI_DIR=${CI_BUILD_DIR}/VST
 # opam install -j ${NJOBS} -y menhir
 git_checkout ${VST_CI_BRANCH} ${VST_CI_GITURL} ${VST_CI_DIR}
 
-# Targets are: msl veric floyd
+# Targets are: msl veric floyd progs , we remove progs to save time
 # Patch to avoid the upper version limit
-( cd ${VST_CI_DIR} && make IGNORECOQVERSION=true )
+( cd ${VST_CI_DIR} && make IGNORECOQVERSION=true .loadpath version.vo msl veric floyd )


### PR DESCRIPTION
We remove the progs target [examples] to save time, we still build the
full library thou.

I guess we can't do better for now unless we get some Travis
subscription.