### PR TITLE
Fixing the 3 cases of a "Stream.Error" ended with two periods.

### DIFF
--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -433,7 +433,7 @@ let glob_local_binder_of_extended = DAst.with_loc_val (fun ?loc -> function
       let t = DAst.make ?loc @@ GHole(Evar_kinds.BinderType na,Misctypes.IntroAnonymous,None) in
       (na,bk,Some c,t)
   | GLocalPattern (_,_,_,_) ->
-      Loc.raise ?loc (Stream.Error "pattern with quote not allowed here.")
+      Loc.raise ?loc (Stream.Error "pattern with quote not allowed here")
   )
 
 let intern_cases_pattern_fwd = ref (fun _ -> failwith "intern_cases_pattern_fwd")

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -261,7 +261,7 @@ let check_param = function
 | CLocalAssum (nas, Default _, _) -> List.iter check_named nas
 | CLocalAssum (nas, Generalized _, _) -> ()
 | CLocalPattern {CAst.loc} ->
-    Loc.raise ?loc (Stream.Error "pattern with quote not allowed here.")
+    Loc.raise ?loc (Stream.Error "pattern with quote not allowed here")
 
 let interp_mutual_inductive (paramsl,indl) notations cum poly prv finite =
   check_all_names_different indl;

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -114,7 +114,7 @@ let typecheck_params_and_fields finite def id poly pl t ps nots fs =
 	(function CLocalDef (b, _, _) -> error default_binder_kind b
 	   | CLocalAssum (ls, bk, ce) -> List.iter (error bk) ls
            | CLocalPattern {CAst.loc} ->
-              Loc.raise ?loc (Stream.Error "pattern with quote not allowed in record parameters.")) ps
+              Loc.raise ?loc (Stream.Error "pattern with quote not allowed in record parameters")) ps
   in 
   let sigma, (impls_env, ((env1,newps), imps)) = interp_context_evars env0 sigma ps in
   let sigma, typ, sort, template = match t with


### PR DESCRIPTION
**Kind:** bug fix

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #7230.

The "Stream.Error" printer does add a period, so, the messages themselves should not (my mistake in not having seen that).
