### PR TITLE
Remove `Automatic Coercions Import` option.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -149,6 +149,8 @@ Vernacular commands
 
 - `Hypotheses` and `Variables` can now take implicit binders inside sections.
 
+- Removed deprecated option `Automatic Coercions Import`.
+
 Tools
 
 - The `-native-compiler` flag of `coqc` and `coqtop` now takes an argument which can have three values:

--- a/doc/sphinx/addendum/implicit-coercions.rst
+++ b/doc/sphinx/addendum/implicit-coercions.rst
@@ -322,21 +322,8 @@ are also forgotten.
 Coercions and Modules
 ---------------------
 
-.. flag:: Automatic Coercions Import
-
-   Since |Coq| version 8.3, the coercions present in a module are activated
-   only when the module is explicitly imported. Formerly, the coercions
-   were activated as soon as the module was required, whether it was
-   imported or not.
-
-   This option makes it possible to recover the behavior of the versions of
-   |Coq| prior to 8.3.
-
-.. warn:: Coercion used but not in scope: @qualid. If you want to use this coercion, please Import the module that contains it.
-
-   This warning is emitted when typechecking relies on a coercion
-   contained in a module that has not been explicitely imported. It helps
-   migrating code and stop relying on the option above.
+The coercions present in a module are activated only when the module is
+explicitly imported.
 
 Examples
 --------

--- a/pretyping/classops.mli
+++ b/pretyping/classops.mli
@@ -113,5 +113,3 @@ val coercions : unit -> coe_info_typ list
 (** [hide_coercion] returns the number of params to skip if the coercion must
    be hidden, [None] otherwise; it raises [Not_found] if not a coercion *)
 val hide_coercion : coe_typ -> int option
-
-val is_coercion_in_scope : GlobRef.t -> bool

--- a/pretyping/coercion.ml
+++ b/pretyping/coercion.ml
@@ -368,20 +368,12 @@ let saturate_evd env evd =
   Typeclasses.resolve_typeclasses
     ~filter:Typeclasses.no_goals ~split:true ~fail:false env evd
 
-let warn_coercion_not_in_scope =
-  CWarnings.create ~name:"coercion-not-in-scope" ~category:"deprecated"
-    Pp.(fun r -> str "Coercion used but not in scope: " ++
-              Nametab.pr_global_env Id.Set.empty r ++ str ". If you want to use "
-              ++ str "this coercion, please Import the module that contains it.")
-
 (* Apply coercion path from p to hj; raise NoCoercion if not applicable *)
 let apply_coercion env sigma p hj typ_cl =
   try
     let j,t,evd = 
       List.fold_left
         (fun (ja,typ_cl,sigma) i ->
-           if not (is_coercion_in_scope i.coe_value) then
-             warn_coercion_not_in_scope i.coe_value;
            let isid = i.coe_is_identity in
            let isproj = i.coe_is_projection in
            let sigma, c = new_global sigma i.coe_value in


### PR DESCRIPTION
This option made the Coercions command follow non-standard scoping rules
(effect on `Require` rather than `Import`). It was already marked for deletion
in 8.8.

- [X] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [X] Entry added in CHANGES.
