### PR TITLE
[nametab] [api] Provide basic support for efficient completion.

### DIFF
--- a/clib/cMap.mli
+++ b/clib/cMap.mli
@@ -60,6 +60,12 @@ sig
   val height : 'a t -> int
   (** An indication of the logarithmic size of a map *)
 
+  val filter_range : (key -> int) -> 'a t -> 'a t
+  (** [find_range in_range m] Given a comparison function [in_range x],
+      that tests if [x] is below, above, or inside a given range
+      [filter_range] returns the submap of [m] whose keys are in
+      range. Note that [in_range] has to define a continouous range. *)
+
   module Smart :
   sig
     val map : ('a -> 'a) -> 'a t -> 'a t

--- a/clib/hMap.ml
+++ b/clib/hMap.ml
@@ -398,6 +398,10 @@ struct
 
   let height s = Int.Map.height s
 
+  (* Not as efficient as the original version *)
+  let filter_range f s =
+    filter (fun x _ -> f x = 0) s
+
   module Unsafe =
   struct
     let map f s =

--- a/library/nametab.mli
+++ b/library/nametab.mli
@@ -118,6 +118,12 @@ val locate_extended_all : qualid -> extended_global_reference list
 val locate_extended_all_dir : qualid -> global_dir_reference list
 val locate_extended_all_modtype : qualid -> ModPath.t list
 
+(** Experimental completion support, API is _unstable_ *)
+val completion_canditates : qualid -> extended_global_reference list
+(** [completion_canditates qualid] will return the list of global
+    references that have [qualid] as a prefix. UI usually will want to
+    compose this with [shortest_qualid_of_global] *)
+
 (** Mapping a full path to a global reference *)
 
 val global_of_path : full_path -> GlobRef.t
@@ -211,6 +217,7 @@ module type NAMETREE = sig
   val user_name : qualid -> t -> user_name
   val shortest_qualid : ?loc:Loc.t -> Id.Set.t -> user_name -> t -> qualid
   val find_prefixes : qualid -> t -> elt list
+  val match_prefixes : qualid -> t -> elt list
 end
 
 module Make (U : UserName) (E : EqualityType) :


### PR DESCRIPTION
We provide a function `completion_candidates id` that will return a
list of candidates global references that have id as prefix.

This should be reasonably efficient, however UI still need to call
`shortest_qualid_of_global` which is a bit heavy. How to improve this
in the future is an open question.

cc: #7164

This is safe an useful enough for users that could be included in 8.9 if so we wish.
