### PR TITLE
Fixes #6787 (minus sign interpreted by coqdoc as a bullet in Ring_theory.v)

### DIFF
--- a/plugins/setoid_ring/Ring_theory.v
+++ b/plugins/setoid_ring/Ring_theory.v
@@ -263,7 +263,7 @@ Section ALMOST_RING.
  Variable SRth : semi_ring_theory 0 1 radd rmul req.
 
  (** Every semi ring can be seen as an almost ring, by taking :
-        -x = x and x - y = x + y *)
+        [-x = x] and [x - y = x + y] *)
  Definition SRopp (x:R) := x. Notation "- x" := (SRopp x).
 
  Definition SRsub x y := x + -y. Infix "-" := SRsub.


### PR DESCRIPTION
Fixes / closes #6787 by encapsulating the coq expression without square brackets in the coqdoc comment.

I made it blindly (w/o testing again the production of the html file) but I guess it should work.