### PR TITLE
Experimenting a functional variant of add_anonymous_leaf

### DIFF
--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -377,7 +377,7 @@ let pattern_printable_in_both_syntax (ind,_ as c) =
   ) impl_st
 
  (* Better to use extern_glob_constr composed with injection/retraction ?? *)
-let rec extern_cases_pattern_in_scope (custom,scopes as allscopes) vars pat =
+let rec extern_cases_pattern_in_scope state (custom,scopes as allscopes) vars pat =
   try
     if !Flags.in_debugger || !Flags.raw_print || !print_no_symbol then raise No_match;
     let (na,sc,p) = uninterp_prim_token_cases_pattern pat in
@@ -393,7 +393,7 @@ let rec extern_cases_pattern_in_scope (custom,scopes as allscopes) vars pat =
   with No_match ->
     try
       if !Flags.in_debugger || !Flags.raw_print || !print_no_symbol then raise No_match;
-      extern_notation_pattern allscopes vars pat
+      extern_notation_pattern state allscopes vars pat
         (uninterp_cases_pattern_notations pat)
     with No_match ->
     let loc = pat.CAst.loc in
@@ -408,7 +408,7 @@ let rec extern_cases_pattern_in_scope (custom,scopes as allscopes) vars pat =
         | PatVar (Name id) -> CAst.make ?loc (CPatAtom (Some (qualid_of_ident ?loc id)))
         | PatVar (Anonymous) -> CAst.make ?loc (CPatAtom None)
 	| PatCstr(cstrsp,args,na) ->
-          let args = List.map (extern_cases_pattern_in_scope allscopes vars) args in
+          let args = List.map (extern_cases_pattern_in_scope state allscopes vars) args in
 	  let p =
 	    try
               if !Flags.raw_print then raise Exit;
@@ -446,7 +446,7 @@ let rec extern_cases_pattern_in_scope (custom,scopes as allscopes) vars pat =
       in
       insert_pat_coercion coercion pat
 
-and apply_notation_to_pattern ?loc gr ((subst,substlist),(nb_to_drop,more_args))
+and apply_notation_to_pattern ?loc state gr ((subst,substlist),(nb_to_drop,more_args))
     (custom, (tmp_scope, scopes) as allscopes) vars =
   function
     | NotationRule (sc,ntn) ->
@@ -462,14 +462,14 @@ and apply_notation_to_pattern ?loc gr ((subst,substlist),(nb_to_drop,more_args))
 	    let scopes' = Option.List.cons scopt scopes in
 	    let l =
               List.map (fun (c,(subentry,(scopt,scl))) ->
-                extern_cases_pattern_in_scope (subentry,(scopt,scl@scopes')) vars c)
+                extern_cases_pattern_in_scope state (subentry,(scopt,scl@scopes')) vars c)
 		subst in
 	    let ll =
               List.map (fun (c,(subentry,(scopt,scl))) ->
                 let subscope = (subentry,(scopt,scl@scopes')) in
-		List.map (extern_cases_pattern_in_scope subscope vars) c)
+                List.map (extern_cases_pattern_in_scope state subscope vars) c)
 		substlist in
-	    let l2 = List.map (extern_cases_pattern_in_scope allscopes vars) more_args in
+            let l2 = List.map (extern_cases_pattern_in_scope state allscopes vars) more_args in
             let l2' = if !asymmetric_patterns || not (List.is_empty ll) then l2
 	      else
 		match drop_implicits_in_patt gr nb_to_drop l2 with
@@ -484,9 +484,9 @@ and apply_notation_to_pattern ?loc gr ((subst,substlist),(nb_to_drop,more_args))
       let qid = shortest_qualid_of_syndef ?loc vars kn in
       let l1 =
         List.rev_map (fun (c,(subentry,(scopt,scl))) ->
-          extern_cases_pattern_in_scope (subentry,(scopt,scl@scopes)) vars c)
+          extern_cases_pattern_in_scope state (subentry,(scopt,scl@scopes)) vars c)
           subst in
-      let l2 = List.map (extern_cases_pattern_in_scope allscopes vars) more_args in
+      let l2 = List.map (extern_cases_pattern_in_scope state allscopes vars) more_args in
       let l2' = if !asymmetric_patterns then l2
 	else
 	  match drop_implicits_in_patt gr (nb_to_drop + List.length l1) l2 with
@@ -495,7 +495,7 @@ and apply_notation_to_pattern ?loc gr ((subst,substlist),(nb_to_drop,more_args))
       in
       assert (List.is_empty substlist);
       mkPat ?loc qid (List.rev_append l1 l2')
-and extern_notation_pattern allscopes vars t = function
+and extern_notation_pattern state allscopes vars t = function
   | [] -> raise No_match
   | (keyrule,pat,n as _rule)::rules ->
     try
@@ -504,45 +504,45 @@ and extern_notation_pattern allscopes vars t = function
       match DAst.get t with
         | PatCstr (cstr,args,na) ->
           let t = if na = Anonymous then t else DAst.make ?loc (PatCstr (cstr,args,Anonymous)) in
-	  let p = apply_notation_to_pattern ?loc (ConstructRef cstr)
+          let p = apply_notation_to_pattern ?loc state (ConstructRef cstr)
 	    (match_notation_constr_cases_pattern t pat) allscopes vars keyrule in
 	  insert_pat_alias ?loc p na
 	| PatVar Anonymous -> CAst.make ?loc @@ CPatAtom None
         | PatVar (Name id) -> CAst.make ?loc @@ CPatAtom (Some (qualid_of_ident ?loc id))
     with
-	No_match -> extern_notation_pattern allscopes vars t rules
+        No_match -> extern_notation_pattern state allscopes vars t rules
 
-let rec extern_notation_ind_pattern allscopes vars ind args = function
+let rec extern_notation_ind_pattern state allscopes vars ind args = function
   | [] -> raise No_match
   | (keyrule,pat,n as _rule)::rules ->
     try
       if is_inactive_rule keyrule then raise No_match;
-      apply_notation_to_pattern (IndRef ind)
+      apply_notation_to_pattern state (IndRef ind)
 	(match_notation_constr_ind_pattern ind args pat) allscopes vars keyrule
     with
-	No_match -> extern_notation_ind_pattern allscopes vars ind args rules
+        No_match -> extern_notation_ind_pattern state allscopes vars ind args rules
 
-let extern_ind_pattern_in_scope (custom,scopes as allscopes) vars ind args =
+let extern_ind_pattern_in_scope state (custom,scopes as allscopes) vars ind args =
   (* pboutill: There are letins in pat which is incompatible with notations and
      not explicit application. *)
   if !Flags.in_debugger||Inductiveops.inductive_has_local_defs ind then
     let c = extern_reference vars (IndRef ind) in
-    let args = List.map (extern_cases_pattern_in_scope allscopes vars) args in
+    let args = List.map (extern_cases_pattern_in_scope state allscopes vars) args in
     CAst.make @@ CPatCstr (c, Some (add_patt_for_params ind args), [])
   else
     try
       if !Flags.raw_print || !print_no_symbol then raise No_match;
-      extern_notation_ind_pattern allscopes vars ind args
+      extern_notation_ind_pattern state allscopes vars ind args
           (uninterp_ind_pattern_notations ind)
     with No_match ->
       let c = extern_reference vars (IndRef ind) in
-      let args = List.map (extern_cases_pattern_in_scope allscopes vars) args in
+      let args = List.map (extern_cases_pattern_in_scope state allscopes vars) args in
       match drop_implicits_in_patt (IndRef ind) 0 args with
 	   |Some true_args -> CAst.make @@ CPatCstr (c, None, true_args)
 	   |None           -> CAst.make @@ CPatCstr (c, Some args, [])
 
-let extern_cases_pattern vars p =
-  extern_cases_pattern_in_scope (InConstrEntrySomeLevel,(None,[])) vars p
+let extern_cases_pattern state vars p =
+  extern_cases_pattern_in_scope state (InConstrEntrySomeLevel,(None,[])) vars p
 
 (**********************************************************************)
 (* Externalising applications *)
@@ -763,7 +763,7 @@ let extern_ref vars ref us =
 
 let extern_var ?loc id = CRef (qualid_of_ident ?loc id,None)
 
-let rec extern inctx scopes vars r =
+let rec extern state inctx scopes vars r =
   let r' = remove_coercions inctx r in
   try
     if !Flags.raw_print || !print_no_symbol then raise No_match;
@@ -772,7 +772,7 @@ let rec extern inctx scopes vars r =
   try
     let r'' = flatten_application r' in
     if !Flags.raw_print || !print_no_symbol then raise No_match;
-    extern_notation scopes vars r'' (uninterp_notations r'')
+    extern_notation state scopes vars r'' (uninterp_notations r'')
   with No_match ->
   let loc = r'.CAst.loc in
   match DAst.get r' with
@@ -798,7 +798,7 @@ let rec extern inctx scopes vars r =
   | GEvar (n,[]) when !print_meta_as_hole -> CHole (None, IntroAnonymous, None)
 
   | GEvar (n,l) ->
-      extern_evar n (List.map (on_snd (extern false scopes vars)) l)
+      extern_evar n (List.map (on_snd (extern state false scopes vars)) l)
 
   | GPatVar kind ->
       if !print_meta_as_hole then CHole (None, IntroAnonymous, None) else
@@ -846,40 +846,40 @@ let rec extern inctx scopes vars r =
 				 | [] -> raise No_match
 				     (* we give up since the constructor is not complete *)
 				 | (arg, scopes) :: tail ->
-                                     let head = extern true scopes vars arg in
+                                     let head = extern state true scopes vars arg in
                                      ip q locs' tail ((extern_reference ?loc Id.Set.empty (ConstRef c), head) :: acc)
 		   in
 		 CRecord (List.rev (ip projs locals args []))
 	       with
 		 | Not_found | No_match | Exit ->
-                    let args = extern_args (extern true) vars args in
+                    let args = extern_args (extern state true) vars args in
 		     extern_app inctx
 		       (select_stronger_impargs (implicits_of_global ref))
                        (Some ref,extern_reference ?loc vars ref) (extern_universes us) args
 	     end
 
 	 | _       ->
-	   explicitize inctx [] (None,sub_extern false scopes vars f)
-             (List.map (fun c -> lazy (sub_extern true scopes vars c)) args))
+           explicitize inctx [] (None,sub_extern state false scopes vars f)
+             (List.map (fun c -> lazy (sub_extern state true scopes vars c)) args))
 
   | GLetIn (na,b,t,c) ->
-      CLetIn (make ?loc na,sub_extern false scopes vars b,
-              Option.map (extern_typ scopes vars) t,
-              extern inctx scopes (add_vname vars na) c)
+      CLetIn (make ?loc na,sub_extern state false scopes vars b,
+              Option.map (extern_typ state scopes vars) t,
+              extern state inctx scopes (add_vname vars na) c)
 
   | GProd (na,bk,t,c) ->
-      let t = extern_typ scopes vars t in
-      factorize_prod scopes (add_vname vars na) na bk t c
+      let t = extern_typ state scopes vars t in
+      factorize_prod state scopes (add_vname vars na) na bk t c
 
   | GLambda (na,bk,t,c) ->
-      let t = extern_typ scopes vars t in
-      factorize_lambda inctx scopes (add_vname vars na) na bk t c
+      let t = extern_typ state scopes vars t in
+      factorize_lambda state inctx scopes (add_vname vars na) na bk t c
 
   | GCases (sty,rtntypopt,tml,eqns) ->
     let vars' =
       List.fold_right (Name.fold_right Id.Set.add)
 	(cases_predicate_names tml) vars in
-    let rtntypopt' = Option.map (extern_typ scopes vars') rtntypopt in
+    let rtntypopt' = Option.map (extern_typ state scopes vars') rtntypopt in
     let tml = List.map (fun (tm,(na,x)) ->
                  let na' = match na, DAst.get tm with
                    | Anonymous, GVar id ->
@@ -893,30 +893,30 @@ let rec extern inctx scopes vars r =
                    | Anonymous, _ -> None
                    | Name id, GVar id' when Id.equal id id' -> None
                    | Name _, _ -> Some (CAst.make na) in
-                 (sub_extern false scopes vars tm,
+                 (sub_extern state false scopes vars tm,
                   na',
                   Option.map (fun {CAst.loc;v=(ind,nal)} ->
                               let args = List.map (fun x -> DAst.make @@ PatVar x) nal in
                               let fullargs = add_cpatt_for_params ind args in
-                              extern_ind_pattern_in_scope scopes vars ind fullargs
+                              extern_ind_pattern_in_scope state scopes vars ind fullargs
                              ) x))
                 tml
     in
-    let eqns = List.map (extern_eqn inctx scopes vars) (factorize_eqns eqns) in
+    let eqns = List.map (extern_eqn state inctx scopes vars) (factorize_eqns eqns) in
     CCases (sty,rtntypopt',tml,eqns)
 
   | GLetTuple (nal,(na,typopt),tm,b) ->
     CLetTuple (List.map CAst.make nal,
         (Option.map (fun _ -> (make na)) typopt,
-         Option.map (extern_typ scopes (add_vname vars na)) typopt),
-        sub_extern false scopes vars tm,
-        extern inctx scopes (List.fold_left add_vname vars nal) b)
+         Option.map (extern_typ state scopes (add_vname vars na)) typopt),
+        sub_extern state false scopes vars tm,
+        extern state inctx scopes (List.fold_left add_vname vars nal) b)
 
   | GIf (c,(na,typopt),b1,b2) ->
-      CIf (sub_extern false scopes vars c,
+      CIf (sub_extern state false scopes vars c,
         (Option.map (fun _ -> (CAst.make na)) typopt,
-         Option.map (extern_typ scopes (add_vname vars na)) typopt),
-        sub_extern inctx scopes vars b1, sub_extern inctx scopes vars b2)
+         Option.map (extern_typ state scopes (add_vname vars na)) typopt),
+        sub_extern state inctx scopes vars b1, sub_extern state inctx scopes vars b2)
 
   | GRec (fk,idv,blv,tyv,bv) ->
       let vars' = Array.fold_right Id.Set.add idv vars in
@@ -926,7 +926,7 @@ let rec extern inctx scopes vars r =
 	       Array.mapi (fun i fi ->
                  let (bl,ty,def) = blv.(i), tyv.(i), bv.(i) in
                  let bl = List.map (extended_glob_local_binder_of_decl ?loc) bl in
-                 let (assums,ids,bl) = extern_local_binder scopes vars bl in
+                 let (assums,ids,bl) = extern_local_binder state scopes vars bl in
                  let vars0 = List.fold_right (Name.fold_right Id.Set.add) ids vars in
                  let vars1 = List.fold_right (Name.fold_right Id.Set.add) ids vars' in
 		 let n =
@@ -934,20 +934,20 @@ let rec extern inctx scopes vars r =
 		     | None -> None
                      | Some x -> Some (CAst.make @@ Name.get_id (List.nth assums x))
 		 in
-		 let ro = extern_recursion_order scopes vars (snd nv.(i)) in
-                 ((CAst.make fi), (n, ro), bl, extern_typ scopes vars0 ty,
-                  extern false scopes vars1 def)) idv
+                 let ro = extern_recursion_order state scopes vars (snd nv.(i)) in
+                 ((CAst.make fi), (n, ro), bl, extern_typ state scopes vars0 ty,
+                  extern state false scopes vars1 def)) idv
 	     in
              CFix (CAst.(make ?loc idv.(n)), Array.to_list listdecl)
 	 | GCoFix n ->
 	     let listdecl =
                Array.mapi (fun i fi ->
                  let bl = List.map (extended_glob_local_binder_of_decl ?loc) blv.(i) in
-                 let (_,ids,bl) = extern_local_binder scopes vars bl in
+                 let (_,ids,bl) = extern_local_binder state scopes vars bl in
                  let vars0 = List.fold_right (Name.fold_right Id.Set.add) ids vars in
                  let vars1 = List.fold_right (Name.fold_right Id.Set.add) ids vars' in
-                 ((CAst.make fi),bl,extern_typ scopes vars0 tyv.(i),
-                  sub_extern false scopes vars1 bv.(i))) idv
+                 ((CAst.make fi),bl,extern_typ state scopes vars0 tyv.(i),
+                  sub_extern state false scopes vars1 bv.(i))) idv
 	     in
              CCoFix (CAst.(make ?loc idv.(n)),Array.to_list listdecl))
 
