### PR TITLE
Make ambiguous coercion paths a warning

### DIFF
--- a/doc/sphinx/addendum/implicit-coercions.rst
+++ b/doc/sphinx/addendum/implicit-coercions.rst
@@ -138,7 +138,7 @@ Declaring Coercions
   .. exn:: @qualid does not respect the uniform inheritance condition.
   .. exn:: Found target class ... instead of ...
 
-  .. warn:: Ambiguous path.
+  .. warn:: Ambiguous paths: ...
 
      When the coercion :token:`qualid` is added to the inheritance graph,
      invalid coercion paths are ignored; they are signaled by a warning

--- a/plugins/ssr/ssrbool.v
+++ b/plugins/ssr/ssrbool.v
@@ -1196,7 +1196,11 @@ Definition in_mem T x mp := nosimpl pred_of_mem T mp x.
 
 Prenex Implicits mem.
 
+(* This coercion, together with [sort_of_simpl_pred], is ambiguous. However,
+[pred_of_mem] will be used as the coercion [mem_pred >-> pred_sort]. *)
+Set Warnings "-ambiguous-paths".
 Coercion pred_of_mem_pred T mp := [pred x : T | in_mem x mp].
+Set Warnings "ambiguous-paths".
 
 Definition eq_mem T p1 p2 := forall x : T, in_mem x p1 = in_mem x p2.
 Definition sub_mem T p1 p2 := forall x : T, in_mem x p1 -> in_mem x p2.

--- a/pretyping/classops.ml
+++ b/pretyping/classops.ml
@@ -327,6 +327,9 @@ let message_ambig env sigma l =
   str"Ambiguous paths:" ++ spc () ++
   prlist_with_sep fnl (fun ijp -> print_path env sigma ijp) l
 
+let warn_ambiguous_paths env sigma =
+  CWarnings.create ~name:"ambiguous-paths" ~category:"typechecker" (message_ambig env sigma)
+
 (* add_coercion_in_graph : coe_index * cl_index * cl_index -> unit
                          coercion,source,target *)
 
@@ -380,8 +383,8 @@ let add_coercion_in_graph env sigma (ic,source,target) =
       old_inheritance_graph
   end;
   let is_ambig = match !ambig_paths with [] -> false | _ -> true in
-  if is_ambig && not !Flags.quiet then
-    Feedback.msg_info (message_ambig env sigma !ambig_paths)
+  if is_ambig then
+    warn_ambiguous_paths env sigma !ambig_paths
 
 type coercion = {
   coercion_type   : coe_typ;

--- a/test-suite/output/AmbiguousPathsWarning.out
+++ b/test-suite/output/AmbiguousPathsWarning.out
@@ -1,0 +1,3 @@
+File "stdin", line 3, characters 0-41:
+Warning: Ambiguous paths: [A_to_unit'] : A >-> unit
+[ambiguous-paths,typechecker]

--- a/test-suite/output/AmbiguousPathsWarning.v
+++ b/test-suite/output/AmbiguousPathsWarning.v
@@ -1,0 +1,6 @@
+Class A := Ael : unit.
+Identity Coercion A_to_unit: A >-> unit.
+Identity Coercion A_to_unit': A >-> unit.
+
+Set Warnings "-ambiguous-paths".
+Identity Coercion A_to_unit'': A >-> unit.

--- a/test-suite/output/ssr_explain_match.out
+++ b/test-suite/output/ssr_explain_match.out
@@ -1,34 +1,34 @@
-File "stdin", line 12, characters 0-61:
+File "stdin", line 14, characters 0-61:
 Warning: Notation "_ - _" was already used in scope nat_scope.
 [notation-overridden,parsing]
-File "stdin", line 12, characters 0-61:
+File "stdin", line 14, characters 0-61:
 Warning: Notation "_ <= _" was already used in scope nat_scope.
 [notation-overridden,parsing]
-File "stdin", line 12, characters 0-61:
+File "stdin", line 14, characters 0-61:
 Warning: Notation "_ < _" was already used in scope nat_scope.
 [notation-overridden,parsing]
-File "stdin", line 12, characters 0-61:
+File "stdin", line 14, characters 0-61:
 Warning: Notation "_ >= _" was already used in scope nat_scope.
 [notation-overridden,parsing]
-File "stdin", line 12, characters 0-61:
+File "stdin", line 14, characters 0-61:
 Warning: Notation "_ > _" was already used in scope nat_scope.
 [notation-overridden,parsing]
-File "stdin", line 12, characters 0-61:
+File "stdin", line 14, characters 0-61:
 Warning: Notation "_ <= _ <= _" was already used in scope nat_scope.
 [notation-overridden,parsing]
-File "stdin", line 12, characters 0-61:
+File "stdin", line 14, characters 0-61:
 Warning: Notation "_ < _ <= _" was already used in scope nat_scope.
 [notation-overridden,parsing]
-File "stdin", line 12, characters 0-61:
+File "stdin", line 14, characters 0-61:
 Warning: Notation "_ <= _ < _" was already used in scope nat_scope.
 [notation-overridden,parsing]
-File "stdin", line 12, characters 0-61:
+File "stdin", line 14, characters 0-61:
 Warning: Notation "_ < _ < _" was already used in scope nat_scope.
 [notation-overridden,parsing]
-File "stdin", line 12, characters 0-61:
+File "stdin", line 14, characters 0-61:
 Warning: Notation "_ + _" was already used in scope nat_scope.
 [notation-overridden,parsing]
-File "stdin", line 12, characters 0-61:
+File "stdin", line 14, characters 0-61:
 Warning: Notation "_ * _" was already used in scope nat_scope.
 [notation-overridden,parsing]
 BEGIN INSTANCES

--- a/test-suite/output/ssr_explain_match.v
+++ b/test-suite/output/ssr_explain_match.v
@@ -8,6 +8,8 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
+Set Warnings "-ambiguous-paths".
+
 Require Import ssrmatching.
 Require Import ssreflect ssrbool TestSuite.ssr_mini_mathcomp.
 


### PR DESCRIPTION
Previously was a feedback message and therefore not configurable with
the warning system.

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** feature (fix for user messages)


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Partial fix for #8207


<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [x] Added / updated test-suite
<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [x] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [ ] Entry added in CHANGES.

No CHANGES entry seemed necessary; this is part of making the new warning system apply to more existing error messages.