### PR TITLE
Extract the record encoding information out of the kernel.

### DIFF
--- a/checker/cic.mli
+++ b/checker/cic.mli
@@ -253,7 +253,6 @@ type wf_paths = recarg Rtree.t
 
 type record_info =
 | NotRecord
-| FakeRecord
 | PrimRecord of (Id.t * Constant.t array * projection_body array) array
 
 type regular_inductive_arity = {

--- a/checker/environ.ml
+++ b/checker/environ.ml
@@ -192,7 +192,7 @@ let add_mind kn mib env =
       (MutInd.to_string kn);
   let new_inds = Mindmap_env.add kn mib env.env_globals.env_inductives in
   let new_projections = match mib.mind_record with
-    | NotRecord | FakeRecord -> env.env_globals.env_projections
+    | NotRecord -> env.env_globals.env_projections
     | PrimRecord projs ->
       Array.fold_left (fun accu (id, kns, pbs) ->
       Array.fold_left2 (fun accu kn pb ->

--- a/checker/subtyping.ml
+++ b/checker/subtyping.ml
@@ -185,7 +185,6 @@ let check_inductive  env mp1 l info1 mib2 spec2 subst1 subst2=
   let record_equal x y =
     match x, y with
     | NotRecord, NotRecord -> true
-    | FakeRecord, FakeRecord -> true
     | PrimRecord info1, PrimRecord info2 ->
       let check (id1, p1, pb1) (id2, p2, pb2) =
         Id.equal id1 id2 &&

--- a/checker/values.ml
+++ b/checker/values.ml
@@ -15,7 +15,7 @@
 To ensure this file is up-to-date, 'make' now compares the md5 of cic.mli
 with a copy we maintain here:
 
-MD5 c395aa2dbfc18794b3b7192f3dc5b2e5 checker/cic.mli
+MD5 0d47bebd301772a371c82c72f2a1ff6f checker/cic.mli
 
 *)
 
@@ -276,7 +276,7 @@ let v_one_ind = v_tuple "one_inductive_body"
 let v_finite = v_enum "recursivity_kind" 3
 
 let v_record_info =
-  v_sum "record_info" 2
+  v_sum "record_info" 1
     [| [| Array (v_tuple "record" [| v_id; Array v_cst; Array v_projbody |]) |] |]
 
 let v_ind_pack_univs = 

--- a/interp/declare.ml
+++ b/interp/declare.ml
@@ -413,9 +413,8 @@ let declare_projections univs mind =
       ) kns projs
     in
     let () = Array.iteri iter info in
-    true, true
-  | FakeRecord -> true, false
-  | NotRecord -> false, false
+    true
+  | NotRecord -> false
 
 (* for initial declaration *)
 let declare_mind mie =
@@ -424,7 +423,7 @@ let declare_mind mie =
     | [] -> anomaly (Pp.str "cannot declare an empty list of inductives.") in
   let (sp,kn as oname) = add_leaf id (inInductive ([],mie)) in
   let mind = Global.mind_of_delta_kn kn in
-  let isrecord,isprim = declare_projections mie.mind_entry_universes mind in
+  let isprim = declare_projections mie.mind_entry_universes mind in
   declare_mib_implicits mind;
   declare_inductive_argument_scopes mind mie;
   oname, isprim

--- a/interp/discharge.ml
+++ b/interp/discharge.ml
@@ -111,9 +111,7 @@ let process_inductive info modlist mib =
   let section_decls' = Context.Named.map discharge section_decls in
   let (params',inds') = abstract_inductive section_decls' nparamdecls inds in
   let record = match mib.mind_record with
-    | PrimRecord info ->
-      Some (Some (Array.map pi1 info))
-    | FakeRecord -> Some None
+    | PrimRecord info -> Some (Array.map pi1 info)
     | NotRecord -> None
   in
   { mind_entry_record = record;

--- a/interp/dumpglob.ml
+++ b/interp/dumpglob.ml
@@ -113,18 +113,20 @@ let type_of_global_ref gr =
 	"var" ^ type_of_logical_kind (Decls.variable_kind v)
     | Globnames.IndRef ind ->
 	let (mib,oib) = Inductive.lookup_mind_specif (Global.env ()) ind in
-          if mib.Declarations.mind_record <> Declarations.NotRecord then
-            begin match mib.Declarations.mind_finite with
-            | Finite -> "indrec"
-            | BiFinite -> "rec"
-	    | CoFinite -> "corec"
-            end
-	  else
-            begin match mib.Declarations.mind_finite with
-            | Finite -> "ind"
-            | BiFinite -> "variant"
-	    | CoFinite -> "coind"
-            end
+        begin match mib.Declarations.mind_record with
+        | Declarations.NotRecord when not (Recordops.emulates_record (fst ind)) ->
+          begin match mib.Declarations.mind_finite with
+          | Finite -> "ind"
+          | BiFinite -> "variant"
+          | CoFinite -> "coind"
+          end
+        | Declarations.NotRecord | Declarations.PrimRecord _ ->
+          begin match mib.Declarations.mind_finite with
+          | Finite -> "indrec"
+          | BiFinite -> "rec"
+          | CoFinite -> "corec"
+          end
+        end
     | Globnames.ConstructRef _ -> "constr"
 
 let remove_sections dir =

--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -836,7 +836,7 @@ let eta_expand_ind_stack env ind m s (f, s') =
       let hstack = Array.map (fun p -> { norm = Red; (* right can't be a constructor though *)
 					 term = FProj (Projection.make p true, right) }) projs in
 	argss, [Zapp hstack]
-    | PrimRecord _ | NotRecord | FakeRecord -> raise Not_found (* disallow eta-exp for non-primitive records *)
+    | PrimRecord _ | NotRecord -> raise Not_found (* disallow eta-exp for non-primitive records *)
 
 let rec project_nth_arg n argstk =
   match argstk with

--- a/kernel/declarations.ml
+++ b/kernel/declarations.ml
@@ -110,20 +110,16 @@ v}
 
 (** Record information:
     If the type is not a record, then NotRecord
-    If the type is a non-primitive record, then FakeRecord
+
     If it is a primitive record, for every type in the block, we get:
     - The identifier for the binder name of the record in primitive projections.
     - The constants associated to each projection.
     - The checked projection bodies.
 
-    The kernel does not exploit the difference between [NotRecord] and
-    [FakeRecord]. It is mostly used by extraction, and should be extruded from
-    the kernel at some point.
 *)
 
 type record_info =
 | NotRecord
-| FakeRecord
 | PrimRecord of (Id.t * Constant.t array * projection_body array) array
 
 type regular_inductive_arity = {

--- a/kernel/declareops.ml
+++ b/kernel/declareops.ml
@@ -210,7 +210,6 @@ let subst_mind_packet sub mbp =
 
 let subst_mind_record sub r = match r with
 | NotRecord -> NotRecord
-| FakeRecord -> FakeRecord
 | PrimRecord infos ->
   let map (id, ps, pb as info) =
     let ps' = Array.Smart.map (subst_constant sub) ps in

--- a/kernel/entries.ml
+++ b/kernel/entries.ml
@@ -49,7 +49,7 @@ type one_inductive_entry = {
   mind_entry_lc : constr list }
 
 type mutual_inductive_entry = {
-  mind_entry_record : (Id.t array option) option;
+  mind_entry_record : Id.t array option;
   (** Some (Some ids): primitive records with ids the binder name of each
       record in their respective projections. Not used by the kernel.
       Some None: non-primitive record *)

--- a/kernel/environ.ml
+++ b/kernel/environ.ml
@@ -519,7 +519,7 @@ let template_polymorphic_pind (ind,u) env =
 let add_mind_key kn (mind, _ as mind_key) env =
   let new_inds = Mindmap_env.add kn mind_key env.env_globals.env_inductives in
   let new_projections = match mind.mind_record with
-    | NotRecord | FakeRecord -> env.env_globals.env_projections
+    | NotRecord -> env.env_globals.env_projections
     | PrimRecord projs ->
       Array.fold_left (fun accu (id, kns, pbs) ->
       Array.fold_left2 (fun accu kn pb ->

--- a/kernel/indtypes.ml
+++ b/kernel/indtypes.ml
@@ -956,7 +956,7 @@ let build_inductive env prv iu env_ar paramsctxt kn isrecord isfinite inds nmr r
     }
   in
   let record_info = match isrecord with
-  | Some (Some rid) ->
+  | Some rid ->
     let is_record pkt =
       pkt.mind_kelim == all_sorts
       && Array.length pkt.mind_consnames == 1
@@ -969,9 +969,8 @@ let build_inductive env prv iu env_ar paramsctxt kn isrecord isfinite inds nmr r
         (id, kn, projs)
       in
       try PrimRecord (Array.mapi map rid)
-      with UndefinableExpansion -> FakeRecord
-    else FakeRecord
-  | Some None -> FakeRecord
+      with UndefinableExpansion -> NotRecord
+    else NotRecord
   | None -> NotRecord
   in
   { mib with mind_record = record_info }

--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -289,7 +289,7 @@ let is_private (mib,_) = mib.mind_private = Some true
 let is_primitive_record (mib,_) = 
   match mib.mind_record with
   | PrimRecord _ -> true
-  | NotRecord | FakeRecord -> false
+  | NotRecord -> false
 
 let build_dependent_inductive ind (_,mip) params =
   let realargs,_ = List.chop mip.mind_nrealdecls mip.mind_arity_ctxt in

--- a/kernel/names.ml
+++ b/kernel/names.ml
@@ -606,6 +606,7 @@ module MutInd = KerPair
 module Mindmap = HMap.Make(MutInd.CanOrd)
 module Mindset = Mindmap.Set
 module Mindmap_env = HMap.Make(MutInd.UserOrd)
+module Mindset_env = Mindmap_env.Set
 
 (** Designation of a (particular) inductive type. *)
 type inductive = MutInd.t      (* the name of the inductive type *)

--- a/kernel/names.mli
+++ b/kernel/names.mli
@@ -456,7 +456,8 @@ end
 
 module Mindset : CSig.SetS with type elt = MutInd.t
 module Mindmap : Map.ExtS with type key = MutInd.t and module Set := Mindset
-module Mindmap_env : CSig.MapS with type key = MutInd.t
+module Mindset_env : CSig.SetS with type elt = MutInd.t
+module Mindmap_env : Map.ExtS with type key = MutInd.t and module Set := Mindset_env
 
 (** Designation of a (particular) inductive type. *)
 type inductive = MutInd.t      (* the name of the inductive type *)

--- a/kernel/nativecode.ml
+++ b/kernel/nativecode.ml
@@ -1994,7 +1994,7 @@ let compile_mind prefix ~interactive mb mind stack =
       Glet (gn, mkMLlam [|c_uid|] code) :: acc
     in
     let projs = match mb.mind_record with
-    | NotRecord | FakeRecord -> []
+    | NotRecord -> []
     | PrimRecord info ->
       let _, _, pbs = info.(i) in
       Array.fold_left_i add_proj [] pbs

--- a/plugins/extraction/extraction.ml
+++ b/plugins/extraction/extraction.ml
@@ -488,7 +488,11 @@ and extract_really_ind env kn mib =
 	    Int.equal (List.length l) 1 && not (type_mem_kn kn (List.hd l))
 	then raise (I Singleton);
 	if List.is_empty l then raise (I Standard);
-        if mib.mind_record == Declarations.NotRecord then raise (I Standard);
+        let () = match mib.mind_record with
+        | Declarations.NotRecord when not (Recordops.emulates_record kn) ->
+          raise (I Standard)
+        | Declarations.NotRecord | Declarations.PrimRecord _ -> ()
+        in
 	(* Now we're sure it's a record. *)
 	(* First, we find its field names. *)
 	let rec names_prod t = match Constr.kind t with

--- a/pretyping/inductiveops.ml
+++ b/pretyping/inductiveops.ml
@@ -278,7 +278,7 @@ let projection_nparams p = projection_nparams_env (Global.env ()) p
 let has_dependent_elim mib =
   match mib.mind_record with
   | PrimRecord _ -> mib.mind_finite == BiFinite
-  | NotRecord | FakeRecord -> true
+  | NotRecord -> true
 
 (* Annotation for cases *)
 let make_case_info env ind style =
@@ -349,7 +349,7 @@ let get_projections env (ind,params) =
     | PrimRecord infos ->
       let (_, projs, _) = infos.(snd (fst ind)) in
       Some projs
-    | NotRecord | FakeRecord -> None
+    | NotRecord -> None
 
 let make_case_or_project env sigma indf ci pred c branches =
   let open EConstr in
@@ -472,7 +472,7 @@ let compute_projections env (kn, i as ind) =
     make_abstract_instance (ACumulativityInfo.univ_context acumi)
   in
   let x = match mib.mind_record with
-  | NotRecord | FakeRecord ->
+  | NotRecord ->
     anomaly Pp.(str "Trying to build primitive projections for a non-primitive record")
   | PrimRecord info-> Name (pi1 (info.(i)))
   in

--- a/pretyping/nativenorm.ml
+++ b/pretyping/nativenorm.ml
@@ -188,7 +188,7 @@ let branch_of_switch lvl ans bs =
 let get_proj env ((mind, n), i) =
   let mib = Environ.lookup_mind mind env in
   match mib.mind_record with
-  | NotRecord | FakeRecord ->
+  | NotRecord ->
     CErrors.anomaly (Pp.strbrk "Return type is not a primitive record")
   | PrimRecord info ->
     let _, projs, _ = info.(n) in

--- a/pretyping/recordops.mli
+++ b/pretyping/recordops.mli
@@ -76,3 +76,13 @@ val is_open_canonical_projection :
   Environ.env -> Evd.evar_map -> Reductionops.state -> bool
 val canonical_projections : unit ->
   ((GlobRef.t * cs_pattern) * obj_typ) list
+
+(** {5 Non-primitive record encodings} *)
+
+val mark_as_record : MutInd.t -> unit
+(** Given a non-primitive record, i.e. mind_record = NotRecord, mark it as a
+    record encoding. This is chiefly used for printing and extraction
+    purposes. *)
+
+val emulates_record : MutInd.t -> bool
+(** Retrieve the record emulation status *)

--- a/printing/prettyp.ml
+++ b/printing/prettyp.ml
@@ -252,7 +252,7 @@ let print_primitive_record recflag mipv = function
     | BiFinite -> str " with eta conversion"
     in
     [Id.print mipv.(0).mind_typename ++ str" has primitive projections" ++ eta ++ str"."]
-  | FakeRecord | NotRecord -> []
+  | NotRecord -> []
 
 let print_primitive ref =
   match ref with 

--- a/printing/printmod.ml
+++ b/printing/printmod.ml
@@ -216,8 +216,10 @@ let print_record env mind mib udecl =
         sigma (instantiate_cumulativity_info cumi)
   )
 
-let pr_mutual_inductive_body env mind mib udecl =
-  if mib.mind_record != NotRecord && not !Flags.raw_print then
+let pr_mutual_inductive_body env mind mib udecl = match mib.mind_record with
+| PrimRecord _ -> print_record env mind mib udecl
+| NotRecord ->
+  if Recordops.emulates_record mind && not !Flags.raw_print then
     print_record env mind mib udecl
   else
     print_mutual_inductive env mind mib udecl

--- a/tactics/tacticals.ml
+++ b/tactics/tacticals.ml
@@ -753,8 +753,8 @@ module New = struct
     let (ind,t) = pf_reduce_to_quantified_ind gl (pf_unsafe_type_of gl c) in
     let isrec,mkelim =
       match (Global.lookup_mind (fst (fst ind))).mind_record with
-      | NotRecord -> true,gl_make_elim
-      | FakeRecord | PrimRecord _ -> false,gl_make_case_dep
+      | NotRecord when not (Recordops.emulates_record (fst (fst ind))) -> true,gl_make_elim
+      | NotRecord | PrimRecord _ -> false,gl_make_case_dep
     in
     general_elim_then_using mkelim isrec None tac None ind (c, t)
     end

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -519,7 +519,7 @@ let declare_mutual_inductive_with_eliminations mie pl impls =
                     (ConstructRef (ind, succ j)) impls)
                 constrimpls)
       impls;
-  let warn_prim = match mie.mind_entry_record with Some (Some _) -> not prim | _ -> false in
+  let warn_prim = match mie.mind_entry_record with Some _ -> not prim | _ -> false in
   Flags.if_verbose Feedback.msg_info (minductive_message warn_prim names);
   if mie.mind_entry_private == None
   then declare_default_schemes mind;


### PR DESCRIPTION
Instead, we remember that an inductive stands for the encoding of a record in a table in Recordops. This allows to simplify both the kernel and the upper layers. In the process it makes clear who is depending on this data.
