### PR TITLE
Replacing Refine.pr_constr by Termops.Internal.print_constr.

### DIFF
--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -87,7 +87,6 @@ let pr_leconstr_core = Proof_diffs.pr_leconstr_core
 let pr_constr_n_env env sigma n c = pr_econstr_n_core false env sigma n (EConstr.of_constr c)
 let pr_lconstr_env = Proof_diffs.pr_lconstr_env
 let pr_constr_env env sigma c = pr_econstr_core false env sigma (EConstr.of_constr c)
-let _ = Hook.set Refine.pr_constr pr_constr_env
 
 let pr_lconstr_goal_style_env env sigma c = pr_leconstr_core true env sigma (EConstr.of_constr c)
 let pr_constr_goal_style_env env sigma c = pr_econstr_core true env sigma (EConstr.of_constr c)

--- a/proofs/refine.ml
+++ b/proofs/refine.ml
@@ -44,9 +44,6 @@ let typecheck_evar ev env sigma =
   let sigma, _ = Typing.sort_of env sigma (Evd.evar_concl info) in
   sigma
 
-let (pr_constrv,pr_constr) =
-  Hook.make ~default:(fun _env _sigma _c -> Pp.str"<constr>") ()
-
 (* Get the side-effect's constant declarations to update the monad's
   * environmnent *)
 let add_if_undefined env eff =
@@ -111,7 +108,7 @@ let generic_refine ~typecheck f gl =
   let sigma = CList.fold_left Proofview.Unsafe.mark_as_goal sigma comb in
   let comb = CList.map (fun x -> Proofview.goal_with_state x state) comb in
   let trace () = Pp.(hov 2 (str"simple refine"++spc()++
-                            Hook.get pr_constrv env sigma (EConstr.Unsafe.to_constr c))) in
+                            Termops.Internal.print_constr_env env sigma c)) in
   Proofview.Trace.name_tactic trace (Proofview.tclUNIT v) >>= fun v ->
   Proofview.Unsafe.tclSETENV (Environ.reset_context env) <*>
   Proofview.Unsafe.tclEVARS sigma <*>

--- a/proofs/refine.mli
+++ b/proofs/refine.mli
@@ -17,10 +17,6 @@ open Proofview
 
 (** {6 The refine tactic} *)
 
-(** Printer used to print the constr which refine refines. *)
-val pr_constr :
-  (Environ.env -> Evd.evar_map -> Constr.constr -> Pp.t) Hook.t
-
 (** {7 Refinement primitives} *)
 
 val refine : typecheck:bool -> (Evd.evar_map -> Evd.evar_map * EConstr.t) -> unit tactic


### PR DESCRIPTION
**Kind:** infrastructure.

This is a very short PR, removing the redundant `Refine.pr_constr` hook.