### PR TITLE
[ssr] extended intro patterns

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -139,6 +139,15 @@ Misc
 
 - Option "Typeclasses Axioms Are Instances" is deprecated. Use Declare Instance for axioms which should be instances.
 
+SSReflect
+
+- New intro patterns:
+  - temporary introduction: => +
+  - block introduction: => [^ prefix ] [^~ suffix ]
+  - fast introduction: => >H
+  - tactics as views: => /ltac:mytac
+  See the reference manual for the actual documentation.
+
 Changes from 8.8.2 to 8.9+beta1
 ===============================
 

--- a/plugins/ssr/ssrast.mli
+++ b/plugins/ssr/ssrast.mli
@@ -64,38 +64,37 @@ type ast_closure_term = {
 
 type ssrview = ast_closure_term list
 
-(* TODO
-type id_mod = Hat | HatTilde | Sharp
- *)
+type id_mod = Dependent
+
+type id_block = Prefix of Id.t | SuffixId of Id.t | SuffixNum of int
 
 (* Only [One] forces an introduction, possibly reducing the goal. *)
 type anon_iter =
-  | One
+  | One of string option (* name hint *)
   | Drop
   | All
-(* TODO
-  | Dependent (* fast mode *)
-  | UntilMark
-  | Temporary (* "+" *)
- *)
+  | Temporary
 
 type ssripat =
   | IPatNoop
-  | IPatId of (*TODO id_mod option * *) Id.t
+  | IPatId of id_mod option * Id.t
   | IPatAnon of anon_iter (* inaccessible name *)
 (* TODO  | IPatClearMark *)
-  | IPatDispatch of bool (* ssr exception: accept a dispatch on the empty list even when there are subgoals *) * ssripatss (* (..|..) *)
-  | IPatCase of (* ipats_mod option * *) ssripatss (* this is not equivalent to /case /[..|..] if there are already multiple goals *)
+  | IPatDispatch of bool (* ssr exception: accept a dispatch on the empty list even when there are subgoals *) * ssripatss_or_block (* (..|..) *)
+  | IPatCase of (* ipats_mod option * *) ssripatss_or_block (* this is not equivalent to /case /[..|..] if there are already multiple goals *)
   | IPatInj of ssripatss
   | IPatRewrite of (*occurrence option * rewrite_pattern **) ssrocc * ssrdir
   | IPatView of bool * ssrview (* {}/view (true if the clear is present) *)
   | IPatClear of ssrclear (* {H1 H2} *)
   | IPatSimpl of ssrsimpl
   | IPatAbstractVars of Id.t list
-  | IPatTac of unit Proofview.tactic
+  | IPatEqGen of unit Proofview.tactic (* internal use: generation of eqn *)
 
 and ssripats = ssripat list
 and ssripatss = ssripats list
+and ssripatss_or_block =
+  | Block of id_block
+  | Regular of ssripats list
 type ssrhpats = ((ssrclear * ssripats) * ssripats) * ssripats
 type ssrhpats_wtransp = bool * ssrhpats
 

--- a/plugins/ssr/ssreflect.v
+++ b/plugins/ssr/ssreflect.v
@@ -86,10 +86,16 @@ Export SsrMatchingSyntax.
 Export SsrSyntax.
 
 (**
+ To define notations for tactic in intro patterns.
+ When "=> /t" is parsed, "t:%ssripat" is actually interpreted. **)
+Declare Scope ssripat_scope.
+Delimit Scope ssripat_scope with ssripat.
+
+(**
  Make the general "if" into a notation, so that we can override it below.
  The notations are "only parsing" because the Coq decompiler will not
  recognize the expansion of the boolean if; using the default printer
- avoids a spurrious trailing %%GEN_IF.                                        **)
+ avoids a spurrious trailing %%GEN_IF. **)
 
 Declare Scope general_if_scope.
 Delimit Scope general_if_scope with GEN_IF.

--- a/plugins/ssr/ssrelim.mli
+++ b/plugins/ssr/ssrelim.mli
@@ -13,7 +13,6 @@
 open Ssrmatching_plugin
 
 val ssrelim :
-  ?ind:(int * EConstr.types array) option ref ->
   ?is_case:bool ->
   ((Ssrast.ssrhyps option * Ssrast.ssrocc) *
      Ssrmatching.cpattern)
@@ -29,26 +28,23 @@ val ssrelim :
    as 'a) ->
   ?elim:EConstr.constr ->
   Ssrast.ssripat option ->
-  ( 'a ->
+  (?seed:Names.Name.t list array -> 'a ->
    Ssrast.ssripat option ->
-   (Goal.goal Evd.sigma -> Goal.goal list Evd.sigma) ->
-   bool -> Ssrast.ssrhyp list -> Tacmach.tactic) ->
-  Goal.goal Evd.sigma -> Goal.goal list Evd.sigma
+   unit Proofview.tactic ->
+   bool -> Ssrast.ssrhyp list -> unit Proofview.tactic) ->
+  unit Proofview.tactic
 
 val elimtac : EConstr.constr -> unit Proofview.tactic
 
 val casetac :
   EConstr.constr ->
-  Goal.goal Evd.sigma -> Goal.goal list Evd.sigma
+  (?seed:Names.Name.t list array -> unit Proofview.tactic -> unit Proofview.tactic) ->
+  unit Proofview.tactic
 
 val is_injection_case : EConstr.t -> Goal.goal Evd.sigma -> bool
 val perform_injection :
   EConstr.constr ->
   Goal.goal Evd.sigma -> Goal.goal list Evd.sigma
-
-val ssrscasetac :
-  EConstr.constr ->
-  unit Proofview.tactic
 
 val ssrscase_or_inj_tac :
   EConstr.constr ->

--- a/plugins/ssr/ssrfwd.ml
+++ b/plugins/ssr/ssrfwd.ml
@@ -104,7 +104,7 @@ let havetac ist
  let itac_c = introstac (IPatClear clr :: pats) in
  let itac, id, clr = introstac pats, Tacticals.tclIDTAC, old_cleartac clr in
  let binderstac n =
-   let rec aux = function 0 -> [] | n -> IPatAnon One :: aux (n-1) in
+   let rec aux = function 0 -> [] | n -> IPatAnon (One None) :: aux (n-1) in
    Tacticals.tclTHEN (if binders <> [] then introstac (aux n) else Tacticals.tclIDTAC)
      (introstac binders) in
  let simpltac = introstac simpl in
@@ -206,7 +206,7 @@ let wlogtac ist (((clr0, pats),_),_) (gens, ((_, ct))) hint suff ghave gl =
   let mkabs gen = abs_wgen false (fun x -> x) gen in
   let mkclr gen clrs = clr_of_wgen gen clrs in
   let mkpats = function
-  | _, Some ((x, _), _) -> fun pats -> IPatId (hoi_id x) :: pats
+  | _, Some ((x, _), _) -> fun pats -> IPatId (None,hoi_id x) :: pats
   | _ -> fun x -> x in
   let ct = match Ssrcommon.ssrterm_of_ast_closure_term ct with
   | (a, (b, Some ct)) ->
@@ -265,7 +265,7 @@ let wlogtac ist (((clr0, pats),_),_) (gens, ((_, ct))) hint suff ghave gl =
       if gens = [] then errorstrm(str"gen have requires some generalizations");
       let clear0 = old_cleartac clr0 in
       let id, name_general_hyp, cleanup, pats = match id, pats with
-      | None, (IPatId id as ip)::pats -> Some id, tacipat [ip], clear0, pats
+      | None, (IPatId(_, id) as ip)::pats -> Some id, tacipat [ip], clear0, pats
       | None, _ -> None, Tacticals.tclIDTAC, clear0, pats
       | Some (Some id),_ -> Some id, introid id, clear0, pats
       | Some _,_ ->

--- a/plugins/ssr/ssripats.ml
+++ b/plugins/ssr/ssripats.ml
@@ -27,14 +27,30 @@ module IpatMachine : sig
   val main : ?eqtac:unit tactic -> first_case_is_dispatch:bool ->
         ssripats -> unit tactic
 
