### PR TITLE
Fix #6323: stronger restrict universe context vs abstract.

### DIFF
--- a/API/API.mli
+++ b/API/API.mli
@@ -2057,7 +2057,7 @@ end
 
 module Univops :
 sig
-  val universes_of_constr : Constr.constr -> Univ.LSet.t
+  val universes_of_constr : Environ.env -> Constr.constr -> Univ.LSet.t
   val restrict_universe_context : Univ.ContextSet.t -> Univ.LSet.t -> Univ.ContextSet.t
 end
 

--- a/dev/ci/user-overlays/06324-SkySkimmer-abstract-vs-restrict.sh
+++ b/dev/ci/user-overlays/06324-SkySkimmer-abstract-vs-restrict.sh
@@ -1,0 +1,4 @@
+if [ "$TRAVIS_PULL_REQUEST" = "6324" ] || [ "$TRAVIS_BRANCH" = "fix-6323-restrict+abstract" ]; then
+    Equations_CI_BRANCH=fix-coq-6324
+    Equations_CI_GITURL=https://github.com/SkySkimmer/Coq-Equations.git
+fi

--- a/engine/eConstr.mli
+++ b/engine/eConstr.mli
@@ -203,7 +203,7 @@ val fold : Evd.evar_map -> ('a -> t -> 'a) -> 'a -> t -> 'a
 
 (** Gather the universes transitively used in the term, including in the
    type of evars appearing in it. *)
-val universes_of_constr : Evd.evar_map -> t -> Univ.LSet.t
+val universes_of_constr : Environ.env -> Evd.evar_map -> t -> Univ.LSet.t
 
 (** {6 Substitutions} *)
 

--- a/engine/uState.mli
+++ b/engine/uState.mli
@@ -87,6 +87,8 @@ val universe_of_name : t -> Id.t -> Univ.Level.t
 
 val restrict : t -> Univ.LSet.t -> t
 
+val demote_seff_univs : Safe_typing.private_constants Entries.definition_entry -> t -> t
+
 type rigid = 
   | UnivRigid
   | UnivFlexible of bool (** Is substitution by an algebraic ok? *)

--- a/engine/univops.ml
+++ b/engine/univops.ml
@@ -9,12 +9,25 @@
 open Univ
 open Constr
 
-let universes_of_constr c =
+let universes_of_constr env c =
+  let open Declarations in
   let rec aux s c = 
     match kind c with
-    | Const (_, u) | Ind (_, u) | Construct (_, u) ->
-      LSet.fold LSet.add (Instance.levels u) s
-    | Sort u when not (Sorts.is_small u) -> 
+    | Const (c, u) ->
+      begin match (Environ.lookup_constant c env).const_universes with
+        | Polymorphic_const _ ->
+          LSet.fold LSet.add (Instance.levels u) s
+        | Monomorphic_const (univs, _) ->
+          LSet.union s univs
+      end
+    | Ind ((mind,_), u) | Construct (((mind,_),_), u) ->
+      begin match (Environ.lookup_mind mind env).mind_universes with
+        | Cumulative_ind _ | Polymorphic_ind _ ->
+          LSet.fold LSet.add (Instance.levels u) s
+        | Monomorphic_ind (univs,_) ->
+          LSet.union s univs
+      end
+    | Sort u when not (Sorts.is_small u) ->
       let u = Sorts.univ_of_sort u in
       LSet.fold LSet.add (Universe.levels u) s
     | _ -> Constr.fold aux s c

--- a/engine/univops.mli
+++ b/engine/univops.mli
@@ -9,7 +9,8 @@
 open Constr
 open Univ
 
-(** Shrink a universe context to a restricted set of variables *)
+(** The universes of monomorphic constants appear. *)
+val universes_of_constr : Environ.env -> constr -> LSet.t
 
-val universes_of_constr : constr -> LSet.t
+(** Shrink a universe context to a restricted set of variables *)
 val restrict_universe_context : ContextSet.t -> LSet.t -> ContextSet.t

--- a/plugins/setoid_ring/newring.ml
+++ b/plugins/setoid_ring/newring.ml
@@ -152,7 +152,8 @@ let ic_unsafe c = (*FIXME remove *)
 
 let decl_constant na univs c =
   let open Constr in
