### PR TITLE
Fix bug #6529: nf_evar_info to nf the evars' env not just the concl

### DIFF
--- a/test-suite/bugs/closed/6529.v
+++ b/test-suite/bugs/closed/6529.v
@@ -1,0 +1,16 @@
+Require Import Vector Program.
+
+Program Definition append_nil_def :=
+  forall A n (ls: t A n), append ls (nil A) = ls. (* Works *)
+
+Lemma append_nil : append_nil_def. (* Works *)
+Proof.
+Admitted.
+
+Program Lemma append_nil' :
+  forall A n (ls: t A n), append ls (nil A) = ls.
+Abort.
+
+Fail Program Lemma append_nil'' :
+  forall A B n (ls: t A n), append ls (nil A) = ls.
+(* Error: Anomaly "Evar ?X25 was not declared." Please report at http://coq.inria.fr/bugs/. *)

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -443,11 +443,13 @@ let start_proof_and_print k l hook =
       let hook env sigma ev =
         let tac = !Obligations.default_tactic in
         let evi = Evd.find sigma ev in
+        let evi = Evarutil.nf_evar_info sigma evi in
         let env = Evd.evar_filtered_env evi in
         try
-          let concl = Evarutil.nf_evars_universes sigma evi.Evd.evar_concl in
-          let concl = EConstr.of_constr concl in
-          if Evarutil.has_undefined_evars sigma concl then raise Exit;
+          let concl = EConstr.of_constr evi.Evd.evar_concl in
+          if not (Evarutil.is_ground_env sigma env &&
+                  Evarutil.is_ground_term sigma concl)
+          then raise Exit;
           let c, _, ctx =
             Pfedit.build_by_tactic env (Evd.evar_universe_context sigma)
                                    concl (Tacticals.New.tclCOMPLETE tac)


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

In the program inference hook, we didn't normalize the environment of an evar and 
didn't check that environment was evar-free before launching the tactic, resulting in
undeclared evar anomalies. Properly normalize and check now. Fixes #6529.
Backportable if time allows.

<!-- Keep what applies -->
**Kind:**  bug fix 