### PR TITLE
coqide: queries from the query window are routed there (fix #5684)

### DIFF
--- a/ide/coqOps.mli
+++ b/ide/coqOps.mli
@@ -9,6 +9,7 @@
 (************************************************************************)
 
 open Coq
+open Interface
 
 class type ops =
 object
@@ -18,7 +19,8 @@ object
   method process_next_phrase : unit task
   method process_until_end_or_error : unit task
   method handle_reset_initial : unit task
-  method raw_coq_query : string -> unit task
+  method raw_coq_query :
+    route_id:int -> next:(query_rty value -> unit task) -> string -> unit task
   method show_goals : unit task
   method backtrack_last_phrase : unit task
   method initialize : unit task
@@ -30,7 +32,7 @@ object
   method get_slaves_status : int * int * string CString.Map.t
 
 
-  method handle_failure : Interface.handle_exn_rty -> unit task
+  method handle_failure : handle_exn_rty -> unit task
   
   method destroy : unit -> unit
 end
@@ -38,7 +40,7 @@ end
 class coqops :
   Wg_ScriptView.script_view ->
   Wg_ProofView.proof_view ->
-  Wg_MessageView.message_view ->
+  Wg_RoutedMessageViews.message_views_router ->
   Wg_Segment.segment ->
   coqtop ->
   (unit -> string option) ->

--- a/ide/ide.mllib
+++ b/ide/ide.mllib
@@ -26,15 +26,16 @@ Gtk_parsing
 Wg_Segment
 Wg_ProofView
 Wg_MessageView
+Wg_RoutedMessageViews
 Wg_Detachable
 Wg_Find
 Wg_Completion
 Wg_ScriptView
 Coq_commands
-Wg_Command
 FileOps
 Document
 CoqOps
+Wg_Command
 Session
 Coqide_ui
 NanoPG

--- a/ide/ideutils.ml
+++ b/ide/ideutils.ml
@@ -473,3 +473,15 @@ let browse_keyword prerr text =
     let u = Lazy.force url_for_keyword text in
     browse prerr (doc_url() ^ u)
   with Not_found -> prerr ("No documentation found for \""^text^"\".\n")
+
+let rec is_valid (s : Pp.t) = match Pp.repr s with
+  | Pp.Ppcmd_empty
+  | Pp.Ppcmd_print_break _
+  | Pp.Ppcmd_force_newline  -> true
+  | Pp.Ppcmd_glue l    -> List.for_all is_valid l
+  | Pp.Ppcmd_string s  -> Glib.Utf8.validate s
+  | Pp.Ppcmd_box (_,s)
+  | Pp.Ppcmd_tag (_,s) -> is_valid s
+  | Pp.Ppcmd_comment s -> List.for_all Glib.Utf8.validate s
+let validate s =
+  if is_valid s then s else Pp.str "This error massage can't be printed."

--- a/ide/ideutils.mli
+++ b/ide/ideutils.mli
@@ -98,3 +98,7 @@ val io_read_all : Glib.Io.channel -> string
 
 val run_command :
   (string -> unit) -> (Unix.process_status -> unit) -> string -> unit
+
+(* Checks if an error message is printable, it not replaces it with
+ * a printable error *)
+val validate : Pp.t -> Pp.t

--- a/ide/session.mli
+++ b/ide/session.mli
@@ -31,7 +31,7 @@ type session = {
   buffer : GText.buffer;
   script : Wg_ScriptView.script_view;
   proof : Wg_ProofView.proof_view;
-  messages : Wg_MessageView.message_view;
+  messages : Wg_RoutedMessageViews.message_views_router;
   segment : Wg_Segment.segment;
   fileops : FileOps.ops;
   coqops : CoqOps.ops;

--- a/ide/wg_MessageView.ml
+++ b/ide/wg_MessageView.ml
@@ -36,8 +36,8 @@ class type message_view =
     method refresh : bool -> unit
     method push : Ideutils.logger
       (** same as [add], but with an explicit level instead of [Notice] *)
-    method buffer : GText.buffer
-      (** for more advanced text edition *)
+    method has_selection : bool
+    method get_selected_text : string
   end
 
 let message_view () : message_view =
@@ -45,7 +45,6 @@ let message_view () : message_view =
     ~highlight_matching_brackets:true
     ~tag_table:Tags.Message.table ()
   in
-  let text_buffer = new GText.buffer buffer#as_buffer in
   let mark = buffer#create_mark ~left_gravity:false buffer#start_iter in
   let box = GPack.vbox () in
   let scroll = GBin.scrolled_window
@@ -120,7 +119,12 @@ let message_view () : message_view =
 
     method set msg = self#clear; self#add msg
 
-    method buffer = text_buffer
+    method has_selection = buffer#has_selection
+    method get_selected_text =
+      if buffer#has_selection then
+        let start, stop = buffer#selection_bounds in
+        buffer#get_text ~slice:true ~start ~stop ()
+      else ""
 
   end
   in

--- a/ide/wg_MessageView.mli
+++ b/ide/wg_MessageView.mli
@@ -26,8 +26,8 @@ class type message_view =
     method refresh : bool -> unit
     method push : Ideutils.logger
       (** same as [add], but with an explicit level instead of [Notice] *)
-    method buffer : GText.buffer
-      (** for more advanced text edition *)
+    method has_selection : bool
+    method get_selected_text : string
   end
 
 val message_view : unit -> message_view

--- a/ide/wg_RoutedMessageViews.ml
+++ b/ide/wg_RoutedMessageViews.ml
@@ -1,0 +1,47 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *   INRIA, CNRS and contributors - Copyright 1999-2018       *)
+(* <O___,, *       (see CREDITS file for the list of authors)           *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+class type message_views_router = object
+  method route : int -> Wg_MessageView.message_view
+  method default_route : Wg_MessageView.message_view
+
+  method has_selection : bool
+  method get_selected_text : string
+
+  method register_route : int -> Wg_MessageView.message_view -> unit
+  method delete_route : int -> unit
+end
+
+let message_views ~route_0 : message_views_router =
+  let route_table = Hashtbl.create 17 in
+  let () = Hashtbl.add route_table 0 route_0 in
+object
+  method route i =
+    try Hashtbl.find route_table i
+    with Not_found ->
+      (* at least the message will be printed somewhere*)
+      Hashtbl.find route_table 0
+
+  method default_route = route_0
+
+  method register_route i mv = Hashtbl.add route_table i mv
+
+  method delete_route i = Hashtbl.remove route_table i
+
+  method has_selection =
+    Hashtbl.fold (fun _ v -> (||) v#has_selection) route_table false
+
+  method get_selected_text =
+    Option.default ""
+      (Hashtbl.fold (fun _ v acc ->
+         if v#has_selection then Some v#get_selected_text else acc)
+      route_table None)
+
+end

--- a/ide/wg_RoutedMessageViews.mli
+++ b/ide/wg_RoutedMessageViews.mli
@@ -8,11 +8,16 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-class command_window : string -> Coq.coqtop -> CoqOps.coqops -> Wg_RoutedMessageViews.message_views_router ->
-  object
-    method new_query : ?command:string -> ?term:string -> unit -> unit
-    method pack_in : (GObj.widget -> unit) -> unit
-    method show : unit
-    method hide : unit
-    method visible : bool
-  end
+class type message_views_router = object
+  method route : int -> Wg_MessageView.message_view
+  method default_route : Wg_MessageView.message_view
+
+  method has_selection : bool
+  method get_selected_text : string
+
+  method register_route : int -> Wg_MessageView.message_view -> unit
+  method delete_route : int -> unit
+end
+
+val message_views :
+  route_0:Wg_MessageView.message_view -> message_views_router


### PR DESCRIPTION
We systematically use Wg_MessageView for both the message panel and each
Query tab; we register all MessageView in a RoutedMessageViews where the
default route (0) is the message panel. Queries from the Query panel pick
a non zero route to have their feedback message delivered to their MessageView
