### PR TITLE
Diff option in CoqIDE

### DIFF
--- a/ide/coq.mli
+++ b/ide/coq.mli
@@ -134,13 +134,15 @@ val stop_worker: Interface.stop_worker_sty-> Interface.stop_worker_rty query
 
 module PrintOpt :
 sig
-  type t (** Representation of an option *)
+  type 'a t (** Representation of an option *)
 
-  type bool_descr = { opts : t list; init : bool; label : string }
+  type 'a descr = { opts : 'a t list; init : 'a; label : string }
 
-  val bool_items : bool_descr list
+  val bool_items : bool descr list
 
-  val set : t -> bool -> unit
+  val diff_item : string descr
+
+  val set : 'a t -> 'a -> unit
 
   val printing_unfocused: unit -> bool
 

--- a/ide/coqide.ml
+++ b/ide/coqide.ml
@@ -826,6 +826,7 @@ let refresh_notebook_pos () =
 
 let menu = GAction.add_actions
 let item = GAction.add_action
+let radio = GAction.add_radio_action
 
 (** Toggle items in menus for printing options *)
 
@@ -1043,7 +1044,19 @@ let build_ui () =
       ~callback:(fun _ -> show_toolbar#set (not show_toolbar#get));
     item "Query Pane" ~label:"_Query Pane"
       ~accel:"F1"
-      ~callback:(cb_on_current_term MiscMenu.show_hide_query_pane)
+      ~callback:(cb_on_current_term MiscMenu.show_hide_query_pane);
+    GAction.group_radio_actions
+      ~callback:begin function
+        | 0 -> List.iter (fun o -> Opt.set o "off") Opt.diff_item.Opt.opts
+        | 1 -> List.iter (fun o -> Opt.set o "on") Opt.diff_item.Opt.opts
+        | 2 -> List.iter (fun o -> Opt.set o "removed") Opt.diff_item.Opt.opts
+        | _ -> assert false
+        end
+      [
+        radio "Unset diff" 0 ~label:"Unset _Diff";
+        radio "Set diff" 1 ~label:"Set Di_ff";
+        radio "Set removed diff" 2 ~label:"Set _Removed Diff";
+      ];
   ];
   toggle_items view_menu Coq.PrintOpt.bool_items;
 

--- a/ide/coqide_ui.ml
+++ b/ide/coqide_ui.ml
@@ -86,6 +86,10 @@ let init () =
 \n    <menuitem action='Display universe levels' />\
 \n    <menuitem action='Display all low-level contents' />\
 \n    <menuitem action='Display unfocused goals' />\
+\n    <separator/>\
+\n    <menuitem action='Unset diff' />\
+\n    <menuitem action='Set diff' />\
+\n    <menuitem action='Set removed diff' />\
 \n  </menu>\
 \n  <menu action='Navigation'>\
 \n    <menuitem action='Forward' />\

--- a/ide/idetop.ml
+++ b/ide/idetop.ml
@@ -530,9 +530,6 @@ let () = Usage.add_to_usage "coqidetop"
 let islave_init ~opts extra_args =
   let args = parse extra_args in
   CoqworkmgrApi.(init High);
-  let open Coqargs in
-    if not opts.diffs_set then
-      Proof_diffs.write_diffs_option "on";
   opts, args
 
 let () =


### PR DESCRIPTION
This is a followup of #6801. We add a way to switch the diff option inside CoqIDE be means of a menu, instead of setting it by default at the start.

EDIT: Fixes #8146.