### PR TITLE
[vernac] Move the flags/attributes out of vernac_expr

### DIFF
--- a/intf/vernacexpr.ml
+++ b/intf/vernacexpr.ml
@@ -314,6 +314,15 @@ type cumulative_inductive_parsing_flag =
 
 (** {6 The type of vernacular expressions} *)
 
+type vernac_implicit_status = Implicit | MaximallyImplicit | NotImplicit
+
+type vernac_argument_status = {
+  name : Name.t;
+  recarg_like : bool;
+  notation_scope : string Loc.located option;
+  implicit_status : vernac_implicit_status;
+}
+
 type vernac_expr =
 
   | VernacLoad of verbose_flag * string
@@ -467,15 +476,6 @@ type vernac_expr =
   | VernacProgram of vernac_expr
   | VernacPolymorphic of bool * vernac_expr
   | VernacLocal of bool * vernac_expr
-
-and vernac_implicit_status = Implicit | MaximallyImplicit | NotImplicit
-
-and vernac_argument_status = {
-  name : Name.t;
-  recarg_like : bool;
-  notation_scope : string Loc.located option;
-  implicit_status : vernac_implicit_status;
-}
 
 type vernac_control =
   | VernacExpr of vernac_expr

--- a/intf/vernacexpr.ml
+++ b/intf/vernacexpr.ml
@@ -323,7 +323,7 @@ type vernac_argument_status = {
   implicit_status : vernac_implicit_status;
 }
 
-type vernac_expr =
+type nonrec vernac_expr =
 
   | VernacLoad of verbose_flag * string
   (* Syntax *)
@@ -472,13 +472,13 @@ type vernac_expr =
   (* For extension *)
   | VernacExtend of extend_name * Genarg.raw_generic_argument list
 
-  (* Flags *)
-  | VernacProgram of vernac_expr
-  | VernacPolymorphic of bool * vernac_expr
-  | VernacLocal of bool * vernac_expr
+type nonrec vernac_flag =
+  | VernacProgram
+  | VernacPolymorphic of bool
+  | VernacLocal of bool
 
 type vernac_control =
-  | VernacExpr of vernac_expr
+  | VernacExpr of vernac_flag list * vernac_expr
   (* boolean is true when the `-time` batch-mode command line flag was set.
      the flag is used to print differently in `-time` vs `Time foo` *)
   | VernacTime of bool * vernac_control located

--- a/plugins/funind/g_indfun.ml4
+++ b/plugins/funind/g_indfun.ml4
@@ -154,7 +154,7 @@ VERNAC COMMAND EXTEND Function
            | _,((_,(_,CStructRec),_,_,_),_) -> false) recsl in
          match
            Vernac_classifier.classify_vernac
-             (Vernacexpr.(VernacExpr(VernacFixpoint(Decl_kinds.NoDischarge, List.map snd recsl))))
+             (Vernacexpr.(VernacExpr([], VernacFixpoint(Decl_kinds.NoDischarge, List.map snd recsl))))
          with
          | Vernacexpr.VtSideff ids, _ when hard ->
              Vernacexpr.(VtStartProof ("Classic", GuaranteesOpacity, ids), VtLater)

--- a/plugins/funind/glob_term_to_relation.ml
+++ b/plugins/funind/glob_term_to_relation.ml
@@ -1509,7 +1509,7 @@ let do_build_inductive
 	in
 	let msg =
 	  str "while trying to define"++ spc () ++
-            Ppvernac.pr_vernac Vernacexpr.(VernacExpr(VernacInductive(GlobalNonCumulativity,false,Declarations.Finite,repacked_rel_inds)))
+            Ppvernac.pr_vernac Vernacexpr.(VernacExpr([], VernacInductive(GlobalNonCumulativity,false,Declarations.Finite,repacked_rel_inds)))
 	    ++ fnl () ++
 	    msg
 	in
@@ -1524,7 +1524,7 @@ let do_build_inductive
 	in
 	let msg =
 	  str "while trying to define"++ spc () ++
-            Ppvernac.pr_vernac Vernacexpr.(VernacExpr(VernacInductive(GlobalNonCumulativity,false,Declarations.Finite,repacked_rel_inds)))
+            Ppvernac.pr_vernac Vernacexpr.(VernacExpr([], VernacInductive(GlobalNonCumulativity,false,Declarations.Finite,repacked_rel_inds)))
 	    ++ fnl () ++
 	    CErrors.print reraise
 	in

