### PR TITLE
Deprecate { … } syntax for instance definitions. Recommend {| … |} instead.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -60,6 +60,9 @@ Vernacular Commands
   was removed. Use Local as a prefix instead.
 - For the Extraction Language command, "OCaml" is spelled correctly.
   The older "Ocaml" is still accepted, but deprecated.
+- To define instances, prefer record-like syntax {| … |} and deprecate the
+  lone brace syntax { … }. Bidirectional type-inference can be enabled using
+  Program.
 
 Universes
 

--- a/doc/refman/Classes.tex
+++ b/doc/refman/Classes.tex
@@ -35,11 +35,11 @@ record syntax of \Coq:
 \end{center}
 \begin{center}
 \[\begin{array}{l}
-\kw{Instance}~\ident~:~\classid{Id}~\term_1 \cdots \term_n := \{\\
+\kw{Instance}~\ident~:~\classid{Id}~\term_1 \cdots \term_n := \{|\\
 \begin{array}{p{0em}lcl}
   & \cst{f}_1 & := & \term_{f_1} ; \\
   & \vdots & &  \\
-  & \cst{f}_m & := & \term_{f_m} \}.
+  & \cst{f}_m & := & \term_{f_m} |\}.
 \end{array}\end{array}\]
 \end{center}
 \begin{coq_eval}
@@ -66,9 +66,9 @@ Leibniz equality on some type. An example implementation is:
 
 \begin{coq_example*}
 Instance unit_EqDec : EqDec unit :=
-{ eqb x y := true ;
+{| eqb x y := true ;
   eqb_leibniz x y H := 
-    match x, y return x = y with tt, tt => eq_refl tt end }.
+    match x, y return x = y with tt, tt => eq_refl tt end |}.
 \end{coq_example*}
 
 If one does not give all the members in the \texttt{Instance}
@@ -77,7 +77,7 @@ inhabitants of the remaining fields, e.g.:
 
 \begin{coq_example*}
 Instance eq_bool : EqDec bool :=
-{ eqb x y := if x then y else negb y }.
+{| eqb (x y: bool) := if x then y else negb y |}.
 \end{coq_example*}
 \begin{coq_example}
 Proof. intros x y H.
