### PR TITLE
[windows] Don't build menhir and int anymore in the packaging scripts.

### DIFF
--- a/dev/build/windows/makecoq_mingw.sh
+++ b/dev/build/windows/makecoq_mingw.sh
@@ -847,7 +847,7 @@ function make_ocaml {
 
 function make_ocaml_tools {
   make_findlib
-  make_menhir
+  # make_menhir
   make_camlp5
 }
 
@@ -856,7 +856,7 @@ function make_ocaml_tools {
 function make_ocaml_libs {
   make_findlib
   make_lablgtk
-  make_stdint
+  # make_stdint
 }
 
 ##### FINDLIB Ocaml library manager #####


### PR DESCRIPTION
As pointed out by @MSoegtropIMC
[here](https://github.com/coq/coq/pull/7522#issuecomment-389478963)
there are not needed to build the packages, so not building them will
save a couple of minutes.
