### PR TITLE
Separate cache representation between CClosure and CBV

### DIFF
--- a/checker/closure.mli
+++ b/checker/closure.mli
@@ -61,10 +61,6 @@ val betadeltaiotanolet : reds
 
 type table_key = Constant.t puniverses tableKey
 
-type 'a infos
-val ref_value_cache: 'a infos -> table_key -> 'a option
-val create: ('a infos -> constr -> 'a) -> reds -> env -> 'a infos
-
 (************************************************************************)
 (*s Lazy reduction. *)
 

--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -224,11 +224,6 @@ let unfold_red kn =
  * abstractions, storing a representation (of type 'a) of the body of
  * this constant or abstraction.
  *  * i_tab is the cache table of the results
- *  * i_repr is the function to get the representation from the current
- *         state of the cache and the body of the constant. The result
- *         is stored in the table.
- *  * i_rels is the array of free rel variables together with their optional
- *    body
  *
  * ref_value_cache searchs in the tab, otherwise uses i_repr to
  * compute the result and store it in the table. If the constant can't
@@ -256,59 +251,11 @@ end
 
 module KeyTable = Hashtbl.Make(IdKeyHash)
 
-let eq_table_key = IdKeyHash.equal
-
-type 'a infos_tab = 'a KeyTable.t
-
-type 'a infos_cache = {
-  i_repr : 'a infos -> 'a infos_tab -> constr -> 'a;
-  i_env : env;
-  i_sigma : existential -> constr option;
-  i_rels : (Constr.rel_declaration * lazy_val) Range.t;
-  i_share : bool;
-}
-
-and 'a infos = {
-  i_flags : reds;
-  i_cache : 'a infos_cache }
-
-let info_flags info = info.i_flags
-let info_env info = info.i_cache.i_env
-
 open Context.Named.Declaration
 
 let assoc_defined id env = match Environ.lookup_named id env with
 | LocalDef (_, c, _) -> c
 | _ -> raise Not_found
-
-let ref_value_cache ({i_cache = cache;_} as infos) tab ref =
-  try
-    Some (KeyTable.find tab ref)
-  with Not_found ->
-  try
-    let body =
-      match ref with
-	| RelKey n ->
-          let open! Context.Rel.Declaration in
-          let i = n - 1 in
-          let (d, _) =
-            try Range.get cache.i_rels i
-            with Invalid_argument _ -> raise Not_found
-          in
-          begin match d with
-          | LocalAssum _ -> raise Not_found
-          | LocalDef (_, t, _) -> lift n t
-          end
-	| VarKey id -> assoc_defined id cache.i_env
-	| ConstKey cst -> constant_value_in cache.i_env cst
-    in
-    let v = cache.i_repr infos tab body in
-    KeyTable.add tab ref v;
-    Some v
-  with
-    | Not_found (* List.assoc *)
-    | NotEvaluableConst _ (* Const *)
-      -> None
 
 (**********************************************************************)
 (* Lazy reduction: the one used in kernel operations                  *)
@@ -376,6 +323,23 @@ let update ~share v1 no t =
      v1.term <- t;
      v1)
   else {norm=no;term=t}
