### PR TITLE
Fix profiling plugin

### DIFF
--- a/plugins/ltac/profile_ltac.ml
+++ b/plugins/ltac/profile_ltac.ml
@@ -408,7 +408,7 @@ let print_results_filter ~cutoff ~filter =
   let results =
     SM.fold (fun _ -> merge_roots ~disjoint:true) !data (empty_treenode root) in
   let results = merge_roots results Local.(CList.last !stack) in
-  Feedback.msg_notice (to_string ~cutoff ~filter results)
+  Feedback.msg_info (to_string ~cutoff ~filter results)
 ;;
 
 let print_results ~cutoff =

--- a/plugins/ltac/profile_ltac_tactics.ml4
+++ b/plugins/ltac/profile_ltac_tactics.ml4
@@ -13,7 +13,7 @@
 open Profile_ltac
 open Stdarg
 
-DECLARE PLUGIN "profile_ltac_plugin"
+DECLARE PLUGIN "ltac_plugin"
 
 let tclSET_PROFILING b =
    Proofview.tclLIFT (Proofview.NonLogical.make (fun () -> set_profiling b))
@@ -22,7 +22,7 @@ TACTIC EXTEND start_ltac_profiling
 | [ "start" "ltac" "profiling" ] -> [ tclSET_PROFILING true ]
 END
 
-TACTIC EXTEND stop_profiling
+TACTIC EXTEND stop_ltac_profiling
 | [ "stop" "ltac" "profiling" ] -> [ tclSET_PROFILING false ]
 END
 

--- a/test-suite/bugs/closed/6378.v
+++ b/test-suite/bugs/closed/6378.v
@@ -1,0 +1,4 @@
+Goal True.
+  start ltac profiling.
+  stop ltac profiling.
+Abort.


### PR DESCRIPTION
Allow LtacProf tactics to be called.

This fixes #6378.  Previously the ML module was never declared anywhere.

Thanks to @cmangin for the pointer.

Also, use `msg_info` for LtacProf, so that `Time Show Ltac Profile.` shows the profile in `*response*` buffer in PG without extra `infomsg` tags from mixed messages.