### PR TITLE
Deprecate positive coinductive types

### DIFF
--- a/doc/sphinx/changes.rst
+++ b/doc/sphinx/changes.rst
@@ -806,6 +806,11 @@ Details of changes in 8.9+beta1
 Kernel
 
 - Mutually defined records are now supported.
+- Positive coinductive types, i.e. the ones defined by a list of constructors,
+  are now deprecated. They were a source of loss of subject reduction in CIC.
+  It is now advised to use their negative counterparts instead, that is, by
+  setting the "Primitive Projections" flag and defining them as records with
+  projections.
 
 Notations
 

--- a/doc/sphinx/language/gallina-specification-language.rst
+++ b/doc/sphinx/language/gallina-specification-language.rst
@@ -1173,7 +1173,8 @@ equality:
    Axiom Stream_ext : forall (s1 s2: Stream), EqSt s1 s2 -> s1 = s2.
 
 As of Coq 8.9, it is now advised to use negative co-inductive types rather than
-their positive counterparts.
+their positive counterparts. As such, the latter are deprecated and their
+support is expected to be discontinued in a future version of Coq.
 
 .. seealso::
    :ref:`primitive_projections` for more information about negative

--- a/test-suite/bugs/closed/bug_2319.v
+++ b/test-suite/bugs/closed/bug_2319.v
@@ -1,6 +1,7 @@
 Section S.
 
-  CoInductive A (X: Type) := mkA: A X -> A X.
+  Set Primitive Projections.
+  CoInductive A (X: Type) := mkA { a : A X }.
   Variable T : Type.
 
   (* This used to loop (bug #2319) *)

--- a/test-suite/bugs/closed/bug_4375.v
+++ b/test-suite/bugs/closed/bug_4375.v
@@ -89,8 +89,8 @@ Print a.
 Print b.
 *)
 
-Polymorphic CoInductive foo@{i} (T : Type@{i}) : Type@{i} :=
-| A : foo T -> foo T.
+Set Primitive Projections.
+Polymorphic CoInductive foo@{i} (T : Type@{i}) : Type@{i} := A { a : foo T }.
 
 Polymorphic CoFixpoint cg@{i} (t : Type@{i}) : foo@{i} t :=
   @A@{i} t (cg t).

--- a/test-suite/bugs/closed/bug_5215.v
+++ b/test-suite/bugs/closed/bug_5215.v
@@ -256,10 +256,7 @@ Definition S_nat_func : Functor Type_Cat Type_Cat :=
 
 Definition S_nat_alg_cat := Algebra_Cat S_nat_func.
 
-CoInductive CoNat : Set :=
-  | CoO : CoNat
-  | CoS : CoNat -> CoNat
-.
+CoInductive CoNat : Set := { coNat : option CoNat }.
 
 Definition S_nat_coalg_cat := @CoAlgebra_Cat Type_Cat S_nat_func.
 

--- a/test-suite/failure/cofixpoint.v
+++ b/test-suite/failure/cofixpoint.v
@@ -1,9 +1,10 @@
 (* A bug in the guard checking of nested cofixpoints. *)
 (* Posted by Maxime Dénès on coqdev (Apr 9, 2014).    *)
 
-CoInductive CoFalse := .
+Set Primitive Projections.
+CoInductive CoFalse := { coFalse : False }.
 
-CoInductive CoTrue := I.
+CoInductive CoTrue := { coTrue : True }.
 
 Fail CoFixpoint loop : CoFalse :=
   (cofix f := loop with g := loop for f).

--- a/test-suite/failure/guard_cofix.v
+++ b/test-suite/failure/guard_cofix.v
@@ -5,9 +5,10 @@ subterm3.v). Posted on Coq-club by Maxime Dénès (02/26/2014). *)
 
 (* First example *)
 
-CoInductive CoFalse : Prop := CF : CoFalse -> False -> CoFalse.
+Set Primitive Projections.
+CoInductive CoFalse : Prop := CF { cL : CoFalse; cR : False }.
 
-CoInductive Pandora : Prop := C : CoFalse -> Pandora.
+CoInductive Pandora : Prop := C { c : CoFalse }.
 
 Axiom prop_ext : forall P Q : Prop, (P<->Q) -> P = Q.
 
@@ -31,7 +32,7 @@ Lemma H : omega = CoFalse.
 Proof.
 apply prop_ext; constructor.
   induction 1; assumption.
-destruct 1; destruct H0.
+destruct 1; destruct cR0.
 Qed.
 
 Fail CoFixpoint loop' : CoFalse :=

