### PR TITLE
Add a comment on EConstr.to_constr regarding evar-freeness.

### DIFF
--- a/engine/eConstr.mli
+++ b/engine/eConstr.mli
@@ -67,7 +67,10 @@ val kind : Evd.evar_map -> t -> (t, t, ESorts.t, EInstance.t) Constr.kind_of_ter
 val kind_upto : Evd.evar_map -> Constr.t -> (Constr.t, Constr.t, Sorts.t, Univ.Instance.t) Constr.kind_of_term
 
 val to_constr : Evd.evar_map -> t -> Constr.t
-(** Returns the evar-normal form of the argument. See {!Evarutil.nf_evar}. *)
+(** Returns the evar-normal form of the argument, and cast it as a theoretically
+    evar-free term. In practice this function does not check that the result
+    is actually evar-free, it is currently the duty of the caller to do so.
+    This might change in the future. *)
 
 val kind_of_type : Evd.evar_map -> t -> (t, t) Term.kind_of_type
 


### PR DESCRIPTION
This mitigates #6308, as asked during the WG.