### PR TITLE
Use whd-all on rigid-flex conversion.

### DIFF
--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -91,6 +91,7 @@ module type RedFlagsSig = sig
   val red_add : reds -> red_kind -> reds
   val red_sub : reds -> red_kind -> reds
   val red_add_transparent : reds -> transparent_state -> reds
+  val red_transparent : reds -> transparent_state
   val mkflags : red_kind list -> reds
   val red_set : reds -> red_kind -> bool
   val red_projection : reds -> projection -> bool
@@ -163,6 +164,8 @@ module RedFlags = (struct
     | VAR id ->
 	let (l1,l2) = red.r_const in
 	{ red with r_const = Id.Pred.remove id l1, l2 }
+
+  let red_transparent red = red.r_const
 
   let red_add_transparent red tr =
     { red with r_const = tr }

--- a/kernel/cClosure.mli
+++ b/kernel/cClosure.mli
@@ -61,6 +61,9 @@ module type RedFlagsSig = sig
   (** Adds a reduction kind to a set *)
   val red_add_transparent : reds -> transparent_state -> reds
 
+  (** Retrieve the transparent state of the reduction flags *)
+  val red_transparent : reds -> transparent_state
+
   (** Build a reduction set from scratch = iter [red_add] on [no_red] *)
   val mkflags : red_kind list -> reds
 

--- a/kernel/reduction.ml
+++ b/kernel/reduction.ml
@@ -483,6 +483,7 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
               Conversion check to rigid terms eventually implies full weak-head
               reduction, so instead of repeatedly performing small-step
               unfoldings, we perform reduction with all flags on. *)
+            let all = RedFlags.red_add_transparent all (RedFlags.red_transparent (info_flags infos)) in
             let r1 = whd_stack (infos_with_reds infos all) def1 v1 in
             eqappr cv_pb l2r infos (lft1, r1) appr2 cuniv
 	| None -> 