--- a/test-suite/modules/errors.v
+++ b/test-suite/modules/errors.v
@@ -34,10 +34,10 @@ Module MA6 : SA6. Inductive TA6 (A B:Type):= CA6 : A -> TA6 A B. Fail End MA6.
 Reset Initial.
 
 Module Type SA7. Inductive TA7 (A:Type) := CA7 : A -> TA7 A. End SA7.
-Module MA7 : SA7. CoInductive TA7 (A:Type):= CA7 : A -> TA7 A. Fail End MA7.
+Module MA7 : SA7. Set Primitive Projections. CoInductive TA7 (A:Type):= CA7 { ca7 : A -> TA7 A }. Unset Primitive Projections. Fail End MA7.
 Reset Initial.
 
-Module Type SA8. CoInductive TA8 (A:Type) := CA8 : A -> TA8 A. End SA8.
+Module Type SA8. Set Primitive Projections. CoInductive TA8 (A:Type) := CA8 { ca8 : A -> TA8 A }. Unset Primitive Projections. End SA8.
 Module MA8 : SA8. Inductive TA8 (A:Type):= CA8 : A -> TA8 A. Fail End MA8.
 Reset Initial.
 

--- a/test-suite/output/Fixpoint.v
+++ b/test-suite/output/Fixpoint.v
@@ -44,7 +44,9 @@ fix even_pos_odd_pos 2 with (odd_pos_even_pos n (H:odd n) {struct H} : n >= 1).
   omega.
 Qed.
 
+Set Primitive Projections.
 CoInductive Inf := S { projS : Inf }.
+Unset Primitive Projections.
 Definition expand_Inf (x : Inf) := S (projS x).
 CoFixpoint inf := S inf.
 Eval compute in inf.

--- a/test-suite/prerequisite/ssr_mini_mathcomp.v
+++ b/test-suite/prerequisite/ssr_mini_mathcomp.v
@@ -196,7 +196,7 @@ Definition clone_subType U v :=
 
 Variable sT : subType.
 
-CoInductive Sub_spec : sT -> Type := SubSpec x Px : Sub_spec (Sub x Px).
+Variant Sub_spec : sT -> Type := SubSpec x Px : Sub_spec (Sub x Px).
 
 Lemma SubP u : Sub_spec u.
 Proof. by case: sT Sub_spec SubSpec u => T' _ C rec /= _. Qed.
@@ -209,7 +209,7 @@ Definition insub x :=
 
 Definition insubd u0 x := odflt u0 (insub x).
 
-CoInductive insub_spec x : option sT -> Type :=
+Variant insub_spec x : option sT -> Type :=
   | InsubSome u of P x & val u = x : insub_spec x (Some u)
   | InsubNone   of ~~ P x          : insub_spec x None.
 
@@ -568,7 +568,7 @@ Fixpoint nth s n {struct n} :=
 
 Fixpoint rcons s z := if s is x :: s' then x :: rcons s' z else [:: z].
 
-CoInductive last_spec : seq T -> Type :=
+Variant last_spec : seq T -> Type :=
   | LastNil        : last_spec [::]
   | LastRcons s x  : last_spec (rcons s x).
 
@@ -1292,7 +1292,7 @@ Open Scope big_scope.
 (* packages both in in a term in which i occurs; it also depends on the       *)
 (* iterated <op>, as this can give more information on the expected type of   *)
 (* the <general_term>, thus allowing for the insertion of coercions.          *)
-CoInductive bigbody R I := BigBody of I & (R -> R -> R) & bool & R.
+Variant bigbody R I := BigBody of I & (R -> R -> R) & bool & R.
 
 Definition applybig {R I} (body : bigbody R I) x :=
   let: BigBody _ op b v := body in if b then op v x else x.

--- a/test-suite/success/Cases.v
+++ b/test-suite/success/Cases.v
@@ -1211,11 +1211,14 @@ Type
   end.
 
 
-
-CoInductive SStream (A : Set) : (nat -> A -> Prop) -> Type :=
-    scons :
-      forall (P : nat -> A -> Prop) (a : A),
-      P 0 a -> SStream A (fun n : nat => P (S n)) -> SStream A P.
+Set Primitive Projections.
+CoInductive SStream (A : Set) (P : nat -> A -> Prop) : Type :=
+    scons {
+      SStream_a : A;
+      SStream_hd : P 0 SStream_a;
+      SStream_tl : SStream A (fun n : nat => P (S n));
+    }.
+Unset Primitive Projections.
 Parameter B : Set.
 
 Type

