### PR TITLE
[build] [dune] Switch to a Dune-based build system.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -59,10 +59,28 @@ before_script:
 # - use artifacts between jobs                       #
 ######################################################
 
-# TODO figure out how to build doc for installed Coq
+# Template for building Coq + stdlib, typical use: overload the switch
 .build-template:
   stage: stage-1
   interruptible: true
+  dependencies: []
+  script:
+    - set -e
+    - make world
+    - set +e
+    - tar cfj _build.tar.bz2 _build
+  variables:
+    OPAM_SWITCH: base
+  artifacts:
+    name: "$CI_JOB_NAME"
+    when: always
+    paths:
+      - _build/log
+      - _build.tar.bz2
+    expire_in: 1 week
+
+.build-make-template:
+  stage: stage-1
   artifacts:
     name: "$CI_JOB_NAME"
     paths:
@@ -75,89 +93,31 @@ before_script:
     - set -e
 
     - echo 'start:coq.clean'
-    - make clean # ensure that `make clean` works on a fresh clone
+    - make -f Makefile.make clean # ensure that `make clean` works on a fresh clone
     - echo 'end:coq.clean'
 
     - echo 'start:coq.config'
-    - ./configure -warn-error yes -prefix "$(pwd)/_install_ci" ${COQ_EXTRA_CONF}"$COQ_EXTRA_CONF_QUOTE"
+    - ./configure -warn-error yes -prefix "$(pwd)/_install_ci"
     - echo 'end:coq.config'
 
     - echo 'start:coq.build'
-    - make -j "$NJOBS" byte
-    - make -j "$NJOBS" world $EXTRA_TARGET
-    - make test-suite/misc/universes/all_stdlib.v
+    - make -f Makefile.make -j "$NJOBS" byte
+    - make -f Makefile.make -j "$NJOBS" world $EXTRA_TARGET
+    - make -f Makefile.make test-suite/misc/universes/all_stdlib.v
     - echo 'end:coq:build'
 
     - echo 'start:coq.install'
-    - make install install-byte $EXTRA_INSTALL
-    - make install-byte
+    - make -f Makefile.make install install-byte $EXTRA_INSTALL
+    - make -f Makefile.make install-byte
     - cp bin/fake_ide _install_ci/bin/
     - echo 'end:coq.install'
 
     - set +e
 
-# Template for building Coq + stdlib, typical use: overload the switch
-.dune-template:
-  stage: stage-1
-  interruptible: true
-  dependencies: []
-  script:
-    - set -e
-    - make -f Makefile.dune world
-    - set +e
-    - tar cfj _build.tar.bz2 _build
-  variables:
-    OPAM_SWITCH: edge
-    OPAM_VARIANT: "+flambda"
-  artifacts:
-    name: "$CI_JOB_NAME"
-    when: always
-    paths:
-      - _build/log
-      - _build.tar.bz2
-    expire_in: 1 week
-
-.dune-ci-template:
-  stage: stage-2
-  interruptible: true
-  needs:
-    - build:edge+flambda:dune:dev
-  dependencies:
-    - build:edge+flambda:dune:dev
-  script:
-    - tar xfj _build.tar.bz2
-    - set -e
-    - echo 'start:coq.test'
-    - make -f Makefile.dune "$DUNE_TARGET"
-    - echo 'end:coq.test'
-    - set +e
-  variables:
-    OPAM_SWITCH: edge
-    OPAM_VARIANT: "+flambda"
-  artifacts:
-    when: always
-    name: "$CI_JOB_NAME"
-    expire_in: 2 months
-
 # every non build job must set dependencies otherwise all build
 # artifacts are used together and we may get some random Coq. To that
 # purpose, we add a spurious dependency `not-a-real-job` that must be
 # overridden otherwise the CI will fail.
