### PR TITLE
[toplevel] [vernac] Remove Load hack and check / document supported scenarios.

### DIFF
--- a/doc/refman/RefMan-oth.tex
+++ b/doc/refman/RefMan-oth.tex
@@ -513,6 +513,9 @@ This command loads the file named {\ident}{\tt .v}, searching
 successively in each of the directories specified in the {\em
   loadpath}. (see Section~\ref{loadpath})
 
+Files loaded this way cannot leave proofs open, and neither the {\tt
+  Load} command can be use inside a proof.
+
 \begin{Variants}
 \item {\tt Load {\str}.}\label{Load-str}\\
   Loads the file denoted by the string {\str}, where {\str} is any
@@ -530,6 +533,8 @@ successively in each of the directories specified in the {\em
 
 \begin{ErrMsgs}
 \item \errindex{Can't find file {\ident} on loadpath}
+\item \errindex{Load is not supported inside proofs}
+\item \errindex{Files processed by Load cannot leave open proofs}
 \end{ErrMsgs}
 
 \section[Compiled files]{Compiled files\label{compiled}\index{Compiled files}}

--- a/test-suite/output/Load.out
+++ b/test-suite/output/Load.out
@@ -1,0 +1,6 @@
+f = 2
+     : nat
+u = I
+     : True
+The command has indeed failed with message:
+Files processed by Load cannot leave open proofs.

--- a/test-suite/output/Load.v
+++ b/test-suite/output/Load.v
@@ -1,0 +1,7 @@
+Load "output/load/Load_noproof.v".
+Print f.
+
+Load "output/load/Load_proof.v".
+Print u.
+
+Fail Load "output/load/Load_openproof.v".

--- a/test-suite/output/load/Load_noproof.v
+++ b/test-suite/output/load/Load_noproof.v
@@ -1,0 +1,1 @@
+Definition f := 2.

--- a/test-suite/output/load/Load_openproof.v
+++ b/test-suite/output/load/Load_openproof.v
@@ -1,0 +1,1 @@
+Lemma k : True.

--- a/test-suite/output/load/Load_proof.v
+++ b/test-suite/output/load/Load_proof.v
@@ -1,0 +1,2 @@
+Lemma u : True.
+Proof. exact I. Qed.


### PR DESCRIPTION
Parsing in `VernacLoad` was broken for a while, but the situation has
improved by miscellaneous refactoring.

However, we still cannot support `Load` properly when proofs are
crossing file boundaries. So in this patch we do two things:

- We check for supported scenarios [no proofs open at `Load` entry/exit]

- Remove the hack in `toplevel` so the behavior of `Load` is
  consistent between `coqide`/`coqc`.

We close #5053 as its main bug was fixed by the main toplevel
refactoring and the remaining cases are documented now.