### PR TITLE
Move VM global tables from C to ML

### DIFF
--- a/kernel/byterun/coq_interp.c
+++ b/kernel/byterun/coq_interp.c
@@ -163,8 +163,11 @@ extern void caml_process_pending_signals(void);
 /* The interpreter itself */
 
 value coq_interprete
-(code_t coq_pc, value coq_accu, value coq_env, long coq_extra_args)
+(code_t coq_pc, value coq_accu, value coq_global_data, value coq_env, long coq_extra_args)
 {
+  /* coq_accu is not allocated on the OCaml heap */
+  CAMLparam1(coq_global_data);
+
   /*Declaration des variables */
 #ifdef PC_REG
   register code_t pc PC_REG;
@@ -196,7 +199,7 @@ value coq_interprete
     coq_instr_table = (char **) coq_jumptable;
     coq_instr_base = coq_Jumptbl_base;
 #endif
-    return Val_unit;
+    CAMLreturn(Val_unit);
   }
 #if defined(THREADED_CODE) && defined(ARCH_SIXTYFOUR) && !defined(ARCH_CODE32)
   coq_jumptbl_base = coq_Jumptbl_base;
@@ -1460,7 +1463,7 @@ value coq_interprete
       Instruct(STOP){
 	print_instr("STOP");
 	coq_sp = sp;
-	return accu;
+        CAMLreturn(accu);
       }
       
   
@@ -1512,12 +1515,12 @@ value coq_push_vstack(value stk, value max_stack_size) {
   return Val_unit;
 }
 
