### PR TITLE
[dune] Fix bad interaction among PR #8627 and #8657

### DIFF
--- a/dune
+++ b/dune
@@ -18,6 +18,7 @@
 
 (install
  (section lib)
+ (package coq)
  (files
    revision))
 


### PR DESCRIPTION
Dangers of not stacking PRs hit again, and here we hit a problem
breaking the build on master due to #8627 adding a new file to install
with for the (implicit) `coq` package and #8657 removing the implicit
status of such package.
