### PR TITLE
[printing] Collect Printing Options in a record (c.f. #6560)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -192,6 +192,21 @@ Funind
 
 - Inductive types declared by Funind will never be template polymorphic.
 
+Printing
+
+- Printing All is no longer an option as such. Instead, the command
+  Set Printing All sets or unsets other Printing options to remove high-level
+  printing features. The new command Set Printing Sugared exactly reverses
+  those options, providing high-level printing features. Unset Printing All
+  restores the printing options in effect at the time of the last Set
+  Printing All.
+- The command Set Printing Defaults restores the default printing options.
+- The command Set Printing Let Binder Types prints the types of binders
+  for let-in expressions, disabled by default. Such printing had been
+  enabled by Set Printing All.
+- The Printing Records option affects the printing of record types, as well
+  as the instances of such types.
+
 Misc
 
 - Option "Typeclasses Axioms Are Instances" is deprecated. Use Declare Instance for axioms which should be instances.

--- a/dev/top_printers.ml
+++ b/dev/top_printers.ml
@@ -23,9 +23,14 @@ open Constr
 open Genarg
 open Clenv
 
-let _ = Detyping.print_evar_arguments := true
-let _ = Detyping.print_universes := true
-let _ = Goptions.set_bool_option_value ["Printing";"Matching"] false
+let _ = Printoptions.(
+    set
+      { (get ()) with
+        existential_instances = true;
+        universes = true;
+        matching = false;
+      })
+
 let _ = Detyping.set_detype_anonymous (fun ?loc _ -> raise Not_found)
 
 (* std_ppcmds *)
@@ -167,8 +172,8 @@ let pp_state_t n = pp (Reductionops.pr_state Global.(env()) Evd.empty n)
 (* proof printers *)
 let pr_evar ev = Pp.int (Evar.repr ev)
 let ppmetas metas = pp(Termops.pr_metaset metas)
-let ppevm evd = pp(Termops.pr_evar_map ~with_univs:!Detyping.print_universes (Some 2) (Global.env ()) evd)
-let ppevmall evd = pp(Termops.pr_evar_map ~with_univs:!Detyping.print_universes None (Global.env ()) evd)
+let ppevm evd = pp(Termops.pr_evar_map ~with_univs:Printoptions.((get()).universes) (Some 2) Global.(env()) evd)
+let ppevmall evd = pp(Termops.pr_evar_map ~with_univs:Printoptions.((get()).universes) None Global.(env()) evd)
 let pr_existentialset evars =
   prlist_with_sep spc pr_evar (Evar.Set.elements evars)
 let ppexistentialset evars =

--- a/ide/coq.ml
+++ b/ide/coq.ml
@@ -541,32 +541,54 @@ struct
 
   (* Boolean options *)
 
-  let implicit = BoolOpt ["Printing"; "Implicit"]
-  let coercions = BoolOpt ["Printing"; "Coercions"]
-  let raw_matching = BoolOpt ["Printing"; "Matching"]
-  let notations = BoolOpt ["Printing"; "Notations"]
-  let all_basic = BoolOpt ["Printing"; "All"]
-  let existential = BoolOpt ["Printing"; "Existential"; "Instances"]
-  let universes = BoolOpt ["Printing"; "Universes"]
-  let unfocused = BoolOpt ["Printing"; "Unfocused"]
+  let default_clause = BoolOpt ["Printing";"Allow";"Match";"Default";"Clause"]
+  let coercions = BoolOpt ["Printing";"Coercions"]
+  let compact_contexts = BoolOpt ["Printing";"Compact";"Contexts"]
+  let existential = BoolOpt ["Printing";"Existential";"Instances"]
+  let factorizable = BoolOpt ["Printing";"Factorizable";"Match";"Patterns"]
+  let implicit = BoolOpt ["Printing";"Implicit"]
+  let implicit_defensive = BoolOpt ["Printing";"Implicit";"Defensive"]
+  let let_binder_types =  BoolOpt ["Printing";"Let";"Binder";"Types"]
+  let notations = BoolOpt ["Printing";"Notations"]
+  let proj_compat = BoolOpt ["Printing";"Primitive";"Projection";"Compatibility"]
+  let proj_parms = BoolOpt  ["Printing";"Primitive";"Projection";"Parameters"]
+  let projections = BoolOpt  ["Printing";"Projections"]
+  let raw_matching = BoolOpt ["Printing";"Matching"]
+  let records = BoolOpt  ["Printing";"Records"]
+  let synth = BoolOpt  ["Printing";"Synth"]
+  let universes = BoolOpt ["Printing";"Universes"]
+  let wildcard = BoolOpt ["Printing";"Wildcard"]
+  let unfocused = BoolOpt ["Printing";"Unfocused"]
   let diff = StringOpt ["Diffs"]
 
   type 'a descr = { opts : 'a t list; init : 'a; label : string }
 
+  (* the order of the following array must match that of the corresponding View menu items in coqide_ui.ml
+
+     the "init" values here should be the same as in the default printing option record in
+     library/printoptions.ml
+   *)
+
   let bool_items = [
     { opts = [implicit]; init = false; label = "Display _implicit arguments" };
+    { opts = [implicit_defensive]; init = true; label = "Display non_strict implicit arguments" };
     { opts = [coercions]; init = false; label = "Display _coercions" };
-    { opts = [raw_matching]; init = true;
-      label = "Display raw _matching expressions" };
+    { opts = [compact_contexts]; init = false; label = "Display compact conte_xts" };
+    { opts = [raw_matching]; init = true; label = "Display raw _matching expressions" };
+    { opts = [default_clause]; init = true; label = "Display match default c_lauses" };
+    { opts = [factorizable]; init = true; label = "Display _factorizable match patterns" };
+    { opts = [projections]; init = false; label = "Display _projections" };
+    { opts = [proj_compat]; init = false; label = "Display primiti_ve projection compatibility" };
+    { opts = [proj_parms]; init = false; label = "Display primitive pro_jection parameters" };
+    { opts = [let_binder_types]; init = false; label = "Display types in _binders" };
     { opts = [notations]; init = true; label = "Display _notations" };
-    { opts = [all_basic]; init = false;
-      label = "Display _all basic low-level contents" };
-    { opts = [existential]; init = false;
-      label = "Display _existential variable instances" };
+    { opts = [records]; init = true; label = "Display _records" };
+    { opts = [existential]; init = false; label = "Display _existential variable instances" };
     { opts = [universes]; init = false; label = "Display _universe levels" };
-    { opts = [all_basic;existential;universes]; init = false;
-      label = "Display all _low-level contents" };
-    { opts = [unfocused]; init = false; label = "Display _unfocused goals" }
+    { opts = [wildcard]; init = true; label = "Display _wildcards in patterns" };
+    { opts = [synth]; init = true; label = "Do not display synthesi_zable return types" };
+    (* in goals, not terms *)
+    { opts = [unfocused]; init = false; label = "Display unfocused _goals" }
   ]
 
   let diff_item = { opts = [diff]; init = "off"; label = "Display _proof diffs" }

--- a/ide/coqide_ui.ml
+++ b/ide/coqide_ui.ml
@@ -76,15 +76,28 @@ let init () =
 \n    <menuitem action='Show Toolbar' />\
 \n    <menuitem action='Query Pane' />\
 \n    <separator/>\
-\n    <menuitem action='Display implicit arguments' />\
-\n    <menuitem action='Display coercions' />\
-\n    <menuitem action='Display raw matching expressions' />\
-\n    <menuitem action='Display notations' />\
-\n    <menuitem action='Display all basic low-level contents' />\
-\n    <menuitem action='Display existential variable instances' />\
-\n    <menuitem action='Display universe levels' />\
 \n    <menuitem action='Display all low-level contents' />\
+\n    <menuitem action='Display no low-level contents' />\
+\n    <menuitem action='Display default low-level contents' />\
+\n    <separator/>\
+\n    <menuitem action='Display coercions' />\
+\n    <menuitem action='Display compact contexts' />\
+\n    <menuitem action='Display existential variable instances' />\
+\n    <menuitem action='Display factorizable match patterns' />\
+\n    <menuitem action='Display implicit arguments' />\
+\n    <menuitem action='Display let binder types' />\
+\n    <menuitem action='Display match default clauses' />\
+\n    <menuitem action='Display nonstrict implicit arguments' />\
+\n    <menuitem action='Display notations' />\
+\n    <menuitem action='Display primitive projection compatibility' />\
+\n    <menuitem action='Display primitive projection parameters' />\
+\n    <menuitem action='Display projections' />\
+\n    <menuitem action='Display raw matching expressions' />\
+\n    <menuitem action='Display records' />\
+\n    <menuitem action='Do not display synthesizable return types' />\
 \n    <menuitem action='Display unfocused goals' />\
+\n    <menuitem action='Display universe levels' />\
+\n    <menuitem action='Display wildcards in patterns' />\
 \n    <separator/>\
 \n    <menuitem action='Unset diff' />\
 \n    <menuitem action='Set diff' />\

--- a/ide/idetop.ml
+++ b/ide/idetop.ml
@@ -44,22 +44,34 @@ let pr_debug_answer q r =
 (** Categories of commands *)
 
 let coqide_known_option table = List.mem table [
-  ["Printing";"Implicit"];
+  ["Printing";"Allow";"Match";"Default";"Clause"];
   ["Printing";"Coercions"];
-  ["Printing";"Matching"];
-  ["Printing";"Synth"];
-  ["Printing";"Notations"];
-  ["Printing";"All"];
-  ["Printing";"Records"];
+  ["Printing";"Compact";"Contexts"];
   ["Printing";"Existential";"Instances"];
+  ["Printing";"Factorizable";"Match";"Patterns"];
+  ["Printing";"Implicit"];
+  ["Printing";"Implicit";"Defensive"];
+  ["Printing";"Let";"Binder";"Types"];
+  ["Printing";"Matching"];
+  ["Printing";"Notations"];
+  ["Printing";"Primitive";"Projection";"Compatibility"];
+  ["Printing";"Primitive";"Projection";"Parameters"];
+  ["Printing";"Projections"];
+  ["Printing";"Records"];
+  ["Printing";"Synth"];
+  ["Printing";"Unfocused"];
   ["Printing";"Universes"];
   ["Printing";"Unfocused"];
+  ["Printing";"Wildcard"];
   ["Diffs"]]
 
 let is_known_option cmd = match Vernacprop.under_control cmd with
   | VernacSetOption (_, o, BoolValue true)
   | VernacSetOption (_, o, StringValue _)
   | VernacUnsetOption (_, o) -> coqide_known_option o
+  | VernacSetPrintingAll
+  | VernacSetPrintingDefaults
+  | VernacSetPrintingSugared -> true
   | _ -> false
 
 (** Check whether a command is forbidden in the IDE *)

--- a/ide/idetop.ml
+++ b/ide/idetop.ml
@@ -69,9 +69,6 @@ let is_known_option cmd = match Vernacprop.under_control cmd with
   | VernacSetOption (_, o, BoolValue true)
   | VernacSetOption (_, o, StringValue _)
   | VernacUnsetOption (_, o) -> coqide_known_option o
-  | VernacSetPrintingAll
-  | VernacSetPrintingDefaults
-  | VernacSetPrintingSugared -> true
   | _ -> false
 
 (** Check whether a command is forbidden in the IDE *)

--- a/interp/constrextern.mli
+++ b/interp/constrextern.mli
@@ -44,16 +44,6 @@ val extern_sort : Evd.evar_map -> Sorts.t -> glob_sort
 val extern_rel_context : constr option -> env -> Evd.evar_map ->
   rel_context -> local_binder_expr list
 
-(** Printing options *)
-val print_implicits : bool ref
-val print_implicits_defensive : bool ref
-val print_arguments : bool ref
-val print_evar_arguments : bool ref
-val print_coercions : bool ref
-val print_universes : bool ref
-val print_no_symbol : bool ref
-val print_projections : bool ref
-
 (** Customization of the global_reference printer *)
 val set_extern_reference :
   (?loc:Loc.t -> Id.Set.t -> GlobRef.t -> qualid) -> unit

--- a/lib/flags.ml
+++ b/lib/flags.ml
@@ -53,8 +53,6 @@ let in_toplevel = ref false
 
 let profile = false
 
-let raw_print = ref false
-
 let we_are_parsing = ref false
 
 (* Compatibility mode *)

--- a/lib/flags.mli
+++ b/lib/flags.mli
@@ -49,9 +49,6 @@ val profile : bool
 (* development flag to detect race conditions, it should go away. *)
 val we_are_parsing : bool ref
 
-(* Set Printing All flag. For some reason it is a global flag *)
-val raw_print : bool ref
-
 type compat_version = V8_7 | V8_8 | V8_9 | Current
 val compat_version : compat_version ref
 val version_compare : compat_version -> compat_version -> int

--- a/library/library.mllib
+++ b/library/library.mllib
@@ -12,6 +12,7 @@ Library
 States
 Kindops
 Goptions
+Printoptions
 Decls
 Keys
 Coqlib

--- a/library/printoptions.ml
+++ b/library/printoptions.ml
@@ -40,6 +40,7 @@ let default_options : t = {
     wildcard = true;
   }
 
+(* Options for "Printing All" *)
 let all_options : t = {
     allow_match_default_clause = false;
     coercions = true;
@@ -60,7 +61,7 @@ let all_options : t = {
     wildcard = false;
   }
 
-(* use negation of corresponding fields in all_options *)
+(* Negation of "Printing All", that is to say "Sugar All" *)
 let sugared_options : t = {
     allow_match_default_clause = not all_options.allow_match_default_clause;
     coercions = not all_options.coercions;
@@ -85,84 +86,6 @@ let current_options = Summary.ref ~name:"printing options" default_options
 
 let get () = !current_options
 let set opts = current_options := opts
-
-let saved_options = Summary.ref ~name:"saved printing options" None
-
-let get_saved_options () = !saved_options
-let set_saved_options opts = saved_options := opts
-
-(* given a print options record, get list of option names and their values,
-   used when setting options locally
-   somewhat redundant with the option declarations, so a bit fragile
- *)
-let options_by_name_value opts =
-  [ (["Printing";"Allow";"Match";"Default";"Clause"],opts.allow_match_default_clause);
-    (["Printing";"Coercions"],opts.coercions);
-    (["Printing";"Compact";"Contexts"],opts.compact_contexts);
-    (["Printing";"Existential";"Instances"],opts.existential_instances);
-    (["Printing";"Factorizable";"Match";"Patterns"],opts.factorizable_match_patterns);
-    (["Printing";"Implicit"],opts.implicit);
-    (["Printing";"Implicit";"Defensive"],opts.implicit_defensive);
-    (["Printing";"Let";"Binder";"Types"],opts.let_binder_types);
-    (["Printing";"Matching"],opts.matching);
-    (["Printing";"Notations"],opts.notations);
-    (["Printing";"Primitive";"Projection";"Compatibility"],opts.primitive_projection_compatibility);
-    (["Printing";"Primitive";"Projection";"Parameters"],opts.primitive_projection_parameters);
-    (["Printing";"Projections"],opts.projections);
-    (["Printing";"Records"],opts.records);
-    (["Printing";"Synth"],opts.synth);
-    (["Printing";"Universes"],opts.universes);
-    (["Printing";"Wildcard"],opts.wildcard);
-  ]
-
-let all_names_values     = options_by_name_value all_options
-let sugared_names_values = options_by_name_value sugared_options
-let default_names_values = options_by_name_value default_options
-
-let mk_printing_local opts_vals =
-  List.iter
-    (fun (opt,b) ->
-      Goptions.(set_bool_option_value_gen ~locality:OptLocal opt b))
-    opts_vals
-
-let set_printing_all_global () = set all_options
-let set_printing_all_local () = mk_printing_local all_names_values
-
-let set_printing_all ~local =
-  set_saved_options (Some (get ()));
-  if local then
-    set_printing_all_local ()
-  else
-    set_printing_all_global ()
-
-let noop_unset_printing_all_warning =
-  CWarnings.create ~name:"noop-unset-printing-all" ~category:"vernacular"
-    (fun () -> Pp.str("Unset Printing All here has no effect."))
-
-let unset_printing_all () =
-  match get_saved_options () with
-  | Some opts ->
-     set opts;
-     set_saved_options None
-  | None -> noop_unset_printing_all_warning ()
-
-let set_printing_sugared_global () = set sugared_options
-let set_printing_sugared_local () = mk_printing_local sugared_names_values
-
-let set_printing_sugared ~local =
-  if local then
-    set_printing_sugared_local ()
-  else
-    set_printing_sugared_global ()
-
-let set_printing_defaults_global () = set default_options
-let set_printing_defaults_local () = mk_printing_local default_names_values
-
-let set_printing_defaults ~local =
-  if local then
-    set_printing_defaults_local ()
-  else
-    set_printing_defaults_global ()
 
 (* set printing option, run `f x`, restore options *)
 (* can't use Flags.with_option, individual printing options are not references *)

--- a/library/printoptions.ml
+++ b/library/printoptions.ml
@@ -1,0 +1,179 @@
+(* record of Printing options *)
+
+type t = {
+    allow_match_default_clause : bool;
+    coercions : bool;
+    compact_contexts : bool;
+    existential_instances : bool;
+    factorizable_match_patterns : bool;
+    implicit: bool;
+    implicit_defensive : bool;
+    let_binder_types : bool;
+    matching : bool;
+    notations : bool;
+    primitive_projection_compatibility : bool;
+    primitive_projection_parameters : bool;
+    projections : bool;
+    records : bool;
+    synth : bool;
+    universes : bool;
+    wildcard : bool;
+  }
+
+let default_options : t = {
+    allow_match_default_clause = true;
+    coercions = false;
+    compact_contexts = false;
+    existential_instances = false;
+    factorizable_match_patterns = true;
+    implicit = false;
+    implicit_defensive = true;
+    let_binder_types = false;
+    matching = true;
+    notations = true;
+    primitive_projection_compatibility = false;
+    primitive_projection_parameters = false;
+    projections = false;
+    records = true;
+    synth = true;
+    universes = false;
+    wildcard = true;
+  }
+
+let all_options : t = {
+    allow_match_default_clause = false;
+    coercions = true;
+    compact_contexts = true;
+    existential_instances = true;
+    factorizable_match_patterns = false;
+    implicit = true;
+    implicit_defensive = true;
+    let_binder_types = true;
+    matching = false;
+    notations = false;
+    primitive_projection_compatibility = true;
+    primitive_projection_parameters = true;
+    projections = false;
+    records = false;
+    synth = false;
+    universes = true;
+    wildcard = false;
+  }
+
+(* use negation of corresponding fields in all_options *)
+let sugared_options : t = {
+    allow_match_default_clause = not all_options.allow_match_default_clause;
+    coercions = not all_options.coercions;
+    compact_contexts = not all_options.compact_contexts;
+    existential_instances = not all_options.existential_instances;
+    factorizable_match_patterns = not all_options.factorizable_match_patterns;
+    implicit = not all_options.implicit;
+    implicit_defensive = not all_options.implicit_defensive;
+    let_binder_types = not all_options.let_binder_types;
+    matching = not all_options.matching;
+    notations = not all_options.notations;
+    primitive_projection_compatibility = not all_options.primitive_projection_compatibility;
+    primitive_projection_parameters = not all_options.primitive_projection_parameters;
+    projections = not all_options.projections;
+    records = not all_options.records;
+    synth = not all_options.synth;
+    universes = not all_options.universes;
+    wildcard = not all_options.wildcard;
+  }
+
+let current_options = Summary.ref ~name:"printing options" default_options
+
+let get () = !current_options
+let set opts = current_options := opts
+
+let saved_options = Summary.ref ~name:"saved printing options" None
+
+let get_saved_options () = !saved_options
+let set_saved_options opts = saved_options := opts
+
+(* given a print options record, get list of option names and their values,
+   used when setting options locally
+   somewhat redundant with the option declarations, so a bit fragile
+ *)
+let options_by_name_value opts =
+  [ (["Printing";"Allow";"Match";"Default";"Clause"],opts.allow_match_default_clause);
+    (["Printing";"Coercions"],opts.coercions);
+    (["Printing";"Compact";"Contexts"],opts.compact_contexts);
+    (["Printing";"Existential";"Instances"],opts.existential_instances);
+    (["Printing";"Factorizable";"Match";"Patterns"],opts.factorizable_match_patterns);
+    (["Printing";"Implicit"],opts.implicit);
+    (["Printing";"Implicit";"Defensive"],opts.implicit_defensive);
+    (["Printing";"Let";"Binder";"Types"],opts.let_binder_types);
+    (["Printing";"Matching"],opts.matching);
+    (["Printing";"Notations"],opts.notations);
+    (["Printing";"Primitive";"Projection";"Compatibility"],opts.primitive_projection_compatibility);
+    (["Printing";"Primitive";"Projection";"Parameters"],opts.primitive_projection_parameters);
+    (["Printing";"Projections"],opts.projections);
+    (["Printing";"Records"],opts.records);
+    (["Printing";"Synth"],opts.synth);
+    (["Printing";"Universes"],opts.universes);
+    (["Printing";"Wildcard"],opts.wildcard);
+  ]
+
+let all_names_values     = options_by_name_value all_options
+let sugared_names_values = options_by_name_value sugared_options
+let default_names_values = options_by_name_value default_options
+
+let mk_printing_local opts_vals =
+  List.iter
+    (fun (opt,b) ->
+      Goptions.(set_bool_option_value_gen ~locality:OptLocal opt b))
+    opts_vals
+
+let set_printing_all_global () = set all_options
+let set_printing_all_local () = mk_printing_local all_names_values
+
+let set_printing_all ~local =
+  set_saved_options (Some (get ()));
+  if local then
+    set_printing_all_local ()
+  else
+    set_printing_all_global ()
+
+let noop_unset_printing_all_warning =
+  CWarnings.create ~name:"noop-unset-printing-all" ~category:"vernacular"
+    (fun () -> Pp.str("Unset Printing All here has no effect."))
+
+let unset_printing_all () =
+  match get_saved_options () with
+  | Some opts ->
+     set opts;
+     set_saved_options None
+  | None -> noop_unset_printing_all_warning ()
+
+let set_printing_sugared_global () = set sugared_options
+let set_printing_sugared_local () = mk_printing_local sugared_names_values
+
+let set_printing_sugared ~local =
+  if local then
+    set_printing_sugared_local ()
+  else
+    set_printing_sugared_global ()
+
+let set_printing_defaults_global () = set default_options
+let set_printing_defaults_local () = mk_printing_local default_names_values
+
+let set_printing_defaults ~local =
+  if local then
+    set_printing_defaults_local ()
+  else
+    set_printing_defaults_global ()
+
+(* set printing option, run `f x`, restore options *)
+(* can't use Flags.with_option, individual printing options are not references *)
+let with_printing_option set_opt f x =
+  let saved_opts = get () in
+  let _ = set (set_opt saved_opts) in
+  try
+    let res = f x in
+    let _ = set saved_opts in
+    res
+  with reraise ->
+    let reraise = Backtrace.add_backtrace reraise in
+    let _ = set saved_opts in
+    Exninfo.iraise reraise

--- a/library/printoptions.mli
+++ b/library/printoptions.mli
@@ -22,18 +22,14 @@ type t = {
   wildcard : bool;
 }
 
-(** the record used for Set Printing All *)
+(** values for default, "Printing All" "Sugar All" *)
+val default_options : t
 val all_options : t
+val sugared_options : t
 
 (** getter/setter for Printing options *)
 val get : unit -> t
 val set : t -> unit
-
-(** getter/setters for Printing options *)
-val set_printing_all : local:bool -> unit
-val unset_printing_all : unit -> unit
-val set_printing_sugared : local:bool -> unit
-val set_printing_defaults : local:bool -> unit
 
 (** run function in context of temporary printing option *)
 val with_printing_option : (t -> t) -> ('a -> 'b) -> 'a -> 'b

--- a/library/printoptions.mli
+++ b/library/printoptions.mli
@@ -1,0 +1,39 @@
+(** Printing options record *)
+
+(* storage of the options is in the current instance of the record *)
+
+type t = {
+  allow_match_default_clause : bool;
+  coercions : bool;
+  compact_contexts : bool;
+  existential_instances : bool;
+  factorizable_match_patterns : bool;
+  implicit : bool;
+  implicit_defensive : bool;
+  let_binder_types : bool;
+  matching : bool;
+  notations : bool;
+  primitive_projection_compatibility : bool;
+  primitive_projection_parameters : bool;
+  projections : bool;
+  records : bool;
+  synth : bool;
+  universes : bool;
+  wildcard : bool;
+}
+
+(** the record used for Set Printing All *)
+val all_options : t
+
+(** getter/setter for Printing options *)
+val get : unit -> t
+val set : t -> unit
+
+(** getter/setters for Printing options *)
+val set_printing_all : local:bool -> unit
+val unset_printing_all : unit -> unit
+val set_printing_sugared : local:bool -> unit
+val set_printing_defaults : local:bool -> unit
+
+(** run function in context of temporary printing option *)
+val with_printing_option : (t -> t) -> ('a -> 'b) -> 'a -> 'b

--- a/pending_refman_update.diff
+++ b/pending_refman_update.diff
@@ -1,0 +1,128 @@
+diff --git a/doc/refman/RefMan-ext.tex b/doc/refman/RefMan-ext.tex
+index a1950d136e..d70a26c164 100644
+--- a/doc/refman/RefMan-ext.tex
++++ b/doc/refman/RefMan-ext.tex
+@@ -134,12 +134,17 @@ Definition half' :=
+      Rat_irred_cond := one_two_irred |}.
+ \end{coq_example}
+ 
+-This syntax can be disabled globally for printing by
++This syntax can be disabled globally for printing records by
+ \begin{quote}
+ {\tt Unset Printing Records.}
+ \optindex{Printing Records}
+ \end{quote}
+-For a given type, one can override this using either
++The same option also affects how record types are printed. When the
++option is set, record types are printed using syntax like that used to
++define them. If the option is not set, record types are printed using
++a syntax closer to their internal representation in {\Coq}.
++
++For a given type, one can override the {\tt Printing Records} option using either
+ \begin{quote}
+ {\tt Add Printing Record {\ident}.}
+ \end{quote}
+@@ -1745,6 +1750,20 @@ Conversely, to force the display of non strict arguments, use command
+ 
+ \SeeAlso {\tt Set Printing All} in Section~\ref{SetPrintingAll}.
+ 
++\subsection{Printing the types of let-in binders}
++\optindex{Printing Let Binder Types}
++
++By default, when printing {\tt let-in} expressions, the types
++of binders are elided. The command
++\begin{quote}
++{\tt Set Printing Let Binder Types}.
++\end{quote}
++allows printing such types. Running
++\begin{quote}
++{\tt Unset Printing Let Binder Types}.
++\end{quote}
++enables the default behavior.
++
+ \subsection{Interaction with subtyping}
+ 
+ When an implicit argument can be inferred from the type of more than
+@@ -1985,7 +2004,9 @@ More details and examples, and a description of the commands related
+ to coercions are provided in Chapter~\ref{Coercions-full}.
+ 
+ \section[Printing constructions in full]{Printing constructions in full\label{SetPrintingAll}
+-\optindex{Printing All}}
++\optindex{Printing All}
++\optindex{Printing Sugared}
++\optindex{Printing Defaults}}
+ 
+ Coercions, implicit arguments, the type of pattern-matching, but also
+ notations (see Chapter~\ref{Addoc-syntax}) can obfuscate the behavior
+@@ -1996,18 +2017,48 @@ subterms are sensitive to the implicit arguments). The command
+ \end{quote}
+ deactivates all high-level printing features such as coercions,
+ implicit arguments, returned type of pattern-matching, notations and
+-various syntactic sugar for pattern-matching or record projections.
+-Otherwise said, {\tt Set Printing All} includes the effects
+-of the commands {\tt Set Printing Implicit}, {\tt Set Printing
+-Coercions}, {\tt Set Printing Synth}, {\tt Unset Printing Projections}
+-and {\tt Unset Printing Notations}.  To reactivate the high-level
+-printing features, use the command
++various syntactic sugar for pattern-matching or record projections, by
++affecting the relevant printing options. More precisely, the command has the
++same effect as running:
++\begin{itemize}
++\item {\tt Set Printing Coercions.}
++\item {\tt Set Printing Compact Contexts.}
++\item {\tt Set Printing Existential Instances.}
++\item {\tt Set Printing Implicit.}
++\item {\tt Set Printing Implicit Defensive.}
++\item {\tt Set Printing Let Binder Types.}
++\item {\tt Set Printing Primitive Projection Compatibility.}
++\item {\tt Set Printing Primitive Projection Parameters.}
++\item {\tt Set Printing Universes.}
++\item {\tt Unset Printing Allow Default Clause.}
++\item {\tt Unset Printing Factorizable Match Patterns.}
++\item {\tt Unset Printing Matching.}
++\item {\tt Unset Printing Notations.}
++\item {\tt Unset Printing Projections.}
++\item {\tt Unset Printing Records.}
++\item {\tt Unset Printing Synth.}
++\item {\tt Unset Printing Wildcard.}
++\end{itemize}
++The command
+ \begin{quote}
+ {\tt Unset Printing All.}
+ \end{quote}
++restores the printing options in effect at the time of the most recent {\tt Set Printing All}.
++Once such options have been restored, running the command again has no effect.
++
++The command
++\begin{quote}
++{\tt Set Printing Sugared.}
++\end{quote}
++exactly reverses the effect of {\tt Set Printing All}, enabling all high-level
++printing features. To restore the default printing options, use the command:
++\begin{quote}
++{\tt Set Printing Defaults.}
++\end{quote}
+ 
+ \section[Printing universes]{Printing universes\label{PrintingUniverses}
+-\optindex{Printing Universes}}
++\optindex{Printing Universes}
++\optindex{Printing Universe Explanations}}
+ 
+ The following command:
+ \begin{quote}
+@@ -2024,6 +2075,15 @@ of the occurrences of {\Type}, use
+ {\tt Unset Printing Universes.}
+ \end{quote}
+ 
++If your script contains a universe inconsistency, {\Coq} will print
++an error message. By default, the message provides details of the
++inconsistency. Use the command
++\begin{quote}
++{\tt Unset Printing Universe Explanations.}
++\end{quote}
++to elide those details; the corresponding {\tt Set} command re-enables
++their printing.
++
+ \comindex{Print Universes}
+ \comindex{Print Sorted Universes}
+ 

--- a/plugins/funind/glob_term_to_relation.ml
+++ b/plugins/funind/glob_term_to_relation.ml
@@ -1530,17 +1530,11 @@ let do_build_inductive
 
 
 let build_inductive evd funconstants funsargs returned_types rtl =
-  let pu = !Detyping.print_universes in
-  let cu = !Constrextern.print_universes in
+  let opts = Printoptions.get () in
   try
-    Detyping.print_universes := true;
-    Constrextern.print_universes := true;
+    Printoptions.(set { opts with universes = true });
     do_build_inductive evd funconstants funsargs returned_types rtl;
-    Detyping.print_universes := pu;
-    Constrextern.print_universes := cu
+    Printoptions.set opts
   with e when CErrors.noncritical e ->
-    Detyping.print_universes := pu;
-    Constrextern.print_universes := cu;
+    Printoptions.set opts;
     raise (Building_graph e)
-
-

--- a/plugins/funind/indfun.ml
+++ b/plugins/funind/indfun.ml
@@ -582,7 +582,7 @@ let map_option f = function
 open Constrexpr
 
 let rec rebuild_bl aux bl typ =
-	match bl,typ with
+       match bl,typ with
 	  | [], _ -> List.rev aux,typ
 	  | (CLocalAssum(nal,bk,_))::bl',typ ->
 	     rebuild_nal aux bk bl' nal  typ

--- a/plugins/funind/indfun_common.ml
+++ b/plugins/funind/indfun_common.ml
@@ -148,15 +148,11 @@ let save with_clean id const ?hook uctx (locality,_,kind) =
   definition_message id
 
 let with_full_print f a =
+  let saved_opts = Printoptions.get () in
   let old_implicit_args = Impargs.is_implicit_args ()
   and old_strict_implicit_args =  Impargs.is_strict_implicit_args ()
   and old_contextual_implicit_args = Impargs.is_contextual_implicit_args () in
-  let old_rawprint = !Flags.raw_print in
-  let old_printuniverses = !Constrextern.print_universes in
-  let old_printallowmatchdefaultclause = !Detyping.print_allow_match_default_clause in
-  Constrextern.print_universes := true;
-  Detyping.print_allow_match_default_clause := false;
-  Flags.raw_print := true;
+  Printoptions.set_printing_all ~local:false;
   Impargs.make_implicit_args false;
   Impargs.make_strict_implicit_args false;
   Impargs.make_contextual_implicit_args false;
@@ -166,9 +162,7 @@ let with_full_print f a =
     Impargs.make_implicit_args old_implicit_args;
     Impargs.make_strict_implicit_args old_strict_implicit_args;
     Impargs.make_contextual_implicit_args old_contextual_implicit_args;
-    Flags.raw_print := old_rawprint;
-    Constrextern.print_universes := old_printuniverses;
-    Detyping.print_allow_match_default_clause := old_printallowmatchdefaultclause;
+    Printoptions.set saved_opts;
     Dumpglob.continue ();
     res
   with
@@ -176,16 +170,9 @@ let with_full_print f a =
 	Impargs.make_implicit_args old_implicit_args;
 	Impargs.make_strict_implicit_args old_strict_implicit_args;
 	Impargs.make_contextual_implicit_args old_contextual_implicit_args;
-	Flags.raw_print := old_rawprint;
-	Constrextern.print_universes := old_printuniverses;
-        Detyping.print_allow_match_default_clause := old_printallowmatchdefaultclause;
+        Printoptions.set saved_opts;
 	Dumpglob.continue ();
 	raise reraise
-
-
-
-
-
 
 (**********************)
 

--- a/plugins/funind/indfun_common.ml
+++ b/plugins/funind/indfun_common.ml
@@ -152,7 +152,7 @@ let with_full_print f a =
   let old_implicit_args = Impargs.is_implicit_args ()
   and old_strict_implicit_args =  Impargs.is_strict_implicit_args ()
   and old_contextual_implicit_args = Impargs.is_contextual_implicit_args () in
-  Printoptions.set_printing_all ~local:false;
+  Printoptions.(set all_options);
   Impargs.make_implicit_args false;
   Impargs.make_strict_implicit_args false;
   Impargs.make_contextual_implicit_args false;

--- a/plugins/funind/indfun_common.mli
+++ b/plugins/funind/indfun_common.mli
@@ -57,7 +57,6 @@ val save
 *)
 val with_full_print : ('a -> 'b) -> 'a -> 'b
 
