### PR TITLE
Add `all.tex` and `all-gal.tex` rules in CoqMakefile.in

### DIFF
--- a/test-suite/coq-makefile/latex2/_CoqProject
+++ b/test-suite/coq-makefile/latex2/_CoqProject
@@ -1,0 +1,11 @@
+-R src test
+-R theories test
+-I src
+
+src/test_plugin.mlpack
+src/test.ml4
+src/test.mli
+src/test_aux.ml
+src/test_aux.mli
+theories/test.v
+theories/sub/testsub.v

--- a/test-suite/coq-makefile/latex2/run.sh
+++ b/test-suite/coq-makefile/latex2/run.sh
@@ -3,7 +3,7 @@
 if which pdflatex; then
 
 . ../template/init.sh
-	
+
 coq_makefile -f _CoqProject -o Makefile
 cat Makefile.conf
 make

--- a/test-suite/coq-makefile/latex2/run.sh
+++ b/test-suite/coq-makefile/latex2/run.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+if which pdflatex; then
+
+. ../template/init.sh
+	
+coq_makefile -f _CoqProject -o Makefile
+cat Makefile.conf
+make
+exec make all.tex
+
+fi
+exit 0 # test skipped

--- a/test-suite/coq-makefile/latex3/_CoqProject
+++ b/test-suite/coq-makefile/latex3/_CoqProject
@@ -1,0 +1,11 @@
+-R src test
+-R theories test
+-I src
+
+src/test_plugin.mlpack
+src/test.ml4
+src/test.mli
+src/test_aux.ml
+src/test_aux.mli
+theories/test.v
+theories/sub/testsub.v

--- a/test-suite/coq-makefile/latex3/run.sh
+++ b/test-suite/coq-makefile/latex3/run.sh
@@ -3,7 +3,7 @@
 if which pdflatex; then
 
 . ../template/init.sh
-	
+
 coq_makefile -f _CoqProject -o Makefile
 cat Makefile.conf
 make

--- a/test-suite/coq-makefile/latex3/run.sh
+++ b/test-suite/coq-makefile/latex3/run.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+if which pdflatex; then
+
+. ../template/init.sh
+	
+coq_makefile -f _CoqProject -o Makefile
+cat Makefile.conf
+make
+exec make all-gal.tex
+
+fi
+exit 0 # test skipped

--- a/tools/CoqMakefile.in
+++ b/tools/CoqMakefile.in
@@ -455,6 +455,11 @@ all.pdf: $(VFILES)
 	$(HIDE)$(COQDOC) \
 		-toc $(COQDOCFLAGS) -pdf $(GAL) $(COQDOCLIBS) \
 		-o $@ `$(COQDEP) -sort -suffix .v $(VFILES)`
+all.tex: $(VFILES)
+	$(SHOW)'COQDOC -latex $(GAL)'
+	$(HIDE)$(COQDOC) \
+		-toc $(COQDOCFLAGS) -latex $(GAL) $(COQDOCLIBS) \
+		-o $@ `$(COQDEP) -sort -suffix .v $(VFILES)`
 
 # FIXME: not quite right, since the output name is different
 gallinahtml: GAL=-g
@@ -465,6 +470,9 @@ all-gal.ps: all.ps
 
 all-gal.pdf: GAL=-g
 all-gal.pdf: all.pdf
+
+all-gal.tex: GAL=-g
+all-gal.tex: all.tex
 
 # ?
 beautify: $(BEAUTYFILES)


### PR DESCRIPTION
Hi, 
I wanted to switch to landscape oriented pages when generating some documentation, and I was surprise not to find how to generate `all.tex` instead of `all.pdf` from the makefile generated by `coq_makefile`; this commit allow the following:
```
$ coq_makefile -o makefile *.v
$ make all-gal.tex
$ ls *.tex
all.tex
```

P.S.: Interestingly, for .mli files, it is the converse, there is only the rule `all-mli.tex`
P.S.2: I don't know whether I'm the only one interested in such things, don't hesitate to close if you find it useless.
P.S.3: There is a rule to generate a `.tex` from a `.v`, but only one at a time