### PR TITLE
[dune] [test-suite] Support for running the test suite with Dune.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -321,6 +321,19 @@ test-suite:edge+flambda:
     OPAM_SWITCH: edge
     OPAM_VARIANT: "+flambda"
 
+test-suite:egde:dune:dev:
+  stage: test
+  dependencies:
+    - build:egde:dune:dev
+  script: make -f Makefile.dune test-suite
+  variables:
+    OPAM_SWITCH: edge
+  artifacts:
+    name: "$CI_JOB_NAME.logs"
+    when: on_failure
+    paths:
+      - _build/default/test-suite/logs
+
 validate:base:
   <<: *validate-template
   dependencies:

--- a/Makefile.dune
+++ b/Makefile.dune
@@ -1,7 +1,7 @@
 # -*- mode: makefile -*-
 # Dune Makefile for Coq
 
-.PHONY: voboot states world watch release apidoc ocheck ireport clean help
+.PHONY: help voboot states world watch test-suite release apidoc ocheck ireport clean
 
 # use DUNEOPT=--display=short for a more verbose build
 # DUNEOPT=--display=short
@@ -13,6 +13,7 @@ help:
 	@echo "  - states:  build a minimal functional coqtop"
 	@echo "  - world:   build all binaries and libraries"
 	@echo "  - watch:   build all binaries and libraries [continuous build]"
+	@echo "  - test-suite: run Coq's test suite"
 	@echo "  - release: build Coq in release mode"
 	@echo "  - apidoc:  build ML API documentation"
 	@echo "  - ocheck:  build for all supported OCaml versions [requires OPAM]"
@@ -32,6 +33,9 @@ world: voboot
 
 watch: voboot
 	dune build $(DUNEOPT) @install -w
+
+test-suite: voboot
+	dune $(DUNEOPT) runtest
 
 release: voboot
 	dune build $(DUNEOPT) -p coq

--- a/config/dune
+++ b/config/dune
@@ -7,7 +7,7 @@
 ; Dune doesn't use configure's output, but it is still necessary for
 ; some Coq files to work; will be fixed in the future.
 (rule
- (targets coq_config.ml)
+ (targets coq_config.ml Makefile)
  (mode fallback)
  (deps %{project_root}/configure.ml %{project_root}/dev/ocamldebug-coq.run (env_var COQ_CONFIGURE_PREFIX))
  (action (chdir %{project_root} (run %{ocaml} configure.ml -no-ask -native-compiler no))))

--- a/configure.ml
+++ b/configure.ml
@@ -1038,7 +1038,7 @@ let do_one_instdir (var,msg,uservalue,selfcontainedlayout,unixlayout,locallayout
           try Some (Sys.getenv "COQ_CONFIGURE_PREFIX")
           with
           | Not_found when !prefs.interactive -> None
-          | Not_found -> Some "_build/install/default"
+          | Not_found -> Some Sys.(getcwd () ^ "/../install/default")
         end
       | p -> p
     in match uservalue, env_prefix with

--- a/dune
+++ b/dune
@@ -29,3 +29,8 @@
  (targets revision)
  (deps (:rev-script dev/tools/make_git_revision.sh))
  (action (with-stdout-to revision (run %{rev-script}))))
+
+; Use summary.log as the target
+(alias
+ (name runtest)
+ (deps test-suite/summary.log))

--- a/ide/dune
+++ b/ide/dune
@@ -10,6 +10,8 @@
 
 (executable
  (name fake_ide)
+ (public_name fake_ide)
+ (package coqide-server)
  (modules fake_ide)
  (libraries coqide-server.protocol coqide-server.core))
 

