### PR TITLE
More robust treatment of the Discharge status

### DIFF
--- a/dev/ci/user-overlays/08726-herbelin-master+more-stable-meaning-to-Discharge-flag.sh
+++ b/dev/ci/user-overlays/08726-herbelin-master+more-stable-meaning-to-Discharge-flag.sh
@@ -1,0 +1,23 @@
+if [ "$CI_PULL_REQUEST" = "8726" ] || [ "$CI_BRANCH" = "master+more-stable-meaning-to-Discharge-flag" ]; then
+
+    fiat_parsers_CI_BRANCH=master+change-for-coq-pr8726
+    fiat_parsers_CI_REF=master+change-for-coq-pr8726
+    fiat_parsers_CI_GITURL=https://github.com/herbelin/fiat
+
+    elpi_CI_BRANCH=coq-master+fix-global-pr8726
+    elpi_CI_REF=coq-master+fix-global-pr8726
+    elpi_CI_GITURL=https://github.com/herbelin/coq-elpi
+
+    equations_CI_BRANCH=master+fix-global-pr8726
+    equations_CI_REF=master+fix-global-pr8726
+    equations_CI_GITURL=https://github.com/herbelin/Coq-Equations
+
+    mtac2_CI_BRANCH=master+fix-global-pr8726
+    mtac2_CI_REF=master+fix-global-pr8726
+    mtac2_CI_GITURL=https://github.com/herbelin/Mtac2
+
+    paramcoq_CI_BRANCH=master+fix-global-pr8726
+    paramcoq_CI_REF=master+fix-global-pr8726
+    paramcoq_CI_GITURL=https://github.com/herbelin/paramcoq
+
+fi

--- a/dev/doc/changes.md
+++ b/dev/doc/changes.md
@@ -5,6 +5,10 @@
 - Functions and types deprecated in 8.10 have been removed in Coq
   8.11.
 
+- Type Decl_kinds.locality has been restructured, see commit
+  message. Main change to do generally is to change the flag "Global"
+  to "Global ImportDefaultBehavior".
+
 ## Changes between Coq 8.9 and Coq 8.10
 
 ### ML4 Pre Processing

--- a/doc/plugin_tutorial/tuto1/src/simple_declare.ml
+++ b/doc/plugin_tutorial/tuto1/src/simple_declare.ml
@@ -7,7 +7,7 @@ let edeclare ?hook ident (_, poly, _ as k) ~opaque sigma udecl body tyopt imps =
   DeclareDef.declare_definition ident k ce ubinders imps ?hook_data
 
 let declare_definition ~poly ident sigma body =
-  let k = (Decl_kinds.Global, poly, Decl_kinds.Definition) in
+  let k = Decl_kinds.(Global ImportDefaultBehavior, poly, Definition) in
   let udecl = UState.default_univ_decl in
   edeclare ident k ~opaque:false sigma udecl body None []
 

--- a/interp/declare.mli
+++ b/interp/declare.mli
@@ -53,14 +53,14 @@ val definition_entry : ?fix_exn:Future.fix_exn ->
   internal specify if the constant has been created by the kernel or by the
   user, and in the former case, if its errors should be silent *)
 val declare_constant :
- ?internal:internal_flag -> ?local:bool -> Id.t -> ?export_seff:bool -> constant_declaration -> Constant.t
+ ?internal:internal_flag -> ?local:import_status -> Id.t -> ?export_seff:bool -> constant_declaration -> Constant.t
 
 val declare_private_constant :
-  role:side_effect_role -> ?internal:internal_flag -> ?local:bool -> Id.t -> constant_declaration -> Constant.t * Safe_typing.private_constants
+  role:side_effect_role -> ?internal:internal_flag -> ?local:import_status -> Id.t -> constant_declaration -> Constant.t * Safe_typing.private_constants
 
 val declare_definition : 
   ?internal:internal_flag -> ?opaque:bool -> ?kind:definition_object_kind ->
