### PR TITLE
Backport all recent changes in CI to v8.8.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,134 +8,68 @@ defaults:
     # reference syntax)
     working_directory: ~/coq
     docker:
-      - image: ocaml/opam:ubuntu
+      - image: $CI_REGISTRY_IMAGE:$CACHEKEY
 
   environment: &envvars
-    # required by some of the targets, e.g. compcert, passed for
-    # instance to opam to configure the number of parallel jobs
-    # allowed
-    NJOBS: 2
-    COMPILER: "system"
-    CAMLP5_VER: "6.14"
-    NATIVE_COMP: "yes"
-
-    # some useful values
-    TIMING_PACKAGES: &timing-packages "time python"
+    CACHEKEY: "bionic_coq-v8.8-V2018-05-17"
+    CI_REGISTRY_IMAGE: registry.gitlab.com/coq/coq
 
 version: 2
 
 before_script: &before_script
-  name: Install system packages
+  name: Setup OPAM Switch
   command: |
     echo export TERM=xterm >> ~/.profile
     source ~/.profile
-    printenv
-    if [ -n "${EXTRA_PACKAGES}" ]; then sudo apt-get update -yq && sudo apt-get install -yq --no-install-recommends ${EXTRA_PACKAGES}; fi
-
-opam-switch: &opam-switch
-  name: Select opam switch
-  command: |
-    source ~/.profile
-    opam switch ${COMPILER}
+    echo . ~/.profile >> $BASH_ENV
+    printenv | sort
+    opam switch "$COMPILER"
     opam config list
     opam list
-
-.opam-boot-template: &opam-boot-template
-  <<: *params
-  steps:
-    - checkout
-    - run: *before_script
-    - run:
-        name: Cache selection
-        command: |
-          source ~/.profile
-          # We can't use environment variables in cache names
-          # So put it in a file and use the checksum
-          echo "$COMPILER" > COMPILER
-    - restore_cache:
-        keys:
-          - coq-opam-cache-v1-{{ arch }}-{{ checksum "COMPILER" }}-{{ checksum ".circleci/config.yml" }}-
-          - coq-opam-cache-v1-{{ arch }}-{{ checksum "COMPILER" }}- # this grabs old cache if checksum doesn't match
-    - run:
-        name: Update opam lists
-        command: |
-          source ~/.profile
-          opam repository set-url default https://opam.ocaml.org
-          opam update
-    - run:
-        name: Install opam packages
-        command: |
-          source ~/.profile
-          opam switch -j ${NJOBS} ${COMPILER}
-          opam install -j ${NJOBS} -y camlp5.${CAMLP5_VER} ocamlfind ${EXTRA_OPAM}
-    - run:
-        name: Clean cache
-        command: |
-          source ~/.profile
-          rm -rf ~/.opam/log/
-    - save_cache:
-        key: coq-opam-cache-v1-{{ arch }}-{{ checksum "COMPILER" }}-{{ checksum ".circleci/config.yml" }}-
-        paths:
-          - ~/.opam
-    - persist_to_workspace:
-        root: &workspace ~/
-        paths:
-          - .opam/
 
 .build-template: &build-template
   <<: *params
   steps:
     - checkout
     - run: *before_script
-    - attach_workspace: &attach_workspace
-        at: *workspace
-    - run: *opam-switch
     - run: &build-configure
         name: Configure
         command: |
-          source ~/.profile
-
           ./configure -local -native-compiler ${NATIVE_COMP} -coqide no
     - run: &build-build
         name: Build
         command: |
-          source ~/.profile
           make -j ${NJOBS} byte
           make -j ${NJOBS}
           make test-suite/misc/universes/all_stdlib.v
     - persist_to_workspace:
-        root: *workspace
+        root: &workspace ~/
         paths:
           - coq/
 
-  environment: *envvars
+  environment:
+    <<: *envvars
+    NATIVE_COMP: "yes"
 
 .ci-template: &ci-template
   <<: *params
   steps:
     - run: *before_script
-    - attach_workspace: *attach_workspace
+    - attach_workspace: &attach_workspace
+        at: *workspace
+
     - run:
         name: Test
         command: |
-          source ~/.profile
           dev/ci/ci-wrapper.sh ${CIRCLE_JOB}
     - persist_to_workspace:
         root: *workspace
         paths:
           - coq/
-  environment: &ci-template-vars
-    <<: *envvars
-    EXTRA_PACKAGES: *timing-packages
+  environment: *envvars
 
 # Defines individual jobs, see the workflows section below for job orchestration
 jobs:
-
-  opam-boot:
-    <<: *opam-boot-template
-    environment:
-      <<: *envvars
-      EXTRA_OPAM: "ocamlgraph ppx_tools_versioned ppx_deriving ocaml-migrate-parsetree"
 
   # Build and prepare test environment
   build: *build-template
@@ -145,24 +79,15 @@ jobs:
 
   color:
     <<: *ci-template
-    environment:
-      <<: *ci-template-vars
-      EXTRA_PACKAGES: *timing-packages
 
   compcert:
     <<: *ci-template
 
   coq-dpdgraph:
     <<: *ci-template
-    environment:
-      <<: *ci-template-vars
-      EXTRA_PACKAGES: "time python autoconf automake"
 
   coquelicot:
     <<: *ci-template
-    environment:
-      <<: *ci-template-vars
-      EXTRA_PACKAGES: "time python autoconf automake"
 
   elpi:
     <<: *ci-template
@@ -181,15 +106,9 @@ jobs:
 
   fiat-parsers:
     <<: *ci-template
-    environment:
-      <<: *ci-template-vars
-      EXTRA_PACKAGES: *timing-packages
 
   flocq:
     <<: *ci-template
-    environment:
-      <<: *ci-template-vars
-      EXTRA_PACKAGES: "time python autoconf automake"
 
   math-classes:
     <<: *ci-template
@@ -202,9 +121,6 @@ jobs:
 
   hott:
     <<: *ci-template
-    environment:
-      <<: *ci-template-vars
-      EXTRA_PACKAGES: "time python autoconf automake"
 
   iris-lambda-rust:
     <<: *ci-template
@@ -217,9 +133,6 @@ jobs:
 
   sf:
     <<: *ci-template
-    environment:
-      <<: *ci-template-vars
-      EXTRA_PACKAGES: "time python wget"
 
   unimath:
     <<: *ci-template
@@ -229,14 +142,11 @@ jobs:
 
 workflows:
   version: 2
+
   # Run on each push
   main:
     jobs:
-      - opam-boot
-
-      - build:
-          requires:
-            - opam-boot
+      - build
 
       - bignums: &req-main
           requires:
@@ -245,16 +155,16 @@ workflows:
           requires:
             - build
             - bignums
-      - compcert: *req-main
-      - coq-dpdgraph: *req-main
-      - coquelicot: *req-main
-      - elpi: *req-main
-      - equations: *req-main
-      - geocoq: *req-main
-      - fcsl-pcm: *req-main
-      - fiat-crypto: *req-main
-      - fiat-parsers: *req-main
-      - flocq: *req-main
+      # - compcert: *req-main
+      # - coq-dpdgraph: *req-main
+      # - coquelicot: *req-main
+      # - elpi: *req-main
+      # - equations: *req-main
+      # - geocoq: *req-main
+      # - fcsl-pcm: *req-main
+      # - fiat-crypto: *req-main
+      # - fiat-parsers: *req-main
+      # - flocq: *req-main
       - math-classes:
           requires:
             - build
