### PR TITLE
Fix issue #8298 OCaml 4.07 download path is incorrect

### DIFF
--- a/dev/build/windows/makecoq_mingw.sh
+++ b/dev/build/windows/makecoq_mingw.sh
@@ -793,7 +793,7 @@ function make_ln {
 
 function make_ocaml {
   get_flex_dll_link_bin
-  if build_prep https://github.com/ocaml/ocaml/archive/4.07.0 ocaml-4.07.0 tar.gz 1 ; then
+  if build_prep https://github.com/ocaml/ocaml/archive 4.07.0 tar.gz 1 ocaml-4.07.0 ; then
     # See README.win32.adoc
     cp config/m-nt.h byterun/caml/m.h
     cp config/s-nt.h byterun/caml/s.h


### PR DESCRIPTION
This fixes issue #8298.

The current download path looks like a kind of typo. Interestingly it does work sometimes (I checked it in firefox when reviewing the commit). For me the current path works only in Firefox, but not with wget, Chrome or IE. For CI @jfehrle reported that it fails sometimes. The new path is the github standard archive path and works in any browser.

Cheers,

Michael