### PR TITLE
[rfc] [ocaml] Enable warning "27" unused variable.

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -1,4 +1,4 @@
-FLG -rectypes -thread -safe-string -w +a-4-9-27-41-42-44-45-48-50
+FLG -rectypes -thread -safe-string -w +a-4-9-41-42-44-45-48-50
 
 S clib
 B clib

--- a/checker/print.ml
+++ b/checker/print.ml
@@ -41,10 +41,22 @@ let print_pure_constr fmt csr =
   | Ind ((sp,i),u) ->
     fprintf fmt "Ind(@[%a,%d,%a@])" sp_display sp i pp_instance u
   | Construct (((sp,i),j),u) ->
-    fprintf fmt "Constr(%a,%d,%d,%a)" sp_display sp i j pp_instance u
-  | Case (ci,p,c,bl) ->
-    let pp_match fmt (_,mc) = fprintf fmt " @[%a@]" pp_term mc in
-    fprintf fmt "@[<v><@[%a@]>@,Case@ @[%a@]@ of@[<v>%a@]@,end@]" pp_term p pp_term c (pp_arrayi pp_match) bl
+      print_string "Constr(";
+      sp_display sp;
+      print_string ",";
+      print_int i; print_string ","; print_int j; 
+      print_string ","; print_instance u; print_string ")"
+  | Case (_ci,p,c,bl) ->
+      open_vbox 0;
+      print_string "<"; box_display p; print_string ">";
+      print_cut(); print_string "Case";
+      print_space(); box_display c; print_space (); print_string "of";
+      open_vbox 0;
+      Array.iter (fun x ->  print_cut();  box_display x) bl;
+      close_box();
+      print_cut();
+      print_string "end";
+      close_box()
   | Fix ((t,i),(lna,tl,bl)) ->
     let pp_fixc fmt (k,_) =
       fprintf fmt "@[<v 0> %a/%d@,:@[%a@]@,:=@[%a@]@]@," pp_name lna.(k) t.(k) pp_term tl.(k) pp_term bl.(k) in

--- a/clib/cList.ml
+++ b/clib/cList.ml
@@ -357,7 +357,7 @@ let make n v = addn n v []
 
 let assign l n e =
   let rec assrec stk l i = match l, i with
-    | ((h::t), 0) -> List.rev_append stk (e :: t)
+    | ((_h::t), 0) -> List.rev_append stk (e :: t)
     | ((h::t), n) -> assrec (h :: stk) t (pred n)
     | ([], _) -> failwith "List.assign"
   in
@@ -604,7 +604,7 @@ let distinct l =
 let distinct_f cmp l =
   let rec loop = function
     | a::b::_ when Int.equal (cmp a b) 0 -> false
-    | a::l -> loop l
+    | _a::l -> loop l
     | [] -> true
   in loop (List.sort cmp l)
 
@@ -884,7 +884,7 @@ let cartesians_filter op init ll =
 
 let rec drop_last = function
   | [] -> assert false
-  | hd :: [] -> []
+  | _hd :: [] -> []
   | hd :: tl -> hd :: drop_last tl
 
 (* Factorize lists of pairs according to the left argument *)

