### PR TITLE
Make universe object Dispose

### DIFF
--- a/interp/declare.ml
+++ b/interp/declare.ml
@@ -479,13 +479,13 @@ let cache_universe_context (p, ctx) =
   Global.push_context_set p ctx;
   if p then Lib.add_section_context ctx
 
+(* Universes are Dispose because they are included in the kernel module structure. *)
 let input_universe_context : universe_context_decl -> Libobject.obj =
   declare_object
     { (default_object "Global universe context state") with
       cache_function = (fun (na, pi) -> cache_universe_context pi);
-      load_function = (fun _ (_, pi) -> cache_universe_context pi);
       discharge_function = (fun (_, (p, _ as x)) -> if p then None else Some x);
-      classify_function = (fun a -> Keep a) }
+      classify_function = (fun a -> Dispose) }
 
 let declare_universe_context poly ctx =
   Lib.add_anonymous_leaf (input_universe_context (poly, ctx))

--- a/interp/declare.ml
+++ b/interp/declare.ml
@@ -471,24 +471,20 @@ let assumption_message id =
   discussion on coqdev: "Chapter 4 of the Reference Manual", 8/10/2015) *)
   Flags.if_verbose Feedback.msg_info (Id.print id ++ str " is declared")
 
-(** Global universe names, in a different summary *)
+(** Monomorphic universes need to survive sections. *)
 
-type universe_context_decl = polymorphic * Univ.ContextSet.t
-
-let cache_universe_context (p, ctx) =
-  Global.push_context_set p ctx;
-  if p then Lib.add_section_context ctx
-
-(* Universes are Dispose because they are included in the kernel module structure. *)
-let input_universe_context : universe_context_decl -> Libobject.obj =
+let input_universe_context : Univ.ContextSet.t -> Libobject.obj =
   declare_object
