### PR TITLE
Evarutil.finalize: combine minimize, to_constr and restrict.

### DIFF
--- a/engine/eConstr.mli
+++ b/engine/eConstr.mli
@@ -318,6 +318,9 @@ val of_rel_decl : (Constr.t, Constr.types) Context.Rel.Declaration.pt -> (t, typ
 
 val to_rel_decl : Evd.evar_map -> (t, types) Context.Rel.Declaration.pt -> (Constr.t, Constr.types) Context.Rel.Declaration.pt
 
+val map_rel_context_gen : (t -> Constr.t) ->
+  (t, types) Context.Rel.pt -> (Constr.t, Constr.types) Context.Rel.pt
+
 (** {5 Unsafe operations} *)
 
 module Unsafe :

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -50,6 +50,18 @@ let new_global evd x =
 (* Expanding/testing/exposing existential variables *)
 (****************************************************)
 
+let finalize ?abort_on_undefined_evars sigma f =
+  let sigma = minimize_universes sigma in
+  let uvars = ref Univ.LSet.empty in
+  let v = f (fun c ->
+      let varsc = EConstr.universes_of_constr sigma c in
+      let c = EConstr.to_constr ?abort_on_undefined_evars sigma c in
+      uvars := Univ.LSet.union !uvars varsc;
+      c)
+  in
+  let sigma = restrict_universe_context sigma !uvars in
+  sigma, v
+
 (* flush_and_check_evars fails if an existential is undefined *)
 
 exception Uninstantiated_evar of Evar.t

--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -181,6 +181,19 @@ val nf_evars_universes : evar_map -> Constr.constr -> Constr.constr
 exception Uninstantiated_evar of Evar.t
 val flush_and_check_evars :  evar_map -> constr -> Constr.constr
 
+(** [finalize env sigma f] combines universe minimisation,
+   evar-and-universe normalisation and universe restriction.
+
+    It minimizes universes in [sigma], calls [f] a normalisation
+   function with respect to the updated [sigma] and restricts the
+   local universes of [sigma] to those encountered while running [f].
+
+    Note that the normalizer passed to [f] holds some imperative state
+   in its closure. *)
+val finalize : ?abort_on_undefined_evars:bool -> evar_map ->
+  ((EConstr.t -> Constr.t) -> 'a) ->
+  evar_map * 'a
+
 (** {6 Term manipulation up to instantiation} *)
 
 (** Like {!Constr.kind} except that [kind_of_term sigma t] exposes [t]

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -1381,5 +1381,5 @@ module MiniEConstr = struct
   let of_rel_decl d = d
   let unsafe_to_rel_decl d = d
   let to_rel_decl sigma d = Context.Rel.Declaration.map_constr (to_constr sigma) d
-
+  let map_rel_context_gen = Context.Rel.map
 end

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -703,4 +703,6 @@ module MiniEConstr : sig
     (t, t) Context.Rel.Declaration.pt
   val to_rel_decl : evar_map -> (t, t) Context.Rel.Declaration.pt ->
     (Constr.t, Constr.types) Context.Rel.Declaration.pt
+  val map_rel_context_gen : (t -> Constr.t) ->
+    (t, t) Context.Rel.pt -> (Constr.t, Constr.t) Context.Rel.pt
 end

--- a/vernac/comAssumption.ml
+++ b/vernac/comAssumption.ml
@@ -158,15 +158,9 @@ let do_assumptions kind nl l =
   in
   let sigma = solve_remaining_evars all_and_fail_flags env sigma (Evd.from_env env) in
   (* The universe constraints come from the whole telescope. *)
-  let sigma = Evd.minimize_universes sigma in
-  let nf_evar c = EConstr.to_constr sigma c in
-  let uvars, l = List.fold_left_map (fun uvars (coe,t,imps) ->
-      let t = nf_evar t in
-      let uvars = Univ.LSet.union uvars (Vars.universes_of_constr t) in
-      uvars, (coe,t,imps))
-      Univ.LSet.empty l
+  let sigma, l = Evarutil.finalize ~abort_on_undefined_evars:false sigma
+      (fun nf -> List.map (fun (coe,t,imps) -> coe,nf t,imps) l)
   in
-  let sigma = Evd.restrict_universe_context sigma uvars in
   let uctx = Evd.check_univ_decl ~poly:(pi2 kind) sigma udecl in
   let ubinders = Evd.universe_binders sigma in
   pi2 (List.fold_left (fun (subst,status,uctx) ((is_coe,idl),t,imps) ->

--- a/vernac/comDefinition.ml
+++ b/vernac/comDefinition.ml
@@ -42,7 +42,6 @@ let check_imps ~impsty ~impsbody =
   if not b then warn_implicits_in_term ()
 
 let interp_definition pl bl poly red_option c ctypopt =
-  let open EConstr in
   let env = Global.env() in
   (* Explicitly bound universes and constraints *)
   let evd, decl = Constrexpr_ops.interp_univ_decl_opt env pl in
@@ -67,18 +66,13 @@ let interp_definition pl bl poly red_option c ctypopt =
   (* Do the reduction *)
   let evd, c = red_constant_body red_option env_bl evd c in
   (* universe minimization *)
-  let evd = Evd.minimize_universes evd in
-  (* Substitute evars and universes, and add parameters.
-     Note: in program mode some evars may remain. *)
-  let ctx = List.map Termops.(map_rel_decl (to_constr ~abort_on_undefined_evars:false evd)) ctx in
-  let c = Term.it_mkLambda_or_LetIn (EConstr.to_constr ~abort_on_undefined_evars:false evd c) ctx in
-  let tyopt = Option.map (fun ty -> Term.it_mkProd_or_LetIn (EConstr.to_constr ~abort_on_undefined_evars:false evd ty) ctx) tyopt in
-  (* Keep only useful universes. *)
-  let uvars_fold uvars c =
-    Univ.LSet.union uvars (universes_of_constr evd (of_constr c))
+  let evd, (ctx, c, tyopt) =
+    (* NB: in program mode evars may remain *)
+    Evarutil.finalize ~abort_on_undefined_evars:false evd
+      (fun nf -> List.map Termops.(map_rel_decl nf) ctx, nf c, Option.map nf tyopt)
   in
-  let uvars = List.fold_left uvars_fold Univ.LSet.empty (Option.List.cons tyopt [c]) in
-  let evd = Evd.restrict_universe_context evd uvars in
+  let c = Term.it_mkLambda_or_LetIn c ctx in
+  let tyopt = Option.map (fun ty -> Term.it_mkProd_or_LetIn ty ctx) tyopt in
   (* Check we conform to declared universes *)
   let uctx = Evd.check_univ_decl ~poly evd decl in
   (* We're done! *)

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -176,19 +176,22 @@ let typecheck_params_and_fields finite def poly pl ps records =
         else sigma, typ
   in
   let (sigma, typs) = List.fold_left2_map fold sigma typs data in
-  let sigma = Evd.minimize_universes sigma in
-  let newps = List.map (EConstr.to_rel_decl sigma) newps in
+  let ce t = Pretyping.check_evars env0 (Evd.from_env env0) sigma t in
+  let () = List.iter (iter_constr ce) (List.rev newps) in
+  let () = List.iter (fun (_, newfs) -> List.iter (iter_constr ce) (List.rev newfs)) data in
+  let sigma, (newps, ans) =
+    Evarutil.finalize sigma (fun nf ->
+        let newps = EConstr.map_rel_context_gen nf newps in
+        let map (impls, newfs) typ =
+          let newfs = EConstr.map_rel_context_gen nf newfs in
+          let typ = nf typ in
+          (typ, impls, newfs)
+        in
+        let ans = List.map2 map data typs in
+        newps, ans)
+  in
   let univs = Evd.check_univ_decl ~poly sigma decl in
   let ubinders = Evd.universe_binders sigma in
-  let ce t = Pretyping.check_evars env0 (Evd.from_env env0) sigma (EConstr.of_constr t) in
-  let () = List.iter (iter_constr ce) (List.rev newps) in
-  let map (impls, newfs) typ =
-    let newfs = List.map (EConstr.to_rel_decl sigma) newfs in
-    let typ = EConstr.to_constr sigma typ in
-    List.iter (iter_constr ce) (List.rev newfs);
-    (typ, impls, newfs)
-  in
-  let ans = List.map2 map data typs in
   ubinders, univs, template, newps, imps, ans
 
 type record_error =


### PR DESCRIPTION
I finally figured out how to get the univ variables for variable numbers of constrs (for universe restriction) in a sensible way, leading to this combination. See diff for what it looks like in practice.

cc @ybertot 

If you look at the context of the changes you may notice some
Pretyping.check_evars calls. This is in some way redundant with
to_constr's abort_on_undefined_evars, and is sometimes called after
a non-evar-permissive to_constr (indicating a probable bug introduced
by the abort flag).

I didn't fix any of those, leaving the order as-is. It should be done
in a separate PR, but we may want to consider how to deal with the
redundancy in a more principled manner. Maybe to_constr should be
raising a sensible error, not an anomaly? There is also
flush_and_check_evars which is used only once.
