### PR TITLE
Add better error message on let destructuring

### DIFF
--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -902,9 +902,13 @@ let rec pretype k0 resolve_tc (tycon : type_constraint) (env : ExtraEnv.t) evdre
       user_err ?loc  (str "Destructing let is only for inductive types" ++
 	str " with one constructor.");
     let cs = cstrs.(0) in
+    let valname = Names.Name.print na in
+    let indtype = (fst (dest_ind_family indf)) in
+    let typename = Printer.pr_pinductive env.ExtraEnv.env indtype  in
+    let varnames = str "VARNAMES" in
     if not (Int.equal (List.length nal) cs.cs_nargs) then
-      user_err ?loc:loc (str "Destructing let on this type expects " ++ 
-	int cs.cs_nargs ++ str " variables.");
+      user_err ?loc:loc (str "Destructing let on value " ++ valname ++ str "(of type " ++ typename ++ str ") expects " ++
+        int cs.cs_nargs ++ str " variables:" ++ varnames ++ str ".");
     let fsign, record = 
       let set_name na d = set_name na (map_rel_decl EConstr.of_constr d) in
       match get_projections env.ExtraEnv.env indf with

--- a/test-suite/output/let_error_message.out
+++ b/test-suite/output/let_error_message.out
@@ -1,0 +1,1 @@
+TOFIX: add stuff here

--- a/test-suite/output/let_error_message.v
+++ b/test-suite/output/let_error_message.v
@@ -1,0 +1,6 @@
+
+Definition point2d : Type := nat * nat.
+
+(** Error: Destructing let on this type expects 2 variables *)
+Definition abs (p: point2d): nat :=
+  let (x, y, z) := p in x * x + y * y + z * z.


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:**  / feature / bug fix.

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #7833 

##### Explanation


```coq
Definition point2d : Type := nat * nat.

(** Error: Destructing let on this type expects 2 variables *)
Definition abs (p: point2d): nat :=
  let (x, y, z) := p in x * x + y * y + z * z.
```

Extend error message so it talks about p and how to destructure it.
Something like, destructing let of "p" (of type "point2d") expects 2 variables.


<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [ ] Added / updated test-suite

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/coq/coq/7943)
<!-- Reviewable:end -->
