### PR TITLE
Further reorganization/simplification of declaration hooks

### DIFF
--- a/dev/ci/user-overlays/08718-herbelin-master+fix8718-reorganization-hook.sh
+++ b/dev/ci/user-overlays/08718-herbelin-master+fix8718-reorganization-hook.sh
@@ -1,0 +1,15 @@
+if [ "$CI_PULL_REQUEST" = "8718" ] || [ "$CI_BRANCH" = "master+reorganization-hook" ]; then
+
+    mtac2_CI_BRANCH=master-sync+adapt-coq8718-declaration-hooks
+    mtac2_CI_REF=master-sync+adapt-coq8718-declaration-hooks
+    mtac2_CI_GITURL=https://github.com/herbelin/Mtac2
+
+    Equations_CI_BRANCH=master+adapt-coq8718-declaration-hooks
+    Equations_CI_REF=master+adapt-coq8718-declaration-hooks
+    Equations_CI_GITURL=https://github.com/herbelin/Coq-Equations
+
+    Elpi_CI_BRANCH=coq-master+adapt-coq8718-declaration-hooks
+    Elpi_CI_REF=coq-master+adapt-coq8718-declaration-hooks
+    Elpi_CI_GITURL=https://github.com/herbelin/coq-elpi
+
+fi

--- a/vernac/lemmas.ml
+++ b/vernac/lemmas.ml
@@ -43,6 +43,11 @@ let call_hook ?hook ?fix_exn l c =
     let e = Option.cata (fun fix -> fix e) e fix_exn in
     iraise e
 
+let no_hook = mk_hook (fun _ _ -> ())
+
+let add_hook_backtrace ?hook ?fix_exn =
+  mk_hook (fun l c -> call_hook ?hook ?fix_exn l c)
+
 (* Support for mutually proved theorems *)
 
 let retrieve_first_recthm uctx = function

--- a/vernac/lemmas.ml
+++ b/vernac/lemmas.ml
@@ -305,7 +305,7 @@ let universe_proof_terminator ?univ_hook compute_guard =
   let open Proof_global in
   make_terminator begin function
   | Admitted (id,k,pe,ctx) ->
-    let hook = Option.map (fun univ_hook -> univ_hook (Some ctx)) univ_hook in
+    let hook = Option.map (fun univ_hook -> univ_hook ctx) univ_hook in
     admit ?hook (id,k,pe) (UState.universe_binders ctx) ();
     Feedback.feedback Feedback.AddedAxiom
   | Proved (opaque,idopt, { id; entries=[const]; persistence; universes } ) ->
@@ -317,7 +317,7 @@ let universe_proof_terminator ?univ_hook compute_guard =
     let id = match idopt with
       | None -> id
       | Some { CAst.v = save_id } -> check_anonymity id save_id; save_id in
-    let hook = Option.map (fun univ_hook -> univ_hook (Some universes)) univ_hook in
+    let hook = Option.map (fun univ_hook -> univ_hook universes) univ_hook in
     save ~export_seff id const universes compute_guard persistence hook
   | Proved (opaque,idopt, _ ) ->
     CErrors.anomaly Pp.(str "[universe_proof_terminator] close_proof returned more than one proof term")
@@ -395,10 +395,6 @@ let start_proof_with_initialization ?hook kind sigma decl recguard thms snl =
   | [] -> anomaly (Pp.str "No proof to start.")
   | (id,(t,(_,imps)))::other_thms ->
       let hook ctx strength ref =
-        let ctx = match ctx with
-        | None -> UState.empty
-        | Some ctx -> ctx
-        in
         let other_thms_data =
           if List.is_empty other_thms then [] else
             (* there are several theorems defined mutually *)

--- a/vernac/lemmas.mli
+++ b/vernac/lemmas.mli
@@ -18,6 +18,10 @@ val call_hook :
   ?hook:declaration_hook -> ?fix_exn:Future.fix_exn ->
   Decl_kinds.locality -> GlobRef.t -> unit
 
+val no_hook : declaration_hook
+val add_hook_backtrace : ?hook:declaration_hook -> ?fix_exn:Future.fix_exn ->
+  declaration_hook
+
 val start_proof : Id.t -> ?pl:UState.universe_decl -> goal_kind -> Evd.evar_map ->
   ?terminator:(?hook:declaration_hook -> Proof_global.lemma_possible_guards -> Proof_global.proof_terminator) ->
   ?sign:Environ.named_context_val ->

