### PR TITLE
Fix printing of raw terms for lambda's without parameters

### DIFF
--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -1866,9 +1866,7 @@ let internalize globalenv env pattern_mode (_, ntnvars as lvar) c =
     | CProdN (bl,c2) ->
         let (env',bl) = List.fold_left intern_local_binder (env,[]) bl in
         expand_binders ?loc mkGProd bl (intern_type env' c2)
-    | CLambdaN ([],c2) ->
-        (* Such a term is built sometimes: it should not change scope *)
-        intern env c2
+    | CLambdaN ([],c2) -> anomaly (Pp.str "the AST is malformed, found lambda without binders")
     | CLambdaN (bl,c2) ->
         let (env',bl) = List.fold_left intern_local_binder (reset_tmp_scope env,[]) bl in
         expand_binders ?loc mkGLambda bl (intern env' c2)

--- a/parsing/g_constr.mlg
+++ b/parsing/g_constr.mlg
@@ -261,7 +261,7 @@ GRAMMAR EXTEND Gram
         { let ty,c1 = match ty, c1 with
           | (_,None), { CAst.v = CCast(c, CastConv t) } -> (Loc.tag ?loc:(constr_loc t) @@ Some t), c (* Tolerance, see G_vernac.def_body *)
           | _, _ -> ty, c1 in
-          CAst.make ~loc @@ CLetIn(id,mkCLambdaN ?loc:(constr_loc c1) bl c1,
+          CAst.make ~loc @@ CLetIn(id,(if bl = [] then c1 else mkCLambdaN ?loc:(constr_loc c1) bl c1),
                  Option.map (mkCProdN ?loc:(fst ty) bl) (snd ty), c2) }
       | "let"; fx = single_fix; "in"; c = operconstr LEVEL "200" ->
           { let fixp = mk_single_fix fx in

--- a/printing/ppconstr.ml
+++ b/printing/ppconstr.ml
@@ -395,7 +395,7 @@ let tag_var = tag Tag.variable
         kw n ++ pr_binder false pr_c (nal,k,t)
       | (CLocalAssum _ | CLocalPattern _ | CLocalDef _) :: _ as bdl ->
         kw n ++ pr_undelimited_binders sep pr_c bdl
-      | [] -> assert false
+      | [] -> anomaly (Pp.str "the ast is malformed, found lambda without binders")
 
   let pr_binders_gen pr_c sep is_open =
     if is_open then pr_delimited_binders pr_com_at sep pr_c


### PR DESCRIPTION
When parsing terms, sometimes lambda's without any variables are
inserted. An example of such a term is
```coq
let x := 1 in True
```
This term gets parsed in to the following pseudo-term:
```coq
let x := fun => 1 in True
```
This means that during parsing, a lambda without parameters gets inserted.
These lambdas are detected and removed when globalizing terms
from ```Constrexpr.constr_expr``` to ```Glob_term.glob_constr``` in function ```Constrintern.internalize```:
https://github.com/coq/coq/blob/dd84c113a154742dff86328ebc758097e9aac8eb/interp/constrintern.ml#L1869-L1871

This works, but I have a usecase where I have to print terms that have not been internalized.
The printing function assumes that all lambdas have at least one parameter, however, as can be seen from the following two snippets:
https://github.com/coq/coq/blob/dd84c113a154742dff86328ebc758097e9aac8eb/printing/ppconstr.ml#L530-L537
https://github.com/coq/coq/blob/dd84c113a154742dff86328ebc758097e9aac8eb/printing/ppconstr.ml#L391-L398

This pull requests updates the printing function to ignore empty lambdas. Note that there are probably much better solutions for this problem. If so, please let me know.

This change does not affect anything in coq directly because raw terms are never printed, this is only for my usecase (and anyone else's in the future). I ran the tests on the v8.8 branch, which passed. I am currently unable to compile master.

<!-- Keep what applies -->
**Kind:** bug fix

<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [ ] Added / updated test-suite
