### PR TITLE
[dune] Add `(package coq)` scope to artifacts.

### DIFF
--- a/checker/dune
+++ b/checker/dune
@@ -19,6 +19,7 @@
 (executable
  (name main)
  (public_name coqchk)
+ (package coq)
  (modules main)
  (flags :standard -open Checklib)
  (libraries coq.checklib))
@@ -26,6 +27,7 @@
 (executable
  (name votour)
  (public_name votour)
+ (package coq)
  (modules votour)
  (flags :standard -open Checklib)
  (libraries coq.checklib))

--- a/coqpp/dune
+++ b/coqpp/dune
@@ -4,5 +4,6 @@
 (executable
  (name coqpp_main)
  (public_name coqpp)
+ (package coq)
  (modules coqpp_ast coqpp_lex coqpp_parse coqpp_main)
  (modules_without_implementation coqpp_ast))

--- a/grammar/dune
+++ b/grammar/dune
@@ -18,6 +18,7 @@
 
 (install
  (section bin)
+ (package coq)
  (files coqp5 coqmlp5))
 
 (rule

--- a/tools/coq_dune.ml
+++ b/tools/coq_dune.ml
@@ -194,7 +194,7 @@ let out_install fmt dir ff =
   let itarget = String.concat "/" dir in
   let ff = pmap (function | VO vo -> Some vo.target | _ -> None) ff in
   let pp_ispec fmt tg = fprintf fmt "(%s as %s)" tg (itarget^"/"^tg) in
-  fprintf fmt "(install@\n @[(section lib)@\n(files @[%a@])@])@\n"
+  fprintf fmt "(install@\n @[(section lib)@\n(package coq)@\n(files @[%a@])@])@\n"
     (pp_list pp_ispec sep) ff
 
 (* For each directory, we must record two things, the build rules and

--- a/tools/coqdoc/dune
+++ b/tools/coqdoc/dune
@@ -1,5 +1,6 @@
 (install
  (section lib)
+ (package coq)
  (files
   (coqdoc.css as tools/coqdoc/coqdoc.css)
   (coqdoc.sty as tools/coqdoc/coqdoc.sty)))
@@ -7,6 +8,7 @@
 (executable
  (name main)
  (public_name coqdoc)
+ (package coq)
  (libraries str coq.config))
 
 (ocamllex cpretty)

--- a/tools/dune
+++ b/tools/dune
@@ -1,5 +1,6 @@
 (install
  (section lib)
+ (package coq)
  (files
   (CoqMakefile.in as tools/CoqMakefile.in)
   (TimeFileMaker.py as tools/TimeFileMaker.py)
@@ -10,18 +11,21 @@
 (executable
  (name coq_makefile)
  (public_name coq_makefile)
+ (package coq)
  (modules coq_makefile)
  (libraries coq.lib))
 
 (executable
  (name coqc)
  (public_name coqc)
+ (package coq)
  (modules coqc)
  (libraries coq.toplevel))
 
 (executable
  (name coqdep)
  (public_name coqdep)
+ (package coq)
  (modules coqdep_lexer coqdep_common coqdep)
  (libraries coq.lib))
 
@@ -30,6 +34,7 @@
 (executable
  (name coqwc)
  (public_name coqwc)
+ (package coq)
  (modules coqwc)
  (libraries))
 
@@ -38,11 +43,13 @@
 (executable
  (name coq_tex)
  (public_name coq_tex)
+ (package coq)
  (modules coq_tex)
  (libraries str))
 
 (executable
  (name coq_dune)
  (public_name coq_dune)
+ (package coq)
  (modules coq_dune)
  (libraries str))

--- a/topbin/dune
+++ b/topbin/dune
@@ -1,5 +1,6 @@
 (install
  (section bin)
+ (package coq)
  (files (coqtop_bin.exe as coqtop)))
 
 (executable


### PR DESCRIPTION
This will allow us to define extra packages such as `coq-refman`.
