### PR TITLE
[configure] fix detection of `md5sum`

### DIFF
--- a/configure.ml
+++ b/configure.ml
@@ -183,14 +183,14 @@ let program_in_path prog =
     Chooses the first one whose execution outputs a non-empty (first) line.
     Dies with message [msg] if none is found. *)
 
-let select_command msg canditates =
+let select_command msg candidates =
   let rec search = function
     | [] -> die msg
     | (p, x, y) :: tl ->
       if fst (tryrun p (x @ y)) <> ""
       then List.fold_left (Printf.sprintf "%s %s") p x
       else search tl
-  in search canditates
+  in search candidates
 
 (** As per bug #4828, ocamlfind on Windows/Cygwin barfs if you pass it
     a quoted path to camlpXo via -pp.  So we only quote camlpXo on not

--- a/configure.ml
+++ b/configure.ml
@@ -178,6 +178,20 @@ let which prog =
 let program_in_path prog =
   try let _ = which prog in true with Not_found -> false
 
+(** Choose a command among a list of candidates
+    (command name, mandatory arguments, arguments for this test).
+    Chooses the first one whose execution outputs a non-empty (first) line.
+    Dies with message [msg] if none is found. *)
+
+let select_command msg canditates =
+  let rec search = function
+    | [] -> die msg
+    | (p, x, y) :: tl ->
+      if fst (tryrun p (x @ y)) <> ""
+      then List.fold_left (Printf.sprintf "%s %s") p x
+      else search tl
+  in search canditates
+
 (** As per bug #4828, ocamlfind on Windows/Cygwin barfs if you pass it
     a quoted path to camlpXo via -pp.  So we only quote camlpXo on not
     Windows, and warn on Windows if the path contains spaces *)
@@ -837,13 +851,7 @@ let strip =
 (** * md5sum command *)
 
 let md5sum =
-  let rec loop = function
-    | [] -> die "Don’t know how to compute MD5 checksums…"
-    | (p, ma, a) :: tl ->
-      if fst (tryrun p (ma @ a)) <> ""
-      then List.fold_left (Printf.sprintf "%s %s") p ma
-      else loop tl
-  in loop [
+  select_command "Don’t know how to compute MD5 checksums…" [
     "md5sum", [], [ "--version" ];
     "md5", ["-q"], [ "-s" ; "''" ];
   ]

--- a/configure.ml
+++ b/configure.ml
@@ -837,9 +837,16 @@ let strip =
 (** * md5sum command *)
 
 let md5sum =
-  if List.mem arch ["Darwin"; "FreeBSD"; "OpenBSD"]
-  then "md5 -q" else "md5sum"
-
+  let rec loop = function
+    | [] -> die "Don’t know how to compute MD5 checksums…"
+    | (p, ma, a) :: tl ->
+      if fst (tryrun p (ma @ a)) <> ""
+      then List.fold_left (Printf.sprintf "%s %s") p ma
+      else loop tl
+  in loop [
+    "md5sum", [], [ "--version" ];
+    "md5", ["-q"], [ "-s" ; "''" ];
+  ]
 
 (** * Documentation : do we have latex, hevea, ... *)
 


### PR DESCRIPTION
Currently, the decision about what command should be used to compute MD5 checksums relies on a spurious correlation to the OS kernel.

This patch makes the `configure.ml` script actually run the chosen command before taking a decision.

