### PR TITLE
[ssreflect] Respect Opaque in FO unification

### DIFF
--- a/plugins/ssrmatching/ssrmatching.ml4
+++ b/plugins/ssrmatching/ssrmatching.ml4
@@ -311,14 +311,14 @@ let unif_HO_args env ise0 pa i ca =
 (* evars into metas, since 8.2 does not TC metas. This means some lossage *)
 (* for HO evars, though hopefully Miller patterns can pick up some of     *)
 (* those cases, and HO matching will mop up the rest.                     *)
-let flags_FO =
+let flags_FO env =
   let flags =
     { (Unification.default_no_delta_unify_flags ()).Unification.core_unify_flags
       with
         Unification.modulo_conv_on_closed_terms = None;
         Unification.modulo_eta = true;
         Unification.modulo_betaiota = true;
-        Unification.modulo_delta_types = full_transparent_state}
+        Unification.modulo_delta_types = Conv_oracle.get_transp_state (Environ.oracle env)}
   in
   { Unification.core_unify_flags = flags;
     Unification.merge_unify_flags = flags;
@@ -328,7 +328,8 @@ let flags_FO =
       (Unification.default_no_delta_unify_flags ()).Unification.resolve_evars
   }
 let unif_FO env ise p c =
-  Unification.w_unify env ise Reduction.CONV ~flags:flags_FO (EConstr.of_constr p) (EConstr.of_constr c)
+  Unification.w_unify env ise Reduction.CONV ~flags:(flags_FO env)
+    (EConstr.of_constr p) (EConstr.of_constr c)
 
 (* Perform evar substitution in main term and prune substitution. *)
 let nf_open_term sigma0 ise c =


### PR DESCRIPTION
This is only a very partial fix, since ssr uses evarconv which doesn't respect Opaque directives.

- [x] CI passed (unrelated timeout in VST)

FTR: This PR is a new incarnation of #7021 that was closed/recreated to use `CODEOWNERS`