### PR TITLE
Refreshing contents of the few ML files mentioning credits

### DIFF
--- a/checker/univ.ml
+++ b/checker/univ.ml
@@ -8,13 +8,6 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(* Created in Caml by Gérard Huet for CoC 4.8 [Dec 1988] *)
-(* Functional code by Jean-Christophe Filliâtre for Coq V7.0 [1999] *)
-(* Extension with algebraic universes by HH for Coq V7.0 [Sep 2001] *)
-(* Additional support for sort-polymorphic inductive types by HH [Mar 2006] *)
-
-(* Revisions by Bruno Barras, Hugo Herbelin, Pierre Letouzey *)
-
 open Pp
 open CErrors
 open Util

--- a/interp/smartlocate.ml
+++ b/interp/smartlocate.ml
@@ -8,12 +8,8 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(* Created by Hugo Herbelin from code formerly dispatched in
-   syntax_def.ml or tacinterp.ml, Sep 2009 *)
-
 (* This file provides high-level name globalization functions *)
 
-(* *)
 open Pp
 open CErrors
 open Libnames

--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -8,18 +8,11 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(* Created by Bruno Barras with Benjamin Werner's account to implement
-   a call-by-value conversion algorithm and a lazy reduction machine
-   with sharing, Nov 1996 *)
-(* Addition of zeta-reduction (let-in contraction) by Hugo Herbelin, Oct 2000 *)
-(* Call-by-value machine moved to cbv.ml, Mar 01 *)
-(* Additional tools for module subtyping by Jacek Chrzaszcz, Aug 2002 *)
-(* Extension with closure optimization by Bruno Barras, Aug 2003 *)
-(* Support for evar reduction by Bruno Barras, Feb 2009 *)
-(* Miscellaneous other improvements by Bruno Barras, 1997-2009 *)
+(* This file implements a lazy reduction machine for the Calculus of
+   Inductive Constructions (CIC) *)
 
-(* This file implements a lazy reduction for the Calculus of Inductive
-   Constructions *)
+(* Created by Bruno Barras, Nov 1996 (see version control system logs
+   for history and full credits of the file) *)
 
 open CErrors
 open Util

--- a/kernel/constr.ml
+++ b/kernel/constr.ml
@@ -8,22 +8,15 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(* File initially created by Gérard Huet and Thierry Coquand in 1984 *)
-(* Extension to inductive constructions by Christine Paulin for Coq V5.6 *)
-(* Extension to mutual inductive constructions by Christine Paulin for
-   Coq V5.10.2 *)
-(* Extension to co-inductive constructions by Eduardo Gimenez *)
-(* Optimization of substitution functions by Chet Murthy *)
-(* Optimization of lifting functions by Bruno Barras, Mar 1997 *)
-(* Hash-consing by Bruno Barras in Feb 1998 *)
-(* Restructuration of Coq of the type-checking kernel by Jean-Christophe 
-   Filliâtre, 1999 *)
-(* Abstraction of the syntax of terms and iterators by Hugo Herbelin, 2000 *)
-(* Cleaning and lightening of the kernel by Bruno Barras, Nov 2001 *)
-
 (* This file defines the internal syntax of the Calculus of
    Inductive Constructions (CIC) terms together with constructors,
    destructors, iterators and basic functions *)
+
+(* This is one of the oldest file, seminally created by Gérard Huet
+   and Thierry Coquand in 1984, with extensions by Christine
+   Paulin to inductive constructions for Coq V5.6 and to mutual
+   inductive constructions for Coq V5.10.2 (see version control system
+   log for history and full credits of the file) *)
 
 open Util
 open Names

