### PR TITLE
[v8.7-only] Fixing #6486, coq_makefile print all its messages.

### DIFF
--- a/tools/coq_makefile.ml
+++ b/tools/coq_makefile.ml
@@ -9,7 +9,17 @@
 (* Coq_makefile: automatically create a Makefile for a Coq development *)
 
 open CoqProject_file
+open Pp
 open Printf
+
+(* A feeders is needed by CoqProject_file functions *)
+let coqmkfile_feed (fb : Feedback.feedback) =
+  let open Feedback in
+  match fb.contents with
+  (* print all messages, warning or errors *)
+  | Message (lvl,loc,msg) ->
+     Pp.pp_with Format.std_formatter (msg ++ Pp.fnl ()) 
+  | _ -> ()
 
 let output_channel = ref stdout
 let makefile_name = ref "Makefile"
@@ -364,6 +374,7 @@ let destination_of { ml_includes; q_includes; r_includes; } file =
   | [s] -> Printf.printf "%s" (quote s)
   | _ -> assert false
 
+
 let share_prefix s1 s2 =
   let s1 = CString.split '.' s1 in
   let s2 = CString.split '.' s2 in
@@ -372,6 +383,8 @@ let share_prefix s1 s2 =
   | _ -> false
 
 let _ =
+  (* Registering the feeder for CoqProject_file functions. *)
+  let _ = Feedback.add_feeder coqmkfile_feed in
   let prog, args =
     if Array.length Sys.argv = 1 then usage ();
     let args = Array.to_list Sys.argv in


### PR DESCRIPTION
This fixes #6486 in a minimalistic way. A feeder is added so that messages fed by analysing options in coq project files do not get lost.
