### PR TITLE
Syntax for naming an existential variable

### DIFF
--- a/doc/sphinx/language/gallina-extensions.rst
+++ b/doc/sphinx/language/gallina-extensions.rst
@@ -2228,7 +2228,7 @@ existential variable used in the same context as its context of definition is wr
    Check (fun x y => _) 0 1.
 
 Existential variables can be named by the user upon creation using
-the syntax ``?``\ `ident`. This is useful when the existential
+the syntax ``?``\ [`ident`]. This is useful when the existential
 variable needs to be explicitly handled later in the script (e.g.
 with a named-goal selector, see :ref:`goal-selectors`).
 

--- a/doc/sphinx/language/gallina-extensions.rst
+++ b/doc/sphinx/language/gallina-extensions.rst
@@ -2228,7 +2228,7 @@ existential variable used in the same context as its context of definition is wr
    Check (fun x y => _) 0 1.
 
 Existential variables can be named by the user upon creation using
-the syntax ``?``\ [`ident`]. This is useful when the existential
+the syntax :n:`?[@ident]`. This is useful when the existential
 variable needs to be explicitly handled later in the script (e.g.
 with a named-goal selector, see :ref:`goal-selectors`).
 


### PR DESCRIPTION
I knew this feature existed but I did not remember the syntax and I could not find the right syntax in the manual (hopefully it was mentionned recently in the mailing list)

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** documentation