### PR TITLE
[library] Remove redundant re-addition of universe constraints.

### DIFF
--- a/interp/declare.ml
+++ b/interp/declare.ml
@@ -60,14 +60,7 @@ let open_constant i ((sp,kn), obj) =
   if obj.cst_locl then ()
   else
     let con = Global.constant_of_delta_kn kn in
-    Nametab.push (Nametab.Exactly i) sp (ConstRef con);
-    match (Global.lookup_constant con).const_body with
-    | (Def _ | Undef _) -> ()
-    | OpaqueDef lc ->
-        match Opaqueproof.get_constraints (Global.opaque_tables ()) lc with
-        | Some f when Future.is_val f ->
-	   Global.push_context_set false (Future.force f)
-        | _ -> ()
+    Nametab.push (Nametab.Exactly i) sp (ConstRef con)
 
 let exists_name id =
   variable_exists id || Global.exists_objlabel (Label.of_id id)


### PR DESCRIPTION
After some analysis this should be taken care of by
`Safe_typing.add_constant`

It was added in
https://github.com/coq/coq/commit/f7338257584ba69e7e815c7ef9ac0d24f0dec36c
, so maybe @gares can provide more context as to how is this stuff
supposed to work.

Note, I am not sure this is correct, I understand very little of this part of the code so this needs careful reviewing.
