### PR TITLE
Fix #6591: anomaly when using selectors outside of a proof.

### DIFF
--- a/proofs/proof_global.ml
+++ b/proofs/proof_global.ml
@@ -485,7 +485,10 @@ let update_global_env () =
 (* XXX: Bullet hook, should be really moved elsewhere *)
 let _ =
   let hook n =
-    let prf = give_me_the_proof () in
-    (Proof_bullet.suggest prf) in
+    try
+      let prf = give_me_the_proof () in
+      (Proof_bullet.suggest prf)
+    with NoCurrentProof -> mt ()
+  in
   Proofview.set_nosuchgoals_hook hook
 


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** bug fix


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes #6591.

The bullet hints thing is assuming that there is an ongoing proof, so we cannot call it in a case where
selectors are used outside a proof.