-
 (*****************)
 
 type function_info =

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -32,12 +32,6 @@ type _ delay =
 | Now : 'a delay
 | Later : [ `thunk ] delay
 
-(** Should we keep details of universes during detyping ? *)
-let print_universes = ref false
-
-(** If true, prints local context of evars, whatever print_arguments *)
-let print_evar_arguments = ref false
-
 let add_name na b t (nenv, env) =
   let open Context.Rel.Declaration in
   add_name na nenv, push_rel (match b with
@@ -129,51 +123,57 @@ module PrintingCasesLet =
 module PrintingIf  = Goptions.MakeRefTable(PrintingCasesIf)
 module PrintingLet = Goptions.MakeRefTable(PrintingCasesLet)
 
-(* Flags.for printing or not wildcard and synthetisable types *)
-
 open Goptions
 
-let wildcard_value = ref true
-let force_wildcard () = !wildcard_value
-
+let pr_get f () = f (Printoptions.get ())
+let pr_set f v  = Printoptions.(set (f (get ()) v))
 let () = declare_bool_option
 	  { optdepr  = false;
 	    optname  = "forced wildcard";
 	    optkey   = ["Printing";"Wildcard"];
-	    optread  = force_wildcard;
-	    optwrite = (:=) wildcard_value }
-
-let synth_type_value = ref true
-let synthetize_type () = !synth_type_value
+            optread  = pr_get (fun r -> r.Printoptions.wildcard);
+            optwrite = pr_set (fun r v -> { r with Printoptions.wildcard = v });
+          }
 
 let () = declare_bool_option
 	  { optdepr  = false;
 	    optname  = "pattern matching return type synthesizability";
 	    optkey   = ["Printing";"Synth"];
-	    optread  = synthetize_type;
-	    optwrite = (:=) synth_type_value }
-
-let reverse_matching_value = ref true
-let reverse_matching () = !reverse_matching_value
+            optread  = pr_get (fun r -> r.Printoptions.synth);
+            optwrite = pr_set (fun r v -> { r with Printoptions.synth = v });
+          }
 
 let () = declare_bool_option
 	  { optdepr  = false;
 	    optname  = "pattern-matching reversibility";
 	    optkey   = ["Printing";"Matching"];
-	    optread  = reverse_matching;
-	    optwrite = (:=) reverse_matching_value }
-
-let print_primproj_params_value = ref false
-let print_primproj_params () = !print_primproj_params_value
+            optread  = pr_get (fun r -> r.Printoptions.matching);
+            optwrite = pr_set (fun r v -> { r with Printoptions.matching = v });
+          }
 
 let () = declare_bool_option
 	  { optdepr  = false;
 	    optname  = "printing of primitive projection parameters";
 	    optkey   = ["Printing";"Primitive";"Projection";"Parameters"];
+<<<<<<< HEAD
 	    optread  = print_primproj_params;
 	    optwrite = (:=) print_primproj_params_value }
 
 	  
+=======
+            optread  = pr_get (fun r -> r.Printoptions.primitive_projection_parameters);
+            optwrite = pr_set (fun r v -> { r with Printoptions.primitive_projection_parameters = v} );
+          }
+
+let _ = declare_bool_option
+	  { optdepr  = false;
+	    optname  = "backwards-compatible printing of primitive projections";
+	    optkey   = ["Printing";"Primitive";"Projection";"Compatibility"];
+            optread  = pr_get (fun r -> r.Printoptions.primitive_projection_compatibility);
+            optwrite = pr_set (fun r v -> { r with Printoptions.primitive_projection_compatibility = v });
+          }
+
+>>>>>>> [printing] Collect Printing Options in a record (c.f. #6560)
 (* Auxiliary function for MutCase printing *)
 (* [computable] tries to tell if the predicate typing the result is inferable*)
 
@@ -243,29 +243,37 @@ let lookup_index_as_renamed env sigma t n =
 (**********************************************************************)
 (* Factorization of match patterns *)
 
+<<<<<<< HEAD
 let print_factorize_match_patterns = ref true
 
 let () =
+=======
+let _ =
+>>>>>>> [printing] Collect Printing Options in a record (c.f. #6560)
   declare_bool_option
     { optdepr  = false;
       optname  = "factorization of \"match\" patterns in printing";
       optkey   = ["Printing";"Factorizable";"Match";"Patterns"];
-      optread  = (fun () -> !print_factorize_match_patterns);
-      optwrite = (fun b -> print_factorize_match_patterns := b) }
+      optread  = pr_get (fun r -> r.Printoptions.factorizable_match_patterns);
+      optwrite = pr_set (fun r v -> {r with Printoptions.factorizable_match_patterns = v});
+    }
 
-let print_allow_match_default_clause = ref true
-
+<<<<<<< HEAD
 let () =
+=======
+let _ =
+>>>>>>> [printing] Collect Printing Options in a record (c.f. #6560)
   declare_bool_option
     { optdepr  = false;
       optname  = "possible use of \"match\" default pattern in printing";
       optkey   = ["Printing";"Allow";"Match";"Default";"Clause"];
-      optread  = (fun () -> !print_allow_match_default_clause);
-      optwrite = (fun b -> print_allow_match_default_clause := b) }
+      optread  = pr_get (fun r -> r.Printoptions.allow_match_default_clause);
+      optwrite = pr_set (fun r v -> { r with Printoptions.allow_match_default_clause = v});
+    }
 
 let rec join_eqns (ids,rhs as x) patll = function
   | ({CAst.loc; v=(ids',patl',rhs')} as eqn')::rest ->
-     if not !Flags.raw_print && !print_factorize_match_patterns &&
+     if Printoptions.((get()).factorizable_match_patterns) &&
         List.eq_set Id.equal ids ids' && glob_constr_eq rhs rhs'
      then
        join_eqns x (patl'::patll) rest
@@ -311,7 +319,7 @@ let factorize_eqns eqns =
   let eqns = aux [] (List.rev eqns) in
   let mk_anon patl = List.map (fun _ -> DAst.make @@ PatVar Anonymous) patl in
   let open CAst in
-  if not !Flags.raw_print && !print_allow_match_default_clause && eqns <> [] then
+  if Printoptions.((get()).allow_match_default_clause) && eqns <> [] then
     match select_default_clause eqns with
     (* At least two clauses and the last one is disjunctive with no variables *)
     | Some {loc=gloc;v=([],patl::_::_,rhs)}, (_::_ as eqns) ->
@@ -330,7 +338,7 @@ let factorize_eqns eqns =
 
 let update_name sigma na ((_,(e,_)),c) =
   match na with
-  | Name _ when force_wildcard () && noccurn sigma (List.index Name.equal na e) c ->
+  | Name _ when Printoptions.((get()).wildcard) && noccurn sigma (List.index Name.equal na e) c ->
       Anonymous
   | _ ->
       na
@@ -435,10 +443,9 @@ let it_destRLambda_or_LetIn_names l c =
 
 let detype_case computable detype detype_eqns testdep avoid data p c bl =
   let (indsp,st,constagsl,k) = data in
-  let synth_type = synthetize_type () in
   let tomatch = detype c in
   let alias, aliastyp, pred=
-    if (not !Flags.raw_print) && synth_type && computable && not (Int.equal (Array.length bl) 0)
+    if Printoptions.((get()).synth) && computable && not (Int.equal (Array.length bl) 0)
     then
       Anonymous, None, None
     else
@@ -455,9 +462,16 @@ let detype_case computable detype detype_eqns testdep avoid data p c bl =
   let constructs = Array.init (Array.length bl) (fun i -> (indsp,i+1)) in
   let tag =
     try
-      if !Flags.raw_print then
-        RegularStyle
-      else if st == LetPatternStyle then
+      (* TODO: Use to have:
+
+         if !Flags.raw_print then
+           RegularStyle
+         else ...
+
+         Which Printing option(s) was raw_print meant to
+         represent here? Do we need a new one?
+      *)
+      if st == LetPatternStyle then
 	st
       else if PrintingLet.active indsp then
 	LetStyle
@@ -600,8 +614,8 @@ let detype_sort sigma = function
   | Prop -> GProp
   | Set -> GSet
   | Type u ->
-    GType
-      (if !print_universes
+     GType
+      (if Printoptions.((get()).universes)
        then detype_universe sigma u
        else [])
 
@@ -651,17 +665,23 @@ and detype_r d flags avoid env sigma t =
 	(try let _ = Global.lookup_named id in GRef (VarRef id, None)
 	 with Not_found -> GVar id)
     | Sort s -> GSort (detype_sort sigma (ESorts.kind sigma s))
-    | Cast (c1,REVERTcast,c2) when not !Flags.raw_print ->
+    (* TODO: when Set Printing All used raw_print ref, the following
+             case used:
+              when not !raw_print
+             as a guard. Is there a different guard, that can be used?
+             Is a new option needed?
+    *)
+    | Cast (c1,REVERTcast,c2) ->
         DAst.get (detype d flags avoid env sigma c1)
     | Cast (c1,k,c2) ->
-        let d1 = detype d flags avoid env sigma c1 in
-	let d2 = detype d flags avoid env sigma c2 in
-    let cast = match k with
-    | VMcast -> CastVM d2
-    | NATIVEcast -> CastNative d2
-    | _ -> CastConv d2
-    in
-	GCast(d1,cast)
+       let d1 = detype d flags avoid env sigma c1 in
+       let d2 = detype d flags avoid env sigma c2 in
+       let cast = match k with
+         | VMcast -> CastVM d2
+         | NATIVEcast -> CastNative d2
+         | _ -> CastConv d2
+       in
+       GCast(d1,cast)
     | Prod (na,ty,c) -> detype_binder d flags BProd avoid env sigma na None ty c
     | Lambda (na,ty,c) -> detype_binder d flags BLambda avoid env sigma na None ty c
     | LetIn (na,b,ty,c) -> detype_binder d flags BLetIn avoid env sigma na (Some b) ty c
@@ -690,12 +710,41 @@ and detype_r d flags avoid env sigma t =
 	  GApp (DAst.make @@ GRef (ConstRef (Projection.constant p), None), 
 		[detype d flags avoid env sigma c])
       else 
+<<<<<<< HEAD
         if print_primproj_params () then
           try
             let c = Retyping.expand_projection (snd env) sigma p c [] in
             DAst.get (detype d flags avoid env sigma c)
           with Retyping.RetypeError _ -> noparams ()
         else noparams ()
+=======
+        if Printoptions.((get()).primitive_projection_compatibility) &&
+           Projection.unfolded p
+        then
+	  (** Print the compatibility match version *)
+	  let c' = 
+	    try 
+              let ind = Projection.inductive p in
+              let bodies = Inductiveops.legacy_match_projection (snd env) ind in
+              let body = bodies.(Projection.arg p) in
+	      let ty = Retyping.get_type_of (snd env) sigma c in
+	      let ((ind,u), args) = Inductiveops.find_mrectype (snd env) sigma ty in
+	      let body' = strip_lam_assum body in
+	      let u = EInstance.kind sigma u in
+	      let body' = CVars.subst_instance_constr u body' in
+	      let body' = EConstr.of_constr body' in
+		substl (c :: List.rev args) body'
+	    with Retyping.RetypeError _ | Not_found -> 
+	      anomaly (str"Cannot detype an unfolded primitive projection.")
+	  in DAst.get (detype d flags avoid env sigma c')
+	else
+          if Printoptions.((get()).primitive_projection_parameters) then
+	    try
+	      let c = Retyping.expand_projection (snd env) sigma p c [] in
+              DAst.get (detype d flags avoid env sigma c)
+	    with Retyping.RetypeError _ -> noparams ()
+	  else noparams ()
+>>>>>>> [printing] Collect Printing Options in a record (c.f. #6560)
 
     | Evar (evk,cl) ->
         let bound_to_itself_or_letin decl c =
@@ -714,7 +763,8 @@ and detype_r d flags avoid env sigma t =
           in
           let l = Evd.evar_instance_array bound_to_itself_or_letin (Evd.find sigma evk) cl in
           let fvs,rels = List.fold_left (fun (fvs,rels) (_,c) -> match EConstr.kind sigma c with Rel n -> (fvs,Int.Set.add n rels) | Var id -> (Id.Set.add id fvs,rels) | _ -> (fvs,rels)) (Id.Set.empty,Int.Set.empty) l in
-          let l = Evd.evar_instance_array (fun d c -> not !print_evar_arguments && (bound_to_itself_or_letin d c && not (isRel sigma c && Int.Set.mem (destRel sigma c) rels || isVar sigma c && (Id.Set.mem (destVar sigma c) fvs)))) (Evd.find sigma evk) cl in
+          let print_evar_arguments = Printoptions.((get()).existential_instances) in
+          let l = Evd.evar_instance_array (fun d c -> not print_evar_arguments && (bound_to_itself_or_letin d c && not (isRel sigma c && Int.Set.mem (destRel sigma c) rels || isVar sigma c && (Id.Set.mem (destVar sigma c) fvs)))) (Evd.find sigma evk) cl in
           id,l
         with Not_found ->
           Id.of_string ("X" ^ string_of_int (Evar.repr evk)),
@@ -740,7 +790,7 @@ and detype_r d flags avoid env sigma t =
 
 and detype_eqns d flags avoid env sigma ci computable constructs consnargsl bl =
   try
-    if !Flags.raw_print || not (reverse_matching ()) then raise Exit;
+    if not Printoptions.((get()).matching) then raise Exit;
     let mat = build_tree Anonymous (snd flags) (avoid,env) sigma ci bl in
     List.map (fun (ids,pat,((avoid,env),c)) ->
         CAst.make (Id.Set.elements ids,[pat],detype d flags avoid env sigma c))
@@ -751,7 +801,7 @@ and detype_eqns d flags avoid env sigma ci computable constructs consnargsl bl =
 
 and detype_eqn d (lax,isgoal as flags) avoid env sigma constr construct_nargs branch =
   let make_pat x avoid env b body ty ids =
-    if force_wildcard () && noccurn sigma 1 b then
+    if Printoptions.((get()).wildcard) && noccurn sigma 1 b then
       DAst.make @@ PatVar Anonymous,avoid,(add_name Anonymous body ty env),ids
     else
       let flag = if isgoal then RenamingForGoal else RenamingForCasesPattern (fst env,b) in
@@ -804,7 +854,7 @@ and detype_binder d (lax,isgoal as flags) bk avoid env sigma na body ty c =
       let c = detype d (lax,false) avoid env sigma (Option.get body) in
       (* Heuristic: we display the type if in Prop *)
       let s = try Retyping.get_sort_family_of (snd env) sigma ty with _ when !Flags.in_debugger || !Flags.in_toplevel -> InType (* Can fail because of sigma missing in debugger *) in
-      let t = if s != InProp  && not !Flags.raw_print then None else Some (detype d (lax,false) avoid env sigma ty) in
+      let t = if s != InProp && not Printoptions.((get()).let_binder_types) then None else Some (detype d (lax,false) avoid env sigma ty) in
       GLetIn (na', c, t, r)
 
 let detype_rel_context d ?(lax=false) where avoid env sigma sign =

--- a/pretyping/detyping.mli
+++ b/pretyping/detyping.mli
@@ -21,20 +21,6 @@ type _ delay =
 | Now : 'a delay
 | Later : [ `thunk ] delay
 
