### PR TITLE
Do not allow spliting in res_pf, this is reserved for pretyping

### DIFF
--- a/proofs/clenvtac.ml
+++ b/proofs/clenvtac.ml
@@ -87,7 +87,7 @@ let clenv_refine ?(with_evars=false) ?(with_classes=true) clenv =
       let evd' =
         if has_typeclass then
           Typeclasses.resolve_typeclasses ~fast_path:false ~filter:Typeclasses.all_evars
-          ~fail:(not with_evars) clenv.env clenv.evd
+          ~fail:(not with_evars) ~split:false clenv.env clenv.evd
         else clenv.evd
       in
       if has_resolvable then

--- a/test-suite/success/Hints.v
+++ b/test-suite/success/Hints.v
@@ -169,7 +169,7 @@ Proof.
 Hint Cut [_* (a_is_b | b_is_c | c_is_d | d_is_e)
                  (a_compose | b_compose | c_compose | d_compose | e_compose)] : typeclass_instances.
 
-  Timeout 1 Fail apply _. (* 0.06s *)
+Timeout 1 Fail apply _. (* 0.06s *)
 Abort.
 End HintCut.
 


### PR DESCRIPTION
<!-- Keep what applies -->
**Kind:** bug fix

Splitting is only useful for better user messages in pretyping where one component of typeclass resolution was resolved while another wasn't. It's unnecessary in res_pf where all resolvable evars should be solved anyway.