### PR TITLE
[toplevel] Update state when `Drop` exception is thrown [#6872]

### DIFF
--- a/dev/base_include
+++ b/dev/base_include
@@ -229,7 +229,7 @@ let _ = Flags.in_toplevel := true
 let _ = Constrextern.set_extern_reference
   (fun ?loc _ r -> Libnames.Qualid (loc,Nametab.shortest_qualid_of_global Id.Set.empty r));;
 
-let go () = Coqloop.loop ~time:false ~state:Option.(get !Coqtop.drop_last_doc)
+let go () = Coqloop.loop ~time:false ~state:Option.(get !Coqloop.drop_last_doc)
 
 let _ =
  print_string

--- a/toplevel/coqloop.mli
+++ b/toplevel/coqloop.mli
@@ -35,3 +35,6 @@ val do_vernac : time:bool -> state:Vernac.State.t -> Vernac.State.t
 
 (** Main entry point of Coq: read and execute vernac commands. *)
 val loop : time:bool -> state:Vernac.State.t -> Vernac.State.t
+
+(** Last document seen after `Drop` *)
+val drop_last_doc : Vernac.State.t option ref

--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -34,7 +34,6 @@ let warning s = Flags.(with_option warn Feedback.msg_warning (strbrk s))
    will not be generally be initialized, thus stateid, etc... may be
    bogus. For now we just print to the console too *)
 let coqtop_init_feed = Coqloop.coqloop_feed
-let drop_last_doc = ref None
 
 (* Default toplevel loop *)
 let console_toploop_run opts ~state =
@@ -44,9 +43,8 @@ let console_toploop_run opts ~state =
     Flags.if_verbose warning "Dumpglob cannot be used in interactive mode.";
     Dumpglob.noglob ()
   end;
-  let state = Coqloop.loop ~time:opts.time ~state in
+  let _ = Coqloop.loop ~time:opts.time ~state in
   (* Initialise and launch the Ocaml toplevel *)
-  drop_last_doc := Some state;
   Coqinit.init_ocaml_path();
   Mltop.ocaml_toploop();
   (* We let the feeder in place for users of Drop *)

--- a/toplevel/coqtop.mli
+++ b/toplevel/coqtop.mli
@@ -15,9 +15,6 @@ val init_toplevel : string list -> Vernac.State.t option * Coqargs.coq_cmdopts
 
 val start : unit -> unit
 
-(* Last document seen after `Drop` *)
-val drop_last_doc : Vernac.State.t option ref
-
 (* For other toploops *)
 val toploop_init : (Coqargs.coq_cmdopts -> string list -> string list) ref
 val toploop_run : (Coqargs.coq_cmdopts -> state:Vernac.State.t -> unit) ref


### PR DESCRIPTION
`Drop` is implemented using exceptions-as-control flow, so the
toplevel state gets corrupted as `do_vernac` will never return when
`Drop` appears.

The right fix would be to remove `Drop` from the vernacular and make
it a toplevel-only command, but meanwhile we can just patch the state
in the exception handler.

Fixes #6872.
