### PR TITLE
Don't use ref universe_opt_subst in universe normalisation function

### DIFF
--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -842,12 +842,12 @@ let universe_rigidity evd l =
   else UnivRigid
 
 let normalize_universe evd =
-  let vars = ref (UState.subst evd.universes) in
+  let vars = UState.subst evd.universes in
   let normalize = Universes.normalize_universe_opt_subst vars in
     normalize
 
 let normalize_universe_instance evd l =
-  let vars = ref (UState.subst evd.universes) in
+  let vars = UState.subst evd.universes in
   let normalize = Universes.level_subst_of (Universes.normalize_univ_variable_opt_subst vars) in
     Univ.Instance.subst_fn normalize l
 

--- a/engine/uState.ml
+++ b/engine/uState.ml
@@ -156,7 +156,7 @@ let process_universe_constraints ctx cstrs =
   let univs = ctx.uctx_universes in
   let vars = ref ctx.uctx_univ_variables in
   let weak = ref ctx.uctx_weak_constraints in
-  let normalize = normalize_univ_variable_opt_subst vars in
+  let normalize u = normalize_univ_variable_opt_subst !vars u in
   let nf_constraint = function
     | ULub (u, v) -> ULub (level_subst_of normalize u, level_subst_of normalize v)
     | UWeak (u, v) -> UWeak (level_subst_of normalize u, level_subst_of normalize v)

--- a/engine/universes.mli
+++ b/engine/universes.mli
@@ -184,19 +184,18 @@ val normalize_univ_variables : universe_opt_subst ->
 
 val normalize_univ_variable : 
   find:(Level.t -> Universe.t) ->
-  update:(Level.t -> Universe.t -> Universe.t) ->
   Level.t -> Universe.t
 
-val normalize_univ_variable_opt_subst : universe_opt_subst ref ->
+val normalize_univ_variable_opt_subst : universe_opt_subst ->
   (Level.t -> Universe.t)
 
-val normalize_univ_variable_subst : universe_subst ref ->
+val normalize_univ_variable_subst : universe_subst ->
   (Level.t -> Universe.t)
 
-val normalize_universe_opt_subst : universe_opt_subst ref ->
+val normalize_universe_opt_subst : universe_opt_subst ->
   (Universe.t -> Universe.t)
 
