### PR TITLE
[vernac] [hooks] Refactor towards optional hooks.

### DIFF
--- a/dev/ci/user-overlays/08705-ejgallego-vernac+remove_empty_hooks.sh
+++ b/dev/ci/user-overlays/08705-ejgallego-vernac+remove_empty_hooks.sh
@@ -1,0 +1,18 @@
+if [ "$CI_PULL_REQUEST" = "8705" ] || [ "$CI_BRANCH" = "vernac+remove_empty_hooks" ]; then
+
+    elpi_CI_REF=vernac+remove_empty_hooks
+    elpi_CI_GITURL=https://github.com/ejgallego/coq-elpi
+
+    equations_CI_REF=vernac+remove_empty_hooks
+    equations_CI_GITURL=https://github.com/ejgallego/Coq-Equations
+
+    paramcoq_CI_REF=vernac+remove_empty_hooks
+    paramcoq_CI_GITURL=https://github.com/ejgallego/paramcoq
+
+    plugin_tutorial_CI_REF=vernac+remove_empty_hooks
+    plugin_tutorial_CI_GITURL=https://github.com/ejgallego/plugin_tutorials
+
+    mtac2_CI_REF=vernac+remove_empty_hooks
+    mtac2_CI_GITURL=https://github.com/ejgallego/mtac2
+
+fi

--- a/plugins/funind/functional_principles_proofs.ml
+++ b/plugins/funind/functional_principles_proofs.ml
@@ -1005,8 +1005,7 @@ let generate_equation_lemma evd fnames f fun_num nb_params nb_args rec_args_num 
     (mk_equation_id f_id)
     (Decl_kinds.Global, false, (Decl_kinds.Proof Decl_kinds.Theorem))
     evd
-  lemma_type
-  (Lemmas.mk_hook (fun _ _ -> ()));
+  lemma_type;
   ignore (Pfedit.by (Proofview.V82.tactic prove_replacement));
   Lemmas.save_proof (Vernacexpr.(Proved(Proof_global.Transparent,None)));
   evd

--- a/plugins/funind/functional_principles_types.ml
+++ b/plugins/funind/functional_principles_types.ml
@@ -310,7 +310,6 @@ let build_functional_principle (evd:Evd.evar_map ref) interactive_proof old_prin
       (Decl_kinds.Global,false,(Decl_kinds.Proof Decl_kinds.Theorem))
       !evd
       (EConstr.of_constr new_principle_type)
-      hook
   ;
     (*       let _tim1 = System.get_time ()  in *)
       let map (c, u) = EConstr.mkConstU (c, EConstr.EInstance.make u) in
@@ -326,7 +325,7 @@ let build_functional_principle (evd:Evd.evar_map ref) interactive_proof old_prin
       match entries with
       | [entry] ->
         discard_current ();
-        (id,(entry,persistence)), CEphemeron.create hook
+        (id,(entry,persistence)), hook
       | _ ->
         CErrors.anomaly Pp.(str "[build_functional_principle] close_proof returned more than one proof term")
   end
@@ -386,7 +385,7 @@ let generate_functional_principle (evd: Evd.evar_map ref)
   (* Pr  1278 :
      Don't forget to close the goal if an error is raised !!!!
   *)
-  save false new_princ_name entry g_kind hook
+  save false new_princ_name entry g_kind ~hook
   with e when CErrors.noncritical e ->
     begin
       begin

