### PR TITLE
Do not run 32-bit Windows builds on pull requests.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -212,6 +212,9 @@ windows32:
   <<: *windows-template
   variables:
     ARCH: "32"
+  except:
+    - /^pr-.*$/
+
 
 pkg:nix:
   image: nixorg/nix:latest # Minimal NixOS image which doesn't even contain git


### PR DESCRIPTION
I have never seen this build fail without the 64-bit Windows build failing as well. So it is just a waste of time to test it on every pull request and we are short in Windows test machines.

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** infrastructure.