### PR TITLE
Fix notation for code snippet in documentation

### DIFF
--- a/doc/sphinx/proof-engine/tactics.rst
+++ b/doc/sphinx/proof-engine/tactics.rst
@@ -2867,8 +2867,8 @@ the conversion in hypotheses :n:`{+ @ident}`.
         .. coqtop:: all
 
            Definition fcomp A B C f (g : A -> B) (x : A) : C := f (g x).
-           Notation "f \o g" := (fcomp f g) (at level 50).
            Arguments fcomp {A B C} f g x /.
+           Notation "f \o g" := (fcomp f g) (at level 50).
 
      After that command the expression :g:`(f \o g)` is left untouched by
      ``simpl`` while :g:`((f \o g) t)` is reduced to :g:`(f (g t))`.


### PR DESCRIPTION
It failed to compile before because the type arguments were declared implicit *after* introducing the notation

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** documentation.