### PR TITLE
Version 8.7 of #6328 (fix #6313: lost goals in nested ltac in refine)

### DIFF
--- a/test-suite/bugs/closed/6313.v
+++ b/test-suite/bugs/closed/6313.v
@@ -1,0 +1,20 @@
+(* Former open goals in nested proofs were lost *)
+
+Inductive foo := a | b | c.
+Goal foo -> foo.
+  intro x.
+  simple refine (match x with
+                 | a => _
+                 | b => ltac:(exact b)
+                 | c => _
+                 end); [exact a|exact c].
+Abort.
+
+(* Another example *)
+
+Goal (True/\0=0 -> True) -> True.
+  intro f.
+  refine
+   (f ltac:(split; only 1:exact I)).
+  reflexivity.
+Qed.


### PR DESCRIPTION
A version of #6328 for v8.7 which does not change the API.

It still does not take into account the shelved/given-up status of remaining goals in `ltac:()` (as I plan to do in #6328) but it fixes the critical lost of the status of goals which resulted in wrongly shelving all the goals generated up to the point of a `ltac:()` inside a `refine`.