### PR TITLE
Fixing debugger after #6859 (loading dynlink.cma before lib.cma).

### DIFF
--- a/dev/checker.dbg
+++ b/dev/checker.dbg
@@ -1,5 +1,6 @@
 load_printer threads.cma
 load_printer str.cma
 load_printer clib.cma
+load_printer dynlink.cma
 load_printer lib.cma
 load_printer check.cma

--- a/dev/core.dbg
+++ b/dev/core.dbg
@@ -2,8 +2,8 @@ source camlp5.dbg
 load_printer threads.cma
 load_printer str.cma
 load_printer clib.cma
-load_printer lib.cma
 load_printer dynlink.cma
+load_printer lib.cma
 load_printer kernel.cma
 load_printer library.cma
 load_printer engine.cma


### PR DESCRIPTION
<!-- Keep what applies -->
**Kind:** developer bug fix

As mentioned by @ejgallego on gitter, this is needed to call the debugger after #6859. Assigning it to @ejgallego.

In passing, I tried to call the debugger on coqchk and I had to manually add the directory `../dev/` for `checker.dbg` to be found. By the way, @skyskimmer, would you have 2 lines to add to `dev/doc/debugging.md` to explain how to use the debugger with `coqchk`?