### PR TITLE
Make overwrite notation scope key a warning

### DIFF
--- a/doc/sphinx/user-extensions/syntax-extensions.rst
+++ b/doc/sphinx/user-extensions/syntax-extensions.rst
@@ -987,6 +987,8 @@ interpreted in the scope stack extended with the scope bound tokey.
    To bind a delimiting key to a scope, use the command
    :n:`Delimit Scope @scope with @ident`
 
+   .. warn:: Overwriting previous delimiting key @ident in scope @scope
+
 .. cmd:: Undelimit Scope @scope
 
    To remove a delimiting key of a scope, use the command

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -191,6 +191,11 @@ let make_current_scopes (tmp_scope,scopes) =
 (**********************************************************************)
 (* Delimiters *)
 
+let warn_overwrite_scope scope =
+  CWarnings.create ~name:"overwrite-delimit-key" ~category:"parsing"
+    (fun oldkey -> str "Overwriting previous delimiting key " ++ str oldkey ++
+                   str " in scope " ++ str scope)
+
 let declare_delimiters scope key =
   let sc = find_scope scope in
   let newsc = { sc with delimiters = Some key } in
@@ -199,9 +204,8 @@ let declare_delimiters scope key =
     | Some oldkey when String.equal oldkey key -> ()
     | Some oldkey ->
         (** FIXME: implement multikey scopes? *)
-	Flags.if_verbose Feedback.msg_info
-	  (str "Overwriting previous delimiting key " ++ str oldkey ++ str " in scope " ++ str scope);
-	scope_map := String.Map.add scope newsc !scope_map
+      warn_overwrite_scope scope oldkey;
+      scope_map := String.Map.add scope newsc !scope_map
   end;
   try
     let oldscope = String.Map.find key !delimiters_map in

--- a/plugins/ssr/ssrbool.v
+++ b/plugins/ssr/ssrbool.v
@@ -11,6 +11,7 @@
 (* This file is (C) Copyright 2006-2015 Microsoft Corporation and Inria. *)
 
 Require Bool.
+
 Require Import ssreflect ssrfun.
 
 (******************************************************************************)
@@ -344,7 +345,8 @@ Reserved Notation "[ 'rel' x y => E ]" (at level 0, x, y at level 8, format
 Reserved Notation "[ 'rel' x y : T => E ]" (at level 0, x, y at level 8, format
   "'[hv' [ 'rel'  x  y :  T  => '/ '  E ] ']'").
 
-(* Shorter delimiter *)
+(* Shorter delimiter (overrides the standard library's delimiter, "bool"). *)
+Undelimit Scope bool_scope.
 Delimit Scope bool_scope with B.
 Open Scope bool_scope.
 

--- a/test-suite/output/OverwriteDelimitKey.out
+++ b/test-suite/output/OverwriteDelimitKey.out
@@ -1,0 +1,3 @@
+File "stdin", line 3, characters 0-29:
+Warning: Overwriting previous delimiting key original in scope scope
+[overwrite-delimit-key,parsing]

--- a/test-suite/output/OverwriteDelimitKey.v
+++ b/test-suite/output/OverwriteDelimitKey.v
@@ -1,0 +1,5 @@
+Notation "x + y" := (plus x y) : scope.
+Delimit Scope scope with original.
+Delimit Scope scope with new.
+Set Warnings "-overwrite-delimit-key".
+Delimit Scope scope with original.


### PR DESCRIPTION
Previously was a feedback and was therefore not configurable using the
warning system.

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** feature (fix to user messages).


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Partial fix for #8207


<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [x] Added / updated test-suite
<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [x] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [ ] Entry added in CHANGES.

No CHANGES entry seemed necessary; this is part of making the new warning system apply to more existing error messages.