### PR TITLE
Missing backslash in a documentation file.

### DIFF
--- a/doc/sphinx/practical-tools/utilities.rst
+++ b/doc/sphinx/practical-tools/utilities.rst
@@ -546,12 +546,12 @@ The printing for one token can be removed with
 
 Initially, the pretty-printing table contains the following mapping:
 
-==== === ==== ===== === ==== ==== ===
-`->`  →       `<-`   ←       `*`   ×
-`<=`  ≤       `>=`   ≥       `=>`  ⇒
-`<>`  ≠       `<->`  ↔       `|-`  ⊢
-`\/`  ∨       `/\\`   ∧       `~`   ¬
-==== === ==== ===== === ==== ==== ===
+===== === ==== ===== === ==== ==== ===
+`->`   →       `<-`   ←       `*`   ×
+`<=`   ≤       `>=`   ≥       `=>`  ⇒
+`<>`   ≠       `<->`  ↔       `|-`  ⊢
+`\\/`  ∨       `/\\`  ∧       `~`   ¬
+===== === ==== ===== === ==== ==== ===
 
 Any of these can be overwritten or suppressed using the printing
 commands.


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** documentation.

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes https://github.com/coq/coq/pull/8172

This is a very minor commit. The `\/` was displayed as `/` instead of `\/` in the documentation.