### PR TITLE
Remove from CircleCI builds that are already taken care of by Travis.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,7 @@
+# This file used to contain configuration to also build documentation and CoqIDE,
+# run the test-suite and the validate targets,
+# including with 32-bits architecture or bleeding-edge compiler.
+
 defaults:
   params: &params
     # Following parameters are used in Coq CircleCI Job (using yaml
@@ -16,19 +20,7 @@ defaults:
     NATIVE_COMP: "yes"
 
     # some useful values
-    COMPILER_32BIT: &compiler-32bit "4.02.3+32bit"
-
-    COMPILER_BLEEDING_EDGE: &compiler-be "4.06.0"
-    CAMLP5_VER_BLEEDING_EDGE: &camlp5-ver-be "7.03"
-
     TIMING_PACKAGES: &timing-packages "time python"
-
-    COQIDE_PACKAGES: &coqide-packages "libgtk2.0-dev libgtksourceview2.0-dev"
-    #COQIDE_PACKAGES_32BIT: "libgtk2.0-dev:i386 libgtksourceview2.0-dev:i386"
-    COQIDE_OPAM: &coqide-opam "lablgtk-extras"
-    COQIDE_OPAM_BE: &coqide-opam-be "num lablgtk.2.18.6 lablgtk-extras.1.6"
-    COQDOC_PACKAGES: &coqdoc-packages "texlive-latex-base texlive-latex-recommended texlive-latex-extra texlive-math-extra texlive-fonts-recommended texlive-fonts-extra latex-xcolor ghostscript transfig imagemagick tipa"
-    COQDOC_OPAM: &coqdoc-opam "hevea"
 
 version: 2
 
@@ -38,7 +30,6 @@ before_script: &before_script
     echo export TERM=xterm >> ~/.profile
     source ~/.profile
     printenv
-    #if [ "$COMPILER" = "$COMPILER_32BIT" ]; then sudo dpkg --add-architecture i386; fi
     if [ -n "${EXTRA_PACKAGES}" ]; then sudo apt-get update -yq && sudo apt-get install -yq --no-install-recommends ${EXTRA_PACKAGES}; fi
 
 opam-switch: &opam-switch
@@ -76,7 +67,7 @@ opam-switch: &opam-switch
         command: |
           source ~/.profile
           opam switch -j ${NJOBS} ${COMPILER}
-          opam install -j ${NJOBS} -y camlp5.${CAMLP5_VER} ocamlfind ${COQIDE_OPAM} ${COQDOC_OPAM} ${EXTRA_OPAM}
+          opam install -j ${NJOBS} -y camlp5.${CAMLP5_VER} ocamlfind ${EXTRA_OPAM}
     - run:
         name: Clean cache
         command: |
@@ -104,7 +95,7 @@ opam-switch: &opam-switch
         command: |
           source ~/.profile
 
-          ./configure -local -native-compiler ${NATIVE_COMP} ${EXTRA_CONF}
+          ./configure -local -native-compiler ${NATIVE_COMP} -coqide no
     - run: &build-build
         name: Build
         command: |
@@ -117,52 +108,7 @@ opam-switch: &opam-switch
         paths:
           - coq/
 
-  environment: &build-variables
-    <<: *envvars
-    EXTRA_CONF: "-coqide opt"
-    EXTRA_PACKAGES: *coqide-packages
-
-.validate-template: &validate-template
-  <<: *params
-  steps:
-    - run: *before_script
-    - attach_workspace: *attach_workspace
-    - run:
-        name: Validate
-        command: |
-          source ~/.profile
-          make validate
   environment: *envvars
