### PR TITLE
fix space in coqchk error

### DIFF
--- a/checker/checker.ml
+++ b/checker/checker.ml
@@ -208,8 +208,7 @@ let usage () =
 open Type_errors
 
 let anomaly_string () = str "Anomaly: "
-let report () = (str "." ++ spc () ++ str "Please report" ++
-                 strbrk "at " ++ str Coq_config.wwwbugtracker ++ str ".")
+let report () = strbrk (". Please report at " ^ Coq_config.wwwbugtracker ^ ".")
 
 let guill s = str "\"" ++ str s ++ str "\""
 


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** bug fix

Currently the checker prints things like
```
Error: Failure: bad recursive trees. Please reportat
       http://coq.inria.fr/bugs/.
```
Looks like there is a space missing? However, I have no idea what `strbrk` does, so this patch may not make any sense whatsoever.