### PR TITLE
Deprecate [Theorem ... with].

### DIFF
--- a/doc/sphinx/language/gallina-specification-language.rst
+++ b/doc/sphinx/language/gallina-specification-language.rst
@@ -1313,28 +1313,6 @@ Chapter :ref:`Tactics`. The basic assertion command is:
 
       These commands are all synonyms of :n:`Theorem @ident {? @binders } : type`.
 
-.. cmdv:: Theorem @ident {? @binders } : @type {* with @ident {? @binders } : @type}
-
-   This command is useful for theorems that are proved by simultaneous induction
-   over a mutually inductive assumption, or that assert mutually dependent
-   statements in some mutual co-inductive type. It is equivalent to
-   :cmd:`Fixpoint` or :cmd:`CoFixpoint` but using tactics to build the proof of
-   the statements (or the body of the specification, depending on the point of
-   view). The inductive or co-inductive types on which the induction or
-   coinduction has to be done is assumed to be non ambiguous and is guessed by
-   the system.
-
-   Like in a :cmd:`Fixpoint` or :cmd:`CoFixpoint` definition, the induction hypotheses
-   have to be used on *structurally smaller* arguments (for a :cmd:`Fixpoint`) or
-   be *guarded by a constructor* (for a :cmd:`CoFixpoint`). The verification that
-   recursive proof arguments are correct is done only at the time of registering
-   the lemma in the environment. To know if the use of induction hypotheses is
-   correct at some time of the interactive development of a proof, use the
-   command :cmd:`Guarded`.
-
-   The command can be used also with :cmd:`Lemma`, :cmd:`Remark`, etc. instead of
-   :cmd:`Theorem`.
-
 .. cmdv:: Definition @ident {? @binders } : @type
 
    This allows defining a term of type :token:`type` using the proof editing
@@ -1356,13 +1334,40 @@ Chapter :ref:`Tactics`. The basic assertion command is:
 
    This generalizes the syntax of :cmd:`Fixpoint` so that one or more bodies
    can be defined interactively using the proof editing mode (when a
-   body is omitted, its type is mandatory in the syntax). When the block
-   of proofs is completed, it is intended to be ended by :cmd:`Defined`.
+   body is omitted, its type is mandatory in the syntax).
+
+   It is useful in particular for theorems that are proved by simultaneous
+   induction over a mutually inductive assumption. The inductive type on
+   which the induction has to be done is assumed to be non-ambiguous and is
+   guessed by the system.
+
+   The induction hypotheses have to be used on *structurally smaller*
+   arguments. The verification that recursive proof arguments are correct
+   is done only at the time of registering the new lemmas / definitions in the
+   environment. To know if the use of induction hypotheses is correct at some
+   time of the interactive development of a proof, use the command :cmd:`Guarded`.
+
+   The command can be used also with ``Theorem``, ``Lemma``, ``Remark``,
+   etc. instead of ``Fixpoint`` but these forms are deprecated.
 
 .. cmdv:: CoFixpoint @ident {? @binders } : @type {* with @ident {? @binders } : @type}
 
    This generalizes the syntax of :cmd:`CoFixpoint` so that one or more bodies
    can be defined interactively using the proof editing mode.
+
+   It is useful in particular for theorems that are proved by simultaneous
+   co-induction over a mutually co-inductive assumption. The co-inductive type
+   on which the co-induction has to be done is assumed to be non-ambiguous and
+   is guessed by the system.
+
+   The co-induction hypotheses have to be *guarded by a constructor*.
+   The verification that recursive proof arguments are correct
+   is done only at the time of registering the new lemmas / definitions in the
+   environment. To know if the use of co-induction hypotheses is correct at some
+   time of the interactive development of a proof, use the command :cmd:`Guarded`.
+
+   The command can be used also with ``Theorem``, ``Lemma``, ``Remark``,
+   etc. instead of ``Fixpoint`` but these forms are deprecated.
 
 A proof starts by the keyword :cmd:`Proof`. Then Coq enters the proof editing mode
 until the proof is completed. The proof editing mode essentially contains

--- a/theories/MSets/MSetRBT.v
+++ b/theories/MSets/MSetRBT.v
@@ -1756,7 +1756,7 @@ Qed.
 
 (** A third approach : Lemma ... with ... *)
 
-Lemma del_arb s x n : rbt (S n) s -> isblack s -> arbt n (del x s)
+Fixpoint del_arb s x n : rbt (S n) s -> isblack s -> arbt n (del x s)
 with del_rb s x n : rbt n s -> notblack s -> rbt n (del x s).
 Proof.
 { revert n.

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -171,6 +171,13 @@ let lname_of_lident : lident -> lname =
 let name_of_ident_decl : ident_decl -> name_decl =
   on_fst lname_of_lident
 
+let warn_deprecated_thm_with =
+  CWarnings.create
+    ~name:"theorem-with" ~category:"deprecated"
+    (fun thm ->
+      str ("[" ^ Kindops.string_of_theorem_kind thm ^ " ... with] is deprecated. Use [Fixpoint ... with] instead.")
+    )
+
 }
 
 (* Gallina declarations *)
@@ -184,7 +191,8 @@ GRAMMAR EXTEND Gram
         l = LIST0
           [ "with"; id = ident_decl; bl = binders; ":"; c = lconstr ->
           { (id,(bl,c)) } ] ->
-          { VernacStartTheoremProof (thm, (id,(bl,c))::l) }
+          { if not (List.is_empty l) then warn_deprecated_thm_with ~loc thm;
+            VernacStartTheoremProof (thm, (id,(bl,c))::l) }
       | stre = assumption_token; nl = inline; bl = assum_list ->
 	  { VernacAssumption (stre, nl, bl) }
       | tk = assumptions_token; nl = inline; bl = assum_list ->


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** clean-up

- [x] Corresponding documentation was added / updated

This is a proposal to deprecate (and subsequently remove the syntax) `Theorem ... with` which allows to define mutually recursive fixed points in proof-editing mode. The migration path is trivial (replace `Theorem` with `Fixpoint` which also supports not providing a body and using the proof-editing mode instead). Preliminary testing has shown that this is only used (among the projects in our CI) in Equations (cc @mattam82) and CompCert (cc @xavierleroy).

I find the command inconsistent and confusing because `Theorem` will change its meaning if there is a `with` or not (will insert a `fix` / `cofix` or not) whereas `Fixpoint` / `CoFixpoint` won't (they will always insert a `fix` / `cofix`).
There are other additional inconsistencies due to a partly different implementation. See #6567 (should the limitation of the `Fixpoint` form noted in this issue be addressed before deprecating the `Theorem` form?).

This makes it also more complicated to unite `Definition` and `Theorem` as was my intention with the project of introducing `Theorem ... := ...`. In this project, the only practical remaining difference between `Definition` and `Theorem` will be the default resulting opacity (but even this could be made tweakable using an attribute).