### PR TITLE
Fixing #8416: Print Assumptions missing module information from compiles files

### DIFF
--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -106,7 +106,8 @@ SUBSYSTEMS := $(VSUBSYSTEMS) misc bugs ide vio coqchk coqwc coq-makefile unit-te
 
 PREREQUISITELOG = prerequisite/admit.v.log			\
   prerequisite/make_local.v.log prerequisite/make_notation.v.log \
-  prerequisite/bind_univs.v.log
+  prerequisite/bind_univs.v.log prerequisite/module_bug8416.v.log \
+  prerequisite/module_bug7192.v.log
 
 #######################################################################
 # Phony targets

--- a/test-suite/output/PrintAssumptions.out
+++ b/test-suite/output/PrintAssumptions.out
@@ -20,3 +20,5 @@ Axioms:
 M.foo : False
 Closed under the global context
 Closed under the global context
+Closed under the global context
+Closed under the global context

--- a/test-suite/output/PrintAssumptions.v
+++ b/test-suite/output/PrintAssumptions.v
@@ -137,3 +137,13 @@ Module F (X : T).
 End F.
 
 End SUBMODULES.
+
+(* Testing a variant of #7192 across files *)
+(* This was missing in the original fix to #7192 *)
+Require Import module_bug7192.
+Print Assumptions M7192.D.f.
+
+(* Testing reporting assumptions from modules in files *)
+(* A regression introduced in the original fix to #7192 was missing implementations *)
+Require Import module_bug8416.
+Print Assumptions M8416.f.

--- a/test-suite/prerequisite/module_bug7192.v
+++ b/test-suite/prerequisite/module_bug7192.v
@@ -1,0 +1,9 @@
+(* Variant of #7192 to be tested in a file requiring this file *)
+(* #7192 is about Print Assumptions not entering implementation of submodules *)
+
+Definition a := True.
+Module Type B. Axiom f : Prop. End B.
+Module Type C. Declare Module D : B. End C.
+Module M7192: C.
+  Module D <: B. Definition f := a. End D.
+End M7192.

--- a/test-suite/prerequisite/module_bug8416.v
+++ b/test-suite/prerequisite/module_bug8416.v
@@ -1,0 +1,2 @@
+Module Type A. Axiom f : True. End A.
+Module M8416 : A. Definition f := I. End M8416.

--- a/vernac/assumptions.ml
+++ b/vernac/assumptions.ml
@@ -70,7 +70,7 @@ let rec fields_of_functor f subs mp0 args = function
 
 let rec lookup_module_in_impl mp =
     match mp with
-    | MPfile _ -> raise Not_found
+    | MPfile _ -> Global.lookup_module mp
     | MPbound _ -> assert false
     | MPdot (mp',lab') ->
        if ModPath.equal mp' (Global.current_modpath ()) then


### PR DESCRIPTION
This fixes the fix 1522b989 to #7192: an incorrect permutation of code in 1522b989 was losing the case `MPfile`. Because of that, the original fix to #7192 was also not effective for instances of #7192 across files.

**Kind:** bug fix

Fixes / closes #8416 

- [X] Added / updated test-suite
