### PR TITLE
Provide an option to drop vio state.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -63,6 +63,13 @@ Documentation
   moved to the GitHub wiki section of this repository; the main entry
   page is https://github.com/coq/coq/wiki/The-Coq-FAQ.
 
+Tools
+
+- A new coqtop option -quick-light and the corresponding Makefile target
+  quick-light that behaves as -quick except that the data necessary to rebuild
+  the proofs is not stored on disk. This generates way smaller object files, but
+  prevents compiling them to a vo file later.
+
 Changes from 8.7.0 to 8.7.1
 ===========================
 

--- a/doc/refman/AsyncProofs.tex
+++ b/doc/refman/AsyncProofs.tex
@@ -150,6 +150,11 @@ when using a \texttt{Makefile} produced by \texttt{coq\_makefile}, the
 \texttt{quick} target can be used to compile all files using the
 \texttt{-quick} flag.
 
+A variant \texttt{-quick-light} flag is also available. It behaves as the
+\texttt{-quick} flag, except that proof data is not stored on disk. This
+produces a \texttt{.vio} file that is substantially smaller, but that cannot
+be compiled into a \texttt{.vo} file nor checked (see below).
+
 A \texttt{.vio} file can be loaded using \texttt{Require} exactly as a
 \texttt{.vo} file but proofs will not be available (the \texttt{Print}
 command produces an error). Moreover, some universe constraints might be

--- a/library/library.mli
+++ b/library/library.mli
@@ -44,6 +44,7 @@ val start_library : CUnix.physical_path -> DirPath.t
 
 (** End the compilation of a library and save it to a ".vo" file *)
 val save_library_to :