@@ -267,10 +177,10 @@ workflows:
           requires:
             - build
             - corn
-      - hott: *req-main
-      - iris-lambda-rust: *req-main
-      - ltac2: *req-main
-      - math-comp: *req-main
-      - sf: *req-main
-      - unimath: *req-main
-      - vst: *req-main
+      # - hott: *req-main
+      # - iris-lambda-rust: *req-main
+      # - ltac2: *req-main
+      # - math-comp: *req-main
+      # - sf: *req-main
+      # - unimath: *req-main
+      # - vst: *req-main

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,76 +1,53 @@
-image: ubuntu:xenial
+image: "$IMAGE"
 
 stages:
-  - opam-boot
+  - docker
   - build
   - test
 
+# some default values
 variables:
-  # some default values
-  NJOBS: "2"
-  COMPILER: "4.02.3"
-  CAMLP5_VER: "6.14"
-  OPAMROOT: "$CI_PROJECT_DIR/.opamcache"
-  OPAMROOTISOK: "true"
+  # Format: $IMAGE-V$DATE [Cache is not used as of today but kept here
+  # for reference]
+  CACHEKEY: "bionic_coq-v8.8-V2018-05-17"
+  IMAGE: "$CI_REGISTRY_IMAGE:$CACHEKEY"
+  # By default, jobs run in the base switch; override to select another switch
+  OPAM_SWITCH: "base"
+  # Used to select special compiler switches such as flambda, 32bits, etc...
+  OPAM_VARIANT: ""
 
-  # some useful values
-  COMPILER_32BIT: "4.02.3+32bit"
-
-  COMPILER_BLEEDING_EDGE: "4.06.0"
-  CAMLP5_VER_BLEEDING_EDGE: "7.03"
-
-  TIMING_PACKAGES: "time python"
-
-  COQIDE_PACKAGES: "libgtk2.0-dev libgtksourceview2.0-dev"
-  #COQIDE_PACKAGES_32BIT: "libgtk2.0-dev:i386 libgtksourceview2.0-dev:i386"
-  COQIDE_OPAM: "lablgtk-extras"
-  COQIDE_OPAM_BE: "lablgtk.2.18.6 lablgtk-extras.1.6"
-  COQDOC_PACKAGES: "texlive-latex-base texlive-latex-recommended texlive-latex-extra texlive-math-extra texlive-fonts-recommended texlive-fonts-extra latex-xcolor ghostscript tipa python3-pip"
-  COQDOC_OPAM: "hevea"
-  SPHINX_PACKAGES: "bs4 sphinx sphinx_rtd_theme pexpect antlr4-python3-runtime sphinxcontrib-bibtex"
-  ELPI_OPAM: "ppx_tools_versioned ppx_deriving ocaml-migrate-parsetree"
-
+docker-boot:
+  stage: docker
+  image: docker:stable
+  services:
+    - docker:dind
+  before_script: []
+  script:
+    - docker login -u gitlab-ci-token -p "$CI_JOB_TOKEN" "$CI_REGISTRY"
+    - cd dev/ci/docker/bionic_coq/
+    - if docker pull "$IMAGE"; then echo "Image prebuilt!"; exit 0; fi
+    - docker build -t "$IMAGE" .
+    - docker push "$IMAGE"
+  except:
+    variables:
+      - $SKIP_DOCKER == "true"
 
 before_script:
+  - cat /proc/{cpu,mem}info || true
   - ls -a # figure out if artifacts are around
-  - printenv
-#  - if [ "$COMPILER" = "$COMPILER_32BIT" ]; then sudo dpkg --add-architecture i386; fi
-  - apt-get update -qq && apt-get install -y -qq m4 opam ${EXTRA_PACKAGES}
-  - if [ -n "${PIP_PACKAGES}" ]; then pip3 install ${PIP_PACKAGES}; fi
-  # if no cache running opam config fails!
-  - if [ -d .opamcache ]; then eval $(opam config env); fi
+  - printenv | sort
+  - declare -A switch_table
+  - switch_table=( ["base"]="$COMPILER" ["edge"]="$COMPILER_BE" )
+  - opam switch -y "${switch_table[$OPAM_SWITCH]}$OPAM_VARIANT"
+  - eval $(opam config env)
+  - opam list
+  - opam config list
 
-################ OPAM SYSTEM ######################
-# - use cache between pipelines
-# - use artifacts between jobs
-#   (in https://gitlab.com/SkySkimmer/coq/-/jobs/63255417
-#    the cache wasn't available at the build step)
-# every non opam-boot job must set dependencies (for ci it's in the template)
-# otherwise all opam-boot artifacts are used together and we get some random switch
+################ GITLAB CACHING ######################
+# - use artifacts between jobs                       #
+######################################################
 
-# set cache key when using
-.opam-boot-template: &opam-boot-template
-  stage: opam-boot
-  artifacts:
-    name: "opam-$COMPILER"
-    paths:
-      - .opamcache
-    expire_in: 1 week
-  script:
-    # the default repo in this docker image is a local directory
-    # at the time of 4aaeb8abf it lagged behind the official
-    # repository such that camlp5 7.01 was not available
-    - opam init -a -y -j $NJOBS --compiler=${COMPILER} default https://opam.ocaml.org
-    - eval $(opam config env)
-    - opam update
-    - opam config list
-    - opam list
-    - opam install -j ${NJOBS} -y camlp5.${CAMLP5_VER} ocamlfind num ${EXTRA_OPAM}
-    - rm -rf ~/.opam/log/
-    - opam list
-
-# TODO figure out how to build doc for installed coq
-# set dependencies when using
+# TODO figure out how to build doc for installed Coq
 .build-template: &build-template
   stage: build
   artifacts:
@@ -80,21 +57,16 @@ before_script:
       - config/Makefile
       - test-suite/misc/universes/all_stdlib.v
     expire_in: 1 week
-  dependencies:
-    - not-a-real-job
   script:
     - set -e
-    - printenv
-    - opam config list
-    - opam list
 
     - echo 'start:coq.config'
-    - ./configure -prefix "$(pwd)/_install_ci" ${EXTRA_CONF}
+    - ./configure -prefix "$(pwd)/_install_ci" ${COQ_EXTRA_CONF}"$COQ_EXTRA_CONF_QUOTE"
     - echo 'end:coq.config'
 
     - echo 'start:coq.build'
-    - make -j ${NJOBS} byte
-    - make -j ${NJOBS}
+    - make -j "$NJOBS" byte
+    - make -j "$NJOBS"
     - make test-suite/misc/universes/all_stdlib.v
     - echo 'end:coq:build'
 
@@ -106,28 +78,28 @@ before_script:
 
     - set +e
 
-# set dependencies when using
 .warnings-template: &warnings-template
   # keep warnings in test stage so we can test things even when warnings occur
   stage: test
-  dependencies:
-    - not-a-real-job
   script:
     - set -e
 
     - echo 'start:coq.config'
-    - ./configure -local ${EXTRA_CONF}
+    - ./configure -local ${COQ_EXTRA_CONF}
     - echo 'end:coq.config'
 
     - echo 'start:coq.build'
-    - make -j ${NJOBS} coqocaml
+    - make -j "$NJOBS" coqocaml
     - echo 'end:coq:build'
 
     - set +e
   variables: &warnings-variables
