### PR TITLE
circle CI: do not use cache from old config.yml versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,6 @@ opam-switch: &opam-switch
     - restore_cache:
         keys:
           - coq-opam-cache-v1-{{ arch }}-{{ checksum "COMPILER" }}-{{ checksum ".circleci/config.yml" }}-
-          - coq-opam-cache-v1-{{ arch }}-{{ checksum "COMPILER" }}- # this grabs old cache if checksum doesn't match
     - run:
         name: Update opam lists
         command: |


### PR DESCRIPTION
It begs things to break when the cache is out of sync with the system packages.
