### PR TITLE
Implementation of mutual records in the higher strata

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,10 @@
 Changes from 8.8.2 to 8.9+beta1
 ===============================
 
+Kernel
+
+- Mutually defined records are now supported.
+
 Tactics
 
 - Added toplevel goal selector ! which expects a single focused goal.

--- a/doc/sphinx/language/gallina-extensions.rst
+++ b/doc/sphinx/language/gallina-extensions.rst
@@ -23,8 +23,9 @@ expressions. In this sense, the :cmd:`Record` construction allows defining
 .. _record_grammar:
 
   .. productionlist:: `sentence`
-     record         : `record_keyword` `ident` [ `binders` ] [: `sort` ] := [ `ident` ] { [ `field` ; … ; `field` ] }.
+     record         : `record_keyword` `record_body` with … with `record_body`
      record_keyword : Record | Inductive | CoInductive
+     record_body    : `ident` [ `binders` ] [: `sort` ] := [ `ident` ] { [ `field` ; … ; `field` ] }.
      field          : `ident` [ `binders` ] : `type` [ where `notation` ]
                     : | `ident` [ `binders` ] [: `type` ] := `term`
 
@@ -167,12 +168,13 @@ and the syntax `term.(@qualid` |term_1| |term_n| `)` to `@qualid` |term_1| `…`
 In each case, `term` is the object projected and the
 other arguments are the parameters of the inductive type.
 
+
 .. note:: Records defined with the ``Record`` keyword are not allowed to be
    recursive (references to the record's name in the type of its field
    raises an  error). To define recursive records, one can use the ``Inductive``
    and ``CoInductive`` keywords, resulting in an inductive or co-inductive record.
-   A *caveat*, however, is that records cannot appear in mutually inductive
-   (or co-inductive) definitions.
+   Definition of mutal inductive or co-inductive records are also allowed, as long
+   as all of the types in the block are records.
 
 .. note:: Induction schemes are automatically generated for inductive records.
    Automatic generation of induction schemes for non-recursive records

--- a/test-suite/success/mutual_record.v
+++ b/test-suite/success/mutual_record.v
@@ -1,0 +1,57 @@
+Module M0.
+
+Inductive foo (A : Type) := Foo {
+  foo0 : option (bar A);
+  foo1 : nat;
+  foo2 := foo1 = 0;
+  foo3 : foo2;
+}
+
+with bar (A : Type) := Bar {
+  bar0 : A;
+  bar1 := 0;
+  bar2 : bar1 = 0;
+  bar3 : nat -> foo A;
+}.
+
+End M0.
+
+Module M1.
+
+Set Primitive Projections.
+
+Inductive foo (A : Type) := Foo {
+  foo0 : option (bar A);
+  foo1 : nat;
+  foo2 := foo1 = 0;
+  foo3 : foo2;
+}
+
+with bar (A : Type) := Bar {
+  bar0 : A;
+  bar1 := 0;
+  bar2 : bar1 = 0;
+  bar3 : nat -> foo A;
+}.
+
+End M1.
+
+Module M2.
+
+Set Primitive Projections.
+
+CoInductive foo (A : Type) := Foo {
+  foo0 : option (bar A);
+  foo1 : nat;
+  foo2 := foo1 = 0;
+  foo3 : foo2;
+}
+
+with bar (A : Type) := Bar {
+  bar0 : A;
+  bar1 := 0;
+  bar2 : bar1 = 0;
+  bar3 : nat -> foo A;
+}.
+
+End M2.

--- a/test-suite/success/vm_records.v
+++ b/test-suite/success/vm_records.v
@@ -1,0 +1,40 @@
+Set Primitive Projections.
+
+Module M.
+
+CoInductive foo := Foo {
+  foo0 : foo;
+  foo1 : bar;
+}
+with bar := Bar {
+  bar0 : foo;
+  bar1 : bar;
+}.
+
+CoFixpoint f : foo := Foo f g
+with g : bar := Bar f g.
+
+Check (@eq_refl _ g.(bar0) <: f.(foo0).(foo0) = g.(bar0)).
+Check (@eq_refl _ g <: g.(bar1).(bar0).(foo1) = g).
+
+End M.
+
+Module N.
+
+Inductive foo := Foo {
+  foo0 : option foo;
+  foo1 : list bar;
+}
+with bar := Bar {
+  bar0 : option bar;
+  bar1 : list foo;
+}.
+
+Definition f_0 := Foo None nil.
+Definition g_0 := Bar None nil.
+
+Definition f := Foo (Some f_0) (cons g_0 nil).
+
+Check (@eq_refl _ f.(foo1) <: f.(foo1) = cons g_0 nil).
+
+End N.

--- a/vernac/record.mli
+++ b/vernac/record.mli
@@ -26,9 +26,14 @@ val declare_projections :
     (Name.t * bool) list * Constant.t option list
 
 val definition_structure :
-  inductive_kind * Decl_kinds.cumulative_inductive_flag * Decl_kinds.polymorphic *
-  Declarations.recursivity_kind * ident_decl with_coercion * local_binder_expr list *
+  inductive_kind -> Decl_kinds.cumulative_inductive_flag -> Decl_kinds.polymorphic ->
+  Declarations.recursivity_kind ->
+  (coercion_flag *
+  Names.lident *
+  universe_decl_expr option *
+  local_binder_expr list *
   (local_decl_expr with_instance with_priority with_notation) list *
-  Id.t * constr_expr option -> GlobRef.t
+  Id.t * constr_expr option) list ->
+  GlobRef.t list
 
 val declare_existing_class : GlobRef.t -> unit


### PR DESCRIPTION
Depends on #7750.

Fixes #7183.

This is the companion PR of #7750 that adds the handling of mutual record types to the higher layers, namely the horrendous files in `vernac` that are doing literally *n'importe quoi* due to the accumulation of minute changes across the span of several years. In retrospect adapting the kernel was easier. This allowed (or actually required) to clean up up this mess thoroughly. So in addition to a nice user-facing feature, we also have a probably slightly less buggy code now.

- [x] Added / updated test-suite
- [x] Entry added in CHANGES.