-
-.doc-template:
-  stage: stage-2
-  interruptible: true
-  dependencies:
-    - not-a-real-job
-  script:
-    - SPHINXENV='COQBIN="'"$PWD"'/_install_ci/bin/"'
-    - make -j "$NJOBS" SPHINXENV="$SPHINXENV" SPHINX_DEPS= refman
-    - make install-doc-sphinx
-  artifacts:
-    name: "$CI_JOB_NAME"
-    paths:
-      - _install_ci/share/doc/coq/
-    expire_in: 2 months
 
 # set dependencies when using
 .test-suite-template:
@@ -166,18 +126,12 @@ before_script:
   dependencies:
     - not-a-real-job
   script:
-    - cd test-suite
-    - make clean
-    # careful with the ending /
-    - BIN=$(readlink -f ../_install_ci/bin)/
-    - LIB=$(readlink -f ../_install_ci/lib/coq)/
-    - export OCAMLPATH=$(readlink -f ../_install_ci/lib/):"$OCAMLPATH"
-    - make -j "$NJOBS" BIN="$BIN" COQLIB="$LIB" COQFLAGS="${COQFLAGS}" all
+    - make test-suite
   artifacts:
     name: "$CI_JOB_NAME.logs"
     when: on_failure
     paths:
-      - test-suite/logs
+      - _build/default/test-suite/logs
     # Gitlab doesn't support yet "expire_in: never" so we use the instance default
     # expire_in: never
 
@@ -188,7 +142,8 @@ before_script:
   dependencies:
     - not-a-real-job
   script:
-    - cd _install_ci
+    - tar xfj _build.tar.bz2
+    - cd _build/install/default
     - find lib/coq/ -name '*.vo' -fprint0 vofiles
     - xargs -0 --arg-file=vofiles bin/coqchk -o -m -coqlib lib/coq/ > ../coqchk.log 2>&1 || touch coqchk.failed
     - tail -n 1000 ../coqchk.log # the log is too big for gitlab so pipe to a file and display the tail
@@ -199,13 +154,15 @@ before_script:
       - coqchk.log
     expire_in: 2 months
 
+# Core CI template
 .ci-template:
   stage: stage-2
   interruptible: true
   script:
+    - tar xfj _build.tar.bz2
     - set -e
     - echo 'start:coq.test'
-    - make -f Makefile.ci -j "$NJOBS" "${CI_JOB_NAME#*:}"
+    - make -j "$NJOBS" "${CI_JOB_NAME#*:}"
     - echo 'end:coq.test'
     - set +e
   needs:
@@ -253,17 +210,19 @@ before_script:
     - git config --global user.name "coqbot"
     - git config --global user.email "coqbot@users.noreply.github.com"
 
-build:base:
-  extends: .build-template
+build:make:base:
+  extends: .build-make-template
   variables:
     COQ_EXTRA_CONF: "-native-compiler yes -coqide opt"
-    # coqdoc for stdlib, until we know how to build it from installed Coq
-    EXTRA_TARGET: "doc-stdlib"
-    EXTRA_INSTALL: "install-doc-stdlib-html install-doc-printable"
+
+build:base:
+  extends: .build-template
 
 # no coqide for 32bit: libgtk installation problems
 build:base+32bit:
   extends: .build-template
+  script:
+    - make coq coqide-server
   variables:
     OPAM_VARIANT: "+32bit"
     COQ_EXTRA_CONF: "-native-compiler yes"
@@ -276,17 +235,10 @@ build:edge+flambda:
   variables:
     OPAM_SWITCH: edge
     OPAM_VARIANT: "+flambda"
-    COQ_EXTRA_CONF: "-native-compiler yes -coqide opt -flambda-opts "
-    COQ_EXTRA_CONF_QUOTE: "-O3 -unbox-closures"
-
-build:edge+flambda:dune:dev:
-  extends: .dune-template
 
 build:base+async:
-  extends: .build-template
-  stage: stage-1
+  extends: .build-make-template
   variables:
