### PR TITLE
Bound proof-search in default program obligation tactic.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -34,6 +34,10 @@ Tactics
 
 - Deprecated the Implicit Tactic family of commands.
 
+- The default program obligation tactic uses a bounded proof search
+  instead of an unbounded and potentially non-terminating one now
+  (source of incompatibility).
+
 - The `simple apply` tactic now respects the `Opaque` flag when called from
   Ltac (`auto` still does not respect it).
 

--- a/theories/Program/Tactics.v
+++ b/theories/Program/Tactics.v
@@ -326,7 +326,7 @@ Ltac program_solve_wf :=
 
 Create HintDb program discriminated.
 
-Ltac program_simpl := program_simplify ; try typeclasses eauto with program ; try program_solve_wf.
+Ltac program_simpl := program_simplify ; try typeclasses eauto 10 with program ; try program_solve_wf.
 
 Obligation Tactic := program_simpl.
 


### PR DESCRIPTION
This issue was first reported on equations where a definition seemingly
took all memory until Coq crashed.

https://github.com/mattam82/Coq-Equations/issues/69

**Kind:** bug fix

I'm don't feel this deserves a Timeout based test-suite file but I can add one if needed.

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes mattam82/Coq-Equations#69
<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [x] Entry added in CHANGES.
