### PR TITLE
Pick up user overlays when running GitLab CI on PRs.

### DIFF
--- a/dev/ci/ci-common.sh
+++ b/dev/ci/ci-common.sh
@@ -10,6 +10,10 @@ if [ -n "${GITLAB_CI}" ];
 then
     export COQBIN="$PWD/_install_ci/bin"
     export CI_BRANCH="$CI_COMMIT_REF_NAME"
+    if [[ ${CI_BRANCH#pr-} =~ ^[0-9]*$ ]]
+    then
+        export CI_PULL_REQUEST="${CI_BRANCH#pr-}"
+    fi
 else
     if [ -n "${TRAVIS}" ];
     then


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** infrastructure.


I recently noticed that user-overlays were not picked up when running GitLab CI on PRs (because the branch name is `pr-NNNN` and the `CI_PULL_REQUEST` variable is not defined). This PR fixes this by finding the pull request number from the branch name and defining `CI_PULL_REQUEST`.