### PR TITLE
Update -compat to support -compat 8.10

### DIFF
--- a/dev/doc/release-process.md
+++ b/dev/doc/release-process.md
@@ -1,76 +1,23 @@
 # Release process #
 
-## Anytime before the previous version is branched off master ##
-
-- [ ] Update the compatibility infrastructure, which consists of doing
-      the following steps.  Note that all but the final step can be
-      performed automatically by
-      [`dev/tools/update-compat.py`](/dev/tools/update-compat.py) with
-      the `--release` flag which sets up Coq to support three
-      `-compat` flag arguments).
-  + [ ] Delete the file `theories/Compat/CoqUU.v`, where U.U is four
-        versions prior to the new version X.X.  After this, there
-        should be exactly three `theories/Compat/CoqNN.v` files.
-  + [ ] Update
-        [`doc/stdlib/index-list.html.template`](/doc/stdlib/index-list.html.template)
-        with the deleted file.
-  + [ ] Remove any notations in the standard library which have `compat "U.U"`.
-  + [ ] Update the type `compat_version` in [`lib/flags.ml`](/lib/flags.ml) by
-        bumping all the version numbers by one, and update the interpretations
-        of those flags in [`toplevel/coqargs.ml`](/toplevel/coqargs.ml) and
-        [`vernac/g_vernac.mlg`](/vernac/g_vernac.mlg).
-
-  + [ ] Remove the file
-        [`test-suite/success/CompatOldOldFlag.v`](/test-suite/success/CompatOldOldFlag.v).
-  + [ ] Update
-        [`test-suite/tools/update-compat/run.sh`](/test-suite/tools/update-compat/run.sh)
-        to ensure that it passes `--release` to the `update-compat.py`
-        script.
-  + [ ] Decide what to do about all test-suite files which mention
-        `-compat U.U` or `Coq.Comapt.CoqUU` (which is no longer valid,
-        since we only keep compatibility against the two previous
-        versions on releases)
-
 ## As soon as the previous version branched off master ##
 
 - [ ] Create a new issue to track the release process where you can copy-paste
   the present checklist.
