### PR TITLE
[wip] Fixpoint common argument lifting.

### DIFF
--- a/clib/cList.ml
+++ b/clib/cList.ml
@@ -111,6 +111,7 @@ sig
   val cartesians_filter :
     ('a -> 'b -> 'b option) -> 'b -> 'a list list -> 'b list
   val factorize_left : 'a eq -> ('a * 'b) list -> ('a * 'b list) list
+  val is_singleton_opt : 'a list list -> 'a list option
 
   module type MonoS = sig
     type elt
@@ -877,6 +878,14 @@ let rec factorize_left cmp = function
       let al,l' = partition (fun (a',_) -> cmp a a') l in
       (a,(b::List.map snd al)) :: factorize_left cmp l'
   | [] -> []
+
+let is_singleton_opt l =
+  let rec fold acc = function
+    | [] -> Some (rev acc)
+    | [x] :: rest -> fold (x::acc) rest
+    | _ :: _ -> None
+  in
+  fold [] l
 
 module type MonoS = sig
   type elt

--- a/clib/cList.mli
+++ b/clib/cList.mli
@@ -249,6 +249,8 @@ sig
 
   val factorize_left : 'a eq -> ('a * 'b) list -> ('a * 'b list) list
 
+  val is_singleton_opt : 'a list list -> 'a list option
+
   module type MonoS = sig
     type elt
     val equal : elt list -> elt list -> bool

--- a/kernel/constr.ml
+++ b/kernel/constr.ml
@@ -445,7 +445,7 @@ let fold_with_binders g f n acc c = match kind c with
   | App (c,l) -> Array.fold_left (f n) (f n acc c) l
   | Proj (p,c) -> f n acc c
   | Evar (_,l) -> Array.fold_left (f n) acc l
-  | Case (_,p,c,bl) -> Array.fold_left (f n) (f n (f n acc p) c) bl
+  | Case (_,p,c,bl) -> Array.fold_left (f n) (f n (f n acc c) p) bl
   | Fix (_,(lna,tl,bl)) ->
     let n' = iterate g (Array.length tl) n in
     Array.fold_left2 (fun acc t b -> f n' (f n acc t) b) acc tl bl

--- a/kernel/constr.mli
+++ b/kernel/constr.mli
@@ -367,8 +367,7 @@ val compare : constr -> constr -> int
 val fold : ('a -> constr -> 'a) -> 'a -> constr -> 'a
 
 (** [fold g f n acc c] folds [f n] on the immediate subterms of [c]
-   starting from [acc] and proceeding from left to right according to
-   the usual representation of the constructions; it carries an extra
+   starting from [acc]; it carries an extra
    data [n] (typically a lift index) which is processed by [g] (which
    typically add 1 to [n]) at each binder traversal; it is not
    recursive *)

--- a/kernel/constr.mli
+++ b/kernel/constr.mli
@@ -366,6 +366,14 @@ val compare : constr -> constr -> int
 
 val fold : ('a -> constr -> 'a) -> 'a -> constr -> 'a
 
+(** [fold g f n acc c] folds [f n] on the immediate subterms of [c]
+   starting from [acc] and proceeding from left to right according to
+   the usual representation of the constructions; it carries an extra
+   data [n] (typically a lift index) which is processed by [g] (which
+   typically add 1 to [n]) at each binder traversal; it is not
+   recursive *)
+val fold_with_binders : ('a -> 'a) -> ('a -> 'b -> constr -> 'b) -> 'a -> 'b -> constr -> 'b
+
 (** [map f c] maps [f] on the immediate subterms of [c]; it is
    not recursive and the order with which subterms are processed is
    not specified *)

--- a/plugins/micromega/Tauto.v
+++ b/plugins/micromega/Tauto.v
@@ -432,7 +432,7 @@ Set Implicit Arguments.
     simpl.
     destruct pol ; simpl.
     intros.
-    apply (IHf false) ; auto.
+    apply (IHf false env) ; auto.
     intros.
     generalize (IHf _ _ H).
     tauto.

--- a/plugins/setoid_ring/Field_theory.v
+++ b/plugins/setoid_ring/Field_theory.v
@@ -1384,7 +1384,7 @@ Proof.
  intros. subst nfe1 nfe2 lmp np1 np2.
  rewrite !(Pphi_pow_ok Rsth Reqe ARth CRmorph pow_th get_sign_spec).
  repeat (rewrite <- (norm_subst_ok Rsth Reqe ARth CRmorph pow_th);trivial).
- simpl. apply Field_simplify_aux_ok; trivial.
+ simpl. refine (Field_simplify_aux_ok _ _ _ _ _ _); trivial.
 Qed.
 
 Theorem Field_simplify_eq_in_correct :

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -120,11 +120,11 @@ let nf_fix sigma (nas, cs, ts) =
   (nas, Array.map inj cs, Array.map inj ts)
 
 let search_guard ?loc env possible_indexes fixdefs =
-  (* Standard situation with only one possibility for each fix. *)
-  (* We treat it separately in order to get proper error msg. *)
-  let is_singleton = function [_] -> true | _ -> false in
-  if List.for_all is_singleton possible_indexes then
-    let indexes = Array.of_list (List.map List.hd possible_indexes) in
+  match CList.is_singleton_opt possible_indexes with
+  | Some indexes ->
+    (* Standard situation with only one possibility for each fix. *)
+    (* We treat it separately in order to get proper error msg. *)
+    let indexes = Array.of_list indexes in
     let fix = ((indexes, 0),fixdefs) in
     (try check_fix env fix
      with reraise ->
@@ -132,7 +132,7 @@ let search_guard ?loc env possible_indexes fixdefs =
        let info = Option.cata (fun loc -> Loc.add_loc info loc) info loc in
        iraise (e, info));
     indexes
-  else
+  | None ->
     (* we now search recursively among all combinations *)
     (try
        List.iter

--- a/test-suite/output/Arguments_renaming.out
+++ b/test-suite/output/Arguments_renaming.out
@@ -44,10 +44,11 @@ Argument C is implicit and maximally inserted
 Argument scopes are [type_scope _ _]
 Expands to: Constructor Top.Test1.myrefl
 myplus = 
-fix myplus (T : Type) (t : T) (n m : nat) {struct n} : nat :=
+fun (T : Type) (_ : T) =>
+fix myplus (n m : nat) {struct n} : nat :=
   match n with
   | 0 => m
-  | S n' => S (myplus T t n' m)
+  | S n' => S (myplus n' m)
   end
      : forall T : Type, T -> nat -> nat -> nat
 
@@ -81,10 +82,11 @@ Expands to: Constructor Top.myrefl
 myrefl
      : forall (A C : Type) (x : A), C -> myEq A C x x
 myplus = 
-fix myplus (T : Type) (t : T) (n m : nat) {struct n} : nat :=
+fun (T : Type) (_ : T) =>
+fix myplus (n m : nat) {struct n} : nat :=
   match n with
   | 0 => m
-  | S n' => S (myplus T t n' m)
+  | S n' => S (myplus n' m)
   end
      : forall T : Type, T -> nat -> nat -> nat
 

