### PR TITLE
[api] Deprecate constructors of Names.name.

### DIFF
--- a/checker/indtypes.ml
+++ b/checker/indtypes.ml
@@ -167,7 +167,7 @@ let typecheck_arity env params inds =
 	   full_arity is used as argument or subject to cast, an
 	   upper universe will be generated *)
 	let id = ind.mind_typename in
-	let env_ar' = push_rel (LocalAssum (Name id, arity)) env_ar in
+        let env_ar' = push_rel (LocalAssum (Name.Name id, arity)) env_ar in
         env_ar')
       env
       inds in
@@ -348,7 +348,7 @@ let check_rec_par (env,n,_,_) hyps nrecp largs =
   in find (n-1) (lpar,List.rev hyps)
 
 let lambda_implicit_lift n a =
-  let lambda_implicit a = Lambda(Anonymous,Evar(0,[||]),a) in
+  let lambda_implicit a = Lambda(Name.Anonymous,Evar(0,[||]),a) in
   iterate lambda_implicit n (lift n a)
 
 (* This removes global parameters of the inductive types in lc (for
@@ -376,7 +376,7 @@ let ienv_push_inductive (env, n, ntypes, ra_env) ((mi,u),lpar) =
   let auxntyp = 1 in
   let specif = lookup_mind_specif env mi in
   let env' =
-    let decl = LocalAssum (Anonymous,
+    let decl = LocalAssum (Name.Anonymous,
                            hnf_prod_applist env (type_of_inductive env (specif,u)) lpar) in
     push_rel decl env in
   let ra_env' =

--- a/checker/inductive.ml
+++ b/checker/inductive.ml
@@ -584,7 +584,7 @@ let ienv_push_inductive (env, ra_env) ((mind,u),lpar) =
   let mib = Environ.lookup_mind mind env in
   let ntypes = mib.mind_ntypes in
   let push_ind specif env =
-     let decl = LocalAssum (Anonymous,
+     let decl = LocalAssum (Name.Anonymous,
 		            hnf_prod_applist env (type_of_inductive env ((mib,specif),u)) lpar) in
      push_rel decl env
   in
@@ -606,7 +606,7 @@ let rec ienv_decompose_prod (env,_ as ienv) n c =
 let lambda_implicit_lift n a =
   let level = Level.make (DirPath.make [Id.of_string "implicit"]) 0 in
   let implicit_sort = Sort (Type (Universe.make level)) in
-  let lambda_implicit a = Lambda (Anonymous, implicit_sort, a) in
+  let lambda_implicit a = Lambda (Name.Anonymous, implicit_sort, a) in
   iterate lambda_implicit n (lift n a)
 
 let abstract_mind_lc ntyps npars lc =

--- a/checker/print.ml
+++ b/checker/print.ml
@@ -23,13 +23,13 @@ let print_pure_constr csr =
   | Cast (c,_, t) -> open_hovbox 1;
       print_string "("; (term_display c); print_cut();
       print_string "::"; (term_display t); print_string ")"; close_box()
-  | Prod (Name(id),t,c) ->
+  | Prod (Name.Name(id),t,c) ->
       open_hovbox 1;
       print_string"("; print_string (Id.to_string id);
       print_string ":"; box_display t;
       print_string ")"; print_cut();
       box_display c; close_box()
-  | Prod (Anonymous,t,c) ->
+  | Prod (Name.Anonymous,t,c) ->
       print_string"("; box_display t; print_cut(); print_string "->";
       box_display c; print_string ")";
   | Lambda (na,t,c) ->
@@ -113,8 +113,8 @@ let print_pure_constr csr =
     | Type u -> print_string "Type("; chk_pp (Univ.pr_uni u); print_string ")"
 
   and name_display = function
-    | Name id -> print_string (Id.to_string id)
-    | Anonymous -> print_string "_"
+    | Name.Name id -> print_string (Id.to_string id)
+    | Name.Anonymous -> print_string "_"
 (* Remove the top names for library and Scratch to avoid long names *)
   and sp_display sp =
 (*    let dir,l = decode_kn sp in

--- a/dev/top_printers.ml
+++ b/dev/top_printers.ml
@@ -307,8 +307,8 @@ let constr_display csr =
         then (" "^i) else "")) (Instance.to_array l) ""
 
   and name_display = function
-    | Name id -> "Name("^(Id.to_string id)^")"
-    | Anonymous -> "Anonymous"
+    | Name.Name id -> "Name("^(Id.to_string id)^")"
+    | Name.Anonymous -> "Anonymous"
 
   in
   pp (str (term_display csr) ++fnl ())
@@ -324,13 +324,13 @@ let print_pure_constr csr =
   | Cast (c,_, t) -> open_hovbox 1;
       print_string "("; (term_display c); print_cut();
       print_string "::"; (term_display t); print_string ")"; close_box()
-  | Prod (Name(id),t,c) ->
+  | Prod (Name.Name(id),t,c) ->
       open_hovbox 1;
       print_string"("; print_string (Id.to_string id);
       print_string ":"; box_display t;
       print_string ")"; print_cut();
       box_display c; close_box()
-  | Prod (Anonymous,t,c) ->
+  | Prod (Name.Anonymous,t,c) ->
       print_string"("; box_display t; print_cut(); print_string "->";
       box_display c; print_string ")";
   | Lambda (na,t,c) ->
@@ -423,8 +423,8 @@ let print_pure_constr csr =
 	print_string "Type("; pp (pr_uni u); print_string ")"; close_box()
 
   and name_display = function
-    | Name id -> print_string (Id.to_string id)
-    | Anonymous -> print_string "_"
+    | Name.Name id -> print_string (Id.to_string id)
+    | Name.Anonymous -> print_string "_"
 (* Remove the top names for library and Scratch to avoid long names *)
   and sp_display sp =
 (*    let dir,l = decode_kn sp in

--- a/engine/eConstr.ml
+++ b/engine/eConstr.ml
@@ -178,7 +178,7 @@ let mkCase (ci, c, r, p) = of_kind (Case (ci, c, r, p))
 let mkFix f = of_kind (Fix f)
 let mkCoFix f = of_kind (CoFix f)
 let mkProj (p, c) = of_kind (Proj (p, c))
-let mkArrow t1 t2 = of_kind (Prod (Anonymous, t1, t2))
+let mkArrow t1 t2 = of_kind (Prod (Name.Anonymous, t1, t2))
 
 let applist (f, arg) = mkApp (f, Array.of_list arg)
 
@@ -800,9 +800,9 @@ let mkLambda_or_LetIn decl c =
   | LocalAssum (na,t) -> mkLambda (na, t, c)
   | LocalDef (na,b,t) -> mkLetIn (na, b, t, c)
 
-let mkNamedProd id typ c = mkProd (Name id, typ, Vars.subst_var id c)
-let mkNamedLambda id typ c = mkLambda (Name id, typ, Vars.subst_var id c)
-let mkNamedLetIn id c1 t c2 = mkLetIn (Name id, c1, t, Vars.subst_var id c2)
+let mkNamedProd id typ c = mkProd (Name.Name id, typ, Vars.subst_var id c)
+let mkNamedLambda id typ c = mkLambda (Name.Name id, typ, Vars.subst_var id c)
+let mkNamedLetIn id c1 t c2 = mkLetIn (Name.Name id, c1, t, Vars.subst_var id c2)
 
 let mkNamedProd_or_LetIn decl c =
   let open Context.Named.Declaration in

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -263,7 +263,7 @@ let next_ident_away id avoid =
 
 let next_name_away na avoid =
   let avoid id = Id.Set.mem id avoid in
-  let id = match na with Name id -> id | Anonymous -> default_non_dependent_ident in
+  let id = match na with Name.Name id -> id | Name.Anonymous -> default_non_dependent_ident in
   next_ident_away_from id avoid
 
 type subst_val =
@@ -351,9 +351,9 @@ let push_rel_decl_to_named_context sigma decl (subst, avoid, nc) =
     decl |> NamedDecl.set_id id' |> map_decl (replace_vars vsubst)
   in
   let extract_if_neq id = function
-    | Anonymous -> None
-    | Name id' when Id.compare id id' = 0 -> None
-    | Name id' -> Some id'
+    | Name.Anonymous -> None
+    | Name.Name id' when Id.compare id id' = 0 -> None
+    | Name.Name id' -> Some id'
   in
   let na = RelDecl.get_name decl in
   let id =

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -1045,7 +1045,7 @@ let meta_ftype evd mv =
 
 let meta_type evd mv = (meta_ftype evd mv).rebus
 
-let meta_declare mv v ?(name=Anonymous) evd =
+let meta_declare mv v ?(name=Name.Anonymous) evd =
   let metas = Metamap.add mv (Cltyp(name,mk_freelisted v)) evd.metas in
   set_metas evd metas
 
@@ -1067,7 +1067,7 @@ let meta_reassign mv (v, pb) evd =
 
 (* If the meta is defined then forget its name *)
 let meta_name evd mv =
-  try fst (clb_name (Metamap.find mv evd.metas)) with Not_found -> Anonymous
+  try fst (clb_name (Metamap.find mv evd.metas)) with Not_found -> Name.Anonymous
 
 let clear_metas evd = {evd with metas = Metamap.empty}
 
@@ -1094,8 +1094,8 @@ let retract_coercible_metas evd =
 
 let evar_source_of_meta mv evd =
   match meta_name evd mv with
-  | Anonymous -> Loc.tag Evar_kinds.GoalEvar
-  | Name id   -> Loc.tag @@ Evar_kinds.VarInstance id
+  | Name.Anonymous -> Loc.tag Evar_kinds.GoalEvar
+  | Name.Name id   -> Loc.tag @@ Evar_kinds.VarInstance id
 
 let dependent_evar_ident ev evd =
   let evi = find evd ev in

--- a/engine/namegen.ml
+++ b/engine/namegen.ml
@@ -103,7 +103,7 @@ let head_name sigma c = (* Find the head constant of a constr if any *)
     | Const _ | Ind _ | Construct _ | Var _ as c ->
 	Some (basename_of_global (global_of_constr c))
     | Fix ((_,i),(lna,_,_)) | CoFix (i,(lna,_,_)) ->
-	Some (match lna.(i) with Name id -> id | _ -> assert false)
+        Some (match lna.(i) with Name.Name id -> id | _ -> assert false)
     | Sort _ | Rel _ | Meta _|Evar _|Case (_, _, _, _) -> None
   in
   hdrec c
@@ -140,11 +140,11 @@ let hdchar env sigma c =
 	(if n<=k then "p" (* the initial term is flexible product/function *)
 	 else
 	   try match lookup_rel (n-k) env with
-	     | LocalAssum (Name id,_)   | LocalDef (Name id,_,_) -> lowercase_first_char id
-	     | LocalAssum (Anonymous,t) | LocalDef (Anonymous,_,t) -> hdrec 0 (lift (n-k) t)
+             | LocalAssum (Name.Name id,_)   | LocalDef (Name.Name id,_,_) -> lowercase_first_char id
+             | LocalAssum (Name.Anonymous,t) | LocalDef (Name.Anonymous,_,t) -> hdrec 0 (lift (n-k) t)
 	   with Not_found -> "y")
     | Fix ((_,i),(lna,_,_)) | CoFix (i,(lna,_,_)) ->
-	let id = match lna.(i) with Name id -> id | _ -> assert false in
+        let id = match lna.(i) with Name.Name id -> id | _ -> assert false in
 	lowercase_first_char id
     | Evar _ (* We could do better... *)
     | Meta _ | Case (_, _, _, _) -> "y"
@@ -152,11 +152,11 @@ let hdchar env sigma c =
   hdrec 0 c
 
 let id_of_name_using_hdchar env sigma a = function
-  | Anonymous -> Id.of_string (hdchar env sigma a)
-  | Name id   -> id
+  | Name.Anonymous -> Id.of_string (hdchar env sigma a)
+  | Name.Name id   -> id
 
 let named_hd env sigma a = function
-  | Anonymous -> Name (Id.of_string (hdchar env sigma a))
+  | Name.Anonymous -> Name.Name (Id.of_string (hdchar env sigma a))
   | x         -> x
 
 let mkProd_name   env sigma (n,a,b) = mkProd (named_hd env sigma a n, a, b)
@@ -165,8 +165,8 @@ let mkLambda_name env sigma (n,a,b) = mkLambda (named_hd env sigma a n, a, b)
 let lambda_name = mkLambda_name
 let prod_name = mkProd_name
 
-let prod_create   env sigma (a,b) = mkProd (named_hd env sigma a Anonymous, a, b)
-let lambda_create env sigma (a,b) =  mkLambda (named_hd env sigma a Anonymous, a, b)
+let prod_create   env sigma (a,b) = mkProd (named_hd env sigma a Name.Anonymous, a, b)
+let lambda_create env sigma (a,b) =  mkLambda (named_hd env sigma a Name.Anonymous, a, b)
 
 let name_assumption env sigma = function
     | LocalAssum (na,t) -> LocalAssum (named_hd env sigma t na, t)
@@ -234,7 +234,7 @@ let visible_ids sigma (nenv, c) =
           None
       in
       let ids = match name with
-      | Some (Name id) -> Id.Set.add id ids
+      | Some (Name.Name id) -> Id.Set.add id ids
       | _ -> ids
       in
       accu := (gseen, vseen, ids)
@@ -249,7 +249,7 @@ let visible_ids sigma (nenv, c) =
 (* 1- Looks for a fresh name for printing in cases pattern *)
 
 let next_name_away_in_cases_pattern sigma env_t na avoid =
-  let id = match na with Name id -> id | Anonymous -> default_dependent_ident in
+  let id = match na with Name.Name id -> id | Name.Anonymous -> default_dependent_ident in
   let visible = visible_ids sigma env_t in
   let bad id = Id.Set.mem id avoid || is_constructor id
                                     || Id.Set.mem id visible in
@@ -271,8 +271,8 @@ let next_ident_away_in_goal id avoid =
 
 let next_name_away_in_goal na avoid =
   let id = match na with
-    | Name id -> id
-    | Anonymous -> default_non_dependent_ident in
+    | Name.Name id -> id
+    | Name.Anonymous -> default_non_dependent_ident in
   next_ident_away_in_goal id avoid
 
 (* 3- Looks for next fresh name outside a list that is moreover valid
@@ -296,18 +296,18 @@ let next_ident_away id avoid =
   else id
 
 let next_name_away_with_default default na avoid =
-  let id = match na with Name id -> id | Anonymous -> Id.of_string default in
+  let id = match na with Name.Name id -> id | Name.Anonymous -> Id.of_string default in
   next_ident_away id avoid
 
-let reserved_type_name = ref (fun t -> Anonymous)
+let reserved_type_name = ref (fun t -> Name.Anonymous)
 let set_reserved_typed_name f = reserved_type_name := f
 
 let next_name_away_with_default_using_types default na avoid t =
   let id = match na with
-    | Name id -> id
-    | Anonymous -> match !reserved_type_name t with
-	| Name id -> id
-	| Anonymous -> Id.of_string default in
+    | Name.Name id -> id
+    | Name.Anonymous -> match !reserved_type_name t with
+        | Name.Name id -> id
+        | Name.Anonymous -> Id.of_string default in
   next_ident_away id avoid
 
 let next_name_away = next_name_away_with_default default_non_dependent_string
@@ -323,7 +323,7 @@ let make_all_name_different env sigma =
        let na = named_hd newenv sigma (RelDecl.get_type decl) (RelDecl.get_name decl) in
        let id = next_name_away na !avoid in
        avoid := Id.Set.add id !avoid;
-       push_rel (RelDecl.set_name (Name id) decl) newenv)
+       push_rel (RelDecl.set_name (Name.Name id) decl) newenv)
     rels ~init:env0
 
 (* 5- Looks for next fresh name outside a list; avoids also to use names that
@@ -338,8 +338,8 @@ let next_ident_away_for_default_printing sigma env_t id avoid =
 
 let next_name_away_for_default_printing sigma env_t na avoid =
   let id = match na with
-  | Name id   -> id
-  | Anonymous ->
+  | Name.Name id   -> id
+  | Name.Anonymous ->
       (* In principle, an anonymous name is not dependent and will not be *)
       (* taken into account by the function compute_displayed_name_in; *)
       (* just in case, invent a valid name *)
@@ -375,14 +375,14 @@ let next_name_for_display sigma flags =
   | RenamingForGoal -> next_name_away_in_goal
   | RenamingElsewhereFor env_t -> next_name_away_for_default_printing sigma env_t
 
-(* Remark: Anonymous var may be dependent in Evar's contexts *)
+(* Remark: Name.Anonymous var may be dependent in Evar's contexts *)
 let compute_displayed_name_in_gen_poly noccurn_fun sigma flags avoid na c =
   match na with
-  | Anonymous when noccurn_fun sigma 1 c ->
-    (Anonymous,avoid)
+  | Name.Anonymous when noccurn_fun sigma 1 c ->
+    (Name.Anonymous,avoid)
   | _ ->
     let fresh_id = next_name_for_display sigma flags na avoid in
-    let idopt = if noccurn_fun sigma 1 c then Anonymous else Name fresh_id in
+    let idopt = if noccurn_fun sigma 1 c then Name.Anonymous else Name.Name fresh_id in
     (idopt, Id.Set.add fresh_id avoid)
 
 let compute_displayed_name_in = compute_displayed_name_in_gen_poly noccurn
@@ -394,15 +394,15 @@ let compute_displayed_name_in_gen f sigma =
 
 let compute_and_force_displayed_name_in sigma flags avoid na c =
   match na with
-  | Anonymous when noccurn sigma 1 c ->
-    (Anonymous,avoid)
+  | Name.Anonymous when noccurn sigma 1 c ->
+    (Name.Anonymous,avoid)
   | _ ->
     let fresh_id = next_name_for_display sigma flags na avoid in
-    (Name fresh_id, Id.Set.add fresh_id avoid)
+    (Name.Name fresh_id, Id.Set.add fresh_id avoid)
 
 let compute_displayed_let_name_in sigma flags avoid na c =
   let fresh_id = next_name_for_display sigma flags na avoid in
-  (Name fresh_id, Id.Set.add fresh_id avoid)
+  (Name.Name fresh_id, Id.Set.add fresh_id avoid)
 
 let rename_bound_vars_as_displayed sigma avoid env c =
   let rec rename avoid env c =

--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -692,7 +692,7 @@ let guard_no_unifiable =
   | [] -> tclUNIT None
   | gls ->
       let l = CList.map (fun g -> Evd.dependent_evar_ident g initial.solution) gls in
-      let l = CList.map (fun id -> Names.Name id) l in
+      let l = CList.map (fun id -> Names.Name.Name id) l in
       tclUNIT (Some l)
 
 (** [unshelve l p] adds all the goals in [l] at the end of the focused
@@ -711,7 +711,7 @@ let mark_in_evm ~goal evd content =
                - GoalEvar (morally not dependent)
                - VarInstance (morally dependent of some name).
                This is a heuristic for naming these evars. *)
-            | loc, (Evar_kinds.QuestionMark (_,Names.Name id) |
+            | loc, (Evar_kinds.QuestionMark (_,Names.Name.Name id) |
                     Evar_kinds.ImplicitArg (_,(_,Some id),_)) -> loc, Evar_kinds.VarInstance id
             | _, (Evar_kinds.VarInstance _ | Evar_kinds.GoalEvar) as x -> x
             | loc,_ -> loc,Evar_kinds.GoalEvar }

--- a/engine/universes.ml
+++ b/engine/universes.ml
@@ -100,8 +100,8 @@ let universe_binders_with_opt_names ref levels = function
     if Int.equal(List.length levels) (List.length udecl)
     then
       List.fold_left2 (fun acc (_,na) lvl -> match na with
-          | Anonymous -> acc
-          | Name na -> Names.Id.Map.add na lvl acc)
+          | Name.Anonymous -> acc
+          | Name.Name na -> Names.Id.Map.add na lvl acc)
         empty_binders udecl levels
     else
       CErrors.user_err ~hdr:"universe_binders_with_opt_names"

--- a/interp/constrexpr_ops.ml
+++ b/interp/constrexpr_ops.ml
@@ -482,8 +482,8 @@ let split_at_annot bl na =
     let rec aux acc = function
       | CLocalAssum (bls, k, t) as x :: rest ->
         let test (_, na) = match na with
-          | Name id' -> Id.equal id id'
-          | Anonymous -> false
+          | Name.Name id' -> Id.equal id id'
+          | Name.Anonymous -> false
         in
         let l, r = List.split_when test bls in
         begin match r with
@@ -496,7 +496,7 @@ let split_at_annot bl na =
             (List.rev ans, CLocalAssum (r, k, t) :: rest)
         end
       | CLocalDef ((_,na),_,_) as x :: rest ->
-        if Name.equal (Name id) na then
+        if Name.equal Name.(Name id) na then
           CErrors.user_err ?loc
             (Id.print id ++ str" must be a proper parameter and not a local definition.")
         else
@@ -542,8 +542,8 @@ let coerce_to_id = function
                          (str "This expression should be a simple identifier.")
 
 let coerce_to_name = function
-  | { CAst.v = CRef (Ident (loc,id),None) } -> (loc,Name id)
-  | { CAst.loc; CAst.v = CHole (None,Misctypes.IntroAnonymous,None) } -> (loc,Anonymous)
+  | { CAst.v = CRef (Ident (loc,id),None) } -> (loc,Name.Name id)
+  | { CAst.loc; CAst.v = CHole (None,Misctypes.IntroAnonymous,None) } -> (loc,Name.Anonymous)
   | { CAst.loc; _ } -> CErrors.user_err ?loc ~hdr:"coerce_to_name"
                          (str "This expression should be a name.")
 
@@ -569,8 +569,8 @@ let rec coerce_to_cases_pattern_expr c = CAst.map_with_loc (fun ?loc -> function
      CPatAtom (Some r)
   | CHole (None,Misctypes.IntroAnonymous,None) ->
      CPatAtom None
-  | CLetIn ((loc,Name id),b,None,{ CAst.v = CRef (Ident (_,id'),None) }) when Id.equal id id' ->
-      CPatAlias (coerce_to_cases_pattern_expr b, (loc,Name id))
+  | CLetIn ((loc,Name.Name id),b,None,{ CAst.v = CRef (Ident (_,id'),None) }) when Id.equal id id' ->
+      CPatAlias (coerce_to_cases_pattern_expr b, (loc,Name.Name id))
   | CApp ((None,p),args) when List.for_all (fun (_,e) -> e=None) args ->
      (mkAppPattern (coerce_to_cases_pattern_expr p) (List.map (fun (a,_) -> coerce_to_cases_pattern_expr a) args)).CAst.v
   | CAppExpl ((None,r,i),args) ->

--- a/interp/discharge.ml
+++ b/interp/discharge.ml
@@ -22,8 +22,8 @@ open Context.Rel.Declaration
 
 let detype_param =
   function
-  | LocalAssum (Name id, p) -> id, LocalAssumEntry p
-  | LocalDef (Name id, p,_) -> id, LocalDefEntry p
+  | LocalAssum (Name.Name id, p) -> id, LocalAssumEntry p
+  | LocalDef (Name.Name id, p,_) -> id, LocalDefEntry p
   | _ -> anomaly (Pp.str "Unnamed inductive local variable.")
 
 (* Replace

--- a/interp/dumpglob.ml
+++ b/interp/dumpglob.ml
@@ -254,8 +254,8 @@ let dump_definition (loc, id) sec s =
 
 let dump_constraint (((loc, n),_), _, _) sec ty =
   match n with
-    | Names.Name id -> dump_definition (loc, id) sec ty
-    | Names.Anonymous -> ()
+    | Names.Name.Name id -> dump_definition (loc, id) sec ty
+    | Names.Name.Anonymous -> ()
 
 let dump_moddef ?loc mp ty =
   let (dp, l) = Lib.split_modpath mp in

--- a/interp/impargs.ml
+++ b/interp/impargs.ml
@@ -323,8 +323,8 @@ let positions_of_implicits (_,impls) =
 
 let rec prepare_implicits f = function
   | [] -> []
-  | (Anonymous, Some _)::_ -> anomaly (Pp.str "Unnamed implicit.")
-  | (Name id, Some imp)::imps ->
+  | (Name.Anonymous, Some _)::_ -> anomaly (Pp.str "Unnamed implicit.")
+  | (Name.Name id, Some imp)::imps ->
       let imps' = prepare_implicits f imps in
       Some (id,imp,(set_maximality imps' f.maximal,true)) :: imps'
   | _::imps -> None :: prepare_implicits f imps
@@ -366,7 +366,7 @@ let set_manual_implicits env flags enriching autoimps l =
     user_err Pp.(str "Some parameters are referred more than once.");
   (* Compare with automatic implicits to recover printing data and names *)
   let rec merge k l = function
-  | (Name id,imp)::imps ->
+  | (Name.Name id,imp)::imps ->
       let l',imp,m =
 	try
           let eq = explicitation_eq in
@@ -388,7 +388,7 @@ let set_manual_implicits env flags enriching autoimps l =
 	(* match imp with Some Manual -> (b,f) *)
 	(* | _ ->  *)set_maximality imps' b, f) m in
       Option.map (set_implicit id imp) m :: imps'
-  | (Anonymous,imp)::imps ->
+  | (Name.Anonymous,imp)::imps ->
       let l', forced = try_forced k l in
 	forced :: merge (k+1) l' imps
   | [] when begin match l with [] -> true | _ -> false end -> []
@@ -431,7 +431,7 @@ let compute_mib_implicits flags manual kn =
         (fun i mip ->
 	  (** No need to care about constraints here *)
 	  let ty, _ = Global.type_of_global_in_context env (IndRef (kn,i)) in
-	  Context.Rel.Declaration.LocalAssum (Name mip.mind_typename, ty))
+          Context.Rel.Declaration.LocalAssum (Name.Name mip.mind_typename, ty))
         mib.mind_packets) in
   let env_ar = push_rel_context ar env in
   let imps_one_inductive i mip =
@@ -497,7 +497,7 @@ let implicits_of_global ref =
       let rec rename implicits names = match implicits, names with
         | [], _ -> []
         | _, [] -> implicits
-        | Some (_, x,y) :: implicits, Name id :: names ->
+        | Some (_, x,y) :: implicits, Name.Name id :: names ->
            Some (id, x,y) :: rename implicits names
         | imp :: implicits, _ :: names -> imp :: rename implicits names
       in

--- a/interp/reserve.ml
+++ b/interp/reserve.ml
@@ -120,7 +120,7 @@ let revert_reserved_type t =
       with No_match -> false
     in
     let (id, _) = ReservedSet.find filter reserved in
-    Name id
-  with Not_found | Failure _ -> Anonymous
+    Name.Name id
+  with Not_found | Failure _ -> Name.Anonymous
 
 let _ = Namegen.set_reserved_typed_name revert_reserved_type

--- a/kernel/context.ml
+++ b/kernel/context.ml
@@ -359,9 +359,9 @@ struct
             
     let to_rel_decl = function
       | LocalAssum (id,t) ->
-          Rel.Declaration.LocalAssum (Name id, t)
+          Rel.Declaration.LocalAssum (Name.Name id, t)
       | LocalDef (id,v,t) ->
-          Rel.Declaration.LocalDef (Name id,v,t)
+          Rel.Declaration.LocalDef (Name.Name id,v,t)
   end
 
   (** Named-context is represented as a list of declarations.

--- a/kernel/indtypes.ml
+++ b/kernel/indtypes.ml
@@ -323,7 +323,7 @@ let typecheck_inductive env mie =
 	 let full_arity = it_mkProd_or_LetIn arity paramsctxt in
 	 let id = ind.mind_entry_typename in
 	 let env_ar' =
-           push_rel (LocalAssum (Name id, full_arity)) env_ar in
+           push_rel (LocalAssum (Name.Name id, full_arity)) env_ar in
              (* (add_constraints cst2 env_ar) in *)
 	   (env_ar', (id,full_arity,sign @ paramsctxt,expltype,deflev,inflev)::l))
       (env',[])
@@ -524,7 +524,7 @@ let ienv_push_inductive (env, n, ntypes, ra_env) ((mi,u),lrecparams) =
   let specif = (lookup_mind_specif env mi, u) in
   let ty = type_of_inductive env specif in
   let env' =
-    let decl = LocalAssum (Anonymous, hnf_prod_applist env ty lrecparams) in
+    let decl = LocalAssum (Name.Anonymous, hnf_prod_applist env ty lrecparams) in
     push_rel decl env in
   let ra_env' =
     (Imbr mi,(Rtree.mk_rec_calls 1).(0)) ::
@@ -824,7 +824,7 @@ let compute_projections ((kn, _ as ind), u as indu) n x nparamargs params
 	ci_pp_info = print_info }
   in
   let len = List.length ctx in
-  let x = Name x in
+  let x = Name.Name x in
   let compat_body ccl i = 
     (* [ccl] is defined in context [params;x:indty] *)
     (* [ccl'] is defined in context [params;x:indty;x:indty] *)
@@ -856,7 +856,7 @@ let compute_projections ((kn, _ as ind), u as indu) n x nparamargs params
         (i, j+1, kns, pbs, subst, letsubst)
     | LocalAssum (na,t) ->
       match na with
-      | Name id ->
+      | Name.Name id ->
 	let kn = Constant.make1 (KerName.make mp dp (Label.of_id id)) in
         (* from [params, field1,..,fieldj |- t(params,field1,..,fieldj)]
            to [params, x:I, field1,..,fieldj |- t(params,field1,..,fieldj] *)
@@ -877,7 +877,7 @@ let compute_projections ((kn, _ as ind), u as indu) n x nparamargs params
 		     proj_body = compat } in
 	  (i + 1, j + 1, kn :: kns, body :: pbs,
 	   fterm :: subst, fterm :: letsubst)
-      | Anonymous -> raise UndefinableExpansion
+      | Name.Anonymous -> raise UndefinableExpansion
   in
   let (_, _, kns, pbs, subst, letsubst) =
     List.fold_right projections ctx (0, 1, [], [], [], paramsletsubst)

--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -578,7 +578,7 @@ let ienv_push_inductive (env, ra_env) ((mind,u),lpar) =
   let mib = Environ.lookup_mind mind env in
   let ntypes = mib.mind_ntypes in
   let push_ind specif env =
-    let decl = LocalAssum (Anonymous, hnf_prod_applist env (type_of_inductive env ((mib,specif),u)) lpar) in
+    let decl = LocalAssum (Name.Anonymous, hnf_prod_applist env (type_of_inductive env ((mib,specif),u)) lpar) in
     push_rel decl env
   in
   let env = Array.fold_right push_ind mib.mind_packets env in
@@ -599,7 +599,7 @@ let rec ienv_decompose_prod (env,_ as ienv) n c =
 let lambda_implicit_lift n a =
   let level = Level.make (DirPath.make [Id.of_string "implicit"]) 0 in
   let implicit_sort = mkType (Universe.make level) in
-  let lambda_implicit a = mkLambda (Anonymous, implicit_sort, a) in
+  let lambda_implicit a = mkLambda (Name.Anonymous, implicit_sort, a) in
   iterate lambda_implicit n (lift n a)
 
 (* This removes global parameters of the inductive types in lc (for

--- a/kernel/names.mli
+++ b/kernel/names.mli
@@ -109,7 +109,11 @@ end
 
 (** {6 Type aliases} *)
 
-type name = Name.t = Anonymous | Name of Id.t
+type name = Name.t =
+  | Anonymous
+      [@ocaml.deprecated "Use Name.Anonymous"]
+  | Name of Id.t
+      [@ocaml.deprecated "Use Name.Name"]
 [@@ocaml.deprecated "Use Name.t"]
 
 type variable = Id.t

--- a/kernel/nativelambda.ml
+++ b/kernel/nativelambda.ml
@@ -291,7 +291,7 @@ let get_value lc =
   | _ -> raise Not_found
 	
 let make_args start _end =
-  Array.init (start - _end + 1) (fun i -> Lrel (Anonymous, start - i))
+  Array.init (start - _end + 1) (fun i -> Lrel (Name.Anonymous, start - i))
     
 (* Translation of constructors *)	
 
@@ -385,7 +385,7 @@ module Renv =
 
 
     let make () = {
-      name_rel = Vect.make 16 Anonymous;
+      name_rel = Vect.make 16 Name.Anonymous;
       construct_tbl = ConstrTable.create 111
     }
 
@@ -540,7 +540,7 @@ let rec lambda_of_constr env sigma c =
 	  match b with
 	  | Llam(ids, body) when Int.equal (Array.length ids) arity -> (cn, ids, body)
 	  | _ -> 
-	      let ids = Array.make arity Anonymous in
+              let ids = Array.make arity Name.Anonymous in
 	      let args = make_args arity 1 in
 	      let ll = lam_lift arity b in
 	      (cn, ids, mkLapp  ll args) in

--- a/kernel/term.ml
+++ b/kernel/term.ml
@@ -235,9 +235,9 @@ let decompose_appvect c =
 (* Other term constructors *)
 (***************************)
 
-let mkNamedProd id typ c = mkProd (Name id, typ, subst_var id c)
-let mkNamedLambda id typ c = mkLambda (Name id, typ, subst_var id c)
-let mkNamedLetIn id c1 t c2 = mkLetIn (Name id, c1, t, subst_var id c2)
+let mkNamedProd id typ c = mkProd (Name.Name id, typ, subst_var id c)
+let mkNamedLambda id typ c = mkLambda (Name.Name id, typ, subst_var id c)
+let mkNamedLetIn id c1 t c2 = mkLetIn (Name.Name id, c1, t, subst_var id c2)
 
 (* Constructs either [(x:t)c] or [[x=b:t]c] *)
 let mkProd_or_LetIn decl c =
@@ -266,7 +266,7 @@ let mkNamedProd_wo_LetIn decl c =
     | LocalDef (id,b,t) -> subst1 b (subst_var id c)
 
 (* non-dependent product t1 -> t2 *)
-let mkArrow t1 t2 = mkProd (Anonymous, t1, t2)
+let mkArrow t1 t2 = mkProd (Name.Anonymous, t1, t2)
 
 (* Constructs either [[x:t]c] or [[x=b:t]c] *)
 let mkLambda_or_LetIn decl c =

--- a/kernel/term_typing.ml
+++ b/kernel/term_typing.ml
@@ -116,7 +116,7 @@ let inline_side_effects env body ctx side_eff =
       let name = Constant.to_string c in
       let map c = if c == '.' || c == '#' then '_' else c in
       let name = String.map map name in
-      Name (Id.of_string name)
+      Name.Name (Id.of_string name)
     in
     let fold (subst, var, ctx, args) (c, cb, b) =
       let (b, opaque) = match cb.const_body, b with

--- a/kernel/typeops.ml
+++ b/kernel/typeops.ml
@@ -460,10 +460,10 @@ let infer_v env cv =
 let infer_local_decl env id = function
   | Entries.LocalDefEntry c ->
       let t = execute env c in
-      RelDecl.LocalDef (Name id, c, t)
+      RelDecl.LocalDef (Name.Name id, c, t)
   | Entries.LocalAssumEntry c ->
       let t = execute env c in
-      RelDecl.LocalAssum (Name id, check_assumption env c t)
+      RelDecl.LocalAssum (Name.Name id, check_assumption env c t)
 
 let infer_local_decls env decls =
   let rec inferec env = function

--- a/parsing/egramcoq.ml
+++ b/parsing/egramcoq.ml
@@ -309,8 +309,8 @@ let interp_entry forpat e = match e with
 | ETProdBinderList (ETBinderClosed tkl) -> TTAny (TTClosedBinderList tkl)
 
 let cases_pattern_expr_of_name (loc,na) = CAst.make ?loc @@ match na with
-  | Anonymous -> CPatAtom None
-  | Name id   -> CPatAtom (Some (Ident (Loc.tag ?loc id)))
+  | Name.Anonymous -> CPatAtom None
+  | Name.Name id   -> CPatAtom (Some (Ident (Loc.tag ?loc id)))
 
 type 'r env = {
   constrs : 'r list;

--- a/parsing/g_constr.ml4
+++ b/parsing/g_constr.ml4
@@ -110,13 +110,13 @@ let name_colon =
             (match stream_nth 1 strm with
               | KEYWORD ":" ->
                   stream_njunk 2 strm;
-                  Name (Names.Id.of_string s)
+                  Name.Name (Names.Id.of_string s)
               | _ -> err ())
 	| KEYWORD "_" ->
           (match stream_nth 1 strm with
               | KEYWORD ":" ->
                   stream_njunk 2 strm;
-                  Anonymous
+                  Name.Anonymous
               | _ -> err ())
         | _ -> err ())
 
@@ -131,7 +131,7 @@ GEXTEND Gram
     [ [ id = Prim.ident -> id ] ]
   ;
   Prim.name:
-    [ [ "_" -> Loc.tag ~loc:!@loc Anonymous ] ]
+    [ [ "_" -> Loc.tag ~loc:!@loc Name.Anonymous ] ]
   ;
   global:
     [ [ r = Prim.reference -> r ] ]
@@ -260,7 +260,7 @@ GEXTEND Gram
               CFix(id,_) -> id
             | CCoFix(id,_) -> id
             | _ -> assert false in
-          CAst.make ~loc:!@loc @@ CLetIn((li,Name id),fixp,None,c)
+          CAst.make ~loc:!@loc @@ CLetIn((li,Name.Name id),fixp,None,c)
       | "let"; lb = ["("; l=LIST0 name SEP ","; ")" -> l | "()" -> []];
 	  po = return_type;
 	  ":="; c1 = operconstr LEVEL "200"; "in";
@@ -433,7 +433,7 @@ GEXTEND Gram
     ] ]
   ;
   impl_name_head:
-    [ [ id = impl_ident_head -> (Loc.tag ~loc:!@loc @@ Name id) ] ]
+    [ [ id = impl_ident_head -> (Loc.tag ~loc:!@loc @@ Name.Name id) ] ]
   ;
   binders_fixannot:
     [ [ na = impl_name_head; assum = impl_ident_tail; bl = binders_fixannot ->
@@ -453,7 +453,7 @@ GEXTEND Gram
       | id = name; idl = LIST0 name; bl = binders ->
           binders_of_names (id::idl) @ bl
       | id1 = name; ".."; id2 = name ->
-          [CLocalAssum ([id1;(Loc.tag ~loc:!@loc (Name ldots_var));id2],
+          [CLocalAssum ([id1;(Loc.tag ~loc:!@loc Name.(Name ldots_var));id2],
 	                  Default Explicit, CAst.make ~loc:!@loc @@ CHole (None, IntroAnonymous, None))]
       | bl = closed_binder; bl' = binders ->
 	  bl@bl'
@@ -499,13 +499,13 @@ GEXTEND Gram
     ] ]
   ;
   typeclass_constraint:
-    [ [ "!" ; c = operconstr LEVEL "200" -> (Loc.tag ~loc:!@loc Anonymous), true, c
+    [ [ "!" ; c = operconstr LEVEL "200" -> (Loc.tag ~loc:!@loc Name.Anonymous), true, c
       | "{"; id = name; "}"; ":" ; expl = [ "!" -> true | -> false ] ; c = operconstr LEVEL "200" ->
 	  id, expl, c
       | iid=name_colon ; expl = [ "!" -> true | -> false ] ; c = operconstr LEVEL "200" ->
 	  (Loc.tag ~loc:!@loc iid), expl, c
       | c = operconstr LEVEL "200" ->
-	  (Loc.tag ~loc:!@loc Anonymous), false, c
+          (Loc.tag ~loc:!@loc Name.Anonymous), false, c
     ] ]
   ;
 

--- a/parsing/g_prim.ml4
+++ b/parsing/g_prim.ml4
@@ -70,8 +70,8 @@ GEXTEND Gram
       ] ]
   ;
   name:
-    [ [ IDENT "_"  -> Loc.tag ~loc:!@loc Anonymous
-      | id = ident -> Loc.tag ~loc:!@loc @@ Name id ] ]
+    [ [ IDENT "_"  -> Loc.tag ~loc:!@loc Name.Anonymous
+      | id = ident -> Loc.tag ~loc:!@loc @@ Name.Name id ] ]
   ;
   reference:
     [ [ id = ident; (l,id') = fields ->

--- a/parsing/g_proofs.ml4
+++ b/parsing/g_proofs.ml4
@@ -29,7 +29,7 @@ GEXTEND Gram
   ;
   command:
     [ [ IDENT "Goal"; c = lconstr ->
-        VernacDefinition (Decl_kinds.(NoDischarge, Definition), ((Loc.tag ~loc:!@loc Names.Anonymous), None), ProveBody ([], c))
+        VernacDefinition (Decl_kinds.(NoDischarge, Definition), ((Loc.tag ~loc:!@loc Names.Name.Anonymous), None), ProveBody ([], c))
       | IDENT "Proof" -> VernacProof (None,None)
       | IDENT "Proof" ; IDENT "Mode" ; mn = string -> VernacProofMode mn
       | IDENT "Proof"; c = lconstr -> VernacExactProof c

--- a/parsing/g_vernac.ml4
+++ b/parsing/g_vernac.ml4
@@ -134,7 +134,7 @@ let test_plural_form_types loc kwd = function
   | _ -> ()
 
 let lname_of_lident : lident -> lname =
-  Loc.map (fun s -> Name s)
+  Loc.map (fun s -> Name.Name s)
 
 let name_of_ident_decl : ident_decl -> name_decl =
   on_fst lname_of_lident
@@ -629,12 +629,12 @@ GEXTEND Gram
 	  VernacCanonical (ByNotation ntn)
       | IDENT "Canonical"; IDENT "Structure"; qid = global; d = def_body ->
           let s = coerce_reference_to_id qid in
-          VernacDefinition ((NoDischarge,CanonicalStructure),((Loc.tag (Name s)),None),d)
+          VernacDefinition ((NoDischarge,CanonicalStructure),((Loc.tag (Name.Name s)),None),d)
 
       (* Coercions *)
       | IDENT "Coercion"; qid = global; d = def_body ->
           let s = coerce_reference_to_id qid in
-          VernacDefinition ((NoDischarge,Coercion),((Loc.tag (Name s)),None),d)
+          VernacDefinition ((NoDischarge,Coercion),((Loc.tag (Name.Name s)),None),d)
       | IDENT "Identity"; IDENT "Coercion"; f = identref; ":";
          s = class_rawexpr; ">->"; t = class_rawexpr ->
            VernacIdentityCoercion (f, s, t)
@@ -800,9 +800,9 @@ GEXTEND Gram
   ;
   instance_name:
     [ [ name = ident_decl; sup = OPT binders ->
-	  (let ((loc,id),l) = name in ((loc, Name id),l)),
+          (let ((loc,id),l) = name in ((loc, Name.Name id),l)),
           (Option.default [] sup)
-      | -> ((Loc.tag ~loc:!@loc Anonymous), None), []  ] ]
+      | -> ((Loc.tag ~loc:!@loc Name.Anonymous), None), []  ] ]
   ;
   hint_info:
     [ [ "|"; i = OPT natural; pat = OPT constr_pattern ->

--- a/plugins/cc/ccalgo.ml
+++ b/plugins/cc/ccalgo.ml
@@ -415,9 +415,9 @@ let new_representative typ =
 
 (* rebuild a constr from an applicative term *)
 
-let _A_ = Name (Id.of_string "A")
-let _B_ = Name (Id.of_string "A")
-let _body_ =  mkProd(Anonymous,mkRel 2,mkRel 2)
+let _A_ = Name.Name (Id.of_string "A")
+let _B_ = Name.Name (Id.of_string "A")
+let _body_ =  mkProd(Name.Anonymous,mkRel 2,mkRel 2)
 
 let cc_product s1 s2 =
   mkLambda(_A_,mkSort(s1),

--- a/plugins/cc/cctac.ml
+++ b/plugins/cc/cctac.ml
@@ -235,7 +235,7 @@ let build_projection intype (cstr:pconstructor) special default gls=
   let sigma = project gls in
   let body=Equality.build_selector (pf_env gls) sigma ci (mkRel 1) intype special default in
   let id=pf_get_new_id (Id.of_string "t") gls in
-  sigma, mkLambda(Name id,intype,body)
+  sigma, mkLambda(Name.Name id,intype,body)
 
 (* generate an adhoc tactic following the proof tree  *)
 
@@ -321,7 +321,7 @@ let rec proof_tac p : unit Proofview.tactic =
 	refresh_universes (type_of tx1) (fun typx ->
 	refresh_universes (type_of (mkApp (tf1,[|tx1|]))) (fun typfx ->
         let id = Tacmach.New.pf_get_new_id (Id.of_string "f") gl in
-	let appx1 = mkLambda(Name id,typf,mkApp(mkRel 1,[|tx1|])) in
+        let appx1 = mkLambda(Name.Name id,typf,mkApp(mkRel 1,[|tx1|])) in
 	let lemma1 = app_global_with_holes _f_equal [|typf;typfx;appx1;tf1;tf2|] 1 in
 	let lemma2 = app_global_with_holes _f_equal [|typx;typfx;tf2;tx1;tx2|] 1 in
 	let prf =
@@ -362,7 +362,7 @@ let refute_tac c t1 t2 p =
   let false_t=mkApp (c,[|mkVar hid|]) in
   let k intype =
     let neweq= app_global _eq [|intype;tt1;tt2|] in
-    Tacticals.New.tclTHENS (neweq (assert_before (Name hid)))
+    Tacticals.New.tclTHENS (neweq (assert_before Name.(Name hid)))
       [proof_tac p; simplest_elim false_t]
   in refresh_universes (Tacmach.New.pf_unsafe_type_of gl tt1) k
   end
@@ -380,9 +380,9 @@ let convert_to_goal_tac c t1 t2 p =
     let neweq= app_global _eq [|sort;tt1;tt2|] in
     let e = Tacmach.New.pf_get_new_id (Id.of_string "e") gl in
     let x = Tacmach.New.pf_get_new_id (Id.of_string "X") gl in
-    let identity=mkLambda (Name x,sort,mkRel 1) in
+    let identity=mkLambda (Name.Name x,sort,mkRel 1) in
     let endt = app_global _eq_rect [|sort;tt1;identity;c;tt2;mkVar e|] in
-    Tacticals.New.tclTHENS (neweq (assert_before (Name e)))
+    Tacticals.New.tclTHENS (neweq (assert_before Name.(Name e)))
 			   [proof_tac p; endt refine_exact_check]
   in refresh_universes (Tacmach.New.pf_unsafe_type_of gl tt2) k
   end
@@ -392,7 +392,7 @@ let convert_to_hyp_tac c1 t1 c2 t2 p =
   let tt2=constr_of_term t2 in
   let h = Tacmach.New.pf_get_new_id (Id.of_string "H") gl in
   let false_t=mkApp (c2,[|mkVar h|]) in
-    Tacticals.New.tclTHENS (assert_before (Name h) tt2)
+    Tacticals.New.tclTHENS (assert_before Name.(Name h) tt2)
       [convert_to_goal_tac c1 t1 t2 p;
        simplest_elim false_t]
   end
@@ -407,7 +407,7 @@ let discriminate_tac cstru p =
     let hid = Tacmach.New.pf_get_new_id (Id.of_string "Heq") gl in
     let neweq=app_global _eq [|intype;lhs;rhs|] in
     Tacticals.New.tclTHEN (Proofview.Unsafe.tclEVARS evm)
-			  (Tacticals.New.tclTHENS (neweq (assert_before (Name hid)))
+                          (Tacticals.New.tclTHENS (neweq (assert_before Name.(Name hid)))
       [proof_tac p; Equality.discrHyp hid])
   end
 

--- a/plugins/extraction/extraction.ml
+++ b/plugins/extraction/extraction.ml
@@ -140,7 +140,7 @@ let make_typvar n vl =
   let id' =
     let s = Id.to_string id in
     if not (String.contains s '\'') && Unicode.is_basic_ascii s then id
-    else id_of_name Anonymous
+    else id_of_name Name.Anonymous
   in
   let vl = Id.Set.of_list vl in
   next_ident_away id' vl
@@ -460,9 +460,9 @@ and extract_really_ind env kn mib =
 	  | [],[] -> []
 	  | _::l, typ::typs when isTdummy (expand env typ) ->
 	      select_fields l typs
-	  | Anonymous::l, typ::typs ->
+          | Name.Anonymous::l, typ::typs ->
 	      None :: (select_fields l typs)
-	  | Name id::l, typ::typs ->
+          | Name.Name id::l, typ::typs ->
 	      let knp = Constant.make2 mp (Label.of_id id) in
 	      (* Is it safe to use [id] for projections [foo.id] ? *)
 	      if List.for_all ((==) Keep) (type2signature env typ)
@@ -573,10 +573,10 @@ let rec extract_term env mle mlt c args =
 	(match args with
 	   | a :: l ->
 	       (* We make as many [LetIn] as possible. *)
- 	       let d' = mkLetIn (Name id,a,t,applistc d (List.map (lift 1) l))
+               let d' = mkLetIn (Name.Name id,a,t,applistc d (List.map (lift 1) l))
 	       in extract_term env mle mlt d' []
 	   | [] ->
-	       let env' = push_rel_assum (Name id, t) env in
+               let env' = push_rel_assum (Name.Name id, t) env in
 	       let id, a =
 		 try check_default env t; Id id, new_meta()
 		 with NotDefault d -> Dummy, Tdummy d
@@ -588,7 +588,7 @@ let rec extract_term env mle mlt c args =
 	       put_magic_if magic (MLlam (id, d')))
     | LetIn (n, c1, t1, c2) ->
 	let id = id_of_name n in
-	let env' = push_rel (LocalDef (Name id, c1, t1)) env in
+        let env' = push_rel (LocalDef (Name.Name id, c1, t1)) env in
 	(* We directly push the args inside the [LetIn].
            TODO: the opt_let_app flag is supposed to prevent that *)
 	let args' = List.map (lift 1) args in

--- a/plugins/extraction/table.ml
+++ b/plugins/extraction/table.ml
@@ -458,8 +458,8 @@ let argnames_of_global r =
 let msg_of_implicit = function
   | Kimplicit (r,i) ->
      let name = match List.nth (argnames_of_global r) (i-1) with
-       | Anonymous -> ""
-       | Name id -> "(" ^ Id.to_string id ^ ") "
+       | Name.Anonymous -> ""
+       | Name.Name id -> "(" ^ Id.to_string id ^ ") "
      in
      (String.ordinal i)^" argument "^name^"of "^(string_of_global r)
   | Ktype | Kprop -> ""
@@ -724,7 +724,7 @@ let add_implicits r l =
 		  safe_pr_global r)
     | ArgId id ->
        try
-         let i = List.index Name.equal (Name id) names in
+         let i = List.index Name.equal Name.(Name id) names in
          Int.Set.add i s
        with Not_found ->
 	 err (str "No argument " ++ Id.print id ++ str " for " ++

--- a/plugins/firstorder/instances.ml
+++ b/plugins/firstorder/instances.ml
@@ -107,14 +107,14 @@ let mk_open_instance env evmap id idc m t =
 	   reduction is not too expensive *)
       let (nam,_,_)=destProd evmap (whd_all env evmap typ) in
 	match nam with
-	    Name id -> id
-	  | Anonymous ->  dummy_bvid in
+            Name.Name id -> id
+          | Name.Anonymous ->  dummy_bvid in
   let revt=substl (List.init m (fun i->mkRel (m-i))) t in
   let rec aux n avoid env evmap decls =
     if Int.equal n 0 then evmap, decls else
       let nid=(fresh_id_in_env avoid var_id env) in
       let (evmap, (c, _)) = Evarutil.new_type_evar env evmap Evd.univ_flexible in
-      let decl = LocalAssum (Name nid, c) in
+      let decl = LocalAssum (Name.Name nid, c) in
 	aux (n-1) (Id.Set.add nid avoid) (EConstr.push_rel decl env) evmap (decl::decls) in
   let evmap, decls = aux m Id.Set.empty env evmap [] in
   (evmap, decls, revt)

--- a/plugins/firstorder/rules.ml
+++ b/plugins/firstorder/rules.ml
@@ -166,9 +166,9 @@ let ll_ind_tac (ind,u as indu) largs backtrack id continue seq =
 let ll_arrow_tac a b c backtrack id continue seq=
   let open EConstr in
   let open Vars in
-  let cc=mkProd(Anonymous,a,(lift 1 b)) in
-  let d idc = mkLambda (Anonymous,b,
-		  mkApp (idc, [|mkLambda (Anonymous,(lift 1 a),(mkRel 2))|])) in
+  let cc=mkProd(Name.Anonymous,a,(lift 1 b)) in
+  let d idc = mkLambda (Name.Anonymous,b,
+                  mkApp (idc, [|mkLambda (Name.Anonymous,(lift 1 a),(mkRel 2))|])) in
     tclORELSE
       (tclTHENS (cut c)
 	 [tclTHENLIST

--- a/plugins/funind/functional_principles_types.ml
+++ b/plugins/funind/functional_principles_types.ml
@@ -40,11 +40,11 @@ let compute_new_princ_type_from_rel rel_to_fun sorts princ_type =
     | [] -> []
     | decl :: predicates ->
        (match Context.Rel.Declaration.get_name decl with
-	| Name x ->
+        | Name.Name x ->
 	   let id = Namegen.next_ident_away x (Id.Set.of_list avoid) in
 	   Hashtbl.add tbl id x;
-	   RelDecl.set_name (Name id) decl :: change_predicates_names (id::avoid) predicates
-	| Anonymous -> anomaly (Pp.str "Anonymous property binder."))
+           RelDecl.set_name Name.(Name id) decl :: change_predicates_names (id::avoid) predicates
+        | Name.Anonymous -> anomaly (Pp.str "Anonymous property binder."))
   in
   let avoid = (Termops.ids_of_context env_with_params ) in
   let princ_type_info =
@@ -240,8 +240,8 @@ let compute_new_princ_type_from_rel rel_to_fun sorts princ_type =
   in
   it_mkProd_or_LetIn
     (it_mkProd_or_LetIn
-       pre_res (List.map (function Context.Named.Declaration.LocalAssum (id,b)   -> LocalAssum (Name (Hashtbl.find tbl id), b)
-                                 | Context.Named.Declaration.LocalDef (id,t,b) -> LocalDef (Name (Hashtbl.find tbl id), t, b))
+       pre_res (List.map (function Context.Named.Declaration.LocalAssum (id,b)   -> LocalAssum (Name.Name (Hashtbl.find tbl id), b)
+                                 | Context.Named.Declaration.LocalDef (id,t,b) -> LocalDef (Name.Name (Hashtbl.find tbl id), t, b))
           	      new_predicates)
     )
     (List.map (fun d -> Termops.map_rel_decl EConstr.Unsafe.to_constr d) princ_type_info.params)
@@ -401,10 +401,10 @@ let get_funs_constant mp dp =
 	  Array.mapi
 	    (fun i na ->
 	       match na with
-		 | Name id ->
+                 | Name.Name id ->
 		     let const = Constant.make3 mp dp (Label.of_id id) in
 		     const,i
-		 | Anonymous ->
+                 | Name.Anonymous ->
 		     anomaly (Pp.str "Anonymous fix.")
 	    )
 	    na

--- a/plugins/funind/indfun.ml
+++ b/plugins/funind/indfun.ml
@@ -468,7 +468,7 @@ let register_wf ?(is_mes=false) fname rec_impls wf_rel_expr wf_arg using_lemmas 
 	if Int.equal (List.length names) 1 then 1
 	else error "Recursive argument must be specified"
       | Some wf_arg ->
-	  List.index Name.equal (Name wf_arg) names
+          List.index Name.equal Name.(Name wf_arg) names
   in
   let unbounded_eq =
     let f_app_args =
@@ -476,8 +476,8 @@ let register_wf ?(is_mes=false) fname rec_impls wf_rel_expr wf_arg using_lemmas 
 	 (None,(Ident (Loc.tag fname)),None) ,
 	 (List.map
 	    (function
-	       | _,Anonymous -> assert false
-	       | _,Name e -> (Constrexpr_ops.mkIdentC e)
+               | _,Name.Anonymous -> assert false
+               | _,Name.Name e -> (Constrexpr_ops.mkIdentC e)
 	    )
 	    (Constrexpr_ops.names_of_local_assums args)
 	 )
@@ -515,7 +515,7 @@ let register_mes fname rec_impls wf_mes_expr wf_rel_expr_opt wf_arg using_lemmas
       | None ->
 	  begin
 	    match args with
-	      | [Constrexpr.CLocalAssum ([(_,Name x)],k,t)] -> t,x
+              | [Constrexpr.CLocalAssum ([(_,Name.Name x)],k,t)] -> t,x
 	      | _ -> error "Recursive argument must be specified"
 	  end
       | Some wf_args ->
@@ -525,7 +525,7 @@ let register_mes fname rec_impls wf_mes_expr wf_rel_expr_opt wf_arg using_lemmas
 		(function
 		   | Constrexpr.CLocalAssum(l,k,t) ->
 		       List.exists
-			 (function (_,Name id) -> Id.equal id wf_args | _ -> false)
+                         (function (_,Name.Name id) -> Id.equal id wf_args | _ -> false)
 			 l
 		   | _ -> false
 		)
@@ -546,7 +546,7 @@ let register_mes fname rec_impls wf_mes_expr wf_rel_expr_opt wf_arg using_lemmas
 	  let fun_from_mes =
 	    let applied_mes =
 	      Constrexpr_ops.mkAppC(wf_mes_expr,[Constrexpr_ops.mkIdentC wf_arg])    in
-	    Constrexpr_ops.mkLambdaC ([(Loc.tag @@ Name wf_arg)],Constrexpr_ops.default_binder_kind,wf_arg_type,applied_mes)
+            Constrexpr_ops.mkLambdaC ([(Loc.tag @@ Name.Name wf_arg)],Constrexpr_ops.default_binder_kind,wf_arg_type,applied_mes)
 	  in
 	  let wf_rel_from_mes =
 	    Constrexpr_ops.mkAppC(Constrexpr_ops.mkRefC  ltof,[wf_arg_type;fun_from_mes])
@@ -557,7 +557,7 @@ let register_mes fname rec_impls wf_mes_expr wf_rel_expr_opt wf_arg using_lemmas
 	    let a = Names.Id.of_string "___a" in 
 	    let b = Names.Id.of_string "___b" in 
 	    Constrexpr_ops.mkLambdaC(
-	      [Loc.tag @@ Name a;Loc.tag @@ Name b],
+              [Loc.tag @@ Name.Name a;Loc.tag @@ Name.Name b],
 	      Constrexpr.Default Explicit,
 	      wf_arg_type,
 	      Constrexpr_ops.mkAppC(wf_rel_expr,

--- a/plugins/funind/indfun_common.ml
+++ b/plugins/funind/indfun_common.ml
@@ -16,11 +16,11 @@ let msgnl m =
 
 let fresh_id avoid s = Namegen.next_ident_away_in_goal (Id.of_string s) (Id.Set.of_list avoid)
 
-let fresh_name avoid s = Name (fresh_id avoid s)
+let fresh_name avoid s = Name.Name (fresh_id avoid s)
 
 let get_name avoid ?(default="H") = function
-  | Anonymous -> fresh_name avoid default
-  | Name n -> Name n
+  | Name.Anonymous -> fresh_name avoid default
+  | Name.Name n -> Name.Name n
 
 let array_get_start a =
   Array.init
@@ -28,7 +28,7 @@ let array_get_start a =
     (fun i -> a.(i))
 
 let id_of_name = function
-    Name id -> id
+    Name.Name id -> id
   | _ -> raise Not_found
 
 let locate  ref =

--- a/plugins/funind/invfun.ml
+++ b/plugins/funind/invfun.ml
@@ -119,8 +119,8 @@ let generate_type evd g_to_f f graph i =
   in
   (*i We need to name the vars [res] and [fv] i*)
   let filter = fun decl -> match RelDecl.get_name decl with
-			   | Name id -> Some id
-			   | Anonymous -> None
+                           | Name.Name id -> Some id
+                           | Name.Anonymous -> None
   in
   let named_ctxt = Id.Set.of_list (List.map_filter filter fun_ctxt) in
   let res_id = Namegen.next_ident_away_in_goal (Id.of_string "_res") named_ctxt in
@@ -147,12 +147,12 @@ let generate_type evd g_to_f f graph i =
     \[\forall (x_1:t_1)\ldots(x_n:t_n), let fv := f x_1\ldots x_n in, forall res,  \]
     i*)
   let pre_ctxt =
-    LocalAssum (Name res_id, lift 1 res_type) :: LocalDef (Name fv_id, mkApp (f,args_as_rels), res_type) :: fun_ctxt
+    LocalAssum (Name.Name res_id, lift 1 res_type) :: LocalDef (Name.Name fv_id, mkApp (f,args_as_rels), res_type) :: fun_ctxt
   in
   (*i and we can return the solution depending on which lemma type we are defining i*)
   if g_to_f
-  then LocalAssum (Anonymous,graph_applied)::pre_ctxt,(lift 1 res_eq_f_of_args),graph
-  else LocalAssum (Anonymous,res_eq_f_of_args)::pre_ctxt,(lift 1 graph_applied),graph
+  then LocalAssum (Name.Anonymous,graph_applied)::pre_ctxt,(lift 1 res_eq_f_of_args),graph
+  else LocalAssum (Name.Anonymous,res_eq_f_of_args)::pre_ctxt,(lift 1 graph_applied),graph
 
 
 (*
@@ -407,7 +407,7 @@ let prove_fun_correct evd funs_constr graphs_constr schemes lemmas_types_infos i
     tclTHENLIST
       [ 
 	observe_tac "principle" (Proofview.V82.of_tactic (assert_by
-	  (Name principle_id)
+          Name.(Name principle_id)
 	  princ_type
 	  (exact_check f_principle)));
 	observe_tac "intro args_names" (tclMAP (fun id -> Proofview.V82.of_tactic (Simple.intro id)) args_names);

--- a/plugins/ltac/coretactics.ml4
+++ b/plugins/ltac/coretactics.ml4
@@ -349,8 +349,8 @@ let initial_tacticals () =
   let varn n = Reference (ArgVar (None, idn n)) in
   let iter (s, t) = Tacenv.register_ltac false false (Id.of_string s) t in
   List.iter iter [
-    "first", TacFun ([Name (idn 0)], TacML (None, (initial_entry "first", [varn 0])));
-    "solve", TacFun ([Name (idn 0)], TacML (None, (initial_entry "solve", [varn 0])));
+    "first", TacFun ([Name.Name (idn 0)], TacML (None, (initial_entry "first", [varn 0])));
+    "solve", TacFun ([Name.Name (idn 0)], TacML (None, (initial_entry "solve", [varn 0])));
   ]
 
 let () = Mltop.declare_cache_obj initial_tacticals "ltac_plugin"

--- a/plugins/ltac/extratactics.ml4
+++ b/plugins/ltac/extratactics.ml4
@@ -662,7 +662,7 @@ let subst_var_with_hole occ tid t =
            else
 	     (incr locref;
               DAst.make ~loc:(Loc.make_loc (!locref,0)) @@
-	      GHole (Evar_kinds.QuestionMark(Evar_kinds.Define true,Anonymous),
+              GHole (Evar_kinds.QuestionMark(Evar_kinds.Define true,Name.Anonymous),
                      Misctypes.IntroAnonymous, None)))
         else x
     | _ -> map_glob_constr_left_to_right substrec x in
@@ -674,13 +674,13 @@ let subst_hole_with_term occ tc t =
   let locref = ref 0 in
   let occref = ref occ in
   let rec substrec c = match DAst.get c with
-    | GHole (Evar_kinds.QuestionMark(Evar_kinds.Define true,Anonymous),Misctypes.IntroAnonymous,s) ->
+    | GHole (Evar_kinds.QuestionMark(Evar_kinds.Define true,Name.Anonymous),Misctypes.IntroAnonymous,s) ->
         decr occref;
         if Int.equal !occref 0 then tc
         else
 	  (incr locref;
            DAst.make ~loc:(Loc.make_loc (!locref,0)) @@
-	   GHole (Evar_kinds.QuestionMark(Evar_kinds.Define true,Anonymous),Misctypes.IntroAnonymous,s))
+           GHole (Evar_kinds.QuestionMark(Evar_kinds.Define true,Name.Anonymous),Misctypes.IntroAnonymous,s))
     | _ -> map_glob_constr_left_to_right substrec c
   in
   substrec t

--- a/plugins/ltac/g_ltac.ml4
+++ b/plugins/ltac/g_ltac.ml4
@@ -226,11 +226,11 @@ GEXTEND Gram
   ;
   let_clause:
     [ [ (l,id) = identref; ":="; te = tactic_expr ->
-         ((l,Name id), arg_of_expr te)
-      | na = ["_" -> (Some !@loc,Anonymous)]; ":="; te = tactic_expr ->
+         ((l,Name.Name id), arg_of_expr te)
+      | na = ["_" -> (Some !@loc,Name.Anonymous)]; ":="; te = tactic_expr ->
          (na, arg_of_expr te)
       | (l,id) = identref; args = LIST1 input_fun; ":="; te = tactic_expr ->
-         ((l,Name id), arg_of_expr (TacFun(args,te))) ] ]
+         ((l,Name.Name id), arg_of_expr (TacFun(args,te))) ] ]
   ;
   match_pattern:
     [ [ IDENT "context";  oid = OPT Constr.ident;

--- a/plugins/ltac/g_tactic.ml4
+++ b/plugins/ltac/g_tactic.ml4
@@ -546,7 +546,7 @@ GEXTEND Gram
       | IDENT "pose"; b = constr; na = as_name ->
 	  TacAtom (Loc.tag ~loc:!@loc @@ TacLetTac (false,na,b,Locusops.nowhere,true,None))
       | IDENT "epose"; (id,b) = bindings_with_parameters ->
-	  TacAtom (Loc.tag ~loc:!@loc @@ TacLetTac (true,Names.Name id,b,Locusops.nowhere,true,None))
+          TacAtom (Loc.tag ~loc:!@loc @@ TacLetTac (true,Names.Name.Name id,b,Locusops.nowhere,true,None))
       | IDENT "epose"; b = constr; na = as_name ->
 	  TacAtom (Loc.tag ~loc:!@loc @@ TacLetTac (true,na,b,Locusops.nowhere,true,None))
       | IDENT "set"; (id,c) = bindings_with_parameters; p = clause_dft_concl ->
@@ -554,7 +554,7 @@ GEXTEND Gram
       | IDENT "set"; c = constr; na = as_name; p = clause_dft_concl ->
           TacAtom (Loc.tag ~loc:!@loc @@ TacLetTac (false,na,c,p,true,None))
       | IDENT "eset"; (id,c) = bindings_with_parameters; p = clause_dft_concl ->
-	  TacAtom (Loc.tag ~loc:!@loc @@ TacLetTac (true,Names.Name id,c,p,true,None))
+          TacAtom (Loc.tag ~loc:!@loc @@ TacLetTac (true,Names.Name.Name id,c,p,true,None))
       | IDENT "eset"; c = constr; na = as_name; p = clause_dft_concl ->
           TacAtom (Loc.tag ~loc:!@loc @@ TacLetTac (true,na,c,p,true,None))
       | IDENT "remember"; c = constr; na = as_name; e = eqn_ipat;

--- a/plugins/ltac/pptactic.ml
+++ b/plugins/ltac/pptactic.ml
@@ -403,15 +403,15 @@ let string_of_genarg_arg (ArgumentType arg) =
     | Some ipat -> pr_as_intro_pattern prc ipat
 
   let pr_as_name = function
-    | Anonymous -> mt ()
-    | Name id -> spc () ++ keyword "as" ++ spc () ++ pr_lident (Loc.tag id)
+    | Name.Anonymous -> mt ()
+    | Name.Name id -> spc () ++ keyword "as" ++ spc () ++ pr_lident (Loc.tag id)
 
   let pr_pose_as_style prc na c =
     spc() ++ prc c ++ pr_as_name na
 
   let pr_pose prc prlc na c = match na with
-    | Anonymous -> spc() ++ prc c
-    | Name id -> spc() ++ surround (pr_id id ++ str " :=" ++ spc() ++ prlc c)
+    | Name.Anonymous -> spc() ++ prc c
+    | Name.Name id -> spc() ++ surround (pr_id id ++ str " :=" ++ spc() ++ prlc c)
 
   let pr_assertion prc prdc _prlc ipat c = match ipat with
     (* Use this "optimisation" or use only the general case ?
@@ -692,10 +692,10 @@ let pr_goal_selector ~toplevel s =
         (nal,ty)::bll ->
           if n <= List.length nal then
             match List.chop (n-1) nal with
-                _, (_,Name id) :: _ -> id, (nal,ty)::bll
-              | bef, (loc,Anonymous) :: aft ->
+                _, (_,Name.Name id) :: _ -> id, (nal,ty)::bll
+              | bef, (loc,Name.Anonymous) :: aft ->
                 let id = next_ident_away (Id.of_string"y") avoid in
-                id, ((bef@(loc,Name id)::aft, ty)::bll)
+                id, ((bef@(loc,Name.Name id)::aft, ty)::bll)
               | _ -> assert false
           else
             let (id,bll') = set_nth_name avoid (n-List.length nal) bll in
@@ -705,7 +705,7 @@ let pr_goal_selector ~toplevel s =
         let names =
           List.fold_left
             (fun ln (nal,_) -> List.fold_left
-              (fun ln na -> match na with (_,Name id) -> Id.Set.add id ln | _ -> ln)
+              (fun ln na -> match na with (_,Name.Name id) -> Id.Set.add id ln | _ -> ln)
               ln nal)
             Id.Set.empty bll in
         let idarg,bll = set_nth_name names n bll in

--- a/plugins/ltac/rewrite.ml
+++ b/plugins/ltac/rewrite.ml
@@ -242,7 +242,7 @@ end) = struct
   let unfold_impl sigma t =
     match EConstr.kind sigma t with
     | App (arrow, [| a; b |])(*  when eq_constr arrow (Lazy.force impl) *) ->
-      mkProd (Anonymous, a, lift 1 b)
+      mkProd (Name.Anonymous, a, lift 1 b)
     | _ -> assert false
 
   let unfold_all sigma t =
@@ -268,7 +268,7 @@ end) = struct
 	(app_poly env evd arrow [| a; b |]), unfold_impl
 	(* (evd, mkProd (Anonymous, a, b)), (fun x -> x) *)
       else if bp then (* Dummy forall *)
-	(app_poly env evd coq_all [| a; mkLambda (Anonymous, a, lift 1 b) |]), unfold_forall
+        (app_poly env evd coq_all [| a; mkLambda (Name.Anonymous, a, lift 1 b) |]), unfold_forall
       else (* None in Prop, use arrow *)
 	(app_poly env evd arrow [| a; b |]), unfold_impl
 
@@ -469,8 +469,8 @@ let rec decompose_app_rel env evd t =
   | App (f, [|arg|]) ->
     let (f', argl, argr) = decompose_app_rel env evd arg in
     let ty = Typing.unsafe_type_of env evd argl in
-    let f'' = mkLambda (Name default_dependent_ident, ty,
-      mkLambda (Name (Id.of_string "y"), lift 1 ty,
+    let f'' = mkLambda (Name.Name default_dependent_ident, ty,
+      mkLambda (Name.Name (Id.of_string "y"), lift 1 ty,
         mkApp (lift 2 f, [| mkApp (lift 2 f', [| mkRel 2; mkRel 1 |]) |])))
     in (f'', argl, argr)
   | App (f, args) ->
@@ -900,7 +900,7 @@ let make_leibniz_proof env c ty r =
 	let prf =
 	  e_app_poly env evars coq_f_equal
 		[| r.rew_car; ty;
-		   mkLambda (Anonymous, r.rew_car, c);
+                   mkLambda (Name.Anonymous, r.rew_car, c);
 		   r.rew_from; r.rew_to; prf |]
 	in RewPrf (rel, prf)
     | RewCast k -> r.rew_prf
@@ -1509,7 +1509,7 @@ let cl_rewrite_clause_aux ?(abs=None) strat env avoid sigma concl is_hyp : resul
 	    | Some (t, ty) ->
               let t = Reductionops.nf_evar evars' t in
               let ty = Reductionops.nf_evar evars' ty in
-		mkApp (mkLambda (Name (Id.of_string "lemma"), ty, p), [| t |])
+                mkApp (mkLambda (Name.Name (Id.of_string "lemma"), ty, p), [| t |])
 	  in
 	  let proof = match is_hyp with
             | None -> term
@@ -1773,7 +1773,7 @@ let rec strategy_of_ast = function
 let mkappc s l = CAst.make @@ CAppExpl ((None,(Libnames.Ident (Loc.tag @@ Id.of_string s)),None),l)
 
 let declare_an_instance n s args =
-  (((Loc.tag @@ Name n),None), Explicit,
+  (((Loc.tag @@ Name.Name n),None), Explicit,
   CAst.make @@ CAppExpl ((None, Qualid (Loc.tag @@  qualid_of_string s),None),
 	   args))
 
@@ -2006,7 +2006,7 @@ let add_morphism glob binders m s n =
   let poly = Flags.is_universe_polymorphism () in
   let instance_id = add_suffix n "_Proper" in
   let instance =
-    (((Loc.tag @@ Name instance_id),None), Explicit,
+    (((Loc.tag @@ Name.Name instance_id),None), Explicit,
     CAst.make @@ CAppExpl (
 	     (None, Qualid (Loc.tag @@ Libnames.qualid_of_string "Coq.Classes.Morphisms.Proper"),None),
 	     [cHole; s; m]))

--- a/plugins/ltac/tacintern.ml
+++ b/plugins/ltac/tacintern.ml
@@ -65,8 +65,8 @@ let intern_ident s ist id =
   id
 
 let intern_name l ist = function
-  | Anonymous -> Anonymous
-  | Name id -> Name (intern_ident l ist id)
+  | Name.Anonymous -> Name.Anonymous
+  | Name.Name id -> Name.Name (intern_ident l ist id)
 
 let strict_check = ref false
 
@@ -443,8 +443,8 @@ let intern_constr_may_eval ist = function
   | ConstrTerm c -> ConstrTerm (intern_constr ist c)
 
 let name_cons accu = function
-| Anonymous -> accu
-| Name id -> Id.Set.add id accu
+| Name.Anonymous -> accu
+| Name.Name id -> Id.Set.add id accu
 
 let opt_cons accu = function
 | None -> accu
@@ -813,7 +813,7 @@ let notation_subst bindings tac =
   let fold id c accu =
     let loc = Glob_ops.loc_of_glob_constr (fst c) in
     let c = ConstrMayEval (ConstrTerm c) in
-    ((loc, Name id), c) :: accu
+    ((loc, Name.Name id), c) :: accu
   in
   let bindings = Id.Map.fold fold bindings [] in
   (** This is theoretically not correct due to potential variable capture, but

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -377,8 +377,8 @@ let interp_ident ist env sigma id =
 
 (* Interprets an optional identifier, bound or fresh *)
 let interp_name ist env sigma = function
-  | Anonymous -> Anonymous
-  | Name id -> Name (interp_ident ist env sigma id)
+  | Name.Anonymous -> Name.Anonymous
+  | Name.Name id -> Name.Name (interp_ident ist env sigma id)
 
 let interp_intro_pattern_var loc ist env sigma id =
   try try_interp_ltac_var (coerce_to_intro_pattern env sigma) ist (Some (env,sigma)) (loc,id)
@@ -719,8 +719,8 @@ let interp_closed_typed_pattern_with_occurrences ist env sigma (occs, a) =
 
 let interp_constr_with_occurrences_and_name_as_list =
   interp_constr_in_compound_list
-    (fun c -> ((AllOccurrences,c),Anonymous))
-    (function ((occs,c),Anonymous) when occs == AllOccurrences -> c
+    (fun c -> ((AllOccurrences,c),Name.Anonymous))
+    (function ((occs,c),Name.Anonymous) when occs == AllOccurrences -> c
       | _ -> raise Not_found)
     (fun ist env sigma (occ_c,na) ->
       let (sigma,c_interp) = interp_constr_with_occurrences ist env sigma occ_c in
@@ -1010,8 +1010,8 @@ let head_with_value (lvar,lval) =
     | ([],[]) -> (lacc,[],[])
     | (vr::tvr,ve::tve) ->
       (match vr with
-      |	Anonymous -> head_with_value_rec lacc (tvr,tve)
-      | Name v -> head_with_value_rec ((v,ve)::lacc) (tvr,tve))
+      |	Name.Anonymous -> head_with_value_rec lacc (tvr,tve)
+      | Name.Name v -> head_with_value_rec ((v,ve)::lacc) (tvr,tve))
     | (vr,[]) -> (lacc,vr,[])
     | ([],ve) -> (lacc,[],ve)
   in
@@ -2096,8 +2096,8 @@ let lift_constr_tac_to_ml_tac vars tac =
     let env = Proofview.Goal.env gl in
     let sigma = project gl in
     let map = function
-    | Anonymous -> None
-    | Name id ->
+    | Name.Anonymous -> None
+    | Name.Name id ->
       let c = Id.Map.find id ist.lfun in
       try Some (coerce_to_closed_constr env c)
       with CannotCoerceTo ty ->

--- a/plugins/ltac/tactic_debug.ml
+++ b/plugins/ltac/tactic_debug.ml
@@ -257,8 +257,8 @@ let db_pattern_rule debug num r =
 
 (* Prints the hypothesis pattern identifier if it exists *)
 let hyp_bound = function
-  | Anonymous -> str " (unbound)"
-  | Name id -> str " (bound to " ++ Id.print id ++ str ")"
+  | Name.Anonymous -> str " (unbound)"
+  | Name.Name id -> str " (bound to " ++ Id.print id ++ str ")"
 
 (* Prints a matched hypothesis *)
 let db_matched_hyp debug env sigma (id,_,c) ido =

--- a/plugins/ltac/tactic_matching.ml
+++ b/plugins/ltac/tactic_matching.ml
@@ -50,8 +50,8 @@ let id_map_try_add id x m =
 (** Adds a binding to a {!Id.Map.t} if the name is [Name id] *)
 let id_map_try_add_name id x m =
   match id with
-  | Name id -> Id.Map.add id x m
-  | Anonymous -> m
+  | Name.Name id -> Id.Map.add id x m
+  | Name.Anonymous -> m
 
 (** Takes the union of two {!Id.Map.t}. If there is conflict,
     the binding of the right-hand argument shadows that of the left-hand

--- a/plugins/ltac/tauto.ml
+++ b/plugins/ltac/tauto.ml
@@ -263,7 +263,7 @@ let with_flags flags _ ist =
 
 let register_tauto_tactic tac name0 args =
   let ids = List.map (fun id -> Id.of_string id) args in
-  let ids = List.map (fun id -> Name id) ids in
+  let ids = List.map (fun id -> Name.Name id) ids in
   let name = { mltac_plugin = tauto_plugin; mltac_tactic = name0; } in
   let entry = { mltac_name = name; mltac_index = 0 } in
   let () = Tacenv.register_ml_tactic name [| tac |] in

--- a/plugins/omega/coq_omega.ml
+++ b/plugins/omega/coq_omega.ml
@@ -462,8 +462,8 @@ let destructurate_prop sigma t =
     | Ind (isp,_), args ->
 	Kapp (Other (string_of_path (path_of_global (IndRef isp))),args)
     | Var id,[] -> Kvar id
-    | Prod (Anonymous,typ,body), [] -> Kimp(typ,body)
-    | Prod (Name _,_,_),[] -> CErrors.user_err Pp.(str "Omega: Not a quantifier-free goal")
+    | Prod (Name.Anonymous,typ,body), [] -> Kimp(typ,body)
+    | Prod (Name.Name _,_,_),[] -> CErrors.user_err Pp.(str "Omega: Not a quantifier-free goal")
     | _ -> Kufo
 
 let nf = Tacred.simpl
@@ -585,7 +585,7 @@ let occurrence sigma path (t : constr) =
 let abstract_path sigma typ path t =
   let term_occur = ref (mkRel 0) in
   let abstract = context sigma (fun i t -> term_occur:= t; mkRel i) path t in
-  mkLambda (Name (Id.of_string "x"), typ, abstract), !term_occur
+  mkLambda (Name.Name (Id.of_string "x"), typ, abstract), !term_occur
 
 let focused_simpl path =
   let open Tacmach.New in
@@ -665,10 +665,10 @@ let clever_rewrite_base_poly typ p result theorem =
   let t =
     applist
       (mkLambda
-	 (Name (Id.of_string "P"),
+         (Name.Name (Id.of_string "P"),
 	  mkArrow typ mkProp,
           mkLambda
-	    (Name (Id.of_string "H"),
+            (Name.Name (Id.of_string "H"),
 	     applist (mkRel 1,[result]),
 	     mkApp (Lazy.force coq_eq_ind_r,
 		       [| typ; result; mkRel 2; mkRel 1; occ; theorem |]))),
@@ -1331,7 +1331,7 @@ let replay_history tactic_normalisation =
             mkApp (Lazy.force coq_ex, [|
 		      Lazy.force coq_Z;
 		      mkLambda
-			(Name vid,
+                        (Name.Name vid,
 			 Lazy.force coq_Z,
 			 mk_eq (mkRel 1) eq1) |])
 	  in
@@ -1795,7 +1795,7 @@ let destructure_hyps =
               let hid = fresh_id Id.Set.empty (add_suffix i "_eqn") gl in
               let hty = mk_gen_eq typ (mkVar i) body in
               tclTHEN
-                (assert_by (Name hid) hty reflexivity)
+                (assert_by Name.(Name hid) hty reflexivity)
                 (loop (LocalAssum (hid, hty) :: lit))
            | _ -> loop lit
          with e when catchable_exception e -> loop lit

--- a/plugins/romega/const_omega.ml
+++ b/plugins/romega/const_omega.ml
@@ -40,7 +40,7 @@ let destructurate t =
   | Ind (isp,_), args ->
      Kapp (string_of_global (Globnames.IndRef isp), args)
   | Var id, [] -> Kvar(Names.Id.to_string id)
-  | Prod (Anonymous,typ,body), [] -> Kimp(typ,body)
+  | Prod (Name.Anonymous,typ,body), [] -> Kimp(typ,body)
   | _ -> Kufo
 
 exception DestConstApp

--- a/plugins/setoid_ring/newring.ml
+++ b/plugins/setoid_ring/newring.ml
@@ -129,7 +129,7 @@ let closed_term_ast l =
     mltac_index = 0;
   } in
   let l = List.map (fun gr -> ArgArg(Loc.tag gr)) l in
-  TacFun([Name(Id.of_string"t")],
+  TacFun([Name.Name(Id.of_string"t")],
   TacML(Loc.tag (tacname,
   [TacGeneric (Genarg.in_gen (Genarg.glbwit Stdarg.wit_constr) (DAst.make @@ GVar(Id.of_string"t"),None));
    TacGeneric (Genarg.in_gen (Genarg.glbwit (Genarg.wit_list Stdarg.wit_ref)) l)])))
@@ -215,7 +215,7 @@ let exec_tactic env evd n f args =
   let lid = List.init n (fun i -> Id.of_string("x"^string_of_int i)) in
   let n = Genarg.in_gen (Genarg.glbwit Stdarg.wit_int) n in
   let get_res = TacML (Loc.tag (get_res, [TacGeneric n])) in
-  let getter = Tacexp (TacFun (List.map (fun n -> Name n) lid, get_res)) in
+  let getter = Tacexp (TacFun (List.map (fun n -> Name.Name n) lid, get_res)) in
   (** Evaluate the whole result *)
   let gl = dummy_goal env evd in
   let gls = Proofview.V82.of_tactic (Tacinterp.eval_tactic_ist ist (ltac_call f (args@[getter]))) gl in
@@ -742,8 +742,8 @@ let ltac_ring_structure e =
   let pow_tac = tacarg e.ring_pow_tac in
   let lemma1 = carg e.ring_lemma1 in
   let lemma2 = carg e.ring_lemma2 in
-  let pretac = tacarg (TacFun([Anonymous],e.ring_pre_tac)) in
-  let posttac = tacarg (TacFun([Anonymous],e.ring_post_tac)) in
+  let pretac = tacarg (TacFun([Name.Anonymous],e.ring_pre_tac)) in
+  let posttac = tacarg (TacFun([Name.Anonymous],e.ring_post_tac)) in
   [req;sth;ext;morph;th;cst_tac;pow_tac;
    lemma1;lemma2;pretac;posttac]
 
@@ -1028,8 +1028,8 @@ let ltac_field_structure e =
   let field_simpl_eq_ok = carg e.field_simpl_eq_ok in
   let field_simpl_eq_in_ok = carg e.field_simpl_eq_in_ok in
   let cond_ok = carg e.field_cond in
-  let pretac = tacarg (TacFun([Anonymous],e.field_pre_tac)) in
-  let posttac = tacarg (TacFun([Anonymous],e.field_post_tac)) in
+  let pretac = tacarg (TacFun([Name.Anonymous],e.field_pre_tac)) in
+  let posttac = tacarg (TacFun([Name.Anonymous],e.field_post_tac)) in
   [req;cst_tac;pow_tac;field_ok;field_simpl_ok;field_simpl_eq_ok;
    field_simpl_eq_in_ok;cond_ok;pretac;posttac]
 

--- a/plugins/ssr/ssrelim.ml
+++ b/plugins/ssr/ssrelim.ml
@@ -390,7 +390,7 @@ let injecteq_id = mk_internal_id "injection equation"
 let revtoptac n0 gl =
   let n = pf_nb_prod gl - n0 in
   let dc, cl = EConstr.decompose_prod_n_assum (project gl) n (pf_concl gl) in
-  let dc' = dc @ [Context.Rel.Declaration.LocalAssum(Name rev_id, EConstr.it_mkProd_or_LetIn cl (List.rev dc))] in
+  let dc' = dc @ [Context.Rel.Declaration.LocalAssum(Name.Name rev_id, EConstr.it_mkProd_or_LetIn cl (List.rev dc))] in
   let f = EConstr.it_mkLambda_or_LetIn (mkEtaApp (EConstr.mkRel (n + 1)) (-n) 1) dc' in
   refine (EConstr.mkApp (f, [|Evarutil.mk_new_meta ()|])) gl
 
@@ -413,7 +413,7 @@ let injectl2rtac sigma c = match EConstr.kind sigma c with
 | Var id -> injectidl2rtac id (EConstr.mkVar id, NoBindings)
 | _ ->
   let id = injecteq_id in
-  let xhavetac id c = Proofview.V82.of_tactic (Tactics.pose_proof (Name id) c) in
+  let xhavetac id c = Proofview.V82.of_tactic (Tactics.pose_proof Name.(Name id) c) in
   Tacticals.tclTHENLIST [xhavetac id c; injectidl2rtac id (EConstr.mkVar id, NoBindings); Proofview.V82.of_tactic (Tactics.clear [id])]
 
 let is_injection_case c gl =
@@ -430,7 +430,7 @@ let perform_injection c gl =
     CErrors.user_err (Pp.str "can't decompose a quantified equality") else
   let cl = pf_concl gl in let n = List.length dc in
   let c_eq = mkEtaApp c n 2 in
-  let cl1 = EConstr.mkLambda EConstr.(Anonymous, mkArrow eqt cl, mkApp (mkRel 1, [|c_eq|])) in
+  let cl1 = EConstr.mkLambda EConstr.(Name.Anonymous, mkArrow eqt cl, mkApp (mkRel 1, [|c_eq|])) in
   let id = injecteq_id in
   let id_with_ebind = (EConstr.mkVar id, NoBindings) in
   let injtac = Tacticals.tclTHEN (introid id) (injectidl2rtac id id_with_ebind) in 

--- a/plugins/ssr/ssrfwd.ml
+++ b/plugins/ssr/ssrfwd.ml
@@ -24,7 +24,7 @@ module RelDecl = Context.Rel.Declaration
 (** Defined identifier *)
 
 
-let settac id c = Tactics.letin_tac None (Name id) c None
+let settac id c = Tactics.letin_tac None Name.(Name id) c None
 let posetac id cl = Proofview.V82.of_tactic (settac id cl Locusops.nowhere)
 
 let ssrposetac ist (id, (_, t)) gl =
@@ -46,7 +46,7 @@ let ssrsettac ist id ((_, (pat, pty)), (_, occ)) gl =
   let c, (gl, cty) =  match EConstr.kind sigma c with
   | Cast(t, DEFAULTcast, ty) -> t, (gl, ty)
   | _ -> c, pfe_type_of gl c in
-  let cl' = EConstr.mkLetIn (Name id, c, cty, cl) in
+  let cl' = EConstr.mkLetIn (Name.Name id, c, cty, cl) in
   let gl = pf_merge_uc ucst gl in
   Tacticals.tclTHEN (Proofview.V82.of_tactic (convert_concl cl')) (introid id) gl
 
@@ -355,10 +355,10 @@ let wlogtac ist (((clr0, pats),_),_) (gens, ((_, ct))) hint suff ghave gl =
     let fake_gl = {Evd.it = k; Evd.sigma = sigma} in
     let _, ct, _, uc = pf_interp_ty ist fake_gl ct in
     let rec var2rel c g s = match EConstr.kind sigma c, g with
-      | Prod(Anonymous,_,c), [] -> EConstr.mkProd(Anonymous, EConstr.Vars.subst_vars s ct, c)
+      | Prod(Name.Anonymous,_,c), [] -> EConstr.mkProd(Name.Anonymous, EConstr.Vars.subst_vars s ct, c)
       | Sort _, [] -> EConstr.Vars.subst_vars s ct
-      | LetIn(Name id as n,b,ty,c), _::g -> EConstr.mkLetIn (n,b,ty,var2rel c g (id::s))
-      | Prod(Name id as n,ty,c), _::g -> EConstr.mkProd (n,ty,var2rel c g (id::s))
+      | LetIn(Name.Name id as n,b,ty,c), _::g -> EConstr.mkLetIn (n,b,ty,var2rel c g (id::s))
+      | Prod(Name.Name id as n,ty,c), _::g -> EConstr.mkProd (n,ty,var2rel c g (id::s))
       | _ -> CErrors.anomaly(str"SSR: wlog: var2rel: " ++ pr_econstr_env env sigma c) in
     let c = var2rel c gens [] in
     let rec pired c = function

--- a/plugins/ssr/ssripats.ml
+++ b/plugins/ssr/ssripats.ml
@@ -83,12 +83,12 @@ let ssrmkabs id gl =
       let (sigma, m) = Evarutil.new_evar env sigma abstract_ty in
       (sigma, (m, abstract_ty)) in
     let sigma, kont =
-      let rd = RelDecl.LocalAssum (Name id, abstract_ty) in
+      let rd = RelDecl.LocalAssum (Name.Name id, abstract_ty) in
       let (sigma, ev) = Evarutil.new_evar (EConstr.push_rel rd env) sigma concl in
       (sigma, ev)
     in
 (*    pp(lazy(pr_econstr concl)); *)
-    let term = EConstr.(mkApp (mkLambda(Name id,abstract_ty,kont) ,[|abstract_proof|])) in
+    let term = EConstr.(mkApp (mkLambda(Name.Name id,abstract_ty,kont) ,[|abstract_proof|])) in
     let sigma, _ = Typing.type_of env sigma term in
     (sigma, term)
   end in
@@ -131,7 +131,7 @@ let delayed_clear force rest clr gl =
 let with_defective maintac deps clr ist gl =
   let top_id =
     match EConstr.kind_of_type (project gl) (pf_concl gl) with
-    | ProdType (Name id, _, _)
+    | ProdType (Name.Name id, _, _)
       when has_discharged_tag (Id.to_string id) -> id
     | _ -> top_id in
   let top_gen = mkclr clr, cpattern_of_id top_id in
@@ -141,7 +141,7 @@ let with_defective_a maintac deps clr ist gl =
   let sigma = sig_sig gl in
   let top_id =
     match EConstr.kind_of_type sigma (without_ctx pf_concl gl) with
-    | ProdType (Name id, _, _)
+    | ProdType (Name.Name id, _, _)
       when has_discharged_tag (Id.to_string id) -> id
     | _ -> top_id in
   let top_gen = mkclr clr, cpattern_of_id top_id in
@@ -310,7 +310,7 @@ let elim_intro_tac ipats ?ist what eqid ssrelim is_rec clr gl =
            let gl, case_ty = pfe_type_of gl case in 
            let refl = EConstr.mkApp (eq, [|EConstr.Vars.lift 1 case_ty; EConstr.mkRel 1; EConstr.Vars.lift 1 case|]) in
            let new_concl = fire_subst gl
-                                      EConstr.(mkProd (Name (name gl), case_ty, mkArrow refl (Vars.lift 2 concl))) in 
+                                      EConstr.(mkProd (Name.Name (name gl), case_ty, mkArrow refl (Vars.lift 2 concl))) in
            let erefl, gl = mkRefl case_ty case gl in
            let erefl = fire_subst gl erefl in
            apply_type new_concl [case;erefl] gl in

--- a/plugins/ssr/ssrparser.ml4
+++ b/plugins/ssr/ssrparser.ml4
@@ -118,7 +118,7 @@ let accept_before_syms_or_ids syms ids strm =
 
 open Ssrast
 let pr_id = Ppconstr.pr_id
-let pr_name = function Name id -> pr_id id | Anonymous -> str "_"
+let pr_name = function Name.Name id -> pr_id id | Name.Anonymous -> str "_"
 let pr_spc () = str " "
 let pr_bar () = Pp.cut() ++ str "|"
 let pr_list = prlist_with_sep
@@ -1037,7 +1037,7 @@ let rec format_constr_expr h0 c0 = let open CAst in match h0, c0 with
   | BFrec (has_str, has_cast) :: h, 
     { v = CFix ( _, [_, (Some locn, CStructRec), bl, t, c]) } ->
     let bs = format_local_binders h bl in
-    let bstr = if has_str then [Bstruct (Name (snd locn))] else [] in
+    let bstr = if has_str then [Bstruct (Name.Name (snd locn))] else [] in
     bs @ bstr @ (if has_cast then [Bcast t] else []), c 
   | BFrec (_, has_cast) :: h, { v = CCoFix ( _, [_, bl, t, c]) } ->
     format_local_binders h bl @ (if has_cast then [Bcast t] else []), c
@@ -1156,8 +1156,8 @@ ARGUMENT EXTEND ssrbvar TYPED AS constr PRINTED BY pr_ssrbvar
 END
 
 let bvar_lname = let open CAst in function
-  | { v = CRef (Ident (loc, id), _) } -> Loc.tag ?loc @@ Name id
-  | { loc = loc } -> Loc.tag ?loc Anonymous
+  | { v = CRef (Ident (loc, id), _) } -> Loc.tag ?loc @@ Name.Name id
+  | { loc = loc } -> Loc.tag ?loc Name.Anonymous
 
 let pr_ssrbinder prc _ _ (_, c) = prc c
 
@@ -1191,7 +1191,7 @@ GEXTEND Gram
   [  ["of" | "&"]; c = operconstr LEVEL "99" ->
      let loc = !@loc in
      (FwdPose, [BFvar]),
-     CAst.make ~loc @@ CLambdaN ([CLocalAssum ([Loc.tag ~loc Anonymous],Default Explicit,c)],mkCHole (Some loc)) ]
+     CAst.make ~loc @@ CLambdaN ([CLocalAssum ([Loc.tag ~loc Name.Anonymous],Default Explicit,c)],mkCHole (Some loc)) ]
   ];
 END
 
@@ -1265,8 +1265,8 @@ ARGUMENT EXTEND ssrfixfwd TYPED AS ident * ssrfwd PRINTED BY pr_ssrfixfwd
       let lb = fix_binders bs in
       let has_struct, i =
         let rec loop = function
-          (l', Name id') :: _ when Option.equal Id.equal sid (Some id') -> true, (l', id')
-          | [l', Name id'] when sid = None -> false, (l', id')
+          (l', Name.Name id') :: _ when Option.equal Id.equal sid (Some id') -> true, (l', id')
+          | [l', Name.Name id'] when sid = None -> false, (l', id')
           | _ :: bn -> loop bn
           | [] -> CErrors.user_err (Pp.str "Bad structural argument") in
         loop (names_of_local_assums lb) in
@@ -1332,9 +1332,9 @@ let intro_id_to_binder = List.map (function
 let binder_to_intro_id = CAst.(List.map (function
   | (FwdPose, [BFvar]), { v = CLambdaN ([CLocalAssum(ids,_,_)],_) }
   | (FwdPose, [BFdecl _]), { v = CLambdaN ([CLocalAssum(ids,_,_)],_) } ->
-      List.map (function (_, Name id) -> IPatId id | _ -> IPatAnon One) ids
-  | (FwdPose, [BFdef]), { v = CLetIn ((_,Name id),_,_,_) } -> [IPatId id]
-  | (FwdPose, [BFdef]), { v = CLetIn ((_,Anonymous),_,_,_) } -> [IPatAnon One]
+      List.map (function (_, Name.Name id) -> IPatId id | _ -> IPatAnon One) ids
+  | (FwdPose, [BFdef]), { v = CLetIn ((_,Name.Name id),_,_,_) } -> [IPatId id]
+  | (FwdPose, [BFdef]), { v = CLetIn ((_,Name.Anonymous),_,_,_) } -> [IPatAnon One]
   | _ -> anomaly "ssrbinder is not a binder"))
 
 let pr_ssrhavefwdwbinders _ _ prt (tr,((hpats, (fwd, hint)))) =

--- a/plugins/ssr/ssrtacticals.ml
+++ b/plugins/ssr/ssrtacticals.ml
@@ -81,7 +81,7 @@ let pf_clauseids gl gens clseq =
 
 let hidden_clseq = function InHyps | InHypsSeq | InAllHyps -> true | _ -> false
 
-let settac id c = Tactics.letin_tac None (Name id) c None
+let settac id c = Tactics.letin_tac None Name.(Name id) c None
 let posetac id cl = Proofview.V82.of_tactic (settac id cl nowhere)
 
 let hidetacs clseq idhide cl0 =
@@ -96,16 +96,16 @@ let endclausestac id_map clseq gl_id cl0 gl =
   let hide_goal = hidden_clseq clseq in
   let c_hidden = hide_goal && EConstr.eq_constr (project gl) c (EConstr.mkVar gl_id) in
   let rec fits forced = function
-  | (id, _) :: ids, decl :: dc' when RelDecl.get_name decl = Name id ->
+  | (id, _) :: ids, decl :: dc' when RelDecl.get_name decl = Name.Name id ->
     fits true (ids, dc')
   | ids, dc' ->
     forced && ids = [] && (not hide_goal || dc' = [] && c_hidden) in
   let rec unmark c = match EConstr.kind (project gl) c with
   | Term.Var id when hidden_clseq clseq && id = gl_id -> cl0
-  | Term.Prod (Name id, t, c') when List.mem_assoc id id_map ->
-    EConstr.mkProd (Name (orig_id id), unmark t, unmark c')
-  | Term.LetIn (Name id, v, t, c') when List.mem_assoc id id_map ->
-    EConstr.mkLetIn (Name (orig_id id), unmark v, unmark t, unmark c')
+  | Term.Prod (Name.Name id, t, c') when List.mem_assoc id id_map ->
+    EConstr.mkProd (Name.Name (orig_id id), unmark t, unmark c')
+  | Term.LetIn (Name.Name id, v, t, c') when List.mem_assoc id id_map ->
+    EConstr.mkLetIn (Name.Name (orig_id id), unmark v, unmark t, unmark c')
   | _ -> EConstr.map (project gl) unmark c in
   let utac hyp =
     Proofview.V82.of_tactic 

--- a/plugins/ssr/ssrvernac.ml4
+++ b/plugins/ssr/ssrvernac.ml4
@@ -118,7 +118,7 @@ GEXTEND Gram
   GLOBAL: closed_binder;
   closed_binder: [
     [ ["of" | "&"]; c = operconstr LEVEL "99" ->
-      [CLocalAssum ([Loc.tag ~loc:!@loc Anonymous], Default Explicit, c)]
+      [CLocalAssum ([Loc.tag ~loc:!@loc Name.Anonymous], Default Explicit, c)]
   ] ];
 END
 (* }}} *)
@@ -553,7 +553,7 @@ GEXTEND Gram
           let s = coerce_reference_to_id qid in
     Vernacexpr.VernacDefinition
       ((Decl_kinds.NoDischarge,Decl_kinds.CanonicalStructure),
-          ((Loc.tag (Name s)),None), d)
+          ((Loc.tag (Name.Name s)),None), d)
   ]];
 END
 

--- a/pretyping/arguments_renaming.ml
+++ b/pretyping/arguments_renaming.ml
@@ -70,7 +70,7 @@ let arguments_names r = Refmap.find r !name_table
 
 let rec rename_prod c = function 
   | [] -> c
-  | (Name _ as n) :: tl -> 
+  | (Name.Name _ as n) :: tl ->
       (match kind_of_type c with
       | ProdType (_, s, t) -> mkProd (n, s, rename_prod t tl)
       | _ -> c)

--- a/pretyping/cases.ml
+++ b/pretyping/cases.ml
@@ -12,6 +12,7 @@ open Pp
 open CErrors
 open Util
 open Names
+open Names.Name
 open Nameops
 open Constr
 open Termops

--- a/pretyping/coercion.ml
+++ b/pretyping/coercion.ml
@@ -77,8 +77,8 @@ let apply_pattern_coercion ?loc pat p =
   List.fold_left
     (fun pat (co,n) ->
        let f i =
-         if i<n then (DAst.make ?loc @@ Glob_term.PatVar Anonymous) else pat in
-        DAst.make ?loc @@ Glob_term.PatCstr (co, List.init (n+1) f, Anonymous))
+         if i<n then (DAst.make ?loc @@ Glob_term.PatVar Name.Anonymous) else pat in
+        DAst.make ?loc @@ Glob_term.PatCstr (co, List.init (n+1) f, Name.Anonymous))
     pat p
 
 (* raise Not_found if no coercion found *)
@@ -205,7 +205,7 @@ and coerce ?loc env evdref (x : EConstr.constr) (y : EConstr.constr)
 	| _ -> subco ())
       | Prod (name, a, b), Prod (name', a', b') ->
 	  let name' = 
-	    Name (Namegen.next_ident_away Namegen.default_dependent_ident (Termops.vars_of_env env))
+            Name.Name (Namegen.next_ident_away Namegen.default_dependent_ident (Termops.vars_of_env env))
 	  in
 	  let env' = push_rel (LocalAssum (name', a')) env in
 	  let c1 = coerce_unify env' (lift 1 a') (lift 1 a) in
@@ -255,7 +255,7 @@ and coerce ?loc env evdref (x : EConstr.constr) (y : EConstr.constr)
 		       | _ -> raise NoSubtacCoercion
 		     in
 		     let (pb, b), (pb', b') = remove_head a pb, remove_head a' pb' in
-		     let env' = push_rel (LocalAssum (Name Namegen.default_dependent_ident, a)) env in
+                     let env' = push_rel (LocalAssum (Name.Name Namegen.default_dependent_ident, a)) env in
 		     let c2 = coerce_unify env' b b' in
 		       match c1, c2 with
 		       | None, None -> None
@@ -324,7 +324,7 @@ and coerce ?loc env evdref (x : EConstr.constr) (y : EConstr.constr)
 	    Some
 	      (fun x ->
 		 let cx = app_opt env evdref c x in
-		 let evar = make_existential ?loc Anonymous env evdref (mkApp (p, [| cx |]))
+                 let evar = make_existential ?loc Name.Anonymous env evdref (mkApp (p, [| cx |]))
 		 in
 		   (papp evdref sig_intro [| u; p; cx; evar |]))
 	| None ->
@@ -481,7 +481,7 @@ let rec inh_conv_coerce_to_fail ?loc env evd rigidonly v t c1 =
           (* Note: we retype the term because template polymorphism may have *)
           (* weakened its type *)
 	  let name = match name with
-	    | Anonymous -> Name Namegen.default_dependent_ident
+            | Name.Anonymous -> Name.Name Namegen.default_dependent_ident
 	    | _ -> name in
 	  let open Context.Rel.Declaration in
 	  let env1 = push_rel (LocalAssum (name,u1)) env in

--- a/pretyping/constr_matching.ml
+++ b/pretyping/constr_matching.ml
@@ -69,7 +69,7 @@ let constrain sigma n (ids, m) (names, terms as subst) =
 
 let add_binders na1 na2 binding_vars (names, terms as subst) =
   match na1, na2 with
-  | Name id1, Name id2 when Id.Set.mem id1 binding_vars ->
+  | Name.Name id1, Name.Name id2 when Id.Set.mem id1 binding_vars ->
     if Id.Map.mem id1 names then
       let () = Glob_ops.warn_variable_collision id1 in
       (names, terms)
@@ -90,7 +90,7 @@ let rec build_lambda sigma vars ctx m = match vars with
   let (na, t, suf) = match suf with
   | [] -> assert false
   | (_, id, t) :: suf ->
-     (Name id, t, suf)
+     (Name.Name id, t, suf)
   in
   (** Check that the abstraction is legal by generating a transitive closure of
       its dependencies. *)
@@ -153,10 +153,10 @@ let rec extract_bound_aux k accu frels ctx = match ctx with
 | (na, _, _) :: ctx ->
   if Int.Set.mem k frels then
     begin match na with
-    | Name id ->
+    | Name.Name id ->
       let () = if Id.Set.mem id accu then raise PatternMatchingFailure in
       extract_bound_aux (k + 1) (Id.Set.add id accu) frels ctx
-    | Anonymous -> raise PatternMatchingFailure
+    | Name.Anonymous -> raise PatternMatchingFailure
     end
   else extract_bound_aux (k + 1) accu frels ctx
 
@@ -166,7 +166,7 @@ let extract_bound_vars frels ctx =
 let dummy_constr = EConstr.mkProp
 
 let make_renaming ids = function
-| (Name id, _, _) ->
+| (Name.Name id, _, _) ->
   begin
     try EConstr.mkRel (List.index Id.equal id ids)
     with Not_found -> dummy_constr
@@ -175,8 +175,8 @@ let make_renaming ids = function
 
 let push_binder na1 na2 t ctx =
   let id2 = match na2 with
-  | Name id2 -> id2
-  | Anonymous ->
+  | Name.Name id2 -> id2
+  | Name.Anonymous ->
      let avoid = Id.Set.of_list (List.map pi2 ctx) in
      Namegen.next_ident_away Namegen.default_non_dependent_ident avoid in
   (na1, id2, t) :: ctx
@@ -330,7 +330,7 @@ let matches_core env sigma allow_bound_rels
 	  let n = Context.Rel.length ctx_b2 in
           let n' = Context.Rel.length ctx_b2' in
 	  if Vars.noccur_between sigma 1 n b2 && Vars.noccur_between sigma 1 n' b2' then
-            let f l (LocalAssum (na,t) | LocalDef (na,_,t)) = push_binder Anonymous na t l in
+            let f l (LocalAssum (na,t) | LocalDef (na,_,t)) = push_binder Name.Anonymous na t l in
 	    let ctx_br = List.fold_left f ctx ctx_b2 in
 	    let ctx_br' = List.fold_left f ctx ctx_b2' in
 	    let b1 = lift_pattern n b1 and b1' = lift_pattern n' b1' in

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -54,8 +54,8 @@ let impossible_default_case () =
 let coq_unit_judge =
   let open Environ in
   let make_judge c t = make_judge (EConstr.of_constr c) (EConstr.of_constr t) in
-  let na1 = Name (Id.of_string "A") in
-  let na2 = Name (Id.of_string "H") in
+  let na1 = Name.Name (Id.of_string "A") in
+  let na2 = Name.Name (Id.of_string "H") in
   fun () ->
     match impossible_default_case () with
     | Some (id, type_of_id, ctx) ->

--- a/pretyping/evardefine.ml
+++ b/pretyping/evardefine.ml
@@ -95,7 +95,7 @@ let define_pure_evar_as_product evd evk =
 	let evd3 = Evd.set_leq_sort evenv evd3 (Type prods) (ESorts.kind evd1 s) in
 	  evd3, rng
   in
-  let prod = mkProd (Name id, dom, subst_var id rng) in
+  let prod = mkProd (Name.Name id, dom, subst_var id rng) in
   let evd3 = Evd.define evk (EConstr.Unsafe.to_constr prod) evd2 in
     evd3,prod
 
@@ -135,7 +135,7 @@ let define_pure_evar_as_lambda env evd evk =
   let filter = Filter.extend 1 (evar_filter evi) in
   let src = evar_source evk evd1 in
   let evd2,body = new_evar newenv evd1 ~src (subst1 (mkVar id) rng) ~filter in
-  let lam = mkLambda (Name id, dom, subst_var id body) in
+  let lam = mkLambda (Name.Name id, dom, subst_var id body) in
   Evd.define evk (EConstr.Unsafe.to_constr lam) evd2, lam
 
 let define_evar_as_lambda env evd (evk,args) =
@@ -179,14 +179,14 @@ let split_tycon ?loc env evd tycon =
 	| Evar ev (* ev is undefined because of whd_all *) ->
 	    let (evd',prod) = define_evar_as_product evd ev in
 	    let (_,dom,rng) = destProd evd prod in
-	      evd',(Anonymous, dom, rng)
+              evd',(Name.Anonymous, dom, rng)
 	| App (c,args) when isEvar evd c ->
 	    let (evd',lam) = define_evar_as_lambda env evd (destEvar evd c) in
 	    real_split evd' (mkApp (lam,args))
 	| _ -> error_not_product ?loc env evd c
   in
     match tycon with
-      | None -> evd,(Anonymous,None,None)
+      | None -> evd,(Name.Anonymous,None,None)
       | Some c ->
 	  let evd', (n, dom, rng) = real_split evd c in
 	    evd', (n, mk_tycon dom, mk_tycon rng)

--- a/pretyping/indrec.ml
+++ b/pretyping/indrec.ml
@@ -53,7 +53,7 @@ let it_mkProd_or_LetIn_name env b l = List.fold_left (fun c d -> mkProd_or_LetIn
 let it_mkLambda_or_LetIn_name env b l = List.fold_left (fun c d -> mkLambda_or_LetIn_name env d c) b l
 
 let make_prod_dep dep env = if dep then mkProd_name env else mkProd
-let mkLambda_string s t c = mkLambda (Name (Id.of_string s), t, c)
+let mkLambda_string s t c = mkLambda (Name.Name (Id.of_string s), t, c)
 
 
 (*******************************************)
@@ -99,7 +99,7 @@ let mis_make_case_com dep env sigma (ind, u as pind) (mib,mip as specif) kind =
       let indf' = lift_inductive_family nbprod indf in
       let arsign,_ = get_arity env indf' in
       let depind = build_dependent_inductive env indf' in
-      let deparsign = LocalAssum (Anonymous,depind)::arsign in
+      let deparsign = LocalAssum (Name.Anonymous,depind)::arsign in
 
       let ci = make_case_info env (fst pind) RegularStyle in
       let pbody =
@@ -110,7 +110,7 @@ let mis_make_case_com dep env sigma (ind, u as pind) (mib,mip as specif) kind =
       let p =
 	it_mkLambda_or_LetIn_name env'
 	  ((if dep then mkLambda_name env' else mkLambda)
-	   (Anonymous,depind,pbody))
+           (Name.Anonymous,depind,pbody))
           arsign
       in
       let obj = 
@@ -132,7 +132,7 @@ let mis_make_case_com dep env sigma (ind, u as pind) (mib,mip as specif) kind =
       let cs = lift_constructor (k+1) constrs.(k) in
       let t = build_branch_type env sigma dep (mkRel (k+1)) cs in
       mkLambda_string "f" t
-	(add_branch (push_rel (LocalAssum (Anonymous, t)) env) (k+1))
+        (add_branch (push_rel (LocalAssum (Name.Anonymous, t)) env) (k+1))
   in
   let (sigma, s) = Evd.fresh_sort_in_family ~rigid:Evd.univ_flexible_alg env sigma kind in
   let typP = make_arity env' sigma dep indf s in
@@ -140,7 +140,7 @@ let mis_make_case_com dep env sigma (ind, u as pind) (mib,mip as specif) kind =
   let c = 
     it_mkLambda_or_LetIn_name env
     (mkLambda_string "P" typP
-     (add_branch (push_rel (LocalAssum (Anonymous,typP)) env') 0)) lnamespar
+     (add_branch (push_rel (LocalAssum (Name.Anonymous,typP)) env') 0)) lnamespar
   in
   (sigma, c)
 
@@ -218,7 +218,7 @@ let type_rec_branch is_rec dep env sigma (vargs,depPvect,decP) tyi cs recargs =
                    (n,t,
 		    mkArrow t_0
 		      (process_constr
-			(push_rel (LocalAssum (Anonymous,t_0)) env')
+                        (push_rel (LocalAssum (Name.Anonymous,t_0)) env')
 			 (i+2) (lift 1 c_0) rest (nhyps-1) (i::li))))
       | LetIn (n,b,t,c_0) ->
 	  mkLetIn (n,b,t,
@@ -341,7 +341,7 @@ let mis_make_indrec env sigma listdepkind mib u =
 
 	    let arsign,_ = get_arity env indf in
 	    let depind = build_dependent_inductive env indf in
-	    let deparsign = LocalAssum (Anonymous,depind)::arsign in
+            let deparsign = LocalAssum (Name.Anonymous,depind)::arsign in
 
 	    let nonrecpar = Context.Rel.length lnonparrec in
 	    let larsign = Context.Rel.length deparsign in
@@ -376,7 +376,7 @@ let mis_make_indrec env sigma listdepkind mib u =
 
 	    let depind' = build_dependent_inductive env indf' in
 	    let arsign',_ = get_arity env indf' in
-	    let deparsign' = LocalAssum (Anonymous,depind')::arsign' in
+            let deparsign' = LocalAssum (Name.Anonymous,depind')::arsign' in
 
 	    let pargs =
 	      let nrpar = Context.Rel.to_extended_list mkRel (2*ndepar) lnonparrec
@@ -393,7 +393,7 @@ let mis_make_indrec env sigma listdepkind mib u =
 	      let pred =
 		it_mkLambda_or_LetIn_name env
 		  ((if dep then mkLambda_name env else mkLambda)
-		      (Anonymous,depind',concl))
+                      (Name.Anonymous,depind',concl))
 		  arsign'
 	      in
 	      let obj =
@@ -422,7 +422,7 @@ let mis_make_indrec env sigma listdepkind mib u =
 	    let fixn = Array.of_list (List.rev ln) in
             let fixtyi = Array.of_list (List.rev ltyp) in
             let fixdef = Array.of_list (List.rev ldef) in
-            let names = Array.make nrec (Name(Id.of_string "F")) in
+            let names = Array.make nrec Name.(Name(Id.of_string "F")) in
 	      mkFix ((fixn,p),(names,fixtyi,fixdef))
       in
 	mrec 0 [] [] []
@@ -444,7 +444,7 @@ let mis_make_indrec env sigma listdepkind mib u =
                   true dep env !evdref (vargs,depPvec,i+j) tyi cs recarg
 	      in
 		mkLambda_string "f" p_0
-		  (onerec (push_rel (LocalAssum (Anonymous,p_0)) env) (j+1))
+                  (onerec (push_rel (LocalAssum (Name.Anonymous,p_0)) env) (j+1))
 	  in onerec env 0
       | [] ->
 	  makefix i listdepkind
@@ -459,7 +459,7 @@ let mis_make_indrec env sigma listdepkind mib u =
 	  let typP = make_arity env !evdref dep indf s in
 	  let typP = EConstr.Unsafe.to_constr typP in
 	    mkLambda_string "P" typP
-	      (put_arity (push_rel (LocalAssum (Anonymous,typP)) env) (i+1) rest)
+              (put_arity (push_rel (LocalAssum (Name.Anonymous,typP)) env) (i+1) rest)
       | [] ->
 	  make_branch env 0 listdepkind
     in

--- a/pretyping/inductiveops.ml
+++ b/pretyping/inductiveops.ml
@@ -430,7 +430,7 @@ let make_arity_signature env sigma dep indf =
   if dep then
     (* We need names everywhere *)
     Namegen.name_context env sigma
-      ((LocalAssum (Anonymous,EConstr.of_constr (build_dependent_inductive env indf)))::arsign)
+      ((LocalAssum (Name.Anonymous,EConstr.of_constr (build_dependent_inductive env indf)))::arsign)
       (* Costly: would be better to name once for all at definition time *)
   else
     (* No need to enforce names *)
@@ -535,8 +535,8 @@ let is_predicate_explicitly_dep env sigma pred arsign =
           the predicate is parametrable! *)
 
           begin match na with
-          | Anonymous -> false
-          | Name _ -> true
+          | Name.Anonymous -> false
+          | Name.Name _ -> true
           end
 
       | _ -> anomaly (Pp.str "Non eta-expanded dep-expanded \"match\" predicate.")

--- a/pretyping/nativenorm.ml
+++ b/pretyping/nativenorm.ml
@@ -89,7 +89,7 @@ let invert_tag cst tag reloc_tbl =
 let decompose_prod env t =
   let (name,dom,codom as res) = destProd (whd_all env t) in
   match name with
-  | Anonymous -> (Name (Id.of_string "x"),dom,codom)
+  | Name.Anonymous -> (Name.Name (Id.of_string "x"),dom,codom)
   | _ -> res
 
 let app_type env c =
@@ -321,7 +321,7 @@ and nf_atom_type env sigma atom =
       mkCase(ci, p, a, branchs), tcase 
   | Afix(tt,ft,rp,s) ->
       let tt = Array.map (fun t -> nf_type env sigma t) tt in
-      let name = Array.map (fun _ -> (Name (Id.of_string "Ffix"))) tt in
+      let name = Array.map (fun _ -> Name.(Name (Id.of_string "Ffix"))) tt in
       let lvl = nb_rel env in
       let nbfix = Array.length ft in
       let fargs = mk_rels_accu lvl (Array.length ft) in
@@ -334,7 +334,7 @@ and nf_atom_type env sigma atom =
       mkFix((rp,s),(name,tt,ft)), tt.(s)
   | Acofix(tt,ft,s,_) | Acofixe(tt,ft,s,_) ->
       let tt = Array.map (nf_type env sigma) tt in
-      let name = Array.map (fun _ -> (Name (Id.of_string "Fcofix"))) tt in
+      let name = Array.map (fun _ -> Name.(Name (Id.of_string "Fcofix"))) tt in
       let lvl = nb_rel env in
       let fargs = mk_rels_accu lvl (Array.length ft) in
       let env = push_rec_types (name,tt,[||]) env in
@@ -376,7 +376,7 @@ and  nf_predicate env sigma ind mip params v pT =
   | Vfun f, _ -> 
       let k = nb_rel env in
       let vb = f (mk_rel_accu k) in
-      let name = Name (Id.of_string "c") in
+      let name = Name.Name (Id.of_string "c") in
       let n = mip.mind_nrealargs in
       let rargs = Array.init n (fun i -> mkRel (n-i)) in
       let params = if Int.equal n 0 then params else Array.map (lift n) params in

--- a/pretyping/patternops.ml
+++ b/pretyping/patternops.ml
@@ -247,7 +247,7 @@ let instantiate_pattern env sigma lvar c =
 	try
 	  let inst =
 	    List.map
-              (fun id -> mkRel (List.index Name.equal (Name id) vars))
+              (fun id -> mkRel (List.index Name.equal Name.(Name id) vars))
               ctx
           in
 	  let c = substl inst c in
@@ -256,7 +256,7 @@ let instantiate_pattern env sigma lvar c =
 	  pattern_of_constr env sigma (EConstr.Unsafe.to_constr c)
 	with Not_found (* List.index failed *) ->
 	  let vars =
-	    List.map_filter (function Name id -> Some id | _ -> None) vars in
+            List.map_filter (function Name.Name id -> Some id | _ -> None) vars in
 	  error_instantiate_pattern id (List.subtract Id.equal ctx vars)
        with Not_found (* Map.find failed *) ->
 	 x)
@@ -357,7 +357,7 @@ let warn_cast_in_pattern =
 
 let rec pat_of_raw metas vars = DAst.with_loc_val (fun ?loc -> function
   | GVar id ->
-      (try PRel (List.index Name.equal (Name id) vars)
+      (try PRel (List.index Name.equal Name.(Name id) vars)
        with Not_found -> PVar id)
   | GPatVar (Evar_kinds.FirstOrderPatVar n) ->
       metas := n::!metas; PMeta (Some n)
@@ -462,7 +462,7 @@ and pats_of_glob_branches loc metas vars ind brs =
     | [] -> false, []
     | (loc',(_,[p], br)) :: brs ->
       begin match DAst.get p, DAst.get br, brs with
-      | PatVar Anonymous, GHole _, [] ->
+      | PatVar Name.Anonymous, GHole _, [] ->
         true, [] (* ends with _ => _ *)
       | PatCstr((indsp,j),lv,_), _, _ ->
         let () = match ind with

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -385,10 +385,10 @@ let process_inference_flags flags env initial_sigma (sigma,c,cty) =
 
 let adjust_evar_source evdref na c =
   match na, kind !evdref c with
-  | Name id, Evar (evk,args) ->
+  | Name.Name id, Evar (evk,args) ->
      let evi = Evd.find !evdref evk in
      begin match evi.evar_source with
-     | loc, Evar_kinds.QuestionMark (b,Anonymous) ->
+     | loc, Evar_kinds.QuestionMark (b,Name.Anonymous) ->
         let src = (loc,Evar_kinds.QuestionMark (b,na)) in
         let (evd, evk') = restrict_evar !evdref evk (evar_filter evi) ~src None in
         evdref := evd;
@@ -415,7 +415,7 @@ let check_instance loc subst = function
    is named, hence possibly dependent *)
 
 let orelse_name name name' = match name with
-  | Anonymous -> name'
+  | Name.Anonymous -> name'
   | _ -> name
 
 let ltac_interp_name_env k0 lvar env sigma =
@@ -671,7 +671,7 @@ let rec pretype k0 resolve_tc (tycon : type_constraint) (env : ExtraEnv.t) evdre
     let lara = Array.map (fun a -> a.utj_val) larj in
     let ftys = Array.map2 (fun e a -> it_mkProd_or_LetIn a e) ctxtv lara in
     let nbfix = Array.length lar in
-    let names = Array.map (fun id -> Name id) names in
+    let names = Array.map (fun id -> Name.Name id) names in
     let _ = 
       match tycon with
       | Some t -> 
@@ -850,10 +850,10 @@ let rec pretype k0 resolve_tc (tycon : type_constraint) (env : ExtraEnv.t) evdre
        the substitution must also be applied on variables before they are
        looked up in the rel context. *)
     let j' = match name with
-      | Anonymous ->
+      | Name.Anonymous ->
         let j = pretype_type empty_valcon env evdref lvar c2 in
           { j with utj_val = lift 1 j.utj_val }
-      | Name _ ->
+      | Name.Name _ ->
         let var = LocalAssum (name, j.utj_val) in
         let env' = push_rel !evdref var env in
           pretype_type empty_valcon env' evdref lvar c2
@@ -940,7 +940,7 @@ let rec pretype k0 resolve_tc (tycon : type_constraint) (env : ExtraEnv.t) evdre
       (* Make dependencies from arity signature impossible *)
     let arsgn =
       let arsgn,_ = get_arity env.ExtraEnv.env indf in
-      List.map (set_name Anonymous) arsgn
+      List.map (set_name Name.Anonymous) arsgn
     in
       let indt = build_dependent_inductive env.ExtraEnv.env indf in
       let psign = LocalAssum (na, indt) :: arsgn in (* For locating names in [po] *)
@@ -1002,7 +1002,7 @@ let rec pretype k0 resolve_tc (tycon : type_constraint) (env : ExtraEnv.t) evdre
       let arsgn =
 	let arsgn,_ = get_arity env.ExtraEnv.env indf in
         (* Make dependencies from arity signature impossible *)
-        List.map (set_name Anonymous) arsgn
+        List.map (set_name Name.Anonymous) arsgn
       in
       let nar = List.length arsgn in
       let indt = build_dependent_inductive env.ExtraEnv.env indf in
@@ -1040,7 +1040,7 @@ let rec pretype k0 resolve_tc (tycon : type_constraint) (env : ExtraEnv.t) evdre
           then Context.Rel.map (whd_betaiota !evdref) cs_args
           else cs_args (* beta-iota-normalization regression in 8.5 and 8.6 *) in
 	let csgn =
-          List.map (set_name Anonymous) cs_args
+          List.map (set_name Name.Anonymous) cs_args
         in
 	let env_c = push_rel_context !evdref csgn env in
 	let bj = pretype (mk_tycon pi) env_c evdref lvar b in

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -1406,7 +1406,7 @@ let plain_instance sigma s c =
 	    match EConstr.kind sigma g with
             | App _ ->
                 let l' = CArray.Fun1.smartmap lift 1 l' in
-                mkLetIn (Name default_plain_instance_ident,g,t,mkApp(mkRel 1, l'))
+                mkLetIn (Name.Name default_plain_instance_ident,g,t,mkApp(mkRel 1, l'))
             | _ -> mkApp (g,l')
 	    with Not_found -> mkApp (f,l'))
         | _ -> mkApp (irec n f,l'))

--- a/pretyping/tacred.ml
+++ b/pretyping/tacred.ml
@@ -228,10 +228,10 @@ let check_fix_reversibility sigma labs args ((lv,i),(_,tys,bds)) =
    components of a mutual fixpoint *)
 
 let invert_name labs l na0 env sigma ref = function
-  | Name id ->
+  | Name.Name id ->
       let minfxargs = List.length l in
       begin match na0 with
-      | Name id' when Id.equal id' id ->
+      | Name.Name id' when Id.equal id' id ->
         Some (minfxargs,ref)
       | _ ->
 	let refi = match ref with
@@ -255,7 +255,7 @@ let invert_name labs l na0 env sigma ref = function
                     else None
 	      with Not_found (* Undefined ref *) -> None
       end
-  | Anonymous -> None (* Actually, should not occur *)
+  | Name.Anonymous -> None (* Actually, should not occur *)
 
 (* [compute_consteval_direct] expand all constant in a whole, but
    [compute_consteval_mutual_fix] only one by one, until finding the
@@ -350,7 +350,7 @@ let reference_eval env sigma = function
    The type Tij' is Tij[yi(j-1)..y1 <- ai(j-1)..a1]
 *)
 
-let x = Name default_dependent_ident
+let x = Name.Name default_dependent_ident
 
 let make_elim_fun (names,(nbfix,lv,n)) u largs =
   let lu = List.firstn n largs in
@@ -512,8 +512,8 @@ let reduce_mind_case_use_function func env sigma mia =
 	    fun i ->
 	      if Int.equal i bodynum then Some (minargs,func)
 	      else match names.(i) with
-		| Anonymous -> None
-		| Name id ->
+                | Name.Anonymous -> None
+                | Name.Name id ->
 		    (* In case of a call to another component of a block of
 		       mutual inductive, try to reuse the global name if
 		       the block was indeed initially built as a global
@@ -1151,7 +1151,7 @@ let compute = cbv_betadeltaiota
 
 let abstract_scheme env sigma (locc,a) (c, sigma) =
   let ta = Retyping.get_type_of env sigma a in
-  let na = named_hd env sigma ta Anonymous in
+  let na = named_hd env sigma ta Name.Anonymous in
   if occur_meta sigma ta then user_err Pp.(str "Cannot find a type for the generalisation.");
   if occur_meta sigma a then
     mkLambda (na,ta,c), sigma

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -107,7 +107,7 @@ let abstract_scheme env evd c l lname_typ =
     (fun (t,evd) (locc,a) decl ->
        let na = RelDecl.get_name decl in
        let ta = RelDecl.get_type decl in
-       let na = match EConstr.kind evd a with Var id -> Name id | _ -> na in
+       let na = match EConstr.kind evd a with Var id -> Name.Name id | _ -> na in
 (* [occur_meta ta] test removed for support of eelim/ecase but consequences
    are unclear...
        if occur_meta ta then error "cannot find a type for the generalisation"
@@ -1628,7 +1628,7 @@ let make_abstraction_core name (test,out) env sigma c ty occs check_occs concl =
     let t = match ty with Some t -> t | None -> get_type_of env sigma c in
     let x = id_of_name_using_hdchar (Global.env()) sigma t name in
     let ids = Environ.ids_of_named_context_val (named_context_val env) in
-    if name == Anonymous then next_ident_away_in_goal x ids else
+    if name == Name.Anonymous then next_ident_away_in_goal x ids else
     if mem_named_context_val x (named_context_val env) then
       user_err ~hdr:"Unification.make_abstraction_core"
         (str "The variable " ++ Id.print x ++ str " is already declared.")

--- a/pretyping/vnorm.ml
+++ b/pretyping/vnorm.ml
@@ -31,8 +31,8 @@ let crazy_type =  mkSet
 let decompose_prod env t =
   let (name,dom,codom as res) = destProd (whd_all env t) in
   match name with
-  | Anonymous -> (Name (Id.of_string "x"), dom, codom)
-  | Name _ -> res
+  | Name.Anonymous -> (Name.Name (Id.of_string "x"), dom, codom)
+  | Name.Name _ -> res
 
 exception Find_at of int
 
@@ -144,7 +144,7 @@ and nf_whd env sigma whd typ =
   | Vsort s -> mkSort s
   | Vprod p ->
       let dom = nf_vtype env sigma (dom p) in
-      let name = Name (Id.of_string "x") in
+      let name = Name.Name (Id.of_string "x") in
       let vc = reduce_fun (nb_rel env) (codom p) in
       let codom = nf_vtype (push_rel (LocalAssum (name,dom)) env) sigma vc  in
       mkProd(name,dom,codom)
@@ -276,7 +276,7 @@ and nf_predicate env sigma ind mip params v pT =
   | Vfun f, _ ->
       let k = nb_rel env in
       let vb = reduce_fun k f in
-      let name = Name (Id.of_string "c") in
+      let name = Name.Name (Id.of_string "c") in
       let n = mip.mind_nrealargs in
       let rargs = Array.init n (fun i -> mkRel (n-i)) in
       let params = if Int.equal n 0 then params else Array.map (lift n) params in
@@ -327,7 +327,7 @@ and nf_fix env sigma f =
   let vb, vt = reduce_fix k f in
   let ndef = Array.length vt in
   let ft = Array.map (fun v -> nf_val env sigma v crazy_type) vt in
-  let name = Array.init ndef (fun _ -> (Name (Id.of_string "Ffix"))) in
+  let name = Array.init ndef (fun _ -> Name.(Name (Id.of_string "Ffix"))) in
   (* Third argument of the tuple is ignored by push_rec_types *)
   let env = push_rec_types (name,ft,ft) env in
   (* We lift here because the types of arguments (in tt) will be evaluated
@@ -349,7 +349,7 @@ and nf_cofix env sigma cf =
   let vb,vt = reduce_cofix k cf in
   let ndef = Array.length vt in
   let cft = Array.map (fun v -> nf_val env sigma v crazy_type) vt in
-  let name = Array.init ndef (fun _ -> (Name (Id.of_string "Fcofix"))) in
+  let name = Array.init ndef (fun _ -> Name.(Name (Id.of_string "Fcofix"))) in
   let env = push_rec_types (name,cft,cft) env in
   let cfb = Util.Array.map2 (fun v t -> nf_val env sigma v t) vb cft in
   mkCoFix (init,(name,cft,cfb))

--- a/printing/ppconstr.ml
+++ b/printing/ppconstr.ml
@@ -236,7 +236,7 @@ let tag_var = tag Tag.variable
                   pr_located pr_id @@ Loc.tag ~loc:(Loc.make_loc (b,b + String.length (Id.to_string id))) id
 
   let pr_lname = function
-    | (loc,Name id) -> pr_lident (loc,id)
+    | (loc,Name.Name id) -> pr_lident (loc,id)
     | lna -> pr_located Name.print lna
 
   let pr_or_var pr = function
@@ -350,10 +350,10 @@ let tag_var = tag Tag.variable
       | Generalized (b, b', t') ->
         assert (match b with Implicit -> true | _ -> false);
         begin match nal with
-          |[loc,Anonymous] ->
+          |[loc,Name.Anonymous] ->
             hov 1 (str"`" ++ (surround_impl b'
                                 ((if t' then str "!" else mt ()) ++ pr t)))
-          |[loc,Name id] ->
+          |[loc,Name.Name id] ->
             hov 1 (str "`" ++ (surround_impl b'
                                  (pr_lident (loc,id) ++ str " : " ++
                                     (if t' then str "!" else mt()) ++ pr t)))
@@ -461,7 +461,7 @@ let tag_var = tag Tag.variable
 
   let pr_simple_return_type pr na po =
     (match na with
-      | Some (_,Name id) ->
+      | Some (_,Name.Name id) ->
         spc () ++ keyword "as" ++ spc () ++ pr_id id
       | _ -> mt ()) ++
       pr_case_type pr po
@@ -533,7 +533,7 @@ let tag_var = tag Tag.variable
               pr_fun_sep ++ pr spc ltop a),
           llambda
         )
-      | CLetIn ((_,Name x), ({ CAst.v = CFix((_,x'),[_])}
+      | CLetIn ((_,Name.Name x), ({ CAst.v = CFix((_,x'),[_])}
                           |  { CAst.v = CCoFix((_,x'),[_]) } as fx), t, b)
           when Id.equal x x' ->
         return (

--- a/printing/ppvernac.ml
+++ b/printing/ppvernac.ml
@@ -711,7 +711,7 @@ open Decl_kinds
             in
             (pr_binders_arg bl,ty,Some (pr_reduce red ++ pr_lconstr body))
           | ProveBody (bl,t) ->
-            let typ u = if snd (fst id) = Anonymous then (assert (bl = []); u) else (str" :" ++ u) in
+            let typ u = if snd (fst id) = Name.Anonymous then (assert (bl = []); u) else (str" :" ++ u) in
             (pr_binders_arg bl, typ (pr_spc_lconstr t), None) in
         let (binds,typ,c) = pr_def_body b in
         return (
@@ -891,8 +891,8 @@ open Decl_kinds
             (if abst then keyword "Declare" ++ spc () else mt ()) ++
               keyword "Instance" ++
               (match instid with
-      	 | (loc, Name id), l -> spc () ++ pr_ident_decl ((loc, id),l) ++ spc ()
-               | (_, Anonymous), _ -> mt ()) ++
+         | (loc, Name.Name id), l -> spc () ++ pr_ident_decl ((loc, id),l) ++ spc ()
+               | (_, Name.Anonymous), _ -> mt ()) ++
               pr_and_type_binders_arg sup ++
               str":" ++ spc () ++
               (match bk with Implicit -> str "! " | Explicit -> mt ()) ++

--- a/printing/prettyp.ml
+++ b/printing/prettyp.ml
@@ -303,7 +303,7 @@ let print_inductive_renames =
   print_args_data_of_inductive_ids
     (fun r ->
       try Arguments_renaming.arguments_names r with Not_found -> [])
-    ((!=) Anonymous)
+    ((!=) Name.Anonymous)
     print_renames_list
 
 let print_inductive_argument_scopes =

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -116,7 +116,7 @@ let pr_constr_under_binders_env_gen pr env sigma (ids,c) =
   (* Warning: clashes can occur with variables of same name in env but *)
   (* we also need to preserve the actual names of the patterns *)
   (* So what to do? *)
-  let assums = List.map (fun id -> (Name id,(* dummy *) mkProp)) ids in
+  let assums = List.map (fun id -> (Name.Name id,(* dummy *) mkProp)) ids in
   pr (Termops.push_rels_assum assums env) sigma c
 
 let pr_constr_under_binders_env = pr_constr_under_binders_env_gen pr_econstr_env
@@ -354,8 +354,8 @@ let pr_rel_decl env sigma decl =
 	(str":=" ++ spc () ++ pb ++ spc ()) in
   let ptyp = pr_ltype_env env sigma typ in
   match na with
-  | Anonymous -> hov 0 (str"<>" ++ spc () ++ pbody ++ str":" ++ spc () ++ ptyp)
-  | Name id -> hov 0 (pr_id id ++ spc () ++ pbody ++ str":" ++ spc () ++ ptyp)
+  | Name.Anonymous -> hov 0 (str"<>" ++ spc () ++ pbody ++ str":" ++ spc () ++ ptyp)
+  | Name.Name id -> hov 0 (pr_id id ++ spc () ++ pbody ++ str":" ++ spc () ++ ptyp)
 
 
 (* Prints out an "env" in a nice format.  We print out the

--- a/printing/printmod.ml
+++ b/printing/printmod.ml
@@ -157,10 +157,10 @@ let get_fields =
   let rec prodec_rec l subst c =
     match kind c with
     | Prod (na,t,c) ->
-        let id = match na with Name id -> id | Anonymous -> Id.of_string "_" in
+        let id = match na with Name.Name id -> id | Name.Anonymous -> Id.of_string "_" in
         prodec_rec ((id,true,Vars.substl subst t)::l) (mkVar id::subst) c
     | LetIn (na,b,_,c) ->
-        let id = match na with Name id -> id | Anonymous -> Id.of_string "_" in
+        let id = match na with Name.Name id -> id | Name.Anonymous -> Id.of_string "_" in
         prodec_rec ((id,false,Vars.substl subst b)::l) (mkVar id::subst) c
     | _               -> List.rev l
   in

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -70,7 +70,7 @@ let clenv_push_prod cl =
     | Prod (na,t,u) ->
 	let mv = new_meta () in
 	let dep = not (noccurn (cl_sigma cl) 1 u) in
-	let na' = if dep then na else Anonymous in
+        let na' = if dep then na else Name.Anonymous in
 	let e' = meta_declare mv (EConstr.Unsafe.to_constr t) ~name:na' cl.evd in
 	let concl = if dep then subst1 (mkMeta mv) u else u in
 	let def = applist (cl.templval.rebus,[mkMeta mv]) in
@@ -104,7 +104,7 @@ let clenv_environments evd bound t =
       | (n, Prod (na,t1,t2)) ->
 	  let mv = new_meta () in
 	  let dep = not (noccurn evd 1 t2) in
-	  let na' = if dep then na else Anonymous in
+          let na' = if dep then na else Name.Anonymous in
 	  let t1 = EConstr.Unsafe.to_constr t1 in
 	  let e' = meta_declare mv t1 ~name:na' e in
 	  clrec (e', (mkMeta mv)::metas) (Option.map ((+) (-1)) n)
@@ -151,7 +151,7 @@ let mentions clenv mv0 =
 let error_incompatible_inst clenv mv  =
   let na = meta_name clenv.evd mv in
   match na with
-      Name id ->
+      Name.Name id ->
         user_err ~hdr:"clenv_assign"
           (str "An incompatible instantiation has already been found for " ++
            Id.print id)
@@ -279,7 +279,7 @@ let adjust_meta_source evd mv = function
   | loc,Evar_kinds.VarInstance id ->
     let rec match_name c l =
       match EConstr.kind evd c, l with
-      | Lambda (Name id,_,c), a::l when EConstr.eq_constr evd a (mkMeta mv) -> Some id
+      | Lambda (Name.Name id,_,c), a::l when EConstr.eq_constr evd a (mkMeta mv) -> Some id
       | Lambda (_,_,c), a::l -> match_name c l
       | _ -> None in
     (* This is very ad hoc code so that an evar inherits the name of the binder
@@ -431,7 +431,7 @@ let explain_no_such_bound_variable evd id =
     | Cltyp (na, _) -> na
     | Clval (na, _, _) -> na
     in
-    if na != Anonymous then Name.get_id na :: l else l
+    if na != Name.Anonymous then Name.get_id na :: l else l
   in
   let mvl = List.fold_left fold [] (Evd.meta_list evd) in
   user_err ~hdr:"Evd.meta_with_name"
@@ -443,7 +443,7 @@ let explain_no_such_bound_variable evd id =
          pr_enum Id.print mvl ++ str").")))
 
 let meta_with_name evd id =
-  let na = Name id in
+  let na = Name.Name id in
   let fold (l1, l2 as l) (n, clb) =
     let (na',def) = match clb with
     | Cltyp (na, _) -> (na, false)
@@ -633,8 +633,8 @@ let make_evar_clause env sigma ?len t =
 
 let explain_no_such_bound_variable holes id =
   let fold h accu = match h.hole_name with
-  | Anonymous -> accu
-  | Name id -> id :: accu
+  | Name.Anonymous -> accu
+  | Name.Name id -> id :: accu
   in
   let mvl = List.fold_right fold holes [] in
   let expl = match mvl with
@@ -646,8 +646,8 @@ let explain_no_such_bound_variable holes id =
 
 let evar_with_name holes id =
   let map h = match h.hole_name with
-  | Anonymous -> None
-  | Name id' -> if Id.equal id id' then Some h else None
+  | Name.Anonymous -> None
+  | Name.Name id' -> if Id.equal id id' then Some h else None
   in
   let hole = List.map_filter map holes in
   match hole with

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -565,7 +565,7 @@ end = struct (* {{{ *)
   let reachable id = reachable !vcs id
   let mk_branch_name { expr = x } = Branch.make
     (match Vernacprop.under_control x with
-    | VernacDefinition (_,((_, Name i),_),_) -> Id.to_string i
+    | VernacDefinition (_,((_, Name.Name i),_),_) -> Id.to_string i
     | VernacStartTheoremProof (_,[((_,i),_),_]) -> Id.to_string i
     | _ -> "branch")
   let edit_branch = Branch.make "edit"

--- a/stm/vernac_classifier.ml
+++ b/stm/vernac_classifier.ml
@@ -50,8 +50,8 @@ let declare_vernac_classifier
 
 let idents_of_name : Names.Name.t -> Names.Id.t list =
   function
-  | Names.Anonymous -> []
-  | Names.Name n -> [n]
+  | Names.Name.Anonymous -> []
+  | Names.Name.Name n -> [n]
 
 let classify_vernac e =
   let static_classifier ~poly e = match e with
@@ -128,7 +128,7 @@ let classify_vernac e =
         | Constructors l -> List.map (fun (_,((_,id),_)) -> id) l
         | RecordDecl (oid,l) -> (match oid with Some (_,x) -> [x] | _ -> []) @
            CList.map_filter (function
-            | ((_,AssumExpr((_,Names.Name n),_)),_),_ -> Some n
+            | ((_,AssumExpr((_,Names.Name.Name n),_)),_),_ -> Some n
             | _ -> None) l) l in
         VtSideff (List.flatten ids), VtLater
     | VernacScheme l ->

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -1608,7 +1608,7 @@ let rec head_of_constr sigma t =
 let head_of_constr h c =
   Proofview.tclEVARMAP >>= fun sigma ->
   let c = head_of_constr sigma c in
-  letin_tac None (Name h) c None Locusops.allHyps
+  letin_tac None Name.(Name h) c None Locusops.allHyps
 
 let not_evar c =
   Proofview.tclEVARMAP >>= fun sigma ->

--- a/tactics/contradiction.ml
+++ b/tactics/contradiction.ml
@@ -21,8 +21,8 @@ module NamedDecl = Context.Named.Declaration
 
 let mk_absurd_proof coq_not t =
   let id = Namegen.default_dependent_ident in
-  mkLambda (Names.Name id,mkApp(coq_not,[|t|]),
-    mkLambda (Names.Name id,t,mkApp (mkRel 2,[|mkRel 1|])))
+  mkLambda (Names.Name.Name id,mkApp(coq_not,[|t|]),
+    mkLambda (Names.Name.Name id,t,mkApp (mkRel 2,[|mkRel 1|])))
 
 let absurd c =
   Proofview.Goal.enter begin fun gl ->

--- a/tactics/eqdecide.ml
+++ b/tactics/eqdecide.ml
@@ -73,7 +73,7 @@ let generalize_right mk typ c1 c2 =
     let env = Proofview.Goal.env gl in
     let store = Proofview.Goal.extra gl in
   Refine.refine ~typecheck:false begin fun sigma ->
-    let na = Name (next_name_away_with_default "x" Anonymous (Termops.vars_of_env env)) in
+    let na = Name.Name (next_name_away_with_default "x" Name.Anonymous (Termops.vars_of_env env)) in
     let newconcl = mkProd (na, typ, mk typ c1 (mkRel 1)) in
     let (sigma, x) = Evarutil.new_evar env sigma ~principal:true ~store newconcl in
     (sigma, mkApp (x, [|c2|]))

--- a/tactics/eqschemes.ml
+++ b/tactics/eqschemes.ml
@@ -198,7 +198,7 @@ let build_sym_scheme env ind =
   let varH = fresh env (default_id_of_sort (snd (mind_arity mip))) in
   let applied_ind = build_dependent_inductive indu specif in
   let realsign_ind =
-    name_context env ((LocalAssum (Name varH,applied_ind))::realsign) in
+    name_context env ((LocalAssum (Name.Name varH,applied_ind))::realsign) in
   let ci = make_case_info (Global.env()) ind RegularStyle in
   let c = 
   (my_it_mkLambda_or_LetIn paramsctxt
@@ -257,7 +257,7 @@ let build_sym_involutive_scheme env ind =
          (Context.Rel.to_extended_vect mkRel (nrealargs+1) mib.mind_params_ctxt)
          (rel_vect (nrealargs+1) nrealargs)) in
   let realsign_ind =
-    name_context env ((LocalAssum (Name varH,applied_ind))::realsign) in
+    name_context env ((LocalAssum (Name.Name varH,applied_ind))::realsign) in
   let ci = make_case_info (Global.env()) ind RegularStyle in
   let c = 
     (my_it_mkLambda_or_LetIn paramsctxt
@@ -377,9 +377,9 @@ let build_l2r_rew_scheme dep env ind kind =
         rel_vect 0 nrealargs]) in
   let realsign_P = lift_rel_context nrealargs realsign in
   let realsign_ind_P =
-    name_context env ((LocalAssum (Name varH,applied_ind_P))::realsign_P) in
+    name_context env ((LocalAssum (Name.Name varH,applied_ind_P))::realsign_P) in
   let realsign_ind_G =
-    name_context env ((LocalAssum (Name varH,applied_ind_G))::
+    name_context env ((LocalAssum (Name.Name varH,applied_ind_G))::
                       lift_rel_context (nrealargs+3) realsign) in
   let applied_sym_C n =
      mkApp(sym,
@@ -428,8 +428,8 @@ let build_l2r_rew_scheme dep env ind kind =
   (mkNamedLambda varH (lift 2 applied_ind)
   (if dep then (* we need a coercion *)
      mkCase (cieq,
-       mkLambda (Name varH,lift 3 applied_ind,
-         mkLambda (Anonymous,
+       mkLambda (Name.Name varH,lift 3 applied_ind,
+         mkLambda (Name.Anonymous,
                    mkApp (eq,[|lift 4 applied_ind;applied_sym_sym;mkRel 1|]),
                    applied_PR)),
        mkApp (sym_involutive,
@@ -490,9 +490,9 @@ let build_l2r_forward_rew_scheme dep env ind kind =
         rel_vect (2*nrealargs+1) nrealargs]) in
   let realsign_P n = lift_rel_context (nrealargs*n+n) realsign in
   let realsign_ind =
-    name_context env ((LocalAssum (Name varH,applied_ind))::realsign) in
+    name_context env ((LocalAssum (Name.Name varH,applied_ind))::realsign) in
   let realsign_ind_P n aP =
-    name_context env ((LocalAssum (Name varH,aP))::realsign_P n) in
+    name_context env ((LocalAssum (Name.Name varH,aP))::realsign_P n) in
   let s, ctx' = Universes.fresh_sort_in_family (Global.env ()) kind in
   let ctx = Univ.ContextSet.union ctx ctx' in
   let s = mkSort s in
@@ -570,7 +570,7 @@ let build_r2l_forward_rew_scheme dep env ind kind =
   let varP = fresh env (Id.of_string "P") in
   let applied_ind = build_dependent_inductive indu specif in
   let realsign_ind =
-    name_context env ((LocalAssum (Name varH,applied_ind))::realsign) in
+    name_context env ((LocalAssum (Name.Name varH,applied_ind))::realsign) in
   let s, ctx' = Universes.fresh_sort_in_family (Global.env ()) kind in
   let ctx = Univ.ContextSet.union ctx ctx' in
   let s = mkSort s in
@@ -595,7 +595,7 @@ let build_r2l_forward_rew_scheme dep env ind kind =
          (mkArrow applied_PG (lift (2*nrealargs+5) applied_PC)),
        mkRel 3 (* varH *),
        [|mkLambda
-          (Name varHC,
+          (Name.Name varHC,
 	   lift (nrealargs+3) applied_PC,
 	   mkRel 1)|]),
     [|mkVar varHC|]))))))
@@ -792,7 +792,7 @@ let build_congr env (eq,refl,ctx) ind =
        my_it_mkLambda_or_LetIn_name
 	 (lift_rel_context (mip.mind_nrealargs+3) realsign)
          (mkLambda
-           (Anonymous,
+           (Name.Anonymous,
             applist
              (mkIndU indu,
 	        Context.Rel.to_extended_list mkRel (2*mip.mind_nrealdecls+3)

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -1034,7 +1034,7 @@ let discr_positions env sigma (lbeq,eqn,(t,t1,t2)) eq_clause cpath dirn =
     let pf_ty = mkArrow eqn absurd_term in
     let absurd_clause = apply_on_clause (pf,pf_ty) eq_clause in
     let pf = Clenvtac.clenv_value_cast_meta absurd_clause in
-    tclTHENS (assert_after Anonymous absurd_term)
+    tclTHENS (assert_after Name.Anonymous absurd_term)
       [onLastHypId gen_absurdity; (Proofview.V82.tactic (Tacmach.refine pf))]
 
 let discrEq (lbeq,_,(t,t1,t2) as u) eq_clause =

--- a/tactics/hipattern.ml
+++ b/tactics/hipattern.ml
@@ -261,11 +261,11 @@ open Evar_kinds
 let mkPattern c = snd (Patternops.pattern_of_glob_constr c)
 let mkGApp f args = DAst.make @@ GApp (f, args)
 let mkGHole = DAst.make @@
-  GHole (QuestionMark (Define false,Anonymous), Misctypes.IntroAnonymous, None)
+  GHole (QuestionMark (Define false,Name.Anonymous), Misctypes.IntroAnonymous, None)
 let mkGProd id c1 c2 = DAst.make @@
-  GProd (Name (Id.of_string id), Explicit, c1, c2)
+  GProd (Name.Name (Id.of_string id), Explicit, c1, c2)
 let mkGArrow c1 c2 = DAst.make @@
-  GProd (Anonymous, Explicit, c1, c2)
+  GProd (Name.Anonymous, Explicit, c1, c2)
 let mkGVar id = DAst.make @@ GVar (Id.of_string id)
 let mkGPatVar id = DAst.make @@ GPatVar(Evar_kinds.FirstOrderPatVar (Id.of_string id))
 let mkGRef r = DAst.make @@ GRef (Lazy.force r, None)

--- a/tactics/inv.ml
+++ b/tactics/inv.ml
@@ -119,7 +119,7 @@ let make_inv_predicate env evd indf realargs id status concl =
 	let eq = Evarutil.evd_comb1 (Evd.fresh_global env) evd eq_term in
         let eq = EConstr.of_constr eq in
         let eqn = applist (eq,[eqnty;lhs;rhs]) in
-        let eqns = (Anonymous, lift n eqn) :: eqns in
+        let eqns = (Name.Anonymous, lift n eqn) :: eqns in
         let refl_term = eqdata.Coqlib.refl in
 	let refl_term = Evarutil.evd_comb1 (Evd.fresh_global env) evd refl_term in
 	let refl_term = EConstr.of_constr refl_term in
@@ -476,7 +476,7 @@ let raw_inversion inv_kind id status names =
     let as_mode = names != None in
     tclTHEN (Proofview.Unsafe.tclEVARS sigma)
       (tclTHENS
-        (assert_before Anonymous cut_concl)
+        (assert_before Name.Anonymous cut_concl)
         [case_tac names
             (introCaseAssumsThen false (* ApplyOn not supported by inversion *)
                (rewrite_equations_tac as_mode inv_kind id neqns))

--- a/tactics/leminv.ml
+++ b/tactics/leminv.ml
@@ -149,7 +149,7 @@ let compute_first_inversion_scheme env sigma ind sort dep_option =
       let pty = make_arity env sigma true indf sort in
       let goal =
 	mkProd
-	  (Anonymous, mkAppliedInd ind, applist(mkVar p,realargs@[mkRel 1]))
+          (Name.Anonymous, mkAppliedInd ind, applist(mkVar p,realargs@[mkRel 1]))
       in
       pty,goal
     else

--- a/vernac/assumptions.ml
+++ b/vernac/assumptions.ml
@@ -258,7 +258,7 @@ and traverse_inductive (curr, data, ax2ty) mind obj =
        Array.fold_left (fun accu oib ->
           let pspecif = Univ.in_punivs (mib, oib) in
           let ind_type = Inductive.type_of_inductive global_env pspecif in
-          let ind_name = Name oib.mind_typename in
+          let ind_name = Name.Name oib.mind_typename in
           Context.Rel.add (Context.Rel.Declaration.LocalAssum (ind_name, ind_type)) accu)
           Context.Rel.empty mib.mind_packets
      in

--- a/vernac/auto_ind_decl.ml
+++ b/vernac/auto_ind_decl.ml
@@ -142,8 +142,8 @@ let build_beq_scheme mode kn =
   let create_input c =
     let myArrow u v = mkArrow u (lift 1 v)
     and eqName = function
-        | Name s -> Id.of_string ("eq_"^(Id.to_string s))
-        | Anonymous -> Id.of_string "eq_A"
+        | Name.Name s -> Id.of_string ("eq_"^(Id.to_string s))
+        | Name.Anonymous -> Id.of_string "eq_A"
     in
     let ext_rel_list = Context.Rel.to_extended_list mkRel 0 lnamesparrec in
       let lift_cnt = ref 0 in
@@ -163,7 +163,7 @@ let build_beq_scheme mode kn =
         List.fold_left (fun a decl ->(* mkLambda(n,t,a)) eq_input rel_list *)
           (* Same here , hoping the auto renaming will do something good ;)  *)
           mkNamedLambda
-                (match RelDecl.get_name decl with Name s -> s | Anonymous ->  Id.of_string "A")
+                (match RelDecl.get_name decl with Name.Name s -> s | Name.Anonymous ->  Id.of_string "A")
                 (RelDecl.get_type decl)  a) eq_input lnamesparrec
  in
  let make_one_eq cur =
@@ -238,8 +238,8 @@ let build_beq_scheme mode kn =
   in
   (* construct the predicate for the Case part*)
   let do_predicate rel_list n =
-     List.fold_left (fun a b -> mkLambda(Anonymous,b,a))
-      (mkLambda (Anonymous,
+     List.fold_left (fun a b -> mkLambda(Name.Anonymous,b,a))
+      (mkLambda (Name.Anonymous,
                  mkFullInd ind (n+3+(List.length rettyp_l)+nb_ind-1),
                  (Lazy.force bb)))
       (List.rev rettyp_l) in
@@ -300,13 +300,13 @@ let build_beq_scheme mode kn =
  	    mkCase (ci, do_predicate rel_list 0,mkVar (Id.of_string "X"),ar))),
         !eff
     in (* build_beq_scheme *)
-    let names = Array.make nb_ind Anonymous and
+    let names = Array.make nb_ind Name.Anonymous and
         types = Array.make nb_ind mkSet and
         cores = Array.make nb_ind mkSet in
     let eff = ref Safe_typing.empty_private_constants in
     let u = Univ.Instance.empty in
     for i=0 to (nb_ind-1) do
-        names.(i) <- Name (Id.of_string (rec_name i));
+        names.(i) <- Name.Name (Id.of_string (rec_name i));
 	types.(i) <- mkArrow (mkFullInd ((kn,i),u) 0)
                      (mkArrow (mkFullInd ((kn,i),u) 1) (Lazy.force bb));
         let c, eff' = make_one_eq i in
@@ -516,8 +516,8 @@ let do_replace_bl mode bl_scheme_key (ind,u as indu) aavoid narg lft rgt =
 *)
 let list_id l = List.fold_left ( fun a decl -> let s' =
       match RelDecl.get_name decl with
-        Name s -> Id.to_string s
-      | Anonymous -> "A" in
+        Name.Name s -> Id.to_string s
+      | Name.Anonymous -> "A" in
           (Id.of_string s',Id.of_string ("eq_"^s'),
               Id.of_string (s'^"_bl"),
               Id.of_string (s'^"_lb"))
@@ -560,13 +560,13 @@ let compute_bl_goal ind lnamesparrec nparrec =
         mkNamedProd sbl b a
       ) c (List.rev list_id) (List.rev bl_typ) in
       let eqs_typ = List.map (fun (s,_,_,_) ->
-          mkProd(Anonymous,mkVar s,mkProd(Anonymous,mkVar s,(Lazy.force bb)))
+          mkProd(Name.Anonymous,mkVar s,mkProd(Name.Anonymous,mkVar s,(Lazy.force bb)))
           ) list_id in
       let eq_input = List.fold_left2 ( fun a (s,seq,_,_) b ->
         mkNamedProd seq b a
       ) bl_input (List.rev list_id) (List.rev eqs_typ) in
       List.fold_left (fun a decl -> mkNamedProd
-                (match RelDecl.get_name decl with Name s -> s | Anonymous -> next_ident_away (Id.of_string "A") avoid)
+                (match RelDecl.get_name decl with Name.Name s -> s | Name.Anonymous -> next_ident_away (Id.of_string "A") avoid)
                 (RelDecl.get_type decl) a) eq_input lnamesparrec
     in
       let n = next_ident_away (Id.of_string "x") avoid and
@@ -704,13 +704,13 @@ let compute_lb_goal ind lnamesparrec nparrec =
         mkNamedProd slb b a
       ) c (List.rev list_id) (List.rev lb_typ) in
       let eqs_typ = List.map (fun (s,_,_,_) ->
-          mkProd(Anonymous,mkVar s,mkProd(Anonymous,mkVar s,bb))
+          mkProd(Name.Anonymous,mkVar s,mkProd(Name.Anonymous,mkVar s,bb))
           ) list_id in
       let eq_input = List.fold_left2 ( fun a (s,seq,_,_) b ->
         mkNamedProd seq b a
       ) lb_input (List.rev list_id) (List.rev eqs_typ) in
       List.fold_left (fun a decl -> mkNamedProd
-                (match (RelDecl.get_name decl) with Name s -> s | Anonymous ->  Id.of_string "A")
+                (match (RelDecl.get_name decl) with Name.Name s -> s | Name.Anonymous ->  Id.of_string "A")
                 (RelDecl.get_type decl)  a) eq_input lnamesparrec
     in
       let n = next_ident_away (Id.of_string "x") avoid and
@@ -846,13 +846,13 @@ let compute_dec_goal ind lnamesparrec nparrec =
       ) lb_input (List.rev list_id) (List.rev bl_typ) in
 
       let eqs_typ = List.map (fun (s,_,_,_) ->
-          mkProd(Anonymous,mkVar s,mkProd(Anonymous,mkVar s,bb))
+          mkProd(Name.Anonymous,mkVar s,mkProd(Name.Anonymous,mkVar s,bb))
           ) list_id in
       let eq_input = List.fold_left2 ( fun a (s,seq,_,_) b ->
         mkNamedProd seq b a
       ) bl_input (List.rev list_id) (List.rev eqs_typ) in
       List.fold_left (fun a decl -> mkNamedProd
-                (match RelDecl.get_name decl with Name s -> s | Anonymous ->  Id.of_string "A")
+                (match RelDecl.get_name decl with Name.Name s -> s | Name.Anonymous ->  Id.of_string "A")
                 (RelDecl.get_type decl) a) eq_input lnamesparrec
     in
       let n = next_ident_away (Id.of_string "x") avoid and
@@ -910,7 +910,7 @@ let compute_dec_tact ind lnamesparrec nparrec =
         intros_using fresh_first_intros;
         intros_using [freshn;freshm];
 	(*we do this so we don't have to prove the same goal twice *)
-        assert_by (Name freshH) (EConstr.of_constr (
+        assert_by Name.(Name freshH) (EConstr.of_constr (
           mkApp(sumbool(),[|eqtrue eqbnm; eqfalse eqbnm|])
 	))
 	  (Tacticals.New.tclTHEN (destruct_on (EConstr.of_constr eqbnm)) Auto.default_auto);
@@ -934,7 +934,7 @@ let compute_dec_tact ind lnamesparrec nparrec =
               unfold_constr (Lazy.force Coqlib.coq_not_ref);
               intro;
               Equality.subst_all ();
-              assert_by (Name freshH3)
+              assert_by Name.(Name freshH3)
 		(EConstr.of_constr (mkApp(eq,[|bb;mkApp(eqI,[|mkVar freshm;mkVar freshm|]);tt|])))
 		(Tacticals.New.tclTHENLIST [
 		  apply (EConstr.of_constr (mkApp(lbI,Array.map (fun x->mkVar x) xargs)));

--- a/vernac/class.ml
+++ b/vernac/class.ml
@@ -185,14 +185,14 @@ let build_id_coercion idf_opt source poly =
   let lams,t = decompose_lam_assum c in
   let val_f =
     it_mkLambda_or_LetIn
-      (mkLambda (Name Namegen.default_dependent_ident,
+      (mkLambda (Name.Name Namegen.default_dependent_ident,
 		 applistc vs (Context.Rel.to_extended_list mkRel 0 lams),
 		 mkRel 1))
        lams
   in
   let typ_f =
     List.fold_left (fun d c -> Term.mkProd_wo_LetIn c d)
-      (mkProd (Anonymous, applistc vs (Context.Rel.to_extended_list mkRel 0 lams), lift 1 t))
+      (mkProd (Name.Anonymous, applistc vs (Context.Rel.to_extended_list mkRel 0 lams), lift 1 t))
       lams
   in
   (* juste pour verification *)

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -174,12 +174,12 @@ let new_instance ?(abstract=false) ?(global=false) ?(refine= !refine_instance)
   in
   let id =
     match instid with
-	Name id ->
+        Name.Name id ->
 	  let sp = Lib.make_path id in
 	    if Nametab.exists_cci sp then
 	      user_err ~hdr:"new_instance" (Id.print id ++ Pp.str " already exists.");
 	    id
-      | Anonymous ->
+      | Name.Anonymous ->
 	  let i = Nameops.add_suffix (id_of_class k) "_instance_0" in
 	    Namegen.next_global_ident_away i (Termops.vars_of_env env)
   in
@@ -236,8 +236,8 @@ let new_instance ?(abstract=false) ?(global=false) ?(refine= !refine_instance)
 		  if is_local_assum decl then
 		    try
 		      let is_id (id', _) = match RelDecl.get_name decl, get_id id' with
-			| Name id, (_, id') -> Id.equal id id'
-			| Anonymous, _ -> false
+                        | Name.Name id, (_, id') -> Id.equal id id'
+                        | Name.Anonymous, _ -> false
                       in
 		       let (loc_mid, c) =
 			 List.find is_id rest 
@@ -247,7 +247,7 @@ let new_instance ?(abstract=false) ?(global=false) ?(refine= !refine_instance)
 		       in
 		       let (loc, mid) = get_id loc_mid in
 			 List.iter (fun (n, _, x) -> 
-				      if Name.equal n (Name mid) then
+                                      if Name.equal n Name.(Name mid) then
 					Option.iter (fun x -> Dumpglob.add_glob ?loc (ConstRef x)) x)
 			   k.cl_projs;
 			 c :: props, rest'
@@ -351,7 +351,7 @@ let named_of_rel_context l =
   let acc, ctx =
     List.fold_right
       (fun decl (subst, ctx) ->
-        let id = match RelDecl.get_name decl with Anonymous -> invalid_arg "named_of_rel_context" | Name id -> id in
+        let id = match RelDecl.get_name decl with Name.Anonymous -> invalid_arg "named_of_rel_context" | Name.Name id -> id in
 	let d = match decl with
 	  | LocalAssum (_,t) -> id, None, substl subst t
 	  | LocalDef (_,b,t) -> id, Some (substl subst b), substl subst t in

--- a/vernac/comFixpoint.ml
+++ b/vernac/comFixpoint.ml
@@ -129,7 +129,7 @@ let build_fix_type (_,ctx) ccl = EConstr.it_mkProd_or_LetIn ccl ctx
 
 let prepare_recursive_declaration fixnames fixtypes fixdefs =
   let defs = List.map (subst_vars (List.rev fixnames)) fixdefs in
-  let names = List.map (fun id -> Name id) fixnames in
+  let names = List.map (fun id -> Name.Name id) fixnames in
   (Array.of_list names, Array.of_list fixtypes, Array.of_list defs)
 
 (* Jump over let-bindings. *)

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -51,7 +51,7 @@ let rec complete_conclusion a cs = CAst.map_with_loc (fun ?loc -> function
   )
 
 let push_types env idl tl =
-  List.fold_left2 (fun env id t -> Environ.push_rel (LocalAssum (Name id,t)) env)
+  List.fold_left2 (fun env id t -> Environ.push_rel (LocalAssum (Name.Name id,t)) env)
     env idl tl
 
 type structured_one_inductive_expr = {
@@ -170,7 +170,7 @@ let sup_list min = List.fold_left Univ.sup min
 let extract_level env evd min tys =
   let sorts = List.map (fun ty ->
     let ctx, concl = Reduction.dest_prod_assum env ty in
-      sign_level env evd (LocalAssum (Anonymous, concl) :: ctx)) tys
+      sign_level env evd (LocalAssum (Name.Anonymous, concl) :: ctx)) tys
   in sup_list min sorts
 
 let is_flexible_sort evd u =
@@ -250,8 +250,8 @@ let inductive_levels env evd poly arities inds =
   in evd, List.rev arities
 
 let check_named (loc, na) = match na with
-| Name _ -> ()
-| Anonymous ->
+| Name.Name _ -> ()
+| Name.Anonymous ->
   let msg = str "Parameters must be named." in
   user_err ?loc  msg
 

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -157,8 +157,8 @@ let pr_explicit env sigma t1 t2 =
 let pr_db env i =
   try
     match env |> lookup_rel i |> get_name with
-      | Name id -> Id.print id
-      | Anonymous -> str "<>"
+      | Name.Name id -> Id.print id
+      | Name.Anonymous -> str "<>"
   with Not_found -> str "UNBOUND_REL_" ++ int i
 
 let explain_unbound_rel env sigma n =
@@ -413,8 +413,8 @@ let explain_ill_formed_rec_body env sigma err names i fixenv vdefj =
   let pr_lconstr_env env sigma c = pr_leconstr_env env sigma c in
   let prt_name i =
     match names.(i) with
-        Name id -> str "Recursive definition of " ++ Id.print id
-      | Anonymous -> str "The " ++ pr_nth i ++ str " definition" in
+        Name.Name id -> str "Recursive definition of " ++ Id.print id
+      | Name.Anonymous -> str "The " ++ pr_nth i ++ str " definition" in
 
   let st = match err with
 
@@ -428,8 +428,8 @@ let explain_ill_formed_rec_body env sigma err names i fixenv vdefj =
       let arg_env = make_all_name_different arg_env sigma in
       let called =
         match names.(j) with
-            Name id -> Id.print id
-          | Anonymous -> str "the " ++ pr_nth i ++ str " definition" in
+            Name.Name id -> Id.print id
+          | Name.Anonymous -> str "the " ++ pr_nth i ++ str " definition" in
       let pr_db x = quote (pr_db env x) in
       let vars =
         match (lt,le) with
@@ -448,8 +448,8 @@ let explain_ill_formed_rec_body env sigma err names i fixenv vdefj =
   | NotEnoughArgumentsForFixCall j ->
       let called =
         match names.(j) with
-            Name id -> Id.print id
-          | Anonymous -> str "the " ++ pr_nth i ++ str " definition" in
+            Name.Name id -> Id.print id
+          | Name.Anonymous -> str "the " ++ pr_nth i ++ str " definition" in
      str "Recursive call to " ++ called ++ str " has not enough arguments"
 
   (* CoFixpoint guard errors *)
@@ -534,9 +534,9 @@ let rec explain_evar_kind env sigma evk ty = function
   | Evar_kinds.CasesType true ->
       strbrk "a subterm of type " ++ ty ++
       strbrk " in the type of this pattern-matching problem"
-  | Evar_kinds.BinderType (Name id) ->
+  | Evar_kinds.BinderType (Name.Name id) ->
       strbrk "the type of " ++ Id.print id
-  | Evar_kinds.BinderType Anonymous ->
+  | Evar_kinds.BinderType Name.Anonymous ->
       strbrk "the type of this anonymous binder"
   | Evar_kinds.ImplicitArg (c,(n,ido),b) ->
       let id = Option.get ido in
@@ -658,7 +658,7 @@ let explain_wrong_abstraction_type env sigma na abs expected result =
   let abs = EConstr.to_constr sigma abs in
   let expected = EConstr.to_constr sigma expected in
   let result = EConstr.to_constr sigma result in
-  let ppname = match na with Name id -> Id.print id ++ spc () | _ -> mt () in
+  let ppname = match na with Name.Name id -> Id.print id ++ spc () | _ -> mt () in
   str "Cannot instantiate metavariable " ++ ppname ++ strbrk "of type " ++
   pr_lconstr_env env sigma expected ++ strbrk " with abstraction " ++
   pr_lconstr_env env sigma abs ++ strbrk " of incompatible type " ++
@@ -867,7 +867,7 @@ let explain_not_match_error = function
   | RecordProjectionsExpected nal ->
     (if List.length nal >= 2 then str "expected projection names are "
      else str "expected projection name is ") ++
-    pr_enum (function Name id -> Id.print id | _ -> str "_") nal
+    pr_enum (function Name.Name id -> Id.print id | _ -> str "_") nal
   | NotEqualInductiveAliases ->
     str "Aliases to inductive types do not match"
   | NoTypeConstraintExpected ->

--- a/vernac/lemmas.ml
+++ b/vernac/lemmas.ml
@@ -389,8 +389,8 @@ let rec_tac_initializer finite guard thms snl =
 let start_proof_with_initialization kind sigma decl recguard thms snl hook =
   let intro_tac (_, (_, (ids, _))) =
     Tacticals.New.tclMAP (function
-    | Name id -> Tactics.intro_mustbe_force id
-    | Anonymous -> Tactics.intro) (List.rev ids) in
+    | Name.Name id -> Tactics.intro_mustbe_force id
+    | Name.Anonymous -> Tactics.intro) (List.rev ids) in
   let init_tac,guard = match recguard with
   | Some (finite,guard,init_tac) ->
       let rec_tac = rec_tac_initializer finite guard thms snl in

--- a/vernac/obligations.ml
+++ b/vernac/obligations.ml
@@ -492,7 +492,7 @@ let declare_definition prg =
 
 let rec lam_index n t acc =
   match Constr.kind t with
-    | Lambda (Name n', _, _) when Id.equal n n' ->
+    | Lambda (Name.Name n', _, _) when Id.equal n n' ->
       acc
     | Lambda (_, _, b) ->
 	lam_index n b (succ acc)
@@ -529,7 +529,7 @@ let declare_mutual_definition l =
 (*   let fixdefs = List.map reduce_fix fixdefs in *)
   let fixkind = Option.get first.prg_fixkind in
   let arrrec, recvec = Array.of_list fixtypes, Array.of_list fixdefs in
-  let fixdecls = (Array.of_list (List.map (fun x -> Name x.prg_name) l), arrrec, recvec) in
+  let fixdecls = (Array.of_list (List.map (fun x -> Name.Name x.prg_name) l), arrrec, recvec) in
   let (local,poly,kind) = first.prg_kind in
   let fixnames = first.prg_deps in
   let opaque = first.prg_opaque in


### PR DESCRIPTION
Unfortunately OCaml doesn't deprecate the constructors of a type when
the type alias is deprecated.