### PR TITLE
Fix numerous anomalies with Scheme Equality

### DIFF
--- a/test-suite/bugs/closed/4612.v
+++ b/test-suite/bugs/closed/4612.v
@@ -1,0 +1,7 @@
+(* While waiting for support, check at least that it does not raise an anomaly *)
+
+Inductive ctype :=
+| Struct: list ctype -> ctype
+| Bot : ctype.
+
+Fail Scheme Equality for ctype.

--- a/test-suite/bugs/closed/4859.v
+++ b/test-suite/bugs/closed/4859.v
@@ -1,0 +1,7 @@
+(* Not supported but check at least that it does not raise an anomaly *)
+
+Inductive Fin{n : nat} : Set :=
+| F1{i : nat}{e : n = S i}
+| FS{i : nat}(f : @ Fin i){e : n = S i}.
+
+Fail Scheme Equality for Fin.

--- a/test-suite/success/SchemeEquality.v
+++ b/test-suite/success/SchemeEquality.v
@@ -5,3 +5,25 @@ Definition N := nat.
 Inductive list := nil | cons : N -> list -> list.
 Scheme Equality for list.
 End A.
+
+Module B.
+  Section A.
+    Context A (eq_A:A->A->bool)
+            (A_bl : forall x y, eq_A x y = true -> x = y)
+            (A_lb : forall x y, x = y -> eq_A x y = true).
+    Inductive I := C : A -> I.
+    Scheme Equality for I.
+  End A.
+End B.
+
+Module C.
+  Parameter A : Type.
+  Parameter eq_A : A->A->bool.
+  Parameter A_bl : forall x y, eq_A x y = true -> x = y.
+  Parameter A_lb : forall x y, x = y -> eq_A x y = true.
+  Hint Resolve A_bl A_lb : core.
+  Inductive I := C : A -> I.
+  Scheme Equality for I.
+  Inductive J := D : list A -> J.
+  Scheme Equality for J.
+End C.

--- a/test-suite/success/SchemeEquality.v
+++ b/test-suite/success/SchemeEquality.v
@@ -1,0 +1,7 @@
+(* Examples of use of Scheme Equality *)
+
+Module A.
+Definition N := nat.
+Inductive list := nil | cons : N -> list -> list.
+Scheme Equality for list.
+End A.

--- a/vernac/auto_ind_decl.ml
+++ b/vernac/auto_ind_decl.ml
@@ -389,13 +389,9 @@ let do_replace_lb mode lb_scheme_key aavoid narg p q =
     | Const (cst,_) ->
       (* Works in specific situations where the args have to be already declared as a
          Parameter (see example "J" in test file SchemeEquality.v) *)
-      (
-        let mp,dir,lbl = Constant.repr3 cst in
-          mkConst (Constant.make3 mp dir (Label.make (
-          if Int.equal offset 1 then ("eq_"^(Label.to_string lbl))
-                       else ((Label.to_string lbl)^"_lb")
-        )))
-      )
+        let lbl = Label.to_string (Constant.label cst) in
+        let newlbl = if Int.equal offset 1 then ("eq_" ^ lbl) else (lbl ^ "_lb") in
+        mkConst (Constant.change_label cst (Label.make newlbl))
     | _ -> raise (ConstructorWithNonParametricInductiveType (fst hd))
 
   in
@@ -453,11 +449,9 @@ let do_replace_bl mode bl_scheme_key (ind,u as indu) aavoid narg lft rgt =
     | Const (cst,_) ->
       (* Works in specific situations where the args have to be already declared as a
          Parameter (see example "J" in test file SchemeEquality.v) *)
-        let mp,dir,lbl = Constant.repr3 cst in
-          mkConst (Constant.make3 mp dir (Label.make (
-          if Int.equal offset 1 then ("eq_"^(Label.to_string lbl))
-                       else ((Label.to_string lbl)^"_bl")
-        )))
+        let lbl = Label.to_string (Constant.label cst) in
+        let newlbl = if Int.equal offset 1 then ("eq_" ^ lbl) else (lbl ^ "_bl") in
+        mkConst (Constant.change_label cst (Label.make newlbl))
     | _ -> raise (ConstructorWithNonParametricInductiveType (fst hd))
   in
 

