### PR TITLE
Better elaboration of pattern-matchings on primitive projections

### DIFF
--- a/pretyping/cases.ml
+++ b/pretyping/cases.ml
@@ -1425,7 +1425,7 @@ and match_current pb (initial,tomatch) =
 	  let ci = make_case_info pb.env (fst mind) pb.casestyle in
           let pred = nf_betaiota pb.env !(pb.evdref) pred in
 	  let case =
-	    make_case_or_project pb.env !(pb.evdref) indf ci pred current brvals
+            make_case_or_project pb.env !(pb.evdref) indf ci pred current brvals
 	  in
           let _ = Evarutil.evd_comb1 (Typing.type_of pb.env) pb.evdref pred in
 	  Typing.check_allowed_sort pb.env !(pb.evdref) mind current pred;

--- a/test-suite/success/letproj.v
+++ b/test-suite/success/letproj.v
@@ -7,3 +7,5 @@ Definition test (A : Type) (f : Foo A) :=
 
 Scheme foo_case := Case for Foo Sort Type.
 
+Definition test' (A : Type) (f : Foo A) :=
+  let 'Build_Foo _ x y := f in x.

--- a/test-suite/success/primitiveproj.v
+++ b/test-suite/success/primitiveproj.v
@@ -199,3 +199,24 @@ split.
 reflexivity.
 Qed.
 *)
+
+(* Primitive projection match compilation *)
+Require Import List.
+Set Primitive Projections.
+
+Record prod (A B : Type) := pair { fst : A ; snd : B }.
+Arguments pair {_ _} _ _.
+
+Fixpoint split_at {A} (l : list A) (n : nat) : prod (list A) (list A) :=
+  match n with
+  | 0 => pair nil l
+  | S n =>
+    match l with
+    | nil => pair nil nil
+    | x :: l => let 'pair l1 l2 := split_at l n in pair (x :: l1) l2
+    end
+  end.
+
+Time Eval vm_compute in split_at (repeat 0 20) 10. (* Takes 0s *)
+Time Eval vm_compute in split_at (repeat 0 40) 20. (* Takes 0.001s *)
+Timeout 1 Time Eval vm_compute in split_at (repeat 0 60) 30. (* Used to take 60s, now takes 0.001s *)


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

Better representation of cases on primitive projections. Work in progress.
Now using let-ins consistently for the thing to destruct and each projection
to avoid blowups. Currently based on 8.7 for testing on current developments.

<!-- Keep what applies -->
**Kind:** feature / performance.

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #5701


<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [x] Corresponding documentation was added / updated.
- [x] Entry added in CHANGES.
