### PR TITLE
Fixing #7700: section variables bound to abbreviations were not found

### DIFF
--- a/test-suite/bugs/closed/7700.v
+++ b/test-suite/bugs/closed/7700.v
@@ -1,0 +1,9 @@
+(* Abbreviations to section variables were not located *)
+Section foo.
+  Let x := Set.
+  Notation y := x.
+  Check y.
+  Variable x' : Set.
+  Notation y' := x'.
+  Check y'.
+End foo.


### PR DESCRIPTION
**Kind:** bug fix

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes #7700

Surprisingly enough this is a serious missing case of the globalization of variables which has remained non reported for more than a decade.

Redundancy between finding section variables in both `interp_var` and `interp_qualid` could probably be cleaned, if some courageous soul is wanting to investigate that.

- [X] Added / updated test-suite