--- a/plugins/ssr/ssrvernac.ml4
+++ b/plugins/ssr/ssrvernac.ml4
@@ -551,9 +551,9 @@ GEXTEND Gram
       | IDENT "Canonical"; qid = Constr.global;
           d = G_vernac.def_body ->
           let s = coerce_reference_to_id qid in
-    Vernacexpr.VernacLocal(false,Vernacexpr.VernacDefinition
+    Vernacexpr.VernacDefinition
       ((Decl_kinds.NoDischarge,Decl_kinds.CanonicalStructure),
-          ((Loc.tag s),None),(d  )))
+          ((Loc.tag s),None), d)
   ]];
 END
 

--- a/stm/proofBlockDelimiter.ml
+++ b/stm/proofBlockDelimiter.ml
@@ -96,7 +96,7 @@ let dynamic_bullet doc { dynamic_switch = id; carry_on_data = b } =
       `ValidBlock {
          base_state = id;
          goals_to_admit = focused;
-         recovery_command = Some (Vernacexpr.VernacExpr(Vernacexpr.VernacBullet (to_bullet_val b)))
+         recovery_command = Some (Vernacexpr.VernacExpr([], Vernacexpr.VernacBullet (to_bullet_val b)))
       }
   | `Not -> `Leaks
 
@@ -125,7 +125,7 @@ let dynamic_curly_brace doc { dynamic_switch = id } =
       `ValidBlock {
          base_state = id;
          goals_to_admit = focused;
-         recovery_command = Some (Vernacexpr.VernacExpr Vernacexpr.VernacEndSubproof)
+         recovery_command = Some (Vernacexpr.VernacExpr ([], Vernacexpr.VernacEndSubproof))
       }
   | `Not -> `Leaks
 

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -1498,7 +1498,7 @@ end = struct (* {{{ *)
           stm_vernac_interp stop
             ~proof:(pobject, terminator) st
             { verbose = false; loc; indentation = 0; strlen = 0;
-              expr = VernacExpr (VernacEndProof (Proved (Opaque,None))) }) in
+              expr = VernacExpr ([], VernacEndProof (Proved (Opaque,None))) }) in
         ignore(Future.join checked_proof);
       end;
       (* STATE: Restore the state XXX: handle exn *)
