### PR TITLE
gitlab: install num for all 4.06 jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,7 +26,7 @@ variables:
   COQIDE_PACKAGES: "libgtk2.0-dev libgtksourceview2.0-dev"
   #COQIDE_PACKAGES_32BIT: "libgtk2.0-dev:i386 libgtksourceview2.0-dev:i386"
   COQIDE_OPAM: "lablgtk-extras"
-  COQIDE_OPAM_BE: "num lablgtk.2.18.6 lablgtk-extras.1.6"
+  COQIDE_OPAM_BE: "lablgtk.2.18.6 lablgtk-extras.1.6"
   COQDOC_PACKAGES: "texlive-latex-base texlive-latex-recommended texlive-latex-extra texlive-math-extra texlive-fonts-recommended texlive-fonts-extra latex-xcolor ghostscript transfig imagemagick tipa"
   COQDOC_OPAM: "hevea"
 
@@ -49,7 +49,7 @@ before_script:
   - opam switch ${COMPILER}
   - eval $(opam config env)
   - opam config list
-  - opam install -j ${NJOBS} -y camlp5.${CAMLP5_VER} ocamlfind ${EXTRA_OPAM}
+  - opam install -j ${NJOBS} -y camlp5.${CAMLP5_VER} ocamlfind num ${EXTRA_OPAM}
   - rm -rf ~/.opam/log/
   - opam list
 


### PR DESCRIPTION
Previously it was installed for the compilation jobs causing random
failures when the other jobs got a cache without it.
