### PR TITLE
Define code owners for more CI files.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,8 +8,12 @@
 
 ########## CI infrastructure ##########
 
-/dev/ci/*.sh      @ejgallego
+/dev/ci/               @ejgallego
 # Secondary maintainer @SkySkimmer
+
+/dev/ci/user-overlays/*.sh @ghost
+# Trick to avoid getting review requests
+# each time someone adds an overlay
 
 /.circleci/       @SkySkimmer
 # Secondary maintainer @ejgallego
@@ -20,7 +24,9 @@
 /.gitlab-ci.yml   @SkySkimmer
 # Secondary maintainer @ejgallego
 
-/appveyor.yml    @maximedenes
+/appveyor.yml          @maximedenes
+/dev/ci/appveyor.*     @maximedenes
+/dev/ci/*.bat          @maximedenes
 # Secondary maintainer @SkySkimmer
 
 /default.nix     @Zimmi48


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** infrastructure.


This fix an issue which was noticed by @ejgallego in https://github.com/coq/coq/pull/7482#issuecomment-388546560.

This also anticipates the additions in #7344.