### PR TITLE
Forbid pretyping algebraic universes in most positions.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -135,6 +135,10 @@ Kernel
 
 - Mutually defined records are now supported.
 
+- Algebraic universes are forbidden in most places. They remain
+  allowed only in the codomain of the type of a definition or
+  inductive type.
+
 Notations
 
 - New support for autonomous grammars of terms, called "custom

--- a/checker/checkInductive.ml
+++ b/checker/checkInductive.ml
@@ -58,7 +58,7 @@ let typecheck_arity env params inds =
   let check_arity arctxt = function
     | RegularArity mar ->
         let ar = mar.mind_user_arity in
-        let _ = Typeops.infer_type env ar in
+        let _ = Typeops.infer_type ~allow_alg:true env ar in
         Reduction.conv env (Term.it_mkProd_or_LetIn (Constr.mkSort mar.mind_sort) arctxt) ar;
         ar
     | TemplateArity par ->

--- a/checker/checker.ml
+++ b/checker/checker.ml
@@ -295,7 +295,8 @@ let explain_exn = function
       | IllFormedRecBody _ -> str"IllFormedRecBody"
       | IllTypedRecBody _ -> str"IllTypedRecBody"
       | UnsatisfiedConstraints _ -> str"UnsatisfiedConstraints"
-      | UndeclaredUniverse _ -> str"UndeclaredUniverse"))
+      | UndeclaredUniverse _ -> str"UndeclaredUniverse"
+      | DisallowedAlgebraicUniverse _ -> str "DisallowedAlgebraicUniverse"))
 
   | Indtypes.InductiveError e ->
       hov 0 (str "Error related to inductive types")

--- a/checker/mod_checking.ml
+++ b/checker/mod_checking.ml
@@ -28,7 +28,7 @@ let check_constant_declaration env kn cb =
     | Some _, _ -> assert false
   in
   let ty = cb.const_type in
-  let _ = infer_type env' ty in
+  let _ = infer_type ~allow_alg:true env' ty in
   let () =
     match Environ.body_of_constant_body env cb with
     | Some bd ->

--- a/kernel/indtypes.ml
+++ b/kernel/indtypes.ml
@@ -277,18 +277,19 @@ let typecheck_inductive env mie =
 	   if isArity ind.mind_entry_arity then
 	     let (ctx,s) = dest_arity env_params ind.mind_entry_arity in
 	       match s with
-	       | Type u when Univ.universe_level u = None ->
+               | Type u when not (Univ.Universe.is_level u) ->
 	         (** We have an algebraic universe as the conclusion of the arity,
-		     typecheck the dummy Π ctx, Prop and do a special case for the conclusion.
+                     typecheck the dummy Π ctx, Prop and do a special case for the conclusion.
+                     XXX why
 		 *)
-	         let proparity = infer_type env_params (mkArity (ctx, Sorts.prop)) in
+                 let proparity = infer_type ~allow_alg:true env_params (mkArity (ctx, Sorts.prop)) in
 		 let (cctx, _) = destArity proparity.utj_val in
 		   (* Any universe is well-formed, we don't need to check [s] here *)
 		   mkArity (cctx, s)
 	       | _ -> 
-		 let arity = infer_type env_params ind.mind_entry_arity in
+                 let arity = infer_type ~allow_alg:true env_params ind.mind_entry_arity in
 		   arity.utj_val
-	   else let arity = infer_type env_params ind.mind_entry_arity in
+           else let arity = infer_type ~allow_alg:true env_params ind.mind_entry_arity in
 		  arity.utj_val
 	 in
 	 let (sign, deflev) = dest_arity env_params arity in

--- a/kernel/term_typing.ml
+++ b/kernel/term_typing.ml
@@ -102,7 +102,7 @@ let infer_declaration (type a) ~(trust : a trust) env (dcl : a constant_entry) =
                        const_entry_universes = Monomorphic_const_entry univs; _ } as c) ->
       let env = push_context_set ~strict:true univs env in
       let { const_entry_body = body; const_entry_feedback = feedback_id ; _ } = c in