-    COQ_EXTRA_CONF: "-native-compiler yes -coqide opt"
     COQUSERFLAGS: "-async-proofs on"
   timeout: 100m
   allow_failure: true # See https://github.com/coq/coq/issues/9658
@@ -295,7 +247,7 @@ build:base+async:
       - $UNRELIABLE =~ /enabled/
 
 build:quick:
-  extends: .build-template
+  extends: .build-make-template
   variables:
     COQ_EXTRA_CONF: "-native-compiler no"
     QUICK: "1"
@@ -366,6 +318,7 @@ pkg:opam:
     # because there is no --extra-trusted-public-key option.
     - nix-build -E "import (fetchTarball $CI_PROJECT_URL/-/archive/$CI_COMMIT_SHA.tar.gz) {}" -K --extra-substituters "$EXTRA_SUBSTITUTERS" --trusted-public-keys "$NIXOS_PUBLIC_KEY $EXTRA_PUBLIC_KEYS" | if [ ! -z "$CACHIX_SIGNING_KEY" ]; then cachix push coq; fi
   artifacts:
+    expire_in: 1 week
     name: "$CI_JOB_NAME.logs"
     when: on_failure
     paths:
@@ -411,29 +364,31 @@ pkg:nix:
     - master
     - /^v.*\..*$/
 
-doc:refman:
-  extends: .doc-template
-  dependencies:
-    - build:base
-  needs:
-    - build:base
-
-doc:refman:dune:
-  extends: .dune-ci-template
-  variables:
-    DUNE_TARGET: refman-html
+doc:apidoc:
+  extends: .ci-template
   artifacts:
+    when: on_success
+    name: "$CI_JOB_NAME"
+    expire_in: 1 week
     paths:
-      - _build/log
+      - _build/default/_doc/
+
+doc:refman-html:
+  extends: .ci-template
+  artifacts:
+    when: on_success
+    name: "$CI_JOB_NAME"
+    expire_in: 2 months
+    paths:
       - _build/default/doc/sphinx_build/html
 
-doc:stdlib:dune:
-  extends: .dune-ci-template
-  variables:
-    DUNE_TARGET: stdlib-html
+doc:stdlib-html:
+  extends: .ci-template
   artifacts:
+    when: on_success
+    name: "$CI_JOB_NAME"
+    expire_in: 2 months
     paths:
-      - _build/log
       - _build/default/doc/stdlib/html
 
 doc:refman:deploy:
@@ -445,13 +400,13 @@ doc:refman:deploy:
     variables:
       - $DOCUMENTATION_DEPLOY_KEY
   dependencies:
-    - doc:ml-api:odoc
-    - doc:refman:dune
-    - doc:stdlib:dune
+    - doc:apidoc
+    - doc:refman-html
+    - doc:stdlib-html
   needs:
-    - doc:ml-api:odoc
-    - doc:refman:dune
-    - doc:stdlib:dune
+    - doc:apidoc
+    - doc:refman-html
+    - doc:stdlib-html
   script:
     - echo "$DOCUMENTATION_DEPLOY_KEY" | tr -d '\r' | ssh-add - > /dev/null
     - git clone git@github.com:coq/doc.git _deploy
@@ -466,15 +421,6 @@ doc:refman:deploy:
     - git add api refman stdlib
     - git commit -m "Documentation of branch “$CI_COMMIT_REF_NAME” at $CI_COMMIT_SHORT_SHA"
     - git push # TODO: rebase and retry on failure
-
-doc:ml-api:odoc:
-  extends: .dune-ci-template
-  variables:
-    DUNE_TARGET: apidoc
-  artifacts:
-    paths:
-      - _build/log
-      - _build/default/_doc/
 
 test-suite:base:
   extends: .test-suite-template
@@ -503,35 +449,26 @@ test-suite:edge+flambda:
     OPAM_SWITCH: edge
     OPAM_VARIANT: "+flambda"
   only: *full-ci
