### PR TITLE
Automatically generate names for universes.

### DIFF
--- a/interp/declare.ml
+++ b/interp/declare.ml
@@ -525,7 +525,7 @@ let declare_univ_binders gr pl =
     let l = match gr with
       | ConstRef c -> Label.to_id @@ Constant.label c
       | IndRef (c, _) -> Label.to_id @@ MutInd.label c
-      | VarRef id -> id
+      | VarRef id -> anomaly ~label:"declare_univ_binders" Pp.(str "declare_univ_binders on variable " ++ Id.print id ++ str".")
       | ConstructRef _ ->
         anomaly ~label:"declare_univ_binders"
           Pp.(str "declare_univ_binders on an constructor reference")

--- a/test-suite/output/UnivBinders.out
+++ b/test-suite/output/UnivBinders.out
@@ -79,8 +79,9 @@ mono
 The command has indeed failed with message:
 Universe u already exists.
 Monomorphic bobmorane = 
-let tt := Type@{tt.v} in let ff := Type@{ff.v} in tt -> ff
-     : Type@{max(tt.u,ff.u)}
+let tt := Type@{UnivBinders.32} in
+let ff := Type@{UnivBinders.34} in tt -> ff
+     : Type@{max(UnivBinders.31,UnivBinders.33)}
 
 bobmorane is not universe polymorphic
 The command has indeed failed with message:

--- a/test-suite/output/UnivBinders.out
+++ b/test-suite/output/UnivBinders.out
@@ -191,12 +191,12 @@ Type@{UnivBinders.57} -> Type@{i}
 axbar is universe polymorphic
 Argument scope is [type_scope]
 Expands to: Constant UnivBinders.axbar
