### PR TITLE
[dune] Remove rule for cLexer.ml4 -> cLexer.ml

### DIFF
--- a/parsing/dune
+++ b/parsing/dune
@@ -5,11 +5,6 @@
  (libraries proofs))
 
 (rule
- (targets cLexer.ml)
- (deps (:ml4-file cLexer.ml4))
- (action (run camlp5o -loc loc -impl %{ml4-file} -o %{targets})))
-
-(rule
  (targets g_prim.ml)
  (deps (:mlg-file g_prim.mlg))
  (action (run coqpp %{mlg-file})))


### PR DESCRIPTION
When merging #8740 we didn't remove this rule.

The build didn't fails as Dune emits a warning for now [due to
compatibility with some schemes], but this will become an error in the
future.
