### PR TITLE
Fix recipe for FAKEIDEBYTE

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -560,7 +560,7 @@ $(FAKEIDE): $(call bestobj, $(FAKEIDECMO)) | $(IDETOP)
 	$(SHOW)'OCAMLBEST -o $@'
 	$(HIDE)$(call bestocaml, -I ide -package str -package dynlink)
 
-$(FAKEIDEBYTE): $(FAKEIDECMO) | $(IDETOPLOOPCMA)
+$(FAKEIDEBYTE): $(FAKEIDECMO) | $(IDETOPBYTE)
 	$(SHOW)'OCAMLC -o $@'
 	$(HIDE)$(call ocamlbyte, -I ide -package str,unix,threads)
 


### PR DESCRIPTION
Caused by a semantic conflict with the separate toplevels PR.
