### PR TITLE
[ci] Add aac-tactics.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -346,6 +346,9 @@ validate:edge+flambda:
     OPAM_SWITCH: edge
     OPAM_VARIANT: "+flambda"
 
+ci-aac-tactics:
+  <<: *ci-template
+
 ci-bedrock2:
   <<: *ci-template
 

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -8,7 +8,9 @@
 ##         #     (see LICENSE file for the text of the license)         ##
 ##########################################################################
 
-CI_TARGETS=ci-bedrock2 \
+CI_TARGETS= \
+    ci-aac-tactics \
+    ci-bedrock2 \
     ci-bignums \
     ci-color \
     ci-compcert \

--- a/dev/build/windows/makecoq_mingw.sh
+++ b/dev/build/windows/makecoq_mingw.sh
@@ -1851,7 +1851,7 @@ function make_addon_coquelicot {
 
 function make_addon_aactactics {
   installer_addon_dependency aac
-  if build_prep_overlay aactactis; then
+  if build_prep_overlay aactactics; then
     installer_addon_section aac "AAC" "Coq plugin for extensible associative and commutative rewriting" ""
     log1 make
     log2 make install

--- a/dev/ci/ci-aac-tactics.sh
+++ b/dev/ci/ci-aac-tactics.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+ci_dir="$(dirname "$0")"
+. "${ci_dir}/ci-common.sh"
+
+git_download aactactics
+
+( cd "${CI_BUILD_DIR}/aactactics" && make && make install )

--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -252,6 +252,6 @@
 ########################################################################
 # aac-tactics
 ########################################################################
-: "${aactactis_CI_REF:=master}"
-: "${aactactis_CI_GITURL:=https://github.com/coq-community/aac-tactics}"
-: "${aactactis_CI_ARCHIVEURL:=${aactactis_CI_GITURL}/archive}"
+: "${aactactics_CI_REF:=master}"
+: "${aactactics_CI_GITURL:=https://github.com/coq-community/aac-tactics}"
+: "${aactactics_CI_ARCHIVEURL:=${aactactics_CI_GITURL}/archive}"


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** infrastructure.

aac-tactics is compatible again with Coq master.

Note: we do not add anything to `dev/ci/ci-basic-overlay.sh` because the required variables were already defined there.

cc @MSoegtropIMC: you might want to reactivate the building of this plugin as part of the Windows package builds.