### PR TITLE
Update CODEOWNERS (mostly regarding the test-suite)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -51,7 +51,7 @@
 # each time someone modifies the dev changelog
 
 /doc/             @maximedenes
-# Secondary maintainer @silene
+# Secondary maintainer @silene @Zimmi48
 
 /man/             @silene
 # Secondary maintainer @maximedenes

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -58,9 +58,9 @@
 
 ########## Coqchk ##########
 
-/checker/         @barras
-/test-suite/coqchk/     @barras
-# Secondary maintainers @maximedenes @ppedrot
+/checker/               @ppedrot
+/test-suite/coqchk/     @ppedrot
+# Secondary maintainers @maximedenes
 
 ########## Coq lib ##########
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -322,6 +322,7 @@
 /Makefile.ci       @ejgallego
 # Secondary maintainer @SkySkimmer
 
+# This file belongs to the doc
 /Makefile.doc        @maximedenes
 # Secondary maintainer @silene
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -59,7 +59,7 @@
 ########## Coqchk ##########
 
 /checker/         @barras
-# Secondary maintainer @maximedenes
+# Secondary maintainers @maximedenes @ppedrot
 
 ########## Coq lib ##########
 
@@ -100,7 +100,7 @@
 ########## Kernel ##########
 
 /kernel/          @maximedenes
-# Secondary maintainer @barras
+# Secondary maintainers @barras @ppedrot
 
 /kernel/byterun/  @maximedenes
 # Secondary maintainer @silene

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -59,11 +59,13 @@
 ########## Coqchk ##########
 
 /checker/         @barras
+/test-suite/coqchk/     @barras
 # Secondary maintainers @maximedenes @ppedrot
 
 ########## Coq lib ##########
 
 /clib/            @ppedrot
+/test-suite/unit-tests/clib/ @ppedrot
 # Secondary maintainer @ejgallego
 
 /lib/             @ejgallego
@@ -90,6 +92,7 @@
 ########## CoqIDE ##########
 
 /ide/             @ppedrot
+/test-suite/ide/  @ppedrot
 # Secondary maintainer @gares
 
 ########## Interpretation ##########
@@ -146,7 +149,8 @@
 /plugins/ltac/          @ppedrot
 # Secondary maintainer @herbelin
 
-/plugins/micromega/     @fajb
+/plugins/micromega/    @fajb
+/test-suite/micromega/ @fajb
 # Secondary maintainer @bgregoir
 
 /plugins/nsatz/         @thery
@@ -162,7 +166,8 @@
 /plugins/ssrmatching/   @gares
 # Secondary maintainer @maximedenes
 
-/plugins/ssr/           @gares
+/plugins/ssr/          @gares
+/test-suite/ssr/       @gares
 # Secondary maintainer @maximedenes
 
 /plugins/syntax/        @ppedrot
@@ -190,13 +195,20 @@
 
 ########## STM ##########
 
-/stm/             @gares
-# Secondary maintainer @ejgallego
+/stm/                    @gares
+/test-suite/interactive/ @gares
+/test-suite/stm/         @gares
+/test-suite/vio/         @gares
+# Secondary maintainer   @ejgallego
 
 ########## Tactics ##########
 
 /tactics/         @ppedrot
 # Secondary maintainer @mattam82
+
+/tactics/class_tactics.* @mattam82
+/test-suite/typeclasses/ @mattam82
+# Secondary maintainer   @ppedrot
 
 ########## Standard library ##########
 
@@ -276,14 +288,14 @@
 
 ########## Tools ##########
 
-/tools/coqdoc/          @silene
+/tools/coqdoc/         @silene
+/test-suite/coqdoc/    @silene
 # Secondary maintainer @mattam82
 
-/tools/coq_makefile*    @gares
-# Secondary maintainer @silene
-
-/tools/CoqMakefile*     @gares
-# Secondary maintainer @silene
+/tools/coq_makefile*      @gares
+/tools/CoqMakefile*       @gares
+/test-suite/coq-makefile/ @gares
+# Secondary maintainer    @silene
 
 /tools/coqdep*          @ppedrot
 # Secondary maintainer @maximedenes
@@ -291,7 +303,8 @@
 /tools/coq_tex*         @silene
 # Secondary maintainer @gares
 
-/tools/coqwc*           @silene
+/tools/coqwc*          @silene
+/test-suite/coqwc/     @silene
 # Secondary maintainer @gares
 
 ########## Toplevel ##########
@@ -325,6 +338,20 @@
 # This file belongs to the doc
 /Makefile.doc        @maximedenes
 # Secondary maintainer @silene
+
+########## Test suite ##########
+
+/test-suite/Makefile    @gares
+/test-suite/_CoqProject @gares
+/test-suite/README.md   @gares
+# Secondary maintainer  @SkySkimmer
+
+/test-suite/save-logs   @SkySkimmer
+
+/test-suite/complexity/ @herbelin
+
+/test-suite/unit-tests/src/ @jfehrle
+# Secondary maintainer      @SkySkimmer
 
 ########## Developer tools ##########
 


### PR DESCRIPTION
This PR is in two parts:

- Add @ppedrot to the list of secondary maintainers for the kernel (without removing @barras). This should mitigate #7346 further and reflect the reality of the situation in #7521 for instance.

- Add maintainers for the test-suite infrastructure and well-delimited components (closes #7426).

@gares agreed to be the primary maintainer for the test-suite. @SkySkimmer is that OK that I put you as the secondary one? (And first one for `save-logs`?)

@jfehrle Would you like to be the primary maintainer for the unit-test infrastructure? The documentation of what is expected of maintainers is here: https://github.com/coq/coq/blob/master/dev/doc/MERGING.md. *You should completely feel free to say no.* I put @SkySkimmer again as secondary maintainer (is that OK with you @SkySkimmer?)

When parts of the test-suite correspond to specific components, I put the same maintainer as for the component. The idea is that these parts will likely be updated simultaneously so this shouldn't create much more noise. We can experiment what it gives in practice. To ease the maintenance, I put these components of the test-suite, not in the test-suite section but in their respective component sections. This is also true for unit tests. For now, there is only `clib/` but as soon as we had more unit tests we should update this file further...