### PR TITLE
Functionalizing calls to the environment in Himsg

### DIFF
--- a/pretyping/indrec.mli
+++ b/pretyping/indrec.mli
@@ -20,7 +20,7 @@ type recursion_scheme_error =
   | NotMutualInScheme of inductive * inductive
   | NotAllowedDependentAnalysis of (*isrec:*) bool * inductive
 
-exception RecursionSchemeError of recursion_scheme_error
+exception RecursionSchemeError of env * recursion_scheme_error
 
 (** Eliminations *)
 

--- a/tactics/inv.ml
+++ b/tactics/inv.ml
@@ -495,7 +495,7 @@ let raw_inversion inv_kind id status names =
 (* Error messages of the inversion tactics *)
 let wrap_inv_error id = function (e, info) -> match e with
   | Indrec.RecursionSchemeError
-      (Indrec.NotAllowedCaseAnalysis (_,(Type _ | Set as k),i)) ->
+      (_, Indrec.NotAllowedCaseAnalysis (_,(Type _ | Set as k),i)) ->
       Proofview.tclENV >>= fun env ->
       Proofview.tclEVARMAP >>= fun sigma ->
       tclZEROMSG (

--- a/vernac/explainErr.ml
+++ b/vernac/explainErr.ml
@@ -76,8 +76,8 @@ let process_vernac_interp_error exn = match fst exn with
       wrap_vernac_error exn (Himsg.explain_module_error e)
   | Modintern.ModuleInternalizationError e ->
       wrap_vernac_error exn (Himsg.explain_module_internalization_error e)
-  | RecursionSchemeError e ->
-      wrap_vernac_error exn (Himsg.explain_recursion_scheme_error e)
+  | RecursionSchemeError (env,e) ->
+      wrap_vernac_error exn (Himsg.explain_recursion_scheme_error env e)
   | Cases.PatternMatchingError (env,sigma,e) ->
       wrap_vernac_error exn (Himsg.explain_pattern_matching_error env sigma e)
   | Tacred.ReductionTacticError e ->

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -601,12 +601,12 @@ let explain_var_not_found env id =
   spc () ++ str "in the current" ++ spc () ++ str "environment" ++ str "."
 
 let explain_wrong_case_info env (ind,u) ci =
-  let pi = pr_inductive (Global.env()) ind in
+  let pi = pr_inductive env ind in
   if eq_ind ci.ci_ind ind then
     str "Pattern-matching expression on an object of inductive type" ++
     spc () ++ pi ++ spc () ++ str "has invalid information."
   else
-    let pc = pr_inductive (Global.env()) ci.ci_ind in
+    let pc = pr_inductive env ci.ci_ind in
     str "A term of inductive type" ++ spc () ++ pi ++ spc () ++
     str "was given to a pattern-matching expression on the inductive type" ++
     spc () ++ pc ++ str "."
@@ -1156,24 +1156,24 @@ let error_large_non_prop_inductive_not_in_type () =
 
 (* Recursion schemes errors *)
 
-let error_not_allowed_case_analysis isrec kind i =
+let error_not_allowed_case_analysis env isrec kind i =
   str (if isrec then "Induction" else "Case analysis") ++
   strbrk " on sort " ++ pr_sort Evd.empty kind ++
   strbrk " is not allowed for inductive definition " ++
-  pr_inductive (Global.env()) (fst i) ++ str "."
+  pr_inductive env (fst i) ++ str "."
 
-let error_not_allowed_dependent_analysis isrec i =
+let error_not_allowed_dependent_analysis env isrec i =
   str "Dependent " ++ str (if isrec then "induction" else "case analysis") ++
   strbrk " is not allowed for inductive definition " ++
-  pr_inductive (Global.env()) i ++ str "."
+  pr_inductive env i ++ str "."
 
-let error_not_mutual_in_scheme ind ind' =
+let error_not_mutual_in_scheme env ind ind' =
   if eq_ind ind ind' then
-    str "The inductive type " ++ pr_inductive (Global.env()) ind ++
+    str "The inductive type " ++ pr_inductive env ind ++
     str " occurs twice."
   else
-    str "The inductive types " ++ pr_inductive (Global.env()) ind ++ spc () ++
-    str "and" ++ spc () ++ pr_inductive (Global.env()) ind' ++ spc () ++
+    str "The inductive types " ++ pr_inductive env ind ++ spc () ++
+    str "and" ++ spc () ++ pr_inductive env ind' ++ spc () ++
     str "are not mutually defined."
 
 (* Inductive constructions errors *)
@@ -1194,12 +1194,12 @@ let explain_inductive_error = function
 
 (* Recursion schemes errors *)
 
-let explain_recursion_scheme_error = function
+let explain_recursion_scheme_error env = function
   | NotAllowedCaseAnalysis (isrec,k,i) ->
-      error_not_allowed_case_analysis isrec k i
-  | NotMutualInScheme (ind,ind')-> error_not_mutual_in_scheme ind ind'
+      error_not_allowed_case_analysis env isrec k i
+  | NotMutualInScheme (ind,ind')-> error_not_mutual_in_scheme env ind ind'
   | NotAllowedDependentAnalysis (isrec, i) ->
-     error_not_allowed_dependent_analysis isrec i
+     error_not_allowed_dependent_analysis env isrec i
 
 (* Pattern-matching errors *)
 

--- a/vernac/himsg.mli
+++ b/vernac/himsg.mli
@@ -29,7 +29,7 @@ val explain_mismatched_contexts : env -> contexts -> Constrexpr.constr_expr list
 
 val explain_typeclass_error : env -> typeclass_error -> Pp.t
 
-val explain_recursion_scheme_error : recursion_scheme_error -> Pp.t
+val explain_recursion_scheme_error : env -> recursion_scheme_error -> Pp.t
 
 val explain_refiner_error : env -> Evd.evar_map -> refiner_error -> Pp.t
 


### PR DESCRIPTION
This shall eventually allow to call Himsg at any point of the execution, independently of the exact current global environment.

This is a small step in direction of better controlling the flow of exceptions in error reporting.

For instance, we turn exceptions into messages in at (presumably) a very precise point of the execution while we could process all kinds of errors, and not only the one dealt with `process_vernac_interp_error` at the same phase (i.e. typically in the `CErrors.iprint` of `vernac_loop`, as far as I understand at the current time).

<!-- Keep what applies -->
**Kind:** infrastructure.