### PR TITLE
[toplevel] Make toplevel state into a record.

### DIFF
--- a/dev/base_include
+++ b/dev/base_include
@@ -230,7 +230,7 @@ let _ = Flags.in_toplevel := true
 let _ = Constrextern.set_extern_reference
   (fun ?loc _ r -> Libnames.Qualid (loc,Nametab.shortest_qualid_of_global Id.Set.empty r));;
 
-let go () = Coqloop.loop Option.(get !Coqtop.drop_last_doc)
+let go () = Coqloop.loop ~time:false ~state:Option.(get !Coqtop.drop_last_doc)
 
 let _ =
  print_string

--- a/ide/coq.ml
+++ b/ide/coq.ml
@@ -9,6 +9,8 @@
 open Ideutils
 open Preferences
 
+let ideslave_coqtop_flags = ref None
+
 (** * Version and date *)
 
 let get_version_date () =
@@ -375,7 +377,7 @@ let spawn_handle args respawner feedback_processor =
   in
   let args = Array.of_list ("--xml_format=Ppcmds" :: "-async-proofs" :: async_default :: "-ideslave" :: args) in
   let env =
-    match !Flags.ideslave_coqtop_flags with
+    match !ideslave_coqtop_flags with
     | None -> None
     | Some s ->
       let open Str in

--- a/ide/coq.mli
+++ b/ide/coq.mli
@@ -171,3 +171,6 @@ val check_connection : string list -> unit
 
 val interrupter : (int -> unit) ref
 val save_all : (unit -> unit) ref
+
+(* Flags to be used for ideslave *)
+val ideslave_coqtop_flags : string option ref

--- a/ide/coqide.ml
+++ b/ide/coqide.ml
@@ -1360,7 +1360,7 @@ let read_coqide_args argv =
       Backtrace.record_backtrace true;
       filter_coqtop coqtop project_files ("-debug"::out) args
     |"-coqtop-flags" :: flags :: args->
-      Flags.ideslave_coqtop_flags := Some flags;
+      Coq.ideslave_coqtop_flags := Some flags;
       filter_coqtop coqtop project_files out args
     |arg::args when out = [] && Minilib.is_prefix_of "-psn_" arg ->
       (* argument added by MacOS during .app launch *)