-(** Should we keep details of universes during detyping ? *)
-val print_universes : bool ref
-
-(** If true, prints full local context of evars *)
-val print_evar_arguments : bool ref
-
-(** If true, contract branches with same r.h.s. and same matching
-    variables in a disjunctive pattern *)
-val print_factorize_match_patterns : bool ref
-
-(** If true and the last non unique clause of a "match" is a
-    variable-free disjunctive pattern, turn it into a catch-call case *)
-val print_allow_match_default_clause : bool ref
-
 val subst_cases_pattern : substitution -> cases_pattern -> cases_pattern
 
 val subst_glob_constr : substitution -> glob_constr -> glob_constr
@@ -70,9 +56,6 @@ val lookup_index_as_renamed : env -> evar_map -> constr -> int -> int option
 
 (* XXX: This is a hack and should go away *)
 val set_detype_anonymous : (?loc:Loc.t -> int -> Id.t) -> unit
-
-val force_wildcard : unit -> bool
-val synthetize_type : unit -> bool
 
 (** Utilities to transform kernel cases to simple pattern-matching problem *)
 

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -198,12 +198,13 @@ let safe_pr_lconstr_env = safe_gen pr_lconstr_env
 let safe_pr_constr_env = safe_gen pr_constr_env
 
 let pr_universe_ctx_set sigma c =
