### PR TITLE
Porting congruence further to new tactic engine and econstr + fix prim. proj.

### DIFF
--- a/plugins/cc/ccalgo.mli
+++ b/plugins/cc/ccalgo.mli
@@ -9,7 +9,7 @@
 (************************************************************************)
 
 open Util
-open Constr
+open EConstr
 open Names
 
 type pa_constructor =
@@ -26,18 +26,18 @@ module PafMap : CSig.MapS with type key = pa_fun
 module PacMap : CSig.MapS with type key = pa_constructor
 
 type cinfo =
-    {ci_constr: pconstructor; (* inductive type *)
+    {ci_constr: Names.constructor * EInstance.t; (* inductive type *)
      ci_arity: int;     (* # args *)
      ci_nhyps: int}     (* # projectable args *)
 
 type term =
-    Symb of constr
+    Symb of Evd.evar_map * constr
   | Product of Sorts.t * Sorts.t
   | Eps of Id.t
   | Appli of term*term
   | Constructor of cinfo (* constructor arity + nhyps *)
 
-module Constrhash : Hashtbl.S with type key = constr
+module Constrhash : Hashtbl.S with type key = Evd.evar_map * constr
 module Termhash : Hashtbl.S with type key = term
 
 
@@ -47,7 +47,7 @@ type ccpattern =
 
 type rule=
     Congruence
-  | Axiom of constr * bool
+  | Axiom of (Evd.evar_map * constr) * bool
   | Injection of int * pa_constructor * int * pa_constructor * int
 
 type from=
@@ -134,7 +134,7 @@ val empty : int -> Goal.goal Evd.sigma -> state
 
 val add_term : state -> term -> int
 
-val add_equality : state -> constr -> term -> term -> unit
+val add_equality : state -> (Evd.evar_map * constr) -> term -> term -> unit
 
 val add_disequality : state -> from -> term -> term -> unit
 

--- a/plugins/cc/ccproof.ml
+++ b/plugins/cc/ccproof.ml
@@ -12,17 +12,17 @@
 (* proof-trees that will be transformed into proof-terms in cctac.ml4   *)
 
 open CErrors
-open Constr
+open EConstr
 open Ccalgo
 open Pp
 
 type rule=
-    Ax of constr
-  | SymAx of constr
+    Ax of (Evd.evar_map*constr)
+  | SymAx of (Evd.evar_map*constr)
   | Refl of term
   | Trans of proof*proof
   | Congr of proof*proof
-  | Inject of proof*pconstructor*int*int
+  | Inject of proof*(Names.constructor*EInstance.t)*int*int
 and proof =
     {p_lhs:term;p_rhs:term;p_rule:rule}
 

--- a/plugins/cc/ccproof.mli
+++ b/plugins/cc/ccproof.mli
@@ -9,15 +9,15 @@
 (************************************************************************)
 
 open Ccalgo
-open Constr
+open EConstr
 
 type rule=
-    Ax of constr
-  | SymAx of constr
+    Ax of (Evd.evar_map*constr)
+  | SymAx of (Evd.evar_map*constr)
   | Refl of term
   | Trans of proof*proof
   | Congr of proof*proof
-  | Inject of proof*pconstructor*int*int
+  | Inject of proof*(Names.constructor*EInstance.t)*int*int
 and proof =
     private {p_lhs:term;p_rhs:term;p_rule:rule}
 
@@ -37,7 +37,7 @@ val pax : (Ccalgo.term * Ccalgo.term) Ccalgo.Constrhash.t ->
 val psymax :  (Ccalgo.term * Ccalgo.term) Ccalgo.Constrhash.t ->
            Ccalgo.Constrhash.key -> proof
 
-val pinject :  proof -> pconstructor -> int -> int -> proof
+val pinject :  proof -> (Names.constructor * EInstance.t) -> int -> int -> proof
 
 (** Proof building functions *)
 


### PR DESCRIPTION
**Kind:** cleanup, fix

This PR is about the implementation of `congruence`. It includes three components:
- getting rid of a call to a V82 layer of the proof engine (see commit message for explanation)
- moving hashtables from constr to econstr (we represent terms by a pair (sigma,term) so that we can use EConstr equality to compare the terms indexing the tables)
- fixing what seems a bug with primitive projections (there was a special treatment of primitive projections constant which seems buggy and redundant; at least removing this code makes congruence working more with primitive projections; @mattam82, am I missing something? do you remember the intent of this code? maybe the objective was to make the projections compact again after expansion? If so, the fix should be improved)

As a consequence, `abort_on_undefined_evars:false` should not be needed anymore in plugin `cc` for #6454.