@@ -956,20 +956,20 @@ let rec extern inctx scopes vars r =
   | GHole (e,naming,_) -> CHole (Some e, naming, None) (** TODO: extern tactics. *)
 
   | GCast (c, c') ->
-      CCast (sub_extern true scopes vars c,
-             map_cast_type (extern_typ scopes vars) c')
+      CCast (sub_extern state true scopes vars c,
+             map_cast_type (extern_typ state scopes vars) c')
   | GProj (p, c) ->
     let pr = extern_reference ?loc Id.Set.empty (ConstRef (Projection.constant p)) in
-    CProj (pr, sub_extern inctx scopes vars c)
+    CProj (pr, sub_extern state inctx scopes vars c)
 
   in insert_coercion coercion (CAst.make ?loc c)
 
-and extern_typ (subentry,(_,scopes)) =
-  extern true (subentry,(Notation.current_type_scope_name (),scopes))
+and extern_typ state (subentry,(_,scopes)) =
+  extern state true (subentry,(Notation.current_type_scope_name (),scopes))
 
-and sub_extern inctx (subentry,(_,scopes)) = extern inctx (subentry,(None,scopes))
+and sub_extern state inctx (subentry,(_,scopes)) = extern state inctx (subentry,(None,scopes))
 
-and factorize_prod scopes vars na bk aty c =
+and factorize_prod state scopes vars na bk aty c =
   let store, get = set_temporary_memory () in
   match na, DAst.get c with
   | Name id, GCases (Constr.LetPatternStyle, None, [(e,(Anonymous,None))],(_::_ as eqns))
@@ -978,15 +978,15 @@ and factorize_prod scopes vars na bk aty c =
      | [{CAst.v=(ids,disj_of_patl,b)}] ->
       let disjpat = List.map (function [pat] -> pat | _ -> assert false) disj_of_patl in
       let disjpat = if occur_glob_constr id b then List.map (set_pat_alias id) disjpat else disjpat in
-      let b = extern_typ scopes vars b in
-      let p = mkCPatOr (List.map (extern_cases_pattern_in_scope scopes vars) disjpat) in
+      let b = extern_typ state scopes vars b in
+      let p = mkCPatOr (List.map (extern_cases_pattern_in_scope state scopes vars) disjpat) in
       let binder = CLocalPattern (make ?loc:c.loc (p,None)) in
       (match b.v with
       | CProdN (bl,b) -> CProdN (binder::bl,b)
       | _ -> CProdN ([binder],b))
      | _ -> assert false)
   | _, _ ->
-      let c = extern_typ scopes vars c in
+      let c = extern_typ state scopes vars c in
       match na, c.v with
       | Name id, CProdN (CLocalAssum(nal,Default bk',ty)::bl,b)
            when binding_kind_eq bk bk' && constr_expr_eq aty ty
@@ -997,7 +997,7 @@ and factorize_prod scopes vars na bk aty c =
       | _, _ ->
          CProdN ([CLocalAssum([make na],Default bk,aty)],c)
 
-and factorize_lambda inctx scopes vars na bk aty c =
+and factorize_lambda state inctx scopes vars na bk aty c =
   let store, get = set_temporary_memory () in
   match na, DAst.get c with
   | Name id, GCases (Constr.LetPatternStyle, None, [(e,(Anonymous,None))],(_::_ as eqns))
@@ -1006,15 +1006,15 @@ and factorize_lambda inctx scopes vars na bk aty c =
      | [{CAst.v=(ids,disj_of_patl,b)}] ->
       let disjpat = List.map (function [pat] -> pat | _ -> assert false) disj_of_patl in
       let disjpat = if occur_glob_constr id b then List.map (set_pat_alias id) disjpat else disjpat in
-      let b = sub_extern inctx scopes vars b in
-      let p = mkCPatOr (List.map (extern_cases_pattern_in_scope scopes vars) disjpat) in
+      let b = sub_extern state inctx scopes vars b in
+      let p = mkCPatOr (List.map (extern_cases_pattern_in_scope state scopes vars) disjpat) in
       let binder = CLocalPattern (make ?loc:c.loc (p,None)) in
       (match b.v with
       | CLambdaN (bl,b) -> CLambdaN (binder::bl,b)
       | _ -> CLambdaN ([binder],b))
      | _ -> assert false)
   | _, _ ->
-      let c = sub_extern inctx scopes vars c in
+      let c = sub_extern state inctx scopes vars c in
       match c.v with
       | CLambdaN (CLocalAssum(nal,Default bk',ty)::bl,b)
            when binding_kind_eq bk bk' && constr_expr_eq aty ty
@@ -1025,20 +1025,20 @@ and factorize_lambda inctx scopes vars na bk aty c =
       | _ ->
          CLambdaN ([CLocalAssum([make na],Default bk,aty)],c)
 
-and extern_local_binder scopes vars = function
+and extern_local_binder state scopes vars = function
     [] -> ([],[],[])
   | b :: l ->
     match DAst.get b with
     | GLocalDef (na,bk,bd,ty) ->
       let (assums,ids,l) =
-        extern_local_binder scopes (Name.fold_right Id.Set.add na vars) l in
+        extern_local_binder state scopes (Name.fold_right Id.Set.add na vars) l in
       (assums,na::ids,
-       CLocalDef(CAst.make na, extern false scopes vars bd,
-                   Option.map (extern false scopes vars) ty) :: l)
+       CLocalDef(CAst.make na, extern state false scopes vars bd,
+                   Option.map (extern state false scopes vars) ty) :: l)
 
     | GLocalAssum (na,bk,ty) ->
-      let ty = extern_typ scopes vars ty in
-      (match extern_local_binder scopes (Name.fold_right Id.Set.add na vars) l with
+      let ty = extern_typ state scopes vars ty in
+      (match extern_local_binder state scopes (Name.fold_right Id.Set.add na vars) l with
           (assums,ids,CLocalAssum(nal,k,ty')::l)
             when constr_expr_eq ty ty' &&
               match na with Name id -> not (occur_var_constr_expr id ty')
@@ -1051,16 +1051,16 @@ and extern_local_binder scopes vars = function
 
     | GLocalPattern ((p,_),_,bk,ty) ->
       let ty =
-        if !Flags.raw_print then Some (extern_typ scopes vars ty) else None in
-      let p = mkCPatOr (List.map (extern_cases_pattern vars) p) in
-      let (assums,ids,l) = extern_local_binder scopes vars l in
+        if !Flags.raw_print then Some (extern_typ state scopes vars ty) else None in
+      let p = mkCPatOr (List.map (extern_cases_pattern state vars) p) in
+      let (assums,ids,l) = extern_local_binder state scopes vars l in
       (assums,ids, CLocalPattern(CAst.make @@ (p,ty)) :: l)
 
-and extern_eqn inctx scopes vars {CAst.loc;v=(ids,pll,c)} =
-  let pll = List.map (List.map (extern_cases_pattern_in_scope scopes vars)) pll in
-  make ?loc (pll,extern inctx scopes vars c)
+and extern_eqn state inctx scopes vars {CAst.loc;v=(ids,pll,c)} =
+  let pll = List.map (List.map (extern_cases_pattern_in_scope state scopes vars)) pll in
+  make ?loc (pll,extern state inctx scopes vars c)
 
-and extern_notation (custom,scopes as allscopes) vars t = function
+and extern_notation state (custom,scopes as allscopes) vars t = function
   | [] -> raise No_match
   | (keyrule,pat,n as _rule)::rules ->
       let loc = Glob_ops.loc_of_glob_constr t in
@@ -1118,54 +1118,56 @@ and extern_notation (custom,scopes as allscopes) vars t = function
                   let scopes' = Option.List.cons scopt (snd scopes) in
 	          let l =
                     List.map (fun (c,(subentry,(scopt,scl))) ->
-		      extern (* assuming no overloading: *) true
+                      extern state (* assuming no overloading: *) true
                         (subentry,(scopt,scl@scopes')) vars c)
                       terms in
 		  let ll =
                     List.map (fun (c,(subentry,(scopt,scl))) ->
-                      List.map (extern true (subentry,(scopt,scl@scopes')) vars) c)
+                      List.map (extern state true (subentry,(scopt,scl@scopes')) vars) c)
                       termlists in
                   let bl =
                     List.map (fun (bl,(subentry,(scopt,scl))) ->
-                      mkCPatOr (List.map (extern_cases_pattern_in_scope (subentry,(scopt,scl@scopes')) vars) bl))
+                      mkCPatOr (List.map (extern_cases_pattern_in_scope state (subentry,(scopt,scl@scopes')) vars) bl))
                       binders in
                   let bll =
                     List.map (fun (bl,(subentry,(scopt,scl))) ->
-                      pi3 (extern_local_binder (subentry,(scopt,scl@scopes')) vars bl))
+                      pi3 (extern_local_binder state (subentry,(scopt,scl@scopes')) vars bl))
                       binderlists in
                   insert_coercion coercion (insert_delimiters (make_notation loc ntn (l,ll,bl,bll)) key))
           | SynDefRule kn ->
 	      let l =
                 List.map (fun (c,(subentry,(scopt,scl))) ->
-                  extern true (subentry,(scopt,scl@snd scopes)) vars c, None)
+                  extern state true (subentry,(scopt,scl@snd scopes)) vars c, None)
 		  terms in
               let a = CRef (shortest_qualid_of_syndef ?loc vars kn,None) in
 	      CAst.make ?loc @@ if List.is_empty l then a else CApp ((None, CAst.make a),l) in
  	if List.is_empty args then e
 	else
           let args = fill_arg_scopes args argsscopes allscopes in
-	  let args = extern_args (extern true) vars args in
+          let args = extern_args (extern state true) vars args in
 	  CAst.make ?loc @@ explicitize false argsimpls (None,e) args
       with
-	  No_match -> extern_notation allscopes vars t rules
+          No_match -> extern_notation state allscopes vars t rules
 
-and extern_recursion_order scopes vars = function
+and extern_recursion_order state scopes vars = function
     GStructRec -> CStructRec
-  | GWfRec c -> CWfRec (extern true scopes vars c)
-  | GMeasureRec (m,r) -> CMeasureRec (extern true scopes vars m,
-				     Option.map (extern true scopes vars) r)
+  | GWfRec c -> CWfRec (extern state true scopes vars c)
+  | GMeasureRec (m,r) -> CMeasureRec (extern state true scopes vars m,
+                                     Option.map (extern state true scopes vars) r)
 
 
-let extern_glob_constr vars c =
-  extern false (InConstrEntrySomeLevel,(None,[])) vars c
+let extern_glob_constr env c =
+  let state = States.get_state () in
+  extern state false (InConstrEntrySomeLevel,(None,[])) env c
 
-let extern_glob_type vars c =
-  extern_typ (InConstrEntrySomeLevel,(None,[])) vars c
+let extern_glob_type env c =
+  let state = States.get_state () in
+  extern_typ state (InConstrEntrySomeLevel,(None,[])) env c
 
 (******************************************************************)
 (* Main translation function from constr -> constr_expr *)
 
-let extern_constr_gen lax goal_concl_style scopt env sigma t =
+let extern_constr_gen lax goal_concl_style scopt state env sigma t =
   (* "goal_concl_style" means do alpha-conversion using the "goal" convention *)
   (* i.e.: avoid using the names of goal/section/rel variables and the short *)
   (* names of global definitions of current module when computing names for *)
@@ -1176,28 +1178,31 @@ let extern_constr_gen lax goal_concl_style scopt env sigma t =
   let avoid = if goal_concl_style then vars_of_env env else Id.Set.empty in
   let r = Detyping.detype Detyping.Later ~lax:lax goal_concl_style avoid env sigma t in
   let vars = vars_of_env env in
-  extern false (InConstrEntrySomeLevel,(scopt,[])) vars r
+  extern state false (InConstrEntrySomeLevel,(scopt,[])) vars r
 
 let extern_constr_in_scope goal_concl_style scope env sigma t =
-  extern_constr_gen false goal_concl_style (Some scope) env sigma t
+  let state = States.get_state () in
+  extern_constr_gen false goal_concl_style (Some scope) state env sigma t
 
 let extern_constr ?(lax=false) goal_concl_style env sigma t =
-  extern_constr_gen lax goal_concl_style None env sigma t
+  let state = States.get_state () in
+  extern_constr_gen lax goal_concl_style None state env sigma t
 
 let extern_type goal_concl_style env sigma t =
   let avoid = if goal_concl_style then vars_of_env env else Id.Set.empty in
   let r = Detyping.detype Detyping.Later goal_concl_style avoid env sigma t in
-  extern_glob_type (vars_of_env env) r
+  extern_glob_type (Termops.vars_of_env env) r
 
 let extern_sort sigma s = extern_glob_sort (detype_sort sigma s)
 
 let extern_closed_glob ?lax goal_concl_style env sigma t =
+  let state = States.get_state () in
   let avoid = if goal_concl_style then vars_of_env env else Id.Set.empty in
   let r =
     Detyping.detype_closed_glob ?lax goal_concl_style avoid env sigma t
   in
   let vars = vars_of_env env in
-  extern false (InConstrEntrySomeLevel,(None,[])) vars r
+  extern state false (InConstrEntrySomeLevel,(None,[])) vars r
 
 (******************************************************************)
 (* Main translation function from pattern -> constr_expr *)
@@ -1306,10 +1311,16 @@ let rec glob_of_pat avoid env sigma pat = DAst.make @@ match pat with
   | PSort s -> GSort s
 
 let extern_constr_pattern env sigma pat =
-  extern true (InConstrEntrySomeLevel,(None,[])) Id.Set.empty (glob_of_pat Id.Set.empty env sigma pat)
+  let state = States.get_state () in
+  extern state true (InConstrEntrySomeLevel,(None,[])) Id.Set.empty (glob_of_pat Id.Set.empty  env sigma pat)
 
 let extern_rel_context where env sigma sign =
+  let state = States.get_state () in
   let a = detype_rel_context Detyping.Later where Id.Set.empty (names_of_rel_context env,env) sigma sign in
   let vars = vars_of_env env in
   let a = List.map (extended_glob_local_binder_of_decl) a in
-  pi3 (extern_local_binder (InConstrEntrySomeLevel,(None,[])) vars a)
+  pi3 (extern_local_binder state (InConstrEntrySomeLevel,(None,[])) vars a)
+
+let extern_cases_pattern a b =
+  let state = States.get_state () in
+  extern_cases_pattern state a b

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -940,7 +940,7 @@ let intern_var state env (ltacvars,ntnvars) namedctx loc id us =
 	(* [id] a section variable *)
 	(* Redundant: could be done in intern_qualid *)
 	let ref = VarRef id in
-	let impls = implicits_of_global ref in
+        let impls = implicits_of_global (project_impargs state.state) ref in
 	let scopes = find_arguments_scope ref in
 	Dumpglob.dump_reference ?loc "<>" (string_of_qualid (Decls.variable_secpath id)) "var";
 	DAst.make ?loc @@ GRef (ref, us), impls, scopes, []
@@ -951,14 +951,14 @@ let intern_var state env (ltacvars,ntnvars) namedctx loc id us =
 let find_appl_head_data state c =
   match DAst.get c with
   | GRef (ref,_) ->
-    let impls = implicits_of_global ref in
+    let impls = implicits_of_global (project_impargs state.state) ref in
     let scopes = find_arguments_scope ref in
       c, impls, scopes, []
   | GApp (r, l) ->
     begin match DAst.get r with
     | GRef (ref,_) when l != [] ->
       let n = List.length l in
-      let impls = implicits_of_global ref in 
+      let impls = implicits_of_global (project_impargs state.state) ref in
       let scopes = find_arguments_scope ref in
 	c, List.map (drop_first_implicits n) impls,
 	List.skipn_at_least n scopes,[]
@@ -1104,8 +1104,8 @@ let rec simple_adjust_scopes n scopes =
   | [] -> None :: simple_adjust_scopes (n-1) []
   | sc::scopes -> sc :: simple_adjust_scopes (n-1) scopes
 
-let find_remaining_scopes pl1 pl2 ref =
-  let impls_st = implicits_of_global ref in
+let find_remaining_scopes state pl1 pl2 ref =
+  let impls_st = implicits_of_global (project_impargs state.state) ref in
   let len_pl1 = List.length pl1 in
   let len_pl2 = List.length pl2 in
   let impl_list = if Int.equal len_pl1 0
@@ -1229,14 +1229,14 @@ let add_implicits_check_length fail nargs nargs_with_letin impls_st len_pl1 pl2 
 let add_implicits_check_constructor_length state loc c len_pl1 pl2 =
   let nargs = Inductiveops.constructor_nallargs c in
   let nargs' = Inductiveops.constructor_nalldecls c in
-  let impls_st = implicits_of_global (ConstructRef c) in
+  let impls_st = implicits_of_global (project_impargs state.state) (ConstructRef c) in
   add_implicits_check_length (error_wrong_numarg_constructor ?loc state.genv c)
     nargs nargs' impls_st len_pl1 pl2
 
 let add_implicits_check_ind_length state loc c len_pl1 pl2 =
   let nallargs = inductive_nallargs_env state.genv c in
   let nalldecls = inductive_nalldecls_env state.genv c in
-  let impls_st = implicits_of_global (IndRef c) in
+  let impls_st = implicits_of_global (project_impargs state.state) (IndRef c) in
   add_implicits_check_length (error_wrong_numarg_inductive ?loc state.genv c)
     nallargs nalldecls impls_st len_pl1 pl2
 
@@ -1504,7 +1504,7 @@ let drop_notations_pattern looked_for state =
           (* Convention: do not deactivate implicit arguments and scopes for further arguments *)
 	  test_kind top g;
 	  let () = assert (List.is_empty vars) in
-	  let (_,argscs) = find_remaining_scopes [] pats g in
+          let (_,argscs) = find_remaining_scopes state [] pats g in
 	  Some (g, [], List.map2 (in_pat_sc scopes) argscs pats)
 	| NApp (NRef g,[]) -> (* special case: Syndef for @Cstr, this deactivates *)
 	      test_kind top g;
@@ -1518,13 +1518,13 @@ let drop_notations_pattern looked_for state =
 	      let pats1,pats2 = List.chop nvars pats in
 	      let subst = make_subst vars pats1 in
               let idspl1 = List.map (in_not false qid.loc scopes (subst, Id.Map.empty) []) args in
-	      let (_,argscs) = find_remaining_scopes pats1 pats2 g in
+              let (_,argscs) = find_remaining_scopes state pats1 pats2 g in
 	      Some (g, idspl1, List.map2 (in_pat_sc scopes) argscs pats2)
 	| _ -> raise Not_found)
       | TrueGlobal g ->
 	  test_kind top g;
           Dumpglob.add_glob ?loc:qid.loc g;
-	  let (_,argscs) = find_remaining_scopes [] pats g in
+          let (_,argscs) = find_remaining_scopes state [] pats g in
 	  Some (g,[],List.map2 (fun x -> in_pat false (x,snd scopes)) argscs pats)
     with Not_found -> None
   and in_pat top scopes pt =
@@ -1562,7 +1562,7 @@ let drop_notations_pattern looked_for state =
       else
         (* Convention: (@r expl_pl) deactivates implicit arguments in expl_pl and in pl *)
         (* but not scopes in expl_pl *)
-        let (argscs1,_) = find_remaining_scopes expl_pl pl g in
+        let (argscs1,_) = find_remaining_scopes state expl_pl pl g in
         DAst.make ?loc @@ RCPatCstr (g, List.map2 (in_pat_sc scopes) argscs1 expl_pl @ List.map (in_pat false scopes) pl, [])
     | CPatNotation ((InConstrEntrySomeLevel,"- _"),([a],[]),[]) when is_non_zero_pat a ->
       let p = match a.CAst.v with CPatPrim (Numeral (p, _)) -> p | _ -> assert false in
@@ -1620,11 +1620,11 @@ let drop_notations_pattern looked_for state =
       end
     | NRef g ->
       ensure_kind top loc g;
-      let (_,argscs) = find_remaining_scopes [] args g in
+      let (_,argscs) = find_remaining_scopes state [] args g in
       DAst.make ?loc @@ RCPatCstr (g, [], List.map2 (in_pat_sc scopes) argscs args)
     | NApp (NRef g,pl) ->
       ensure_kind top loc g;
-      let (argscs1,argscs2) = find_remaining_scopes pl args g in
+      let (argscs1,argscs2) = find_remaining_scopes state pl args g in
       let pl = List.map2 (fun x -> in_not false loc (x,snd scopes) fullsubst []) argscs1 pl in
       let pl = add_local_defs_and_check_length loc state.genv g pl args in
       DAst.make ?loc @@ RCPatCstr (g, pl @ List.map (in_pat false scopes) args, [])

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -74,6 +74,8 @@ type ltac_sign = {
   ltac_extra : Genintern.Store.t;
 }
 
+type intern_state = { state : States.state; genv : Environ.env }
+
 let interning_grammar = ref false
 
 (* Historically for parsing grammar rules, but in fact used only for
@@ -385,7 +387,7 @@ let push_name_env ?(global_level=false) ntnvars implargs env =
       else Dumpglob.dump_binding ?loc id;
       {env with ids = Id.Set.add id env.ids; impls = Id.Map.add id implargs env.impls}
 
-let intern_generalized_binder ?(global_level=false) intern_type ntnvars
+let intern_generalized_binder ?(global_level=false) intern_type state ntnvars
     env {loc;v=na} b b' t ty =
   let ids = (match na with Anonymous -> fun x -> x | Name na -> Id.Set.add na) env.ids in
   let ty, ids' =
@@ -413,12 +415,12 @@ let intern_generalized_binder ?(global_level=false) intern_type ntnvars
               | { v = CApp ((_, { v = CRef (qid,_) } ), _) } when qualid_is_ident qid ->
                 qualid_basename qid
 	      | _ -> default_non_dependent_ident
-	    in Implicit_quantifiers.make_fresh ids' (Global.env ()) id
+            in Implicit_quantifiers.make_fresh ids' state.genv id
 	  in Name name
     | _ -> na
   in (push_name_env ~global_level ntnvars (impls_type_list ty')(*?*) env' (make ?loc na)), (make ?loc (na,b',ty')) :: List.rev bl
 
-let intern_assumption intern ntnvars env nal bk ty =
+let intern_assumption intern state ntnvars env nal bk ty =
   let intern_type env = intern (set_type_scope env) in
   match bk with
   | Default k ->
@@ -431,7 +433,7 @@ let intern_assumption intern ntnvars env nal bk ty =
            (make ?loc (na,k,locate_if_hole ?loc na ty))::bl))
 	(env, []) nal
   | Generalized (b,b',t) ->
-     let env, b = intern_generalized_binder intern_type ntnvars env (List.hd nal) b b' t ty in
+     let env, b = intern_generalized_binder intern_type state ntnvars env (List.hd nal) b b' t ty in
      env, b
 
 let glob_local_binder_of_extended = DAst.with_loc_val (fun ?loc -> function
@@ -452,9 +454,9 @@ let intern_letin_binder intern ntnvars env (({loc;v=na} as locna),def,ty) =
   (push_name_env ntnvars (impls_term_list term) env locna,
    (na,Explicit,term,ty))
 
-let intern_cases_pattern_as_binder ?loc ntnvars env p =
+let intern_cases_pattern_as_binder ?loc state ntnvars env p =
   let il,disjpat =
-    let (il, subst_disjpat) = !intern_cases_pattern_fwd ntnvars (None,env.scopes) p in
+    let (il, subst_disjpat) = !intern_cases_pattern_fwd state ntnvars (None,env.scopes) p in
     let substl,disjpat = List.split subst_disjpat in
     if not (List.for_all (fun subst -> Id.Map.equal Id.equal subst Id.Map.empty) substl) then
       user_err ?loc (str "Unsupported nested \"as\" clause.");
@@ -467,9 +469,9 @@ let intern_cases_pattern_as_binder ?loc ntnvars env p =
   let na = make ?loc @@ Name id in
   env,((disjpat,il),id),na
 
-let intern_local_binder_aux ?(global_level=false) intern ntnvars (env,bl) = function
+let intern_local_binder_aux ?(global_level=false) intern state ntnvars (env,bl) = function
   | CLocalAssum(nal,bk,ty) ->
-      let env, bl' = intern_assumption intern ntnvars env nal bk ty in
+      let env, bl' = intern_assumption intern state ntnvars env nal bk ty in
       let bl' = List.map (fun {loc;v=(na,c,t)} -> DAst.make ?loc @@ GLocalAssum (na,c,t)) bl' in
       env, bl' @ bl
   | CLocalDef( {loc; v=na} as locna,def,ty) ->
@@ -481,9 +483,9 @@ let intern_local_binder_aux ?(global_level=false) intern ntnvars (env,bl) = func
         | Some ty -> ty
         | None -> CAst.make ?loc @@ CHole(None,IntroAnonymous,None)
       in
-      let env, ((disjpat,il),id),na = intern_cases_pattern_as_binder ?loc ntnvars env p in
+      let env, ((disjpat,il),id),na = intern_cases_pattern_as_binder ?loc state ntnvars env p in
       let bk = Default Explicit in
-      let _, bl' = intern_assumption intern ntnvars env [na] bk tyc in
+      let _, bl' = intern_assumption intern state ntnvars env [na] bk tyc in
       let {v=(_,bk,t)} = List.hd bl' in
       (env, (DAst.make ?loc @@ GLocalPattern((disjpat,List.map (fun x -> x.v) il),id,bk,t)) :: bl)
 
@@ -574,14 +576,14 @@ let term_of_name = function
        let st = Evar_kinds.Define (not (Program.get_proofs_transparency ())) in
     DAst.make (GHole (Evar_kinds.QuestionMark { Evar_kinds.default_question_mark with Evar_kinds.qm_obligation=st }, IntroAnonymous, None))
 
-let traverse_binder intern_pat ntnvars (terms,_,binders,_ as subst) avoid (renaming,env) = function
+let traverse_binder intern_pat state ntnvars (terms,_,binders,_ as subst) avoid (renaming,env) = function
  | Anonymous -> (renaming,env), None, Anonymous
  | Name id ->
   let store,get = set_temporary_memory () in
   try
     (* We instantiate binder name with patterns which may be parsed as terms *)
     let pat = coerce_to_cases_pattern_expr (fst (Id.Map.find id terms)) in
-    let env,((disjpat,ids),id),na = intern_pat ntnvars env pat in
+    let env,((disjpat,ids),id),na = intern_pat state ntnvars env pat in
     let pat, na = match disjpat with
     | [pat] when is_var store pat -> let na = get () in None, na
     | _ -> Some ((List.map (fun x -> x.v) ids,disjpat),id), na.v in
@@ -598,7 +600,7 @@ let traverse_binder intern_pat ntnvars (terms,_,binders,_ as subst) avoid (renam
       (renaming,env), None, na
     else
       (* Interpret as a pattern *)
-      let env,((disjpat,ids),id),na = intern_pat ntnvars env pat in
+      let env,((disjpat,ids),id),na = intern_pat state ntnvars env pat in
       let pat, na =
         match disjpat with
         | [pat] when is_var store pat -> let na = get () in None, na
@@ -662,7 +664,7 @@ let flatten_binders bl =
     | a -> [a] in
   List.flatten (List.map dispatch bl)
 
-let instantiate_notation_constr loc intern intern_pat ntnvars subst infos c =
+let instantiate_notation_constr loc intern intern_pat state ntnvars subst infos c =
   let (terms,termlists,binders,binderlists) = subst in
   (* when called while defining a notation, avoid capturing the private binders
      of the expression by variables bound by the notation (see #3892) *)
@@ -674,7 +676,7 @@ let instantiate_notation_constr loc intern intern_pat ntnvars subst infos c =
         let rec aux_letin env = function
         | [],terminator,_ -> aux (terms,None,None) (renaming,env) terminator
         | AddPreBinderIter (y,binder)::rest,terminator,iter ->
-           let env,binders = intern_local_binder_aux intern ntnvars (env,[]) binder in
+           let env,binders = intern_local_binder_aux intern state ntnvars (env,[]) binder in
            let binder,extra = flatten_generalized_binders_if_any y binders in
            aux (terms,Some (y,binder),Some (extra@rest,terminator,iter)) (renaming,env) iter
         | AddBinderIter (y,binder)::rest,terminator,iter ->
@@ -695,7 +697,7 @@ let instantiate_notation_constr loc intern intern_pat ntnvars subst infos c =
         with Not_found ->
         try
           let (bl,(scopt,subscopes)) = Id.Map.find x binderlists in
-	  let env,bl' = List.fold_left (intern_local_binder_aux intern ntnvars) (env,[]) bl in
+          let env,bl' = List.fold_left (intern_local_binder_aux intern state ntnvars) (env,[]) bl in
           terms_of_binders (if revert then bl' else List.rev bl'),(None,[])
         with Not_found ->
           anomaly (Pp.str "Inconsistent substitution of recursive notation.") in
@@ -728,7 +730,7 @@ let instantiate_notation_constr loc intern intern_pat ntnvars subst infos c =
           if onlyident then
             let na = out_var c in term_of_name na, None
           else
-            let _,((disjpat,_),_),_ = intern_pat ntnvars nenv c in
+            let _,((disjpat,_),_),_ = intern_pat state ntnvars nenv c in
             match disjpat with
             | [pat] -> (glob_constr_of_cases_pattern pat, None)
             | _ -> error_cannot_coerce_disjunctive_pattern_term ?loc:c.loc ()
@@ -762,17 +764,17 @@ let instantiate_notation_constr loc intern intern_pat ntnvars subst infos c =
     (* Two special cases to keep binder name synchronous with BinderType *)
     | NProd (na,NHole(Evar_kinds.BinderType na',naming,arg),c')
         when Name.equal na na' ->
-        let subinfos,disjpat,na = traverse_binder intern_pat ntnvars subst avoid subinfos na in
+        let subinfos,disjpat,na = traverse_binder intern_pat state ntnvars subst avoid subinfos na in
         let ty = DAst.make ?loc @@ GHole (Evar_kinds.BinderType na,naming,arg) in
         DAst.make ?loc @@ GProd (na,Explicit,ty,Option.fold_right apply_cases_pattern disjpat (aux subst' subinfos c'))
     | NLambda (na,NHole(Evar_kinds.BinderType na',naming,arg),c')
         when Name.equal na na' ->
-        let subinfos,disjpat,na = traverse_binder intern_pat ntnvars subst  avoid subinfos na in
+        let subinfos,disjpat,na = traverse_binder intern_pat state ntnvars subst  avoid subinfos na in
         let ty = DAst.make ?loc @@ GHole (Evar_kinds.BinderType na,naming,arg) in
         DAst.make ?loc @@ GLambda (na,Explicit,ty,Option.fold_right apply_cases_pattern disjpat (aux subst' subinfos c'))
     | t ->
       glob_constr_of_notation_constr_with_binders ?loc
-        (traverse_binder intern_pat ntnvars subst  avoid) (aux subst') subinfos t
+        (traverse_binder intern_pat state ntnvars subst  avoid) (aux subst') subinfos t
   and subst_var (terms, binderopt, _terminopt) (renaming, env) id =
     (* subst remembers the delimiters stack in the interpretation *)
     (* of the notations *)
@@ -790,7 +792,7 @@ let instantiate_notation_constr loc intern intern_pat ntnvars subst infos c =
       if onlyident then
         term_of_name (out_var pat)
       else
-        let env,((disjpat,ids),id),na = intern_pat ntnvars env pat in
+        let env,((disjpat,ids),id),na = intern_pat state ntnvars env pat in
         match disjpat with
         | [pat] -> glob_constr_of_cases_pattern pat
         | _ -> user_err Pp.(str "Cannot turn a disjunctive pattern into a term.")
@@ -875,7 +877,7 @@ let make_subst ids l =
   let fold accu (id, scopes) a = Id.Map.add id (a, scopes) accu in
   List.fold_left2 fold Id.Map.empty ids l
 
-let intern_notation intern env ntnvars loc ntn fullargs =
+let intern_notation intern state env ntnvars loc ntn fullargs =
   (* Adjust to parsing of { } *)
   let ntn,fullargs = contract_curly_brackets ntn fullargs in
   (* Recover interpretation { } *)
@@ -884,7 +886,7 @@ let intern_notation intern env ntnvars loc ntn fullargs =
   (* Dispatch parsing substitution to an interpretation substitution *)
   let subst = split_by_type ids fullargs in
   (* Instantiate the notation *)
-  instantiate_notation_constr loc intern intern_cases_pattern_as_binder ntnvars subst (Id.Map.empty, env) c
+  instantiate_notation_constr loc intern intern_cases_pattern_as_binder state ntnvars subst (Id.Map.empty, env) c
 
 (**********************************************************************)
 (* Discriminating between bound variables and global references       *)
@@ -901,7 +903,7 @@ let gvar (loc, id) us = match us with
   user_err ?loc  (str "Variable " ++ Id.print id ++
     str " cannot have a universe instance")
 
-let intern_var env (ltacvars,ntnvars) namedctx loc id us =
+let intern_var state env (ltacvars,ntnvars) namedctx loc id us =
   (* Is [id] a notation variable *)
   if Id.Map.mem id ntnvars then
     begin
@@ -946,7 +948,7 @@ let intern_var env (ltacvars,ntnvars) namedctx loc id us =
 	(* [id] a goal variable *)
 	gvar (loc,id) us, [], [], []
 
-let find_appl_head_data c =
+let find_appl_head_data state c =
   match DAst.get c with
   | GRef (ref,_) ->
     let impls = implicits_of_global ref in
@@ -1003,7 +1005,7 @@ let glob_sort_of_level (level: glob_level) : glob_sort =
   | GType info -> GType [sort_info_of_level_info info]
 
 (* Is it a global reference or a syntactic definition? *)
-let intern_qualid ?(no_secvar=false) qid intern env ntnvars us args =
+let intern_qualid ?(no_secvar=false) intern state qid env ntnvars us args =
   let loc = qid.loc in
   match intern_extended_global_of_qualid qid with
   | TrueGlobal (VarRef _) when no_secvar ->
@@ -1020,7 +1022,7 @@ let intern_qualid ?(no_secvar=false) qid intern env ntnvars us args =
       let subst = (terms, Id.Map.empty, Id.Map.empty, Id.Map.empty) in
       let infos = (Id.Map.empty, env) in
       let projapp = match c with NRef _ -> true | _ -> false in
-      let c = instantiate_notation_constr loc intern intern_cases_pattern_as_binder ntnvars subst infos c in
+      let c = instantiate_notation_constr loc intern intern_cases_pattern_as_binder state ntnvars subst infos c in
       let loc = c.loc in
       let err () =
         user_err ?loc  (str "Notation " ++ pr_qualid qid
@@ -1045,14 +1047,14 @@ let intern_qualid ?(no_secvar=false) qid intern env ntnvars us args =
       in
       c, projapp, args2
 
-let intern_applied_reference intern env namedctx (_, ntnvars as lvar) us args qid =
+let intern_applied_reference intern state env namedctx (_, ntnvars as lvar) us args qid =
   let loc = qid.CAst.loc in
   if qualid_is_ident qid then
-      try intern_var env lvar namedctx loc (qualid_basename qid) us, args
+      try intern_var state env lvar namedctx loc (qualid_basename qid) us, args
       with Not_found ->
       try
-        let r, projapp, args2 = intern_qualid ~no_secvar:true qid intern env ntnvars us args in
-	let x, imp, scopes, l = find_appl_head_data r in
+        let r, projapp, args2 = intern_qualid ~no_secvar:true intern state qid env ntnvars us args in
+        let x, imp, scopes, l = find_appl_head_data state r in
 	  (x,imp,scopes,l), args2
       with Not_found ->
         (* Extra allowance for non globalizing functions *)
@@ -1061,15 +1063,16 @@ let intern_applied_reference intern env namedctx (_, ntnvars as lvar) us args qi
         else error_global_not_found qid
   else
     let r,projapp,args2 =
-      try intern_qualid qid intern env ntnvars us args
+      try intern_qualid intern state qid env ntnvars us args
       with Not_found -> error_global_not_found qid
     in
-    let x, imp, scopes, l = find_appl_head_data r in
+    let x, imp, scopes, l = find_appl_head_data state r in
     (x,imp,scopes,l), args2
 
 let interp_reference vars r =
   let (r,_,_,_),_ =
     intern_applied_reference (fun _ -> error_not_enough_arguments ?loc:None)
+      {state = States.get_state (); genv = Global.env ()}
       {ids = Id.Set.empty; unb = false ;
        tmp_scope = None; scopes = []; impls = empty_internalization_env} []
       (vars, Id.Map.empty) None [] r
@@ -1223,18 +1226,18 @@ let add_implicits_check_length fail nargs nargs_with_letin impls_st len_pl1 pl2 
       else let (b,out) = aux (succ i) (q,tt) in (b,hh::out)
   in aux 0 (impl_list,pl2)
 
-let add_implicits_check_constructor_length env loc c len_pl1 pl2 =
+let add_implicits_check_constructor_length state loc c len_pl1 pl2 =
   let nargs = Inductiveops.constructor_nallargs c in
   let nargs' = Inductiveops.constructor_nalldecls c in
   let impls_st = implicits_of_global (ConstructRef c) in
-  add_implicits_check_length (error_wrong_numarg_constructor ?loc env c)
+  add_implicits_check_length (error_wrong_numarg_constructor ?loc state.genv c)
     nargs nargs' impls_st len_pl1 pl2
 
-let add_implicits_check_ind_length env loc c len_pl1 pl2 =
-  let nallargs = inductive_nallargs_env env c in
-  let nalldecls = inductive_nalldecls_env env c in
+let add_implicits_check_ind_length state loc c len_pl1 pl2 =
+  let nallargs = inductive_nallargs_env state.genv c in
+  let nalldecls = inductive_nalldecls_env state.genv c in
   let impls_st = implicits_of_global (IndRef c) in
-  add_implicits_check_length (error_wrong_numarg_inductive ?loc env c)
+  add_implicits_check_length (error_wrong_numarg_inductive ?loc state.genv c)
     nallargs nalldecls impls_st len_pl1 pl2
 
 (** Do not raise NotEnoughArguments thanks to preconditions*)
@@ -1462,7 +1465,7 @@ let is_non_zero_pat c = match c with
 | { CAst.v = CPatPrim (Numeral (p, true)) } -> not (is_zero p)
 | _ -> false
 
-let drop_notations_pattern looked_for genv =
+let drop_notations_pattern looked_for state =
   (* At toplevel, Constructors and Inductives are accepted, in recursive calls
      only constructor are allowed *)
   let ensure_kind top loc g =
@@ -1623,7 +1626,7 @@ let drop_notations_pattern looked_for genv =
       ensure_kind top loc g;
       let (argscs1,argscs2) = find_remaining_scopes pl args g in
       let pl = List.map2 (fun x -> in_not false loc (x,snd scopes) fullsubst []) argscs1 pl in
-      let pl = add_local_defs_and_check_length loc genv g pl args in
+      let pl = add_local_defs_and_check_length loc state.genv g pl args in
       DAst.make ?loc @@ RCPatCstr (g, pl @ List.map (in_pat false scopes) args, [])
     | NList (x,y,iter,terminator,revert) ->
       if not (List.is_empty args) then user_err ?loc 
@@ -1645,9 +1648,9 @@ let drop_notations_pattern looked_for genv =
     | t -> error_invalid_pattern_notation ?loc ()
   in in_pat true
 
-let rec intern_pat genv ntnvars aliases pat =
+let rec intern_pat state ntnvars aliases pat =
   let intern_cstr_with_all_args loc c with_letin idslpl1 pl2 =
-    let idslpl2 = List.map (intern_pat genv ntnvars empty_alias) pl2 in
+    let idslpl2 = List.map (intern_pat state ntnvars empty_alias) pl2 in
     let (ids',pll) = product_of_cases_patterns aliases (idslpl1@idslpl2) in
     let pl' = List.map (fun (asubst,pl) ->
       (asubst, DAst.make ?loc @@ PatCstr (c,chop_params_pattern loc (fst c) pl with_letin,alias_of aliases))) pll in
@@ -1656,18 +1659,18 @@ let rec intern_pat genv ntnvars aliases pat =
   match DAst.get pat with
     | RCPatAlias (p, id) ->
       let aliases' = merge_aliases aliases id in
-      intern_pat genv ntnvars aliases' p
+      intern_pat state ntnvars aliases' p
     | RCPatCstr (head, expl_pl, pl) ->
       if !asymmetric_patterns then
         let len = if List.is_empty expl_pl then Some (List.length pl) else None in
 	let c,idslpl1 = find_constructor loc len head in
 	let with_letin =
-	  check_constructor_length genv loc c (List.length idslpl1 + List.length expl_pl) pl in
+          check_constructor_length state.genv loc c (List.length idslpl1 + List.length expl_pl) pl in
 	intern_cstr_with_all_args loc c with_letin idslpl1 (expl_pl@pl)
       else
 	let c,idslpl1 = find_constructor loc None head in
 	let with_letin, pl2 =
-	  add_implicits_check_constructor_length genv loc c (List.length idslpl1 + List.length expl_pl) pl in
+          add_implicits_check_constructor_length state loc c (List.length idslpl1 + List.length expl_pl) pl in
 	intern_cstr_with_all_args loc c with_letin idslpl1 (expl_pl@pl2)
     | RCPatAtom (Some ({loc;v=id},scopes)) ->
       let aliases = merge_aliases aliases (make ?loc @@ Name id) in
@@ -1678,33 +1681,33 @@ let rec intern_pat genv ntnvars aliases pat =
       (ids, [asubst, DAst.make ?loc @@ PatVar (alias_of aliases)])
     | RCPatOr pl ->
       assert (not (List.is_empty pl));
-      let pl' = List.map (intern_pat genv ntnvars aliases) pl in
+      let pl' = List.map (intern_pat state ntnvars aliases) pl in
       let (idsl,pl') = List.split pl' in
       let ids = List.hd idsl in
       check_or_pat_variables loc ids (List.tl idsl);
       (ids,List.flatten pl')
 
-let intern_cases_pattern genv ntnvars scopes aliases pat =
-  intern_pat genv ntnvars aliases
-    (drop_notations_pattern (function ConstructRef _ -> () | _ -> raise Not_found) genv scopes pat)
+let intern_cases_pattern state ntnvars scopes aliases pat =
+  intern_pat state ntnvars aliases
+    (drop_notations_pattern (function ConstructRef _ -> () | _ -> raise Not_found) state scopes pat)
 
 let _ =
   intern_cases_pattern_fwd :=
-    fun ntnvars scopes p -> intern_cases_pattern (Global.env ()) ntnvars scopes empty_alias p
+    fun state ntnvars scopes p -> intern_cases_pattern state ntnvars scopes empty_alias p
 
-let intern_ind_pattern genv ntnvars scopes pat =
+let intern_ind_pattern state ntnvars scopes pat =
   let no_not =
     try
-      drop_notations_pattern (function (IndRef _ | ConstructRef _) -> () | _ -> raise Not_found) genv scopes pat
+      drop_notations_pattern (function (IndRef _ | ConstructRef _) -> () | _ -> raise Not_found) state scopes pat
     with InternalizationError(loc,NotAConstructor _) -> error_bad_inductive_type ?loc
   in
   let loc = no_not.CAst.loc in
   match DAst.get no_not with
     | RCPatCstr (head, expl_pl, pl) ->
       let c = (function IndRef ind -> ind | _ -> error_bad_inductive_type ?loc) head in
-      let with_letin, pl2 = add_implicits_check_ind_length genv loc c
+      let with_letin, pl2 = add_implicits_check_ind_length state loc c
 	(List.length expl_pl) pl in
-      let idslpl = List.map (intern_pat genv ntnvars empty_alias) (expl_pl@pl2) in
+      let idslpl = List.map (intern_pat state ntnvars empty_alias) (expl_pl@pl2) in
       (with_letin,
        match product_of_cases_patterns empty_alias idslpl with
        | _,[_,pl] -> (c,chop_params_pattern loc c pl with_letin)
@@ -1783,11 +1786,11 @@ let extract_explicit_arg imps args =
 (**********************************************************************)
 (* Main loop                                                          *)
 
-let internalize globalenv env pattern_mode (_, ntnvars as lvar) c =
+let internalize state env pattern_mode (_, ntnvars as lvar) c =
   let rec intern env = CAst.with_loc_val (fun ?loc -> function
     | CRef (ref,us) ->
 	let (c,imp,subscopes,l),_ =
-	  intern_applied_reference intern env (Environ.named_context globalenv)
+          intern_applied_reference intern state env (Environ.named_context state.genv)
 	    lvar us [] ref
 	in
 	  apply_impargs c env imp subscopes l loc
@@ -1883,7 +1886,7 @@ let internalize globalenv env pattern_mode (_, ntnvars as lvar) c =
        intern env (CAst.make ?loc @@ CPrim (Numeral (p,false)))
     | CNotation ((InConstrEntrySomeLevel,"( _ )"),([a],[],[],[])) -> intern env a
     | CNotation (ntn,args) ->
-        intern_notation intern env ntnvars loc ntn args
+        intern_notation intern state env ntnvars loc ntn args
     | CGeneralization (b,a,c) ->
         intern_generalization intern env ntnvars loc b a c
     | CPrim p ->
@@ -1894,7 +1897,7 @@ let internalize globalenv env pattern_mode (_, ntnvars as lvar) c =
     | CAppExpl ((isproj,ref,us), args) ->
         let (f,_,args_scopes,_),args =
 	  let args = List.map (fun a -> (a,None)) args in
-	  intern_applied_reference intern env (Environ.named_context globalenv) 
+          intern_applied_reference intern state env (Environ.named_context state.genv)
 	    lvar us args ref 
 	in
         (* Rem: GApp(_,f,[]) stands for @f *)
@@ -1911,11 +1914,11 @@ let internalize globalenv env pattern_mode (_, ntnvars as lvar) c =
 	let (c,impargs,args_scopes,l),args =
           match f.CAst.v with
             | CRef (ref,us) -> 
-	       intern_applied_reference intern env
-		 (Environ.named_context globalenv) lvar us args ref
+               intern_applied_reference intern state env
+                 (Environ.named_context state.genv) lvar us args ref
             | CNotation (ntn,([],[],[],[])) ->
-                let c = intern_notation intern env ntnvars loc ntn ([],[],[],[]) in
-                let x, impl, scopes, l = find_appl_head_data c in
+                let c = intern_notation intern state env ntnvars loc ntn ([],[],[],[]) in
+                let x, impl, scopes, l = find_appl_head_data state c in
 		  (x,impl,scopes,l), args
             | _ -> (intern env f,[],[],[]), args in
           apply_impargs c env impargs args_scopes
@@ -1983,7 +1986,7 @@ let internalize globalenv env pattern_mode (_, ntnvars as lvar) c =
                   (DAst.make ?loc @@ GHole(Evar_kinds.CasesType false,IntroAnonymous,None))
                   rtnpo) (* "=> P" if there were a return predicate P, and "=> _" otherwise *) in
              let catch_all_sub_eqn =
-               if List.for_all (irrefutable globalenv) thepats then [] else
+               if List.for_all (irrefutable state.genv) thepats then [] else
                   [CAst.make @@ ([],List.make (List.length thepats) (DAst.make @@ PatVar Anonymous), (* "|_,..,_" *)
                    DAst.make @@ GHole(Evar_kinds.ImpossibleCase,IntroAnonymous,None))]   (* "=> _" *) in
              Some (DAst.make @@ GCases(RegularStyle,sub_rtn,sub_tms,main_sub_eqn::catch_all_sub_eqn))
@@ -2032,7 +2035,7 @@ let internalize globalenv env pattern_mode (_, ntnvars as lvar) c =
           let lvars = Id.Set.union lvars ntnvars in
           let ltacvars = Id.Set.union lvars env.ids in
           let ist = {
-            Genintern.genv = globalenv;
+            Genintern.genv = state.genv;
             ltacvars;
             extra;
           } in
@@ -2073,11 +2076,11 @@ let internalize globalenv env pattern_mode (_, ntnvars as lvar) c =
   and intern_type env = intern (set_type_scope env)
 
   and intern_local_binder env bind : intern_env * Glob_term.extended_glob_local_binder list =
-    intern_local_binder_aux intern ntnvars env bind
+    intern_local_binder_aux intern state ntnvars env bind
 
   (* Expands a multiple pattern into a disjunction of multiple patterns *)
   and intern_multiple_pattern env n pl =
-    let idsl_pll = List.map (intern_cases_pattern globalenv ntnvars (None,env.scopes) empty_alias) pl in
+    let idsl_pll = List.map (intern_cases_pattern state ntnvars (None,env.scopes) empty_alias) pl in
     let loc = loc_of_multiple_pattern pl in
     check_number_of_pattern loc n pl;
     product_of_cases_patterns empty_alias idsl_pll
@@ -2117,8 +2120,8 @@ let internalize globalenv env pattern_mode (_, ntnvars as lvar) c =
     (* the "in" part *)
     let match_td,typ = match t with
     | Some t ->
-        let with_letin,(ind,l) = intern_ind_pattern globalenv ntnvars (None,env.scopes) t in
-	let (mib,mip) = Inductive.lookup_mind_specif globalenv ind in
+        let with_letin,(ind,l) = intern_ind_pattern state ntnvars (None,env.scopes) t in
+        let (mib,mip) = Inductive.lookup_mind_specif state.genv ind in
 	let nparams = (List.length (mib.Declarations.mind_params_ctxt)) in
 	(* for "in Vect n", we answer (["n","n"],[(loc,"n")])
 
@@ -2248,16 +2251,18 @@ let intern_gen kind env sigma
                ?(impls=empty_internalization_env) ?(pattern_mode=false) ?(ltacvars=empty_ltac_sign)
                c =
   let tmp_scope = scope_of_type_kind sigma kind in
-  internalize env {ids = extract_ids env; unb = false;
+  internalize {state = States.get_state (); genv = env}
+                        {ids = extract_ids env; unb = false;
 		         tmp_scope = tmp_scope; scopes = [];
 			 impls = impls}
     pattern_mode (ltacvars, Id.Map.empty) c
 
 let intern_constr env sigma c = intern_gen WithoutTypeConstraint env sigma c
 let intern_type env sigma c = intern_gen IsType env sigma c
-let intern_pattern globalenv patt =
+let intern_pattern env patt =
   try
-    intern_cases_pattern globalenv Id.Map.empty (None,[]) empty_alias patt
+    intern_cases_pattern {state = States.get_state (); genv = env}
+      Id.Map.empty (None,[]) empty_alias patt
   with
       InternalizationError (loc,e) ->
 	user_err ?loc ~hdr:"internalize" (explain_internalization_error e)
@@ -2330,8 +2335,9 @@ let interp_notation_constr env ?(impls=empty_internalization_env) nenv a =
   (* [vl] is intended to remember the scope of the free variables of [a] *)
   let vl = Id.Map.map (fun typ -> (ref false, ref None, typ)) nenv.ninterp_var_type in
   let impls = Id.Map.fold (fun id _ impls -> Id.Map.remove id impls) nenv.ninterp_var_type impls in
-  let c = internalize (Global.env()) {ids = extract_ids env; unb = false;
-						tmp_scope = None; scopes = []; impls = impls}
+  let c = internalize {state = States.get_state (); genv = env}
+            {ids = extract_ids env; unb = false;
+             tmp_scope = None; scopes = []; impls = impls}
     false (empty_ltac_sign, vl) a in
   (* Translate and check that [c] has all its free variables bound in [vars] *)
   let a, reversible = notation_constr_of_glob_constr nenv c in
@@ -2356,16 +2362,16 @@ let interp_binder_evars env sigma na t =
   let t' = locate_if_hole ?loc:(loc_of_glob_constr t) na t in
   understand_tcc env sigma ~expected_type:IsType t'
 
-let my_intern_constr env lvar acc c =
-  internalize env acc false lvar c
+let my_intern_constr state lvar acc c =
+  internalize state acc false lvar c
 
 let intern_context global_level env impl_env binders =
+  let state = { state = States.get_state (); genv = env } in
   try
   let lvar = (empty_ltac_sign, Id.Map.empty) in
   let lenv, bl = List.fold_left
 	    (fun (lenv, bl) b ->
-	       let (env, bl) = intern_local_binder_aux ~global_level (my_intern_constr env lvar) Id.Map.empty (lenv, bl) b in
-	       (env, bl))
+               intern_local_binder_aux ~global_level (my_intern_constr state lvar) state Id.Map.empty (lenv, bl) b)
 	    ({ids = extract_ids env; unb = false;
 	      tmp_scope = None; scopes = []; impls = impl_env}, []) binders in
   (lenv.impls, List.map glob_local_binder_of_extended bl)

--- a/interp/declare.ml
+++ b/interp/declare.ml
@@ -126,7 +126,7 @@ let declare_scheme = ref (fun _ _ -> assert false)
 let set_declare_scheme f = declare_scheme := f
 
 let update_tables c =
-  declare_constant_implicits c;
+  States.modify_state (declare_constant_implicits c);
   Heads.declare_head (EvalConstRef c);
   Notation.declare_ref_arguments_scope Evd.empty (ConstRef c)
 
@@ -264,7 +264,7 @@ let inVariable : variable_obj -> obj =
 (* for initial declaration *)
 let declare_variable id obj =
   let oname = add_leaf id (inVariable (Inr (id,obj))) in
-  declare_var_implicits id;
+  States.modify_state (declare_var_implicits id);
   Notation.declare_ref_arguments_scope Evd.empty (VarRef id);
   Heads.declare_head (EvalVarRef id);
   oname
@@ -412,7 +412,7 @@ let declare_mind mie =
   let (sp,kn as oname) = add_leaf id (inInductive mie) in
   let mind = Global.mind_of_delta_kn kn in
   let isprim = declare_projections mie.mind_entry_universes mind in
-  declare_mib_implicits mind;
+  States.modify_state (declare_mib_implicits mind);
   declare_inductive_argument_scopes mind mie;
   oname, isprim
 

--- a/interp/impargs.ml
+++ b/interp/impargs.ml
@@ -508,11 +508,15 @@ type implicit_discharge_request =
   | ImplInteractive of GlobRef.t * implicits_flags *
       implicit_interactive_request
 
-let implicits_table = Summary.ref GlobRef.Map.empty ~name:"implicits"
+type impargs_state = implicits_list list GlobRef.Map.t
 
-let implicits_of_global ref =
+let _, implicits_tag = Summary.ref_tag GlobRef.Map.empty ~name:"implicits"
+
+let project_impargs st = Summary.project_from_summary (States.summary_of_state st) implicits_tag
+
+let implicits_of_global state ref =
   try
-    let l = GlobRef.Map.find ref !implicits_table in
+    let l = GlobRef.Map.find ref state in
     try
       let rename_l = Arguments_renaming.arguments_names ref in
       let rec rename implicits names = match implicits, names with
@@ -527,7 +531,7 @@ let implicits_of_global ref =
   with Not_found -> [DefaultImpArgs,[]]
 
 let cache_implicits_decl (ref,imps) =
-  implicits_table := GlobRef.Map.add ref imps !implicits_table
+  States.modify_state_tag implicits_tag (fun s -> GlobRef.Map.add ref imps s)
 
 let load_implicits _ (_,(_,l)) = List.iter cache_implicits_decl l
 

--- a/interp/impargs.mli
+++ b/interp/impargs.mli
@@ -12,6 +12,12 @@ open Names
 open EConstr
 open Environ
 
+(** {6 Implicit Arguments state} *)
+
+type impargs_state
+
+val project_impargs : States.state -> impargs_state
+
 (** {6 Implicit Arguments } *)
 (** Here we store the implicit arguments. Notice that we
     are outside the kernel, which knows nothing about implicit arguments. *)
@@ -118,7 +124,7 @@ val declare_manual_implicits : bool -> GlobRef.t -> ?enriching:bool ->
 val maybe_declare_manual_implicits : bool -> GlobRef.t -> ?enriching:bool ->
   manual_implicits -> unit
 
-val implicits_of_global : GlobRef.t -> implicits_list list
+val implicits_of_global : impargs_state -> GlobRef.t -> implicits_list list
 
 val extract_impargs_data :
   implicits_list list -> ((int * int) option * implicit_status list) list

--- a/interp/impargs.mli
+++ b/interp/impargs.mli
@@ -104,11 +104,11 @@ val compute_implicits_names : env -> Evd.evar_map -> types -> Name.t list
 
 (** {6 Computation of implicits (done using the global environment). } *)
 
-val declare_var_implicits : variable -> unit
-val declare_constant_implicits : Constant.t -> unit
-val declare_mib_implicits : MutInd.t -> unit
+val declare_var_implicits : variable -> States.state -> States.state
+val declare_constant_implicits : Constant.t -> States.state -> States.state
+val declare_mib_implicits : MutInd.t -> States.state -> States.state
 
-val declare_implicits : bool -> GlobRef.t -> unit
+val declare_implicits : bool -> GlobRef.t -> States.state -> States.state
 
 (** [declare_manual_implicits local ref enriching l]
    Manual declaration of which arguments are expected implicit.
@@ -117,12 +117,12 @@ val declare_implicits : bool -> GlobRef.t -> unit
    Unsets implicits if [l] is empty. *)
 
 val declare_manual_implicits : bool -> GlobRef.t -> ?enriching:bool ->
-  manual_implicits list -> unit
+  manual_implicits list -> States.state -> States.state
 
 (** If the list is empty, do nothing, otherwise declare the implicits. *)
 
 val maybe_declare_manual_implicits : bool -> GlobRef.t -> ?enriching:bool ->
-  manual_implicits -> unit
+  manual_implicits -> States.state -> States.state
 
 val implicits_of_global : impargs_state -> GlobRef.t -> implicits_list list
 

--- a/library/lib.ml
+++ b/library/lib.ml
@@ -262,6 +262,14 @@ let add_anonymous_leaf ?(cache_first = true) obj =
     cache_object (oname,obj)
   end
 
+let add_anonymous_sps_leaf obj (fl,fs) =
+  let id = Names.Id.of_string ("_" ^ string_of_int fl.counter) in
+  let oname = Libnames.make_oname fl.path_prefix id in
+  let fs = cache_sps_object (oname,obj) fs in
+  let fl = { fl with lib_stk = (oname,Leaf obj) :: fl.lib_stk;
+                     counter = fl.counter } in
+  (fl,fs)
+
 (* Modules. *)
 
 let is_opening_node = function

--- a/library/lib.ml
+++ b/library/lib.ml
@@ -99,12 +99,14 @@ type lib_state = {
   comp_name   : DirPath.t option;
   lib_stk     : library_segment;
   path_prefix : object_prefix;
+  counter     : int;
 }
 
 let initial_lib_state = {
   comp_name   = None;
   lib_stk     = [];
   path_prefix = initial_prefix;
+  counter     = 0;
 }
 
 let lib_state = ref initial_lib_state
@@ -209,9 +211,10 @@ let add_entry sp node =
 let pull_to_head oname =
   lib_state := { !lib_state with lib_stk = (oname,List.assoc oname !lib_state.lib_stk) :: List.remove_assoc oname !lib_state.lib_stk }
 
-let anonymous_id =
-  let n = ref 0 in
-  fun () -> incr n; Names.Id.of_string ("_" ^ (string_of_int !n))
+let anonymous_id () =
+  let n = !lib_state.counter + 1 in
+  lib_state := { !lib_state with counter = n};
+  Names.Id.of_string ("_" ^ (string_of_int n))
 
 let add_anonymous_entry node =
   add_entry (make_oname (anonymous_id ())) node

--- a/library/lib.mli
+++ b/library/lib.mli
@@ -146,6 +146,9 @@ val close_section : unit -> unit
 
 type frozen
 
+val add_anonymous_sps_leaf : Libobject.obj ->
+  frozen * Summary.summaries -> frozen * Summary.summaries
+
 val freeze : marshallable:Summary.marshallable -> frozen
 val unfreeze : frozen -> unit
 

--- a/library/libobject.ml
+++ b/library/libobject.ml
@@ -21,6 +21,9 @@ type 'a object_declaration = {
   cache_function : object_name * 'a -> unit;
   load_function : int -> object_name * 'a -> unit;
   open_function : int -> object_name * 'a -> unit;
+  cache_sps_function : object_name * 'a -> Summary.summaries -> Summary.summaries;
+  load_sps_function : int -> object_name * 'a -> Summary.summaries -> Summary.summaries;
+  open_sps_function : int -> object_name * 'a -> Summary.summaries -> Summary.summaries;
   classify_function : 'a -> 'a substitutivity;
   subst_function : Mod_subst.substitution * 'a -> 'a;
   discharge_function : object_name * 'a -> 'a option;
@@ -31,6 +34,9 @@ let default_object s = {
   cache_function = (fun _ -> ());
   load_function = (fun _ _ -> ());
   open_function = (fun _ _ -> ());
+  cache_sps_function = (fun _ x -> x);
+  load_sps_function = (fun _ _ x -> x);
+  open_sps_function = (fun _ _ x -> x);
   subst_function = (fun _ ->
     CErrors.anomaly (str "The object " ++ str s ++ str " does not know how to substitute!"));
   classify_function = (fun obj -> Keep obj);
@@ -57,6 +63,9 @@ type dynamic_object_declaration = {
   dyn_cache_function : object_name * obj -> unit;
   dyn_load_function : int -> object_name * obj -> unit;
   dyn_open_function : int -> object_name * obj -> unit;
+  dyn_cache_sps_function : object_name * obj -> Summary.summaries -> Summary.summaries;
+  dyn_load_sps_function : int -> object_name * obj -> Summary.summaries -> Summary.summaries;
+  dyn_open_sps_function : int -> object_name * obj -> Summary.summaries -> Summary.summaries;
   dyn_subst_function : Mod_subst.substitution * obj -> obj;
   dyn_classify_function : obj -> obj substitutivity;
   dyn_discharge_function : object_name * obj -> obj option;
@@ -73,6 +82,9 @@ let declare_object_full odecl =
   let cacher (oname,lobj) = odecl.cache_function (oname,outfun lobj)
   and loader i (oname,lobj) = odecl.load_function i (oname,outfun lobj)
   and opener i (oname,lobj) = odecl.open_function i (oname,outfun lobj)
+  and cacher_sps (oname,lobj) = odecl.cache_sps_function (oname,outfun lobj)
+  and loader_sps i (oname,lobj) = odecl.load_sps_function i (oname,outfun lobj)
+  and opener_sps i (oname,lobj) = odecl.open_sps_function i (oname,outfun lobj)
   and substituter (sub,lobj) = infun (odecl.subst_function (sub,outfun lobj))
   and classifier lobj = match odecl.classify_function (outfun lobj) with
   | Dispose -> Dispose
@@ -86,6 +98,9 @@ let declare_object_full odecl =
   Hashtbl.add cache_tab na { dyn_cache_function = cacher;
 			     dyn_load_function = loader;
                              dyn_open_function = opener;
+                             dyn_cache_sps_function = cacher_sps;
+                             dyn_load_sps_function = loader_sps;
+                             dyn_open_sps_function = opener_sps;
 			     dyn_subst_function = substituter;
 			     dyn_classify_function = classifier;
 			     dyn_discharge_function = discharge;
@@ -114,6 +129,15 @@ let load_object i ((_,lobj) as node) =
 
 let open_object i ((_,lobj) as node) =
   apply_dyn_fun (fun d -> d.dyn_open_function i node) lobj
+
+let cache_sps_object ((_,lobj) as node) =
+  apply_dyn_fun (fun d -> d.dyn_cache_sps_function node) lobj
+
+let load_sps_object i ((_,lobj) as node) =
+  apply_dyn_fun (fun d -> d.dyn_load_sps_function i node) lobj
+
+let open_sps_object i ((_,lobj) as node) =
+  apply_dyn_fun (fun d -> d.dyn_open_sps_function i node) lobj
 
 let subst_object ((_,lobj) as node) = 
   apply_dyn_fun (fun d -> d.dyn_subst_function node) lobj

--- a/library/libobject.mli
+++ b/library/libobject.mli
@@ -10,6 +10,7 @@
 
 open Libnames
 open Mod_subst
+open Summary
 
 (** [Libobject] declares persistent objects, given with methods:
 
@@ -71,6 +72,9 @@ type 'a object_declaration = {
   cache_function : object_name * 'a -> unit;
   load_function : int -> object_name * 'a -> unit;
   open_function : int -> object_name * 'a -> unit;
+  cache_sps_function : object_name * 'a -> summaries -> summaries;
+  load_sps_function : int -> object_name * 'a -> summaries -> summaries;
+  open_sps_function : int -> object_name * 'a -> summaries -> summaries;
   classify_function : 'a -> 'a substitutivity;
   subst_function :  substitution * 'a -> 'a;
   discharge_function : object_name * 'a -> 'a option;
@@ -108,6 +112,9 @@ val object_tag : obj -> string
 val cache_object : object_name * obj -> unit
 val load_object : int -> object_name * obj -> unit
 val open_object : int -> object_name * obj -> unit
+val cache_sps_object : object_name * obj -> summaries -> summaries
+val load_sps_object : int -> object_name * obj -> summaries -> summaries
+val open_sps_object : int -> object_name * obj -> summaries -> summaries
 val subst_object : substitution * obj -> obj
 val classify_object : obj -> obj substitutivity
 val discharge_object : object_name * obj -> obj option

--- a/library/library.mllib
+++ b/library/library.mllib
@@ -1,7 +1,7 @@
 Libnames
 Globnames
-Libobject
 Summary
+Libobject
 Nametab
 Global
 Decl_kinds

--- a/library/states.ml
+++ b/library/states.ml
@@ -30,6 +30,12 @@ let intern_state s =
   unfreeze (with_magic_number_check (System.intern_state Coq_config.state_magic_number) s);
   Library.overwrite_library_filenames s
 
+let get_state () = freeze ~marshallable:`No
+
+let modify_state_tag tag f =
+  let (fl,fs) = freeze ~marshallable:`No in
+  unfreeze (fl,Summary.modify_summary fs tag (f (Summary.project_from_summary fs tag)))
+
 (* Rollback. *)
 
 let with_state_protection f x =

--- a/library/states.ml
+++ b/library/states.ml
@@ -36,6 +36,8 @@ let modify_state_tag tag f =
   let (fl,fs) = freeze ~marshallable:`No in
   unfreeze (fl,Summary.modify_summary fs tag (f (Summary.project_from_summary fs tag)))
 
+let add_anonymous_sps_leaf = Lib.add_anonymous_sps_leaf
+
 (* Rollback. *)
 
 let with_state_protection f x =

--- a/library/states.ml
+++ b/library/states.ml
@@ -36,6 +36,9 @@ let modify_state_tag tag f =
   let (fl,fs) = freeze ~marshallable:`No in
   unfreeze (fl,Summary.modify_summary fs tag (f (Summary.project_from_summary fs tag)))
 
+let modify_state f =
+  unfreeze (f (freeze ~marshallable:`No))
+
 let add_anonymous_sps_leaf = Lib.add_anonymous_sps_leaf
 
 (* Rollback. *)

--- a/library/states.mli
+++ b/library/states.mli
@@ -25,6 +25,11 @@ val unfreeze : state -> unit
 val summary_of_state : state -> Summary.frozen
 val replace_summary : state -> Summary.frozen -> state
 
+(* Alias for Summary.freeze_summaries ~marshallable:`No *)
+val get_state : unit -> state
+
+val modify_state_tag : 'a Summary.Dyn.tag -> ('a -> 'a) -> unit
+
 (** {6 Rollback } *)
 
 (** [with_state_protection f x] applies [f] to [x] and restores the

--- a/library/states.mli
+++ b/library/states.mli
@@ -30,6 +30,8 @@ val get_state : unit -> state
 
 val modify_state_tag : 'a Summary.Dyn.tag -> ('a -> 'a) -> unit
 
+val add_anonymous_sps_leaf : Libobject.obj -> state -> state
+
 (** {6 Rollback } *)
 
 (** [with_state_protection f x] applies [f] to [x] and restores the

--- a/library/states.mli
+++ b/library/states.mli
@@ -30,6 +30,8 @@ val get_state : unit -> state
 
 val modify_state_tag : 'a Summary.Dyn.tag -> ('a -> 'a) -> unit
 
+val modify_state : (state -> state) -> unit
+
 val add_anonymous_sps_leaf : Libobject.obj -> state -> state
 
 (** {6 Rollback } *)

--- a/library/summary.ml
+++ b/library/summary.ml
@@ -67,6 +67,8 @@ type frozen = {
   (** Special handling of the ml_module summary. *)
 }
 
+type summaries = frozen
+
 let empty_frozen = { summaries = String.Map.empty; ml_module = None }
 
 let freeze_summaries ~marshallable : frozen =

--- a/library/summary.mli
+++ b/library/summary.mli
@@ -80,6 +80,8 @@ val nop : unit -> unit
 
 type frozen
 
+type summaries = frozen
+
 val empty_frozen : frozen
 val freeze_summaries : marshallable:marshallable -> frozen
 val unfreeze_summaries : ?partial:bool -> frozen -> unit

--- a/plugins/funind/glob_term_to_relation.ml
+++ b/plugins/funind/glob_term_to_relation.ml
@@ -310,13 +310,15 @@ let make_discr_match brl =
 
 (* [build_constructors_of_type] construct the array of pattern of its inductive argument*)
 let build_constructors_of_type ind' argl =
-  let (mib,ind) = Inductive.lookup_mind_specif (Global.env()) ind' in
+  let env = Global.env() in
+  let state = States.get_state () in
+  let (mib,ind) = Inductive.lookup_mind_specif env ind' in
   let npar = mib.Declarations.mind_nparams in
   Array.mapi (fun i _ ->
 		let construct = ind',i+1 in
 		let constructref = ConstructRef(construct) in
 		let _implicit_positions_of_cst =
-		  Impargs.implicits_of_global constructref
+                  Impargs.implicits_of_global (Impargs.project_impargs state) constructref
 		in
 		let cst_narg =
 		  Inductiveops.constructor_nallargs_env

--- a/plugins/ssr/ssrvernac.ml4
+++ b/plugins/ssr/ssrvernac.ml4
@@ -149,7 +149,8 @@ let declare_one_prenex_implicit locality f =
       errorstrm (str "Expected prenex implicits for " ++ pr_qualid f)
   | _ -> [] in
   let impls =
-    match Impargs.implicits_of_global fref  with
+    let state = States.get_state () in
+    match Impargs.implicits_of_global (Impargs.project_impargs state) fref  with
     | [cond,impls] -> impls
     | [] -> errorstrm (str "Expected some implicits for " ++ pr_qualid f)
     | _ -> errorstrm (str "Multiple implicits not supported") in

--- a/plugins/ssr/ssrvernac.ml4
+++ b/plugins/ssr/ssrvernac.ml4
@@ -165,7 +165,7 @@ VERNAC COMMAND FUNCTIONAL EXTEND Ssrpreneximplicits CLASSIFIED AS SIDEFF
   -> [ fun ~atts ~st ->
          let open Vernacinterp in
          let locality = Locality.make_section_locality atts.locality in
-         List.iter (declare_one_prenex_implicit locality) fl;
+         States.modify_state (List.fold_right (declare_one_prenex_implicit locality) fl);
          st
      ]
 END

--- a/printing/prettyp.ml
+++ b/printing/prettyp.ml
@@ -156,7 +156,7 @@ let need_expansion impl ref =
 
 let print_impargs ref =
   let ref = Smartlocate.smart_global ref in
-  let impl = implicits_of_global ref in
+  let impl = implicits_of_global (project_impargs (States.get_state ())) ref in
   let has_impl = not (List.is_empty impl) in
   (* Need to reduce since implicits are computed with products flattened *)
   pr_infos_list
@@ -258,7 +258,7 @@ let print_primitive ref =
   | _ -> []
 
 let print_name_infos ref =
-  let impls = implicits_of_global ref in
+  let impls = implicits_of_global (project_impargs (States.get_state ())) ref in
   let scopes = Notation.find_arguments_scope ref in
   let renames =
     try Arguments_renaming.arguments_names ref with Not_found -> [] in
@@ -296,7 +296,8 @@ let print_args_data_of_inductive_ids get test pr sp mipv =
 
 let print_inductive_implicit_args =
   print_args_data_of_inductive_ids
-    implicits_of_global (fun l -> not (List.is_empty (positions_of_implicits l)))
+    (fun ref -> implicits_of_global (project_impargs (States.get_state ())) ref)
+    (fun l -> not (List.is_empty (positions_of_implicits l)))
     print_impargs_list
 
 let print_inductive_renames =

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -108,7 +108,7 @@ let id_of_class cl =
 open Pp
 
 let instance_hook k info global imps ?hook cst =
-  Impargs.maybe_declare_manual_implicits false cst ~enriching:false imps;
+  States.modify_state (Impargs.maybe_declare_manual_implicits false cst ~enriching:false imps);
   let info = intern_info info in
   Typeclasses.declare_instance (Some info) (not global) cst;
   (match hook with Some h -> h cst | None -> ())
@@ -300,7 +300,7 @@ let new_instance ?(abstract=false) ?(global=false) ?(refine= !refine_instance)
             if program_mode then
 	      let hook vis gr _ =
 		let cst = match gr with ConstRef kn -> kn | _ -> assert false in
-                  Impargs.declare_manual_implicits false gr ~enriching:false [imps];
+                  States.modify_state (Impargs.declare_manual_implicits false gr ~enriching:false [imps]);
                   let pri = intern_info pri in
 		  Typeclasses.declare_instance (Some pri) (not global) (ConstRef cst)
 	      in

--- a/vernac/comAssumption.ml
+++ b/vernac/comAssumption.ml
@@ -73,7 +73,7 @@ match local with
   let decl = (ParameterEntry (None,(c,ctx),inl), IsAssumption kind) in
   let kn = declare_constant ident ~local decl in
   let gr = ConstRef kn in
-  let () = maybe_declare_manual_implicits false gr imps in
+  let () = States.modify_state (maybe_declare_manual_implicits false gr imps) in
   let () = Declare.declare_univ_binders gr pl in
   let () = assumption_message ident in
   let () = if do_instance then Typeclasses.declare_instance None false gr in

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -543,13 +543,12 @@ let declare_mutual_inductive_with_eliminations mie pl impls =
   List.iteri (fun i (indimpls, constrimpls) ->
               let ind = (mind,i) in
               let gr = IndRef ind in
-              maybe_declare_manual_implicits false gr indimpls;
               Declare.declare_univ_binders gr pl;
-              List.iteri
-                (fun j impls ->
-                 maybe_declare_manual_implicits false
-                    (ConstructRef (ind, succ j)) impls)
-                constrimpls)
+              States.modify_state
+                (maybe_declare_manual_implicits false gr indimpls %>
+                 List.fold_right_i (fun j impls ->
+                  maybe_declare_manual_implicits false
+                    (ConstructRef (ind, succ j)) impls) 0 (List.rev constrimpls)))
       impls;
   let warn_prim = match mie.mind_entry_record with Some (Some _) -> not prim | _ -> false in
   Flags.if_verbose Feedback.msg_info (minductive_message warn_prim names);

--- a/vernac/comProgramFixpoint.ml
+++ b/vernac/comProgramFixpoint.ml
@@ -216,7 +216,7 @@ let build_wellfounded (recname,pl,n,bl,arityc,body) poly r measure notation =
         let gr = ConstRef c in
         let () = UnivNames.register_universe_binders gr (Evd.universe_binders sigma) in
         if Impargs.is_implicit_args () || not (List.is_empty impls) then
-          Impargs.declare_manual_implicits false gr [impls]
+          States.modify_state (Impargs.declare_manual_implicits false gr [impls])
       in
       let typ = it_mkProd_or_LetIn top_arity binders in
       hook, name, typ
@@ -224,7 +224,7 @@ let build_wellfounded (recname,pl,n,bl,arityc,body) poly r measure notation =
       let typ = it_mkProd_or_LetIn top_arity binders_rel in
       let hook sigma l gr _ =
         if Impargs.is_implicit_args () || not (List.is_empty impls) then
-          Impargs.declare_manual_implicits false gr [impls]
+          States.modify_state (Impargs.declare_manual_implicits false gr [impls])
       in hook, recname, typ
   in
   (* XXX: Capturing sigma here... bad bad *)

--- a/vernac/declareDef.ml
+++ b/vernac/declareDef.ml
@@ -37,7 +37,7 @@ let declare_global_definition ident ce local k pl imps =
   let local = get_locality ident ~kind:"definition" local in
   let kn = declare_constant ident ~local (DefinitionEntry ce, IsDefinition k) in
   let gr = ConstRef kn in
-  let () = maybe_declare_manual_implicits false gr imps in
+  let () = States.modify_state (maybe_declare_manual_implicits false gr imps) in
   let () = Declare.declare_univ_binders gr pl in
   let () = definition_message ident in
   gr
@@ -50,7 +50,7 @@ let declare_definition ident (local, p, k) ce pl imps hook =
     let _ = declare_variable ident (Lib.cwd(), c, IsDefinition k) in
     let () = definition_message ident in
     let gr = VarRef ident in
-    let () = maybe_declare_manual_implicits false gr imps in
+    let () = States.modify_state (maybe_declare_manual_implicits false gr imps) in
     let () = Declare.declare_univ_binders gr pl in
     let () = if Proof_global.there_are_pending_proofs () then
 	       warn_definition_not_visible ident

--- a/vernac/lemmas.ml
+++ b/vernac/lemmas.ml
@@ -425,7 +425,7 @@ let start_proof_with_initialization kind sigma decl recguard thms snl hook =
             List.map_i (save_remaining_recthms kind norm uctx body opaq) 1 other_thms in
         let thms_data = (strength,ref,imps)::other_thms_data in
         List.iter (fun (strength,ref,imps) ->
-	  maybe_declare_manual_implicits false ref imps;
+          States.modify_state (maybe_declare_manual_implicits false ref imps);
 	  call_hook (fun exn -> exn) hook strength ref) thms_data in
       start_proof_univs id ~pl:decl kind sigma t ?init_tac (fun ctx -> mk_hook (hook ctx)) ~compute_guard:guard
 

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -374,7 +374,7 @@ let declare_projections indsp ctx ?(kind=StructureComponent) binder_name coers u
                   raise (NotDefinable (BadTypedProj (fid,ctx,te))) 
 	    in
 	    let refi = ConstRef kn in
-	    Impargs.maybe_declare_manual_implicits false refi impls;
+            States.modify_state (Impargs.maybe_declare_manual_implicits false refi impls);
 	    if coe then begin
 	      let cl = Class.class_of_global (IndRef indsp) in
 	        Class.try_add_new_coercion_with_source refi ~local:false poly ~source:cl
@@ -503,9 +503,10 @@ let declare_class finite def cum ubinders univs id idbuild paramimpls params ari
         (DefinitionEntry proj_entry, IsDefinition Definition)
       in
       let cref = ConstRef cst in
-      Impargs.declare_manual_implicits false cref [paramimpls];
       UnivNames.register_universe_binders cref ubinders;
-      Impargs.declare_manual_implicits false (ConstRef proj_cst) [List.hd fieldimpls];
+      States.modify_state
+          (Impargs.declare_manual_implicits false cref [paramimpls] %>
+           Impargs.declare_manual_implicits false (ConstRef proj_cst) [List.hd fieldimpls]);
       UnivNames.register_universe_binders (ConstRef proj_cst) ubinders;
       Classes.set_typeclass_transparency (EvalConstRef cst) false false;
       let sub = match List.hd coers with

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1075,10 +1075,11 @@ let vernac_declare_implicits ~atts r l =
   let local = make_section_locality atts.locality in
   match l with
   | [] ->
-      Impargs.declare_implicits local (smart_global r)
+      States.modify_state (Impargs.declare_implicits local (smart_global r))
   | _::_ as imps ->
-      Impargs.declare_manual_implicits local (smart_global r) ~enriching:false
-	(List.map (List.map (fun (ex,b,f) -> ex, (b,true,f))) imps)
+      States.modify_state
+        (Impargs.declare_manual_implicits local (smart_global r) ~enriching:false
+        (List.map (List.map (fun (ex,b,f) -> ex, (b,true,f))) imps))
 
 let warn_arguments_assert =
   CWarnings.create ~name:"arguments-assert" ~category:"vernacular"


### PR DESCRIPTION
**Kind:** experiment

[skip ci]

This is an experiment in providing a functional version of `add_anonymous_leaf`.

The idea is to provide three new methods for functional modification of the state (sps = state-passing-style):
```ocaml
val cache_sps_function : object_name * 'a -> Summary.frozen -> Summary.frozen
val load_sps_function : int -> object_name * 'a -> Summary.frozen -> Summary.frozen
val open_sps_function : int -> object_name * 'a -> Summary.frozen -> Summary.frozen
```
Then, this allows to provide a state-free function:
```ocaml
val add_anonymous_sps_leaf : Libobject.obj -> state -> state
```
and, consequently, functional variants of the various functions to add objects to the environment.

As an application, the table of implicit arguments is made fully functional, in both input and output.

At the current time, this is dramatically slow because of intensive useless freezing/unfreezing of the state (so as to synchronize the functional part and the effectful part).