### PR TITLE
Move maps & sets indexed by GlobRef.t into the kernel

### DIFF
--- a/engine/namegen.ml
+++ b/engine/namegen.ml
@@ -258,15 +258,15 @@ let restart_subscript id =
     forget_subscript id
 
 let visible_ids sigma (nenv, c) =
-  let accu = ref (Refset_env.empty, Int.Set.empty, Id.Set.empty) in
+  let accu = ref (GlobRef.Set_env.empty, Int.Set.empty, Id.Set.empty) in
   let rec visible_ids n c = match EConstr.kind sigma c with
   | Const _ | Ind _ | Construct _ | Var _ as c ->
     let (gseen, vseen, ids) = !accu in
     let g = global_of_constr c in
-    if not (Refset_env.mem g gseen) then
+    if not (GlobRef.Set_env.mem g gseen) then
       begin
       try
-      let gseen = Refset_env.add g gseen in
+      let gseen = GlobRef.Set_env.add g gseen in
       let short = shortest_qualid_of_global Id.Set.empty g in
       let dir, id = repr_qualid short in
       let ids = if DirPath.is_empty dir then Id.Set.add id ids else ids in

--- a/engine/univNames.ml
+++ b/engine/univNames.ml
@@ -10,7 +10,6 @@
 
 open Names
 open Univ
-open Globnames
 open Nametab
 
 
@@ -51,15 +50,15 @@ type universe_binders = Univ.Level.t Names.Id.Map.t
 
 let empty_binders = Id.Map.empty
 
-let universe_binders_table = Summary.ref Refmap.empty ~name:"universe binders"
+let universe_binders_table = Summary.ref GlobRef.Map.empty ~name:"universe binders"
 
 let universe_binders_of_global ref : universe_binders =
   try
-    let l = Refmap.find ref !universe_binders_table in l
+    let l = GlobRef.Map.find ref !universe_binders_table in l
   with Not_found -> Names.Id.Map.empty
 
 let cache_ubinder (_,(ref,l)) =
-  universe_binders_table := Refmap.add ref l !universe_binders_table
+  universe_binders_table := GlobRef.Map.add ref l !universe_binders_table
 
 let subst_ubinder (subst,(ref,l as orig)) =
   let ref' = fst (Globnames.subst_global subst ref) in

--- a/interp/impargs.ml
+++ b/interp/impargs.ml
@@ -508,11 +508,11 @@ type implicit_discharge_request =
   | ImplInteractive of GlobRef.t * implicits_flags *
       implicit_interactive_request
 
-let implicits_table = Summary.ref Refmap.empty ~name:"implicits"
+let implicits_table = Summary.ref GlobRef.Map.empty ~name:"implicits"
 
 let implicits_of_global ref =
   try
-    let l = Refmap.find ref !implicits_table in
+    let l = GlobRef.Map.find ref !implicits_table in
     try
       let rename_l = Arguments_renaming.arguments_names ref in
       let rec rename implicits names = match implicits, names with
@@ -527,7 +527,7 @@ let implicits_of_global ref =
   with Not_found -> [DefaultImpArgs,[]]
 
 let cache_implicits_decl (ref,imps) =
-  implicits_table := Refmap.add ref imps !implicits_table
+  implicits_table := GlobRef.Map.add ref imps !implicits_table
 
 let load_implicits _ (_,(_,l)) = List.iter cache_implicits_decl l
 

--- a/interp/reserve.ml
+++ b/interp/reserve.ml
@@ -28,7 +28,7 @@ type key =
 (** TODO: share code from Notation *)
 
 let key_compare k1 k2 = match k1, k2 with
-| RefKey gr1, RefKey gr2 -> RefOrdered.compare gr1 gr2
+| RefKey gr1, RefKey gr2 -> GlobRef.Ordered.compare gr1 gr2
 | RefKey _, Oth -> -1
 | Oth, RefKey _ -> 1
 | Oth, Oth -> 0

--- a/kernel/names.mli
+++ b/kernel/names.mli
@@ -645,6 +645,28 @@ module GlobRef : sig
 
   val equal : t -> t -> bool
 
