### PR TITLE
Fixing capital letters in the "in" syntax of instantiate.

### DIFF
--- a/doc/sphinx/proof-engine/tactics.rst
+++ b/doc/sphinx/proof-engine/tactics.rst
@@ -1323,8 +1323,8 @@ name of the variable (here :g:`n`) is chosen based on :g:`T`.
    changes in the goal, its use is strongly discouraged.
 
 .. tacv:: instantiate ( @num := @term ) in @ident
-.. tacv:: instantiate ( @num := @term ) in ( Value of @ident )
-.. tacv:: instantiate ( @num := @term ) in ( Type of @ident )
+.. tacv:: instantiate ( @num := @term ) in ( value of @ident )
+.. tacv:: instantiate ( @num := @term ) in ( type of @ident )
 
    These allow to refer respectively to existential variables occurring in a
    hypothesis or in the body or the type of a local definition.


### PR DESCRIPTION
This trace of V7-style capital letters in an admittedly uncommon syntax remained unnoticed for 14 years.

**Kind:** bug fix

Found by @zeimer (see #8072).

The PR is purely about the syntax side (not about the technical issues with `instantiate`, #5378, #5504, #5505, ...).