### PR TITLE
Fix #6297: handle constraints like (u+1 <= Set/Prop)

### DIFF
--- a/engine/uState.ml
+++ b/engine/uState.ml
@@ -197,14 +197,18 @@ let process_universe_constraints ctx cstrs =
               | None -> user_err Pp.(str "Algebraic universe on the right")
               | Some r' ->
                 if Univ.Level.is_small r' then
-                  let levels = Univ.Universe.levels l in
-                  let fold l' local =
-                    let l = Univ.Universe.make l' in
-                    if Univ.Level.is_small l' || is_local l' then
-                      equalize_variables false l l' r r' local
-                    else raise (Univ.UniverseInconsistency (Univ.Le, l, r, None))
-                  in
-                  Univ.LSet.fold fold levels local
+                  if not (Univ.Universe.is_levels l)
+                  then
+                    raise (Univ.UniverseInconsistency (Univ.Le, l, r, None))
+                  else
+                    let levels = Univ.Universe.levels l in
+                    let fold l' local =
+                      let l = Univ.Universe.make l' in
+                      if Univ.Level.is_small l' || is_local l' then
+                        equalize_variables false l l' r r' local
+                      else raise (Univ.UniverseInconsistency (Univ.Le, l, r, None))
+                    in
+                    Univ.LSet.fold fold levels local
                 else
                   Univ.enforce_leq l r local
               end

--- a/test-suite/bugs/closed/6297.v
+++ b/test-suite/bugs/closed/6297.v
@@ -1,0 +1,8 @@
+Set Printing Universes.
+
+(* Error: Anomaly "Uncaught exception "Anomaly: Incorrect universe Set
+   declared for inductive type, inferred level is max(Prop, Set+1)."."
+   Please report at http://coq.inria.fr/bugs/. *)
+Fail Record LTS: Set :=
+  lts { St: Set;
+        init: St }.


### PR DESCRIPTION
Universe.levels is super suspicious honestly, we should make the caller explicitly ignore the +1s if they need to (but not in a backportable fix).