### PR TITLE
Add merlin to default.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -49,6 +49,8 @@ stdenv.mkDerivation rec {
     rsync
     which
 
+  ] else []) ++ (if lib.inNixShell then [
+    ocamlPackages.merlin
   ] else []);
 
   src =


### PR DESCRIPTION
Following a suggestion by @maximedenes.
I'm not sure how to configure Emacs from the `default.nix` file. Maybe @jwiegley can give some advice here.
I'm personally using `use-package` and my configuration contains this:

```elisp
;; Tuareg
(use-package tuareg
  :ensure t
  :mode ("\\.ml[iylp4]?$" . tuareg-mode)
  :config
  (add-hook 'tuareg-mode-hook 'merlin-mode))

;; Merlin is installed with Nix
(use-package merlin
  :init
  (setq merlin-command "ocamlmerlin")
  :config
  (add-hook 'merlin-mode-hook #'company-mode))
```

In particular, the `(setq merlin-command "ocamlmerlin")` part is important because the Emacs mode will look for the command using `opam` by default (instead of looking in the PATH), see ocaml/merlin#691.