### PR TITLE
Fix error with univ binders on monomorphic records.

### DIFF
--- a/test-suite/output/UnivBinders.out
+++ b/test-suite/output/UnivBinders.out
@@ -149,24 +149,24 @@ inmod@{u} -> Type@{v}
 (* u v |=  *)
 
 Applied.infunct is universe polymorphic
-axfoo@{i Top.41 Top.42} : Type@{Top.41} -> Type@{i}
-(* i Top.41 Top.42 |=  *)
+axfoo@{i Top.44 Top.45} : Type@{Top.44} -> Type@{i}
+(* i Top.44 Top.45 |=  *)
 
 axfoo is universe polymorphic
 Argument scope is [type_scope]
 Expands to: Constant Top.axfoo
-axbar@{i Top.41 Top.42} : Type@{Top.42} -> Type@{i}
-(* i Top.41 Top.42 |=  *)
+axbar@{i Top.44 Top.45} : Type@{Top.45} -> Type@{i}
+(* i Top.44 Top.45 |=  *)
 
 axbar is universe polymorphic
 Argument scope is [type_scope]
 Expands to: Constant Top.axbar
-axfoo' : Type@{Top.44} -> Type@{axbar'.i}
+axfoo' : Type@{Top.47} -> Type@{axbar'.i}
 
 axfoo' is not universe polymorphic
 Argument scope is [type_scope]
 Expands to: Constant Top.axfoo'
-axbar' : Type@{Top.44} -> Type@{axbar'.i}
+axbar' : Type@{Top.47} -> Type@{axbar'.i}
 
 axbar' is not universe polymorphic
 Argument scope is [type_scope]

--- a/test-suite/output/UnivBinders.v
+++ b/test-suite/output/UnivBinders.v
@@ -44,6 +44,9 @@ Module mono.
 
   Monomorphic Definition monomono := Type@{MONOU}.
   Check monomono.
+
+  Monomorphic Inductive monoind@{i} : Type@{i} := .
+  Monomorphic Record monorecord@{i} : Type@{i} := mkmonorecord {}.
 End mono.
 Check mono.monomono. (* qualified MONOU *)
 Import mono.

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -594,13 +594,12 @@ let definition_structure (kind,cum,poly,finite,(is_coe,({CAst.loc;v=idstruc},pl)
   let pl, univs, arity, template, implpars, params, implfs, fields =
     States.with_state_protection (fun () ->
       typecheck_params_and_fields finite (kind = Class true) idstruc poly pl s ps notations fs) () in
-  let gr = match kind with
+  match kind with
   | Class def ->
-     let priorities = List.map (fun id -> {hint_priority = id; hint_pattern = None}) priorities in
-     let gr = declare_class finite def cum pl univs (loc,idstruc) idbuild
-          implpars params arity template implfs fields is_coe coers priorities in
-	gr
-    | _ ->
+    let priorities = List.map (fun id -> {hint_priority = id; hint_pattern = None}) priorities in
+    declare_class finite def cum pl univs (loc,idstruc) idbuild
+      implpars params arity template implfs fields is_coe coers priorities
+  | _ ->
       let implfs = List.map
 	  (fun impls -> implpars @ Impargs.lift_implicits
 	           (succ (List.length params)) impls) implfs 
@@ -618,7 +617,4 @@ let definition_structure (kind,cum,poly,finite,(is_coe,({CAst.loc;v=idstruc},pl)
       let ind = declare_structure finite pl univs idstruc
 	  idbuild implpars params arity template implfs 
           fields is_coe (List.map (fun coe -> not (Option.is_empty coe)) coers) in
-	IndRef ind
-  in
-  Declare.declare_univ_binders gr pl;
-  gr
+      IndRef ind


### PR DESCRIPTION
Since 4eb6d29d1ca7e0cc28d59d19a50adb83f7b30a2a universe binders were
declared twice for all records.
Since 4fcf1fa32ff395d6bd5f6ce4803eee18173c4d36 this causes an
observable error for monomorphic records.
