### PR TITLE
[makefile] Address #6291: install more development files.

### DIFF
--- a/Makefile.install
+++ b/Makefile.install
@@ -101,12 +101,16 @@ INSTALLCMI = $(sort \
 	$(foreach lib,$(CORECMA), $(addsuffix .cmi,$($(lib:.cma=_MLLIB_DEPENDENCIES))))) \
 	$(PLUGINS:.cmo=.cmi)
 
+INSTALLCMX = $(sort $(filter-out checker/% ide/% tools/% dev/% configure.cmx, $(MLFILES:.ml=.cmx)))
+
 install-devfiles:
 	$(MKDIR) $(FULLBINDIR)
 	$(INSTALLBIN) $(COQMKTOP) $(FULLBINDIR)
 	$(MKDIR) $(FULLCOQLIB)
 	$(INSTALLSH)  $(FULLCOQLIB) $(GRAMMARCMA)
 	$(INSTALLSH)  $(FULLCOQLIB) $(INSTALLCMI)
+	$(INSTALLSH)  $(FULLCOQLIB) $(INSTALLCMX)
+	$(INSTALLSH)  $(FULLCOQLIB) $(PLUGINSCMO:.cmo=.o)
 	$(INSTALLSH)  $(FULLCOQLIB) $(TOOLS_HELPERS)
 ifeq ($(BEST),opt)
 	$(INSTALLSH)  $(FULLCOQLIB) $(LINKCMX) $(CORECMA:.cma=.a) $(STATICPLUGINS:.cma=.a)


### PR DESCRIPTION
As noted in the bug #6291, `.cmx` files are not installed in the
coqlib, which yields the warning:

```
Warning 58: no cmx file was found in path for module Sorts, and its
interface was not compiled with -opaque
```

We thus install the `cmx` files to fix this problem, and also install
the `.o` files for plugins' `.o` to support linking the plugins
statically.

This closes #5099 and #6291.