### PR TITLE
[Work and discussion in progress] Add `Unguarded` syntax for (co)fixpoints and `Assumed Positive` for (co)inductive types.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -37,6 +37,9 @@ Vernacular Commands
 - Nested proofs may be enabled through the option `Nested Proofs Allowed`.
   By default, they are disabled and produce an error. The deprecation
   warning which used to occur when using nested proofs has been removed.
+- Guard check can be temporary disabled to define non terminating fixpoints
+  or non productive cofixpoints with the commands `Unguarded Fixpoints`
+  and `Unguarded CoFixpoint`.
 
 Coq binaries and process model
 

--- a/CHANGES
+++ b/CHANGES
@@ -38,8 +38,11 @@ Vernacular Commands
   By default, they are disabled and produce an error. The deprecation
   warning which used to occur when using nested proofs has been removed.
 - Guard check can be temporary disabled to define non terminating fixpoints
-  or non productive cofixpoints with the commands `Unguarded Fixpoints`
+  or non productive cofixpoints with the commands `Unguarded Fixpoint`
   and `Unguarded CoFixpoint`.
+- Positivity check can be temporary disabled to define non positive inductive
+  or coinductive types with the commands `Assumed Positive Inductive`
+  and `Assumed Positive CoInductive`.
 
 Coq binaries and process model
 

--- a/dev/doc/changes.md
+++ b/dev/doc/changes.md
@@ -8,6 +8,13 @@ Misctypes
   to `Glob_term`, as these are turned into kernel terms by
   `Pretyping`.
 
+- Arguments `check_guard` or `check_positivity` have been added to
+  `do_(co)fixpoint`, `declare_(co)fixpoint`, `do_mutual_inductive`,
+  and `declare_mutual_inductive_with_eliminations`. You can set it
+  to `None` if you don't want to customize guard/positivity checking.
+  Attributes have been added to `Vernacinterp.atts`, they also can be
+  set to `None`.
+
 Proof engine
 
 - More functions have been changed to use `EConstr`, notably the

--- a/doc/sphinx/language/gallina-specification-language.rst
+++ b/doc/sphinx/language/gallina-specification-language.rst
@@ -1141,10 +1141,16 @@ constructions.
 
    .. example::
 
+<<<<<<< 8a15241643eaf41b8b367f05b465fd90153437a2
       The recursive call may not only be on direct subterms of the recursive
       variable :g:`n` but also on a deeper subterm and we can directly write
       the function :g:`mod2` which gives the remainder modulo 2 of a natural
       number.
+=======
+The check of decreasing argument can be temporary disabled using ``Unguarded``.
+Warning: this can break the consistency of the system, use at your own risk.
+Unchecked fixpoint are printed by ``Print Assumptions``.
+>>>>>>> Fix documentation.
 
          Fixpoint mod2 (n:nat) : nat :=
          match n with
@@ -1260,6 +1266,7 @@ Definitions of recursive objects in co-inductive types
       mutually dependent methods.
 
    .. cmdv:: Unguarded CoFixpoint @ident {? @binders } {? : @type } := @term
+
       Define a cofixpoint without checking productivity.
       Warning: this can break the consistency of the system, use at your own risk.
       Unchecked cofixpoint are printed by ``Print Assumptions``.

--- a/doc/sphinx/language/gallina-specification-language.rst
+++ b/doc/sphinx/language/gallina-specification-language.rst
@@ -508,12 +508,12 @@ The Vernacular
                       : | ( `ident` … `ident` : `term` ) … ( `ident` … `ident` : `term` )
    definition         : [Local] Definition `ident` [`binders`] [: `term`] := `term` .
                       : | Let `ident` [`binders`] [: `term`] := `term` .
-   inductive          : Inductive `ind_body` with … with `ind_body` .
-                      : | CoInductive `ind_body` with … with `ind_body` .
+   inductive          : [Assumed Positive] Inductive `ind_body` with … with `ind_body` .
+                      : | [Assumed Positive] CoInductive `ind_body` with … with `ind_body` .
    ind_body           : `ident` [`binders`] : `term` :=
                       : [[|] `ident` [`binders`] [:`term`] | … | `ident` [`binders`] [:`term`]]
    fixpoint           : [Unguarded] Fixpoint `fix_body` with … with `fix_body` .
-                      : | CoFixpoint `cofix_body` with … with `cofix_body` .
+                      : | [Unguarded] CoFixpoint `cofix_body` with … with `cofix_body` .
    assertion          : `assertion_keyword` `ident` [`binders`] : `term` .
    assertion_keyword  : Theorem | Lemma
                       : | Remark | Fact
@@ -740,6 +740,13 @@ Simple inductive types
       The types of the constructors have to satisfy a *positivity condition*
       (see Section :ref:`positivity`). This condition ensures the soundness of
       the inductive definition.
+
+   .. cmdv:: Assumed Positive Inductive @ident : {? @sort } := {? | } @ident : @type {* | @ident : @type }
+      :name: Assumed Positive Inductive
+
+      The positivity condition checking can be disabled using :cmd:`Assumed Positive
+      Inductive`. Warning: this can break the consistency of the system, use at your
+      own risk. Unchecked inductive types are printed by :cmd:`Print Assumptions`.
 
    .. exn:: The conclusion of @type is not valid; it must be built from @ident.
 
@@ -1045,6 +1052,13 @@ co-inductive definitions are also allowed.
    object of type :g:`(EqSt s1 s2)`. We will see how to introduce infinite
    objects in Section :ref:`cofixpoint`.
 
