### PR TITLE
Restore previous printing filtering; always reprint the context after "Set Diffs"

### DIFF
--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -362,7 +362,7 @@ let init_color opts =
       false
   in
   if Proof_diffs.show_diffs () && not term_color && not opts.batch_mode then
-    CErrors.user_err Pp.(str "Error: -diffs requires enabling -color");
+    (prerr_endline "Error: -diffs requires enabling -color"; exit 1);
   Topfmt.init_terminal_output ~color:term_color
 
 let print_style_tags opts =


### PR DESCRIPTION
**Kind:** bug fix / feature.

Bug fix: restore previous printing behavior that was unintentionally changed in 7d2a9df
(current code always prints context, should print only if the proof has changed).

Bug fix: fix message that came out as "Error: Error: -diffs requires ..."

Enhancement: always print the context after the "Set Diffs" command.

