### PR TITLE
Fix default.nix following a package renaming.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -71,7 +71,7 @@ stdenv.mkDerivation rec {
 
   ] else []) ++ (if lib.inNixShell then [
     ocamlPackages.merlin
-    ocamlPackages.ocpIndent
+    ocamlPackages.ocp-indent
 
     # Dependencies of the merging script
     jq

--- a/default.nix
+++ b/default.nix
@@ -72,6 +72,7 @@ stdenv.mkDerivation rec {
   ] else []) ++ (if lib.inNixShell then [
     ocamlPackages.merlin
     ocamlPackages.ocp-indent
+    ocamlPackages.ocp-index
 
     # Dependencies of the merging script
     jq


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** infrastructure.

@vbgl You are the one who did this renaming upstream.