### PR TITLE
Let dtauto recognize '@sigT A (fun _ => B)' as a conjunction.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -40,6 +40,8 @@ Tactics
 - Added tactic optimize_heap, analogous to the Vernacular Optimize
   Heap, which performs a major garbage collection and heap compaction
   in the OCaml run-time system.
+- The tactic "dtauto" now handles some inductives such as
+  "@sigT A (fun _ => B)" as non-dependent conjunctions.
 
 Vernacular Commands
 

--- a/tactics/hipattern.ml
+++ b/tactics/hipattern.ml
@@ -88,6 +88,12 @@ let is_lax_conjunction = function
 
 let prod_assum sigma t = fst (decompose_prod_assum sigma t)
 
+(* whd_beta normalize the types of arguments in a product *)
+let rec whd_beta_prod sigma c = match EConstr.kind sigma c with
+  | Prod (n,t,c) -> mkProd (n,Reductionops.whd_beta sigma t,whd_beta_prod sigma c)
+  | LetIn (n,d,t,c) -> mkLetIn (n,d,t,whd_beta_prod sigma c)
+  | _ -> c
+
 let match_with_one_constructor sigma style onlybinary allow_rec t =
   let (hdapp,args) = decompose_app sigma t in
   let res = match EConstr.kind sigma hdapp with
@@ -111,7 +117,8 @@ let match_with_one_constructor sigma style onlybinary allow_rec t =
 	    Some (hdapp,args)
 	  else None
 	else
-	  let ctyp = Termops.prod_applist sigma (EConstr.of_constr mip.mind_nf_lc.(0)) args in
+          let ctyp = whd_beta_prod sigma
+            (Termops.prod_applist sigma (EConstr.of_constr mip.mind_nf_lc.(0)) args) in
 	  let cargs = List.map RelDecl.get_type (prod_assum sigma ctyp) in
 	  if not (is_lax_conjunction style) || has_nodep_prod sigma ctyp then
 	    (* Record or non strict conjunction *)

--- a/test-suite/bugs/opened/6393.v
+++ b/test-suite/bugs/opened/6393.v
@@ -1,0 +1,11 @@
+(* These always worked. *)
+Goal prod True True. firstorder. Qed.
+Goal True -> @sigT True (fun _ => True). firstorder. Qed.
+Goal prod True True. dtauto. Qed.
+Goal prod True True. tauto. Qed.
+
+(* These should work. *)
+Goal @sigT True (fun _ => True). dtauto. Qed.
+(* These should work, but don't *)
+(* Goal @sigT True (fun _ => True). firstorder. Qed. *)
+(* Goal @sigT True (fun _ => True). tauto. Qed. *)


### PR DESCRIPTION
This beta-normalizes before checking the type of the constructor in `match_with_one_constructor` in `hipattern`. (so `forall (a : A) (b : (fun _ => B) a), @sigT A (fun _ => B)` reduces to
`A -> B -> @sigT A (fun _ => B)`, which has no dependent products).

This allows `dtauto` to recognize `@sigT A (fun _ => B)` as a conjunction.

A benchmark may be warranted to determine how this affects performance.

I plan on a separate pair of PRs to
1. rework `has_nodep_prod` (improving performance and making way for 2).
2. add `whd_beta` reduction to `has_nodep_prod`, which would supersede this PR.

See #6393 for the original issue.