### PR TITLE
Fix evar handling in native_compute conversion

### DIFF
--- a/kernel/nativecode.mli
+++ b/kernel/nativecode.mli
@@ -44,7 +44,7 @@ val get_ind : symbols -> int -> inductive
 
 val get_meta : symbols -> int -> metavariable
 
-val get_evar : symbols -> int -> existential
+val get_evar : symbols -> int -> Evar.t
 
 val get_level : symbols -> int -> Univ.Level.t
 

--- a/kernel/nativeconv.ml
+++ b/kernel/nativeconv.ml
@@ -54,7 +54,7 @@ and conv_accu env pb lvl k1 k2 cu =
     conv_atom env pb lvl (atom_of_accu k1) (atom_of_accu k2) cu
   else
     let cu = conv_atom env pb lvl (atom_of_accu k1) (atom_of_accu k2) cu in
-    List.fold_right2 (conv_val env CONV lvl) (args_of_accu k1) (args_of_accu k2) cu
+    Array.fold_right2 (conv_val env CONV lvl) (args_of_accu k1) (args_of_accu k2) cu
 
 and conv_atom env pb lvl a1 a2 cu =
   if a1 == a2 then cu

--- a/kernel/nativeconv.ml
+++ b/kernel/nativeconv.ml
@@ -60,7 +60,12 @@ and conv_atom env pb lvl a1 a2 cu =
   if a1 == a2 then cu
   else
     match a1, a2 with
-    | Ameta _, _ | _, Ameta _ | Aevar _, _ | _, Aevar _ -> assert false
+    | Ameta (m1,_), Ameta (m2,_) ->
+      if Int.equal m1 m2 then cu else raise NotConvertible
+    | Aevar (ev1,_,args1), Aevar (ev2,_,args2) ->
+      if Evar.equal ev1 ev2 then
+        Array.fold_right2 (conv_val env CONV lvl) args1 args2 cu
+      else raise NotConvertible
     | Arel i1, Arel i2 -> 
 	if Int.equal i1 i2 then cu else raise NotConvertible
     | Aind (ind1,u1), Aind (ind2,u2) ->
@@ -112,7 +117,7 @@ and conv_atom env pb lvl a1 a2 cu =
        else conv_accu env CONV lvl ac1 ac2 cu
     | Arel _, _ | Aind _, _ | Aconstant _, _ | Asort _, _ | Avar _, _
     | Acase _, _ | Afix _, _ | Acofix _, _ | Acofixe _, _ | Aprod _, _
-    | Aproj _, _ -> raise NotConvertible
+    | Aproj _, _ | Ameta _, _ | Aevar _, _ -> raise NotConvertible
 
 (* Precondition length t1 = length f1 = length f2 = length t2 *)
 and conv_fix env lvl t1 f1 t2 f2 cu =

--- a/kernel/nativeinstr.mli
+++ b/kernel/nativeinstr.mli
@@ -23,7 +23,7 @@ and lambda =
   | Lrel          of Name.t * int 
   | Lvar          of Id.t
   | Lmeta         of metavariable * lambda (* type *)
-  | Levar         of existential * lambda (* type *)
+  | Levar         of Evar.t * lambda (* type *) * lambda array (* arguments *)
   | Lprod         of lambda * lambda 
   | Llam          of Name.t array * lambda  
   | Llet          of Name.t * lambda * lambda

--- a/kernel/nativelambda.ml
+++ b/kernel/nativelambda.ml
@@ -453,11 +453,12 @@ let rec lambda_of_constr env sigma c =
      let ty = meta_type sigma mv in
      Lmeta (mv, lambda_of_constr env sigma ty)
 
-  | Evar ev ->
+  | Evar (evk,args as ev) ->
      (match evar_value sigma ev with
      | None ->
 	let ty = evar_type sigma ev in
-	Levar(ev, lambda_of_constr env sigma ty)
+        let args = Array.map (lambda_of_constr env sigma) args in
+        Levar(evk, lambda_of_constr env sigma ty, args)
      | Some t -> lambda_of_constr env sigma t)
 
   | Cast (c, _, _) -> lambda_of_constr env sigma c

