### PR TITLE
Unify Const_sorts and Const_type, and remove Vsort

### DIFF
--- a/dev/vm_printers.ml
+++ b/dev/vm_printers.ml
@@ -61,7 +61,7 @@ and ppstack s =
 and ppatom a =
   match a with
   | Aid idk -> print_idkey idk
-  | Atype u -> print_string "Type(...)"
+  | Asort u -> print_string "Sort(...)"
   | Aind(sp,i) ->  print_string "Ind(";
       print_string (MutInd.to_string sp);
       print_string ","; print_int i;
@@ -69,7 +69,6 @@ and ppatom a =
 
 and ppwhd whd =
   match whd with
-  | Vsort s -> ppsort s
   | Vprod _ -> print_string "product"
   | Vfun _ -> print_string "function"
   | Vfix _ -> print_vfix()

--- a/kernel/cbytecodes.mli
+++ b/kernel/cbytecodes.mli
@@ -26,13 +26,12 @@ val cofix_evaluated_tag : tag
 val last_variant_tag : tag
 
 type structured_constant =
-  | Const_sorts of Sorts.t
+  | Const_sort of Sorts.t
   | Const_ind of inductive
   | Const_proj of Constant.t
   | Const_b0 of tag
   | Const_bn of tag * structured_constant array
   | Const_univ_level of Univ.Level.t
-  | Const_type of Univ.Universe.t
 
 val pp_struct_const : structured_constant -> Pp.t
 

--- a/kernel/cbytegen.ml
+++ b/kernel/cbytegen.ml
@@ -480,23 +480,23 @@ let rec compile_lam env reloc lam sz cont =
         (Const_ind ind) (Univ.Instance.to_array u) sz cont
 
   | Lsort (Sorts.Prop _ as s) ->
-    compile_structured_constant reloc (Const_sorts s) sz cont
+    compile_structured_constant reloc (Const_sort s) sz cont
   | Lsort (Sorts.Type u) ->
-     (* We separate global and local universes in [u]. The former will be part
-        of the structured constant, while the later (if any) will be applied as
-        arguments. *)
-     let open Univ in begin
+    (* We separate global and local universes in [u]. The former will be part
+       of the structured constant, while the later (if any) will be applied as
+       arguments. *)
+    let open Univ in begin
       let u,s = Universe.compact u in
       (* We assume that [Universe.type0m] is a neutral element for [Universe.sup] *)
+      let compile_get_univ reloc idx sz cont =
+        set_max_stack_size sz;
+        compile_fv_elem reloc (FVuniv_var idx) sz cont
+      in
       if List.is_empty s then
-        compile_structured_constant reloc (Const_sorts (Sorts.Type u)) sz cont
+        compile_structured_constant reloc (Const_sort (Sorts.Type u)) sz cont
       else
-	let compile_get_univ reloc idx sz cont =
-          set_max_stack_size sz;
-	  compile_fv_elem reloc (FVuniv_var idx) sz cont
-	in
         comp_app compile_structured_constant compile_get_univ reloc
-          (Const_type u) (Array.of_list s) sz cont
+        (Const_sort (Sorts.Type u)) (Array.of_list s) sz cont
     end
 
   | Llet (id,def,body) ->

--- a/kernel/cemitcodes.ml
+++ b/kernel/cemitcodes.ml
@@ -350,7 +350,7 @@ type to_patch = emitcodes * patches * fv
 (* Substitution *)
 let rec subst_strcst s sc =
   match sc with
-  | Const_sorts _ | Const_b0 _ | Const_univ_level _ | Const_type _ -> sc
+  | Const_sort _ | Const_b0 _ | Const_univ_level _ -> sc
   | Const_proj p -> Const_proj (subst_constant s p)
   | Const_bn(tag,args) -> Const_bn(tag,Array.map (subst_strcst s) args)
   | Const_ind ind -> let kn,i = ind in Const_ind (subst_mind s kn, i)

