### PR TITLE
[dune] Build also API documentation for plugins, improve ugly hack.

### DIFF
--- a/Makefile.dune
+++ b/Makefile.dune
@@ -34,10 +34,10 @@ watch: voboot
 release: voboot
 	dune build $(DUNEOPT) -p coq
 
-apidoc:
+apidoc: voboot
         # Ugly workaround for https://github.com/ocaml/odoc/issues/148
 	mv checker/dune checker/dune.disabled || true
-	dune build $(DUNEOPT) @doc
+	dune build $(DUNEOPT) @doc || ( mv checker/dune.disabled checker/dune && false )
 	mv checker/dune.disabled checker/dune || true
 
 clean:


### PR DESCRIPTION
IMHO we'd like to build documentation for plugins too, so we need to
run `voboot` before `apidoc` then.

We also try to make the horrendous hack to avoid `odoc` dying more
robust; suggestions on how to improve it welcome.
