### PR TITLE
Towards selecting "best" unification failure among several

### DIFF
--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -227,7 +227,10 @@ let check_conv_record env sigma (t1,sk1) (t2,sk2) =
 (* Precondition: one of the terms of the pb is an uninstantiated evar,
  * possibly applied to arguments. *)
 
-let join_failures evd1 evd2 e1 e2 = (evd2,e2)
+let join_failures evd1 evd2 e1 e2 =
+  match e1, e2 with
+  | _, CannotSolveConstraint (_,ProblemBeyondCapabilities) -> (evd1,e1)
+  | _ -> (evd2,e2)
 
 let rec ise_try evd = function
     [] -> assert false

--- a/test-suite/output/unifconstraints.out
+++ b/test-suite/output/unifconstraints.out
@@ -63,3 +63,11 @@ unification constraint:
    True /\ True /\ True \/
    veeryyyyyyyyyyyyloooooooooooooonggidentifier =
    veeryyyyyyyyyyyyloooooooooooooonggidentifier
+The command has indeed failed with message:
+In environment
+P : nat -> Type
+x : nat
+h : P x
+Unable to unify "P x" with "?P x"
+(unable to find a well-typed instantiation for "?P": cannot ensure that
+"nat -> Type" is a subtype of "nat -> Prop").

--- a/test-suite/output/unifconstraints.v
+++ b/test-suite/output/unifconstraints.v
@@ -20,3 +20,9 @@ Goal forall n m : nat, True /\ True /\ True \/
   3:clear m.
   Show.
 Admitted.
+Unset Printing Existential Instances.
+
+(* Check non regression of error message (the example can eventually
+   improve though and succeed) *)
+
+Fail Check fun P (x:nat) (h:P x) => exist _ x (h : P x).


### PR DESCRIPTION
**Kind:** enhancement

This is both a shy step towards better understanding the kind of unification failures we may encounter and a concrete improvement of some particular kind of unification error, namely when a first-order unification fails because of a typing error.

The concrete example solved is:
```coq
Check fun P (x:nat) (h:P x) => exist _ x (h : P x).
```
Formerly: 
```
Unable to unify "P x" with "?P x" (cannot satisfy constraint "?P x" == "P x").
```
With the PR:
```coq
Unable to unify "P x" with "?P x"
(unable to find a well-typed instantiation for "?P": cannot ensure that
"nat -> Type" is a subtype of "nat -> Prop").
```

In the longer term, whatever direction is taken for unification (rewritten on a new backtracking engine, integrated to the backtracking monad, or any other approach), I feel that we could be able to classify the different kind of branching in unification and to fine-tune what kind of failures to report (maybe several sometimes).

Also, about the specific example above, even if the PR improves the explanation of the failure, I think that it should succeed, in the sense that nothing says that `P` should necessarily be in a sort which excludes `Prop`. Anyone with ongoing projects towards making the example succeed?
