### PR TITLE
Revert "Add a note about [ci skip] in CI README."

### DIFF
--- a/dev/ci/README.md
+++ b/dev/ci/README.md
@@ -86,11 +86,6 @@ We are currently running tests on the following platforms:
 - AppVeyor is used to test the compilation of Coq and run the test-suite on
   Windows.
 
-GitLab CI and Travis CI and AppVeyor support putting `[ci skip]` in a commit
-message to bypass CI. Do not use this unless your commit only changes files
-that are not compiled (e.g. Markdown files like this one, or files under
-[`.github/`](../../.github/)).
-
 You can anticipate the results of most of these tests prior to submitting your
 PR by running GitLab CI on your private branches. To do so follow these steps:
 


### PR DESCRIPTION
This reverts commit 3a44a190a7f5d057b6a4bcb50124b42d83f3d03d.

In #7783, @maximedenes made me realize that we should never encourage skipping CI because it's very hard to predict when something will have no effect. (Just moving markdown files around can have some effect.)

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** documentation