### PR TITLE
Extensible interpretation for attributes

### DIFF
--- a/plugins/firstorder/g_ground.ml4
+++ b/plugins/firstorder/g_ground.ml4
@@ -67,9 +67,9 @@ let (set_default_solver, default_solver, print_default_solver) =
 
 VERNAC COMMAND FUNCTIONAL EXTEND Firstorder_Set_Solver CLASSIFIED AS SIDEFF
 | [ "Set" "Firstorder" "Solver" tactic(t) ] -> [
-    fun ~atts ~st -> let open Attributes in
+    fun ~atts ~st ->
       set_default_solver
-        (Locality.make_section_locality atts.locality)
+        (Locality.make_section_locality (Attributes.locality atts))
         (Tacintern.glob_tactic t);
         st
   ]

--- a/plugins/firstorder/g_ground.ml4
+++ b/plugins/firstorder/g_ground.ml4
@@ -67,7 +67,7 @@ let (set_default_solver, default_solver, print_default_solver) =
 
 VERNAC COMMAND FUNCTIONAL EXTEND Firstorder_Set_Solver CLASSIFIED AS SIDEFF
 | [ "Set" "Firstorder" "Solver" tactic(t) ] -> [
-    fun ~atts ~st -> let open Vernacinterp in
+    fun ~atts ~st -> let open Attributes in
       set_default_solver
         (Locality.make_section_locality atts.locality)
         (Tacintern.glob_tactic t);

--- a/plugins/ltac/extratactics.ml4
+++ b/plugins/ltac/extratactics.ml4
@@ -27,7 +27,6 @@ open Equality
 open Namegen
 open Tactypes
 open Proofview.Notations
-open Attributes
 
 DECLARE PLUGIN "ltac_plugin"
 
@@ -275,14 +274,14 @@ let classify_hint _ = Vernacexpr.VtSideff [], Vernacexpr.VtLater
 
 VERNAC COMMAND FUNCTIONAL EXTEND HintRewrite CLASSIFIED BY classify_hint
   [ "Hint" "Rewrite" orient(o) ne_constr_list(l) ":" preident_list(bl) ] ->
-  [ fun ~atts ~st -> add_rewrite_hint ~poly:atts.polymorphic bl o None l; st ]
+  [ fun ~atts ~st -> add_rewrite_hint ~poly:(Attributes.polymorphic atts) bl o None l; st ]
 | [ "Hint" "Rewrite" orient(o) ne_constr_list(l) "using" tactic(t)
     ":" preident_list(bl) ] ->
-  [ fun ~atts ~st -> add_rewrite_hint ~poly:atts.polymorphic bl o (Some t) l; st ]
+  [ fun ~atts ~st -> add_rewrite_hint ~poly:(Attributes.polymorphic atts) bl o (Some t) l; st ]
 | [ "Hint" "Rewrite" orient(o) ne_constr_list(l) ] ->
-  [ fun ~atts ~st -> add_rewrite_hint ~poly:atts.polymorphic ["core"] o None l; st ]
+  [ fun ~atts ~st -> add_rewrite_hint ~poly:(Attributes.polymorphic atts) ["core"] o None l; st ]
 | [ "Hint" "Rewrite" orient(o) ne_constr_list(l) "using" tactic(t) ] ->
-  [ fun ~atts ~st -> add_rewrite_hint ~poly:atts.polymorphic ["core"] o (Some t) l; st ]
+  [ fun ~atts ~st -> add_rewrite_hint ~poly:(Attributes.polymorphic atts) ["core"] o (Some t) l; st ]
 END
 
 (**********************************************************************)
@@ -359,36 +358,36 @@ VERNAC COMMAND FUNCTIONAL EXTEND DeriveInversionClear
 | [ "Derive" "Inversion_clear" ident(na) "with" constr(c) "Sort" sort_family(s) ]
   => [ seff na ]
   -> [ fun ~atts ~st ->
-      add_inversion_lemma_exn ~poly:atts.polymorphic na c s false inv_clear_tac; st ]
+      add_inversion_lemma_exn ~poly:(Attributes.polymorphic atts) na c s false inv_clear_tac; st ]
 
 | [ "Derive" "Inversion_clear" ident(na) "with" constr(c) ] => [ seff na ]
   -> [ fun ~atts ~st ->
-      add_inversion_lemma_exn ~poly:atts.polymorphic na c Sorts.InProp false inv_clear_tac; st ]
+      add_inversion_lemma_exn ~poly:(Attributes.polymorphic atts) na c Sorts.InProp false inv_clear_tac; st ]
 END
 
 VERNAC COMMAND FUNCTIONAL EXTEND DeriveInversion
 | [ "Derive" "Inversion" ident(na) "with" constr(c) "Sort" sort_family(s) ]
   => [ seff na ]
   -> [ fun ~atts ~st ->
-      add_inversion_lemma_exn ~poly:atts.polymorphic na c s false inv_tac; st ]
+      add_inversion_lemma_exn ~poly:(Attributes.polymorphic atts) na c s false inv_tac; st ]
 
 | [ "Derive" "Inversion" ident(na) "with" constr(c) ] => [ seff na ]
   -> [ fun ~atts ~st ->
-      add_inversion_lemma_exn ~poly:atts.polymorphic na c Sorts.InProp false inv_tac; st ]
+      add_inversion_lemma_exn ~poly:(Attributes.polymorphic atts) na c Sorts.InProp false inv_tac; st ]
 END
 
 VERNAC COMMAND FUNCTIONAL EXTEND DeriveDependentInversion
 | [ "Derive" "Dependent" "Inversion" ident(na) "with" constr(c) "Sort" sort_family(s) ]
   => [ seff na ]
   -> [  fun ~atts ~st ->
-      add_inversion_lemma_exn ~poly:atts.polymorphic na c s true dinv_tac; st ]
+      add_inversion_lemma_exn ~poly:(Attributes.polymorphic atts) na c s true dinv_tac; st ]
 END
 
 VERNAC COMMAND FUNCTIONAL EXTEND DeriveDependentInversionClear
 | [ "Derive" "Dependent" "Inversion_clear" ident(na) "with" constr(c) "Sort" sort_family(s) ]
   => [ seff na ]
   -> [  fun ~atts ~st ->
-      add_inversion_lemma_exn ~poly:atts.polymorphic na c s true dinv_clear_tac; st ]
+      add_inversion_lemma_exn ~poly:(Attributes.polymorphic atts) na c s true dinv_clear_tac; st ]
 END
 
 (**********************************************************************)

--- a/plugins/ltac/extratactics.ml4
+++ b/plugins/ltac/extratactics.ml4
@@ -27,7 +27,7 @@ open Equality
 open Namegen
 open Tactypes
 open Proofview.Notations
-open Vernacinterp
+open Attributes
 
 DECLARE PLUGIN "ltac_plugin"
 
@@ -359,12 +359,10 @@ VERNAC COMMAND FUNCTIONAL EXTEND DeriveInversionClear
 | [ "Derive" "Inversion_clear" ident(na) "with" constr(c) "Sort" sort_family(s) ]
   => [ seff na ]
   -> [ fun ~atts ~st ->
-      let open Vernacinterp in
       add_inversion_lemma_exn ~poly:atts.polymorphic na c s false inv_clear_tac; st ]
 
 | [ "Derive" "Inversion_clear" ident(na) "with" constr(c) ] => [ seff na ]
   -> [ fun ~atts ~st ->
-      let open Vernacinterp in
       add_inversion_lemma_exn ~poly:atts.polymorphic na c Sorts.InProp false inv_clear_tac; st ]
 END
 
