### PR TITLE
V8.4: support for ocaml 4.06.0

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -46,6 +46,8 @@ WHAT DO YOU NEED ?
 
      - Camlp5 (version <= 4.08, or 5.* transitional)
 
+     - The num library if with Objective Caml version 4.06.0 or later
+
      - GNU Make version 3.81 or later
        (
 	available at http://www.gnu.org/software/make/, but also a

--- a/configure
+++ b/configure
@@ -110,6 +110,7 @@ coq_debug_flag=
 coq_debug_flag_opt=
 coq_profile_flag=
 coq_annotate_flag=
+coq_safe_string_flag=
 best_compiler=opt
 cflags="-Wall -Wno-unused"
 natdynlink=yes
@@ -453,8 +454,17 @@ case $CAMLVERSION in
 	    echo "          Configuration script failed!"
 	    exit 1
 	fi;;
-    3.11.2|3.12*|4.*)
+    4.02.0)
 	CAMLP4COMPAT="-loc loc" 
+        echo "Warning: OCaml 4.02.0 suffers from a bug inducing"
+        echo "very slow compilation times"
+        break;;
+    3.11.2|3.12*|4.0[012345]*)
+	CAMLP4COMPAT="-loc loc" 
+	echo "You have Objective-Caml $CAMLVERSION. Good!";;
+    4.*)
+	CAMLP4COMPAT="-loc loc" 
+        coq_safe_string_flag=-unsafe-string
 	echo "You have Objective-Caml $CAMLVERSION. Good!";;
     *)
 	echo "I found the Objective-Caml compiler but cannot find its version number!"
@@ -1223,7 +1233,7 @@ CAMLOPTLINK="$nativecamlc"
 CAMLMKTOP="$ocamlmktopexec"
 
 # Caml flags
-CAMLFLAGS=-rectypes $coq_annotate_flag
+CAMLFLAGS=-rectypes $coq_annotate_flag $coq_safe_string_flag
 
 # Compilation debug flags
 CAMLDEBUG=$coq_debug_flag


### PR DESCRIPTION
I shall not go up to Coq 1.0... but I think that there is nothing to lose at enabling support for OCaml 4.06.0 for those who might have to use this version, for a reason or another.