### PR TITLE
[ide] Use Dune to support separate CoqIDE build.

### DIFF
--- a/ide/coqide.opam
+++ b/ide/coqide.opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer:  "The Coq Development Team <coqdev@sympa.inria.fr>"
+authors:     "The Coq Development Team"
+homepage:    "https://coq.inria.fr/"
+bug-reports: "https://github.com/coq/coq/issues"
+dev-repo:    "https://github.com/coq/coq.git"
+license:     "LGPL-2.1"
+
+name: "coqide"
+available: [ocaml-version >= "4.02.3"]
+
+depends: [
+  "coq"       { >= "8.9" & < "8.10" }
+  "camlp5"
+  "jbuild"    { build }
+  "ocamlfind" { build }
+  "num"
+]
+
+build: [["jbuilder" "build" "-p" name "-j" jobs]]

--- a/ide/jbuild
+++ b/ide/jbuild
@@ -1,0 +1,27 @@
+(jbuild_version 1)
+
+(executable
+ ((name idetop)
+  (public_name coqidetop.opt)
+  (package coqide)
+  (modules (idetop))
+  (libraries (coq.toplevel coqide.protocol))
+  (flags -rectypes)
+  (link_flags -linkall)))
+
+(rule
+ ((targets (coqide_main.ml))
+  (deps (coqide_main.ml4))
+  ; XXX: when Coq is built with dune the following line will do the job:
+  ; (action (run coqmlp5 -loc loc -impl ${<} -o ${@}))))
+  (action (system "camlp5o pa_extend.cmo q_MLast.cmo pa_macro.cmo pr_o.cmo -loc loc -impl ${<} -o ${@}"))))
+
+(executable
+ ((name coqide_main)
+  (public_name coqide)
+  (package coqide)
+  (flags -rectypes)
+  (modules (:standard \ idetop))
+  (libraries (dynlink threads str lablgtk2.sourceview2 coq.lib coqide.protocol))))
+
+(ocamllex (utf8_convert config_lexer coq_lex))

--- a/ide/protocol/jbuild
+++ b/ide/protocol/jbuild
@@ -1,0 +1,10 @@
+(jbuild_version 1)
+
+(library
+ ((name protocol)
+  (public_name coqide.protocol)
+  (wrapped false)
+  (flags (-rectypes))
+  (libraries (coq.lib))))
+
+(ocamllex (xml_lexer))


### PR DESCRIPTION
Packagers have long wanted to build CoqIDE against the installed Coq
libraries instead of having to rebuild parts of Coq itself.

In fact, this is indeed possible since since some time, as for example
other topleves in OPAM such as `coq-serapi` do.

We thus provide the needed `dune` files so CoqIDE can be built
separately by issuing `jbuilder build -p coqide`.

This can be backported to 8.8.1, but IMO protocol files should be
moved to its own directory as done in `master`; I don't see a lot of
risk on it tho.

Note that as of today, the resulting files have to be installed in the
same place where the `coqworker*` binaries are installed.  This could
be improved by tweaking the search heuristic of coqide / coqlib.

The Dune-generated `coqide.install` file does the right thing in that
regard.
