### PR TITLE
Script to identify the code owner for given files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -321,3 +321,6 @@
 /dev/tools/pre-commit @SkySkimmer
 
 /dev/tools/sudo-apt-get-update @JasonGross
+
+/dev/tools/check-owners*.sh @SkySkimmer
+# Secondary maintainer @maximedenes

--- a/dev/tools/check-owners-pr.sh
+++ b/dev/tools/check-owners-pr.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env sh
+
+usage() {
+    { echo "usage: $0 PR [ARGS]..."
+      echo "A wrapper around check-owners.sh to check owners for a PR."
+      echo "Assumes upstream is the canonical Coq repository."
+      echo "Assumes the PR is against master."
+      echo
+      echo "  PR: PR number"
+      echo "  ARGS: passed through to check-owners.sh"
+    } >&2
+}
+
+case "$1" in
+    "--help"|"-h")
+        usage
+        if [ $# = 1 ]; then exit 0; else exit 1; fi;;
+    "")
+        usage
+        exit 1;;
+esac
+
+PR="$1"
+shift
+
+# this puts both refs in the FETCH_HEAD file but git rev-parse will use the first
+git fetch upstream "+refs/pull/$PR/head" master
+
+head=$(git rev-parse FETCH_HEAD)
+base=$(git merge-base upstream/master "$head")
+
+git diff --name-only -z "$base" "$head" | xargs -0 dev/tools/check-owners.sh "$@"

--- a/dev/tools/check-owners.sh
+++ b/dev/tools/check-owners.sh
@@ -2,20 +2,56 @@
 
 # Determine CODEOWNERS of the files given in argument
 # For a given commit range:
-# git diff --name-only -z COMMIT1 COMMIT2 | xargs -0 dev/tools/check-owners.sh
+# git diff --name-only -z COMMIT1 COMMIT2 | xargs -0 dev/tools/check-owners.sh [opts]
 
 # NB: gitignore files will be messed up if you interrupt the script.
 # You should be able to just move the .gitignore.bak files back manually.
 
-if [ $# = 0 ]; then
-    >&2 echo "usage: $0 [FILE]..."
-    exit 1
-fi
+usage() {
+    { echo "usage: $0 [--show-patterns] [--owner OWNER] [FILE]..."
+      echo "  --show-patterns: instead of printing file names print the matching patterns (more compact)"
+      echo "  --owner: show only files/patterns owned by OWNER (use Nobody to see only non-owned files)"
+    } >&2
+}
+
+case "$1" in
+    "--help"|"-h")
+        usage
+        if [ $# = 1 ]; then exit 0; else exit 1; fi
+esac
 
 if ! [ -e .github/CODEOWNERS ]; then
     >&2 echo "No CODEOWNERS set up or calling from wrong directory."
     exit 1
 fi
+
+files=()
+show_patterns=false
+
+target_owner=""
+
+while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+        "--show-patterns")
+            show_patterns=true
+            shift;;
+        "--owner")
+            if [[ "$#" = 1 ]]; then
+                >&2 echo "Missing argument to --owner"
+                usage
+                exit 1
+            elif [[ "$target_owner" != "" ]]; then
+                >&2 echo "Only one --owner allowed"
+                usage
+                exit 1
+            fi
+            target_owner="$2"
+            shift 2;;
+        *)
+            files+=("$@")
+            break;;
+    esac
+done
 
 # CODEOWNERS uses .gitignore patterns so we want to use git to parse it
 # The only available tool for that is git check-ignore
@@ -43,23 +79,46 @@ done < .github/CODEOWNERS
 # associative array [file => owner]
 declare -A owners
 
-for f in "$@"; do
+for f in "${files[@]}"; do
     data=$(git check-ignore --verbose --no-index "./$f")
     code=$?
 
     if [[ "$code" = 1 ]] || ! [[ "$data" =~ .gitignore:.* ]] ; then
         # no match, or match from non tracked gitignore (eg global gitignore)
