### PR TITLE
Add .byte targets for every bestocaml target

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -240,6 +240,10 @@ $(OCAMLOPT) $(MLINCLUDES) $(OPTFLAGS) $(LINKMETADATA) -o $@ -linkpkg $(1) $^ && 
 $(OCAMLC) $(MLINCLUDES) $(BYTEFLAGS) $(CUSTOM) -o $@ -linkpkg $(1) $^)
 endef
 
+define ocamlbyte
+$(OCAMLC) $(MLINCLUDES) $(BYTEFLAGS) $(CUSTOM) -o $@ -linkpkg $(1) $^
+endef
+
 # Camlp5 settings
 
 CAMLP5DEPS:=grammar/grammar.cma
@@ -418,6 +422,10 @@ $(COQC): $(call bestobj, $(COQCCMO))
 	$(SHOW)'OCAMLBEST -o $@'
 	$(HIDE)$(call bestocaml, $(SYSMOD))
 
+$(COQCBYTE): $(COQCCMO)
+	$(SHOW)'OCAMLC -o $@'
+	$(HIDE)$(call ocamlbyte, $(SYSMOD))
+
 ###########################################################################
 # other tools
 ###########################################################################
@@ -455,9 +463,17 @@ $(COQDEPBOOT): $(call bestobj, $(COQDEPBOOTSRC))
 	$(SHOW)'OCAMLBEST -o $@'
 	$(HIDE)$(call bestocaml, -I tools -package unix)
 
+$(COQDEPBOOTBYTE): $(COQDEPBOOTSRC)
+	$(SHOW)'OCAMLC -o $@'
+	$(HIDE)$(call ocamlbyte, -I tools -package unix)
+
 $(OCAMLLIBDEP): $(call bestobj, tools/ocamllibdep.cmo)
 	$(SHOW)'OCAMLBEST -o $@'
 	$(HIDE)$(call bestocaml, -I tools -package unix)
+
+$(OCAMLLIBDEPBYTE): tools/ocamllibdep.cmo
+	$(SHOW)'OCAMLBEST -o $@'
+	$(HIDE)$(call ocamlbyte, -I tools -package unix)
 
 # The full coqdep (unused by this build, but distributed by make install)
 
@@ -468,9 +484,17 @@ $(COQDEP): $(call bestobj, $(COQDEPCMO))
 	$(SHOW)'OCAMLBEST -o $@'
 	$(HIDE)$(call bestocaml, $(SYSMOD))
 
+$(COQDEPBYTE): $(COQDEPCMO)
+	$(SHOW)'OCAMLC -o $@'
+	$(HIDE)$(call ocamlbyte, $(SYSMOD))
+
 $(GALLINA): $(call bestobj, tools/gallina_lexer.cmo tools/gallina.cmo)
 	$(SHOW)'OCAMLBEST -o $@'
 	$(HIDE)$(call bestocaml,)
+
+$(GALLINABYTE): tools/gallina_lexer.cmo tools/gallina.cmo
+	$(SHOW)'OCAMLC -o $@'
+	$(HIDE)$(call ocamlbyte,)
 
 COQMAKEFILECMO:=clib/clib.cma lib/lib.cma tools/coq_makefile.cmo
 
@@ -478,13 +502,25 @@ $(COQMAKEFILE): $(call bestobj,$(COQMAKEFILECMO))
 	$(SHOW)'OCAMLBEST -o $@'
 	$(HIDE)$(call bestocaml, -package str,unix,threads)
 
+$(COQMAKEFILEBYTE): $(COQMAKEFILECMO)
+	$(SHOW)'OCAMLC -o $@'
+	$(HIDE)$(call ocamlbyte, -package str,unix,threads)
+
 $(COQTEX): $(call bestobj, tools/coq_tex.cmo)
 	$(SHOW)'OCAMLBEST -o $@'
 	$(HIDE)$(call bestocaml, -package str)
 
+$(COQTEXBYTE): tools/coq_tex.cmo
+	$(SHOW)'OCAMLC -o $@'
+	$(HIDE)$(call ocamlbyte, -package str)
+
 $(COQWC): $(call bestobj, tools/coqwc.cmo)
 	$(SHOW)'OCAMLBEST -o $@'
 	$(HIDE)$(call bestocaml, -package str)
+
+$(COQWCBYTE): tools/coqwc.cmo
+	$(SHOW)'OCAMLC -o $@'
+	$(HIDE)$(call ocamlbyte, -package str)
 
 COQDOCCMO:=clib/clib.cma lib/lib.cma $(addprefix tools/coqdoc/, \
   cdglobals.cmo alpha.cmo index.cmo tokens.cmo output.cmo cpretty.cmo main.cmo )
@@ -493,9 +529,19 @@ $(COQDOC): $(call bestobj, $(COQDOCCMO))
 	$(SHOW)'OCAMLBEST -o $@'
 	$(HIDE)$(call bestocaml, -package str,unix)
 
-$(COQWORKMGR): $(call bestobj, clib/clib.cma lib/lib.cma stm/spawned.cmo stm/coqworkmgrApi.cmo tools/coqworkmgr.cmo)
+$(COQDOCBYTE): $(COQDOCCMO)
+	$(SHOW)'OCAMLC -o $@'
+	$(HIDE)$(call ocamlbyte, -package str,unix)
+
+COQWORKMGRCMO:=clib/clib.cma lib/lib.cma stm/spawned.cmo stm/coqworkmgrApi.cmo tools/coqworkmgr.cmo
+
+$(COQWORKMGR): $(call bestobj, $(COQWORKMGRCMO))
 	$(SHOW)'OCAMLBEST -o $@'
 	$(HIDE)$(call bestocaml, $(SYSMOD))
