### PR TITLE
Simplify code for [Definition := Eval ...]

### DIFF
--- a/pretyping/nativenorm.ml
+++ b/pretyping/nativenorm.ml
@@ -132,15 +132,15 @@ let construct_of_constr_notnative const env tag (mind, _ as ind) u allargs =
   (mkApp(mkConstructU((ind,i),u), params), ctyp)
  
 
-let construct_of_constr const env tag typ =
+let construct_of_constr const env sigma tag typ =
   let t, l = app_type env typ in
-  match kind t with
+  match EConstr.kind_upto sigma t with
   | Ind (ind,u) -> 
       construct_of_constr_notnative const env tag ind u l
   | _ -> assert false
 
-let construct_of_constr_const env tag typ = 
-  fst (construct_of_constr true env tag typ)
+let construct_of_constr_const env sigma tag typ =
+  fst (construct_of_constr true env sigma tag typ)
 
 let construct_of_constr_block = construct_of_constr false
 
@@ -207,9 +207,9 @@ let rec nf_val env sigma v typ =
       let env = push_rel (LocalAssum (name,dom)) env in
       let body = nf_val env sigma (f (mk_rel_accu lvl)) codom in
       mkLambda(name,dom,body)
-  | Vconst n -> construct_of_constr_const env n typ
+  | Vconst n -> construct_of_constr_const env sigma n typ
   | Vblock b ->
-      let capp,ctyp = construct_of_constr_block env (block_tag b) typ in
+      let capp,ctyp = construct_of_constr_block env sigma (block_tag b) typ in
       let args = nf_bargs env sigma b ctyp in
       mkApp(capp,args)
 

--- a/test-suite/bugs/closed/bug_3690.v
+++ b/test-suite/bugs/closed/bug_3690.v
@@ -41,8 +41,5 @@ Type@{Top.34} -> Type@{Top.37}
                                   Top.36 < Top.34
                                   Top.37 < Top.36
                                    *) *)
-Fail Check @qux@{Set Set}.
-Check @qux@{Type Type Type Type}.
-(* [qux] should only need two universes *)
-Check @qux@{i j k l}.  (* Error: The command has not failed!, but I think this is suboptimal *)
-Fail Check @qux@{i j}.
+Check @qux@{Type Type}.
+(* used to have 4 universes *)

--- a/test-suite/bugs/closed/bug_3956.v
+++ b/test-suite/bugs/closed/bug_3956.v
@@ -129,13 +129,13 @@ Module Comodality_Theory (F : Comodality).
       := IdmapM FPM.
     Module cip_FPM := FPM.coindpathsM FPM cmpinv_o_cmp_M idmap_FPM.
     Module cip_FPHM <: HomotopyM FPM cmpM.PM cip_FPM.fhM cip_FPM.fkM.
-      Definition m : forall x, cip_FPM.fhM.m@{i j} x = cip_FPM.fkM.m@{i j} x.
+      Definition m : forall x, cip_FPM.fhM.m x = cip_FPM.fkM.m x.
       Proof.
         intros x.
-        refine (concat (cmpinvM.m_beta@{i j} (cmpM.m@{i j} x)) _).
+        refine (concat (cmpinvM.m_beta (cmpM.m x)) _).
         apply path_prod@{i i i}; simpl.
-        - exact (cmpM.FfstM.mM.m_beta@{i j} x).
-        - exact (cmpM.FsndM.mM.m_beta@{i j} x).
+        - exact (cmpM.FfstM.mM.m_beta x).
+        - exact (cmpM.FsndM.mM.m_beta x).
       Defined.
     End cip_FPHM.
   End isequiv_F_prod_cmp_M.

--- a/test-suite/bugs/closed/bug_7631.v
+++ b/test-suite/bugs/closed/bug_7631.v
@@ -7,6 +7,7 @@ Section Foo.
 Let bar := foo.
 
 Eval native_compute in bar.
+Eval vm_compute in bar.
 
 End Foo.
 
@@ -17,5 +18,6 @@ Module RelContext.
 Definition foo := true.
 
 Definition bar (x := foo) := Eval native_compute in x.
+Definition barvm (x := foo) := Eval vm_compute in x.
 
 End RelContext.


### PR DESCRIPTION
This fixes #3690 for real (it was added to the test suite as closed even though it was wontfix for some reason) by restricting universes after running the Eval.

Note the commit touching nativenorm, I don't know if that's the right fix but without it the test for #7631 breaks with assert false. I don't know if there's a way to trigger it with the current system but it's not good for a function taking econstr to fail when the constr is not evar normal.
I have further simplification in mind which would may make it suboptimal to econstr.to_constr before the eval so I avoided it but if someone strongly thinks it's better I can deal with it.