### PR TITLE
merge script support https + typos in doc

### DIFF
--- a/dev/doc/MERGING.md
+++ b/dev/doc/MERGING.md
@@ -70,7 +70,7 @@ To merge the PR proceed in the following way
 ```
 $ git checkout master
 $ git pull
-$ dev/tools/merge-pr XXXX
+$ dev/tools/merge-pr.sh XXXX
 $ git push upstream
 ```
 where `XXXX` is the number of the PR to be merged and `upstream` is the name

--- a/dev/tools/merge-pr.sh
+++ b/dev/tools/merge-pr.sh
@@ -5,7 +5,7 @@ set -o pipefail
 
 API=https://api.github.com/repos/coq/coq
 OFFICIAL_REMOTE_GIT_URL="git@github.com:coq/coq"
-OFFICIAL_REMOTE_HTTPS_URL="https://github.com/coq/coq"
+OFFICIAL_REMOTE_HTTPS_URL="github.com/coq/coq"
 
 # This script depends (at least) on git (>= 2.7) and jq.
 # It should be used like this: dev/tools/merge-pr.sh /PR number/
@@ -91,8 +91,10 @@ fi
 REMOTE_URL=$(git remote get-url "$REMOTE" --all)
 if [ "$REMOTE_URL" != "${OFFICIAL_REMOTE_GIT_URL}" ] && \
    [ "$REMOTE_URL" != "${OFFICIAL_REMOTE_GIT_URL}.git" ] && \
-   [ "$REMOTE_URL" != "${OFFICIAL_REMOTE_HTTPS_URL}" ] && \
-   [ "$REMOTE_URL" != "${OFFICIAL_REMOTE_HTTPS_URL}.git" ]; then
+   [ "$REMOTE_URL" != "https://${OFFICIAL_REMOTE_HTTPS_URL}" ] && \
+   [ "$REMOTE_URL" != "https://${OFFICIAL_REMOTE_HTTPS_URL}.git" ] && \
+   [[ "$REMOTE_URL" != "https://"*"@${OFFICIAL_REMOTE_HTTPS_URL}" ]] && \
+   [[ "$REMOTE_URL" != "https://"*"@${OFFICIAL_REMOTE_HTTPS_URL}.git" ]] ; then
   error "remote ${BLUE}$REMOTE${RESET} does not point to the official Coq repo"
   error "that is ${BLUE}$OFFICIAL_REMOTE_GIT_URL"
   error "it points to ${BLUE}$REMOTE_URL${RESET} instead"


### PR DESCRIPTION
**Kind:** documentation / infrastructure.
as I just used the merge script for the first time, I detected very small glitches here and there.
This PR contains:

+ 1 Small fix in the merge script doc
+ 1 suggestion in the merge script doc
+ 1 Suggestion in the merge script itself to detect coq https url.

The latter is probably to be discussed:
1) is it necessary?
2) is it correctly implemented? I tested a bit but I am not a bash expert.

Fixes #7232 