### PR TITLE
Clarifying that the "print" functions in Names are mainly for debugging

### DIFF
--- a/checker/environ.ml
+++ b/checker/environ.ml
@@ -118,7 +118,7 @@ let anomaly s = anomaly (Pp.str s)
 let add_constant kn cs env =
   if Cmap_env.mem kn env.env_globals.env_constants then
     Printf.ksprintf anomaly ("Constant %s is already defined.")
-      (Constant.to_string kn);
+      (Constant.debug_to_string kn);
   let new_constants =
     Cmap_env.add kn cs env.env_globals.env_constants in
   let new_globals =
@@ -184,7 +184,7 @@ let lookup_mind kn env =
 let add_mind kn mib env =
   if Mindmap_env.mem kn env.env_globals.env_inductives then
     Printf.ksprintf anomaly ("Mutual inductive block %s is already defined.")
-      (MutInd.to_string kn);
+      (MutInd.debug_to_string kn);
   let new_inds = Mindmap_env.add kn mib env.env_globals.env_inductives in
   let kn1,kn2 =  MutInd.user kn, MutInd.canonical kn in
   let new_inds_eq = if KerName.equal kn1 kn2 then

--- a/checker/subtyping.ml
+++ b/checker/subtyping.ml
@@ -114,7 +114,7 @@ let check_inductive  env mp1 l info1 mib2 spec2 subst1 subst2=
         let v = Univ.ACumulativityInfo.variance cumi in
         let v' = Univ.ACumulativityInfo.variance cumi' in
         if not (Array.for_all2 Univ.Variance.check_subtype v' v) then
-          CErrors.anomaly Pp.(str "Variance mismatch for " ++ MutInd.print kn)
+          CErrors.anomaly Pp.(str "Variance mismatch for " ++ MutInd.debug_print kn)
       in
       let auctx = Univ.ACumulativityInfo.univ_context cumi in
       let auctx' = Univ.ACumulativityInfo.univ_context cumi' in

--- a/checker/typeops.ml
+++ b/checker/typeops.ml
@@ -75,7 +75,7 @@ let judge_of_constant env (kn,u as cst) =
   let _cb =
     try lookup_constant kn env
     with Not_found ->
-      failwith ("Cannot find constant: "^Constant.to_string kn)
+      failwith ("Cannot find constant: "^Constant.debug_to_string kn)
   in
   let ty, cu = constant_type env cst in
   let () = check_constraints cu env in
@@ -158,7 +158,7 @@ let judge_of_inductive_knowing_parameters env (ind,u) (paramstyp:constr array) =
   let specif =
     try lookup_mind_specif env ind
     with Not_found ->
-      failwith ("Cannot find mutual inductive block: "^MutInd.to_string (fst ind))
+      failwith ("Cannot find mutual inductive block: "^MutInd.debug_to_string (fst ind))
   in
   type_of_inductive_knowing_parameters env (specif,u) paramstyp
 
@@ -172,7 +172,7 @@ let judge_of_constructor env (c,u) =
   let specif =
     try lookup_mind_specif env ind
     with Not_found ->
-      failwith ("Cannot find mutual inductive block: "^MutInd.to_string (fst ind))
+      failwith ("Cannot find mutual inductive block: "^MutInd.debug_to_string (fst ind))
   in
   type_of_constructor (c,u) specif
 

--- a/dev/checker_printers.ml
+++ b/dev/checker_printers.ml
@@ -26,7 +26,7 @@ let ppdir dir = pp (DirPath.print dir)
 let ppmp mp = pp(str (ModPath.debug_to_string mp))
 let ppcon con = pp(Constant.debug_print con)
 let ppproj con = pp(Constant.debug_print (Projection.constant con))
-let ppkn kn = pp(str (KerName.to_string kn))
+let ppkn kn = pp(str (KerName.debug_to_string kn))
 let ppmind kn = pp(MutInd.debug_print kn)
 let ppind (kn,i) = pp(MutInd.debug_print kn ++ str"," ++int i)
 

--- a/dev/doc/changes.md
+++ b/dev/doc/changes.md
@@ -119,6 +119,16 @@ Termops
 - Internal printing functions have been placed under the
   `Termops.Internal` namespace.
 
+Name printers
+
+- Name printers in names.ml have been renamed with a `debug` prefix
+  and the old names are deprecated. These printers were indeed
+  debugging printers and they may produce results which are not
+  meaningful from the point of view of a Coq user (e.g. printing the
+  first name of a block of inductive types rather than the second name
+  of the block). Use printers from `printer.ml` or
+  `Termops.print_constr` instead.
+
 ### Unit testing
 
 The test suite now allows writing unit tests against OCaml code in the Coq

--- a/dev/top_printers.ml
+++ b/dev/top_printers.ml
@@ -44,7 +44,7 @@ let ppdir dir = pp (DirPath.print dir)
 let ppmp mp = pp(str (ModPath.debug_to_string mp))
 let ppcon con = pp(Constant.debug_print con)
 let ppproj con = pp(Constant.debug_print (Projection.constant con))
-let ppkn kn = pp(str (KerName.to_string kn))
+let ppkn kn = pp(str (KerName.debug_to_string kn))
 let ppmind kn = pp(MutInd.debug_print kn)
 let ppind (kn,i) = pp(MutInd.debug_print kn ++ str"," ++int i)
 let ppsp sp = pp(pr_path sp)
@@ -55,9 +55,9 @@ let ppscheme k = pp (Ind_tables.pr_scheme_kind k)
 let prrecarg = function
   | Declarations.Norec -> str "Norec"
   | Declarations.Mrec (mind,i) ->
-     str "Mrec[" ++ MutInd.print mind ++ pr_comma () ++ int i ++ str "]"
+     str "Mrec[" ++ MutInd.debug_print mind ++ pr_comma () ++ int i ++ str "]"
   | Declarations.Imbr (mind,i) ->
-     str "Imbr[" ++ MutInd.print mind ++ pr_comma () ++ int i ++ str "]"
+     str "Imbr[" ++ MutInd.debug_print mind ++ pr_comma () ++ int i ++ str "]"
 let ppwf_paths x = pp (Rtree.pp_tree prrecarg x)
 
 (* term printers *)
@@ -146,7 +146,7 @@ let safe_pr_global = function
 let ppglobal x = try pp(pr_global x) with _ -> safe_pr_global x
 
 let ppconst (sp,j) =
-    pp (str"#" ++ KerName.print sp ++ str"=" ++ envpp pr_lconstr_env j.uj_val)
+    pp (str"#" ++ KerName.debug_print sp ++ str"=" ++ envpp pr_lconstr_env j.uj_val)
 
 let ppvar ((id,a)) =
     pp (str"#" ++ Id.print id ++ str":" ++ envpp pr_lconstr_env a)
@@ -238,7 +238,7 @@ let ppenv e = pp
 let ppenvwithcst e = pp
   (str "[" ++ pr_named_context_of e Evd.empty ++ str "]" ++ spc() ++
    str "[" ++ pr_rel_context e Evd.empty (rel_context e) ++ str "]" ++ spc() ++
-   str "{" ++ Environ.fold_constants (fun a _ s -> Constant.print a ++ spc () ++ s) e (mt ()) ++ str "}")
+   str "{" ++ Environ.fold_constants (fun a _ s -> Constant.debug_print a ++ spc () ++ s) e (mt ()) ++ str "}")
 
 let pptac = (fun x -> pp(Ltac_plugin.Pptactic.pr_glob_tactic (Global.env()) x))
 
