### PR TITLE
Fix #6313: lost goals in nested ltac in refine

### DIFF
--- a/clib/option.ml
+++ b/clib/option.ml
@@ -52,6 +52,9 @@ let get = function
 (** [make x] returns [Some x]. *)
 let make x = Some x
 
+(** [bind x f] is [f y] if [x] is [Some y] and [None] otherwise *)
+let bind x f = match x with Some y -> f y | None -> None
+
 (** [init b x] returns [Some x] if [b] is [true] and [None] otherwise. *)
 let init b x =
   if b then

--- a/clib/option.mli
+++ b/clib/option.mli
@@ -43,6 +43,9 @@ val get : 'a option -> 'a
 (** [make x] returns [Some x]. *)
 val make : 'a -> 'a option
 
+(** [bind x f] is [f y] if [x] is [Some y] and [None] otherwise *)
+val bind : 'a option -> ('a -> 'b option) -> 'b option
+
 (** [init b x] returns [Some x] if [b] is [true] and [None] otherwise. *)
 val init : bool -> 'a -> 'a option
 

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -946,7 +946,7 @@ let principal_future_goal evd = evd.principal_future_goal
 let reset_future_goals evd =
   { evd with future_goals = [] ; principal_future_goal=None }
 
-let restore_future_goals evd gls pgl =
+let restore_future_goals evd (gls,pgl) =
   { evd with future_goals = gls ; principal_future_goal = pgl }
 
 (**********************************************************)

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -943,6 +943,8 @@ let future_goals evd = evd.future_goals
 
 let principal_future_goal evd = evd.principal_future_goal
 
+let save_future_goals evd = (evd.future_goals, evd.principal_future_goal)
+
 let reset_future_goals evd =
   { evd with future_goals = [] ; principal_future_goal=None }
 

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -303,7 +303,7 @@ val reset_future_goals : evar_map -> evar_map
 (** Clears the list of future goals (as well as the principal future
     goal). Used by the [refine] primitive of the tactic engine. *)
 
