### PR TITLE
Check whitespace errors per-commit.

### DIFF
--- a/dev/lint-commits.sh
+++ b/dev/lint-commits.sh
@@ -19,14 +19,21 @@ fi
 BASE_COMMIT="$1"
 HEAD_COMMIT="$2"
 
-# git diff --check
-# uses .gitattributes to know what to check
-if git diff --check "$BASE_COMMIT" "$HEAD_COMMIT";
+bad=()
+while IFS= read -r commit; do
+    echo Checking "$commit"
+    # git diff --check
+    # uses .gitattributes to know what to check
+    if ! git diff --check "${commit}^" "$commit";
+    then
+        bad+=("$commit")
+    fi
+done < <(git rev-list "$HEAD_COMMIT" --not "$BASE_COMMIT" --)
+
+if [ "${#bad[@]}" != 0 ]
 then
-    :
-else
     >&2 echo "Whitespace errors!"
-    >&2 echo "Running 'git diff --check $BASE_COMMIT $HEAD_COMMIT'."
+    >&2 echo "In commits ${bad[*]}"
     >&2 echo "If you use emacs, you can prevent this kind of error from reocurring by installing ws-butler and enabling ws-butler-convert-leading-tabs-or-spaces."
     exit 1
 fi


### PR DESCRIPTION
Otherwise it is possible to detect errors that are not fixed by git
rebase since that works per-commit.

See #982.