### PR TITLE
Added newline at the end of usage of coqdep.

### DIFF
--- a/tools/coqdep.ml
+++ b/tools/coqdep.ml
@@ -455,7 +455,7 @@ let usage () =
   eprintf "  -coqlib dir : set the coq standard library directory\n";
   eprintf "  -suffix s : \n";
   eprintf "  -slash : deprecated, no effect\n";
-  eprintf "  -dyndep (opt|byte|both|no|var) : set how dependencies over ML modules are printed";
+  eprintf "  -dyndep (opt|byte|both|no|var) : set how dependencies over ML modules are printed\n";
   exit 1
 
 let split_period = Str.split (Str.regexp (Str.quote "."))


### PR DESCRIPTION
This is a mini fix for the printing of the usage of `coqdep`, which should have a newline at the end.