### PR TITLE
gitlab windows: do not make artifacts

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -154,12 +154,6 @@ before_script:
 
 .windows-template: &windows-template
   stage: test
-  artifacts:
-    name: "%CI_JOB_NAME%"
-    paths:
-      - dev\nsis\*.exe
-      - coq-opensource-archive-windows-*.zip
-    expire_in: 1 week
   dependencies: []
   tags:
     - windows

--- a/dev/ci/gitlab.bat
+++ b/dev/ci/gitlab.bat
@@ -26,22 +26,10 @@ if exist %CYGROOT%\build\ rd /s /q %CYGROOT%\build
 if exist %DESTCOQ%\ rd /s /q %DESTCOQ%
 
 call %CI_PROJECT_DIR%\dev\build\windows\MakeCoq_MinGW.bat -threads=1 ^
-  -arch=%ARCH% -installer=Y -coqver=%CI_PROJECT_DIR_CFMT% ^
+  -arch=%ARCH% -coqver=%CI_PROJECT_DIR_CFMT% ^
   -destcyg=%CYGROOT% -destcoq=%DESTCOQ% -cygcache=%CYGCACHE% ^
   -addon=bignums -make=N ^
   -setup %CI_PROJECT_DIR%\%SETUP% || GOTO ErrorExit
-
-copy "%CYGROOT%\build\coq-local\dev\nsis\*.exe" dev\nsis || GOTO ErrorExit
-7z a coq-opensource-archive-windows-%ARCHLONG%.zip %CYGROOT%\build\tarballs\* || GOTO ErrorExit
-
-REM DO NOT echo the signing command below, as this would leak secrets in the logs
-IF DEFINED WIN_CERTIFICATE_PATH (
-  IF DEFINED WIN_CERTIFICATE_PASSWORD (
-    ECHO Signing package
-    @signtool sign /f %WIN_CERTIFICATE_PATH% /p %WIN_CERTIFICATE_PASSWORD% dev\nsis\*.exe
-    signtool verify /pa dev\nsis\*.exe
-  )
-)
 
 GOTO :EOF
 


### PR DESCRIPTION
- the runners are insecure
- (the real reason) I want to see if it's significantly faster
