### PR TITLE
Remove references to deleted Unicode.Unsupported exception

### DIFF
--- a/kernel/names.mli
+++ b/kernel/names.mli
@@ -40,19 +40,16 @@ sig
   (** Hash over identifiers. *)
 
   val is_valid : string -> bool
-  (** Check that a string may be converted to an identifier.
-  @raise Unicode.Unsupported if the provided string contains unsupported UTF-8 characters. *)
+  (** Check that a string may be converted to an identifier. *)
 
   val of_bytes : bytes -> t
   val of_string : string -> t
   (** Converts a string into an identifier.
-      @raise UserError if the string is invalid as an identifier.
-      @raise Unicode.Unsupported if the provided string contains unsupported UTF-8 characters. *)
+      @raise UserError if the string is invalid as an identifier. *)
 
   val of_string_soft : string -> t
   (** Same as {!of_string} except that any string made of supported UTF-8 characters is accepted.
-      @raise UserError if the string is invalid as an UTF-8 string.
-      @raise Unicode.Unsupported if the provided string contains unsupported UTF-8 characters. *)
+      @raise UserError if the string is invalid as an UTF-8 string. *)
 
   val to_string : t -> string
   (** Converts a identifier into an string. *)


### PR DESCRIPTION
This exception was removed [on Oct 13, 2016](https://github.com/coq/coq/commit/57c6ffd23836364168ffd1c66dbddbecf830c7c6#diff-297bc4c11289c2c0ed18d5eebf817c47).

**Kind:** documentation.
