### PR TITLE
Only check overlay extensions on git-tracked files

### DIFF
--- a/dev/tools/check-overlays.sh
+++ b/dev/tools/check-overlays.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-for f in dev/ci/user-overlays/*
+for f in $(git ls-files "dev/ci/user-overlays/")
 do
-    if ! ([[ $f = dev/ci/user-overlays/README.md ]] || [[ $f == *.sh ]])
+    if ! ([[ "$f" = dev/ci/user-overlays/README.md ]] || [[ "$f" == *.sh ]])
     then
         >&2 echo "Bad overlay '$f'."
         >&2 echo "User overlays need to have extension .sh to be picked up!"


### PR DESCRIPTION
This way, when editors leave over temporary files from editing
user-overlays, we don't prevent commits unless they are added to git.

**Kind:** feature / infrastructure.