### PR TITLE
Non-backtracking hints

### DIFF
--- a/pretyping/typeclasses.ml
+++ b/pretyping/typeclasses.ml
@@ -8,7 +8,6 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(*i*)
 open Names
 open Globnames
 open Term
@@ -19,12 +18,16 @@ open Util
 open Typeclasses_errors
 open Context.Rel.Declaration
 
-(*i*)
+type hint_commit =
+  | NoCommit (** the default *)
+  | Commit (** do not try to backtrack the application of this hint *)
 
 (* Core typeclasses hints *)
-type 'a hint_info_gen =
-    { hint_priority : int option;
-      hint_pattern : 'a option }
+type 'a hint_info_gen = {
+  hint_priority : int option;
+  hint_pattern : 'a option;
+  hint_commit : hint_commit;
+}
 
 type hint_info = (Pattern.patvar list * Pattern.constr_pattern) hint_info_gen
 

--- a/pretyping/typeclasses.mli
+++ b/pretyping/typeclasses.mli
@@ -15,10 +15,16 @@ open Environ
 
 type direction = Forward | Backward
 
+type hint_commit =
+  | NoCommit (** the default *)
+  | Commit (** do not try to backtrack the application of this hint *)
+
 (* Core typeclasses hints *)
-type 'a hint_info_gen =
-    { hint_priority : int option;
-      hint_pattern : 'a option }
+type 'a hint_info_gen = {
+  hint_priority : int option;
+  hint_pattern : 'a option;
+  hint_commit : hint_commit;
+}
 
 type hint_info = (Pattern.patvar list * Pattern.constr_pattern) hint_info_gen
 

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -516,11 +516,11 @@ let make_resolve_hyp env sigma st only_classes pri decl =
             (List.map_append
              (fun (path,info,c) ->
               let h = IsConstr (EConstr.of_constr c,Univ.ContextSet.empty) [@ocaml.warning "-3"] in
-              make_resolves env sigma ~name:(PathHints path) info NoCommit ~check:true ~poly:false h)
+              make_resolves env sigma ~name:(PathHints path) info ~check:true ~poly:false h)
                hints)
         else []
       in
-        (hints @ make_resolves env sigma pri NoCommit ~name ~check:false ~poly:false (IsGlobRef id))
+        (hints @ make_resolves env sigma pri ~name ~check:false ~poly:false (IsGlobRef id))
     else []
 
 let make_hints g (modes,st) only_classes sign =

--- a/tactics/hints.mli
+++ b/tactics/hints.mli
@@ -55,16 +55,12 @@ type 'a hints_path_atom_gen =
 type hints_path_atom = GlobRef.t hints_path_atom_gen
 type hint_db_name = string
 
-type commit =
-  | NoCommit (** the default *)
-  | Commit (** do not try to backtrack the application of this hint *)
-
 module FullHint :
 sig
   type t
   val priority : t -> int
   val pattern : t -> Pattern.constr_pattern option
-  val commit : t -> commit
+  val commit : t -> hint_commit
   val database : t -> string option
   val run : t -> (hint hint_ast -> 'r Proofview.tactic) -> 'r Proofview.tactic
   val name : t -> hints_path_atom
@@ -178,13 +174,13 @@ type hint_term =
   | IsConstr of constr * Univ.ContextSet.t [@ocaml.deprecated "Declare a hint constant instead"]
 
 type hints_entry =
-  | HintsResolveEntry of (hint_info * bool * commit * hnf * hints_path_atom * hint_term) list
-  | HintsImmediateEntry of (hints_path_atom * bool * commit * hint_term) list
+  | HintsResolveEntry of (hint_info * bool * hnf * hints_path_atom * hint_term) list
+  | HintsImmediateEntry of (hints_path_atom * bool * hint_commit * hint_term) list
   | HintsCutEntry of hints_path
   | HintsUnfoldEntry of evaluable_global_reference list
   | HintsTransparencyEntry of evaluable_global_reference hints_transparency_target * bool
   | HintsModeEntry of GlobRef.t * hint_mode list
-  | HintsExternEntry of hint_info * commit * Genarg.glob_generic_argument
+  | HintsExternEntry of hint_info * Genarg.glob_generic_argument
 
 val searchtable_map : hint_db_name -> hint_db
 
@@ -216,7 +212,7 @@ val prepare_hint : bool (* Check no remaining evars *) ->
          has missing arguments. *)
 
 val make_resolves :
