### PR TITLE
 Fix overlay selection for Circle CI. 

### DIFF
--- a/dev/ci/ci-common.sh
+++ b/dev/ci/ci-common.sh
@@ -5,8 +5,17 @@ set -xe
 if [ -n "${GITLAB_CI}" ];
 then
     export COQBIN=`pwd`/_install_ci/bin
-    export TRAVIS_BRANCH="$CI_COMMIT_REF_NAME"
+    export CI_BRANCH="$CI_COMMIT_REF_NAME"
 else
+    if [ -n "${TRAVIS}" ];
+    then
+        export CI_PULL_REQUEST="$TRAVIS_PULL_REQUEST"
+        export CI_BRANCH="$TRAVIS_BRANCH"
+    elif [ -n "${CIRCLECI}" ];
+    then
+        export CI_PULL_REQUEST="$CIRCLE_PR_NUMBER"
+        export CI_BRANCH="$CIRCLE_BRANCH"
+    fi
     export COQBIN=`pwd`/bin
 fi
 export PATH="$COQBIN:$PATH"

--- a/dev/ci/user-overlays/00669-maximedenes-ssr-merge.sh
+++ b/dev/ci/user-overlays/00669-maximedenes-ssr-merge.sh
@@ -1,4 +1,4 @@
-if [ "$TRAVIS_PULL_REQUEST" = "669" ] || [ "$TRAVIS_BRANCH" = "ssr-merge" ]; then
+if [ "$CI_PULL_REQUEST" = "669" ] || [ "$CI_BRANCH" = "ssr-merge" ]; then
     mathcomp_CI_BRANCH=ssr-merge
     mathcomp_CI_GITURL=https://github.com/maximedenes/math-comp.git
 fi

--- a/dev/ci/user-overlays/01033-SkySkimmer-restrict-harder.sh
+++ b/dev/ci/user-overlays/01033-SkySkimmer-restrict-harder.sh
@@ -1,9 +1,0 @@
-if [ "$TRAVIS_PULL_REQUEST" = "1033" ] || [ "$TRAVIS_BRANCH" = "restrict-harder" ]; then
-    formal_topology_CI_BRANCH=ci
-    formal_topology_CI_GITURL=https://github.com/SkySkimmer/topology.git
-
-    HoTT_CI_BRANCH=coq-pr-1033
-    HoTT_CI_GITURL=https://github.com/SkySkimmer/HoTT.git
-
-    Equations_CI_GITURL=https://github.com/SkySkimmer/Coq-Equations.git
-fi

--- a/dev/ci/user-overlays/06158-herbelin-master+fix-pr6158-ltac-value-printer.sh
+++ b/dev/ci/user-overlays/06158-herbelin-master+fix-pr6158-ltac-value-printer.sh
@@ -1,4 +1,0 @@
-if [ "$TRAVIS_PULL_REQUEST" = "6158" ] || [ "$TRAVIS_BRANCH" = "master+some-fix-ltac-printing+refined-printers" ]; then
-    ltac2_CI_BRANCH=master+fix-pr6158-ltac-value-printer
-    ltac2_CI_GITURL=https://github.com/herbelin/ltac2.git
-fi

--- a/dev/ci/user-overlays/06169-Zimmi48-clean-up-deprecated-options.sh
+++ b/dev/ci/user-overlays/06169-Zimmi48-clean-up-deprecated-options.sh
@@ -1,4 +1,0 @@
-if [ "$TRAVIS_PULL_REQUEST" = "6169" ] || [ "$TRAVIS_BRANCH" = "clean-up/deprecated-options" ]; then
-    ltac2_CI_BRANCH=master
-    ltac2_CI_GITURL=https://github.com/Zimmi48/ltac2
-fi

--- a/dev/ci/user-overlays/06197-ejgallego-plugins+remove_locality_hack.sh
+++ b/dev/ci/user-overlays/06197-ejgallego-plugins+remove_locality_hack.sh
@@ -1,4 +1,0 @@
-if [ "$TRAVIS_PULL_REQUEST" = "6197" ] || [ "$TRAVIS_BRANCH" = "plugins+remove_locality_hack" ]; then
-    ltac2_CI_BRANCH=localityfixyou
-    ltac2_CI_GITURL=https://github.com/ejgallego/ltac2.git
-fi

--- a/dev/ci/user-overlays/06217-coqdep-at-once.sh
+++ b/dev/ci/user-overlays/06217-coqdep-at-once.sh
@@ -1,3 +1,0 @@
-if [ "$TRAVIS_PULL_REQUEST" = "6217" ] || [ "$TRAVIS_BRANCH" = "coqdep-at-once" ]; then
-    UniMath_CI_GITURL=https://github.com/SkySkimmer/UniMath.git
-fi

--- a/dev/ci/user-overlays/06324-SkySkimmer-abstract-vs-restrict.sh
+++ b/dev/ci/user-overlays/06324-SkySkimmer-abstract-vs-restrict.sh
@@ -1,4 +1,0 @@
-if [ "$TRAVIS_PULL_REQUEST" = "6324" ] || [ "$TRAVIS_BRANCH" = "fix-6323-restrict+abstract" ]; then
-    Equations_CI_BRANCH=fix-coq-6324
-    Equations_CI_GITURL=https://github.com/SkySkimmer/Coq-Equations.git
-fi

--- a/dev/ci/user-overlays/06392-ejgallego-econstr+fix_class.sh
+++ b/dev/ci/user-overlays/06392-ejgallego-econstr+fix_class.sh
@@ -1,4 +1,0 @@
-if [ "$TRAVIS_PULL_REQUEST" = "6392" ] || [ "$TRAVIS_BRANCH" = "econstr+fix_class" ]; then
-    Equations_CI_BRANCH=econstr+fix_class
-    Equations_CI_GITURL=https://github.com/ejgallego/Coq-Equations.git
-fi

--- a/dev/ci/user-overlays/06413-ejgallego-interp+less_impstyle_p2.sh
+++ b/dev/ci/user-overlays/06413-ejgallego-interp+less_impstyle_p2.sh
@@ -1,4 +1,0 @@
-if [ "$TRAVIS_PULL_REQUEST" = "6413" ] || [ "$TRAVIS_BRANCH" = "interp+less_impstyle_p2" ]; then
-    Equations_CI_BRANCH=interp+less_impstyle_p2
-    Equations_CI_GITURL=https://github.com/ejgallego/Coq-Equations.git
-fi

--- a/dev/ci/user-overlays/README.md
+++ b/dev/ci/user-overlays/README.md
@@ -7,8 +7,10 @@ The name of your overlay file should be of the form `five_digit_PR_number-GitHub
 Example: `00669-maximedenes-ssr-merge.sh` containing
 
 ```
-if [ "$TRAVIS_PULL_REQUEST" = "669" ] || [ "$TRAVIS_BRANCH" = "ssr-merge" ]; then
+if [ "$CI_PULL_REQUEST" = "669" ] || [ "$CI_BRANCH" = "ssr-merge" ]; then
     mathcomp_CI_BRANCH=ssr-merge
     mathcomp_CI_GITURL=https://github.com/maximedenes/math-comp.git
 fi
 ```
+
+(`CI_PULL_REQUEST` and `CI_BRANCH` are set in [`ci-common.sh`](/dev/ci/ci-common.sh))


### PR DESCRIPTION
Use our own CI-system-independent variables set in ci-common instead of TRAVIS_foo.