### PR TITLE
Canonical representation of kernel substitutions

### DIFF
--- a/checker/cic.mli
+++ b/checker/cic.mli
@@ -132,7 +132,7 @@ type delta_hint =
 
 type delta_resolver = ModPath.t MPmap.t * delta_hint KNmap.t
 
-type 'a umap_t = 'a MPmap.t * 'a MBImap.t
+type 'a umap_t = 'a MPmap.t
 type substitution = (ModPath.t * delta_resolver) umap_t
 
 (** {6 Delayed constr} *)

--- a/checker/values.ml
+++ b/checker/values.ml
@@ -15,7 +15,7 @@
 To ensure this file is up-to-date, 'make' now compares the md5 of cic.mli
 with a copy we maintain here:
 
-MD5 f7b267579138eabf86a74d6f2a7ed794 checker/cic.mli
+MD5 a127e0c2322c7846914bbca9921309c7 checker/cic.mli
 
 *)
 
@@ -185,10 +185,7 @@ let v_resolver =
 let v_mp_resolver = v_tuple "" [|v_mp;v_resolver|]
 
 let v_subst =
-  v_tuple "substitution"
-    [|v_map v_mp v_mp_resolver;
-      v_map v_uid v_mp_resolver|]
-
+  Annot ("substitution", v_map v_mp v_mp_resolver)
 
 (** kernel/lazyconstr *)
 

--- a/kernel/mod_subst.ml
+++ b/kernel/mod_subst.ml
@@ -61,7 +61,6 @@ module Umap = struct
   let add_mp mp x (m1,m2) = (MPmap.add mp x m1, m2)
   let find_mp mp map = MPmap.find mp (fst map)
   let find_mbi mbi map = MBImap.find mbi (snd map)
-  let iter_mbi f map = MBImap.iter f (snd map)
   let fold fmp fmbi (m1,m2) i =
     MPmap.fold fmp m1 (MBImap.fold fmbi m2 i)
   let join map1 map2 = fold add_mp add_mbi map1 map2
@@ -550,20 +549,6 @@ let join subst1 subst2 =
   let mbi_apply_subst mbi = apply_subst (MPbound mbi) (Umap.add_mbi mbi) in
   let subst = Umap.fold mp_apply_subst mbi_apply_subst subst1 empty_subst in
   Umap.join subst2 subst
-
-let rec occur_in_path mbi = function
-  | MPbound bid' -> MBId.equal mbi bid'
-  | MPdot (mp1,_) -> occur_in_path mbi mp1
-  | _ -> false
-
-let occur_mbid mbi sub =
-  let check_one mbi' (mp,_) =
-    if MBId.equal mbi mbi' || occur_in_path mbi mp then raise Exit
-  in
-  try
-    Umap.iter_mbi check_one sub;
-    false
-  with Exit -> true
 
 type 'a substituted = {
   mutable subst_value : 'a;

--- a/kernel/mod_subst.mli
+++ b/kernel/mod_subst.mli
@@ -165,11 +165,6 @@ val replace_mp_in_kn : ModPath.t -> ModPath.t -> KerName.t -> KerName.t
    names appearing in [c] *)
 val subst_mps : substitution -> constr -> constr
 
-(** [occur_*id id sub] returns true iff [id] occurs in [sub]
-   on either side *)
-
-val occur_mbid : MBId.t -> substitution -> bool
-
 (** [repr_substituted r] dumps the representation of a substituted:
     - [None, a] when r is a value
     - [Some s, a] when r is a delayed substitution [s] applied to [a] *)


### PR DESCRIPTION
For some reason the code was implementing substitutions as pairs of maps, but the invariant ensured actually no observable difference between fetching a module ident from one or the other. The split seems to be mostly due to historical reasons. We make this invariant static by representing substitutions as a single map.
