### PR TITLE
Remove cross-crypto from Travis. It is still tested in GitLab CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,9 +82,6 @@ matrix:
       - TEST_TARGET="ci-coquelicot"
     - if: NOT (type = pull_request)
       env:
-      - TEST_TARGET="ci-cross-crypto"
-    - if: NOT (type = pull_request)
-      env:
       - TEST_TARGET="ci-elpi" EXTRA_OPAM="elpi"
       # ppx_tools_versioned requires a specific version findlib
       - FINDLIB_VER=""


### PR DESCRIPTION
This fixes #7734.

**Kind:** infrastructure.

Since there are already quite a few projects that are only tested in GitLab CI, and not in Travis, it doesn't harm to remove cross-crypto from Travis as well.