--- a/test-suite/output/Cases.out
+++ b/test-suite/output/Cases.out
@@ -28,11 +28,12 @@ end
 
 Argument scopes are [nat_scope nat_scope function_scope _ _]
 foo = 
-fix foo (A : Type) (l : list A) {struct l} : option A :=
+fun A : Type =>
+fix foo (l : list A) : option A :=
   match l with
   | nil => None
   | x0 :: nil => Some x0
-  | x0 :: (_ :: _) as l0 => foo A l0
+  | x0 :: (_ :: _) as l0 => foo l0
   end
      : forall A : Type, list A -> option A
 

--- a/test-suite/output/Quote.v
+++ b/test-suite/output/Quote.v
@@ -10,6 +10,7 @@ Inductive formula : Type :=
   | f_atom : index -> formula
   | f_const : Prop -> formula.
 
+Unset Fixpoints Lift Arguments.
 Fixpoint interp_f (vm:
                     varmap Prop) (f:formula) {struct f} : Prop :=
   match f with

--- a/theories/Lists/List.v
+++ b/theories/Lists/List.v
@@ -738,8 +738,8 @@ Section ListOps.
     intuition.
     subst.
     apply in_or_app; right; simpl; auto.
-    apply in_or_app; left; firstorder.
-    destruct (in_app_or _ _ _ H); firstorder.
+    apply in_or_app; left; apply IHl; auto.
+    destruct (in_app_or _ _ _ H) as [?|H0];try apply IHl in H0; firstorder.
   Qed.
 
   Lemma rev_length : forall l, length (rev l) = length l.

--- a/theories/Lists/SetoidList.v
+++ b/theories/Lists/SetoidList.v
@@ -143,7 +143,7 @@ Qed.
 Global Instance InA_compat : Proper (eqA==>equivlistA==>iff) InA.
 Proof.
  intros x x' Hxx' l l' Hll'. rewrite (Hll' x).
- rewrite 2 InA_alt; firstorder.
+ rewrite 2 InA_alt; split;intros [y [Heq HIn]];(exists y;split;[firstorder|exact HIn]).
 Qed.
 
 (** For compatibility, an immediate consequence of [InA_compat] *)

--- a/theories/Reals/Rsqrt_def.v
+++ b/theories/Reals/Rsqrt_def.v
@@ -13,6 +13,8 @@ Require Import SeqSeries.
 Require Import Ranalysis1.
 Local Open Scope R_scope.
 
+(* simpl issues *)
+Local Unset Fixpoints Lift Arguments.
 Fixpoint Dichotomy_lb (x y:R) (P:R -> bool) (N:nat) {struct N} : R :=
   match N with
     | O => x


### PR DESCRIPTION
This turns

     Fixpoint map A f l = match l with ... end

into

     fun A f => fix map l => match l with ... end

Gated by option "Fixpoints Lift Arguments" (turned on by default).

TODO doc
TODO add tests
TODO consider if mutual fixpoints break the algorithm
TODO firstorder issue #6630
TODO maybe simpl issue (see Rsqrt_def)
TODO maybe apply issue (see Field_theory and Tauto) (old unification?)
TODO look at CI results
TODO benchmark
