### PR TITLE
Minor update of the documentation about the rcfile

### DIFF
--- a/doc/sphinx/practical-tools/coq-commands.rst
+++ b/doc/sphinx/practical-tools/coq-commands.rst
@@ -55,15 +55,20 @@ Customization at launch time
 By resource file
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-When |Coq| is launched, with either ``coqtop`` or ``coqc``, the resource file
-``$XDG_CONFIG_HOME/coq/coqrc.xxx`` is loaded, where ``$XDG_CONFIG_HOME``
+When |Coq| is launched, with either ``coqtop`` or ``coqc``, the
+resource file ``$XDG_CONFIG_HOME/coq/coqrc.xxx``, if it exists, will
+be implicitly prepended to any document read by Coq, whether it is an
+interactive session or a file to compile. Here, ``$XDG_CONFIG_HOME``
 is the configuration directory of the user (by default its home
-directory ``/.config`` and ``xxx`` is the version number (e.g. 8.8). If
+directory ``~/.config``) and ``xxx`` is the version number (e.g. 8.8). If
 this file is not found, then the file ``$XDG_CONFIG_HOME/coqrc`` is
-searched. You can also specify an arbitrary name for the resource file
+searched. If not found, it is the file ``~/.coqrc.xxx`` which is searched,
+and, if still not found, the file ``~/.coqrc``. If the latter is also
+absent, no resource file is loaded.
+You can also specify an arbitrary name for the resource file
 (see option ``-init-file`` below).
 
-This file may contain, for instance, ``Add LoadPath`` commands to add
+The resource file may contain, for instance, ``Add LoadPath`` commands to add
 directories to the load path of |Coq|. It is possible to skip the
 loading of the resource file with the option ``-q``.
 

--- a/man/coqtop.1
+++ b/man/coqtop.1
@@ -110,7 +110,7 @@ print Coq version and exit
 
 .TP
 .B \-q
-skip loading of rcfile
+skip loading of rcfile (resource file) if any
 
 .TP
 .BI \-init\-file \ filename


### PR DESCRIPTION
**Kind:** documentation

To some extend, fixes #6662.

This makes more precise the doc about the `coqrc` file in the reference manual. This incidentally fixes a missing parenthesis. This gives an alternative less-idiomatic name to the pre-unix expression "rcfile".

We also use a `~` to refer to the home directory. Maybe this is too unix specific, but I don't know how this could/should be said on, e.g. windows.

Added: sphinx search seems to have a little problem. If I e.g. search for [coqrc](https://coq.inria.fr/refman/search.html?q=coqrc&check_keywords=yes&area=default) in the online manual, then the search tool does not see that a sequence of `~~~~~~~~~~~` is actually the underlining of the previous section header. Don't know if this is easily fixable from our side.