### PR TITLE
[build] Simpler byte/opt toplevel build.

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -386,21 +386,16 @@ coqbinaries: $(COQTOPEXE) $(CHICKEN) $(CSDPCERT) $(FAKEIDE)
 
 coqbyte: $(COQTOPBYTE) $(CHICKENBYTE)
 
-COQTOP_OPT_MLTOP=toplevel/coqtop_opt_bin.cmx
-COQTOP_BYTE_MLTOP=toplevel/coqtop_byte_bin.cmo
-
-$(COQTOP_BYTE_MLTOP): toplevel/coqtop_byte_bin.ml
-	$(SHOW)'OCAMLC    $<'
-	$(HIDE)$(OCAMLC) $(MLINCLUDES) $(BYTEFLAGS) -package compiler-libs.toplevel -c $<
+COQTOP_OPT=toplevel/coqtop_opt_bin.ml
+COQTOP_BYTE=toplevel/coqtop_byte_bin.ml
 
 ifeq ($(BEST),opt)
-$(COQTOPEXE): $(LINKCMX) $(LIBCOQRUN) $(TOPLOOPCMA:.cma=.cmxs) $(COQTOP_OPT_MLTOP)
+$(COQTOPEXE): $(LINKCMX) $(LIBCOQRUN) $(TOPLOOPCMA:.cma=.cmxs) $(COQTOP_OPT)
 	$(SHOW)'COQMKTOP -o $@'
-	$(HIDE)$(OCAMLOPT) -linkall -linkpkg -I toplevel \
+	$(HIDE)$(OCAMLOPT) -linkall -linkpkg -I vernac -I toplevel \
 	                   -I kernel/byterun/ -cclib -lcoqrun \
-                           $(SYSMOD) -package camlp5.gramlib \
-	                   $(LINKCMX) $(OPTFLAGS) $(LINKMETADATA) \
-	                   $(COQTOP_OPT_MLTOP) toplevel/coqtop_bin.ml -o $@
+			   $(SYSMOD) -package camlp5.gramlib \
+			   $(LINKCMX) $(OPTFLAGS) $(LINKMETADATA) $(COQTOP_OPT) -o $@
 	$(STRIP) $@
 	$(CODESIGN) $@
 else
@@ -409,13 +404,12 @@ $(COQTOPEXE): $(COQTOPBYTE)
 endif
 
 # VMBYTEFLAGS will either contain -custom of the right -dllpath for the VM
-$(COQTOPBYTE): $(LINKCMO) $(LIBCOQRUN) $(TOPLOOPCMA) $(COQTOP_BYTE_MLTOP)
+$(COQTOPBYTE): $(LINKCMO) $(LIBCOQRUN) $(TOPLOOPCMA) $(COQTOP_BYTE)
 	$(SHOW)'COQMKTOP -o $@'
-	$(HIDE)$(OCAMLC) -linkall -linkpkg -I toplevel \
+	$(HIDE)$(OCAMLC) -linkall -linkpkg -I lib -I vernac -I toplevel \
 	                 -I kernel/byterun/ -cclib -lcoqrun $(VMBYTEFLAGS) \
-                         $(SYSMOD) -package camlp5.gramlib,compiler-libs.toplevel \
-	                 $(LINKCMO) $(BYTEFLAGS) \
-	                 $(COQTOP_BYTE_MLTOP) toplevel/coqtop_bin.ml -o $@
+			 $(SYSMOD) -package camlp5.gramlib,compiler-libs.toplevel \
+			 $(LINKCMO) $(BYTEFLAGS) $(COQTOP_BYTE) -o $@
 
 # For coqc
 COQCCMO:=clib/clib.cma lib/lib.cma toplevel/usage.cmo tools/coqc.cmo

--- a/toplevel/coqtop_bin.ml
+++ b/toplevel/coqtop_bin.ml
@@ -1,2 +1,0 @@
-(* Main coqtop initialization *)
-let () = Coqtop.start()

--- a/toplevel/coqtop_byte_bin.ml
+++ b/toplevel/coqtop_byte_bin.ml
@@ -1,3 +1,13 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *   INRIA, CNRS and contributors - Copyright 1999-2018       *)
+(* <O___,, *       (see CREDITS file for the list of authors)           *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
 let drop_setup () =
   begin try
     (* Enable rectypes in the toplevel if it has the directive #rectypes *)
@@ -18,4 +28,7 @@ let drop_setup () =
              ml_loop  = (fun () -> Toploop.loop ppf);
            })
 
-let _ = drop_setup ()
+(* Main coqtop initialization *)
+let _ =
+  drop_setup ();
+  Coqtop.start()

--- a/toplevel/coqtop_opt_bin.ml
+++ b/toplevel/coqtop_opt_bin.ml
@@ -1,3 +1,16 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *   INRIA, CNRS and contributors - Copyright 1999-2018       *)
+(* <O___,, *       (see CREDITS file for the list of authors)           *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
 let drop_setup () = Mltop.remove ()
 
-let _ = drop_setup ()
+(* Main coqtop initialization *)
+let _ =
+  drop_setup ();
+  Coqtop.start()


### PR DESCRIPTION
Instead of playing static linking games, we just ship two different
top-level files depending on whether we want to enable `Drop` support
[bytecode case] or not.

The savings of the old approach [1 line of code] were not worth the
complexities of the linking hack.