### PR TITLE
Deprecate undocumented "intros until 0" in favor of "intros *"

### DIFF
--- a/plugins/micromega/Tauto.v
+++ b/plugins/micromega/Tauto.v
@@ -211,7 +211,7 @@ Set Implicit Arguments.
       (* BC *)
       simpl.
       case_eq (deduce t t) ; auto.
-      intros until 0.
+      intros *.
       case_eq (unsat t0) ; auto.
       unfold eval_clause.
       rewrite make_conj_cons. 
@@ -263,7 +263,7 @@ Set Implicit Arguments.
   Proof.
     induction cl.
     simpl. tauto.
-    intros until 0.
+    intros *.
     simpl.
     assert (HH := add_term_correct env a cl').
     case_eq (add_term a cl').

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -1102,7 +1102,13 @@ let msg_quantified_hypothesis = function
       pr_nth n ++
       str " non dependent hypothesis"
 
+let warn_deprecated_intros_until_0 =
+  CWarnings.create ~name:"deprecated-intros-until-0" ~category:"tactics"
+    (fun () ->
+       strbrk"\"intros until 0\" is deprecated, use \"intros *\"; instead of \"induction 0\" and \"destruct 0\" use explicitly a name.\"")
+
 let depth_of_quantified_hypothesis red h gl =
+  if h = AnonHyp 0 then warn_deprecated_intros_until_0 ();
   match lookup_hypothesis_as_renamed_gen red h gl with
     | Some depth -> depth
     | None ->


### PR DESCRIPTION
Who knows `intros until 0`? Who knows that `induction 0` is doing induction on the last variable before a non-dependent product? I did not remember it existed. This is a hack in `Detyping.lookup_quantified_hypothesis_as_displayed` which I'm proposing to remove since the (compositional) introduction pattern `*` is more general.

This PR adds a deprecation warning with the objective to eventually remove this undocumented feature.

**Kind:** infrastructure / cleaning.

Side question: Since the code for `until` already exists, this actually suggests that `until n` could be generalized into an introduction pattern usable at any place where a (core) introduction pattern is expected. The worry is the space between `until` and `n`, while the space is already the default separator for list of introduction patterns, but assuming that we have another syntax for it, would that make sense? (The question of course includes Quill's people if ever they feel interested.)
