### PR TITLE
Remove {Safe_typing,Global}.push_context

### DIFF
--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -273,7 +273,6 @@ let add_constraints_list cst senv =
   List.fold_left (fun acc c -> add_constraints c acc) senv cst
 
 let push_context_set poly ctx = add_constraints (Now (poly,ctx))
-let push_context poly ctx = add_constraints (Now (poly,Univ.ContextSet.of_context ctx))
 
 let is_curmod_library senv =
   match senv.modvariant with LIBRARY -> true | _ -> false

--- a/kernel/safe_typing.mli
+++ b/kernel/safe_typing.mli
@@ -128,9 +128,6 @@ val add_modtype :
 val push_context_set :
   bool -> Univ.ContextSet.t -> safe_transformer0
 
-val push_context :
-  bool -> Univ.UContext.t -> safe_transformer0
-
 val add_constraints :
   Univ.Constraint.t -> safe_transformer0
 

--- a/library/global.ml
+++ b/library/global.ml
@@ -86,7 +86,6 @@ let push_named_assum a = globalize0 (Safe_typing.push_named_assum a)
 let push_named_def d = globalize0 (Safe_typing.push_named_def d)
 let add_constraints c = globalize0 (Safe_typing.add_constraints c)
 let push_context_set b c = globalize0 (Safe_typing.push_context_set b c)
-let push_context b c = globalize0 (Safe_typing.push_context b c)
 
 let set_engagement c = globalize0 (Safe_typing.set_engagement c)
 let set_typing_flags c = globalize0 (Safe_typing.set_typing_flags c)

--- a/library/global.mli
+++ b/library/global.mli
@@ -49,7 +49,6 @@ val add_mind :
 (** Extra universe constraints *)
 val add_constraints : Univ.Constraint.t -> unit
 
-val push_context : bool -> Univ.UContext.t -> unit
 val push_context_set : bool -> Univ.ContextSet.t -> unit
 
 (** Non-interactive modules and module types *)


### PR DESCRIPTION
Adding a ucontext to the global environment only makes sense
internally when checking a polymorphic constant.
