### PR TITLE
Fix #7586: Anomaly "Uncaught exception Not_found".

### DIFF
--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -1391,7 +1391,7 @@ let w_merge env with_types flags (evd,metas,evars : subst0) =
 	      
   and mimick_undefined_evar evd flags hdc nargs sp =
     let ev = Evd.find_undefined evd sp in
-    let sp_env = Global.env_of_context ev.evar_hyps in
+    let sp_env = Global.env_of_context (evar_filtered_hyps ev) in
     let (evd', c) = applyHead sp_env evd nargs hdc in
     let (evd'',mc,ec) =
       unify_0 sp_env evd' CUMUL flags

--- a/test-suite/bugs/closed/7392.v
+++ b/test-suite/bugs/closed/7392.v
@@ -1,0 +1,9 @@
+Inductive R : nat -> Prop := ER : forall n, R n -> R (S n).
+
+Goal (forall (n : nat), R n -> False) -> True -> False.
+Proof.
+intros H0 H1.
+eapply H0.
+clear H1.
+apply ER.
+simpl.


### PR DESCRIPTION
The old unification engine was using the unfiltered environment when a
context had been cleared, leading to an ill-typed goal.

Fixes #7586.