-  env -> evar_map -> hint_info -> commit -> check:bool -> poly:bool -> ?name:hints_path_atom ->
+  env -> evar_map -> hint_info -> check:bool -> poly:bool -> ?name:hints_path_atom ->
   hint_term -> hint_entry list
 
 (** [make_resolve_hyp hname htyp].

--- a/tactics/hints.mli
+++ b/tactics/hints.mli
@@ -55,11 +55,16 @@ type 'a hints_path_atom_gen =
 type hints_path_atom = GlobRef.t hints_path_atom_gen
 type hint_db_name = string
 
+type commit =
+  | NoCommit (** the default *)
+  | Commit (** do not try to backtrack the application of this hint *)
+
 module FullHint :
 sig
   type t
   val priority : t -> int
   val pattern : t -> Pattern.constr_pattern option
+  val commit : t -> commit
   val database : t -> string option
   val run : t -> (hint hint_ast -> 'r Proofview.tactic) -> 'r Proofview.tactic
   val name : t -> hints_path_atom
@@ -173,13 +178,13 @@ type hint_term =
   | IsConstr of constr * Univ.ContextSet.t [@ocaml.deprecated "Declare a hint constant instead"]
 
 type hints_entry =
-  | HintsResolveEntry of (hint_info * bool * hnf * hints_path_atom * hint_term) list
-  | HintsImmediateEntry of (hints_path_atom * bool * hint_term) list
+  | HintsResolveEntry of (hint_info * bool * commit * hnf * hints_path_atom * hint_term) list
+  | HintsImmediateEntry of (hints_path_atom * bool * commit * hint_term) list
   | HintsCutEntry of hints_path
   | HintsUnfoldEntry of evaluable_global_reference list
   | HintsTransparencyEntry of evaluable_global_reference hints_transparency_target * bool
   | HintsModeEntry of GlobRef.t * hint_mode list
-  | HintsExternEntry of hint_info * Genarg.glob_generic_argument
+  | HintsExternEntry of hint_info * commit * Genarg.glob_generic_argument
 
 val searchtable_map : hint_db_name -> hint_db
 
@@ -211,7 +216,7 @@ val prepare_hint : bool (* Check no remaining evars *) ->
          has missing arguments. *)
 
 val make_resolves :
-  env -> evar_map -> hint_info -> check:bool -> poly:bool -> ?name:hints_path_atom ->
+  env -> evar_map -> hint_info -> commit -> check:bool -> poly:bool -> ?name:hints_path_atom ->
   hint_term -> hint_entry list
 
 (** [make_resolve_hyp hname htyp].

--- a/test-suite/success/CommitHint.v
+++ b/test-suite/success/CommitHint.v
@@ -1,0 +1,24 @@
+
+Class E (a b : nat) := e{}.
+
+Class C (a b : nat) := c{}.
+
+Class D (a:nat) := d{}.
+
+Instance d2 : D 2 := {}.
+
+Instance c2 : C 0 2 | 10 := {}.
+
+Instance exy (a b:nat) `{C a b} `{D b} : E a b := {}.
+
+Module Back.
+  Instance c0 : C 0 0 | 1 := {}.
+  Type _ : E _ _.
+End Back.
+
+Module NoBack.
+  Type _ : E _ _.
+  Instance c0 : C 0 0 ! 1 := {}.
+  Fail Type _ : E _ _.
+  Type _ : C 0 0.
+End NoBack.

--- a/vernac/.ocamlformat-enable
+++ b/vernac/.ocamlformat-enable
@@ -1,1 +1,0 @@
-comHints.ml

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -45,7 +45,7 @@ let add_instance_hint inst path ~locality info poly =
      Flags.silently (fun () ->
        Hints.add_hints ~locality [typeclasses_db]
           (Hints.HintsResolveEntry
-             [info, poly, Hints.NoCommit, false, Hints.PathHints path, inst])) ()
+             [info, poly, false, Hints.PathHints path, inst])) ()
 
 let is_local_for_hint i =
   match i.is_global with
