### PR TITLE
Don't try to install native compiled files if native-compile is not set

### DIFF
--- a/Makefile.install
+++ b/Makefile.install
@@ -82,7 +82,7 @@ endif
 
 install-tools:
 	$(MKDIR) $(FULLBINDIR)
-	# recopie des fichiers de style pour coqide
+	# copy style files for coqide
 	$(MKDIR) $(FULLCOQLIB)/tools/coqdoc
 	$(INSTALLLIB) tools/coqdoc/coqdoc.css tools/coqdoc/coqdoc.sty $(FULLCOQLIB)/tools/coqdoc
 	$(INSTALLBIN) $(TOOLS) $(FULLBINDIR)

--- a/Makefile.vofiles
+++ b/Makefile.vofiles
@@ -30,9 +30,10 @@ vo_to_cm = $(foreach vo,$(1),$(dir $(vo)).coq-native/$(subst /,_,$(patsubst theo
 vo_to_obj = $(foreach vo,$(1),$(dir $(vo)).coq-native/$(subst /,_,$(patsubst theories/%,NCoq_%,$(patsubst plugins/%,NCoq_%,$(vo:.vo=.o)))))
 
 GLOBFILES:=$(ALLVO:.vo=.glob)
-LIBFILES:=$(ALLVO) $(call vo_to_cm,$(ALLVO)) \
-	    $(call vo_to_obj,$(ALLVO)) \
-	    $(VFILES) $(GLOBFILES)
+ifdef NATIVECOMPUTE
+NATIVEFILES := $(call vo_to_cm,$(ALLVO)) $(call vo_to_obj,$(ALLVO))
+endif
+LIBFILES:=$(ALLVO) $(NATIVEFILES) $(VFILES) $(GLOBFILES)
 
 # For emacs:
 # Local Variables:


### PR DESCRIPTION
**Kind:** infrastructure.

`make install` tries to install native-compiled files even when the build is not using native-compile (the default option on win32 and cygwin).  This generates a vast number of error messages similar to those shown below.  It is also surprisingly slow, at least on my system.  This change makes the installation conditional.

```
install: cannot stat 'plugins/setoid_ring/.coq-native/NCoq_setoid_ring_ArithRing.cm*': No such file or directory
install: cannot stat 'plugins/setoid_ring/.coq-native/NCoq_setoid_ring_ZArithRing.o': No such file or directory
```
