### PR TITLE
Fix #5719: Uncaught exception Invalid_argument.

### DIFF
--- a/pretyping/cases.ml
+++ b/pretyping/cases.ml
@@ -1699,7 +1699,8 @@ let abstract_tycon ?loc env evdref subst tycon extenv t =
 	let ty = get_type_of env !evdref t in
 	  Evarutil.evd_comb1 (refresh_universes (Some false) env) evdref ty
       in
-      let ty = lift (-k) (aux x ty) in
+      let dummy_subst = List.init k (fun _ -> mkProp) in
+      let ty = substl dummy_subst (aux x ty) in
       let depvl = free_rels !evdref ty in
       let inst =
 	List.map_i

--- a/test-suite/bugs/closed/5719.v
+++ b/test-suite/bugs/closed/5719.v
@@ -1,0 +1,9 @@
+Axiom cons_data_one :
+  forall (Aone : unit -> Set) (i : unit) (a : Aone i), nat.
+Axiom P : nat -> Prop.
+Axiom children_data_rect3 : forall {Aone : unit -> Set}
+  (cons_one_case : forall (i : unit) (b : Aone i),
+     nat -> nat -> P (cons_data_one Aone i b)),
+  P 0.
+Fail Definition decide_children_equality IH := children_data_rect3
+  (fun _ '(existT _ _ _) => match IH with tt => _ end).


### PR DESCRIPTION
It seems that lifting a term with a negative index is not equivalent to strengthening it by applying to a dummy substitution. This looks suspicious at best.