-        owners[$f]="Nobody"
+        if [ "$target_owner" != "" ] && [ "$target_owner" != Nobody ] ; then
+            owner=""
+        else
+            owner="Nobody"
+            pat="$f" # no patterns for unowned files
+        fi
     else
         # data looks like [.gitignore:$line:$pattern $file]
         # extract the line to look it up in CODEOWNERS
         data=${data#'.gitignore:'}
-        data=${data%%:*}
+        line=${data%%:*}
 
         # NB: supports multiple owners
         # Does not support secondary owners declared in comment
-        read -r _ fowners < <(sed "${data}q;d" .github/CODEOWNERS)
-        owners["$f"]="$fowners"
+        read -r pat fowners < <(sed "${line}q;d" .github/CODEOWNERS)
+
+        owner=""
+        if [ "$target_owner" != "" ]; then
+            for o in $fowners; do # do not quote: multiple owners possible
+                if [ "$o" = "$target_owner" ]; then
+                    owner="$o"
+                fi
+            done
+        else
+            owner="$fowners"
+        fi
+    fi
+
+    if [ "$owner" != "" ]; then
+        if $show_patterns; then
+            owners[$pat]="$owner"
+        else
+            owners[$f]="$owner"
+        fi
     fi
 done
 

--- a/dev/tools/check-owners.sh
+++ b/dev/tools/check-owners.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+# Determine CODEOWNERS of the files given in argument
+# For a given commit range:
+# git diff --name-only -z COMMIT1 COMMIT2 | xargs -0 dev/tools/check-owners.sh
+
+# NB: gitignore files will be messed up if you interrupt the script.
+# You should be able to just move the .gitignore.bak files back manually.
+
+if [ $# = 0 ]; then
+    >&2 echo "usage: $0 [FILE]..."
+    exit 1
+fi
+
+if ! [ -e .github/CODEOWNERS ]; then
+    >&2 echo "No CODEOWNERS set up or calling from wrong directory."
+    exit 1
+fi
+
+# CODEOWNERS uses .gitignore patterns so we want to use git to parse it
+# The only available tool for that is git check-ignore
+# However it provides no way to use alternate .gitignore files
+# so we rename them temporarily
+
+find . -name .gitignore -print0 | while IFS= read -r -d '' f; do
+    if [ -e "$f.bak" ]; then
+        >&2 echo "$f.bak exists!"
+        exit 1
+    else
+        mv "$f" "$f.bak"
+    fi
+done
+
+# CODEOWNERS is not quite .gitignore patterns:
+# after the pattern is the owner (space separated)
+# git would interpret that as a big pattern containing spaces
+# so we create a valid .gitignore by removing all but the first field
+
+while read -r pat _; do
+    printf "%s\n" "$pat" >> .gitignore
+done < .github/CODEOWNERS
+
+# associative array [file => owner]
+declare -A owners
+
+for f in "$@"; do
+    data=$(git check-ignore --verbose --no-index "./$f")
+    code=$?
+
+    if [[ "$code" = 1 ]] || ! [[ "$data" =~ .gitignore:.* ]] ; then
+        # no match, or match from non tracked gitignore (eg global gitignore)
+        owners[$f]="Nobody"
+    else
+        # data looks like [.gitignore:$line:$pattern $file]
+        # extract the line to look it up in CODEOWNERS
+        data=${data#'.gitignore:'}
+        data=${data%%:*}
+
+        # NB: supports multiple owners
+        # Does not support secondary owners declared in comment
+        read -r _ fowners < <(sed "${data}q;d" .github/CODEOWNERS)
+        owners["$f"]="$fowners"
+    fi
+done
+
+for f in "${!owners[@]}"; do
+    printf "%s: %s\n" "$f" "${owners[$f]}"
+done | sort -k 2 -k 1 # group by owner
+
+# restort gitignore files
+rm .gitignore
+find . -name .gitignore.bak -print0 | while IFS= read -r -d '' f; do
+    base=${f%.bak}
+    if [ -e "$base" ]; then
+        >&2 echo "$base exists!"
+    else
+        mv "$f" "$base"
+    fi
+done

--- a/dev/tools/check-owners.sh
+++ b/dev/tools/check-owners.sh
@@ -73,7 +73,7 @@ done
 # so we create a valid .gitignore by removing all but the first field
 
 while read -r pat _; do
-    printf "%s\n" "$pat" >> .gitignore
+    printf '%s\n' "$pat" >> .gitignore
 done < .github/CODEOWNERS
 
 # associative array [file => owner]
@@ -123,10 +123,10 @@ for f in "${files[@]}"; do
 done
 
 for f in "${!owners[@]}"; do
-    printf "%s: %s\n" "$f" "${owners[$f]}"
+    printf '%s: %s\n' "$f" "${owners[$f]}"
 done | sort -k 2 -k 1 # group by owner
 
-# restort gitignore files
+# restore gitignore files
 rm .gitignore
 find . -name .gitignore.bak -print0 | while IFS= read -r -d '' f; do
     base=${f%.bak}


### PR DESCRIPTION
Can be used with git diff --name-only to identify owners for changes
in given commits.

Example output (commit range f29f8f80c8ad94576c7a36f3f638866c208338a0 to this commit):
```
toplevel/coqloop.ml: @ejgallego
toplevel/g_toplevel.ml4: @ejgallego
stm/stm.ml: @gares
stm/vernac_classifier.ml: @gares
parsing/g_vernac.ml4: @herbelin
printing/ppvernac.ml: @herbelin
intf/vernacexpr.ml: @letouzey
Makefile.doc: @letouzey
vernac/vernacentries.ml: @mattam82
vernac/vernacprop.ml: @mattam82
doc/refman/Coercion.tex: @maximedenes
doc/refman/Extraction.tex: @maximedenes
doc/refman/Nsatz.tex: @maximedenes
doc/refman/Polynom.tex: @maximedenes
doc/refman/Program.tex: @maximedenes
doc/refman/Reference-Manual.tex: @maximedenes
doc/refman/Setoid.tex: @maximedenes
doc/sphinx/addendum/extraction.rst: @maximedenes
doc/sphinx/addendum/generalized-rewriting.rst: @maximedenes
doc/sphinx/addendum/implicit-coercions.rst: @maximedenes
doc/sphinx/addendum/nsatz.rst: @maximedenes
doc/sphinx/addendum/program.rst: @maximedenes
doc/sphinx/addendum/ring.rst: @maximedenes
doc/sphinx/index.rst: @maximedenes
doc/sphinx/language/gallina-extensions.rst: @maximedenes
dev/tools/check-owners.sh: Nobody
test-suite/coq-makefile/timing/run.sh: Nobody
```