### PR TITLE
Selection of occurrences of indices now using pattern-matching in `destruct`/`induction`

### DIFF
--- a/interp/constrexpr_ops.ml
+++ b/interp/constrexpr_ops.ml
@@ -366,6 +366,14 @@ let free_vars_of_constr_expr c =
     | c -> fold_constr_expr_with_binders (fun a l -> a::l) aux bdvars l c
   in aux [] Id.Set.empty c
 
+let free_names_of_constr_expr c =
+  let vars = ref Id.Set.empty in
+  let rec aux () () = function
+    | { CAst.v = CRef (qid, _) } when qualid_is_ident qid ->
+      let id = qualid_basename qid in vars := Id.Set.add id !vars
+    | c -> fold_constr_expr_with_binders (fun a () -> vars := Id.Set.add a !vars) aux () () c
+  in aux () () c; !vars
+
 let occur_var_constr_expr id c = Id.Set.mem id (free_vars_of_constr_expr c)
 
 (* Used in correctness and interface *)

--- a/interp/constrexpr_ops.mli
+++ b/interp/constrexpr_ops.mli
@@ -119,6 +119,9 @@ val ids_of_cases_indtype : cases_pattern_expr -> Id.Set.t
 val free_vars_of_constr_expr : constr_expr -> Id.Set.t
 val occur_var_constr_expr : Id.t -> constr_expr -> bool
 
+(** Return all names treating binders as names *)
+val free_names_of_constr_expr : constr_expr -> Id.Set.t
+
 val split_at_annot : local_binder_expr list -> lident option -> local_binder_expr list * local_binder_expr list
 
 val ntn_loc : ?loc:Loc.t -> constr_notation_substitution -> notation -> (int * int) list

--- a/test-suite/bugs/closed/bug_9229.v
+++ b/test-suite/bugs/closed/bug_9229.v
@@ -1,0 +1,6 @@
+(* There was a problem of freshness with Infix choice of vars *)
+
+(* In particular, x and y were special... *)
+
+Infix "#" := (fun x y => x + y) (at level 50, left associativity).
+Check (3 # 5).

--- a/test-suite/success/destruct.v
+++ b/test-suite/success/destruct.v
@@ -437,3 +437,12 @@ intro H.
 destruct (H (fun x => True)).
 match goal with |- True => idtac end.
 Abort.
+
+(* Basic support for unification on the indices of the inductive type *)
+
+Goal forall x y , (forall y, x < S y) -> x = S y -> x = S y.
+intros.
+destruct H.
+- exact H0.
+-
+Show.

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -1563,14 +1563,17 @@ let add_notation_extra_printing_rule df k v =
 
 (* Infix notations *)
 
-let inject_var x = CAst.make @@ CRef (qualid_of_ident (Id.of_string x),None)
+let inject_var x = CAst.make @@ CRef (qualid_of_ident x,None)
 
 let add_infix local env ({CAst.loc;v=inf},modifiers) pr sc =
   check_infix_modifiers modifiers;
   (* check the precedence *)
-  let metas = [inject_var "x"; inject_var "y"] in
+  let vars = free_names_of_constr_expr pr in
+  let x = Namegen.next_ident_away (Id.of_string "x") vars in
+  let y = Namegen.next_ident_away (Id.of_string "y") vars in
+  let metas = [inject_var x; inject_var y] in
   let c = mkAppC (pr,metas) in
-  let df = CAst.make ?loc @@ "x "^(quote_notation_token inf)^" y" in
+  let df = CAst.make ?loc @@ Id.to_string x ^" "^(quote_notation_token inf)^" "^Id.to_string y in
   add_notation local env c (df,modifiers) sc
 
 (**********************************************************************)


### PR DESCRIPTION
**Kind:** feature; depends on #6844.

This is an exploration towards making `destruct`/`induction`/`edestruct`/`einduction` succeeds more often by using pattern-matching on indices to find instances for the variables of the lemma. A typical example targetted by this PR is:
```coq
Goal forall x y , (forall y, x < S y) -> x = S (S y) -> x = y.
intros.
destruct H.
```
I however wonder whether this may be either too strong or too weak but not the right level. When several subterms match, the default (by consistency with what is done for the main term on which `destruct` is applied) is to consider the one occurring in the most ancient hypothesis is taken (other strategies could be possible, like failing if several subterm matching syntactically are found; or, using subterm selection up to conversion, or up to inner conversion).

This is in the direction of making `destruct` stronger in interactive mode. In the context of developping bricks for a tactic programming language, this would probably too strong and too difficult to control (compared to providing a language of primitive functions for subterm selection).

This is nothing compared to what an ideal extension of `destruct` could do, being able to invert automatically variables which can be so, as in
```coq
Goal forall x y , (forall y, x < S y) -> x = S y -> x = y.
intros; destruct H.
```
where we could detect that the second `y` can be rewritten as `pred (S y)` so that a most general unifier taken into account all occurrences of `y` can be found. In this sense, this PR is probably not good enough. (Neither `dependent destruction` nor `inversion` seem to be able to do that straightforwardly either.)

This change impacts `dependent destruction` since it calls `destruct`.

Wondering about the opinion of users.

Wondering about the compatibility with existing developments.

Wondering about similar works in this direction.

- [ ] Documentation: wondering whether this is the right time to document this level of details. I'm a bit reticent a priori.
- [ ] Probably needs a note in CHANGES so that users confrounted to an incompatibility can understand from where it comes


