### PR TITLE
Allow Prop as source for coercions

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -77,6 +77,7 @@ Vernacular Commands
 - Using “Require” inside a section is deprecated.
 - An experimental command "Show Extraction" allows to extract the content
   of the current ongoing proof (grant wish #4129).
+- Coercion now accepts the type of its argument to be "Prop" or "Type".
 
 Universes
 

--- a/Makefile.build
+++ b/Makefile.build
@@ -386,21 +386,16 @@ coqbinaries: $(COQTOPEXE) $(CHICKEN) $(CSDPCERT) $(FAKEIDE)
 
 coqbyte: $(COQTOPBYTE) $(CHICKENBYTE)
 
-COQTOP_OPT_MLTOP=toplevel/coqtop_opt_bin.cmx
-COQTOP_BYTE_MLTOP=toplevel/coqtop_byte_bin.cmo
-
-$(COQTOP_BYTE_MLTOP): toplevel/coqtop_byte_bin.ml
-	$(SHOW)'OCAMLC    $<'
-	$(HIDE)$(OCAMLC) $(MLINCLUDES) $(BYTEFLAGS) -package compiler-libs.toplevel -c $<
+COQTOP_OPT=toplevel/coqtop_opt_bin.ml
+COQTOP_BYTE=toplevel/coqtop_byte_bin.ml
 
 ifeq ($(BEST),opt)
-$(COQTOPEXE): $(LINKCMX) $(LIBCOQRUN) $(TOPLOOPCMA:.cma=.cmxs) $(COQTOP_OPT_MLTOP)
+$(COQTOPEXE): $(LINKCMX) $(LIBCOQRUN) $(TOPLOOPCMA:.cma=.cmxs) $(COQTOP_OPT)
 	$(SHOW)'COQMKTOP -o $@'
-	$(HIDE)$(OCAMLOPT) -linkall -linkpkg -I toplevel \
+	$(HIDE)$(OCAMLOPT) -linkall -linkpkg -I vernac -I toplevel \
 	                   -I kernel/byterun/ -cclib -lcoqrun \
-                           $(SYSMOD) -package camlp5.gramlib \
-	                   $(LINKCMX) $(OPTFLAGS) $(LINKMETADATA) \
-	                   $(COQTOP_OPT_MLTOP) toplevel/coqtop_bin.ml -o $@
+			   $(SYSMOD) -package camlp5.gramlib \
+			   $(LINKCMX) $(OPTFLAGS) $(LINKMETADATA) $(COQTOP_OPT) -o $@
 	$(STRIP) $@
 	$(CODESIGN) $@
 else
@@ -409,13 +404,12 @@ $(COQTOPEXE): $(COQTOPBYTE)
 endif
 
 # VMBYTEFLAGS will either contain -custom of the right -dllpath for the VM
-$(COQTOPBYTE): $(LINKCMO) $(LIBCOQRUN) $(TOPLOOPCMA) $(COQTOP_BYTE_MLTOP)
+$(COQTOPBYTE): $(LINKCMO) $(LIBCOQRUN) $(TOPLOOPCMA) $(COQTOP_BYTE)
 	$(SHOW)'COQMKTOP -o $@'
-	$(HIDE)$(OCAMLC) -linkall -linkpkg -I toplevel \
+	$(HIDE)$(OCAMLC) -linkall -linkpkg -I lib -I vernac -I toplevel \
 	                 -I kernel/byterun/ -cclib -lcoqrun $(VMBYTEFLAGS) \
-                         $(SYSMOD) -package camlp5.gramlib,compiler-libs.toplevel \
-	                 $(LINKCMO) $(BYTEFLAGS) \
-	                 $(COQTOP_BYTE_MLTOP) toplevel/coqtop_bin.ml -o $@
+			 $(SYSMOD) -package camlp5.gramlib,compiler-libs.toplevel \
+			 $(LINKCMO) $(BYTEFLAGS) $(COQTOP_BYTE) -o $@
 
 # For coqc
 COQCCMO:=clib/clib.cma lib/lib.cma toplevel/usage.cmo tools/coqc.cmo

--- a/doc/refman/Coercion.tex
+++ b/doc/refman/Coercion.tex
@@ -33,7 +33,7 @@ classes:
 
 \begin{itemize}
 \item {\tt Sortclass}, the class of sorts; 
-  its objects are the terms whose type is a sort.
+  its objects are the terms whose type is a sort (e.g., \ssrC{Prop} or \ssrC{Type}).
 \item {\tt Funclass}, the class of functions; 
   its objects are all the terms with a functional 
   type, i.e. of form $forall~ x:A, B$.
@@ -73,8 +73,8 @@ conditions holds:
 
 We then write $f:C \mbox{\texttt{>->}} D$. The restriction on the type
 of coercions is called {\em the uniform inheritance condition}.
-Remark that the abstract classes {\tt Funclass} and {\tt Sortclass}
-cannot be source classes.
+Remark: the abstract class {\tt Sortclass} can be used as source class,
+but the abstract class {\tt Funclass} cannot.
 
 To coerce an object $t:C~t_1..t_n$ of $C$ towards $D$, we have to
 apply the coercion $f$ to it; the obtained term $f~t_1..t_n~t$ is
@@ -160,7 +160,6 @@ Declares the construction denoted by {\qualid} as a coercion between
 \item {\qualid} \errindex{not declared}
 \item {\qualid} \errindex{is already a coercion}
 \item \errindex{Funclass cannot be a source class}
-\item \errindex{Sortclass cannot be a source class}
 \item {\qualid} \errindex{is not a function}
 \item \errindex{Cannot find the source class of {\qualid}}
 \item \errindex{Cannot recognize {\class$_1$} as a source class of {\qualid}}

--- a/test-suite/output/UnivBinders.out
+++ b/test-suite/output/UnivBinders.out
@@ -149,24 +149,24 @@ inmod@{u} -> Type@{v}
 (* u v |=  *)
 
 Applied.infunct is universe polymorphic
-axfoo@{i Top.41 Top.42} : Type@{Top.41} -> Type@{i}
-(* i Top.41 Top.42 |=  *)
+axfoo@{i Top.44 Top.45} : Type@{Top.44} -> Type@{i}
+(* i Top.44 Top.45 |=  *)
 
 axfoo is universe polymorphic
 Argument scope is [type_scope]
 Expands to: Constant Top.axfoo
-axbar@{i Top.41 Top.42} : Type@{Top.42} -> Type@{i}
-(* i Top.41 Top.42 |=  *)
+axbar@{i Top.44 Top.45} : Type@{Top.45} -> Type@{i}
+(* i Top.44 Top.45 |=  *)
 
 axbar is universe polymorphic
 Argument scope is [type_scope]
 Expands to: Constant Top.axbar
-axfoo' : Type@{Top.44} -> Type@{axbar'.i}
+axfoo' : Type@{Top.47} -> Type@{axbar'.i}
 
 axfoo' is not universe polymorphic
 Argument scope is [type_scope]
 Expands to: Constant Top.axfoo'
