### PR TITLE
Better controls for template polymorphism

### DIFF
--- a/doc/sphinx/language/cic.rst
+++ b/doc/sphinx/language/cic.rst
@@ -1025,8 +1025,26 @@ the Type hierarchy.
 Template polymorphism
 +++++++++++++++++++++
 
-Inductive types declared in :math:`\Type` are polymorphic over their arguments
-in :math:`\Type`. If :math:`A` is an arity of some sort and :math:`s` is a sort, we write :math:`A_{/s}`
+Inductive types can be made polymorphic over their arguments
+in :math:`\Type`.
+
+.. opt:: Auto Template Polymorphism
+
+  This option, enabled by default, makes every inductive type declared
+  at level :math:`Type` (without annotations or hiding it behind a
+  definition) template polymorphic.
+
+  This can be prevented using the ``notemplate`` attribute.
+
+  An inductive type can be forced to be template polymorphic using the
+  ``template`` attribute.
+
+  Template polymorphism and universe polymorphism (see Chapter
+  :ref:`polymorphicuniverses`) are incompatible, so if the later is
+  enabled it will prevail over automatic template polymorphism and
+  cause an error when using the ``template`` attribute.
+
+If :math:`A` is an arity of some sort and :math:`s` is a sort, we write :math:`A_{/s}`
 for the arity obtained from :math:`A` by replacing its sort with :math:`s`.
 Especially, if :math:`A` is well-typed in some global environment and local
 context, then :math:`A_{/s}` is typable by typability of all products in the

--- a/plugins/funind/glob_term_to_relation.ml
+++ b/plugins/funind/glob_term_to_relation.ml
@@ -1499,7 +1499,7 @@ let do_build_inductive
   let _time2 = System.get_time () in
   try
     with_full_print
-      (Flags.silently (ComInductive.do_mutual_inductive rel_inds (Flags.is_universe_polymorphism ()) false false ~uniform:ComInductive.NonUniformParameters))
+      (Flags.silently (ComInductive.do_mutual_inductive ~template:None rel_inds (Flags.is_universe_polymorphism ()) false false ~uniform:ComInductive.NonUniformParameters))
       Declarations.Finite
   with
     | UserError(s,msg) as e ->

--- a/test-suite/success/Template.v
+++ b/test-suite/success/Template.v
@@ -1,6 +1,6 @@
 Set Printing Universes.
 
-Module Auto.
+Module AutoYes.
   Inductive Box (A:Type) : Type := box : A -> Box A.
 
   About Box.
@@ -10,7 +10,19 @@ Module Auto.
   Definition j_lebox (A:Type@{j}) := Box A.
   Definition box_lti A := Box A : Type@{i}.
 
-End Auto.
+End AutoYes.
+
+Module AutoNo.
+  Unset Auto Template Polymorphism.
+  Inductive Box (A:Type) : Type := box : A -> Box A.
+
+  About Box.
+
+  Universe i j. Constraint i < j.
+  Definition j_lebox (A:Type@{j}) := Box A.
+  Fail Definition box_lti A := Box A : Type@{i}.
+
+End AutoNo.
 
 Module Yes.
   #[template]

--- a/test-suite/success/Template.v
+++ b/test-suite/success/Template.v
@@ -1,0 +1,36 @@
+Set Printing Universes.
+
+Module Auto.
+  Inductive Box (A:Type) : Type := box : A -> Box A.
+
+  About Box.
+
+  (* This checks that Box is template poly, see module No for how it fails *)
+  Universe i j. Constraint i < j.
+  Definition j_lebox (A:Type@{j}) := Box A.
+  Definition box_lti A := Box A : Type@{i}.
+
+End Auto.
+
+Module Yes.
+  #[template]
+  Inductive Box@{i} (A:Type@{i}) : Type@{i} := box : A -> Box A.
+
+  About Box.
+
+  Universe i j. Constraint i < j.
+  Definition j_lebox (A:Type@{j}) := Box A.
+  Definition box_lti A := Box A : Type@{i}.
+
+End Yes.
+
+Module No.
+  #[notemplate]
+  Inductive Box (A:Type) : Type := box : A -> Box A.
+
+  About Box.
+
+  Universe i j. Constraint i < j.
+  Definition j_lebox (A:Type@{j}) := Box A.
+  Fail Definition box_lti A := Box A : Type@{i}.
+End No.

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -410,6 +410,7 @@ let interp_mutual_inductive_gen env0 (uparamsl,paramsl,indl) notations cum poly 
   let arities = List.map nf arities in
   let constructors = List.map (fun (idl,cl,impsl) -> (idl,List.map nf cl,impsl)) constructors in
   let ctx_params = List.map Termops.(map_rel_decl (EConstr.to_constr sigma)) ctx_params in
