### PR TITLE
Add utop to default.nix for use in nix-shell (see #8426).

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -76,7 +76,7 @@ stdenv.mkDerivation rec {
   )
   ++ optionals shell (
     [ jq curl git gnupg ] # Dependencies of the merging script
-    ++ (with ocamlPackages; [ merlin ocp-indent ocp-index ]) # Dev tools
+    ++ (with ocamlPackages; [ merlin ocp-indent ocp-index utop ]) # Dev tools
   );
 
   src =


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** infrastructure.