### PR TITLE
Use old option --comp to avoid spurious failures.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -211,7 +211,7 @@ before_install:
 - if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then echo "Tested commit (followed by parent commits):"; git log -1; for commit in `git log -1 --format="%P"`; do echo; git log -1 $commit; done; fi
 
 install:
-- opam init -j ${NJOBS} --compiler=${COMPILER} -n -y
+- opam init -j ${NJOBS} --comp=${COMPILER} -n -y
 - eval $(opam config env)
 - opam config list
 - opam install -j ${NJOBS} -y camlp5.${CAMLP5_VER} ocamlfind.${FINDLIB_VER} ${EXTRA_OPAM}


### PR DESCRIPTION
It is very common these days that Travis will fail to fetch the latest versions from the Ubuntu package repositories. In this case, it falls back to using cached packages but the version of OPAM is older and does
not know about the --compiler option. So we are using the --comp option instead for greater robustness.

Note: that's this will fix the spurious builds related to "failed to fetch error messages" is only a wild guess. But if this passes Travis, it should probably be safe to merge.