### PR TITLE
Removing debugging warning when no exception handler is registered in futures

### DIFF
--- a/lib/future.ml
+++ b/lib/future.ml
@@ -33,7 +33,7 @@ let _ = CErrors.register_handler (function
   | _ -> raise CErrors.Unhandled)
 
 type fix_exn = Exninfo.iexn -> Exninfo.iexn
-let id x = prerr_endline "Future: no fix_exn.\nYou have probably created a Future.computation from a value without passing the ~fix_exn argument.  You probably want to chain with an already existing future instead."; x
+let id x = x
 
 module UUID = struct
   type t = int


### PR DESCRIPTION
**Kind:** architecture

Fixes / closes #8685 

As far as I understood from @gares at #8685, this was useful for tine-tuning the stm but this is no longuer needed: it is ok not to have exception handler when a constant registration does not span over several commands (such as "Goal ... Qed" or obligations). Please correct me if this is wrong.

