### PR TITLE
Fix issue #8800 (gtk warning about gtk_scrolled_window_add_with_viewport)

### DIFF
--- a/ide/wg_Command.ml
+++ b/ide/wg_Command.ml
@@ -98,7 +98,7 @@ object(self)
 	~packing:(vbox#pack ~fill:true ~expand:true) () in
     let result = Wg_MessageView.message_view () in
     router#register_route route_id result;
-    r_bin#add (result :> GObj.widget);
+    r_bin#add_with_viewport (result :> GObj.widget);
     views <- (frame#coerce, result, combo#entry) :: views;
     let cb clr = result#misc#modify_base [`NORMAL, `NAME clr] in
     let _ = background_color#connect#changed ~callback:cb in


### PR DESCRIPTION
GTK loudly complains that we are not using `gtk_scrolled_window_add_with_viewport`, so let us do.

Fixes #8800.