### PR TITLE
Remove Elpi from Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,11 +82,6 @@ matrix:
       - TEST_TARGET="ci-coquelicot"
     - if: NOT (type = pull_request)
       env:
-      - TEST_TARGET="ci-elpi" EXTRA_OPAM="elpi"
-      # ppx_tools_versioned requires a specific version findlib
-      - FINDLIB_VER=""
-    - if: NOT (type = pull_request)
-      env:
       - TEST_TARGET="ci-equations"
     - if: NOT (type = pull_request)
       env:


### PR DESCRIPTION
Elpi is currently failing on Travis but not on GitLab CI, likely because of the recent dependency update that was only done in the Docker image.

Rather than trying to keep the version of dependencies in sync with GitLab CI, we choose to remove Elpi from Travis. Travis tests are already far from complete compared to GitLab CI so this doesn't do harm.