+  module Ordered : sig
+    type nonrec t = t
+    val compare : t -> t -> int
+    val equal : t -> t -> bool
+    val hash : t -> int
+  end
+
+  module Ordered_env : sig
+    type nonrec t = t
+    val compare : t -> t -> int
+    val equal : t -> t -> bool
+    val hash : t -> int
+  end
+
+  module Set_env : CSig.SetS with type elt = t
+  module Map_env : Map.ExtS
+    with type key = t and module Set := Set_env
+
+  module Set : CSig.SetS with type elt = t
+  module Map : Map.ExtS
+    with type key = t and module Set := Set
+
 end
 
 type global_reference = GlobRef.t

--- a/library/coqlib.ml
+++ b/library/coqlib.ml
@@ -47,7 +47,7 @@ let gen_reference_in_modules locstr dirs s =
   let dirs = List.map make_dir dirs in
   let qualid = qualid_of_string s in
   let all = Nametab.locate_all qualid in
-  let all = List.sort_uniquize RefOrdered_env.compare all in
+  let all = List.sort_uniquize GlobRef.Ordered_env.compare all in
   let these = List.filter (has_suffix_in_dirs dirs) all in
   match these with
     | [x] -> x

--- a/library/globnames.ml
+++ b/library/globnames.ml
@@ -87,65 +87,14 @@ let printable_constr_of_global = function
   | ConstructRef sp -> mkConstruct sp
   | IndRef sp -> mkInd sp
 
-let global_eq_gen eq_cst eq_ind eq_cons x y =
-  x == y ||
-  match x, y with
-  | ConstRef cx, ConstRef cy -> eq_cst cx cy
-  | IndRef indx, IndRef indy -> eq_ind indx indy
-  | ConstructRef consx, ConstructRef consy -> eq_cons consx consy
-  | VarRef v1, VarRef v2 -> Id.equal v1 v2
-  | (VarRef _ | ConstRef _ | IndRef _ | ConstructRef _), _ -> false
+module RefOrdered = Names.GlobRef.Ordered
+module RefOrdered_env = Names.GlobRef.Ordered_env
 
-let global_ord_gen ord_cst ord_ind ord_cons x y =
-  if x == y then 0
-  else match x, y with
-  | VarRef v1, VarRef v2 -> Id.compare v1 v2
-  | VarRef _, _ -> -1
-  | _, VarRef _ -> 1
-  | ConstRef cx, ConstRef cy -> ord_cst cx cy
-  | ConstRef _, _ -> -1
-  | _, ConstRef _ -> 1
-  | IndRef indx, IndRef indy -> ord_ind indx indy
-  | IndRef _, _ -> -1
-  | _ , IndRef _ -> 1
-  | ConstructRef consx, ConstructRef consy -> ord_cons consx consy
+module Refmap = Names.GlobRef.Map
+module Refset = Names.GlobRef.Set
 
-let global_hash_gen hash_cst hash_ind hash_cons gr =
-  let open Hashset.Combine in
-  match gr with
-  | ConstRef c -> combinesmall 1 (hash_cst c)
-  | IndRef i -> combinesmall 2 (hash_ind i)
-  | ConstructRef c -> combinesmall 3 (hash_cons c)
-  | VarRef id -> combinesmall 4 (Id.hash id)
-
-(* By default, [global_reference] are ordered on their canonical part *)
-
-module RefOrdered = struct
-  open Constant.CanOrd
-  type t = global_reference
-  let compare gr1 gr2 =
-    global_ord_gen compare ind_ord constructor_ord gr1 gr2
-  let equal gr1 gr2 = global_eq_gen equal eq_ind eq_constructor gr1 gr2
-  let hash gr = global_hash_gen hash ind_hash constructor_hash gr
-end
-
-module RefOrdered_env = struct
-  open Constant.UserOrd
-  type t = global_reference
-  let compare gr1 gr2 =
-    global_ord_gen compare ind_user_ord constructor_user_ord gr1 gr2
-  let equal gr1 gr2 =
-    global_eq_gen equal eq_user_ind eq_user_constructor gr1 gr2
-  let hash gr = global_hash_gen hash ind_user_hash constructor_user_hash gr
-end
-
-module Refmap = HMap.Make(RefOrdered)
-module Refset = Refmap.Set
-
-(* Alternative sets and maps indexed by the user part of the kernel names *)
-
-module Refmap_env = HMap.Make(RefOrdered_env)
-module Refset_env = Refmap_env.Set
+module Refmap_env = Names.GlobRef.Map_env
+module Refset_env = Names.GlobRef.Set_env
 
 (* Extended global references *)
 
