### PR TITLE
Add a reminder to update the OPAM using page to the release doc.

### DIFF
--- a/dev/doc/release-process.md
+++ b/dev/doc/release-process.md
@@ -98,3 +98,10 @@ Repeat the generic process documented above for all releases.
 
 We generally do not update the magic numbers at this point (see
 [`2881a18`](https://github.com/coq/coq/commit/2881a18)).
+
+## Note for the OPAM package maintainers ##
+
+In addition to updating the OPAM package, the using instructions at
+<https://coq.inria.fr/opam/www/using.html> must be updated.
+To do so, edit the `COQV` and `OCAMLV` variables at
+<https://github.com/coq/opam-coq-archive/blob/master/Makefile>.


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** documentation

cc @RalfJung 
Do you think that it is OK to consider that it is the role of the OPAM maintainer to update this page?