### PR TITLE
Adapt the VM to use index-based projections.

### DIFF
--- a/dev/vm_printers.ml
+++ b/dev/vm_printers.ml
@@ -16,8 +16,8 @@ let ppripos (ri,pos) =
       print_string "structured constant\n"
   | Reloc_getglobal kn ->
     print_string ("getglob "^(Constant.to_string kn)^"\n")
-  | Reloc_proj_name p ->
-    print_string ("proj "^(Constant.to_string p)^"\n")
+  | Reloc_proj_name ((mind, n), i) ->
+    print_string ("proj "^(MutInd.to_string mind)^","^(string_of_int n)^","^(string_of_int i)^"\n")
   );
    print_flush ()
 

--- a/kernel/cbytecodes.ml
+++ b/kernel/cbytecodes.ml
@@ -128,7 +128,7 @@ type instruction =
   | Ksetfield of int
   | Kstop
   | Ksequence of bytecodes * bytecodes
-  | Kproj of int * Constant.t  (* index of the projected argument,
+  | Kproj of (inductive * int)  (* index of the projected argument,
                                            name of projection *)
   | Kensurestackcapacity of int
 (* spiwack: instructions concerning integers *)
@@ -239,6 +239,9 @@ let pp_sort s =
   | Prop Pos -> str "Set"
   | Type u -> str "Type@{" ++ Univ.pr_uni u ++ str "}"
 
+let pp_proj ((mind, n), i) =
+  MutInd.print mind ++ str"#" ++ int n ++ str "." ++ int i
+
 let rec pp_struct_const = function
   | Const_sort s -> pp_sort s
   | Const_ind (mind, i) -> MutInd.print mind ++ str"#" ++ int i
@@ -310,7 +313,7 @@ let rec pp_instr i =
 
   | Kbranch lbl -> str "branch " ++ pp_lbl lbl
 
-  | Kproj(n,p) -> str "proj " ++ int n ++ str " " ++ Constant.print p
+  | Kproj p -> str "proj " ++ pp_proj p
 
   | Kensurestackcapacity size -> str "growstack " ++ int size
 

--- a/kernel/cbytecodes.mli
+++ b/kernel/cbytecodes.mli
@@ -88,8 +88,7 @@ type instruction =
   | Ksetfield of int                    (** accu[n] = sp[0] ; sp = pop sp *)
   | Kstop
   | Ksequence of bytecodes * bytecodes
-  | Kproj of int * Constant.t  (** index of the projected argument,
-                                            name of projection *)
+  | Kproj of (inductive * int)  (** inductive, index of the projected argument *)
   | Kensurestackcapacity of int
 
 (** spiwack: instructions concerning integers *)

--- a/kernel/cbytegen.ml
+++ b/kernel/cbytegen.ml
@@ -479,8 +479,8 @@ let rec compile_lam env cenv lam sz cont =
 
   | Lval v -> compile_structured_constant cenv v sz cont
 
-  | Lproj (n,kn,arg) ->
-     compile_lam env cenv arg sz (Kproj (n,kn) :: cont)
+  | Lproj (p, arg) ->
+     compile_lam env cenv arg sz (Kproj p :: cont)
 
   | Lvar id -> pos_named id cenv :: cont
 

--- a/kernel/cemitcodes.ml
+++ b/kernel/cemitcodes.ml
@@ -27,7 +27,7 @@ type reloc_info =
   | Reloc_annot of annot_switch
   | Reloc_const of structured_constant
   | Reloc_getglobal of Names.Constant.t
-  | Reloc_proj_name of Constant.t
+  | Reloc_proj_name of (inductive * int)
 
 let eq_reloc_info r1 r2 = match r1, r2 with
 | Reloc_annot sw1, Reloc_annot sw2 -> eq_annot_switch sw1 sw2
@@ -36,7 +36,7 @@ let eq_reloc_info r1 r2 = match r1, r2 with
 | Reloc_const _, _ -> false
 | Reloc_getglobal c1, Reloc_getglobal c2 -> Constant.equal c1 c2
 | Reloc_getglobal _, _ -> false
-| Reloc_proj_name p1, Reloc_proj_name p2 -> Constant.equal p1 p2
+| Reloc_proj_name (i1, n1), Reloc_proj_name (i2, n2) -> eq_ind i1 i2 && Int.equal n1 n2
 | Reloc_proj_name _, _ -> false
 
 let hash_reloc_info r =
@@ -45,7 +45,7 @@ let hash_reloc_info r =
   | Reloc_annot sw -> combinesmall 1 (hash_annot_switch sw)
   | Reloc_const c -> combinesmall 2 (hash_structured_constant c)
   | Reloc_getglobal c -> combinesmall 3 (Constant.hash c)
-  | Reloc_proj_name p -> combinesmall 4 (Constant.hash p)
+  | Reloc_proj_name (ind, n) -> combinesmall 4 (combine (ind_hash ind) n)
 
 module RelocTable = Hashtbl.Make(struct
   type t = reloc_info
@@ -284,7 +284,7 @@ let emit_instr env = function
       if n <= 1 then out env (opSETFIELD0+n)
       else (out env opSETFIELD;out_int env n)
   | Ksequence _ -> invalid_arg "Cemitcodes.emit_instr"
-  | Kproj (n,p) -> out env opPROJ; out_int env n; slot_for_proj_name env p
+  | Kproj (_, n as p) -> out env opPROJ; out_int env n; slot_for_proj_name env p
   | Kensurestackcapacity size -> out env opENSURESTACKCAPACITY; out_int env size
   (* spiwack *)
   | Kbranch lbl -> out env opBRANCH; out_label env lbl
@@ -371,7 +371,7 @@ let subst_reloc s ri =
       Reloc_annot {a with ci = ci}
   | Reloc_const sc -> Reloc_const (subst_strcst s sc)
   | Reloc_getglobal kn -> Reloc_getglobal (subst_constant s kn)
-  | Reloc_proj_name p -> Reloc_proj_name (subst_constant s p)
+  | Reloc_proj_name (ind, n) -> Reloc_proj_name (subst_ind s ind, n)
 
 let subst_patches subst p =
   let infos = CArray.map (fun (r, pos) -> (subst_reloc subst r, pos)) p.reloc_infos in

--- a/kernel/cemitcodes.mli
+++ b/kernel/cemitcodes.mli
@@ -5,7 +5,7 @@ type reloc_info =
   | Reloc_annot of annot_switch
   | Reloc_const of structured_constant
   | Reloc_getglobal of Constant.t
-  | Reloc_proj_name of Constant.t
+  | Reloc_proj_name of (inductive * int)
 
 type patches
 type emitcodes

--- a/kernel/cinstr.mli
+++ b/kernel/cinstr.mli
@@ -36,7 +36,7 @@ and lambda =
   | Lval          of structured_constant
   | Lsort         of Sorts.t
   | Lind          of pinductive
-  | Lproj         of int * Constant.t * lambda
+  | Lproj         of (inductive * int) * lambda
   | Luint         of uint
 
 (* Cofixpoints have to be in eta-expanded form for their call-by-need evaluation

--- a/kernel/clambda.ml
+++ b/kernel/clambda.ml
@@ -111,9 +111,9 @@ let rec pp_lam lam =
       (str "(PRIM " ++ pr_con kn ++  spc() ++
        prlist_with_sep spc pp_lam  (Array.to_list args) ++
        str")")
-  | Lproj(i,kn,arg) ->
+  | Lproj(((mind, n), i), arg) ->
     hov 1
-      (str "(proj#" ++ int i ++ spc() ++ pr_con kn ++ str "(" ++ pp_lam arg
+      (str "(proj#" ++ int i ++ spc() ++ MutInd.print mind ++ spc () ++ int n ++ str "(" ++ pp_lam arg
        ++ str ")")
   | Luint _ ->
     str "(uint)"
@@ -205,9 +205,9 @@ let rec map_lam_with_binders g f n lam =
   | Lprim(kn,ar,op,args) ->
     let args' = Array.Smart.map (f n) args in
     if args == args' then lam else Lprim(kn,ar,op,args')
-  | Lproj(i,kn,arg) ->
+  | Lproj (p, arg) ->
     let arg' = f n arg in
-    if arg == arg' then lam else Lproj(i,kn,arg')
+    if arg == arg' then lam else Lproj (p, arg')
   | Luint u ->
     let u' = map_uint g f n u in
     if u == u' then lam else Luint u'
@@ -376,7 +376,7 @@ let rec occurrence k kind lam =
     let kind = occurrence_args k kind ltypes in
     let _ = occurrence_args (k+Array.length ids) false lbodies in
     kind
-  | Lproj(_,_,arg) ->
+  | Lproj (_, arg) ->
     occurrence k kind arg
   | Luint u -> occurrence_uint k kind u
 
@@ -711,7 +711,7 @@ let rec lambda_of_constr env c =
     let pb = lookup_projection p env.global_env in
     let n = pb.proj_arg in
     let lc = lambda_of_constr env c in
-    Lproj (n,Projection.constant p,lc)
+    Lproj ((pb.proj_ind, n), lc)
 
 and lambda_of_app env f args =
   match Constr.kind f with

--- a/kernel/csymtable.ml
+++ b/kernel/csymtable.ml
@@ -78,9 +78,9 @@ module AnnotTable = Hashtbl.Make (struct
 end)
 
 module ProjNameTable = Hashtbl.Make (struct
-  type t = Constant.t
-  let equal = Constant.equal
-  let hash = Constant.hash
+  type t = inductive * int
+  let equal (i1, n1) (i2, n2) = eq_ind i1 i2 && Int.equal n1 n2
+  let hash (ind, n) = Hashset.Combine.combine (ind_hash ind) n
 end)
 
 let str_cst_tbl : int SConstTable.t = SConstTable.create 31

--- a/kernel/vconv.ml
+++ b/kernel/vconv.ml
@@ -138,8 +138,8 @@ and conv_stack env k stk1 stk2 cu =
 	done;
 	conv_stack env k stk1 stk2 !rcu
       else raise NotConvertible
-  | Zproj p1 :: stk1, Zproj p2 :: stk2 ->
-    if Constant.equal p1 p2 then conv_stack env k stk1 stk2 cu
+  | Zproj (i1, n1) :: stk1, Zproj (i2, n2) :: stk2 ->
+    if eq_ind i1 i2 && Int.equal n1 n2 then conv_stack env k stk1 stk2 cu
     else raise NotConvertible
   | [], _ | Zapp _ :: _, _ | Zfix _ :: _, _ | Zswitch _ :: _, _
   | Zproj _ :: _, _ -> raise NotConvertible

--- a/kernel/vmvalues.ml
+++ b/kernel/vmvalues.ml
@@ -150,7 +150,7 @@ type zipper =
   | Zapp of arguments
   | Zfix of vfix*arguments  (* Possibly empty *)
   | Zswitch of vswitch
-  | Zproj of Constant.t (* name of the projection *)
+  | Zproj of (inductive * int) (* projection by index, starting at 0 *)
 
 type stack = zipper list
 
@@ -313,7 +313,7 @@ let val_of_str_const str = val_of_obj (obj_of_str_const str)
 
 let val_of_atom a = val_of_obj (obj_of_atom a)
 
-let atom_of_proj kn v =
+let atom_of_proj (kn : inductive * int) v =
   let r = Obj.new_block proj_tag 2 in
   Obj.set_field r 0 (Obj.repr kn);
   Obj.set_field r 1 (Obj.repr v);
@@ -354,7 +354,7 @@ let val_of_constant c = val_of_idkey (ConstKey c)
 let val_of_evar evk = val_of_idkey (EvarKey evk)
 
 external val_of_annot_switch : annot_switch -> values = "%identity"
-external val_of_proj_name : Constant.t -> values = "%identity"
+external val_of_proj_name : (inductive * int) -> values = "%identity"
 
 (*************************************************)
 (** Operations manipulating data types ***********)
@@ -553,4 +553,5 @@ and pr_zipper z =
   | Zapp args -> str "Zapp(len = " ++ int (nargs args) ++ str ")"
   | Zfix (f,args) -> str "Zfix(..., len=" ++ int (nargs args) ++ str ")"
   | Zswitch s -> str "Zswitch(...)"
-  | Zproj c -> str "Zproj(" ++ Constant.print c ++ str ")")
+  | Zproj ((mind, n), i) ->
+    str "Zproj(" ++ MutInd.print mind ++ str "," ++ int n ++ str "," ++ int i ++ str ")")