@@ -270,13 +270,13 @@ let constr_display csr =
       ^(term_display t)^","^(term_display c)^")"
   | App (c,l) -> "App("^(term_display c)^","^(array_display l)^")\n"
   | Evar (e,l) -> "Evar("^(Pp.string_of_ppcmds (Evar.print e))^","^(array_display l)^")"
-  | Const (c,u) -> "Const("^(Constant.to_string c)^","^(universes_display u)^")"
+  | Const (c,u) -> "Const("^(Constant.debug_to_string c)^","^(universes_display u)^")"
   | Ind ((sp,i),u) ->
-      "MutInd("^(MutInd.to_string sp)^","^(string_of_int i)^","^(universes_display u)^")"
+      "MutInd("^(MutInd.debug_to_string sp)^","^(string_of_int i)^","^(universes_display u)^")"
   | Construct (((sp,i),j),u) ->
-      "MutConstruct(("^(MutInd.to_string sp)^","^(string_of_int i)^"),"
+      "MutConstruct(("^(MutInd.debug_to_string sp)^","^(string_of_int i)^"),"
       ^","^(universes_display u)^(string_of_int j)^")"
-  | Proj (p, c) -> "Proj("^(Constant.to_string (Projection.constant p))^","^term_display c ^")"
+  | Proj (p, c) -> "Proj("^(Constant.debug_to_string (Projection.constant p))^","^term_display c ^")"
   | Case (ci,p,c,bl) ->
       "MutCase(<abs>,"^(term_display p)^","^(term_display c)^","
       ^(array_display bl)^")"

