### PR TITLE
Remove an internal function from an mli.

### DIFF
--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -4927,6 +4927,7 @@ let shrink_entry sign const =
   } in
   (const, args)
 
+(** Internal function only used by tclABSTRACT *)
 let cache_term_by_tactic_then ~opaque ?(goal_type=None) id gk tac tacK =
   let open Tacticals.New in
   let open Tacmach.New in

--- a/tactics/tactics.mli
+++ b/tactics/tactics.mli
@@ -407,8 +407,6 @@ val generalize_dep  : ?with_let:bool (** Don't lose let bindings *) -> constr  -
 
 val unify           : ?state:Names.transparent_state -> constr -> constr -> unit Proofview.tactic
 
-val cache_term_by_tactic_then : opaque:bool -> ?goal_type:(constr option) -> Id.t -> Decl_kinds.goal_kind -> unit Proofview.tactic -> (constr -> constr list -> unit Proofview.tactic) -> unit Proofview.tactic
-
 val tclABSTRACT : ?opaque:bool -> Id.t option -> unit Proofview.tactic -> unit Proofview.tactic
 
 val abstract_generalize : ?generalize_vars:bool -> ?force_dep:bool -> Id.t -> unit Proofview.tactic


### PR DESCRIPTION
This trivial commit removes a function from an mli that wasn't used anywhere. Are these kinds of clean-ups wanted or not?