### PR TITLE
Issue 8659 not always build all addons

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -186,7 +186,7 @@ after_script:
     - call dev/ci/gitlab.bat
   only:
     variables:
-      - $WINDOWS == "enabled"
+      - $WINDOWS =~ /enabled/
 
 build:base:
   <<: *build-template

--- a/dev/ci/README.md
+++ b/dev/ci/README.md
@@ -175,13 +175,13 @@ If your repository has access to runners tagged `windows`, setting the
 secret variable `WINDOWS` to `enabled` will add jobs building Windows
 versions of Coq (32bit and 64bit).
 
+If the secret variable `WINDOWS` is set to `enabled_all_addons`,
+an extended set of addons will be added to the Windows installer.
+This leads to a considerable runtime in CI so this is not enabled
+by default for pipelines for pull requests.
+
 The Windows jobs are enabled on Coq's repository, where pipelines for
 pull requests run.
-
-If the additional secret variable `WINDOWS_ALL_ADDONS` is set to `enabled`,
-an extended set of addons will be added to the Windows installer.
-This leads to a considerable runtime in CI and is disabled by default for
-pipelines for pull requests.
 
 ### GitLab and Docker
 

--- a/dev/ci/README.md
+++ b/dev/ci/README.md
@@ -178,6 +178,11 @@ versions of Coq (32bit and 64bit).
 The Windows jobs are enabled on Coq's repository, where pipelines for
 pull requests run.
 
+If the additional secret variable `WINDOWS_ALL_ADDONS` is set to `enabled`,
+an extended set of addons will be added to the Windows installer.
+This leads to a considerable runtime in CI and is disabled by default for
+pipelines for pull requests.
+
 ### GitLab and Docker
 
 System and opam packages are installed in a Docker image. The image is

--- a/dev/ci/gitlab.bat
+++ b/dev/ci/gitlab.bat
@@ -40,6 +40,22 @@ SET PATH=%PATH%;C:\Program Files\7-Zip\;C:\Program Files\Microsoft SDKs\Windows\
 if exist %CYGROOT%\build\ rd /s /q %CYGROOT%\build
 if exist %DESTCOQ%\ rd /s /q %DESTCOQ%
 
+IF "%WINDOWS_ALL_ADDONS%" == "enabled" (
+  SET EXTRA_ADDONS=^
+    -addon=mathcomp ^
+    -addon=menhir ^
+    -addon=menhirlib ^
+    -addon=compcert ^
+    -addon=extlib ^
+    -addon=quickchick ^
+    -addon=coquelicot
+  REM addons with build issues
+  REM -addon=vst ^
+  REM -addon=aactactics ^
+) ELSE (
+  SET "EXTRA_ADDONS= "
+)
+
 call %CI_PROJECT_DIR%\dev\build\windows\MakeCoq_MinGW.bat -threads=1 ^
   -arch=%ARCH% -installer=Y -coqver=%CI_PROJECT_DIR_CFMT% ^
   -destcyg=%CYGROOT% -destcoq=%DESTCOQ% -cygcache=%CYGCACHE% ^
@@ -47,19 +63,9 @@ call %CI_PROJECT_DIR%\dev\build\windows\MakeCoq_MinGW.bat -threads=1 ^
   -addon=equations ^
   -addon=ltac2 ^
   -addon=mtac2 ^
-  -addon=mathcomp ^
-  -addon=menhir ^
-  -addon=menhirlib ^
-  -addon=compcert ^
-  -addon=extlib ^
-  -addon=quickchick ^
-  -addon=coquelicot ^
+  %EXTRA_ADDONS% ^
   -make=N ^
   -setup %CI_PROJECT_DIR%\%SETUP% || GOTO ErrorCopyLogFilesAndExit
-
-REM addons with build issues
-REM -addon=vst ^
-REM -addon=aactactics ^
 
 ECHO "Start Artifact Creation"
 TIME /T

--- a/dev/ci/gitlab.bat
+++ b/dev/ci/gitlab.bat
@@ -37,9 +37,6 @@ SET CI_PROJECT_DIR_CFMT=%CI_PROJECT_DIR_MFMT:C:/=/cygdrive/c/%
 SET COQREGTESTING=Y
 SET PATH=%PATH%;C:\Program Files\7-Zip\;C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin
 
-if exist %CYGROOT%\build\ rd /s /q %CYGROOT%\build
-if exist %DESTCOQ%\ rd /s /q %DESTCOQ%
-
 IF "%WINDOWS_ALL_ADDONS%" == "enabled" (
   SET EXTRA_ADDONS=^
     -addon=mathcomp ^

--- a/dev/ci/gitlab.bat
+++ b/dev/ci/gitlab.bat
@@ -37,7 +37,7 @@ SET CI_PROJECT_DIR_CFMT=%CI_PROJECT_DIR_MFMT:C:/=/cygdrive/c/%
 SET COQREGTESTING=Y
 SET PATH=%PATH%;C:\Program Files\7-Zip\;C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin
 
-IF "%WINDOWS_ALL_ADDONS%" == "enabled" (
+IF "%WINDOWS%" == "enabled_all_addons" (
   SET EXTRA_ADDONS=^
     -addon=mathcomp ^
     -addon=menhir ^


### PR DESCRIPTION
This PR fixes #8659 Not always build extended set of addons for Windows installer.

I already added the variable WINDOWS_ALL_ADDONS to gitlab but didn't add CI runs with this enabled nor did I add machinery to enable it for release builds.

I though about using the same mechanism as in makecoq_mingw.sh to decide if the open source archive should be build to check if this is a release build, but I think using the WINDOWS_ALL_ADDONS variable this can be done more properly (and possibly a variable to build the open source archive can be added at the same time, so that I can remove this hack).