### PR TITLE
[refine] obey the use_unification_heuristics flag

### DIFF
--- a/plugins/ltac/extratactics.ml4
+++ b/plugins/ltac/extratactics.ml4
@@ -293,7 +293,7 @@ open Vars
 
 let constr_flags () = {
   Pretyping.use_typeclasses = true;
-  Pretyping.solve_unification_constraints = true;
+  Pretyping.solve_unification_constraints = Pfedit.use_unification_heuristics ();
   Pretyping.use_hook = Pfedit.solve_by_implicit_tactic ();
   Pretyping.fail_evar = false;
   Pretyping.expand_evars = true }

--- a/proofs/pfedit.mli
+++ b/proofs/pfedit.mli
@@ -85,6 +85,9 @@ val solve : ?with_end_tac:unit Proofview.tactic ->
 
 val by : unit Proofview.tactic -> bool
 
+(** Option telling if unification heuristics should be used. *)
+val use_unification_heuristics : unit -> bool
+
 (** [instantiate_nth_evar_com n c] instantiate the [n]th undefined
    existential variable of the current focused proof by [c] or raises a
    UserError if no proof is focused or if there is no such [n]th


### PR DESCRIPTION
Refine now respects this existing flag so users can control when and when not to resolve unification constraints heuristically. Observationally this does not change anything yet as the heuristics used during typechecking (i.e. evaraconv) are the same as the ones used by solve_remaining, and we silently ignore during typechecking of the term by refine if the constraints can be solved or not, but still try it even if the flag is off.

**Kind:** enhancement