+.. cmdv:: Assumed Positive CoInductive @ident : {? @sort } := {? | } @ident : @type {* | @ident : @type }
+   :name: Assumed Positive CoInductive
+
+   The positivity condition checking can be disabled using :cmd:`Assumed Positive
+   CoInductive`. Warning: this can break the consistency of the system, use at your
+   own risk. Unchecked coinductive types are printed by :cmd:`Print Assumptions`.
+
 Definition of recursive functions
 ---------------------------------
 
@@ -1141,16 +1155,12 @@ constructions.
 
    .. example::
 
-<<<<<<< 8a15241643eaf41b8b367f05b465fd90153437a2
       The recursive call may not only be on direct subterms of the recursive
       variable :g:`n` but also on a deeper subterm and we can directly write
       the function :g:`mod2` which gives the remainder modulo 2 of a natural
       number.
-=======
-The check of decreasing argument can be temporary disabled using ``Unguarded``.
-Warning: this can break the consistency of the system, use at your own risk.
-Unchecked fixpoint are printed by ``Print Assumptions``.
->>>>>>> Fix documentation.
+
+      .. coqtop:: all
 
          Fixpoint mod2 (n:nat) : nat :=
          match n with
@@ -1184,10 +1194,12 @@ Unchecked fixpoint are printed by ``Print Assumptions``.
             end.
 
    .. cmdv:: Unguarded Fixpoint @ident @binders {? {struct @ident} } {? : @type } := @term
+      :name: Unguarded Fixpoint
 
-      The check of decreasing argument can be temporary disabled using ``Unguarded``.
-      Warning: this can break the consistency of the system, use at your own risk.
-      Unchecked fixpoint are printed by ``Print Assumptions``.
+      The check of decreasing argument can be temporary disabled using :cmd:`Unguarded Fixpoint`.
+      Warning: this can break the consistency of the system, use at your own risk. Decreasing
+      argument can still be specified but the decrease is not checked anymore. Unchecked fixpoint
+      are printed by :cmd:`Print Assumptions`.
 
       .. example::
          False can be proved in the following way.
@@ -1199,20 +1211,22 @@ Unchecked fixpoint are printed by ``Print Assumptions``.
 
       .. example::
 
-         Decreasing argument can still be specified but the decrease is not checked anymore.
-         Here is for instance the definition of the Ackermann function.
-
          .. coqtop:: all
 
-            Unguarded Fixpoint ackermann (m n : nat) {struct m} : nat.
-              destruct m. exact (S n).
-              destruct n. exact (ackermann m 1).
-              exact (ackermann m (ackermann (S m) n)).
-            Defined.
+            Unguarded Fixpoint ackermann (m n : nat) {struct m} : nat :=
+              match m with
+              | 0 => S n
+              | S m =>
+                  match n with
+                  | 0 => ackermann m 1
+                  | S n => ackermann m (ackermann (S m) n)
+                  end
+              end.
 
             Print Assumptions ackermann.
-            (* ackermann is assumed to be guarded *)
 
+         Note that the proper way to define the Ackermann function is to use
+         well-founded recursion (see. :cmd:`Program Fixpoint`).
 
 .. _cofixpoint:
 
@@ -1266,10 +1280,11 @@ Definitions of recursive objects in co-inductive types
       mutually dependent methods.
 
    .. cmdv:: Unguarded CoFixpoint @ident {? @binders } {? : @type } := @term
+      :name: Unguarded CoFixpoint
 
-      Define a cofixpoint without checking productivity.
-      Warning: this can break the consistency of the system, use at your own risk.
-      Unchecked cofixpoint are printed by ``Print Assumptions``.
+      Define a cofixpoint without checking productivity. Warning: this can
+      break the consistency of the system, use at your own risk. Unchecked
+      cofixpoint are printed by :cmd:`Print Assumptions`.
 
 .. _Assertions:
 

--- a/doc/sphinx/language/gallina-specification-language.rst
+++ b/doc/sphinx/language/gallina-specification-language.rst
@@ -512,7 +512,7 @@ The Vernacular
                       : | CoInductive `ind_body` with … with `ind_body` .
    ind_body           : `ident` [`binders`] : `term` :=
                       : [[|] `ident` [`binders`] [:`term`] | … | `ident` [`binders`] [:`term`]]
-   fixpoint           : Fixpoint `fix_body` with … with `fix_body` .
+   fixpoint           : [Unguarded] Fixpoint `fix_body` with … with `fix_body` .
                       : | CoFixpoint `cofix_body` with … with `cofix_body` .
    assertion          : `assertion_keyword` `ident` [`binders`] : `term` .
    assertion_keyword  : Theorem | Lemma
@@ -1146,8 +1146,6 @@ constructions.
       the function :g:`mod2` which gives the remainder modulo 2 of a natural
       number.
 
-      .. coqtop:: all
-
          Fixpoint mod2 (n:nat) : nat :=
          match n with
          | O => O
@@ -1178,6 +1176,37 @@ constructions.
             | leaf b => 1
             | cons t f' => (tree_size t + forest_size f')
             end.
+
+   .. cmdv:: Unguarded Fixpoint @ident @binders {? {struct @ident} } {? : @type } := @term
+
+      The check of decreasing argument can be temporary disabled using ``Unguarded``.
+      Warning: this can break the consistency of the system, use at your own risk.
+      Unchecked fixpoint are printed by ``Print Assumptions``.
+
+      .. example::
+         False can be proved in the following way.
+
+         .. coqtop:: all
+
+            Unguarded Fixpoint f (n : nat) : False
+              := f n.
+
+      .. example::
+
+         Decreasing argument can still be specified but the decrease is not checked anymore.
+         Here is for instance the definition of the Ackermann function.
+
+         .. coqtop:: all
+
+            Unguarded Fixpoint ackermann (m n : nat) {struct m} : nat.
+              destruct m. exact (S n).
+              destruct n. exact (ackermann m 1).
+              exact (ackermann m (ackermann (S m) n)).
+            Defined.
+
+            Print Assumptions ackermann.
+            (* ackermann is assumed to be guarded *)
+
 
 .. _cofixpoint:
 
