### PR TITLE
Add option Typeclasses Default Generalize Instance Variables.

### DIFF
--- a/API/API.mli
+++ b/API/API.mli
@@ -4077,7 +4077,7 @@ sig
 
   type class_rawexpr = FunClass | SortClass | RefClass of reference or_by_notation
 
-  type typeclass_constraint = (Names.Name.t Loc.located * universe_decl_expr option) * Decl_kinds.binding_kind * constr_expr
+  type typeclass_constraint = (Names.Name.t Loc.located * universe_decl_expr option) * Decl_kinds.binding_kind option * constr_expr
 
   type definition_expr =
     | ProveBody of local_binder_expr list * constr_expr

--- a/doc/refman/Classes.tex
+++ b/doc/refman/Classes.tex
@@ -469,6 +469,13 @@ This option (off by default since 8.8) automatically declares axioms
 whose type is a typeclass at declaration time as instances of that
 class.
 
+\subsection{\tt Set Typeclasses Default Generalize Instance Variables}
+\optindex{Typeclasses Default Generalize Instance Variables}
+
+This option (on by default) enables generalizing variables (as per
+{\tt Generalizable Variables} \ref{GeneralizableVariables}) in the
+type of an {\tt Instance} declaration.
+
 \subsection{\tt Set Typeclasses Dependency Order}
 \optindex{Typeclasses Dependency Order}
 

--- a/intf/vernacexpr.ml
+++ b/intf/vernacexpr.ml
@@ -204,7 +204,7 @@ type inductive_expr =
 type one_inductive_expr =
   ident_decl * local_binder_expr list * constr_expr option * constructor_expr list
 
-type typeclass_constraint = (Name.t Loc.located * universe_decl_expr option) * binding_kind * constr_expr
+type typeclass_constraint = (Name.t Loc.located * universe_decl_expr option) * binding_kind option * constr_expr
 
 and typeclass_context = typeclass_constraint list
 

--- a/parsing/g_vernac.ml4
+++ b/parsing/g_vernac.ml4
@@ -24,7 +24,7 @@ open Pcoq.Constr
 open Pcoq.Vernac_
 open Pcoq.Module
 
-let vernac_kw = [ ";"; ","; ">->"; ":<"; "<:"; "where"; "at" ]
+let vernac_kw = [ ";"; ","; ">->"; ":<"; "<:"; "where"; "at"; "!"; "`" ]
 let _ = List.iter CLexer.add_keyword vernac_kw
 
 (* Rem: do not join the different GEXTEND into one, it breaks native *)
@@ -641,7 +641,7 @@ GEXTEND Gram
 	  VernacContext c
 
       | IDENT "Instance"; namesup = instance_name; ":";
-	 expl = [ "!" -> Decl_kinds.Implicit | -> Decl_kinds.Explicit ] ; t = operconstr LEVEL "200";
+         expl = OPT [ "!" -> Decl_kinds.Implicit | "`" -> Decl_kinds.Explicit ] ; t = operconstr LEVEL "200";
 	 info = hint_info ;
 	 props = [ ":="; "{"; r = record_declaration; "}" -> Some (true,r) |
 	     ":="; c = lconstr -> Some (false,c) | -> None ] ->
@@ -821,7 +821,8 @@ GEXTEND Gram
 
       (* Hack! Should be in grammar_ext, but camlp4 factorize badly *)
       | IDENT "Declare"; IDENT "Instance"; namesup = instance_name; ":";
-	 expl = [ "!" -> Decl_kinds.Implicit | -> Decl_kinds.Explicit ] ; t = operconstr LEVEL "200";
+        expl = OPT [ "!" -> Decl_kinds.Implicit | "`" -> Decl_kinds.Explicit ] ;
+        t = operconstr LEVEL "200";
 	 info = hint_info ->
 	   VernacInstance (true, snd namesup, (fst namesup, expl, t), None, info)
 

