### PR TITLE
Deprecate unused internal ComInductive API

### DIFF
--- a/dev/doc/changes.md
+++ b/dev/doc/changes.md
@@ -60,6 +60,9 @@ Vernacular commands
   `tactics/`. In all cases adapting is a matter of changing the module
   name.
 
+- Part of the Internal API in `vernac/comInductive` has been deprecated
+  because it appeared to have no more users.
+
 ### Unit testing
 
   The test suite now allows writing unit tests against OCaml code in the Coq

--- a/vernac/comInductive.mli
+++ b/vernac/comInductive.mli
@@ -51,13 +51,16 @@ type structured_one_inductive_expr = {
   ind_arity : constr_expr;
   ind_lc : (Id.t * constr_expr) list
 }
+[@@ocaml.deprecated "This API is internal"]
 
 type structured_inductive_expr =
   local_binder_expr list * structured_one_inductive_expr list
+[@@ocaml.deprecated "This API is internal"]
 
 val extract_mutual_inductive_declaration_components :
   (one_inductive_expr * decl_notation list) list ->
     structured_inductive_expr * (*coercions:*) qualid list * decl_notation list
+[@@ocaml.deprecated "This API is internal"]
 
 (** Typing mutual inductive definitions *)
 
@@ -65,3 +68,4 @@ val interp_mutual_inductive :
   structured_inductive_expr -> decl_notation list -> cumulative_inductive_flag ->
   polymorphic -> private_flag -> Declarations.recursivity_kind ->
   mutual_inductive_entry * UnivNames.universe_binders * one_inductive_impls list
+[@@ocaml.deprecated "This API is internal"]


### PR DESCRIPTION
**Kind:** cleanup
- [x] Entry added in dev/doc/changes.md.

No one seems to be using these outside of `comInductive.ml` anymore.
They were marked as "Internal" and "Exported for Funind", and Funind doesn't use them anymore.
In the spirit of pruning the API, I suggest deprecation followed by removal.

I also have a branch removing this API here: https://github.com/jashug/coq/tree/remove-internal-comInductive-API
with Travis run at https://travis-ci.org/jashug/coq/builds/388047239

A note: deprecating the types `structured_one_inductive_expr` and `structured_inductive_expr` raises warnings when they are referenced in the following deprecated functions.