### PR TITLE
Fixes #7712 (an anomaly in reporting bad recursive notation format).

### DIFF
--- a/test-suite/bugs/closed/7712.v
+++ b/test-suite/bugs/closed/7712.v
@@ -1,0 +1,4 @@
+(* This used to raise an anomaly *)
+
+Fail Reserved Notation "'[tele_arg' x ';' .. ';' z ]"
+       (format "[tele_arg '[hv'  x .. z ']' ]").


### PR DESCRIPTION
**Kind:** bug fix

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Closes #7712.

The error message was overlooking the case of an empty list of separators. This PR fixes the anomaly and slightly changes the location reporting.

Now it says `The format does not match the notation` and it underlines as follows:
```coq
Notation "'[tele_arg' x ';' .. ';' z ]" :=
  (TargS x ( .. (TargS z TargO) ..))
  (format "[tele_arg '[hv'  x .. z ']' ]").
                            ^^^^
```
Would it better to underline only `x`?

- [X] Added / updated test-suite

