### PR TITLE
[tactics] Refine test for unresolved evars: not reachable from initial evars

### DIFF
--- a/doc/changelog/02-specification-language/07825-rechable-from-evars.rst
+++ b/doc/changelog/02-specification-language/07825-rechable-from-evars.rst
@@ -1,0 +1,9 @@
+- **Changed:**
+  In :tacn:`refine`, new existential variables unified with existing ones are no
+  longer considered as fresh. The behavior of :tacn:`simple refine` no longer depends on
+  the orientation of evar-evar unification problems, and new existential variables
+  are always turned into (unshelved) goals. This can break compatibility in
+  some cases (`#7825 <https://github.com/coq/coq/pull/7825>`_, by Matthieu
+  Sozeau, with help from Maxime Dénès, review by Pierre-Marie Pédrot and
+  Enrico Tassi, fixes `#4095 <https://github.com/coq/coq/issues/4095>`_ and
+  `#4413 <https://github.com/coq/coq/issues/4413>`_).

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -516,12 +516,7 @@ let restrict_evar evd evk filter ?src candidates =
   let candidates = Option.map (filter_effective_candidates evd evar_info filter) candidates in
   match candidates with
   | Some [] -> raise (ClearDependencyError (*FIXME*)(Id.of_string "blah", (NoCandidatesLeft evk), None))
-  | _ ->
-     let evd, evk' = Evd.restrict evk filter ?candidates ?src evd in
-     (* Mark new evar as future goal, removing previous one,
-        circumventing Proofview.advance but making Proof.run_tactic catch these. *)
-     let evd = Evd.remove_future_goal evd evk in
-     (Evd.declare_future_goal evk' evd, evk')
+  | _ -> Evd.restrict evk filter ?candidates ?src evd
 
 let rec check_and_clear_in_constr env evdref err ids global c =
   (* returns a new constr where all the evars have been 'cleaned'
@@ -703,9 +698,21 @@ let rec advance sigma evk =
   match evi.evar_body with
   | Evar_empty -> Some evk
   | Evar_defined v ->
-      match is_restricted_evar sigma evk with
+      match is_aliased_evar sigma evk with
       | Some evk -> advance sigma evk
       | None -> None
+
+let reachable_from_evars sigma evars =
+  let aliased = Evd.get_aliased_evars sigma in
+  let rec search evk visited =
+    if Evar.Set.mem evk visited then visited
+    else
+      let visited = Evar.Set.add evk visited in
+      match Evar.Map.find evk aliased with
+      | evk' -> search evk' visited
+      | exception Not_found -> visited
+  in
+  Evar.Set.fold (fun evk visited -> search evk visited) evars Evar.Set.empty
 
 (** The following functions return the set of undefined evars
     contained in the object, the defined evars being traversed.

--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -112,6 +112,10 @@ val gather_dependent_evars : evar_map -> Evar.t list -> (Evar.Set.t option) Evar
     solved. *)
 val advance : evar_map -> Evar.t -> Evar.t option
 
+(** [reachable_from_evars sigma seeds] computes the descendents of
+    evars in [seeds] by restriction or evar-evar unifications in [sigma]. *)
+val reachable_from_evars : evar_map -> Evar.Set.t -> Evar.Set.t
+
 (** The following functions return the set of undefined evars
     contained in the object, the defined evars being traversed.
     This is roughly a combination of the previous functions and
@@ -234,8 +238,8 @@ exception ClearDependencyError of Id.t * clear_dependency_error * GlobRef.t opti
 
 (** Restrict an undefined evar according to a (sub)filter and candidates.
     The evar will be defined if there is only one candidate left,
-@raise ClearDependencyError NoCandidatesLeft if the filter turns the candidates
-  into an empty list. *)
+    @raise ClearDependencyError NoCandidatesLeft if the filter turns the candidates
+    into an empty list. *)
 
 val restrict_evar : evar_map -> Evar.t -> Filter.t ->
   ?src:Evar_kinds.t Loc.located -> constr list option -> evar_map * Evar.t

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -284,8 +284,11 @@ val restrict : Evar.t-> Filter.t -> ?candidates:econstr list ->
     possibly limiting the instances to a set of candidates (candidates
     are filtered according to the filter) *)
 