-  if !Detyping.print_universes && not (Univ.ContextSet.is_empty c) then
+  if Printoptions.((get()).universes) && not (Univ.ContextSet.is_empty c) then
     fnl()++pr_in_comment (v 0 (Univ.pr_universe_context_set (Termops.pr_evd_level sigma) c))
   else
     mt()
 
 let pr_universe_ctx sigma ?variance c =
+<<<<<<< HEAD
   if !Detyping.print_universes && not (Univ.UContext.is_empty c) then
     fnl()++pr_in_comment (v 0 (Univ.pr_universe_context (Termops.pr_evd_level sigma) ?variance c))
   else
@@ -224,6 +225,40 @@ let pr_abstract_universe_ctx sigma ?variance ?priv c =
 let pr_universes sigma ?variance ?priv = function
   | Declarations.Monomorphic ctx -> pr_universe_ctx_set sigma ctx
   | Declarations.Polymorphic ctx -> pr_abstract_universe_ctx sigma ?variance ?priv ctx
+=======
+  if Printoptions.((get()).universes) && not (Univ.UContext.is_empty c) then
+    fnl()++pr_in_comment (fun c -> v 0
+      (Univ.pr_universe_context (Termops.pr_evd_level sigma) ?variance c)) c
+  else
+    mt()
+
+let pr_abstract_universe_ctx sigma ?variance c =
+  if Printoptions.((get()).universes) && not (Univ.AUContext.is_empty c) then
+    fnl()++pr_in_comment (fun c -> v 0
+      (Univ.pr_abstract_universe_context (Termops.pr_evd_level sigma) ?variance c)) c
+  else
+    mt()
+
+let pr_constant_universes sigma = function
+  | Declarations.Monomorphic_const ctx -> pr_universe_ctx_set sigma ctx
+  | Declarations.Polymorphic_const ctx -> pr_abstract_universe_ctx sigma ctx
+
+let pr_cumulativity_info sigma cumi =
+  if Printoptions.((get()).universes)
+  && not (Univ.UContext.is_empty (Univ.CumulativityInfo.univ_context cumi)) then
+    fnl()++pr_in_comment (fun uii -> v 0 
+      (Univ.pr_cumulativity_info (Termops.pr_evd_level sigma) uii)) cumi
+  else
+    mt()
+
+let pr_abstract_cumulativity_info sigma cumi =
+  if Printoptions.((get()).universes)
+  && not (Univ.AUContext.is_empty (Univ.ACumulativityInfo.univ_context cumi)) then
+    fnl()++pr_in_comment (fun uii -> v 0
+      (Univ.pr_abstract_cumulativity_info (Termops.pr_evd_level sigma) uii)) cumi
+  else
+    mt()
+>>>>>>> [printing] Collect Printing Options in a record (c.f. #6560)
 
 (**********************************************************************)
 (* Global references *)
@@ -246,7 +281,7 @@ let pr_universe_instance evd inst =
   pr_universe_instance_constraints evd inst Univ.Constraint.empty
 
 let pr_puniverses f env sigma (c,u) =
-  if !Constrextern.print_universes
+  if Printoptions.((get()).universes)
   then f env c ++ pr_universe_instance sigma u
   else f env c
 
@@ -275,10 +310,6 @@ let pr_pattern t = pr_pattern_env (Global.env()) empty_names_context t*)
 
 
 (* Flag for compact display of goals *)
