### PR TITLE
CoqIDE scrolls the proof buffer down to the first goal.

### DIFF
--- a/ide/wg_ProofView.ml
+++ b/ide/wg_ProofView.ml
@@ -103,7 +103,7 @@ let mode_tactic sel_cb (proof : #GText.view_skel) goals ~unfoc_goals hints = mat
           else []
         in
         proof#buffer#insert (goal_str ~shownum:true 1 goals_cnt);
-        insert_xml proof#buffer (Richpp.richpp_of_pp width cur_goal);
+        insert_xml ~tags:[Tags.Proof.goal] proof#buffer (Richpp.richpp_of_pp width cur_goal);
         proof#buffer#insert "\n"
       in
       (* Insert remaining goals (no hypotheses) *)
@@ -128,7 +128,7 @@ let mode_tactic sel_cb (proof : #GText.view_skel) goals ~unfoc_goals hints = mat
       ignore(proof#buffer#place_cursor
                ~where:(proof#buffer#end_iter#backward_to_tag_toggle
                          (Some Tags.Proof.goal)));
-      ignore(proof#scroll_to_mark ~use_align:true ~yalign:0.95 `INSERT)
+      ignore(proof#scroll_to_mark `INSERT)
 
 let rec flatten = function
 | [] -> []


### PR DESCRIPTION
**Kind:** feature.
Closes #7931.

The proof buffer in CoqIDE now focuses on the first goal as requested (I actually found myself to be annoyed by this a few times).
The change is trivial (and I think the insertion of the tag was actually forgotten, as the focusing part was already there), but I have no opinion on the precise design decision.

By that I mean that this PR makes it so that the last line displayed in the proof buffer is the last line of the first goal. I could make it so that it is the next line to give a bit of breathing room for instance. I don't know what is best.
