### PR TITLE
allow `make check` to succeed when -prefix is given to ./configure and make install not run yet

### DIFF
--- a/lib/envars.ml
+++ b/lib/envars.ml
@@ -110,6 +110,7 @@ let check_file_else ~dir ~file oth =
   if Sys.file_exists (path / file) then path else oth ()
 
 let guess_coqlib fail =
+  getenv_else "COQLIB" (fun () ->
   let prelude = "theories/Init/Prelude.vo" in
   check_file_else ~dir:Coq_config.coqlibsuffix ~file:prelude
     (fun () ->
@@ -117,6 +118,7 @@ let guess_coqlib fail =
       then Coq_config.coqlib
       else
         fail "cannot guess a path for Coq libraries; please use -coqlib option")
+  )
 
 (** coqlib is now computed once during coqtop initialization *)
 


### PR DESCRIPTION
In others PR I read that @SkySkimmer wants to be able to run make check without having installed Coq but having configured Coq for system-wide installation (eg `./configure -prefix /usr`). Well, here it is.

On my PC this patch is sufficient to configure Coq in system wide mode and run
```
CAML_LD_LIBRARY_PATH=$PWD/kernel/byterun COQLIB=$PWD make -j2 -C test-suite
```
before installing Coq.