@@ -164,14 +113,14 @@ module ExtRefOrdered = struct
   let equal x y =
     x == y ||
     match x, y with
-    | TrueGlobal rx, TrueGlobal ry -> RefOrdered_env.equal rx ry
+    | TrueGlobal rx, TrueGlobal ry -> GlobRef.Ordered_env.equal rx ry
     | SynDef knx, SynDef kny -> KerName.equal knx kny
     | (TrueGlobal _ | SynDef _), _ -> false
 
   let compare x y =
     if x == y then 0
     else match x, y with
-      | TrueGlobal rx, TrueGlobal ry -> RefOrdered_env.compare rx ry
+      | TrueGlobal rx, TrueGlobal ry -> GlobRef.Ordered_env.compare rx ry
       | SynDef knx, SynDef kny -> KerName.compare knx kny
       | TrueGlobal _, SynDef _ -> -1
       | SynDef _, TrueGlobal _ -> 1
@@ -179,7 +128,7 @@ module ExtRefOrdered = struct
   open Hashset.Combine
 
   let hash = function
-  | TrueGlobal gr -> combinesmall 1 (RefOrdered_env.hash gr)
+  | TrueGlobal gr -> combinesmall 1 (GlobRef.Ordered_env.hash gr)
   | SynDef kn -> combinesmall 2 (KerName.hash kn)
 
 end

--- a/library/globnames.mli
+++ b/library/globnames.mli
@@ -8,7 +8,6 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-open Util
 open Names
 open Constr
 open Mod_subst
@@ -49,27 +48,21 @@ val printable_constr_of_global : GlobRef.t -> constr
    raise [Not_found] if not a global reference *)
 val global_of_constr : constr -> GlobRef.t
 
-module RefOrdered : sig
-  type t = GlobRef.t
-  val compare : t -> t -> int
-  val equal : t -> t -> bool
-  val hash : t -> int
-end
+module RefOrdered = Names.GlobRef.Ordered
+[@@ocaml.deprecated "Use Names.GlobRef.Ordered"]
 
-module RefOrdered_env : sig
-  type t = GlobRef.t
-  val compare : t -> t -> int
-  val equal : t -> t -> bool
-  val hash : t -> int
-end
+module RefOrdered_env = Names.GlobRef.Ordered_env
+[@@ocaml.deprecated "Use Names.GlobRef.Ordered_env"]
 
-module Refset : CSig.SetS with type elt = GlobRef.t
-module Refmap : Map.ExtS
-  with type key = GlobRef.t and module Set := Refset
+module Refset = Names.GlobRef.Set
+[@@ocaml.deprecated "Use Names.GlobRef.Set"]
+module Refmap = Names.GlobRef.Map
+[@@ocaml.deprecated "Use Names.GlobRef.Map"]
 
-module Refset_env : CSig.SetS with type elt = GlobRef.t
-module Refmap_env : Map.ExtS
-  with type key = GlobRef.t and module Set := Refset_env
+module Refset_env = GlobRef.Set_env
+[@@ocaml.deprecated "Use Names.GlobRef.Set_env"]
+module Refmap_env = GlobRef.Map_env
+[@@ocaml.deprecated "Use Names.GlobRef.Map_env"]
 
 (** {6 Extended global references } *)
 

--- a/library/keys.ml
+++ b/library/keys.ml
@@ -31,7 +31,7 @@ module KeyOrdered = struct
 
   let hash gr =
     match gr with
-    | KGlob gr -> 8 + RefOrdered.hash gr
+    | KGlob gr -> 8 + GlobRef.Ordered.hash gr
     | KLam -> 0
     | KLet -> 1
     | KProd -> 2