-
-let get_compact_context,set_compact_context =
-  let compact_context = ref false in
-  (fun () -> !compact_context),(fun b  -> compact_context := b)
 
 let pr_compacted_decl env sigma decl =
   let ids, pbody, typ = match decl with
@@ -364,7 +395,7 @@ let pr_ne_context_of header env sigma =
 (* Heuristic for horizontalizing hypothesis that the user probably
    considers as "variables": An hypothesis H:T where T:S and S<>Prop. *)
 let should_compact env sigma typ =
-  get_compact_context() &&
+  Printoptions.((get()).compact_contexts) &&
     let type_of_typ = Retyping.get_type_of env sigma (EConstr.of_constr typ) in
     not (is_Prop (EConstr.to_constr sigma type_of_typ))
 

--- a/printing/printer.mli
+++ b/printing/printer.mli
@@ -111,10 +111,6 @@ val pr_pconstructor : env -> evar_map -> pconstructor -> Pp.t
 
 (** Contexts *)
 
-(** Display compact contexts of goals (simple hyps on the same line) *)
-val set_compact_context : bool -> unit
-val get_compact_context : unit -> bool
-
 val pr_context_unlimited   : env -> evar_map -> Pp.t
 val pr_ne_context_of       : Pp.t -> env -> evar_map -> Pp.t
 

