### PR TITLE
Add GitLab CI badge in first position.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Coq
 
+[![pipeline status](https://gitlab.com/coq/coq/badges/master/pipeline.svg)](https://gitlab.com/coq/coq/commits/master)
 [![Travis](https://travis-ci.org/coq/coq.svg?branch=master)](https://travis-ci.org/coq/coq/builds)
 [![Appveyor](https://ci.appveyor.com/api/projects/status/eln43k05pa2vm908/branch/master?svg=true)](https://ci.appveyor.com/project/coq/coq/branch/master)
 [![Circle CI](https://circleci.com/gh/coq/coq/tree/master.svg?style=shield)](https://circleci.com/gh/coq/workflows/coq/tree/master)


### PR DESCRIPTION
Note that I find the current number of badge a bit much.
I would like to remove CircleCI badge (simply because we can remove CircleCI).
I would also like to ensure that the Travis badge is more often green (by moving the redundant jobs to the allow failure category maybe). The only job left to care in Travis (on branches, where the linter is not run) is the macOS job.

Requesting @maximedenes' review as secondary code owner.