-    EXTRA_CONF: "-native-compiler yes -coqide byte -byte-only"
-    EXTRA_PACKAGES: "$COQIDE_PACKAGES"
-    EXTRA_OPAM: "$COQIDE_OPAM"
+    COQ_EXTRA_CONF: "-native-compiler yes -coqide byte -byte-only -warn-error yes"
+
+# every non build job must set dependencies otherwise all build
+# artifacts are used together and we may get some random Coq. To that
+# purpose, we add a spurious dependency `not-a-real-job` that must be
+# overridden otherwise the CI will fail.
 
 # set dependencies when using
 .test-suite-template: &test-suite-template
@@ -140,7 +112,7 @@ before_script:
     # careful with the ending /
     - BIN=$(readlink -f ../_install_ci/bin)/
     - LIB=$(readlink -f ../_install_ci/lib/coq)/
-    - make -j ${NJOBS} BIN="$BIN" LIB="$LIB" all
+    - make -j "$NJOBS" BIN="$BIN" LIB="$LIB" all
   artifacts:
     name: "$CI_JOB_NAME.logs"
     when: on_failure
@@ -163,151 +135,159 @@ before_script:
   script:
     - set -e
     - echo 'start:coq.test'
-    - make -f Makefile.ci -j ${NJOBS} ${TEST_TARGET}
+    - make -f Makefile.ci -j "$NJOBS" ${TEST_TARGET}
     - echo 'end:coq.test'
     - set +e
   dependencies:
-    - opam-boot
-    - build
+    - build:base
   variables: &ci-template-vars
     TEST_TARGET: "$CI_JOB_NAME"
-    EXTRA_PACKAGES: "$TIMING_PACKAGES"
 
-opam-boot:
-  <<: *opam-boot-template
-  cache:
-    paths: &cache-paths
-      - .opamcache
-    key: main
-  variables:
-    EXTRA_OPAM: "$COQIDE_OPAM $COQDOC_OPAM ocamlgraph $ELPI_OPAM"
-    EXTRA_PACKAGES: "$COQIDE_PACKAGES"
-
-opam-boot:32bit:
-  <<: *opam-boot-template
-  cache:
-    paths: *cache-paths
-    key: 32bit
-  variables:
-    COMPILER: "$COMPILER_32BIT"
-    EXTRA_PACKAGES: "gcc-multilib"
-
-opam-boot:bleeding-edge:
-  <<: *opam-boot-template
-  cache:
-    paths: *cache-paths
-    key: be
-  variables:
-    COMPILER: "$COMPILER_BLEEDING_EDGE"
-    CAMLP5_VER: "$CAMLP5_VER_BLEEDING_EDGE"
-    EXTRA_PACKAGES: "$COQIDE_PACKAGES"
-    EXTRA_OPAM: "$COQIDE_OPAM_BE"
-
-build:
-  <<: *build-template
+.ci-template-flambda: &ci-template-flambda
+  <<: *ci-template
   dependencies:
-    - opam-boot
+    - build:edge+flambda
   variables:
-    EXTRA_CONF: "-native-compiler yes -coqide opt -with-doc yes"
-    EXTRA_PACKAGES: "$COQIDE_PACKAGES $COQDOC_PACKAGES"
-    PIP_PACKAGES: "$SPHINX_PACKAGES"
+    <<: *ci-template-vars
+    OPAM_SWITCH: "edge"
+    OPAM_VARIANT: "+flambda"
+
+.windows-template: &windows-template
+  stage: test
+  artifacts:
+    name: "%CI_JOB_NAME%"
+    paths:
+      - dev\nsis\*.exe
+      - coq-opensource-archive-windows-*.zip
+    expire_in: 1 week
+  dependencies: []
+  tags:
+    - windows
+  before_script: []
+  script:
+    - call dev/ci/gitlab.bat
+  only:
+    variables:
+      - $WINDOWS == "enabled"
+
+build:base:
+  <<: *build-template
+  variables:
+    COQ_EXTRA_CONF: "-native-compiler yes -coqide opt -with-doc yes"
 
 # no coqide for 32bit: libgtk installation problems
-build:32bit:
+build:base+32bit:
   <<: *build-template
-  dependencies:
-    - opam-boot:32bit
   variables:
-    EXTRA_CONF: "-native-compiler yes"
-    EXTRA_PACKAGES: "gcc-multilib"
+    OPAM_VARIANT: "+32bit"
+    COQ_EXTRA_CONF: "-native-compiler yes"
 
-build:bleeding-edge:
+build:edge:
   <<: *build-template
-  dependencies:
-    - opam-boot:bleeding-edge
   variables:
-    EXTRA_CONF: "-native-compiler yes -coqide opt"
-    EXTRA_PACKAGES: "$COQIDE_PACKAGES"
+    OPAM_SWITCH: edge
+    COQ_EXTRA_CONF: "-native-compiler yes -coqide opt"
 
-warnings:
+build:edge+flambda:
+  <<: *build-template
+  variables:
+    OPAM_SWITCH: edge
+    OPAM_VARIANT: "+flambda"
+    COQ_EXTRA_CONF: "-native-compiler no -coqide opt -flambda-opts "
+    COQ_EXTRA_CONF_QUOTE: "-O3 -unbox-closures"
+
+windows64:
+  <<: *windows-template
+  variables:
+    ARCH: "64"
+
+windows32:
+  <<: *windows-template
+  variables:
+    ARCH: "32"
+
+warnings:base:
   <<: *warnings-template
-  dependencies:
-    - opam-boot
 
 # warnings:32bit:
 #   <<: *warnings-template
 #   variables:
 #     <<: *warnings-variables
-#     EXTRA_PACKAGES: "$gcc-multilib COQIDE_PACKAGES_32BIT"
-#   dependencies:
-#     - opam-boot:32bit
 
-warnings:bleeding-edge:
+warnings:edge:
   <<: *warnings-template
-  dependencies:
-    - opam-boot:bleeding-edge
+  variables:
+    <<: *warnings-variables
+    OPAM_SWITCH: edge
 
-test-suite:
+test-suite:base:
   <<: *test-suite-template
   dependencies:
-    - opam-boot
-    - build
-  variables:
-    EXTRA_PACKAGES: "$TIMING_PACKAGES"
+    - build:base
 
-test-suite:32bit:
+test-suite:base+32bit:
   <<: *test-suite-template
   dependencies:
-    - opam-boot:32bit
-    - build:32bit
+    - build:base+32bit
   variables:
-    EXTRA_PACKAGES: "gcc-multilib $TIMING_PACKAGES"
+    OPAM_VARIANT: "+32bit"
 
-test-suite:bleeding-edge:
+test-suite:edge:
   <<: *test-suite-template
   dependencies:
-    - opam-boot:bleeding-edge
-    - build:bleeding-edge
+    - build:edge
   variables:
-    EXTRA_PACKAGES: "$TIMING_PACKAGES"
+    OPAM_SWITCH: edge
 
-validate:
+test-suite:edge+flambda:
+  <<: *test-suite-template
+  dependencies:
+    - build:edge+flambda
+  variables:
+    OPAM_SWITCH: edge
+    OPAM_VARIANT: "+flambda"
+
+validate:base:
   <<: *validate-template
   dependencies:
-    - opam-boot
-    - build
+    - build:base
 
-validate:32bit:
+validate:base+32bit:
   <<: *validate-template
   dependencies:
-    - opam-boot:32bit
-    - build:32bit
+    - build:base+32bit
   variables:
-    EXTRA_PACKAGES: "gcc-multilib"
+    OPAM_VARIANT: "+32bit"
+
+validate:edge:
+  <<: *validate-template
+  dependencies:
+    - build:edge
+  variables:
+    OPAM_SWITCH: edge
+
+validate:edge+flambda:
+  <<: *validate-template
+  dependencies:
+    - build:edge+flambda
+  variables:
+    OPAM_SWITCH: edge
+    OPAM_VARIANT: "+flambda"
 
 ci-bignums:
   <<: *ci-template
 
 ci-color:
-  <<: *ci-template
-  variables:
-    <<: *ci-template-vars
-    EXTRA_PACKAGES: "$TIMING_PACKAGES"
+  <<: *ci-template-flambda
 
 ci-compcert:
-  <<: *ci-template
+  <<: *ci-template-flambda
 
 ci-coq-dpdgraph:
   <<: *ci-template
-  variables:
-    <<: *ci-template-vars
-    EXTRA_PACKAGES: "$TIMING_PACKAGES autoconf"
 
 ci-coquelicot:
   <<: *ci-template
-  variables:
-    <<: *ci-template-vars
-    EXTRA_PACKAGES: "$TIMING_PACKAGES autoconf"
 
 ci-elpi:
   <<: *ci-template
@@ -315,59 +295,41 @@ ci-elpi:
 ci-equations:
   <<: *ci-template
 
-ci-geocoq:
-  <<: *ci-template
-  allow_failure: true
-
 ci-fcsl-pcm:
   <<: *ci-template
 
-# ci-fiat-crypto:
-#   <<: *ci-template
-#   # out of memory error
-#   allow_failure: true
+ci-fiat-crypto:
+  <<: *ci-template-flambda
 
 ci-fiat-parsers:
   <<: *ci-template
-  variables:
-    <<: *ci-template-vars
-    EXTRA_PACKAGES: "$TIMING_PACKAGES"
 
 ci-flocq:
   <<: *ci-template
-  variables:
-    <<: *ci-template-vars
-    EXTRA_PACKAGES: "$TIMING_PACKAGES autoconf"
 
 ci-formal-topology:
-  <<: *ci-template
+  <<: *ci-template-flambda
+
+ci-geocoq:
+  <<: *ci-template-flambda
 
 ci-hott:
   <<: *ci-template
-  variables:
-    <<: *ci-template-vars
-    EXTRA_PACKAGES: "$TIMING_PACKAGES autoconf"
 
 ci-iris-lambda-rust:
-  <<: *ci-template
+  <<: *ci-template-flambda
 
 ci-ltac2:
   <<: *ci-template
 
-ci-math-classes:
-  <<: *ci-template
-
 ci-math-comp:
-  <<: *ci-template
+  <<: *ci-template-flambda
 
 ci-sf:
   <<: *ci-template
-  variables:
-    <<: *ci-template-vars
-    EXTRA_PACKAGES: "$TIMING_PACKAGES wget"
 
 ci-unimath:
-  <<: *ci-template
+  <<: *ci-template-flambda
 
 ci-vst:
-  <<: *ci-template
+  <<: *ci-template-flambda

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,26 +39,32 @@ env:
   - NJOBS=2
   # system is == 4.02.3
   - COMPILER="system"
-  - COMPILER_BE="4.06.0"
+  - COMPILER_BE="4.06.1"
   - CAMLP5_VER=".6.14"
-  - CAMLP5_VER_BE=".7.03"
+  - CAMLP5_VER_BE=".7.05"
   - FINDLIB_VER=".1.4.1"
-  - FINDLIB_VER_BE=".1.7.3"
+  - FINDLIB_VER_BE=".1.8.0"
   - LABLGTK="lablgtk.2.18.3 lablgtk-extras.1.6"
   - LABLGTK_BE="lablgtk.2.18.6 lablgtk-extras.1.6"
   - NATIVE_COMP="yes"
   - COQ_DEST="-local"
   - MAIN_TARGET="world"
-  # Main test suites
-  matrix:
-  - TEST_TARGET="test-suite" COMPILER="4.02.3+32bit"
-  - TEST_TARGET="validate"                           TW="travis_wait"
-  - TEST_TARGET="validate"   COMPILER="4.02.3+32bit" TW="travis_wait"
-  - TEST_TARGET="validate"   COMPILER="${COMPILER_BE}+flambda" CAMLP5_VER="${CAMLP5_VER_BE}" NATIVE_COMP="no" EXTRA_CONF="-flambda-opts -O3" FINDLIB_VER="${FINDLIB_VER_BE}"
 
 matrix:
 
   include:
+    - if: NOT (type = pull_request)
+      env:
+      - TEST_TARGET="test-suite" COMPILER="4.02.3+32bit"
+    - if: NOT (type = pull_request)
+      env:
+      - TEST_TARGET="validate"                           TW="travis_wait"
+    - if: NOT (type = pull_request)
+      env:
+      - TEST_TARGET="validate"   COMPILER="4.02.3+32bit" TW="travis_wait"
+    - if: NOT (type = pull_request)
+      env:
+      - TEST_TARGET="validate"   COMPILER="${COMPILER_BE}+flambda" CAMLP5_VER="${CAMLP5_VER_BE}" NATIVE_COMP="no" EXTRA_CONF="-flambda-opts -O3" FINDLIB_VER="${FINDLIB_VER_BE}"
     - if: NOT (type = pull_request)
       env:
       - TEST_TARGET="ci-bignums"
@@ -67,7 +73,7 @@ matrix:
       - TEST_TARGET="ci-color"
     - if: NOT (type = pull_request)
       env:
-      - TEST_TARGET="ci-compcert"
+      - TEST_TARGET="ci-compcert" EXTRA_OPAM="menhir"
     - if: NOT (type = pull_request)
       env:
       - TEST_TARGET="ci-coq-dpdgraph" EXTRA_OPAM="ocamlgraph"
@@ -84,13 +90,7 @@ matrix:
       - TEST_TARGET="ci-equations"
     - if: NOT (type = pull_request)
       env:
-      - TEST_TARGET="ci-geocoq"
-    - if: NOT (type = pull_request)
-      env:
       - TEST_TARGET="ci-fcsl-pcm"
-    - if: NOT (type = pull_request)
-      env:
-      - TEST_TARGET="ci-fiat-crypto"
     - if: NOT (type = pull_request)
       env:
       - TEST_TARGET="ci-fiat-parsers"
@@ -99,13 +99,7 @@ matrix:
       - TEST_TARGET="ci-flocq"
     - if: NOT (type = pull_request)
       env:
-      - TEST_TARGET="ci-formal-topology"
-    - if: NOT (type = pull_request)
-      env:
       - TEST_TARGET="ci-hott"
-    - if: NOT (type = pull_request)
-      env:
-      - TEST_TARGET="ci-iris-lambda-rust"
     - if: NOT (type = pull_request)
       env:
       - TEST_TARGET="ci-ltac2"
@@ -114,16 +108,7 @@ matrix:
       - TEST_TARGET="ci-math-classes"
     - if: NOT (type = pull_request)
       env:
-      - TEST_TARGET="ci-math-comp"
-    - if: NOT (type = pull_request)
-      env:
       - TEST_TARGET="ci-sf"
-    - if: NOT (type = pull_request)
-      env:
-      - TEST_TARGET="ci-unimath"
-    - if: NOT (type = pull_request)
-      env:
-      - TEST_TARGET="ci-vst"
 
     - env:
       - TEST_TARGET="lint"