@@ -372,12 +370,10 @@ VERNAC COMMAND FUNCTIONAL EXTEND DeriveInversion
 | [ "Derive" "Inversion" ident(na) "with" constr(c) "Sort" sort_family(s) ]
   => [ seff na ]
   -> [ fun ~atts ~st ->
-      let open Vernacinterp in
       add_inversion_lemma_exn ~poly:atts.polymorphic na c s false inv_tac; st ]
 
 | [ "Derive" "Inversion" ident(na) "with" constr(c) ] => [ seff na ]
   -> [ fun ~atts ~st ->
-      let open Vernacinterp in
       add_inversion_lemma_exn ~poly:atts.polymorphic na c Sorts.InProp false inv_tac; st ]
 END
 
@@ -385,7 +381,6 @@ VERNAC COMMAND FUNCTIONAL EXTEND DeriveDependentInversion
 | [ "Derive" "Dependent" "Inversion" ident(na) "with" constr(c) "Sort" sort_family(s) ]
   => [ seff na ]
   -> [  fun ~atts ~st ->
-      let open Vernacinterp in
       add_inversion_lemma_exn ~poly:atts.polymorphic na c s true dinv_tac; st ]
 END
 
@@ -393,7 +388,6 @@ VERNAC COMMAND FUNCTIONAL EXTEND DeriveDependentInversionClear
 | [ "Derive" "Dependent" "Inversion_clear" ident(na) "with" constr(c) "Sort" sort_family(s) ]
   => [ seff na ]
   -> [  fun ~atts ~st ->
-      let open Vernacinterp in
       add_inversion_lemma_exn ~poly:atts.polymorphic na c s true dinv_clear_tac; st ]
 END
 

