### PR TITLE
[WIP] Add support for explicitly uniform inductive parameters

### DIFF
--- a/library/decl_kinds.ml
+++ b/library/decl_kinds.ml
@@ -22,6 +22,8 @@ type private_flag = bool
 
 type cumulative_inductive_flag = bool
 
+type uniform_inductive_flag = bool
+
 type theorem_kind =
   | Theorem
   | Lemma

--- a/parsing/g_vernac.ml4
+++ b/parsing/g_vernac.ml4
@@ -162,11 +162,12 @@ GEXTEND Gram
       | IDENT "Let"; id = identref; b = def_body ->
           VernacDefinition ((DoDischarge, Let), (lname_of_lident id, None), b)
       (* Gallina inductive declarations *)
-      | cum = OPT cumulativity_token; priv = private_token; f = finite_token;
+      | cum = OPT cumulativity_token; priv = private_token;
+        uni = OPT uniformity_token; f = finite_token;
         indl = LIST1 inductive_definition SEP "with" ->
 	  let (k,f) = f in
           let indl=List.map (fun ((a,b,c,d),e) -> ((a,b,c,k,d),e)) indl in
-          VernacInductive (cum, priv,f,indl)
+          VernacInductive (cum, priv, uni, f, indl)
       | "Fixpoint"; recs = LIST1 rec_definition SEP "with" ->
           VernacFixpoint (NoDischarge, recs)
       | IDENT "Let"; "Fixpoint"; recs = LIST1 rec_definition SEP "with" ->
@@ -250,6 +251,10 @@ GEXTEND Gram
   cumulativity_token:
     [ [ IDENT "Cumulative" -> VernacCumulative
       | IDENT "NonCumulative" -> VernacNonCumulative ] ]
+  ;
+  uniformity_token:
+    [ [ IDENT "Uniform" -> VernacUniformParams
+      | IDENT "NonUniform" -> VernacNonUniformParams ] ]
   ;
   private_token:
     [ [ IDENT "Private" -> true | -> false ] ]

--- a/plugins/funind/glob_term_to_relation.ml
+++ b/plugins/funind/glob_term_to_relation.ml
@@ -1500,7 +1500,7 @@ let do_build_inductive
   let _time2 = System.get_time () in
   try
     with_full_print
-      (Flags.silently (ComInductive.do_mutual_inductive rel_inds (Flags.is_universe_polymorphism ()) false false))
+      (Flags.silently (ComInductive.do_mutual_inductive rel_inds (Flags.is_universe_polymorphism ()) false false false))
       Declarations.Finite
   with
     | UserError(s,msg) as e ->
@@ -1512,7 +1512,7 @@ let do_build_inductive
 	in
 	let msg =
 	  str "while trying to define"++ spc () ++
-            Ppvernac.pr_vernac Vernacexpr.(VernacExpr([], VernacInductive(None,false,Declarations.Finite,repacked_rel_inds)))
+            Ppvernac.pr_vernac Vernacexpr.(VernacExpr([], VernacInductive(None,false,Some Vernacexpr.VernacNonUniformParams,Declarations.Finite,repacked_rel_inds)))
 	    ++ fnl () ++
 	    msg
 	in
@@ -1527,7 +1527,7 @@ let do_build_inductive
 	in
 	let msg =
 	  str "while trying to define"++ spc () ++
-            Ppvernac.pr_vernac Vernacexpr.(VernacExpr([], VernacInductive(None,false,Declarations.Finite,repacked_rel_inds)))
+            Ppvernac.pr_vernac Vernacexpr.(VernacExpr([], VernacInductive(None,false,Some Vernacexpr.VernacNonUniformParams,Declarations.Finite,repacked_rel_inds)))
 	    ++ fnl () ++
 	    CErrors.print reraise
 	in

--- a/pretyping/vernacexpr.ml
+++ b/pretyping/vernacexpr.ml
@@ -303,6 +303,9 @@ type module_binder = bool option * lident list * module_ast_inl
     we should use the global flag. *)
 type vernac_cumulative = VernacCumulative | VernacNonCumulative
 
+(** [Some b] if locally specified, [None] to use global flag. *)
+type vernac_uniformity = VernacUniformParams | VernacNonUniformParams
+
 (** {6 The type of vernacular expressions} *)
 
 type vernac_implicit_status = Implicit | MaximallyImplicit | NotImplicit
@@ -336,7 +339,7 @@ type nonrec vernac_expr =
   | VernacExactProof of constr_expr
   | VernacAssumption of (Decl_kinds.discharge * Decl_kinds.assumption_object_kind) *
       Declaremods.inline * (ident_decl list * constr_expr) with_coercion list
