### PR TITLE
[build] enable warnings on kernel/% in make based builds

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -685,6 +685,8 @@ plugins/nsatz/%.cmi: plugins/nsatz/%.mli
 	$(SHOW)'OCAMLC    $<'
 	$(HIDE)$(OCAMLC) $(COND_BYTEFLAGS) -package unix,num -c $<
 
+kernel/%.cmi: COND_BYTEFLAGS+=-w +a-4-44-50
+
 %.cmi: %.mli
 	$(SHOW)'OCAMLC    $<'
 	$(HIDE)$(OCAMLC) $(COND_BYTEFLAGS) -c $<
@@ -696,6 +698,8 @@ plugins/micromega/%.cmo: plugins/micromega/%.ml
 plugins/nsatz/%.cmo: plugins/nsatz/%.ml
 	$(SHOW)'OCAMLC    $<'
 	$(HIDE)$(OCAMLC) $(COND_BYTEFLAGS) -package unix,num -c $<
+
+kernel/%.cmo: COND_BYTEFLAGS+=-w +a-4-44-50
 
 %.cmo: %.ml
 	$(SHOW)'OCAMLC    $<'
@@ -741,6 +745,8 @@ plugins/nsatz/%.cmx: plugins/nsatz/%.ml
 plugins/%.cmx: plugins/%.ml
 	$(SHOW)'OCAMLOPT  $<'
 	$(HIDE)$(OCAMLOPT) $(COND_OPTFLAGS) $(HACKMLI) $($(@:.cmx=_FORPACK)) -c $<
+
+kernel/%.cmx: COND_OPTFLAGS+=-w +a-4-44-50
 
 %.cmx: %.ml
 	$(SHOW)'OCAMLOPT  $<'


### PR DESCRIPTION
This is to sync with the dune build system that sets these warnings