### PR TITLE
Slight improvement of messages related to direct and indirect uses of tactic `clear`.

### DIFF
--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -224,7 +224,7 @@ type clear_dependency_error =
 | OccurHypInSimpleClause of Id.t option
 | EvarTypingBreak of Constr.existential
 
-exception ClearDependencyError of Id.t * clear_dependency_error
+exception ClearDependencyError of Id.t * clear_dependency_error * Globnames.global_reference option
 
 val clear_hyps_in_evi : env -> evar_map ref -> named_context_val -> types ->
   Id.Set.t -> named_context_val * types


### PR DESCRIPTION
**Kind:** local enhancement

This is part 3 and 4 of #6826 and #6833:

3. Improving error message when asking to clear a section hypothesis implicitly dependent in a definition of the section
4. Warning when destruct/induction cannot remove a section hypothesis because it is dependent in a definition of the section

An example of 3. is the change of error message in the following case:
```coq
Section A. Variable a:nat. Definition b:=a=a.
Goal b=b. clear a.
(* before: a is used in conclusion *)
(* after: a is used implicitly in b in conclusion *)
```
An example of 4. is the warning in the following case:
```coq
Section A. Variable a:nat. Definition b:=a=a.
Goal b=b. destruct a.
(* Cannot remove a, it is used implicitly in b *)
```


