### PR TITLE
Fixing an anomaly in the presence of "let-in" in the type of a record.

### DIFF
--- a/test-suite/success/Inductive.v
+++ b/test-suite/success/Inductive.v
@@ -200,3 +200,9 @@ Module NonRecLetIn.
     (fun n b c => f_equal (Rec n) eq_refl) 0 (Rec 0 (Base 1)).
 
 End NonRecLetIn.
+
+(* Test treatment of let-in in the definition of Records *)
+(* Should fail with "Sort expected" *)
+
+Fail Inductive foo (T : Type) : let T := Type in T :=
+  { r : forall x : T, x = x }.

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -121,7 +121,7 @@ let typecheck_params_and_fields finite def id poly pl t ps nots fs =
          match t with
          | { CAst.v = CSort (Misctypes.GType []) } -> true | _ -> false in
        let sigma, s = interp_type_evars env sigma ~impls:empty_internalization_env t in
-       let sred = Reductionops.whd_all env sigma s in
+       let sred = Reductionops.whd_allnolet env sigma s in
          (match EConstr.kind sigma sred with
 	 | Sort s' ->
             let s' = EConstr.ESorts.kind sigma s' in


### PR DESCRIPTION
Fixes a bug reported on gitter by @JasonGross.

The following was failing with an anomaly "Not enough arguments.".
```coq
Inductive foo (T : Type) : let T' := Type in T' := { r : forall x : T, x = x }.
```
We fix it by expecting the type annotation to reduce to a sort but having preserved let-ins in the reduction, since the let-ins contribute to forming the arity of a record/inductive, i.e. contribute to the context of indices of the type.

Alternative fixes could be:
- to early expand the `let` and tell that the type of the record is the type after unfolding of the `let` (e.g. `Print foo` would report `Inductive foo (T : Type) : Prop := { r : forall x : T, x = x }` with the `let` pre-expanded);
- or to keep the let in the arity but to add the `let` in the type of the projections (e.g. `r := fun (T : Type) (T' := Type) (f : foo T) => match f with Build_foo _ r => r end`).
