### PR TITLE
CI: Run coqchk on Iris

### DIFF
--- a/dev/ci/ci-iris-lambda-rust.sh
+++ b/dev/ci/ci-iris-lambda-rust.sh
@@ -34,8 +34,8 @@ git_checkout ${stdpp_CI_BRANCH} ${stdpp_URL_PARTS[0]} ${stdpp_CI_DIR} ${stdpp_UR
 # Build std++
 ( cd ${stdpp_CI_DIR} && make && make install )
 
-# Build iris
-( cd ${Iris_CI_DIR} && make && make install )
+# Build and validate (except on Travis, i.e., skip if TRAVIS is non-empty) Iris
+( cd ${Iris_CI_DIR} && make && (test -n "${TRAVIS}" || make validate) && make install )
 
 # Build lambdaRust
 ( cd ${lambdaRust_CI_DIR} && make && make install )


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** infrastructure (I guess).

Run `make validate` on Iris to make sure it does not regress. Notice that right now we don't run `make validate` as part of our CI; the plan is to run it in LambdaRust once <https://github.com/coq/coq/issues/5747> is fixed.