--- a/test-suite/success/Fixpoint.v
+++ b/test-suite/success/Fixpoint.v
@@ -11,23 +11,28 @@ Fixpoint f (n:nat) (m:=pred n) (l:listn m) (p:=S n) {struct l} : nat :=
 
 Eval compute in (f 2 (consn 0 0 niln)).
 
-CoInductive Stream : nat -> Set :=
-  Consn : forall n, nat -> Stream n -> Stream (S n).
+Set Primitive Projections.
+CoInductive Stream (n : nat) : Set :=
+  Consn {
+    Stream_hd : nat;
+    Stream_tl : Stream (pred n);
+    Stream_eq : 0 <> n;
+  }.
 
 CoFixpoint g (n:nat) (m:=pred n) (l:Stream m) (p:=S n) : Stream p :=
     match n return (let m:=pred n in forall l:Stream m, let p:=S n in Stream p)
     with
-    | O => fun l:Stream 0 => Consn O 0 l
+    | O => fun l:Stream 0 => Consn (S O) 0 l (O_S 0)
     | S n' =>
       fun l:Stream n' =>
       let l' :=
-        match l in Stream q return Stream (pred q) with Consn _ _ l => l end
+        match l in Stream _ return Stream _ with Consn _ _ l _ => l end
       in
-      let a := match l with Consn _ a l => a end in
-      Consn (S n') (S a) (g n' l')
+      let a := match l with Consn _ a l _ => a end in
+      Consn (S (S n')) (S a) (g n' l') (O_S (S n'))
    end l.
 
-Eval compute in (fun l => match g 2 (Consn 0 6 l) with Consn _ a _ => a end).
+Eval compute in (fun l => match g 2 (Consn (S 0) 6 l (O_S 0)) with Consn _ a _ _ => a end).
 
 (* Check inference of simple types in presence of non ambiguous
    dependencies (needs revision 10125) *)

--- a/test-suite/success/Inductive.v
+++ b/test-suite/success/Inductive.v
@@ -67,9 +67,11 @@ Check (fun x:I1 =>
 Set Implicit Arguments.
 Unset Strict Implicit.
 
-CoInductive LList (A : Set) : Set :=
-  | LNil : LList A
-  | LCons : A -> LList A -> LList A.
+Set Primitive Projections.
+
+CoInductive LList (A : Set) : Set := { llist : option (prod A (LList A)) }.
+Definition LNil A := @Build_LList A None.
+Definition LCons A x l := @Build_LList A (Some (pair x l)).
 
 Arguments LNil [A].
 

--- a/theories/Classes/CMorphisms.v
+++ b/theories/Classes/CMorphisms.v
@@ -227,7 +227,7 @@ Ltac subrelation_tac T U :=
 
 Hint Extern 3 (@subrelation _ ?T ?U) => subrelation_tac T U : typeclass_instances.
 
-CoInductive apply_subrelation : Prop := do_subrelation.
+Variant apply_subrelation : Prop := do_subrelation.
 
 Ltac proper_subrelation :=
   match goal with
@@ -454,7 +454,7 @@ End GenericInstances.
 
 Class PartialApplication.
 
-CoInductive normalization_done : Prop := did_normalization.
+Variant normalization_done : Prop := did_normalization.
 
 Ltac partial_application_tactic :=
   let rec do_partial_apps H m cont := 

--- a/theories/Classes/Morphisms.v
+++ b/theories/Classes/Morphisms.v
@@ -225,7 +225,7 @@ Ltac subrelation_tac T U :=
 
 Hint Extern 3 (@subrelation _ ?T ?U) => subrelation_tac T U : typeclass_instances.
 
-CoInductive apply_subrelation : Prop := do_subrelation.
+Variant apply_subrelation : Prop := do_subrelation.
 
 Ltac proper_subrelation :=
   match goal with
@@ -461,7 +461,7 @@ End GenericInstances.
 
 Class PartialApplication.
 
-CoInductive normalization_done : Prop := did_normalization.
+Variant normalization_done : Prop := did_normalization.
 
 Class Params {A : Type} (of : A) (arity : nat).
 

--- a/theories/Lists/StreamMemo.v
+++ b/theories/Lists/StreamMemo.v
@@ -35,7 +35,7 @@ Theorem memo_get_correct: forall n, memo_get n memo_list = f n.
 Proof.
 assert (F1: forall n m, memo_get n (memo_make m) = f (n + m)).
 { induction n as [| n Hrec]; try (intros m; reflexivity).
-  intros m; cbn; rewrite Hrec.
+  intros m; simpl; rewrite Hrec.
   rewrite plus_n_Sm; auto. }
 intros n; transitivity (f (n + 0)); try exact (F1 n 0).
 rewrite <- plus_n_O; auto.
@@ -61,7 +61,7 @@ Theorem imemo_get_correct: forall n, memo_get n imemo_list = f n.
 Proof.
 assert (F1: forall n m, memo_get n (imemo_make (f m)) = f (S (n + m))).
 { induction n as [| n Hrec]; try (intros m; exact (eq_sym (Hg_correct m))).
-  cbn; intros m; rewrite <- Hg_correct, Hrec, <- plus_n_Sm; auto. }
+  simpl; intros m; rewrite <- Hg_correct, Hrec, <- plus_n_Sm; auto. }
 destruct n as [| n]; try reflexivity.
 unfold imemo_list; simpl; rewrite F1.
 rewrite <- plus_n_O; auto.

--- a/theories/Lists/StreamMemo.v
+++ b/theories/Lists/StreamMemo.v
@@ -35,7 +35,7 @@ Theorem memo_get_correct: forall n, memo_get n memo_list = f n.
 Proof.
 assert (F1: forall n m, memo_get n (memo_make m) = f (n + m)).
 { induction n as [| n Hrec]; try (intros m; reflexivity).
-  intros m; simpl; rewrite Hrec.
+  intros m; cbn; rewrite Hrec.
   rewrite plus_n_Sm; auto. }
 intros n; transitivity (f (n + 0)); try exact (F1 n 0).
 rewrite <- plus_n_O; auto.
@@ -61,7 +61,7 @@ Theorem imemo_get_correct: forall n, memo_get n imemo_list = f n.
 Proof.
 assert (F1: forall n m, memo_get n (imemo_make (f m)) = f (S (n + m))).
 { induction n as [| n Hrec]; try (intros m; exact (eq_sym (Hg_correct m))).
-  simpl; intros m; rewrite <- Hg_correct, Hrec, <- plus_n_Sm; auto. }
+  cbn; intros m; rewrite <- Hg_correct, Hrec, <- plus_n_Sm; auto. }
 destruct n as [| n]; try reflexivity.
 unfold imemo_list; simpl; rewrite F1.
 rewrite <- plus_n_O; auto.

