### PR TITLE
Fix coq_makefile not passing -R options to coqdoc, breaking links (#6697)

### DIFF
--- a/tools/CoqMakefile.in
+++ b/tools/CoqMakefile.in
@@ -169,7 +169,8 @@ endif
 
 COQFLAGS?=-q $(OPT) $(COQLIBS) $(OTHERFLAGS)
 COQCHKFLAGS?=-silent -o $(COQLIBS)
-COQDOCFLAGS?=-interpolate -utf8 $(COQLIBS_NOML)
+COQDOCFLAGS?=-interpolate -utf8
+COQDOCLIBS?=$(COQLIBS_NOML)
 
 # The version of Coq being run and the version of coq_makefile that
 # generated this makefile


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->
`COQDOCLIBS` was defined under 8.6, but is undefined under 8.7, so this does restore the old behaviour for my use case.

The coq-makefile tests still work.

<!-- Keep what applies -->
**Kind:** bug fix 


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #6697 
