### PR TITLE
[dune] Enable warning 60 [unused local module]

### DIFF
--- a/dune-workspace
+++ b/dune-workspace
@@ -2,5 +2,5 @@
 
 ; Add custom flags here. Default developer profile is `dev`
 (env
- (dev     (flags :standard -rectypes -w -9-27-50))
+ (dev     (flags :standard -rectypes -w -9-27-50+60))
  (release (flags :standard -rectypes)))


### PR DESCRIPTION
This corrects a discrepancy with the make-based system.
