### PR TITLE
[kernel] Move lazy object loading to the kernel.

### DIFF
--- a/checker/safe_checking.ml
+++ b/checker/safe_checking.ml
@@ -11,14 +11,14 @@
 open Declarations
 open Environ
 
-let import senv clib univs digest =
+let import senv clib univs digest dd =
   let mb = Safe_typing.module_of_library clib in
   let env = Safe_typing.env_of_safe_env senv in
   let env = push_context_set ~strict:true mb.mod_constraints env in
   let env = push_context_set ~strict:true univs env in
   let env = Modops.add_retroknowledge mb.mod_retroknowledge env in
   Mod_checking.check_module env mb.mod_mp mb;
-  let (_,senv) = Safe_typing.import clib univs digest senv in senv
+  let (_,senv) = Safe_typing.import clib univs digest dd senv in senv
 
-let unsafe_import senv clib univs digest =
-  let (_,senv) = Safe_typing.import clib univs digest senv in senv
+let unsafe_import senv clib univs digest dd =
+  let (_,senv) = Safe_typing.import clib univs digest dd senv in senv

--- a/kernel/delayed.ml
+++ b/kernel/delayed.ml
@@ -1,0 +1,43 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *   INRIA, CNRS and contributors - Copyright 1999-2018       *)
+(* <O___,, *       (see CREDITS file for the list of authors)           *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+(************************************************************************)
+(** Serialized objects loaded on-the-fly *)
+
+exception Faulty of string
+
+type 'a t = {
+  del_file : string;
+  del_off : int;
+  del_digest : Digest.t;
+}
+
+let in_delayed f ch =
+  let pos = pos_in ch in
+  let _, digest = System.skip_in_segment f ch in
+  ({ del_file = f; del_digest = digest; del_off = pos; }, digest)
+
+(** Fetching a table of opaque terms at position [pos] in file [f],
+    expecting to find first a copy of [digest]. *)
+
+let raw_intern_library f =
+  System.with_magic_number_check
+    (System.raw_intern_state Coq_config.vo_magic_number) f
+
+let fetch del =
+  let { del_digest = digest; del_file = f; del_off = pos; } = del in
+  try
+    let ch = raw_intern_library f in
+    let () = seek_in ch pos in
+    let obj, _, digest' = System.marshal_in_segment f ch in
+    let () = close_in ch in
+    if not (String.equal digest digest') then raise (Faulty f);
+    obj
+  with e when CErrors.noncritical e -> raise (Faulty f)

--- a/kernel/delayed.mli
+++ b/kernel/delayed.mli
@@ -8,9 +8,8 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(*i*)
-open Safe_typing
-(*i*)
+exception Faulty of string
 
-val import : safe_environment -> compiled_library -> Univ.ContextSet.t -> vodigest -> Opaqueproof.disk_data -> safe_environment
-val unsafe_import : safe_environment -> compiled_library -> Univ.ContextSet.t -> vodigest -> Opaqueproof.disk_data -> safe_environment
+type 'a t
+val in_delayed : string -> in_channel -> 'a t * Digest.t
+val fetch : 'a t -> 'a

--- a/kernel/environ.mli
+++ b/kernel/environ.mli
@@ -74,6 +74,7 @@ type env = private {
   env_typing_flags  : typing_flags;
   retroknowledge : Retroknowledge.retroknowledge;
   indirect_pterms : Opaqueproof.opaquetab;
+  opaque_disk_data : Opaqueproof.DiskData.t;
 }
 
 val oracle : env -> Conv_oracle.oracle
@@ -311,6 +312,9 @@ val really_needed : env -> Id.Set.t -> Id.Set.t
 
 (** like [really_needed] but computes a well ordered named context *)
 val keep_hyps : env -> Id.Set.t -> Constr.named_context
+
+(** Lazy loading of opaque proof data *)
+val add_opaque_disk_data : env -> DirPath.t -> Opaqueproof.disk_data -> env
 
 (** {5 Unsafe judgments. }
     We introduce here the pre-type of judgments, which is

--- a/kernel/kernel.mllib
+++ b/kernel/kernel.mllib
@@ -16,6 +16,7 @@ Vmvalues
 Cbytecodes
 Copcodes
 Cemitcodes
+Delayed
 Opaqueproof
 Declarations
 Entries

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -465,7 +465,7 @@ let globalize_constant_universes env cb =
     (match cb.const_body with
      | (Undef _ | Def _ | Primitive _) -> []
      | OpaqueDef lc ->
-       match Opaqueproof.get_constraints (Environ.opaque_tables env) lc with
+       match Opaqueproof.get_constraints env.Environ.opaque_disk_data (Environ.opaque_tables env) lc with
        | None -> []
        | Some fc ->
             match Future.peek_val fc with
@@ -1139,7 +1139,7 @@ let export ?except ~output_native_objects senv dir =
 
 (* cst are the constraints that were computed by the vi2vo step and hence are
  * not part of the mb.mod_constraints field (but morally should be) *)
-let import lib cst vodigest senv =
+let import lib cst vodigest dd senv =
   check_required senv.required lib.comp_deps;
   check_engagement senv.env lib.comp_enga;
   if DirPath.equal (ModPath.dp senv.modpath) lib.comp_name then
@@ -1151,6 +1151,7 @@ let import lib cst vodigest senv =
 				     (Univ.ContextSet.union mb.mod_constraints cst)
 				     senv.env
   in
+  let env = Environ.add_opaque_disk_data env lib.comp_name dd in
   mp,
   { senv with
     env =

--- a/kernel/safe_typing.mli
+++ b/kernel/safe_typing.mli
@@ -192,7 +192,7 @@ val export :
 
 (* Constraints are non empty iff the file is a vi2vo *)
 val import : compiled_library -> Univ.ContextSet.t -> vodigest ->
-  ModPath.t safe_transformer
+  Opaqueproof.disk_data -> ModPath.t safe_transformer
 
 (** {6 Safe typing judgments } *)
 

--- a/library/declaremods.ml
+++ b/library/declaremods.ml
@@ -900,7 +900,7 @@ type library_objects = Lib.lib_objects * Lib.lib_objects
 
 (** For the native compiler, we cache the library values *)
 
-let register_library dir cenv (objs:library_objects) digest univ =
+let register_library dir cenv (objs:library_objects) digest univ disk_data =
   let mp = MPfile dir in
   let () =
     try
@@ -908,7 +908,7 @@ let register_library dir cenv (objs:library_objects) digest univ =
       ignore(Global.lookup_module mp);
     with Not_found ->
       (* If not, let's do it now ... *)
-      let mp' = Global.import cenv univ digest in
+      let mp' = Global.import cenv univ digest disk_data in
       if not (ModPath.equal mp mp') then
         anomaly (Pp.str "Unexpected disk module name.");
   in
@@ -936,8 +936,6 @@ let end_library ?except ~output_native_objects dir =
   assert (ModPath.equal mp (MPfile dir));
   let substitute, keep, _ = Lib.classify_segment lib_stack in
   cenv,(substitute,keep),ast
-
-
 
 (** {6 Implementation of Import and Export commands} *)
 

--- a/library/declaremods.mli
+++ b/library/declaremods.mli
@@ -92,7 +92,7 @@ type library_objects
 val register_library :
   library_name ->
   Safe_typing.compiled_library -> library_objects -> Safe_typing.vodigest ->
-  Univ.ContextSet.t -> unit
+  Univ.ContextSet.t -> Opaqueproof.disk_data -> unit
 
 val get_library_native_symbols : library_name -> Nativecode.symbols
 

--- a/library/global.ml
+++ b/library/global.ml
@@ -131,9 +131,9 @@ let lookup_modtype kn = lookup_modtype kn (env())
 let exists_objlabel id = Safe_typing.exists_objlabel id (safe_env ())
 
 let opaque_tables () = Environ.opaque_tables (env ())
+let opaque_disk_data () = (env ()).Environ.opaque_disk_data
 
 let body_of_constant_body ce = body_of_constant_body (env ()) ce
-
 let body_of_constant cst = body_of_constant_body (lookup_constant cst)
 
 (** Operations on kernel names *)
@@ -149,8 +149,7 @@ let mind_of_delta_kn kn =
 let start_library dir = globalize (Safe_typing.start_library dir)
 let export ?except ~output_native_objects s =
   Safe_typing.export ?except ~output_native_objects (safe_env ()) s
-let import c u d = globalize (Safe_typing.import c u d)
-
+let import c u d dd = globalize (Safe_typing.import c u d dd)
 
 (** Function to get an environment from the constants part of the global
     environment and a given context. *)

--- a/library/global.mli
+++ b/library/global.mli
@@ -99,6 +99,7 @@ val constant_of_delta_kn : KerName.t -> Constant.t
 val mind_of_delta_kn : KerName.t -> MutInd.t
 
 val opaque_tables : unit -> Opaqueproof.opaquetab
+val opaque_disk_data : unit -> Opaqueproof.DiskData.t
 
 val body_of_constant : Constant.t -> (Constr.constr * Univ.AUContext.t) option
 (** Returns the body of the constant if it has any, and the polymorphic context
@@ -116,7 +117,7 @@ val export : ?except:Future.UUIDSet.t -> output_native_objects:bool -> DirPath.t
   ModPath.t * Safe_typing.compiled_library * Safe_typing.native_library
 val import :
   Safe_typing.compiled_library -> Univ.ContextSet.t -> Safe_typing.vodigest ->
-  ModPath.t
+  Opaqueproof.disk_data -> ModPath.t
 
 (** {6 Misc } *)
 

--- a/plugins/extraction/extraction.ml
+++ b/plugins/extraction/extraction.ml
@@ -115,7 +115,7 @@ let get_body lconstr = EConstr.of_constr (Mod_subst.force_constr lconstr)
 
 let get_opaque env c =
   EConstr.of_constr
-    (Opaqueproof.force_proof (Environ.opaque_tables env) c)
+    (Opaqueproof.force_proof (env.Environ.opaque_disk_data) (Environ.opaque_tables env) c)
 
 let applistc c args = EConstr.mkApp (c, Array.of_list args)
 

--- a/printing/prettyp.ml
+++ b/printing/prettyp.ml
@@ -554,10 +554,11 @@ let print_constant with_values sep sp udecl =
   let univs =
     let open Univ in
     let otab = Global.opaque_tables () in
+    let odisk = Global.opaque_disk_data () in
     match cb.const_body with
     | Undef _ | Def _ | Primitive _ -> cb.const_universes
     | OpaqueDef o ->
-      let body_uctxs = Opaqueproof.force_constraints otab o in
+      let body_uctxs = Opaqueproof.force_constraints odisk otab o in
       match cb.const_universes with
       | Monomorphic ctx ->
         Monomorphic (ContextSet.union body_uctxs ctx)
@@ -717,7 +718,7 @@ let print_full_pure_context env sigma =
 	      | OpaqueDef lc ->
 		str "Theorem " ++ print_basename con ++ cut () ++
                 str " : " ++ pr_ltype_env env sigma typ ++ str "." ++ fnl () ++
-                str "Proof " ++ pr_lconstr_env env sigma (Opaqueproof.force_proof (Global.opaque_tables ()) lc)
+                str "Proof " ++ pr_lconstr_env env sigma (Opaqueproof.force_proof Global.(opaque_disk_data ()) (Global.opaque_tables ()) lc)
 	      | Def c ->
 		str "Definition " ++ print_basename con ++ cut () ++
                 str "  : " ++ pr_ltype_env env sigma typ ++ cut () ++ str " := " ++

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -1830,7 +1830,7 @@ end = struct (* {{{ *)
           | _ -> assert false in
         let uc =
           Option.get
-            (Opaqueproof.get_constraints (Global.opaque_tables ()) o) in
+            (Opaqueproof.get_constraints Global.(opaque_disk_data ()) (Global.opaque_tables ()) o) in
         (* We only manipulate monomorphic terms here. *)
         let map (c, ctx) = assert (Univ.AUContext.is_empty ctx); c in
         let pr =


### PR DESCRIPTION
This fixes a key problem in regards of making the kernel
self-contained as it removes the "indirect_opaque_accessor" hook, used
to perform lazy-loading of opaque data.

Indeed, that part was a key component of the trusted base, however it
was living in library and made available to the kernel thru a "hook".

Instead, we add to the environment information about where the opaque
data lives and fetch it under demand. We need to be careful as to keep
the environments marshallable thus we add local cache to
`Opaqueproofs`.

This refactors quite a bit of code, and IMO opens the door to further
improvements in `Opaqueproofs`.
