### PR TITLE
Fixing little printing bug with "Locate" on recursive notations

### DIFF
--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -1051,7 +1051,7 @@ let locate_notation prglob ntn scope =
   | [] -> str "Unknown notation"
   | _ ->
     str "Notation" ++ fnl () ++
-    prlist (fun (ntn,l) ->
+    prlist_with_sep fnl (fun (ntn,l) ->
       let scope = find_default ntn scopes in
       prlist
 	(fun (sc,r,(_,df)) ->
@@ -1060,8 +1060,7 @@ let locate_notation prglob ntn scope =
 	    (if String.equal sc default_scope then mt ()
              else (spc () ++ str ": " ++ str sc)) ++
 	    (if Option.equal String.equal (Some sc) scope
-             then spc () ++ str "(default interpretation)" else mt ())
-	    ++ fnl ()))
+             then spc () ++ str "(default interpretation)" else mt ())))
 	l) ntns
 
 let collect_notation_in_scope scope sc known =

--- a/interp/notation_ops.ml
+++ b/interp/notation_ops.ml
@@ -165,15 +165,15 @@ let glob_constr_of_notation_constr_with_binders ?loc g f e nc =
   | NApp (a,args) -> GApp (f e a, List.map (f e) args)
   | NList (x,y,iter,tail,swap) ->
       let t = f e tail in let it = f e iter in
-      let innerl = (ldots_var,t)::(if swap then [] else [x, lt @@ GVar y]) in
+      let innerl = (ldots_var,t)::(if swap then [y, lt @@ GVar x] else []) in
       let inner  = lt @@ GApp (lt @@ GVar (ldots_var),[subst_glob_vars innerl it]) in
-      let outerl = (ldots_var,inner)::(if swap then [x, lt @@ GVar y] else []) in
+      let outerl = (ldots_var,inner)::(if swap then [] else [y, lt @@ GVar x]) in
       DAst.get (subst_glob_vars outerl it)
   | NBinderList (x,y,iter,tail,swap) ->
       let t = f e tail in let it = f e iter in
-      let innerl = (ldots_var,t)::(if swap then [] else [x, lt @@ GVar y]) in
+      let innerl = (ldots_var,t)::(if swap then [y, lt @@ GVar x] else []) in
       let inner  = lt @@ GApp (lt @@ GVar ldots_var,[subst_glob_vars innerl it]) in
-      let outerl = (ldots_var,inner)::(if swap then [x, lt @@ GVar y] else []) in
+      let outerl = (ldots_var,inner)::(if swap then [] else [y, lt @@ GVar x]) in
       DAst.get (subst_glob_vars outerl it)
   | NLambda (na,ty,c) ->
       let e',disjpat,na = g e na in GLambda (na,Explicit,f e ty,Option.fold_right (apply_cases_pattern ?loc) disjpat (f e' c))

--- a/test-suite/output/Notations3.out
+++ b/test-suite/output/Notations3.out
@@ -231,3 +231,13 @@ fun l : list nat => match l with
      : list nat -> list nat
 
 Argument scope is [list_scope]
+Notation
+"'exists' x .. y , p" := ex (fun x => .. (ex (fun y => p)) ..) : type_scope
+(default interpretation)
+"'exists' ! x .. y , p" := ex
+                             (unique
+                                (fun x => .. (ex (unique (fun y => p))) ..))
+: type_scope (default interpretation)
+Notation
+"( x , y , .. , z )" := pair .. (pair x y) .. z : core_scope
+(default interpretation)

--- a/test-suite/output/Notations3.v
+++ b/test-suite/output/Notations3.v
@@ -380,3 +380,8 @@ Definition foo (l : list nat) :=
 end.
 Print foo.
 End Issue7110.
+
+Module LocateNotations.
+Locate "exists".
+Locate "( _ , _ , .. , _ )".
+End LocateNotations.


### PR DESCRIPTION
**Kind:** bug fix

Since v8.6, we had the following:
```
Locate "( _ , _ , .. , _ )".
(* Notation "( x , y , .. , z )" := pair .. (pair x z) .. z : core_scope (default interpretation) *)
```
This PR repairs the `y` which is printed `z`.

We seize the opportunity of this PR to also fix a superflous trailing newline.