--- a/theories/Lists/Streams.v
+++ b/theories/Lists/Streams.v
@@ -9,17 +9,26 @@
 (************************************************************************)
 
 Set Implicit Arguments.
-Set Primitive Projections.
+
+Set Warnings "-deprecated-positive-coinductive".
 
 (** Streams *)
 
 CoInductive Stream (A : Type) :=
-  Cons { hd : A; tl : Stream A }.
+  Cons : A -> Stream A -> Stream A.
 
 Section Streams.
   Variable A : Type.
 
   Notation Stream := (Stream A).
+
+Definition hd (x:Stream) := match x with
+                            | Cons a _ => a
+                            end.
+
+Definition tl (x:Stream) := match x with
+                            | Cons _ s => s
+                            end.
 
 Fixpoint Str_nth_tl (n:nat) (s:Stream) : Stream :=
   match n with
@@ -28,6 +37,17 @@ Fixpoint Str_nth_tl (n:nat) (s:Stream) : Stream :=
   end.
 
 Definition Str_nth (n:nat) (s:Stream) : A := hd (Str_nth_tl n s).
+
+
+Lemma unfold_Stream :
+ forall x:Stream, x = match x with
+                      | Cons a s => Cons a s
+                      end.
+Proof.
+  intro x.
+  case x.
+  trivial.
+Qed.
 
 Lemma tl_nth_tl :
  forall (n:nat) (s:Stream), tl (Str_nth_tl n s) = Str_nth_tl n (tl s).
@@ -39,7 +59,6 @@ Hint Resolve tl_nth_tl: datatypes.
 Lemma Str_nth_tl_plus :
  forall (n m:nat) (s:Stream),
    Str_nth_tl n (Str_nth_tl m s) = Str_nth_tl (n + m) s.
-Proof.
 simple induction n; simpl; intros; auto with datatypes.
 rewrite <- H.
 rewrite tl_nth_tl; trivial with datatypes.
@@ -47,17 +66,15 @@ Qed.
 
 Lemma Str_nth_plus :
  forall (n m:nat) (s:Stream), Str_nth n (Str_nth_tl m s) = Str_nth (n + m) s.
