### PR TITLE
Check for Num lib if OCaml >= 4.06, fixes #6162

### DIFF
--- a/configure.ml
+++ b/configure.ml
@@ -678,6 +678,22 @@ let operating_system, osdeplibs =
   else
     (try Sys.getenv "OS" with Not_found -> ""), osdeplibs
 
+(** Num library *)
+
+(* since 4.06, the Num library is no longer distributed with OCaml (replaced
+   by Zarith)
+*)
+
+let check_for_numlib () =
+  if caml_version_nums >= [4;6;0] then
+    let numlib,_ = tryrun "ocamlfind" ["query";"num"] in
+    match numlib with
+    | ""  ->
+       die "Num library not installed, required for OCaml 4.06 or later"
+    | _   -> printf "You have the Num library installed. Good!\n"
+
+let numlib =
+  check_for_numlib ()
 
 (** * lablgtk2 and CoqIDE *)
 


### PR DESCRIPTION
There's a list of files to check, currently just the interface file and bytecode library. The full installation of Num contains more files, and we could check for them, but maybe just these two is enough.

Update: the strategy is now just to call `ocamlfind query num` and examine the result, per the comments below.

This PR fixes #6162.


