### PR TITLE
Owners for developer tools

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -293,3 +293,24 @@
 
 /META.coq         @ejgallego
 # Secondary maintainer @letouzey
+
+
+########## Developer tools ##########
+
+/dev/tools/backport-pr.sh     @Zimmi48
+# Secondary maintainer @maximedenes
+
+/dev/tools/change-header      @herbelin
+
+/dev/tools/check-eof-newline.sh @SkySkimmer
+
+/dev/tools/coqdev.el @SkySkimmer
+
+/dev/tools/github-check-prs.py @SkySkimmer
+
+/dev/tools/merge-pr.sh @maximedenes
+# Secondary maintainer @gares
+
+/dev/tools/pre-commit @SkySkimmer
+
+/dev/tools/sudo-apt-get-update @JasonGross


### PR DESCRIPTION
This PR adds owners for scripts in `dev/tools`. We need secondary maintainers for most of them, please volunteer!