### PR TITLE
Indicate in the doc that clearbody can take several idents

### DIFF
--- a/doc/sphinx/proof-engine/tactics.rst
+++ b/doc/sphinx/proof-engine/tactics.rst
@@ -893,17 +893,14 @@ quantification or an implication.
    This clears the hypothesis :n:`@ident` and all the hypotheses that depend on
    it.
 
-.. tacv:: clearbody @ident
+.. tacv:: clearbody {+ @ident}
    :name: clearbody
 
-   This tactic expects :n:`@ident` to be a local definition then clears its
-   body. Otherwise said, this tactic turns a definition into an assumption.
+   This tactic expects :n:`{+ @ident}` to be local definitions and clears their
+   respective bodies.
+   In other words, it turns the given definitions into assumptions.
 
 .. exn:: @ident is not a local definition.
-
-.. tacv:: clearbody {+ @ident}
-
-   This is equivalent to :n:`clearbody @ident. ... clearbody @ident.`
 
 .. tacn:: revert {+ @ident}
    :name: revert

--- a/doc/sphinx/proof-engine/tactics.rst
+++ b/doc/sphinx/proof-engine/tactics.rst
@@ -879,14 +879,6 @@ quantification or an implication.
 
    This is equivalent to :n:`clear @ident. ... clear @ident.`
 
-.. tacv:: clearbody @ident
-   :name: clearbody
-
-   This tactic expects :n:`@ident` to be a local definition then clears its
-   body. Otherwise said, this tactic turns a definition into an assumption.
-
-.. exn:: @ident is not a local definition.
-
 .. tacv:: clear - {+ @ident}
 
    This tactic clears all the hypotheses except the ones depending in the
@@ -900,6 +892,18 @@ quantification or an implication.
 
    This clears the hypothesis :n:`@ident` and all the hypotheses that depend on
    it.
+
+.. tacv:: clearbody @ident
+   :name: clearbody
+
+   This tactic expects :n:`@ident` to be a local definition then clears its
+   body. Otherwise said, this tactic turns a definition into an assumption.
+
+.. exn:: @ident is not a local definition.
+
+.. tacv:: clearbody {+ @ident}
+
+   This is equivalent to :n:`clearbody @ident. ... clearbody @ident.`
 
 .. tacn:: revert {+ @ident}
    :name: revert


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** documentation.

Change documentation of `clearbody` to account for the fact that it can take several identifiers.

<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [x] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [ ] Entry added in CHANGES.
