### PR TITLE
[ssr] Enable flag with_evars in pirrel_rewrite

### DIFF
--- a/plugins/ssr/ssrequality.ml
+++ b/plugins/ssr/ssrequality.ml
@@ -347,7 +347,7 @@ let pirrel_rewrite pred rdx rdx_ty new_rdx dir (sigma, c) c_ty gl =
     try Typing.type_of env sigma proof with _ -> raise PRtype_error in
   ppdebug(lazy Pp.(str"pirrel_rewrite proof term of type: " ++ pr_econstr_env env sigma proof_ty));
   try refine_with 
-    ~first_goes_last:(not !ssroldreworder) ~with_evars:false (sigma, proof) gl
+    ~first_goes_last:(not !ssroldreworder) ~with_evars:true (sigma, proof) gl
   with _ -> 
     (* we generate a msg like: "Unable to find an instance for the variable" *)
     let hd_ty, miss = match EConstr.kind sigma c with


### PR DESCRIPTION
**Kind:** tentative fix

As suggested by @gares, I'm opening this PR to study the impact of changing SSR rewrite's "behavior regarding evars".

#### In particular, before the patch we get:

```
From mathcomp Require Import ssreflect ssrnat bigop.
Lemma test (n : nat) :
  \big[addn/O]_(0 <= j < n) 0 = 0.
Proof.
rewrite eq_bigr.

(* Toplevel input, characters 15-30: *)
(* > rewrite eq_bigr. *)
(* > ^^^^^^^^^^^^^^^ *)
(* Ltac call to "rewrite (ssrrwargs) (ssrclauses)" failed. *)
(* Error: Unable to find an instance for the variable F2. *)
(* Rule's type: *)
(* (forall (R : Type) (idx : R) (op : R -> R -> R) (I : Type) (r : list I) (P : ssrbool.pred I) *)
(*    (F1 F2 : I -> R), *)
(*  (forall i : I, is_true (P i) -> F1 i = F2 i) -> *)
(*  \big[op/idx]_(i <- r | P i) F1 i = \big[op/idx]_(i <- r | P i) F2 i) *)
```

#### and after the patch we get:

```
(* ...same code... *)
rewrite eq_bigr.

(* 2 focused subgoals *)
(* (shelved: 3) (ID 20) *)
(*    *)
(*   n : nat *)
(*   ============================ *)
(*   \sum_(0 <= i < n) ?Goal i = 0 *)
(*  *)
(* subgoal 2 (ID 21) is: *)
(*  forall i : nat, is_true true -> 0 = ?Goal i *)
```