### PR TITLE
Allow vernacular controls before focus selector

### DIFF
--- a/ide/coq_lex.mll
+++ b/ide/coq_lex.mll
@@ -19,7 +19,11 @@ let space = [' ' '\n' '\r' '\t' '\012'] (* '\012' is form-feed *)
 
 let number = [ '0'-'9' ]+
 
+let string = "\"" _+ "\""
+
 let undotted_sep = (number space* ':' space*)? '{' | '}' | '-'+ | '+'+ | '*'+
+
+let vernac_control = "Fail" | "Time" | "Redirect" space+ string | "Timeout" space+ number
 
 let dot_sep = '.' (space | eof)
 
@@ -67,7 +71,7 @@ and sentence initial stamp = parse
       stamp (utf8_lexeme_start lexbuf) Tags.Script.sentence;
       sentence true stamp lexbuf
     }
-  | undotted_sep {
+  | (vernac_control space+)* undotted_sep {
       (* Separators like { or } and bullets * - + are only active
 	 at the start of a sentence *)
       if initial then stamp (utf8_lexeme_start lexbuf + String.length (Lexing.lexeme lexbuf) - 1) Tags.Script.sentence;


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

In CoqIDE, allow vernacular controls before focus, unfocus brackets, bullets when tokenizing into sentences.

<!-- Keep what applies -->
**Kind:** bug fix

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Not a complete fix for #6587. There is still the anomaly that should not occur.

<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->

