### PR TITLE
[dune] [configure] Further tweaks for interactive use.

### DIFF
--- a/Makefile.dune
+++ b/Makefile.dune
@@ -7,9 +7,6 @@
 # DUNEOPT=--display=short
 
 BUILD_CONTEXT=_build/default
-COQ_CONFIGURE_PREFIX?=_build/install/default
-
-export COQ_CONFIGURE_PREFIX
 
 help:
 	@echo "Welcome to Coq's Dune-based build system. Targets are:"

--- a/config/dune
+++ b/config/dune
@@ -10,4 +10,4 @@
  (targets coq_config.ml)
  (mode fallback)
  (deps %{project_root}/configure.ml %{project_root}/dev/ocamldebug-coq.run (env_var COQ_CONFIGURE_PREFIX))
- (action (chdir %{project_root} (run %{ocaml} configure.ml -native-compiler no))))
+ (action (chdir %{project_root} (run %{ocaml} configure.ml -no-ask -native-compiler no))))

--- a/configure.ml
+++ b/configure.ml
@@ -1239,7 +1239,10 @@ let write_configml f =
   pr "\nlet core_src_dirs = [\n%s]\n" core_src_dirs;
   pr "\nlet plugins_dirs = [\n";
 
-  let plugins = Sys.readdir "plugins" in
+  let plugins =
+    try Sys.readdir "plugins"
+    with _ -> [||]
+  in
   Array.sort compare plugins;
   Array.iter
     (fun f ->

--- a/configure.ml
+++ b/configure.ml
@@ -242,6 +242,7 @@ type ide = Opt | Byte | No
 type preferences = {
   prefix : string option;
   local : bool;
+  interactive : bool;
   vmbyteflags : string option;
   custom : bool option;
   bindir : string option;
@@ -279,6 +280,7 @@ module Profiles = struct
 let default = {
   prefix = None;
   local = false;
+  interactive = true;
   vmbyteflags = None;
   custom = None;
   bindir = None;
@@ -331,6 +333,11 @@ end
 
 let prefs = ref Profiles.default
 
+(* Support don't ask *)
+let cprintf x =
+  if !prefs.interactive
+  then cprintf x
+  else Printf.ifprintf stdout x
 
 let get_bool = function
   | "true" | "yes" | "y" | "all" -> true
@@ -366,6 +373,8 @@ let args_options = Arg.align [
     "<dir> Set installation directory to <dir>";
   "-local", arg_set (fun p local -> { p with local }),
     " Set installation directory to the current source tree";
+  "-no-ask", arg_clear (fun p interactive -> { p with interactive }),
+    " Don't ask questions / print variables during configure [questions will be filled with defaults]";
   "-vmbyteflags", arg_string_option (fun p vmbyteflags -> { p with vmbyteflags }),
     "<flags> Comma-separated link flags for the VM of coqtop.byte";
   "-custom", arg_set_option (fun p custom -> { p with custom }),
@@ -1043,7 +1052,9 @@ let do_one_instdir (var,msg,uservalue,selfcontainedlayout,unixlayout,locallayout
       | None ->
         begin
           try Some (Sys.getenv "COQ_CONFIGURE_PREFIX")
-          with Not_found -> None
+          with
+          | Not_found when !prefs.interactive -> None
+          | Not_found -> Some "_build/default/install"
         end
       | p -> p
     in match uservalue, env_prefix with
@@ -1144,8 +1155,8 @@ let print_summary () =
   pr "*Warning* To compile the system for a new architecture\n";
   pr "          don't forget to do a 'make clean' before './configure'.\n"
 
-let _ = print_summary ()
-
+let _ =
+  if !prefs.interactive then print_summary ()
 
 (** * Build the dev/ocamldebug-coq file *)
 


### PR DESCRIPTION
These two commits allow to call Dune directly in the Coq repository:
- we don't force the Dune user to set envars anymore in order to use the build system,
- configure doesn't die anymore if the sandbox doesn't contain Coq's stdlib.

See individual commits for details.