### PR TITLE
Remove FCast from CClosure.fterm.

### DIFF
--- a/kernel/cClosure.mli
+++ b/kernel/cClosure.mli
@@ -131,7 +131,6 @@ type fconstr
 type fterm =
   | FRel of int
   | FAtom of constr (** Metas and Sorts *)
-  | FCast of fconstr * cast_kind * fconstr
   | FFlex of table_key
   | FInd of inductive Univ.puniverses
   | FConstruct of constructor Univ.puniverses

--- a/kernel/reduction.ml
+++ b/kernel/reduction.ml
@@ -605,7 +605,7 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
      (* Should not happen because both (hd1,v1) and (hd2,v2) are in whnf *)
      | ( (FLetIn _, _) | (FCaseT _,_) | (FApp _,_) | (FCLOS _,_) | (FLIFT _,_)
        | (_, FLetIn _) | (_,FCaseT _) | (_,FApp _) | (_,FCLOS _) | (_,FLIFT _)
-       | (FLOCKED,_) | (_,FLOCKED) ) | (FCast _, _) | (_, FCast _) -> assert false
+       | (FLOCKED,_) | (_,FLOCKED) ) -> assert false
 
      | (FRel _ | FAtom _ | FInd _ | FFix _ | FCoFix _
         | FProd _ | FEvar _), _ -> raise NotConvertible

--- a/pretyping/inferCumulativity.ml
+++ b/pretyping/inferCumulativity.ml
@@ -137,7 +137,7 @@ let rec infer_fterm cv_pb infos variances hd stk =
     infer_stack infos variances stk
 
   (* Removed by whnf *)
-  | FLOCKED | FCaseT _ | FCast _ | FLetIn _ | FApp _ | FLIFT _ | FCLOS _ -> assert false
+  | FLOCKED | FCaseT _ | FLetIn _ | FApp _ | FLIFT _ | FCLOS _ -> assert false
 
 and infer_stack infos variances (stk:CClosure.stack) =
   match stk with


### PR DESCRIPTION
Just like in the Sixth Sense, it turns out it was dead code all along.
