### PR TITLE
Fix #8043: Unsafe assignment in checker.

### DIFF
--- a/checker/validate.ml
+++ b/checker/validate.ml
@@ -85,6 +85,7 @@ let rec val_gen v ctx o = match v with
   | Fail s -> fail ctx o ("unexpected object " ^ s)
   | Annot (s,v) -> val_gen v (ctx/CtxAnnot s) o
   | Dyn -> val_dyn ctx o
+  | Proxy { contents = v } -> val_gen v ctx o
 
 (* Check that an object is a tuple (or a record). vs is an array of
    value representation for each field. Its size corresponds to the

--- a/checker/values.mli
+++ b/checker/values.mli
@@ -20,6 +20,7 @@ type value =
   | String
   | Annot of string * value
   | Dyn
+  | Proxy of value ref
 
 val v_univopaques : value
 val v_libsum : value


### PR DESCRIPTION
We use a dedicated mutable constructor to perform a Landin knot.