@@ -137,7 +122,8 @@ matrix:
         - dev/lint-repository.sh
 
     # Full Coq test-suite with two compilers
-    - env:
+    - if: NOT (type = pull_request)
+      env:
       - TEST_TARGET="test-suite"
       - EXTRA_CONF="-coqide opt -with-doc yes"
       - EXTRA_OPAM="hevea ${LABLGTK}"
@@ -165,7 +151,8 @@ matrix:
           - python3-pip
           - python3-setuptools
 
-    - env:
+    - if: NOT (type = pull_request)
+      env:
       - TEST_TARGET="test-suite"
       - COMPILER="${COMPILER_BE}"
       - FINDLIB_VER="${FINDLIB_VER_BE}"
@@ -180,7 +167,8 @@ matrix:
           packages: *extra-packages
 
     # Full test-suite with flambda
-    - env:
+    - if: NOT (type = pull_request)
+      env:
       - TEST_TARGET="test-suite"
       - COMPILER="${COMPILER_BE}+flambda"
       - FINDLIB_VER="${FINDLIB_VER_BE}"
@@ -196,7 +184,8 @@ matrix:
           packages: *extra-packages
 
     # Ocaml warnings with two compilers
-    - env:
+    - if: NOT (type = pull_request)
+      env:
       - MAIN_TARGET="coqocaml"
       - EXTRA_CONF="-byte-only -coqide byte -warn-error yes"
       - EXTRA_OPAM="hevea ${LABLGTK}"
@@ -210,7 +199,8 @@ matrix:
           - libgtk2.0-dev
           - libgtksourceview2.0-dev
 
-    - env:
+    - if: NOT (type = pull_request)
+      env:
       - MAIN_TARGET="coqocaml"
       - COMPILER="${COMPILER_BE}"
       - FINDLIB_VER="${FINDLIB_VER_BE}"
@@ -272,6 +262,7 @@ install:
 - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then travis_retry ./dev/tools/sudo-apt-get-update.sh -q; fi
 - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then sudo apt-get install -y opam aspcud gcc-multilib; fi
 - opam init -j ${NJOBS} --compiler=${COMPILER} -n -y
+- opam switch "$COMPILER" && opam update
 - eval $(opam config env)
 - opam config list
 - opam install -j ${NJOBS} -y num camlp5${CAMLP5_VER} ocamlfind${FINDLIB_VER} ${EXTRA_OPAM}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,10 +10,6 @@ image:
 environment:
   CYGMIRROR: http://ftp.inf.tu-dresden.de/software/windows/cygwin32
   matrix:
-  - USEOPAM: false
-    ARCH: 32
-  - USEOPAM: false
-    ARCH: 64
   - USEOPAM: true
     ARCH: 64
 
@@ -21,11 +17,3 @@ build_script:
 - cmd: 'call %APPVEYOR_BUILD_FOLDER%\dev\ci\appveyor.bat'
 
 test: off
-
-artifacts:
-  - path: 'dev\nsis\*.exe'
-    name: installer
-
-  - path: 'coq-opensource-archive-*.zip'
-    name: opensource-archive
-

--- a/dev/ci/appveyor.sh
+++ b/dev/ci/appveyor.sh
@@ -4,6 +4,6 @@ wget https://github.com/fdopen/opam-repository-mingw/releases/download/0.0.0.1/o
 tar -xf opam64.tar.xz
 bash opam64/install.sh
 opam init -a mingw https://github.com/fdopen/opam-repository-mingw.git --comp 4.02.3+mingw64c --switch 4.02.3+mingw64c
-eval $(opam config env)
+eval "$(opam config env)"
 opam install -y ocamlfind camlp5
-cd $APPVEYOR_BUILD_FOLDER && ./configure -local && make && make byte && make -C test-suite all INTERACTIVE= && make validate
+cd "$APPVEYOR_BUILD_FOLDER" && ./configure -local && make && make byte && make -C test-suite all INTERACTIVE= && make validate

--- a/dev/ci/ci-bignums.sh
+++ b/dev/ci/ci-bignums.sh
@@ -6,11 +6,11 @@ ci_dir="$(dirname "$0")"
 # Let's avoid to source ci-common twice in this case
 if [ -z "${CI_BUILD_DIR}" ];
 then
-    source ${ci_dir}/ci-common.sh
+    . "${ci_dir}/ci-common.sh"
 fi
 
-bignums_CI_DIR=${CI_BUILD_DIR}/Bignums
+bignums_CI_DIR="${CI_BUILD_DIR}/Bignums"
 
-git_checkout ${bignums_CI_BRANCH} ${bignums_CI_GITURL} ${bignums_CI_DIR}
+git_checkout "${bignums_CI_BRANCH}" "${bignums_CI_GITURL}" "${bignums_CI_DIR}"
 
-( cd ${bignums_CI_DIR} && make && make install)
+( cd "${bignums_CI_DIR}" && make && make install)

--- a/dev/ci/ci-color.sh
+++ b/dev/ci/ci-color.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
 ci_dir="$(dirname "$0")"
-source ${ci_dir}/ci-common.sh
+. "${ci_dir}/ci-common.sh"
 
 CoLoR_CI_DIR=${CI_BUILD_DIR}/color
 
 # Compile CoLoR
-git_checkout ${CoLoR_CI_BRANCH} ${CoLoR_CI_GITURL} ${CoLoR_CI_DIR}
-( cd ${CoLoR_CI_DIR} && make )
+git_checkout "${CoLoR_CI_BRANCH}" "${CoLoR_CI_GITURL}" "${CoLoR_CI_DIR}"
+( cd "${CoLoR_CI_DIR}" && make )

--- a/dev/ci/ci-compcert.sh
+++ b/dev/ci/ci-compcert.sh
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
 
 ci_dir="$(dirname "$0")"
-source ${ci_dir}/ci-common.sh
+. "${ci_dir}/ci-common.sh"
 
-CompCert_CI_DIR=${CI_BUILD_DIR}/CompCert
+CompCert_CI_DIR="${CI_BUILD_DIR}/CompCert"
 
-opam install -j "$NJOBS" -y menhir
-git_checkout ${CompCert_CI_BRANCH} ${CompCert_CI_GITURL} ${CompCert_CI_DIR}
+git_checkout "${CompCert_CI_BRANCH}" "${CompCert_CI_GITURL}" "${CompCert_CI_DIR}"
 
-( cd ${CompCert_CI_DIR} && ./configure -ignore-coq-version x86_32-linux && make && make check-proof )
+( cd "${CompCert_CI_DIR}" && ./configure -ignore-coq-version x86_32-linux && make && make check-proof )

--- a/dev/ci/ci-coq-dpdgraph.sh
+++ b/dev/ci/ci-coq-dpdgraph.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
 ci_dir="$(dirname "$0")"
-source ${ci_dir}/ci-common.sh
+. "${ci_dir}/ci-common.sh"
 
-coq_dpdgraph_CI_DIR=${CI_BUILD_DIR}/coq-dpdgraph
+coq_dpdgraph_CI_DIR="${CI_BUILD_DIR}/coq-dpdgraph"
 
-git_checkout ${coq_dpdgraph_CI_BRANCH} ${coq_dpdgraph_CI_GITURL} ${coq_dpdgraph_CI_DIR}
+git_checkout "${coq_dpdgraph_CI_BRANCH}" "${coq_dpdgraph_CI_GITURL}" "${coq_dpdgraph_CI_DIR}"
 
