### PR TITLE
Introduce a team of code owners for the CI system.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,21 +8,14 @@
 
 ########## CI infrastructure ##########
 
-/dev/ci/               @ejgallego
-# Secondary maintainer @SkySkimmer
+/dev/ci/          @coq/ci-maintainers
+/.circleci/       @coq/ci-maintainers
+/.travis.yml      @coq/ci-maintainers
+/.gitlab-ci.yml   @coq/ci-maintainers
 
 /dev/ci/user-overlays/*.sh @ghost
 # Trick to avoid getting review requests
 # each time someone adds an overlay
-
-/.circleci/       @SkySkimmer
-# Secondary maintainer @ejgallego
-
-/.travis.yml      @ejgallego
-# Secondary maintainer @SkySkimmer
-
-/.gitlab-ci.yml   @SkySkimmer
-# Secondary maintainer @ejgallego
 
 /appveyor.yml          @maximedenes
 /dev/ci/appveyor.*     @maximedenes


### PR DESCRIPTION
This means that all the members of the team will receive a review request for PRs on the CI, but only one of them will need to approve the PR, and this will remove the review request for the others.

Currently the team contains Emilio and Gaetan, the two current code owners of these files. It makes sense to start experimenting on this component since they had already decided to make their role symmetric.

Updating the list of maintainers can be done by updating the list members, and without changing the CODEOWNER file.

If this is seen as a good idea, we can slowly convert the rest of the CODEOWNER file using this style (add a documentation-maintainers team, build-system-maintainers team, etc.).