### PR TITLE
gitlab CI: remove math-classes job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -278,9 +278,6 @@ ci-iris-lambda-rust:
 ci-ltac2:
   <<: *ci-template
 
-ci-math-classes:
-  <<: *ci-template
-
 ci-math-comp:
   <<: *ci-template-flambda
 


### PR DESCRIPTION
It's redundant as a dependency of formal-topology.