-axfoo' : Type@{UnivBinders.59} -> Type@{axbar'.i}
+axfoo' : Type@{axbar'.u0} -> Type@{axbar'.i}
 
 axfoo' is not universe polymorphic
 Argument scope is [type_scope]
 Expands to: Constant UnivBinders.axfoo'
-axbar' : Type@{UnivBinders.59} -> Type@{axbar'.i}
+axbar' : Type@{axbar'.u0} -> Type@{axbar'.i}
 
 axbar' is not universe polymorphic
 Argument scope is [type_scope]

--- a/test-suite/output/UnivBinders.v
+++ b/test-suite/output/UnivBinders.v
@@ -73,19 +73,10 @@ Module SecLet.
     (* Fail Let foo@{} := Type@{u}. (* doesn't parse: Let foo@{...} doesn't exist *) *)
     Unset Strict Universe Declaration.
     Let tt : Type@{u} := Type@{v}. (* names disappear in the ether *)
-    Let ff : Type@{u}. Proof. exact Type@{v}. Qed. (* if Set Universe Polymorphism: universes are named ff.u and ff.v. Otherwise names disappear into space *)
+    Let ff : Type@{u}. Proof. exact Type@{v}. Qed. (* names disappear into space *)
     Definition bobmorane := tt -> ff.
   End foo.
-  Print bobmorane. (*
-                     bobmorane@{UnivBinders.15 UnivBinders.16 ff.u ff.v} =
-                     let tt := Type@{UnivBinders.16} in let ff := Type@{ff.v} in tt -> ff
-                     : Type@{max(UnivBinders.15,ff.u)}
-                     (* UnivBinders.15 UnivBinders.16 ff.u ff.v |= UnivBinders.16 < UnivBinders.15
-                     ff.v < ff.u
-                    *)
-
-                    bobmorane is universe polymorphic
-                    *)
+  Print bobmorane.
 End SecLet.
 
 (* fun x x => foo is nonsense with local binders *)

--- a/test-suite/success/unidecls.v
+++ b/test-suite/success/unidecls.v
@@ -46,12 +46,12 @@ Universe secfoo.
 Section Foo'.
   Fail Universe secfoo.
   Universe secfoo2.
-  Check Type@{Foo'.secfoo2}.
+  Fail Check Type@{Foo'.secfoo2}.
+  Check Type@{secfoo2}.
   Constraint secfoo2 < a.
 End Foo'.
 
 Check Type@{secfoo2}.
-Fail Check Type@{Foo'.secfoo2}.
 Fail Check eq_refl : Type@{secfoo2} = Type@{a}.
 
 (** Below, u and v are global, fixed universes *)

--- a/test-suite/success/unidecls.v
+++ b/test-suite/success/unidecls.v
@@ -1,4 +1,4 @@
-(* coq-prog-args: ("-top" "unidecls") *)
+(* -*- coq-prog-args: ("-top" "unidecls"); -*- *)
 Set Printing Universes.
 
 Module decls.

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -535,11 +535,11 @@ let declare_mutual_inductive_with_eliminations mie pl impls =
   let names = List.map (fun e -> e.mind_entry_typename) mie.mind_entry_inds in
   let (_, kn), prim = declare_mind mie in
   let mind = Global.mind_of_delta_kn kn in
+  Declare.declare_univ_binders (IndRef (mind,0)) pl;
   List.iteri (fun i (indimpls, constrimpls) ->
               let ind = (mind,i) in
               let gr = IndRef ind in
               maybe_declare_manual_implicits false gr indimpls;
-              Declare.declare_univ_binders gr pl;
               List.iteri
                 (fun j impls ->
                  maybe_declare_manual_implicits false

--- a/vernac/declareDef.ml
+++ b/vernac/declareDef.ml
@@ -43,9 +43,11 @@ let declare_definition ident (local, p, k) ce pl imps hook =
   | Discharge | Local | Global ->
       let local = get_locality ident ~kind:"definition" local in
       let kn = declare_constant ident ~local (DefinitionEntry ce, IsDefinition k) in
-      ConstRef kn in
+      let gr = ConstRef kn in
+      let () = Declare.declare_univ_binders gr pl in
+      gr
+  in
   let () = maybe_declare_manual_implicits false gr imps in
-  let () = Declare.declare_univ_binders gr pl in
   let () = definition_message ident in
   Lemmas.call_hook fix_exn hook local gr; gr
 

--- a/vernac/lemmas.ml
+++ b/vernac/lemmas.ml
@@ -197,10 +197,11 @@ let save ?export_seff id const uctx do_guard (locality,poly,kind) hook =
           let () = if should_suggest
             then Proof_using.suggest_constant (Global.env ()) kn
           in
-          ConstRef kn
+          let gr = ConstRef kn in
+          Declare.declare_univ_binders gr (UState.universe_binders uctx);
+          gr
     in
     definition_message id;
-    Declare.declare_univ_binders r (UState.universe_binders uctx);
     call_hook (fun exn -> exn) hook locality r
   with e when CErrors.noncritical e ->
     let e = CErrors.push e in


### PR DESCRIPTION
The names are `uXXX` with `XXX` some number avoiding collision.

Note that there may be some collisions with polymorphic binders, eg
something like

~~~
Set Universe Polymorphism.
Section foo.
  Universe u0.
  Definition bar := Type.
  (* bar@{u0} = Type@{u0} but this isn't the section u0 *)

  Definition baz := Type@{u0}. (* this one is the section u0 *)
  Definition foobar := Eval compute in baz -> Type.
  (* Type@{u0} -> Type@{u0} but these aren't the same u0 *)
~~~
So maybe we should do a nametab lookup too. This is strictly a
printing issue (polymorphic binder names have no other use).

In the monomorphic case names are qualified by the parent definition
so it should be fine (barring module/definition collision but we
already have those).

Note that there are still unnamed universes as they didn't go through
UState (eg schemes).

The "universe already exists" error which I mentioned in https://github.com/coq/coq/issues/2829#issuecomment-350362026 seems to have been because we did strange things with section paths. Since those aren't in kernames any more the first commit in this PR also drops them from universe names.

We could provide an option to select the prefix (`u` by default) but let's not bother for now.