### PR TITLE
Cachix can now be installed from nixpkgs.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -225,7 +225,6 @@ pkg:nix:
     EXTRA_PUBLIC_KEYS: coq.cachix.org-1:Jgt0DwGAUo+wpxCM52k2V+E0hLoOzFPzvg94F65agtI=
     # The following variables should not be overridden
     GIT_STRATEGY: none
-    CACHIX_PUBLIC_KEY: cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM=
     NIXOS_PUBLIC_KEY: cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
 
   dependencies: [] # We don't need to download build artifacts
@@ -233,8 +232,9 @@ pkg:nix:
   script:
     # Use current worktree as tmpdir to allow exporting artifacts in case of failure
     - export TMPDIR=$PWD
-    # Install Cachix as documented at https://github.com/cachix/cachix
-    - nix-env -if https://github.com/cachix/cachix/tarball/master --substituters https://cachix.cachix.org --trusted-public-keys "$CACHIX_PUBLIC_KEY"
+    # Fetch the pinned version of nixpkgs
+    - wget $CI_PROJECT_URL/raw/$CI_COMMIT_SHA/dev/pin.nix
+    - nix-env -iA cachix -f pin.nix
     # We build an expression rather than a direct URL to not be dependent on
     # the URL location; we are forced to put the public key of cache.nixos.org
     # because there is no --extra-trusted-public-key option.

--- a/default.nix
+++ b/default.nix
@@ -21,11 +21,7 @@
 # Once the build is finished, you will find, in the current directory,
 # a symlink to where Coq was installed.
 
-{ pkgs ?
-    (import (fetchTarball {
-      url = "https://github.com/NixOS/nixpkgs/archive/060a98e9f4ad879492e48d63e887b0b6db26299e.tar.gz";
-      sha256 = "1lzvp3md0hf6kp2bvc6dbzh40navlyd51qlns9wbkz6lqk3lgf6j";
-    }) {})
+{ pkgs ? import dev/pin.nix
 , ocamlPackages ? pkgs.ocaml-ng.ocamlPackages_4_06
 , buildIde ? true
 , buildDoc ? true

--- a/dev/pin.nix
+++ b/dev/pin.nix
@@ -1,0 +1,4 @@
+import (fetchTarball {
+  url = "https://github.com/NixOS/nixpkgs/tarball/87ae21cd122d2d74ea4ea55d4db6e2166d126ab6";
+  sha256 = "1vm5m97vqrp98ggnvrwbbbbmx3clb7riiigmmnb3r699x11n17za";
+}) {}


### PR DESCRIPTION
So we use the same version of nixpkgs to install Cachix and the dependencies of Coq.