### PR TITLE
Fixing #8532: regression in Print Assumptions within a functor.

### DIFF
--- a/test-suite/bugs/closed/8532.v
+++ b/test-suite/bugs/closed/8532.v
@@ -1,0 +1,8 @@
+(* Checking Print Assumptions relatively to a bound module *)
+
+Module Type Typ.
+  Parameter Inline(10) t : Type.
+End Typ.
+Module  Terms_mod (SetVars : Typ).
+Print Assumptions SetVars.t.
+End Terms_mod.

--- a/vernac/assumptions.ml
+++ b/vernac/assumptions.ml
@@ -71,7 +71,7 @@ let rec fields_of_functor f subs mp0 args = function
 let rec lookup_module_in_impl mp =
     match mp with
     | MPfile _ -> Global.lookup_module mp
-    | MPbound _ -> assert false
+    | MPbound _ -> Global.lookup_module mp
     | MPdot (mp',lab') ->
        if ModPath.equal mp' (Global.current_modpath ()) then
          Global.lookup_module mp


### PR DESCRIPTION
The regression was introduced in 1522b989 (PR #7193) which itself was fixing bug #7192. (Note another regression introduced by the same commit which has been fixed in #8416 :worried:.)

<!-- Keep what applies -->
**Kind:** bug fix

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #8532

- [X] Added / updated test-suite
