### PR TITLE
[vernac] Move `Quit` and `Drop` to the toplevel layer.

### DIFF
--- a/dev/base_include
+++ b/dev/base_include
@@ -232,7 +232,7 @@ let _ = Flags.in_toplevel := true
 let _ = Constrextern.set_extern_reference
   (fun ?loc _ r -> CAst.make ?loc @@ Libnames.Qualid (Nametab.shortest_qualid_of_global Id.Set.empty r));;
 
-let go () = Coqloop.loop ~time:false ~state:Option.(get !Coqloop.drop_last_doc)
+let go () = Coqloop.loop ~state:Option.(get !Coqloop.drop_last_doc)
 
 let _ =
  print_string

--- a/ide/ide_slave.ml
+++ b/ide/ide_slave.ml
@@ -359,8 +359,6 @@ let handle_exn (e, info) =
     | _        -> None in
   let mk_msg () = CErrors.print ~info e in
   match e with
-  | CErrors.Drop -> dummy, None, Pp.str "Drop is not allowed by coqide!"
-  | CErrors.Quit -> dummy, None, Pp.str "Quit is not allowed by coqide!"
   | e ->
       match Stateid.get info with
       | Some (valid, _) -> valid, loc_of info, mk_msg ()

--- a/intf/vernacexpr.ml
+++ b/intf/vernacexpr.ml
@@ -457,8 +457,6 @@ type nonrec vernac_expr =
   | VernacCheckGuard
   | VernacProof of Genarg.raw_generic_argument option * section_subset_expr option
   | VernacProofMode of string
-  (* Toplevel control *)
-  | VernacToplevelControl of exn
 
   (* For extension *)
   | VernacExtend of extend_name * Genarg.raw_generic_argument list

--- a/lib/cErrors.ml
+++ b/lib/cErrors.ml
@@ -47,8 +47,6 @@ exception AlreadyDeclared of Pp.t (* for already declared Schemes *)
 let alreadydeclared pps = raise (AlreadyDeclared(pps))
 
 exception Timeout
-exception Drop
-exception Quit
 
 let handle_stack = ref []
 
@@ -126,7 +124,7 @@ end
 let noncritical = function
   | Sys.Break | Out_of_memory | Stack_overflow
   | Assert_failure _ | Match_failure _ | Anomaly _
-  | Timeout | Drop | Quit -> false
+  | Timeout -> false
   | Invalid_argument "equal: functional value" -> false
   | _ -> true
 [@@@ocaml.warning "+52"]

--- a/lib/cErrors.mli
+++ b/lib/cErrors.mli
@@ -53,8 +53,6 @@ val invalid_arg : ?loc:Loc.t -> string -> 'a
 val todo : string -> unit
 
 exception Timeout
-exception Drop
-exception Quit
 
 (** [register_handler h] registers [h] as a handler.
     When an expression is printed with [print e], it

--- a/parsing/g_vernac.ml4
+++ b/parsing/g_vernac.ml4
@@ -845,10 +845,6 @@ GEXTEND Gram
       | IDENT "Cd" -> VernacChdir None
       | IDENT "Cd"; dir = ne_string -> VernacChdir (Some dir)
 
-      (* Toplevel control *)
-      | IDENT "Drop" -> VernacToplevelControl Drop
-      | IDENT "Quit" -> VernacToplevelControl Quit
-
       | IDENT "Load"; verbosely = [ IDENT "Verbose" -> true | -> false ];
 	s = [ s = ne_string -> s | s = IDENT -> s ] ->
 	  VernacLoad (verbosely, s)

--- a/printing/ppvernac.ml
+++ b/printing/ppvernac.ml
@@ -181,8 +181,6 @@ open Decl_kinds
       | BoolValue b -> mt()
     in pr_printoption a None ++ pr_opt_value b
 
-  let pr_topcmd _ = str"(* <Warning> : No printer for toplevel commands *)"
-
   let pr_opt_hintbases l = match l with
     | [] -> mt()
     | _ as z -> str":" ++ spc() ++ prlist_with_sep sep str z
@@ -1187,10 +1185,6 @@ open Decl_kinds
             (keyword "Comments" ++ spc()
              ++ prlist_with_sep sep (pr_comment pr_constr) l)
         )
