### PR TITLE
Add an option to force parameters to be uniform

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -52,6 +52,9 @@ Vernacular Commands
 - Nested proofs may be enabled through the option `Nested Proofs Allowed`.
   By default, they are disabled and produce an error. The deprecation
   warning which used to occur when using nested proofs has been removed.
+- Added option Uniform Inductive Parameters which abstracts over parameters
+  before typechecking constructors, allowing to write for example
+  `Inductive list (A : Type) := nil : list | cons : A -> list -> list.`
 
 Coq binaries and process model
 

--- a/doc/sphinx/language/gallina-specification-language.rst
+++ b/doc/sphinx/language/gallina-specification-language.rst
@@ -905,6 +905,32 @@ Parametrized inductive types
      sort for the inductive definition and will produce a less convenient
      rule for case elimination.
 
+.. opt:: Uniform Inductive Parameters
+
+     When this option is set (it is off by default),
+     inductive definitions are abstracted over their parameters
+     before typechecking constructors, allowing to write:
+
+     .. coqtop:: all undo
+
+        Set Uniform Inductive Parameters.
+        Inductive list3 (A:Set) : Set :=
+        | nil3 : list3
+        | cons3 : A -> list3 -> list3.
+
+     This behavior is essentially equivalent to starting a new section
+     and using :cmd:`Context` to give the uniform parameters, like so
+     (cf. :ref:`section-mechanism`):
+
+     .. coqtop:: all undo
+
+        Section list3.
+        Context (A:Set).
+        Inductive list3 : Set :=
+        | nil3 : list3
+        | cons3 : A -> list3 -> list3.
+        End list3.
+
 .. seealso::
    Section :ref:`inductive-definitions` and the :tacn:`induction` tactic.
 

--- a/plugins/funind/glob_term_to_relation.ml
+++ b/plugins/funind/glob_term_to_relation.ml
@@ -1499,7 +1499,7 @@ let do_build_inductive
   let _time2 = System.get_time () in
   try
     with_full_print
-      (Flags.silently (ComInductive.do_mutual_inductive rel_inds (Flags.is_universe_polymorphism ()) false false))
+      (Flags.silently (ComInductive.do_mutual_inductive rel_inds (Flags.is_universe_polymorphism ()) false false ~uniform:ComInductive.NonUniformParameters))
       Declarations.Finite
   with
     | UserError(s,msg) as e ->

--- a/test-suite/success/uniform_inductive_parameters.v
+++ b/test-suite/success/uniform_inductive_parameters.v
@@ -1,0 +1,13 @@
+Set Uniform Inductive Parameters.
+
+Inductive list (A : Type) :=
+  | nil : list
+  | cons : A -> list -> list.
+Check (list : Type -> Type).
+Check (cons : forall A, A -> list A -> list A).
+
+Inductive list2 (A : Type) (A' := prod A A) :=
+  | nil2 : list2
+  | cons2 : A' -> list2 -> list2.
+Check (list2 : Type -> Type).
+Check (cons2 : forall A (A' := prod A A), A' -> list2 A -> list2 A).

--- a/vernac/comInductive.mli
+++ b/vernac/comInductive.mli
@@ -19,9 +19,14 @@ open Decl_kinds
 
 (** Entry points for the vernacular commands Inductive and CoInductive *)
 
+type uniform_inductive_flag =
+  | UniformParameters
+  | NonUniformParameters
+
 val do_mutual_inductive :
   (one_inductive_expr * decl_notation list) list -> cumulative_inductive_flag ->
-  polymorphic -> private_flag -> Declarations.recursivity_kind -> unit
+  polymorphic -> private_flag -> uniform:uniform_inductive_flag ->
+  Declarations.recursivity_kind -> unit
 
 (************************************************************************)
 (** Internal API  *)

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -537,7 +537,12 @@ let should_treat_as_cumulative cum poly =
     else user_err Pp.(str "The NonCumulative prefix can only be used in a polymorphic context.")
   | None -> poly && Flags.is_polymorphic_inductive_cumulativity ()
 
-let should_treat_as_uniform () = ComInductive.NonUniformParameters (* TODO: Add a flag *)
+let uniform_inductive_parameters = ref false
+
+let should_treat_as_uniform () =
+  if !uniform_inductive_parameters
+  then ComInductive.UniformParameters
+  else ComInductive.NonUniformParameters
 
 let vernac_record cum k poly finite records =
   let is_cumulative = should_treat_as_cumulative cum poly in
@@ -1472,6 +1477,14 @@ let _ =
       optkey   = ["Polymorphic"; "Inductive"; "Cumulativity"];
       optread  = Flags.is_polymorphic_inductive_cumulativity;
       optwrite = Flags.make_polymorphic_inductive_cumulativity }
+
+let _ =
+  declare_bool_option
+    { optdepr  = false;
+      optname  = "Uniform inductive parameters";
+      optkey   = ["Uniform"; "Inductive"; "Parameters"];
+      optread  = (fun () -> !uniform_inductive_parameters);
+      optwrite = (fun b -> uniform_inductive_parameters := b) }
 
 let _ =
   declare_int_option

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -537,6 +537,8 @@ let should_treat_as_cumulative cum poly =
     else user_err Pp.(str "The NonCumulative prefix can only be used in a polymorphic context.")
   | None -> poly && Flags.is_polymorphic_inductive_cumulativity ()
 
+let should_treat_as_uniform () = ComInductive.NonUniformParameters (* TODO: Add a flag *)
+
 let vernac_record cum k poly finite records =
   let is_cumulative = should_treat_as_cumulative cum poly in
   let map ((coe, (id, pl)), binders, sort, nameopt, cfs) =
@@ -642,7 +644,8 @@ let vernac_inductive ~atts cum lo finite indl =
     in
     let indl = List.map unpack indl in
     let is_cumulative = should_treat_as_cumulative cum atts.polymorphic in
-    ComInductive.do_mutual_inductive indl is_cumulative atts.polymorphic lo finite
+    let uniform = should_treat_as_uniform () in
+    ComInductive.do_mutual_inductive indl is_cumulative atts.polymorphic lo ~uniform finite
   else
     user_err (str "Mixed record-inductive definitions are not allowed")
 (*
@@ -2089,7 +2092,7 @@ let interp ?proof ~atts ~st c =
   | VernacExactProof c -> vernac_exact_proof c
   | VernacAssumption ((discharge,kind),nl,l) ->
       vernac_assumption ~atts discharge kind l nl
-  | VernacInductive (cum, priv,finite,l) -> vernac_inductive ~atts cum priv finite l
+  | VernacInductive (cum, priv, finite, l) -> vernac_inductive ~atts cum priv finite l
   | VernacFixpoint (discharge, l) -> vernac_fixpoint ~atts discharge l
   | VernacCoFixpoint (discharge, l) -> vernac_cofixpoint ~atts discharge l
   | VernacScheme l -> vernac_scheme l


### PR DESCRIPTION
**Kind:** feature

Supersedes #7439.

We support an option `Set Uniform Inductive Parameters` that abstracts inductives over their parameters before type-checking the constructors. This allows to write ex.
```
Inductive list (A : Type) := nil : list | cons : A -> list -> list.
```
This patch does not include earlier syntax which allowed for `Uniform Inductive` and `NonUniform Inductive`, as that can wait for attributes to be implemented.

- [x] Added / updated test-suite
- [x] Corresponding documentation was added / updated.
- [x] Entry added in CHANGES.
