### PR TITLE
Delay Universe Substitution in CClosure

### DIFF
--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -537,14 +537,14 @@ let destFLambda clos_fun t =
 
 (* Optimization: do not enclose variables in a closure.
    Makes variable access much faster *)
-let subst_if_not_empty subst u = if Univ.Instance.is_empty u then u else Univ.subst_instance_instance subst u
+let subst_if_not_empty subst u = if Univ.Instance.is_empty subst then u else Univ.subst_instance_instance subst u
 let mk_clos (e : fconstr fusubs) t =
   match kind t with
   | Rel i -> clos_rel (fst e) i
     | Var x -> { norm = Red; term = FFlex (VarKey x) }
-  | Const (c,u) -> { norm = Red; term = FFlex (ConstKey (c, subst_instance_instance (snd e) u)) }
+  | Const (c,u) -> { norm = Red; term = FFlex (ConstKey (c, subst_if_not_empty (snd e) u)) }
   | Meta _ -> { norm = Norm; term = FAtom t }
-  | Sort (Sorts.Type u) ->  { norm = Norm; term = FAtom (mkSort (Sorts.Type (subst_instance_universe (snd e) u))) }
+  | Sort (Sorts.Type u) ->  { norm = Norm; term = FAtom (mkSort (Sorts.Type (if Instance.is_empty (snd e) then u else subst_instance_universe (snd e) u))) }
   | Sort _ -> { norm = Norm; term = FAtom t }
   | Ind (i, u) -> { norm = Norm; term = FInd (i, subst_if_not_empty (snd e) u) }
   | Construct (c, u) -> { norm = Cstr; term = FConstruct (c, subst_if_not_empty (snd e) u) }

--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -282,8 +282,6 @@ let assoc_defined id env = match Environ.lookup_named id env with
 | LocalDef (_, c, _) -> c
 | _ -> raise Not_found
 
-open Declarations
-
 let ref_value_cache ({i_cache = cache;_} as infos) tab ref =
   try
     Some (KeyTable.find tab ref)

--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -571,16 +571,22 @@ let rec to_constr lfts v =
     | FInd op -> mkIndU op
     | FConstruct op -> mkConstructU op
     | FCaseT (ci,p,c,ve,env) ->
-      if is_subs_id (fst env) && is_lift_id lfts && Instance.is_empty (snd env) then
+      let is_id1 = is_subs_id (fst env) && is_lift_id lfts in
+      if is_id1 && Instance.is_empty (snd env) then
         mkCase (ci, p, to_constr lfts c, ve)
+      else if is_id1 then
+        subst_instance_constr (snd env) (mkCase (ci, p, to_constr lfts c, ve))
       else
         let subs = comp_subs lfts env in
         mkCase (ci, subst_constr (subs, snd env) p,
             to_constr lfts c,
             Array.map (fun b -> subst_constr (subs, snd env) b) ve)
     | FFix ((op,(lna,tys,bds)) as fx, e) ->
-      if is_subs_id (fst e) && is_lift_id lfts && Instance.is_empty (snd e) then
+      let is_id1 = is_subs_id (fst e) && is_lift_id lfts in
+      if is_id1 && Instance.is_empty (snd e) then
         mkFix fx
+      else if is_id1 then
+        subst_instance_constr (snd e) (mkFix fx)
       else
         let n = Array.length bds in
         let subs_ty = comp_subs lfts e in
@@ -589,8 +595,11 @@ let rec to_constr lfts v =
         let bds = Array.Fun1.map subst_constr (subs_bd, snd e) bds in
         mkFix (op, (lna, tys, bds))
     | FCoFix ((op,(lna,tys,bds)) as cfx, e) ->
-      if is_subs_id (fst e) && is_lift_id lfts && Instance.is_empty (snd e) then
+      let is_id1 = is_subs_id (fst e) && is_lift_id lfts in
+      if is_id1 && Instance.is_empty (snd e) then
         mkCoFix cfx
+      else if is_id1 then
+        subst_instance_constr (snd e) (mkCoFix cfx)
       else
         let n = Array.length bds in
         let subs_ty = comp_subs lfts e in