--- a/vernac/lemmas.mli
+++ b/vernac/lemmas.mli
@@ -25,10 +25,10 @@ val start_proof : Id.t -> ?pl:UState.universe_decl -> goal_kind -> Evd.evar_map 
   ?hook:declaration_hook ->  EConstr.types -> unit
 
 val start_proof_univs : Id.t -> ?pl:UState.universe_decl -> goal_kind -> Evd.evar_map ->
-  ?terminator:(?univ_hook:(UState.t option -> declaration_hook) -> Proof_global.lemma_possible_guards -> Proof_global.proof_terminator) ->
+  ?terminator:(?univ_hook:(UState.t -> declaration_hook) -> Proof_global.lemma_possible_guards -> Proof_global.proof_terminator) ->
   ?sign:Environ.named_context_val ->
   ?compute_guard:Proof_global.lemma_possible_guards ->
-  ?univ_hook:(UState.t option -> declaration_hook) -> EConstr.types -> unit
+  ?univ_hook:(UState.t -> declaration_hook) -> EConstr.types -> unit
 
 val start_proof_com :
   program_mode:bool -> ?inference_hook:Pretyping.inference_hook ->
@@ -44,7 +44,7 @@ val start_proof_with_initialization :
   int list option -> unit
 
 val universe_proof_terminator :
-  ?univ_hook:(UState.t option -> declaration_hook) ->
+  ?univ_hook:(UState.t -> declaration_hook) ->
   Proof_global.lemma_possible_guards ->
   Proof_global.proof_terminator
 

--- a/vernac/obligations.ml
+++ b/vernac/obligations.ml
@@ -29,6 +29,8 @@ let call_univ_hook ?univ_hook ?fix_exn uctx trans l c =
     let e = Option.cata (fun fix -> fix e) e fix_exn in
     iraise e
 
+let no_univ_hook = mk_univ_hook (fun _ _ _ _ -> ())
+
 module NamedDecl = Context.Named.Declaration
 
 let get_fix_exn, stm_get_fix_exn = Hook.make ()
@@ -482,7 +484,7 @@ let declare_definition prg =
   let ce = definition_entry ~fix_exn ~opaque ~types:typ ~univs body in
   let () = progmap_remove prg in
   let ubinders = UState.universe_binders uctx in
-  let hook = Lemmas.mk_hook (fun l r -> call_univ_hook ?univ_hook:prg.prg_hook ~fix_exn uctx obls l r; ()) in
+  let hook = Lemmas.mk_hook (fun l r -> call_univ_hook ?univ_hook:prg.prg_hook ~fix_exn uctx obls l r) in
   DeclareDef.declare_definition prg.prg_name
     prg.prg_kind ce ubinders prg.prg_implicits ~hook
 

--- a/vernac/obligations.ml
+++ b/vernac/obligations.ml
@@ -922,7 +922,6 @@ let obligation_hook prg obl num auto ctx' _ gr =
        if not transparent then err_not_transp ()
     | _ -> ()
   in
-  let ctx' = match ctx' with None -> prg.prg_ctx | Some ctx' -> ctx' in
   let inst, ctx' =
     if not (pi2 prg.prg_kind) (* Not polymorphic *) then
       (* The universe context was declared globally, we continue

--- a/vernac/obligations.mli
+++ b/vernac/obligations.mli
@@ -19,6 +19,8 @@ val mk_univ_hook : (UState.t -> (Id.t * constr) list -> Decl_kinds.locality -> G
 val call_univ_hook : ?univ_hook:univ_declaration_hook -> ?fix_exn:Future.fix_exn ->
   UState.t -> (Id.t * constr) list -> Decl_kinds.locality -> GlobRef.t -> unit
 
+val no_univ_hook : univ_declaration_hook
+
 (* This is a hack to make it possible for Obligations to craft a Qed
  * behind the scenes.  The fix_exn the Stm attaches to the Future proof
  * is not available here, so we provide a side channel to get it *)


### PR DESCRIPTION
**Kind:** architecture / cleanup

~~Depends on #8704 and #8717.~~

The main change is to unify the two kinds of hooks, the one depending on a `UState.t` and the other, leading to removal of redundancies (mainly in `lemmas.ml`).

Otherwise, it also starts a "hook API". Don't know yet if it is worth encapsulating it in a module.

It partially overlaps with #8705 in providing a `no_hook` where #8705 uses an optional argument.

- [ ] Entry added in `dev/doc/changes.md`? Probably to be added when stabilized

Better to skip the dependencies and see the diff only for the proper, last three, commits.