### PR TITLE
coq_makefile: don't set .DEFAULT_GOAL for inclusion friendliness

### DIFF
--- a/tools/CoqMakefile.in
+++ b/tools/CoqMakefile.in
@@ -6,6 +6,8 @@
 ###############################################################################
 ## GNUMakefile for Coq @COQ_VERSION@
 
+all: # Default goal, real definition below.
+
 # For debugging purposes (must stay here, don't move below)
 INITIAL_VARS := $(.VARIABLES)
 # To implement recursion we save the name of the main Makefile
@@ -807,5 +809,3 @@ debug:
 	       		$(.VARIABLES))),\
 	       	$(info $(v) = $($(v))))
 .PHONY: debug
-
-.DEFAULT_GOAL := all


### PR DESCRIPTION
Close #5074.
