### PR TITLE
make-both-single-timing-files: fix --sort-by=diff

### DIFF
--- a/tools/TimeFileMaker.py
+++ b/tools/TimeFileMaker.py
@@ -144,13 +144,14 @@ def make_diff_table_string(left_times_dict, right_times_dict,
                                    for name, lseconds, rseconds in prediff_times)
     # update to sort by approximate difference, first
     get_key_abs = make_sorting_key(all_names_dict, descending=descending)
-    get_key_diff = (lambda name: fix_sign_for_sorting(int(abs(to_seconds(diff_times_dict[name]))), descending=descending))
+    get_key_diff_float = (lambda name: fix_sign_for_sorting(abs(to_seconds(diff_times_dict[name])), descending=descending))
+    get_key_diff_int = (lambda name: fix_sign_for_sorting(int(abs(to_seconds(diff_times_dict[name]))), descending=descending))
     if sort_by == 'absolute':
         get_key = get_key_abs
     elif sort_by == 'diff':
-        get_key = get_key_diff
+        get_key = get_key_diff_float
     else: # sort_by == 'auto'
-        get_key = (lambda name: (get_key_diff(name), get_key_abs(name)))
+        get_key = (lambda name: (get_key_diff_int(name), get_key_abs(name)))
     names = sorted(all_names_dict.keys(), key=get_key)
     #names = get_sorted_file_list_from_times_dict(all_names_dict, descending=descending)
     # set the widths of each of the columns by the longest thing to go in that column

--- a/tools/TimeFileMaker.py
+++ b/tools/TimeFileMaker.py
@@ -144,14 +144,14 @@ def make_diff_table_string(left_times_dict, right_times_dict,
                                    for name, lseconds, rseconds in prediff_times)
     # update to sort by approximate difference, first
     get_key_abs = make_sorting_key(all_names_dict, descending=descending)
-    get_key_diff_float = (lambda name: fix_sign_for_sorting(abs(to_seconds(diff_times_dict[name])), descending=descending))
-    get_key_diff_int = (lambda name: fix_sign_for_sorting(int(abs(to_seconds(diff_times_dict[name]))), descending=descending))
+    get_key_diff_float = (lambda name: fix_sign_for_sorting(to_seconds(diff_times_dict[name]), descending=descending))
+    get_key_diff_absint = (lambda name: fix_sign_for_sorting(int(abs(to_seconds(diff_times_dict[name]))), descending=descending))
     if sort_by == 'absolute':
         get_key = get_key_abs
     elif sort_by == 'diff':
         get_key = get_key_diff_float
     else: # sort_by == 'auto'
-        get_key = (lambda name: (get_key_diff_int(name), get_key_abs(name)))
+        get_key = (lambda name: (get_key_diff_absint(name), get_key_abs(name)))
     names = sorted(all_names_dict.keys(), key=get_key)
     #names = get_sorted_file_list_from_times_dict(all_names_dict, descending=descending)
     # set the widths of each of the columns by the longest thing to go in that column


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** bug fix.

Previously, "sorted" output could look like this:
```
After     | Code                                                          | Before    || Change    | % Change 
--------------------------------------------------------------------------------------------------------------
3m23.75s  | Total                                                         | 2m38.35s  || +0m45.40s | +28.67%  
--------------------------------------------------------------------------------------------------------------
0m32.08s  | Chars 60026 - 60035 [End~code.]                               | 0m23.932s || +0m08.14s | +34.04%  
0m19.326s | Chars 60021 - 60025 [Qed.]                                    | 0m15.875s || +0m03.45s | +21.73%  
0m04.327s | Chars 44373 - 44377 [Qed.]                                    | 0m03.119s || +0m01.20s | +38.73%  
0m06.806s | Chars 19856 - 19860 [Qed.]                                    | 0m05.006s || +0m01.79s | +35.95%  
0m07.917s | Chars 09831 - 10013 [(constructor;~~~solve_proper_c...]       | 0m05.942s || +0m01.97s | +33.23%  
0m04.843s | Chars 32121 - 32125 [Qed.]                                    | 0m03.479s || +0m01.36s | +39.20%  
0m04.099s | Chars 09048 - 09052 [Qed.]                                    | 0m02.538s || +0m01.56s | +61.50%  
0m04.826s | Chars 48906 - 48910 [Qed.]                                    | 0m03.514s || +0m01.31s | +37.33%  
0m03.844s | Chars 26074 - 26078 [Qed.]                                    | 0m02.719s || +0m01.12s | +41.37%  
0m00.003s | Chars 15737 - 15747 [iModIntro.]                              | 0m00.001s || +0m00.00s | +200.00% 
0m00.074s | Chars 31688 - 31816 [(<ssreflect_plugin::ssrtclseq@...]       | 0m00.12s  || -0m00.04s | -38.33%  
0m00.107s | Chars 46605 - 46611 [wp_op.]                                  | 0m00.072s || +0m00.03s | +48.61%  
0m00.s    | Chars 47297 - 47298 [{]                                       | 0m00.s    || +0m00.00s | N/A
```
Not very sorted, if you ask me.