### PR TITLE
[performance] Evarutil.finalize redux

### DIFF
--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -54,6 +54,20 @@ let new_global evd x =
 (* Expanding/testing/exposing existential variables *)
 (****************************************************)
 
+let finalize ?abort_on_undefined_evars ?(skip_restrict=false) env sigma f =
+  let sigma = minimize_universes sigma in
+  if skip_restrict then sigma, f (fun c -> EConstr.to_constr ?abort_on_undefined_evars sigma c)
+  else
+    let uvars = ref Univ.LSet.empty in
+    let v = f (fun c ->
+        let varsc = EConstr.universes_of_constr sigma c in
+        let c = EConstr.to_constr ?abort_on_undefined_evars sigma c in
+        uvars := Univ.LSet.union !uvars varsc;
+        c)
+    in
+    let sigma = restrict_universe_context sigma !uvars in
+    sigma, v
+
 (* flush_and_check_evars fails if an existential is undefined *)
 
 exception Uninstantiated_evar of Evar.t

--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -185,6 +185,19 @@ val nf_evar_map_universes : evar_map -> evar_map * (Constr.constr -> Constr.cons
 exception Uninstantiated_evar of Evar.t
 val flush_and_check_evars :  evar_map -> constr -> Constr.constr
 
+(** [finalize env sigma f] combines universe minimisation,
+   evar-and-universe normalisation and universe restriction.
+
+    It minimizes universes in [sigma], calls [f] a normalisation
+   function with respect to the updated [sigma] and restricts the
+   local universes of [sigma] to those encountered while running [f].
+
+    Note that the normalizer passed to [f] holds some imperative state
+   in its closure. *)
+val finalize : ?abort_on_undefined_evars:bool -> ?skip_restrict:bool -> env -> evar_map ->
+  ((EConstr.t -> Constr.t) -> 'a) ->
+  evar_map * 'a
+
 (** {6 Term manipulation up to instantiation} *)
 
 (** Like {!Constr.kind} except that [kind_of_term sigma t] exposes [t]

--- a/vernac/comAssumption.ml
+++ b/vernac/comAssumption.ml
@@ -159,15 +159,9 @@ let do_assumptions kind nl l =
   in
   let sigma = solve_remaining_evars all_and_fail_flags env sigma (Evd.from_env env) in
   (* The universe constraints come from the whole telescope. *)
-  let sigma = Evd.minimize_universes sigma in
-  let nf_evar c = EConstr.to_constr sigma c in
-  let uvars, l = List.fold_left_map (fun uvars (coe,t,imps) ->
-      let t = nf_evar t in
-      let uvars = Univ.LSet.union uvars (Univops.universes_of_constr t) in
-      uvars, (coe,t,imps))
-      Univ.LSet.empty l
+  let sigma, l = Evarutil.finalize env sigma
+      (fun nf -> List.map (fun (coe,t,imps) -> coe,nf t,imps) l)
   in
-  let sigma = Evd.restrict_universe_context sigma uvars in
   let uctx = Evd.check_univ_decl ~poly:(pi2 kind) sigma udecl in
   let ubinders = Evd.universe_binders sigma in
   pi2 (List.fold_left (fun (subst,status,uctx) ((is_coe,idl),t,imps) ->


### PR DESCRIPTION
@SkySkimmer 
This is a fork of coq/coq#7530, `SkySkimmer:evar-finalize`, to investigate
the performance loss there. The uses of finalize in `vernac/comAssumption.ml` and
`vernac/comDefinition.ml` at most change whether the universes are
calculated after normalization by either `Univops.universes_of_constr c`
or `EConstr.universes_of_constr sigma (EConstr.of_constr c)` to
calculating before normalizing by `EConstr.universes_of_constr sigma c`.

The remaining changes in #7530, `vernac/classes.ml`,
`vernac/comFixpoint.ml`, and `vernac/record.ml`
look like they change functionality more dramatically,
so I'll put them in a separate commit.

I'd like this to be benchmarked, so we can see if the time increase in hott and odd-order persists with this reduced change set.