### PR TITLE
A few useless accesses to the global environment in pretyping and engine

### DIFF
--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -579,7 +579,7 @@ let rec check_and_clear_in_constr env evdref err ids global c =
                      has dependencies in another hyp of the context of ev
                      and transitively remember the dependency *)
                     let check id _ =
-                      if occur_var_in_decl (Global.env ()) !evdref id h
+                      if occur_var_in_decl env !evdref id h
                       then raise (Depends id)
                     in
                     let () = Id.Map.iter check ri in

--- a/engine/termops.ml
+++ b/engine/termops.ml
@@ -963,7 +963,7 @@ let collect_vars sigma c =
 
 let vars_of_global_reference env gr =
   let c, _ = Global.constr_of_global_in_context env gr in
-  vars_of_global (Global.env ()) c
+  vars_of_global env c
 
 (* Tests whether [m] is a subterm of [t]:
    [m] is appropriately lifted through abstractions of [t] *)

--- a/pretyping/cases.ml
+++ b/pretyping/cases.ml
@@ -994,8 +994,8 @@ let expand_arg tms (p,ccl) ((_,t),_,na) =
   let k = length_of_tomatch_type_sign na t in
   (p+k,liftn_predicate (k-1) (p+1) ccl tms)
 
-let use_unit_judge evd =
-  let j, ctx = coq_unit_judge () in
+let use_unit_judge env evd =
+  let j, ctx = coq_unit_judge !!env in
   let evd' = Evd.merge_context_set Evd.univ_flexible_alg evd ctx in
     evd', j
 
@@ -1024,7 +1024,7 @@ let adjust_impossible_cases sigma pb pred tomatch submat =
     | Evar (evk,_) when snd (evar_source evk sigma) == Evar_kinds.ImpossibleCase ->
         let sigma =
           if not (Evd.is_defined sigma evk) then
-            let sigma, default = use_unit_judge sigma in
+            let sigma, default = use_unit_judge pb.env sigma in
             let sigma = Evd.define evk default.uj_type sigma in
             sigma
           else sigma
@@ -2512,7 +2512,7 @@ let compile_program_cases ?loc style (typing_function, sigma) tycon env
     (predopt, tomatchl, eqns) =
   let typing_fun tycon env sigma = function
     | Some t ->	typing_function tycon env sigma t
-    | None -> use_unit_judge sigma in
+    | None -> use_unit_judge env sigma in
 
   (* We build the matrix of patterns and right-hand side *)
   let matx = matx_of_eqns env eqns in
@@ -2593,7 +2593,7 @@ let compile_program_cases ?loc style (typing_function, sigma) tycon env
     
   let typing_function tycon env sigma = function
     | Some t -> typing_function tycon env sigma t