-val is_restricted_evar : evar_map -> Evar.t -> Evar.t option
-(** Tell if an evar comes from restriction of another evar, and if yes, which *)
+val get_aliased_evars : evar_map -> Evar.t Evar.Map.t
+(** The map of aliased evars *)
+
+val is_aliased_evar : evar_map -> Evar.t -> Evar.t option
+(** Tell if an evar has been aliased to another evar, and if yes, which *)
 
 val set_typeclass_evars : evar_map -> Evar.Set.t -> evar_map
 (** Mark the given set of evars as available for resolution.
@@ -387,7 +390,6 @@ val push_future_goals : evar_map -> evar_map
 val pop_future_goals : evar_map -> FutureGoals.t * evar_map
 
 val fold_future_goals : (evar_map -> Evar.t -> evar_map) -> evar_map -> evar_map
-
 
 val remove_future_goal : evar_map -> Evar.t -> evar_map
 

--- a/engine/proofview_monad.ml
+++ b/engine/proofview_monad.ml
@@ -202,6 +202,11 @@ module type State = sig
   val modify : (t->t) -> unit Logical.t
 end
 
+module type Reader = sig
+  type t
+  val get : t Logical.t
+end
+
 module type Writer = sig
   type t
   val put : t -> unit Logical.t

--- a/engine/proofview_monad.mli
+++ b/engine/proofview_monad.mli
@@ -79,7 +79,7 @@ val with_empty_state : goal -> goal_with_state
 val map_goal_with_state : (goal -> goal) -> goal_with_state -> goal_with_state
 
 (** Type of proof views: current [evar_map] together with the list of
-    focused goals. *)
+    focused goals, locally shelved goals and globally shelved goals. *)
 type proofview = {
   solution : Evd.evar_map;
   comb : goal_with_state list;
@@ -114,6 +114,10 @@ module type State = sig
   val get : t Logical.t
   val set : t -> unit Logical.t
   val modify : (t->t) -> unit Logical.t
+end
+module type Reader = sig
+  type t
+  val get : t Logical.t
 end
 
 module type Writer = sig

--- a/engine/termops.ml
+++ b/engine/termops.ml
@@ -310,15 +310,15 @@ let pr_evar_map_gen with_univs pr_evars env sigma =
 
 let pr_evar_list env sigma l =
   let open Evd in
-  let pr_restrict ev =
-    match is_restricted_evar sigma ev with
+  let pr_alias ev =
+    match is_aliased_evar sigma ev with
     | None -> mt ()
-    | Some ev' -> str " (restricted to " ++ Evar.print ev' ++ str ")"
+    | Some ev' -> str " (aliased to " ++ Evar.print ev' ++ str ")"
   in
   let pr (ev, evi) =
     h 0 (Evar.print ev ++
       str "==" ++ pr_evar_info env sigma evi ++
-      pr_restrict ev ++
+      pr_alias ev ++
       (if evi.evar_body == Evar_empty
        then str " {" ++ pr_existential_key sigma ev ++ str "}"
        else mt ()))

--- a/proofs/refine.ml
+++ b/proofs/refine.ml
@@ -75,6 +75,8 @@ let generic_refine ~typecheck f gl =
   let future_goals, sigma = Evd.pop_future_goals sigma in
   (* Select the goals *)
   let future_goals = Evd.FutureGoals.map_filter (Proofview.Unsafe.advance sigma) future_goals in
+  let shelf = Evd.shelf sigma in
+  let future_goals = Evd.FutureGoals.filter (fun ev -> not @@ List.mem ev shelf) future_goals in
   (* Proceed to the refinement *)
   let sigma = match Proofview.Unsafe.advance sigma self with
   | None ->

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -5184,14 +5184,14 @@ end
 
 (** Tacticals defined directly in term of Proofview *)
 module New = struct
-  open Genredexpr
-  open Locus
-
   let reduce_after_refine =
-    reduce
-      (Lazy {rBeta=true;rMatch=true;rFix=true;rCofix=true;
-             rZeta=false;rDelta=false;rConst=[]})
-      {onhyps = Some []; concl_occs = AllOccurrences }
+    (* For backward compatibility reasons, we do not contract let-ins, but we unfold them. *)
+    let redfun env t =
+      let open CClosure in
+      let flags = RedFlags.red_add_transparent allnolet TransparentState.empty in
+      clos_norm_flags flags env t
+    in
+    reduct_in_concl ~check:false (redfun,DEFAULTcast)
 
   let refine ~typecheck c =
     Refine.refine ~typecheck c <*>

--- a/test-suite/bugs/closed/bug_4413.v
+++ b/test-suite/bugs/closed/bug_4413.v
@@ -1,0 +1,8 @@
+
+(* Regression wrt v8.4 related to the change of order of resolution of evar-evar unification problems. *)
+Goal exists x, x=1 -> True.
+eexists. intro H.
+pose proof (f_equal (fun k => k) H).
+Undo.
+pose (@f_equal _ _ S _ _ H).
+Abort.

--- a/test-suite/bugs/closed/bug_7825.v
+++ b/test-suite/bugs/closed/bug_7825.v
@@ -1,0 +1,50 @@
+Record T (x : nat) := { t : x = x }.
+
+Goal exists x, T x.
+  refine (ex_intro _ _ _).
+  Show Existentials.
+  simple refine {| t := _ |}.
+  reflexivity.
+  Unshelve. exact 0.
+Qed.
+
+(** Fine if the new evar is defined as the originally shelved evar:  we do nothing.
+  In the other direction we promote the non-shelved new goal to a shelved one:
+  shelved status has priority over goal status. *)
+
+Goal forall a : nat,  exists x, T x.
+   evar (x : nat). subst x. Show Existentials.
+   intros a. simple refine (ex_intro ?[x0] _ _). shelve. simpl.
+   (** Here ?x := ?x0 which is shelved, so ?x becomes shelved even if it would
+   not be by default (refine ?x and _ produce non-shelved evars by default)*)
+   simple refine (Build_T ?x _).
+   reflexivity.
+   Unshelve. exact 0.
+Qed.
+
+Goal { A : _ & { P : _ & @sigT A P } }.
+  epose _ as A;
+  epose _ as P;
+  exists A, P.
+  (* Regardless of which evars are in the goals vs the hypotheses,
+     [simple refine (existT _ _ _)] should leave over two goals.  This
+     should be true even when chained with epose. *)
+  assert_succeeds (simple refine (existT _ _ _); let n := numgoals in guard n = 2);
+  subst P;
+  assert_succeeds (simple refine (existT _ _ _); let n := numgoals in guard n = 2);
+  subst A;
+  assert_succeeds (simple refine (existT _ _ _); let n := numgoals in guard n = 2).
+  (* fails *)
+Abort.
+
+Goal { A : _ & { P : _ & @sigT A P } }.
+  epose _ as A;
+  epose _ as P;
+  exists A, P; (* In this example we chain everything *)
+  assert_succeeds (simple refine (existT _ _ _); let n := numgoals in guard n = 2);
+  subst P;
+  assert_succeeds (simple refine (existT _ _ _); let n := numgoals in guard n = 2);
+  subst A;
+  assert_succeeds (simple refine (existT _ _ _); let n := numgoals in guard n = 2).
+  (* fails *)
+Abort.

--- a/vernac/comFixpoint.ml
+++ b/vernac/comFixpoint.ml
@@ -247,6 +247,7 @@ let interp_fixpoint ?(check_recursivity=true) ~cofix l :
     (EConstr.rel_context * Impargs.manual_implicits * int option) list) =
   let (env,_,pl,evd),fix,info = interp_recursive ~program_mode:false ~cofix l in
   if check_recursivity then check_recursive true env evd fix;
+  let evd = Pretyping.(solve_remaining_evars all_no_fail_flags env evd) in
   let uctx,fix = ground_fixpoint env evd fix in
   (fix,pl,uctx,info)
 


### PR DESCRIPTION
The test is refined to handle aliases: i.e. undefined evars coming from
restrictions and evar-evar unifications with an initial evar are not
considered fresh unresolved evars. To check this, we generalize
the restricted_evars map of the evar_map into an aliased_evars map,
which is extended in Evd.restrict and Evd.define_with_evar cases.
This is now on top of PR #8741. I basically implements the proposal
in PR #370 to have a test of unresolved evars independent of the evar-evar
orientation order.

This allows [apply] to refine an evar with a new one if it results from a
[clear] request or an evar-evar solution only, otherwise the new evar was
considered fresh and an error was incorrectly raised.

**Kind:** bug fix
- Fixes #4413
- Fixes #4095
- Fixes #4631
- [ ] Added test-suite files 