### PR TITLE
Update configure.ml to only warn on lablgtk >= 2.16.0 and < 2.18.3

### DIFF
--- a/configure.ml
+++ b/configure.ml
@@ -768,7 +768,13 @@ let check_lablgtk_version src dir = match src with
       begin
         (* Version 2.18.3 is known to report incorrectly as 2.18.0 *)
         printf "Warning: could not check the version of lablgtk2.\nMake sure your version is at least 2.18.3.\n";
-        (true, "an unknown version")
+        (true, "an unknown version claiming to be 2.18.0")
+      end
+    else if arch = "Linux" && vi = [2; 16; 0] then
+      begin
+        (* Launchpad packages report as version 2.16.0 due to a misconfigured META file; see https://bugs.launchpad.net/ubuntu/+source/lablgtk2/+bug/1577236 *)
+        printf "Warning: could not check the version of lablgtk2.\nMake sure your version is at least 2.18.3.\nSee https://bugs.launchpad.net/ubuntu/+source/lablgtk2/+bug/1577236 for more details.";
+        (true, "an unknown version claiming to be 2.16.0")
       end
     else
       ([2; 18; 3] <= vi, v)

--- a/configure.ml
+++ b/configure.ml
@@ -764,20 +764,16 @@ let check_lablgtk_version src dir = match src with
   let v, _ = tryrun camlexec.find ["query"; "-format"; "%v"; "lablgtk2"] in
   try
     let vi = List.map s2i (numeric_prefix_list v) in
-    if vi = [2; 18; 0] then
+    if vi < [2; 16; 0] then
+      (false, v)
+    else if vi < [2; 18; 3] then
       begin
-        (* Version 2.18.3 is known to report incorrectly as 2.18.0 *)
-        printf "Warning: could not check the version of lablgtk2.\nMake sure your version is at least 2.18.3.\n";
-        (true, "an unknown version claiming to be 2.18.0")
-      end
-    else if arch = "Linux" && vi = [2; 16; 0] then
-      begin
-        (* Launchpad packages report as version 2.16.0 due to a misconfigured META file; see https://bugs.launchpad.net/ubuntu/+source/lablgtk2/+bug/1577236 *)
-        printf "Warning: could not check the version of lablgtk2.\nMake sure your version is at least 2.18.3.\nSee https://bugs.launchpad.net/ubuntu/+source/lablgtk2/+bug/1577236 for more details.";
-        (true, "an unknown version claiming to be 2.16.0")
+        (* Version 2.18.3 is known to report incorrectly as 2.18.0, and Launchpad packages report as version 2.16.0 due to a misconfigured META file; see https://bugs.launchpad.net/ubuntu/+source/lablgtk2/+bug/1577236 *)
+        printf "Warning: Your installed lablgtk reports as %s.\n It is possible that the installed version is actually more recent\n but reports an incorrect version. If the installed version is\n actually more recent than 2.18.3, that's fine; if it is not,\n CoqIDE will compile but may be very unstable.\n" v;
+        (true, "an unknown version")
       end
     else
-      ([2; 18; 3] <= vi, v)
+      (true, v)
   with _ -> (false, v)
 
 let pr_ide = function No -> "no" | Byte -> "only bytecode" | Opt -> "native"


### PR DESCRIPTION
The Launchpad packages for lablgtk2 are misconfigured to report 2.16.0
even for much newer versions.  This makes building Coq on Ubuntu
impossible without modifying configure.  This commit fixes that problem.

See https://bugs.launchpad.net/ubuntu/+source/lablgtk2/+bug/1577236 for
the upstream bug.

This closes #6585