@@ -141,7 +141,7 @@ let warning_not_a_class =
 
 let declare_instance ?(warn = false) env sigma info local glob =
   let ty, _ = Typeops.type_of_global_in_context env glob in
-  let info = Option.default {hint_priority = None; hint_pattern = None} info in
+  let info = Option.default Hints.empty_hint_info info in
   match class_of_constr env sigma (EConstr.of_constr ty) with
   | Some (rels, ((tc,_), args) as _cl) ->
     assert (not (isVarRef glob) || local);
@@ -257,11 +257,11 @@ let add_class env sigma cl =
       | _ -> ())
     cl.cl_projs
 
-let intern_info {hint_priority;hint_pattern} =
+let intern_info info =
   let env = Global.env() in
   let sigma = Evd.from_env env in
-  let hint_pattern = Option.map (Constrintern.intern_constr_pattern env sigma) hint_pattern in
-  {hint_priority;hint_pattern}
+  let hint_pattern = Option.map (Constrintern.intern_constr_pattern env sigma) info.hint_pattern in
+  {info with hint_pattern}
 
 (** TODO: add subinstances *)
 let existing_instance glob g info =

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -45,7 +45,7 @@ let add_instance_hint inst path ~locality info poly =
      Flags.silently (fun () ->
        Hints.add_hints ~locality [typeclasses_db]
           (Hints.HintsResolveEntry
-             [info, poly, false, Hints.PathHints path, inst])) ()
+             [info, poly, Hints.NoCommit, false, Hints.PathHints path, inst])) ()
 
 let is_local_for_hint i =
   match i.is_global with

--- a/vernac/comHints.mli
+++ b/vernac/comHints.mli
@@ -8,4 +8,4 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-val interp_hints : poly:bool -> Vernacexpr.hints_expr -> Hints.hints_entry
+val interp_hints : poly:bool -> Hints.commit -> Vernacexpr.hints_expr -> Hints.hints_entry

--- a/vernac/comHints.mli
+++ b/vernac/comHints.mli
@@ -8,4 +8,4 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-val interp_hints : poly:bool -> Hints.commit -> Vernacexpr.hints_expr -> Hints.hints_entry
+val interp_hints : poly:bool -> Typeclasses.hint_commit -> Vernacexpr.hints_expr -> Hints.hints_entry

--- a/vernac/g_proofs.mlg
+++ b/vernac/g_proofs.mlg
@@ -13,6 +13,7 @@
 open Glob_term
 open Constrexpr
 open Vernacexpr
+open Typeclasses
 open Hints
 
 open Pcoq

--- a/vernac/g_proofs.mlg
+++ b/vernac/g_proofs.mlg
@@ -102,7 +102,9 @@ GRAMMAR EXTEND Gram
       | IDENT "Remove"; IDENT "Hints"; ids = LIST1 global; dbnames = opt_hintbases ->
           { VernacRemoveHints (dbnames, ids) }
       | IDENT "Hint"; h = hint; dbnames = opt_hintbases ->
