### PR TITLE
Closes #7699: confusing undocumented multi-class syntax of Bind Scope

### DIFF
--- a/test-suite/bugs/closed/3732.v
+++ b/test-suite/bugs/closed/3732.v
@@ -54,7 +54,8 @@ Section machine.
   Definition interp specs := valid specs nil.
 End machine.
 Notation "'ExX' : A , P" := (ExistsX (A := A) P) (at level 89) : PropX_scope.
-Bind Scope PropX_scope with PropX propX.
+Bind Scope PropX_scope with PropX.
+Bind Scope PropX_scope with propX.
 Variables pc state : Type.
 
 Inductive subs : list Type -> Type :=

--- a/theories/Arith/PeanoNat.v
+++ b/theories/Arith/PeanoNat.v
@@ -751,7 +751,8 @@ End Nat.
 (** Re-export notations that should be available even when
     the [Nat] module is not imported. *)
 
-Bind Scope nat_scope with Nat.t nat.
+Bind Scope nat_scope with Nat.t.
+Bind Scope nat_scope with nat.
 
 Infix "^" := Nat.pow : nat_scope.
 Infix "=?" := Nat.eqb (at level 70) : nat_scope.

--- a/theories/NArith/BinNat.v
+++ b/theories/NArith/BinNat.v
@@ -926,7 +926,8 @@ Qed.
 
 End N.
 
-Bind Scope N_scope with N.t N.
+Bind Scope N_scope with N.t.
+Bind Scope N_scope with N.
 
 (** Exportation of notations *)
 

--- a/theories/PArith/BinPos.v
+++ b/theories/PArith/BinPos.v
@@ -1867,7 +1867,8 @@ Qed.
 
 End Pos.
 
-Bind Scope positive_scope with Pos.t positive.
+Bind Scope positive_scope with Pos.t.
+Bind Scope positive_scope with positive.
 
 (** Exportation of notations *)
 

--- a/theories/ZArith/BinInt.v
+++ b/theories/ZArith/BinInt.v
@@ -1244,7 +1244,8 @@ Qed.
 
 End Z.
 
-Bind Scope Z_scope with Z.t Z.
+Bind Scope Z_scope with Z.t.
+Bind Scope Z_scope with Z.
 
 (** Re-export Notations *)
 

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -490,6 +490,10 @@ let warn_deprecated_include_type =
   CWarnings.create ~name:"deprecated-include-type" ~category:"deprecated"
          (fun () -> strbrk "Include Type is deprecated; use Include instead")
 
+let warn_deprecated_bind_several_scopes =
+  CWarnings.create ~name:"deprecated-bind-multiple-scopes" ~category:"deprecated"
+         (fun () -> strbrk "Binding a scope to several types at the same time is deprecated.")
+
 }
 
 (* Modules and Sections *)
@@ -1119,7 +1123,9 @@ GRAMMAR EXTEND Gram
 	 { VernacDelimiters (sc, None) }
 
      | IDENT "Bind"; IDENT "Scope"; sc = IDENT; "with";
-       refl = LIST1 class_rawexpr -> { VernacBindScope (sc,refl) }
+       refl = LIST1 class_rawexpr ->
+         { if List.length refl > 1 then warn_deprecated_bind_several_scopes ();
+           VernacBindScope (sc,refl) }
 
      | IDENT "Infix"; op = ne_lstring; ":="; p = constr;
          modl = [ "("; l = LIST1 syntax_modifier SEP ","; ")" -> { l } | -> { [] } ];


### PR DESCRIPTION
**Kind:** syntax clarification 

Fixes #7699.

Only `Bind Scope a_scope with class` is documented. Do not provide `Bind Scope a_scope with class1 .. classn` as it is a source of confusion. Think e.g. as `Bind Scope b_scope with option nat`.

Note that the standard library was using the feature though in the form of `Bind Scope nat_scope with Nat.t nat`. Note also that some users do it (e.g. @jasongross in issue #3732). So, even if not documented, it might be worth a message in `CHANGES` if the decision is to restrict the syntax.

If ever we really want the syntax, maybe better to provide `Bind Scope a_scope with class1, ..., class2`? That would be less confusing, and that would let open a syntax `Bind Scope a_scope with class_pattern` with `class_pattern` being e.g. `option _`.