@@ -43,14 +43,14 @@ module KeyOrdered = struct
 
   let compare gr1 gr2 =
     match gr1, gr2 with
-    | KGlob gr1, KGlob gr2 -> RefOrdered.compare gr1 gr2
+    | KGlob gr1, KGlob gr2 -> GlobRef.Ordered.compare gr1 gr2
     | _, KGlob _ -> -1
     | KGlob _, _ -> 1
     | k, k' -> Int.compare (hash k) (hash k')
     
   let equal k1 k2 =
     match k1, k2 with
-    | KGlob gr1, KGlob gr2 -> RefOrdered.equal gr1 gr2
+    | KGlob gr1, KGlob gr2 -> GlobRef.Ordered.equal gr1 gr2
     | _, KGlob _ -> false
     | KGlob _, _ -> false
     | k, k' -> k == k'

--- a/plugins/extraction/extract_env.ml
+++ b/plugins/extraction/extract_env.ml
@@ -710,10 +710,10 @@ let structure_for_compute env sg c =
   init false false ~compute:true;
   let ast, mlt = Extraction.extract_constr env sg c in
   let ast = Mlutil.normalize ast in
-  let refs = ref Refset.empty in
-  let add_ref r = refs := Refset.add r !refs in
+  let refs = ref GlobRef.Set.empty in
+  let add_ref r = refs := GlobRef.Set.add r !refs in
   let () = ast_iter_references add_ref add_ref add_ref ast in
-  let refs = Refset.elements !refs in
+  let refs = GlobRef.Set.elements !refs in
   let struc = optimize_struct (refs,[]) (mono_environment refs []) in
   (flatten_structure struc), ast, mlt
 

--- a/plugins/extraction/table.ml
+++ b/plugins/extraction/table.ml
@@ -30,8 +30,8 @@ let capitalize = String.capitalize
 (** Sets and maps for [global_reference] that use the "user" [kernel_name]
     instead of the canonical one *)
 
-module Refmap' = Refmap_env
-module Refset' = Refset_env
+module Refmap' = GlobRef.Map_env
+module Refset' = GlobRef.Set_env
 
 (*S Utilities about [module_path] and [kernel_names] and [global_reference] *)
 
@@ -213,12 +213,12 @@ let is_recursor = function
 
 (* NB: here, working modulo name equivalence is ok *)
 
-let projs = ref (Refmap.empty : (inductive*int) Refmap.t)
-let init_projs () = projs := Refmap.empty
-let add_projection n kn ip = projs := Refmap.add (ConstRef kn) (ip,n) !projs
-let is_projection r = Refmap.mem r !projs
-let projection_arity r = snd (Refmap.find r !projs)
-let projection_info r = Refmap.find r !projs
+let projs = ref (GlobRef.Map.empty : (inductive*int) GlobRef.Map.t)
+let init_projs () = projs := GlobRef.Map.empty
+let add_projection n kn ip = projs := GlobRef.Map.add (ConstRef kn) (ip,n) !projs
+let is_projection r = GlobRef.Map.mem r !projs
+let projection_arity r = snd (GlobRef.Map.find r !projs)
+let projection_info r = GlobRef.Map.find r !projs
 
 (*s Table of used axioms *)
 

--- a/plugins/firstorder/instances.ml
+++ b/plugins/firstorder/instances.ml
@@ -38,7 +38,7 @@ let compare_gr id1 id2 =
   if id1==id2 then 0 else
     if id1==dummy_id then 1
     else if id2==dummy_id then -1
-    else Globnames.RefOrdered.compare id1 id2
+    else GlobRef.Ordered.compare id1 id2
 
 module OrderedInstance=
 struct

--- a/plugins/firstorder/sequent.ml
+++ b/plugins/firstorder/sequent.ml
@@ -62,7 +62,7 @@ module Hitem=
 struct
   type t = h_item
   let compare (id1,co1) (id2,co2)=
-    let c = Globnames.RefOrdered.compare id1 id2 in
+    let c = GlobRef.Ordered.compare id1 id2 in
     if c = 0 then
       let cmp (i1, c1) (i2, c2) =
         let c = Int.compare i1 i2 in

