### PR TITLE
Removing deprecated undocumented syntax for binding a scope to several types

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,11 @@ Plugins
   externally, the Coq development team can provide assistance for extracting
   the plugin and setting up a new repository.
 
+Notations
+
+- Removed undocumented support for binding a scope to several types at
+  the same time.
+
 Changes from 8.8.2 to 8.9+beta1
 ===============================
 

--- a/test-suite/bugs/closed/3732.v
+++ b/test-suite/bugs/closed/3732.v
@@ -54,7 +54,8 @@ Section machine.
   Definition interp specs := valid specs nil.
 End machine.
 Notation "'ExX' : A , P" := (ExistsX (A := A) P) (at level 89) : PropX_scope.
-Bind Scope PropX_scope with PropX propX.
+Bind Scope PropX_scope with PropX.
+Bind Scope PropX_scope with propX.
 Variables pc state : Type.
 
 Inductive subs : list Type -> Type :=

--- a/theories/Arith/PeanoNat.v
+++ b/theories/Arith/PeanoNat.v
@@ -751,7 +751,8 @@ End Nat.
 (** Re-export notations that should be available even when
     the [Nat] module is not imported. *)
 
-Bind Scope nat_scope with Nat.t nat.
+Bind Scope nat_scope with Nat.t.
+Bind Scope nat_scope with nat.
 
 Infix "^" := Nat.pow : nat_scope.
 Infix "=?" := Nat.eqb (at level 70) : nat_scope.

--- a/theories/NArith/BinNat.v
+++ b/theories/NArith/BinNat.v
@@ -926,7 +926,8 @@ Qed.
 
 End N.
 
-Bind Scope N_scope with N.t N.
+Bind Scope N_scope with N.t.
+Bind Scope N_scope with N.
 
 (** Exportation of notations *)
 

--- a/theories/PArith/BinPos.v
+++ b/theories/PArith/BinPos.v
@@ -1867,7 +1867,8 @@ Qed.
 
 End Pos.
 
-Bind Scope positive_scope with Pos.t positive.
+Bind Scope positive_scope with Pos.t.
+Bind Scope positive_scope with positive.
 
 (** Exportation of notations *)
 

--- a/theories/ZArith/BinInt.v
+++ b/theories/ZArith/BinInt.v
@@ -1244,7 +1244,8 @@ Qed.
 
 End Z.
 
-Bind Scope Z_scope with Z.t Z.
+Bind Scope Z_scope with Z.t.
+Bind Scope Z_scope with Z.
 
 (** Re-export Notations *)
 

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -490,10 +490,6 @@ let warn_deprecated_include_type =
   CWarnings.create ~name:"deprecated-include-type" ~category:"deprecated"
          (fun () -> strbrk "Include Type is deprecated; use Include instead")
 
-let warn_deprecated_bind_several_scopes =
-  CWarnings.create ~name:"deprecated-bind-multiple-scopes" ~category:"deprecated"
-         (fun () -> strbrk "Binding a scope to several types at the same time is deprecated.")
-
 }
 
 (* Modules and Sections *)
@@ -1123,9 +1119,8 @@ GRAMMAR EXTEND Gram
 	 { VernacDelimiters (sc, None) }
 
      | IDENT "Bind"; IDENT "Scope"; sc = IDENT; "with";
-       refl = LIST1 class_rawexpr ->
-         { if List.length refl > 1 then warn_deprecated_bind_several_scopes ();
-           VernacBindScope (sc,refl) }
+       refl = class_rawexpr ->
+         { VernacBindScope (sc,[refl]) }
 
      | IDENT "Infix"; op = ne_lstring; ":="; p = constr;
          modl = [ "("; l = LIST1 syntax_modifier SEP ","; ")" -> { l } | -> { [] } ];

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -490,6 +490,10 @@ let warn_deprecated_include_type =
   CWarnings.create ~name:"deprecated-include-type" ~category:"deprecated"
          (fun () -> strbrk "Include Type is deprecated; use Include instead")
 
+let warn_deprecated_bind_several_scopes =
+  CWarnings.create ~name:"deprecated-bind-multiple-scopes" ~category:"deprecated"
+         (fun () -> strbrk "Binding a scope to several types at the same time is deprecated.")
+
 }
 
 (* Modules and Sections *)
@@ -1119,7 +1123,9 @@ GRAMMAR EXTEND Gram
 	 { VernacDelimiters (sc, None) }
 
      | IDENT "Bind"; IDENT "Scope"; sc = IDENT; "with";
-       refl = LIST1 class_rawexpr -> { VernacBindScope (sc,refl) }
+       refl = LIST1 class_rawexpr ->
+         { if List.length refl > 1 then warn_deprecated_bind_several_scopes ();
+           VernacBindScope (sc,refl) }
 
      | IDENT "Infix"; op = ne_lstring; ":="; p = constr;
          modl = [ "("; l = LIST1 syntax_modifier SEP ","; ")" -> { l } | -> { [] } ];


### PR DESCRIPTION
**Kind:** removal of undocumented deprecated syntax

This is a following of #7762, which it includes, targetting _8.10_.

- [X] Entry added in CHANGES.
