### PR TITLE
Ho matching occ sel

### DIFF
--- a/dev/ci/user-overlays/07819-mattam-ho-matching-occ-sel.sh
+++ b/dev/ci/user-overlays/07819-mattam-ho-matching-occ-sel.sh
@@ -7,4 +7,6 @@ if [ "$CI_PULL_REQUEST" = "7819" ] || [ "$CI_BRANCH" = "$_OVERLAY_BRANCH" ]; the
     mtac2_CI_REF="PR7819-overlay"
     mtac2_CI_GITURL=https://github.com/mattam82/Mtac2
 
+    Equations_CI_REF="PR7819-overlay"
+
 fi

--- a/dev/ci/user-overlays/07819-mattam-ho-matching-occ-sel.sh
+++ b/dev/ci/user-overlays/07819-mattam-ho-matching-occ-sel.sh
@@ -7,6 +7,7 @@ if [ "$CI_PULL_REQUEST" = "7819" ] || [ "$CI_BRANCH" = "$_OVERLAY_BRANCH" ]; the
     mtac2_CI_REF="PR7819-overlay"
     mtac2_CI_GITURL=https://github.com/mattam82/Mtac2
 
-    Equations_CI_REF="PR7819-overlay"
+    equations_CI_GITURL=https://github.com/mattam82/Coq-Equations
+    equations_CI_REF="PR7819-overlay"
 
 fi

--- a/dev/ci/user-overlays/07819-mattam-ho-matching-occ-sel.sh
+++ b/dev/ci/user-overlays/07819-mattam-ho-matching-occ-sel.sh
@@ -1,0 +1,10 @@
+_OVERLAY_BRANCH=ho-matching-occ-sel
+
+if [ "$CI_PULL_REQUEST" = "7819" ] || [ "$CI_BRANCH" = "$_OVERLAY_BRANCH" ]; then
+
+    unicoq_CI_REF="PR7819-overlay"
+
+    mtac2_CI_REF="PR7819-overlay"
+    mtac2_CI_GITURL=https://github.com/mattam82/Mtac2
+
+fi

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -424,8 +424,8 @@ let new_pure_evar_full evd ?typeclass_candidate evi =
   let evd = Evd.declare_future_goal evk evd in
   (evd, evk)
 
-let new_pure_evar?(src=default_source) ?(filter = Filter.identity) ?candidates ?naming ?typeclass_candidate
-    ?(principal=false) sign evd typ =
+let new_pure_evar?(src=default_source) ?(filter = Filter.identity) ?(abstract_arguments = Abstraction.identity)
+    ?candidates ?naming ?typeclass_candidate ?(principal=false) sign evd typ =
   let default_naming = IntroAnonymous in
   let naming = Option.default default_naming naming in
   let name = match naming with
@@ -441,6 +441,7 @@ let new_pure_evar?(src=default_source) ?(filter = Filter.identity) ?candidates ?
     evar_concl = typ;
     evar_body = Evar_empty;
     evar_filter = filter;
+    evar_abstract_arguments = abstract_arguments;
     evar_source = src;
     evar_candidates = candidates }
   in
@@ -452,11 +453,12 @@ let new_pure_evar?(src=default_source) ?(filter = Filter.identity) ?candidates ?
   in
   (evd, newevk)
 
-let new_evar_instance ?src ?filter ?candidates ?naming ?typeclass_candidate ?principal sign evd typ instance =
+let new_evar_instance ?src ?filter ?abstract_arguments ?candidates ?naming ?typeclass_candidate
+    ?principal sign evd typ instance =
   let open EConstr in
   assert (not !Flags.debug ||
             List.distinct (ids_of_named_context (named_context_of_val sign)));
-  let (evd, newevk) = new_pure_evar sign evd ?src ?filter ?candidates ?naming ?typeclass_candidate ?principal typ in
+  let (evd, newevk) = new_pure_evar sign evd ?src ?filter ?abstract_arguments ?candidates ?naming ?typeclass_candidate ?principal typ in
   evd, mkEvar (newevk,Array.of_list instance)
 
 let new_evar_from_context ?src ?filter ?candidates ?naming ?typeclass_candidate ?principal sign evd typ =
@@ -469,7 +471,8 @@ let new_evar_from_context ?src ?filter ?candidates ?naming ?typeclass_candidate 
 
 (* [new_evar] declares a new existential in an env env with type typ *)
 (* Converting the env into the sign of the evar to define *)
-let new_evar ?src ?filter ?candidates ?naming ?typeclass_candidate ?principal ?hypnaming env evd typ =
+let new_evar ?src ?filter ?abstract_arguments ?candidates ?naming ?typeclass_candidate
+    ?principal ?hypnaming env evd typ =
   let sign,typ',instance,subst = push_rel_context_to_named_context ?hypnaming env evd typ in
   let map c = csubst_subst subst c in
   let candidates = Option.map (fun l -> List.map map l) candidates in
@@ -477,7 +480,8 @@ let new_evar ?src ?filter ?candidates ?naming ?typeclass_candidate ?principal ?h
     match filter with
     | None -> instance
     | Some filter -> Filter.filter_list filter instance in
-  new_evar_instance sign evd typ' ?src ?filter ?candidates ?naming ?typeclass_candidate ?principal instance
+  new_evar_instance sign evd typ' ?src ?filter ?abstract_arguments ?candidates ?naming
+    ?typeclass_candidate ?principal instance
 
 let new_type_evar ?src ?filter ?naming ?principal ?hypnaming env evd rigid =
   let (evd', s) = new_sort_variable rigid evd in

--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -42,7 +42,7 @@ type naming_mode =
 
 val new_evar :
   ?src:Evar_kinds.t Loc.located -> ?filter:Filter.t ->
-  ?candidates:constr list ->
+  ?abstract_arguments:Abstraction.t -> ?candidates:constr list ->
   ?naming:intro_pattern_naming_expr ->
   ?typeclass_candidate:bool ->
   ?principal:bool -> ?hypnaming:naming_mode ->
@@ -50,7 +50,7 @@ val new_evar :
 
 val new_pure_evar :
   ?src:Evar_kinds.t Loc.located -> ?filter:Filter.t ->
-  ?candidates:constr list ->
+  ?abstract_arguments:Abstraction.t -> ?candidates:constr list ->
   ?naming:intro_pattern_naming_expr ->
   ?typeclass_candidate:bool ->
   ?principal:bool ->
@@ -80,7 +80,8 @@ val new_global : evar_map -> GlobRef.t -> evar_map * constr
    of [inst] are typed in the occurrence context and their type (seen
    as a telescope) is [sign] *)
 val new_evar_instance :
-  ?src:Evar_kinds.t Loc.located -> ?filter:Filter.t -> ?candidates:constr list ->
+  ?src:Evar_kinds.t Loc.located -> ?filter:Filter.t ->
+  ?abstract_arguments:Abstraction.t -> ?candidates:constr list ->
   ?naming:intro_pattern_naming_expr ->
   ?typeclass_candidate:bool ->
   ?principal:bool ->

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -126,6 +126,15 @@ struct
 
 end
 
+module Abstraction = struct
+
+  type t = bool list
+
+  let identity = []
+
+  let abstract_last l = true :: l
+end
+
 (* The kinds of existential variables are now defined in [Evar_kinds] *)
 
 (* The type of mappings for existential variables *)
@@ -143,6 +152,7 @@ type evar_info = {
   evar_hyps : named_context_val;
   evar_body : evar_body;
   evar_filter : Filter.t;
+  evar_abstract_arguments : Abstraction.t;
   evar_source : Evar_kinds.t Loc.located;
   evar_candidates : constr list option; (* if not None, list of allowed instances *)}
 
@@ -151,6 +161,7 @@ let make_evar hyps ccl = {
   evar_hyps = hyps;
   evar_body = Evar_empty;
   evar_filter = Filter.identity;
+  evar_abstract_arguments = Abstraction.identity;
   evar_source = Loc.tag @@ Evar_kinds.InternalHole;
   evar_candidates = None; }
 

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -128,11 +128,15 @@ end
 
 module Abstraction = struct
 
-  type t = bool list
+  type abstraction =
+    | Abstract
+    | Imitate
+
+  type t = abstraction list
 
   let identity = []
 
-  let abstract_last l = true :: l
+  let abstract_last l = Abstract :: l
 end
 
 (* The kinds of existential variables are now defined in [Evar_kinds] *)

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -77,6 +77,14 @@ sig
 
 end
 
+module Abstraction : sig
+  type t = bool list
+
+  val identity : t
+
+  val abstract_last : t -> t
+end
+
 (** {6 Evar infos} *)
 
 type evar_body =
