### PR TITLE
pre-commit, linter: verify user overlay extensions (must be sh)

### DIFF
--- a/dev/lint-repository.sh
+++ b/dev/lint-repository.sh
@@ -31,4 +31,6 @@ fi
 find . "(" -path ./.git -prune ")" -o -type f -print0 |
     xargs -0 dev/tools/check-eof-newline.sh || CODE=1
 
+dev/tools/check-overlays.sh || CODE=1
+
 exit $CODE

--- a/dev/tools/check-overlays.sh
+++ b/dev/tools/check-overlays.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+for f in dev/ci/user-overlays/*
+do
+    if ! ([[ $f = dev/ci/user-overlays/README.md ]] || [[ $f == *.sh ]])
+    then
+        >&2 echo "Bad overlay '$f'."
+        >&2 echo "User overlays need to have extension .sh to be picked up!"
+        exit 1
+    fi
+done

--- a/dev/tools/pre-commit
+++ b/dev/tools/pre-commit
@@ -5,6 +5,8 @@
 
 set -e
 
+dev/tools/check-overlays.sh
+
 if ! git diff --cached --name-only -z | xargs -0 dev/tools/check-eof-newline.sh ||
         ! git diff-index --check --cached HEAD >/dev/null 2>&1 ;
 then


### PR DESCRIPTION
This has come up a couple times.
