### PR TITLE
Compatibility of the Coq macOS package with OS X 10.11.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -183,6 +183,7 @@ matrix:
 
     - if: NOT (type = pull_request)
       os: osx
+      osx_image: xcode7.3
       env:
       - TEST_TARGET=""
       - COMPILER="4.02.3"


### PR DESCRIPTION
Travis has moved on to macOS 10.12 but this makes the package incompatible with earlier versions.
This fix restores the compatibility with OS X 10.11.
We could go further and restore the compatibility with OS X 10.10 by setting osx_image to xcode6.4 but so far no user has complained.

Running here: https://travis-ci.org/Zimmi48/coq/jobs/316596953