### PR TITLE
 Warnings on coercions used without being Imported

### DIFF
--- a/doc/sphinx/addendum/implicit-coercions.rst
+++ b/doc/sphinx/addendum/implicit-coercions.rst
@@ -325,6 +325,12 @@ Coercions and Modules
    This option makes it possible to recover the behavior of the versions of
    |Coq| prior to 8.3.
 
+.. warn:: Coercion used but not in scope: @qualid. If you want to use this coercion, please Import the module that contains it.
+
+          This warning is emitted when typechecking relies on a coercion
+          contained in a module that has not been explicitely imported. It helps
+          migrating code and stop relying on the option above.
+
 Examples
 --------
 

--- a/pretyping/classops.mli
+++ b/pretyping/classops.mli
@@ -113,3 +113,5 @@ val coercions : unit -> coe_info_typ list
 (** [hide_coercion] returns the number of params to skip if the coercion must
    be hidden, [None] otherwise; it raises [Not_found] if not a coercion *)
 val hide_coercion : coe_typ -> int option
+
+val is_coercion_in_scope : GlobRef.t -> bool


### PR DESCRIPTION
This warning makes it much easier to stop relying on `Set Automatic
Coercions Import`. Tested with success on math-classes.

Depends on #8103 [merged].