### PR TITLE
Fix Travis CI by pinning brew OPAM package to version 1.2.2.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -166,7 +166,9 @@ matrix:
       before_install:
       - brew update
       - brew unlink python
-      - brew install opam gnu-time
+      - brew install gnu-time
+      # only way to continue using OPAM 1.2
+      - brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/d156edeeed7291f4bc1e08620b331bbd05d52b78/Formula/opam.rb
 
     - if: NOT (type = pull_request)
       os: osx
@@ -183,7 +185,9 @@ matrix:
       before_install:
       - brew update
       - brew unlink python
-      - brew install opam gnu-time gtk+ expat gtksourceview gdk-pixbuf
+      - brew install gnu-time gtk+ expat gtksourceview gdk-pixbuf
+      # only way to continue using OPAM 1.2
+      - brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/d156edeeed7291f4bc1e08620b331bbd05d52b78/Formula/opam.rb
       - brew unlink python@2
       - brew install python3
       - pip3 install macpack


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** infrastructure fix.

Passed here: https://travis-ci.com/Zimmi48/coq/builds/85596553
The rest of CI is irrelevant.