--- a/printing/printmod.ml
+++ b/printing/printmod.ml
@@ -179,7 +179,7 @@ let print_record env mind mib udecl =
   )
 
 let pr_mutual_inductive_body env mind mib udecl =
-  if mib.mind_record != NotRecord && not !Flags.raw_print then
+  if mib.mind_record != NotRecord && Printoptions.((get()).records) then
     print_record env mind mib udecl
   else
     print_mutual_inductive env mind mib udecl

--- a/stm/vernac_classifier.ml
+++ b/stm/vernac_classifier.ml
@@ -159,8 +159,6 @@ let classify_vernac e =
     | VernacUnsetOption _ | VernacSetOption _
     | VernacAddOption _ | VernacRemoveOption _
     | VernacMemOption _ | VernacPrintOption _
-    | VernacSetPrintingAll | VernacSetPrintingSugared
-    | VernacSetPrintingDefaults | VernacUnsetPrintingAll
     | VernacGlobalCheck _
     | VernacDeclareReduction _
     | VernacExistingClass _ | VernacExistingInstance _

--- a/stm/vernac_classifier.ml
+++ b/stm/vernac_classifier.ml
@@ -159,6 +159,8 @@ let classify_vernac e =
     | VernacUnsetOption _ | VernacSetOption _
     | VernacAddOption _ | VernacRemoveOption _
     | VernacMemOption _ | VernacPrintOption _
+    | VernacSetPrintingAll | VernacSetPrintingSugared
+    | VernacSetPrintingDefaults | VernacUnsetPrintingAll
     | VernacGlobalCheck _
     | VernacDeclareReduction _
     | VernacExistingClass _ | VernacExistingInstance _

--- a/test-suite/output/Cases.out
+++ b/test-suite/output/Cases.out
@@ -142,6 +142,7 @@ match x return nat with
 | Gt => O
 end
      : forall _ : comparison, nat
+(* {Top.68 Top.67 Top.66 Top.65} |=  *)
 fun x : K => match x with
              | a3 | a4 => 3
              | _ => 2

--- a/test-suite/output/Cases.v
+++ b/test-suite/output/Cases.v
@@ -209,10 +209,9 @@ Unset Printing Allow Match Default Clause.
 Check fun x => match x with Eq => 1 | _ => 0 end.
 Set Printing Allow Match Default Clause.
 
-(* No factorization in printing all mode *)
 Set Printing All.
 Check fun x => match x with Eq => 1 | _ => 0 end.
-Unset Printing All.
+Set Printing Defaults.
 
 (* Several clauses *)
 Inductive K := a1|a2|a3|a4|a5|a6.

--- a/test-suite/output/LocalPrinting.out
+++ b/test-suite/output/LocalPrinting.out
@@ -1,0 +1,140 @@
+foo = @id Set nat
+     : Set
+foo = id nat
+     : Set
+The possible use of "match" default pattern in printing mode is on
+The coercion printing mode is off
+The display compact goal contexts mode is off
+The printing of existential variable instances mode is off
+The factorization of "match" patterns in printing mode is on
+The implicit arguments printing mode is off
+The implicit arguments defensive printing mode is on
+The printing types of let-in binders mode is off
+The pattern-matching reversibility mode is on
+The notations printing mode is on
+The backwards-compatible printing of primitive projections mode is off
+The printing of primitive projection parameters mode is off
+The projection printing using dot notation mode is off
+The record printing mode is on
+The pattern matching return type synthesizability mode is on
+The printing of universes mode is off
+The forced wildcard mode is on
+The possible use of "match" default pattern in printing mode is off
+The coercion printing mode is on
+The display compact goal contexts mode is on
+The printing of existential variable instances mode is on
+The factorization of "match" patterns in printing mode is off
+The implicit arguments printing mode is on
+The implicit arguments defensive printing mode is on
+The printing types of let-in binders mode is on
+The pattern-matching reversibility mode is off
+The notations printing mode is off
+The backwards-compatible printing of primitive projections mode is on
+The printing of primitive projection parameters mode is on
+The projection printing using dot notation mode is off
+The record printing mode is off
+The pattern matching return type synthesizability mode is off
+The printing of universes mode is on
+The forced wildcard mode is off
+The possible use of "match" default pattern in printing mode is on
+The coercion printing mode is off
+The display compact goal contexts mode is off
+The printing of existential variable instances mode is off
+The factorization of "match" patterns in printing mode is on
+The implicit arguments printing mode is off
+The implicit arguments defensive printing mode is on
+The printing types of let-in binders mode is off
+The pattern-matching reversibility mode is on
+The notations printing mode is on
+The backwards-compatible printing of primitive projections mode is off
+The printing of primitive projection parameters mode is off
+The projection printing using dot notation mode is off
+The record printing mode is on
+The pattern matching return type synthesizability mode is on
+The printing of universes mode is off
+The forced wildcard mode is on
+The possible use of "match" default pattern in printing mode is on
+The coercion printing mode is off
+The display compact goal contexts mode is off
+The printing of existential variable instances mode is off
+The factorization of "match" patterns in printing mode is on
+The implicit arguments printing mode is off
+The implicit arguments defensive printing mode is off
+The printing types of let-in binders mode is off
+The pattern-matching reversibility mode is on
+The notations printing mode is on
+The backwards-compatible printing of primitive projections mode is off
+The printing of primitive projection parameters mode is off
+The projection printing using dot notation mode is on
+The record printing mode is on
+The pattern matching return type synthesizability mode is on
+The printing of universes mode is off
+The forced wildcard mode is on
+The possible use of "match" default pattern in printing mode is on
+The coercion printing mode is off
+The display compact goal contexts mode is off
+The printing of existential variable instances mode is off
+The factorization of "match" patterns in printing mode is on
+The implicit arguments printing mode is off
+The implicit arguments defensive printing mode is on
+The printing types of let-in binders mode is off
+The pattern-matching reversibility mode is on
+The notations printing mode is on
+The backwards-compatible printing of primitive projections mode is off
+The printing of primitive projection parameters mode is off
+The projection printing using dot notation mode is off
+The record printing mode is on
+The pattern matching return type synthesizability mode is on
+The printing of universes mode is off
+The forced wildcard mode is on
+The possible use of "match" default pattern in printing mode is off
+The coercion printing mode is on
+The display compact goal contexts mode is on
+The printing of existential variable instances mode is on
+The factorization of "match" patterns in printing mode is off
+The implicit arguments printing mode is on
+The implicit arguments defensive printing mode is on
+The printing types of let-in binders mode is on
+The pattern-matching reversibility mode is off
+The notations printing mode is off
+The backwards-compatible printing of primitive projections mode is on
+The printing of primitive projection parameters mode is on
+The projection printing using dot notation mode is off
+The record printing mode is off
+The pattern matching return type synthesizability mode is off
+The printing of universes mode is on
+The forced wildcard mode is off
+The possible use of "match" default pattern in printing mode is on
+The coercion printing mode is off
+The display compact goal contexts mode is off
+The printing of existential variable instances mode is off
+The factorization of "match" patterns in printing mode is on
+The implicit arguments printing mode is off
+The implicit arguments defensive printing mode is on
+The printing types of let-in binders mode is off
+The pattern-matching reversibility mode is on
+The notations printing mode is on
+The backwards-compatible printing of primitive projections mode is off
+The printing of primitive projection parameters mode is off
+The projection printing using dot notation mode is off
+The record printing mode is on
+The pattern matching return type synthesizability mode is on
+The printing of universes mode is off
+The forced wildcard mode is on
+The possible use of "match" default pattern in printing mode is off
+The coercion printing mode is on
+The display compact goal contexts mode is on
+The printing of existential variable instances mode is on
+The factorization of "match" patterns in printing mode is off
+The implicit arguments printing mode is on
+The implicit arguments defensive printing mode is on
+The printing types of let-in binders mode is on
+The pattern-matching reversibility mode is off
+The notations printing mode is off
+The backwards-compatible printing of primitive projections mode is on
+The printing of primitive projection parameters mode is on
+The projection printing using dot notation mode is off
+The record printing mode is off
+The pattern matching return type synthesizability mode is off
+The printing of universes mode is on
+The forced wildcard mode is off

