### PR TITLE
[sphinx] Remove migration artefacts.

### DIFF
--- a/doc/sphinx/addendum/miscellaneous-extensions.rst
+++ b/doc/sphinx/addendum/miscellaneous-extensions.rst
@@ -5,9 +5,6 @@
 Miscellaneous extensions
 =======================
 
-:Source: https://coq.inria.fr/distrib/current/refman/miscellaneous.html
-:Converted by: Paul Steckler
-
 .. contents::
    :local:
    :depth: 1

--- a/doc/sphinx/addendum/type-classes.rst
+++ b/doc/sphinx/addendum/type-classes.rst
@@ -5,9 +5,6 @@
 Type Classes
 ============
 
-:Source: https://coq.inria.fr/distrib/current/refman/type-classes.html
-:Author: Matthieu Sozeau
-
 This chapter presents a quick reference of the commands related to type
 classes. For an actual introduction to type classes, there is a
 description of the system :cite:`sozeau08` and the literature on type

--- a/doc/sphinx/language/coq-library.rst
+++ b/doc/sphinx/language/coq-library.rst
@@ -5,9 +5,6 @@
 The |Coq| library
 =================
 
-:Source: https://coq.inria.fr/distrib/current/refman/stdlib.html
-:Converted by: Pierre Letouzey
-
 .. index::
    single: Theories
 

--- a/doc/sphinx/proof-engine/ssreflect-proof-language.rst
+++ b/doc/sphinx/proof-engine/ssreflect-proof-language.rst
@@ -6,10 +6,7 @@
  The |SSR| proof language
 ------------------------------
 
-:Source: https://coq.inria.fr/distrib/current/refman/ssreflect.html
-:Converted by: Enrico Tassi
-
-Author: Georges Gonthier, Assia Mahboubi, Enrico Tassi
+:Authors: Georges Gonthier, Assia Mahboubi, Enrico Tassi
 
 
 Introduction


### PR DESCRIPTION
These were used very inconsistently, serve no purpose and the link to the source is particularly useless because it's a moving target.