+  ?light:bool ->
   ?todo:(((Future.UUID.t,'document) Stateid.request * bool) list * 'counters) ->
   DirPath.t -> string -> Opaqueproof.opaquetab -> unit
 

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -2680,11 +2680,11 @@ let handle_failure (e, info) vcs =
       VCS.print ();
       Exninfo.iraise (e, info)
 
-let snapshot_vio ~doc ldir long_f_dot_vo =
+let snapshot_vio ~light ~doc ldir long_f_dot_vo =
   let doc = finish ~doc in
   if List.length (VCS.branches ()) > 1 then
     CErrors.user_err ~hdr:"stm" (str"Cannot dump a vio with open proofs");
-  Library.save_library_to ~todo:(dump_snapshot ()) ldir long_f_dot_vo
+  Library.save_library_to ~light ~todo:(dump_snapshot ()) ldir long_f_dot_vo
     (Global.opaque_tables ());
   doc
 

--- a/stm/stm.mli
+++ b/stm/stm.mli
@@ -92,7 +92,7 @@ val join : doc:doc -> doc
    - if the worker proof is not empty, then it waits until all workers
      are done with their current jobs and then dumps (or fails if one
      of the completed tasks is a failure) *)
-val snapshot_vio : doc:doc -> DirPath.t -> string -> doc
+val snapshot_vio : light:bool -> doc:doc -> DirPath.t -> string -> doc
 
 (* Empties the task queue, can be used only if the worker pool is empty (E.g.
  * after having built a .vio in batch mode *)

--- a/tools/CoqMakefile.in
+++ b/tools/CoqMakefile.in
@@ -380,8 +380,13 @@ optfiles: $(if $(DO_NATDYNLINK),$(CMXSFILES))
 .PHONY: optfiles
 
 # FIXME, see Ralph's bugreport
+quick: COQQUICK := -quick
 quick: $(VOFILES:.vo=.vio)
 .PHONY: quick
+
+quick-light: COQQUICK := -quick-light
+quick-light: $(VOFILES:.vo=.vio)
+.PHONY: quick-light
 
 vio2vo:
 	$(TIMER) $(COQC) $(COQDEBUG) $(COQFLAGS) \
@@ -649,8 +654,8 @@ $(GLOBFILES): %.glob: %.v
 	$(TIMER) $(COQC) $(COQDEBUG) $(COQFLAGS) $<
 
 $(VFILES:.v=.vio): %.vio: %.v
-	$(SHOW)COQC -quick $<
-	$(HIDE)$(TIMER) $(COQC) -quick $(COQDEBUG) $(COQFLAGS) $<
+	$(SHOW)COQC $(COQQUICK) $<
+	$(HIDE)$(TIMER) $(COQC) $(COQQUICK) $(COQDEBUG) $(COQFLAGS) $<
 
 $(addsuffix .timing.diff,$(VFILES)): %.timing.diff : %.before-timing %.after-timing
 	$(SHOW)PYTHON TIMING-DIFF $<

--- a/tools/coqc.ml
+++ b/tools/coqc.ml
@@ -96,7 +96,7 @@ let parse_args () =
       |"-q"|"-profile"|"-echo" |"-quiet"
       |"-silent"|"-m"|"-beautify"|"-strict-implicit"
       |"-impredicative-set"|"-vm"|"-native-compiler"
-      |"-indices-matter"|"-quick"|"-type-in-type"
+      |"-indices-matter"|"-quick"|"-quick-light"|"-type-in-type"
       |"-async-proofs-always-delegate"|"-async-proofs-never-reopen-branch"
       |"-stm-debug"
       as o) :: rem ->

--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -228,7 +228,7 @@ let glob_opt = ref false
 
 let compile_list = ref ([] : (bool * string) list)
 
-type compilation_mode = BuildVo | BuildVio | Vio2Vo
+type compilation_mode = BuildVo | BuildVio of bool | Vio2Vo
 let compilation_mode = ref BuildVo
 let compilation_output_name = ref None
 
@@ -334,7 +334,7 @@ let compile ~verbosely ~f_in ~f_out =
       Aux_file.stop_aux_file ();
       Dumpglob.end_dump_glob ()
 
-  | BuildVio ->
+  | BuildVio light ->
       Flags.record_aux_file := false;
       Dumpglob.noglob ();
 
@@ -357,7 +357,7 @@ let compile ~verbosely ~f_in ~f_out =
       let doc, _ = Vernac.load_vernac ~verbosely ~check:false ~interactive:false doc (Stm.get_current_state ~doc) long_f_dot_v in
       let doc = Stm.finish ~doc in
       check_pending_proofs ();
-      let _doc = Stm.snapshot_vio ~doc ldir long_f_dot_vio in
+      let _doc = Stm.snapshot_vio ~light ~doc ldir long_f_dot_vio in
       Stm.reset_task_queue ()
 
   | Vio2Vo ->
@@ -734,7 +734,8 @@ let parse_args arglist =
     |"-profile-ltac" -> Flags.profile_ltac := true
     |"-q" -> Coqinit.no_load_rc ()
     |"-quiet"|"-silent" -> Flags.quiet := true; Flags.make_warn false
-    |"-quick" -> compilation_mode := BuildVio
+    |"-quick" -> compilation_mode := BuildVio false
+    |"-quick-light" -> compilation_mode := BuildVio true
     |"-list-tags" -> print_tags := true
     |"-time" -> Flags.time := true
     |"-type-in-type" -> set_type_in_type ()

--- a/toplevel/usage.ml
+++ b/toplevel/usage.ml
@@ -49,6 +49,7 @@ let print_usage_channel co command =
 \n  -compile-verbose f.v   verbosely compile Coq file f.v (implies -batch)\
 \n  -o f.vo                use f.vo as the output file name\
 \n  -quick                 quickly compile .v files to .vio files (skip proofs)\
+\n  -quick-light           same as -quick but does not store proof tasks\
 \n  -schedule-vio2vo j f1..fn   run up to j instances of Coq to turn each fi.vio\
 \n                         into fi.vo\
 \n  -schedule-vio-checking j f1..fn   run up to j instances of Coq to check all\


### PR DESCRIPTION
This forbids turning such vio files into vo files, but at the same time it drastically reduces the amount of memory they need on disk.

This feature is accessible using `-quick-light` in `coqtop` and `coqc`, and there is a `quick-light` target in the `coq_makefile`. It has been asked repeatedly, amongst others by @charguer.

Currently, checking or compiling such a vio silently fails, but it is unrelated to this PR. It seems that any failure in vio compilation is caught at some point in the code, so this probably deserves a separate bug report.
