### PR TITLE
[default.nix] Pin nixpkgs version to include Sphinx dependencies

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -46,7 +46,6 @@ stdenv.mkDerivation rec {
   ] else []) ++ (if buildDoc then [
 
     # Sphinx doc dependencies
-    ocamlPackages.lablgtk
     pkgconfig (python3.withPackages
       (ps: [ ps.sphinx ps.sphinx_rtd_theme ps.pexpect ps.beautifulsoup4
              ps.antlr4-python3-runtime ps.sphinxcontrib-bibtex ]))

--- a/default.nix
+++ b/default.nix
@@ -21,8 +21,15 @@
 # Once the build is finished, you will find, in the current directory,
 # a symlink to where Coq was installed.
 
-{ pkgs ? (import <nixpkgs> {}), ocamlPackages ? pkgs.ocamlPackages,
-  buildIde ? true, buildDoc ? true, doCheck ? true }:
+{ pkgs ?
+    (import (fetchTarball
+      "https://github.com/NixOS/nixpkgs/archive/4345a2cef228a91c1d6d4bf626a0f933eb8cc4f9.tar.gz")
+    {})
+, ocamlPackages ? pkgs.ocamlPackages
+, buildIde ? true
+, buildDoc ? true
+, doCheck ? true
+}:
 
 with pkgs;
 


### PR DESCRIPTION
This pins the version of `nixpkgs` to some recent version that includes the freshly added sphinx modules (that are needed by the new doc infrastructure).

Current channels are too old (about 5 days old…) but binary substitutes for the packages we used should be available.
