### PR TITLE
Fixes #8106: anomaly if declaring levels for only printing then only parsing

### DIFF
--- a/parsing/notgram_ops.ml
+++ b/parsing/notgram_ops.ml
@@ -19,8 +19,10 @@ open Notation_gram
 let notation_level_map = Summary.ref ~name:"notation_level_map" NotationMap.empty
 
 let declare_notation_level ?(onlyprint=false) ntn level =
-  if NotationMap.mem ntn !notation_level_map then
-    anomaly (str "Notation " ++ pr_notation ntn ++ str " is already assigned a level.");
+  try
+    let (level,onlyprint) = NotationMap.find ntn !notation_level_map in
+    if not onlyprint then anomaly (str "Notation " ++ pr_notation ntn ++ str " is already assigned a level.")
+  with Not_found ->
   notation_level_map := NotationMap.add ntn (level,onlyprint) !notation_level_map
 
 let level_of_notation ?(onlyprint=false) ntn =

--- a/test-suite/bugs/closed/8106.v
+++ b/test-suite/bugs/closed/8106.v
@@ -1,0 +1,4 @@
+(* Was raising an anomaly "already assigned a level" on the second line *)
+
+Notation "c1 ; c2" := (c1 + c2) (only printing, at level 76, right associativity, c1 at level 76, c2 at level 76).
+Notation "c1 ; c2" := (c1 + c2) (only parsing, at level 76, right associativity, c2 at level 76).


### PR DESCRIPTION
The fix is simple, see code.

Remark: Notations were not initially designed to support independent parsing and printing rules. Some redesign of this part of the code shall be necessary at some time.

**Kind:** bug fix

Fixes / closes #8106

- [X] Added / updated test-suite