### PR TITLE
Fixes #7636: location missing on deprecated compatibility notations.

### DIFF
--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -999,7 +999,7 @@ let intern_qualid qid intern env ntnvars us args =
   match intern_extended_global_of_qualid qid with
   | TrueGlobal ref -> (DAst.make ?loc @@ GRef (ref, us)), true, args
   | SynDef sp ->
-      let (ids,c) = Syntax_def.search_syntactic_definition sp in
+      let (ids,c) = Syntax_def.search_syntactic_definition ?loc sp in
       let nids = List.length ids in
       if List.length args < nids then error_not_enough_arguments ?loc;
       let args1,args2 = List.chop nids args in

--- a/interp/syntax_def.ml
+++ b/interp/syntax_def.ml
@@ -96,13 +96,13 @@ let warn_compatibility_notation =
   CWarnings.(create ~name:"compatibility-notation"
                     ~category:"deprecated" ~default:Enabled pr_compat_warning)
 
-let verbose_compat kn def = function
+let verbose_compat ?loc kn def = function
   | Some v when Flags.version_strictly_greater v ->
-     warn_compatibility_notation (kn, def, v)
+     warn_compatibility_notation ?loc (kn, def, v)
   | _ -> ()
 
-let search_syntactic_definition kn =
+let search_syntactic_definition ?loc kn =
   let pat,v = KNmap.find kn !syntax_table in
   let def = out_pat pat in
-  verbose_compat kn def v;
+  verbose_compat ?loc kn def v;
   def

--- a/interp/syntax_def.mli
+++ b/interp/syntax_def.mli
@@ -18,4 +18,4 @@ type syndef_interpretation = (Id.t * subscopes) list * notation_constr
 val declare_syntactic_definition : bool -> Id.t ->
   Flags.compat_version option -> syndef_interpretation -> unit
 
-val search_syntactic_definition : KerName.t -> syndef_interpretation
+val search_syntactic_definition : ?loc:Loc.t -> KerName.t -> syndef_interpretation


### PR DESCRIPTION
**Kind:** bug fix

Fixes / closes #7636.

This is quick straightforward fix for #7636.

Note that I did not fix the second general problem about `Instance` whose unlocated warnings do not even get at least the location of the sentence. This is maybe stm-related (while trying to print the warning, the `Stm.get_ast` in `Coqloop.extract_default_loc` fails to find the corresponding `id`).

It is not a priority to me to prepare a test but help is welcome to add one (you can push to the branch).