--- a/kernel/vmvalues.mli
+++ b/kernel/vmvalues.mli
@@ -81,7 +81,7 @@ type zipper =
   | Zapp of arguments
   | Zfix of vfix * arguments  (** might be empty *)
   | Zswitch of vswitch
-  | Zproj of Constant.t (* name of the projection *)
+  | Zproj of (inductive * int) (* projection by index, starting at 0 *)
 
 type stack = zipper list
 
@@ -108,11 +108,11 @@ val val_of_rel : int -> values
 val val_of_named : Id.t -> values
 val val_of_constant : Constant.t -> values
 val val_of_evar : Evar.t -> values
-val val_of_proj : Constant.t -> values -> values
+val val_of_proj : (inductive * int) -> values -> values
 val val_of_atom : atom -> values
 
 external val_of_annot_switch : annot_switch -> values = "%identity"
-external val_of_proj_name : Constant.t -> values = "%identity"
+external val_of_proj_name : (inductive * int) -> values = "%identity"
 
 (** Destructors *)
 

--- a/pretyping/vnorm.ml
+++ b/pretyping/vnorm.ml
@@ -280,8 +280,15 @@ and nf_stk ?from:(from=0) env sigma c t stk  =
       let tcase = build_case_type dep p realargs c in
       let ci = sw.sw_annot.Cbytecodes.ci in
       nf_stk env sigma (mkCase(ci, p, c, branchs)) tcase stk
-  | Zproj p :: stk ->
+  | Zproj ((mind, n), i) :: stk ->
      assert (from = 0) ;
+    let mib = Environ.lookup_mind mind env in
+    let p = match mib.mind_record with
+    | PrimRecord info ->
+      let (_, kns, _) = info.(n) in
+      kns.(i)
+    | FakeRecord | NotRecord -> assert false
+    in
      let p' = Projection.make p true in
      let ty = Inductiveops.type_of_projection_knowing_arg env sigma p' (EConstr.of_constr c) (EConstr.of_constr t) in
      nf_stk env sigma (mkProj(p',c)) ty stk


### PR DESCRIPTION
This depend on #7750 [merged].

Part of the project to switch to an index-based representation of primitive projections.