### PR TITLE
[v8.8] Fix #7333: soundness bug with VM/native and cofixpoints

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,10 @@
 Changes from 8.8.0 to 8.8.1
 ===========================
 
+Kernel
+
+- Fix a soundness bug with CoFixpoints and VM/native_compute (see #7333).
+
 Notations
 
 - Fixed unexpected collision between only-parsing and only-printing

--- a/kernel/cinstr.mli
+++ b/kernel/cinstr.mli
@@ -31,13 +31,17 @@ and lambda =
   | Lprim         of pconstant * int (* arity *) * instruction * lambda array
   | Lcase         of case_info * reloc_table * lambda * lambda * lam_branches
   | Lfix          of (int array * int) * fix_decl
-  | Lcofix        of int * fix_decl
+  | Lcofix        of int * fix_decl (* must be in eta-expanded form *)
   | Lmakeblock    of int * lambda array
   | Lval          of structured_constant
   | Lsort         of Sorts.t
   | Lind          of pinductive
   | Lproj         of int * Constant.t * lambda
   | Luint         of uint
+
+(* Cofixpoints have to be in eta-expanded form for their call-by-need evaluation
+to be correct. Otherwise, memoization of previous evaluations will be applied
+again to extra arguments (see #7333). *)
 
 and lam_branches =
   { constant_branches : lambda array;

--- a/kernel/clambda.ml
+++ b/kernel/clambda.ml
@@ -605,6 +605,8 @@ end
 
 open Renv
 
+let (eta_expand,eta_expand_hook) = Hook.make ()
+
 let rec lambda_of_constr env c =
   match Constr.kind c with
   | Meta _ -> raise (Invalid_argument "Cbytegen.lambda_of_constr: Meta")
@@ -700,6 +702,7 @@ let rec lambda_of_constr env c =
     Lfix(rec_init, (names, ltypes, lbodies))
 
   | CoFix(init,(names,type_bodies,rec_bodies)) ->
+    let rec_bodies = Array.map2 (Hook.get eta_expand env.global_env) rec_bodies type_bodies in
     let ltypes = lambda_of_args env 0 type_bodies in
     Renv.push_rels env names;
     let lbodies = lambda_of_args env 0 rec_bodies in

--- a/kernel/clambda.mli
+++ b/kernel/clambda.mli
@@ -25,3 +25,6 @@ val dynamic_int31_compilation : bool -> lambda array -> lambda
 (*spiwack: compiling function to insert dynamic decompilation before
            matching integers (in case they are in processor representation) *)
 val int31_escape_before_match : bool -> lambda -> lambda
+
+val eta_expand : (Pre_env.env -> Constr.t -> Constr.types -> Constr.t) Hook.value
+val eta_expand_hook : (Pre_env.env -> Constr.t -> Constr.types -> Constr.t) Hook.t

--- a/kernel/nativeinstr.mli
+++ b/kernel/nativeinstr.mli
@@ -37,7 +37,7 @@ and lambda =
                   (* annotations, term being matched, accu, branches *)
   | Lif           of lambda * lambda * lambda
   | Lfix          of (int array * int) * fix_decl 
-  | Lcofix        of int * fix_decl 
+  | Lcofix        of int * fix_decl (* must be in eta-expanded form *)
   | Lmakeblock    of prefix * pconstructor * int * lambda array
                   (* prefix, constructor name, constructor tag, arguments *)
 	(* A fully applied constructor *)
@@ -49,6 +49,10 @@ and lambda =
   | Lind          of prefix * pinductive
   | Llazy
   | Lforce
+
+(* Cofixpoints have to be in eta-expanded form for their call-by-need evaluation
+to be correct. Otherwise, memoization of previous evaluations will be applied
+again to extra arguments (see #7333). *)
 
 and lam_branches = (constructor * Name.t array * lambda) array 
 

--- a/kernel/nativelambda.ml
+++ b/kernel/nativelambda.ml
@@ -572,6 +572,7 @@ let rec lambda_of_constr env sigma c =
       Lfix(rec_init, (names, ltypes, lbodies))
 	
   | CoFix(init,(names,type_bodies,rec_bodies)) ->
+      let rec_bodies = Array.map2 (Hook.get Clambda.eta_expand !global_env) rec_bodies type_bodies in
       let ltypes = lambda_of_args env sigma 0 type_bodies in 
       Renv.push_rels env names;
       let lbodies = lambda_of_args env sigma 0 rec_bodies in

--- a/kernel/reduction.ml
+++ b/kernel/reduction.ml
@@ -879,6 +879,17 @@ let dest_prod env =
   in
   decrec env Context.Rel.empty
 
+let dest_lam env =
+  let rec decrec env m c =
+    let t = whd_all env c in
+    match kind t with
+      | Lambda (n,a,c0) ->
+          let d = LocalAssum (n,a) in
+          decrec (push_rel d env) (Context.Rel.add d m) c0
+      | _ -> m,t
+  in
+  decrec env Context.Rel.empty
+
 (* The same but preserving lets in the context, not internal ones. *)
 let dest_prod_assum env =
   let rec prodec_rec env l ty =
@@ -924,3 +935,15 @@ let is_arity env c =
     let _ = dest_arity env c in
     true
   with NotArity -> false
+
+let eta_expand env t ty =
+  let env = env_of_pre_env env in
+  let ctxt, codom = dest_prod env ty in
+  let ctxt',t = dest_lam env t in
+  let d = Context.Rel.nhyps ctxt - Context.Rel.nhyps ctxt' in
+  let eta_args = List.rev_map mkRel (List.interval 1 d) in
+  let t = Term.applistc (Vars.lift d t) eta_args in
+  let t = Term.it_mkLambda_or_LetIn t (List.firstn d ctxt) in
+  Term.it_mkLambda_or_LetIn t ctxt'
+
+let _ = Hook.set Clambda.eta_expand_hook eta_expand

--- a/kernel/reduction.mli
+++ b/kernel/reduction.mli
@@ -122,6 +122,7 @@ val betazeta_appvect : int -> constr -> constr array -> constr
 
 val dest_prod       : env -> types -> Context.Rel.t * types
 val dest_prod_assum : env -> types -> Context.Rel.t * types
+val dest_lam        : env -> types -> Context.Rel.t * constr
 val dest_lam_assum  : env -> types -> Context.Rel.t * types
 
 exception NotArity

--- a/test-suite/bugs/7333.v
+++ b/test-suite/bugs/7333.v
@@ -1,0 +1,39 @@
+Module Example1.
+
+CoInductive wrap : Type :=
+ | item : unit -> wrap.
+
+Definition extract (t : wrap) : unit :=
+match t with
+| item x => x
+end.
+
+CoFixpoint close u : unit -> wrap :=
+match u with
+| tt => item
+end.
+
+Definition table : wrap := close tt tt.
+
+Eval vm_compute in (extract table).
+Eval vm_compute in (extract table).
+
+End Example1.
+
+Module Example2.
+
+Set Primitive Projections.
+CoInductive wrap : Type :=
+ item { extract : unit }.
+
+CoFixpoint close u : unit -> wrap :=
+match u with
+| tt => item
+end.
+
+Definition table : wrap := close tt tt.
+
+Eval vm_compute in (extract table).
+Eval vm_compute in (extract table).
+
+End Example2.


### PR DESCRIPTION
This is an 8.8 backport of #7521. The soundness fix is the same, but it relies on a `Hook` because of dependency issues that I fixed in 8.9.