### PR TITLE
Implement VERNAC EXTEND in coqpp

### DIFF
--- a/coqpp/coqpp_ast.mli
+++ b/coqpp/coqpp_ast.mli
@@ -85,12 +85,31 @@ type tactic_ext = {
   tacext_rules : tactic_rule list;
 }
 
+type classification =
+| ClassifDefault
+| ClassifCode of code
+| ClassifName of string
+
+type vernac_rule = {
+  vernac_toks : ext_token list;
+  vernac_class : code option;
+  vernac_depr : bool;
+  vernac_body : code;
+}
+
+type vernac_ext = {
+  vernacext_name : string;
+  vernacext_entry : code option;
+  vernacext_class : classification;
+  vernacext_rules : vernac_rule list;
+}
+
 type node =
 | Code of code
 | Comment of string
 | DeclarePlugin of string
 | GramExt of grammar_ext
-| VernacExt
+| VernacExt of vernac_ext
 | TacticExt of tactic_ext
 
 type t = node list

--- a/coqpp/coqpp_lex.mll
+++ b/coqpp/coqpp_lex.mll
@@ -95,12 +95,16 @@ rule extend = parse
 | "{" { start_ocaml lexbuf; ocaml lexbuf }
 | "GRAMMAR" { GRAMMAR }
 | "VERNAC" { VERNAC }
+| "COMMAND" { COMMAND }
 | "TACTIC" { TACTIC }
 | "EXTEND" { EXTEND }
 | "END" { END }
 | "DECLARE" { DECLARE }
 | "PLUGIN" { PLUGIN }
 | "DEPRECATED" { DEPRECATED }
+| "CLASSIFIED" { CLASSIFIED }
+| "BY" { BY }
+| "AS" { AS }
 (** Camlp5 specific keywords *)
 | "GLOBAL" { GLOBAL }
 | "FIRST" { FIRST }
@@ -122,6 +126,7 @@ rule extend = parse
 | ']' { RBRACKET }
 | '|' { PIPE }
 | "->" { ARROW }
+| "=>" { FUN }
 | ',' { COMMA }
 | ':' { COLON }
 | ';' { SEMICOLON }

--- a/coqpp/coqpp_main.ml
+++ b/coqpp/coqpp_main.ml
@@ -306,7 +306,7 @@ let print_rule_classifier fmt r = match r.vernac_class with
 | Some f -> fprintf fmt "Some @[(fun %a-> %s)@]" print_binders r.vernac_toks f.code
 
 let print_body fmt r =
-  fprintf fmt "@[(fun %a~atts@ ~st@ -> %s)@]"
+  fprintf fmt "@[(fun %a~atts@ ~st@ -> let () = %s in st)@]"
     print_binders r.vernac_toks r.vernac_body.code
 
 let rec print_sig fmt = function

--- a/coqpp/coqpp_main.ml
+++ b/coqpp/coqpp_main.ml
@@ -296,17 +296,16 @@ let rec print_symbol fmt = function
 let rec print_clause fmt = function
 | [] -> fprintf fmt "@[TyNil@]"
 | ExtTerminal s :: cl -> fprintf fmt "@[TyIdent (\"%s\", %a)@]" s print_clause cl
-| ExtNonTerminal (g, TokNone) :: cl ->
-  fprintf fmt "@[TyAnonArg (%a, %a)@]"
+| ExtNonTerminal (g, _) :: cl ->
+  fprintf fmt "@[TyArg (%a, %a)@]"
     print_symbol g print_clause cl
-| ExtNonTerminal (g, TokName id) :: cl ->
-  fprintf fmt "@[TyArg (%a, \"%s\", %a)@]"
-    print_symbol g id print_clause cl
 
 let rec print_binders fmt = function
 | [] -> fprintf fmt "ist@ "
