### PR TITLE
Fix #6286 (non stability of micromega csdp cache rebuilding)

### DIFF
--- a/plugins/micromega/persistent_cache.ml
+++ b/plugins/micromega/persistent_cache.ml
@@ -149,7 +149,7 @@ let open_in f =
     match read_key_elem inch with
       | None -> ()
       | Some (key,elem) ->
-	  Table.add htbl key elem ;
+          Table.replace htbl key elem ;
 	  xload () in
     try
       (* Locking of the (whole) file while reading *)
@@ -195,7 +195,7 @@ let add t k e =
     else
       let fd = descr_of_out_channel outch in
       begin
-       Table.add tbl k e ;
+       Table.replace tbl k e ;
        do_under_lock Write fd 
         (fun _ -> 
          Marshal.to_channel outch (k,e) [Marshal.No_sharing] ;


### PR DESCRIPTION
This fixes #6286 as suggested by PMP (replacing `Hashtbl.add` with `Hashtbl.replace`). See details of discussion at #6286.