### PR TITLE
[dune] Fix Dune build in Windows.

### DIFF
--- a/Makefile.dune
+++ b/Makefile.dune
@@ -40,7 +40,7 @@ help:
 
 voboot:
 	dune build $(DUNEOPT) @vodeps
-	dune exec coq_dune $(BUILD_CONTEXT)/.vfiles.d
+	dune exec ./tools/coq_dune.exe $(BUILD_CONTEXT)/.vfiles.d
 
 states: voboot
 	dune build $(DUNEOPT) theories/Init/Prelude.vo

--- a/dune
+++ b/dune
@@ -19,7 +19,7 @@
  (deps
   (source_tree theories)
   (source_tree plugins))
- (action (with-stdout-to .vfiles.d (system "%{bin:coqdep} -dyndep opt -noglob -boot `find theories plugins -type f -name *.v`"))))
+ (action (with-stdout-to .vfiles.d (bash "%{bin:coqdep} -dyndep opt -noglob -boot `find theories plugins -type f -name *.v`"))))
 
 (alias
  (name vodeps)
@@ -35,7 +35,7 @@
 (rule
  (targets revision)
  (deps (:rev-script dev/tools/make_git_revision.sh))
- (action (with-stdout-to revision (run %{rev-script}))))
+ (action (with-stdout-to revision (bash %{rev-script}))))
 
 ; Use summary.log as the target
 (alias

--- a/kernel/byterun/dune
+++ b/kernel/byterun/dune
@@ -6,5 +6,5 @@
 
 (rule
  (targets coq_jumptbl.h)
- (deps (:h-file coq_instruct.h))
- (action (run ./make_jumptbl.sh %{h-file} %{targets})))
+ (deps (:h-file coq_instruct.h) make_jumptbl.sh)
+ (action (bash "./make_jumptbl.sh %{h-file} %{targets}")))

--- a/kernel/dune
+++ b/kernel/dune
@@ -8,8 +8,8 @@
 
 (rule
  (targets copcodes.ml)
- (deps (:h-file byterun/coq_instruct.h) make-opcodes)
- (action (run ./make_opcodes.sh %{h-file} %{targets})))
+ (deps (:h-file byterun/coq_instruct.h) make-opcodes make_opcodes.sh)
+ (action (bash "./make_opcodes.sh %{h-file} %{targets}")))
 
 (executable
   (name write_uint63)

--- a/test-suite/misc/universes/dune
+++ b/test-suite/misc/universes/dune
@@ -5,4 +5,4 @@
    (source_tree ../../../plugins))
  (action
    (with-outputs-to all_stdlib.v
-    (run ./build_all_stdlib.sh))))
+    (bash "./build_all_stdlib.sh"))))

--- a/tools/coq_dune.ml
+++ b/tools/coq_dune.ml
@@ -271,8 +271,13 @@ let exec_ifile f =
   match Array.length Sys.argv with
   | 1 -> f stdin
   | 2 ->
-    let ic = open_in Sys.argv.(1) in
-    (try f ic with _ -> close_in ic)
+    let in_file = Sys.argv.(1) in
+    begin try
+      let ic = open_in in_file in
+      (try f ic
+       with _ -> eprintf "Error: exec_ifile@\n%!"; close_in ic)
+      with _ -> eprintf "Error: cannot open input file %s@\n%!" in_file
+    end
   | _ -> eprintf "Error: wrong number of arguments@\n%!"; exit 1
 
 let _ =


### PR DESCRIPTION
In order for Dune to work in Windows we need to tweak some script
calls, they need a POSIX shell and the `(run ...)` / `(system ...)`
actions use `cmd.exe` on Windows.

Hopefully, we will rely less on `bash` when Dune can understand Coq
libraries. This affects shell scripts in `kernel/**.sh` for example.

It is interesting to see how faster the Coq Windows build is with Dune + Windows.

There are some problems with PATHs that prevent the test suite from
working, these will be fixed in a future PR.
