### PR TITLE
[stdlib] Do not use deprecated notations

### DIFF
--- a/plugins/extraction/ExtrOcamlNatBigInt.v
+++ b/plugins/extraction/ExtrOcamlNatBigInt.v
@@ -46,7 +46,7 @@ Extract Constant EqNat.eq_nat_decide => "Big.eq".
 
 Extract Constant Peano_dec.eq_nat_dec => "Big.eq".
 
-Extract Constant Compare_dec.nat_compare =>
+Extract Constant Nat.compare =>
  "Big.compare_case Eq Lt Gt".
 
 Extract Constant Compare_dec.leb => "Big.le".

--- a/plugins/extraction/ExtrOcamlNatInt.v
+++ b/plugins/extraction/ExtrOcamlNatInt.v
@@ -59,7 +59,7 @@ Extract Inlined Constant EqNat.eq_nat_decide => "(=)".
 
 Extract Inlined Constant Peano_dec.eq_nat_dec => "(=)".
 
-Extract Constant Compare_dec.nat_compare =>
+Extract Constant Nat.compare =>
  "fun n m -> if n=m then Eq else if n<m then Lt else Gt".
 Extract Inlined Constant Compare_dec.leb => "(<=)".
 Extract Inlined Constant Compare_dec.le_lt_dec => "(<=)".


### PR DESCRIPTION
This fixes two warnings in the standard library.