### PR TITLE
Strong invariants in polymorphic definitions

### DIFF
--- a/dev/ci/user-overlays/06482-ppedrot-check-poly-effects.sh
+++ b/dev/ci/user-overlays/06482-ppedrot-check-poly-effects.sh
@@ -1,0 +1,4 @@
+if [ "$TRAVIS_PULL_REQUEST" = "6483" ] || [ "$TRAVIS_BRANCH" = "check-poly-effects" ]; then
+    HoTT_CI_BRANCH=check-poly-effects
+    HoTT_CI_GITURL=https://github.com/ppedrot/HoTT.git
+fi

--- a/proofs/proof_global.ml
+++ b/proofs/proof_global.ml
@@ -343,16 +343,15 @@ let close_proof ~keep_body_ucst_separate ?feedback_id ~now
     if poly || now then
       let make_body t (c, eff) =
         let body = c in
-	let typ =
-	  if not (keep_body_ucst_separate || not (Safe_typing.empty_private_constants = eff)) then
-	    nf t
-	  else t
+        let allow_deferred =
+          not poly && (keep_body_ucst_separate ||
+          not (Safe_typing.empty_private_constants = eff))
         in
+        let typ = if allow_deferred then t else nf t in
         let env = Global.env () in
         let used_univs_body = Univops.universes_of_constr env body in
         let used_univs_typ = Univops.universes_of_constr env typ in
-        if keep_body_ucst_separate ||
-           not (Safe_typing.empty_private_constants = eff) then
+        if allow_deferred then
           let initunivs = UState.const_univ_entry ~poly initial_euctx in
           let ctx = constrain_variables universes in
           (* For vi2vo compilation proofs are computed now but we need to

--- a/test-suite/success/abstract_poly.v
+++ b/test-suite/success/abstract_poly.v
@@ -17,4 +17,4 @@ intros m n P e p.
 abstract (rewrite e in p; exact p).
 Defined.
 
-Check bar_subproof@{Set Set Set}.
+Check bar_subproof@{Set Set}.


### PR DESCRIPTION
This PR enforces in the kernel the following invariant for polymorphic definitions: both internal constraints (as generated by forcing the body) and side-effect constraints (as generated by side-effect inlining) must be empty. This allows to ensure that there is no messy universe context union in the kernel, and in particular that the universe bounds provided by the user are preserved.

As such, it is an alternative of #735. I'm suspecting the latter was not thoroughly tested, or at least at the time a few tests were missing, because this PR required a few subtle changes in the implementation of abstract.

This PR breaks backward compatibility in a few very uncommon corner cases. For instance, HoTT breaks but can be fixed with a 6-line patch fiddling with universe binders.

This PR depends on #6469.