-
-      (* Toplevel control *)
-      | VernacToplevelControl exn ->
-        return (pr_topcmd exn)
 
       (* For extension *)
       | VernacExtend (s,c) ->

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -2734,7 +2734,6 @@ let merge_proof_branch ~valid ?id qast keep brname =
 (* When tty is true, this code also does some of the job of the user interface:
    jump back to a state that is valid *)
 let handle_failure (e, info) vcs =
-  if e = CErrors.Drop then Exninfo.iraise (e, info) else
   match Stateid.get info with
   | None ->
       VCS.restore vcs;
@@ -2881,11 +2880,6 @@ let process_transaction ?(newtip=Stateid.fresh ()) ?(part_of_script=true)
           rc
 
       (* Side effect on all branches *)
-      | VtUnknown, _ when Vernacprop.under_control expr = VernacToplevelControl Drop ->
-        let st = Vernacstate.freeze_interp_state `No in
-        ignore(stm_vernac_interp (VCS.get_branch_pos head) st x);
-        `Ok
-
       | VtSideff l, w ->
           let in_proof = not (VCS.Branch.equal head VCS.Branch.master) in
           let id = VCS.new_node ~id:newtip () in

--- a/stm/vernac_classifier.ml
+++ b/stm/vernac_classifier.ml
@@ -185,7 +185,6 @@ let classify_vernac e =
     | VernacResetName _ | VernacResetInitial
     | VernacBacktrack _ | VernacBackTo _ | VernacRestart -> VtMeta, VtNow
     (* What are these? *)
-    | VernacToplevelControl _
     | VernacRestoreState _
     | VernacWriteState _ -> VtSideff [], VtNow
     (* Plugins should classify their commands *)

--- a/toplevel/coqinit.ml
+++ b/toplevel/coqinit.ml
@@ -23,12 +23,12 @@ let set_debug () =
 
 let rcdefaultname = "coqrc"
 
-let load_rcfile ~rcfile ~time ~state =
+let load_rcfile ~rcfile ~state =
     try
       match rcfile with
       | Some rcfile ->
         if CUnix.file_readable_p rcfile then
-          Vernac.load_vernac ~time ~echo:false ~interactive:false ~check:true ~state rcfile
+          Vernac.load_vernac ~echo:false ~interactive:false ~check:true ~state rcfile
         else raise (Sys_error ("Cannot read rcfile: "^ rcfile))
       | None ->
 	try
@@ -39,7 +39,7 @@ let load_rcfile ~rcfile ~time ~state =
 	    Envars.home ~warn / "."^rcdefaultname^"."^Coq_config.version;
 	    Envars.home ~warn / "."^rcdefaultname
 	  ] in
