### PR TITLE
[ssr] simpler semantics for delayed clears

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -61,6 +61,20 @@ Coq binaries and process model
   `coq{proof,tactic,query}worker` are in charge of task-specific and
   parallel proof checking.
 
+SSReflect
+
+- The implementation of delayed clear switches in intro patterns
+  is now simpler to explain:
+  1. The immediate effect of a clear switch like {x} is to rename the
+     variable x to _x_ (i.e. a reserved identifier that cannot be mentioned
+     explicitly)
+  2. The delayed effect of {x} is that _x_ is cleared at the end of the intro
+     pattern
+  3. A clear switch immediately before a view application like {x}/v is
+     translated to /v{x}.
+  In particular rule 3 lets one write {x}/v even if v uses the variable x:
+  indeed the view is executed before the renaming.
+
 Changes from 8.8.0 to 8.8.1
 ===========================
 

--- a/CHANGES
+++ b/CHANGES
@@ -75,6 +75,12 @@ SSReflect
   In particular rule 3 lets one write {x}/v even if v uses the variable x:
   indeed the view is executed before the renaming.
 
+- An empty clear switch is now accepted in intro patterns before a 
+  view application whenever the view is a variable.
+  One can now write {}/v to mean {v}/v.  Remark that {}/x is very similar
+  to the idiom {}e for the rewrite tactic (the equation e is used for
+  rewriting and then discarded).
+
 Changes from 8.8.0 to 8.8.1
 ===========================
 

--- a/doc/sphinx/proof-engine/ssreflect-proof-language.rst
+++ b/doc/sphinx/proof-engine/ssreflect-proof-language.rst
@@ -624,7 +624,8 @@ where:
   list is a natural, this element should be a number, and not an Ltac
   variable. The empty list ``{}`` is not interpreted as a valid occurrence
   switch, it is rather used as a flag to signal the intent of the user to
-  clear the name following it (see :ref:`ssr_rewrite_occ_switch`)
+  clear the name following it (see :ref:`ssr_rewrite_occ_switch` and
+  :ref:`introduction_ssr`)
 
 The tactic:
 
@@ -1540,7 +1541,7 @@ whose general syntax is
    :name: =>
 
 .. prodn::
-   i_item ::= @i_pattern %| @s_item %| @clear_switch %| /@term
+   i_item ::= @i_pattern %| @s_item %| @clear_switch %| {? %{%} } /@term
 
 .. prodn::
    s_item ::= /= %| // %| //=
@@ -1642,6 +1643,11 @@ The view is applied to the top assumption.
   While it is good style to use the :token:`i_item` i * to pop the variables
   and assumptions corresponding to each constructor, this is not enforced by
   |SSR|.
