### PR TITLE
Owners of Makefile.{ci,doc} are teams {ci,doc}-maintainers.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,11 +6,23 @@
 /.github/         @maximedenes
 # Secondary maintainer @Zimmi48
 
+########## Build system ##########
+
+/Makefile*        @gares
+
+/configure*       @ejgallego
+
+/META.coq.in      @ejgallego
+
+/dev/build/windows @MSoegtropIMC
+# Secondary maintainer @maximedenes
+
 ########## CI infrastructure ##########
 
 /dev/ci/          @coq/ci-maintainers
 /.travis.yml      @coq/ci-maintainers
 /.gitlab-ci.yml   @coq/ci-maintainers
+/Makefile.ci      @coq/ci-maintainers
 
 /dev/ci/user-overlays/*.sh @ghost
 # Trick to avoid getting review requests
@@ -43,6 +55,7 @@
 # each time someone modifies the dev changelog
 
 /doc/             @coq/doc-maintainers
+/Makefile.doc     @coq/doc-maintainers
 
 /man/             @silene
 # Secondary maintainer @maximedenes
@@ -291,25 +304,6 @@
 
 /vernac/          @mattam82
 # Secondary maintainer @maximedenes
-
-########## Build system ##########
-
-/Makefile*        @gares
-
-/configure*       @ejgallego
-
-/META.coq.in      @ejgallego
-
-/dev/build/windows @MSoegtropIMC
-# Secondary maintainer @maximedenes
-
-# This file belongs to CI
-/Makefile.ci       @ejgallego
-# Secondary maintainer @SkySkimmer
-
-# This file belongs to the doc
-/Makefile.doc        @maximedenes
-# Secondary maintainer @silene
 
 ########## Test suite ##########
 


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** infrastructure / meta fix


I noticed in #8312 that I had forgotten to update the owners of `Makefile.ci` (and `Makefile.doc`) when moving to code owner teams. To avoid this kind of problems in the future, the build system is moved at the top of the `CODEOWNERS` file and the special `Makefile` are put in the section where they belong.