-| (ExtTerminal _ | ExtNonTerminal (_, TokNone)) :: rem -> print_binders fmt rem
-| (ExtNonTerminal (_, TokName id)) :: rem ->
+| ExtTerminal _ :: rem -> print_binders fmt rem
+| ExtNonTerminal (_, TokNone) :: rem ->
+  fprintf fmt "_@ %a" print_binders rem
+| ExtNonTerminal (_, TokName id) :: rem ->
   fprintf fmt "%s@ %a" id print_binders rem
 
 let print_rule fmt r =

--- a/dev/doc/changes.md
+++ b/dev/doc/changes.md
@@ -159,7 +159,33 @@ END
 
 #### VERNAC EXTEND
 
-Not handled yet.
+Steps to perform:
+- replace the brackets enclosing OCaml code in actions and rule classifiers with
+  braces
+- if not there yet, add a leading `|̀  to the first rule
+
+Handwritten classifiers declared through the `CLASSIFIED BY` statement are
+considered OCaml code, so they also need to be wrapped in braces.
+
+All extension macros are now behaving as if they were declared `FUNCTIONAL`,
+which means that they must return an interpretation state. This should
+currently be done by merely returning the `st` variable that is implicitly
+passed to the rule code.
+
+For instance, code of the form:
+```
+VERNAC COMMAND EXTEND my_command CLASSIFIED BY classifier
+  [ "foo" int(i) ] => [ classif' ] -> [ cmd1 i ]
+| [ "bar" ] -> [ cmd2 ]
+END
+```
+should be turned into
+```
+VERNAC COMMAND EXTEND my_command CLASSIFIED BY { classifier }
+  [ "foo" int(i) ] => { classif' } -> { let () = cmd1 i in st }
+| [ "bar" ] -> { let () = cmd2 in st  }
+END
+```
 
 #### ARGUMENT EXTEND
 

--- a/dev/doc/changes.md
+++ b/dev/doc/changes.md
@@ -167,11 +167,6 @@ Steps to perform:
 Handwritten classifiers declared through the `CLASSIFIED BY` statement are
 considered OCaml code, so they also need to be wrapped in braces.
 
-All extension macros are now behaving as if they were declared `FUNCTIONAL`,
-which means that they must return an interpretation state. This should
-currently be done by merely returning the `st` variable that is implicitly
-passed to the rule code.
-
 For instance, code of the form:
 ```
 VERNAC COMMAND EXTEND my_command CLASSIFIED BY classifier
@@ -182,8 +177,8 @@ END
 should be turned into
 ```
 VERNAC COMMAND EXTEND my_command CLASSIFIED BY { classifier }
-  [ "foo" int(i) ] => { classif' } -> { let () = cmd1 i in st }
-| [ "bar" ] -> { let () = cmd2 in st  }
+| [ "foo" int(i) ] => { classif' } -> { cmd1 i }
+| [ "bar" ] -> { cmd2 }
 END
 ```
 

--- a/dev/top_printers.ml
+++ b/dev/top_printers.ml
@@ -527,7 +527,7 @@ let _ =
   extend_vernac_command_grammar ("PrintConstr", 0) None
     [GramTerminal "PrintConstr";
       GramNonTerminal
-        (Loc.tag (Some (rawwit wit_constr),Extend.Aentry Pcoq.Constr.constr))]
+        (Loc.tag (rawwit wit_constr,Extend.Aentry Pcoq.Constr.constr))]
 
 let _ =
   try
@@ -543,7 +543,7 @@ let _ =
   extend_vernac_command_grammar ("PrintPureConstr", 0) None
     [GramTerminal "PrintPureConstr";
       GramNonTerminal
-        (Loc.tag (Some (rawwit wit_constr),Extend.Aentry Pcoq.Constr.constr))]
+        (Loc.tag (rawwit wit_constr,Extend.Aentry Pcoq.Constr.constr))]
 
 (* Setting printer of unbound global reference *)
 open Names

--- a/grammar/q_util.mli
+++ b/grammar/q_util.mli
@@ -50,3 +50,5 @@ val type_of_user_symbol : user_symbol -> argument_type
 val parse_user_entry : string -> string -> user_symbol
 
 val mlexpr_of_symbol : user_symbol -> MLast.expr
