### PR TITLE
The usual order of strings.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -115,6 +115,9 @@ Standard Library
   Imported. This should be relevant only when importing files which
   don't use -noinit into files which do.
 
+- Added `Coq.Structures.OrderedTypeEx.String_as_OT` to make strings an
+  ordered type (using lexical order).
+
 Universes
 
 - Added `Print Universes Subgraph` variant of `Print Universes`.

--- a/CREDITS
+++ b/CREDITS
@@ -122,8 +122,11 @@ of the Coq Proof assistant during the indicated time:
   Sébastien Hinderer (INRIA, 2014)
   Gérard Huet (INRIA, 1985-1997)
   Matej Košík (INRIA, 2015-2017)
+  Leonidas Lampropoulos (University of Pennsylvania, 2018)
   Pierre Letouzey (LRI, 2000-2004, PPS, 2005-2008,
                    INRIA-PPS then IRIF, 2009-now)
+  Yao Li (ORCID: https://orcid.org/0000-0001-8720-883X,
+          University of Pennsylvania, 2018)
   Yishuai Li (ORCID: https://orcid.org/0000-0002-5728-5903
               U. Penn, 2018)
   Patrick Loiseleur (Paris Sud, 1997-1999)


### PR DESCRIPTION
**Kind:** feature.

- [x] Corresponding documentation was added / updated.
- [x] Entry added in CHANGES.

I do not know if there is a particular reason that the order of strings is not in `OrderedTypeEx`. This PR adds that to it.