### PR TITLE
Remove the implicit tactic feature following #7229.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -67,6 +67,8 @@ Vernacular commands
 - Binders for an `Instance` now act more like binders for a `Theorem`.
   Names may not be repeated, and may not overlap with section variable names.
 
+- Removed the deprecated `Implicit Tactic` family of commands.
+
 Tools
 
 - The `-native-compiler` flag of `coqc` and `coqtop` now takes an argument which can have three values:

--- a/dev/ci/user-overlays/08779-ppedrot-rm-implicit-tactic.sh
+++ b/dev/ci/user-overlays/08779-ppedrot-rm-implicit-tactic.sh
@@ -1,0 +1,8 @@
+_OVERLAY_BRANCH=rm-implicit-tactic
+
+if [ "$CI_PULL_REQUEST" = "8779" ] || [ "$CI_BRANCH" = "$_OVERLAY_BRANCH" ]; then
+
+    ltac2_CI_REF="$_OVERLAY_BRANCH"
+    ltac2_CI_GITURL=https://github.com/ppedrot/ltac2
+
+fi

--- a/doc/sphinx/language/gallina-extensions.rst
+++ b/doc/sphinx/language/gallina-extensions.rst
@@ -2247,7 +2247,3 @@ expression as described in :ref:`ltac`.
 This construction is useful when one wants to define complicated terms
 using highly automated tactics without resorting to writing the proof-term
 by means of the interactive proof engine.
-
-This mechanism is comparable to the ``Declare Implicit Tactic`` command
-defined at :ref:`tactics-implicit-automation`, except that the used
-tactic is local to each hole instead of being declared globally.

--- a/doc/sphinx/proof-engine/tactics.rst
+++ b/doc/sphinx/proof-engine/tactics.rst
@@ -3745,32 +3745,6 @@ Setting implicit automation tactics
 
       Combines in a single line ``Proof with`` and ``Proof using``, see :ref:`proof-editing-mode`
 