-val restore_future_goals : evar_map -> Evar.t list -> Evar.t option -> evar_map
+val restore_future_goals : evar_map -> Evar.t list * Evar.t option -> evar_map
 (** Sets the future goals (including the principal future goal) to a
     previous value. Intended to be used after a local list of future
     goals has been consumed. Used by the [refine] primitive of the

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -299,6 +299,10 @@ val principal_future_goal : evar_map -> Evar.t option
 (** Retrieves the name of the principal existential variable if there
     is one. Used by the [refine] primitive of the tactic engine. *)
 
+val save_future_goals : evar_map -> Evar.t list * Evar.t option
+(** Retrieves the list of future goals including the principal future
+    goal. Used by the [refine] primitive of the tactic engine. *)
+
 val reset_future_goals : evar_map -> evar_map
 (** Clears the list of future goals (as well as the principal future
     goal). Used by the [refine] primitive of the tactic engine. *)

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -282,11 +282,13 @@ val drop_side_effects : evar_map -> evar_map
 
 (** {5 Future goals} *)
 
-val declare_future_goal : Evar.t -> evar_map -> evar_map
+type goal_kind = ToShelve | ToGiveUp
+
+val declare_future_goal : ?tag:goal_kind -> Evar.t -> evar_map -> evar_map
 (** Adds an existential variable to the list of future goals. For
     internal uses only. *)
 
-val declare_principal_goal : Evar.t -> evar_map -> evar_map
+val declare_principal_goal : ?tag:goal_kind -> Evar.t -> evar_map -> evar_map
 (** Adds an existential variable to the list of future goals and make
     it principal. Only one existential variable can be made principal, an
     error is raised otherwise. For internal uses only. *)
@@ -299,7 +301,9 @@ val principal_future_goal : evar_map -> Evar.t option
 (** Retrieves the name of the principal existential variable if there
     is one. Used by the [refine] primitive of the tactic engine. *)
 
-val save_future_goals : evar_map -> Evar.t list * Evar.t option
+type future_goals
+
+val save_future_goals : evar_map -> future_goals
 (** Retrieves the list of future goals including the principal future
     goal. Used by the [refine] primitive of the tactic engine. *)
 
@@ -307,11 +311,30 @@ val reset_future_goals : evar_map -> evar_map
 (** Clears the list of future goals (as well as the principal future
     goal). Used by the [refine] primitive of the tactic engine. *)
 
-val restore_future_goals : evar_map -> Evar.t list * Evar.t option -> evar_map
+val restore_future_goals : evar_map -> future_goals -> evar_map
 (** Sets the future goals (including the principal future goal) to a
     previous value. Intended to be used after a local list of future
     goals has been consumed. Used by the [refine] primitive of the
     tactic engine. *)
+
+val fold_future_goals : (evar_map -> Evar.t -> evar_map) -> evar_map -> future_goals -> evar_map
+(** Fold future goals *)
+
+val map_filter_future_goals : (Evar.t -> Evar.t option) -> future_goals -> future_goals
+(** Applies a function on the future goals *)
+
+val filter_future_goals : (Evar.t -> bool) -> future_goals -> future_goals
+(** Applies a filter on the future goals *)
+
+val dispatch_future_goals : future_goals -> Evar.t list * Evar.t list * Evar.t list * Evar.t option
+(** Returns the future_goals dispatched into regular, shelved, given_up
+   goals; last argument is the goal tagged as principal if any *)
+
+val extract_given_up_future_goals : future_goals -> Evar.t list * Evar.t list
+(** An ad hoc variant for Proof.proof; not for general use *)
+
+val shelve_on_future_goals : Evar.t list -> future_goals -> future_goals
+(** Push goals on the shelve of future goals *)
 
 (** {5 Sort variables}
 

--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -1010,6 +1010,15 @@ module Unsafe = struct
 
   let tclSETGOALS = Comb.set
 
+  let tclGETSHELF = Shelf.get
+
+  let tclSETSHELF = Shelf.set
+
+  let tclPUTSHELF to_shelve =
+    tclBIND tclGETSHELF (fun shelf -> tclSETSHELF (to_shelve@shelf))
+
+  let tclPUTGIVENUP = Giveup.put
+
   let tclEVARSADVANCE evd =
     Pv.modify (fun ps -> { ps with solution = evd; comb = undefined evd ps.comb })
 

--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -768,6 +768,8 @@ let with_shelf tac =
   tac >>= fun ans ->
   Pv.get >>= fun npv ->
   let { shelf = gls; solution = sigma } = npv in
+  (* The pending future goals are necessarily coming from V82.tactic *)
+  (* and thus considered as to shelve, as in Proof.run_tactic *)
   let gls' = Evd.future_goals sigma in
   let fgoals = Evd.save_future_goals solution in
   let sigma = Evd.restore_future_goals sigma fgoals in

--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -771,7 +771,7 @@ let with_shelf tac =
   let gls' = Evd.future_goals sigma in
   let fgoals = Evd.future_goals solution in
   let pgoal = Evd.principal_future_goal solution in
-  let sigma = Evd.restore_future_goals sigma fgoals pgoal in
+  let sigma = Evd.restore_future_goals sigma (fgoals,pgoal) in
   (* Ensure we mark and return only unsolved goals *)
   let gls' = undefined_evars sigma (CList.rev_append gls' gls) in
   let sigma = CList.fold_left (mark_in_evm ~goal:false) sigma gls' in

--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -769,9 +769,8 @@ let with_shelf tac =
   Pv.get >>= fun npv ->
   let { shelf = gls; solution = sigma } = npv in
   let gls' = Evd.future_goals sigma in
-  let fgoals = Evd.future_goals solution in
-  let pgoal = Evd.principal_future_goal solution in
-  let sigma = Evd.restore_future_goals sigma (fgoals,pgoal) in
+  let fgoals = Evd.save_future_goals solution in
+  let sigma = Evd.restore_future_goals sigma fgoals in
   (* Ensure we mark and return only unsolved goals *)
   let gls' = undefined_evars sigma (CList.rev_append gls' gls) in
   let sigma = CList.fold_left (mark_in_evm ~goal:false) sigma gls' in

--- a/engine/proofview.mli
+++ b/engine/proofview.mli
@@ -435,6 +435,18 @@ module Unsafe : sig
   (** [tclGETGOALS] returns the list of goals under focus. *)
   val tclGETGOALS : Proofview_monad.goal_with_state list tactic
 
+  (** [tclSETSHELF gls] sets goals [gls] as the current shelf. *)
+  val tclSETSHELF : Evar.t list -> unit tactic
+
+  (** [tclGETSHELF] returns the list of goals on the shelf. *)
+  val tclGETSHELF : Evar.t list tactic
+
+  (** [tclPUTSHELF] appends goals to the shelf. *)
+  val tclPUTSHELF : Evar.t list -> unit tactic
+
+  (** [tclPUTGIVENUP] add an given up goal. *)
+  val tclPUTGIVENUP : Evar.t list -> unit tactic
+
   (** Sets the evar universe context. *)
   val tclEVARUNIVCONTEXT : UState.t -> unit tactic
 

--- a/proofs/goal.ml
+++ b/proofs/goal.ml
@@ -74,7 +74,7 @@ module V82 = struct
     in
     let evi = Typeclasses.mark_unresolvable evi in
     let (evars, evk) = Evarutil.new_pure_evar_full evars evi in