--- a/plugins/setoid_ring/newring.ml
+++ b/plugins/setoid_ring/newring.ml
@@ -99,7 +99,7 @@ let protect_tac_in map id =
 let rec closed_under sigma cset t =
   try
     let (gr, _) = Termops.global_of_constr sigma t in
-    Refset_env.mem gr cset
+    GlobRef.Set_env.mem gr cset
   with Not_found ->
     match EConstr.kind sigma t with
     | Cast(c,_,_) -> closed_under sigma cset c
@@ -111,7 +111,7 @@ let closed_term args _ = match args with
   let t = Option.get (Value.to_constr t) in
   let l = List.map (fun c -> Value.cast (Genarg.topwit Stdarg.wit_ref) c) (Option.get (Value.to_list l)) in
   Proofview.tclEVARMAP >>= fun sigma ->
-  let cs = List.fold_right Refset_env.add l Refset_env.empty in
+  let cs = List.fold_right GlobRef.Set_env.add l GlobRef.Set_env.empty in
   if closed_under sigma cs t then Proofview.tclUNIT () else Tacticals.New.tclFAIL 0 (mt())
 | _ -> assert false
 

--- a/pretyping/arguments_renaming.ml
+++ b/pretyping/arguments_renaming.ml
@@ -21,7 +21,7 @@ module NamedDecl = Context.Named.Declaration
 (*i*)
 
 let name_table =
-  Summary.ref (Refmap.empty : Name.t list Refmap.t)
+  Summary.ref (GlobRef.Map.empty : Name.t list GlobRef.Map.t)
     ~name:"rename-arguments"
 
 type req =
@@ -29,7 +29,7 @@ type req =
   | ReqGlobal of GlobRef.t * Name.t list
 
 let load_rename_args _ (_, (_, (r, names))) =
-  name_table := Refmap.add r names !name_table
+  name_table := GlobRef.Map.add r names !name_table
 
 let cache_rename_args o = load_rename_args 1 o
 
@@ -68,7 +68,7 @@ let rename_arguments local r names =
   let req = if local then ReqLocal else ReqGlobal (r, names) in
   Lib.add_anonymous_leaf (inRenameArgs (req, (r, names)))       
 
-let arguments_names r = Refmap.find r !name_table
+let arguments_names r = GlobRef.Map.find r !name_table
 
 let rec rename_prod c = function 
   | [] -> c