--- a/plugins/funind/indfun.ml
+++ b/plugins/funind/indfun.ml
@@ -415,7 +415,7 @@ let register_struct is_rec (fixpoint_exprl:(Vernacexpr.fixpoint_expr * Vernacexp
         ~program_mode:false
 	fname
         (Decl_kinds.Global,false,Decl_kinds.Definition) pl
-	bl None body (Some ret_type) (Lemmas.mk_hook (fun _ _ -> ()));
+        bl None body (Some ret_type);
        let evd,rev_pconstants =
 	 List.fold_left
            (fun (evd,l) ((({CAst.v=fname},_),_,_,_,_),_) ->

--- a/plugins/funind/indfun_common.ml
+++ b/plugins/funind/indfun_common.ml
@@ -129,7 +129,7 @@ let get_locality = function
 | Local -> true
 | Global -> false
 
-let save with_clean id const (locality,_,kind) hook =
+let save with_clean id const ?hook (locality,_,kind) =
   let fix_exn = Future.fix_exn_of const.const_entry_body in
   let l,r = match locality with
     | Discharge when Lib.sections_are_opened () ->
@@ -144,7 +144,7 @@ let save with_clean id const (locality,_,kind) hook =
 	(locality, ConstRef kn)
   in
   if with_clean then Proof_global.discard_current ();
-  CEphemeron.iter_opt hook (fun f -> Lemmas.call_hook fix_exn f l r);
+  Lemmas.call_hook ?hook ~fix_exn l r;
   definition_message id
 
 let with_full_print f a =

--- a/plugins/funind/indfun_common.mli
+++ b/plugins/funind/indfun_common.mli
@@ -42,8 +42,7 @@ val const_of_id: Id.t ->  GlobRef.t(* constantyes *)
 val jmeq : unit -> EConstr.constr
 val jmeq_refl : unit -> EConstr.constr
 
-val save : bool -> Id.t -> Safe_typing.private_constants Entries.definition_entry  -> Decl_kinds.goal_kind ->
-  Lemmas.declaration_hook CEphemeron.key -> unit
+val save : bool -> Id.t -> Safe_typing.private_constants Entries.definition_entry -> ?hook:Lemmas.declaration_hook -> Decl_kinds.goal_kind -> unit
 
 (* [with_full_print f a] applies [f] to [a] in full printing environment.
 

--- a/plugins/funind/invfun.ml
+++ b/plugins/funind/invfun.ml
@@ -806,8 +806,7 @@ let derive_correctness make_scheme (funs: pconstant list) (graphs:inductive list
 	   lem_id
            (Decl_kinds.Global,false,((Decl_kinds.Proof Decl_kinds.Theorem)))
            !evd
-	   typ
-           (Lemmas.mk_hook (fun _ _ -> ()));
+           typ;
 	 ignore (Pfedit.by
 		   (Proofview.V82.tactic (observe_tac ("prove correctness ("^(Id.to_string f_id)^")")
 						      (proving_tac i))));
@@ -867,8 +866,7 @@ let derive_correctness make_scheme (funs: pconstant list) (graphs:inductive list
 	 let lem_id = mk_complete_id f_id in
 	 Lemmas.start_proof lem_id
            (Decl_kinds.Global,false,(Decl_kinds.Proof Decl_kinds.Theorem)) sigma
-	 (fst lemmas_types_infos.(i))
-           (Lemmas.mk_hook (fun _ _ -> ()));
+         (fst lemmas_types_infos.(i));
 	 ignore (Pfedit.by
 	   (Proofview.V82.tactic (observe_tac ("prove completeness ("^(Id.to_string f_id)^")")
 	      (proving_tac i)))) ;

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -1372,7 +1372,7 @@ let open_new_goal build_proof sigma using_lemmas ref_ goal_name (gls_type,decomp
     na
     (Decl_kinds.Global, false (* FIXME *), Decl_kinds.Proof Decl_kinds.Lemma)
     sigma gls_type
-    (Lemmas.mk_hook hook);
+    ~hook:(Lemmas.mk_hook hook);
   if Indfun_common.is_strict_tcc  ()
   then
     ignore (by (Proofview.V82.tactic (tclIDTAC)))
@@ -1418,7 +1418,7 @@ let com_terminate
     let evd, env = Pfedit.get_current_context () in
     Lemmas.start_proof thm_name
       (Global, false (* FIXME *), Proof Lemma) ~sign:(Environ.named_context_val env)
-      ctx (EConstr.of_constr (compute_terminate_type nb_args fonctional_ref)) hook;
+      ctx (EConstr.of_constr (compute_terminate_type nb_args fonctional_ref)) ~hook;
 
     ignore (by (Proofview.V82.tactic (observe_tac (str "starting_tac") tac_start)));
     ignore (by (Proofview.V82.tactic (observe_tac (str "whole_start") (whole_start tac_end nb_args is_mes fonctional_ref
@@ -1474,8 +1474,7 @@ let (com_eqn : int -> Id.t ->
     (Lemmas.start_proof eq_name (Global, false, Proof Lemma)
        ~sign:(Environ.named_context_val env)
        evd
-       (EConstr.of_constr equation_lemma_type)
-       (Lemmas.mk_hook (fun _ _ -> ()));
+       (EConstr.of_constr equation_lemma_type);
      ignore (by
        (Proofview.V82.tactic (start_equation f_ref terminate_ref
 	  (fun  x ->

--- a/plugins/ltac/rewrite.ml
+++ b/plugins/ltac/rewrite.ml
@@ -1998,7 +1998,7 @@ let add_morphism_infer atts m n =
       let hook = Lemmas.mk_hook hook in
 	Flags.silently
 	  (fun () ->
-	    Lemmas.start_proof instance_id kind (Evd.from_ctx uctx) (EConstr.of_constr instance) hook;
+            Lemmas.start_proof ~hook instance_id kind (Evd.from_ctx uctx) (EConstr.of_constr instance);
 	    ignore (Pfedit.by (Tacinterp.interp tac))) ()
 
 let add_morphism atts binders m s n =

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -1543,7 +1543,7 @@ end = struct (* {{{ *)
           let pobject, _ =
             Proof_global.close_future_proof ~opaque ~feedback_id:stop (Future.from_val ~fix_exn p) in
           let terminator = (* The one sent by master is an InvalidKey *)
-            Lemmas.(standard_proof_terminator [] (mk_hook (fun _ _ -> ()))) in
+            Lemmas.(standard_proof_terminator []) in
 
           let st = Vernacstate.freeze_interp_state `No in
           stm_vernac_interp stop
@@ -1682,9 +1682,8 @@ end = struct (* {{{ *)
         `OK_ADMITTED
       else begin
       (* The original terminator, a hook, has not been saved in the .vio*)
-      Proof_global.set_terminator
-        (Lemmas.standard_proof_terminator []
-           (Lemmas.mk_hook (fun _ _ -> ())));
+      Proof_global.set_terminator (Lemmas.standard_proof_terminator []);
+
       let opaque = Proof_global.Opaque in
       let proof =
         Proof_global.close_proof ~opaque ~keep_body_ucst_separate:true (fun x -> x) in

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -163,10 +163,10 @@ let declare_instance_open env sigma ?hook ~tac ~program_mode ~global ~poly k id 
         in obls, Some constr, typ
       | None -> [||], None, termtype
     in
-    let hook = Obligations.mk_univ_hook hook in
+    let univ_hook = Obligations.mk_univ_hook hook in
     let ctx = Evd.evar_universe_context sigma in
     ignore (Obligations.add_definition id ?term:constr
-              ~univdecl:decl typ ctx ~kind:(Global,poly,Instance) ~hook obls)
+              ~univdecl:decl typ ctx ~kind:(Global,poly,Instance) ~univ_hook obls)
   else
     Flags.silently (fun () ->
         (* spiwack: it is hard to reorder the actions to do
@@ -176,7 +176,7 @@ let declare_instance_open env sigma ?hook ~tac ~program_mode ~global ~poly k id 
         let gls = List.rev (Evd.future_goals sigma) in
         let sigma = Evd.reset_future_goals sigma in
         Lemmas.start_proof id ~pl:decl kind sigma (EConstr.of_constr termtype)
-          (Lemmas.mk_hook
+          ~hook:(Lemmas.mk_hook
              (fun _ -> instance_hook k pri global imps ?hook));
         (* spiwack: I don't know what to do with the status here. *)
         if not (Option.is_empty term) then
@@ -423,8 +423,7 @@ let context poly l =
       | Some b ->
         let decl = (Discharge, poly, Definition) in
         let entry = Declare.definition_entry ~univs ~types:t b in
-        let hook = Lemmas.mk_hook (fun _ _ -> ()) in
-        let _ = DeclareDef.declare_definition id decl entry UnivNames.empty_binders [] hook in
+        let _ = DeclareDef.declare_definition id decl entry UnivNames.empty_binders [] in
         Lib.sections_are_opened () || Lib.is_modtype_strict ()
       in
 	status && nstatus

--- a/vernac/comDefinition.ml
+++ b/vernac/comDefinition.ml
@@ -90,7 +90,7 @@ let check_definition (ce, evd, _, imps) =
   check_evars_are_solved env evd;
   ce
 
-let do_definition ~program_mode ident k univdecl bl red_option c ctypopt hook =
+let do_definition ~program_mode ?hook ident k univdecl bl red_option c ctypopt =
   let (ce, evd, univdecl, imps as def) =
     interp_definition univdecl bl (pi2 k) red_option c ctypopt
   in
@@ -108,8 +108,8 @@ let do_definition ~program_mode ident k univdecl bl red_option c ctypopt hook =
         Obligations.eterm_obligations env ident evd 0 c typ
       in
       let ctx = Evd.evar_universe_context evd in
-      let hook = Obligations.mk_univ_hook (fun _ _ l r -> Lemmas.call_hook (fun x -> x) hook l r) in
+      let univ_hook = Obligations.mk_univ_hook (fun _ _ l r -> Lemmas.call_hook ?hook l r) in
       ignore(Obligations.add_definition
-          ident ~term:c cty ctx ~univdecl ~implicits:imps ~kind:k ~hook obls)
+          ident ~term:c cty ctx ~univdecl ~implicits:imps ~kind:k ~univ_hook obls)
     else let ce = check_definition def in
-      ignore(DeclareDef.declare_definition ident k ce (Evd.universe_binders evd) imps hook)
+      ignore(DeclareDef.declare_definition ident k ce (Evd.universe_binders evd) imps ?hook)

--- a/vernac/comDefinition.mli
+++ b/vernac/comDefinition.mli
@@ -17,9 +17,10 @@ open Constrexpr
 (** {6 Definitions/Let} *)
 
 val do_definition : program_mode:bool ->
+  ?hook:Lemmas.declaration_hook ->
   Id.t -> definition_kind -> universe_decl_expr option ->
   local_binder_expr list -> red_expr option -> constr_expr ->
-  constr_expr option -> Lemmas.declaration_hook -> unit
+  constr_expr option -> unit
 
 (************************************************************************)
 (** Internal API  *)

--- a/vernac/comFixpoint.ml
+++ b/vernac/comFixpoint.ml
@@ -261,7 +261,7 @@ let declare_fixpoint local poly ((fixnames,fixdefs,fixtypes),pl,ctx,fiximps) ind
         fixdefs) in
     let evd = Evd.from_ctx ctx in
     Lemmas.start_proof_with_initialization (local,poly,DefinitionBody Fixpoint)
-      evd pl (Some(false,indexes,init_tac)) thms None (Lemmas.mk_hook (fun _ _ -> ()))
+      evd pl (Some(false,indexes,init_tac)) thms None
   else begin
     (* We shortcut the proof process *)
     let fixdefs = List.map Option.get fixdefs in
@@ -296,7 +296,7 @@ let declare_cofixpoint local poly ((fixnames,fixdefs,fixtypes),pl,ctx,fiximps) n
         fixdefs) in
     let evd = Evd.from_ctx ctx in
       Lemmas.start_proof_with_initialization (Global,poly, DefinitionBody CoFixpoint)
-      evd pl (Some(true,[],init_tac)) thms None (Lemmas.mk_hook (fun _ _ -> ()))
+      evd pl (Some(true,[],init_tac)) thms None
   else begin
     (* We shortcut the proof process *)
     let fixdefs = List.map Option.get fixdefs in

--- a/vernac/comProgramFixpoint.ml
+++ b/vernac/comProgramFixpoint.ml
@@ -227,7 +227,7 @@ let build_wellfounded (recname,pl,n,bl,arityc,body) poly r measure notation =
       in hook, recname, typ
   in
   (* XXX: Capturing sigma here... bad bad *)
-  let hook = Obligations.mk_univ_hook (hook sigma) in
+  let univ_hook = Obligations.mk_univ_hook (hook sigma) in
   (* XXX: Grounding non-ground terms here... bad bad *)
   let fullcoqc = EConstr.to_constr ~abort_on_undefined_evars:false sigma def in
   let fullctyp = EConstr.to_constr sigma typ in
@@ -237,7 +237,7 @@ let build_wellfounded (recname,pl,n,bl,arityc,body) poly r measure notation =
   in
   let ctx = Evd.evar_universe_context sigma in
     ignore(Obligations.add_definition recname ~term:evars_def ~univdecl:decl
-             evars_typ ctx evars ~hook)
+             evars_typ ctx evars ~univ_hook)
 
 let out_def = function
   | Some def -> def

--- a/vernac/declareDef.ml
+++ b/vernac/declareDef.ml
@@ -33,7 +33,7 @@ let get_locality id ~kind = function
 | Local -> true
 | Global -> false
 
-let declare_definition ident (local, p, k) ce pl imps hook =
+let declare_definition ident (local, p, k) ?hook ce pl imps =
   let fix_exn = Future.fix_exn_of ce.const_entry_body in
   let gr = match local with
   | Discharge when Lib.sections_are_opened () ->
@@ -49,8 +49,8 @@ let declare_definition ident (local, p, k) ce pl imps hook =
   in
   let () = maybe_declare_manual_implicits false gr imps in
   let () = definition_message ident in
-  Lemmas.call_hook fix_exn hook local gr; gr
+  Lemmas.call_hook ~fix_exn ?hook local gr; gr
 
 let declare_fix ?(opaque = false) (_,poly,_ as kind) pl univs f ((def,_),eff) t imps =
   let ce = definition_entry ~opaque ~types:t ~univs ~eff def in
-  declare_definition f kind ce pl imps (Lemmas.mk_hook (fun _ _ -> ()))
+  declare_definition f kind ce pl imps

--- a/vernac/declareDef.mli
+++ b/vernac/declareDef.mli
@@ -14,8 +14,9 @@ open Decl_kinds
 val get_locality : Id.t -> kind:string -> Decl_kinds.locality -> bool
 
 val declare_definition : Id.t -> definition_kind ->
+  ?hook:Lemmas.declaration_hook ->
   Safe_typing.private_constants Entries.definition_entry -> UnivNames.universe_binders -> Impargs.manual_implicits ->
-  Lemmas.declaration_hook -> GlobRef.t
+  GlobRef.t
 
 val declare_fix : ?opaque:bool -> definition_kind ->
   UnivNames.universe_binders -> Entries.constant_universes_entry ->

--- a/vernac/lemmas.mli
+++ b/vernac/lemmas.mli
@@ -12,41 +12,45 @@ open Names
 open Decl_kinds
 
 type declaration_hook
+
 val mk_hook : (Decl_kinds.locality -> GlobRef.t -> unit) -> declaration_hook
-val call_hook : Future.fix_exn -> declaration_hook -> Decl_kinds.locality -> GlobRef.t -> unit
+val call_hook :
+  ?hook:declaration_hook -> ?fix_exn:Future.fix_exn ->
+  Decl_kinds.locality -> GlobRef.t -> unit
 
 val start_proof : Id.t -> ?pl:UState.universe_decl -> goal_kind -> Evd.evar_map ->
-  ?terminator:(Proof_global.lemma_possible_guards -> declaration_hook -> Proof_global.proof_terminator) ->
-  ?sign:Environ.named_context_val -> EConstr.types ->
+  ?terminator:(?hook:declaration_hook -> Proof_global.lemma_possible_guards -> Proof_global.proof_terminator) ->
+  ?sign:Environ.named_context_val ->
   ?compute_guard:Proof_global.lemma_possible_guards ->
-  declaration_hook -> unit
+  ?hook:declaration_hook ->  EConstr.types -> unit
 
 val start_proof_univs : Id.t -> ?pl:UState.universe_decl -> goal_kind -> Evd.evar_map ->
-  ?terminator:(Proof_global.lemma_possible_guards -> (UState.t option -> declaration_hook) -> Proof_global.proof_terminator) ->
-  ?sign:Environ.named_context_val -> EConstr.types ->
+  ?terminator:(?univ_hook:(UState.t option -> declaration_hook) -> Proof_global.lemma_possible_guards -> Proof_global.proof_terminator) ->
+  ?sign:Environ.named_context_val ->
   ?compute_guard:Proof_global.lemma_possible_guards ->
-  (UState.t option -> declaration_hook) -> unit
+  ?univ_hook:(UState.t option -> declaration_hook) -> EConstr.types -> unit
 
 val start_proof_com :
   ?inference_hook:Pretyping.inference_hook ->
-  goal_kind -> Vernacexpr.proof_expr list ->
-  declaration_hook -> unit
+  ?hook:declaration_hook -> goal_kind -> Vernacexpr.proof_expr list ->
+  unit
 
 val start_proof_with_initialization :
+  ?hook:declaration_hook ->
   goal_kind -> Evd.evar_map -> UState.universe_decl ->
   (bool * Proof_global.lemma_possible_guards * unit Proofview.tactic list option) option ->
   (Id.t (* name of thm *) *
-     (EConstr.types (* type of thm *) * (Name.t list (* names to pre-introduce *) * Impargs.manual_explicitation list))) list
-  -> int list option -> declaration_hook -> unit
+     (EConstr.types (* type of thm *) * (Name.t list (* names to pre-introduce *) * Impargs.manual_explicitation list))) list ->
+  int list option -> unit
 
 val universe_proof_terminator :
+  ?univ_hook:(UState.t option -> declaration_hook) ->
   Proof_global.lemma_possible_guards ->
-    (UState.t option -> declaration_hook) ->
-    Proof_global.proof_terminator
+  Proof_global.proof_terminator
 
 val standard_proof_terminator :
-  Proof_global.lemma_possible_guards -> declaration_hook ->
-    Proof_global.proof_terminator
+  ?hook:declaration_hook -> Proof_global.lemma_possible_guards ->
+  Proof_global.proof_terminator
 
 val fresh_name_for_anonymous_theorem : unit -> Id.t
 

--- a/vernac/obligations.mli
+++ b/vernac/obligations.mli
@@ -14,8 +14,10 @@ open Evd
 open Names
 
 type univ_declaration_hook
-val mk_univ_hook : (UState.t -> (Id.t * constr) list -> Decl_kinds.locality -> GlobRef.t -> unit) -> univ_declaration_hook
-val call_univ_hook : Future.fix_exn -> univ_declaration_hook -> UState.t -> (Id.t * constr) list -> Decl_kinds.locality -> GlobRef.t -> unit
+val mk_univ_hook : (UState.t -> (Id.t * constr) list -> Decl_kinds.locality -> GlobRef.t -> unit) ->
+  univ_declaration_hook
+val call_univ_hook : ?univ_hook:univ_declaration_hook -> ?fix_exn:Future.fix_exn ->
+  UState.t -> (Id.t * constr) list -> Decl_kinds.locality -> GlobRef.t -> unit
 
 (* This is a hack to make it possible for Obligations to craft a Qed
  * behind the scenes.  The fix_exn the Stm attaches to the Future proof
@@ -56,14 +58,14 @@ type progress = (* Resolution status of a program *)
 
 val default_tactic : unit Proofview.tactic ref
 
-val add_definition : Names.Id.t -> ?term:constr -> types -> 
+val add_definition : Names.Id.t -> ?term:constr -> types ->
   UState.t ->
   ?univdecl:UState.universe_decl -> (* Universe binders and constraints *)
   ?implicits:(Constrexpr.explicitation * (bool * bool * bool)) list ->
   ?kind:Decl_kinds.definition_kind ->
   ?tactic:unit Proofview.tactic ->
   ?reduce:(constr -> constr) ->
-  ?hook:univ_declaration_hook -> ?opaque:bool -> obligation_info -> progress
+  ?univ_hook:univ_declaration_hook -> ?opaque:bool -> obligation_info -> progress
 
 type notations =
     (lstring * Constrexpr.constr_expr * Notation_term.scope_name option) list
@@ -80,7 +82,7 @@ val add_mutual_definitions :
   ?tactic:unit Proofview.tactic ->
   ?kind:Decl_kinds.definition_kind ->
   ?reduce:(constr -> constr) ->
-  ?hook:univ_declaration_hook -> ?opaque:bool ->
+  ?univ_hook:univ_declaration_hook -> ?opaque:bool ->
   notations ->
   fixpoint_kind -> unit
 


### PR DESCRIPTION
We make `declaration_hook`s optional arguments everywhere, and thus we
avoid some "fake" functions having to be passed.

This identifies positively the code really using hooks [funind,
rewrite, coercions, program, and canonicals] and helps moving toward
some hope of reification.