### PR TITLE
Give code ownership of merging doc to pushers team to notify members when it changes.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -53,6 +53,10 @@
 /dev/doc/         @Zimmi48
 # Secondary maintainer @maximedenes
 
+/dev/doc/MERGING.md @coq/pushers
+# This ensures that all members of the @coq/pushers
+# team are notified when the merging doc changes.
+
 /dev/doc/changes.md    @ghost
 # Trick to avoid getting review requests
 # each time someone modifies the dev changelog


### PR DESCRIPTION
This is a simple trick to make sure that people with merging rights are made aware of any changes to the merging doc.