--- a/dev/vm_printers.ml
+++ b/dev/vm_printers.ml
@@ -10,13 +10,13 @@ let ppripos (ri,pos) =
   | Reloc_annot a ->
       let sp,i = a.ci.ci_ind in
       print_string
-        ("annot : MutInd("^(MutInd.to_string sp)^","^(string_of_int i)^")\n")
+        ("annot : MutInd("^(MutInd.debug_to_string sp)^","^(string_of_int i)^")\n")
   | Reloc_const _ ->
       print_string "structured constant\n"
   | Reloc_getglobal kn ->
-    print_string ("getglob "^(Constant.to_string kn)^"\n")
+    print_string ("getglob "^(Constant.debug_to_string kn)^"\n")
   | Reloc_proj_name p ->
-    print_string ("proj "^(Projection.Repr.to_string p)^"\n")
+    print_string ("proj "^(Projection.Repr.debug_to_string p)^"\n")
   );
    print_flush ()
 
@@ -35,7 +35,7 @@ let print_idkey idk =
   match idk with
   | ConstKey sp ->
       print_string "Cons(";
-      print_string (Constant.to_string sp);
+      print_string (Constant.debug_to_string sp);
       print_string ")"
   | VarKey id -> print_string (Id.to_string id)
   | RelKey i -> print_string "~";print_int i
@@ -70,7 +70,7 @@ and ppatom a =
   | Aid idk -> print_idkey idk
   | Asort u -> print_string "Sort(...)"
   | Aind(sp,i) ->  print_string "Ind(";
-      print_string (MutInd.to_string sp);
+      print_string (MutInd.debug_to_string sp);
       print_string ","; print_int i;
       print_string ")"
 

--- a/engine/termops.ml
+++ b/engine/termops.ml
@@ -36,7 +36,7 @@ let pr_sort_family = function
   | InProp -> (str "Prop")
   | InType -> (str "Type")
 
-let pr_con sp = str(Constant.to_string sp)
+let pr_con sp = str(Constant.debug_to_string sp)
 
 let pr_fix pr_constr ((t,i),(lna,tl,bl)) =
   let fixl = Array.mapi (fun i na -> (na,t.(i),tl.(i),bl.(i))) lna in
@@ -81,9 +81,9 @@ let rec pr_constr c = match kind c with
       (str"Evar#" ++ int (Evar.repr e) ++ str"{" ++
        prlist_with_sep spc pr_constr (Array.to_list l) ++str"}")
   | Const (c,u) -> str"Cst(" ++ pr_puniverses (pr_con c) u ++ str")"
-  | Ind ((sp,i),u) -> str"Ind(" ++ pr_puniverses (MutInd.print sp ++ str"," ++ int i) u ++ str")"
+  | Ind ((sp,i),u) -> str"Ind(" ++ pr_puniverses (MutInd.debug_print sp ++ str"," ++ int i) u ++ str")"
   | Construct (((sp,i),j),u) ->
