### PR TITLE
Turn a dead branch into an assertion failure in VM reification.

### DIFF
--- a/pretyping/vnorm.ml
+++ b/pretyping/vnorm.ml
@@ -311,7 +311,7 @@ and nf_predicate env sigma ind mip params v pT =
       let dom = mkApp(mkIndU ind,Array.append params rargs) in
       let body = nf_vtype (push_rel (LocalAssum (name,dom)) env) sigma vb in
       mkLambda(name,dom,body)
-    | _ -> nf_val env sigma v crazy_type
+    | _ -> assert false
 
 and nf_args env sigma vargs ?from:(f=0) t =
   let t = ref t in


### PR DESCRIPTION
In #7607, dead code that used to handle non-dependent return predicates was removed. This made the reification branch expecting non-functions in predicates dead code. We fix this by using an assert instead.
