### PR TITLE
[Makefile] New target “install-merlin”

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,7 @@ export MLLIBFILES := $(call find, '*.mllib')
 export MLPACKFILES := $(call find, '*.mlpack')
 export ML4FILES := $(call find, '*.ml4')
 export CFILES := $(call findindir, 'kernel/byterun', '*.c')
+export MERLINFILES := $(call find, '.merlin')
 
 # NB: The lists of currently existing .ml and .mli files will change
 # before and after a build or a make clean. Hence we do not export

--- a/Makefile.install
+++ b/Makefile.install
@@ -58,7 +58,7 @@ FULLDOCDIR=$(DOCDIR)
 endif
 
 .PHONY: install-coq install-binaries install-byte install-opt
-.PHONY: install-tools install-library install-devfiles
+.PHONY: install-tools install-library install-devfiles install-merlin
 .PHONY: install-coq-info install-coq-manpages install-emacs install-latex
 .PHONY: install-meta
 
@@ -111,6 +111,9 @@ install-devfiles:
 ifeq ($(BEST),opt)
 	$(INSTALLSH)  $(FULLCOQLIB) $(LINKCMX) $(CORECMA:.cma=.a) $(STATICPLUGINS:.cma=.a)
 endif
+
+install-merlin:
+	$(INSTALLSH) $(FULLCOQLIB) $(wildcard $(INSTALLCMX:.cmx=.cmt) $(INSTALLCMI:.cmi=.cmti) $(MLIFILES) $(MLFILES) $(MERLINFILES))
 
 install-library:
 	$(MKDIR) $(FULLCOQLIB)


### PR DESCRIPTION
Building this target installs the files that are used by merlin:
 -  .merlin files (.merlin);
 -  bin-annot files (.cmt, .cmti);
 -  source files (.ml, .mli).

Plug-in developers can thus work with an “installed” version of Coq.
