### PR TITLE
Clean-up user-overlays folder.

### DIFF
--- a/dev/ci/user-overlays/07746-cleanup-unused-various.sh
+++ b/dev/ci/user-overlays/07746-cleanup-unused-various.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-if [ "$CI_PULL_REQUEST" = "7746" ] || [ "$CI_BRANCH" = "cleanup-unused-various" ]; then
-    Equations_CI_BRANCH="adapt-unused"
-    Equations_CI_GITURL="https://github.com/SkySkimmer/Coq-Equations.git"
-fi

--- a/dev/ci/user-overlays/07820-mattam82-hints-constants.sh
+++ b/dev/ci/user-overlays/07820-mattam82-hints-constants.sh
@@ -1,6 +1,0 @@
-_OVERLAY_BRANCH=hints-variables-overlay
-
-if [ "$CI_PULL_REQUEST" = "7820" ] || [ "$CI_BRANCH" = "_OVERLAY_BRANCH" ]; then
-
-    Equations_CI_BRANCH="$_OVERLAY_BRANCH"
-fi

--- a/dev/ci/user-overlays/07898-ppedrot-rm-campl4-remains.sh
+++ b/dev/ci/user-overlays/07898-ppedrot-rm-campl4-remains.sh
@@ -1,8 +1,0 @@
-_OVERLAY_BRANCH=rm-campl4-remains
-
-if [ "$CI_PULL_REQUEST" = "7898" ] || [ "$CI_BRANCH" = "$_OVERLAY_BRANCH" ]; then
-
-    pidetop_CI_BRANCH="$_OVERLAY_BRANCH"
-    pidetop_CI_GITURL=https://github.com/ppedrot/pidetop
-
-fi

--- a/dev/ci/user-overlays/07902-ppedrot-camlp5-parser.sh
+++ b/dev/ci/user-overlays/07902-ppedrot-camlp5-parser.sh
@@ -1,8 +1,0 @@
-_OVERLAY_BRANCH=camlp5-parser
-
-if [ "$CI_PULL_REQUEST" = "7902" ] || [ "$CI_BRANCH" = "$_OVERLAY_BRANCH" ]; then
-
-    ltac2_CI_BRANCH="$_OVERLAY_BRANCH"
-    ltac2_CI_GITURL=https://github.com/ppedrot/ltac2
-
-fi


### PR DESCRIPTION
The main point of this PR is to get rid of `dev/ci/user-overlays/07746-cleanup-unused-various.sh` to avoid confusion.