--- a/plugins/ltac/g_auto.ml4
+++ b/plugins/ltac/g_auto.ml4
@@ -218,7 +218,7 @@ END
 VERNAC COMMAND FUNCTIONAL EXTEND HintCut CLASSIFIED AS SIDEFF
 | [ "Hint" "Cut" "[" hints_path(p) "]" opthints(dbnames) ] -> [
     fun ~atts ~st -> begin
-        let open Vernacinterp in
+        let open Attributes in
         let entry = Hints.HintsCutEntry (Hints.glob_hints_path p) in
         Hints.add_hints ~local:(Locality.make_section_locality atts.locality)
           (match dbnames with None -> ["core"] | Some l -> l) entry;

--- a/plugins/ltac/g_auto.ml4
+++ b/plugins/ltac/g_auto.ml4
@@ -218,9 +218,8 @@ END
 VERNAC COMMAND FUNCTIONAL EXTEND HintCut CLASSIFIED AS SIDEFF
 | [ "Hint" "Cut" "[" hints_path(p) "]" opthints(dbnames) ] -> [
     fun ~atts ~st -> begin
-        let open Attributes in
         let entry = Hints.HintsCutEntry (Hints.glob_hints_path p) in
-        Hints.add_hints ~local:(Locality.make_section_locality atts.locality)
+        Hints.add_hints ~local:(Locality.make_section_locality (Attributes.locality atts))
           (match dbnames with None -> ["core"] | Some l -> l) entry;
         st
       end

--- a/plugins/ltac/g_ltac.ml4
+++ b/plugins/ltac/g_ltac.ml4
@@ -468,7 +468,7 @@ END
 VERNAC COMMAND FUNCTIONAL EXTEND VernacTacticNotation
 | [ "Tactic" "Notation" ltac_tactic_level_opt(n) ne_ltac_production_item_list(r) ":=" tactic(e) ] =>
   [ VtSideff [], VtNow ] ->
-  [ fun ~atts ~st -> let open Vernacinterp in
+  [ fun ~atts ~st -> let open Attributes in
       let n = Option.default 0 n in
       let deprecation = atts.deprecated in
       Tacentries.add_tactic_notation (Locality.make_module_locality atts.locality) n ?deprecation r e;
@@ -514,7 +514,7 @@ VERNAC COMMAND FUNCTIONAL EXTEND VernacDeclareTacticDefinition
     VtSideff (List.map (function
       | TacticDefinition ({CAst.v=r},_) -> r
       | TacticRedefinition (qid,_) -> qualid_basename qid) l), VtLater
-  ] -> [ fun ~atts ~st -> let open Vernacinterp in
+  ] -> [ fun ~atts ~st -> let open Attributes in
            let deprecation = atts.deprecated in
            Tacentries.register_ltac (Locality.make_module_locality atts.locality) ?deprecation l;
            st

--- a/plugins/ltac/g_ltac.ml4
+++ b/plugins/ltac/g_ltac.ml4
@@ -468,10 +468,10 @@ END
 VERNAC COMMAND FUNCTIONAL EXTEND VernacTacticNotation
 | [ "Tactic" "Notation" ltac_tactic_level_opt(n) ne_ltac_production_item_list(r) ":=" tactic(e) ] =>
   [ VtSideff [], VtNow ] ->
-  [ fun ~atts ~st -> let open Attributes in
+  [ fun ~atts ~st ->
       let n = Option.default 0 n in
-      let deprecation = atts.deprecated in
-      Tacentries.add_tactic_notation (Locality.make_module_locality atts.locality) n ?deprecation r e;
+      let deprecation = Attributes.deprecated atts in
+      Tacentries.add_tactic_notation (Locality.make_module_locality (Attributes.locality atts)) n ?deprecation r e;
       st
   ]
 END
@@ -514,9 +514,9 @@ VERNAC COMMAND FUNCTIONAL EXTEND VernacDeclareTacticDefinition
     VtSideff (List.map (function
       | TacticDefinition ({CAst.v=r},_) -> r
       | TacticRedefinition (qid,_) -> qualid_basename qid) l), VtLater
-  ] -> [ fun ~atts ~st -> let open Attributes in
-           let deprecation = atts.deprecated in
-           Tacentries.register_ltac (Locality.make_module_locality atts.locality) ?deprecation l;
+  ] -> [ fun ~atts ~st ->
+           let deprecation = Attributes.deprecated atts in
+           Tacentries.register_ltac (Locality.make_module_locality (Attributes.locality atts)) ?deprecation l;
            st
   ]
 END

--- a/plugins/ltac/g_obligations.ml4
+++ b/plugins/ltac/g_obligations.ml4
@@ -126,7 +126,7 @@ VERNAC COMMAND FUNCTIONAL EXTEND Set_Solver CLASSIFIED AS SIDEFF
 | [ "Obligation" "Tactic" ":=" tactic(t) ] -> [
     fun ~atts ~st -> begin
         set_default_tactic
-          (Locality.make_section_locality atts.Attributes.locality)
+          (Locality.make_section_locality (Attributes.locality atts))
           (Tacintern.glob_tactic t);
         st
       end]

--- a/plugins/ltac/g_obligations.ml4
+++ b/plugins/ltac/g_obligations.ml4
@@ -125,9 +125,8 @@ END
 VERNAC COMMAND FUNCTIONAL EXTEND Set_Solver CLASSIFIED AS SIDEFF
 | [ "Obligation" "Tactic" ":=" tactic(t) ] -> [
     fun ~atts ~st -> begin
-        let open Vernacinterp in
         set_default_tactic
-          (Locality.make_section_locality atts.locality)
+          (Locality.make_section_locality atts.Attributes.locality)
           (Tacintern.glob_tactic t);
         st
       end]

--- a/plugins/ltac/g_rewrite.ml4
+++ b/plugins/ltac/g_rewrite.ml4
@@ -24,7 +24,6 @@ open Pcoq.Prim
 open Pcoq.Constr
 open Pvernac.Vernac_
 open Pltac
-open Attributes
 
 DECLARE PLUGIN "ltac_plugin"
 
@@ -247,32 +246,32 @@ END
 VERNAC COMMAND FUNCTIONAL EXTEND AddSetoid1 CLASSIFIED AS SIDEFF
    [ "Add" "Setoid" constr(a) constr(aeq) constr(t) "as" ident(n) ] ->
      [ fun ~atts ~st ->
-         add_setoid (not (Locality.make_section_locality atts.locality)) [] a aeq t n;
+         add_setoid (not (Locality.make_section_locality (Attributes.locality atts))) [] a aeq t n;
          st
      ]
   | [ "Add" "Parametric" "Setoid" binders(binders) ":" constr(a) constr(aeq) constr(t) "as" ident(n) ] ->
      [ fun ~atts ~st ->
-         add_setoid (not (Locality.make_section_locality atts.locality)) binders a aeq t n;
+         add_setoid (not (Locality.make_section_locality (Attributes.locality atts))) binders a aeq t n;
          st
      ]
   | [ "Add" "Morphism" constr(m) ":" ident(n) ]
     (* This command may or may not open a goal *)
     => [ Vernacexpr.VtUnknown, Vernacexpr.VtNow ]
     -> [ fun ~atts ~st ->
-           add_morphism_infer (not (Locality.make_section_locality atts.locality)) m n;
+           add_morphism_infer (not (Locality.make_section_locality (Attributes.locality atts))) m n;
            st
        ]
   | [ "Add" "Morphism" constr(m) "with" "signature" lconstr(s) "as" ident(n) ]
     => [ Vernacexpr.(VtStartProof("Classic",GuaranteesOpacity,[n]), VtLater) ]
     -> [ fun ~atts ~st ->
-           add_morphism (not (Locality.make_section_locality atts.locality)) [] m s n;
+           add_morphism (not (Locality.make_section_locality (Attributes.locality atts))) [] m s n;
            st
        ]
   | [ "Add" "Parametric" "Morphism" binders(binders) ":" constr(m)
         "with" "signature" lconstr(s) "as" ident(n) ]
     => [ Vernacexpr.(VtStartProof("Classic",GuaranteesOpacity,[n]), VtLater) ]
     -> [ fun ~atts ~st ->
-           add_morphism (not (Locality.make_section_locality atts.locality)) binders m s n;
+           add_morphism (not (Locality.make_section_locality (Attributes.locality atts))) binders m s n;
            st
        ]
 END

--- a/plugins/ltac/g_rewrite.ml4
+++ b/plugins/ltac/g_rewrite.ml4
@@ -24,6 +24,7 @@ open Pcoq.Prim
 open Pcoq.Constr
 open Pvernac.Vernac_
 open Pltac
+open Attributes
 
 DECLARE PLUGIN "ltac_plugin"
 
@@ -245,32 +246,32 @@ END
 
 VERNAC COMMAND FUNCTIONAL EXTEND AddSetoid1 CLASSIFIED AS SIDEFF
    [ "Add" "Setoid" constr(a) constr(aeq) constr(t) "as" ident(n) ] ->
-     [ fun ~atts ~st -> let open Vernacinterp in
+     [ fun ~atts ~st ->
          add_setoid (not (Locality.make_section_locality atts.locality)) [] a aeq t n;
          st
      ]
   | [ "Add" "Parametric" "Setoid" binders(binders) ":" constr(a) constr(aeq) constr(t) "as" ident(n) ] ->
-     [ fun ~atts ~st -> let open Vernacinterp in
+     [ fun ~atts ~st ->
          add_setoid (not (Locality.make_section_locality atts.locality)) binders a aeq t n;
          st
      ]
   | [ "Add" "Morphism" constr(m) ":" ident(n) ]
     (* This command may or may not open a goal *)
     => [ Vernacexpr.VtUnknown, Vernacexpr.VtNow ]
-    -> [ fun ~atts ~st -> let open Vernacinterp in
+    -> [ fun ~atts ~st ->
            add_morphism_infer (not (Locality.make_section_locality atts.locality)) m n;
            st
        ]
   | [ "Add" "Morphism" constr(m) "with" "signature" lconstr(s) "as" ident(n) ]
     => [ Vernacexpr.(VtStartProof("Classic",GuaranteesOpacity,[n]), VtLater) ]
-    -> [ fun ~atts ~st -> let open Vernacinterp in
+    -> [ fun ~atts ~st ->
            add_morphism (not (Locality.make_section_locality atts.locality)) [] m s n;
            st
        ]
   | [ "Add" "Parametric" "Morphism" binders(binders) ":" constr(m)
         "with" "signature" lconstr(s) "as" ident(n) ]
     => [ Vernacexpr.(VtStartProof("Classic",GuaranteesOpacity,[n]), VtLater) ]
-    -> [ fun ~atts ~st -> let open Vernacinterp in
+    -> [ fun ~atts ~st ->
            add_morphism (not (Locality.make_section_locality atts.locality)) binders m s n;
            st
        ]

--- a/plugins/ltac/tacentries.mli
+++ b/plugins/ltac/tacentries.mli
@@ -12,7 +12,7 @@
 
 open Vernacexpr
 open Tacexpr
-open Vernacinterp
+open Attributes
 
 (** {5 Tactic Definitions} *)
 

--- a/plugins/ltac/tacenv.ml
+++ b/plugins/ltac/tacenv.ml
@@ -55,7 +55,7 @@ type alias = KerName.t
 type alias_tactic =
   { alias_args: Id.t list;
     alias_body: glob_tactic_expr;
-    alias_deprecation: Vernacinterp.deprecation option;
+    alias_deprecation: Attributes.deprecation option;
   }
 
 let alias_map = Summary.ref ~name:"tactic-alias"
@@ -122,7 +122,7 @@ type ltac_entry = {
   tac_for_ml : bool;
   tac_body : glob_tactic_expr;
   tac_redef : ModPath.t list;
-  tac_deprecation : Vernacinterp.deprecation option
+  tac_deprecation : Attributes.deprecation option
 }
 
 let mactab =
@@ -179,7 +179,7 @@ let subst_md (subst, (local, id, b, t, deprecation)) =
 let classify_md (local, _, _, _, _ as o) = Substitute o
 
 let inMD : bool * ltac_constant option * bool * glob_tactic_expr *
-           Vernacinterp.deprecation option -> obj =
+           Attributes.deprecation option -> obj =
   declare_object {(default_object "TAC-DEFINITION") with
      cache_function  = cache_md;
      load_function   = load_md;

--- a/plugins/ltac/tacenv.mli
+++ b/plugins/ltac/tacenv.mli
@@ -12,7 +12,7 @@ open Names
 open Libnames
 open Tacexpr
 open Geninterp
-open Vernacinterp
+open Attributes
 
 (** This module centralizes the various ways of registering tactics. *)
 
@@ -33,7 +33,7 @@ type alias = KerName.t
 type alias_tactic =
   { alias_args: Id.t list;
     alias_body: glob_tactic_expr;
-    alias_deprecation: Vernacinterp.deprecation option;
+    alias_deprecation: deprecation option;
   }
 (** Contents of a tactic notation *)
 

--- a/plugins/ltac/tacintern.ml
+++ b/plugins/ltac/tacintern.ml
@@ -121,15 +121,15 @@ let warn_deprecated_tactic =
   CWarnings.create ~name:"deprecated-tactic" ~category:"deprecated"
     (fun (qid,depr) -> str "Tactic " ++ pr_qualid qid ++
       strbrk " is deprecated" ++
-      pr_opt (fun since -> str "since " ++ str since) depr.Vernacinterp.since ++
-      str "." ++ pr_opt (fun note -> str note) depr.Vernacinterp.note)
+      pr_opt (fun since -> str "since " ++ str since) depr.Attributes.since ++
+      str "." ++ pr_opt (fun note -> str note) depr.Attributes.note)
 
 let warn_deprecated_alias =
   CWarnings.create ~name:"deprecated-tactic-notation" ~category:"deprecated"
     (fun (kn,depr) -> str "Tactic Notation " ++ Pptactic.pr_alias_key kn ++
       strbrk " is deprecated since" ++
-      pr_opt (fun since -> str "since " ++ str since) depr.Vernacinterp.since ++
-      str "." ++ pr_opt (fun note -> str note) depr.Vernacinterp.note)
+      pr_opt (fun since -> str "since " ++ str since) depr.Attributes.since ++
+      str "." ++ pr_opt (fun note -> str note) depr.Attributes.note)
 
 let intern_isolated_global_tactic_reference qid =
   let loc = qid.CAst.loc in

--- a/plugins/romega/g_romega.mlg
+++ b/plugins/romega/g_romega.mlg
@@ -42,7 +42,7 @@ let romega_tactic unsafe l =
        (total_reflexive_omega_tactic unsafe))
 
 let romega_depr =
-  Vernacinterp.mk_deprecation
+  Attributes.mk_deprecation
     ~since:(Some "8.9")
     ~note:(Some "Use lia instead.")
     ()

--- a/plugins/ssr/ssrvernac.ml4
+++ b/plugins/ssr/ssrvernac.ml4
@@ -162,7 +162,7 @@ let declare_one_prenex_implicit locality f =
 VERNAC COMMAND FUNCTIONAL EXTEND Ssrpreneximplicits CLASSIFIED AS SIDEFF
   | [ "Prenex" "Implicits" ne_global_list(fl) ]
   -> [ fun ~atts ~st ->
-         let open Vernacinterp in
+         let open Attributes in
          let locality = Locality.make_section_locality atts.locality in
          List.iter (declare_one_prenex_implicit locality) fl;
          st

--- a/plugins/ssr/ssrvernac.ml4
+++ b/plugins/ssr/ssrvernac.ml4
@@ -162,8 +162,7 @@ let declare_one_prenex_implicit locality f =
 VERNAC COMMAND FUNCTIONAL EXTEND Ssrpreneximplicits CLASSIFIED AS SIDEFF
   | [ "Prenex" "Implicits" ne_global_list(fl) ]
   -> [ fun ~atts ~st ->
-         let open Attributes in
-         let locality = Locality.make_section_locality atts.locality in
+         let locality = Locality.make_section_locality (Attributes.locality atts) in
          List.iter (declare_one_prenex_implicit locality) fl;
          st
      ]

--- a/plugins/syntax/g_numeral.ml4
+++ b/plugins/syntax/g_numeral.ml4
@@ -13,7 +13,6 @@ DECLARE PLUGIN "numeral_notation_plugin"
 open Numeral
 open Pp
 open Names
-open Attributes
 open Ltac_plugin
 open Stdarg
 open Pcoq.Prim
@@ -33,5 +32,5 @@ END
 VERNAC COMMAND EXTEND NumeralNotation CLASSIFIED AS SIDEFF
   | [ "Numeral" "Notation" reference(ty) reference(f) reference(g) ":"
       ident(sc) numnotoption(o) ] ->
-    [ vernac_numeral_notation (Locality.make_module_locality atts.locality) ty f g (Id.to_string sc) o ]
+    [ vernac_numeral_notation (Locality.make_module_locality (Attributes.locality atts)) ty f g (Id.to_string sc) o ]
 END

--- a/plugins/syntax/g_numeral.ml4
+++ b/plugins/syntax/g_numeral.ml4
@@ -13,7 +13,7 @@ DECLARE PLUGIN "numeral_notation_plugin"
 open Numeral
 open Pp
 open Names
-open Vernacinterp
+open Attributes
 open Ltac_plugin
 open Stdarg
 open Pcoq.Prim

--- a/stm/vernac_classifier.ml
+++ b/stm/vernac_classifier.ml
@@ -194,8 +194,8 @@ let classify_vernac e =
   in
   let rec static_control_classifier ~poly = function
     | VernacExpr (f, e) ->
-      let _, atts = Vernacentries.attributes_of_flags f Vernacinterp.(mk_atts ~polymorphic:poly ()) in
-      let poly = atts.Vernacinterp.polymorphic in
+      let _, atts = Vernacentries.attributes_of_flags f Attributes.(mk_atts ~polymorphic:poly ()) in
+      let poly = atts.Attributes.polymorphic in
       static_classifier ~poly e
     | VernacTimeout (_,e) -> static_control_classifier ~poly e
     | VernacTime (_,{v=e}) | VernacRedirect (_, {v=e}) ->

--- a/stm/vernac_classifier.ml
+++ b/stm/vernac_classifier.ml
@@ -194,7 +194,7 @@ let classify_vernac e =
   in
   let rec static_control_classifier ~poly = function
     | VernacExpr (f, e) ->
-      let _, atts = Vernacentries.attributes_of_flags f Attributes.(mk_atts ~polymorphic:poly ()) in
+      let _, atts = Attributes.attributes_of_flags f Attributes.(mk_atts ~polymorphic:poly ()) in
       let poly = atts.Attributes.polymorphic in
       static_classifier ~poly e
     | VernacTimeout (_,e) -> static_control_classifier ~poly e

--- a/stm/vernac_classifier.ml
+++ b/stm/vernac_classifier.ml
@@ -195,7 +195,7 @@ let classify_vernac e =
   let rec static_control_classifier ~poly = function
     | VernacExpr (f, e) ->
       let _, atts = Attributes.attributes_of_flags f Attributes.(mk_atts ~polymorphic:poly ()) in
-      let poly = atts.Attributes.polymorphic in
+      let poly = Attributes.polymorphic atts in
       static_classifier ~poly e
     | VernacTimeout (_,e) -> static_control_classifier ~poly e
     | VernacTime (_,{v=e}) | VernacRedirect (_, {v=e}) ->

--- a/test-suite/success/attribute_syntax.v
+++ b/test-suite/success/attribute_syntax.v
@@ -1,4 +1,4 @@
-From Coq Require Program.
+From Coq Require Program.Wf.
 
 Section Scope.
 

--- a/vernac/attributes.ml
+++ b/vernac/attributes.ml
@@ -32,8 +32,16 @@ let default = {
   deprecated = None;
 }
 
+let locality {locality;_} = locality
+let polymorphic {polymorphic;_} = polymorphic
+let template {template;_} = template
+let program {program;_} = program
+let deprecated {deprecated;_} = deprecated
+
 let mk_atts ?(polymorphic=default.polymorphic) ?(program=default.program) () =
   { default with polymorphic; program }
+
+let set_polymorphic atts polymorphic = {atts with polymorphic}
 
 let attributes_of_flags f atts =
   let assert_empty k v =

--- a/vernac/attributes.ml
+++ b/vernac/attributes.ml
@@ -24,8 +24,16 @@ type t = {
   deprecated : deprecation option;
 }
 
-let mk_atts ?(locality=None) ?(polymorphic=false) ?(template=None) ?(program=false) ?(deprecated=None) () =
-  { locality ; polymorphic ; program ; deprecated; template }
+let default = {
+  locality = None;
+  polymorphic = false;
+  template = None;
+  program = false;
+  deprecated = None;
+}
+
+let mk_atts ?(polymorphic=default.polymorphic) ?(program=default.program) () =
+  { default with polymorphic; program }
 
 let attributes_of_flags f atts =
   let assert_empty k v =

--- a/vernac/attributes.ml
+++ b/vernac/attributes.ml
@@ -14,7 +14,6 @@ let mk_deprecation ?(since=None) ?(note=None) () =
   { since ; note }
 
 type t = {
-  loc : Loc.t option;
   locality : bool option;
   polymorphic : bool;
   template : bool option;
@@ -22,5 +21,5 @@ type t = {
   deprecated : deprecation option;
 }
 
-let mk_atts ?(loc=None) ?(locality=None) ?(polymorphic=false) ?(template=None) ?(program=false) ?(deprecated=None) () =
-  { loc ; locality ; polymorphic ; program ; deprecated; template }
+let mk_atts ?(locality=None) ?(polymorphic=false) ?(template=None) ?(program=false) ?(deprecated=None) () =
+  { locality ; polymorphic ; program ; deprecated; template }

--- a/vernac/attributes.ml
+++ b/vernac/attributes.ml
@@ -8,6 +8,9 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
+open CErrors
+open Vernacexpr
+
 type deprecation = { since : string option ; note : string option }
 
 let mk_deprecation ?(since=None) ?(note=None) () =
@@ -23,3 +26,61 @@ type t = {
 
 let mk_atts ?(locality=None) ?(polymorphic=false) ?(template=None) ?(program=false) ?(deprecated=None) () =
   { locality ; polymorphic ; program ; deprecated; template }
+
+let attributes_of_flags f atts =
+  let assert_empty k v =
+    if v <> VernacFlagEmpty
+    then user_err Pp.(str "Attribute " ++ str k ++ str " does not accept arguments")
+  in
+  List.fold_left
+    (fun (polymorphism, atts) (k, v) ->
+       match k with
+       | "program" when not atts.program ->
+         assert_empty k v;
+         (polymorphism, { atts with program = true })
+       | "program" ->
+         user_err Pp.(str "Program mode specified twice")
+       | "polymorphic" when polymorphism = None ->
+         assert_empty k v;
+         (Some true, atts)
+       | "monomorphic" when polymorphism = None ->
+         assert_empty k v;
+         (Some false, atts)
+       | ("polymorphic" | "monomorphic") ->
+         user_err Pp.(str "Polymorphism specified twice")
+       | "template" when atts.template = None ->
+         assert_empty k v;
+         polymorphism, { atts with template = Some true }
+       | "notemplate" when atts.template = None ->
+         assert_empty k v;
+         polymorphism, { atts with template = Some false }
+       | "template" | "notemplate" ->
+         user_err Pp.(str "Templateness specified twice")
+       | "local" when Option.is_empty atts.locality ->
+         assert_empty k v;
+         (polymorphism, { atts with locality = Some true })
+       | "global" when Option.is_empty atts.locality ->
+         assert_empty k v;
+         (polymorphism, { atts with locality = Some false })
+       | ("local" | "global") ->
+         user_err Pp.(str "Locality specified twice")
+       | "deprecated" when Option.is_empty atts.deprecated ->
+           begin match v with
+             | VernacFlagList [ "since", VernacFlagLeaf since ; "note", VernacFlagLeaf note ]
+             | VernacFlagList [ "note", VernacFlagLeaf note ; "since", VernacFlagLeaf since ] ->
+               let since = Some since and note = Some note in
+               (polymorphism, { atts with deprecated = Some (mk_deprecation ~since ~note ()) })
+             | VernacFlagList [ "since", VernacFlagLeaf since ] ->
+               let since = Some since in
+               (polymorphism, { atts with deprecated = Some (mk_deprecation ~since ()) })
+             | VernacFlagList [ "note", VernacFlagLeaf note ] ->
+               let note = Some note in
+               (polymorphism, { atts with deprecated = Some (mk_deprecation ~note ()) })
+             |  _ -> CErrors.user_err (Pp.str "Ill formed “deprecated” attribute")
+           end
+       | "deprecated" ->
+         user_err Pp.(str "Deprecation specified twice")
+       | _ -> user_err Pp.(str "Unknown attribute " ++ str k)
+    )
+    (None, atts)
+    f

--- a/vernac/attributes.ml
+++ b/vernac/attributes.ml
@@ -8,14 +8,19 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(** Interpretation of extended vernac phrases. *)
+type deprecation = { since : string option ; note : string option }
 
-type 'a vernac_command = 'a -> atts:Attributes.t -> st:Vernacstate.t -> Vernacstate.t
+let mk_deprecation ?(since=None) ?(note=None) () =
+  { since ; note }
 
-type plugin_args = Genarg.raw_generic_argument list
+type t = {
+  loc : Loc.t option;
+  locality : bool option;
+  polymorphic : bool;
+  template : bool option;
+  program : bool;
+  deprecated : deprecation option;
+}
 
-val vinterp_init : unit -> unit
-val vinterp_add : bool -> Vernacexpr.extend_name -> plugin_args vernac_command -> unit
-val overwriting_vinterp_add : Vernacexpr.extend_name -> plugin_args vernac_command -> unit
-
-val call : Vernacexpr.extend_name -> plugin_args -> atts:Attributes.t -> st:Vernacstate.t -> Vernacstate.t
+let mk_atts ?(loc=None) ?(locality=None) ?(polymorphic=false) ?(template=None) ?(program=false) ?(deprecated=None) () =
+  { loc ; locality ; polymorphic ; program ; deprecated; template }

--- a/vernac/attributes.mli
+++ b/vernac/attributes.mli
@@ -8,14 +8,19 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(** Interpretation of extended vernac phrases. *)
+type deprecation = { since : string option ; note : string option }
 
-type 'a vernac_command = 'a -> atts:Attributes.t -> st:Vernacstate.t -> Vernacstate.t
+val mk_deprecation : ?since: string option -> ?note: string option -> unit -> deprecation
 
-type plugin_args = Genarg.raw_generic_argument list
+type t = {
+  loc : Loc.t option;
+  locality : bool option;
+  polymorphic : bool;
+  template : bool option;
+  program : bool;
+  deprecated : deprecation option;
+}
 
-val vinterp_init : unit -> unit
-val vinterp_add : bool -> Vernacexpr.extend_name -> plugin_args vernac_command -> unit
-val overwriting_vinterp_add : Vernacexpr.extend_name -> plugin_args vernac_command -> unit
-
-val call : Vernacexpr.extend_name -> plugin_args -> atts:Attributes.t -> st:Vernacstate.t -> Vernacstate.t
+val mk_atts : ?loc: Loc.t option -> ?locality: bool option ->
+  ?polymorphic: bool -> ?template:bool option ->
+  ?program: bool -> ?deprecated: deprecation option -> unit -> t

--- a/vernac/attributes.mli
+++ b/vernac/attributes.mli
@@ -23,3 +23,6 @@ type t = {
 val mk_atts : ?locality: bool option ->
   ?polymorphic: bool -> ?template:bool option ->
   ?program: bool -> ?deprecated: deprecation option -> unit -> t
+
+val attributes_of_flags : Vernacexpr.vernac_flags -> t ->
+  bool option (* polymorphism attr *) * t

--- a/vernac/attributes.mli
+++ b/vernac/attributes.mli
@@ -12,13 +12,7 @@ type deprecation = { since : string option ; note : string option }
 
 val mk_deprecation : ?since: string option -> ?note: string option -> unit -> deprecation
 
-type t = {
-  locality : bool option;
-  polymorphic : bool;
-  template : bool option;
-  program : bool;
-  deprecated : deprecation option;
-}
+type t
 
 val mk_atts :
   ?polymorphic: bool ->
@@ -26,3 +20,11 @@ val mk_atts :
 
 val attributes_of_flags : Vernacexpr.vernac_flags -> t ->
   bool option (* polymorphism attr *) * t
+
+val locality : t -> bool option
+val polymorphic : t -> bool
+val template : t -> bool option
+val program : t -> bool
+val deprecated : t -> deprecation option
+
+val set_polymorphic : t -> bool -> t

--- a/vernac/attributes.mli
+++ b/vernac/attributes.mli
@@ -25,7 +25,7 @@ val read : 'a attribute -> t -> 'a option
 
 val mk_atts :
   ?polymorphic: bool ->
-  ?program: bool -> unit -> t
+  unit -> t
 
 val attributes_of_flags : Vernacexpr.vernac_flags -> t ->
   bool option (* polymorphism attr *) * t
@@ -47,7 +47,7 @@ val register_attribute : name:string -> 'a flag_parser CString.Map.t ->
 val locality : t -> bool option
 val polymorphic : t -> bool
 val template : t -> bool option
-val program : t -> bool
+val program : t -> bool option
 val deprecated : t -> deprecation option
 
 val set_polymorphic : t -> bool -> t

--- a/vernac/attributes.mli
+++ b/vernac/attributes.mli
@@ -13,7 +13,6 @@ type deprecation = { since : string option ; note : string option }
 val mk_deprecation : ?since: string option -> ?note: string option -> unit -> deprecation
 
 type t = {
-  loc : Loc.t option;
   locality : bool option;
   polymorphic : bool;
   template : bool option;
@@ -21,6 +20,6 @@ type t = {
   deprecated : deprecation option;
 }
 
-val mk_atts : ?loc: Loc.t option -> ?locality: bool option ->
+val mk_atts : ?locality: bool option ->
   ?polymorphic: bool -> ?template:bool option ->
   ?program: bool -> ?deprecated: deprecation option -> unit -> t

--- a/vernac/attributes.mli
+++ b/vernac/attributes.mli
@@ -21,6 +21,20 @@ val mk_atts :
 val attributes_of_flags : Vernacexpr.vernac_flags -> t ->
   bool option (* polymorphism attr *) * t
 
+
+type 'a flag_parser = 'a option -> Vernacexpr.vernac_flag_value -> 'a
+(** How to parse some specific attribute key (eg "polymorphic" and
+   "monomorphic" are separate keys for the same attribute). The
+   previous value of the attribute if set is also passed, allowing
+   handling of multiply set attributes as you desire (error, make a
+   list, etc). *)
+
+val register_attribute : name:string -> 'a flag_parser CString.Map.t ->
+  t -> 'a option
+(** You can register multiple keys for the same attribute, eg
+   "template" and "notemplate" keys both affect the "template"
+   attribute. The [name] is currently not used. *)
+
 val locality : t -> bool option
 val polymorphic : t -> bool
 val template : t -> bool option

--- a/vernac/attributes.mli
+++ b/vernac/attributes.mli
@@ -20,9 +20,9 @@ type t = {
   deprecated : deprecation option;
 }
 
-val mk_atts : ?locality: bool option ->
-  ?polymorphic: bool -> ?template:bool option ->
-  ?program: bool -> ?deprecated: deprecation option -> unit -> t
+val mk_atts :
+  ?polymorphic: bool ->
+  ?program: bool -> unit -> t
 
 val attributes_of_flags : Vernacexpr.vernac_flags -> t ->
   bool option (* polymorphism attr *) * t

--- a/vernac/attributes.mli
+++ b/vernac/attributes.mli
@@ -31,7 +31,7 @@ val attributes_of_flags : Vernacexpr.vernac_flags -> t ->
   bool option (* polymorphism attr *) * t
 
 
-type 'a flag_parser = 'a option -> Vernacexpr.vernac_flag_value -> 'a
+type 'a flag_parser = 'a option -> ?loc:Loc.t -> Vernacexpr.vernac_flag_value -> 'a
 (** How to parse some specific attribute key (eg "polymorphic" and
    "monomorphic" are separate keys for the same attribute). The
    previous value of the attribute if set is also passed, allowing

--- a/vernac/attributes.mli
+++ b/vernac/attributes.mli
@@ -13,6 +13,15 @@ type deprecation = { since : string option ; note : string option }
 val mk_deprecation : ?since: string option -> ?note: string option -> unit -> deprecation
 
 type t
+(** The type of parsed attributes *)
+
+type 'a attribute
+(** Used to get the value for some attribute out of [t] in a typed
+   way. *)
+
+val read : 'a attribute -> t -> 'a option
+(** [read x atts] returns the value of attribute [x] if it is set in
+   [atts] *)
 
 val mk_atts :
   ?polymorphic: bool ->
@@ -30,10 +39,10 @@ type 'a flag_parser = 'a option -> Vernacexpr.vernac_flag_value -> 'a
    list, etc). *)
 
 val register_attribute : name:string -> 'a flag_parser CString.Map.t ->
-  t -> 'a option
+  'a attribute
 (** You can register multiple keys for the same attribute, eg
-   "template" and "notemplate" keys both affect the "template"
-   attribute. The [name] is currently not used. *)
+   "template" and "notemplate" keys produce values for the same
+   "templateness" attribute. The [name] is currently not used. *)
 
 val locality : t -> bool option
 val polymorphic : t -> bool

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -96,7 +96,7 @@ GRAMMAR EXTEND Gram
     ]
   ;
   attribute:
-    [ [ k = ident ; v = attribute_value -> { Names.Id.to_string k, v } ]
+    [ [ k = ident ; v = attribute_value -> { CAst.make ~loc (Names.Id.to_string k, v) } ]
     ]
   ;
   attribute_value:
@@ -106,23 +106,23 @@ GRAMMAR EXTEND Gram
     ]
   ;
   vernac:
-    [ [ IDENT "Local"; v = vernac_poly -> { let (f, v) = v in (("local", VernacFlagEmpty) :: f, v) }
-      | IDENT "Global"; v = vernac_poly -> { let (f, v) = v in (("global", VernacFlagEmpty) :: f, v) }
+    [ [ IDENT "Local"; v = vernac_poly -> { let (f, v) = v in (CAst.make ("local", VernacFlagEmpty) :: f, v) }
+      | IDENT "Global"; v = vernac_poly -> { let (f, v) = v in (CAst.make ("global", VernacFlagEmpty) :: f, v) }
 
       | v = vernac_poly -> { v } ]
     ]
   ;
   vernac_poly:
-    [ [ IDENT "Polymorphic"; v = vernac_aux -> { let (f, v) = v in (("polymorphic", VernacFlagEmpty) :: f, v) }
-      | IDENT "Monomorphic"; v = vernac_aux -> { let (f, v) = v in (("monomorphic", VernacFlagEmpty) :: f, v) }
+    [ [ IDENT "Polymorphic"; v = vernac_aux -> { let (f, v) = v in (CAst.make ("polymorphic", VernacFlagEmpty) :: f, v) }
+      | IDENT "Monomorphic"; v = vernac_aux -> { let (f, v) = v in (CAst.make ("monomorphic", VernacFlagEmpty) :: f, v) }
       | v = vernac_aux -> { v } ]
     ]
   ;
   vernac_aux:
     (* Better to parse "." here: in case of failure (e.g. in coerce_to_var), *)
     (* "." is still in the stream and discard_to_dot works correctly         *)
-    [ [ IDENT "Program"; g = gallina; "." -> { (["program", VernacFlagEmpty], g) }
-      | IDENT "Program"; g = gallina_ext; "." -> { (["program", VernacFlagEmpty], g) }
+    [ [ IDENT "Program"; g = gallina; "." -> { ([CAst.make ("program", VernacFlagEmpty)], g) }
+      | IDENT "Program"; g = gallina_ext; "." -> { ([CAst.make ("program", VernacFlagEmpty)], g) }
       | g = gallina; "." -> { ([], g) }
       | g = gallina_ext; "." -> { ([], g) }
       | c = command; "." -> { ([], c) }

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -1206,7 +1206,7 @@ open Pputils
       | VernacEndSubproof ->
         return (str "}")
 
-let rec pr_vernac_flag (k, v) =
+let rec pr_vernac_flag {CAst.v=k, v} =
   let k = keyword k in
   match v with
   | VernacFlagEmpty -> k

--- a/vernac/vernac.mllib
+++ b/vernac/vernac.mllib
@@ -7,6 +7,7 @@ Himsg
 ExplainErr
 Locality
 Egramml
+Attributes
 Vernacinterp
 Ppvernac
 Proof_using

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -2346,64 +2346,6 @@ let with_fail st b f =
       | _ -> assert false
   end
 
-let attributes_of_flags f atts =
-  let assert_empty k v =
-    if v <> VernacFlagEmpty
-    then user_err Pp.(str "Attribute " ++ str k ++ str " does not accept arguments")
-  in
-  List.fold_left
-    (fun (polymorphism, atts) (k, v) ->
-       match k with
-       | "program" when not atts.program ->
-         assert_empty k v;
-         (polymorphism, { atts with program = true })
-       | "program" ->
-         user_err Pp.(str "Program mode specified twice")
-       | "polymorphic" when polymorphism = None ->
-         assert_empty k v;
-         (Some true, atts)
-       | "monomorphic" when polymorphism = None ->
-         assert_empty k v;
-         (Some false, atts)
-       | ("polymorphic" | "monomorphic") ->
-         user_err Pp.(str "Polymorphism specified twice")
-       | "template" when atts.template = None ->
-         assert_empty k v;
-         polymorphism, { atts with template = Some true }
-       | "notemplate" when atts.template = None ->
-         assert_empty k v;
-         polymorphism, { atts with template = Some false }
-       | "template" | "notemplate" ->
-         user_err Pp.(str "Templateness specified twice")
-       | "local" when Option.is_empty atts.locality ->
-         assert_empty k v;
-         (polymorphism, { atts with locality = Some true })
-       | "global" when Option.is_empty atts.locality ->
-         assert_empty k v;
-         (polymorphism, { atts with locality = Some false })
-       | ("local" | "global") ->
-         user_err Pp.(str "Locality specified twice")
-       | "deprecated" when Option.is_empty atts.deprecated ->
-           begin match v with
-             | VernacFlagList [ "since", VernacFlagLeaf since ; "note", VernacFlagLeaf note ]
-             | VernacFlagList [ "note", VernacFlagLeaf note ; "since", VernacFlagLeaf since ] ->
-               let since = Some since and note = Some note in
-               (polymorphism, { atts with deprecated = Some (mk_deprecation ~since ~note ()) })
-             | VernacFlagList [ "since", VernacFlagLeaf since ] ->
-               let since = Some since in
-               (polymorphism, { atts with deprecated = Some (mk_deprecation ~since ()) })
-             | VernacFlagList [ "note", VernacFlagLeaf note ] ->
-               let note = Some note in
-               (polymorphism, { atts with deprecated = Some (mk_deprecation ~note ()) })
-             |  _ -> CErrors.user_err (Pp.str "Ill formed “deprecated” attribute")
-           end
-       | "deprecated" ->
-         user_err Pp.(str "Deprecation specified twice")
-       | _ -> user_err Pp.(str "Unknown attribute " ++ str k)
-    )
-    (None, atts)
-    f
-
 let interp ?(verbosely=true) ?proof ~st {CAst.loc;v=c} =
   let orig_univ_poly = Flags.is_universe_polymorphism () in
   let orig_program_mode = Flags.is_program_mode () in

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -2351,7 +2351,7 @@ let interp ?(verbosely=true) ?proof ~st {CAst.loc;v=c} =
   let orig_program_mode = Flags.is_program_mode () in
   let rec control = function
   | VernacExpr (f, v) ->
-    let (polymorphism, atts) = attributes_of_flags f (mk_atts ~program:orig_program_mode ()) in
+    let (polymorphism, atts) = attributes_of_flags f (mk_atts ()) in
     aux ~polymorphism ~atts v
   | VernacFail v -> with_fail st true (fun () -> control v)
   | VernacTimeout (n,v) ->
@@ -2371,8 +2371,9 @@ let interp ?(verbosely=true) ?proof ~st {CAst.loc;v=c} =
       check_vernac_supports_locality c (Attributes.locality atts);
       check_vernac_supports_polymorphism c polymorphism;
       let polymorphic = Option.default (Flags.is_universe_polymorphism ()) polymorphism in
+      let program = Option.default orig_program_mode (Attributes.program atts) in
       Flags.make_universe_polymorphism polymorphic;
-      Obligations.set_program_mode (Attributes.program atts);
+      Obligations.set_program_mode program;
       try
         vernac_timeout begin fun () ->
           let atts = Attributes.set_polymorphic atts polymorphic in
@@ -2381,7 +2382,7 @@ let interp ?(verbosely=true) ?proof ~st {CAst.loc;v=c} =
           else Flags.silently  (interp ?proof ~atts ~st) c;
           (* If the command is `(Un)Set Program Mode` or `(Un)Set Universe Polymorphism`,
              we should not restore the previous state of the flag... *)
-          if orig_program_mode || not !Flags.program_mode || (Attributes.program atts) then
+          if orig_program_mode || not !Flags.program_mode || program then
             Flags.program_mode := orig_program_mode;
           if (Flags.is_universe_polymorphism() = polymorphic) then
             Flags.make_universe_polymorphism orig_univ_poly;

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -718,14 +718,14 @@ let vernac_combined_scheme lid l =
 
 let vernac_universe ~atts l =
   if atts.polymorphic && not (Lib.sections_are_opened ()) then
-    user_err ?loc:atts.loc ~hdr:"vernac_universe"
+    user_err ~hdr:"vernac_universe"
 		 (str"Polymorphic universes can only be declared inside sections, " ++
 		  str "use Monomorphic Universe instead");
   Declare.do_universe atts.polymorphic l
 
 let vernac_constraint ~atts l =
   if atts.polymorphic && not (Lib.sections_are_opened ()) then
-    user_err ?loc:atts.loc ~hdr:"vernac_constraint"
+    user_err ~hdr:"vernac_constraint"
 		 (str"Polymorphic universe constraints can only be declared"
 		  ++ str " inside sections, use Monomorphic Constraint instead");
   Declare.do_constraint atts.polymorphic l
@@ -1699,7 +1699,7 @@ let query_command_selector ?loc = function
       (str "Query commands only support the single numbered goal selector.")
 
 let vernac_check_may_eval ~atts redexp glopt rc =
-  let glopt = query_command_selector ?loc:atts.loc glopt in
+  let glopt = query_command_selector glopt in
   let (sigma, env) = get_current_context_of_args glopt in
   let sigma, c = interp_open_constr env sigma rc in
   let sigma = Evarconv.solve_unif_constraints_with_heuristics env sigma in
@@ -1793,7 +1793,6 @@ let print_about_hyp_globs ?loc ref_or_by_not udecl glopt =
     print_about env sigma ref_or_by_not udecl
 
 let vernac_print ~atts env sigma =
-  let loc = atts.loc in
   function
   | PrintTables -> print_tables ()
   | PrintFullContext-> print_full_context_typ env sigma
@@ -1841,7 +1840,7 @@ let vernac_print ~atts env sigma =
   | PrintVisibility s ->
     Notation.pr_visibility (Constrextern.without_symbols (pr_lglob_constr_env env)) s
   | PrintAbout (ref_or_by_not,udecl,glnumopt) ->
-    print_about_hyp_globs ?loc ref_or_by_not udecl glnumopt
+    print_about_hyp_globs ref_or_by_not udecl glnumopt
   | PrintImplicit qid ->
     dump_global qid;
     print_impargs qid
@@ -1906,7 +1905,7 @@ let _ =
       optwrite = (:=) search_output_name_only }
 
 let vernac_search ~atts s gopt r =
-  let gopt = query_command_selector ?loc:atts.loc gopt in
+  let gopt = query_command_selector gopt in
   let r = interp_search_restriction r in
   let env,gopt =
     match gopt with | None ->
@@ -2232,7 +2231,7 @@ let interp ?proof ~atts ~st c =
     let using = Option.append using (Proof_using.get_default_proof_using ()) in
     let tacs = if Option.is_empty tac then "tac:no" else "tac:yes" in
     let usings = if Option.is_empty using then "using:no" else "using:yes" in
-    Aux_file.record_in_aux_at ?loc:atts.loc "VernacProof" (tacs^" "^usings);
+    Aux_file.record_in_aux_at "VernacProof" (tacs^" "^usings);
     Option.iter vernac_set_end_tac tac;
     Option.iter vernac_set_used_variables using
   | VernacProofMode mn -> Proof_global.set_proof_mode mn [@ocaml.warning "-3"]

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -31,6 +31,7 @@ open Redexpr
 open Lemmas
 open Locality
 open Vernacinterp
+open Attributes
 
 module NamedDecl = Context.Named.Declaration
 
@@ -2086,7 +2087,6 @@ let vernac_load interp fname =
  * still parsed as the obsolete_locality grammar entry for retrocompatibility.
  * loc is the Loc.t of the vernacular command being interpreted. *)
 let interp ?proof ~atts ~st c =
-  let open Vernacinterp in
   vernac_pperr_endline (fun () -> str "interpreting: " ++ Ppvernac.pr_vernac_expr c);
   match c with
 
@@ -2481,7 +2481,7 @@ open Extend
 type classifier = Genarg.raw_generic_argument list -> vernac_classification
 
 type (_, _) ty_sig =
-| TyNil : (atts:atts -> st:Vernacstate.t -> Vernacstate.t, Vernacexpr.vernac_classification) ty_sig
+| TyNil : (atts:Attributes.t -> st:Vernacstate.t -> Vernacstate.t, Vernacexpr.vernac_classification) ty_sig
 | TyTerminal : string * ('r, 's) ty_sig -> ('r, 's) ty_sig
 | TyNonTerminal :
   string option * ('a, 'b, 'c) Extend.ty_user_symbol * ('r, 's) ty_sig -> ('a -> 'r, 'a -> 's) ty_sig

--- a/vernac/vernacentries.mli
+++ b/vernac/vernacentries.mli
@@ -41,14 +41,14 @@ val universe_polymorphism_option_name : string list
 
 (** Elaborate a [atts] record out of a list of flags.
     Also returns whether polymorphism is explicitly (un)set. *)
-val attributes_of_flags : Vernacexpr.vernac_flags -> Vernacinterp.atts -> bool option * Vernacinterp.atts
+val attributes_of_flags : Vernacexpr.vernac_flags -> Attributes.t -> bool option * Attributes.t
 
 (** {5 VERNAC EXTEND} *)
 
 type classifier = Genarg.raw_generic_argument list -> Vernacexpr.vernac_classification
 
 type (_, _) ty_sig =
-| TyNil : (atts:Vernacinterp.atts -> st:Vernacstate.t -> Vernacstate.t, Vernacexpr.vernac_classification) ty_sig
+| TyNil : (atts:Attributes.t -> st:Vernacstate.t -> Vernacstate.t, Vernacexpr.vernac_classification) ty_sig
 | TyTerminal : string * ('r, 's) ty_sig -> ('r, 's) ty_sig
 | TyNonTerminal :
   string option *

--- a/vernac/vernacentries.mli
+++ b/vernac/vernacentries.mli
@@ -39,10 +39,6 @@ val interp_redexp_hook : (Environ.env -> Evd.evar_map -> Genredexpr.raw_red_expr
 
 val universe_polymorphism_option_name : string list
 
-(** Elaborate a [atts] record out of a list of flags.
-    Also returns whether polymorphism is explicitly (un)set. *)
-val attributes_of_flags : Vernacexpr.vernac_flags -> Attributes.t -> bool option * Attributes.t
-
 (** {5 VERNAC EXTEND} *)
 
 type classifier = Genarg.raw_generic_argument list -> Vernacexpr.vernac_classification

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -463,7 +463,7 @@ type nonrec vernac_expr =
   | VernacExtend of extend_name * Genarg.raw_generic_argument list
 
 type vernac_flags = vernac_flag list
-and vernac_flag = string * vernac_flag_value
+and vernac_flag = (string * vernac_flag_value) CAst.t
 and vernac_flag_value =
   | VernacFlagEmpty
   | VernacFlagLeaf of string

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -462,7 +462,8 @@ type nonrec vernac_expr =
   (* For extension *)
   | VernacExtend of extend_name * Genarg.raw_generic_argument list
 
-type vernac_flags = (string * vernac_flag_value) list
+type vernac_flags = vernac_flag list
+and vernac_flag = string * vernac_flag_value
 and vernac_flag_value =
   | VernacFlagEmpty
   | VernacFlagLeaf of string

--- a/vernac/vernacinterp.ml
+++ b/vernac/vernacinterp.ml
@@ -12,24 +12,7 @@ open Util
 open Pp
 open CErrors
 
-type deprecation = { since : string option ; note : string option }
-
-let mk_deprecation ?(since=None) ?(note=None) () =
-  { since ; note }
-
-type atts = {
-  loc : Loc.t option;
-  locality : bool option;
-  polymorphic : bool;
-  template : bool option;
-  program : bool;
-  deprecated : deprecation option;
-}
-
-let mk_atts ?(loc=None) ?(locality=None) ?(polymorphic=false) ?(template=None) ?(program=false) ?(deprecated=None) () : atts =
-  { loc ; locality ; polymorphic ; program ; deprecated; template }
-
-type 'a vernac_command = 'a -> atts:atts -> st:Vernacstate.t -> Vernacstate.t
+type 'a vernac_command = 'a -> atts:Attributes.t -> st:Vernacstate.t -> Vernacstate.t
 
 type plugin_args = Genarg.raw_generic_argument list
 


### PR DESCRIPTION
This PR adds a way to define new attributes without touching the attribute type or its interp function. It should also work from plugins although that's untested. 
Pre-existent attributes are moved to the new system, with some special casing for polymorphism as we do silly things with it.
As a bonus the classifier stops ignoring local `Polymorphic`/`#[polymorphic]` attributes.

The API looks like this (in `Attributes`):
~~~ocaml
type t (* parsed attributes *)
type 'a attribute (* typed key for some attribute, eg we can have [val program : bool attribute] *)

val read : 'a attribute -> t -> 'a option
(* was the attribute set, and if so what's the value? *)

type 'a flag_parser = 'a option -> ?loc:Loc.t -> Vernacexpr.vernac_flag_value -> 'a
(** How to parse some specific attribute key (eg "polymorphic" and
   "monomorphic" are separate keys for the same attribute). The
   previous value of the attribute if set is also passed, allowing
   handling of multiply set attributes as you desire (error, make a
   list, etc). *)

val register_attribute : name:string -> 'a flag_parser CString.Map.t -> 'a attribute
(** You can register multiple keys for the same attribute, eg
   "template" and "notemplate" keys produce values for the same
   "templateness" attribute. The [name] is currently not used. *)

(* type t is inhabited by these 2, whose use is centralised. users don't care about them. *)
val mk_atts : ?polymorphic: bool ->
  unit -> t

val attributes_of_flags : Vernacexpr.vernac_flags -> t ->
  bool option (* polymorphism attr *) * t
~~~

Underneath `t` is just a store, and `register_attribute` updates some ref with ways to fill the store.

The magic we do with polymorphism is too much for me so I gave up on removing it in this PR (there is also some weird stuff still done with program mode, but at least I got that out of the attribute stuff).
Aside from the magic around VernacLoad or whatever this stuff is, if we make polymorphism a regular attribute we can only get a `bool option` from the attribute type, so we would have to use `is_universe_polymorphism ()` all over the place again for the default case. I feel like this is an indicator that we're doing something suboptimally but not sure of the solution. It seems related to the issue of detecting unsupported attributes: each command wants not the type `t` of the collected attributes but instead some subset of it, or even a transformation of that subset (transformation which can eg insert default values). That however is beyond this PR or orthogonal to it.

3rd party plugins using attributes are broken: since the system is generic there are no more projections to access the attributes, you need to use functions. Overlay will come later.