### PR TITLE
Apply whd_beta before checking dependencies in dtauto

### DIFF
--- a/tactics/hipattern.ml
+++ b/tactics/hipattern.ml
@@ -64,10 +64,13 @@ let is_non_recursive_type sigma t = op2bool (match_with_non_recursive_type sigma
 
 let rec has_nodep_prod_after n sigma c =
   match EConstr.kind sigma c with
-    | Prod (_,_,b) | LetIn (_,_,_,b) ->
-	( n>0 || Vars.noccurn sigma 1 b)
-	&& (has_nodep_prod_after (n-1) sigma b)
-    | _            -> true
+  | Prod (_,t,c) ->
+     (n>=0 || Vars.noccur_between sigma 1 (-n) t)
+     && (has_nodep_prod_after (n-1) sigma c)
+  | LetIn (_,b,t,c) ->
+     (n>=0 || (Vars.noccur_between sigma 1 (-n) b && Vars.noccur_between sigma 1 (-n) t))
+     && (has_nodep_prod_after (n-1) sigma c)
+  | _ -> n>=0 || Vars.noccur_between sigma 1 (-n) c
 
 let has_nodep_prod sigma c = has_nodep_prod_after 0 sigma c
 

--- a/tactics/hipattern.ml
+++ b/tactics/hipattern.ml
@@ -61,16 +61,16 @@ let is_non_recursive_type sigma t = op2bool (match_with_non_recursive_type sigma
 
 (* NB: we consider also the let-in case in the following function,
    since they may appear in types of inductive constructors (see #2629) *)
-
+let noccur_after sigma n t = n >= 0 || Vars.noccur_between sigma 1 (-n) (Reductionops.whd_beta sigma t)
 let rec has_nodep_prod_after n sigma c =
   match EConstr.kind sigma c with
   | Prod (_,t,c) ->
-     (n>=0 || Vars.noccur_between sigma 1 (-n) t)
-     && (has_nodep_prod_after (n-1) sigma c)
+     noccur_after sigma n t
+     && has_nodep_prod_after (n-1) sigma c
   | LetIn (_,b,t,c) ->
-     (n>=0 || (Vars.noccur_between sigma 1 (-n) b && Vars.noccur_between sigma 1 (-n) t))
-     && (has_nodep_prod_after (n-1) sigma c)
-  | _ -> n>=0 || Vars.noccur_between sigma 1 (-n) c
+     noccur_after sigma n b && noccur_after sigma n t
+     && has_nodep_prod_after (n-1) sigma c
+  | _ -> noccur_after sigma n c
 
 let has_nodep_prod sigma c = has_nodep_prod_after 0 sigma c
 

--- a/test-suite/bugs/opened/6393.v
+++ b/test-suite/bugs/opened/6393.v
@@ -1,0 +1,11 @@
+(* These always worked. *)
+Goal prod True True. firstorder. Qed.
+Goal True -> @sigT True (fun _ => True). firstorder. Qed.
+Goal prod True True. dtauto. Qed.
+Goal prod True True. tauto. Qed.
+
+(* These should work. *)
+Goal @sigT True (fun _ => True). dtauto. Qed.
+(* These should work, but don't *)
+(* Goal @sigT True (fun _ => True). firstorder. Qed. *)
+(* Goal @sigT True (fun _ => True). tauto. Qed. *)


### PR DESCRIPTION
Original issue #6393.

I rewrote `has_nodep_prod_after` to only perform one pass over the term being checked, and to
`whd_beta` reduce the types of arguments before checking for dependencies on previous arguments.
(c.f. my other PR which used `nf_beta`).

In #6461, @SkySkimmer said that the returned args from `match_with_one_constructor` should
also be beta reduced. This PR currently does not do so, such reduction could be done simply by
a `List.map whd_beta` or by having `has_nodep_prod` return the list of normalized args
(note that `prod_assum` runs the exact same loop as `has_nodep_prod`).

This should be faster than the other PR, but the little testing I did suggests this is
way off any performance-critical path. Also:
* The rewritten `has_nodep_prod_after` is harder to understand.
* If we want to strengthen the normalization to a full normal form (not head-normal), then
  we may as well normalize the whole type once at the beginning.
* In this approach, I don't see how to reduce let-ins in the middle of the type, as suggested in #2629.

My opinion is that #6461 is a better approach, but I wanted to share this version for comparison.