### PR TITLE
Fix #7291: unify tactic should have more descriptive error messages.

### DIFF
--- a/doc/sphinx/proof-engine/tactics.rst
+++ b/doc/sphinx/proof-engine/tactics.rst
@@ -3976,7 +3976,7 @@ succeeds, and results in an error otherwise.
    This tactic checks whether its arguments are unifiable, potentially
    instantiating existential variables.
 
-.. exn:: Not unifiable.
+.. exn:: Unable to unify @term with @term.
 
 .. tacv:: unify @term @term with @ident
 

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -5062,6 +5062,7 @@ let constr_eq ~strict x y =
 
 let unify ?(state=full_transparent_state) x y =
   Proofview.Goal.enter begin fun gl ->
+  let env = Proofview.Goal.env gl in
   let sigma = Proofview.Goal.sigma gl in
   try
     let core_flags =
@@ -5077,7 +5078,7 @@ let unify ?(state=full_transparent_state) x y =
     let sigma = w_unify (Tacmach.New.pf_env gl) sigma Reduction.CONV ~flags x y in
     Proofview.Unsafe.tclEVARS sigma
   with e when CErrors.noncritical e ->
-    Tacticals.New.tclFAIL 0 (str"Not unifiable")
+    Proofview.tclZERO (PretypeError (env, sigma, CannotUnify (x, y, None)))
   end
 
 module Simple = struct


### PR DESCRIPTION
We simply reuse the same exception as the pretyper instead of raising the generic failure exception in Tactics.unify.

Fixes / closes #7291.