### PR TITLE
Extrude monomorphic universe contexts from with Definition constraints.

### DIFF
--- a/checker/cic.mli
+++ b/checker/cic.mli
@@ -358,9 +358,7 @@ type ('ty,'a) functorize =
     and won't play any role into the kernel after that : they are kept
     only for short module printing and for extraction. *)
 
-type with_declaration =
-  | WithMod of Id.t list * ModPath.t
-  | WithDef of Id.t list * (constr * Univ.universe_context)
+type with_declaration
 
 type module_alg_expr =
   | MEident of ModPath.t

--- a/checker/declarations.ml
+++ b/checker/declarations.ml
@@ -573,14 +573,10 @@ let implem_map fs fa = function
   | Algebraic a -> Algebraic (fa a)
   | impl -> impl
 
-let subst_with_body sub = function
-  | WithMod(id,mp) -> WithMod(id,subst_mp sub mp)
-  | WithDef(id,(c,ctx)) -> WithDef(id,(subst_mps sub c,ctx))
-
 let rec subst_expr sub = function
   | MEident mp -> MEident (subst_mp sub mp)
   | MEapply (me1,mp2)-> MEapply (subst_expr sub me1, subst_mp sub mp2)
-  | MEwith (me,wd)-> MEwith (subst_expr sub me, subst_with_body sub wd)
+  | MEwith (me,wd)-> MEwith (subst_expr sub me, wd)
 
 let rec subst_expression sub me =
   functor_map (subst_module_type sub) (subst_expr sub) me

--- a/checker/values.ml
+++ b/checker/values.ml
@@ -13,7 +13,7 @@
 To ensure this file is up-to-date, 'make' now compares the md5 of cic.mli
 with a copy we maintain here:
 
-MD5 483493b20fe91cc1bea4350a2db2f82d checker/cic.mli
+MD5 79ed7b5c069b1994bf1a8d2cec22bdce checker/cic.mli
 
 *)
 
@@ -295,16 +295,11 @@ let v_ind_pack = v_tuple "mutual_inductive_body"
     Opt v_bool;
     v_typing_flags|]
 
-let v_with =
-  Sum ("with_declaration_body",0,
-       [|[|List v_id;v_mp|];
-         [|List v_id;v_tuple "with_def" [|v_constr;v_context|]|]|])
-
 let rec v_mae =
   Sum ("module_alg_expr",0,
   [|[|v_mp|];         (* SEBident *)
     [|v_mae;v_mp|];   (* SEBapply *)
-    [|v_mae;v_with|]  (* SEBwith *)
+    [|v_mae; Any|]  (* SEBwith *)
   |])
 
 let rec v_sfb =

--- a/interp/modintern.mli
+++ b/interp/modintern.mli
@@ -28,4 +28,4 @@ exception ModuleInternalizationError of module_internalization_error
    isn't ModAny. *)
 
 val interp_module_ast :
-  env -> module_kind -> module_ast -> module_struct_entry * module_kind
+  env -> module_kind -> module_ast -> module_struct_entry * module_kind * Univ.ContextSet.t

--- a/kernel/declarations.ml
+++ b/kernel/declarations.ml
@@ -219,7 +219,7 @@ type ('ty,'a) functorize =
 
 type with_declaration =
   | WithMod of Id.t list * ModPath.t
-  | WithDef of Id.t list * constr Univ.in_universe_context
+  | WithDef of Id.t list * (constr * Univ.AUContext.t option)
 
 type module_alg_expr =
   | MEident of ModPath.t

--- a/library/declaremods.mli
+++ b/library/declaremods.mli
@@ -13,7 +13,7 @@ open Vernacexpr
 
 type 'modast module_interpretor =
   Environ.env -> Misctypes.module_kind -> 'modast ->
-    Entries.module_struct_entry * Misctypes.module_kind
+    Entries.module_struct_entry * Misctypes.module_kind * Univ.ContextSet.t
 
 type 'modast module_params =
   (Id.t Loc.located list * ('modast * inline)) list

--- a/test-suite/modules/SeveralWith.v
+++ b/test-suite/modules/SeveralWith.v
@@ -1,0 +1,12 @@
+Module Type S.
+Parameter A : Type.
+End S.
+
+Module Type ES.
+Parameter A : Type.
+Parameter eq : A -> A -> Type.
+End ES.
+
+Module Make
+  (AX : S)
+  (X : ES with Definition A := AX.A with Definition eq := @eq AX.A).


### PR DESCRIPTION
We defer the computation of the universe quantification to the upper layer,
outside of the kernel.

First step towards getting rid of the nasty universe inference requirement in module subtyping!