@@ -1229,6 +1258,11 @@ Definitions of recursive objects in co-inductive types
 
       As in the :cmd:`Fixpoint` command, it is possible to introduce a block of
       mutually dependent methods.
+
+   .. cmdv:: Unguarded CoFixpoint @ident {? @binders } {? : @type } := @term
+      Define a cofixpoint without checking productivity.
+      Warning: this can break the consistency of the system, use at your own risk.
+      Unchecked cofixpoint are printed by ``Print Assumptions``.
 
 .. _Assertions:
 

--- a/library/decl_kinds.ml
+++ b/library/decl_kinds.ml
@@ -12,6 +12,8 @@
 
 type discharge = DoDischarge | NoDischarge
 
+type check_guard = bool option
+
 type locality = Discharge | Local | Global
 
 type binding_kind = Explicit | Implicit

--- a/plugins/funind/g_indfun.ml4
+++ b/plugins/funind/g_indfun.ml4
@@ -157,7 +157,7 @@ VERNAC COMMAND EXTEND Function
            | _,((_,(_,CStructRec),_,_,_),_) -> false) recsl in
          match
            Vernac_classifier.classify_vernac
-             (Vernacexpr.(VernacExpr([], VernacFixpoint(None, Decl_kinds.NoDischarge, List.map snd recsl))))
+             (Vernacexpr.(VernacExpr([], VernacFixpoint(Decl_kinds.NoDischarge, List.map snd recsl))))
          with
          | Vernacexpr.VtSideff ids, _ when hard ->
              Vernacexpr.(VtStartProof ("Classic", GuaranteesOpacity, ids), VtLater)

--- a/plugins/funind/g_indfun.ml4
+++ b/plugins/funind/g_indfun.ml4
@@ -157,7 +157,7 @@ VERNAC COMMAND EXTEND Function
            | _,((_,(_,CStructRec),_,_,_),_) -> false) recsl in
          match
            Vernac_classifier.classify_vernac
-             (Vernacexpr.(VernacExpr([], VernacFixpoint(Decl_kinds.NoDischarge, List.map snd recsl))))
+             (Vernacexpr.(VernacExpr([], VernacFixpoint(None, Decl_kinds.NoDischarge, List.map snd recsl))))
          with
          | Vernacexpr.VtSideff ids, _ when hard ->
              Vernacexpr.(VtStartProof ("Classic", GuaranteesOpacity, ids), VtLater)

--- a/plugins/funind/glob_term_to_relation.ml
+++ b/plugins/funind/glob_term_to_relation.ml
@@ -1500,7 +1500,7 @@ let do_build_inductive
   let _time2 = System.get_time () in
   try
     with_full_print
-      (Flags.silently (ComInductive.do_mutual_inductive rel_inds (Flags.is_universe_polymorphism ()) false false))
+      (Flags.silently (ComInductive.do_mutual_inductive ~check_positivity:None rel_inds (Flags.is_universe_polymorphism ()) false false))
       Declarations.Finite
   with
     | UserError(s,msg) as e ->