@@ -605,8 +614,11 @@ let rec to_constr lfts v =
         mkProj (p,to_constr lfts c)
 
     | FLambda (len, tys, f, e) ->
-      if is_subs_id (fst e) && is_lift_id lfts && Instance.is_empty (snd e) then
+      let is_id1 = is_subs_id (fst e) && is_lift_id lfts in
+      if is_id1 && Instance.is_empty (snd e) then
         Term.compose_lam (List.rev tys) f
+      else if is_id1 then
+        subst_instance_constr (snd e) (Term.compose_lam (List.rev tys) f)
       else
         let subs = comp_subs lfts e in
         let tys = List.mapi (fun i (na, c) -> na, subst_constr (subs_liftn i subs, snd e) c) tys in
@@ -625,7 +637,11 @@ let rec to_constr lfts v =
         mkEvar(ev,Array.map (fun a -> subst_constr (subs, snd env) a) args)
     | FLIFT (k,a) -> to_constr (el_shft k lfts) a
     | FCLOS (t,env) ->
-      if is_subs_id (fst env) && is_lift_id lfts && Instance.is_empty (snd env) then t
+      let is_id1 = is_subs_id (fst env) && is_lift_id lfts in
+      if is_id1 && Instance.is_empty (snd env) then
+ t
+      else if is_id1 then
+ subst_instance_constr (snd env) (t)
       else
         let subs = comp_subs lfts env in
         subst_constr (subs, snd env) t

--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -571,16 +571,16 @@ let rec to_constr lfts v =
     | FInd op -> mkIndU op
     | FConstruct op -> mkConstructU op
     | FCaseT (ci,p,c,ve,env) ->
-      if is_subs_id (fst env) && is_lift_id lfts && Instance.is_empty (snd env) then
-        mkCase (ci, p, to_constr lfts c, ve)
+      if is_subs_id (fst env) && is_lift_id lfts then
+        subst_instance_constr (snd env) (mkCase (ci, p, to_constr lfts c, ve))
       else
         let subs = comp_subs lfts env in
         mkCase (ci, subst_constr (subs, snd env) p,
             to_constr lfts c,
             Array.map (fun b -> subst_constr (subs, snd env) b) ve)
     | FFix ((op,(lna,tys,bds)) as fx, e) ->
-      if is_subs_id (fst e) && is_lift_id lfts && Instance.is_empty (snd e) then
-        mkFix fx
+      if is_subs_id (fst e) && is_lift_id lfts then
+        subst_instance_constr (snd e) (mkFix fx)
       else
         let n = Array.length bds in
         let subs_ty = comp_subs lfts e in
@@ -589,8 +589,8 @@ let rec to_constr lfts v =
         let bds = Array.Fun1.map subst_constr (subs_bd, snd e) bds in
         mkFix (op, (lna, tys, bds))
     | FCoFix ((op,(lna,tys,bds)) as cfx, e) ->
-      if is_subs_id (fst e) && is_lift_id lfts && Instance.is_empty (snd e) then
-        mkCoFix cfx
+      if is_subs_id (fst e) && is_lift_id lfts then
+        subst_instance_constr (snd e) (mkCoFix cfx)
       else
         let n = Array.length bds in
         let subs_ty = comp_subs lfts e in
@@ -605,8 +605,8 @@ let rec to_constr lfts v =
         mkProj (p,to_constr lfts c)
 
     | FLambda (len, tys, f, e) ->
-      if is_subs_id (fst e) && is_lift_id lfts && Instance.is_empty (snd e) then
-        Term.compose_lam (List.rev tys) f
+      if is_subs_id (fst e) && is_lift_id lfts then
+        subst_instance_constr (snd e) (Term.compose_lam (List.rev tys) f)
       else
         let subs = comp_subs lfts e in
         let tys = List.mapi (fun i (na, c) -> na, subst_constr (subs_liftn i subs, snd e) c) tys in
@@ -625,7 +625,8 @@ let rec to_constr lfts v =
         mkEvar(ev,Array.map (fun a -> subst_constr (subs, snd env) a) args)
     | FLIFT (k,a) -> to_constr (el_shft k lfts) a
     | FCLOS (t,env) ->
