### PR TITLE
Have `gitFull` in the nix-shell

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -75,7 +75,7 @@ stdenv.mkDerivation rec {
     ++ [ ocamlPackages.ounit rsync which ]
   )
   ++ optionals shell (
-    [ jq curl git gnupg ] # Dependencies of the merging script
+    [ jq curl gitFull gnupg ] # Dependencies of the merging script
     ++ (with ocamlPackages; [ merlin ocp-indent ocp-index utop ]) # Dev tools
   );
 


### PR DESCRIPTION
<!-- Keep what applies -->
**Kind:** infrastructure.

Update `default.nix` so that a `nix-shell` brings `gitFull` into the context, instead of just `git`, which was potentially masking extra git commands.