--- a/ide/ide_slave.ml
+++ b/ide/ide_slave.ml
@@ -458,8 +458,9 @@ let msg_format = ref (fun () ->
 
 (* The loop ignores the command line arguments as the current model delegates
    its handing to the toplevel container. *)
-let loop _args doc =
-  set_doc doc;
+let loop _args ~state =
+  let open Vernac.State in
+  set_doc state.doc;
   init_signal_handler ();
   catch_break := false;
   let in_ch, out_ch = Spawned.get_channels ()                        in

--- a/lib/flags.ml
+++ b/lib/flags.ml
@@ -56,10 +56,8 @@ let in_toplevel = ref false
 let profile = false
 
 let ide_slave = ref false
-let ideslave_coqtop_flags = ref None
 
 let raw_print = ref false
-
 let univ_print = ref false
 
 let we_are_parsing = ref false

--- a/lib/flags.mli
+++ b/lib/flags.mli
@@ -33,7 +33,6 @@ val profile : bool
 
 (* -ide_slave: printing will be more verbose, will affect stm caching *)
 val ide_slave : bool ref
-val ideslave_coqtop_flags : string option ref
 
 (* development flag to detect race conditions, it should go away. *)
 val we_are_parsing : bool ref

--- a/proofs/proof_global.ml
+++ b/proofs/proof_global.ml
@@ -146,6 +146,7 @@ let cur_pstate () =
   | [] -> raise NoCurrentProof
 
 let give_me_the_proof () = (cur_pstate ()).proof
+let give_me_the_proof_opt () = try Some (give_me_the_proof ()) with | NoCurrentProof -> None
 let get_current_proof_name () = (cur_pstate ()).pid
 
 let with_current_proof f =

--- a/proofs/proof_global.mli
+++ b/proofs/proof_global.mli
@@ -24,6 +24,7 @@ val discard : Names.Id.t Loc.located -> unit
 val discard_current : unit -> unit
 val discard_all : unit -> unit
 
+val give_me_the_proof_opt : unit -> Proof.t option
 exception NoCurrentProof
 val give_me_the_proof : unit -> Proof.t
 (** @raise NoCurrentProof when outside proof mode. *)

--- a/stm/proofworkertop.ml
+++ b/stm/proofworkertop.ml
@@ -10,5 +10,5 @@ module W = AsyncTaskQueue.MakeWorker(Stm.ProofTask) ()
 
 let () = Coqtop.toploop_init := WorkerLoop.loop W.init_stdout
 
-let () = Coqtop.toploop_run := (fun _ _ -> W.main_loop ())
+let () = Coqtop.toploop_run := (fun _ ~state:_ -> W.main_loop ())
 

--- a/stm/queryworkertop.ml
+++ b/stm/queryworkertop.ml
@@ -10,5 +10,5 @@ module W = AsyncTaskQueue.MakeWorker(Stm.QueryTask) ()
 
 let () = Coqtop.toploop_init := WorkerLoop.loop W.init_stdout
 
-let () = Coqtop.toploop_run := (fun _ _ -> W.main_loop ())
+let () = Coqtop.toploop_run := (fun _ ~state:_ -> W.main_loop ())
 

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -2106,8 +2106,7 @@ and Reach : sig
 end = struct (* {{{ *)
 
 let async_policy () =
-  let open Flags in
-  if is_universe_polymorphism () then false
+  if Flags.is_universe_polymorphism () then false
   else if VCS.is_interactive () = `Yes then
     (async_proofs_is_master !cur_opt || !cur_opt.async_proofs_mode = APonLazy)
   else

--- a/stm/tacworkertop.ml
+++ b/stm/tacworkertop.ml
@@ -10,5 +10,5 @@ module W = AsyncTaskQueue.MakeWorker(Stm.TacTask) ()
 
 let () = Coqtop.toploop_init := WorkerLoop.loop W.init_stdout
 
-let () = Coqtop.toploop_run := (fun _ _ -> W.main_loop ())
+let () = Coqtop.toploop_run := (fun _ ~state:_ -> W.main_loop ())
 

--- a/toplevel/coqinit.ml
+++ b/toplevel/coqinit.ml
@@ -21,12 +21,12 @@ let set_debug () =
 
 let rcdefaultname = "coqrc"
 
-let load_rcfile ~rcfile ~time doc sid =
+let load_rcfile ~rcfile ~time ~state =
     try
       match rcfile with
       | Some rcfile ->
         if CUnix.file_readable_p rcfile then
-          Vernac.load_vernac ~time ~verbosely:false ~interactive:false ~check:true doc sid rcfile
+          Vernac.load_vernac ~time ~verbosely:false ~interactive:false ~check:true ~state rcfile
         else raise (Sys_error ("Cannot read rcfile: "^ rcfile))
       | None ->
 	try
@@ -37,8 +37,8 @@ let load_rcfile ~rcfile ~time doc sid =
 	    Envars.home ~warn / "."^rcdefaultname^"."^Coq_config.version;
 	    Envars.home ~warn / "."^rcdefaultname
 	  ] in
-          Vernac.load_vernac ~time ~verbosely:false ~interactive:false ~check:true doc sid inferedrc
-	with Not_found -> doc, sid
+          Vernac.load_vernac ~time ~verbosely:false ~interactive:false ~check:true ~state inferedrc
+        with Not_found -> state
 	(*
 	Flags.if_verbose
 	  mSGNL (str ("No coqrc or coqrc."^Coq_config.version^

--- a/toplevel/coqinit.mli
+++ b/toplevel/coqinit.mli
@@ -10,7 +10,7 @@
 
 val set_debug : unit -> unit
 
-val load_rcfile : rcfile:(string option) -> time:bool -> Stm.doc -> Stateid.t -> Stm.doc * Stateid.t
+val load_rcfile : rcfile:(string option) -> time:bool -> state:Vernac.State.t -> Vernac.State.t
 
 val init_ocaml_path : unit -> unit
 

--- a/toplevel/coqloop.mli
+++ b/toplevel/coqloop.mli
@@ -31,9 +31,7 @@ val set_prompt : (unit -> string) -> unit
 val coqloop_feed : Feedback.feedback -> unit
 
 (** Parse and execute one vernac command. *)
-
-val do_vernac : time:bool -> Stm.doc -> Stateid.t -> Stm.doc * Stateid.t
+val do_vernac : time:bool -> state:Vernac.State.t -> Vernac.State.t
 
 (** Main entry point of Coq: read and execute vernac commands. *)
-
-val loop : time:bool -> Stm.doc -> Stm.doc
+val loop : time:bool -> state:Vernac.State.t -> Vernac.State.t

--- a/toplevel/coqtop.mli
+++ b/toplevel/coqtop.mli
@@ -11,14 +11,13 @@
    state, load the files given on the command line, load the resource file,
    produce the output state if any, and finally will launch [Coqloop.loop]. *)
 
-val init_toplevel : string list -> (Stm.doc * Stateid.t) option * Coqargs.coq_cmdopts
+val init_toplevel : string list -> Vernac.State.t option * Coqargs.coq_cmdopts
 
 val start : unit -> unit
 
 (* Last document seen after `Drop` *)
-val drop_last_doc : Stm.doc option ref
+val drop_last_doc : Vernac.State.t option ref
 
 (* For other toploops *)
 val toploop_init : (Coqargs.coq_cmdopts -> string list -> string list) ref
-val toploop_run : (Coqargs.coq_cmdopts -> Stm.doc -> unit) ref
-
+val toploop_run : (Coqargs.coq_cmdopts -> state:Vernac.State.t -> unit) ref

--- a/toplevel/vernac.mli
+++ b/toplevel/vernac.mli
@@ -7,14 +7,24 @@
 (************************************************************************)
 
 (** Parsing of vernacular. *)
+module State : sig
+
+  type t = {
+    doc : Stm.doc;
+    sid : Stateid.t;
+    proof : Proof.t option;
+  }
+
+end
 
 (** [process_expr sid cmd] Executes vernac command [cmd]. Callers are
     expected to handle and print errors in form of exceptions, however
     care is taken so the state machine is left in a consistent
     state. *)
-val process_expr : time:bool -> Stm.doc -> Stateid.t -> Vernacexpr.vernac_control Loc.located -> Stm.doc * Stateid.t
+val process_expr : time:bool -> state:State.t -> Vernacexpr.vernac_control Loc.located -> State.t
 
 (** [load_vernac echo sid file] Loads [file] on top of [sid], will
     echo the commands if [echo] is set. Callers are expected to handle
     and print errors in form of exceptions. *)
-val load_vernac : time:bool -> verbosely:bool -> check:bool -> interactive:bool -> Stm.doc -> Stateid.t -> string -> Stm.doc * Stateid.t
+val load_vernac : time:bool -> verbosely:bool -> check:bool -> interactive:bool ->
+  state:State.t -> string -> State.t


### PR DESCRIPTION
We organize the toplevel execution as a record and pass it
around. This will be used by future PRs as to for example decouple
goal printing from the classifier.