+
+val binders_of_tokens : MLast.expr -> extend_token list -> MLast.expr

--- a/grammar/q_util.mlp
+++ b/grammar/q_util.mlp
@@ -142,3 +142,9 @@ let rec mlexpr_of_symbol = function
   assert (e = "tactic");
   let wit = <:expr< $lid:"wit_"^e$ >> in
   <:expr< Extend.TUentryl (Genarg.get_arg_tag $wit$) $mlexpr_of_int l$>>
+
+let rec binders_of_tokens e = function
+| [] -> e
+| ExtNonTerminal(_,None) :: cl -> <:expr< fun _ -> $binders_of_tokens e cl$ >>
+| ExtNonTerminal(_,Some id) :: cl -> <:expr< fun $lid:id$ -> $binders_of_tokens e cl$ >>
+| ExtTerminal _ :: cl -> binders_of_tokens e cl

--- a/grammar/tacextend.mlp
+++ b/grammar/tacextend.mlp
@@ -20,16 +20,8 @@ let plugin_name = <:expr< __coq_plugin_name >>
 let rec mlexpr_of_clause = function
 | [] -> <:expr< TyNil >>
 | ExtTerminal s :: cl -> <:expr< TyIdent($str:s$, $mlexpr_of_clause cl$) >>
-| ExtNonTerminal(g,None) :: cl ->
-  <:expr< TyAnonArg($mlexpr_of_symbol g$, $mlexpr_of_clause cl$) >>
-| ExtNonTerminal(g,Some id) :: cl ->
-  <:expr< TyArg($mlexpr_of_symbol g$, $mlexpr_of_string id$, $mlexpr_of_clause cl$) >>
-
-let rec binders_of_clause e = function
-| [] -> <:expr< fun ist -> $e$ >>
-| ExtNonTerminal(_,None) :: cl -> binders_of_clause e cl
-| ExtNonTerminal(_,Some id) :: cl -> <:expr< fun $lid:id$ -> $binders_of_clause e cl$ >>
-| _ :: cl -> binders_of_clause e cl
+| ExtNonTerminal (g, _) :: cl ->
+  <:expr< TyArg($mlexpr_of_symbol g$, $mlexpr_of_clause cl$) >>
 
 open Pcaml
 
@@ -52,7 +44,8 @@ EXTEND
   tacrule:
     [ [ "["; l = LIST1 tacargs; "]";
         "->"; "["; e = Pcaml.expr; "]" ->
-         <:expr< TyML($mlexpr_of_clause l$, $binders_of_clause e l$) >>
+        let e = <:expr< fun ist -> $e$ >> in
+         <:expr< TyML($mlexpr_of_clause l$, $binders_of_tokens e l$) >>
     ] ]
   ;
 

--- a/grammar/vernacextend.mlp
+++ b/grammar/vernacextend.mlp
@@ -24,23 +24,16 @@ type rule = {
   (** Whether this entry is deprecated *)
 }
 
-let rec make_patt r = function
-| [] -> r
-| ExtNonTerminal (_, Some p) :: l -> <:expr< fun $lid:p$ -> $make_patt r l$ >>
-| ExtNonTerminal (_, None) :: l -> <:expr< fun _ -> $make_patt r l$ >>
-| ExtTerminal _ :: l -> make_patt r l
-
 let rec mlexpr_of_clause = function
 | [] -> <:expr< Vernacentries.TyNil >>
 | ExtTerminal s :: cl -> <:expr< Vernacentries.TyTerminal ($str:s$, $mlexpr_of_clause cl$) >>
 | ExtNonTerminal (g, id) :: cl ->
-  let id = mlexpr_of_option mlexpr_of_string id in
-  <:expr< Vernacentries.TyNonTerminal ($id$, $mlexpr_of_symbol g$, $mlexpr_of_clause cl$) >>
+  <:expr< Vernacentries.TyNonTerminal ($mlexpr_of_symbol g$, $mlexpr_of_clause cl$) >>
 
 let make_rule r =
   let ty = mlexpr_of_clause r.r_patt in
