### PR TITLE
No universe constraints in Let definitions

### DIFF
--- a/interp/declare.ml
+++ b/interp/declare.ml
@@ -231,7 +231,15 @@ let cache_variable ((sp,_),o) =
     | SectionLocalDef (de) ->
       let (de, eff) = Global.export_private_constants ~in_section:true de in
       let () = List.iter register_side_effect eff in
-      let univs = Global.push_named_def (id,de) in
+      let body = Future.chain de.const_entry_body (fun (body, ()) -> body) in
+      let se = {
+        secdef_body = body;
+        secdef_secctx = de.const_entry_secctx;
+        secdef_universes = de.const_entry_universes;
+        secdef_feedback = de.const_entry_feedback;
+        secdef_type = de.const_entry_type;
+      } in
+      let univs = Global.push_named_def (id, se) in
       let poly = match de.const_entry_universes with
       | Monomorphic_const_entry _ -> false
       | Polymorphic_const_entry _ -> true

--- a/kernel/entries.ml
+++ b/kernel/entries.ml
@@ -82,11 +82,10 @@ type 'a definition_entry = {
   const_entry_inline_code : bool }
 
 type section_def_entry = {
-  secdef_body : constr Univ.in_universe_context_set Future.computation;
+  secdef_body : constr;
   secdef_secctx : Context.Named.t option;
   secdef_feedback : Stateid.t option;
   secdef_type : types option;
-  secdef_universes : constant_universes_entry;
 }
 
 type inline = int option (* inlining level, None for no inlining *)

--- a/kernel/entries.ml
+++ b/kernel/entries.ml
@@ -81,6 +81,14 @@ type 'a definition_entry = {
   const_entry_opaque      : bool;
   const_entry_inline_code : bool }
 
+type section_def_entry = {
+  secdef_body : constr Univ.in_universe_context_set Future.computation;
+  secdef_secctx : Context.Named.t option;
+  secdef_feedback : Stateid.t option;
+  secdef_type : types option;
+  secdef_universes : constant_universes_entry;
+}
+
 type inline = int option (* inlining level, None for no inlining *)
 
 type parameter_entry = 

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -384,7 +384,7 @@ let safe_push_named d env =
 let push_named_def (id,de) senv =
   let open Entries in
   let c,typ,univs = Term_typing.translate_local_def senv.env id de in
-  let poly = match de.Entries.const_entry_universes with
+  let poly = match de.Entries.secdef_universes with
   | Monomorphic_const_entry _ -> false
   | Polymorphic_const_entry _ -> true
   in

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -383,8 +383,7 @@ let safe_push_named d env =
 
 let push_named_def (id,de) senv =
   let open Entries in
-  let trust = Term_typing.SideEffects senv.revstruct in
-  let c,typ,univs = Term_typing.translate_local_def trust senv.env id de in
+  let c,typ,univs = Term_typing.translate_local_def senv.env id de in
   let poly = match de.Entries.const_entry_universes with
   | Monomorphic_const_entry _ -> false
   | Polymorphic_const_entry _ -> true

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -382,22 +382,9 @@ let safe_push_named d env =
 
 
 let push_named_def (id,de) senv =
