### PR TITLE
Tentative fix for #6520: camlcity.org unresponsive makes AppVeyor fail.

### DIFF
--- a/dev/build/windows/makecoq_mingw.sh
+++ b/dev/build/windows/makecoq_mingw.sh
@@ -848,7 +848,7 @@ function make_ocaml_libs {
 
 function make_findlib {
   make_ocaml
-  if build_prep http://download.camlcity.org/download findlib-1.5.6 tar.gz 1 ; then
+  if build_prep https://opam.ocaml.org/archives ocamlfind.1.5.6+opam tar.gz 1 ; then
     logn configure ./configure -bindir "$PREFIXOCAML\\bin" -sitelib "$PREFIXOCAML\\libocaml\\site-lib" -config "$PREFIXOCAML\\etc\\findlib.conf"
     # Note: findlib doesn't support -j 8, so don't pass MAKE_OPT
     log2 make all


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** infrastructure fix


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #6520 

Let's hope that this works! BTW, I don't like the many unsafe HTTP downloads that this script contains. Especially, given that we subsequently sign and distribute the resulting packages.
