### PR TITLE
Uninstall doc dir, not dev (which is not installed), fixes #6007

### DIFF
--- a/dev/build/windows/patches_coq/coq_new.nsi
+++ b/dev/build/windows/patches_coq/coq_new.nsi
@@ -188,7 +188,7 @@ SectionEnd
 Section "Uninstall"
   ; Files and folders
   RMDir /r "$INSTDIR\bin"
-  RMDir /r "$INSTDIR\dev"
+  RMDir /r "$INSTDIR\doc"
   RMDir /r "$INSTDIR\etc"
   RMDir /r "$INSTDIR\lib"
   RMDir /r "$INSTDIR\libocaml"


### PR DESCRIPTION
I don't know how to build an installer to test this fix. But it seems as though the uninstaller was removing a `dev` directory which was not installed, instead of the `doc` directory.

This fixes #6007.