### PR TITLE
[build] Remove target binary before copy.

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -390,9 +390,10 @@ grammar/%.cmi: grammar/%.mli
 coqbinaries: $(TOPBIN) $(CHICKEN) $(CSDPCERT) $(FAKEIDE)
 coqbyte: $(TOPBYTE) $(CHICKENBYTE)
 
-# Special rule for coqtop
+# Special rule for coqtop, we imitate `ocamlopt` can delete the target
+# to avoid #7666
 $(COQTOPEXE): $(TOPBIN:.opt=.$(BEST))
-	cp $< $@
+	rm -f $@ && cp $< $@
 
 bin/%.opt$(EXE): topbin/%_bin.ml $(LINKCMX) $(LIBCOQRUN)
 	$(SHOW)'COQMKTOP -o $@'


### PR DESCRIPTION
Fixes #7666. Due to shared mapping of executables Linux doesn't allow
to overwrite binaries that are running; we do as `ocamlopt` and delete
the target file before copy.
