### PR TITLE
[configure]: support for profiles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -190,7 +190,7 @@ matrix:
     # Ocaml warnings with two compilers
     - env:
       - MAIN_TARGET="coqocaml"
-      - EXTRA_CONF="-byte-only -coqide byte -warn-error"
+      - EXTRA_CONF="-byte-only -coqide byte -warn-error yes"
       - EXTRA_OPAM="hevea ${LABLGTK}"
       # dummy target
       - BUILD_TARGET="clean"
@@ -209,7 +209,7 @@ matrix:
       - COMPILER="${COMPILER_BE}"
       - FINDLIB_VER="${FINDLIB_VER_BE}"
       - CAMLP5_VER="${CAMLP5_VER_BE}"
-      - EXTRA_CONF="-byte-only -coqide byte -warn-error"
+      - EXTRA_CONF="-byte-only -coqide byte -warn-error yes"
       - EXTRA_OPAM="num hevea ${LABLGTK_BE}"
       # dummy target
       - BUILD_TARGET="clean"
@@ -239,7 +239,7 @@ matrix:
       - CAMLP5_VER=".6.17"
       - NATIVE_COMP="no"
       - COQ_DEST="-prefix ${PWD}/_install"
-      - EXTRA_CONF="-coqide opt -warn-error"
+      - EXTRA_CONF="-coqide opt -warn-error yes"
       - EXTRA_OPAM="${LABLGTK}"
       before_install:
       - brew update

--- a/configure.ml
+++ b/configure.ml
@@ -315,7 +315,7 @@ let devel state = { state with
   annot = true;
   warn_error = true;
 }
-let devel_doc = "-local -annot -bin-annot -warn-error"
+let devel_doc = "-local -annot -bin-annot -warn-error yes"
 
 let get = function
   | "devel" -> devel
@@ -428,8 +428,8 @@ let args_options = Arg.align [
     " Force OCaml version";
   "-force-findlib-version", arg_set (fun p force_findlib_version -> { p with force_findlib_version }),
     " Force findlib version";
-  "-warn-error", arg_set (fun p warn_error -> { p with warn_error }),
-    " Make OCaml warnings into errors";
+  "-warn-error", arg_bool (fun p warn_error -> { p with warn_error }),
+    "(yes|no) Make OCaml warnings into errors (default no)";
   "-camldir", Arg.String (fun _ -> ()),
     "<dir> Specifies path to 'ocaml' for running configure script";
   "-profile", arg_profile,

--- a/dev/doc/setup.txt
+++ b/dev/doc/setup.txt
@@ -41,15 +41,15 @@ Building coqtop:
   cd ~/git/coq
   git checkout trunk
   make distclean
-  ./configure -annotate -local
+  ./configure -profile devel
   make clean
   make -j4 coqide printers
 
-The "-annotate" option is essential when one wants to use Merlin.
+The "-profile devel" enables all options recommended for developers (like
+warnings, support for Merlin, etc).  Moreover Coq is configured so that
+it can be run without installing it (i.e. from the current directory).
 
-The "-local" option is useful if one wants to run the coqtop and coqide binaries without running make install
-
-Then check if
+Once the compilation is over check if
 - bin/coqtop
 - bin/coqide
 behave as expected.


### PR DESCRIPTION
Profiles are a way to specify in one go a set of configure flags.
Profiles are a way to have all developers use a sane set of flags.

This PR is made of 2 commits, the first one refactors the code
while the latter adds a profile. I picked my options of choice, but I'm open to suggestions.
```
./configure -help
…
  -profile <profile>          Sets a bunch of flags. Supported profiles: 
     devel = -local -annot -bin-annot -warn-error
…
```

The code lets one easily add profiles later on, so they truly belong to different PRs.
For example I can imagine a `bisect` profile that never builds the coqide even if gtk is detected.

On a side note, I think .merlin should be generated (maybe just partially) by `./configure` so that the selected flags go in there too, but this is for another PR.
