### PR TITLE
Use "rm -rf" in "make clean" so .coq-native directories are removed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -268,7 +268,7 @@ distclean: clean cleanconfig cacheclean timingclean
 voclean:
 	find theories plugins test-suite \( -name '*.vo' -o -name '*.glob' -o -name "*.cmxs" \
 	-o -name "*.native" -o -name "*.cmx" -o -name "*.cmi" -o -name "*.o" \) -exec rm -f {} +
-	find theories plugins test-suite -name .coq-native -empty -exec rm -f {} +
+	find theories plugins test-suite -name .coq-native -empty -exec rm -rf {} +
 
 timingclean:
 	find theories plugins test-suite \( -name '*.v.timing' -o -name '*.v.before-timing' \


### PR DESCRIPTION
**Kind:** infrastructure.

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #8496 
