### PR TITLE
Fixes #8553: regression of tactic "change" under binders.

### DIFF
--- a/dev/ci/user-overlays/08554-herbelin-master+fix8553-change-under-binders.sh
+++ b/dev/ci/user-overlays/08554-herbelin-master+fix8553-change-under-binders.sh
@@ -1,0 +1,11 @@
+if [ "$CI_PULL_REQUEST" = "8554" ] || [ "$CI_BRANCH" = "master+fix8553-change-under-binders" ]; then
+
+    ltac2_CI_BRANCH=master+fix-pr8554-change-takes-env
+    ltac2_CI_REF=master+fix-pr8554-change-takes-env
+    ltac2_CI_GITURL=https://github.com/herbelin/ltac2
+
+    Equations_CI_BRANCH=master+fix-pr8554-change-takes-env
+    Equations_CI_REF=master+fix-pr8554-change-takes-env
+    Equations_CI_GITURL=https://github.com/herbelin/Coq-Equations
+
+fi

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -713,7 +713,7 @@ let mkDestructEq :
     observe_tclTHENLIST (str "mkDestructEq")
      [Proofview.V82.of_tactic (generalize new_hyps);
       (fun g2 ->
-        let changefun patvars sigma =
+        let changefun patvars env sigma =
           pattern_occs [Locus.AllOccurrencesBut [1], expr] (pf_env g2) sigma (pf_concl g2)
         in
 	Proofview.V82.of_tactic (change_in_concl None changefun) g2);

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -791,9 +791,9 @@ let e_change_in_hyp redfun (id,where) =
     (convert_hyp c)
   end
 
-type change_arg = Ltac_pretype.patvar_map -> evar_map -> evar_map * EConstr.constr
+type change_arg = Ltac_pretype.patvar_map -> env -> evar_map -> evar_map * EConstr.constr
 
-let make_change_arg c pats sigma = (sigma, replace_vars (Id.Map.bindings pats) c)
+let make_change_arg c pats env sigma = (sigma, replace_vars (Id.Map.bindings pats) c)
 
 let check_types env sigma mayneedglobalcheck deep newc origc =
   let t1 = Retyping.get_type_of env sigma newc in
@@ -818,7 +818,7 @@ let check_types env sigma mayneedglobalcheck deep newc origc =
 
 (* Now we introduce different instances of the previous tacticals *)
 let change_and_check cv_pb mayneedglobalcheck deep t env sigma c =
-  let (sigma, t') = t sigma in
+  let (sigma, t') = t env sigma in
   let sigma = check_types env sigma mayneedglobalcheck deep t' c in
   match infer_conv ~pb:cv_pb env sigma t' c with
   | None -> user_err ~hdr:"convert-check-hyp" (str "Not convertible.");

--- a/tactics/tactics.mli
+++ b/tactics/tactics.mli
@@ -145,7 +145,7 @@ val exact_proof      : Constrexpr.constr_expr -> unit Proofview.tactic
 type tactic_reduction = Reductionops.reduction_function
 type e_tactic_reduction = Reductionops.e_reduction_function
 
-type change_arg = patvar_map -> evar_map -> evar_map * constr
+type change_arg = patvar_map -> env -> evar_map -> evar_map * constr
 
 val make_change_arg   : constr -> change_arg
 val reduct_in_hyp     : ?check:bool -> tactic_reduction -> hyp_location -> unit Proofview.tactic

--- a/test-suite/bugs/closed/8553.v
+++ b/test-suite/bugs/closed/8553.v
@@ -1,0 +1,7 @@
+(* Using tactic "change" under binders *)
+
+Definition add2 n := n +2.
+Goal (fun n => n) = (fun n => n+2).
+change (?n + 2) with (add2 n).
+match goal with |- _ = (fun n => add2 n) => idtac end. (* To test the presence of add2 *)
+Abort.


### PR DESCRIPTION
**Kind:** bug fix

Fixes / closes #8553

Easy fix: the exact environment at the time of type-checking the subterm was not passed. A pity that we did not use more systematically regression tests earlier.

- [X] Added / updated test-suite
