### PR TITLE
Making tactic-in-term aware of "Set Ltac Debug"

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -14,9 +14,9 @@ Vernacular Commands
 Tactic language
 
 - Support for fix/cofix added in Ltac "match" and "lazymatch".
-
 - Ltac backtraces now contain include trace information about tactics
   called by OCaml-defined tactics.
+- Option "Ltac Debug" now applies also to terms built using Ltac functions.
 
 Changes from 8.8+beta1 to 8.8.0
 ===============================

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -2010,7 +2010,8 @@ let interp_redexp env sigma r =
 
 let _ =
   let eval lfun env sigma ty tac =
-    let ist = { lfun = lfun; extra = TacStore.empty; } in
+    let extra = TacStore.set TacStore.empty f_debug (get_debug ()) in
+    let ist = { lfun = lfun; extra; } in
     let tac = interp_tactic ist tac in
     let (c, sigma) = Pfedit.refine_by_tactic env sigma ty tac in
     (EConstr.of_constr c, sigma)


### PR DESCRIPTION
**Kind:** minor feature

I found a bit frustrating that tactics in terms could not be debugged. This PR runs tactics-in-terms with the debug flag as it is set at the time of starting the execution.

@ppedrot: Would you like this to be applied to `ltac2/src/tac2core.ml` too?

- [x] Entry added in CHANGES.