@@ -147,9 +147,9 @@ the constraints as a binding context before the instance, e.g.:
 
 \begin{coq_example}
 Instance prod_eqb `(EA : EqDec A, EB : EqDec B) : EqDec (A * B) :=
-{ eqb x y := match x, y with
+{| eqb x y := match x, y with
   | (la, ra), (lb, rb) => andb (eqb la lb) (eqb ra rb)
-  end }.
+  end |}.
 \end{coq_example}
 \begin{coq_eval}
 Admitted.
@@ -173,11 +173,11 @@ Section EqDec_defs.
 
 \begin{coq_example*}
   Global Instance option_eqb : EqDec (option A) :=
-  { eqb x y := match x, y with
+  {| eqb x y := match x, y with
     | Some x, Some y => eqb x y
     | None, None => true
     | _, _ => false
-    end }.
+    end |}.
 \end{coq_example*}
 \begin{coq_eval}
 Proof.
@@ -310,7 +310,7 @@ parameters {\binder$_1$} to {\binder$_n$} and fields {\tt field$_1$} to
 
 \subsection{\tt Instance {\ident} {\binder$_1$ \ldots \binder$_n$} :
   {Class} {t$_1$ \ldots t$_n$} [| \textit{priority}]
-  := \{ field$_1$ := b$_1$ ; \ldots ; field$_i$ := b$_i$ \}}
+  := \{| field$_1$ := b$_1$ ; \ldots ; field$_i$ := b$_i$ |\}}
 \comindex{Instance}
 \label{Instance}
 

--- a/parsing/g_vernac.ml4
+++ b/parsing/g_vernac.ml4
@@ -603,6 +603,10 @@ let warn_deprecated_implicit_arguments =
   CWarnings.create ~name:"deprecated-implicit-arguments" ~category:"deprecated"
          (fun () -> strbrk "Implicit Arguments is deprecated; use Arguments instead")
 
+let warn_deprecated_lone_braces =
+  CWarnings.create ~name:"deprecated-lone-braces" ~category:"deprecated"
+         (fun () -> strbrk "Lone braces syntax { … } is deprecated: use record notation {| … |} instead.")
+
 (* Extensions: implicits, coercions, etc. *)
 GEXTEND Gram
   GLOBAL: gallina_ext instance_name hint_info;
@@ -645,7 +649,9 @@ GEXTEND Gram
       | IDENT "Instance"; namesup = instance_name; ":";
 	 expl = [ "!" -> Decl_kinds.Implicit | -> Decl_kinds.Explicit ] ; t = operconstr LEVEL "200";
 	 info = hint_info ;
-	 props = [ ":="; "{"; r = record_declaration; "}" -> Some (true,r) |
+        props = [ ":="; "{"; r = record_declaration; "}" ->
+          warn_deprecated_lone_braces ~loc:!@loc ();
+          Some (true,r) |
 	     ":="; c = lconstr -> Some (false,c) | -> None ] ->
 	   VernacInstance (false,snd namesup,(fst namesup,expl,t),props,info)
 

--- a/plugins/btauto/Algebra.v
+++ b/plugins/btauto/Algebra.v
@@ -127,20 +127,20 @@ End Definitions.
 
 Section Computational.
 
-Program Instance Decidable_PosEq : forall (p q : positive), Decidable (p = q) :=
-  { Decidable_witness := Pos.eqb p q }.
+Program Instance Decidable_PosEq (p q : positive) : Decidable (p = q) :=
+  {| Decidable_witness := Pos.eqb p q |}.
 Next Obligation.
 apply Pos.eqb_eq.
 Qed.
 
-Program Instance Decidable_PosLt : forall p q, Decidable (Pos.lt p q) :=
-  { Decidable_witness := Pos.ltb p q }.
+Program Instance Decidable_PosLt p q : Decidable (Pos.lt p q) :=
+  {| Decidable_witness := Pos.ltb p q |}.
 Next Obligation.
 apply Pos.ltb_lt.
 Qed.
 
-Program Instance Decidable_PosLe : forall p q, Decidable (Pos.le p q) :=
-  { Decidable_witness := Pos.leb p q }.
+Program Instance Decidable_PosLe p q : Decidable (Pos.le p q) :=
+  {| Decidable_witness := Pos.leb p q |}.
 Next Obligation.
 apply Pos.leb_le.
 Qed.
@@ -165,9 +165,9 @@ match pl with
 end.
 
 (* We could do that with [decide equality] but dependency in proofs is heavy *)
-Program Instance Decidable_eq_poly : forall (p q : poly), Decidable (eq p q) := {
+Program Instance Decidable_eq_poly (p q : poly) : Decidable (eq p q) := {|
   Decidable_witness := beq_poly p q
-}.
+|}.
 
 Next Obligation.
 split.
@@ -177,9 +177,9 @@ revert q; induction p; intros [] Heq; simpl in *; bool; try_decide; intuition;
   try injection Heq; first[congruence|intuition].
 Qed.
 
-Program Instance Decidable_null : forall p, Decidable (null p) := {
+Program Instance Decidable_null p : Decidable (null p) := {|
   Decidable_witness := match p with Cst false => true | _ => false end
-}.
+|}.
 Next Obligation.
 split.
   destruct p as [[]|]; first [discriminate|constructor].
@@ -207,9 +207,9 @@ match p with
     valid_dec i p && valid_dec (Pos.succ i) q
 end.
 
-Program Instance Decidable_valid : forall n p, Decidable (valid n p) := {
+Program Instance Decidable_valid n p : Decidable (valid n p) := {|
   Decidable_witness := valid_dec n p
-}.
+|}.
 Next Obligation.
 split.
   revert n; induction p; unfold valid_dec in *; intuition; bool; try_decide; auto.

--- a/plugins/setoid_ring/Ncring.v
+++ b/plugins/setoid_ring/Ncring.v
@@ -87,7 +87,7 @@ Definition ZN(x:Z):=
 end.
 
 Instance power_ring {R:Type}`{Ring R} : Power:=
-  {power x y := pow_N x (ZN y)}.
+  fun x y => pow_N x (ZN y).
 
 (** Interpretation morphisms definition*)
 