-- [ ] Change the version name to the next major version and the magic numbers
-  (see [#7008](https://github.com/coq/coq/pull/7008/files)).
-- [ ] Update the compatibility infrastructure, which consists of doing
-      the following steps.  Note that all of these steps can be
-      performed automatically by
-      [`dev/tools/update-compat.py`](/dev/tools/update-compat.py).
-      Note that the `update-compat.py` script must be run twice: once
-      *before* branching with the `--release` flag (see above), and
-      again *after* branching with the `--master` flag (which sets up
-      Coq to support four `-compat` flag arguments), *in the same
-      commit* as the one that updates `coq_version` in
-      [`configure.ml`](/configure.ml).
-  + [ ] Add a file `theories/Compat/CoqXX.v` which contains just the header
-        from [`dev/header.ml`](/dev/header.ml)
-  + [ ] Add the line `Require Export Coq.Compat.CoqXX.` at the top of
-        `theories/Compat/CoqYY.v`, where Y.Y is the version prior to X.X.
-  + [ ] Update
-        [`doc/stdlib/index-list.html.template`](/doc/stdlib/index-list.html.template)
-        with the added file.
-  + [ ] Update the type `compat_version` in [`lib/flags.ml`](/lib/flags.ml) by
-        bumping all the version numbers by one, and update the interpretations
-        of those flags in [`toplevel/coqargs.ml`](/toplevel/coqargs.ml) and
-        [`vernac/g_vernac.mlg`](/vernac/g_vernac.mlg).
-  + [ ] Update the files
-        [`test-suite/success/CompatCurrentFlag.v`](/test-suite/success/CompatCurrentFlag.v),
-        [`test-suite/success/CompatPreviousFlag.v`](/test-suite/success/CompatPreviousFlag.v),
-        and
-        [`test-suite/success/CompatOldFlag.v`](/test-suite/success/CompatOldFlag.v)
-        by bumping all version numbers by 1.  Re-create the file
-        [`test-suite/success/CompatOldOldFlag.v`](/test-suite/success/CompatOldOldFlag.v)
-        with its version numbers also bumped by 1 (file should have
-        been removed right before branching; see above).
-  + [ ] Update
-        [`test-suite/tools/update-compat/run.sh`](/test-suite/tools/update-compat/run.sh)
-        to ensure that it passes `--master` to the `update-compat.py`
-        script.
+- [ ] Change the version name to the next major version and the magic
+  numbers (see [#7008](https://github.com/coq/coq/pull/7008/files)).
+
+  Additionally, in the same commit, update the compatibility
+  infrastructure, which consists of invoking
+  [`dev/tools/update-compat.py`](../tools/update-compat.py) with the
+  `--master` flag.
+
+  Note that the `update-compat.py` script must be run twice: once
+  *immediately after* branching with the `--master` flag (which sets
+  up Coq to support four `-compat` flag arguments), *in the same
+  commit* as the one that updates `coq_version` in
+  [`configure.ml`](../../configure.ml), and once again later on before
+  the next branch point with the `--release` flag (see next section).
 - [ ] Put the corresponding alpha tag using `git tag -s`.
   The `VX.X+alpha` tag marks the first commit to be in `master` and not in the
   branch of the previous version.
@@ -78,6 +25,19 @@
 - [ ] Decide the release calendar with the team (freeze date, beta date, final
   release date) and put this information in the milestone (using the
   description and due date fields).
+
+## Anytime after the previous version is branched off master ##
+
+- [ ] Update the compatibility infrastructure to the next release,
+  which consists of invoking
+  [`dev/tools/update-compat.py`](../tools/update-compat.py) with the
+  `--release` flag; this sets up Coq to support three `-compat` flag
+  arguments.  To ensure that CI passes, you will have to decide what
+  to do about all test-suite files which mention `-compat U.U` or
+  `Coq.Comapt.CoqUU` (which is no longer valid, since we only keep
+  compatibility against the two previous versions on releases), and
+  you may have to prepare overlays for projects using the
+  compatibility flags.
 
 ## About one month before the beta ##
 

--- a/dev/doc/release-process.md
+++ b/dev/doc/release-process.md
@@ -1,5 +1,36 @@
 # Release process #
 
+## Anytime before the previous version is branched off master ##
+
+- [ ] Update the compatibility infrastructure, which consists of doing
+      the following steps.  Note that all but the final step can be
+      performed automatically by
+      [`dev/tools/update-compat.py`](/dev/tools/update-compat.py) with
+      the `--release` flag which sets up Coq to support three
+      `-compat` flag arguments).
+  + [ ] Delete the file `theories/Compat/CoqUU.v`, where U.U is four
+        versions prior to the new version X.X.  After this, there
+        should be exactly three `theories/Compat/CoqNN.v` files.
+  + [ ] Update
+        [`doc/stdlib/index-list.html.template`](/doc/stdlib/index-list.html.template)
+        with the deleted file.
+  + [ ] Remove any notations in the standard library which have `compat "U.U"`.
+  + [ ] Update the type `compat_version` in [`lib/flags.ml`](/lib/flags.ml) by
+        bumping all the version numbers by one, and update the interpretations
+        of those flags in [`toplevel/coqargs.ml`](/toplevel/coqargs.ml) and
+        [`vernac/g_vernac.mlg`](/vernac/g_vernac.mlg).
+
+  + [ ] Remove the file
+        [`test-suite/success/CompatOldOldFlag.v`](/test-suite/success/CompatOldOldFlag.v).
+  + [ ] Update
+        [`test-suite/tools/update-compat/run.sh`](/test-suite/tools/update-compat/run.sh)
+        to ensure that it passes `--release` to the `update-compat.py`
+        script.
+  + [ ] Decide what to do about all test-suite files which mention
+        `-compat U.U` or `Coq.Comapt.CoqUU` (which is no longer valid,
+        since we only keep compatibility against the two previous
+        versions on releases)
+
 ## As soon as the previous version branched off master ##
 
 - [ ] Create a new issue to track the release process where you can copy-paste
@@ -7,21 +38,22 @@
 - [ ] Change the version name to the next major version and the magic numbers
   (see [#7008](https://github.com/coq/coq/pull/7008/files)).
 - [ ] Update the compatibility infrastructure, which consists of doing
-      the following steps.  Note that all but the final step can be
+      the following steps.  Note that all of these steps can be
       performed automatically by
-      [`dev/tools/update-compat.py`](/dev/tools/update-compat.py) so
-      long as you have already updated `coq_version` in
+      [`dev/tools/update-compat.py`](/dev/tools/update-compat.py).
+      Note that the `update-compat.py` script must be run twice: once
+      *before* branching with the `--release` flag (see above), and
+      again *after* branching with the `--master` flag (which sets up
+      Coq to support four `-compat` flag arguments), *in the same
+      commit* as the one that updates `coq_version` in
       [`configure.ml`](/configure.ml).
   + [ ] Add a file `theories/Compat/CoqXX.v` which contains just the header
         from [`dev/header.ml`](/dev/header.ml)
   + [ ] Add the line `Require Export Coq.Compat.CoqXX.` at the top of
         `theories/Compat/CoqYY.v`, where Y.Y is the version prior to X.X.
-  + [ ] Delete the file `theories/Compat/CoqWW.v`, where W.W is three versions
-        prior to X.X.
   + [ ] Update
         [`doc/stdlib/index-list.html.template`](/doc/stdlib/index-list.html.template)
-        with the deleted/added files.
-  + [ ] Remove any notations in the standard library which have `compat "W.W"`.
+        with the added file.
   + [ ] Update the type `compat_version` in [`lib/flags.ml`](/lib/flags.ml) by
         bumping all the version numbers by one, and update the interpretations
         of those flags in [`toplevel/coqargs.ml`](/toplevel/coqargs.ml) and
@@ -31,10 +63,14 @@
         [`test-suite/success/CompatPreviousFlag.v`](/test-suite/success/CompatPreviousFlag.v),
         and
         [`test-suite/success/CompatOldFlag.v`](/test-suite/success/CompatOldFlag.v)
-        by bumping all version numbers by 1.
-  + [ ] Decide what to do about all test-suite files which mention `-compat
-        W.W` or `Coq.Comapt.CoqWW` (which is no longer valid, since we only
-        keep compatibility against the two previous versions)
+        by bumping all version numbers by 1.  Re-create the file
+        [`test-suite/success/CompatOldOldFlag.v`](/test-suite/success/CompatOldOldFlag.v)
+        with its version numbers also bumped by 1 (file should have
+        been removed right before branching; see above).
+  + [ ] Update
+        [`test-suite/tools/update-compat/run.sh`](/test-suite/tools/update-compat/run.sh)
+        to ensure that it passes `--master` to the `update-compat.py`
+        script.
 - [ ] Put the corresponding alpha tag using `git tag -s`.
   The `VX.X+alpha` tag marks the first commit to be in `master` and not in the
   branch of the previous version.

--- a/doc/stdlib/index-list.html.template
+++ b/doc/stdlib/index-list.html.template
@@ -618,5 +618,6 @@ through the <tt>Require Import</tt> command.</p>
     theories/Compat/Coq87.v
     theories/Compat/Coq88.v
     theories/Compat/Coq89.v
+    theories/Compat/Coq810.v
   </dd>
 </dl>

--- a/lib/flags.ml
+++ b/lib/flags.ml
@@ -66,7 +66,7 @@ let we_are_parsing = ref false
 (* Current means no particular compatibility consideration.
    For correct comparisons, this constructor should remain the last one. *)
 
-type compat_version = V8_7 | V8_8 | Current
+type compat_version = V8_7 | V8_8 | V8_9 | Current
 
 let compat_version = ref Current
 
@@ -77,6 +77,9 @@ let version_compare v1 v2 = match v1, v2 with
   | V8_8, V8_8 -> 0
   | V8_8, _ -> -1
   | _, V8_8 -> 1
+  | V8_9, V8_9 -> 0
+  | V8_9, _ -> -1
+  | _, V8_9 -> 1
   | Current, Current -> 0
 
 let version_strictly_greater v = version_compare !compat_version v > 0
@@ -85,6 +88,7 @@ let version_less_or_equal v = not (version_strictly_greater v)
 let pr_version = function
   | V8_7 -> "8.7"
   | V8_8 -> "8.8"
+  | V8_9 -> "8.9"
   | Current -> "current"
 
 (* Translate *)

--- a/lib/flags.mli
+++ b/lib/flags.mli
@@ -58,7 +58,7 @@ val we_are_parsing : bool ref
 (* Set Printing All flag. For some reason it is a global flag *)
 val raw_print : bool ref
 
-type compat_version = V8_7 | V8_8 | Current
+type compat_version = V8_7 | V8_8 | V8_9 | Current
 val compat_version : compat_version ref
 val version_compare : compat_version -> compat_version -> int
 val version_strictly_greater : compat_version -> bool

--- a/test-suite/success/CompatCurrentFlag.v
+++ b/test-suite/success/CompatCurrentFlag.v
@@ -1,3 +1,3 @@
-(* -*- coq-prog-args: ("-compat" "8.9") -*- *)
+(* -*- coq-prog-args: ("-compat" "8.10") -*- *)
 (** Check that the current compatibility flag actually requires the relevant modules. *)
-Import Coq.Compat.Coq89.
+Import Coq.Compat.Coq810.

--- a/test-suite/success/CompatOldFlag.v
+++ b/test-suite/success/CompatOldFlag.v
@@ -1,5 +1,5 @@
-(* -*- coq-prog-args: ("-compat" "8.7") -*- *)
+(* -*- coq-prog-args: ("-compat" "8.8") -*- *)
 (** Check that the current-minus-two compatibility flag actually requires the relevant modules. *)
+Import Coq.Compat.Coq810.
 Import Coq.Compat.Coq89.
 Import Coq.Compat.Coq88.
-Import Coq.Compat.Coq87.

--- a/test-suite/success/CompatOldOldFlag.v
+++ b/test-suite/success/CompatOldOldFlag.v
@@ -1,0 +1,6 @@
+(* -*- coq-prog-args: ("-compat" "8.7") -*- *)
+(** Check that the current-minus-three compatibility flag actually requires the relevant modules. *)
+Import Coq.Compat.Coq810.
+Import Coq.Compat.Coq89.
+Import Coq.Compat.Coq88.
+Import Coq.Compat.Coq87.

--- a/test-suite/success/CompatPreviousFlag.v
+++ b/test-suite/success/CompatPreviousFlag.v
@@ -1,4 +1,4 @@
-(* -*- coq-prog-args: ("-compat" "8.8") -*- *)
+(* -*- coq-prog-args: ("-compat" "8.9") -*- *)
 (** Check that the current-minus-one compatibility flag actually requires the relevant modules. *)
+Import Coq.Compat.Coq810.
 Import Coq.Compat.Coq89.
-Import Coq.Compat.Coq88.

--- a/test-suite/tools/update-compat/run.sh
+++ b/test-suite/tools/update-compat/run.sh
@@ -6,4 +6,4 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 # we assume that the script lives in test-suite/tools/update-compat/,
 # and that update-compat.py lives in dev/tools/
 cd "${SCRIPT_DIR}/../../.."
-dev/tools/update-compat.py --assert-unchanged --cur-version=8.9 || exit $?
+dev/tools/update-compat.py --assert-unchanged --master || exit $?

--- a/theories/Compat/Coq810.v
+++ b/theories/Compat/Coq810.v
@@ -8,10 +8,4 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(** Compatibility file for making Coq act similar to Coq v8.9 *)
-Local Set Warnings "-deprecated".
-
-Require Export Coq.Compat.Coq810.
-
-Unset Private Polymorphic Universes.
-Set Refine Instance Mode.
+(** Compatibility file for making Coq act similar to Coq v8.10 *)

--- a/toplevel/coqargs.ml
+++ b/toplevel/coqargs.ml
@@ -165,7 +165,8 @@ let add_compat_require opts v =
   match v with
   | Flags.V8_7 -> add_vo_require opts "Coq.Compat.Coq87" None (Some false)
   | Flags.V8_8 -> add_vo_require opts "Coq.Compat.Coq88" None (Some false)
-  | Flags.Current -> add_vo_require opts "Coq.Compat.Coq89" None (Some false)
+  | Flags.V8_9 -> add_vo_require opts "Coq.Compat.Coq89" None (Some false)
+  | Flags.Current -> add_vo_require opts "Coq.Compat.Coq810" None (Some false)
 
 let set_batch_mode opts =
   (* XXX: This should be in the argument record *)

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -61,7 +61,8 @@ let make_bullet s =
   | _ -> assert false
 
 let parse_compat_version = let open Flags in function
-  | "8.9" -> Current
+  | "8.10" -> Current
+  | "8.9" -> V8_9
   | "8.8" -> V8_8
   | "8.7" -> V8_7
   | ("8.6" | "8.5" | "8.4" | "8.3" | "8.2" | "8.1" | "8.0") as s ->


### PR DESCRIPTION
**Kind:** infrastructure

- [x] Added / updated test-suite
- [x] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).

This PR institutes the policy that three `-compat` versions are supported on release branches, and four `-compat` versions are supported on master.  The `dev/tools/update-compat.py` script is updated to account for this policy, and now supports the `--master` flag (to be run on master) and the `--release` flag (to be used right before branching).

This is on top of #8634, and should be reviewed and merged once that PR is merged.

Note that this PR does not remove any compat notations.