-
-.documentation-template: &documentation-template
-  <<: *params
-  steps:
-    - run: *before_script
-    - attach_workspace: *attach_workspace
-    - run:
-        name: Documentation
-        command: |
-          source ~/.profile
-          make -j ${NJOBS} doc
-  environment: &documentation-variables
-    <<: *envvars
-    EXTRA_PACKAGES: *coqdoc-packages
-
-.test-suite-template: &test-suite-template
-  <<: *params
-  steps:
-    - run: *before_script
-    - attach_workspace: *attach_workspace
-    - run:
-        name: Test
-        command: |
-          source ~/.profile
-          cd test-suite
-          make clean
-          make -j ${NJOBS} all
-  environment: &test-suite-variables
-    <<: *envvars
-    EXTRA_PACKAGES: *timing-packages
 
 .ci-template: &ci-template
   <<: *params
@@ -184,83 +130,15 @@ opam-switch: &opam-switch
 
 # Defines individual jobs, see the workflows section below for job orchestration
 jobs:
-  # TODO: linter
 
   opam-boot:
     <<: *opam-boot-template
     environment:
       <<: *envvars
-      EXTRA_PACKAGES: *coqide-packages
       EXTRA_OPAM: "ocamlgraph ppx_tools_versioned ppx_deriving ocaml-migrate-parsetree"
-
-  opam-boot-32bit:
-    <<: *opam-boot-template
-    environment:
-      <<: *envvars
-      EXTRA_PACKAGES: "gcc-multilib"
-      COMPILER: *compiler-32bit
-      COQIDE_OPAM: ""
-      COQDOC_OPAM: ""
-
-  opam-boot-be:
-    <<: *opam-boot-template
-    environment:
-      <<: *envvars
-      EXTRA_PACKAGES: *coqide-packages
-      COMPILER: *compiler-be
-      CAMLP5_VER: *camlp5-ver-be
-      COQIDE_OPAM: *coqide-opam-be
 
   # Build and prepare test environment
   build: *build-template
-
-  build-32bit:
-    <<: *build-template
-    environment:
-      <<: *envvars # no coqide for 32bit
-      EXTRA_PACKAGES: "gcc-multilib"
-      COMPILER: *compiler-32bit
-
-  build-be:
-    <<: *build-template
-    environment:
-      <<: *build-variables
-      COMPILER: *compiler-be
-
-  validate: *validate-template
-
-  validate-32bit:
-    <<: *validate-template
-    environment:
-      <<: *envvars
-      COMPILER: *compiler-32bit
-      EXTRA_PACKAGES: "gcc-multilib"
-
-  documentation: *documentation-template
-
-  documentation-be:
-    <<: *documentation-template
-    environment:
-      <<: *documentation-variables
-      COMPILER: *compiler-be
-      CAMLP5_VER: *camlp5-ver-be
-
-  test-suite:
-    <<: *test-suite-template
-
-  test-suite-32bit:
-    <<: *test-suite-template
-    environment:
-      <<: *test-suite-variables
-      COMPILER: *compiler-32bit
-      EXTRA_PACKAGES: "gcc-multilib time python"
-
-  test-suite-be:
-    <<: *test-suite-template
-    environment:
-      <<: *test-suite-variables
-      COMPILER: *compiler-be
-      EXTRA_PACKAGES: *timing-packages
 
   bignums:
     <<: *ci-template
@@ -352,19 +230,14 @@ workflows:
   main:
     jobs:
       - opam-boot
-      - opam-boot-32bit
-      - opam-boot-be
 
       - build:
           requires:
             - opam-boot
-      - validate: &req-main
+
+      - bignums: &req-main
           requires:
             - build
-      - test-suite: *req-main
-      - documentation: *req-main
-
-      - bignums: *req-main
       - color:
           requires:
             - build
@@ -397,19 +270,3 @@ workflows:
       - sf: *req-main
       - unimath: *req-main
       - vst: *req-main
-
-      - build-32bit:
-          requires:
-            - opam-boot-32bit
-      - validate-32bit: &req-32bit
-          requires:
-            - build-32bit
-      - test-suite-32bit: *req-32bit
-
-      - build-be:
-          requires:
-            - opam-boot-be
-      - test-suite-be: &req-be
-          requires:
-            - build-be
-      - documentation-be: *req-be


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** infrastructure.

Should save some build time now that CircleCI is overloaded.