### PR TITLE
[default.nix] needs ncurses for the test-suite

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -45,6 +45,7 @@ stdenv.mkDerivation rec {
   ] else []) ++ (if doCheck then [
 
     # Test-suite dependencies
+    ncurses
     python
     rsync
     which

--- a/default.nix
+++ b/default.nix
@@ -42,10 +42,13 @@ stdenv.mkDerivation rec {
     # CoqIDE dependencies
     ocamlPackages.lablgtk
 
-  ] else []) ++ (if doCheck then [
+  ] else []) ++ (if doCheck then
 
     # Test-suite dependencies
-    ncurses
+    let inherit (stdenv.lib) versionAtLeast optional; in
+    /* ncurses is required to build an OCaml REPL */
+    optional (!versionAtLeast ocaml.version "4.07") ncurses
+    ++ [
     python
     rsync
     which


### PR DESCRIPTION
The test suite depends on ncurses when running `coqmktop`.