### PR TITLE
Direct implementation of Ascii.eqb and String.eqb

### DIFF
--- a/theories/Bool/Bool.v
+++ b/theories/Bool/Bool.v
@@ -814,3 +814,10 @@ Defined.
 
 (** Reciprocally, from a decidability, we could state a
     [reflect] as soon as we have a [bool_of_sumbool]. *)
+
+(** For instance, we could state the correctness of [Bool.eqb] via [reflect]: *)
+
+Lemma eqb_spec (b b' : bool) : reflect (b = b') (eqb b b').
+Proof.
+ destruct b, b'; now constructor.
+Qed.

--- a/theories/Numbers/DecimalString.v
+++ b/theories/Numbers/DecimalString.v
@@ -94,7 +94,7 @@ Definition int_of_string s :=
  match s with
  | EmptyString => Some (Pos Nil)
  | String a s' =>
-   if ascii_dec a "-" then option_map Neg (uint_of_string s')
+   if Ascii.eqb a "-" then option_map Neg (uint_of_string s')
    else option_map Pos (uint_of_string s)
  end.
 
@@ -131,8 +131,8 @@ Proof.
  - unfold int_of_string.
    destruct (string_of_uint d) eqn:Hd.
    + now destruct d.
-   + destruct ascii_dec; subst.
-     * now destruct d.
+   + case Ascii.eqb_spec.
+     * intros ->. now destruct d.
      * rewrite <- Hd, usu; auto.
  - rewrite usu; auto.
 Qed.
@@ -141,8 +141,8 @@ Lemma sis s d :
  int_of_string s = Some d -> string_of_int d = s.
 Proof.
  destruct s; [intros [= <-]| ]; simpl; trivial.
- destruct ascii_dec; subst; simpl.
- - destruct (uint_of_string s) eqn:Hs; simpl; intros [= <-].
+ case Ascii.eqb_spec.
+ - intros ->. destruct (uint_of_string s) eqn:Hs; simpl; intros [= <-].
    simpl; f_equal. now apply sus.
  - destruct d; [ | now destruct uint_of_char].
    simpl string_of_int.
@@ -178,7 +178,7 @@ Definition int_of_string s :=
  match s with
  | EmptyString => None
  | String a s' =>
-   if ascii_dec a "-" then option_map Neg (uint_of_string s')
+   if Ascii.eqb a "-" then option_map Neg (uint_of_string s')
    else option_map Pos (uint_of_string s)
  end.
 
@@ -228,8 +228,8 @@ Proof.
    unfold int_of_string.
    destruct (string_of_uint d) eqn:Hd.
    + now destruct d.
-   + destruct ascii_dec; subst.
-     * now destruct d.
+   + case Ascii.eqb_spec.
+     * intros ->. now destruct d.
      * rewrite <- Hd, usu; auto. now intros ->.
  - intros _ H.
    rewrite usu; auto. now intros ->.
@@ -253,8 +253,8 @@ Lemma sis s d :
  int_of_string s = Some d -> string_of_int d = s.
 Proof.
  destruct s; [intros [=]| ]; simpl.
- destruct ascii_dec; subst; simpl.
- - destruct (uint_of_string s) eqn:Hs; simpl; intros [= <-].
+ case Ascii.eqb_spec.
+ - intros ->. destruct (uint_of_string s) eqn:Hs; simpl; intros [= <-].
    simpl; f_equal. now apply sus.
  - destruct d; [ | now destruct uint_of_char].
    simpl string_of_int.

--- a/theories/Strings/Ascii.v
+++ b/theories/Strings/Ascii.v
@@ -40,6 +40,25 @@ Proof.
   decide equality; apply bool_dec.
 Defined.
 
+Local Open Scope lazy_bool_scope.
+
+Definition eqb (a b : ascii) : bool :=
+ match a, b with
+ | Ascii a0 a1 a2 a3 a4 a5 a6 a7,
+   Ascii b0 b1 b2 b3 b4 b5 b6 b7 =>
+    Bool.eqb a0 b0 &&& Bool.eqb a1 b1 &&& Bool.eqb a2 b2 &&& Bool.eqb a3 b3
+    &&& Bool.eqb a4 b4 &&& Bool.eqb a5 b5 &&& Bool.eqb a6 b6 &&& Bool.eqb a7 b7
+ end.
+
+Infix "=?" := eqb : char_scope.
+
+Lemma eqb_spec (a b : ascii) : reflect (a = b) (a =? b)%char.
+Proof.
+ destruct a, b; simpl.
+ do 8 (case Bool.eqb_spec; [ intros -> | constructor; now intros [= ] ]).
+ now constructor.
+Qed.
+
 (** * Conversion between natural numbers modulo 256 and ascii characters *)
 
 (** Auxiliary function that turns a positive into an ascii by

--- a/theories/Strings/String.v
+++ b/theories/Strings/String.v
@@ -14,6 +14,7 @@
 
 Require Import Arith.
 Require Import Ascii.
+Require Import Bool.
 Declare ML Module "string_syntax_plugin".
 
 (** *** Definition of strings *)
@@ -34,6 +35,24 @@ Definition string_dec : forall s1 s2 : string, {s1 = s2} + {s1 <> s2}.
 Proof.
  decide equality; apply ascii_dec.
 Defined.
+
+Local Open Scope lazy_bool_scope.
+
+Fixpoint eqb s1 s2 : bool :=
+ match s1, s2 with
+ | EmptyString, EmptyString => true
+ | String c1 s1', String c2 s2' => Ascii.eqb c1 c2 &&& eqb s1' s2'
+ | _,_ => false
+ end.
+
+Infix "=?" := eqb : string_scope.
+
+Lemma eqb_spec s1 s2 : Bool.reflect (s1 = s2) (s1 =? s2)%string.
+Proof.
+ revert s2. induction s1; destruct s2; try (constructor; easy); simpl.
+ case Ascii.eqb_spec; simpl; [intros -> | constructor; now intros [= ]].
+ case IHs1; [intros ->; now constructor | constructor; now intros [= ]].
+Qed.
 
 (** *** Concatenation of strings *)
 


### PR DESCRIPTION
This is an alternative proposal for #6596 : instead of relying on a future improvement of Scheme Equality (#6794), I've directly written boolean equalities for type `ascii` and `string`, since this isn't so hard. For now, I only provide a `eqb_spec` correctness property, based on `Bool.reflect`, see an example of use in `DecimalString.v`. But the amount of properties around these new `eqb` functions could be extended later. We could also decide someday to implement `ascii_dec` and `string_dec` through these new fonctions plus `Bool.reflect_dec`.
