### PR TITLE
Add index for focusing braces.

### DIFF
--- a/doc/sphinx/proof-engine/proof-handling.rst
+++ b/doc/sphinx/proof-engine/proof-handling.rst
@@ -315,6 +315,9 @@ Navigation in the proof tree
 
 .. _curly-braces:
 
+.. index:: {
+           }
+
 .. cmd:: %{ %| %}
 
    The command ``{`` (without a terminating period) focuses on the first
@@ -369,7 +372,7 @@ Navigation in the proof tree
       Brackets are used to focus on a single goal given either by its position
       or by its name if it has one.
 
-    .. seealso:: The error messages about bullets below.
+  .. seealso:: The error messages about bullets below.
 
 .. _bullets:
 


### PR DESCRIPTION
And fix wrong indentation.

Unfortunately, this is not as good as I would like this to be: while this provides a way to find the documentation of braces, this does not in turn gives people browsing the documentation an easy way to find an anchor for this command description.