### PR TITLE
Delay computation of lifts in the reduction machine.

### DIFF
--- a/kernel/reduction.ml
+++ b/kernel/reduction.ml
@@ -336,9 +336,8 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
     if in_whnf st1' then (st1',st2') else whd_both st1' st2' in
   let ((hd1,v1),(hd2,v2)) = whd_both st1 st2 in
   let appr1 = (lft1,(hd1,v1)) and appr2 = (lft2,(hd2,v2)) in
-  (* compute the lifts that apply to the head of the term (hd1 and hd2) *)
-  let el1 = el_stack lft1 v1 in
-  let el2 = el_stack lft2 v2 in
+  (** We delay the computation of the lifts that apply to the head of the term
+      with [el_stack] inside the branches where they are actually used. *)
   match (fterm_of hd1, fterm_of hd2) with
     (* case of leaves *)
     | (FAtom a1, FAtom a2) ->
@@ -354,6 +353,8 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
 	   | _ -> raise NotConvertible)
     | (FEvar ((ev1,args1),env1), FEvar ((ev2,args2),env2)) ->
         if Evar.equal ev1 ev2 then
+          let el1 = el_stack lft1 v1 in
+          let el2 = el_stack lft2 v2 in
           let cuniv = convert_stacks l2r infos lft1 lft2 v1 v2 cuniv in
           convert_vect l2r infos el1 el2
             (Array.map (mk_clos env1) args1)
@@ -362,6 +363,8 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
 
     (* 2 index known to be bound to no constant *)
     | (FRel n, FRel m) ->
+        let el1 = el_stack lft1 v1 in
+        let el2 = el_stack lft2 v2 in
         if Int.equal (reloc_rel n el1) (reloc_rel m el2)
         then convert_stacks l2r infos lft1 lft2 v1 v2 cuniv
         else raise NotConvertible
@@ -406,6 +409,8 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
 	| None -> 
           if Constant.equal (Projection.constant p1) (Projection.constant p2)
 	     && compare_stack_shape v1 v2 then
+            let el1 = el_stack lft1 v1 in
+            let el2 = el_stack lft2 v2 in
             let u1 = ccnv CONV l2r infos el1 el2 c1 c2 cuniv in
               convert_stacks l2r infos lft1 lft2 v1 v2 u1
 	  else (* Two projections in WHNF: unfold *)
@@ -445,6 +450,8 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
 	  anomaly (Pp.str "conversion was given ill-typed terms (FLambda).");
         let (_,ty1,bd1) = destFLambda mk_clos hd1 in
         let (_,ty2,bd2) = destFLambda mk_clos hd2 in
+        let el1 = el_stack lft1 v1 in
+        let el2 = el_stack lft2 v2 in
         let cuniv = ccnv CONV l2r infos el1 el2 ty1 ty2 cuniv in
         ccnv CONV l2r infos (el_lift el1) (el_lift el2) bd1 bd2 cuniv
 