+
+$(COQWORKMGRBYTE): $(COQWORKMGRCMO)
+	$(SHOW)'OCAMLC -o $@'
+	$(HIDE)$(call ocamlbyte, $(SYSMOD))
 
 # fake_ide : for debugging or test-suite purpose, a fake ide simulating
 # a connection to coqtop -ideslave
@@ -509,11 +555,21 @@ $(FAKEIDE): $(call bestobj, $(FAKEIDECMO)) | $(IDETOPLOOPCMA:.cma=$(BESTDYN))
 	$(SHOW)'OCAMLBEST -o $@'
 	$(HIDE)$(call bestocaml, -I ide -package str,unix,threads)
 
+$(FAKEIDEBYTE): $(FAKEIDECMO) | $(IDETOPLOOPCMA)
+	$(SHOW)'OCAMLC -o $@'
+	$(HIDE)$(call ocamlbyte, -I ide -package str,unix,threads)
+
 # votour: a small vo explorer (based on the checker)
 
-bin/votour: $(call bestobj, clib/cObj.cmo checker/analyze.cmo checker/values.cmo checker/votour.cmo)
+VOTOURCMO:=clib/cObj.cmo checker/analyze.cmo checker/values.cmo checker/votour.cmo
+
+bin/votour: $(call bestobj, $(VOTOURCMO))
 	$(SHOW)'OCAMLBEST -o $@'
 	$(HIDE)$(call bestocaml, -I checker)
+
+bin/votour.byte: $(VOTOURCMO)
+	$(SHOW)'OCAMLC -o $@'
+	$(HIDE)$(call ocamlbyte, -I checker)
 
 ###########################################################################
 # Csdp to micromega special targets
@@ -526,6 +582,10 @@ CSDPCERTCMO:=clib/clib.cma $(addprefix plugins/micromega/, \
 $(CSDPCERT): $(call bestobj, $(CSDPCERTCMO))
 	$(SHOW)'OCAMLBEST -o $@'
 	$(HIDE)$(call bestocaml, -package num,unix)
+
+$(CSDPCERTBYTE): $(CSDPCERTCMO)
+	$(SHOW)'OCAMLC -o $@'
+	$(HIDE)$(call ocamlbyte, -package num,unix)
 
 ###########################################################################
 # tests

--- a/Makefile.common
+++ b/Makefile.common
@@ -18,13 +18,21 @@ COQTOPBYTE:=bin/coqtop.byte$(EXE)
 COQTOPEXE:=bin/coqtop$(EXE)
 
 COQDEP:=bin/coqdep$(EXE)
+COQDEPBYTE:=bin/coqdep.byte$(EXE)
 COQMAKEFILE:=bin/coq_makefile$(EXE)
+COQMAKEFILEBYTE:=bin/coq_makefile.byte$(EXE)
 GALLINA:=bin/gallina$(EXE)
+GALLINABYTE:=bin/gallina.byte$(EXE)
 COQTEX:=bin/coq-tex$(EXE)
+COQTEXBYTE:=bin/coq-tex.byte$(EXE)
 COQWC:=bin/coqwc$(EXE)
+COQWCBYTE:=bin/coqwc.byte$(EXE)
 COQDOC:=bin/coqdoc$(EXE)
+COQDOCBYTE:=bin/coqdoc.byte$(EXE)
 COQC:=bin/coqc$(EXE)
+COQCBYTE:=bin/coqc.byte$(EXE)
 COQWORKMGR:=bin/coqworkmgr$(EXE)
+COQWORKMGRBYTE:=bin/coqworkmgr.byte$(EXE)
 COQMAKE_ONE_TIME_FILE:=tools/make-one-time-file.py
 COQTIME_FILE_MAKER:=tools/TimeFileMaker.py
 COQMAKE_BOTH_TIME_FILES:=tools/make-both-time-files.py
@@ -36,12 +44,16 @@ TOOLS_HELPERS:=tools/CoqMakefile.in $(COQMAKE_ONE_TIME_FILE) $(COQTIME_FILE_MAKE
 	$(COQMAKE_BOTH_TIME_FILES) $(COQMAKE_BOTH_SINGLE_TIMING_FILES)
 
 COQDEPBOOT:=bin/coqdep_boot$(EXE)
+COQDEPBOOTBYTE:=bin/coqdep_boot.byte$(EXE)
 OCAMLLIBDEP:=bin/ocamllibdep$(EXE)
+OCAMLLIBDEPBYTE:=bin/ocamllibdep.byte$(EXE)
 FAKEIDE:=bin/fake_ide$(EXE)
+FAKEIDEBYTE:=bin/fake_ide.byte$(EXE)
 
 PRIVATEBINARIES:=$(FAKEIDE) $(OCAMLLIBDEP) $(COQDEPBOOT)
 
 CSDPCERT:=plugins/micromega/csdpcert$(EXE)
+CSDPCERTBYTE:=plugins/micromega/csdpcert.byte$(EXE)
 
 ###########################################################################
 # Object and Source files


### PR DESCRIPTION
This makes it easier to compile our executables for debug purposes.
