### PR TITLE
Introduce a team of code owners for the documentation.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -42,11 +42,7 @@
 # Trick to avoid getting review requests
 # each time someone modifies the dev changelog
 
-/doc/             @maximedenes
-# Secondary maintainer @silene @Zimmi48
-
-/doc/tools/coqrst/ @maximedenes
-# Secondary maintainer @cpitclaudel
+/doc/             @coq/doc-maintainers
 
 /man/             @silene
 # Secondary maintainer @maximedenes


### PR DESCRIPTION
As was previously done for the CI, this means that there are no more principal / secondary code owners, and we can update the team of owner without changing the `CODEOWNERS` file. All the members of the team can choose to review and self-assign any documentation PR that is not their own. All the members of the team receive notifications for all new PRs affecting the `doc/` folder.

For now the team members are @cpitclaudel @maximedenes @Zimmi48. It will be better for me since I will get review requests (I was already acting as principal maintainer) and it will allow @cpitclaudel to review and merge my own documentation PRs.

@silene I didn't put you in the @coq/doc-maintainers team yet. Should I do it?