### PR TITLE
[build] Fix checks and notes noting 4.02.1 instead of 4.02.3

### DIFF
--- a/INSTALL.ide
+++ b/INSTALL.ide
@@ -22,7 +22,7 @@ Else, read the rest of this document to compile your own CoqIde.
 
 COMPILATION REQUIREMENTS
 
-- OCaml >= 4.02.1 with native threads support.
+- OCaml >= 4.02.3 with native threads support.
 - make world must succeed.
 - The graphical toolkit GTK+ 2.x. See http://www.gtk.org.
   The official supported version is at least 2.24.x.

--- a/configure.ml
+++ b/configure.ml
@@ -601,14 +601,14 @@ let caml_version_nums =
          "Is it installed properly?")
 
 let check_caml_version () =
-  if caml_version_nums >= [4;2;1] then
+  if caml_version_nums >= [4;2;3] then
     cprintf "You have OCaml %s. Good!" caml_version
   else
     let () = cprintf "Your version of OCaml is %s." caml_version in
     if !prefs.force_caml_version then
       warn "Your version of OCaml is outdated."
     else
-      die "You need OCaml 4.02.1 or later."
+      die "You need OCaml 4.02.3 or later."
 
 let _ = check_caml_version ()
 

--- a/dev/doc/profiling.txt
+++ b/dev/doc/profiling.txt
@@ -7,7 +7,7 @@ want to profile time or memory consumption. AFAIK, this only works for Linux.
 
 In Coq source folder:
 
-opam switch 4.02.1+fp
+opam switch 4.02.3+fp
 ./configure -local -debug
 make
 perf record -g bin/coqtop -compile file.v


### PR DESCRIPTION
Bumping to 4.02.3 was decided some time ago in the WG, however a
couple of places escaped updating.
