### PR TITLE
[toplevel] Don't ignore output filename provided by user in -o

### DIFF
--- a/test-suite/misc/coqc_dash_o.sh
+++ b/test-suite/misc/coqc_dash_o.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+DOUT=misc/tmp_coqc_dash_o/
+OUT=${DOUT}coqc_dash_o.vo
+
+
+mkdir -p "${DOUT}"
+rm -f "${OUT}"
+$coqc misc/coqc_dash_o.v -o "${OUT}"
+if [ ! -f "${OUT}" ]; then
+  printf "coqc -o not working"
+  exit 1
+fi
+rm -fr "${DOUT}"
+exit 0

--- a/test-suite/misc/coqc_dash_o.v
+++ b/test-suite/misc/coqc_dash_o.v
@@ -1,0 +1,1 @@
+Definition x := nat.

--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -315,11 +315,12 @@ let compile cur_feeder opts ~echo ~f_in ~f_out =
   CoqworkmgrApi.giveback 1
 
 let compile_file cur_feeder opts (f_in, echo) =
+  let f_out = opts.compilation_output_name in
   if !Flags.beautify then
     Flags.with_option Flags.beautify_file
-      (fun f_in -> compile cur_feeder opts ~echo ~f_in ~f_out:None) f_in
+      (fun f_in -> compile cur_feeder opts ~echo ~f_in ~f_out) f_in
   else
-    compile cur_feeder opts ~echo ~f_in ~f_out:None
+    compile cur_feeder opts ~echo ~f_in ~f_out
 
 let compile_files cur_feeder opts =
   let compile_list = List.rev opts.compile_list in


### PR DESCRIPTION
This was a silly bug introduced in
675a1dc401eb9a5540ba5bc9a522c1f84d4c3d54 that forgot to properly
forward the command line option.

Thanks to @SkySkimmer for finding out the problem.

closes #7447
closes #7457