### PR TITLE
Remove auto-retry in GitLab CI now that @coqbot is handling it.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,7 +55,6 @@ after_script:
 # TODO figure out how to build doc for installed Coq
 .build-template: &build-template
   stage: build
-  retry: 1
   artifacts:
     name: "$CI_JOB_NAME"
     paths:


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** infrastructure.

@coqbot is now automatically retrying builds which failed because of a runner failure (those without the magic sentence "The build completed normally"). You may have noticed already, but it's also adding new status checks for real failures too.