### PR TITLE
[doc] Fix grammar of goal selectors.

### DIFF
--- a/doc/sphinx/proof-engine/ltac.rst
+++ b/doc/sphinx/proof-engine/ltac.rst
@@ -144,10 +144,11 @@ mode but it can also be used in toplevel definitions as shown below.
                      : | `integer` (< | <= | > | >=) `integer`
    selector          : [`ident`]
                      : | `integer`
-                     : (`integer` | `integer` - `integer`), ..., (`integer` | `integer` - `integer`)
+                     : | (`integer` | `integer` - `integer`), ..., (`integer` | `integer` - `integer`)
    toplevel_selector : `selector`
-                     : | `all`
-                     : | `par`
+                     : | all
+                     : | par
+                     : | !
 
 .. productionlist:: coq
    top              : [Local] Ltac `ltac_def` with ... with `ltac_def`


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** documentation fix

The grammar had not been updated in #6944.