### PR TITLE
Fix 'unbound variable' issue on Windows packaging jobs.

### DIFF
--- a/dev/build/windows/makecoq_mingw.sh
+++ b/dev/build/windows/makecoq_mingw.sh
@@ -1437,12 +1437,16 @@ function make_addon_equations {
 }
 
 function make_addons {
-  if [ -n "${GITLAB_CI}" ]; then
+  if [ -n "$GITLAB_CI" ]; then
     export CI_BRANCH="$CI_COMMIT_REF_NAME"
-    if [[ ${CI_BRANCH#pr-} =~ ^[0-9]*$ ]]
-    then
+    if [[ ${CI_BRANCH#pr-} =~ ^[0-9]*$ ]]; then
       export CI_PULL_REQUEST="${CI_BRANCH#pr-}"
+    else
+      export CI_PULL_REQUEST=""
     fi
+  else
+    export CI_BRANCH=""
+    export CI_PULL_REQUEST=""
   fi
   . /build/ci-basic-overlay.sh
   for overlay in /build/user-overlays/*.sh; do


### PR DESCRIPTION
Since #7831 was merged, the Windows packaging jobs are failing with:
```
/build/user-overlays/00669-maximedenes-ssr-merge.sh: line 3: CI_PULL_REQUEST: unbound variable
ERROR MakeCoq_MinGW.bat failed
ERROR dev/ci/gitlab.bat failed
```
This was hard to anticipate given that it works well on pull requests.
The fix I'm proposing is to remove `set -o nounset` which is causing the failure. I'm not expecting this proposed fix to get approved given that it was put there for a reason, but it's hard to reason about our shell scripts if we don't use consistent programming styles in the whole code base (and indeed, we frequently assume that variables can be unset, that's why we put them in quotes to compare them to their expected value...).