### PR TITLE
Option -distrust-sections to retypecheck at section end.

### DIFF
--- a/interp/declare.ml
+++ b/interp/declare.ml
@@ -110,6 +110,11 @@ let discharge_constant ((sp, kn), obj) =
   let new_hyps = (discharged_hyps kn hyps) @ obj.cst_hyps in
   let abstract = (named_of_variable_context hyps, subst, uctx) in
   let new_decl = GlobalRecipe{ from; info = { Opaqueproof.modlist; abstract}} in
+  let new_decl =
+    if Global.is_distrust_sections ()
+    then Discharge.process_constant new_decl
+    else new_decl
+  in
   Some { obj with cst_hyps = new_hyps; cst_decl = Some new_decl; }
 
 (* Hack to reduce the size of .vo: we keep only what load/open needs *)

--- a/interp/discharge.mli
+++ b/interp/discharge.mli
@@ -12,5 +12,8 @@ open Declarations
 open Entries
 open Opaqueproof
 
+val process_constant :
+  Safe_typing.global_declaration -> Safe_typing.global_declaration
+
 val process_inductive :
   Lib.abstr_info -> work_list -> mutual_inductive_body -> mutual_inductive_entry

--- a/kernel/safe_typing.mli
+++ b/kernel/safe_typing.mli
@@ -150,6 +150,9 @@ val add_constraints :
 val set_engagement : Declarations.engagement -> safe_transformer0
 val set_typing_flags : Declarations.typing_flags -> safe_transformer0
 
+val is_distrust_sections : safe_environment -> bool
+val set_distrust_sections : bool -> safe_transformer0
+
 (** {6 Interactive module functions } *)
 
 val start_module : Label.t -> ModPath.t safe_transformer

--- a/library/global.ml
+++ b/library/global.ml
@@ -259,6 +259,13 @@ let is_type_in_type r =
   | IndRef ind -> Environ.type_in_type_ind ind env
   | ConstructRef cstr -> Environ.type_in_type_ind (inductive_of_constructor cstr) env
 
+let set_distrust_sections b =
+  globalize0 (Safe_typing.set_distrust_sections b)
+
+let is_distrust_sections () =
+  let senv = safe_env () in
+  Safe_typing.is_distrust_sections senv
+
 let current_dirpath () = 
   Safe_typing.current_dirpath (safe_env ())
 

--- a/library/global.mli
+++ b/library/global.mli
@@ -127,6 +127,9 @@ val is_polymorphic : Globnames.global_reference -> bool
 val is_template_polymorphic : Globnames.global_reference -> bool
 val is_type_in_type : Globnames.global_reference -> bool
 
+val is_distrust_sections : unit -> bool
+val set_distrust_sections : bool -> unit
+
 val constr_of_global_in_context : Environ.env ->
   Globnames.global_reference -> Constr.types * Univ.AUContext.t
 (** Returns the type of the constant in its local universe

--- a/tools/coqc.ml
+++ b/tools/coqc.ml
@@ -97,7 +97,7 @@ let parse_args () =
       |"-batch"|"-noinit"|"-nois"|"-noglob"|"-no-glob"
       |"-q"|"-profile"|"-echo" |"-quiet"
       |"-silent"|"-m"|"-beautify"|"-strict-implicit"
-      |"-impredicative-set"|"-vm"|"-native-compiler"
+      |"-distrust-sections"|"-impredicative-set"|"-vm"|"-native-compiler"
       |"-indices-matter"|"-quick"|"-type-in-type"
       |"-async-proofs-always-delegate"|"-async-proofs-never-reopen-branch"
       |"-stm-debug"

--- a/toplevel/coqargs.ml
+++ b/toplevel/coqargs.ml
@@ -66,6 +66,7 @@ type coq_cmdopts = {
 
   color : color;
 
+  distrust_sections : bool;
   impredicative_set : Declarations.set_predicativity;
   stm_flags   : Stm.AsyncOpts.stm_opt;
   debug       : bool;
@@ -114,6 +115,7 @@ let init_args = {
 
   color = `AUTO;
 
+  distrust_sections = false;
   impredicative_set = Declarations.PredicativeSet;
   stm_flags    = Stm.AsyncOpts.default_opts;
   debug        = false;
@@ -544,6 +546,8 @@ let parse_args arglist : coq_cmdopts * string list =
       Flags.ide_slave := true;
       { oval with toploop = Some "coqidetop" }
 
+    | "-distrust-sections" ->
+      { oval with distrust_sections = true }
     |"-impredicative-set" ->
       { oval with impredicative_set = Declarations.ImpredicativeSet }
     |"-indices-matter" -> Indtypes.enforce_indices_matter (); oval

--- a/toplevel/coqargs.mli
+++ b/toplevel/coqargs.mli
@@ -41,6 +41,7 @@ type coq_cmdopts = {
 
   color : color;
 
+  distrust_sections : bool;
   impredicative_set : Declarations.set_predicativity;
   stm_flags   : Stm.AsyncOpts.stm_opt;
   debug       : bool;

--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -442,6 +442,7 @@ let init_toplevel arglist =
       end;
       Flags.if_verbose print_header ();
       Mltop.init_known_plugins ();
+      Global.set_distrust_sections opts.distrust_sections;
       Global.set_engagement opts.impredicative_set;
 
       (* Allow the user to load an arbitrary state here *)

--- a/toplevel/usage.ml
+++ b/toplevel/usage.ml
@@ -76,6 +76,7 @@ let print_usage_channel co command =
 \n  -emacs                 tells Coq it is executed under Emacs\
 \n  -noglob                do not dump globalizations\
 \n  -dump-glob f           dump globalizations in file f (to be used by coqdoc)\
+\n  -distrust-sections     developer option, do not use\
 \n  -impredicative-set     set sort Set impredicative\
 \n  -indices-matter        levels of indices (and nonuniform parameters) contribute to the level of inductives\
 \n  -type-in-type          disable universe consistency checking\


### PR DESCRIPTION
(when the option is set) We call cooking from outside the kernel then translate to a constant entry. This just means messing with futures for opaque constants and getting back the non-abstract universes for polymorphic constants.

Not tested with vio/IDE async.

Closes #6389.

- [ ] Corresponding documentation was added / updated.
- [ ] Entry added in CHANGES.