-  let open Entries in
-  let c,typ,univs = Term_typing.translate_local_def senv.env id de in
-  let poly = match de.Entries.secdef_universes with
-  | Monomorphic_const_entry _ -> false
-  | Polymorphic_const_entry _ -> true
-  in
-  let c, univs = match c with
-    | Def c -> Mod_subst.force_constr c, univs
-    | OpaqueDef o ->
-        Opaqueproof.force_proof (Environ.opaque_tables senv.env) o,
-        Univ.ContextSet.union univs 
-	(Opaqueproof.force_constraints (Environ.opaque_tables senv.env) o)
-    | _ -> assert false in
-  let senv' = push_context_set poly univs senv in
-  let env'' = safe_push_named (LocalDef (id,c,typ)) senv'.env in
-    univs, {senv' with env=env''}
+  let c, typ = Term_typing.translate_local_def senv.env id de in
+  let env'' = safe_push_named (LocalDef (id, c, typ)) senv.env in
+  { senv with env = env'' }
 
 let push_named_assum ((id,t,poly),ctx) senv =
   let senv' = push_context_set poly ctx senv in

--- a/kernel/safe_typing.mli
+++ b/kernel/safe_typing.mli
@@ -90,7 +90,7 @@ val push_named_assum :
 (** Returns the full universe context necessary to typecheck the definition
   (futures are forced) *)
 val push_named_def :
-  Id.t * Entries.section_def_entry -> Univ.ContextSet.t safe_transformer
+  Id.t * Entries.section_def_entry -> safe_transformer0
 
 (** Insertion of global axioms or definitions *)
 

--- a/kernel/safe_typing.mli
+++ b/kernel/safe_typing.mli
@@ -90,7 +90,7 @@ val push_named_assum :
 (** Returns the full universe context necessary to typecheck the definition
   (futures are forced) *)
 val push_named_def :
-  Id.t * private_constants Entries.definition_entry -> Univ.ContextSet.t safe_transformer
+  Id.t * unit Entries.definition_entry -> Univ.ContextSet.t safe_transformer
 
 (** Insertion of global axioms or definitions *)
 
@@ -106,8 +106,8 @@ type exported_private_constant =
   Constant.t * private_constant_role
 
 val export_private_constants : in_section:bool ->
-  private_constants Entries.constant_entry ->
-  (unit Entries.constant_entry * exported_private_constant list) safe_transformer
+  private_constants Entries.definition_entry ->
+  (unit Entries.definition_entry * exported_private_constant list) safe_transformer
 
 (** returns the main constant plus a list of auxiliary constants (empty
     unless one requires the side effects to be exported) *)

--- a/kernel/safe_typing.mli
+++ b/kernel/safe_typing.mli
@@ -90,7 +90,7 @@ val push_named_assum :
 (** Returns the full universe context necessary to typecheck the definition
   (futures are forced) *)
 val push_named_def :
-  Id.t * unit Entries.definition_entry -> Univ.ContextSet.t safe_transformer
+  Id.t * Entries.section_def_entry -> Univ.ContextSet.t safe_transformer
 
 (** Insertion of global axioms or definitions *)
 

--- a/kernel/term_typing.ml
+++ b/kernel/term_typing.ml
@@ -533,14 +533,10 @@ type side_effect_role =
 type exported_side_effect = 
   Constant.t * constant_body * side_effect_role
 
-let export_side_effects mb env ce =
-  match ce with
-  | ParameterEntry e -> [], ParameterEntry e
-  | ProjectionEntry e -> [], ProjectionEntry e
-  | DefinitionEntry c ->
+let export_side_effects mb env c =
       let { const_entry_body = body } = c in
       let _, eff = Future.force body in
-      let ce = DefinitionEntry { c with
+      let ce = { c with
         const_entry_body = Future.chain body
           (fun (b_ctx, _) -> b_ctx, ()) } in
       let not_exists (c,_,_,_) =
@@ -609,9 +605,9 @@ let translate_recipe env kn r =
   let hcons = DirPath.is_empty dir in
   build_constant_declaration kn env (Cooking.cook_constant ~hcons env r)
 
-let translate_local_def mb env id centry =
+let translate_local_def env id centry =
   let open Cooking in
-  let decl = infer_declaration ~trust:mb env None (DefinitionEntry centry) in
+  let decl = infer_declaration ~trust:Pure env None (DefinitionEntry centry) in
   let typ = decl.cook_type in
   if Option.is_empty decl.cook_context && !Flags.record_aux_file then begin
     match decl.cook_body with

--- a/kernel/term_typing.ml
+++ b/kernel/term_typing.ml
@@ -607,6 +607,16 @@ let translate_recipe env kn r =
 
 let translate_local_def env id centry =
   let open Cooking in
+  let body = Future.chain centry.secdef_body (fun body -> body, ()) in
+  let centry = {
+    const_entry_body = body;
+    const_entry_secctx = centry.secdef_secctx;
+    const_entry_feedback = centry.secdef_feedback;
+    const_entry_type = centry.secdef_type;
+    const_entry_universes = centry.secdef_universes;
+    const_entry_opaque = false;
+    const_entry_inline_code = false;
+  } in
   let decl = infer_declaration ~trust:Pure env None (DefinitionEntry centry) in
   let typ = decl.cook_type in
   if Option.is_empty decl.cook_context && !Flags.record_aux_file then begin

--- a/kernel/term_typing.mli
+++ b/kernel/term_typing.mli
@@ -19,7 +19,7 @@ type _ trust =
 | SideEffects : structure_body -> side_effects trust
 
 val translate_local_def : env -> Id.t -> section_def_entry ->
-  constant_def * types * Univ.ContextSet.t
+  constr * types
 
 val translate_local_assum : env -> types -> types
 
@@ -72,7 +72,7 @@ val translate_recipe : env -> Constant.t -> Cooking.recipe -> constant_body
 
 (** Internal functions, mentioned here for debug purpose only *)
 
-val infer_declaration : trust:'a trust -> env -> Constant.t option -> 
+val infer_declaration : trust:'a trust -> env ->
   'a constant_entry -> Cooking.result
 
 val build_constant_declaration :

--- a/kernel/term_typing.mli
+++ b/kernel/term_typing.mli
@@ -18,7 +18,7 @@ type _ trust =
 | Pure : unit trust
 | SideEffects : structure_body -> side_effects trust
 
-val translate_local_def : env -> Id.t -> unit definition_entry ->
+val translate_local_def : env -> Id.t -> section_def_entry ->
   constant_def * types * Univ.ContextSet.t
 
 val translate_local_assum : env -> types -> types

--- a/kernel/term_typing.mli
+++ b/kernel/term_typing.mli
@@ -18,7 +18,7 @@ type _ trust =
 | Pure : unit trust
 | SideEffects : structure_body -> side_effects trust
 
-val translate_local_def : 'a trust -> env -> Id.t -> 'a definition_entry ->
+val translate_local_def : env -> Id.t -> unit definition_entry ->
   constant_def * types * Univ.ContextSet.t
 
 val translate_local_assum : env -> types -> types
@@ -62,8 +62,8 @@ type exported_side_effect =
  * be pushed in the safe_env by safe typing.  The main constant entry
  * needs to be translated as usual after this step. *)
 val export_side_effects :
-  structure_body -> env -> side_effects constant_entry ->
-    exported_side_effect list * unit constant_entry
+  structure_body -> env -> side_effects definition_entry ->
+    exported_side_effect list * unit definition_entry
 
 val translate_mind :
   env -> MutInd.t -> mutual_inductive_entry -> mutual_inductive_body

--- a/library/global.ml
+++ b/library/global.ml
@@ -81,7 +81,7 @@ let globalize_with_summary fs f =
 let i2l = Label.of_id
 
 let push_named_assum a = globalize0 (Safe_typing.push_named_assum a)
-let push_named_def d = globalize (Safe_typing.push_named_def d)
+let push_named_def d = globalize0 (Safe_typing.push_named_def d)
 let add_constraints c = globalize0 (Safe_typing.add_constraints c)
 let push_context_set b c = globalize0 (Safe_typing.push_context_set b c)
 let push_context b c = globalize0 (Safe_typing.push_context b c)

--- a/library/global.mli
+++ b/library/global.mli
@@ -32,11 +32,11 @@ val set_typing_flags : Declarations.typing_flags -> unit
 (** Variables, Local definitions, constants, inductive types *)
 
 val push_named_assum : (Id.t * Constr.types * bool) Univ.in_universe_context_set -> unit
-val push_named_def   : (Id.t * Safe_typing.private_constants Entries.definition_entry) -> Univ.ContextSet.t
+val push_named_def   : (Id.t * unit Entries.definition_entry) -> Univ.ContextSet.t
 
 val export_private_constants : in_section:bool ->
-  Safe_typing.private_constants Entries.constant_entry ->
-  unit Entries.constant_entry * Safe_typing.exported_private_constant list
+  Safe_typing.private_constants Entries.definition_entry ->
+  unit Entries.definition_entry * Safe_typing.exported_private_constant list
 
 val add_constant :
   DirPath.t -> Id.t -> Safe_typing.global_declaration -> Constant.t

--- a/library/global.mli
+++ b/library/global.mli
@@ -32,7 +32,7 @@ val set_typing_flags : Declarations.typing_flags -> unit
 (** Variables, Local definitions, constants, inductive types *)
 
 val push_named_assum : (Id.t * Constr.types * bool) Univ.in_universe_context_set -> unit
-val push_named_def   : (Id.t * unit Entries.definition_entry) -> Univ.ContextSet.t
+val push_named_def   : (Id.t * Entries.section_def_entry) -> Univ.ContextSet.t
 
 val export_private_constants : in_section:bool ->
   Safe_typing.private_constants Entries.definition_entry ->

--- a/library/global.mli
+++ b/library/global.mli
@@ -32,7 +32,7 @@ val set_typing_flags : Declarations.typing_flags -> unit
 (** Variables, Local definitions, constants, inductive types *)
 
 val push_named_assum : (Id.t * Constr.types * bool) Univ.in_universe_context_set -> unit
-val push_named_def   : (Id.t * Entries.section_def_entry) -> Univ.ContextSet.t
+val push_named_def   : (Id.t * Entries.section_def_entry) -> unit
 
 val export_private_constants : in_section:bool ->
   Safe_typing.private_constants Entries.definition_entry ->


### PR DESCRIPTION
Let definitions do not create new universe constraints.

We force the upper layers to extrude the universe constraints before sending them to the kernel. This simplifies the suspicious handling of polymorphic constraints for section-local definitions.

This PR depends on #6449.