### PR TITLE
Fix #7829: Spurious documentation failures.

### DIFF
--- a/doc/sphinx/proof-engine/ssreflect-proof-language.rst
+++ b/doc/sphinx/proof-engine/ssreflect-proof-language.rst
@@ -3657,7 +3657,8 @@ selective rewriting, blocking on the fly the reduction in the term ``t``.
 
   .. coqtop:: reset
 
-     From Coq Require Import ssreflect ssrfun ssrbool List.
+     From Coq Require Import ssreflect ssrfun ssrbool.
+     From Coq Require Import List.
      Set Implicit Arguments.
      Unset Strict Implicit.
      Unset Printing Implicit Defensive.


### PR DESCRIPTION
We split a Require Import in two to avoid reaching the timeout.

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** infrastructure.


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Hopefully enough to fix #7829.