### PR TITLE
Missing backslach in documentation

### DIFF
--- a/doc/sphinx/practical-tools/utilities.rst
+++ b/doc/sphinx/practical-tools/utilities.rst
@@ -550,7 +550,7 @@ Initially, the pretty-printing table contains the following mapping:
 `->`  →       `<-`   ←       `*`   ×
 `<=`  ≤       `>=`   ≥       `=>`  ⇒
 `<>`  ≠       `<->`  ↔       `|-`  ⊢
-`\/`  ∨       `/\\`   ∧       `~`   ¬
+`\\/`  ∨       `/\\`   ∧       `~`   ¬
 ==== === ==== ===== === ==== ==== ===
 
 Any of these can be overwritten or suppressed using the printing

--- a/doc/sphinx/practical-tools/utilities.rst
+++ b/doc/sphinx/practical-tools/utilities.rst
@@ -546,12 +546,12 @@ The printing for one token can be removed with
 
 Initially, the pretty-printing table contains the following mapping:
 
-==== === ==== ===== === ==== ==== ===
-`->`  →       `<-`   ←       `*`   ×
-`<=`  ≤       `>=`   ≥       `=>`  ⇒
-`<>`  ≠       `<->`  ↔       `|-`  ⊢
-`\\/`  ∨       `/\\`   ∧       `~`   ¬
-==== === ==== ===== === ==== ==== ===
+===== === ==== ===== === ==== ==== ===
+`->`   →       `<-`   ←       `*`   ×
+`<=`   ≤       `>=`   ≥       `=>`  ⇒
+`<>`   ≠       `<->`  ↔       `|-`  ⊢
+`\\/`  ∨       `/\\`  ∧       `~`   ¬
+===== === ==== ===== === ==== ==== ===
 
 Any of these can be overwritten or suppressed using the printing
 commands.


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

<!-- Keep what applies -->
**Kind:** documentation.

It is a very minor commit. The `\/` was simply displayed as `/` instead of `\/`.