### PR TITLE
Compile `coqpp` inside the `bin/` folder and make it available after installation

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -377,7 +377,7 @@ grammar/grammar.cma : $(GRAMCMO)
 	$(SHOW)'OCAMLC -a $@'
 	$(HIDE)$(GRAMC) $^ -linkall -a -o $@
 
-grammar/coqpp: $(COQPPCMO) grammar/coqpp_main.ml
+$(COQPP): $(COQPPCMO) grammar/coqpp_main.ml
 	$(SHOW)'OCAMLC -a $@'
 	$(HIDE)$(GRAMC) $^ -linkall -o $@
 
@@ -764,14 +764,14 @@ plugins/%.cmx: plugins/%.ml
 	$(SHOW)'OCAMLYACC  $<'
 	$(HIDE)$(OCAMLYACC) --strict "$*.mly"
 
-%.ml: %.ml4 $(CAMLP5DEPS) grammar/coqpp
+%.ml: %.ml4 $(CAMLP5DEPS) $(COQPP)
 	$(SHOW)'CAMLP5O   $<'
 	$(HIDE)$(CAMLP5O) -I $(MYCAMLP5LIB) $(PR_O) \
 	  $(CAMLP5DEPS) $(CAMLP5USE) $(CAMLP5COMPAT) -impl $< -o $@
 
-%.ml: %.mlg grammar/coqpp
+%.ml: %.mlg $(COQPP)
 	$(SHOW)'COQPP   $<'
-	$(HIDE)grammar/coqpp $<
+	$(HIDE)$(COQPP) $<
 
 ###########################################################################
 # Dependencies of ML code

--- a/Makefile.common
+++ b/Makefile.common
@@ -21,6 +21,7 @@ COQTOPEXE:=bin/coqtop$(EXE)
 COQTOPBYTE:=bin/coqtop.byte$(EXE)
 
 COQDEP:=bin/coqdep$(EXE)
+COQPP:=bin/coqpp$(EXE)
 COQDEPBYTE:=bin/coqdep.byte$(EXE)
 COQMAKEFILE:=bin/coq_makefile$(EXE)
 COQMAKEFILEBYTE:=bin/coq_makefile.byte$(EXE)
@@ -40,7 +41,7 @@ COQMAKE_BOTH_TIME_FILES:=tools/make-both-time-files.py
 COQMAKE_BOTH_SINGLE_TIMING_FILES:=tools/make-both-single-timing-files.py
 
 TOOLS:=$(COQDEP) $(COQMAKEFILE) $(COQTEX) $(COQWC) $(COQDOC) $(COQC)\
-	$(COQWORKMGR)
+	$(COQWORKMGR) $(COQPP)
 TOOLS_HELPERS:=tools/CoqMakefile.in $(COQMAKE_ONE_TIME_FILE) $(COQTIME_FILE_MAKER)\
 	$(COQMAKE_BOTH_TIME_FILES) $(COQMAKE_BOTH_SINGLE_TIMING_FILES)
 


### PR DESCRIPTION
Compile `coqpp` inside the `bin/` folder and make it available after installation. No need to put it inside `.gitignore`.