### PR TITLE
[default.nix] Add dependencies of the merging script.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -73,6 +73,13 @@ stdenv.mkDerivation rec {
     ocamlPackages.merlin
     ocamlPackages.ocpIndent
     ocamlPackages.ocp-index
+
+    # Dependencies of the merging script
+    jq
+    curl
+    git
+    gnupg
+
   ] else []);
 
   src =


### PR DESCRIPTION
This may be useful for new code owners who now need to use the merging script.