### PR TITLE
Splitting primitive numeral parser/printer for positive, N, Z into three files

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -143,8 +143,8 @@ BTAUTOCMO:=plugins/btauto/btauto_plugin.cmo
 RTAUTOCMO:=plugins/rtauto/rtauto_plugin.cmo
 NATSYNTAXCMO:=plugins/syntax/nat_syntax_plugin.cmo
 OTHERSYNTAXCMO:=$(addprefix plugins/syntax/, \
-        z_syntax_plugin.cmo \
-        r_syntax_plugin.cmo \
+        positive_syntax_plugin.cmo n_syntax_plugin.cmo \
+        z_syntax_plugin.cmo r_syntax_plugin.cmo \
 	int31_syntax_plugin.cmo \
 	ascii_syntax_plugin.cmo \
         string_syntax_plugin.cmo )

--- a/dev/doc/changes.md
+++ b/dev/doc/changes.md
@@ -72,6 +72,12 @@ Vernacular commands
   `tactics/`. In all cases adapting is a matter of changing the module
   name.
 
+Primitive number parsers
+
+- For better modularity, the primitive parsers for positive, N and Z
+  have been split over three files (plugins/syntax/positive_syntax.ml,
+  plugins/syntax/n_syntax.ml, plugins/syntax/z_syntax.ml).
+
 ### Unit testing
 
   The test suite now allows writing unit tests against OCaml code in the Coq

