### PR TITLE
Infrastructure for partial imports, with example Import(options)

### DIFF
--- a/interp/declare.ml
+++ b/interp/declare.ml
@@ -126,7 +126,7 @@ let (inConstant : constant_obj -> obj) =
   declare_object { (default_object "CONSTANT") with
     cache_function = cache_constant;
     load_function = load_constant;
-    open_function = open_constant;
+    open_function = import_filter [] open_constant;
     classify_function = classify_constant;
     subst_function = ident_subst_function;
     discharge_function = discharge_constant }
@@ -376,7 +376,7 @@ let inInductive : inductive_obj -> obj =
   declare_object {(default_object "INDUCTIVE") with
     cache_function = cache_inductive;
     load_function = load_inductive;
-    open_function = open_inductive;
+    open_function = import_filter [] open_inductive;
     classify_function = (fun a -> Substitute (dummy_inductive_entry a));
     subst_function = ident_subst_function;
     discharge_function = discharge_inductive;
@@ -552,7 +552,7 @@ let input_universe : universe_decl -> Libobject.obj =
     { (default_object "Global universe name state") with
       cache_function = cache_universe;
       load_function = load_universe;
-      open_function = open_universe;
+      open_function = import_filter [] open_universe;
       discharge_function = discharge_universe;
       subst_function = (fun (subst, a) -> (** Actually the name is generated once and for all. *) a);
       classify_function = (fun a -> Substitute a) }

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -190,7 +190,7 @@ let classify_scope (local,_,_ as o) =
 let inScope : bool * bool * scope_elem -> obj =
   declare_object {(default_object "SCOPE") with
       cache_function = cache_scope;
-      open_function = open_scope;
+      open_function = import_filter [] open_scope;
       subst_function = subst_scope;
       discharge_function = discharge_scope;
       classify_function = classify_scope }
@@ -452,9 +452,12 @@ let subst_prim_token_interpretation (subs,infos) =
 let classify_prim_token_interpretation infos =
     if infos.pt_local then Dispose else Substitute infos
 
+let open_prim_token_interpretation i o =
+  if Int.equal i 1 then cache_prim_token_interpretation o
+
 let inPrimTokenInterp : prim_token_infos -> obj =
   declare_object {(default_object "PRIM-TOKEN-INTERP") with
-     open_function  = (fun i o -> if Int.equal i 1 then cache_prim_token_interpretation o);
+     open_function  = import_filter [] open_prim_token_interpretation;
      cache_function = cache_prim_token_interpretation;
      subst_function = subst_prim_token_interpretation;
      classify_function = classify_prim_token_interpretation}

--- a/interp/syntax_def.ml
+++ b/interp/syntax_def.ml
@@ -69,7 +69,7 @@ let in_syntax_constant
   declare_object {(default_object "SYNTAXCONSTANT") with
     cache_function = cache_syntax_constant;
     load_function = load_syntax_constant;
-    open_function = open_syntax_constant;
+    open_function = import_filter [] open_syntax_constant;
     subst_function = subst_syntax_constant;
     classify_function = classify_syntax_constant }
 

--- a/library/declaremods.mli
+++ b/library/declaremods.mli
@@ -54,7 +54,7 @@ val declare_module :
 
 val start_module :
   'modast module_interpretor ->
-  bool option -> Id.t ->
+  Lib.export -> Id.t ->
   'modast module_params ->
   ('modast * inline) module_signature -> ModPath.t
 
@@ -110,13 +110,13 @@ val append_end_library_hook : (unit -> unit) -> unit
    every object of the module. Raises [Not_found] when [mp] is unknown
    or when [mp] corresponds to a functor. *)
 
-val really_import_module : ModPath.t -> unit
+val really_import_module : cat:Libobject.import_filter option -> ModPath.t -> unit
 
 (** [import_module export mp] is a synchronous version of
    [really_import_module]. If [export] is [true], the module is also
    opened every time the module containing it is. *)
 
-val import_module : bool -> ModPath.t -> unit
+val import_module : Lib.qualified_export -> ModPath.t -> unit
 
 (** Include  *)
 

--- a/library/goptions.ml
+++ b/library/goptions.ml
@@ -92,8 +92,8 @@ module MakeTable =
         let inGo : option_mark * A.t -> obj =
           Libobject.declare_object {(Libobject.default_object nick) with
                 Libobject.load_function = load_options;
-		Libobject.open_function = load_options;
-		Libobject.cache_function = cache_options;
+                Libobject.open_function = import_filter [] load_options;
+                Libobject.cache_function = cache_options;
 		Libobject.subst_function = subst_options;
 		Libobject.classify_function = (fun x -> Substitute x)}
 	in
@@ -265,7 +265,7 @@ let declare_option cast uncast append ?(preprocess = fun x -> x)
         declare_object
           { (default_object (nickname key)) with
             load_function = load_options;
-            open_function = open_options;
+            open_function = import_filter [] open_options;
             cache_function = cache_options;
             subst_function = subst_options;
             discharge_function = discharge_options;

--- a/library/goptions.ml
+++ b/library/goptions.ml
@@ -17,6 +17,8 @@ open Libobject
 open Libnames
 open Mod_subst
 
+let opt_cats = [Names.Id.of_string "options"]
+
 type option_name = string list
 type option_value =
   | BoolValue   of bool
@@ -92,9 +94,9 @@ module MakeTable =
         let inGo : option_mark * A.t -> obj =
           Libobject.declare_object {(Libobject.default_object nick) with
                 Libobject.load_function = load_options;
-                Libobject.open_function = import_filter [] load_options;
+                Libobject.open_function = import_filter opt_cats load_options;
                 Libobject.cache_function = cache_options;
-		Libobject.subst_function = subst_options;
+                Libobject.subst_function = subst_options;
 		Libobject.classify_function = (fun x -> Substitute x)}
 	in
         ((fun c -> Lib.add_anonymous_leaf (inGo (GOadd, c))),
@@ -265,7 +267,7 @@ let declare_option cast uncast append ?(preprocess = fun x -> x)
         declare_object
           { (default_object (nickname key)) with
             load_function = load_options;
-            open_function = import_filter [] open_options;
+            open_function = import_filter opt_cats open_options;
             cache_function = cache_options;
             subst_function = subst_options;
             discharge_function = discharge_options;

--- a/library/goptions.mli
+++ b/library/goptions.mli
@@ -52,6 +52,8 @@ type option_name = string list
 
 type option_locality = OptDefault | OptLocal | OptExport | OptGlobal
 
+val opt_cats : Libobject.import_filter
+
 (** {6 Tables. } *)
 
 (** The functor [MakeStringTable] declares a table containing objects

--- a/library/lib.ml
+++ b/library/lib.ml
@@ -20,7 +20,9 @@ open Context.Named.Declaration
 module NamedDecl = Context.Named.Declaration
 
 type is_type = bool (* Module Type or just Module *)
-type export = bool option (* None for a Module Type *)
+type export_flag = Import | Export
+type qualified_export = export_flag * import_filter option
+type export = qualified_export option (* None for a Module Type *)
 
 type node =
   | Leaf of obj
@@ -41,7 +43,7 @@ let iter_objects f i prefix =
   List.iter (fun (id,obj) -> f i (make_oname prefix id, obj))
 
 let load_objects i pr = iter_objects load_object i pr
-let open_objects i pr = iter_objects open_object i pr
+let open_objects ~cat i pr = iter_objects (open_object ~cat) i pr
 
 let subst_objects subst seg = 
   let subst_one = fun (id,obj as node) ->

--- a/library/lib.mli
+++ b/library/lib.mli
@@ -17,7 +17,9 @@ open Names
    mechanism (at a low level; discharge is not known at this step). *)
 
 type is_type = bool (* Module Type or just Module *)
-type export = bool option (* None for a Module Type *)
+type export_flag = Import | Export
+type qualified_export = export_flag * Libobject.import_filter option
+type export = qualified_export option (* None for a Module Type *)
 
 type node =
   | Leaf of Libobject.obj
@@ -31,7 +33,7 @@ type lib_objects = (Id.t * Libobject.obj) list
 
 (** {6 Object iteration functions. } *)
 
-val open_objects : int -> Libnames.object_prefix -> lib_objects -> unit
+val open_objects : cat:Libobject.import_filter option -> int -> Libnames.object_prefix -> lib_objects -> unit
 val load_objects : int -> Libnames.object_prefix -> lib_objects -> unit
 val subst_objects : Mod_subst.substitution -> lib_objects -> lib_objects
 (*val load_and_subst_objects : int -> Libnames.object_prefix -> Mod_subst.substitution -> lib_objects -> lib_objects*)

--- a/library/libobject.mli
+++ b/library/libobject.mli
@@ -66,11 +66,20 @@ open Mod_subst
 type 'a substitutivity =
     Dispose | Substitute of 'a | Keep of 'a | Anticipate of 'a
 
+(** Object import filters (currently a list of adhoc categories).
+
+    When using a qualified import [Import(cat1 ... catn)] objects are
+   given the list of names when opened.
+
+    It is customary to define objects with a list (possibly empty) of
+   categories which must match for import to happen. *)
+type import_filter = Names.Id.t list
+
 type 'a object_declaration = {
   object_name : string;
   cache_function : object_name * 'a -> unit;
   load_function : int -> object_name * 'a -> unit;
-  open_function : int -> object_name * 'a -> unit;
+  open_function : cat:import_filter option -> int -> object_name * 'a -> unit;
   classify_function : 'a -> 'a substitutivity;
   subst_function :  substitution * 'a -> 'a;
   discharge_function : object_name * 'a -> 'a option;
@@ -86,6 +95,9 @@ type 'a object_declaration = {
 *)
 
 val default_object : string -> 'a object_declaration
+val import_filter : import_filter -> ('a -> 'b -> unit) -> cat:import_filter option -> 'a -> 'b -> unit
+(** [import_filter ocat f] produces a function which calls [f] when [cat]
+   is [None] or matches [ocat]. *)
 
 (** the identity substitution function *)
 val ident_subst_function : substitution * 'a -> 'a
@@ -107,7 +119,7 @@ val object_tag : obj -> string
 
 val cache_object : object_name * obj -> unit
 val load_object : int -> object_name * obj -> unit
-val open_object : int -> object_name * obj -> unit
+val open_object : cat:import_filter option -> int -> object_name * obj -> unit
 val subst_object : substitution * obj -> obj
 val classify_object : obj -> obj substitutivity
 val discharge_object : object_name * obj -> obj option

--- a/library/library.mli
+++ b/library/library.mli
@@ -22,7 +22,7 @@ open Libnames
 (** {6 ... } *)
 (** Require = load in the environment + open (if the optional boolean
     is not [None]); mark also for export if the boolean is [Some true] *)
-val require_library_from_dirpath : (DirPath.t * string) list -> bool option -> unit
+val require_library_from_dirpath : (DirPath.t * string) list -> Lib.export_flag option -> unit
 
 (** {6 Start the compilation of a library } *)
 
@@ -36,7 +36,7 @@ type seg_proofs = Constr.constr Future.computation array
 
 (** Open a module (or a library); if the boolean is true then it's also
    an export otherwise just a simple import *)
-val import_module : bool -> qualid list -> unit
+val import_module : Lib.qualified_export -> qualid list -> unit
 
 (** Start the compilation of a file as a library. The first argument must be
     output file, and the 

--- a/plugins/ltac/extratactics.ml4
+++ b/plugins/ltac/extratactics.ml4
@@ -475,7 +475,7 @@ let subst_transitivity_lemma (subst,(b,ref)) = (b,subst_mps subst ref)
 let inTransitivity : bool * Constr.t -> obj =
   declare_object {(default_object "TRANSITIVITY-STEPS") with
     cache_function = cache_transitivity_lemma;
-    open_function = (fun i o -> if Int.equal i 1 then cache_transitivity_lemma o);
+    open_function = import_filter [] (fun i o -> if Int.equal i 1 then cache_transitivity_lemma o);
     subst_function = subst_transitivity_lemma;
     classify_function = (fun o -> Substitute o) }
 
@@ -519,7 +519,7 @@ let subst_implicit_tactic (subst,tac) =
 
 let inImplicitTactic : glob_tactic_expr option -> obj =
   declare_object {(default_object "IMPLICIT-TACTIC") with
-       open_function = (fun i o -> if Int.equal i 1 then cache_implicit_tactic o);
+       open_function = import_filter [] (fun i o -> if Int.equal i 1 then cache_implicit_tactic o);
        cache_function = cache_implicit_tactic;
        subst_function = subst_implicit_tactic;
        classify_function = (fun o -> Dispose)}

--- a/plugins/ltac/tacentries.ml
+++ b/plugins/ltac/tacentries.ml
@@ -299,7 +299,7 @@ let classify_tactic_notation tacobj = Substitute tacobj
 
 let inTacticGrammar : tactic_grammar_obj -> obj =
   declare_object {(default_object "TacticGrammar") with
-       open_function = open_tactic_notation;
+       open_function = import_filter [] open_tactic_notation;
        load_function = load_tactic_notation;
        cache_function = cache_tactic_notation;
        subst_function = subst_tactic_notation;

--- a/plugins/ltac/tacenv.ml
+++ b/plugins/ltac/tacenv.ml
@@ -183,7 +183,7 @@ let inMD : bool * ltac_constant option * bool * glob_tactic_expr *
   declare_object {(default_object "TAC-DEFINITION") with
      cache_function  = cache_md;
      load_function   = load_md;
-     open_function   = open_md;
+     open_function   = import_filter [] open_md;
      subst_function = subst_md;
      classify_function = classify_md}
 

--- a/plugins/ltac/tactic_option.ml
+++ b/plugins/ltac/tactic_option.ml
@@ -36,9 +36,9 @@ let declare_tactic_option ?(default=Tacexpr.TacId []) name =
       { (default_object name) with
 	cache_function = cache;
 	load_function = (fun _ -> load);
-        open_function = import_filter [] (fun _ -> load);
+        open_function = import_filter Goptions.opt_cats (fun _ -> load);
         classify_function = (fun (local, tac) ->
-	  if local then Dispose else Substitute (local, tac));
+          if local then Dispose else Substitute (local, tac));
 	subst_function = subst}
   in
   let put local tac =

--- a/plugins/ltac/tactic_option.ml
+++ b/plugins/ltac/tactic_option.ml
@@ -36,8 +36,8 @@ let declare_tactic_option ?(default=Tacexpr.TacId []) name =
       { (default_object name) with
 	cache_function = cache;
 	load_function = (fun _ -> load);
-	open_function = (fun _ -> load);
-	classify_function = (fun (local, tac) ->
+        open_function = import_filter [] (fun _ -> load);
+        classify_function = (fun (local, tac) ->
 	  if local then Dispose else Substitute (local, tac));
 	subst_function = subst}
   in

--- a/plugins/setoid_ring/newring.ml
+++ b/plugins/setoid_ring/newring.ml
@@ -402,7 +402,7 @@ let theory_to_obj : ring_info -> obj =
   let cache_th (name,th) = add_entry name th in
   declare_object
     {(default_object "tactic-new-ring-theory") with
-      open_function = (fun i o -> if Int.equal i 1 then cache_th o);
+      open_function = import_filter [] (fun i o -> if Int.equal i 1 then cache_th o);
       cache_function = cache_th;
       subst_function = subst_th;
       classify_function = (fun x -> Substitute x)}
@@ -899,7 +899,7 @@ let ftheory_to_obj : field_info -> obj =
   let cache_th (name,th) = add_field_entry name th in
   declare_object
     {(default_object "tactic-new-field-theory") with
-      open_function = (fun i o -> if Int.equal i 1 then cache_th o);
+      open_function = import_filter [] (fun i o -> if Int.equal i 1 then cache_th o);
       cache_function = cache_th;
       subst_function = subst_th;
       classify_function = (fun x -> Substitute x) }

--- a/plugins/ssr/ssrvernac.ml4
+++ b/plugins/ssr/ssrvernac.ml4
@@ -175,7 +175,7 @@ GEXTEND Gram
   GLOBAL: gallina_ext;
   gallina_ext:
    [ [ IDENT "Import"; IDENT "Prenex"; IDENT "Implicits" ->
-      Vernacexpr.VernacUnsetOption (false, ["Printing"; "Implicit"; "Defensive"])
+      Vernacexpr.VernacUnsetOption (Lib.Import, ["Printing"; "Implicit"; "Defensive"])
    ] ]
   ;
 END

--- a/plugins/ssr/ssrview.ml
+++ b/plugins/ssr/ssrview.ml
@@ -48,13 +48,13 @@ module AdaptorDb = struct
   let classify_adaptor x = Libobject.Substitute x
 
   let in_db =
-    Libobject.declare_object {
-       (Libobject.default_object "VIEW_ADAPTOR_DB")
+    Libobject.(declare_object {
+       (default_object "VIEW_ADAPTOR_DB")
     with
-       Libobject.open_function = (fun i o -> if i = 1 then cache_adaptor o);
-       Libobject.cache_function = cache_adaptor;
-       Libobject.subst_function = subst_adaptor;
-       Libobject.classify_function = classify_adaptor }
+       open_function = import_filter [] (fun i o -> if i = 1 then cache_adaptor o);
+       cache_function = cache_adaptor;
+       subst_function = subst_adaptor;
+       classify_function = classify_adaptor })
 
   let declare kind terms =
     List.iter (fun term -> Lib.add_anonymous_leaf (in_db (kind,term)))

--- a/pretyping/classops.ml
+++ b/pretyping/classops.ml
@@ -499,7 +499,7 @@ let classify_coercion obj =
 
 let inCoercion : coercion -> obj =
   declare_object {(default_object "COERCION") with
-    open_function = open_coercion;
+    open_function = import_filter [] open_coercion;
     load_function = load_coercion;
     cache_function = (fun objn ->
         set_coercion_in_scope objn;

--- a/pretyping/recordops.ml
+++ b/pretyping/recordops.ml
@@ -320,7 +320,7 @@ let discharge_canonical_structure (_,(cst,ind)) =
 
 let inCanonStruc : Constant.t * inductive -> obj =
   declare_object {(default_object "CANONICAL-STRUCTURE") with
-    open_function = open_canonical_structure;
+    open_function = import_filter [] open_canonical_structure;
     cache_function = cache_canonical_structure;
     subst_function = subst_canonical_structure;
     classify_function = (fun x -> Substitute x);

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -71,7 +71,7 @@ let subst_reduction_effect (subst,(con,funkey)) =
 let inReductionEffect : Constant.t * string -> obj =
   declare_object {(default_object "REDUCTION-EFFECT") with
     cache_function = cache_reduction_effect;
-    open_function = (fun i o -> if Int.equal i 1 then cache_reduction_effect o);
+    open_function = import_filter [] (fun i o -> if Int.equal i 1 then cache_reduction_effect o);
     subst_function = subst_reduction_effect;
     classify_function = (fun o -> Substitute o) }
 

--- a/pretyping/typeclasses.ml
+++ b/pretyping/typeclasses.ml
@@ -255,7 +255,7 @@ let class_input : typeclass -> obj =
     { (default_object "type classes state") with
       cache_function = cache_class;
       load_function = (fun _ -> load_class);
-      open_function = (fun _ -> load_class);
+      open_function = import_filter [] (fun _ -> load_class);
       classify_function = (fun x -> Substitute x);
       discharge_function = (fun a -> Some (discharge_class a));
       rebuild_function = rebuild_class;
@@ -406,7 +406,7 @@ let instance_input : instance_action * instance -> obj =
     { (default_object "type classes instances state") with
       cache_function = cache_instance;
       load_function = (fun _ x -> cache_instance x);
-      open_function = (fun _ x -> cache_instance x);
+      open_function = import_filter [] (fun _ x -> cache_instance x);
       classify_function = classify_instance;
       discharge_function = discharge_instance;
       rebuild_function = rebuild_instance;

--- a/printing/printmod.ml
+++ b/printing/printmod.ml
@@ -278,7 +278,8 @@ let nametab_register_body mp dir (l,body) =
 
 let nametab_register_module_body mp struc =
   (* If [mp] is a globally visible module, we simply import it *)
-  try Declaremods.really_import_module mp
+  (* TODO import only categories relevant to name stuff *)
+  try Declaremods.really_import_module ~cat:None mp
   with Not_found ->
     (* Otherwise we try to emulate an import by playing with nametab *)
     nametab_register_dir mp;

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -2553,7 +2553,7 @@ type stm_init_options = {
      [lib,prefix,import_export] means require library [lib] from
      optional [prefix] and [import_export] if [Some false/Some true]
      is used.  *)
-  require_libs : (string * string option * bool option) list;
+  require_libs : (string * string option * Lib.export_flag option) list;
 
   (* STM options that apply to the current document. *)
   stm_options  : AsyncOpts.stm_opt;

--- a/stm/stm.mli
+++ b/stm/stm.mli
@@ -73,7 +73,7 @@ type stm_init_options = {
      [lib,prefix,import_export] means require library [lib] from
      optional [prefix] and [import_export] if [Some false/Some true]
      is used.  *)
-  require_libs : (string * string option * bool option) list;
+  require_libs : (string * string option * Lib.export_flag option) list;
 
   (* STM options that apply to the current document. *)
   stm_options  : AsyncOpts.stm_opt;

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -1162,7 +1162,7 @@ let inAutoHint : hint_obj -> obj =
   declare_object {(default_object "AUTOHINT") with
                     cache_function = cache_autohint;
 		    load_function = load_autohint;
-		    open_function = open_autohint;
+                    open_function = import_filter [] open_autohint;
 		    subst_function = subst_autohint;
 		    classify_function = classify_autohint; }
 

--- a/test-suite/success/QualifiedImport.v
+++ b/test-suite/success/QualifiedImport.v
@@ -1,0 +1,23 @@
+
+Module M.
+
+  Export Set Universe Polymorphism.
+  Definition foo := Type.
+
+End M.
+
+Module N.
+
+  Definition bar := Type. Fail Check bar@{_}.
+
+  Import M.
+  Definition baz := Type. Check baz@{_}.
+End N.
+
+Module Z.
+  Import(fake) M.
+  Definition bar := Type. Fail Check bar@{_}.
+
+  Import(options) M.
+  Definition baz := Type. Check baz@{_}.
+End Z.

--- a/toplevel/coqargs.ml
+++ b/toplevel/coqargs.ml
@@ -44,7 +44,7 @@ type coq_cmdopts = {
 
   ml_includes : string list;
   vo_includes : (string * Names.DirPath.t * bool) list;
-  vo_requires : (string * string option * bool option) list;
+  vo_requires : (string * string option * Lib.export_flag option) list;
   (* None = No Import; Some false = Import; Some true = Export *)
 
   (* XXX: Fusion? *)
@@ -152,9 +152,9 @@ let add_vo_require opts d p export =
 
 let add_compat_require opts v =
   match v with
-  | Flags.V8_6 -> add_vo_require opts "Coq.Compat.Coq86" None (Some false)
-  | Flags.V8_7 -> add_vo_require opts "Coq.Compat.Coq87" None (Some false)
-  | Flags.Current -> add_vo_require opts "Coq.Compat.Coq88" None (Some false)
+  | Flags.V8_6 -> add_vo_require opts "Coq.Compat.Coq86" None (Some Lib.Import)
+  | Flags.V8_7 -> add_vo_require opts "Coq.Compat.Coq87" None (Some Lib.Import)
+  | Flags.Current -> add_vo_require opts "Coq.Compat.Coq88" None (Some Lib.Import)
 
 let set_batch_mode opts =
   Flags.quiet := true;
@@ -480,7 +480,7 @@ let parse_args arglist : coq_cmdopts * string list =
       Flags.profile_ltac_cutoff := get_float opt (next ());
       oval
 
-    |"-require" -> add_vo_require oval (next ()) None (Some false)
+    |"-require" -> add_vo_require oval (next ()) None (Some Lib.Import)
 
     |"-top" ->
       let topname = Libnames.dirpath_of_string (next ()) in
@@ -558,7 +558,7 @@ let parse_args arglist : coq_cmdopts * string list =
     |"-list-tags" -> { oval with print_tags = true }
     |"-time" -> { oval with time = true }
     |"-type-in-type" -> set_type_in_type (); oval
-    |"-unicode" -> add_vo_require oval "Utf8_core" None (Some false)
+    |"-unicode" -> add_vo_require oval "Utf8_core" None (Some Lib.Import)
     |"-where" -> { oval with print_where = true }
     |"-h"|"-H"|"-?"|"-help"|"--help" -> usage oval.batch_mode; oval
     |"-v"|"--version" -> Usage.version (exitcode oval)

--- a/toplevel/coqargs.mli
+++ b/toplevel/coqargs.mli
@@ -19,7 +19,7 @@ type coq_cmdopts = {
 
   ml_includes : string list;
   vo_includes : (string * Names.DirPath.t * bool) list;
-  vo_requires : (string * string option * bool option) list;
+  vo_requires : (string * string option * Lib.export_flag option) list;
 
   (* Fuse these two? Currently, [batch_mode] is only used to
      distinguish coqc / coqtop in help display. *)

--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -107,7 +107,7 @@ let load_init_vernaculars cur_feeder opts ~state =
 (* Startup LoadPath and Modules                                               *)
 (******************************************************************************)
 (* prelude_data == From Coq Require Export Prelude. *)
-let prelude_data = "Prelude", Some "Coq", Some true
+let prelude_data = "Prelude", Some "Coq", Some Lib.Export
 
 let require_libs opts =
   if opts.load_init then prelude_data :: opts.vo_requires else opts.vo_requires

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -21,6 +21,7 @@ open Constrexpr_ops
 open Extend
 open Decl_kinds
 open Declaremods
+open Lib
 open Declarations
 open Namegen
 open Tok (* necessary for camlp5 *)
@@ -524,17 +525,20 @@ GRAMMAR EXTEND Gram
       | IDENT "From" ; ns = global ; IDENT "Require"; export = export_token
 	; qidl = LIST1 global ->
 	{ VernacRequire (Some ns, export, qidl) }
-      | IDENT "Import"; qidl = LIST1 global -> { VernacImport (false,qidl) }
-      | IDENT "Export"; qidl = LIST1 global -> { VernacImport (true,qidl) }
+      | IDENT "Import"; cat = export_cats; qidl = LIST1 global -> { VernacImport ((Import,cat),qidl) }
+      | IDENT "Export"; cat = export_cats; qidl = LIST1 global -> { VernacImport ((Export,cat),qidl) }
       | IDENT "Include"; e = module_type_inl; l = LIST0 ext_module_expr ->
 	  { VernacInclude(e::l) }
       | IDENT "Include"; "Type"; e = module_type_inl; l = LIST0 ext_module_type ->
 	 { warn_deprecated_include_type ~loc ();
         VernacInclude(e::l) } ] ]
   ;
+  export_cats:
+    [ [ cat = OPT [ "("; cat = LIST1 ident; ")" -> { cat } ] -> { cat } ] ]
+  ;
   export_token:
-    [ [ IDENT "Import" -> { Some false }
-      | IDENT "Export" -> { Some true }
+    [ [ IDENT "Import"; cat = export_cats -> { Some (Import,cat) }
+      | IDENT "Export"; cat = export_cats -> { Some (Export,cat) }
       |  -> { None } ] ]
   ;
   ext_module_type:
@@ -832,9 +836,9 @@ GRAMMAR EXTEND Gram
 
   gallina_ext:
     [ [ IDENT "Export"; "Set"; table = option_table; v = option_value ->
-        { VernacSetOption (true, table, v) }
+        { VernacSetOption (Export, table, v) }
       | IDENT "Export"; IDENT "Unset"; table = option_table ->
-          { VernacUnsetOption (true, table) }
+          { VernacUnsetOption (Export, table) }
     ] ];
 
   command:
@@ -900,9 +904,9 @@ GRAMMAR EXTEND Gram
 
       (* For acting on parameter tables *)
       | "Set"; table = option_table; v = option_value ->
-          { VernacSetOption (false, table, v) }
+          { VernacSetOption (Import, table, v) }
       | IDENT "Unset"; table = option_table ->
-          { VernacUnsetOption (false, table) }
+          { VernacUnsetOption (Import, table) }
 
       | IDENT "Print"; IDENT "Table"; table = option_table ->
 	  { VernacPrintOption table }
@@ -1080,10 +1084,10 @@ GRAMMAR EXTEND Gram
 
 (* Tactic Debugger *)
       |	IDENT "Debug"; IDENT "On" ->
-          { VernacSetOption (false, ["Ltac";"Debug"], BoolValue true) }
+          { VernacSetOption (Import, ["Ltac";"Debug"], BoolValue true) }
 
       |	IDENT "Debug"; IDENT "Off" ->
-          { VernacSetOption (false, ["Ltac";"Debug"], BoolValue false) }
+          { VernacSetOption (Import, ["Ltac";"Debug"], BoolValue false) }
 
 (* registration of a custom reduction *)
 

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -34,7 +34,7 @@ let cache_token (_,s) = CLexer.add_keyword s
 
 let inToken : string -> obj =
   declare_object {(default_object "TOKEN") with
-       open_function = (fun i o -> if Int.equal i 1 then cache_token o);
+       open_function = import_filter [] (fun i o -> if Int.equal i 1 then cache_token o);
        cache_function = cache_token;
        subst_function = Libobject.ident_subst_function;
        classify_function = (fun o -> Substitute o)}
@@ -788,7 +788,7 @@ let classify_syntax_definition (local, _ as o) =
 
 let inSyntaxExtension : syntax_extension_obj -> obj =
   declare_object {(default_object "SYNTAX-EXTENSION") with
-       open_function = (fun i o -> if Int.equal i 1 then cache_syntax_extension o);
+       open_function = import_filter [] (fun i o -> if Int.equal i 1 then cache_syntax_extension o);
        cache_function = cache_syntax_extension;
        subst_function = subst_syntax_extension;
        classify_function = classify_syntax_definition}
@@ -1352,7 +1352,7 @@ let classify_notation nobj =
 
 let inNotation : notation_obj -> obj =
   declare_object {(default_object "NOTATION") with
-       open_function = open_notation;
+       open_function = import_filter [] open_notation;
        cache_function = cache_notation;
        subst_function = subst_notation;
        load_function = load_notation;
@@ -1626,7 +1626,7 @@ let classify_scope_command (local, _, _ as o) =
 let inScopeCommand : locality_flag * scope_name * scope_command -> obj =
   declare_object {(default_object "DELIMITERS") with
       cache_function = cache_scope_command;
-      open_function = open_scope_command;
+      open_function = import_filter [] open_scope_command;
       load_function = load_scope_command;
       subst_function = subst_scope_command;
       classify_function = classify_scope_command}
@@ -1689,7 +1689,7 @@ let classify_custom_entry (local,s as o) =
 let inCustomEntry : locality_flag * string -> obj =
   declare_object {(default_object "CUSTOM-ENTRIES") with
       cache_function = cache_custom_entry;
-      open_function = open_custom_entry;
+      open_function = import_filter [] open_custom_entry;
       load_function = load_custom_entry;
       subst_function = subst_custom_entry;
       classify_function = classify_custom_entry}

--- a/vernac/vernacentries.mli
+++ b/vernac/vernacentries.mli
@@ -12,7 +12,7 @@ val dump_global : Libnames.qualid Constrexpr.or_by_notation -> unit
 
 (** Vernacular entries *)
 val vernac_require :
-  Libnames.qualid option -> bool option -> Libnames.qualid list -> unit
+  Libnames.qualid option -> Lib.export_flag option -> Libnames.qualid list -> unit
 
 (** The main interpretation function of vernacular expressions *)
 val interp :

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -147,8 +147,8 @@ type opacity_flag   = Proof_global.opacity_flag = Opaque | Transparent
  [@ocaml.deprecated "Please use [Proof_global.opacity_flag]"]
 type coercion_flag  = bool (* true = AddCoercion    false = NoCoercion     *)
 type instance_flag  = bool option
-  (* Some true = Backward instance; Some false = Forward instance, None = NoInstance *)
-type export_flag    = bool (* true = Export;        false = Import         *)
+(* Some true = Backward instance; Some false = Forward instance, None = NoInstance *)
+
 type inductive_flag = Declarations.recursivity_kind
 type onlyparsing_flag = Flags.compat_version option
  (* Some v = Parse only;  None = Print also.
@@ -302,7 +302,7 @@ type inline = Declaremods.inline =
 [@@ocaml.deprecated "please use [Declaremods.inline]."]
 
 type module_ast_inl = module_ast * Declaremods.inline
-type module_binder = bool option * lident list * module_ast_inl
+type module_binder = Lib.qualified_export option * lident list * module_ast_inl
 
 (** [Some b] if locally enabled/disabled according to [b], [None] if
     we should use the global flag. *)
@@ -355,8 +355,8 @@ type nonrec vernac_expr =
   | VernacBeginSection of lident
   | VernacEndSegment of lident
   | VernacRequire of
-      qualid option * export_flag option * qualid list
-  | VernacImport of export_flag * qualid list
+      qualid option * Lib.qualified_export option * qualid list
+  | VernacImport of Lib.qualified_export * qualid list
   | VernacCanonical of qualid or_by_notation
   | VernacCoercion of qualid or_by_notation *
       class_rawexpr * class_rawexpr
@@ -379,9 +379,9 @@ type nonrec vernac_expr =
   | VernacDeclareClass of qualid (* inductive or definition name *)
 
   (* Modules and Module Types *)
-  | VernacDeclareModule of bool option * lident *
+  | VernacDeclareModule of Lib.qualified_export option * lident *
       module_binder list * module_ast_inl
-  | VernacDefineModule of bool option * lident * module_binder list *
+  | VernacDefineModule of Lib.qualified_export option * lident * module_binder list *
       module_ast_inl Declaremods.module_signature * module_ast_inl list
   | VernacDeclareModuleType of lident *
       module_binder list * module_ast_inl list * module_ast_inl list
@@ -426,8 +426,8 @@ type nonrec vernac_expr =
   | VernacSetOpacity of (Conv_oracle.level * qualid or_by_notation list)
   | VernacSetStrategy of
       (Conv_oracle.level * qualid or_by_notation list) list
-  | VernacUnsetOption of export_flag * Goptions.option_name
-  | VernacSetOption of export_flag * Goptions.option_name * option_value
+  | VernacUnsetOption of Lib.export_flag * Goptions.option_name
+  | VernacSetOption of Lib.export_flag * Goptions.option_name * option_value
   | VernacAddOption of Goptions.option_name * option_ref_value list
   | VernacRemoveOption of Goptions.option_name * option_ref_value list
   | VernacMemOption of Goptions.option_name * option_ref_value list


### PR DESCRIPTION
This adds infrastructure do to partial imports, and plugs it for options.

We can pass a list of "categories" (list of ident) to Import/Export to filter what gets imported.

The list is passed around down to the `open_function` which gets a `cat:categories option` argument.
Originally I wanted to just add a field `object_categories : categories` but it seems unworkable for eg `Include`:
~~~coq
Module M.
  Include Foo.
End M.
Import(options) M. (* needs to filter the opening of the objects of Foo for the category, but this opening is done through the open_function of the INCLUDE object *)
~~~
The same kind of thing seems to be an issue with the MODULE and MODULE KEEP objects (based on where I needed to come up with a category list when adapting the code).
Maybe a redesign could change this but include is tricky so who knows.

For regular objects a function `filter_cat` takes a list of categories and an old-style open function to produce the new style open function. Perhaps this should be replaced with some intermediate object type which could have an object_category field.

User side we might want something more specific than categories, eg `Import(constants(foo)) M.` to import only the `M.foo` constant, in which case I guess passing the `cat` to `open_function` would be more necessary.

Note that partial imports are not allowed for `Require`: `Require Import(options) foo.` will fail at interp time. (Require is tricky, see eg #3556)
Also partial imports disable the "optimisation" mentioned here https://github.com/coq/coq/blob/15649c16bc4e20ef2c2b1b0ac645f83ee03c3589/library/library.ml#L585-L591
I'm not fully understanding what it does so there might be unexpected behaviour.

Most objects currently have an empty category list, meaning they only get imported with unqualified Import. Options are in category `options` (including the ones declared through Tactic_options). See test suite change for how it works.

Because of how dynamic this is it seems impossible to check whether a category is known, so nothing stops the user from writing `Import(fake categories) foo.` (which should be a fancy noop).