### PR TITLE
Fix URIs in the configuration script

### DIFF
--- a/configure.ml
+++ b/configure.ml
@@ -1214,8 +1214,8 @@ let write_configml f =
   pr_s "browser" browser;
   pr_s "wwwcoq" !prefs.coqwebsite;
   pr_s "wwwbugtracker" (!prefs.coqwebsite ^ "bugs/");
-  pr_s "wwwrefman" (!prefs.coqwebsite ^ "distrib/" ^ coq_version ^ "/refman/");
-  pr_s "wwwstdlib" (!prefs.coqwebsite ^ "distrib/" ^ coq_version ^ "/stdlib/");
+  pr_s "wwwrefman" (!prefs.coqwebsite ^ "distrib/V" ^ coq_version ^ "/refman/");
+  pr_s "wwwstdlib" (!prefs.coqwebsite ^ "distrib/V" ^ coq_version ^ "/stdlib/");
   pr_s "localwwwrefman"  ("file:/" ^ docdir ^ "/html/refman");
   pr_b "bytecode_compiler" !prefs.bytecodecompiler;
   pr_b "native_compiler" !prefs.nativecompiler;


### PR DESCRIPTION
**Kind:** bug fix.

The naming conversion of documentation URIs seems to be changed since V8.8+beta1 (see: https://coq.inria.fr/distrib/). Currently `configure.ml` doesn't follow it and some documentation of external libraries point wrong URIs (e.g., `plus` and `minus` in http://math-comp.github.io/math-comp/htmldoc/mathcomp.ssreflect.ssrnat.html).