--- a/kernel/context.ml
+++ b/kernel/context.ml
@@ -8,15 +8,6 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(* Created by Jean-Christophe Filliâtre out of names.ml as part of the
-   rebuilding of Coq around a purely functional abstract type-checker,
-   Aug 1999 *)
-(* Miscellaneous extensions, restructurations and bug-fixes by Hugo
-   Herbelin and Bruno Barras *)
-
-(* This file defines types and combinators regarding indexes-based and
-   names-based contexts *)
-
 (** The modules defined below represent a {e local context}
     as defined by Chapter 4 in the Reference Manual:
 

--- a/kernel/cooking.ml
+++ b/kernel/cooking.ml
@@ -10,7 +10,8 @@
 
 (* Created by Jean-Christophe Filliâtre out of V6.3 file constants.ml
    as part of the rebuilding of Coq around a purely functional
-   abstract type-checker, Nov 1999 *)
+   abstract type-checker, Nov 1999 (see version control system logs
+   for history and full credits of the file) *)
 
 (* This module implements kernel-level discharching of local
    declarations over global constants and inductive types *)

--- a/kernel/csymtable.ml
+++ b/kernel/csymtable.ml
@@ -9,8 +9,8 @@
 (************************************************************************)
 
 (* Created by Bruno Barras for Benjamin Grégoire as part of the
-   bytecode-based reduction machine, Oct 2004 *)
-(* Bug fix #1419 by Jean-Marc Notin, Mar 2007 *)
+   bytecode-based reduction machine, Oct 2004 (see version control
+   system logs for history and full credits of the file) *)
 
 (* This file manages the table of global symbols for the bytecode machine *)
 

--- a/kernel/environ.ml
+++ b/kernel/environ.ml
@@ -8,19 +8,13 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(* Author: Jean-Christophe Filliâtre as part of the rebuilding of Coq
-   around a purely functional abstract type-checker, Aug 1999 *)
-(* Cleaning and lightening of the kernel by Bruno Barras, Nov 2001 *)
-(* Flag for predicativity of Set by Hugo Herbelin in Oct 2003 *)
-(* Support for virtual machine by Benjamin Grégoire in Oct 2004 *)
-(* Support for retroknowledge by Arnaud Spiwack in May 2007 *)
-(* Support for assumption dependencies by Arnaud Spiwack in May 2007 *)
-
-(* Miscellaneous maintenance by Bruno Barras, Hugo Herbelin, Jean-Marc
-   Notin, Matthieu Sozeau *)
-
 (* This file defines the type of environments on which the
    type-checker works, together with simple related functions *)
+
+(* This file was a core component of Jean-Christophe Filliâtre's
+   rebuilding of Coq around a purely functional abstract type-checker,
+   Aug 1999 (see version control system logs for history and full
+   credits of the file) *)
 
 open CErrors
 open Util

--- a/kernel/mod_subst.ml
+++ b/kernel/mod_subst.ml
@@ -9,8 +9,9 @@
 (************************************************************************)
 
 (* Created by Claudio Sacerdoti from contents of term.ml, names.ml and
-   new support for constant inlining in functor application, Nov 2004 *)
-(* Optimizations and bug fixes by Élie Soubiran, from Feb 2008 *)
+   new support for constant inlining in functor application, Nov 2004
+   (see version control system logs for history and full credits of
+   the file) *)
 
 (* This file provides types and functions for managing name
    substitution in module constructions *)

--- a/kernel/mod_typing.ml
+++ b/kernel/mod_typing.ml
@@ -9,7 +9,8 @@
 (************************************************************************)
 
 (* Created by Jacek Chrzaszcz, Aug 2002 as part of the implementation of
-   the Coq module system *)
+   the Coq module system (see version control system logs for history
+   and full credits of the file) *)
 
 (* This module provides the main functions for type-checking module
    declarations *)

--- a/kernel/modops.ml
+++ b/kernel/modops.ml
@@ -8,12 +8,10 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(* Created by Jacek Chrzaszcz, Aug 2002 as part of the implementation of
-   the Coq module system *)
-(* Inlining and more liberal use of modules and module types by Claudio
-   Sacerdoti, Nov 2004 *)
-(* New structure-based model of modules and miscellaneous bug fixes by
-   Élie Soubiran, from Feb 2008 *)
+(* Created by Jacek Chrzaszcz, Aug 2002 as part of the implementation
+   of the Coq module system; structure-based model of modules by Élie
+   Soubiran, 2008 (see version control system logs for history and
+   full credits of the file) *)
 
 (* This file provides with various operations on modules and module types *)
 

