### PR TITLE
Fix typo in documentation, heigth --> height.

### DIFF
--- a/theories/FSets/FSetAVL.v
+++ b/theories/FSets/FSetAVL.v
@@ -13,7 +13,7 @@
     It follows the implementation from Ocaml's standard library,
 
     All operations given here expect and produce well-balanced trees
-    (in the ocaml sense: heigths of subtrees shouldn't differ by more
+    (in the ocaml sense: heights of subtrees shouldn't differ by more
     than 2), and hence has low complexities (e.g. add is logarithmic
     in the size of the set). But proving these balancing preservations
     is in fact not necessary for ensuring correct operational behavior

--- a/theories/MSets/MSetGenTree.v
+++ b/theories/MSets/MSetGenTree.v
@@ -11,7 +11,7 @@
     This module factorizes common parts in implementations
     of finite sets as AVL trees and as Red-Black trees. The nodes
     of the trees defined here include an generic information
-    parameter, that will be the heigth in AVL trees and the color
+    parameter, that will be the height in AVL trees and the color
     in Red-Black trees. Without more details here about these
     information parameters, trees here are not known to be
     well-balanced, but simply binary-search-trees.


### PR DESCRIPTION
**Kind:** documentation / typo
