### PR TITLE
Making printing functions dependent on global state + making impargs table functional

### DIFF
--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -299,8 +299,8 @@ let add_cpatt_for_params ind l =
   if !Flags.in_debugger then l else
     Util.List.addn  (Inductiveops.inductive_nparamdecls ind) (DAst.make @@ PatVar Anonymous) l
 
-let drop_implicits_in_patt cst nb_expl args =
-  let impl_st = (implicits_of_global cst) in
+let drop_implicits_in_patt state cst nb_expl args =
+  let impl_st = implicits_of_global (project_impargs state) cst in
   let impl_data = extract_impargs_data impl_st in
   let rec impls_fit l = function
     |[],t -> Some (List.rev_append l t)
@@ -367,8 +367,8 @@ let mkPat ?loc qid l = CAst.make ?loc @@
   (* Normally irrelevant test with v8 syntax, but let's do it anyway *)
   if List.is_empty l then CPatAtom (Some qid) else CPatCstr (qid,None,l)
 
-let pattern_printable_in_both_syntax (ind,_ as c) =
-  let impl_st = extract_impargs_data (implicits_of_global (ConstructRef c)) in
+let pattern_printable_in_both_syntax state (ind,_ as c) =
+  let impl_st = extract_impargs_data (implicits_of_global (project_impargs state) (ConstructRef c)) in
   let nb_params = Inductiveops.inductive_nparams ind in
   List.exists (fun (_,impls) ->
     (List.length impls >= nb_params) &&
@@ -433,12 +433,12 @@ let rec extern_cases_pattern_in_scope state (custom,scopes as allscopes) vars pa
 		Not_found | No_match | Exit ->
                   let c = extern_reference Id.Set.empty (ConstructRef cstrsp) in
                   if !asymmetric_patterns then
-                    if pattern_printable_in_both_syntax cstrsp
+                    if pattern_printable_in_both_syntax state cstrsp
 		    then CPatCstr (c, None, args)
 		    else CPatCstr (c, Some (add_patt_for_params (fst cstrsp) args), [])
 		  else
 		    let full_args = add_patt_for_params (fst cstrsp) args in
-                    match drop_implicits_in_patt (ConstructRef cstrsp) 0 full_args with
+                    match drop_implicits_in_patt state (ConstructRef cstrsp) 0 full_args with
 		      | Some true_args -> CPatCstr (c, None, true_args)
 		      | None           -> CPatCstr (c, Some full_args, [])
           in
@@ -472,7 +472,7 @@ and apply_notation_to_pattern ?loc state gr ((subst,substlist),(nb_to_drop,more_
             let l2 = List.map (extern_cases_pattern_in_scope state allscopes vars) more_args in
             let l2' = if !asymmetric_patterns || not (List.is_empty ll) then l2
 	      else
-                match drop_implicits_in_patt gr nb_to_drop l2 with
+                match drop_implicits_in_patt state gr nb_to_drop l2 with
 		  |Some true_args -> true_args
 		  |None -> raise No_match
 	    in
@@ -489,7 +489,7 @@ and apply_notation_to_pattern ?loc state gr ((subst,substlist),(nb_to_drop,more_
       let l2 = List.map (extern_cases_pattern_in_scope state allscopes vars) more_args in
       let l2' = if !asymmetric_patterns then l2
 	else
-          match drop_implicits_in_patt gr (nb_to_drop + List.length l1) l2 with
+          match drop_implicits_in_patt state gr (nb_to_drop + List.length l1) l2 with
 	    |Some true_args -> true_args
 	    |None -> raise No_match
       in
@@ -537,7 +537,7 @@ let extern_ind_pattern_in_scope state (custom,scopes as allscopes) vars ind args
     with No_match ->
       let c = extern_reference vars (IndRef ind) in
       let args = List.map (extern_cases_pattern_in_scope state allscopes vars) args in
-      match drop_implicits_in_patt (IndRef ind) 0 args with
+      match drop_implicits_in_patt state (IndRef ind) 0 args with
 	   |Some true_args -> CAst.make @@ CPatCstr (c, None, true_args)
 	   |None           -> CAst.make @@ CPatCstr (c, Some args, [])
 
@@ -757,8 +757,8 @@ let extern_universes = function
   | Some _ as l when !print_universes -> l
   | _ -> None
 
-let extern_ref vars ref us =
-  extern_global (select_stronger_impargs (implicits_of_global ref))
+let extern_ref state vars ref us =
+  extern_global (select_stronger_impargs (implicits_of_global (project_impargs state) ref))
     (extern_reference vars ref) (extern_universes us)
 
 let extern_var ?loc id = CRef (qualid_of_ident ?loc id,None)
@@ -776,7 +776,7 @@ let rec extern state inctx scopes vars r =
   with No_match ->
   let loc = r'.CAst.loc in
   match DAst.get r' with
-  | GRef (ref,us) when entry_has_global (fst scopes) -> CAst.make ?loc (extern_ref vars ref us)
+  | GRef (ref,us) when entry_has_global (fst scopes) -> CAst.make ?loc (extern_ref state vars ref us)
 
   | GVar id when entry_has_ident (fst scopes) -> CAst.make ?loc (extern_var ?loc id)
 
@@ -791,7 +791,7 @@ let rec extern state inctx scopes vars r =
 
   (* The remaining cases are only for the constr entry *)
 
-  | GRef (ref,us) -> extern_ref vars ref us
+  | GRef (ref,us) -> extern_ref state vars ref us
 
   | GVar id -> extern_var ?loc id
 
@@ -854,7 +854,7 @@ let rec extern state inctx scopes vars r =
 		 | Not_found | No_match | Exit ->
                     let args = extern_args (extern state true) vars args in
 		     extern_app inctx
-                       (select_stronger_impargs (implicits_of_global ref))
+                       (select_stronger_impargs (implicits_of_global (project_impargs state) ref))
                        (Some ref,extern_reference ?loc vars ref) (extern_universes us) args
 	     end
 
@@ -1080,7 +1080,7 @@ and extern_notation state (custom,scopes as allscopes) vars t = function
 	          let impls =
 		    let impls =
 		      select_impargs_size
-                        (List.length args) (implicits_of_global ref) in
+                        (List.length args) (implicits_of_global (project_impargs state) ref) in
 		    try List.skipn n impls with Failure _ -> [] in
                   subscopes,impls
                 | _ ->
@@ -1093,7 +1093,7 @@ and extern_notation state (custom,scopes as allscopes) vars t = function
 	      let subscopes = find_arguments_scope ref in
 	      let impls =
 		  select_impargs_size
-                    (List.length args) (implicits_of_global ref) in
+                    (List.length args) (implicits_of_global (project_impargs state) ref) in
 	      f, args, subscopes, impls
             | _ -> t, [], [], []
             end

--- a/interp/constrextern.mli
+++ b/interp/constrextern.mli
@@ -9,7 +9,6 @@
 (************************************************************************)
 
 open Names
-open Termops
 open EConstr
 open Environ
 open Libnames
@@ -23,12 +22,12 @@ open Ltac_pretype
 (** Translation of pattern, cases pattern, glob_constr and term into syntax
    trees for printing *)
 
-val extern_cases_pattern : Id.Set.t -> 'a cases_pattern_g -> cases_pattern_expr
-val extern_glob_constr : Id.Set.t -> 'a glob_constr_g -> constr_expr
-val extern_glob_type : Id.Set.t -> 'a glob_constr_g -> constr_expr
-val extern_constr_pattern : names_context -> Evd.evar_map ->
+val extern_cases_pattern : States.state -> Id.Set.t -> 'a cases_pattern_g -> cases_pattern_expr
+val extern_glob_constr : States.state -> env -> 'a glob_constr_g -> constr_expr
+val extern_glob_type : States.state -> env -> 'a glob_constr_g -> constr_expr
+val extern_constr_pattern : States.state -> env -> Evd.evar_map ->
   constr_pattern -> constr_expr
-val extern_closed_glob : ?lax:bool -> bool -> env -> Evd.evar_map -> closed_glob_constr -> constr_expr
+val extern_closed_glob : ?lax:bool -> bool -> States.state -> env -> Evd.evar_map -> closed_glob_constr -> constr_expr
 
 (** If [b=true] in [extern_constr b env c] then the variables in the first
    level of quantification clashing with the variables in [env] are renamed.
@@ -36,12 +35,12 @@ val extern_closed_glob : ?lax:bool -> bool -> env -> Evd.evar_map -> closed_glob
     env, sigma
 *)
 
-val extern_constr : ?lax:bool -> bool -> env -> Evd.evar_map -> constr -> constr_expr
-val extern_constr_in_scope : bool -> scope_name -> env -> Evd.evar_map -> constr -> constr_expr
+val extern_constr : ?lax:bool -> bool -> States.state -> env -> Evd.evar_map -> constr -> constr_expr
+val extern_constr_in_scope : bool -> scope_name -> States.state -> env -> Evd.evar_map -> constr -> constr_expr
 val extern_reference : ?loc:Loc.t -> Id.Set.t -> GlobRef.t -> qualid
-val extern_type : bool -> env -> Evd.evar_map -> types -> constr_expr
+val extern_type : bool -> States.state -> env -> Evd.evar_map -> types -> constr_expr
 val extern_sort : Evd.evar_map -> Sorts.t -> glob_sort
-val extern_rel_context : constr option -> env -> Evd.evar_map ->
+val extern_rel_context : constr option -> States.state -> env -> Evd.evar_map ->
   rel_context -> local_binder_expr list
 
 (** Printing options *)

--- a/interp/impargs.mli
+++ b/interp/impargs.mli
@@ -12,6 +12,12 @@ open Names
 open EConstr
 open Environ
 
+(** {6 Implicit Arguments state} *)
+
+type impargs_state
+
+val project_impargs : States.state -> impargs_state
+
 (** {6 Implicit Arguments } *)
 (** Here we store the implicit arguments. Notice that we
     are outside the kernel, which knows nothing about implicit arguments. *)
@@ -118,7 +124,7 @@ val declare_manual_implicits : bool -> GlobRef.t -> ?enriching:bool ->
 val maybe_declare_manual_implicits : bool -> GlobRef.t -> ?enriching:bool ->
   manual_implicits -> unit
 
-val implicits_of_global : GlobRef.t -> implicits_list list
+val implicits_of_global : impargs_state -> GlobRef.t -> implicits_list list
 
 val extract_impargs_data :
   implicits_list list -> ((int * int) option * implicit_status list) list

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -399,7 +399,7 @@ type numeral_notation_error =
   | UnexpectedTerm of Constr.t
   | UnexpectedNonOptionTerm of Constr.t
 
-exception NumeralNotationError of Environ.env * Evd.evar_map * numeral_notation_error
+exception NumeralNotationError of States.state * Environ.env * Evd.evar_map * numeral_notation_error
 
 type numnot_option =
   | Nop
@@ -638,7 +638,9 @@ let rec glob_of_constr ?loc env sigma c = match Constr.kind c with
   | Const (c, _) -> DAst.make ?loc (Glob_term.GRef (ConstRef c, None))
   | Ind (ind, _) -> DAst.make ?loc (Glob_term.GRef (IndRef ind, None))
   | Var id -> DAst.make ?loc (Glob_term.GRef (VarRef id, None))
-  | _ -> Loc.raise ?loc (NumeralNotationError(env,sigma,UnexpectedTerm c))
+  | _ ->
+      let state = States.get_state () in
+      Loc.raise ?loc (NumeralNotationError(state,env,sigma,UnexpectedTerm c))
 
 let no_such_number ?loc ty =
   CErrors.user_err ?loc
@@ -649,7 +651,9 @@ let interp_option ty ?loc env sigma c =
   match Constr.kind c with
   | App (_Some, [| _; c |]) -> glob_of_constr ?loc env sigma c
   | App (_None, [| _ |]) -> no_such_number ?loc ty
-  | x -> Loc.raise ?loc (NumeralNotationError(env,sigma,UnexpectedNonOptionTerm c))
+  | x ->
+      let state = States.get_state () in
+      Loc.raise ?loc (NumeralNotationError(state,env,sigma,UnexpectedNonOptionTerm c))
 
 let uninterp_option c =
   match Constr.kind c with

--- a/interp/notation.mli
+++ b/interp/notation.mli
@@ -108,7 +108,7 @@ type numeral_notation_error =
   | UnexpectedTerm of Constr.t
   | UnexpectedNonOptionTerm of Constr.t
 
-exception NumeralNotationError of Environ.env * Evd.evar_map * numeral_notation_error
+exception NumeralNotationError of States.state * Environ.env * Evd.evar_map * numeral_notation_error
 
 type numnot_option =
   | Nop

--- a/library/states.ml
+++ b/library/states.ml
@@ -30,6 +30,12 @@ let intern_state s =
   unfreeze (with_magic_number_check (System.intern_state Coq_config.state_magic_number) s);
   Library.overwrite_library_filenames s
 
+let get_state () = freeze ~marshallable:`No
+
+let modify_state tag f =
+  let (fl,fs) = freeze ~marshallable:`No in
+  unfreeze (fl,Summary.modify_summary fs tag (f (Summary.project_from_summary fs tag)))
+
 (* Rollback. *)
 
 let with_state_protection f x =

--- a/library/states.mli
+++ b/library/states.mli
@@ -25,6 +25,11 @@ val unfreeze : state -> unit
 val summary_of_state : state -> Summary.frozen
 val replace_summary : state -> Summary.frozen -> state
 
+(* Alias for Summary.freeze_summaries ~marshallable:`No *)
+val get_state : unit -> state
+
+val modify_state : 'a Summary.Dyn.tag -> ('a -> 'a) -> unit
+
 (** {6 Rollback } *)
 
 (** [with_state_protection f x] applies [f] to [x] and restores the

--- a/plugins/btauto/refl_btauto.ml
+++ b/plugins/btauto/refl_btauto.ml
@@ -213,7 +213,8 @@ module Btauto = struct
         let map_msg (key, v) =
           let b = if v then str "true" else str "false" in
           let sigma, env = Pfedit.get_current_context () in
-          let term = Printer.pr_constr_env env sigma key in
+          let state = States.get_state () in
+          let term = Printer.pr_constr_env state env sigma key in
           term ++ spc () ++ str ":=" ++ spc () ++ b
         in
         let assign = List.map map_msg assign in

--- a/plugins/cc/ccalgo.ml
+++ b/plugins/cc/ccalgo.ml
@@ -28,7 +28,8 @@ let cc_verbose=ref false
 
 let print_constr t =
   let sigma, env = Pfedit.get_current_context () in
-  Printer.pr_econstr_env env sigma t
+  let state = States.get_state () in
+  Printer.pr_econstr_env state env sigma t
 
 let debug x =
   if !cc_verbose then Feedback.msg_debug (x ())

--- a/plugins/cc/cctac.ml
+++ b/plugins/cc/cctac.ml
@@ -442,12 +442,13 @@ let cc_tactic depth additionnal_terms =
 	| Incomplete ->
             let open Glob_term in
             let env = Proofview.Goal.env gl in
+            let state = States.get_state () in
             let terms_to_complete = List.map (build_term_to_complete uf) (epsilons uf) in
             let hole = DAst.make @@ GHole (Evar_kinds.InternalHole, Namegen.IntroAnonymous, None) in
             let pr_missing (c, missing) =
               let c = Detyping.detype Detyping.Now ~lax:true false Id.Set.empty env sigma c in
               let holes = List.init missing (fun _ -> hole) in
-              Printer.pr_glob_constr_env env (DAst.make @@ GApp (c, holes))
+              Printer.pr_glob_constr_env state env (DAst.make @@ GApp (c, holes))
             in
 	    Feedback.msg_info
 	      (Pp.str "Goal is solvable by congruence but some arguments are missing.");

--- a/plugins/firstorder/sequent.ml
+++ b/plugins/firstorder/sequent.ml
@@ -231,7 +231,8 @@ let print_cmap map=
   let print_entry c l s=
     let env = Global.env () in
     let sigma = Evd.from_env env in
-    let xc=Constrextern.extern_constr false env sigma (EConstr.of_constr c) in
+    let state = States.get_state () in
+    let xc=Constrextern.extern_constr false state env sigma (EConstr.of_constr c) in
       str "| " ++
       prlist Printer.pr_global l ++
       str " : " ++

--- a/plugins/funind/glob_term_to_relation.ml
+++ b/plugins/funind/glob_term_to_relation.ml
@@ -311,13 +311,14 @@ let make_discr_match brl =
 (* [build_constructors_of_type] construct the array of pattern of its inductive argument*)
 let build_constructors_of_type ind' argl =
   let env = Global.env() in
+  let state = States.get_state () in
   let (mib,ind) = Inductive.lookup_mind_specif env ind' in
   let npar = mib.Declarations.mind_nparams in
   Array.mapi (fun i _ ->
 		let construct = ind',i+1 in
 		let constructref = ConstructRef(construct) in
 		let _implicit_positions_of_cst =
-                  Impargs.implicits_of_global constructref
+                  Impargs.implicits_of_global (Impargs.project_impargs state) constructref
 		in
 		let cst_narg =
 		  Inductiveops.constructor_nallargs_env

--- a/plugins/funind/indfun_common.ml
+++ b/plugins/funind/indfun_common.ml
@@ -330,15 +330,17 @@ let discharge_Function (_,finfos) =
 
 let pr_ocst c =
   let sigma, env = Pfedit.get_current_context () in
-  Option.fold_right (fun v acc -> Printer.pr_lconstr_env env sigma (mkConst v)) c (mt ())
+  let state = States.get_state () in
+  Option.fold_right (fun v acc -> Printer.pr_lconstr_env state env sigma (mkConst v)) c (mt ())
 
 let pr_info f_info =
   let sigma, env = Pfedit.get_current_context () in
+  let state = States.get_state () in
   str "function_constant := " ++
-  Printer.pr_lconstr_env env sigma (mkConst f_info.function_constant)++ fnl () ++
+  Printer.pr_lconstr_env state env sigma (mkConst f_info.function_constant)++ fnl () ++
   str "function_constant_type := " ++
   (try
-     Printer.pr_lconstr_env env sigma
+     Printer.pr_lconstr_env state env sigma
        (fst (Global.type_of_global_in_context env (ConstRef f_info.function_constant)))
    with e when CErrors.noncritical e -> mt ()) ++ fnl () ++
   str "equation_lemma := " ++ pr_ocst f_info.equation_lemma ++ fnl () ++
@@ -347,7 +349,7 @@ let pr_info f_info =
   str "rect_lemma := " ++ pr_ocst f_info.rect_lemma ++ fnl () ++
   str "rec_lemma := " ++ pr_ocst f_info.rec_lemma ++ fnl () ++
   str "prop_lemma := " ++ pr_ocst f_info.prop_lemma ++ fnl () ++
-  str "graph_ind := " ++ Printer.pr_lconstr_env env sigma (mkInd f_info.graph_ind) ++ fnl ()
+  str "graph_ind := " ++ Printer.pr_lconstr_env state env sigma (mkInd f_info.graph_ind) ++ fnl ()
 
 let pr_table tb =
   let l = Cmap_env.fold (fun k v acc -> v::acc) tb [] in

--- a/plugins/funind/invfun.ml
+++ b/plugins/funind/invfun.ml
@@ -758,6 +758,7 @@ let derive_correctness make_scheme (funs: pconstant list) (graphs:inductive list
   funind_purify
     (fun () ->
      let env = Global.env () in
+     let state = States.get_state () in
      let evd = ref (Evd.from_env env) in 
      let graphs_constr = Array.map mkInd graphs in
      let lemmas_types_infos =
@@ -770,10 +771,10 @@ let derive_correctness make_scheme (funs: pconstant list) (graphs:inductive list
 	 let type_info = (type_of_lemma_ctxt,type_of_lemma_concl) in
 	 graphs_constr.(i) <- graph;
 	 let type_of_lemma = EConstr.it_mkProd_or_LetIn type_of_lemma_concl type_of_lemma_ctxt in
-         let sigma, _ = Typing.type_of (Global.env ()) !evd type_of_lemma in
+         let sigma, _ = Typing.type_of env !evd type_of_lemma in
          evd := sigma;
 	   let type_of_lemma = nf_zeta type_of_lemma in
-	   observe (str "type_of_lemma := " ++ Printer.pr_leconstr_env (Global.env ()) !evd type_of_lemma);
+           observe (str "type_of_lemma := " ++ Printer.pr_leconstr_env state env !evd type_of_lemma);
 	   type_of_lemma,type_info
 	)
 	funs_constr
@@ -840,7 +841,7 @@ let derive_correctness make_scheme (funs: pconstant list) (graphs:inductive list
 	   EConstr.it_mkProd_or_LetIn type_of_lemma_concl type_of_lemma_ctxt
 	 in
 	 let type_of_lemma = nf_zeta type_of_lemma in
-         observe (str "type_of_lemma := " ++ Printer.pr_leconstr_env env !evd type_of_lemma);
+         observe (str "type_of_lemma := " ++ Printer.pr_leconstr_env state env !evd type_of_lemma);
 	 type_of_lemma,type_info
 	)
 	funs_constr

--- a/plugins/ltac/extraargs.ml4
+++ b/plugins/ltac/extraargs.ml4
@@ -137,7 +137,8 @@ let pr_gen prc _prlc _prtac c = prc c
 
 let pr_globc _prc _prlc _prtac (_,glob) =
   let _, env = Pfedit.get_current_context () in
-  Printer.pr_glob_constr_env env glob
+  let state = States.get_state () in
+  Printer.pr_glob_constr_env state env glob
 
 let interp_glob ist gl (t,_) = Tacmach.project gl , (ist,t)
 

--- a/plugins/ltac/extratactics.ml4
+++ b/plugins/ltac/extratactics.ml4
@@ -637,7 +637,7 @@ let hResolve id c occ t =
     try 
       Pretyping.understand env sigma t_hole
     with
-      | Pretype_errors.PretypeError (_,_,Pretype_errors.UnsolvableImplicit _) as e ->
+      | Pretype_errors.PretypeError (_,_,_,Pretype_errors.UnsolvableImplicit _) as e ->
           let (e, info) = CErrors.push e in
           let loc_begin = Option.cata (fun l -> fst (Loc.unloc l)) 0 (Loc.get_loc info) in
           resolve_hole (subst_hole_with_term loc_begin c_raw t_hole)

--- a/plugins/ltac/g_auto.ml4
+++ b/plugins/ltac/g_auto.ml4
@@ -54,10 +54,12 @@ let eval_uconstrs ist cs =
 let pr_auto_using_raw _ _ _  = Pptactic.pr_auto_using Ppconstr.pr_constr_expr
 let pr_auto_using_glob _ _ _ = Pptactic.pr_auto_using (fun (c,_) ->
     let _, env = Pfedit.get_current_context () in
-    Printer.pr_glob_constr_env env c)
+    let state = States.get_state () in
+    Printer.pr_glob_constr_env state env c)
 let pr_auto_using _ _ _ = Pptactic.pr_auto_using
     (let sigma, env = Pfedit.get_current_context () in
-     Printer.pr_closed_glob_env env sigma)
+     let state = States.get_state () in
+     Printer.pr_closed_glob_env state env sigma)
 
 ARGUMENT EXTEND auto_using
   TYPED AS uconstr_list

--- a/plugins/ltac/g_rewrite.ml4
+++ b/plugins/ltac/g_rewrite.ml4
@@ -33,10 +33,12 @@ type glob_constr_with_bindings_sign = interp_sign * Tacexpr.glob_constr_and_expr
 
 let pr_glob_constr_with_bindings_sign _ _ _ (ge : glob_constr_with_bindings_sign) =
   let _, env = Pfedit.get_current_context () in
-  Printer.pr_glob_constr_env env (fst (fst (snd ge)))
+  let state = States.get_state () in
+  Printer.pr_glob_constr_env state env (fst (fst (snd ge)))
 let pr_glob_constr_with_bindings _ _ _ (ge : glob_constr_with_bindings) =
   let _, env = Pfedit.get_current_context () in
-  Printer.pr_glob_constr_env env (fst (fst ge))
+  let state = States.get_state () in
+  Printer.pr_glob_constr_env state env (fst (fst ge))
 let pr_constr_expr_with_bindings prc _ _ (ge : constr_expr_with_bindings) = prc (fst ge)
 let interp_glob_constr_with_bindings ist gl c = Tacmach.project gl , (ist, c)
 let glob_glob_constr_with_bindings ist l = Tacintern.intern_constr_with_bindings ist l
@@ -293,5 +295,6 @@ END
 VERNAC COMMAND EXTEND PrintRewriteHintDb CLASSIFIED AS QUERY
   [ "Print" "Rewrite" "HintDb" preident(s) ] ->
   [ let sigma, env = Pfedit.get_current_context () in
-    Feedback.msg_notice (Autorewrite.print_rewrite_hintdb env sigma s) ]
+    let state = States.get_state () in
+    Feedback.msg_notice (Autorewrite.print_rewrite_hintdb state env sigma s) ]
 END

--- a/plugins/ltac/pptactic.mli
+++ b/plugins/ltac/pptactic.mli
@@ -118,7 +118,7 @@ val pr_glb_generic : env -> glevel generic_argument -> Pp.t
 val pr_raw_extend: env -> int ->
   ml_tactic_entry -> raw_tactic_arg list -> Pp.t
 
-val pr_glob_extend: env -> int ->
+val pr_glob_extend: States.state -> env -> int ->
   ml_tactic_entry -> glob_tactic_arg list -> Pp.t
 
 val pr_extend :
@@ -135,9 +135,9 @@ val pr_raw_tactic : raw_tactic_expr -> Pp.t
 
 val pr_raw_tactic_level : tolerability -> raw_tactic_expr -> Pp.t
 
-val pr_glob_tactic : env -> glob_tactic_expr -> Pp.t
+val pr_glob_tactic : States.state -> env -> glob_tactic_expr -> Pp.t
 
-val pr_atomic_tactic : env -> Evd.evar_map -> atomic_tactic_expr -> Pp.t
+val pr_atomic_tactic : States.state -> env -> Evd.evar_map -> atomic_tactic_expr -> Pp.t
 
 val pr_hintbases : string list option -> Pp.t
 
@@ -153,5 +153,5 @@ val pr_value : tolerability -> Val.t -> Pp.t
 
 val ltop : tolerability
 
-val make_constr_printer : (env -> Evd.evar_map -> tolerability -> 'a -> Pp.t) ->
+val make_constr_printer : (States.state -> env -> Evd.evar_map -> tolerability -> 'a -> Pp.t) ->
   'a Genprint.top_printer

--- a/plugins/ltac/profile_ltac.ml
+++ b/plugins/ltac/profile_ltac.ml
@@ -250,12 +250,12 @@ let string_of_call ck =
        | Tacexpr.LtacNameCall cst -> Pptactic.pr_ltac_constant cst
        | Tacexpr.LtacVarCall (id, t) -> Names.Id.print id
        | Tacexpr.LtacAtomCall te ->
-         (Pptactic.pr_glob_tactic (Global.env ())
+         (Pptactic.pr_glob_tactic (States.get_state()) (Global.env ())
             (Tacexpr.TacAtom (Loc.tag te)))
        | Tacexpr.LtacConstrInterp (c, _) ->
-         pr_glob_constr_env (Global.env ()) c
+         pr_glob_constr_env (States.get_state()) (Global.env ()) c
        | Tacexpr.LtacMLCall te ->
-         (Pptactic.pr_glob_tactic (Global.env ())
+         (Pptactic.pr_glob_tactic (States.get_state()) (Global.env ())
             te)
     ) in
   let s = String.map (fun c -> if c = '\n' then ' ' else c) s in

--- a/plugins/ltac/taccoerce.ml
+++ b/plugins/ltac/taccoerce.ml
@@ -38,7 +38,7 @@ let (wit_constr_under_binders : (Empty.t, Empty.t, Ltac_pretype.constr_under_bin
   let () = register_val0 wit None in
   let () = Genprint.register_val_print0 (base_val_typ wit)
              (fun c ->
-               Genprint.TopPrinterNeedsContext (fun env sigma -> Printer.pr_constr_under_binders_env env sigma c)) in
+               Genprint.TopPrinterNeedsContext (fun state env sigma -> Printer.pr_constr_under_binders_env state env sigma c)) in
   wit
 
 (** All the types considered here are base types *)
@@ -399,14 +399,14 @@ let pr_argument_type arg =
 let pr_value env v =
   let pr_with_env pr =
     match env with
-    | Some (env,sigma) -> pr env sigma
+    | Some (state,env,sigma) -> pr state env sigma
     | None -> str "a value of type" ++ spc () ++ pr_argument_type v in
   let open Genprint in
   match generic_val_print v with
   | TopPrinterBasic pr -> pr ()
   | TopPrinterNeedsContext pr -> pr_with_env pr
   | TopPrinterNeedsContextAndLevel { default_already_surrounded; printer } ->
-     pr_with_env (fun env sigma -> printer env sigma default_already_surrounded)
+     pr_with_env (fun state env sigma -> printer state env sigma default_already_surrounded)
 
 let error_ltac_variable ?loc id env v s =
    CErrors.user_err ?loc  (str "Ltac variable " ++ Id.print id ++

--- a/plugins/ltac/taccoerce.mli
+++ b/plugins/ltac/taccoerce.mli
@@ -95,7 +95,7 @@ val wit_constr_context : (Empty.t, Empty.t, EConstr.constr) genarg_type
 val wit_constr_under_binders : (Empty.t, Empty.t, Ltac_pretype.constr_under_binders) genarg_type
 
 val error_ltac_variable : ?loc:Loc.t -> Id.t ->
-  (Environ.env * Evd.evar_map) option -> Value.t -> string -> 'a
+  (States.state * Environ.env * Evd.evar_map) option -> Value.t -> string -> 'a
 
 (** Abstract application, to print ltac functions *)
 type appl =
@@ -110,4 +110,4 @@ type tacvalue =
 
 val wit_tacvalue : (Empty.t, tacvalue, tacvalue) Genarg.genarg_type
 
-val pr_value : (Environ.env * Evd.evar_map) option -> Geninterp.Val.t -> Pp.t
+val pr_value : (States.state * Environ.env * Evd.evar_map) option -> Geninterp.Val.t -> Pp.t

--- a/plugins/ltac/tacentries.ml
+++ b/plugins/ltac/tacentries.ml
@@ -638,13 +638,14 @@ let lift_constr_tac_to_ml_tac vars tac =
   let tac _ ist = Proofview.Goal.enter begin fun gl ->
     let env = Proofview.Goal.env gl in
     let sigma = Tacmach.New.project gl in
+    let state = States.get_state () in
     let map = function
     | Anonymous -> None
     | Name id ->
       let c = Id.Map.find id ist.Geninterp.lfun in
       try Some (Taccoerce.Value.of_constr @@ Taccoerce.coerce_to_closed_constr env c)
       with Taccoerce.CannotCoerceTo ty ->
-        Taccoerce.error_ltac_variable dummy_id (Some (env,sigma)) c ty
+        Taccoerce.error_ltac_variable dummy_id (Some (state,env,sigma)) c ty
     in
     let args = List.map_filter map vars in
     tac args ist

--- a/plugins/ltac/tacintern.ml
+++ b/plugins/ltac/tacintern.ml
@@ -783,7 +783,7 @@ let print_ltac id =
   hv 2 (
     hov 2 (str "Ltac" ++ spc() ++ pr_qualid id ++
            prlist pr_ltac_fun_arg l ++ spc () ++ str ":=")
-    ++ spc() ++ Pptactic.pr_glob_tactic (Global.env ()) t) ++ redefined
+    ++ spc() ++ Pptactic.pr_glob_tactic (States.get_state ()) (Global.env ()) t) ++ redefined
  with
   Not_found ->
    user_err ~hdr:"print_ltac"

--- a/plugins/ltac/tacinterp.mli
+++ b/plugins/ltac/tacinterp.mli
@@ -128,7 +128,7 @@ val hide_interp : bool -> raw_tactic_expr -> unit Proofview.tactic option -> uni
 (** Internals that can be useful for syntax extensions. *)
 
 val interp_ltac_var : (value -> 'a) -> interp_sign ->
-  (Environ.env * Evd.evar_map) option -> lident -> 'a
+  (States.state * Environ.env * Evd.evar_map) option -> lident -> 'a
 
 val interp_int : interp_sign -> lident -> int
 

--- a/plugins/ltac/tacsubst.ml
+++ b/plugins/ltac/tacsubst.ml
@@ -96,8 +96,9 @@ let subst_global_reference subst =
   let ref',t' = subst_global subst ref in
    if not (is_global ref' t') then
     (let sigma, env = Pfedit.get_current_context () in
+     let state = States.get_state () in
      Feedback.msg_warning (strbrk "The reference " ++ pr_global ref ++ str " is not " ++
-          str " expanded to \"" ++ pr_lconstr_env env sigma t' ++ str "\", but to " ++
+          str " expanded to \"" ++ pr_lconstr_env state env sigma t' ++ str "\", but to " ++
           pr_global ref'));
    ref'
  in

--- a/plugins/ltac/tactic_debug.mli
+++ b/plugins/ltac/tactic_debug.mli
@@ -36,7 +36,7 @@ val debug_prompt :
 val db_initialize : unit Proofview.NonLogical.t
 
 (** Prints a constr *)
-val db_constr : debug_info -> env -> evar_map -> constr -> unit Proofview.NonLogical.t
+val db_constr : debug_info -> States.state -> env -> evar_map -> constr -> unit Proofview.NonLogical.t
 
 (** Prints the pattern rule *)
 val db_pattern_rule :
@@ -44,17 +44,17 @@ val db_pattern_rule :
 
 (** Prints a matched hypothesis *)
 val db_matched_hyp :
-  debug_info -> env -> evar_map -> Id.t * constr option * constr -> Name.t -> unit Proofview.NonLogical.t
+  debug_info -> States.state -> env -> evar_map -> Id.t * constr option * constr -> Name.t -> unit Proofview.NonLogical.t
 
 (** Prints the matched conclusion *)
-val db_matched_concl : debug_info -> env -> evar_map -> constr -> unit Proofview.NonLogical.t
+val db_matched_concl : debug_info -> States.state -> env -> evar_map -> constr -> unit Proofview.NonLogical.t
 
 (** Prints a success message when the goal has been matched *)
 val db_mc_pattern_success : debug_info -> unit Proofview.NonLogical.t
 
 (** Prints a failure message for an hypothesis pattern *)
 val db_hyp_pattern_failure :
-  debug_info -> env -> evar_map -> Name.t * constr_pattern match_pattern -> unit Proofview.NonLogical.t
+  debug_info -> States.state -> env -> evar_map -> Name.t * constr_pattern match_pattern -> unit Proofview.NonLogical.t
 
 (** Prints a matching failure message for a rule *)
 val db_matching_failure : debug_info -> unit Proofview.NonLogical.t

--- a/plugins/ltac/tactic_option.ml
+++ b/plugins/ltac/tactic_option.ml
@@ -47,7 +47,7 @@ let declare_tactic_option ?(default=Tacexpr.TacId []) name =
   in
   let get () = !locality, Tacinterp.eval_tactic !default_tactic in
   let print () = 
-    Pptactic.pr_glob_tactic (Global.env ()) !default_tactic_expr ++
+    Pptactic.pr_glob_tactic (States.get_state ()) (Global.env ()) !default_tactic_expr ++
       (if !locality then str" (locally defined)" else str" (globally defined)")
   in
   put, get, print

--- a/plugins/micromega/coq_micromega.ml
+++ b/plugins/micromega/coq_micromega.ml
@@ -859,7 +859,8 @@ struct
     if debug
     then (
       let _, env = Pfedit.get_current_context () in
-      Feedback.msg_debug (Pp.str "parse_expr: " ++ Printer.pr_leconstr_env env sigma term));
+      let state = States.get_state () in
+      Feedback.msg_debug (Pp.str "parse_expr: " ++ Printer.pr_leconstr_env state env sigma term));
 
 (*
     let constant_or_variable env term =
@@ -980,8 +981,9 @@ struct
 
   let rconstant sigma term =
     let _, env = Pfedit.get_current_context () in
+    let state = States.get_state () in
     if debug
-    then Feedback.msg_debug (Pp.str "rconstant: " ++ Printer.pr_leconstr_env env sigma term ++ fnl ());
+    then Feedback.msg_debug (Pp.str "rconstant: " ++ Printer.pr_leconstr_env state env sigma term ++ fnl ());
     let res = rconstant sigma term in
       if debug then 
 	(Printf.printf "rconstant -> %a\n" pp_Rcst res ; flush stdout) ;
@@ -1022,7 +1024,10 @@ struct
   let  parse_arith parse_op parse_expr env cstr gl =
     let sigma = gl.sigma in
     if debug
-    then Feedback.msg_debug (Pp.str "parse_arith: " ++ Printer.pr_leconstr_env gl.env sigma cstr ++ fnl ());
+    then begin
+      let state = States.get_state () in
+      Feedback.msg_debug (Pp.str "parse_arith: " ++ Printer.pr_leconstr_env state gl.env sigma cstr ++ fnl ())
+      end;
     match EConstr.kind sigma cstr with
     | App(op,args) ->
        let (op,lhs,rhs) = parse_op gl (op,args) in
@@ -1650,7 +1655,8 @@ let micromega_tauto negate normalise unsat deduce spec prover env polys1 polys2 
      let formula_typ = (EConstr.mkApp(Lazy.force coq_Cstr, [|spec.coeff|])) in
      let ff = dump_formula formula_typ
        (dump_cstr spec.typ spec.dump_coeff) ff in
-       Feedback.msg_notice (Printer.pr_leconstr_env gl.env gl.sigma ff);
+     let state = States.get_state () in
+       Feedback.msg_notice (Printer.pr_leconstr_env state gl.env gl.sigma ff);
        Printf.fprintf stdout "cnf : %a\n" (pp_cnf (fun o _ -> ())) cnf_ff
    end;
 
@@ -1675,7 +1681,8 @@ let micromega_tauto negate normalise unsat deduce spec prover env polys1 polys2 
       let formula_typ = (EConstr.mkApp( Lazy.force coq_Cstr,[| spec.coeff|])) in
       let ff' = dump_formula formula_typ
           (dump_cstr spec.typ spec.dump_coeff) ff' in
-      Feedback.msg_notice (Printer.pr_leconstr_env gl.env gl.sigma ff');
+      let state = States.get_state () in
+      Feedback.msg_notice (Printer.pr_leconstr_env state gl.env gl.sigma ff');
       Printf.fprintf stdout "cnf : %a\n" (pp_cnf (fun o _ -> ())) cnf_ff'
     end;
 

--- a/plugins/setoid_ring/g_newring.ml4
+++ b/plugins/setoid_ring/g_newring.ml4
@@ -78,10 +78,11 @@ VERNAC COMMAND EXTEND AddSetoidRing CLASSIFIED AS SIDEFF
     Feedback.msg_notice (strbrk "The following ring structures have been declared:");
     Spmap.iter (fun fn fi ->
       let sigma, env = Pfedit.get_current_context () in
+      let state = States.get_state () in
       Feedback.msg_notice (hov 2
         (Ppconstr.pr_id (Libnames.basename fn)++spc()++
-          str"with carrier "++ pr_constr_env env sigma fi.ring_carrier++spc()++
-          str"and equivalence relation "++ pr_constr_env env sigma fi.ring_req))
+          str"with carrier "++ pr_constr_env state env sigma fi.ring_carrier++spc()++
+          str"and equivalence relation "++ pr_constr_env state env sigma fi.ring_req))
     ) !from_name ]
 END
 
@@ -114,10 +115,11 @@ VERNAC COMMAND EXTEND AddSetoidField CLASSIFIED AS SIDEFF
     Feedback.msg_notice (strbrk "The following field structures have been declared:");
     Spmap.iter (fun fn fi ->
       let sigma, env = Pfedit.get_current_context () in
+      let state = States.get_state () in
       Feedback.msg_notice (hov 2
         (Ppconstr.pr_id (Libnames.basename fn)++spc()++
-          str"with carrier "++ pr_constr_env env sigma fi.field_carrier++spc()++
-          str"and equivalence relation "++ pr_constr_env env sigma fi.field_req))
+          str"with carrier "++ pr_constr_env state env sigma fi.field_carrier++spc()++
+          str"and equivalence relation "++ pr_constr_env state env sigma fi.field_req))
     ) !field_from_name ]
 END
 

--- a/plugins/setoid_ring/newring.ml
+++ b/plugins/setoid_ring/newring.ml
@@ -348,9 +348,10 @@ let find_ring_structure env sigma l =
         List.iter check cl';
         (try ring_for_carrier (EConstr.to_constr sigma ty)
         with Not_found ->
+          let state = States.get_state () in
           CErrors.user_err ~hdr:"ring"
             (str"cannot find a declared ring structure over"++
-             spc() ++ str"\"" ++ pr_econstr_env env sigma ty ++ str"\""))
+             spc() ++ str"\"" ++ pr_econstr_env state env sigma ty ++ str"\""))
     | [] -> assert false
 
 let add_entry (sp,_kn) e =
@@ -513,19 +514,21 @@ let ring_equality env evd (r,add,mul,opp,req) =
 		  op_morph r add mul opp req add_m_lem mul_m_lem opp_m_lem in
 		  Flags.if_verbose
 		    Feedback.msg_info
-                    (str"Using setoid \""++ pr_econstr_env env !evd req++str"\""++spc()++
-                        str"and morphisms \""++pr_econstr_env env !evd add_m_lem ++
-                        str"\","++spc()++ str"\""++pr_econstr_env env !evd mul_m_lem++
-                        str"\""++spc()++str"and \""++pr_econstr_env env !evd opp_m_lem++
+                    (let state = States.get_state () in
+                        str"Using setoid \""++ pr_econstr_env state env !evd req++str"\""++spc()++
+                        str"and morphisms \""++pr_econstr_env state env !evd add_m_lem ++
+                        str"\","++spc()++ str"\""++pr_econstr_env state env !evd mul_m_lem++
+                        str"\""++spc()++str"and \""++pr_econstr_env state env !evd opp_m_lem++
 			str"\"");
 		  op_morph)
             | None ->
 		(Flags.if_verbose
 		    Feedback.msg_info
-                    (str"Using setoid \""++pr_econstr_env env !evd req ++str"\"" ++ spc() ++
-                        str"and morphisms \""++pr_econstr_env env !evd add_m_lem ++
+                    (let state = States.get_state () in
+                        str"Using setoid \""++pr_econstr_env state env !evd req ++str"\"" ++ spc() ++
+                        str"and morphisms \""++pr_econstr_env state env !evd add_m_lem ++
 			str"\""++spc()++str"and \""++
-                        pr_econstr_env env !evd mul_m_lem++str"\"");
+                        pr_econstr_env state env !evd mul_m_lem++str"\"");
 		 op_smorph r add mul req add_m_lem mul_m_lem) in
           (setoid,op_morph)
 
@@ -850,9 +853,10 @@ let find_field_structure env sigma l =
         List.iter check cl';
         (try field_for_carrier (EConstr.to_constr sigma ty)
         with Not_found ->
+          let state = States.get_state () in
           CErrors.user_err ~hdr:"field"
             (str"cannot find a declared field structure over"++
-             spc()++str"\""++pr_econstr_env env sigma ty++str"\""))
+             spc()++str"\""++pr_econstr_env state env sigma ty++str"\""))
     | [] -> assert false
 
 let add_field_entry (sp,_kn) e =

--- a/plugins/ssr/ssrbwd.ml
+++ b/plugins/ssr/ssrbwd.ml
@@ -51,7 +51,7 @@ let interp_agen ist gl ((goclr, _), (k, gc as c)) (clr, rcs) =
         SsrHyp (Loc.tag ?loc id) :: clr', rcs'
     | _ -> clr', rcs'
 
-let pf_pr_glob_constr gl = pr_glob_constr_env (pf_env gl)
+let pf_pr_glob_constr gl = pr_glob_constr_env (States.get_state ()) (pf_env gl)
 
 let interp_nbargs ist gl rc =
   try

--- a/plugins/ssr/ssrelim.ml
+++ b/plugins/ssr/ssrelim.ml
@@ -45,9 +45,10 @@ let analyze_eliminator elimty env sigma =
     let env' = EConstr.push_rel_context ctx env in
     let t' = Reductionops.whd_all env' sigma t in
     if not (EConstr.eq_constr sigma t t') then loop ctx t' else
+      let state = States.get_state () in
       errorstrm Pp.(str"The eliminator has the wrong shape."++spc()++
       str"A (applied) bound variable was expected as the conclusion of "++
-      str"the eliminator's"++Pp.cut()++str"type:"++spc()++pr_econstr_env env' sigma elimty) in
+      str"the eliminator's"++Pp.cut()++str"type:"++spc()++pr_econstr_env state env' sigma elimty) in
   let ctx, pred_id, elim_is_dep, n_pred_args,concl = loop [] elimty in
   let n_elim_args = Context.Rel.nhyps ctx in
   let is_rec_elim = 
@@ -125,7 +126,7 @@ let ssrelim ?(ind=ref None) ?(is_case=false) deps what ?elim eqid elim_intro_tac
     ppdebug(lazy Pp.(str"matching: " ++ pr_occ occ ++ pp_pattern p));
     let (c,ucst), cl =
       fill_occ_pattern ~raise_NoMatch:true env sigma0 (EConstr.Unsafe.to_constr cl) p occ h in
-    ppdebug(lazy Pp.(str"     got: " ++ pr_constr_env env sigma0 c));
+    ppdebug(let state = States.get_state () in lazy Pp.(str"     got: " ++ pr_constr_env state env sigma0 c));
     c, EConstr.of_constr cl, ucst in
   let mkTpat gl t = (* takes a term, refreshes it and makes a T pattern *)
     let n, t, _, ucst = pf_abs_evars orig_gl (project gl, fire_subst gl t) in 
@@ -237,9 +238,10 @@ let ssrelim ?(ind=ref None) ?(is_case=false) deps what ?elim eqid elim_intro_tac
               pf_unify_HO gl c_ty inf_arg_ty) with
       | Some (c, _, _,gl) -> true, gl
       | None ->
+        let state = States.get_state () in
         errorstrm Pp.(str"Unable to apply the eliminator to the term"++
-          spc()++pr_econstr_env env (project gl) c++spc()++str"or to unify it's type with"++
-          pr_econstr_env env (project gl) inf_arg_ty) in
+          spc()++pr_econstr_env state env (project gl) c++spc()++str"or to unify it's type with"++
+          pr_econstr_env state env (project gl) inf_arg_ty) in
   ppdebug(lazy Pp.(str"c_is_head_p= " ++ bool c_is_head_p));
   let gl, predty = pfe_type_of gl pred in
   (* Patterns for the inductive types indexes to be bound in pred are computed

--- a/plugins/ssr/ssrprinters.ml
+++ b/plugins/ssr/ssrprinters.ml
@@ -26,7 +26,8 @@ let pp_concat hd ?(sep=str", ") = function [] -> hd | x :: xs ->
   hd ++ List.fold_left (fun acc x -> acc ++ sep ++ x) x xs
 
 let pp_term gl t =
-  let t = Reductionops.nf_evar (project gl) t in pr_econstr_env (pf_env gl) (project gl) t
+  let state = States.get_state () in
+  let t = Reductionops.nf_evar (project gl) t in pr_econstr_env state (pf_env gl) (project gl) t
 
 (* FIXME *)
 (* terms are pre constr, the kind is parsing/printing flag to distinguish
@@ -58,8 +59,8 @@ let pr_guarded guard prc c =
   if guard s (skip_wschars s 0) then pr_paren prc c else prc c
 
 let prl_constr_expr = Ppconstr.pr_lconstr_expr
-let pr_glob_constr c = Printer.pr_glob_constr_env (Global.env ()) c
-let prl_glob_constr c = Printer.pr_lglob_constr_env (Global.env ()) c
+let pr_glob_constr c = Printer.pr_glob_constr_env (States.get_state ()) (Global.env ()) c
+let prl_glob_constr c = Printer.pr_lglob_constr_env (States.get_state ()) (Global.env ()) c
 let pr_glob_constr_and_expr = function
   | _, Some c -> Ppconstr.pr_constr_expr c
   | c, None -> pr_glob_constr c

--- a/plugins/ssr/ssrvernac.ml4
+++ b/plugins/ssr/ssrvernac.ml4
@@ -149,7 +149,8 @@ let declare_one_prenex_implicit locality f =
       errorstrm (str "Expected prenex implicits for " ++ pr_qualid f)
   | _ -> [] in
   let impls =
-    match Impargs.implicits_of_global fref  with
+    let state = States.get_state () in
+    match Impargs.implicits_of_global (Impargs.project_impargs state) fref  with
     | [cond,impls] -> impls
     | [] -> errorstrm (str "Expected some implicits for " ++ pr_qualid f)
     | _ -> errorstrm (str "Multiple implicits not supported") in

--- a/plugins/ssr/ssrvernac.ml4
+++ b/plugins/ssr/ssrvernac.ml4
@@ -347,8 +347,9 @@ let coerce_search_pattern_to_sort hpat =
   if np < na then CErrors.user_err (Pp.str "too many arguments in head search pattern") else
   let hpat' = if np = na then hpat else mkPApp hpat (np - na) [||] in
   let warn () =
+    let state = States.get_state () in
     Feedback.msg_warning (str "Listing only lemmas with conclusion matching " ++ 
-      pr_constr_pattern_env env sigma hpat') in
+      pr_constr_pattern_env state env sigma hpat') in
   if EConstr.isSort sigma ht then begin warn (); true, hpat' end else
   let filter_head, coe_path =
     try 
@@ -443,7 +444,8 @@ let interp_modloc mr =
 (* The unified, extended vernacular "Search" command *)
 
 let ssrdisplaysearch gr env t =
-  let pr_res = pr_global gr ++ spc () ++ str " " ++ pr_lconstr_env env Evd.empty t in
+  let state = States.get_state () in
+  let pr_res = pr_global gr ++ spc () ++ str " " ++ pr_lconstr_env state env Evd.empty t in
   Feedback.msg_info (hov 2 pr_res ++ fnl ())
 
 VERNAC COMMAND EXTEND SsrSearchPattern CLASSIFIED AS QUERY
@@ -477,10 +479,11 @@ let pr_raw_ssrhintref prc _ _ = let open CAst in function
 
 let pr_rawhintref c =
   let _, env = Pfedit.get_current_context () in
+  let state = States.get_state () in
   match DAst.get c with
   | GApp (f, args) when isRHoles args ->
-    pr_glob_constr_env env f ++ str "|" ++ int (List.length args)
-  | _ -> pr_glob_constr_env env c
+    pr_glob_constr_env state env f ++ str "|" ++ int (List.length args)
+  | _ -> pr_glob_constr_env state env c
 
 let pr_glob_ssrhintref _ _ _ (c, _) = pr_rawhintref c
 

--- a/plugins/ssr/ssrview.ml
+++ b/plugins/ssr/ssrview.ml
@@ -170,15 +170,18 @@ let interp_glob ist glob = Goal.enter_one ~__LOC__ begin fun goal ->
   let env = Goal.env goal in
   let sigma = Goal.sigma goal in
   Ssrprinters.ppdebug (lazy
-    Pp.(str"interp-in: " ++ Printer.pr_glob_constr_env env glob));
+        (let state = States.get_state () in
+         Pp.(str"interp-in: " ++ Printer.pr_glob_constr_env state env glob)));
   try
     let sigma,term = Tacinterp.interp_open_constr ist env sigma (glob,None) in
     Ssrprinters.ppdebug (lazy
-      Pp.(str"interp-out: " ++ Printer.pr_econstr_env env sigma term));
+     (let state = States.get_state () in
+      Pp.(str"interp-out: " ++ Printer.pr_econstr_env state env sigma term)));
     tclUNIT (env,sigma,term)
   with e ->
     Ssrprinters.ppdebug (lazy
-    Pp.(str"interp-err: " ++ Printer.pr_glob_constr_env env glob));
+    (let state = States.get_state () in
+    Pp.(str"interp-err: " ++ Printer.pr_glob_constr_env state env glob)));
      tclZERO e
 end
 
@@ -191,7 +194,8 @@ let tclKeepOpenConstr (_env, sigma, t) = Unsafe.tclEVARS sigma <*> tclUNIT t
 
 let tclADD_CLEAR_IF_ID (env, ist, t) x =
   Ssrprinters.ppdebug (lazy
-    Pp.(str"tclADD_CLEAR_IF_ID: " ++ Printer.pr_econstr_env env ist t));
+   (let state = States.get_state () in
+    Pp.(str"tclADD_CLEAR_IF_ID: " ++ Printer.pr_econstr_env state env ist t)));
   let hd, _ = EConstr.decompose_app ist t in
   match EConstr.kind ist hd with
   | Constr.Var id when Ssrcommon.not_section_id id -> tclUNIT (x, [id])
@@ -296,8 +300,9 @@ Goal.enter_one ~__LOC__ begin fun g ->
   let rigid = rigid_of und0 in
   let n, p, to_prune, _ucst = pf_abs_evars2 s0 rigid (sigma, p) in
   let p = if simple_types then pf_abs_cterm s0 n p else p in
-  Ssrprinters.ppdebug (lazy Pp.(str"view@finalized: " ++
-    Printer.pr_econstr_env env sigma p));
+  Ssrprinters.ppdebug (lazy (let state = States.get_state () in
+    Pp.(str"view@finalized: " ++
+    Printer.pr_econstr_env state env sigma p)));
   let sigma = List.fold_left Evd.remove sigma to_prune in
   Unsafe.tclEVARS sigma <*>
   tclUNIT p

--- a/pretyping/indrec.mli
+++ b/pretyping/indrec.mli
@@ -20,7 +20,7 @@ type recursion_scheme_error =
   | NotMutualInScheme of inductive * inductive
   | NotAllowedDependentAnalysis of (*isrec:*) bool * inductive
 
-exception RecursionSchemeError of recursion_scheme_error
+exception RecursionSchemeError of env * recursion_scheme_error
 
 (** Eliminations *)
 

--- a/pretyping/pretype_errors.mli
+++ b/pretyping/pretype_errors.mli
@@ -64,7 +64,7 @@ type pretype_error =
     (Evar.t * Evar_kinds.t) option * Evar.Set.t option
     (** unresolvable evar, connex component *)
 
-exception PretypeError of env * Evd.evar_map * pretype_error
+exception PretypeError of States.state * env * Evd.evar_map * pretype_error
 
 val precatchable_exception : exn -> bool
 
@@ -125,7 +125,7 @@ val error_cannot_unify : ?loc:Loc.t -> env -> Evd.evar_map ->
 
 val error_cannot_unify_local : env -> Evd.evar_map -> constr * constr * constr -> 'b
 
-val error_cannot_find_well_typed_abstraction : env -> Evd.evar_map ->
+val error_cannot_find_well_typed_abstraction : States.state -> env -> Evd.evar_map ->
       constr -> constr list -> (env * type_error) option -> 'b
 
 val error_wrong_abstraction_type :  env -> Evd.evar_map ->

--- a/pretyping/tacred.mli
+++ b/pretyping/tacred.mli
@@ -19,7 +19,7 @@ open Univ
 open Ltac_pretype
 
 type reduction_tactic_error =
-    InvalidAbstraction of env * evar_map * constr * (env * Type_errors.type_error)
+    InvalidAbstraction of States.state * env * Evd.evar_map * EConstr.constr * (env * Type_errors.type_error)
 
 exception ReductionTacticError of reduction_tactic_error
 

--- a/printing/genprint.mli
+++ b/printing/genprint.mli
@@ -21,11 +21,11 @@ type printer_result =
 | PrinterBasic of (unit -> Pp.t)
 | PrinterNeedsLevel of (Notation_gram.tolerability -> Pp.t) with_level
 
-type printer_fun_with_level = Environ.env -> Evd.evar_map -> Notation_gram.tolerability -> Pp.t
+type printer_fun_with_level = States.state -> Environ.env -> Evd.evar_map -> Notation_gram.tolerability -> Pp.t
 
 type top_printer_result =
 | TopPrinterBasic of (unit -> Pp.t)
-| TopPrinterNeedsContext of (Environ.env -> Evd.evar_map -> Pp.t)
+| TopPrinterNeedsContext of (States.state -> Environ.env -> Evd.evar_map -> Pp.t)
 | TopPrinterNeedsContextAndLevel of printer_fun_with_level with_level
 
 type 'a printer = 'a -> printer_result

--- a/printing/ppconstr.ml
+++ b/printing/ppconstr.ml
@@ -702,16 +702,17 @@ let tag_var = tag Tag.variable
     | { CAst.v = CAppExpl ((None,f,us),[]) } -> str "@" ++ pr_cref f us
     | c -> pr prec c
 
-  let transf env sigma c =
+  let transf state env sigma c =
     if !Flags.beautify_file then
       let r = Constrintern.for_grammar (Constrintern.intern_constr env sigma) c in
-      Constrextern.extern_glob_constr (Termops.vars_of_env env) r
+      Constrextern.extern_glob_constr state env r
     else c
 
   let pr_expr prec c =
     let env = Global.env () in
     let sigma = Evd.from_env env in
-    pr prec (transf env sigma c)
+    let state = States.get_state () in
+    pr prec (transf state env sigma c)
 
   let pr_simpleconstr = pr_expr lsimpleconstr
 

--- a/printing/pputils.ml
+++ b/printing/pputils.ml
@@ -118,8 +118,8 @@ let pr_red_expr (pr_constr,pr_lconstr,pr_ref,pr_pattern) keyword = function
   | CbvNative o ->
     keyword "native_compute" ++ pr_opt (pr_with_occurrences (pr_union pr_ref pr_pattern) keyword) o
 
-let pr_red_expr_env env sigma (pr_constr,pr_lconstr,pr_ref,pr_pattern) =
-  pr_red_expr (pr_constr env sigma, pr_lconstr env sigma, pr_ref, pr_pattern env sigma)
+let pr_red_expr_env state env sigma (pr_constr,pr_lconstr,pr_ref,pr_pattern) =
+  pr_red_expr (pr_constr state env sigma, pr_lconstr state env sigma, pr_ref, pr_pattern state env sigma)
 
 let pr_or_by_notation f = let open Constrexpr in function
   | {CAst.loc; v=AN v} -> f v

--- a/printing/pputils.mli
+++ b/printing/pputils.mli
@@ -28,11 +28,11 @@ val pr_red_expr :
   ('a -> Pp.t) * ('a -> Pp.t) * ('b -> Pp.t) * ('c -> Pp.t) ->
   (string -> Pp.t) -> ('a,'b,'c) red_expr_gen -> Pp.t
 
-val pr_red_expr_env : Environ.env -> Evd.evar_map ->
-  (Environ.env -> Evd.evar_map -> 'a -> Pp.t) *
-  (Environ.env -> Evd.evar_map -> 'a -> Pp.t) *
+val pr_red_expr_env : States.state -> Environ.env -> Evd.evar_map ->
+  (States.state -> Environ.env -> Evd.evar_map -> 'a -> Pp.t) *
+  (States.state -> Environ.env -> Evd.evar_map -> 'a -> Pp.t) *
   ('b -> Pp.t) *
-  (Environ.env -> Evd.evar_map -> 'c -> Pp.t) ->
+  (States.state -> Environ.env -> Evd.evar_map -> 'c -> Pp.t) ->
   (string -> Pp.t) ->
   ('a,'b,'c) red_expr_gen -> Pp.t
 

--- a/printing/prettyp.ml
+++ b/printing/prettyp.ml
@@ -157,7 +157,7 @@ let need_expansion impl ref =
 
 let print_impargs ref =
   let ref = Smartlocate.smart_global ref in
-  let impl = implicits_of_global ref in
+  let impl = implicits_of_global (project_impargs (States.get_state ())) ref in
   let has_impl = not (List.is_empty impl) in
   (* Need to reduce since implicits are computed with products flattened *)
   pr_infos_list
@@ -259,7 +259,7 @@ let print_primitive ref =
   | _ -> []
 
 let print_name_infos ref =
-  let impls = implicits_of_global ref in
+  let impls = implicits_of_global (project_impargs (States.get_state ())) ref in
   let scopes = Notation.find_arguments_scope ref in
   let renames =
     try Arguments_renaming.arguments_names ref with Not_found -> [] in
@@ -297,7 +297,8 @@ let print_args_data_of_inductive_ids get test pr sp mipv =
 
 let print_inductive_implicit_args =
   print_args_data_of_inductive_ids
-    implicits_of_global (fun l -> not (List.is_empty (positions_of_implicits l)))
+    (fun ref -> implicits_of_global (project_impargs (States.get_state ())) ref)
+    (fun l -> not (List.is_empty (positions_of_implicits l)))
     print_impargs_list
 
 let print_inductive_renames =

--- a/printing/prettyp.mli
+++ b/printing/prettyp.mli
@@ -18,23 +18,23 @@ open Libnames
 val assumptions_for_print : Name.t list -> Termops.names_context
 
 val print_closed_sections : bool ref
-val print_context : env -> Evd.evar_map -> bool -> int option -> Lib.library_segment -> Pp.t
-val print_library_entry : env -> Evd.evar_map -> bool -> (object_name * Lib.node) -> Pp.t option
-val print_full_context : env -> Evd.evar_map -> Pp.t
-val print_full_context_typ : env -> Evd.evar_map -> Pp.t
-val print_full_pure_context : env -> Evd.evar_map -> Pp.t
-val print_sec_context : env -> Evd.evar_map -> qualid -> Pp.t
-val print_sec_context_typ : env -> Evd.evar_map -> qualid -> Pp.t
-val print_judgment : env -> Evd.evar_map -> EConstr.unsafe_judgment -> Pp.t
-val print_safe_judgment : env -> Evd.evar_map -> Safe_typing.judgment -> Pp.t
+val print_context : States.state -> env -> Evd.evar_map -> bool -> int option -> Lib.library_segment -> Pp.t
+val print_library_entry : States.state -> env -> Evd.evar_map -> bool -> (object_name * Lib.node) -> Pp.t option
+val print_full_context : States.state -> env -> Evd.evar_map -> Pp.t
+val print_full_context_typ : States.state -> env -> Evd.evar_map -> Pp.t
+val print_full_pure_context : States.state -> env -> Evd.evar_map -> Pp.t
+val print_sec_context : States.state -> env -> Evd.evar_map -> qualid -> Pp.t
+val print_sec_context_typ : States.state -> env -> Evd.evar_map -> qualid -> Pp.t
+val print_judgment : States.state -> env -> Evd.evar_map -> EConstr.unsafe_judgment -> Pp.t
+val print_safe_judgment : States.state -> env -> Evd.evar_map -> Safe_typing.judgment -> Pp.t
 val print_eval :
-  reduction_function -> env -> Evd.evar_map ->
+  reduction_function -> States.state -> env -> Evd.evar_map ->
     Constrexpr.constr_expr -> EConstr.unsafe_judgment -> Pp.t
 
-val print_name : env -> Evd.evar_map -> qualid Constrexpr.or_by_notation ->
+val print_name : States.state -> env -> Evd.evar_map -> qualid Constrexpr.or_by_notation ->
   UnivNames.univ_name_list option -> Pp.t
-val print_opaque_name : env -> Evd.evar_map -> qualid -> Pp.t
-val print_about : env -> Evd.evar_map -> qualid Constrexpr.or_by_notation ->
+val print_opaque_name : States.state -> env -> Evd.evar_map -> qualid -> Pp.t
+val print_about : States.state -> env -> Evd.evar_map -> qualid Constrexpr.or_by_notation ->
   UnivNames.univ_name_list option -> Pp.t
 val print_impargs : qualid Constrexpr.or_by_notation -> Pp.t
 
@@ -43,14 +43,14 @@ val print_graph : unit -> Pp.t
 val print_classes : unit -> Pp.t
 val print_coercions : unit -> Pp.t
 val print_path_between : Classops.cl_typ -> Classops.cl_typ -> Pp.t
-val print_canonical_projections : env -> Evd.evar_map -> Pp.t
+val print_canonical_projections : States.state -> env -> Evd.evar_map -> Pp.t
 
 (** Pretty-printing functions for type classes and instances *)
 val print_typeclasses : unit -> Pp.t
 val print_instances : GlobRef.t -> Pp.t
 val print_all_instances : unit -> Pp.t
 
-val inspect : env -> Evd.evar_map -> int -> Pp.t
+val inspect : States.state -> env -> Evd.evar_map -> int -> Pp.t
 
 (** {5 Locate} *)
 
@@ -84,15 +84,15 @@ val print_located_other : string -> qualid -> Pp.t
 type object_pr = {
   print_inductive           : MutInd.t -> UnivNames.univ_name_list option -> Pp.t;
   print_constant_with_infos : Constant.t -> UnivNames.univ_name_list option -> Pp.t;
-  print_section_variable    : env -> Evd.evar_map -> variable -> Pp.t;
-  print_syntactic_def       : env -> KerName.t -> Pp.t;
+  print_section_variable    : States.state -> env -> Evd.evar_map -> variable -> Pp.t;
+  print_syntactic_def       : States.state -> env -> KerName.t -> Pp.t;
   print_module              : bool -> ModPath.t -> Pp.t;
   print_modtype             : ModPath.t -> Pp.t;
-  print_named_decl          : env -> Evd.evar_map -> Constr.named_declaration -> Pp.t;
-  print_library_entry       : env -> Evd.evar_map -> bool -> (object_name * Lib.node) -> Pp.t option;
-  print_context             : env -> Evd.evar_map -> bool -> int option -> Lib.library_segment -> Pp.t;
-  print_typed_value_in_env  : Environ.env -> Evd.evar_map -> EConstr.constr * EConstr.types -> Pp.t;
-  print_eval                : Reductionops.reduction_function -> env -> Evd.evar_map -> Constrexpr.constr_expr -> EConstr.unsafe_judgment -> Pp.t;
+  print_named_decl          : States.state -> env -> Evd.evar_map -> Constr.named_declaration -> Pp.t;
+  print_library_entry       : States.state -> env -> Evd.evar_map -> bool -> (object_name * Lib.node) -> Pp.t option;
+  print_context             : States.state -> env -> Evd.evar_map -> bool -> int option -> Lib.library_segment -> Pp.t;
+  print_typed_value_in_env  : States.state -> env -> Evd.evar_map -> EConstr.constr * EConstr.types -> Pp.t;
+  print_eval                : Reductionops.reduction_function -> States.state -> env -> Evd.evar_map -> Constrexpr.constr_expr -> EConstr.unsafe_judgment -> Pp.t;
 }
 
 val set_object_pr : object_pr -> unit

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -78,33 +78,35 @@ let _ =
    and only names of goal/section variables and rel names that do
    _not_ occur in the scope of the binder to be printed are avoided. *)
 
-let pr_econstr_n_core goal_concl_style env sigma n t =
-  pr_constr_expr_n n (extern_constr goal_concl_style env sigma t)
-let pr_econstr_core goal_concl_style env sigma t =
-  pr_constr_expr (extern_constr goal_concl_style env sigma t)
+let pr_econstr_n_core goal_concl_style state env sigma n t =
+  pr_constr_expr_n n (extern_constr goal_concl_style state env sigma t)
+let pr_econstr_core goal_concl_style state env sigma t =
+  pr_constr_expr (extern_constr goal_concl_style state env sigma t)
 let pr_leconstr_core = Proof_diffs.pr_leconstr_core
 
-let pr_constr_n_env env sigma n c = pr_econstr_n_core false env sigma n (EConstr.of_constr c)
+let pr_constr_n_env state env sigma n c = pr_econstr_n_core false state env sigma n (EConstr.of_constr c)
 let pr_lconstr_env = Proof_diffs.pr_lconstr_env
-let pr_constr_env env sigma c = pr_econstr_core false env sigma (EConstr.of_constr c)
+let pr_constr_env state env sigma c = pr_econstr_core false state env sigma (EConstr.of_constr c)
 
-let pr_lconstr_goal_style_env env sigma c = pr_leconstr_core true env sigma (EConstr.of_constr c)
-let pr_constr_goal_style_env env sigma c = pr_econstr_core true env sigma (EConstr.of_constr c)
+let pr_lconstr_goal_style_env state env sigma c = pr_leconstr_core true state env sigma (EConstr.of_constr c)
+let pr_constr_goal_style_env state env sigma c = pr_econstr_core true state env sigma (EConstr.of_constr c)
 
-let pr_econstr_n_env env sigma c = pr_econstr_n_core false env sigma c
-let pr_leconstr_env env sigma c = pr_leconstr_core false env sigma c
-let pr_econstr_env env sigma c = pr_econstr_core false env sigma c
+let pr_econstr_n_env state env sigma c = pr_econstr_n_core false state env sigma c
+let pr_leconstr_env state env sigma c = pr_leconstr_core false state env sigma c
+let pr_econstr_env state env sigma c = pr_econstr_core false state env sigma c
 
-let pr_open_lconstr_env env sigma (_,c) = pr_leconstr_env env sigma c
-let pr_open_constr_env env sigma (_,c) = pr_econstr_env env sigma c
+let pr_open_lconstr_env state env sigma (_,c) = pr_leconstr_env state env sigma c
+let pr_open_constr_env state env sigma (_,c) = pr_econstr_env state env sigma c
 
 (* NB do not remove the eta-redexes! Global.env() has side-effects... *)
 let pr_lconstr t =
+  let state = States.get_state () in
   let (sigma, env) = Pfedit.get_current_context () in
-  pr_lconstr_env env sigma t
+  pr_lconstr_env state env sigma t
 let pr_constr t =
+  let state = States.get_state () in
   let (sigma, env) = Pfedit.get_current_context () in
-  pr_constr_env env sigma t
+  pr_constr_env state env sigma t
 
 let pr_leconstr c = pr_lconstr (EConstr.Unsafe.to_constr c)
 let pr_econstr c = pr_constr (EConstr.Unsafe.to_constr c)
@@ -112,87 +114,100 @@ let pr_econstr c = pr_constr (EConstr.Unsafe.to_constr c)
 let pr_open_lconstr (_,c) = pr_leconstr c
 let pr_open_constr (_,c) = pr_econstr c
 
-let pr_constr_under_binders_env_gen pr env sigma (ids,c) =
+let pr_constr_under_binders_env_gen pr state env sigma (ids,c) =
   (* Warning: clashes can occur with variables of same name in env but *)
   (* we also need to preserve the actual names of the patterns *)
   (* So what to do? *)
   let assums = List.map (fun id -> (Name id,(* dummy *) mkProp)) ids in
-  pr (Termops.push_rels_assum assums env) sigma c
+  pr state (Termops.push_rels_assum assums env) sigma c
 
 let pr_constr_under_binders_env = pr_constr_under_binders_env_gen pr_econstr_env
 let pr_lconstr_under_binders_env = pr_constr_under_binders_env_gen pr_leconstr_env
 
 let pr_constr_under_binders c =
+  let state = States.get_state () in
   let (sigma, env) = Pfedit.get_current_context () in
-  pr_constr_under_binders_env env sigma c
+  pr_constr_under_binders_env state env sigma c
 let pr_lconstr_under_binders c =
+  let state = States.get_state () in
   let (sigma, env) = Pfedit.get_current_context () in
-  pr_lconstr_under_binders_env env sigma c
+  pr_lconstr_under_binders_env state env sigma c
 
-let pr_etype_core goal_concl_style env sigma t =
-  pr_constr_expr (extern_type goal_concl_style env sigma t)
+let pr_etype_core goal_concl_style state env sigma t =
+  pr_constr_expr (extern_type goal_concl_style state env sigma t)
 let pr_letype_core = Proof_diffs.pr_letype_core
 
-let pr_ltype_env env sigma c = pr_letype_core false env sigma (EConstr.of_constr c)
-let pr_type_env env sigma c = pr_etype_core false env sigma (EConstr.of_constr c)
+let pr_ltype_env state env sigma c = pr_letype_core false state env sigma (EConstr.of_constr c)
+let pr_type_env state env sigma c = pr_etype_core false state env sigma (EConstr.of_constr c)
 
 let pr_ltype t =
-    let (sigma, env) = Pfedit.get_current_context () in
-    pr_ltype_env env sigma t
+  let state = States.get_state () in
+  let (sigma, env) = Pfedit.get_current_context () in
+  pr_ltype_env state env sigma t
 let pr_type t =
-    let (sigma, env) = Pfedit.get_current_context () in
-    pr_type_env env sigma t
+  let state = States.get_state () in
+  let (sigma, env) = Pfedit.get_current_context () in
+  pr_type_env state env sigma t
 
-let pr_etype_env env sigma c = pr_etype_core false env sigma c
-let pr_letype_env env sigma c = pr_letype_core false env sigma c
-let pr_goal_concl_style_env env sigma c = pr_letype_core true env sigma c
+let pr_etype_env state env sigma c = pr_etype_core false state env sigma c
+let pr_letype_env state env sigma c = pr_letype_core false state env sigma c
+let pr_goal_concl_style_env state env sigma c = pr_letype_core true state env sigma c
 
-let pr_ljudge_env env sigma j =
-  (pr_leconstr_env env sigma j.uj_val, pr_leconstr_env env sigma j.uj_type)
+let pr_ljudge_env state env sigma j =
+  (pr_leconstr_env state env sigma j.uj_val, pr_leconstr_env state env sigma j.uj_type)
 
 let pr_ljudge j =
+  let state = States.get_state () in
   let (sigma, env) = Pfedit.get_current_context () in
-  pr_ljudge_env env sigma j
+  pr_ljudge_env state env sigma j
 
-let pr_lglob_constr_env env c =
-  pr_lconstr_expr (extern_glob_constr (Termops.vars_of_env env) c)
-let pr_glob_constr_env env c =
-  pr_constr_expr (extern_glob_constr (Termops.vars_of_env env) c)
+let pr_lglob_constr_env state env c =
+  pr_lconstr_expr (extern_glob_constr state env c)
+let pr_glob_constr_env state env c =
+  pr_constr_expr (extern_glob_constr state env c)
 
 let pr_lglob_constr c =
+  let state = States.get_state () in
   let (sigma, env) = Pfedit.get_current_context () in
-  pr_lglob_constr_env env c
+  pr_lglob_constr_env state env c
 let pr_glob_constr c =
+  let state = States.get_state () in
   let (sigma, env) = Pfedit.get_current_context () in
-  pr_glob_constr_env env c
+  pr_glob_constr_env state env c
 
-let pr_closed_glob_n_env env sigma n c =
-  pr_constr_expr_n n (extern_closed_glob false env sigma c)
-let pr_closed_glob_env env sigma c =
-  pr_constr_expr (extern_closed_glob false env sigma c)
+let pr_closed_glob_n_env state env sigma n c =
+  pr_constr_expr_n n (extern_closed_glob false state env sigma c)
+let pr_closed_glob_env state env sigma c =
+  pr_constr_expr (extern_closed_glob false state env sigma c)
 let pr_closed_glob c =
+  let state = States.get_state () in
   let (sigma, env) = Pfedit.get_current_context () in
-  pr_closed_glob_env env sigma c
+  pr_closed_glob_env state env sigma c
 
-let pr_lconstr_pattern_env env sigma c =
-  pr_lconstr_pattern_expr (extern_constr_pattern (Termops.names_of_rel_context env) sigma c)
-let pr_constr_pattern_env env sigma c =
-  pr_constr_pattern_expr (extern_constr_pattern (Termops.names_of_rel_context env) sigma c)
+let pr_lconstr_pattern_env state env sigma c =
+  pr_lconstr_pattern_expr (extern_constr_pattern state env sigma c)
+let pr_constr_pattern_env state env sigma c =
+  pr_constr_pattern_expr (extern_constr_pattern state env sigma c)
 
 let pr_cases_pattern t =
-  pr_cases_pattern_expr (extern_cases_pattern Names.Id.Set.empty t)
+  let state = States.get_state () in
+  pr_cases_pattern_expr (extern_cases_pattern state Names.Id.Set.empty t)
 
 let pr_lconstr_pattern t =
+  let state = States.get_state () in
   let (sigma, env) = Pfedit.get_current_context () in
-  pr_lconstr_pattern_env env sigma t
+  pr_lconstr_pattern_env state env sigma t
 let pr_constr_pattern t =
+  let state = States.get_state () in
   let (sigma, env) = Pfedit.get_current_context () in
-  pr_constr_pattern_env env sigma t
+  pr_constr_pattern_env state env sigma t
 
 let pr_sort sigma s = pr_glob_sort (extern_sort sigma s)
 
 let _ = Termops.Internal.set_print_constr
-  (fun env sigma t -> pr_lconstr_expr (extern_constr ~lax:true false env sigma t))
+  (fun env sigma t ->
+    let state = States.get_state () in
+    pr_lconstr_expr (extern_constr ~lax:true false state env sigma t))
 
 let pr_in_comment pr x = str "(* " ++ pr x ++ str " *)"
 
@@ -229,7 +244,7 @@ let dirpath_of_global = function
 let qualid_of_global ?loc env r =
   Libnames.make_qualid ?loc (dirpath_of_global r) (id_of_global env r)
 
-let safe_gen f env sigma c =
+let safe_gen f state env sigma c =
   let orig_extern_ref = Constrextern.get_extern_reference () in
   let extern_ref ?loc vars r =
     try orig_extern_ref vars r
@@ -238,7 +253,7 @@ let safe_gen f env sigma c =
   in
   Constrextern.set_extern_reference extern_ref;
   try
-    let p = f env sigma c in
+    let p = f state env sigma c in
     Constrextern.set_extern_reference orig_extern_ref;
     p
   with e when CErrors.noncritical e ->
@@ -248,12 +263,14 @@ let safe_gen f env sigma c =
 let safe_pr_lconstr_env = safe_gen pr_lconstr_env
 let safe_pr_constr_env = safe_gen pr_constr_env
 let safe_pr_lconstr t =
+  let state = States.get_state () in
   let (sigma, env) = Pfedit.get_current_context () in
-  safe_pr_lconstr_env env sigma t
+  safe_pr_lconstr_env state env sigma t
 
 let safe_pr_constr t =
+  let state = States.get_state () in
   let (sigma, env) = Pfedit.get_current_context () in
-  safe_pr_constr_env env sigma t
+  safe_pr_constr_env state env sigma t
 
 let pr_universe_ctx_set sigma c =
   if !Detyping.print_universes && not (Univ.ContextSet.is_empty c) then
@@ -299,22 +316,22 @@ let pr_abstract_cumulativity_info sigma cumi =
 (**********************************************************************)
 (* Global references *)
 
-let pr_global_env = pr_global_env
-let pr_global = pr_global_env Id.Set.empty
+let pr_global_env state = pr_global_env
+let pr_global = pr_global_env (States.get_state ()) Id.Set.empty
 
 let pr_universe_instance evd inst =
   str"@{" ++ Univ.Instance.pr (Termops.pr_evd_level evd) inst ++ str"}"
 
-let pr_puniverses f env sigma (c,u) =
+let pr_puniverses f state env sigma (c,u) =
   if !Constrextern.print_universes
-  then f env c ++ pr_universe_instance sigma u
-  else f env c
+  then f state env c ++ pr_universe_instance sigma u
+  else f state env c
 
-let pr_constant env cst = pr_global_env (Termops.vars_of_env env) (ConstRef cst)
+let pr_constant state env cst = pr_global_env state (Termops.vars_of_env env) (ConstRef cst)
 let pr_existential_key = Termops.pr_existential_key
-let pr_existential env sigma ev = pr_lconstr_env env sigma (mkEvar ev)
-let pr_inductive env ind = pr_lconstr_env env (Evd.from_env env) (mkInd ind)
-let pr_constructor env cstr = pr_lconstr_env env (Evd.from_env env) (mkConstruct cstr)
+let pr_existential state env sigma ev = pr_lconstr_env state env sigma (mkEvar ev)
+let pr_inductive state env ind = pr_lconstr_env state env (Evd.from_env env) (mkInd ind)
+let pr_constructor state env cstr = pr_lconstr_env state env (Evd.from_env env) (mkConstruct cstr)
 
 let pr_pconstant = pr_puniverses pr_constant
 let pr_pinductive = pr_puniverses pr_inductive
@@ -340,35 +357,35 @@ let get_compact_context,set_compact_context =
   let compact_context = ref false in
   (fun () -> !compact_context),(fun b  -> compact_context := b)
 
-let pr_compacted_decl env sigma decl =
+let pr_compacted_decl state env sigma decl =
   let ids, pbody, typ = match decl with
     | CompactedDecl.LocalAssum (ids, typ) ->
        ids, mt (), typ
     | CompactedDecl.LocalDef (ids,c,typ) ->
        (* Force evaluation *)
-       let pb = pr_lconstr_env env sigma c in
+       let pb = pr_lconstr_env state env sigma c in
        let pb = if isCast c then surround pb else pb in
        ids, (str" := " ++ pb ++ cut ()), typ
   in
   let pids = prlist_with_sep pr_comma pr_id ids in
-  let pt = pr_ltype_env env sigma typ in
+  let pt = pr_ltype_env state env sigma typ in
   let ptyp = (str" : " ++ pt) in
   hov 0 (pids ++ pbody ++ ptyp)
 
-let pr_named_decl env sigma decl =
-  decl |> CompactedDecl.of_named_decl |> pr_compacted_decl env sigma
+let pr_named_decl state env sigma decl =
+  decl |> CompactedDecl.of_named_decl |> pr_compacted_decl state env sigma
 
-let pr_rel_decl env sigma decl =
+let pr_rel_decl state env sigma decl =
   let na = RelDecl.get_name decl in
   let typ = RelDecl.get_type decl in
   let pbody = match decl with
     | RelDecl.LocalAssum _ -> mt ()
     | RelDecl.LocalDef (_,c,_) ->
 	(* Force evaluation *)
-	let pb = pr_lconstr_env env sigma c in
+        let pb = pr_lconstr_env state env sigma c in
 	let pb = if isCast c then surround pb else pb in
 	(str":=" ++ spc () ++ pb ++ spc ()) in
-  let ptyp = pr_ltype_env env sigma typ in
+  let ptyp = pr_ltype_env state env sigma typ in
   match na with
   | Anonymous -> hov 0 (str"<>" ++ spc () ++ pbody ++ str":" ++ spc () ++ ptyp)
   | Name id -> hov 0 (pr_id id ++ spc () ++ pbody ++ str":" ++ spc () ++ ptyp)
@@ -379,47 +396,47 @@ let pr_rel_decl env sigma decl =
  * It's printed out from outermost to innermost, so it's readable. *)
 
 (* Prints a signature, all declarations on the same line if possible *)
-let pr_named_context_of env sigma =
-  let make_decl_list env d pps = pr_named_decl env sigma d :: pps in
+let pr_named_context_of state env sigma =
+  let make_decl_list env d pps = pr_named_decl state env sigma d :: pps in
   let psl = List.rev (fold_named_context make_decl_list env ~init:[]) in
   hv 0 (prlist_with_sep (fun _ -> ws 2) (fun x -> x) psl)
 
-let pr_var_list_decl env sigma decl =
-  hov 0 (pr_compacted_decl env sigma decl)
+let pr_var_list_decl state env sigma decl =
+  hov 0 (pr_compacted_decl state env sigma decl)
 
-let pr_named_context env sigma ne_context =
+let pr_named_context state env sigma ne_context =
   hv 0 (Context.Named.fold_outside
-	  (fun d pps -> pps ++ ws 2 ++ pr_named_decl env sigma d)
+          (fun d pps -> pps ++ ws 2 ++ pr_named_decl state env sigma d)
           ne_context ~init:(mt ()))
 
-let pr_rel_context env sigma rel_context =
+let pr_rel_context state env sigma rel_context =
   let rel_context = List.map (fun d -> Termops.map_rel_decl EConstr.of_constr d) rel_context in
-  pr_binders (extern_rel_context None env sigma rel_context)
+  pr_binders (extern_rel_context None state env sigma rel_context)
 
-let pr_rel_context_of env sigma =
-  pr_rel_context env sigma (rel_context env)
+let pr_rel_context_of state env sigma =
+  pr_rel_context state env sigma (rel_context env)
 
 (* Prints an env (variables and de Bruijn). Separator: newline *)
-let pr_context_unlimited env sigma =
+let pr_context_unlimited state env sigma =
   let sign_env =
     Context.Compacted.fold
       (fun d pps ->
-         let pidt =  pr_compacted_decl env sigma d in
+         let pidt =  pr_compacted_decl state env sigma d in
          (pps ++ fnl () ++ pidt))
       (Termops.compact_named_context (named_context env)) ~init:(mt ())
   in
   let db_env =
     fold_rel_context
       (fun env d pps ->
-         let pnat = pr_rel_decl env sigma d in (pps ++ fnl () ++ pnat))
+         let pnat = pr_rel_decl state env sigma d in (pps ++ fnl () ++ pnat))
       env ~init:(mt ())
   in
   (sign_env ++ db_env)
 
-let pr_ne_context_of header env sigma =
+let pr_ne_context_of header state env sigma =
   if List.is_empty (Environ.rel_context env) &&
     List.is_empty (Environ.named_context env)  then (mt ())
-  else let penv = pr_context_unlimited env sigma in (header ++ penv ++ fnl ())
+  else let penv = pr_context_unlimited state env sigma in (header ++ penv ++ fnl ())
 
 (* Heuristic for horizontalizing hypothesis that the user probably
    considers as "variables": An hypothesis H:T where T:S and S<>Prop. *)
@@ -432,30 +449,30 @@ let should_compact env sigma typ =
 (* If option Compact Contexts is set, we pack "simple" hypothesis in a
    hov box (with three sapaces as a separator), the global box being a
    v box *)
-let rec bld_sign_env env sigma ctxt pps =
+let rec bld_sign_env state env sigma ctxt pps =
   match ctxt with
   | [] -> pps
   | CompactedDecl.LocalAssum (ids,typ)::ctxt' when should_compact env sigma typ ->
-    let pps',ctxt' = bld_sign_env_id env sigma ctxt (mt ()) true in
+    let pps',ctxt' = bld_sign_env_id state env sigma ctxt (mt ()) true in
     (* putting simple hyps in a more horizontal flavor *)
-    bld_sign_env env sigma ctxt' (pps ++ brk (0,0) ++ hov 0 pps')
+    bld_sign_env state env sigma ctxt' (pps ++ brk (0,0) ++ hov 0 pps')
   | d:: ctxt' ->
-    let pidt = pr_var_list_decl env sigma d in
+    let pidt = pr_var_list_decl state env sigma d in
     let pps' = pps ++ brk (0,0) ++ pidt in
-    bld_sign_env env sigma ctxt' pps'
-and bld_sign_env_id env sigma ctxt pps is_start =
+    bld_sign_env state env sigma ctxt' pps'
+and bld_sign_env_id state env sigma ctxt pps is_start =
   match ctxt with
   | [] -> pps,ctxt
  | CompactedDecl.LocalAssum(ids,typ) as d :: ctxt' when should_compact env sigma typ ->
-    let pidt = pr_var_list_decl env sigma d in
+    let pidt = pr_var_list_decl state env sigma d in
     let pps' = pps ++ (if not is_start then brk (3,0) else (mt ())) ++ pidt in
-    bld_sign_env_id env sigma ctxt' pps' false
+    bld_sign_env_id state env sigma ctxt' pps' false
   | _ -> pps,ctxt
 
 
 (* compact printing an env (variables and de Bruijn). Separator: three
    spaces between simple hyps, and newline otherwise *)
-let pr_context_limit_compact ?n env sigma =
+let pr_context_limit_compact ?n state env sigma =
   let ctxt = Termops.compact_named_context (named_context env) in
   let lgth = List.length ctxt in
   let n_capped =
@@ -467,9 +484,9 @@ let pr_context_limit_compact ?n env sigma =
   (* a dot line hinting the number of hidden hyps. *)
   let hidden_dots = String.make (List.length ctxt_hidden) '.' in
   let sign_env = v 0 (str hidden_dots ++ (mt ())
-                 ++ bld_sign_env env sigma (List.rev ctxt_chopped) (mt ())) in
+                 ++ bld_sign_env state env sigma (List.rev ctxt_chopped) (mt ())) in
   let db_env =
-    fold_rel_context (fun env d pps -> pps ++ fnl () ++ pr_rel_decl env sigma d)
+    fold_rel_context (fun env d pps -> pps ++ fnl () ++ pr_rel_decl state env sigma d)
       env ~init:(mt ()) in
   sign_env ++ db_env
 
@@ -486,9 +503,9 @@ let _ =
       optread  = (fun () -> !print_hyps_limit);
       optwrite = (fun x -> print_hyps_limit := x) }
 
-let pr_context_of env sigma = match !print_hyps_limit with
-  | None -> hv 0 (pr_context_limit_compact env sigma)
-  | Some n -> hv 0 (pr_context_limit_compact ~n env sigma)
+let pr_context_of state env sigma = match !print_hyps_limit with
+  | None -> hv 0 (pr_context_limit_compact state env sigma)
+  | Some n -> hv 0 (pr_context_limit_compact ~n state env sigma)
 
 (* display goal parts (Proof mode) *)
 
@@ -500,7 +517,7 @@ let pr_predicate pr_elt (b, elts) =
     else
       if List.is_empty elts then str"none" else pr_elts
 
-let pr_cpred p = pr_predicate (pr_constant (Global.env())) (Cpred.elements p)
+let pr_cpred p = pr_predicate (pr_constant (States.get_state()) (Global.env())) (Cpred.elements p)
 let pr_idpred p = pr_predicate Id.print (Id.Pred.elements p)
 
 let pr_transparent_state (ids, csts) =
@@ -516,13 +533,14 @@ let pr_goal ?(diffs=false) ?og_s g_s =
   let sigma = project g_s in
   let env = Goal.V82.env sigma g in
   let concl = Goal.V82.concl sigma g in
+  let state = States.get_state () in
   let goal =
     if diffs then
       Proof_diffs.diff_goal ?og_s g sigma
     else
-      pr_context_of env sigma ++ cut () ++
+      pr_context_of state env sigma ++ cut () ++
         str "============================" ++ cut ()  ++
-        pr_goal_concl_style_env env sigma concl
+        pr_goal_concl_style_env state env sigma concl
   in
   str "  " ++ v 0 goal
 
@@ -545,19 +563,20 @@ let pr_goal_header nme sigma g =
 let pr_concl n ?(diffs=false) ?og_s sigma g =
   let (g,sigma) = Goal.V82.nf_evar sigma g in
   let env = Goal.V82.env sigma g in
+  let state = States.get_state () in
   let pc =
     if diffs then
       Proof_diffs.diff_concl ?og_s sigma g
     else
-      pr_goal_concl_style_env env sigma (Goal.V82.concl sigma g)
+      pr_goal_concl_style_env state env sigma (Goal.V82.concl sigma g)
   in
   let header = pr_goal_header (int n) sigma g in
   header ++ str " is:" ++ cut () ++ str" "  ++ pc
 
 (* display evar type: a context and a type *)
-let pr_evgl_sign sigma evi =
+let pr_evgl_sign state sigma evi =
   let env = evar_env evi in
-  let ps = pr_named_context_of env sigma in
+  let ps = pr_named_context_of state env sigma in
   let _, l = match Filter.repr (evar_filter evi) with
   | None -> [], []
   | Some f -> List.filter2 (fun b c -> not b) f (evar_context evi)
@@ -567,12 +586,12 @@ let pr_evgl_sign sigma evi =
     if List.is_empty ids then mt () else
       (str " (" ++ prlist_with_sep pr_comma pr_id ids ++ str " cannot be used)")
   in
-  let pc = pr_leconstr_env env sigma evi.evar_concl in
+  let pc = pr_leconstr_env state env sigma evi.evar_concl in
   let candidates =
     match evi.evar_body, evi.evar_candidates with
     | Evar_empty, Some l ->
        spc () ++ str "= {" ++
-         prlist_with_sep (fun () -> str "|") (pr_leconstr_env env sigma) l ++ str "}"
+         prlist_with_sep (fun () -> str "|") (pr_leconstr_env state env sigma) l ++ str "}"
     | _ ->
        mt ()
   in
@@ -581,8 +600,8 @@ let pr_evgl_sign sigma evi =
 
 (* Print an existential variable *)
 
-let pr_evar sigma (evk, evi) =
-  let pegl = pr_evgl_sign sigma evi in
+let pr_evar state sigma (evk, evi) =
+  let pegl = pr_evgl_sign state sigma evi in
   hov 0 (pr_existential_key sigma evk ++ str " : " ++ pegl)
 
 (* Print an enumerated list of existential variables *)
@@ -592,7 +611,7 @@ let rec pr_evars_int_hd pr sigma i = function
       (hov 0 (pr i evk evi)) ++
       (match rest with [] -> mt () | _ -> fnl () ++ pr_evars_int_hd pr sigma (i+1) rest)
 
-let pr_evars_int sigma ~shelf ~givenup i evs =
+let pr_evars_int state sigma ~shelf ~givenup i evs =
   let pr_status i =
     if List.mem i shelf then str " (shelved)"
     else if List.mem i givenup then str " (given up)"
@@ -600,19 +619,19 @@ let pr_evars_int sigma ~shelf ~givenup i evs =
   pr_evars_int_hd
     (fun i evk evi ->
       str "Existential " ++ int i ++ str " =" ++
-      spc () ++ pr_evar sigma (evk,evi) ++ pr_status evk)
+      spc () ++ pr_evar state sigma (evk,evi) ++ pr_status evk)
     sigma i (Evar.Map.bindings evs)
 
-let pr_evars sigma evs =
-  pr_evars_int_hd (fun i evk evi -> pr_evar sigma (evk,evi)) sigma 1 (Evar.Map.bindings evs)
+let pr_evars state sigma evs =
+  pr_evars_int_hd (fun i evk evi -> pr_evar state sigma (evk,evi)) sigma 1 (Evar.Map.bindings evs)
 
 (* Display a list of evars given by their name, with a prefix *)
-let pr_ne_evar_set hd tl sigma l =
+let pr_ne_evar_set hd tl state sigma l =
   if l != Evar.Set.empty then
     let l = Evar.Set.fold (fun ev ->
       Evar.Map.add ev (Evarutil.nf_evar_info sigma (Evd.find sigma ev)))
       l Evar.Map.empty in
-    hd ++ pr_evars sigma l ++ tl
+    hd ++ pr_evars state sigma l ++ tl
   else
     mt ()
 
@@ -634,17 +653,17 @@ let pr_subgoal n sigma =
 
 let pr_internal_existential_key ev = Evar.print ev
 
-let print_evar_constraints gl sigma =
+let print_evar_constraints gl state sigma =
   let pr_env =
     match gl with
-    | None -> fun e' -> pr_context_of e' sigma
+    | None -> fun env -> pr_context_of state env sigma
     | Some g ->
-       let env = Goal.V82.env sigma g in fun e' ->
+       let env = Goal.V82.env sigma g in fun env' ->
        begin
-         if Context.Named.equal Constr.equal (named_context env) (named_context e') then
-           if Context.Rel.equal Constr.equal (rel_context env) (rel_context e') then mt ()
-           else pr_rel_context_of e' sigma ++ str " |-" ++ spc ()
-         else pr_context_of e' sigma ++ str " |-" ++ spc ()
+         if Context.Named.equal Constr.equal (named_context env) (named_context env') then
+           if Context.Rel.equal Constr.equal (rel_context env) (rel_context env') then mt ()
+           else pr_rel_context_of state env' sigma ++ str " |-" ++ spc ()
+         else pr_context_of state env' sigma ++ str " |-" ++ spc ()
        end
   in
   let pr_evconstr (pbty,env,t1,t2) =
@@ -659,15 +678,15 @@ let print_evar_constraints gl sigma =
           naming/renaming *)
       Namegen.make_all_name_different env sigma in
     str" " ++
-      hov 2 (pr_env env ++ pr_leconstr_env env sigma t1 ++ spc () ++
+      hov 2 (pr_env env ++ pr_leconstr_env state env sigma t1 ++ spc () ++
              str (match pbty with
                   | Reduction.CONV -> "=="
                   | Reduction.CUMUL -> "<=") ++
-             spc () ++ pr_leconstr_env env sigma t2)
+             spc () ++ pr_leconstr_env state env sigma t2)
   in
   let pr_candidate ev evi (candidates,acc) =
     if Option.has_some evi.evar_candidates then
-      (succ candidates, acc ++ pr_evar sigma (ev,evi) ++ fnl ())
+      (succ candidates, acc ++ pr_evar state sigma (ev,evi) ++ fnl ())
     else (candidates, acc)
   in
   let constraints =
@@ -694,8 +713,8 @@ let _ =
       optread  = (fun () -> !should_print_dependent_evars);
       optwrite = (fun v -> should_print_dependent_evars := v) }
 
-let print_dependent_evars gl sigma seeds =
-  let constraints = print_evar_constraints gl sigma in
+let print_dependent_evars gl state sigma seeds =
+  let constraints = print_evar_constraints gl state sigma in
   let evars () =
     if !should_print_dependent_evars then
       let evars = Evarutil.gather_dependent_evars sigma seeds in
@@ -726,6 +745,7 @@ module GoalMap = Evar.Map
 (* [os_map] is derived from the previous proof step, used for diffs *)
 let pr_subgoals ?(pr_first=true) ?(diffs=false) ?os_map
                         close_cmd sigma ~seeds ~shelf ~stack ~unfocused ~goals =
+  let state = States.get_state () in
   let diff_goal_map =
     match os_map with
     | Some (_, diff_goal_map) -> diff_goal_map
@@ -804,13 +824,13 @@ let pr_subgoals ?(pr_first=true) ?(diffs=false) ?os_map
       begin
 	let exl = Evd.undefined_map sigma in
 	if Evar.Map.is_empty exl then
-	  (str"No more subgoals." ++ print_dependent_evars None sigma seeds)
+          (str"No more subgoals." ++ print_dependent_evars None state sigma seeds)
 	else
-          let pei = pr_evars_int sigma ~shelf ~givenup:[] 1 exl in
+          let pei = pr_evars_int state sigma ~shelf ~givenup:[] 1 exl in
 	  v 0 ((str "No more subgoals,"
                 ++ str " but there are non-instantiated existential variables:"
 	        ++ cut () ++ (hov 0 pei)
-                ++ print_dependent_evars None sigma seeds
+                ++ print_dependent_evars None state sigma seeds
                 ++ cut () ++ str "You can use Grab Existential Variables."))
       end
   | g1::rest ->
@@ -825,7 +845,7 @@ let pr_subgoals ?(pr_first=true) ?(diffs=false) ?os_map
         ++ (if unfocused=[] then str ""
            else (cut() ++ cut() ++ str "*** Unfocused goals:" ++ cut()
                  ++ pr_rec (List.length rest + 2) unfocused))
-	++ print_dependent_evars (Some g1) sigma seeds
+        ++ print_dependent_evars (Some g1) state sigma seeds
       )
 
 let pr_open_subgoals_diff ?(quiet=false) ?(diffs=false) ?oproof proof =
@@ -950,31 +970,31 @@ end
 module ContextObjectSet = Set.Make (OrderedContextObject)
 module ContextObjectMap = Map.Make (OrderedContextObject)
 
-let pr_assumptionset env sigma s =
+let pr_assumptionset state env sigma s =
   if ContextObjectMap.is_empty s &&
        engagement env = PredicativeSet then
     str "Closed under the global context"
   else
     let safe_pr_constant env kn =
-      try pr_constant env kn
+      try pr_constant state env kn
       with Not_found ->
         (* FIXME? *)
 	let mp,_,lab = Constant.repr3 kn in
         str (ModPath.to_string mp) ++ str "." ++ Label.print lab
     in
     let safe_pr_inductive env kn =
-      try pr_inductive env (kn,0)
+      try pr_inductive state env (kn,0)
       with Not_found ->
         (* FIXME? *)
         MutInd.print kn
     in
     let safe_pr_ltype env sigma typ =
-      try str " : " ++ pr_ltype_env env sigma typ
+      try str " : " ++ pr_ltype_env state env sigma typ
       with e when CErrors.noncritical e -> mt ()
     in
     let safe_pr_ltype_relctx (rctx, typ) =
       let env = Environ.push_rel_context rctx env in
-      try str " " ++ pr_ltype_env env sigma typ
+      try str " " ++ pr_ltype_env state env sigma typ
       with e when CErrors.noncritical e -> mt ()
     in
     let pr_axiom env ax typ =
@@ -990,7 +1010,7 @@ let pr_assumptionset env sigma s =
       let (v, a, o, tr) = accu in
       match t with
       | Variable id ->
-        let var = pr_id id ++ str " : " ++ pr_ltype_env env sigma typ in
+        let var = pr_id id ++ str " : " ++ pr_ltype_env state env sigma typ in
         (var :: v, a, o, tr)
       | Axiom (axiom, []) ->
         let ax = pr_axiom env axiom typ in

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -87,7 +87,6 @@ let pr_leconstr_core = Proof_diffs.pr_leconstr_core
 let pr_constr_n_env env sigma n c = pr_econstr_n_core false env sigma n (EConstr.of_constr c)
 let pr_lconstr_env = Proof_diffs.pr_lconstr_env
 let pr_constr_env env sigma c = pr_econstr_core false env sigma (EConstr.of_constr c)
-let _ = Hook.set Refine.pr_constr pr_constr_env
 
 let pr_lconstr_goal_style_env env sigma c = pr_leconstr_core true env sigma (EConstr.of_constr c)
 let pr_constr_goal_style_env env sigma c = pr_econstr_core true env sigma (EConstr.of_constr c)

--- a/printing/printer.mli
+++ b/printing/printer.mli
@@ -26,89 +26,89 @@ val enable_goal_names_printing     : bool ref
 
 (** Terms *)
 
-val pr_lconstr_env         : env -> evar_map -> constr -> Pp.t
+val pr_lconstr_env         : States.state -> env -> evar_map -> constr -> Pp.t
 val pr_lconstr             : constr -> Pp.t
 [@@ocaml.deprecated "The global printing API is deprecated, please use the _env functions"]
-val pr_lconstr_goal_style_env : env -> evar_map -> constr -> Pp.t
+val pr_lconstr_goal_style_env : States.state -> env -> evar_map -> constr -> Pp.t
 
-val pr_constr_env          : env -> evar_map -> constr -> Pp.t
+val pr_constr_env          : States.state -> env -> evar_map -> constr -> Pp.t
 val pr_constr              : constr -> Pp.t
 [@@ocaml.deprecated "The global printing API is deprecated, please use the _env functions"]
-val pr_constr_goal_style_env : env -> evar_map -> constr -> Pp.t
+val pr_constr_goal_style_env : States.state -> env -> evar_map -> constr -> Pp.t
 
-val pr_constr_n_env        : env -> evar_map -> Notation_gram.tolerability -> constr -> Pp.t
+val pr_constr_n_env        : States.state -> env -> evar_map -> Notation_gram.tolerability -> constr -> Pp.t
 
 (** Same, but resilient to [Nametab] errors. Prints fully-qualified
     names when [shortest_qualid_of_global] has failed. Prints "??"
     in case of remaining issues (such as reference not in env). *)
 
-val safe_pr_lconstr_env         : env -> evar_map -> constr -> Pp.t
+val safe_pr_lconstr_env         : States.state -> env -> evar_map -> constr -> Pp.t
 val safe_pr_lconstr             : constr -> Pp.t
 [@@ocaml.deprecated "The global printing API is deprecated, please use the _env functions"]
 
-val safe_pr_constr_env          : env -> evar_map -> constr -> Pp.t
+val safe_pr_constr_env          : States.state -> env -> evar_map -> constr -> Pp.t
 val safe_pr_constr              : constr -> Pp.t
 [@@ocaml.deprecated "The global printing API is deprecated, please use the _env functions"]
 
-val pr_econstr_env     : env -> evar_map -> EConstr.t -> Pp.t
+val pr_econstr_env     : States.state -> env -> evar_map -> EConstr.t -> Pp.t
 val pr_econstr         : EConstr.t -> Pp.t
 [@@ocaml.deprecated "The global printing API is deprecated, please use the _env functions"]
-val pr_leconstr_env     : env -> evar_map -> EConstr.t -> Pp.t
+val pr_leconstr_env     : States.state -> env -> evar_map -> EConstr.t -> Pp.t
 val pr_leconstr         : EConstr.t -> Pp.t
 [@@ocaml.deprecated "The global printing API is deprecated, please use the _env functions"]
 
-val pr_econstr_n_env    : env -> evar_map -> Notation_gram.tolerability -> EConstr.t -> Pp.t
+val pr_econstr_n_env    : States.state -> env -> evar_map -> Notation_gram.tolerability -> EConstr.t -> Pp.t
 
-val pr_etype_env           : env -> evar_map -> EConstr.types -> Pp.t
-val pr_letype_env           : env -> evar_map -> EConstr.types -> Pp.t
+val pr_etype_env           : States.state -> env -> evar_map -> EConstr.types -> Pp.t
+val pr_letype_env           : States.state -> env -> evar_map -> EConstr.types -> Pp.t
 
-val pr_open_constr_env     : env -> evar_map -> open_constr -> Pp.t
+val pr_open_constr_env     : States.state -> env -> evar_map -> open_constr -> Pp.t
 val pr_open_constr         : open_constr -> Pp.t
 [@@ocaml.deprecated "The global printing API is deprecated, please use the _env functions"]
 
-val pr_open_lconstr_env    : env -> evar_map -> open_constr -> Pp.t
+val pr_open_lconstr_env    : States.state -> env -> evar_map -> open_constr -> Pp.t
 val pr_open_lconstr        : open_constr -> Pp.t
 [@@ocaml.deprecated "The global printing API is deprecated, please use the _env functions"]
 
-val pr_constr_under_binders_env  : env -> evar_map -> constr_under_binders -> Pp.t
+val pr_constr_under_binders_env  : States.state -> env -> evar_map -> constr_under_binders -> Pp.t
 val pr_constr_under_binders      : constr_under_binders -> Pp.t
 [@@ocaml.deprecated "The global printing API is deprecated, please use the _env functions"]
 
-val pr_lconstr_under_binders_env : env -> evar_map -> constr_under_binders -> Pp.t
+val pr_lconstr_under_binders_env : States.state -> env -> evar_map -> constr_under_binders -> Pp.t
 val pr_lconstr_under_binders     : constr_under_binders -> Pp.t
 [@@ocaml.deprecated "The global printing API is deprecated, please use the _env functions"]
 
-val pr_goal_concl_style_env : env -> evar_map -> EConstr.types -> Pp.t
-val pr_ltype_env           : env -> evar_map -> types -> Pp.t
+val pr_goal_concl_style_env : States.state -> env -> evar_map -> EConstr.types -> Pp.t
+val pr_ltype_env           : States.state -> env -> evar_map -> types -> Pp.t
 val pr_ltype               : types -> Pp.t
 [@@ocaml.deprecated "The global printing API is deprecated, please use the _env functions"]
 
-val pr_type_env            : env -> evar_map -> types -> Pp.t
+val pr_type_env            : States.state -> env -> evar_map -> types -> Pp.t
 val pr_type                : types -> Pp.t
 [@@ocaml.deprecated "The global printing API is deprecated, please use the _env functions"]
 
-val pr_closed_glob_n_env   : env -> evar_map -> Notation_gram.tolerability -> closed_glob_constr -> Pp.t
-val pr_closed_glob_env     : env -> evar_map -> closed_glob_constr -> Pp.t
+val pr_closed_glob_n_env   : States.state -> env -> evar_map -> Notation_gram.tolerability -> closed_glob_constr -> Pp.t
+val pr_closed_glob_env     : States.state -> env -> evar_map -> closed_glob_constr -> Pp.t
 val pr_closed_glob         : closed_glob_constr -> Pp.t
 [@@ocaml.deprecated "The global printing API is deprecated, please use the _env functions"]
 
-val pr_ljudge_env          : env -> evar_map -> EConstr.unsafe_judgment -> Pp.t * Pp.t
+val pr_ljudge_env          : States.state -> env -> evar_map -> EConstr.unsafe_judgment -> Pp.t * Pp.t
 val pr_ljudge              : EConstr.unsafe_judgment -> Pp.t * Pp.t
 [@@ocaml.deprecated "The global printing API is deprecated, please use the _env functions"]
 
-val pr_lglob_constr_env      : env -> 'a glob_constr_g -> Pp.t
+val pr_lglob_constr_env      : States.state -> env -> 'a glob_constr_g -> Pp.t
 val pr_lglob_constr          : 'a glob_constr_g -> Pp.t
 [@@ocaml.deprecated "The global printing API is deprecated, please use the _env functions"]
 
-val pr_glob_constr_env       : env -> 'a glob_constr_g -> Pp.t
+val pr_glob_constr_env       : States.state -> env -> 'a glob_constr_g -> Pp.t
 val pr_glob_constr           : 'a glob_constr_g -> Pp.t
 [@@ocaml.deprecated "The global printing API is deprecated, please use the _env functions"]
 
-val pr_lconstr_pattern_env : env -> evar_map -> constr_pattern -> Pp.t
+val pr_lconstr_pattern_env : States.state -> env -> evar_map -> constr_pattern -> Pp.t
 val pr_lconstr_pattern     : constr_pattern -> Pp.t
 [@@ocaml.deprecated "The global printing API is deprecated, please use the _env functions"]
 
-val pr_constr_pattern_env  : env -> evar_map -> constr_pattern -> Pp.t
+val pr_constr_pattern_env  : States.state -> env -> evar_map -> constr_pattern -> Pp.t
 val pr_constr_pattern      : constr_pattern -> Pp.t
 [@@ocaml.deprecated "The global printing API is deprecated, please use the _env functions"]
 
@@ -132,19 +132,19 @@ val pr_abstract_cumulativity_info   : evar_map -> Univ.ACumulativityInfo.t -> Pp
 
 (** Printing global references using names as short as possible *)
 
-val pr_global_env          : Id.Set.t -> GlobRef.t -> Pp.t
+val pr_global_env          : States.state -> Id.Set.t -> GlobRef.t -> Pp.t
 val pr_global              : GlobRef.t -> Pp.t
 
-val pr_constant            : env -> Constant.t -> Pp.t
+val pr_constant            : States.state -> env -> Constant.t -> Pp.t
 val pr_existential_key     : evar_map -> Evar.t -> Pp.t
-val pr_existential         : env -> evar_map -> existential -> Pp.t
-val pr_constructor         : env -> constructor -> Pp.t
-val pr_inductive           : env -> inductive -> Pp.t
+val pr_existential         : States.state -> env -> evar_map -> existential -> Pp.t
+val pr_constructor         : States.state -> env -> constructor -> Pp.t
+val pr_inductive           : States.state -> env -> inductive -> Pp.t
 val pr_evaluable_reference : evaluable_global_reference -> Pp.t
 
-val pr_pconstant : env -> evar_map -> pconstant -> Pp.t
-val pr_pinductive : env -> evar_map -> pinductive -> Pp.t
-val pr_pconstructor : env -> evar_map -> pconstructor -> Pp.t
+val pr_pconstant : States.state -> env -> evar_map -> pconstant -> Pp.t
+val pr_pinductive : States.state -> env -> evar_map -> pinductive -> Pp.t
+val pr_pconstructor : States.state -> env -> evar_map -> pconstructor -> Pp.t
 
 
 (** Contexts *)
@@ -152,18 +152,18 @@ val pr_pconstructor : env -> evar_map -> pconstructor -> Pp.t
 val set_compact_context : bool -> unit
 val get_compact_context : unit -> bool
 
-val pr_context_unlimited   : env -> evar_map -> Pp.t
-val pr_ne_context_of       : Pp.t -> env -> evar_map -> Pp.t
+val pr_context_unlimited   : States.state -> env -> evar_map -> Pp.t
+val pr_ne_context_of       : Pp.t -> States.state -> env -> evar_map -> Pp.t
 
-val pr_named_decl          : env -> evar_map -> Constr.named_declaration -> Pp.t
-val pr_compacted_decl      : env -> evar_map -> Constr.compacted_declaration -> Pp.t
-val pr_rel_decl            : env -> evar_map -> Constr.rel_declaration -> Pp.t
+val pr_named_decl          : States.state -> env -> evar_map -> Constr.named_declaration -> Pp.t
+val pr_compacted_decl      : States.state -> env -> evar_map -> Constr.compacted_declaration -> Pp.t
+val pr_rel_decl            : States.state -> env -> evar_map -> Constr.rel_declaration -> Pp.t
 
-val pr_named_context       : env -> evar_map -> Constr.named_context -> Pp.t
-val pr_named_context_of    : env -> evar_map -> Pp.t
-val pr_rel_context         : env -> evar_map -> Constr.rel_context -> Pp.t
-val pr_rel_context_of      : env -> evar_map -> Pp.t
-val pr_context_of          : env -> evar_map -> Pp.t
+val pr_named_context       : States.state -> env -> evar_map -> Constr.named_context -> Pp.t
+val pr_named_context_of    : States.state -> env -> evar_map -> Pp.t
+val pr_rel_context         : States.state -> env -> evar_map -> Constr.rel_context -> Pp.t
+val pr_rel_context_of      : States.state -> env -> evar_map -> Pp.t
+val pr_context_of          : States.state -> env -> evar_map -> Pp.t
 
 (** Predicates *)
 
@@ -216,10 +216,10 @@ val pr_concl               : int -> ?diffs:bool -> ?og_s:(goal sigma) -> evar_ma
 val pr_open_subgoals_diff  : ?quiet:bool -> ?diffs:bool -> ?oproof:Proof.t -> Proof.t -> Pp.t
 val pr_open_subgoals       : proof:Proof.t -> Pp.t
 val pr_nth_open_subgoal    : proof:Proof.t -> int -> Pp.t
-val pr_evar                : evar_map -> (Evar.t * evar_info) -> Pp.t
-val pr_evars_int           : evar_map -> shelf:goal list -> givenup:goal list -> int -> evar_info Evar.Map.t -> Pp.t
-val pr_evars               : evar_map -> evar_info Evar.Map.t -> Pp.t
-val pr_ne_evar_set         : Pp.t -> Pp.t -> evar_map ->
+val pr_evar                : States.state -> evar_map -> (Evar.t * evar_info) -> Pp.t
+val pr_evars_int           : States.state -> evar_map -> shelf:goal list -> givenup:goal list -> int -> evar_info Evar.Map.t -> Pp.t
+val pr_evars               : States.state -> evar_map -> evar_info Evar.Map.t -> Pp.t
+val pr_ne_evar_set         : Pp.t -> Pp.t -> States.state -> evar_map ->
   Evar.Set.t -> Pp.t
 
 val pr_prim_rule           : prim_rule -> Pp.t
@@ -248,7 +248,7 @@ module ContextObjectSet : Set.S with type elt = context_object
 module ContextObjectMap : CMap.ExtS
   with type key = context_object and module Set := ContextObjectSet
 
-val pr_assumptionset : env -> evar_map -> types ContextObjectMap.t -> Pp.t
+val pr_assumptionset : States.state -> env -> evar_map -> types ContextObjectMap.t -> Pp.t
 
 val pr_goal_by_id : proof:Proof.t -> Id.t -> Pp.t
 

--- a/printing/printmod.mli
+++ b/printing/printmod.mli
@@ -13,7 +13,7 @@ open Names
 (** false iff the module is an element of an open module type *)
 val printable_body : DirPath.t -> bool
 
-val pr_mutual_inductive_body : Environ.env ->
+val pr_mutual_inductive_body : States.state -> Environ.env ->
   MutInd.t -> Declarations.mutual_inductive_body ->
   UnivNames.univ_name_list option -> Pp.t
 val print_module : bool -> ModPath.t -> Pp.t

--- a/printing/proof_diffs.mli
+++ b/printing/proof_diffs.mli
@@ -48,9 +48,9 @@ val diff_goal : ?og_s:(goal sigma) -> goal -> Evd.evar_map -> Pp.t
 (** Convert a string to a list of token strings using the lexer *)
 val tokenize_string : string -> string list
 
-val pr_letype_core         : bool -> Environ.env -> Evd.evar_map -> EConstr.types -> Pp.t
-val pr_leconstr_core       : bool -> Environ.env -> Evd.evar_map -> EConstr.constr -> Pp.t
-val pr_lconstr_env         : env -> evar_map -> constr -> Pp.t
+val pr_letype_core         : bool -> States.state -> Environ.env -> Evd.evar_map -> EConstr.types -> Pp.t
+val pr_leconstr_core       : bool -> States.state -> Environ.env -> Evd.evar_map -> EConstr.constr -> Pp.t
+val pr_lconstr_env         : States.state -> env -> evar_map -> constr -> Pp.t
 
 (** Computes diffs for a single conclusion *)
 val diff_concl : ?og_s:goal sigma -> Evd.evar_map -> Goal.goal -> Pp.t

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -488,7 +488,7 @@ let clenv_unify_binding_type clenv c t u =
       let evd,c = w_coerce_to_type (cl_env clenv) clenv.evd c t u in
       TypeProcessed, { clenv with evd = evd }, c
     with 
-      | PretypeError (_,_,ActualTypeNotCoercible (_,_,
+      | PretypeError (_,_,_,ActualTypeNotCoercible (_,_,
           (NotClean _ | ConversionFailed _))) as e ->
 	  raise e
       | e when precatchable_exception e ->

--- a/proofs/logic.ml
+++ b/proofs/logic.ml
@@ -68,7 +68,7 @@ let catchable_exception = function
   (* reduction errors *)
   | Tacred.ReductionTacticError _ -> true
   (* unification and typing errors *)
-  | PretypeError(_,_, e) -> is_unification_error e || is_typing_error e 
+  | PretypeError(_,_,_,e) -> is_unification_error e || is_typing_error e
   | _ -> false
 
 let error_no_such_hypothesis env sigma id = raise (RefinerError (env, sigma, NoSuchHyp id))

--- a/proofs/refine.ml
+++ b/proofs/refine.ml
@@ -44,9 +44,6 @@ let typecheck_evar ev env sigma =
   let sigma, _ = Typing.sort_of env sigma (Evd.evar_concl info) in
   sigma
 
-let (pr_constrv,pr_constr) =
-  Hook.make ~default:(fun _env _sigma _c -> Pp.str"<constr>") ()
-
 (* Get the side-effect's constant declarations to update the monad's
   * environmnent *)
 let add_if_undefined env eff =
@@ -111,7 +108,7 @@ let generic_refine ~typecheck f gl =
   let sigma = CList.fold_left Proofview.Unsafe.mark_as_goal sigma comb in
   let comb = CList.map (fun x -> Proofview.goal_with_state x state) comb in
   let trace () = Pp.(hov 2 (str"simple refine"++spc()++
-                            Hook.get pr_constrv env sigma (EConstr.Unsafe.to_constr c))) in
+                            Termops.Internal.print_constr_env env sigma c)) in
   Proofview.Trace.name_tactic trace (Proofview.tclUNIT v) >>= fun v ->
   Proofview.Unsafe.tclSETENV (Environ.reset_context env) <*>
   Proofview.Unsafe.tclEVARS sigma <*>

--- a/proofs/refine.mli
+++ b/proofs/refine.mli
@@ -17,10 +17,6 @@ open Proofview
 
 (** {6 The refine tactic} *)
 
-(** Printer used to print the constr which refine refines. *)
-val pr_constr :
-  (Environ.env -> Evd.evar_map -> Constr.constr -> Pp.t) Hook.t
-
 (** {7 Refinement primitives} *)
 
 val refine : typecheck:bool -> (Evd.evar_map -> Evd.evar_map * EConstr.t) -> unit tactic

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -2024,9 +2024,10 @@ end = struct (* {{{ *)
           match Future.join f with
           | Some (pt, uc) ->
             let sigma, env = Pfedit.get_current_context () in
+            let state = States.get_state () in
             stm_pperr_endline (fun () -> hov 0 (
               str"g=" ++ int (Evar.repr gid) ++ spc () ++
-              str"t=" ++ (Printer.pr_constr_env env sigma pt) ++ spc () ++
+              str"t=" ++ (Printer.pr_constr_env state env sigma pt) ++ spc () ++
               str"uc=" ++ Termops.pr_evar_universe_context uc));
             (if abstract then Tactics.tclABSTRACT None else (fun x -> x))
               (V82.tactic (Refiner.tclPUSHEVARUNIVCONTEXT uc) <*>

--- a/tactics/auto.ml
+++ b/tactics/auto.ml
@@ -396,7 +396,8 @@ and tac_of_hint dbg db_list local_db concl (flags, ({pat=p; code=t;poly=poly;db=
     | Some n -> str " (in " ++ str n ++ str ")"
     in
     let sigma, env = Pfedit.get_current_context () in
-    pr_hint env sigma t ++ origin
+    let state = States.get_state () in
+    pr_hint state env sigma t ++ origin
   in
   tclLOG dbg pr_hint (run_hint t tactic)
 

--- a/tactics/autorewrite.mli
+++ b/tactics/autorewrite.mli
@@ -42,7 +42,7 @@ val auto_multi_rewrite : ?conds:conditions -> string list -> Locus.clause -> uni
 
 val auto_multi_rewrite_with : ?conds:conditions -> unit Proofview.tactic -> string list -> Locus.clause -> unit Proofview.tactic
 
-val print_rewrite_hintdb : Environ.env -> Evd.evar_map -> string -> Pp.t
+val print_rewrite_hintdb : States.state -> Environ.env -> Evd.evar_map -> string -> Pp.t
 
 open Clenv
 
@@ -60,5 +60,5 @@ type hypinfo = {
 
 val find_applied_relation :
   ?loc:Loc.t -> bool ->
-  Environ.env -> Evd.evar_map -> constr -> bool -> hypinfo
+  States.state -> Environ.env -> Evd.evar_map -> constr -> bool -> hypinfo
 

--- a/tactics/eauto.ml
+++ b/tactics/eauto.ml
@@ -145,16 +145,17 @@ let rec e_trivial_fail_db db_list local_db =
     e_trivial_fail_db db_list (Hint_db.add_list (Tacmach.New.pf_env gl) (Tacmach.New.project gl) hintl local_db)
   end in
   Proofview.Goal.enter begin fun gl ->
+  let state = States.get_state () in
   let secvars = compute_secvars gl in
   let tacl =
     registered_e_assumption ::
     (Tacticals.New.tclTHEN Tactics.intro next) ::
-    (List.map fst (e_trivial_resolve (Tacmach.New.pf_env gl) (Tacmach.New.project gl) db_list local_db secvars (Tacmach.New.pf_concl gl)))
+    (List.map fst (e_trivial_resolve state (Tacmach.New.pf_env gl) (Tacmach.New.project gl) db_list local_db secvars (Tacmach.New.pf_concl gl)))
   in
   Tacticals.New.tclFIRST (List.map Tacticals.New.tclCOMPLETE tacl)
   end
 
-and e_my_find_search env sigma db_list local_db secvars hdc concl =
+and e_my_find_search state env sigma db_list local_db secvars hdc concl =
   let hint_of_db = hintmap_of sigma secvars hdc concl in
   let hintl =
       List.map_append (fun db ->
@@ -179,19 +180,19 @@ and e_my_find_search env sigma db_list local_db secvars hdc concl =
         | Extern tacast -> conclPattern concl p tacast
        in
        let tac = run_hint t tac in
-       (tac, lazy (pr_hint env sigma t)))
+       (tac, lazy (pr_hint state env sigma t)))
   in
   List.map tac_of_hint hintl
 
-and e_trivial_resolve env sigma db_list local_db secvars gl =
+and e_trivial_resolve state env sigma db_list local_db secvars gl =
   let hd = try Some (decompose_app_bound sigma gl) with Bound -> None in
-  try priority (e_my_find_search env sigma db_list local_db secvars hd gl)
+  try priority (e_my_find_search state env sigma db_list local_db secvars hd gl)
   with Not_found -> []
 
-let e_possible_resolve env sigma db_list local_db secvars gl =
+let e_possible_resolve state env sigma db_list local_db secvars gl =
   let hd = try Some (decompose_app_bound sigma gl) with Bound -> None in
   try List.map (fun (b, (tac, pp)) -> (tac, b, pp))
-               (e_my_find_search env sigma db_list local_db secvars hd gl)
+               (e_my_find_search state env sigma db_list local_db secvars hd gl)
   with Not_found -> []
 
 let find_first_goal gls =
@@ -290,8 +291,9 @@ module SearchProblem = struct
       let rec_tacs =
 	let l =
           let concl = Reductionops.nf_evar (project g) (pf_concl g) in
+          let state = States.get_state () in
 	  filter_tactics s.tacres
-                         (e_possible_resolve (pf_env g) (project g) s.dblist (List.hd s.localdb) secvars concl)
+                         (e_possible_resolve state (pf_env g) (project g) s.dblist (List.hd s.localdb) secvars concl)
 	in
 	List.map
 	  (fun (lgls, cost, pp) ->

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -279,8 +279,8 @@ let general_elim_clause with_evars frzevars cls rew elim =
     | Some _ -> rewrite_elim with_evars frzevars cls rew elim
     end
     begin function (e, info) -> match e with
-    | PretypeError (env, evd, NoOccurrenceFound (c', _)) ->
-      Proofview.tclZERO (PretypeError (env, evd, NoOccurrenceFound (c', cls)))
+    | PretypeError (state, env, evd, NoOccurrenceFound (c', _)) ->
+      Proofview.tclZERO (PretypeError (state, env, evd, NoOccurrenceFound (c', cls)))
     | e -> Proofview.tclZERO ~info e
     end
 

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -837,12 +837,13 @@ let make_apply_entry env sigma (eapply,hnf,verbose) info poly ?(name=PathAny) (c
     else begin
       if not eapply then failwith "make_apply_entry";
       if verbose then begin
+        let state = States.get_state () in
         let variables = str (CString.plural nmiss "variable") in
         Feedback.msg_info (
           strbrk "The hint " ++
-          pr_leconstr_env env sigma' c ++
+          pr_leconstr_env state env sigma' c ++
           strbrk " will only be used by eauto, because applying " ++
-          pr_leconstr_env env sigma' c ++
+          pr_leconstr_env state env sigma' c ++
           strbrk " would leave " ++ variables ++ Pp.spc () ++
           Pp.prlist_with_sep Pp.pr_comma Name.print (List.map (Evd.meta_name ce.evd) miss) ++
           strbrk " as unresolved existential " ++ variables ++ str "."
@@ -859,11 +860,11 @@ let make_apply_entry env sigma (eapply,hnf,verbose) info poly ?(name=PathAny) (c
    c is a constr
    cty is the type of constr *)
 
-let pr_hint_term env sigma ctx = function
+let pr_hint_term state env sigma ctx = function
   | IsGlobRef gr -> pr_global gr
   | IsConstr (c, ctx) ->
      let sigma = Evd.merge_context_set Evd.univ_flexible sigma ctx in
-     pr_econstr_env env sigma c
+     pr_econstr_env state env sigma c
 
 let warn_polymorphic_hint =
   CWarnings.create ~name:"polymorphic-hint" ~category:"automation"
@@ -882,8 +883,10 @@ let fresh_global_or_constr env sigma poly cr =
     if poly then (c, ctx)
     else if Univ.ContextSet.is_empty ctx then (c, ctx)
     else begin
-      if isgr then
-        warn_polymorphic_hint (pr_hint_term env sigma ctx cr);
+      if isgr then begin
+        let state = States.get_state () in
+        warn_polymorphic_hint (pr_hint_term state env sigma ctx cr)
+        end;
       Declare.declare_universe_context false ctx;
       (c, Univ.ContextSet.empty)
     end
@@ -897,11 +900,13 @@ let make_resolves env sigma flags info poly ?name cr =
 			     [make_exact_entry env sigma info poly ?name;
 			      make_apply_entry env sigma flags info poly ?name]
   in
-  if List.is_empty ents then
+  if List.is_empty ents then begin
+    let state = States.get_state () in
     user_err ~hdr:"Hint"
-      (pr_leconstr_env env sigma c ++ spc() ++
+      (pr_leconstr_env state env sigma c ++ spc() ++
         (if pi1 flags then str"cannot be used as a hint."
-	else str "can be used as a hint only for eauto."));
+        else str "can be used as a hint only for eauto."))
+    end;
   ents
 
 (* used to add an hypothesis to the local hint database *)
@@ -1442,34 +1447,34 @@ let make_db_list dbnames =
 (*                    Functions for printing the hints                    *)
 (**************************************************************************)
 
-let pr_hint_elt env sigma (c, _, _) = pr_econstr_env env sigma c
+let pr_hint_elt state env sigma (c, _, _) = pr_econstr_env state env sigma c
 
-let pr_hint env sigma h = match h.obj with
-  | Res_pf (c, _) -> (str"simple apply " ++ pr_hint_elt env sigma c)
-  | ERes_pf (c, _) -> (str"simple eapply " ++ pr_hint_elt env sigma c)
-  | Give_exact (c, _) -> (str"exact " ++ pr_hint_elt env sigma c)
+let pr_hint state env sigma h = match h.obj with
+  | Res_pf (c, _) -> (str"simple apply " ++ pr_hint_elt state env sigma c)
+  | ERes_pf (c, _) -> (str"simple eapply " ++ pr_hint_elt state env sigma c)
+  | Give_exact (c, _) -> (str"exact " ++ pr_hint_elt state env sigma c)
   | Res_pf_THEN_trivial_fail (c, _) ->
-      (str"simple apply " ++ pr_hint_elt env sigma c ++ str" ; trivial")
+      (str"simple apply " ++ pr_hint_elt state env sigma c ++ str" ; trivial")
   | Unfold_nth c ->
     str"unfold " ++  pr_evaluable_reference c
   | Extern tac ->
     str "(*external*) " ++ Pputils.pr_glb_generic env tac
 
-let pr_id_hint env sigma (id, v) =
-  let pr_pat p = str", pattern " ++ pr_lconstr_pattern_env env sigma p in
-  (pr_hint env sigma v.code ++ str"(level " ++ int v.pri ++ pr_opt_no_spc pr_pat v.pat
+let pr_id_hint state env sigma (id, v) =
+  let pr_pat p = str", pattern " ++ pr_lconstr_pattern_env state env sigma p in
+  (pr_hint state env sigma v.code ++ str"(level " ++ int v.pri ++ pr_opt_no_spc pr_pat v.pat
    ++ str", id " ++ int id ++ str ")" ++ spc ())
 
-let pr_hint_list env sigma hintlist =
-  (str "  " ++ hov 0 (prlist (pr_id_hint env sigma) hintlist) ++ fnl ())
+let pr_hint_list state env sigma hintlist =
+  (str "  " ++ hov 0 (prlist (pr_id_hint state env sigma) hintlist) ++ fnl ())
 
-let pr_hints_db env sigma (name,db,hintlist) =
+let pr_hints_db state env sigma (name,db,hintlist) =
   (str "In the database " ++ str name ++ str ":" ++
      if List.is_empty hintlist then (str " nothing" ++ fnl ())
-     else (fnl () ++ pr_hint_list env sigma hintlist))
+     else (fnl () ++ pr_hint_list state env sigma hintlist))
 
 (* Print all hints associated to head c in any database *)
-let pr_hint_list_for_head env sigma c =
+let pr_hint_list_for_head state env sigma c =
   let dbs = current_db () in
   let validate (name, db) =
     let hints = List.map (fun v -> 0, v) (Hint_db.map_all ~secvars:Id.Pred.full c db) in
@@ -1481,13 +1486,13 @@ let pr_hint_list_for_head env sigma c =
   else
     hov 0
       (str"For " ++ pr_global c ++ str" -> " ++ fnl () ++
-         hov 0 (prlist (pr_hints_db env sigma) valid_dbs))
+         hov 0 (prlist (pr_hints_db state env sigma) valid_dbs))
 
 let pr_hint_ref ref = pr_hint_list_for_head ref
 
 (* Print all hints associated to head id in any database *)
 
-let pr_hint_term env sigma cl =
+let pr_hint_term state env sigma cl =
   try
     let dbs = current_db () in
     let valid_dbs =
@@ -1505,7 +1510,7 @@ let pr_hint_term env sigma cl =
 	(str "No hint applicable for current goal")
       else
 	(str "Applicable Hints :" ++ fnl () ++
-            hov 0 (prlist (pr_hints_db env sigma) valid_dbs))
+            hov 0 (prlist (pr_hints_db state env sigma) valid_dbs))
   with Match_failure _ | Failure _ ->
     (str "No hint applicable for current goal")
 
@@ -1513,11 +1518,12 @@ let pr_hint_term env sigma cl =
 let pr_applicable_hint () =
   let env = Global.env () in
   let pts = Proof_global.give_me_the_proof () in
+  let state = States.get_state () in
   let glss,_,_,_,sigma = Proof.proof pts in
   match glss with
   | [] -> CErrors.user_err Pp.(str "No focused goal.")
   | g::_ ->
-    pr_hint_term env sigma (Goal.V82.concl sigma g)
+    pr_hint_term state env sigma (Goal.V82.concl sigma g)
 
 let pp_hint_mode = function
   | ModeInput -> str"+"
@@ -1525,7 +1531,7 @@ let pp_hint_mode = function
   | ModeOutput -> str"-"
 
 (* displays the whole hint database db *)
-let pr_hint_db_env env sigma db =
+let pr_hint_db_env state env sigma db =
   let pr_mode = prvect_with_sep spc pp_hint_mode in
   let pr_modes l =
     if List.is_empty l then mt ()
@@ -1537,7 +1543,7 @@ let pr_hint_db_env env sigma db =
       | None -> str "For any goal"
       | Some head -> str "For " ++ pr_global head ++ pr_modes modes
       in
-      let hints = pr_hint_list env sigma (List.map (fun x -> (0, x)) hintlist) in
+      let hints = pr_hint_list state env sigma (List.map (fun x -> (0, x)) hintlist) in
       let hint_descr = hov 0 (goal_descr ++ str " -> " ++ hints) in
       accu ++ hint_descr
     in
@@ -1555,19 +1561,20 @@ let pr_hint_db_env env sigma db =
 (* Deprecated in the mli *)
 let pr_hint_db db =
   let sigma, env = Pfedit.get_current_context () in
-  pr_hint_db_env env sigma db
+  let state = States.get_state () in
+  pr_hint_db_env state env sigma db
 
-let pr_hint_db_by_name env sigma dbname =
+let pr_hint_db_by_name state env sigma dbname =
   try
-    let db = searchtable_map dbname in pr_hint_db_env env sigma db
+    let db = searchtable_map dbname in pr_hint_db_env state env sigma db
   with Not_found ->
     error_no_such_hint_database dbname
 
 (* displays all the hints of all databases *)
-let pr_searchtable env sigma =
+let pr_searchtable state env sigma =
   let fold name db accu =
     accu ++ str "In the database " ++ str name ++ str ":" ++ fnl () ++
-    pr_hint_db_env env sigma db ++ fnl ()
+    pr_hint_db_env state env sigma db ++ fnl ()
   in
   Hintdbmap.fold fold !searchtable (mt ())
 
@@ -1588,7 +1595,8 @@ let warn h x =
   let open Proofview in
   tclBIND tclENV     (fun env   ->
   tclBIND tclEVARMAP (fun sigma ->
-          let hint = pr_hint env sigma h in
+          let state = States.get_state () in
+          let hint = pr_hint state env sigma h in
           let (mp, _, _) = KerName.repr h.uid in
           warn_non_imported_hint (hint,mp);
           Proofview.tclUNIT x))

--- a/tactics/hints.mli
+++ b/tactics/hints.mli
@@ -284,14 +284,14 @@ val rewrite_db : hint_db_name
 
 (** Printing  hints *)
 
-val pr_searchtable : env -> evar_map -> Pp.t
+val pr_searchtable : States.state -> env -> evar_map -> Pp.t
 val pr_applicable_hint : unit -> Pp.t
-val pr_hint_ref : env -> evar_map -> GlobRef.t -> Pp.t
-val pr_hint_db_by_name : env -> evar_map -> hint_db_name -> Pp.t
-val pr_hint_db_env : env -> evar_map -> Hint_db.t -> Pp.t
+val pr_hint_ref : States.state -> env -> evar_map -> GlobRef.t -> Pp.t
+val pr_hint_db_by_name : States.state -> env -> evar_map -> hint_db_name -> Pp.t
+val pr_hint_db_env : States.state -> env -> evar_map -> Hint_db.t -> Pp.t
 val pr_hint_db : Hint_db.t -> Pp.t
 [@@ocaml.deprecated "please used pr_hint_db_env"]
-val pr_hint : env -> evar_map -> hint -> Pp.t
+val pr_hint : States.state -> env -> evar_map -> hint -> Pp.t
 
 type nonrec hint_info = hint_info
 [@@ocaml.deprecated "Use [Typeclasses.hint_info]"]

--- a/tactics/inv.ml
+++ b/tactics/inv.ml
@@ -289,11 +289,12 @@ let error_too_many_names pats =
   let loc = Loc.merge_opt (List.hd pats).CAst.loc (List.last pats).CAst.loc in
   Proofview.tclENV >>= fun env ->
   Proofview.tclEVARMAP >>= fun sigma ->
+  let state = States.get_state () in
   tclZEROMSG ?loc (
     str "Unexpected " ++
     str (String.plural (List.length pats) "introduction pattern") ++
     str ": " ++ pr_enum (Miscprint.pr_intro_pattern
-                           (fun c -> Printer.pr_econstr_env env sigma (snd (c env (Evd.from_env env))))) pats ++
+                           (fun c -> Printer.pr_econstr_env state env sigma (snd (c env (Evd.from_env env))))) pats ++
     str ".")
 
 let get_names (allow_conj,issimple) ({CAst.loc;v=pat} as x) = match pat with
@@ -498,11 +499,12 @@ let wrap_inv_error id = function (e, info) -> match e with
       (_, Indrec.NotAllowedCaseAnalysis (_,(Type _ | Set as k),i)) ->
       Proofview.tclENV >>= fun env ->
       Proofview.tclEVARMAP >>= fun sigma ->
+      let state = States.get_state () in
       tclZEROMSG (
 	(strbrk "Inversion would require case analysis on sort " ++
         pr_sort sigma k ++
 	strbrk " which is not allowed for inductive definition " ++
-	pr_inductive env (fst i) ++ str "."))
+        pr_inductive state env (fst i) ++ str "."))
   | e -> Proofview.tclZERO ~info e
 
 (* The most general inversion tactic *)

--- a/tactics/inv.ml
+++ b/tactics/inv.ml
@@ -495,7 +495,7 @@ let raw_inversion inv_kind id status names =
 (* Error messages of the inversion tactics *)
 let wrap_inv_error id = function (e, info) -> match e with
   | Indrec.RecursionSchemeError
-      (Indrec.NotAllowedCaseAnalysis (_,(Type _ | Set as k),i)) ->
+      (_, Indrec.NotAllowedCaseAnalysis (_,(Type _ | Set as k),i)) ->
       Proofview.tclENV >>= fun env ->
       Proofview.tclEVARMAP >>= fun sigma ->
       tclZEROMSG (

--- a/tactics/tacticals.ml
+++ b/tactics/tacticals.ml
@@ -640,6 +640,7 @@ module New = struct
     let ind = on_snd (fun u -> EInstance.kind sigma u) ind in
     Proofview.tclTHEN (Proofview.Unsafe.tclEVARS sigma)
     (Proofview.Goal.enter begin fun gl ->
+    let state = States.get_state () in
     let indclause = mk_clenv_from gl (c, t) in
     (* applying elimination_scheme just a little modified *)
     let elimclause = mk_clenv_from gl (elim,Tacmach.New.pf_unsafe_type_of gl elim)  in
@@ -655,7 +656,7 @@ module New = struct
       | _ ->
 	  let name_elim =
 	    match EConstr.kind sigma elim with
-            | Const _ | Var _ -> str " " ++ Printer.pr_econstr_env (pf_env gl) sigma elim
+            | Const _ | Var _ -> str " " ++ Printer.pr_econstr_env state (pf_env gl) sigma elim
             | _ -> mt ()
 	  in
 	  user_err ~hdr:"Tacticals.general_elim_then_using"

--- a/test-suite/output/PrintModule.out
+++ b/test-suite/output/PrintModule.out
@@ -1,5 +1,9 @@
 Module N : S with Definition T := nat := M
 
+Module N : S with Definition T := M
+
 Module N : S with Module T := K := M
+
+Module N : S with Module T := M
 
 Module Type Func = Funsig (T0:Test) Sig Parameter x : T0.t. End

--- a/test-suite/output/PrintModule.v
+++ b/test-suite/output/PrintModule.v
@@ -1,3 +1,5 @@
+(* Bug #2169 *)
+
 Module FOO.
 
 Module M.
@@ -11,6 +13,10 @@ End S.
 Module N : S with Definition T := nat := M.
 
 Print Module N.
+
+Set Short Module Printing.
+Print Module N.
+Unset Short Module Printing.
 
 End FOO.
 
@@ -31,7 +37,13 @@ Module N : S with Module T := K := M.
 
 Print Module N.
 
+Set Short Module Printing.
+Print Module N.
+Unset Short Module Printing.
+
 End BAR.
+
+(* Bug #4661 *)
 
 Module QUX.
 

--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -533,7 +533,8 @@ let start_coq custom =
     flush_all();
     if opts.output_context then begin
       let sigma, env = Pfedit.get_current_context () in
-      Feedback.msg_notice (Flags.(with_option raw_print (Prettyp.print_full_pure_context env) sigma) ++ fnl ())
+      let state = States.get_state () in
+      Feedback.msg_notice (Flags.(with_option raw_print (Prettyp.print_full_pure_context state env) sigma) ++ fnl ())
     end;
     CProfile.print_profile ();
     exit 0

--- a/vernac/auto_ind_decl.ml
+++ b/vernac/auto_ind_decl.ml
@@ -407,11 +407,12 @@ let do_replace_lb mode lb_scheme_key aavoid narg p q =
         with Not_found ->
           (* spiwack: the format of this error message should probably
 	              be improved. *)
+          let state = States.get_state () in
           let err_msg =
 	    (str "Leibniz->boolean:" ++
              str "You have to declare the" ++
 	     str "decidability over " ++
-             Printer.pr_econstr_env env sigma type_of_pq ++
+             Printer.pr_econstr_env state env sigma type_of_pq ++
 	     str " first.")
           in
           Tacticals.New.tclZEROMSG err_msg
@@ -477,11 +478,12 @@ let do_replace_bl mode bl_scheme_key (ind,u as indu) aavoid narg lft rgt =
                with Not_found ->
 		 (* spiwack: the format of this error message should probably
 	                     be improved. *)
+                 let state = States.get_state () in
 		 let err_msg =
 	                                (str "boolean->Leibniz:" ++
                                          str "You have to declare the" ++
 			   	         str "decidability over " ++
-                                         Printer.pr_econstr_env env sigma tt1 ++
+                                         Printer.pr_econstr_env state env sigma tt1 ++
 				         str " first.")
 		 in
 		 user_err err_msg
@@ -550,8 +552,11 @@ let eqI ind l =
                            (List.map (fun (_,seq,_,_)-> mkVar seq) list_id ))
   and e, eff = 
     try let c, eff = find_scheme beq_scheme_kind ind in mkConst c, eff 
-    with Not_found -> user_err ~hdr:"AutoIndDecl.eqI"
-      (str "The boolean equality on " ++ Printer.pr_inductive (Global.env ()) ind ++ str " is needed.");
+    with Not_found ->
+      let state = States.get_state () in
+      let env = Global.env () in
+      user_err ~hdr:"AutoIndDecl.eqI"
+      (str "The boolean equality on " ++ Printer.pr_inductive state env ind ++ str " is needed.");
   in (if Array.equal Constr.equal eA [||] then e else mkApp(e,eA)), eff
 
 (**********************************************************************)

--- a/vernac/comProgramFixpoint.ml
+++ b/vernac/comProgramFixpoint.ml
@@ -91,6 +91,7 @@ let build_wellfounded (recname,pl,n,bl,arityc,body) poly r measure notation =
   let lift_rel_context n l = Termops.map_rel_context_with_binders (liftn n) l in
   Coqlib.check_required_library ["Coq";"Program";"Wf"];
   let env = Global.env() in
+  let state = States.get_state () in
   let sigma, decl = Constrexpr_ops.interp_univ_decl_opt env pl in
   let sigma, (_, ((env', binders_rel), impls)) = interp_context_evars env sigma bl in
   let len = List.length binders_rel in
@@ -108,7 +109,7 @@ let build_wellfounded (recname,pl,n,bl,arityc,body) poly r measure notation =
     let error () =
       user_err ?loc:(constr_loc r)
                ~hdr:"Command.build_wellfounded"
-                    (Printer.pr_econstr_env env sigma rel ++ str " is not an homogeneous binary relation.")
+                    (Printer.pr_econstr_env state env sigma rel ++ str " is not an homogeneous binary relation.")
     in
       try
         let ctx, ar = Reductionops.splay_prod_n env sigma 2 relty in

--- a/vernac/explainErr.ml
+++ b/vernac/explainErr.ml
@@ -59,31 +59,39 @@ let process_vernac_interp_error exn = match fst exn with
       else
 	mt() in
     wrap_vernac_error exn (str "Universe inconsistency" ++ msg ++ str ".")
-  | TypeError(ctx,te) ->
+  | TypeError(env,te) ->
+      let state = States.get_state () in
       let te = Himsg.map_ptype_error EConstr.of_constr te in
-      wrap_vernac_error exn (Himsg.explain_type_error ctx Evd.empty te)
-  | PretypeError(ctx,sigma,te) ->
-      wrap_vernac_error exn (Himsg.explain_pretype_error ctx sigma te)
-  | Notation.NumeralNotationError(ctx,sigma,te) ->
-      wrap_vernac_error exn (Himsg.explain_numeral_notation_error ctx sigma te)
+      wrap_vernac_error exn (Himsg.explain_type_error state env Evd.empty te)
+  | PretypeError(state,env,sigma,te) ->
+      wrap_vernac_error exn (Himsg.explain_pretype_error state env sigma te)
+  | Notation.NumeralNotationError(state,env,sigma,te) ->
+      wrap_vernac_error exn (Himsg.explain_numeral_notation_error state env sigma te)
   | Typeclasses_errors.TypeClassError(env, te) ->
-      wrap_vernac_error exn (Himsg.explain_typeclass_error env te)
+      let state = States.get_state () in
+      wrap_vernac_error exn (Himsg.explain_typeclass_error state env te)
   | Implicit_quantifiers.MismatchedContextInstance(e,c,l,x) ->
-    wrap_vernac_error exn (Himsg.explain_mismatched_contexts e c l x)
+      let state = States.get_state () in
+      wrap_vernac_error exn (Himsg.explain_mismatched_contexts state e c l x)
   | InductiveError e ->
-      wrap_vernac_error exn (Himsg.explain_inductive_error e)
+      let state = States.get_state () in
+      wrap_vernac_error exn (Himsg.explain_inductive_error state e)
   | Modops.ModuleTypingError e ->
-      wrap_vernac_error exn (Himsg.explain_module_error e)
+      let state = States.get_state () in
+      wrap_vernac_error exn (Himsg.explain_module_error state e)
   | Modintern.ModuleInternalizationError e ->
       wrap_vernac_error exn (Himsg.explain_module_internalization_error e)
   | RecursionSchemeError (env,e) ->
-      wrap_vernac_error exn (Himsg.explain_recursion_scheme_error env e)
+      let state = States.get_state () in
+      wrap_vernac_error exn (Himsg.explain_recursion_scheme_error state env e)
   | Cases.PatternMatchingError (env,sigma,e) ->
-      wrap_vernac_error exn (Himsg.explain_pattern_matching_error env sigma e)
+      let state = States.get_state () in
+      wrap_vernac_error exn (Himsg.explain_pattern_matching_error state env sigma e)
   | Tacred.ReductionTacticError e ->
       wrap_vernac_error exn (Himsg.explain_reduction_tactic_error e)
   | Logic.RefinerError (env, sigma, e) ->
-    wrap_vernac_error exn (Himsg.explain_refiner_error env sigma e)
+      let state = States.get_state () in
+      wrap_vernac_error exn (Himsg.explain_refiner_error state env sigma e)
   | Nametab.GlobalizationError q ->
       wrap_vernac_error exn
         (str "The reference" ++ spc () ++ Libnames.pr_qualid q ++

--- a/vernac/explainErr.ml
+++ b/vernac/explainErr.ml
@@ -76,8 +76,8 @@ let process_vernac_interp_error exn = match fst exn with
       wrap_vernac_error exn (Himsg.explain_module_error e)
   | Modintern.ModuleInternalizationError e ->
       wrap_vernac_error exn (Himsg.explain_module_internalization_error e)
-  | RecursionSchemeError e ->
-      wrap_vernac_error exn (Himsg.explain_recursion_scheme_error e)
+  | RecursionSchemeError (env,e) ->
+      wrap_vernac_error exn (Himsg.explain_recursion_scheme_error env e)
   | Cases.PatternMatchingError (env,sigma,e) ->
       wrap_vernac_error exn (Himsg.explain_pattern_matching_error env sigma e)
   | Tacred.ReductionTacticError e ->

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -90,9 +90,9 @@ let jv_nf_betaiotaevar env sigma jl =
 
 (** Printers *)
 
-let pr_lconstr_env e s c = quote (pr_lconstr_env e s c)
-let pr_leconstr_env e s c = quote (pr_leconstr_env e s c)
-let pr_ljudge_env e s c = let v,t = pr_ljudge_env e s c in (quote v,quote t)
+let pr_lconstr_env st e s c = quote (pr_lconstr_env st e s c)
+let pr_leconstr_env st e s c = quote (pr_leconstr_env st e s c)
+let pr_ljudge_env st e s c = let v,t = pr_ljudge_env st e s c in (quote v,quote t)
 
 (** A canonisation procedure for constr such that comparing there
     externalisation catches more equalities *)
@@ -112,31 +112,31 @@ let canonize_constr sigma c =
   canonize_binders c
 
 (** Tries to realize when the two terms, albeit different are printed the same. *)
-let display_eq ~flags env sigma t1 t2 =
+let display_eq ~flags state env sigma t1 t2 =
   (* terms are canonized, then their externalisation is compared syntactically *)
   let open Constrextern in
   let t1 = canonize_constr sigma t1 in
   let t2 = canonize_constr sigma t2 in
-  let ct1 = Flags.with_options flags (fun () -> extern_constr false env sigma t1) () in
-  let ct2 = Flags.with_options flags (fun () -> extern_constr false env sigma t2) () in
+  let ct1 = Flags.with_options flags (fun () -> extern_constr false state env sigma t1) () in
+  let ct2 = Flags.with_options flags (fun () -> extern_constr false state env sigma t2) () in
   Constrexpr_ops.constr_expr_eq ct1 ct2
 
 (** This function adds some explicit printing flags if the two arguments are
     printed alike. *)
-let rec pr_explicit_aux env sigma t1 t2 = function
+let rec pr_explicit_aux state env sigma t1 t2 = function
 | [] ->
   (** no specified flags: default. *)
-  (quote (Printer.pr_leconstr_env env sigma t1), quote (Printer.pr_leconstr_env env sigma t2))
+  (quote (Printer.pr_leconstr_env state env sigma t1), quote (Printer.pr_leconstr_env state env sigma t2))
 | flags :: rem ->
-  let equal = display_eq ~flags env sigma t1 t2 in
+  let equal = display_eq ~flags state env sigma t1 t2 in
   if equal then
     (** The two terms are the same from the user point of view *)
-    pr_explicit_aux env sigma t1 t2 rem
+    pr_explicit_aux state env sigma t1 t2 rem
   else
     let open Constrextern in
-    let ct1 = Flags.with_options flags (fun () -> extern_constr false env sigma t1) ()
+    let ct1 = Flags.with_options flags (fun () -> extern_constr false state env sigma t1) ()
     in
-    let ct2 = Flags.with_options flags (fun () -> extern_constr false env sigma t2) ()
+    let ct2 = Flags.with_options flags (fun () -> extern_constr false state env sigma t2) ()
     in
     quote (Ppconstr.pr_lconstr_expr ct1), quote (Ppconstr.pr_lconstr_expr ct2)
 
@@ -149,8 +149,8 @@ let explicit_flags =
     [print_implicits; print_coercions; print_no_symbol]; (** Then more! *)
     [print_universes; print_implicits; print_coercions; print_no_symbol] (** and more! *) ]
 
-let pr_explicit env sigma t1 t2 =
-  pr_explicit_aux env sigma t1 t2 explicit_flags
+let pr_explicit state env sigma t1 t2 =
+  pr_explicit_aux state env sigma t1 t2 explicit_flags
 
 let pr_db env i =
   try
@@ -159,8 +159,8 @@ let pr_db env i =
       | Anonymous -> str "<>"
   with Not_found -> str "UNBOUND_REL_" ++ int i
 
-let explain_unbound_rel env sigma n =
-  let pe = pr_ne_context_of (str "In environment") env sigma in
+let explain_unbound_rel state env sigma n =
+  let pe = pr_ne_context_of (str "In environment") state env sigma in
   str "Unbound reference: " ++ pe ++
   str "The reference " ++ int n ++ str " is free."
 
@@ -168,16 +168,16 @@ let explain_unbound_var env v =
   let var = Id.print v in
   str "No such section variable or assumption: " ++ var ++ str "."
 
-let explain_not_type env sigma j =
-  let pe = pr_ne_context_of (str "In environment") env sigma in
-  let pc,pt = pr_ljudge_env env sigma j in
+let explain_not_type state env sigma j =
+  let pe = pr_ne_context_of (str "In environment") state env sigma in
+  let pc,pt = pr_ljudge_env state env sigma j in
   pe ++ str "The term" ++ brk(1,1) ++ pc ++ spc () ++
   str "has type" ++ spc () ++ pt ++ spc () ++
   str "which should be Set, Prop or Type."
 
-let explain_bad_assumption env sigma j =
-  let pe = pr_ne_context_of (str "In environment") env sigma in
-  let pc,pt = pr_ljudge_env env sigma j in
+let explain_bad_assumption state env sigma j =
+  let pe = pr_ne_context_of (str "In environment") state env sigma in
+  let pc,pt = pr_ljudge_env state env sigma j in
   pe ++ str "Cannot declare a variable or hypothesis over the term" ++
   brk(1,1) ++ pc ++ spc () ++ str "of type" ++ spc () ++ pt ++ spc () ++
   str "because this term is not a type."
@@ -194,11 +194,11 @@ let rec pr_disjunction pr = function
   | a::l -> pr a ++ str "," ++ spc () ++ pr_disjunction pr l
   | [] -> assert false
 
-let explain_elim_arity env sigma ind sorts c pj okinds =
+let explain_elim_arity state env sigma ind sorts c pj okinds =
   let open EConstr in
   let env = make_all_name_different env sigma in
-  let pi = pr_inductive env (fst ind) in
-  let pc = pr_leconstr_env env sigma c in
+  let pi = pr_inductive state env (fst ind) in
+  let pc = pr_leconstr_env state env sigma c in
   let msg = match okinds with
   | Some(kp,ki,explanation) ->
       let pki = pr_sort_family ki in
@@ -211,7 +211,7 @@ let explain_elim_arity env sigma ind sorts c pj okinds =
 	| WrongArity ->
 	  "wrong arity" in
       let ppar = pr_disjunction (fun s -> quote (pr_sort_family s)) sorts in
-      let ppt = pr_leconstr_env env sigma (snd (decompose_prod_assum sigma pj.uj_type)) in
+      let ppt = pr_leconstr_env state env sigma (snd (decompose_prod_assum sigma pj.uj_type)) in
       hov 0
 	(str "the return type has sort" ++ spc () ++ ppt ++ spc () ++
 	 str "while it" ++ spc () ++ str "should be " ++ ppar ++ str ".") ++
@@ -229,10 +229,10 @@ let explain_elim_arity env sigma ind sorts c pj okinds =
     str "in the inductive type" ++ spc () ++ quote pi ++ str ":") ++
   fnl () ++ msg
 
-let explain_case_not_inductive env sigma cj =
+let explain_case_not_inductive state env sigma cj =
   let env = make_all_name_different env sigma in
-  let pc = pr_leconstr_env env sigma cj.uj_val in
-  let pct = pr_leconstr_env env sigma cj.uj_type in
+  let pc = pr_leconstr_env state env sigma cj.uj_val in
+  let pct = pr_leconstr_env state env sigma cj.uj_type in
     match EConstr.kind sigma cj.uj_type with
       | Evar _ ->
 	  str "Cannot infer a type for this expression."
@@ -241,49 +241,49 @@ let explain_case_not_inductive env sigma cj =
 	  str "has type" ++ brk(1,1) ++ pct ++ spc () ++
 	  str "which is not a (co-)inductive type."
 
-let explain_number_branches env sigma cj expn =
+let explain_number_branches state env sigma cj expn =
   let env = make_all_name_different env sigma in
-  let pc = pr_leconstr_env env sigma cj.uj_val in
-  let pct = pr_leconstr_env env sigma cj.uj_type in
+  let pc = pr_leconstr_env state env sigma cj.uj_val in
+  let pct = pr_leconstr_env state env sigma cj.uj_type in
   str "Matching on term" ++ brk(1,1) ++ pc ++ spc () ++
   str "of type" ++ brk(1,1) ++ pct ++ spc () ++
   str "expects " ++  int expn ++ str " branches."
 
-let explain_ill_formed_branch env sigma c ci actty expty =
+let explain_ill_formed_branch state env sigma c ci actty expty =
   let simp t = Reductionops.nf_betaiota env sigma t in
   let env = make_all_name_different env sigma in
-  let pc = pr_leconstr_env env sigma c in
-  let pa, pe = pr_explicit env sigma (simp actty) (simp expty) in
+  let pc = pr_leconstr_env state env sigma c in
+  let pa, pe = pr_explicit state env sigma (simp actty) (simp expty) in
   strbrk "In pattern-matching on term" ++ brk(1,1) ++ pc ++
   spc () ++ strbrk "the branch for constructor" ++ spc () ++
-  quote (pr_pconstructor env sigma ci) ++
+  quote (pr_pconstructor state env sigma ci) ++
   spc () ++ str "has type" ++ brk(1,1) ++ pa ++ spc () ++
   str "which should be" ++ brk(1,1) ++ pe ++ str "."
 
-let explain_generalization env sigma (name,var) j =
-  let pe = pr_ne_context_of (str "In environment") env sigma in
-  let pv = pr_letype_env env sigma var in
-  let (pc,pt) = pr_ljudge_env (push_rel_assum (name,var) env) sigma j in
+let explain_generalization state env sigma (name,var) j =
+  let pe = pr_ne_context_of (str "In environment") state env sigma in
+  let pv = pr_letype_env state env sigma var in
+  let (pc,pt) = pr_ljudge_env state (push_rel_assum (name,var) env) sigma j in
   pe ++ str "Cannot generalize" ++ brk(1,1) ++ pv ++ spc () ++
   str "over" ++ brk(1,1) ++ pc ++ str "," ++ spc () ++
   str "it has type" ++ spc () ++ pt ++
   spc () ++ str "which should be Set, Prop or Type."
 
-let explain_unification_error env sigma p1 p2 = function
+let explain_unification_error state env sigma p1 p2 = function
   | None -> mt()
   | Some e ->
      let rec aux p1 p2 = function
      | OccurCheck (evk,rhs) ->
         [str "cannot define " ++ quote (pr_existential_key sigma evk) ++
-	strbrk " with term " ++ pr_leconstr_env env sigma rhs ++
+        strbrk " with term " ++ pr_leconstr_env state env sigma rhs ++
         strbrk " that would depend on itself"]
      | NotClean ((evk,args),env,c) ->
         [str "cannot instantiate " ++ quote (pr_existential_key sigma evk)
-        ++ strbrk " because " ++ pr_leconstr_env env sigma c ++
+        ++ strbrk " because " ++ pr_leconstr_env state env sigma c ++
 	strbrk " is not in its scope" ++
         (if Array.is_empty args then mt() else
          strbrk ": available arguments are " ++
-         pr_sequence (pr_leconstr_env env sigma) (List.rev (Array.to_list args)))]
+         pr_sequence (pr_leconstr_env state env sigma) (List.rev (Array.to_list args)))]
      | NotSameArgSize | NotSameHead | NoCanonicalStructure ->
         (* Error speaks from itself *) []
      | ConversionFailed (env,t1,t2) ->
@@ -292,7 +292,7 @@ let explain_unification_error env sigma p1 p2 = function
         if EConstr.eq_constr sigma t1 p1 && EConstr.eq_constr sigma t2 p2 then [] else
         let env = make_all_name_different env sigma in
         if not (EConstr.eq_constr sigma t1 p1) || not (EConstr.eq_constr sigma t2 p2) then
-          let t1, t2 = pr_explicit env sigma t1 t2 in
+          let t1, t2 = pr_explicit state env sigma t1 t2 in
           [str "cannot unify " ++ t1 ++ strbrk " and " ++ t2]
         else []
      | MetaOccurInBody evk ->
@@ -300,7 +300,7 @@ let explain_unification_error env sigma p1 p2 = function
 	strbrk " refers to a metavariable - please report your example" ++
         strbrk "at " ++ str Coq_config.wwwbugtracker ++ str "."]
      | InstanceNotSameType (evk,env,t,u) ->
-        let t, u = pr_explicit env sigma t u in
+        let t, u = pr_explicit state env sigma t u in
         [str "unable to find a well-typed instantiation for " ++
         quote (pr_existential_key sigma evk) ++
         strbrk ": cannot ensure that " ++
@@ -313,8 +313,8 @@ let explain_unification_error env sigma p1 p2 = function
           [str "universe inconsistency"]
      | CannotSolveConstraint ((pb,env,t,u),e) ->
         let env = make_all_name_different env sigma in
-        (strbrk "cannot satisfy constraint " ++ pr_leconstr_env env sigma t ++
-        str " == " ++ pr_leconstr_env env sigma u)
+        (strbrk "cannot satisfy constraint " ++ pr_leconstr_env state env sigma t ++
+        str " == " ++ pr_leconstr_env state env sigma u)
         :: aux t u e
      | ProblemBeyondCapabilities ->
         []
@@ -324,15 +324,15 @@ let explain_unification_error env sigma p1 p2 = function
      | l -> spc () ++ str "(" ++
             prlist_with_sep pr_semicolon (fun x -> x) l ++ str ")"
 
-let explain_actual_type env sigma j t reason =
+let explain_actual_type state env sigma j t reason =
   let env = make_all_name_different env sigma in
   let j = j_nf_betaiotaevar env sigma j in
   let t = Reductionops.nf_betaiota env sigma t in
   (** Actually print *)
-  let pe = pr_ne_context_of (str "In environment") env sigma in
-  let pc = pr_leconstr_env env sigma (Environ.j_val j) in
-  let (pt, pct) = pr_explicit env sigma t (Environ.j_type j) in
-  let ppreason = explain_unification_error env sigma j.uj_type t reason in
+  let pe = pr_ne_context_of (str "In environment") state env sigma in
+  let pc = pr_leconstr_env state env sigma (Environ.j_val j) in
+  let (pt, pct) = pr_explicit state env sigma t (Environ.j_type j) in
+  let ppreason = explain_unification_error state env sigma j.uj_type t reason in
   pe ++
   hov 0 (
   str "The term" ++ brk(1,1) ++ pc ++ spc () ++
@@ -340,21 +340,21 @@ let explain_actual_type env sigma j t reason =
   str "while it is expected to have type" ++ brk(1,1) ++ pt ++
   ppreason ++ str ".")
 
-let explain_cant_apply_bad_type env sigma (n,exptyp,actualtyp) rator randl =
+let explain_cant_apply_bad_type state env sigma (n,exptyp,actualtyp) rator randl =
   let randl = jv_nf_betaiotaevar env sigma randl in
   let actualtyp = Reductionops.nf_betaiota env sigma actualtyp in
   let env = make_all_name_different env sigma in
-  let actualtyp, exptyp = pr_explicit env sigma actualtyp exptyp in
+  let actualtyp, exptyp = pr_explicit state env sigma actualtyp exptyp in
   let nargs = Array.length randl in
-(*  let pe = pr_ne_context_of (str "in environment") env sigma in*)
-  let pr,prt = pr_ljudge_env env sigma rator in
+(*  let pe = pr_ne_context_of (str "in environment") state env sigma in*)
+  let pr,prt = pr_ljudge_env state env sigma rator in
   let term_string1 = str (String.plural nargs "term") in
   let term_string2 =
     if nargs>1 then str "The " ++ pr_nth n ++ str " term" else str "This term"
   in
   let appl = prvect_with_sep fnl
 	       (fun c ->
-		  let pc,pct = pr_ljudge_env env sigma c in
+                  let pc,pct = pr_ljudge_env state env sigma c in
 		  hov 2 (pc ++ spc () ++ str ": " ++ pct)) randl
   in
   str "Illegal application: " ++ (* pe ++ *) fnl () ++
@@ -366,16 +366,16 @@ let explain_cant_apply_bad_type env sigma (n,exptyp,actualtyp) rator randl =
   str "which should be coercible to" ++ brk(1,1) ++
   exptyp ++ str "."
 
-let explain_cant_apply_not_functional env sigma rator randl =
+let explain_cant_apply_not_functional state env sigma rator randl =
   let env = make_all_name_different env sigma in
   let nargs = Array.length randl in
-(*  let pe = pr_ne_context_of (str "in environment") env sigma in*)
-  let pr = pr_leconstr_env env sigma rator.uj_val in
-  let prt = pr_leconstr_env env sigma rator.uj_type in
+(*  let pe = pr_ne_context_of (str "in environment") state env sigma in*)
+  let pr = pr_leconstr_env state env sigma rator.uj_val in
+  let prt = pr_leconstr_env state env sigma rator.uj_type in
   let appl = prvect_with_sep fnl
 	       (fun c ->
-		  let pc = pr_leconstr_env env sigma c.uj_val in
-		  let pct = pr_leconstr_env env sigma c.uj_type in
+                  let pc = pr_leconstr_env state env sigma c.uj_val in
+                  let pct = pr_leconstr_env state env sigma c.uj_type in
 		  hov 2 (pc ++ spc () ++ str ": " ++ pct)) randl
   in
   str "Illegal application (Non-functional construction): " ++
@@ -385,22 +385,21 @@ let explain_cant_apply_not_functional env sigma rator randl =
   str "cannot be applied to the " ++ str (String.plural nargs "term") ++
   fnl () ++ str " " ++ v 0 appl
 
-let explain_unexpected_type env sigma actual_type expected_type =
-  let pract, prexp = pr_explicit env sigma actual_type expected_type in
+let explain_unexpected_type state env sigma actual_type expected_type =
+  let pract, prexp = pr_explicit state env sigma actual_type expected_type in
   str "Found type" ++ spc () ++ pract ++ spc () ++
   str "where" ++ spc () ++ prexp ++ str " was expected."
 
-let explain_not_product env sigma c =
+let explain_not_product state env sigma c =
   let c = EConstr.to_constr sigma c in
-  let pr = pr_lconstr_env env sigma c in
+  let pr = pr_lconstr_env state env sigma c in
   str "The type of this term is a product" ++ spc () ++
   str "while it is expected to be" ++
   (if Constr.is_Type c then str " a sort" else (brk(1,1) ++ pr)) ++ str "."
 
 (* TODO: use the names *)
 (* (co)fixpoints *)
-let explain_ill_formed_rec_body env sigma err names i fixenv vdefj =
-  let pr_lconstr_env env sigma c = pr_leconstr_env env sigma c in
+let explain_ill_formed_rec_body state env sigma err names i fixenv vdefj =
   let prt_name i =
     match names.(i) with
         Name id -> str "Recursive definition of " ++ Id.print id
@@ -412,7 +411,7 @@ let explain_ill_formed_rec_body env sigma err names i fixenv vdefj =
   | NotEnoughAbstractionInFixBody ->
       str "Not enough abstractions in the definition"
   | RecursionNotOnInductiveType c ->
-      str "Recursive definition on" ++ spc () ++ pr_lconstr_env env sigma c ++
+      str "Recursive definition on" ++ spc () ++ pr_leconstr_env state env sigma c ++
       spc () ++ str "which should be a recursive inductive type"
   | RecursionOnIllegalTerm(j,(arg_env, arg),le,lt) ->
       let arg_env = make_all_name_different arg_env sigma in
@@ -433,7 +432,7 @@ let explain_ill_formed_rec_body env sigma err names i fixenv vdefj =
               pr_sequence pr_db lt in
       str "Recursive call to " ++ called ++ spc () ++
       strbrk "has principal argument equal to" ++ spc () ++
-      pr_lconstr_env arg_env sigma arg ++ strbrk " instead of " ++ vars
+      pr_leconstr_env state arg_env sigma arg ++ strbrk " instead of " ++ vars
 
   | NotEnoughArgumentsForFixCall j ->
       let called =
@@ -444,77 +443,77 @@ let explain_ill_formed_rec_body env sigma err names i fixenv vdefj =
 
   (* CoFixpoint guard errors *)
   | CodomainNotInductiveType c ->
-      str "The codomain is" ++ spc () ++ pr_lconstr_env env sigma c ++ spc () ++
+      str "The codomain is" ++ spc () ++ pr_leconstr_env state env sigma c ++ spc () ++
       str "which should be a coinductive type"
   | NestedRecursiveOccurrences ->
       str "Nested recursive occurrences"
   | UnguardedRecursiveCall c ->
-      str "Unguarded recursive call in" ++ spc () ++ pr_lconstr_env env sigma c
+      str "Unguarded recursive call in" ++ spc () ++ pr_leconstr_env state env sigma c
   | RecCallInTypeOfAbstraction c ->
       str "Recursive call forbidden in the domain of an abstraction:" ++
-      spc () ++ pr_lconstr_env env sigma c
+      spc () ++ pr_leconstr_env state env sigma c
   | RecCallInNonRecArgOfConstructor c ->
       str "Recursive call on a non-recursive argument of constructor" ++
-      spc () ++ pr_lconstr_env env sigma c
+      spc () ++ pr_leconstr_env state env sigma c
   | RecCallInTypeOfDef c ->
       str "Recursive call forbidden in the type of a recursive definition" ++
-      spc () ++ pr_lconstr_env env sigma c
+      spc () ++ pr_leconstr_env state env sigma c
   | RecCallInCaseFun c ->
       str "Invalid recursive call in a branch of" ++
-      spc () ++ pr_lconstr_env env sigma c
+      spc () ++ pr_leconstr_env state env sigma c
   | RecCallInCaseArg c ->
       str "Invalid recursive call in the argument of \"match\" in" ++ spc () ++
-      pr_lconstr_env env sigma c
+      pr_leconstr_env state env sigma c
   | RecCallInCasePred c ->
       str "Invalid recursive call in the \"return\" clause of \"match\" in" ++
-      spc () ++ pr_lconstr_env env sigma c
+      spc () ++ pr_leconstr_env state env sigma c
   | NotGuardedForm c ->
-      str "Sub-expression " ++ pr_lconstr_env env sigma c ++
+      str "Sub-expression " ++ pr_leconstr_env state env sigma c ++
       strbrk " not in guarded form (should be a constructor," ++
       strbrk " an abstraction, a match, a cofix or a recursive call)"
   | ReturnPredicateNotCoInductive c ->
      str "The return clause of the following pattern matching should be" ++
      strbrk " a coinductive type:" ++
-     spc () ++ pr_lconstr_env env sigma c
+     spc () ++ pr_leconstr_env state env sigma c
   in
   prt_name i ++ str " is ill-formed." ++ fnl () ++
-  pr_ne_context_of (str "In environment") env sigma ++
+  pr_ne_context_of (str "In environment") state env sigma ++
   st ++ str "." ++ fnl () ++
   (try (* May fail with unresolved globals. *)
       let fixenv = make_all_name_different fixenv sigma in
-      let pvd = pr_lconstr_env fixenv sigma vdefj.(i).uj_val in
+      let pvd = pr_leconstr_env state fixenv sigma vdefj.(i).uj_val in
 	str"Recursive definition is:" ++ spc () ++ pvd ++ str "."
     with e when CErrors.noncritical e -> mt ())
 
-let explain_ill_typed_rec_body env sigma i names vdefj vargs =
+let explain_ill_typed_rec_body state env sigma i names vdefj vargs =
   let env = make_all_name_different env sigma in
-  let pvd = pr_leconstr_env env sigma vdefj.(i).uj_val in
-  let pvdt, pv = pr_explicit env sigma vdefj.(i).uj_type vargs.(i) in
+  let pvd = pr_leconstr_env state env sigma vdefj.(i).uj_val in
+  let pvdt, pv = pr_explicit state env sigma vdefj.(i).uj_type vargs.(i) in
   str "The " ++
   (match vdefj with [|_|] -> mt () | _ -> pr_nth (i+1) ++ spc ()) ++
   str "recursive definition" ++ spc () ++ pvd ++ spc () ++
   str "has type" ++ spc () ++ pvdt ++ spc () ++
   str "while it should be" ++ spc () ++ pv ++ str "."
 
-let explain_cant_find_case_type env sigma c =
+let explain_cant_find_case_type state env sigma c =
   let env = make_all_name_different env sigma in
-  let pe = pr_leconstr_env env sigma c in
+  let pe = pr_leconstr_env state env sigma c in
   str "Cannot infer the return type of pattern-matching on" ++ ws 1 ++
     pe ++ str "."
 
-let explain_occur_check env sigma ev rhs =
+let explain_occur_check state env sigma ev rhs =
   let env = make_all_name_different env sigma in
-  let pt = pr_leconstr_env env sigma rhs in
+  let pt = pr_leconstr_env state env sigma rhs in
   str "Cannot define " ++ pr_existential_key sigma ev ++ str " with term" ++
   brk(1,1) ++ pt ++ spc () ++ str "that would depend on itself."
 
-let pr_trailing_ne_context_of env sigma =
+let pr_trailing_ne_context_of state env sigma =
   if List.is_empty (Environ.rel_context env) &&
     List.is_empty (Environ.named_context env)
   then str "."
-  else (str " in environment:"++ pr_context_unlimited env sigma)
+  else (str " in environment:"++ pr_context_unlimited state env sigma)
 
-let rec explain_evar_kind env sigma evk ty =
+let rec explain_evar_kind state env sigma evk ty =
     let open Evar_kinds in
     function
   | Evar_kinds.NamedHole id ->
@@ -522,7 +521,7 @@ let rec explain_evar_kind env sigma evk ty =
   | Evar_kinds.QuestionMark {qm_record_field=None} ->
       strbrk "this placeholder of type " ++ ty
   | Evar_kinds.QuestionMark {qm_record_field=Some {fieldname; recordname}} ->
-          str "field " ++ (Printer.pr_constant env fieldname) ++ str " of record " ++ (Printer.pr_inductive env recordname)
+          str "field " ++ (Printer.pr_constant state env fieldname) ++ str " of record " ++ (Printer.pr_inductive state env recordname)
   | Evar_kinds.CasesType false ->
       strbrk "the type of this pattern-matching problem"
   | Evar_kinds.CasesType true ->
@@ -540,7 +539,7 @@ let rec explain_evar_kind env sigma evk ty =
   | Evar_kinds.InternalHole -> strbrk "an internal placeholder of type " ++ ty
   | Evar_kinds.TomatchTypeParameter (tyi,n) ->
       strbrk "the " ++ pr_nth n ++
-      strbrk " argument of the inductive type (" ++ pr_inductive env tyi ++
+      strbrk " argument of the inductive type (" ++ pr_inductive state env tyi ++
       strbrk ") of this term"
   | Evar_kinds.GoalEvar ->
       strbrk "an existential variable of type " ++ ty
@@ -554,7 +553,7 @@ let rec explain_evar_kind env sigma evk ty =
   | Evar_kinds.SubEvar (where,evk') ->
       let evi = Evd.find sigma evk' in
       let pc = match evi.evar_body with
-      | Evar_defined c -> pr_leconstr_env env sigma c
+      | Evar_defined c -> pr_leconstr_env state env sigma c
       | Evar_empty -> assert false in
       let ty' = evi.evar_concl in
       (match where with
@@ -565,19 +564,19 @@ let rec explain_evar_kind env sigma evk ty =
       pr_existential_key sigma evk ++ str " of type " ++ ty ++
       str " in the partial instance " ++ pc ++
       str " found for ") ++
-      explain_evar_kind env sigma evk'
-      (pr_leconstr_env env sigma ty') (snd evi.evar_source)
+      explain_evar_kind state env sigma evk'
+      (pr_leconstr_env state env sigma ty') (snd evi.evar_source)
 
-let explain_typeclass_resolution env sigma evi k =
+let explain_typeclass_resolution state env sigma evi k =
   match Typeclasses.class_of_constr sigma evi.evar_concl with
   | Some _ ->
     let env = Evd.evar_filtered_env evi in
       fnl () ++ str "Could not find an instance for " ++
-      pr_leconstr_env env sigma evi.evar_concl ++
-      pr_trailing_ne_context_of env sigma
+      pr_leconstr_env state env sigma evi.evar_concl ++
+      pr_trailing_ne_context_of state env sigma
   | _ -> mt()
 
-let explain_placeholder_kind env sigma c e =
+let explain_placeholder_kind state env sigma c e =
   match e with
   | Some (SeveralInstancesFound n) ->
       strbrk " (several distinct possible type class instances found)"
@@ -586,143 +585,143 @@ let explain_placeholder_kind env sigma c e =
       | Some _ -> strbrk " (no type class instance found)"
       | _ -> mt ()
 
-let explain_unsolvable_implicit env sigma evk explain =
+let explain_unsolvable_implicit state env sigma evk explain =
   let evi = Evarutil.nf_evar_info sigma (Evd.find_undefined sigma evk) in
   let env = Evd.evar_filtered_env evi in
-  let type_of_hole = pr_leconstr_env env sigma evi.evar_concl in
-  let pe = pr_trailing_ne_context_of env sigma in
+  let type_of_hole = pr_leconstr_env state env sigma evi.evar_concl in
+  let pe = pr_trailing_ne_context_of state env sigma in
   strbrk "Cannot infer " ++
-  explain_evar_kind env sigma evk type_of_hole (snd evi.evar_source) ++
-  explain_placeholder_kind env sigma evi.evar_concl explain ++ pe
+  explain_evar_kind state env sigma evk type_of_hole (snd evi.evar_source) ++
+  explain_placeholder_kind state env sigma evi.evar_concl explain ++ pe
 
 let explain_var_not_found env id =
   str "The variable" ++ spc () ++ Id.print id ++
   spc () ++ str "was not found" ++
   spc () ++ str "in the current" ++ spc () ++ str "environment" ++ str "."
 
-let explain_wrong_case_info env (ind,u) ci =
-  let pi = pr_inductive env ind in
+let explain_wrong_case_info state env (ind,u) ci =
+  let pi = pr_inductive state env ind in
   if eq_ind ci.ci_ind ind then
     str "Pattern-matching expression on an object of inductive type" ++
     spc () ++ pi ++ spc () ++ str "has invalid information."
   else
-    let pc = pr_inductive env ci.ci_ind in
+    let pc = pr_inductive state env ci.ci_ind in
     str "A term of inductive type" ++ spc () ++ pi ++ spc () ++
     str "was given to a pattern-matching expression on the inductive type" ++
     spc () ++ pc ++ str "."
 
-let explain_cannot_unify env sigma m n e =
+let explain_cannot_unify state env sigma m n e =
   let env = make_all_name_different env sigma in
-  let pm, pn = pr_explicit env sigma m n in
-  let ppreason = explain_unification_error env sigma m n e in
-  let pe = pr_ne_context_of (str "In environment") env sigma in
+  let pm, pn = pr_explicit state env sigma m n in
+  let ppreason = explain_unification_error state env sigma m n e in
+  let pe = pr_ne_context_of (str "In environment") state env sigma in
   pe ++ str "Unable to unify" ++ brk(1,1) ++ pm ++ spc () ++
   str "with" ++ brk(1,1) ++ pn ++ ppreason ++ str "."
 
-let explain_cannot_unify_local env sigma m n subn =
-  let pm = pr_leconstr_env env sigma m in
-  let pn = pr_leconstr_env env sigma n in
-  let psubn = pr_leconstr_env env sigma subn in
+let explain_cannot_unify_local state env sigma m n subn =
+  let pm = pr_leconstr_env state env sigma m in
+  let pn = pr_leconstr_env state env sigma n in
+  let psubn = pr_leconstr_env state env sigma subn in
     str "Unable to unify" ++ brk(1,1) ++ pm ++ spc () ++
       str "with" ++ brk(1,1) ++ pn ++ spc () ++ str "as" ++ brk(1,1) ++
       psubn ++ str " contains local variables."
 
-let explain_refiner_cannot_generalize env sigma ty =
+let explain_refiner_cannot_generalize state env sigma ty =
   str "Cannot find a well-typed generalisation of the goal with type: " ++
-  pr_leconstr_env env sigma ty ++ str "."
+  pr_leconstr_env state env sigma ty ++ str "."
 
-let explain_no_occurrence_found env sigma c id =
-  str "Found no subterm matching " ++ pr_leconstr_env env sigma c ++
+let explain_no_occurrence_found state env sigma c id =
+  str "Found no subterm matching " ++ pr_leconstr_env state env sigma c ++
   str " in " ++
     (match id with
       | Some id -> Id.print id
       | None -> str"the current goal") ++ str "."
 
-let explain_cannot_unify_binding_type env sigma m n =
-  let pm = pr_leconstr_env env sigma m in
-  let pn = pr_leconstr_env env sigma n in
+let explain_cannot_unify_binding_type state env sigma m n =
+  let pm = pr_leconstr_env state env sigma m in
+  let pn = pr_leconstr_env state env sigma n in
   str "This binding has type" ++ brk(1,1) ++ pm ++ spc () ++
   str "which should be unifiable with" ++ brk(1,1) ++ pn ++ str "."
 
-let explain_cannot_find_well_typed_abstraction env sigma p l e =
+let explain_cannot_find_well_typed_abstraction state env sigma p l e =
   let p = EConstr.to_constr sigma p in
   str "Abstracting over the " ++
   str (String.plural (List.length l) "term") ++ spc () ++
-  hov 0 (pr_enum (fun c -> pr_lconstr_env env sigma (EConstr.to_constr sigma c)) l) ++ spc () ++
-  str "leads to a term" ++ spc () ++ pr_lconstr_goal_style_env env sigma p ++
+  hov 0 (pr_enum (fun c -> pr_lconstr_env state env sigma (EConstr.to_constr sigma c)) l) ++ spc () ++
+  str "leads to a term" ++ spc () ++ pr_lconstr_goal_style_env state env sigma p ++
   spc () ++ str "which is ill-typed." ++
   (match e with None -> mt () | Some e -> fnl () ++ str "Reason is: " ++ e)
 
-let explain_wrong_abstraction_type env sigma na abs expected result =
+let explain_wrong_abstraction_type state env sigma na abs expected result =
   let abs = EConstr.to_constr sigma abs in
   let expected = EConstr.to_constr sigma expected in
   let result = EConstr.to_constr sigma result in
   let ppname = match na with Name id -> Id.print id ++ spc () | _ -> mt () in
   str "Cannot instantiate metavariable " ++ ppname ++ strbrk "of type " ++
-  pr_lconstr_env env sigma expected ++ strbrk " with abstraction " ++
-  pr_lconstr_env env sigma abs ++ strbrk " of incompatible type " ++
-  pr_lconstr_env env sigma result ++ str "."
+  pr_lconstr_env state env sigma expected ++ strbrk " with abstraction " ++
+  pr_lconstr_env state env sigma abs ++ strbrk " of incompatible type " ++
+  pr_lconstr_env state env sigma result ++ str "."
 
 let explain_abstraction_over_meta _ m n =
   strbrk "Too complex unification problem: cannot find a solution for both " ++
   Name.print m ++ spc () ++ str "and " ++ Name.print n ++ str "."
 
-let explain_non_linear_unification env sigma m t =
+let explain_non_linear_unification state env sigma m t =
   let t = EConstr.to_constr sigma t in
   strbrk "Cannot unambiguously instantiate " ++
   Name.print m ++ str ":" ++
   strbrk " which would require to abstract twice on " ++
-  pr_lconstr_env env sigma t ++ str "."
+  pr_lconstr_env state env sigma t ++ str "."
 
-let explain_unsatisfied_constraints env sigma cst =
+let explain_unsatisfied_constraints state env sigma cst =
   strbrk "Unsatisfied constraints: " ++ 
     Univ.pr_constraints (Termops.pr_evd_level sigma) cst ++ 
     spc () ++ str "(maybe a bugged tactic)."
 
-let explain_undeclared_universe env sigma l =
+let explain_undeclared_universe state env sigma l =
   strbrk "Undeclared universe: " ++
     Termops.pr_evd_level sigma l ++
     spc () ++ str "(maybe a bugged tactic)."
 
-let explain_type_error env sigma err =
+let explain_type_error state env sigma err =
   let env = make_all_name_different env sigma in
   match err with
   | UnboundRel n ->
-      explain_unbound_rel env sigma n
+      explain_unbound_rel state env sigma n
   | UnboundVar v ->
       explain_unbound_var env v
   | NotAType j ->
-      explain_not_type env sigma j
+      explain_not_type state env sigma j
   | BadAssumption c ->
-      explain_bad_assumption env sigma c
+      explain_bad_assumption state env sigma c
   | ReferenceVariables (id,c) ->
       explain_reference_variables sigma id c
   | ElimArity (ind, aritylst, c, pj, okinds) ->
-      explain_elim_arity env sigma ind aritylst c pj okinds
+      explain_elim_arity state env sigma ind aritylst c pj okinds
   | CaseNotInductive cj ->
-      explain_case_not_inductive env sigma cj
+      explain_case_not_inductive state env sigma cj
   | NumberBranches (cj, n) ->
-      explain_number_branches env sigma cj n
+      explain_number_branches state env sigma cj n
   | IllFormedBranch (c, i, actty, expty) ->
-      explain_ill_formed_branch env sigma c i actty expty
+      explain_ill_formed_branch state env sigma c i actty expty
   | Generalization (nvar, c) ->
-      explain_generalization env sigma nvar c
+      explain_generalization state env sigma nvar c
   | ActualType (j, pt) ->
-      explain_actual_type env sigma j pt None
+      explain_actual_type state env sigma j pt None
   | CantApplyBadType (t, rator, randl) ->
-      explain_cant_apply_bad_type env sigma t rator randl
+      explain_cant_apply_bad_type state env sigma t rator randl
   | CantApplyNonFunctional (rator, randl) ->
-      explain_cant_apply_not_functional env sigma rator randl
+      explain_cant_apply_not_functional state env sigma rator randl
   | IllFormedRecBody (err, lna, i, fixenv, vdefj) ->
-      explain_ill_formed_rec_body env sigma err lna i fixenv vdefj
+      explain_ill_formed_rec_body state env sigma err lna i fixenv vdefj
   | IllTypedRecBody (i, lna, vdefj, vargs) ->
-     explain_ill_typed_rec_body env sigma i lna vdefj vargs
+     explain_ill_typed_rec_body state env sigma i lna vdefj vargs
   | WrongCaseInfo (ind,ci) ->
-      explain_wrong_case_info env ind ci
+      explain_wrong_case_info state env ind ci
   | UnsatisfiedConstraints cst ->
-      explain_unsatisfied_constraints env sigma cst
+      explain_unsatisfied_constraints state env sigma cst
   | UndeclaredUniverse l ->
-     explain_undeclared_universe env sigma l
+     explain_undeclared_universe state env sigma l
 
 let pr_position (cl,pos) =
   let clpos = match cl with
@@ -732,7 +731,7 @@ let pr_position (cl,pos) =
     | Some (id,Locus.InHypValueOnly) -> str " of the body of hypothesis " ++ Id.print id in
   int pos ++ clpos
 
-let explain_cannot_unify_occurrences env sigma nested ((cl2,pos2),t2) ((cl1,pos1),t1) e =
+let explain_cannot_unify_occurrences state env sigma nested ((cl2,pos2),t2) ((cl1,pos1),t1) e =
   if nested then
     str "Found nested occurrences of the pattern at positions " ++
     int pos1 ++ strbrk " and " ++ pr_position (cl2,pos2) ++ str "."
@@ -740,16 +739,16 @@ let explain_cannot_unify_occurrences env sigma nested ((cl2,pos2),t2) ((cl1,pos1
     let ppreason = match e with
     | None -> mt()
     | Some (c1,c2,e) ->
-      explain_unification_error env sigma c1 c2 (Some e)
+      explain_unification_error state env sigma c1 c2 (Some e)
     in
     str "Found incompatible occurrences of the pattern" ++ str ":" ++
-    spc () ++ str "Matched term " ++ pr_lconstr_env env sigma (EConstr.to_constr sigma t2) ++
+    spc () ++ str "Matched term " ++ pr_lconstr_env state env sigma (EConstr.to_constr sigma t2) ++
     strbrk " at position " ++ pr_position (cl2,pos2) ++
     strbrk " is not compatible with matched term " ++
-    pr_lconstr_env env sigma (EConstr.to_constr sigma t1) ++ strbrk " at position " ++
+    pr_lconstr_env state env sigma (EConstr.to_constr sigma t1) ++ strbrk " at position " ++
     pr_position (cl1,pos1) ++ ppreason ++ str "."
 
-let pr_constraints printenv env sigma evars cstrs =
+let pr_constraints printenv state env sigma evars cstrs =
   let (ev, evi) = Evar.Map.choose evars in
     if Evar.Map.for_all (fun ev' evi' ->
       eq_named_context_val evi.evar_hyps evi'.evar_hyps) evars
@@ -758,20 +757,20 @@ let pr_constraints printenv env sigma evars cstrs =
       let env' = reset_with_named_context evi.evar_hyps env in
       let pe =
         if printenv then
-          pr_ne_context_of (str "In environment:") env' sigma
+          pr_ne_context_of (str "In environment:") state env' sigma
         else mt ()
       in
       let evs =
         prlist
         (fun (ev, evi) -> fnl () ++ pr_existential_key sigma ev ++
-            str " : " ++ pr_leconstr_env env' sigma evi.evar_concl ++ fnl ()) l
+            str " : " ++ pr_leconstr_env state env' sigma evi.evar_concl ++ fnl ()) l
       in
       h 0 (pe ++ evs ++ pr_evar_constraints sigma cstrs)
     else
       let filter evk _ = Evar.Map.mem evk evars in
       pr_evar_map_filter ~with_univs:false filter sigma
 
-let explain_unsatisfiable_constraints env sigma constr comp =
+let explain_unsatisfiable_constraints state env sigma constr comp =
   let (_, constraints) = Evd.extract_all_conv_pbs sigma in
   let undef = Evd.undefined_map sigma in
   (** Only keep evars that are subject to resolution and members of the given
@@ -788,57 +787,57 @@ let explain_unsatisfiable_constraints env sigma constr comp =
   match constr with
   | None ->
     str "Unable to satisfy the following constraints:" ++ fnl () ++
-    pr_constraints true env sigma undef constraints
+    pr_constraints true state env sigma undef constraints
   | Some (ev, k) ->
     let cstr =
       let remaining = Evar.Map.remove ev undef in
       if not (Evar.Map.is_empty remaining) then
         str "With the following constraints:" ++ fnl () ++
-          pr_constraints false env sigma remaining constraints
+          pr_constraints false state env sigma remaining constraints
       else mt ()
     in
     let info = Evar.Map.find ev undef in
-    explain_typeclass_resolution env sigma info k ++ fnl () ++ cstr
+    explain_typeclass_resolution state env sigma info k ++ fnl () ++ cstr
 
-let explain_pretype_error env sigma err =
+let explain_pretype_error state env sigma err =
   let env = Evardefine.env_nf_betaiotaevar sigma env in
   let env = make_all_name_different env sigma in
   match err with
-  | CantFindCaseType c -> explain_cant_find_case_type env sigma c
+  | CantFindCaseType c -> explain_cant_find_case_type state env sigma c
   | ActualTypeNotCoercible (j,t,e) ->
     let {uj_val = c; uj_type = actty} = j in
     let (env, c, actty, expty), e = contract3' env sigma c actty t e in
     let j = {uj_val = c; uj_type = actty} in
-    explain_actual_type env sigma j expty (Some e)
-  | UnifOccurCheck (ev,rhs) -> explain_occur_check env sigma ev rhs
-  | UnsolvableImplicit (evk,exp) -> explain_unsolvable_implicit env sigma evk exp
+    explain_actual_type state env sigma j expty (Some e)
+  | UnifOccurCheck (ev,rhs) -> explain_occur_check state env sigma ev rhs
+  | UnsolvableImplicit (evk,exp) -> explain_unsolvable_implicit state env sigma evk exp
   | VarNotFound id -> explain_var_not_found env id
   | UnexpectedType (actual,expect) ->
     let env, actual, expect = contract2 env sigma actual expect in
-    explain_unexpected_type env sigma actual expect
-  | NotProduct c -> explain_not_product env sigma c
+    explain_unexpected_type state env sigma actual expect
+  | NotProduct c -> explain_not_product state env sigma c
   | CannotUnify (m,n,e) ->
     let env, m, n = contract2 env sigma m n in
-    explain_cannot_unify env sigma m n e
-  | CannotUnifyLocal (m,n,sn) -> explain_cannot_unify_local env sigma m n sn
-  | CannotGeneralize ty -> explain_refiner_cannot_generalize env sigma ty
-  | NoOccurrenceFound (c, id) -> explain_no_occurrence_found env sigma c id
-  | CannotUnifyBindingType (m,n) -> explain_cannot_unify_binding_type env sigma m n
+    explain_cannot_unify state env sigma m n e
+  | CannotUnifyLocal (m,n,sn) -> explain_cannot_unify_local state env sigma m n sn
+  | CannotGeneralize ty -> explain_refiner_cannot_generalize state env sigma ty
+  | NoOccurrenceFound (c, id) -> explain_no_occurrence_found state env sigma c id
+  | CannotUnifyBindingType (m,n) -> explain_cannot_unify_binding_type state env sigma m n
   | CannotFindWellTypedAbstraction (p,l,e) ->
-      explain_cannot_find_well_typed_abstraction env sigma p l
-        (Option.map (fun (env',e) -> explain_type_error env' sigma e) e)
+      explain_cannot_find_well_typed_abstraction state env sigma p l
+        (Option.map (fun (env',e) -> explain_type_error state env' sigma e) e)
   | WrongAbstractionType (n,a,t,u) ->
-      explain_wrong_abstraction_type env sigma n a t u
+      explain_wrong_abstraction_type state env sigma n a t u
   | AbstractionOverMeta (m,n) -> explain_abstraction_over_meta env m n
-  | NonLinearUnification (m,c) -> explain_non_linear_unification env sigma m c
-  | TypingError t -> explain_type_error env sigma t
-  | CannotUnifyOccurrences (b,c1,c2,e) -> explain_cannot_unify_occurrences env sigma b c1 c2 e
-  | UnsatisfiableConstraints (c,comp) -> explain_unsatisfiable_constraints env sigma c comp
+  | NonLinearUnification (m,c) -> explain_non_linear_unification state env sigma m c
+  | TypingError t -> explain_type_error state env sigma t
+  | CannotUnifyOccurrences (b,c1,c2,e) -> explain_cannot_unify_occurrences state env sigma b c1 c2 e
+  | UnsatisfiableConstraints (c,comp) -> explain_unsatisfiable_constraints state env sigma c comp
 (* Module errors *)
 
 open Modops
 
-let explain_not_match_error = function
+let explain_not_match_error state = function
   | InductiveFieldExpected _ ->
     strbrk "an inductive definition is expected"
   | DefinitionFieldExpected ->
@@ -853,9 +852,9 @@ let explain_not_match_error = function
     str "the body of definitions differs"
   | NotConvertibleTypeField (env, typ1, typ2) ->
     str "expected type" ++ spc ()  ++
-    quote (Printer.safe_pr_lconstr_env env (Evd.from_env env) typ2) ++ spc () ++
+    quote (Printer.safe_pr_lconstr_env state env (Evd.from_env env) typ2) ++ spc () ++
     str "but found type" ++ spc () ++
-    quote (Printer.safe_pr_lconstr_env env (Evd.from_env env) typ1)
+    quote (Printer.safe_pr_lconstr_env state env (Evd.from_env env) typ1)
   | NotSameConstructorNamesField ->
     str "constructor names differ"
   | NotSameInductiveNameInBlockField ->
@@ -891,18 +890,18 @@ let explain_not_match_error = function
       Univ.explain_universe_inconsistency UnivNames.pr_with_global_universes incon
   | IncompatiblePolymorphism (env, t1, t2) ->
     str "conversion of polymorphic values generates additional constraints: " ++
-      quote (Printer.safe_pr_lconstr_env env (Evd.from_env env) t1) ++ spc () ++
+      quote (Printer.safe_pr_lconstr_env state env (Evd.from_env env) t1) ++ spc () ++
       str "compared to " ++ spc () ++
-      quote (Printer.safe_pr_lconstr_env env (Evd.from_env env) t2)
+      quote (Printer.safe_pr_lconstr_env state env (Evd.from_env env) t2)
   | IncompatibleConstraints cst ->
     str " the expected (polymorphic) constraints do not imply " ++
       let cst = Univ.UContext.constraints (Univ.AUContext.repr cst) in
       (** FIXME: provide a proper naming for the bound variables *)
       quote (Univ.pr_constraints (Termops.pr_evd_level Evd.empty) cst)
 
-let explain_signature_mismatch l spec why =
+let explain_signature_mismatch l spec state why =
   str "Signature components for label " ++ Label.print l ++
-  str " do not match:" ++ spc () ++ explain_not_match_error why ++ str "."
+  str " do not match:" ++ spc () ++ explain_not_match_error state why ++ str "."
 
 let explain_label_already_declared l =
   str "The label " ++ Label.print l ++ str " is already declared."
@@ -969,8 +968,8 @@ let explain_include_restricted_functor mp =
   strbrk " since it has a restricted signature. " ++
   strbrk "You may name first an instance of this functor, and include it."
 
-let explain_module_error = function
-  | SignatureMismatch (l,spec,err) -> explain_signature_mismatch l spec err
+let explain_module_error state = function
+  | SignatureMismatch (l,spec,err) -> explain_signature_mismatch l spec state err
   | LabelAlreadyDeclared l -> explain_label_already_declared l
   | ApplicationToNotPath mexpr -> explain_application_to_not_path mexpr
   | NotAFunctor -> explain_not_a_functor ()
@@ -1013,10 +1012,10 @@ let explain_module_internalization_error = function
 
 (* Typeclass errors *)
 
-let explain_not_a_class env c =
+let explain_not_a_class state env c =
   let sigma = Evd.from_env env in
   let c = EConstr.to_constr sigma c in
-  pr_constr_env env sigma c ++ str" is not a declared type class."
+  pr_constr_env state env sigma c ++ str" is not a declared type class."
 
 let explain_unbound_method env cid { CAst.v = id } =
   str "Unbound method name " ++ Id.print (id) ++ spc () ++
@@ -1027,82 +1026,82 @@ let pr_constr_exprs exprs =
 	 (fun d pps -> ws 2 ++ Ppconstr.pr_constr_expr d ++ pps)
          exprs (mt ()))
 
-let explain_mismatched_contexts env c i j =
+let explain_mismatched_contexts state env c i j =
   str"Mismatched contexts while declaring instance: " ++ brk (1,1) ++
-    hov 1 (str"Expected:" ++ brk (1, 1) ++ pr_rel_context env (Evd.from_env env) j) ++
+    hov 1 (str"Expected:" ++ brk (1, 1) ++ pr_rel_context state env (Evd.from_env env) j) ++
     fnl () ++ brk (1,1) ++
     hov 1 (str"Found:" ++ brk (1, 1) ++ pr_constr_exprs i)
 
-let explain_typeclass_error env = function
-  | NotAClass c -> explain_not_a_class env c
+let explain_typeclass_error state env = function
+  | NotAClass c -> explain_not_a_class state env c
   | UnboundMethod (cid, id) -> explain_unbound_method env cid id
 
 (* Refiner errors *)
 
-let explain_refiner_bad_type env sigma arg ty conclty =
+let explain_refiner_bad_type state env sigma arg ty conclty =
   str "Refiner was given an argument" ++ brk(1,1) ++
-  pr_lconstr_env env sigma arg ++ spc () ++
-  str "of type" ++ brk(1,1) ++ pr_lconstr_env env sigma ty ++ spc () ++
-  str "instead of" ++ brk(1,1) ++ pr_lconstr_env env sigma conclty ++ str "."
+  pr_lconstr_env state env sigma arg ++ spc () ++
+  str "of type" ++ brk(1,1) ++ pr_lconstr_env state env sigma ty ++ spc () ++
+  str "instead of" ++ brk(1,1) ++ pr_lconstr_env state env sigma conclty ++ str "."
 
 let explain_refiner_unresolved_bindings l =
   str "Unable to find an instance for the " ++
   str (String.plural (List.length l) "variable") ++ spc () ++
   prlist_with_sep pr_comma Name.print l ++ str"."
 
-let explain_refiner_cannot_apply env sigma t harg =
+let explain_refiner_cannot_apply state env sigma t harg =
   str "In refiner, a term of type" ++ brk(1,1) ++
-  pr_lconstr_env env sigma t ++ spc () ++ str "could not be applied to" ++ brk(1,1) ++
-  pr_lconstr_env env sigma harg ++ str "."
+  pr_lconstr_env state env sigma t ++ spc () ++ str "could not be applied to" ++ brk(1,1) ++
+  pr_lconstr_env state env sigma harg ++ str "."
 
-let explain_refiner_not_well_typed env sigma c =
-  str "The term " ++ pr_lconstr_env env sigma c ++ str " is not well-typed."
+let explain_refiner_not_well_typed state env sigma c =
+  str "The term " ++ pr_lconstr_env state env sigma c ++ str " is not well-typed."
 
 let explain_intro_needs_product () =
   str "Introduction tactics needs products."
 
-let explain_does_not_occur_in env sigma c hyp =
-  str "The term" ++ spc () ++ pr_lconstr_env env sigma c ++ spc () ++
+let explain_does_not_occur_in state env sigma c hyp =
+  str "The term" ++ spc () ++ pr_lconstr_env state env sigma c ++ spc () ++
   str "does not occur in" ++ spc () ++ Id.print hyp ++ str "."
 
-let explain_non_linear_proof env sigma c =
-  str "Cannot refine with term" ++ brk(1,1) ++ pr_lconstr_env env sigma c ++
+let explain_non_linear_proof state env sigma c =
+  str "Cannot refine with term" ++ brk(1,1) ++ pr_lconstr_env state env sigma c ++
   spc () ++ str "because a metavariable has several occurrences."
 
-let explain_meta_in_type env sigma c =
-  str "In refiner, a meta appears in the type " ++ brk(1,1) ++ pr_leconstr_env env sigma c ++
+let explain_meta_in_type state env sigma c =
+  str "In refiner, a meta appears in the type " ++ brk(1,1) ++ pr_leconstr_env state env sigma c ++
   str " of another meta"
 
 let explain_no_such_hyp id =
   str "No such hypothesis: " ++ Id.print id
 
-let explain_refiner_error env sigma = function
-  | BadType (arg,ty,conclty) -> explain_refiner_bad_type env sigma arg ty conclty
+let explain_refiner_error state env sigma = function
+  | BadType (arg,ty,conclty) -> explain_refiner_bad_type state env sigma arg ty conclty
   | UnresolvedBindings t -> explain_refiner_unresolved_bindings t
-  | CannotApply (t,harg) -> explain_refiner_cannot_apply env sigma t harg
-  | NotWellTyped c -> explain_refiner_not_well_typed env sigma c
+  | CannotApply (t,harg) -> explain_refiner_cannot_apply state env sigma t harg
+  | NotWellTyped c -> explain_refiner_not_well_typed state env sigma c
   | IntroNeedsProduct -> explain_intro_needs_product ()
-  | DoesNotOccurIn (c,hyp) -> explain_does_not_occur_in env sigma c hyp
-  | NonLinearProof c -> explain_non_linear_proof env sigma c
-  | MetaInType c -> explain_meta_in_type env sigma c
+  | DoesNotOccurIn (c,hyp) -> explain_does_not_occur_in state env sigma c hyp
+  | NonLinearProof c -> explain_non_linear_proof state env sigma c
+  | MetaInType c -> explain_meta_in_type state env sigma c
   | NoSuchHyp id -> explain_no_such_hyp id
 
 (* Inductive errors *)
 
-let error_non_strictly_positive env c v =
-  let pc = pr_lconstr_env env (Evd.from_env env) c in
-  let pv = pr_lconstr_env env (Evd.from_env env) v in
+let error_non_strictly_positive state env c v =
+  let pc = pr_lconstr_env state env (Evd.from_env env) c in
+  let pv = pr_lconstr_env state env (Evd.from_env env) v in
   str "Non strictly positive occurrence of " ++ pv ++ str " in" ++
   brk(1,1) ++ pc ++ str "."
 
-let error_ill_formed_inductive env c v =
-  let pc = pr_lconstr_env env (Evd.from_env env) c in
-  let pv = pr_lconstr_env env (Evd.from_env env) v in
+let error_ill_formed_inductive state env c v =
+  let pc = pr_lconstr_env state env (Evd.from_env env) c in
+  let pv = pr_lconstr_env state env (Evd.from_env env) v in
   str "Not enough arguments applied to the " ++ pv ++
   str " in" ++ brk(1,1) ++ pc ++ str "."
 
-let error_ill_formed_constructor env id c v nparams nargs =
-  let pv = pr_lconstr_env env (Evd.from_env env) v in
+let error_ill_formed_constructor state env id c v nparams nargs =
+  let pv = pr_lconstr_env state env (Evd.from_env env) v in
   let atomic = Int.equal (nb_prod Evd.empty (EConstr.of_constr c)) (** FIXME *) 0 in
   str "The type of constructor" ++ brk(1,1) ++ Id.print id ++ brk(1,1) ++
   str "is not valid;" ++ brk(1,1) ++
@@ -1120,14 +1119,14 @@ let error_ill_formed_constructor env id c v nparams nargs =
    else
      mt()) ++ str "."
 
-let pr_ltype_using_barendregt_convention_env env c =
+let pr_ltype_using_barendregt_convention_env state env c =
   (* Use goal_concl_style as an approximation of Barendregt's convention (?) *)
-  quote (pr_goal_concl_style_env env (Evd.from_env env) (EConstr.of_constr c))
+  quote (pr_goal_concl_style_env state env (Evd.from_env env) (EConstr.of_constr c))
 
-let error_bad_ind_parameters env c n v1 v2  =
-  let pc = pr_ltype_using_barendregt_convention_env env c in
-  let pv1 = pr_lconstr_env env (Evd.from_env env) v1 in
-  let pv2 = pr_lconstr_env env (Evd.from_env env) v2 in
+let error_bad_ind_parameters state env c n v1 v2  =
+  let pc = pr_ltype_using_barendregt_convention_env state env c in
+  let pv1 = pr_lconstr_env state env (Evd.from_env env) v1 in
+  let pv2 = pr_lconstr_env state env (Evd.from_env env) v2 in
   str "Last occurrence of " ++ pv2 ++ str " must have " ++ pv1 ++
   str " as " ++ pr_nth n ++ str " argument in" ++ brk(1,1) ++ pc ++ str "."
 
@@ -1144,8 +1143,8 @@ let error_same_names_overlap idl =
   str "names:" ++ spc () ++
   prlist_with_sep pr_comma Id.print idl ++ str "."
 
-let error_not_an_arity env c =
-  str "The type" ++ spc () ++ pr_lconstr_env env (Evd.from_env env) c ++ spc () ++
+let error_not_an_arity state env c =
+  str "The type" ++ spc () ++ pr_lconstr_env state env (Evd.from_env env) c ++ spc () ++
   str "is not an arity."
 
 let error_bad_entry () =
@@ -1156,66 +1155,66 @@ let error_large_non_prop_inductive_not_in_type () =
 
 (* Recursion schemes errors *)
 
-let error_not_allowed_case_analysis env isrec kind i =
+let error_not_allowed_case_analysis state env isrec kind i =
   str (if isrec then "Induction" else "Case analysis") ++
   strbrk " on sort " ++ pr_sort Evd.empty kind ++
   strbrk " is not allowed for inductive definition " ++
-  pr_inductive env (fst i) ++ str "."
+  pr_inductive state env (fst i) ++ str "."
 
-let error_not_allowed_dependent_analysis env isrec i =
+let error_not_allowed_dependent_analysis state env isrec i =
   str "Dependent " ++ str (if isrec then "induction" else "case analysis") ++
   strbrk " is not allowed for inductive definition " ++
-  pr_inductive env i ++ str "."
+  pr_inductive state env i ++ str "."
 
-let error_not_mutual_in_scheme env ind ind' =
+let error_not_mutual_in_scheme state env ind ind' =
   if eq_ind ind ind' then
-    str "The inductive type " ++ pr_inductive env ind ++
+    str "The inductive type " ++ pr_inductive state env ind ++
     str " occurs twice."
   else
-    str "The inductive types " ++ pr_inductive env ind ++ spc () ++
-    str "and" ++ spc () ++ pr_inductive env ind' ++ spc () ++
+    str "The inductive types " ++ pr_inductive state env ind ++ spc () ++
+    str "and" ++ spc () ++ pr_inductive state env ind' ++ spc () ++
     str "are not mutually defined."
 
 (* Inductive constructions errors *)
 
-let explain_inductive_error = function
-  | NonPos (env,c,v) -> error_non_strictly_positive env c v
-  | NotEnoughArgs (env,c,v) -> error_ill_formed_inductive env c v
+let explain_inductive_error state = function
+  | NonPos (env,c,v) -> error_non_strictly_positive state env c v
+  | NotEnoughArgs (env,c,v) -> error_ill_formed_inductive state env c v
   | NotConstructor (env,id,c,v,n,m) ->
-      error_ill_formed_constructor env id c v n m
-  | NonPar (env,c,n,v1,v2) -> error_bad_ind_parameters env c n v1 v2
+      error_ill_formed_constructor state env id c v n m
+  | NonPar (env,c,n,v1,v2) -> error_bad_ind_parameters state env c n v1 v2
   | SameNamesTypes id -> error_same_names_types id
   | SameNamesConstructors id -> error_same_names_constructors id
   | SameNamesOverlap idl -> error_same_names_overlap idl
-  | NotAnArity (env, c) -> error_not_an_arity env c
+  | NotAnArity (env, c) -> error_not_an_arity state env c
   | BadEntry -> error_bad_entry ()
   | LargeNonPropInductiveNotInType ->
       error_large_non_prop_inductive_not_in_type ()
 
 (* Recursion schemes errors *)
 
-let explain_recursion_scheme_error env = function
+let explain_recursion_scheme_error state env = function
   | NotAllowedCaseAnalysis (isrec,k,i) ->
-      error_not_allowed_case_analysis env isrec k i
-  | NotMutualInScheme (ind,ind')-> error_not_mutual_in_scheme env ind ind'
+      error_not_allowed_case_analysis state env isrec k i
+  | NotMutualInScheme (ind,ind')-> error_not_mutual_in_scheme state env ind ind'
   | NotAllowedDependentAnalysis (isrec, i) ->
-     error_not_allowed_dependent_analysis env isrec i
+     error_not_allowed_dependent_analysis state env isrec i
 
 (* Pattern-matching errors *)
 
-let explain_bad_pattern env sigma cstr ty =
+let explain_bad_pattern state env sigma cstr ty =
   let ty = EConstr.to_constr sigma ty in
   let env = make_all_name_different env sigma in
-  let pt = pr_lconstr_env env sigma ty in
-  let pc = pr_constructor env cstr in
+  let pt = pr_lconstr_env state env sigma ty in
+  let pc = pr_constructor state env cstr in
   str "Found the constructor " ++ pc ++ brk(1,1) ++
   str "while matching a term of type " ++ pt ++ brk(1,1) ++
   str "which is not an inductive type."
 
-let explain_bad_constructor env cstr ind =
-  let pi = pr_inductive env ind in
+let explain_bad_constructor state env cstr ind =
+  let pi = pr_inductive state env ind in
 (*  let pc = pr_constructor env cstr in*)
-  let pt = pr_inductive env (inductive_of_constructor cstr) in
+  let pt = pr_inductive state env (inductive_of_constructor cstr) in
   str "Found a constructor of inductive type " ++ pt ++ brk(1,1) ++
   str "while a constructor of " ++ pi ++ brk(1,1) ++
   str "is expected."
@@ -1225,13 +1224,13 @@ let decline_string n s =
   else if Int.equal n 1 then str "1 " ++ str s
   else (int n ++ str " " ++ str s ++ str "s")
 
-let explain_wrong_numarg_constructor env cstr n =
-  str "The constructor " ++ pr_constructor env cstr ++
-  str " (in type " ++ pr_inductive env (inductive_of_constructor cstr) ++
+let explain_wrong_numarg_constructor state env cstr n =
+  str "The constructor " ++ pr_constructor state env cstr ++
+  str " (in type " ++ pr_inductive state env (inductive_of_constructor cstr) ++
   str ") expects " ++ decline_string n "argument" ++ str "."
 
-let explain_wrong_numarg_inductive env ind n =
-  str "The inductive type " ++ pr_inductive env ind ++
+let explain_wrong_numarg_inductive state env ind n =
+  str "The inductive type " ++ pr_inductive state env ind ++
   str " expects " ++ decline_string n "argument" ++ str "."
 
 let explain_unused_clause env pats =
@@ -1242,32 +1241,32 @@ let explain_non_exhaustive env pats =
   str (String.plural (List.length pats) "pattern") ++
   spc () ++ hov 0 (prlist_with_sep pr_comma pr_cases_pattern pats)
 
-let explain_cannot_infer_predicate env sigma typs =
+let explain_cannot_infer_predicate state env sigma typs =
   let inj c = EConstr.to_constr sigma c in
   let typs = Array.map_to_list (fun (c1, c2) -> (inj c1, inj c2)) typs in
   let env = make_all_name_different env sigma in
   let pr_branch (cstr,typ) =
     let cstr,_ = decompose_app cstr in
-    str "For " ++ pr_lconstr_env env sigma cstr ++ str ": " ++ pr_lconstr_env env sigma typ
+    str "For " ++ pr_lconstr_env state env sigma cstr ++ str ": " ++ pr_lconstr_env state env sigma typ
   in
   str "Unable to unify the types found in the branches:" ++
   spc () ++ hov 0 (prlist_with_sep fnl pr_branch typs)
 
-let explain_pattern_matching_error env sigma = function
+let explain_pattern_matching_error state env sigma = function
   | BadPattern (c,t) ->
-      explain_bad_pattern env sigma c t
+      explain_bad_pattern state env sigma c t
   | BadConstructor (c,ind) ->
-      explain_bad_constructor env c ind
+      explain_bad_constructor state env c ind
   | WrongNumargConstructor (c,n) ->
-      explain_wrong_numarg_constructor env c n
+      explain_wrong_numarg_constructor state env c n
   | WrongNumargInductive (c,n) ->
-      explain_wrong_numarg_inductive env c n
+      explain_wrong_numarg_inductive state env c n
   | UnusedClause tms ->
       explain_unused_clause env tms
   | NonExhaustive tms ->
       explain_non_exhaustive env tms
   | CannotInferPredicate typs ->
-      explain_cannot_infer_predicate env sigma typs
+      explain_cannot_infer_predicate state env sigma typs
 
 let map_pguard_error f = function
 | NotEnoughAbstractionInFixBody -> NotEnoughAbstractionInFixBody
@@ -1310,19 +1309,19 @@ let map_ptype_error f = function
 | UndeclaredUniverse l -> UndeclaredUniverse l
 
 let explain_reduction_tactic_error = function
-  | Tacred.InvalidAbstraction (env,sigma,c,(env',e)) ->
+  | Tacred.InvalidAbstraction (state,env,sigma,c,(env',e)) ->
       let e = map_ptype_error EConstr.of_constr e in
       str "The abstracted term" ++ spc () ++
-      quote (pr_goal_concl_style_env env sigma c) ++
+      quote (pr_goal_concl_style_env state env sigma c) ++
       spc () ++ str "is not well typed." ++ fnl () ++
-      explain_type_error env' (Evd.from_env env') e
+      explain_type_error state env' (Evd.from_env env') e
 
-let explain_numeral_notation_error env sigma = function
+let explain_numeral_notation_error state env sigma = function
   | Notation.UnexpectedTerm c ->
     (strbrk "Unexpected term " ++
-     pr_constr_env env sigma c ++
+     pr_constr_env state env sigma c ++
      strbrk " while parsing a numeral notation.")
   | Notation.UnexpectedNonOptionTerm c ->
     (strbrk "Unexpected non-option term " ++
-     pr_constr_env env sigma c ++
+     pr_constr_env state env sigma c ++
      strbrk " while parsing a numeral notation.")

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -601,12 +601,12 @@ let explain_var_not_found env id =
   spc () ++ str "in the current" ++ spc () ++ str "environment" ++ str "."
 
 let explain_wrong_case_info env (ind,u) ci =
-  let pi = pr_inductive (Global.env()) ind in
+  let pi = pr_inductive env ind in
   if eq_ind ci.ci_ind ind then
     str "Pattern-matching expression on an object of inductive type" ++
     spc () ++ pi ++ spc () ++ str "has invalid information."
   else
-    let pc = pr_inductive (Global.env()) ci.ci_ind in
+    let pc = pr_inductive env ci.ci_ind in
     str "A term of inductive type" ++ spc () ++ pi ++ spc () ++
     str "was given to a pattern-matching expression on the inductive type" ++
     spc () ++ pc ++ str "."
@@ -1156,24 +1156,24 @@ let error_large_non_prop_inductive_not_in_type () =
 
 (* Recursion schemes errors *)
 
-let error_not_allowed_case_analysis isrec kind i =
+let error_not_allowed_case_analysis env isrec kind i =
   str (if isrec then "Induction" else "Case analysis") ++
   strbrk " on sort " ++ pr_sort Evd.empty kind ++
   strbrk " is not allowed for inductive definition " ++
-  pr_inductive (Global.env()) (fst i) ++ str "."
+  pr_inductive env (fst i) ++ str "."
 
-let error_not_allowed_dependent_analysis isrec i =
+let error_not_allowed_dependent_analysis env isrec i =
   str "Dependent " ++ str (if isrec then "induction" else "case analysis") ++
   strbrk " is not allowed for inductive definition " ++
-  pr_inductive (Global.env()) i ++ str "."
+  pr_inductive env i ++ str "."
 
-let error_not_mutual_in_scheme ind ind' =
+let error_not_mutual_in_scheme env ind ind' =
   if eq_ind ind ind' then
-    str "The inductive type " ++ pr_inductive (Global.env()) ind ++
+    str "The inductive type " ++ pr_inductive env ind ++
     str " occurs twice."
   else
-    str "The inductive types " ++ pr_inductive (Global.env()) ind ++ spc () ++
-    str "and" ++ spc () ++ pr_inductive (Global.env()) ind' ++ spc () ++
+    str "The inductive types " ++ pr_inductive env ind ++ spc () ++
+    str "and" ++ spc () ++ pr_inductive env ind' ++ spc () ++
     str "are not mutually defined."
 
 (* Inductive constructions errors *)
@@ -1194,12 +1194,12 @@ let explain_inductive_error = function
 
 (* Recursion schemes errors *)
 
-let explain_recursion_scheme_error = function
+let explain_recursion_scheme_error env = function
   | NotAllowedCaseAnalysis (isrec,k,i) ->
-      error_not_allowed_case_analysis isrec k i
-  | NotMutualInScheme (ind,ind')-> error_not_mutual_in_scheme ind ind'
+      error_not_allowed_case_analysis env isrec k i
+  | NotMutualInScheme (ind,ind')-> error_not_mutual_in_scheme env ind ind'
   | NotAllowedDependentAnalysis (isrec, i) ->
-     error_not_allowed_dependent_analysis isrec i
+     error_not_allowed_dependent_analysis env isrec i
 
 (* Pattern-matching errors *)
 

--- a/vernac/himsg.mli
+++ b/vernac/himsg.mli
@@ -19,27 +19,27 @@ open Logic
 
 (** This module provides functions to explain the type errors. *)
 
-val explain_type_error : env -> Evd.evar_map -> type_error -> Pp.t
+val explain_type_error : States.state -> env -> Evd.evar_map -> type_error -> Pp.t
 
-val explain_pretype_error : env -> Evd.evar_map -> pretype_error -> Pp.t
+val explain_pretype_error : States.state -> env -> Evd.evar_map -> pretype_error -> Pp.t
 
-val explain_inductive_error : inductive_error -> Pp.t
+val explain_inductive_error : States.state -> inductive_error -> Pp.t
 
-val explain_mismatched_contexts : env -> contexts -> Constrexpr.constr_expr list -> Constr.rel_context -> Pp.t
+val explain_mismatched_contexts : States.state -> env -> contexts -> Constrexpr.constr_expr list -> Constr.rel_context -> Pp.t
 
-val explain_typeclass_error : env -> typeclass_error -> Pp.t
+val explain_typeclass_error : States.state -> env -> typeclass_error -> Pp.t
 
-val explain_recursion_scheme_error : env -> recursion_scheme_error -> Pp.t
+val explain_recursion_scheme_error : States.state -> env -> recursion_scheme_error -> Pp.t
 
-val explain_refiner_error : env -> Evd.evar_map -> refiner_error -> Pp.t
+val explain_refiner_error : States.state -> env -> Evd.evar_map -> refiner_error -> Pp.t
 
 val explain_pattern_matching_error :
-  env -> Evd.evar_map -> pattern_matching_error -> Pp.t
+  States.state -> env -> Evd.evar_map -> pattern_matching_error -> Pp.t
 
 val explain_reduction_tactic_error :
   Tacred.reduction_tactic_error -> Pp.t
 
-val explain_module_error : Modops.module_typing_error -> Pp.t
+val explain_module_error : States.state -> Modops.module_typing_error -> Pp.t
 
 val explain_module_internalization_error :
   Modintern.module_internalization_error -> Pp.t
@@ -47,4 +47,4 @@ val explain_module_internalization_error :
 val map_pguard_error : ('c -> 'd) -> 'c pguard_error -> 'd pguard_error
 val map_ptype_error : ('c -> 'd) -> ('c, 'c) ptype_error -> ('d, 'd) ptype_error
 
-val explain_numeral_notation_error : env -> Evd.evar_map -> Notation.numeral_notation_error -> Pp.t
+val explain_numeral_notation_error : States.state -> env -> Evd.evar_map -> Notation.numeral_notation_error -> Pp.t

--- a/vernac/himsg.mli
+++ b/vernac/himsg.mli
@@ -29,7 +29,7 @@ val explain_mismatched_contexts : env -> contexts -> Constrexpr.constr_expr list
 
 val explain_typeclass_error : env -> typeclass_error -> Pp.t
 
-val explain_recursion_scheme_error : recursion_scheme_error -> Pp.t
+val explain_recursion_scheme_error : env -> recursion_scheme_error -> Pp.t
 
 val explain_refiner_error : env -> Evd.evar_map -> refiner_error -> Pp.t
 

--- a/vernac/indschemes.ml
+++ b/vernac/indschemes.ml
@@ -157,11 +157,13 @@ let try_declare_scheme what f internal names kn =
     | NonSingletonProp ind ->
 	alarm what internal
 	  (str "Cannot extract computational content from proposition " ++
-	   quote (Printer.pr_inductive (Global.env()) ind) ++ str ".")
+           quote (Printer.pr_inductive (States.get_state ())
+                    (Global.env()) ind) ++ str ".")
     | EqNotFound (ind',ind) ->
 	alarm what internal
 	  (str "Boolean equality on " ++
-	   quote (Printer.pr_inductive (Global.env()) ind') ++
+           quote (Printer.pr_inductive (States.get_state ())
+                    (Global.env()) ind') ++
 	   strbrk " is missing.")
     | UndefinedCst s ->
 	alarm what internal
@@ -183,7 +185,7 @@ let try_declare_scheme what f internal names kn =
     | ConstructorWithNonParametricInductiveType ind ->
          alarm what internal
            (strbrk "Unsupported constructor with an argument whose type is a non-parametric inductive type." ++
-            strbrk " Type " ++ quote (Printer.pr_inductive (Global.env()) ind) ++
+            strbrk " Type " ++ quote (Printer.pr_inductive (States.get_state ()) (Global.env()) ind) ++
             str " is applied to an argument which is not a variable.")
     | e when CErrors.noncritical e ->
         alarm what internal
@@ -198,7 +200,7 @@ let beq_scheme_msg mind =
   let mib = Global.lookup_mind mind in
   (* TODO: mutual inductive case *)
   str "Boolean equality on " ++
-    pr_enum (fun ind -> quote (Printer.pr_inductive (Global.env()) ind))
+    pr_enum (fun ind -> quote (Printer.pr_inductive (States.get_state ()) (Global.env()) ind))
     (List.init (Array.length mib.mind_packets) (fun i -> (mind,i)))
 
 let declare_beq_scheme_with l kn =
@@ -276,7 +278,7 @@ let declare_eq_decidability_gen internal names kn =
     ignore (define_mutual_scheme eq_dec_scheme_kind internal names kn)
 
 let eq_dec_scheme_msg ind = (* TODO: mutual inductive case *)
-  str "Decidable equality on " ++ quote (Printer.pr_inductive (Global.env()) ind)
+  str "Decidable equality on " ++ quote (Printer.pr_inductive (States.get_state ()) (Global.env()) ind)
 
 let declare_eq_decidability_scheme_with l kn =
   try_declare_scheme (eq_dec_scheme_msg (kn,0))

--- a/vernac/lemmas.ml
+++ b/vernac/lemmas.ml
@@ -195,7 +195,7 @@ let save ?export_seff id const uctx do_guard (locality,poly,kind) hook =
           let kn =
            declare_constant ?export_seff id ~local (DefinitionEntry const, k) in
           let () = if should_suggest
-            then Proof_using.suggest_constant (Global.env ()) kn
+            then Proof_using.suggest_constant (States.get_state ()) (Global.env ()) kn
           in
           (locality, ConstRef kn)
     in
@@ -257,7 +257,8 @@ let save_remaining_recthms (locality,p,kind) norm univs body opaq i (id,(t_i,(_,
         | App (t, args) -> mkApp (body_i t, args)
         | _ ->
           let sigma, env = Pfedit.get_current_context () in
-          anomaly Pp.(str "Not a proof by induction: " ++ Printer.pr_constr_env env sigma body ++ str ".") in
+          let state = States.get_state () in
+          anomaly Pp.(str "Not a proof by induction: " ++ Printer.pr_constr_env state env sigma body ++ str ".") in
       let body_i = body_i body in
       match locality with
       | Discharge ->

--- a/vernac/obligations.ml
+++ b/vernac/obligations.ml
@@ -1075,9 +1075,10 @@ let show_obligations_of_prg ?(msg=true) prg =
 			 let x = subst_deps_obl obls x in
                          let env = Global.env () in
                          let sigma = Evd.from_env env in
+                         let state = States.get_state () in
 			 Feedback.msg_info (str "Obligation" ++ spc() ++ int (succ i) ++ spc () ++
 				   str "of" ++ spc() ++ Id.print n ++ str ":" ++ spc () ++
-                                   hov 1 (Printer.pr_constr_env env sigma x.obl_type ++
+                                   hov 1 (Printer.pr_constr_env state env sigma x.obl_type ++
 					    str "." ++ fnl ())))
 		   | Some _ -> ())
       obls
@@ -1095,9 +1096,10 @@ let show_term n =
   let n = prg.prg_name in
   let env = Global.env () in
   let sigma = Evd.from_env env in
+  let state = States.get_state () in
     (Id.print n ++ spc () ++ str":" ++ spc () ++
-             Printer.pr_constr_env env sigma prg.prg_type ++ spc () ++ str ":=" ++ fnl ()
-            ++ Printer.pr_constr_env env sigma prg.prg_body)
+             Printer.pr_constr_env state env sigma prg.prg_type ++ spc () ++ str ":=" ++ fnl ()
+            ++ Printer.pr_constr_env state env sigma prg.prg_body)
 
 let add_definition n ?term t ctx ?(univdecl=UState.default_univ_decl)
                    ?(implicits=[]) ?(kind=Global,false,Definition) ?tactic

--- a/vernac/proof_using.ml
+++ b/vernac/proof_using.ml
@@ -145,14 +145,14 @@ let _ =
       Goptions.optread  = (fun () -> !suggest_proof_using);
       Goptions.optwrite = ((:=) suggest_proof_using) }
 
-let suggest_constant env kn =
+let suggest_constant state env kn =
   if !suggest_proof_using
   then begin
     let open Declarations in
     let body = lookup_constant kn env in
     let used = Id.Set.of_list @@ List.map NamedDecl.get_id body.const_hyps in
     let ids_typ = global_vars_set env body.const_type in
-    suggest_common env (Printer.pr_constant env kn) used ids_typ Id.Set.empty
+    suggest_common env (Printer.pr_constant state env kn) used ids_typ Id.Set.empty
   end
 
 let suggest_variable env id =

--- a/vernac/proof_using.mli
+++ b/vernac/proof_using.mli
@@ -16,7 +16,7 @@ val process_expr :
 
 val name_set : Names.Id.t -> Vernacexpr.section_subset_expr -> unit
 
-val suggest_constant : Environ.env -> Names.Constant.t -> unit
+val suggest_constant : States.state -> Environ.env -> Names.Constant.t -> unit
 
 val suggest_variable : Environ.env -> Names.Id.t -> unit
 

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -223,12 +223,12 @@ let warning_or_error coe indsp err =
 	  | ElimArity (_,_,_,_,Some (_,_,NonInformativeToInformative)) ->
               (Id.print fi ++
 		strbrk" cannot be defined because it is informative and " ++
-		Printer.pr_inductive (Global.env()) indsp ++
+                Printer.pr_inductive (States.get_state ()) (Global.env()) indsp ++
 		strbrk " is not.")
 	  | ElimArity (_,_,_,_,Some (_,_,StrongEliminationOnNonSmallType)) ->
 	      (Id.print fi ++
 		strbrk" cannot be defined because it is large and " ++
-		Printer.pr_inductive (Global.env()) indsp ++
+                Printer.pr_inductive (States.get_state ()) (Global.env()) indsp ++
 		strbrk " is not.")
 	  | _ ->
               (Id.print fi ++ strbrk " cannot be defined because it is not typable.")
@@ -280,8 +280,8 @@ let instantiate_possibly_recursive_type ind u ntypes paramdecls fields =
 
 let warn_non_primitive_record =
   CWarnings.create ~name:"non-primitive-record" ~category:"record"
-         (fun (env,indsp) ->
-          (hov 0 (str "The record " ++ Printer.pr_inductive env indsp ++ 
+         (fun (state,env,indsp) ->
+          (hov 0 (str "The record " ++ Printer.pr_inductive state env indsp ++
                     strbrk" could not be defined as a primitive record")))
 
 (* We build projections *)
@@ -307,8 +307,10 @@ let declare_projections indsp ctx ?(kind=StructureComponent) binder_name coers u
         | PrimRecord _ -> true
         | FakeRecord | NotRecord -> false
       in
-	if not is_primitive then 
-	  warn_non_primitive_record (env,indsp);
+        if not is_primitive then begin
+            let state = States.get_state () in
+            warn_non_primitive_record (state,env,indsp)
+          end;
 	is_primitive
     else false
   in


### PR DESCRIPTION
**Kind:** cleanup

This is an experiment in threading the state through printing functions.

There are different ways to do it. Here, we experiment giving to printing functions a type of the form:
```coq
val pr_lconstr_env : States.state -> env -> evar_map -> constr -> Pp.t
```
but alternatives have been proposed (e.g. [here](https://github.com/coq/coq/pull/8590#issuecomment-425659103)). Since the type `States.state` is easy to grep, a global replace could be possible at some time.

We experiment using this state for implicit arguments (which are then threaded functionally to the printer and other clients of `implicits_of_global`). Depending on the direction to which we decide to go, it would be quite easy to do it for notations, argument scopes, coercions, and even probably `Nametab`.

This is on top of #8590, #8594, #8595. To see the diff specific to this PR, look at the main (huge) commit "Passing functionally a state to printing functions". The diff for `Impargs` is then shorter, see "Dealing with the table of implicit arguments functionally".

Basically all features are concerned since the need for printers is pervasive.

I tried to follow the following general adaptation scheme:
- when the `env` and `sigma` are obtained by side-effects (`Pfedit.get_current_context ()`) I get the `state` by side-effects
- when the `env` and `sigma` come from a goal, I also use a side effect (by lack of another possibility), but ideally, if the state is attached to the goal, it will be just a `Proofview.Goal.state`

Added: the re-computation of the state is costly: in O(N) for N the number of declared objects, i.e. apparently 67 (and even worth if some tables are not themselves functional). So, optimizations shall have to be considered to avoid useless recomputations. In particular this is the cause for test `4429` to fail.