### PR TITLE
[dune] [plugins] Fix plugin name ground -> firstorder

### DIFF
--- a/plugins/firstorder/plugin_base.dune
+++ b/plugins/firstorder/plugin_base.dune
@@ -1,5 +1,5 @@
 (library
  (name ground_plugin)
- (public_name coq.plugins.ground)
+ (public_name coq.plugins.firstorder)
  (synopsis "Coq's first order logic solver plugin")
  (libraries coq.plugins.ltac))


### PR DESCRIPTION
This is needed for compatibility with directory-listing
infrastructure.