-      if is_subs_id (fst env) && is_lift_id lfts && Instance.is_empty (snd env) then t
+      if is_subs_id (fst env) && is_lift_id lfts then
+        subst_instance_constr (snd env) t
       else
         let subs = comp_subs lfts env in
         subst_constr (subs, snd env) t

--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -571,22 +571,16 @@ let rec to_constr lfts v =
     | FInd op -> mkIndU op
     | FConstruct op -> mkConstructU op
     | FCaseT (ci,p,c,ve,env) ->
-      let is_id1 = is_subs_id (fst env) && is_lift_id lfts in
-      if is_id1 && Instance.is_empty (snd env) then
+      if is_subs_id (fst env) && is_lift_id lfts && Instance.is_empty (snd env) then
         mkCase (ci, p, to_constr lfts c, ve)
-      else if is_id1 then
-        subst_instance_constr (snd env) (mkCase (ci, p, to_constr lfts c, ve))
       else
         let subs = comp_subs lfts env in
         mkCase (ci, subst_constr (subs, snd env) p,
             to_constr lfts c,
             Array.map (fun b -> subst_constr (subs, snd env) b) ve)
     | FFix ((op,(lna,tys,bds)) as fx, e) ->
-      let is_id1 = is_subs_id (fst e) && is_lift_id lfts in
-      if is_id1 && Instance.is_empty (snd e) then
+      if is_subs_id (fst e) && is_lift_id lfts && Instance.is_empty (snd e) then
         mkFix fx
-      else if is_id1 then
-        subst_instance_constr (snd e) (mkFix fx)
       else
         let n = Array.length bds in
         let subs_ty = comp_subs lfts e in
@@ -595,11 +589,8 @@ let rec to_constr lfts v =
         let bds = Array.Fun1.map subst_constr (subs_bd, snd e) bds in
         mkFix (op, (lna, tys, bds))
     | FCoFix ((op,(lna,tys,bds)) as cfx, e) ->
-      let is_id1 = is_subs_id (fst e) && is_lift_id lfts in
-      if is_id1 && Instance.is_empty (snd e) then
+      if is_subs_id (fst e) && is_lift_id lfts && Instance.is_empty (snd e) then
         mkCoFix cfx
-      else if is_id1 then
-        subst_instance_constr (snd e) (mkCoFix cfx)
       else
         let n = Array.length bds in
         let subs_ty = comp_subs lfts e in
@@ -614,11 +605,8 @@ let rec to_constr lfts v =
         mkProj (p,to_constr lfts c)
 
     | FLambda (len, tys, f, e) ->
-      let is_id1 = is_subs_id (fst e) && is_lift_id lfts in
-      if is_id1 && Instance.is_empty (snd e) then
+      if is_subs_id (fst e) && is_lift_id lfts && Instance.is_empty (snd e) then
         Term.compose_lam (List.rev tys) f
-      else if is_id1 then
-        subst_instance_constr (snd e) (Term.compose_lam (List.rev tys) f)
       else
         let subs = comp_subs lfts e in
         let tys = List.mapi (fun i (na, c) -> na, subst_constr (subs_liftn i subs, snd e) c) tys in
@@ -637,11 +625,7 @@ let rec to_constr lfts v =
         mkEvar(ev,Array.map (fun a -> subst_constr (subs, snd env) a) args)
     | FLIFT (k,a) -> to_constr (el_shft k lfts) a
     | FCLOS (t,env) ->
-      let is_id1 = is_subs_id (fst env) && is_lift_id lfts in
-      if is_id1 && Instance.is_empty (snd env) then
- t
-      else if is_id1 then
- subst_instance_constr (snd env) (t)
+      if is_subs_id (fst env) && is_lift_id lfts && Instance.is_empty (snd env) then t
       else
         let subs = comp_subs lfts env in
         subst_constr (subs, snd env) t

--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -1052,7 +1052,8 @@ let whd_val info tab v =
 let norm_val info tab v =
   with_stats (lazy (kl info tab v))
 