+``/`` :token:`term`
+  Interprets the top of the stack with the view :token:`term`.
+  It is equivalent to ``move/term``. The optional flag ``{}`` can
+  be used to signal that the :token:`term`, when it is a context entry,
+  has to be cleared.
 ``-``
   does nothing, but counts as an intro pattern. It can also be used to
   force the interpretation of ``[`` :token:`i_item` * ``| … |``
@@ -5284,7 +5290,7 @@ generalization item see :ref:`structure_ssr`
 
 intro pattern :ref:`introduction_ssr`
 
-.. prodn:: i_item ::= @clear_switch %| @s_item %| @i_pattern %| / @term
+.. prodn:: i_item ::= @clear_switch %| @s_item %| @i_pattern %| {? %{%} } / @term
 
 intro item  see :ref:`introduction_ssr`
 

--- a/doc/sphinx/proof-engine/ssreflect-proof-language.rst
+++ b/doc/sphinx/proof-engine/ssreflect-proof-language.rst
@@ -623,7 +623,8 @@ where:
 + In the occurrence switch :token:`occ_switch`, if the first element of the
   list is a natural, this element should be a number, and not an Ltac
   variable. The empty list ``{}`` is not interpreted as a valid occurrence
-  switch.
+  switch, it is rather used as a flag to signal the intent of the user to
+  clear the name following it (see :ref:`ssr_rewrite_occ_switch`)
 
 The tactic:
 
@@ -3236,6 +3237,7 @@ the equality.
   Indeed the left hand side of ``H`` does not match
   the redex identified by the pattern ``x + y * 4``.
 
+.. _ssr_rewrite_occ_switch:
 
 Occurrence switches and redex switches
 ``````````````````````````````````````
@@ -3260,6 +3262,9 @@ the rewrite tactic. The effect of the tactic on the initial goal is to
 rewrite this lemma at the second occurrence of the first matching
 ``x + y + 0`` of the explicit rewrite redex ``_ + y + 0``.
 
+An empty occurrence switch ``{}`` is not interpreted as a valid occurrence
+switch. It has the effect of clearing the :token:`r_item` (when it is the name
+of a context entry).
 
 Occurrence selection and repetition
 ```````````````````````````````````

--- a/plugins/ssr/ssrast.mli
+++ b/plugins/ssr/ssrast.mli
@@ -88,7 +88,7 @@ type ssripat =
   | IPatCase of (* ipats_mod option * *) ssripatss (* this is not equivalent to /case /[..|..] if there are already multiple goals *)
   | IPatInj of ssripatss
   | IPatRewrite of (*occurrence option * rewrite_pattern **) ssrocc * ssrdir
-  | IPatView of ssrview (* /view *)
+  | IPatView of bool * ssrview (* {}/view (true if the clear is present) *)
   | IPatClear of ssrclear (* {H1 H2} *)
   | IPatSimpl of ssrsimpl
   | IPatAbstractVars of Id.t list

--- a/plugins/ssr/ssripats.ml
+++ b/plugins/ssr/ssripats.ml
@@ -212,8 +212,8 @@ let tclLOG p t =
 
 let rec ipat_tac1 ipat : unit tactic =
   match ipat with
-  | IPatView l ->
-      Ssrview.tclIPAT_VIEWS ~views:l
+  | IPatView (clear_if_id,l) ->
+      Ssrview.tclIPAT_VIEWS ~views:l ~clear_if_id
         ~conclusion:(fun ~to_clear:clr -> intro_clear clr)
   | IPatDispatch ipatss ->
       tclEXTEND (List.map ipat_tac ipatss) (tclUNIT ()) []
@@ -588,7 +588,7 @@ let ssrmovetac = function
        (tacVIEW_THEN_GRAB view ~conclusion) <*>
      tclIPAT (IPatClear clr :: ipats)
   | _::_ as view, (_, ({ gens = []; clr }, ipats)) ->
-     tclIPAT (IPatView view :: IPatClear clr :: ipats)
+     tclIPAT (IPatView (false,view) :: IPatClear clr :: ipats)
   | _, (Some pat, (dgens, ipats)) ->
     let dgentac = with_dgens dgens eqmovetac in
     dgentac <*> tclIPAT (eqmoveipats pat ipats)

--- a/plugins/ssr/ssrprinters.ml
+++ b/plugins/ssr/ssrprinters.ml
@@ -107,7 +107,8 @@ let rec pr_ipat p =
   | IPatAnon All -> str "*"
   | IPatAnon Drop -> str "_"
   | IPatAnon One -> str "?"
-  | IPatView v -> pr_view2 v
+  | IPatView (false,v) -> pr_view2 v
+  | IPatView (true,v) -> str"{}" ++ pr_view2 v
   | IPatNoop -> str "-"
   | IPatAbstractVars l -> str "[:" ++ pr_list spc Id.print l ++ str "]"
   | IPatTac _ -> str "<tac>"

--- a/plugins/ssr/ssrview.mli
+++ b/plugins/ssr/ssrview.mli
@@ -20,9 +20,11 @@ module AdaptorDb : sig
 
 end
 
-(* Apply views to the top of the stack (intro pattern) *)
+(* Apply views to the top of the stack (intro pattern). If clear_if_id is
+ * true (default false) then views that happen to be a variable are considered
+ * as to be cleared (see the to_clear argument to the continuation) *)
 val tclIPAT_VIEWS :
-    views:ast_closure_term list ->
+    views:ast_closure_term list -> ?clear_if_id:bool ->
     conclusion:(to_clear:Names.Id.t list -> unit Proofview.tactic) ->
   unit Proofview.tactic
 

--- a/test-suite/ssr/ipat_clear_if_id.v
+++ b/test-suite/ssr/ipat_clear_if_id.v
@@ -1,0 +1,23 @@
+Require Import ssreflect.
+
+Axiom v1 : nat -> bool.
+
+Section Foo.
+
+Variable v2 : nat -> bool.
+
+Lemma test (v3 : nat -> bool) (v4 : bool -> bool) (v5 : bool -> bool) : nat -> nat -> nat -> nat -> True.
+Proof.
+move=> {}/v1 b1 {}/v2 b2 {}/v3 b3 {}/v2/v4/v5 b4.
+Check b1 : bool.
+Check b2 : bool.
+Check b3 : bool.
+Check b4 : bool.
+Fail Check v3.
+Fail Check v4.
+Fail Check v5.
+Check v2 : nat -> bool.
+by [].
+Qed.
+
+End Foo.


### PR DESCRIPTION
- we always rename
- we compile {clear}/view to /view{clear}

supersedes #7166 