### PR TITLE
Taking into account the renaming of bound variables for tactics-in-terms

### DIFF
--- a/interp/interp.mllib
+++ b/interp/interp.mllib
@@ -2,7 +2,6 @@ Constrexpr
 Genredexpr
 Redops
 Tactypes
-Stdarg
 Genintern
 Notation_term
 Notation_ops

--- a/interp/stdarg.ml
+++ b/interp/stdarg.ml
@@ -37,7 +37,8 @@ let wit_int_or_var =
   make0 ~dyn:(val_tag (topwit wit_int)) "int_or_var"
 
 let wit_ident =
-  make0 "ident"
+  (* Early defined in Geninterp *)
+  Geninterp.wit_ident
 
 let wit_var =
   make0 ~dyn:(val_tag (topwit wit_ident)) "var"

--- a/interp/stdarg.mli
+++ b/interp/stdarg.mli
@@ -38,6 +38,7 @@ val wit_pre_ident : string uniform_genarg_type
 val wit_int_or_var : (int or_var, int or_var, int) genarg_type
 
 val wit_ident : Id.t uniform_genarg_type
+  (* Same as Geninterp.wit_ident *)
 
 val wit_var : (lident, lident, Id.t) genarg_type
 

--- a/pretyping/cases.ml
+++ b/pretyping/cases.ml
@@ -406,8 +406,7 @@ let coerce_to_indtype typing_fun evdref env matx tomatchl =
 (* Utils *)
 
 let mkExistential env ?(src=(Loc.tag Evar_kinds.InternalHole)) evdref =