-( cd ${coq_dpdgraph_CI_DIR} && autoconf && ./configure && make && make test-suite )
+( cd "${coq_dpdgraph_CI_DIR}" && autoconf && ./configure && make && make test-suite )

--- a/dev/ci/ci-coquelicot.sh
+++ b/dev/ci/ci-coquelicot.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
 ci_dir="$(dirname "$0")"
-source ${ci_dir}/ci-common.sh
+. "${ci_dir}/ci-common.sh"
 
-Coquelicot_CI_DIR=${CI_BUILD_DIR}/coquelicot
+Coquelicot_CI_DIR="${CI_BUILD_DIR}/coquelicot"
 
 install_ssreflect
 
-git_checkout ${Coquelicot_CI_BRANCH} ${Coquelicot_CI_GITURL} ${Coquelicot_CI_DIR}
+git_checkout "${Coquelicot_CI_BRANCH}" "${Coquelicot_CI_GITURL}" "${Coquelicot_CI_DIR}"
 
-( cd ${Coquelicot_CI_DIR} && ./autogen.sh && ./configure && ./remake -j${NJOBS} )
+( cd "${Coquelicot_CI_DIR}" && ./autogen.sh && ./configure && ./remake "-j${NJOBS}" )

--- a/dev/ci/ci-corn.sh
+++ b/dev/ci/ci-corn.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
 ci_dir="$(dirname "$0")"
-source ${ci_dir}/ci-common.sh
+. "${ci_dir}/ci-common.sh"
 
-Corn_CI_DIR=${CI_BUILD_DIR}/corn
+Corn_CI_DIR="${CI_BUILD_DIR}/corn"
 
-git_checkout ${Corn_CI_BRANCH} ${Corn_CI_GITURL} ${Corn_CI_DIR}
+git_checkout "${Corn_CI_BRANCH}" "${Corn_CI_GITURL}" "${Corn_CI_DIR}"
 
-( cd ${Corn_CI_DIR} && make && make install )
+( cd "${Corn_CI_DIR}" && make && make install )

--- a/dev/ci/ci-cpdt.sh
+++ b/dev/ci/ci-cpdt.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
 
 ci_dir="$(dirname "$0")"
-source ${ci_dir}/ci-common.sh
+. "${ci_dir}/ci-common.sh"
 
 wget http://adam.chlipala.net/cpdt/cpdt.tgz
 tar xvfz cpdt.tgz
 
 ( cd cpdt && make clean && make )
-

--- a/dev/ci/ci-elpi.sh
+++ b/dev/ci/ci-elpi.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
 ci_dir="$(dirname "$0")"
-source ${ci_dir}/ci-common.sh
+. "${ci_dir}/ci-common.sh"
 
-Elpi_CI_DIR=${CI_BUILD_DIR}/elpi
+Elpi_CI_DIR="${CI_BUILD_DIR}/elpi"
 
-git_checkout ${Elpi_CI_BRANCH} ${Elpi_CI_GITURL} ${Elpi_CI_DIR}
+git_checkout "${Elpi_CI_BRANCH}" "${Elpi_CI_GITURL}" "${Elpi_CI_DIR}"
 
-( cd ${Elpi_CI_DIR} && make && make install )
+( cd "${Elpi_CI_DIR}" && make && make install )

--- a/dev/ci/ci-equations.sh
+++ b/dev/ci/ci-equations.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
 ci_dir="$(dirname "$0")"
-source ${ci_dir}/ci-common.sh
+. "${ci_dir}/ci-common.sh"
 
-Equations_CI_DIR=${CI_BUILD_DIR}/Equations
+Equations_CI_DIR="${CI_BUILD_DIR}/Equations"
 
-git_checkout ${Equations_CI_BRANCH} ${Equations_CI_GITURL} ${Equations_CI_DIR}
+git_checkout "${Equations_CI_BRANCH}" "${Equations_CI_GITURL}" "${Equations_CI_DIR}"
 
-( cd ${Equations_CI_DIR} && coq_makefile -f _CoqProject -o Makefile && make && make test-suite && make examples && make install)
+( cd "${Equations_CI_DIR}" && coq_makefile -f _CoqProject -o Makefile && make && make test-suite && make examples && make install)

--- a/dev/ci/ci-fiat-parsers.sh
+++ b/dev/ci/ci-fiat-parsers.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
 ci_dir="$(dirname "$0")"
-source ${ci_dir}/ci-common.sh
+. "${ci_dir}/ci-common.sh"
 
-fiat_parsers_CI_DIR=${CI_BUILD_DIR}/fiat
+fiat_parsers_CI_DIR="${CI_BUILD_DIR}/fiat"
 
-git_checkout ${fiat_parsers_CI_BRANCH} ${fiat_parsers_CI_GITURL} ${fiat_parsers_CI_DIR}
+git_checkout "${fiat_parsers_CI_BRANCH}" "${fiat_parsers_CI_GITURL}" "${fiat_parsers_CI_DIR}"
 
-( cd ${fiat_parsers_CI_DIR} && make parsers parsers-examples && make fiat-core )
+( cd "${fiat_parsers_CI_DIR}" && make parsers parsers-examples && make fiat-core )

--- a/dev/ci/ci-flocq.sh
+++ b/dev/ci/ci-flocq.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
 ci_dir="$(dirname "$0")"
-source ${ci_dir}/ci-common.sh
+. "${ci_dir}/ci-common.sh"
 
-Flocq_CI_DIR=${CI_BUILD_DIR}/flocq
+Flocq_CI_DIR="${CI_BUILD_DIR}/flocq"
 
-git_checkout ${Flocq_CI_BRANCH} ${Flocq_CI_GITURL} ${Flocq_CI_DIR}
+git_checkout "${Flocq_CI_BRANCH}" "${Flocq_CI_GITURL}" "${Flocq_CI_DIR}"
 
-( cd ${Flocq_CI_DIR} && ./autogen.sh && ./configure && ./remake -j${NJOBS} )
+( cd "${Flocq_CI_DIR}" && ./autogen.sh && ./configure && ./remake "-j${NJOBS}" )

--- a/dev/ci/ci-formal-topology.sh
+++ b/dev/ci/ci-formal-topology.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
 ci_dir="$(dirname "$0")"
-source ${ci_dir}/ci-common.sh
+. "${ci_dir}/ci-common.sh"
 
-formal_topology_CI_DIR=${CI_BUILD_DIR}/formal-topology
+formal_topology_CI_DIR="${CI_BUILD_DIR}/formal-topology"
 
-git_checkout ${formal_topology_CI_BRANCH} ${formal_topology_CI_GITURL} ${formal_topology_CI_DIR}
+git_checkout "${formal_topology_CI_BRANCH}" "${formal_topology_CI_GITURL}" "${formal_topology_CI_DIR}"
 
-( cd ${formal_topology_CI_DIR} && make )
+( cd "${formal_topology_CI_DIR}" && make )

--- a/dev/ci/ci-geocoq.sh
+++ b/dev/ci/ci-geocoq.sh
@@ -1,12 +1,10 @@
 #!/usr/bin/env bash
 
 ci_dir="$(dirname "$0")"
-source ${ci_dir}/ci-common.sh
+. "${ci_dir}/ci-common.sh"
 
-GeoCoq_CI_DIR=${CI_BUILD_DIR}/GeoCoq
+GeoCoq_CI_DIR="${CI_BUILD_DIR}/GeoCoq"
 
