### PR TITLE
Split closure cache and remove whd_both

### DIFF
--- a/kernel/cClosure.mli
+++ b/kernel/cClosure.mli
@@ -98,13 +98,15 @@ val unfold_red : evaluable_global_reference -> reds
 type table_key = Constant.t Univ.puniverses tableKey
 
 type 'a infos_cache
+type 'a infos_tab
 type 'a infos = {
   i_flags : reds;
   i_cache : 'a infos_cache }
 
-val ref_value_cache: 'a infos -> table_key -> 'a option
-val create: ('a infos -> constr -> 'a) -> reds -> env ->
+val ref_value_cache: 'a infos -> 'a infos_tab -> table_key -> 'a option
+val create: ('a infos -> 'a infos_tab -> constr -> 'a) -> reds -> env ->
   (existential -> constr option) -> 'a infos
+val create_tab : unit -> 'a infos_tab
 val evar_value : 'a infos_cache -> existential -> constr option
 
 val info_env : 'a infos -> env
@@ -198,15 +200,15 @@ val infos_with_reds : clos_infos -> reds -> clos_infos
 (** Reduction function *)
 
 (** [norm_val] is for strong normalization *)
-val norm_val : clos_infos -> fconstr -> constr
+val norm_val : clos_infos -> fconstr infos_tab -> fconstr -> constr
 
 (** [whd_val] is for weak head normalization *)
-val whd_val : clos_infos -> fconstr -> constr
+val whd_val : clos_infos -> fconstr infos_tab -> fconstr -> constr
 
 (** [whd_stack] performs weak head normalization in a given stack. It
    stops whenever a reduction is blocked. *)
 val whd_stack :
-  clos_infos -> fconstr -> stack -> fconstr * stack
+  clos_infos -> fconstr infos_tab -> fconstr -> stack -> fconstr * stack
 
 (** [eta_expand_ind_stack env ind c s t] computes stacks correspoding
     to the conversion of the eta expansion of t, considered as an inhabitant
@@ -223,7 +225,7 @@ val eta_expand_ind_stack : env -> inductive -> fconstr -> stack ->
 (** Conversion auxiliary functions to do step by step normalisation *)
 
 (** [unfold_reference] unfolds references in a [fconstr] *)
-val unfold_reference : clos_infos -> table_key -> fconstr option
+val unfold_reference : clos_infos -> fconstr infos_tab -> table_key -> fconstr option
 
 val eq_table_key : table_key -> table_key -> bool
 
@@ -239,9 +241,9 @@ val mk_clos_deep :
   (fconstr subs -> constr -> fconstr) ->
    fconstr subs -> constr -> fconstr
 
-val kni: clos_infos -> fconstr -> stack -> fconstr * stack
-val knr: clos_infos -> fconstr -> stack -> fconstr * stack
-val kl : clos_infos -> fconstr -> constr
+val kni: clos_infos -> fconstr infos_tab -> fconstr -> stack -> fconstr * stack
+val knr: clos_infos -> fconstr infos_tab -> fconstr -> stack -> fconstr * stack
+val kl : clos_infos -> fconstr infos_tab -> fconstr -> constr
 
 val to_constr : (lift -> fconstr -> constr) -> lift -> fconstr -> constr
 

--- a/kernel/reduction.ml
+++ b/kernel/reduction.ml
@@ -313,47 +313,6 @@ let compare_stacks f fmind lft1 stk1 lft2 stk2 cuniv =
     cmp_rec (pure_stack lft1 stk1) (pure_stack lft2 stk2) cuniv
   else raise NotConvertible
 
-let rec no_arg_available = function
-  | [] -> true
-  | Zupdate _ :: stk -> no_arg_available stk
-  | Zshift _ :: stk -> no_arg_available stk
-  | Zapp v :: stk -> Int.equal (Array.length v) 0 && no_arg_available stk
-  | Zproj _ :: _ -> true
-  | ZcaseT _ :: _ -> true
-  | Zfix _ :: _ -> true
-
-let rec no_nth_arg_available n = function
-  | [] -> true
-  | Zupdate _ :: stk -> no_nth_arg_available n stk
-  | Zshift _ :: stk -> no_nth_arg_available n stk
-  | Zapp v :: stk ->
-      let k = Array.length v in
-      if n >= k then no_nth_arg_available (n-k) stk
-      else false
-  | Zproj _ :: _ -> true
-  | ZcaseT _ :: _ -> true
-  | Zfix _ :: _ -> true
-
-let rec no_case_available = function
-  | [] -> true
-  | Zupdate _ :: stk -> no_case_available stk
-  | Zshift _ :: stk -> no_case_available stk
-  | Zapp _ :: stk -> no_case_available stk
-  | Zproj (_,_,p) :: _ -> false
-  | ZcaseT _ :: _ -> false
-  | Zfix _ :: _ -> true
-
-let in_whnf (t,stk) =
-  match fterm_of t with
-    | (FLetIn _ | FCaseT _ | FApp _ 
-	  | FCLOS _ | FLIFT _ | FCast _) -> false
-    | FLambda _ -> no_arg_available stk
-    | FConstruct _ -> no_case_available stk
-    | FCoFix _ -> no_case_available stk
-    | FFix(((ri,n),(_,_,_)),_) -> no_nth_arg_available ri.(n) stk
-    | (FFlex _ | FProd _ | FEvar _ | FInd _ | FAtom _ | FRel _ | FProj _) -> true
-    | FLOCKED -> assert false
-
 type conv_tab = {
   cnv_inf : clos_infos;
   lft_tab : fconstr infos_tab;
@@ -361,6 +320,9 @@ type conv_tab = {
 }
 (** Invariant: for any tl ∈ lft_tab and tr ∈ rgt_tab, there is no mutable memory
     location contained both in tl and in tr. *)
+
+(** The same heap separation invariant must hold for the fconstr arguments
+    passed to each respective side of the conversion function below. *)
 
 (* Conversion between  [lft1]term1 and [lft2]term2 *)
 let rec ccnv cv_pb l2r infos lft1 lft2 term1 term2 cuniv =
@@ -371,14 +333,9 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
   Control.check_for_interrupt ();
   (* First head reduce both terms *)
   let ninfos = infos_with_reds infos.cnv_inf betaiotazeta in
-  let rec whd_both (t1,stk1) (t2,stk2) =
-    let st1' = whd_stack ninfos infos.lft_tab t1 stk1 in
-    let st2' = whd_stack ninfos infos.rgt_tab t2 stk2 in
-    (* Now, whd_stack on term2 might have modified st1 (due to sharing),
-       and st1 might not be in whnf anymore. If so, we iterate ccnv. *)
-    if in_whnf st1' then (st1',st2') else whd_both st1' st2' in
-  let ((hd1,v1),(hd2,v2)) = whd_both st1 st2 in
-  let appr1 = (lft1,(hd1,v1)) and appr2 = (lft2,(hd2,v2)) in
+  let (hd1, v1 as appr1) = whd_stack ninfos infos.lft_tab (fst st1) (snd st1) in
+  let (hd2, v2 as appr2) = whd_stack ninfos infos.rgt_tab (fst st2) (snd st2) in
+  let appr1 = (lft1, appr1) and appr2 = (lft2, appr2) in
   (** We delay the computation of the lifts that apply to the head of the term
       with [el_stack] inside the branches where they are actually used. *)
   match (fterm_of hd1, fterm_of hd2) with

--- a/plugins/setoid_ring/newring.ml
+++ b/plugins/setoid_ring/newring.ml
@@ -88,7 +88,7 @@ let lookup_map map =
 let protect_red map env sigma c0 =
   let evars ev = Evarutil.safe_evar_value sigma ev in
   let c = EConstr.Unsafe.to_constr c0 in
-  EConstr.of_constr (kl (create_clos_infos ~evars all env)
+  EConstr.of_constr (kl (create_clos_infos ~evars all env) (create_tab ())
     (mk_clos_but (lookup_map map sigma c0) (Esubst.subs_id 0) c));;
 
 let protect_tac map =

--- a/pretyping/cbv.ml
+++ b/pretyping/cbv.ml
@@ -132,7 +132,7 @@ let mkSTACK = function
   | STACK(0,v0,stk0), stk -> STACK(0,v0,stack_concat stk0 stk)
   | v,stk -> STACK(0,v,stk)
 
-type cbv_infos = { infos : cbv_value infos; sigma : Evd.evar_map }
+type cbv_infos = { tab : cbv_value infos_tab; infos : cbv_value infos; sigma : Evd.evar_map }
 
 (* Change: zeta reduction cannot be avoided in CBV *)
 
@@ -316,7 +316,7 @@ let rec norm_head info env t stack =
 
 and norm_head_ref k info env stack normt =
   if red_set_ref (info_flags info.infos) normt then
-    match ref_value_cache info.infos normt with
+    match ref_value_cache info.infos info.tab normt with
       | Some body ->
          if !debug_cbv then Feedback.msg_debug Pp.(str "Unfolding " ++ pr_key normt);
          strip_appl (shift_value k body) stack
@@ -453,8 +453,8 @@ let cbv_norm infos constr =
 (* constant bodies are normalized at the first expansion *)
 let create_cbv_infos flgs env sigma =
   let infos = create
-    (fun old_info c -> cbv_stack_term { infos = old_info; sigma } TOP (subs_id 0) c)
+    (fun old_info tab c -> cbv_stack_term { tab; infos = old_info; sigma } TOP (subs_id 0) c)
     flgs
     env
     (Reductionops.safe_evar_value sigma) in
-  { infos; sigma }
+  { tab = CClosure.create_tab (); infos; sigma }

--- a/pretyping/inferCumulativity.ml
+++ b/pretyping/inferCumulativity.ml
@@ -81,10 +81,12 @@ let infer_table_key infos variances c =
     infer_generic_instance_eq variances u
   | VarKey _ | RelKey _ -> variances
 
+let whd_stack (infos, tab) hd stk = CClosure.whd_stack infos tab hd stk
+
 let rec infer_fterm cv_pb infos variances hd stk =
   Control.check_for_interrupt ();
-  let open CClosure in
   let hd,stk = whd_stack infos hd stk in
+  let open CClosure in
   match fterm_of hd with
   | FAtom a ->
     begin match kind a with
@@ -114,7 +116,7 @@ let rec infer_fterm cv_pb infos variances hd stk =
       if Instance.is_empty u then variances
       else
         let nargs = stack_args_size stk in
-        infer_inductive_instance cv_pb (info_env infos) variances ind nargs u
+        infer_inductive_instance cv_pb (info_env (fst infos)) variances ind nargs u
     in
     infer_stack infos variances stk
   | FConstruct (ctor,u) ->
@@ -122,7 +124,7 @@ let rec infer_fterm cv_pb infos variances hd stk =
       if Instance.is_empty u then variances
       else
         let nargs = stack_args_size stk in
-        infer_constructor_instance_eq (info_env infos) variances ctor nargs u
+        infer_constructor_instance_eq (info_env (fst infos)) variances ctor nargs u
     in
     infer_stack infos variances stk
   | FFix ((_,(_,tys,cl)),e) | FCoFix ((_,(_,tys,cl)),e) ->
@@ -159,7 +161,7 @@ and infer_vect infos variances v =
 
 let infer_term cv_pb env variances c =
   let open CClosure in
-  let infos = create_clos_infos all env in
+  let infos = (create_clos_infos all env, create_tab ()) in
   infer_fterm cv_pb infos variances (CClosure.inject c) []
 
 let infer_arity_constructor is_arity env variances arcn =

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -1230,6 +1230,7 @@ let clos_norm_flags flgs env sigma t =
     let evars ev = safe_evar_value sigma ev in
     EConstr.of_constr (CClosure.norm_val
       (CClosure.create_clos_infos ~evars flgs env)
+      (CClosure.create_tab ())
       (CClosure.inject (EConstr.Unsafe.to_constr t)))
   with e when is_anomaly e -> user_err Pp.(str "Tried to normalize ill-typed term")
 
@@ -1238,6 +1239,7 @@ let clos_whd_flags flgs env sigma t =
     let evars ev = safe_evar_value sigma ev in
     EConstr.of_constr (CClosure.whd_val
       (CClosure.create_clos_infos ~evars flgs env)
+      (CClosure.create_tab ())
       (CClosure.inject (EConstr.Unsafe.to_constr t)))
   with e when is_anomaly e -> user_err Pp.(str "Tried to normalize ill-typed term")
 


### PR DESCRIPTION
This is a corrected version of #6733, where we split the constant cache in conversion so that each side of the conversion is living in its own logical heap (as in separation logic). This allows to remove the `whd_both` hack, as now reducing one side cannot affect the other.

I'm summoning @ggonthier as he's probably the most capable person about that issue, and for some reason I cannot add him as a reviewer.

Bench:
```
┌──────────────────────────┬─────────────────────────┬─────────────────────────────────────┬───────────────────────────────────────┬─────────────────────────┬─────────────────┐
│                          │      user time [s]      │             CPU cycles              │           CPU instructions            │  max resident mem [KB]  │   mem faults    │
│                          │                         │                                     │                                       │                         │                 │
│             package_name │     NEW     OLD PDIFF   │           NEW           OLD PDIFF   │            NEW            OLD PDIFF   │     NEW     OLD PDIFF   │ NEW OLD PDIFF   │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│       coq-mathcomp-field │  416.22  437.90 -4.95 % │ 1158201155109 1218880658806 -4.98 % │  1970745076979  2022214736364 -2.55 % │  721364  721500 -0.02 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│ coq-mathcomp-real_closed │  159.47  164.82 -3.25 % │  442799243163  458145663962 -3.35 % │   686199420842   698579532573 -1.77 % │  725844  727656 -0.25 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│               coq-geocoq │ 2941.72 3034.87 -3.07 % │ 8210413476343 8457069891430 -2.92 % │ 13758764906873 13940870146673 -1.31 % │ 1248416 1248388 +0.00 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│              coq-unimath │ 1159.17 1186.97 -2.34 % │ 3233372055596 3310042660133 -2.32 % │  5685530194893  5744499209580 -1.03 % │ 1053656 1017224 +3.58 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│   coq-mathcomp-character │  257.66  261.72 -1.55 % │  716885446183  727653489507 -1.48 % │  1070124619091  1072827932701 -0.25 % │  982756  982472 +0.03 % │   3  36 -91.67 % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│                  coq-vst │ 2852.64 2889.63 -1.28 % │ 7954415791079 8053201867980 -1.23 % │ 11670929088692 11714129914440 -0.37 % │ 2220020 2217708 +0.10 % │   2   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│   coq-mathcomp-odd_order │ 1340.05 1354.09 -1.04 % │ 3733000900342 3771720694871 -1.03 % │  6594310295279  6582871414843 +0.17 % │ 1038204 1041208 -0.29 % │   0   1 -100.00 % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│    coq-mathcomp-solvable │  186.63  188.44 -0.96 % │  518713925928  523712684217 -0.95 % │   759107842492   760042900003 -0.12 % │  715148  715144 +0.00 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│                 coq-hott │  309.22  312.02 -0.90 % │  842564792566  848844785972 -0.74 % │  1370444442166  1369415221874 +0.08 % │  522660  522652 +0.00 % │   1   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│              coq-bignums │   74.25   74.73 -0.64 % │  206948958199  208100773890 -0.55 % │   281631200474   281263589051 +0.13 % │  512748  521652 -1.71 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│   coq-mathcomp-ssreflect │   39.75   39.97 -0.55 % │  109185093965  109512761499 -0.30 % │   136070518386   135889509580 +0.13 % │  476604  475628 +0.21 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│            coq-fiat-core │  100.24  100.55 -0.31 % │  285948551954  286282307943 -0.12 % │   373136614701   373050485198 +0.02 % │  500980  500332 +0.13 % │   9   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│           coq-coquelicot │   74.72   74.93 -0.28 % │  205705055822  206288492310 -0.28 % │   257067702851   257645900491 -0.22 % │  659028  658972 +0.01 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│                coq-color │  560.19  561.64 -0.26 % │ 1567351601137 1571489744326 -0.26 % │  1981015748328  1973796136103 +0.37 % │ 1448272 1440600 +0.53 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│    coq-mathcomp-fingroup │   59.22   59.37 -0.25 % │  163547825361  164674912251 -0.68 % │   230192354530   229988332607 +0.09 % │  526408  526644 -0.04 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│         coq-fiat-parsers │  651.51  652.94 -0.22 % │ 1823130139222 1828461295690 -0.29 % │  2956777442254  2958980179647 -0.07 % │ 3503964 3514404 -0.30 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│                 coq-corn │ 1459.06 1462.11 -0.21 % │ 4074495340246 4085650525427 -0.27 % │  6386419854244  6380407868334 +0.09 % │  823344  802568 +2.59 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│      coq-formal-topology │   33.62   33.58 +0.12 % │   93046092838   93123862439 -0.08 % │   123151425205   123278196038 -0.10 % │  483092  482968 +0.03 % │  14   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│             coq-compcert │  812.14  810.98 +0.14 % │ 2263844026132 2262003798168 +0.08 % │  3420748377554  3412048999813 +0.25 % │ 1350236 1344408 +0.43 % │   3   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│                coq-flocq │   58.94   58.64 +0.51 % │  162120549530  161626631410 +0.31 % │   209009373261   209082031780 -0.03 % │  644480  646284 -0.28 % │  44   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│     coq-mathcomp-algebra │  171.59  166.64 +2.97 % │  476371113881  462870239450 +2.92 % │   680671521858   653350184643 +4.18 % │  585756  597724 -2.00 % │   0   0  +nan % │
└──────────────────────────┴─────────────────────────┴─────────────────────────────────────┴───────────────────────────────────────┴─────────────────────────┴─────────────────┘

NEW = addc96078e4a1e957815d4625a868b8a1de08354
OLD = d2fb531761e1f4fa02d0c7e7b5b51febe48e357e
```

Overall, this is more efficient than the previous scheme, except strangely for mathcomp-algebra. Nonetheless, I think the gain in clarity and efficiency on average is in favour of merging this patch altogether.
