### PR TITLE
An attempt to distinguish "sort" variables from "Type" variables in pretyping (fixes #4328, #3529)

### DIFF
--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -784,7 +784,7 @@ let new_univ_level_variable ?loc ?name rigid evd =
     ({evd with universes = uctx'}, u)
 
 let new_univ_variable ?loc ?name rigid evd =
-  let uctx', u = UState.new_univ_variable ?loc rigid name evd.universes in
+  let uctx', u = UState.new_univ_variable ?loc ~above_set:false rigid name evd.universes in
     ({evd with universes = uctx'}, Univ.Universe.make u)
 
 let new_sort_variable ?loc ?name rigid d =

--- a/engine/uState.ml
+++ b/engine/uState.ml
@@ -481,7 +481,7 @@ let emit_side_effects eff u =
   let uctxs = Safe_typing.universes_of_private eff in
   List.fold_left (merge true univ_rigid) u uctxs
 
-let new_univ_variable ?loc rigid name
+let new_univ_variable ?loc ?(above_set=true) rigid name
   ({ uctx_local = ctx; uctx_univ_variables = uvars; uctx_univ_algebraic = avars} as uctx) =
   let u = UnivGen.new_univ_level () in
   let ctx' = Univ.ContextSet.add_universe u ctx in
@@ -499,13 +499,13 @@ let new_univ_variable ?loc rigid name
     | Some n -> add_uctx_names ?loc n u uctx.uctx_names
     | None -> add_uctx_loc u loc uctx.uctx_names
   in
-  let initial =
-    UGraph.add_universe u false uctx.uctx_initial_universes
-  in                                                 
+  let add u =
+    if above_set then UGraph.add_universe u false
+    else UGraph.add_universe_unconstrained u in
   let uctx' =
     {uctx' with uctx_names = names; uctx_local = ctx';
-                uctx_universes = UGraph.add_universe u false uctx.uctx_universes;
-                uctx_initial_universes = initial}
+                uctx_universes = add u uctx.uctx_universes;
+                uctx_initial_universes = add u uctx.uctx_initial_universes}
   in uctx', u
 
 let make_with_initial_binders e us =

--- a/engine/uState.mli
+++ b/engine/uState.mli
@@ -107,7 +107,7 @@ val merge : ?loc:Loc.t -> bool -> rigid -> t -> Univ.ContextSet.t -> t
 val merge_subst : t -> UnivSubst.universe_opt_subst -> t
 val emit_side_effects : Safe_typing.private_constants -> t -> t
 
-val new_univ_variable : ?loc:Loc.t -> rigid -> Id.t option -> t -> t * Univ.Level.t
+val new_univ_variable : ?loc:Loc.t -> ?above_set:bool -> rigid -> Id.t option -> t -> t * Univ.Level.t
 val add_global_univ : t -> Univ.Level.t -> t
 
 (** [make_flexible_variable g algebraic l]

--- a/pretyping/evardefine.ml
+++ b/pretyping/evardefine.ml
@@ -163,7 +163,7 @@ let rec evar_absorb_arguments env evd (evk,args as ev) = function
 (* Refining an evar to a sort *)
 
 let define_evar_as_sort env evd (ev,args) =
-  let evd, u = new_univ_variable univ_rigid evd in
+  let evd, u = new_univ_variable univ_flexible evd in
   let evi = Evd.find_undefined evd ev in 
   let s = Type u in
   let concl = Reductionops.whd_all (evar_env evi) evd evi.evar_concl in

--- a/test-suite/bugs/closed/3529.v
+++ b/test-suite/bugs/closed/3529.v
@@ -1,0 +1,16 @@
+(* Check that Prop can be inferred to fill some sorts *)
+
+Module Example1.
+Class R T := { f: T -> Prop }.
+Instance r : R Prop := {| f P := P -> P |}.
+Definition foo : R Prop := Build_R _ (fun P => P -> P).
+End Example1.
+
+Require Coq.Setoids.Setoid.
+Import Coq.Setoids.Setoid.
+
+Module Example2.
+Class ILogicOps Frm := { lentails: relation Frm }.
+Instance ILogicOps_Prop : ILogicOps Prop | 2 := {| lentails P Q := P -> Q |}.
+Definition ILogicOps_Prop' : ILogicOps Prop := {| lentails P Q := P -> Q |}.
+End Example2.

--- a/test-suite/bugs/closed/4328.v
+++ b/test-suite/bugs/closed/4328.v
@@ -1,6 +1,6 @@
 Inductive M (A:Type) : Type := M'.
 Axiom pi : forall (P : Prop) (p : P), Prop.
-Definition test1 A (x : _) := pi A x.           (* success     *)
-Fail Definition test2 A (x : A) := pi A x.           (* failure ??? *)
-Fail Definition test3 A (x : A) (_ : M A) := pi A x. (* failure     *)
-Fail Definition test4 A (_ : M A) (x : A) := pi A x. (* success ??? *)
+Definition test1 A (x : _) := pi A x.           (* success *)
+Definition test2 A (x : A) := pi A x.           (* success *)
+Definition test3 A (x : A) (_ : M A) := pi A x. (* success *)
+Fail Definition test4 A (_ : M A) (x : A) := pi A x. (* but should success *)


### PR DESCRIPTION
<!-- Keep what applies -->
**Kind:** bug fix / enhancement

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #4328. Added: also fixes #3529.

When an evar has to be instantiated by an unkown sort, a level >= `Set` is generated, possibly prevening further unification of the sort with `Prop` to happen (see discussion at #7361 and #4328).

This relaxes the constraint that such unknown sort is necessarily >= `Set`.

At the current time, this is done in an ad hoc way, while waiting for the feedback from universe experts.

The only kernel modification is to allow to declare variables >= `Prop` instead of necessarily >= `Set`. I thus make here the assumption that the kernel graph algorithm, which includes `Prop` as a node, is indeed designed to deal correctly with `Prop` as a level.

The main modification is otherwise in `uState.ml`, where I added an extra case to collapse `t` into `Prop` whenever we need `t <= Prop`. If what I'm doing makes sense, this shall have to be more smoothly integrated to the rest of the `process_universe_constraints` algorithm.