### PR TITLE
Refuse to parse empty [Context] command.

### DIFF
--- a/vernac/g_vernac.ml4
+++ b/vernac/g_vernac.ml4
@@ -631,8 +631,8 @@ GEXTEND Gram
          t = class_rawexpr ->
           VernacCoercion (CAst.make ~loc:!@loc @@ ByNotation ntn, s, t)
 
-      | IDENT "Context"; c = binders ->
-	  VernacContext c
+      | IDENT "Context"; c = LIST1 binder ->
+          VernacContext (List.flatten c)
 
       | IDENT "Instance"; namesup = instance_name; ":";
 	 expl = [ "!" -> Decl_kinds.Implicit | -> Decl_kinds.Explicit ] ; t = operconstr LEVEL "200";


### PR DESCRIPTION
The error is now:
    Syntax error: [constr:binder] expected after 'Context' (in [vernac:gallina_ext]).

Close #7452.
