### PR TITLE
Mention warning and error message docs in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,5 +12,5 @@ Fixes / closes #????
 
 <!-- If this is a feature pull request / breaks compatibility: -->
 <!-- (Otherwise, remove these lines.) -->
-- [ ] Corresponding documentation was added / updated.
+- [ ] Corresponding documentation was added / updated (including any warning- and error-messages added / removed / modified).
 - [ ] Entry added in CHANGES.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,5 +12,5 @@ Fixes / closes #????
 
 <!-- If this is a feature pull request / breaks compatibility: -->
 <!-- (Otherwise, remove these lines.) -->
-- [ ] Corresponding documentation was added / updated (including any warning- and error-messages added / removed / modified).
+- [ ] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
 - [ ] Entry added in CHANGES.


### PR DESCRIPTION
This closes #7580

c.f. https://github.com/coq/coq/pull/7559#issuecomment-390749207 and
https://github.com/coq/coq/pull/7559#issuecomment-390872924.  This
should be reverted if and when we move to autogenerated docs for
warnings and errors, as suggested in #7373.

**Kind:** documentation / infrastructure.

Fixes / closes #7580