### PR TITLE
V8.5: support for ocaml 4.06.0

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -35,6 +35,8 @@ WHAT DO YOU NEED ?
    - Camlp5 (version >= 6.02) (Coq compiles with Camlp4 but might be less
      well supported)
 
+   - From Objective Caml version 4.06.0, the Num library
+
    - GNU Make version 3.81 or later
 
    - a C compiler

--- a/configure
+++ b/configure
@@ -26,7 +26,7 @@ done
 
 ## We check that $cmd is ok before the real exec $cmd
 
-`$cmd -version > /dev/null 2>&1` && exec $cmd $script "$@"
+`$cmd -version > /dev/null 2>&1` && exec $cmd -w "-3" $script "$@"
 
 ## If we're still here, something is wrong with $cmd
 

--- a/configure.ml
+++ b/configure.ml
@@ -392,7 +392,7 @@ let coq_debug_flag = if !Prefs.debug then "-g" else ""
 let coq_profile_flag = if !Prefs.profile then "-p" else ""
 let coq_annotate_flag =
   if !Prefs.annotate
-  then if program_in_path "ocamlmerlin" then "-bin-annot" else "-dtypes"
+  then if program_in_path "ocamlmerlin" then " -bin-annot" else " -dtypes"
   else ""
 
 let cflags = "-Wall -Wno-unused -g -O2"
@@ -526,7 +526,10 @@ let camltag = match caml_version_list with
   | _ -> assert false
 
 let coq_warn_flag =
-  if caml_version_nums > [4;2;3] then "-w -3-52-56" else ""
+  if caml_version_nums > [4;2;3] then " -w -3-52-56" else ""
+
+let coq_safe_string =
+  if caml_version_nums >= [4;6;0] then " -unsafe-string" else ""
 
 (** * CamlpX configuration *)
 
@@ -823,7 +826,6 @@ let coqide_flags () =
     | _ -> ()
 
 let _ = coqide_flags ()
-
 
 (** * strip command *)
 
@@ -1158,7 +1160,7 @@ let write_makefile f =
   pr "CAMLLINK=%S\n" camlexec.byte;
   pr "CAMLOPTLINK=%S\n\n" camlexec.opt;
   pr "# Caml flags\n";
-  pr "CAMLFLAGS=-rectypes %s %s\n" coq_annotate_flag coq_warn_flag;
+  pr "CAMLFLAGS=-rectypes%s%s%s\n" coq_annotate_flag coq_warn_flag coq_safe_string;
   pr "# User compilation flag\n";
   pr "USERFLAGS=\n\n";
   pr "# Flags for GCC\n";

--- a/configure.ml
+++ b/configure.ml
@@ -525,6 +525,8 @@ let camltag = match caml_version_list with
   | x::y::_ -> "OCAML"^x^y
   | _ -> assert false
 
+let coq_warn_flag =
+  if caml_version_nums > [4;2;3] then "-w -3-52-56" else ""
 
 (** * CamlpX configuration *)
 
@@ -1140,7 +1142,7 @@ let write_makefile f =
   pr "CAMLLINK=%S\n" camlexec.byte;
   pr "CAMLOPTLINK=%S\n\n" camlexec.opt;
   pr "# Caml flags\n";
-  pr "CAMLFLAGS=-rectypes %s\n" coq_annotate_flag;
+  pr "CAMLFLAGS=-rectypes %s %s\n" coq_annotate_flag coq_warn_flag;
   pr "# User compilation flag\n";
   pr "USERFLAGS=\n\n";
   pr "# Flags for GCC\n";

--- a/configure.ml
+++ b/configure.ml
@@ -702,6 +702,22 @@ let operating_system, osdeplibs =
   else
     (try Sys.getenv "OS" with Not_found -> ""), osdeplibs
 
+(** Num library *)
+
+(* since 4.06, the Num library is no longer distributed with OCaml (replaced
+   by Zarith)
+*)
+
+let check_for_numlib () =
+  if caml_version_nums >= [4;6;0] then
+    let numlib,_ = tryrun "ocamlfind" ["query";"num"] in
+    match numlib with
+    | ""  ->
+       die "Num library not installed, required for OCaml 4.06 or later"
+    | _   -> printf "You have the Num library installed. Good!\n"
+
+let numlib =
+  check_for_numlib ()
 
 (** * lablgtk2 and CoqIDE *)
 


### PR DESCRIPTION
This cherry-picks a couple of patches to `configure` and `configure.ml` to support more recent versions of OCaml in 8.5.

This is in no way pretending an "official" support for 8.5. This is just making life a priori easier for people needing to compile 8.5 without having to worry about the OCaml version.