-
-test-suite:edge:dune:dev:
-  stage: stage-2
-  dependencies:
-    - build:edge+flambda:dune:dev
-  needs:
-    - build:edge+flambda:dune:dev
-  script:
-    - tar xfj _build.tar.bz2
-    - make -f Makefile.dune test-suite
-  variables:
-    OPAM_SWITCH: edge
-    OPAM_VARIANT: "+flambda"
   artifacts:
     name: "$CI_JOB_NAME.logs"
     when: on_failure
     paths:
+      - _build/log
       - _build/default/test-suite/logs
     # Gitlab doesn't support yet "expire_in: never" so we use the instance default
     # expire_in: never
+    expire_in: 1 week
 
 test-suite:base+async:
-  extends: .test-suite-template
+  stage: stage-2
   dependencies:
-    - build:base
+    - build:make:base
   needs:
-    - build:base
+    - build:make:base
   variables:
     COQFLAGS: "-async-proofs on -async-proofs-cache force"
+  script:
+    - make -f Makefile.make test-suite
   timeout: 100m
   allow_failure: true
   only:
@@ -733,13 +670,6 @@ plugin:ci-paramcoq:
 
 plugin:ci-perennial:
   extends: .ci-template-flambda
-
-plugin:plugin-tutorial:
-  stage: stage-1
-  dependencies: []
-  script:
-    - ./configure -local -warn-error yes
-    - make -j "$NJOBS" plugin-tutorial
 
 plugin:ci-quickchick:
   extends: .ci-template-flambda

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,7 +14,7 @@ To compile Coq yourself, you need:
 
 - The [findlib](http://projects.camlcity.org/projects/findlib.html) library (version >= 1.8.0)
 
-- GNU Make (version >= 3.81)
+- [Dune](https://github.com/ocaml/dune) >= 2.4 _or_ GNU Make (version >= 3.81)
 
 - a C compiler
 
@@ -69,11 +69,14 @@ for more details.
 Build and Installation Procedure
 --------------------------------
 
-Coq offers the choice of two build systems, an experimental one based
-on [Dune](https://github.com/ocaml/dune), and the standard
-makefile-based one.
+Coq offers the choice of two build systems, one based on
+[Dune](https://github.com/ocaml/dune), the standard OCaml build tool,
+and one based on make. The default and recommended in the Dune-based
+one.
 
-Please see [INSTALL.make.md](dev/doc/INSTALL.make.md) for build and
-installation instructions using `make`. If you wish to experiment with
-the Dune-based system see the [dune guide for
-developers](dev/doc/build-system.dune.md).
+Please see [INSTALL.dune.md](dev/doc/INSTALL.dune.md) for build and
+installation instructions using `dune`. Also see the [dune guide for
+developers](dev/doc/build-system.dune).
+
+Instructions to install Coq with make can be found in
+[INSTALL.make.md](dev/doc/INSTALL.make.md).

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 ##########################################################################
 
 # The default build system is make-based one.
-ifndef COQ_USE_DUNE
+ifdef COQ_USE_MAKE
 include Makefile.make
 else
 include Makefile.dune

--- a/Makefile.dune
+++ b/Makefile.dune
@@ -116,6 +116,8 @@ ireport:
 clean:
 	dune clean
 
+include Makefile.ci
+
 # Other common dev targets:
 #
 # dune build coq.install

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -68,7 +68,7 @@ jobs:
       opam switch set ocaml-base-compiler.$COMPILER
       eval $(opam env)
       opam update
-      opam install -j "$NJOBS" num ocamlfind${FINDLIB_VER} ounit lablgtk3-sourceview3
+      opam install -j "$NJOBS" num ocamlfind${FINDLIB_VER} ounit dune lablgtk3-sourceview3
       opam list
     displayName: 'Install OCaml dependencies'
     env:
@@ -76,18 +76,17 @@ jobs:
       FINDLIB_VER: ".1.8.1"
       OPAMYES: "true"
 
+  # We don't install gtk for now
   - script: |
       set -e
-
       eval $(opam env)
       ./configure -prefix '$(Build.BinariesDirectory)' -warn-error yes -native-compiler no -coqide opt
-      make -j "$NJOBS" byte
-      make -j "$NJOBS"
+      make coq coqide-server coqide
     displayName: 'Build Coq'
 
   - script: |
       eval $(opam env)
-      make -j "$NJOBS" test-suite PRINT_LOGS=1
+      make NJOBS="$NJOBS" test-suite
     displayName: 'Run Coq Test Suite'
 
   - script: |

--- a/default.nix
+++ b/default.nix
@@ -84,10 +84,11 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  buildFlags = [ "world" "byte" ] ++ optional buildDoc "doc-html";
+  buildFlags = [ "world" ] ++ optional buildDoc "refman-html";
 
-  installTargets =
-    [ "install" "install-byte" ] ++ optional buildDoc "install-doc-html";
+  # Nix Dune:
+  # it should use "dune-install pkg" [opam-install for the refman]
+  # installTargets = [ "install" ] ++ optional buildDoc "install-html";
 
   createFindlibDestdir = !shell;
 

--- a/dev/build/osx/make-macos-dmg.sh
+++ b/dev/build/osx/make-macos-dmg.sh
@@ -9,10 +9,10 @@ VERSION=$(sed -n -e '/^let coq_version/ s/^[^"]*"\([^"]*\)"$/\1/p' configure.ml)
 APP=bin/CoqIDE_${VERSION}.app
 
 # Create a .app file with CoqIDE, without signing it
-make PRIVATEBINARIES="$APP" -j "$NJOBS" -l2 "$APP"
+make -f Makefile.make PRIVATEBINARIES="$APP" -j "$NJOBS" -l2 "$APP"
 
 # Add Coq to the .app file
-make OLDROOT="$OUTDIR" COQINSTALLPREFIX="$APP/Contents/Resources" install-coq install-ide-toploop
+make -f Makefile.make OLDROOT="$OUTDIR" COQINSTALLPREFIX="$APP/Contents/Resources/" install-coq install-ide-toploop
 
 # Create the dmg bundle
 mkdir -p "$DMGDIR"

--- a/dev/build/windows/makecoq_mingw.sh
+++ b/dev/build/windows/makecoq_mingw.sh
@@ -1357,17 +1357,17 @@ function make_coq {
 
     # 8.4x doesn't support parallel make
     if [[ $COQ_VERSION == 8.4* ]] ; then
-      log1 make
+      log1 make -f Makefile.make
     else
       # shellcheck disable=SC2086
-      log1 make $MAKE_OPT
+      log1 make -f Makefile.make $MAKE_OPT
     fi
 
     if [ "$INSTALLMODE" == "relocatable" ]; then
       logn reconfigure ./configure -with-doc no -prefix "$PREFIXCOQ" -libdir "$PREFIXCOQ/lib/coq" -mandir "$PREFIXCOQ/man"
     fi
 
-    log2 make install
+    log2 make -f Makefile.make install
     log1 copy_coq_dlls
     log1 copy_coq_gtk
 

--- a/dev/ci/ci-common.sh
+++ b/dev/ci/ci-common.sh
@@ -8,9 +8,10 @@ export NJOBS
 
 if [ -n "${GITLAB_CI}" ];
 then
-    # Gitlab build, Coq installed into `_install_ci`
-    export OCAMLPATH="$PWD/_install_ci/lib:$OCAMLPATH"
-    export COQBIN="$PWD/_install_ci/bin"
+    # Gitlab build with Dune
+    export OCAMLPATH="$PWD/_build/install/default/lib/"
+    export COQBIN="$PWD/_build/install/default/bin"
+    export COQLIB="$PWD/_build/install/default/lib/coq"
     export CI_BRANCH="$CI_COMMIT_REF_NAME"
     if [[ ${CI_BRANCH#pr-} =~ ^[0-9]*$ ]]
     then

--- a/dev/ci/user-overlays/08729-ejgallego-dune+kill_make.sh
+++ b/dev/ci/user-overlays/08729-ejgallego-dune+kill_make.sh
@@ -1,0 +1,14 @@
+if [ "$CI_PULL_REQUEST" = "8729" ] || [ "$CI_BRANCH" = "dune+kill_make" ]; then
+
+    true
+
+    # ltac2_CI_REF=rm-section-path
+    # ltac2_CI_GITURL=https://github.com/maximedenes/ltac2
+
+    # Elpi_CI_REF=fix_ltac_packing
+    # Elpi_CI_GITURL=https://github.com/ejgallego/coq-elpi
+
+    # Equations_CI_REF=vernac+monify_hook
+    # Equations_CI_GITURL=https://github.com/ejgallego/Coq-Equations
+
+fi

--- a/dev/doc/INSTALL.dune.md
+++ b/dev/doc/INSTALL.dune.md
@@ -1,0 +1,20 @@
+# Installing with Dune
+
+The build and installation procedure using Dune is quite
+straightforward. We recommend you read Dune's user manual for
+questions, as Coq mostly implements a standard build workflow.
+
+## Quick Installation Procedure [Dune].
+=======================================
+
+1. COQ_CONFIGURE_PREFIX=$prefix make release
+2. dune install [--prefix=$prefix] coq
+
+If you don't pass the prefix argument to `dune install` it will choose
+your default OCaml library path.
+
+## Developer setup.
+===================
+
+For more information about the Dune build system just type `make`, you
+can also read `dev/doc/build-system.dune.md`

--- a/dev/doc/INSTALL.make.md
+++ b/dev/doc/INSTALL.make.md
@@ -2,8 +2,8 @@ Quick Installation Procedure using Make.
 ----------------------------------------
 
     $ ./configure
-    $ make
-    $ make install (you may need superuser rights)
+    $ make -f Makefile.make
+    $ make -f Makefile.make install (you may need superuser rights)
 
 Detailed Installation Procedure.
 --------------------------------
@@ -92,7 +92,7 @@ Detailed Installation Procedure.
 
 4. Still in the root directory, do
 
-        make
+        make -f Makefile.make
 
    to compile Coq in the best OCaml mode available (native-code if supported,
    bytecode otherwise).
@@ -115,17 +115,17 @@ Detailed Installation Procedure.
    defined at configuration time (step 3). Just do
 
         umask 022
-        make install
+        make -f Makefile.make install
 
    Of course, you may need superuser rights to do that.
 
 6. Optionally, you could build the bytecode version of Coq via:
 
-        make byte
+        make -f Makefile.make byte
 
    and install it via
 
-        make install-byte
+        make -f Makefile.make install-byte
 
   This version is much slower than the native code version of Coq, but could
   be helpful for debugging purposes. In particular, coqtop.byte embeds an OCaml
@@ -133,7 +133,7 @@ Detailed Installation Procedure.
 
 7. You can now clean all the sources. (You can even erase them.)
 
-        make clean
+        make -f Makefile.make clean
 
 Installation Procedure For Plugin Developers.
 ---------------------------------------------
@@ -206,7 +206,7 @@ So, in order to compile Coq for a new architecture, proceed as follows:
 * Omit step 7 above and clean only the architecture dependent files:
   it is done automatically with the command
 
-        make archclean
+        make -f Makefile.make archclean
 
 * Configure the system for the new architecture:
 

--- a/dev/doc/build-system.dune.md
+++ b/dev/doc/build-system.dune.md
@@ -220,6 +220,11 @@ useful to Coq, some examples are:
 - Automatic Generation of OPAM files.
 - Multi-directory libraries.
 
+## Tweaking `dune` files
+
+As a developer, you should not have to deal with `dune` configuration
+files on a regular basis, unless adding a new library or plugin.
+
 ## FAQ
 
 - I get "Error: Dynlink error: Interface mismatch":

--- a/tools/coqdep_common.ml
+++ b/tools/coqdep_common.ml
@@ -400,6 +400,8 @@ let add_caml_known phys_dir _ f =
   match suff with
     | ".mllib" -> add_mllib_known basename (Some phys_dir) suff
     | ".mlpack" -> add_mlpack_known basename (Some phys_dir) suff
+    (* Must add support to remove the mlpack files *)
+    (* | ".dune" -> add_mlpack_known basename (Some phys_dir) suff *)
     | _ -> ()
 
 let add_coqlib_known recur phys_dir log_dir f =


### PR DESCRIPTION
Over the last months we have added support to build Coq with Dune, I
feel we have reached a point where we can start to discuss if we
should replace the make-based system with a Dune-based one.

The *main rationale* for the switch is that maintaining two build
systems is hard, and Dune seems superior to make in almost every
aspect.

Indeed, I think it is going to be hard to find technical arguments to
defend the make-base system. Dune outperforms it on almost every
possible metric.

Additionally, the make-based system has grew organically over the
years, and these days we are spending significant developer resources
on it. The number of bugs that would be fixed by Dune is large [see #8052].
It is not a coincidence that few large projects do use `make` anymore,
but most have moved to `CMake`, `Ninja`, or some other alternative.

On this side, Dune provides a well-defined model that seems to git
Coq's present and future necessities well.

*Blockers*: the single blocker for a merge as of today, apart from the
depending PRs, is the lack of native-compute support. This is due to a
technical limitation wrt targets and can be solved in several
different ways. Also, it is likely that a smooth developer profile is
not possible until https://github.com/ocaml/dune/issues/1155 lands in
Dune itself. https://github.com/ocaml/dune/issues/1377 may be
convenient for the reference manual but we can have a small workaround
to generate the install file for now.

*Risk analysis*: it is important to understand the risks that such a
move would entail. After Dune support is merged we could always go
back to a make-based system, however we are very likely to depend on
Dune-specific features that would be hard to replicate. The main risks are:

- lock-in: indeed lock-in risk is significant and Coq's source code
  may depend on some Dune features. On the other hand, Dune is
  strongly poised to be the standard build tool for the OCaml platform
  and ecosystem, and more than 50% of OPAM packages use it.

  It is safe to say that if Dune would become unsupported in the
  future, there would be more important problems than Coq itself.

- lack of in-house knowledge: indeed, Dune requires some specific
  training in order to understand its build rules, which may become a
  problem. This risk is mitigated in 2 different ways and attenuated
  by an additional consideration: first, Dune rules are fairly simple
  and declarative and it is reasonable to expect developers get to
  know them without too much effort. This is one of the reasons for
  the high adoption numbers in the ecosystem. Second, Dune developers
  are very reactive and care about Coq, thus it is safe to assume that
  we would get external help if needed. The additional consideration
  that may make this less of a problem is that our in-house knowledge
  of make may be even worse than Dune's. A non-negligible number of
  developers have expressed discomfort with make and the amount of
  required knowledge to master make seems way higher than what you
  need to use Dune.

- lack of flexibility: indeed, Dune is way less flexible than
  make. Dune only knows how to do well two things: building OCaml
  executables and libraries. However, that is basically 99% of what
  building Coq entails; building other parts [documentation or Coq
  libraries] is fairly straightforward and seem to pose not a problem.

- lack of maturity: indeed, Dune develops fast, it is not free of
  bugs, and some amount of adaptation is expected from us. This risk
  can only be mitigated if there is continued developer interest.  In
  the worst case, Coq could become stuck in a particular Dune version.

- bootstrapping: this is not a problem as witnessed by #8615, Dune can
  be bootstrapped very easily as it depends only on OCaml and it is
  designed to do so.
