### PR TITLE
Cache the build of the Nix package using Cachix.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -245,7 +245,8 @@ pkg:nix:
   before_script: [] # We don't want to use the shared 'before_script'
   script:
     - export TMPDIR=$PWD
-    - nix-build "$CI_PROJECT_URL/-/archive/$CI_COMMIT_SHA.tar.gz" -K
+    - nix-env -if https://github.com/cachix/cachix/tarball/master --substituters https://cachix.cachix.org --trusted-public-keys cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM=
+    - nix-build "$CI_PROJECT_URL/-/archive/$CI_COMMIT_SHA.tar.gz" -K --extra-substituters https://coq.cachix.org --trusted-public-keys "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= coq.cachix.org-1:Jgt0DwGAUo+wpxCM52k2V+E0hLoOzFPzvg94F65agtI=" | if [ ! -z "$CACHIX_SIGNING_KEY" ]; then cachix push coq; fi
   artifacts:
     name: "$CI_JOB_NAME.logs"
     when: on_failure

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -240,13 +240,25 @@ pkg:nix:
   image: nixorg/nix:latest # Minimal NixOS image which doesn't even contain git
   stage: test
   variables:
+    # By default we use coq.cachix.org as an extra substituter but this can be overridden
+    EXTRA_SUBSTITUTERS: https://coq.cachix.org
+    EXTRA_PUBLIC_KEYS: coq.cachix.org-1:Jgt0DwGAUo+wpxCM52k2V+E0hLoOzFPzvg94F65agtI=
+    # The following variables should not be overridden
     GIT_STRATEGY: none
+    CACHIX_PUBLIC_KEY: cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM=
+    NIXOS_PUBLIC_KEY: cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+
   dependencies: [] # We don't need to download build artifacts
   before_script: [] # We don't want to use the shared 'before_script'
   script:
+    # Use current worktree as tmpdir to allow exporting artifacts in case of failure
     - export TMPDIR=$PWD
-    - nix-env -if https://github.com/cachix/cachix/tarball/master --substituters https://cachix.cachix.org --trusted-public-keys cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM=
-    - nix-build -E "import (fetchTarball $CI_PROJECT_URL/-/archive/$CI_COMMIT_SHA.tar.gz) {}" -K --extra-substituters https://coq.cachix.org --trusted-public-keys "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= coq.cachix.org-1:Jgt0DwGAUo+wpxCM52k2V+E0hLoOzFPzvg94F65agtI=" | if [ ! -z "$CACHIX_SIGNING_KEY" ]; then cachix push coq; fi
+    # Install Cachix as documented at https://github.com/cachix/cachix
+    - nix-env -if https://github.com/cachix/cachix/tarball/master --substituters https://cachix.cachix.org --trusted-public-keys "$CACHIX_PUBLIC_KEY"
+    # We build an expression rather than a direct URL to not be dependent on
+    # the URL location; we are forced to put the public key of cache.nixos.org
+    # because there is no --extra-trusted-public-key option.
+    - nix-build -E "import (fetchTarball $CI_PROJECT_URL/-/archive/$CI_COMMIT_SHA.tar.gz) {}" -K --extra-substituters "$EXTRA_SUBSTITUTERS" --trusted-public-keys "$NIXOS_PUBLIC_KEY $EXTRA_PUBLIC_KEYS" | if [ ! -z "$CACHIX_SIGNING_KEY" ]; then cachix push coq; fi
   artifacts:
     name: "$CI_JOB_NAME.logs"
     when: on_failure

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -246,7 +246,7 @@ pkg:nix:
   script:
     - export TMPDIR=$PWD
     - nix-env -if https://github.com/cachix/cachix/tarball/master --substituters https://cachix.cachix.org --trusted-public-keys cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM=
-    - nix-build "$CI_PROJECT_URL/-/archive/$CI_COMMIT_SHA.tar.gz" -K --extra-substituters https://coq.cachix.org --trusted-public-keys "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= coq.cachix.org-1:Jgt0DwGAUo+wpxCM52k2V+E0hLoOzFPzvg94F65agtI=" | if [ ! -z "$CACHIX_SIGNING_KEY" ]; then cachix push coq; fi
+    - nix-build -E "import (fetchTarball $CI_PROJECT_URL/-/archive/$CI_COMMIT_SHA.tar.gz) {}" -K --extra-substituters https://coq.cachix.org --trusted-public-keys "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= coq.cachix.org-1:Jgt0DwGAUo+wpxCM52k2V+E0hLoOzFPzvg94F65agtI=" | if [ ! -z "$CACHIX_SIGNING_KEY" ]; then cachix push coq; fi
   artifacts:
     name: "$CI_JOB_NAME.logs"
     when: on_failure

