### PR TITLE
[coqtop] Tweak API to avoid abstraction breakage.

### DIFF
--- a/checker/checker.ml
+++ b/checker/checker.ml
@@ -377,7 +377,7 @@ let init_with_argv argv =
   if not !initialized then begin
     initialized := true;
     Sys.catch_break false; (* Ctrl-C is fatal during the initialisation *)
-    let _fhandle = Feedback.(add_feeder (console_feedback_listener Format.err_formatter)) in
+    Feedback.(add_feeder "console" (console_feedback_listener Format.err_formatter));
     try
       parse_args argv;
       if !Flags.debug then Printexc.record_backtrace true;

--- a/dev/ci/user-overlays/08789-ejgallego-toplevel+tweak_feeder.sh
+++ b/dev/ci/user-overlays/08789-ejgallego-toplevel+tweak_feeder.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+if [ "$CI_PULL_REQUEST" = "8789" ] || [ "$CI_BRANCH" = "toplevel+tweak_feeder" ]; then
+
+    pidetop_CI_REF=toplevel+tweak_feeder
+    pidetop_CI_GITURL=https://bitbucket.org/ejgallego/pidetop
+
+fi

--- a/ide/idetop.ml
+++ b/ide/idetop.ml
@@ -494,7 +494,7 @@ let loop ~opts:_ ~state =
   (* SEXP parser make *)
   let xml_ic        = Xml_parser.make (Xml_parser.SLexbuf in_lb) in
   let () = Xml_parser.check_eof xml_ic false in
-  ignore (Feedback.add_feeder (slave_feeder (!msg_format ()) xml_oc));
+  Feedback.add_feeder "idetop" (slave_feeder (!msg_format ()) xml_oc);
   while not !quit do
     try
       let xml_query = Xml_parser.parse xml_ic in

--- a/lib/feedback.mli
+++ b/lib/feedback.mli
@@ -60,11 +60,16 @@ type feedback = {
  * during interpretation are attached to it.
  *)
 
-(** [add_feeder f] adds a feeder listiner [f], returning its id *)
-val add_feeder : (feedback -> unit) -> int
+(** [add_feeder fid f] adds a feeder listener [f] *)
+val add_feeder : string -> (feedback -> unit) -> unit
 
 (** [del_feeder fid] removes the feeder with id [fid] *)
-val del_feeder : int -> unit
+val del_feeder : string -> unit
+
+(** [mask_feeders fid fb f x] will temporary redirect the output of
+   feeder [fid] when executing [f x] to [bf], correctly resetting the
+   feeder state on error and success.] *)
+val mask_feeder : string -> (feedback -> unit) -> ('a -> 'b) -> 'a -> 'b
 
 (** [feedback ?did ?sid ?route fb] produces feedback [fb], with
     [route] and [did, sid] set appropiatedly, if absent, it will use

--- a/plugins/ltac/profile_ltac.ml
+++ b/plugins/ltac/profile_ltac.ml
@@ -384,7 +384,7 @@ module SM = Map.Make(DData)
 let data = ref SM.empty
 
 let _ =
-  Feedback.(add_feeder (function
+  Feedback.(add_feeder "ltac_profile" (function
     | { doc_id = d;
         span_id = s;
         contents = Custom (_, "ltacprof_results", xml) } ->

--- a/stm/asyncTaskQueue.ml
+++ b/stm/asyncTaskQueue.ml
@@ -308,7 +308,7 @@ module Make(T : Task) () = struct
     (* We pass feedback to master *)
     let slave_feeder oc fb =
       Marshal.to_channel oc (RespFeedback (debug_with_pid fb)) []; flush oc in
-    ignore (Feedback.add_feeder (fun x -> slave_feeder (Option.get !slave_oc) x));
+    Feedback.add_feeder "slave_worker" (fun x -> slave_feeder (Option.get !slave_oc) x);
     (* We ask master to allocate universe identifiers *)
     UnivGen.set_remote_new_univ_id (bufferize (fun () ->
       marshal_response (Option.get !slave_oc) RespGetCounterNewUnivLevel;

--- a/tools/coq_makefile.ml
+++ b/tools/coq_makefile.ml
@@ -385,7 +385,7 @@ let share_prefix s1 s2 =
   | _ -> false
 
 let _ =
-  let _fhandle = Feedback.(add_feeder (console_feedback_listener Format.err_formatter)) in
+  Feedback.(add_feeder "console" (console_feedback_listener Format.err_formatter));
   let prog, args =
     let args = Array.to_list Sys.argv in
     let prog = List.hd args in

--- a/toplevel/coqloop.ml
+++ b/toplevel/coqloop.ml
@@ -430,7 +430,7 @@ let loop ~opts ~state =
   let open Coqargs in
   print_emacs := opts.print_emacs;
   (* We initialize the console only if we run the toploop_run *)
-  let tl_feed = Feedback.add_feeder (coqloop_feed Topfmt.InteractiveLoop) in
+  Feedback.add_feeder "console" (coqloop_feed Topfmt.InteractiveLoop);
   if Dumpglob.dump () then begin
     Flags.if_verbose warning "Dumpglob cannot be used in interactive mode.";
     Dumpglob.noglob ()
@@ -441,4 +441,4 @@ let loop ~opts ~state =
   Mltop.ocaml_toploop();
   (* We delete the feeder after the OCaml toploop has ended so users
      of Drop can see the feedback. *)
-  Feedback.del_feeder tl_feed
+  Feedback.del_feeder "console"


### PR DESCRIPTION
We provide a principled mechanism to mask a particular feeder, and
modify the feeder API so it users can name them.

This allows to clean up the use of different feeders in `coqtop`, in
particular it avoids having to leak feeder ids to miscellaneous
subroutines.