### PR TITLE
Make Travis faster by removing more builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,9 +67,6 @@ matrix:
       - TEST_TARGET="validate"   COMPILER="${COMPILER_BE}+flambda" CAMLP5_VER="${CAMLP5_VER_BE}" NATIVE_COMP="no" EXTRA_CONF="-flambda-opts -O3" FINDLIB_VER="${FINDLIB_VER_BE}"
     - if: NOT (type = pull_request)
       env:
-      - TEST_TARGET="ci-bignums"
-    - if: NOT (type = pull_request)
-      env:
       - TEST_TARGET="ci-color"
     - if: NOT (type = pull_request)
       env:
@@ -85,9 +82,6 @@ matrix:
       - TEST_TARGET="ci-equations"
     - if: NOT (type = pull_request)
       env:
-      - TEST_TARGET="ci-fcsl-pcm"
-    - if: NOT (type = pull_request)
-      env:
       - TEST_TARGET="ci-fiat-parsers"
     - if: NOT (type = pull_request)
       env:
@@ -98,9 +92,6 @@ matrix:
     - if: NOT (type = pull_request)
       env:
       - TEST_TARGET="ci-ltac2"
-    - if: NOT (type = pull_request)
-      env:
-      - TEST_TARGET="ci-math-classes"
     - if: NOT (type = pull_request)
       env:
       - TEST_TARGET="ci-mtac2"


### PR DESCRIPTION
We remove all the testing of external projects from Travis. The current state was inconsistent anyways.
We keep the matrix of test-suite / validate / warnings / doc targets with different OCaml versions.
If people want to do more thorough testing on their personal branches, they will have to setup GitLab CI as explained in dev/ci/README.md. It's not difficult to setup.

The motivation is that yesterday it look longer for just the linter than for the full GitLab CI test suite to run on some PRs, due to a high number of recently merged PRs.