+
+(** Reduction cache *)
+
+type infos_cache = {
+  i_env : env;
+  i_sigma : existential -> constr option;
+  i_share : bool;
+}
+
+type clos_infos = {
+  i_flags : reds;
+  i_cache : infos_cache }
+
+type clos_tab = fconstr KeyTable.t
+
+let info_flags info = info.i_flags
+let info_env info = info.i_cache.i_env
 
 (**********************************************************************)
 (* The type of (machine) stacks (= lambda-bar-calculus' contexts)     *)
@@ -525,6 +489,8 @@ let mk_clos e t =
     | (CoFix _|Lambda _|Fix _|Prod _|Evar _|App _|Case _|Cast _|LetIn _|Proj _) ->
         {norm = Red; term = FCLOS(t,e)}
 
+let inject c = mk_clos (subs_id 0) c
+
 (** Hand-unrolling of the map function to bypass the call to the generic array
     allocation *)
 let mk_clos_vect env v = match v with
@@ -535,6 +501,35 @@ let mk_clos_vect env v = match v with
 | [|v0; v1; v2; v3|] ->
   [|mk_clos env v0; mk_clos env v1; mk_clos env v2; mk_clos env v3|]
 | v -> Array.Fun1.map mk_clos env v
+
+let ref_value_cache ({ i_cache = cache; _ }) tab ref =
+  try
+    Some (KeyTable.find tab ref)
+  with Not_found ->
+  try
+    let body =
+      match ref with
+        | RelKey n ->
+          let open! Context.Rel.Declaration in
+          let i = n - 1 in
+          let (d, _) =
+            try Range.get cache.i_env.env_rel_context.env_rel_map i
+            with Invalid_argument _ -> raise Not_found
+          in
+          begin match d with
+          | LocalAssum _ -> raise Not_found
+          | LocalDef (_, t, _) -> lift n t
+          end
+        | VarKey id -> assoc_defined id cache.i_env
+        | ConstKey cst -> constant_value_in cache.i_env cst
+    in
+    let v = inject body in
+    KeyTable.add tab ref v;
+    Some v
+  with
+    | Not_found (* List.assoc *)
+    | NotEvaluableConst _ (* Const *)
+      -> None
 
 (* The inverse of mk_clos: move back to constr *)
 let rec to_constr lfts v =
@@ -1026,8 +1021,6 @@ let whd_val info tab v =
 let norm_val info tab v =
   with_stats (lazy (kl info tab v))
 
-let inject c = mk_clos (subs_id 0) c
-
 let whd_stack infos tab m stk = match m.norm with
 | Whnf | Norm ->
   (** No need to perform [kni] nor to unlock updates because
@@ -1038,17 +1031,11 @@ let whd_stack infos tab m stk = match m.norm with
   let () = if infos.i_cache.i_share then ignore (fapp_stack k) in (* to unlock Zupdates! *)
   k
 
-(* cache of constants: the body is computed only when needed. *)
-type clos_infos = fconstr infos
-type clos_tab = fconstr infos_tab
-
 let create_clos_infos ?(evars=fun _ -> None) flgs env =
   let share = (Environ.typing_flags env).Declarations.share_reduction in
   let cache = {
-    i_repr = (fun _ _ c -> inject c);
     i_env = env;
     i_sigma = evars;
-    i_rels = env.env_rel_context.env_rel_map;
     i_share = share;
   } in
   { i_flags = flgs; i_cache = cache }

--- a/kernel/cClosure.mli
+++ b/kernel/cClosure.mli
@@ -218,8 +218,6 @@ val eta_expand_ind_stack : env -> inductive -> fconstr -> stack ->
 (** [unfold_reference] unfolds references in a [fconstr] *)
 val unfold_reference : clos_infos -> clos_tab -> table_key -> fconstr option
 
-val eq_table_key : table_key -> table_key -> bool
-
 (***********************************************************************
   i This is for lazy debug *)
 

--- a/kernel/reduction.ml
+++ b/kernel/reduction.ml
@@ -316,8 +316,8 @@ let compare_stacks f fmind lft1 stk1 lft2 stk2 cuniv =
 
 type conv_tab = {
   cnv_inf : clos_infos;
-  lft_tab : fconstr infos_tab;
-  rgt_tab : fconstr infos_tab;
+  lft_tab : clos_tab;
+  rgt_tab : clos_tab;
 }
 (** Invariant: for any tl ∈ lft_tab and tr ∈ rgt_tab, there is no mutable memory
     location contained both in tl and in tr. *)
@@ -346,7 +346,7 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
 	   | (Sort s1, Sort s2) ->
 	       if not (is_empty_stack v1 && is_empty_stack v2) then
 		 anomaly (Pp.str "conversion was given ill-typed terms (Sort).");
-              sort_cmp_universes (env_of_infos infos.cnv_inf) cv_pb s1 s2 cuniv
+              sort_cmp_universes (info_env infos.cnv_inf) cv_pb s1 s2 cuniv
 	   | (Meta n, Meta m) ->
                if Int.equal n m
                then convert_stacks l2r infos lft1 lft2 v1 v2 cuniv


### PR DESCRIPTION
This PR separates the kernel implementation for the term cache and its reuse in the out-of-kernel CBV reduction. This allows for further cleanups of static or unused data.

Interestingly this also seems to provide a slight speedup of reduction-sensitive code.
```
┌──────────────────────────┬─────────────────────────┬───────────────────────────────────────┬───────────────────────────────────────┬─────────────────────────┬────────────────────┐
│                          │      user time [s]      │              CPU cycles               │           CPU instructions            │  max resident mem [KB]  │     mem faults     │
│                          │                         │                                       │                                       │                         │                    │
│             package_name │     NEW     OLD PDIFF   │            NEW            OLD PDIFF   │            NEW            OLD PDIFF   │     NEW     OLD PDIFF   │  NEW  OLD  PDIFF   │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼────────────────────┤
│   coq-mathcomp-odd-order │ 1413.05 1433.83 -1.45 % │  3936200361735  3991982030141 -1.40 % │  6657542410323  6652776875661 +0.07 % │ 1356092 1345092 +0.82 % │    4    0   +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼────────────────────┤
│              coq-unimath │ 1325.72 1336.06 -0.77 % │  3680931560751  3709374098474 -0.77 % │  6223627455366  6225637391659 -0.03 % │  985872  985580 +0.03 % │  348   21 +1557.14 % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼────────────────────┤
│                 coq-corn │ 1541.16 1550.72 -0.62 % │  4278355546708  4302072163965 -0.55 % │  6346360131011  6348694252677 -0.04 % │  817852  818160 -0.04 % │   44   44  +0.00 % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼────────────────────┤
│      coq-formal-topology │   57.82   58.12 -0.52 % │   158252480280   158862827706 -0.38 % │   239278904725   239331308650 -0.02 % │  477680  477528 +0.03 % │    1    0   +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼────────────────────┤
│               coq-sf-vfa │   47.25   47.49 -0.51 % │   131097445726   131399601231 -0.23 % │   209549446297   209686634872 -0.07 % │  535292  535256 +0.01 % │   28    5 +460.00 % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼────────────────────┤
│                 coq-hott │  340.96  342.64 -0.49 % │   943983791515   950635728409 -0.70 % │  1439975222178  1439870859678 +0.01 % │  666940  666980 -0.01 % │  352    0   +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼────────────────────┤
│         coq-math-classes │  249.17  250.39 -0.49 % │   686942585955   688630954925 -0.25 % │   899313771879   899466497392 -0.02 % │  522888  522212 +0.13 % │   64   84 -23.81 % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼────────────────────┤
│                coq-flocq │  592.77  595.04 -0.38 % │  1649059475849  1653074410465 -0.24 % │  2404513919593  2406543201466 -0.08 % │ 1764112 1764340 -0.01 % │  344   32 +975.00 % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼────────────────────┤
│                coq-sf-lf │   44.24   44.39 -0.34 % │   121932405828   122626918467 -0.57 % │   198885677984   199012338540 -0.06 % │  423264  423300 -0.01 % │  129    0   +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼────────────────────┤
│              coq-bignums │   98.77   99.08 -0.31 % │   273657555331   274535522530 -0.32 % │   393510509924   393892288229 -0.10 % │  534136  538748 -0.86 % │   86    0   +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼────────────────────┤
│ coq-mathcomp-real-closed │  188.30  188.68 -0.20 % │   523440151820   524391610432 -0.18 % │   789843292993   789976527848 -0.02 % │  826472  831292 -0.58 % │    0    0   +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼────────────────────┤
│                  coq-vst │ 1717.76 1720.14 -0.14 % │  4776374591324  4780909974134 -0.09 % │  6525488495716  6532166702347 -0.10 % │ 2217968 2228656 -0.48 % │  194  299 -35.12 % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼────────────────────┤
│            coq-fiat-core │  135.18  135.33 -0.11 % │   377999966645   377779853405 +0.06 % │   503923863163   503939929462 -0.00 % │  498120  498068 +0.01 % │  375   87 +331.03 % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼────────────────────┤
│               coq-sf-plf │   74.63   74.71 -0.11 % │   206396236504   206726735480 -0.16 % │   300637338941   300839115016 -0.07 % │  518504  517796 +0.14 % │   15    0   +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼────────────────────┤
│   coq-mathcomp-character │  293.80  294.00 -0.07 % │   815880104751   817338238136 -0.18 % │  1185191881805  1188810406387 -0.30 % │ 1059884 1121056 -5.46 % │    2    1 +100.00 % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼────────────────────┤
│    coq-mathcomp-fingroup │   85.07   85.12 -0.06 % │   235223378961   235449271478 -0.10 % │   348178560496   348365967702 -0.05 % │  587972  586136 +0.31 % │   97    0   +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼────────────────────┤
│     coq-mathcomp-algebra │  205.79  205.88 -0.04 % │   570404737780   570928523892 -0.09 % │   798681235303   798758320160 -0.01 % │  641188  640976 +0.03 % │    3    8 -62.50 % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼────────────────────┤
│         coq-fiat-parsers │  721.09  721.25 -0.02 % │  1999945286551  2002628103041 -0.13 % │  3059005727085  3057044369804 +0.06 % │ 2885928 2893888 -0.28 % │   75  587 -87.22 % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼────────────────────┤
│       coq-mathcomp-field │  469.04  469.09 -0.01 % │  1304710899828  1305702280513 -0.08 % │  2126286498831  2126317357619 -0.00 % │  805448  803620 +0.23 % │    0   16 -100.00 % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼────────────────────┤
│             coq-compcert │  891.81  891.82 -0.00 % │  2474262675171  2473064164018 +0.05 % │  3564477250562  3564731108132 -0.01 % │ 1338256 1355804 -1.29 % │  241  187 +28.88 % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼────────────────────┤
│           coq-coquelicot │  103.85  103.82 +0.03 % │   287231604244   286765317288 +0.16 % │   386312079100   386467983760 -0.04 % │  713136  713892 -0.11 % │  280   13 +2053.85 % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼────────────────────┤
│          coq-fiat-crypto │ 6316.50 6314.11 +0.04 % │ 17565493923648 17551920695226 +0.08 % │ 28902570487302 28910277315266 -0.03 % │ 2450616 2498820 -1.93 % │ 1456 1657 -12.13 % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼────────────────────┤
│    coq-mathcomp-solvable │  220.72  220.30 +0.19 % │   612335913431   611910070003 +0.07 % │   872563463204   873075353816 -0.06 % │  823900  830012 -0.74 % │   38  262 -85.50 % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼────────────────────┤
│   coq-mathcomp-ssreflect │   65.52   65.31 +0.32 % │   180002611438   179979782598 +0.01 % │   256309184417   256391588636 -0.03 % │  532240  532300 -0.01 % │    3    0   +nan % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼────────────────────┤
│                coq-color │  740.47  737.30 +0.43 % │  2052826863434  2041882358223 +0.54 % │  2469067663213  2469659508054 -0.02 % │ 1370332 1370692 -0.03 % │   30  243 -87.65 % │
├──────────────────────────┼─────────────────────────┼───────────────────────────────────────┼───────────────────────────────────────┼─────────────────────────┼────────────────────┤
│               coq-geocoq │ 2870.61 2849.27 +0.75 % │  7979869322158  7920706343924 +0.75 % │ 12577347545415 12578877488088 -0.01 % │ 1289212 1286460 +0.21 % │  198  179 +10.61 % │
└──────────────────────────┴─────────────────────────┴───────────────────────────────────────┴───────────────────────────────────────┴─────────────────────────┴────────────────────┘
```