### PR TITLE
[econstr] Continue consolidation of EConstr API under `interp`.

### DIFF
--- a/dev/base_include
+++ b/dev/base_include
@@ -196,7 +196,10 @@ let parse_tac    = Pcoq.parse_string Ltac_plugin.Pltac.tactic;;
 (* build a term of type glob_constr without type-checking or resolution of 
    implicit syntax *)
 
-let e s = Constrintern.intern_constr (Global.env()) (parse_constr s);;
+let e s =
+  let env = Global.env () in
+  let sigma = Evd.from_env env in
+  Constrintern.intern_constr env sigma (parse_constr s);;
 
 (* build a term of type constr with type-checking and resolution of 
    implicit syntax *)

--- a/dev/ci/user-overlays/06511-ejgallego-econstr+more_fix.sh
+++ b/dev/ci/user-overlays/06511-ejgallego-econstr+more_fix.sh
@@ -1,0 +1,7 @@
+ if [ "$CI_PULL_REQUEST" = "6511" ] || [ "$CI_BRANCH" = "econstr+more_fix" ]; then
+    ltac2_CI_BRANCH=econstr+more_fix
+    ltac2_CI_GITURL=https://github.com/ejgallego/ltac2
+
+    Equations_CI_BRANCH=econstr+more_fix
+    Equations_CI_GITURL=https://github.com/ejgallego/Coq-Equations
+fi

--- a/dev/top_printers.ml
+++ b/dev/top_printers.ml
@@ -313,6 +313,8 @@ let constr_display csr =
   in
   pp (str (term_display csr) ++fnl ())
 
+let econstr_display c = constr_display EConstr.Unsafe.(to_constr c) ;;
+
 open Format;;
 
 let print_pure_constr csr =
@@ -452,6 +454,8 @@ let print_pure_constr csr =
 	print_string (Printexc.to_string e);print_flush ();
 	raise e
 
+let print_pure_econstr c = print_pure_constr EConstr.Unsafe.(to_constr c) ;;
+
 let pploc x = let (l,r) = Loc.unloc x in
   print_string"(";print_int l;print_string",";print_int r;print_string")"
 
@@ -505,7 +509,7 @@ let _ =
       (function
          [c] when genarg_tag c = unquote (topwit wit_constr) && true ->
            let c = out_gen (rawwit wit_constr) c in
-           (fun ~atts ~st -> in_current_context constr_display c; st)
+           (fun ~atts ~st -> in_current_context econstr_display c; st)
        | _ -> failwith "Vernac extension: cannot occur")
   with
     e -> pp (CErrors.print e)
@@ -521,7 +525,7 @@ let _ =
       (function
          [c] when genarg_tag c = unquote (topwit wit_constr) && true ->
            let c = out_gen (rawwit wit_constr) c in
-           (fun ~atts ~st -> in_current_context print_pure_constr c; st)
+           (fun ~atts ~st -> in_current_context print_pure_econstr c; st)
        | _ -> failwith "Vernac extension: cannot occur")
   with
     e -> pp (CErrors.print e)

--- a/engine/termops.ml
+++ b/engine/termops.ml
@@ -797,9 +797,9 @@ let fold_constr_with_binders sigma g f n acc c =
    each binder traversal; it is not recursive and the order with which
    subterms are processed is not specified *)
 
-let iter_constr_with_full_binders g f l c =
+let iter_constr_with_full_binders sigma g f l c =
   let open RelDecl in
-  match kind c with
+  match EConstr.kind sigma c with
   | (Rel _ | Meta _ | Var _   | Sort _ | Const _ | Ind _
     | Construct _) -> ()
   | Cast (c,_, t) -> f l c; f l t

