### PR TITLE
[ci] [dune] [opam] Fixes to OPAM and CI target.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,7 +9,7 @@ stages:
 variables:
   # Format: $IMAGE-V$DATE [Cache is not used as of today but kept here
   # for reference]
-  CACHEKEY: "bionic_coq-V2018-09-25-V1"
+  CACHEKEY: "bionic_coq-V2018-10-04-V1"
   IMAGE: "$CI_REGISTRY_IMAGE:$CACHEKEY"
   # By default, jobs run in the base switch; override to select another switch
   OPAM_SWITCH: "base"
@@ -234,12 +234,17 @@ windows32:
   except:
     - /^pr-.*$/
 
-pkg:dune-release:
-  <<: *dune-template
+pkg:opam:
   stage: test
+  # OPAM will build out-of-tree so no point in importing artifacts
+  dependencies: []
+  script:
+    - set -e
+    - opam pin add coq .
+    - opam pin add coqide ide
+    - set +e
   variables:
     OPAM_SWITCH: edge
-    DUNE_TARGET: release
 
 pkg:nix:
   image: nixorg/nix:latest # Minimal NixOS image which doesn't even contain git

--- a/INSTALL
+++ b/INSTALL
@@ -39,14 +39,14 @@ WHAT DO YOU NEED ?
    - Findlib (version >= 1.4.1)
      (available at http://projects.camlcity.org/projects/findlib.html)
 
-   - Camlp5 (version >= 7.01)
+   - Camlp5 (version >= 7.03)
      (available at https://camlp5.github.io/)
 
    - GNU Make version 3.81 or later
 
    - a C compiler
 
-   - for CoqIDE, the lablgtk development files (version >= 2.18.3),
+   - for CoqIDE, the lablgtk development files (version >= 2.18.5),
      and the GTK 2.x libraries including gtksourceview2.
 
    Note that num, camlp5 and lablgtk should be properly registered with

--- a/coq.opam
+++ b/coq.opam
@@ -6,13 +6,13 @@ bug-reports: "https://github.com/coq/coq/issues"
 dev-repo: "https://github.com/coq/coq.git"
 license: "LGPL-2.1"
 
-available: [ ocaml-version >= "4.02.3" ]
+available: [ ocaml-version >= "4.05.0" ]
 
 depends: [
-  "dune"      { build }
+  "dune"      { build & >= "1.2.0" }
   "ocamlfind" { build }
   "num"
-  "camlp5"
+  "camlp5"    {         >= "7.03"  }
 ]
 
 build-env: [

--- a/dev/ci/docker/bionic_coq/Dockerfile
+++ b/dev/ci/docker/bionic_coq/Dockerfile
@@ -1,4 +1,4 @@
-# CACHEKEY: "bionic_coq-V2018-09-25-V1"
+# CACHEKEY: "bionic_coq-V2018-10-04-V2"
 # ^^ Update when modifying this file.
 
 FROM ubuntu:bionic
@@ -41,7 +41,7 @@ ENV BASE_OPAM="num ocamlfind.1.8.0 dune.1.2.1 ounit.2.0.8 odoc.1.2.0" \
     CI_OPAM="menhir.20180530 elpi.1.1.0 ocamlgraph.1.8.8"
 
 # BASE switch; CI_OPAM contains Coq's CI dependencies.
-ENV CAMLP5_VER="7.01" \
+ENV CAMLP5_VER="7.03" \
     COQIDE_OPAM="lablgtk.2.18.5 conf-gtksourceview.2"
 
 # base switch

--- a/ide/coqide.opam
+++ b/ide/coqide.opam
@@ -6,14 +6,16 @@ bug-reports: "https://github.com/coq/coq/issues"
 dev-repo: "https://github.com/coq/coq.git"
 license: "LGPL-2.1"
 
-available: [ocaml-version >= "4.02.3"]
+available: [ocaml-version >= "4.05.0"]
 
 depends: [
-  "dune"      { build }
-  "ocamlfind" { build }
-  "num"
-  "camlp5"
+  "dune"               { build & >= "1.2.0" }
   "coq"
+  "conf-gtksourceview"
+  "lablgtk"            {         >= "2.18.5" }
 ]
 
+build-env: [
+  [ COQ_CONFIGURE_PREFIX = "%{prefix}" ]
+]
 build: [ [ "dune" "build" "-p" name "-j" jobs ] ]

--- a/ide/dune-workspace
+++ b/ide/dune-workspace
@@ -1,0 +1,6 @@
+(lang dune 1.2)
+
+; Add custom flags here. Default developer profile is `dev`
+(env
+ (dev     (flags :standard -rectypes -w -9-27-50+60))
+ (release (flags :standard -rectypes)))


### PR DESCRIPTION
The Dune `release` profile is used by OPAM so that should cover the
testing.
