### PR TITLE
When ltac is used in a notation, insert the variables bound by the notation as uconstr.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,4 @@
-Changes from 8.8.2 to 8.9+beta1
+Changes from 8.8.1 to 8.9+beta1
 ===============================
 
 Kernel
@@ -148,6 +148,9 @@ Notations
   and vector_scope both open with vector_scope on top, and expect `++` to
   refer to `app`.
   Solution: wrap `_ ++ _` in `(_ ++ _)%list` (or whichever scope you want). 
+
+- Notations expanding to expressions containing calls to `ltac:(tac)` now
+  accept that their arguments contain unresolved existential variables.
 
 Changes from 8.8.0 to 8.8.1
 ===========================

--- a/plugins/ltac/tacintern.ml
+++ b/plugins/ltac/tacintern.ml
@@ -838,7 +838,7 @@ let () =
 let notation_subst bindings tac =
   let fold id c accu =
     let loc = Glob_ops.loc_of_glob_constr (fst c) in
-    let c = ConstrMayEval (ConstrTerm c) in
+    let c = TacGeneric (Genarg.in_gen (Genarg.glbwit Stdarg.wit_uconstr) c) in
     (make ?loc @@ Name id, c) :: accu
   in
   let bindings = Id.Map.fold fold bindings [] in

--- a/test-suite/bugs/closed/3278.v
+++ b/test-suite/bugs/closed/3278.v
@@ -4,11 +4,7 @@ Module a.
 
   Notation foo x := (let x' := x in ltac:(exact x')).
 
-  Fail Check foo _. (* Error:
-Cannot infer an internal placeholder of type "Type" in environment:
-
-x' := ?42 : ?41
-. *)
+  Check foo _.
 End a.
 
 Module b.
@@ -17,9 +13,5 @@ Module b.
 
   Check let x' := _ in ltac:(exact I). (* let x' := ?5 in I *)
   Check bar _. (* let x' := ?9 in let y := I in I *)
-  Fail Check foo _. (* Error:
-Cannot infer an internal placeholder of type "Type" in environment:
-
-x' := ?42 : ?41
-. *)
+  Check foo _.
 End b.

--- a/test-suite/bugs/closed/4728.v
+++ b/test-suite/bugs/closed/4728.v
@@ -69,4 +69,4 @@ Notation "( x , y , .. , z )" := (pair .. (pair x y) .. z) : core_scope.
 Notation "{ old 'with' new }" := (ltac:({ old with new })) (only parsing).
 
 Check ltac:({ (1, 1) with {| snd := 2 |} }).
-Fail Check { (1, 1) with {| snd := 2 |} }. (* Error: Cannot infer this placeholder of type "Type"; should succeed *)
+Check { (1, 1) with {| snd := 2 |} }.

--- a/test-suite/bugs/closed/8190.v
+++ b/test-suite/bugs/closed/8190.v
@@ -1,0 +1,24 @@
+Module Example1.
+Notation zero := (ltac: (exact 0)).
+
+Definition f (m n : nat) : nat := m.
+Notation fzero m := (f zero m).
+
+Lemma test : False.
+eset (H := fzero _).
+Abort.
+End Example1.
+
+Module Example2.
+Definition f (m n : nat) : nat := m.
+Notation f_exact_zero m := (f (ltac: (exact 0)) m).
+
+Lemma test : False.
+eset (H := f_exact_zero _).
+Abort.
+End Example2.
+
+Module ReducedExample.
+Notation foo x := (ltac:(exact tt)).
+Check foo _.
+End ReducedExample.


### PR DESCRIPTION
**Kind:** bug fix

Fixes #8190,  #3278 and #4728

- [x] Entry added in CHANGES.
