### PR TITLE
ssrmatching: fix globalization of patterns (fix #6687)

### DIFF
--- a/test-suite/bugs/closed/6687.v
+++ b/test-suite/bugs/closed/6687.v
@@ -1,0 +1,18 @@
+Require Import ssreflect.
+
+Module A.
+
+Definition truth := I.
+
+Ltac t :=
+  move: truth.
+
+Ltac t' :=
+  generalize truth.
+
+End A.
+
+Goal True.
+  A.t.
+  apply.
+Qed.


### PR DESCRIPTION
The fix is partial, only for pattern of the simplest form (eg `term`, not `in term` & co)