### PR TITLE
[stm] Move VernacBacktrack to the toplevel.

### DIFF
--- a/intf/vernacexpr.ml
+++ b/intf/vernacexpr.ml
@@ -446,7 +446,6 @@ type nonrec vernac_expr =
   | VernacRestart
   | VernacUndo of int
   | VernacUndoTo of int
-  | VernacBacktrack of int*int*int
   | VernacFocus of int option
   | VernacUnfocus
   | VernacUnfocused

--- a/parsing/g_vernac.ml4
+++ b/parsing/g_vernac.ml4
@@ -1065,8 +1065,6 @@ GEXTEND Gram
       | IDENT "Back" -> VernacBack 1
       | IDENT "Back"; n = natural -> VernacBack n
       | IDENT "BackTo"; n = natural -> VernacBackTo n
-      | IDENT "Backtrack"; n = natural ; m = natural ; p = natural ->
-	  VernacBacktrack (n,m,p)
 
 (* Tactic Debugger *)
       |	IDENT "Debug"; IDENT "On" ->

--- a/printing/ppvernac.ml
+++ b/printing/ppvernac.ml
@@ -591,8 +591,6 @@ open Decl_kinds
         )
       | VernacUndoTo i ->
         return (keyword "Undo" ++ spc() ++ keyword "To" ++ pr_intarg i)
-      | VernacBacktrack (i,j,k) ->
-        return (keyword "Backtrack" ++  spc() ++ prlist_with_sep sep int [i;j;k])
       | VernacFocus i ->
         return (keyword "Focus" ++ pr_opt int i)
       | VernacShow s ->

--- a/stm/vernac_classifier.ml
+++ b/stm/vernac_classifier.ml
@@ -183,7 +183,7 @@ let classify_vernac e =
     | VernacBack _ | VernacAbortAll
     | VernacUndoTo _ | VernacUndo _
     | VernacResetName _ | VernacResetInitial
-    | VernacBacktrack _ | VernacBackTo _ | VernacRestart -> VtMeta, VtNow
+    | VernacBackTo _ | VernacRestart -> VtMeta, VtNow
     (* What are these? *)
     | VernacRestoreState _
     | VernacWriteState _ -> VtSideff [], VtNow

--- a/toplevel/coqloop.ml
+++ b/toplevel/coqloop.ml
@@ -338,6 +338,13 @@ let rec vernac_loop ~state =
   try
     let input = top_buffer.tokens in
     match read_sentence ~state input with
+    | {v=VernacBacktrack(bid,_,_)} ->
+      let bid = Stateid.of_int bid in
+      let doc, res = Stm.edit_at ~doc:state.doc bid in
+      assert (res = `NewTip);
+      let state = { state with doc; sid = bid } in
+      vernac_loop ~state
+
     | {v=VernacQuit} ->
       exit 0
     | {v=VernacDrop} ->

--- a/toplevel/g_toplevel.ml4
+++ b/toplevel/g_toplevel.ml4
@@ -9,10 +9,12 @@
 (************************************************************************)
 
 open Pcoq
+open Pcoq.Prim
 open Vernacexpr
 
 (* Vernaculars specific to the toplevel *)
 type vernac_toplevel =
+  | VernacBacktrack of int * int * int
   | VernacDrop
   | VernacQuit
   | VernacControl of vernac_control
@@ -31,6 +33,8 @@ GEXTEND Gram
   vernac_toplevel: FIRST
     [ [ IDENT "Drop"; "." -> CAst.make VernacDrop
       | IDENT "Quit"; "." -> CAst.make VernacQuit
+      | IDENT "Backtrack"; n = natural ; m = natural ; p = natural; "." ->
+        CAst.make (VernacBacktrack (n,m,p))
       | cmd = main_entry ->
               match cmd with
               | None -> raise Stm.End_of_input

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -2008,7 +2008,6 @@ let interp ?proof ~atts ~st c =
   | VernacRestart     -> CErrors.user_err  (str "Restart cannot be used through the Load command")
   | VernacUndo _      -> CErrors.user_err  (str "Undo cannot be used through the Load command")
   | VernacUndoTo _    -> CErrors.user_err  (str "UndoTo cannot be used through the Load command")
-  | VernacBacktrack _ -> CErrors.user_err  (str "Backtrack cannot be used through the Load command")
 
   (* Resetting *)
   | VernacResetName _  -> anomaly (str "VernacResetName not handled by Stm.")

--- a/vernac/vernacprop.ml
+++ b/vernac/vernacprop.ml
@@ -31,7 +31,6 @@ let rec has_Fail = function
 let is_navigation_vernac_expr = function
   | VernacResetInitial
   | VernacResetName _
-  | VernacBacktrack _
   | VernacBackTo _
   | VernacBack _ -> true
   | _ -> false


### PR DESCRIPTION
This command is legacy, equivalent to `EditAt` and only used by
Emacs. We move it to the toplevel so we can kill some legacy code and
in particular the `part_of_script` hack.
