### PR TITLE
Fixing #8011: full check of typability of terms from ltac signature.

### DIFF
--- a/test-suite/bugs/closed/bug_3459.v
+++ b/test-suite/bugs/closed/bug_3459.v
@@ -6,14 +6,12 @@ Goal 1 = 2.
 Proof.
 (* This line used to fail with a Not_found up to some point, and then
    to produce an ill-typed term *)
-match goal with
+Fail match goal with
   | [ |- context G[2] ] => let y := constr:(fun x => ltac:(let r := constr:(@eq Set x x) in
                                                        clear x;
                                                        exact r)) in
                            pose y
 end.
-(* Add extra test for typability (should not fail when bug closed) *)
-Fail match goal with P:?c |- _ => try (let x := type of c in idtac) || fail 2 end.
 Abort.
 
 (* Second report raising a Not_found at the time of 21 Oct 2014 *)

--- a/test-suite/bugs/closed/bug_3460.v
+++ b/test-suite/bugs/closed/bug_3460.v
@@ -1,0 +1,14 @@
+Goal Set -> Prop.
+intro x.
+Fail let r := constr:(@ eq Set x x) in
+clear x;
+exact r.
+Abort.
+
+Goal False.
+Proof.
+Fail set (x := True);
+let y := constr: (I : x) in
+clear x; set (x := False);
+exact y.
+Abort.

--- a/test-suite/bugs/closed/bug_8011.v
+++ b/test-suite/bugs/closed/bug_8011.v
@@ -1,0 +1,23 @@
+Goal forall a b : nat, forall (X:a = b), True.
+  intros.
+  Fail let T := constr:(a = b) in
+    destruct X;
+      pose (fun Y:T => ltac:(destruct Y; exact I) : True);
+    exact I.
+(* was: Anomaly "variable b unbound." Please report at http://coq.inria.fr/bugs/. *)
+Abort.
+
+Goal forall a b : nat, forall (X:a = b), True.
+  intros.
+  Fail let T := constr:(a = b) in
+    destruct X;
+      pose (fun Y:T => ltac:(induction Y; exact I) : True);
+    exact I.
+(* Was: Anomaly "variable b unbound." Please report at http://coq.inria.fr/bugs/. *)
+Abort.
+
+Goal forall a b : nat, True.
+intros.
+Fail let T := constr:(a = b) in clear b; pose (fun Y:T => Y).
+(* was not failing but building a wrong context *)
+Abort.

--- a/test-suite/success/Case22.v
+++ b/test-suite/success/Case22.v
@@ -3,7 +3,10 @@
 Inductive I : let a := 1 in a=a -> let b := 2 in Type := C : I (eq_refl).
 Lemma a : forall x:I eq_refl, match x in I a b c return b = b with C => eq_refl end = eq_refl.
 intro.
+(* cbv does not preserve let-in in return predicate, let's wait for #9870 to fix it *)
+Unset Ltac Constr Full Typing.
 match goal with |- ?c => let x := eval cbv in c in change x end.
+Set Ltac Constr Full Typing.
 Abort.
 
 Check forall x:I eq_refl, match x in I x return x = x with C => eq_refl end = eq_refl.


### PR DESCRIPTION
**Kind:**  bug fix

Fixes #8011 (and possibly other similar bug reports).

@zimmi48 comment at [#8011](https://github.com/coq/coq/issues/8011#issuecomment-403096166) convinced me that it was unreasonable to deliberatedly leave a known source of anomaly. This PR fixes the problem, to the price of some (possible) overhead. I did not follow closely the evolution of the benchmark infrastructure. If someone can start a bench on code using ltac intensively, that would be great.

Added:  fixes #3459, fixes #3460, fixes #5378, fixes #5504.