### PR TITLE
Fix make ml-doc

### DIFF
--- a/Makefile.doc
+++ b/Makefile.doc
@@ -385,11 +385,18 @@ install-doc-index-urls:
 # Documentation of the source code (using ocamldoc)
 ###########################################################################
 
+# To skip building docs for plugins and build docs for core only, set this
+# variable to 1 (or any non-empty value):
+NOPLUGINDOCS ?=
+
 OCAMLDOCDIR=dev/ocamldoc
 
-DOCMLS=$(foreach lib,$(CORECMA:.cma=_MLLIB_DEPENDENCIES),$(addsuffix .ml, $($(lib))))
+DOCMLLIBS=$(if $(NOPLUGINDOCS), \
+		  $(CORECMA:.cma=_MLLIB_DEPENDENCIES), \
+		  $(CORECMA:.cma=_MLLIB_DEPENDENCIES) $(PLUGINSCMO:.cmo=_MLPACK_DEPENDENCIES))
+DOCMLS=$(foreach lib,$(DOCMLLIBS),$(addsuffix .ml, $($(lib))))
 
-DOCMLIS=$(wildcard $(addsuffix /*.mli, $(CORESRCDIRS)))
+DOCMLIS=$(wildcard $(addsuffix /*.mli, $(if $(NOPLUGINDOCS),$(CORESRCDIRS),$(SRCDIRS))))
 
 # Defining options to generate dependencies graphs
 DOT=dot

--- a/Makefile.doc
+++ b/Makefile.doc
@@ -387,10 +387,9 @@ install-doc-index-urls:
 
 OCAMLDOCDIR=dev/ocamldoc
 
-DOCMLIS=$(wildcard ./lib/*.mli ./intf/*.mli ./kernel/*.mli ./library/*.mli \
-	./engine/*.mli ./pretyping/*.mli ./interp/*.mli printing/*.mli \
-	./parsing/*.mli ./proofs/*.mli \
-	./tactics/*.mli ./stm/*.mli ./toplevel/*.mli ./ltac/*.mli)
+DOCMLS=$(foreach lib,$(CORECMA:.cma=_MLLIB_DEPENDENCIES),$(addsuffix .ml, $($(lib))))
+
+DOCMLIS=$(wildcard $(addsuffix /*.mli, $(CORESRCDIRS)))
 
 # Defining options to generate dependencies graphs
 DOT=dot
@@ -434,7 +433,7 @@ OCAMLDOC_MLLIBD = $(OCAMLFIND) ocamldoc -rectypes $(MLINCLUDES) $(ODOCDOTOPTS) -
 	$(OCAMLDOC_MLLIBD)
 
 ml-doc:
-	$(OCAMLFIND) ocamldoc -charset utf-8 -html -rectypes -I +threads $(MLINCLUDES) $(COQIDEFLAGS) -d $(OCAMLDOCDIR) $(MLSTATICFILES)
+	$(OCAMLFIND) ocamldoc -charset utf-8 -html -rectypes -I +threads $(MLINCLUDES) $(COQIDEFLAGS) -d $(OCAMLDOCDIR) $(DOCMLS)
 
 parsing/parsing.dot : | parsing/parsing.mllib.d
 	$(OCAMLDOC_MLLIBD)

--- a/Makefile.doc
+++ b/Makefile.doc
@@ -385,18 +385,12 @@ install-doc-index-urls:
 # Documentation of the source code (using ocamldoc)
 ###########################################################################
 
-# To skip building docs for plugins and build docs for core only, set this
-# variable to 1 (or any non-empty value):
-NOPLUGINDOCS ?=
-
 OCAMLDOCDIR=dev/ocamldoc
 
-DOCMLLIBS=$(if $(NOPLUGINDOCS), \
-		  $(CORECMA:.cma=_MLLIB_DEPENDENCIES), \
-		  $(CORECMA:.cma=_MLLIB_DEPENDENCIES) $(PLUGINSCMO:.cmo=_MLPACK_DEPENDENCIES))
+DOCMLLIBS= $(CORECMA:.cma=_MLLIB_DEPENDENCIES) $(PLUGINSCMO:.cmo=_MLPACK_DEPENDENCIES)
 DOCMLS=$(foreach lib,$(DOCMLLIBS),$(addsuffix .ml, $($(lib))))
 
-DOCMLIS=$(wildcard $(addsuffix /*.mli, $(if $(NOPLUGINDOCS),$(CORESRCDIRS),$(SRCDIRS))))
+DOCMLIS=$(wildcard $(addsuffix /*.mli, $(SRCDIRS)))
 
 # Defining options to generate dependencies graphs
 DOT=dot

--- a/Makefile.doc
+++ b/Makefile.doc
@@ -433,7 +433,12 @@ OCAMLDOC_MLLIBD = $(OCAMLFIND) ocamldoc -rectypes $(MLINCLUDES) $(ODOCDOTOPTS) -
 	$(OCAMLDOC_MLLIBD)
 
 ml-doc:
-	$(OCAMLFIND) ocamldoc -charset utf-8 -html -rectypes -I +threads $(MLINCLUDES) $(COQIDEFLAGS) -d $(OCAMLDOCDIR) $(DOCMLS)
+	$(SHOW)'OCAMLDOC -html'
+	$(HIDE)mkdir -p $(OCAMLDOCDIR)/html/implementation
+	$(HIDE)$(OCAMLFIND) ocamldoc -charset utf-8 -html -rectypes -I +threads $(MLINCLUDES) $(COQIDEFLAGS) \
+	$(DOCMLS) -d $(OCAMLDOCDIR)/html/implementation -colorize-code \
+	-t "Coq mls documentation" \
+	-css-style ../style.css
 
 parsing/parsing.dot : | parsing/parsing.mllib.d
 	$(OCAMLDOC_MLLIBD)

--- a/checker/univ.mli
+++ b/checker/univ.mli
@@ -84,7 +84,7 @@ val check_eq : universe check_function
 val initial_universes : universes
 
 (** Adds a universe to the graph, ensuring it is >= or > Set.
-   @raises AlreadyDeclared if the level is already declared in the graph. *)
+   @raise AlreadyDeclared if the level is already declared in the graph. *)
 
 exception AlreadyDeclared
 

--- a/clib/option.ml
+++ b/clib/option.ml
@@ -44,7 +44,7 @@ let hash f = function
 exception IsNone
 
 (** [get x] returns [y] where [x] is [Some y].
-    @raise [IsNone] if [x] equals [None]. *)
+    @raise IsNone if [x] equals [None]. *)
 let get = function
   | Some y -> y
   | _ -> raise IsNone

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -321,7 +321,7 @@ exception UniversesDiffer
 val add_universe_constraints : evar_map -> Universes.Constraints.t -> evar_map
 (** Add the given universe unification constraints to the evar map.
     @raise UniversesDiffer in case a first-order unification fails.
-    @raise UniverseInconsistency
+    @raise UniverseInconsistency .
 *)
 
 (** {5 Extra data}

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -320,8 +320,8 @@ exception UniversesDiffer
 
 val add_universe_constraints : evar_map -> Universes.Constraints.t -> evar_map
 (** Add the given universe unification constraints to the evar map.
-    @raises UniversesDiffer in case a first-order unification fails.
-    @raises UniverseInconsistency
+    @raise UniversesDiffer in case a first-order unification fails.
+    @raise UniverseInconsistency
 *)
 
 (** {5 Extra data}

--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -127,7 +127,7 @@ let focus_context (left,right) =
 
 (** This (internal) function extracts a sublist between two indices,
     and returns this sublist together with its context: if it returns
-    [(a,(b,c))] then [a] is the sublist and (rev b)@a@c is the
+    [(a,(b,c))] then [a] is the sublist and [(rev b) @ a @ c] is the
     original list.  The focused list has lenght [j-i-1] and contains
     the goals from number [i] to number [j] (both included) the first
     goal of the list being numbered [1].  [focus_sublist i j l] raises
@@ -572,8 +572,8 @@ let tclDISPATCHL tacs = tclDISPATCHGEN CList.rev tacs
 
 
 (** [extend_to_list startxs rx endxs l] builds a list
-    [startxs@[rx,...,rx]@endxs] of the same length as [l]. Raises
-    [SizeMismatch] if [startxs@endxs] is already longer than [l]. *)
+    [startxs @ [rx,...,rx] @ endxs] of the same length as [l]. Raises
+    [SizeMismatch] if [startxs @ endxs] is already longer than [l]. *)
 let extend_to_list startxs rx endxs l =
   (* spiwack: I use [l] essentially as a natural number *)
   let rec duplicate acc = function

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -1077,7 +1077,7 @@ type 'a raw_cases_pattern_expr_r =
   | RCPatAlias of 'a raw_cases_pattern_expr * Misctypes.lname
   | RCPatCstr  of Globnames.global_reference
     * 'a raw_cases_pattern_expr list * 'a raw_cases_pattern_expr list
-  (** [RCPatCstr (loc, c, l1, l2)] represents ((@c l1) l2) *)
+  (** [RCPatCstr (loc, c, l1, l2)] represents [((@ c l1) l2)] *)
   | RCPatAtom  of (Misctypes.lident * (Notation_term.tmp_scope_name option * Notation_term.scope_name list)) option
   | RCPatOr    of 'a raw_cases_pattern_expr list
 and 'a raw_cases_pattern_expr = ('a raw_cases_pattern_expr_r, 'a) DAst.t

--- a/intf/constrexpr.ml
+++ b/intf/constrexpr.ml
@@ -121,7 +121,7 @@ and recursion_order_expr =
   | CWfRec of constr_expr
   | CMeasureRec of constr_expr * constr_expr option (** measure, relation *)
 
-(** Anonymous defs allowed ?? *)
+(* Anonymous defs allowed ?? *)
 and local_binder_expr =
   | CLocalAssum   of lname list * binder_kind * constr_expr
   | CLocalDef     of lname * constr_expr * constr_expr option

--- a/intf/constrexpr.ml
+++ b/intf/constrexpr.ml
@@ -51,7 +51,7 @@ type cases_pattern_expr_r =
   | CPatAlias of cases_pattern_expr * lname
   | CPatCstr  of reference
     * cases_pattern_expr list option * cases_pattern_expr list
-  (** [CPatCstr (_, c, Some l1, l2)] represents (@c l1) l2 *)
+  (** [CPatCstr (_, c, Some l1, l2)] represents [(@ c l1) l2] *)
   | CPatAtom of reference option
   | CPatOr   of cases_pattern_expr list
   | CPatNotation of notation * cases_pattern_notation_substitution

--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -798,7 +798,7 @@ let drop_parameters depth n argstk =
     s.
     @assumes [t] is an irreducible term, and not a constructor. [ind] is the inductive
     of the constructor term [c]
-    @raises Not_found if the inductive is not a primitive record, or if the
+    @raise Not_found if the inductive is not a primitive record, or if the
     constructor is partially applied.
  *)
 let eta_expand_ind_stack env ind m s (f, s') =

--- a/kernel/cClosure.mli
+++ b/kernel/cClosure.mli
@@ -216,7 +216,7 @@ val whd_stack :
     s.
     @assumes [t] is a rigid term, and not a constructor. [ind] is the inductive
     of the constructor term [c]
-    @raises Not_found if the inductive is not a primitive record, or if the
+    @raise Not_found if the inductive is not a primitive record, or if the
     constructor is partially applied.
  *)
 val eta_expand_ind_stack : env -> inductive -> fconstr -> stack ->

--- a/kernel/environ.mli
+++ b/kernel/environ.mli
@@ -201,7 +201,7 @@ val lookup_modtype : ModPath.t -> env -> module_type_body
 (** {5 Universe constraints } *)
 
 (** Add universe constraints to the environment.
-    @raise UniverseInconsistency
+    @raise UniverseInconsistency .
 *)
 val add_constraints : Univ.Constraint.t -> env -> env
 

--- a/kernel/environ.mli
+++ b/kernel/environ.mli
@@ -201,7 +201,7 @@ val lookup_modtype : ModPath.t -> env -> module_type_body
 (** {5 Universe constraints } *)
 
 (** Add universe constraints to the environment.
-    @raises UniverseInconsistency
+    @raise UniverseInconsistency
 *)
 val add_constraints : Univ.Constraint.t -> env -> env
 

--- a/kernel/uGraph.mli
+++ b/kernel/uGraph.mli
@@ -43,7 +43,7 @@ val check_constraint  : t -> univ_constraint -> bool
 val check_constraints : Constraint.t -> t -> bool
 
 (** Adds a universe to the graph, ensuring it is >= or > Set.
-   @raises AlreadyDeclared if the level is already declared in the graph. *)
+   @raise AlreadyDeclared if the level is already declared in the graph. *)
 
 exception AlreadyDeclared
 

--- a/lib/lib.mllib
+++ b/lib/lib.mllib
@@ -15,7 +15,6 @@ CWarnings
 Rtree
 System
 Explore
-RTree
 CProfile
 Future
 Spawn

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -460,7 +460,7 @@ let red_product_skip_id env sigma c = match EConstr.kind sigma c with
 
 let ssrevaltac ist gtac = Tacinterp.tactic_of_value ist gtac
 
-(** Open term to lambda-term coercion  {{{ ************************************)
+(** Open term to lambda-term coercion  *)(* {{{ ************************************)
 
 (* This operation takes a goal gl and an open term (sigma, t), and   *)
 (* returns a term t' where all the new evars in sigma are abstracted *)
@@ -1000,7 +1000,7 @@ let refine_with ?(first_goes_last=false) ?beta ?(with_evars=true) oc gl =
   try applyn ~with_evars ~with_shelve:true ?beta n (EConstr.of_constr oc) gl
   with e when CErrors.noncritical e -> raise dependent_apply_error
 
-(** Profiling {{{ *************************************************************)
+(** Profiling *)(* {{{ *************************************************************)
 type profiler = { 
   profile : 'a 'b. ('a -> 'b) -> 'a -> 'b;
   reset : unit -> unit;
@@ -1128,7 +1128,7 @@ let interp_clr sigma = function
 
 (** Basic tacticals *)
 
-(** Multipliers {{{ ***********************************************************)
+(** Multipliers *)(* {{{ ***********************************************************)
 
 (* tactical *)
 
@@ -1168,7 +1168,7 @@ let tclMULT = function
 let old_cleartac clr = check_hyps_uniq [] clr; Proofview.V82.of_tactic (Tactics.clear (hyps_ids clr))
 let cleartac clr = check_hyps_uniq [] clr; Tactics.clear (hyps_ids clr)
 
-(** }}} *)
+(* }}} *)
 
 (** Generalize tactic *)
 

--- a/plugins/ssr/ssrparser.ml4
+++ b/plugins/ssr/ssrparser.ml4
@@ -952,7 +952,7 @@ let pr_ssrhint _ _ = pr_hint
 ARGUMENT EXTEND ssrhint TYPED AS ssrhintarg PRINTED BY pr_ssrhint
 | [ ]                       -> [ nohint ]
 END
-(** The "in" pseudo-tactical {{{ **********************************************)
+(** The "in" pseudo-tactical *)(* {{{ **********************************************)
 
 (* We can't make "in" into a general tactical because this would create a  *)
 (* crippling conflict with the ltac let .. in construct. Hence, we add     *)
@@ -1438,7 +1438,7 @@ let tactic_expr = Pltac.tactic_expr
 let old_tac = V82.tactic
 
 
-(** Name generation {{{ *******************************************************)
+(** Name generation *)(* {{{ *******************************************************)
 
 (* Since Coq now does repeated internal checks of its external lexical *)
 (* rules, we now need to carve ssreflect reserved identifiers out of   *)
@@ -1490,7 +1490,7 @@ let _ = add_internal_name (is_tagged perm_tag)
 
 (* We must not anonymize context names discharged by the "in" tactical. *)
 
-(** Tactical extensions. {{{ **************************************************)
+(** Tactical extensions. *)(* {{{ **************************************************)
 
 (* The TACTIC EXTEND facility can't be used for defining new user   *)
 (* tacticals, because:                                              *)

--- a/plugins/ssr/ssrtacticals.ml
+++ b/plugins/ssr/ssrtacticals.ml
@@ -59,7 +59,7 @@ let tclSEQAT ist atac1 dir (ivar, ((_, atacs2), atac3)) =
   | L2R, pad, tacs2 -> Tacticals.tclTHENSFIRSTn tac1 (Array.of_list (pad @ tacs2)) tac3
   | R2L, pad, tacs2 -> Tacticals.tclTHENSLASTn tac1 tac3 (Array.of_list (tacs2 @ pad))
 
-(** The "in" pseudo-tactical {{{ **********************************************)
+(** The "in" pseudo-tactical *)(* {{{ **********************************************)
 
 let hidden_goal_tag = "the_hidden_goal"
 

--- a/plugins/ssr/ssrvernac.ml4
+++ b/plugins/ssr/ssrvernac.ml4
@@ -49,7 +49,7 @@ let frozen_lexer = CLexer.get_keyword_state () ;;
 
 (* global syntactic changes and vernacular commands *)
 
-(** Alternative notations for "match" and anonymous arguments. {{{ ************)
+(** Alternative notations for "match" and anonymous arguments. *)(* {{{ ************)
 
 (* Syntax:                                                        *)
 (*  if <term> is <pattern> then ... else ...                      *)
@@ -127,7 +127,7 @@ GEXTEND Gram
 END
 (* }}} *)
 
-(** Vernacular commands: Prenex Implicits and Search {{{ **********************)
+(** Vernacular commands: Prenex Implicits and Search *)(* {{{ **********************)
 
 (* This should really be implemented as an extension to the implicit   *)
 (* arguments feature, but unfortuately that API is sealed. The current *)
@@ -461,7 +461,7 @@ END
 
 (* }}} *)
 
-(** View hint database and View application. {{{ ******************************)
+(** View hint database and View application. *)(* {{{ ******************************)
 
 (* There are three databases of lemmas used to mediate the application  *)
 (* of reflection lemmas: one for forward chaining, one for backward     *)

--- a/plugins/ssrmatching/ssrmatching.ml4
+++ b/plugins/ssrmatching/ssrmatching.ml4
@@ -70,7 +70,7 @@ let _ =
       Goptions.optwrite = debug }
 let pp s = !pp_ref s
 
-(** Utils {{{ *****************************************************************)
+(** Utils *)(* {{{ *****************************************************************)
 let env_size env = List.length (Environ.named_context env)
 let safeDestApp c =
   match kind c with App (f, a) -> f, a | _ -> c, [| |]
@@ -179,7 +179,7 @@ let nf_evar sigma c =
 
 (* }}} *)
 
-(** Profiling {{{ *************************************************************)
+(** Profiling *)(* {{{ *************************************************************)
 type profiler = { 
   profile : 'a 'b. ('a -> 'b) -> 'a -> 'b;
   reset : unit -> unit;

--- a/plugins/ssrmatching/ssrmatching.mli
+++ b/plugins/ssrmatching/ssrmatching.mli
@@ -74,7 +74,7 @@ val interp_cpattern :
     pattern
 
 (** The set of occurrences to be matched. The boolean is set to true
- *  to signal the complement of this set (i.e. {-1 3}) *)
+ *  to signal the complement of this set (i.e. \{-1 3\}) *)
 type occ = (bool * int list) option
 
 (** [subst e p t i]. [i] is the number of binders

--- a/pretyping/reductionops.mli
+++ b/pretyping/reductionops.mli
@@ -278,7 +278,7 @@ val check_conv : ?pb:conv_pb -> ?ts:transparent_state -> env ->  evar_map -> con
 
 (** [infer_conv] Adds necessary universe constraints to the evar map.
     pb defaults to CUMUL and ts to a full transparent state.
-    @raises UniverseInconsistency iff catch_incon is set to false, 
+    @raise UniverseInconsistency iff catch_incon is set to false,
     otherwise returns false in that case.
  *)
 val infer_conv : ?catch_incon:bool -> ?pb:conv_pb -> ?ts:transparent_state -> 

--- a/tactics/hipattern.ml
+++ b/tactics/hipattern.ml
@@ -511,10 +511,10 @@ let coq_eqdec ~sum ~rev =
     mkPattern (mkGAppRef sum args)
   )
 
-(** { ?X2 = ?X3 :> ?X1 } + { ~ ?X2 = ?X3 :> ?X1 } *)
+(** [{ ?X2 = ?X3 :> ?X1 } + { ~ ?X2 = ?X3 :> ?X1 }] *)
 let coq_eqdec_inf_pattern = coq_eqdec ~sum:coq_sumbool_ref ~rev:false
 
-(** { ~ ?X2 = ?X3 :> ?X1 } + { ?X2 = ?X3 :> ?X1 } *)
+(** [{ ~ ?X2 = ?X3 :> ?X1 } + { ?X2 = ?X3 :> ?X1 }] *)
 let coq_eqdec_inf_rev_pattern = coq_eqdec ~sum:coq_sumbool_ref ~rev:true
 
 (** %coq_or_ref (?X2 = ?X3 :> ?X1) (~ ?X2 = ?X3 :> ?X1) *)


### PR DESCRIPTION
**Kind:** bug fix.

This PR
* uses the dependencies generated from the `.mllib` files to run `make ml-doc`
  - previously this used a wildcard via `MLSTATICFILES`, which included files in the wrong order (and some files from the checker etc.), causing a fatal error
  - now the `.ml` files are including in the order they are compiled and linked
* tweaks some comments to correct `ocamldoc` errors/warnings
* removes a module in `lib.mllib` that never existed (was introduced as a typo)
* places the files in a dedicated directory `$(OCAMLDOCDIR)/html/implementation`
  - previously this was just `$(OCAMLDOCDIR)`, which also contains the LaTeX build and some docs tools

Note:
* as far as I can tell, `make ml-doc` has never actually worked before
* `make ml-doc` can be run from clean if it has `$(LINKCMX)` as a dependency. I didn't do this to avoid a recompile on every comment change.
* there are still lots of warnings from `ocamldoc`, because of its (well-documented) limitations