### PR TITLE
Check that lambda/prod ast's have proper binders during interning/printing

### DIFF
--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -1863,12 +1863,11 @@ let internalize globalenv env pattern_mode (_, ntnvars as lvar) c =
               Array.map (fun (bl,_,_) -> bl) idl,
               Array.map (fun (_,ty,_) -> ty) idl,
               Array.map (fun (_,_,bd) -> bd) idl)
+    | CProdN ([],c2) -> anomaly (Pp.str "The AST is malformed, found prod without binders.")
     | CProdN (bl,c2) ->
         let (env',bl) = List.fold_left intern_local_binder (env,[]) bl in
         expand_binders ?loc mkGProd bl (intern_type env' c2)
-    | CLambdaN ([],c2) ->
-        (* Such a term is built sometimes: it should not change scope *)
-        intern env c2
+    | CLambdaN ([],c2) -> anomaly (Pp.str "The AST is malformed, found lambda without binders.")
     | CLambdaN (bl,c2) ->
         let (env',bl) = List.fold_left intern_local_binder (reset_tmp_scope env,[]) bl in
         expand_binders ?loc mkGLambda bl (intern env' c2)

--- a/printing/ppconstr.ml
+++ b/printing/ppconstr.ml
@@ -394,7 +394,7 @@ let tag_var = tag Tag.variable
         kw n ++ pr_binder false pr_c (nal,k,t)
       | (CLocalAssum _ | CLocalPattern _ | CLocalDef _) :: _ as bdl ->
         kw n ++ pr_undelimited_binders sep pr_c bdl
-      | [] -> assert false
+      | [] -> anomaly (Pp.str "The ast is malformed, found lambda/prod without proper binders.")
 
   let pr_binders_gen pr_c sep is_open =
     if is_open then pr_delimited_binders pr_com_at sep pr_c


### PR DESCRIPTION
**Kind:** internal invariants

This is the part of #8490 which ensures stronger interning invariants on the form of Lambda/Prod AST, and reports a more meaningful error on the invariant not satisfied at printing.

I don't have a strong opinion on the Constrintern part (it seems better, but I don't know if plugins around enforce the invariant). The Ppconstr part is an improvement though. @ejgallego, are you ok?