### PR TITLE
Document that GITURL variables shouldn't have a trailing .git anymore.

### DIFF
--- a/dev/ci/user-overlays/07863-rm-sorts-contents.sh
+++ b/dev/ci/user-overlays/07863-rm-sorts-contents.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-if [ "$CI_PULL_REQUEST" = "7863" ] || [ "$CI_BRANCH" = "rm-sorts-contents" ]; then
-    Elpi_CI_BRANCH=fix-sorts-contents
-    Elpi_CI_GITURL=https://github.com/SkySkimmer/coq-elpi.git
-fi

--- a/dev/ci/user-overlays/07906-univs-of-constr.sh
+++ b/dev/ci/user-overlays/07906-univs-of-constr.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-if [ "$CI_PULL_REQUEST" = "7906" ] || [ "$CI_BRANCH" = "univs-of-constr-noseff" ]; then
-    Equations_CI_BRANCH=fix-univs-of-constr
-    Equations_CI_GITURL=https://github.com/SkySkimmer/Coq-Equations.git
-
-    Elpi_CI_BRANCH=fix-universes-of-constr
-    Elpi_CI_GITURL=https://github.com/SkySkimmer/coq-elpi.git
-fi

--- a/dev/ci/user-overlays/7080-herbelin-master+swapping-modules-constr-context.sh
+++ b/dev/ci/user-overlays/7080-herbelin-master+swapping-modules-constr-context.sh
@@ -1,7 +1,0 @@
-if [ "$CI_PULL_REQUEST" = "7080" ] || [ "$CI_BRANCH" = "master+swapping-modules-constr-context" ]; then
-    Equations_CI_BRANCH=master+adapting-coq-pr7080
-    Equations_CI_GITURL=https://github.com/herbelin/Coq-Equations.git
-
-    Elpi_CI_BRANCH=coq-master+adapting-coq-pr7080
-    Elpi_CI_GITURL=https://github.com/herbelin/coq-elpi.git
-fi

--- a/dev/ci/user-overlays/README.md
+++ b/dev/ci/user-overlays/README.md
@@ -9,6 +9,8 @@ testing is possible. It redefines some variables from
 [`ci-basic-overlay.sh`](../ci-basic-overlay.sh):
 give the name of your branch using a `_CI_BRANCH` variable and the location of
 your fork using a `_CI_GITURL` variable.
+The `_CI_GITURL` variable should be the URL of the repository without a
+trailing `.git`.
 
 Moreover, the file contains very simple logic to test the pull request number
 or branch name and apply it only in this case.


### PR DESCRIPTION
This allows to append `/archive` at the end (cf. #7831).