### PR TITLE
Mention -quiet flag for Fail

### DIFF
--- a/doc/refman/RefMan-oth.tex
+++ b/doc/refman/RefMan-oth.tex
@@ -917,9 +917,9 @@ This command displays whether some default timeout has be set or not.
 For debugging {\Coq} scripts, sometimes it is desirable to know
 whether a command or a tactic fails. If the given command or tactic
 fails, the {\tt Fail} statement succeeds, without changing the proof
-state, and {\Coq} prints a message confirming the failure. If the
-command or tactic succeeds, the statement is an error, and {\Coq}
-prints a message indicating that the failure did not occur.
+state, and in interactive mode, {\Coq} prints a message confirming the failure.
+If the command or tactic succeeds, the statement is an error, and
+{\Coq} prints a message indicating that the failure did not occur.
 
 \section{Controlling display}
 


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** documentation.

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->

This is a small change to the documentation of Fail introduced in #6657.

I've added a mention of the `-quiet` flag, which will suppress a message in the cases where a statement fails. That's so, unless the undocumented `-test-mode` flag is used, or you're using the XML protocol (as in CoqIDE). Those details are more complicated than maybe warrants documentation, so I just mentioned the `-quiet` flag.

Incidentally, the `-quiet` flag is not mentioned in the manual for `coqtop` and `coqc`. I'll file an issue for that.

<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
