### PR TITLE
[lib] Re-add `set_timeout` to help users workaround #7408

### DIFF
--- a/lib/control.ml
+++ b/lib/control.ml
@@ -85,4 +85,7 @@ let timeout_fun = match Sys.os_type with
 | "Unix" | "Cygwin" -> { timeout = unix_timeout }
 | _ -> { timeout = windows_timeout }
 
-let timeout n f e = timeout_fun.timeout n f e
+let timeout_fun_ref = ref timeout_fun
+let set_timeout f = timeout_fun_ref := f
+
+let timeout n f e = !timeout_fun_ref.timeout n f e

--- a/lib/control.mli
+++ b/lib/control.mli
@@ -24,3 +24,8 @@ val check_for_interrupt : unit -> unit
 val timeout : int -> ('a -> 'b) -> 'a -> exn -> 'b
 (** [timeout n f x e] tries to compute [f x], and if it fails to do so
     before [n] seconds, it raises [e] instead. *)
+
+(** Set a particular timeout function; warning, this is an internal
+   API and it is scheduled to go away. *)
+type timeout = { timeout : 'a 'b. int -> ('a -> 'b) -> 'a -> exn -> 'b }
+val set_timeout : timeout -> unit


### PR DESCRIPTION
It seems like #7408 will need some potentially intrusive work, so
let's add the low-level hook back so third party developments can work
well with `8.8.1/master` for the moment.
