### PR TITLE
Handle diffs better for the "Undo" command.

### DIFF
--- a/ide/idetop.ml
+++ b/ide/idetop.ml
@@ -211,15 +211,13 @@ let add_diffs oldp newp intf =
     { intf with fg_goals = { first_goal with goal_hyp = hyps_pp_list; goal_ccl = concl_pp } :: tl }
 
 let goals () =
-  let oldp =
-    try Some (Proof_global.give_me_the_proof ())
-    with Proof_global.NoCurrentProof -> None in
   let doc = get_doc () in
   set_doc @@ Stm.finish ~doc;
   try
     let newp = Proof_global.give_me_the_proof () in
     let intf = export_pre_goals (Proof.map_structured_proof newp process_goal) in
     if Proof_diffs.show_diffs () then
+      let oldp = Stm.get_prev_proof ~doc (Stm.get_current_state ~doc) in
       try
         Some (add_diffs oldp (Some newp) intf)
       with Pp_diff.Diff_Failure _ -> Some intf

--- a/stm/stm.mli
+++ b/stm/stm.mli
@@ -110,6 +110,10 @@ val add : doc:doc -> ontop:Stateid.t -> ?newtip:Stateid.t ->
   bool -> Vernacexpr.vernac_control CAst.t ->
   doc * Stateid.t * [ `NewTip | `Unfocus of Stateid.t ]
 
+(* Returns the proof state before the last tactic that was applied at or before
+the specified state.  Used to compute proof diffs. *)
+val get_prev_proof : doc:doc -> Stateid.t -> Proof.t option
+
 (* [query at ?report_with cmd] Executes [cmd] at a given state [at],
    throwing away side effects except messages. Feedback will
    be sent with [report_with], which defaults to the dummy state id *)

--- a/toplevel/coqloop.ml
+++ b/toplevel/coqloop.ml
@@ -376,7 +376,8 @@ let rec vernac_loop ~state =
       else (Feedback.msg_warning (str "There is no ML toplevel."); vernac_loop ~state)
     | {v=VernacControl c; loc} ->
       let nstate = Vernac.process_expr ~state (make ?loc c) in
-      top_goal_print state.proof nstate.proof;
+      let dproof = Stm.get_prev_proof ~doc:state.doc (Stm.get_current_state ~doc:state.doc) in
+      top_goal_print dproof nstate.proof;
       vernac_loop ~state:nstate
   with
   | Stm.End_of_input ->


### PR DESCRIPTION
**Kind:** bug fix / feature.

(I'll file a bug report if that's really needed, but this is on the borderline between a bug and a feature.  Hypothetically if the spec says "Coq crashes if you do X", then it's not a bug--just a (probably) dumb spec.)

Current code shows diffs between the current proof state and the proof state before the last command/tactic was applied.  That's probably not what the user wants to see if they enter an `Undo` command--they want to see the diffs that were previously displayed for that proof state.  Diffs should really be between the current proof state and the proof state  before the last tactic was applied.

Here's what you get now: the first and third diffs correspond to the same proof state but the diff info is not the same--not helpful.

![bad undo](https://user-images.githubusercontent.com/1253341/43358374-80fa3650-925e-11e8-9f9e-30f2e64f1d0f.PNG)

And here is the improved behavior; the first and third diffs are the same.  Much better.

![image](https://user-images.githubusercontent.com/1253341/43358379-933636c0-925e-11e8-9d75-bdb0dd146a1e.png)

The "Back" command doesn't keep enough info to allow finding the correct prior proof state.  Not planning to address that unless someone else wants to provide the necessary data.  I'm not seeing how "Back" is a particularly useful command.

This change also handles going backward in CoqIDE using the "Backward One Command" button.

Note there are other cases where the diffs should use different data.  For example, `all: swap 1 2` only changes the proof view, not the underlying proof state.  More on that later...