-value  coq_interprete_ml(value tcode, value a, value e, value ea) {
+value  coq_interprete_ml(value tcode, value a, value g, value e, value ea) {
   print_instr("coq_interprete");
-  return coq_interprete((code_t)tcode, a, e, Long_val(ea));
+  return coq_interprete((code_t)tcode, a, g, e, Long_val(ea));
   print_instr("end coq_interprete");
 }
 
-value coq_eval_tcode (value tcode, value e) {
-  return coq_interprete_ml(tcode, Val_unit, e, 0);
+value coq_eval_tcode (value tcode, value g, value e) {
+  return coq_interprete_ml(tcode, Val_unit, g, e, 0);
 }

--- a/kernel/byterun/coq_interp.c
+++ b/kernel/byterun/coq_interp.c
@@ -163,10 +163,10 @@ extern void caml_process_pending_signals(void);
 /* The interpreter itself */
 
 value coq_interprete
-(code_t coq_pc, value coq_accu, value coq_global_data, value coq_env, long coq_extra_args)
+(code_t coq_pc, value coq_accu, value coq_atom_tbl, value coq_global_data, value coq_env, long coq_extra_args)
 {
   /* coq_accu is not allocated on the OCaml heap */
-  CAMLparam1(coq_global_data);
+  CAMLparam2(coq_atom_tbl, coq_global_data);
 
   /*Declaration des variables */
 #ifdef PC_REG
@@ -1515,12 +1515,16 @@ value coq_push_vstack(value stk, value max_stack_size) {
   return Val_unit;
 }
 
-value  coq_interprete_ml(value tcode, value a, value g, value e, value ea) {
+value  coq_interprete_ml(value tcode, value a, value t, value g, value e, value ea) {
   print_instr("coq_interprete");
-  return coq_interprete((code_t)tcode, a, g, e, Long_val(ea));
+  return coq_interprete((code_t)tcode, a, t, g, e, Long_val(ea));
   print_instr("end coq_interprete");
 }
 
-value coq_eval_tcode (value tcode, value g, value e) {
-  return coq_interprete_ml(tcode, Val_unit, g, e, 0);
+value coq_interprete_byte(value* argv, int argn){
+  return coq_interprete_ml(argv[0], argv[1], argv[2], argv[3], argv[4], argv[5]);
+}
+
+value coq_eval_tcode (value tcode, value t, value g, value e) {
+  return coq_interprete_ml(tcode, Val_unit, t, g, e, 0);
 }

--- a/kernel/byterun/coq_interp.h
+++ b/kernel/byterun/coq_interp.h
@@ -17,11 +17,9 @@ value coq_push_arguments(value args);
 
 value coq_push_vstack(value stk);
 
-value  coq_interprete_ml(value tcode, value a, value e, value ea);
+value coq_interprete_ml(value tcode, value a, value g, value e, value ea);
 
 value coq_interprete
-    (code_t coq_pc, value coq_accu, value coq_env, long coq_extra_args);
+    (code_t coq_pc, value coq_accu, value coq_global_data, value coq_env, long coq_extra_args);
 
-value coq_eval_tcode (value tcode, value e);
-
-
+value coq_eval_tcode (value tcode, value g, value e);

--- a/kernel/byterun/coq_interp.h
+++ b/kernel/byterun/coq_interp.h
@@ -17,9 +17,10 @@ value coq_push_arguments(value args);
 
 value coq_push_vstack(value stk);
 
-value coq_interprete_ml(value tcode, value a, value g, value e, value ea);
+value coq_interprete_ml(value tcode, value a, value t, value g, value e, value ea);
+value coq_interprete_byte(value* argv, int argn);
 
 value coq_interprete
-    (code_t coq_pc, value coq_accu, value coq_global_data, value coq_env, long coq_extra_args);
+    (code_t coq_pc, value coq_accu, value coq_atom_tbl, value coq_global_data, value coq_env, long coq_extra_args);
 
-value coq_eval_tcode (value tcode, value g, value e);
+value coq_eval_tcode (value tcode, value t, value g, value e);

--- a/kernel/byterun/coq_memory.c
+++ b/kernel/byterun/coq_memory.c
@@ -25,7 +25,6 @@ asize_t coq_max_stack_size = Coq_max_stack_size;
 /* global_data */
 
 
-value coq_global_data;
 value coq_atom_tbl;
 
 int drawinstr;
@@ -59,7 +58,6 @@ static void coq_scan_roots(scanning_action action)
 {
   register value * i;
   /* Scan the global variables */
-  (*action)(coq_global_data, &coq_global_data);
   (*action)(coq_atom_tbl, &coq_atom_tbl);
   /* Scan the stack */
   for (i = coq_sp; i < coq_stack_high; i++) {
@@ -79,14 +77,6 @@ void init_coq_stack()
   coq_max_stack_size = Coq_max_stack_size;
 }  
 
-void init_coq_global_data(long requested_size)
-{
-  int i;
-  coq_global_data = alloc_shr(requested_size, 0);
-  for (i = 0; i < requested_size; i++) 
-    Field (coq_global_data, i) = Val_unit;
-}
-
 void init_coq_atom_tbl(long requested_size){
   int i;
   coq_atom_tbl = alloc_shr(requested_size, 0);
@@ -96,7 +86,7 @@ void init_coq_atom_tbl(long requested_size){
 void init_coq_interpreter()
 {
   coq_sp = coq_stack_high;
-  coq_interprete(NULL, Val_unit, Val_unit, 0);
+  coq_interprete(NULL, Val_unit, Atom(0), Val_unit, 0);
 }
 
 static int coq_vm_initialized = 0;
@@ -112,7 +102,6 @@ value init_coq_vm(value unit) /* ML */
 #endif /* THREADED_CODE */
     /* Allocate the table of global and the stack */
     init_coq_stack();
-    init_coq_global_data(Coq_global_data_Size);
     init_coq_atom_tbl(40);
     /* Initialing the interpreter */
     init_coq_interpreter();
@@ -157,33 +146,9 @@ void realloc_coq_stack(asize_t required_space)
 #undef shift
 }
 
-value get_coq_global_data(value unit)                /* ML */
-{
-  return coq_global_data;
-}
-
 value get_coq_atom_tbl(value unit)                  /* ML */
 {
   return coq_atom_tbl;
-}
-
-value realloc_coq_global_data(value size)           /* ML */
-{
-  mlsize_t requested_size, actual_size, i;
-  value new_global_data;
-  requested_size = Long_val(size);
-  actual_size = Wosize_val(coq_global_data);
-  if (requested_size >= actual_size) {
-    requested_size = (requested_size + 0x100) & 0xFFFFFF00;
-    new_global_data = alloc_shr(requested_size, 0);
-    for (i = 0; i < actual_size; i++)
-      initialize(&Field(new_global_data, i), Field(coq_global_data, i));
-    for (i = actual_size; i < requested_size; i++){
-      Field (new_global_data, i) = Val_long (0);
-    }
-    coq_global_data = new_global_data;
-  }
-  return Val_unit;
 }
 
 value realloc_coq_atom_tbl(value size)            /* ML */

--- a/kernel/byterun/coq_memory.h
+++ b/kernel/byterun/coq_memory.h
@@ -34,7 +34,6 @@ extern value * coq_stack_threshold;
 /* global_data */
 
 extern int coq_all_transp;
-extern value coq_atom_tbl;
 
 extern int drawinstr;
 /* interp state */
@@ -51,8 +50,6 @@ value init_coq_vm(value unit); /* ML */
 value re_init_coq_vm(value unit); /* ML */
 
 void  realloc_coq_stack(asize_t required_space); 
-value get_coq_atom_tbl(value unit); /* ML */
-value realloc_coq_atom_tbl(value size); /* ML */
 value coq_set_transp_value(value transp); /* ML */
 value get_coq_transp_value(value unit); /* ML */
 #endif /* _COQ_MEMORY_ */

--- a/kernel/byterun/coq_memory.h
+++ b/kernel/byterun/coq_memory.h
@@ -20,7 +20,6 @@
 
 #define Coq_stack_size (4096 * sizeof(value))
 #define Coq_stack_threshold (256 * sizeof(value))
-#define Coq_global_data_Size (4096 * sizeof(value))
 #define Coq_max_stack_size (256 * 1024)
 
 #define TRANSP 0
@@ -34,7 +33,6 @@ extern value * coq_stack_threshold;
 
 /* global_data */
 
-extern value coq_global_data;
 extern int coq_all_transp;
 extern value coq_atom_tbl;
 
@@ -53,8 +51,6 @@ value init_coq_vm(value unit); /* ML */
 value re_init_coq_vm(value unit); /* ML */
 
 void  realloc_coq_stack(asize_t required_space); 
-value get_coq_global_data(value unit); /* ML */
-value realloc_coq_global_data(value size); /* ML */
 value get_coq_atom_tbl(value unit); /* ML */
 value realloc_coq_atom_tbl(value size); /* ML */
 value coq_set_transp_value(value transp); /* ML */

--- a/kernel/csymtable.ml
+++ b/kernel/csymtable.ml
@@ -26,7 +26,9 @@ open Cbytegen
 module NamedDecl = Context.Named.Declaration
 module RelDecl = Context.Rel.Declaration
 
-external eval_tcode : tcode -> values array -> values = "coq_eval_tcode"
+external eval_tcode : tcode -> vm_global -> values array -> values = "coq_eval_tcode"
+
+type global_data = { mutable glob_len : int; mutable glob_val : values array }
 
 (*******************)
 (* Linkage du code *)
@@ -37,21 +39,28 @@ external eval_tcode : tcode -> values array -> values = "coq_eval_tcode"
 (* [global_data] contient les valeurs des constantes globales
    (axiomes,definitions), les annotations des switch et les structured
    constant *)
-external global_data : unit -> values array = "get_coq_global_data"
+let global_data = {
+  glob_len = 0;
+  glob_val = Array.make 4096 crazy_val;
+}
 
-(* [realloc_global_data n] augmente de n la taille de [global_data] *)
-external realloc_global_data : int -> unit = "realloc_coq_global_data"
+let get_global_data () = Vmvalues.vm_global global_data.glob_val
+
+let realloc_global_data n =
+  let n = min (n + 0x100) Sys.max_array_length in
+  let ans = Array.make n crazy_val in
+  let src = global_data.glob_val in
+  let () = Array.blit src 0 ans 0 (Array.length src) in
+  global_data.glob_val <- ans
 
 let check_global_data n =
-  if n >= Array.length (global_data()) then realloc_global_data n
-
-let num_global = ref 0
+  if n >= Array.length global_data.glob_val then realloc_global_data n
 
 let set_global v =
-  let n = !num_global in
+  let n = global_data.glob_len in
   check_global_data n;
-  (global_data()).(n) <- v;
-  incr num_global;
+  global_data.glob_val.(n) <- v;
+  global_data.glob_len <- global_data.glob_len + 1;
   n
 
 (* table pour les structured_constant et les annotations des switchs *)
@@ -164,7 +173,7 @@ and eval_to_patch env (buff,pl,fv) =
   in
   let tc = patch buff pl slots in
   let vm_env = Array.map (slot_for_fv env) fv in
-  eval_tcode tc vm_env
+  eval_tcode tc (vm_global global_data.glob_val) vm_env
 
 and val_of_constr env c =
   match compile ~fail_on_error:true env c with

--- a/kernel/csymtable.ml
+++ b/kernel/csymtable.ml
@@ -26,7 +26,7 @@ open Cbytegen
 module NamedDecl = Context.Named.Declaration
 module RelDecl = Context.Rel.Declaration
 
-external eval_tcode : tcode -> vm_global -> values array -> values = "coq_eval_tcode"
+external eval_tcode : tcode -> atom array -> vm_global -> values array -> values = "coq_eval_tcode"
 
 type global_data = { mutable glob_len : int; mutable glob_val : values array }
 
@@ -173,7 +173,7 @@ and eval_to_patch env (buff,pl,fv) =
   in
   let tc = patch buff pl slots in
   let vm_env = Array.map (slot_for_fv env) fv in
-  eval_tcode tc (vm_global global_data.glob_val) vm_env
+  eval_tcode tc (get_atom_rel ()) (vm_global global_data.glob_val) vm_env
 
 and val_of_constr env c =
   match compile ~fail_on_error:true env c with

--- a/kernel/csymtable.ml
+++ b/kernel/csymtable.ml
@@ -47,7 +47,7 @@ let global_data = {
 let get_global_data () = Vmvalues.vm_global global_data.glob_val
 
 let realloc_global_data n =
-  let n = min (n + 0x100) Sys.max_array_length in
+  let n = min (2 * n + 0x100) Sys.max_array_length in
   let ans = Array.make n crazy_val in
   let src = global_data.glob_val in
   let () = Array.blit src 0 ans 0 (Array.length src) in

--- a/kernel/csymtable.mli
+++ b/kernel/csymtable.mli
@@ -18,3 +18,5 @@ val val_of_constr : env -> constr -> Vmvalues.values
 
 val set_opaque_const      : Constant.t -> unit
 val set_transparent_const : Constant.t -> unit
+
+val get_global_data : unit -> Vmvalues.vm_global

--- a/kernel/kernel.mllib
+++ b/kernel/kernel.mllib
@@ -43,6 +43,6 @@ Subtyping
 Mod_typing
 Nativelibrary
 Safe_typing
-Vm
 Csymtable
+Vm
 Vconv

--- a/kernel/vm.ml
+++ b/kernel/vm.ml
@@ -42,11 +42,11 @@ external push_vstack : vstack -> int -> unit = "coq_push_vstack"
 
 
 (* interpreteur *)
-external coq_interprete : tcode -> values -> vm_global -> vm_env -> int -> values =
-  "coq_interprete_ml"
+external coq_interprete : tcode -> values -> atom array -> vm_global -> vm_env -> int -> values =
+  "coq_interprete_byte" "coq_interprete_ml"
 
 let interprete code v env k =
-  coq_interprete code v (Csymtable.get_global_data ()) env k
+  coq_interprete code v (get_atom_rel ()) (Csymtable.get_global_data ()) env k
 
 (* Functions over arguments *)
 

--- a/kernel/vm.ml
+++ b/kernel/vm.ml
@@ -42,8 +42,11 @@ external push_vstack : vstack -> int -> unit = "coq_push_vstack"
 
 
 (* interpreteur *)
-external interprete : tcode -> values -> vm_env -> int -> values =
+external coq_interprete : tcode -> values -> vm_global -> vm_env -> int -> values =
   "coq_interprete_ml"
+
+let interprete code v env k =
+  coq_interprete code v (Csymtable.get_global_data ()) env k
 
 (* Functions over arguments *)
 
@@ -184,6 +187,6 @@ let apply_whd k whd =
       push_val v;
       interprete (cofix_upd_code to_up) (cofix_upd_val to_up) (cofix_upd_env to_up) 0
   | Vatom_stk(a,stk) ->
-      apply_stack (val_of_atom a) stk v 
+      apply_stack (val_of_atom a) stk v
   | Vuniv_level lvl -> assert false
 

--- a/kernel/vmvalues.ml
+++ b/kernel/vmvalues.ml
@@ -43,6 +43,7 @@ let fix_val v = (Obj.magic v : values)
 let cofix_upd_val v = (Obj.magic v : values)
 
 type vm_env
+type vm_global
 let fun_env v = (Obj.magic v : vm_env)
 let fix_env v = (Obj.magic v : vm_env)
 let cofix_env v = (Obj.magic v : vm_env)
@@ -50,6 +51,8 @@ let cofix_upd_env v = (Obj.magic v : vm_env)
 type vstack = values array
 
 let fun_of_val v = (Obj.magic v : vfun)
+
+let vm_global (v : values array) = (Obj.magic v : vm_global)
 
 (*******************************************)
 (* Machine code *** ************************)

--- a/kernel/vmvalues.ml
+++ b/kernel/vmvalues.ml
@@ -417,7 +417,7 @@ let atom_rel : atom array ref =
 let get_atom_rel () = !atom_rel
 
 let realloc_atom_rel n =
-  let n = min (n + 0x100) Sys.max_array_length in
+  let n = min (2 * n + 0x100) Sys.max_array_length in
   let init i = Aid (RelKey i) in
   let ans = Array.init n init in
   atom_rel := ans

--- a/kernel/vmvalues.ml
+++ b/kernel/vmvalues.ml
@@ -410,13 +410,20 @@ let check_fix f1 f2 =
     else false
   else false
 
-external atom_rel : unit -> atom array = "get_coq_atom_tbl"
-external realloc_atom_rel : int -> unit = "realloc_coq_atom_tbl"
+let atom_rel : atom array ref =
+  let init i = Aid (RelKey i) in
+  ref (Array.init 40 init)
+
+let get_atom_rel () = !atom_rel
+
+let realloc_atom_rel n =
+  let n = min (n + 0x100) Sys.max_array_length in
+  let init i = Aid (RelKey i) in
+  let ans = Array.init n init in
+  atom_rel := ans
 
 let relaccu_tbl =
-  let atom_rel = atom_rel() in
-  let len = Array.length atom_rel in
-  for i = 0 to len - 1 do atom_rel.(i) <- Aid (RelKey i) done;
+  let len = Array.length !atom_rel in
   ref (Array.init len mkAccuCode)
 
 let relaccu_code i =
@@ -425,9 +432,7 @@ let relaccu_code i =
   else
     begin
       realloc_atom_rel i;
-      let atom_rel = atom_rel () in
-      let nl = Array.length atom_rel in
-      for j = len to nl - 1 do atom_rel.(j) <- Aid(RelKey j) done;
+      let nl = Array.length !atom_rel in
       relaccu_tbl :=
         Array.init nl
           (fun j -> if j < len then !relaccu_tbl.(j) else mkAccuCode j);

--- a/kernel/vmvalues.mli
+++ b/kernel/vmvalues.mli
@@ -15,6 +15,7 @@ open Cbytecodes
 
 type values
 type vm_env
+type vm_global
 type vprod
 type vfun
 type vfix
@@ -32,6 +33,8 @@ val fun_env : vfun -> vm_env
 val fix_env : vfix -> vm_env
 val cofix_env : vcofix -> vm_env
 val cofix_upd_env : to_update -> vm_env
+
+val vm_global : values array -> vm_global
 
 (** Cast a value known to be a function, unsafe in general *)
 val fun_of_val : values -> vfun

--- a/kernel/vmvalues.mli
+++ b/kernel/vmvalues.mli
@@ -72,6 +72,9 @@ type atom =
   | Aind of inductive
   | Asort of Sorts.t
 
+val get_atom_rel : unit -> atom array
+(** Global table of rels *)
+
 (** Zippers *)
 
 type zipper =


### PR DESCRIPTION
This PR moves the VM global tables from the C implementation to the ML implementation. We declare them in ML code and pass them as an argument to the C reduction functions. This is a first step towards being able to synchronize this state with the Coq summary, so as to free unused memory, as well as locally replacing the value of a global, e.g. to implement local opacity in the VM.

This also makes the code slightly cleaner, e.g. automatically properly initializing the rel tables without them containing dummy data.

I was afraid that this might have been slower due to the C compiler performing less optimizations, but it doesn't seem to be the case after all. I guess it makes sense, as the pointer is allocated by the OCaml GC anyways.

Bench:
```
┌──────────────────────────┬─────────────────────────┬─────────────────────────────────────┬───────────────────────────────────────┬─────────────────────────┬─────────────────┐
│                          │      user time [s]      │             CPU cycles              │           CPU instructions            │  max resident mem [KB]  │   mem faults    │
│                          │                         │                                     │                                       │                         │                 │
│             package_name │     NEW     OLD PDIFF   │           NEW           OLD PDIFF   │            NEW            OLD PDIFF   │     NEW     OLD PDIFF   │ NEW OLD PDIFF   │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│    coq-mathcomp-fingroup │   60.44   60.80 -0.59 % │  166428584127  166896752508 -0.28 % │   231469653541   231593430204 -0.05 % │  529468  529564 -0.02 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│   coq-mathcomp-odd_order │ 1338.04 1343.05 -0.37 % │ 3722799312064 3730030746943 -0.19 % │  6591138192844  6588931938305 +0.03 % │ 1002808 1074176 -6.64 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│   coq-mathcomp-character │  262.67  263.37 -0.27 % │  728361468299  730425121020 -0.28 % │  1074466695631  1074665224701 -0.02 % │  984344  984600 -0.03 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│               coq-geocoq │ 3047.73 3051.96 -0.14 % │ 8476299150818 8486750182257 -0.12 % │ 13965502296280 13967856271799 -0.02 % │ 1240308 1242196 -0.15 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│             coq-compcert │  814.51  814.76 -0.03 % │ 2273965839896 2272410670086 +0.07 % │  3424265355466  3425603069430 -0.04 % │ 1368320 1369244 -0.07 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│     coq-mathcomp-algebra │  169.31  169.32 -0.01 % │  467079817224  466856454705 +0.05 % │   656166961721   656018828796 +0.02 % │  588608  588768 -0.03 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│         coq-fiat-parsers │  659.88  659.57 +0.05 % │ 1840217524385 1843765680640 -0.19 % │  2957382112931  2958206304060 -0.03 % │ 3374380 3348048 +0.79 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│           coq-coquelicot │   75.43   75.39 +0.05 % │  207446521549  207965394423 -0.25 % │   259630758430   259967721173 -0.13 % │  660052  656348 +0.56 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│              coq-bignums │   75.10   75.05 +0.07 % │  208687387455  208352870670 +0.16 % │   283223957401   283302640068 -0.03 % │  526356  526552 -0.04 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│                coq-color │  570.68  570.26 +0.07 % │ 1586587466967 1585912435822 +0.04 % │  1989591666968  1990298191910 -0.04 % │ 1438704 1439344 -0.04 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│                 coq-hott │  309.40  309.14 +0.08 % │  842513689729  842397799466 +0.01 % │  1375685832726  1376007763700 -0.02 % │  496448  496576 -0.03 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│ coq-mathcomp-real_closed │  165.54  165.34 +0.12 % │  459517066767  458971705800 +0.12 % │   699295227362   699416163376 -0.02 % │  714956  715232 -0.04 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│                coq-flocq │   59.36   59.23 +0.22 % │  163587367310  163808903677 -0.14 % │   211527066041   211563117381 -0.02 % │  664056  660820 +0.49 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│       coq-mathcomp-field │  441.04  439.72 +0.30 % │ 1223911680284 1220353697453 +0.29 % │  2024761406182  2024961143264 -0.01 % │  713300  713760 -0.06 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│                 coq-corn │ 1479.40 1474.02 +0.36 % │ 4106968669794 4102830785496 +0.10 % │  6397483028130  6400106610373 -0.04 % │  839512  835800 +0.44 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│    coq-mathcomp-solvable │  190.59  189.75 +0.44 % │  526621150340  526430860914 +0.04 % │   761548805325   761445630119 +0.01 % │  716420  716156 +0.04 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│            coq-fiat-core │  102.73  102.20 +0.52 % │  290549062565  290036335676 +0.18 % │   378266514772   378135129211 +0.03 % │  500864  501416 -0.11 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│   coq-mathcomp-ssreflect │   40.70   40.48 +0.54 % │  111612473841  111675287704 -0.06 % │   137656515666   137869727221 -0.15 % │  478660  478812 -0.03 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│      coq-formal-topology │   34.33   34.08 +0.73 % │   94943536842   94961475070 -0.02 % │   125133046104   125084139188 +0.04 % │  483396  483864 -0.10 % │   0   0  +nan % │
└──────────────────────────┴─────────────────────────┴─────────────────────────────────────┴───────────────────────────────────────┴─────────────────────────┴─────────────────┘


PDIFF = proportional difference between measurements done for the NEW and the OLD Coq version
      = (NEW_measurement - OLD_measurement) / OLD_measurement * 100%

NEW = 3c38a282d505ed2ced734ac2f212c9328d704b6a
OLD = df9d3a36e71d6d224286811fdc529ad5a955deb7
```