-    { (default_object "Global universe context state") with
-      cache_function = (fun (na, pi) -> cache_universe_context pi);
-      discharge_function = (fun (_, (p, _ as x)) -> if p then None else Some x);
+    { (default_object "Monomorphic section universes") with
+      cache_function = (fun (na, uctx) -> Global.push_context_set false uctx);
+      discharge_function = (fun (_, x) -> Some x);
       classify_function = (fun a -> Dispose) }
 
 let declare_universe_context poly ctx =
-  Lib.add_anonymous_leaf (input_universe_context (poly, ctx))
+  if poly then
+    (Global.push_context_set true ctx; Lib.add_section_context ctx)
+  else
+    Lib.add_anonymous_leaf (input_universe_context ctx)
 
 (** Global universes are not substitutive objects but global objects
    bound at the *library* or *module* level. The polymorphic flag is


### PR DESCRIPTION
It's only needed to survive sections, after that the universe information is included in the module structures.

This should reduce re-declaration of universes.

Bench: https://ci.inria.fr/coq/view/benchmarking/job/benchmark-part-of-the-branch/497/console
~~~

┌──────────────────────────┬─────────────────────────┬───────────────────────────────────────┬───────────────────────────────────────┬─────────────────────────┬────────────────────┐
│                          │      user time [s]      │              CPU cycles               │           CPU instructions            │  max resident mem [KB]  │     mem faults     │
│                          │                         │                                       │                                       │                         │                    │
│             package_name │     NEW     OLD PDIFF   │            NEW            OLD PDIFF   │            NEW            OLD PDIFF   │     NEW     OLD PDIFF   │ NEW OLD    PDIFF   │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼────────────────────┤
│                coq-flocq │  275.83  278.12 -0.82 % │   765970042775   773011671930 -0.91 % │   984485895312   987555557450 -0.31 % │ 1246104 1244544 +0.13 % │  37   8  +362.50 % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼────────────────────┤
│   coq-mathcomp-odd-order │ 1430.72 1439.69 -0.62 % │  3985463638744  4011292746132 -0.64 % │  6704423109521  6703939098174 +0.01 % │ 1370824 1381752 -0.79 % │ 215   0     +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼────────────────────┤
│              coq-bignums │   96.32   96.89 -0.59 % │   265851198904   267233174781 -0.52 % │   378657344479   378933348121 -0.07 % │  516432  516448 -0.00 % │   1   0     +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼────────────────────┤
│      coq-formal-topology │   54.52   54.84 -0.58 % │   149205220391   149190966763 +0.01 % │   223246597387   223462095308 -0.10 % │  478632  479180 -0.11 % │   0   0     +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼────────────────────┤
│               coq-sf-vfa │   43.92   44.12 -0.45 % │   121063758262   121671696215 -0.50 % │   192744245732   193016963105 -0.14 % │  533128  533212 -0.02 % │   2   1  +100.00 % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼────────────────────┤
│                  coq-vst │ 1711.42 1717.53 -0.36 % │  4757833132874  4771503580375 -0.29 % │  6475308157023  6474799615008 +0.01 % │ 2225288 2226204 -0.04 % │   7  29   -75.86 % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼────────────────────┤
│                 coq-corn │ 1558.88 1563.89 -0.32 % │  4325792536476  4341883663791 -0.37 % │  6381917296554  6395399835103 -0.21 % │  882936  883960 -0.12 % │  60   0     +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼────────────────────┤
│         coq-math-classes │  242.42  243.03 -0.25 % │   667657646430   669267058182 -0.24 % │   863420662033   865265654364 -0.21 % │  526600  529712 -0.59 % │  81   0     +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼────────────────────┤
│               coq-geocoq │ 2833.16 2840.08 -0.24 % │  7854575718464  7876750409708 -0.28 % │ 12573382305536 12572940724843 +0.00 % │ 1387936 1387932 +0.00 % │  40  50   -20.00 % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼────────────────────┤
│   coq-mathcomp-ssreflect │   62.48   62.63 -0.24 % │   171812850209   171658018509 +0.09 % │   242358399194   242519269966 -0.07 % │  531692  531968 -0.05 % │   1   0     +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼────────────────────┤
│     coq-mathcomp-algebra │  200.48  200.84 -0.18 % │   555505213340   555088100621 +0.08 % │   779344798499   779779181110 -0.06 % │  640852  641128 -0.04 % │   0   0     +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼────────────────────┤
│   coq-mathcomp-character │  289.19  289.69 -0.17 % │   803919309837   805310579983 -0.17 % │  1171455098140  1171709250780 -0.02 % │ 1114700 1118804 -0.37 % │   6   0     +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼────────────────────┤
│               coq-sf-plf │   70.90   71.00 -0.14 % │   196163970745   195901158383 +0.13 % │   283310150418   283477699708 -0.06 % │  515616  515996 -0.07 % │   0   0     +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼────────────────────┤
│                 coq-hott │  328.49  328.83 -0.10 % │   910001390446   913497990968 -0.38 % │  1366966483272  1367217053392 -0.02 % │  611100  611120 -0.00 % │  12   0     +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼────────────────────┤
│    coq-mathcomp-fingroup │   81.79   81.82 -0.04 % │   225419349114   225906226815 -0.22 % │   333857716939   334161644670 -0.09 % │  586656  586728 -0.01 % │   0   2  -100.00 % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼────────────────────┤
│ coq-mathcomp-real-closed │  184.71  184.65 +0.03 % │   514167759196   513391187985 +0.15 % │   778111123293   778445069747 -0.04 % │  831560  832176 -0.07 % │   0   0     +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼────────────────────┤
│                coq-color │  730.00  729.72 +0.04 % │  2024097271308  2022785185739 +0.06 % │  2432617785267  2433948043770 -0.05 % │ 1387616 1387660 -0.00 % │   6  11   -45.45 % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼────────────────────┤
│       coq-mathcomp-field │  464.87  464.11 +0.16 % │  1293321143050  1291388903602 +0.15 % │  2118872436484  2118956387330 -0.00 % │  803288  803452 -0.02 % │   0   0     +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼────────────────────┤
│    coq-mathcomp-solvable │  217.65  217.16 +0.23 % │   601936586483   602316438709 -0.06 % │   858261686411   858935529893 -0.08 % │  831316  835580 -0.51 % │   0   0     +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼────────────────────┤
│                coq-sf-lf │   38.18   38.09 +0.24 % │   104926424184   105048559906 -0.12 % │   172465137097   172687240814 -0.13 % │  422820  423092 -0.06 % │   7   0     +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼────────────────────┤
│           coq-coquelicot │  100.74  100.50 +0.24 % │   278320682925   278240944236 +0.03 % │   370888534947   371234438363 -0.09 % │  715040  715344 -0.04 % │ 178   8 +2125.00 % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼────────────────────┤
│              coq-unimath │ 1324.91 1321.01 +0.30 % │  3669006962839  3662996050890 +0.16 % │  6230188616888  6230598315615 -0.01 % │  998560  994856 +0.37 % │   2   0     +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼────────────────────┤
│            coq-fiat-core │  128.83  128.44 +0.30 % │   359398316024   359021650008 +0.10 % │   476320737890   476658973429 -0.07 % │  496508  496480 +0.01 % │  20   1 +1900.00 % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼────────────────────┤
│         coq-fiat-parsers │  715.56  712.15 +0.48 % │  1985597910610  1976133921474 +0.48 % │  3037690373919  3034801011459 +0.10 % │ 3372136 3373904 -0.05 % │   1  18   -94.44 % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼────────────────────┤
│             coq-compcert │  891.82  885.25 +0.74 % │  2471193429119  2451682763879 +0.80 % │  3548659222459  3549458147300 -0.02 % │ 1348652 1349416 -0.06 % │  25 400   -93.75 % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼────────────────────┤
│          coq-fiat-crypto │ 5597.87 5446.95 +2.77 % │ 15563529743152 15675810545067 -0.72 % │ 26235899689169 26250976373005 -0.06 % │ 3199980 3181884 +0.57 % │ 136 134    +1.49 % │
└──────────────────────────┴─────────────────────────┴───────────────────────────────────────┴───────────────────────────────────────┴─────────────────────────┴────────────────────┘
~~~
Not sure what happened with fiat-crypto there, maybe the machine paused so I reran https://ci.inria.fr/coq/view/benchmarking/job/benchmark-part-of-the-branch/500/console
~~~

┌─────────────────┬─────────────────────────┬───────────────────────────────────────┬───────────────────────────────────────┬─────────────────────────┬───────────────────┐
│                 │      user time [s]      │              CPU cycles               │           CPU instructions            │  max resident mem [KB]  │    mem faults     │
│                 │                         │                                       │                                       │                         │                   │
│    package_name │     NEW     OLD PDIFF   │            NEW            OLD PDIFF   │            NEW            OLD PDIFF   │     NEW     OLD PDIFF   │ NEW OLD   PDIFF   │
├─────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼───────────────────┤
│ coq-fiat-crypto │ 5883.68 5939.20 -0.93 % │ 16355319451795 16490444105753 -0.82 % │ 27622620325783 27643178430448 -0.07 % │ 3199428 3180700 +0.59 % │ 489 236 +107.20 % │
├─────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼───────────────────┤
│    coq-compcert │  896.36  889.42 +0.78 % │  2486435571888  2466931281427 +0.79 % │  3570481064624  3571978094144 -0.04 % │ 1331876 1332240 -0.03 % │  44  18 +144.44 % │
└─────────────────┴─────────────────────────┴───────────────────────────────────────┴───────────────────────────────────────┴─────────────────────────┴───────────────────┘
~~~

EDIT: This is on top of #8100.