### PR TITLE
Remove naked pointers from the VM

### DIFF
--- a/kernel/byterun/coq_fix_code.h
+++ b/kernel/byterun/coq_fix_code.h
@@ -26,7 +26,7 @@ void init_arity();
 
 #define Is_instruction(pc,instr) (*pc == VALINSTR(instr))
 
-value coq_tcode_of_code(value code, value len);
+value coq_tcode_of_code(value code);
 value coq_makeaccu (value i);
 value coq_pushpop (value i);
 value coq_is_accumulate_code(value code);

--- a/kernel/byterun/coq_memory.c
+++ b/kernel/byterun/coq_memory.c
@@ -10,6 +10,7 @@
 
 #include <stdio.h>
 #include <string.h> 
+#include <caml/alloc.h>
 #include "coq_gc.h"
 #include "coq_instruct.h"
 #include "coq_fix_code.h"
@@ -46,7 +47,11 @@ value coq_static_alloc(value size) /* ML */
 
 value accumulate_code(value unit) /* ML */
 {
-  return (value) accumulate;
+  CAMLparam1(unit);
+  CAMLlocal1(res);
+  res = caml_alloc_small(1, Abstract_tag);
+  Code_val(res) = accumulate;
+  CAMLreturn(res);
 }
 
 static void (*coq_prev_scan_roots_hook) (scanning_action);

--- a/kernel/byterun/coq_memory.c
+++ b/kernel/byterun/coq_memory.c
@@ -11,6 +11,7 @@
 #include <stdio.h>
 #include <string.h> 
 #include <caml/alloc.h>
+#include <caml/address_class.h>
 #include "coq_gc.h"
 #include "coq_instruct.h"
 #include "coq_fix_code.h"
@@ -61,6 +62,10 @@ static void coq_scan_roots(scanning_action action)
   register value * i;
   /* Scan the stack */
   for (i = coq_sp; i < coq_stack_high; i++) {
+#ifdef NO_NAKED_POINTERS
+    /* The VM stack may contain C-allocated bytecode */
+    if (Is_block(*i) && !Is_in_heap_or_young(*i)) continue;
+#endif
     (*action) (*i, i);
   };
   /* Hook */

--- a/kernel/byterun/coq_memory.c
+++ b/kernel/byterun/coq_memory.c
@@ -99,8 +99,12 @@ value init_coq_vm(value unit) /* ML */
     /* Initialing the interpreter */
     init_coq_interpreter();
     
-    /* Some predefined pointer code */
-    accumulate = (code_t) coq_stat_alloc(sizeof(opcode_t));
+    /* Some predefined pointer code.
+     * It is typically contained in accumlator blocks whose tag is 0 and thus
+     * scanned by the GC, so make it look like an OCaml block. */
+    value accu_block = (value) coq_stat_alloc(2 * sizeof(value));
+    Hd_hp (accu_block) = Make_header (1, Abstract_tag, Caml_black);        \
+    accumulate = (code_t) Val_hp(accu_block);
     *accumulate = VALINSTR(ACCUMULATE);
 
   /* Initialize GC */

--- a/kernel/cemitcodes.ml
+++ b/kernel/cemitcodes.ml
@@ -20,7 +20,7 @@ open Mod_subst
 
 type emitcodes = String.t
 
-external tcode_of_code : Bytes.t -> int -> Vmvalues.tcode = "coq_tcode_of_code"
+external tcode_of_code : Bytes.t -> Vmvalues.tcode = "coq_tcode_of_code"
 
 (* Relocation information *)
 type reloc_info =
@@ -82,7 +82,7 @@ let patch buff pl f =
   (** Order seems important here? *)
   let reloc = CArray.map (fun (r, pos) -> (f r, pos)) pl.reloc_infos in
   let buff = patch_int buff reloc in
-  tcode_of_code buff (Bytes.length buff)
+  tcode_of_code buff
 
 (* Buffering of bytecode *)
 


### PR DESCRIPTION
Depends on #6908.

This PR makes Coq compatible with the `no-naked-pointer` configure flag of OCaml. This flag changes the runtime of OCaml by assuming the following memory layout invariants:
- any pointer reachable from a non-abstract (tag < Abstract_tag) and non-closure OCaml datastructure must have a valid OCaml block header
- any such reachable block living out of the OCaml heap must have black color.

This is always enforced by the OCaml code, but obviously C code can mess with this assumption. In particular, in Coq, the VM is notably breaking it. This sometimes wreak havoc with exotic compiler flags, in particular the no-naked-pointer one. This patch fixes it by:
- wrapping all OCaml-facing Coq VM bytecode, which are C-allocated strings, into an abstract block.
- equipping the VM accumulate code with a proper header, as it can appear in arbitrary structures
- when the no-naked-pointer flag is set, making the GC aware that the VM stack may contain naked pointers.

