### PR TITLE
dir-locals: add bug-reference-mode variables

### DIFF
--- a/dev/tools/coqdev.el
+++ b/dev/tools/coqdev.el
@@ -103,5 +103,17 @@ Note that this function is executed before _Coqproject is read if it exists."
      2 (3 . 4) (5 . 6)))
   (add-to-list 'compilation-error-regexp-alist 'coq-backtrace))
 
+(defvar bug-reference-bug-regexp)
+(defvar bug-reference-url-format)
+(defun coqdev-setup-bug-reference-mode ()
+  "Setup `bug-reference-bug-regexp' and `bug-reference-url-format' for Coq.
+
+This does not enable `bug-reference-mode'."
+  (let ((dir (coqdev-default-directory)))
+    (when dir
+      (setq-local bug-reference-bug-regexp "#\\(?2:[0-9]+\\)")
+      (setq-local bug-reference-url-format "https://github.com/coq/coq/issues/%s"))))
+(add-hook 'hack-local-variables-hook #'coqdev-setup-bug-reference-mode)
+
 (provide 'coqdev)
 ;;; coqdev ends here


### PR DESCRIPTION
This makes it so that after `M-x bug-reference-mode` when you see `#4567` in the code it gets turned into a link (open with `C-c RET`) leading to #4567.