### PR TITLE
Sphinx docs: fix typo in Chrząszcz (non-ASCII character lost in sphinx migration)

### DIFF
--- a/doc/sphinx/credits.rst
+++ b/doc/sphinx/credits.rst
@@ -376,7 +376,7 @@ contributed by Jean Goubault was integrated in the basic theories.
 Pierre Courtieu developed a command and a tactic to reason on the
 inductive structure of recursively defined functions.
 
-Jacek Chrzszcz designed and implemented the module system of |Coq| whose
+Jacek Chrząszcz designed and implemented the module system of |Coq| whose
 foundations are in Judicaël Courant’s PhD thesis.
 
 The development was coordinated by C. Paulin.
@@ -478,7 +478,7 @@ Marché and Bruno Barras.
 Claude Marché coordinated the edition of the Reference Manual for |Coq|
 V8.0.
 
-Pierre Letouzey and Jacek Chrzszcz respectively maintained the
+Pierre Letouzey and Jacek Chrząszcz respectively maintained the
 extraction tool and module system of |Coq|.
 
 Jean-Christophe Filliâtre, Pierre Letouzey, Hugo Herbelin and other


### PR DESCRIPTION
**Kind:** documentation

The non-ASCII character `ą` in `Jacek Chrząszcz` (LaTeX `\k{a}`) was lost in the migration of the manual to Sphinx (specifically, b2fa2802), leaving `Chrzszcz`.  This PR reinstates it.

I have checked that no other occurrences of the Polish `\k{…}` were lost, but I have not checked for other similar LaTeX-to-utf8 losses.