### PR TITLE
Simplify declaration of universe names

### DIFF
--- a/library/nametab.ml
+++ b/library/nametab.ml
@@ -30,6 +30,9 @@ let error_global_not_found qid =
 *)
 type visibility = Until of int | Exactly of int
 
+let map_visibility f = function
+  | Until i -> Until (f i)
+  | Exactly i -> Exactly (f i)
 
 (* Data structure for nametabs *******************************************)
 

--- a/library/nametab.mli
+++ b/library/nametab.mli
@@ -75,6 +75,8 @@ val error_global_not_found : qualid -> 'a
 
 type visibility = Until of int | Exactly of int
 
+val map_visibility : (int -> int) -> visibility -> visibility
+
 val push : visibility -> full_path -> GlobRef.t -> unit
 val push_modtype : visibility -> full_path -> ModPath.t -> unit
 val push_dir : visibility -> DirPath.t -> global_dir_reference -> unit


### PR DESCRIPTION
Declaring the universe to the kernel/section mechanism is centralized
to [Declare.declare_universe_context].
Then the universe name object really is only about the user visible
names.
