### PR TITLE
[located] More work towards using CAst.t

### DIFF
--- a/dev/ci/user-overlays/06831-ejgallego-located+vernac_2.sh
+++ b/dev/ci/user-overlays/06831-ejgallego-located+vernac_2.sh
@@ -1,0 +1,14 @@
+if [ "$CI_PULL_REQUEST" = "6831" ] || [ "$CI_BRANCH" = "located+vernac_2" ]; then
+
+    ltac2_CI_BRANCH=located+vernac_2
+    ltac2_CI_GITURL=https://github.com/ejgallego/ltac2
+
+    Equations_CI_BRANCH=located+vernac_2
+    Equations_CI_GITURL=https://github.com/ejgallego/Coq-Equations
+
+    # fiat_parsers_CI_BRANCH=located+vernac
+    # fiat_parsers_CI_GITURL=https://github.com/ejgallego/fiat
+
+    Elpi_CI_BRANCH=located+vernac_2
+    Elpi_CI_GITURL=https://github.com/ejgallego/coq-elpi.git
+fi

--- a/ide/ide_slave.ml
+++ b/ide/ide_slave.ml
@@ -63,7 +63,7 @@ let is_known_option cmd = match Vernacprop.under_control cmd with
 
 (** Check whether a command is forbidden in the IDE *)
 
-let ide_cmd_checks ~id (loc,ast) =
+let ide_cmd_checks ~id {CAst.loc;v=ast} =
   let user_error s = CErrors.user_err ?loc ~hdr:"IDE" (str s) in
   let warn msg = Feedback.(feedback ~id (Message (Warning, loc, strbrk msg))) in
   if is_debug ast then
@@ -120,7 +120,7 @@ let query (route, (s,id)) =
 
 let annotate phrase =
   let doc = get_doc () in
