### PR TITLE
-time-log: log timing info in .aux file

### DIFF
--- a/lib/flags.ml
+++ b/lib/flags.ml
@@ -54,6 +54,7 @@ let in_debugger = ref false
 let in_toplevel = ref false
 
 let profile = false
+let measure_time_in_aux = ref false
 
 let ide_slave = ref false
 let ideslave_coqtop_flags = ref None

--- a/lib/flags.mli
+++ b/lib/flags.mli
@@ -30,6 +30,7 @@ val in_debugger : bool ref
 val in_toplevel : bool ref
 
 val profile : bool
+val measure_time_in_aux : bool ref
 
 (* -ide_slave: printing will be more verbose, will affect stm caching *)
 val ide_slave : bool ref

--- a/lib/system.mli
+++ b/lib/system.mli
@@ -101,6 +101,7 @@ val skip_in_segment : string -> in_channel -> int * Digest.t
 type time
 
 val get_time : unit -> time
+(** arguments are "time before" and "time after", in this order *)
 val time_difference : time -> time -> float (** in seconds *)
 val fmt_time_difference : time -> time -> Pp.t
 

--- a/tools/CoqMakefile.in
+++ b/tools/CoqMakefile.in
@@ -210,7 +210,7 @@ TIMING_EXT=timing
 endif
 endif
 else
-TIMING_ARG=
+TIMING_ARG ?=
 endif
 
 # Retro compatibility (DESTDIR is standard on Unix, DSTROOT is not)

--- a/tools/coqc.ml
+++ b/tools/coqc.ml
@@ -91,7 +91,7 @@ let parse_args () =
 
 (* Options for coqtop : a) options with 0 argument *)
 
-    | ("-bt"|"-debug"|"-nolib"|"-boot"|"-time"|"-profile-ltac"
+    | ("-bt"|"-debug"|"-nolib"|"-boot"|"-time"|"-time-log"|"-profile-ltac"
       |"-batch"|"-noinit"|"-nois"|"-noglob"|"-no-glob"
       |"-q"|"-profile"|"-echo" |"-quiet"
       |"-silent"|"-m"|"-beautify"|"-strict-implicit"

--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -781,6 +781,7 @@ let parse_args arglist =
     |"-quick" -> compilation_mode := BuildVio
     |"-list-tags" -> print_tags := true
     |"-time" -> measure_time := true
+    |"-time-log" -> Flags.measure_time_in_aux := true
     |"-type-in-type" -> set_type_in_type ()
     |"-unicode" -> add_require ("Utf8_core", None, Some false)
     |"-v"|"--version" -> Usage.version (exitcode ())


### PR DESCRIPTION
Thanks to this PR + coq/coq-bench#37 you get stuff like this on pendulum
  https://ci.inria.fr/coq/job/benchmark-2-commits/ws/3/html/coq-mathcomp-ssreflect/mathcomp/ssreflect/
For each command in the script you get timing info

## Rationale

I'm not using `-time` because one needs a redirection hell, while this option can be enabled on any Coq project using Coq makefile by just exporting a shell variable.

It is complementary, and maybe should be "merged" with the timing targets @JasonGross implemented (these are per file, not per line).

The use case is to get better insight in changes as #6648 (I've just scheduled a job filling in https://ci.inria.fr/coq/job/benchmark-2-commits/ws/4/html/ where the commit in question is rebased on top of this PR).

## Status

- [ ] Corresponding documentation was added / updated.
- [ ] Entry added in CHANGES.
