### PR TITLE
Workaround for #2800: handling non-value arguments in tactics.

### DIFF
--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -1049,8 +1049,7 @@ and eval_tactic ist tac : unit Proofview.tactic = match tac with
       push_trace(loc,call) ist >>= fun trace ->
       Profile_ltac.do_profile "eval_tactic:2" trace
         (catch_error_tac trace (interp_atomic ist t))
-  | TacFun _ | TacLetIn _ -> assert false
-  | TacMatchGoal _ | TacMatch _ -> assert false
+  | TacFun _ | TacLetIn _ | TacMatchGoal _ | TacMatch _ -> interp_tactic ist tac
   | TacId [] -> Proofview.tclLIFT (db_breakpoint (curr_debug ist) [])
   | TacId s ->
       let msgnl =

--- a/test-suite/bugs/closed/2800.v
+++ b/test-suite/bugs/closed/2800.v
@@ -4,3 +4,16 @@ intuition
   match goal with
   | |- _ => idtac " foo"
   end.
+
+  lazymatch goal with _ => idtac end.
+  match goal with _ => idtac end.
+  unshelve lazymatch goal with _ => idtac end.
+  unshelve match goal with _ => idtac end.
+  unshelve (let x := I in idtac).
+Abort.
+
+Require Import ssreflect.
+
+Goal True.
+match goal with _ => idtac end => //.
+Qed.


### PR DESCRIPTION
Although the fix is not a proper one, it seems to solve every instance of #2800 that I could test, I would be welcoming any counterexample.
Also, I have no idea what would be the proper fix. See the issue discussion for more details.

**Kind:** bug fix.
Fixes #2800 
- [x] Added / updated test-suite