-axbar' : Type@{Top.44} -> Type@{axbar'.i}
+axbar' : Type@{Top.47} -> Type@{axbar'.i}
 
 axbar' is not universe polymorphic
 Argument scope is [type_scope]

--- a/test-suite/output/UnivBinders.v
+++ b/test-suite/output/UnivBinders.v
@@ -44,6 +44,9 @@ Module mono.
 
   Monomorphic Definition monomono := Type@{MONOU}.
   Check monomono.
+
+  Monomorphic Inductive monoind@{i} : Type@{i} := .
+  Monomorphic Record monorecord@{i} : Type@{i} := mkmonorecord {}.
 End mono.
 Check mono.monomono. (* qualified MONOU *)
 Import mono.

--- a/test-suite/success/coercions.v
+++ b/test-suite/success/coercions.v
@@ -130,7 +130,7 @@ Local Coercion l2v2 : list >-> vect.
    of coercions *)
 Fail Check (fun l : list (T1 * T1) => (l : vect _ _)).
 Check (fun l : list (T1 * T1) => (l2v2 l : vect _ _)).
-Section what_we_could_do.
+End what_we_could_do.
 
 
 (** Unit test for Prop as source class *)
@@ -156,3 +156,33 @@ Module TestPropAsSourceCoercion.
   (* Print test. -- reveals [hpure] coercions *)
 
 End TestPropAsSourceCoercion.