+
+  val tclSEED_SUBGOALS : Names.Name.t list array -> unit tactic -> unit tactic
+
 end = struct (* {{{ *)
 
 module State : sig
+
+  type delayed_gen = {
+    tmp_id : Id.t;    (* Temporary name *)
+    orig_name : Name.t   (* Old name *)
+  }
 
   (* to_clear API *)
   val isCLR_PUSH    : Id.t -> unit tactic
   val isCLR_PUSHL   : Id.t list -> unit tactic
   val isCLR_CONSUME : unit tactic
+
+  (* to_generalize API *)
+  val isGEN_PUSH    : delayed_gen -> unit tactic
+  val isGEN_CONSUME : unit tactic
+
+  (* name_seed API *)
+  val isNSEED_SET : Names.Name.t list -> unit tactic
+  val isNSEED_CONSUME : (Names.Name.t list option -> unit tactic) -> unit tactic
 
   (* Some data may expire *)
   val isTICK : ssripat -> unit tactic
@@ -48,10 +64,23 @@ type istate = {
   (* Delayed clear *)
   to_clear : Id.t list;
 
+  (* Temporary intros, to be generalized back *)
+  to_generalize : delayed_gen list;
+
+  (* The type of the inductive constructor corresponding to the current proof
+   * branch: name seeds are taken from that in an intro block *)
+  name_seed : Names.Name.t list option;
+
+}
+and delayed_gen = {
+  tmp_id : Id.t;    (* Temporary name *)
+  orig_name : Name.t   (* Old name *)
 }
 
 let empty_state = {
   to_clear = [];
+  to_generalize = [];
+  name_seed = None;
 }
 
 include Ssrcommon.MakeState(struct
@@ -59,28 +88,69 @@ include Ssrcommon.MakeState(struct
   let init = empty_state
 end)
 
+let print_name_seed env sigma = function
+  | None -> Pp.str "-"
+  | Some nl -> Pp.prlist Names.Name.print nl
+
+let print_delayed_gen { tmp_id; orig_name } =
+  Pp.(Id.print tmp_id ++ str"->" ++ Name.print orig_name)
+
 let isPRINT g =
+  let env, sigma = Goal.env g, Goal.sigma g in
   let state = get g in
   Pp.(str"{{ to_clear: " ++
         prlist_with_sep spc Id.print state.to_clear ++ spc () ++
-      str" }}")
+      str"to_generalize: " ++
+        prlist_with_sep spc print_delayed_gen state.to_generalize ++ spc () ++
+      str"name_seed: " ++ print_name_seed env sigma state.name_seed ++ str" }}")
 
 
 let isCLR_PUSH id =
-  tclGET (fun { to_clear = ids } ->
-  tclSET { to_clear = id :: ids })
+  tclGET (fun ({ to_clear = ids } as s) ->
+  tclSET { s with to_clear = id :: ids })
 
 let isCLR_PUSHL more_ids =
-  tclGET (fun { to_clear = ids } ->
-  tclSET { to_clear = more_ids @ ids })
+  tclGET (fun ({ to_clear = ids } as s) ->
+  tclSET { s with to_clear = more_ids @ ids })
 
 let isCLR_CONSUME =
-  tclGET (fun { to_clear = ids } ->
-  tclSET { to_clear = [] } <*>
+  tclGET (fun ({ to_clear = ids } as s) ->
+  tclSET { s with to_clear = [] } <*>
   Tactics.clear ids)
 
 
-let isTICK _ = tclUNIT ()
+let isGEN_PUSH dg =
+  tclGET (fun s ->
+  tclSET { s with to_generalize = dg :: s.to_generalize })
+
+(* generalize `id` as `new_name` *)
+let gen_astac id new_name =
+ let gen = ((None,Some(false,[])),Ssrmatching.cpattern_of_id id) in
+ V82.tactic (Ssrcommon.gentac gen)
+ <*> Ssrcommon.tclRENAME_HD_PROD new_name
+
+(* performs and resets all delayed generalizations *)
+let isGEN_CONSUME =
+  tclGET (fun ({ to_generalize = dgs } as s) ->
+  tclSET { s with to_generalize = [] } <*>
+  Tacticals.New.tclTHENLIST
+    (List.map (fun { tmp_id; orig_name } ->
+       gen_astac tmp_id orig_name) dgs) <*>
+  Tactics.clear (List.map (fun gen -> gen.tmp_id) dgs))
+
+
+let isNSEED_SET ty =
+  tclGET (fun s ->
+  tclSET { s with name_seed = Some ty })
+
+let isNSEED_CONSUME k =
+  tclGET (fun ({ name_seed = x } as s) ->
+  tclSET { s with name_seed = None } <*>
+  k x)
+
+let isTICK = function
+  | IPatSimpl _ | IPatClear _ -> tclUNIT ()
+  | _ -> tclGET (fun s -> tclSET { s with name_seed = None })
 
 end (* }}} *************************************************************** *)
 
@@ -105,18 +175,49 @@ let intro_anon_all = Goal.enter begin fun gl ->
   let sigma = Goal.sigma gl in
   let g = Goal.concl gl in
   let n = nb_assums env sigma g in
-  Tacticals.New.tclDO n Ssrcommon.tclINTRO_ANON
+  Tacticals.New.tclDO n (Ssrcommon.tclINTRO_ANON ())
+end
+
+(*** [=> >*] **************************************************************)
+(** [nb_deps_assums] returns the number of dependent premises *)
+let rec nb_deps_assums cur env sigma t =
+  let t' = Reductionops.whd_allnolet env sigma t in
+  match EConstr.kind sigma t' with
+  | Constr.Prod(name,ty,body) ->
+     if EConstr.Vars.noccurn sigma 1 body &&
+        not (Typeclasses.is_class_type sigma ty) then cur
+     else nb_deps_assums (cur+1) env sigma body
+  | Constr.LetIn(name,ty,t1,t2) ->
+     nb_deps_assums (cur+1) env sigma t2
+  | Constr.Cast(t,_,_) ->
+     nb_deps_assums cur env sigma t
+  | _ -> cur
+let nb_deps_assums = nb_deps_assums 0
+
+let intro_anon_deps = Goal.enter begin fun gl ->
+  let env = Goal.env gl in
+  let sigma = Goal.sigma gl in
+  let g = Goal.concl gl in
+  let n = nb_deps_assums env sigma g in
+  Tacticals.New.tclDO n (Ssrcommon.tclINTRO_ANON ())
 end
 
 (** [intro_drop] behaves like [intro_anon] but registers the id of the
     introduced assumption for a delayed clear. *)
 let intro_drop =
-  Ssrcommon.tclINTRO ~id:None
+  Ssrcommon.tclINTRO ~id:Ssrcommon.Anon
     ~conclusion:(fun ~orig_name:_ ~new_name -> isCLR_PUSH new_name)
+
+(** [intro_temp] behaves like [intro_anon] but registers the id of the
+    introduced assumption for a regeneralization. *)
+let intro_anon_temp =
+  Ssrcommon.tclINTRO ~id:Ssrcommon.Anon
+    ~conclusion:(fun ~orig_name ~new_name ->
+      isGEN_PUSH { tmp_id = new_name; orig_name })
 
 (** [intro_end] performs the actions that have been delayed. *)
 let intro_end =
-  Ssrcommon.tcl0G (isCLR_CONSUME)
+  Ssrcommon.tcl0G ~default:() (isCLR_CONSUME <*> isGEN_CONSUME)
 
 (** [=> _] *****************************************************************)
 let intro_clear ids =
@@ -138,6 +239,27 @@ let tacCHECK_HYPS_EXIST hyps = Goal.enter begin fun gl ->
 end
 
 (** [=> []] *****************************************************************)
+
+(* calls t1 then t2 on each subgoal passing to t2 the index of the current
+ * subgoal (starting from 0) as well as the number of subgoals *)
+let tclTHENin t1 t2 =
+  tclUNIT () >>= begin fun () -> let i = ref (-1) in
+  t1 <*> numgoals >>= fun n ->
+  Goal.enter begin fun g -> incr i; t2 !i n end
+end
+
+(* Attaches one element of `seeds` to each of the last k goals generated by
+`tac`, where k is the size of `seeds` *)
+let tclSEED_SUBGOALS seeds tac =
+  tclTHENin tac (fun i n ->
+          Ssrprinters.ppdebug (lazy Pp.(str"seeding"));
+      (* eg [case: (H _ : nat)] generates 3 goals:
+         - 1 for _
+         - 2 for the nat constructors *)
+    let extra_goals = n - Array.length seeds in
+    if i < extra_goals then tclUNIT ()
+    else isNSEED_SET seeds.(i - extra_goals))
+
 let tac_case t =
   Goal.enter begin fun _ ->
     Ssrcommon.tacTYPEOF t >>= fun ty ->
@@ -145,10 +267,36 @@ let tac_case t =
     if is_inj then
       V82.tactic ~nf_evars:false (Ssrelim.perform_injection t)
     else
-      Ssrelim.ssrscasetac t
+      Goal.enter begin fun g ->
+         (Ssrelim.casetac t (fun ?seed k ->
+           match seed with
+           | None -> k
+           | Some seed -> tclSEED_SUBGOALS seed k))
+      end
 end
 
-(***[=> [: id]] ************************************************************)
+(** [=> [^ seed ]] *********************************************************)
+let tac_intro_seed interp_ipats fix = Goal.enter begin fun gl ->
+  isNSEED_CONSUME begin fun seeds ->
+    let seeds =
+      Ssrcommon.option_assert_get seeds Pp.(str"tac_intro_seed: no seed") in
+    let ipats = List.map (function
+       | Anonymous ->
+           let s = match fix with
+             | Prefix id ->  Id.to_string id ^ "?"
+             | SuffixNum n -> "?" ^ string_of_int n
+             | SuffixId id -> "?" ^ Id.to_string id in
+           IPatAnon (One (Some s))
+       | Name id ->
+           let s = match fix with
+             | Prefix fix ->  Id.to_string fix ^ Id.to_string id
+             | SuffixNum n -> Id.to_string id ^ string_of_int n
+             | SuffixId fix -> Id.to_string id ^ Id.to_string fix in
+           IPatId (None, Id.of_string s)) seeds in
+    interp_ipats ipats
+end end
+
+(*** [=> [: id]] ************************************************************)
 [@@@ocaml.warning "-3"]
 let mk_abstract_id =
   let open Coqlib in
@@ -205,95 +353,112 @@ let tclLOG p t =
   end
   <*>
     t p
-  <*>
+  >>= fun ret ->
   Goal.enter begin fun g ->
     Ssrprinters.ppdebug (lazy Pp.(str "done: " ++ isPRINT g));
     tclUNIT ()
   end
+  >>= fun () -> tclUNIT ret
 
-let rec ipat_tac1 ipat : unit tactic =
+let notTAC = tclUNIT false
+
+(* returns true if it was a tactic (eg /ltac:tactic) *)
+let rec ipat_tac1 ipat : bool tactic =
   match ipat with
   | IPatView (clear_if_id,l) ->
-      Ssrview.tclIPAT_VIEWS ~views:l ~clear_if_id
+      Ssrview.tclIPAT_VIEWS
+        ~views:l ~clear_if_id
         ~conclusion:(fun ~to_clear:clr -> intro_clear clr)
 
-  | IPatDispatch(true,[[]]) ->
-      tclUNIT ()
-  | IPatDispatch(_,ipatss) ->
-      tclDISPATCH (List.map ipat_tac ipatss)
+  | IPatDispatch(true, Regular [[]]) ->
+      notTAC
+  | IPatDispatch(_, Regular ipatss) ->
+      tclDISPATCH (List.map ipat_tac ipatss) <*> notTAC
+  | IPatDispatch(_,Block id_block) ->
+      tac_intro_seed ipat_tac id_block <*> notTAC
 
-  | IPatId id -> Ssrcommon.tclINTRO_ID id
+  | IPatId (None, id) -> Ssrcommon.tclINTRO_ID id <*> notTAC
+  | IPatId (Some Dependent, id) ->
+      intro_anon_deps <*> Ssrcommon.tclINTRO_ID id <*> notTAC
 
-  | IPatCase ipatss ->
-     tclIORPAT (Ssrcommon.tclWITHTOP tac_case) ipatss
+  | IPatCase (Block id_block) ->
+      Ssrcommon.tclWITHTOP tac_case <*> tac_intro_seed ipat_tac id_block <*> notTAC
+
+  | IPatCase (Regular ipatss) ->
+     tclIORPAT (Ssrcommon.tclWITHTOP tac_case) ipatss <*> notTAC
   | IPatInj ipatss ->
      tclIORPAT (Ssrcommon.tclWITHTOP
        (fun t -> V82.tactic  ~nf_evars:false (Ssrelim.perform_injection t)))
        ipatss
+     <*> notTAC
 
-  | IPatAnon Drop -> intro_drop
-  | IPatAnon One -> Ssrcommon.tclINTRO_ANON
-  | IPatAnon All -> intro_anon_all
+  | IPatAnon Drop -> intro_drop <*> notTAC
+  | IPatAnon (One seed) -> Ssrcommon.tclINTRO_ANON ?seed () <*> notTAC
+  | IPatAnon All -> intro_anon_all <*> notTAC
+  | IPatAnon Temporary -> intro_anon_temp <*> notTAC
 
-  | IPatNoop -> tclUNIT ()
-  | IPatSimpl Nop -> tclUNIT ()
+  | IPatNoop -> notTAC
+  | IPatSimpl Nop -> notTAC
 
   | IPatClear ids ->
       tacCHECK_HYPS_EXIST ids <*>
-      intro_clear (List.map Ssrcommon.hyp_id ids)
+      intro_clear (List.map Ssrcommon.hyp_id ids) <*>
+      notTAC
 
-  | IPatSimpl (Simpl n) ->
-       V82.tactic ~nf_evars:false (Ssrequality.simpltac (Simpl n))
-  | IPatSimpl (Cut n) ->
-       V82.tactic ~nf_evars:false (Ssrequality.simpltac (Cut n))
-  | IPatSimpl (SimplCut (n,m)) ->
-       V82.tactic ~nf_evars:false (Ssrequality.simpltac (SimplCut (n,m)))
+  | IPatSimpl x ->
+      V82.tactic ~nf_evars:false (Ssrequality.simpltac x) <*> notTAC
 
   | IPatRewrite (occ,dir) ->
      Ssrcommon.tclWITHTOP
-       (fun x -> V82.tactic  ~nf_evars:false (Ssrequality.ipat_rewrite occ dir x))
+       (fun x -> V82.tactic  ~nf_evars:false (Ssrequality.ipat_rewrite occ dir x)) <*> notTAC
 
-  | IPatAbstractVars ids -> tclMK_ABSTRACT_VARS ids
+  | IPatAbstractVars ids -> tclMK_ABSTRACT_VARS ids <*> notTAC
 
-  | IPatTac t -> t
+  | IPatEqGen t -> t <*> notTAC
 
 and ipat_tac pl : unit tactic =
   match pl with
   | [] -> tclUNIT ()
   | pat :: pl ->
-      Ssrcommon.tcl0G (tclLOG pat ipat_tac1) <*>
-      isTICK pat <*>
-      ipat_tac pl
+      Ssrcommon.tcl0G ~default:false (tclLOG pat ipat_tac1) >>= fun was_tac ->
+      isTICK pat (* drops expired seeds *) >>= fun () ->
+      if was_tac then (* exception *)
+        let ip_before, case, ip_after = split_at_first_case pl in
+        let case = ssr_exception true case in
+        let case = option_to_list case in
+        ipat_tac (ip_before @ case @ ip_after)
+      else ipat_tac pl
 
 and tclIORPAT tac = function
   | [[]] -> tac
   | p -> Tacticals.New.tclTHENS tac (List.map ipat_tac p)
 
-let split_at_first_case ipats =
-  let rec loop acc = function
-    | (IPatSimpl _ | IPatClear _) as x :: rest -> loop (x :: acc) rest
-    | IPatCase _ as x :: xs -> CList.rev acc, Some x, xs
-    | pats -> CList.rev acc, None, pats
-  in
-    loop [] ipats
-
-let ssr_exception is_on = function
+and ssr_exception is_on = function
   | Some (IPatCase l) when is_on -> Some (IPatDispatch(true, l))
   | x -> x
 
-let option_to_list = function None -> [] | Some x -> [x]
+and option_to_list = function None -> [] | Some x -> [x]
+
+and split_at_first_case ipats =
+  let rec loop acc = function
+    | (IPatSimpl _ | IPatClear _) as x :: rest -> loop (x :: acc) rest
+    | (IPatCase _ | IPatDispatch _) as x :: xs -> CList.rev acc, Some x, xs
+    | pats -> CList.rev acc, None, pats
+  in
+    loop [] ipats
+;;
 
 (* Simple pass doing {x}/v ->  /v{x} *)
 let elaborate_ipats l =
   let rec elab = function
   | [] -> []
   | (IPatClear _ as p1) :: (IPatView _ as p2) :: rest -> p2 :: p1 :: elab rest
-  | IPatDispatch(s,p) :: rest -> IPatDispatch (s,List.map elab p) :: elab rest
-  | IPatCase p :: rest -> IPatCase (List.map elab p) :: elab rest
+  | IPatDispatch(s, Regular p) :: rest -> IPatDispatch (s, Regular (List.map elab p)) :: elab rest
+  | IPatCase (Regular p) :: rest -> IPatCase (Regular (List.map elab p)) :: elab rest
   | IPatInj p :: rest -> IPatInj (List.map elab p) :: elab rest
-  | (IPatTac _ | IPatId _ | IPatSimpl _ | IPatClear _ |
+  | (IPatEqGen _ | IPatId _ | IPatSimpl _ | IPatClear _ |
      IPatAnon _ | IPatView _ | IPatNoop | IPatRewrite _ |
-     IPatAbstractVars _) as x :: rest -> x :: elab rest
+     IPatAbstractVars _ | IPatDispatch(_, Block _) | IPatCase(Block _)) as x :: rest -> x :: elab rest
   in
     elab l
 
@@ -302,8 +467,8 @@ let main ?eqtac ~first_case_is_dispatch ipats =
   let ip_before, case, ip_after = split_at_first_case ipats in
   let case = ssr_exception first_case_is_dispatch case in
   let case = option_to_list case in
-  let eqtac = option_to_list (Option.map (fun x -> IPatTac x) eqtac) in
-  Ssrcommon.tcl0G (ipat_tac (ip_before @ case @ eqtac @ ip_after) <*> intro_end)
+  let eqtac = option_to_list (Option.map (fun x -> IPatEqGen x) eqtac) in
+  Ssrcommon.tcl0G ~default:() (ipat_tac (ip_before @ case @ eqtac @ ip_after) <*> intro_end)
 
 end (* }}} *)
 
