### PR TITLE
Extend `zify_N` with knowledge about `N.pred`

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -32,6 +32,7 @@ Tactics
   such as "x := 5 : Z" (see BZ#148). This could be disabled via
   Unset Omega UseLocalDefs.
 - The tactic "romega" is also aware now of the bodies of context variables.
+- The tactic "zify" resp. "omega with N" is now aware of N.pred.
 - Tactic "decide equality" now able to manage constructors which
   contain proofs.
 - Added tactics reset ltac profile, show ltac profile (and variants)

--- a/plugins/omega/PreOmega.v
+++ b/plugins/omega/PreOmega.v
@@ -26,7 +26,7 @@ Local Open Scope Z_scope.
      - on Z: Z.min, Z.max, Z.abs, Z.sgn are translated in term of <= < =
      - on nat: + * - S O pred min max Pos.to_nat N.to_nat Z.abs_nat
      - on positive: Zneg Zpos xI xO xH + * - Pos.succ Pos.pred Pos.min Pos.max Pos.of_succ_nat
-     - on N: N0 Npos + * - N.succ N.min N.max N.of_nat Z.abs_N
+     - on N: N0 Npos + * - N.pred N.succ N.min N.max N.of_nat Z.abs_N
 *)
 
 
@@ -390,6 +390,10 @@ Ltac zify_N_op :=
   (* N.sub -> Z.max 0 (Z.sub ... ...) *)
   | H : context [ Z.of_N (N.sub ?a ?b) ] |- _ => rewrite (N2Z.inj_sub_max a b) in H
   | |- context [ Z.of_N (N.sub ?a ?b) ] => rewrite (N2Z.inj_sub_max a b)
+
+  (* pred -> minus ... -1 -> Z.max (Z.sub ... -1) 0 *)
+  | H : context [ Z.of_N (N.pred ?a) ] |- _ => rewrite (N.pred_sub a) in H
+  | |- context [ Z.of_N (N.pred ?a) ] => rewrite (N.pred_sub a)
 
   (* N.succ -> Z.succ *)
   | H : context [ Z.of_N (N.succ ?a) ] |- _ => rewrite (N2Z.inj_succ a) in H

--- a/test-suite/bugs/opened/6602.v
+++ b/test-suite/bugs/opened/6602.v
@@ -1,0 +1,17 @@
+Require Import Omega.
+
+Lemma test_nat:
+  forall n, (5 + pred n <= 5 + n).
+Proof.
+  intros.
+  zify.
+  omega.
+Qed.
+
+Lemma test_N:
+  forall n, (5 + N.pred n <= 5 + n)%N.
+Proof.
+  intros.
+  zify.
+  omega.
+Qed.


### PR DESCRIPTION
by doing the same thing as `zify_nat` does for `nat.pred`.
This fixes #6602.

**Kind:** feature, closes #6602.

- [ ] Corresponding documentation was added / updated.
- [x] Entry added in CHANGES.

(I did not find corresponding documentation besides the comments in the file.)