-let inject (c, u) = mk_clos (subs_id 0, u) c
+let inject c = mk_clos (subs_id 0, Instance.empty) c
+let inject_with_univ (c, u) = mk_clos (subs_id 0, u) c
 
 let whd_stack infos tab m stk = match m.norm with
 | Whnf | Norm ->
@@ -1069,7 +1070,7 @@ type clos_infos = fconstr infos
 
 let create_clos_infos ?(evars=fun _ -> None) flgs env =
   let share = (Environ.typing_flags env).Declarations.share_reduction in
-  create ~share ~repr:(fun _ _ c -> inject c) flgs env evars
+  create ~share ~repr:(fun _ _ c -> inject_with_univ c) flgs env evars
 
 let create_tab () = KeyTable.create 17
 

--- a/kernel/cClosure.mli
+++ b/kernel/cClosure.mli
@@ -187,7 +187,7 @@ val unfold_projection : 'a infos -> Projection.t -> stack_member option
    [create_clos_infos], inject the term to reduce with [inject]; then use
    a reduction function *)
 
-val inject : constr puniverses -> fconstr
+val inject : constr -> fconstr
 
 (** mk_atom: prevents a term from being evaluated *)
 val mk_atom : constr -> fconstr

--- a/kernel/reduction.ml
+++ b/kernel/reduction.ml
@@ -117,12 +117,12 @@ let whd_betaiota env t =
     | App (c, _) ->
       begin match kind c with
       | Ind _ | Construct _ | Evar _ | Meta _ | Const _ | LetIn _ -> t
-      | _ -> whd_val (create_clos_infos betaiota env) (create_tab ()) (inject (t, Univ.Instance.empty))
+      | _ -> whd_val (create_clos_infos betaiota env) (create_tab ()) (inject t)
       end
-    | _ -> whd_val (create_clos_infos betaiota env) (create_tab ()) (inject (t, Univ.Instance.empty))
+    | _ -> whd_val (create_clos_infos betaiota env) (create_tab ()) (inject t)
 
 let nf_betaiota env t =
-  norm_val (create_clos_infos betaiota env) (create_tab ()) (inject (t, Univ.Instance.empty))
+  norm_val (create_clos_infos betaiota env) (create_tab ()) (inject t)
 
 let whd_betaiotazeta env x =
   match kind x with
@@ -133,10 +133,10 @@ let whd_betaiotazeta env x =
       | Ind _ | Construct _ | Evar _ | Meta _ | Const _ -> x
       | Sort _ | Rel _ | Var _ | Cast _ | Prod _ | Lambda _ | LetIn _ | App _
         | Case _ | Fix _ | CoFix _ | Proj _ ->
-         whd_val (create_clos_infos betaiotazeta env) (create_tab ()) (inject (x, Univ.Instance.empty))
+         whd_val (create_clos_infos betaiotazeta env) (create_tab ()) (inject x)
       end
     | Rel _ | Cast _ | LetIn _ | Case _ | Proj _ ->
-        whd_val (create_clos_infos betaiotazeta env) (create_tab ()) (inject (x, Univ.Instance.empty))
+        whd_val (create_clos_infos betaiotazeta env) (create_tab ()) (inject x)
 
 let whd_all env t =
   match kind t with
@@ -147,10 +147,10 @@ let whd_all env t =
       | Ind _ | Construct _ | Evar _ | Meta _ -> t
       | Sort _ | Rel _ | Var _ | Cast _ | Prod _ | Lambda _ | LetIn _ | App _
         | Const _ |Case _ | Fix _ | CoFix _ | Proj _ ->
-         whd_val (create_clos_infos all env) (create_tab ()) (inject (t, Univ.Instance.empty))
+         whd_val (create_clos_infos all env) (create_tab ()) (inject t)
       end
     | Rel _ | Cast _ | LetIn _ | Case _ | Proj _ | Const _ | Var _ ->
-        whd_val (create_clos_infos all env) (create_tab ()) (inject (t, Univ.Instance.empty))
+        whd_val (create_clos_infos all env) (create_tab ()) (inject t)
 
 let whd_allnolet env t =
   match kind t with
