### PR TITLE
[ci] Pin CI_REF to plugin_tutorial to use not yet merged commit.

### DIFF
--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -238,7 +238,7 @@
 ########################################################################
 # plugin_tutorial
 ########################################################################
-: "${plugin_tutorial_CI_REF:=master}"
+: "${plugin_tutorial_CI_REF:=14b2976cdf67db788b79d9421ce1e89bd15c7313}"
 : "${plugin_tutorial_CI_GITURL:=https://github.com/ybertot/plugin_tutorials}"
 : "${plugin_tutorial_CI_ARCHIVEURL:=${plugin_tutorial_CI_GITURL}/archive}"
 


### PR DESCRIPTION
This fixes the CI until this commit is merged into master.

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** infrastructure.

Following https://github.com/coq/coq/pull/8365#issuecomment-430963099.