### PR TITLE
Fix #7026: ssr: applying an overloaded lemma as a view takes too long.

### DIFF
--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -228,8 +228,9 @@ let splay_open_constr gl (sigma, c) =
   Reductionops.splay_prod env sigma t
 
 let isAppInd env sigma c =
-  try ignore(Tacred.reduce_to_atomic_ind env sigma c); true
-  with CErrors.UserError _ -> false
+  let c = Reductionops.clos_whd_flags CClosure.all env sigma c in
+  let c, _ = decompose_app_vect sigma c in
+  EConstr.isInd sigma c
 
 (** Generic argument-based globbing/typing utilities *)
 


### PR DESCRIPTION
Ssreflect was using a very complex function performing amongst other things
refolding to check that a term was an applied inductive type. It now relies
on a simple reduction followed by term matching.

Fixes #7026.