### PR TITLE
Fix restrict_universe_context

### DIFF
--- a/dev/ci/user-overlays/07495-gares-elpi-test-bug.sh
+++ b/dev/ci/user-overlays/07495-gares-elpi-test-bug.sh
@@ -1,0 +1,8 @@
+if [ "$CI_PULL_REQUEST" = "7495" ] || [ "$CI_BRANCH" = "fix-restrict" ]; then
+
+    # this branch contains a commit not present on coq-master that triggers
+    # the universe restriction bug #7472
+    Elpi_CI_BRANCH=overlay-7495
+    Elpi_CI_GITURL=https://github.com/LPCIC/coq-elpi.git
+
+fi

--- a/engine/univops.ml
+++ b/engine/univops.ml
@@ -35,79 +35,14 @@ let universes_of_constr env c =
     | _ -> Constr.fold aux s c
   in aux LSet.empty c
 
-type graphnode = {
-  mutable up : constraint_type LMap.t;
-  mutable visited : bool
-}
-
-let merge_types d d0 =
-  match d, d0 with
-  | _, Lt | Lt, _ -> Lt
-  | Le, _ | _, Le -> Le
-  | Eq, Eq -> Eq
-
-let merge_up d b up =
-  let find = try Some (LMap.find b up) with Not_found -> None in
-  match find with
-  | Some d0 ->
-    let d = merge_types d d0 in
-    if d == d0 then up else LMap.add b d up
-  | None -> LMap.add b d up
-
-let add_up a d b graph =
-  let node, graph =
-    try LMap.find a graph, graph
-    with Not_found ->
-      let node = { up = LMap.empty; visited = false } in
-      node, LMap.add a node graph
-  in
-  node.up <- merge_up d b node.up;
-  graph
-
-(* for each node transitive close until you find a non removable, discard the rest *)
-let transitive_close removable graph =
-  let rec do_node a node =
-    if not node.visited
-    then
-      let keepup =
-        LMap.fold (fun b d keepup ->
-            if not (LSet.mem b removable)
-            then merge_up d b keepup
-            else
-              begin
-                match LMap.find b graph with
-                | bnode ->
-                  do_node b bnode;
-                  LMap.fold (fun k d' keepup ->
-                    merge_up (merge_types d d') k keepup)
-                    bnode.up keepup
-                | exception Not_found -> keepup
-              end
-          )
-          node.up LMap.empty
-      in
-      node.up <- keepup;
-      node.visited <- true
-  in
-  LMap.iter do_node graph
-
-let restrict_universe_context (univs,csts) keep =
-  let removable = LSet.diff univs keep in
-  let (csts, rem) =
-    Constraint.fold (fun (a,d,b as cst) (csts, rem) ->
-        if LSet.mem a removable || LSet.mem b removable
-        then (csts, add_up a d b rem)
-        else (Constraint.add cst csts, rem))
-      csts (Constraint.empty, LMap.empty)
-  in
-  transitive_close removable rem;
-  let csts =
-    LMap.fold (fun a node csts ->
-        if LSet.mem a removable
-        then csts
-        else
-          LMap.fold (fun b d csts -> Constraint.add (a,d,b) csts)
-            node.up csts)
-      rem csts
-  in
+let restrict_universe_context (univs, csts) keep =
+  let removed = LSet.diff univs keep in
+  if LSet.is_empty removed then univs, csts
+  else
+  let allunivs = Constraint.fold (fun (u,_,v) all -> LSet.add u (LSet.add v all)) csts univs in
+  let g = UGraph.empty_universes in
+  let g = LSet.fold UGraph.add_universe_unconstrained allunivs g in
+  let g = UGraph.merge_constraints csts g in
+  let allkept = LSet.diff allunivs removed in
+  let csts = UGraph.constraints_for ~kept:allkept g in
   (LSet.inter univs keep, csts)

--- a/engine/univops.mli
+++ b/engine/univops.mli
@@ -14,5 +14,8 @@ open Univ
 (** The universes of monomorphic constants appear. *)
 val universes_of_constr : Environ.env -> constr -> LSet.t
 
-(** Shrink a universe context to a restricted set of variables *)
+(** [restrict_universe_context (univs,csts) keep] restricts [univs] to
+   the universes in [keep]. The constraints [csts] are adjusted so
+   that transitive constraints between remaining universes (those in
+   [keep] and those not in [univs]) are preserved. *)
 val restrict_universe_context : ContextSet.t -> LSet.t -> ContextSet.t

--- a/kernel/uGraph.mli
+++ b/kernel/uGraph.mli
@@ -49,13 +49,15 @@ exception AlreadyDeclared
 
 val add_universe : Level.t -> bool -> t -> t
 
+(** Add a universe without (Prop,Set) <= u *)
+val add_universe_unconstrained : Level.t -> t -> t
+
 (** {6 Pretty-printing of universes. } *)
 
 val pr_universes : (Level.t -> Pp.t) -> t -> Pp.t
 
 (** The empty graph of universes *)
 val empty_universes : t
-[@@ocaml.deprecated "Use UGraph.initial_universes"]
 
 val sort_universes : t -> t
 
@@ -63,6 +65,12 @@ val sort_universes : t -> t
    [csts] are the non-Eq constraints and [partition] is the partition
    of the universes into equivalence classes. *)
 val constraints_of_universes : t -> Constraint.t * LSet.t list
+
+(** [constraints_for ~kept g] returns the constraints about the
+   universes [kept] in [g] up to transitivity.
+
+    eg if [g] is [a <= b <= c] then [constraints_for ~kept:{a, c} g] is [a <= c]. *)
+val constraints_for : kept:LSet.t -> t -> Constraint.t
 
 val check_subtype : AUContext.t check_function
 (** [check_subtype univ ctx1 ctx2] checks whether [ctx2] is an instance of


### PR DESCRIPTION
This should fix #7472 although I didn't test it.

Instead of messing with a buggy custom graph algorithm we go through the ugraph algorithm in a slightly brute-force manner.
It seems this impacts some tricky heuristic causing HoTT and formal-topology (and a HoTT-based test suite file) to fail. Still investigating.

Bench: https://ci.inria.fr/coq/view/benchmarking/job/benchmark-part-of-the-branch/426/console
Despite the unsophisticated algorithm there is little impact, I think we rarely have many new universes / constraints per object.
```
┌──────────────────────────┬─────────────────────────┬───────────────────────────────────────┬───────────────────────────────────────┬─────────────────────────┬─────────────────┐
│                          │      user time [s]      │              CPU cycles               │           CPU instructions            │  max resident mem [KB]  │   mem faults    │
│                          │                         │                                       │                                       │                         │                 │
│             package_name │     NEW     OLD PDIFF   │            NEW            OLD PDIFF   │            NEW            OLD PDIFF   │     NEW     OLD PDIFF   │ NEW OLD PDIFF   │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│               coq-sf-vfa │   26.19   26.48 -1.10 % │    72078267639    72152115741 -0.10 % │    93867490685    94035628199 -0.18 % │  541376  541380 -0.00 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│                coq-sf-lf │   20.78   20.88 -0.48 % │    56161474465    56271106701 -0.19 % │    73618512048    73872348912 -0.34 % │  429260  429140 +0.03 % │   7   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│              coq-bignums │   79.78   80.08 -0.37 % │   220549849581   220674642906 -0.06 % │   285941360780   286264820515 -0.11 % │  528684  528732 -0.01 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│          coq-fiat-crypto │ 4108.89 4113.51 -0.11 % │ 11397157329157 11410919665169 -0.12 % │ 18427840323976 18442342141631 -0.08 % │ 3185336 3147660 +1.20 % │   8  33 -75.76 % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│         coq-math-classes │  228.35  228.58 -0.10 % │   628530108909   629035769844 -0.08 % │   788150193061   786417458071 +0.22 % │  532584  533152 -0.11 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│                 coq-corn │ 1563.74 1564.48 -0.05 % │  4341727574523  4325870881332 +0.37 % │  6452506241544  6450126963962 +0.04 % │  875020  874056 +0.11 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│    coq-mathcomp-fingroup │   64.94   64.97 -0.05 % │   178952540988   179084420300 -0.07 % │   239204768022   239794506122 -0.25 % │  588384  589000 -0.10 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│           coq-coquelicot │   83.52   83.54 -0.02 % │   230493921022   230181842101 +0.14 % │   275444082307   275437213366 +0.00 % │  721580  720136 +0.20 % │  29   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│                coq-flocq │  263.23  263.24 -0.00 % │   730312386310   730385581913 -0.01 % │   903594177302   903317960182 +0.03 % │ 1245704 1245604 +0.01 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│       coq-mathcomp-field │  460.97  460.98 -0.00 % │  1282709326728  1282401193211 +0.02 % │  2066762859212  2064538964300 +0.11 % │  814584  814392 +0.02 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│         coq-fiat-parsers │  703.45  703.24 +0.03 % │  1946437216614  1946269578221 +0.01 % │  2975529193808  2979563842492 -0.14 % │ 3376576 3376520 +0.00 % │   0   9 -100.00 % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│    coq-mathcomp-solvable │  201.21  201.12 +0.04 % │   558641643648   558190473032 +0.08 % │   770409292656   770917220716 -0.07 % │  839588  866264 -3.08 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│ coq-mathcomp-real-closed │  171.78  171.54 +0.14 % │   477975725875   477399075006 +0.12 % │   699118837987   698698054275 +0.06 % │  839508  837272 +0.27 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│                coq-color │  723.37  722.23 +0.16 % │  1999700567406  1995187718879 +0.23 % │  2385012886632  2384593340636 +0.02 % │ 1450604 1446404 +0.29 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│             coq-compcert │  875.59  873.48 +0.24 % │  2425409110563  2419988860901 +0.22 % │  3483911297171  3481702485365 +0.06 % │ 1335604 1333456 +0.16 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│                  coq-vst │ 3849.68 3840.16 +0.25 % │ 10701114539363 10672001365828 +0.27 % │ 14014496246065 14003087057603 +0.08 % │ 2232116 2234312 -0.10 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│              coq-unimath │ 1291.28 1287.94 +0.26 % │  3576386632018  3566802329864 +0.27 % │  6047356902985  6047511516079 -0.00 % │ 1071100 1071192 -0.01 % │   1   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│   coq-mathcomp-ssreflect │   45.31   45.19 +0.27 % │   123795015548   123548759317 +0.20 % │   145512283840   145469700027 +0.03 % │  537116  537276 -0.03 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│     coq-mathcomp-algebra │  185.64  185.10 +0.29 % │   514971975928   513827131380 +0.22 % │   693801057199   693315221524 +0.07 % │  650772  645120 +0.88 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│               coq-geocoq │ 3104.64 3092.45 +0.39 % │  8610245606594  8578404414075 +0.37 % │ 13830358266032 13818865418258 +0.08 % │ 1239700 1210724 +2.39 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│               coq-sf-plf │   53.94   53.63 +0.58 % │   148135110655   147999661663 +0.09 % │   187565992538   187696689307 -0.07 % │  514416  514684 -0.05 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│            coq-fiat-core │  111.95  111.25 +0.63 % │   310466951147   309300228426 +0.38 % │   380270573253   379700140505 +0.15 % │  502092  500004 +0.42 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│   coq-mathcomp-odd-order │ 1420.54 1411.10 +0.67 % │  3957117294869  3931405783138 +0.65 % │  6664863723229  6666033452918 -0.02 % │ 1416680 1393308 +1.68 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│   coq-mathcomp-character │  276.06  274.16 +0.69 % │   767362696214   762136638822 +0.69 % │  1091194393647  1087543890712 +0.34 % │ 1130488 1120628 +0.88 % │   0   0  +nan % │
└──────────────────────────┴─────────────────────────┴───────────────────────────────────────┴───────────────────────────────────────┴─────────────────────────┴─────────────────┘
```