### PR TITLE
Update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -294,6 +294,9 @@
 /META.coq         @ejgallego
 # Secondary maintainer @letouzey
 
+/dev/build/windows @MSoegtropIMC
+# Secondary maintainer @maximedenes
+
 
 ########## Developer tools ##########
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -104,8 +104,8 @@
 /plugins/btauto/  @ppedrot
 # Secondary maintainer @herbelin
 
-# I don't know Pierre Corbineau's GitHub nickname
-/plugins/cc/            @herbelin
+/plugins/cc/           @PierreCorbineau
+# Secondary maintainer @herbelin
 
 /plugins/derive/        @aspiwack
 # Secondary maintainer @ppedrot
@@ -113,8 +113,8 @@
 /plugins/extraction/    @letouzey
 # Secondary maintainer @maximedenes
 
-# I don't know Pierre Corbineau's GitHub nickname
-/plugins/firstorder/    @herbelin
+/plugins/firstorder/   @PierreCorbineau
+# Secondary maintainer @herbelin
 
 /plugins/fourier/       @herbelin
 # Secondary maintainer @gares
@@ -149,8 +149,8 @@
 
 /plugins/quote/ @herbelin
 
-# Should be Pierre Corbineau too
-/plugins/rtauto/ @herbelin
+/plugins/rtauto/       @PierreCorbineau
+# Secondary maintainer @herbelin
 
 ########## Pretyper ##########
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -37,6 +37,10 @@
 /dev/doc/         @Zimmi48
 # Secondary maintainer @maximedenes
 
+/dev/doc/changes.md    @ghost
+# Trick to avoid getting review requests
+# each time someone modifies the dev changelog
+
 /doc/             @maximedenes
 # Secondary maintainer @silene
 


### PR DESCRIPTION
Two updates to the CODEOWNERS file:

- Use @PierreCorbineau GitHub nickname.
- Add @MSoegtropIMC as code owner for Windows build scripts (Michael, for the context, you might want to check https://github.com/coq/coq/blob/master/dev/doc/MERGING.md and https://github.com/coq/coq/issues/7032).