### PR TITLE
Simplify ci-unimath.sh

### DIFF
--- a/dev/ci/ci-unimath.sh
+++ b/dev/ci/ci-unimath.sh
@@ -1,14 +1,13 @@
 #!/usr/bin/env bash
 
-ci_dir="$(dirname "$0")"
-source ${ci_dir}/ci-common.sh
+ci_dir=$(dirname "$0") &&
+. "${ci_dir}"/ci-common.sh &&
 
-UniMath_CI_DIR=${CI_BUILD_DIR}/UniMath
+UniMath_CI_DIR=${CI_BUILD_DIR}/UniMath &&
 
-git_checkout ${UniMath_CI_BRANCH} ${UniMath_CI_GITURL} ${UniMath_CI_DIR}
+git_checkout "${UniMath_CI_BRANCH}" "${UniMath_CI_GITURL}" "${UniMath_CI_DIR}" &&
 
-( cd ${UniMath_CI_DIR}                        && \
-  sed -i.bak '/Folds/d'              Makefile && \
-  sed -i.bak '/HomologicalAlgebra/d' Makefile && \
-  make BUILD_COQ=no )
+(cd "${UniMath_CI_DIR}"                        && \
+  sed -i.bak '/Folds/d;/HomologicalAlgebra/d' Makefile && \
+  make BUILD_COQ=no)
 


### PR DESCRIPTION
- Do not silently fail
- Quote when needed and not when it is not needed
- I have no idea why a sub-shell is created in the script. Without a comment with a reason, it's probably wrong.