### PR TITLE
Use dependent induction for elim and induction whenever needed on dependent proof

### DIFF
--- a/doc/changelog/05-tactic-language/6833-master+dependent-prop-induction.rst
+++ b/doc/changelog/05-tactic-language/6833-master+dependent-prop-induction.rst
@@ -1,0 +1,7 @@
+- **Changed:**
+  When applied on proofs, the tactics "elim" and "induction" now use
+  dependent elimination by default whenever needed, as it is the case
+  with expressions whose type is not in Prop. The former behavior can
+  be restored by issuing "Unset Dependent Propositions Induction"
+  (`#6833 <https://github.com/coq/coq/pull/6833>`_,
+  by Hugo Herbelin).

--- a/plugins/funind/indfun.ml
+++ b/plugins/funind/indfun.ml
@@ -37,7 +37,7 @@ let is_rec_info sigma scheme_info =
 
 let choose_dest_or_ind scheme_info args =
   Proofview.tclBIND Proofview.tclEVARMAP (fun sigma ->
-      Tactics.induction_destruct (is_rec_info sigma scheme_info) false args)
+      Tactics.induction_destruct ~dep:Tactics.DependentIfNotInProp (is_rec_info sigma scheme_info) false args)
 
 let functional_induction with_clean c princl pat =
   let open Proofview.Notations in

--- a/pretyping/indrec.mli
+++ b/pretyping/indrec.mli
@@ -37,9 +37,10 @@ val build_case_analysis_scheme : env -> Evd.evar_map -> pinductive ->
 val build_case_analysis_scheme_default : env -> evar_map -> pinductive ->
       Sorts.family -> evar_map * Constr.t * Constr.types
 
-(** Builds a recursive induction scheme (Peano-induction style) in the same
-   sort family as the inductive family; it is dependent if not in Prop
-   or a recursive record with primitive projections.  *)
+(** Builds a recursive induction scheme (Peano-induction style) in the
+   given sort family with the expected dependency; fails if asking for
+   a dependent scheme when the type is a recursive record with
+   primitive projections.  *)
 
 val build_induction_scheme : env -> evar_map -> pinductive ->
       dep_flag -> Sorts.family -> evar_map * constr

--- a/tactics/contradiction.ml
+++ b/tactics/contradiction.ml
@@ -119,7 +119,7 @@ let contradiction_term (c,lbind as cl) =
     let _, ccl = splay_prod env sigma typ in
     if is_empty_type env sigma ccl then
       Tacticals.tclTHEN
-        (elim false None cl None)
+        (default_elim ~dep:(GivenDependency false) false None cl)
         (Tacticals.tclTRY assumption)
     else
       Proofview.tclORELSE

--- a/tactics/elimschemes.ml
+++ b/tactics/elimschemes.ml
@@ -72,9 +72,17 @@ let rect_dep_scheme_kind_from_type =
   declare_individual_scheme_object "_rect" ~aux:"_rect_from_type"
     (fun env _ x -> build_induction_scheme_in_type env true InType x)
 
+let rect_dep_scheme_kind_from_prop =
+  declare_individual_scheme_object "_rect_dep" ~aux:"_rect_dep_from_prop"
+    (fun env _ x -> build_induction_scheme_in_type env true InType x)
+
 let rec_scheme_kind_from_type =
   declare_individual_scheme_object "_rec_nodep" ~aux:"_rec_nodep_from_type"
   (optimize_non_type_induction_scheme rect_scheme_kind_from_type false InSet)
+
+let ind_dep_scheme_kind_from_prop =
+  declare_individual_scheme_object "_ind_dep" ~aux:"_ind_dep_from_prop"
+  (optimize_non_type_induction_scheme rect_scheme_kind_from_prop true InProp)
 
 let rec_scheme_kind_from_prop =
   declare_individual_scheme_object "_rec" ~aux:"_rec_from_prop"

--- a/tactics/elimschemes.mli
+++ b/tactics/elimschemes.mli
@@ -13,24 +13,26 @@ open Ind_tables
 (** Induction/recursion schemes *)
 
 val rect_scheme_kind_from_prop : individual scheme_kind
+val rect_dep_scheme_kind_from_prop : individual scheme_kind
 val ind_scheme_kind_from_prop : individual scheme_kind
 val sind_scheme_kind_from_prop : individual scheme_kind
+val ind_dep_scheme_kind_from_prop : individual scheme_kind
 val rec_scheme_kind_from_prop : individual scheme_kind
 val rect_scheme_kind_from_type : individual scheme_kind
 val rect_dep_scheme_kind_from_type : individual scheme_kind
