### PR TITLE
coq_makefile: Support "" as the prefix in _CoqProject

### DIFF
--- a/test-suite/coq-makefile/emptyprefix/_CoqProject
+++ b/test-suite/coq-makefile/emptyprefix/_CoqProject
@@ -1,0 +1,11 @@
+-R theories ""
+-R src ""
+-I src
+-arg "-w default"
+
+src/test_plugin.mlpack
+src/test.ml4
+src/test.mli
+src/test_aux.ml
+src/test_aux.mli
+theories/test.v

--- a/test-suite/coq-makefile/emptyprefix/_CoqProject.sub
+++ b/test-suite/coq-makefile/emptyprefix/_CoqProject.sub
@@ -1,0 +1,3 @@
+-R ../theories ""
+-I ../src
+testsub.v

--- a/test-suite/coq-makefile/emptyprefix/run.sh
+++ b/test-suite/coq-makefile/emptyprefix/run.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -e
+
+. ../template/init.sh
+
+mv theories/sub theories2
+
+coq_makefile -f _CoqProject -o Makefile
+cat Makefile.conf
+make
+
+cp ../_CoqProject.sub theories2/_CoqProject
+cd theories2
+coq_makefile -f _CoqProject -o Makefile
+cat Makefile.conf
+make

--- a/tools/coq_makefile.ml
+++ b/tools/coq_makefile.ml
@@ -124,7 +124,7 @@ let read_whole_file s =
     close_in ic;
     Buffer.contents b
 
-let quote s = if String.contains s ' ' then "'" ^ s ^ "'" else s
+let quote s = if String.contains s ' ' || CString.is_empty s then "'" ^ s ^ "'" else s
 
 let generate_makefile oc conf_file local_file args project =
   let makefile_template =


### PR DESCRIPTION
This fixes #6350 (and even comes with a test case).

Refering to other directories as `-R … ""` is maybe not best practice,
but some people out there do it, so as long as it does not cause too
much trouble, we can continue to support it.