--- a/test-suite/output/LocalPrinting.v
+++ b/test-suite/output/LocalPrinting.v
@@ -1,0 +1,169 @@
+(* tests of Local versions of Set Printing All/Sugared/Defaults *)
+
+(* an example use *)
+
+Section Example.
+  Local Set Printing All.
+  Definition foo := id nat.
+  Print foo.
+End Example.
+Print foo.
+
+(* the default printing options *)
+Test Printing Allow Match Default Clause.
+Test Printing Coercions.
+Test Printing Compact Contexts.
+Test Printing Existential Instances.
+Test Printing Factorizable Match Patterns.
+Test Printing Implicit.
+Test Printing Implicit Defensive.
+Test Printing Let Binder Types.
+Test Printing Matching.
+Test Printing Notations.
+Test Printing Primitive Projection Compatibility.
+Test Printing Primitive Projection Parameters.
+Test Printing Projections.
+Test Printing Records.
+Test Printing Synth.
+Test Printing Universes.
+Test Printing Wildcard.
+
+Section AllSection.
+  Local Set Printing All.
+  Test Printing Allow Match Default Clause.
+  Test Printing Coercions.
+  Test Printing Compact Contexts.
+  Test Printing Existential Instances.
+  Test Printing Factorizable Match Patterns.
+  Test Printing Implicit.
+  Test Printing Implicit Defensive.
+  Test Printing Let Binder Types.
+  Test Printing Matching.
+  Test Printing Notations.
+  Test Printing Primitive Projection Compatibility.
+  Test Printing Primitive Projection Parameters.
+  Test Printing Projections.
+  Test Printing Records.
+  Test Printing Synth.
+  Test Printing Universes.
+  Test Printing Wildcard.
+End AllSection.
+
+(* should see defaults agains *)
+Test Printing Allow Match Default Clause.
+Test Printing Coercions.
+Test Printing Compact Contexts.
+Test Printing Existential Instances.
+Test Printing Factorizable Match Patterns.
+Test Printing Implicit.
+Test Printing Implicit Defensive.
+Test Printing Let Binder Types.
+Test Printing Matching.
+Test Printing Notations.
+Test Printing Primitive Projection Compatibility.
+Test Printing Primitive Projection Parameters.
+Test Printing Projections.
+Test Printing Records.
+Test Printing Synth.
+Test Printing Universes.
+Test Printing Wildcard.
+
+Section SugaredSection.
+  Local Set Printing Sugared.
+  Test Printing Allow Match Default Clause.
+  Test Printing Coercions.
+  Test Printing Compact Contexts.
+  Test Printing Existential Instances.
+  Test Printing Factorizable Match Patterns.
+  Test Printing Implicit.
+  Test Printing Implicit Defensive.
+  Test Printing Let Binder Types.
+  Test Printing Matching.
+  Test Printing Notations.
+  Test Printing Primitive Projection Compatibility.
+  Test Printing Primitive Projection Parameters.
+  Test Printing Projections.
+  Test Printing Records.
+  Test Printing Synth.
+  Test Printing Universes.
+  Test Printing Wildcard.
+End SugaredSection.
+
+(* should see defaults another time *)
+Test Printing Allow Match Default Clause.
+Test Printing Coercions.
+Test Printing Compact Contexts.
+Test Printing Existential Instances.
+Test Printing Factorizable Match Patterns.
+Test Printing Implicit.
+Test Printing Implicit Defensive.
+Test Printing Let Binder Types.
+Test Printing Matching.
+Test Printing Notations.
+Test Printing Primitive Projection Compatibility.
+Test Printing Primitive Projection Parameters.
+Test Printing Projections.
+Test Printing Records.
+Test Printing Synth.
+Test Printing Universes.
+Test Printing Wildcard.
+
+(* should see All options here *)
+Set Printing All.
+Test Printing Allow Match Default Clause.
+Test Printing Coercions.
+Test Printing Compact Contexts.
+Test Printing Existential Instances.
+Test Printing Factorizable Match Patterns.
+Test Printing Implicit.
+Test Printing Implicit Defensive.
+Test Printing Let Binder Types.
+Test Printing Matching.
+Test Printing Notations.
+Test Printing Primitive Projection Compatibility.
+Test Printing Primitive Projection Parameters.
+Test Printing Projections.
+Test Printing Records.
+Test Printing Synth.
+Test Printing Universes.
+Test Printing Wildcard.
+
+Section DefaultsSection.
+  Local Set Printing Defaults.
+  Test Printing Allow Match Default Clause.
+  Test Printing Coercions.
+  Test Printing Compact Contexts.
+  Test Printing Existential Instances.
+  Test Printing Factorizable Match Patterns.
+  Test Printing Implicit.
+  Test Printing Implicit Defensive.
+  Test Printing Let Binder Types.
+  Test Printing Matching.
+  Test Printing Notations.
+  Test Printing Primitive Projection Compatibility.
+  Test Printing Primitive Projection Parameters.
+  Test Printing Projections.
+  Test Printing Records.
+  Test Printing Synth.
+  Test Printing Universes.
+  Test Printing Wildcard.
+End DefaultsSection.
+
+(* should see All options again *)
+Test Printing Allow Match Default Clause.
+Test Printing Coercions.
+Test Printing Compact Contexts.
+Test Printing Existential Instances.
+Test Printing Factorizable Match Patterns.
+Test Printing Implicit.
+Test Printing Implicit Defensive.
+Test Printing Let Binder Types.
+Test Printing Matching.
+Test Printing Notations.
+Test Printing Primitive Projection Compatibility.
+Test Printing Primitive Projection Parameters.
+Test Printing Projections.
+Test Printing Records.
+Test Printing Synth.
+Test Printing Universes.
+Test Printing Wildcard.

--- a/test-suite/output/PrintingVernacs.out
+++ b/test-suite/output/PrintingVernacs.out
@@ -1,0 +1,5 @@
+The implicit arguments printing mode is on
+The implicit arguments printing mode is off
+File "stdin", line 13, characters 0-19:
+Warning: Unset Printing All here has no effect.
+[noop-unset-printing-all,vernacular]

--- a/test-suite/output/PrintingVernacs.out
+++ b/test-suite/output/PrintingVernacs.out
@@ -1,5 +1,5 @@
 The implicit arguments printing mode is on
 The implicit arguments printing mode is off
 File "stdin", line 13, characters 0-19:
-Warning: Unset Printing All here has no effect.
-[noop-unset-printing-all,vernacular]
+Warning: Unset Printing here has no effect.
+[noop-unset-printing,vernacular]

--- a/test-suite/output/PrintingVernacs.v
+++ b/test-suite/output/PrintingVernacs.v
@@ -1,0 +1,13 @@
+(* these should succeed, no warning printed *)
+
+Set Printing All.
+Set Printing Sugared.
+Set Printing Defaults.
+
+Set Printing All.
+Test Printing Implicit. (* on *)
+
+Unset Printing All.
+Test Printing Implicit. (* off *)
+
+Unset Printing All. (* warning *)

--- a/test-suite/output/bug6560.out
+++ b/test-suite/output/bug6560.out
@@ -1,0 +1,2 @@
+The implicit arguments printing mode is on
+The implicit arguments printing mode is off

--- a/test-suite/output/bug6560.v
+++ b/test-suite/output/bug6560.v
@@ -1,0 +1,7 @@
+(* Unset Printing Implicit should disable printing of implicits after Set Printing All *)
+
+Set Printing All.
+Test Printing Implicit.
+
+Unset Printing Implicit.
+Test Printing Implicit.

--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -263,6 +263,7 @@ let coqtop_toplevel =
   }
 
 let start_coq custom =
+<<<<<<< HEAD
   let init_feeder = Feedback.add_feeder Coqloop.coqloop_feed in
   (* Init phase *)
   let state, opts =
@@ -284,3 +285,21 @@ let start_coq custom =
   Feedback.del_feeder init_feeder;
   if not opts.batch then custom.run ~opts ~state;
   exit 0
