### PR TITLE
Print something after the build completed if it wasn't a runner failure.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,6 +45,9 @@ before_script:
   - opam list
   - opam config list
 
+after_script:
+  - echo "The build completed normally (not a runner failure)."
+
 ################ GITLAB CACHING ######################
 # - use artifacts between jobs                       #
 ######################################################


### PR DESCRIPTION
This can then be leveraged by @coqbot to know which builds to restart.

See also coq/bot#3 and https://gitlab.com/gitlab-org/gitlab-ee/issues/6408.

For instances of failed builds showing or not the marker:
- https://gitlab.com/Zimmi48/coq/-/jobs/79270266 (VST, currently broken)
- https://gitlab.com/Zimmi48/coq/-/jobs/79270265 (UniMath, marked as a script failure by GitLab but it actually is a runner system / code 137 failure)
- https://gitlab.com/Zimmi48/coq/-/jobs/79270263 (QuickChick, same thing)
- https://gitlab.com/Zimmi48/coq/-/jobs/79270258 (mtac2, currently broken)
- https://gitlab.com/Zimmi48/coq/-/jobs/79270233 (test-suite:edge, marked as a runner system failure by GitLab).