### PR TITLE
Sanitize universe declaration in Context (stop using a ref...)

### DIFF
--- a/test-suite/bugs/closed/2245.v
+++ b/test-suite/bugs/closed/2245.v
@@ -1,0 +1,11 @@
+Module Type Test.
+
+Section Sec.
+Variables (A:Type).
+Context (B:Type).
+End Sec.
+
+Fail Check B. (* used to be found !!! *)
+Fail Check A.
+
+End Test.


### PR DESCRIPTION
When there is more than one variable to declare we stop trying to
attach global universes (ie monomorphic or section polymorphic) to one
of them.

Add a test for #2245 since it was caused by this part of the code back then.