### PR TITLE
[ci] Require runner `docker` tag on `docker-boot` job.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,6 +31,8 @@ docker-boot:
   except:
     variables:
       - $SKIP_DOCKER == "true"
+  tags:
+    - docker
 
 before_script:
   - cat /proc/{cpu,mem}info || true


### PR DESCRIPTION
Not all runners are equipped with docker services, thus we must add a
hard dependency on the `docker` tag for our Docker job.
