### PR TITLE
[v8.7 only] Fix synch of LtacProf with document

### DIFF
--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -1106,7 +1106,7 @@ end = struct (* {{{ *)
           VtStm (VtBack oid, true), VtLater
       | VernacBacktrack (id,_,_)
       | VernacBackTo id ->
-          VtStm (VtBack (Stateid.of_int id), not !Flags.batch_mode), VtNow
+          VtStm (VtBack (Stateid.of_int id), !Flags.batch_mode), VtNow
       | _ -> VtUnknown, VtNow
     with
     | Not_found ->


### PR DESCRIPTION
This is a #6240 solution, for 8.7 only.  In
6b041a242607ec906fbab451e53c15af6339e4ef, the sense of whether or not to
invalidate states (or something related to that) was flipped; it was
wrong to replace `not !Flags.print_emacs` with `not !Flags.batch_mode`,
which should have been `!Flags.batch_mode`, since `-emacs` goes with
"not batch-mode".  Apparently this logic has been removed in master, so
I shall leave it to @ejgallego to fix the issue for 8.8.