@@ -161,10 +161,10 @@ let whd_allnolet env t =
       | Ind _ | Construct _ | Evar _ | Meta _ | LetIn _ -> t
       | Sort _ | Rel _ | Var _ | Cast _ | Prod _ | Lambda _ | App _
         | Const _ | Case _ | Fix _ | CoFix _ | Proj _ ->
-         whd_val (create_clos_infos allnolet env) (create_tab ()) (inject (t, Univ.Instance.empty))
+         whd_val (create_clos_infos allnolet env) (create_tab ()) (inject t)
       end
     | Rel _ | Cast _ | Case _ | Proj _ | Const _ | Var _ ->
-        whd_val (create_clos_infos allnolet env) (create_tab ()) (inject (t, Univ.Instance.empty))
+        whd_val (create_clos_infos allnolet env) (create_tab ()) (inject t)
 
 (********************************************************************)
 (*                         Conversion                               *)
@@ -637,7 +637,7 @@ let clos_gen_conv trans cv_pb l2r evars env univs t1 t2 =
     lft_tab = create_tab ();
     rgt_tab = create_tab ();
   } in
-  ccnv cv_pb l2r infos el_id el_id (inject (t1, Univ.Instance.empty)) (inject (t2, Univ.Instance.empty)) univs
+  ccnv cv_pb l2r infos el_id el_id (inject t1) (inject t2) univs
 
 
 let check_eq univs u u' = 

--- a/kernel/reduction.ml
+++ b/kernel/reduction.ml
@@ -117,12 +117,12 @@ let whd_betaiota env t =
     | App (c, _) ->
       begin match kind c with
       | Ind _ | Construct _ | Evar _ | Meta _ | Const _ | LetIn _ -> t
-      | _ -> whd_val (create_clos_infos betaiota env) (create_tab ()) (inject t)
+      | _ -> whd_val (create_clos_infos betaiota env) (create_tab ()) (inject (t, Univ.Instance.empty))
       end
-    | _ -> whd_val (create_clos_infos betaiota env) (create_tab ()) (inject t)
+    | _ -> whd_val (create_clos_infos betaiota env) (create_tab ()) (inject (t, Univ.Instance.empty))
 
 let nf_betaiota env t =
-  norm_val (create_clos_infos betaiota env) (create_tab ()) (inject t)
+  norm_val (create_clos_infos betaiota env) (create_tab ()) (inject (t, Univ.Instance.empty))
 
 let whd_betaiotazeta env x =
   match kind x with
@@ -133,10 +133,10 @@ let whd_betaiotazeta env x =
       | Ind _ | Construct _ | Evar _ | Meta _ | Const _ -> x
       | Sort _ | Rel _ | Var _ | Cast _ | Prod _ | Lambda _ | LetIn _ | App _
         | Case _ | Fix _ | CoFix _ | Proj _ ->
-         whd_val (create_clos_infos betaiotazeta env) (create_tab ()) (inject x)
+         whd_val (create_clos_infos betaiotazeta env) (create_tab ()) (inject (x, Univ.Instance.empty))
       end
     | Rel _ | Cast _ | LetIn _ | Case _ | Proj _ ->
-        whd_val (create_clos_infos betaiotazeta env) (create_tab ()) (inject x)
+        whd_val (create_clos_infos betaiotazeta env) (create_tab ()) (inject (x, Univ.Instance.empty))
 
 let whd_all env t =
   match kind t with
@@ -147,10 +147,10 @@ let whd_all env t =
       | Ind _ | Construct _ | Evar _ | Meta _ -> t
       | Sort _ | Rel _ | Var _ | Cast _ | Prod _ | Lambda _ | LetIn _ | App _
         | Const _ |Case _ | Fix _ | CoFix _ | Proj _ ->
-         whd_val (create_clos_infos all env) (create_tab ()) (inject t)
+         whd_val (create_clos_infos all env) (create_tab ()) (inject (t, Univ.Instance.empty))
       end
     | Rel _ | Cast _ | LetIn _ | Case _ | Proj _ | Const _ | Var _ ->