+  let arityconcl = List.map (Option.map (EConstr.ESorts.kind sigma)) arityconcl in
   let sigma = restrict_inductive_universes sigma ctx_params arities constructors in
   let uctx = Evd.check_univ_decl ~poly sigma decl in
   List.iter (fun c -> check_evars env_params (Evd.from_env env_params) sigma (EConstr.of_constr c)) arities;
@@ -422,7 +423,7 @@ let interp_mutual_inductive_gen env0 (uparamsl,paramsl,indl) notations cum poly 
   let entries = List.map4 (fun ind arity concl (cnames,ctypes,cimpls) -> {
     mind_entry_typename = ind.ind_name;
     mind_entry_arity = arity;
-    mind_entry_template = Option.has_some concl;
+    mind_entry_template = Option.cata (fun s -> not (Sorts.is_small s)) false concl;
     mind_entry_consnames = cnames;
     mind_entry_lc = ctypes
   }) indl arities arityconcl constructors in

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -423,7 +423,7 @@ let interp_mutual_inductive_gen env0 (uparamsl,paramsl,indl) notations cum poly 
   let entries = List.map4 (fun ind arity concl (cnames,ctypes,cimpls) -> {
     mind_entry_typename = ind.ind_name;
     mind_entry_arity = arity;
-    mind_entry_template = Option.cata (fun s -> not (Sorts.is_small s)) false concl;
+    mind_entry_template = not poly && Option.cata (fun s -> not (Sorts.is_small s)) false concl;
     mind_entry_consnames = cnames;
     mind_entry_lc = ctypes
   }) indl arities arityconcl constructors in

--- a/vernac/comInductive.mli
+++ b/vernac/comInductive.mli
@@ -24,7 +24,7 @@ type uniform_inductive_flag =
   | NonUniformParameters
 
 val do_mutual_inductive :
-  (one_inductive_expr * decl_notation list) list -> cumulative_inductive_flag ->
+  template:bool option -> (one_inductive_expr * decl_notation list) list -> cumulative_inductive_flag ->
   polymorphic -> private_flag -> uniform:uniform_inductive_flag ->
   Declarations.recursivity_kind -> unit
 
@@ -67,6 +67,6 @@ val extract_mutual_inductive_declaration_components :
 (** Typing mutual inductive definitions *)
 
 val interp_mutual_inductive :
-  structured_inductive_expr -> decl_notation list -> cumulative_inductive_flag ->
+  template:bool option -> structured_inductive_expr -> decl_notation list -> cumulative_inductive_flag ->
   polymorphic -> private_flag -> Declarations.recursivity_kind ->
   mutual_inductive_entry * UnivNames.universe_binders * one_inductive_impls list

--- a/vernac/comInductive.mli
+++ b/vernac/comInductive.mli
@@ -45,6 +45,8 @@ val declare_mutual_inductive_with_eliminations :
   mutual_inductive_entry -> UnivNames.universe_binders -> one_inductive_impls list ->
   MutInd.t
 