--- a/plugins/setoid_ring/Ncring_initial.v
+++ b/plugins/setoid_ring/Ncring_initial.v
@@ -207,4 +207,4 @@ reflexivity.
 End ZMORPHISM.
 
 Instance multiplication_phi_ring{R:Type}`{Ring R} : Multiplication  :=
-  {multiplication x y := (gen_phiZ x) * y}.
+  fun x y => (gen_phiZ x) * y.

--- a/plugins/setoid_ring/Ncring_polynom.v
+++ b/plugins/setoid_ring/Ncring_polynom.v
@@ -46,7 +46,7 @@ Notation "x =? y" := (equalityb x y) (at level 70, no associativity).
 Variable Ceqb_eq: forall x y:C, Ceqb x y = true -> (x == y).
 
 Instance equalityb_coef : Equalityb C :=
-  {equalityb x y := Ceqb x y}.
+  {| equalityb x y := Ceqb x y |}.
 
  Fixpoint Peq (P P' : Pol) {struct P'} : bool :=
   match P, P' with
@@ -60,7 +60,7 @@ Instance equalityb_coef : Equalityb C :=
   end.
 
 Instance equalityb_pol : Equalityb Pol :=
-  {equalityb x y := Peq x y}.
+  {| equalityb x y := Peq x y |}.
 
 (* Q a ses variables de queue < i *)
  Definition mkPX P i n Q :=

--- a/test-suite/bugs/closed/3513.v
+++ b/test-suite/bugs/closed/3513.v
@@ -28,7 +28,7 @@ Instance ILogicOps_Prop : ILogicOps Prop | 2 := {| lentails P Q := (P : Prop) ->
                                                    lor      P Q := P \/ Q |}.
 Axiom Action : Set.
 Definition Actions := list Action.
-Instance ActionsEquiv : Equiv Actions := { equiv a1 a2 := a1 = a2 }.
+Instance ActionsEquiv : Equiv Actions := fun a1 a2 => a1 = a2 .
 Definition OPred := ILFunFrm Actions Prop.
 Local Existing Instance ILFun_Ops.
 Local Existing Instance ILFun_ILogic.

--- a/test-suite/bugs/closed/3647.v
+++ b/test-suite/bugs/closed/3647.v
@@ -362,9 +362,9 @@ Defined.
 Section FunEq.
   Context A `{eT: type A}.
 
-  Global Instance FunEquiv {T} : Equiv (T -> A) := {
-                                                    equiv P Q := forall a, P a === Q a
-                                                  }.
+  Global Instance FunEquiv {T} : Equiv (T -> A) :=
+                                                    fun P Q => forall a, P a === Q a
+                                                  .
 End FunEq.
 
 Section SepAlgSect.
@@ -403,13 +403,13 @@ Section BISepAlg.
   Context {A} `{sa : SepAlg A}.
   Context {B} `{IL: ILogic B}.
 