-val ind_scheme_kind_from_type : individual scheme_kind
+val ind_scheme_kind_from_type : individual scheme_kind (* not dep *)
 val ind_dep_scheme_kind_from_type : individual scheme_kind
 val sind_scheme_kind_from_type : individual scheme_kind
 val sind_dep_scheme_kind_from_type : individual scheme_kind
-val rec_scheme_kind_from_type : individual scheme_kind
+val rec_scheme_kind_from_type : individual scheme_kind (* not dep *)
 val rec_dep_scheme_kind_from_type : individual scheme_kind
 
 val nondep_elim_scheme : Sorts.family -> Sorts.family -> individual scheme_kind
 
 (** Case analysis schemes *)
 
-val case_scheme_kind_from_type : individual scheme_kind
-val case_scheme_kind_from_prop : individual scheme_kind
+val case_scheme_kind_from_type : individual scheme_kind (* not dep *)
+val case_scheme_kind_from_prop : individual scheme_kind (* not dep *)
 val case_dep_scheme_kind_from_type : individual scheme_kind
 val case_dep_scheme_kind_from_type_in_prop : individual scheme_kind
 val case_dep_scheme_kind_from_prop : individual scheme_kind

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -59,6 +59,18 @@ let typ_of env sigma c =
 
 open Goptions
 
+let dependent_propositions_induction = ref true
+
+let use_dependent_propositions_induction () =
+  !dependent_propositions_induction
+
+let _ =
+  declare_bool_option
+    { optdepr  = false;
+      optkey   = ["Dependent";"Propositions";"Induction"];
+      optread  = (fun () -> !dependent_propositions_induction) ;
+      optwrite = (fun b -> dependent_propositions_induction := b) }
+
 let clear_hyp_by_default = ref false
 
 let use_clear_hyp_by_default () = !clear_hyp_by_default
@@ -1675,7 +1687,7 @@ let is_nonrec env mind = (Environ.lookup_mind (fst mind) env).mind_finite == Dec
 
 let find_ind_eliminator env sigma dep (ind,_ as indu) s =
   let indsort = Inductive.inductive_sort_family (snd (Global.lookup_inductive ind)) in
-  if dep = Some true && indsort == Sorts.InProp then
+  if use_dependent_propositions_induction () && dep = Some true && indsort == Sorts.InProp then
     let sigma, c = build_induction_scheme env sigma indu true s in
     sigma, EConstr.of_constr c
   else