-  ?local:bool -> Id.t -> ?types:constr ->
+  ?local:import_status -> Id.t -> ?types:constr ->
   constr Entries.in_universes_entry -> Constant.t
 
 (** Since transparent constants' side effects are globally declared, we

--- a/interp/dumpglob.ml
+++ b/interp/dumpglob.ml
@@ -91,7 +91,8 @@ let type_of_logical_kind = function
       (match a with
       | Definitional -> "defax"
       | Logical -> "prfax"
-      | Conjectural -> "prfax")
+      | Conjectural -> "prfax"
+      | Context -> "prfax")
   | IsProof th ->
       (match th with
       | Theorem

--- a/library/decl_kinds.ml
+++ b/library/decl_kinds.ml
@@ -46,7 +46,7 @@ type definition_object_kind =
   | Method
   | Let
 
-type assumption_object_kind = Definitional | Logical | Conjectural
+type assumption_object_kind = Definitional | Logical | Conjectural | Context
 
 (* [assumption_kind]
 

--- a/library/decl_kinds.ml
+++ b/library/decl_kinds.ml
@@ -12,7 +12,9 @@
 
 type discharge = DoDischarge | NoDischarge
 
-type locality = Discharge | Local | Global
+type import_status = ImportDefaultBehavior | ImportNeedQualified
+
+type locality = Discharge | Global of import_status
 
 type binding_kind = Explicit | Implicit
 

--- a/plugins/derive/derive.ml
+++ b/plugins/derive/derive.ml
@@ -26,7 +26,7 @@ let start_deriving f suchthat lemma =
 
   let env = Global.env () in
   let sigma = Evd.from_env env in
-  let kind = Decl_kinds.(Global,false,DefinitionBody Definition) in
+  let kind = Decl_kinds.(Global ImportDefaultBehavior,false,DefinitionBody Definition) in
 
   (* create a sort variable for the type of [f] *)
   (* spiwack: I don't know what the rigidity flag does, picked the one

--- a/plugins/funind/functional_principles_proofs.ml
+++ b/plugins/funind/functional_principles_proofs.ml
@@ -995,7 +995,7 @@ let generate_equation_lemma evd fnames f fun_num nb_params nb_args rec_args_num 
       Ensures by: obvious
       i*)
     (mk_equation_id f_id)
-    (Decl_kinds.Global, false, (Decl_kinds.Proof Decl_kinds.Theorem))
+    Decl_kinds.(Global ImportDefaultBehavior, false, Proof Theorem)
     evd
   lemma_type
   in

--- a/plugins/funind/functional_principles_types.ml
+++ b/plugins/funind/functional_principles_types.ml
@@ -311,7 +311,7 @@ let build_functional_principle (evd:Evd.evar_map ref) interactive_proof old_prin
   let pstate =
     Lemmas.start_proof
       new_princ_name
-      (Decl_kinds.Global,false,(Decl_kinds.Proof Decl_kinds.Theorem))
+      Decl_kinds.(Global ImportDefaultBehavior,false,Proof Theorem)
       !evd
       (EConstr.of_constr new_principle_type)
   in

--- a/plugins/funind/indfun.ml
+++ b/plugins/funind/indfun.ml
@@ -417,7 +417,7 @@ let register_struct is_rec (fixpoint_exprl:(Vernacexpr.fixpoint_expr * Vernacexp
       ComDefinition.do_definition
         ~program_mode:false
 	fname
-        (Decl_kinds.Global,false,Decl_kinds.Definition) pl
+        Decl_kinds.(Global ImportDefaultBehavior,false,Definition) pl
         bl None body (Some ret_type);
        let evd,rev_pconstants =
 	 List.fold_left
@@ -434,7 +434,7 @@ let register_struct is_rec (fixpoint_exprl:(Vernacexpr.fixpoint_expr * Vernacexp
        in
        None, evd,List.rev rev_pconstants
     | _ ->
-       ComFixpoint.do_fixpoint Global false fixpoint_exprl;
+       ComFixpoint.do_fixpoint (Global ImportDefaultBehavior) false fixpoint_exprl;
        let evd,rev_pconstants =
 	 List.fold_left
            (fun (evd,l) ((({CAst.v=fname},_),_,_,_,_),_) ->

--- a/plugins/funind/indfun_common.ml
+++ b/plugins/funind/indfun_common.ml
@@ -124,26 +124,20 @@ open Declare
 
 let definition_message = Declare.definition_message
 
-let get_locality = function
-| Discharge -> true
-| Local -> true
-| Global -> false
-
 let save id const ?hook uctx (locality,_,kind) =
   let fix_exn = Future.fix_exn_of const.const_entry_body in
-  let l,r = match locality with
-    | Discharge when Lib.sections_are_opened () ->
+  let r = match locality with
+    | Discharge ->
         let k = Kindops.logical_kind_of_goal_kind kind in
 	let c = SectionLocalDef const in
 	let _ = declare_variable id (Lib.cwd(), c, k) in
-	(Local, VarRef id)
-    | Discharge | Local | Global ->
-        let local = get_locality locality in
+        VarRef id
+    | Global local ->
         let k = Kindops.logical_kind_of_goal_kind kind in
         let kn = declare_constant id ~local (DefinitionEntry const, k) in
-	(locality, ConstRef kn)
+        ConstRef kn
   in
-  Lemmas.call_hook ?hook ~fix_exn uctx [] l r;
+  Lemmas.call_hook ?hook ~fix_exn uctx [] locality r;
   definition_message id
 
 let with_full_print f a =

--- a/plugins/funind/invfun.ml
+++ b/plugins/funind/invfun.ml
@@ -805,7 +805,7 @@ let derive_correctness make_scheme (funs: pconstant list) (graphs:inductive list
          let (typ,_) = lemmas_types_infos.(i) in
          let pstate = Lemmas.start_proof
 	   lem_id
-           (Decl_kinds.Global,false,((Decl_kinds.Proof Decl_kinds.Theorem)))
+           Decl_kinds.(Global ImportDefaultBehavior,false,Proof Theorem)
            !evd
            typ in
          let pstate = fst @@ Pfedit.by
@@ -866,7 +866,7 @@ let derive_correctness make_scheme (funs: pconstant list) (graphs:inductive list
 	   i*)
 	 let lem_id = mk_complete_id f_id in
          let pstate = Lemmas.start_proof lem_id
-           (Decl_kinds.Global,false,(Decl_kinds.Proof Decl_kinds.Theorem)) sigma
+           Decl_kinds.(Global ImportDefaultBehavior,false,Proof Theorem) sigma
          (fst lemmas_types_infos.(i)) in
          let pstate = fst (Pfedit.by
 	   (Proofview.V82.tactic (observe_tac ("prove completeness ("^(Id.to_string f_id)^")")

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -1371,7 +1371,7 @@ let open_new_goal pstate build_proof sigma using_lemmas ref_ goal_name (gls_type
   in
   let pstate = Lemmas.start_proof
     na
-    (Decl_kinds.Global, false (* FIXME *), Decl_kinds.Proof Decl_kinds.Lemma)
+    Decl_kinds.(Global ImportDefaultBehavior, false (* FIXME *), Proof Lemma)
     sigma gls_type ~hook:(Lemmas.mk_hook hook) in
   let pstate = if Indfun_common.is_strict_tcc  ()
   then
@@ -1411,7 +1411,7 @@ let com_terminate
     hook =
   let start_proof env ctx (tac_start:tactic) (tac_end:tactic) =
     let pstate = Lemmas.start_proof thm_name
-      (Global, false (* FIXME *), Proof Lemma) ~sign:(Environ.named_context_val env)
+      (Global ImportDefaultBehavior, false (* FIXME *), Proof Lemma) ~sign:(Environ.named_context_val env)
       ctx (EConstr.of_constr (compute_terminate_type nb_args fonctional_ref)) ~hook in
     let pstate = fst @@ by (Proofview.V82.tactic (observe_tac (fun _ _ -> str "starting_tac") tac_start)) pstate in
     fst @@ by (Proofview.V82.tactic (observe_tac (fun _ _ -> str "whole_start") (whole_start tac_end nb_args is_mes fonctional_ref
@@ -1457,7 +1457,7 @@ let com_eqn sign uctx nb_arg eq_name functional_ref f_ref terminate_ref equation
     let evd = Evd.from_ctx uctx in
     let f_constr = constr_of_monomorphic_global f_ref in
     let equation_lemma_type = subst1 f_constr equation_lemma_type in
-    let pstate = Lemmas.start_proof eq_name (Global, false, Proof Lemma) ~sign evd
+    let pstate = Lemmas.start_proof eq_name (Global ImportDefaultBehavior, false, Proof Lemma) ~sign evd
        (EConstr.of_constr equation_lemma_type) in
     let pstate = fst @@ by
        (Proofview.V82.tactic (start_equation f_ref terminate_ref

--- a/plugins/ltac/rewrite.ml
+++ b/plugins/ltac/rewrite.ml
@@ -1995,7 +1995,7 @@ let add_morphism_interactive atts m n : Proof_global.t =
   let env = Global.env () in
   let evd = Evd.from_env env in
   let uctx, instance = build_morphism_signature env evd m in
-  let kind = Decl_kinds.Global, atts.polymorphic,
+  let kind = Decl_kinds.Global Decl_kinds.ImportDefaultBehavior, atts.polymorphic,
              Decl_kinds.DefinitionBody Decl_kinds.Instance
   in
   let tac = make_tactic "Coq.Classes.SetoidTactics.add_morphism_tactic" in

--- a/proofs/pfedit.ml
+++ b/proofs/pfedit.ml
@@ -117,7 +117,7 @@ open Decl_kinds
 
 let next = let n = ref 0 in fun () -> incr n; !n
 
-let build_constant_by_tactic id ctx sign ?(goal_kind = Global, false, Proof Theorem) typ tac =
+let build_constant_by_tactic id ctx sign ?(goal_kind = Global ImportDefaultBehavior, false, Proof Theorem) typ tac =
   let evd = Evd.from_ctx ctx in
   let terminator = Proof_global.make_terminator (fun _ -> ()) in
   let goals = [ (Global.env_of_context sign , typ) ] in
@@ -139,7 +139,7 @@ let build_constant_by_tactic id ctx sign ?(goal_kind = Global, false, Proof Theo
 let build_by_tactic ?(side_eff=true) env sigma ?(poly=false) typ tac =
   let id = Id.of_string ("temporary_proof"^string_of_int (next())) in
   let sign = val_of_named_context (named_context env) in
-  let gk = Global, poly, Proof Theorem in
+  let gk = Global ImportDefaultBehavior, poly, Proof Theorem in
   let ce, status, univs =
     build_constant_by_tactic id sigma sign ~goal_kind:gk typ tac in
   let body = Future.force ce.const_entry_body in

--- a/tactics/abstract.ml
+++ b/tactics/abstract.ml
@@ -103,8 +103,8 @@ let cache_term_by_tactic_then ~opaque ~name_op ?(goal_type=None) tac tacK =
      question, how does abstract behave when discharge is local for example?
   *)
   let goal_kind, suffix = if opaque
-    then (Global,poly,Proof Theorem), "_subproof"
-    else (Global,poly,DefinitionBody Definition), "_subterm" in
+    then (Global ImportDefaultBehavior,poly,Proof Theorem), "_subproof"
+    else (Global ImportDefaultBehavior,poly,DefinitionBody Definition), "_subterm" in
   let id, goal_kind = name_op_to_name ~name_op ~name ~goal_kind suffix in
   Proofview.Goal.enter begin fun gl ->
   let env = Proofview.Goal.env gl in
@@ -158,7 +158,7 @@ let cache_term_by_tactic_then ~opaque ~name_op ?(goal_type=None) tac tacK =
     (* do not compute the implicit arguments, it may be costly *)
     let () = Impargs.make_implicit_args false in
     (* ppedrot: seems legit to have abstracted subproofs as local*)
-    Declare.declare_private_constant ~role:Entries.Subproof ~internal:Declare.InternalTacticRequest ~local:true id decl
+    Declare.declare_private_constant ~role:Entries.Subproof ~internal:Declare.InternalTacticRequest ~local:ImportNeedQualified id decl
   in
   let cst, eff = Impargs.with_implicit_protection cst () in
   let inst = match const.Entries.const_entry_universes with

--- a/test-suite/bugs/closed/bug_8725.v
+++ b/test-suite/bugs/closed/bug_8725.v
@@ -1,0 +1,2 @@
+Set Warnings "+local-declaration".
+Fail Let foo : True.

--- a/test-suite/success/LocalDefinition.v
+++ b/test-suite/success/LocalDefinition.v
@@ -1,0 +1,53 @@
+(* Test consistent behavior of Local Definition (#8722) *)
+
+(* Test consistent behavior of Local Definition wrt Admitted *)
+
+Module TestAdmittedVisibility.
+  Module A.
+    Let a1 : nat. Admitted. (* Suppose to behave like a "Local Definition" *)
+    Local Definition b1 : nat. Admitted. (* Told to be a "Local Definition" *)
+    Local Definition c1 := 0.
+    Local Parameter d1 : nat.
+    Section S.
+      Let a2 : nat. Admitted. (* Told to be turned into a toplevel assumption *)
+      Local Definition b2 : nat. Admitted. (* Told to be a "Local Definition" *)
+      Local Definition c2 := 0.
+      Local Parameter d2 : nat.
+    End S.
+  End A.
+  Import A.
+  Fail Check a1. (* used to be accepted *)
+  Fail Check b1. (* used to be accepted *)
+  Fail Check c1.
+  Fail Check d1.
+  Fail Check a2. (* used to be accepted *)
+  Fail Check b2. (* used to be accepted *)
+  Fail Check c2.
+  Fail Check d2.
+End TestAdmittedVisibility.
+
+(* Test consistent behavior of Local Definition wrt automatic declaration of instances *)
+
+Module TestVariableAsInstances.
+  Module Test1.
+    Set Typeclasses Axioms Are Instances.
+    Class U.
+    Local Parameter b : U.
+    Definition testU := _ : U. (* _ resolved *)
+
+    Class T.
+    Variable a : T.  (* warned to be the same as "Local Parameter" *)
+    Definition testT := _ : T. (* _ resolved *)
+  End Test1.
+
+  Module Test2.
+    Unset Typeclasses Axioms Are Instances.
+    Class U.
+    Local Parameter b : U.
+    Fail Definition testU := _ : U. (* _ unresolved *)
+
+    Class T.
+    Variable a : T.  (* warned to be the same as "Local Parameter" thus should not be an instance *)
+    Fail Definition testT := _ : T. (* used to succeed *)
+  End Test2.
+End TestVariableAsInstances.

--- a/vernac/class.ml
+++ b/vernac/class.ml
@@ -358,9 +358,9 @@ let try_add_new_coercion_with_source ref ~local poly ~source =
 
 let add_coercion_hook poly _uctx _trans local ref =
   let local = match local with
-  | Discharge
-  | Local -> true
-  | Global -> false
+  | Discharge -> assert false (* Local Coercion in section behaves like Local Definition *)
+  | Global ImportNeedQualified -> true
+  | Global ImportDefaultBehavior -> false
   in
   let () = try_add_new_coercion ref ~local poly in
   let msg = Nametab.pr_global_env Id.Set.empty ref ++ str " is now a coercion" in
@@ -370,9 +370,9 @@ let add_coercion_hook poly = Lemmas.mk_hook (add_coercion_hook poly)
 
 let add_subclass_hook poly _uctx _trans local ref =
   let stre = match local with
-  | Local -> true
-  | Global -> false
-  | Discharge -> assert false
+  | Discharge -> assert false (* Local Subclass in section behaves like Local Definition *)
+  | Global ImportNeedQualified -> true
+  | Global ImportDefaultBehavior -> false
   in
   let cl = class_of_global ref in
   try_add_new_coercion_subclass cl ~local:stre poly

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -367,7 +367,7 @@ let declare_instance_program env sigma ~global ~poly id pri imps decl term termt
   let hook = Lemmas.mk_hook hook in
   let ctx = Evd.evar_universe_context sigma in
   ignore(Obligations.add_definition id ?term:constr
-           ~univdecl:decl typ ctx ~kind:(Global,poly,Instance) ~hook obls)
+           ~univdecl:decl typ ctx ~kind:(Global ImportDefaultBehavior,poly,Instance) ~hook obls)
 
 
 let declare_instance_open sigma ?hook ~tac ~global ~poly id pri imps decl ids term termtype =
@@ -377,7 +377,7 @@ let declare_instance_open sigma ?hook ~tac ~global ~poly id pri imps decl ids te
      the refinement manually.*)
   let gls = List.rev (Evd.future_goals sigma) in
   let sigma = Evd.reset_future_goals sigma in
-  let kind = Decl_kinds.Global, poly, Decl_kinds.DefinitionBody Decl_kinds.Instance in
+  let kind = Decl_kinds.(Global ImportDefaultBehavior, poly, DefinitionBody Instance) in
   let pstate = Lemmas.start_proof id ~pl:decl kind sigma (EConstr.of_constr termtype)
       ~hook:(Lemmas.mk_hook
                (fun _ _ _ -> instance_hook pri global imps ?hook)) in

--- a/vernac/comAssumption.ml
+++ b/vernac/comAssumption.ml
@@ -45,7 +45,7 @@ let should_axiom_into_instance = function
 
 let declare_assumption is_coe (local,p,kind) (c,ctx) pl imps impl nl {CAst.v=ident} =
 match local with
-| Discharge when Lib.sections_are_opened () ->
+| Discharge ->
   let ctx = match ctx with
     | Monomorphic_entry ctx -> ctx
     | Polymorphic_entry (_, ctx) -> Univ.ContextSet.of_context ctx
@@ -61,9 +61,8 @@ match local with
   let () = if is_coe then Class.try_add_new_coercion r ~local:true false in
   (r,Univ.Instance.empty,true)
 
-| Global | Local | Discharge ->
+| Global local ->
   let do_instance = should_axiom_into_instance kind in
-  let local = DeclareDef.get_locality ident ~kind:"axiom" local in
   let inl = let open Declaremods in match nl with
     | NoInline -> None
     | DefaultInline -> Some (Flags.get_inline_level())
@@ -78,6 +77,7 @@ match local with
   let env = Global.env () in
   let sigma = Evd.from_env env in
   let () = if do_instance then Classes.declare_instance env sigma None false gr in
+  let local = match local with ImportNeedQualified -> true | ImportDefaultBehavior -> false in
   let () = if is_coe then Class.try_add_new_coercion gr ~local p in
   let inst = match ctx with
     | Polymorphic_entry (_, ctx) -> Univ.UContext.instance ctx
@@ -124,7 +124,7 @@ let process_assumptions_udecls kind l =
     | (_, ([], _))::_ | [] -> assert false
   in
   let () = match kind, udecl with
-    | (Discharge, _, _), Some _ when Lib.sections_are_opened () ->
+    | (Discharge, _, _), Some _ ->
       let loc = first_id.CAst.loc in
       let msg = Pp.str "Section variables cannot be polymorphic." in
       user_err ?loc  msg
@@ -288,7 +288,9 @@ let context poly l =
       | _ -> false
       in
       let impl = List.exists test impls in
-      let decl = (Discharge, poly, Context) in
+      let persistence =
+        if Lib.sections_are_opened () then Discharge else Global ImportDefaultBehavior in
+      let decl = (persistence, poly, Context) in
       let nstatus = match b with
       | None ->
         pi3 (declare_assumption false decl (t, univs) UnivNames.empty_binders [] impl

--- a/vernac/comAssumption.ml
+++ b/vernac/comAssumption.ml
@@ -37,11 +37,11 @@ let () =
       optwrite = (:=) axiom_into_instance; }
 
 let should_axiom_into_instance = function
-  | Discharge ->
+  | Context ->
     (* The typeclass behaviour of Variable and Context doesn't depend
        on section status *)
     true
-  | Global | Local -> !axiom_into_instance
+  | Definitional | Logical | Conjectural -> !axiom_into_instance
 
 let declare_assumption is_coe (local,p,kind) (c,ctx) pl imps impl nl {CAst.v=ident} =
 match local with
@@ -62,7 +62,7 @@ match local with
   (r,Univ.Instance.empty,true)
 
 | Global | Local | Discharge ->
-  let do_instance = should_axiom_into_instance local in
+  let do_instance = should_axiom_into_instance kind in
   let local = DeclareDef.get_locality ident ~kind:"axiom" local in
   let inl = let open Declaremods in match nl with
     | NoInline -> None
@@ -288,7 +288,7 @@ let context poly l =
       | _ -> false
       in
       let impl = List.exists test impls in
-      let decl = (Discharge, poly, Definitional) in
+      let decl = (Discharge, poly, Context) in
       let nstatus = match b with
       | None ->
         pi3 (declare_assumption false decl (t, univs) UnivNames.empty_binders [] impl

--- a/vernac/comFixpoint.ml
+++ b/vernac/comFixpoint.ml
@@ -305,7 +305,7 @@ let declare_cofixpoint_interactive local poly ((fixnames,fixrs,fixdefs,fixtypes)
       fixdefs) in
   let evd = Evd.from_ctx ctx in
   let pstate = Lemmas.start_proof_with_initialization
-    (Global,poly, DefinitionBody CoFixpoint)
+    (Global ImportDefaultBehavior,poly, DefinitionBody CoFixpoint)
     evd pl (Some(true,[],init_tac)) thms None in
   declare_cofixpoint_notations ntns;
   pstate

--- a/vernac/declareDef.mli
+++ b/vernac/declareDef.mli
@@ -11,8 +11,6 @@
 open Names
 open Decl_kinds
 
-val get_locality : Id.t -> kind:string -> Decl_kinds.locality -> bool
-
 val declare_definition
   : Id.t
   -> definition_kind

--- a/vernac/obligations.ml
+++ b/vernac/obligations.ml
@@ -643,7 +643,7 @@ let declare_obligation prg obl body ty uctx =
           const_entry_feedback = None;
       } in
       (* ppedrot: seems legit to have obligations as local *)
-      let constant = Declare.declare_constant obl.obl_name ~local:true
+      let constant = Declare.declare_constant obl.obl_name ~local:ImportNeedQualified
 	(DefinitionEntry ce,IsProof Property)
       in
       if not opaque then add_hint (Locality.make_section_locality None) prg constant;
@@ -787,9 +787,11 @@ let dependencies obls n =
       obls;
     !res
 
-let goal_kind poly = Decl_kinds.Local, poly, Decl_kinds.DefinitionBody Decl_kinds.Definition
+let goal_kind poly =
+  Decl_kinds.(Global ImportNeedQualified, poly, DefinitionBody Definition)
 
-let goal_proof_kind poly = Decl_kinds.Local, poly, Decl_kinds.Proof Decl_kinds.Lemma
+let goal_proof_kind poly =
+  Decl_kinds.(Global ImportNeedQualified, poly, Proof Lemma)
 
 let kind_of_obligation poly o =
   match o with
@@ -1102,7 +1104,7 @@ let show_term n =
             ++ Printer.pr_constr_env env sigma prg.prg_body)
 
 let add_definition n ?term t ctx ?(univdecl=UState.default_univ_decl)
-                   ?(implicits=[]) ?(kind=Global,false,Definition) ?tactic
+                   ?(implicits=[]) ?(kind=Global ImportDefaultBehavior,false,Definition) ?tactic
     ?(reduce=reduce) ?hook ?(opaque = false) obls =
   let sign = Lemmas.initialize_named_context_for_proof () in
   let info = Id.print n ++ str " has type-checked" in
@@ -1122,7 +1124,7 @@ let add_definition n ?term t ctx ?(univdecl=UState.default_univ_decl)
 	| _ -> res)
 
 let add_mutual_definitions l ctx ?(univdecl=UState.default_univ_decl) ?tactic
-                           ?(kind=Global,false,Definition) ?(reduce=reduce)
+                           ?(kind=Global ImportDefaultBehavior,false,Definition) ?(reduce=reduce)
     ?hook ?(opaque = false) notations fixkind =
   let sign = Lemmas.initialize_named_context_for_proof () in
   let deps = List.map (fun (n, b, t, imps, obls) -> n) l in
@@ -1153,7 +1155,7 @@ let admit_prog prg =
         | None ->
             let x = subst_deps_obl obls x in
             let ctx = UState.univ_entry ~poly:false prg.prg_ctx in
-            let kn = Declare.declare_constant x.obl_name ~local:true
+            let kn = Declare.declare_constant x.obl_name ~local:ImportNeedQualified
               (ParameterEntry (None,(x.obl_type,ctx),None), IsAssumption Conjectural)
             in
               assumption_message x.obl_name;

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -359,6 +359,8 @@ open Pputils
         keyword (if many then "Variables" else "Variable")
       | (DoDischarge,Conjectural) ->
         anomaly (Pp.str "Don't know how to beautify a local conjecture.")
+      | (_,Context) ->
+        anomaly (Pp.str "Context is used only internally.")
 
   let pr_params pr_c (xl,(c,t)) =
     hov 2 (prlist_with_sep sep pr_lident xl ++ spc() ++

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -606,7 +606,7 @@ let vernac_definition_name lid local =
   let () =
     match local with
     | Discharge -> Dumpglob.dump_definition lid true "var"
-    | Local | Global -> Dumpglob.dump_definition lid false "def"
+    | Global _ -> Dumpglob.dump_definition lid false "def"
   in
   lid
 
@@ -658,13 +658,13 @@ let vernac_exact_proof ~pstate c =
 let vernac_assumption ~atts discharge kind l nl =
   let open DefAttributes in
   let local = enforce_locality_exp atts.locality discharge in
-  let global = local == Global in
   let kind = local, atts.polymorphic, kind in
   List.iter (fun (is_coe,(idl,c)) ->
     if Dumpglob.dump () then
       List.iter (fun (lid, _) ->
-	if global then Dumpglob.dump_definition lid false "ax"
-	else Dumpglob.dump_definition lid true "var") idl) l;
+          match local with
+            | Global _ -> Dumpglob.dump_definition lid false "ax"
+            | Discharge -> Dumpglob.dump_definition lid true "var") idl) l;
   let status = ComAssumption.do_assumptions ~program_mode:atts.program kind nl l in
   if not status then Feedback.feedback Feedback.AddedAxiom
 


### PR DESCRIPTION
**Kind:** cleanup / bug fix

Has overlays to be merged synchronously:
- LPCIC/coq-elpi#62
- mattam82/Coq-Equations#210
- Mtac2/Mtac2#210
- mit-plv/fiat#27
- coq-community/paramcoq#32

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes #8722

Update: It was intended to also fix #8725 but the latter has been fixed differently.

- [X] Added / updated test-suite
- [ ] Entry to be added in CHANGES.md? I have no idea whether one can fall on these side corner examples by chance, and rely on them. [Update: personally, I would not add a comment to the coq-level change log but I can if at least someone insist.]

See [this](https://github.com/coq/coq/pull/8717#issuecomment-429317576) comment for some questions on the design issues. The names of constructors are a bit long but I could not find one both short and non too ambiguous. [Update: I found a simplification of the names of constructors. See [below](https://github.com/coq/coq/pull/8726#issuecomment-497938838).]

See #8722 and #8725 to evaluate whether the reported behaviors have indeed to be fixed or not.

I changed the message `id is declared as a local definition` into the much longer `Interpreting this declaration as if a global declaration prefixed by "Local" i.e. as a global declaration which shall not be available without qualification when imported.`. The point is that the message is now given at the step going from parser to command interpreter. I drop the name of `id` but I can reintroduce it if there is a demand. Suggestions to simplify the message welcome. [Update: the message seems then ok.]

@ejgallego: Where do you suggest I put the locality type? Maybe in `declare.ml`? [Update: I kept them in `decl_kinds.ml` which seems ok.]