### PR TITLE
Reduce circular dependency constants <-> projections

### DIFF
--- a/checker/cic.mli
+++ b/checker/cic.mli
@@ -241,7 +241,7 @@ type constant_body = {
     const_type : constr;
     const_body_code : to_patch_substituted;
     const_universes : constant_universes;
-    const_proj : projection_body option;
+    const_proj : bool;
     const_inline_code : bool;
     const_typing_flags : typing_flags;
 }

--- a/checker/environ.mli
+++ b/checker/environ.mli
@@ -5,6 +5,7 @@ open Cic
 
 type globals = {
   env_constants : constant_body Cmap_env.t;
+  env_projections : projection_body Cmap_env.t;
   env_inductives : mutual_inductive_body Mindmap_env.t;
   env_inductives_eq : KerName.t KNmap.t;
   env_modules : module_body MPmap.t;

--- a/checker/mod_checking.ml
+++ b/checker/mod_checking.ml
@@ -47,13 +47,8 @@ let check_constant_declaration env kn cb =
   let () = 
     match body_of_constant cb with
     | Some bd ->
-      (match cb.const_proj with 
-      | None -> let j = infer envty bd in
-		  conv_leq envty j ty
-      | Some pb -> 
-	let env' = add_constant kn cb env' in
-	let j = infer env' bd in
-	  conv_leq envty j ty)
+      let j = infer envty bd in
+      conv_leq envty j ty
     | None -> ()
   in
   let env =

--- a/checker/values.ml
+++ b/checker/values.ml
@@ -15,7 +15,7 @@
 To ensure this file is up-to-date, 'make' now compares the md5 of cic.mli
 with a copy we maintain here:
 
-MD5 c4fdf8a846aed45c27b5acb1add7d1c6 checker/cic.mli
+MD5 92de14d7bf9134532e8a0cff5618bd50 checker/cic.mli
 
 *)
 
@@ -240,7 +240,7 @@ let v_cb = v_tuple "constant_body"
     v_constr;
     Any;
     v_const_univs;
-    Opt v_projbody;
+    v_bool;
     v_bool;
     v_typing_flags|]
 

--- a/kernel/clambda.ml
+++ b/kernel/clambda.ml
@@ -708,12 +708,10 @@ let rec lambda_of_constr env c =
     Lcofix(init, (names, ltypes, lbodies))
 
   | Proj (p,c) ->
-    let kn = Projection.constant p in
-    let cb = lookup_constant kn env.global_env in
-    let pb = Option.get cb.const_proj in
+    let pb = lookup_projection p env.global_env in
     let n = pb.proj_arg in
     let lc = lambda_of_constr env c in
-    Lproj (n,kn,lc)
+    Lproj (n,Projection.constant p,lc)
 
 and lambda_of_app env f args =
   match Constr.kind f with

