### PR TITLE
[build] Build Coq and plugins with `-strict-sequence`

### DIFF
--- a/configure.ml
+++ b/configure.ml
@@ -475,6 +475,7 @@ let coq_bin_annot_flag = if !prefs.bin_annot then "-bin-annot" else ""
 (* This variable can be overriden only for debug purposes, use with
    care. *)
 let coq_safe_string = "-safe-string"
+let coq_strict_sequence = "-strict-sequence"
 
 let cflags = "-Wall -Wno-unused -g -O2"
 
@@ -661,7 +662,7 @@ let coq_warn_error =
 
 (* Flags used to compile Coq and plugins (via coq_makefile) *)
 let caml_flags =
-  Printf.sprintf "-thread -rectypes %s %s %s %s" coq_warnings coq_annot_flag coq_bin_annot_flag coq_safe_string
+  Printf.sprintf "-thread -rectypes %s %s %s %s %s" coq_warnings coq_annot_flag coq_bin_annot_flag coq_safe_string coq_strict_sequence
 
 (* Flags used to compile Coq but _not_ plugins (via coq_makefile) *)
 let coq_caml_flags =

--- a/ide/gtk_parsing.ml
+++ b/ide/gtk_parsing.ml
@@ -35,8 +35,11 @@ let find_word_start (it:GText.iter) =
       (Minilib.log "find_word_start: cannot backward"; it)
     else if is_word_char it#char
     then step_to_start it
-    else (it#nocopy#forward_char;
-	Minilib.log ("Word start at: "^(string_of_int it#offset));it)
+    else begin
+      ignore(it#nocopy#forward_char);
+      Minilib.log ("Word start at: "^(string_of_int it#offset));
+      it
+    end
   in
     step_to_start it#copy
 

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -552,7 +552,7 @@ let find_fresh_name renaming (terms,termlists,binders,binderlists) avoid id =
 
 let is_var store pat =
   match DAst.get pat with
-  | PatVar na -> store na; true
+  | PatVar na -> ignore(store na); true
   | _ -> false
 
 let out_var pat =

--- a/plugins/funind/recdef.mli
+++ b/plugins/funind/recdef.mli
@@ -14,6 +14,6 @@ bool ->
            int -> Constrexpr.constr_expr -> (pconstant ->
             Indfun_common.tcc_lemma_value ref ->
             pconstant ->
-            pconstant -> int -> EConstr.types -> int -> EConstr.constr -> 'a) -> Constrexpr.constr_expr list -> unit
+            pconstant -> int -> EConstr.types -> int -> EConstr.constr -> unit) -> Constrexpr.constr_expr list -> unit
 
 

--- a/plugins/micromega/mutils.mli
+++ b/plugins/micromega/mutils.mli
@@ -30,7 +30,7 @@ end
 
 module TagSet : CSig.SetS with type elt = Tag.t
 
-val pp_list : (out_channel -> 'a -> 'b) -> out_channel -> 'a list -> unit
+val pp_list : (out_channel -> 'a -> unit) -> out_channel -> 'a list -> unit
 
 module CamlToCoq : sig
 


### PR DESCRIPTION
Fixes #8067. This is becoming the default in many developments, so it
makes sense to require it too, both for Coq and for Plugins.