--- a/vernac/auto_ind_decl.ml
+++ b/vernac/auto_ind_decl.ml
@@ -428,7 +428,7 @@ let do_replace_lb mode lb_scheme_key aavoid narg p q =
              Equality.replace p q ; apply app ; Auto.default_auto]
   end
 
-(* used in the bool -> leib side *)
+(* used in the bool -> leb side *)
 let do_replace_bl mode bl_scheme_key (ind,u as indu) aavoid narg lft rgt =
   let open EConstr in
   let avoid = Array.of_list aavoid in

--- a/vernac/auto_ind_decl.ml
+++ b/vernac/auto_ind_decl.ml
@@ -60,6 +60,7 @@ exception NonSingletonProp of inductive
 exception DecidabilityMutualNotSupported
 exception NoDecidabilityCoInductive
 exception ConstructorWithNonParametricInductiveType of inductive
+exception DecidabilityIndicesNotSupported
 
 let constr_of_global g = lazy (UnivGen.constr_of_global g)
 
@@ -121,6 +122,10 @@ let check_bool_is_defined () =
   try let _ = Global.type_of_global_in_context (Global.env ()) Coqlib.glob_bool in ()
   with e when CErrors.noncritical e -> raise (UndefinedCst "bool")
 
+let check_no_indices mib =
+  if Array.exists (fun mip -> mip.mind_nrealargs <> 0) mib.mind_packets then
+    raise DecidabilityIndicesNotSupported
+
 let beq_scheme_kind_aux = ref (fun _ -> failwith "Undefined")
 
 let build_beq_scheme mode kn =
@@ -134,6 +139,7 @@ let build_beq_scheme mode kn =
   (* number of params in the type *)
   let nparams = mib.mind_nparams in
   let nparrec = mib.mind_nparams_rec in
+  check_no_indices mib;
   (* params context divided *)
   let lnonparrec,lnamesparrec =
     context_chop (nparams-nparrec) mib.mind_params_ctxt in

--- a/vernac/auto_ind_decl.mli
+++ b/vernac/auto_ind_decl.mli
@@ -27,6 +27,7 @@ exception ParameterWithoutEquality of GlobRef.t
 exception NonSingletonProp of inductive
 exception DecidabilityMutualNotSupported
 exception NoDecidabilityCoInductive
+exception ConstructorWithNonParametricInductiveType of inductive
 
 val beq_scheme_kind : mutual scheme_kind
 val build_beq_scheme : mutual_scheme_object_function

--- a/vernac/auto_ind_decl.mli
+++ b/vernac/auto_ind_decl.mli
@@ -28,6 +28,7 @@ exception NonSingletonProp of inductive
 exception DecidabilityMutualNotSupported
 exception NoDecidabilityCoInductive
 exception ConstructorWithNonParametricInductiveType of inductive
+exception DecidabilityIndicesNotSupported
 
 val beq_scheme_kind : mutual scheme_kind
 val build_beq_scheme : mutual_scheme_object_function

--- a/vernac/indschemes.ml
+++ b/vernac/indschemes.ml
@@ -177,6 +177,9 @@ let try_declare_scheme what f internal names kn =
     | NoDecidabilityCoInductive ->
          alarm what internal
            (str "Scheme Equality is only for inductive types.")
+    | DecidabilityIndicesNotSupported ->
+         alarm what internal
+           (str "Inductive types with annotations not supported.")
     | ConstructorWithNonParametricInductiveType ind ->
          alarm what internal
            (strbrk "Unsupported constructor with an argument whose type is a non-parametric inductive type." ++


### PR DESCRIPTION
**Kind:** bug fix

We protect `Scheme Equality` against a few anomalies raised when out of its domain of specification. The case of inductive types with indices seems difficult but the cases of nested or mutual inductive types should be eventually implementable without too much pain (even if maybe with another methodology than using tactics).

This fixes / closes #4859, #2550, #8492, #4612.

- [X] Added / updated test-suite

PS: I had to decapsulate exceptions out of `TacticFailure` in `indschemes.ml`. I found this strange so I wonder if I did not do something wrong in `auto_ind_decl.ml` at the time of raising the exception. Maybe should I have used another primitive than `raise`??
