### PR TITLE
Fix failing packaging job.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -243,7 +243,8 @@ matrix:
       - EXTRA_OPAM="${LABLGTK}"
       before_install:
       - brew update
-      - brew install opam gnu-time gtk+ expat gtksourceview libxml2 gdk-pixbuf python3
+      - brew install opam gnu-time gtk+ expat gtksourceview gdk-pixbuf
+      - brew upgrade python
       - pip3 install macpack
       before_deploy:
         - dev/build/osx/make-macos-dmg.sh


### PR DESCRIPTION
`gtksourceview` depends transitively on `py2cairo` which was updated in Homebrew to depend explicitly on `python2` (see Homebrew/homebrew-core#24714): this makes the `python3` install step impossible.

We also remove the `libxml2` install step which was failing in a non-fatal way.

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** infrastructure fix.

Currently tested at https://travis-ci.org/Zimmi48/coq/jobs/349386516. This passed the failing step so we should be good but let's wait until the build is finished to be sure.

EDIT: test passed.

FTR here are two example builds on master, the first one before the failure, the second one after:
- https://travis-ci.org/coq/coq/jobs/347699957
- https://travis-ci.org/coq/coq/jobs/348953221

Now backported to v8.7.