-      str"Constr(" ++ pr_puniverses (MutInd.print sp ++ str"," ++ int i ++ str"," ++ int j) u ++ str")"
+      str"Constr(" ++ pr_puniverses (MutInd.debug_print sp ++ str"," ++ int i ++ str"," ++ int j) u ++ str")"
   | Proj (p,c) -> str"Proj(" ++ pr_con (Projection.constant p) ++ str"," ++ bool (Projection.unfolded p) ++ pr_constr c ++ str")"
   | Case (ci,p,c,bl) -> v 0
       (hv 0 (str"<"++pr_constr p++str">"++ cut() ++ str"Case " ++

--- a/kernel/cbytecodes.ml
+++ b/kernel/cbytecodes.ml
@@ -202,7 +202,7 @@ let rec pp_instr i =
 	     prlist_with_sep spc pp_lbl (Array.to_list lblt) ++
 	     str " bodies = " ++
 	     prlist_with_sep spc pp_lbl (Array.to_list lblb))
-  | Kgetglobal idu -> str "getglobal " ++ Constant.print idu
+  | Kgetglobal idu -> str "getglobal " ++ Constant.debug_print idu
   | Kconst sc ->
       str "const " ++ pp_struct_const sc
   | Kmakeblock(n, m) ->
@@ -224,7 +224,7 @@ let rec pp_instr i =
 
   | Kbranch lbl -> str "branch " ++ pp_lbl lbl
 
-  | Kproj p -> str "proj " ++ Projection.Repr.print p
+  | Kproj p -> str "proj " ++ Projection.Repr.debug_print p
 
   | Kensurestackcapacity size -> str "growstack " ++ int size
 

--- a/kernel/clambda.ml
+++ b/kernel/clambda.ml
@@ -106,7 +106,7 @@ let rec pp_lam lam =
        str")")
   | Lval _ -> str "values"
   | Lsort s -> pp_sort s
-  | Lind ((mind,i), _) -> MutInd.print mind ++ str"#" ++ int i
+  | Lind ((mind,i), _) -> MutInd.debug_print mind ++ str"#" ++ int i
   | Lprim((kn,_u),_ar,_op,args) ->
     hov 1
       (str "(PRIM " ++ pr_con kn ++  spc() ++
@@ -114,7 +114,7 @@ let rec pp_lam lam =
        str")")
   | Lproj(p,arg) ->
     hov 1
