### PR TITLE
More detailed error messages for Canonical Structure, #6398

### DIFF
--- a/test-suite/output/ErrorInCanonicalStructures.out
+++ b/test-suite/output/ErrorInCanonicalStructures.out
@@ -1,0 +1,5 @@
+File "stdin", line 3, characters 0-24:
+Error:
+Could not declare a canonical structure Foo.
+Expected an instance of a record or structure.
+

--- a/test-suite/output/ErrorInCanonicalStructures.v
+++ b/test-suite/output/ErrorInCanonicalStructures.v
@@ -1,0 +1,3 @@
+Record Foo := MkFoo { field1 : nat; field2 : nat -> nat }.
+
+Canonical Structure Foo.

--- a/test-suite/output/ErrorInCanonicalStructures2.out
+++ b/test-suite/output/ErrorInCanonicalStructures2.out
@@ -1,0 +1,5 @@
+File "stdin", line 3, characters 0-24:
+Error:
+Could not declare a canonical structure bar.
+Expected an instance of a record or structure.
+

--- a/test-suite/output/ErrorInCanonicalStructures2.v
+++ b/test-suite/output/ErrorInCanonicalStructures2.v
@@ -1,0 +1,3 @@
+Definition bar := 99.
+
+Canonical Structure bar.


### PR DESCRIPTION
This PR provides more detailed error message when `Canonical Structure` fails. Fixes #6398.

A couple of the added tests currently fail in the test suite, because there's a message:
```
You have probably created a Future.computation from a value without 
  passing the ~fix_exn argument.  
You probably want to chain with an already existing future instead.
```
These messages are the subject of #6420. So that should be fixed before this can be merged.