### PR TITLE
[warnings] Remove `set_current_loc` hack.

### DIFF
--- a/lib/cWarnings.ml
+++ b/lib/cWarnings.ml
@@ -22,10 +22,7 @@ type t = {
 let warnings : (string, t) Hashtbl.t = Hashtbl.create 97
 let categories : (string, string list) Hashtbl.t = Hashtbl.create 97
 
-let current_loc = ref None
 let flags = ref ""
-
-let set_current_loc loc = current_loc := loc
 
 let get_flags () = !flags
 
@@ -170,7 +167,6 @@ let create ~name ~category ?(default=Enabled) pp =
   set_flags !flags;
   fun ?loc x ->
            let w = Hashtbl.find warnings name in
-           let loc = Option.append loc !current_loc in
            match w.status with
            | Disabled -> ()
            | AsError -> CErrors.user_err ?loc (pp x)

--- a/lib/cWarnings.mli
+++ b/lib/cWarnings.mli
@@ -10,8 +10,6 @@
 
 type status = Disabled | Enabled | AsError
 
-val set_current_loc : Loc.t option -> unit
-
 val create : name:string -> category:string -> ?default:status ->
              ('a -> Pp.t) -> ?loc:Loc.t -> 'a -> unit
 

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -3013,7 +3013,6 @@ let add ~doc ~ontop ?newtip verb { CAst.loc; v=ast } =
        str ") than the tip: " ++ str (Stateid.to_string cur_tip) ++ str "." ++ fnl () ++
        str "This is not supported yet, sorry.");
   let indentation, strlen = compute_indentation ?loc ontop in
-  CWarnings.set_current_loc loc;
   (* XXX: Classifiy vernac should be moved inside process transaction *)
   let clas = Vernac_classifier.classify_vernac ast in
   let aast = { verbose = verb; indentation; strlen; loc; expr = ast } in
@@ -3037,7 +3036,6 @@ let query ~doc ~at ~route s =
       while true do
         let { CAst.loc; v=ast } = parse_sentence ~doc at s in
         let indentation, strlen = compute_indentation ?loc at in
-        CWarnings.set_current_loc loc;
         let st = State.get_cached at in
         let aast = { verbose = true; indentation; strlen; loc; expr = ast } in
         ignore(stm_vernac_interp ~route at st aast)


### PR DESCRIPTION
Instead of the current hack that won't work as soon as we check some
part of the document asynchronously, we make the warning processor
recover a proper location if the warning doesn't have one attached.

This is what CoqIDE does [but it queries it's own document model].

EDIT by Théo: this happens to fix #6172.