### PR TITLE
[bin] Fix binary location procedure to work with symlinks.

### DIFF
--- a/ide/ideutils.ml
+++ b/ide/ideutils.ml
@@ -328,15 +328,18 @@ let coqtop_path () =
       | None ->
         try
           let new_prog = System.get_toplevel_path "coqidetop" in
-            if Sys.file_exists new_prog then new_prog
+            (* The file exists or it is to be found by path *)
+            if Sys.file_exists new_prog ||
+               CString.equal Filename.(basename new_prog) new_prog
+            then new_prog
 	    else
 	      let in_macos_bundle =
 		Filename.concat
 		  (Filename.dirname new_prog)
 		  (Filename.concat "../Resources/bin" (Filename.basename new_prog))
 	      in if Sys.file_exists in_macos_bundle then in_macos_bundle
-                 else "coqidetop"
-        with Not_found -> "coqidetop"
+                 else "coqidetop.opt"
+        with Not_found -> "coqidetop.opt"
   in file
 
 (* In win32, when a command-line is to be executed via cmd.exe

--- a/lib/system.ml
+++ b/lib/system.ml
@@ -301,8 +301,11 @@ let with_time ~batch f x =
     Feedback.msg_info (str msg ++ fmt_time_difference tstart tend ++ str msg2);
     raise e
 
+(* We use argv.[0] as we don't want to resolve symlinks *)
 let get_toplevel_path top =
-  let dir = Filename.dirname Sys.executable_name in
+  let open Filename in
+  let dir = if String.equal (basename Sys.argv.(0)) Sys.argv.(0)
+            then "" else dirname Sys.argv.(0) ^ dir_sep in
   let exe = if Sys.(os_type = "Win32" || os_type = "Cygwin") then ".exe" else "" in
   let eff = if Dynlink.is_native then ".opt" else ".byte" in
-  dir ^ Filename.dir_sep ^ top ^ eff ^ exe
+  dir ^ top ^ eff ^ exe


### PR DESCRIPTION
In #7860 `Sys.executable_name` was introduced to locate coq private
binaries; however, this breaks use cases with symlinks, such as Dune.

In order to fix this, we adopt a simpler strategy; we will always
adapt the name originally provided by the user, and only add a
directory if it was originally present.

This should work (hopefully) in all cases.

This fixes `coqide` not working on Dune builds.
