### PR TITLE
An attempt to clarify error message for Arguments needing "rename" flag

### DIFF
--- a/test-suite/output/Arguments_renaming.out
+++ b/test-suite/output/Arguments_renaming.out
@@ -1,6 +1,5 @@
 The command has indeed failed with message:
-To rename arguments the "rename" flag must be specified.
-Argument A renamed to B.
+Flag "rename" expected to rename A into B.
 File "stdin", line 2, characters 0-25:
 Warning: This command is just asserting the names of arguments of identity.
 If this is what you want add ': assert' to silence the warning. If you want
@@ -113,5 +112,4 @@ Argument z cannot be declared implicit.
 The command has indeed failed with message:
 Extra arguments: y.
 The command has indeed failed with message:
-To rename arguments the "rename" flag must be specified.
-Argument A renamed to R.
+Flag "rename" expected to rename A into R.

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1131,15 +1131,16 @@ let vernac_arguments ~atts reference args more_implicits nargs_for_red flags =
   let names = rename prev_names names in
   let renaming_specified = Option.has_some !example_renaming in
 
-  if !rename_flag_required && not rename_flag then
-    user_err ~hdr:"vernac_declare_arguments"
-      (strbrk "To rename arguments the \"rename\" flag must be specified."
-    ++ spc () ++
-       match !example_renaming with
-       | None -> mt ()
-       | Some (o,n) ->
-          str "Argument " ++ Name.print o ++
-            str " renamed to " ++ Name.print n ++ str ".");
+  if !rename_flag_required && not rename_flag then begin
+    let msg =
+      match !example_renaming with
+      | None ->
+        strbrk "To rename arguments the \"rename\" flag must be specified."
+      | Some (o,n) ->
+        strbrk "Flag \"rename\" expected to rename " ++ Name.print o ++
+        strbrk " into " ++ Name.print n ++ str "."
+    in user_err ~hdr:"vernac_declare_arguments" msg
+  end;
 
   let duplicate_names =
     List.duplicates Name.equal (List.filter ((!=) Anonymous) names)


### PR DESCRIPTION
**Kind:** error message enhancement 

Taking the initiative to use a formulation which makes it is clear that no renaming has been
done. Hoping it is ok, see discussion at issue #2987.