-          { VernacHints (dbnames, h) }
+          { VernacHints (dbnames, h, NoCommit) }
+      | IDENT "Committed"; IDENT "Hint"; h = hint; dbnames = opt_hintbases ->
+          { VernacHints (dbnames, h, Commit) }
       ] ];
   reference_or_constr:
    [ [ r = global -> { HintsReference r }

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -702,8 +702,14 @@ GRAMMAR EXTEND Gram
 
       | IDENT "Existing"; IDENT "Instances"; ids = LIST1 global;
         pri = OPT [ "|"; i = natural -> { i } ] ->
-         { let info = { Typeclasses.hint_priority = pri; hint_pattern = None } in
-         let insts = List.map (fun i -> (i, info)) ids in
+        {
+          let info = Typeclasses.{
+            hint_priority = pri;
+            hint_pattern = None;
+            hint_commit = NoCommit
+          }
+          in
+          let insts = List.map (fun i -> (i, info)) ids in
           VernacExistingInstance insts }
 
       | IDENT "Existing"; IDENT "Class"; is = global -> { VernacExistingClass is }
@@ -810,8 +816,8 @@ GRAMMAR EXTEND Gram
   ;
   hint_info:
     [ [ "|"; i = OPT natural; pat = OPT constr_pattern ->
-         { { Typeclasses.hint_priority = i; hint_pattern = pat } }
-      | -> { { Typeclasses.hint_priority = None; hint_pattern = None } } ] ]
+         { Typeclasses.{ hint_priority = i; hint_pattern = pat; hint_commit = NoCommit } }
+      | -> {  Hints.empty_hint_info } ] ]
   ;
   reserv_list:
     [ [ bl = LIST1 reserv_tuple -> { bl } | b = simple_reserv -> { [b] } ] ]

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -816,7 +816,9 @@ GRAMMAR EXTEND Gram
   ;
   hint_info:
     [ [ "|"; i = OPT natural; pat = OPT constr_pattern ->
-         { Typeclasses.{ hint_priority = i; hint_pattern = pat; hint_commit = NoCommit } }
+        { Typeclasses.{ hint_priority = i; hint_pattern = pat; hint_commit = NoCommit } }
+      | "!"; i = OPT natural; pat = OPT constr_pattern ->
+         { Typeclasses.{ hint_priority = i; hint_pattern = pat; hint_commit = Commit } }
       | -> {  Hints.empty_hint_info } ] ]
   ;
   reserv_list:

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -241,8 +241,8 @@ open Pputils
     | ModeOutput -> str"-"
 
   let pr_hint_commit = function
-    | Hints.NoCommit -> mt ()
-    | Hints.Commit -> str "Commited"
+    | Typeclasses.NoCommit -> mt ()
+    | Typeclasses.Commit -> str "Commited"
 
   let pr_hint_info pr_pat { Typeclasses.hint_priority = pri; hint_pattern = pat } =
     pr_opt (fun x -> str"|" ++ int x) pri ++

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -240,12 +240,17 @@ open Pputils
     | ModeNoHeadEvar -> str"!"
     | ModeOutput -> str"-"
 
+  let pr_hint_commit = function
+    | Hints.NoCommit -> mt ()
+    | Hints.Commit -> str "Commited"
+
   let pr_hint_info pr_pat { Typeclasses.hint_priority = pri; hint_pattern = pat } =
     pr_opt (fun x -> str"|" ++ int x) pri ++
     pr_opt (fun y -> (if Option.is_empty pri then str"| " else mt()) ++ pr_pat y) pat
 
-  let pr_hints db h pr_c pr_pat =
+  let pr_hints db h commit pr_c pr_pat =
     let opth = pr_opt_hintbases db  in
+    let ppcommited = pr_hint_commit commit in
     let pph =
       let open Hints in
       match h with
@@ -283,7 +288,7 @@ open Pputils
           keyword "Extern" ++ spc() ++ int n ++ spc() ++ pat ++ str" =>" ++
             spc() ++ Pputils.pr_raw_generic env sigma tac
     in
-    hov 2 (keyword "Hint "++ pph ++ opth)
+    hov 2 (ppcommited ++ keyword "Hint "++ pph ++ opth)
 
   let pr_with_declaration pr_c = function
     | CWith_Definition (id,udecl,c) ->
@@ -1078,8 +1083,8 @@ open Pputils
                    prlist_with_sep spc (fun r -> pr_id (coerce_reference_to_id r)) ids ++
                    pr_opt_hintbases dbnames)
         )