--- a/tactics/tactics.mli
+++ b/tactics/tactics.mli
@@ -275,31 +275,44 @@ type elim_scheme = {
 
 val compute_elim_sig : evar_map -> types -> elim_scheme
 
+type dependent_scheme_style =
+  (* Tell if use a dependent scheme or not *)
+  | GivenDependency of Indrec.dep_flag
+  (* No dependent elimination if inductive in Prop (legacy behavior) *)
+  | DependentIfNotInProp
+  (* Default behavior, depending on dynamic configuration *)
+  | DefaultDependency
+
 val general_elim_clause : evars_flag -> unify_flags -> Id.t option ->
   (EConstr.t * EConstr.types) -> EConstr.t -> unit Proofview.tactic
 
-val default_elim  : evars_flag -> clear_flag -> constr with_bindings ->
-  unit Proofview.tactic
-val simplest_elim : constr -> unit Proofview.tactic
+val default_elim  : ?dep:dependent_scheme_style ->
+  evars_flag -> clear_flag -> constr with_bindings -> unit Proofview.tactic
+val simplest_elim : ?dep:dependent_scheme_style -> constr -> unit Proofview.tactic
 val elim :
   evars_flag -> clear_flag -> constr with_bindings -> constr with_bindings option -> unit Proofview.tactic
 
-val induction : evars_flag -> clear_flag -> constr -> or_and_intro_pattern option ->
+val induction : ?dep:dependent_scheme_style ->
+  evars_flag -> clear_flag -> constr -> or_and_intro_pattern option ->
   constr with_bindings option -> unit Proofview.tactic
 
 (** {6 Case analysis tactics. } *)
 
-val general_case_analysis : evars_flag -> clear_flag -> constr with_bindings ->  unit Proofview.tactic
-val simplest_case         : constr -> unit Proofview.tactic
+val general_case_analysis : ?dep:dependent_scheme_style ->
+  evars_flag -> clear_flag -> constr with_bindings ->  unit Proofview.tactic
 
-val destruct : evars_flag -> clear_flag -> constr -> or_and_intro_pattern option ->
+val simplest_case         : ?dep:dependent_scheme_style ->
+  constr -> unit Proofview.tactic
+
+val destruct : ?dep:dependent_scheme_style ->
+  evars_flag -> clear_flag -> constr -> or_and_intro_pattern option ->
   constr with_bindings option -> unit Proofview.tactic
 
 (** {6 Generic case analysis / induction tactics. } *)
 
 (** Implements user-level "destruct" and "induction" *)
 
-val induction_destruct : rec_flag -> evars_flag ->
+val induction_destruct : ?dep:dependent_scheme_style -> rec_flag -> evars_flag ->
   (delayed_open_constr_with_bindings destruction_arg
    * (intro_pattern_naming option * or_and_intro_pattern option)
    * clause option) list *
@@ -308,7 +321,7 @@ val induction_destruct : rec_flag -> evars_flag ->
 (** {6 Eliminations giving the type instead of the proof. } *)
 
 val case_type         : types -> unit Proofview.tactic
-val elim_type         : types -> unit Proofview.tactic
+val elim_type         : ?dep:dependent_scheme_style -> types -> unit Proofview.tactic
 
 (** {6 Constructor tactics. } *)
 

--- a/test-suite/success/contradiction.v
+++ b/test-suite/success/contradiction.v
@@ -30,3 +30,9 @@ Proof.
 intros; contradiction.
 Qed.
 
+(* A border case which failed to be proved because dependent
+   elimination was used, and used only on the conclusion *)
+
+Lemma L7 : forall a: Empty_set, forall b : a = a, b = eq_refl a.
+contradiction.
+Qed.

--- a/test-suite/success/induct.v
+++ b/test-suite/success/induct.v
@@ -164,3 +164,10 @@ Undo.
 destruct 1 as [? IHv].
 exact IHv. (* Check that the name is granted *)
 Qed.
+
+(* Was failing up to 8.7 *)
+
+Goal forall H : True/\False, H = H.
+induction H.
+reflexivity.
+Qed.

--- a/theories/Reals/MVT.v
+++ b/theories/Reals/MVT.v
@@ -630,7 +630,7 @@ Proof.
   { intros; apply derivable_continuous_pt; apply derivable_pt_minus;
     [ apply H3 | apply H4 ]; assumption. }
   assert (H7 : forall (x:R) (P:a < x < b), derive_pt (g1 - g2) x (H5 x P) = 0).
-  { intros; elim P; intros; apply derive_pt_eq_0; replace 0 with (f x0 - f x0);
+  { intros; elim P; intros H7 H8; apply derive_pt_eq_0; replace 0 with (f x0 - f x0);
     [ idtac | ring ].
     assert (H9 : a <= x0 <= b).
     { split; left; assumption. }

--- a/theories/Reals/Ratan.v
+++ b/theories/Reals/Ratan.v
@@ -343,9 +343,9 @@ assert (local_derivable_pt_tan : forall x, -PI/2 < x < PI/2 ->
 { intros ; apply derivable_pt_tan ; intuition. }
 apply derive_increasing_interv with (a:=-PI/2) (b:=PI/2) (pr:=local_derivable_pt_tan) ; intuition.
 { lra. }
-assert (Temp := pr_nu tan t (derivable_pt_tan t t_encad) (local_derivable_pt_tan t t_encad)) ;
+assert (Temp := pr_nu tan t (derivable_pt_tan t (conj r r0)) (local_derivable_pt_tan t (conj r r0))) ;
   rewrite <- Temp ; clear Temp.
-assert (Temp := derive_pt_tan t t_encad) ; rewrite Temp ; clear Temp.
+assert (Temp := derive_pt_tan t (conj r r0)) ; rewrite Temp ; clear Temp.
 apply plus_Rsqr_gt_0.
 Qed.
 

--- a/theories/Reals/RiemannInt.v
+++ b/theories/Reals/RiemannInt.v
@@ -2653,7 +2653,8 @@ Lemma RiemannInt_P28 :
     (C0:forall x:R, a <= x <= b -> continuity_pt f x),
     a <= x <= b -> derivable_pt_lim (primitive h (FTC_P1 h C0)) x (f x).
 Proof.
-  intro f; intros; elim h; intro.
+  intro f; intros; elim h; intro H0;
+  clear h; [set (h:=or_introl H0)|set (h:=or_intror H0)].
   1:elim H; clear H; intros; elim H; intro.
   - elim H1; intro.
     { apply RiemannInt_P27; split; assumption. }
@@ -2709,7 +2710,7 @@ Proof.
           { rewrite <- Rabs_Ropp; apply RRle_abs. }
           left; assumption. }
         unfold del; apply Rle_trans with (Rmin x1 (b - a)); apply Rmin_r. }
-      replace (primitive h (FTC_P1 h C0) (b + h0) - primitive h (FTC_P1 h C0) b)
+      replace (primitive h (FTC_P1 h C0) (b + h0) - primitive h (FTC_P1 _ C0) b)
         with (- RiemannInt H13).
       { replace (f b) with (- RiemannInt (RiemannInt_P14 (b + h0) b (f b)) / h0).
         2:{ rewrite RiemannInt_P15.

--- a/theories/Reals/RiemannInt_SF.v
+++ b/theories/Reals/RiemannInt_SF.v
@@ -2293,7 +2293,7 @@ Proof.
     { left; assumption. }
     elim H0; intros; assumption. }
   eapply StepFun_P7;
-    [ elim H0; intros; apply Rle_trans with c; [ apply H2 | apply H3 ]
+    [ elim H0; intros H2 H3; apply Rle_trans with c; [ apply H2 | apply H3 ]
     | apply H ].
 Qed.
 
@@ -2368,7 +2368,7 @@ Proof.
         split with lf1'; assumption. }
     split; [ left; assumption | elim H0; intros; assumption ]. }
   eapply StepFun_P7;
-    [ elim H0; intros; apply Rle_trans with c; [ apply H2 | apply H3 ]
+    [ elim H0; intros H2 H3; apply Rle_trans with c; [ apply H2 | apply H3 ]
     | apply H ].
 Qed.
 

--- a/vernac/auto_ind_decl.ml
+++ b/vernac/auto_ind_decl.ml
@@ -63,18 +63,18 @@ let float64_eqb () = UnivGen.constr_of_monomorphic_global (Global.env ()) (Coqli
 let sumbool () = UnivGen.constr_of_monomorphic_global (Global.env ()) (Coqlib.lib_ref "core.sumbool.type")
 let andb = fun _ -> UnivGen.constr_of_monomorphic_global (Global.env ()) (Coqlib.lib_ref "core.bool.andb")
 
-let induct_on  c = Tactics.induction false None c None None
-let destruct_on c = Tactics.destruct false None c None None
+let induct_on  c = Tactics.induction ~dep:DefaultDependency false None c None None
+let destruct_on c = Tactics.destruct ~dep:DefaultDependency false None c None None
 
 let destruct_on_using c id =
   let open Tactypes in
-  Tactics.destruct false None c
+  Tactics.destruct ~dep:DefaultDependency false None c
     (Some (CAst.make @@ IntroOrPattern [[CAst.make @@ IntroNaming IntroAnonymous];
                [CAst.make @@ IntroNaming (IntroIdentifier id)]]))
     None
 
 let destruct_on_as c l =
-  Tactics.destruct false None c (Some (CAst.make l)) None
+  Tactics.destruct ~dep:DefaultDependency false None c (Some (CAst.make l)) None
 
 let inj_flags = Some {
     Equality.keep_proof_equalities = true; (* necessary *)


### PR DESCRIPTION
Edit: An extra PR #6866 (merged) has been created for points 3 and 4 below. The code of the PR includes it (as it also includes #6846 for convenience). This PR is now strictly about "using dependent elimination scheme in case of a dependent proposition" and its impact on `contradiction`.

This is parts 2, 3 and 4 of #6826, namely:
2. Using dependent elimination scheme in case of a dependent proposition when using `induction`
3. Improving error message when asking to `clear` a section hypothesis implicitly dependent in a definition of the section
4. Warning when `destruct`/`induction` cannot remove a section hypothesis because it is dependent in a definition of the section

Added 27/2/18:
5. Fixed a border-case failure of `contradiction` in the presence of a dependent term in an empty type.
6. Add configurability of whether the scheme has to be dependent or not in `elim` for better control of `elim` from ML-written tactics
7. Include #6846 for convenience (move of old `simple induction`/`simple destruct` to `coretactics.ml4`)

The discussion in #6826 focussed on part 1 of #6826. I open this new PR for specific discusssions about the other parts, if any, but also to distinguish the impact of the semantic changes of 2 from the semantic changes in 1 on the tested packages.

**Kind:** enhancement / bug fix

<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [ ] Corresponding documentation was added / updateddependent or not elimination.
- [x] Entry added in CHANGES.

The documentation is currently silent about when `elim`/`induction` are using dependent elimination or not but I believe that it shall have to say something and to document the new associated `Unset Dependent Propositions Induction`.