### PR TITLE
[stm] Remove unused functionality to send states back from workers.

### DIFF
--- a/intf/vernacexpr.ml
+++ b/intf/vernacexpr.ml
@@ -505,14 +505,13 @@ type vernac_type =
   | VtProofMode of string
   (* Queries are commands assumed to be "pure", that is to say, they
      don't modify the interpretation state. *)
-  | VtQuery of vernac_part_of_script * Feedback.route_id
+  | VtQuery
   (* To be removed *)
   | VtMeta
   | VtUnknown
 and vernac_qed_type = VtKeep | VtKeepAsAxiom | VtDrop (* Qed/Admitted, Abort *)
 and vernac_start = string * opacity_guarantee * Id.t list
 and vernac_sideff_type = Id.t list
-and vernac_part_of_script = bool
 and opacity_guarantee =
   | GuaranteesOpacity (** Only generates opaque terms at [Qed] *)
   | Doesn'tGuaranteeOpacity (** May generate transparent terms even with [Qed].*)

--- a/intf/vernacexpr.ml
+++ b/intf/vernacexpr.ml
@@ -446,7 +446,6 @@ type nonrec vernac_expr =
   | VernacRestart
   | VernacUndo of int
   | VernacUndoTo of int
-  | VernacBacktrack of int*int*int
   | VernacFocus of int option
   | VernacUnfocus
   | VernacUnfocused

--- a/parsing/g_vernac.ml4
+++ b/parsing/g_vernac.ml4
@@ -1065,8 +1065,6 @@ GEXTEND Gram
       | IDENT "Back" -> VernacBack 1
       | IDENT "Back"; n = natural -> VernacBack n
       | IDENT "BackTo"; n = natural -> VernacBackTo n
-      | IDENT "Backtrack"; n = natural ; m = natural ; p = natural ->
-	  VernacBacktrack (n,m,p)
 
 (* Tactic Debugger *)
       |	IDENT "Debug"; IDENT "On" ->

--- a/printing/ppvernac.ml
+++ b/printing/ppvernac.ml
@@ -591,8 +591,6 @@ open Decl_kinds
         )
       | VernacUndoTo i ->
         return (keyword "Undo" ++ spc() ++ keyword "To" ++ pr_intarg i)
-      | VernacBacktrack (i,j,k) ->
-        return (keyword "Backtrack" ++  spc() ++ prlist_with_sep sep int [i;j;k])
       | VernacFocus i ->
         return (keyword "Focus" ++ pr_opt int i)
       | VernacShow s ->

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -363,7 +363,7 @@ module VCS : sig
   val reached : id -> unit
   val goals : id -> int -> unit
   val set_state : id -> cached_state -> unit
-  val get_state : id -> cached_state
+  (* val get_state : id -> cached_state *)
 
   (* cuts from start -> stop, raising Expired if some nodes are not there *)
   val slice : block_start:id -> block_stop:id -> vcs