--- a/default.nix
+++ b/default.nix
@@ -86,4 +86,18 @@ stdenv.mkDerivation rec {
 
   installCheckTarget = [ "check" ];
 
+  passthru = { inherit ocamlPackages; };
+
+  meta = {
+    description = "Coq proof assistant";
+    longDescription = ''
+      Coq is a formal proof management system.  It provides a formal language
+      to write mathematical definitions, executable algorithms and theorems
+      together with an environment for semi-interactive development of
+      machine-checked proofs.
+    '';
+    homepage = http://coq.inria.fr;
+    license = licenses.lgpl21;
+  };
+
 }

--- a/default.nix
+++ b/default.nix
@@ -30,6 +30,9 @@
 , buildIde ? true
 , buildDoc ? true
 , doInstallCheck ? true
+, shell ? false
+  # We don't use lib.inNixShell because that would also apply
+  # when in a nix-shell of some package depending on this one.
 }:
 
 with pkgs;
@@ -58,13 +61,13 @@ stdenv.mkDerivation rec {
     optional (!versionAtLeast ocaml.version "4.07") ncurses
     ++ [ ocamlPackages.ounit rsync which ]
   )
-  ++ optionals lib.inNixShell (
+  ++ optionals shell (
     [ jq curl git gnupg ] # Dependencies of the merging script
     ++ (with ocamlPackages; [ merlin ocp-indent ocp-index ]) # Dev tools
   );
 
   src =
-    if lib.inNixShell then null
+    if shell then null
     else
       with builtins; filterSource
         (path: _:

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,4 @@
 # Some developers don't want a pinned nix-shell by default.
 # If you want to use the pin nix-shell or a more sophisticated set of arguments:
-# $ nix-shell default.nix
-import ./default.nix { pkgs = import <nixpkgs> {}; }
+# $ nix-shell default.nix --arg shell true
+import ./default.nix { pkgs = import <nixpkgs> {}; shell = true; }


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

<!-- Keep what applies -->
**Kind:** infrastructure.

This is one more step towards #7161 and #7753.

This PR adds support for the binary cache https://coq.cachix.org for the Coq Nix package.
More precisely, if the `CACHIX_SIGNING_KEY` variable is defined, it will sign the produced packages and push them to the above mentioned binary cache. I'll put this variable on GitLab CI as a protected variable, which means that it will only apply to builds on protected branches, such as master or v8.8.

Since the variable is also defined on my personal GitLab fork, and the build already passed there https://gitlab.com/Zimmi48/coq/-/jobs/79593568, the build of the Nix package for this PR should be quite fast (just fetching binaries).

This was initially inspired by the way Cachix does for its own package (https://github.com/cachix/cachix/, see in particular https://github.com/cachix/cachix/blob/7e31c778db910c829db4235a065f8c5ba46da20f/.travis.yml#L15) but I've changed the way to fetch the package into `nix-build -E "import (fetchTarball $CI_PROJECT_URL/-/archive/$CI_COMMIT_SHA.tar.gz) {}"` because this will avoid depending on the exact URL from where the tarball is downloaded. Instead, the hash of the tarball is computed after download which means that I can compile `$CI_PROJECT_URL/-/archive/$CI_COMMIT_SHA.tar.gz` and then install the package from https://github.com/coq/coq/tarball/master.

It also means that I can depend on this package in other packages. This allows me to setup CI on some external package in the simplest way: https://github.com/Zimmi48/aac-tactics/commit/b788c75f93c2edb6836b73d295e31224830f4a64.  See the corresponding build here https://travis-ci.com/Zimmi48/aac-tactics/builds/78159513. It ends up failing because aac_tactics is not yet compatible with Coq master. But notice how Coq is fetched and not rebuilt.

cc @domenkozar: I'm sure you'll be interested to hear about this application of Cachix.