-          Vernac.load_vernac ~time ~echo:false ~interactive:false ~check:true ~state inferedrc
+          Vernac.load_vernac ~echo:false ~interactive:false ~check:true ~state inferedrc
         with Not_found -> state
 	(*
 	Flags.if_verbose

--- a/toplevel/coqinit.mli
+++ b/toplevel/coqinit.mli
@@ -12,12 +12,12 @@
 
 val set_debug : unit -> unit
 
-val load_rcfile : rcfile:(string option) -> time:bool -> state:Vernac.State.t -> Vernac.State.t
+val load_rcfile : rcfile:(string option) -> state:Vernac.State.t -> Vernac.State.t
 
 val init_ocaml_path : unit -> unit
 
 (* LoadPath for toploop toplevels *)
-val toplevel_init_load_path : unit ->  Mltop.coq_path list
+val toplevel_init_load_path : unit -> Mltop.coq_path list
 
 (* LoadPath for Coq user libraries *)
 val libs_init_load_path : load_init:bool -> Mltop.coq_path list

--- a/toplevel/coqloop.mli
+++ b/toplevel/coqloop.mli
@@ -32,11 +32,8 @@ val set_prompt : (unit -> string) -> unit
 (** Toplevel feedback printer. *)
 val coqloop_feed : Feedback.feedback -> unit
 
-(** Parse and execute one vernac command. *)
-val do_vernac : time:bool -> state:Vernac.State.t -> Vernac.State.t
-
 (** Main entry point of Coq: read and execute vernac commands. *)
-val loop : time:bool -> state:Vernac.State.t -> Vernac.State.t
+val loop : state:Vernac.State.t -> Vernac.State.t
 
 (** Last document seen after `Drop` *)
 val drop_last_doc : Vernac.State.t option ref

--- a/toplevel/g_toplevel.ml4
+++ b/toplevel/g_toplevel.ml4
@@ -1,0 +1,43 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *   INRIA, CNRS and contributors - Copyright 1999-2018       *)
+(* <O___,, *       (see CREDITS file for the list of authors)           *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+open Pcoq
+open Vernacexpr
+
+(* Vernaculars specific to the toplevel *)
+type vernac_toplevel =
+  | VernacDrop
+  | VernacQuit
+  | VernacControl of vernac_control
+
+module Toplevel_ : sig
+  val vernac_toplevel : vernac_toplevel CAst.t Gram.entry
+end = struct
+  let gec_vernac s = Gram.entry_create ("toplevel:" ^ s)
+  let vernac_toplevel = gec_vernac "vernac_toplevel"
+end
+
+open Toplevel_
+
+GEXTEND Gram
+  GLOBAL: vernac_toplevel;
+  vernac_toplevel: FIRST
+    [ [ IDENT "Drop"; "." -> CAst.make VernacDrop
+      | IDENT "Quit"; "." -> CAst.make VernacQuit
+      | cmd = main_entry ->
+              match cmd with
+              | None -> raise Stm.End_of_input
+              | Some (loc,c) -> CAst.make ~loc (VernacControl c)
+      ]
+    ]
+  ;
+END
+
+let parse_toplevel pa = Pcoq.Gram.entry_parse vernac_toplevel pa

--- a/toplevel/toplevel.mllib
+++ b/toplevel/toplevel.mllib
@@ -1,5 +1,6 @@
 Vernac
 Usage
+G_toplevel
 Coqloop
 Coqinit
 Coqargs

--- a/toplevel/vernac.mli
+++ b/toplevel/vernac.mli
@@ -15,6 +15,7 @@ module State : sig
     doc : Stm.doc;
     sid : Stateid.t;
     proof : Proof.t option;
+    time : bool;
   }
 
 end
@@ -23,10 +24,10 @@ end
     expected to handle and print errors in form of exceptions, however
     care is taken so the state machine is left in a consistent
     state. *)
-val process_expr : time:bool -> state:State.t -> Vernacexpr.vernac_control CAst.t -> State.t
+val process_expr : state:State.t -> Vernacexpr.vernac_control CAst.t -> State.t
 
 (** [load_vernac echo sid file] Loads [file] on top of [sid], will
     echo the commands if [echo] is set. Callers are expected to handle
     and print errors in form of exceptions. *)
-val load_vernac : time:bool -> echo:bool -> check:bool -> interactive:bool ->
+val load_vernac : echo:bool -> check:bool -> interactive:bool ->
   state:State.t -> string -> State.t

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -2010,9 +2010,6 @@ let interp ?proof ~atts ~st c =
   | VernacUndoTo _    -> CErrors.user_err  (str "UndoTo cannot be used through the Load command")
   | VernacBacktrack _ -> CErrors.user_err  (str "Backtrack cannot be used through the Load command")
 
-  (* Toplevel control *)
-  | VernacToplevelControl e -> raise e
-
   (* Resetting *)
   | VernacResetName _  -> anomaly (str "VernacResetName not handled by Stm.")
   | VernacResetInitial -> anomaly (str "VernacResetInitial not handled by Stm.")

--- a/vernac/vernacinterp.ml
+++ b/vernac/vernacinterp.ml
@@ -79,7 +79,6 @@ let call opn converted_args ~atts ~st =
     phase := "Executing command";
     hunk ~atts ~st
   with
-    | Drop -> raise Drop
     | reraise ->
         let reraise = CErrors.push reraise in
         if !Flags.debug then


### PR DESCRIPTION
This is a first step towards moving REPL-specific commands out of the
core layers. In particular, we remove `Quit` and `Drop` from the core
vernacular to specific toplevel-level parsing rules.