--- a/plugins/funind/indfun.ml
+++ b/plugins/funind/indfun.ml
@@ -432,7 +432,7 @@ let register_struct is_rec (fixpoint_exprl:(Vernacexpr.fixpoint_expr * Vernacexp
        in
        evd,List.rev rev_pconstants
     | _ ->
-       ComFixpoint.do_fixpoint Global (Flags.is_universe_polymorphism ()) fixpoint_exprl;
+       ComFixpoint.do_fixpoint None Global (Flags.is_universe_polymorphism ()) fixpoint_exprl;
        let evd,rev_pconstants =
 	 List.fold_left
            (fun (evd,l) ((({CAst.v=fname},_),_,_,_,_),_) ->

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -915,9 +915,9 @@ let pr_assumptionset env sigma s =
       | Constant kn ->
           safe_pr_constant env kn ++ safe_pr_ltype typ
       | Positive m ->
-          hov 2 (MutInd.print m ++ spc () ++ strbrk"is positive.")
+          hov 2 (MutInd.print m ++ spc () ++ strbrk"is assumed to be positive")
       | Guarded kn ->
-          hov 2 (safe_pr_constant env kn ++ spc () ++ strbrk"is positive.")
+          hov 2 (safe_pr_constant env kn ++ spc () ++ strbrk"is assumed to be guarded")
     in
     let fold t typ accu =
       let (v, a, o, tr) = accu in

--- a/stm/vernac_classifier.ml
+++ b/stm/vernac_classifier.ml
@@ -202,7 +202,7 @@ let classify_vernac e =
       let poly = List.fold_left (fun poly f ->
           match f with
           | VernacPolymorphic b -> b
-          | (VernacProgram | VernacLocal _ | VernacGuarded _) -> poly
+          | (VernacProgram | VernacLocal _ | VernacGuarded _ | VernacCheckedPositive _) -> poly
         ) poly f in
       static_classifier ~poly e
     | VernacTimeout (_,e) -> static_control_classifier ~poly e

--- a/stm/vernac_classifier.ml
+++ b/stm/vernac_classifier.ml
@@ -105,7 +105,7 @@ let classify_vernac e =
         let ids = List.map (fun (({v=i}, _), _) -> i) l in
        let guarantee = if poly then Doesn'tGuaranteeOpacity else GuaranteesOpacity in
         VtStartProof (default_proof_mode (),guarantee,ids), VtLater
-    | VernacFixpoint (discharge,l) ->
+    | VernacFixpoint (_, discharge,l) ->
        let guarantee =
          if discharge = Decl_kinds.DoDischarge || poly then Doesn'tGuaranteeOpacity
          else GuaranteesOpacity
@@ -116,7 +116,7 @@ let classify_vernac e =
         if open_proof
         then VtStartProof (default_proof_mode (),guarantee,ids), VtLater
         else VtSideff ids, VtLater
-    | VernacCoFixpoint (discharge,l) ->
+    | VernacCoFixpoint (_, discharge,l) ->
        let guarantee =
          if discharge = Decl_kinds.DoDischarge || poly then Doesn'tGuaranteeOpacity
          else GuaranteesOpacity

--- a/stm/vernac_classifier.ml
+++ b/stm/vernac_classifier.ml
@@ -105,7 +105,7 @@ let classify_vernac e =
         let ids = List.map (fun (({v=i}, _), _) -> i) l in
        let guarantee = if poly then Doesn'tGuaranteeOpacity else GuaranteesOpacity in
         VtStartProof (default_proof_mode (),guarantee,ids), VtLater
-    | VernacFixpoint (_, discharge,l) ->
+    | VernacFixpoint (discharge,l) ->
        let guarantee =
          if discharge = Decl_kinds.DoDischarge || poly then Doesn'tGuaranteeOpacity
          else GuaranteesOpacity
@@ -116,7 +116,7 @@ let classify_vernac e =
         if open_proof
         then VtStartProof (default_proof_mode (),guarantee,ids), VtLater
         else VtSideff ids, VtLater
-    | VernacCoFixpoint (_, discharge,l) ->
+    | VernacCoFixpoint (discharge,l) ->
        let guarantee =
          if discharge = Decl_kinds.DoDischarge || poly then Doesn'tGuaranteeOpacity
          else GuaranteesOpacity
@@ -202,7 +202,7 @@ let classify_vernac e =
       let poly = List.fold_left (fun poly f ->
           match f with
           | VernacPolymorphic b -> b
-          | (VernacProgram | VernacLocal _) -> poly
+          | (VernacProgram | VernacLocal _ | VernacGuarded _) -> poly
         ) poly f in
       static_classifier ~poly e
     | VernacTimeout (_,e) -> static_control_classifier ~poly e

--- a/vernac/comFixpoint.mli
+++ b/vernac/comFixpoint.mli
@@ -19,12 +19,12 @@ open Vernacexpr
 (** Entry points for the vernacular commands Fixpoint and CoFixpoint *)
 
 val do_fixpoint :
-  (* When [false], assume guarded. *)
-  locality -> polymorphic -> (fixpoint_expr * decl_notation list) list -> unit
+  (* When [Some false], assume guarded. *)
+  bool option -> locality -> polymorphic -> (fixpoint_expr * decl_notation list) list -> unit
 
 val do_cofixpoint :
-  (* When [false], assume guarded. *)
-  locality -> polymorphic -> (cofixpoint_expr * decl_notation list) list -> unit
+  (* When [Some false], assume guarded. *)
+  bool option -> locality -> polymorphic -> (cofixpoint_expr * decl_notation list) list -> unit
 
 (************************************************************************)
 (** Internal API  *)
@@ -80,12 +80,13 @@ val interp_fixpoint :
 (** Registering fixpoints and cofixpoints in the environment *)
 (** [Not used so far] *)
 val declare_fixpoint :
-  locality -> polymorphic ->
+  bool option -> locality -> polymorphic ->
   recursive_preentry * Univdecls.universe_decl * UState.t *
   (Context.Rel.t * Impargs.manual_implicits * int option) list ->
   Proof_global.lemma_possible_guards -> decl_notation list -> unit
 
-val declare_cofixpoint : locality -> polymorphic ->
+val declare_cofixpoint :
+  bool option -> locality -> polymorphic ->
   recursive_preentry * Univdecls.universe_decl * UState.t *
   (Context.Rel.t * Impargs.manual_implicits * int option) list ->
   decl_notation list -> unit

--- a/vernac/comFixpoint.mli
+++ b/vernac/comFixpoint.mli
@@ -19,12 +19,10 @@ open Vernacexpr
 (** Entry points for the vernacular commands Fixpoint and CoFixpoint *)
 
 val do_fixpoint :
-  (* When [Some false], assume guarded. *)
-  bool option -> locality -> polymorphic -> (fixpoint_expr * decl_notation list) list -> unit
+  check_guard:check_guard -> locality -> polymorphic -> (fixpoint_expr * decl_notation list) list -> unit
 
 val do_cofixpoint :
-  (* When [Some false], assume guarded. *)
-  bool option -> locality -> polymorphic -> (cofixpoint_expr * decl_notation list) list -> unit
+  check_guard:check_guard -> locality -> polymorphic -> (cofixpoint_expr * decl_notation list) list -> unit
 
 (************************************************************************)
 (** Internal API  *)
@@ -80,13 +78,13 @@ val interp_fixpoint :
 (** Registering fixpoints and cofixpoints in the environment *)
 (** [Not used so far] *)
 val declare_fixpoint :
-  bool option -> locality -> polymorphic ->
+  check_guard:check_guard -> locality -> polymorphic ->
   recursive_preentry * Univdecls.universe_decl * UState.t *
   (Context.Rel.t * Impargs.manual_implicits * int option) list ->
   Proof_global.lemma_possible_guards -> decl_notation list -> unit
 
 val declare_cofixpoint :
-  bool option -> locality -> polymorphic ->
+  check_guard:check_guard -> locality -> polymorphic ->
   recursive_preentry * Univdecls.universe_decl * UState.t *
   (Context.Rel.t * Impargs.manual_implicits * int option) list ->
   decl_notation list -> unit

--- a/vernac/comInductive.mli
+++ b/vernac/comInductive.mli
@@ -20,8 +20,9 @@ open Decl_kinds
 (** Entry points for the vernacular commands Inductive and CoInductive *)
 
 val do_mutual_inductive :
-  (one_inductive_expr * decl_notation list) list -> cumulative_inductive_flag ->
-  polymorphic -> private_flag -> Declarations.recursivity_kind -> unit
+  check_positivity:check_guard -> (one_inductive_expr * decl_notation list) list ->
+  cumulative_inductive_flag -> polymorphic -> private_flag ->
+  Declarations.recursivity_kind -> unit
 
 (************************************************************************)
 (** Internal API  *)
@@ -37,8 +38,8 @@ type one_inductive_impls =
   Impargs.manual_implicits list (** for constrs *)
 
 val declare_mutual_inductive_with_eliminations :
-  mutual_inductive_entry -> UnivNames.universe_binders -> one_inductive_impls list ->
-  MutInd.t
+  check_positivity:check_guard -> mutual_inductive_entry -> UnivNames.universe_binders ->
+  one_inductive_impls list -> MutInd.t
 
 (** Exported for Funind *)
 

--- a/vernac/g_vernac.ml4
+++ b/vernac/g_vernac.ml4
@@ -78,9 +78,15 @@ GEXTEND Gram
     ]
   ;
   vernac:
+    [ [ IDENT "Unguarded";   (f, v) = vernac_loc -> (VernacGuarded false  :: f, v)
+      (* Disabled to not confuse the user: for the moment there is not way to disable guard check globally. *)
+      (* | IDENT "Guarded"; (f, v) = vernac_loc -> (VernacGuarded true :: f, v) *)
+      | v = vernac_loc -> v ]
+    ]
+  ;
+  vernac_loc:
     [ [ IDENT "Local"; (f, v) = vernac_poly -> (VernacLocal true :: f, v)
       | IDENT "Global"; (f, v) = vernac_poly -> (VernacLocal false :: f, v)
-
       | v = vernac_poly -> v ]
     ]
   ;
@@ -169,17 +175,13 @@ GEXTEND Gram
           let indl=List.map (fun ((a,b,c,d),e) -> ((a,b,c,k,d),e)) indl in
           VernacInductive (cum, priv,f,indl)
       | "Fixpoint"; recs = LIST1 rec_definition SEP "with" ->
-          VernacFixpoint (None, NoDischarge, recs)
+          VernacFixpoint (NoDischarge, recs)
       | IDENT "Let"; "Fixpoint"; recs = LIST1 rec_definition SEP "with" ->
-          VernacFixpoint (None, DoDischarge, recs)
-      | IDENT "Unguarded"; "Fixpoint"; recs = LIST1 rec_definition SEP "with" ->
-          VernacFixpoint (Some false, NoDischarge, recs)
+          VernacFixpoint (DoDischarge, recs)
       | "CoFixpoint"; corecs = LIST1 corec_definition SEP "with" ->
-          VernacCoFixpoint (None, NoDischarge, corecs)
+          VernacCoFixpoint (NoDischarge, corecs)
       | IDENT "Let"; "CoFixpoint"; corecs = LIST1 corec_definition SEP "with" ->
-          VernacCoFixpoint (None, DoDischarge, corecs)
-      | IDENT "Unguarded"; "CoFixpoint"; corecs = LIST1 corec_definition SEP "with" ->
-          VernacCoFixpoint (Some false, DoDischarge, corecs)
+          VernacCoFixpoint (DoDischarge, corecs)
       | IDENT "Scheme"; l = LIST1 scheme SEP "with" -> VernacScheme l
       | IDENT "Combined"; IDENT "Scheme"; id = identref; IDENT "from";
 	      l = LIST1 identref SEP "," -> VernacCombinedScheme (id, l)

--- a/vernac/g_vernac.ml4
+++ b/vernac/g_vernac.ml4
@@ -74,13 +74,20 @@ GEXTEND Gram
       | IDENT "Redirect"; s = ne_string; c = located_vernac -> VernacRedirect (s, c)
       | IDENT "Timeout"; n = natural; v = vernac_control -> VernacTimeout(n,v)
       | IDENT "Fail"; v = vernac_control -> VernacFail v
-      | (f, v) = vernac -> VernacExpr(f, v) ]
+      | (f, v) = vernac_guard -> VernacExpr(f, v) ]
     ]
   ;
