### PR TITLE
[default.nix] Add odoc to the documentation build-inputs

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -23,8 +23,8 @@
 
 { pkgs ?
     (import (fetchTarball {
-      url = "https://github.com/NixOS/nixpkgs/archive/52a1179b6c20e923beddde1dd1e0034aa19176d2.tar.gz";
-      sha256 = "040xrsgnip6gqljfyy1ad0l7q41h659h5hqbcn96bzhdiakcr4yc";
+      url = "https://github.com/NixOS/nixpkgs/archive/4c95508641fe780efe41885366e03339b95d04fb.tar.gz";
+      sha256 = "1wjspwhzdb6d1kz4khd9l0fivxdk2nq3qvj93pql235sb7909ygx";
     }) {})
 , ocamlPackages ? pkgs.ocaml-ng.ocamlPackages_4_06
 , buildIde ? true

--- a/default.nix
+++ b/default.nix
@@ -55,6 +55,7 @@ stdenv.mkDerivation rec {
       (ps: [ ps.sphinx ps.sphinx_rtd_theme ps.pexpect ps.beautifulsoup4
              ps.antlr4-python3-runtime ps.sphinxcontrib-bibtex ]))
     antlr4
+    ocamlPackages.odoc
   ]
   ++ optionals doInstallCheck (
     # Test-suite dependencies

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,3 @@
-# Some developers don't want a pinned nix-shell by default.
-# If you want to use the pin nix-shell or a more sophisticated set of arguments:
+# If you want to use a more sophisticated set of arguments:
 # $ nix-shell default.nix --arg shell true
-import ./default.nix { pkgs = import <nixpkgs> {}; shell = true; }
+import ./default.nix { shell = true; }


### PR DESCRIPTION
This adds the `odoc` tool to the nix shell (when `buildDoc` is not unset).

The default reference to nixpkgs is also updated so as to incorporate a recent fix of `odoc` packaging.

Finally, that reference is not overridden by default: unless explicitly asked, each developer will get the same nix shell. Last week we had a bit of friction due to a wrong version of `dune`.

I recommend to update the reference to nixpkgs when we need it or when we feel it is too old (at least two weeks).