-  | VernacInductive of vernac_cumulative option * Decl_kinds.private_flag * inductive_flag * (inductive_expr * decl_notation list) list
+  | VernacInductive of vernac_cumulative option * Decl_kinds.private_flag * vernac_uniformity option * inductive_flag * (inductive_expr * decl_notation list) list
   | VernacFixpoint of Decl_kinds.discharge * (fixpoint_expr * decl_notation list) list
   | VernacCoFixpoint of Decl_kinds.discharge * (cofixpoint_expr * decl_notation list) list
   | VernacScheme of (lident option * scheme) list

--- a/printing/ppvernac.ml
+++ b/printing/ppvernac.ml
@@ -733,7 +733,7 @@ open Pputils
         let assumptions = prlist_with_sep spc (fun p -> hov 1 (str "(" ++ pr_params p ++ str ")")) l in
         return (hov 2 (pr_assumption_token (n > 1) discharge kind ++
                        pr_non_empty_arg pr_assumption_inline t ++ spc() ++ assumptions))
-      | VernacInductive (cum, p,f,l) ->
+      | VernacInductive (cum, p, uni, f, l) ->
         let pr_constructor (coe,(id,c)) =
           hov 2 (pr_lident id ++ str" " ++
                    (if coe then str":>" else str":") ++
@@ -765,14 +765,20 @@ open Pputils
                        | Inductive_kw -> "Inductive" | CoInductive -> "CoInductive"
                        | Class _ -> "Class" | Variant -> "Variant"
           in
-          if p then
+          if p then (* Why only when p? *)
             let cm =
               match cum with
               | Some VernacCumulative -> "Cumulative"
               | Some VernacNonCumulative -> "NonCumulative"
               | None -> ""
             in
-            cm ^ " " ^ kind
+            let uniform_tag =
+              match uni with
+              | Some VernacUniformParams -> "Uniform "
+              | Some VernacNonUniformParams -> "NonUniform "
+              | None -> ""
+            in
+            cm ^ " " ^ uniform_tag ^ kind
           else kind
         in
         return (

--- a/stm/vernac_classifier.ml
+++ b/stm/vernac_classifier.ml
@@ -125,7 +125,7 @@ let classify_vernac e =
         let ids = List.flatten (List.map (fun (_,(l,_)) -> List.map (fun (id, _) -> id.v) l) l) in
         VtSideff ids, VtLater
     | VernacDefinition (_,({v=id},_),DefineBody _) -> VtSideff (idents_of_name id), VtLater
-    | VernacInductive (_, _,_,l) ->
+    | VernacInductive (_, _, _, _, l) ->
         let ids = List.map (fun (((_,({v=id},_)),_,_,_,cl),_) -> id :: match cl with
         | Constructors l -> List.map (fun (_,({v=id},_)) -> id) l
         | RecordDecl (oid,l) -> (match oid with Some {v=x} -> [x] | _ -> []) @

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -148,7 +148,6 @@ let interp_cstrs env sigma impls mldata arity ind =
   let sigma, (ctyps'', cimpls) =
     on_snd List.split @@
     List.fold_left_map (fun sigma l ->
-        on_snd (on_fst EConstr.Unsafe.to_constr) @@
         interp_type_evars_impls env sigma ~impls l) sigma ctyps' in
   sigma, (cnames, ctyps'', cimpls)
 
@@ -263,14 +262,15 @@ let check_param = function
 | CLocalPattern {CAst.loc} ->
     Loc.raise ?loc (Stream.Error "pattern with quote not allowed here")
 
-let interp_mutual_inductive (paramsl,indl) notations cum poly prv finite =
+let interp_mutual_inductive_gen env0 (uparamsl,paramsl,indl) notations cum poly prv finite =
   check_all_names_different indl;
   List.iter check_param paramsl;
-  let env0 = Global.env() in
   let pl = (List.hd indl).ind_univs in
   let sigma, decl = Univdecls.interp_univ_decl_opt env0 pl in
+  let sigma, (uimpls, ((env_uparams, ctx_uparams), useruimpls)) =
+    interp_context_evars env0 sigma uparamsl in
   let sigma, (impls, ((env_params, ctx_params), userimpls)) =
-    interp_context_evars env0 sigma paramsl
+    interp_context_evars ~impl_env:uimpls env_uparams sigma paramsl
   in
   let indnames = List.map (fun ind -> ind.ind_name) indl in
 
@@ -282,15 +282,15 @@ let interp_mutual_inductive (paramsl,indl) notations cum poly prv finite =
   let sigma, arities = List.fold_left_map (fun sigma -> interp_ind_arity env_params sigma) sigma indl in
 
   let fullarities = List.map (fun (c, _, _) -> EConstr.it_mkProd_or_LetIn c ctx_params) arities in
-  let env_ar = push_types env0 indnames fullarities in
+  let env_ar = push_types env_uparams indnames fullarities in
   let env_ar_params = EConstr.push_rel_context ctx_params env_ar in
 
   (* Compute interpretation metadatas *)
   let indimpls = List.map (fun (_, _, impls) -> userimpls @
     lift_implicits (Context.Rel.nhyps ctx_params) impls) arities in
   let arities = List.map pi1 arities and aritypoly = List.map pi2 arities in
-  let impls = compute_internalization_env env0 sigma ~impls (Inductive (params,true)) indnames fullarities indimpls in
-  let ntn_impls = compute_internalization_env env0 sigma (Inductive (params,true)) indnames fullarities indimpls in
+  let impls = compute_internalization_env env_uparams sigma ~impls (Inductive (params,true)) indnames fullarities indimpls in
+  let ntn_impls = compute_internalization_env env_uparams sigma (Inductive (params,true)) indnames fullarities indimpls in
   let mldatas = List.map2 (mk_mltype_data sigma env_params params) arities indnames in
 
   let sigma, constructors =
@@ -300,6 +300,25 @@ let interp_mutual_inductive (paramsl,indl) notations cum poly prv finite =
      (* Interpret the constructor types *)
      List.fold_left3_map (fun sigma -> interp_cstrs env_ar_params sigma impls) sigma mldatas arities indl)
      () in
+
+  (* generalize over the uniform parameters *)
+  let nparams = Context.Rel.length ctx_params in
+  let nuparams = Context.Rel.length ctx_uparams in
+  let uargs = Context.Rel.to_extended_vect EConstr.mkRel 0 ctx_uparams in
+  let uparam_subst =
+    List.init (List.length indl) EConstr.(fun i -> mkApp (mkRel (i + 1 + nuparams), uargs))
+    @ List.init nuparams EConstr.(fun i -> mkRel (i + 1)) in
+  let generalize_constructor c = EConstr.Unsafe.to_constr (EConstr.Vars.substnl uparam_subst nparams c) in
+  let constructors = List.map (fun (cnames,ctypes,cimpls) ->
+                         (cnames,List.map generalize_constructor ctypes,cimpls))
+                       constructors
+  in
+  let ctx_params = ctx_params @ ctx_uparams in
+  let userimpls = useruimpls @ (lift_implicits (Context.Rel.nhyps ctx_uparams) userimpls) in
+  let indimpls = List.map (fun iimpl -> useruimpls @ (lift_implicits (Context.Rel.nhyps ctx_uparams) iimpl)) indimpls in
+  let fullarities = List.map (fun c -> EConstr.it_mkProd_or_LetIn c ctx_uparams) fullarities in
+  let env_ar = push_types env0 indnames fullarities in
+  let env_ar_params = EConstr.push_rel_context ctx_params env_ar in
 
   (* Try further to solve evars, and instantiate them *)
   let sigma = solve_remaining_evars all_and_fail_flags env_params sigma Evd.empty in
@@ -356,6 +375,9 @@ let interp_mutual_inductive (paramsl,indl) notations cum poly prv finite =
   (if poly && cum then
       InferCumulativity.infer_inductive env_ar mind_ent
    else mind_ent), Evd.universe_binders sigma, impls
+
+let interp_mutual_inductive (paramsl,indl) notations cum poly prv finite =
+  interp_mutual_inductive_gen (Global.env()) ([],paramsl,indl) notations cum poly prv finite
 
 (* Very syntactical equality *)
 let eq_local_binders bl1 bl2 =
@@ -439,10 +461,11 @@ type one_inductive_impls =
   Impargs.manual_explicitation list (* for inds *)*
   Impargs.manual_explicitation list list (* for constrs *)
 
-let do_mutual_inductive indl cum poly prv finite =
-  let indl,coes,ntns = extract_mutual_inductive_declaration_components indl in
+let do_mutual_inductive indl cum poly prv uni finite =
+  let (params,indl),coes,ntns = extract_mutual_inductive_declaration_components indl in
   (* Interpret the types *)
-  let mie,pl,impls = interp_mutual_inductive indl ntns cum poly prv finite in
+  let indl = if uni then (params, [], indl) else ([], params, indl) in
+  let mie,pl,impls = interp_mutual_inductive_gen (Global.env()) indl ntns cum poly prv finite in
   (* Declare the mutual inductive block with its associated schemes *)
   ignore (declare_mutual_inductive_with_eliminations mie pl impls);
   (* Declare the possible notations of inductive types *)

--- a/vernac/comInductive.mli
+++ b/vernac/comInductive.mli
@@ -21,7 +21,8 @@ open Decl_kinds
 
 val do_mutual_inductive :
   (one_inductive_expr * decl_notation list) list -> cumulative_inductive_flag ->
-  polymorphic -> private_flag -> Declarations.recursivity_kind -> unit
+  polymorphic -> private_flag -> uniform_inductive_flag ->
+  Declarations.recursivity_kind -> unit
 
 (************************************************************************)
 (** Internal API  *)

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -543,6 +543,12 @@ let should_treat_as_cumulative cum poly =
     else user_err Pp.(str "The NonCumulative prefix can only be used in a polymorphic context.")
   | None -> poly && Flags.is_polymorphic_inductive_cumulativity ()
 
+let should_treat_as_uniform uni =
+  match uni with
+  | Some VernacUniformParams -> true
+  | Some VernacNonUniformParams -> false
+  | None -> false (* TODO: Add a flag *)
+
 let vernac_record cum k poly finite struc binders sort nameopt cfs =
   let is_cumulative = should_treat_as_cumulative cum poly in
   let const = match nameopt with
@@ -561,7 +567,7 @@ let vernac_record cum k poly finite struc binders sort nameopt cfs =
     then the type is declared private (as per the [Private] keyword). [finite]
     indicates whether the type is inductive, co-inductive or
     neither. *)
-let vernac_inductive ~atts cum lo finite indl =
+let vernac_inductive ~atts cum lo uni finite indl =
   if Dumpglob.dump () then
     List.iter (fun (((coe,(lid,_)), _, _, _, cstrs), _) ->
       match cstrs with
@@ -599,7 +605,8 @@ let vernac_inductive ~atts cum lo finite indl =
     in
     let indl = List.map unpack indl in
     let is_cumulative = should_treat_as_cumulative cum atts.polymorphic in
-    ComInductive.do_mutual_inductive indl is_cumulative atts.polymorphic lo finite
+    let is_uniform = should_treat_as_uniform uni in
+    ComInductive.do_mutual_inductive indl is_cumulative atts.polymorphic lo is_uniform finite
 
 let vernac_fixpoint ~atts discharge l =
   let local = enforce_locality_exp atts.locality discharge in
@@ -2035,7 +2042,7 @@ let interp ?proof ~atts ~st c =
   | VernacExactProof c -> vernac_exact_proof c
   | VernacAssumption ((discharge,kind),nl,l) ->
       vernac_assumption ~atts discharge kind l nl
-  | VernacInductive (cum, priv,finite,l) -> vernac_inductive ~atts cum priv finite l
+  | VernacInductive (cum, priv, uni, finite, l) -> vernac_inductive ~atts cum priv uni finite l
   | VernacFixpoint (discharge, l) -> vernac_fixpoint ~atts discharge l
   | VernacCoFixpoint (discharge, l) -> vernac_cofixpoint ~atts discharge l
   | VernacScheme l -> vernac_scheme l


### PR DESCRIPTION
**Kind:** feature

TL;DR: Support `Uniform Inductive` which fixes the parameters in the body of the inductive.

#7254 is a proposal to remove ad-hoc filling of inductive parameters. That makes the pattern below not work, where we have parameters we don't want to mention, and are uniform but not inferable:
```
Inductive expr {vars : Type} : Type :=
  add : expr -> expr -> expr.
```
This is commonly used by fiat and @JasonGross.

This feature is a proposal to support
```
Uniform Inductive expr (vars : Type) : Type :=
  add : expr -> expr -> expr.
```
where `Uniform` indicates all parameters are uniform. Inside the constructors, `expr` has type `Type`, so there is no need to infer a value for vars. After pretyping, constructors are generalized over the uniform parameters.

As a user, I think this is a useful semantic indicator, and can also save on writing out the parameters in the constructors when you want them to be uniform.

My current implementation is rather hacky, but it is remarkably short (17 lines for the meat of the code; hopefully it is not too terse). Suggestions welcome.

- [ ] Support `Set Uniform Inductives` to make this default (`NonUniform` prefix to escape)
- [ ] Add tests
- [ ] Corresponding documentation was added.
- [ ] Entry added in CHANGES.

---

In #7254, @herbelin suggested filling the remaining holes with the default heuristics (i.e. the canonical instantiation `(var:=var)`) using an evar flag or evar kind. I think the approach I take here is simpler and easier to understand / control (no need to track whether each hole is a parameter of the current inductive type).
