### PR TITLE
Emergency fix for OSX packaging job on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -250,8 +250,10 @@ matrix:
       - EXTRA_OPAM="${LABLGTK}"
       before_install:
       - brew update
+      - brew unlink python
       - brew install opam gnu-time gtk+ expat gtksourceview gdk-pixbuf
-      - brew upgrade python
+      - brew unlink python@2
+      - brew install python3
       - pip3 install macpack
       before_deploy:
         - dev/build/osx/make-macos-dmg.sh


### PR DESCRIPTION
Updates to homebrew packages can currently make this packaging job fail
at any stage of the release cycle. Also, we are leaving dangerously
because we depend on python2 and python3 at the same time, which is not
supported by homebrew. To make this more reliable, we should switch to a
Nix-based build infrastructure at least for macOS.
