### PR TITLE
use at least 6 Xs in mktemp filename templates

### DIFF
--- a/dev/tools/pre-commit
+++ b/dev/tools/pre-commit
@@ -14,9 +14,9 @@ then
 
     # We fix whitespace in the index and in the working tree
     # separately to preserve non-added changes.
-    index=$(mktemp "git-fix-ws-index.XXXXX")
-    fixed_index=$(mktemp "git-fix-ws-index-fixed.XXXXX")
-    tree=$(mktemp "git-fix-ws-tree.XXXXX")
+    index=$(mktemp "git-fix-ws-index.XXXXXX")
+    fixed_index=$(mktemp "git-fix-ws-index-fixed.XXXXXX")
+    tree=$(mktemp "git-fix-ws-tree.XXXXXX")
     1>&2 echo "Patches are saved in '$index', '$fixed_index' and '$tree'."
     1>&2 echo "If an error destroys your changes you can recover using them."
     1>&2 echo "(The files are cleaned up on success.)"

--- a/test-suite/save-logs.sh
+++ b/test-suite/save-logs.sh
@@ -9,7 +9,7 @@ mkdir "$SAVEDIR"
 # keep this synced with test-suite/Makefile
 FAILMARK="==========> FAILURE <=========="
 
-FAILED=$(mktemp /tmp/coq-check-XXXXX)
+FAILED=$(mktemp /tmp/coq-check-XXXXXX)
 find . '(' -path ./bugs/opened -prune ')' -o '(' -name '*.log' -exec grep "$FAILMARK" -q '{}' ';' -print0 ')' > "$FAILED"
 
 rsync -a --from0 --files-from="$FAILED" . "$SAVEDIR"


### PR DESCRIPTION
OpenBSD mktemp fails with an error otherwise.

**Kind:**  bug fix

Fixes #7469 