To check that this was properly done, I compiled all of fiat with this PR and the no-naked-pointer flavour of the OCaml compiler, and it worked like a charm. (Not on the first try. Nor on the second. But I'm pretty confident this is OK now.)

I don't have the infrastructure to test this assumption yet (see coq/coq-bench#38) but in theory, the no-naked-pointer option should shave off a few percents of the compilation time of Coq files, as it makes amongst other things weak pointers cheaper, the latter being used intensively in hashconsing, a well-known bottleneck.

Performance-wise, the PR makes the VM allocate four more words in the SWITCHBLOCK VM case to wrap the bytecode, and adds a few indirections in reification, but that's about it. It doesn't seem to have any kind of influence on the benchmarks though.

Benchmark:
```
┌──────────────────────────┬─────────────────────────┬───────────────────────────────────────┬───────────────────────────────────────┬─────────────────────────┬─────────────────┐
│                          │      user time [s]      │              CPU cycles               │           CPU instructions            │  max resident mem [KB]  │   mem faults    │
│                          │                         │                                       │                                       │                         │                 │
│             package_name │     NEW     OLD PDIFF   │            NEW            OLD PDIFF   │            NEW            OLD PDIFF   │     NEW     OLD PDIFF   │ NEW OLD PDIFF   │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│      coq-formal-topology │   37.06   37.38 -0.86 % │   100372361096   100757205162 -0.38 % │   125220765417   125350096529 -0.10 % │  483268  483584 -0.07 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│                  coq-vst │ 4039.74 4066.06 -0.65 % │ 11229911198063 11301029500966 -0.63 % │ 14851774646908 14867787217659 -0.11 % │ 2225624 2227168 -0.07 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│                 coq-corn │ 1559.81 1565.24 -0.35 % │  4316114645730  4332138067164 -0.37 % │  6417426619302  6417112345381 +0.00 % │  879248  875092 +0.47 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│   coq-mathcomp-character │  274.87  275.67 -0.29 % │   761834950448   764236798600 -0.31 % │  1081622525354  1081574300664 +0.00 % │ 1072844 1072876 -0.00 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│              coq-bignums │   80.09   80.27 -0.22 % │   220743711193   221155259807 -0.19 % │   285770630953   285803808436 -0.01 % │  527000  527284 -0.05 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│    coq-mathcomp-solvable │  201.45  201.90 -0.22 % │   558018492354   558931381147 -0.16 % │   767192885608   767172101594 +0.00 % │  866080  866536 -0.05 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│     coq-mathcomp-algebra │  184.94  185.34 -0.22 % │   512085081368   512136637520 -0.01 % │   689577546990   689574639065 +0.00 % │  645952  652424 -0.99 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│                coq-flocq │   63.31   63.42 -0.17 % │   174709756577   174464909593 +0.14 % │   211429853604   211476916980 -0.02 % │  667372  663860 +0.53 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│ coq-mathcomp-real_closed │  172.65  172.64 +0.01 % │   477630777356   477891582901 -0.05 % │   700137324946   700195737379 -0.01 % │  843468  843508 -0.00 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│                 coq-hott │  327.15  326.94 +0.06 % │   907754071650   905909403436 +0.20 % │  1400910474942  1401361344029 -0.03 % │  497644  497700 -0.01 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│            coq-fiat-core │  111.43  111.33 +0.09 % │   309286287035   309364672331 -0.03 % │   376486300674   376711650304 -0.06 % │  502100  502284 -0.04 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│               coq-geocoq │ 3113.93 3111.12 +0.09 % │  8637948430133  8629326858949 +0.10 % │ 13801513309635 13800933785665 +0.00 % │ 1211972 1241552 -2.38 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│    coq-mathcomp-fingroup │   64.34   64.26 +0.12 % │   177630282267   177711946792 -0.05 % │   235697132120   235806653497 -0.05 % │  592848  592240 +0.10 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│         coq-fiat-parsers │  705.76  704.16 +0.23 % │  1953584227267  1948153325431 +0.28 % │  2971642129330  2974567287766 -0.10 % │ 3367756 3367580 +0.01 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│   coq-mathcomp-ssreflect │   44.82   44.70 +0.27 % │   122443951304   122384676751 +0.05 % │   142407570019   142562990727 -0.11 % │  537536  537712 -0.03 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│           coq-coquelicot │   81.44   81.22 +0.27 % │   224821578246   224749169993 +0.03 % │   265325295549   265272191883 +0.02 % │  716820  715016 +0.25 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│   coq-mathcomp-odd_order │ 1432.12 1424.66 +0.52 % │  3977197232545  3957272435656 +0.50 % │  6664264491816  6664774453398 -0.01 % │ 1394208 1394036 +0.01 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│       coq-mathcomp-field │  460.90  458.49 +0.53 % │  1279325805031  1272994015206 +0.50 % │  2061027840908  2061156247631 -0.01 % │  814352  814376 -0.00 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│             coq-compcert │  866.68  861.76 +0.57 % │  2404172632721  2388459373290 +0.66 % │  3427568749211  3429343979958 -0.05 % │ 1321300 1322480 -0.09 % │   0   0  +nan % │
└──────────────────────────┴─────────────────────────┴───────────────────────────────────────┴───────────────────────────────────────┴─────────────────────────┴─────────────────┘
NEW = 24accc42da9fc3c3b27e5839b702933bbf24da6a
OLD = e128900aee63c972d7977fd47e3fd21649b63409
```