-      | VernacHints (dbnames,h) ->
-        return (pr_hints dbnames h (pr_constr env sigma) (pr_constr_pattern_expr env sigma))
+      | VernacHints (dbnames,h,commit) ->
+        return (pr_hints dbnames h commit (pr_constr env sigma) (pr_constr_pattern_expr env sigma))
       | VernacSyntacticDefinition (id,(ids,c),{onlyparsing}) ->
         return (
           hov 2

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -720,7 +720,12 @@ let definition_structure udecl kind ~template ~cumulative ~poly finite records =
     | [r], [d] -> r, d
     | _, _ -> CErrors.user_err (str "Mutual definitional classes are not handled")
     in
-    let priorities = List.map (fun (_, { rf_priority }) -> {hint_priority = rf_priority ; hint_pattern = None}) cfs in
+    let priorities = List.map (fun (_, { rf_priority }) ->
+        { hint_priority = rf_priority;
+          hint_pattern = None;
+          hint_commit = NoCommit; })
+        cfs
+    in
     let coers = List.map (fun (_, { rf_subclass }) -> rf_subclass) cfs in
     declare_class def cumulative ubinders univs id.CAst.v idbuild
       implpars params univ arity template implfs fields coers priorities

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1294,7 +1294,7 @@ let vernac_remove_hints ~module_local dbnames ids =
   in
   Hints.remove_hints module_local dbnames (List.map Smartlocate.global_with_alias ids)
 
-let vernac_hints ~atts dbnames h =
+let vernac_hints ~atts dbnames h commit =
   let dbnames =
     if List.is_empty dbnames then
       (warn_implicit_core_hint_db (); ["core"])
@@ -1312,7 +1312,7 @@ let vernac_hints ~atts dbnames h =
       "This command does not support the export attribute in sections.");
   | OptDefault | OptLocal -> ()
   in
-  Hints.add_hints ~locality dbnames (ComHints.interp_hints ~poly h)
+  Hints.add_hints ~locality dbnames (ComHints.interp_hints ~poly commit h)
 
 let vernac_syntactic_definition ~atts lid x only_parsing =
   let module_local, deprecation = Attributes.(parse Notations.(module_locality ++ deprecation) atts) in
@@ -2157,9 +2157,9 @@ let translate_vernac ~atts v = let open Vernacextend in match v with
   | VernacRemoveHints (dbnames,ids) ->
     VtDefault(fun () ->
         with_module_locality ~atts vernac_remove_hints dbnames ids)
-  | VernacHints (dbnames,hints) ->
+  | VernacHints (dbnames,hints,commit) ->
     VtDefault(fun () ->
-        vernac_hints ~atts dbnames hints)
+        vernac_hints ~atts dbnames hints commit)
   | VernacSyntacticDefinition (id,c,b) ->
      VtDefault(fun () -> vernac_syntactic_definition ~atts id c b)
   | VernacArguments (qid, args, more_implicits, flags) ->

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -412,7 +412,7 @@ type nonrec vernac_expr =
   (* Commands *)
   | VernacCreateHintDb of string * bool
   | VernacRemoveHints of string list * qualid list
-  | VernacHints of string list * hints_expr
+  | VernacHints of string list * hints_expr * Hints.commit
   | VernacSyntacticDefinition of
       lident * (Id.t list * constr_expr) *
       onlyparsing_flag

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -412,7 +412,7 @@ type nonrec vernac_expr =
   (* Commands *)
   | VernacCreateHintDb of string * bool
   | VernacRemoveHints of string list * qualid list
-  | VernacHints of string list * hints_expr * Hints.commit
+  | VernacHints of string list * hints_expr * Typeclasses.hint_commit
   | VernacSyntacticDefinition of
       lident * (Id.t list * constr_expr) *
       onlyparsing_flag


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

This is joint work with @Zimmi48 and @MSoegtropIMC .
~~This is based on top of #7655 and #7649 which should be merged first.~~

<!-- Keep what applies -->
**Kind:** feature.

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->

This pull-request proposes to add a new `NonBacktracking` flag for auto hints (more specifically, for `Hint Resolve`, `Hint Immediate` and `Hint Extern`). For example, to declare a Hint Resolve as nonbacktracking, one can write:

```NonBacktracking Hint Resolve foo : mybase```

Support for the flag has been implemented in `typeclasses eauto`.

The semantics of this flag is as follows: during proof search, if a nonbacktracking hint is applied with success, then alternative possible hints are thrown away and never considered -- the proof search never "backtracks" the application of the nonbacktracking hint. 

The intent of adding this flag is that it seems particularly useful to perform forward reasoning, or more generally for invertible steps (e.g. saturating the context). Backtracking the application of such steps is useless and easily leads to exponential blowup of the search.


Work left to be done:
- [ ] Update the documentation
- [ ] Clarify whether the flag makes sense for Hint Unfold
- [ ] Update the debugging messages of typeclasses eauto
- [ ] Add an entry in CHANGES.
