### PR TITLE
Don't use dune-template for apidoc

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -288,13 +288,12 @@ doc:ml-api:ocamldoc:
       - dev/ocamldoc
 
 doc:ml-api:odoc:
-  <<: *dune-template
   stage: test
   dependencies:
     - build:egde:dune:dev
+  script: make -f Makefile.dune apidoc
   variables:
     OPAM_SWITCH: edge
-    DUNE_TARGET: apidoc
   artifacts:
     name: "$CI_JOB_NAME"
     paths:


### PR DESCRIPTION
dune-template works for the build jobs but followup jobs are different
enough to make reuse more confusing than useful IMO.
