### PR TITLE
[ci] [docker] Move to OPAM 2.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,7 +9,7 @@ stages:
 variables:
   # Format: $IMAGE-V$DATE [Cache is not used as of today but kept here
   # for reference]
-  CACHEKEY: "bionic_coq-V2018-09-21-V2"
+  CACHEKEY: "bionic_coq-V2018-09-23-V01"
   IMAGE: "$CI_REGISTRY_IMAGE:$CACHEKEY"
   # By default, jobs run in the base switch; override to select another switch
   OPAM_SWITCH: "base"
@@ -40,8 +40,8 @@ before_script:
   - printenv -0 | sort -z | tr '\0' '\n'
   - declare -A switch_table
   - switch_table=( ["base"]="$COMPILER" ["edge"]="$COMPILER_EDGE" )
-  - opam switch -y "${switch_table[$OPAM_SWITCH]}$OPAM_VARIANT"
-  - eval $(opam config env)
+  - opam switch set -y "${switch_table[$OPAM_SWITCH]}$OPAM_VARIANT"
+  - eval $(opam env)
   - opam list
   - opam config list
 

--- a/dev/ci/docker/bionic_coq/Dockerfile
+++ b/dev/ci/docker/bionic_coq/Dockerfile
@@ -1,4 +1,4 @@
-# CACHEKEY: "bionic_coq-V2018-09-21-V2"
+# CACHEKEY: "bionic_coq-V2018-09-23-V01"
 # ^^ Update when modifying this file.
 
 FROM ubuntu:bionic
@@ -8,7 +8,7 @@ ENV DEBIAN_FRONTEND="noninteractive"
 
 RUN apt-get update -qq && apt-get install --no-install-recommends -y -qq \
         # Dependencies of the image, the test-suite and external projects
-        m4 automake autoconf time wget rsync git gcc-multilib opam \
+        m4 automake autoconf time wget rsync git gcc-multilib build-essential unzip \
         # Dependencies of lablgtk (for CoqIDE)
         libgtk2.0-dev libgtksourceview2.0-dev \
         # Dependencies of stdlib and sphinx doc
@@ -21,15 +21,18 @@ RUN apt-get update -qq && apt-get install --no-install-recommends -y -qq \
 RUN pip3 install sphinx==1.7.8 sphinx_rtd_theme==0.2.5b2 \
                  antlr4-python3-runtime==4.7.1 sphinxcontrib-bibtex==0.4.0
 
+# We need to install OPAM 2.0 manually for now.
+RUN wget https://github.com/ocaml/opam/releases/download/2.0.0/opam-2.0.0-x86_64-linux -O /usr/bin/opam && chmod 755 /usr/bin/opam
+
 # Basic OPAM setup
 ENV NJOBS="2" \
+    OPAMJOBS="2" \
     OPAMROOT=/root/.opamcache \
-    OPAMROOTISOK="true"
+    OPAMROOTISOK="true" \
+    OPAMYES="true"
 
 # Base opam is the set of base packages required by Coq
 ENV COMPILER="4.02.3"
-
-RUN opam init -a -y -j $NJOBS --compiler="$COMPILER" default https://opam.ocaml.org && eval $(opam config env) && opam update
 
 # Common OPAM packages.
 # `num` does not have a version number as the right version to install varies
@@ -41,12 +44,15 @@ ENV BASE_OPAM="num ocamlfind.1.8.0 dune.1.2.1 ounit.2.0.8" \
 ENV CAMLP5_VER="6.14" \
     COQIDE_OPAM="lablgtk.2.18.5 conf-gtksourceview.2"
 
-RUN opam switch -y -j $NJOBS "$COMPILER" && eval $(opam config env) && \
-    opam install -j $NJOBS $BASE_OPAM camlp5.$CAMLP5_VER $COQIDE_OPAM $CI_OPAM
+# The separate `opam install ocamlfind` workarounds an OPAM repository bug in 4.02.3
+RUN opam init -a --disable-sandboxing --compiler="$COMPILER" default https://opam.ocaml.org && eval $(opam env) && opam update && \
+    opam install ocamlfind.1.8.0 && \
+    opam install $BASE_OPAM camlp5.$CAMLP5_VER $COQIDE_OPAM $CI_OPAM
 
 # base+32bit switch
-RUN opam switch -y -j $NJOBS "${COMPILER}+32bit" && eval $(opam config env) && \
-    opam install -j $NJOBS $BASE_OPAM camlp5.$CAMLP5_VER
+RUN opam switch create "${COMPILER}+32bit" && eval $(opam env) && \
+    opam install ocamlfind.1.8.0 && \
+    opam install $BASE_OPAM camlp5.$CAMLP5_VER
 
 # EDGE switch
 ENV COMPILER_EDGE="4.07.0" \
@@ -54,10 +60,12 @@ ENV COMPILER_EDGE="4.07.0" \
     COQIDE_OPAM_EDGE="lablgtk.2.18.6 conf-gtksourceview.2" \
     BASE_OPAM_EDGE="odoc.1.2.0 dune-release.0.3.0"
 
-RUN opam switch -y -j $NJOBS $COMPILER_EDGE && eval $(opam config env) && \
-    opam install -j $NJOBS $BASE_OPAM $BASE_OPAM_EDGE camlp5.$CAMLP5_VER_EDGE $COQIDE_OPAM_EDGE
+RUN opam switch create $COMPILER_EDGE && eval $(opam env) && \
+    opam install $BASE_OPAM $BASE_OPAM_EDGE camlp5.$CAMLP5_VER_EDGE $COQIDE_OPAM_EDGE
 
 # EDGE+flambda switch, we install CI_OPAM as to be able to use
 # `ci-template-flambda` with everything.
-RUN opam switch -y -j $NJOBS "${COMPILER_EDGE}+flambda" && eval $(opam config env) && \
-    opam install -j $NJOBS $BASE_OPAM $BASE_OPAM_EDGE camlp5.$CAMLP5_VER_EDGE $COQIDE_OPAM_EDGE $CI_OPAM
+RUN opam switch create "${COMPILER_EDGE}+flambda" && eval $(opam env) && \
+    opam install $BASE_OPAM $BASE_OPAM_EDGE camlp5.$CAMLP5_VER_EDGE $COQIDE_OPAM_EDGE $CI_OPAM
+
+RUN opam clean -a -c


### PR DESCRIPTION
The OPAM 1.2 repository has been frozen, thus we must use OPAM 2.0 if
we want to get newer versions of packages / compilers.

For now we must perform a manual install of OPAM as no packages for
Ubuntu 18.04 exist.

Note that this means nothing about the installability of Coq itself,
whose OPAM repository should remain in 1.2 format for quite a long
period.