--- a/test-suite/dune
+++ b/test-suite/dune
@@ -1,0 +1,73 @@
+(rule
+ (targets summary.log)
+ (deps
+   ; File that should be promoted.
+   misc/universes/all_stdlib.v
+   ; Dependencies of the legacy makefile
+   ../Makefile.common
+   ../config/Makefile
+   ; Stuff for the compat script test
+   ../dev/header.ml
+   ../dev/tools/update-compat.py
+   ../doc/stdlib/index-list.html.template
+   (package coq)
+   ; For fake_ide
+   (package coqide-server)
+   (source_tree .))
+   ; Finer-grained dependencies look like this
+   ; ../tools/CoqMakefile.in
+   ; ../theories/Init/Prelude.vo
+   ; ../theories/Arith/Arith.vo
+   ; ../theories/Arith/Compare.vo
+   ; ../theories/PArith/PArith.vo
+   ; ../theories/QArith/QArith.vo
+   ; ../theories/QArith/Qcanon.vo
+   ; ../theories/ZArith/ZArith.vo
+   ; ../theories/ZArith/Zwf.vo
+   ; ../theories/Sets/Ensembles.vo
+   ; ../theories/Numbers/Natural/Peano/NPeano.vo
+   ; ../theories/Numbers/Cyclic/Int31/Cyclic31.vo
+   ; ../theories/FSets/FMaps.vo
+   ; ../theories/FSets/FSets.vo
+   ; ../theories/MSets/MSets.vo
+   ; ../theories/Compat/Coq87.vo
+   ; ../theories/Compat/Coq88.vo
+   ; ../theories/Relations/Relations.vo
+   ; ../theories/Unicode/Utf8.vo
+   ; ../theories/Program/Program.vo
+   ; ../theories/Classes/EquivDec.vo
+   ; ../theories/Classes/DecidableClass.vo
+   ; ../theories/Classes/SetoidClass.vo
+   ; ../theories/Classes/RelationClasses.vo
+   ; ../theories/Logic/Classical.vo
+   ; ../theories/Logic/Hurkens.vo
+   ; ../theories/Logic/ClassicalFacts.vo
+   ; ../theories/Reals/Reals.vo
+   ; ../theories/Lists/Streams.vo
+   ; ../plugins/micromega/Lia.vo
+   ; ../plugins/micromega/Lqa.vo
+   ; ../plugins/micromega/Psatz.vo
+   ; ../plugins/micromega/MExtraction.vo
+   ; ../plugins/nsatz/Nsatz.vo
+   ; ../plugins/omega/Omega.vo
+   ; ../plugins/ssr/ssrbool.vo
+   ; ../plugins/derive/Derive.vo
+   ; ../plugins/funind/Recdef.vo
+   ; ../plugins/extraction/Extraction.vo
+   ; ../plugins/extraction/ExtrOcamlNatInt.vo
+   ; coqtop
+   ; coqtop.opt
+   ; coqidetop.opt
+   ; coqqueryworker.opt
+   ; coqtacticworker.opt
+   ; coqproofworker.opt
+   ; coqc
+   ; coqchk
+   ; coqdoc
+   ; %{bin:coq_makefile}
+   ; %{bin:fake_ide}
+ (action
+  (progn
+   ; XXX: we will allow to set the NJOBS variable in a future Dune
+   ; version, either by using an env var or by letting Dune set `-j`
+   (run make -j 2 BIN= PRINT_LOGS=1))))

--- a/test-suite/misc/universes/build_all_stdlib.sh
+++ b/test-suite/misc/universes/build_all_stdlib.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+echo "Require $(find ../../../theories ../../../plugins -type f -name "*.v" | \
+        sed 's/^.*\/theories\///' | sed 's/^.*\/plugins\///' | sed 's/\.v$//' | sed 's/\//./g') ."

--- a/test-suite/misc/universes/dune
+++ b/test-suite/misc/universes/dune
@@ -1,0 +1,8 @@
+(rule
+ (targets all_stdlib.v)
+ (deps
+   (source_tree ../../../theories)
+   (source_tree ../../../plugins))
+ (action
+   (with-outputs-to all_stdlib.v
+    (run ./build_all_stdlib.sh))))


### PR DESCRIPTION
This patch adds support to run the test suite from Dune. We depend on the whole `coq` build for now, but ideally, we would run `coqdep` over the test suite to extract proper dependencies.

The PR depends on a few cleanups, but nothing substantial, and IMO it should be fairly close to be ready.

There is indeed the possibility to port some parts of the test suite to Dune or to a different testing framework, but that's not for the immediate future.