-      let tyj = infer_type env typ in
+      let tyj = infer_type ~allow_alg:true env typ in
       let proofterm =
         Future.chain body (fun ((body,uctx),side_eff) ->
           (* don't redeclare universes which are declared for the type *)
@@ -172,7 +172,7 @@ let infer_declaration (type a) ~(trust : a trust) env (dcl : a constant_entry) =
         | None ->
           Vars.subst_univs_level_constr usubst j.uj_type
         | Some t ->
-           let tj = infer_type env t in
+           let tj = infer_type ~allow_alg:true env t in
            let _ = judge_of_cast env j DEFAULTcast tj in
            Vars.subst_univs_level_constr usubst t
       in

--- a/kernel/type_errors.ml
+++ b/kernel/type_errors.ml
@@ -63,6 +63,7 @@ type ('constr, 'types) ptype_error =
       int * Name.t array * ('constr, 'types) punsafe_judgment array * 'types array
   | UnsatisfiedConstraints of Univ.Constraint.t
   | UndeclaredUniverse of Univ.Level.t
+  | DisallowedAlgebraicUniverse of Univ.Universe.t
 
 type type_error = (constr, types) ptype_error
 
@@ -129,3 +130,6 @@ let error_unsatisfied_constraints env c =
 
 let error_undeclared_universe env l =
   raise (TypeError (env, UndeclaredUniverse l))
+
+let error_disallowed_algebraic_universe env u =
+  raise (TypeError (env, DisallowedAlgebraicUniverse u))

--- a/kernel/type_errors.mli
+++ b/kernel/type_errors.mli
@@ -64,6 +64,7 @@ type ('constr, 'types) ptype_error =
       int * Name.t array * ('constr, 'types) punsafe_judgment array * 'types array
   | UnsatisfiedConstraints of Univ.Constraint.t
   | UndeclaredUniverse of Univ.Level.t
+  | DisallowedAlgebraicUniverse of Univ.Universe.t
 
 type type_error = (constr, types) ptype_error
 
@@ -111,3 +112,5 @@ val error_elim_explain : Sorts.family -> Sorts.family -> arity_error
 val error_unsatisfied_constraints : env -> Univ.Constraint.t -> 'a
 
 val error_undeclared_universe : env -> Univ.Level.t -> 'a
+
+val error_disallowed_algebraic_universe : env -> Univ.Universe.t -> 'a

--- a/kernel/typeops.ml
+++ b/kernel/typeops.ml
@@ -490,16 +490,34 @@ and execute_recdef env (names,lar,vdef) i =
 
 and execute_array env = Array.map (execute env)
 
+let rec check_no_alg env c =
+  match kind c with
+  | Sort (Type u) -> if not (Universe.is_level u) then error_disallowed_algebraic_universe env u
+  | _ -> Constr.iter (check_no_alg env) c
+
+let rec check_maybe_alg env c =
+  match kind c with
+  | Prod (_,a,b) ->
+    check_no_alg env a;
+    check_maybe_alg env b
+  | LetIn (_,b,t,c) ->
+    check_no_alg env t;
+    check_no_alg env b;
+    check_maybe_alg env c
+  | _ -> Constr.iter (check_no_alg env) c
+
 (* Derived functions *)
 
-let check_wellformed_universes env c =
+let check_wellformed_universes ~allow_alg env c =
   let univs = universes_of_constr c in
-  try UGraph.check_declared_universes (universes env) univs
-  with UGraph.UndeclaredLevel u ->
-    error_undeclared_universe env u
+  let () = try UGraph.check_declared_universes (universes env) univs
+    with UGraph.UndeclaredLevel u ->
+      error_undeclared_universe env u
+  in
+  if allow_alg then check_maybe_alg env c else check_no_alg env c
 
 let infer env constr =
-  let () = check_wellformed_universes env constr in
+  let () = check_wellformed_universes env ~allow_alg:false constr in
   let t = execute env constr in
     make_judge constr t
 
@@ -516,14 +534,14 @@ let type_judgment env {uj_val=c; uj_type=t} =
   let s = check_type env c t in
   {utj_val = c; utj_type = s }
 
-let infer_type env constr =
-  let () = check_wellformed_universes env constr in
+let infer_type ?(allow_alg=false) env constr =
+  let () = check_wellformed_universes env ~allow_alg constr in
   let t = execute env constr in
   let s = check_type env constr t in
   {utj_val = constr; utj_type = s}
 
 let infer_v env cv =
-  let () = Array.iter (check_wellformed_universes env) cv in
+  let () = Array.iter (check_wellformed_universes ~allow_alg:false env) cv in
   let jv = execute_array env cv in
     make_judgev cv jv
 

--- a/kernel/typeops.mli
+++ b/kernel/typeops.mli
@@ -22,9 +22,9 @@ open Environ
  *)
 
 
-val infer      : env -> constr       -> unsafe_judgment
-val infer_v    : env -> constr array -> unsafe_judgment array
-val infer_type : env -> types        -> unsafe_type_judgment
+val infer : env -> constr -> unsafe_judgment
+val infer_v : env -> constr array -> unsafe_judgment array
+val infer_type : ?allow_alg:bool -> env -> types -> unsafe_type_judgment
 
 val check_context :
   env -> Constr.rel_context -> env

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -683,6 +683,10 @@ let explain_undeclared_universe env sigma l =
     Termops.pr_evd_level sigma l ++
     spc () ++ str "(maybe a bugged tactic)."
 
+let explain_disallowed_algebraic_universe env sigma u =
+  str "Algebraic universe " ++ Univ.Universe.pr_with (Termops.pr_evd_level sigma) u ++
+  str " not allowed here."
+
 let explain_type_error env sigma err =
   let env = make_all_name_different env sigma in
   match err with
@@ -722,6 +726,8 @@ let explain_type_error env sigma err =
       explain_unsatisfied_constraints env sigma cst
   | UndeclaredUniverse l ->
      explain_undeclared_universe env sigma l
+  | DisallowedAlgebraicUniverse u ->
+    explain_disallowed_algebraic_universe env sigma u
 
 let pr_position (cl,pos) =
   let clpos = match cl with
@@ -1317,6 +1323,7 @@ let map_ptype_error f = function
   IllTypedRecBody (n, na, Array.map (on_judgment f) jv, Array.map f t)
 | UnsatisfiedConstraints g -> UnsatisfiedConstraints g
 | UndeclaredUniverse l -> UndeclaredUniverse l
+| DisallowedAlgebraicUniverse u -> DisallowedAlgebraicUniverse u
 
 let explain_reduction_tactic_error = function
   | Tacred.InvalidAbstraction (env,sigma,c,(env',e)) ->


### PR DESCRIPTION
They are allowed when we pretype with [IsType] constraint and from
that in the codomain of products and in the body of letins.

This should cut down on algebraic-universe-in-constraint anomalies.

I'm hoping nobody has these annotations anywhere else, let's see what CI says.

@mattam82 does that seem about right to you?

- [x] Entry added in CHANGES.
