### PR TITLE
[api] Build with -disable_API as default.

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -195,7 +195,7 @@ TIMER=$(if $(TIMED), $(STDTIME), $(TIMECMD))
 COQOPTS=$(NATIVECOMPUTE)
 BOOTCOQC=$(TIMER) $(COQTOPBEST) -boot $(COQOPTS) -compile
 
-LOCALINCLUDES=$(if $(filter plugins/%,$@),-I lib -I API -open API $(addprefix -I plugins/,$(PLUGINDIRS)),$(addprefix -I ,$(SRCDIRS)))
+LOCALINCLUDES=$(addprefix -I ,$(SRCDIRS))
 MLINCLUDES=$(LOCALINCLUDES) -I $(MYCAMLP4LIB)
 
 OCAMLC := $(OCAMLFIND) ocamlc $(CAMLFLAGS)

--- a/dev/top_printers.ml
+++ b/dev/top_printers.ml
@@ -233,7 +233,7 @@ let ppenvwithcst e = pp
    str "[" ++ pr_rel_context e Evd.empty (rel_context e) ++ str "]" ++ spc() ++
    str "{" ++ Cmap_env.fold (fun a _ s -> Constant.print a ++ spc () ++ s) (Obj.magic e).Pre_env.env_globals.Pre_env.env_constants (mt ()) ++ str "}")
 
-let pptac = (fun x -> pp(Ltac_plugin.Pptactic.pr_glob_tactic (API.Global.env()) x))
+let pptac = (fun x -> pp(Ltac_plugin.Pptactic.pr_glob_tactic (Global.env()) x))
 
 let ppobj obj = Format.print_string (Libobject.object_tag obj)
 

--- a/lib/coqProject_file.ml4
+++ b/lib/coqProject_file.ml4
@@ -195,11 +195,11 @@ let process_cmd_line orig_dir proj args =
  (******************************* API ************************************)
 
 let cmdline_args_to_project ~curdir args =
-  process_cmd_line curdir (mk_project None None None true false) args
+  process_cmd_line curdir (mk_project None None None true true) args
 
 let read_project_file f =
   process_cmd_line (Filename.dirname f)
-    (mk_project (Some f) None (Some NoInstall) true false) (parse f)
+    (mk_project (Some f) None (Some NoInstall) true true) (parse f)
 
 let rec find_project_file ~from ~projfile_name =
   let fname = Filename.concat from projfile_name in

--- a/plugins/.merlin
+++ b/plugins/.merlin
@@ -1,2 +1,0 @@
-REC
-FLG -open API

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -861,7 +861,7 @@ let rec prove_le g =
         | App (c, [| x0 ; _ |]) ->
           EConstr.isVar sigma x0 &&
           Id.equal (destVar sigma x0) (destVar sigma x) &&
-          is_global sigma (le ()) c
+          Termops.is_global sigma (le ()) c
         | _ -> false
         in
 	let (h,t) = List.find (fun (_,t) -> matching_fun t) (pf_hyps_types g)


### PR DESCRIPTION
As agreed in the WG, we disable API.mli until we finish a new duplicate-free publishing system.