### PR TITLE
Print information about the origin of constraints in Print Universes

### DIFF
--- a/dev/top_printers.ml
+++ b/dev/top_printers.ml
@@ -130,14 +130,16 @@ let ppclosedglobconstridmap x = pp (pr_closed_glob_constr_idmap x)
 let pP s = pp (hov 0 s)
 
 let safe_pr_global = function
-  | ConstRef kn -> pp (str "CONSTREF(" ++ Constant.debug_print kn ++ str ")")
-  | IndRef (kn,i) -> pp (str "INDREF(" ++ MutInd.debug_print kn ++ str "," ++
-			  int i ++ str ")")
-  | ConstructRef ((kn,i),j) -> pp (str "INDREF(" ++ MutInd.debug_print kn ++ str "," ++
-				      int i ++ str "," ++ int j ++ str ")")
-  | VarRef id -> pp (str "VARREF(" ++ Id.print id ++ str ")")
+  | ConstRef kn -> str "CONSTREF(" ++ Constant.debug_print kn ++ str ")"
+  | IndRef (kn,i) -> str "INDREF(" ++ MutInd.debug_print kn ++ str "," ++
+                          int i ++ str ")"
+  | ConstructRef ((kn,i),j) -> str "INDREF(" ++ MutInd.debug_print kn ++ str "," ++
+                                      int i ++ str "," ++ int j ++ str ")"
+  | VarRef id -> str "VARREF(" ++ Id.print id ++ str ")"
 
-let ppglobal x = try pp(pr_global x) with _ -> safe_pr_global x
+let ppglobal x = try pp(pr_global x) with _ -> pp (safe_pr_global x)
+
+let ppuniverses u = pp (UGraph.pr_universes safe_pr_global Level.pr u)
 
 let ppconst (sp,j) =
     pp (str"#" ++ KerName.print sp ++ str"=" ++ envpp pr_lconstr_env j.uj_val)
@@ -219,7 +221,6 @@ let ppuniverse_context_future c =
     ppuniverse_context ctx
 let ppcumulativity_info c = pp (Univ.pr_cumulativity_info Univ.Level.pr c)
 let ppabstract_cumulativity_info c = pp (Univ.pr_abstract_cumulativity_info Univ.Level.pr c)
-let ppuniverses u = pp (UGraph.pr_universes Level.pr u)
 let ppnamedcontextval e =
   let env = Global.env () in
   let sigma = Evd.from_env env in

--- a/kernel/environ.ml
+++ b/kernel/environ.ml
@@ -353,35 +353,35 @@ let map_universes f env =
 let set_universes env u =
   { env with env_stratification = { env.env_stratification with env_universes = u } }
 
-let add_constraints c env =
+let add_constraints ?orig c env =
   if Univ.Constraint.is_empty c then env
-  else map_universes (UGraph.merge_constraints c) env
+  else map_universes (UGraph.merge_constraints ?orig c) env
 
 let check_constraints c env =
   UGraph.check_constraints c env.env_stratification.env_universes
 
-let push_constraints_to_env (_,univs) env =
-  add_constraints univs env
+let push_constraints_to_env ?orig (_,univs) env =
+  add_constraints ?orig univs env
 
-let add_universes strict ctx g =
+let add_universes ?orig strict ctx g =
   let g = Array.fold_left
 	    (* Be lenient, module typing reintroduces universes and constraints due to includes *)
 	    (fun g v -> try UGraph.add_universe v strict g with UGraph.AlreadyDeclared -> g)
 	    g (Univ.Instance.to_array (Univ.UContext.instance ctx))
   in
-    UGraph.merge_constraints (Univ.UContext.constraints ctx) g
+    UGraph.merge_constraints ?orig (Univ.UContext.constraints ctx) g
 			   
-let push_context ?(strict=false) ctx env =
-  map_universes (add_universes strict ctx) env
+let push_context ?orig ?(strict=false) ctx env =
+  map_universes (add_universes ?orig strict ctx) env
 
-let add_universes_set strict ctx g =
+let add_universes_set ?orig strict ctx g =
   let g = Univ.LSet.fold
 	    (fun v g -> try UGraph.add_universe v strict g with UGraph.AlreadyDeclared -> g)
 	    (Univ.ContextSet.levels ctx) g
-  in UGraph.merge_constraints (Univ.ContextSet.constraints ctx) g
+  in UGraph.merge_constraints ?orig (Univ.ContextSet.constraints ctx) g
 
