### PR TITLE
Faster and cleaner fconstr-to-constr conversion function.

### DIFF
--- a/kernel/cClosure.mli
+++ b/kernel/cClosure.mli
@@ -244,6 +244,6 @@ val kni: clos_infos -> fconstr infos_tab -> fconstr -> stack -> fconstr * stack
 val knr: clos_infos -> fconstr infos_tab -> fconstr -> stack -> fconstr * stack
 val kl : clos_infos -> fconstr infos_tab -> fconstr -> constr
 
-val to_constr : (lift -> fconstr -> constr) -> lift -> fconstr -> constr
+val to_constr : lift -> fconstr -> constr
 
 (** End of cbn debug section i*)

--- a/kernel/esubst.mli
+++ b/kernel/esubst.mli
@@ -72,3 +72,10 @@ val el_liftn : int -> lift -> lift
 val el_lift : lift -> lift
 val reloc_rel : int -> lift -> int
 val is_lift_id : lift -> bool
+
+(** Lift applied to substitution: [lift_subst mk_clos el s] computes a
+    substitution equivalent to applying el then s. Argument
+    mk_clos is used when a closure has to be created, i.e. when
+    el is applied on an element of s.
+*)
+val lift_subst : (lift -> 'a -> 'b) -> lift -> 'a subs -> 'b subs


### PR DESCRIPTION
We untangle the implementation in several ways.
- No higher-order self argument function as there is only one caller.
- Compute composition of lifts + substitution on terms using a dedicated
  function instead of mk_clos followed by to_constr.
- Take more advantage of identity substitutions.

Bench:
```
┌──────────────────────────┬─────────────────────────┬───────────────────────────────────────┬───────────────────────────────────────┬─────────────────────────┬─────────────────┐
│                          │      user time [s]      │              CPU cycles               │           CPU instructions            │  max resident mem [KB]  │   mem faults    │
│                          │                         │                                       │                                       │                         │                 │
│             package_name │     NEW     OLD PDIFF   │            NEW            OLD PDIFF   │            NEW            OLD PDIFF   │     NEW     OLD PDIFF   │ NEW OLD PDIFF   │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│                coq-flocq │  261.84  265.62 -1.42 % │   726815818055   736784714142 -1.35 % │   904399958617   905357590401 -0.11 % │ 1245412 1245548 -0.01 % │   5   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│              coq-bignums │   79.51   80.10 -0.74 % │   219570223062   220892990075 -0.60 % │   285830455287   286150884400 -0.11 % │  519748  519656 +0.02 % │  50   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│               coq-geocoq │ 3075.84 3095.58 -0.64 % │  8536677520416  8589010834875 -0.61 % │ 13786682515241 13795254075289 -0.06 % │ 1239732 1239712 +0.00 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│              coq-unimath │ 1285.33 1292.70 -0.57 % │  3559351630976  3582413036430 -0.64 % │  6028958999957  6048047126643 -0.32 % │  985752 1079564 -8.69 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│               coq-sf-vfa │   26.47   26.62 -0.56 % │    72634096094    72553044551 +0.11 % │    94274191380    94389646309 -0.12 % │  536472  537064 -0.11 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│   coq-mathcomp-odd-order │ 1420.32 1427.78 -0.52 % │  3945225780194  3966755302431 -0.54 % │  6650443687863  6661149536389 -0.16 % │ 1392596 1368680 +1.75 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│   coq-mathcomp-character │  274.00  275.20 -0.44 % │   760306454906   762910757755 -0.34 % │  1085608035736  1086816722162 -0.11 % │ 1130436 1143052 -1.10 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│    coq-mathcomp-solvable │  201.57  202.42 -0.42 % │   557701982541   559051144605 -0.24 % │   770406935336   771046794393 -0.08 % │  864992  868900 -0.45 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│       coq-mathcomp-field │  457.79  459.65 -0.40 % │  1270374569318  1275497555897 -0.40 % │  2055633542359  2056246080133 -0.03 % │  808036  808832 -0.10 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│           coq-coquelicot │   83.70   84.04 -0.40 % │   231183838070   231368461426 -0.08 % │   275391354242   275927530196 -0.19 % │  720040  721172 -0.16 % │  17   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│                coq-sf-lf │   20.86   20.94 -0.38 % │    56707037592    56843281546 -0.24 % │    74015202382    74185996409 -0.23 % │  429648  429616 +0.01 % │   5   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│                  coq-vst │ 3821.40 3835.85 -0.38 % │ 10624629000343 10661857719621 -0.35 % │ 13984728269463 14010204748792 -0.18 % │ 2228252 2226680 +0.07 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│     coq-mathcomp-algebra │  185.22  185.91 -0.37 % │   512039229101   513483566919 -0.28 % │   690992640086   691702137102 -0.10 % │  644096  644484 -0.06 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│ coq-mathcomp-real-closed │  170.87  171.45 -0.34 % │   474628404766   475646441349 -0.21 % │   695461125393   696281602233 -0.12 % │  837340  838412 -0.13 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│                 coq-hott │  333.27  334.36 -0.33 % │   925289711463   928728460967 -0.37 % │  1431010143632  1432669421416 -0.12 % │  588920  588932 -0.00 % │   1   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│            coq-fiat-core │  111.66  111.99 -0.29 % │   310958533200   310936530847 +0.01 % │   380108776010   380542605025 -0.11 % │  498316  497800 +0.10 % │   8   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│    coq-mathcomp-fingroup │   65.13   65.31 -0.28 % │   178559207178   179348995035 -0.44 % │   238911748847   239187782036 -0.12 % │  589144  590016 -0.15 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│         coq-math-classes │  227.44  227.68 -0.11 % │   625174256882   625446258183 -0.04 % │   779422557797   780941093451 -0.19 % │  532932  531996 +0.18 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│                coq-color │  721.61  722.21 -0.08 % │  1993250647702  1996318257795 -0.15 % │  2377224375155  2380416185716 -0.13 % │ 1446260 1445696 +0.04 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│      coq-formal-topology │   37.79   37.76 +0.08 % │   101714882583   101747418754 -0.03 % │   126665387098   126804049615 -0.11 % │  482412  482284 +0.03 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│                 coq-corn │ 1564.31 1562.46 +0.12 % │  4327385452138  4325347202568 +0.05 % │  6434085145418  6439901504916 -0.09 % │  932916  933176 -0.03 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│         coq-fiat-parsers │  701.74  700.74 +0.14 % │  1942726853926  1940215446294 +0.13 % │  2965467496220  2974131370271 -0.29 % │ 3374500 3378656 -0.12 % │   0   4 -100.00 % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│          coq-fiat-crypto │ 4108.61 4100.00 +0.21 % │ 11401917851810 11383598454365 +0.16 % │ 18382428200653 18431509438564 -0.27 % │ 3210284 3200852 +0.29 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│   coq-mathcomp-ssreflect │   45.52   45.34 +0.40 % │   123463495022   123897472831 -0.35 % │   145399583160   145739685397 -0.23 % │  536968  536808 +0.03 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│             coq-compcert │  872.56  867.82 +0.55 % │  2418848934084  2405162557247 +0.57 % │  3471882788131  3481038536160 -0.26 % │ 1387788 1387860 -0.01 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼─────────────────┤
│               coq-sf-plf │   54.00   53.69 +0.58 % │   148683138901   148771919147 -0.06 % │   187586065942   188078261976 -0.26 % │  515204  514460 +0.14 % │   0   0  +nan % │
└──────────────────────────┴─────────────────────────┴───────────────────────────────────────┴───────────────────────────────────────┴─────────────────────────┴─────────────────┘
```