+val should_auto_template : unit -> bool
+
 (** Exported for Funind *)
 
 (** Extracting the semantical components out of the raw syntax of mutual

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -393,14 +393,14 @@ open Typeclasses
 
 let declare_structure finite ubinders univs paramimpls params template ?(kind=StructureComponent) ?name record_data =
   let nparams = List.length params in
-  let template, ctx =
+  let poly, ctx =
     match univs with
     | Monomorphic_ind_entry ctx ->
-      template, Monomorphic_const_entry Univ.ContextSet.empty
+      false, Monomorphic_const_entry Univ.ContextSet.empty
     | Polymorphic_ind_entry ctx ->
-      false, Polymorphic_const_entry ctx
+      true, Polymorphic_const_entry ctx
     | Cumulative_ind_entry cumi ->
-      false, Polymorphic_const_entry (Univ.CumulativityInfo.univ_context cumi)
+      true, Polymorphic_const_entry (Univ.CumulativityInfo.univ_context cumi)
   in
   let binder_name =
     match name with
@@ -418,9 +418,16 @@ let declare_structure finite ubinders univs paramimpls params template ?(kind=St
     let ind = applist (mkRel (ntypes - i + nparams + nfields), args) in
     let type_constructor = it_mkProd_or_LetIn ind fields in
     let template =
-      template &&
-      let _, s = Reduction.dest_arity (Global.env()) arity in
-      not (Sorts.is_small s)
+      match template with
+      | Some template, _ ->
+        (* templateness explicitly requested *)
+        if poly && template then user_err Pp.(strbrk "template and polymorphism not compatible");
+        template
+      | None, template ->
+        (* auto detect template *)
+        template && not poly &&
+        let _, s = Reduction.dest_arity (Global.env()) arity in
+        not (Sorts.is_small s)
     in
     { mind_entry_typename = id;
       mind_entry_arity = arity;
@@ -446,7 +453,6 @@ let declare_structure finite ubinders univs paramimpls params template ?(kind=St
     let cstr = (rsp, 1) in
     let kinds,sp_projs = declare_projections rsp ctx ~kind binder_name.(i) coers ubinders fieldimpls fields in
     let build = ConstructRef cstr in
-    let poly = match ctx with | Polymorphic_const_entry _ -> true | Monomorphic_const_entry _ -> false in
     let () = if is_coe then Class.try_add_new_coercion build ~local:false poly in
     let () = Recordops.declare_structure(rsp,cstr,List.rev kinds,List.rev sp_projs) in
     rsp
@@ -661,13 +667,14 @@ let extract_record_data records =
 (* [fs] corresponds to fields and [ps] to parameters; [coers] is a
    list telling if the corresponding fields must me declared as coercions
    or subinstances. *)
-let definition_structure kind cum poly finite records =
+let definition_structure kind ~template cum poly finite records =
   let () = check_unique_names records in
   let () = check_priorities kind records in
   let pl, ps, data = extract_record_data records in
-  let pl, univs, template, params, implpars, data =
+  let pl, univs, auto_template, params, implpars, data =
     States.with_state_protection (fun () ->
-      typecheck_params_and_fields finite (kind = Class true) poly pl ps data) () in
+        typecheck_params_and_fields finite (kind = Class true) poly pl ps data) () in
+  let template = template, auto_template in
   match kind with
   | Class def ->
     let (_, id, _, _, cfs, idbuild, _), (arity, implfs, fields) = match records, data with

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -417,6 +417,11 @@ let declare_structure finite ubinders univs paramimpls params template ?(kind=St
     let args = Context.Rel.to_extended_list mkRel nfields params in
     let ind = applist (mkRel (ntypes - i + nparams + nfields), args) in
     let type_constructor = it_mkProd_or_LetIn ind fields in
+    let template =
+      template &&
+      let _, s = Reduction.dest_arity (Global.env()) arity in
+      not (Sorts.is_small s)
+    in
     { mind_entry_typename = id;
       mind_entry_arity = arity;
       mind_entry_template = template;

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -425,7 +425,7 @@ let declare_structure finite ubinders univs paramimpls params template ?(kind=St
         template
       | None, template ->
         (* auto detect template *)
-        template && not poly &&
+        ComInductive.should_auto_template () && template && not poly &&
         let _, s = Reduction.dest_arity (Global.env()) arity in
         not (Sorts.is_small s)
     in

--- a/vernac/record.mli
+++ b/vernac/record.mli
@@ -26,7 +26,8 @@ val declare_projections :
     (Name.t * bool) list * Constant.t option list
 
 val definition_structure :
-  inductive_kind -> Decl_kinds.cumulative_inductive_flag -> Decl_kinds.polymorphic ->
+  inductive_kind -> template:bool option ->
+  Decl_kinds.cumulative_inductive_flag -> Decl_kinds.polymorphic ->
   Declarations.recursivity_kind ->
   (coercion_flag *
   Names.lident *

--- a/vernac/vernacinterp.ml
+++ b/vernac/vernacinterp.ml
@@ -21,12 +21,13 @@ type atts = {
   loc : Loc.t option;
   locality : bool option;
   polymorphic : bool;
+  template : bool option;
   program : bool;
   deprecated : deprecation option;
 }
 
-let mk_atts ?(loc=None) ?(locality=None) ?(polymorphic=false) ?(program=false) ?(deprecated=None) () : atts =
-  { loc ; locality ; polymorphic ; program ; deprecated }
+let mk_atts ?(loc=None) ?(locality=None) ?(polymorphic=false) ?(template=None) ?(program=false) ?(deprecated=None) () : atts =
+  { loc ; locality ; polymorphic ; program ; deprecated; template }
 
 type 'a vernac_command = 'a -> atts:atts -> st:Vernacstate.t -> Vernacstate.t
 

--- a/vernac/vernacinterp.mli
+++ b/vernac/vernacinterp.mli
@@ -18,12 +18,14 @@ type atts = {
   loc : Loc.t option;
   locality : bool option;
   polymorphic : bool;
+  template : bool option;
   program : bool;
   deprecated : deprecation option;
 }
 
 val mk_atts : ?loc: Loc.t option -> ?locality: bool option ->
-  ?polymorphic: bool -> ?program: bool -> ?deprecated: deprecation option -> unit -> atts
+  ?polymorphic: bool -> ?template:bool option ->
+  ?program: bool -> ?deprecated: deprecation option -> unit -> atts
 
 type 'a vernac_command = 'a -> atts:atts -> st:Vernacstate.t -> Vernacstate.t
 


### PR DESCRIPTION
This adds atributes `template` and `notemplate` to control whether an inductive type should be made template polymorphic.
When neither is specified, templateness is inferred as previously unless new option `Auto Template Polymorphism` is unset.

There are tests for the basic functionality (in addition to the stdlib of course) but could be more extensive, eg records are a different code path, etc
Feel free to post some tests to this PR and I'll add them (or if you have the perms you can push directly).

Eventually we may want to move towards remove the automatic option (and someday maybe even remove template completely) but let's get the controls in first.