### PR TITLE
[proofview] goals come with a state

### DIFF
--- a/dev/ci/user-overlays/06676-gares-proofview-goals-come-with-a-state.sh
+++ b/dev/ci/user-overlays/06676-gares-proofview-goals-come-with-a-state.sh
@@ -1,0 +1,6 @@
+if [ "$CI_PULL_REQUEST" = "6676" ] || [ "$CI_BRANCH" = "proofview/goal-w-state" ]; then
+    ltac2_CI_BRANCH=fix-for/6676
+    ltac2_CI_GITURL=https://github.com/gares/ltac2.git
+    Equations_CI_BRANCH=fix-for/6676
+    Equations_CI_GITURL=https://github.com/gares/Coq-Equations.git
+fi

--- a/engine/proofview.mli
+++ b/engine/proofview.mli
@@ -72,7 +72,15 @@ val return : proofview -> Evd.evar_map
 val partial_proof : entry -> proofview -> constr list
 val initial_goals : entry -> (constr * types) list
 
+(** goal <-> goal_with_state *)
 
+val with_empty_state :
+  Proofview_monad.goal ->  Proofview_monad.goal_with_state
+val drop_state :
+  Proofview_monad.goal_with_state -> Proofview_monad.goal
+val goal_with_state :
+  Proofview_monad.goal -> Proofview_monad.StateStore.t ->
+    Proofview_monad.goal_with_state
 
 (** {6 Focusing commands} *)
 
@@ -416,14 +424,14 @@ module Unsafe : sig
   (** [tclNEWGOALS gls] adds the goals [gls] to the ones currently
       being proved, appending them to the list of focused goals. If a
       goal is already solved, it is not added. *)
-  val tclNEWGOALS : Evar.t list -> unit tactic
+  val tclNEWGOALS : Proofview_monad.goal_with_state list -> unit tactic
 
   (** [tclSETGOALS gls] sets goals [gls] as the goals being under focus. If a
       goal is already solved, it is not set. *)
-  val tclSETGOALS : Evar.t list -> unit tactic
+  val tclSETGOALS : Proofview_monad.goal_with_state list -> unit tactic
 
   (** [tclGETGOALS] returns the list of goals under focus. *)
-  val tclGETGOALS : Evar.t list tactic
+  val tclGETGOALS : Proofview_monad.goal_with_state list tactic
 
   (** Sets the evar universe context. *)
   val tclEVARUNIVCONTEXT : UState.t -> unit tactic
@@ -480,6 +488,7 @@ module Goal : sig
   val env : t -> Environ.env
   val sigma : t -> Evd.evar_map
   val extra : t -> Evd.Store.t
