### PR TITLE
Use Defined, not Qed, for well_founded lemmas of `N`

### DIFF
--- a/test-suite/bugs/closed/7060.v
+++ b/test-suite/bugs/closed/7060.v
@@ -17,5 +17,7 @@ Program Fixpoint fib (n : N) {measure n (N.lt)} : N
     fib (n - 1) + fib (n - 2).
 Solve Obligations with (solve_fib).
 
+(* to debug this, this can be helpful *)
+(* Eval cbv in fib 0. *)
 
 Goal fib 5 = 5. reflexivity. Qed.

--- a/test-suite/bugs/closed/7060.v
+++ b/test-suite/bugs/closed/7060.v
@@ -1,0 +1,21 @@
+Require Import Coq.Program.Wf.
+Require Import Coq.Program.Tactics.
+Require Import Coq.Program.Utils.
+Require Import Coq.NArith.BinNat.
+Require Import Psatz.
+Open Scope N_scope.
+
+Ltac solve_fib :=
+  program_simplify;
+  try apply N.lt_wf_0;
+  repeat match goal with  H : _ = false |- _ => apply N.eqb_neq in H end;
+  lia.
+
+Program Fixpoint fib (n : N) {measure n (N.lt)} : N
+ := if dec (n =? 0) then 0 else
+    if n =? 1 then 1 else
+    fib (n - 1) + fib (n - 2).
+Solve Obligations with (solve_fib).
+
+
+Goal fib 5 = 5. reflexivity. Qed.

--- a/theories/NArith/BinNat.v
+++ b/theories/NArith/BinNat.v
@@ -161,7 +161,7 @@ Theorem bi_induction :
     A 0 -> (forall n, A n <-> A (succ n)) -> forall n : N, A n.
 Proof.
 intros A A_wd A0 AS. apply peano_rect. assumption. intros; now apply -> AS.
-Qed.
+Defined.
 
 Definition recursion {A} : A -> (N -> A -> A) -> N -> A :=
   peano_rect (fun _ => A).

--- a/theories/Numbers/NatInt/NZOrder.v
+++ b/theories/Numbers/NatInt/NZOrder.v
@@ -626,7 +626,7 @@ auto with typeclass_instances.
 intros n H; constructor; intros y [H1 H2].
 apply nle_gt in H2. elim H2. now apply le_trans with z.
 intros n H1 H2; constructor; intros m [H3 H4]. now apply H2.
-Qed.
+Defined.
 
 Theorem gt_wf : well_founded Rgt.
 Proof.
@@ -637,7 +637,7 @@ intros n H; constructor; intros y [H1 H2].
 apply nle_gt in H2. elim H2. now apply le_lt_trans with n.
 intros n H1 H2; constructor; intros m [H3 H4].
 apply H2. assumption. now apply le_succ_l.
-Qed.
+Defined.
 
 End WF.
 

--- a/theories/Numbers/NatInt/NZOrder.v
+++ b/theories/Numbers/NatInt/NZOrder.v
@@ -432,7 +432,7 @@ Theorem strong_right_induction: right_step' -> forall n, z <= n -> A n.
 Proof.
 intro RS'; apply A'A_right; unfold A'; nzinduct n z;
 [apply rbase | apply rs'_rs''; apply RS'].
-Qed.
+Defined.
 
 Theorem right_induction : A z -> right_step -> forall n, z <= n -> A n.
 Proof.
@@ -458,7 +458,7 @@ destruct (lt_trichotomy n z) as [H | [H | H]].
 apply L; now apply lt_le_incl.
 apply L; now apply eq_le_incl.
 apply strong_right_induction. assumption. now apply lt_le_incl.
-Qed.
+Defined.
 
 End RightInduction.
 


### PR DESCRIPTION
so that a `Program Fixpoint` that uses `lt_wf` as a measure still
computes.