### PR TITLE
[printing] [diffs] Refactor, correct doc, remove redundant parameters.

### DIFF
--- a/lib/pp_diff.ml
+++ b/lib/pp_diff.ml
@@ -146,12 +146,10 @@ let get_dinfo = function
   | `Removed (_, s) -> (`Removed, s)
   | `Added (_, s) -> (`Added, s)
 
-[@@@ocaml.warning "-32"]
-let string_of_diff_type = function
+let _string_of_diff_type = function
   | `Common  -> "Common"
   | `Removed -> "Removed"
   | `Added -> "Added"
-[@@@ocaml.warning "+32"]
 
 let wrap_in_bg diff_tag pp =
   let open Pp in

--- a/printing/printer.mli
+++ b/printing/printer.mli
@@ -138,55 +138,53 @@ val pr_transparent_state   : transparent_state -> Pp.t
 
 (** Proofs, these functions obey [Hyps Limit] and [Compact contexts]. *)
 
-(** [pr_goal ~diffs ~og_s g_s] prints the goal specified by [g_s].  If [diffs] is true,
-    highlight the differences between the old goal, [og_s], and [g_s].  [g_s] and [og_s] are
-    records containing the goal and sigma for, respectively, the new and old proof steps,
-    e.g. [{ it = g ; sigma = sigma }].
-*)
-val pr_goal                : ?diffs:bool -> ?og_s:(goal sigma) -> goal sigma -> Pp.t
+(** [pr_goal ?diff_goal g_s] prints the goal specified by [g_s].  If
+   [diff_goal] is passed, highlight the differences between the old
+   goal, [diff_goal], and [g_s]. *)
+val pr_goal                : ?diff_goal:(goal sigma) -> goal sigma -> Pp.t
 
-(** [pr_subgoals ~pr_first ~diffs ~os_map close_cmd sigma ~seeds ~shelf ~stack ~unfocused ~goals]
-   prints the goals in [goals] followed by the goals in [unfocused] in a compact form
-   (typically only the conclusion).  If [pr_first] is true, print the first goal in full.
+(** [pr_subgoals ?pr_first ?os_map close_cmd sigma ~seeds ~shelf
+   ~stack ~unfocused ~goals] prints the goals in [goals] followed by
+   the goals in [unfocused] in a compact form (typically only the
+   conclusion).  If [pr_first] is true, print the first goal in full.
    [close_cmd] is printed afterwards verbatim.
 
-   If [diffs] is true, then highlight diffs relative to [os_map] in the output for first goal.
-   [os_map] contains sigma for the old proof step and the goal map created by
+   If [os_map] is set, then it will highlight diffs relative to
+   [os_map] in the output for first goal.  [os_map] contains sigma for
+   the old proof step and the goal map created by
    [Proof_diffs.make_goal_map].
 
-   This function prints only the focused goals unless the corresponding option [enable_unfocused_goal_printing] is set.
-   [seeds] is for printing dependent evars (mainly for emacs proof tree mode).  [shelf] is from
-   Proof.proof and is used to identify shelved goals in a message if there are no more subgoals but
-   there are non-instantiated existential variables.  [stack] is used to print summary info on unfocused
-   goals.
-*)
-val pr_subgoals            : ?pr_first:bool -> ?diffs:bool -> ?os_map:(evar_map * Evar.t Evar.Map.t) -> Pp.t option -> evar_map
+   This function prints only the focused goals unless the
+   corresponding option [enable_unfocused_goal_printing] is set.
+   [seeds] is for printing dependent evars (mainly for emacs proof
+   tree mode).  [shelf] is from Proof.proof and is used to identify
+   shelved goals in a message if there are no more subgoals but there
+   are non-instantiated existential variables.  [stack] is used to
+   print summary info on unfocused goals.  *)
+val pr_subgoals            : ?pr_first:bool -> ?os_map:(evar_map * Evar.t Evar.Map.t) -> Pp.t option -> evar_map
                              -> seeds:goal list -> shelf:goal list -> stack:int list
                              -> unfocused: goal list -> goals:goal list -> Pp.t
 
 val pr_subgoal             : int -> evar_map -> goal list -> Pp.t
 
-(** [pr_concl n ~diffs ~og_s sigma g] prints the conclusion of the goal [g] using [sigma].  The output
-    is labelled "subgoal [n]".  If [diffs] is true, highlight the differences between the old conclusion,
-    [og_s], and [g]+[sigma].  [og_s] is a record containing the old goal and sigma, e.g. [{ it = g ; sigma = sigma }].
-*)
-val pr_concl               : int -> ?diffs:bool -> ?og_s:(goal sigma) -> evar_map -> goal -> Pp.t
+(** [pr_concl n ?og_s sigma g] prints the conclusion of the goal [g]
+   using [sigma].  The output is labelled "subgoal [n]".  If [og_s] is
+   passed, highlight the differences between the old conclusion,
+   [og_s], and [g]+[sigma]. *)
+val pr_concl               : int -> ?og_s:goal sigma -> evar_map -> goal -> Pp.t
 
-(** [pr_open_subgoals_diff ~quiet ~diffs ~oproof proof] shows the context for [proof] as used by, for example, coqtop.
-    The first active goal is printed with all its antecedents and the conclusion.  The other active goals only show their
-     conclusions.  If [diffs] is true, highlight the differences between the old proof, [oproof], and [proof].  [quiet]
-     disables printing messages as Feedback.
-*)
-val pr_open_subgoals_diff  : ?quiet:bool -> ?diffs:bool -> ?oproof:Proof.t -> Proof.t -> Pp.t
-val pr_open_subgoals       : proof:Proof.t -> Pp.t
+(** [pr_open_subgoals ?quiet ?oproof ~proof] shows the context for
+   [proof] as used by, for example, coqtop. The first active goal is
+   printed with all its antecedents and the conclusion.  The other
+   active goals only show their conclusions. If [diff_proof] is passed, it
+   the differences between the [diff_proof] and [proof] will be
+   highlight. *)
+val pr_open_subgoals : ?diff_proof:Proof.t -> proof:Proof.t -> Pp.t
 val pr_nth_open_subgoal    : proof:Proof.t -> int -> Pp.t
 val pr_evar                : evar_map -> (Evar.t * evar_info) -> Pp.t
 val pr_evars_int           : evar_map -> shelf:goal list -> givenup:goal list -> int -> evar_info Evar.Map.t -> Pp.t
 val pr_evars               : evar_map -> evar_info Evar.Map.t -> Pp.t
-val pr_ne_evar_set         : Pp.t -> Pp.t -> evar_map ->
-  Evar.Set.t -> Pp.t
-
-val print_and_diff : Proof.t option -> Proof.t option -> unit
+val pr_ne_evar_set         : Pp.t -> Pp.t -> evar_map -> Evar.Set.t -> Pp.t
 
 (** Declarations for the "Print Assumption" command *)
 type axiom =

--- a/printing/proof_diffs.mli
+++ b/printing/proof_diffs.mli
@@ -31,7 +31,7 @@ If you want to make your call especially bulletproof, catch these
 exceptions, print a user-visible message, then recall this routine with
 the first argument set to None, which will skip the diff.
 *)
-val diff_goal_ide : goal sigma option -> goal -> Evd.evar_map -> Pp.t list * Pp.t
+val diff_goal_ide : prev_goal:goal sigma -> goal -> Evd.evar_map -> Pp.t list * Pp.t
 
 (** Computes the diff between two goals
 
@@ -43,7 +43,7 @@ If you want to make your call especially bulletproof, catch these
 exceptions, print a user-visible message, then recall this routine with
 the first argument set to None, which will skip the diff.
 *)
-val diff_goal : ?og_s:(goal sigma) -> goal -> Evd.evar_map -> Pp.t
+val diff_goal : prev_goal:goal sigma -> goal -> Evd.evar_map -> Pp.t
 
 (** Convert a string to a list of token strings using the lexer *)
 val tokenize_string : string -> string list
@@ -61,12 +61,7 @@ will have the same goal id in both versions.
 
 [op] and [np] must be from the same proof document and [op] must be for a state
 before [np]. *)
-val make_goal_map : Proof.t option -> Proof.t -> Evar.t Evar.Map.t
-
-(* Exposed for unit test, don't use these otherwise *)
-(* output channel for the test log file *)
-val log_out_ch : out_channel ref
-
+val make_goal_map : Proof.t -> Proof.t -> Evar.t Evar.Map.t
 
 type hyp_info = {
   idents: string list;

--- a/test-suite/unit-tests/printing/proof_diffs_test.ml
+++ b/test-suite/unit-tests/printing/proof_diffs_test.ml
@@ -13,7 +13,6 @@ let add_test name test = tests := (mk_test name (TestCase test)) :: !tests
 let log_out_ch = open_log_out_ch __FILE__
 let cfprintf oc = Printf.(kfprintf (fun oc -> fprintf oc "") oc)
 let cprintf s = cfprintf log_out_ch s
-let _ = Proof_diffs.log_out_ch := log_out_ch
 
 let string_of_string s : string = "\"" ^ s ^ "\""
 

--- a/toplevel/coqloop.ml
+++ b/toplevel/coqloop.ml
@@ -354,8 +354,15 @@ let top_goal_print ~doc c oldp newp =
     let print_goals = proof_changed && Proof_global.there_are_pending_proofs () ||
                       print_anyway c in
     if not !Flags.quiet && print_goals then begin
-      let dproof = Stm.get_prev_proof ~doc (Stm.get_current_state ~doc) in
-      Printer.print_and_diff dproof newp
+      let diff_proof =
+        if Proof_diffs.show_diffs () then
+          Stm.get_prev_proof ~doc (Stm.get_current_state ~doc)
+        else None
+      in
+      Option.iter (fun proof ->
+          let proof_msg = Printer.pr_open_subgoals ?diff_proof ~proof in
+          Feedback.msg_notice proof_msg)
+        newp
     end
   with
   | exn ->

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -2031,7 +2031,7 @@ let vernac_show = function
   | ShowGoal goalref ->
     let proof = Proof_global.give_me_the_proof () in
     begin match goalref with
-    | OpenSubgoals -> pr_open_subgoals ~proof
+    | OpenSubgoals -> pr_open_subgoals ?diff_proof:None ~proof
     | NthGoal n -> pr_nth_open_subgoal ~proof n
     | GoalId id -> pr_goal_by_id ~proof id
     end


### PR DESCRIPTION
We refactor code of proofs diffs a bit, in particular we remove the
redundant [~diffs] parameter. If the client don't want to see diffs it
should not set [?diff_goal].

We also correct some nits in the documentation, and perform some
minimal refactoring.