--- a/kernel/vconv.ml
+++ b/kernel/vconv.ml
@@ -44,7 +44,6 @@ let rec conv_val env pb k v1 v2 cu =
 and conv_whd env pb k whd1 whd2 cu =
 (*  Pp.(msg_debug (str "conv_whd(" ++ pr_whd whd1 ++ str ", " ++ pr_whd whd2 ++ str ")")) ; *)
   match whd1, whd2 with
-  | Vsort s1, Vsort s2 -> sort_cmp_universes env pb s1 s2 cu
   | Vuniv_level _ , _
   | _ , Vuniv_level _ ->
     (** Both of these are invalid since universes are handled via
@@ -81,7 +80,7 @@ and conv_whd env pb k whd1 whd2 cu =
      (* on the fly eta expansion *)
       conv_val env CONV (k+1) (apply_whd k whd1) (apply_whd k whd2) cu
 
-  | Vsort _, _ | Vprod _, _ | Vfix _, _ | Vcofix _, _  | Vconstr_const _, _
+  | Vprod _, _ | Vfix _, _ | Vcofix _, _  | Vconstr_const _, _
   | Vconstr_block _, _ | Vatom_stk _, _ -> raise NotConvertible
 
 
@@ -119,8 +118,9 @@ and conv_atom env pb k a1 stk1 a2 stk2 cu =
     if Vars.eq_id_key ik1 ik2 && compare_stack stk1 stk2 then
 	conv_stack env k stk1 stk2 cu
       else raise NotConvertible
-  | Atype _ , _ | _, Atype _ -> assert false
-  | Aind _, _ | Aid _, _ -> raise NotConvertible
+  | Asort s1, Asort s2 ->
+    sort_cmp_universes env pb s1 s2 cu
+  | Asort _ , _ | Aind _, _ | Aid _, _ -> raise NotConvertible
 
 and conv_stack env k stk1 stk2 cu =
   match stk1, stk2 with

--- a/kernel/vm.ml
+++ b/kernel/vm.ml
@@ -168,7 +168,7 @@ let rec apply_stack a stk v =
 let apply_whd k whd =
   let v = val_of_rel k in
   match whd with
-  | Vsort _ | Vprod _ | Vconstr_const _ | Vconstr_block _ -> assert false
+  | Vprod _ | Vconstr_const _ | Vconstr_block _ -> assert false
   | Vfun f -> reduce_fun k f
   | Vfix(f, None) -> 
       push_ra stop;

--- a/kernel/vmvalues.mli
+++ b/kernel/vmvalues.mli
@@ -57,7 +57,7 @@ val cofix_upd_code : to_update -> tcode
 type atom =
   | Aid of Vars.id_key
   | Aind of inductive
-  | Atype of Univ.Universe.t
+  | Asort of Sorts.t
 
 (** Zippers *)
 
@@ -70,7 +70,6 @@ type zipper =
 type stack = zipper list
 
 type whd =
-  | Vsort of Sorts.t
   | Vprod of vprod
   | Vfun of vfun
   | Vfix of vfix * arguments option

--- a/pretyping/vnorm.ml
+++ b/pretyping/vnorm.ml
@@ -141,7 +141,6 @@ and nf_vtype env sigma v =  nf_val env sigma v crazy_type
 
 and nf_whd env sigma whd typ =
   match whd with
-  | Vsort s -> mkSort s
   | Vprod p ->
       let dom = nf_vtype env sigma (dom p) in
       let name = Name (Id.of_string "x") in
@@ -182,7 +181,8 @@ and nf_whd env sigma whd typ =
        let pind = (ind, u) in (mkIndU pind, type_of_ind env pind)
      in
      nf_univ_args ~nb_univs mk env sigma stk
-  | Vatom_stk(Atype u, stk) -> assert false
+  | Vatom_stk(Asort s, stk) ->
+    assert (List.is_empty stk); mkSort s
   | Vuniv_level lvl ->
     assert false
 


### PR DESCRIPTION
This simplifies the representation of values, and brings it closer to
the ones of the native compiler.

Should be benchmarked because in theory it could have some cost.

Depends on #6827 [edit: no longer the case]