+
+
+(** Unit test for Type as source class *)
+
+Module TestTypeAsSourceCoercion.
+
+  Require Import Coq.Setoids.Setoid.
+
+  Record setoid := { A : Type ; R : relation A ; eqv : Equivalence R }.
+
+  Definition default_setoid (T : Type) : setoid
+    := {| A := T ; R := eq ; eqv := _ |}.
+
+  Coercion default_setoid : Sortclass >-> setoid.
+
+  Definition foo := Type : setoid.
+
+  Inductive type := U | Nat.
+  Inductive term : type -> Type :=
+  | ty (_ : Type) : term U
+  | nv (_ : nat) : term Nat.
+
+  Coercion ty : Sortclass >-> term.
+
+  Definition ty1 := Type : term _.
+  Definition ty2 := Prop : term _.
+  Definition ty3 := Set : term _.
+  Definition ty4 := (Type : Type) : term _.
+
+End TestTypeAsSourceCoercion.

--- a/test-suite/success/coercions.v
+++ b/test-suite/success/coercions.v
@@ -131,3 +131,28 @@ Local Coercion l2v2 : list >-> vect.
 Fail Check (fun l : list (T1 * T1) => (l : vect _ _)).
 Check (fun l : list (T1 * T1) => (l2v2 l : vect _ _)).
 Section what_we_could_do.
+
+
+(** Unit test for Prop as source class *)
+
+Module TestPropAsSourceCoercion.
+
+  Parameter heap : Prop.
+
+  Parameter heap_empty : heap.
+
+  Definition hprop := heap -> Prop.
+
+  Coercion hpure (P:Prop) : hprop := fun h => h = heap_empty /\ P.
+
+  Parameter heap_single : nat -> nat -> hprop.
+
+  Parameter hstar : hprop -> hprop -> hprop.
+
+  Notation "H1 \* H2" := (hstar H1 H2) (at level 69).
+
+  Definition test := heap_single 4 5 \* (5 <> 4) \* heap_single 2 4 \* (True).
+
+  (* Print test. -- reveals [hpure] coercions *)
+
+End TestPropAsSourceCoercion.

--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -344,13 +344,13 @@ let init_color color_mode =
     match colors with
     | None ->
       (** Default colors *)
+      Topfmt.default_styles ();
       Topfmt.init_terminal_output ~color:true
     | Some "" ->
       (** No color output *)
       Topfmt.init_terminal_output ~color:false
     | Some s ->
       (** Overwrite all colors *)
-      Topfmt.clear_styles ();
       Topfmt.parse_color_config s;
       Topfmt.init_terminal_output ~color:true
   end

--- a/toplevel/coqtop_bin.ml
+++ b/toplevel/coqtop_bin.ml
@@ -1,2 +1,0 @@
-(* Main coqtop initialization *)
-let () = Coqtop.start()

--- a/toplevel/coqtop_byte_bin.ml
+++ b/toplevel/coqtop_byte_bin.ml
@@ -1,3 +1,13 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *   INRIA, CNRS and contributors - Copyright 1999-2018       *)
+(* <O___,, *       (see CREDITS file for the list of authors)           *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
 let drop_setup () =
   begin try
     (* Enable rectypes in the toplevel if it has the directive #rectypes *)
@@ -18,4 +28,7 @@ let drop_setup () =
              ml_loop  = (fun () -> Toploop.loop ppf);
            })
 
-let _ = drop_setup ()
+(* Main coqtop initialization *)
+let _ =
+  drop_setup ();
+  Coqtop.start()