-  vernac:
-    [ [ IDENT "Unguarded";   (f, v) = vernac_loc -> (VernacGuarded false  :: f, v)
-      (* Disabled to not confuse the user: for the moment there is not way to disable guard check globally. *)
-      (* | IDENT "Guarded"; (f, v) = vernac_loc -> (VernacGuarded true :: f, v) *)
+  vernac_guard:
+    [ [ IDENT "Unguarded";   (f, v) = vernac_positive -> (VernacGuarded false  :: f, v)
+      (* Disabled to not confuse the user: for the moment there is no way to disable guard check globally. *)
+      (* | IDENT "Guarded"; (f, v) = vernac_positive -> (VernacGuarded true :: f, v) *)
+      | v = vernac_positive -> v ]
+    ]
+  ;
+  vernac_positive:
+    [ [ IDENT "Assumed"; IDENT "Positive"; (f, v) = vernac_loc -> (VernacCheckedPositive false  :: f, v)
+      (* Disabled to not confuse the user: for the moment there is no way to disable guard check globally. *)
+      (* | IDENT "Checked"; IDENT "Positive"; (f, v) = vernac_loc -> (VernacCheckedPositive true :: f, v) *)
       | v = vernac_loc -> v ]
     ]
   ;

--- a/vernac/g_vernac.ml4
+++ b/vernac/g_vernac.ml4
@@ -169,13 +169,17 @@ GEXTEND Gram
           let indl=List.map (fun ((a,b,c,d),e) -> ((a,b,c,k,d),e)) indl in
           VernacInductive (cum, priv,f,indl)
       | "Fixpoint"; recs = LIST1 rec_definition SEP "with" ->
-          VernacFixpoint (NoDischarge, recs)
+          VernacFixpoint (None, NoDischarge, recs)
       | IDENT "Let"; "Fixpoint"; recs = LIST1 rec_definition SEP "with" ->
-          VernacFixpoint (DoDischarge, recs)
+          VernacFixpoint (None, DoDischarge, recs)
+      | IDENT "Unguarded"; "Fixpoint"; recs = LIST1 rec_definition SEP "with" ->
+          VernacFixpoint (Some false, NoDischarge, recs)
       | "CoFixpoint"; corecs = LIST1 corec_definition SEP "with" ->
-          VernacCoFixpoint (NoDischarge, corecs)
+          VernacCoFixpoint (None, NoDischarge, corecs)
       | IDENT "Let"; "CoFixpoint"; corecs = LIST1 corec_definition SEP "with" ->
-          VernacCoFixpoint (DoDischarge, corecs)
+          VernacCoFixpoint (None, DoDischarge, corecs)
+      | IDENT "Unguarded"; "CoFixpoint"; corecs = LIST1 corec_definition SEP "with" ->
+          VernacCoFixpoint (Some false, DoDischarge, corecs)
       | IDENT "Scheme"; l = LIST1 scheme SEP "with" -> VernacScheme l
       | IDENT "Combined"; IDENT "Scheme"; id = identref; IDENT "from";
 	      l = LIST1 identref SEP "," -> VernacCombinedScheme (id, l)

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -781,9 +781,9 @@ open Pputils
           (prlist (fun ind -> fnl() ++ hov 1 (pr_oneind "with" ind)) (List.tl l))
         )
 
-      | VernacFixpoint (safe, local, recs) ->
-        let safe = match safe with
-          | Some false -> keyword "Unsafe" ++ spc ()
+      | VernacFixpoint (guarded, local, recs) ->
+        let guarded = match guarded with
+          | Some false -> keyword "Unguarded" ++ spc ()
           | _ -> str ""
         in
         let local = match local with
@@ -791,14 +791,14 @@ open Pputils
           | NoDischarge -> str ""
         in
         return (
-          hov 0 (safe ++ local ++ keyword "Fixpoint" ++ spc () ++
+          hov 0 (guarded ++ local ++ keyword "Fixpoint" ++ spc () ++
                    prlist_with_sep (fun _ -> fnl () ++ keyword "with"
                      ++ spc ()) pr_rec_definition recs)
         )
 
-      | VernacCoFixpoint (safe, local, corecs) ->
-        let safe = match safe with
-          | Some false -> keyword "Unsafe " ++ spc ()
+      | VernacCoFixpoint (guarded, local, corecs) ->
+        let guarded = match guarded with
+          | Some false -> keyword "Unguarded" ++ spc ()
           | _ -> str ""
         in
         let local = match local with
@@ -812,7 +812,7 @@ open Pputils
             prlist (pr_decl_notation pr_constr) ntn
         in
         return (
-          hov 0 (safe ++ local ++ keyword "CoFixpoint" ++ spc() ++
+          hov 0 (guarded ++ local ++ keyword "CoFixpoint" ++ spc() ++
                    prlist_with_sep (fun _ -> fnl() ++ keyword "with" ++ spc ()) pr_onecorec corecs)
         )
       | VernacScheme l ->

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -781,26 +781,18 @@ open Pputils
           (prlist (fun ind -> fnl() ++ hov 1 (pr_oneind "with" ind)) (List.tl l))
         )
 
-      | VernacFixpoint (guarded, local, recs) ->
-        let guarded = match guarded with
-          | Some false -> keyword "Unguarded" ++ spc ()
-          | _ -> str ""
-        in
+      | VernacFixpoint (local, recs) ->
         let local = match local with
           | DoDischarge -> keyword "Let" ++ spc ()
           | NoDischarge -> str ""
         in
         return (
-          hov 0 (guarded ++ local ++ keyword "Fixpoint" ++ spc () ++
+          hov 0 (local ++ keyword "Fixpoint" ++ spc () ++
                    prlist_with_sep (fun _ -> fnl () ++ keyword "with"
                      ++ spc ()) pr_rec_definition recs)
         )
 
-      | VernacCoFixpoint (guarded, local, corecs) ->
-        let guarded = match guarded with
-          | Some false -> keyword "Unguarded" ++ spc ()
-          | _ -> str ""
-        in
+      | VernacCoFixpoint (local, corecs) ->
         let local = match local with
           | DoDischarge -> keyword "Let" ++ spc ()
           | NoDischarge -> str ""
@@ -812,7 +804,7 @@ open Pputils
             prlist (pr_decl_notation pr_constr) ntn
         in
         return (
-          hov 0 (guarded ++ local ++ keyword "CoFixpoint" ++ spc() ++
+          hov 0 (local ++ keyword "CoFixpoint" ++ spc() ++
                    prlist_with_sep (fun _ -> fnl() ++ keyword "with" ++ spc ()) pr_onecorec corecs)
         )
       | VernacScheme l ->
@@ -1202,6 +1194,8 @@ let pr_vernac_flag =
   function
   | VernacPolymorphic true -> keyword "Polymorphic"
   | VernacPolymorphic false -> keyword "Monomorphic"
+  | VernacGuarded true -> keyword "Guarded"
+  | VernacGuarded false -> keyword "Unguarded"
   | VernacProgram -> keyword "Program"
   | VernacLocal local -> pr_locality local
 

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -781,18 +781,26 @@ open Pputils
           (prlist (fun ind -> fnl() ++ hov 1 (pr_oneind "with" ind)) (List.tl l))
         )
 
-      | VernacFixpoint (local, recs) ->
+      | VernacFixpoint (safe, local, recs) ->
+        let safe = match safe with
+          | Some false -> keyword "Unsafe" ++ spc ()
+          | _ -> str ""
+        in
         let local = match local with
-          | DoDischarge -> "Let "
-          | NoDischarge -> ""
+          | DoDischarge -> keyword "Let" ++ spc ()
+          | NoDischarge -> str ""
         in
         return (
-          hov 0 (str local ++ keyword "Fixpoint" ++ spc () ++
+          hov 0 (safe ++ local ++ keyword "Fixpoint" ++ spc () ++
                    prlist_with_sep (fun _ -> fnl () ++ keyword "with"
                      ++ spc ()) pr_rec_definition recs)
         )
 
-      | VernacCoFixpoint (local, corecs) ->
+      | VernacCoFixpoint (safe, local, corecs) ->
+        let safe = match safe with
+          | Some false -> keyword "Unsafe " ++ spc ()
+          | _ -> str ""
+        in
         let local = match local with
           | DoDischarge -> keyword "Let" ++ spc ()
           | NoDischarge -> str ""
@@ -804,7 +812,7 @@ open Pputils
             prlist (pr_decl_notation pr_constr) ntn
         in
         return (
-          hov 0 (local ++ keyword "CoFixpoint" ++ spc() ++
+          hov 0 (safe ++ local ++ keyword "CoFixpoint" ++ spc() ++
                    prlist_with_sep (fun _ -> fnl() ++ keyword "with" ++ spc ()) pr_onecorec corecs)
         )
       | VernacScheme l ->

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -1196,6 +1196,8 @@ let pr_vernac_flag =
   | VernacPolymorphic false -> keyword "Monomorphic"
   | VernacGuarded true -> keyword "Guarded"
   | VernacGuarded false -> keyword "Unguarded"
+  | VernacCheckedPositive true -> keyword "Checked" ++ spc() ++ keyword "Positive"
+  | VernacCheckedPositive false -> keyword "Assumed" ++ spc() ++ keyword "Positive"
   | VernacProgram -> keyword "Program"
   | VernacLocal local -> pr_locality local
 

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -411,7 +411,7 @@ let declare_structure finite ubinders univs id idbuild paramimpls params arity t
     }
   in
   let mie = InferCumulativity.infer_inductive (Global.env ()) mie in
-  let kn = ComInductive.declare_mutual_inductive_with_eliminations mie ubinders [(paramimpls,[])] in
+  let kn = ComInductive.declare_mutual_inductive_with_eliminations ~check_positivity:None mie ubinders [(paramimpls,[])] in
   let rsp = (kn,0) in (* This is ind path of idstruc *)
   let cstr = (rsp,1) in
   let kinds,sp_projs = declare_projections rsp ctx ~kind binder_name coers ubinders fieldimpls fields in

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -601,26 +601,27 @@ let vernac_inductive ~atts cum lo finite indl =
     let is_cumulative = should_treat_as_cumulative cum atts.polymorphic in
     ComInductive.do_mutual_inductive indl is_cumulative atts.polymorphic lo finite
 
-let vernac_fixpoint ~atts discharge l =
+let vernac_fixpoint ~atts guarded discharge l =
   let local = enforce_locality_exp atts.locality discharge in
   if Dumpglob.dump () then
     List.iter (fun (((lid,_), _, _, _, _), _) -> Dumpglob.dump_definition lid false "def") l;
   (* XXX: Switch to the attribute system and match on ~atts *)
   let do_fixpoint = if Flags.is_program_mode () then
+      (* TODO: Unguarded Program Fixpoint *)
       ComProgramFixpoint.do_fixpoint
     else
-      ComFixpoint.do_fixpoint
+      ComFixpoint.do_fixpoint guarded
   in
   do_fixpoint local atts.polymorphic l
 
-let vernac_cofixpoint ~atts discharge l =
+let vernac_cofixpoint ~atts guarded discharge l =
   let local = enforce_locality_exp atts.locality discharge in
   if Dumpglob.dump () then
     List.iter (fun (((lid,_), _, _, _), _) -> Dumpglob.dump_definition lid false "def") l;
   let do_cofixpoint = if Flags.is_program_mode () then
       ComProgramFixpoint.do_cofixpoint
     else
-      ComFixpoint.do_cofixpoint
+      ComFixpoint.do_cofixpoint guarded
   in
   do_cofixpoint local atts.polymorphic l
 
@@ -2037,8 +2038,8 @@ let interp ?proof ~atts ~st c =
   | VernacAssumption ((discharge,kind),nl,l) ->
       vernac_assumption ~atts discharge kind l nl
   | VernacInductive (cum, priv,finite,l) -> vernac_inductive ~atts cum priv finite l
-  | VernacFixpoint (discharge, l) -> vernac_fixpoint ~atts discharge l
-  | VernacCoFixpoint (discharge, l) -> vernac_cofixpoint ~atts discharge l
+  | VernacFixpoint (guarded, discharge, l) -> vernac_fixpoint ~atts guarded discharge l
+  | VernacCoFixpoint (guarded, discharge, l) -> vernac_cofixpoint ~atts guarded discharge l
   | VernacScheme l -> vernac_scheme l
   | VernacCombinedScheme (id, l) -> vernac_combined_scheme id l
   | VernacUniverse l -> vernac_universe ~atts l

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -337,8 +337,8 @@ type nonrec vernac_expr =
   | VernacAssumption of (Decl_kinds.discharge * Decl_kinds.assumption_object_kind) *
       Declaremods.inline * (ident_decl list * constr_expr) with_coercion list
   | VernacInductive of vernac_cumulative option * Decl_kinds.private_flag * inductive_flag * (inductive_expr * decl_notation list) list
-  | VernacFixpoint of Decl_kinds.discharge * (fixpoint_expr * decl_notation list) list
-  | VernacCoFixpoint of Decl_kinds.discharge * (cofixpoint_expr * decl_notation list) list
+  | VernacFixpoint of bool option * Decl_kinds.discharge * (fixpoint_expr * decl_notation list) list
+  | VernacCoFixpoint of bool option * Decl_kinds.discharge * (cofixpoint_expr * decl_notation list) list
   | VernacScheme of (lident option * scheme) list
   | VernacCombinedScheme of lident * lident list
   | VernacUniverse of lident list

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -459,6 +459,7 @@ type nonrec vernac_flag =
   | VernacPolymorphic of bool
   | VernacLocal of bool
   | VernacGuarded of bool
+  | VernacCheckedPositive of bool
 
 type vernac_control =
   | VernacExpr of vernac_flag list * vernac_expr

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -337,8 +337,8 @@ type nonrec vernac_expr =
   | VernacAssumption of (Decl_kinds.discharge * Decl_kinds.assumption_object_kind) *
       Declaremods.inline * (ident_decl list * constr_expr) with_coercion list
   | VernacInductive of vernac_cumulative option * Decl_kinds.private_flag * inductive_flag * (inductive_expr * decl_notation list) list
-  | VernacFixpoint of bool option * Decl_kinds.discharge * (fixpoint_expr * decl_notation list) list
-  | VernacCoFixpoint of bool option * Decl_kinds.discharge * (cofixpoint_expr * decl_notation list) list
+  | VernacFixpoint of Decl_kinds.discharge * (fixpoint_expr * decl_notation list) list
+  | VernacCoFixpoint of Decl_kinds.discharge * (cofixpoint_expr * decl_notation list) list
   | VernacScheme of (lident option * scheme) list
   | VernacCombinedScheme of lident * lident list
   | VernacUniverse of lident list
@@ -458,6 +458,7 @@ type nonrec vernac_flag =
   | VernacProgram
   | VernacPolymorphic of bool
   | VernacLocal of bool
+  | VernacGuarded of bool
 
 type vernac_control =
   | VernacExpr of vernac_flag list * vernac_expr

--- a/vernac/vernacinterp.ml
+++ b/vernac/vernacinterp.ml
@@ -17,6 +17,7 @@ type deprecation = bool
 type atts = {
   loc : Loc.t option;
   locality : bool option;
+  check_guard : bool option;
   polymorphic : bool;
   program : bool;
 }

--- a/vernac/vernacinterp.ml
+++ b/vernac/vernacinterp.ml
@@ -18,6 +18,7 @@ type atts = {
   loc : Loc.t option;
   locality : bool option;
   check_guard : bool option;
+  check_positivity : bool option;
   polymorphic : bool;
   program : bool;
 }

--- a/vernac/vernacinterp.mli
+++ b/vernac/vernacinterp.mli
@@ -16,6 +16,7 @@ type atts = {
   loc : Loc.t option;
   locality : bool option;
   check_guard : bool option; (* None -> use global setting (true by default); Some -> override *)
+  check_positivity : bool option; (* None -> use global setting (true by default); Some -> override *)
   polymorphic : bool;
   program : bool;
 }

--- a/vernac/vernacinterp.mli
+++ b/vernac/vernacinterp.mli
@@ -15,6 +15,7 @@ type deprecation = bool
 type atts = {
   loc : Loc.t option;
   locality : bool option;
+  check_guard : bool option; (* None -> use global setting (true by default); Some -> override *)
   polymorphic : bool;
   program : bool;
 }


### PR DESCRIPTION
Disable guard check for (co)fixpoints when defined with `Ungarded` keyword.
We can now write:
```
Unguarded Fixpoint f (n : nat) : False
  := f n.

Unguarded Fixpoint ackermann (m n : nat) {struct m} : nat.
  destruct m. exact (S n).
  destruct n. exact (ackermann m 1).
  exact (ackermann m (ackermann (S m) n)).
Defined.

Compute (ackermann 3 4).

Print Assumptions ackermann.
(* ackermann is assumed to be guarded *)

Unguarded CoFixpoint fer (s : Stream nat) : Stream nat.
Proof.
  exact (fer s).
Defined.
```


<!-- Keep what applies -->
**Kind:** feature.


<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [x] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [x] Entry added in CHANGES.

I know that this PR is far from being perfect, any comment welcome.
