### PR TITLE
[api] Remove unnecessary type alias introduced in 8.9

### DIFF
--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -42,7 +42,7 @@ let typeclasses_db = "typeclass_instances"
 
 let set_typeclass_transparency c local b = 
   Hints.add_hints ~local [typeclasses_db]
-    (Hints.HintsTransparencyEntry (Vernacexpr.HintsReferences [c], b))
+    (Hints.HintsTransparencyEntry (Hints.HintsReferences [c], b))
     
 let _ =
   Hook.set Typeclasses.add_instance_hint_hook

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -121,11 +121,6 @@ type 'a hint_info_gen = 'a Typeclasses.hint_info_gen =
 type hint_info_expr = Hints.hint_info_expr
 [@@ocaml.deprecated "Please use [Hints.hint_info_expr]"]
 
-type 'a hints_transparency_target = 'a Hints.hints_transparency_target =
-  | HintsVariables
-  | HintsConstants
-  | HintsReferences of 'a list
-
 type hints_expr = Hints.hints_expr =
   | HintsResolve of (Hints.hint_info_expr * bool * Hints.reference_or_constr) list
         [@ocaml.deprecated "Use the constructor in module [Hints]"]
@@ -135,7 +130,7 @@ type hints_expr = Hints.hints_expr =
         [@ocaml.deprecated "Use the constructor in module [Hints]"]
   | HintsUnfold of qualid list
         [@ocaml.deprecated "Use the constructor in module [Hints]"]
-  | HintsTransparency of qualid hints_transparency_target * bool
+  | HintsTransparency of qualid Hints.hints_transparency_target * bool
         [@ocaml.deprecated "Use the constructor in module [Hints]"]
   | HintsMode of qualid * Hints.hint_mode list
                    [@ocaml.deprecated "Use the constructor in module [Hints]"]


### PR DESCRIPTION
This was introduced in #7820 and it is not needed indeed. As 8.9 was
not released we don't need to perform a deprecation phase.
