### PR TITLE
Fix #5983 (many frequent AppVeyor failures) by increasing spawn timeout.

### DIFF
--- a/lib/spawn.ml
+++ b/lib/spawn.ml
@@ -10,7 +10,7 @@
 
 let proto_version = 0
 let prefer_sock = Sys.os_type = "Win32"
-let accept_timeout = 2.0
+let accept_timeout = 10.0
 
 let pr_err s = Printf.eprintf "(Spawn  ,%d) %s\n%!" (Unix.getpid ()) s
 let prerr_endline s = if !Flags.debug then begin pr_err s end else ()


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** bug fix

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes #5983

The same workaround was used for the Sphinx timeouts.