### PR TITLE
Statically generate a universe for omega type1.

### DIFF
--- a/plugins/romega/const_omega.ml
+++ b/plugins/romega/const_omega.ml
@@ -170,8 +170,8 @@ let mk_list univ typ l =
   loop l
 
 let mk_plist =
-  let type1lev = Universes.new_univ_level () in
-  fun l -> mk_list type1lev EConstr.mkProp l
+  let type1lev = Univ.Level.make (DirPath.make (List.map Id.of_string ["Coq";"romega";"Internal"])) 0 in
+    fun l -> mk_list type1lev EConstr.mkProp l
 
 let mk_list = mk_list Univ.Level.set
 


### PR DESCRIPTION
This is useful with [-natdynlink no] as otherwise every universe level
is bumped by one, leading to diffs in the output tests.