### PR TITLE
Fix #6631: Derive Plugin gives "Anomaly: more than one statement".

### DIFF
--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -4987,15 +4987,15 @@ let anon_id = Id.of_string "anonymous"
 let name_op_to_name name_op object_kind suffix =
   let open Proof_global in
   let default_gk = (Global, false, object_kind) in
+  let name, gk = match Proof_global.V82.get_current_initial_conclusions () with
+  | (id, (_, gk)) -> Some id, gk
+  | exception NoCurrentProof -> None, default_gk
+  in
   match name_op with
-    | Some s ->
-      (try let _, gk, _ = Pfedit.current_proof_statement () in s, gk
-       with NoCurrentProof -> s, default_gk)
-    | None   ->
-      let name, gk =
-	try let name, gk, _ = Pfedit.current_proof_statement () in name, gk
-	with NoCurrentProof -> anon_id, default_gk in
-      add_suffix name suffix, gk
+  | Some s -> s, gk
+  | None ->
+    let name = Option.default anon_id name in
+    add_suffix name suffix, gk
 
 let tclABSTRACT ?(opaque=true) name_op tac =
   let s, gk = if opaque

--- a/test-suite/bugs/closed/6631.v
+++ b/test-suite/bugs/closed/6631.v
@@ -1,0 +1,7 @@
+Require Import Coq.derive.Derive.
+
+Derive f SuchThat (f = 1 + 1) As feq.
+Proof.
+  transitivity 2; [refine (eq_refl 2)|].
+  transitivity 2.
+  2:abstract exact (eq_refl 2).


### PR DESCRIPTION
We use a lower level function that accesses the proof without raising an
anomaly. This is a direct candidate for backport, so I used a V82 API but
eventually this API should be cleaned up.

Fixes #6631.