@@ -344,10 +509,11 @@ let mkCoqRefl t c env sigma =
 
 (** Intro patterns processing for elim tactic, in particular when used in
     conjunction with equation generation as in [elim E: x] *)
-let elim_intro_tac ipats ?ist what eqid ssrelim is_rec clr =
+let elim_intro_tac ipats ?seed what eqid ssrelim is_rec clr =
   let intro_eq =
     match eqid with
-    | Some (IPatId ipat) when not is_rec ->
+    | Some (IPatId (Some _, _)) -> assert false (* parser *)
+    | Some (IPatId (None,ipat)) when not is_rec ->
        let rec intro_eq () = Goal.enter begin fun g ->
          let sigma, env, concl = Goal.(sigma g, env g, concl g) in
          match EConstr.kind_of_type sigma concl with
@@ -356,12 +522,12 @@ let elim_intro_tac ipats ?ist what eqid ssrelim is_rec clr =
              | Term.AtomicType (hd, _) when Ssrcommon.is_protect hd env sigma ->
                 V82.tactic ~nf_evars:false Ssrcommon.unprotecttac <*>
                 Ssrcommon.tclINTRO_ID ipat
-             | _ -> Ssrcommon.tclINTRO_ANON <*> intro_eq ()
+             | _ -> Ssrcommon.tclINTRO_ANON () <*> intro_eq ()
              end
          |_ -> Ssrcommon.errorstrm (Pp.str "Too many names in intro pattern")
        end in
        intro_eq ()