-  let (e, u) = evd_comb1 (new_type_evar env ~src:src) evdref univ_flexible_alg in
-  e
+  GlobEnv.e_new_type_evar env evdref ~src
 
 let evd_comb2 f evdref x y =
   let (evd',y) = f !evdref x y in
@@ -1693,7 +1692,7 @@ let abstract_tycon ?loc env evdref subst tycon extenv t =
 	    (fun i _ ->
               try list_assoc_in_triple i subst0 with Not_found -> mkRel i)
               1 (rel_context !!env) in
-        let ev' = evd_comb1 (Evarutil.new_evar !!env ~src) evdref ty in
+        let ev' = e_new_evar env evdref ~src ty in
         begin match solve_simple_eqn (evar_conv_x full_transparent_state) !!env !evdref (None,ev,substl inst ev') with
         | Success evd -> evdref := evd
         | UnifFailure _ -> assert false
@@ -2514,7 +2513,7 @@ let compile_program_cases ?loc style (typing_function, evdref) tycon env
   let tycon, arity =
     let nar = List.fold_left (fun n sign -> List.length sign + n) 0 sign in
     match tycon' with
-    | None -> let ev = mkExistential !!env evdref in ev, lift nar ev
+    | None -> let ev = mkExistential env evdref in ev, lift nar ev
     | Some t ->
 	let pred =
 	  match prepare_predicate_from_arsign_tycon env !evdref loc tomatchs sign t with

--- a/pretyping/cases.ml
+++ b/pretyping/cases.ml
@@ -406,7 +406,7 @@ let coerce_to_indtype typing_fun evdref env matx tomatchl =
 (* Utils *)
 
 let mkExistential env ?(src=(Loc.tag Evar_kinds.InternalHole)) evdref =
-  GlobEnv.e_new_type_evar env evdref ~src
+  evd_comb0 (GlobEnv.new_type_evar ~src env) evdref
 
 let evd_comb2 f evdref x y =
   let (evd',y) = f !evdref x y in
@@ -1692,7 +1692,7 @@ let abstract_tycon ?loc env evdref subst tycon extenv t =
 	    (fun i _ ->
               try list_assoc_in_triple i subst0 with Not_found -> mkRel i)
               1 (rel_context !!env) in
-        let ev' = e_new_evar env evdref ~src ty in
+        let ev' = evd_comb1 (new_evar ~src env) evdref ty in
         begin match solve_simple_eqn (evar_conv_x full_transparent_state) !!env !evdref (None,ev,substl inst ev') with
         | Success evd -> evdref := evd
         | UnifFailure _ -> assert false
@@ -1740,8 +1740,8 @@ let build_tycon ?loc env tycon_env s subst tycon extenv evdref t =
         let n' = Context.Rel.length (rel_context !!tycon_env) in
         let impossible_case_type, u =
           evd_comb1
-            (new_type_evar (reset_context !!env) ~src:(Loc.tag ?loc Evar_kinds.ImpossibleCase))
-            evdref univ_flexible_alg
+            (Evarutil.new_type_evar ~src:(Loc.tag ?loc Evar_kinds.ImpossibleCase) (reset_context !!env))
+            evdref Evd.univ_flexible_alg
         in
         (lift (n'-n) impossible_case_type, mkSort u)
     | Some t ->
@@ -2042,7 +2042,7 @@ let prepare_predicate ?loc typing_fun env sigma tomatchs arsign tycon pred =
 	| Some t -> refresh_tycon sigma t
 	| None -> 
           let (sigma, (t, _)) =
-            new_type_evar !!env sigma univ_flexible_alg ~src:(Loc.tag ?loc @@ Evar_kinds.CasesType false) in
+            Evarutil.new_type_evar !!env sigma univ_flexible_alg ~src:(Loc.tag ?loc @@ Evar_kinds.CasesType false) in
 	    sigma, t
 	in
         (* First strategy: we build an "inversion" predicate *)

--- a/pretyping/geninterp.ml
+++ b/pretyping/geninterp.ml
@@ -100,3 +100,10 @@ module Interp = Register(InterpObj)
 let interp = Interp.obj
 
 let register_interp0 = Interp.register0
+
+(* We need wit_ident exceptionnaly early *)
+
+let wit_ident =
+  let wit = Genarg.make0 "ident" in
+  let () = register_val0 wit None in
+  wit

--- a/pretyping/geninterp.mli
+++ b/pretyping/geninterp.mli
@@ -72,3 +72,7 @@ val interp : ('raw, 'glb, 'top) genarg_type -> ('glb, Val.t) interp_fun
 
 val register_interp0 :
   ('raw, 'glb, 'top) genarg_type -> ('glb, Val.t) interp_fun -> unit
+
+(* We need wit_ident exceptionally early *)
+
+val wit_ident : Id.t uniform_genarg_type

--- a/pretyping/globEnv.ml
+++ b/pretyping/globEnv.ml
@@ -94,7 +94,7 @@ let push_rec_types sigma (lna,typarray) env =
   let env,ctx = Array.fold_left_map (fun e assum -> let (d,e) = push_rel sigma assum e in (e,d)) env ctxt in
   Array.map get_name ctx, env
 
-let e_new_evar env evdref ?src ?naming typ =
+let new_evar ?src ?naming env sigma typ =
   let open Context.Named.Declaration in
   let inst_vars = List.map (get_id %> mkVar) (named_context env.renamed_env) in
   let inst_rels = List.rev (rel_list 0 (nb_rel env.renamed_env)) in
@@ -102,15 +102,11 @@ let e_new_evar env evdref ?src ?naming typ =
   let typ' = csubst_subst subst typ in
   let instance = inst_rels @ inst_vars in
   let sign = val_of_named_context nc in
-  let sigma = !evdref in
-  let (sigma, e) = new_evar_instance sign sigma typ' ?src ?naming instance in
-  evdref := sigma;
-  e
+  new_evar_instance sign sigma typ' ?src ?naming instance
 
-let e_new_type_evar env evdref ~src =
-  let (evd', s) = Evd.new_sort_variable Evd.univ_flexible_alg !evdref in
-  evdref := evd';
-  e_new_evar env evdref ~src (EConstr.mkSort s)
+let new_type_evar ~src env sigma =
+  let (sigma', s) = Evd.new_sort_variable Evd.univ_flexible_alg sigma in
+  new_evar ~src env sigma' (EConstr.mkSort s)
 
 let hide_variable env expansion id =
   let lvar = env.lvar in

--- a/pretyping/globEnv.mli
+++ b/pretyping/globEnv.mli
@@ -53,10 +53,10 @@ val push_rec_types : evar_map -> Name.t array * constr array -> t -> Name.t arra
 
 (** Declare an evar using renaming information *)
 
-val e_new_evar : t -> evar_map ref -> ?src:Evar_kinds.t Loc.located ->
-  ?naming:Namegen.intro_pattern_naming_expr -> constr -> constr
+val new_evar : ?src:Evar_kinds.t Loc.located ->
+  ?naming:Namegen.intro_pattern_naming_expr -> t -> evar_map -> constr -> evar_map * constr
 
-val e_new_type_evar : t -> evar_map ref -> src:Evar_kinds.t Loc.located -> constr
+val new_type_evar : src:Evar_kinds.t Loc.located -> t -> evar_map -> evar_map * constr
 
 (** [hide_variable env na id] tells to hide the binding of [id] in
     the ltac environment part of [env] and to additionally rebind

--- a/pretyping/pretyping.mllib
+++ b/pretyping/pretyping.mllib
@@ -1,5 +1,6 @@
 Geninterp
 Locus
+Stdarg
 Locusops
 Pretype_errors
 Reductionops

--- a/test-suite/bugs/closed/3248.v
+++ b/test-suite/bugs/closed/3248.v
@@ -13,5 +13,5 @@ Proof.
   intros A B x y.
   pose (f := fun (x y : A) => conj x y).
   pose (a := ltac:(ret_and_left f)).
-  Fail unify (a x y) (conj x y).
+  unify (a x y) (conj x y).
 Abort.

--- a/test-suite/output/Notations.out
+++ b/test-suite/output/Notations.out
@@ -117,8 +117,8 @@ fun x : list ?T => match x with
                    end
      : list ?T -> option (list ?T)
 where
-?T : [x : list ?T  x1 : list ?T  x0 := x1 : list ?T |- Type] (x, x1,
-     x0 cannot be used)
+?T : [x : list ?T  x0 : list ?T  x1 := x0 : list ?T |- Type] (x, x0,
+     x1 cannot be used)
 s
      : s
 10

--- a/test-suite/success/ltac.v
+++ b/test-suite/success/ltac.v
@@ -377,3 +377,11 @@ f y true.
 Abort.
 
 End LtacNames.
+
+(* A naming problem initially submitted by Beta Ziliani *)
+
+Section test.
+Variable x : nat.
+Definition ex := fun x y:nat=>ltac:(exact (x + y)).
+Check eq_refl : ex = fun x y : nat => x + y.
+End test.

--- a/test-suite/success/ltac.v
+++ b/test-suite/success/ltac.v
@@ -385,3 +385,11 @@ Variable x : nat.
 Definition ex := fun x y:nat=>ltac:(exact (x + y)).
 Check eq_refl : ex = fun x y : nat => x + y.
 End test.
+
+Ltac f_rec n x y := match n with
+  | 3 => constr:((x,y))
+  | _ => constr:(let z := n in ltac:(let ret := f_rec (S n) y z in exact ret))
+ end.
+Theorem Thm : ltac:(let b := f_rec 1 0 0 in exact (b=(1,2))).
+reflexivity.
+Qed.


### PR DESCRIPTION
**Kind:** bug fix, enhancement

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes #7299 and grants #3248.

<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [ ] Corresponding documentation was added / updated.
- [ ] Entry added in CHANGES.

This PR fixes issues with bound term variables in Ltac (and virtually in Ltac2). The first issue, #7299, is an obvious clash between a  bound variable name and a section variable name. The second issue is more generally about giving a proper meaning to term binders in Ltac expressions such as `constr:(fun x => ltac:(... x ...))` when `x` is not already bound to an Ltac name (e.g. via a `fresh`). It thus grants a wish implicit in issue #3248.

The fix is by taking into account evar context renamings for interpreting tactics-in-terms.

Notes:
- It depends on ~~#307~~ (for a keep-name renaming policy), ~~#7288~~ (for the modular treatment of renaming in pretyping), ~~#7257~~ (for the fix in sensitivity of naming to alphabet), ~~#7274~~ (for improved dependency in return clause). The interesting commits here are "Taking into account evar context renaming for interpreting tactics-in-terms" and "Control tac-in-term process of renaming in GlobEnv rather than in Proofview".
- I did not investigate but this is part of code which is shared by Ltac2, so I would assume that this would also apply to Ltac2. However, it did not out of the box, so, some tweaking is maybe also needed on Ltac2 side, but waiting first for a feedback from @ppedrot.
- This allows to interpret more tactics-in-terms examples, but I don't claim that this is an absolute answer. E.g. mixing  `rename` or `clear` with binders in an LtacX code might lead to strange things. I feel however that we may be able in the longer term to set a kind of type system to track binders (adding, renaming, and removing effects) in LtacX code.