### PR TITLE
make clean: remove g_*.ml files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,6 +183,7 @@ indepclean:
 	rm -f $(GENFILES)
 	rm -f $(COQTOPBYTE) $(CHICKENBYTE) $(TOPBYTE)
 	find . \( -name '*~' -o -name '*.cm[ioat]' -o -name '*.cmti' \) -delete
+	find . -name 'g_*.ml' -delete
 	rm -f */*.pp[iox] plugins/*/*.pp[iox]
 	rm -rf $(SOURCEDOCDIR)
 	rm -f toplevel/mltop.byteml toplevel/mltop.optml


### PR DESCRIPTION
People keep running into issues with these since the one PR which moved them. This isn't a very general solution but it's better than nothing.

Since our CI cleans before building it will detect if someone adds a non-generated file named g_foo.ml.

NB: g_*.ml is already in our gitignore.

