### PR TITLE
Slightly refining some error messages about unresolvable evars.

### DIFF
--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -807,11 +807,11 @@ let judge_of_new_Type evd =
   let (evd', s) = new_univ_variable univ_rigid evd in
   (evd', { uj_val = mkSort (Type s); uj_type = mkSort (Type (Univ.super s)) })
 
-let subterm_source evk (loc,k) =
+let subterm_source evk ?where (loc,k) =
   let evk = match k with
-    | Evar_kinds.SubEvar (evk) -> evk
+    | Evar_kinds.SubEvar (None,evk) when where = None -> evk
     | _ -> evk in
-  (loc,Evar_kinds.SubEvar evk)
+  (loc,Evar_kinds.SubEvar (where,evk))
 
 (* Add equality constraints for covariant/invariant positions. For
    irrelevant positions, unify universes when flexible. *)

--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -254,7 +254,7 @@ val evd_comb0 : (evar_map -> evar_map * 'a) -> evar_map ref -> 'a
 val evd_comb1 : (evar_map -> 'b -> evar_map * 'a) -> evar_map ref -> 'b -> 'a
 val evd_comb2 : (evar_map -> 'b -> 'c -> evar_map * 'a) -> evar_map ref -> 'b -> 'c -> 'a
 
-val subterm_source : Evar.t -> Evar_kinds.t Loc.located ->
+val subterm_source : Evar.t -> ?where:Evar_kinds.subevar_kind -> Evar_kinds.t Loc.located ->
   Evar_kinds.t Loc.located
 
 val meta_counter_summary_tag : int Summary.Dyn.tag

--- a/engine/termops.ml
+++ b/engine/termops.ml
@@ -206,8 +206,12 @@ let pr_evar_source = function
   | Evar_kinds.ImpossibleCase -> str "type of impossible pattern-matching clause"
   | Evar_kinds.MatchingVar _ -> str "matching variable"
   | Evar_kinds.VarInstance id -> str "instance of " ++ Id.print id
-  | Evar_kinds.SubEvar evk ->
-    str "subterm of " ++ Evar.print evk
+  | Evar_kinds.SubEvar (where,evk) ->
+     (match where with
+     | None -> str "subterm of "
+     | Some Evar_kinds.Body -> str "body of "
+     | Some Evar_kinds.Domain -> str "domain of "
+     | Some Evar_kinds.Codomain -> str "codomain of ") ++ Evar.print evk
 
 let pr_evar_info evi =
   let open Evd in

--- a/intf/evar_kinds.ml
+++ b/intf/evar_kinds.ml
@@ -21,6 +21,8 @@ type obligation_definition_status = Define of bool | Expand
 
 type matching_var_kind = FirstOrderPatVar of patvar | SecondOrderPatVar of patvar
 
+type subevar_kind = Domain | Codomain | Body
+
 type t =
   | ImplicitArg of global_reference * (int * Id.t option)
      * bool (** Force inference *)
@@ -34,4 +36,4 @@ type t =
   | ImpossibleCase
   | MatchingVar of matching_var_kind
   | VarInstance of Id.t
-  | SubEvar of Evar.t
+  | SubEvar of subevar_kind option * Evar.t

--- a/pretyping/cases.ml
+++ b/pretyping/cases.ml
@@ -1662,7 +1662,7 @@ let rec list_assoc_in_triple x = function
 let abstract_tycon ?loc env evdref subst tycon extenv t =
   let t = nf_betaiota env !evdref t in (* it helps in some cases to remove K-redex*)
   let src = match EConstr.kind !evdref t with
-    | Evar (evk,_) -> (Loc.tag ?loc @@ Evar_kinds.SubEvar evk)
+    | Evar (evk,_) -> (Loc.tag ?loc @@ Evar_kinds.SubEvar (None,evk))
     | _ -> (Loc.tag ?loc @@ Evar_kinds.CasesType true) in
   let subst0,t0 = adjust_to_extended_env_and_remove_deps env extenv !evdref subst t in
   (* We traverse the type T of the original problem Xi looking for subterms

--- a/test-suite/output/Errors.out
+++ b/test-suite/output/Errors.out
@@ -8,3 +8,11 @@ Unable to unify "nat" with "True".
 The command has indeed failed with message:
 Ltac call to "instantiate ( (ident) := (lglob) )" failed.
 Instance is not well-typed in the environment of ?x.
+The command has indeed failed with message:
+Cannot infer the domain of the type of f.
+The command has indeed failed with message:
+Cannot infer the domain of the implicit parameter A of id whose type is
+"Type".
+The command has indeed failed with message:
+Cannot infer the codomain of the type of f in environment:
+x : nat

--- a/test-suite/output/Errors.v
+++ b/test-suite/output/Errors.v
@@ -25,3 +25,9 @@ eexists ?[x].
 destruct H1 as [x1 H1].
 Fail instantiate (x:=projT1 x1).
 Abort.
+
+(* Test some messages for non solvable evars *)
+
+Fail Goal forall a f, f a = 0.
+Fail Goal forall f x, id f x = 0.
+Fail Goal forall f P,  P (f 0).

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -559,15 +559,21 @@ let rec explain_evar_kind env sigma evk ty = function
   | Evar_kinds.VarInstance id ->
       strbrk "an instance of type " ++ ty ++
       str " for the variable " ++ Id.print id
-  | Evar_kinds.SubEvar evk' ->
+  | Evar_kinds.SubEvar (where,evk') ->
       let evi = Evd.find sigma evk' in
       let pc = match evi.evar_body with
       | Evar_defined c -> pr_leconstr_env env sigma (EConstr.of_constr c)
       | Evar_empty -> assert false in
       let ty' = EConstr.of_constr evi.evar_concl in
+      (match where with
+      | Some Evar_kinds.Body -> str "the body of "
+      | Some Evar_kinds.Domain -> str "the domain of "
+      | Some Evar_kinds.Codomain -> str "the codomain of "
+      | None ->
       pr_existential_key sigma evk ++ str " of type " ++ ty ++
       str " in the partial instance " ++ pc ++
-      str " found for " ++ explain_evar_kind env sigma evk'
+      str " found for ") ++
+      explain_evar_kind env sigma evk'
       (pr_leconstr_env env sigma ty') (snd evi.evar_source)
 
 let explain_typeclass_resolution env sigma evi k =


### PR DESCRIPTION
**Kind:** enhancement

This is a slight enhancement in explaining the location of unresolved evars obtained by product or lambda refinement. For instance:
```coq
Goal forall a f, f a = 0.
(* before: Cannot infer an internal placeholder of type "Type" (unlocated) *)
(* after: Cannot infer the domain of the type of f (located at f) *)
```
```coq
Goal forall f P, P (f 0).
(* before: Cannot infer the type of f in environment: x : nat (already located at f) *)
(* after: Cannot infer the codomain of the type of f in environment: x : nat (located at f) *)
```

Note: I don't think this is worth being reported in documentation.