### PR TITLE
[CI] Fix the script used by math-classes.

### DIFF
--- a/dev/ci/ci-math-classes.sh
+++ b/dev/ci/ci-math-classes.sh
@@ -7,4 +7,4 @@ math_classes_CI_DIR="${CI_BUILD_DIR}/math-classes"
 
 git_checkout "${math_classes_CI_BRANCH}" "${math_classes_CI_GITURL}" "${math_classes_CI_DIR}"
 
-( cd "${math_classes_CI_DIR}" && make && make install )
+( cd "${math_classes_CI_DIR}" && ./configure.sh && make && make install )


### PR DESCRIPTION
We call configure to properly regenerate the Makefile and its dependencies.

The current build script of math-classes is somewhat strange as it has a hardcoded makefile that is never regenerated. This is troublesome if one wishes to add files to the library, or switch Coq versions.

This is required for the CI of #7536 to succeed.