@@ -1646,7 +1646,7 @@ end = struct (* {{{ *)
       let st = Vernacstate.freeze_interp_state `No in
       ignore(stm_vernac_interp stop ~proof st
         { verbose = false; loc; indentation = 0; strlen = 0;
-          expr = VernacExpr (VernacEndProof (Proved (Opaque,None))) });
+          expr = VernacExpr ([], VernacEndProof (Proved (Opaque,None))) });
       `OK proof
       end
     with e ->
@@ -2177,7 +2177,7 @@ let collect_proof keep cur hd brkind id =
         (try
           let name, hint = name ids, get_hint_ctx loc  in
           let t, v = proof_no_using last in
-          v.expr <- VernacExpr(VernacProof(t, Some hint));
+          v.expr <- VernacExpr([], VernacProof(t, Some hint));
           `ASync (parent last,accn,name,delegate name)
         with Not_found ->
           let name = name ids in
@@ -2872,10 +2872,9 @@ let process_transaction ?(newtip=Stateid.fresh ()) ?(part_of_script=true)
             if not in_proof && Proof_global.there_are_pending_proofs () then
             begin
               let bname = VCS.mk_branch_name x in
-              let rec opacity_of_produced_term = function
+              let opacity_of_produced_term = function
                 (* This AST is ambiguous, hence we check it dynamically *)
                 | VernacInstance (false, _,_ , None, _) -> GuaranteesOpacity
-                | VernacLocal (_,e) -> opacity_of_produced_term e
                 | _ -> Doesn'tGuaranteeOpacity in
               VCS.commit id (Fork (x,bname,opacity_of_produced_term (Vernacprop.under_control x.expr),[]));
               let proof_mode = default_proof_mode () in

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -2202,9 +2202,8 @@ let interp ?(verbosely=true) ?proof ~st (loc,c) =
   let orig_program_mode = Flags.is_program_mode () in
   let rec control = function
   | VernacExpr v ->
-      let atts = { loc; locality = None; polymorphic = false; } in
-      aux ~atts orig_program_mode v
-  | VernacFail v -> with_fail st true (fun () -> control v)
+      let atts = { loc; locality = None; polymorphic = false; program = orig_program_mode; } in
+      aux ~atts v
   | VernacTimeout (n,v) ->
       current_timeout := Some n;
       control v
@@ -2213,22 +2212,22 @@ let interp ?(verbosely=true) ?proof ~st (loc,c) =
   | VernacTime (batch, (_loc,v)) ->
       System.with_time ~batch control v;
 
-  and aux ?polymorphism ~atts isprogcmd = function
+  and aux ?polymorphism ~atts = function
 
-    | VernacProgram c when not isprogcmd ->
-      aux ?polymorphism ~atts true c
+    | VernacProgram c when not atts.program ->
+      aux ?polymorphism ~atts:{ atts with program = true } c
 
     | VernacProgram _ ->
       user_err Pp.(str "Program mode specified twice")
 
     | VernacPolymorphic (b, c) when polymorphism = None ->
-      aux ~polymorphism:b ~atts:atts isprogcmd c
+      aux ~polymorphism:b ~atts:atts c
 
     | VernacPolymorphic (b, c) ->
       user_err Pp.(str "Polymorphism specified twice")
 
     | VernacLocal (b, c) when Option.is_empty atts.locality ->
-      aux ?polymorphism ~atts:{atts with locality = Some b} isprogcmd c
+      aux ?polymorphism ~atts:{atts with locality = Some b} c
 
     | VernacLocal _ ->
       user_err Pp.(str "Locality specified twice")
@@ -2240,7 +2239,7 @@ let interp ?(verbosely=true) ?proof ~st (loc,c) =
       check_vernac_supports_polymorphism c polymorphism;
       let polymorphic = Option.default (Flags.is_universe_polymorphism ()) polymorphism in
       Flags.make_universe_polymorphism polymorphic;
-      Obligations.set_program_mode isprogcmd;
+      Obligations.set_program_mode atts.program;
       try
         vernac_timeout begin fun () ->
           let atts = { atts with polymorphic } in
@@ -2249,7 +2248,7 @@ let interp ?(verbosely=true) ?proof ~st (loc,c) =
           else Flags.silently  (interp ?proof ~atts ~st) c;
           (* If the command is `(Un)Set Program Mode` or `(Un)Set Universe Polymorphism`,
              we should not restore the previous state of the flag... *)
-          if orig_program_mode || not !Flags.program_mode || isprogcmd then
+          if orig_program_mode || not !Flags.program_mode || atts.program then
             Flags.program_mode := orig_program_mode;
           if (Flags.is_universe_polymorphism() = polymorphic) then
             Flags.make_universe_polymorphism orig_univ_poly;

--- a/vernac/vernacinterp.ml
+++ b/vernac/vernacinterp.ml
@@ -16,6 +16,7 @@ type atts = {
   loc : Loc.t option;
   locality : bool option;
   polymorphic : bool;
+  program : bool;
 }
 
 type 'a vernac_command = 'a -> atts:atts -> st:Vernacstate.t -> Vernacstate.t

--- a/vernac/vernacinterp.mli
+++ b/vernac/vernacinterp.mli
@@ -14,6 +14,7 @@ type atts = {
   loc : Loc.t option;
   locality : bool option;
   polymorphic : bool;
+  program : bool;
 }
 
 type 'a vernac_command = 'a -> atts:atts -> st:Vernacstate.t -> Vernacstate.t

--- a/vernac/vernacprop.ml
+++ b/vernac/vernacprop.ml
@@ -12,14 +12,14 @@
 open Vernacexpr
 
 let rec under_control = function
-  | VernacExpr c -> c
+  | VernacExpr (_, c) -> c
   | VernacRedirect (_,(_,c))
   | VernacTime (_,(_,c))
   | VernacFail c
   | VernacTimeout (_,c) -> under_control c
 
 let rec has_Fail = function
-  | VernacExpr c -> false
+  | VernacExpr _ -> false
   | VernacRedirect (_,(_,c))
   | VernacTime (_,(_,c))
   | VernacTimeout (_,c) -> has_Fail c
@@ -45,8 +45,8 @@ let rec is_deep_navigation_vernac = function
 
 (* NB: Reset is now allowed again as asked by A. Chlipala *)
 let is_reset = function
-  | VernacExpr VernacResetInitial
-  | VernacExpr (VernacResetName _) -> true
+  | VernacExpr ( _, VernacResetInitial)
+  | VernacExpr (_, VernacResetName _) -> true
   | _ -> false
 
 let is_debug cmd = match under_control cmd with


### PR DESCRIPTION
The command modifiers (Program, Local, and Polymorphic) are now a standalone type `vernac_flag`. A `vernac_expr` thus comes with a list of such flags.