### PR TITLE
Add notation {x & P} for sigT

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -223,6 +223,7 @@ Standard Library
   lemmas such as INR_IZR_INZ should be used instead.
 - Real constants are now represented using IZR rather than R0 and R1;
   this might cause rewriting rules to fail to apply to constants.
+- Added new notation {x & P} for sigT (without a type for x)
 
 Plugins
 

--- a/theories/Init/Notations.v
+++ b/theories/Init/Notations.v
@@ -75,6 +75,7 @@ Reserved Notation "{ x  |  P  & Q }" (at level 0, x at level 99).
 Reserved Notation "{ x : A  |  P }" (at level 0, x at level 99).
 Reserved Notation "{ x : A  |  P  & Q }" (at level 0, x at level 99).
 
+Reserved Notation "{ x  &  P }" (at level 0, x at level 99).
 Reserved Notation "{ x : A  & P }" (at level 0, x at level 99).
 Reserved Notation "{ x : A  & P  & Q }" (at level 0, x at level 99).
 

--- a/theories/Init/Specif.v
+++ b/theories/Init/Specif.v
@@ -49,6 +49,7 @@ Notation "{ x  |  P  & Q }" := (sig2 (fun x => P) (fun x => Q)) : type_scope.
 Notation "{ x : A  |  P }" := (sig (A:=A) (fun x => P)) : type_scope.
 Notation "{ x : A  |  P  & Q }" := (sig2 (A:=A) (fun x => P) (fun x => Q)) :
   type_scope.
+Notation "{ x  &  P }" := (sigT (fun x => P)) : type_scope.
 Notation "{ x : A  & P }" := (sigT (A:=A) (fun x => P)) : type_scope.
 Notation "{ x : A  & P  & Q }" := (sigT2 (A:=A) (fun x => P) (fun x => Q)) :
   type_scope.


### PR DESCRIPTION
<!-- Keep what applies -->
**Kind:** feature


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes #6709


<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [ ] Corresponding documentation was added / updated.
- [x] Entry added in CHANGES.

----

Analogous to existing `{x | P}` notation for `sig`, where the type of
`x` is inferred instead of specified.