### PR TITLE
[default.nix] Update dependency list

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -67,6 +67,7 @@ stdenv.mkDerivation rec {
     python
     rsync
     which
+    ocamlPackages.ounit
 
   ] else []) ++ (if lib.inNixShell then [
     ocamlPackages.merlin

--- a/default.nix
+++ b/default.nix
@@ -69,7 +69,6 @@ stdenv.mkDerivation rec {
   ] else []) ++ (if lib.inNixShell then [
     ocamlPackages.merlin
     ocamlPackages.ocpIndent
-    ocamlPackages.ocp-index
 
     # Dependencies of the merging script
     jq

--- a/default.nix
+++ b/default.nix
@@ -35,9 +35,11 @@ stdenv.mkDerivation rec {
 
   name = "coq";
 
-  buildInputs = (with ocamlPackages; [
+  buildInputs = [
 
     # Coq dependencies
+    hostname
+  ] ++ (with ocamlPackages; [
     ocaml
     findlib
     camlp5_strict

--- a/default.nix
+++ b/default.nix
@@ -22,7 +22,7 @@
 # a symlink to where Coq was installed.
 
 { pkgs ? (import <nixpkgs> {})
-, ocamlPackages ? pkgs.ocamlPackages
+, ocamlPackages ? pkgs.ocaml-ng.ocamlPackages_4_06
 , buildIde ? true
 , buildDoc ? true
 , doCheck ? true


### PR DESCRIPTION
Use OCaml 4.06 as the default.
Drop ocp-index (I cannot manage to build it with OCaml 4.06).
Adds hostname and ounit, which were missing.