### PR TITLE
Remove most uses of function extensionality in Program.Combinators

### DIFF
--- a/theories/Logic/FunctionalExtensionality.v
+++ b/theories/Logic/FunctionalExtensionality.v
@@ -221,13 +221,12 @@ Tactic Notation "extensionality" "in" hyp(H) :=
   (* If we [subst H], things break if we already have another equation of the form [_ = H] *)
   destruct Heq; rename H_out into H.
 
-(** Eta expansion follows from extensionality. *)
+(** Eta expansion is built into Coq. *)
 
 Lemma eta_expansion_dep {A} {B : A -> Type} (f : forall x : A, B x) :
   f = fun x => f x.
 Proof.
   intros.
-  extensionality x.
   reflexivity.
 Qed.
 

--- a/theories/Program/Combinators.v
+++ b/theories/Program/Combinators.v
@@ -22,15 +22,13 @@ Open Scope program_scope.
 Lemma compose_id_left : forall A B (f : A -> B), id ∘ f = f.
 Proof.
   intros.
-  unfold id, compose.
-  symmetry. apply eta_expansion.
+  reflexivity.
 Qed.
 
 Lemma compose_id_right : forall A B (f : A -> B), f ∘ id = f.
 Proof.
   intros.
-  unfold id, compose.
-  symmetry ; apply eta_expansion.
+  reflexivity.
 Qed.
 
 Lemma compose_assoc : forall A B C D (f : A -> B) (g : B -> C) (h : C -> D),
@@ -47,9 +45,7 @@ Hint Rewrite <- @compose_assoc : core.
 
 Lemma flip_flip : forall A B C, @flip A B C ∘ flip = id.
 Proof.
-  unfold flip, compose.
   intros.
-  extensionality x ; extensionality y ; extensionality z.
   reflexivity.
 Qed.
 
@@ -57,9 +53,7 @@ Qed.
 
 Lemma prod_uncurry_curry : forall A B C, @prod_uncurry A B C ∘ prod_curry = id.
 Proof.
-  simpl ; intros.
-  unfold prod_uncurry, prod_curry, compose.
-  extensionality x ; extensionality y ; extensionality z.
+  intros.
   reflexivity.
 Qed.
 


### PR DESCRIPTION
Since functions now have a definitional eta rule, all but one of the proofs in Program.Combinators
do not need to use the function extensionality axiom, and can be changed to reflexivity.

The one remaining proof, prod_curry_uncurry, could be replaced with reflexivity if
Primitive Projections are turned on for prod.

Since these proofs are opaque, I don't anticipate any compatibility issues.
