### PR TITLE
Fix #6404 - Print tactics called by ML tactics

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -15,6 +15,9 @@ Tactic language
 
 - Support for fix/cofix added in Ltac "match" and "lazymatch".
 
+- Ltac backtraces now contain include trace information about tactics
+  called by OCaml-defined tactics.
+
 Changes from 8.7.2 to 8.8+beta1
 ===============================
 

--- a/plugins/ltac/tactic_debug.ml
+++ b/plugins/ltac/tactic_debug.ml
@@ -391,13 +391,10 @@ let explain_ltac_call_trace last trace loc =
 
 let skip_extensions trace =
   let rec aux = function
-  | (_,Tacexpr.LtacNameCall f as tac) :: _
-       when Tacenv.is_ltac_for_ml_tactic f -> [tac]
-  | (_,Tacexpr.LtacNotationCall _ as tac) :: (_,Tacexpr.LtacMLCall _) :: _ ->
+  | (_,Tacexpr.LtacNotationCall _ as tac) :: (_,Tacexpr.LtacMLCall _) :: tail ->
      (* Case of an ML defined tactic with entry of the form <<"foo" args>> *)
      (* see tacextend.mlp *)
-     [tac]
-  | (_,Tacexpr.LtacMLCall _ as tac) :: _ -> [tac]
+     tac :: aux tail
   | t :: tail -> t :: aux tail
   | [] -> [] in
   List.rev (aux (List.rev trace))

--- a/test-suite/output/bug6404.out
+++ b/test-suite/output/bug6404.out
@@ -1,4 +1,4 @@
 The command has indeed failed with message:
-In nested Ltac calls to "c", "abs", "abstract b ltac:(())", 
+In nested Ltac calls to "c", "abs", "transparent_abstract (tactic3)", 
 "b", "a", "pose (I : I)" and "(I : I)", last term evaluation failed.
 The term "I" has type "True" which should be Set, Prop or Type.

--- a/test-suite/output/bug6404.v
+++ b/test-suite/output/bug6404.v
@@ -1,0 +1,7 @@
+Ltac a _ := pose (I : I).
+Ltac b _ := a ().
+Ltac abs _ := transparent_abstract b ().
+Ltac c _ := abs ().
+Goal True.
+  Fail c ().
+Abort.


### PR DESCRIPTION
This fixes #6404.

Note that this changes the test-case of #6406, so whichever one is merged first, the other will have to be updated accordingly.

I'm tag this as `needs: discussion` because it seems like the behavior I'm changing was intentional, and it can lead to more verbose error messages in some cases (such as `intuition` and `tauto`, but not, e.g., `congruence`), though perhaps not much discussion is needed.
```coq
Goal False.
  tauto.
(* current master: Error:
In nested Ltac calls to "tauto" and "<Coq.Init.Tauto.with_uniform_flags>",
last call failed.
Tactic failure: tauto failed. *)
(* with this PR: Error:
In nested Ltac calls to "tauto", "<Coq.Init.Tauto.with_uniform_flags>",
"<tauto_plugin::with_uniform_flags@0>",
"<tauto_plugin::with_uniform_flags@0>", "f" (bound to
fun flags => <Coq.Init.Tauto.tauto_gen> flags),
"<Coq.Init.Tauto.tauto_gen>" and "<Coq.Init.Tauto.tauto_classical>", last
call failed.
Tactic failure: tauto failed. *)
```
and
```coq
Goal False.
  intuition fail.
(* current master: Error:
In nested Ltac calls to "intuition (tactic)",
"<Coq.Init.Tauto.intuition_then>" and "<Coq.Init.Tauto.with_uniform_flags>",
last call failed.
Tactic failure. *)
(* with this PR: Error:
In nested Ltac calls to "intuition (tactic)",
"<Coq.Init.Tauto.intuition_then>", "<Coq.Init.Tauto.with_uniform_flags>",
"<tauto_plugin::with_uniform_flags@0>",
"<tauto_plugin::with_uniform_flags@0>", "f" (bound to
fun flags => <Coq.Init.Tauto.intuition_gen> flags tac),
"<Coq.Init.Tauto.intuition_gen>", "<Coq.Init.Tauto.tauto_intuit>",
"t_tauto_intuit" (bound to
<Coq.Init.Tauto.simplif> flags;
 <Coq.Init.Tauto.axioms> flags ||
   match reverse goal with
   | id:(?X1 -> ?X2) -> ?X3
     |- _ =>
         cut X3;
          [ intro; clear id; t_tauto_intuit
          | cut (X1 -> X2);
             [ exact
             id
             | generalize (fun y : X2 => id (fun x : X1 => y)); intro; clear
                id; (solve [ t_tauto_intuit ]) ] ]
   | id:~ ?X1 -> ?X3
     |- _ =>
         cut X3;
          [ intro; clear id; t_tauto_intuit
          | cut (~ X1);
             [ exact id | clear id; intro; (solve [ t_tauto_intuit ]) ] ]
   | |- ?X1 =>
         <Coq.Init.Tauto.is_disj> flags X1; (solve
          [ left; t_tauto_intuit | right; t_tauto_intuit ])
   end ||
     match goal with
     | |- _ -> _ => intro; t_tauto_intuit
     | |- _ => t_reduce; t_solver
     end || t_solver) and "t_solver" (bound to fail), last call failed.
Tactic failure. *)
```

Also, perhaps I am messing something up, because the initial commit 21bbdd6b3cea2a2d9763bfc786b56a4b9e95ad06 by @herbelin seems to be about locations, not strictly about traces (and the issue I am solving here is only about improving backtraces, not error locations (unless I am mixing up terminology)).