### PR TITLE
Preserving canonical structure of return predicate in vm_compute and native_compute (partial fix to #7068; also fixes #7076))

### DIFF
--- a/test-suite/bugs/closed/7068.v
+++ b/test-suite/bugs/closed/7068.v
@@ -1,0 +1,6 @@
+(* These tests are only about a subset of #7068 *)
+(* The original issue is still open *)
+
+Inductive foo : let T := Type in T := .
+Definition bob1 := Eval vm_compute in foo_rect.
+Definition bob2 := Eval native_compute in foo_rect.

--- a/test-suite/bugs/closed/7076.v
+++ b/test-suite/bugs/closed/7076.v
@@ -1,0 +1,4 @@
+(* These calls were raising an anomaly at some time *)
+Inductive A : nat -> id (nat->Type) := .
+Eval vm_compute in fun x => match x in A y z return y = z with end.
+Eval native_compute in fun x => match x in A y z return y = z with end.


### PR DESCRIPTION
**Kind:** bug fix

This is a partial fix of #7068 for the case of `vm_compute` and `native_compute`. This also fixes #7076.

As a curiosity, I did not try to bypass an invisible peculiarity of the `lazy` machine that `vm_compute` and `native_compute` use to normalize the assumptions of the arity of an inductive types. In the presence of:
```coq
Inductive A : let B:=nat in B -> Type := .
Eval vm_compute in fun x => match x in A y z return y = z with end.
```
the `B` used in the internal representation of the return predicate shall not be reduced to `nat`. I believe that this is not important (see also ceps [#35](https://github.com/coq/ceps/pull/35)).

