### PR TITLE
Document Arguments extra scopes flag

### DIFF
--- a/doc/refman/RefMan-syn.tex
+++ b/doc/refman/RefMan-syn.tex
@@ -1021,6 +1021,14 @@ Arguments scopes can be cleared with the following command:
 {\tt Arguments {\qualid} : clear scopes}
 \end{quote}
 
+Extra argument scopes, to be used in case of coercion to Funclass
+(see Chapter~\ref{Coercions-full}) or with a computed type,
+can be given with
+
+\begin{quote}
+{\tt Arguments} {\qualid} \nelist{\textunderscore {\tt \%} \scope}{} {\tt : extra scopes.}
+\end{quote}
+
 \begin{Variants}
 \item {\tt Global Arguments} {\qualid} \nelist{\name {\tt \%}\scope}{}
 


### PR DESCRIPTION
**Kind:** documentation

See also #6802

The `Arguments` command can be used with `: extra scopes` which allows giving extra scopes to be used in case of coercion to Funclass or computation in the type. This flag was undocumented.