-Proof.
 intros; unfold Str_nth; rewrite Str_nth_tl_plus;
  trivial with datatypes.
 Qed.
 
 (** Extensional Equality between two streams  *)
 
-CoInductive EqSt (s1 s2: Stream) : Prop := eqst {
-  eqst_hd : hd s1 = hd s2;
-  eqst_tl : EqSt (tl s1) (tl s2);
-}.
+CoInductive EqSt (s1 s2: Stream) : Prop :=
+    eqst :
+        hd s1 = hd s2 -> EqSt (tl s1) (tl s2) -> EqSt s1 s2.
 
 (** A coinduction principle *)
 
@@ -69,13 +86,11 @@ Ltac coinduction proof :=
 (** Extensional equality is an equivalence relation *)
 
 Theorem EqSt_reflex : forall s:Stream, EqSt s s.
-Proof.
 coinduction EqSt_reflex.
 reflexivity.
 Qed.
 
 Theorem sym_EqSt : forall s1 s2:Stream, EqSt s1 s2 -> EqSt s2 s1.
-Proof.
 coinduction Eq_sym.
 + case H; intros; symmetry ; assumption.
 + case H; intros; assumption.
@@ -84,7 +99,6 @@ Qed.
 
 Theorem trans_EqSt :
  forall s1 s2 s3:Stream, EqSt s1 s2 -> EqSt s2 s3 -> EqSt s1 s3.
-Proof.
 coinduction Eq_trans.
 - transitivity (hd s2).
   + case H; intros; assumption.
@@ -99,7 +113,6 @@ Qed.
 
 Theorem eqst_ntheq :
  forall (n:nat) (s1 s2:Stream), EqSt s1 s2 -> Str_nth n s1 = Str_nth n s2.
-Proof.
 unfold Str_nth; simple induction n.
 - intros s1 s2 H; case H; trivial with datatypes.
 - intros m hypind.
@@ -112,7 +125,6 @@ Qed.
 Theorem ntheq_eqst :
  forall s1 s2:Stream,
    (forall n:nat, Str_nth n s1 = Str_nth n s2) -> EqSt s1 s2.
-Proof.
 coinduction Equiv2.
 - apply (H 0).
 - intros n; apply (H (S n)).
@@ -133,7 +145,7 @@ Inductive Exists ( x: Stream ) : Prop :=
   | Further : Exists (tl x) -> Exists x.
 
 CoInductive ForAll (x: Stream) : Prop :=
-    HereAndFurther { Forall_here : P x; Forall_further : ForAll (tl x) }.
+    HereAndFurther : P x -> ForAll (tl x) -> ForAll x.
 
 Lemma ForAll_Str_nth_tl : forall m x, ForAll x -> ForAll (Str_nth_tl m x).
 Proof.
@@ -151,7 +163,6 @@ Hypothesis InvThenP : forall x:Stream, Inv x -> P x.
 Hypothesis InvIsStable : forall x:Stream, Inv x -> Inv (tl x).
 
 Theorem ForAll_coind : forall x:Stream, Inv x -> ForAll x.
-Proof.
 coinduction ForAll_coind; auto.
 Qed.
 End Co_Induction_ForAll.
@@ -171,7 +182,6 @@ induction n.
 - reflexivity.
 - simpl.
   intros s.
-  cbn.
   apply IHn.
 Qed.
 
@@ -219,8 +229,7 @@ Lemma Str_nth_tl_zipWith : forall n (a:Stream A) (b:Stream B),
 Proof.
 induction n.
 - reflexivity.
-- cbn.
-  intros ? ?.
+- intros [x xs] [y ys].
   unfold Str_nth in *.
   simpl in *.
   apply IHn.


### PR DESCRIPTION
Adding a warning when declaring positive coinductive types.

Such types a fundamentally wrong and are known to break subject reduction of CIC. We advertise for the use of negative coinductive types instead, i.e. defined by means of primitive records.

Due to the fact that the kernel is currently unable to handle mutually corecursive negative records, we currently only produce the warning on coinductive types which only made of one block, which is the vast majority of the uses. When this is solved, the warning needs to be adapted accordingly.

We adapted the standard library and tests to use primitive corecursive records.

Most of the changes are actually due to the Coq "design pattern" that CoInductive types do not generate induction schemes.

The only part of the stdlib that was really using them is the Stream library, which is probably not much used in the wild.

Depending on the case, tests were either adapted, or removed if they were made moot by the transition, e.g. if they relied on properties not holding with negative coinductive types.

This was documented both in the Coq reference manual and in the CHANGES.