--- a/kernel/names.ml
+++ b/kernel/names.ml
@@ -8,17 +8,9 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(* File created around Apr 1994 for CiC V5.10.5 by Chet Murthy collecting
-   parts of file initial.ml from CoC V4.8, Dec 1988, by Gérard Huet,
-   Thierry Coquand and Christine Paulin *)
-(* Hash-consing by Bruno Barras in Feb 1998 *)
-(* Extra functions for splitting/generation of identifiers by Hugo Herbelin *)
-(* Restructuration by Jacek Chrzaszcz as part of the implementation of
-   the module system, Aug 2002 *)
-(* Abstraction over the type of constant for module inlining by Claudio
-   Sacerdoti, Nov 2004 *)
-(* Miscellaneous features or improvements by Hugo Herbelin, 
-   Élie Soubiran, ... *)
+(* This file defines the different notions of names used pervasively
+   in the definition of terms in the Calculus of Inductive
+   Constructions (CIC) *)
 
 open Pp
 open Util

--- a/kernel/pre_env.ml
+++ b/kernel/pre_env.ml
@@ -8,11 +8,6 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(* Created by Benjamin Grégoire out of environ.ml for better
-   modularity in the design of the bytecode virtual evaluation
-   machine, Dec 2005 *)
-(* Bug fix by Jean-Marc Notin *)
-
 (* This file defines the type of kernel environments *)
 
 open Util

--- a/kernel/reduction.ml
+++ b/kernel/reduction.ml
@@ -8,14 +8,12 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(* Created under Benjamin Werner account by Bruno Barras to implement
-   a call-by-value conversion algorithm and a lazy reduction machine
-   with sharing, Nov 1996 *)
-(* Addition of zeta-reduction (let-in contraction) by Hugo Herbelin, Oct 2000 *)
-(* Irreversibility of opacity by Bruno Barras *)
-(* Cleaning and lightening of the kernel by Bruno Barras, Nov 2001 *)
-(* Equal inductive types by Jacek Chrzaszcz as part of the module
-   system, Aug 2002 *)
+(* This file implement the conversion rule of the Calculus of
+   Inductive Constructions (CIC), as well as related functions about
+   reduction in the CIC *)
+
+(* Created by Bruno Barras, Nov 1996 (see version control system logs
+   for history and full credits of the file) *)
 
 open CErrors
 open Util

--- a/kernel/retroknowledge.ml
+++ b/kernel/retroknowledge.ml
@@ -8,9 +8,8 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(* Created by Arnaud Spiwack, May 2007 *)
-(* Addition of native Head (nb of heading 0) and Tail (nb of trailing 0) by
-   Benjamin Grégoire, Jun 2007 *)
+(* Created by Arnaud Spiwack, May 2007 (see version control system
+   logs for history and full credits of the file) *)
 
 (* This file defines the knowledge that the kernel is able to optimize
    for evaluation in the bytecode virtual machine *)

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -9,7 +9,9 @@
 (************************************************************************)
 
 (* Created by Jean-Christophe Filliâtre as part of the rebuilding of
-   Coq around a purely functional abstract type-checker, Dec 1999 *)
+   Coq around a purely functional abstract type-checker, Dec 1999
+   (see version control system logs for history and full credits of
+   the file) *)
 
 (* This file provides the entry points to the kernel type-checker. It
    defines the abstract type of well-formed environments and

--- a/kernel/term_typing.ml
+++ b/kernel/term_typing.ml
@@ -9,7 +9,8 @@
 (************************************************************************)
 
 (* Created by Jacek Chrzaszcz, Aug 2002 as part of the implementation of
-   the Coq module system *)
+   the Coq module system (see version control system logs for history
+   and credits of the file) *)
 
 (* This module provides the main entry points for type-checking basic
    declarations *)