+=======
+  match init_toplevel custom.init (List.tl (Array.to_list Sys.argv)) with
+  (* Batch mode *)
+  | Some state, opts when not opts.batch_mode ->
+    custom.run ~opts ~state;
+    exit 1
+  | _ , opts ->
+    flush_all();
+    if opts.output_context then begin
+      let sigma, env = Pfedit.get_current_context () in
+      let open Printoptions in
+      Feedback.msg_notice
+        ((with_printing_option (fun _ -> all_options)
+            (Prettyp.print_full_pure_context env) sigma) ++ fnl ())
+      end;
+    CProfile.print_profile ();
+    exit 0
+>>>>>>> [printing] Collect Printing Options in a record (c.f. #6560)

--- a/vernac/explainErr.ml
+++ b/vernac/explainErr.ml
@@ -50,9 +50,9 @@ let wrap_vernac_error (exn, info) strm = (EvaluatedError (strm, None), info)
 
 let process_vernac_interp_error exn = match fst exn with
   | Univ.UniverseInconsistency i ->
-    let msg =
-      if !Constrextern.print_universes then
-	str "." ++ spc() ++ 
+     let msg =
+       if Printoptions.((get()).universes) then
+        str "." ++ spc() ++
           Univ.explain_universe_inconsistency UnivNames.pr_with_global_universes i
       else
 	mt() in

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -947,21 +947,8 @@ GRAMMAR EXTEND Gram
       | "Set"; table = option_table; v = option_value ->
           { VernacSetOption (false, table, v) }
 
-      | "Set"; table = option_table ->
-          { begin match table with
-            | ["Printing";"All"]      -> VernacSetPrintingAll
-            | ["Printing";"Sugared"]  -> VernacSetPrintingSugared
-            | ["Printing";"Defaults"] -> VernacSetPrintingDefaults
-            | _                       -> VernacSetOption (false,table,BoolValue true)
-            end
-          }
-
       | IDENT "Unset"; table = option_table ->
-         { begin match table with
-           | ["Printing";"All"] -> VernacUnsetPrintingAll
-           | _                  -> VernacUnsetOption (false,table)
-           end
-         }
+          { VernacUnsetOption (false,table) }
 
       | IDENT "Print"; IDENT "Table"; table = option_table ->
 	  { VernacPrintOption table }

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -946,8 +946,22 @@ GRAMMAR EXTEND Gram
       (* For acting on parameter tables *)
       | "Set"; table = option_table; v = option_value ->
           { VernacSetOption (false, table, v) }
+
+      | "Set"; table = option_table ->
+          { begin match table with
+            | ["Printing";"All"]      -> VernacSetPrintingAll
+            | ["Printing";"Sugared"]  -> VernacSetPrintingSugared
+            | ["Printing";"Defaults"] -> VernacSetPrintingDefaults
+            | _                       -> VernacSetOption (false,table,BoolValue true)
+            end
+          }
+
       | IDENT "Unset"; table = option_table ->
-          { VernacUnsetOption (false, table) }
+         { begin match table with
+           | ["Printing";"All"] -> VernacUnsetPrintingAll
+           | _                  -> VernacUnsetOption (false,table)
+           end
+         }
 
       | IDENT "Print"; IDENT "Table"; table = option_table ->
 	  { VernacPrintOption table }
@@ -963,6 +977,7 @@ GRAMMAR EXTEND Gram
 
       | IDENT "Test"; table = option_table; "for"; v = LIST1 option_ref_value
         -> { VernacMemOption (table, v) }
+
       | IDENT "Test"; table = option_table ->
           { VernacPrintOption table }
 

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -111,13 +111,13 @@ let canonize_constr sigma c =
   canonize_binders c
 
 (** Tries to realize when the two terms, albeit different are printed the same. *)
-let display_eq ~flags env sigma t1 t2 =
+let display_eq ~pr_opts env sigma t1 t2 =
   (* terms are canonized, then their externalisation is compared syntactically *)
   let open Constrextern in
   let t1 = canonize_constr sigma t1 in
   let t2 = canonize_constr sigma t2 in
-  let ct1 = Flags.with_options flags (fun () -> extern_constr false env sigma t1) () in
-  let ct2 = Flags.with_options flags (fun () -> extern_constr false env sigma t2) () in
+  let ct1 = Printoptions.with_printing_option pr_opts (fun () -> extern_constr false env sigma t1) () in
+  let ct2 = Printoptions.with_printing_option pr_opts (fun () -> extern_constr false env sigma t2) () in
   Constrexpr_ops.constr_expr_eq ct1 ct2
 
 (** This function adds some explicit printing flags if the two arguments are
@@ -126,20 +126,20 @@ let rec pr_explicit_aux env sigma t1 t2 = function
 | [] ->
   (* no specified flags: default. *)
   (quote (Printer.pr_leconstr_env env sigma t1), quote (Printer.pr_leconstr_env env sigma t2))
-| flags :: rem ->
-  let equal = display_eq ~flags env sigma t1 t2 in
+| pr_opts :: rem ->
+  let equal = display_eq ~pr_opts env sigma t1 t2 in
   if equal then
     (* The two terms are the same from the user point of view *)
     pr_explicit_aux env sigma t1 t2 rem
   else
     let open Constrextern in
-    let ct1 = Flags.with_options flags (fun () -> extern_constr false env sigma t1) ()
-    in
-    let ct2 = Flags.with_options flags (fun () -> extern_constr false env sigma t2) ()
-    in
+    let open Printoptions in
+    let ct1 = with_printing_option pr_opts (fun () -> extern_constr false env sigma t1) () in
+    let ct2 = with_printing_option pr_opts (fun () -> extern_constr false env sigma t2) () in
     quote (Ppconstr.pr_lconstr_expr ct1), quote (Ppconstr.pr_lconstr_expr ct2)
 
 let explicit_flags =
+<<<<<<< HEAD
   let open Constrextern in
   [ []; (* First, try with the current flags *)
     [print_implicits]; (* Then with implicit *)
@@ -147,6 +147,21 @@ let explicit_flags =
     [print_universes; print_implicits]; (* With universes AND implicits *)
     [print_implicits; print_coercions; print_no_symbol]; (* Then more! *)
     [print_universes; print_implicits; print_coercions; print_no_symbol] (* and more! *) ]
+=======
+  let open Printoptions in
+  let print_id opts = opts in
+  let print_implicits opts = { opts with implicit = true } in
+  let print_universes opts = { opts with universes = true } in
+  let print_coercions opts = { opts with coercions = true } in
+  let print_no_symbol opts = { opts with notations = false } in
+  let (<<) f g x = f (g x) in
+  [ print_id; (** First, try with the current printing options *)
+    print_implicits; (** Then with implicits *)
+    print_universes; (** Then with universes *)
+    print_universes << print_implicits; (** With universes AND implicits *)
+    print_implicits << print_coercions << print_no_symbol; (** Then more! *)
+    print_universes << print_implicits << print_coercions << print_no_symbol (** and more! *) ]
+>>>>>>> [printing] Collect Printing Options in a record (c.f. #6560)
 
 let pr_explicit env sigma t1 t2 =
   pr_explicit_aux env sigma t1 t2 explicit_flags
@@ -305,7 +320,7 @@ let explain_unification_error env sigma p1 p2 = function
         strbrk ": cannot ensure that " ++
         t ++ strbrk " is a subtype of " ++ u]
      | UnifUnivInconsistency p ->
-        if !Constrextern.print_universes then
+        if Printoptions.((get()).universes) then
 	  [str "universe inconsistency: " ++
           Univ.explain_universe_inconsistency UnivNames.pr_with_global_universes p]
 	else

--- a/vernac/locality.ml
+++ b/vernac/locality.ml
@@ -11,7 +11,6 @@
 open Decl_kinds
 
 (** * Managing locality *)
-
 let local_of_bool = function
   | true -> Local
   | false -> Global

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -1000,24 +1000,6 @@ open Pputils
       | VernacChdir s ->
         return (keyword "Cd" ++ pr_opt qs s)
 
-      (* Printing categories *)
-      | VernacSetPrintingAll ->
-         return (
-             keyword "Set Printing All"
-           )
-      | VernacSetPrintingSugared ->
-         return (
-             keyword "Set Printing Sugared"
-           )
-      | VernacSetPrintingDefaults ->
-         return (
-             keyword "Set Printing Defaults"
-           )
-      | VernacUnsetPrintingAll ->
-         return (
-             keyword "Unset Printing All"
-           )
-
       (* Commands *)
       | VernacCreateHintDb (dbname,b) ->
         return (

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -1000,6 +1000,24 @@ open Pputils
       | VernacChdir s ->
         return (keyword "Cd" ++ pr_opt qs s)
 
+      (* Printing categories *)
+      | VernacSetPrintingAll ->
+         return (
+             keyword "Set Printing All"
+           )
+      | VernacSetPrintingSugared ->
+         return (
+             keyword "Set Printing Sugared"
+           )
+      | VernacSetPrintingDefaults ->
+         return (
+             keyword "Set Printing Defaults"
+           )
+      | VernacUnsetPrintingAll ->
+         return (
+             keyword "Unset Printing All"
+           )
+
       (* Commands *)
       | VernacCreateHintDb (dbname,b) ->
         return (

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1512,61 +1512,70 @@ let () =
       optread  = Impargs.is_maximal_implicit_args;
       optwrite = Impargs.make_maximal_implicit_args }
 
+let pr_get f () = f (Printoptions.get ())
+let pr_set f v  = Printoptions.(set (f (get ()) v))
 let () =
   declare_bool_option
     { optdepr  = false;
       optname  = "coercion printing";
       optkey   = ["Printing";"Coercions"];
-      optread  = (fun () -> !Constrextern.print_coercions);
-      optwrite = (fun b ->  Constrextern.print_coercions := b) }
+      optread  = pr_get (fun r -> r.Printoptions.coercions);
+      optwrite = pr_set (fun r v -> { r with Printoptions.coercions = v });
+    }
 
 let () =
   declare_bool_option
     { optdepr  = false;
       optname  = "printing of existential variable instances";
       optkey   = ["Printing";"Existential";"Instances"];
-      optread  = (fun () -> !Detyping.print_evar_arguments);
-      optwrite = (:=) Detyping.print_evar_arguments }
+      optread  = pr_get (fun r -> r.Printoptions.existential_instances);
+      optwrite = pr_set (fun r v -> { r with Printoptions.existential_instances = v});
+    }
 
 let () =
   declare_bool_option
     { optdepr  = false;
       optname  = "implicit arguments printing";
       optkey   = ["Printing";"Implicit"];
-      optread  = (fun () -> !Constrextern.print_implicits);
-      optwrite = (fun b ->  Constrextern.print_implicits := b) }
+      optread  = pr_get (fun r -> r.Printoptions.implicit);
+      optwrite = pr_set (fun r v -> { r with Printoptions.implicit = v });
+    }
 
 let () =
   declare_bool_option
     { optdepr  = false;
       optname  = "implicit arguments defensive printing";
       optkey   = ["Printing";"Implicit";"Defensive"];
-      optread  = (fun () -> !Constrextern.print_implicits_defensive);
-      optwrite = (fun b ->  Constrextern.print_implicits_defensive := b) }
+      optread  = pr_get (fun r -> r.Printoptions.implicit_defensive);
+      optwrite = pr_set (fun r v -> { r with Printoptions.implicit_defensive = v });
+    }
+
+let () =
+  declare_bool_option
+    { optdepr  = false;
+      optname  = "printing types of let-in binders";
+      optkey   = ["Printing";"Let";"Binder";"Types"];
+      optread  = pr_get (fun r -> r.Printoptions.let_binder_types);
+      optwrite = pr_set (fun r v -> { r with Printoptions.let_binder_types = v });
+    }
 
 let () =
   declare_bool_option
     { optdepr  = false;
       optname  = "projection printing using dot notation";
       optkey   = ["Printing";"Projections"];
-      optread  = (fun () -> !Constrextern.print_projections);
-      optwrite = (fun b ->  Constrextern.print_projections := b) }
+      optread  = pr_get (fun r -> r.Printoptions.projections);
+      optwrite = pr_set (fun r v -> { r with Printoptions.projections = v });
+    }
 
 let () =
   declare_bool_option
     { optdepr  = false;
       optname  = "notations printing";
       optkey   = ["Printing";"Notations"];
-      optread  = (fun () -> not !Constrextern.print_no_symbol);
-      optwrite = (fun b ->  Constrextern.print_no_symbol := not b) }
-
-let () =
-  declare_bool_option
-    { optdepr  = false;
-      optname  = "raw printing";
-      optkey   = ["Printing";"All"];
-      optread  = (fun () -> !Flags.raw_print);
-      optwrite = (fun b -> Flags.raw_print := b) }
+      optread  = pr_get (fun r -> r.Printoptions.notations);
+      optwrite = pr_set (fun r v -> { r with Printoptions.notations = v });
+    }
 
 let () =
   declare_int_option
@@ -1591,8 +1600,9 @@ let () =
     { optdepr  = false;
       optname  = "display compact goal contexts";
       optkey   = ["Printing";"Compact";"Contexts"];
-      optread  = (fun () -> Printer.get_compact_context());
-      optwrite = (fun b -> Printer.set_compact_context b) }
+      optread  = pr_get (fun r -> r.Printoptions.compact_contexts);
+      optwrite = pr_set (fun r v -> { r with Printoptions.compact_contexts = v });
+    }
 
 let () =
   declare_int_option
@@ -1615,8 +1625,9 @@ let () =
     { optdepr  = false;
       optname  = "printing of universes";
       optkey   = ["Printing";"Universes"];
-      optread  = (fun () -> !Constrextern.print_universes);
-      optwrite = (fun b -> Constrextern.print_universes:=b) }
+      optread  = pr_get (fun r -> r.Printoptions.universes);
+      optwrite = pr_set (fun r v -> { r with Printoptions.universes = v });
+    }
 
 let () =
   declare_bool_option
@@ -2272,6 +2283,15 @@ let interp ?proof ~atts ~st c =
   | VernacAddMLPath (isrec,s) -> unsupported_attributes atts; vernac_add_ml_path isrec s
   | VernacDeclareMLModule l -> with_locality ~atts vernac_declare_ml_module l
   | VernacChdir s -> unsupported_attributes atts; vernac_chdir s
+
+  (* Printing categories *)
+  | VernacSetPrintingAll ->
+    with_locality ~atts (fun ~local -> let local = Locality.make_locality local in Printoptions.set_printing_all ~local)
+  | VernacSetPrintingSugared ->
+    with_locality ~atts (fun ~local -> let local = Locality.make_locality local in Printoptions.set_printing_sugared ~local)
+  | VernacSetPrintingDefaults ->
+    with_locality ~atts (fun ~local -> let local = Locality.make_locality local in Printoptions.set_printing_defaults ~local)
+  | VernacUnsetPrintingAll -> Printoptions.unset_printing_all ()
 
   (* State management *)
   | VernacWriteState s -> unsupported_attributes atts; vernac_write_state s

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -347,12 +347,6 @@ type nonrec vernac_expr =
   | VernacBack of int
   | VernacBackTo of int
 
-  (* Printing categories *)
-  | VernacSetPrintingAll
-  | VernacSetPrintingSugared
-  | VernacSetPrintingDefaults
-  | VernacUnsetPrintingAll
-
   (* Commands *)
   | VernacCreateHintDb of string * bool
   | VernacRemoveHints of string list * qualid list

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -347,6 +347,12 @@ type nonrec vernac_expr =
   | VernacBack of int
   | VernacBackTo of int
 
+  (* Printing categories *)
+  | VernacSetPrintingAll
+  | VernacSetPrintingSugared
+  | VernacSetPrintingDefaults
+  | VernacUnsetPrintingAll
+
   (* Commands *)
   | VernacCreateHintDb of string * bool
   | VernacRemoveHints of string list * qualid list


### PR DESCRIPTION
This PR was originally written by Paul Steckler (#6698), and updated,
rebased, and modified by me and others.

The main changes are the placement of all printing options in a
centralized record, thus the printing state is accessible in a more
convenient place. See CHANGES for printing semantic changes.

The most important change is that `Set Printing All` is not an ad-hoc
operation anymore, but just setting all options to "display".

There remain some important TODOs, apart from code review:

- Update the reference manual, diff in `pending_refman_update.diff`.
- Check IDE changes by an expert.

Co-authored-by: Paul Steckler <steck@stecksoft.com>