-val normalize_universe_subst : universe_subst ref ->
+val normalize_universe_subst : universe_subst ->
   (Universe.t -> Universe.t)
 
 (** Create a fresh global in the global environment, without side effects.


### PR DESCRIPTION
It complicates the API and doesn't seem to improve performance usefully.

https://ci.inria.fr/coq/view/benchmarking/job/benchmark-part-of-the-branch/425/console
```

┌──────────────────────────┬─────────────────────────┬───────────────────────────────────────┬───────────────────────────────────────┬─────────────────────────┬─────────────────┐
│                          │      user time [s]      │              CPU cycles               │           CPU instructions            │  max resident mem [KB]  │   mem faults    │
│                          │                         │                                       │                                       │                         │                 │
│             package_name │     NEW     OLD PDIFF   │            NEW            OLD PDIFF   │            NEW            OLD PDIFF   │     NEW     OLD PDIFF   │ NEW OLD PDIFF   │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│                coq-sf-lf │   20.50   20.85 -1.68 % │    56329718498    56224244118 +0.19 % │    73694262339    73821775002 -0.17 % │  429988  429216 +0.18 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│       coq-mathcomp-field │  455.84  460.53 -1.02 % │  1265186052362  1278289804010 -1.03 % │  2055057808908  2064531452171 -0.46 % │  814336  814320 +0.00 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│ coq-mathcomp-real-closed │  170.62  171.75 -0.66 % │   473283984836   476110413158 -0.59 % │   695386482794   698667977221 -0.47 % │  839164  837284 +0.22 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│           coq-coquelicot │   83.30   83.59 -0.35 % │   230351916811   230306993508 +0.02 % │   275169134559   275671832016 -0.18 % │  719224  719408 -0.03 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│     coq-mathcomp-algebra │  185.02  185.47 -0.24 % │   511234623282   512626474529 -0.27 % │   691294762182   693202195552 -0.28 % │  643520  645156 -0.25 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│    coq-mathcomp-fingroup │   65.02   65.15 -0.20 % │   178294239464   178865173035 -0.32 % │   238434741165   239750244202 -0.55 % │  592412  588924 +0.59 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│         coq-fiat-parsers │  702.50  703.48 -0.14 % │  1944701391331  1947154777939 -0.13 % │  2974224027344  2980292207108 -0.20 % │ 3376892 3376656 +0.01 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│                coq-flocq │  263.71  264.06 -0.13 % │   731440978965   732719631471 -0.17 % │   902932978232   904185925614 -0.14 % │ 1245532 1245592 -0.00 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│               coq-sf-plf │   53.90   53.92 -0.04 % │   148282687713   148133668896 +0.10 % │   187504866807   187798335993 -0.16 % │  520704  519968 +0.14 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│   coq-mathcomp-character │  274.45  274.55 -0.04 % │   761134177503   761444092323 -0.04 % │  1085188701492  1087520861291 -0.21 % │ 1132520 1120944 +1.03 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│              coq-bignums │   79.84   79.83 +0.01 % │   220278021620   219837686154 +0.20 % │   285461443157   286063083519 -0.21 % │  519432  528648 -1.74 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│                coq-color │  723.40  723.16 +0.03 % │  1997660769084  1997350705462 +0.02 % │  2382080127464  2384357287580 -0.10 % │ 1451044 1450516 +0.04 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│   coq-mathcomp-ssreflect │   45.28   45.26 +0.04 % │   123384053458   123302466663 +0.07 % │   145156701687   145258672128 -0.07 % │  537352  537112 +0.04 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│               coq-geocoq │ 3107.24 3104.94 +0.07 % │  8620760334016  8615796904665 +0.06 % │ 13798865708698 13823041562866 -0.17 % │ 1240128 1208768 +2.59 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│            coq-fiat-core │  111.77  111.68 +0.08 % │   310307858818   309916952926 +0.13 % │   379618396165   379731687494 -0.03 % │  498424  499936 -0.30 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│                 coq-corn │ 1563.83 1562.24 +0.10 % │  4328940232713  4322169073318 +0.16 % │  6437817589849  6449369724038 -0.18 % │  932740  874160 +6.70 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│                  coq-vst │ 3842.51 3838.55 +0.10 % │ 10684085757561 10668112750911 +0.15 % │ 13998592026762 13999286062787 -0.00 % │ 2230416 2234792 -0.20 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│              coq-unimath │ 1290.99 1288.79 +0.17 % │  3574927722781  3569379401512 +0.16 % │  6047123580295  6044640503898 +0.04 % │ 1034500 1070188 -3.33 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│      coq-formal-topology │   37.43   37.36 +0.19 % │   101288428625   101239598211 +0.05 % │   126172712915   126294861202 -0.10 % │  482472  482404 +0.01 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│    coq-mathcomp-solvable │  202.22  201.76 +0.23 % │   558339435475   557479127484 +0.15 % │   771165625051   770748577148 +0.05 % │  868320  857696 +1.24 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│         coq-math-classes │  228.94  228.32 +0.27 % │   627711608907   627517992486 +0.03 % │   785572705642   786283833251 -0.09 % │  528172  533272 -0.96 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│          coq-fiat-crypto │ 4104.71 4093.54 +0.27 % │ 11388420409373 11361073222526 +0.24 % │ 18401725943235 18429613450826 -0.15 % │ 3200988 3179992 +0.66 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│             coq-compcert │  876.47  874.00 +0.28 % │  2427080046831  2422448017931 +0.19 % │  3479930798350  3483315940020 -0.10 % │ 1387836 1333192 +4.10 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│               coq-sf-vfa │   26.47   26.34 +0.49 % │    72139605070    72168295122 -0.04 % │    93891249668    93997240646 -0.11 % │  541740  541644 +0.02 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│   coq-mathcomp-odd-order │ 1422.74 1413.27 +0.67 % │  3952291041611  3926625038654 +0.65 % │  6658609458421  6665601922118 -0.10 % │ 1371276 1393436 -1.59 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│                 coq-hott │  331.83  329.58 +0.68 % │   919403886514   914341656639 +0.55 % │  1424642884849  1426480829979 -0.13 % │  588968  588948 +0.00 % │   0   0  +nan % │
└──────────────────────────┴─────────────────────────┴───────────────────────────────────────┴───────────────────────────────────────┴─────────────────────────┴─────────────────┘


```