-      (str "(proj " ++ Projection.Repr.print p ++ str "(" ++ pp_lam arg
+      (str "(proj " ++ Projection.Repr.debug_print p ++ str "(" ++ pp_lam arg
        ++ str ")")
   | Lint i ->
     Pp.(str "(int:" ++ int i ++ str ")")

--- a/kernel/mod_subst.ml
+++ b/kernel/mod_subst.ml
@@ -85,11 +85,11 @@ let is_empty_subst = Umap.is_empty
 let string_of_hint = function
   | Inline (_,Some _) -> "inline(Some _)"
   | Inline _ -> "inline()"
-  | Equiv kn -> KerName.to_string kn
+  | Equiv kn -> KerName.debug_to_string kn
 
 let debug_string_of_delta resolve =
   let kn_to_string kn hint l =
-    (KerName.to_string kn ^ "=>" ^ string_of_hint hint) :: l
+    (KerName.debug_to_string kn ^ "=>" ^ string_of_hint hint) :: l
   in
   let mp_to_string mp mp' l =
     (ModPath.to_string mp ^ "=>" ^ ModPath.to_string mp') :: l

--- a/kernel/names.ml
+++ b/kernel/names.ml
@@ -385,11 +385,13 @@ module KerName = struct
   let to_string_gen mp_to_string kn =
     mp_to_string kn.modpath ^ "." ^ Label.to_string kn.knlabel
 
-  let to_string kn = to_string_gen ModPath.to_string kn
+  let to_string kn = to_string_gen ModPath.to_string kn (* deprecated *)
+
+  let print kn = str (to_string kn) (* deprecated *)
 
   let debug_to_string kn = to_string_gen ModPath.debug_to_string kn
 
-  let print kn = str (to_string kn)
+  let debug_print kn = str (debug_to_string kn)
 
   let compare (kn1 : kernel_name) (kn2 : kernel_name) =
     if kn1 == kn2 then 0
@@ -498,8 +500,8 @@ module KerPair = struct
       if mp1 == mp2 then same kn
       else make kn (KerName.make mp2 lbl)
 
-  let to_string kp = KerName.to_string (user kp)
-  let print kp = str (to_string kp)
+  let to_string kp = KerName.to_string (user kp) (* deprecated *)
+  let print kp = str (to_string kp) (* deprecated *)
 
   let debug_to_string = function
     | Same kn -> "(" ^ KerName.debug_to_string kn ^ ")"
@@ -852,8 +854,8 @@ struct
 
     let map f p = map_npars (fun mind n -> f mind, n) p
 
-    let to_string p = Constant.to_string (constant p)
-    let print p = Constant.print (constant p)
+    let debug_to_string p = Constant.debug_to_string (constant p)
+    let debug_print p = Constant.debug_print (constant p)
   end
 
   type t = Repr.t * bool
@@ -915,8 +917,11 @@ struct
     let c' = Repr.map_npars f c in
     if c' == c then x else (c', b)
 
-  let to_string p = Constant.to_string (constant p)
-  let print p = Constant.print (constant p)
+  let debug_to_string p = Constant.debug_to_string (constant p)
+  let debug_print p = Constant.debug_print (constant p)
+
+  let to_string = debug_to_string (* deprecated *)
+  let print = debug_print (* deprecated *)
 
 end
 

--- a/kernel/names.mli
+++ b/kernel/names.mli
@@ -286,11 +286,13 @@ sig
 
   (** Display *)
   val to_string : t -> string
-
-  val debug_to_string : t -> string
-  (** Same as [to_string], but outputs information related to debug. *)
+  [@@ocaml.deprecated "Kernel names are for internal use and can be turned into string by using [debug_to_string kn]"]
 
   val print : t -> Pp.t
+  [@@ocaml.deprecated "Kernel names are for internal use and can be printed using [debug_print kn]"]
+
+  val debug_to_string : t -> string
+  val debug_print : t -> Pp.t
 
   (** Comparisons *)
   val compare : t -> t -> int
@@ -365,7 +367,11 @@ sig
   (** Displaying *)
 
   val to_string : t -> string
+  [@@ocaml.deprecated "If for debug, use [debug_to_string cst]; if for printing, use [Printer.pr_constant_env env cst]; at worst, use [Termops.print_constr (EConstr.mkConst cst)]"]
+
   val print : t -> Pp.t
+  [@@ocaml.deprecated "If for debug, use [debug_print cst]; if for printing, use [Printer.pr_constant_env env cst]; at worst, use [Termops.print_constr (EConstr.mkConst ind)]"]
+
   val debug_to_string : t -> string
   val debug_print : t -> Pp.t
 
@@ -444,7 +450,11 @@ sig
   (** Displaying *)
 
   val to_string : t -> string
+  [@@ocaml.deprecated "If for debug, use [debug_to_string kn]; if for printing, get from it an object [ind] of type [inductive] and use [Printer.pr_inductive_env env ind]; at worst, use [Termops.print_constr (EConstr.mkInd ind)]"]
+
   val print : t -> Pp.t
+  [@@ocaml.deprecated "If for debug, use [debug_print kn]; if for printing, get from it an object [ind] of type [inductive] and use [Printer.pr_inductive_env env ind]; at worst, use [Termops.print_constr (EConstr.mkInd ind)]"]
+
   val debug_to_string : t -> string
   val debug_print : t -> Pp.t
 
@@ -575,8 +585,8 @@ module Projection : sig
     val map : (MutInd.t -> MutInd.t) -> t -> t
     val map_npars : (MutInd.t -> int -> MutInd.t * int) -> t -> t
 
-    val print : t -> Pp.t
-    val to_string : t -> string
+    val debug_print : t -> Pp.t
+    val debug_to_string : t -> string
   end
   type t (* = Repr.t * bool *)
 
@@ -614,7 +624,13 @@ module Projection : sig
   val map_npars : (MutInd.t -> int -> MutInd.t * int) -> t -> t
 
   val to_string : t -> string
+  [@@ocaml.deprecated "If for debug, use [debug_to_string kn]; if for printing, use [Printer.pr_constant_env env (Projection.constant kn)] or one of its variant, at worst [Termops.print_constr (EConstr.mkConst (Projection.constant kn))]"]
+
   val print : t -> Pp.t
+  [@@ocaml.deprecated "If for debug, use [debug_print kn]; if for user-readable printing, use [Printer.pr_constr_env (Constr.mkProj (kn,c))] or one of its variant, at worst [Termops.print_constr (EConstr.mkProj (kn,c))]"]
+
+  val debug_to_string : t -> string
+  val debug_print : t -> Pp.t
 
 end
 

--- a/kernel/nativelibrary.ml
+++ b/kernel/nativelibrary.ml
@@ -29,7 +29,7 @@ and translate_field prefix mp env acc (l,x) =
   | SFBconst cb ->
      let con = Constant.make2 mp l in
      (if !Flags.debug then
-        let msg = Printf.sprintf "Compiling constant %s..." (Constant.to_string con) in
+        let msg = Printf.sprintf "Compiling constant %s..." (Constant.debug_to_string con) in
 	Feedback.msg_debug (Pp.str msg));
      compile_constant_field env prefix con acc cb
   | SFBmind mb ->

--- a/kernel/subtyping.ml
+++ b/kernel/subtyping.ml
@@ -125,8 +125,8 @@ let check_inductive cst env mp1 l info1 mp2 mib2 spec2 subst1 subst2 reso1 reso2
         let v = ACumulativityInfo.variance cumi in
         let v' = ACumulativityInfo.variance cumi' in
         if not (Array.for_all2 Variance.check_subtype v' v) then
-          CErrors.anomaly Pp.(str "Variance of " ++ KerName.print kn1 ++
-            str " is not compatible with the one of " ++ KerName.print kn2)
+          CErrors.anomaly Pp.(str "Variance of " ++ KerName.debug_print kn1 ++
+            str " is not compatible with the one of " ++ KerName.debug_print kn2)
       in
       let auctx = Univ.ACumulativityInfo.univ_context cumi in
       let auctx' = Univ.ACumulativityInfo.univ_context cumi' in

--- a/kernel/vmvalues.ml
+++ b/kernel/vmvalues.ml
@@ -138,7 +138,7 @@ let pp_sort s =
 
 let pp_struct_const = function
   | Const_sort s -> pp_sort s
-  | Const_ind (mind, i) -> Pp.(MutInd.print mind ++ str"#" ++ int i)
+  | Const_ind (mind, i) -> Pp.(MutInd.debug_print mind ++ str"#" ++ int i)
   | Const_b0 i -> Pp.int i
   | Const_univ_level l -> Univ.Level.pr l
   | Const_val _ -> Pp.str "(value)"
@@ -646,10 +646,10 @@ let branch_arg k (tag,arity) =
 let rec pr_atom a =
   Pp.(match a with
   | Aid c -> str "Aid(" ++ (match c with
-                            | ConstKey c -> Constant.print c
+                            | ConstKey c -> Constant.debug_print c
                             | RelKey i -> str "#" ++ int i
                             | _ -> str "...") ++ str ")"
-  | Aind (mi,i) -> str "Aind(" ++ MutInd.print mi ++ str "#" ++ int i ++ str ")"
+  | Aind (mi,i) -> str "Aind(" ++ MutInd.debug_print mi ++ str "#" ++ int i ++ str ")"
   | Asort _ -> str "Asort(")
 and pr_whd w =
   Pp.(match w with
@@ -668,6 +668,6 @@ and pr_stack stk =
 and pr_zipper z =
   Pp.(match z with
   | Zapp args -> str "Zapp(len = " ++ int (nargs args) ++ str ")"
-  | Zfix (_f,args) -> str "Zfix(..., len=" ++ int (nargs args) ++ str ")"
-  | Zswitch _s -> str "Zswitch(...)"
-  | Zproj c -> str "Zproj(" ++ Projection.Repr.print c ++ str ")")
+  | Zfix (f,args) -> str "Zfix(..., len=" ++ int (nargs args) ++ str ")"
+  | Zswitch s -> str "Zswitch(...)"
+  | Zproj c -> str "Zproj(" ++ Projection.Repr.debug_print c ++ str ")")

--- a/plugins/ltac/pptactic.ml
+++ b/plugins/ltac/pptactic.ml
@@ -274,7 +274,7 @@ let string_of_genarg_arg (ArgumentType arg) =
     with Not_found ->
       (* FIXME: This key, moreover printed with a low-level printer,
          has no meaning user-side *)
-      KerName.print key
+      KerName.debug_print key
 
   let pr_alias_gen pr_gen lev key l =
     try
@@ -292,7 +292,7 @@ let string_of_genarg_arg (ArgumentType arg) =
       if pp.pptac_level > lev then surround p else p
     with Not_found ->
       let pr _ = str "_" in
-      KerName.print key ++ spc() ++ pr_sequence pr l ++ str" (* Generic printer *)"
+      KerName.debug_print key ++ spc() ++ pr_sequence pr l ++ str" (* Generic printer *)"
 
   let pr_farg prtac arg = prtac (1, Any) (TacArg (Loc.tag arg))
 
@@ -375,11 +375,11 @@ let string_of_genarg_arg (ArgumentType arg) =
     | ArgVar {CAst.loc;v=id} -> pr_with_comments ?loc (pr_id id)
 
   let pr_ltac_constant kn =
-    if !Flags.in_debugger then KerName.print kn
+    if !Flags.in_debugger then KerName.debug_print kn
     else try
            pr_qualid (Tacenv.shortest_qualid_of_tactic kn)
       with Not_found -> (* local tactic not accessible anymore *)
-        str "<" ++ KerName.print kn ++ str ">"
+        str "<" ++ KerName.debug_print kn ++ str ">"
 
   let pr_evaluable_reference_env env = function
     | EvalVarRef id -> pr_id id

--- a/plugins/ltac/tacenv.ml
+++ b/plugins/ltac/tacenv.ml
@@ -66,7 +66,7 @@ let register_alias key tac =
 
 let interp_alias key =
   try KNmap.find key !alias_map
-  with Not_found -> CErrors.anomaly (str "Unknown tactic alias: " ++ KerName.print key ++ str ".")
+  with Not_found -> CErrors.anomaly (str "Unknown tactic alias: " ++ KerName.debug_print key ++ str ".")
 
 let check_alias key = KNmap.mem key !alias_map
 

--- a/pretyping/cbv.ml
+++ b/pretyping/cbv.ml
@@ -188,7 +188,7 @@ let _ = Goptions.declare_bool_option {
 }
 
 let debug_pr_key = function
-  | ConstKey (sp,_) -> Names.Constant.print sp
+  | ConstKey (sp,_) -> Names.Constant.debug_print sp
   | VarKey id -> Names.Id.print id
   | RelKey n -> Pp.(str "REL_" ++ int n)
 

--- a/pretyping/heads.ml
+++ b/pretyping/heads.ml
@@ -73,7 +73,7 @@ let kind_of_head env t =
        with Not_found ->
          CErrors.anomaly
            Pp.(str "constant not found in kind_of_head: " ++
-               Names.Constant.print cst ++
+               Names.Constant.debug_print cst ++
                str "."))
   | Construct _ | CoFix _ ->
       if b then NotImmediatelyComputableHead else ConstructorHead

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -896,7 +896,7 @@ let pr_assumptionset env sigma s =
       try pr_inductive env (kn,0)
       with Not_found ->
         (* FIXME? *)
-        MutInd.print kn
+        MutInd.debug_print kn
     in
     let safe_pr_ltype env sigma typ =
       try str " : " ++ pr_ltype_env env sigma typ

--- a/vernac/assumptions.ml
+++ b/vernac/assumptions.ml
@@ -132,7 +132,7 @@ let lookup_constant_in_impl cst fallback =
        - The label has not been found in the structure. This is an error *)
     match fallback with
       | Some cb -> cb