-    let evars = Evd.restore_future_goals evars prev_future_goals prev_principal_goal in
+    let evars = Evd.restore_future_goals evars (prev_future_goals,prev_principal_goal) in
     let ctxt = Environ.named_context_of_val hyps in
     let inst = Array.map_of_list (NamedDecl.get_id %> EConstr.mkVar) ctxt in
     let ev = EConstr.mkEvar (evk,inst) in

--- a/proofs/goal.ml
+++ b/proofs/goal.ml
@@ -62,8 +62,7 @@ module V82 = struct
        goals are restored to their initial value after the evar is
        created. *)
     let concl = EConstr.Unsafe.to_constr concl in
-    let prev_future_goals = Evd.future_goals evars in
-    let prev_principal_goal = Evd.principal_future_goal evars in
+    let prev_future_goals = Evd.save_future_goals evars in
     let evi = { Evd.evar_hyps = hyps;
 		Evd.evar_concl = concl;
 		Evd.evar_filter = Evd.Filter.identity;
@@ -74,7 +73,7 @@ module V82 = struct
     in
     let evi = Typeclasses.mark_unresolvable evi in
     let (evars, evk) = Evarutil.new_pure_evar_full evars evi in
-    let evars = Evd.restore_future_goals evars (prev_future_goals,prev_principal_goal) in
+    let evars = Evd.restore_future_goals evars prev_future_goals in
     let ctxt = Environ.named_context_of_val hyps in
     let inst = Array.map_of_list (NamedDecl.get_id %> EConstr.mkVar) ctxt in
     let ev = EConstr.mkEvar (evk,inst) in

--- a/proofs/proof_global.ml
+++ b/proofs/proof_global.ml
@@ -169,6 +169,7 @@ let with_current_proof f =
       let p = { p with proof = newpr } in
       pstates := p :: rest;
       ret
+
 let simple_with_current_proof f = with_current_proof (fun t p -> f t p , ())
 
 let compact_the_proof () = simple_with_current_proof (fun _ -> Proof.compact)

--- a/proofs/refine.ml
+++ b/proofs/refine.ml
@@ -78,8 +78,7 @@ let generic_refine ~typecheck f gl =
   let state = Proofview.Goal.state gl in
   (** Save the [future_goals] state to restore them after the
       refinement. *)
-  let prev_future_goals = Evd.future_goals sigma in
-  let prev_principal_goal = Evd.principal_future_goal sigma in
+  let prev_future_goals = Evd.save_future_goals sigma in
   (** Create the refinement term *)
   Proofview.Unsafe.tclEVARS (Evd.reset_future_goals sigma) >>= fun () ->
   f >>= fun (v, c) ->
@@ -119,7 +118,7 @@ let generic_refine ~typecheck f gl =
         | Some id -> Evd.rename evk id sigma
   in
   (** Restore the [future goals] state. *)
-  let sigma = Evd.restore_future_goals sigma (prev_future_goals,prev_principal_goal) in
+  let sigma = Evd.restore_future_goals sigma prev_future_goals in
   (** Select the goals *)
   let comb = CList.map_filter (Proofview.Unsafe.advance sigma) (CList.rev evs) in
   let sigma = CList.fold_left Proofview.Unsafe.mark_as_goal sigma comb in

--- a/proofs/refine.ml
+++ b/proofs/refine.ml
@@ -119,7 +119,7 @@ let generic_refine ~typecheck f gl =
         | Some id -> Evd.rename evk id sigma
   in
   (** Restore the [future goals] state. *)
-  let sigma = Evd.restore_future_goals sigma prev_future_goals prev_principal_goal in
+  let sigma = Evd.restore_future_goals sigma (prev_future_goals,prev_principal_goal) in
   (** Select the goals *)
   let comb = CList.map_filter (Proofview.Unsafe.advance sigma) (CList.rev evs) in
   let sigma = CList.fold_left Proofview.Unsafe.mark_as_goal sigma comb in

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -966,8 +966,7 @@ module Search = struct
            top_sort evm' goals
          else List.map (fun (ev, _) -> ev) (Evar.Map.bindings goals)
        in
-       let fgoals = Evd.future_goals evm in
-       let pgoal = Evd.principal_future_goal evm in
+       let fgoals = Evd.save_future_goals evm in
        let _, pv = Proofview.init evm' [] in
        let pv = Proofview.unshelve goals pv in
        try
@@ -983,7 +982,8 @@ module Search = struct
                           (str "leaking evar " ++ int (Evar.repr ev) ++
                              spc () ++ pr_ev evm' ev);
                       acc && okev) evm' true);
-           let evm' = Evd.restore_future_goals evm' (shelved @ fgoals, pgoal) in
+           let fgoals = Evd.shelve_on_future_goals shelved fgoals in
+           let evm' = Evd.restore_future_goals evm' fgoals in
            let evm' = evars_reset_evd ~with_conv_pbs:true ~with_univs:false evm' evm in
            Some evm'
          else raise Not_found

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -983,7 +983,7 @@ module Search = struct
                           (str "leaking evar " ++ int (Evar.repr ev) ++
                              spc () ++ pr_ev evm' ev);
                       acc && okev) evm' true);
-           let evm' = Evd.restore_future_goals evm' (shelved @ fgoals) pgoal in
+           let evm' = Evd.restore_future_goals evm' (shelved @ fgoals, pgoal) in
            let evm' = evars_reset_evd ~with_conv_pbs:true ~with_univs:false evm' evm in
            Some evm'
          else raise Not_found

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -973,6 +973,8 @@ module Search = struct
          let (), pv', (unsafe, shelved, gaveup), _ =
            Proofview.apply env tac pv
          in
+         if not (List.is_empty gaveup) then
+           CErrors.anomaly (Pp.str "run_on_evars not assumed to apply tactics generating given up goals.");
          if Proofview.finished pv' then
            let evm' = Proofview.return pv' in
            assert(Evd.fold_undefined (fun ev _ acc ->

--- a/test-suite/bugs/closed/6313.v
+++ b/test-suite/bugs/closed/6313.v
@@ -1,5 +1,7 @@
 (* Former open goals in nested proofs were lost *)
 
+(* This used to fail with "Incorrect number of goals (expected 1 tactic)." *)
+
 Inductive foo := a | b | c.
 Goal foo -> foo.
   intro x.
@@ -10,7 +12,7 @@ Goal foo -> foo.
                  end); [exact a|exact c].
 Abort.
 
-(* Another example *)
+(* This used to leave the goal on the shelf and fails at reflexivity *)
 
 Goal (True/\0=0 -> True) -> True.
   intro f.
@@ -18,3 +20,45 @@ Goal (True/\0=0 -> True) -> True.
    (f ltac:(split; only 1:exact I)).
   reflexivity.
 Qed.
+
+(* The "Unshelve" used to not see the explicitly "shelved" goal *)
+
+Lemma f (b:comparison) : b=b.
+refine (match b with
+   Eq => ltac:(shelve)
+ | Lt => ltac:(give_up)
+ | Gt => _
+ end).
+exact (eq_refl Gt).
+Unshelve.
+exact (eq_refl Eq).
+Fail auto. (* Check that there are no more regular subgoals *)
+Admitted.
+
+(* The "Unshelve" used to not see the explicitly "shelved" goal *)
+
+Lemma f2 (b:comparison) : b=b.
+refine (match b with
+   Eq => ltac:(shelve)
+ | Lt => ltac:(give_up)
+ | Gt => _
+ end).
+Unshelve. (* Note: Unshelve puts goals at the end *)
+exact (eq_refl Gt).
+exact (eq_refl Eq).
+Fail auto. (* Check that there are no more regular subgoals *)
+Admitted.
+
+(* The "unshelve" used to not see the explicitly "shelved" goal *)
+
+Lemma f3 (b:comparison) : b=b.
+unshelve refine (match b with
+   Eq => ltac:(shelve)
+ | Lt => ltac:(give_up)
+ | Gt => _
+ end).
+(* Note: unshelve puts goals at the beginning *)
+exact (eq_refl Eq).
+exact (eq_refl Gt).
+Fail auto. (* Check that there are no more regular subgoals *)
+Admitted.

--- a/test-suite/bugs/closed/6313.v
+++ b/test-suite/bugs/closed/6313.v
@@ -1,0 +1,20 @@
+(* Former open goals in nested proofs were lost *)
+
+Inductive foo := a | b | c.
+Goal foo -> foo.
+  intro x.
+  simple refine (match x with
+                 | a => _
+                 | b => ltac:(exact b)
+                 | c => _
+                 end); [exact a|exact c].
+Abort.
+
+(* Another example *)
+
+Goal (True/\0=0 -> True) -> True.
+  intro f.
+  refine
+   (f ltac:(split; only 1:exact I)).
+  reflexivity.
+Qed.


### PR DESCRIPTION
This fixes what is actually a critical bug in nesting calls to the proof engine as `ltac:(...)`-in-terms does.

The fix is simply to save the list of pending goals (the "future" goals) and to restore them (as was done already for "side effects"), in `refine_by_tactic`.

Some issue remains with `ltac:(tac)`: what is it supposed to do with the shelf. If the shelf produced by `tac` is non empty, should the call fail or return the shelf? The current situation is not good as the shelf is simply lost, i.e. tacitly moved in the ether.

This should probably be versed to 8.7.1, but I modified the API, so a version of the PR which does not change the API should be done. But, first, let's answer the shelve in `ltac:()` question.

(Edited for clarification.)