-  Program Instance SABIOps: BILOperators (ILFunFrm A B) := {
+  Program Instance SABIOps: BILOperators (ILFunFrm A B) := {|
                                                             empSP := mkILFunFrm e (fun x => sa_unit === x /\\ ltrue) _;
                                                             sepSP P Q := mkILFunFrm e (fun x => Exists x1, Exists x2, sa_mul x1 x2 x /\\
                                                                                                                              P x1 //\\ Q x2) _;
                                                             wandSP P Q := mkILFunFrm e (fun x => Forall x1, Forall x2, sa_mul x x1 x2 ->>
                                                                                                                               P x1 -->> Q x2) _
-                                                          }.
+                                                          |}.
   Next Obligation.
     admit.
   Defined.
@@ -433,9 +433,9 @@ Inductive Action :=
 
 Definition Actions := list Action.
 
-Instance ActionsEquiv : Equiv Actions := {
-                                          equiv a1 a2 := a1 = a2
-                                        }.
+Instance ActionsEquiv : Equiv Actions :=
+                                          fun a1 a2 => a1 = a2
+                                        .
 
 Definition OPred := ILFunFrm Actions Prop.
 Definition mkOPred (P : Actions -> Prop) : OPred.

--- a/test-suite/bugs/closed/4095.v
+++ b/test-suite/bugs/closed/4095.v
@@ -30,7 +30,7 @@ Instance ILogicOps_Prop : ILogicOps Prop | 2 := {| lentails P Q := (P : Prop) ->
                                                    lor      P Q := P \/ Q |}.
 Axiom Action : Set.
 Definition Actions := list Action.
-Instance ActionsEquiv : Equiv Actions := { equiv a1 a2 := a1 = a2 }.
+Instance ActionsEquiv : Equiv Actions := fun a1 a2 => a1 = a2.
 Definition OPred := ILFunFrm Actions Prop.
 Local Existing Instance ILFun_Ops.
 Local Existing Instance ILFun_ILogic.

--- a/test-suite/success/Typeclasses.v
+++ b/test-suite/success/Typeclasses.v
@@ -30,7 +30,7 @@ Module shelve_non_class_subgoals.
   Variable foo : Foo.
   Hint Extern 0 Foo => exact foo : typeclass_instances.
   Class Bar := {}.
-  Instance bar1 (f:Foo) : Bar := {}.
+  Instance bar1 (f:Foo) : Bar.
 
   Typeclasses eauto := debug.
   Set Typeclasses Debug Verbosity 2.
@@ -43,8 +43,8 @@ End shelve_non_class_subgoals.
 Module RefineVsNoTceauto.
 
   Class Foo (A : Type) := foo : A.
-  Instance: Foo nat := { foo := 0 }.
-  Instance: Foo nat := { foo := 42 }.
+  Instance: Foo nat := 0.
+  Instance: Foo nat := 42.
   Hint Extern 0 (_ = _) => refine eq_refl : typeclass_instances.
   Goal exists (f : Foo nat), @foo _ f = 0.
   Proof.
@@ -183,8 +183,8 @@ End sec.
 Module UniqueSolutions.
   Set Typeclasses Unique Solutions.
   Class Eq (A : Type) : Set.
-    Instance eqa : Eq nat := {}.
-    Instance eqb : Eq nat := {}.
+    Instance eqa : Eq nat.
+    Instance eqb : Eq nat.
 
     Goal Eq nat.
       try apply _.
@@ -199,9 +199,9 @@ Module UniqueInstances.
   Set Typeclasses Unique Instances.
   Class Eq (A : Type) : Set.
     Instance eqa : Eq nat := _. constructor. Qed.
-    Instance eqb : Eq nat := {}.
+    Instance eqb : Eq nat.
     Class Foo (A : Type) (e : Eq A) : Set.
-    Instance fooa : Foo _ eqa := {}.
+    Instance fooa : Foo _ eqa.
 
     Tactic Notation "refineu" open_constr(c) := unshelve refine c.
 

--- a/theories/Classes/CRelationClasses.v
+++ b/theories/Classes/CRelationClasses.v
@@ -97,8 +97,8 @@ Section Defs.
   (** An Equivalence is a PER plus reflexivity. *)
   
   Global Instance Equivalence_PER {R} `(Equivalence R) : PER R | 10 :=
-    { PER_Symmetric := Equivalence_Symmetric ;
-      PER_Transitive := Equivalence_Transitive }.
+    {| PER_Symmetric := Equivalence_Symmetric ;
+       PER_Transitive := Equivalence_Transitive |}.
 
   (** We can now define antisymmetry w.r.t. an equivalence crelation on the carrier. *)
   

--- a/theories/Classes/DecidableClass.v
+++ b/theories/Classes/DecidableClass.v
@@ -63,30 +63,30 @@ Tactic Notation "decide" constr(P) :=
 
 Require Import Bool Arith ZArith.
 
-Program Instance Decidable_eq_bool : forall (x y : bool), Decidable (eq x y) := {
+Program Instance Decidable_eq_bool (x y : bool) : Decidable (eq x y) := {|
   Decidable_witness := Bool.eqb x y
-}.
+|}.
 Next Obligation.
  apply eqb_true_iff.
 Qed.
 
-Program Instance Decidable_eq_nat : forall (x y : nat), Decidable (eq x y) := {
+Program Instance Decidable_eq_nat (x y : nat) : Decidable (eq x y) := {|
   Decidable_witness := Nat.eqb x y
-}.
+|}.
 Next Obligation.
  apply Nat.eqb_eq.
 Qed.
 
-Program Instance Decidable_le_nat : forall (x y : nat), Decidable (x <= y) := {
+Program Instance Decidable_le_nat (x y : nat) : Decidable (x <= y) := {|
   Decidable_witness := Nat.leb x y
-}.
+|}.
 Next Obligation.
  apply Nat.leb_le.
 Qed.
 
-Program Instance Decidable_eq_Z : forall (x y : Z), Decidable (eq x y) := {
+Program Instance Decidable_eq_Z (x y : Z) : Decidable (eq x y) := {|
   Decidable_witness := Z.eqb x y
-}.
+|}.
 Next Obligation.
  apply Z.eqb_eq.
 Qed.

--- a/theories/Classes/EquivDec.v
+++ b/theories/Classes/EquivDec.v
@@ -93,32 +93,32 @@ Obligation Tactic := unfold complement, equiv ; program_simpl.
 
 Program Instance prod_eqdec `(EqDec A eq, EqDec B eq) :
   ! EqDec (prod A B) eq :=
-  { equiv_dec x y :=
+  fun x y =>
     let '(x1, x2) := x in
     let '(y1, y2) := y in
     if x1 == y1 then
       if x2 == y2 then in_left
       else in_right
-    else in_right }.
+    else in_right.
 
 Program Instance sum_eqdec `(EqDec A eq, EqDec B eq) :
-  EqDec (sum A B) eq := {
-  equiv_dec x y :=
+  EqDec (sum A B) eq :=
+  fun x y =>
     match x, y with
       | inl a, inl b => if a == b then in_left else in_right
       | inr a, inr b => if a == b then in_left else in_right
       | inl _, inr _ | inr _, inl _ => in_right
-    end }.
+    end.
 
 (** Objects of function spaces with countable domains like bool have decidable
   equality. Proving the reflection requires functional extensionality though. *)
 
 Program Instance bool_function_eqdec `(EqDec A eq) : ! EqDec (bool -> A) eq :=
-  { equiv_dec f g :=
+  fun f g =>
     if f true == g true then
       if f false == g false then in_left
       else in_right
-    else in_right }.
+    else in_right.
 
   Next Obligation.
   Proof.
@@ -129,7 +129,6 @@ Program Instance bool_function_eqdec `(EqDec A eq) : ! EqDec (bool -> A) eq :=
 Require Import List.
 
 Program Instance list_eqdec `(eqa : EqDec A eq) : ! EqDec (list A) eq :=
-  { equiv_dec :=
     fix aux (x y : list A) :=
     match x, y with
       | nil, nil => in_left
@@ -138,7 +137,7 @@ Program Instance list_eqdec `(eqa : EqDec A eq) : ! EqDec (list A) eq :=
           if aux tl tl' then in_left else in_right
           else in_right
       | _, _ => in_right
-    end }.
+    end.
 
   Next Obligation. destruct y ; unfold not in *; eauto. Defined.
 

--- a/theories/Classes/RelationClasses.v
+++ b/theories/Classes/RelationClasses.v
@@ -85,14 +85,14 @@ Section Defs.
     Equivalence_Transitive :> Transitive R }.
 
   (** An Equivalence is a PER plus reflexivity. *)
-  
+
   Global Instance Equivalence_PER {R} `(E:Equivalence R) : PER R | 10 :=
-    { }. 
+    {| PER_Symmetric := _ |}.
 
   (** An Equivalence is a PreOrder plus symmetry. *)
 
   Global Instance Equivalence_PreOrder {R} `(E:Equivalence R) : PreOrder R | 10 :=
-    { }.
+    {| PreOrder_Reflexive := _ |}.
 
   (** We can now define antisymmetry w.r.t. an equivalence relation on the carrier. *)
   

--- a/theories/Classes/SetoidClass.v
+++ b/theories/Classes/SetoidClass.v
@@ -55,7 +55,7 @@ Existing Instance setoid_trans.
 (*   equiv := eq ; setoid_equiv := eq_equivalence. *)
 
 Program Instance iff_setoid : Setoid Prop :=
-  { equiv := iff ; setoid_equiv := iff_equivalence }.
+  {| equiv := iff ; setoid_equiv := iff_equivalence |}.
 
 (** Overloaded notations for setoid equivalence and inequivalence. Not to be confused with [eq] and [=]. *)
 

--- a/theories/Classes/SetoidDec.v
+++ b/theories/Classes/SetoidDec.v
@@ -79,7 +79,7 @@ Require Import Coq.Arith.Arith.
   it by specifying which setoid we're talking about. *)
 
 Program Instance eq_setoid A : Setoid A | 10 :=
-  { equiv := eq ; setoid_equiv := eq_equivalence }.
+  {| equiv := eq ; setoid_equiv := eq_equivalence |}.
 
 Program Instance nat_eq_eqdec : EqDec (eq_setoid nat) :=
   eq_nat_dec.

--- a/theories/MSets/MSetGenTree.v
+++ b/theories/MSets/MSetGenTree.v
@@ -302,7 +302,7 @@ Definition IsOk := bst.
 
 Class Ok (s:tree) : Prop := ok : bst s.
 
-Instance bst_Ok s (Hs : bst s) : Ok s := { ok := Hs }.
+Instance bst_Ok s (Hs : bst s) : Ok s := Hs.
 
 Fixpoint ltb_tree x s :=
  match s with

--- a/theories/MSets/MSetList.v
+++ b/theories/MSets/MSetList.v
@@ -238,7 +238,7 @@ Module MakeRaw (X: OrderedType) <: RawSets X.
   Hint Resolve ok.
   Hint Unfold Ok.
 
-  Instance Sort_Ok s `(Hs : Sort s) : Ok s := { ok := Hs }.
+  Instance Sort_Ok s `(Hs : Sort s) : Ok s := Hs.
 
   Lemma inf_iff : forall x l, Inf x l <-> inf x l = true.
   Proof.

--- a/theories/MSets/MSetWeakList.v
+++ b/theories/MSets/MSetWeakList.v
@@ -131,7 +131,7 @@ Module MakeRaw (X:DecidableType) <: WRawSets X.
   Hint Unfold Ok.
   Hint Resolve ok.
 
-  Instance NoDup_Ok s (nd : NoDup s) : Ok s := { ok := nd }.
+  Instance NoDup_Ok s (nd : NoDup s) : Ok s := nd.
 
   Ltac inv_ok := match goal with
    | H:Ok (_ :: _) |- _ => inversion_clear H; inv_ok

--- a/theories/Numbers/Cyclic/Int31/Cyclic31.v
+++ b/theories/Numbers/Cyclic/Int31/Cyclic31.v
@@ -1117,61 +1117,61 @@ Section Basics.
 End Basics.
 
 Instance int31_ops : ZnZ.Ops int31 :=
-{
- digits      := 31%positive; (* number of digits *)
- zdigits     := 31; (* number of digits *)
- to_Z        := phi; (* conversion to Z *)
- of_pos      := positive_to_int31; (* positive -> N*int31 :  p => N,i
+{|
+ ZnZ.digits      := 31%positive; (* number of digits *)
+ ZnZ.zdigits     := 31; (* number of digits *)
+ ZnZ.to_Z        := phi; (* conversion to Z *)
+ ZnZ.of_pos      := positive_to_int31; (* positive -> N*int31 :  p => N,i
                                       where p = N*2^31+phi i *)
- head0       := head031;  (* number of head 0 *)
- tail0       := tail031;  (* number of tail 0 *)
- zero        := 0;
- one         := 1;
- minus_one   := Tn; (* 2^31 - 1 *)
- compare     := compare31;
- eq0         := fun i => match i ?= 0 with Eq => true | _ => false end;
- opp_c       := fun i => 0 -c i;
- opp         := opp31;
- opp_carry   := fun i => 0-i-1;
- succ_c      := fun i => i +c 1;
- add_c       := add31c;
- add_carry_c := add31carryc;
- succ        := fun i => i + 1;
- add         := add31;
- add_carry   := fun i j => i + j + 1;
- pred_c      := fun i => i -c 1;
- sub_c       := sub31c;
- sub_carry_c := sub31carryc;
- pred        := fun i => i - 1;
- sub         := sub31;
- sub_carry   := fun i j => i - j - 1;
- mul_c       := mul31c;
- mul         := mul31;
- square_c    := fun x => x *c x;
- div21       := div3121;
- div_gt      := div31; (* this is supposed to be the special case of
+ ZnZ.head0       := head031;  (* number of head 0 *)
+ ZnZ.tail0       := tail031;  (* number of tail 0 *)
+ ZnZ.zero        := 0;
+ ZnZ.one         := 1;
+ ZnZ.minus_one   := Tn; (* 2^31 - 1 *)
+ ZnZ.compare     := compare31;
+ ZnZ.eq0         := fun i => match i ?= 0 with Eq => true | _ => false end;
+ ZnZ.opp_c       := fun i => 0 -c i;
+ ZnZ.opp         := opp31;
+ ZnZ.opp_carry   := fun i => 0-i-1;
+ ZnZ.succ_c      := fun i => i +c 1;
+ ZnZ.add_c       := add31c;
+ ZnZ.add_carry_c := add31carryc;
+ ZnZ.succ        := fun i => i + 1;
+ ZnZ.add         := add31;
+ ZnZ.add_carry   := fun i j => i + j + 1;
+ ZnZ.pred_c      := fun i => i -c 1;
+ ZnZ.sub_c       := sub31c;
+ ZnZ.sub_carry_c := sub31carryc;
+ ZnZ.pred        := fun i => i - 1;
+ ZnZ.sub         := sub31;
+ ZnZ.sub_carry   := fun i j => i - j - 1;
+ ZnZ.mul_c       := mul31c;
+ ZnZ.mul         := mul31;
+ ZnZ.square_c    := fun x => x *c x;
+ ZnZ.div21       := div3121;
+ ZnZ.div_gt      := div31; (* this is supposed to be the special case of
                          division a/b where a > b *)
- div         := div31;
- modulo_gt   := fun i j => let (_,r) := i/j in r;
- modulo      := fun i j => let (_,r) := i/j in r;
- gcd_gt      := gcd31;
- gcd         := gcd31;
- add_mul_div := addmuldiv31;
- pos_mod     := (* modulo 2^p *)
+ ZnZ.div         := div31;
+ ZnZ.modulo_gt   := fun i j => let (_,r) := i/j in r;
+ ZnZ.modulo      := fun i j => let (_,r) := i/j in r;
+ ZnZ.gcd_gt      := gcd31;
+ ZnZ.gcd         := gcd31;
+ ZnZ.add_mul_div := addmuldiv31;
+ ZnZ.pos_mod     := (* modulo 2^p *)
   fun p i =>
   match p ?= 31 with
     | Lt => addmuldiv31 p 0 (addmuldiv31 (31-p) i 0)
     | _ => i
   end;
- is_even      :=
+ ZnZ.is_even      :=
   fun i => let (_,r) := i/2 in
   match r ?= 0 with Eq => true | _ => false end;
- sqrt2       := sqrt312;
- sqrt        := sqrt31;
- lor         := lor31;
- land        := land31;
- lxor        := lxor31
-}.
+ ZnZ.sqrt2       := sqrt312;
+ ZnZ.sqrt        := sqrt31;
+ ZnZ.lor         := lor31;
+ ZnZ.land        := land31;
+ ZnZ.lxor        := lxor31
+|}.
 
 Section Int31_Specs.
 
@@ -2483,53 +2483,53 @@ Qed.
    apply Z.max_lub_lt; apply log2_phi_bounded.
  Qed.
 
- Global Instance int31_specs : ZnZ.Specs int31_ops := {
-    spec_to_Z   := phi_bounded;
-    spec_of_pos := positive_to_int31_spec;
-    spec_zdigits := spec_zdigits;
-    spec_more_than_1_digit := spec_more_than_1_digit;
-    spec_0   := spec_0;
-    spec_1   := spec_1;
-    spec_m1  := spec_m1;
-    spec_compare := spec_compare;
-    spec_eq0 := spec_eq0;
-    spec_opp_c := spec_opp_c;
-    spec_opp := spec_opp;
-    spec_opp_carry := spec_opp_carry;
-    spec_succ_c := spec_succ_c;
-    spec_add_c := spec_add_c;
-    spec_add_carry_c := spec_add_carry_c;
-    spec_succ := spec_succ;
-    spec_add := spec_add;
-    spec_add_carry := spec_add_carry;
-    spec_pred_c := spec_pred_c;
-    spec_sub_c := spec_sub_c;
-    spec_sub_carry_c := spec_sub_carry_c;
-    spec_pred := spec_pred;
-    spec_sub := spec_sub;
-    spec_sub_carry := spec_sub_carry;
-    spec_mul_c := spec_mul_c;
-    spec_mul := spec_mul;
-    spec_square_c := spec_square_c;
-    spec_div21 := spec_div21;
-    spec_div_gt := fun a b _ => spec_div a b;
-    spec_div := spec_div;
-    spec_modulo_gt := fun a b _ => spec_mod a b;
-    spec_modulo := spec_mod;
-    spec_gcd_gt := fun a b _ => spec_gcd a b;
-    spec_gcd := spec_gcd;
-    spec_head00 := spec_head00;
-    spec_head0 := spec_head0;
-    spec_tail00 := spec_tail00;
-    spec_tail0 := spec_tail0;
-    spec_add_mul_div := spec_add_mul_div;
-    spec_pos_mod := spec_pos_mod;
-    spec_is_even := spec_is_even;
-    spec_sqrt2 := spec_sqrt2;
-    spec_sqrt := spec_sqrt;
-    spec_lor := spec_lor;
-    spec_land := spec_land;
-    spec_lxor := spec_lxor }.
+ Global Instance int31_specs : ZnZ.Specs int31_ops := {|
+    ZnZ.spec_to_Z   := phi_bounded;
+    ZnZ.spec_of_pos := positive_to_int31_spec;
+    ZnZ.spec_zdigits := spec_zdigits;
+    ZnZ.spec_more_than_1_digit := spec_more_than_1_digit;
+    ZnZ.spec_0   := spec_0;
+    ZnZ.spec_1   := spec_1;
+    ZnZ.spec_m1  := spec_m1;
+    ZnZ.spec_compare := spec_compare;
+    ZnZ.spec_eq0 := spec_eq0;
+    ZnZ.spec_opp_c := spec_opp_c;
+    ZnZ.spec_opp := spec_opp;
+    ZnZ.spec_opp_carry := spec_opp_carry;
+    ZnZ.spec_succ_c := spec_succ_c;
+    ZnZ.spec_add_c := spec_add_c;
+    ZnZ.spec_add_carry_c := spec_add_carry_c;
+    ZnZ.spec_succ := spec_succ;
+    ZnZ.spec_add := spec_add;
+    ZnZ.spec_add_carry := spec_add_carry;
+    ZnZ.spec_pred_c := spec_pred_c;
+    ZnZ.spec_sub_c := spec_sub_c;
+    ZnZ.spec_sub_carry_c := spec_sub_carry_c;
+    ZnZ.spec_pred := spec_pred;
+    ZnZ.spec_sub := spec_sub;
+    ZnZ.spec_sub_carry := spec_sub_carry;
+    ZnZ.spec_mul_c := spec_mul_c;
+    ZnZ.spec_mul := spec_mul;
+    ZnZ.spec_square_c := spec_square_c;
+    ZnZ.spec_div21 := spec_div21;
+    ZnZ.spec_div_gt := fun a b _ => spec_div a b;
+    ZnZ.spec_div := spec_div;
+    ZnZ.spec_modulo_gt := fun a b _ => spec_mod a b;
+    ZnZ.spec_modulo := spec_mod;
+    ZnZ.spec_gcd_gt := fun a b _ => spec_gcd a b;
+    ZnZ.spec_gcd := spec_gcd;
+    ZnZ.spec_head00 := spec_head00;
+    ZnZ.spec_head0 := spec_head0;
+    ZnZ.spec_tail00 := spec_tail00;
+    ZnZ.spec_tail0 := spec_tail0;
+    ZnZ.spec_add_mul_div := spec_add_mul_div;
+    ZnZ.spec_pos_mod := spec_pos_mod;
+    ZnZ.spec_is_even := spec_is_even;
+    ZnZ.spec_sqrt2 := spec_sqrt2;
+    ZnZ.spec_sqrt := spec_sqrt;
+    ZnZ.spec_lor := spec_lor;
+    ZnZ.spec_land := spec_land;
+    ZnZ.spec_lxor := spec_lxor |}.
 
 End Int31_Specs.
 

--- a/theories/Sorting/Permutation.v
+++ b/theories/Sorting/Permutation.v
@@ -80,10 +80,10 @@ Local Hint Resolve Permutation_sym Permutation_trans.
 (* This provides reflexivity, symmetry and transitivity and rewriting
    on morphims to come *)
 
-Instance Permutation_Equivalence A : Equivalence (@Permutation A) | 10 := {
+Instance Permutation_Equivalence A : Equivalence (@Permutation A) | 10 := {|
   Equivalence_Reflexive := @Permutation_refl A ;
   Equivalence_Symmetric := @Permutation_sym A ;
-  Equivalence_Transitive := @Permutation_trans A }.
+  Equivalence_Transitive := @Permutation_trans A |}.
 
 Instance Permutation_cons A :
  Proper (Logic.eq ==> @Permutation A ==> @Permutation A) (@cons A) | 10.


### PR DESCRIPTION
- [x] Corresponding documentation was added / updated.
- [x] Entry added in CHANGES.