-      | None -> anomaly (str "Print Assumption: unknown constant " ++ Constant.print cst ++ str ".")
+      | None -> anomaly (str "Print Assumption: unknown constant " ++ Constant.debug_print cst ++ str ".")
 
 let lookup_constant cst =
   try
@@ -147,7 +147,7 @@ let lookup_mind_in_impl mind =
     let fields = memoize_fields_of_mp mp in
       search_mind_label lab fields
   with Not_found ->
-    anomaly (str "Print Assumption: unknown inductive " ++ MutInd.print mind ++ str ".")
+    anomaly (str "Print Assumption: unknown inductive " ++ MutInd.debug_print mind ++ str ".")
 
 let lookup_mind mind =
   try Global.lookup_mind mind


### PR DESCRIPTION
**Kind:** cleanup

The `print` and `to_string` functions in `Names` were printing full names (not taking into account visibility). They were also printing `#` for sections, which is not part of the user-level syntax of names.

We requalify them as "debug" printers. In passing, this allows to catch quite a number of misuses of these functions in code supposed to be read by the user (Added: submitted separately in #8534 on which this PR now depends).

Use of these printers in reporting anomalies are expected and were kept.

~~Still not perfect (see a few FIXME).~~

This is a step in helping external contributors and plugin developer not to use the wrong printing functions. We shall still have to tell where are the good functions (namely in `Printer`, or for code below `Printer`, for lack of anything better, using `Termops.print_constr`).

The design choices can be discussed. This is just a proposal.

- [ ] Entry to add in `dev/doc/changes.md`