-        whd_val (create_clos_infos all env) (create_tab ()) (inject t)
+        whd_val (create_clos_infos all env) (create_tab ()) (inject (t, Univ.Instance.empty))
 
 let whd_allnolet env t =
   match kind t with
@@ -161,10 +161,10 @@ let whd_allnolet env t =
       | Ind _ | Construct _ | Evar _ | Meta _ | LetIn _ -> t
       | Sort _ | Rel _ | Var _ | Cast _ | Prod _ | Lambda _ | App _
         | Const _ | Case _ | Fix _ | CoFix _ | Proj _ ->
-         whd_val (create_clos_infos allnolet env) (create_tab ()) (inject t)
+         whd_val (create_clos_infos allnolet env) (create_tab ()) (inject (t, Univ.Instance.empty))
       end
     | Rel _ | Cast _ | Case _ | Proj _ | Const _ | Var _ ->
-        whd_val (create_clos_infos allnolet env) (create_tab ()) (inject t)
+        whd_val (create_clos_infos allnolet env) (create_tab ()) (inject (t, Univ.Instance.empty))
 
 (********************************************************************)
 (*                         Conversion                               *)
@@ -574,8 +574,8 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
 	  let n = Array.length cl1 in
           let fty1 = Array.map (mk_clos e1) tys1 in
           let fty2 = Array.map (mk_clos e2) tys2 in
-          let fcl1 = Array.map (mk_clos (subs_liftn n e1)) cl1 in
-          let fcl2 = Array.map (mk_clos (subs_liftn n e2)) cl2 in
+          let fcl1 = Array.map (mk_clos (fstapp (subs_liftn n) e1)) cl1 in
+          let fcl2 = Array.map (mk_clos (fstapp (subs_liftn n) e2)) cl2 in
           let el1 = el_stack lft1 v1 in
           let el2 = el_stack lft2 v2 in
           let cuniv = convert_vect l2r infos el1 el2 fty1 fty2 cuniv in
@@ -591,8 +591,8 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
 	  let n = Array.length cl1 in
           let fty1 = Array.map (mk_clos e1) tys1 in
           let fty2 = Array.map (mk_clos e2) tys2 in
-          let fcl1 = Array.map (mk_clos (subs_liftn n e1)) cl1 in
-          let fcl2 = Array.map (mk_clos (subs_liftn n e2)) cl2 in
+          let fcl1 = Array.map (mk_clos (fstapp (subs_liftn n) e1)) cl1 in
+          let fcl2 = Array.map (mk_clos (fstapp (subs_liftn n) e2)) cl2 in
           let el1 = el_stack lft1 v1 in
           let el2 = el_stack lft2 v2 in
           let cuniv = convert_vect l2r infos el1 el2 fty1 fty2 cuniv in
@@ -637,7 +637,7 @@ let clos_gen_conv trans cv_pb l2r evars env univs t1 t2 =
     lft_tab = create_tab ();
     rgt_tab = create_tab ();
   } in
-  ccnv cv_pb l2r infos el_id el_id (inject t1) (inject t2) univs
+  ccnv cv_pb l2r infos el_id el_id (inject (t1, Univ.Instance.empty)) (inject (t2, Univ.Instance.empty)) univs
 
 
 let check_eq univs u u' = 

--- a/plugins/setoid_ring/newring.ml
+++ b/plugins/setoid_ring/newring.ml
@@ -62,7 +62,7 @@ let rec mk_clos_but f_map n t =
   | None -> mk_atom t
 
 and tag_arg f_map n tag c = match tag with
-| Eval -> mk_clos (Esubst.subs_id n) c
+| Eval -> mk_clos (Esubst.subs_id n, Univ.Instance.empty) c
 | Prot -> mk_atom c
 | Rec -> mk_clos_but f_map n c
 

--- a/pretyping/cbv.ml
+++ b/pretyping/cbv.ml
@@ -456,7 +456,7 @@ let cbv_norm infos constr =
 let create_cbv_infos flgs env sigma =
   let infos = create
     ~share:true (** Not used by cbv *)
