### PR TITLE
Do not inline let-bound functions in clambda optimization.

### DIFF
--- a/kernel/clambda.ml
+++ b/kernel/clambda.ml
@@ -269,7 +269,7 @@ let lam_subst_args subst args =
 let can_subst lam =
   match lam with
   | Lrel _ | Lvar _ | Lconst _
-  | Lval _ | Lsort _ | Lind _ | Llam _ -> true
+  | Lval _ | Lsort _ | Lind _ -> true
   | _ -> false
 
 let rec simplify subst lam =


### PR DESCRIPTION
This was triggering an exponential blowup in the size of the generated
intermediate VM code.

Fixes #8277.
