### PR TITLE
Option for quick compilation of the reference manual, bypassing dependencies

### DIFF
--- a/Makefile.doc
+++ b/Makefile.doc
@@ -49,7 +49,11 @@ DOCCOMMON:=doc/common/version.tex doc/common/title.tex doc/common/macros.tex
 
 doc: sphinx stdlib
 
-sphinx: coq
+ifndef QUICK
+SPHINX_DEPS := coq
+endif
+
+sphinx: $(SPHINX_DEPS)
 	$(SHOW)'SPHINXBUILD doc/sphinx'
 	$(HIDE)COQBIN="$(PWD)/bin" $(SPHINXBUILD) -W -b html $(ALLSPHINXOPTS) doc/sphinx $(SPHINXBUILDDIR)/html
 	@echo


### PR DESCRIPTION
**Kind:** infrastructure.

This adds a way to bypass the compilation of the standard library while compiling sphinx, as we did for the LaTeX version. Command is `make QUICK=1 sphinx`.