### PR TITLE
Add [shelf] and [unshelve_goals], and [unshelve_evar] tactics

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -50,6 +50,8 @@ Tactics
 - Added tactic optimize_heap, analogous to the Vernacular Optimize
   Heap, which performs a major garbage collection and heap compaction
   in the OCaml run-time system.
+- Added tactics unshelve_goals and unshelve_evar that allow focusing on
+  previously shelved goals by name or a given undefined evar term.
 - The tactics "dtauto", "dintuition", "firstorder" now handle inductive types
   with let bindings in the parameters.
 - The tactic "dtauto" now handles some inductives such as

--- a/doc/refman/RefMan-tac.tex
+++ b/doc/refman/RefMan-tac.tex
@@ -5365,6 +5365,16 @@ Reset Initial.
 
 \end{Variants}
 
+\subsection[\tt unshelve\_goals]{\tt
+  Unshelve\comindex{unshelve\_goals $\ident_1$ \dots $\ident_n$}\label{unshelvegoals}}
+
+This tactic unshelves the named goals {\ident$_1$ \dots \ident$_n$}, in
+the given order, putting them at the beginning of the subgoal list.
+It fails if any of those names does not correspond to a shelved subgoal.
+
+\subsection[\tt unshelve\_goals]{\tt
+  Unshelve\comindex{unshelve\_goals $\ident_1$ \dots $\ident_n$}\label{unshelvegoals}}
+
 \subsection[\tt Unshelve]{\tt Unshelve\comindex{Unshelve}\label{unshelve}}
 
 This command moves all the goals on the shelf (see Section~\ref{shelve}) from the

--- a/engine/proofview.mli
+++ b/engine/proofview.mli
@@ -307,6 +307,9 @@ val tclINDEPENDENTL: 'a tactic -> 'a list tactic
 
 (** {7 Goal manipulation} *)
 
+(** Returns the current shelved goals *)
+val shelf : Goal.goal list tactic
+
 (** Shelves all the goals under focus. The goals are placed on the
     shelf for later use (or being solved by side-effects). *)
 val shelve : unit tactic
@@ -330,9 +333,17 @@ val shelve_unifiable : unit tactic
     goals are unifiable (see {!shelve_unifiable}) in the current focus. *)
 val guard_no_unifiable : Names.Name.t list option tactic
 
+exception NotASubsetOfTheShelf
+
 (** [unshelve l p] adds all the goals in [l] at the end of the focused
-    goals of p *)
+    goals of [p].
+    @raise NotASubsetOfTheShelf if [l] refers to goals that are not actually
+    on the shelf. *)
 val unshelve : Evar.t list -> proofview -> proofview
+
+(** [unshelve_goals l] applies [unshelve] on the current proofview.
+    It can error with NotASubsetOfTheShelf. *)
+val unshelve_goals : Goal.goal list -> unit tactic
 
 (** [depends_on g1 g2 sigma] checks if g1 occurs in the type/ctx of g2 *)
 val depends_on : Evd.evar_map -> Evar.t -> Evar.t -> bool

--- a/plugins/ltac/extratactics.ml4
+++ b/plugins/ltac/extratactics.ml4
@@ -984,6 +984,32 @@ TACTIC EXTEND unshelve
     ]
 END
 
+let unshelve_goals gls =
+  Proofview.tclORELSE (Proofview.unshelve_goals gls)
+    (function (Proofview.NotASubsetOfTheShelf, _) ->
+       Tacticals.New.tclFAIL 0 (str "Not a subset of the shelf")
+            | (exn, info) -> Proofview.tclZERO ~info exn)
+
+(* Unshelves the specified goals. *)
+TACTIC EXTEND unshelve_goals
+| [ "unshelve_goals" ne_ident_list(l) ] ->
+   [
+     Proofview.tclEVARMAP >>= fun sigma ->
+     let goals = List.map (fun id -> Evd.evar_key id sigma) l in
+     unshelve_goals goals
+    ]
+END
+
+TACTIC EXTEND unshelve_evar
+| [ "unshelve_evar" constr(c) ] ->
+   [
+     Proofview.tclEVARMAP >>= fun sigma ->
+     let goals = [if isEvar sigma c then fst (destEvar sigma c)
+                  else user_err (str"Not an evar")] in
+     Proofview.unshelve_goals goals
+    ]
+END
+
 (* Command to add every unshelved variables to the focus *)
 VERNAC COMMAND EXTEND Unshelve
 [ "Unshelve" ]

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -969,10 +969,14 @@ module Search = struct
        let fgoals = Evd.future_goals evm in
        let pgoal = Evd.principal_future_goal evm in
        let _, pv = Proofview.init evm' [] in
-       let pv = Proofview.unshelve goals pv in
+       let inittac =
+         Proofview.tclTHEN (* Register in the shelf and unshelve *)
+           (Proofview.shelve_goals goals)
+           (Proofview.unshelve_goals goals)
+       in
        try
          let (), pv', (unsafe, shelved, gaveup), _ =
-           Proofview.apply env tac pv
+           Proofview.apply env (Proofview.tclTHEN inittac tac) pv
          in
          if Proofview.finished pv' then
            let evm' = Proofview.return pv' in

--- a/test-suite/success/unshelve.v
+++ b/test-suite/success/unshelve.v
@@ -17,3 +17,19 @@ intros F.
 unshelve (eapply (F _);clear F).
 2:reflexivity.
 Qed.
+
+Axioms A B : Prop.
+Goal A /\ B -> exists a : A, B.
+  clear; intros; evar (a:A); exists a.
+  revert a.
+  unshelve_evar ?a.
+  unshelve_goals a. all:cycle 1. apply (proj1 H).
+  Undo.
+  shelve. instantiate (1:=ltac:(refine (proj1 ?[a']))).
+  simple refine (let pf : A /\ B := ?[pf] in _); cycle 1.
+  intro a.
+  unify a (proj1 ?pf).
+  unify (proj1 ?pf) a.
+  Fail all: [ > unify ?pf ?a' | ]; [ | ].
+  Fail all: [ > unify ?a' ?pf | ]; [ | ].
+Abort.


### PR DESCRIPTION


Extruded this commit from unifall-infra as it is orthogonal and currently breaks, not sure if it can make it to 8.8.

Unshelve tactic removes shelved goals from the shelf

In testing unshelve_goals, w_unify is incorrect, it does not unfold
variables to see if some evar occur in them to continue unification.
With evarconv this is done correctly.

Beware unshelve goals is not a multigoal tactic as it takes idents.

Fix unshelve/unshelve_goals to throw an exception outside its domain
of definition, report to the user and document in CHANGES

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** feature




<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [x] Corresponding documentation was added / updated.
- [x] Entry added in CHANGES.