--- a/plugins/ltac/rewrite.ml
+++ b/plugins/ltac/rewrite.ml
@@ -1774,7 +1774,7 @@ let rec strategy_of_ast = function
 let mkappc s l = CAst.make @@ CAppExpl ((None,(Libnames.Ident (Loc.tag @@ Id.of_string s)),None),l)
 
 let declare_an_instance n s args =
-  (((Loc.tag @@ Name n),None), Explicit,
+  (((Loc.tag @@ Name n),None), Some Explicit,
   CAst.make @@ CAppExpl ((None, Qualid (Loc.tag @@  qualid_of_string s),None),
 	   args))
 
@@ -2006,7 +2006,7 @@ let add_morphism glob binders m s n =
   let poly = Flags.is_universe_polymorphism () in
   let instance_id = add_suffix n "_Proper" in
   let instance =
-    (((Loc.tag @@ Name instance_id),None), Explicit,
+    (((Loc.tag @@ Name instance_id),None), Some Explicit,
     CAst.make @@ CAppExpl (
 	     (None, Qualid (Loc.tag @@ Libnames.qualid_of_string "Coq.Classes.Morphisms.Proper"),None),
 	     [cHole; s; m]))

--- a/printing/ppvernac.ml
+++ b/printing/ppvernac.ml
@@ -885,7 +885,10 @@ open Decl_kinds
                | (_, Anonymous), _ -> mt ()) ++
               pr_and_type_binders_arg sup ++
               str":" ++ spc () ++
-              (match bk with Implicit -> str "! " | Explicit -> mt ()) ++
+              (match bk with
+                | Some Implicit -> str "! "
+                | Some Explicit -> str "`"
+                | None -> mt ()) ++
               pr_constr cl ++ pr_hint_info pr_constr_pattern_expr info ++
               (match props with
                 | Some (true, { CAst.v = CRecord l}) -> spc () ++ str":=" ++ spc () ++ str"{" ++ pr_record_body l ++ str "}"

--- a/test-suite/success/Typeclasses.v
+++ b/test-suite/success/Typeclasses.v
@@ -257,3 +257,20 @@ Module AxiomsAreInstances.
   Definition testdef2 : TestClass2 := _.
 
 End AxiomsAreInstances.
+
+Module GeneralizeVariables.
+  Class Foo := {}.
+  Class Bar (A:Foo) := {}.
+
+  Generalizable All Variables.
+
+  Instance bar1 : `Bar A := {}.
+  Fail Instance bar2 : !Bar A := {}.
+
+  Unset Typeclasses Default Generalize Instance Variables.
+  Fail Instance bar2 : Bar A := {}.
+
+  Set Typeclasses Default Generalize Instance Variables.
+  Instance bar2 : Bar A := {}.
+
+End GeneralizeVariables.

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -130,10 +130,23 @@ let declare_instance_constant k info global imps ?hook id decl poly evm term ter
     instance_hook k info global imps ?hook (ConstRef kn);
     id
 
+let get_default_generalize_instance =
+  let ref = ref true in
+  let open Goptions in
+  let _ = declare_bool_option
+           { optdepr  = false;
+             optname  = "generalize variables in the type of an Instance";
+             optkey   = ["Typeclasses";"Default";"Generalize";"Instance";"Variables"];
+             optread  = (fun () -> !ref);
+             optwrite = (fun b -> ref := b); }
+  in
+  fun () -> if !ref then Explicit else Implicit
+
 let new_instance ?(abstract=false) ?(global=false) ?(refine= !refine_instance)
   poly ctx (instid, bk, cl) props ?(generalize=true)
   ?(tac:unit Proofview.tactic option) ?hook pri =
   let env = Global.env() in
+  let bk = Option.default (get_default_generalize_instance ()) bk in
   let ((loc, instid), pl) = instid in
   let evd, decl = Univdecls.interp_univ_decl_opt env pl in
   let evars = ref evd in


### PR DESCRIPTION
Not sure the \ref in the documentation is the correct one.

Not sure I completely understood what it's doing, as I feel like the meaning of `Implicit` and `Explicit` are inverted.

Ping @RalfJung, see #6030.