### PR TITLE
[ssr] let the user override intro patterns

### DIFF
--- a/plugins/ltac/g_ltac.ml4
+++ b/plugins/ltac/g_ltac.ml4
@@ -342,9 +342,11 @@ GEXTEND Gram
           Vernacexpr.VernacProof (ta,Some l) ] ]
   ;
   hint:
-    [ [ IDENT "Extern"; n = natural; c = OPT Constr.constr_pattern ; "=>";
+    [ [ IDENT "Extern";
+        args = LIST0 [ v = IDENT -> Id.of_string v ];
+        n = natural; c = OPT Constr.constr_pattern ; "=>";
         tac = Pltac.tactic ->
-          Vernacexpr.HintsExtern (n,c, in_tac tac) ] ]
+          Vernacexpr.HintsExtern (args,n,c, in_tac tac) ] ]
   ;
   operconstr: LEVEL "0"
     [ [ IDENT "ltac"; ":"; "("; tac = Pltac.tactic_expr; ")" ->

--- a/plugins/ltac/rewrite.ml
+++ b/plugins/ltac/rewrite.ml
@@ -610,7 +610,7 @@ let solve_remaining_by env sigma holes by =
     in
     (** Only solve independent holes *)
     let indep = List.map_filter map holes in
-    let ist = { Geninterp.lfun = Id.Map.empty; extra = Geninterp.TacStore.empty } in
+    let ist = Geninterp.empty_interp_sign in
     let solve_tac = match tac with
     | Genarg.GenArg (Genarg.Glbwit tag, tac) ->
       Ftactic.run (Geninterp.interp tag ist tac) (fun _ -> Proofview.tclUNIT ())

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -1237,9 +1237,7 @@ let gentac gen gl =
 let genstac (gens, clr) =
   tclTHENLIST (old_cleartac clr :: List.rev_map gentac gens)
 
-let gen_tmp_ids
-  ?(ist=Geninterp.({ lfun = Id.Map.empty; extra = Tacinterp.TacStore.empty })) gl
-=
+let gen_tmp_ids ?(ist=Geninterp.empty_interp_sign) gl =
   let gl, ctx = pull_ctx gl in
   push_ctxs ctx
     (tclTHENLIST

--- a/plugins/ssr/ssrcommon.mli
+++ b/plugins/ssr/ssrcommon.mli
@@ -28,7 +28,7 @@ val allocc : ssrocc
 
 val hyp_id : ssrhyp -> Id.t
 val hyps_ids : ssrhyps -> Id.t list
-val check_hyp_exists : ('a, 'b) Context.Named.pt -> ssrhyp -> unit
+val check_hyp_exists : ('a, 'b) Context.Named.pt -> ssrhyp -> unit Proofview.tactic
 val test_hypname_exists : ('a, 'b) Context.Named.pt -> Id.t -> bool
 val check_hyps_uniq : Id.t list -> ssrhyps -> unit
 val not_section_id : Id.t -> bool

--- a/plugins/ssr/ssrdispatch.ml
+++ b/plugins/ssr/ssrdispatch.ml
@@ -1,0 +1,125 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *   INRIA, CNRS and contributors - Copyright 1999-2018       *)
+(* <O___,, *       (see CREDITS file for the list of authors)           *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+open Names
+open Ltac_plugin
+
+type _ ffi =
+| Arg : ('a,'b,'c) Genarg.genarg_type * 'f ffi -> ('c -> 'f) ffi
+| Nil : unit Proofview.tactic ffi
+
+let rec length : type a. a ffi -> int =
+  function Nil -> 0 | Arg(_,x) -> 1 + length x
+
+let to_ltac name ffi f args =
+  let rec aux
+    : type a. a ffi -> a -> Geninterp.Val.t list -> unit Proofview.tactic
+    = fun ffi f args ->
+    match ffi with
+    | Nil ->
+        begin match args with
+        | [] -> f
+        | _::_ ->
+           CErrors.anomaly ~label:"ssreflect"
+             Pp.(str "FFI: too many arguments: " ++ str name) end
+    | Arg(w,ffi) ->
+        begin match args with
+        | x :: xs ->
+           let arg = Tacinterp.Value.cast (Genarg.topwit w) x in
+           aux ffi (f arg) xs
+        | [] ->
+           CErrors.anomaly ~label:"ssreflect"
+             Pp.(str "FFI: too few arguments: " ++ str name) end
+  in
+    aux ffi f args
+
+let report_errors db_name = function
+  | [] -> CErrors.anomaly Pp.(str "tclFIRST_WITH_ERRORS on an empty list")
+  | [e] -> Util.iraise e
+  | l -> CErrors.user_err ~hdr:"ssreflect"
+           Pp.(str "Using the hint base " ++ str db_name ++
+               str " the following errors were raised:" ++ fnl () ++ fnl () ++
+               prlist_with_sep (fun () -> fnl () ++ fnl ()) CErrors.iprint
+                 (List.map ExplainErr.process_vernac_interp_error (List.rev l)))
+
+let rec tclFIRST_WITH_ERRORS n errors = function
+  | [] -> report_errors n errors
+  | x :: xs ->
+      Proofview.tclORELSE x (fun e -> tclFIRST_WITH_ERRORS n (e::errors) xs)
+
+let locate_tac_db name sigma goal secvars args =
+  let db =
+    try Hints.searchtable_map name
+    with Not_found ->
+      CErrors.anomaly ~label:"ssreflect"
+        Pp.(str"hint db " ++ str name ++
+            str " not declared (should be in ssreflect.v)") in
+  let hs =
+    match Hints.decompose_app_bound sigma goal with
+    | Some goal_skel -> Hints.Hint_db.map_eauto sigma ~secvars goal_skel goal db
+    | None -> Hints.Hint_db.map_none ~secvars db in
+  if hs = [] then CErrors.anomaly Pp.(str "empty hint db " ++ str name);
+  tclFIRST_WITH_ERRORS name []
+    (hs |> List.map (fun h -> Hints.run_hint h.Hints.code (function
+      | Hints.Extern ({ Hints.arg_names } as tac) ->
+          if List.length arg_names != List.length args then
+            CErrors.user_err ~hdr:"ssreflect"
+              Pp.(str"wrong number of arguments for tactic " ++ str name);
+          let args =
+            List.fold_left2 (fun m id t -> Id.Map.add id t m)
+              Id.Map.empty arg_names args in
+          Auto.conclPattern args goal h.Hints.pat tac
+      | _ -> CErrors.user_err ~hdr:"ssreflect"
+            Pp.(str"only Hint Extern can be declared for " ++ str name))))
+
+let call_tac name args : unit Proofview.tactic =
+  Proofview.Goal.enter (fun gl ->
+    let sigma = Proofview.Goal.sigma gl in
+    let goal = Proofview.Goal.concl gl in
+    let secvars = Auto.compute_secvars gl in
+    locate_tac_db name sigma goal secvars args)
+
+let to_ml name ffi =
+  let rec aux : type a. a ffi -> Geninterp.Val.t list -> a
+  = fun ffi args ->
+    match ffi with
+    | Nil -> call_tac name (List.rev args)
+    | Arg(w,ffi) ->
+        let open Geninterp in
+        fun x ->
+          let x = Val.inject (val_tag (Genarg.topwit w)) x in
+          aux ffi (x :: args)
+  in
+    aux ffi []
+
+let register_overloaded name ffi tac =
+  let bios_ml = "ssreflect_plugin" in
+  let name = "ssr_" ^ name in
+  let nargs = length ffi in
+  let args = CList.init nargs (fun i ->
+               Id.of_string (Printf.sprintf "%s_arg_%d" name i)) in
+  let mltac _ ist =
+    let args =
+      List.map (fun arg ->
+        try Id.Map.find arg ist.Tacinterp.lfun
+        with Not_found ->
+          CErrors.anomaly Pp.(str "calling convention mismatch: " ++
+            str name ++ str " arg " ++ Ppconstr.pr_id arg)
+      ) args
+    in
+      to_ltac name ffi tac args in
+  let mltac_name = { Tacexpr.mltac_plugin = bios_ml; mltac_tactic = name; } in
+  let () = Tacenv.register_ml_tactic mltac_name [|mltac|] in
+  let tac =
+    Tacexpr.TacFun (List.map (fun x -> Name.Name x) args,
+      Tacexpr.TacML (None,({Tacexpr.mltac_name; mltac_index = 0}, []))) in
+  let obj () = Tacenv.register_ltac true false (Id.of_string name) tac in
+  Mltop.declare_cache_obj obj bios_ml;
+  to_ml name ffi

--- a/plugins/ssr/ssrdispatch.mli
+++ b/plugins/ssr/ssrdispatch.mli
@@ -1,0 +1,20 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *   INRIA, CNRS and contributors - Copyright 1999-2018       *)
+(* <O___,, *       (see CREDITS file for the list of authors)           *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+type _ ffi =
+| Arg : ('a,'b,'c) Genarg.genarg_type * 'f ffi -> ('c -> 'f) ffi
+| Nil : unit Proofview.tactic ffi
+
+(* [register_overloaded name ffi f] registers an Ltac symbol ["ssr_"^name]
+ * pointing to [f] and returns some code [f'] that goes trough the Hint Extern
+ * db called ["ssr_"^name]. The designer is expected to put in the
+ * Hint db a default entry with the Ltac symbol. The user can add more
+ * entries to overload the meaning of [name] *)
+val register_overloaded : string -> 'a ffi -> 'a -> 'a

--- a/plugins/ssr/ssreflect.v
+++ b/plugins/ssr/ssreflect.v
@@ -339,6 +339,15 @@ Lemma lock A x : x = locked x :> A. Proof. unlock; reflexivity. Qed.
 Lemma not_locked_false_eq_true : locked false <> true.
 Proof. unlock; discriminate. Qed.
 
+(* Basic tactic overloading                                                   *)
+Hint Extern id    10 => ssr_intro_id id             : ssr_intro_id.
+Hint Extern       10 => ssr_intro_anon              : ssr_intro_anon.
+Hint Extern       10 => ssr_intro_drop              : ssr_intro_drop.
+Hint Extern id    10 => ssr_intro_delayed_clear id  : ssr_intro_delayed_clear.
+Hint Extern t     10 => ssr_intro_case t            : ssr_intro_case.
+Hint Extern o d t 10 => ssr_intro_subst o d t       : ssr_intro_subst.
+Hint Extern t     10 => ssr_intro_injection t       : ssr_intro_injection.
+
 (* The basic closing tactic "done".                                           *)
 Ltac done :=
   trivial; hnf; intros; solve

--- a/plugins/ssr/ssreflect_plugin.mlpack
+++ b/plugins/ssr/ssreflect_plugin.mlpack
@@ -1,5 +1,6 @@
 Ssrast
 Ssrprinters
+Ssrdispatch
 Ssrcommon
 Ssrtacticals
 Ssrelim

--- a/pretyping/geninterp.ml
+++ b/pretyping/geninterp.ml
@@ -88,6 +88,8 @@ type interp_sign = {
 
 type ('glb, 'top) interp_fun = interp_sign -> 'glb -> 'top Ftactic.t
 
+let empty_interp_sign = { lfun = Id.Map.empty; extra = TacStore.empty }
+
 module InterpObj =
 struct
   type ('raw, 'glb, 'top) obj = ('glb, Val.t) interp_fun

--- a/pretyping/geninterp.mli
+++ b/pretyping/geninterp.mli
@@ -68,6 +68,8 @@ type interp_sign = {
 
 type ('glb, 'top) interp_fun = interp_sign -> 'glb -> 'top Ftactic.t
 
+val empty_interp_sign : interp_sign
+
 val interp : ('raw, 'glb, 'top) genarg_type -> ('glb, Val.t) interp_fun
 
 val register_interp0 :

--- a/proofs/proof_global.ml
+++ b/proofs/proof_global.ml
@@ -163,7 +163,7 @@ let with_current_proof f =
         | None -> Proofview.tclUNIT ()
         | Some tac ->
           let open Geninterp in
-          let ist = { lfun = Id.Map.empty; extra = TacStore.empty } in
+          let ist = empty_interp_sign in
           let Genarg.GenArg (Genarg.Glbwit tag, tac) = tac in
           let tac = Geninterp.interp tag ist tac in
           Ftactic.run tac (fun _ -> Proofview.tclUNIT ())

--- a/tactics/auto.ml
+++ b/tactics/auto.ml
@@ -400,11 +400,7 @@ and tac_of_hint dbg db_list local_db concl (flags, ({pat=p; code=t;poly=poly;db=
 
 and trivial_resolve sigma dbg mod_delta db_list local_db secvars cl =
   try
-    let head =
-      try let hdconstr = decompose_app_bound sigma cl in
-	    Some hdconstr
-      with Bound -> None
-    in
+    let head = decompose_app_bound sigma cl in
       List.map (tac_of_hint dbg db_list local_db cl)
 	(priority
 	    (my_find_search mod_delta sigma db_list local_db secvars head cl))
@@ -447,11 +443,7 @@ let h_trivial ?(debug=Off) lems l = gen_trivial ~debug lems l
 
 let possible_resolve sigma dbg mod_delta db_list local_db secvars cl =
   try
-    let head =
-      try let hdconstr = decompose_app_bound sigma cl in
-	    Some hdconstr
-      with Bound -> None
-    in
+    let head = decompose_app_bound sigma cl in
       List.map (tac_of_hint dbg db_list local_db cl)
 	(my_find_search mod_delta sigma db_list local_db secvars head cl)
   with Not_found -> []

--- a/tactics/auto.mli
+++ b/tactics/auto.mli
@@ -33,9 +33,10 @@ val unify_resolve : polymorphic -> Unification.unify_flags -> (raw_hint * clause
 (** [ConclPattern concl pat tacast]:
    if the term concl matches the pattern pat, (in sense of
    [Pattern.somatches], then replace [?1] [?2] metavars in tacast by the
-   right values to build a tactic *)
+   right values to build a tactic.
+   [ist] can contain pre-existing bindings (empty by default) *)
 
-val conclPattern : constr -> constr_pattern option -> Genarg.glob_generic_argument -> unit Proofview.tactic
+val conclPattern : Geninterp.Val.t Names.Id.Map.t -> constr -> constr_pattern option -> Hints.extern_hint_tac -> unit Proofview.tactic
 
 (** The Auto tactic *)
 

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -428,7 +428,11 @@ and e_my_find_search db_list local_db secvars hdc complete only_classes env sigm
          Tacticals.New.tclTHEN fst snd
       | Unfold_nth c ->
          Proofview.tclPROGRESS (unfold_in_concl [AllOccurrences,c])
-      | Extern tacast -> conclPattern concl p tacast
+      | Extern ({ Hints.arg_names = [] } as h) ->
+          conclPattern Id.Map.empty concl p h
+      | Extern _ ->
+          CErrors.user_err ~hdr:"typeclasses_eauto"
+            (str "external hints with arguments are not supported")
       in
       let tac = run_hint t tac in
       let tac = if complete then Tacticals.New.tclCOMPLETE tac else tac in

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -448,13 +448,13 @@ and e_my_find_search db_list local_db secvars hdc complete only_classes env sigm
   in List.map tac_of_hint hintl
 
 and e_trivial_resolve db_list local_db secvars only_classes env sigma concl =
-  let hd = try Some (decompose_app_bound sigma concl) with Bound -> None in
+  let hd = decompose_app_bound sigma concl in
   try
     e_my_find_search db_list local_db secvars hd true only_classes env sigma concl
   with Not_found -> []
 
 let e_possible_resolve db_list local_db secvars only_classes env sigma concl =
-  let hd = try Some (decompose_app_bound sigma concl) with Bound -> None in
+  let hd = decompose_app_bound sigma concl in
   try
     e_my_find_search db_list local_db secvars hd false only_classes env sigma concl
   with Not_found -> []

--- a/tactics/eauto.ml
+++ b/tactics/eauto.ml
@@ -188,12 +188,12 @@ and e_my_find_search env sigma db_list local_db secvars hdc concl =
   List.map tac_of_hint hintl
 
 and e_trivial_resolve env sigma db_list local_db secvars gl =
-  let hd = try Some (decompose_app_bound sigma gl) with Bound -> None in
+  let hd = decompose_app_bound sigma gl in
   try priority (e_my_find_search env sigma db_list local_db secvars hd gl)
   with Not_found -> []
 
 let e_possible_resolve env sigma db_list local_db secvars gl =
-  let hd = try Some (decompose_app_bound sigma gl) with Bound -> None in
+  let hd = decompose_app_bound sigma gl in
   try List.map (fun (b, (tac, pp)) -> (tac, b, pp))
                (e_my_find_search env sigma db_list local_db secvars hd gl)
   with Not_found -> []

--- a/tactics/eauto.ml
+++ b/tactics/eauto.ml
@@ -176,7 +176,11 @@ and e_my_find_search env sigma db_list local_db secvars hdc concl =
           Tacticals.New.tclTHEN (unify_e_resolve poly st (term,cl))
             (e_trivial_fail_db db_list local_db)
         | Unfold_nth c -> reduce (Unfold [AllOccurrences,c]) onConcl
-        | Extern tacast -> conclPattern concl p tacast
+        | Extern ({ Hints.arg_names = [] } as h) ->
+            conclPattern Id.Map.empty concl p h
+        | Extern _ ->
+            CErrors.user_err ~hdr:"eauto"
+               (str "external hints with arguments are not supported")
        in
        let tac = run_hint t tac in
        (tac, lazy (pr_hint env sigma t)))

--- a/tactics/hints.mli
+++ b/tactics/hints.mli
@@ -21,8 +21,6 @@ open Typeclasses
 
 (** {6 General functions. } *)
 
-exception Bound
-
 val decompose_app_bound :
   evar_map -> constr -> (GlobRef.t * constr array) option
 

--- a/test-suite/ssr/ssr_overload_ipats.v
+++ b/test-suite/ssr/ssr_overload_ipats.v
@@ -1,0 +1,24 @@
+Require Import ssreflect.
+
+Axiom frl : (nat -> Prop) -> Prop.
+Axiom frl_intro : forall P : nat -> Prop, (forall x, P x) -> (frl P).
+Notation "`all x , P" := (frl (fun x : _ => P)) (x ident, at level 20).
+
+Lemma test : frl (fun x => x = 0).
+Proof.
+Fail move=> x.
+Fail move=> ?.
+Abort.
+
+Hint Extern id 0 (frl _) => apply: frl_intro => id : ssr_intro_id.
+Hint Extern 0 (frl _) => apply: frl_intro => ?  : ssr_intro_anon.
+Hint Extern 0 (frl _) => apply: frl_intro => _  : ssr_intro_drop.
+Hint Extern id 0 => idtac "check" id : ssr_check_hyp_exists.
+Hint Extern id 0 => clear id || idtac : ssr_intro_delayed_clear.
+Hint Extern o d x 0 => idtac "occ" o "dir" d "subject" x : ssr_intro_subst.
+
+Lemma test : forall w, `all y, `all x, (x = w).
+Proof.
+move=> ? _ [|x]. Undo.
+move=> w {-3}<- x {y q}.
+Abort.

--- a/test-suite/success/hintdb_arguments.v
+++ b/test-suite/success/hintdb_arguments.v
@@ -1,0 +1,2 @@
+Hint Extern foo 0 => apply foo : foodb.
+Fail Hint Extern 0 => apply foo : foodb.

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -220,9 +220,11 @@ open Pputils
         | HintsConstructors c ->
           keyword "Constructors"
           ++ spc() ++ prlist_with_sep spc pr_qualid c
-        | HintsExtern (n,c,tac) ->
+        | HintsExtern (names,n,c,tac) ->
           let pat = match c with None -> mt () | Some pat -> pr_pat pat in
-          keyword "Extern" ++ spc() ++ int n ++ spc() ++ pat ++ str" =>" ++
+          keyword "Extern" ++ spc () ++
+            prlist_with_sep spc Id.print names ++
+            spc() ++ int n ++ spc() ++ pat ++ str" =>" ++
             spc() ++ Pputils.pr_raw_generic (Global.env ()) tac
     in
     hov 2 (keyword "Hint "++ pph ++ opth)

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -134,7 +134,7 @@ type hints_expr = Hints.hints_expr =
   | HintsTransparency of qualid hints_transparency_target * bool
   | HintsMode of qualid * Hints.hint_mode list
   | HintsConstructors of qualid list
-  | HintsExtern of int * constr_expr option * Genarg.raw_generic_argument
+  | HintsExtern of Id.t list * int * constr_expr option * Genarg.raw_generic_argument
 [@@ocaml.deprecated "Please use [Hints.hints_expr]"]
 
 type search_restriction =


### PR DESCRIPTION
This PR revives the code doing dynamic dispatching of ssr2 (once demoed at a working group).
It is *very* preliminary, mainly to benchmark the cost of dynamic dispatching.

CC: @CohenCyril @amahboubi and @bgregoir  showed interest in this recently (maybe give a look at the test file). If the cost of dispatching is not too bad I can try to let one override also the other intro patterns.

As usual comments on the code by the Ltac internal's guru are welcome, CC: @ppedrot 

bench says no overhead:
```
┌──────────────────────────┬─────────────────────────┬─────────────────────────────────────┬─────────────────────────────────────┬─────────────────────────┬─────────────────┐
│                          │      user time [s]      │             CPU cycles              │          CPU instructions           │  max resident mem [KB]  │   mem faults    │
│                          │                         │                                     │                                     │                         │                 │
│             package_name │     NEW     OLD PDIFF   │           NEW           OLD PDIFF   │           NEW           OLD PDIFF   │     NEW     OLD PDIFF   │ NEW OLD PDIFF   │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼─────────────────────────────────────┼─────────────────────────┼─────────────────┤
│     coq-mathcomp-algebra │  198.96  199.93 -0.49 % │  552412295463  555015863617 -0.47 % │  777929340685  778356542439 -0.05 % │  646336  644156 +0.34 % │   0   1 -100.00 % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼─────────────────────────────────────┼─────────────────────────┼─────────────────┤
│       coq-mathcomp-field │  462.97  464.90 -0.42 % │ 1288279041998 1293496276708 -0.40 % │ 2116792705975 2117369395833 -0.03 % │  803568  803504 +0.01 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼─────────────────────────────────────┼─────────────────────────┼─────────────────┤
│   coq-mathcomp-odd-order │ 1425.66 1430.76 -0.36 % │ 3971889780869 3986579773744 -0.37 % │ 6707676093761 6703742475407 +0.06 % │ 1366216 1350324 +1.18 % │ 224   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼─────────────────────────────────────┼─────────────────────────┼─────────────────┤
│   coq-mathcomp-character │  288.55  289.47 -0.32 % │  802184064308  804989530668 -0.35 % │ 1170307404943 1170233786423 +0.01 % │ 1131468 1114704 +1.50 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼─────────────────────────────────────┼─────────────────────────┼─────────────────┤
│    coq-mathcomp-fingroup │   81.24   81.44 -0.25 % │  224222977563  224849540621 -0.28 % │  332908333324  332835955836 +0.02 % │  588648  586928 +0.29 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼─────────────────────────────────────┼─────────────────────────┼─────────────────┤
│    coq-mathcomp-solvable │  216.45  216.79 -0.16 % │  600219161579  601616391073 -0.23 % │  858087279404  857342084062 +0.09 % │  832552  860220 -3.22 % │   5   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼─────────────────────────────────────┼─────────────────────────┼─────────────────┤
│ coq-mathcomp-real-closed │  184.10  184.23 -0.07 % │  511931441712  513005335333 -0.21 % │  777385527178  777131383258 +0.03 % │  832640  831680 +0.12 % │   2   1 +100.00 % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼─────────────────────────────────────┼─────────────────────────┼─────────────────┤
│   coq-mathcomp-ssreflect │   62.26   62.21 +0.08 % │  170882509840  170337389872 +0.32 % │  241273247139  241037074639 +0.10 % │  533280  531708 +0.30 % │   0   0  +nan % │
├──────────────────────────┼─────────────────────────┼─────────────────────────────────────┼─────────────────────────────────────┼─────────────────────────┼─────────────────┤
│              coq-bignums │   96.16   95.88 +0.29 % │  266073464377  265101193852 +0.37 % │  377734059966  377957425485 -0.06 % │  516732  516492 +0.05 % │  11   0  +nan % │
└──────────────────────────┴─────────────────────────┴─────────────────────────────────────┴─────────────────────────────────────┴─────────────────────────┴─────────────────┘
```