### PR TITLE
Fix #8288: cumulativity inferance ignores args to bound variables

### DIFF
--- a/pretyping/inferCumulativity.ml
+++ b/pretyping/inferCumulativity.ml
@@ -99,7 +99,7 @@ let rec infer_fterm cv_pb infos variances hd stk =
   | FEvar ((_,args),e) ->
     let variances = infer_stack infos variances stk in
     infer_vect infos variances (Array.map (mk_clos e) args)
-  | FRel _ -> variances
+  | FRel _ -> infer_stack infos variances stk
   | FFlex fl ->
     let variances = infer_table_key infos variances fl in
     infer_stack infos variances stk

--- a/test-suite/bugs/closed/8288.v
+++ b/test-suite/bugs/closed/8288.v
@@ -1,0 +1,7 @@
+Set Universe Polymorphism.
+Set Printing Universes.
+
+Set Polymorphic Inductive Cumulativity.
+
+Inductive foo := C : (forall A : Type -> Type, A Type) -> foo.
+(* anomaly invalid subtyping relation *)


### PR DESCRIPTION
(NB: only variables whose binder is inside the constructor argument,
ie

        Inductive foo := C : forall A : Type -> Type, A Type -> foo.

does not trigger the bug because A becomes a RelKey.)

Who knows how long this would have been undetected (and it would have been a proof of False) if infercumulativity was in the kernel. 