-   .. cmd:: Declare Implicit Tactic @tactic
-
-      This command declares a tactic to be used to solve implicit arguments
-      that Coq does not know how to solve by unification. It is used every
-      time the term argument of a tactic has one of its holes not fully
-      resolved.
-
-      .. deprecated:: 8.9
-
-         This command is deprecated. Use :ref:`typeclasses <typeclasses>` or
-         :ref:`tactics-in-terms <tactics-in-terms>` instead.
-
-      .. example::
-
-         .. coqtop:: all
-
-            Parameter quo : nat -> forall n:nat, n<>0 -> nat.
-            Notation "x // y" := (quo x y _) (at level 40).
-            Declare Implicit Tactic assumption.
-            Goal forall n m, m<>0 -> { q:nat & { r | q * m + r = n } }.
-            intros.
-            exists (n // m).
-
-         The tactic ``exists (n // m)`` did not fail. The hole was solved
-         by ``assumption`` so that it behaved as ``exists (quo n m H)``.
-
 .. _decisionprocedures:
 
 Decision procedures

--- a/plugins/ltac/extratactics.mlg
+++ b/plugins/ltac/extratactics.mlg
@@ -48,7 +48,6 @@ let with_delayed_uconstr ist c tac =
   let flags = {
     Pretyping.use_typeclasses = false;
     solve_unification_constraints = true;
-    use_hook = Pfedit.solve_by_implicit_tactic ();
     fail_evar = false;
     expand_evars = true
  } in
@@ -343,7 +342,6 @@ open Vars
 let constr_flags () = {
   Pretyping.use_typeclasses = true;
   Pretyping.solve_unification_constraints = Pfedit.use_unification_heuristics ();
-  Pretyping.use_hook = Pfedit.solve_by_implicit_tactic ();
   Pretyping.fail_evar = false;
   Pretyping.expand_evars = true }
 
@@ -570,44 +568,6 @@ VERNAC COMMAND EXTEND AddStepr CLASSIFIED AS SIDEFF
 | [ "Declare" "Right" "Step" constr(t) ] ->
     { add_transitivity_lemma false t }
 END
-
-{
-
-let cache_implicit_tactic (_,tac) = match tac with
-  | Some tac -> Pfedit.declare_implicit_tactic (Tacinterp.eval_tactic tac)
-  | None -> Pfedit.clear_implicit_tactic ()
-
-let subst_implicit_tactic (subst,tac) =
-  Option.map (Tacsubst.subst_tactic subst) tac
-
-let inImplicitTactic : glob_tactic_expr option -> obj =
-  declare_object {(default_object "IMPLICIT-TACTIC") with
-       open_function = (fun i o -> if Int.equal i 1 then cache_implicit_tactic o);
-       cache_function = cache_implicit_tactic;
-       subst_function = subst_implicit_tactic;
-       classify_function = (fun o -> Dispose)}
-
-let warn_deprecated_implicit_tactic =
-  CWarnings.create ~name:"deprecated-implicit-tactic" ~category:"deprecated"
-    (fun () -> strbrk "Implicit tactics are deprecated")
-
-let declare_implicit_tactic tac =
-  let () = warn_deprecated_implicit_tactic () in
-  Lib.add_anonymous_leaf (inImplicitTactic (Some (Tacintern.glob_tactic tac)))
-
-let clear_implicit_tactic () =
-  let () = warn_deprecated_implicit_tactic () in
-  Lib.add_anonymous_leaf (inImplicitTactic None)
-
-}
-
-VERNAC COMMAND EXTEND ImplicitTactic CLASSIFIED AS SIDEFF
-| [ "Declare" "Implicit" "Tactic" tactic(tac) ] -> { declare_implicit_tactic tac }
-| [ "Clear" "Implicit" "Tactic" ] -> { clear_implicit_tactic () }
-END
-
-
-
 
 (**********************************************************************)
 (* sozeau: abs/gen for induction on instantiated dependent inductives, using "Ford" induction as

--- a/plugins/ltac/g_auto.mlg
+++ b/plugins/ltac/g_auto.mlg
@@ -55,7 +55,6 @@ let eval_uconstrs ist cs =
   let flags = {
     Pretyping.use_typeclasses = false;
     solve_unification_constraints = true;
-    use_hook = Pfedit.solve_by_implicit_tactic ();
     fail_evar = false;
     expand_evars = true
   } in

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -543,7 +543,6 @@ let interp_gen kind ist pattern_mode flags env sigma c =
 let constr_flags () = {
   use_typeclasses = true;
   solve_unification_constraints = true;
-  use_hook = Pfedit.solve_by_implicit_tactic ();
   fail_evar = true;
   expand_evars = true }
 
@@ -558,21 +557,18 @@ let interp_type = interp_constr_gen IsType
 let open_constr_use_classes_flags () = {
   use_typeclasses = true;
   solve_unification_constraints = true;
-  use_hook = Pfedit.solve_by_implicit_tactic ();
   fail_evar = false;
   expand_evars = true }
 
 let open_constr_no_classes_flags () = {
   use_typeclasses = false;
   solve_unification_constraints = true;
-  use_hook = Pfedit.solve_by_implicit_tactic ();
   fail_evar = false;
   expand_evars = true }
 
 let pure_open_constr_flags = {
   use_typeclasses = false;
   solve_unification_constraints = true;
-  use_hook = None;
   fail_evar = false;
   expand_evars = false }
 
@@ -987,7 +983,7 @@ let rec read_match_rule lfun ist env sigma = function
   | [] -> []
 
 (* Fully evaluate an untyped constr *)
-let type_uconstr ?(flags = {(constr_flags ()) with use_hook = None })
+let type_uconstr ?(flags = (constr_flags ()))
   ?(expected_type = WithoutTypeConstraint) ist c =
   begin fun env sigma ->
   let { closure; term } = c in

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -242,7 +242,6 @@ let interp_refine ist gl rc =
   let flags = {
     Pretyping.use_typeclasses = true;
     solve_unification_constraints = true;
-    use_hook = None;
     fail_evar = false;
     expand_evars = true }
   in

--- a/pretyping/pretyping.mli
+++ b/pretyping/pretyping.mli
@@ -35,7 +35,6 @@ type inference_hook = env -> evar_map -> Evar.t -> evar_map * constr
 type inference_flags = {
   use_typeclasses : bool;
   solve_unification_constraints : bool;
-  use_hook : inference_hook option;
   fail_evar : bool;
   expand_evars : bool
 }
@@ -95,7 +94,7 @@ val understand : ?flags:inference_flags -> ?expected_type:typing_constraint ->
    with candidate and no other conversion problems that the one in
    [pending], however, it can contain more evars than the pending ones. *)
 
-val solve_remaining_evars : inference_flags ->
+val solve_remaining_evars : ?hook:inference_hook -> inference_flags ->
   env -> (* current map *) evar_map -> (* initial map *) evar_map -> evar_map
 
 (** Checking evars and pending conversion problems are all solved,

--- a/proofs/evar_refiner.ml
+++ b/proofs/evar_refiner.ml
@@ -53,7 +53,6 @@ let w_refine (evk,evi) (ltac_var,rawc) sigma =
     let flags = {
       Pretyping.use_typeclasses = true;
       Pretyping.solve_unification_constraints = true;
-      Pretyping.use_hook = None;
       Pretyping.fail_evar = false;
       Pretyping.expand_evars = true } in
     try Pretyping.understand_ltac flags

--- a/proofs/pfedit.mli
+++ b/proofs/pfedit.mli
@@ -116,13 +116,3 @@ val refine_by_tactic : env -> Evd.evar_map -> EConstr.types -> unit Proofview.ta
     evars solved by side-effects are NOT purged, so that unexpected failures may
     occur. Ideally all code using this function should be rewritten in the
     monad. *)
-
-(** Declare the default tactic to fill implicit arguments *)
-
-val declare_implicit_tactic : unit Proofview.tactic -> unit
-
-(** To remove the default tactic *)
-val clear_implicit_tactic : unit -> unit
-
-(* Raise Exit if cannot solve *)
-val solve_by_implicit_tactic : unit -> Pretyping.inference_hook option

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -1152,7 +1152,6 @@ let rec intros_move = function
 let tactic_infer_flags with_evar = {
   Pretyping.use_typeclasses = true;
   Pretyping.solve_unification_constraints = true;
-  Pretyping.use_hook = Pfedit.solve_by_implicit_tactic ();
   Pretyping.fail_evar = not with_evar;
   Pretyping.expand_evars = true }
 

--- a/vernac/lemmas.ml
+++ b/vernac/lemmas.ml
@@ -418,8 +418,8 @@ let start_proof_com ?inference_hook kind thms hook =
     let evd, (impls, ((env, ctx), imps)) = interp_context_evars env0 evd bl in
     let evd, (t', imps') = interp_type_evars_impls ~impls env evd t in
     let flags = all_and_fail_flags in
-    let flags = { flags with use_hook = inference_hook } in
-    let evd = solve_remaining_evars flags env evd Evd.empty in
+    let hook = inference_hook in
+    let evd = solve_remaining_evars ?hook flags env evd Evd.empty in
     let ids = List.map RelDecl.get_name ctx in
     check_name_freshness (pi1 kind) id;
     (* XXX: The nf_evar is critical !! *)


### PR DESCRIPTION
We also remove the documentation and adapt the only place that still relies on the pretyping hook feature (guess what, it is Program).