### PR TITLE
Adding a functional version of constant- and mind_of_delta_kn + functional version of is_polymorphic

### DIFF
--- a/kernel/environ.ml
+++ b/kernel/environ.ml
@@ -680,6 +680,16 @@ let remove_hyps ids check_context check_value ctxt =
   in
   fst (remove_hyps ctxt)
 
+(* A general request *)
+
+let is_polymorphic env r =
+  let open Names.GlobRef in
+  match r with
+  | VarRef _id -> false
+  | ConstRef c -> polymorphic_constant c env
+  | IndRef ind -> polymorphic_ind ind env
+  | ConstructRef cstr -> polymorphic_ind (inductive_of_constructor cstr) env
+
 (*spiwack: the following functions assemble the pieces of the retroknowledge
    note that the "consistent" register function is available in the module
    Safetyping, Environ only synchronizes the proactive and the reactive parts*)

--- a/kernel/environ.mli
+++ b/kernel/environ.mli
@@ -315,7 +315,7 @@ val apply_to_hyp : named_context_val -> variable ->
 
 val remove_hyps : Id.Set.t -> (Constr.named_declaration -> Constr.named_declaration) -> (lazy_val -> lazy_val) -> named_context_val -> named_context_val
 
-
+val is_polymorphic : env -> Names.GlobRef.t -> bool
 
 open Retroknowledge
 (** functions manipulating the retroknowledge 

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -168,6 +168,12 @@ let is_initial senv =
 
 let delta_of_senv senv = senv.modresolver,senv.paramresolver
 
+let constant_of_delta_kn_senv senv kn =
+  Mod_subst.constant_of_deltas_kn senv.paramresolver senv.modresolver kn
+
+let mind_of_delta_kn_senv senv kn =
+  Mod_subst.mind_of_deltas_kn senv.paramresolver senv.modresolver kn
+
 (** The safe_environment state monad *)
 
 type safe_transformer0 = safe_environment -> safe_environment

--- a/kernel/safe_typing.mli
+++ b/kernel/safe_typing.mli
@@ -204,6 +204,9 @@ val exists_objlabel : Label.t -> safe_environment -> bool
 val delta_of_senv :
   safe_environment -> Mod_subst.delta_resolver * Mod_subst.delta_resolver
 
+val constant_of_delta_kn_senv : safe_environment -> KerName.t -> Constant.t
+val mind_of_delta_kn_senv : safe_environment -> KerName.t -> MutInd.t
+
 (** {6 Retroknowledge / Native compiler } *)
 
 open Retroknowledge

--- a/library/global.ml
+++ b/library/global.ml
@@ -147,18 +147,10 @@ let body_of_constant cst = body_of_constant_body (lookup_constant cst)
 (** Operations on kernel names *)
 
 let constant_of_delta_kn kn =
-  let resolver,resolver_param = Safe_typing.delta_of_senv (safe_env ())
-  in
-  (* TODO : are resolver and resolver_param orthogonal ?
-     the effect of resolver is lost if resolver_param isn't
-     trivial at that spot. *)
-  Mod_subst.constant_of_deltas_kn resolver_param resolver kn
+  Safe_typing.constant_of_delta_kn_senv (safe_env ()) kn
 
 let mind_of_delta_kn kn =
-  let resolver,resolver_param = Safe_typing.delta_of_senv (safe_env ())
-  in
-  (* TODO idem *)
-  Mod_subst.mind_of_deltas_kn resolver_param resolver kn
+  Safe_typing.mind_of_delta_kn_senv (safe_env ()) kn
 
 (** Operations on libraries *)
 

--- a/library/global.ml
+++ b/library/global.ml
@@ -227,13 +227,7 @@ let universes_of_global env r =
 let universes_of_global gr = 
   universes_of_global (env ()) gr
 
-let is_polymorphic r =
-  let env = env() in 
-  match r with
-  | VarRef id -> false
-  | ConstRef c -> Environ.polymorphic_constant c env
-  | IndRef ind -> Environ.polymorphic_ind ind env
-  | ConstructRef cstr -> Environ.polymorphic_ind (inductive_of_constructor cstr) env
+let is_polymorphic r = Environ.is_polymorphic (env()) r
 
 let is_template_polymorphic r = 
   let env = env() in 


### PR DESCRIPTION
**Kind:** architecture

This is a very short PR introducing a functional version of `constant_of_delta_kn` and `mind_of_delta_kn` in order to be able to call them without referring to the global environment.

We put these new functions in `Safe_typing` which seems to be the only reasonable place where to put them inbetween `Safe_typing` and `Global`.

I (reasonably) checked that the two "mod" and "param" resolvers are independent and removed the comment which was asking about whether they were independent.

Note that the two functions depend on the _full_ safe environment (with all the module structure) and not only on the `Environ.env`. This seems to be the only ones in this case. (Maybe that should be taken into account in organizing the global state wrt to its kernel components.) 

I don't know the exact projects of @ppedrot about kernel pairs, but I don't think it is a problem if `constant_of_delta_kn` and `mind_of_delta_kn` eventually become obsolete.