### PR TITLE
[v8.7] [stm] Partial fix for bug #6884 [location missing from replay nodes]

### DIFF
--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -2672,6 +2672,7 @@ let get_ast id =
   match VCS.visit id with
   | { step = `Cmd { cast = { loc; expr } } }
   | { step = `Fork (({ loc; expr }, _, _, _), _) } 
+  | { step = `Sideff ((ReplayCommand {loc; expr}) , _) }
   | { step = `Qed ({ qast = { loc; expr } }, _) } ->
          Some (Loc.tag ?loc expr)
   | _ -> None


### PR DESCRIPTION
Backport of: https://github.com/coq/coq/pull/6885

Merging would be useful as some 8.7 users may want to build from git to avoid this problem.