### PR TITLE
stm: don't propagate side effects when editing a proof

### DIFF
--- a/test-suite/ide/bug7088.fake
+++ b/test-suite/ide/bug7088.fake
@@ -1,0 +1,13 @@
+ADD { Arguments id T x : rename. }
+ADD { Lemma foo : True. }
+ADD here { Proof. }
+ADD { exact 3. }
+ADD { Qed. }
+WAIT
+EDIT_AT here
+ADD { Arguments id FOO BAR : rename. }
+ADD { exact I. }
+ADD { Qed. }
+ADD { Arguments id T x : assert. }
+JOIN
+


### PR DESCRIPTION
Fix #7088 

## Problem

When a proof id edited, the only changes that are allowed are local to the proof branch being `Edit`ed.
The API `propagate_side_effect` alters all branches, not just the current one (it is its sole purpose)

## Fix

We don't propagate the side effect when we are editing a proof.

## Drawback (unfixable)

A command like `Transparent` that is added late (while editing a proof) has only effect inside the proof.
This is not the case for the same command when it is there from the very beginning.
The only fix would be to change the semantics: commands inside proofs always have a local effect, but this is for Coq 9 (for sure, not for a last minute bugfix)