### PR TITLE
[toplevel] Respect COQ_COLORS environment variable

### DIFF
--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -344,13 +344,13 @@ let init_color color_mode =
     match colors with
     | None ->
       (** Default colors *)
+      Topfmt.default_styles ();
       Topfmt.init_terminal_output ~color:true
     | Some "" ->
       (** No color output *)
       Topfmt.init_terminal_output ~color:false
     | Some s ->
       (** Overwrite all colors *)
-      Topfmt.clear_styles ();
       Topfmt.parse_color_config s;
       Topfmt.init_terminal_output ~color:true
   end

--- a/vernac/topfmt.ml
+++ b/vernac/topfmt.ml
@@ -187,8 +187,8 @@ let init_tag_map styles =
   let set accu (name, st) = CString.Map.add name st accu in
   tag_map := List.fold_left set !tag_map styles
 
-let clear_styles () =
-  tag_map := CString.Map.empty
+let default_styles () =
+  init_tag_map (default_tag_map ())
 
 let parse_color_config file =
   let styles = Terminal.parse file in
@@ -257,7 +257,6 @@ let make_printing_functions () =
   print_prefix, print_suffix
 
 let init_terminal_output ~color =
-  init_tag_map (default_tag_map ());
   let push_tag, pop_tag, clear_tag = make_style_stack () in
   let print_prefix, print_suffix = make_printing_functions () in
   let tag_handler ft = {

--- a/vernac/topfmt.mli
+++ b/vernac/topfmt.mli
@@ -43,7 +43,7 @@ val std_logger   : ?pre_hdr:Pp.t -> Feedback.level -> Pp.t -> unit
 val emacs_logger : ?pre_hdr:Pp.t -> Feedback.level -> Pp.t -> unit
 
 (** Color output *)
-val clear_styles : unit -> unit
+val default_styles : unit -> unit
 val parse_color_config : string -> unit
 val dump_tags : unit -> (string * Terminal.style) list
 


### PR DESCRIPTION
Since 3fc02bb2034a ("[pp] Move terminal-specific tagging to the toplevel."), the `COQ_COLORS` environment variable has been ignored, since `init_terminal_output` unconditionally called init_tag_map with the default colors, overwriting any custom colors that had been previously set. Fix this by creating a separate function, `default_styles`, to set the default colors.

Also, remove the `clear_styles` function, as it was only called in one place and did nothing (since `tag_map` is empty to begin with).

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** bug fix


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes #6940