-git_checkout ${GeoCoq_CI_BRANCH} ${GeoCoq_CI_GITURL} ${GeoCoq_CI_DIR}
+git_checkout "${GeoCoq_CI_BRANCH}" "${GeoCoq_CI_GITURL}" "${GeoCoq_CI_DIR}"
 
-( cd ${GeoCoq_CI_DIR}                                     && \
-  ./configure-ci.sh                                       && \
-  make )
+( cd "${GeoCoq_CI_DIR}" && ./configure.sh && make )

--- a/dev/ci/ci-hott.sh
+++ b/dev/ci/ci-hott.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
 ci_dir="$(dirname "$0")"
-source ${ci_dir}/ci-common.sh
+. "${ci_dir}/ci-common.sh"
 
-HoTT_CI_DIR=${CI_BUILD_DIR}/HoTT
+HoTT_CI_DIR="${CI_BUILD_DIR}"/HoTT
 
-git_checkout ${HoTT_CI_BRANCH} ${HoTT_CI_GITURL} ${HoTT_CI_DIR}
+git_checkout "${HoTT_CI_BRANCH}" "${HoTT_CI_GITURL}" "${HoTT_CI_DIR}"
 
-( cd ${HoTT_CI_DIR} && ./autogen.sh && ./configure && make )
+( cd "${HoTT_CI_DIR}" && ./autogen.sh && ./configure && make )

--- a/dev/ci/ci-ltac2.sh
+++ b/dev/ci/ci-ltac2.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
 ci_dir="$(dirname "$0")"
-source ${ci_dir}/ci-common.sh
+. "${ci_dir}/ci-common.sh"
 
-ltac2_CI_DIR=${CI_BUILD_DIR}/ltac2
+ltac2_CI_DIR="${CI_BUILD_DIR}/ltac2"
 
-git_checkout ${ltac2_CI_BRANCH} ${ltac2_CI_GITURL} ${ltac2_CI_DIR}
+git_checkout "${ltac2_CI_BRANCH}" "${ltac2_CI_GITURL}" "${ltac2_CI_DIR}"
 
-( cd ${ltac2_CI_DIR} && make && make tests && make install )
+( cd "${ltac2_CI_DIR}" && make && make tests && make install )

--- a/dev/ci/ci-math-classes.sh
+++ b/dev/ci/ci-math-classes.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
 ci_dir="$(dirname "$0")"
-source ${ci_dir}/ci-common.sh
+. "${ci_dir}/ci-common.sh"
 
-math_classes_CI_DIR=${CI_BUILD_DIR}/math-classes
+math_classes_CI_DIR="${CI_BUILD_DIR}/math-classes"
 
-git_checkout ${math_classes_CI_BRANCH} ${math_classes_CI_GITURL} ${math_classes_CI_DIR}
+git_checkout "${math_classes_CI_BRANCH}" "${math_classes_CI_GITURL}" "${math_classes_CI_DIR}"
 
-( cd ${math_classes_CI_DIR} && make && make install )
+( cd "${math_classes_CI_DIR}" && ./configure.sh && make && make install )

--- a/dev/ci/ci-math-comp.sh
+++ b/dev/ci/ci-math-comp.sh
@@ -2,14 +2,10 @@
 
 # $0 is not the safest way, but...
 ci_dir="$(dirname "$0")"
-source ${ci_dir}/ci-common.sh
+. "${ci_dir}/ci-common.sh"
 
-mathcomp_CI_DIR=${CI_BUILD_DIR}/math-comp
+mathcomp_CI_DIR="${CI_BUILD_DIR}/math-comp"
 
-checkout_mathcomp ${mathcomp_CI_DIR}
+git_checkout "${mathcomp_CI_BRANCH}" "${mathcomp_CI_GITURL}" "${mathcomp_CI_DIR}"
 
-# odd_order takes too much time for travis.
-( cd ${mathcomp_CI_DIR}/mathcomp                  && \
-  sed -i.bak '/PFsection/d'                  Make && \
-  sed -i.bak '/stripped_odd_order_theorem/d' Make && \
-  make Makefile.coq && make -f Makefile.coq all )
+( cd "${mathcomp_CI_DIR}/mathcomp" && make )

--- a/dev/ci/ci-sf.sh
+++ b/dev/ci/ci-sf.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
 ci_dir="$(dirname "$0")"
-source ${ci_dir}/ci-common.sh
+. "${ci_dir}/ci-common.sh"
 
-mkdir -p ${CI_BUILD_DIR} && cd ${CI_BUILD_DIR}
-wget -qO- ${sf_lf_CI_TARURL}  | tar xvz
-wget -qO- ${sf_plf_CI_TARURL} | tar xvz
-wget -qO- ${sf_vfa_CI_TARURL} | tar xvz
+mkdir -p "${CI_BUILD_DIR}" && cd "${CI_BUILD_DIR}" || exit 1
+wget -qO- "${sf_lf_CI_TARURL}"  | tar xvz
+wget -qO- "${sf_plf_CI_TARURL}" | tar xvz
+wget -qO- "${sf_vfa_CI_TARURL}" | tar xvz
 
 sed -i.bak '1i From Coq Require Extraction.' lf/Extraction.v
 sed -i.bak '1i From Coq Require Extraction.' vfa/Extract.v

--- a/dev/ci/ci-template.sh
+++ b/dev/ci/ci-template.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
 ci_dir="$(dirname "$0")"
-source ${ci_dir}/ci-common.sh
+. "${ci_dir}/ci-common.sh"
 
 Template_CI_BRANCH=master
 Template_CI_GITURL=https://github.com/Template/Template
-Template_CI_DIR=${CI_BUILD_DIR}/Template
+Template_CI_DIR="${CI_BUILD_DIR}/Template"
 
-git_checkout ${Template_CI_BRANCH} ${Template_CI_GITURL} ${Template_CI_DIR}
+git_checkout "${Template_CI_BRANCH}" "${Template_CI_GITURL}" "${Template_CI_DIR}"
 
-( cd ${Template_CI_DIR} && make )
+( cd "${Template_CI_DIR}" && make )

--- a/dev/ci/ci-tlc.sh
+++ b/dev/ci/ci-tlc.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
 ci_dir="$(dirname "$0")"
-source ${ci_dir}/ci-common.sh
+. "${ci_dir}/ci-common.sh"
 
-tlc_CI_DIR=${CI_BUILD_DIR}/tlc
+tlc_CI_DIR="${CI_BUILD_DIR}/tlc"
 
-git_checkout ${tlc_CI_BRANCH} ${tlc_CI_GITURL} ${tlc_CI_DIR}
+git_checkout "${tlc_CI_BRANCH}" "${tlc_CI_GITURL}" "${tlc_CI_DIR}"
 
-( cd ${tlc_CI_DIR} && make )
+( cd "${tlc_CI_DIR}" && make )

--- a/dev/ci/ci-unimath.sh
+++ b/dev/ci/ci-unimath.sh
@@ -1,14 +1,10 @@
 #!/usr/bin/env bash
 
 ci_dir="$(dirname "$0")"
-source ${ci_dir}/ci-common.sh
+. "${ci_dir}/ci-common.sh"
 
-UniMath_CI_DIR=${CI_BUILD_DIR}/UniMath
+UniMath_CI_DIR="${CI_BUILD_DIR}/UniMath"
 
-git_checkout ${UniMath_CI_BRANCH} ${UniMath_CI_GITURL} ${UniMath_CI_DIR}
+git_checkout "${UniMath_CI_BRANCH}" "${UniMath_CI_GITURL}" "${UniMath_CI_DIR}"
 
