### PR TITLE
Fix #6279: revert change of ML API in stable branch.

### DIFF
--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -410,7 +410,7 @@ let context poly l =
       let decl = (Discharge, poly, Definitional) in
       let nstatus = match b with
       | None ->
-        pi3 (Command.declare_assumption false decl (t, ctx) [] [] impl
+        pi3 (Command.declare_assumption false decl (t, !uctx) [] [] impl
           Vernacexpr.NoInline (Loc.tag id))
       | Some b ->
         let decl = (Discharge, poly, Definition) in

--- a/vernac/command.ml
+++ b/vernac/command.ml
@@ -175,7 +175,6 @@ let do_definition ident k pl bl red_option c ctypopt hook =
 let declare_assumption is_coe (local,p,kind) (c,ctx) pl imps impl nl (_,ident) =
 match local with
 | Discharge when Lib.sections_are_opened () ->
-  let ctx = Univ.ContextSet.of_context ctx in
   let decl = (Lib.cwd(), SectionLocalAssum ((c,ctx),p,impl), IsAssumption kind) in
   let _ = declare_variable ident decl in
   let () = assumption_message ident in
@@ -196,6 +195,7 @@ match local with
     | DefaultInline -> Some (Flags.get_inline_level())
     | InlineAt i -> Some i
   in
+  let ctx = Univ.ContextSet.to_context ctx in
   let decl = (ParameterEntry (None,p,(c,ctx),inl), IsAssumption kind) in
   let kn = declare_constant ident ~local decl in
   let gr = ConstRef kn in
@@ -217,7 +217,7 @@ let interp_assumption evdref env impls bl c =
   (ty, impls)
 
 (* When monomorphic the universe constraints are declared with the first declaration only. *)
-let next_uctx poly uctx = if poly then uctx else Univ.UContext.empty
+let next_uctx poly uctx = if poly then uctx else Univ.ContextSet.empty
 
 let declare_assumptions idl is_coe k (c,uctx) pl imps nl =
   let refs, status, _ =
@@ -300,7 +300,7 @@ let do_assumptions kind nl l =
           idl refs
       in
       subst'@subst, status' && status, next_uctx (pi2 kind) uctx)
-    ([], true, uctx) l)
+    ([], true, Univ.ContextSet.of_context uctx) l)
 
 (* 3a| Elimination schemes for mutual inductive definitions *)
 

--- a/vernac/command.mli
+++ b/vernac/command.mli
@@ -43,7 +43,7 @@ val do_definition : Id.t -> definition_kind -> lident list option ->
 (** returns [false] if the assumption is neither local to a section,
     nor in a module type and meant to be instantiated. *)
 val declare_assumption : coercion_flag -> assumption_kind -> 
-  types Univ.in_universe_context ->
+  types Univ.in_universe_context_set ->
   Universes.universe_binders -> Impargs.manual_implicits ->
   bool (** implicit *) -> Vernacexpr.inline -> variable Loc.located ->
   global_reference * Univ.Instance.t * bool


### PR DESCRIPTION
The commit merged in master uses the universe entry variant. Replacing
the variant with UContext.t was the wrong choice for the backport PR.

The ContextSet.of_context (operation which loses information) was
removed by the problem commit so this should be OK.