### PR TITLE
Add unicode category LM

### DIFF
--- a/clib/unicode.ml
+++ b/clib/unicode.ml
@@ -86,6 +86,7 @@ let classify =
         Unicodetable.ll;           (* Letter, lowercase.                *)
         Unicodetable.lt;           (* Letter, titlecase.                *)
         Unicodetable.lo;           (* Letter, others.                   *)
+        Unicodetable.lm;           (* Letter, modifier.                 *)
       ];
     mk_lookup_table_from_unicode_tables_for IdentPart
       [


### PR DESCRIPTION
Since the Unicode character category LM contains some characters frequently used in Japanese words (e.g., U+30FC "ー" is used in words like データ, which means "data", オーバーフロー, which means "overflow", etc.,) so this change will be very helpful to write Coq codes in Japanese.