-  let vars = Univops.universes_of_constr c in
+  let env = Global.env () in
+  let vars = Univops.universes_of_constr env c in
   let univs = Univops.restrict_universe_context univs vars in
   let univs = Monomorphic_const_entry univs in
   mkConst(declare_constant (Id.of_string na) 

--- a/proofs/pfedit.ml
+++ b/proofs/pfedit.ml
@@ -140,6 +140,7 @@ let build_constant_by_tactic id ctx sign ?(goal_kind = Global, false, Proof Theo
     let status = by tac in
     let _,(const,univs,_) = cook_proof () in
     Proof_global.discard_current ();
+    let univs = UState.demote_seff_univs const univs in
     const, status, univs
   with reraise ->
     let reraise = CErrors.push reraise in

--- a/proofs/proof_global.ml
+++ b/proofs/proof_global.ml
@@ -348,13 +348,9 @@ let close_proof ~keep_body_ucst_separate ?feedback_id ~now
 	    nf t
 	  else t
         in
-        let used_univs_body = Univops.universes_of_constr body in
-        let used_univs_typ = Univops.universes_of_constr typ in
-        (* Universes for private constants are relevant to the body *)
-        let used_univs_body =
-          List.fold_left (fun acc (us,_) -> Univ.LSet.union acc us)
-            used_univs_body (Safe_typing.universes_of_private eff)
-        in
+        let env = Global.env () in
+        let used_univs_body = Univops.universes_of_constr env body in
+        let used_univs_typ = Univops.universes_of_constr env typ in
         if keep_body_ucst_separate ||
            not (Safe_typing.empty_private_constants = eff) then
           let initunivs = UState.const_univ_entry ~poly initial_euctx in
@@ -362,7 +358,7 @@ let close_proof ~keep_body_ucst_separate ?feedback_id ~now
           (* For vi2vo compilation proofs are computed now but we need to
              complement the univ constraints of the typ with the ones of
              the body.  So we keep the two sets distinct. *)
-	  let used_univs = Univ.LSet.union used_univs_body used_univs_typ in
+          let used_univs = Univ.LSet.union used_univs_body used_univs_typ in
           let ctx_body = UState.restrict ctx used_univs in
           let univs = UState.check_mono_univ_decl ctx_body universe_decl in
           (initunivs, typ), ((body, univs), eff)

--- a/test-suite/bugs/closed/6323.v
+++ b/test-suite/bugs/closed/6323.v
@@ -1,0 +1,9 @@
+Goal True.
+  simple refine (let X : Type := _ in _);
+    [ abstract exact Set using Set'
+    | let X' := (eval cbv delta [X] in X) in
+      clear X;
+      simple refine (let id' : { x : X' | True } -> X' := _ in _);
+      [ abstract refine (@proj1_sig _ _) | ]
+    ].
+Abort.

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -114,9 +114,10 @@ let instance_hook k info global imps ?hook cst =
 
 let declare_instance_constant k info global imps ?hook id decl poly evm term termtype =
   let kind = IsDefinition Instance in
-  let evm = 
-    let levels = Univ.LSet.union (Univops.universes_of_constr termtype) 
-				 (Univops.universes_of_constr term) in
+  let evm =
+    let env = Global.env () in
+    let levels = Univ.LSet.union (Univops.universes_of_constr env termtype)
+                                 (Univops.universes_of_constr env term) in
     Evd.restrict_universe_context evm levels 
   in
   let uctx = Evd.check_univ_decl ~poly evm decl in

--- a/vernac/obligations.ml
+++ b/vernac/obligations.ml
@@ -477,7 +477,10 @@ let declare_definition prg =
   let fix_exn = Hook.get get_fix_exn () in
   let typ = nf typ in
   let body = nf body in
-  let uvars = Univ.LSet.union (Univops.universes_of_constr typ) (Univops.universes_of_constr body) in
+  let env = Global.env () in
+  let uvars = Univ.LSet.union
+      (Univops.universes_of_constr env typ)
+      (Univops.universes_of_constr env body) in
   let uctx = UState.restrict prg.prg_ctx uvars in
   let univs = UState.check_univ_decl ~poly:(pi2 prg.prg_kind) uctx prg.prg_univdecl in
   let ce = definition_entry ~fix_exn ~opaque ~types:typ ~univs body in


### PR DESCRIPTION
In the test we do [let X : Type@{i} := Set in ...] with Set
abstracted. The constraint [Set < i] was lost in the abstract.

We keep track in the UState of which universes are used in side
effects (and so should not be restricted away).