### PR TITLE
[ssr] anomaly -> error

### DIFF
--- a/plugins/ssr/ssrelim.ml
+++ b/plugins/ssr/ssrelim.ml
@@ -293,7 +293,8 @@ let ssrelim ?(ind=ref None) ?(is_case=false) deps what ?elim eqid elim_intro_tac
         let c, cl, ucst = match_pat env p occ h cl in
         let gl = pf_merge_uc ucst gl in
         let c = EConstr.of_constr c in
-        let gl = try pf_unify_HO gl inf_t c with _ -> error gl c inf_t in
+        let gl = try pf_unify_HO gl inf_t c
+                 with exn when CErrors.noncritical exn -> error gl c inf_t in
         cl, gl, post
       with 
       | NoMatch | NoProgress ->
@@ -302,7 +303,8 @@ let ssrelim ?(ind=ref None) ?(is_case=false) deps what ?elim eqid elim_intro_tac
           let e = EConstr.of_constr e in
           let n, e, _, _ucst =  pf_abs_evars gl (fst p, e) in
           let e, _, _, gl = pf_saturate ~beta:true gl e n in 
-          let gl = try pf_unify_HO gl inf_t e with _ -> error gl e inf_t in
+          let gl = try pf_unify_HO gl inf_t e
+                   with exn when CErrors.noncritical exn -> error gl e inf_t in
           cl, gl, post
     in        
     let rec match_all concl gl patterns =

--- a/plugins/ssr/ssrequality.ml
+++ b/plugins/ssr/ssrequality.ml
@@ -115,7 +115,8 @@ let newssrcongrtac arg ist gl =
   (* utils *)
   let fs gl t = Reductionops.nf_evar (project gl) t in
   let tclMATCH_GOAL (c, gl_c) proj t_ok t_fail gl =
-    match try Some (pf_unify_HO gl_c (pf_concl gl) c) with _ -> None with  
+    match try Some (pf_unify_HO gl_c (pf_concl gl) c)
+          with exn when CErrors.noncritical exn -> None with
     | Some gl_c ->
         tclTHEN (Proofview.V82.of_tactic (convert_concl (fs gl_c c)))
           (t_ok (proj gl_c)) gl

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -291,7 +291,10 @@ let unif_EQ_args env sigma pa a =
   prof_unif_eq_args.profile (unif_EQ_args env sigma pa) a 
 ;;
 
-let unif_HO env ise p c = Evarconv.the_conv_x env p c ise
+let unif_HO env ise p c =
+  try Evarconv.the_conv_x env p c ise
+  with Evarconv.UnableToUnify(ise, err) ->
+    raise Pretype_errors.(PretypeError(env,ise,CannotUnify(p,c,Some err)))
 
 let unif_HO_args env ise0 pa i ca =
   let n = Array.length pa in


### PR DESCRIPTION
Looks like this bug was introduced when unification started raising the
UnableToUnify exception in 8ac929e .
I now turn this exception into a PretypeError that is correctly catched
and printed.