### PR TITLE
[ci] [appveyor] Enable cache for builds.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,10 @@
 version: '{branch}~{build}'
 clone_depth: 10
 
+cache:
+  - C:\cygwin64 -> dev\ci\appveyor.bat
+  - C:\cygwin64\home\appveyor\.opam -> dev\ci\appveyor.sh
+
 platform:
 - x64
 


### PR DESCRIPTION
We cache CYGWIN and OPAM. Current cygwin install is not deterministic
but should do the job in the scope of this job.
