### PR TITLE
Accepting let's in the arity of a record (alternative solution to #6749)

### DIFF
--- a/test-suite/success/Inductive.v
+++ b/test-suite/success/Inductive.v
@@ -204,5 +204,5 @@ End NonRecLetIn.
 (* Test treatment of let-in in the definition of Records *)
 (* Should fail with "Sort expected" *)
 
-Fail Inductive foo (T : Type) : let T := Type in T :=
+Inductive foo (T : Type) : let T := Type in T :=
   { r : forall x : T, x = x }.


### PR DESCRIPTION
**Kind:** alternative bug fix / enhancement

This answers @skyskimmer's answer to this [question](https://github.com/coq/coq/pull/6749#issuecomment-366049275).

Otherwise, I find that this change is too much about a border case to justify being mentioned, but a policy which reports by principle about any change is also ok to me.