### PR TITLE
[coqdep] Minor cleanups.

### DIFF
--- a/tools/coqdep_common.mli
+++ b/tools/coqdep_common.mli
@@ -10,6 +10,8 @@
 
 module StrSet : Set.S with type elt = string
 
+val coqdep_warning : ('a, Format.formatter, unit, unit) format4 -> 'a
+
 (** [find_dir_logpath dir] Return the logical path of directory [dir]
     if it has been given one. Raise [Not_found] otherwise. In
     particular we can check if "." has been attributed a logical path


### PR DESCRIPTION
- Remove inclusion of the `tactics` directory, this is coming from a
  time loadable modules were found there, now all are under `plugins`.
- Remove 4 dependencies on modules so we can bootstrap coqdep earlier.
- Use `Format` instead of `Printf` for printing.