@@ -94,6 +102,10 @@ type evar_info = {
   (** Boolean mask over {!evar_hyps}. Should have the same length.
       When filtered out, the corresponding variable is not allowed to occur
       in the solution *)
+  evar_abstract_arguments : Abstraction.t;
+  (** Boolean information over {!evar_hyps}, telling if an hypothesis instance
+      can be immitated or should stay abstract in HO unification problems
+      and inversion (see [second_order_matching_with_args] for its use). *)
   evar_source : Evar_kinds.t located;
   (** Information about the evar. *)
   evar_candidates : econstr list option;

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -104,7 +104,7 @@ type evar_info = {
       in the solution *)
   evar_abstract_arguments : Abstraction.t;
   (** Boolean information over {!evar_hyps}, telling if an hypothesis instance
-      can be immitated or should stay abstract in HO unification problems
+      can be imitated or should stay abstract in HO unification problems
       and inversion (see [second_order_matching_with_args] for its use). *)
   evar_source : Evar_kinds.t located;
   (** Information about the evar. *)

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -78,7 +78,11 @@ sig
 end
 
 module Abstraction : sig
-  type t = bool list
+  type abstraction =
+    | Abstract
+    | Imitate
+
+  type t = abstraction list
 
   val identity : t
 

--- a/plugins/funind/functional_principles_proofs.ml
+++ b/plugins/funind/functional_principles_proofs.ml
@@ -238,7 +238,9 @@ let change_eq env sigma hyp_id (context:rel_context) x t end_of_type  =
       raise NoChange;
     end
   in
-  let eq_constr c1 c2 = Option.has_some (Evarconv.conv env sigma c1 c2) in
+  let eq_constr c1 c2 =
+    try ignore(Evarconv.unify_delay env sigma c1 c2); true
+    with Evarconv.UnableToUnify _ -> false in
   if not (noccurn sigma 1 end_of_type)
   then nochange "dependent"; (* if end_of_type depends on this term we don't touch it  *)
     if not (isApp sigma t) then nochange "not an equality";

--- a/plugins/ltac/rewrite.ml
+++ b/plugins/ltac/rewrite.ml
@@ -449,7 +449,7 @@ let evd_convertible env evd x y =
        unsolvable constraints remain, so we check that this unification
        does not introduce any new problem. *)
     let _, pbs = Evd.extract_all_conv_pbs evd in
-    let evd' = Evarconv.the_conv_x env x y evd in
+    let evd' = Evarconv.unify_delay env evd x y in
     let _, pbs' = Evd.extract_all_conv_pbs evd' in
     if evd' == evd || problem_inclusion pbs' pbs then Some evd'
     else None

--- a/plugins/ltac/tacintern.ml
+++ b/plugins/ltac/tacintern.ml
@@ -557,7 +557,7 @@ let rec intern_atomic lf ist x =
       | _ -> false
       in
       let is_onconcl = match cl.concl_occs with
-      | AllOccurrences | NoOccurrences -> true
+      | AtLeastOneOccurrence | AllOccurrences | NoOccurrences -> true
       | _ -> false
       in
       TacChange (None,

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -1746,7 +1746,7 @@ and interp_atomic ist tac : unit Proofview.tactic =
           | _ -> false
         in
         let is_onconcl = match cl.concl_occs with
-          | AllOccurrences | NoOccurrences -> true
+          | AtLeastOneOccurrence | AllOccurrences | NoOccurrences -> true
           | _ -> false
         in
         let c_interp patvars env sigma =

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -213,7 +213,7 @@ let unif_EQ_args env sigma pa a =
   loop 0
 
 let unif_HO env ise p c =
-  try Evarconv.the_conv_x env p c ise
+  try Evarconv.unify_delay env ise p c
   with Evarconv.UnableToUnify(ise, err) ->
     raise Pretype_errors.(PretypeError(env,ise,CannotUnify(p,c,Some err)))
 

--- a/pretyping/cases.ml
+++ b/pretyping/cases.ml
@@ -1709,8 +1709,7 @@ let abstract_tycon ?loc env sigma subst tycon extenv t =
         let sigma, ev' = Evarutil.new_evar ~src ~typeclass_candidate:false !!env sigma ty in
         begin
           let flags = (default_flags_of TransparentState.full) in
-          let conv = conv_fun evar_conv_x flags in
-          match solve_simple_eqn conv !!env sigma (None,ev,substl inst ev') with
+          match solve_simple_eqn evar_unify flags !!env sigma (None,ev,substl inst ev') with
           | Success evd -> evdref := evd
           | UnifFailure _ -> assert false
         end;

--- a/pretyping/coercion.ml
+++ b/pretyping/coercion.ml
@@ -466,7 +466,7 @@ let inh_coerce_to_prod ?loc ~program_mode env evd t =
       !evdref, typ'
   else (evd, t)
 
-let inh_coerce_to_fail env evd rigidonly v t c1 =
+let inh_coerce_to_fail flags env evd rigidonly v t c1 =
   if rigidonly && not (Heads.is_rigid env (EConstr.Unsafe.to_constr c1) && Heads.is_rigid env (EConstr.Unsafe.to_constr t))
   then
     raise NoCoercion
@@ -483,13 +483,16 @@ let inh_coerce_to_fail env evd rigidonly v t c1 =
 	  | None -> evd, None, t
       with Not_found -> raise NoCoercion
     in
-      try (the_conv_x_leq env t' c1 evd, v')
+      try (unify_leq flags env evd t' c1, v')
       with UnableToUnify _ -> raise NoCoercion
 
-let rec inh_conv_coerce_to_fail ?loc env evd rigidonly v t c1 =
-  try (the_conv_x_leq env t c1 evd, v)
+let default_flags_of env =
+  default_flags_of TransparentState.full
+
+let rec inh_conv_coerce_to_fail ?loc env evd ?(flags=default_flags_of env) rigidonly v t c1 =
+  try (unify_leq flags env evd t c1, v)
   with UnableToUnify (best_failed_evd,e) ->
-    try inh_coerce_to_fail env evd rigidonly v t c1
+    try inh_coerce_to_fail flags env evd rigidonly v t c1
     with NoCoercion ->
       match
       EConstr.kind evd (whd_all env evd t),
@@ -520,10 +523,10 @@ let rec inh_conv_coerce_to_fail ?loc env evd rigidonly v t c1 =
       | _ -> raise (NoCoercionNoUnifier (best_failed_evd,e))
 
 (* Look for cj' obtained from cj by inserting coercions, s.t. cj'.typ = t *)
-let inh_conv_coerce_to_gen ?loc ~program_mode resolve_tc rigidonly env evd cj t =
+let inh_conv_coerce_to_gen ?loc ~program_mode resolve_tc rigidonly flags env evd cj t =
   let (evd', val') =
     try
-      inh_conv_coerce_to_fail ?loc env evd rigidonly (Some cj.uj_val) cj.uj_type t
+      inh_conv_coerce_to_fail ?loc env evd ~flags rigidonly (Some cj.uj_val) cj.uj_type t
     with NoCoercionNoUnifier (best_failed_evd,e) ->
       try
         if program_mode then
@@ -545,15 +548,14 @@ let inh_conv_coerce_to_gen ?loc ~program_mode resolve_tc rigidonly env evd cj t 
   let val' = match val' with Some v -> v | None -> assert(false) in
     (evd',{ uj_val = val'; uj_type = t })
 
-let inh_conv_coerce_to ?loc ~program_mode resolve_tc =
-  inh_conv_coerce_to_gen ?loc ~program_mode resolve_tc false
+let inh_conv_coerce_to ?loc ~program_mode resolve_tc env evd ?(flags=default_flags_of env) =
+  inh_conv_coerce_to_gen ?loc ~program_mode resolve_tc false flags env evd
+let inh_conv_coerce_rigid_to ?loc ~program_mode resolve_tc env evd ?(flags=default_flags_of env) =
+  inh_conv_coerce_to_gen ?loc ~program_mode resolve_tc true flags env evd
 
-let inh_conv_coerce_rigid_to ?loc ~program_mode resolve_tc =
-  inh_conv_coerce_to_gen ~program_mode resolve_tc ?loc true
-
-let inh_conv_coerces_to ?loc env evd t t' =
+let inh_conv_coerces_to ?loc env evd ?(flags=default_flags_of env) t t' =
   try
-    fst (inh_conv_coerce_to_fail ?loc env evd true None t t')
+    fst (inh_conv_coerce_to_fail ?loc env evd ~flags true None t t')
   with NoCoercion ->
     evd (* Maybe not enough information to unify *)
       

--- a/pretyping/coercion.mli
+++ b/pretyping/coercion.mli
@@ -45,11 +45,14 @@ val inh_coerce_to_prod : ?loc:Loc.t -> program_mode:bool ->
     a way [t] and [j.uj_type] are convertible; it fails if no coercion is
     applicable. resolve_tc=false disables resolving type classes (as the last
     resort before failing) *)
+
 val inh_conv_coerce_to : ?loc:Loc.t -> program_mode:bool -> bool ->
-  env -> evar_map -> unsafe_judgment -> types -> evar_map * unsafe_judgment
+  env -> evar_map -> ?flags:Evarconv.unify_flags ->
+  unsafe_judgment -> types -> evar_map * unsafe_judgment
 
 val inh_conv_coerce_rigid_to : ?loc:Loc.t -> program_mode:bool ->bool ->
-  env -> evar_map -> unsafe_judgment -> types -> evar_map * unsafe_judgment
+  env -> evar_map -> ?flags:Evarconv.unify_flags ->
+  unsafe_judgment -> types -> evar_map * unsafe_judgment
 
 (** [inh_conv_coerces_to loc env isevars t t'] checks if an object of type [t]
     is coercible to an object of type [t'] adding evar constraints if needed;

--- a/pretyping/coercion.mli
+++ b/pretyping/coercion.mli
@@ -58,7 +58,8 @@ val inh_conv_coerce_rigid_to : ?loc:Loc.t -> program_mode:bool ->bool ->
     is coercible to an object of type [t'] adding evar constraints if needed;
     it fails if no coercion exists *)
 val inh_conv_coerces_to : ?loc:Loc.t ->
-  env -> evar_map -> types -> types -> evar_map
+  env -> evar_map -> ?flags:Evarconv.unify_flags ->
+  types -> types -> evar_map
 
 (** [inh_pattern_coerce_to loc env isevars pat ind1 ind2] coerces the Cases
     pattern [pat] typed in [ind1] into a pattern typed in [ind2];

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -788,7 +788,15 @@ and evar_eqappr_x ?(rhs_is_already_stuck = false) flags env evd pbty
           else UnifFailure (i,NotSameHead)
         and f3 i = miller true (sp1,al1) appr1 appr2 i
         and f4 i = miller false (sp2,al2) appr2 appr1 i
-        and f5 i = consume true appr1 appr2 i in
+        and f5 i =
+          (** We ensure failure of consuming the stacks does not
+             propagate an error about unification of the stacks while
+             the heads themselves cannot be unified, so we return
+             NotSameHead. *)
+          match consume true appr1 appr2 i with
+          | Success _ as x -> x
+          | UnifFailure _ -> quick_fail i
+        in
         ise_try evd [f1; f2; f3; f4; f5]
 
     | Flexible ev1, MaybeFlexible v2 ->

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -1201,7 +1201,7 @@ let default_occurrences_selection ?(frozen_evars=Evar.Set.empty) ts n =
 
 let apply_on_subterm env evdref fixedref f test c t =
   let test = test env !evdref c in
-  let prc env = print_constr_env env !evdref in
+  let prc env = Termops.Internal.print_constr_env env !evdref in
   let rec applyrec (env,(k,c) as acc) t =
     if Evar.Set.exists (fun fixed -> occur_evar !evdref fixed t) !fixedref then
       match EConstr.kind !evdref t with
@@ -1323,8 +1323,8 @@ let second_order_matching flags env_rhs evd (evk,args) (test,argoccs) rhs =
   let sign = named_context_val env_evar in
   let ctxt = evar_filtered_context evi in
   if !debug_ho_unification then
-    (Feedback.msg_debug Pp.(str"env rhs: " ++ print_env env_rhs);
-     Feedback.msg_debug Pp.(str"env evars: " ++ print_env env_evar));
+    (Feedback.msg_debug Pp.(str"env rhs: " ++ Termops.Internal.print_env env_rhs);
+     Feedback.msg_debug Pp.(str"env evars: " ++ Termops.Internal.print_env env_evar));
   let args = Array.map (nf_evar evd) args in
   let vars = List.map NamedDecl.get_id ctxt in
   let argsubst = List.map2 (fun id c -> (id, c)) vars (Array.to_list args) in
@@ -1335,7 +1335,7 @@ let second_order_matching flags env_rhs evd (evk,args) (test,argoccs) rhs =
       the solution we are trying to build here by adding the problem as a constraint. *)
   let evd = Evarutil.add_unification_pb (CONV,env_rhs,mkEvar (evk,args),rhs) evd in
   let evdref = ref evd in
-  let prc env c = print_constr_env env !evdref c in
+  let prc env c = Termops.Internal.print_constr_env env !evdref c in
   let rec make_subst = function
   | decl'::ctxt', c::l, occs::occsl when isVarId evd (NamedDecl.get_id decl') c ->
       begin match occs with

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -1765,3 +1765,15 @@ let the_conv_x_leq env ?(ts=default_transparent_state env) t1 t2 evd =
   match evar_conv_x flags env evd CUMUL t1 t2 with
   | Success evd' -> evd'
   | UnifFailure (evd',e) -> raise (UnableToUnify (evd',e))
+
+let make_opt = function
+  | Success evd -> Some evd
+  | UnifFailure _ -> None
+
+let conv env ?(ts=default_transparent_state env) evd t1 t2 =
+  let flags = default_flags_of ts in
+  make_opt(evar_conv_x flags env evd CONV t1 t2)
+
+let cumul env ?(ts=default_transparent_state env) evd t1 t2 =
+  let flags = default_flags_of ts in
+  make_opt(evar_conv_x flags env evd CUMUL t1 t2)

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -1148,7 +1148,7 @@ let second_order_matching ts env_rhs evd (evk,args) argoccs rhs =
   | (id,_,c,cty,evsref,filter,occs)::subst ->
       let set_var k =
         match occs with
-        | Some Locus.AllOccurrences -> mkVar id
+        | Some (Locus.AtLeastOneOccurrence | Locus.AllOccurrences) -> mkVar id
         | Some _ -> user_err Pp.(str "Selection of specific occurrences not supported")
         | None ->
         let evty = set_holes evdref cty subst in

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -768,7 +768,7 @@ and evar_eqappr_x ?(rhs_is_already_stuck = false) flags env evd pbty
              Feedback.msg_notice (v 0 (pr_state env evd appr1 ++ cut () ++ pr_state env evd appr2 ++ cut ())) in
   match (flex_kind_of_term flags env evd term1 sk1,
          flex_kind_of_term flags env evd term2 sk2) with
-    | Flexible (sp1,al1 as ev1), Flexible (sp2,al2 as ev2) ->
+    | Flexible (sp1,al1), Flexible (sp2,al2) ->
         (* sk1[?ev1] =? sk2[?ev2] *)
         let f1 i = first_order env i term1 term2 sk1 sk2
 	and f2 i =

--- a/pretyping/evarconv.mli
+++ b/pretyping/evarconv.mli
@@ -24,7 +24,7 @@ val default_flags_of : ?subterm_ts:transparent_state -> transparent_state -> uni
 type unify_fun = unify_flags ->
   env -> evar_map -> conv_pb -> constr -> constr -> Evarsolve.unification_result
 
-val conv_fun : unify_fun -> unify_flags -> Evarsolve.conv_fun
+val conv_fun : unify_fun -> unify_flags -> Evarsolve.unifier
 
 exception UnableToUnify of evar_map * Pretype_errors.unification_error
 

--- a/pretyping/evarconv.mli
+++ b/pretyping/evarconv.mli
@@ -35,6 +35,9 @@ exception UnableToUnify of evar_map * Pretype_errors.unification_error
     heuristics ([unify]). *)
 
 (** Theses functions allow to pass arbitrary flags to the unifier and can delay constraints.
+    In case the flags are not specified, they default to
+    [default_flags_of full_transparent_state] currently.
+
     In case of success, the two terms are hence unifiable only if the remaining constraints
     can be solved or [check_problems_are_solved] is true.
 
@@ -47,6 +50,12 @@ val unify_leq_delay : ?flags:unify_flags -> env -> evar_map -> constr -> constr 
 val the_conv_x     : env -> ?ts:TransparentState.t -> constr -> constr -> evar_map -> evar_map
 [@@ocaml.deprecated "Use Evarconv.unify_delay instead"]
 val the_conv_x_leq : env -> ?ts:TransparentState.t -> constr -> constr -> evar_map -> evar_map
+[@@ocaml.deprecated "Use Evarconv.unify_leq_delay instead"]
+(** The same function resolving evars by side-effect and
+   catching the exception *)
+val conv : env -> ?ts:transparent_state -> evar_map -> constr -> constr -> evar_map option
+[@@ocaml.deprecated "Use Evarconv.unify_delay instead"]
+val cumul : env -> ?ts:transparent_state -> evar_map -> constr -> constr -> evar_map option
 [@@ocaml.deprecated "Use Evarconv.unify_leq_delay instead"]
 
 (** This function also calls [solve_unif_constraints_with_heuristics] to resolve any remaining

--- a/pretyping/evarconv.mli
+++ b/pretyping/evarconv.mli
@@ -24,7 +24,7 @@ val default_flags_of : ?subterm_ts:transparent_state -> transparent_state -> uni
 type unify_fun = unify_flags ->
   env -> evar_map -> conv_pb -> constr -> constr -> Evarsolve.unification_result
 
-val conv_fun : unify_fun -> unify_flags -> Evarsolve.unifier
+val conv_fun : unify_fun -> Evarsolve.unifier
 
 exception UnableToUnify of evar_map * Pretype_errors.unification_error
 
@@ -111,6 +111,8 @@ val set_evar_conv : unify_fun -> unit
 
 (** The default unification algorithm with evars and universes. *)
 val evar_conv_x : unify_fun
+
+val evar_unify : Evarsolve.unifier
 
 (**/**)
 (* For debugging *)

--- a/pretyping/evarconv.mli
+++ b/pretyping/evarconv.mli
@@ -120,6 +120,9 @@ val evar_eqappr_x : ?rhs_is_already_stuck:bool -> unify_flags ->
   env -> evar_map ->
     conv_pb -> state * Cst_stack.t -> state * Cst_stack.t ->
       Evarsolve.unification_result
+
+val occur_rigidly : Evarsolve.unify_flags ->
+  'a -> Evd.evar_map -> Evar.t * 'b -> EConstr.t -> bool
 (**/**)
 
 (** {6 Functions to deal with impossible cases } *)

--- a/pretyping/evarconv.mli
+++ b/pretyping/evarconv.mli
@@ -80,11 +80,10 @@ type occurrence_match_test =
 
 (** When given the choice of abstracting an occurrence or leaving it,
     force abstration. *)
-type prefer_abstraction = bool
 
 type occurrence_selection =
   | AtOccurrences of occurrences
-  | Unspecified of prefer_abstraction
+  | Unspecified of Abstraction.abstraction
 
 (** By default, unspecified, not preferring abstraction.
     This provides the most general solutions. *)

--- a/pretyping/evarconv.mli
+++ b/pretyping/evarconv.mli
@@ -19,7 +19,7 @@ open Locus
 type unify_flags = Evarsolve.unify_flags
 
 (** The default subterm transparent state is no unfoldings *)
-val default_flags_of : ?subterm_ts:transparent_state -> transparent_state -> unify_flags
+val default_flags_of : ?subterm_ts:TransparentState.t -> TransparentState.t -> unify_flags
 
 type unify_fun = unify_flags ->
   env -> evar_map -> conv_pb -> constr -> constr -> Evarsolve.unification_result
@@ -36,7 +36,7 @@ exception UnableToUnify of evar_map * Pretype_errors.unification_error
 
 (** Theses functions allow to pass arbitrary flags to the unifier and can delay constraints.
     In case the flags are not specified, they default to
-    [default_flags_of full_transparent_state] currently.
+    [default_flags_of TransparentState.full] currently.
 
     In case of success, the two terms are hence unifiable only if the remaining constraints
     can be solved or [check_problems_are_solved] is true.
@@ -53,9 +53,10 @@ val the_conv_x_leq : env -> ?ts:TransparentState.t -> constr -> constr -> evar_m
 [@@ocaml.deprecated "Use Evarconv.unify_leq_delay instead"]
 (** The same function resolving evars by side-effect and
    catching the exception *)
-val conv : env -> ?ts:transparent_state -> evar_map -> constr -> constr -> evar_map option
+
+val conv : env -> ?ts:TransparentState.t -> evar_map -> constr -> constr -> evar_map option
 [@@ocaml.deprecated "Use Evarconv.unify_delay instead"]
-val cumul : env -> ?ts:transparent_state -> evar_map -> constr -> constr -> evar_map option
+val cumul : env -> ?ts:TransparentState.t -> evar_map -> constr -> constr -> evar_map option
 [@@ocaml.deprecated "Use Evarconv.unify_leq_delay instead"]
 
 (** This function also calls [solve_unif_constraints_with_heuristics] to resolve any remaining

--- a/pretyping/evardefine.ml
+++ b/pretyping/evardefine.ml
@@ -139,7 +139,8 @@ let define_pure_evar_as_lambda env evd evk =
   let newenv = push_named (LocalAssum (id, dom)) evenv in
   let filter = Filter.extend 1 (evar_filter evi) in
   let src = subterm_source evk ~where:Body (evar_source evk evd1) in
-  let evd2,body = new_evar newenv evd1 ~src (subst1 (mkVar id) rng) ~filter in
+  let abstract_arguments = Abstraction.abstract_last evi.evar_abstract_arguments in
+  let evd2,body = new_evar newenv evd1 ~src (subst1 (mkVar id) rng) ~filter ~abstract_arguments in
   let lam = mkLambda (Name id, dom, subst_var id body) in
   Evd.define evk lam evd2, lam
 

--- a/pretyping/evarsolve.ml
+++ b/pretyping/evarsolve.ml
@@ -26,9 +26,9 @@ open Pretype_errors
 
 type unify_flags = {
   modulo_betaiota: bool;
-  open_ts : transparent_state;
-  closed_ts : transparent_state;
-  subterm_ts : transparent_state;
+  open_ts : TransparentState.t;
+  closed_ts : TransparentState.t;
+  subterm_ts : TransparentState.t;
   frozen_evars : Evar.Set.t;
   allow_K_at_toplevel : bool;
   with_cs : bool }
@@ -1442,8 +1442,8 @@ let occur_evar_upto_types sigma n c =
   try occur_rec c; false with Occur -> true
 
 let instantiate_evar unify flags evd evk body =
-  (** Check instance freezing the evar to be defined, as
-      checking could involve the same evar definition problem again otherwise *)
+  (* Check instance freezing the evar to be defined, as
+     checking could involve the same evar definition problem again otherwise *)
   let flags = { flags with frozen_evars = Evar.Set.add evk flags.frozen_evars } in
   let evd' = check_evar_instance unify flags evd evk body in
   Evd.define evk body evd'

--- a/pretyping/evarsolve.ml
+++ b/pretyping/evarsolve.ml
@@ -24,6 +24,15 @@ open Reductionops
 open Evarutil
 open Pretype_errors
 
+type unify_flags = {
+  modulo_betaiota: bool;
+  open_ts : transparent_state;
+  closed_ts : transparent_state;
+  subterm_ts : transparent_state;
+  frozen_evars : Evar.Set.t;
+  allow_K_at_toplevel : bool;
+  with_cs : bool }
+
 let normalize_evar evd ev =
   match EConstr.kind evd (mkEvar ev) with
   | Evar (evk,args) -> (evk,args)
@@ -141,8 +150,8 @@ type unification_result =
 
 let is_success = function Success _ -> true | UnifFailure _ -> false
 
-let test_success conv_algo env evd c c' rhs =
-  is_success (conv_algo env evd c c' rhs)
+let test_success conv_algo b env evd c c' rhs =
+  is_success (conv_algo b env evd c c' rhs)
 
 let add_conv_oriented_pb ?(tail=true) (pbty,env,t1,t2) evd =
   match pbty with
@@ -165,7 +174,7 @@ let recheck_applications conv_algo env evdref t =
 	 if i < Array.length argsty then
 	 match EConstr.kind !evdref (whd_all env !evdref ty) with
 	 | Prod (na, dom, codom) ->
-	    (match conv_algo env !evdref Reduction.CUMUL argsty.(i) dom with
+            (match conv_algo true env !evdref Reduction.CUMUL argsty.(i) dom with
 	     | Success evd -> evdref := evd;
 			     aux (succ i) (subst1 args.(i) codom)
 	     | UnifFailure (evd, reason) ->
@@ -734,6 +743,19 @@ let restrict_upon_filter evd evk p args =
   let len = Array.length args in
   Filter.restrict_upon oldfullfilter len (fun i -> p (Array.unsafe_get args i))
 
+let check_evar_instance evd evk1 body conv_algo =
+  let evi = Evd.find evd evk1 in
+  let evenv = evar_env evi in
+  (* FIXME: The body might be ill-typed when this is called from w_merge *)
+  (* This happens in practice, cf MathClasses build failure on 2013-3-15 *)
+  let ty =
+    try Retyping.get_type_of ~lax:true evenv evd body
+    with Retyping.RetypeError _ -> user_err (Pp.(str "Ill-typed evar instance"))
+  in
+  match conv_algo true evenv evd Reduction.CUMUL ty evi.evar_concl with
+  | Success evd -> evd
+  | UnifFailure _ -> raise (IllTypedInstance (evenv,ty,evi.evar_concl))
+
 (***************)
 (* Unification *)
 
@@ -869,12 +891,13 @@ let rec find_solution_type evarenv = function
  * pass [define] to [do_projection_effects] as a parameter.
  *)
 
-let rec do_projection_effects define_fun env ty evd = function
+let rec do_projection_effects conv_algo define_fun env ty evd = function
   | ProjectVar -> evd
   | ProjectEvar ((evk,argsv),evi,id,p) ->
-      let evd = Evd.define evk (mkVar id) evd in
+      let evd = check_evar_instance evd evk (mkVar id) conv_algo in
+      let evd = Evd.define evk (EConstr.mkVar id) evd in
       (* TODO: simplify constraints involving evk *)
-      let evd = do_projection_effects define_fun env ty evd p in
+      let evd = do_projection_effects conv_algo define_fun env ty evd p in
       let ty = whd_all env evd (Lazy.force ty) in
       if not (isSort evd ty) then
         (* Don't try to instantiate if a sort because if evar_concl is an
@@ -1112,7 +1135,7 @@ let postpone_non_unique_projection env evd pbty (evk,argsv as ev) sols rhs =
 
 let filter_compatible_candidates conv_algo env evd evi args rhs c =
   let c' = instantiate_evar_array evi c args in
-  match conv_algo env evd Reduction.CONV rhs c' with
+  match conv_algo false env evd Reduction.CONV rhs c' with
   | Success evd -> Some (c,evd)
   | UnifFailure _ -> None
 
@@ -1225,19 +1248,6 @@ let project_evar_on_evar force g env evd aliases k2 pbty (evk1,argsv1 as ev1) (e
   else
     raise (CannotProject (evd,ev1'))
 
-let check_evar_instance evd evk1 body conv_algo =
-  let evi = Evd.find evd evk1 in
-  let evenv = evar_env evi in
-  (* FIXME: The body might be ill-typed when this is called from w_merge *)
-  (* This happens in practice, cf MathClasses build failure on 2013-3-15 *)
-  let ty =
-    try Retyping.get_type_of ~lax:true evenv evd body
-    with Retyping.RetypeError _ -> user_err Pp.(str "Ill-typed evar instance")
-  in
-  match conv_algo evenv evd Reduction.CUMUL ty evi.evar_concl with
-  | Success evd -> evd
-  | UnifFailure _ -> raise (IllTypedInstance (evenv,ty, evi.evar_concl))
-
 let update_evar_info ev1 ev2 evd =
   (* We update the source of obligation evars during evar-evar unifications. *)
   let loc, evs1 = evar_source ev1 evd in
@@ -1264,22 +1274,27 @@ let preferred_orientation evd evk1 evk2 =
   else if is_obligation_evar evd evk2 then false
   else true
 
-let solve_evar_evar_aux force f g env evd pbty (evk1,args1 as ev1) (evk2,args2 as ev2) =
+(** Precondition evk1 is not frozen, evk2 might be. *)
+let solve_evar_evar_aux force flags f g env evd pbty (evk1,args1 as ev1) (evk2,args2 as ev2) =
   let aliases = make_alias_map env evd in
+  let frozen_ev2 = Evar.Set.mem evk2 flags.frozen_evars in
   if preferred_orientation evd evk1 evk2 then
     try solve_evar_evar_l2r force f g env evd aliases (opp_problem pbty) ev2 ev1
-    with CannotProject (evd,ev2) ->
+    with CannotProject (evd,ev2) when not frozen_ev2 ->
     try solve_evar_evar_l2r force f g env evd aliases pbty ev1 ev2
     with CannotProject (evd,ev1) ->
     add_conv_oriented_pb ~tail:true (pbty,env,mkEvar ev1,mkEvar ev2) evd
   else
-    try solve_evar_evar_l2r force f g env evd aliases pbty ev1 ev2
+    try if not frozen_ev2 then
+          solve_evar_evar_l2r force f g env evd aliases pbty ev1 ev2
+        else raise (CannotProject (evd,ev1))
     with CannotProject (evd,ev1) ->
     try solve_evar_evar_l2r force f g env evd aliases (opp_problem pbty) ev2 ev1
     with CannotProject (evd,ev2) ->
     add_conv_oriented_pb ~tail:true (pbty,env,mkEvar ev1,mkEvar ev2) evd
 
-let solve_evar_evar ?(force=false) f g env evd pbty (evk1,args1 as ev1) (evk2,args2 as ev2) =
+(** Precondition: evk1 is not frozen *)
+let solve_evar_evar ?(force=false) flags f g env evd pbty (evk1,args1 as ev1) (evk2,args2 as ev2) =
   let pbty = if force then None else pbty in
   let evi = Evd.find evd evk1 in
   let downcast evk t evd = downcast evk t evd in
@@ -1314,20 +1329,22 @@ let solve_evar_evar ?(force=false) f g env evd pbty (evk1,args1 as ev1) (evk2,ar
           downcast evk2 t2 (downcast evk1 t1 evd)
     with Reduction.NotArity -> 
       evd in
-  solve_evar_evar_aux force f g env evd pbty ev1 ev2
+  solve_evar_evar_aux force flags f g env evd pbty ev1 ev2
+
+type types_or_terms = bool
 
 type conv_fun =
-  env ->  evar_map -> conv_pb -> EConstr.constr -> EConstr.constr -> unification_result
+  types_or_terms -> env ->  evar_map -> conv_pb -> EConstr.constr -> EConstr.constr -> unification_result
 
 type conv_fun_bool =
-  env ->  evar_map -> conv_pb -> EConstr.constr -> EConstr.constr -> bool
+  types_or_terms -> env ->  evar_map -> conv_pb -> EConstr.constr -> EConstr.constr -> bool
 
 (* Solve pbs ?e[t1..tn] = ?e[u1..un] which arise often in fixpoint
  * definitions. We try to unify the ti with the ui pairwise. The pairs
  * that don't unify are discarded (i.e. ?e is redefined so that it does not
  * depend on these args). *)
 
-let solve_refl ?(can_drop=false) conv_algo env evd pbty evk argsv1 argsv2 =
+let solve_refl ?(can_drop=false) flags conv_algo env evd pbty evk argsv1 argsv2 =
   let evdref = ref evd in
   let eq_constr c1 c2 = match EConstr.eq_constr_universes env !evdref c1 c2 with
   | None -> false
@@ -1340,7 +1357,7 @@ let solve_refl ?(can_drop=false) conv_algo env evd pbty evk argsv1 argsv2 =
   let args = Array.map2 (fun a1 a2 -> (a1, a2)) argsv1 argsv2 in
   let untypedfilter =
     restrict_upon_filter evd evk
-      (fun (a1,a2) -> conv_algo env evd Reduction.CONV a1 a2) args in
+      (fun (a1,a2) -> conv_algo false env evd Reduction.CONV a1 a2) args in
   let candidates = filter_candidates evd evk untypedfilter NoUpdate in
   let filter = closure_of_filter evd evk untypedfilter in
   let evd,ev1 = restrict_applied_evar evd (evk,argsv1) filter candidates in
@@ -1428,7 +1445,8 @@ exception NotEnoughInformationEvarEvar of EConstr.constr
 exception OccurCheckIn of evar_map * EConstr.constr
 exception MetaOccurInBodyInternal
 
-let rec invert_definition conv_algo choose env evd pbty (evk,argsv as ev) rhs =
+let rec invert_definition flags conv_algo choose imitate_defs
+                          env evd pbty (evk,argsv as ev) rhs =
   let aliases = make_alias_map env evd in
   let evdref = ref evd in
   let progress = ref false in
@@ -1447,7 +1465,7 @@ let rec invert_definition conv_algo choose env evd pbty (evk,argsv as ev) rhs =
             if choose then (mkVar id, p) else raise (NotUniqueInType sols)
       in
       let ty = lazy (Retyping.get_type_of env !evdref (of_alias t)) in
-      let evd = do_projection_effects (evar_define conv_algo ~choose) env ty !evdref p in
+      let evd = do_projection_effects conv_algo (evar_define flags conv_algo ~choose) env ty !evdref p in
       evdref := evd;
       c
     with
@@ -1460,7 +1478,7 @@ let rec invert_definition conv_algo choose env evd pbty (evk,argsv as ev) rhs =
           let ty = find_solution_type (evar_filtered_env evi) sols in
           let ty' = instantiate_evar_array evi ty argsv in
           let (evd,evar,(evk',argsv' as ev')) =
-            materialize_evar (evar_define conv_algo ~choose) env !evdref 0 ev ty' in
+            materialize_evar (evar_define flags conv_algo ~choose) env !evdref 0 ev ty' in
           let ts = expansions_of_var evd aliases t in
           let test c = isEvar evd c || List.exists (is_alias evd c) ts in
           let filter = restrict_upon_filter evd evk test argsv' in
@@ -1484,13 +1502,15 @@ let rec invert_definition conv_algo choose env evd pbty (evk,argsv as ev) rhs =
         | LocalAssum _ -> project_variable (RelAlias (i-k))
         | LocalDef (_,b,_) ->
           try project_variable (RelAlias (i-k))
-          with NotInvertibleUsingOurAlgorithm _ -> imitate envk (lift i (EConstr.of_constr b)))
+          with NotInvertibleUsingOurAlgorithm _ when imitate_defs ->
+            imitate envk (lift i (EConstr.of_constr b)))
     | Var id ->
         (match Environ.lookup_named id env' with
         | LocalAssum _ -> project_variable (VarAlias id)
         | LocalDef (_,b,_) ->
           try project_variable (VarAlias id)
-          with NotInvertibleUsingOurAlgorithm _ -> imitate envk (EConstr.of_constr b))
+          with NotInvertibleUsingOurAlgorithm _ when imitate_defs ->
+            imitate envk (EConstr.of_constr b))
     | LetIn (na,b,u,c) ->
         imitate envk (subst1 b c)
     | Evar (evk',args' as ev') ->
@@ -1510,7 +1530,7 @@ let rec invert_definition conv_algo choose env evd pbty (evk,argsv as ev) rhs =
           (* Make the virtual left evar real *)
           let ty = get_type_of env' evd t in
           let (evd,evar'',ev'') =
-             materialize_evar (evar_define conv_algo ~choose) env' evd k ev ty in
+             materialize_evar (evar_define flags conv_algo ~choose) env' evd k ev ty in
           (* materialize_evar may instantiate ev' by another evar; adjust it *)
           let (evk',args' as ev') = normalize_evar evd ev' in
           let evd =
@@ -1555,7 +1575,7 @@ let rec invert_definition conv_algo choose env evd pbty (evk,argsv as ev) rhs =
             | [x] -> x
             | _ ->
               let (evd,evar'',ev'') =
-                materialize_evar (evar_define conv_algo ~choose) env' !evdref k ev ty in
+                materialize_evar (evar_define flags conv_algo ~choose) env' !evdref k ev ty in
               evdref := restrict_evar evd (fst ev'') None (UpdateWith candidates);
               evar'')
         | None ->
@@ -1594,46 +1614,33 @@ let rec invert_definition conv_algo choose env evd pbty (evk,argsv as ev) rhs =
  * [define] tries to find an instance lhs such that
  * "lhs [hyps:=args]" unifies to rhs. The term "lhs" must be closed in
  * context "hyps" and not referring to itself.
+ * ev is assumed not to be frozen.
  *)
 
-and evar_define conv_algo ?(choose=false) env evd pbty (evk,argsv as ev) rhs =
+and evar_define flags conv_algo ?(choose=false) ?(imitate_defs=true) env evd pbty (evk,argsv as ev) rhs =
   match EConstr.kind evd rhs with
   | Evar (evk2,argsv2 as ev2) ->
       if Evar.equal evk evk2 then
-        solve_refl ~can_drop:choose
+        solve_refl ~can_drop:choose flags
           (test_success conv_algo) env evd pbty evk argsv argsv2
       else
-        solve_evar_evar ~force:choose
-          (evar_define conv_algo) conv_algo env evd pbty ev ev2
+        solve_evar_evar ~force:choose flags
+          (evar_define flags conv_algo) conv_algo env evd pbty ev ev2
   | _ ->
   try solve_candidates conv_algo env evd ev rhs
   with NoCandidates ->
   try
-    let (evd',body) = invert_definition conv_algo choose env evd pbty ev rhs in
+    let (evd',body) = invert_definition flags conv_algo choose imitate_defs env evd pbty ev rhs in
     if occur_meta evd' body then raise MetaOccurInBodyInternal;
     (* invert_definition may have instantiate some evars of rhs with evk *)
     (* so we recheck acyclicity *)
     if occur_evar_upto_types evd' evk body then raise (OccurCheckIn (evd',body));
     (* needed only if an inferred type *)
     let evd', body = refresh_universes pbty env evd' body in
-(* Cannot strictly type instantiations since the unification algorithm
- * does not unify applications from left to right.
- * e.g problem f x == g y yields x==y and f==g (in that order)
- * Another problem is that type variables are evars of type Type
-   let _ =
-      try
-        let env = evar_filtered_env evi in
-        let ty = evi.evar_concl in
-        Typing.check env evd' body ty
-      with e ->
-        msg_info
-          (str "Ill-typed evar instantiation: " ++ fnl() ++
-           pr_evar_map evd' ++ fnl() ++
-           str "----> " ++ int ev ++ str " := " ++
-           print_constr body);
-        raise e in*)
-    let evd' = check_evar_instance evd' evk body conv_algo in
-    Evd.define evk body evd'
+    let evd' = Evd.define evk body evd' in
+    (** Check after definition, as checking could involve the same
+        evar definition problem again otherwise *)
+    check_evar_instance evd' evk body conv_algo
   with
     | NotEnoughInformationToProgress sols ->
         postpone_non_unique_projection env evd pbty ev sols rhs
@@ -1648,8 +1655,8 @@ and evar_define conv_algo ?(choose=false) env evd pbty (evk,argsv as ev) rhs =
         let c = whd_all env evd rhs in
         match EConstr.kind evd c with
         | Evar (evk',argsv2) when Evar.equal evk evk' ->
-	    solve_refl (fun env sigma pb c c' -> is_fconv pb env sigma c c')
-              env evd pbty evk argsv argsv2
+            solve_refl flags (fun _b env sigma pb c c' -> is_fconv pb env sigma c c')
+                       env evd pbty evk argsv argsv2
         | _ ->
 	    raise (OccurCheckIn (evd,rhs))
 
@@ -1689,7 +1696,7 @@ let reconsider_unif_constraints conv_algo evd =
     (fun p (pbty,env,t1,t2 as x) ->
        match p with
        | Success evd ->
-           (match conv_algo env evd pbty t1 t2 with
+           (match conv_algo true env evd pbty t1 t2 with
            | Success _ as x -> x
            | UnifFailure (i,e) -> UnifFailure (i,CannotSolveConstraint (x,e)))
        | UnifFailure _ as x -> x)
@@ -1702,10 +1709,11 @@ let reconsider_unif_constraints conv_algo evd =
  * if the problem couldn't be solved. *)
 
 (* Rq: uncomplete algorithm if pbty = CONV_X_LEQ ! *)
-let solve_simple_eqn conv_algo ?(choose=false) env evd (pbty,(evk1,args1 as ev1),t2) =
+let solve_simple_eqn flags conv_algo ?(choose=false) ?(imitate_defs=true)
+                     env evd (pbty,(evk1,args1 as ev1),t2) =
   try
     let t2 = whd_betaiota evd t2 in (* includes whd_evar *)
-    let evd = evar_define conv_algo ~choose env evd pbty ev1 t2 in
+    let evd = evar_define flags conv_algo ~choose ~imitate_defs env evd pbty ev1 t2 in
       reconsider_unif_constraints conv_algo evd
   with
     | NotInvertibleUsingOurAlgorithm t ->

--- a/pretyping/evarsolve.mli
+++ b/pretyping/evarsolve.mli
@@ -16,6 +16,15 @@ type alias
 
 val of_alias : alias -> EConstr.t
 
+type unify_flags = {
+  modulo_betaiota : bool;
+  open_ts : Names.transparent_state;
+  closed_ts : Names.transparent_state;
+  subterm_ts : Names.transparent_state;
+  frozen_evars : Evar.Set.t;
+  allow_K_at_toplevel : bool;
+  with_cs : bool}
+
 type unification_result =
   | Success of evar_map
   | UnifFailure of evar_map * Pretype_errors.unification_error
@@ -31,14 +40,16 @@ val expand_vars_in_term : env -> evar_map -> constr -> constr
    some problems that cannot be solved in a unique way (except if choose is
    true); fails if the instance is not valid for the given [ev] *)
 
-type conv_fun =
-  env ->  evar_map -> conv_pb -> constr -> constr -> unification_result
+type types_or_terms = bool
 
-type conv_fun_bool =
+type conv_fun = types_or_terms ->
+  env -> evar_map -> conv_pb -> constr -> constr -> unification_result
+
+type conv_fun_bool = types_or_terms ->
   env ->  evar_map -> conv_pb -> constr -> constr -> bool
 
-val evar_define : conv_fun -> ?choose:bool -> env -> evar_map -> 
-  bool option -> existential -> constr -> evar_map
+val evar_define : unify_flags -> conv_fun -> ?choose:bool -> ?imitate_defs:bool ->
+  env -> evar_map -> bool option -> existential -> constr -> evar_map
 
 val refresh_universes :
   ?status:Evd.rigid ->
@@ -49,15 +60,15 @@ val refresh_universes :
   bool option (* direction: true for levels lower than the existing levels *) ->
   env -> evar_map -> types -> evar_map * types
 
-val solve_refl : ?can_drop:bool -> conv_fun_bool -> env ->  evar_map ->
+val solve_refl : ?can_drop:bool -> unify_flags -> conv_fun_bool -> env ->  evar_map ->
   bool option -> Evar.t -> constr array -> constr array -> evar_map
 
-val solve_evar_evar : ?force:bool ->
+val solve_evar_evar : ?force:bool -> unify_flags ->
   (env -> evar_map -> bool option -> existential -> constr -> evar_map) ->
   conv_fun ->
   env ->  evar_map -> bool option -> existential -> existential -> evar_map
 
-val solve_simple_eqn : conv_fun -> ?choose:bool -> env ->  evar_map ->
+val solve_simple_eqn : unify_flags -> conv_fun -> ?choose:bool -> ?imitate_defs:bool -> env ->  evar_map ->
   bool option * existential * constr -> unification_result
 
 val reconsider_unif_constraints : conv_fun -> evar_map -> unification_result

--- a/pretyping/evarsolve.mli
+++ b/pretyping/evarsolve.mli
@@ -59,6 +59,17 @@ type unifier = unify_flags -> unification_kind ->
 type conversion_check = unify_flags -> unification_kind ->
   env -> evar_map -> conv_pb -> constr -> constr -> bool
 
+(** [instantiate_evar unify flags env sigma ev c] defines the evar [ev] with [c],
+    checking that the type of [c] is unifiable with [ev]'s declared type first.
+
+    Preconditions:
+    - [ev] does not occur in [c].
+    - [c] does not contain any Meta(_)
+ *)
+
+val instantiate_evar : unifier -> unify_flags -> evar_map ->
+  Evar.t -> constr -> evar_map
+
 (** [evar_define choose env ev c] try to instantiate [ev] with [c] (typed in [env]),
    possibly solving related unification problems, possibly leaving open
    some problems that cannot be solved in a unique way (except if choose is
@@ -66,6 +77,7 @@ type conversion_check = unify_flags -> unification_kind ->
 
 val evar_define : unifier -> unify_flags -> ?choose:bool -> ?imitate_defs:bool ->
   env -> evar_map -> bool option -> existential -> constr -> evar_map
+
 
 val refresh_universes :
   ?status:Evd.rigid ->

--- a/pretyping/evarsolve.mli
+++ b/pretyping/evarsolve.mli
@@ -19,11 +19,11 @@ val of_alias : alias -> EConstr.t
 type unify_flags = {
   modulo_betaiota : bool;
   (* Enable beta-iota reductions during unification *)
-  open_ts : Names.transparent_state;
+  open_ts : TransparentState.t;
   (* Enable delta reduction according to open_ts for open terms *)
-  closed_ts : Names.transparent_state;
+  closed_ts : TransparentState.t;
   (* Enable delta reduction according to closed_ts for closed terms (when calling conversion) *)
-  subterm_ts : Names.transparent_state;
+  subterm_ts : TransparentState.t;
   (* Enable delta reduction according to subterm_ts for selection of subterms during higher-order
      unifications. *)
   frozen_evars : Evar.Set.t;

--- a/pretyping/evarsolve.mli
+++ b/pretyping/evarsolve.mli
@@ -18,12 +18,22 @@ val of_alias : alias -> EConstr.t
 
 type unify_flags = {
   modulo_betaiota : bool;
+  (* Enable beta-iota reductions during unification *)
   open_ts : Names.transparent_state;
+  (* Enable delta reduction according to open_ts for open terms *)
   closed_ts : Names.transparent_state;
+  (* Enable delta reduction according to closed_ts for closed terms (when calling conversion) *)
   subterm_ts : Names.transparent_state;
+  (* Enable delta reduction according to subterm_ts for selection of subterms during higher-order
+     unifications. *)
   frozen_evars : Evar.Set.t;
+  (* Frozen evars are treated like rigid variables during unification: they can not be instantiated. *)
   allow_K_at_toplevel : bool;
-  with_cs : bool}
+  (* During higher-order unifications, allow to produce K-redexes: i.e. to produce
+     an abstraction for an unused argument *)
+  with_cs : bool
+  (* Enable canonical structure resolution during unification *)
+}
 
 type unification_result =
   | Success of evar_map

--- a/pretyping/evarsolve.mli
+++ b/pretyping/evarsolve.mli
@@ -35,11 +35,6 @@ val is_success : unification_result -> bool
    their representative that is most ancient in the context *)
 val expand_vars_in_term : env -> evar_map -> constr -> constr
 
-(** [evar_define choose env ev c] try to instantiate [ev] with [c] (typed in [env]),
-   possibly solving related unification problems, possibly leaving open
-   some problems that cannot be solved in a unique way (except if choose is
-   true); fails if the instance is not valid for the given [ev] *)
-
 (** One might want to use different conversion strategies for types and terms:
     e.g. preventing delta reductions when doing term unifications but allowing
     arbitrary delta conversion when checking the types of evar instances. *)
@@ -48,18 +43,28 @@ type unification_kind =
   | TypeUnification
   | TermUnification
 
-(** A unification function: parameterized by the kind of unification,
-    environment, sigma, conversion problem and the two terms to unify. *)
-type unifier = unification_kind ->
+(** A unification function parameterized by:
+    - unification flags
+    - the kind of unification
+    - environment
+    - sigma
+    - conversion problem
+    - the two terms to unify. *)
+type unifier = unify_flags -> unification_kind ->
   env -> evar_map -> conv_pb -> constr -> constr -> unification_result
 
 (** A conversion function: parameterized by the kind of unification,
     environment, sigma, conversion problem and the two terms to convert.
     Conversion is not allowed to instantiate evars contrary to unification. *)
-type conversion_check = unification_kind ->
-  env ->  evar_map -> conv_pb -> constr -> constr -> bool
+type conversion_check = unify_flags -> unification_kind ->
+  env -> evar_map -> conv_pb -> constr -> constr -> bool
 
-val evar_define : unify_flags -> unifier -> ?choose:bool -> ?imitate_defs:bool ->
+(** [evar_define choose env ev c] try to instantiate [ev] with [c] (typed in [env]),
+   possibly solving related unification problems, possibly leaving open
+   some problems that cannot be solved in a unique way (except if choose is
+   true); fails if the instance is not valid for the given [ev] *)
+
+val evar_define : unifier -> unify_flags -> ?choose:bool -> ?imitate_defs:bool ->
   env -> evar_map -> bool option -> existential -> constr -> evar_map
 
 val refresh_universes :
@@ -71,18 +76,18 @@ val refresh_universes :
   bool option (* direction: true for levels lower than the existing levels *) ->
   env -> evar_map -> types -> evar_map * types
 
-val solve_refl : ?can_drop:bool -> unify_flags -> conversion_check -> env ->  evar_map ->
+val solve_refl : ?can_drop:bool -> conversion_check -> unify_flags -> env ->  evar_map ->
   bool option -> Evar.t -> constr array -> constr array -> evar_map
 
-val solve_evar_evar : ?force:bool -> unify_flags ->
+val solve_evar_evar : ?force:bool ->
   (env -> evar_map -> bool option -> existential -> constr -> evar_map) ->
-  unifier ->
+  unifier -> unify_flags ->
   env ->  evar_map -> bool option -> existential -> existential -> evar_map
 
-val solve_simple_eqn : unify_flags -> unifier -> ?choose:bool -> ?imitate_defs:bool -> env ->  evar_map ->
+val solve_simple_eqn : unifier -> unify_flags -> ?choose:bool -> ?imitate_defs:bool -> env ->  evar_map ->
   bool option * existential * constr -> unification_result
 
-val reconsider_unif_constraints : unifier -> evar_map -> unification_result
+val reconsider_unif_constraints : unifier -> unify_flags -> evar_map -> unification_result
 
 val is_unification_pattern_evar : env -> evar_map -> existential -> constr list ->
   constr -> alias list option
@@ -97,8 +102,8 @@ val noccur_evar : env -> evar_map -> Evar.t -> constr -> bool
 exception IllTypedInstance of env * types * types
 
 (* May raise IllTypedInstance if types are not convertible *)
-val check_evar_instance :
-  evar_map -> Evar.t -> constr -> unifier -> evar_map
+val check_evar_instance : unifier -> unify_flags ->
+  evar_map -> Evar.t -> constr -> evar_map
 
 val remove_instance_local_defs :
   evar_map -> Evar.t -> 'a array -> 'a list

--- a/pretyping/find_subterm.ml
+++ b/pretyping/find_subterm.ml
@@ -125,7 +125,7 @@ let replace_term_occ_gen_modulo sigma occs like_first test bywhat cl occ t =
          end;
          add_subst t subst; incr pos;
          (* Check nested matching subterms *)
-         if occs != Locus.AllOccurrences && occs != Locus.NoOccurrences then
+         if not (Locusops.is_all_occurrences occs) && occs != Locus.NoOccurrences then
            begin nested := true; ignore (subst_below k t); nested := false end;
          (* Do the effective substitution *)
          Vars.lift k (bywhat ()))

--- a/pretyping/locus.ml
+++ b/pretyping/locus.ml
@@ -20,6 +20,7 @@ type 'a or_var =
 
 type 'a occurrences_gen =
   | AllOccurrences
+  | AtLeastOneOccurrence
   | AllOccurrencesBut of 'a list (** non-empty *)
   | NoOccurrences
   | OnlyOccurrences of 'a list (** non-empty *)

--- a/pretyping/locusops.mli
+++ b/pretyping/locusops.mli
@@ -21,6 +21,8 @@ val convert_occs : occurrences -> bool * int list
 
 val is_selected : int -> occurrences -> bool
 
+val is_all_occurrences : 'a occurrences_gen -> bool
+
 (** Usual clauses *)
 
 val allHypsAndConcl : 'a clause_expr

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -260,7 +260,7 @@ let apply_inference_hook hook env sigma frozen = match frozen with
 let apply_heuristics env sigma fail_evar =
   (* Resolve eagerly, potentially making wrong choices *)
   try solve_unif_constraints_with_heuristics
-        ~ts:(Typeclasses.classes_transparent_state ()) env sigma
+        ~flags:(default_flags_of (Typeclasses.classes_transparent_state ())) env sigma
   with e when CErrors.noncritical e ->
     let e = CErrors.push e in
     if fail_evar then iraise e else sigma

--- a/pretyping/tacred.ml
+++ b/pretyping/tacred.ml
@@ -1105,6 +1105,7 @@ let unfoldoccs env sigma (occs,name) c =
     | AllOccurrences -> unfold env sigma name c
     | OnlyOccurrences l -> unfo true l
     | AllOccurrencesBut l -> unfo false l
+    | AtLeastOneOccurrence -> unfo false []
 
 (* Unfold reduction tactic: *)
 let unfoldn loccname env sigma c =

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -141,7 +141,8 @@ let abstract_list_all env evd typ c l =
   evd,(p,typp)
 
 let set_occurrences_of_last_arg args =
-  Some AllOccurrences :: List.tl (Array.map_to_list (fun _ -> None) args)
+  Evarconv.AtOccurrences AllOccurrences ::
+    List.tl (Array.map_to_list (fun _ -> Evarconv.default_occurrence_selection) args)
 
 let abstract_list_all_with_dependencies env evd typ c l =
   let (evd, ev) = new_evar env evd typ in
@@ -149,8 +150,8 @@ let abstract_list_all_with_dependencies env evd typ c l =
   let n = List.length l in
   let argoccs = set_occurrences_of_last_arg (Array.sub (snd ev') 0 n) in
   let evd,b =
-    Evarconv.second_order_matching TransparentState.empty
-      env evd ev' argoccs c in
+    Evarconv.second_order_matching (Evarconv.default_flags_of TransparentState.empty)
+    env evd ev' (Evarconv.default_occurrence_test ~frozen_evars:Evar.Set.empty TransparentState.empty, argoccs) c in
   if b then
     let p = nf_evar evd ev in
       evd, p
@@ -1315,8 +1316,8 @@ let order_metas metas =
 
 (* Solve an equation ?n[x1=u1..xn=un] = t where ?n is an evar *)
 
-let solve_simple_evar_eqn ts env evd ev rhs =
-  match solve_simple_eqn (Evarconv.evar_conv_x ts) env evd (None,ev,rhs) with
+let solve_simple_evar_eqn flags env evd ev rhs =
+  match solve_simple_eqn flags (Evarconv.conv_fun Evarconv.evar_conv_x flags) env evd (None,ev,rhs) with
   | UnifFailure (evd,reason) ->
       error_cannot_unify env evd ~reason (mkEvar ev,rhs);
   | Success evd -> evd
@@ -1326,6 +1327,7 @@ let solve_simple_evar_eqn ts env evd ev rhs =
    is true, unification of types of metas is required *)
 
 let w_merge env with_types flags (evd,metas,evars : subst0) =
+  let eflags = Evarconv.default_flags_of flags.modulo_delta_types in
   let rec w_merge_rec evd metas evars eqns =
 
     (* Process evars *)
@@ -1350,14 +1352,14 @@ let w_merge env with_types flags (evd,metas,evars : subst0) =
 	      else
 		let evd' = 
 		  let evd', rhs'' = pose_all_metas_as_evars curenv evd rhs' in
-		    try solve_simple_evar_eqn flags.modulo_delta_types curenv evd' ev rhs''
+                  try solve_simple_evar_eqn eflags curenv evd' ev rhs''
 		    with Retyping.RetypeError _ ->
 		      error_cannot_unify curenv evd' (mkEvar ev,rhs'')
 		in w_merge_rec evd' metas evars' eqns
           | _ ->
 	      let evd', rhs'' = pose_all_metas_as_evars curenv evd rhs' in
 	      let evd' = 
-		try solve_simple_evar_eqn flags.modulo_delta_types curenv evd' ev rhs''
+                try solve_simple_evar_eqn eflags curenv evd' ev rhs''
 		with Retyping.RetypeError _ -> error_cannot_unify curenv evd' (mkEvar ev, rhs'')
 	      in
 		w_merge_rec evd' metas evars' eqns

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -1325,7 +1325,7 @@ let order_metas metas =
 (* Solve an equation ?n[x1=u1..xn=un] = t where ?n is an evar *)
 
 let solve_simple_evar_eqn flags env evd ev rhs =
-  match solve_simple_eqn flags (Evarconv.conv_fun Evarconv.evar_conv_x flags) env evd (None,ev,rhs) with
+  match solve_simple_eqn Evarconv.evar_unify flags env evd (None,ev,rhs) with
   | UnifFailure (evd,reason) ->
       error_cannot_unify env evd ~reason (mkEvar ev,rhs);
   | Success evd -> evd

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -142,7 +142,7 @@ let abstract_list_all env evd typ c l =
 
 let set_occurrences_of_last_arg args =
   Evarconv.AtOccurrences AllOccurrences ::
-    List.tl (Array.map_to_list (fun _ -> Evarconv.Unspecified true) args)
+    List.tl (Array.map_to_list (fun _ -> Evarconv.Unspecified Abstraction.Abstract) args)
 
 let occurrence_test _ _ _ env sigma _ c1 c2 =
   match EConstr.eq_constr_universes env sigma c1 c2 with

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -142,7 +142,14 @@ let abstract_list_all env evd typ c l =
 
 let set_occurrences_of_last_arg args =
   Evarconv.AtOccurrences AllOccurrences ::
-    List.tl (Array.map_to_list (fun _ -> Evarconv.default_occurrence_selection) args)
+    List.tl (Array.map_to_list (fun _ -> Evarconv.Unspecified true) args)
+
+let occurrence_test _ _ _ env sigma _ c1 c2 =
+  match EConstr.eq_constr_universes env sigma c1 c2 with
+  | None -> false, sigma
+  | Some cstr ->
+     try true, Evd.add_universe_constraints sigma cstr
+     with UniversesDiffer -> false, sigma
 
 let abstract_list_all_with_dependencies env evd typ c l =
   let (evd, ev) = new_evar env evd typ in
@@ -150,8 +157,9 @@ let abstract_list_all_with_dependencies env evd typ c l =
   let n = List.length l in
   let argoccs = set_occurrences_of_last_arg (Array.sub (snd ev') 0 n) in
   let evd,b =
-    Evarconv.second_order_matching (Evarconv.default_flags_of TransparentState.empty)
-    env evd ev' (Evarconv.default_occurrence_test ~frozen_evars:Evar.Set.empty TransparentState.empty, argoccs) c in
+    Evarconv.second_order_matching
+      (Evarconv.default_flags_of TransparentState.empty)
+      env evd ev' (occurrence_test, argoccs) c in
   if b then
     let p = nf_evar evd ev in
       evd, p

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -1649,7 +1649,7 @@ let make_abstraction_core name (test,out) env sigma c ty occs check_occs concl =
     match occurrences_of_hyp hyp occs with
     | NoOccurrences, InHyp ->
         (push_named_context_val d sign,depdecls)
-    | AllOccurrences, InHyp as occ ->
+    | (AllOccurrences | AtLeastOneOccurrence), InHyp as occ ->
         let occ = if likefirst then LikeFirst else AtOccs occ in
         let newdecl = replace_term_occ_decl_modulo sigma occ test mkvarid d in
         if Context.Named.Declaration.equal (EConstr.eq_constr sigma) d newdecl

--- a/proofs/evar_refiner.ml
+++ b/proofs/evar_refiner.ml
@@ -37,8 +37,8 @@ let define_and_solve_constraints evk c env evd =
   match
     List.fold_left
       (fun p (pbty,env,t1,t2) -> match p with
-        | Success evd -> Evarconv.evar_conv_x TransparentState.full env evd pbty t1 t2
-	| UnifFailure _ as x -> x) (Success evd)
+        | Success evd -> Evarconv.evar_conv_x (Evarconv.default_flags_of TransparentState.full) env evd pbty t1 t2
+        | UnifFailure _ as x -> x) (Success evd)
       pbs
   with
     | Success evd -> evd

--- a/proofs/goal.ml
+++ b/proofs/goal.ml
@@ -58,11 +58,11 @@ module V82 = struct
        created. *)
     let prev_future_goals = Evd.save_future_goals evars in
     let evi = { Evd.evar_hyps = hyps;
-		Evd.evar_concl = concl;
-		Evd.evar_filter = Evd.Filter.identity;
+                Evd.evar_concl = concl;
+                Evd.evar_filter = Evd.Filter.identity;
                 Evd.evar_abstract_arguments = Evd.Abstraction.identity;
-		Evd.evar_body = Evd.Evar_empty;
-		Evd.evar_source = (Loc.tag Evar_kinds.GoalEvar);
+                Evd.evar_body = Evd.Evar_empty;
+                Evd.evar_source = (Loc.tag Evar_kinds.GoalEvar);
                 Evd.evar_candidates = None }
     in
     let (evars, evk) = Evarutil.new_pure_evar_full evars ~typeclass_candidate:false evi in

--- a/proofs/goal.ml
+++ b/proofs/goal.ml
@@ -60,6 +60,7 @@ module V82 = struct
     let evi = { Evd.evar_hyps = hyps;
 		Evd.evar_concl = concl;
 		Evd.evar_filter = Evd.Filter.identity;
+                Evd.evar_abstract_arguments = Evd.Abstraction.identity;
 		Evd.evar_body = Evd.Evar_empty;
 		Evd.evar_source = (Loc.tag Evar_kinds.GoalEvar);
                 Evd.evar_candidates = None }

--- a/tactics/autorewrite.ml
+++ b/tactics/autorewrite.ml
@@ -145,7 +145,7 @@ let gen_auto_multi_rewrite conds tac_main lbas cl =
   let try_do_hyps treat_id l =
     autorewrite_multi_in ~conds (List.map treat_id l) tac_main lbas
   in
-  if cl.concl_occs != AllOccurrences &&
+  if not (Locusops.is_all_occurrences cl.concl_occs) &&
      cl.concl_occs != NoOccurrences
   then
     Tacticals.New.tclZEROMSG (str"The \"at\" syntax isn't available yet for the autorewrite tactic.")

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -1103,7 +1103,7 @@ let initial_select_evars filter =
 let resolve_typeclass_evars debug depth unique env evd filter split fail =
   let evd =
     try Evarconv.solve_unif_constraints_with_heuristics
-      ~ts:(Typeclasses.classes_transparent_state ()) env evd
+      ~flags:(Evarconv.default_flags_of (Typeclasses.classes_transparent_state ())) env evd
     with e when CErrors.noncritical e -> evd
   in
     resolve_all_evars debug depth unique env

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -230,8 +230,9 @@ let unify_resolve_refine poly flags gls ((c, t, ctx),n,clenv) =
       let sigma', cl = Clenv.make_evar_clause env sigma ?len:n ty in
       let term = applist (term, List.map (fun x -> x.hole_evar) cl.cl_holes) in
       let sigma' =
-        Evarconv.the_conv_x_leq env ~ts:flags.core_unify_flags.modulo_delta
-                                cl.cl_concl concl sigma'
+        Evarconv.(unify_leq_delay
+                    ~flags:(default_flags_of flags.core_unify_flags.modulo_delta)
+                              env sigma' cl.cl_concl concl)
       in (sigma', term) end
 
 let unify_resolve_refine poly flags gl clenv =

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -636,7 +636,7 @@ let replace_using_leibniz clause c1 c2 l2r unsafe try_prove_eq_opt =
   let evd = 
     if unsafe then Some (Tacmach.New.project gl)
     else
-      try Some (Evarconv.the_conv_x (Proofview.Goal.env gl) t1 t2 (Tacmach.New.project gl))
+      try Some (Evarconv.unify_delay (Proofview.Goal.env gl) (Tacmach.New.project gl) t1 t2)
       with Evarconv.UnableToUnify _ -> None
   in
   match evd with
@@ -1194,9 +1194,8 @@ let sig_clausal_form env sigma sort_of_ty siglen ty dflt =
       (* is the default value typable with the expected type *)
       let dflt_typ = unsafe_type_of env sigma dflt in
       try
-        let sigma = Evarconv.the_conv_x_leq env dflt_typ p_i sigma in
-        let sigma =
-          Evarconv.solve_unif_constraints_with_heuristics env sigma in
+        let sigma = Evarconv.unify_leq_delay env sigma dflt_typ p_i in
+        let sigma = Evarconv.solve_unif_constraints_with_heuristics env sigma in
         sigma, dflt
       with Evarconv.UnableToUnify _ ->
 	user_err Pp.(str "Cannot solve a unification problem.")
@@ -1211,11 +1210,11 @@ let sig_clausal_form env sigma sort_of_ty siglen ty dflt =
       match evopt with
 	| Some w ->
           let w_type = unsafe_type_of env sigma w in
-          begin match Evarconv.cumul env sigma w_type a with
-            | Some sigma ->
+          begin match Evarconv.unify_leq_delay env sigma w_type a with
+            | sigma ->
               let sigma, exist_term = Evd.fresh_global env sigma sigdata.intro in
               sigma, applist(exist_term,[a;p_i_minus_1;w;tuple_tail])
-            | None ->
+            | exception Evarconv.UnableToUnify _ ->
               user_err Pp.(str "Cannot solve a unification problem.")
           end
 	| None ->

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -437,7 +437,7 @@ let rewrite_side_tac tac sidetac = side_tac tac (Option.map fst sidetac)
 
 let general_rewrite_ebindings_clause cls lft2rgt occs frzevars dep_proof_ok ?tac
     ((c,l) : constr with_bindings) with_evars =
-  if occs != AllOccurrences then (
+  if not (Locusops.is_all_occurrences occs) then (
     rewrite_side_tac (Hook.get forward_general_setoid_rewrite_clause cls lft2rgt occs (c,l) ~new_goals:[]) tac)
   else
     Proofview.Goal.enter begin fun gl ->
@@ -595,15 +595,16 @@ let init_setoid () =
   if is_dirpath_prefix_of classes_dirpath (Lib.cwd ()) then ()
   else check_required_library ["Coq";"Setoids";"Setoid"]
 
-let check_setoid cl = 
+let check_setoid cl =
+  let concloccs = Locusops.occurrences_map (fun x -> x) cl.concl_occs in
   Option.fold_left
-    ( List.fold_left 
+    (List.fold_left
 	(fun b ((occ,_),_) -> 
-	  b||(Locusops.occurrences_map (fun x -> x) occ <> AllOccurrences)
+          b||(not (Locusops.is_all_occurrences (Locusops.occurrences_map (fun x -> x) occ)))
 	)
     )
-    ((Locusops.occurrences_map (fun x -> x) cl.concl_occs <> AllOccurrences) &&
-	(Locusops.occurrences_map (fun x -> x) cl.concl_occs <> NoOccurrences))
+    (not (Locusops.is_all_occurrences concloccs) &&
+     (concloccs <> NoOccurrences))
     cl.onhyps
 
 let replace_core clause l2r eq =
@@ -1724,7 +1725,7 @@ let subst_one dep_proof_ok x (hyp,rhs,dir) =
   tclTHENLIST
     ((if need_rewrite then
       [revert (List.map snd dephyps);
-       general_rewrite dir AllOccurrences true dep_proof_ok (mkVar hyp);
+       general_rewrite dir AtLeastOneOccurrence true dep_proof_ok (mkVar hyp);
        (tclMAP (fun (dest,id) -> intro_move (Some id) dest) dephyps)]
       else
        [Proofview.tclUNIT ()]) @

--- a/tactics/ppred.ml
+++ b/tactics/ppred.ml
@@ -6,6 +6,7 @@ open Pputils
 
 let pr_with_occurrences pr keyword (occs,c) =
   match occs with
+    | AtLeastOneOccurrence -> hov 1 (pr c ++ spc () ++ keyword "at" ++ str" +")
     | AllOccurrences ->
       pr c
     | NoOccurrences ->


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

This is the big higher-order matching update commit of unifall, which extends the capabilities of evar_conv_x and second_order_matching to be configurable by flags and occurrence selection strategy. It's not called much at this point, only by abstract_list_all_with_dependencies and when calling `solve_unif_constraints_with_heuristics` with an explicit `with_ho:true` argument.

<!-- Keep what applies -->
**Kind:**  feature

Mainly the internally used interfaces of evarconv changed and code in pretyping was adapted. The the_conv_x and the_conv_x_leq functions have been deprecated in favor of unify_delay/unify_leq_delay and the complete unify function. The passing of flags changed as well to support parameterizing evar_conv with transparent states, frozen_evars and flags for betaiota reduction and canonical structure resolution.