-  let (loc, ast) =
+  let {CAst.loc;v=ast} =
     let pa = Pcoq.Gram.parsable (Stream.of_string phrase) in
     Stm.parse_sentence ~doc (Stm.get_current_state ~doc) pa
   in

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -850,7 +850,7 @@ let rec extern inctx scopes vars r =
                    | Name _, _ -> Some (CAst.make na) in
                  (sub_extern false scopes vars tm,
                   na',
-                  Option.map (fun (loc,(ind,nal)) ->
+                  Option.map (fun {CAst.loc;v=(ind,nal)} ->
                               let args = List.map (fun x -> DAst.make @@ PatVar x) nal in
                               let fullargs = add_cpatt_for_params ind args in
                               extern_ind_pattern_in_scope scopes vars ind fullargs
@@ -929,7 +929,7 @@ and factorize_prod scopes vars na bk aty c =
   | Name id, GCases (LetPatternStyle, None, [(e,(Anonymous,None))],(_::_ as eqns))
          when is_gvar id e && List.length (store (factorize_eqns eqns)) = 1 ->
     (match get () with
-     | [(_,(ids,disj_of_patl,b))] ->
+     | [{CAst.v=(ids,disj_of_patl,b)}] ->
       let disjpat = List.map (function [pat] -> pat | _ -> assert false) disj_of_patl in
       let disjpat = if occur_glob_constr id b then List.map (set_pat_alias id) disjpat else disjpat in
       let b = extern_typ scopes vars b in
@@ -957,7 +957,7 @@ and factorize_lambda inctx scopes vars na bk aty c =
   | Name id, GCases (LetPatternStyle, None, [(e,(Anonymous,None))],(_::_ as eqns))
          when is_gvar id e && List.length (store (factorize_eqns eqns)) = 1 ->
     (match get () with
-     | [(_,(ids,disj_of_patl,b))] ->
+     | [{CAst.v=(ids,disj_of_patl,b)}] ->
       let disjpat = List.map (function [pat] -> pat | _ -> assert false) disj_of_patl in
       let disjpat = if occur_glob_constr id b then List.map (set_pat_alias id) disjpat else disjpat in
       let b = sub_extern inctx scopes vars b in
@@ -1010,7 +1010,7 @@ and extern_local_binder scopes vars = function
       let (assums,ids,l) = extern_local_binder scopes vars l in
       (assums,ids, CLocalPattern(CAst.make @@ (p,ty)) :: l)
 
-and extern_eqn inctx scopes vars (loc,(ids,pll,c)) =
+and extern_eqn inctx scopes vars {CAst.loc;v=(ids,pll,c)} =
   let pll = List.map (List.map (extern_cases_pattern_in_scope scopes vars)) pll in
   make ?loc (pll,extern inctx scopes vars c)
 
@@ -1155,7 +1155,7 @@ let extern_closed_glob ?lax goal_concl_style env sigma t =
 
 let any_any_branch =
   (* | _ => _ *)
-  Loc.tag ([],[DAst.make @@ PatVar Anonymous], DAst.make @@ GHole (Evar_kinds.InternalHole,Misctypes.IntroAnonymous,None))
+  CAst.make ([],[DAst.make @@ PatVar Anonymous], DAst.make @@ GHole (Evar_kinds.InternalHole,Misctypes.IntroAnonymous,None))
 
 let compute_displayed_name_in_pattern sigma avoid na c =
   let open Namegen in

--- a/interp/smartlocate.ml
+++ b/interp/smartlocate.ml
@@ -68,16 +68,16 @@ let global_with_alias ?head r =
 let smart_global ?head = function
   | AN r ->
       global_with_alias ?head r
-  | ByNotation (loc,(ntn,sc)) ->
+  | ByNotation {CAst.loc;v=(ntn,sc)} ->
       Notation.interp_notation_as_global_reference ?loc (fun _ -> true) ntn sc
 
 let smart_global_inductive = function
   | AN r ->
       global_inductive_with_alias r
-  | ByNotation (loc,(ntn,sc)) ->
+  | ByNotation {CAst.loc;v=(ntn,sc)} ->
       destIndRef
         (Notation.interp_notation_as_global_reference ?loc isIndRef ntn sc)
 
 let loc_of_smart_reference = function
   | AN r -> loc_of_reference r
-  | ByNotation (loc,(_,_)) -> loc
+  | ByNotation {CAst.loc;v=(_,_)} -> loc

--- a/interp/stdarg.ml
+++ b/interp/stdarg.ml
@@ -34,7 +34,7 @@ let wit_pre_ident : string uniform_genarg_type =
 
 let loc_of_or_by_notation f = function
   | AN c -> f c
-  | ByNotation (loc,(s,_)) -> loc
+  | ByNotation {CAst.loc;v=(s,_)} -> loc
 
 let wit_int_or_var =
   make0 ~dyn:(val_tag (topwit wit_int)) "int_or_var"

--- a/interp/stdarg.mli
+++ b/interp/stdarg.mli
@@ -39,7 +39,7 @@ val wit_pre_ident : string uniform_genarg_type
 
 val wit_int_or_var : (int or_var, int or_var, int) genarg_type
 
-val wit_intro_pattern : (constr_expr intro_pattern_expr located, glob_constr_and_expr intro_pattern_expr located, intro_pattern) genarg_type
+val wit_intro_pattern : (constr_expr intro_pattern_expr CAst.t, glob_constr_and_expr intro_pattern_expr CAst.t, intro_pattern) genarg_type
 
 val wit_ident : Id.t uniform_genarg_type
 
@@ -88,7 +88,7 @@ val wit_reference : (reference, global_reference located or_var, global_referenc
 val wit_global : (reference, global_reference located or_var, global_reference) genarg_type
 val wit_clause :  (lident Locus.clause_expr, lident Locus.clause_expr, Names.Id.t Locus.clause_expr) genarg_type
 val wit_quantified_hypothesis : quantified_hypothesis uniform_genarg_type
-val wit_intropattern : (constr_expr intro_pattern_expr located, glob_constr_and_expr intro_pattern_expr located, intro_pattern) genarg_type
+val wit_intropattern : (constr_expr intro_pattern_expr CAst.t, glob_constr_and_expr intro_pattern_expr CAst.t, intro_pattern) genarg_type
 val wit_redexpr :
   ((constr_expr,reference or_by_notation,constr_expr) red_expr_gen,
   (glob_constr_and_expr,evaluable_global_reference and_short_name or_var,glob_constr_pattern_and_expr) red_expr_gen,

--- a/interp/tactypes.ml
+++ b/interp/tactypes.ml
@@ -12,7 +12,6 @@
     lower API. It's not clear whether this is a temporary API or if this is
     meant to stay. *)
 
-open Loc
 open Names
 open Constrexpr
 open Pattern
@@ -29,7 +28,7 @@ type 'a delayed_open = Environ.env -> Evd.evar_map -> Evd.evar_map * 'a
 type delayed_open_constr = EConstr.constr delayed_open
 type delayed_open_constr_with_bindings = EConstr.constr with_bindings delayed_open
 
-type intro_pattern = delayed_open_constr intro_pattern_expr located
-type intro_patterns = delayed_open_constr intro_pattern_expr located list
-type or_and_intro_pattern = delayed_open_constr or_and_intro_pattern_expr located
-type intro_pattern_naming = intro_pattern_naming_expr located
+type intro_pattern = delayed_open_constr intro_pattern_expr CAst.t
+type intro_patterns = delayed_open_constr intro_pattern_expr CAst.t list
+type or_and_intro_pattern = delayed_open_constr or_and_intro_pattern_expr CAst.t
+type intro_pattern_naming = intro_pattern_naming_expr CAst.t

--- a/intf/constrexpr.ml
+++ b/intf/constrexpr.ml
@@ -143,8 +143,8 @@ type constr_pattern_expr = constr_expr
 (** Concrete syntax for modules and module types *)
 
 type with_declaration_ast =
-  | CWith_Module of Id.t list Loc.located * qualid Loc.located
-  | CWith_Definition of Id.t list Loc.located * universe_decl_expr option * constr_expr
+  | CWith_Module of Id.t list CAst.t * qualid CAst.t
+  | CWith_Definition of Id.t list CAst.t * universe_decl_expr option * constr_expr
 
 type module_ast_r =
   | CMident of qualid

--- a/intf/glob_term.ml
+++ b/intf/glob_term.ml
@@ -72,14 +72,14 @@ and 'a fix_kind_g =
   | GCoFix of int
 
 and 'a predicate_pattern_g =
-    Name.t * (inductive * Name.t list) Loc.located option
+    Name.t * (inductive * Name.t list) CAst.t option
       (** [(na,id)] = "as 'na' in 'id'" where if [id] is [Some(l,I,k,args)]. *)
 
 and 'a tomatch_tuple_g = ('a glob_constr_g * 'a predicate_pattern_g)
 
 and 'a tomatch_tuples_g = 'a tomatch_tuple_g list
 
-and 'a cases_clause_g = (Id.t list * 'a cases_pattern_g list * 'a glob_constr_g) Loc.located
+and 'a cases_clause_g = (Id.t list * 'a cases_pattern_g list * 'a glob_constr_g) CAst.t
 (** [(p,il,cl,t)] = "|'cl' => 't'". Precondition: the free variables
     of [t] are members of [il]. *)
 and 'a cases_clauses_g = 'a cases_clause_g list
@@ -96,7 +96,7 @@ type fix_recursion_order = [ `any ] fix_recursion_order_g
 
 type any_glob_constr = AnyGlobConstr : 'r glob_constr_g -> any_glob_constr
 
-type 'a disjunctive_cases_clause_g = (Id.t list * 'a cases_pattern_g list list * 'a glob_constr_g) Loc.located
+type 'a disjunctive_cases_clause_g = (Id.t list * 'a cases_pattern_g list list * 'a glob_constr_g) CAst.t
 type 'a disjunctive_cases_clauses_g = 'a disjunctive_cases_clause_g list
 type 'a cases_pattern_disjunction_g = 'a cases_pattern_g list
 

--- a/intf/misctypes.ml
+++ b/intf/misctypes.ml
@@ -35,12 +35,12 @@ and intro_pattern_naming_expr =
 and 'constr intro_pattern_action_expr =
   | IntroWildcard
   | IntroOrAndPattern of 'constr or_and_intro_pattern_expr
-  | IntroInjection of ('constr intro_pattern_expr) Loc.located list
-  | IntroApplyOn of 'constr Loc.located * 'constr intro_pattern_expr Loc.located
+  | IntroInjection of ('constr intro_pattern_expr) CAst.t list
+  | IntroApplyOn of 'constr CAst.t * 'constr intro_pattern_expr CAst.t
   | IntroRewrite of bool
 and 'constr or_and_intro_pattern_expr =
-  | IntroOrPattern of ('constr intro_pattern_expr) Loc.located list list
-  | IntroAndPattern of ('constr intro_pattern_expr) Loc.located list
+  | IntroOrPattern of ('constr intro_pattern_expr) CAst.t list list
+  | IntroAndPattern of ('constr intro_pattern_expr) CAst.t list
 
 (** Move destination for hypothesis *)
 
@@ -95,7 +95,7 @@ type 'a cast_type =
 
 type quantified_hypothesis = AnonHyp of int | NamedHyp of Id.t
 
-type 'a explicit_bindings = (quantified_hypothesis * 'a) Loc.located list
+type 'a explicit_bindings = (quantified_hypothesis * 'a) CAst.t list
 
 type 'a bindings =
   | ImplicitBindings of 'a list
@@ -115,7 +115,7 @@ type 'a and_short_name = 'a * lident option
 
 type 'a or_by_notation =
   | AN of 'a
-  | ByNotation of (string * string option) Loc.located
+  | ByNotation of (string * string option) CAst.t
 
 (* NB: the last string in [ByNotation] is actually a [Notation.delimiters],
    but this formulation avoids a useless dependency. *)

--- a/parsing/g_prim.ml4
+++ b/parsing/g_prim.ml4
@@ -62,8 +62,8 @@ GEXTEND Gram
       ] ]
   ;
   fullyqualid:
-    [ [ id = ident; (l,id')=fields -> Loc.tag ~loc:!@loc @@ id::List.rev (id'::l)
-      | id = ident -> Loc.tag ~loc:!@loc [id]
+    [ [ id = ident; (l,id')=fields -> CAst.make ~loc:!@loc @@ id::List.rev (id'::l)
+      | id = ident -> CAst.make ~loc:!@loc [id]
       ] ]
   ;
   basequalid:
@@ -82,14 +82,14 @@ GEXTEND Gram
       ] ]
   ;
   by_notation:
-    [ [ s = ne_string; sc = OPT ["%"; key = IDENT -> key ] -> Loc.tag ~loc:!@loc (s, sc) ] ]
+    [ [ s = ne_string; sc = OPT ["%"; key = IDENT -> key ] -> CAst.make ~loc:!@loc (s, sc) ] ]
   ;
   smart_global:
     [ [ c = reference -> Misctypes.AN c
       | ntn = by_notation -> Misctypes.ByNotation ntn ] ]
   ;
   qualid:
-    [ [ qid = basequalid -> Loc.tag ~loc:!@loc qid ] ]
+    [ [ qid = basequalid -> CAst.make ~loc:!@loc qid ] ]
   ;
   ne_string:
     [ [ s = STRING ->

--- a/parsing/g_vernac.ml4
+++ b/parsing/g_vernac.ml4
@@ -554,7 +554,7 @@ GEXTEND Gram
       ] ]
   ;
   module_expr_atom:
-    [ [ qid = qualid -> CAst.make ~loc:!@loc @@ CMident (snd qid) | "("; me = module_expr; ")" -> me ] ]
+    [ [ qid = qualid -> CAst.make ~loc:!@loc @@ CMident (qid.CAst.v) | "("; me = module_expr; ")" -> me ] ]
   ;
   with_declaration:
     [ [ "Definition"; fqid = fullyqualid; udecl = OPT univ_decl; ":="; c = Constr.lconstr ->
@@ -564,7 +564,7 @@ GEXTEND Gram
       ] ]
   ;
   module_type:
-    [ [ qid = qualid -> CAst.make ~loc:!@loc @@ CMident (snd qid)
+    [ [ qid = qualid -> CAst.make ~loc:!@loc @@ CMident (qid.CAst.v)
       | "("; mt = module_type; ")" -> mt
       | mty = module_type; me = module_expr_atom ->
           CAst.make ~loc:!@loc @@ CMapply (mty,me)

--- a/parsing/pcoq.mli
+++ b/parsing/pcoq.mli
@@ -8,7 +8,6 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-open Loc
 open Names
 open Extend
 open Vernacexpr
@@ -208,10 +207,10 @@ module Prim :
     val integer : int Gram.entry
     val string : string Gram.entry
     val lstring : lstring Gram.entry
-    val qualid : qualid located Gram.entry
-    val fullyqualid : Id.t list located Gram.entry
+    val qualid : qualid CAst.t Gram.entry
+    val fullyqualid : Id.t list CAst.t Gram.entry
     val reference : reference Gram.entry
-    val by_notation : (string * string option) Loc.located Gram.entry
+    val by_notation : (string * string option) CAst.t Gram.entry
     val smart_global : reference or_by_notation Gram.entry
     val dirpath : DirPath.t Gram.entry
     val ne_string : string Gram.entry

--- a/plugins/funind/g_indfun.ml4
+++ b/plugins/funind/g_indfun.ml4
@@ -68,9 +68,9 @@ let pr_intro_as_pat _prc _ _ pat =
         str"<simple_intropattern>"
     | None -> mt ()
 
-let out_disjunctive = function
-  | loc, IntroAction (IntroOrAndPattern l) -> (loc,l)
-  | _ -> CErrors.user_err Pp.(str "Disjunctive or conjunctive intro pattern expected.")
+let out_disjunctive = CAst.map (function
+  | IntroAction (IntroOrAndPattern l) -> l
+  | _ -> CErrors.user_err Pp.(str "Disjunctive or conjunctive intro pattern expected."))
 
 ARGUMENT EXTEND with_names TYPED AS intropattern_opt PRINTED BY pr_intro_as_pat
 |   [ "as"  simple_intropattern(ipat) ] -> [ Some ipat ]

--- a/plugins/funind/glob_term_to_relation.ml
+++ b/plugins/funind/glob_term_to_relation.ml
@@ -287,7 +287,7 @@ let make_discr_match_el  =
 *)
 let make_discr_match_brl i =
   List.map_i
-    (fun j (_,(idl,patl,_)) -> Loc.tag @@
+    (fun j {CAst.v=(idl,patl,_)} -> CAst.make @@
        if Int.equal j i
        then (idl,patl, mkGRef (Lazy.force coq_True_ref))
        else (idl,patl, mkGRef (Lazy.force coq_False_ref))
@@ -659,7 +659,7 @@ let rec build_entry_lc env funnames avoid rt : glob_constr build_entry_return =
 	assert (Int.equal (Array.length case_pats) 2);
 	let brl =
 	  List.map_i
-	    (fun i x -> Loc.tag ([],[case_pats.(i)],x))
+            (fun i x -> CAst.make ([],[case_pats.(i)],x))
 	    0
 	    [lhs;rhs]
 	in
@@ -689,7 +689,7 @@ let rec build_entry_lc env funnames avoid rt : glob_constr build_entry_return =
 	  in
 	  let case_pats = build_constructors_of_type (fst ind) nal_as_glob_constr in
 	  assert (Int.equal (Array.length case_pats) 1);
-	  let br = Loc.tag ([],[case_pats.(0)],e) in
+          let br = CAst.make ([],[case_pats.(0)],e) in
 	  let match_expr = mkGCases(None,[b,(Anonymous,None)],[br]) in
 	  build_entry_lc env funnames avoid match_expr
 
@@ -756,7 +756,7 @@ and build_entry_lc_from_case_term env types funname make_discr patterns_to_preve
     | [] -> (* computed_branches  *) {result = [];to_avoid = avoid}
     | br::brl' ->
 	(* alpha conversion to prevent name clashes *)
-	let _,(idl,patl,return) = alpha_br avoid br in
+        let {CAst.v=(idl,patl,return)} = alpha_br avoid br in
 	let new_avoid  = idl@avoid in 	(* for now we can no more use idl as an identifier *)
 	(* building a list of precondition stating that we are not in this branch
 	   (will be used in the following recursive calls)

--- a/plugins/funind/indfun.ml
+++ b/plugins/funind/indfun.ml
@@ -215,7 +215,7 @@ let is_rec names =
 	List.exists (fun (e,_) -> lookup names e) el ||
 	  List.exists (lookup_br names) brl
     | GProj(_,c) -> lookup names c
-  and lookup_br names (_,(idl,_,rt)) =
+  and lookup_br names {CAst.v=(idl,_,rt)} =
     let new_names = List.fold_right Id.Set.remove idl names in
     lookup new_names rt
   in

--- a/plugins/funind/invfun.ml
+++ b/plugins/funind/invfun.ml
@@ -240,7 +240,7 @@ let prove_fun_correct evd funs_constr graphs_constr schemes lemmas_types_infos i
       List.map
 	(fun decl ->
 	   List.map
-	     (fun id -> Loc.tag @@ IntroNaming (IntroIdentifier id))
+             (fun id -> CAst.make @@ IntroNaming (IntroIdentifier id))
 	     (generate_fresh_id (Id.of_string "y") ids (List.length (fst (decompose_prod_assum evd (RelDecl.get_type decl)))))
 	)
 	branches
@@ -256,7 +256,7 @@ let prove_fun_correct evd funs_constr graphs_constr schemes lemmas_types_infos i
       (* We get the identifiers of this branch *)
       let pre_args =
       	List.fold_right
-      	  (fun (_,pat) acc ->
+          (fun {CAst.v=pat} acc ->
       	     match pat with
 	       | IntroNaming (IntroIdentifier id) -> id::acc
       	       | _ -> anomaly (Pp.str "Not an identifier.")

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -206,7 +206,7 @@ let (value_f: Constr.t list -> global_reference -> Constr.t) =
 	(RegularStyle,None,
 	 [DAst.make @@ GApp(DAst.make @@ GRef(fterm,None), List.rev_map (fun x_id -> DAst.make @@ GVar x_id) rev_x_id_l),
 	  (Anonymous,None)],
-	 [Loc.tag ([v_id], [DAst.make @@ PatCstr ((destIndRef (delayed_force coq_sig_ref),1),
+         [CAst.make ([v_id], [DAst.make @@ PatCstr ((destIndRef (delayed_force coq_sig_ref),1),
 			   [DAst.make @@ PatVar(Name v_id); DAst.make @@ PatVar Anonymous],
                            Anonymous)],
 	    DAst.make @@ GVar v_id)])
@@ -899,8 +899,8 @@ let rec make_rewrite_list expr_info max = function
 	  Proofview.V82.of_tactic (general_rewrite_bindings false Locus.AllOccurrences
 	    true (* dep proofs also: *) true 
 	    (mkVar hp,
-	     ExplicitBindings[Loc.tag @@ (NamedHyp def, expr_info.f_constr);
-                              Loc.tag @@ (NamedHyp k, f_S max)]) false) g) )
+             ExplicitBindings[CAst.make @@ (NamedHyp def, expr_info.f_constr);
+                              CAst.make @@ (NamedHyp k, f_S max)]) false) g) )
       )
       [make_rewrite_list expr_info max l;
        observe_tclTHENLIST (str "make_rewrite_list")[ (* x < S max proof *)
@@ -926,8 +926,8 @@ let make_rewrite expr_info l hp max =
 	   (Proofview.V82.of_tactic (general_rewrite_bindings false Locus.AllOccurrences
 	    true (* dep proofs also: *) true 
 	    (mkVar hp,
-	     ExplicitBindings[Loc.tag @@ (NamedHyp def, expr_info.f_constr);
-                              Loc.tag @@ (NamedHyp k, f_S (f_S max))]) false)) g)
+             ExplicitBindings[CAst.make @@ (NamedHyp def, expr_info.f_constr);
+                              CAst.make @@ (NamedHyp k, f_S (f_S max))]) false)) g)
        [observe_tac(str "make_rewrite finalize") (
 	 (* tclORELSE( h_reflexivity) *)
 	 (observe_tclTHENLIST (str "make_rewrite")[

--- a/plugins/ltac/extratactics.ml4
+++ b/plugins/ltac/extratactics.ml4
@@ -264,7 +264,7 @@ let add_rewrite_hint ~poly bases ort t lcsr =
 	  (Declare.declare_universe_context false ctx;
            Univ.ContextSet.empty)
     in
-      Loc.tag ?loc:(Constrexpr_ops.constr_loc ce) ((c, ctx), ort, Option.map (in_gen (rawwit wit_ltac)) t) in
+      CAst.make ?loc:(Constrexpr_ops.constr_loc ce) ((c, ctx), ort, Option.map (in_gen (rawwit wit_ltac)) t) in
   let eqs = List.map f lcsr in
   let add_hints base = add_rew_rules base eqs in
   List.iter add_hints bases

--- a/plugins/ltac/g_ltac.ml4
+++ b/plugins/ltac/g_ltac.ml4
@@ -198,7 +198,8 @@ GEXTEND Gram
      verbose most of the time. *)
   fresh_id:
     [ [ s = STRING -> ArgArg s (*| id = ident -> ArgVar (!@loc,id)*)
-        | qid = qualid -> let (_pth,id) = Libnames.repr_qualid (snd qid) in ArgVar (CAst.make ~loc:!@loc id) ] ]
+        | qid = qualid -> let (_pth,id) = Libnames.repr_qualid qid.CAst.v in
+                          ArgVar (CAst.make ~loc:!@loc id) ] ]
   ;
   constr_eval:
     [ [ IDENT "eval"; rtc = red_expr; "in"; c = Constr.constr ->

--- a/plugins/ltac/pltac.mli
+++ b/plugins/ltac/pltac.mli
@@ -10,7 +10,6 @@
 
 (** Ltac parsing entries *)
 
-open Loc
 open Pcoq
 open Libnames
 open Constrexpr
@@ -29,7 +28,7 @@ val quantified_hypothesis : quantified_hypothesis Gram.entry
 val destruction_arg : constr_expr with_bindings destruction_arg Gram.entry
 val int_or_var : int or_var Gram.entry
 val simple_tactic : raw_tactic_expr Gram.entry
-val simple_intropattern : constr_expr intro_pattern_expr located Gram.entry
+val simple_intropattern : constr_expr intro_pattern_expr CAst.t Gram.entry
 val in_clause : lident Locus.clause_expr Gram.entry
 val clause_dft_concl : lident Locus.clause_expr Gram.entry
 val tactic_arg : raw_tactic_arg Gram.entry

--- a/plugins/ltac/pptactic.ml
+++ b/plugins/ltac/pptactic.ml
@@ -183,7 +183,7 @@ let string_of_genarg_arg (ArgumentType arg) =
 
   let pr_or_by_notation f = function
     | AN v -> f v
-    | ByNotation (_,(s,sc)) -> qs s ++ pr_opt (fun sc -> str "%" ++ str sc) sc
+    | ByNotation {CAst.v=(s,sc)} -> qs s ++ pr_opt (fun sc -> str "%" ++ str sc) sc
 
   let pr_located pr (loc,x) = pr x
 
@@ -382,9 +382,9 @@ let string_of_genarg_arg (ArgumentType arg) =
 
   let pr_as_disjunctive_ipat prc ipatl =
     keyword "as" ++ spc () ++
-      pr_or_var (fun (loc,p) -> Miscprint.pr_or_and_intro_pattern prc p) ipatl
+      pr_or_var (fun {CAst.loc;v=p} -> Miscprint.pr_or_and_intro_pattern prc p) ipatl
 
-  let pr_eqn_ipat (_,ipat) = keyword "eqn:" ++ Miscprint.pr_intro_pattern_naming ipat
+  let pr_eqn_ipat {CAst.v=ipat} = keyword "eqn:" ++ Miscprint.pr_intro_pattern_naming ipat
 
   let pr_with_induction_names prc = function
     | None, None -> mt ()
@@ -426,7 +426,7 @@ let string_of_genarg_arg (ArgumentType arg) =
   let pr_assumption prc prdc prlc ipat c = match ipat with
     (* Use this "optimisation" or use only the general case ?*)
     (* it seems that this "optimisation" is somehow more natural *)
-    | Some (_,IntroNaming (IntroIdentifier id)) ->
+    | Some {CAst.v=IntroNaming (IntroIdentifier id)} ->
       spc() ++ surround (pr_id id ++ str " :" ++ spc() ++ prlc c)
     | ipat ->
       spc() ++ prc c ++ pr_as_ipat prdc ipat
@@ -744,7 +744,7 @@ let pr_goal_selector ~toplevel s =
         | TacIntroPattern (ev,(_::_ as p)) ->
            hov 1 (primitive (if ev then "eintros" else "intros") ++
                     (match p with
-                    | [_,Misctypes.IntroForthcoming false] -> mt ()
+                    | [{CAst.v=Misctypes.IntroForthcoming false}] -> mt ()
                     | _ -> spc () ++ prlist_with_sep spc (Miscprint.pr_intro_pattern pr.pr_dconstr) p))
         | TacApply (a,ev,cb,inhyp) ->
           hov 1 (

--- a/plugins/ltac/taccoerce.ml
+++ b/plugins/ltac/taccoerce.ml
@@ -147,7 +147,7 @@ let coerce_var_to_ident fresh env sigma v =
   let fail () = raise (CannotCoerceTo "a fresh identifier") in
   if has_type v (topwit wit_intro_pattern) then
     match out_gen (topwit wit_intro_pattern) v with
-    | _, IntroNaming (IntroIdentifier id) -> id
+    | { CAst.v=IntroNaming (IntroIdentifier id)} -> id
     | _ -> fail ()
   else if has_type v (topwit wit_var) then
     out_gen (topwit wit_var) v
@@ -171,7 +171,7 @@ let id_of_name = function
   let fail () = raise (CannotCoerceTo "an identifier") in
   if has_type v (topwit wit_intro_pattern) then
     match out_gen (topwit wit_intro_pattern) v with
-    | _, IntroNaming (IntroIdentifier id) -> id
+    | {CAst.v=IntroNaming (IntroIdentifier id)} -> id
     | _ -> fail ()
   else if has_type v (topwit wit_var) then
     out_gen (topwit wit_var) v
@@ -207,7 +207,7 @@ let id_of_name = function
 
 let coerce_to_intro_pattern env sigma v =
   if has_type v (topwit wit_intro_pattern) then
-    snd (out_gen (topwit wit_intro_pattern) v)
+    (out_gen (topwit wit_intro_pattern) v).CAst.v
   else if has_type v (topwit wit_var) then
     let id = out_gen (topwit wit_var) v in
     IntroNaming (IntroIdentifier id)
@@ -226,7 +226,7 @@ let coerce_to_intro_pattern_naming env sigma v =
 let coerce_to_hint_base v =
   if has_type v (topwit wit_intro_pattern) then
     match out_gen (topwit wit_intro_pattern) v with
-    | _, IntroNaming (IntroIdentifier id) -> Id.to_string id
+    | {CAst.v=IntroNaming (IntroIdentifier id)} -> Id.to_string id
     | _ -> raise (CannotCoerceTo "a hint base name")
   else raise (CannotCoerceTo "a hint base name")
 
@@ -239,7 +239,7 @@ let coerce_to_constr env v =
   let fail () = raise (CannotCoerceTo "a term") in
   if has_type v (topwit wit_intro_pattern) then
     match out_gen (topwit wit_intro_pattern) v with
-    | _, IntroNaming (IntroIdentifier id) ->
+    | {CAst.v=IntroNaming (IntroIdentifier id)} ->
       (try ([], constr_of_id env id) with Not_found -> fail ())
     | _ -> fail ()
   else if has_type v (topwit wit_constr) then
@@ -268,7 +268,7 @@ let coerce_to_evaluable_ref env sigma v =
   let ev =
   if has_type v (topwit wit_intro_pattern) then
     match out_gen (topwit wit_intro_pattern) v with
-    | _, IntroNaming (IntroIdentifier id) when is_variable env id -> EvalVarRef id
+    | {CAst.v=IntroNaming (IntroIdentifier id)} when is_variable env id -> EvalVarRef id
     | _ -> fail ()
   else if has_type v (topwit wit_var) then
     let id = out_gen (topwit wit_var) v in
@@ -300,14 +300,14 @@ let coerce_to_intro_pattern_list ?loc env sigma v =
   match Value.to_list v with
   | None -> raise (CannotCoerceTo "an intro pattern list")
   | Some l ->
-    let map v = Loc.tag ?loc @@ coerce_to_intro_pattern env sigma v in
+    let map v = CAst.make ?loc @@ coerce_to_intro_pattern env sigma v in
     List.map map l
 
 let coerce_to_hyp env sigma v =
   let fail () = raise (CannotCoerceTo "a variable") in
   if has_type v (topwit wit_intro_pattern) then
     match out_gen (topwit wit_intro_pattern) v with
-    | _, IntroNaming (IntroIdentifier id) when is_variable env id -> id
+    | {CAst.v=IntroNaming (IntroIdentifier id)} when is_variable env id -> id
     | _ -> fail ()
   else if has_type v (topwit wit_var) then
     let id = out_gen (topwit wit_var) v in
@@ -340,7 +340,7 @@ let coerce_to_quantified_hypothesis sigma v =
   if has_type v (topwit wit_intro_pattern) then
     let v = out_gen (topwit wit_intro_pattern) v in
     match v with
-    | _, IntroNaming (IntroIdentifier id) -> NamedHyp id
+    | {CAst.v=IntroNaming (IntroIdentifier id)} -> NamedHyp id
     | _ -> raise (CannotCoerceTo "a quantified hypothesis")
   else if has_type v (topwit wit_var) then
     let id = out_gen (topwit wit_var) v in

--- a/plugins/ltac/tacexpr.mli
+++ b/plugins/ltac/tacexpr.mli
@@ -56,9 +56,9 @@ type inversion_kind = Misctypes.inversion_kind =
 
 type ('c,'d,'id) inversion_strength =
   | NonDepInversion of
-      inversion_kind * 'id list * 'd or_and_intro_pattern_expr located or_var option
+      inversion_kind * 'id list * 'd or_and_intro_pattern_expr CAst.t or_var option
   | DepInversion of
-      inversion_kind * 'c option * 'd or_and_intro_pattern_expr located or_var option
+      inversion_kind * 'c option * 'd or_and_intro_pattern_expr CAst.t or_var option
   | InversionUsing of 'c * 'id list
 
 type ('a,'b) location = HypLocation of 'a | ConclLocation of 'b
@@ -70,8 +70,8 @@ type 'id message_token =
 
 type ('dconstr,'id) induction_clause =
     'dconstr with_bindings destruction_arg *
-    (intro_pattern_naming_expr located option (* eqn:... *)
-    * 'dconstr or_and_intro_pattern_expr located or_var option) (* as ... *)
+    (intro_pattern_naming_expr CAst.t option (* eqn:... *)
+    * 'dconstr or_and_intro_pattern_expr CAst.t or_var option) (* as ... *)
     * 'id clause_expr option (* in ... *)
 
 type ('constr,'dconstr,'id) induction_clause_list =
@@ -126,28 +126,28 @@ type delayed_open_constr_with_bindings = EConstr.constr with_bindings delayed_op
 
 type delayed_open_constr = EConstr.constr delayed_open
 
-type intro_pattern = delayed_open_constr intro_pattern_expr located
-type intro_patterns = delayed_open_constr intro_pattern_expr located list
-type or_and_intro_pattern = delayed_open_constr or_and_intro_pattern_expr located
-type intro_pattern_naming = intro_pattern_naming_expr located
+type intro_pattern = delayed_open_constr intro_pattern_expr CAst.t
+type intro_patterns = delayed_open_constr intro_pattern_expr CAst.t list
+type or_and_intro_pattern = delayed_open_constr or_and_intro_pattern_expr CAst.t
+type intro_pattern_naming = intro_pattern_naming_expr CAst.t
 
 (** Generic expressions for atomic tactics *)
 
 type 'a gen_atomic_tactic_expr =
   (* Basic tactics *)
-  | TacIntroPattern of evars_flag * 'dtrm intro_pattern_expr located list
+  | TacIntroPattern of evars_flag * 'dtrm intro_pattern_expr CAst.t list
   | TacApply of advanced_flag * evars_flag * 'trm with_bindings_arg list *
-      ('nam * 'dtrm intro_pattern_expr located option) option
+      ('nam * 'dtrm intro_pattern_expr CAst.t option) option
   | TacElim of evars_flag * 'trm with_bindings_arg * 'trm with_bindings option
   | TacCase of evars_flag * 'trm with_bindings_arg
   | TacMutualFix of Id.t * int * (Id.t * int * 'trm) list
   | TacMutualCofix of Id.t * (Id.t * 'trm) list
   | TacAssert of
       evars_flag * bool * 'tacexpr option option *
-      'dtrm intro_pattern_expr located option * 'trm
+      'dtrm intro_pattern_expr CAst.t option * 'trm
   | TacGeneralize of ('trm with_occurrences * Name.t) list
   | TacLetTac of evars_flag * Name.t * 'trm * 'nam clause_expr * letin_flag *
-      intro_pattern_naming_expr located option
+      intro_pattern_naming_expr CAst.t option
 
   (* Derived basic tactics *)
   | TacInductionDestruct of

--- a/plugins/micromega/coq_micromega.ml
+++ b/plugins/micromega/coq_micromega.ml
@@ -1991,7 +1991,7 @@ let micromega_gen
 
        let intro_vars = Tacticals.New.tclTHENLIST (List.map intro vars) in
        let intro_props = Tacticals.New.tclTHENLIST (List.map intro props) in
-       let ipat_of_name id = Some (Loc.tag @@ Misctypes.IntroNaming (Misctypes.IntroIdentifier id)) in
+       let ipat_of_name id = Some (CAst.make @@ Misctypes.IntroNaming (Misctypes.IntroIdentifier id)) in
        let goal_name = fresh_id Id.Set.empty (Names.Id.of_string "__arith") gl in
        let env' = List.map (fun (id,i) -> EConstr.mkVar id,i) vars in 
 
@@ -2106,7 +2106,7 @@ let micromega_genr prover tac =
 
        let intro_vars = Tacticals.New.tclTHENLIST (List.map intro vars) in
        let intro_props = Tacticals.New.tclTHENLIST (List.map intro props) in
-       let ipat_of_name id = Some (Loc.tag @@ Misctypes.IntroNaming (Misctypes.IntroIdentifier id)) in
+       let ipat_of_name id = Some (CAst.make @@ Misctypes.IntroNaming (Misctypes.IntroIdentifier id)) in
        let goal_name = fresh_id Id.Set.empty (Names.Id.of_string "__arith") gl in
        let env' = List.map (fun (id,i) -> EConstr.mkVar id,i) vars in 
        

--- a/plugins/ssr/ssrparser.ml4
+++ b/plugins/ssr/ssrparser.ml4
@@ -541,7 +541,7 @@ END
 (* ipats *)
 
 
-let remove_loc = snd
+let remove_loc x = x.CAst.v
 
 let ipat_of_intro_pattern p = Misctypes.(
   let rec ipat_of_intro_pattern = function
@@ -608,14 +608,15 @@ let interp_intro_pattern = interp_wit wit_intro_pattern
 
 let interp_introid ist gl id = Misctypes.(
  try IntroNaming (IntroIdentifier (hyp_id (snd (interp_hyp ist gl (SsrHyp (Loc.tag id))))))
- with _ -> snd(snd (interp_intro_pattern ist gl (Loc.tag @@ IntroNaming (IntroIdentifier id))))
+ with _ -> (snd (interp_intro_pattern ist gl (CAst.make @@ IntroNaming (IntroIdentifier id)))).CAst.v
 )
 
 let get_intro_id = function
   | IntroNaming (IntroIdentifier id) -> id
   | _ -> assert false
 
-let rec add_intro_pattern_hyps (loc, ipat) hyps = Misctypes.(
+let rec add_intro_pattern_hyps ipat hyps = Misctypes.(
+  let {CAst.loc=loc;v=ipat} = ipat in
   match ipat with
   | IntroNaming (IntroIdentifier id) ->
     if not_section_id id then SsrHyp (loc, id) :: hyps else
@@ -646,7 +647,7 @@ let interp_ipat ist gl =
   | IPatClear clr ->
     let add_hyps (SsrHyp (loc, id) as hyp) hyps =
       if not (ltacvar id) then hyp :: hyps else
-      add_intro_pattern_hyps (loc, (interp_introid ist gl id)) hyps in
+      add_intro_pattern_hyps CAst.(make ?loc (interp_introid ist gl id)) hyps in
     let clr' = List.fold_right add_hyps clr [] in
     check_hyps_uniq [] clr'; IPatClear clr'
   | IPatCase(iorpat) ->

--- a/pretyping/cases.ml
+++ b/pretyping/cases.ml
@@ -347,7 +347,7 @@ let unify_tomatch_with_patterns evdref env loc typ pats realnames =
 
 let find_tomatch_tycon evdref env loc = function
   (* Try if some 'in I ...' is present and can be used as a constraint *)
-  | Some (_,(ind,realnal)) ->
+  | Some {CAst.v=(ind,realnal)} ->
       mk_tycon (inductive_template evdref env loc ind),Some (List.rev realnal)
   | None ->
       empty_tycon,None
@@ -1565,7 +1565,7 @@ substituer après par les initiaux *)
  * and linearizing the _ patterns.
  * Syntactic correctness has already been done in constrintern *)
 let matx_of_eqns env eqns =
-  let build_eqn (loc,(ids,initial_lpat,initial_rhs)) =
+  let build_eqn {CAst.loc;v=(ids,initial_lpat,initial_rhs)} =
     let avoid = ids_of_named_context_val (named_context_val env) in
     let avoid = List.fold_left (fun accu id -> Id.Set.add id accu) avoid ids in
     let rhs =
@@ -1883,8 +1883,8 @@ let extract_arity_signature ?(dolift=true) env0 lvar tomatchl tmsign =
 	    | None -> let sign = match bo with
 		       | None -> [LocalAssum (na, lift n typ)]
 		       | Some b -> [LocalDef (na, lift n b, lift n typ)] in sign,sign
-	    | Some (loc,_) ->
- 	    user_err ?loc 
+            | Some {CAst.loc} ->
+            user_err ?loc
                 (str"Unexpected type annotation for a term of non inductive type."))
       | IsInd (term,IndType(indf,realargs),_) ->
           let indf' = if dolift then lift_inductive_family n indf else indf in
@@ -1894,7 +1894,7 @@ let extract_arity_signature ?(dolift=true) env0 lvar tomatchl tmsign =
 	  let arsign = List.map (fun d -> map_rel_decl EConstr.of_constr d) arsign in
 	  let realnal, realnal' =
 	    match t with
-	      | Some (loc,(ind',realnal)) ->
+              | Some {CAst.loc;v=(ind',realnal)} ->
 		  if not (eq_ind ind ind') then
 		    user_err ?loc  (str "Wrong inductive type.");
 		  if not (Int.equal nrealargs_ctxt (List.length realnal)) then

--- a/pretyping/miscops.ml
+++ b/pretyping/miscops.ml
@@ -65,7 +65,7 @@ let map_red_expr_gen f g h = function
 (** Mapping bindings *)
 
 let map_explicit_bindings f l =
-  let map (loc, (hyp, x)) = (loc, (hyp, f x)) in
+  let map = CAst.map (fun (hyp, x) -> (hyp, f x)) in
   List.map map l
 
 let map_bindings f = function

--- a/pretyping/patternops.ml
+++ b/pretyping/patternops.ml
@@ -416,17 +416,17 @@ let rec pat_of_raw metas vars = DAst.with_loc_val (fun ?loc -> function
       | _ -> None
       in
       let get_ind = function
-	| (_,(_,[p],_))::_ -> get_ind p
+        | {CAst.v=(_,[p],_)}::_ -> get_ind p
 	| _ -> None
       in
       let ind_tags,ind = match indnames with
-	| Some (_,(ind,nal)) -> Some (List.length nal), Some ind
+        | Some {CAst.v=(ind,nal)} -> Some (List.length nal), Some ind
 	| None -> None, get_ind brs
       in
       let ext,brs = pats_of_glob_branches loc metas vars ind brs
       in
       let pred = match p,indnames with
-	| Some p, Some (_,(_,nal)) ->
+        | Some p, Some {CAst.v=(_,nal)} ->
           let nvars = na :: List.rev nal @ vars in
           rev_it_mkPLambda nal (mkPLambda na (pat_of_raw metas nvars p))
         | None, _ -> PMeta None
@@ -462,7 +462,7 @@ and pats_of_glob_branches loc metas vars ind brs =
   in
   let rec get_pat indexes = function
     | [] -> false, []
-    | (loc',(_,[p], br)) :: brs ->
+    | {CAst.loc=loc';v=(_,[p], br)} :: brs ->
       begin match DAst.get p, DAst.get br, brs with
       | PatVar Anonymous, GHole _, [] ->
         true, [] (* ends with _ => _ *)
@@ -484,7 +484,7 @@ and pats_of_glob_branches loc metas vars ind brs =
       | _ ->
         err ?loc:loc' (Pp.str "Non supported pattern.")
       end
-    | (loc,(_,_,_)) :: _ -> err ?loc (Pp.str "Non supported pattern.")
+    | {CAst.loc;v=(_,_,_)} :: _ -> err ?loc (Pp.str "Non supported pattern.")
   in
   get_pat Int.Set.empty brs
 

--- a/pretyping/typeclasses_errors.ml
+++ b/pretyping/typeclasses_errors.ml
@@ -9,7 +9,6 @@
 (************************************************************************)
 
 (*i*)
-open Names
 open EConstr
 open Environ
 open Constrexpr
@@ -20,7 +19,7 @@ type contexts = Parameters | Properties
 
 type typeclass_error =
     | NotAClass of constr
-    | UnboundMethod of global_reference * Id.t Loc.located (* Class name, method *)
+    | UnboundMethod of global_reference * Misctypes.lident (* Class name, method *)
     | MismatchedContextInstance of contexts * constr_expr list * Context.Rel.t (* found, expected *)
 
 exception TypeClassError of env * typeclass_error

--- a/pretyping/typeclasses_errors.mli
+++ b/pretyping/typeclasses_errors.mli
@@ -8,8 +8,6 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-open Loc
-open Names
 open EConstr
 open Environ
 open Constrexpr
@@ -19,14 +17,14 @@ type contexts = Parameters | Properties
 
 type typeclass_error =
   | NotAClass of constr
-  | UnboundMethod of global_reference * Id.t located (** Class name, method *)
+  | UnboundMethod of global_reference * Misctypes.lident (** Class name, method *)
   | MismatchedContextInstance of contexts * constr_expr list * Context.Rel.t (** found, expected *)
 
 exception TypeClassError of env * typeclass_error
 
 val not_a_class : env -> constr -> 'a
 
-val unbound_method : env -> global_reference -> Id.t located -> 'a
+val unbound_method : env -> global_reference -> Misctypes.lident -> 'a
 
 val mismatched_ctx_inst : env -> contexts -> constr_expr list -> Context.Rel.t -> 'a
 

--- a/printing/pputils.ml
+++ b/printing/pputils.ml
@@ -124,7 +124,7 @@ let pr_red_expr_env env sigma (pr_constr,pr_lconstr,pr_ref,pr_pattern) =
 
 let pr_or_by_notation f = function
   | AN v -> f v
-  | ByNotation (_,(s,sc)) -> qs s ++ pr_opt (fun sc -> str "%" ++ str sc) sc
+  | ByNotation {CAst.v=(s,sc)} -> qs s ++ pr_opt (fun sc -> str "%" ++ str sc) sc
 
 let hov_if_not_empty n p = if Pp.ismt p then p else hov n p
 

--- a/printing/ppvernac.ml
+++ b/printing/ppvernac.ml
@@ -69,7 +69,7 @@ open Decl_kinds
 
   let pr_fqid fqid = str (string_of_fqid fqid)
 
-  let pr_lfqid (loc,fqid) =
+  let pr_lfqid {CAst.loc;v=fqid} =
     match loc with
     | None     -> pr_fqid fqid
     | Some loc -> let (b,_) = Loc.unloc loc in
@@ -238,7 +238,7 @@ open Decl_kinds
       keyword "Definition" ++ spc() ++ pr_lfqid id ++ pr_universe_decl udecl ++ str" := " ++ p
     | CWith_Module (id,qid) ->
       keyword "Module" ++ spc() ++ pr_lfqid id ++ str" := " ++
-        pr_located pr_qualid qid
+        pr_ast pr_qualid qid
 
   let rec pr_module_ast leading_space pr_c = function
     | { loc ; v = CMident qid } ->

--- a/printing/prettyp.ml
+++ b/printing/prettyp.ml
@@ -838,7 +838,7 @@ let print_any_name env sigma na udecl =
 
 let print_name env sigma na udecl =
   match na with
-  | ByNotation (loc,(ntn,sc)) ->
+  | ByNotation {CAst.loc;v=(ntn,sc)} ->
       print_any_name env sigma
         (Term (Notation.interp_notation_as_global_reference ?loc (fun _ -> true)
                ntn sc))
@@ -891,7 +891,7 @@ let print_about_any ?loc env sigma k udecl =
 
 let print_about env sigma na udecl =
   match na with
-  | ByNotation (loc,(ntn,sc)) ->
+  | ByNotation {CAst.loc;v=(ntn,sc)} ->
       print_about_any ?loc env sigma
         (Term (Notation.interp_notation_as_global_reference ?loc (fun _ -> true)
                ntn sc)) udecl

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -416,7 +416,7 @@ let qhyp_eq h1 h2 = match h1, h2 with
 | _ -> false
 
 let check_bindings bl =
-  match List.duplicates qhyp_eq (List.map (fun x -> fst (snd x)) bl) with
+  match List.duplicates qhyp_eq (List.map (fun {CAst.v=x} -> fst x) bl) with
     | NamedHyp s :: _ ->
 	user_err 
 	  (str "The variable " ++ Id.print s ++
@@ -512,7 +512,7 @@ let clenv_match_args bl clenv =
     let mvs = clenv_independent clenv in
     check_bindings bl;
     List.fold_left
-      (fun clenv (loc,(b,c)) ->
+      (fun clenv {CAst.loc;v=(b,c)} ->
 	let k = meta_of_binder clenv loc mvs b in
         if meta_defined clenv.evd k then
           if EConstr.eq_constr clenv.evd (EConstr.of_constr (fst (meta_fvalue clenv.evd k)).rebus) c then clenv
@@ -710,7 +710,7 @@ let solve_evar_clause env sigma hyp_only clause = function
     error_not_right_number_missing_arguments len
 | ExplicitBindings lbind ->
   let () = check_bindings lbind in
-  let fold sigma (_, (binder, c)) =
+  let fold sigma {CAst.v=(binder, c)} =
     let ev = evar_of_binder clause.cl_holes binder in
     define_with_type sigma env ev c
   in

--- a/proofs/miscprint.ml
+++ b/proofs/miscprint.ml
@@ -14,7 +14,7 @@ open Misctypes
 
 (** Printing of [intro_pattern] *)
 
-let rec pr_intro_pattern prc (_,pat) = match pat with
+let rec pr_intro_pattern prc {CAst.v=pat} = match pat with
   | IntroForthcoming true -> str "*"
   | IntroForthcoming false -> str "**"
   | IntroNaming p -> pr_intro_pattern_naming p
@@ -31,7 +31,7 @@ and pr_intro_pattern_action prc = function
   | IntroInjection pl ->
       str "[=" ++ hv 0 (prlist_with_sep spc (pr_intro_pattern prc) pl) ++
       str "]"
-  | IntroApplyOn ((_,c),pat) -> pr_intro_pattern prc pat ++ str "%" ++ prc c
+  | IntroApplyOn ({CAst.v=c},pat) -> pr_intro_pattern prc pat ++ str "%" ++ prc c
   | IntroRewrite true -> str "->"
   | IntroRewrite false -> str "<-"
 
@@ -52,9 +52,9 @@ let pr_move_location pr_id = function
   | MoveLast -> str " at bottom"
 
 (** Printing of bindings *)
-let pr_binding prc = function
-  | loc, (NamedHyp id, c) -> hov 1 (Names.Id.print id ++ str " := " ++ cut () ++ prc c)
-  | loc, (AnonHyp n, c) -> hov 1 (int n ++ str " := " ++ cut () ++ prc c)
+let pr_binding prc = let open CAst in function
+  | {loc;v=(NamedHyp id, c)} -> hov 1 (Names.Id.print id ++ str " := " ++ cut () ++ prc c)
+  | {loc;v=(AnonHyp n, c)} -> hov 1 (int n ++ str " := " ++ cut () ++ prc c)
 
 let pr_bindings prc prlc = function
   | ImplicitBindings l ->

--- a/proofs/miscprint.mli
+++ b/proofs/miscprint.mli
@@ -13,7 +13,7 @@ open Misctypes
 (** Printing of [intro_pattern] *)
 
 val pr_intro_pattern :
-  ('a -> Pp.t) -> 'a intro_pattern_expr Loc.located -> Pp.t
+  ('a -> Pp.t) -> 'a intro_pattern_expr CAst.t -> Pp.t
 
 val pr_or_and_intro_pattern :
   ('a -> Pp.t) -> 'a or_and_intro_pattern_expr -> Pp.t

--- a/proofs/proof_global.ml
+++ b/proofs/proof_global.ml
@@ -207,7 +207,7 @@ let check_no_pending_proof () =
 let discard_gen id =
   pstates := List.filter (fun { pid = id' } -> not (Id.equal id id')) !pstates
 
-let discard (loc,id) =
+let discard {CAst.loc;v=id} =
   let n = List.length !pstates in
   discard_gen id;
   if Int.equal (List.length !pstates) n then
@@ -297,13 +297,13 @@ let set_used_variables l =
     match entry with
     | LocalAssum (x,_) ->
        if Id.Set.mem x all_safe then orig
-       else (ctx, all_safe, (Loc.tag x)::to_clear) 
+       else (ctx, all_safe, (CAst.make x)::to_clear)
     | LocalDef (x,bo, ty) as decl ->
        if Id.Set.mem x all_safe then orig else
        let vars = Id.Set.union (vars_of env bo) (vars_of env ty) in
        if Id.Set.subset vars all_safe
        then (decl :: ctx, Id.Set.add x all_safe, to_clear)
-       else (ctx, all_safe, (Loc.tag x) :: to_clear) in
+       else (ctx, all_safe, (CAst.make x) :: to_clear) in
   let ctx, _, to_clear =
     Environ.fold_named_context aux env ~init:(ctx,ctx_set,[]) in
   let to_clear = if !proof_using_auto_clear then to_clear else [] in

--- a/proofs/proof_global.mli
+++ b/proofs/proof_global.mli
@@ -22,7 +22,7 @@ val check_no_pending_proof : unit -> unit
 val get_current_proof_name : unit -> Names.Id.t
 val get_all_proof_names : unit -> Names.Id.t list
 
-val discard : Names.Id.t Loc.located -> unit
+val discard : Misctypes.lident -> unit
 val discard_current : unit -> unit
 val discard_all : unit -> unit
 
@@ -124,7 +124,7 @@ val set_endline_tactic : Genarg.glob_generic_argument -> unit
  * (w.r.t. type dependencies and let-ins covered by it) + a list of
  * ids to be cleared *)
 val set_used_variables :
-  Names.Id.t list -> Context.Named.t * Names.Id.t Loc.located list
+  Names.Id.t list -> Context.Named.t * Misctypes.lident list
 val get_used_variables : unit -> Context.Named.t option
 
 (** Get the universe declaration associated to the current proof. *)

--- a/stm/stm.mli
+++ b/stm/stm.mli
@@ -80,7 +80,7 @@ val new_doc  : stm_init_options -> doc * Stateid.t
 (* [parse_sentence sid pa] Reads a sentence from [pa] with parsing
    state [sid] Returns [End_of_input] if the stream ends *)
 val parse_sentence : doc:doc -> Stateid.t -> Pcoq.Gram.coq_parsable ->
-  Vernacexpr.vernac_control Loc.located
+  Vernacexpr.vernac_control CAst.t
 
 (* Reminder: A parsable [pa] is constructed using
    [Pcoq.Gram.coq_parsable stream], where [stream : char Stream.t]. *)
@@ -94,7 +94,7 @@ exception End_of_input
    If [newtip] is provided, then the returned state id is guaranteed
    to be [newtip] *)
 val add : doc:doc -> ontop:Stateid.t -> ?newtip:Stateid.t ->
-  bool -> Vernacexpr.vernac_control Loc.located ->
+  bool -> Vernacexpr.vernac_control CAst.t ->
   doc * Stateid.t * [ `NewTip | `Unfocus of Stateid.t ]
 
 (* [query at ?report_with cmd] Executes [cmd] at a given state [at],

--- a/tactics/autorewrite.ml
+++ b/tactics/autorewrite.ml
@@ -85,7 +85,7 @@ let print_rewrite_hintdb env sigma bas =
 	       Pputils.pr_glb_generic (Global.env()) tac) (mt ()) h.rew_tac)
 	   (find_rewrites bas))
 
-type raw_rew_rule = (constr Univ.in_universe_context_set * bool * Genarg.raw_generic_argument option) Loc.located
+type raw_rew_rule = (constr Univ.in_universe_context_set * bool * Genarg.raw_generic_argument option) CAst.t
 
 (* Applies all the rules of one base *)
 let one_base general_rewrite_maybe_in tac_main bas =
@@ -275,7 +275,7 @@ let add_rew_rules base lrul =
   let intern tac = snd (Genintern.generic_intern ist tac) in
   let lrul =
     List.fold_left
-      (fun dn (loc,((c,ctx),b,t)) ->
+      (fun dn {CAst.loc;v=((c,ctx),b,t)} ->
 	let sigma = Evd.merge_context_set Evd.univ_rigid sigma ctx in
 	let info = find_applied_relation ?loc false env sigma c b in
 	let pat = if b then info.hyp_left else info.hyp_right in

--- a/tactics/autorewrite.mli
+++ b/tactics/autorewrite.mli
@@ -14,7 +14,7 @@ open Constr
 open Equality
 
 (** Rewriting rules before tactic interpretation *)
-type raw_rew_rule = (constr Univ.in_universe_context_set * bool * Genarg.raw_generic_argument option) Loc.located
+type raw_rew_rule = (constr Univ.in_universe_context_set * bool * Genarg.raw_generic_argument option) CAst.t
 
 (** To add rewriting rules to a base *)
 val add_rew_rules : string -> raw_rew_rule list -> unit

--- a/tactics/tacticals.ml
+++ b/tactics/tacticals.ml
@@ -185,8 +185,8 @@ let check_or_and_pattern_size ?loc check_and names branchsigns =
   match names with
   | IntroAndPattern l ->
       if not (Int.equal n 1) then errn n;
-      let l' = List.filter (function _,IntroForthcoming _ -> true | _,IntroNaming _ | _,IntroAction _ -> false) l in
-      if l' != [] then errforthcoming ?loc:(fst (List.hd l'));
+      let l' = List.filter CAst.(function {v=IntroForthcoming _} -> true | {v=IntroNaming _} | {v=IntroAction _} -> false) l in
+      if l' != [] then errforthcoming ?loc:(List.hd l').CAst.loc;
       if check_and then
         let p1 = List.count (fun x -> x) branchsigns.(0) in
         let p2 = List.length branchsigns.(0) in
@@ -194,7 +194,7 @@ let check_or_and_pattern_size ?loc check_and names branchsigns =
         if not (Int.equal p p1 || Int.equal p p2) then err1 p1 p2;
         if Int.equal p p1 then
           IntroAndPattern
-            (List.extend branchsigns.(0) (Loc.tag @@ IntroNaming IntroAnonymous) l)
+            (List.extend branchsigns.(0) (CAst.make @@ IntroNaming IntroAnonymous) l)
         else
           names
       else
@@ -218,7 +218,7 @@ let get_and_check_or_and_pattern ?loc = get_and_check_or_and_pattern_gen ?loc tr
 let compute_induction_names_gen check_and branchletsigns = function
   | None ->
       Array.make (Array.length branchletsigns) []
-  | Some (loc,names) ->
+  | Some {CAst.loc;v=names} ->
       let names = fix_empty_or_and_pattern (Array.length branchletsigns) names in
       get_and_check_or_and_pattern_gen check_and ?loc names branchletsigns
 

--- a/tactics/tactics.mli
+++ b/tactics/tactics.mli
@@ -8,7 +8,6 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-open Loc
 open Names
 open Constr
 open EConstr
@@ -196,10 +195,10 @@ val apply                 : constr -> unit Proofview.tactic
 val eapply                : constr -> unit Proofview.tactic
 
 val apply_with_bindings_gen :
-  advanced_flag -> evars_flag -> (clear_flag * constr with_bindings located) list -> unit Proofview.tactic
+  advanced_flag -> evars_flag -> (clear_flag * constr with_bindings CAst.t) list -> unit Proofview.tactic
 
 val apply_with_delayed_bindings_gen :
-  advanced_flag -> evars_flag -> (clear_flag * delayed_open_constr_with_bindings located) list -> unit Proofview.tactic
+  advanced_flag -> evars_flag -> (clear_flag * delayed_open_constr_with_bindings CAst.t) list -> unit Proofview.tactic
 
 val apply_with_bindings   : constr with_bindings -> unit Proofview.tactic
 val eapply_with_bindings  : constr with_bindings -> unit Proofview.tactic
@@ -208,12 +207,12 @@ val cut_and_apply         : constr -> unit Proofview.tactic
 
 val apply_in :
   advanced_flag -> evars_flag -> Id.t -> 
-    (clear_flag * constr with_bindings located) list ->
+    (clear_flag * constr with_bindings CAst.t) list ->
     intro_pattern option -> unit Proofview.tactic
 
 val apply_delayed_in :
   advanced_flag -> evars_flag -> Id.t -> 
-    (clear_flag * delayed_open_constr_with_bindings located) list ->
+    (clear_flag * delayed_open_constr_with_bindings CAst.t) list ->
     intro_pattern option -> unit Proofview.tactic
 
 (** {6 Elimination tactics. } *)

--- a/toplevel/vernac.mli
+++ b/toplevel/vernac.mli
@@ -23,7 +23,7 @@ end
     expected to handle and print errors in form of exceptions, however
     care is taken so the state machine is left in a consistent
     state. *)
-val process_expr : time:bool -> state:State.t -> Vernacexpr.vernac_control Loc.located -> State.t
+val process_expr : time:bool -> state:State.t -> Vernacexpr.vernac_control CAst.t -> State.t
 
 (** [load_vernac echo sid file] Loads [file] on top of [sid], will
     echo the commands if [echo] is set. Callers are expected to handle

--- a/vernac/auto_ind_decl.ml
+++ b/vernac/auto_ind_decl.ml
@@ -86,12 +86,12 @@ let destruct_on c = destruct false None c None None
 
 let destruct_on_using c id =
   destruct false None c
-    (Some (Loc.tag @@ IntroOrPattern [[Loc.tag @@ IntroNaming IntroAnonymous];
-               [Loc.tag @@ IntroNaming (IntroIdentifier id)]]))
+    (Some (CAst.make @@ IntroOrPattern [[CAst.make @@ IntroNaming IntroAnonymous];
+               [CAst.make @@ IntroNaming (IntroIdentifier id)]]))
     None
 
 let destruct_on_as c l =
-  destruct false None c (Some (Loc.tag l)) None
+  destruct false None c (Some (CAst.make l)) None
 
 let inj_flags = Some {
     Equality.keep_proof_equalities = true; (* necessary *)
@@ -620,8 +620,8 @@ repeat ( apply andb_prop in z;let z1:= fresh "Z" in destruct z as [z1 z]).
                          Proofview.Goal.enter begin fun gl ->
                            let fresht = fresh_id (Id.of_string "Z") gl in
                             destruct_on_as (EConstr.mkVar freshz)
-                                  (IntroOrPattern [[Loc.tag @@ IntroNaming (IntroIdentifier fresht);
-                                    Loc.tag @@ IntroNaming (IntroIdentifier freshz)]])
+                                  (IntroOrPattern [[CAst.make @@ IntroNaming (IntroIdentifier fresht);
+                                    CAst.make @@ IntroNaming (IntroIdentifier freshz)]])
                          end
                         ]);
 (*

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -229,8 +229,8 @@ let new_instance ?(abstract=false) ?(global=false) ?(refine= !refine_instance)
 	| Some (Inl props) ->
 	    let get_id =
 	      function
-		| Ident id' -> id'
-		| Qualid (loc,id') -> (Loc.tag ?loc @@ snd (repr_qualid id'))
+                | Ident (loc, id') -> CAst.(make ?loc @@ id')
+                | Qualid (loc,id') -> CAst.(make ?loc @@ snd (repr_qualid id'))
 	    in
 	    let props, rest =
 	      List.fold_left
@@ -238,7 +238,7 @@ let new_instance ?(abstract=false) ?(global=false) ?(refine= !refine_instance)
 		  if is_local_assum decl then
 		    try
 		      let is_id (id', _) = match RelDecl.get_name decl, get_id id' with
-			| Name id, (_, id') -> Id.equal id id'
+                        | Name id, {CAst.v=id'} -> Id.equal id id'
 			| Anonymous, _ -> false
                       in
 		       let (loc_mid, c) =
@@ -247,7 +247,7 @@ let new_instance ?(abstract=false) ?(global=false) ?(refine= !refine_instance)
 		       let rest' = 
 			 List.filter (fun v -> not (is_id v)) rest 
 		       in
-		       let (loc, mid) = get_id loc_mid in
+                       let {CAst.loc;v=mid} = get_id loc_mid in
 			 List.iter (fun (n, _, x) -> 
 				      if Name.equal n (Name mid) then
 					Option.iter (fun x -> Dumpglob.add_glob ?loc (ConstRef x)) x)

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -1015,8 +1015,8 @@ let explain_not_a_class env c =
   let c = EConstr.to_constr Evd.empty c in
   pr_constr_env env Evd.empty c ++ str" is not a declared type class."
 
-let explain_unbound_method env cid id =
-  str "Unbound method name " ++ Id.print (snd id) ++ spc () ++
+let explain_unbound_method env cid { CAst.v = id } =
+  str "Unbound method name " ++ Id.print (id) ++ spc () ++
   str"of class" ++ spc () ++ pr_global cid ++ str "."
 
 let pr_constr_exprs exprs =

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -907,7 +907,7 @@ let vernac_set_used_variables e =
         (str "Unknown variable: " ++ Id.print id))
     l;
   let _, to_clear = Proof_global.set_used_variables l in
-  let to_clear = List.map snd to_clear in
+  let to_clear = List.map (fun x -> x.CAst.v) to_clear in
   Proof_global.with_current_proof begin fun _ p ->
     if List.is_empty to_clear then (p, ())
     else
@@ -1860,8 +1860,8 @@ let vernac_search ~atts s gopt r =
 let vernac_locate = function
   | LocateAny (AN qid)  -> print_located_qualid qid
   | LocateTerm (AN qid) -> print_located_term qid
-  | LocateAny (ByNotation (_, (ntn, sc))) (** TODO : handle Ltac notations *)
-  | LocateTerm (ByNotation (_, (ntn, sc))) ->
+  | LocateAny (ByNotation { CAst.v=(ntn, sc)}) (** TODO : handle Ltac notations *)
+  | LocateTerm (ByNotation { CAst.v=(ntn, sc)}) ->
     let _, env = Pfedit.get_current_context () in
     Notation.locate_notation
       (Constrextern.without_symbols (pr_lglob_constr_env env)) ntn sc
@@ -2259,7 +2259,7 @@ let with_fail st b f =
       | _ -> assert false
   end
 
-let interp ?(verbosely=true) ?proof ~st (loc,c) =
+let interp ?(verbosely=true) ?proof ~st {CAst.loc;v=c} =
   let orig_univ_poly = Flags.is_universe_polymorphism () in
   let orig_program_mode = Flags.is_program_mode () in
   let flags f atts =

--- a/vernac/vernacentries.mli
+++ b/vernac/vernacentries.mli
@@ -20,7 +20,7 @@ val vernac_require :
 val interp :
   ?verbosely:bool ->
   ?proof:Proof_global.closed_proof ->
-  st:Vernacstate.t -> Vernacexpr.vernac_control Loc.located -> Vernacstate.t
+  st:Vernacstate.t -> Vernacexpr.vernac_control CAst.t -> Vernacstate.t
 
 (** Prepare a "match" template for a given inductive type.
     For each branch of the match, we list the constructor name


### PR DESCRIPTION
We continue with the work of #402 and #6745 and update most of the
remaining parts of the AST:

- module declarations
- intro patterns
- top-level sentences

Now, parsed documents should be full annotated by `CAst` nodes.

Overlays:
- https://github.com/LPCIC/coq-elpi/pull/11
- https://github.com/ppedrot/ltac2/pull/45
- https://github.com/mattam82/Coq-Equations/pull/59

Depends on #6374 [merged]
