### PR TITLE
[ci] [docker] Pin specific versions of OPAM CI dependencies.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ defaults:
       - image: $CI_REGISTRY_IMAGE:$CACHEKEY
 
   environment: &envvars
-    CACHEKEY: "bionic_coq-V2018-05-07-V2"
+    CACHEKEY: "bionic_coq-V2018-06-04-V2"
     CI_REGISTRY_IMAGE: registry.gitlab.com/coq/coq
 
 version: 2

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,7 +9,7 @@ stages:
 variables:
   # Format: $IMAGE-V$DATE [Cache is not used as of today but kept here
   # for reference]
-  CACHEKEY: "bionic_coq-V2018-05-07-V2"
+  CACHEKEY: "bionic_coq-V2018-06-04-V2"
   IMAGE: "$CI_REGISTRY_IMAGE:$CACHEKEY"
   # By default, jobs run in the base switch; override to select another switch
   OPAM_SWITCH: "base"
@@ -37,7 +37,7 @@ before_script:
   - ls -a # figure out if artifacts are around
   - printenv -0 | sort -z | tr '\0' '\n'
   - declare -A switch_table
-  - switch_table=( ["base"]="$COMPILER" ["edge"]="$COMPILER_BE" )
+  - switch_table=( ["base"]="$COMPILER" ["edge"]="$COMPILER_EDGE" )
   - opam switch -y "${switch_table[$OPAM_SWITCH]}$OPAM_VARIANT"
   - eval $(opam config env)
   - opam list

--- a/dev/ci/ci-compcert.sh
+++ b/dev/ci/ci-compcert.sh
@@ -5,10 +5,6 @@ ci_dir="$(dirname "$0")"
 
 CompCert_CI_DIR="${CI_BUILD_DIR}/CompCert"
 
-# Temporal workaround, to be removed when upstream decides what to do
-# with their problem.
-opam install -y menhir.20180528
-
 git_checkout "${CompCert_CI_BRANCH}" "${CompCert_CI_GITURL}" "${CompCert_CI_DIR}"
 
 ( cd "${CompCert_CI_DIR}" && ./configure -ignore-coq-version x86_32-linux && make && make check-proof )

--- a/dev/ci/docker/bionic_coq/Dockerfile
+++ b/dev/ci/docker/bionic_coq/Dockerfile
@@ -1,4 +1,4 @@
-# CACHEKEY: "bionic_coq-V2018-05-07-V2"
+# CACHEKEY: "bionic_coq-V2018-06-04-V2"
 # ^^ Update when modifying this file.
 
 FROM ubuntu:bionic
@@ -8,7 +8,7 @@ ENV DEBIAN_FRONTEND="noninteractive"
 
 RUN apt-get update -qq && apt-get install -y -qq m4 wget time gcc-multilib opam \
         libgtk2.0-dev libgtksourceview2.0-dev \
-        texlive-latex-extra texlive-fonts-recommended hevea \
+        texlive-latex-extra texlive-fonts-recommended texlive-science \
         python3-sphinx python3-pexpect python3-sphinx-rtd-theme python3-bs4 python3-sphinxcontrib.bibtex python3-pip
 
 RUN pip3 install antlr4-python3-runtime
@@ -19,15 +19,19 @@ ENV NJOBS="2" \
     OPAMROOTISOK="true"
 
 # Base opam is the set of base packages required by Coq
-ENV COMPILER="4.02.3" \
-    BASE_OPAM="num ocamlfind jbuilder ounit"
+ENV COMPILER="4.02.3"
 
 RUN opam init -a -y -j $NJOBS --compiler="$COMPILER" default https://opam.ocaml.org && eval $(opam config env) && opam update
 
-# Setup of the base switch; CI_OPAM contains Coq's CI dependencies.
+# Common OPAM packages.
+# `num` does not have a version number as the right version to install varies
+# with the compiler version.
+ENV BASE_OPAM="num ocamlfind.1.8.0 jbuilder.1.0+beta20 ounit.2.0.8" \
+    CI_OPAM="menhir.20180530 elpi.1.0.3 ocamlgraph.1.8.8"
+
+# BASE switch; CI_OPAM contains Coq's CI dependencies.
 ENV CAMLP5_VER="6.14" \
-    COQIDE_OPAM="lablgtk.2.18.5 conf-gtksourceview.2" \
-    CI_OPAM="menhir elpi ocamlgraph"
+    COQIDE_OPAM="lablgtk.2.18.5 conf-gtksourceview.2"
 
 RUN opam switch -y -j $NJOBS "$COMPILER" && eval $(opam config env) && \
     opam install -j $NJOBS $BASE_OPAM camlp5.$CAMLP5_VER $COQIDE_OPAM $CI_OPAM
@@ -36,14 +40,15 @@ RUN opam switch -y -j $NJOBS "$COMPILER" && eval $(opam config env) && \
 RUN opam switch -y -j $NJOBS "${COMPILER}+32bit" && eval $(opam config env) && \
     opam install -j $NJOBS $BASE_OPAM camlp5.$CAMLP5_VER
 
-# BE switch
-ENV COMPILER_BE="4.06.1" \
-    CAMLP5_VER_BE="7.05" \
-    COQIDE_OPAM_BE="lablgtk.2.18.6 conf-gtksourceview.2"
+# EDGE switch
+ENV COMPILER_EDGE="4.06.1" \
+    CAMLP5_VER_EDGE="7.05" \
+    COQIDE_OPAM_EDGE="lablgtk.2.18.6 conf-gtksourceview.2"
 
-RUN opam switch -y -j $NJOBS $COMPILER_BE && eval $(opam config env) && \
-    opam install -j $NJOBS $BASE_OPAM camlp5.$CAMLP5_VER_BE $COQIDE_OPAM_BE
+RUN opam switch -y -j $NJOBS $COMPILER_EDGE && eval $(opam config env) && \
+    opam install -j $NJOBS $BASE_OPAM camlp5.$CAMLP5_VER_EDGE $COQIDE_OPAM_EDGE
 
-# BE+flambda switch
-RUN opam switch -y -j $NJOBS "${COMPILER_BE}+flambda" && eval $(opam config env) && \
-    opam install -j $NJOBS $BASE_OPAM camlp5.$CAMLP5_VER_BE $COQIDE_OPAM_BE $CI_OPAM
+# EDGE+flambda switch, we install CI_OPAM as to be able to use
+# `ci-template-flambda` with everything.
+RUN opam switch -y -j $NJOBS "${COMPILER_EDGE}+flambda" && eval $(opam config env) && \
+    opam install -j $NJOBS $BASE_OPAM camlp5.$CAMLP5_VER_EDGE $COQIDE_OPAM_EDGE $CI_OPAM


### PR DESCRIPTION
Things like Menhir or Elpi seem to fragile as to allow a
non-deterministic install in the Dockefile, we thus specify the
version for all `CI_OPAM` packages.

cc: https://github.com/AbsInt/CompCert/issues/234
