### PR TITLE
Made names of existential variables interpretable as Ltac variables.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -59,6 +59,10 @@ Tactics
 
 - The `romega` tactics have been deprecated; please use `lia` instead.
 
+- Names of existential variables occurring in Ltac functions
+  (e.g. "?[n]" or "?n" in terms - not in patterns) are now interpreted
+  the same way as other variable names occurring in Ltac functions.
+
 Focusing
 
 - Focusing bracket `{` now supports named goal selectors,

--- a/pretyping/globEnv.mli
+++ b/pretyping/globEnv.mli
@@ -76,6 +76,11 @@ val hide_variable : t -> Name.t -> Id.t -> t
 val interp_ltac_variable : ?loc:Loc.t -> (t -> Glob_term.glob_constr -> unsafe_judgment) ->
   t -> evar_map -> Id.t -> unsafe_judgment
 
+(** Interp an identifier as an ltac variable bound to an identifier,
+    or as the identifier itself if not bound to an ltac variable *)
+
+val interp_ltac_id : t -> Id.t -> Id.t
+
 (** Interpreting a generic argument, typically a "ltac:(...)", taking
     into account the possible renaming *)
 

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -480,6 +480,7 @@ let rec pretype k0 resolve_tc (tycon : type_constraint) (env : GlobEnv.t) evdref
   | GEvar (id, inst) ->
       (* Ne faudrait-il pas s'assurer que hyps est bien un
 	 sous-contexte du contexte courant, et qu'il n'y a pas de Rel "caché" *)
+      let id = interp_ltac_id env id in
       let evk =
         try Evd.evar_key id !evdref
         with Not_found ->
@@ -499,6 +500,11 @@ let rec pretype k0 resolve_tc (tycon : type_constraint) (env : GlobEnv.t) evdref
       { uj_val = e_new_evar env evdref ~src:(loc,k) ty; uj_type = ty }
 
   | GHole (k, naming, None) ->
+      let open Namegen in
+      let naming = match naming with
+        | IntroIdentifier id -> IntroIdentifier (interp_ltac_id env id)
+        | IntroAnonymous -> IntroAnonymous
+        | IntroFresh id -> IntroFresh (interp_ltac_id env id) in
       let ty =
         match tycon with
         | Some ty -> ty

--- a/test-suite/success/ltac.v
+++ b/test-suite/success/ltac.v
@@ -377,3 +377,30 @@ f y true.
 Abort.
 
 End LtacNames.
+
+(* Test binding of the name of existential variables in Ltac *)
+
+Module EvarNames.
+
+Ltac pick x := eexists ?[x].
+Goal exists y, y = 0.
+pick foo.
+[foo]:exact 0.
+auto.
+Qed.
+
+Ltac goal x := refine ?[x].
+
+Goal forall n, n + 0 = n.
+Proof.
+  induction n; [ goal Base | goal Rec ].
+  [Base]: {
+    easy.
+  }
+  [Rec]: {
+    simpl.
+    now f_equal.
+  }
+Qed.
+
+End EvarNames.


### PR DESCRIPTION
**Kind:** in between bug fix / feature / enhancement

While variable names are possibly interpreted as Ltac variables linking to names, this was not the case of existential variable names. This is what this PR does.

This concerns `?[id]`, `?[?id]` or `?id` (in terms, not in patterns) and this also allows for instance to write code such as:
```
Ltac pick x := eexists ?[x].
Goal exists x, x = 0.
pick foo.
```

Eventually, one could also expect that existential variable names occurring in Ltac code are mandatorily parametric (as in #7292), so that no Ltac code relies on an exact given name and accidentally fails in rare occasions because of this name being already used.

<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [ ] Corresponding documentation was added / updated.
- [x] Entry added in CHANGES.

EDIT by @Zimmi48: Closes #8344