### PR TITLE
Fix #7854: Native compilation + flambda trigger SEGFAULT.

### DIFF
--- a/test-suite/bugs/closed/7854.v
+++ b/test-suite/bugs/closed/7854.v
@@ -1,0 +1,10 @@
+Set Primitive Projections.
+
+CoInductive stream (A : Type) := cons {
+  hd : A;
+  tl : stream A;
+}.
+
+CoFixpoint const {A} (x : A) := cons A x (const x).
+
+Check (@eq_refl _ (const tt) <<: tl unit (const tt) = const tt).


### PR DESCRIPTION
We use a more abstract representation for accumulators in the native compilation scheme, that requires less fiddling with low-level implementation details. It might be slower though.

It should probably be backported, as it doesn't break the API.

Fixes #7854.