### PR TITLE
[doc] Update Sphinx build instructions for Debian derivatives.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ plugins/micromega/csdpcert
 plugins/micromega/.micromega.ml.generated
 kernel/byterun/dllcoqrun.so
 coqdoc.sty
+coqdoc.css
 time-of-build.log
 time-of-build-pretty.log
 time-of-build-before.log

--- a/INSTALL.doc
+++ b/INSTALL.doc
@@ -31,16 +31,26 @@ To produce all the documents, the following tools are needed:
   - Antlr4 runtime for Python 3
 
 
-Under Debian based operating systems (Debian, Ubuntu, ...) a
-working set of packages for compiling the documentation for Coq is:
+Under recent Debian based operating systems (Debian 10 "Buster",
+Ubuntu 18.04, ...) a working set of packages for compiling the
+documentation for Coq is:
 
-  texlive texlive-latex-extra texlive-math-extra texlive-fonts-extra
-  texlive-humanities texlive-pictures latex-xcolor hevea python3
-  python-pip3
+  texlive-latex-extra texlive-fonts-recommended hevea python3-sphinx
+  python3-pexpect python3-sphinx-rtd-theme python3-bs4
+  python3-sphinxcontrib.bibtex python3-pip
 
-To install the Python packages required to build the user manual, run:
+Then, install the Python3 Antlr4 package:
+
+  pip3 install antlr4-python3-runtime
+
+Nix users should get the correct development environment to build the
+Sphinx documentation from Coq's `default.nix`. [Note Nix setup doesn't
+include the LaTeX packages needed to build the full documentation.]
+
+If you are in an older/different distribution you can install the
+Python packages required to build the user manual using python3-pip:
+
   pip3 install sphinx sphinx_rtd_theme beautifulsoup4 antlr4-python3-runtime pexpect sphinxcontrib-bibtex
-
 
 Compilation
 -----------


### PR DESCRIPTION
This can still be improved as I am sure we have too many packages listed.

cc: #7377 

Depends on #7381.