### PR TITLE
Make diffs work for more input strings

### DIFF
--- a/parsing/cLexer.mli
+++ b/parsing/cLexer.mli
@@ -56,3 +56,14 @@ val set_lexer_state : lexer_state -> unit
 val get_lexer_state : unit -> lexer_state
 val drop_lexer_state : unit -> unit
 val get_comment_state : lexer_state -> ((int * int) * string) list
+
+(** Create a lexer.  true enables alternate handling for computing diffs.
+It ensures that, ignoring white space, the concatenated tokens equal the input
+string.  Specifically:
+- for strings, return the enclosing quotes as tokens and treat the quoted value
+as if it was unquoted, possibly becoming multiple tokens
+- for comments, return the "(*" as a token and treat the contents of the comment as if
+it was not in a comment, possibly becoming multiple tokens
+- return any unrecognized Ascii or UTF-8 character as a string
+*)
+val make_lexer : diff_mode:bool -> Tok.t Gramlib.Plexing.lexer

--- a/parsing/tok.ml
+++ b/parsing/tok.ml
@@ -40,18 +40,19 @@ let extract_string diff_mode = function
   | KEYWORD s -> s
   | IDENT s -> s
   | STRING s ->
-   if diff_mode then
-    let escape_quotes s =
-      let len = String.length s in
-      let buf = Buffer.create len in
-      for i = 0 to len-1 do
-        let ch = String.get s i in
-        Buffer.add_char buf ch;
-        if ch = '"' then Buffer.add_char buf '"' else ()
-      done;
-      Buffer.contents buf
-    in
-    "\"" ^ (escape_quotes s) ^ "\"" else s
+    if diff_mode then
+      let escape_quotes s =
+        let len = String.length s in
+        let buf = Buffer.create len in
+        for i = 0 to len-1 do
+          let ch = String.get s i in
+          Buffer.add_char buf ch;
+          if ch = '"' then Buffer.add_char buf '"' else ()
+        done;
+        Buffer.contents buf
+      in
+      "\"" ^ (escape_quotes s) ^ "\""
+    else s
   | PATTERNIDENT s -> s
   | FIELD s -> if diff_mode then "." ^ s else s
   | INT s -> s

--- a/printing/proof_diffs.ml
+++ b/printing/proof_diffs.ml
@@ -88,7 +88,8 @@ let tokenize_string s =
   let st = CLexer.get_lexer_state () in
   try
     let istr = Stream.of_string s in
-    let lex = CLexer.lexer.Gramlib.Plexing.tok_func istr in
+    let lexer = CLexer.make_lexer ~diff_mode:true in
+    let lex = lexer.Gramlib.Plexing.tok_func istr in
     let toks = stream_tok [] (fst lex) in
     CLexer.set_lexer_state st;
     toks


### PR DESCRIPTION
Diff code uses the lexer to recognize tokens in the inputs, which can be
Pp.t's or strings.  To add the highlights in the resulting Pp.t, the diff code
matches characters in the input to characters in the tokens.  Current
code fails for inputs containing quote marks or "(*" because the quote
marks and comments don't appear in the tokens.  Also some characters
such as "&" and UTF-8 characters that are considered `Symbol`s are rejected
by the lexer.  This commit adds a "diff mode" to the lexer to return those
characters, making the diff routine more robust.

Note: It will still be possible to get a Diff_Failure if the string contains ill-formed UTF-8 characters.

**Kind:** bug fix.

Fixes https://github.com/coq/coq/issues/8120 issue 1 (issue 3 has already been done, issue 2 is not important)

- [x] Added / updated test-suite
