### PR TITLE
Ad hoc fix for #5696, #7903 (ltac subterms and open subterms in notations).

### DIFF
--- a/test-suite/bugs/closed/5696.v
+++ b/test-suite/bugs/closed/5696.v
@@ -1,0 +1,5 @@
+(* Slightly improving interpretation of Ltac subterms in notations *)
+
+Notation "'var2' x .. y = z ; e" := (ltac:(exact z), (fun x => .. (fun y => e)
+..)) (at level 200, x binder, y binder, e at level 220).
+Check (var2 a = 1; a).

--- a/test-suite/bugs/closed/7903.v
+++ b/test-suite/bugs/closed/7903.v
@@ -1,0 +1,4 @@
+(* Slightly improving interpretation of Ltac subterms in notations *)
+
+Notation bar x f := (let z := ltac:(exact 1) in (fun x : nat => f)).
+Check bar x (x + x).


### PR DESCRIPTION
We fix the issue by removing terms of the substitutions which have free variables and are thus not interpretable in the context of the `ltac:` subterm.

This remains rather ad hoc, since, in an expression `Notation f x := ltac:(foo)`, we interpret `x` at calling time of `foo` rather than at use time of `x` in `foo`, even if `x` is not necessary.

Independently, we could also imagine that binders in the ltac expressions are then interpreted but that would start to be (very) complicated.

Note that this will presumably "fix" ltac2 quotations at the same time.

**Kind:** bug fix

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Closes #5696. Closes #7903.

- [x] Added / updated test-suite
