### PR TITLE
Fix #7615: Functor inlining drops universe substitution.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@ Changes from 8.8.0 to 8.8.1
 Kernel
 
 - Fix a soundness bug with CoFixpoints and VM/native_compute (see #7333).
+- Fix a critical bug with inlining of polymorphic constants (#7615).
 
 Notations
 

--- a/checker/declarations.ml
+++ b/checker/declarations.ml
@@ -196,7 +196,7 @@ let subst_con0 sub con u =
   let dup con = con, Const (con, u) in
   let side,con',resolve = gen_subst_mp rebuild_con sub mp1 mp2 in
   match constant_of_delta_with_inline resolve con' with
-    | Some t -> con', t
+    | Some t -> con', subst_instance_constr u t
     | None ->
       let con'' = match side with
 	| User -> constant_of_delta resolve con'

--- a/kernel/mod_subst.ml
+++ b/kernel/mod_subst.ml
@@ -302,7 +302,7 @@ let subst_con0 sub (cst,u) =
   match search_delta_inline resolve knu knc with
     | Some t ->
       (* In case of inlining, discard the canonical part (cf #2608) *)
-      Constant.make1 knu, t
+      Constant.make1 knu, Vars.subst_instance_constr u t
     | None ->
       let knc' =
         progress (kn_of_delta resolve) (if user then knu else knc) ~orelse:knc

--- a/kernel/modops.ml
+++ b/kernel/modops.ml
@@ -403,7 +403,7 @@ let inline_delta_resolver env inl mp mbid mtb delta =
 	    | Undef _ | OpaqueDef _ -> l
 	    | Def body ->
 	      let constr = Mod_subst.force_constr body in
-	      add_inline_delta_resolver kn (lev, Some constr) l
+              add_inline_delta_resolver kn (lev, Some constr) l
 	with Not_found ->
 	  error_no_such_label_sub (Constant.label con)
 	    (ModPath.to_string (Constant.modpath con))

--- a/test-suite/bugs/closed/7615.v
+++ b/test-suite/bugs/closed/7615.v
@@ -1,0 +1,19 @@
+Set Universe Polymorphism.
+
+Module Type S.
+Parameter Inline T@{i} : Type@{i+1}.
+End S.
+
+Module F (X : S).
+Definition X@{j i} : Type@{j} := X.T@{i}.
+End F.
+
+Module M.
+Definition T@{i} := Type@{i}.
+End M.
+
+Module N := F(M).
+
+Require Import Hurkens.
+
+Fail Definition eqU@{i j} : @eq Type@{j} N.X@{i Set} Type@{i} := eq_refl.


### PR DESCRIPTION
Backport of #7616.