### PR TITLE
Archive COMPATIBILITY

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -51,6 +51,9 @@ Focusing
 
 Vernacular Commands
 
+- Proofs ending in "Qed exporting ident, .., ident" are not supported
+  anymore. Constants generated during `abstract` are kept private to the
+  local environment.
 - The deprecated Coercion Local, Open Local Scope, Notation Local syntax
   was removed. Use Local as a prefix instead.
 - For the Extraction Language command, "OCaml" is spelled correctly.

--- a/COMPATIBILITY
+++ b/COMPATIBILITY
@@ -5,10 +5,6 @@ Potential sources of incompatibilities between Coq V8.6 and V8.7
   error rather than a warning when the superfluous name is already in
   use. The easy fix is to remove the superfluous name.
 
-- Proofs ending in "Qed exporting ident, .., ident" are not supported
-  anymore. Constants generated during `abstract` are kept private to the
-  local environment.
-
 Potential sources of incompatibilities between Coq V8.5 and V8.6
 ----------------------------------------------------------------
 

--- a/dev/doc/COMPATIBILITY
+++ b/dev/doc/COMPATIBILITY
@@ -1,3 +1,6 @@
+Note: this file isn't used anymore. Incompatibilities are documented
+as part of CHANGES.
+
 Potential sources of incompatibilities between Coq V8.6 and V8.7
 ----------------------------------------------------------------
 


### PR DESCRIPTION
The COMPATIBILITY file isn't really used anymore and its purpose kind of duplicates the one of CHANGES.

We fix a wrongly positioned mention at the same time.