--- a/kernel/uGraph.ml
+++ b/kernel/uGraph.ml
@@ -8,18 +8,11 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
+(* This file is about graphs of universes. *)
+
 open Pp
 open Util
 open Univ
-
-(* Created in Caml by Gérard Huet for CoC 4.8 [Dec 1988] *)
-(* Functional code by Jean-Christophe Filliâtre for Coq V7.0 [1999] *)
-(* Extension with algebraic universes by HH for Coq V7.0 [Sep 2001] *)
-(* Additional support for sort-polymorphic inductive types by HH [Mar 2006] *)
-(* Support for universe polymorphism by MS [2014] *)
-
-(* Revisions by Bruno Barras, Hugo Herbelin, Pierre Letouzey, Matthieu
-   Sozeau, Pierre-Marie Pédrot, Jacques-Henri Jourdan *)
 
 let error_inconsistency o u v (p:explanation option) =
   raise (UniverseInconsistency (o,Universe.make u,Universe.make v,p))

--- a/kernel/univ.ml
+++ b/kernel/univ.ml
@@ -8,14 +8,10 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(* Created in Caml by Gérard Huet for CoC 4.8 [Dec 1988] *)
-(* Functional code by Jean-Christophe Filliâtre for Coq V7.0 [1999] *)
-(* Extension with algebraic universes by HH for Coq V7.0 [Sep 2001] *)
-(* Additional support for sort-polymorphic inductive types by HH [Mar 2006] *)
-(* Support for universe polymorphism by MS [2014] *)
+(* This file defines basic types and operations about universes. *)
 
-(* Revisions by Bruno Barras, Hugo Herbelin, Pierre Letouzey, Matthieu
-   Sozeau, Pierre-Marie Pédrot *)
+(* Created in Caml by Gérard Huet for CoC 4.8, Dec 1988 (see version
+   control system logs for history and full credits of the file) *)
 
 open Pp
 open CErrors

--- a/pretyping/coercion.ml
+++ b/pretyping/coercion.ml
@@ -8,13 +8,12 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(* Created by Hugo Herbelin for Coq V7 by isolating the coercion
-   mechanism out of the type inference algorithm in file trad.ml from
-   Coq V6.3, Nov 1999; The coercion mechanism was implemented in
-   trad.ml by Amokrane Saïbi, May 1996 *)
-(* Addition of products and sorts in canonical structures by Pierre
-   Corbineau, Feb 2008 *)
-(* Turned into an abstract compilation unit by Matthieu Sozeau, March 2006 *)
+(* This file provides support for insertion of coercions *)
+
+(* Created by Hugo Herbelin for Coq V7 by isolating Amokrane Saïbi's
+   seminal coercion mechanism (May 1996) out of the type inference
+   algorithm in file trad.ml from Coq V6.3 (see version control system
+   logs for history and full credits of the file) *)
 
 open CErrors
 open Util

--- a/pretyping/indrec.ml
+++ b/pretyping/indrec.ml
@@ -8,7 +8,8 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(* File initially created by Christine Paulin, 1996 *)
+(* File initially created by Christine Paulin, 1996 (see version
+   control system logs for history and full credits of the file) *)
 
 (* This file builds various inductive schemes *)
 

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -8,20 +8,12 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(* This file contains the syntax-directed part of the type inference
-   algorithm introduced by Murthy in Coq V5.10, 1995; the type
-   inference algorithm was initially developed in a file named trad.ml
-   which formerly contained a simple concrete-to-abstract syntax
-   translation function introduced in CoC V4.10 for implementing the
-   "exact" tactic, 1989 *)
-(* Support for typing term in Ltac environment by David Delahaye, 2000 *)
-(* Type inference algorithm made a functor of the coercion and
-   pattern-matching compilation by Matthieu Sozeau, March 2006 *)
-(* Fixpoint guard index computation by Pierre Letouzey, July 2007 *)
+(* This file implements the main part of the type inference algorithm *)
 
