### PR TITLE
In Ltac definitions, experimenting forcing introduction identifiers to be either declared in advance or chosen up to renaming

### DIFF
--- a/plugins/ltac/tacintern.ml
+++ b/plugins/ltac/tacintern.ml
@@ -232,7 +232,10 @@ let rec intern_intro_pattern lf ist = map (function
 
 and intern_intro_pattern_naming lf ist = function
   | IntroIdentifier id ->
-      IntroIdentifier (intern_ident lf ist id)
+      if !strict_check then
+        if find_var id ist then IntroIdentifier id else Pretype_errors.error_var_not_found id
+      else
+        IntroIdentifier (intern_ident lf ist id)
   | IntroFresh id ->
       IntroFresh (intern_ident lf ist id)
   | IntroAnonymous as x -> x

--- a/plugins/micromega/Lia.v
+++ b/plugins/micromega/Lia.v
@@ -26,7 +26,7 @@ Ltac preprocess :=
   zify ; unfold Z.succ in * ; unfold Z.pred in *.
 
 Ltac zchange := 
-  intros __wit __varmap __ff ;
+  intros ?__wit ?__varmap ?__ff ;
   change (Tauto.eval_f (Zeval_formula (@find Z Z0 __varmap)) __ff) ;
   apply (ZTautoChecker_sound __ff __wit).
 

--- a/plugins/micromega/Lqa.v
+++ b/plugins/micromega/Lqa.v
@@ -22,7 +22,7 @@ Require Coq.micromega.Tauto.
 Declare ML Module "micromega_plugin".
 
 Ltac rchange := 
-  intros __wit __varmap __ff ;
+  intros ?__wit ?__varmap ?__ff ;
   change (Tauto.eval_f (Qeval_formula (@find Q 0%Q __varmap)) __ff) ;
   apply (QTautoChecker_sound __ff __wit).
 

--- a/plugins/micromega/Lra.v
+++ b/plugins/micromega/Lra.v
@@ -23,7 +23,7 @@ Require Coq.micromega.Tauto.
 Declare ML Module "micromega_plugin".
 
 Ltac rchange := 
-  intros __wit __varmap __ff ;
+  intros ?__wit ?__varmap ?__ff ;
   change (Tauto.eval_f (Reval_formula (@find R 0%R __varmap)) __ff) ;
   apply (RTautoChecker_sound __ff __wit).
 

--- a/plugins/setoid_ring/Field_tac.v
+++ b/plugins/setoid_ring/Field_tac.v
@@ -215,7 +215,7 @@ Ltac fold_field_cond req :=
 Ltac simpl_PCond FLD :=
   let req := get_FldEq FLD in
   let lemma := get_CondLemma FLD in
-  try (apply lemma; intros lock lock_def; vm_compute; rewrite lock_def; clear lock_def lock); 
+  try (apply lemma; intros ?lock ?lock_def; vm_compute; rewrite lock_def; clear lock_def lock);
   protect_fv "field_cond";
   fold_field_cond req;
   try exact I.
@@ -223,7 +223,7 @@ Ltac simpl_PCond FLD :=
 Ltac simpl_PCond_BEURK FLD :=
   let req := get_FldEq FLD in
   let lemma := get_CondLemma FLD in
-  (apply lemma; intros lock lock_def; vm_compute; rewrite lock_def; clear lock_def lock);
+  (apply lemma; intros ?lock ?lock_def; vm_compute; rewrite lock_def; clear lock_def lock);
   protect_fv "field_cond";
   fold_field_cond req.
 

--- a/theories/FSets/FMapAVL.v
+++ b/theories/FSets/FMapAVL.v
@@ -542,14 +542,14 @@ Ltac intuition_in := repeat (intuition; inv In; inv MapsTo).
    Let's do its job by hand: *)
 
 Ltac join_tac :=
- intros l; induction l as [| ll _ lx ld lr Hlr lh];
-   [ | intros x d r; induction r as [| rl Hrl rx rd rr _ rh]; unfold join;
-     [ | destruct (gt_le_dec lh (rh+2)) as [GT|LE];
+ intros ?l; induction l as [| ?ll _ ?lx ?ld ?lr ?Hlr ?lh];
+   [ | intros ?x ?d ?r; induction r as [| ?rl ?Hrl ?rx ?rd ?rr _ ?rh]; unfold join;
+     [ | destruct (gt_le_dec lh (rh+2)) as [?GT|?LE];
        [ match goal with |- context [ bal ?u ?v ?w ?z ] =>
            replace (bal u v w z)
            with (bal ll lx ld (join lr x d (Node rl rx rd rr rh))); [ | auto]
          end
-       | destruct (gt_le_dec rh (lh+2)) as [GT'|LE'];
+       | destruct (gt_le_dec rh (lh+2)) as [?GT'|?LE'];
          [ match goal with |- context [ bal ?u ?v ?w ?z ] =>
              replace (bal u v w z)
              with (bal (join (Node ll lx ld lr lh) x d rl) rx rd rr); [ | auto]

--- a/theories/MSets/MSetAVL.v
+++ b/theories/MSets/MSetAVL.v
@@ -420,14 +420,14 @@ Local Open Scope Int_scope.
 
 Ltac join_tac :=
  let l := fresh "l" in
- intro l; induction l as [| lh ll _ lx lr Hlr];
-   [ | intros x r; induction r as [| rh rl Hrl rx rr _]; unfold join;
-     [ | destruct ((rh+2) <? lh) eqn:LT;
+ intros l; induction l as [| ?lh ?ll _ ?lx ?lr ?Hlr];
+   [ | intros ?x ?r; induction r as [| ?rh ?rl ?Hrl ?rx ?rr _]; unfold join;
+     [ | destruct ((rh+2) <? lh) eqn:?LT;
        [ match goal with |- context b [ bal ?a ?b ?c] =>
            replace (bal a b c)
            with (bal ll lx (join lr x (Node rh rl rx rr))); [ | auto]
          end
-       | destruct ((lh+2) <? rh) eqn:LT';
+       | destruct ((lh+2) <? rh) eqn:?LT';
          [ match goal with |- context b [ bal ?a ?b ?c] =>
              replace (bal a b c)
              with (bal (join (Node lh ll lx lr) x rl) rx rr); [ | auto]

--- a/theories/MSets/MSetGenTree.v
+++ b/theories/MSets/MSetGenTree.v
@@ -519,7 +519,7 @@ Qed.
 Local Hint Resolve lt_tree_not_in lt_tree_trans gt_tree_not_in gt_tree_trans.
 
 Ltac induct s x :=
- induction s as [|i l IHl x' r IHr]; simpl; intros;
+ induction s as [|?i ?l ?IHl ?x' ?r ?IHr]; simpl; intros;
  [|elim_compare x x'; intros; inv].
 
 Ltac auto_tc := auto with typeclass_instances.

--- a/theories/MSets/MSetList.v
+++ b/theories/MSets/MSetList.v
@@ -386,9 +386,9 @@ Module MakeRaw (X: OrderedType) <: RawSets X.
   Ltac induction2 :=
     simple induction s;
      [ simpl; auto; try solve [ intros; inv ]
-     | intros x l Hrec; simple induction s';
+     | intros ?x ?l ?Hrec; simple induction s';
         [ simpl; auto; try solve [ intros; inv ]
-        | intros x' l' Hrec'; simpl; elim_compare x x'; intros; inv; auto ]].
+        | intros ?x' ?l' ?Hrec'; simpl; elim_compare x x'; intros; inv; auto ]].
 
   Lemma union_inf :
    forall (s s' : t) (a : elt) (Hs : Ok s) (Hs' : Ok s'),

--- a/theories/MSets/MSetRBT.v
+++ b/theories/MSets/MSetRBT.v
@@ -759,18 +759,18 @@ Hint Rewrite lbalS_spec rbalS_spec : rb.
 (** ** Append for deletion *)
 
 Ltac append_tac l r :=
- induction l as [| lc ll _ lx lr IHlr];
- [intro r; simpl
- |induction r as [| rc rl IHrl rx rr _];
+ induction l as [| ?lc ?ll _ ?lx ?lr ?IHlr];
+ [intros ?r; simpl
+ |induction r as [| ?rc ?rl ?IHrl ?rx ?rr _];
    [simpl
    |destruct lc, rc;
      [specialize (IHlr rl); clear IHrl
      |simpl;
-      assert (Hr:notred (Bk rl rx rr)) by (simpl; trivial);
+      assert (notred (Bk rl rx rr)) as ?Hr by (simpl; trivial);
       set (r:=Bk rl rx rr) in *; clearbody r; clear IHrl rl rx rr;
       specialize (IHlr r)
      |change (append _ _) with (Rd (append (Bk ll lx lr) rl) rx rr);
-      assert (Hl:notred (Bk ll lx lr)) by (simpl; trivial);
+      assert (notred (Bk ll lx lr)) as ?Hl by (simpl; trivial);
       set (l:=Bk ll lx lr) in *; clearbody l; clear IHlr ll lx lr
      |specialize (IHlr rl); clear IHrl]]].
 

--- a/theories/PArith/BinPos.v
+++ b/theories/PArith/BinPos.v
@@ -1738,7 +1738,7 @@ Qed.
 
 Ltac destr_pggcdn IHn :=
  match goal with |- context [ ggcdn _ ?x ?y ] =>
-  generalize (IHn x y); destruct ggcdn as (g,(u,v)); simpl
+  generalize (IHn x y); destruct ggcdn as (?g,(?u,?v)); simpl
  end.
 
 Lemma ggcdn_correct_divisors : forall n a b,

--- a/theories/Structures/OrderedType.v
+++ b/theories/Structures/OrderedType.v
@@ -182,15 +182,15 @@ Module OrderedTypeFacts (Import O: OrderedType).
 
   Ltac elim_comp_eq x y :=
     elim (elim_compare_eq (x:=x) (y:=y));
-     [ intros _1 _2; rewrite _2; clear _1 _2 | auto ].
+     [ intros ?_1 ?_2; rewrite _2; clear _1 _2 | auto ].
 
   Ltac elim_comp_lt x y :=
     elim (elim_compare_lt (x:=x) (y:=y));
-     [ intros _1 _2; rewrite _2; clear _1 _2 | auto ].
+     [ intros ?_1 ?_2; rewrite _2; clear _1 _2 | auto ].
 
   Ltac elim_comp_gt x y :=
     elim (elim_compare_gt (x:=x) (y:=y));
-     [ intros _1 _2; rewrite _2; clear _1 _2 | auto ].
+     [ intros ?_1 ?_2; rewrite _2; clear _1 _2 | auto ].
 
   (** For compatibility reasons *)
   Definition eq_dec := eq_dec.


### PR DESCRIPTION
**Kind:** feature (but also a fix wrt the natural tendency of a tactic programmer)

This PR is a small experiment in the direction of better understanding and better controlling name scoping in Ltac (and Ltac2) functions.

The rationale is that an Ltac (or Ltac2) function with an `intros X` where `X` is not a Ltac (or Ltac2) variable name would not be robust enough as it will fail whenever the context already contains a variable named `X`. It should typically either be `intros ?X`, or e.g. `let X := fresh in intros X`.

We can find examples In the standard library of code written without `fresh` or `?X`. This is not surprising since it is simpler and nicer to write `intros X` than `intros ?X`, so that, until problems are eventually found in practice, the programmer does not see the need to ensure freshness.

I'm afraid that applying the PR would require to change quite a lot of code, and moreover in a way which makes it more complicated to read. Another alternative would be to change the semantic of `intros` in Ltac (or Ltac2) functions so that `intros X` is by default the same as `intros ?X`, which is after all certainly the intent of the programmer, and which is what happens already in the case of a `fun X => t` (up to #307-style issues). However, if we do that, should we change `intros X` also in interactive code (i.e. technically, when `strict_check` is `false`)? This latter step looks slippery.

Note: `intro` is not changed by the PR (more difficult to do, so waiting first for a direction where to go).