### PR TITLE
Make OrderedTypeFullFacts a module functor

### DIFF
--- a/theories/Structures/OrdersFacts.v
+++ b/theories/Structures/OrdersFacts.v
@@ -77,7 +77,7 @@ End CompareFacts.
 
  (** * Properties of [OrderedTypeFull] *)
 
-Module Type OrderedTypeFullFacts (Import O:OrderedTypeFull').
+Module OrderedTypeFullFacts (Import O:OrderedTypeFull').
 
  Module OrderTac := OTF_to_OrderTac O.
  Ltac order := OrderTac.order.


### PR DESCRIPTION
<!-- Keep what applies -->
**Kind:** bug fix 

**Description:** For the same reason that `OrderedTypeFacts` is a module functor, `OrderedTypeFullFacts` should be a module functor as well.