### PR TITLE
Explicitly require python2 in python scripts in tools/

### DIFF
--- a/tools/make-both-single-timing-files.py
+++ b/tools/make-both-single-timing-files.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import sys
 from TimeFileMaker import *
 

--- a/tools/make-both-time-files.py
+++ b/tools/make-both-time-files.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import sys
 from TimeFileMaker import *
 

--- a/tools/make-one-time-file.py
+++ b/tools/make-one-time-file.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import sys
 from TimeFileMaker import *
 


### PR DESCRIPTION
On my system, `python` is pointing to `python3`. This explicitly requires `python2` in the python scripts in tools/. Otherwise, these scripts do not work when called with python 3.