### PR TITLE
[api] Fix wrong deprecation warning (#7915)

### DIFF
--- a/vernac/misctypes.ml
+++ b/vernac/misctypes.ml
@@ -17,10 +17,10 @@ type 'a or_by_notation = 'a Constrexpr.or_by_notation
 [@@ocaml.deprecated "use [Constrexpr.or_by_notation]"]
 
 type intro_pattern_naming_expr = Namegen.intro_pattern_naming_expr =
-  | IntroIdentifier of Id.t [@ocaml.deprecated "Use version in [Evarutil]"]
-  | IntroFresh of Id.t [@ocaml.deprecated "Use version in [Evarutil]"]
-  | IntroAnonymous [@ocaml.deprecated "Use version in [Evarutil]"]
-[@@ocaml.deprecated "use [Evarutil.intro_pattern_naming_expr]"]
+  | IntroIdentifier of Id.t [@ocaml.deprecated "Use version in [Namegen]"]
+  | IntroFresh of Id.t [@ocaml.deprecated "Use version in [Namegen]"]
+  | IntroAnonymous [@ocaml.deprecated "Use version in [Namegen]"]
+[@@ocaml.deprecated "use [Namegen.intro_pattern_naming_expr]"]
 
 type 'a or_var = 'a Locus.or_var =
   | ArgArg of 'a [@ocaml.deprecated "Use version in [Locus]"]


### PR DESCRIPTION
Fixes: #7915.

Due to a change in the original misctypes removal PR, the deprecation
notice went out of sync.