--- a/clib/cMap.ml
+++ b/clib/cMap.ml
@@ -144,13 +144,13 @@ struct
 
   let rec fold_left f (s : 'a map) accu = match map_prj s with
   | MEmpty -> accu
-  | MNode (l, k, v, r, h) ->
+  | MNode (l, k, v, r, _h) ->
     let accu = f k v (fold_left f l accu) in
     fold_left f r accu
 
   let rec fold_right f (s : 'a map) accu = match map_prj s with
   | MEmpty -> accu
-  | MNode (l, k, v, r, h) ->
+  | MNode (l, k, v, r, _h) ->
     let accu = f k v (fold_right f r accu) in
     fold_right f l accu
 
@@ -194,14 +194,14 @@ struct
 
     let rec fold_left f s accu = match map_prj s with
     | MEmpty -> return accu
-    | MNode (l, k, v, r, h) ->
+    | MNode (l, k, v, r, _h) ->
       fold_left f l accu >>= fun accu ->
       f k v accu >>= fun accu ->
       fold_left f r accu
 
     let rec fold_right f s accu = match map_prj s with
     | MEmpty -> return accu
-    | MNode (l, k, v, r, h) ->
+    | MNode (l, k, v, r, _h) ->
       fold_right f r accu >>= fun accu ->
       f k v accu >>= fun accu ->
       fold_right f l accu

--- a/clib/deque.ml
+++ b/clib/deque.ml
@@ -57,9 +57,9 @@ let ltl q = match q.face with
 | [] ->
   begin match q.rear with
   | [] -> raise Empty
-  | t :: _ -> empty
+  | _t :: _ -> empty
   end
-| t :: r -> balance { q with lenf = pred q.lenf; face = r }
+| _t :: r -> balance { q with lenf = pred q.lenf; face = r }
 
 let rcons x q =
   balance { q with lenr = succ q.lenr; rear = x :: q.rear }
@@ -68,7 +68,7 @@ let rhd q = match q.rear with
 | [] ->
   begin match q.face with
   | [] -> raise Empty
-  | t :: r -> t
+  | t :: _r -> t
   end
 | t :: _ -> t
 
@@ -76,9 +76,9 @@ let rtl q = match q.rear with
 | [] ->
   begin match q.face with
   | [] -> raise Empty
-  | t :: r -> empty
+  | _t :: _r -> empty
   end
-| t :: r ->
+| _t :: r ->
   balance { q with lenr = pred q.lenr; rear = r }
 
 let rev q = {

--- a/clib/hMap.ml
+++ b/clib/hMap.ml
@@ -213,7 +213,7 @@ struct
     let (_, m) = Int.Map.choose s in
     Set.choose m
 
-  let split s x = assert false (** Cannot be implemented efficiently *)
+  let split _s _x = assert false (** Cannot be implemented efficiently *)
 
 end
 
@@ -273,7 +273,7 @@ struct
     with Not_found -> s
 
   let merge f s1 s2 =
-    let fm h m1 m2 = match m1, m2 with
+    let fm _h m1 m2 = match m1, m2 with
     | None, None -> None
     | Some m, None ->
       let m = Map.merge f m Map.empty in
@@ -355,7 +355,7 @@ struct
 
   let get k s = try find k s with Not_found -> assert false
 
-  let split k s = assert false (** Cannot be implemented efficiently *)
+  let split _k _s = assert false (** Cannot be implemented efficiently *)
 
   let map f s =
     let fs m = Map.map f m in

--- a/clib/int.ml
+++ b/clib/int.ml
@@ -37,7 +37,7 @@ struct
 
   let rec find i s = match map_prj s with
   | MEmpty -> raise Not_found
-  | MNode (l, k, v, r, h) ->
+  | MNode (l, k, v, r, _h) ->
     if i < k then find i l
     else if i = k then v
     else find i r

--- a/clib/minisys.ml
+++ b/clib/minisys.ml
@@ -70,7 +70,7 @@ let apply_subdir f path name =
     | Unix.S_REG -> f (FileRegular name)
     | _ -> ()
 
-let readdir dir = try Sys.readdir dir with any -> [||]
+let readdir dir = try Sys.readdir dir with _any -> [||]
 
 let process_directory f path =
   Array.iter (apply_subdir f path) (readdir path)

--- a/clib/segmenttree.ml
+++ b/clib/segmenttree.ml
@@ -78,7 +78,7 @@ let make segments =
     (** We start from leaves: the last level of the tree is initialized
 	with the given segments... *)
     list_iteri 
-      (fun i ((start, stop), value) ->
+      (fun i ((start, stop), _value) ->
 	 let k = leaves_offset + i in
 	 let i = Interval (start, stop) in
 	   tree.(k) <- (i, Some i))
@@ -106,7 +106,7 @@ let make segments =
 
     (** Finally, annotation are replaced with the image related to each leaf. *)
     let final_tree = 
-      Array.mapi (fun i (segment, value) -> (segment, None)) tree
+      Array.mapi (fun _i (segment, _value) -> (segment, None)) tree
     in
       list_iteri 
 	(fun i ((start, stop), value) -> 

--- a/clib/trie.ml
+++ b/clib/trie.ml
@@ -41,7 +41,7 @@ type label = Y.t
 type t = Node of X.t * t T_codom.t
 
 let codom_for_all f m =
-  let fold key v accu = f v && accu in
+  let fold _key v accu = f v && accu in
   T_codom.fold fold m true
 
 let empty = Node (X.nil, T_codom.empty)

--- a/clib/unicode.ml
+++ b/clib/unicode.ml
@@ -267,7 +267,7 @@ let lowercase_unicode =
 
 let lowercase_first_char s =
   assert (s <> "");
-  let j, n = next_utf8 s 0 in
+  let _j, n = next_utf8 s 0 in
   utf8_of_unicode (lowercase_unicode n)
 
 let split_at_first_letter s =

--- a/clib/unionfind.ml
+++ b/clib/unionfind.ml
@@ -115,7 +115,7 @@ module Make (S:SetS)(M:MapS with type key = S.elt) = struct
     if x = y then ()
     else
       let xcan, ycan = if x < y then xcan, ycan else ycan, xcan in
-      let x,xnode = xcan and y,ynode = ycan in
+      let x,xnode = xcan and _y,ynode = ycan in
       match !xnode, !ynode with
 	| Canon lx, Canon ly ->
 	  xnode := Canon (S.union lx ly);
@@ -130,7 +130,7 @@ module Make (S:SetS)(M:MapS with type key = S.elt) = struct
 
   let partition p =
     List.rev (M.fold
-		(fun x node acc -> match !node with
+		(fun _x node acc -> match !node with
 		  | Equiv _ -> acc
 		  | Canon lx -> lx::acc)
 		!p [])

--- a/configure.ml
+++ b/configure.ml
@@ -642,7 +642,7 @@ let camltag = match caml_version_list with
     50: unexpected documentation comment: too common and annoying to avoid
     56: unreachable match case: the [_ -> .] syntax doesn't exist in 4.02.3
 *)
-let coq_warnings = "-w +a-4-9-27-41-42-44-45-48-50"
+let coq_warnings = "-w +a-4-9-41-42-44-45-48-50"
 let coq_warn_error =
     if !prefs.warn_error
     then "-warn-error +a"

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -162,7 +162,7 @@ let is_ground_env = memo is_ground_env
 
 exception NoHeadEvar
 
-let head_evar sigma c =
+let head_evar _sigma c =
   (** FIXME: this breaks if using evar-insensitive code *)
   let c = EConstr.Unsafe.to_constr c in
   let rec hrec c = match kind c with
@@ -170,7 +170,7 @@ let head_evar sigma c =
     | Case (_,_,c,_) -> hrec c
     | App (c,_)      -> hrec c
     | Cast (c,_,_)   -> hrec c
-    | Proj (p, c)    -> hrec c
+    | Proj (_p, c)    -> hrec c
     | _              -> raise NoHeadEvar
   in
   hrec c
@@ -489,12 +489,12 @@ let e_new_type_evar env evdref ?src ?filter ?naming ?principal rigid =
     evdref := evd;
     c
 
-let new_Type ?(rigid=Evd.univ_flexible) env evd = 
+let new_Type ?(rigid=Evd.univ_flexible) _env evd = 
   let open EConstr in
   let (evd, s) = new_sort_variable rigid evd in
   (evd, mkSort s)
 
-let e_new_Type ?(rigid=Evd.univ_flexible) env evdref =
+let e_new_Type ?(rigid=Evd.univ_flexible) _env evdref =
   let evd', s = new_sort_variable rigid !evdref in
     evdref := evd'; EConstr.mkSort s
 
@@ -702,7 +702,7 @@ let rec advance sigma evk =
   let evi = Evd.find sigma evk in
   match evi.evar_body with
   | Evar_empty -> Some evk
-  | Evar_defined v ->
+  | Evar_defined _v ->
       match is_restricted_evar evi with
       | Some evk -> advance sigma evk
       | None -> None

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -364,7 +364,7 @@ type t = Id.t EvMap.t * Evar.t Id.Map.t
 
 let empty = (EvMap.empty, Id.Map.empty)
 
-let add_name_newly_undefined id evk evi (evtoid, idtoev as names) =
+let add_name_newly_undefined id evk _evi (evtoid, idtoev as names) =
   match id with
   | None -> names
   | Some id ->
@@ -372,7 +372,7 @@ let add_name_newly_undefined id evk evi (evtoid, idtoev as names) =
       user_err  (str "Already an existential evar of name " ++ Id.print id);
     (EvMap.add evk id evtoid, Id.Map.add id evk idtoev)
 
-let add_name_undefined naming evk evi (evtoid,idtoev as evar_names) =
+let add_name_undefined naming evk evi (evtoid,_idtoev as evar_names) =
   if EvMap.mem evk evtoid then
     evar_names
   else
@@ -699,7 +699,7 @@ let extract_changed_conv_pbs evd p =
 let extract_all_conv_pbs evd =
   extract_conv_pbs evd (fun _ -> true)
 
-let loc_of_conv_pb evd (pbty,env,t1,t2) =
+let loc_of_conv_pb evd (_pbty,_env,t1,t2) =
   match kind (fst (decompose_app t1)) with
   | Evar (evk1,_) -> fst (evar_source evk1 evd)
   | _ ->
@@ -809,7 +809,7 @@ let fresh_constructor_instance ?loc env evd c =
 let fresh_global ?loc ?(rigid=univ_flexible) ?names env evd gr =
   with_context_set ?loc rigid evd (Universes.fresh_global_instance ?names env gr)
 
-let whd_sort_variable evd t = t
+let whd_sort_variable _evd t = t
 
 let is_sort_variable evd s = UState.is_sort_variable evd.universes s
 
@@ -900,9 +900,9 @@ let nf_univ_variables evd =
   let evd' = {evd with universes = uctx'} in
     evd', subst
 
-let minimize_universes evd =
-  let subst, uctx' = UState.normalize_variables evd.universes in
-  let uctx' = UState.minimize uctx' in
+let nf_constraints evd =
+  let _subst, uctx' = normalize_evar_universe_context_variables evd.universes in
+  let uctx' = normalize_evar_universe_context uctx' in
     {evd with universes = uctx'}
 
 let universe_of_name evd s = UState.universe_of_name evd.universes s
@@ -1020,8 +1020,8 @@ let meta_list evd = metamap_to_list evd.metas
 
 let undefined_metas evd =
   let filter = function
-    | (n,Clval(_,_,typ)) -> None
-    | (n,Cltyp (_,typ))  -> Some n
+    | (_n,Clval(_,_,_typ)) -> None
+    | (n,Cltyp (_,_typ))  -> Some n
   in
   let m = List.map_filter filter (meta_list evd) in
   List.sort Int.compare m

--- a/engine/logic_monad.ml
+++ b/engine/logic_monad.ml
@@ -88,7 +88,7 @@ struct
   let catch = fun s h -> ();
     fun () -> try s ()
       with Exception e as src ->
-        let (src, info) = CErrors.push src in
+        let (_src, info) = CErrors.push src in
         h (e, info) ()
 
   let read_line = fun () -> try Pervasives.read_line () with e ->
@@ -113,7 +113,7 @@ struct
 
   let run = fun x ->
     try x () with Exception e as src ->
-      let (src, info) = CErrors.push src in
+      let (_src, info) = CErrors.push src in
       Util.iraise (e, info)
 end
 
@@ -197,7 +197,7 @@ struct
     { iolist = fun s nil cons -> m.iolist s nil (fun x s next -> cons (f x) s next) }
 
   let zero e =
-    { iolist = fun _ nil cons -> nil e }
+    { iolist = fun _ nil _cons -> nil e }
 
   let plus m1 m2 =
     { iolist = fun s nil cons -> m1.iolist s (fun e -> (m2 e).iolist s nil cons) cons }

--- a/engine/namegen.ml
+++ b/engine/namegen.ml
@@ -338,7 +338,7 @@ let next_name_away_with_default default na avoid =
   let id = match na with Name id -> id | Anonymous -> Id.of_string default in
   next_ident_away id avoid
 
-let reserved_type_name = ref (fun t -> Anonymous)
+let reserved_type_name = ref (fun _t -> Anonymous)
 let set_reserved_typed_name f = reserved_type_name := f
 
 let next_name_away_with_default_using_types default na avoid t =
@@ -439,7 +439,7 @@ let compute_and_force_displayed_name_in sigma flags avoid na c =
     let fresh_id = next_name_for_display sigma flags na avoid in
     (Name fresh_id, Id.Set.add fresh_id avoid)
 
-let compute_displayed_let_name_in sigma flags avoid na c =
+let compute_displayed_let_name_in sigma flags avoid na _c =
   let fresh_id = next_name_for_display sigma flags na avoid in
   (Name fresh_id, Id.Set.add fresh_id avoid)
 

--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -353,7 +353,7 @@ exception NoSuchGoals of int
 (* This hook returns a string to be appended to the usual message.
    Primarily used to add a suggestion about the right bullet to use to
    focus the next goal, if applicable. *)
-let nosuchgoals_hook:(int -> Pp.t) ref = ref (fun n -> mt ())
+let nosuchgoals_hook:(int -> Pp.t) ref = ref (fun _n -> mt ())
 let set_nosuchgoals_hook f = nosuchgoals_hook := f
 
 
@@ -723,7 +723,7 @@ let shelve_unifiable =
 let guard_no_unifiable =
   let open Proof in
   Pv.get >>= fun initial ->
-  let (u,n) = partition_unifiable initial.solution initial.comb in
+  let (u,_n) = partition_unifiable initial.solution initial.comb in
   match u with
   | [] -> tclUNIT None
   | gls ->

--- a/engine/proofview_monad.ml
+++ b/engine/proofview_monad.ml
@@ -54,7 +54,7 @@ module Trace = struct
 
   let to_tree = function
     | { head ; opened=[] } -> mirror head
-    | { head ; opened=_::_} -> assert false
+    | { opened=_::_ ; _  } -> assert false
 
 end
 

--- a/engine/uState.ml
+++ b/engine/uState.ml
@@ -58,7 +58,7 @@ let is_empty ctx =
 let uname_union s t =
   if s == t then s
   else
-    UNameMap.merge (fun k l r ->
+    UNameMap.merge (fun _k l r ->
         match l, r with
         | Some _, _ -> l
         | _, _ -> r) s t
@@ -294,7 +294,7 @@ let constrain_variables diff ctx =
   { ctx with uctx_local = (univs, local); uctx_univ_variables = vars }
   
 let reference_of_level uctx =
-  let map, map_rev = uctx.uctx_names in 
+  let _map, map_rev = uctx.uctx_names in 
     fun l ->
       try CAst.make @@ Libnames.Ident (Option.get (Univ.LMap.find l map_rev).uname)
       with Not_found | Option.IsNone ->
@@ -327,7 +327,7 @@ let universe_context ~names ~extensible uctx =
   let levels = ContextSet.levels uctx.uctx_local in
   let newinst, left =
     List.fold_right
-      (fun { CAst.loc; v = id } (newinst, acc) ->
+      (fun (_loc,id) (newinst, acc) ->
          let l =
            try UNameMap.find id (fst uctx.uctx_names)
            with Not_found -> assert false
@@ -347,7 +347,7 @@ let check_universe_context_set ~names ~extensible uctx =
   if extensible then ()
   else
     let open Univ in
-    let left = List.fold_left (fun left { CAst.loc; v = id } ->
+    let left = List.fold_left (fun left (_loc,id) ->
         let l =
           try UNameMap.find id (fst uctx.uctx_names)
           with Not_found -> assert false
@@ -396,7 +396,7 @@ let check_univ_decl ~poly uctx decl =
 
 let restrict ctx vars =
   let vars = Univ.LSet.union vars ctx.uctx_seff_univs in
-  let vars = Names.Id.Map.fold (fun na l vars -> Univ.LSet.add l vars)
+  let vars = Names.Id.Map.fold (fun _na l vars -> Univ.LSet.add l vars)
       (fst ctx.uctx_names) vars
   in
   let uctx' = Univops.restrict_universe_context ctx.uctx_local vars in
@@ -473,7 +473,7 @@ let new_univ_variable ?loc rigid name
   ({ uctx_local = ctx; uctx_univ_variables = uvars; uctx_univ_algebraic = avars} as uctx) =
   let u = Universes.new_univ_level () in
   let ctx' = Univ.ContextSet.add_universe u ctx in
-  let uctx', pred =
+  let uctx', _pred =
     match rigid with
     | UnivRigid -> uctx, true
     | UnivFlexible b -> 
@@ -525,7 +525,7 @@ let make_flexible_variable ctx ~algebraic u =
       in
       let has_upper_constraint () =
         Univ.Constraint.exists
-          (fun (l,d,r) -> d == Univ.Lt && Univ.Level.equal l u)
+          (fun (l,d,_r) -> d == Univ.Lt && Univ.Level.equal l u)
           (Univ.ContextSet.constraints cstrs)
       in
         if not (Univ.LMap.exists substu_not_alg uvars || has_upper_constraint ())
@@ -552,7 +552,7 @@ let subst_univs_context_with_def def usubst (ctx, cst) =
   (Univ.LSet.diff ctx def, Universes.subst_univs_constraints usubst cst)
 
 let normalize_variables uctx =
-  let normalized_variables, undef, def, subst = 
+  let normalized_variables, _undef, def, subst = 
     Universes.normalize_univ_variables uctx.uctx_univ_variables 
   in
   let ctx_local = subst_univs_context_with_def def (Univ.make_subst subst) uctx.uctx_local in

--- a/engine/univops.ml
+++ b/engine/univops.ml
@@ -66,7 +66,7 @@ let add_up a d b graph =
 
 (* for each node transitive close until you find a non removable, discard the rest *)
 let transitive_close removable graph =
-  let rec do_node a node =
+  let rec do_node _a node =
     if not node.visited
     then
       let keepup =

--- a/interp/dumpglob.ml
+++ b/interp/dumpglob.ml
@@ -112,7 +112,7 @@ let type_of_global_ref gr =
     | Globnames.VarRef v ->
 	"var" ^ type_of_logical_kind (Decls.variable_kind v)
     | Globnames.IndRef ind ->
-	let (mib,oib) = Inductive.lookup_mind_specif (Global.env ()) ind in
+	let (mib,_oib) = Inductive.lookup_mind_specif (Global.env ()) ind in
 	  if mib.Declarations.mind_record <> None then
             begin match mib.Declarations.mind_finite with
             | Finite -> "indrec"
@@ -232,7 +232,7 @@ let add_glob ?loc ref =
     add_glob_gen ?loc sp lib_dp ty
 
 let mp_of_kn kn =
-  let mp,sec,l = Names.KerName.repr kn in
+  let mp,_sec,l = Names.KerName.repr kn in
     Names.MPdot (mp,l)
 
 let add_glob_kn ?loc kn =
@@ -241,7 +241,7 @@ let add_glob_kn ?loc kn =
     let lib_dp = Lib.dp_of_mp (mp_of_kn kn) in
     add_glob_gen ?loc sp lib_dp "syndef"
 
-let dump_binding ?loc id = ()
+let dump_binding ?loc _id = ignore(loc)
 
 let dump_def ?loc ty secpath id = Option.iter (fun loc ->
   if !glob_output = Feedback then
@@ -260,7 +260,7 @@ let dump_constraint (({ CAst.loc; v = n },_), _, _) sec ty =
     | Names.Anonymous -> ()
 
 let dump_moddef ?loc mp ty =
-  let (dp, l) = Lib.split_modpath mp in
+  let (_dp, l) = Lib.split_modpath mp in
   let mp = Names.DirPath.to_string (Names.DirPath.make l) in
   dump_def ?loc ty "<>" mp
 

--- a/interp/smartlocate.ml
+++ b/interp/smartlocate.ml
@@ -55,10 +55,10 @@ let global_inductive_with_alias ({CAst.loc} as lr)  =
   let qid = qualid_of_reference lr in
   try match locate_global_with_alias qid with
   | IndRef ind -> ind
-  | ref ->
-      user_err ?loc ~hdr:"global_inductive"
-        (pr_reference lr ++ spc () ++ str "is not an inductive type.")
-  with Not_found -> Nametab.error_global_not_found qid
+  | _ref ->
+      user_err ?loc:(loc_of_reference r) ~hdr:"global_inductive"
+        (pr_reference r ++ spc () ++ str "is not an inductive type.")
+  with Not_found -> Nametab.error_global_not_found ?loc qid
 
 let global_with_alias ?head r =
   let qid = qualid_of_reference r in

--- a/interp/stdarg.ml
+++ b/interp/stdarg.ml
@@ -31,6 +31,10 @@ let wit_string : string uniform_genarg_type =
 let wit_pre_ident : string uniform_genarg_type =
   make0 "preident"
 
+let loc_of_or_by_notation f = function
+  | AN c -> f c
+  | ByNotation (loc,(_s,_)) -> loc
+
 let wit_int_or_var =
   make0 ~dyn:(val_tag (topwit wit_int)) "int_or_var"
 

--- a/interp/syntax_def.ml
+++ b/interp/syntax_def.ml
@@ -78,7 +78,7 @@ type syndef_interpretation = (Id.t * subscopes) list * notation_constr
 (* Coercions to the general format of notation that also supports
    variables bound to list of expressions *)
 let in_pat (ids,ac) = (List.map (fun (id,sc) -> (id,(sc,NtnTypeConstr))) ids,ac)
-let out_pat (ids,ac) = (List.map (fun (id,(sc,typ)) -> (id,sc)) ids,ac)
+let out_pat (ids,ac) = (List.map (fun (id,(sc,_typ)) -> (id,sc)) ids,ac)
 
 let declare_syntactic_definition local id onlyparse pat =
   let _ = add_leaf id (in_syntax_constant (local,in_pat pat,onlyparse)) in ()

--- a/kernel/cbytecodes.ml
+++ b/kernel/cbytecodes.ml
@@ -202,10 +202,7 @@ let compare e1 e2 = match e1, e2 with
 | FVrel r1, FVrel r2 -> Int.compare r1 r2
 | FVrel _, (FVuniv_var _ | FVevar _) -> -1
 | FVuniv_var i1, FVuniv_var i2 -> Int.compare i1 i2
-| FVuniv_var i1, (FVnamed _ | FVrel _) -> 1
-| FVuniv_var i1, FVevar _ -> -1
-| FVevar _, (FVnamed _ | FVrel _ | FVuniv_var _) -> 1
-| FVevar e1, FVevar e2 -> Evar.compare e1 e2
+| FVuniv_var _i1, _ -> 1
 
 end
 

--- a/kernel/constr.ml
+++ b/kernel/constr.ml
@@ -368,17 +368,17 @@ let destConst c = match kind c with
 
 (* Destructs an existential variable *)
 let destEvar c = match kind c with
-  | Evar (kn, a as r) -> r
+  | Evar (_kn, _a as r) -> r
   | _ -> raise DestKO
 
 (* Destructs a (co)inductive type named kn *)
 let destInd c = match kind c with
-  | Ind (kn, a as r) -> r
+  | Ind (_kn, _a as r) -> r
   | _ -> raise DestKO
 
 (* Destructs a constructor *)
 let destConstruct c = match kind c with
-  | Construct (kn, a as r) -> r
+  | Construct (_kn, _a as r) -> r
   | _ -> raise DestKO
 
 (* Destructs a term <p>Case c of lc1 | lc2 .. | lcn end *)
@@ -429,12 +429,12 @@ let fold f acc c = match kind c with
   | Lambda (_,t,c) -> f (f acc t) c
   | LetIn (_,b,t,c) -> f (f (f acc b) t) c
   | App (c,l) -> Array.fold_left f (f acc c) l
-  | Proj (p,c) -> f acc c
+  | Proj (_p,c) -> f acc c
   | Evar (_,l) -> Array.fold_left f acc l
   | Case (_,p,c,bl) -> Array.fold_left f (f (f acc p) c) bl
-  | Fix (_,(lna,tl,bl)) ->
+  | Fix (_,(_lna,tl,bl)) ->
     Array.fold_left2 (fun acc t b -> f (f acc t) b) acc tl bl
-  | CoFix (_,(lna,tl,bl)) ->
+  | CoFix (_,(_lna,tl,bl)) ->
     Array.fold_left2 (fun acc t b -> f (f acc t) b) acc tl bl
 
 (* [iter f c] iters [f] on the immediate subterms of [c]; it is
@@ -449,7 +449,7 @@ let iter f c = match kind c with
   | Lambda (_,t,c) -> f t; f c
   | LetIn (_,b,t,c) -> f b; f t; f c
   | App (c,l) -> f c; Array.iter f l
-  | Proj (p,c) -> f c
+  | Proj (_p,c) -> f c
   | Evar (_,l) -> Array.iter f l
   | Case (_,p,c,bl) -> f p; f c; Array.iter f bl
   | Fix (_,(_,tl,bl)) -> Array.iter f tl; Array.iter f bl
@@ -471,7 +471,7 @@ let iter_with_binders g f n c = match kind c with
   | App (c,l) -> f n c; CArray.Fun1.iter f n l
   | Evar (_,l) -> CArray.Fun1.iter f n l
   | Case (_,p,c,bl) -> f n p; f n c; CArray.Fun1.iter f n bl
-  | Proj (p,c) -> f n c
+  | Proj (_p,c) -> f n c
   | Fix (_,(_,tl,bl)) ->
       CArray.Fun1.iter f n tl;
       CArray.Fun1.iter f (iterate g (Array.length tl) n) bl
@@ -773,7 +773,7 @@ let eq_constr_univs_infer univs m n =
   if m == n then true, Constraint.empty
   else 
     let cstrs = ref Constraint.empty in
-    let eq_universes _ _ = UGraph.check_eq_instances univs in
+    let eq_universes _strict = UGraph.check_eq_instances univs in
     let eq_sorts s1 s2 = 
       if Sorts.equal s1 s2 then true
       else
@@ -793,7 +793,7 @@ let leq_constr_univs_infer univs m n =
   if m == n then true, Constraint.empty
   else 
     let cstrs = ref Constraint.empty in
-    let eq_universes _ _ l l' = UGraph.check_eq_instances univs l l' in
+    let eq_universes _strict l l' = UGraph.check_eq_instances univs l l' in
     let eq_sorts s1 s2 = 
       if Sorts.equal s1 s2 then true
       else
@@ -860,11 +860,11 @@ let constr_ord_int f t1 t2 =
     | LetIn _, _ -> -1 | _, LetIn _ -> 1
     | App (c1,l1), App (c2,l2) -> (f =? (Array.compare f)) c1 c2 l1 l2
     | App _, _ -> -1 | _, App _ -> 1
-    | Const (c1,u1), Const (c2,u2) -> Constant.CanOrd.compare c1 c2
+    | Const (c1,_u1), Const (c2,_u2) -> Constant.CanOrd.compare c1 c2
     | Const _, _ -> -1 | _, Const _ -> 1
-    | Ind (ind1, u1), Ind (ind2, u2) -> ind_ord ind1 ind2
+    | Ind (ind1, _u1), Ind (ind2, _u2) -> ind_ord ind1 ind2
     | Ind _, _ -> -1 | _, Ind _ -> 1
-    | Construct (ct1,u1), Construct (ct2,u2) -> constructor_ord ct1 ct2
+    | Construct (ct1,_u1), Construct (ct2,_u2) -> constructor_ord ct1 ct2
     | Construct _, _ -> -1 | _, Construct _ -> 1
     | Case (_,p1,c1,bl1), Case (_,p2,c2,bl2) ->
         ((f =? f) ==? (Array.compare f)) p1 p2 c1 c2 bl1 bl2
@@ -1123,9 +1123,9 @@ let rec hash t =
       combinesmall 11 (combine (constructor_hash c) (Instance.hash u))
     | Case (_ , p, c, bl) ->
       combinesmall 12 (combine3 (hash c) (hash p) (hash_term_array bl))
-    | Fix (ln ,(_, tl, bl)) ->
+    | Fix (_ln ,(_, tl, bl)) ->
       combinesmall 13 (combine (hash_term_array bl) (hash_term_array tl))
-    | CoFix(ln, (_, tl, bl)) ->
+    | CoFix(_ln, (_, tl, bl)) ->
        combinesmall 14 (combine (hash_term_array bl) (hash_term_array tl))
     | Meta n -> combinesmall 15 n
     | Rel n -> combinesmall 16 n

--- a/kernel/context.ml
+++ b/kernel/context.ml
@@ -144,8 +144,8 @@ struct
     (** Reduce all terms in a given declaration to a single value. *)
     let fold_constr f decl acc =
       match decl with
-      | LocalAssum (n,ty) -> f ty acc
-      | LocalDef (n,v,ty) -> f ty (f v acc)
+      | LocalAssum (_n,ty) -> f ty acc
+      | LocalDef (_n,v,ty) -> f ty (f v acc)
 
     let to_tuple = function
       | LocalAssum (na, ty) -> na, None, ty

--- a/kernel/csymtable.ml
+++ b/kernel/csymtable.ml
@@ -152,8 +152,7 @@ and slot_for_fv env fv =
         env |> Pre_env.lookup_rel i |> RelDecl.get_value |> fill_fv_cache rv i val_of_rel env_of_rel
       | Some (v, _) -> v
       end
-  | FVevar evk -> val_of_evar evk
-  | FVuniv_var idu ->
+  | FVuniv_var _idu ->
     assert false
 
 and eval_to_patch env (buff,pl,fv) =
@@ -171,5 +170,5 @@ and val_of_constr env c =
   | Some v -> eval_to_patch env (to_memory v)
   | None -> assert false
 
-let set_transparent_const kn = () (* !?! *)
-let set_opaque_const kn = () (* !?! *)
+let set_transparent_const _kn = () (* !?! *)
+let set_opaque_const _kn = () (* !?! *)

--- a/kernel/declareops.ml
+++ b/kernel/declareops.ml
@@ -187,7 +187,7 @@ let subst_regular_ind_arity sub s =
     if uar' == s.mind_user_arity then s 
     else { mind_user_arity = uar'; mind_sort = s.mind_sort }
 
-let subst_template_ind_arity sub s = s
+let subst_template_ind_arity _sub s = s
 
 (* FIXME records *)
 let subst_ind_arity =
@@ -240,14 +240,14 @@ let inductive_polymorphic_context mib =
 let inductive_is_polymorphic mib =
   match mib.mind_universes with
   | Monomorphic_ind _ -> false
-  | Polymorphic_ind ctx -> true
-  | Cumulative_ind cumi -> true
+  | Polymorphic_ind _ctx -> true
+  | Cumulative_ind _cumi -> true
 
 let inductive_is_cumulative mib =
   match mib.mind_universes with
   | Monomorphic_ind _ -> false
-  | Polymorphic_ind ctx -> false
-  | Cumulative_ind cumi -> true
+  | Polymorphic_ind _ctx -> false
+  | Cumulative_ind _cumi -> true
 
 (** {6 Hash-consing of inductive declarations } *)
 

--- a/kernel/environ.ml
+++ b/kernel/environ.ml
@@ -165,7 +165,7 @@ let fold_named_context f env ~init =
   let rec fold_right env =
     match match_named_context_val env.env_named_context with
     | None -> init
-    | Some (d, v, rem) ->
+    | Some (d, _v, rem) ->
 	let env =
 	  reset_with_named_context rem env in
 	f env d (fold_right env)
@@ -246,7 +246,7 @@ let constant_type env (kn,u) =
   let cb = lookup_constant kn env in
   match cb.const_universes with
   | Monomorphic_const _ -> cb.const_type, Univ.Constraint.empty
-  | Polymorphic_const ctx -> 
+  | Polymorphic_const _ctx -> 
     let csts = constraints_of cb u in
     (subst_instance_constr u cb.const_type, csts)
 
@@ -332,14 +332,14 @@ let is_projection cst env =
 (* Mutual Inductives *)
 let lookup_mind = lookup_mind
 
-let polymorphic_ind (mind,i) env =
+let polymorphic_ind (mind,_i) env =
   Declareops.inductive_is_polymorphic (lookup_mind mind env)
 
 let polymorphic_pind (ind,u) env =
   if Univ.Instance.is_empty u then false
   else polymorphic_ind ind env
 
-let type_in_type_ind (mind,i) env =
+let type_in_type_ind (mind,_i) env =
   not (lookup_mind mind env).mind_typing_flags.check_universes
 
 let template_polymorphic_ind (mind,i) env =
@@ -367,7 +367,7 @@ let lookup_constant_variables c env =
   let cmap = lookup_constant c env in
   Context.Named.to_vars cmap.const_hyps
 
-let lookup_inductive_variables (kn,i) env =
+let lookup_inductive_variables (kn,_i) env =
   let mis = lookup_mind kn env in
   Context.Named.to_vars mis.mind_hyps
 
@@ -577,7 +577,7 @@ fun rk value field ->
   let int31_binop_from_const op prim = int31_op_from_const 2 op prim in
   let int31_unop_from_const op prim = int31_op_from_const 1 op prim in
   match field with
-    | KInt31 (grp, Int31Type) ->
+    | KInt31 (_grp, Int31Type) ->
         let int31bit =
           (* invariant : the type of bits is registered, otherwise the function
              would raise Not_found. The invariant is enforced in safe_typing.ml *)

--- a/kernel/indtypes.ml
+++ b/kernel/indtypes.ml
@@ -254,7 +254,7 @@ let check_subtyping cumi paramsctxt env_ar inds =
     in
     let env = Environ.add_constraints subtyp_constraints env in
     (* process individual inductive types: *)
-    Array.iter (fun (id,cn,lc,(sign,arity)) ->
+    Array.iter (fun (_id,_cn,lc,(_sign,arity)) ->
       match arity with
         | RegularArity (_, full_arity, _) ->
            check_subtyping_arity_constructor env dosubst full_arity numparams true;
@@ -354,7 +354,7 @@ let typecheck_inductive env mie =
   (* Compute/check the sorts of the inductive types *)
 
   let inds =
-    Array.map (fun ((id,full_arity,sign,expltype,def_level,inf_level),cn,lc,(is_unit,clev))  ->
+    Array.map (fun ((id,full_arity,sign,expltype,def_level,inf_level),cn,lc,(_is_unit,clev))  ->
       let infu = 
 	(** Inferred level, with parameters and constructors. *)
 	match inf_level with
@@ -380,7 +380,7 @@ let typecheck_inductive env mie =
 	  RegularArity (not is_natural,full_arity,defu)
       in
       let template_polymorphic () =
-	let sign, s =
+	let _sign, s =
           try dest_arity env full_arity
           with NotArity -> raise (InductiveError (NotAnArity (env, full_arity)))
 	in
@@ -437,7 +437,7 @@ exception IllFormedInd of ill_formed_ind
 let mind_extract_params = decompose_prod_n_assum
 
 let explain_ind_err id ntyp env nparamsctxt c err =
-  let (lparams,c') = mind_extract_params nparamsctxt c in
+  let (_lparams,c') = mind_extract_params nparamsctxt c in
   match err with
     | LocalNonPos kt ->
 	raise (InductiveError (NonPos (env,c',mkRel (kt+nparamsctxt))))
@@ -605,7 +605,7 @@ let check_positivity_one ~chkpos recursive (env,_,ntypes,_ as ienv) paramsctxt (
                 discharged to the [check_positive_nested] function. *)
             if List.for_all (noccur_between n ntypes) largs then (nmr,mk_norec)
             else check_positive_nested ienv nmr (ind_kn, largs)
-	| err ->
+	| _err ->
             (** If an inductive of the mutually inductive block
                 appears in any other way, then the positivy check gives
                 up. *)
@@ -622,7 +622,7 @@ let check_positivity_one ~chkpos recursive (env,_,ntypes,_ as ienv) paramsctxt (
       defined types, not one of the types of the mutually inductive
       block being defined). *)
   (* accesses to the environment are not factorised, but is it worth? *)
-  and check_positive_nested (env,n,ntypes,ra_env as ienv) nmr ((mi,u), largs) =
+  and check_positive_nested (env,n,ntypes,_ra_env as ienv) nmr ((mi,u), largs) =
     let (mib,mip) = lookup_mind_specif env mi in
     let auxnrecpar = mib.mind_nparams_rec in
     let auxnnonrecpar = mib.mind_nparams - auxnrecpar in
@@ -673,7 +673,7 @@ let check_positivity_one ~chkpos recursive (env,_,ntypes,_ as ienv) paramsctxt (
       the type [c]) is checked to be the right (properly applied)
       inductive type. *)
   and check_constructors ienv check_head nmr c =
-    let rec check_constr_rec (env,n,ntypes,ra_env as ienv) nmr lrec c =
+    let rec check_constr_rec (env,n,ntypes,_ra_env as ienv) nmr lrec c =
       let x,largs = decompose_app (whd_all env c) in
 	match kind x with
 
@@ -797,9 +797,9 @@ exception UndefinableExpansion
     build an expansion function.
     The term built is expecting to be substituted first by 
     a substitution of the form [params, x : ind params] *)
-let compute_projections ((kn, _ as ind), u as indu) n x nparamargs params
+let compute_projections ((kn, _ as ind), _u as indu) _n x nparamargs params
     mind_consnrealdecls mind_consnrealargs paramslet ctx =
-  let mp, dp, l = MutInd.repr3 kn in
+  let mp, dp, _l = MutInd.repr3 kn in
   (** We build a substitution smashing the lets in the record parameters so
       that typechecking projections requires just a substitution and not
       matching with a parameter context. *)
@@ -838,7 +838,7 @@ let compute_projections ((kn, _ as ind), u as indu) n x nparamargs params
   in
   let projections decl (i, j, kns, pbs, subst, letsubst) =
     match decl with
-    | LocalDef (na,c,t) ->
+    | LocalDef (_na,c,_t) ->
         (* From [params, field1,..,fieldj |- c(params,field1,..,fieldj)]
            to [params, x:I, field1,..,fieldj |- c(params,field1,..,fieldj)] *)
         let c = liftn 1 j c in
@@ -881,7 +881,7 @@ let compute_projections ((kn, _ as ind), u as indu) n x nparamargs params
 	   fterm :: subst, fterm :: letsubst)
       | Anonymous -> raise UndefinableExpansion
   in
-  let (_, _, kns, pbs, subst, letsubst) =
+  let (_, _, kns, pbs, _subst, _letsubst) =
     List.fold_right projections ctx (0, 1, [], [], [], paramsletsubst)
   in
     Array.of_list (List.rev kns),
@@ -983,7 +983,7 @@ let build_inductive env prv iu env_ar paramsctxt kn isrecord isfinite inds nmr r
         | Cumulative_ind acumi -> Univ.make_abstract_instance (Univ.ACumulativityInfo.univ_context acumi)
       in
       let indsp = ((kn, 0), u) in
-      let rctx, indty = decompose_prod_assum (subst1 (mkIndU indsp) pkt.mind_nf_lc.(0)) in
+      let rctx, _indty = decompose_prod_assum (subst1 (mkIndU indsp) pkt.mind_nf_lc.(0)) in
 	(try 
 	   let fields, paramslet = List.chop pkt.mind_consnrealdecls.(0) rctx in
 	   let kns, projs = 

--- a/kernel/mod_subst.ml
+++ b/kernel/mod_subst.ml
@@ -222,7 +222,7 @@ let search_delta_inline resolve kn1 kn2 =
 let subst_mp0 sub mp = (* 's like subst *)
  let rec aux mp =
   match mp with
-    | MPfile sid -> Umap.find_mp mp sub
+    | MPfile _sid -> Umap.find_mp mp sub
     | MPbound bid ->
 	begin
 	  try Umap.find_mbi bid sub
@@ -317,12 +317,12 @@ let subst_con sub cst =
 let subst_con_kn sub con =
   subst_con sub (con,Univ.Instance.empty)
 
-let subst_pcon sub (con,u as pcon) = 
-  try let con', can = subst_con0 sub pcon in 
+let subst_pcon sub (_con,u as pcon) = 
+  try let con', _can = subst_con0 sub pcon in 
 	con',u
   with No_subst -> pcon
 
-let subst_pcon_term sub (con,u as pcon) = 
+let subst_pcon_term sub (_con,u as pcon) = 
   try let con', can = subst_con0 sub pcon in 
 	(con',u), can
   with No_subst -> pcon, mkConstU pcon
@@ -437,7 +437,7 @@ let replace_mp_in_kn mpfrom mpto kn =
 let rec mp_in_mp mp mp1 =
   match mp1 with
     | _ when ModPath.equal mp1 mp -> true
-    | MPdot (mp2,l) -> mp_in_mp mp mp2
+    | MPdot (mp2,_l) -> mp_in_mp mp mp2
     | _ -> false
 
 let subset_prefixed_by mp resolver =
@@ -522,7 +522,7 @@ let substition_prefixed_by k mp subst =
       Umap.add_mp new_key (mp_to,reso) sub
     else sub
   in
-  let mbi_prefixmp mbi _ sub = sub
+  let mbi_prefixmp _mbi _ sub = sub
   in
   Umap.fold mp_prefixmp mbi_prefixmp subst empty_subst
 

--- a/kernel/modops.ml
+++ b/kernel/modops.ml
@@ -139,7 +139,7 @@ let rec functor_smartmap fty f0 funct = match funct with
     let a' = f0 a in if a==a' then funct else NoFunctor a'
 
 let rec functor_iter fty f0 = function
-  |MoreFunctor (mbid,ty,e) -> fty ty; functor_iter fty f0 e
+  |MoreFunctor (_mbid,ty,e) -> fty ty; functor_iter fty f0 e
   |NoFunctor a -> f0 a
 
 (** {6 Misc operations } *)
@@ -172,7 +172,7 @@ let implem_iter fs fa impl = match impl with
 
 (** {6 Substitutions of modular structures } *)
 
-let id_delta x y = x
+let id_delta x _y = x
 
 let subst_with_body sub = function
   |WithMod(id,mp) as orig ->
@@ -266,7 +266,7 @@ let subst_structure subst = subst_structure subst do_delta_codom
 (* spiwack: here comes the function which takes care of importing
    the retroknowledge declared in the library *)
 (* lclrk : retroknowledge_action list, rkaction : retroknowledge action *)
-let add_retroknowledge mp =
+let add_retroknowledge _mp =
   let perform rkaction env = match rkaction with
     | Retroknowledge.RKRegister (f, e) when (isConst e || isInd e) ->
       Environ.register env f e
@@ -372,7 +372,7 @@ and strengthen_sig mp_from struc mp_to reso = match struc with
     let item' = l,SFBmodule mb' in
     let reso',rest' = strengthen_sig mp_from rest mp_to reso in
     add_delta_resolver reso' mb.mod_delta, item':: rest'
-  |(l,SFBmodtype mty as item) :: rest ->
+  |(_l,SFBmodtype _mty as item) :: rest ->
     let reso',rest' = strengthen_sig mp_from rest mp_to reso in
     reso',item::rest'
 
@@ -628,7 +628,7 @@ let join_structure except otab s =
   let rec join_module : 'a. 'a generic_module_body -> unit = fun mb ->
     Option.iter join_expression mb.mod_type_alg;
     join_signature mb.mod_type
-  and join_field (l,body) = match body with
+  and join_field (_l,body) = match body with
     |SFBconst sb -> join_constant_body except otab sb
     |SFBmind _ -> ()
     |SFBmodule m ->

--- a/kernel/names.ml
+++ b/kernel/names.ml
@@ -207,7 +207,7 @@ struct
 
   let repr mbid = mbid
 
-  let to_string (i, s, p) =
+  let to_string (_i, s, p) =
     DirPath.to_string p ^ "." ^ s
 
   let debug_to_string (i, s, p) =
@@ -328,7 +328,7 @@ module ModPath = struct
   let rec dp = function
   | MPfile sl -> sl
   | MPbound (_,_,dp) -> dp
-  | MPdot (mp,l) -> dp mp
+  | MPdot (mp,_l) -> dp mp
 
   module Self_Hashcons = struct
     type t = module_path
@@ -626,8 +626,8 @@ let constr_modpath (ind,_) = ind_modpath ind
 
 let ith_mutual_inductive (mind, _) i = (mind, i)
 let ith_constructor_of_inductive ind i = (ind, i)
-let inductive_of_constructor (ind, i) = ind
-let index_of_constructor (ind, i) = i
+let inductive_of_constructor (ind, _i) = ind
+let index_of_constructor (_ind, i) = i
 
 let eq_ind (m1, i1) (m2, i2) = Int.equal i1 i2 && MutInd.equal m1 m2
 let eq_user_ind (m1, i1) (m2, i2) =

--- a/kernel/nativecode.ml
+++ b/kernel/nativecode.ml
@@ -977,7 +977,7 @@ let compile_prim decl cond paux =
  *)
   let rec opt_prim_aux paux =
     match paux with
-    | PAprim(prefix, kn, op, args) ->
+    | PAprim(_prefix, _kn, op, args) ->
 	let args = Array.map opt_prim_aux args in
 	app_prim (Coq_primitive(op,None)) args
 (*
@@ -1041,7 +1041,7 @@ let ml_of_instance instance u =
   match t with
   | Lrel(id ,i) -> get_rel env id i
   | Lvar id -> get_var env id
-  | Lmeta(mv,ty) ->
+  | Lmeta(mv,_ty) ->
      let tyn = fresh_lname Anonymous in
      let i = push_symbol (SymbMeta mv) in
      MLapp(MLprimitive Mk_meta, [|get_meta_code i; MLlocal tyn|])
@@ -1155,7 +1155,7 @@ let ml_of_instance instance u =
       let lf,env_n = push_rels (empty_env env.env_univ ()) ids in
       let t_params = Array.make ndef [||] in
       let t_norm_f = Array.make ndef (Gnorm (l,-1)) in
-      let mk_let envi (id,def) t = MLlet (id,def,t) in
+      let mk_let _envi (id,def) t = MLlet (id,def,t) in
       let mk_lam_or_let (params,lets,env) (id,def) =
         let ln,env' = push_rel env id in
         match def with
@@ -1188,7 +1188,7 @@ let ml_of_instance instance u =
          (Array.map (fun g -> mkMLapp (MLglobal g) fv_args') t_norm_f) in
       (* Compilation of fix *)
       let fv_args = fv_args env fvn fvr in      
-      let lf, env = push_rels env ids in
+      let lf, _env = push_rels env ids in
       let lf_args = Array.map (fun id -> MLlocal id) lf in
       let mk_norm = MLapp(MLglobal norm, fv_args) in
       let mkrec i lname = 
@@ -1242,9 +1242,9 @@ let ml_of_instance instance u =
       let mk_norm = MLapp(MLglobal norm, fv_args) in
       let lnorm = fresh_lname Anonymous in
       let ltype = fresh_lname Anonymous in
-      let lf, env = push_rels env ids in
+      let lf, _env = push_rels env ids in
       let lf_args = Array.map (fun id -> MLlocal id) lf in
-      let upd i lname cont =
+      let upd i _lname cont =
 	let paramsi = t_params.(i) in
 	let pargsi = Array.map (fun id -> MLlocal id) paramsi in
 	let uniti = fresh_lname Anonymous in
@@ -1275,7 +1275,7 @@ let ml_of_instance instance u =
 	(lname, paramsi, body) in
       MLletrec(Array.mapi mkrec lf, lf_args.(start)) *)
 
-  | Lmakeblock (prefix,(cn,u),_,args) ->
+  | Lmakeblock (prefix,(cn,_u),_,args) ->
      let args = Array.map (ml_of_lam env l) args in
      MLconstruct(prefix,cn,args)
   | Lconstruct (prefix, (cn,u)) ->
@@ -1529,7 +1529,7 @@ let rec list_of_mp acc = function
 let list_of_mp mp = list_of_mp [] mp
 
 let string_of_kn kn =
-  let (mp,dp,l) = KerName.repr kn in
+  let (mp,_dp,l) = KerName.repr kn in
   let mp = list_of_mp mp in
   String.concat "_" mp ^ "_" ^ string_of_label l
 
@@ -1633,7 +1633,7 @@ let pp_mllam fmt l =
 
   and pp_letrec fmt defs =
     let len = Array.length defs in
-    let pp_one_rec i (fn, argsn, body) =
+    let pp_one_rec _i (fn, argsn, body) =
       Format.fprintf fmt "%a%a =@\n  %a"
 	pp_lname fn 
 	pp_ldecls argsn pp_mllam body in
@@ -1959,7 +1959,8 @@ let is_code_loaded ~interactive name =
 let param_name = Name (Id.of_string "params")
 let arg_name = Name (Id.of_string "arg")
 
-let compile_mind prefix ~interactive mb mind stack =
+let compile_mind _prefix ~interactive mb mind stack =
+  ignore(interactive);
   let u = Declareops.inductive_polymorphic_context mb in
   let f i stack ob =
     let gtype = Gtype((mind, i), Array.map snd ob.mind_reloc_tbl) in
@@ -2018,9 +2019,9 @@ let compile_mind_deps env prefix ~interactive
    reverse order, as well as linking information updates *)
 let rec compile_deps env sigma prefix ~interactive init t =
   match kind t with
-  | Ind ((mind,_),u) -> compile_mind_deps env prefix ~interactive init mind
+  | Ind ((mind,_),_u) -> compile_mind_deps env prefix ~interactive init mind
   | Const c ->
-      let c,u = get_alias env c in
+      let c,_u = get_alias env c in
       let cb,(nameref,_) = lookup_constant_key c env in
       let (_, (_, const_updates)) = init in
       if is_code_loaded ~interactive nameref
@@ -2042,11 +2043,11 @@ let rec compile_deps env sigma prefix ~interactive init t =
       let comp_stack = code@comp_stack in
       let const_updates = Cmap_env.add c (nameref, name) const_updates in
       comp_stack, (mind_updates, const_updates)
-  | Construct (((mind,_),_),u) -> compile_mind_deps env prefix ~interactive init mind
+  | Construct (((mind,_),_),_u) -> compile_mind_deps env prefix ~interactive init mind
   | Proj (p,c) ->
     let term = mkApp (mkConst (Projection.constant p), [|c|]) in
       compile_deps env sigma prefix ~interactive init term
-  | Case (ci, p, c, ac) ->
+  | Case (ci, _p, _c, _ac) ->
       let mind = fst ci.ci_ind in
       let init = compile_mind_deps env prefix ~interactive init mind in
       Constr.fold (compile_deps env sigma prefix ~interactive) init t

--- a/kernel/nativeconv.ml
+++ b/kernel/nativeconv.ml
@@ -25,9 +25,9 @@ let rec conv_val env pb lvl v1 v2 cu =
     | Vfun f1, Vfun f2 ->
 	let v = mk_rel_accu lvl in
 	conv_val env CONV (lvl+1) (f1 v) (f2 v) cu
-    | Vfun f1, _ ->
+    | Vfun _f1, _ ->
 	conv_val env CONV lvl v1 (fun x -> v2 x) cu
-    | _, Vfun f2 ->
+    | _, Vfun _f2 ->
 	conv_val env CONV lvl (fun x -> v1 x) v2 cu
     | Vaccu k1, Vaccu k2 ->
 	conv_accu env pb lvl k1 k2 cu
@@ -110,7 +110,7 @@ and conv_atom env pb lvl a1 a2 cu =
 	else
 	  if not (Int.equal (Array.length f1) (Array.length f2)) then raise NotConvertible
 	  else conv_fix env lvl t1 f1 t2 f2 cu 
-    | Aprod(_,d1,c1), Aprod(_,d2,c2) ->
+    | Aprod(_,d1,_c1), Aprod(_,d2,_c2) ->
        let cu = conv_val env CONV lvl d1 d2 cu in
        let v = mk_rel_accu lvl in
        conv_val env pb (lvl + 1) (d1 v) (d2 v) cu

--- a/kernel/nativelambda.ml
+++ b/kernel/nativelambda.ml
@@ -201,7 +201,7 @@ let can_subst lam =
 
 let can_merge_if bt bf =
   match bt, bf with
-  | Llam(idst,_), Llam(idsf,_) -> true
+  | Llam(_idst,_), Llam(_idsf,_) -> true
   | _ -> false
 
 let merge_if t bt bf =
@@ -433,7 +433,7 @@ module Renv =
 (* What about pattern matching ?*)
 let is_lazy prefix t =
   match kind t with
-  | App (f,args) ->
+  | App (f,_args) ->
      begin match kind f with
      | Construct (c,_) ->
 	let entry = mkInd (fst c) in
@@ -484,7 +484,7 @@ let rec lambda_of_constr env sigma c =
 
   | Sort s -> Lsort s
 
-  | Ind (ind,u as pind) ->
+  | Ind (ind,_u as pind) ->
       let prefix = get_mind_prefix !global_env (fst ind) in
       Lind (prefix, pind)
 
@@ -578,7 +578,7 @@ let rec lambda_of_constr env sigma c =
 
 and lambda_of_app env sigma f args =
   match kind f with
-  | Const (kn,u as c) ->
+  | Const (_kn,_u as c) ->
       let kn,u = get_alias !global_env c in
       let cb = lookup_constant kn !global_env in
       (try

--- a/kernel/nativelib.ml
+++ b/kernel/nativelib.ml
@@ -40,7 +40,7 @@ let include_dirs () =
   [Filename.get_temp_dir_name (); coqlib () / "kernel"; coqlib () / "library"]
 
 (* Pointer to the function linking an ML object into coq's toplevel *)
-let load_obj = ref (fun x -> () : string -> unit)
+let load_obj = ref (fun _x -> () : string -> unit)
 
 let rt1 = ref (dummy_value ())
 let rt2 = ref (dummy_value ())
@@ -112,7 +112,7 @@ let call_compiler ?profile:(profile=false) ml_filename =
     let res = CUnix.sys_command (ocamlfind ()) args in
     let res = match res with
       | Unix.WEXITED 0 -> true
-      | Unix.WEXITED n | Unix.WSIGNALED n | Unix.WSTOPPED n ->
+      | Unix.WEXITED _n | Unix.WSIGNALED _n | Unix.WSTOPPED _n ->
         warn_native_compiler_failed (Inl res); false
     in
     res, link_filename

--- a/kernel/pre_env.ml
+++ b/kernel/pre_env.ml
@@ -195,7 +195,7 @@ let lookup_named_val id env =
   snd(Id.Map.find id env.env_named_context.env_named_map)
 
 (* Warning all the names should be different *)
-let env_of_named id env = env
+let env_of_named _id env = env
 
 (* Global constants *)
 

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -242,7 +242,7 @@ let universes_of_private eff =
   List.fold_left
     (fun acc { Entries.eff } ->
        match eff with
-       | Entries.SEscheme (l,s) ->
+       | Entries.SEscheme (l,_s) ->
          List.fold_left
            (fun acc (_,_,cb,c) ->
               let acc = match c with
@@ -255,7 +255,7 @@ let universes_of_private eff =
               | Polymorphic_const _ -> acc
            )
            acc l
-       | Entries.SEsubproof (c, cb, e) ->
+       | Entries.SEsubproof (_c, cb, _e) ->
          match cb.const_universes with
               | Monomorphic_const ctx ->
                 ctx :: acc
@@ -900,7 +900,7 @@ let typing senv = Typeops.infer (env_of_senv senv)
 let retroknowledge f senv =
   Environ.retroknowledge f (env_of_senv senv)
 
-let register field value by_clause senv =
+let register field value _by_clause senv =
   (* todo : value closed, by_clause safe, by_clause of the proper type*)
   (* spiwack : updates the safe_env with the information that the register
      action has to be performed (again) when the environment is imported *)

--- a/kernel/subtyping.ml
+++ b/kernel/subtyping.ml
@@ -194,7 +194,7 @@ let check_inductive cst env mp1 l info1 mp2 mib2 spec2 subst1 subst2 reso1 reso2
 	cst
   in
   let mind = MutInd.make1 kn1 in
-  let check_cons_types i cst p1 p2 =
+  let check_cons_types _i cst p1 p2 =
     Array.fold_left3
       (fun cst id t1 t2 -> check_conv (NotConvertibleConstructorField id) cst
 	(inductive_is_polymorphic mib1) infer_conv env t1 t2)
@@ -255,7 +255,7 @@ let check_inductive cst env mp1 l info1 mp2 mib2 spec2 subst1 subst2 reso1 reso2
     cst
 
     
-let check_constant cst env mp1 l info1 cb2 spec2 subst1 subst2 = 
+let check_constant cst env _mp1 l info1 cb2 spec2 subst1 subst2 = 
   let error why = error_signature_mismatch l spec2 why in
   let check_conv cst poly f = check_conv_error error cst poly f in
   let check_type poly cst env t1 t2 =
@@ -345,13 +345,13 @@ let check_constant cst env mp1 l info1 cb2 spec2 subst1 subst2 =
 	      let c1 = Mod_subst.force_constr lc1 in
 	      let c2 = Mod_subst.force_constr lc2 in
 	      check_conv NotConvertibleBodyField cst poly infer_conv env c1 c2))
-   | IndType ((kn,i),mind1) ->
+   | IndType ((_kn,_i),_mind1) ->
        CErrors.user_err Pp.(str @@
        "The kernel does not recognize yet that a parameter can be " ^
        "instantiated by an inductive type. Hint: you can rename the " ^
        "inductive type and give a definition to map the old name to the new " ^
        "name.")
-   | IndConstr (((kn,i),j),mind1) ->
+   | IndConstr (((_kn,_i),_j),_mind1) ->
       CErrors.user_err Pp.(str @@
        "The kernel does not recognize yet that a parameter can be " ^
        "instantiated by a constructor. Hint: you can rename the " ^

--- a/kernel/term.ml
+++ b/kernel/term.ml
@@ -259,13 +259,13 @@ let mkProd_wo_LetIn decl c =
   let open Context.Rel.Declaration in
   match decl with
   | LocalAssum (na,t) -> mkProd (na, t, c)
-  | LocalDef (na,b,t) -> subst1 b c
+  | LocalDef (_na,b,_t) -> subst1 b c
 
 let mkNamedProd_wo_LetIn decl c =
   let open Context.Named.Declaration in
   match decl with
     | LocalAssum (id,t) -> mkNamedProd id t c
-    | LocalDef (id,b,t) -> subst1 b (subst_var id c)
+    | LocalDef (id,b,_t) -> subst1 b (subst_var id c)
 
 (* non-dependent product t1 -> t2 *)
 let mkArrow t1 t2 = mkProd (Anonymous, t1, t2)
@@ -286,7 +286,7 @@ let mkNamedLambda_or_LetIn decl c =
 (* prodn n [xn:Tn;..;x1:T1;Gamma] b = (x1:T1)..(xn:Tn)b *)
 let prodn n env b =
   let rec prodrec = function
-    | (0, env, b)        -> b
+    | (0, _env, b)        -> b
     | (n, ((v,t)::l), b) -> prodrec (n-1,  l, mkProd (v,t,b))
     | _ -> assert false
   in
@@ -298,7 +298,7 @@ let compose_prod l b = prodn (List.length l) l b
 (* lamn n [xn:Tn;..;x1:T1;Gamma] b = [x1:T1]..[xn:Tn]b *)
 let lamn n env b =
   let rec lamrec = function
-    | (0, env, b)        -> b
+    | (0, _env, b)        -> b
     | (n, ((v,t)::l), b) -> lamrec (n-1,  l, mkLambda (v,t,b))
     | _ -> assert false
   in
@@ -481,7 +481,7 @@ let decompose_prod_n_assum n =
       | Prod (x,t,c)    -> prodec_rec (Context.Rel.add (LocalAssum (x,t)) l) (n-1) c
       | LetIn (x,b,t,c) -> prodec_rec (Context.Rel.add (LocalDef (x,b,t)) l) (n-1) c
       | Cast (c,_,_)      -> prodec_rec l n c
-      | c -> user_err (str  "decompose_prod_n_assum: not enough assumptions")
+      | _c -> user_err (str  "decompose_prod_n_assum: not enough assumptions")
   in
   prodec_rec Context.Rel.empty n
 
@@ -502,7 +502,7 @@ let decompose_lam_n_assum n =
       | Lambda (x,t,c)  -> lamdec_rec (Context.Rel.add (LocalAssum (x,t)) l) (n-1) c
       | LetIn (x,b,t,c) -> lamdec_rec (Context.Rel.add (LocalDef (x,b,t)) l) n c
       | Cast (c,_,_)      -> lamdec_rec l n c
-      | c -> user_err (str "decompose_lam_n_assum: not enough abstractions")
+      | _c -> user_err (str "decompose_lam_n_assum: not enough abstractions")
   in
   lamdec_rec Context.Rel.empty n
 
@@ -518,7 +518,7 @@ let decompose_lam_n_decls n =
       | Lambda (x,t,c)  -> lamdec_rec (Context.Rel.add (LocalAssum (x,t)) l) (n-1) c
       | LetIn (x,b,t,c) -> lamdec_rec (Context.Rel.add (LocalDef (x,b,t)) l) (n-1) c
       | Cast (c,_,_)      -> lamdec_rec l n c
-      | c -> user_err (str "decompose_lam_n_decls: not enough abstractions")
+      | _c -> user_err (str "decompose_lam_n_decls: not enough abstractions")
   in
   lamdec_rec Context.Rel.empty n
 

--- a/kernel/term_typing.ml
+++ b/kernel/term_typing.ml
@@ -133,7 +133,7 @@ let inline_side_effects env body ctx side_eff =
         let subst = Cmap_env.add c (Inr var) subst in
         let ctx = Univ.ContextSet.union ctx univs in
         (subst, var + 1, ctx, (cname c, b, ty, opaque) :: args)
-      | Polymorphic_const auctx ->
+      | Polymorphic_const _auctx ->
         (** Inline the term to emulate universe polymorphism *)
         let subst = Cmap_env.add c (Inl b) subst in
         (subst, var, ctx, args)
@@ -351,9 +351,9 @@ let infer_declaration (type a) ~(trust : a trust) env (dcl : a constant_entry) =
 
   | ProjectionEntry {proj_entry_ind = ind; proj_entry_arg = i} ->
     let mib, _ = Inductive.lookup_mind_specif env (ind,0) in
-    let kn, pb = 
+    let _kn, pb = 
       match mib.mind_record with
-      | Some (Some (id, kns, pbs)) -> 
+      | Some (Some (_id, kns, pbs)) -> 
 	if i < Array.length pbs then
 	  kns.(i), pbs.(i)
 	else assert false
@@ -408,7 +408,7 @@ let build_constant_declaration kn env result =
          str "Proof using " ++ declared_vars ++ fnl () ++
          str "to" ++ fnl () ++
          str "Proof using " ++ inferred_vars) in
-  let sort evn l =
+  let sort _evn l =
     List.filter (fun decl ->
       let id = NamedDecl.get_id decl in
       List.exists (NamedDecl.get_id %> Names.Id.equal id) l)
@@ -461,7 +461,7 @@ let build_constant_declaration kn env result =
     let res =
       match result.cook_proj with
       | None -> compile_constant_body env univs def
-      | Some pb ->
+      | Some _pb ->
 	(* The compilation of primitive projections is a bit tricky, because
            they refer to themselves (the body of p looks like fun c =>
            Proj(p,c)). We break the cycle by building an ad-hoc compilation
@@ -589,7 +589,7 @@ let export_side_effects mb env c =
            let cbs_len = List.length cbs in
            let cbs = List.map turn_direct cbs in
            let env = List.fold_left push_seff env cbs in
-           let ecbs = List.map (fun (kn,cb,u,r) ->
+           let ecbs = List.map (fun (kn,cb,_u,r) ->
              kn, cb, r) cbs in
            translate_seff (Some (sl-cbs_len)) rest (ecbs @ acc) env
      in
@@ -608,7 +608,7 @@ let translate_recipe env kn r =
   let hcons = DirPath.is_empty dir in
   build_constant_declaration kn env (Cooking.cook_constant ~hcons env r)
 
-let translate_local_def env id centry =
+let translate_local_def mb env _id centry =
   let open Cooking in
   let body = Future.from_val ((centry.secdef_body, Univ.ContextSet.empty), ()) in
   let centry = {

--- a/kernel/typeops.ml
+++ b/kernel/typeops.ml
@@ -69,7 +69,7 @@ let type_of_type u =
     mkType uu
 
 let type_of_sort = function
-  | Prop c -> type1
+  | Prop _c -> type1
   | Type u -> type_of_type u
 
 (*s Type of a de Bruijn index. *)
@@ -118,14 +118,14 @@ let check_hyps_inclusion env f c sign =
 (* Type of constants *)
 
 
-let type_of_constant env (kn,u as cst) =
+let type_of_constant env (kn,_u as cst) =
   let cb = lookup_constant kn env in
   let () = check_hyps_inclusion env mkConstU cst cb.const_hyps in
   let ty, cu = constant_type env cst in
   let () = check_constraints cu env in
     ty
 
-let type_of_constant_in env (kn,u as cst) =
+let type_of_constant_in env (kn,_u as cst) =
   let cb = lookup_constant kn env in
   let () = check_hyps_inclusion env mkConstU cst cb.const_hyps in
   constant_type_in env cst
@@ -142,7 +142,7 @@ let type_of_constant_in env (kn,u as cst) =
   and no upper constraint exists on the sort $s$, we don't need to compute $s$
 *)
 
-let type_of_abstraction env name var ty =
+let type_of_abstraction _env name var ty =
   mkProd (name, var, ty)
 
 (* Type of an application. *)
@@ -204,7 +204,7 @@ let sort_of_product env domsort rangsort =
 
   where j.uj_type is convertible to a sort s2
 *)
-let type_of_product env name s1 s2 =
+let type_of_product env _name s1 s2 =
   let s = sort_of_product env s1 s2 in
     mkSort s
 
@@ -247,7 +247,7 @@ let check_cast env c ct k expected_type =
    dynamic constraints of the form u<=v are enforced *)
 
 let type_of_inductive_knowing_parameters env (ind,u as indu) args =
-  let (mib,mip) as spec = lookup_mind_specif env ind in
+  let (mib,_mip) as spec = lookup_mind_specif env ind in
   check_hyps_inclusion env mkIndU indu mib.mind_hyps;
   let t,cst = Inductive.constrained_type_of_inductive_knowing_parameters 
     env (spec,u) args
@@ -264,7 +264,7 @@ let type_of_inductive env (ind,u as indu) =
 
 (* Constructors. *)
 
-let type_of_constructor env (c,u as cu) =
+let type_of_constructor env (c,_u as cu) =
   let () =
     let ((kn,_),_) = c in
     let mib = lookup_mind kn env in
@@ -285,7 +285,7 @@ let check_branch_types env (ind,u) c ct lft explft =
     | Invalid_argument _ ->
         error_number_branches env (make_judge c ct) (Array.length explft)
 
-let type_of_case env ci p pt c ct lf lft =
+let type_of_case env ci p pt c ct _lf lft =
   let (pind, _ as indspec) =
     try find_rectype env ct
     with Not_found -> error_case_not_inductive env (make_judge c ct) in
@@ -399,7 +399,7 @@ let rec execute env cstr =
         let lft = execute_array env lf in
           type_of_case env ci p pt c ct lf lft
 
-    | Fix ((vn,i as vni),recdef) ->
+    | Fix ((_vn,i as vni),recdef) ->
       let (fix_ty,recdef') = execute_recdef env recdef i in
       let fix = (vni,recdef') in
         check_fix env fix; fix_ty
@@ -509,7 +509,7 @@ let judge_of_product env x varj outj =
   make_judge (mkProd (x, varj.utj_val, outj.utj_val))
              (mkSort (sort_of_product env varj.utj_type outj.utj_type))
 
-let judge_of_letin env name defj typj j =
+let judge_of_letin _env name defj typj j =
   make_judge (mkLetIn (name, defj.uj_val, typj.utj_val, j.uj_val))
              (subst1 defj.uj_val j.uj_type)
 

--- a/kernel/uGraph.ml
+++ b/kernel/uGraph.ml
@@ -194,7 +194,7 @@ let check_universes_invariants g =
   UMap.iter (fun l u ->
     match u with
     | Canonical u ->
-      UMap.iter (fun v strict ->
+      UMap.iter (fun v _strict ->
           incr n_edges;
           let v = repr g v in
           assert (topo_compare u v = -1);
@@ -435,7 +435,7 @@ let reorder g u v =
     | n0::q0 ->
       (* Computing new root. *)
       let root, rank_rest =
-        List.fold_left (fun ((best, rank_rest) as acc) n ->
+        List.fold_left (fun ((best, _rank_rest) as acc) n ->
           if n.rank >= best.rank then n, best.rank else acc)
           (n0, min_int) q0
       in
@@ -760,7 +760,7 @@ let normalize_universes g =
   in
   UMap.fold (fun _ u g ->
     match u with
-    | Equiv u -> g
+    | Equiv _u -> g
     | Canonical u ->
       let _, u, g = get_ltle g u in
       let _, _, g = get_gtge g u in

--- a/kernel/vars.ml
+++ b/kernel/vars.ml
@@ -66,7 +66,7 @@ let isMeta c = match Constr.kind c with
 let noccur_with_meta n m term =
   let rec occur_rec n c = match Constr.kind c with
     | Constr.Rel p -> if n<=p && p<n+m then raise LocalOccur
-    | Constr.App(f,cl) ->
+    | Constr.App(f,_cl) ->
         (match Constr.kind f with
            | Constr.Cast (c,_,_) when isMeta c -> ()
            | Constr.Meta _ -> ()
@@ -188,7 +188,7 @@ let adjust_rel_to_rel_context sign n =
     let open RelDecl in
     match sign with
     | LocalAssum _ :: sign' -> let (n',p) = aux sign' in (n'+1,p)
-    | LocalDef (_,c,_)::sign' -> let (n',p) = aux sign' in (n'+1,if n'<n then p+1 else p)
+    | LocalDef (_,_c,_)::sign' -> let (n',p) = aux sign' in (n'+1,if n'<n then p+1 else p)
     | [] -> (0,n)
   in snd (aux sign)
 

--- a/kernel/vconv.ml
+++ b/kernel/vconv.ml
@@ -14,7 +14,7 @@ let val_of_constr env c =
 let compare_zipper z1 z2 =
   match z1, z2 with
   | Zapp args1, Zapp args2 -> Int.equal (nargs args1) (nargs args2)
-  | Zfix(f1,args1), Zfix(f2,args2) ->  Int.equal (nargs args1) (nargs args2)
+  | Zfix(_f1,args1), Zfix(_f2,args2) ->  Int.equal (nargs args1) (nargs args2)
   | Zswitch _, Zswitch _ | Zproj _, Zproj _ -> true
   | Zapp _ , _ | Zfix _, _ | Zswitch _, _ | Zproj _, _ -> false
 
@@ -84,10 +84,10 @@ and conv_whd env pb k whd1 whd2 cu =
   | Vconstr_block _, _ | Vatom_stk _, _ -> raise NotConvertible
 
 
-and conv_atom env pb k a1 stk1 a2 stk2 cu =
+and conv_atom env _pb k a1 stk1 a2 stk2 cu =
 (*  Pp.(msg_debug (str "conv_atom(" ++ pr_atom a1 ++ str ", " ++ pr_atom a2 ++ str ")")) ; *)
   match a1, a2 with
-  | Aind ((mi,i) as ind1) , Aind ind2 ->
+  | Aind ((mi,_i) as ind1) , Aind ind2 ->
     if eq_ind ind1 ind2 && compare_stack stk1 stk2 then
       if Environ.polymorphic_ind ind1 env then
         let mib = Environ.lookup_mind mi env in

--- a/lib/cErrors.ml
+++ b/lib/cErrors.ml
@@ -20,7 +20,7 @@ exception Anomaly of string option * Pp.t (* System errors *)
 
 let _ =
   let pr = function
-  | Anomaly (s, pp) -> Some ("\"Anomaly: " ^ string_of_ppcmds pp ^ "\"")
+  | Anomaly (_, pp) -> Some ("\"Anomaly: " ^ string_of_ppcmds pp ^ "\"")
   | _ -> None
   in
   Printexc.register_printer pr

--- a/lib/cProfile.ml
+++ b/lib/cProfile.ml
@@ -68,7 +68,7 @@ let create_record () = {
 let ajoute_totalloc e dw = e.totalloc <- e.totalloc +. dw
 let ajoute_ownalloc e dw = e.ownalloc <- e.ownalloc +. dw
 
-let reset_record (n,e) =
+let reset_record (_,e) =
   e.owntime <- 0;
   e.tottime <- 0;
   e.ownalloc <- 0.0;
@@ -348,7 +348,7 @@ let close_profile print =
 	  let updated_data =
 	    match !recording_file with
 	      |	"" -> current_data
-	      | name -> merge_profile !recording_file current_data
+	      | _name -> merge_profile !recording_file current_data
 	  in
 	  if print then format_profile updated_data;
 	  init_profile ()

--- a/lib/cWarnings.ml
+++ b/lib/cWarnings.ml
@@ -95,7 +95,7 @@ let split_flags s =
     "all" flag, and reverses the list. *)
 let rec cut_before_all_rev acc = function
   | [] -> acc
-  | (status,name as w) :: warnings ->
+  | (_status,name as w) :: warnings ->
     let acc =
       if is_all_keyword name then [w]
       else if is_none_keyword name then [(Disabled,"all")]
@@ -124,6 +124,7 @@ let uniquize_flags_rev flags =
 (** [normalize_flags] removes redundant warnings. Unknown warnings are kept
     because they may be declared in a plugin that will be linked later. *)
 let normalize_flags ~silent warnings =
+  ignore(silent);
   let warnings = cut_before_all_rev warnings in
   uniquize_flags_rev warnings
 

--- a/lib/coqProject_file.ml4
+++ b/lib/coqProject_file.ml4
@@ -92,7 +92,7 @@ and parse_string2 = parser
   | [< >] -> raise (Parsing_error "unterminated string")
 and parse_skip_comment = parser
   | [< ''\n'; s >] -> s
-  | [< 'c; s >] -> parse_skip_comment s
+  | [< '_; s >] -> parse_skip_comment s
   | [< >] -> [< >]
 and parse_args = parser
   | [< '' ' | '\n' | '\t'; s >] -> parse_args s

--- a/lib/envars.ml
+++ b/lib/envars.ml
@@ -74,7 +74,7 @@ let expand_path_macros ~warn s =
 	  in
 	  let s = v^(String.sub s n (l-n)) in
 	  expand_macros s (String.length v)
-	| c -> expand_macros s (i+1)
+	| _ -> expand_macros s (i+1)
   in expand_macros s 0
 
 (** {1 Paths} *)

--- a/lib/genarg.ml
+++ b/lib/genarg.ml
@@ -133,7 +133,7 @@ let out_gen (type a) (type l) (t : (a, l) abstract_argument_type) (o : l generic
   | None -> failwith "out_gen"
   | Some Refl -> v
 
-let has_type (GenArg (t, v)) u = match abstract_argument_type_eq t u with
+let has_type (GenArg (t, _v)) u = match abstract_argument_type_eq t u with
 | None -> false
 | Some _ -> true
 

--- a/lib/pp.ml
+++ b/lib/pp.ml
@@ -170,7 +170,7 @@ let rec pr_com ft s =
 (* pretty printing functions *)
 let pp_with ft pp =
   let cpp_open_box = function
-    | Pp_hbox n   -> Format.pp_open_hbox ft ()
+    | Pp_hbox _   -> Format.pp_open_hbox ft ()
     | Pp_vbox n   -> Format.pp_open_vbox ft n
     | Pp_hvbox n  -> Format.pp_open_hvbox ft n
     | Pp_hovbox n -> Format.pp_open_hovbox ft n

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -39,7 +39,7 @@ let is_blank = function
 module Empty =
 struct
   type t
-  let abort (x : t) = assert false
+  let abort (_x : t) = assert false
 end
 
 (* Strings *)

--- a/library/declaremods.ml
+++ b/library/declaremods.ml
@@ -72,7 +72,7 @@ module ModSubstObjs :
    let table =
      Summary.ref (MPmap.empty : substitutive_objects MPmap.t)
        ~name:"MODULE-SUBSTOBJS"
-   let missing_handler = ref (fun mp -> assert false)
+   let missing_handler = ref (fun _mp -> assert false)
    let set_missing_handler f = (missing_handler := f)
    let set mp objs = (table := MPmap.add mp objs !table)
    let get mp =
@@ -325,7 +325,7 @@ let rec register_mod_objs mp (id,obj) = match object_tag obj with
   | _ -> ()
 
 let handle_missing_substobjs mp = match mp with
-  | MPdot (mp',l) ->
+  | MPdot (mp',_l) ->
     let objs = expand_sobjs (ModSubstObjs.get mp') in
     List.iter (register_mod_objs mp') objs;
     ModSubstObjs.get mp
@@ -355,7 +355,7 @@ let get_applications mexpr =
 let rec compute_subst env mbids sign mp_l inl =
   match mbids,mp_l with
     | _,[] -> mbids,empty_subst
-    | [],r -> user_err Pp.(str "Application of a functor with too few arguments.")
+    | [],_r -> user_err Pp.(str "Application of a functor with too few arguments.")
     | mbid::mbids,mp::mp_l ->
 	let farg_id, farg_b, fbody_b = Modops.destr_functor sign in
 	let mb = Environ.lookup_module mp env in
@@ -595,7 +595,7 @@ let start_module interp_modast export id args res fs =
   mp
 
 let end_module () =
-  let oldoname,oldprefix,fs,lib_stack = Lib.end_module () in
+  let oldoname,_oldprefix,fs,lib_stack = Lib.end_module () in
   let substitute, keep, special = Lib.classify_segment lib_stack in
   let m_info = !openmod_info in
 
@@ -713,7 +713,7 @@ let start_modtype interp_modast id args mtys fs =
   mp
 
 let end_modtype () =
-  let oldoname,prefix,fs,lib_stack = Lib.end_modtype () in
+  let oldoname,_prefix,fs,lib_stack = Lib.end_modtype () in
   let id = basename (fst oldoname) in
   let substitute, _, special = Lib.classify_segment lib_stack in
   let sub_mty_l = !openmodtype_info in
@@ -918,7 +918,7 @@ let end_library ?except dir =
   !end_library_hook();
   let oname = Lib.end_compilation_checks dir in
   let mp,cenv,ast = Global.export ?except dir in
-  let prefix, lib_stack = Lib.end_compilation oname in
+  let _prefix, lib_stack = Lib.end_compilation oname in
   assert (ModPath.equal mp (MPfile dir));
   let substitute, keep, _ = Lib.classify_segment lib_stack in
   cenv,(substitute,keep),ast

--- a/library/global.ml
+++ b/library/global.ml
@@ -187,11 +187,11 @@ let constr_of_global_in_context env r =
     let univs = Declareops.constant_polymorphic_context cb in
     mkConstU (c, Univ.make_abstract_instance univs), univs
   | IndRef ind ->
-    let (mib, oib as specif) = Inductive.lookup_mind_specif env ind in
+    let (mib, _oib as _specif) = Inductive.lookup_mind_specif env ind in
     let univs = Declareops.inductive_polymorphic_context mib in
     mkIndU (ind, Univ.make_abstract_instance univs), univs
   | ConstructRef cstr ->
-    let (mib,oib as specif) =
+    let (mib, _oib as _specif) =
       Inductive.lookup_mind_specif env (inductive_of_constructor cstr)
     in
     let univs = Declareops.inductive_polymorphic_context mib in
@@ -205,13 +205,13 @@ let type_of_global_in_context env r =
     let univs = Declareops.constant_polymorphic_context cb in
     cb.Declarations.const_type, univs
   | IndRef ind ->
-    let (mib, oib as specif) = Inductive.lookup_mind_specif env ind in
+    let (mib, _oib as specif) = Inductive.lookup_mind_specif env ind in
     let univs = Declareops.inductive_polymorphic_context mib in
     let inst = Univ.make_abstract_instance univs in
     let env = Environ.push_context ~strict:false (Univ.AUContext.repr univs) env in
     Inductive.type_of_inductive env (specif, inst), univs
   | ConstructRef cstr ->
-    let (mib,oib as specif) =
+    let (mib, _oib as specif) =
       Inductive.lookup_mind_specif env (inductive_of_constructor cstr) 
     in
     let univs = Declareops.inductive_polymorphic_context mib in
@@ -220,15 +220,15 @@ let type_of_global_in_context env r =
 
 let universes_of_global env r = 
     match r with
-    | VarRef id -> Univ.AUContext.empty
+    | VarRef _id -> Univ.AUContext.empty
     | ConstRef c -> 
       let cb = Environ.lookup_constant c env in 
       Declareops.constant_polymorphic_context cb
     | IndRef ind ->
-      let (mib, oib) = Inductive.lookup_mind_specif env ind in
+      let (mib, _oib) = Inductive.lookup_mind_specif env ind in
       Declareops.inductive_polymorphic_context mib
     | ConstructRef cstr ->
-      let (mib,oib) = 
+      let (mib, _oib) = 
         Inductive.lookup_mind_specif env (inductive_of_constructor cstr) in
       Declareops.inductive_polymorphic_context mib
 
@@ -238,7 +238,7 @@ let universes_of_global gr =
 let is_polymorphic r =
   let env = env() in 
   match r with
-  | VarRef id -> false
+  | VarRef _id -> false
   | ConstRef c -> Environ.polymorphic_constant c env
   | IndRef ind -> Environ.polymorphic_ind ind env
   | ConstructRef cstr -> Environ.polymorphic_ind (inductive_of_constructor cstr) env
@@ -246,15 +246,15 @@ let is_polymorphic r =
 let is_template_polymorphic r = 
   let env = env() in 
   match r with
-  | VarRef id -> false
-  | ConstRef c -> false
+  | VarRef _id -> false
+  | ConstRef _c -> false
   | IndRef ind -> Environ.template_polymorphic_ind ind env
   | ConstructRef cstr -> Environ.template_polymorphic_ind (inductive_of_constructor cstr) env
 
 let is_type_in_type r =
   let env = env() in
   match r with
-  | VarRef id -> false
+  | VarRef _id -> false
   | ConstRef c -> Environ.type_in_type_constant c env
   | IndRef ind -> Environ.type_in_type_ind ind env
   | ConstructRef cstr -> Environ.type_in_type_ind (inductive_of_constructor cstr) env

--- a/library/globnames.ml
+++ b/library/globnames.ml
@@ -45,15 +45,15 @@ let subst_constructor subst (ind,j as ref) =
     else (ind',j), mkConstruct (ind',j)
 
 let subst_global_reference subst ref = match ref with
-  | VarRef var -> ref
+  | VarRef _var -> ref
   | ConstRef kn ->
     let kn' = subst_constant subst kn in
       if kn==kn' then ref else ConstRef kn'
   | IndRef ind ->
     let ind' = subst_ind subst ind in
       if ind==ind' then ref else IndRef ind'
-  | ConstructRef ((kn,i),j as c) ->
-    let c',t = subst_constructor subst c in
+  | ConstructRef ((_kn,_i),_j as c) ->
+    let c',_t = subst_constructor subst c in
       if c'==c then ref else ConstructRef c'
 
 let subst_global subst ref = match ref with
@@ -64,7 +64,7 @@ let subst_global subst ref = match ref with
   | IndRef ind ->
       let ind' = subst_ind subst ind in
       if ind==ind' then ref, mkInd ind else IndRef ind', mkInd ind'
-  | ConstructRef ((kn,i),j as c) ->
+  | ConstructRef ((_kn,_i),_j as c) ->
       let c',t = subst_constructor subst c in
 	if c'==c then ref,t else ConstructRef c', t
 
@@ -75,9 +75,9 @@ let canonical_gr = function
   | VarRef id -> VarRef id
 
 let global_of_constr c = match kind c with
-  | Const (sp,u) -> ConstRef sp
-  | Ind (ind_sp,u) -> IndRef ind_sp
-  | Construct (cstr_cp,u) -> ConstructRef cstr_cp
+  | Const (sp,_u) -> ConstRef sp
+  | Ind (ind_sp,_u) -> IndRef ind_sp
+  | Construct (cstr_cp,_u) -> ConstructRef cstr_cp
   | Var id -> VarRef id
   |  _ -> raise Not_found
 
@@ -244,4 +244,4 @@ let pop_global_reference = function
   | ConstRef con -> ConstRef (pop_con con)
   | IndRef (kn,i) -> IndRef (pop_kn kn,i)
   | ConstructRef ((kn,i),j) -> ConstructRef ((pop_kn kn,i),j)
-  | VarRef id -> anomaly (Pp.str "VarRef not poppable.")
+  | VarRef _id -> anomaly (Pp.str "VarRef not poppable.")

--- a/library/heads.ml
+++ b/library/heads.ml
@@ -172,9 +172,9 @@ let subst_head (subst,(ref,k)) =
 let discharge_head (_,(ref,k)) =
   match ref with
   | EvalConstRef cst -> Some (EvalConstRef (pop_con cst), k)
-  | EvalVarRef id -> None
+  | EvalVarRef _id -> None
 
-let rebuild_head (ref,k) =
+let rebuild_head (ref,_k) =
   (ref, compute_head ref)
 
 type head_obj = evaluable_global_reference * head_approximation

--- a/library/keys.ml
+++ b/library/keys.ml
@@ -63,7 +63,7 @@ module Keyset = Keymap.Set
 let keys = Summary.ref Keymap.empty ~name:"Keys_decl"
 
 let add_kv k v m =
-  try Keymap.modify k (fun k' vs -> Keyset.add v vs) m
+  try Keymap.modify k (fun _k' vs -> Keyset.add v vs) m
   with Not_found -> Keymap.add k (Keyset.singleton v) m
 
 let add_keys k v = 
@@ -122,8 +122,8 @@ let constr_key kind c =
     let rec aux k = 
       match kind k with
       | Const (c, _) -> KGlob (ConstRef c)
-      | Ind (i, u) -> KGlob (IndRef i)
-      | Construct (c,u) -> KGlob (ConstructRef c)
+      | Ind (i, _u) -> KGlob (IndRef i)
+      | Construct (c,_u) -> KGlob (ConstructRef c)
       | Var id -> KGlob (VarRef id)
       | App (f, _) -> aux f
       | Proj (p, _) -> KGlob (ConstRef (Names.Projection.constant p))

--- a/library/lib.ml
+++ b/library/lib.ml
@@ -63,7 +63,7 @@ let subst_objects subst seg =
 let classify_segment seg =
   let rec clean ((substl,keepl,anticipl) as acc) = function
     | (_,CompilingLibrary _) :: _ | [] -> acc
-    | ((sp,kn),Leaf o) :: stk ->
+    | ((_sp,kn),Leaf o) :: stk ->
 	let id = Names.Label.to_id (Names.KerName.label kn) in
 	  (match classify_object o with
 	     | Dispose -> clean acc stk
@@ -148,9 +148,9 @@ let make_oname id = Libnames.make_oname !lib_state.path_prefix id
 
 let recalc_path_prefix () =
   let rec recalc = function
-    | (sp, OpenedSection (dir,_)) :: _ -> dir
-    | (sp, OpenedModule (_,_,dir,_)) :: _ -> dir
-    | (sp, CompilingLibrary dir) :: _ -> dir
+    | (_sp, OpenedSection (dir,_)) :: _ -> dir
+    | (_sp, OpenedModule (_,_,dir,_)) :: _ -> dir
+    | (_sp, CompilingLibrary dir) :: _ -> dir
     | _::l -> recalc l
     | [] -> initial_prefix
   in
@@ -187,8 +187,8 @@ let split_lib_gen test =
       	if test hd
 	then Some (collect after [hd] before)
 	else (match hd with
-		| (sp,ClosedModule  seg)
-		| (sp,ClosedSection seg) ->
+		| (_sp,ClosedModule  seg)
+		| (_sp,ClosedSection seg) ->
 		    (match findeq after seg with
 		       | None -> findeq (hd::after) before
 		       | Some (sub_after,sub_equal,sub_before) ->
@@ -279,7 +279,7 @@ let is_opening_node_or_lib = function
 
 let current_mod_id () =
   try match find_entry_p is_opening_node_or_lib with
-    | oname,OpenedModule (_,_,_,fs) -> basename (fst oname)
+    | oname,OpenedModule (_,_,_,_fs) -> basename (fst oname)
     | oname,CompilingLibrary _ -> basename (fst oname)
     | _ -> user_err Pp.(str "you are not in a module")
   with Not_found -> user_err Pp.(str "no opened modules")
@@ -359,7 +359,7 @@ let end_compilation_checks dir =
   in
   let oname =
     try match find_entry_p is_opening_lib with
-      |	(oname, CompilingLibrary prefix) -> oname
+      |	(oname, CompilingLibrary _prefix) -> oname
       | _ -> assert false
     with Not_found -> anomaly (Pp.str "No module declared.")
   in
@@ -374,7 +374,7 @@ let end_compilation_checks dir =
   oname
 
 let end_compilation oname =
-  let (after,mark,before) = split_lib_at_opening oname in
+  let (after,_mark,_before) = split_lib_at_opening oname in
   lib_state := { !lib_state with comp_name = None };
   !lib_state.path_prefix,after
 
@@ -620,7 +620,7 @@ let init () =
 (* Misc *)
 
 let mp_of_global = function
-  | VarRef id -> !lib_state.path_prefix.obj_mp
+  | VarRef _id -> !lib_state.path_prefix.obj_mp
   | ConstRef cst -> Names.Constant.modpath cst
   | IndRef ind -> Names.ind_modpath ind
   | ConstructRef constr -> Names.constr_modpath constr
@@ -638,7 +638,7 @@ let rec split_modpath = function
     (dp, Names.Label.to_id l :: ids)
 
 let library_part = function
-  |VarRef id -> library_dp ()
+  |VarRef _id -> library_dp ()
   |ref -> dp_of_mp (mp_of_global ref)
 
 (************************)

--- a/library/libnames.ml
+++ b/library/libnames.ml
@@ -199,17 +199,21 @@ let qualid_of_reference = CAst.map (function
   | Qualid qid -> qid
   | Ident id -> qualid_of_ident id)
 
-let string_of_reference = CAst.with_val (function
-  | Qualid qid -> string_of_qualid qid
-  | Ident id -> Id.to_string id)
+let string_of_reference = function
+  | Qualid (_loc,qid) -> string_of_qualid qid
+  | Ident (_loc,id) -> Id.to_string id
 
 let pr_reference = CAst.with_val (function
   | Qualid qid -> pr_qualid qid
   | Ident id -> Id.print id)
 
-let eq_reference {CAst.v=r1} {CAst.v=r2} = match r1, r2 with
-| Qualid q1, Qualid q2 -> qualid_eq q1 q2
-| Ident id1, Ident id2 -> Id.equal id1 id2
+let loc_of_reference = function
+  | Qualid (loc,_qid) -> loc
+  | Ident (loc,_id) -> loc
+
+let eq_reference r1 r2 = match r1, r2 with
+| Qualid (_, q1), Qualid (_, q2) -> qualid_eq q1 q2
+| Ident (_, id1), Ident (_, id2) -> Id.equal id1 id2
 | _ -> false
 
 let join_reference {CAst.loc=l1;v=ns} {CAst.loc=l2;v=r} =

--- a/library/libobject.ml
+++ b/library/libobject.ml
@@ -98,7 +98,7 @@ let declare_object_full odecl = declare_object_full odecl
 (* this function describes how the cache, load, open, and export functions
    are triggered. *)
 
-let apply_dyn_fun deflt f lobj =
+let apply_dyn_fun _deflt f lobj =
   let tag = object_tag lobj in
   let dodecl =
     try Hashtbl.find cache_tab tag

--- a/library/library.ml
+++ b/library/library.ml
@@ -167,7 +167,7 @@ let opened_libraries () = !libraries_imports_list
 
 let register_loaded_library m =
   let libname = m.libsum_name in
-  let link m =
+  let link _m =
     let dirname = Filename.dirname (library_full_filename libname) in
     let prefix = Nativecode.mod_uid_of_dirpath libname ^ "." in
     let f = prefix ^ "cmo" in
@@ -296,7 +296,7 @@ let locate_absolute_library dir =
   | [vo;vi] when Unix.((stat vo).st_mtime < (stat vi).st_mtime) ->
     warn_several_object_files (vi, vo);
     vi
-  | [vo;vi] -> vo
+  | [vo;_vi] -> vo
   | _ -> assert false
 
 let locate_qualified_library ?root ?(warn = true) qid =
@@ -315,7 +315,7 @@ let locate_qualified_library ?root ?(warn = true) qid =
     match find ".vo" @ find ".vio" with
     | [] -> raise LibNotFound
     | [lpath, file] -> lpath, file
-    | [lpath_vo, vo; lpath_vi, vi]
+    | [_lpath_vo, vo; lpath_vi, vi]
       when Unix.((stat vo).st_mtime < (stat vi).st_mtime) ->
       warn_several_object_files (vi, vo);
        lpath_vi, vi
@@ -431,7 +431,7 @@ let mk_summary m = {
 
 let intern_from_file f =
   let ch = raw_intern_library f in
-  let (lsd : seg_sum), _, digest_lsd = System.marshal_in_segment f ch in
+  let (lsd : seg_sum), _, _digest_lsd = System.marshal_in_segment f ch in
   let ((lmd : seg_lib delayed), digest_lmd) = in_delayed f ch in
   let (univs : seg_univ option), _, digest_u = System.marshal_in_segment f ch in
   let _ = System.skip_in_segment f ch in
@@ -489,7 +489,7 @@ let rec_intern_library libs (dir, f) =
 
 let native_name_from_filename f =
   let ch = raw_intern_library f in
-  let (lmd : seg_sum), pos, digest_lmd = System.marshal_in_segment f ch in
+  let (lmd : seg_sum), _pos, _digest_lmd = System.marshal_in_segment f ch in
   Nativecode.mod_uid_of_dirpath lmd.md_name
 
 (**********************************************************************)
@@ -523,10 +523,10 @@ let register_library m =
    - called at module or module type closing when a Require occurs in
      the module or module type
    - not called from a library (i.e. a module identified with a file) *)
-let load_require _ (_,(needed,modl,_)) =
+let load_require _ (_,(needed,_modl,_)) =
   List.iter register_library needed
 
-let open_require i (_,(_,modl,export)) =
+let open_require _i (_,(_,modl,export)) =
   Option.iter (fun exp -> open_libraries exp (List.map find_library modl))
     export
 

--- a/library/nametab.ml
+++ b/library/nametab.ml
@@ -195,14 +195,14 @@ let find_node qid tab =
 
 let locate qid tab =
   let o = match find_node qid tab with
-    | Absolute (uname,o) | Relative (uname,o) -> o
+    | Absolute (_uname,o) | Relative (_uname,o) -> o
     | Nothing -> raise Not_found
   in
     o
 
 let user_name qid tab =
   let uname = match find_node qid tab with
-    | Absolute (uname,o) | Relative (uname,o) -> uname
+    | Absolute (uname,_o) | Relative (uname,_o) -> uname
     | Nothing -> raise Not_found
   in
     uname
@@ -542,9 +542,10 @@ let pr_global_env env ref =
 let global_inductive ({CAst.loc; v=r} as lr) =
   match global lr with
   | IndRef ind -> ind
-  | ref ->
-      user_err ?loc ~hdr:"global_inductive"
-        (pr_reference lr ++ spc () ++ str "is not an inductive type")
+  | _ref ->
+      user_err ?loc:(loc_of_reference r) ~hdr:"global_inductive"
+        (pr_reference r ++ spc () ++ str "is not an inductive type")
+
 
 (********************************************************************)
 

--- a/library/summary.ml
+++ b/library/summary.ml
@@ -157,7 +157,7 @@ let surgery_summary { summaries; ml_module } bits =
     String.Map.fold (fun hash state sum -> String.Map.set hash state sum ) summaries bits in
   { summaries; ml_module }
 
-let project_summary { summaries; ml_module } ?(complement=false) ids =
+let project_summary { summaries; _ } ?(complement=false) ids =
   String.Map.filter (fun name _ -> complement <> List.(mem name ids)) summaries
 
 let pointer_equal l1 l2 =

--- a/parsing/egramcoq.ml
+++ b/parsing/egramcoq.ml
@@ -120,7 +120,7 @@ let find_position_gen current ensure assoc lev =
 
 let rec list_mem_assoc_triple x = function
   | [] -> false
-  | (a,b,c) :: l -> Int.equal a x || list_mem_assoc_triple x l
+  | (a,_b,_c) :: l -> Int.equal a x || list_mem_assoc_triple x l
 
 let register_empty_levels accu forpat levels =
   let rec filter accu = function
@@ -198,16 +198,16 @@ let adjust_level assoc from = function
   | (NumLevel n,BorderProd (_,None)) -> Some (Some (n,true))
 (* Compute production name on the right side *)
   (* If NonA or LeftA on the right-hand side, set to NEXT *)
-  | (NumLevel n,BorderProd (Right,Some (NonA|LeftA))) ->
+  | (NumLevel _n,BorderProd (Right,Some (NonA|LeftA))) ->
       Some None
   (* If RightA on the right-hand side, set to the explicit (current) level *)
   | (NumLevel n,BorderProd (Right,Some RightA)) ->
       Some (Some (n,true))
 (* Compute production name on the left side *)
   (* If NonA on the left-hand side, adopt the current assoc ?? *)
-  | (NumLevel n,BorderProd (Left,Some NonA)) -> None
+  | (NumLevel _n,BorderProd (Left,Some NonA)) -> None
   (* If the expected assoc is the current one, set to SELF *)
-  | (NumLevel n,BorderProd (Left,Some a)) when assoc_eq a (camlp5_assoc assoc) ->
+  | (NumLevel _n,BorderProd (Left,Some a)) when assoc_eq a (camlp4_assoc assoc) ->
       None
   (* Otherwise, force the level, n or n-1, according to expected assoc *)
   | (NumLevel n,BorderProd (Left,Some a)) ->
@@ -252,7 +252,7 @@ let target_entry : type s. s target -> s Gram.entry = function
 | ForPattern -> Constr.pattern
 
 let is_self from e = match e with
-| (NumLevel n, BorderProd (Right, _ (* Some(NonA|LeftA) *))) -> false
+| (NumLevel _n, BorderProd (Right, _ (* Some(NonA|LeftA) *))) -> false
 | (NumLevel n, BorderProd (Left, _)) -> Int.equal from n
 | _ -> false
 
@@ -282,7 +282,7 @@ let symbol_of_target : type s. _ -> _ -> _ -> s target -> (s, s) symbol = fun p 
     begin match lev with
     | None -> Aentry g
     | Some None -> Anext
-    | Some (Some (lev, cur)) -> Aentryl (g, lev)
+    | Some (Some (lev, _cur)) -> Aentryl (g, lev)
     end
 
 let symbol_of_entry : type s r. _ -> _ -> (s, r) entry -> (s, r) symbol = fun assoc from typ -> match typ with

--- a/parsing/egramml.ml
+++ b/parsing/egramml.ml
@@ -52,8 +52,8 @@ type 'r gen_eval = Loc.t -> raw_generic_argument list -> 'r
 
 let rec ty_eval : type s a. (s, a, Loc.t -> s) ty_rule -> s gen_eval -> a = function
 | TyStop -> fun f loc -> f loc []
-| TyNext (rem, tok, None) -> fun f _ -> ty_eval rem f
-| TyNext (rem, tok, Some inj) -> fun f x ->
+| TyNext (rem, _tok, None) -> fun f _ -> ty_eval rem f
+| TyNext (rem, _tok, Some inj) -> fun f x ->
   let f loc args = f loc (inj x :: args) in
   ty_eval rem f
 
@@ -79,6 +79,6 @@ let get_extend_vernac_rule (s, i) =
 let extend_vernac_command_grammar s nt gl =
   let nt = Option.default Vernac_.command nt in
   vernac_exts := (s,gl) :: !vernac_exts;
-  let mkact loc l = VernacExtend (s, l) in
+  let mkact _loc l = VernacExtend (s, l) in
   let rules = [make_rule mkact gl] in
   grammar_extend nt None (None, [None, None, rules])

--- a/parsing/g_constr.ml4
+++ b/parsing/g_constr.ml4
@@ -21,6 +21,7 @@ open Pcoq
 open Pcoq.Prim
 open Pcoq.Constr
 
+
 (* TODO: avoid this redefinition without an extra dep to Notation_ops *)
 let ldots_var = Id.of_string ".."
 
@@ -45,14 +46,14 @@ let binder_of_name expl { CAst.loc = loc; v = na } =
 let binders_of_names l =
   List.map (binder_of_name Explicit) l
 
-let mk_fixb (id,bl,ann,body,(loc,tyc)) : fix_expr =
+let mk_fixb (id,bl,ann,body,(_loc,tyc)) =
   let ty = match tyc with
       Some ty -> ty
     | None    -> CAst.make @@ CHole (None, IntroAnonymous, None) in
   (id,ann,bl,ty,body)
 
-let mk_cofixb (id,bl,ann,body,(loc,tyc)) : cofix_expr =
-  let _ = Option.map (fun { CAst.loc = aloc } ->
+let mk_cofixb (id,bl,ann,body,(_loc,tyc)) =
+  let _ = Option.map (fun (aloc,_) ->
     CErrors.user_err ?loc:aloc
       ~hdr:"Constr:mk_cofixb"
       (Pp.str"Annotation forbidden in cofix expression.")) (fst ann) in

--- a/plugins/cc/ccalgo.ml
+++ b/plugins/cc/ccalgo.ml
@@ -149,8 +149,8 @@ let rec term_equal t1 t2 =
     | Product (s1, t1), Product (s2, t2) -> family_eq s1 s2 && family_eq t1 t2
     | Eps i1, Eps i2 -> Id.equal i1 i2
     | Appli (t1, u1), Appli (t2, u2) -> term_equal t1 t2 && term_equal u1 u2
-    | Constructor {ci_constr=(c1,u1); ci_arity=i1; ci_nhyps=j1},
-      Constructor {ci_constr=(c2,u2); ci_arity=i2; ci_nhyps=j2} ->
+    | Constructor {ci_constr=(c1,_u1); ci_arity=i1; ci_nhyps=j1},
+      Constructor {ci_constr=(c2,_u2); ci_arity=i2; ci_nhyps=j2} ->
       Int.equal i1 i2 && Int.equal j1 j2 && eq_constructor c1 c2 (* FIXME check eq? *)
     | _ -> false
 
@@ -161,7 +161,7 @@ let rec hash_term = function
   | Product (s1, s2) -> combine3 2 (Sorts.hash s1) (Sorts.hash s2)
   | Eps i -> combine 3 (Id.hash i)
   | Appli (t1, t2) -> combine3 4 (hash_term t1) (hash_term t2)
-  | Constructor {ci_constr=(c,u); ci_arity=i; ci_nhyps=j} -> combine4 5 (constructor_hash c) i j
+  | Constructor {ci_constr=(c,_u); ci_arity=i; ci_nhyps=j} -> combine4 5 (constructor_hash c) i j
 
 type ccpattern =
     PApp of term * ccpattern list (* arguments are reversed *)
@@ -525,7 +525,7 @@ let rec add_term state t=
 		     constructors=PacMap.empty;
 		     vertex= Leaf;
 		     term= t}
-	      | Eps id ->
+	      | Eps _id ->
 		  {clas= Rep (new_representative typ);
 		   cpath= -1;
 		   constructors=PacMap.empty;
@@ -647,7 +647,7 @@ let eq_pair (i1, j1) (i2, j2) = Int.equal i1 i2 && Int.equal j1 j2
 let rec min_path=function
     ([],l2)->([],l2)
   | (l1,[])->(l1,[])
-  | (((c1,t1)::q1),((c2,t2)::q2)) when eq_pair c1 c2 -> min_path (q1,q2)
+  | (((c1,_t1)::q1),((c2,_t2)::q2)) when eq_pair c1 c2 -> min_path (q1,q2)
   | cpl -> cpl
 
 let join_path uf i j=
@@ -710,8 +710,8 @@ let merge eq state = (* merge and no-merge *)
 let update t state = (* update 1 and 2 *)
   debug
     (fun () -> str "Updating term " ++ pr_idx_term state.uf t ++ str ".");
-  let (i,j) as sign = signature state.uf t in
-  let (u,v) = subterms state.uf t in
+  let (i,_j) as sign = signature state.uf t in
+  let (_u,v) = subterms state.uf t in
   let rep = get_representative state.uf i in
     begin
       match rep.inductive_status with

--- a/plugins/cc/cctac.ml
+++ b/plugins/cc/cctac.ml
@@ -202,8 +202,8 @@ let make_prb gls depth additionnal_terms =
 	 begin
 	   let cid=Constr.mkVar id in
 	   match litteral_of_constr env sigma (NamedDecl.get_type decl) with
-	       `Eq (t,a,b) -> add_equality state cid a b
-	     | `Neq (t,a,b) -> add_disequality state (Hyp cid) a b
+	       `Eq (_t,a,b) -> add_equality state cid a b
+	     | `Neq (_t,a,b) -> add_disequality state (Hyp cid) a b
 	     | `Other ph ->
 		 List.iter
 		   (fun (cidn,nh) ->
@@ -221,7 +221,7 @@ let make_prb gls depth additionnal_terms =
 	 end) (Proofview.Goal.hyps gls);
     begin
       match atom_of_constr env sigma (pf_concl gls) with
-	  `Eq (t,a,b) -> add_disequality state Goal a b
+	  `Eq (_t,a,b) -> add_disequality state Goal a b
 	|	`Other g ->
 		  List.iter
 	      (fun (idp,ph) ->
@@ -400,7 +400,7 @@ let convert_to_hyp_tac c1 t1 c2 t2 p =
   end
 
 (* Essentially [assert (Heq : lhs = rhs) by proof_tac p; discriminate Heq] *)
-let discriminate_tac cstru p =
+let discriminate_tac _cstru p =
   Proofview.Goal.enter begin fun gl ->
     let lhs=constr_of_term p.p_lhs and rhs=constr_of_term p.p_rhs in
     let env = Proofview.Goal.env gl in
@@ -525,7 +525,7 @@ let f_equal =
       begin match EConstr.kind sigma concl with
       | App (r,[|_;t;t'|]) when is_global sigma (Lazy.force _eq) r ->
 	  begin match EConstr.kind sigma t, EConstr.kind sigma t' with
-	  | App (f,v), App (f',v') when Int.equal (Array.length v) (Array.length v') ->
+	  | App (_f,v), App (_f',v') when Int.equal (Array.length v) (Array.length v') ->
 	      let rec cuts i =
 		if i < 0 then Tacticals.New.tclTRY (congruence_tac 1000 [])
 		else Tacticals.New.tclTHENFIRST (cut_eq v.(i) v'.(i)) (cuts (i-1))

--- a/plugins/firstorder/ground.ml
+++ b/plugins/firstorder/ground.ml
@@ -67,7 +67,7 @@ let ground_tac solver startseq =
 		      | Ror->
 			  or_tac  backtrack continue (re_add seq1)
 		      | Rfalse->backtrack
-		      | Rexists(i,dom,triv)->
+		      | Rexists(_i,_dom,_triv)->
 			  let (lfp,seq2)=collect_quantified (project gl) seq in
 			  let backtrack2=toptac (lfp@skipped) seq2 in
 			    if  !qflag && seq.depth>0 then

--- a/plugins/firstorder/instances.ml
+++ b/plugins/firstorder/instances.ml
@@ -176,7 +176,7 @@ let left_instance_tac (inst,id) continue seq=
 
 let right_instance_tac inst continue seq=
   let open EConstr in
-  Proofview.Goal.enter begin fun gl ->
+  Proofview.Goal.enter begin fun _gl ->
   match inst with
       Phantom dom ->
 	tclTHENS (cut dom)
@@ -191,7 +191,7 @@ let right_instance_tac inst continue seq=
     | Real ((0,t),_) ->
 	(tclTHEN (split (ImplicitBindings [t]))
 	   (tclSOLVE [wrap 0 true continue (deepen seq)]))
-    | Real ((m,t),_) ->
+    | Real ((_m,_t),_) ->
 	tclFAIL 0 (Pp.str "not implemented ... yet")
   end
 

--- a/plugins/funind/glob_termops.ml
+++ b/plugins/funind/glob_termops.ml
@@ -23,6 +23,61 @@ let mkGHole ()          = DAst.make @@ GHole(Evar_kinds.BinderType Anonymous,Mis
   Some basic functions to decompose glob_constrs
   These are analogous to the ones constrs
 *)
+let glob_decompose_prod =
+  let rec glob_decompose_prod args c = match DAst.get c with
+  | GProd(n,_k,t,b) ->
+      glob_decompose_prod ((n,t)::args) b
+  | _ -> args,c
+  in
+  glob_decompose_prod []
+
+let glob_decompose_prod_or_letin =
+  let rec glob_decompose_prod args rt = match DAst.get rt with
+  | GProd(n,_k,t,b) ->
+      glob_decompose_prod ((n,None,Some t)::args) b
+  | GLetIn(n,b,t,c) ->
+      glob_decompose_prod ((n,Some b,t)::args) c
+  | _ -> args,rt
+  in
+  glob_decompose_prod []
+
+let glob_compose_prod =
+  List.fold_left (fun b (n,t) -> mkGProd(n,t,b))
+
+let glob_compose_prod_or_letin =
+  List.fold_left (
+      fun concl decl ->
+	match decl with
+	  | (n,None,Some t) -> mkGProd(n,t,concl)
+	  | (n,Some bdy,t) -> mkGLetIn(n,bdy,t,concl)
+	  | _ -> assert false)
+
+let glob_decompose_prod_n n =
+  let rec glob_decompose_prod i args c =
+    if i<=0 then args,c
+    else
+      match DAst.get c with
+	| GProd(n,_,t,b) ->
+	    glob_decompose_prod (i-1) ((n,t)::args) b
+	| _ -> args,c
+  in
+  glob_decompose_prod n []
+
+
+let glob_decompose_prod_or_letin_n n =
+  let rec glob_decompose_prod i args c =
+    if i<=0 then args,c
+    else
+      match DAst.get c with
+	| GProd(n,_,t,b) ->
+	    glob_decompose_prod (i-1) ((n,None,Some t)::args) b
+	| GLetIn(n,b,t,c) ->
+	    glob_decompose_prod (i-1) ((n,Some b,t)::args) c
+	| _ -> args,c
+  in
+  glob_decompose_prod n []
+
+
 let glob_decompose_app =
   let rec decompose_rapp acc rt =
 (*     msgnl (str "glob_decompose_app on : "++ Printer.pr_glob_constr rt); *)
@@ -174,7 +229,7 @@ let raw_get_pattern_id pat acc =
       | PatVar(Anonymous) -> assert false
       | PatVar(Name id) ->
 	  [id]
-      | PatCstr(constr,patternl,_) ->
+      | PatCstr(_constr,patternl,_) ->
 	  List.fold_right
 	  (fun pat idl ->
 	     let idl' = get_pattern_id pat in
@@ -298,8 +353,8 @@ let rec alpha_rt excluded rt =
   in
   new_rt
 
-and alpha_br excluded {CAst.loc;v=(ids,patl,res)} =
-  let new_patl,new_excluded,mapping = alpha_patl excluded patl in
+and alpha_br excluded (loc,(_ids,patl,res)) =
+  let new_patl,_new_excluded,mapping = alpha_patl excluded patl in
   let new_ids = List.fold_right raw_get_pattern_id new_patl [] in
   let new_excluded = new_ids@excluded in
   let renamed_res = change_vars mapping res in
@@ -310,7 +365,7 @@ and alpha_br excluded {CAst.loc;v=(ids,patl,res)} =
    [is_free_in id rt] checks if [id] is a free variable in [rt]
 *)
 let is_free_in id =
-  let rec is_free_in x = DAst.with_loc_val (fun ?loc -> function
+  let rec is_free_in x = DAst.with_val (function
     | GRef _ ->  false
     | GVar id' -> Id.compare id' id == 0
     | GEvar _ -> false
@@ -510,6 +565,97 @@ let ids_of_pat =
     )
   in
   ids_of_pat Id.Set.empty
+
+let id_of_name = function
+  | Anonymous -> Id.of_string "x"
+  | Name x -> x
+
+(* TODO: finish Rec caes *)
+let ids_of_glob_constr c =
+  let rec ids_of_glob_constr acc c =
+    let idof = id_of_name in
+    match DAst.get c with
+      | GVar id -> id::acc
+      | GApp (g,args) ->
+          ids_of_glob_constr [] g @ List.flatten (List.map (ids_of_glob_constr []) args) @ acc
+      | GLambda (na,_k,ty,c) -> idof na :: ids_of_glob_constr [] ty @ ids_of_glob_constr [] c @ acc
+      | GProd (na,_k,ty,c) -> idof na :: ids_of_glob_constr [] ty @ ids_of_glob_constr [] c @ acc
+      | GLetIn (na,b,t,c) -> idof na :: ids_of_glob_constr [] b @ Option.cata (ids_of_glob_constr []) [] t @ ids_of_glob_constr [] c @ acc
+      | GCast (c,(CastConv t|CastVM t|CastNative t)) -> ids_of_glob_constr [] c @ ids_of_glob_constr [] t @ acc
+      | GCast (c,CastCoerce) -> ids_of_glob_constr [] c @ acc
+      | GIf (c,(_na,_po),b1,b2) -> ids_of_glob_constr [] c @ ids_of_glob_constr [] b1 @ ids_of_glob_constr [] b2 @ acc
+      | GLetTuple (nal,(_na,_po),b,c) ->
+          List.map idof nal @ ids_of_glob_constr [] b @ ids_of_glob_constr [] c @ acc
+      | GCases (_sty,_rtntypopt,_tml,brchl) ->
+	  List.flatten (List.map (fun (_,(idl,_patl,c)) -> idl @ ids_of_glob_constr [] c) brchl)
+      | GRec _ -> failwith "Fix inside a constructor branch"
+      | (GSort _ | GHole _ | GRef _ | GEvar _ | GPatVar _) -> []
+  in
+  (* build the set *)
+  List.fold_left (fun acc x -> Id.Set.add x acc) Id.Set.empty (ids_of_glob_constr [] c)
+
+
+
+
+
+let zeta_normalize =
+  let rec zeta_normalize_term x = DAst.map (function
+      | GRef _
+      | GVar _
+      | GEvar _
+      | GPatVar _ as rt -> rt
+      | GApp(rt',rtl) ->
+	  GApp(zeta_normalize_term rt',
+	       List.map zeta_normalize_term rtl
+	      )
+      | GLambda(name,k,t,b) ->
+	  GLambda(name,
+		  k,
+		  zeta_normalize_term t,
+		  zeta_normalize_term b
+		 )
+      | GProd(name,k,t,b) ->
+	  GProd(name,
+	        k,
+		zeta_normalize_term t,
+		zeta_normalize_term b
+		 )
+      | GLetIn(Name id,def,_typ,b) ->
+	  DAst.get (zeta_normalize_term (replace_var_by_term id def b))
+      | GLetIn(Anonymous,_def,_typ,b) ->
+          DAst.get (zeta_normalize_term b)
+      | GLetTuple(nal,(na,rto),def,b) ->
+	  GLetTuple(nal,
+		    (na,Option.map zeta_normalize_term rto),
+		    zeta_normalize_term def,
+		    zeta_normalize_term b
+		   )
+      | GCases(sty,infos,el,brl) ->
+	  GCases(sty,
+		 infos,
+		 List.map (fun (e,x) -> (zeta_normalize_term e,x)) el,
+		 List.map zeta_normalize_br brl
+		)
+      | GIf(b,(na,e_option),lhs,rhs) ->
+	  GIf(zeta_normalize_term b,
+	      (na,Option.map zeta_normalize_term e_option),
+	      zeta_normalize_term lhs,
+	      zeta_normalize_term rhs
+	     )
+      | GRec _ -> raise (UserError(None,str "Not handled GRec"))
+      | GSort _
+      | GHole _ as rt -> rt
+      | GCast(b,c) ->
+	  GCast(zeta_normalize_term b,
+                Miscops.map_cast_type zeta_normalize_term c)
+    ) x
+  and zeta_normalize_br (loc,(idl,patl,res)) =
+    (loc,(idl,patl,zeta_normalize_term res))
+  in
+  zeta_normalize_term
+
+
+
 
 let expand_as =
 

--- a/plugins/funind/indfun_common.ml
+++ b/plugins/funind/indfun_common.ml
@@ -11,7 +11,7 @@ let mk_correct_id id = Nameops.add_suffix (mk_rel_id id) "_correct"
 let mk_complete_id id = Nameops.add_suffix (mk_rel_id id) "_complete"
 let mk_equation_id id = Nameops.add_suffix id "_equation"
 
-let msgnl m =
+let msgnl _m =
   ()
 
 let fresh_id avoid s = Namegen.next_ident_away_in_goal (Id.of_string s) (Id.Set.of_list avoid)
@@ -32,7 +32,7 @@ let id_of_name = function
   | _ -> raise Not_found
 
 let locate  ref =
-    let {CAst.v=qid} = qualid_of_reference ref in
+    let (_loc,qid) = qualid_of_reference ref in
     Nametab.locate qid
 
 let locate_ind ref =
@@ -69,7 +69,7 @@ let chop_rlambda_n  =
       then List.rev acc,rt
       else
 	match DAst.get rt with
-	  | Glob_term.GLambda(name,k,t,b) -> chop_lambda_n ((name,t,None)::acc) (n-1) b
+	  | Glob_term.GLambda(name,_k,t,b) -> chop_lambda_n ((name,t,None)::acc) (n-1) b
 	  | Glob_term.GLetIn(name,v,t,b) -> chop_lambda_n ((name,v,t)::acc) (n-1) b
 	  | _ ->
 	      raise (CErrors.UserError(Some "chop_rlambda_n",
@@ -83,7 +83,7 @@ let chop_rprod_n  =
       then List.rev acc,rt
       else
 	match DAst.get rt with
-	  | Glob_term.GProd(name,k,t,b) -> chop_prod_n ((name,t)::acc) (n-1) b
+	  | Glob_term.GProd(name,_k,t,b) -> chop_prod_n ((name,t)::acc) (n-1) b
 	  | _ -> raise (CErrors.UserError(Some "chop_rprod_n",str "chop_rprod_n: Not enough products"))
   in
   chop_prod_n []
@@ -332,7 +332,7 @@ let discharge_Function (_,finfos) =
 
 let pr_ocst c =
   let sigma, env = Pfedit.get_current_context () in
-  Option.fold_right (fun v acc -> Printer.pr_lconstr_env env sigma (mkConst v)) c (mt ())
+  Option.fold_right (fun v _acc -> Printer.pr_lconstr_env env sigma (mkConst v)) c (mt ())
 
 let pr_info f_info =
   let sigma, env = Pfedit.get_current_context () in
@@ -352,7 +352,7 @@ let pr_info f_info =
   str "graph_ind := " ++ Printer.pr_lconstr_env env sigma (mkInd f_info.graph_ind) ++ fnl ()
 
 let pr_table tb =
-  let l = Cmap_env.fold (fun k v acc -> v::acc) tb [] in
+  let l = Cmap_env.fold (fun _k v acc -> v::acc) tb [] in
   Pp.prlist_with_sep fnl pr_info l
 
 let in_Function : function_info -> Libobject.obj =
@@ -523,7 +523,7 @@ let decompose_lam_n sigma n =
 let lamn n env b =
   let open EConstr in
   let rec lamrec = function
-    | (0, env, b)        -> b
+    | (0, _env, b)        -> b
     | (n, ((v,t)::l), b) -> lamrec (n-1,  l, mkLambda (v,t,b))
     | _ -> assert false
   in
@@ -536,7 +536,7 @@ let compose_lam l b = lamn (List.length l) l b
 let prodn n env b =
   let open EConstr in
   let rec prodrec = function
-    | (0, env, b)        -> b
+    | (0, _env, b)        -> b
     | (n, ((v,t)::l), b) -> prodrec (n-1,  l, mkProd (v,t,b))
     | _ -> assert false
   in

--- a/plugins/ltac/evar_tactics.ml
+++ b/plugins/ltac/evar_tactics.ml
@@ -41,7 +41,7 @@ let instantiate_evar evk (ist,rawc) sigma =
 let evar_list sigma c =
   let rec evrec acc c =
     match EConstr.kind sigma c with
-    | Evar (evk, _ as ev) -> ev :: acc
+    | Evar (_evk, _ as ev) -> ev :: acc
     | _ -> EConstr.fold sigma evrec acc c in
   evrec [] c
 

--- a/plugins/ltac/profile_ltac.ml
+++ b/plugins/ltac/profile_ltac.ml
@@ -188,7 +188,7 @@ let to_string ~filter ?(cutoff=0.0) node =
   let all_total = M.fold (fun _ { total } a -> total +. a) node.children 0.0 in
   let flat_tree =
     let global = ref M.empty in
-    let find_tactic tname l =
+    let find_tactic tname _l =
       try M.find tname !global
       with Not_found ->
         let e = empty_treenode tname in
@@ -248,7 +248,7 @@ let string_of_call ck =
     (match ck with
        | Tacexpr.LtacNotationCall s -> Pptactic.pr_alias_key s
        | Tacexpr.LtacNameCall cst -> Pptactic.pr_ltac_constant cst
-       | Tacexpr.LtacVarCall (id, t) -> Names.Id.print id
+       | Tacexpr.LtacVarCall (id, _t) -> Names.Id.print id
        | Tacexpr.LtacAtomCall te ->
          (Pptactic.pr_glob_tactic (Global.env ())
             (Tacexpr.TacAtom (Loc.tag te)))
@@ -289,7 +289,7 @@ let merge_roots ?(disjoint=true) t1 t2 =
 let rec find_in_stack what acc = function
   | [] -> None
   | { name } as x :: rest when String.equal name what -> Some(acc, x, rest)
-  | { name } as x :: rest -> find_in_stack what (x :: acc) rest
+  | x :: rest -> find_in_stack what (x :: acc) rest
 
 let exit_tactic ~count_call start_time c =
   let diff = time () -. start_time in
@@ -343,7 +343,7 @@ let tclFINALLY tac (finally : unit Proofview.tactic) =
     (fun v -> finally <*> Proofview.tclUNIT v)
     (fun (exn, info) -> finally <*> Proofview.tclZERO ~info exn)
 
-let do_profile s call_trace ?(count_call=true) tac =
+let do_profile _s call_trace tac =
   let open Proofview.Notations in
   Proofview.tclLIFT (Proofview.NonLogical.make (fun () ->
   if !is_profiling then

--- a/plugins/ltac/taccoerce.ml
+++ b/plugins/ltac/taccoerce.ml
@@ -163,7 +163,7 @@ let coerce_var_to_ident fresh env sigma v =
 (* Interprets, if possible, a constr to an identifier which may not
    be fresh but suitable to be given to the fresh tactic. Works for
    vars, constants, inductive, constructors and sorts. *)
-let coerce_to_ident_not_fresh env sigma v =
+let coerce_to_ident_not_fresh _env sigma v =
 let g = sigma in
 let id_of_name = function
   | Name.Anonymous -> Id.of_string "x"
@@ -205,7 +205,8 @@ let id_of_name = function
        | _ -> fail()
 
 
-let coerce_to_intro_pattern env sigma v =
+let coerce_to_intro_pattern _env sigma v =
+  let v = Value.normalize v in
   if has_type v (topwit wit_intro_pattern) then
     (out_gen (topwit wit_intro_pattern) v).CAst.v
   else if has_type v (topwit wit_var) then
@@ -252,7 +253,8 @@ let coerce_to_constr env v =
     (try [], constr_of_id env id with Not_found -> fail ())
   else fail ()
 
-let coerce_to_uconstr env v =
+let coerce_to_uconstr _env v =
+  let v = Value.normalize v in
   if has_type v (topwit wit_uconstr) then
     out_gen (topwit wit_uconstr) v
   else
@@ -325,7 +327,8 @@ let coerce_to_hyp_list env sigma v =
   | None -> raise (CannotCoerceTo "a variable list")
 
 (* Interprets a qualified name *)
-let coerce_to_reference env sigma v =
+let coerce_to_reference _env sigma v =
+  let v = Value.normalize v in
   match Value.to_constr v with
   | Some c ->
     begin
@@ -353,7 +356,8 @@ let coerce_to_quantified_hypothesis sigma v =
 
 (* Quantified named or numbered hypothesis or hypothesis in context *)
 (* (as in Inversion) *)
-let coerce_to_decl_or_quant_hyp env sigma v =
+let coerce_to_decl_or_quant_hyp _env sigma v =
+  let v = Value.normalize v in
   if has_type v (topwit wit_int) then
     AnonHyp (out_gen (topwit wit_int) v)
   else

--- a/plugins/ltac/tacentries.ml
+++ b/plugins/ltac/tacentries.ml
@@ -222,7 +222,7 @@ let interp_prod_item = function
       | None -> user_err Pp.(str ("Unknown entry "^s^"."))
       | Some arg -> arg
       end
-    | Some n ->
+    | Some _n ->
       (** FIXME: do better someday *)
       assert (String.equal s "tactic");
       begin match Tacarg.wit_tactic with
@@ -343,10 +343,10 @@ let extend_atomic_tactic name entries =
     | _ -> assert false (** Not handled by the ML extension syntax *)
     in
     let empty_value = function
-    | TacTerm s -> raise NonEmptyArgument
+    | TacTerm _s -> raise NonEmptyArgument
     | TacNonTerm (_, (symb, _)) ->
       let EntryName (typ, e) = prod_item_of_symbol 0 symb in
-      let Genarg.Rawwit wit = typ in
+      let Genarg.Rawwit _wit = typ in
       let inj x = TacArg (Loc.tag @@ TacGeneric (Genarg.in_gen typ x)) in
       let default = epsilon_value inj e in
       match default with
@@ -371,7 +371,7 @@ let add_ml_tactic_notation name ~level prods =
   let iter i prods =
     let open Tacexpr in
     let get_id = function
-    | TacTerm s -> None
+    | TacTerm _s -> None
     | TacNonTerm (_, (_, ido)) -> ido
     in
     let ids = List.map_filter get_id prods in
@@ -509,7 +509,7 @@ let print_ltacs () =
   in
   let entries = List.map_filter map entries in
   let pr_entry (qid, body) =
-    let (l, t) = match body with
+    let (l, _t) = match body with
     | Tacexpr.TacFun (l, t) -> (l, t)
     | _ -> ([], body)
     in

--- a/plugins/ltac/tacenv.ml
+++ b/plugins/ltac/tacenv.ml
@@ -151,7 +151,7 @@ let open_md i ((sp, kn), (local, id, b, t)) = match id with
   add kn b t
 | Some kn0 -> replace kn0 kn t
 
-let cache_md ((sp, kn), (local, id ,b, t)) = match id with
+let cache_md ((sp, kn), (_local, id ,b, t)) = match id with
 | None ->
   let () = push_tactic (Until 1) sp kn in
   add kn b t
@@ -164,7 +164,7 @@ let subst_kind subst id = match id with
 let subst_md (subst, (local, id, b, t)) =
   (local, subst_kind subst id, b, Tacsubst.subst_tactic subst t)
 
-let classify_md (local, _, _, _ as o) = Substitute o
+let classify_md (_local, _, _, _ as o) = Substitute o
 
 let inMD : bool * ltac_constant option * bool * glob_tactic_expr -> obj =
   declare_object {(default_object "TAC-DEFINITION") with

--- a/plugins/ltac/tacsubst.ml
+++ b/plugins/ltac/tacsubst.ml
@@ -48,9 +48,9 @@ let subst_glob_with_bindings subst (c,bl) =
 let subst_glob_with_bindings_arg subst (clear,c) =
   (clear,subst_glob_with_bindings subst c)
 
-let rec subst_intro_pattern subst = CAst.map (function
-  | IntroAction p -> IntroAction (subst_intro_pattern_action subst p)
-  | IntroNaming _ | IntroForthcoming _ as x -> x)
+let rec subst_intro_pattern subst = function
+  | loc,IntroAction p -> loc, IntroAction (subst_intro_pattern_action subst p)
+  | _loc, IntroNaming _ | _loc, IntroForthcoming _ as x -> x
 
 and subst_intro_pattern_action subst = let open CAst in function
   | IntroApplyOn ({loc;v=t},pat) ->
@@ -68,10 +68,10 @@ and subst_intro_or_and_pattern subst = function
 
 let subst_destruction_arg subst = function
   | clear,ElimOnConstr c -> clear,ElimOnConstr (subst_glob_with_bindings subst c)
-  | clear,ElimOnAnonHyp n as x -> x
-  | clear,ElimOnIdent id as x -> x
+  | _clear,ElimOnAnonHyp _n as x -> x
+  | _clear,ElimOnIdent _id as x -> x
 
-let subst_and_short_name f (c,n) =
+let subst_and_short_name f (c,_n) =
 (*  assert (n=None); *)(* since tacdef are strictly globalized *)
   (f c,None)
 
@@ -284,7 +284,7 @@ and subst_genarg subst (GenArg (Glbwit wit, x)) =
     let p = out_gen (glbwit wit1) (subst_genarg subst (in_gen (glbwit wit1) p)) in
     let q = out_gen (glbwit wit2) (subst_genarg subst (in_gen (glbwit wit2) q)) in
     in_gen (glbwit (wit_pair wit1 wit2)) (p, q)
-  | ExtraArg s ->
+  | ExtraArg _s ->
       Genintern.generic_substitute subst (in_gen (glbwit wit) x)
 
 (** Registering *)

--- a/plugins/ltac/tactic_debug.ml
+++ b/plugins/ltac/tactic_debug.ml
@@ -338,7 +338,7 @@ let db_breakpoint debug s =
   let open Proofview.NonLogical in
   !breakpoint >>= fun opt_breakpoint ->
   match debug with
-  | DebugOn lev when not (CList.is_empty s) && is_breakpoint opt_breakpoint s ->
+  | DebugOn _lev when not (CList.is_empty s) && is_breakpoint opt_breakpoint s ->
       breakpoint:=None
   | _ ->
       return ()
@@ -348,13 +348,13 @@ let db_breakpoint debug s =
 let is_defined_ltac trace =
   let rec aux = function
   | (_, Tacexpr.LtacNameCall f) :: _ -> not (Tacenv.is_ltac_for_ml_tactic f)
-  | (_, Tacexpr.LtacNotationCall f) :: _ -> true
+  | (_, Tacexpr.LtacNotationCall _f) :: _ -> true
   | (_, Tacexpr.LtacAtomCall _) :: _ -> false
   | _ :: tail -> aux tail
   | [] -> false in
   aux (List.rev trace)
 
-let explain_ltac_call_trace last trace loc =
+let explain_ltac_call_trace last trace _loc =
   let calls = last :: List.rev_map snd trace in
   let pr_call ck = match ck with
     | Tacexpr.LtacNotationCall kn -> quote (Pptactic.pr_alias_key kn)

--- a/plugins/ltac/tactic_matching.ml
+++ b/plugins/ltac/tactic_matching.ml
@@ -94,7 +94,7 @@ let equal_instances env sigma (ctx',c') (ctx,c) =
     equal according to {!equal_instances}. *)
 exception Not_coherent_metas
 let verify_metas_coherence env sigma (ln1,lcm) (ln,lm) =
-  let merge id oc1 oc2 = match oc1, oc2 with
+  let merge _id oc1 oc2 = match oc1, oc2 with
     | None, None -> None
     | None, Some c | Some c, None -> Some c
     | Some c1, Some c2 ->
@@ -229,7 +229,7 @@ module PatternMatching (E:StaticEnvironment) = struct
   (** [pattern_match_term refresh pat term lhs] returns the possible
       matchings of [term] with the pattern [pat => lhs]. If refresh is
       true, refreshes the universes of [term]. *)
-  let pattern_match_term refresh pat term lhs = 
+  let pattern_match_term _refresh pat term lhs = 
 (*     let term = if refresh then Termops.refresh_universes_strict term else term in *)
     match pat with
     | Term p ->
@@ -301,7 +301,7 @@ module PatternMatching (E:StaticEnvironment) = struct
           pattern_match_term true typepat hyp () <*>
           put_terms (id_map_try_add_name hypname (EConstr.mkVar id) empty_term_subst) <*>
           return id
-      | LocalAssum (id,hyp) -> fail
+      | LocalAssum (_id,_hyp) -> fail
 
   (** [hyp_match pat hyps] dispatches to
       {!hyp_match_type} or {!hyp_match_body_and_type} depending on whether

--- a/plugins/ltac/tauto.ml
+++ b/plugins/ltac/tauto.ml
@@ -112,10 +112,10 @@ let is_unit_or_eq _ ist =
 
 let bugged_is_binary sigma t =
   isApp sigma t &&
-  let (hdapp,args) = decompose_app sigma t in
+  let (hdapp,_args) = decompose_app sigma t in
     match EConstr.kind sigma hdapp with
-    | Ind (ind,u)  ->
-        let (mib,mip) = Global.lookup_inductive ind in
+    | Ind (ind,_u)  ->
+        let (mib,_mip) = Global.lookup_inductive ind in
          Int.equal mib.Declarations.mind_nparams 2
     | _ -> false
 
@@ -203,7 +203,7 @@ let coq_nnpp_path =
   let dir = List.map Id.of_string ["Classical_Prop";"Logic";"Coq"] in
   Libnames.make_path (DirPath.make dir) (Id.of_string "NNPP")
 
-let apply_nnpp _ ist =
+let apply_nnpp _ _ist =
   Proofview.tclBIND
     (Proofview.tclUNIT ())
     begin fun () -> try

--- a/plugins/omega/coq_omega.ml
+++ b/plugins/omega/coq_omega.ml
@@ -39,14 +39,14 @@ open OmegaSolver
 (* Added by JCF, 09/03/98 *)
 
 let elim_id id =
-  Proofview.Goal.enter begin fun gl ->
+  Proofview.Goal.enter begin fun _gl ->
     simplest_elim (mkVar id)
   end
-let resolve_id id = Proofview.Goal.enter begin fun gl ->
+let resolve_id id = Proofview.Goal.enter begin fun _gl ->
   apply (mkVar id)
 end
 
-let timing timer_name f arg = f arg
+let timing _timer_name f arg = f arg
 
 let display_time_flag = ref false
 let display_system_flag = ref false
@@ -370,7 +370,7 @@ let coq_True = lazy (init_constant "True")
 
 (* For unfold *)
 let evaluable_ref_of_constr s c = match EConstr.kind Evd.empty (Lazy.force c) with
-  | Const (kn,u) when Tacred.is_evaluable (Global.env()) (EvalConstRef kn) ->
+  | Const (kn,_u) when Tacred.is_evaluable (Global.env()) (EvalConstRef kn) ->
       EvalConstRef kn
   | _ -> anomaly ~label:"Coq_omega" (Pp.str (s^" is not an evaluable constant."))
 
@@ -568,17 +568,17 @@ let occurrence sigma path (t : constr) =
   let rec loop p0 t = match (p0,EConstr.kind sigma t) with
     | (p, Cast (c,_,_)) -> loop p c
     | ([], _) -> t
-    | ((P_APP n :: p),  App (f,v)) -> loop p v.(pred n)
+    | ((P_APP n :: p),  App (_f,v)) -> loop p v.(pred n)
     | ((P_BRANCH n :: p), Case (_,_,_,v)) -> loop p v.(n)
     | ((P_ARITY :: p),  App (f,_)) -> loop p f
-    | ((P_ARG :: p),  App (f,v)) -> loop p v.(0)
+    | ((P_ARG :: p),  App (_f,v)) -> loop p v.(0)
     | (p, Fix((_,n) ,(_,_,v))) -> loop p v.(n)
-    | ((P_BODY :: p), Prod (n,t,c)) -> loop p c
-    | ((P_BODY :: p), Lambda (n,t,c)) -> loop p c
-    | ((P_BODY :: p), LetIn (n,b,t,c)) -> loop p c
-    | ((P_TYPE :: p), Prod (n,term,c)) -> loop p term
-    | ((P_TYPE :: p), Lambda (n,term,c)) -> loop p term
-    | ((P_TYPE :: p), LetIn (n,b,term,c)) -> loop p term
+    | ((P_BODY :: p), Prod (_n,_t,c)) -> loop p c
+    | ((P_BODY :: p), Lambda (_n,_t,c)) -> loop p c
+    | ((P_BODY :: p), LetIn (_n,_b,_t,c)) -> loop p c
+    | ((P_TYPE :: p), Prod (_n,term,_c)) -> loop p term
+    | ((P_TYPE :: p), Lambda (_n,term,_c)) -> loop p term
+    | ((P_TYPE :: p), LetIn (_n,_b,term,_c)) -> loop p term
     | (p, _) ->
 	failwith ("occurrence " ^ string_of_int(List.length p))
   in
@@ -592,7 +592,7 @@ let abstract_path sigma typ path t =
 let focused_simpl path =
   let open Tacmach.New in
   Proofview.Goal.nf_enter begin fun gl ->
-  let newc = context (project gl) (fun i t -> pf_nf gl t) (List.rev path) (pf_concl gl) in
+  let newc = context (project gl) (fun _i t -> pf_nf gl t) (List.rev path) (pf_concl gl) in
   convert_concl_no_check newc DEFAULTcast
   end
 
@@ -616,7 +616,7 @@ let rec oprint = function
       oprint t2; print_string ")"
   | Oatom s -> print_string (Id.to_string s)
   | Oz i -> print_string (string_of_bigint i)
-  | Oufo f -> print_string "?"
+  | Oufo _f -> print_string "?"
 
 let rec weight = function
   | Oatom c -> intern_id c
@@ -833,7 +833,7 @@ let shuffle_mult p_init k1 e1 k2 e2 =
                             [P_APP 2; P_APP 2]]
             (Lazy.force coq_fast_OMEGA12) ::
           loop (P_APP 2 :: p) (l1',l2)
-    | ({c=c1;v=v1}::l1), [] ->
+    | ({c=_c1;v=_v1}::l1), [] ->
         clever_rewrite p [[P_APP 1; P_APP 1; P_APP 1; P_APP 1];
                           [P_APP 1; P_APP 1; P_APP 1; P_APP 2];
                           [P_APP 1; P_APP 1; P_APP 2];
@@ -841,7 +841,7 @@ let shuffle_mult p_init k1 e1 k2 e2 =
                           [P_APP 1; P_APP 2]]
           (Lazy.force coq_fast_OMEGA11) ::
         loop (P_APP 2 :: p) (l1,[])
-    | [],({c=c2;v=v2}::l2) ->
+    | [],({c=_c2;v=_v2}::l2) ->
         clever_rewrite p  [[P_APP 2; P_APP 1; P_APP 1; P_APP 1];
                            [P_APP 2; P_APP 1; P_APP 1; P_APP 2];
                            [P_APP 1];
@@ -887,11 +887,11 @@ let shuffle_mult_right p_init e1 k2 e2 =
                             [P_APP 2; P_APP 2]]
             (Lazy.force coq_fast_OMEGA12) ::
           loop (P_APP 2 :: p) (l1',l2)
-    | ({c=c1;v=v1}::l1), [] ->
+    | ({c=_c1;v=_v1}::l1), [] ->
         clever_rewrite p [[P_APP 1;P_APP 1]; [P_APP 1; P_APP 2];[P_APP 2]]
           (Lazy.force coq_fast_Zplus_assoc_reverse) ::
         loop (P_APP 2 :: p) (l1,[])
-    | [],({c=c2;v=v2}::l2) ->
+    | [],({c=_c2;v=_v2}::l2) ->
         clever_rewrite p [[P_APP 2; P_APP 1; P_APP 1; P_APP 1];
                           [P_APP 2; P_APP 1; P_APP 1; P_APP 2];
                           [P_APP 1];
@@ -933,7 +933,7 @@ let rec scalar p n = function
          (Lazy.force coq_fast_Zmult_assoc_reverse);
        focused_simpl (P_APP 2 :: p)],
       Otimes(t1,Oz (n*x))
-  | Otimes(t1,t2) -> CErrors.user_err Pp.(str "Omega: Can't solve a goal with non-linear products")
+  | Otimes(_t1,_t2) -> CErrors.user_err Pp.(str "Omega: Can't solve a goal with non-linear products")
   | (Oatom _ as t) -> [], Otimes(t,Oz n)
   | Oz i -> [focused_simpl p],Oz(n*i)
   | Oufo c -> [], Oufo (mkApp (Lazy.force coq_Zmult, [| mk_integer n; c |]))
@@ -985,7 +985,7 @@ let rec negate p = function
       [clever_rewrite p [[P_APP 1;P_APP 1];[P_APP 1;P_APP 2]]
          (Lazy.force coq_fast_Zopp_mult_distr_r);
        focused_simpl (P_APP 2 :: p)], Otimes(t1,Oz (neg x))
-  | Otimes(t1,t2) -> CErrors.user_err Pp.(str "Omega: Can't solve a goal with non-linear products")
+  | Otimes(_t1,_t2) -> CErrors.user_err Pp.(str "Omega: Can't solve a goal with non-linear products")
   | (Oatom _ as t) ->
       let r = Otimes(t,Oz(negone)) in
       [clever_rewrite p [[P_APP 1]] (Lazy.force coq_fast_Zopp_eq_mult_neg_1)], r
@@ -1056,11 +1056,11 @@ let shrink_pair p f1 f2 =
 	let r = Otimes(Oatom v,Oplus(c2,Oz one)) in
 	clever_rewrite p [[P_APP 1];[P_APP 2;P_APP 2]]
 	  (Lazy.force coq_fast_Zred_factor2), r
-    | Otimes (v1,c1),Oatom v ->
+    | Otimes (_v1,c1),Oatom v ->
 	let r = Otimes(Oatom v,Oplus(c1,Oz one)) in
 	clever_rewrite p [[P_APP 2];[P_APP 1;P_APP 2]]
           (Lazy.force coq_fast_Zred_factor3), r
-    | Otimes (Oatom v,c1),Otimes (v2,c2) ->
+    | Otimes (Oatom v,c1),Otimes (_v2,c2) ->
 	let r = Otimes(Oatom v,Oplus(c1,c2)) in
 	clever_rewrite p
           [[P_APP 1;P_APP 1];[P_APP 1;P_APP 2];[P_APP 2;P_APP 2]]
@@ -1075,7 +1075,7 @@ let reduce_factor p = function
   | Oatom v ->
       let r = Otimes(Oatom v,Oz one) in
       [clever_rewrite p [[]] (Lazy.force coq_fast_Zred_factor0)],r
-  | Otimes(Oatom v,Oz n) as f -> [],f
+  | Otimes(Oatom _v,Oz _n) as f -> [],f
   | Otimes(Oatom v,c) ->
       let rec compute = function
         | Oz n -> n
@@ -1120,7 +1120,7 @@ let rec condense p = function
       tac @ [tac'], final
 
 let rec clear_zero p = function
-  | Oplus(Otimes(Oatom v,Oz n),r) when n =? zero ->
+  | Oplus(Otimes(Oatom _v,Oz n),r) when n =? zero ->
       let tac =
 	clever_rewrite p [[P_APP 1;P_APP 1];[P_APP 2]]
 	  (Lazy.force coq_fast_Zred_factor5) in
@@ -1144,7 +1144,7 @@ let replay_history tactic_normalisation =
 		(Id.List.assoc (hyp_of_tag e.id) tactic_normalisation)
 		(loop l)
 	    with Not_found -> loop l end
-      | NEGATE_CONTRADICT (e2,e1,b) :: l ->
+      | NEGATE_CONTRADICT (e2,e1,b) :: _l ->
 	  let eq1 = decompile e1
 	  and eq2 = decompile e2 in
 	  let id1 = hyp_of_tag e1.id
@@ -1164,7 +1164,7 @@ let replay_history tactic_normalisation =
 	    resolve_id aux;
             reflexivity
           ]
-      | CONTRADICTION (e1,e2) :: l ->
+      | CONTRADICTION (e1,e2) :: _l ->
 	  let eq1 = decompile e1
 	  and eq2 = decompile e2 in
 	  let p_initial = [P_APP 2;P_TYPE] in
@@ -1229,7 +1229,7 @@ let replay_history tactic_normalisation =
                 ];
 	      tclTHEN (mk_then tac) reflexivity ]
 
-      | NOT_EXACT_DIVIDE (e1,k) :: l ->
+      | NOT_EXACT_DIVIDE (e1,k) :: _l ->
 	  let c = floor_div e1.constant k in
 	  let d = Bigint.sub e1.constant (Bigint.mult c k) in
 	  let e2 =  {id=e1.id; kind=EQUA;constant = c;
@@ -1359,7 +1359,7 @@ let replay_history tactic_normalisation =
 	      (intros_using [id]);
 	      (loop l) ];
             tclTHEN (exists_tac eq1) reflexivity ]
-      | SPLIT_INEQ(e,(e1,act1),(e2,act2)) :: l ->
+      | SPLIT_INEQ(e,(e1,act1),(e2,act2)) :: _l ->
 	  let id1 = new_identifier ()
 	  and id2 = new_identifier () in
 	  tag_hypothesis id1 e1; tag_hypothesis id2 e2;
@@ -1423,11 +1423,11 @@ let replay_history tactic_normalisation =
 		unfold sp_Zgt;
                 simpl_in_concl;
 		reflexivity ] ]
-      | CONSTANT_NOT_NUL(e,k) :: l ->
+      | CONSTANT_NOT_NUL(e,_k) :: _l ->
 	  tclTHEN ((generalize_tac [mkVar (hyp_of_tag e)])) Equality.discrConcl
-      | CONSTANT_NUL(e) :: l ->
+      | CONSTANT_NUL(e) :: _l ->
 	  tclTHEN (resolve_id (hyp_of_tag e)) reflexivity
-      | CONSTANT_NEG(e,k) :: l ->
+      | CONSTANT_NEG(e,_k) :: _l ->
 	  tclTHENLIST [
 	    (generalize_tac [mkVar (hyp_of_tag e)]);
             unfold sp_Zle;
@@ -1807,7 +1807,7 @@ let destructure_hyps =
        Proofview.tclEVARMAP >>= fun sigma ->
 	  begin try match destructurate_prop sigma (NamedDecl.get_type decl) with
 	  | Kapp(False,[]) -> elim_id i
-          | Kapp((Zle|Zge|Zgt|Zlt|Zne),[t1;t2]) -> loop lit
+          | Kapp((Zle|Zge|Zgt|Zlt|Zne),[_t1;_t2]) -> loop lit
           | Kapp(Or,[t1;t2]) ->
               (tclTHENS
                  (elim_id i)
@@ -1948,11 +1948,11 @@ let destructure_goal =
       let prop () = Proofview.tclUNIT (destructurate_prop sigma t) in
       Proofview.V82.wrap_exceptions prop >>= fun prop ->
       match prop with
-      | Kapp(Not,[t]) ->
+      | Kapp(Not,[_t]) ->
           (tclTHEN
 	     (tclTHEN (unfold sp_not) intro)
 	     destructure_hyps)
-      | Kimp(a,b) -> (tclTHEN intro (loop b))
+      | Kimp(_a,b) -> (tclTHEN intro (loop b))
       | Kapp(False,[]) -> destructure_hyps
       | _ ->
 	  let goal_tac =

--- a/plugins/omega/omega.ml
+++ b/plugins/omega/omega.ml
@@ -175,7 +175,7 @@ let sbi = string_of_bigint
 
 let rec display_action print_var = function
   | act :: l -> begin match act with
-      | DIVIDE_AND_APPROX (e1,e2,k,d) ->
+      | DIVIDE_AND_APPROX (e1,_e2,k,d) ->
           Printf.printf
             "Inequation E%d is divided by %s and the constant coefficient is \
             rounded by substracting %s.\n" e1.id (sbi k) (sbi d)
@@ -213,7 +213,7 @@ let rec display_action print_var = function
           Printf.printf
             "Equations E%d and E%d imply a contradiction on their \
             constant factors.\n" e1.id e2.id
-      | NEGATE_CONTRADICT(e1,e2,b) ->
+      | NEGATE_CONTRADICT(e1,e2,_b) ->
           Printf.printf
             "Equations E%d and E%d state that their body is at the same time \
             equal and different\n" e1.id e2.id
@@ -319,7 +319,7 @@ let normalize ({id=id; kind=eq_flag; body=e; constant =x} as eq) =
     end else [eq]
 
 let eliminate_with_in new_eq_id {v=v;c=c_unite} eq2
-                        ({body=e1; constant=c1} as eq1) =
+                        ({body=e1; constant=_c1} as eq1) =
   try
     let (f,_) = chop_var v e1 in
     let coeff = if c_unite=?one then neg f.c else if c_unite=? negone then f.c
@@ -353,7 +353,7 @@ let banerjee_step (new_eq_id,new_var_id,print_var) original l1 l2 =
   add_event (STATE {st_new_eq = new_eq; st_def = definition;
 		    st_orig = original; st_coef = m; st_var = sigma});
   let new_eq = List.hd (normalize new_eq) in
-  let eliminated_var, def = chop_var var new_eq.body in
+  let eliminated_var, _def = chop_var var new_eq.body in
   let other_equations =
     Util.List.map_append
       (fun e ->
@@ -367,10 +367,10 @@ let banerjee_step (new_eq_id,new_var_id,print_var) original l1 l2 =
   add_event (EXACT_DIVIDE (original',m));
   List.hd (normalize mod_original),other_equations,inequations
 
-let rec eliminate_one_equation ((new_eq_id,new_var_id,print_var) as new_ids) (e,other,ineqs) =
+let rec eliminate_one_equation ((new_eq_id,_new_var_id,print_var) as new_ids) (e,other,ineqs) =
   if !debug then display_system print_var (e::other);
   try
-    let v,def = chop_factor_1 e.body in
+    let v,_def = chop_factor_1 e.body in
     (Util.List.map_append
       (fun e' -> normalize (eliminate_with_in new_eq_id v e e')) other,
      Util.List.map_append
@@ -452,11 +452,11 @@ let redundancy_elimination new_eq_id system =
   let accu_ineq = ref [] in
   Hashtbl.iter
     (fun p0 p1 -> match (p0,p1) with
-       | (e, (Some x, Some y)) when x.constant =? y.constant ->
+       | (_e, (Some x, Some y)) when x.constant =? y.constant ->
            let id=new_eq_id () in
            add_event (MERGE_EQ(id,x,y.id));
            push {id=id; kind=EQUA; body=x.body; constant=x.constant} accu_eq
-       | (e, (optnorm,optinvert)) ->
+       | (_e, (optnorm,optinvert)) ->
            begin match optnorm with
                Some x -> push x accu_ineq | _ -> () end;
            begin match optinvert with
@@ -485,7 +485,7 @@ let select_variable system =
 let classify v system =
   List.fold_left
     (fun (not_occ,below,over) eq ->
-       try let f,eq' = chop_var v eq.body in
+       try let f,_eq' = chop_var v eq.body in
        if f.c >=? zero then (not_occ,((f.c,eq) :: below),over)
        else (not_occ,below,((neg f.c,eq) :: over))
        with CHOPVAR -> (eq::not_occ,below,over))
@@ -510,7 +510,7 @@ let product new_eq_id dark_shadow low high =
                        constant = eq.constant - delta}
                     else eq
                   in final_eq :: accu
-              | (e::_) -> failwith "Product dardk"
+              | (_e::_) -> failwith "Product dardk"
               | [] -> accu)
          accu high)
     [] low
@@ -521,7 +521,7 @@ let fourier_motzkin (new_eq_id,_,print_var) dark_shadow system =
   let expanded = ineq_out @ product new_eq_id dark_shadow ineq_low ineq_high in
   if !debug then display_system print_var expanded; expanded
 
-let simplify ((new_eq_id,new_var_id,print_var) as new_ids) dark_shadow system =
+let simplify ((new_eq_id,_new_var_id,print_var) as new_ids) dark_shadow system =
   if List.exists (fun e -> e.kind = DISE) system then
     failwith "disequation in simplify";
   clear_history ();
@@ -609,7 +609,7 @@ let negation (eqs,ineqs) =
 
 exception FULL_SOLUTION of action list * int list
 
-let simplify_strong ((new_eq_id,new_var_id,print_var) as new_ids) system =
+let simplify_strong ((new_eq_id,_new_var_id,print_var) as new_ids) system =
   clear_history ();
   List.iter (fun e -> add_event (HYP e)) system;
   (* Initial simplification phase *)

--- a/plugins/quote/quote.ml
+++ b/plugins/quote/quote.ml
@@ -229,12 +229,12 @@ let compute_ivs f cs gl =
   let body = Environ.constant_value_in (Global.env()) (cst, u) in
   let body = EConstr.of_constr body in
   match decomp_term sigma body with
-    | Fix(([| len |], 0), ([| name |], [| typ |], [| body2 |])) ->
+    | Fix(([| _len |], 0), ([| _name |], [| _typ |], [| body2 |])) ->
         let (args3, body3) = decompose_lam sigma body2 in
         let nargs3 = List.length args3 in
         let is_conv = Reductionops.is_conv env sigma in
           begin match decomp_term sigma body3 with
-          | Case(_,p,c,lci) -> (* <p> Case c of c1 ... cn end *)
+          | Case(_,p,_c,lci) -> (* <p> Case c of c1 ... cn end *)
               let n_lhs_rhs = ref []
               and v_lhs = ref (None : constr option)
               and c_lhs = ref (None : constr option) in
@@ -365,7 +365,7 @@ let path_of_int n =
 let rec subterm gl (t : constr) (t' : constr) =
   (pf_conv_x gl t t') ||
   (match EConstr.kind (project gl) t with
-     | App (f,args) -> Array.exists (fun t -> subterm gl t t') args
+     | App (_f,args) -> Array.exists (fun t -> subterm gl t t') args
      | Cast(t,_,_) -> (subterm gl t t')
      | _ -> false)
 
@@ -376,7 +376,7 @@ let rec sort_subterm gl l =
   let sigma = project gl in
   let rec insert c = function
     | [] -> [c]
-    | (h::t as l) when EConstr.eq_constr sigma c h -> l (* Avoid doing the same work twice *)
+    | (h::_t as l) when EConstr.eq_constr sigma c h -> l (* Avoid doing the same work twice *)
     | h::t -> if subterm gl c h then c::h::t else h::(insert c t)
   in
   match l with

--- a/plugins/romega/refl_omega.ml
+++ b/plugins/romega/refl_omega.ml
@@ -278,7 +278,7 @@ let rec pprint ch = function
   | Por (_,t1,t2) -> Printf.fprintf ch "(%a or %a)" pprint t1 pprint t2
   | Pand(_,t1,t2) -> Printf.fprintf ch "(%a and %a)" pprint t1 pprint t2
   | Pimp(_,t1,t2) -> Printf.fprintf ch "(%a => %a)" pprint t1 pprint t2
-  | Pprop c -> Printf.fprintf ch "Prop"
+  | Pprop _c -> Printf.fprintf ch "Prop"
 
 (* \subsection{Omega vers Oformula} *)
 
@@ -442,7 +442,7 @@ let rec normalize = function
 
 (* From normalized formulas to omega representations *)
 
-let omega_of_nformula env kind nf =
+let omega_of_nformula _env kind nf =
   { id = new_omega_eq ();
     kind;
     constant=nf.cst;
@@ -611,7 +611,7 @@ and destruct_neg_hyp eqns = function
 
 let rec destructurate_hyps = function
   | [] -> [[]]
-  | (i,_,t) :: l ->
+  | (_i,_,t) :: l ->
      let l_syst1 = destruct_pos_hyp [] t in
      let l_syst2 = destructurate_hyps l in
      List.cartesian (@) l_syst1 l_syst2
@@ -896,7 +896,7 @@ let rec reify_trace env env_hyp =
      mkApp (Lazy.force coq_s_split_ineq,
             [| hyp_idx env_hyp e.id; r1 ; r2 |])
   | (FORGET_C _ | FORGET _ | FORGET_I _) :: l -> reify_trace env env_hyp l
-  | WEAKEN  _ :: l -> failwith "not_treated"
+  | WEAKEN  _ :: _l -> failwith "not_treated"
   | _ -> failwith "bad history"
 
 let rec decompose_tree env ctxt = function

--- a/plugins/setoid_ring/newring.ml
+++ b/plugins/setoid_ring/newring.ml
@@ -47,7 +47,7 @@ let tag_arg tag_rec map subs i c =
     | Rec -> if Int.equal i (-1) then mk_clos subs c else tag_rec c
 
 let global_head_of_constr sigma c = 
-  let f, args = decompose_app sigma c in
+  let f, _args = decompose_app sigma c in
     try fst (Termops.global_of_constr sigma f)
     with Not_found -> CErrors.anomaly (str "global_head_of_constr.")
 
@@ -511,18 +511,18 @@ let ring_equality env evd (r,add,mul,opp,req) =
     | _ ->
 	let setoid = setoid_of_relation (Global.env ()) evd r req in
 	let signature = [Some (r,Some req);Some (r,Some req)],Some(r,Some req) in
-	let add_m, add_m_lem =
+	let _add_m, add_m_lem =
 	  try Rewrite.default_morphism signature add
           with Not_found ->
             error "ring addition should be declared as a morphism" in
-	let mul_m, mul_m_lem =
+	let _mul_m, mul_m_lem =
           try Rewrite.default_morphism signature mul
           with Not_found ->
             error "ring multiplication should be declared as a morphism" in
         let op_morph =
           match opp with
             | Some opp ->
-		(let opp_m,opp_m_lem =
+		(let _opp_m,opp_m_lem =
 		  try Rewrite.default_morphism ([Some(r,Some req)],Some(r,Some req)) opp
 		  with Not_found ->
                     error "ring opposite should be declared as a morphism" in
@@ -573,7 +573,7 @@ let reflect_coeff rkind =
     | Computational c -> lapp coq_comp [|c|]
     | Morphism m -> lapp coq_morph [|m|]
 
-let interp_cst_tac env sigma rk kind (zero,one,add,mul,opp) cst_tac =
+let interp_cst_tac _env _sigma _rk _kind (_zero,_one,_add,_mul,_opp) cst_tac =
   match cst_tac with
       Some (CstTac t) -> Tacintern.glob_tactic t
     | Some (Closed lc) ->
@@ -633,7 +633,7 @@ let interp_div env evd div =
 let add_theory0 name (sigma, rth) eqth morphth cst_tac (pre,post) power sign div =
   check_required_library (cdir@["Ring_base"]);
   let env = Global.env() in
-  let (kind,r,zero,one,add,mul,sub,opp,req) = dest_ring env sigma rth in
+  let (kind,r,zero,one,add,mul,_sub,opp,req) = dest_ring env sigma rth in
   let evd = ref sigma in
   let (sth,ext) = build_setoid_params env evd r add mul opp req eqth in
   let (pow_tac, pspec) = interp_power env evd power in
@@ -923,7 +923,7 @@ let field_equality evd r inv req =
     | _ ->
 	let _setoid = setoid_of_relation (Global.env ()) evd r req in
 	let signature = [Some (r,Some req)],Some(r,Some req) in
-	let inv_m, inv_m_lem =
+	let _inv_m, inv_m_lem =
 	  try Rewrite.default_morphism signature inv
           with Not_found ->
             error "field inverse should be declared as a morphism" in
@@ -935,7 +935,7 @@ let add_field_theory0 name fth eqth morphth cst_tac inj (pre,post) power sign od
   let (sigma,fth) = ic fth in
   let env = Global.env() in
   let evd = ref sigma in
-  let (kind,r,zero,one,add,mul,sub,opp,div,inv,req,rth) =
+  let (kind,r,zero,one,add,mul,_sub,opp,_div,inv,req,rth) =
     dest_field env evd fth in
   let (sth,ext) = build_setoid_params env evd r add mul opp req eqth in
   let eqth = Some(sth,ext) in

--- a/plugins/syntax/z_syntax.ml
+++ b/plugins/syntax/z_syntax.ml
@@ -54,7 +54,7 @@ let pos_of_bignat ?loc x =
     match div2_with_rest x with
       | (q,false) -> DAst.make ?loc @@ GApp (ref_xO,[pos_of q])
       | (q,true) when not (Bigint.equal q zero) -> DAst.make ?loc @@ GApp (ref_xI,[pos_of q])
-      | (q,true) -> ref_xH
+      | (_q,true) -> ref_xH
   in
   pos_of x
 
@@ -113,7 +113,7 @@ let glob_Npos = ConstructRef path_of_Npos
 
 let n_path = make_path binnums "N"
 
-let n_of_binnat ?loc pos_or_neg n = DAst.make ?loc @@
+let n_of_binnat ?loc _pos_or_neg n = DAst.make ?loc @@
   if not (Bigint.equal n zero) then
     GApp(DAst.make @@ GRef (glob_Npos,None), [pos_of_bignat ?loc n])
   else

--- a/pretyping/arguments_renaming.ml
+++ b/pretyping/arguments_renaming.ml
@@ -101,9 +101,9 @@ let rename_typing env c =
   let j = Typeops.infer env c in
   let j' =
     match kind c with
-    | Const (c,u) -> { j with uj_type = rename_type j.uj_type (ConstRef c) }
-    | Ind (i,u) -> { j with uj_type = rename_type j.uj_type (IndRef i) }
-    | Construct (k,u) -> { j with uj_type = rename_type j.uj_type (ConstructRef k) }
+    | Const (c,_u) -> { j with uj_type = rename_type j.uj_type (ConstRef c) }
+    | Ind (i,_u) -> { j with uj_type = rename_type j.uj_type (IndRef i) }
+    | Construct (k,_u) -> { j with uj_type = rename_type j.uj_type (ConstructRef k) }
     | _ -> j
   in j'
 

--- a/pretyping/classops.ml
+++ b/pretyping/classops.ml
@@ -211,7 +211,7 @@ let subst_cl_typ subst ct = match ct with
   | CL_FUN
   | CL_SECVAR _ -> ct
   | CL_PROJ c ->
-    let c',t = subst_con_kn subst c in
+    let c',_t = subst_con_kn subst c in
       if c' == c then ct else CL_PROJ c'
   | CL_CONST c ->
       let c',t = subst_con_kn subst c in
@@ -228,7 +228,7 @@ let subst_coe_typ subst t = subst_global_reference subst t
 (* class_of : Term.constr -> int *)
 
 let class_of env sigma t =
-  let (t, n1, i, u, args) =
+  let (t, n1, i, _u, args) =
     try
       let (cl, u, args) = find_class_type sigma t in
       let (i, { cl_param = n1 } ) = class_info cl in
@@ -243,7 +243,7 @@ let class_of env sigma t =
 
 let inductive_class_of ind = fst (class_info (CL_IND ind))
 
-let class_args_of env sigma c = pi3 (find_class_type sigma c)
+let class_args_of _env sigma c = pi3 (find_class_type sigma c)
 
 let string_of_class = function
   | CL_FUN -> "Funclass"
@@ -272,14 +272,14 @@ let lookup_path_to_sort_from_class s =
 
 let apply_on_class_of env sigma t cont =
   try
-    let (cl,u,args) = find_class_type sigma t in
+    let (cl,_u,args) = find_class_type sigma t in
     let (i, { cl_param = n1 } ) = class_info cl in
     if not (Int.equal (List.length args) n1) then raise Not_found;
     t, cont i
   with Not_found ->
     (* Is it worth to be more incremental on the delta steps? *)
     let t = Tacred.hnf_constr env sigma t in
-    let (cl, u, args) = find_class_type sigma t in
+    let (cl, _u, args) = find_class_type sigma t in
     let (i, { cl_param = n1 } ) = class_info cl in
     if not (Int.equal (List.length args) n1) then raise Not_found;
     t, cont i
@@ -302,7 +302,7 @@ let get_coercion_constructor env coe =
     Reductionops.whd_all_stack env Evd.empty (EConstr.of_constr coe.coe_value)
   in
   match EConstr.kind Evd.empty (** FIXME *) c with
-  | Construct (cstr,u) ->
+  | Construct (cstr,_u) ->
       (cstr, Inductiveops.constructor_nrealargs cstr -1)
   | _ ->
       raise Not_found

--- a/pretyping/evardefine.ml
+++ b/pretyping/evardefine.ml
@@ -162,7 +162,7 @@ let rec evar_absorb_arguments env evd (evk,args as ev) = function
 
 (* Refining an evar to a sort *)
 
-let define_evar_as_sort env evd (ev,args) =
+let define_evar_as_sort env evd (ev,_args) =
   let evd, u = new_univ_variable univ_rigid evd in
   let evi = Evd.find_undefined evd ev in 
   let s = Type u in

--- a/pretyping/find_subterm.ml
+++ b/pretyping/find_subterm.ml
@@ -43,7 +43,7 @@ let error_occurrences_error e =
 let error_invalid_occurrence occ =
   error_occurrences_error (InvalidOccurrence occ)
 
-let check_used_occurrences nbocc (nowhere_except_in,locs) =
+let check_used_occurrences nbocc (_nowhere_except_in,locs) =
   let rest = List.filter (fun o -> o >= nbocc) locs in
   match rest with
   | [] -> ()
@@ -134,7 +134,7 @@ let replace_term_occ_gen_modulo sigma occs like_first test bywhat cl occ t =
     with NotUnifiable _ ->
       subst_below k t
   and subst_below k t =
-    map_constr_with_binders_left_to_right sigma (fun d k -> k+1) substrec k t
+    map_constr_with_binders_left_to_right sigma (fun _d k -> k+1) substrec k t
   in
   let t' = substrec 0 t in
   (!pos, t')

--- a/pretyping/indrec.ml
+++ b/pretyping/indrec.ml
@@ -75,7 +75,7 @@ let check_privacy_block mib =
 (* Building case analysis schemes *)
 (* Christine Paulin, 1996 *)
 
-let mis_make_case_com dep env sigma (ind, u as pind) (mib,mip as specif) kind =
+let mis_make_case_com dep env sigma (_ind, u as pind) (mib,mip as specif) kind =
   let lnamespar = Vars.subst_instance_context u mib.mind_params_ctxt in
   let indf = make_ind_family(pind, Context.Rel.to_extended_list mkRel 0 lnamespar) in
   let constrs = get_constructors env indf in
@@ -317,7 +317,7 @@ let mis_make_indrec env sigma listdepkind mib u =
     let rec
 	assign k = function
 	  | [] -> ()
-          | ((indi,u),mibi,mipi,dep,_)::rest ->
+          | ((indi,_u),_mibi,_mipi,dep,_)::rest ->
               (Array.set depPvec (snd indi) (Some(dep,mkRel k));
                assign (k-1) rest)
     in
@@ -331,7 +331,7 @@ let mis_make_indrec env sigma listdepkind mib u =
   let make_one_rec p =
     let makefix nbconstruct =
       let rec mrec i ln ltyp ldef = function
-	| ((indi,u),mibi,mipi,dep,_)::rest ->
+	| ((indi,u),_mibi,mipi,dep,_)::rest ->
 	    let tyi = snd indi in
 	    let nctyi =
               Array.length mipi.mind_consnames in (* nb constructeurs du type*)
@@ -470,7 +470,7 @@ let mis_make_indrec env sigma listdepkind mib u =
     let ((indi,u),mibi,mipi,dep,kind) = List.nth listdepkind p in
 
       if (mis_is_recursive_subset
-	(List.map (fun ((indi,u),_,_,_,_) -> snd indi) listdepkind)
+	(List.map (fun ((indi,_u),_,_,_,_) -> snd indi) listdepkind)
 	mipi.mind_recargs)
       then
 	let env' = push_rel_context lnamesparrec env in
@@ -546,7 +546,7 @@ let weaken_sort_scheme env evd set sort npars term ty =
 
 let check_arities env listdepkind =
   let _ = List.fold_left
-    (fun ln (((_,ni as mind),u),mibi,mipi,dep,kind) ->
+    (fun ln (((_,ni as mind),u),mibi,mipi,_dep,kind) ->
        let kelim = elim_sorts (mibi,mipi) in
        if not (Sorts.List.mem kind kelim) then raise
 	 (RecursionSchemeError
@@ -563,7 +563,7 @@ let build_mutual_induction_scheme env sigma = function
       let (mib,mip) = lookup_mind_specif env mind in
       if dep && not (Inductiveops.has_dependent_elim mib) then
         raise (RecursionSchemeError (NotAllowedDependentAnalysis (true, mind)));
-      let (sp,tyi) = mind in
+      let (sp,_tyi) = mind in
       let listdepkind =
 	((mind,u),mib,mip,dep,s)::
     	(List.map
@@ -602,7 +602,7 @@ let make_elimination_ident id s = add_suffix id (elimination_suffix s)
 
 let lookup_eliminator ind_sp s =
   let kn,i = ind_sp in
-  let mp,dp,l = KerName.repr (MutInd.canonical kn) in
+  let mp,dp,_l = KerName.repr (MutInd.canonical kn) in
   let ind_id = (Global.lookup_mind kn).mind_packets.(i).mind_typename in
   let id = add_suffix ind_id (elimination_suffix s) in
   (* Try first to get an eliminator defined in the same section as the *)

--- a/pretyping/inductiveops.ml
+++ b/pretyping/inductiveops.ml
@@ -38,12 +38,12 @@ let type_of_constructor env (cstr,u) =
  Inductive.type_of_constructor (cstr,u) specif
 
 (* Return constructor types in user form *)
-let type_of_constructors env (ind,u as indu) =
+let type_of_constructors env (ind,_u as indu) =
  let specif = Inductive.lookup_mind_specif env ind in
   Inductive.type_of_constructors indu specif
 
 (* Return constructor types in normal form *)
-let arities_of_constructors env (ind,u as indu) =
+let arities_of_constructors env (ind,_u as indu) =
  let specif = Inductive.lookup_mind_specif env ind in
   Inductive.arities_of_constructors indu specif
 
@@ -91,7 +91,7 @@ let mis_is_recursive_subset listind rarg =
   in
   Array.exists one_is_rec (dest_subterms rarg)
 
-let mis_is_recursive (ind,mib,mip) =
+let mis_is_recursive (_ind,mib,mip) =
   mis_is_recursive_subset (List.interval 0 (mib.mind_ntypes - 1))
     mip.mind_recargs
 
@@ -208,21 +208,21 @@ let inductive_nallargs_env env ind =
 (* Length of arity (w/o local defs) *)
 
 let inductive_nparams ind =
-  let (mib,mip) = Global.lookup_inductive ind in
+  let (mib,_mip) = Global.lookup_inductive ind in
   mib.mind_nparams
 
 let inductive_nparams_env env ind =
-  let (mib,mip) = Inductive.lookup_mind_specif env ind in
+  let (mib,_mip) = Inductive.lookup_mind_specif env ind in
   mib.mind_nparams
 
 (* Length of arity (with local defs) *)
 
 let inductive_nparamdecls ind =
-  let (mib,mip) = Global.lookup_inductive ind in
+  let (mib,_mip) = Global.lookup_inductive ind in
   Context.Rel.length mib.mind_params_ctxt
 
 let inductive_nparamdecls_env env ind =
-  let (mib,mip) = Inductive.lookup_mind_specif env ind in
+  let (mib,_mip) = Inductive.lookup_mind_specif env ind in
   Context.Rel.length mib.mind_params_ctxt
 
 (* Full length of arity (with local defs) *)
@@ -238,19 +238,19 @@ let inductive_nalldecls_env env ind =
 (* Others *)
 
 let inductive_paramdecls (ind,u) =
-  let (mib,mip) = Global.lookup_inductive ind in
+  let (mib,_mip) = Global.lookup_inductive ind in
     Inductive.inductive_paramdecls (mib,u)
 
 let inductive_paramdecls_env env (ind,u) =
-  let (mib,mip) = Inductive.lookup_mind_specif env ind in
+  let (mib,_mip) = Inductive.lookup_mind_specif env ind in
     Inductive.inductive_paramdecls (mib,u)
 
 let inductive_alldecls (ind,u) =
-  let (mib,mip) = Global.lookup_inductive ind in
+  let (_mib,mip) = Global.lookup_inductive ind in
     Vars.subst_instance_context u mip.mind_arity_ctxt
 
 let inductive_alldecls_env env (ind,u) =
-  let (mib,mip) = Inductive.lookup_mind_specif env ind in
+  let (_mib,mip) = Inductive.lookup_mind_specif env ind in
     Vars.subst_instance_context u mip.mind_arity_ctxt
 
 let constructor_has_local_defs (indsp,j) =
@@ -265,8 +265,8 @@ let inductive_has_local_defs ind =
   let l2 = mib.mind_nparams + mip.mind_nrealargs in
   not (Int.equal l1 l2)
 
-let allowed_sorts env (kn,i as ind) =
-  let (mib,mip) = Inductive.lookup_mind_specif env ind in
+let allowed_sorts env (_kn,_i as ind) =
+  let (_mib,mip) = Inductive.lookup_mind_specif env ind in
   mip.mind_kelim
 
 let projection_nparams_env env p = 
@@ -343,10 +343,10 @@ let get_constructors env (ind,params) =
   Array.init (Array.length mip.mind_consnames)
     (fun j -> get_constructor (ind,mib,mip,params) (j+1))
 
-let get_projections env (ind,params) =
-  let (mib,mip) = Inductive.lookup_mind_specif env (fst ind) in
+let get_projections env (ind,_params) =
+  let (mib,_mip) = Inductive.lookup_mind_specif env (fst ind) in
     match mib.mind_record with
-    | Some (Some (id, projs, pbs)) -> Some projs
+    | Some (Some (_id, projs, _pbs)) -> Some projs
     | _ -> None
 
 let make_case_or_project env sigma indf ci pred c branches =
@@ -368,15 +368,15 @@ let make_case_or_project env sigma indf ci pred c branches =
      in
      let branch = branches.(0) in
      let ctx, br = decompose_lam_n_assum sigma (Array.length ps) branch in
-     let n, subst =
+     let _n, subst =
        List.fold_right
          (fun decl (i, subst) ->
-          match decl with
-          | LocalAssum (na, t) ->
-             let t = mkProj (Projection.make ps.(i) true, c) in
-             (i + 1, t :: subst)
-          | LocalDef (na, b, t) -> (i, Vars.substl subst b :: subst))
-         ctx (0, [])
+	  match decl with
+	  | LocalAssum (_na, _t) ->
+	     let t = mkProj (Projection.make ps.(i) true, c) in
+	     (i + 1, t :: subst)
+	  | LocalDef (_na, b, _t) -> (i, Vars.substl subst b :: subst))
+	 ctx (0, [])
      in Vars.substl subst br
 
 (* substitution in a signature *)
@@ -475,7 +475,7 @@ let find_rectype env sigma c =
   let (t, l) = decompose_app sigma (whd_all env sigma c) in
   match EConstr.kind sigma t with
     | Ind (ind,u) ->
-        let (mib,mip) = Inductive.lookup_mind_specif env ind in
+        let (mib,_mip) = Inductive.lookup_mind_specif env ind in
         if mib.mind_nparams > List.length l then raise Not_found;
         let l = List.map EConstr.Unsafe.to_constr l in
         let (par,rargs) = List.chop mib.mind_nparams l in
@@ -513,8 +513,8 @@ let is_predicate_explicitly_dep env sigma pred arsign =
     let pv' = whd_all env sigma pval in
     match EConstr.kind sigma pv', arsign with
       | Lambda (na,t,b), (LocalAssum _)::arsign ->
-          srec (push_rel_assum (na, t) env) b arsign
-      | Lambda (na,_,t), _ ->
+	  srec (push_rel_assum (na, t) env) b arsign
+      | Lambda (na,_,_t), _ ->
 
        (* The following code has an impact on the introduction names
           given by the tactics "case" and "inversion": when the
@@ -616,7 +616,7 @@ let rec instantiate_universes env evdref scl is = function
   | sign, [] -> sign (* Uniform parameters are exhausted *)
   | [], _ -> assert false
 
-let type_of_inductive_knowing_conclusion env sigma ((mib,mip),u) conclty =
+let type_of_inductive_knowing_conclusion env sigma ((_mib,mip),u) conclty =
   match mip.mind_arity with
   | RegularArity s -> sigma, EConstr.of_constr (subst_instance_constr u s.mind_user_arity)
   | TemplateArity ar ->
@@ -631,7 +631,7 @@ let type_of_inductive_knowing_conclusion env sigma ((mib,mip),u) conclty =
 
 let type_of_projection_knowing_arg env sigma p c ty =
   let c = EConstr.Unsafe.to_constr c in
-  let IndType(pars,realargs) =
+  let IndType(pars,_realargs) =
     try find_rectype env sigma ty
     with Not_found ->
       raise (Invalid_argument "type_of_projection_knowing_arg_type: not an inductive type")

--- a/pretyping/nativenorm.ml
+++ b/pretyping/nativenorm.ml
@@ -299,7 +299,7 @@ and nf_atom_type env sigma atom =
       mkVar id, Typeops.type_of_variable env id
   | Acase(ans,accu,p,bs) ->
       let a,ta = nf_accu_type env sigma accu in
-      let ((mind,_),u as ind),allargs = find_rectype_a env ta in
+      let ((_mind,_),u as ind),allargs = find_rectype_a env ta in
       let (mib,mip) = Inductive.lookup_mind_specif env (fst ind) in
       let nparams = mib.mind_nparams in
       let params,realargs = Array.chop nparams allargs in
@@ -486,5 +486,6 @@ let native_conv_generic pb sigma t =
   Nativeconv.native_conv_gen pb (evars_of_evar_map sigma) t
 
 let native_infer_conv ?(pb=Reduction.CUMUL) env sigma t1 t2 =
-  Reductionops.infer_conv_gen (fun pb ~l2r sigma ts -> native_conv_generic pb sigma)
+  Reductionops.infer_conv_gen (fun pb ~l2r sigma _ts ->
+      ignore(l2r); native_conv_generic pb sigma)
     ~catch_incon:true ~pb env sigma t1 t2

--- a/pretyping/recordops.ml
+++ b/pretyping/recordops.ml
@@ -52,7 +52,7 @@ let projection_table =
 type struc_tuple =
     inductive * constructor * (Name.t * bool) list * Constant.t option list
 
-let load_structure i (_,(ind,id,kl,projs)) =
+let load_structure _i (_,(ind,id,kl,projs)) =
   let n = (fst (Global.lookup_inductive ind)).Declarations.mind_nparams in
   let struc =
     { s_CONST = id; s_EXPECTEDPARAM = n; s_PROJ = projs; s_PROJKIND = kl } in
@@ -264,7 +264,7 @@ let add_canonical_structure warn o =
       with Not_found -> None
       in match ocs with
         | None -> object_table := Refmap.add proj ((pat,s)::l) !object_table;
-        | Some (c, cs) ->
+        | Some (_c, cs) ->
               let old_can_s = (Termops.print_constr (EConstr.of_constr cs.o_DEF))
               and new_can_s = (Termops.print_constr (EConstr.of_constr s.o_DEF)) in
               let prj = (Nametab.pr_global_env Id.Set.empty proj)
@@ -324,13 +324,9 @@ let check_and_decompose_canonical_structure ref =
     | _ ->
        error_not_structure ref "Expected a record or structure constructor applied to arguments." in
   let indsp = match kind f with
-    | Construct ((indsp,1),u) -> indsp
-    | _ -> error_not_structure ref "Expected an instance of a record or structure." in
-  let s =
-    try lookup_structure indsp
-    with Not_found ->
-      error_not_structure ref
-        ("Could not find the record or structure " ^ (MutInd.to_string (fst indsp))) in
+    | Construct ((indsp,1),_u) -> indsp
+    | _ -> error_not_structure ref in
+  let s = try lookup_structure indsp with Not_found -> error_not_structure ref in
   let ntrue_projs = List.count snd s.s_PROJKIND in
   if s.s_EXPECTEDPARAM + ntrue_projs > Array.length args then
     error_not_structure ref "Got too few arguments to the record or structure constructor.";
@@ -344,7 +340,7 @@ let lookup_canonical_conversion (proj,pat) =
 
 let decompose_projection sigma c args =
   match EConstr.kind sigma c with
-  | Const (c, u) ->
+  | Const (c, _u) ->
      let n = find_projection_nparams (ConstRef c) in
      (** Check if there is some canonical projection attached to this structure *)
      let _ = Refmap.find (ConstRef c) !object_table in

--- a/pretyping/typeclasses.ml
+++ b/pretyping/typeclasses.ml
@@ -146,7 +146,7 @@ let class_of_constr sigma c =
   with e when CErrors.noncritical e -> None
 
 let is_class_constr sigma c = 
-  try let gr, u = Termops.global_of_constr sigma c in
+  try let gr, _u = Termops.global_of_constr sigma c in
 	Refmap.mem gr !classes
   with Not_found -> false
 
@@ -261,7 +261,7 @@ let add_class cl =
 
 let check_instance env sigma c =
   try 
-    let (evd, c) = resolve_one_typeclass env sigma
+    let (evd, _c) = resolve_one_typeclass env sigma
       (Retyping.get_type_of env sigma c) in
       not (Evd.has_undefined evd)
   with e when CErrors.noncritical e -> false
@@ -290,7 +290,7 @@ let build_subclasses ~check env sigma glob { hint_priority = pri } =
 	let instapp = EConstr.Unsafe.to_constr instapp in
 	let projargs = Array.of_list (args @ [instapp]) in
 	let projs = List.map_filter 
-	  (fun (n, b, proj) ->
+	  (fun (_n, b, proj) ->
 	   match b with 
 	   | None -> None
 	   | Some (Backward, _) -> None
@@ -419,14 +419,14 @@ let declare_instance info local glob =
   let ty, _ = Global.type_of_global_in_context (Global.env ()) glob in
   let info = Option.default {hint_priority = None; hint_pattern = None} info in
     match class_of_constr Evd.empty (EConstr.of_constr ty) with
-    | Some (rels, ((tc,_), args) as _cl) ->
+    | Some (_rels, ((tc,_), _args) as _cl) ->
       assert (not (isVarRef glob) || local);
       add_instance (new_instance tc info (not local) glob)
     | None -> ()
 
 let add_class cl =
   add_class cl;
-  List.iter (fun (n, inst, body) ->
+  List.iter (fun (_n, inst, body) ->
 	     match inst with
 	     | Some (Backward, info) ->
 	       (match body with
@@ -461,14 +461,14 @@ let instance_constructor (cl,u) args =
 
 let typeclasses () = Refmap.fold (fun _ l c -> l :: c) !classes []
 
-let cmap_elements c = Refmap.fold (fun k v acc -> v :: acc) c []
+let cmap_elements c = Refmap.fold (fun _k v acc -> v :: acc) c []
 
 let instances_of c =
   try cmap_elements (Refmap.find c.cl_impl !instances) with Not_found -> []
 
 let all_instances () = 
-  Refmap.fold (fun k v acc ->
-    Refmap.fold (fun k v acc -> v :: acc) v acc)
+  Refmap.fold (fun _k v acc ->
+    Refmap.fold (fun _k v acc -> v :: acc) v acc)
     !instances []
 
 let instances r = 

--- a/pretyping/typing.ml
+++ b/pretyping/typing.ml
@@ -243,7 +243,7 @@ let judge_of_variable env id =
 
 let judge_of_projection env sigma p cj =
   let pb = lookup_projection p env in
-  let (ind,u), args =
+  let (_ind,u), args =
     try find_mrectype env sigma cj.uj_type
     with Not_found -> error_case_not_inductive env sigma cj
   in
@@ -253,7 +253,7 @@ let judge_of_projection env sigma p cj =
       {uj_val = EConstr.mkProj (p,cj.uj_val);
        uj_type = ty}
 
-let judge_of_abstraction env name var j =
+let judge_of_abstraction _env name var j =
   { uj_val = mkLambda (name, var.utj_val, j.uj_val);
     uj_type = mkProd (name, var.utj_val, j.uj_type) }
 
@@ -262,7 +262,7 @@ let judge_of_product env name t1 t2 =
   { uj_val = mkProd (name, t1.utj_val, t2.utj_val);
     uj_type = mkSort s }
 
-let judge_of_letin env name defj typj j =
+let judge_of_letin _env name defj typj j =
   { uj_val = mkLetIn (name, defj.uj_val, typj.utj_val, j.uj_val) ;
     uj_type = subst1 defj.uj_val j.uj_type }
 
@@ -304,7 +304,7 @@ let rec execute env evdref cstr =
         let lfj = execute_array env evdref lf in
         e_judge_of_case env evdref ci pj cj lfj
 
-    | Fix ((vn,i as vni),recdef) ->
+    | Fix ((_vn,i as vni),recdef) ->
         let (_,tys,_ as recdef') = execute_recdef env evdref recdef in
 	let fix = (vni,recdef') in
         check_fix env !evdref fix;

--- a/pretyping/univdecls.ml
+++ b/pretyping/univdecls.ml
@@ -21,7 +21,7 @@ let default_univ_decl =
     univdecl_constraints = Univ.Constraint.empty;
     univdecl_extensible_constraints = true }
 
-let interp_univ_constraints env evd cstrs =
+let interp_univ_constraints _env evd cstrs =
   let interp (evd,cstrs) (u, d, u') =
     let ul = Pretyping.interp_known_glob_level evd u in
     let u'l = Pretyping.interp_known_glob_level evd u' in

--- a/printing/pputils.ml
+++ b/printing/pputils.ml
@@ -69,7 +69,7 @@ let pr_short_red_flag pr r =
 
 let pr_red_flag pr r =
   try pr_short_red_flag pr r
-  with complexRedFlags ->
+  with _complexRedFlags ->
     (if r.rBeta then pr_arg str "beta" else mt ()) ++
       (if r.rMatch && r.rFix && r.rCofix then pr_arg str "iota" else
           (if r.rMatch then pr_arg str "match" else mt ()) ++
@@ -87,7 +87,7 @@ let pr_union pr1 pr2 = function
   | Inl a -> pr1 a
   | Inr b -> pr2 b
 
-let pr_red_expr (pr_constr,pr_lconstr,pr_ref,pr_pattern) keyword = function
+let pr_red_expr (pr_constr,_pr_lconstr,pr_ref,pr_pattern) keyword = function
   | Red false -> keyword "red"
   | Hnf -> keyword "hnf"
   | Simpl (f,o) -> keyword "simpl" ++ (pr_short_red_flag pr_ref f)
@@ -145,7 +145,7 @@ let rec pr_raw_generic env (GenArg (Rawwit wit, x)) =
       let p = in_gen (rawwit wit1) p in
       let q = in_gen (rawwit wit2) q in
       hov_if_not_empty 0 (pr_sequence (pr_raw_generic env) [p; q])
-    | ExtraArg s ->
+    | ExtraArg _s ->
        let open Genprint in
        match generic_raw_print (in_gen (rawwit wit) x) with
        | PrinterBasic pp -> pp ()
@@ -170,7 +170,7 @@ let rec pr_glb_generic env (GenArg (Glbwit wit, x)) =
       let q = in_gen (glbwit wit2) q in
       let ans = pr_sequence (pr_glb_generic env) [p; q] in
       hov_if_not_empty 0 ans
-    | ExtraArg s ->
+    | ExtraArg _s ->
        let open Genprint in
        match generic_glb_print (in_gen (glbwit wit) x) with
        | PrinterBasic pp -> pp ()

--- a/printing/ppvernac.ml
+++ b/printing/ppvernac.ml
@@ -157,7 +157,7 @@ open Decl_kinds
 
   let pr_explanation (e,b,f) =
     let a = match e with
-      | ExplByPos (n,_) -> anomaly (Pp.str "No more supported.")
+      | ExplByPos (_n,_) -> anomaly (Pp.str "No more supported.")
       | ExplByName id -> pr_id id in
     let a = if f then str"!" ++ a else a in
     if b then str "[" ++ a ++ str "]" else a
@@ -178,7 +178,7 @@ open Decl_kinds
       | StringValue s -> spc() ++ str s
       | StringOptValue None -> mt()
       | StringOptValue (Some s) -> spc() ++ str s
-      | BoolValue b -> mt()
+      | BoolValue _b -> mt()
     in pr_printoption a None ++ pr_opt_value b
 
   let pr_opt_hintbases l = match l with
@@ -279,7 +279,7 @@ open Decl_kinds
       keyword "Import" ++ spc ()
     | None -> mt()
 
-  let pr_module_vardecls pr_c (export,idl,(mty,inl)) =
+  let pr_module_vardecls pr_c (export,idl,(mty,_inl)) =
     let m = pr_module_ast true pr_c mty in
     spc() ++
       hov 1 (str"(" ++ pr_require_token export ++
@@ -289,10 +289,10 @@ open Decl_kinds
     prlist_strict (pr_module_vardecls pr_c) l
 
   let pr_type_option pr_c = function
-    | { v = CHole (k, Misctypes.IntroAnonymous, _) } -> mt()
+    | { CAst.v = CHole (_k, Misctypes.IntroAnonymous, _) } -> mt()
     | _ as c -> brk(0,2) ++ str" :" ++ pr_c c
 
-  let pr_decl_notation prc ({loc; v=ntn},c,scopt) =
+  let pr_decl_notation prc ((_loc,ntn),c,scopt) =
     fnl () ++ keyword "where " ++ qs ntn ++ str " := "
     ++ Flags.without_option Flags.beautify prc c ++
       pr_opt (fun sc -> str ": " ++ str sc) scopt
@@ -446,7 +446,7 @@ open Decl_kinds
     let prpri = match pri with None -> mt() | Some i -> str "| " ++ int i in
     prx ++ prpri ++ prlist (pr_decl_notation pr_constr) ntn
 
-  let pr_record_decl b c fs =
+  let pr_record_decl _b c fs =
     pr_opt pr_lident c ++ (if c = None then str"{" else str" {") ++
       hv 0 (prlist_with_sep pr_semicolon pr_record_field fs ++ str"}")
 
@@ -691,7 +691,7 @@ open Decl_kinds
         )
 
       (* Gallina *)
-      | VernacDefinition ((discharge,kind),id,b) -> (* A verifier... *)
+      | VernacDefinition ((_discharge,kind),id,b) -> (* A verifier... *)
         let pr_def_token dk =
           keyword (
             if Name.is_anonymous (fst id).v
@@ -751,7 +751,7 @@ open Decl_kinds
         let assumptions = prlist_with_sep spc (fun p -> hov 1 (str "(" ++ pr_params p ++ str ")")) l in
         return (hov 2 (pr_assumption_token (n > 1) discharge kind ++
                        pr_non_empty_arg pr_assumption_inline t ++ spc() ++ assumptions))
-      | VernacInductive (cum, p,f,l) ->
+      | VernacInductive (cum, p,_f,l) ->
         let pr_constructor (coe,(id,c)) =
           hov 2 (pr_lident id ++ str" " ++
                    (if coe then str":>" else str":") ++

--- a/printing/prettyp.ml
+++ b/printing/prettyp.ml
@@ -245,7 +245,7 @@ let print_type_in_type ref =
   else []
 
 let print_primitive_record recflag mipv = function
-  | Some (Some (_, ps,_)) ->
+  | Some (Some (_, _ps,_)) ->
     let eta = match recflag with
     | CoFinite | Finite -> str" without eta conversion"
     | BiFinite -> str " with eta conversion"
@@ -344,7 +344,7 @@ let register_locatable name f =
 exception ObjFound of logical_name
 
 let locate_any_name ref =
-  let {v=qid} = qualid_of_reference ref in
+  let (_loc,qid) = qualid_of_reference ref in
   try Term (Nametab.locate qid)
   with Not_found ->
   try Syntactic (Nametab.locate_syndef qid)
@@ -453,7 +453,7 @@ type locatable_kind =
 | LocAny
 
 let print_located_qualid name flags ref =
-  let {v=qid} = qualid_of_reference ref in
+  let (_loc,qid) = qualid_of_reference ref in
   let located = match flags with
   | LocTerm -> locate_term qid
   | LocModule -> locate_modtype qid @ locate_module qid
@@ -650,14 +650,14 @@ let gallina_print_leaf_entry env sigma with_values ((sp,kn as oname),lobj) =
       | (_,("AUTOHINT"|"GRAMMAR"|"SYNTAXCONSTANT"|"PPSYNTAX"|"TOKEN"|"CLASS"|
 	    "COERCION"|"REQUIRE"|"END-SECTION"|"STRUCTURE")) -> None
       (* To deal with forgotten cases... *)
-      | (_,s) -> None
+      | (_,_s) -> None
 
 let gallina_print_library_entry env sigma with_values ent =
   let pr_name (sp,_) = Id.print (basename sp) in
   match ent with
     | (oname,Lib.Leaf lobj) ->
         gallina_print_leaf_entry env sigma with_values (oname,lobj)
-    | (oname,Lib.OpenedSection (dir,_)) ->
+    | (oname,Lib.OpenedSection (_dir,_)) ->
         Some (str " >>>>>>> Section " ++ pr_name oname)
     | (oname,Lib.ClosedSection _) ->
         Some (str " >>>>>>> Closed Section " ++ pr_name oname)
@@ -793,7 +793,7 @@ let read_sec_context r =
   let rec get_cxt in_cxt = function
     | (_,Lib.OpenedSection ({obj_dir;_},_) as hd)::rest ->
         if DirPath.equal dir obj_dir then (hd::in_cxt) else get_cxt (hd::in_cxt) rest
-    | (_,Lib.ClosedSection _)::rest ->
+    | (_,Lib.ClosedSection _)::_rest ->
         user_err Pp.(str "Cannot print the contents of a closed section.")
 	(* LEM: Actually, we could if we wanted to. *)
     | [] -> []
@@ -811,7 +811,7 @@ let print_sec_context_typ env sigma sec =
 let maybe_error_reject_univ_decl na udecl =
   match na, udecl with
   | _, None | Term (ConstRef _ | IndRef _ | ConstructRef _), Some _ -> ()
-  | (Term (VarRef _) | Syntactic _ | Dir _ | ModuleType _ | Other _ | Undefined _), Some udecl ->
+  | (Term (VarRef _) | Syntactic _ | Dir _ | ModuleType _ | Other _ | Undefined _), Some _udecl ->
     (* TODO Print na somehow *)
     user_err ~hdr:"reject_univ_decl" (str "This object does not support universe names.")
 
@@ -867,7 +867,7 @@ let print_opaque_name env sigma qid =
     | VarRef id ->
         env |> lookup_named id |> print_named_decl env sigma
 
-let print_about_any ?loc env sigma k udecl =
+let print_about_any ?loc env _sigma k udecl =
   maybe_error_reject_univ_decl k udecl;
   match k with
   | Term ref ->
@@ -966,14 +966,14 @@ let print_canonical_projections env sigma =
 
 open Typeclasses
 
-let pr_typeclass env t =
+let pr_typeclass _env t =
   print_ref false t.cl_impl None
 
 let print_typeclasses () =
   let env = Global.env () in
     prlist_with_sep fnl (pr_typeclass env) (typeclasses ())
 
-let pr_instance env i =
+let pr_instance _env i =
   (*   gallina_print_constant_with_infos i.is_impl *)
   (* lighter *)
   print_ref false (instance_impl i) None ++

--- a/printing/printmod.ml
+++ b/printing/printmod.ml
@@ -360,7 +360,7 @@ let print_body is_impl env mp (l,body) =
 let print_struct is_impl env mp struc =
   prlist_with_sep spc (print_body is_impl env mp) struc
 
-let print_structure is_type env mp locals struc =
+let print_structure is_type env mp _locals struc =
   let env' = Option.map
     (Modops.add_structure mp struc Mod_subst.empty_delta_resolver) env in
   nametab_register_module_body mp struc;
@@ -397,7 +397,7 @@ let rec print_typ_expr env mp locals mty =
              keyword "Module"++ spc() ++ str s ++ spc() ++ str ":="++ spc()
              ++ print_modpath locals mp')
 
-let print_mod_expr env mp locals = function
+let print_mod_expr _env _mp locals = function
   | MEident mp -> print_modpath locals mp
   | MEapply _ as me ->
       let lapp = flatten_app me [] in

--- a/proofs/evar_refiner.ml
+++ b/proofs/evar_refiner.ml
@@ -24,7 +24,7 @@ open Ltac_pretype
 
 type glob_constr_ltac_closure = ltac_var_map * glob_constr
 
-let depends_on_evar sigma evk _ (pbty,_,t1,t2) =
+let depends_on_evar sigma evk _ (_pbty,_,t1,t2) =
   let t1 = EConstr.of_constr t1 in
   let t2 = EConstr.of_constr t2 in
   try Evar.equal (head_evar sigma t1) evk

--- a/proofs/logic.ml
+++ b/proofs/logic.ml
@@ -280,7 +280,7 @@ let insert_decl_in_named_context sigma decl hto sign =
 (* Will only be used on terms given to the Refine rule which have meta
 variables only in Application and Case *)
 
-let error_unsupported_deep_meta c =
+let error_unsupported_deep_meta _c =
   user_err  (strbrk "Application of lemmas whose beta-iota normal " ++
     strbrk "form contains metavariables deep inside the term is not " ++
     strbrk "supported; try \"refine\" instead.")
@@ -363,7 +363,7 @@ let rec mk_refgoals sigma goal goalacc conclty trm =
 	  if is_template_polymorphic env sigma (EConstr.of_constr f) then
 	    let ty = 
 	      (* Template polymorphism of definitions and inductive types *)
-	      let firstmeta = Array.findi (fun i x -> occur_meta sigma (EConstr.of_constr x)) l in
+	      let firstmeta = Array.findi (fun _i x -> occur_meta sigma (EConstr.of_constr x)) l in
 	      let args, _ = Option.cata (fun i -> CArray.chop i l) (l, [||]) firstmeta in
 	        type_of_global_reference_knowing_parameters env sigma (EConstr.of_constr f) (Array.map EConstr.of_constr args)
 	    in
@@ -378,7 +378,7 @@ let rec mk_refgoals sigma goal goalacc conclty trm =
         (acc'',conclty',sigma, ans)
 
       | Proj (p,c) ->
-	let (acc',cty,sigma,c') = mk_hdgoals sigma goal goalacc c in
+	let (acc',_cty,sigma,c') = mk_hdgoals sigma goal goalacc c in
 	let c = mkProj (p, c') in
 	let ty = get_type_of env sigma (EConstr.of_constr c) in
 	let ty = EConstr.Unsafe.to_constr ty in
@@ -454,7 +454,7 @@ and mk_hdgoals sigma goal goalacc trm =
 	(acc'',conclty',sigma, ans)
 
     | Proj (p,c) ->
-         let (acc',cty,sigma,c') = mk_hdgoals sigma goal goalacc c in
+         let (acc',_cty,sigma,c') = mk_hdgoals sigma goal goalacc c in
 	 let c = mkProj (p, c') in
          let ty = get_type_of env sigma (EConstr.of_constr c) in
          let ty = EConstr.Unsafe.to_constr ty in
@@ -477,7 +477,7 @@ and mk_arggoals sigma goal goalacc funty allargs =
     let t = collapse t in
     match kind t with
     | Prod (_, c1, b) ->
-      let (acc, hargty, sigma, arg) = mk_refgoals sigma goal goalacc c1 harg in
+      let (acc, _hargty, sigma, arg) = mk_refgoals sigma goal goalacc c1 harg in
       (acc, subst1 harg b, sigma), arg
     | _ ->
       let env = Goal.V82.env sigma goal in
@@ -489,7 +489,7 @@ and mk_casegoals sigma goal goalacc p c =
   let env = Goal.V82.env sigma goal in
   let (acc',ct,sigma,c') = mk_hdgoals sigma goal goalacc c in
   let ct = EConstr.of_constr ct in
-  let (acc'',pt,sigma,p') = mk_hdgoals sigma goal acc' p in
+  let (acc'',_pt,sigma,p') = mk_hdgoals sigma goal acc' p in
   let ((ind, u), spec) =
     try Tacred.find_hnf_rectype env sigma ct
     with Not_found -> anomaly (Pp.str "mk_casegoals.") in

--- a/proofs/miscprint.ml
+++ b/proofs/miscprint.ml
@@ -52,9 +52,9 @@ let pr_move_location pr_id = function
   | MoveLast -> str " at bottom"
 
 (** Printing of bindings *)
-let pr_binding prc = let open CAst in function
-  | {loc;v=(NamedHyp id, c)} -> hov 1 (Names.Id.print id ++ str " := " ++ cut () ++ prc c)
-  | {loc;v=(AnonHyp n, c)} -> hov 1 (int n ++ str " := " ++ cut () ++ prc c)
+let pr_binding prc = function
+  | _loc, (NamedHyp id, c) -> hov 1 (Names.Id.print id ++ str " := " ++ cut () ++ prc c)
+  | _loc, (AnonHyp n, c) -> hov 1 (int n ++ str " := " ++ cut () ++ prc c)
 
 let pr_bindings prc prlc = function
   | ImplicitBindings l ->

--- a/proofs/proof_global.ml
+++ b/proofs/proof_global.ml
@@ -410,7 +410,7 @@ let close_proof ~keep_body_ucst_separate ?feedback_id ~now
   fun pr_ending -> CEphemeron.get terminator pr_ending
 
 let return_proof ?(allow_partial=false) () =
- let { pid; proof; strength = (_,poly,_) } = cur_pstate () in
+ let { pid; proof; strength = (_,_poly,_) } = cur_pstate () in
  if allow_partial then begin
   let proofs = Proof.partial_proof proof in
   let _,_,_,_, evd = Proof.proof proof in
@@ -463,7 +463,7 @@ module V82 = struct
   let get_current_initial_conclusions () =
   let { pid; strength; proof } = cur_pstate () in
   let initial = Proof.initial_goals proof in
-  let goals = List.map (fun (o, c) -> c) initial in
+  let goals = List.map (fun (_o, c) -> c) initial in
     pid, (goals, strength)
 end
 
@@ -483,16 +483,13 @@ let update_global_env () =
   with_current_proof (fun _ p ->
      Proof.in_proof p (fun sigma ->
        let tac = Proofview.Unsafe.tclEVARS (Evd.update_sigma_env sigma (Global.env ())) in
-       let (p,(status,info)) = Proof.run_tactic (Global.env ()) tac p in
+       let (p,(_status,_info)) = Proof.run_tactic (Global.env ()) tac p in
          (p, ())))
 
 (* XXX: Bullet hook, should be really moved elsewhere *)
 let _ =
-  let hook n =
-    try
-      let prf = give_me_the_proof () in
-      (Proof_bullet.suggest prf)
-    with NoCurrentProof -> mt ()
-  in
+  let hook _n =
+    let prf = give_me_the_proof () in
+    (Proof_bullet.suggest prf) in
   Proofview.set_nosuchgoals_hook hook
 

--- a/proofs/refine.ml
+++ b/proofs/refine.ml
@@ -62,10 +62,10 @@ let add_if_undefined kn cb env =
 
 (* Add the side effects to the monad's environment, if not already done. *)
 let add_side_effect env = function
-  | { Entries.eff = Entries.SEsubproof (kn, cb, eff_env) } ->
+  | { Entries.eff = Entries.SEsubproof (kn, cb, _eff_env) } ->
     add_if_undefined kn cb env
   | { Entries.eff = Entries.SEscheme (l,_) } ->
-    List.fold_left (fun env (_,kn,cb,eff_env) ->
+    List.fold_left (fun env (_,kn,cb,_eff_env) ->
         add_if_undefined kn cb env) env l
 
 let add_side_effects env effects =

--- a/proofs/refiner.ml
+++ b/proofs/refiner.ml
@@ -62,15 +62,15 @@ let tclIDTAC_MESSAGE s gls =
   Feedback.msg_info (hov 0 s); tclIDTAC gls
 
 (* General failure tactic *)
-let tclFAIL_s s gls = user_err ~hdr:"Refiner.tclFAIL_s" (str s)
+let tclFAIL_s s _gls = user_err ~hdr:"Refiner.tclFAIL_s" (str s)
 
 (* A special exception for levels for the Fail tactic *)
 exception FailError of int * Pp.t Lazy.t
 
 (* The Fail tactic *)
-let tclFAIL lvl s g = raise (FailError (lvl,lazy s))
+let tclFAIL lvl s _g = raise (FailError (lvl,lazy s))
 
-let tclFAIL_lazy lvl s g = raise (FailError (lvl,s))
+let tclFAIL_lazy lvl s _g = raise (FailError (lvl,s))
 
 let start_tac gls =
   let sigr, g = unpackage gls in

--- a/stm/asyncTaskQueue.ml
+++ b/stm/asyncTaskQueue.ml
@@ -259,7 +259,7 @@ module Make(T : Task) () = struct
 
   let broadcast { queue } = TQueue.broadcast queue
 
-  let enqueue_task { queue; active } t ~cancel_switch =
+  let enqueue_task { queue; _ } t ~cancel_switch =
     stm_prerr_endline ("Enqueue task "^T.name_of_task t);
     TQueue.push queue (t, cancel_switch)
 

--- a/stm/coqworkmgrApi.ml
+++ b/stm/coqworkmgrApi.ml
@@ -139,7 +139,7 @@ let tryget n =
 let giveback n =
   with_manager
   (fun () -> ())
-  (fun cin cout ->
+  (fun _cin cout ->
     output_string cout (print_request (GiveBack n));
     flush cout)
 

--- a/stm/proofBlockDelimiter.ml
+++ b/stm/proofBlockDelimiter.ml
@@ -107,8 +107,8 @@ let () = register_proof_block_delimiter
 
 (* ******************** { block } ***************************************** *)
   
-let static_curly_brace ({ entry_point; prev_node } as view) =
-  assert(Vernacprop.under_control entry_point.ast = Vernacexpr.VernacEndSubproof);
+let static_curly_brace ({ entry_point; prev_node = _ } as view) =
+  assert(entry_point.ast = Vernacexpr.VernacEndSubproof);
   crawl view (fun (nesting,prev) node ->
     if Vernacprop.has_Fail node.ast then `Cont (nesting,node)
     else match Vernacprop.under_control node.ast with
@@ -164,7 +164,7 @@ let static_indent ({ entry_point; prev_node } as view) =
    | Some last_tac ->
       if last_tac.indentation <= entry_point.indentation then None
       else
-        crawl view ~init:(Some last_tac) (fun prev node ->
+        crawl view ~init:(Some last_tac) (fun _prev node ->
         if node.indentation >= last_tac.indentation then `Cont node
         else 
           `Found { block_stop = entry_point.id; block_start = node.id;

--- a/stm/tQueue.ml
+++ b/stm/tQueue.ml
@@ -31,13 +31,13 @@ end = struct
     let rec aux acc = function
       | [] -> raise Queue.Empty
       | (_,x) :: xs when picky x -> t := (List.rev acc @ xs, rel); x
-      | (_,x) as hd :: xs -> aux (hd :: acc) xs in
+      | (_,_x) as hd :: xs -> aux (hd :: acc) xs in
     aux [] l
   let push ({ contents = (xs, rel) } as t) x =
     incr age;
     (* re-roting the whole list is not the most efficient way... *)
     t := (List.sort rel (xs @ [!age,x]), rel)
-  let clear ({ contents = (l, rel) } as t) = t := ([], rel)
+  let clear ({ contents = (_l, rel) } as t) = t := ([], rel)
   let set_rel rel ({ contents = (xs, _) } as t) =
     let rel (_,x) (_,y) = rel x y in
     t := (List.sort rel xs, rel)
@@ -102,12 +102,12 @@ let length { queue = q; lock = m } =
   Mutex.unlock m;
   n
 
-let clear { queue = q; lock = m; cond = c } =
+let clear { queue = q; lock = m; cond = _c } =
   Mutex.lock m;
   PriorityQueue.clear q;
   Mutex.unlock m
 
-let clear_saving { queue = q; lock = m; cond = c } f =
+let clear_saving { queue = q; lock = m; cond = _c } f =
   Mutex.lock m;
   let saved = ref [] in
   while not (PriorityQueue.is_empty q) do

--- a/stm/vcs.ml
+++ b/stm/vcs.ml
@@ -182,7 +182,7 @@ let reachable vcs i = closure Dag.NodeSet.empty vcs.dag i
 
 let gc vcs =
   let alive =
-    BranchMap.fold (fun b { pos } s -> closure s vcs.dag pos)
+    BranchMap.fold (fun _b { pos } s -> closure s vcs.dag pos)
       vcs.heads Dag.NodeSet.empty in
   let dead = Dag.NodeSet.diff (Dag.all_nodes vcs.dag) alive in
   { vcs with dag = Dag.del_nodes vcs.dag dead }, dead

--- a/stm/vernac_classifier.ml
+++ b/stm/vernac_classifier.ml
@@ -97,9 +97,10 @@ let classify_vernac e =
        let guarantee = if poly then Doesn'tGuaranteeOpacity else GuaranteesOpacity in
         VtStartProof(default_proof_mode (),guarantee, idents_of_name i), VtLater
     | VernacStartTheoremProof (_,l) ->
-        let ids = List.map (fun (({v=i}, _), _) -> i) l in
-       let guarantee = if poly then Doesn'tGuaranteeOpacity else GuaranteesOpacity in
-        VtStartProof (default_proof_mode (),guarantee,ids), VtLater
+        let ids = 
+          CList.map_filter (function (Some ((_,i),_pl), _) -> Some i | _ -> None) l in
+        VtStartProof (default_proof_mode (),GuaranteesOpacity,ids), VtLater
+    | VernacGoal _ -> VtStartProof (default_proof_mode (),GuaranteesOpacity,[]), VtLater
     | VernacFixpoint (discharge,l) ->
        let guarantee =
          if discharge = Decl_kinds.DoDischarge || poly then Doesn'tGuaranteeOpacity

--- a/stm/vio_checking.ml
+++ b/stm/vio_checking.ml
@@ -54,7 +54,7 @@ let schedule_vio_checking j fs =
         let rec aux last acc = function
           | [] -> [last,acc]
           | ((f',id),_,_) :: tl when last = f' -> aux last (id::acc) tl
-          | ((f',id),_,_) :: _ as l -> (last,acc) :: aux f' [] l in
+          | ((f',_id),_,_) :: _ as l -> (last,acc) :: aux f' [] l in
         aux f [] l in
   let prog = Sys.argv.(0) in  
   let stdargs = filter_argv false (List.tl (Array.to_list Sys.argv)) in
@@ -125,7 +125,7 @@ let schedule_vio_compilation j fs =
   let prog = Sys.argv.(0) in  
   let stdargs = filter_argv false (List.tl (Array.to_list Sys.argv)) in
   let make_job () =
-    let f, t = List.hd !jobs in
+    let f, _t = List.hd !jobs in
     jobs := List.tl !jobs;
     [ "-vio2vo"; f ] in
   let rc = ref 0 in

--- a/tactics/auto.ml
+++ b/tactics/auto.ml
@@ -100,7 +100,7 @@ let connect_hint_clenv poly (c, _, ctx) clenv gl =
 
 let unify_resolve poly flags ((c : raw_hint), clenv) =
   Proofview.Goal.enter begin fun gl ->
-  let clenv, c = connect_hint_clenv poly c clenv gl in
+  let clenv, _c = connect_hint_clenv poly c clenv gl in
   let clenv = clenv_unique_resolver ~flags clenv gl in
   Clenvtac.clenv_refine false clenv
   end
@@ -376,7 +376,7 @@ and my_find_search_delta sigma db_list local_db secvars hdc concl =
 and tac_of_hint dbg db_list local_db concl (flags, ({pat=p; code=t;poly=poly;db=dbname})) =
   let tactic = function
     | Res_pf (c,cl) -> unify_resolve_gen poly flags (c,cl)
-    | ERes_pf _ -> Proofview.Goal.enter (fun gl -> Tacticals.New.tclZEROMSG (str "eres_pf"))
+    | ERes_pf _ -> Proofview.Goal.enter (fun _gl -> Tacticals.New.tclZEROMSG (str "eres_pf"))
     | Give_exact (c, cl)  -> exact poly (c, cl)
     | Res_pf_THEN_trivial_fail (c,cl) ->
       Tacticals.New.tclTHEN

--- a/tactics/autorewrite.ml
+++ b/tactics/autorewrite.ml
@@ -40,11 +40,11 @@ module HintIdent =
 struct
   type t = int * rew_rule
 
-  let compare (i, t) (j, t') = i - j
+  let compare (i, _t) (j, _t') = i - j
 
   let subst s (i,t) = (i,subst_hint s t)
 
-  let constr_of (i,t) = t.rew_pat
+  let constr_of (_i,t) = t.rew_pat
 end
 
 module HintOpt =
@@ -237,7 +237,7 @@ let decompose_applied_relation metas env sigma c ctype left2right =
     in
       try
 	let others,(c1,c2) = split_last_two args in
-	let ty1, ty2 =
+	let ty1, _ty2 =
 	  Typing.unsafe_type_of env eqclause.evd (EConstr.of_constr c1), Typing.unsafe_type_of env eqclause.evd (EConstr.of_constr c2)
 	in
 	let ty = EConstr.Unsafe.to_constr ty in

--- a/tactics/btermdn.ml
+++ b/tactics/btermdn.ml
@@ -53,8 +53,8 @@ let decomp sigma t =
 let constr_val_discr sigma t =
   let c, l = decomp sigma t in
     match EConstr.kind sigma c with
-    | Ind (ind_sp,u) -> Label(GRLabel (IndRef ind_sp),l)
-    | Construct (cstr_sp,u) -> Label(GRLabel (ConstructRef cstr_sp),l)
+    | Ind (ind_sp,_u) -> Label(GRLabel (IndRef ind_sp),l)
+    | Construct (cstr_sp,_u) -> Label(GRLabel (ConstructRef cstr_sp),l)
     | Var id -> Label(GRLabel (VarRef id),l)
     | Const _ -> Everything
     | _ -> Nothing
@@ -66,18 +66,18 @@ let constr_pat_discr t =
     match decomp_pat t with
     | PRef ((IndRef _) as ref), args
     | PRef ((ConstructRef _ ) as ref), args -> Some (GRLabel ref,args)
-    | PRef ((VarRef v) as ref), args -> Some(GRLabel ref,args)
+    | PRef ((VarRef _v) as ref), args -> Some(GRLabel ref,args)
     | _ -> None
 
 let constr_val_discr_st sigma (idpred,cpred) t =
   let c, l = decomp sigma t in
     match EConstr.kind sigma c with
-    | Const (c,u) -> if Cpred.mem c cpred then Everything else Label(GRLabel (ConstRef c),l)
-    | Ind (ind_sp,u) -> Label(GRLabel (IndRef ind_sp),l)
-    | Construct (cstr_sp,u) -> Label(GRLabel (ConstructRef cstr_sp),l)
+    | Const (c,_u) -> if Cpred.mem c cpred then Everything else Label(GRLabel (ConstRef c),l)
+    | Ind (ind_sp,_u) -> Label(GRLabel (IndRef ind_sp),l)
+    | Construct (cstr_sp,_u) -> Label(GRLabel (ConstructRef cstr_sp),l)
     | Var id when not (Id.Pred.mem id idpred) -> Label(GRLabel (VarRef id),l)
-    | Prod (n, d, c) -> Label(ProdLabel, [d; c])
-    | Lambda (n, d, c) -> 
+    | Prod (_n, d, c) -> Label(ProdLabel, [d; c])
+    | Lambda (_n, d, c) -> 
       if List.is_empty l then 
 	Label(LambdaLabel, [d; c] @ l)
       else Everything
@@ -97,7 +97,7 @@ let constr_pat_discr_st (idpred,cpred) t =
       Some (GRLabel ref, args)
   | PProd (_, d, c), [] -> Some (ProdLabel, [d ; c])
   | PLambda (_, d, c), [] -> Some (LambdaLabel, [d ; c])
-  | PSort s, [] -> Some (SortLabel, [])
+  | PSort _s, [] -> Some (SortLabel, [])
   | _ -> None
 
 let bounded_constr_pat_discr_st st (t,depth) =

--- a/tactics/dn.ml
+++ b/tactics/dn.ml
@@ -17,8 +17,8 @@ struct
 	    if Int.equal m 0 then
 	      n-n'
 	    else m
-	| Some(l,n),None -> 1
-	| None, Some(l,n) -> -1
+	| Some(_l,_n),None -> 1
+	| None, Some(_l,_n) -> -1
   end
   module ZSet = Set.Make(Z)
   module X_tries =
@@ -87,7 +87,7 @@ prefix ordering, [dna] is the function returning the main node of a pattern *)
 		 (tm_of tm (Some(lbl,List.length v))) v)
 	| Everything -> skip_arg 1 tm
     in
-    List.flatten (List.map (fun (tm,b) -> ZSet.elements (Trie.get tm)) (lookrec t tm))
+    List.flatten (List.map (fun (tm,_b) -> ZSet.elements (Trie.get tm)) (lookrec t tm))
 
   let add tm dna (pat,inf) =
     let p = path_of dna pat in Trie.add p (ZSet.singleton inf) tm

--- a/tactics/dnet.ml
+++ b/tactics/dnet.ml
@@ -80,7 +80,7 @@ struct
   let empty : t = Nodes (Tmap.empty, Mmap.empty)
 
   (* the head of a data is of type unit structure *)
-  let head w = T.map (fun c -> ()) w
+  let head w = T.map (fun _c -> ()) w
 
   (* given a node of the net and a word, returns the subnet with the
      same head as the word (with the rest of the nodes) *)

--- a/tactics/eauto.ml
+++ b/tactics/eauto.ml
@@ -131,7 +131,7 @@ let hintmap_of sigma secvars hdc concl =
      else (fun db -> Hint_db.map_auto sigma ~secvars hdc concl db)
    (* FIXME: should be (Hint_db.map_eauto hdc concl db) *)
 
-let e_exact poly flags (c,clenv) =
+let e_exact poly _flags (c,clenv) =
   Proofview.Goal.enter begin fun gl ->
     let clenv', c = connect_hint_clenv poly c clenv gl in
     Tacticals.New.tclTHEN
@@ -434,7 +434,7 @@ let make_dimension n = function
 
 let cons a l = a :: l
 
-let autounfolds db occs cls gl =
+let autounfolds db _occs cls gl =
   let unfolds = List.concat (List.map (fun dbname -> 
     let db = try searchtable_map dbname 
       with Not_found -> user_err ~hdr:"autounfold" (str "Unknown database " ++ str dbname)
@@ -480,11 +480,11 @@ let unfold_head env sigma (ids, csts) c =
 	| true, f' -> true, Reductionops.whd_betaiota sigma (mkApp (f', args))
 	| false, _ -> 
 	    let done_, args' = 
-	      Array.fold_left_i (fun i (done_, acc) arg -> 
+	      Array.fold_left_i (fun _i (done_, acc) arg -> 
 		if done_ then done_, arg :: acc 
 		else match aux arg with
 		| true, arg' -> true, arg' :: acc
-		| false, arg' -> false, arg :: acc)
+		| false, _arg' -> false, arg :: acc)
 		(false, []) args
 	    in 
 	      if done_ then true, mkApp (f, Array.of_list (List.rev args'))

--- a/tactics/elim.ml
+++ b/tactics/elim.ml
@@ -105,7 +105,7 @@ let head_in indl t gl =
 let decompose_these c l =
   Proofview.Goal.enter begin fun gl ->
   let indl = List.map (fun x -> x, Univ.Instance.empty) l in
-  general_decompose (fun sigma (_,t) -> head_in indl t gl) c
+  general_decompose (fun _sigma (_,t) -> head_in indl t gl) c
   end
 
 let decompose_and c =

--- a/tactics/elimschemes.ml
+++ b/tactics/elimschemes.ml
@@ -45,7 +45,7 @@ let optimize_non_type_induction_scheme kind dep sort _ ind =
       else
 	mib.mind_nparams in
     let sigma, sort = Evd.fresh_sort_in_family env sigma sort in
-    let sigma, t', c' = weaken_sort_scheme env sigma false sort npars c t in
+    let sigma, _t', c' = weaken_sort_scheme env sigma false sort npars c t in
     let sigma, nf = Evarutil.nf_evars_and_universes sigma in
       (nf c', Evd.evar_universe_context sigma), eff
   else

--- a/tactics/eqdecide.ml
+++ b/tactics/eqdecide.ml
@@ -82,7 +82,7 @@ let generalize_right mk typ c1 c2 =
   end
   end
 
-let mkBranches (eqonleft,mk,c1,c2,typ) =
+let mkBranches (_eqonleft,mk,c1,c2,typ) =
   tclTHENLIST
     [generalize_right mk typ c1 c2;
      Simple.elim c1;
@@ -98,7 +98,7 @@ let inj_flags = Some {
   }
 
 let discrHyp id =
-  let c env sigma = (sigma, (mkVar id, NoBindings)) in
+  let c _env sigma = (sigma, (mkVar id, NoBindings)) in
   let tac c = Equality.discr_tac false (Some (None, ElimOnConstr c)) in
   Tacticals.New.tclDELAYEDWITHHOLES false c tac
 
@@ -143,7 +143,7 @@ let eqCase tac =
   tclTHEN intro (onLastHypId tac)
 
 let injHyp id =
-  let c env sigma = (sigma, (mkVar id, NoBindings)) in
+  let c _env sigma = (sigma, (mkVar id, NoBindings)) in
   let tac c = Equality.injClause inj_flags None false (Some (None, ElimOnConstr c)) in
   Tacticals.New.tclDELAYEDWITHHOLES false c tac
 
@@ -213,7 +213,7 @@ let solveEqBranch rectype =
         let env = Proofview.Goal.env gl in
         let sigma = project gl in
         match_eqdec env sigma concl >>= fun (eqonleft,mk,lhs,rhs,_) ->
-          let (mib,mip) = Global.lookup_inductive rectype in
+          let (mib,_mip) = Global.lookup_inductive rectype in
           let nparams   = mib.mind_nparams in
           let getargs l = List.skipn nparams (snd (decompose_app sigma l)) in
           let rargs   = getargs rhs
@@ -240,7 +240,7 @@ let decideGralEquality =
         let concl = pf_concl gl in
         let env = Proofview.Goal.env gl in
         let sigma = project gl in
-        match_eqdec env sigma concl >>= fun (eqonleft,mk,c1,c2,typ as data) ->
+        match_eqdec env sigma concl >>= fun (eqonleft,_mk,_c1,_c2,typ as data) ->
         let headtyp = hd_app sigma (pf_compute gl typ) in
         begin match EConstr.kind sigma headtyp with
         | Ind (mi,_) -> Proofview.tclUNIT mi

--- a/tactics/eqschemes.ml
+++ b/tactics/eqschemes.ml
@@ -67,7 +67,7 @@ module RelDecl = Context.Rel.Declaration
 let hid = Id.of_string "H"
 let xid = Id.of_string "X"
 let default_id_of_sort = function InProp | InSet -> hid | InType -> xid
-let fresh env id = next_global_ident_away id Id.Set.empty
+let fresh _env id = next_global_ident_away id Id.Set.empty
 let with_context_set ctx (b, ctx') = 
   (b, Univ.ContextSet.union ctx ctx')
 
@@ -192,7 +192,7 @@ let get_non_sym_eq_data env (ind,u) =
 (**********************************************************************)
 
 let build_sym_scheme env ind =
-  let (ind,u as indu), ctx = Universes.fresh_inductive_instance env ind in
+  let (ind,_u as indu), ctx = Universes.fresh_inductive_instance env ind in
   let (mib,mip as specif),nrealargs,realsign,paramsctxt,paramsctxt1 =
     get_sym_eq_data env indu in
   let cstr n =
@@ -238,14 +238,14 @@ let sym_scheme_kind =
 (*                                                                    *)
 (**********************************************************************)
 
-let const_of_scheme kind env ind ctx = 
+let const_of_scheme kind _env ind ctx = 
   let sym_scheme, eff = (find_scheme kind ind) in
   let sym, ctx = with_context_set ctx 
     (Universes.fresh_constant_instance (Global.env()) sym_scheme) in
     mkConstU sym, ctx, eff
 
 let build_sym_involutive_scheme env ind =
-  let (ind,u as indu), ctx = Universes.fresh_inductive_instance env ind in
+  let (ind,_u as indu), ctx = Universes.fresh_inductive_instance env ind in
   let (mib,mip as specif),nrealargs,realsign,paramsctxt,paramsctxt1 =
     get_sym_eq_data env indu in
   let eq,eqrefl,ctx = get_coq_eq ctx in
@@ -353,12 +353,12 @@ let sym_involutive_scheme_kind =
 (**********************************************************************)
 
 let build_l2r_rew_scheme dep env ind kind =
-  let (ind,u as indu), ctx = Universes.fresh_inductive_instance env ind in
-  let (mib,mip as specif),nrealargs,realsign,paramsctxt,paramsctxt1 =
+  let (ind,_u as indu), ctx = Universes.fresh_inductive_instance env ind in
+  let (_mib,mip as specif),nrealargs,realsign,paramsctxt,paramsctxt1 =
     get_sym_eq_data env indu in
   let sym, ctx, eff = const_of_scheme sym_scheme_kind env ind ctx in
   let sym_involutive, ctx, eff' = const_of_scheme sym_involutive_scheme_kind env ind ctx in
-  let eq,eqrefl,ctx = get_coq_eq ctx in
+  let eq,_eqrefl,ctx = get_coq_eq ctx in
   let cstr n p =
     mkApp (mkConstructUi(indu,1),
       Array.concat [Context.Rel.to_extended_vect mkRel n paramsctxt1;
@@ -469,8 +469,8 @@ let build_l2r_rew_scheme dep env ind kind =
 (**********************************************************************)
 
 let build_l2r_forward_rew_scheme dep env ind kind =
-  let (ind,u as indu), ctx = Universes.fresh_inductive_instance env ind in
-  let (mib,mip as specif),nrealargs,realsign,paramsctxt,paramsctxt1 =
+  let (ind,_u as indu), ctx = Universes.fresh_inductive_instance env ind in
+  let (_mib,mip as specif),nrealargs,realsign,paramsctxt,paramsctxt1 =
     get_sym_eq_data env indu in
   let cstr n p =
     mkApp (mkConstructUi(indu,1),
@@ -561,7 +561,7 @@ let build_l2r_forward_rew_scheme dep env ind kind =
 (**********************************************************************)
 
 let build_r2l_forward_rew_scheme dep env ind kind = 
-  let (ind,u as indu), ctx = Universes.fresh_inductive_instance env ind in
+  let (ind,_u as indu), ctx = Universes.fresh_inductive_instance env ind in
   let ((mib,mip as specif),constrargs,realsign,paramsctxt,nrealargs) =
     get_non_sym_eq_data env indu in
   let cstr n =

--- a/tactics/hipattern.ml
+++ b/tactics/hipattern.ml
@@ -49,8 +49,8 @@ let match_with_non_recursive_type sigma t =
     | App _ ->
         let (hdapp,args) = decompose_app sigma t in
         (match EConstr.kind sigma hdapp with
-           | Ind (ind,u) ->
-               if (Global.lookup_mind (fst ind)).mind_finite == CoFinite then
+           | Ind (ind,_u) ->
+               if (Global.lookup_mind (fst ind)).mind_finite == Decl_kinds.CoFinite then
 		 Some (hdapp,args)
 	       else
 		 None
@@ -132,8 +132,8 @@ let match_with_one_constructor sigma style onlybinary allow_rec t =
 	None
   | _ -> None in
   match res with
-  | Some (hdapp, args) when not onlybinary -> res
-  | Some (hdapp, [_; _]) -> res
+  | Some (_hdapp, _args) when not onlybinary -> res
+  | Some (_hdapp, [_; _]) -> res
   | _ -> None
 
 let match_with_conjunction ?(strict=false) ?(onlybinary=false) sigma t =
@@ -175,7 +175,7 @@ let test_strict_disjunction n lc =
 let match_with_disjunction ?(strict=false) ?(onlybinary=false) sigma t =
   let (hdapp,args) = decompose_app sigma t in
   let res = match EConstr.kind sigma hdapp with
-  | Ind (ind,u)  ->
+  | Ind (ind,_u)  ->
       let car = constructors_nrealargs ind in
       let (mib,mip) = Global.lookup_inductive ind in
       if Array.for_all (fun ar -> Int.equal ar 1) car
@@ -196,8 +196,8 @@ let match_with_disjunction ?(strict=false) ?(onlybinary=false) sigma t =
 	None
   | _ -> None in
   match res with
-  | Some (hdapp,args) when not onlybinary -> res
-  | Some (hdapp,[_; _]) -> res
+  | Some (_hdapp,_args) when not onlybinary -> res
+  | Some (_hdapp,[_; _]) -> res
   | _ -> None
 
 let is_disjunction ?(strict=false) ?(onlybinary=false) sigma t =
@@ -207,10 +207,10 @@ let is_disjunction ?(strict=false) ?(onlybinary=false) sigma t =
    constructors *)
 
 let match_with_empty_type sigma t =
-  let (hdapp,args) = decompose_app sigma t in
+  let (hdapp,_args) = decompose_app sigma t in
   match EConstr.kind sigma hdapp with
     | Ind (ind, _) ->
-        let (mib,mip) = Global.lookup_inductive ind in
+        let (_mib,mip) = Global.lookup_inductive ind in
         let nconstr = Array.length mip.mind_consnames in
 	if Int.equal nconstr 0 then Some hdapp else None
     | _ ->  None
@@ -221,7 +221,7 @@ let is_empty_type sigma t = op2bool (match_with_empty_type sigma t)
    Parameters and indices are allowed *)
 
 let match_with_unit_or_eq_type sigma t =
-  let (hdapp,args) = decompose_app sigma t in
+  let (hdapp,_args) = decompose_app sigma t in
   match EConstr.kind sigma hdapp with
     | Ind (ind , _) ->
         let (mib,mip) = Global.lookup_inductive ind in
@@ -293,7 +293,7 @@ let match_with_equation env sigma t =
   if not (isApp sigma t) then raise NoEquationFound;
   let (hdapp,args) = destApp sigma t in
   match EConstr.kind sigma hdapp with
-  | Ind (ind,u) ->
+  | Ind (ind,_u) ->
       if eq_gr (IndRef ind) glob_eq then
 	Some (build_coq_eq_data()),hdapp,
 	PolymorphicLeibnizEq(args.(0),args.(1),args.(2))
@@ -304,7 +304,7 @@ let match_with_equation env sigma t =
 	Some (build_coq_jmeq_data()),hdapp,
 	HeterogenousEq(args.(0),args.(1),args.(2),args.(3))
       else
-        let (mib,mip) = Global.lookup_inductive ind in
+        let (_mib,mip) = Global.lookup_inductive ind in
         let constr_types = mip.mind_nf_lc in
         let nconstr = Array.length mip.mind_consnames in
 	if Int.equal nconstr 1 then
@@ -324,7 +324,7 @@ let match_with_equation env sigma t =
    in particular, True/unit are provable by "reflexivity" *)
 
 let is_inductive_equality ind =
-  let (mib,mip) = Global.lookup_inductive ind in
+  let (_mib,mip) = Global.lookup_inductive ind in
   let nconstr = Array.length mip.mind_consnames in
   Int.equal nconstr 1 && Int.equal (constructor_nrealargs (ind,1)) 0
 
@@ -445,7 +445,7 @@ let equalities =
 
 let find_eq_data sigma eqn = (* fails with PatternMatchingFailure *)
   let d,k = first_match (match_eq sigma eqn) equalities in
-  let hd,u = destInd sigma (fst (destApp sigma eqn)) in
+  let _hd,u = destInd sigma (fst (destApp sigma eqn)) in
     d,u,k
 
 let extract_eq_args gl = function
@@ -474,7 +474,7 @@ let find_this_eq_data_decompose gl eqn =
 
 (*** Sigma-types *)
 
-let match_sigma env sigma ex =
+let match_sigma _env sigma ex =
   match EConstr.kind sigma ex with
   | App (f, [| a; p; car; cdr |]) when Termops.is_global sigma (Lazy.force coq_exist_ref) f -> 
       build_sigma (), (snd (destConstruct sigma f), a, p, car, cdr)

--- a/tactics/ind_tables.ml
+++ b/tactics/ind_tables.ml
@@ -157,9 +157,9 @@ let define_individual_scheme_base kind suff f mode idopt (mind,i as ind) =
   const, Safe_typing.add_private
      (Safe_typing.private_con_of_scheme ~kind (Global.safe_env()) [ind,const]) eff
 
-let define_individual_scheme kind mode names (mind,i as ind) =
+let define_individual_scheme kind mode names (_mind,_i as ind) =
   match Hashtbl.find scheme_object_table kind with
-  | _,MutualSchemeFunction f -> assert false
+  | _,MutualSchemeFunction _f -> assert false
   | s,IndividualSchemeFunction f ->
       define_individual_scheme_base kind s f mode names ind
 

--- a/tactics/leminv.ml
+++ b/tactics/leminv.ml
@@ -159,7 +159,7 @@ let compute_first_inversion_scheme env sigma ind sort dep_option =
       let ivars = global_vars env sigma i in
       let revargs,ownsign =
 	fold_named_context
-	  (fun env d (revargs,hyps) ->
+	  (fun _env d (revargs,hyps) ->
             let d = map_named_decl EConstr.of_constr d in
              let id = NamedDecl.get_id d in
              if Id.List.mem id ivars then
@@ -210,7 +210,7 @@ let inversion_scheme env sigma t sort dep_option inv_op =
   let global_named_context = Global.named_context_val () in
   let ownSign = ref begin
     fold_named_context
-      (fun env d sign ->
+      (fun _env d sign ->
         let d = map_named_decl EConstr.of_constr d in
          if mem_named_context_val (NamedDecl.get_id d) global_named_context then sign
 	 else Context.Named.add d sign)
@@ -273,7 +273,7 @@ let lemInv id c =
     | NoSuchBinding ->
 	user_err 
 	  (hov 0 (pr_econstr_env (pf_env gls) (project gls) c ++ spc () ++ str "does not refer to an inversion lemma."))
-    | UserError (a,b) ->
+    | UserError (_a,_b) ->
 	 user_err ~hdr:"LemInv"
 	   (str "Cannot refine current goal with the lemma " ++
 	      pr_leconstr_env (pf_env gls) (project gls) c)

--- a/tactics/tacticals.ml
+++ b/tactics/tacticals.ml
@@ -225,7 +225,7 @@ let compute_induction_names_gen check_and branchletsigns = function
 let compute_induction_names = compute_induction_names_gen true
 
 (* Compute the let-in signature of case analysis or standard induction scheme *)
-let compute_constructor_signatures isrec ((_,k as ity),u) =
+let compute_constructor_signatures isrec ((_,k as ity),_u) =
   let rec analrec c recargs =
     match Constr.kind c, recargs with
     | Prod (_,_,c), recarg::rest ->
@@ -404,7 +404,7 @@ module New = struct
     tclINDEPENDENT begin
       Proofview.tclIFCATCH t1
         (fun () -> t2)
-        (fun (e, info) -> Proofview.tclORELSE t3 (fun e' -> tclZERO ~info e))
+        (fun (e, info) -> Proofview.tclORELSE t3 (fun _e' -> tclZERO ~info e))
     end
   let tclIFTHENSVELSE t1 a t3 =
     Proofview.tclIFCATCH t1
@@ -480,14 +480,14 @@ module New = struct
       match Evd.evar_body evi with
       | Evd.Evar_empty -> Some (evk,evi)
       | Evd.Evar_defined c -> match Constr.kind c with
-        | Term.Evar (evk,l) -> is_undefined_up_to_restriction sigma evk
+        | Term.Evar (evk,_l) -> is_undefined_up_to_restriction sigma evk
         | _ -> 
           (* We make the assumption that there is no way to refine an
             evar remaining after typing from the initial term given to
             apply/elim and co tactics, is it correct? *)
           None in
     let rest =
-      Evd.fold_undefined (fun evk evi acc ->
+      Evd.fold_undefined (fun evk _evi acc ->
         match is_undefined_up_to_restriction sigma evk with
         | Some (evk',evi) -> (evk',evi)::acc
         | _ -> acc)

--- a/tactics/term_dnet.ml
+++ b/tactics/term_dnet.ml
@@ -58,7 +58,7 @@ struct
     | DCtx (ctx,t) -> f ctx ++ spc() ++ str "|-" ++ spc () ++ f t
     | DLambda (t1,t2) -> str "fun"++ spc() ++ f t1 ++ spc() ++ str"->" ++ spc() ++ f t2
     | DApp (t1,t2) -> f t1 ++ spc() ++ f t2
-    | DCase (_,t1,t2,ta) -> str "case"
+    | DCase (_,_t1,_t2,_ta) -> str "case"
     | DFix _ -> str "fix"
     | DCoFix _ -> str "cofix"
     | DCons ((t,dopt),tl) -> f t ++ (match dopt with
@@ -161,22 +161,22 @@ struct
     | DCtx (ctx,c) -> f (f acc ctx) c
     | DLambda (t,c) -> f (f acc t) c
     | DApp (t,u) -> f (f acc t) u
-    | DCase (ci,p,c,bl) -> Array.fold_left f (f (f acc p) c) bl
-    | DFix (ia,i,ta,ca) ->
+    | DCase (_ci,p,c,bl) -> Array.fold_left f (f (f acc p) c) bl
+    | DFix (_ia,_i,ta,ca) ->
 	Array.fold_left f (Array.fold_left f acc ta) ca
-    | DCoFix(i,ta,ca) ->
+    | DCoFix(_i,ta,ca) ->
 	Array.fold_left f (Array.fold_left f acc ta) ca
     | DCons ((t,topt),u) -> f (Option.fold_left f (f acc t) topt) u
 
   let choose f = function
     | (DRel | DSort | DNil | DRef _) -> invalid_arg "choose"
-    | DCtx (ctx,c) -> f ctx
-    | DLambda (t,c) -> f t
-    | DApp (t,u) -> f u
-    | DCase (ci,p,c,bl) -> f c
-    | DFix (ia,i,ta,ca) -> f ta.(0)
-    | DCoFix (i,ta,ca) -> f ta.(0)
-    | DCons ((t,topt),u) -> f u
+    | DCtx (ctx,_c) -> f ctx
+    | DLambda (t,_c) -> f t
+    | DApp (_t,u) -> f u
+    | DCase (_ci,_p,c,_bl) -> f c
+    | DFix (_ia,_i,ta,_ca) -> f ta.(0)
+    | DCoFix (_i,ta,_ca) -> f ta.(0)
+    | DCons ((_t,_topt),u) -> f u
 
   let dummy_cmp () () = 0
 
@@ -189,11 +189,11 @@ struct
 	| (DCtx (c1,t1), DCtx (c2,t2)
 	  | DApp (c1,t1), DApp (c2,t2)
 	  | DLambda (c1,t1), DLambda (c2,t2)) -> f (f acc c1 c2) t1 t2
-	| DCase (ci,p1,c1,bl1),DCase (_,p2,c2,bl2) ->
+	| DCase (_ci,p1,c1,bl1),DCase (_,p2,c2,bl2) ->
 	    Array.fold_left2 f (f (f acc p1 p2) c1 c2) bl1 bl2
-	| DFix (ia,i,ta1,ca1), DFix (_,_,ta2,ca2) ->
+	| DFix (_ia,_i,ta1,ca1), DFix (_,_,ta2,ca2) ->
 	    Array.fold_left2 f (Array.fold_left2 f acc ta1 ta2) ca1 ca2
-	| DCoFix(i,ta1,ca1), DCoFix(_,ta2,ca2) ->
+	| DCoFix(_i,ta1,ca1), DCoFix(_,ta2,ca2) ->
 	    Array.fold_left2 f (Array.fold_left2 f acc ta1 ta2) ca1 ca2
 	| DCons ((t1,topt1),u1), DCons ((t2,topt2),u2) ->
 	    f (Option.fold_left2 f (f acc t1 t2) topt1 topt2) u1 u2
@@ -287,9 +287,9 @@ struct
     | Rel _          -> Term DRel
     | Sort _         -> Term DSort
     | Var i          -> Term (DRef (VarRef i))
-    | Const (c,u)    -> Term (DRef (ConstRef c))
-    | Ind (i,u)      -> Term (DRef (IndRef i))
-    | Construct (c,u)-> Term (DRef (ConstructRef c))
+    | Const (c,_u)    -> Term (DRef (ConstRef c))
+    | Ind (i,_u)      -> Term (DRef (IndRef i))
+    | Construct (c,_u)-> Term (DRef (ConstructRef c))
     | Term.Meta _    -> assert false
     | Evar (i,_)     ->
       let meta =

--- a/tools/coqdep_common.ml
+++ b/tools/coqdep_common.ml
@@ -493,7 +493,7 @@ let coq_dependencies () =
 let rec suffixes = function
   | [] -> assert false
   | [name] -> [[name]]
-  | dir::suffix as l -> l::suffixes suffix
+  | _dir::suffix as l -> l::suffixes suffix
 
 let add_caml_known phys_dir _ f =
   let basename,suff =
@@ -505,7 +505,7 @@ let add_caml_known phys_dir _ f =
     | ".mlpack" -> add_mlpack_known basename (Some phys_dir) suff
     | _ -> ()
 
-let add_coqlib_known recur phys_dir log_dir f =
+let add_coqlib_known recur _phys_dir log_dir f =
   match get_extension f [".vo"; ".vio"] with
     | (basename, (".vo" | ".vio")) ->
         let name = log_dir@[basename] in

--- a/toplevel/coqloop.ml
+++ b/toplevel/coqloop.ml
@@ -54,7 +54,7 @@ let emacs_prompt_endstring   () = if !print_emacs then "</prompt>" else ""
 
 (* Read a char in an input channel, displaying a prompt at every
    beginning of line. *)
-let prompt_char doc ic ibuf count =
+let prompt_char doc ic ibuf _count =
   let bol = match ibuf.bols with
     | ll::_ -> Int.equal ibuf.len ll
     | [] -> Int.equal ibuf.len 0
@@ -234,7 +234,7 @@ let top_buffer =
 
 let set_prompt prompt =
   top_buffer.prompt
-  <- (fun doc ->
+  <- (fun _doc ->
     emacs_prompt_startstring()
     ^ prompt ()
     ^ emacs_prompt_endstring())
@@ -288,7 +288,7 @@ let coqloop_feed (fb : Feedback.feedback) = let open Feedback in
   | FileLoaded (_,_) -> ()
   | Custom (_,_,_) -> ()
   (* Re-enable when we switch back to feedback-based error printing *)
-  | Message (Error,loc,msg) -> ()
+  | Message (Error,_loc,_msg) -> ()
   (* TopErr.print_error_for_buffer ?loc lvl msg top_buffer *)
   | Message (lvl,loc,msg) ->
     TopErr.print_error_for_buffer ?loc lvl msg top_buffer

--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -75,6 +75,26 @@ let print_memory_stat () =
 let _ = at_exit print_memory_stat
 
 (******************************************************************************)
+(* Engagement                                                                 *)
+(******************************************************************************)
+let impredicative_set = ref Declarations.PredicativeSet
+let set_impredicative_set _c = impredicative_set := Declarations.ImpredicativeSet
+let set_type_in_type () =
+  let typing_flags = Environ.typing_flags (Global.env ()) in
+  Global.set_typing_flags { typing_flags with Declarations.check_universes = false }
+let engage () =
+  Global.set_engagement !impredicative_set
+
+(******************************************************************************)
+(* Interactive toplevel name                                                  *)
+(******************************************************************************)
+let toplevel_default_name = Names.(DirPath.make [Id.of_string "Top"])
+let toplevel_name = ref toplevel_default_name
+let set_toplevel_name dir =
+  if Names.DirPath.is_empty dir then user_err Pp.(str "Need a non empty toplevel module name");
+  toplevel_name := dir
+
+(******************************************************************************)
 (* Input/Output State                                                         *)
 (******************************************************************************)
 let inputstate opts =
@@ -223,9 +243,8 @@ let compile opts ~echo ~f_in ~f_out =
             iload_path; require_libs; stm_options;
           }) in
 
-      let state = { doc; sid; proof = None; time = opts.time } in
-      let state = load_init_vernaculars opts ~state in
-      let ldir = Stm.get_ldir ~doc:state.doc in
+      let doc, _sid = load_init_vernaculars doc sid in
+      let ldir = Stm.get_ldir ~doc in
       Aux_file.(start_aux_file
         ~aux_file:(aux_file_name_for long_f_dot_vo)
         ~v_file:long_f_dot_v);
@@ -270,11 +289,11 @@ let compile opts ~echo ~f_in ~f_out =
             iload_path; require_libs; stm_options;
           }) in
 
-      let state = { doc; sid; proof = None; time = opts.time } in
-      let state = load_init_vernaculars opts ~state in
-      let ldir = Stm.get_ldir ~doc:state.doc in
-      let state = Vernac.load_vernac ~echo ~check:false ~interactive:false ~state long_f_dot_v in
-      let doc = Stm.finish ~doc:state.doc in
+      let doc, _sid = load_init_vernaculars doc sid in
+
+      let ldir = Stm.get_ldir ~doc in
+      let doc, _ = Vernac.load_vernac ~verbosely ~check:false ~interactive:false doc (Stm.get_current_state ~doc) long_f_dot_v in
+      let doc = Stm.finish ~doc in
       check_pending_proofs ();
       let _doc = Stm.snapshot_vio ~doc ldir long_f_dot_vio in
       Stm.reset_task_queue ()
@@ -300,9 +319,9 @@ let compile_file opts (f_in, echo) =
   else
     compile opts ~echo ~f_in ~f_out:None
 
-let compile_files opts =
-  let compile_list = List.rev opts.compile_list in
-  List.iter (compile_file opts) compile_list
+let compile_files _doc =
+  if !compile_list == [] then ()
+  else List.iter compile_file (List.rev !compile_list)
 
 (******************************************************************************)
 (* VIO Dispatching                                                            *)
@@ -404,7 +423,281 @@ let init_gc () =
              Gc.minor_heap_size = 33554432; (** 4M *)
              Gc.space_overhead = 120}
 
-(** Main init routine *)
+(*s Parsing of the command line.
+    We no longer use [Arg.parse], in order to use share [Usage.print_usage]
+    between coqtop and coqc. *)
+
+let usage_no_coqlib = CWarnings.create ~name:"usage-no-coqlib" ~category:"filesystem"
+    (fun () -> Pp.str "cannot guess a path for Coq libraries; dynaminally loaded flags will not be mentioned")
+
+exception NoCoqLib
+
+let usage batch =
+  begin
+  try
+  Envars.set_coqlib ~fail:(fun _x -> raise NoCoqLib);
+  Coqinit.init_load_path ~load_init:!load_init;
+  with NoCoqLib -> usage_no_coqlib ()
+  end;
+  if batch then Usage.print_usage_coqc ()
+  else begin
+    Mltop.load_ml_objects_raw_rex
+      (Str.regexp (if Mltop.is_native then "^.*top.cmxs$" else "^.*top.cma$"));
+    Usage.print_usage_coqtop ()
+  end
+
+let print_style_tags () =
+  let () = init_color () in
+  let tags = Topfmt.dump_tags () in
+  let iter (t, st) =
+    let opt = Terminal.eval st ^ t ^ Terminal.reset ^ "\n" in
+    print_string opt
+  in
+  let make (t, st) =
+    let tags = List.map string_of_int (Terminal.repr st) in
+    (t ^ "=" ^ String.concat ";" tags)
+  in
+  let repr = List.map make tags in
+  let () = Printf.printf "COQ_COLORS=\"%s\"\n" (String.concat ":" repr) in
+  let () = List.iter iter tags in
+  flush_all ()
+
+let error_missing_arg s =
+  prerr_endline ("Error: extra argument expected after option "^s);
+  prerr_endline "See -help for the syntax of supported options";
+  exit 1
+
+let filter_opts = ref false
+let exitcode () = if !filter_opts then 2 else 0
+
+let print_where = ref false
+let print_config = ref false
+let print_tags = ref false
+
+let get_priority opt s =
+  try CoqworkmgrApi.priority_of_string s
+  with Invalid_argument _ ->
+    prerr_endline ("Error: low/high expected after "^opt); exit 1
+
+let get_async_proofs_mode opt = let open Stm.AsyncOpts in function
+  | "no" | "off" -> APoff
+  | "yes" | "on" -> APon
+  | "lazy" -> APonLazy
+  | _ -> prerr_endline ("Error: on/off/lazy expected after "^opt); exit 1
+
+let get_cache opt = function
+  | "force" -> Some Stm.AsyncOpts.Force
+  | _ -> prerr_endline ("Error: force expected after "^opt); exit 1
+
+
+let set_worker_id _opt s =
+  assert (s <> "master");
+  Flags.async_proofs_worker_id := s
+
+let get_bool opt = function
+  | "yes" | "on" -> true
+  | "no" | "off" -> false
+  | _ -> prerr_endline ("Error: yes/no expected after option "^opt); exit 1
+
+let get_int opt n =
+  try int_of_string n
+  with Failure _ ->
+    prerr_endline ("Error: integer expected after option "^opt); exit 1
+
+let get_float opt n =
+  try float_of_string n
+  with Failure _ ->
+    prerr_endline ("Error: float expected after option "^opt); exit 1
+
+let get_host_port opt s =
+  match CString.split ':' s with
+  | [host; portr; portw] ->
+       Some (Spawned.Socket(host, int_of_string portr, int_of_string portw))
+  | ["stdfds"] -> Some Spawned.AnonPipe
+  | _ ->
+     prerr_endline ("Error: host:portr:portw or stdfds expected after option "^opt);
+     exit 1
+
+let get_error_resilience _opt = function
+  | "on" | "all" | "yes" -> `All
+  | "off" | "no" -> `None
+  | s -> `Only (CString.split ',' s)
+
+let get_task_list s = List.map int_of_string (Str.split (Str.regexp ",") s)
+
+let is_not_dash_option = function
+  | Some f when String.length f > 0 && f.[0] <> '-' -> true
+  | _ -> false
+
+let get_native_name s =
+  (* We ignore even critical errors because this mode has to be super silent *)
+  try
+    String.concat "/" [Filename.dirname s;
+      Nativelib.output_dir; Library.native_name_from_filename s]
+  with _ -> ""
+
+(** Prints info which is either an error or an anomaly and then exits
+    with the appropriate error code *)
+let fatal_error ?extra exn =
+  Topfmt.print_err_exn ?extra exn;
+  let exit_code = if CErrors.(is_anomaly exn || not (handled exn)) then 129 else 1 in
+  exit exit_code
+
+let parse_args arglist =
+  let args = ref arglist in
+  let extras = ref [] in
+  let rec parse () = match !args with
+  | [] -> List.rev !extras
+  | opt :: rem ->
+    args := rem;
+    let next () = match !args with
+      | x::rem -> args := rem; x
+      | [] -> error_missing_arg opt
+    in
+    let peek_next () = match !args with
+      | x::_ -> Some x
+      | [] -> None
+    in
+    begin match opt with
+
+    (* Complex options with many args *)
+    |"-I"|"-include" ->
+      begin match rem with
+      | d :: rem -> Coqinit.push_ml_include d; args := rem
+      | [] -> error_missing_arg opt
+      end
+    |"-Q" ->
+      begin match rem with
+      | d :: p :: rem -> set_include d p false; args := rem
+      | _ -> error_missing_arg opt
+      end
+    |"-R" ->
+      begin match rem with
+      | d :: p :: rem -> set_include d p true; args := rem
+      | _ -> error_missing_arg opt
+      end
+
+    (* Options with two arg *)
+    |"-check-vio-tasks" ->
+        let tno = get_task_list (next ()) in
+        let tfile = next () in
+        add_vio_task (tno,tfile)
+    |"-schedule-vio-checking" ->
+        vio_checking := true;
+        set_vio_checking_j opt (next ());
+        add_vio_file (next ());
+        while is_not_dash_option (peek_next ()) do add_vio_file (next ()); done
+    |"-schedule-vio2vo" ->
+        set_vio_checking_j opt (next ());
+        add_vio_file (next ());
+        while is_not_dash_option (peek_next ()) do add_vio_file (next ()); done
+
+    (* Options with one arg *)
+    |"-coqlib" -> Flags.coqlib_spec:=true; Flags.coqlib:=(next ())
+    |"-async-proofs" ->
+        Stm.AsyncOpts.async_proofs_mode := get_async_proofs_mode opt (next())
+    |"-async-proofs-j" ->
+        Stm.AsyncOpts.async_proofs_n_workers := (get_int opt (next ()))
+    |"-async-proofs-cache" ->
+        Stm.AsyncOpts.async_proofs_cache := get_cache opt (next ())
+    |"-async-proofs-tac-j" ->
+        Stm.AsyncOpts.async_proofs_n_tacworkers := (get_int opt (next ()))
+    |"-async-proofs-worker-priority" ->
+        WorkerLoop.async_proofs_worker_priority := get_priority opt (next ())
+    |"-async-proofs-private-flags" ->
+        Stm.AsyncOpts.async_proofs_private_flags := Some (next ());
+    |"-async-proofs-tactic-error-resilience" ->
+        Stm.AsyncOpts.async_proofs_tac_error_resilience := get_error_resilience opt (next ())
+    |"-async-proofs-command-error-resilience" ->
+        Stm.AsyncOpts.async_proofs_cmd_error_resilience := get_bool opt (next ())
+    |"-async-proofs-delegation-threshold" ->
+        Stm.AsyncOpts.async_proofs_delegation_threshold:= get_float opt (next ())
+    |"-worker-id" -> set_worker_id opt (next ())
+    |"-compat" ->
+        let v = G_vernac.parse_compat_version ~allow_old:false (next ()) in
+        Flags.compat_version := v; add_compat_require v
+    |"-compile" -> add_compile false (next ())
+    |"-compile-verbose" -> add_compile true (next ())
+    |"-dump-glob" -> Dumpglob.dump_into_file (next ()); glob_opt := true
+    |"-feedback-glob" -> Dumpglob.feedback_glob ()
+    |"-exclude-dir" -> System.exclude_directory (next ())
+    |"-init-file" -> Coqinit.set_rcfile (next ())
+    |"-inputstate"|"-is" -> set_inputstate (next ())
+    |"-load-ml-object" -> Mltop.dir_ml_load (next ())
+    |"-load-ml-source" -> Mltop.dir_ml_use (next ())
+    |"-load-vernac-object" -> add_require (next (), None, None)
+    |"-load-vernac-source"|"-l" -> add_load_vernacular false (next ())
+    |"-load-vernac-source-verbose"|"-lv" -> add_load_vernacular true (next ())
+    |"-outputstate" -> set_outputstate (next ())
+    |"-print-mod-uid" -> let s = String.concat " " (List.map get_native_name rem) in print_endline s; exit 0
+    |"-profile-ltac-cutoff" -> Flags.profile_ltac := true; Flags.profile_ltac_cutoff := get_float opt (next ())
+    |"-require" -> add_require (next (), None, Some false)
+    |"-top" -> set_toplevel_name (dirpath_of_string (next ()))
+    |"-main-channel" -> Spawned.main_channel := get_host_port opt (next())
+    |"-control-channel" -> Spawned.control_channel := get_host_port opt (next())
+    |"-vio2vo" ->
+      add_compile false (next ());
+      compilation_mode := Vio2Vo
+    |"-toploop" -> set_toploop (next ())
+    |"-w" | "-W" ->
+      let w = next () in
+      if w = "none" then CWarnings.set_flags w
+      else
+        let w = CWarnings.get_flags () ^ "," ^ w in
+        CWarnings.set_flags (CWarnings.normalize_flags_string w)
+    |"-o" -> compilation_output_name := Some (next())
+
+    (* Options with zero arg *)
+    |"-async-queries-always-delegate"
+    |"-async-proofs-always-delegate"
+    |"-async-proofs-full" ->
+        Stm.AsyncOpts.async_proofs_full := true;
+    |"-async-proofs-never-reopen-branch" ->
+        Stm.AsyncOpts.async_proofs_never_reopen_branch := true;
+    |"-batch" -> set_batch_mode ()
+    |"-test-mode" -> Flags.test_mode := true
+    |"-beautify" -> Flags.beautify := true
+    |"-boot" -> Flags.boot := true; Coqinit.no_load_rc ()
+    |"-bt" -> Backtrace.record_backtrace true
+    |"-color" -> set_color (next ())
+    |"-config"|"--config" -> print_config := true
+    |"-debug" -> Coqinit.set_debug ()
+    |"-stm-debug" -> Stm.stm_debug := true
+    |"-emacs" -> set_emacs ()
+    |"-filteropts" -> filter_opts := true
+    |"-h"|"-H"|"-?"|"-help"|"--help" -> usage !batch_mode
+    |"-ideslave" -> set_ideslave ()
+    |"-impredicative-set" -> set_impredicative_set ()
+    |"-indices-matter" -> Indtypes.enforce_indices_matter ()
+    |"-m"|"--memory" -> memory_stat := true
+    |"-noinit"|"-nois" -> load_init := false
+    |"-no-glob"|"-noglob" -> Dumpglob.noglob (); glob_opt := true
+    |"-native-compiler" ->
+      if Coq_config.no_native_compiler then
+        warning "Native compilation was disabled at configure time."
+      else Flags.native_compiler := true
+    |"-output-context" -> output_context := true
+    |"-profile-ltac" -> Flags.profile_ltac := true
+    |"-q" -> Coqinit.no_load_rc ()
+    |"-quiet"|"-silent" -> Flags.quiet := true; Flags.make_warn false
+    |"-quick" -> compilation_mode := BuildVio
+    |"-list-tags" -> print_tags := true
+    |"-time" -> Flags.time := true
+    |"-type-in-type" -> set_type_in_type ()
+    |"-unicode" -> add_require ("Utf8_core", None, Some false)
+    |"-v"|"--version" -> Usage.version (exitcode ())
+    |"-print-version"|"--print-version" -> Usage.machine_readable_version (exitcode ())
+    |"-where" -> print_where := true
+
+    (* Unknown option *)
+    | s -> extras := s :: !extras
+    end;
+    parse ()
+  in
+  try
+    parse ()
+  with any -> fatal_error any
+
 let init_toplevel arglist =
   (* Coq's init process, phase 1:
      OCaml parameters, basic structures, and IO
@@ -503,8 +796,8 @@ let init_toplevel arglist =
 let start () =
   match init_toplevel (List.tl (Array.to_list Sys.argv)) with
   (* Batch mode *)
-  | Some state, opts when not opts.batch_mode ->
-    !toploop_run opts ~state;
+  | Some (doc, _sid) when not !batch_mode ->
+    !toploop_run doc;
     exit 1
   | _ , opts ->
     flush_all();

--- a/vernac/assumptions.ml
+++ b/vernac/assumptions.ml
@@ -120,7 +120,7 @@ and fields_of_expression x = fields_of_functor fields_of_expr x
 
 let lookup_constant_in_impl cst fallback =
   try
-    let mp,dp,lab = KerName.repr (Constant.canonical cst) in
+    let mp,_dp,lab = KerName.repr (Constant.canonical cst) in
     let fields = memoize_fields_of_mp mp in
     (* A module found this way is necessarily closed, in particular
        our constant cannot be in an opened section : *)
@@ -144,7 +144,7 @@ let lookup_constant cst =
 
 let lookup_mind_in_impl mind =
   try
-    let mp,dp,lab = KerName.repr (MutInd.canonical mind) in
+    let mp,_dp,lab = KerName.repr (MutInd.canonical mind) in
     let fields = memoize_fields_of_mp mp in
       search_mind_label lab fields
   with Not_found ->
@@ -172,7 +172,7 @@ let fold_constr_with_full_binders g f n acc c =
   | Lambda (na,t,c) -> f (g (LocalAssum (na,t)) n) (f n acc t) c
   | LetIn (na,b,t,c) -> f (g (LocalDef (na,b,t)) n) (f n (f n acc b) t) c
   | App (c,l) -> Array.fold_left (f n) (f n acc c) l
-  | Proj (p,c) -> f n acc c
+  | Proj (_p,c) -> f n acc c
   | Evar (_,l) -> Array.fold_left (f n) acc l
   | Case (_,p,c,bl) -> Array.fold_left (f n) (f n (f n acc p) c) bl
   | Fix (_,(lna,tl,bl)) ->
@@ -316,7 +316,7 @@ let traverse current t =
 let type_of_constant cb = cb.Declarations.const_type
 
 let assumptions ?(add_opaque=false) ?(add_transparent=false) st gr t =
-  let (idts, knst) = st in
+  let (_idts, knst) = st in
   (** Only keep the transitive dependencies *)
   let (_, graph, ax2ty) = traverse (label_of gr) t in
   let fold obj _ accu = match obj with

--- a/vernac/auto_ind_decl.ml
+++ b/vernac/auto_ind_decl.ml
@@ -34,12 +34,12 @@ module RelDecl = Context.Rel.Declaration
 
 let quick_chop n l =
   let rec kick_last = function
-    | t::[] -> []
+    | _t::[] -> []
     | t::q -> t::(kick_last q)
     | [] -> failwith "kick_last"
 and aux = function
     | (0,l') -> l'
-    | (n,h::t) -> aux (n-1,t)
+    | (n,_h::t) -> aux (n-1,t)
     | _ -> failwith "quick_chop"
   in
   if n > (List.length l) then failwith "quick_chop args"
@@ -108,7 +108,7 @@ let mkFullInd (ind,u) n =
   let nparams = mib.mind_nparams in
   let nparrec = mib.mind_nparams_rec in
   (* params context divided *)
-  let lnonparrec,lnamesparrec =
+  let _lnonparrec,lnamesparrec =
     context_chop (nparams-nparrec) mib.mind_params_ctxt in
   if nparrec > 0
     then mkApp (mkIndU (ind,u),
@@ -133,7 +133,7 @@ let build_beq_scheme mode kn =
   let nparams = mib.mind_nparams in
   let nparrec = mib.mind_nparams_rec in
   (* params context divided *)
-  let lnonparrec,lnamesparrec =
+  let _lnonparrec,lnamesparrec =
     context_chop (nparams-nparrec) mib.mind_params_ctxt in
   (* predef coq's boolean type *)
   (* rec name *)
@@ -184,7 +184,7 @@ let build_beq_scheme mode kn =
         eqA   = the de Bruijn index of the first eq param
         ndx   = how much to translate due to the 2nd Case
     *)
-    let compute_A_equality rel_list nlist eqA ndx t =
+    let compute_A_equality _rel_list nlist eqA ndx t =
       let lifti = ndx in
       let sigma = Evd.empty (** FIXME *) in
       let rec aux c =
@@ -200,7 +200,7 @@ let build_beq_scheme mode kn =
           mkVar eid, Safe_typing.empty_private_constants
         | Cast (x,_,_) -> aux (EConstr.applist (x,a))
         | App _ -> assert false
-        | Ind ((kn',i as ind'),u) (*FIXME: universes *) -> 
+        | Ind ((kn',i as ind'),_u) (*FIXME: universes *) -> 
             if MutInd.equal kn kn' then mkRel(eqA-nlist-i+nb_ind-1), Safe_typing.empty_private_constants
             else begin
               try
@@ -239,7 +239,7 @@ let build_beq_scheme mode kn =
       aux t
   in
   (* construct the predicate for the Case part*)
-  let do_predicate rel_list n =
+  let do_predicate _rel_list n =
      List.fold_left (fun a b -> mkLambda(Anonymous,b,a))
       (mkLambda (Anonymous,
                  mkFullInd ind (n+3+(List.length rettyp_l)+nb_ind-1),
@@ -412,7 +412,7 @@ let do_replace_lb mode lb_scheme_key aavoid narg p q =
   end
 
 (* used in the bool -> leib side *)
-let do_replace_bl mode bl_scheme_key (ind,u as indu) aavoid narg lft rgt =
+let do_replace_bl _mode bl_scheme_key (ind,_u as indu) aavoid narg lft rgt =
   let open EConstr in
   let avoid = Array.of_list aavoid in
   let do_arg sigma v offset =
@@ -558,13 +558,13 @@ let compute_bl_goal ind lnamesparrec nparrec =
                ( mkApp(Lazy.force eq,[|mkVar s;mkVar x;mkVar y|]))
           ))
         ) list_id in
-      let bl_input = List.fold_left2 ( fun a (s,_,sbl,_) b ->
+      let bl_input = List.fold_left2 ( fun a (_s,_,sbl,_) b ->
         mkNamedProd sbl b a
       ) c (List.rev list_id) (List.rev bl_typ) in
       let eqs_typ = List.map (fun (s,_,_,_) ->
           mkProd(Anonymous,mkVar s,mkProd(Anonymous,mkVar s,(Lazy.force bb)))
           ) list_id in
-      let eq_input = List.fold_left2 ( fun a (s,seq,_,_) b ->
+      let eq_input = List.fold_left2 ( fun a (_s,seq,_,_) b ->
         mkNamedProd seq b a
       ) bl_input (List.rev list_id) (List.rev eqs_typ) in
       List.fold_left (fun a decl -> mkNamedProd
@@ -634,7 +634,7 @@ repeat ( apply andb_prop in z;let z1:= fresh "Z" in destruct z as [z1 z]).
                         match EConstr.kind sigma concl with
                         | App (c,ca) -> (
                           match EConstr.kind sigma c with
-                          | Ind (indeq, u) ->
+                          | Ind (indeq, _u) ->
                               if eq_gr (IndRef indeq) Coqlib.glob_eq
                               then
                                 Tacticals.New.tclTHEN
@@ -668,7 +668,7 @@ let make_bl_scheme mode mind =
   let ind = (mind,0) in
   let nparams = mib.mind_nparams in
   let nparrec = mib.mind_nparams_rec in
-  let lnonparrec,lnamesparrec = (* TODO subst *)
+  let _lnonparrec,lnamesparrec = (* TODO subst *)
     context_chop (nparams-nparrec) mib.mind_params_ctxt in
   let bl_goal, eff = compute_bl_goal ind lnamesparrec nparrec in
   let ctx = UState.make (Global.universes ()) in
@@ -702,13 +702,13 @@ let compute_lb_goal ind lnamesparrec nparrec =
                ( mkApp(eq,[|bb;mkApp(mkVar seq,[|mkVar x;mkVar y|]);tt|]))
           ))
         ) list_id in
-      let lb_input = List.fold_left2 ( fun a (s,_,_,slb) b ->
+      let lb_input = List.fold_left2 ( fun a (_s,_,_,slb) b ->
         mkNamedProd slb b a
       ) c (List.rev list_id) (List.rev lb_typ) in
       let eqs_typ = List.map (fun (s,_,_,_) ->
           mkProd(Anonymous,mkVar s,mkProd(Anonymous,mkVar s,bb))
           ) list_id in
-      let eq_input = List.fold_left2 ( fun a (s,seq,_,_) b ->
+      let eq_input = List.fold_left2 ( fun a (_s,seq,_,_) b ->
         mkNamedProd seq b a
       ) lb_input (List.rev list_id) (List.rev eqs_typ) in
       List.fold_left (fun a decl -> mkNamedProd
@@ -726,7 +726,7 @@ let compute_lb_goal ind lnamesparrec nparrec =
               (mkApp(eq,[|bb;mkApp(eqI,[|mkVar n;mkVar m|]);tt|]))
         ))), eff
 
-let compute_lb_tact mode lb_scheme_key ind lnamesparrec nparrec =
+let compute_lb_tact mode lb_scheme_key _ind lnamesparrec nparrec =
   let list_id = list_id lnamesparrec in
     let avoid = ref [] in
       let first_intros =
@@ -766,8 +766,8 @@ let compute_lb_tact mode lb_scheme_key ind lnamesparrec nparrec =
                         let sigma = Tacmach.New.project gl in
                         (* assume the goal to be eq (eq_type ...) = true *)
                         match EConstr.kind sigma concl with
-                        | App(c,ca) -> (match (EConstr.kind sigma ca.(1)) with
-                          | App(c',ca') ->
+                        | App(_c,ca) -> (match (EConstr.kind sigma ca.(1)) with
+                          | App(_c',ca') ->
                               let n = Array.length ca' in
                               do_replace_lb mode lb_scheme_key
 				(!avoid)
@@ -792,7 +792,7 @@ let make_lb_scheme mode mind =
   let ind = (mind,0) in
   let nparams = mib.mind_nparams in
   let nparrec = mib.mind_nparams_rec in
-  let lnonparrec,lnamesparrec =
+  let _lnonparrec,lnamesparrec =
     context_chop (nparams-nparrec) mib.mind_params_ctxt in
   let lb_goal, eff = compute_lb_goal ind lnamesparrec nparrec in
   let ctx = UState.make (Global.universes ()) in
@@ -840,17 +840,17 @@ let compute_dec_goal ind lnamesparrec nparrec =
           ))
         ) list_id in
 
-      let lb_input = List.fold_left2 ( fun a (s,_,_,slb) b ->
+      let lb_input = List.fold_left2 ( fun a (_s,_,_,slb) b ->
         mkNamedProd slb b a
       ) c (List.rev list_id) (List.rev lb_typ) in
-      let bl_input = List.fold_left2 ( fun a (s,_,sbl,_) b ->
+      let bl_input = List.fold_left2 ( fun a (_s,_,sbl,_) b ->
         mkNamedProd sbl b a
       ) lb_input (List.rev list_id) (List.rev bl_typ) in
 
       let eqs_typ = List.map (fun (s,_,_,_) ->
           mkProd(Anonymous,mkVar s,mkProd(Anonymous,mkVar s,bb))
           ) list_id in
-      let eq_input = List.fold_left2 ( fun a (s,seq,_,_) b ->
+      let eq_input = List.fold_left2 ( fun a (_s,seq,_,_) b ->
         mkNamedProd seq b a
       ) bl_input (List.rev list_id) (List.rev eqs_typ) in
       List.fold_left (fun a decl -> mkNamedProd
@@ -965,8 +965,8 @@ let make_eq_decidability mode mind =
   let nparams = mib.mind_nparams in
   let nparrec = mib.mind_nparams_rec in
   let u = Univ.Instance.empty in
-  let ctx = UState.make (Global.universes ()) in
-  let lnonparrec,lnamesparrec =
+  let ctx = Evd.make_evar_universe_context (Global.env ()) None in
+  let _lnonparrec,lnamesparrec =
     context_chop (nparams-nparrec) mib.mind_params_ctxt in
   let side_eff = side_effect_of_mode mode in
   let (ans, _, ctx) = Pfedit.build_by_tactic ~side_eff (Global.env()) ctx

--- a/vernac/class.ml
+++ b/vernac/class.ml
@@ -122,7 +122,7 @@ let get_source lp source =
          | [] -> raise Not_found
          | LocalDef _ :: lt -> aux lt
          | LocalAssum (_,t1) :: lt ->
-            let cl1,u1,lv1 = find_class_type Evd.empty (EConstr.of_constr t1) in
+            let cl1,_u1,lv1 = find_class_type Evd.empty (EConstr.of_constr t1) in
             cl1,lt,lv1,1
        in aux lp
     | Some cl ->
@@ -132,7 +132,7 @@ let get_source lp source =
          | LocalDef _ as decl :: lt -> aux (decl::acc) lt
          | LocalAssum (_,t1) as decl :: lt ->
             try
-              let cl1,u1,lv1 = find_class_type Evd.empty (EConstr.of_constr t1) in
+              let cl1,_u1,lv1 = find_class_type Evd.empty (EConstr.of_constr t1) in
               if cl_typ_eq cl cl1 then cl1,acc,lv1,Context.Rel.nhyps lt+1
               else raise Not_found
             with Not_found -> aux (decl::acc) lt
@@ -148,8 +148,8 @@ let get_target t ind =
     | x -> x
       
 let strength_of_cl = function
-  | CL_CONST kn -> `GLOBAL
-  | CL_SECVAR id -> `LOCAL
+  | CL_CONST _kn -> `GLOBAL
+  | CL_SECVAR _id -> `LOCAL
   | _ -> `GLOBAL
 
 let strength_of_global = function
@@ -210,7 +210,7 @@ let build_id_coercion idf_opt source poly =
     match idf_opt with
       | Some idf -> idf
       | None ->
-	  let cl,u,_ = find_class_type sigma (EConstr.of_constr t) in
+	  let cl,_u,_ = find_class_type sigma (EConstr.of_constr t) in
 	  Id.of_string ("Id_"^(ident_key_of_class source)^"_"^
                         (ident_key_of_class cl))
   in
@@ -245,7 +245,7 @@ let warn_uniform_inheritance =
           Printer.pr_global g ++
             strbrk" does not respect the uniform inheritance condition")
 
-let add_new_coercion_core coef stre poly source target isid =
+let add_new_coercion_core coef stre _poly source target isid =
   check_source source;
   let t, _ = Global.type_of_global_in_context (Global.env ()) coef in
   if coercion_exists coef then raise (CoercionError AlreadyExists);

--- a/vernac/declareDef.ml
+++ b/vernac/declareDef.ml
@@ -42,7 +42,7 @@ let declare_global_definition ident ce local k pl imps =
   let () = definition_message ident in
   gr
 
-let declare_definition ident (local, p, k) ce pl imps hook =
+let declare_definition ident (local, _p, k) ce pl imps hook =
   let fix_exn = Future.fix_exn_of ce.const_entry_body in
   let r = match local with
   | Discharge when Lib.sections_are_opened () ->
@@ -60,7 +60,7 @@ let declare_definition ident (local, p, k) ce pl imps hook =
     declare_global_definition ident ce local k pl imps in
   Lemmas.call_hook fix_exn hook local r
 
-let declare_fix ?(opaque = false) (_,poly,_ as kind) pl univs f ((def,_),eff) t imps =
+let declare_fix ?(opaque = false) (_,_poly,_ as kind) pl univs f ((def,_),eff) t imps =
   let ce = definition_entry ~opaque ~types:t ~univs ~eff def in
   declare_definition f kind ce pl imps (Lemmas.mk_hook (fun _ r -> r))
 

--- a/vernac/explainErr.ml
+++ b/vernac/explainErr.ml
@@ -48,7 +48,7 @@ let _ = CErrors.register_handler explain_exn_default
 
 (** Pre-explain a vernac interpretation error *)
 
-let wrap_vernac_error (exn, info) strm = (EvaluatedError (strm, None), info)
+let wrap_vernac_error (_exn, info) strm = (EvaluatedError (strm, None), info)
 
 let process_vernac_interp_error exn = match fst exn with
   | Univ.UniverseInconsistency i ->

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -168,7 +168,7 @@ let explain_unbound_rel env sigma n =
   str "Unbound reference: " ++ pe ++
   str "The reference " ++ int n ++ str " is free."
 
-let explain_unbound_var env v =
+let explain_unbound_var _env v =
   let var = Id.print v in
   str "No such section variable or assumption: " ++ var ++ str "."
 
@@ -321,7 +321,7 @@ let explain_unification_error env sigma p1 p2 = function
           Univ.explain_universe_inconsistency Universes.pr_with_global_universes p]
 	else
           [str "universe inconsistency"]
-     | CannotSolveConstraint ((pb,env,t,u),e) ->
+     | CannotSolveConstraint ((_pb,env,t,u),e) ->
         let t = EConstr.of_constr t in
         let u = EConstr.of_constr u in
         let env = make_all_name_different env sigma in
@@ -498,7 +498,7 @@ let explain_ill_formed_rec_body env sigma err names i fixenv vdefj =
 	str"Recursive definition is:" ++ spc () ++ pvd ++ str "."
     with e when CErrors.noncritical e -> mt ())
 
-let explain_ill_typed_rec_body env sigma i names vdefj vargs =
+let explain_ill_typed_rec_body env sigma i _names vdefj vargs =
   let env = make_all_name_different env sigma in
   let pvd = pr_leconstr_env env sigma vdefj.(i).uj_val in
   let pvdt, pv = pr_explicit env sigma vdefj.(i).uj_type vargs.(i) in
@@ -540,7 +540,7 @@ let rec explain_evar_kind env sigma evk ty = function
       strbrk "the type of " ++ Id.print id
   | Evar_kinds.BinderType Anonymous ->
       strbrk "the type of this anonymous binder"
-  | Evar_kinds.ImplicitArg (c,(n,ido),b) ->
+  | Evar_kinds.ImplicitArg (c,(_n,ido),_b) ->
       let id = Option.get ido in
       strbrk "the implicit parameter " ++ Id.print id ++ spc () ++ str "of" ++
       spc () ++ Nametab.pr_global_env Id.Set.empty c ++
@@ -576,7 +576,7 @@ let rec explain_evar_kind env sigma evk ty = function
       explain_evar_kind env sigma evk'
       (pr_leconstr_env env sigma ty') (snd evi.evar_source)
 
-let explain_typeclass_resolution env sigma evi k =
+let explain_typeclass_resolution _env sigma evi _k =
   match Typeclasses.class_of_constr sigma (EConstr.of_constr evi.evar_concl) with
   | Some _ ->
     let env = Evd.evar_filtered_env evi in
@@ -585,16 +585,16 @@ let explain_typeclass_resolution env sigma evi k =
       pr_trailing_ne_context_of env sigma
   | _ -> mt()
 
-let explain_placeholder_kind env sigma c e =
+let explain_placeholder_kind _env sigma c e =
   match e with
-  | Some (SeveralInstancesFound n) ->
+  | Some (SeveralInstancesFound _n) ->
       strbrk " (several distinct possible type class instances found)"
   | None ->
       match Typeclasses.class_of_constr sigma (EConstr.of_constr c) with
       | Some _ -> strbrk " (no type class instance found)"
       | _ -> mt ()
 
-let explain_unsolvable_implicit env sigma evk explain =
+let explain_unsolvable_implicit _env sigma evk explain =
   let evi = Evarutil.nf_evar_info sigma (Evd.find_undefined sigma evk) in
   let env = Evd.evar_filtered_env evi in
   let type_of_hole = pr_lconstr_env env sigma evi.evar_concl in
@@ -603,12 +603,12 @@ let explain_unsolvable_implicit env sigma evk explain =
   explain_evar_kind env sigma evk type_of_hole (snd evi.evar_source) ++
   explain_placeholder_kind env sigma evi.evar_concl explain ++ pe
 
-let explain_var_not_found env id =
+let explain_var_not_found _env id =
   str "The variable" ++ spc () ++ Id.print id ++
   spc () ++ str "was not found" ++
   spc () ++ str "in the current" ++ spc () ++ str "environment" ++ str "."
 
-let explain_wrong_case_info env (ind,u) ci =
+let explain_wrong_case_info _env (ind,_u) ci =
   let pi = pr_inductive (Global.env()) ind in
   if eq_ind ci.ci_ind ind then
     str "Pattern-matching expression on an object of inductive type" ++
@@ -683,7 +683,7 @@ let explain_non_linear_unification env sigma m t =
   strbrk " which would require to abstract twice on " ++
   pr_lconstr_env env sigma t ++ str "."
 
-let explain_unsatisfied_constraints env sigma cst =
+let explain_unsatisfied_constraints _env sigma cst =
   strbrk "Unsatisfied constraints: " ++ 
     Univ.pr_constraints (Termops.pr_evd_level sigma) cst ++ 
     spc () ++ str "(maybe a bugged tactic)."
@@ -752,8 +752,8 @@ let explain_cannot_unify_occurrences env sigma nested ((cl2,pos2),t2) ((cl1,pos1
     pr_position (cl1,pos1) ++ ppreason ++ str "."
 
 let pr_constraints printenv env sigma evars cstrs =
-  let (ev, evi) = Evar.Map.choose evars in
-    if Evar.Map.for_all (fun ev' evi' ->
+  let (_ev, evi) = Evar.Map.choose evars in
+    if Evar.Map.for_all (fun _ev' evi' ->
       eq_named_context_val evi.evar_hyps evi'.evar_hyps) evars
     then
       let l = Evar.Map.bindings evars in
@@ -865,9 +865,9 @@ let explain_not_match_error = function
   | FiniteInductiveFieldExpected isfinite ->
     str "type is expected to be " ++
     str (if isfinite then "coinductive" else "inductive")
-  | InductiveNumbersFieldExpected n ->
+  | InductiveNumbersFieldExpected _n ->
     str "number of inductive types differs"
-  | InductiveParamsNumberField n ->
+  | InductiveParamsNumberField _n ->
     str "inductive type has not the right number of parameters"
   | RecordFieldExpected isrecord ->
     str "type is expected " ++ str (if isrecord then "" else "not ") ++
@@ -904,7 +904,7 @@ let explain_not_match_error = function
       let cst = Univ.AUContext.instantiate (Univ.AUContext.instance cst) cst in
       quote (Univ.pr_constraints (Termops.pr_evd_level Evd.empty) cst)
 
-let explain_signature_mismatch l spec why =
+let explain_signature_mismatch l _spec why =
   str "Signature components for label " ++ Label.print l ++
   str " do not match:" ++ spc () ++ explain_not_match_error why ++ str "."
 
@@ -935,7 +935,7 @@ let explain_incompatible_module_types mexpr1 mexpr2 =
       str " arguments, found " ++ int len1 ++ str "."
   else str "Incompatible module types."
 
-let explain_not_equal_module_paths mp1 mp2 =
+let explain_not_equal_module_paths _mp1 _mp2 =
   str "Non equal modules."
 
 let explain_no_such_label l =
@@ -1021,8 +1021,8 @@ let explain_not_a_class env c =
   let c = EConstr.to_constr Evd.empty c in
   pr_constr_env env Evd.empty c ++ str" is not a declared type class."
 
-let explain_unbound_method env cid { CAst.v = id } =
-  str "Unbound method name " ++ Id.print (id) ++ spc () ++
+let explain_unbound_method _env cid id =
+  str "Unbound method name " ++ Id.print (snd id) ++ spc () ++
   str"of class" ++ spc () ++ pr_global cid ++ str "."
 
 let pr_constr_exprs exprs =
@@ -1030,7 +1030,7 @@ let pr_constr_exprs exprs =
 	 (fun d pps -> ws 2 ++ Ppconstr.pr_constr_expr d ++ pps)
          exprs (mt ()))
 
-let explain_mismatched_contexts env c i j =
+let explain_mismatched_contexts env _c i j =
   str"Mismatched contexts while declaring instance: " ++ brk (1,1) ++
     hov 1 (str"Expected:" ++ brk (1, 1) ++ pr_rel_context env Evd.empty j) ++
     fnl () ++ brk (1,1) ++
@@ -1238,7 +1238,7 @@ let explain_wrong_numarg_inductive env ind n =
   str "The inductive type " ++ pr_inductive env ind ++
   str " expects " ++ decline_string n "argument" ++ str "."
 
-let explain_unused_clause env pats =
+let explain_unused_clause _env _pats =
 (* Without localisation
   let s = if List.length pats > 1 then "s" else "" in
   (str ("Unused clause with pattern"^s) ++ spc () ++
@@ -1246,7 +1246,7 @@ let explain_unused_clause env pats =
 *)
   str "This clause is redundant."
 
-let explain_non_exhaustive env pats =
+let explain_non_exhaustive _env pats =
   str "Non exhaustive pattern-matching: no clause found for " ++
   str (String.plural (List.length pats) "pattern") ++
   spc () ++ hov 0 (prlist_with_sep pr_comma pr_cases_pattern pats)

--- a/vernac/indschemes.ml
+++ b/vernac/indschemes.ml
@@ -157,7 +157,7 @@ let try_declare_scheme what f internal names kn =
 	alarm what internal
 	  (str "Cannot extract computational content from proposition " ++
 	   quote (Printer.pr_inductive (Global.env()) ind) ++ str ".")
-    | EqNotFound (ind',ind) ->
+    | EqNotFound (ind',_ind) ->
 	alarm what internal
 	  (str "Boolean equality on " ++
 	   quote (Printer.pr_inductive (Global.env()) ind') ++
@@ -401,7 +401,7 @@ let do_mutual_induction_scheme lnamedepindsort =
 
 let get_common_underlying_mutual_inductive = function
   | [] -> assert false
-  | (id,(mind,i as ind))::l as all ->
+  | (_id,(mind,_i as ind))::l as all ->
       match List.filter (fun (_,(mind',_)) -> not (MutInd.equal mind mind')) l with
       | (_,ind')::_ ->
 	  raise (RecursionSchemeError (NotMutualInScheme (ind,ind')))
@@ -433,7 +433,7 @@ tried to declare different schemes at once *)
 
 let list_split_rev_at index l =
   let rec aux i acc = function
-      hd :: tl when Int.equal i index -> acc, tl
+      _hd :: tl when Int.equal i index -> acc, tl
     | hd :: tl -> aux (succ i) (hd :: acc) tl
     | [] -> failwith "List.split_when: Invalid argument"
   in aux 0 [] l
@@ -451,17 +451,17 @@ let build_combined_scheme env schemes =
     let evd, c = Evd.fresh_constant_instance env !evdref cst in
     evdref := evd; (c, Typeops.type_of_constant_in env c)) schemes in
   let find_inductive ty =
-    let (ctx, arity) = decompose_prod ty in
+    let (ctx, _arity) = decompose_prod ty in
     let (_, last) = List.hd ctx in
       match Constr.kind last with
-	| App (ind, args) ->
+	| App (ind, _args) ->
 	    let ind = destInd ind in
 	    let (_,spec) = Inductive.lookup_mind_specif env (fst ind) in
 	      ctx, ind, spec.mind_nrealargs
 	| _ -> ctx, destInd last, 0
   in
-  let (c, t) = List.hd defs in
-  let ctx, ind, nargs = find_inductive t in
+  let (_c, t) = List.hd defs in
+  let ctx, _ind, nargs = find_inductive t in
   (* Number of clauses, including the predicates quantification *)
   let prods = nb_prod !evdref (EConstr.of_constr t) - (nargs + 1) in
   let sigma, coqand  = mk_coq_and !evdref in

--- a/vernac/mltop.ml
+++ b/vernac/mltop.ml
@@ -80,7 +80,7 @@ let set_top toplevel = load :=
 (* Removes the toplevel (if any) *)
 let remove () =
   load := WithoutTop;
-  Nativelib.load_obj := (fun x -> () : string -> unit)
+  Nativelib.load_obj := (fun _x -> () : string -> unit)
 
 (* Tests if an Ocaml toplevel runs under Coq *)
 let is_ocaml_top () =

--- a/vernac/search.ml
+++ b/vernac/search.ml
@@ -64,7 +64,7 @@ let iter_named_context_name_type f =
 let iter_hypothesis glnum (fn : global_reference -> env -> constr -> unit) =
   let env = Global.env () in
   let iter_hyp idh typ = fn (VarRef idh) env typ in
-  let evmap,e = Pfedit.get_goal_context glnum in
+  let _evmap,e = Pfedit.get_goal_context glnum in
   let pfctxt = named_context e in
   iter_named_context_name_type iter_hyp pfctxt
 
@@ -199,12 +199,12 @@ let full_name_of_reference ref =
 (** Whether a reference is blacklisted *)
 let blacklist_filter_aux () =
   let l = SearchBlacklist.elements () in
-  fun ref env typ ->
+  fun ref _env _typ ->
   let name = full_name_of_reference ref in
   let is_not_bl str = not (String.string_contains ~where:name ~what:str) in
   List.for_all is_not_bl l
 
-let module_filter (mods, outside) ref env typ =
+let module_filter (mods, outside) ref _env _typ =
   let sp = path_of_global ref in
   let sl = dirpath sp in
   let is_outside md = not (is_dirpath_prefix_of md sl) in
@@ -347,7 +347,7 @@ let interface_search =
     (blacklist || blacklist_filter ref env constr)
   in
   let ans = ref [] in
-  let print_function ref env constr =
+  let print_function ref _env constr =
     let fullpath = DirPath.repr (Nametab.dirpath_of_global ref) in
     let qualid = Nametab.shortest_qualid_of_global Id.Set.empty ref in
     let (shortpath, basename) = Libnames.repr_qualid qualid in

--- a/vernac/topfmt.ml
+++ b/vernac/topfmt.ml
@@ -108,6 +108,7 @@ module Tag = struct
 end
 
 let msgnl_with ?pre_hdr fmt strm =
+  ignore(pre_hdr);
   pp_with fmt (strm ++ fnl ());
   Format.pp_print_flush fmt ()
 


### PR DESCRIPTION
IMHO this warning is important to be on, specially in the upper layers
that are supposed to handle environments in "let style".

Lots of funny stuff in the diff.

Unfortunately CAMPLX does not understand `[@@@ocaml.warning "-27"]` so
this PR is not ready for merge as `ml4` files will trigger the warning
in abundance due to unused `loc` generated by parsing rules.

Suggestions on how to disable the warning for `ml4`-generated files
are welcome.