### PR TITLE
Fix #6878: univ undefined for [with Definition] bad instance size.

### DIFF
--- a/kernel/uGraph.ml
+++ b/kernel/uGraph.ml
@@ -833,7 +833,7 @@ let sort_universes g =
 (** Subtyping of polymorphic contexts *)
 
 let check_subtype univs ctxT ctx =
-  if AUContext.size ctx == AUContext.size ctx then
+  if AUContext.size ctxT == AUContext.size ctx then
     let (inst, cst) = UContext.dest (AUContext.repr ctx) in
     let cstT = UContext.constraints (AUContext.repr ctxT) in
     let push accu v = add_universe v false accu in

--- a/test-suite/bugs/closed/6878.v
+++ b/test-suite/bugs/closed/6878.v
@@ -1,0 +1,8 @@
+
+Set Universe Polymorphism.
+Module Type T.
+  Axiom foo : Prop.
+End T.
+
+(** Used to anomaly *)
+Fail Module M : T with Definition foo := Type.


### PR DESCRIPTION
Just a silly typo.

Note that checking subtyping in the regular path (ie `Module M : T. Definition foo := Type. End M.`) guards the check_subtype call with a check on instance lengths, so this bug is only with `with Definition`.