-(* Structural maintainer: Hugo Herbelin *)
-(* Secondary maintenance: collective *)
-
+(* Type inference was introduced as an algorithm distinct from
+   type-checking by Murthy in Coq V5.10, 1995 (see version control
+   system logs for history and full credits of this file, formerly
+   called trad.ml) *)
 
 open Pp
 open CErrors

--- a/pretyping/recordops.ml
+++ b/pretyping/recordops.ml
@@ -8,9 +8,8 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(* Created by Amokrane Saïbi, Dec 1998 *)
-(* Addition of products and sorts in canonical structures by Pierre
-   Corbineau, Feb 2008 *)
+(* Created by Amokrane Saïbi, Dec 1998 (see version control system
+   logs for history and full credits of the file) *)
 
 (* This file registers properties of records: projections and
    canonical structures *)

--- a/tactics/elimschemes.ml
+++ b/tactics/elimschemes.ml
@@ -8,11 +8,6 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(* Created by Hugo Herbelin from contents related to inductive schemes
-   initially developed by Christine Paulin (induction schemes), Vincent
-   Siles (decidable equality and boolean equality) and Matthieu Sozeau
-   (combined scheme) in file command.ml, Sep 2009 *)
-
 (* This file builds schemes related to case analysis and recursion schemes *)
 
 open Sorts

--- a/tactics/eqschemes.ml
+++ b/tactics/eqschemes.ml
@@ -8,7 +8,8 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(* File created by Hugo Herbelin, Nov 2009 *)
+(* File created by Hugo Herbelin, Nov 2009 (see version control system
+   logs for history and full credits of the file) *)
 
 (* This file builds schemes related to equality inductive types,
    especially for dependent rewrite, rewriting on arbitrary equality

--- a/tactics/ind_tables.ml
+++ b/tactics/ind_tables.ml
@@ -8,11 +8,13 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(* File created by Vincent Siles, Oct 2007, extended into a generic
-   support for generation of inductive schemes by Hugo Herbelin, Nov 2009 *)
-
 (* This file provides support for registering inductive scheme builders,
    declaring schemes and generating schemes on demand *)
+
+(* File created by Vincent Siles, Oct 2007, extended into a generic
+   support for generation of inductive schemes by Hugo Herbelin, Nov
+   2009 (see version control system logs for history and full credits
+   of the file) *)
 
 open Names
 open Mod_subst

--- a/vernac/indschemes.ml
+++ b/vernac/indschemes.ml
@@ -8,11 +8,6 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(* Created by Hugo Herbelin from contents related to inductive schemes
-   initially developed by Christine Paulin (induction schemes), Vincent
-   Siles (decidable equality and boolean equality) and Matthieu Sozeau
-   (combined scheme) in file command.ml, Sep 2009 *)
-
 (* This file provides entry points for manually or automatically
    declaring new schemes *)
 

--- a/vernac/lemmas.ml
+++ b/vernac/lemmas.ml
@@ -8,9 +8,6 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(* Created by Hugo Herbelin from contents related to lemma proofs in
-   file command.ml, Aug 2009 *)
-
 open CErrors
 open Util
 open Pp


### PR DESCRIPTION
<!-- Keep what applies -->
**Kind:** credits

At the time of registering Coq to the software agency around 2009, an effort was started to add credits to the files of the archive. The task was in itself huge and only about 30 files were addressed, mainly in the kernel, mainly about the oldest files.

Since then, this has not been extended further, and, for some of the files for which credits were indicated, the credits do not anymore correctly reflect what happened since then.

This PR removes the attempts to report about the different contributions to these files, keeping only the main original names when their work is well-identified, and inviting to look at the commit logs for more details.

Even trying to be objective and fair with respect to my knowledge of the situation and of the history, the choice of keeping or not this or that name includes some subjectivity. Please mandatorily tell if you feel that the selection of compromises I made is unfair or incorrect.  The point of credits is precisely to reflect a form of human truth which has to be told in a fair way.

This PR is what I feel should be my contribution to adapt these mentions of credits in ML files to the current situation. I leave it to others, and in particular to @mattam82, to see what should be done for a well-balanced treatment of credits in a longer term.