@@ -579,7 +579,8 @@ end = struct (* {{{ *)
   let set_state id s =
     (get_info id).state <- s;
     if async_proofs_is_master !cur_opt then Hooks.(call state_ready id)
-  let get_state id = (get_info id).state
+  (* let get_state id = (get_info id).state *)
+
   let reached id =
     let info = get_info id in
     info.n_reached <- info.n_reached + 1
@@ -782,18 +783,7 @@ module State : sig
 
   val exn_on : Stateid.t -> valid:Stateid.t -> Exninfo.iexn -> Exninfo.iexn
 
-  (* to send states across worker/master *)
   val get_cached : Stateid.t -> Vernacstate.t
-  val same_env : Vernacstate.t -> Vernacstate.t -> bool
-
-  type proof_part
-
-  type partial_state =
-    [ `Full of Vernacstate.t
-    | `ProofOnly of Stateid.t * proof_part ]
-
-  val proof_part_of_frozen : Vernacstate.t -> proof_part
-  val assign : Stateid.t -> partial_state -> unit
 
   (* Handlers for initial state, prior to document creation. *)
   val register_root_state : unit -> unit
@@ -809,23 +799,6 @@ end = struct (* {{{ *)
    * failed, so the global state may contain garbage *)
   let cur_id = ref Stateid.dummy
   let fix_exn_ref = ref (fun x -> x)
-
-  type proof_part =
-    Proof_global.t *
-    int *                                   (* Evarutil.meta_counter_summary_tag *)
-    int *                                   (* Evd.evar_counter_summary_tag *)
-    Obligations.program_info Names.Id.Map.t (* Obligations.program_tcc_summary_tag *)
-
-  type partial_state =
-    [ `Full of Vernacstate.t
-    | `ProofOnly of Stateid.t * proof_part ]
-
-  let proof_part_of_frozen { Vernacstate.proof; system } =
-    let st = States.summary_of_state system in
-    proof,
-    Summary.project_from_summary st Util.(pi1 summary_pstate),
-    Summary.project_from_summary st Util.(pi2 summary_pstate),
-    Summary.project_from_summary st Util.(pi3 summary_pstate)
 
   let freeze marshallable id =
     VCS.set_state id (Valid (Vernacstate.freeze_interp_state marshallable))
@@ -870,39 +843,6 @@ end = struct (* {{{ *)
     | _ -> anomaly Pp.(str "not a cached state.")
     with VCS.Expired -> anomaly Pp.(str "not a cached state (expired).")
 
-  let assign id what =
-    let open Vernacstate in
-    if VCS.get_state id <> Empty then () else
-    try match what with
-    | `Full s ->
-         let s =
-           try
-            let prev = (VCS.visit id).next in
-            if is_cached_and_valid prev
-            then { s with proof =
-              Proof_global.copy_terminators
-                ~src:(get_cached prev).proof ~tgt:s.proof }
-            else s
-           with VCS.Expired -> s in
-         VCS.set_state id (Valid s)
-    | `ProofOnly(ontop,(pstate,c1,c2,c3)) ->
-         if is_cached_and_valid ontop then
-           let s = get_cached ontop in
-           let s = { s with proof =
-             Proof_global.copy_terminators ~src:s.proof ~tgt:pstate } in
-           let s = { s with system =
-             States.replace_summary s.system
-               begin
-                 let st = States.summary_of_state s.system in
-                 let st = Summary.modify_summary st Util.(pi1 summary_pstate) c1 in
-                 let st = Summary.modify_summary st Util.(pi2 summary_pstate) c2 in
-                 let st = Summary.modify_summary st Util.(pi3 summary_pstate) c3 in
-                 st
-               end
-                } in
-           VCS.set_state id (Valid s)
-    with VCS.Expired -> ()
-
   let exn_on id ~valid (e, info) =
     match Stateid.get info with
     | Some _ -> (e, info)
@@ -911,13 +851,6 @@ end = struct (* {{{ *)
         let (e, info) = Hooks.(call_process_error_once (e, info)) in
         execution_error ?loc id (iprint (e, info));
         (e, Stateid.add info ~valid id)
-
-  let same_env { Vernacstate.system = s1 } { Vernacstate.system = s2 } =
-    let s1 = States.summary_of_state s1 in
-    let e1 = Summary.project_from_summary s1 Global.global_env_summary_tag in
-    let s2 = States.summary_of_state s2 in
-    let e2 = Summary.project_from_summary s2 Global.global_env_summary_tag in
-    e1 == e2
 
   let define ?safe_id ?(redefine=false) ?(cache=`No) ?(feedback_processed=true)
         f id
@@ -1340,11 +1273,9 @@ module rec ProofTask : sig
 
   type task =
     | BuildProof of task_build_proof
-    | States of Stateid.t list
 
   type request =
   | ReqBuildProof of (Future.UUID.t,VCS.vcs) Stateid.request * bool * competence
-  | ReqStates of Stateid.t list
 
   include AsyncTaskQueue.Task
   with type task := task
@@ -1378,13 +1309,11 @@ end = struct (* {{{ *)
 
   type task =
     | BuildProof of task_build_proof
-    | States of Stateid.t list
 
   type worker_status = Fresh | Old of competence
 
   type request =
   | ReqBuildProof of (Future.UUID.t,VCS.vcs) Stateid.request * bool * competence
-  | ReqStates of Stateid.t list
 
   type error = {
     e_error_at    : Stateid.t;
@@ -1395,7 +1324,6 @@ end = struct (* {{{ *)
   type response =
     | RespBuiltProof of Proof_global.closed_proof_output * float
     | RespError of error
-    | RespStates of (Stateid.t * State.partial_state) list
 
   let name = ref "proofworker"
   let extra_env () = !async_proofs_workers_extra_env
@@ -1408,19 +1336,14 @@ end = struct (* {{{ *)
     | Fresh, BuildProof { t_states } ->
         not !cur_opt.async_proofs_full ||
         List.exists (fun x -> CList.mem_f Stateid.equal x !perspective) t_states
-    | Old my_states, States l ->
-        List.for_all (fun x -> CList.mem_f Stateid.equal x my_states) l
     | _ -> false
 
   let name_of_task = function
     | BuildProof t -> "proof: " ^ t.t_name
-    | States l -> "states: " ^ String.concat "," (List.map Stateid.to_string l)
   let name_of_request = function
     | ReqBuildProof(r,_,_) -> "proof: " ^ r.Stateid.name
-    | ReqStates l -> "states: "^String.concat "," (List.map Stateid.to_string l)
 
   let request_of_task age = function
-    | States l -> Some (ReqStates l)
     | BuildProof {
         t_exn_info;t_start;t_stop;t_loc;t_uuid;t_name;t_states;t_drop
       } ->
@@ -1436,28 +1359,22 @@ end = struct (* {{{ *)
 
   let use_response (s : worker_status) t r =
     match s, t, r with
-    | Old c, States _, RespStates l ->
-        List.iter (fun (id,s) -> State.assign id s) l; `End
     | Fresh, BuildProof { t_assign; t_loc; t_name; t_states; t_drop },
               RespBuiltProof (pl, time) ->
         feedback (InProgress ~-1);
         t_assign (`Val pl);
         record_pb_time ?loc:t_loc t_name time;
-        if !cur_opt.async_proofs_full || t_drop
-        then `Stay(t_states,[States t_states])
-        else `End
+        `End
     | Fresh, BuildProof { t_assign; t_loc; t_name; t_states },
             RespError { e_error_at; e_safe_id = valid; e_msg; e_safe_states } ->
         feedback (InProgress ~-1);
         let info = Stateid.add ~valid Exninfo.null e_error_at in
         let e = (RemoteException e_msg, info) in
-        t_assign (`Exn e);
-        `Stay(t_states,[States e_safe_states])
+        t_assign (`Exn e); `End
     | _ -> assert false
 
   let on_task_cancellation_or_expiration_or_slave_death = function
     | None -> ()
-    | Some (States _) -> ()
     | Some (BuildProof { t_start = start; t_assign }) ->
         let s = "Worker dies or task expired" in
         let info = Stateid.add ~valid:start Exninfo.null start in
@@ -1527,52 +1444,10 @@ end = struct (* {{{ *)
         let e_safe_states = List.filter State.is_cached_and_valid my_states in
         RespError { e_error_at; e_safe_id; e_msg; e_safe_states }
 
-  let perform_states query =
-    if query = [] then [] else
-    let is_tac e = match Vernac_classifier.classify_vernac e with
-    | VtProofStep _, _ -> true
-    | _ -> false
-    in
-    let initial =
-      let rec aux id =
-        try match VCS.visit id with { next } -> aux next
-        with VCS.Expired -> id in
-      aux (List.hd query) in
-    let get_state seen id =
-      let prev =
-        try
-          let { next = prev; step } = VCS.visit id in
-          if State.is_cached_and_valid prev && List.mem prev seen
-          then Some (prev, State.get_cached prev, step)
-          else None
-        with VCS.Expired -> None in
-      let this =
-        if State.is_cached_and_valid id then Some (State.get_cached id) else None in
-      match prev, this with
-      | _, None -> None
-      | Some (prev, o, `Cmd { cast = { expr }}), Some n
-        when is_tac expr && State.same_env o n -> (* A pure tactic *)
-          Some (id, `ProofOnly (prev, State.proof_part_of_frozen n))
-      | Some _, Some s ->
-          msg_debug (Pp.str "STM: sending back a fat state");
-          Some (id, `Full s)
-      | _, Some s -> Some (id, `Full s) in
-    let rec aux seen = function
-      | [] -> []
-      | id :: rest ->
-          match get_state seen id with
-          | None -> aux seen rest
-          | Some stuff -> stuff :: aux (id :: seen) rest in
-    aux [initial] query
-
   let perform = function
     | ReqBuildProof (bp,drop,states) -> perform_buildp bp drop states
-    | ReqStates sl -> RespStates (perform_states sl)
 
   let on_marshal_error s = function
-    | States _ ->
-      msg_warning Pp.(strbrk("Marshalling error: "^s^". "^
-                             "The system state could not be sent to the master process."))
     | BuildProof { t_exn_info; t_stop; t_assign; t_loc; t_drop = drop_pt } ->
       msg_warning Pp.(strbrk("Marshalling error: "^s^". "^
                              "The system state could not be sent to the worker process. "^
@@ -1752,7 +1627,7 @@ end = struct (* {{{ *)
      match task1, task2 with
      | BuildProof { t_states = s1 },
        BuildProof { t_states = s2 } -> overlap_rel s1 s2
-     | _ -> 0)
+    )
 
   let build_proof ?loc ~drop_pt ~exn_info ~block_start ~block_stop ~name:pname =
     let id, valid as t_exn_info = exn_info in

--- a/stm/vernac_classifier.ml
+++ b/stm/vernac_classifier.ml
@@ -183,7 +183,7 @@ let classify_vernac e =
     | VernacBack _ | VernacAbortAll
     | VernacUndoTo _ | VernacUndo _
     | VernacResetName _ | VernacResetInitial
-    | VernacBacktrack _ | VernacBackTo _ | VernacRestart -> VtMeta, VtNow
+    | VernacBackTo _ | VernacRestart -> VtMeta, VtNow
     (* What are these? *)
     | VernacRestoreState _
     | VernacWriteState _ -> VtSideff [], VtNow

--- a/toplevel/coqloop.ml
+++ b/toplevel/coqloop.ml
@@ -338,6 +338,13 @@ let rec vernac_loop ~state =
   try
     let input = top_buffer.tokens in
     match read_sentence ~state input with
+    | {v=VernacBacktrack(bid,_,_)} ->
+      let bid = Stateid.of_int bid in
+      let doc, res = Stm.edit_at ~doc:state.doc bid in
+      assert (res = `NewTip);
+      let state = { state with doc; sid = bid } in
+      vernac_loop ~state
+
     | {v=VernacQuit} ->
       exit 0
     | {v=VernacDrop} ->

--- a/toplevel/g_toplevel.ml4
+++ b/toplevel/g_toplevel.ml4
@@ -9,10 +9,12 @@
 (************************************************************************)
 
 open Pcoq
+open Pcoq.Prim
 open Vernacexpr
 
 (* Vernaculars specific to the toplevel *)
 type vernac_toplevel =
+  | VernacBacktrack of int * int * int
   | VernacDrop
   | VernacQuit
   | VernacControl of vernac_control
@@ -31,6 +33,8 @@ GEXTEND Gram
   vernac_toplevel: FIRST
     [ [ IDENT "Drop"; "." -> CAst.make VernacDrop
       | IDENT "Quit"; "." -> CAst.make VernacQuit
+      | IDENT "Backtrack"; n = natural ; m = natural ; p = natural; "." ->
+        CAst.make (VernacBacktrack (n,m,p))
       | cmd = main_entry ->
               match cmd with
               | None -> raise Stm.End_of_input

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -2008,7 +2008,6 @@ let interp ?proof ~atts ~st c =
   | VernacRestart     -> CErrors.user_err  (str "Restart cannot be used through the Load command")
   | VernacUndo _      -> CErrors.user_err  (str "Undo cannot be used through the Load command")
   | VernacUndoTo _    -> CErrors.user_err  (str "UndoTo cannot be used through the Load command")
-  | VernacBacktrack _ -> CErrors.user_err  (str "Backtrack cannot be used through the Load command")
 
   (* Resetting *)
   | VernacResetName _  -> anomaly (str "VernacResetName not handled by Stm.")

--- a/vernac/vernacprop.ml
+++ b/vernac/vernacprop.ml
@@ -31,7 +31,6 @@ let rec has_Fail = function
 let is_navigation_vernac_expr = function
   | VernacResetInitial
   | VernacResetName _
-  | VernacBacktrack _
   | VernacBackTo _
   | VernacBack _ -> true
   | _ -> false


### PR DESCRIPTION
This is done after a suggestion with @gares, we simplify the code a
bit before trying to move to a more functional API.

The functionality was not yet hooked to the proof processing engine,
but indeed it could provide some interesting advantages, hopefully we
resurrect this functionality in the future once the functional task
queue is in place.

Depends on #7139 