### PR TITLE
Set PYTHONIOENCODING in ci-wrapper

### DIFF
--- a/dev/ci/ci-wrapper.sh
+++ b/dev/ci/ci-wrapper.sh
@@ -21,6 +21,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "${DIR}/../.."
 
 export TIMED=1
+export PYTHONIOENCODING=UTF-8
 "${DIR}/${CI_SCRIPT}" 2>&1 | tee time-of-build.log
 travis_fold 'start' 'coq.test.timing' && echo 'Aggregating timing log...'
 python ./tools/make-one-time-file.py time-of-build.log


### PR DESCRIPTION
**Kind:** bug fix
Fix unicode encoding bug noticed after #7990 was merged.

This should work, but I didn't test it. Take it with a grain of salt.
I can write something which always outputs UTF-8, but I'll have to case on `sys.version_num`.

@JasonGross @Zimmi48