### PR TITLE
Fixes #8215: "critical" type inference bug in interpreting evars by name

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -81,6 +81,11 @@ Specification language
   variables) may occasionally change type inference in incompatible
   ways, especially regarding the inference of the return clause of "match".
 
+- Fixing a missing check in interpreting instances of existential
+  variables which are bound to local definitions might exceptionally
+  induce an overhead if the cost of checking the conversion of the
+  corresponding definitions is additionally high (PR #8215).
+
 Standard Library
 
 - Added `Ascii.eqb` and `String.eqb` and the `=?` notation for them,

--- a/test-suite/bugs/closed/8215.v
+++ b/test-suite/bugs/closed/8215.v
@@ -1,0 +1,14 @@
+(* Check that instances for local definitions in evars have compatible body *)
+Goal False.
+Proof.
+  pose (n := 1).
+  evar (m:nat).
+  subst n.
+  pose (n := 0).
+  Fail Check ?m. (* n cannot be reinterpreted with a value convertible to 1 *)
+  clearbody n.
+  Fail Check ?m. (* n cannot be reinterpreted with a value convertible to 1 *)
+  clear n.
+  pose (n := 0+1).
+  Check ?m. (* Should be ok *)
+Abort.


### PR DESCRIPTION
When interpreting an existential variable "?n@{inst}" in the current context, check that variables bound to local definitions are replaced by variables with convertible body.

Also give a message explaining the type error or non-convertibility error rather than wrongly saying that there is no binding for the variable.

<!-- Keep what applies -->
**Kind:** bug fix

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #8215

- [X] Added / updated test-suite
