### PR TITLE
Cut in typeclasses eauto: hint extern when implementation

### DIFF
--- a/dev/ci/user-overlays/6285-mattam82-cut-typeclasses-eauto.sh
+++ b/dev/ci/user-overlays/6285-mattam82-cut-typeclasses-eauto.sh
@@ -1,0 +1,2 @@
+overlay fiat_parsers https://github.com/mattam82/fiat pr-6285 6285
+overlay coqhammer https://github.com/mattam82/coqhammer pr-6285 6285

--- a/plugins/ltac/g_ltac.mlg
+++ b/plugins/ltac/g_ltac.mlg
@@ -336,10 +336,31 @@ GRAMMAR EXTEND Gram
         "with"; ta = Pltac.tactic ->
           { Vernacexpr.VernacProof (Some (in_tac ta),Some l) } ] ]
   ;
+  extern_body:
+    [ [ "=>"; tac = Pltac.tactic ->
+        { (None, tac) }
+      | IDENT "when"; iftac = Pltac.tactic; "=>"; thentac = Pltac.tactic ->
+        { (Some iftac, thentac) } ] ]
+  ;
   hint: TOP
-    [ [ IDENT "Extern"; n = natural; c = OPT Constr.constr_pattern ; "=>";
-        tac = Pltac.tactic ->
-        { Vernacexpr.HintsExtern (n,c, in_tac tac) } ] ]
+    [ [ IDENT "Extern"; self = OPT identref;
+        n = natural; c = OPT Constr.constr_pattern ;
+        tacs = extern_body ->
+        { let (iftac, thentac) =
+            match self with
+            | Some id ->
+              CAst.with_val (fun self ->
+                let iftac, thentac = tacs in
+                (Option.map (Tacinterp.make_extern self) iftac,
+                 Tacinterp.make_extern self thentac)) id
+            | None -> tacs
+          in
+          let open Vernacexpr in
+          HintsExtern { hint_extern_self = self;
+            hint_extern_priority = n;
+            hint_extern_pattern = c;
+            hint_extern_iftac = Option.map in_tac iftac;
+            hint_extern_body = in_tac thentac } } ] ]
   ;
   term: LEVEL "0"
     [ [ IDENT "ltac"; ":"; "("; tac = Pltac.ltac_expr; ")" ->

--- a/plugins/ltac/tacinterp.mli
+++ b/plugins/ltac/tacinterp.mli
@@ -147,3 +147,9 @@ val interp_int_or_var : interp_sign -> int Locus.or_var -> int
 
 val default_ist : unit -> Geninterp.interp_sign
 (** Empty ist with debug set on the current value. *)
+
+(** Assuming [id] is a free variable in the tactic,
+  bind it to a [val_callback] from typeclasses eauto on the
+  same ident: this allows passing an arbitrary ML tactic
+  to the user hint. *)
+val make_extern : Id.t -> raw_tactic_expr -> raw_tactic_expr

--- a/tactics/auto.mli
+++ b/tactics/auto.mli
@@ -16,6 +16,10 @@ open Pattern
 open Hints
 open Tactypes
 
+(* This generic value type is used internally to allow for the interpretation
+  of tactic arguments to `Hint Extern If self`. Do not use. *)
+val val_callback : unit Proofview.tactic Geninterp.Val.typ
+
 val compute_secvars : Proofview.Goal.t -> Id.Pred.t
 
 val default_search_depth : int ref
@@ -25,12 +29,26 @@ val auto_flags_of_state : TransparentState.t -> Unification.unify_flags
 (** Try unification with the precompiled clause, then use registered Apply *)
 val unify_resolve : Unification.unify_flags -> hint -> unit Proofview.tactic
 
-(** [ConclPattern concl pat tacast]:
-   if the term concl matches the pattern pat, (in sense of
-   [Pattern.somatches], then replace [?1] [?2] metavars in tacast by the
-   right values to build a tactic *)
+(** Generic [conclPattern]:
+  @aises Constr_matching.PatternMatchingFailure in case the conclusion does not match the pattern.
 
-val conclPattern : constr -> constr_pattern option -> Genarg.glob_generic_argument -> unit Proofview.tactic
+  Otherwise returns the bindings of pattern variables in the pattern extending the given ist, if any.
+  *)
+val conclPattern_gen : Environ.env -> Evd.evar_map -> ?ist:Geninterp.Val.t Id.Map.t ->
+  constr -> constr_pattern option -> Geninterp.Val.t Id.Map.t
+
+(** [ConclPattern self concl pat ist iftac thentac cont]:
+  if the term concl matches the pattern pat, (in sense of
+  [Pattern.somatches], then replace [?1] [?2] metavars in iftac and thentac by the
+  right values to build tactics.
+  If [self] is given, then it also binds it to [cont] when evaluating the tactics.
+  If [iftac] is given, then the resulting tactic is `tclIFCATCH iftac thentac cont`
+*)
+
+val conclPattern : Environ.env -> Evd.evar_map -> Names.Id.t CAst.t option ->
+  constr -> constr_pattern option ->
+  Genarg.glob_generic_argument option -> Genarg.glob_generic_argument ->
+  unit hint_tactic
 
 (** The Auto tactic *)
 

--- a/test-suite/bugs/closed/bug_3794.v
+++ b/test-suite/bugs/closed/bug_3794.v
@@ -1,0 +1,6 @@
+#[local] Hint Extern 10 ((?X = ?Y) -> False) => intros; discriminate : core.
+#[local] Hint Unfold not : core.
+
+Goal true<>false.
+typeclasses eauto with core.
+Qed.

--- a/test-suite/bugs/opened/bug_3794.v
+++ b/test-suite/bugs/opened/bug_3794.v
@@ -1,7 +1,0 @@
-Hint Extern 10 ((?X = ?Y) -> False) => intros; discriminate.
-Hint Unfold not : core.
-
-Goal true<>false.
-Set Typeclasses Debug.
-Fail typeclasses eauto with core.
-Abort.

--- a/test-suite/output/TypeclassDebug.out
+++ b/test-suite/output/TypeclassDebug.out
@@ -1,17 +1,17 @@
 Debug: 1: looking for foo without backtracking
-Debug: 1.1: simple apply H on foo, 1 subgoal(s)
-Debug: 1.1-1 : foo
-Debug: 1.1-1: looking for foo without backtracking
-Debug: 1.1-1.1: simple apply H on foo, 1 subgoal(s)
-Debug: 1.1-1.1-1 : foo
-Debug: 1.1-1.1-1: looking for foo without backtracking
-Debug: 1.1-1.1-1.1: simple apply H on foo, 1 subgoal(s)
-Debug: 1.1-1.1-1.1-1 : foo
-Debug: 1.1-1.1-1.1-1: looking for foo without backtracking
-Debug: 1.1-1.1-1.1-1.1: simple apply H on foo, 1 subgoal(s)
-Debug: 1.1-1.1-1.1-1.1-1 : foo
-Debug: 1.1-1.1-1.1-1.1-1: looking for foo without backtracking
-Debug: 1.1-1.1-1.1-1.1-1.1: simple apply H on foo, 1 subgoal(s)
-Debug: 1.1-1.1-1.1-1.1-1.1-1 : foo
+Debug: 1-1: simple apply H on foo, 1 subgoal(s)
+Debug: 1-1.1: foo
+Debug: 1-1.1: looking for foo without backtracking
+Debug: 1-1.1-1: simple apply H on foo, 1 subgoal(s)
+Debug: 1-1.1-1.1: foo
+Debug: 1-1.1-1.1: looking for foo without backtracking
+Debug: 1-1.1-1.1-1: simple apply H on foo, 1 subgoal(s)
+Debug: 1-1.1-1.1-1.1: foo
+Debug: 1-1.1-1.1-1.1: looking for foo without backtracking
+Debug: 1-1.1-1.1-1.1-1: simple apply H on foo, 1 subgoal(s)
+Debug: 1-1.1-1.1-1.1-1.1: foo
+Debug: 1-1.1-1.1-1.1-1.1: looking for foo without backtracking
+Debug: 1-1.1-1.1-1.1-1.1-1: simple apply H on foo, 1 subgoal(s)
+Debug: 1-1.1-1.1-1.1-1.1-1.1: foo
 The command has indeed failed with message:
 Tactic failure: Proof search reached its limit.

--- a/vernac/comHints.ml
+++ b/vernac/comHints.ml
@@ -155,13 +155,23 @@ let interp_hints ~poly h =
           , hint_globref gr ))
     in
     HintsResolveEntry (List.flatten (List.map constr_hints_of_ind lqid))
-  | HintsExtern (pri, patcom, tacexp) ->
+  | HintsExtern { hint_extern_self = lid;
+    hint_extern_priority = pri;
+    hint_extern_pattern = patcom;
+    hint_extern_iftac = iftacexp;
+    hint_extern_body = bodytacexp } ->
     let pat = Option.map (fp sigma) patcom in
     let l = match pat with None -> [] | Some (l, _) -> l in
-    let ltacvars =
-      List.fold_left (fun accu x -> Id.Set.add x accu) Id.Set.empty l
+    let thenvars =
+      match lid with
+      | Some lid -> CAst.with_val Id.Set.singleton lid
+      | None -> Id.Set.empty
     in
-    let env = Genintern.{(empty_glob_sign env) with ltacvars} in
-    let _, tacexp = Genintern.generic_intern env tacexp in
+    let ltacvars =
+      List.fold_left (fun accu x -> Id.Set.add x accu) thenvars l
+    in
+    let tacenv = Genintern.({ (empty_glob_sign env) with ltacvars }) in
+    let iftacexp = Option.map (fun x -> snd (Genintern.generic_intern tacenv x)) iftacexp in
+    let _, bodytacexp = Genintern.generic_intern tacenv bodytacexp in
     HintsExternEntry
-      ({Typeclasses.hint_priority = Some pri; hint_pattern = pat}, tacexp)
+      ({ Typeclasses.hint_priority = Some pri; hint_pattern = pat }, lid, iftacexp, bodytacexp)

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -310,10 +310,17 @@ let pr_hints db h pr_c pr_pat =
     | HintsConstructors c ->
       keyword "Constructors"
       ++ spc() ++ prlist_with_sep spc pr_qualid c
-    | HintsExtern (n,c,tac) ->
+    | HintsExtern { hint_extern_self = lid; hint_extern_priority = n;
+      hint_extern_pattern = c; hint_extern_iftac = iftac; hint_extern_body = thentac } ->
+      let idmsg = match lid with Some lid -> CAst.with_val Id.print lid ++ spc() | None -> mt () in
       let pat = match c with None -> mt () | Some pat -> pr_pat pat in
-      keyword "Extern" ++ spc() ++ int n ++ spc() ++ pat ++ str" =>" ++
-      spc() ++ pr_gen tac
+      let tacmsg = spc() ++ pr_gen thentac in
+      let tacmsg = match iftac with
+        | None -> str " =>" ++ tacmsg
+        | Some iftac ->
+          keyword " when" ++ spc () ++ pr_gen iftac ++ str" =>" ++ tacmsg
+      in
+      keyword "Extern" ++ spc() ++ idmsg ++ int n ++ spc() ++ pat ++ tacmsg
   in
   hov 2 (keyword "Hint "++ pph ++ opth)
 

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -301,6 +301,14 @@ type reference_or_constr =
   | HintsReference of Libnames.qualid
   | HintsConstr of Constrexpr.constr_expr
 
+type hint_extern_expr =
+  { hint_extern_self : lident option;
+    hint_extern_priority : int;
+    hint_extern_pattern : Constrexpr.constr_expr option;
+    hint_extern_iftac : Genarg.raw_generic_argument option;
+    hint_extern_body : Genarg.raw_generic_argument
+  }
+
 type hints_expr =
   | HintsResolve of (hint_info_expr * bool * reference_or_constr) list
   | HintsResolveIFF of bool * Libnames.qualid list * int option
@@ -309,7 +317,7 @@ type hints_expr =
   | HintsTransparency of Libnames.qualid Hints.hints_transparency_target * bool
   | HintsMode of Libnames.qualid * Hints.hint_mode list
   | HintsConstructors of Libnames.qualid list
-  | HintsExtern of int * Constrexpr.constr_expr option * Genarg.raw_generic_argument
+  | HintsExtern of hint_extern_expr
 
 type nonrec vernac_expr =
 


### PR DESCRIPTION
This provides a new "Hint Extern self? priority pattern? (when iftac)? => thentac" hint kind allowing to implement full backtracking and cuts in (typeclasses) eauto resolution, giving access to the tclIFCATCH primitive of the proof-engine.

Two new things:
- Using self allows the hint extern to completely drive the proof search at this point: the tactic may choose to call self to continue resolution on the remaining subgoals but also to use it in a nested way to solve goals it produces itself. If one puts self but no `when` clause, then it can just be used to do recursive calls of proof search respecting the depth/hint databases etc... of the ongoing proof search. If one doesn't call `self` on resulting subgoals of an extern application, then it is run on the resulting subgoals, as before.
- If `when iftac` is provided then the hint acts as `tclIFCATCH iftac thentac`. This is a little bit more restrictive than a `tclCASE` which could also decide to do something specific ratner than continue resolution if the `iftac` has no success, but still allows to implement (hard) cut: if `iftac` succeeds at least once, `thentac` is executed and no backtracking on the "brother" subgoals of resolution can happen (in other words the failure continuation is dropped). One can use `once` and `self` in iftac and thentac to implement additional soft cuts.

[ ] documentation
[ ] changelog entry