-    | Some (IPatId ipat) ->
+    | Some (IPatId (None,ipat)) ->
        let intro_lhs = Goal.enter begin fun g ->
          let sigma = Goal.sigma g in
          let elim_name = match clr, what with
@@ -369,12 +535,9 @@ let elim_intro_tac ipats ?ist what eqid ssrelim is_rec clr =
            | _, `EConstr(_,_,t) when EConstr.isVar sigma t ->
               EConstr.destVar sigma t
            | _ -> Ssrcommon.mk_anon_id "K" (Tacmach.New.pf_ids_of_hyps g) in
-         let elim_name =
-           if Ssrcommon.is_name_in_ipats elim_name ipats then
-             Ssrcommon.mk_anon_id "K" (Tacmach.New.pf_ids_of_hyps g)
-           else elim_name
-         in
-         Ssrcommon.tclINTRO_ID elim_name
+         Tacticals.New.tclFIRST
+           [ Ssrcommon.tclINTRO_ID elim_name
+           ; Ssrcommon.tclINTRO_ANON ~seed:"K" ()]
        end in
        let rec gen_eq_tac () = Goal.enter begin fun g ->
          let sigma, env, concl = Goal.(sigma g, env g, concl g) in
@@ -389,7 +552,7 @@ let elim_intro_tac ipats ?ist what eqid ssrelim is_rec clr =
            | _ -> assert false in
          let case = args.(Array.length args-1) in
          if not(EConstr.Vars.closed0 sigma case)
-         then Ssrcommon.tclINTRO_ANON <*> gen_eq_tac ()
+         then Ssrcommon.tclINTRO_ANON () <*> gen_eq_tac ()
          else
            Ssrcommon.tacTYPEOF case >>= fun case_ty ->
            let open EConstr in
@@ -407,13 +570,14 @@ let elim_intro_tac ipats ?ist what eqid ssrelim is_rec clr =
        intro_lhs <*>
        Ssrcommon.tclINTRO_ID ipat
     | _ -> tclUNIT () in
-  let unprot =
+  let unprotect =
     if eqid <> None && is_rec
     then V82.tactic ~nf_evars:false Ssrcommon.unprotecttac else tclUNIT () in
-  V82.of_tactic begin
-    V82.tactic ~nf_evars:false ssrelim <*>
-    tclIPAT_EQ (intro_eq <*> unprot) ipats
-  end
+  begin match seed with
+  | None -> ssrelim
+  | Some s -> IpatMachine.tclSEED_SUBGOALS s ssrelim end <*>
+  tclIPAT_EQ (intro_eq <*> unprotect) ipats
+;;
 
 let mkEq dir cl c t n env sigma =
   let open EConstr in
@@ -506,13 +670,11 @@ let ssrelimtac (view, (eqid, (dgens, ipats))) =
     | [v] ->
       Ssrcommon.tclINTERP_AST_CLOSURE_TERM_AS_CONSTR v >>= fun cs ->
       tclDISPATCH (List.map (fun elim ->
-        V82.tactic ~nf_evars:false
           (Ssrelim.ssrelim deps (`EGen gen) ~elim eqid (elim_intro_tac ipats)))
         cs)
     | [] ->
       tclINDEPENDENT
