### PR TITLE
Make coqpp handle OCaml locations

### DIFF
--- a/coqpp/coqpp_ast.mli
+++ b/coqpp/coqpp_ast.mli
@@ -11,7 +11,7 @@ type loc = {
   loc_end : Lexing.position;
 }
 
-type code = { code : string }
+type code = { code : string; loc : loc; }
 
 type user_symbol =
 | Ulist1 of user_symbol


### PR DESCRIPTION
We dump the line number of the quotation and pad it enough so that the error message location corresponds to the one from the code to be preprocessed.

Fixes #8018.