### PR TITLE
Encapsulating declarations of primitive string syntax in a module

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -138,8 +138,9 @@ Standard Library
 
 - Syntax notations for `string`, `ascii`, `Z`, `positive`, `N`, `R`,
   and `int31` are no longer available merely by `Require`ing the files
-  that define the inductives.  You must `Import` `Coq.Strings.String`,
-  `Coq.Strings.Ascii`, `Coq.ZArith.BinIntDef`, `Coq.PArith.BinPosDef`,
+  that define the inductives.  You must `Import` `Coq.Strings.String.StringSyntax`
+  (after `Require` `Coq.Strings.String`), `Coq.Strings.Ascii.AsciiSyntax` (after
+  `Require` `Coq.Strings.Ascii`), `Coq.ZArith.BinIntDef`, `Coq.PArith.BinPosDef`,
   `Coq.NArith.BinNatDef`, `Coq.Reals.Rdefinitions`, and
   `Coq.Numbers.Cyclic.Int31.Int31`, respectively, to be able to use
   these notations.  Note that passing `-compat 8.8` or issuing

--- a/theories/Compat/Coq88.v
+++ b/theories/Compat/Coq88.v
@@ -15,11 +15,10 @@ Require Export Coq.Compat.Coq89.
     [Require].  So we make all of the relevant notations accessible in
     compatibility mode. *)
 Require Coq.Strings.Ascii Coq.Strings.String.
+Export String.StringSyntax Ascii.AsciiSyntax.
 Require Coq.ZArith.BinIntDef Coq.PArith.BinPosDef Coq.NArith.BinNatDef.
 Require Coq.Reals.Rdefinitions.
 Require Coq.Numbers.Cyclic.Int31.Int31.
-Declare ML Module "string_syntax_plugin".
-Declare ML Module "ascii_syntax_plugin".
 Declare ML Module "r_syntax_plugin".
 Declare ML Module "int31_syntax_plugin".
 Numeral Notation BinNums.Z BinIntDef.Z.of_int BinIntDef.Z.to_int : Z_scope.

--- a/theories/Strings/Ascii.v
+++ b/theories/Strings/Ascii.v
@@ -23,7 +23,7 @@ Inductive ascii : Set := Ascii (_ _ _ _ _ _ _ _ : bool).
 Register Ascii as plugins.syntax.Ascii.
 
 Declare Scope char_scope.
-Declare ML Module "ascii_syntax_plugin".
+Module Export AsciiSyntax. Declare ML Module "ascii_syntax_plugin". End AsciiSyntax.
 Delimit Scope char_scope with char.
 Bind Scope char_scope with ascii.
 

--- a/theories/Strings/String.v
+++ b/theories/Strings/String.v
@@ -25,7 +25,7 @@ Inductive string : Set :=
   | String : ascii -> string -> string.
 
 Declare Scope string_scope.
-Declare ML Module "string_syntax_plugin".
+Module Export StringSyntax. Declare ML Module "string_syntax_plugin". End StringSyntax.
 Delimit Scope string_scope with string.
 Bind Scope string_scope with string.
 Local Open Scope string_scope.


### PR DESCRIPTION
**Kind:** "bug fix"

This addresses @JasonGross' comment [here](https://github.com/coq/coq/issues/8793#issuecomment-431951074)

This is supposed to go together with @jasongross `fix.py` script for primitive string notations not being available by default anymore.

Drawback: This makes the fix needs two steps, a `Require` and an `Import`, with not so nice names.