-  let cmd = make_patt r.r_branch r.r_patt in
-  let make_classifier c = make_patt c r.r_patt in
+  let cmd = binders_of_tokens r.r_branch r.r_patt in
+  let make_classifier c = binders_of_tokens c r.r_patt in
   let classif = mlexpr_of_option make_classifier r.r_class in
   <:expr< Vernacentries.TyML ($mlexpr_of_bool r.r_depr$, $ty$, $cmd$, $classif$) >>
 

--- a/plugins/derive/g_derive.mlg
+++ b/plugins/derive/g_derive.mlg
@@ -8,13 +8,21 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
+{
+
 open Stdarg
+
+}
 
 DECLARE PLUGIN "derive_plugin"
 
+{
+
 let classify_derive_command _ = Vernacexpr.(VtStartProof ("Classic",Doesn'tGuaranteeOpacity,[]),VtLater)
 
-VERNAC COMMAND EXTEND Derive CLASSIFIED BY classify_derive_command
+}
+
+VERNAC COMMAND EXTEND Derive CLASSIFIED BY { classify_derive_command }
 | [ "Derive" ident(f) "SuchThat" constr(suchthat) "As" ident(lemma) ] ->
-     [ Derive.start_deriving f suchthat lemma ]
+  { let () = Derive.start_deriving f suchthat lemma in st }
 END

--- a/plugins/derive/g_derive.mlg
+++ b/plugins/derive/g_derive.mlg
@@ -24,5 +24,5 @@ let classify_derive_command _ = Vernacexpr.(VtStartProof ("Classic",Doesn'tGuara
 
 VERNAC COMMAND EXTEND Derive CLASSIFIED BY { classify_derive_command }
 | [ "Derive" ident(f) "SuchThat" constr(suchthat) "As" ident(lemma) ] ->
-  { let () = Derive.start_deriving f suchthat lemma in st }
+  { Derive.start_deriving f suchthat lemma }
 END

--- a/plugins/ltac/tacentries.mli
+++ b/plugins/ltac/tacentries.mli
@@ -73,10 +73,7 @@ val print_located_tactic : Libnames.qualid -> unit
 type _ ty_sig =
 | TyNil : (Geninterp.interp_sign -> unit Proofview.tactic) ty_sig
 | TyIdent : string * 'r ty_sig -> 'r ty_sig
-| TyArg :
-  ('a, 'b, 'c) Extend.ty_user_symbol * string * 'r ty_sig -> ('c -> 'r) ty_sig
-| TyAnonArg :
-  ('a, 'b, 'c) Extend.ty_user_symbol * 'r ty_sig -> 'r ty_sig
+| TyArg : ('a, 'b, 'c) Extend.ty_user_symbol * 'r ty_sig -> ('c -> 'r) ty_sig
 
 type ty_ml = TyML : 'r ty_sig * 'r -> ty_ml
 

--- a/vernac/egramml.ml
+++ b/vernac/egramml.ml
@@ -19,7 +19,7 @@ open Vernacexpr
 type 's grammar_prod_item =
   | GramTerminal of string
   | GramNonTerminal :
-      ('a raw_abstract_argument_type option * ('s, 'a) symbol) Loc.located -> 's grammar_prod_item
+      ('a raw_abstract_argument_type * ('s, 'a) symbol) Loc.located -> 's grammar_prod_item
 
 type 'a ty_arg = ('a -> raw_generic_argument)
 
@@ -40,7 +40,7 @@ let rec ty_rule_of_gram = function
   AnyTyRule r
 | GramNonTerminal (_, (t, tok)) :: rem ->
   let AnyTyRule rem = ty_rule_of_gram rem in
-  let inj = Option.map (fun t obj -> Genarg.in_gen t obj) t in
+  let inj = Some (fun obj -> Genarg.in_gen t obj) in
   let r = TyNext (rem, tok, inj) in
   AnyTyRule r
 

--- a/vernac/egramml.mli
+++ b/vernac/egramml.mli
@@ -17,7 +17,7 @@ open Vernacexpr
 
 type 's grammar_prod_item =
   | GramTerminal of string
-  | GramNonTerminal : ('a Genarg.raw_abstract_argument_type option *
+  | GramNonTerminal : ('a Genarg.raw_abstract_argument_type *
       ('s, 'a) Extend.symbol) Loc.located -> 's grammar_prod_item
 
 val extend_vernac_command_grammar :

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -2497,8 +2497,7 @@ type classifier = Genarg.raw_generic_argument list -> vernac_classification
 type (_, _) ty_sig =
 | TyNil : (atts:atts -> st:Vernacstate.t -> Vernacstate.t, Vernacexpr.vernac_classification) ty_sig
 | TyTerminal : string * ('r, 's) ty_sig -> ('r, 's) ty_sig
-| TyNonTerminal :
-  string option * ('a, 'b, 'c) Extend.ty_user_symbol * ('r, 's) ty_sig -> ('a -> 'r, 'a -> 's) ty_sig
+| TyNonTerminal : ('a, 'b, 'c) Extend.ty_user_symbol * ('r, 's) ty_sig -> ('a -> 'r, 'a -> 's) ty_sig
 
 type ty_ml = TyML : bool * ('r, 's) ty_sig * 'r * 's option -> ty_ml
 
@@ -2511,7 +2510,7 @@ let rec untype_classifier : type r s. (r, s) ty_sig -> s -> classifier = functio
   | _ :: _ -> type_error ()
   end
 | TyTerminal (_, ty) -> fun f args -> untype_classifier ty f args
-| TyNonTerminal (_, tu, ty) -> fun f args ->
+| TyNonTerminal (tu, ty) -> fun f args ->
   begin match args with
   | [] -> type_error ()
   | Genarg.GenArg (Rawwit tag, v) :: args ->
@@ -2528,7 +2527,7 @@ let rec untype_command : type r s. (r, s) ty_sig -> r -> plugin_args vernac_comm
   | _ :: _ -> type_error ()
   end
 | TyTerminal (_, ty) -> fun f args -> untype_command ty f args
-| TyNonTerminal (_, tu, ty) -> fun f args ->
+| TyNonTerminal (tu, ty) -> fun f args ->
   begin match args with
   | [] -> type_error ()
   | Genarg.GenArg (Rawwit tag, v) :: args ->
@@ -2549,8 +2548,8 @@ let rec untype_user_symbol : type s a b c. (a, b, c) Extend.ty_user_symbol -> (s
 let rec untype_grammar : type r s. (r, s) ty_sig -> vernac_expr Egramml.grammar_prod_item list = function
 | TyNil -> []
 | TyTerminal (tok, ty) -> Egramml.GramTerminal tok :: untype_grammar ty
-| TyNonTerminal (id, tu, ty) ->
-  let t = Option.map (fun _ -> rawwit (Egramml.proj_symbol tu)) id in
+| TyNonTerminal (tu, ty) ->
+  let t = rawwit (Egramml.proj_symbol tu) in
   let symb = untype_user_symbol tu in
   Egramml.GramNonTerminal (Loc.tag (t, symb)) :: untype_grammar ty
 

--- a/vernac/vernacentries.mli
+++ b/vernac/vernacentries.mli
@@ -51,7 +51,6 @@ type (_, _) ty_sig =
 | TyNil : (atts:Vernacinterp.atts -> st:Vernacstate.t -> Vernacstate.t, Vernacexpr.vernac_classification) ty_sig
 | TyTerminal : string * ('r, 's) ty_sig -> ('r, 's) ty_sig
 | TyNonTerminal :
-  string option *
   ('a, 'b, 'c) Extend.ty_user_symbol * ('r, 's) ty_sig ->
     ('a -> 'r, 'a -> 's) ty_sig
 


### PR DESCRIPTION
Quite straightforward. Only one file has been ported, as all other users of this macro also declare `ARGUMENT EXTEND` extensions.
