### PR TITLE
Removing the Camlp5 macros from CLexer.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,7 +135,6 @@ coqpp/coqpp_parse.mli
 g_*.ml
 
 lib/coqProject_file.ml
-parsing/cLexer.ml
 plugins/ltac/coretactics.ml
 plugins/ltac/extratactics.ml
 plugins/ltac/extraargs.ml

--- a/Makefile.build
+++ b/Makefile.build
@@ -406,7 +406,7 @@ grammar/%.cmi: grammar/%.mli
 
 .PHONY: coqbinaries coqbyte
 
-coqbinaries: $(TOPBINOPT) $(COQTOPEXE) $(CHICKEN) $(CSDPCERT) $(FAKEIDE)
+coqbinaries: $(TOPBINOPT) $(COQTOPEXE) $(CHICKEN) $(CSDPCERT) $(FAKEIDE) $(GRAMMARCMA)
 coqbyte: $(TOPBYTE) $(CHICKENBYTE)
 
 # Special rule for coqtop, we imitate `ocamlopt` can delete the target


### PR DESCRIPTION
We partially hand-translated so as to result in the minimal diff possible.