-    ~repr:(fun old_info tab c -> cbv_stack_term { tab; infos = old_info; sigma } TOP (subs_id 0) c)
+    ~repr:(fun old_info tab (c, u) -> cbv_stack_term { tab; infos = old_info; sigma } TOP (subs_id 0) (subst_instance_constr u c))
     flgs
     env
     (Reductionops.safe_evar_value sigma) in

--- a/pretyping/inferCumulativity.ml
+++ b/pretyping/inferCumulativity.ml
@@ -170,14 +170,14 @@ let infer_arity_constructor is_arity env variances arcn =
   let infer_typ typ (env,variances) =
     match typ with
     | Context.Rel.Declaration.LocalAssum (_, typ') ->
-      (Environ.push_rel typ env, infer_term CUMUL env variances (typ', Instance.empty))
+      (Environ.push_rel typ env, infer_term CUMUL env variances typ')
     | Context.Rel.Declaration.LocalDef _ -> assert false
   in
   let typs, codom = Reduction.dest_prod env arcn in
   let env, variances = Context.Rel.fold_outside infer_typ typs ~init:(env, variances) in
   (* If we have Inductive foo@{i j} : ... -> Type@{i} := C : ... -> foo Type@{j}
      i is irrelevant, j is invariant. *)
-  if not is_arity then infer_term CUMUL env variances (codom, Instance.empty) else variances
+  if not is_arity then infer_term CUMUL env variances codom else variances
 
 let infer_inductive env mie =
   let open Entries in

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -1237,7 +1237,7 @@ let clos_norm_flags flgs env sigma t =
     EConstr.of_constr (CClosure.norm_val
       (CClosure.create_clos_infos ~evars flgs env)
       (CClosure.create_tab ())
-      (CClosure.inject (EConstr.Unsafe.to_constr t)))
+      (CClosure.inject (EConstr.Unsafe.to_constr t, Instance.empty)))
   with e when is_anomaly e -> user_err Pp.(str "Tried to normalize ill-typed term")
 
 let clos_whd_flags flgs env sigma t =
@@ -1246,7 +1246,7 @@ let clos_whd_flags flgs env sigma t =
     EConstr.of_constr (CClosure.whd_val
       (CClosure.create_clos_infos ~evars flgs env)
       (CClosure.create_tab ())
-      (CClosure.inject (EConstr.Unsafe.to_constr t)))
+      (CClosure.inject (EConstr.Unsafe.to_constr t, Instance.empty)))
   with e when is_anomaly e -> user_err Pp.(str "Tried to normalize ill-typed term")
 
 let nf_beta = clos_norm_flags CClosure.beta

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -1237,7 +1237,7 @@ let clos_norm_flags flgs env sigma t =
     EConstr.of_constr (CClosure.norm_val
       (CClosure.create_clos_infos ~evars flgs env)
       (CClosure.create_tab ())
-      (CClosure.inject (EConstr.Unsafe.to_constr t, Instance.empty)))
+      (CClosure.inject (EConstr.Unsafe.to_constr t)))
   with e when is_anomaly e -> user_err Pp.(str "Tried to normalize ill-typed term")
 
 let clos_whd_flags flgs env sigma t =
@@ -1246,7 +1246,7 @@ let clos_whd_flags flgs env sigma t =
     EConstr.of_constr (CClosure.whd_val
       (CClosure.create_clos_infos ~evars flgs env)
       (CClosure.create_tab ())
-      (CClosure.inject (EConstr.Unsafe.to_constr t, Instance.empty)))
+      (CClosure.inject (EConstr.Unsafe.to_constr t)))
   with e when is_anomaly e -> user_err Pp.(str "Tried to normalize ill-typed term")
 
 let nf_beta = clos_norm_flags CClosure.beta


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->
This patch (written together with @pythonesque) addresses the simpler proposal from #8721. We tried the other, more complicated variant but currently that is slow and does not work.

In local benchmarks we see a slight slowdown (0.1%, could be noise) in building the standard library but HoTT got a 2.5% improvement (and Mtac2 also saw a measurable improvement with similar changes to its very outdated copy of cClosure.ml).

<!-- Keep what applies -->
**Kind:** performance.


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #8721 
