### PR TITLE
[test-suite] Use ocamlfind to locate Coq libraries in unit tests.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -130,6 +130,7 @@ after_script:
     # careful with the ending /
     - BIN=$(readlink -f ../_install_ci/bin)/
     - LIB=$(readlink -f ../_install_ci/lib/coq)/
+    - export OCAMLPATH=$(readlink -f ../_install_ci/lib/):"$OCAMLPATH"
     - make -j "$NJOBS" BIN="$BIN" LIB="$LIB" all
   artifacts:
     name: "$CI_JOB_NAME.logs"

--- a/default.nix
+++ b/default.nix
@@ -93,6 +93,7 @@ stdenv.mkDerivation rec {
   preInstallCheck = ''
     patchShebangs tools/
     patchShebangs test-suite/
+    export OCAMLPATH=$OCAMLFIND_DESTDIR:$OCAMLPATH
   '';
 
   installCheckTarget = [ "check" ];

--- a/default.nix
+++ b/default.nix
@@ -75,12 +75,18 @@ stdenv.mkDerivation rec {
         (path: _:
            !elem (baseNameOf path) [".git" "result" "bin" "_build" "_build_ci"]) ./.;
 
+  preConfigure = "patchShebangs kernel/";
+
   prefixKey = "-prefix ";
 
   buildFlags = [ "world" "byte" ] ++ optional buildDoc "doc-html";
 
   installTargets =
     [ "install" "install-byte" ] ++ optional buildDoc "install-doc-html";
+
+  createFindlibDestdir = !shell;
+
+  postInstall = "ln -s $out/lib/coq $OCAMLFIND_DESTDIR/coq";
 
   inherit doInstallCheck;
 

--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -250,11 +250,11 @@ $(addsuffix .log,$(wildcard bugs/closed/*.v)): %.v.log: %.v
 # Unit tests
 #######################################################################
 
-OCAMLOPT := $(OCAMLFIND) opt $(CAMLFLAGS)
-SYSMOD:=-package num,str,unix,dynlink,threads
+ifeq ($(LOCAL),true)
+  export OCAMLPATH := $(patsubst "%",%,$(COQLIBINSTALL))
+endif
 
-COQSRCDIRS:=$(addprefix -I $(LIB)/,$(CORESRCDIRS))
-COQCMXS:=$(addprefix $(LIB)/,$(LINKCMX))
+OCAMLOPT := $(OCAMLFIND) opt $(CAMLFLAGS)
 
 # ML files from unit-test framework, not containing tests
 UNIT_SRCFILES:=$(shell find ./unit-tests/src -name *.ml)
@@ -278,10 +278,8 @@ unit-tests: $(UNIT_LOGFILES)
 # Build executable, run it to generate log file
 unit-tests/%.ml.log: unit-tests/%.ml
 	$(SHOW) 'TEST      $<'
-	$(HIDE)$(OCAMLOPT) -linkall -linkpkg -cclib -lcoqrun \
-		   $(SYSMOD) -package camlp5.gramlib,oUnit  \
-	     -I unit-tests/src $(COQSRCDIRS) $(COQCMXS) \
-	     $(UNIT_CMXS) $< -o $<.test;
+	$(HIDE)$(OCAMLOPT) -linkall -linkpkg -package coq.toplevel,oUnit \
+	     -I unit-tests/src $(UNIT_CMXS) $< -o $<.test;
 	$(HIDE)./$<.test
 
 #######################################################################

--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -250,8 +250,11 @@ $(addsuffix .log,$(wildcard bugs/closed/*.v)): %.v.log: %.v
 # Unit tests
 #######################################################################
 
+# COQLIBINSTALL is quoted in config/make thus we must unquote it,
+# otherwise the directory name will include the quotes, see
+# see for example https://stackoverflow.com/questions/10424645/how-to-convert-a-quoted-string-to-a-normal-one-in-makefile
 ifeq ($(LOCAL),true)
-  export OCAMLPATH := $(patsubst "%",%,$(COQLIBINSTALL))
+  export OCAMLPATH := $(shell echo $(COQLIBINSTALL))
 endif
 
 OCAMLOPT := $(OCAMLFIND) opt $(CAMLFLAGS)


### PR DESCRIPTION
This is slightly more robust and allows to run the test suite with
Dune which may place OCaml objects differently.
