### PR TITLE
Export options

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -77,6 +77,9 @@ Vernacular Commands
 - Using “Require” inside a section is deprecated.
 - An experimental command "Show Extraction" allows to extract the content
   of the current ongoing proof (grant wish #4129).
+- The "Export" modifier can now be used when setting and unsetting options, and
+  will result in performing the same change when the module corresponding the
+  command is imported.
 
 Universes
 

--- a/dev/ci/user-overlays/06923-ppedrot-export-options.sh
+++ b/dev/ci/user-overlays/06923-ppedrot-export-options.sh
@@ -1,0 +1,7 @@
+if [ "$CI_PULL_REQUEST" = "6923" ] || [ "$CI_BRANCH" = "export-options" ]; then
+    ltac2_CI_BRANCH=export-options
+    ltac2_CI_GITURL=https://github.com/ppedrot/ltac2
+
+    Equations_CI_BRANCH=export-options
+    Equations_CI_GITURL=https://github.com/ppedrot/Coq-Equations
+fi

--- a/ide/ide_slave.ml
+++ b/ide/ide_slave.ml
@@ -340,7 +340,7 @@ let set_options options =
   | IntValue i -> Goptions.set_int_option_value name i
   | StringValue s -> Goptions.set_string_option_value name s
   | StringOptValue (Some s) -> Goptions.set_string_option_value name s
-  | StringOptValue None -> Goptions.unset_option_value_gen None name
+  | StringOptValue None -> Goptions.unset_option_value_gen name
   in
   List.iter iter options
 

--- a/ide/ide_slave.ml
+++ b/ide/ide_slave.ml
@@ -57,8 +57,8 @@ let coqide_known_option table = List.mem table [
   ["Printing";"Unfocused"]]
 
 let is_known_option cmd = match Vernacprop.under_control cmd with
-  | VernacSetOption (o,BoolValue true)
-  | VernacUnsetOption o -> coqide_known_option o
+  | VernacSetOption (_, o, BoolValue true)
+  | VernacUnsetOption (_, o) -> coqide_known_option o
   | _ -> false
 
 (** Check whether a command is forbidden in the IDE *)

--- a/intf/vernacexpr.ml
+++ b/intf/vernacexpr.ml
@@ -425,9 +425,8 @@ type nonrec vernac_expr =
   | VernacSetOpacity of (Conv_oracle.level * reference or_by_notation list)
   | VernacSetStrategy of
       (Conv_oracle.level * reference or_by_notation list) list
-  | VernacUnsetOption of Goptions.option_name
-  | VernacSetOption of Goptions.option_name * option_value
-  | VernacSetAppendOption of Goptions.option_name * string
+  | VernacUnsetOption of export_flag * Goptions.option_name
+  | VernacSetOption of export_flag * Goptions.option_name * option_value
   | VernacAddOption of Goptions.option_name * option_ref_value list
   | VernacRemoveOption of Goptions.option_name * option_ref_value list
   | VernacMemOption of Goptions.option_name * option_ref_value list

--- a/library/goptions.mli
+++ b/library/goptions.mli
@@ -50,7 +50,7 @@ open Mod_subst
 
 type option_name = string list
 
-type option_locality = OptLocal | OptDefault | OptGlobal
+type option_locality = OptDefault | OptLocal | OptExport | OptGlobal
 
 (** {6 Tables. } *)
 

--- a/library/goptions.mli
+++ b/library/goptions.mli
@@ -50,6 +50,8 @@ open Mod_subst
 
 type option_name = string list
 
+type option_locality = OptLocal | OptDefault | OptGlobal
+
 (** {6 Tables. } *)
 
 (** The functor [MakeStringTable] declares a table containing objects
@@ -150,13 +152,12 @@ val get_ref_table :
       mem : reference -> unit;
       print : unit >
 
-(** The first argument is a locality flag.
-    [Some true] = "Local", [Some false]="Global". *)
-val set_int_option_value_gen    : bool option -> option_name -> int option -> unit
-val set_bool_option_value_gen   : bool option -> option_name -> bool   -> unit
-val set_string_option_value_gen : bool option -> option_name -> string -> unit
-val set_string_option_append_value_gen : bool option -> option_name -> string -> unit
-val unset_option_value_gen : bool option -> option_name -> unit
+(** The first argument is a locality flag. *)
+val set_int_option_value_gen    : ?locality:option_locality -> option_name -> int option -> unit
+val set_bool_option_value_gen   : ?locality:option_locality -> option_name -> bool   -> unit
+val set_string_option_value_gen : ?locality:option_locality -> option_name -> string -> unit
+val set_string_option_append_value_gen : ?locality:option_locality -> option_name -> string -> unit
+val unset_option_value_gen : ?locality:option_locality -> option_name -> unit
 
 val set_int_option_value    : option_name -> int option -> unit
 val set_bool_option_value   : option_name -> bool   -> unit

--- a/plugins/ssr/ssrvernac.ml4
+++ b/plugins/ssr/ssrvernac.ml4
@@ -178,7 +178,7 @@ GEXTEND Gram
   GLOBAL: gallina_ext;
   gallina_ext:
    [ [ IDENT "Import"; IDENT "Prenex"; IDENT "Implicits" ->
-      Vernacexpr.VernacUnsetOption (["Printing"; "Implicit"; "Defensive"])
+      Vernacexpr.VernacUnsetOption (false, ["Printing"; "Implicit"; "Defensive"])
    ] ]
   ;
 END

--- a/printing/ppvernac.ml
+++ b/printing/ppvernac.ml
@@ -1118,18 +1118,15 @@ open Decl_kinds
           hov 1 (keyword "Strategy" ++ spc() ++
                    hv 0 (prlist_with_sep sep pr_line l))
         )
-      | VernacUnsetOption (na) ->
+      | VernacUnsetOption (export, na) ->
+        let export = if export then keyword "Export" ++ spc () else mt () in
         return (
-          hov 1 (keyword "Unset" ++ spc() ++ pr_printoption na None)
+          hov 1 (export ++ keyword "Unset" ++ spc() ++ pr_printoption na None)
         )
-      | VernacSetOption (na,v) ->
+      | VernacSetOption (export, na,v) ->
+        let export = if export then keyword "Export" ++ spc () else mt () in
         return (
-          hov 2 (keyword "Set" ++ spc() ++ pr_set_option na v)
-        )
-      | VernacSetAppendOption (na,v) ->
-        return (
-          hov 2 (keyword "Set" ++ spc() ++ pr_printoption na None ++
-                   spc() ++ keyword "Append" ++ spc() ++ qs v)
+          hov 2 (export ++ keyword "Set" ++ spc() ++ pr_set_option na v)
         )
       | VernacAddOption (na,l) ->
         return (

--- a/stm/vernac_classifier.ml
+++ b/stm/vernac_classifier.ml
@@ -61,7 +61,7 @@ let classify_vernac e =
     (* Univ poly compatibility: we run it now, so that we can just
      * look at Flags in stm.ml.  Would be nicer to have the stm
      * look at the entire dag to detect this option. *)
-    | ( VernacSetOption (l,_) | VernacUnsetOption l)
+    | ( VernacSetOption (_, l,_) | VernacUnsetOption (_, l))
       when CList.equal String.equal l Vernacentries.universe_polymorphism_option_name ->
        VtSideff [], VtNow
     (* Qed *)
@@ -87,8 +87,8 @@ let classify_vernac e =
                       proof_block_detection = Some "curly" },
         VtLater
     (* Options changing parser *)
-    | VernacUnsetOption (["Default";"Proof";"Using"])
-    | VernacSetOption (["Default";"Proof";"Using"],_) -> VtSideff [], VtNow
+    | VernacUnsetOption (_, ["Default";"Proof";"Using"])
+    | VernacSetOption (_, ["Default";"Proof";"Using"],_) -> VtSideff [], VtNow
     (* StartProof *)
     | VernacDefinition ((Decl_kinds.DoDischarge,_),({v=i},_),ProveBody _) ->
       VtStartProof(default_proof_mode (),Doesn'tGuaranteeOpacity, idents_of_name i), VtLater
@@ -149,7 +149,7 @@ let classify_vernac e =
     | VernacReserve _
     | VernacGeneralizable _
     | VernacSetOpacity _ | VernacSetStrategy _
-    | VernacUnsetOption _ | VernacSetOption _ | VernacSetAppendOption _
+    | VernacUnsetOption _ | VernacSetOption _
     | VernacAddOption _ | VernacRemoveOption _
     | VernacMemOption _ | VernacPrintOption _
     | VernacGlobalCheck _

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1539,13 +1539,17 @@ let vernac_set_opacity ~atts (v,l) =
   let l = List.map glob_ref l in
   Redexpr.set_strategy local [v,l]
 
-let get_option_locality = function
-| Some true -> OptLocal
-| Some false -> OptGlobal
-| None -> OptDefault
+let get_option_locality export local =
+  if export then
+    if Option.is_empty local then OptExport
+    else user_err Pp.(str "Locality modifiers forbidden with Export")
+  else match local with
+  | Some true -> OptLocal
+  | Some false -> OptGlobal
+  | None -> OptDefault
 
-let vernac_set_option ~atts key opt =
-  let locality = get_option_locality atts.locality in
+let vernac_set_option0 ~atts export key opt =
+  let locality = get_option_locality export atts.locality in
   match opt with
   | StringValue s -> set_string_option_value_gen ~locality key s
   | StringOptValue (Some s) -> set_string_option_value_gen ~locality key s
@@ -1553,12 +1557,26 @@ let vernac_set_option ~atts key opt =
   | IntValue n -> set_int_option_value_gen ~locality key n
   | BoolValue b -> set_bool_option_value_gen ~locality key b
 
-let vernac_set_append_option ~atts key s =
-  let locality = get_option_locality atts.locality in
+let vernac_set_append_option ~atts export key s =
+  let locality = get_option_locality export atts.locality in
   set_string_option_append_value_gen ~locality key s
 
-let vernac_unset_option ~atts key =
-  let locality = get_option_locality atts.locality in
+let vernac_set_option ~atts export table v = match v with
+| StringValue s ->
+  (* We make a special case for warnings because appending is their
+  natural semantics *)
+  if CString.List.equal table ["Warnings"] then
+    vernac_set_append_option ~atts export table s
+  else
+    let (last, prefix) = List.sep_last table in
+    if String.equal last "Append" && not (List.is_empty prefix) then
+      vernac_set_append_option ~atts export prefix s
+    else
+      vernac_set_option0 ~atts export table v
+| _ -> vernac_set_option0 ~atts export table v
+
+let vernac_unset_option ~atts export key =
+  let locality = get_option_locality export atts.locality in
   unset_option_value_gen ~locality key
 
 let vernac_add_option key lv =
@@ -2092,9 +2110,8 @@ let interp ?proof ~atts ~st c =
   | VernacGeneralizable gen -> vernac_generalizable ~atts gen
   | VernacSetOpacity qidl -> vernac_set_opacity ~atts qidl
   | VernacSetStrategy l -> vernac_set_strategy ~atts l
-  | VernacSetOption (key,v) -> vernac_set_option ~atts key v
-  | VernacSetAppendOption (key,v) -> vernac_set_append_option ~atts key v
-  | VernacUnsetOption key -> vernac_unset_option ~atts key
+  | VernacSetOption (export, key,v) -> vernac_set_option ~atts export key v
+  | VernacUnsetOption (export, key) -> vernac_unset_option ~atts export key
   | VernacRemoveOption (key,v) -> vernac_remove_option key v
   | VernacAddOption (key,v) -> vernac_add_option key v
   | VernacMemOption (key,v) -> vernac_mem_option key v
@@ -2157,7 +2174,7 @@ let check_vernac_supports_locality c l =
     | VernacArgumentsScope _ | VernacDeclareImplicits _ | VernacArguments _
     | VernacGeneralizable _
     | VernacSetOpacity _ | VernacSetStrategy _
-    | VernacSetOption _ | VernacSetAppendOption _ | VernacUnsetOption _
+    | VernacSetOption _ | VernacUnsetOption _
     | VernacDeclareReduction _
     | VernacExtend _ 
     | VernacInductive _) -> ()

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1539,18 +1539,27 @@ let vernac_set_opacity ~atts (v,l) =
   let l = List.map glob_ref l in
   Redexpr.set_strategy local [v,l]
 
-let vernac_set_option ~atts key = function
-  | StringValue s -> set_string_option_value_gen atts.locality key s
-  | StringOptValue (Some s) -> set_string_option_value_gen atts.locality key s
-  | StringOptValue None -> unset_option_value_gen atts.locality key
-  | IntValue n -> set_int_option_value_gen atts.locality key n
-  | BoolValue b -> set_bool_option_value_gen atts.locality key b
+let get_option_locality = function
+| Some true -> OptLocal
+| Some false -> OptGlobal
+| None -> OptDefault
+
+let vernac_set_option ~atts key opt =
+  let locality = get_option_locality atts.locality in
+  match opt with
+  | StringValue s -> set_string_option_value_gen ~locality key s
+  | StringOptValue (Some s) -> set_string_option_value_gen ~locality key s
+  | StringOptValue None -> unset_option_value_gen ~locality key
+  | IntValue n -> set_int_option_value_gen ~locality key n
+  | BoolValue b -> set_bool_option_value_gen ~locality key b
 
 let vernac_set_append_option ~atts key s =
-  set_string_option_append_value_gen atts.locality key s
+  let locality = get_option_locality atts.locality in
+  set_string_option_append_value_gen ~locality key s
 
 let vernac_unset_option ~atts key =
-  unset_option_value_gen atts.locality key
+  let locality = get_option_locality atts.locality in
+  unset_option_value_gen ~locality key
 
 let vernac_add_option key lv =
   let f = function

--- a/vernac/vernacprop.ml
+++ b/vernac/vernacprop.ml
@@ -52,7 +52,7 @@ let is_reset = function
   | _ -> false
 
 let is_debug cmd = match under_control cmd with
-  | VernacSetOption (["Ltac";"Debug"], _) -> true
+  | VernacSetOption (_, ["Ltac";"Debug"], _) -> true
   | _ -> false
 
 let is_undo cmd = match under_control cmd with


### PR DESCRIPTION
This PR implements the Export Set/Unset feature as discussed in the last WG.

This feature has been asked many times by different people, and allows to have options in a module that are performed when this module is imported.

This supersedes the well-numbered cursed PR #313.

I did not document it in the refman yet, as I don't know what's the protocol regarding the sphinx port of the documentation. What is recommended?