### PR TITLE
pre-commit : do not fail miserably if git config has `apply.whitespace = fix`

### DIFF
--- a/dev/tools/pre-commit
+++ b/dev/tools/pre-commit
@@ -27,8 +27,8 @@ then
 
     # reset work tree and index
     # NB: untracked files which were not added are untouched
-    git apply --cached -R "$index"
-    git apply -R "$tree"
+    git apply --whitespace=nowarn --cached -R "$index"
+    git apply --whitespace=nowarn -R "$tree"
 
     # Fix index
     # For end of file newlines we must go through the worktree
@@ -45,7 +45,7 @@ then
     # making git fail. Don't fail now: we fix the worktree first.
     if [ -s "$fixed_index" ]
     then
-        git apply -R "$fixed_index"
+        git apply --whitespace=nowarn -R "$fixed_index"
     fi
 
     # Fix worktree


### PR DESCRIPTION
 Having `--whitespace=` on all `git apply` in this script should make it insensitive to user setup in `~/.gitconfig`, at least `[apply] whitespace = fix`.

 Note that even this way, this script remains hugely fragile and non mature, and would better *not* be set by default for everybody. Seriously, a suggestion to iterate the process in case of failure ?? Seriously again, the developer's work left in some obscure `git-fix-ws-*`files in case of havoc (and havoc *do* occur in real life), without at least a recovery routine attempted (or precise instructions to sort the mess) ?? Could we at least have a message explaining how to disable this experimental script ??

Frankly, putting anything in the way between a developer and its next commit is a *very* good way to get her/him really angry. So please don't. 
