### PR TITLE
[ssr] rewrite: turn anomaly into regular error

### DIFF
--- a/plugins/ssr/ssrequality.ml
+++ b/plugins/ssr/ssrequality.ml
@@ -417,8 +417,6 @@ let rwcltac cl rdx dir sr gl =
       then errorstrm Pp.(str "Rewriting impacts evars")
       else errorstrm Pp.(str "Dependent type error in rewrite of "
         ++ pr_constr_env (pf_env gl) (project gl) (Term.mkNamedLambda pattern_id (EConstr.Unsafe.to_constr rdxt) (EConstr.Unsafe.to_constr cl)))
-    | CErrors.UserError _ as e -> raise e
-    | e -> anomaly ("cvtac's exception: " ^ Printexc.to_string e);
   in
   tclTHEN cvtac' rwtac gl
 

--- a/test-suite/ssr/ssr_rew_illtyped.v
+++ b/test-suite/ssr/ssr_rew_illtyped.v
@@ -1,0 +1,9 @@
+From Coq Require Import ssreflect Setoid.
+
+Structure SEProp := {prop_of : Prop; _ : prop_of <-> True}.
+
+Fact anomaly: forall P : SEProp, prop_of P.
+Proof.
+move=> [P E].
+Fail rewrite E.
+Abort.


### PR DESCRIPTION
I think the bug was introduces when apply_type was made safe.
In the test joint to #7255 rewrite (setoid case) generates an
ill-typed goal and apply_type raises a Pretype_error.

It is unclear to me why the tactic monad does not turn the
pretype_error into a UserError

Fix #7255 