### PR TITLE
Use travis_retry on apt-get update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,19 @@ addons:
   apt:
     sources:
     - avsm
+## Due to issues like
+## https://github.com/travis-ci/travis-ci/issues/8507 ,
+## https://github.com/travis-ci/travis-ci/issues/9000 ,
+## https://github.com/travis-ci/travis-ci/issues/9081 , and
+## https://github.com/travis-ci/travis-ci/issues/9126 , we get frequent
+## failures with using `packages`.  Therefore, for most targets, we
+## instead invoke `apt-get update` manually with `travis_retry` before
+## invoking `apt-get install`, manually, below in the `install:`
+## target.
+#    packages:
+#    - opam
+#    - aspcud
+#    - gcc-multilib
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,6 @@ addons:
   apt:
     sources:
     - avsm
-    packages:
-    - opam
-    - aspcud
-    - gcc-multilib
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -212,6 +212,8 @@ before_install:
 - if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then echo "Tested commit (followed by parent commits):"; git log -1; for commit in `git log -1 --format="%P"`; do echo; git log -1 $commit; done; fi
 
 install:
+- if [ "${TRAVIS_OS_NAME}" == "linux" ]; then travis_retry ./dev/tools/sudo-apt-get-update.sh -q; fi
+- if [ "${TRAVIS_OS_NAME}" == "linux" ]; then sudo apt-get install -y opam aspcud gcc-multilib; fi
 - opam init -j ${NJOBS} --compiler=${COMPILER} -n -y
 - eval $(opam config env)
 - opam config list

--- a/dev/tools/sudo-apt-get-update.sh
+++ b/dev/tools/sudo-apt-get-update.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+(sudo apt-get update "$@" 2>&1 || echo 'E: update failed') | tee /tmp/apt.err
+! grep -q '^\(E:\|W: Failed to fetch\)' /tmp/apt.err || exit $?


### PR DESCRIPTION
Script modified from
https://unix.stackexchange.com/questions/175146/apt-get-update-exit-status

I stuck the code in "install" rather than "before_install" so that the
lint target didn't need to be changed.  I also haven't touched the
targets that add more packages; I'll leave that to someone who knows
more about the "&" and "*" syntax being used in the configuration.

Related: #6616