@@ -452,6 +459,8 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
         if not (is_empty_stack v1 && is_empty_stack v2) then
 	  anomaly (Pp.str "conversion was given ill-typed terms (FProd).");
 	(* Luo's system *)
+        let el1 = el_stack lft1 v1 in
+        let el2 = el_stack lft2 v2 in
         let cuniv = ccnv CONV l2r infos el1 el2 c1 c'1 cuniv in
         ccnv cv_pb l2r infos (el_lift el1) (el_lift el2) c2 c'2 cuniv
 
@@ -564,6 +573,8 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
           let fty2 = Array.map (mk_clos e2) tys2 in
           let fcl1 = Array.map (mk_clos (subs_liftn n e1)) cl1 in
           let fcl2 = Array.map (mk_clos (subs_liftn n e2)) cl2 in
+          let el1 = el_stack lft1 v1 in
+          let el2 = el_stack lft2 v2 in
           let cuniv = convert_vect l2r infos el1 el2 fty1 fty2 cuniv in
           let cuniv =
             convert_vect l2r infos
@@ -579,6 +590,8 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
           let fty2 = Array.map (mk_clos e2) tys2 in
           let fcl1 = Array.map (mk_clos (subs_liftn n e1)) cl1 in
           let fcl2 = Array.map (mk_clos (subs_liftn n e2)) cl2 in
+          let el1 = el_stack lft1 v1 in
+          let el2 = el_stack lft2 v2 in
           let cuniv = convert_vect l2r infos el1 el2 fty1 fty2 cuniv in
           let cuniv =
             convert_vect l2r infos


### PR DESCRIPTION
This definitely qualifies as a micro-optimization, but it would not be performed by Flambda. Indeed, it is unsound in general w.r.t. OCaml semantics, as it involves a fixpoint and changes potential non-termination. In our case it doesn't matter semantically, but it is indeed observable on computation-intensive developments like UniMath.

Benchmark:
```
┌──────────────────────────┬─────────────────────────┬─────────────────────────────────────┬───────────────────────────────────────┬─────────────────────────┬─────────────────┐
│                          │      user time [s]      │             CPU cycles              │           CPU instructions            │  max resident mem [KB]  │   mem faults    │
│                          │                         │                                     │                                       │                         │                 │
│             package_name │     NEW     OLD PDIFF   │           NEW           OLD PDIFF   │            NEW            OLD PDIFF   │     NEW     OLD PDIFF   │ NEW OLD PDIFF   │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│              coq-unimath │ 1229.90 1295.43 -5.06 % │ 3430107160307 3616415501524 -5.15 % │  5924008383562  6270772400601 -5.53 % │ 1116104 1042748 +7.03 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│       coq-mathcomp-field │  441.01  451.07 -2.23 % │ 1228168199693 1256954318061 -2.29 % │  2025356155075  2099026320614 -3.51 % │  723660  725428 -0.24 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│ coq-mathcomp-real_closed │  165.68  168.43 -1.63 % │  460540668798  468061231422 -1.61 % │   699448756254   717319573679 -2.49 % │  725668  727004 -0.18 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│               coq-geocoq │ 3040.87 3089.57 -1.58 % │ 8481337062911 8620098946590 -1.61 % │ 13925826929158 14282959858608 -2.50 % │ 1248652 1211236 +3.09 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│   coq-mathcomp-character │  263.55  266.74 -1.20 % │  732300342428  741516342968 -1.24 % │  1078053098597  1097086769579 -1.73 % │  982568  982836 -0.03 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│     coq-mathcomp-algebra │  169.31  171.22 -1.12 % │  470156842470  476483095299 -1.33 % │   662089991808   677033574391 -2.21 % │  590488  587752 +0.47 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│    coq-mathcomp-fingroup │   60.01   60.68 -1.10 % │  165876884761  167564079239 -1.01 % │   230112280867   233766610045 -1.56 % │  525720  529132 -0.64 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│    coq-mathcomp-solvable │  189.82  191.84 -1.05 % │  527195749861  533058536847 -1.10 % │   761232307410   774255040150 -1.68 % │  711708  711972 -0.04 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│   coq-mathcomp-odd_order │ 1357.88 1370.20 -0.90 % │ 3783415920554 3817696557321 -0.90 % │  6614162210562  6682114816314 -1.02 % │ 1063232 1081008 -1.64 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│              coq-bignums │   74.10   74.54 -0.59 % │  206789798201  207523737605 -0.35 % │   280855717866   281918076162 -0.38 % │  522788  522216 +0.11 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│                coq-color │  560.12  562.78 -0.47 % │ 1568160627655 1573313101675 -0.33 % │  1971251268709  1976995752187 -0.29 % │ 1438296 1438644 -0.02 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│          coq-fiat-crypto │ 3497.93 3510.23 -0.35 % │ 9754073856238 9777372139940 -0.24 % │ 16476326191604 16538819267464 -0.38 % │ 3195836 3193528 +0.07 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│           coq-coquelicot │   75.58   75.76 -0.24 % │  208290374774  208855038211 -0.27 % │   261478796402   262236174780 -0.29 % │  657336  657324 +0.00 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│             coq-compcert │  805.51  807.36 -0.23 % │ 2246324794882 2249262588267 -0.13 % │  3405766616130  3414078586582 -0.24 % │ 1353760 1353780 -0.00 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│                coq-flocq │   58.65   58.75 -0.17 % │  161576451310  162331759361 -0.47 % │   208160802591   209889272681 -0.82 % │  646544  650284 -0.58 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│            coq-fiat-core │  100.11  100.16 -0.05 % │  285700370127  286078498828 -0.13 % │   371840756019   372096435192 -0.07 % │  500904  500832 +0.01 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│         coq-fiat-parsers │  652.46  652.28 +0.03 % │ 1823331747778 1826125197509 -0.15 % │  2963716786358  2970295498509 -0.22 % │ 3396288 3516056 -3.41 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│   coq-mathcomp-ssreflect │   39.84   39.74 +0.25 % │  109734758250  109952738583 -0.20 % │   135561746394   136222073584 -0.48 % │  477680  477920 -0.05 % │   0   0  +nan % │
└──────────────────────────┴─────────────────────────┴─────────────────────────────────────┴───────────────────────────────────────┴─────────────────────────┴─────────────────┘
```