-    | None -> use_unit_judge sigma in
+    | None -> use_unit_judge env sigma in
 
   let pb =
     { env      = env;
@@ -2668,7 +2668,7 @@ let compile_cases ?loc style (typing_fun, sigma) tycon env (predopt, tomatchl, e
     (* A typing function that provides with a canonical term for absurd cases*)
     let typing_fun tycon env sigma = function
     | Some t -> typing_fun tycon env sigma t
-    | None -> use_unit_judge sigma in
+    | None -> use_unit_judge env sigma in
 
     let pb =
       { env       = env;

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -647,6 +647,7 @@ and detype_r d flags avoid env sigma t =
         else
 	  GEvar (Id.of_string_soft ("M" ^ string_of_int n), [])
     | Var id ->
+        (* Discriminate between section variable and non-section variable *)
 	(try let _ = Global.lookup_named id in GRef (VarRef id, None)
 	 with Not_found -> GVar id)
     | Sort s -> GSort (detype_sort sigma (ESorts.kind sigma s))

--- a/pretyping/evarconv.mli
+++ b/pretyping/evarconv.mli
@@ -80,4 +80,4 @@ val evar_eqappr_x : ?rhs_is_already_stuck:bool -> transparent_state * bool ->
 (**/**)
 
 (** {6 Functions to deal with impossible cases } *)
-val coq_unit_judge : unit -> EConstr.unsafe_judgment Univ.in_universe_context_set
+val coq_unit_judge : env -> EConstr.unsafe_judgment Univ.in_universe_context_set

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -1417,7 +1417,7 @@ let w_merge env with_types flags (evd,metas,evars : subst0) =
 	      
   and mimick_undefined_evar evd flags hdc nargs sp =
     let ev = Evd.find_undefined evd sp in
-    let sp_env = Global.env_of_context (evar_filtered_hyps ev) in
+    let sp_env = reset_with_named_context (evar_filtered_hyps ev) env in
     let (evd', c) = applyHead sp_env evd nargs hdc in
     let (evd'',mc,ec) =
       unify_0 sp_env evd' CUMUL flags
@@ -1633,7 +1633,7 @@ let make_eq_test env evd c =
 let make_abstraction_core name (test,out) env sigma c ty occs check_occs concl =
   let id =
     let t = match ty with Some t -> t | None -> get_type_of env sigma c in
-    let x = id_of_name_using_hdchar (Global.env()) sigma t name in
+    let x = id_of_name_using_hdchar env sigma t name in
     let ids = Environ.ids_of_named_context_val (named_context_val env) in
     if name == Anonymous then next_ident_away_in_goal x ids else
     if mem_named_context_val x (named_context_val env) then

--- a/proofs/logic.ml
+++ b/proofs/logic.ml
@@ -230,8 +230,7 @@ let hyp_of_move_location = function
   | MoveBefore id -> id
   | _ -> assert false
 
-let move_hyp sigma toleft (left,declfrom,right) hto =
-  let env = Global.env() in
+let move_hyp env sigma toleft (left,declfrom,right) hto =
   let test_dep d d2 =
     if toleft
     then occur_var_in_decl env sigma (NamedDecl.get_id d2) d
@@ -280,11 +279,11 @@ let move_hyp_in_named_context env sigma hfrom hto sign =
   let open EConstr in
   let (left,right,declfrom,toleft) =
     split_sign env sigma hfrom hto (named_context_of_val sign) in
-  move_hyp sigma toleft (left,declfrom,right) hto
+  move_hyp env sigma toleft (left,declfrom,right) hto
 
-let insert_decl_in_named_context sigma decl hto sign =
+let insert_decl_in_named_context env sigma decl hto sign =
   let open EConstr in
-  move_hyp sigma false ([],decl,named_context_of_val sign) hto
+  move_hyp env sigma false ([],decl,named_context_of_val sign) hto
 
 (**********************************************************************)
 

--- a/proofs/logic.mli
+++ b/proofs/logic.mli
@@ -75,6 +75,6 @@ val convert_hyp : bool -> Environ.named_context_val -> evar_map ->
 val move_hyp_in_named_context : Environ.env -> Evd.evar_map -> Id.t -> Id.t move_location ->
   Environ.named_context_val -> Environ.named_context_val
 
-val insert_decl_in_named_context : Evd.evar_map ->
+val insert_decl_in_named_context : Environ.env -> Evd.evar_map ->
   EConstr.named_declaration -> Id.t move_location ->
   Environ.named_context_val -> Environ.named_context_val

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -451,7 +451,7 @@ let internal_cut_gen ?(check=true) dir replace id t =
       if replace then
         let nexthyp = get_next_hyp_position env sigma id (named_context_of_val sign) in
         let sigma,sign',t,concl = clear_hyps2 env sigma (Id.Set.singleton id) sign t concl in
-        let sign' = insert_decl_in_named_context sigma (LocalAssum (id,t)) nexthyp sign' in
+        let sign' = insert_decl_in_named_context env sigma (LocalAssum (id,t)) nexthyp sign' in
         sign',t,concl,sigma
       else
         (if check && mem_named_context_val id sign then


### PR DESCRIPTION
**Kind:** architecture

This is a short PR to remove in `pretyping` and `engine` a couple of lookups in the global environement which could be done instead in an environment easily available.

----

Going further is not easy. The remaining accesses to the `Global.env` are difficult to remove.

- Several of them are done in the scope of an `add_anonymous_leaf` and thus require to change the interface of `declare_object`. This is the case in `recordops.ml`, `typeclasses.ml`, `classops.ml`, `heads.ml`.

- `Evarutil.new_global`: question to universe expert, would it be correct to pass it the env known by the caller, or does it have to be _the_ global environment?
- `Evd.evar_env`, `Evd.evar_filtered_env`, `Termops.pr_evar_suggested_name`: simplest solution seems to keep a copy of the `env` in the `evar_map` (w/o rels nor named variable)??
- `Global.lookup_named` in `Detyping.detype`: needs a way to distinguish section variables from other named variables in an env...
