### PR TITLE
[meta] Add `num` to the set of base libraries.

### DIFF
--- a/META.coq
+++ b/META.coq
@@ -20,7 +20,7 @@ package "clib" (
   version     = "8.8"
 
   directory   = "clib"
-  requires    = "str, unix, threads"
+  requires    = "num, str, unix, threads"
 
   archive(byte)    = "clib.cma"
   archive(native)  = "clib.cmxa"


### PR DESCRIPTION
In the META file, the set of base libraries is determined by the
dependencies of the `coq.clib` package.

We add `num` to the dependencies as otherwise dynamically loading
`micromega` and `nsatz` will fail as they require the toplevel to have
`num` linked in.
