### PR TITLE
pretyping: restore API understand_judgment_tcc (now understand_tcc_ty)

### DIFF
--- a/pretyping/pretyping.mli
+++ b/pretyping/pretyping.mli
@@ -59,7 +59,7 @@ val understand_tcc : ?flags:inference_flags -> env -> evar_map ->
   ?expected_type:typing_constraint -> glob_constr -> evar_map * constr
 
 (** As [understand_tcc] but also returns the type of the elaborated term.
-    the [expand] evars flag is not applied to the type (only to the term). *)
+    The [expand_evars] flag is not applied to the type (only to the term). *)
 val understand_tcc_ty : ?flags:inference_flags -> env -> evar_map ->
   ?expected_type:typing_constraint -> glob_constr -> evar_map * constr * types
 

--- a/pretyping/pretyping.mli
+++ b/pretyping/pretyping.mli
@@ -58,6 +58,11 @@ val all_and_fail_flags : inference_flags
 val understand_tcc : ?flags:inference_flags -> env -> evar_map ->
   ?expected_type:typing_constraint -> glob_constr -> evar_map * constr
 
+(** As [understand_tcc] but also returns the type of the elaborated term.
+    the [expand] evars flag is not applied to the type (only to the term). *)
+val understand_tcc_ty : ?flags:inference_flags -> env -> evar_map ->
+  ?expected_type:typing_constraint -> glob_constr -> evar_map * constr * types
+
 (** More general entry point with evars from ltac *)
 
 (** Generic call to the interpreter from glob_constr to constr
@@ -116,7 +121,7 @@ val pretype_type :
 
 val ise_pretype_gen :
   inference_flags -> env -> evar_map ->
-  ltac_var_map -> typing_constraint -> glob_constr -> evar_map * constr
+  ltac_var_map -> typing_constraint -> glob_constr -> evar_map * constr * types
 
 (**/**)
 


### PR DESCRIPTION
removed in 533c4f693a, used in elpi