### PR TITLE
[ci] Fix #7396: VST is broken

### DIFF
--- a/dev/ci/ci-vst.sh
+++ b/dev/ci/ci-vst.sh
@@ -8,6 +8,10 @@ VST_CI_DIR="${CI_BUILD_DIR}/VST"
 # opam install -j ${NJOBS} -y menhir
 git_checkout "${VST_CI_BRANCH}" "${VST_CI_GITURL}" "${VST_CI_DIR}"
 
-# Targets are: msl veric floyd progs , we remove progs to save time
-# Patch to avoid the upper version limit
-( cd "${VST_CI_DIR}" && make IGNORECOQVERSION=true .loadpath version.vo msl veric floyd )
+# HACK: from the upstream makefile:
+#
+# default_target: _CoqProject version.vo msl veric floyd progs
+#
+# We have to omit progs as otherwise we timeout on Travis; once we
+# move to Gitlab we will able to just use `make`
+( cd "${VST_CI_DIR}" && make IGNORECOQVERSION=true _CoqProject version.vo msl veric floyd )


### PR DESCRIPTION
This is due to our CI script relying on their makefile internals,
unfortunately we still have to do this to avoid timeouts.
