### PR TITLE
Attempt to fix the doubly encapsulated Ltac errors in coqide

### DIFF
--- a/ide/ide_slave.ml
+++ b/ide/ide_slave.ml
@@ -352,7 +352,6 @@ let about () = {
 }
 
 let handle_exn (e, info) =
-  let (e, info) = ExplainErr.process_vernac_interp_error (e, info) in
   let dummy = Stateid.dummy in
   let loc_of e = match Loc.get_loc e with
     | Some loc -> Some (Loc.unloc loc)


### PR DESCRIPTION
<!-- Keep what applies -->
**Kind:** tentative bug fix

Symptom: In CoqIDE, `Goal true. intro.` prints
```
Ltac call to "intro" failed.
Ltac call to "intro" failed.
No product even after head-reduction.
```
showing that `ExplainErr.process_vernac_interp_error` is called twice.

It is called a first time in `Stm.stm_vernac_interp` (via `Stm.call_process_error_once`) and a second time in the `handle_exn` method used by CoqIDE to handle exceptions coming from Coq (`ide_slave.ml/xmlprotocol.ml`).

The proposed fix is to remove the call in CoqIDE, assuming that the `process_vernac_interp_error` call is done otherwise on all potential error paths. However I don't know if this latter assumption is correct.

Supervision from @gares and @ejgallego needed.