### PR TITLE
Documenting -arg in _CoqProject.

### DIFF
--- a/doc/sphinx/practical-tools/utilities.rst
+++ b/doc/sphinx/practical-tools/utilities.rst
@@ -41,15 +41,17 @@ Building a |Coq| project with coq_makefile
 The majority of |Coq| projects are very similar: a collection of ``.v``
 files and eventually some ``.ml`` ones (a |Coq| plugin). The main piece of
 metadata needed in order to build the project are the command line
-options to ``coqc`` (e.g. ``-R``, ``-I``, see also: section
-:ref:`command-line-options`). Collecting the list of files and options is the job
-of the ``_CoqProject`` file.
+options to ``coqc`` (e.g. ``-R``, ``Q``, ``-I``, see :ref:`command
+line options <command-line-options>`). Collecting the list of files
+and options is the job of the ``_CoqProject`` file.
 
 A simple example of a ``_CoqProject`` file follows:
 
 ::
 
     -R theories/ MyCode
+    -arg -w
+    -arg all
     theories/foo.v
     theories/bar.v
     -I src/
@@ -57,6 +59,11 @@ A simple example of a ``_CoqProject`` file follows:
     src/bazaux.ml
     src/qux_plugin.mlpack
 
+where options ``-R``, ``-Q`` and ``-I`` are natively recognized, as well as
+file names. The lines of the form ``-arg foo`` are used in order to tell
+to literally pass an argument ``foo`` to ``coqc``: in the
+example, this allows to pass the two-word option ``-w all`` (see
+:ref:`command line options <command-line-options>`).
 
 Currently, both |CoqIDE| and Proof-General (version ≥ ``4.3pre``)
 understand ``_CoqProject`` files and invoke |Coq| with the desired options.


### PR DESCRIPTION
We follow Proof General documentation, [section 11.2](http://proofgeneral.inf.ed.ac.uk/htmlshow.php?title=Proof_General+manual&file=releases%2FProofGeneral-latest%2Fdoc%2FProofGeneral%2FProofGeneral_12.html#Using-the-Coq-project-file) "Using the Coq project file".

I did not document the behavior with quotes and spaces yet (e.g. the incorrect `-arg -w -all`, the PG-only `-arg "-w all"`, the CoqIDE-only `-arg -init-file -arg "my init file"`, ...), as it is not (yet) consistent between PG, `coq_makefile` and CoqIDE (see ProofGeneral/PG#392).

**Kind:** documentation / bug fix

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #5773

- [X] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).

