### PR TITLE
[econstr] Removal of unsafe 3: occur_evar_upto

### DIFF
--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -696,11 +696,9 @@ let undefined_evars_of_evar_info evd evi =
    [evar_map]. If unification only need to check superficially, tactics
    do not have this luxury, and need the more complete version. *)
 let occur_evar_upto sigma n c =
-  let c = EConstr.Unsafe.to_constr c in
-  let rec occur_rec c = match kind c with
+  let rec occur_rec c = match EConstr.kind sigma c with
     | Evar (sp,_) when Evar.equal sp n -> raise Occur
-    | Evar e -> Option.iter occur_rec (existential_opt_value sigma e)
-    | _ -> Constr.iter occur_rec c
+    | _ -> EConstr.iter sigma occur_rec c
   in
   try occur_rec c; false with Occur -> true
 


### PR DESCRIPTION
This is a minor cleanup in `evarutil`.