### PR TITLE
Fix #7836: tools/inferior-coq.el uses next-line instead of forward-line.

### DIFF
--- a/tools/inferior-coq.el
+++ b/tools/inferior-coq.el
@@ -265,7 +265,7 @@ With argument, position cursor at end of buffer."
     (let ((end (point)))
       (beginning-of-line)
       (coq-send-region (point) end)))
-  (next-line 1))
+  (forward-line 1))
 
 (defun coq-send-abort ()
   "Send the command \"Abort.\" to the inferior Coq process."


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** bug fix

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #7836