-( cd ${UniMath_CI_DIR}                        && \
-  sed -i.bak '/Folds/d'              Makefile && \
-  sed -i.bak '/HomologicalAlgebra/d' Makefile && \
-  make BUILD_COQ=no )
-
+( cd "${UniMath_CI_DIR}" && make BUILD_COQ=no )

--- a/dev/ci/ci-vst.sh
+++ b/dev/ci/ci-vst.sh
@@ -5,9 +5,6 @@ ci_dir="$(dirname "$0")"
 
 VST_CI_DIR="${CI_BUILD_DIR}/VST"
 
-# opam install -j ${NJOBS} -y menhir
 git_checkout "${VST_CI_BRANCH}" "${VST_CI_GITURL}" "${VST_CI_DIR}"
 
-# We have to omit progs as otherwise we timeout on Travis; on Gitlab
-# we will be able to just use `make`
-( cd "${VST_CI_DIR}" && make IGNORECOQVERSION=true -o progs )
+( cd "${VST_CI_DIR}" && make IGNORECOQVERSION=true )

--- a/dev/ci/docker/bionic_coq/Dockerfile
+++ b/dev/ci/docker/bionic_coq/Dockerfile
@@ -1,0 +1,46 @@
+FROM ubuntu:bionic
+LABEL maintainer="e@x80.org"
+
+ENV DEBIAN_FRONTEND="noninteractive"
+
+RUN apt-get update -qq && apt-get install -y -qq m4 wget time gcc-multilib opam \
+        libgtk2.0-dev libgtksourceview2.0-dev \
+        texlive-latex-extra texlive-fonts-recommended hevea \
+        python3-sphinx python3-pexpect python3-sphinx-rtd-theme python3-bs4 python3-sphinxcontrib.bibtex python3-pip
+
+RUN pip3 install antlr4-python3-runtime
+
+# Basic OPAM setup
+ENV NJOBS="2" \
+    OPAMROOT=/root/.opamcache \
+    OPAMROOTISOK="true"
+
+# Base opam is the set of base packages required by Coq
+ENV COMPILER="4.02.3" \
+    BASE_OPAM="num ocamlfind"
+
+RUN opam init -a -y -j $NJOBS --compiler="$COMPILER" default https://opam.ocaml.org && eval $(opam config env) && opam update
+
+# Setup of the base switch; CI_OPAM contains Coq's CI dependencies.
+ENV CAMLP5_VER="6.14" \
+    COQIDE_OPAM="lablgtk.2.18.5 conf-gtksourceview.2" \
+    CI_OPAM="menhir ppx_tools_versioned ppx_deriving ocaml-migrate-parsetree ocamlgraph"
+
+RUN opam switch -y -j $NJOBS "$COMPILER" && eval $(opam config env) && \
+    opam install -j $NJOBS $BASE_OPAM camlp5.$CAMLP5_VER $COQIDE_OPAM $CI_OPAM
+
+# base+32bit switch
+RUN opam switch -y -j $NJOBS "${COMPILER}+32bit" && eval $(opam config env) && \
+    opam install -j $NJOBS $BASE_OPAM camlp5.$CAMLP5_VER
+
+# BE switch
+ENV COMPILER_BE="4.06.1" \
+    CAMLP5_VER_BE="7.05" \
+    COQIDE_OPAM_BE="lablgtk.2.18.6 conf-gtksourceview.2"
+
+RUN opam switch -y -j $NJOBS $COMPILER_BE && eval $(opam config env) && \
+    opam install -j $NJOBS $BASE_OPAM camlp5.$CAMLP5_VER_BE $COQIDE_OPAM_BE
+
+# BE+flambda switch
+RUN opam switch -y -j $NJOBS "${COMPILER_BE}+flambda" && eval $(opam config env) && \
+    opam install -j $NJOBS $BASE_OPAM camlp5.$CAMLP5_VER_BE $COQIDE_OPAM_BE $CI_OPAM

--- a/dev/ci/gitlab.bat
+++ b/dev/ci/gitlab.bat
@@ -1,0 +1,50 @@
+@ECHO OFF
+
+REM This script builds and signs the Windows packages on Gitlab
+
+if %ARCH% == 32 (
+  SET ARCHLONG=i686
+  SET CYGROOT=C:\cygwin
+  SET SETUP=setup-x86.exe
+)
+
+if %ARCH% == 64 (
+  SET ARCHLONG=x86_64
+  SET CYGROOT=C:\cygwin64
+  SET SETUP=setup-x86_64.exe
+)
+
+powershell -Command "(New-Object Net.WebClient).DownloadFile('http://www.cygwin.com/%SETUP%', '%SETUP%')"
+SET CYGCACHE=%CYGROOT%\var\cache\setup
+SET CI_PROJECT_DIR_MFMT=%CI_PROJECT_DIR:\=/%
+SET CI_PROJECT_DIR_CFMT=%CI_PROJECT_DIR_MFMT:C:/=/cygdrive/c/%
+SET DESTCOQ=C:\coq%ARCH%_inst
+SET COQREGTESTING=Y
+SET PATH=%PATH%;C:\Program Files\7-Zip\;C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin
+
+if exist %CYGROOT%\build\ rd /s /q %CYGROOT%\build
+if exist %DESTCOQ%\ rd /s /q %DESTCOQ%
+
+call %CI_PROJECT_DIR%\dev\build\windows\MakeCoq_MinGW.bat -threads=1 ^
+  -arch=%ARCH% -installer=Y -coqver=%CI_PROJECT_DIR_CFMT% ^
+  -destcyg=%CYGROOT% -destcoq=%DESTCOQ% -cygcache=%CYGCACHE% ^
+  -addon=bignums -make=N ^
+  -setup %CI_PROJECT_DIR%\%SETUP% || GOTO ErrorExit
+
+copy "%CYGROOT%\build\coq-local\dev\nsis\*.exe" dev\nsis || GOTO ErrorExit
+7z a coq-opensource-archive-windows-%ARCHLONG%.zip %CYGROOT%\build\tarballs\* || GOTO ErrorExit
+
+REM DO NOT echo the signing command below, as this would leak secrets in the logs
+IF DEFINED WIN_CERTIFICATE_PATH (
+  IF DEFINED WIN_CERTIFICATE_PASSWORD (
+    ECHO Signing package
+    @signtool sign /f %WIN_CERTIFICATE_PATH% /p %WIN_CERTIFICATE_PASSWORD% dev\nsis\*.exe
+    signtool verify /pa dev\nsis\*.exe
+  )
+)
+
+GOTO :EOF
+
+:ErrorExit
+  ECHO ERROR %0 failed
+  EXIT /b 1


### PR DESCRIPTION
We use a different Docker image because the dependencies have changed slightly in master compared to what was the case in v8.8. (This was BTW the opportunity for me to notice that the Docker image used in master still contains `hevea`.)

I chose to backport all the recent CI changes in one go like this because my usual method of backporting PR by PR would have mean solving conflict after conflict given that there are also a few new or changed CI targets that are not backportable.

~~I chose to remove CircleCI entirely because it has been a long time already that I've stopped running it before backporting and now that it is redundant, it really doesn't make much sense to keep it.~~
EDIT: keeping it until we remove it from master to avoid uncontrollable failing status.

This branch was already tested on Travis, GitLab CI and AppVeyor but on GitLab CI I didn't test the Windows target yet because this was on my fork.