--- a/engine/termops.mli
+++ b/engine/termops.mli
@@ -76,9 +76,10 @@ val fold_constr_with_full_binders : Evd.evar_map ->
   (Context.Rel.Declaration.t -> 'a -> 'a) -> ('a -> 'b -> constr -> 'b) ->
     'a -> 'b -> constr -> 'b
 
-val iter_constr_with_full_binders :
-  (Context.Rel.Declaration.t -> 'a -> 'a) -> ('a -> Constr.constr -> unit) -> 'a ->
-    Constr.constr -> unit
+val iter_constr_with_full_binders : Evd.evar_map ->
+  (rel_declaration -> 'a -> 'a) ->
+  ('a -> constr -> unit) -> 'a ->
+  constr -> unit
 
 (**********************************************************************)
 

--- a/ide/ide_slave.ml
+++ b/ide/ide_slave.ml
@@ -281,7 +281,7 @@ let pattern_of_string ?env s =
     | Some e -> e
   in
   let constr = Pcoq.parse_string Pcoq.Constr.lconstr_pattern s in
-  let (_, pat) = Constrintern.intern_constr_pattern env constr in
+  let (_, pat) = Constrintern.intern_constr_pattern env Evd.empty constr in
   pat
 
 let dirpath_of_string_list s =

--- a/interp/declare.ml
+++ b/interp/declare.ml
@@ -135,7 +135,7 @@ let set_declare_scheme f = declare_scheme := f
 let update_tables c =
   declare_constant_implicits c;
   Heads.declare_head (EvalConstRef c);
-  Notation.declare_ref_arguments_scope (ConstRef c)
+  Notation.declare_ref_arguments_scope Evd.empty (ConstRef c)
 
 let register_side_effect (c, role) =
   let o = inConstant {
@@ -275,7 +275,7 @@ let inVariable : variable_obj -> obj =
 let declare_variable id obj =
   let oname = add_leaf id (inVariable (Inr (id,obj))) in
   declare_var_implicits id;
-  Notation.declare_ref_arguments_scope (VarRef id);
+  Notation.declare_ref_arguments_scope Evd.empty (VarRef id);
   Heads.declare_head (EvalVarRef id);
   oname
 
@@ -283,9 +283,9 @@ let declare_variable id obj =
 
 let declare_inductive_argument_scopes kn mie =
   List.iteri (fun i {mind_entry_consnames=lc} ->
-    Notation.declare_ref_arguments_scope (IndRef (kn,i));
+    Notation.declare_ref_arguments_scope Evd.empty (IndRef (kn,i));
     for j=1 to List.length lc do
-      Notation.declare_ref_arguments_scope (ConstructRef ((kn,i),j));
+      Notation.declare_ref_arguments_scope Evd.empty (ConstructRef ((kn,i),j));
     done) mie.mind_entry_inds
 
 let inductive_names sp kn mie =

--- a/interp/impargs.mli
+++ b/interp/impargs.mli
@@ -7,7 +7,7 @@
 (************************************************************************)
 
 open Names
-open Constr
+open EConstr
 open Globnames
 open Environ
 
@@ -90,10 +90,10 @@ type manual_explicitation = Constrexpr.explicitation *
 
 type manual_implicits = manual_explicitation list
 
-val compute_implicits_with_manual : env -> types -> bool ->
+val compute_implicits_with_manual : env -> Evd.evar_map -> types -> bool ->
   manual_implicits -> implicit_status list
 
-val compute_implicits_names : env -> types -> Name.t list
+val compute_implicits_names : env -> Evd.evar_map -> types -> Name.t list
 
 (** {6 Computation of implicits (done using the global environment). } *)
 

--- a/interp/modintern.ml
+++ b/interp/modintern.ml
@@ -61,13 +61,16 @@ let transl_with_decl env = function
   | CWith_Module ((_,fqid),qid) ->
       WithMod (fqid,lookup_module qid), Univ.ContextSet.empty
   | CWith_Definition ((_,fqid),c) ->
-    let c, ectx = interp_constr env (Evd.from_env env) c in
+    let sigma = Evd.from_env env in
+    let c, ectx = interp_constr env sigma c in
     if Flags.is_universe_polymorphism () then
       let ctx = UState.context ectx in
       let inst, ctx = Univ.abstract_universes ctx in
-      let c = Vars.subst_univs_level_constr (Univ.make_instance_subst inst) c in
+      let c = EConstr.Vars.subst_univs_level_constr (Univ.make_instance_subst inst) c in
+      let c = EConstr.to_constr sigma c in
       WithDef (fqid,(c, Some ctx)), Univ.ContextSet.empty
     else
+      let c = EConstr.to_constr sigma c in
       WithDef (fqid,(c, None)), UState.context_set ectx
 
 let loc_of_module l = l.CAst.loc

--- a/interp/notation.mli
+++ b/interp/notation.mli
@@ -163,10 +163,10 @@ val subst_scope_class :
   Mod_subst.substitution -> scope_class -> scope_class option
 
 val declare_scope_class : scope_name -> scope_class -> unit
-val declare_ref_arguments_scope : global_reference -> unit
+val declare_ref_arguments_scope : Evd.evar_map -> global_reference -> unit
 
-val compute_arguments_scope : Constr.types -> scope_name option list
-val compute_type_scope : Constr.types -> scope_name option
+val compute_arguments_scope : Evd.evar_map -> EConstr.types -> scope_name option list
+val compute_type_scope : Evd.evar_map -> EConstr.types -> scope_name option
 
 (** Get the current scope bound to Sortclass, if it exists *)
 val current_type_scope_name : unit -> scope_name option

--- a/plugins/funind/indfun.ml
+++ b/plugins/funind/indfun.ml
@@ -141,8 +141,7 @@ let rec abstract_glob_constr c = function
   | Constrexpr.CLocalPattern _::bl -> assert false
 
 let interp_casted_constr_with_implicits env sigma impls c  =
-  Constrintern.intern_gen Pretyping.WithoutTypeConstraint env ~impls
-    c
+  Constrintern.intern_gen Pretyping.WithoutTypeConstraint env sigma ~impls c
 
 (*
    Construct a fixpoint as a Glob_term
@@ -160,9 +159,9 @@ let build_newrecursive
         let arity,ctx = Constrintern.interp_type env0 sigma arityc in
         let evd = Evd.from_env env0 in
         let evd, (_, (_, impls')) = Constrintern.interp_context_evars env evd bl in
-	let impl = Constrintern.compute_internalization_data env0 Constrintern.Recursive arity impls' in
+        let impl = Constrintern.compute_internalization_data env0 evd Constrintern.Recursive arity impls' in
         let open Context.Named.Declaration in
-        (Environ.push_named (LocalAssum (recname,arity)) env, Id.Map.add recname impl impls))
+        (EConstr.push_named (LocalAssum (recname,arity)) env, Id.Map.add recname impl impls))
       (env0,Constrintern.empty_internalization_env) lnameargsardef in
   let recdef =
     (* Declare local notations *)

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -210,6 +210,7 @@ let (value_f: Constr.t list -> global_reference -> Constr.t) =
 	    DAst.make @@ GVar v_id)])
     in
     let body = fst (understand env (Evd.from_env env) glob_body)(*FIXME*) in
+    let body = EConstr.Unsafe.to_constr body in
     it_mkLambda_or_LetIn body context
 
 let (declare_f : Id.t -> logical_kind -> Constr.t list -> global_reference -> global_reference) =
@@ -1400,7 +1401,7 @@ let open_new_goal build_proof sigma using_lemmas ref_ goal_name (gls_type,decomp
 	 	     (fun c ->
 	 		Proofview.V82.of_tactic (Tacticals.New.tclTHENLIST 
 	 		  [intros;
-	 		   Simple.apply (EConstr.of_constr (fst (interp_constr (Global.env()) Evd.empty c))) (*FIXME*);
+                           Simple.apply (fst (interp_constr (Global.env()) Evd.empty c)) (*FIXME*);
 	 		   Tacticals.New.tclCOMPLETE Auto.default_auto
 	 		  ])
 	 	     )
@@ -1599,7 +1600,9 @@ let recursive_definition is_mes function_name rec_impls type_of_f r rec_arg_num 
       and functional_ref = destConst (constr_of_global functional_ref)
       and eq_ref = destConst (constr_of_global eq_ref) in
       generate_induction_principle f_ref tcc_lemma_constr
-        functional_ref eq_ref rec_arg_num (EConstr.of_constr rec_arg_type) (nb_prod evd (EConstr.of_constr res)) (EConstr.of_constr relation);
+        functional_ref eq_ref rec_arg_num
+        (EConstr.of_constr rec_arg_type)
+        (nb_prod evd (EConstr.of_constr res)) relation;
       Flags.if_verbose
         msgnl (h 1 (Ppconstr.pr_id function_name ++
 			 spc () ++ str"is defined" )++ fnl () ++
@@ -1614,7 +1617,7 @@ let recursive_definition is_mes function_name rec_impls type_of_f r rec_arg_num 
       tcc_lemma_constr
       is_mes functional_ref
       (EConstr.of_constr rec_arg_type)
-      (EConstr.of_constr relation) rec_arg_num
+      relation rec_arg_num
       term_id
       using_lemmas
       (List.length res_vars)

--- a/plugins/ltac/extratactics.ml4
+++ b/plugins/ltac/extratactics.ml4
@@ -253,6 +253,7 @@ let add_rewrite_hint ~poly bases ort t lcsr =
   let sigma = Evd.from_env env in
   let f ce =
     let c, ctx = Constrintern.interp_constr env sigma ce in
+    let c = EConstr.to_constr sigma c in
     let ctx =
       let ctx = UState.context_set ctx in
         if poly then ctx
@@ -554,6 +555,7 @@ let add_transitivity_lemma left lem =
   let env = Global.env () in
   let sigma = Evd.from_env env in
   let lem',ctx (*FIXME*) = Constrintern.interp_constr env sigma lem in
+  let lem' = EConstr.to_constr sigma lem' in
   add_anonymous_leaf (inTransitivity (left,lem'))
 
 (* Vernacular syntax *)
@@ -611,8 +613,10 @@ END
 
 VERNAC COMMAND EXTEND RetroknowledgeRegister CLASSIFIED AS SIDEFF
  | [ "Register" constr(c) "as" retroknowledge_field(f) "by" constr(b)] ->
-           [ let tc,ctx = Constrintern.interp_constr (Global.env ()) Evd.empty c in
-             let tb,ctx(*FIXME*) = Constrintern.interp_constr (Global.env ()) Evd.empty b in
+           [ let tc,_ctx = Constrintern.interp_constr (Global.env ()) Evd.empty c in
+             let tb,_ctx(*FIXME*) = Constrintern.interp_constr (Global.env ()) Evd.empty b in
+             let tc = EConstr.to_constr Evd.empty tc in
+             let tb = EConstr.to_constr Evd.empty tb in
              Global.register f tc tb ]
 END
 
@@ -705,7 +709,6 @@ let hResolve id c occ t =
           resolve_hole (subst_hole_with_term loc_begin c_raw t_hole)
   in
   let t_constr,ctx = resolve_hole (subst_var_with_hole occ id t_raw) in
-  let t_constr = EConstr.of_constr t_constr in
   let sigma = Evd.merge_universe_context sigma ctx in
   let t_constr_type = Retyping.get_type_of env sigma t_constr in
   Proofview.tclTHEN (Proofview.Unsafe.tclEVARS sigma)

--- a/plugins/ltac/rewrite.ml
+++ b/plugins/ltac/rewrite.ml
@@ -1896,7 +1896,6 @@ let declare_projection n instance_id r =
 
 let build_morphism_signature env sigma m =
   let m,ctx = Constrintern.interp_constr env sigma m in
-  let m = EConstr.of_constr m in
   let sigma = Evd.from_ctx ctx in
   let t = Typing.unsafe_type_of env sigma m in
   let cstrs =

--- a/plugins/ltac/tacintern.ml
+++ b/plugins/ltac/tacintern.ml
@@ -199,7 +199,7 @@ let intern_constr_gen pattern_mode isarity {ltacvars=lfun; genv=env; extra} c =
     ltac_extra = extra;
   } in
   let c' =
-    warn (Constrintern.intern_gen scope ~pattern_mode ~ltacvars env) c
+    warn (Constrintern.intern_gen scope ~pattern_mode ~ltacvars env Evd.(from_env env)) c
   in
   (c',if !strict_check then None else Some c)
 
@@ -316,7 +316,7 @@ let intern_constr_pattern ist ~as_type ~ltacvars pc =
     ltac_extra = ist.extra;
   } in
   let metas,pat = Constrintern.intern_constr_pattern
-    ist.genv ~as_type ~ltacvars pc
+    ist.genv Evd.(from_env ist.genv) ~as_type ~ltacvars pc
   in
   let (glob,_ as c) = intern_constr_gen true false ist pc in
   let bound_names = Glob_ops.bound_glob_vars glob in
@@ -335,7 +335,7 @@ let intern_typed_pattern ist ~as_type ~ltacvars p =
           ltac_bound = Id.Set.empty;
           ltac_extra = ist.extra;
         } in
-      Constrintern.intern_constr_pattern ist.genv ~as_type ~ltacvars p
+      Constrintern.intern_constr_pattern ist.genv Evd.(from_env ist.genv) ~as_type ~ltacvars p
     else
       [], dummy_pat in
   let (glob,_ as c) = intern_constr_gen true false ist p in

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -584,7 +584,7 @@ let interp_glob_closure ist env sigma ?(kind=WithoutTypeConstraint) ?(pattern_mo
         ltac_bound = Id.Map.domain ist.lfun;
         ltac_extra = Genintern.Store.empty;
       } in
-      { closure ; term = intern_gen kind ~pattern_mode ~ltacvars env term_expr }
+      { closure ; term = intern_gen kind ~pattern_mode ~ltacvars env sigma term_expr }
 
 let interp_uconstr ist env sigma c = interp_glob_closure ist env sigma c
 

--- a/plugins/setoid_ring/newring.ml
+++ b/plugins/setoid_ring/newring.ml
@@ -148,7 +148,7 @@ let ic c =
 let ic_unsafe c = (*FIXME remove *)
   let env = Global.env() in
   let sigma = Evd.from_env env in
-    EConstr.of_constr (fst (Constrintern.interp_constr env sigma c))
+  fst (Constrintern.interp_constr env sigma c)
 
 let decl_constant na univs c =
   let open Constr in

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -203,7 +203,7 @@ let glob_constr ist genv = function
     let vars = Id.Map.fold (fun x _ accu -> Id.Set.add x accu) ist.Tacinterp.lfun Id.Set.empty in
     let ltacvars = {
       Constrintern.empty_ltac_sign with Constrintern.ltac_vars = vars } in
-    Constrintern.intern_gen Pretyping.WithoutTypeConstraint ~ltacvars genv ce
+    Constrintern.intern_gen Pretyping.WithoutTypeConstraint ~ltacvars genv Evd.(from_env genv) ce
   | rc, None -> rc
 
 let pf_intern_term ist gl (_, c) = glob_constr ist (pf_env gl) c

--- a/plugins/ssr/ssrvernac.ml4
+++ b/plugins/ssr/ssrvernac.ml4
@@ -335,7 +335,8 @@ let push_rels_assum l e =
   push_rels_assum l e
 
 let coerce_search_pattern_to_sort hpat =
-  let env = Global.env () and sigma = Evd.empty in
+  let env = Global.env () in
+  let sigma = Evd.(from_env env) in
   let mkPApp fp n_imps args =
     let args' = Array.append (Array.make n_imps (Pattern.PMeta None)) args in
     Pattern.PApp (fp, args') in
@@ -393,8 +394,9 @@ let interp_search_arg arg =
       interp_search_notation ~loc s key
   | RGlobSearchSubPattern p ->
       try
-        let intern = Constrintern.intern_constr_pattern in 
-        Search.GlobSearchSubPattern (snd (intern (Global.env()) p))
+        let env = Global.env () in
+        let _, p = Constrintern.intern_constr_pattern env (Evd.from_env env) p in
+        Search.GlobSearchSubPattern p
       with e -> let e = CErrors.push e in iraise (ExplainErr.process_vernac_interp_error e)) arg in
   let hpat, a1 = match arg with
   | (_, Search.GlobSearchSubPattern (Pattern.PMeta _)) :: a' -> all_true, a'

--- a/plugins/ssr/ssrview.ml
+++ b/plugins/ssr/ssrview.ml
@@ -55,7 +55,8 @@ let in_viewhint =
        Libobject.classify_function = classify_viewhint }
 
 let glob_view_hints lvh =
-  List.map (Constrintern.intern_constr (Global.env ())) lvh
+  let env = Global.env () in
+  List.map (Constrintern.intern_constr env Evd.(from_env env)) lvh
 
 let add_view_hints lvh i = Lib.add_anonymous_leaf (in_viewhint (i, lvh))
 

--- a/plugins/ssrmatching/ssrmatching.ml4
+++ b/plugins/ssrmatching/ssrmatching.ml4
@@ -73,11 +73,11 @@ let env_size env = List.length (Environ.named_context env)
 let safeDestApp c =
   match kind c with App (f, a) -> f, a | _ -> c, [| |]
 (* Toplevel constr must be globalized twice ! *)
-let glob_constr ist genv = function
+let glob_constr ist genv sigma = function
   | _, Some ce ->
     let vars = Id.Map.fold (fun x _ accu -> Id.Set.add x accu) ist.lfun Id.Set.empty in
     let ltacvars = { Constrintern.empty_ltac_sign with Constrintern.ltac_vars = vars } in
-    Constrintern.intern_gen WithoutTypeConstraint ~ltacvars:ltacvars genv ce
+    Constrintern.intern_gen WithoutTypeConstraint ~ltacvars:ltacvars genv sigma ce
   | rc, None -> rc
 
 (* Term printing utilities functions for deciding bracketing.  *)
@@ -1009,7 +1009,7 @@ let interp_wit wit ist gl x =
   sigma, Value.cast (topwit wit) arg
 let interp_open_constr ist gl gc =
   interp_wit wit_open_constr ist gl gc
-let pf_intern_term ist gl (_, c) = glob_constr ist (pf_env gl) c
+let pf_intern_term ist gl (_, c) = glob_constr ist (pf_env gl) gl.sigma c
 let interp_term ist gl (_, c) = on_snd EConstr.Unsafe.to_constr (interp_open_constr ist gl c)
 let pr_ssrterm _ _ _ = pr_term
 let input_ssrtermkind strm = match stream_nth 0 strm with

--- a/pretyping/inductiveops.ml
+++ b/pretyping/inductiveops.ml
@@ -643,8 +643,9 @@ let type_of_projection_knowing_arg env sigma p c ty =
 (* A function which checks that a term well typed verifies both
    syntactic conditions *)
 
-let control_only_guard env c =
-  let check_fix_cofix e c = match kind c with
+let control_only_guard env sigma c =
+  let check_fix_cofix e c =
+    match kind (EConstr.to_constr sigma c) with
     | CoFix (_,(_,_,_) as cofix) ->
       Inductive.check_cofix e cofix
     | Fix (_,(_,_,_) as fix) ->
@@ -653,6 +654,6 @@ let control_only_guard env c =
   in
   let rec iter env c =
     check_fix_cofix env c;
-    iter_constr_with_full_binders push_rel iter env c
+    iter_constr_with_full_binders sigma EConstr.push_rel iter env c
   in
   iter env c

--- a/pretyping/inductiveops.mli
+++ b/pretyping/inductiveops.mli
@@ -198,4 +198,4 @@ val type_of_inductive_knowing_conclusion :
   env -> evar_map -> Inductive.mind_specif Univ.puniverses -> EConstr.types -> evar_map * EConstr.types
 
 (********************)
-val control_only_guard : env -> types -> unit
+val control_only_guard : env -> Evd.evar_map -> EConstr.types -> unit

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -1205,8 +1205,7 @@ let all_no_fail_flags = default_inference_flags false
 
 let ise_pretype_gen_ctx flags env sigma lvar kind c =
   let evd, c, _ = ise_pretype_gen flags env sigma lvar kind c in
-  let evd, f = Evarutil.nf_evars_and_universes evd in
-    f (EConstr.Unsafe.to_constr c), Evd.evar_universe_context evd
+  c, Evd.evar_universe_context evd
 
 (** Entry points of the high-level type synthesis algorithm *)
 

--- a/pretyping/pretyping.mli
+++ b/pretyping/pretyping.mli
@@ -12,7 +12,6 @@
    into elementary ones, insertion of coercions and resolution of
    implicit arguments. *)
 
-open Constr
 open Environ
 open Evd
 open EConstr
@@ -26,7 +25,7 @@ val interp_known_glob_level : ?loc:Loc.t -> Evd.evar_map ->
 (** An auxiliary function for searching for fixpoint guard indexes *)
 
 val search_guard :
-  ?loc:Loc.t -> env -> int list list -> rec_declaration -> int array
+  ?loc:Loc.t -> env -> int list list -> Constr.rec_declaration -> int array
 
 type typing_constraint = OfType of types | IsType | WithoutTypeConstraint
 
@@ -85,9 +84,8 @@ val understand_ltac : inference_flags ->
     heuristics (but no external tactic solver hook), as well as to
     ensure that conversion problems are all solved and that no
     unresolved evar remains, expanding evars. *)
-
 val understand : ?flags:inference_flags -> ?expected_type:typing_constraint ->
-  env -> evar_map -> glob_constr -> Constr.constr Evd.in_evar_universe_context
+  env -> evar_map -> glob_constr -> constr Evd.in_evar_universe_context
 
 (** Trying to solve remaining evars and remaining conversion problems
     possibly using type classes, heuristics, external tactic solver

--- a/printing/ppconstr.ml
+++ b/printing/ppconstr.ml
@@ -701,13 +701,16 @@ let tag_var = tag Tag.variable
     | { CAst.v = CAppExpl ((None,f,us),[]) } -> str "@" ++ pr_cref f us
     | c -> pr prec c
 
-  let transf env c =
+  let transf env sigma c =
     if !Flags.beautify_file then
-      let r = Constrintern.for_grammar (Constrintern.intern_constr env) c in
+      let r = Constrintern.for_grammar (Constrintern.intern_constr env sigma) c in
       Constrextern.extern_glob_constr (Termops.vars_of_env env) r
     else c
 
-  let pr_expr prec c = pr prec (transf (Global.env()) c)
+  let pr_expr prec c =
+    let env = Global.env () in
+    let sigma = Evd.from_env env in
+    pr prec (transf env sigma c)
 
   let pr_simpleconstr = pr_expr lsimpleconstr
 

--- a/proofs/proof.ml
+++ b/proofs/proof.ml
@@ -432,7 +432,7 @@ module V82 = struct
           CList.nth evl (n-1)
       in
       let env = Evd.evar_filtered_env evi in
-      let rawc = Constrintern.intern_constr env com in
+      let rawc = Constrintern.intern_constr env sigma com in
       let ltac_vars = Glob_ops.empty_lvar in
       let sigma = Evar_refiner.w_refine (evk, evi) (ltac_vars, rawc) sigma in
       Proofview.Unsafe.tclEVARS sigma

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -581,7 +581,7 @@ let make_resolve_hyp env sigma st flags only_classes pri decl =
              (fun (path,info,c) ->
 	      let info =
 		{ info with Vernacexpr.hint_pattern =
-			    Option.map (Constrintern.intern_constr_pattern env)
+                            Option.map (Constrintern.intern_constr_pattern env sigma)
 				       info.Vernacexpr.hint_pattern }
 	      in
 	      make_resolves env sigma ~name:(PathHints path)

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -1270,7 +1270,7 @@ let prepare_hint check (poly,local) env init (sigma,c) =
 
 let interp_hints poly =
   fun h ->
-  let env = (Global.env()) in
+  let env = Global.env () in
   let sigma = Evd.from_env env in
   let f poly c =
     let evd,c = Constrintern.interp_open_constr env sigma c in
@@ -1279,9 +1279,7 @@ let interp_hints poly =
     let gr = global_with_alias r in
     Dumpglob.add_glob ?loc:(loc_of_reference r) gr;
     gr in
-  let fr r = 
-    evaluable_of_global_reference (Global.env()) (fref r)
-  in
+  let fr r = evaluable_of_global_reference env (fref r) in
   let fi c =
     match c with
     | HintsReference c ->
@@ -1289,7 +1287,7 @@ let interp_hints poly =
 	(PathHints [gr], poly, IsGlobRef gr)
     | HintsConstr c -> (PathAny, poly, f poly c)
   in
-  let fp = Constrintern.intern_constr_pattern (Global.env()) in
+  let fp = Constrintern.intern_constr_pattern env sigma in
   let fres (info, b, r) =
     let path, poly, gr = fi r in
     let info = { info with hint_pattern = Option.map fp info.hint_pattern } in

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -1991,7 +1991,6 @@ let exact_proof c =
   Proofview.Goal.enter begin fun gl ->
   Refine.refine ~typecheck:false begin fun sigma ->
     let (c, ctx) = Constrintern.interp_casted_constr (pf_env gl) sigma c (pf_concl gl) in
-    let c = EConstr.of_constr c in
     let sigma = Evd.merge_universe_context sigma ctx in
     (sigma, c)
   end

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -52,7 +52,7 @@ let _ =
        let open Vernacexpr in
        { info with hint_pattern =
 		   Option.map
-		     (Constrintern.intern_constr_pattern (Global.env()))
+                     (Constrintern.intern_constr_pattern (Global.env()) Evd.(from_env Global.(env())))
 		     info.hint_pattern } in
      Flags.silently (fun () ->
 	Hints.add_hints local [typeclasses_db]

--- a/vernac/comFixpoint.ml
+++ b/vernac/comFixpoint.ml
@@ -212,8 +212,7 @@ let interp_recursive ~program_mode ~cofix fixl notations =
   let env_rec = push_named_context rec_sign env in
 
   (* Get interpretation metadatas *)
-  let fixtypes = List.map EConstr.Unsafe.to_constr fixtypes in
-  let impls = compute_internalization_env env Recursive fixnames fixtypes fiximps in
+  let impls = compute_internalization_env env sigma Recursive fixnames fixtypes fiximps in
 
   (* Interp bodies with rollback because temp use of notations/implicit *)
   let sigma, fixdefs =
@@ -226,10 +225,9 @@ let interp_recursive ~program_mode ~cofix fixl notations =
 
   (* Instantiate evars and check all are resolved *)
   let sigma = solve_unif_constraints_with_heuristics env_rec sigma in
-  let sigma, nf = nf_evars_and_universes sigma in
-  let fixdefs = List.map (fun c -> Option.map EConstr.Unsafe.to_constr c) fixdefs in
-  let fixdefs = List.map (Option.map nf) fixdefs in
-  let fixtypes = List.map nf fixtypes in
+  let sigma, _ = nf_evars_and_universes sigma in
+  let fixdefs = List.map (fun c -> Option.map EConstr.(to_constr sigma) c) fixdefs in
+  let fixtypes = List.map EConstr.(to_constr sigma) fixtypes in
   let fixctxs = List.map (fun (_,ctx) -> ctx) fixctxs in
 
   (* Build the fix declaration block *)

--- a/vernac/comProgramFixpoint.ml
+++ b/vernac/comProgramFixpoint.ml
@@ -171,8 +171,8 @@ let build_wellfounded (recname,pl,n,bl,arityc,body) poly r measure notation =
   let sigma, intern_body =
     let ctx = LocalAssum (Name recname, get_type curry_fun) :: binders_rel in
     let (r, l, impls, scopes) =
-      Constrintern.compute_internalization_data env
-        Constrintern.Recursive (EConstr.Unsafe.to_constr full_arity) impls
+      Constrintern.compute_internalization_data env sigma
+        Constrintern.Recursive full_arity impls
     in
     let newimpls = Id.Map.singleton recname
         (r, l, impls @ [(Some (Id.of_string "recproof", Impargs.Manual, (true, false)))],

--- a/vernac/obligations.ml
+++ b/vernac/obligations.ml
@@ -816,13 +816,13 @@ let solve_by_tac name evi t poly ctx =
   let id = name in
   let concl = EConstr.of_constr evi.evar_concl in
   (* spiwack: the status is dropped. *)
-  let (entry,_,ctx') = Pfedit.build_constant_by_tactic 
+  let (entry,_,ctx') = Pfedit.build_constant_by_tactic
     id ~goal_kind:(goal_kind poly) ctx evi.evar_hyps concl (Tacticals.New.tclCOMPLETE t) in
   let env = Global.env () in
   let entry = Safe_typing.inline_private_constants_in_definition_entry env entry in
   let body, () = Future.force entry.const_entry_body in
   let ctx' = Evd.merge_context_set ~sideff:true Evd.univ_rigid (Evd.from_ctx ctx') (snd body) in
-  Inductiveops.control_only_guard (Global.env ()) (fst body);
+  Inductiveops.control_only_guard env ctx' (EConstr.of_constr (fst body));
   (fst body), entry.const_entry_type, Evd.evar_universe_context ctx'
 
 let obligation_terminator name num guard hook auto pf =
@@ -838,7 +838,7 @@ let obligation_terminator name num guard hook auto pf =
     let (body, cstr), () = Future.force entry.Entries.const_entry_body in
     let sigma = Evd.from_ctx uctx in
     let sigma = Evd.merge_context_set ~sideff:true Evd.univ_rigid sigma cstr in
-    Inductiveops.control_only_guard (Global.env ()) body;
+    Inductiveops.control_only_guard (Global.env ()) sigma (EConstr.of_constr body);
     (** Declare the obligation ourselves and drop the hook *)
     let prg = get_info (ProgMap.find name !from_prg) in
     (** Ensure universes are substituted properly in body and type *)

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -70,7 +70,7 @@ let interp_fields_evars env sigma impls_env nots l =
       let impls =
 	match i with
 	| Anonymous -> impls
-        | Name id -> Id.Map.add id (compute_internalization_data env Constrintern.Method (EConstr.to_constr sigma t') impl) impls
+        | Name id -> Id.Map.add id (compute_internalization_data env sigma Constrintern.Method t' impl) impls
       in
       let d = match b' with
 	      | None -> LocalAssum (i,t')
@@ -145,7 +145,7 @@ let typecheck_params_and_fields finite def id poly pl t ps nots fs =
   let assums = List.filter is_local_assum newps in
   let params = List.map (RelDecl.get_name %> Name.get_id) assums in
   let ty = Inductive (params,(finite != Declarations.BiFinite)) in
-  let impls_env = compute_internalization_env env0 ~impls:impls_env ty [id] [EConstr.to_constr sigma arity] [imps] in
+  let impls_env = compute_internalization_env env0 sigma ~impls:impls_env ty [id] [arity] [imps] in
   let env2,sigma,impls,newfs,data =
     interp_fields_evars env_ar sigma impls_env nots (binders_of_decls fs)
   in


### PR DESCRIPTION
This commit was motivated by true spurious conversions arising in my
`to_constr` debug branch.

The changes here need careful review as the tradeoffs are subtle and
still a lot of clean up remains to be done in `vernac/*`.

We have opted for penalize [minimally] the few users coming from true
`Constr`-land, but I am sure we can tweak code in a much better way.

In particular, it is not clear if internalization should take an
`evar_map` even in the cases where it is not triggered, see the
changes under `plugins` for a good example.

Also, the new return type of `Pretyping.understand` should undergo
careful review.

We don't touch `Impargs` as it is not clear how to proceed, however,
the current type of `compute_implicits_gen` looks very suspicious as
it is called often with free evars.
