### PR TITLE
V8.6: backport of fix to vm critical bug #6677

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+Changes since 8.6.1
+===================
+
+- Fix #6677: Critical bug with VM and universes.
+
 Changes from 8.6 to 8.6.1
 =========================
 

--- a/kernel/cbytegen.ml
+++ b/kernel/cbytegen.ml
@@ -628,27 +628,17 @@ let rec compile_constr reloc c sz cont =
         of the structured constant, while the later (if any) will be applied as
         arguments. *)
      let open Univ in begin
-      let levels = Universe.levels u in
-      let global_levels =
-	LSet.filter (fun x -> Level.var_index x = None) levels
-      in
-      let local_levels =
-	List.map_filter (fun x -> Level.var_index x)
-	  (LSet.elements levels)
-      in
+      let u,s = Universe.compact u in
       (* We assume that [Universe.type0m] is a neutral element for [Universe.sup] *)
-      let uglob =
-	LSet.fold (fun lvl u -> Universe.sup u (Universe.make lvl)) global_levels Universe.type0m
-      in
-      if local_levels = [] then
-	compile_str_cst reloc (Bstrconst (Const_sorts (Type uglob))) sz cont
+      if List.is_empty s then
+        compile_str_cst reloc (Bstrconst (Const_sorts (Sorts.Type u))) sz cont
       else
 	let compile_get_univ reloc idx sz cont =
           set_max_stack_size sz;
 	  compile_fv_elem reloc (FVuniv_var idx) sz cont
 	in
         comp_app compile_str_cst compile_get_univ reloc
-	  (Bstrconst (Const_type u)) (Array.of_list local_levels) sz cont
+          (Bstrconst (Const_type u)) (Array.of_list s) sz cont
     end
   | LetIn(_,xb,_,body) ->
       compile_constr reloc xb sz

--- a/kernel/csymtable.ml
+++ b/kernel/csymtable.ml
@@ -68,7 +68,7 @@ let rec eq_structured_constant c1 c2 = match c1, c2 with
 | Const_bn _, _ -> false
 | Const_univ_level l1 , Const_univ_level l2 -> Univ.eq_levels l1 l2
 | Const_univ_level _ , _ -> false
-| Const_type u1 , Const_type u2 -> Univ.Universe.equal u1 u2
+| Const_type u1, Const_type u2 -> Univ.Universe.equal u1 u2
 | Const_type _ , _ -> false
 
 let rec hash_structured_constant c =

--- a/kernel/univ.mli
+++ b/kernel/univ.mli
@@ -121,6 +121,13 @@ sig
 
   val exists : (Level.t * int -> bool) -> t -> bool
   val for_all : (Level.t * int -> bool) -> t -> bool
+
+  val compact : t -> t * int list
+  (** [compact u] remaps local variables in [u] such that their indices become
+       consecutive. It returns the new universe and the mapping.
+       Example: compact [(Var 0, i); (Prop, 0); (Var 2; j))] =
+         [(Var 0,i); (Prop, 0); (Var 1; j)], [0; 2]
+  *)
 end
 
 type universe = Universe.t

--- a/kernel/vm.ml
+++ b/kernel/vm.ml
@@ -9,6 +9,7 @@
 open Names
 open Term
 open Cbytecodes
+open Univ
 
 external set_drawinstr : unit -> unit = "coq_set_drawinstr"
 
@@ -247,11 +248,11 @@ let rec whd_accu a stk =
   | i when Int.equal i type_atom_tag ->
      begin match stk with
      | [Zapp args] ->
-	let u = ref (Obj.obj (Obj.field at 0)) in
-	for i = 0 to nargs args - 1 do
-	  u := Univ.Universe.sup !u (Univ.Universe.make (uni_lvl_val (arg args i)))
-	done;
-	Vsort (Type !u)
+        let args = Array.init (nargs args) (arg args) in
+        let u = Obj.obj (Obj.field at 0) in
+        let inst = Instance.of_array (Array.map uni_lvl_val args) in
+        let u = Univ.subst_instance_universe inst u in
+        Vsort (Type u)
      | _ -> assert false
      end
   | i when i <= max_atom_tag ->

--- a/test-suite/bugs/closed/6677.v
+++ b/test-suite/bugs/closed/6677.v
@@ -1,0 +1,5 @@
+Set Universe Polymorphism.
+
+Definition T@{i} := Type@{i}.
+Fail Definition U@{i} := (T@{i} <: Type@{i}).
+Fail Definition eqU@{i j} : @eq T@{j} U@{i} T@{i} := eq_refl.


### PR DESCRIPTION
This is a backport of #6713 to 8.6 (via 8.5). I had to re-use `Huniv`.

**Kind:** bug fix

Fixes / closes #6677 for v8.6.

- [X] Entry added in CHANGES.
