### PR TITLE
 Fix expected number of arguments for cumulative constructors.

### DIFF
--- a/kernel/reduction.ml
+++ b/kernel/reduction.ml
@@ -251,11 +251,8 @@ let convert_inductives cv_pb ind nargs u1 u2 (s, check) =
     cv_pb ind nargs u1 u2 s, check
 
 let constructor_cumulativity_arguments (mind, ind, ctor) =
-  let nparamsctxt =
-    mind.Declarations.mind_nparams +
-    mind.Declarations.mind_packets.(ind).Declarations.mind_nrealargs
-    (* Context.Rel.length mind.Declarations.mind_params_ctxt *) in
-  nparamsctxt + mind.Declarations.mind_packets.(ind).Declarations.mind_consnrealargs.(ctor - 1)
+  mind.Declarations.mind_nparams +
+  mind.Declarations.mind_packets.(ind).Declarations.mind_consnrealargs.(ctor - 1)
 
 let convert_constructors_gen cmp_instances cmp_cumul (mind, ind, cns) nargs u1 u2 s =
   match mind.Declarations.mind_universes with

--- a/test-suite/success/cumulativity.v
+++ b/test-suite/success/cumulativity.v
@@ -128,3 +128,12 @@ Definition foo2@{i} : bar@{i} := let x := mkfoo in x. (* must reduce *)
 (* Rigid universes however should not be unified unnecessarily. *)
 Definition foo3@{i j|} : foo@{i} := let x := mkfoo@{j} in x.
 Definition foo4@{i j|} : bar@{i} := let x := mkfoo@{j} in x.
+
+(* Constructors for an inductive with indices *)
+Module WithIndex.
+  Inductive foo@{i} : (Prop -> Prop) -> Prop := mkfoo: foo (fun x => x).
+
+  Monomorphic Universes i j.
+  Monomorphic Constraint i < j.
+  Definition bar : eq mkfoo@{i} mkfoo@{j} := eq_refl _.
+End WithIndex.


### PR DESCRIPTION
We expected `nparams + nrealargs + consnrealargs` but the `nrealargs`
should not be there. This breaks cumulativity of constructors for any
inductive with indices (so records still work, explaining why the test
case in #6747 works).

There will be some conflict with #6775 because it factorizes the computation of expected arguments away from the instance in evarconv and with #6775 and #6747 because they all append to the `cumulativity.v` test.