### PR TITLE
Adding library object methods for functional updates.

### DIFF
--- a/library/lib.ml
+++ b/library/lib.ml
@@ -37,11 +37,17 @@ type lib_objects =  (Names.Id.t * obj) list
 let module_kind is_type =
   if is_type then "module type" else "module"
 
-let iter_objects f i prefix =
-  List.iter (fun (id,obj) -> f i (make_oname prefix id, obj))
+let iter_objects f f' i prefix =
+  List.iter (fun (id,obj) ->
+      let o = (make_oname prefix id, obj) in
+      f i o;
+      Summary.save_functional_summaries (f' i o (Summary.get_functional_summaries ())))
 
-let load_objects i pr = iter_objects load_object i pr
-let open_objects i pr = iter_objects open_object i pr
+let load_objects i pr =
+  iter_objects load_object load_sps_object i pr
+
+let open_objects i pr =
+  iter_objects open_object open_sps_object i pr
 
 let subst_objects subst seg = 
   let subst_one = fun (id,obj as node) ->
@@ -228,13 +234,15 @@ let add_discharged_leaf id obj =
   let oname = make_oname id in
   let newobj = rebuild_object obj in
   cache_object (oname,newobj);
+  Summary.save_functional_summaries (cache_sps_object (oname,newobj) (Summary.get_functional_summaries ()));
   add_entry oname (Leaf newobj)
 
 let add_leaves id objs =
   let oname = make_oname id in
   let add_obj obj =
     add_entry oname (Leaf obj);
-    load_object 1 (oname,obj)
+    load_object 1 (oname,obj);
+    Summary.save_functional_summaries (load_sps_object 1 (oname,obj) (Summary.get_functional_summaries ()));
   in
   List.iter add_obj objs;
   oname
@@ -249,6 +257,13 @@ let add_anonymous_leaf ?(cache_first = true) obj =
     add_entry oname (Leaf obj);
     cache_object (oname,obj)
   end
+
+let add_anonymous_sps_leaf obj fs =
+  let id = anonymous_id () in
+  let oname = make_oname id in
+  let fs = cache_sps_object (oname,obj) fs in
+  add_entry oname (Leaf obj);
+  fs
 
 (* Modules. *)
 

--- a/library/lib.mli
+++ b/library/lib.mli
@@ -57,6 +57,9 @@ val add_leaf : Id.t -> Libobject.obj -> Libnames.object_name
 val add_anonymous_leaf : ?cache_first:bool -> Libobject.obj -> unit
 val pull_to_head : Libnames.object_name -> unit
 
+val add_anonymous_sps_leaf : Libobject.obj ->
+  Summary.functional_summaries -> Summary.functional_summaries
+
 (** this operation adds all objects with the same name and calls [load_object]
    for each of them *)
 val add_leaves : Id.t -> Libobject.obj list -> Libnames.object_name

--- a/library/libobject.mli
+++ b/library/libobject.mli
@@ -10,6 +10,7 @@
 
 open Libnames
 open Mod_subst
+open Summary
 
 (** [Libobject] declares persistent objects, given with methods:
 
@@ -71,6 +72,9 @@ type 'a object_declaration = {
   cache_function : object_name * 'a -> unit;
   load_function : int -> object_name * 'a -> unit;
   open_function : int -> object_name * 'a -> unit;
+  cache_sps_function : object_name * 'a -> functional_summaries -> functional_summaries;
+  load_sps_function : int -> object_name * 'a -> functional_summaries -> functional_summaries;
+  open_sps_function : int -> object_name * 'a -> functional_summaries -> functional_summaries;
   classify_function : 'a -> 'a substitutivity;
   subst_function :  substitution * 'a -> 'a;
   discharge_function : object_name * 'a -> 'a option;
@@ -108,6 +112,9 @@ val object_tag : obj -> string
 val cache_object : object_name * obj -> unit
 val load_object : int -> object_name * obj -> unit
 val open_object : int -> object_name * obj -> unit
+val cache_sps_object : object_name * obj -> functional_summaries -> functional_summaries
+val load_sps_object : int -> object_name * obj -> functional_summaries -> functional_summaries
+val open_sps_object : int -> object_name * obj -> functional_summaries -> functional_summaries
 val subst_object : substitution * obj -> obj
 val classify_object : obj -> obj substitutivity
 val discharge_object : object_name * obj -> obj option

--- a/library/library.mllib
+++ b/library/library.mllib
@@ -1,7 +1,7 @@
 Libnames
 Globnames
-Libobject
 Summary
+Libobject
 Nametab
 Global
 Decl_kinds

--- a/library/summary.mli
+++ b/library/summary.mli
@@ -91,5 +91,16 @@ val modify_summary : frozen -> 'a Dyn.tag -> 'a -> frozen
 val project_from_summary : frozen -> 'a Dyn.tag -> 'a
 val remove_from_summary : frozen -> 'a Dyn.tag -> frozen
 
+(** Functional summaries *)
+
+type functional_summaries
+
+val declare_functional_summary : name:string -> 'a -> 'a Dyn.tag
+val get_functional_summaries : unit -> functional_summaries
+val save_functional_summaries : functional_summaries -> unit
+val project_from_functional_summary : functional_summaries -> 'a Dyn.tag -> 'a
+val lift_functional_summary : 'a Dyn.tag -> ('a -> 'a) -> functional_summaries -> functional_summaries
+val modify_functional_summary : (functional_summaries -> functional_summaries) -> unit
+
 (** {6 Debug} *)
 val dump : unit -> (int * string) list


### PR DESCRIPTION
**Kind:** architecture

This PR is a possible proof of concept for stepwise moving `declare_object` and `declare_summary` to a functional model.

Some summaries can be declared as functional using `declare_functional_summary`. In return, this gives a `tag` to project from the functionally-threaded state and to modify the functionally-threaded state.

For objects which come with functional summaries, new methods `cache_sps_object`, `load_sps_object` and `open_sps_object` are provided as functional alternatives to `cache_object`, `load_object` and `open_object`. Then `add_anonymous_sps_leaf` is used for functional modification of the state.

Note: `rebuild`/`discharge` remain to be done.