-        (V82.tactic ~nf_evars:false
-          (Ssrelim.ssrelim deps (`EGen gen) eqid (elim_intro_tac ipats)))
+          (Ssrelim.ssrelim deps (`EGen gen) eqid (elim_intro_tac ipats))
     | _ ->
       Ssrcommon.errorstrm
         Pp.(str "elim: only one elimination lemma can be provided")
@@ -535,9 +697,8 @@ let ssrcasetac (view, (eqid, (dgens, ipats))) =
             if view <> [] && eqid <> None && deps = []
             then [gen], [], None
             else deps, clear, occ in
-          V82.tactic ~nf_evars:false
-            (Ssrelim.ssrelim ~is_case:true deps (`EConstr (clear, occ, vc))
-              eqid (elim_intro_tac ipats))
+          Ssrelim.ssrelim ~is_case:true deps (`EConstr (clear, occ, vc))
+            eqid (elim_intro_tac ipats)
       in
       if view = [] then conclusion false c clear c
       else tacVIEW_THEN_GRAB ~simple_types:false view ~conclusion info)
@@ -556,18 +717,16 @@ let pushmoveeqtac cl c = Goal.enter begin fun g ->
   Tactics.apply_type ~typecheck:true (EConstr.mkProd (x, t, cl2)) [c; eqc]
 end
 
-let eqmovetac _ gen = Goal.enter begin fun g ->
-  Ssrcommon.tacSIGMA >>= fun gl ->
-  let cl, c, _, gl = Ssrcommon.pf_interp_gen gl false gen in
-  Unsafe.tclEVARS (Tacmach.project gl) <*>
-  pushmoveeqtac cl c
-end
+let eqmovetac _ gen =
+  Ssrcommon.pfLIFT (Ssrcommon.pf_interp_gen false gen) >>=
+  fun (cl, c, _) -> pushmoveeqtac cl c
+;;
 
 let rec eqmoveipats eqpat = function
   | (IPatSimpl _ | IPatClear _ as ipat) :: ipats ->
        ipat :: eqmoveipats eqpat ipats
   | (IPatAnon All :: _ | []) as ipats ->
-       IPatAnon One :: eqpat :: ipats
+       IPatAnon (One None) :: eqpat :: ipats
   | ipat :: ipats ->
        ipat :: eqpat :: ipats
 
@@ -700,8 +859,8 @@ let ssrabstract dgens =
      let open Ssrmatching in
      let ipats = List.map (fun (_,cp) ->
        match id_of_pattern (interp_cpattern gl0 cp None) with
-       | None -> IPatAnon One
-       | Some id -> IPatId id)
+       | None -> IPatAnon (One None)
+       | Some id -> IPatId (None,id))
        (List.tl gens) in
      conclusion ipats
   end in

--- a/plugins/ssr/ssrparser.mlg
+++ b/plugins/ssr/ssrparser.mlg
@@ -605,18 +605,18 @@ let remove_loc x = x.CAst.v
 
 let ipat_of_intro_pattern p = Tactypes.(
   let rec ipat_of_intro_pattern = function
-    | IntroNaming (IntroIdentifier id) -> IPatId id
+    | IntroNaming (IntroIdentifier id) -> IPatId (None,id)
     | IntroAction IntroWildcard -> IPatAnon Drop
     | IntroAction (IntroOrAndPattern (IntroOrPattern iorpat)) ->
-      IPatCase 
-       (List.map (List.map ipat_of_intro_pattern) 
- 	 (List.map (List.map remove_loc) iorpat))
+      IPatCase (Regular(
+       List.map (List.map ipat_of_intro_pattern) 
+ 	 (List.map (List.map remove_loc) iorpat)))
     | IntroAction (IntroOrAndPattern (IntroAndPattern iandpat)) ->
       IPatCase 
-       [List.map ipat_of_intro_pattern (List.map remove_loc iandpat)]
-    | IntroNaming IntroAnonymous -> IPatAnon One
+       (Regular [List.map ipat_of_intro_pattern (List.map remove_loc iandpat)])
+    | IntroNaming IntroAnonymous -> IPatAnon (One None)
     | IntroAction (IntroRewrite b) -> IPatRewrite (allocc, if b then L2R else R2L)
-    | IntroNaming (IntroFresh id) -> IPatAnon One
+    | IntroNaming (IntroFresh id) -> IPatAnon (One None)
     | IntroAction (IntroApplyOn _) -> (* to do *) CErrors.user_err (Pp.str "TO DO")
     | IntroAction (IntroInjection ips) ->
         IPatInj [List.map ipat_of_intro_pattern (List.map remove_loc ips)]
@@ -630,14 +630,20 @@ let ipat_of_intro_pattern p = Tactypes.(
 
 let rec map_ipat map_id map_ssrhyp map_ast_closure_term = function
   | (IPatSimpl _ | IPatAnon _ | IPatRewrite _ | IPatNoop) as x -> x
-  | IPatId id -> IPatId (map_id id)
+  | IPatId (m,id) -> IPatId (m,map_id id)
   | IPatAbstractVars l -> IPatAbstractVars (List.map map_id l)
   | IPatClear clr -> IPatClear (List.map map_ssrhyp clr)
-  | IPatCase iorpat -> IPatCase (List.map (List.map (map_ipat map_id map_ssrhyp map_ast_closure_term)) iorpat)
-  | IPatDispatch (s,iorpat) -> IPatDispatch (s,List.map (List.map (map_ipat map_id map_ssrhyp map_ast_closure_term)) iorpat)
+  | IPatCase (Regular iorpat) -> IPatCase (Regular (List.map (List.map (map_ipat map_id map_ssrhyp map_ast_closure_term)) iorpat))
+  | IPatCase (Block(hat)) -> IPatCase (Block(map_block map_id hat))
+  | IPatDispatch (s, Regular iorpat) -> IPatDispatch (s, Regular (List.map (List.map (map_ipat map_id map_ssrhyp map_ast_closure_term)) iorpat))
+  | IPatDispatch (s, Block (hat)) -> IPatDispatch (s, Block(map_block map_id hat))
   | IPatInj iorpat -> IPatInj (List.map (List.map (map_ipat map_id map_ssrhyp map_ast_closure_term)) iorpat)
   | IPatView (clr,v) -> IPatView (clr,List.map map_ast_closure_term v)
-  | IPatTac _ -> assert false (*internal usage only *)
+  | IPatEqGen _ -> assert false (*internal usage only *)
+and map_block map_id = function
+  | Prefix id -> Prefix (map_id id)
+  | SuffixId id -> SuffixId (map_id id)
+  | SuffixNum _ as x -> x
 
 type ssripatrep = ssripat
 let wit_ssripatrep = add_genarg "ssripatrep" pr_ipat
@@ -688,8 +694,20 @@ let rec add_intro_pattern_hyps ipat hyps =
  * we have no clue what a name could be bound to (maybe another ipat) *)
 let interp_ipat ist gl =
   let ltacvar id = Id.Map.mem id ist.Tacinterp.lfun in
+  let interp_block = function
+    | Prefix id when ltacvar id ->
+        begin match interp_introid ist gl id with
+        | IntroNaming (IntroIdentifier id) -> Prefix id
+        | _ -> Ssrcommon.errorstrm Pp.(str"Variable " ++ Id.print id ++ str" in block intro pattern should be bound to an identifier.")
+        end
+    | SuffixId id when ltacvar id ->
+        begin match interp_introid ist gl id with
+        | IntroNaming (IntroIdentifier id) -> SuffixId id
+        | _ -> Ssrcommon.errorstrm Pp.(str"Variable " ++ Id.print id ++ str" in block intro pattern should be bound to an identifier.")
+        end
+    | x -> x in
   let rec interp = function
-  | IPatId id when ltacvar id ->
+  | IPatId(_, id) when ltacvar id ->
     ipat_of_intro_pattern (interp_introid ist gl id)
   | IPatId _ as x -> x
   | IPatClear clr ->
@@ -698,17 +716,21 @@ let interp_ipat ist gl =
       add_intro_pattern_hyps CAst.(make ?loc (interp_introid ist gl id)) hyps in
     let clr' = List.fold_right add_hyps clr [] in
     check_hyps_uniq [] clr'; IPatClear clr'
-  | IPatCase(iorpat) ->
-      IPatCase(List.map (List.map interp) iorpat)
-  | IPatDispatch(s,iorpat) ->
-      IPatDispatch(s,List.map (List.map interp) iorpat)
+  | IPatCase(Regular iorpat) ->
+      IPatCase(Regular(List.map (List.map interp) iorpat))
+  | IPatCase(Block(hat)) -> IPatCase(Block(interp_block hat))
+
+  | IPatDispatch(s,Regular iorpat) ->
+      IPatDispatch(s,Regular (List.map (List.map interp) iorpat))
+  | IPatDispatch(s,Block(hat)) -> IPatDispatch(s,Block(interp_block hat))
+
   | IPatInj iorpat -> IPatInj (List.map (List.map interp) iorpat)
   | IPatAbstractVars l ->
      IPatAbstractVars (List.map get_intro_id (List.map (interp_introid ist gl) l))
   | IPatView (clr,l) -> IPatView (clr,List.map (fun x -> snd(interp_ast_closure_term ist
      gl x)) l)
   | (IPatSimpl _ | IPatAnon _ | IPatRewrite _ | IPatNoop) as x -> x
-  | IPatTac _ -> assert false (*internal usage only *)
+  | IPatEqGen _ -> assert false (*internal usage only *)
     in
   interp
 
@@ -729,19 +751,11 @@ ARGUMENT EXTEND ssripat TYPED AS ssripatrep list PRINTED BY { pr_ssripats }
   GLOBALIZED BY { intern_ipats }
   | [ "_" ] -> { [IPatAnon Drop] }
   | [ "*" ] -> { [IPatAnon All] }
-             (*
-  | [ "^" "*" ] -> { [IPatFastMode] }
-  | [ "^" "_" ] -> { [IPatSeed `Wild] }
-  | [ "^_" ] -> { [IPatSeed `Wild] }
-  | [ "^" "?" ] -> { [IPatSeed `Anon] }
-  | [ "^?" ] -> { [IPatSeed `Anon] }
-  | [ "^" ident(id) ] -> { [IPatSeed (`Id(id,`Pre))] }
-  | [ "^" "~" ident(id) ] -> { [IPatSeed (`Id(id,`Post))] }
-  | [ "^~" ident(id) ] -> { [IPatSeed (`Id(id,`Post))] }
-              *)
-  | [ ident(id) ] -> { [IPatId id] }
-  | [ "?" ] -> { [IPatAnon One] }
-(* TODO  | [ "+" ] -> [ [IPatAnon Temporary] ] *)
+  | [ ">" ident(id) ] -> { [IPatId(Some Dependent,id)] }
+  | [ ident(id) ] -> { [IPatId (None,id)] }
+  | [ "?" ] -> { [IPatAnon (One None)] }
+  | [ "+" ] -> { [IPatAnon Temporary] }
+  | [ "++" ] -> { [IPatAnon Temporary; IPatAnon Temporary] }
   | [ ssrsimpl_ne(sim) ] -> { [IPatSimpl sim] }
   | [ ssrdocc(occ) "->" ] -> { match occ with
       | Some [], _ -> CErrors.user_err ~loc (str"occ_switch expected")
@@ -805,28 +819,42 @@ let reject_ssrhid strm =
 
 let test_nohidden = Pcoq.Entry.of_parser "test_ssrhid" reject_ssrhid
 
+let rec reject_binder crossed_paren k s =
+  match
+    try Some (Util.stream_nth k s)
+    with Stream.Failure -> None
+  with
+  | Some (Tok.KEYWORD "(") when not crossed_paren -> reject_binder true (k+1) s
+  | Some (Tok.IDENT _) when crossed_paren -> reject_binder true (k+1) s
+  | Some (Tok.KEYWORD ":" | Tok.KEYWORD ":=") when crossed_paren ->
+      raise Stream.Failure
+  | Some (Tok.KEYWORD ")") when crossed_paren -> raise Stream.Failure
+  | _ -> if crossed_paren then () else raise Stream.Failure
+
+let _test_nobinder = Pcoq.Entry.of_parser "test_nobinder" (reject_binder false 0)
+
 }
 
 ARGUMENT EXTEND ssrcpat TYPED AS ssripatrep PRINTED BY { pr_ssripat }