-let push_context_set ?(strict=false) ctx env =
-  map_universes (add_universes_set strict ctx) env
+let push_context_set ?orig ?(strict=false) ctx env =
+  map_universes (add_universes_set ?orig strict ctx) env
 
 let set_engagement c env = (* Unsafe *)
   { env with env_stratification =

--- a/kernel/environ.mli
+++ b/kernel/environ.mli
@@ -256,13 +256,14 @@ val lookup_modtype : ModPath.t -> env -> module_type_body
 (** Add universe constraints to the environment.
     @raise UniverseInconsistency .
 *)
-val add_constraints : Univ.Constraint.t -> env -> env
+val add_constraints : ?orig:UGraph.origin -> Univ.Constraint.t -> env -> env
 
 (** Check constraints are satifiable in the environment. *)
 val check_constraints : Univ.Constraint.t -> env -> bool
-val push_context : ?strict:bool -> Univ.UContext.t -> env -> env
-val push_context_set : ?strict:bool -> Univ.ContextSet.t -> env -> env
-val push_constraints_to_env : 'a Univ.constrained -> env -> env
+val push_context : ?orig:UGraph.origin -> ?strict:bool -> Univ.UContext.t -> env -> env
+val push_context_set : ?orig:UGraph.origin -> ?strict:bool -> Univ.ContextSet.t -> env -> env
+val push_constraints_to_env : ?orig:UGraph.origin -> 'a Univ.constrained -> env -> env
+[@@@ocaml.deprecated "Use push_context_set"]
 
 val set_engagement : engagement -> env -> env
 val set_typing_flags : typing_flags -> env -> env

--- a/kernel/uGraph.ml
+++ b/kernel/uGraph.ml
@@ -945,22 +945,25 @@ let check_eq_instances g t1 t2 =
 
 (** Pretty-printing *)
 
-let pr_arc prl = function
+let pr_arc pro prl = function
   | _, Canonical {univ=u; ltle} ->
     if UMap.is_empty ltle then mt ()
     else
       prl u ++ str " " ++
       v 0
-        (pr_sequence (fun (v, (strict,_)) ->
-          (if strict then str "< " else str "<= ") ++ prl v)
+        (pr_sequence (fun (v, (strict,orig)) ->
+             (if strict then str "< " else str "<= ") ++ prl v ++
+             (match orig with
+              | None -> mt ()
+              | Some orig -> str " (from " ++ pro orig ++ str")" ))
            (UMap.bindings ltle)) ++
       fnl ()
   | u, Equiv v ->
       prl u  ++ str " = " ++ prl v ++ fnl ()
 
-let pr_universes prl g =
+let pr_universes pro prl g =
   let graph = UMap.fold (fun u a l -> (u,a)::l) g.entries [] in
-  prlist (pr_arc prl) graph
+  prlist (pr_arc pro prl) graph
 
 (* Dumping constraints to a file *)
 

--- a/kernel/uGraph.mli
+++ b/kernel/uGraph.mli
@@ -10,6 +10,8 @@
 
 open Univ
 
+type origin = Names.GlobRef.t
+
 (** {6 Graphs of universes. } *)
 type t
 type universes = t
@@ -36,8 +38,8 @@ val check_eq_instances : Instance.t check_function
   universes graph. It raises the exception [UniverseInconsistency] if the
   constraints are not satisfiable. *)
 
-val enforce_constraint : univ_constraint -> t -> t
-val merge_constraints : Constraint.t -> t -> t
+val enforce_constraint : ?orig:origin -> univ_constraint -> t -> t
+val merge_constraints : ?orig:origin -> Constraint.t -> t -> t
 
 val check_constraint  : t -> univ_constraint -> bool
 val check_constraints : Constraint.t -> t -> bool

--- a/kernel/uGraph.mli
+++ b/kernel/uGraph.mli
@@ -65,7 +65,7 @@ val check_declared_universes : t -> Univ.LSet.t -> unit
 
 (** {6 Pretty-printing of universes. } *)
 
-val pr_universes : (Level.t -> Pp.t) -> t -> Pp.t
+val pr_universes : (origin -> Pp.t) -> (Level.t -> Pp.t) -> t -> Pp.t
 
 (** The empty graph of universes *)
 val empty_universes : t

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1825,7 +1825,7 @@ let vernac_print ~atts env sigma =
        else str"There may remain asynchronous universe constraints"
      in
      begin match dst with
-     | None -> UGraph.pr_universes UnivNames.pr_with_global_universes univ ++ pr_remaining
+     | None -> UGraph.pr_universes pr_global UnivNames.pr_with_global_universes univ ++ pr_remaining
      | Some s -> dump_universes_gen univ s
      end
   | PrintHint r -> Hints.pr_hint_ref env sigma (smart_global r)


### PR DESCRIPTION
Current limitations:
- constraints not associated with a constant or inductive have no origin
- the information is only about constraints in currently-open modules, so it's lost after module `End` and when loading files
- equality constraints have no origin (I didn't want to figure out how to deal with collapsing a cycle)
- constraints `foo <(=) Set` from declaring a universe have no origin (probably easily could be made to have one)

I think removing these limitations (especially the second one) won't require rewriting these patches so it's worth submitting now.

Here's how it looks after the `Logic_lemmas` section in Init/Logic.v:
~~~
Top.14 <= Top.9 (from eq_rect_r)
Top.13 <= Top.10 (from eq_rect_r)
       <= Top.8 (from eq_rect_r)
Top.12 <= Top.10 (from eq_rec_r)
       <= Top.8 (from eq_rec_r)
Top.11 <= Top.10 (from eq_ind_r)
       <= Top.8 (from eq_ind_r)
Top.10 <= Top.8 (from eq_sym)
Top.7 <= Top.6 (from inst)
Set < Top.14
    < Top.13
    < Top.12
    < Top.11
    < Top.10
    < Top.9
    < Top.8
    < Top.7
    < Top.6
    < Top.5
    < Top.4
    < Top.3
    < Top.2
    < Top.1
Prop < Set
~~~