### PR TITLE
Build with windows line endings

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -302,7 +302,7 @@ kernel/byterun/coq_jumptbl.h : kernel/byterun/coq_instruct.h
                -e '/^}/q' $< $(TOTARGET)
 
 kernel/copcodes.ml: kernel/byterun/coq_instruct.h
-	sed -n -e '/^enum/p' -e 's/,//g' -e '/^  /p' $< | \
+	tr -d "\r" < $< | sed -n -e '/^enum/p' -e 's/,//g' -e '/^  /p' | \
 	awk -f kernel/make-opcodes $(TOTARGET)
 
 %.o: %.c

--- a/Makefile.checker
+++ b/Makefile.checker
@@ -75,8 +75,9 @@ checker/%.cmx: checker/%.ml
 
 md5chk:
 	$(SHOW)'MD5SUM cic.mli'
-	$(HIDE)if grep -q `$(MD5SUM) checker/cic.mli` checker/values.ml; \
-	       then true; else echo "Error: outdated checker/values.ml"; false; fi
+	$(HIDE)v=`tr -d "\r" < checker/cic.mli | $(MD5SUM) | sed -n -e 's/ .*//' -e '/^/p'`; \
+	       if grep -q "$$v" checker/values.ml; \
+	       then true; else echo "Error: outdated checker/values.ml: $$v" >&2; false; fi
 
 .PHONY: md5chk
 

--- a/dev/build/windows/MakeCoq_MinGW.bat
+++ b/dev/build/windows/MakeCoq_MinGW.bat
@@ -345,7 +345,7 @@ IF "%COQREGTESTING%" == "Y" (
 SET "EXTRAPACKAGES= "
 
 IF NOT "%APPVEYOR%" == "True" (
-  SET EXTRAPACKAGES="-P wget,curl,git,gcc-core,gcc-g++,automake1.5"
+  SET EXTRAPACKAGES=-P wget,curl,git,gcc-core,gcc-g++,automake1.5
 )
 
 IF "%RUNSETUP%"=="Y" (


### PR DESCRIPTION
These make it possible to run make successfully if the source tree was checked out with Windows line endings:
- Fixes #6249 Segmentation fault when building Coq on Windows 10
- Converts windows line endings before MD5 is computed to get the correct value

Plus:
- Remove incorrect quote marks in Windows build file (causes unknown parameter error in the next command)

(My first pull request for Coq.)