### PR TITLE
Add flash infos for find and replace

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -68,6 +68,11 @@ Checker
 
 - The checker now accepts filenames in addition to logical paths.
 
+CoqIDE
+
+- Find and Replace All report the number of occurrences found; Find indicates
+  when it wraps.
+
 Documentation
 
 - The Coq FAQ, formerly located at https://coq.inria.fr/faq, has been


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** feature


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes #6452.

Uses the "flash info" mechanism to inform user about:

 - find wrapping
 - find not found
 - find occurrence and total number of occurrences
 - number of replacements on a replace all. 

Getting the total number of occurrences requires a complete traversal of the buffer, could be expensive. Also, I'm using an assoc list of occurrences, so that lookup is linear in the number of occurrences, but shouldn't be too bad in practice.

<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->

- [x] Entry added in [CHANGES](/CHANGES).