-  | [ "YouShouldNotTypeThis" ssriorpat(x) ] -> { IPatCase(x) }
+  | [ "YouShouldNotTypeThis" ssriorpat(x) ] -> { IPatCase(Regular x) }
 END
 
 (* Pcoq *)
 GRAMMAR EXTEND Gram
   GLOBAL: ssrcpat;
+  hat: [
+  [ "^"; id = ident -> { Prefix id }
+  | "^"; "~"; id = ident -> { SuffixId id }
+  | "^"; "~"; n = natural -> { SuffixNum n }
+  | "^~"; id = ident -> { SuffixId id }
+  | "^~"; n = natural -> { SuffixNum n }
+  ]];
   ssrcpat: [
-   [ test_nohidden; "["; iorpat = ssriorpat; "]" -> {
-(*      check_no_inner_seed !@loc false iorpat;
-      IPatCase (understand_case_type iorpat) *)
-      IPatCase iorpat }
-(*
-   | test_nohidden; "("; iorpat = ssriorpat; ")" ->
-(*      check_no_inner_seed !@loc false iorpat;
-      IPatCase (understand_case_type iorpat) *)
-      IPatDispatch iorpat
-*)
+   [ test_nohidden; "["; hat_id = hat; "]" -> {
+      IPatCase (Block(hat_id)) }
+   | test_nohidden; "["; iorpat = ssriorpat; "]" -> {
+      IPatCase (Regular iorpat) }
    | test_nohidden; "[="; iorpat = ssriorpat; "]" -> {
-(*      check_no_inner_seed !@loc false iorpat; *)
       IPatInj iorpat } ]];
 END
 
@@ -1464,7 +1492,7 @@ END
 {
 
 let intro_id_to_binder = List.map (function 
-  | IPatId id ->
+  | IPatId (None,id) ->
       let { CAst.loc=xloc } as x = bvar_lname (mkCVar id) in
       (FwdPose, [BFvar]),
         CAst.make @@ CLambdaN ([CLocalAssum([x], Default Explicit, mkCHole xloc)],
@@ -1474,9 +1502,9 @@ let intro_id_to_binder = List.map (function
 let binder_to_intro_id = CAst.(List.map (function
   | (FwdPose, [BFvar]), { v = CLambdaN ([CLocalAssum(ids,_,_)],_) }
   | (FwdPose, [BFdecl _]), { v = CLambdaN ([CLocalAssum(ids,_,_)],_) } ->
-      List.map (function {v=Name id} -> IPatId id | _ -> IPatAnon One) ids
-  | (FwdPose, [BFdef]), { v = CLetIn ({v=Name id},_,_,_) } -> [IPatId id]
-  | (FwdPose, [BFdef]), { v = CLetIn ({v=Anonymous},_,_,_) } -> [IPatAnon One]
+      List.map (function {v=Name id} -> IPatId (None,id) | _ -> IPatAnon (One None)) ids
+  | (FwdPose, [BFdef]), { v = CLetIn ({v=Name id},_,_,_) } -> [IPatId (None,id)]
+  | (FwdPose, [BFdef]), { v = CLetIn ({v=Anonymous},_,_,_) } -> [IPatAnon (One None)]
   | _ -> anomaly "ssrbinder is not a binder"))
 
 let pr_ssrhavefwdwbinders _ _ prt (tr,((hpats, (fwd, hint)))) =
@@ -1966,9 +1994,10 @@ let test_ssreqid = Pcoq.Entry.of_parser "test_ssreqid" accept_ssreqid
 GRAMMAR EXTEND Gram
   GLOBAL: ssreqid;
   ssreqpat: [
-    [ id = Prim.ident -> { IPatId id }
+    [ id = Prim.ident -> { IPatId (None,id) }
     | "_" -> { IPatAnon Drop }
-    | "?" -> { IPatAnon One }
+    | "?" -> { IPatAnon (One None) }
+    | "+" -> { IPatAnon Temporary }
     | occ = ssrdocc; "->" -> { match occ with
       | None, occ -> IPatRewrite (occ, L2R)
       | _ -> CErrors.user_err ~loc (str"Only occurrences are allowed here") }

--- a/plugins/ssr/ssrprinters.ml
+++ b/plugins/ssr/ssrprinters.ml
@@ -97,24 +97,30 @@ let pr_view2 = pr_list mt (fun c -> str "/" ++ pr_ast_closure_term c)
 
 let rec pr_ipat p =
   match p with
-  | IPatId id -> Id.print id
+  | IPatId (None,id) -> Id.print id
+  | IPatId (Some Dependent,id) -> str">" ++ Id.print id
   | IPatSimpl sim -> pr_simpl sim
   | IPatClear clr -> pr_clear mt clr
-  | IPatCase iorpat -> hov 1 (str "[" ++ pr_iorpat iorpat ++ str "]")
-  | IPatDispatch(_,iorpat) -> hov 1 (str "/[" ++ pr_iorpat iorpat ++ str "]")
+  | IPatCase (Regular iorpat) -> hov 1 (str "[" ++ pr_iorpat iorpat ++ str "]")
+  | IPatCase (Block m) -> hov 1 (str"[" ++ pr_block m ++ str"]")
+  | IPatDispatch(_,Regular iorpat) -> hov 1 (str "(" ++ pr_iorpat iorpat ++ str ")")
+  | IPatDispatch (_,Block m) -> hov 1 (str"(" ++ pr_block m ++ str")")
   | IPatInj iorpat -> hov 1 (str "[=" ++ pr_iorpat iorpat ++ str "]")
   | IPatRewrite (occ, dir) -> pr_occ occ ++ pr_dir dir
   | IPatAnon All -> str "*"
   | IPatAnon Drop -> str "_"
-  | IPatAnon One -> str "?"
+  | IPatAnon (One _) -> str "?"
   | IPatView (false,v) -> pr_view2 v
   | IPatView (true,v) -> str"{}" ++ pr_view2 v
+  | IPatAnon Temporary -> str "+"
   | IPatNoop -> str "-"
   | IPatAbstractVars l -> str "[:" ++ pr_list spc Id.print l ++ str "]"
-  | IPatTac _ -> str "<tac>"
-(* TODO  | IPatAnon Temporary -> str "+" *)
+  | IPatEqGen _ -> str "<tac>"
 and pr_ipats ipats = pr_list spc pr_ipat ipats
 and pr_iorpat iorpat = pr_list pr_bar pr_ipats iorpat
+and pr_block = function (Prefix id) -> str"^" ++ Id.print id
+                      | (SuffixId id) -> str"^~" ++ Id.print id
+                      | (SuffixNum n) -> str"^~" ++ int n
 
 (* 0 cost pp function. Active only if Debug Ssreflect is Set *)
 let ppdebug_ref = ref (fun _ -> ())

--- a/plugins/ssr/ssrview.mli
+++ b/plugins/ssr/ssrview.mli
@@ -22,11 +22,12 @@ end
 
 (* Apply views to the top of the stack (intro pattern). If clear_if_id is
  * true (default false) then views that happen to be a variable are considered
- * as to be cleared (see the to_clear argument to the continuation) *)
-val tclIPAT_VIEWS :
-    views:ast_closure_term list -> ?clear_if_id:bool ->
+ * as to be cleared (see the to_clear argument to the continuation)
+ *
+ * returns true if the last view was a tactic *)
+val tclIPAT_VIEWS : views:ast_closure_term list -> ?clear_if_id:bool ->
     conclusion:(to_clear:Names.Id.t list -> unit Proofview.tactic) ->
-  unit Proofview.tactic
+  bool Proofview.tactic
 
 (* Apply views to a given subject (as if was the top of the stack), then
    call conclusion on the obtained term (something like [v2 (v1 subject)]).

--- a/test-suite/ssr/elim.v
+++ b/test-suite/ssr/elim.v
@@ -33,7 +33,7 @@ Qed.
 (* The same but without names for variables involved in the generated eq *)
 Lemma testL3 : forall A (s : seq A), s = s.
 Proof.
-move=> A s; elim branch: s; move: (s) => _.
+move=> A s; elim branch: s.
 match goal with _ : _ = [::] |- [::] = [::] => move: branch => // | _ => fail end.
 move=> _; match goal with _ : _ =  _ :: _ |- _ :: _ = _ :: _ => move: branch => // | _ => fail end.
 Qed.

--- a/test-suite/ssr/ipat_clear_if_id.v
+++ b/test-suite/ssr/ipat_clear_if_id.v
@@ -8,6 +8,7 @@ Variable v2 : nat -> bool.
 
 Lemma test (v3 : nat -> bool) (v4 : bool -> bool) (v5 : bool -> bool) : nat -> nat -> nat -> nat -> True.
 Proof.
+Set Debug Ssreflect.
 move=> {}/v1 b1 {}/v2 b2 {}/v3 b3 {}/v2/v4/v5 b4.
 Check b1 : bool.
 Check b2 : bool.
@@ -19,5 +20,13 @@ Fail Check v5.
 Check v2 : nat -> bool.
 by [].
 Qed.
+
+Lemma test2 (v : True <-> False) : True -> False.
+Proof.
+move=> {}/v.
+Fail Check v.
+by [].
+Qed.
+
 
 End Foo.

--- a/test-suite/ssr/ipat_fastid.v
+++ b/test-suite/ssr/ipat_fastid.v
@@ -1,0 +1,31 @@
+Require Import ssreflect.
+
+Axiom odd : nat -> Prop.
+
+Lemma simple :
+  forall x, 3 <= x -> forall y, odd (y+x) -> x = y -> True.
+Proof.
+move=> >x_ge_3 >xy_odd.
+lazymatch goal with
+| |- ?x = ?y -> True => done
+end.
+Qed.
+
+
+Definition stuff x := 3 <= x -> forall y, odd (y+x) -> x = y -> True.
+
+Lemma harder : forall x, stuff x.
+Proof.
+move=> >x_ge_3 >xy_odd.
+lazymatch goal with
+| |- ?x = ?y -> True => done
+end.
+Qed.
+
+Lemma homotop : forall x : nat, forall e : x = x, e = e -> True.
+Proof.
+move=> >eq_ee.
+lazymatch goal with
+| |- True => done
+end.
+Qed.

--- a/test-suite/ssr/ipat_seed.v
+++ b/test-suite/ssr/ipat_seed.v
@@ -1,0 +1,60 @@
+Require Import ssreflect.
+
+Section foo.
+
+Variable A : Type.
+
+Record bar (X : Type) := mk_bar {
+  a : X * A;
+  b : A;
+  c := (a,7);
+  _ : X;
+  _ : X
+}.
+
+Inductive baz (X : Type) (Y : Type) : nat -> Type :=
+| K1 x (e : 0=1) (f := 3) of x=x:>X : baz X Y O
+| K2 n of n=n & baz X nat 0 : baz X Y (n+1).
+
+Axiom Q : nat -> Prop.
+Axiom Qx : forall x, Q x.
+Axiom my_ind :
+  forall P : nat -> Prop, P O -> (forall n m (w : P n /\ P m), P (n+m)) ->
+     forall w, P w.
+
+Lemma test x : bar nat -> baz nat nat x -> forall n : nat, Q n.
+Proof.
+
+(* record *)
+move => [^~ _ccc ].
+Check (refl_equal _ : c_ccc = (a_ccc, 7)).
+
+(* inductive *)
+move=> [^ xxx_ ].
+Check (refl_equal _ : xxx_f = 3).
+  by [].
+Check (refl_equal _ : xxx_n = xxx_n).
+
+(* eliminator *)
+elim/my_ind => [^ wow_ ].
+  exact: Qx 0.
+Check (wow_w : Q wow_n /\ Q wow_m).
+exact: Qx (wow_n + wow_m).
+
+Qed.
+
+Arguments mk_bar A x y z w : rename.
+Arguments K1 A B a b c : rename.
+
+
+Lemma test2 x : bar nat -> baz nat nat x -> forall n : nat, Q n.
+Proof.
+move=> [^~ _ccc ].
+Check (refl_equal _ :  c_ccc = (x_ccc, 7)).
+move=> [^ xxx_ ].
+Check (refl_equal _ : xxx_f = 3).
+  by [].
+Check (refl_equal _ : xxx_n = xxx_n).
+Abort.
+
+End foo.

--- a/test-suite/ssr/ipat_tac.v
+++ b/test-suite/ssr/ipat_tac.v
@@ -1,0 +1,38 @@
+Require Import ssreflect.
+
+Ltac fancy := case; last first.
+
+Notation fancy := (ltac:( fancy )).
+
+Ltac replicate n :=
+  let what := fresh "_replicate_" in
+  move=> what; do n! [ have := what ]; clear what.
+
+Notation replicate n := (ltac:( replicate n )).
+
+Lemma foo x (w : nat) (J : bool -> nat -> nat) : exists y, x=0+y.
+Proof.
+move: (w) => /ltac:(idtac) _.
+move: w => /(replicate 6) w1 w2 w3 w4 w5 w6.
+move: w1 => /J/fancy [w'||];last exact: false.
+  move: w' => /J/fancy[w''||]; last exact: false.
+    by exists x.
+  by exists x.
+by exists x.
+Qed.
+
+Ltac unfld what := rewrite /what.
+
+Notation "% n" := (ltac:( unfld n )) (at level 0) : ssripat_scope.
+Notation "% n" := n : nat_scope.
+
+Open Scope nat_scope.
+
+
+Definition def := 4.
+
+Lemma test : True -> def = 4.
+Proof.
+move=> _ /(% def).
+match goal with |- 4 = 4 => reflexivity end.
+Qed.

--- a/test-suite/ssr/ipat_tmp.v
+++ b/test-suite/ssr/ipat_tmp.v
@@ -1,0 +1,22 @@
+Require Import ssreflect ssrbool.
+
+ Axiom eqn : nat -> nat -> bool.
+ Infix "==" := eqn (at level 40).
+ Axiom eqP : forall x y : nat, reflect (x = y) (x == y).
+
+ Lemma test1 :
+   forall x y : nat, x = y -> forall z : nat, y == z -> x = z.
+ Proof.
+ by move=> x y + z /eqP <-; apply.
+ Qed.
+
+ Lemma test2 : forall (x y : nat) (e : x = y), e = e -> x = y.
+ Proof.
+ move=> + y + _ => x def_x; exact: (def_x : x = y).
+ Qed.
+
+ Lemma test3 :
+   forall x y : nat, x = y -> forall z : nat, y == z -> x = z.
+ Proof.
+ move=> ++++ /eqP <- => x y e z; exact: e.
+ Qed.

--- a/test-suite/ssr/misc_extended.v
+++ b/test-suite/ssr/misc_extended.v
@@ -1,0 +1,83 @@
+Require Import ssreflect.
+
+Require Import List.
+
+Lemma test_elim_pattern_1 : forall A (l:list A), l ++ nil = l.
+Proof.
+intros A.
+elim/list_ind => [^~ 1 ].
+  by [].
+match goal with |- (a1 :: l1) ++ nil = a1 :: l1 => idtac end.
+Abort.
+
+Lemma test_elim_pattern_2 : forall A (l:list A), l ++ nil = l.
+Proof.
+intros. elim: l => [^~ 1 ].
+  by [].
+match goal with |- (a1 :: l1) ++ nil = a1 :: l1 => idtac end.
+Abort.
+
+Lemma test_elim_pattern_3 : forall A (l:list A), l ++ nil = l.
+Proof.
+intros. elim: l => [ | x l' IH ].
+  by [].
+match goal with |- (x :: l') ++ nil = x :: l' => idtac end.
+Abort.
+
+
+Generalizable Variables A.
+
+Class Inhab (A:Type) : Type :=
+  { arbitrary : A }.
+
+Lemma test_intro_typeclass_1 : forall A `{Inhab A} (l1 l2:list A), l2 = nil -> l1 ++ l2 = l1.
+Proof.
+move =>> H.
+  match goal with |- _ = _ => idtac end.
+Abort.
+
+Lemma test_intro_typeclass_2 : forall A `{Inhab A} (x:A), x = arbitrary -> x = arbitrary.
+Proof.
+move =>> H.
+  match goal with |- _ = _ => idtac end.
+Abort.
+
+Lemma test_intro_temporary_1 : forall A (l1 l2:list A), l2 = nil -> l1 ++ l2 = l1.
+Proof.
+move => A + l2.
+  match goal with |- forall l1, l2 = nil -> l1 ++ l2 = l1 => idtac end.
+Abort.
+
+Lemma test_intro_temporary_2 : forall A `{Inhab A} (l1 l2:list A), l2 = nil -> l1 ++ l2 = l1.
+Proof.
+move => > E.
+  match goal with |- _ = _ => idtac end.
+Abort.
+
+Lemma test_dispatch : (forall x:nat, x= x )/\ (forall y:nat, y = y).
+Proof.
+intros. split => [ a | b ].
+  match goal with |- a = a => by [] end.
+match goal with |- b = b => by [] end.
+Abort.
+
+Lemma test_tactics_as_view_1 : forall A (l1:list A), nil ++ l1 = l1.
+Proof.
+move => /ltac:(simpl).
+Abort.
+
+Lemma test_tactics_as_view_2 : forall A, (forall (l1:list A), nil ++ l1 = l1) /\ (nil ++ nil = @nil A).
+Proof.
+move => A.
+(* TODO: I want to do  [split =>.] as a temporary step in setting up my script,
+    but this syntax does not seem to be supported. Can't we have an empty ipat?
+   Note that I can do [split => [ | ]]*)
+split => [| /ltac:(simpl)].
+Abort.
+
+Notation "%%" := (ltac:(simpl)) : ssripat_scope.
+
+Lemma test_tactics_as_view_3 : forall A, (forall (l1:list A), nil ++ l1 = l1) /\ (nil ++ nil = @nil A).
+Proof.
+move => /ltac:(split) [ | /%% ].
+Abort.

--- a/test-suite/ssr/misc_tc.v
+++ b/test-suite/ssr/misc_tc.v
@@ -1,0 +1,30 @@
+Require Import ssreflect List.
+
+Generalizable Variables A B.
+
+Class Inhab (A:Type) : Type :=
+  { arbitrary : A }.
+
+Lemma test_intro_typeclass_1 : forall A `{Inhab A} (x:A), x = arbitrary -> x = arbitrary.
+Proof.
+move =>> H. (* introduces [H:x=arbitrary] because first non dependent hypothesis *)
+Abort.
+
+Lemma test_intro_typeclass_2 : forall A `{Inhab A} (l1 l2:list A), l2 = nil -> l1 ++ l2 = l1.
+Proof.
+move =>> H. (* introduces [Inhab A] automatically because it is a typeclass instance *)
+Abort.
+
+Lemma test_intro_typeclass_3 : forall `{Inhab A, Inhab B} (x:A) (y:B), True -> x = x.
+Proof. (* Above types [A] and [B] are implicitly quantified *)
+move =>> y H. (* introduces the two typeclass instances automatically *)
+Abort.
+
+Class Foo `{Inhab A} : Type :=
+  { foo : A }.
+
+Lemma test_intro_typeclass_4 : forall `{Foo A}, True -> True.
+Proof. (* Above, [A] and [{Inhab A}] are implicitly quantified *)
+move =>> H. (* introduces [A] and [Inhab A] because they are dependently used,
+               and introduce [Foo A] automatically because it is an instance. *)
+Abort.


### PR DESCRIPTION
# extended intro patterns

This PR implements the following intro patterns for ssr:
  - temporary introduction: `=> +`
  - block introduction: `=> [^ prefix ] [^~ suffix ]`
  - fast introduction: `=> >H`
  - tactics as views: `=> /ltac:mytac`

See the reference manual for the actual documentation.

## Status

- [x] Corresponding documentation was added / updated.
- [x] Entry added in CHANGES.
- [x] Check all bugs reported by Cyril are fixed