--- a/toplevel/coqtop_opt_bin.ml
+++ b/toplevel/coqtop_opt_bin.ml
@@ -1,3 +1,16 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *   INRIA, CNRS and contributors - Copyright 1999-2018       *)
+(* <O___,, *       (see CREDITS file for the list of authors)           *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
 let drop_setup () = Mltop.remove ()
 
-let _ = drop_setup ()
+(* Main coqtop initialization *)
+let _ =
+  drop_setup ();
+  Coqtop.start()

--- a/vernac/class.ml
+++ b/vernac/class.ml
@@ -225,7 +225,7 @@ let build_id_coercion idf_opt source poly =
   ConstRef kn
 
 let check_source = function
-| Some (CL_FUN|CL_SORT as s) -> raise (CoercionError (ForbiddenSourceClass s))
+| Some (CL_FUN as s) -> raise (CoercionError (ForbiddenSourceClass s))
 | _ -> ()
 
 (*

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -594,13 +594,12 @@ let definition_structure (kind,cum,poly,finite,(is_coe,({CAst.loc;v=idstruc},pl)
   let pl, univs, arity, template, implpars, params, implfs, fields =
     States.with_state_protection (fun () ->
       typecheck_params_and_fields finite (kind = Class true) idstruc poly pl s ps notations fs) () in
-  let gr = match kind with
+  match kind with
   | Class def ->
-     let priorities = List.map (fun id -> {hint_priority = id; hint_pattern = None}) priorities in
-     let gr = declare_class finite def cum pl univs (loc,idstruc) idbuild
-          implpars params arity template implfs fields is_coe coers priorities in
-	gr
-    | _ ->
+    let priorities = List.map (fun id -> {hint_priority = id; hint_pattern = None}) priorities in
+    declare_class finite def cum pl univs (loc,idstruc) idbuild
+      implpars params arity template implfs fields is_coe coers priorities
+  | _ ->
       let implfs = List.map
 	  (fun impls -> implpars @ Impargs.lift_implicits
 	           (succ (List.length params)) impls) implfs 
@@ -618,7 +617,4 @@ let definition_structure (kind,cum,poly,finite,(is_coe,({CAst.loc;v=idstruc},pl)
       let ind = declare_structure finite pl univs idstruc
 	  idbuild implpars params arity template implfs 
           fields is_coe (List.map (fun coe -> not (Option.is_empty coe)) coers) in
-	IndRef ind
-  in
-  Declare.declare_univ_binders gr pl;
-  gr
+      IndRef ind

--- a/vernac/topfmt.ml
+++ b/vernac/topfmt.ml
@@ -187,8 +187,8 @@ let init_tag_map styles =
   let set accu (name, st) = CString.Map.add name st accu in
   tag_map := List.fold_left set !tag_map styles
 
-let clear_styles () =
-  tag_map := CString.Map.empty
+let default_styles () =
+  init_tag_map (default_tag_map ())
 
 let parse_color_config file =
   let styles = Terminal.parse file in
@@ -257,7 +257,6 @@ let make_printing_functions () =
   print_prefix, print_suffix
 
 let init_terminal_output ~color =
-  init_tag_map (default_tag_map ());
   let push_tag, pop_tag, clear_tag = make_style_stack () in
   let print_prefix, print_suffix = make_printing_functions () in
   let tag_handler ft = {

--- a/vernac/topfmt.mli
+++ b/vernac/topfmt.mli
@@ -43,7 +43,7 @@ val std_logger   : ?pre_hdr:Pp.t -> Feedback.level -> Pp.t -> unit
 val emacs_logger : ?pre_hdr:Pp.t -> Feedback.level -> Pp.t -> unit
 
 (** Color output *)
-val clear_styles : unit -> unit
+val default_styles : unit -> unit
 val parse_color_config : string -> unit
 val dump_tags : unit -> (string * Terminal.style) list
 


### PR DESCRIPTION
The goal of this PR is to allow Prop to be source for coercions. 
Doing so is highly useful for shallow embedding of logics.
A unit test showing a use case for Separation Logic is included.

Note: this pull request is significant in its diff size on the main code base: -9 chars :)

For technical reasons, the patch allows any sort to be used as source class.
It should be specified in the documentation that using Type as source class has unspecified behavior.

Matthieu told me that preventing Type explicitly does not appear necessary, and would require adding some complexity to the code.