@@ -499,6 +500,7 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
        (match unfold_reference infos fl2 with
         | Some def2 ->
           (** Symmetrical case of above. *)
+          let all = RedFlags.red_add_transparent all (RedFlags.red_transparent (info_flags infos)) in
           let r2 = whd_stack (infos_with_reds infos all) def2 v2 in
           eqappr cv_pb l2r infos appr1 (lft2, r2) cuniv
         | None -> 

--- a/kernel/reduction.ml
+++ b/kernel/reduction.ml
@@ -479,7 +479,12 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
     | (FFlex fl1, c2)      ->
        (match unfold_reference infos fl1 with
 	| Some def1 ->
-           eqappr cv_pb l2r infos (lft1, (def1, v1)) appr2 cuniv
+          (** By virtue of the previous case analyses, we know [c2] is rigid.
+              Conversion check to rigid terms eventually implies full weak-head
+              reduction, so instead of repeatedly performing small-step
+              unfoldings, we perform reduction with all flags on. *)
+            let r1 = whd_stack (infos_with_reds infos all) def1 v1 in
+            eqappr cv_pb l2r infos (lft1, r1) appr2 cuniv
 	| None -> 
 	   match c2 with
 	   | FConstruct ((ind2,j2),u2) ->
@@ -493,7 +498,9 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
     | (c1, FFlex fl2)      ->
        (match unfold_reference infos fl2 with
         | Some def2 ->
-           eqappr cv_pb l2r infos appr1 (lft2, (def2, v2)) cuniv
+          (** Symmetrical case of above. *)
+          let r2 = whd_stack (infos_with_reds infos all) def2 v2 in
+          eqappr cv_pb l2r infos appr1 (lft2, r2) cuniv
         | None -> 
 	   match c1 with
 	   | FConstruct ((ind1,j1),u1) ->


### PR DESCRIPTION
This heuristic is justified by the fact that during a conversion check
between a flexible and a rigid term, the flexible one is eventually going
to be fully weak-head normalized. So in this case instead of performing
many small reduction steps on the flexible term, we perform full weak-head
reduction, including delta.

It is slightly more efficient in actual developments, and it fixes a corner
case encountered by Jason Gross.

Fixes #6667: Kernel conversion is much, much slower than `Eval lazy`.

Benchmark:
```
┌──────────────────────────┬─────────────────────────┬─────────────────────────────────────┬───────────────────────────────────────┬─────────────────────────┬─────────────────┐
│                          │      user time [s]      │             CPU cycles              │           CPU instructions            │  max resident mem [KB]  │   mem faults    │
│                          │                         │                                     │                                       │                         │                 │
│             package_name │     NEW     OLD PDIFF   │           NEW           OLD PDIFF   │            NEW            OLD PDIFF   │     NEW     OLD PDIFF   │ NEW OLD PDIFF   │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│              coq-unimath │ 1241.31 1297.21 -4.31 % │ 3458345226440 3614097727778 -4.31 % │  6024111291256  6272321576988 -3.96 % │ 1136176 1042768 +8.96 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│     coq-mathcomp-algebra │  168.40  171.22 -1.65 % │  467216422178  475865017909 -1.82 % │   663891862312   677263614242 -1.97 % │  597020  587852 +1.56 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│    coq-mathcomp-solvable │  189.26  191.26 -1.05 % │  526923710620  531816438132 -0.92 % │   770081309560   774157553526 -0.53 % │  715176  711864 +0.47 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│   coq-mathcomp-character │  263.61  266.37 -1.04 % │  732932485095  740246738635 -0.99 % │  1089891725405  1095017816038 -0.47 % │  982624  982968 -0.03 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│          coq-fiat-crypto │ 3469.04 3499.29 -0.86 % │ 9664482828760 9749083704837 -0.87 % │ 16389337243988 16537641162212 -0.90 % │ 3190868 3194496 -0.11 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│    coq-mathcomp-fingroup │   59.92   60.44 -0.86 % │  165868473256  166983753191 -0.67 % │   232891989094   234018111075 -0.48 % │  526860  529124 -0.43 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│                coq-flocq │   58.58   59.05 -0.80 % │  161631117313  162415305102 -0.48 % │   208427507339   209924941195 -0.71 % │  646344  650176 -0.59 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│   coq-mathcomp-odd_order │ 1352.63 1363.46 -0.79 % │ 3769030715806 3799891967199 -0.81 % │  6653741138654  6683580820421 -0.45 % │ 1052652 1073920 -1.98 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│              coq-bignums │   74.22   74.78 -0.75 % │  206505082713  207271292283 -0.37 % │   281491229031   281875637748 -0.14 % │  522132  522248 -0.02 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│ coq-mathcomp-real_closed │  167.06  168.22 -0.69 % │  464365707520  467577560635 -0.69 % │   715225148437   717214910266 -0.28 % │  728932  726020 +0.40 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│           coq-coquelicot │   75.54   76.00 -0.61 % │  208578827541  208704560817 -0.06 % │   262589313272   262377980030 +0.08 % │  657824  657380 +0.07 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│               coq-geocoq │ 3063.56 3081.48 -0.58 % │ 8546325762611 8594296084665 -0.56 % │ 14315274807601 14283473878855 +0.22 % │ 1248640 1211236 +3.09 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│       coq-mathcomp-field │  449.02  451.01 -0.44 % │ 1248464349227 1256334284014 -0.63 % │  2093610410890  2099272693122 -0.27 % │  721936  725908 -0.55 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│         coq-fiat-parsers │  649.84  652.52 -0.41 % │ 1820440366451 1827330390101 -0.38 % │  2964494645257  2970754490881 -0.21 % │ 3508092 3515844 -0.22 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│   coq-mathcomp-ssreflect │   39.62   39.70 -0.20 % │  109136880644  109660017420 -0.48 % │   135782879715   136234019613 -0.33 % │  475396  477908 -0.53 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│             coq-compcert │  793.96  795.48 -0.19 % │ 2214121241856 2218144073337 -0.18 % │  3412680885303  3413579988700 -0.03 % │ 1337796 1354420 -1.23 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│                coq-color │  561.31  561.22 +0.02 % │ 1571827330020 1570230711952 +0.10 % │  1977361972261  1977052168443 +0.02 % │ 1442764 1437956 +0.33 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│            coq-fiat-core │  100.59   99.74 +0.85 % │  285556279108  285474171780 +0.03 % │   371664793614   372152245302 -0.13 % │  500700  500388 +0.06 % │   0   0  +nan % │
└──────────────────────────┴─────────────────────────┴─────────────────────────────────────┴───────────────────────────────────────┴─────────────────────────┴─────────────────┘


```