### PR TITLE
Move to a team of code owners for the Nix files.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,8 +21,7 @@
 /dev/ci/*.bat          @maximedenes
 # Secondary maintainer @SkySkimmer
 
-/default.nix     @Zimmi48
-# Secondary maintainer @vbgl
+*.nix             @coq/nix-maintainers
 
 ########## Documentation ##########
 


### PR DESCRIPTION
I propose to move to a team of code owners for the `default.nix` and `shell.nix` files (as we did before for the CI and the doc). The members of the team @coq/nix-maintainers currently are @maximedenes, @vbgl and myself.

@maximedenes: The next candidate I have in mind for a code owner team is GitHub meta-data + developer documentation.