--- a/kernel/cooking.mli
+++ b/kernel/cooking.mli
@@ -21,7 +21,7 @@ type inline = bool
 type result = {
   cook_body : constant_def;
   cook_type : types;
-  cook_proj : projection_body option;
+  cook_proj : bool;
   cook_universes : constant_universes;
   cook_inline : inline;
   cook_context : Context.Named.t option;

--- a/kernel/declarations.ml
+++ b/kernel/declarations.ml
@@ -87,7 +87,7 @@ type constant_body = {
     const_type : types;
     const_body_code : Cemitcodes.to_patch_substituted option;
     const_universes : constant_universes;
-    const_proj : projection_body option;
+    const_proj : bool;
     const_inline_code : bool;
     const_typing_flags : typing_flags; (** The typing options which
                                            were used for

--- a/kernel/declareops.ml
+++ b/kernel/declareops.ml
@@ -94,14 +94,13 @@ let subst_const_body sub cb =
   else
     let body' = subst_const_def sub cb.const_body in
     let type' = subst_const_type sub cb.const_type in
-    let proj' = Option.Smart.map (subst_const_proj sub) cb.const_proj in
     if body' == cb.const_body && type' == cb.const_type
-      && proj' == cb.const_proj then cb
+    then cb
     else
       { const_hyps = [];
         const_body = body';
         const_type = type';
-        const_proj = proj';
+        const_proj = cb.const_proj;
         const_body_code =
           Option.map (Cemitcodes.subst_to_patch_subst sub) cb.const_body_code;
         const_universes = cb.const_universes;

--- a/kernel/environ.mli
+++ b/kernel/environ.mli
@@ -48,6 +48,7 @@ type mind_key = mutual_inductive_body * link_info ref
 
 type globals = {
   env_constants : constant_key Cmap_env.t;
+  env_projections : projection_body Cmap_env.t;
   env_inductives : mind_key Mindmap_env.t;
   env_modules : module_body MPmap.t;
   env_modtypes : module_type_body MPmap.t

--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -803,9 +803,7 @@ let rec subterm_specif renv stack t =
          (* We take the subterm specs of the constructor of the record *)
          let wf_args = (dest_subterms wf).(0) in
          (* We extract the tree of the projected argument *)
-         let kn = Projection.constant p in
-         let cb = lookup_constant kn renv.env in
-         let pb = Option.get cb.const_proj in
+         let pb = lookup_projection p renv.env in
          let n = pb.proj_arg in
          spec_of_tree (List.nth wf_args n)
        | Dead_code -> Dead_code

--- a/kernel/nativecode.ml
+++ b/kernel/nativecode.ml
@@ -1859,7 +1859,7 @@ and compile_named env sigma univ auxdefs id =
 
 let compile_constant env sigma prefix ~interactive con cb =
   match cb.const_proj with
-  | None ->
+  | false ->
      let no_univs =
        match cb.const_universes with
        | Monomorphic_const _ -> true
@@ -1903,7 +1903,8 @@ let compile_constant env sigma prefix ~interactive con cb =
 	  if interactive then LinkedInteractive prefix
 	  else Linked prefix
     end
-  | Some pb ->
+  | true ->
+      let pb = lookup_projection (Projection.make con false) env in
       let mind = pb.proj_ind in
       let ind = (mind,0) in
       let mib = lookup_mind mind env in
@@ -2029,11 +2030,12 @@ let rec compile_deps env sigma prefix ~interactive init t =
       else
       let comp_stack, (mind_updates, const_updates) =
 	match cb.const_proj, cb.const_body with
-        | None, Def t ->
+        | false, Def t ->
 	   compile_deps env sigma prefix ~interactive init (Mod_subst.force_constr t)
-	| Some pb, _ ->
-	   let mind = pb.proj_ind in
-	   compile_mind_deps env prefix ~interactive init mind
+        | true, _ ->
+          let pb = lookup_projection (Projection.make c false) env in
+          let mind = pb.proj_ind in
+          compile_mind_deps env prefix ~interactive init mind
         | _ -> init
       in
       let code, name =

--- a/kernel/typeops.ml
+++ b/kernel/typeops.ml
@@ -528,13 +528,3 @@ let judge_of_case env ci pj cj lfj =
   let lf, lft = dest_judgev lfj in
   make_judge (mkCase (ci, (*nf_betaiota*) pj.uj_val, cj.uj_val, lft))
              (type_of_case env ci pj.uj_val pj.uj_type cj.uj_val cj.uj_type lf lft)
-
-let type_of_projection_constant env (p,u) =
-  let cst = Projection.constant p in
-  let cb = lookup_constant cst env in
-  match cb.const_proj with
-  | Some pb ->
-    if Declareops.constant_is_polymorphic cb then
-      Vars.subst_instance_constr u pb.proj_type
-    else pb.proj_type
-  | None -> raise (Invalid_argument "type_of_projection: not a projection")

--- a/kernel/typeops.mli
+++ b/kernel/typeops.mli
@@ -100,8 +100,6 @@ val judge_of_case : env -> case_info
   -> unsafe_judgment -> unsafe_judgment -> unsafe_judgment array
     -> unsafe_judgment
 
-val type_of_projection_constant : env -> Projection.t puniverses -> types
-
 val type_of_constant_in : env -> pconstant -> types
 
 (** Check that hyps are included in env and fails with error otherwise *)

--- a/library/heads.ml
+++ b/library/heads.ml
@@ -129,7 +129,7 @@ let compute_head = function
    let cb = Environ.lookup_constant cst env in
    let is_Def = function Declarations.Def _ -> true | _ -> false in
    let body = 
-     if cb.Declarations.const_proj = None && is_Def cb.Declarations.const_body
+     if not cb.Declarations.const_proj && is_Def cb.Declarations.const_body
      then Global.body_of_constant cst else None
    in
      (match body with

--- a/plugins/extraction/extraction.ml
+++ b/plugins/extraction/extraction.ml
@@ -1066,8 +1066,10 @@ let extract_constant env kn cb =
 	  | Undef _ -> warn_info (); mk_typ_ax ()
 	  | Def c ->
 	     (match cb.const_proj with
-              | None -> mk_typ (get_body c)
-              | Some pb -> mk_typ (EConstr.of_constr pb.proj_body))
+              | false -> mk_typ (get_body c)
+              | true ->
+                let pb = lookup_projection (Projection.make kn false) env in
+                mk_typ (EConstr.of_constr pb.proj_body))
 	  | OpaqueDef c ->
 	    add_opaque r;
             if access_opaque () then mk_typ (get_opaque env c)
@@ -1077,8 +1079,10 @@ let extract_constant env kn cb =
 	  | Undef _ -> warn_info (); mk_ax ()
 	  | Def c ->
 	     (match cb.const_proj with
-              | None -> mk_def (get_body c)
-              | Some pb -> mk_def (EConstr.of_constr pb.proj_body))
+              | false -> mk_def (get_body c)
+              | true ->
+                let pb = lookup_projection (Projection.make kn false) env in
+                mk_def (EConstr.of_constr pb.proj_body))
 	  | OpaqueDef c ->
 	    add_opaque r;
             if access_opaque () then mk_def (get_opaque env c)

--- a/pretyping/inductiveops.ml
+++ b/pretyping/inductiveops.ml
@@ -629,6 +629,10 @@ let type_of_inductive_knowing_conclusion env sigma ((mib,mip),u) conclty =
         env evdref scl ar.template_level (ctx,ar.template_param_levels) in
       !evdref, EConstr.of_constr (mkArity (List.rev ctx,scl))
 
+let type_of_projection_constant env (p,u) =
+  let pb = lookup_projection p env in
+  Vars.subst_instance_constr u pb.proj_type
+
 let type_of_projection_knowing_arg env sigma p c ty =
   let c = EConstr.Unsafe.to_constr c in
   let IndType(pars,realargs) =
@@ -637,7 +641,7 @@ let type_of_projection_knowing_arg env sigma p c ty =
       raise (Invalid_argument "type_of_projection_knowing_arg_type: not an inductive type")
   in
   let (_,u), pars = dest_ind_family pars in
-  substl (c :: List.rev pars) (Typeops.type_of_projection_constant env (p,u))
+  substl (c :: List.rev pars) (type_of_projection_constant env (p,u))
 
 (***********************************************)
 (* Guard condition *)

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -293,15 +293,15 @@ let strip_params env sigma c =
   | App (f, args) -> 
     (match EConstr.kind sigma f with
     | Const (p,_) ->
-      let cb = lookup_constant p env in
-	(match cb.Declarations.const_proj with
-	| Some pb -> 
-	  let n = pb.Declarations.proj_npars in
-	    if Array.length args > n then
-	      mkApp (mkProj (Projection.make p false, args.(n)), 
-		     Array.sub args (n+1) (Array.length args - (n + 1)))
-	    else c
-	| None -> c)
+      let p = Projection.make p false in
+      (match lookup_projection p env with
+       | pb ->
+         let n = pb.Declarations.proj_npars in
+         if Array.length args > n then
+           mkApp (mkProj (p, args.(n)),
+                  Array.sub args (n+1) (Array.length args - (n + 1)))
+         else c
+       | exception Not_found -> c)
     | _ -> c)
   | _ -> c
 


### PR DESCRIPTION
Instead of having the projection data in the constant data we have it
independently in the environment.

This notably simplifies byte compiling of projection constants (in term_typing) and whatever was going on with projection constants in cooking.

Side note: `type_of_projection_constant` was moved from kernel/typeops making it internal to inductiveops.