+  val state : t -> Proofview_monad.StateStore.t
 
   (** [nf_enter t] applies the goal-dependent tactic [t] in each goal
       independently, in the manner of {!tclINDEPENDENT} except that

--- a/plugins/ltac/extratactics.ml4
+++ b/plugins/ltac/extratactics.ml4
@@ -973,6 +973,7 @@ TACTIC EXTEND unshelve
 | [ "unshelve" tactic1(t) ] ->
     [
       Proofview.with_shelf (Tacinterp.tactic_of_value ist t) >>= fun (gls, ()) ->
+      let gls = List.map Proofview.with_empty_state gls in
       Proofview.Unsafe.tclGETGOALS >>= fun ogls ->
       Proofview.Unsafe.tclSETGOALS (gls @ ogls)
     ]

--- a/plugins/ltac/rewrite.ml
+++ b/plugins/ltac/rewrite.ml
@@ -1568,7 +1568,8 @@ let cl_rewrite_clause_newtac ?abs ?origsigma ~progress strat clause =
         let (undef, prf, newt) = res in
         let fold ev _ accu = if Evd.mem sigma ev then accu else ev :: accu in
         let gls = List.rev (Evd.fold_undefined fold undef []) in
-	match clause, prf with
+        let gls = List.map Proofview.with_empty_state gls in
+          match clause, prf with
 	| Some id, Some p ->
             let tac = tclTHENLIST [
               Refine.refine ~typecheck:true (fun h -> (h,p));

--- a/proofs/refine.ml
+++ b/proofs/refine.ml
@@ -73,6 +73,7 @@ let generic_refine ~typecheck f gl =
   let sigma = Proofview.Goal.sigma gl in
   let env = Proofview.Goal.env gl in
   let concl = Proofview.Goal.concl gl in
+  let state = Proofview.Goal.state gl in
   (** Save the [future_goals] state to restore them after the
       refinement. *)
   let prev_future_goals = Evd.future_goals sigma in
@@ -120,6 +121,7 @@ let generic_refine ~typecheck f gl =
   (** Select the goals *)
   let comb = CList.map_filter (Proofview.Unsafe.advance sigma) (CList.rev evs) in
   let sigma = CList.fold_left Proofview.Unsafe.mark_as_goal sigma comb in
+  let comb = CList.map (fun x -> Proofview.goal_with_state x state) comb in
   let trace () = Pp.(hov 2 (str"simple refine"++spc()++ Hook.get pr_constrv env sigma c)) in
   Proofview.Trace.name_tactic trace (Proofview.tclUNIT v) >>= fun v ->
   Proofview.Unsafe.tclSETENV (Environ.reset_context env) <*>

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -1131,6 +1131,7 @@ module Search = struct
       let rec result (shelf, ()) i k =
         foundone := true;
         Proofview.Unsafe.tclGETGOALS >>= fun gls ->
+        let gls = CList.map Proofview.drop_state gls in
         let j = List.length gls in
         (if !typeclasses_debug > 0 then
            Feedback.msg_debug
@@ -1179,7 +1180,7 @@ module Search = struct
               (if List.is_empty goals then tclUNIT ()
                else
 	         let sigma' = mark_unresolvables sigma goals in
-	         with_shelf (Unsafe.tclEVARS sigma' <*> Unsafe.tclNEWGOALS goals) >>=
+                 with_shelf (Unsafe.tclEVARS sigma' <*> Unsafe.tclNEWGOALS (CList.map Proofview.with_empty_state goals)) >>=
                       fun s -> result s i (Some (Option.default 0 k + j)))
           end
         in with_shelf res >>= fun (sh, ()) ->
@@ -1272,6 +1273,7 @@ module Search = struct
           search_tac_gl ~st only_classes dep hints depth (succ i) sigma gls gl end
     in
       Proofview.Unsafe.tclGETGOALS >>= fun gls ->
+      let gls = CList.map Proofview.drop_state gls in
       Proofview.tclEVARMAP >>= fun sigma ->
       let j = List.length gls in
       (tclDISPATCH (List.init j (fun i -> tac sigma gls i)))

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -334,7 +334,7 @@ let new_instance ?(abstract=false) ?(global=false) ?(refine= !refine_instance)
                   let init_refine =
                     Tacticals.New.tclTHENLIST [
                       Refine.refine ~typecheck:false (fun sigma -> (sigma,EConstr.of_constr (Option.get term)));
-                      Proofview.Unsafe.tclNEWGOALS gls;
+                      Proofview.Unsafe.tclNEWGOALS (CList.map Proofview.with_empty_state gls);
                       Tactics.New.reduce_after_refine;
                     ]
                   in


### PR DESCRIPTION
This PR attaches to goals a (extensible) state.
The purpose is to make the threading of data between sub-tactics easy, in turn to let one write tactics out of smaller components.

For example take the goal:
```
=====
forall a, a = 3 -> G
```
the semantics of `=> _ b` (for any b) is `intro "_a_" <*> b <*> clear "_a_"`.
The actual clear is delayed to accommodate cases in which "_a_" is used in the goal, but the rest of the intro patters (`b` in the example) gets rid of all occurrences of `_a_` (examples of such `b` is `->`, or `_` if `G` does not contain `a`).

Of course one could process the entire sequence of ipat in one gigantic tactic, but I want to write it in the
more natural/compositional style `init_state <*> ipat_1 <*>... <*> ipat_n <*> end_state`.  For this to work some state (e.g. the list of hyps to be cleared) has to be threaded with goals and inherited by subgoals (e.g. is a clear was scheduled, and a case (`[]`) is performed, all branches have to inherit the set of hyps to be cleared).

This PR is related to the work of implementing the intro-patter-machine (`ssripats.ml`) in the tactic monad.