--- a/pretyping/classops.ml
+++ b/pretyping/classops.ml
@@ -38,7 +38,7 @@ type cl_info_typ = {
 
 type coe_typ = GlobRef.t
 
-module CoeTypMap = Refmap_env
+module CoeTypMap = GlobRef.Map_env
 
 type coe_info_typ = {
   coe_value : GlobRef.t;
@@ -118,7 +118,7 @@ let coercion_tab =
   ref (CoeTypMap.empty : coe_info_typ CoeTypMap.t)
 
 let coercions_in_scope =
-  ref Refset_env.empty
+  ref GlobRef.Set_env.empty
 
 module ClPairOrd =
 struct
@@ -450,7 +450,7 @@ let load_coercion _ o =
 
 let set_coercion_in_scope (_, c) =
   let r = c.coercion_type in
-  coercions_in_scope := Refset_env.add r !coercions_in_scope
+  coercions_in_scope := GlobRef.Set_env.add r !coercions_in_scope
 
 let open_coercion i o =
   if Int.equal i 1 then begin
@@ -545,7 +545,7 @@ let coercion_of_reference r =
 module CoercionPrinting =
   struct
     type t = coe_typ
-    let compare = RefOrdered.compare
+    let compare = GlobRef.Ordered.compare
     let encode = coercion_of_reference
     let subst = subst_coe_typ
     let printer x = pr_global_env Id.Set.empty x
@@ -565,4 +565,4 @@ let hide_coercion coe =
   else None
 
 let is_coercion_in_scope r =
-  Refset_env.mem r !coercions_in_scope
+  GlobRef.Set_env.mem r !coercions_in_scope

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -88,6 +88,7 @@ let set_reduction_effect x funkey =
 (** Machinery to custom the behavior of the reduction *)
 module ReductionBehaviour = struct
   open Globnames
+  open Names
   open Libobject
 
   type t = {
@@ -97,7 +98,7 @@ module ReductionBehaviour = struct
   }
 
   let table =
-    Summary.ref (Refmap.empty : t Refmap.t) ~name:"reductionbehaviour"
+    Summary.ref (GlobRef.Map.empty : t GlobRef.Map.t) ~name:"reductionbehaviour"
 
   type flag = [ `ReductionDontExposeCase | `ReductionNeverUnfold ]
   type req =
@@ -105,7 +106,7 @@ module ReductionBehaviour = struct
     | ReqGlobal of GlobRef.t * (int list * int * flag list)
 
   let load _ (_,(_,(r, b))) =
-    table := Refmap.add r b !table
+    table := GlobRef.Map.add r b !table
 
   let cache o = load 1 o
 
@@ -160,7 +161,7 @@ module ReductionBehaviour = struct
 
   let get r =
     try
-      let b = Refmap.find r !table in
+      let b = GlobRef.Map.find r !table in
       let flags =
 	if Int.equal b.b_nargs max_int then [`ReductionNeverUnfold]
 	else if b.b_dont_expose_case then [`ReductionDontExposeCase] else [] in

--- a/tactics/btermdn.ml
+++ b/tactics/btermdn.ml
@@ -28,7 +28,7 @@ type term_label =
 | SortLabel
 
 let compare_term_label t1 t2 = match t1, t2 with
-| GRLabel gr1, GRLabel gr2 -> RefOrdered.compare gr1 gr2
+| GRLabel gr1, GRLabel gr2 -> GlobRef.Ordered.compare gr1 gr2
 | _ -> Pervasives.compare t1 t2 (** OK *)
 
 type 'res lookup_res = 'res Dn.lookup_res = Label of 'res | Nothing | Everything

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -288,7 +288,7 @@ let lookup_tacs sigma concl st se =
   let sl' = List.stable_sort pri_order_int l' in
   List.merge pri_order_int se.sentry_nopat sl'
 
-module Constr_map = Map.Make(RefOrdered)
+module Constr_map = Map.Make(GlobRef.Ordered)
 
 let is_transparent_gr (ids, csts) = function
   | VarRef id -> Id.Pred.mem id ids

--- a/tactics/term_dnet.ml
+++ b/tactics/term_dnet.ml
@@ -100,7 +100,7 @@ struct
   | DRel, _ -> -1 | _, DRel -> 1
   | DSort, DSort -> 0
   | DSort, _ -> -1 | _, DSort -> 1
-  | DRef gr1, DRef gr2 -> RefOrdered.compare gr1 gr2
+  | DRef gr1, DRef gr2 -> GlobRef.Ordered.compare gr1 gr2
   | DRef _, _ -> -1 | _, DRef _ -> 1
 
   | DCtx (tl1, tr1), DCtx (tl2, tr2)

--- a/vernac/assumptions.mli
+++ b/vernac/assumptions.mli
@@ -10,7 +10,6 @@
 
 open Names
 open Constr
-open Globnames
 open Printer
 
 (** Collects all the objects on which a term directly relies, bypassing kernel
@@ -22,8 +21,8 @@ open Printer
 *)
 val traverse :
   Label.t -> constr ->
-    (Refset_env.t * Refset_env.t Refmap_env.t *
-     (Label.t * Constr.rel_context * types) list Refmap_env.t)
+    (GlobRef.Set_env.t * GlobRef.Set_env.t GlobRef.Map_env.t *
+     (Label.t * Constr.rel_context * types) list GlobRef.Map_env.t)
 
 (** Collects all the assumptions (optionally including opaque definitions)
    on which a term relies (together with their type). The above warning of


### PR DESCRIPTION
This moves the modules `RefOrdered`, `RefOrdered_env`, `Refmap`, `Refmap_env`, `Refset`, and `Refset_env` from `Globnames` to `Names`.