### PR TITLE
[build] Add -cclib -lcoqrun options to build of kernel.cmxa.

### DIFF
--- a/META.coq
+++ b/META.coq
@@ -57,9 +57,6 @@ package "vm" (
 # We currently prefer static linking of the VM.
   archive(byte)    = "libcoqrun.a"
   linkopts(byte)   = "-custom"
-
-  linkopts(native) = "-cclib -lcoqrun"
-
 )
 
 package "kernel" (

--- a/Makefile.build
+++ b/Makefile.build
@@ -393,7 +393,6 @@ $(COQTOPEXE): $(TOPBIN:.opt=.$(BEST))
 bin/%.opt$(EXE): topbin/%_bin.ml $(LINKCMX) $(LIBCOQRUN)
 	$(SHOW)'COQMKTOP -o $@'
 	$(HIDE)$(OCAMLOPT) -linkall -linkpkg $(MLINCLUDES) \
-	                   -I kernel/byterun/ -cclib -lcoqrun \
 			   $(SYSMOD) -package camlp5.gramlib \
 			   $(LINKCMX) $(OPTFLAGS) $(LINKMETADATA) $< -o $@
 	$(STRIP) $@
@@ -576,6 +575,11 @@ test-suite: world byte $(ALLSTDLIB).v
 kernel/kernel.cma: kernel/kernel.mllib
 	$(SHOW)'OCAMLC -a -o $@'
 	$(HIDE)$(OCAMLC) $(MLINCLUDES) $(BYTEFLAGS) $(VMBYTEFLAGS) -a -o $@ $(filter-out %.mllib, $^)
+
+# Specific rule for kernel.cmxa as to adjoin -cclib -lcoqrun
+kernel/kernel.cmxa: kernel/kernel.mllib
+	$(SHOW)'OCAMLOPT -a -o $@'
+	$(HIDE)$(OCAMLOPT) $(MLINCLUDES) $(OPTFLAGS) -I kernel/byterun/ -cclib -lcoqrun -a -o $@ $(filter-out %.mllib, $^)
 
 %.cma: %.mllib
 	$(SHOW)'OCAMLC -a -o $@'

--- a/Makefile.ide
+++ b/Makefile.ide
@@ -147,7 +147,6 @@ $(IDETOPEXE): $(IDETOP:.opt=.$(BEST))
 $(IDETOP): ide/idetop.ml $(LINKCMX) $(LIBCOQRUN) $(IDETOPCMX)
 	$(SHOW)'COQMKTOP -o $@'
 	$(HIDE)$(OCAMLOPT) -linkall -linkpkg $(MLINCLUDES) -I ide \
-	                   -I kernel/byterun/ -cclib -lcoqrun \
 			   $(SYSMOD) -package camlp5.gramlib \
 			   $(LINKCMX) $(IDETOPCMX) $(OPTFLAGS) $(LINKMETADATA) $< -o $@
 	$(STRIP) $@


### PR DESCRIPTION
It seems that it is standard practice in the OCaml world to set the
`-cclib` flags at library creation time, at least in native libraries.

Indeed, this seems to make linking easier as seen for example in #7563.
