### PR TITLE
[dune] Allow to build CI after a Dune build.

### DIFF
--- a/dev/ci/ci-common.sh
+++ b/dev/ci/ci-common.sh
@@ -8,6 +8,7 @@ export NJOBS
 
 if [ -n "${GITLAB_CI}" ];
 then
+    # Gitlab build, Coq installed into `_install_ci`
     export OCAMLPATH="$PWD/_install_ci/lib:$OCAMLPATH"
     export COQBIN="$PWD/_install_ci/bin"
     export CI_BRANCH="$CI_COMMIT_REF_NAME"
@@ -15,18 +16,29 @@ then
     then
         export CI_PULL_REQUEST="${CI_BRANCH#pr-}"
     fi
-else
-    if [ -n "${TRAVIS}" ];
-    then
-        export CI_PULL_REQUEST="$TRAVIS_PULL_REQUEST"
-        export CI_BRANCH="$TRAVIS_BRANCH"
-    else # assume local
-        CI_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
-        export CI_BRANCH
-    fi
+elif [ -n "${TRAVIS}" ];
+then
+    # Travis build, `-local` passed to `configure`
     export OCAMLPATH="$PWD:$OCAMLPATH"
     export COQBIN="$PWD/bin"
+    export CI_PULL_REQUEST="$TRAVIS_PULL_REQUEST"
+    export CI_BRANCH="$TRAVIS_BRANCH"
+elif [ -d "$PWD/_build/install/default/" ];
+then
+    # Dune build
+    export OCAMLPATH="$PWD/_build/install/default/lib/"
+    export COQBIN="$PWD/_build/install/default/bin"
+    export COQLIB="$PWD/_build/install/default/lib/coq"
+    CI_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+    export CI_BRANCH
+else
+    # We assume we are in `-profile devel` build, thus `-local` is set
+    export OCAMLPATH="$PWD:$OCAMLPATH"
+    export COQBIN="$PWD/bin"
+    CI_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+    export CI_BRANCH
 fi
+
 export PATH="$COQBIN:$PATH"
 
 # Coq's tools need an ending slash :S, we should fix them.

--- a/lib/system.ml
+++ b/lib/system.ml
@@ -302,10 +302,10 @@ let with_time ~batch f x =
     raise e
 
 (* We use argv.[0] as we don't want to resolve symlinks *)
-let get_toplevel_path top =
+let get_toplevel_path ?(byte=not Dynlink.is_native) top =
   let open Filename in
   let dir = if String.equal (basename Sys.argv.(0)) Sys.argv.(0)
             then "" else dirname Sys.argv.(0) ^ dir_sep in
   let exe = if Sys.(os_type = "Win32" || os_type = "Cygwin") then ".exe" else "" in
-  let eff = if Dynlink.is_native then ".opt" else ".byte" in
+  let eff = if byte then ".byte" else ".opt" in
   dir ^ top ^ eff ^ exe

--- a/lib/system.mli
+++ b/lib/system.mli
@@ -122,4 +122,4 @@ val with_time : batch:bool -> ('a -> 'b) -> 'a -> 'b
  the right name you want you execution to fail rather than fall into
  choosing some random binary from the system-wide installation of
  Coq. *)
-val get_toplevel_path : string -> string
+val get_toplevel_path : ?byte:bool -> string -> string

--- a/tools/coqc.ml
+++ b/tools/coqc.ml
@@ -24,7 +24,7 @@
 
 let environment = Unix.environment ()
 
-let binary = ref "coqtop"
+let use_bytecode = ref false
 let image = ref ""
 
 let verbose = ref false
@@ -69,8 +69,8 @@ let parse_args () =
 	verbose := true ; parse (cfiles,args) rem
     | "-image" :: f :: rem -> image := f; parse (cfiles,args) rem
     | "-image" :: [] ->	usage ()
-    | "-byte" :: rem -> binary := "coqtop.byte"; parse (cfiles,args) rem
-    | "-opt" :: rem -> binary := "coqtop"; parse (cfiles,args) rem
+    | "-byte" :: rem -> use_bytecode := true; parse (cfiles,args) rem
+    | "-opt" :: rem -> use_bytecode := false; parse (cfiles,args) rem
 
 (* Informative options *)
 
@@ -155,7 +155,7 @@ let main () =
     end;
     let coqtopname =
       if !image <> "" then !image
-      else Filename.concat Envars.coqbin (!binary ^ Coq_config.exec_extension)
+      else System.get_toplevel_path ~byte:!use_bytecode "coqtop"
     in
       (*  List.iter (compile coqtopname args) cfiles*)
       Unix.handle_unix_error (compile coqtopname args) cfiles

--- a/topbin/dune
+++ b/topbin/dune
@@ -1,6 +1,10 @@
+(install
+ (section bin)
+ (files (coqtop_bin.exe as coqtop)))
+
 (executable
  (name coqtop_bin)
- (public_name coqtop)
+ (public_name coqtop.opt)
  (package coq)
  (modules coqtop_bin)
  (libraries coq.toplevel)


### PR DESCRIPTION
This PR allows to perform `make ci-$pkg` after building Coq with Dune.

It surely needs refinement and there are some plugins that won't build [due to makefile hacks?] but it should be a good base to start with.