### PR TITLE
[Numeral notations] Use Coqlib registered constants

### DIFF
--- a/doc/sphinx/user-extensions/syntax-extensions.rst
+++ b/doc/sphinx/user-extensions/syntax-extensions.rst
@@ -1496,12 +1496,13 @@ Numeral notations
      function returns :g:`None`, or if the interpretation is registered
      for only non-negative integers, and the given numeral is negative.
 
-   .. exn:: @ident should go from Decimal.int to @type or (option @type). Instead of Decimal.int, the types Decimal.uint or Z could be used{? (require BinNums first)}.
+
+   .. exn:: @ident should go from Decimal.int to @type or (option @type). Instead of Decimal.int, the types Decimal.uint or Z could be used (you may need to require BinNums or Decimal first).
 
      The parsing function given to the :cmd:`Numeral Notation`
      vernacular is not of the right type.
 
-   .. exn:: @ident should go from @type to Decimal.int or (option Decimal.int).  Instead of Decimal.int, the types Decimal.uint or Z could be used{? (require BinNums first)}.
+   .. exn:: @ident should go from @type to Decimal.int or (option Decimal.int).  Instead of Decimal.int, the types Decimal.uint or Z could be used (you may need to require BinNums or Decimal first).
 
      The printing function given to the :cmd:`Numeral Notation`
      vernacular is not of the right type.

--- a/theories/Init/Decimal.v
+++ b/theories/Init/Decimal.v
@@ -40,7 +40,7 @@ Notation zero := (D0 Nil).
 
 (** For signed integers, we use two constructors [Pos] and [Neg]. *)
 
-Inductive int := Pos (d:uint) | Neg (d:uint).
+Variant int := Pos (d:uint) | Neg (d:uint).
 
 Declare Scope dec_uint_scope.
 Delimit Scope dec_uint_scope with uint.
@@ -49,6 +49,9 @@ Bind Scope dec_uint_scope with uint.
 Declare Scope dec_int_scope.
 Delimit Scope dec_int_scope with int.
 Bind Scope dec_int_scope with int.
+
+Register uint as num.uint.type.
+Register int as num.int.type.
 
 (** This representation favors simplicity over canonicity.
     For normalizing numbers, we need to remove head zero digits,

--- a/theories/Numbers/BinNums.v
+++ b/theories/Numbers/BinNums.v
@@ -29,6 +29,7 @@ Bind Scope positive_scope with positive.
 Arguments xO _%positive.
 Arguments xI _%positive.
 
+Register positive as num.pos.type.
 Register xI as num.pos.xI.
 Register xO as num.pos.xO.
 Register xH as num.pos.xH.


### PR DESCRIPTION
Fixes #8564.

Waiting for HoTT release, see https://github.com/coq/coq/pull/8720#issuecomment-434597150