### PR TITLE
Fixes bug #6774 (anomaly with ill-typed template polymorphism).

### DIFF
--- a/test-suite/bugs/closed/6774.v
+++ b/test-suite/bugs/closed/6774.v
@@ -1,0 +1,7 @@
+(* Was an anomaly with ill-typed template polymorphism *)
+Definition huh (b:bool) := if b then Set else Prop.
+Definition lol b: huh b :=
+  if b return huh b then nat else True.
+Goal (lol true) * unit.
+Fail generalize true. (* should fail with error, not anomaly *)
+Abort.


### PR DESCRIPTION
Computation of the sort of the inductive type was done before ensuring that the arguments of the inductive type had the correct types, possibly brutally failing with `NotArity` in case one of the types expected to be typed with an arity was not so.

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #6774.

I made a minimal fix in a well-delimited portion of code so that when template polymorphism is replaced by full polymorphism, the code can easily be removed.
