### PR TITLE
[ide] Don't set `quiet` on start.

### DIFF
--- a/ide/ide_slave.ml
+++ b/ide/ide_slave.ml
@@ -508,7 +508,6 @@ let rec parse = function
 
 let () = Coqtop.toploop_init := (fun coq_args extra_args ->
         let args = parse extra_args in
-        Flags.quiet := true;
         CoqworkmgrApi.(init High);
         coq_args, args)
 


### PR DESCRIPTION
This makes `coqidetop` behavior consistent with the one of
`coqtop`.

This was likely needed in the past when Coq used to print all kind of
stuff to stdout, including goal display. Now, it is not the case
anymore and this flag mainly controls printing verbosity.
