### PR TITLE
Adding tclBINDFIRST/tclBINDLAST, generalizing type of tclTHENFIRST/tclTHENLAST, informative version of shelve unifiable

### DIFF
--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -1041,6 +1041,8 @@ module Unsafe = struct
 
   let advance = Evarutil.advance
 
+  let undefined = undefined
+
   let mark_as_unresolvable p gl =
     { p with solution = mark_in_evm ~goal:false p.solution gl }
 

--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -710,13 +710,19 @@ let partition_unifiable sigma l =
 (** Shelves the unifiable goals under focus, i.e. the goals which
     appear in other goals under focus (the unfocused goals are not
     considered). *)
-let shelve_unifiable =
+let shelve_unifiable_informative =
   let open Proof in
   Pv.get >>= fun initial ->
   let (u,n) = partition_unifiable initial.solution initial.comb in
   Comb.set n >>
   InfoL.leaf (Info.Tactic (fun () -> Pp.str"shelve_unifiable")) >>
-  Shelf.modify (fun gls -> gls @ CList.map drop_state u)
+  let u = CList.map drop_state u in
+  Shelf.modify (fun gls -> gls @ u) >>
+  tclUNIT u
+
+let shelve_unifiable =
+  let open Proof in
+  shelve_unifiable_informative >>= fun _ -> tclUNIT ()
 
 (** [guard_no_unifiable] returns the list of unifiable goals if some
     goals are unifiable (see {!shelve_unifiable}) in the current focus. *)

--- a/engine/proofview.mli
+++ b/engine/proofview.mli
@@ -326,6 +326,9 @@ val unifiable : Evd.evar_map -> Evar.t -> Evar.t list -> bool
     considered). *)
 val shelve_unifiable : unit tactic
 
+(** Idem but also returns the list of shelved variables *)
+val shelve_unifiable_informative : Evar.t list tactic
+
 (** [guard_no_unifiable] returns the list of unifiable goals if some
     goals are unifiable (see {!shelve_unifiable}) in the current focus. *)
 val guard_no_unifiable : Names.Name.t list option tactic

--- a/engine/proofview.mli
+++ b/engine/proofview.mli
@@ -469,6 +469,12 @@ module Unsafe : sig
       solved. *)
   val advance : Evd.evar_map -> Evar.t -> Evar.t option
 
+  (** [undefined sigma l] applies [advance] to the goals of [l], then
+      returns the subset of resulting goals which have not yet been
+      defined *)
+  val undefined : Evd.evar_map -> Proofview_monad.goal_with_state list ->
+    Proofview_monad.goal_with_state list
+
   val typeclass_resolvable : unit Evd.Store.field
 
 end

--- a/tactics/tacticals.mli
+++ b/tactics/tacticals.mli
@@ -196,8 +196,10 @@ module New : sig
   (** [tclTHENFIRST tac1 tac2 gls] applies the tactic [tac1] to [gls]
       and [tac2] to the first resulting subgoal *)
   val tclTHENFIRST : unit tactic -> unit tactic -> unit tactic
+  val tclBINDFIRST : 'a tactic -> ('a -> 'b tactic) -> 'b tactic
   val tclTHENLASTn : unit tactic -> unit tactic array -> unit tactic
   val tclTHENLAST  : unit tactic -> unit tactic -> unit tactic
+  val tclBINDLAST  : 'a tactic -> ('a -> 'b tactic) -> 'b tactic
   (* [tclTHENS t l = t <*> tclDISPATCH l] *)
   val tclTHENS : unit tactic -> unit tactic list -> unit tactic
   (* [tclTHENLIST [t1;…;tn]] is [t1<*>…<*>tn] *)


### PR DESCRIPTION
This provides the following addition / generalization:
```
val tclTHENFIRST : unit tactic -> 'a tactic -> 'a tactic
val tclBINDFIRST : 'a tactic -> ('a -> 'b tactic) -> 'b tactic
val tclTHENLAST  : unit tactic -> 'a tactic -> 'a tactic
val tclBINDLAST  : 'a tactic -> ('a -> 'b tactic) -> 'b tactic
val shelve_unifiable_informative : Evar.t list tactic
```
Is there already a canonical naming scheme for variants of tactics which returns extra information?

Or, maybe should `shelve_unifiable_informative` just be the replacement of `shelve_unifiable` (but I'm afraid that this raises incompatibilities). 

Thanks to @ppedrot for his help. Any opinion on naming scheme @aspiwack?

**Kind:** infrastructure.

- [ ] Maybe an entry in changes.txt?