### PR TITLE
Actually take advantage of the normalization status of kernel closures.

### DIFF
--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -1052,7 +1052,12 @@ let norm_val info tab v =
 
 let inject c = mk_clos (subs_id 0) c
 
-let whd_stack infos tab m stk =
+let whd_stack infos tab m stk = match m.norm with
+| Whnf | Norm ->
+  (** No need to perform [kni] nor to unlock updates because
+      every head subterm of [m] is [Whnf] or [Norm] *)
+  knh infos m stk
+| Red | Cstr ->
   let k = kni infos tab m stk in
   let () = if !share then ignore (fapp_stack k) in (* to unlock Zupdates! *)
   k


### PR DESCRIPTION
We know that when a fterm is marked as Whnf or Norm, the only thing that can happen in the reduction machine is administrative reduction pushing the destructured term on the stack. Thus there is no need to perform any actual performative reduction.

Furthermore, every head subterm of those terms are recursively Whnf or Norm, which implies that no update mark is pushed on the stack during the destructuration. So there is no need to unzip the stack to unset FLOCKED nodes as well.

Hopefully merging this PR will hide the slowdown of #7085, following the ancestral trick!

Bench:
```
┌──────────────────────────┬─────────────────────────┬───────────────────────────────────────┬───────────────────────────────────────┬─────────────────────────┬─────────────────┐
│                          │      user time [s]      │              CPU cycles               │           CPU instructions            │  max resident mem [KB]  │   mem faults    │
│                          │                         │                                       │                                       │                         │                 │
│             package_name │     NEW     OLD PDIFF   │            NEW            OLD PDIFF   │            NEW            OLD PDIFF   │     NEW     OLD PDIFF   │ NEW OLD PDIFF   │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│       coq-mathcomp-field │  450.21  459.77 -2.08 % │  1252926273660  1279168634320 -2.05 % │  2032636044132  2060983099846 -1.38 % │  814632  814520 +0.01 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│ coq-mathcomp-real-closed │  169.07  171.63 -1.49 % │   470025988614   477404910043 -1.55 % │   686418438450   697746767182 -1.62 % │  840740  839248 +0.18 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│             coq-compcert │  867.83  876.31 -0.97 % │  2408230355894  2427322390412 -0.79 % │  3474688696912  3479122030742 -0.13 % │ 1330864 1329352 +0.11 % │   1   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│     coq-mathcomp-algebra │  183.54  184.88 -0.72 % │   509154106599   512734418360 -0.70 % │   686237704338   691190149349 -0.72 % │  651828  644624 +1.12 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│                coq-flocq │  261.69  263.26 -0.60 % │   727511323481   731782015185 -0.58 % │   898827678437   900504391845 -0.19 % │ 1245684 1245556 +0.01 % │   5  14 -64.29 % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│              coq-bignums │   79.62   80.08 -0.57 % │   220334082554   221079144965 -0.34 % │   286055368157   285667481455 +0.14 % │  528052  528252 -0.04 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│              coq-unimath │ 1282.14 1288.67 -0.51 % │  3552056492706  3568279813179 -0.45 % │  6034858418349  6044660813550 -0.16 % │ 1038640 1014792 +2.35 % │   1   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│               coq-geocoq │ 3076.98 3089.45 -0.40 % │  8534648775874  8570174047126 -0.41 % │ 13773700706623 13785767856966 -0.09 % │ 1239708 1239912 -0.02 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│                  coq-vst │ 3846.48 3861.05 -0.38 % │ 10691588821269 10734672838861 -0.40 % │ 13995663078227 14034898305681 -0.28 % │ 2232400 2229544 +0.13 % │   1   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│   coq-mathcomp-character │  273.57  274.18 -0.22 % │   760625369084   762184295092 -0.20 % │  1082051533450  1085662987216 -0.33 % │ 1137832 1129908 +0.70 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│         coq-fiat-parsers │  699.99  701.26 -0.18 % │  1938749495314  1942555597440 -0.20 % │  2969071617034  2969575601360 -0.02 % │ 3376568 3374244 +0.07 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│    coq-mathcomp-solvable │  200.59  200.95 -0.18 % │   556428019765   557073947854 -0.12 % │   766122403103   767660756150 -0.20 % │  863596  866968 -0.39 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│   coq-mathcomp-ssreflect │   44.91   44.99 -0.18 % │   123171675277   123134576036 +0.03 % │   144660343842   144975601927 -0.22 % │  536860  536752 +0.02 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│   coq-mathcomp-odd-order │ 1418.16 1420.68 -0.18 % │  3950002600234  3958225337229 -0.21 % │  6639532824424  6648637369709 -0.14 % │ 1374168 1382752 -0.62 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│          coq-fiat-crypto │ 4072.73 4074.55 -0.04 % │ 11298615160110 11306858277173 -0.07 % │ 18198179142376 18226750264437 -0.16 % │ 3169948 3187100 -0.54 % │   0   1 -100.00 % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│    coq-mathcomp-fingroup │   64.74   64.72 +0.03 % │   178065854948   178363810318 -0.17 % │   237410214020   238327339688 -0.38 % │  589824  591452 -0.28 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│      coq-formal-topology │   37.57   37.55 +0.05 % │   101130400425   101333826990 -0.20 % │   126122043380   126387772508 -0.21 % │  482608  482392 +0.04 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│            coq-fiat-core │  111.68  111.56 +0.11 % │   310805994418   310308693886 +0.16 % │   379133769438   379387010063 -0.07 % │  500240  499028 +0.24 % │   3   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│                coq-color │  724.23  723.00 +0.17 % │  2000950422301  1998020496867 +0.15 % │  2376507013030  2378642918778 -0.09 % │ 1446536 1446688 -0.01 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│                 coq-hott │  330.82  330.13 +0.21 % │   919324667597   921673604329 -0.25 % │  1425790567899  1426420393371 -0.04 % │  588868  588972 -0.02 % │   4   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│         coq-math-classes │  228.07  227.45 +0.27 % │   626700703841   626682481950 +0.00 % │   783731512910   784176221411 -0.06 % │  531980  533036 -0.20 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│                 coq-corn │ 1557.00 1551.03 +0.38 % │  4319634828408  4304778595552 +0.35 % │  6404868301981  6410000019889 -0.08 % │  923276  864784 +6.76 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│           coq-coquelicot │   83.54   83.21 +0.40 % │   230421271409   229953300077 +0.20 % │   274390189046   274525783267 -0.05 % │  719212  717540 +0.23 % │   0   0  +nan % │
└──────────────────────────┴─────────────────────────┴───────────────────────────────────────┴───────────────────────────────────────┴─────────────────────────┴─────────────────┘


PDIFF = proportional difference between measurements done for the NEW and the OLD Coq version
      = (NEW_measurement - OLD_measurement) / OLD_measurement * 100%

NEW = 5e310fc0456bc5123ab5aef255d61dde6ee8f4d7
OLD = 97ee8fbd0bf917c29e47f746c0a28623ebc7da9a
```