### PR TITLE
[ssr] [camlp5] Remove warning from camlp5

### DIFF
--- a/plugins/ssr/ssrparser.ml4
+++ b/plugins/ssr/ssrparser.ml4
@@ -342,7 +342,7 @@ let interp_index ist gl idx =
 
 open Pltac
 
-ARGUMENT EXTEND ssrindex TYPED AS ssrindex PRINTED BY pr_ssrindex
+ARGUMENT EXTEND ssrindex PRINTED BY pr_ssrindex
   INTERPRETED BY interp_index
 | [ int_or_var(i) ] -> [ mk_index ~loc i ]
 END


### PR DESCRIPTION
Current compilation of ssrparser.ml4 produces:

```
       coqp5 plugins/ssr/ssrparser.ml
Redundant [TYPED AS] clause in [ARGUMENT EXTEND ssrindex].
```

the solution is easy.