--- a/plugins/syntax/n_syntax.ml
+++ b/plugins/syntax/n_syntax.ml
@@ -8,16 +8,18 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
+open Pp
+open CErrors
 open Names
 open Bigint
 open Positive_syntax_plugin.Positive_syntax
 
 (* Poor's man DECLARE PLUGIN *)
-let __coq_plugin_name = "z_syntax_plugin"
+let __coq_plugin_name = "n_syntax_plugin"
 let () = Mltop.add_known_module __coq_plugin_name
 
 (**********************************************************************)
-(* Parsing Z via scopes                                               *)
+(* Parsing N via scopes                                               *)
 (**********************************************************************)
 
 open Globnames
@@ -31,48 +33,49 @@ let make_path dir id = Libnames.make_path (make_dir dir) (Id.of_string id)
 (* TODO: temporary hack *)
 let make_kn dir id = Globnames.encode_mind dir id
 
-let z_path = make_path binnums "Z"
-let z_kn = make_kn (make_dir binnums) (Id.of_string "Z")
-let glob_z = IndRef (z_kn,0)
-let path_of_ZERO = ((z_kn,0),1)
-let path_of_POS = ((z_kn,0),2)
-let path_of_NEG = ((z_kn,0),3)
-let glob_ZERO = ConstructRef path_of_ZERO
-let glob_POS = ConstructRef path_of_POS
-let glob_NEG = ConstructRef path_of_NEG
+let n_kn = make_kn (make_dir binnums) (Id.of_string "N")
+let glob_n = IndRef (n_kn,0)
+let path_of_N0 = ((n_kn,0),1)
+let path_of_Npos = ((n_kn,0),2)
+let glob_N0 = ConstructRef path_of_N0
+let glob_Npos = ConstructRef path_of_Npos
 
-let z_of_int ?loc n =
+let n_path = make_path binnums "N"
+
+let n_of_binnat ?loc pos_or_neg n = DAst.make ?loc @@
   if not (Bigint.equal n zero) then
-    let sgn, n =
-      if is_pos_or_zero n then glob_POS, n else glob_NEG, Bigint.neg n in
-    DAst.make ?loc @@ GApp(DAst.make ?loc @@ GRef(sgn,None), [pos_of_bignat ?loc n])
+    GApp(DAst.make @@ GRef (glob_Npos,None), [pos_of_bignat ?loc n])
   else
-    DAst.make ?loc @@ GRef(glob_ZERO, None)
+    GRef(glob_N0, None)
+
+let error_negative ?loc =
+  user_err ?loc ~hdr:"interp_N" (str "No negative numbers in type \"N\".")
+
+let n_of_int ?loc n =
+  if is_pos_or_zero n then n_of_binnat ?loc true n
+  else error_negative ?loc
 
 (**********************************************************************)
-(* Printing Z via scopes                                              *)
+(* Printing N via scopes                                              *)
 (**********************************************************************)
 
-let bigint_of_z z = DAst.with_val (function
-  | GApp (r, [a]) when is_gr r glob_POS -> bignat_of_pos a
-  | GApp (r, [a]) when is_gr r glob_NEG -> Bigint.neg (bignat_of_pos a)
-  | GRef (a, _) when GlobRef.equal a glob_ZERO -> Bigint.zero
+let bignat_of_n n = DAst.with_val (function
+  | GApp (r, [a]) when is_gr r glob_Npos -> bignat_of_pos a
+  | GRef (a,_) when GlobRef.equal a glob_N0 -> Bigint.zero
   | _ -> raise Non_closed_number
-  ) z
+  ) n
 
-let uninterp_z (AnyGlobConstr p) =
-  try
-    Some (bigint_of_z p)
+let uninterp_n (AnyGlobConstr p) =
+  try Some (bignat_of_n p)
   with Non_closed_number -> None
 
 (************************************************************************)
-(* Declaring interpreters and uninterpreters for Z *)
+(* Declaring interpreters and uninterpreters for N *)
 
-let _ = Notation.declare_numeral_interpreter "Z_scope"
-  (z_path,binnums)
-  z_of_int
-  ([DAst.make @@ GRef (glob_ZERO, None);
-    DAst.make @@ GRef (glob_POS, None);
-    DAst.make @@ GRef (glob_NEG, None)],
-  uninterp_z,
+let _ = Notation.declare_numeral_interpreter "N_scope"
+  (n_path,binnums)
+  n_of_int
+  ([DAst.make @@ GRef (glob_N0, None);
+    DAst.make @@ GRef (glob_Npos, None)],
+  uninterp_n,
   true)

--- a/plugins/syntax/n_syntax_plugin.mlpack
+++ b/plugins/syntax/n_syntax_plugin.mlpack
@@ -1,0 +1,1 @@
+N_syntax

--- a/plugins/syntax/positive_syntax.ml
+++ b/plugins/syntax/positive_syntax.ml
@@ -1,0 +1,101 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *   INRIA, CNRS and contributors - Copyright 1999-2018       *)
+(* <O___,, *       (see CREDITS file for the list of authors)           *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+open Pp
+open CErrors
+open Util
+open Names
+open Bigint
+
+(* Poor's man DECLARE PLUGIN *)
+let __coq_plugin_name = "positive_syntax_plugin"
+let () = Mltop.add_known_module __coq_plugin_name
+
+exception Non_closed_number
+
+(**********************************************************************)
+(* Parsing positive via scopes                                        *)
+(**********************************************************************)
+
+open Globnames
+open Glob_term
+
+let binnums = ["Coq";"Numbers";"BinNums"]
+
+let make_dir l = DirPath.make (List.rev_map Id.of_string l)
+let make_path dir id = Libnames.make_path (make_dir dir) (Id.of_string id)
+
+let positive_path = make_path binnums "positive"
+
+(* TODO: temporary hack *)
+let make_kn dir id = Globnames.encode_mind dir id
+
+let positive_kn = make_kn (make_dir binnums) (Id.of_string "positive")
+let glob_positive = IndRef (positive_kn,0)
+let path_of_xI = ((positive_kn,0),1)
+let path_of_xO = ((positive_kn,0),2)
+let path_of_xH = ((positive_kn,0),3)
+let glob_xI = ConstructRef path_of_xI
+let glob_xO = ConstructRef path_of_xO
+let glob_xH = ConstructRef path_of_xH
+
+let pos_of_bignat ?loc x =
+  let ref_xI = DAst.make ?loc @@ GRef (glob_xI, None) in
+  let ref_xH = DAst.make ?loc @@ GRef (glob_xH, None) in
+  let ref_xO = DAst.make ?loc @@ GRef (glob_xO, None) in
+  let rec pos_of x =
+    match div2_with_rest x with
+      | (q,false) -> DAst.make ?loc @@ GApp (ref_xO,[pos_of q])
+      | (q,true) when not (Bigint.equal q zero) -> DAst.make ?loc @@ GApp (ref_xI,[pos_of q])
+      | (q,true) -> ref_xH
+  in
+  pos_of x
+
+let error_non_positive ?loc =
+  user_err ?loc ~hdr:"interp_positive"
+   (str "Only strictly positive numbers in type \"positive\".")
+
+let interp_positive ?loc n =
+  if is_strictly_pos n then pos_of_bignat ?loc n
+  else error_non_positive ?loc
+
+(**********************************************************************)
+(* Printing positive via scopes                                       *)
+(**********************************************************************)
+
+let is_gr c gr = match DAst.get c with
+| GRef (r, _) -> GlobRef.equal r gr
+| _ -> false
+
+let rec bignat_of_pos x = DAst.with_val (function
+  | GApp (r ,[a]) when is_gr r glob_xO -> mult_2(bignat_of_pos a)
+  | GApp (r ,[a]) when is_gr r glob_xI -> add_1(mult_2(bignat_of_pos a))
+  | GRef (a, _)                when GlobRef.equal a glob_xH -> Bigint.one
+  | _ -> raise Non_closed_number
+  ) x
+
+let uninterp_positive (AnyGlobConstr p) =
+  try
+    Some (bignat_of_pos p)
+  with Non_closed_number ->
+    None
+
+(************************************************************************)
+(* Declaring interpreters and uninterpreters for positive *)
+(************************************************************************)
+
+let _ = Notation.declare_numeral_interpreter "positive_scope"
+  (positive_path,binnums)
+  interp_positive
+  ([DAst.make @@ GRef (glob_xI, None);
+    DAst.make @@ GRef (glob_xO, None);
+    DAst.make @@ GRef (glob_xH, None)],
+   uninterp_positive,
+   true)

--- a/plugins/syntax/positive_syntax_plugin.mlpack
+++ b/plugins/syntax/positive_syntax_plugin.mlpack
@@ -1,0 +1,1 @@
+Positive_syntax

--- a/theories/Numbers/BinNums.v
+++ b/theories/Numbers/BinNums.v
@@ -12,6 +12,8 @@
 
 Set Implicit Arguments.
 
+Declare ML Module "positive_syntax_plugin".
+Declare ML Module "n_syntax_plugin".
 Declare ML Module "z_syntax_plugin".
 
 (** [positive] is a datatype representing the strictly positive integers


### PR DESCRIPTION
**Kind:** redesign/cleanup

This is part of #7135 and intended to increase modularity in dealing with the primitive parsers for N, Z and positive. In particular, in a view where scopes are declared before declaring primitive parsers, we get a better modularity by successively, for each type, declaring the scope, loading the primitive parser/printer, declaring the delimiter, binding the scope to a type.


Risk of conflict with #496 though.