### PR TITLE
Fixing #7867: class error message tried to print a "fun" with no binders

### DIFF
--- a/parsing/g_constr.mlg
+++ b/parsing/g_constr.mlg
@@ -249,7 +249,7 @@ GRAMMAR EXTEND Gram
 
   record_field_declaration:
     [ [ id = global; bl = binders; ":="; c = lconstr ->
-      { (id, mkCLambdaN ~loc bl c) } ] ]
+      { (id, if bl = [] then c else mkCLambdaN ~loc bl c) } ] ]
   ;
   binder_constr:
     [ [ "forall"; bl = open_binders; ","; c = operconstr LEVEL "200" ->

--- a/test-suite/bugs/closed/7867.v
+++ b/test-suite/bugs/closed/7867.v
@@ -1,0 +1,4 @@
+(* Was a printer anomaly due to an internal lambda with no binders *)
+
+Class class := { foo : nat }.
+Fail Instance : class := { foo := 0 ; bar := 0 }.


### PR DESCRIPTION
**Kind:** bug fix

Fixes / closes #7867.

Note: the printer cannot print a `fun` or a `forall` with no binders. It is not exactly clear who should be responsible of ensuring that an internal `CLamdaN` or internal `CProdN` node has at least one binder. We fix the bug by modifying the parser so that it does not generate such degenerate `CLamdaN` or `CProdN` node.

- [X] Added / updated test-suite
