### PR TITLE
[stm] Partial fix for bug #6884 [location missing from replay nodes]

### DIFF
--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -2949,6 +2949,7 @@ let get_ast ~doc id =
   match VCS.visit id with
   | { step = `Cmd { cast = { loc; expr } } }
   | { step = `Fork (({ loc; expr }, _, _, _), _) }
+  | { step = `Sideff ((ReplayCommand {loc; expr}) , _) }
   | { step = `Qed ({ qast = { loc; expr } }, _) } ->
          Some (Loc.tag ?loc expr)
   | _ -> None


### PR DESCRIPTION
Example not yet fixed by this patch:
```coq
Definition u : Type.
  Definition m : Type.
    exact nat.
  Defined.
  exact bool.
Defined.
```
