### PR TITLE
Fix handling of universe context for expanded program obligations.

### DIFF
--- a/vernac/obligations.ml
+++ b/vernac/obligations.ml
@@ -865,7 +865,7 @@ let obligation_terminator name num guard hook auto pf =
       else UState.union prg.prg_ctx ctx
     in
     let uctx = UState.const_univ_entry ~poly:(pi2 prg.prg_kind) ctx in
-    let (_, obl) = declare_obligation prg obl body ty uctx in
+    let (defined, obl) = declare_obligation prg obl body ty uctx in
     let obls = Array.copy obls in
     let _ = obls.(num) <- obl in
     let prg_ctx =
@@ -874,10 +874,12 @@ let obligation_terminator name num guard hook auto pf =
             polymorphic obligation with the existing ones *)
         UState.union prg.prg_ctx ctx
       else
-        (** The first obligation declares the univs of the constant,
+        (** The first obligation, if defined,
+            declares the univs of the constant,
             each subsequent obligation declares its own additional
             universes and constraints if any *)
-        UState.make (Global.universes ())
+        if defined then UState.make (Global.universes ())
+        else ctx
     in
     let prg = { prg with prg_ctx } in
     try


### PR DESCRIPTION
The universe context was dropped even though it isn't added to the
global universes yet. Keep it so that it is properly defined with
the constant the expanded obligation appears in.

**Kind:**  bug fix


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes mattam82/Coq-Equations#75