--- a/kernel/nativevalues.ml
+++ b/kernel/nativevalues.ml
@@ -61,7 +61,7 @@ type atom =
   | Acofixe of t array * t array * int * t
   | Aprod of Name.t * t * (t -> t)
   | Ameta of metavariable * t
-  | Aevar of existential * t
+  | Aevar of Evar.t * t * t array
   | Aproj of Constant.t * accumulator
 
 let accumulate_tag = 0
@@ -132,8 +132,8 @@ let mk_prod_accu s dom codom =
 let mk_meta_accu mv ty =
   mk_accu (Ameta (mv,ty))
 
-let mk_evar_accu ev ty =
-  mk_accu (Aevar (ev,ty))
+let mk_evar_accu ev ty args =
+  mk_accu (Aevar (ev,ty,args))
 
 let mk_proj_accu kn c = 
   mk_accu (Aproj (kn,c))

--- a/kernel/nativevalues.ml
+++ b/kernel/nativevalues.ml
@@ -153,8 +153,7 @@ let accu_nargs (k:accumulator) =
 let args_of_accu (k:accumulator) =
   let nargs = accu_nargs k in
   let f i = (Obj.magic (Obj.field (Obj.magic k) (nargs-i+2)) : t) in
-  let t = Array.init nargs f in
-  Array.to_list t
+  Array.init nargs f
 
 let is_accu x =
   let o = Obj.repr x in
@@ -179,11 +178,10 @@ let force_cofix (cofix : t) =
     let atom = atom_of_accu accu in
     match atom with
     | Acofix(typ,norm,pos,f) ->
-	let f = ref f in
-    let args = List.rev (args_of_accu accu) in
-    List.iter (fun x -> f := !f x) args;
-	let v = !f (Obj.magic ()) in
-	set_atom_of_accu accu (Acofixe(typ,norm,pos,v));
+      let args = args_of_accu accu in
+      let f = Array.fold_right (fun arg f -> f arg) args f in
+      let v = f (Obj.magic ()) in
+      set_atom_of_accu accu (Acofixe(typ,norm,pos,v));
 	v
     | Acofixe(_,_,_,v) -> v 
     | _ -> cofix

--- a/kernel/nativevalues.mli
+++ b/kernel/nativevalues.mli
@@ -51,7 +51,7 @@ type atom =
   | Acofixe of t array * t array * int * t
   | Aprod of Name.t * t * (t -> t)
   | Ameta of metavariable * t
-  | Aevar of existential * t
+  | Aevar of Evar.t * t (* type *) * t array (* arguments *)
   | Aproj of Constant.t * accumulator
 
 (* Constructors *)
@@ -68,7 +68,7 @@ val mk_prod_accu : Name.t -> t -> t -> t
 val mk_fix_accu : rec_pos  -> int -> t array -> t array -> t
 val mk_cofix_accu : int -> t array -> t array -> t
 val mk_meta_accu : metavariable -> t
-val mk_evar_accu : existential -> t -> t
+val mk_evar_accu : Evar.t -> t -> t array -> t
 val mk_proj_accu : Constant.t -> accumulator -> t
 val upd_cofix : t -> t -> unit
 val force_cofix : t -> t 

--- a/kernel/nativevalues.mli
+++ b/kernel/nativevalues.mli
@@ -84,7 +84,7 @@ val napply : t -> t array -> t
 
 val dummy_value : unit -> t
 val atom_of_accu : accumulator -> atom
-val args_of_accu : accumulator -> t list
+val args_of_accu : accumulator -> t array
 val accu_nargs : accumulator -> int
 
 val cast_accu : t -> accumulator

--- a/pretyping/nativenorm.ml
+++ b/pretyping/nativenorm.ml
@@ -246,7 +246,7 @@ and nf_args env sigma accu t =
     let c = nf_val env sigma arg dom in
     (subst1 c codom, c::l)
   in
-  let t,l = List.fold_right aux (args_of_accu accu) (t,[]) in
+  let t,l = Array.fold_right aux (args_of_accu accu) (t,[]) in
   t, List.rev l
 
 and nf_bargs env sigma b t =


### PR DESCRIPTION
This PR improves the handling of evars in `native_compute`. Unlike `vm_compute`, they were already supported, but triggering anomalies on some examples in conversion, for example on:

`Check eq_refl <<: true = true.`

Inspired by #935.