### PR TITLE
Added two proofs to the Lists library: Forall_inv_tail and Exists_impl

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -86,6 +86,7 @@ list of persons and groups:
   J.-P. Jouannaud, S. Lescuyer, A. Miquel, J.-F. Monin, P.-Y. Strub
   the Foundations Group (Radboud University, Nijmegen, The Netherlands),
   Laboratoire J.-A. Dieudonné (University of Nice-Sophia Antipolis),
+  L. Lee (https://orcid.org/0000-0002-7128-9257, 2018),
   INRIA-Gallium project,
   the CS dept at Yale, the CIS dept at U. Penn,
   the CSE dept at Harvard, the CS dept at Princeton, the CS dept at MIT

--- a/theories/Lists/List.v
+++ b/theories/Lists/List.v
@@ -2250,6 +2250,32 @@ Section Exists_Forall.
 
   End One_predicate.
 
+  Theorem Forall_inv_tail
+    :  forall (P : A -> Prop) (x0 : A) (xs : list A), Forall P (x0 :: xs) -> Forall P xs.
+  Proof.
+    intros P x0 xs H.
+    apply Forall_forall with (l := xs).
+    assert (H0 : forall x : A, In x (x0 :: xs) -> P x).
+    apply Forall_forall with (P := P) (l := x0 :: xs).
+    exact H.
+    assert (H1 : forall (x : A) (H2 : In x xs), P x).
+    intros x H2.
+    apply (H0 x).
+    right.
+    exact H2.
+    intros x H2.
+    apply (H1 x H2).
+  Qed.
+
+  Theorem Exists_impl
+    :  forall (P Q : A -> Prop), (forall x : A, P x -> Q x) -> forall xs : list A, Exists P xs -> Exists Q xs.
+  Proof.
+    intros P Q H xs H0.
+    induction H0.
+    apply (Exists_cons_hd Q x l (H x H0)).
+    apply (Exists_cons_tl x IHExists).
+  Qed.
+
   Lemma Forall_Exists_neg (P:A->Prop)(l:list A) :
    Forall (fun x => ~ P x) l <-> ~(Exists P l).
   Proof.


### PR DESCRIPTION
Added two new theorems to the List library: Exists_impl and Forall_inv_tail. Exists_impl provides a theorem analogous to Forall_impl. Forall_inv_tail naturally extends Forall_inv.

Exists_impl accepts two predicates, [P] and [Q], and a list, [xs], and proves that, if [P -> Q], and there exists an element in [xs] for which [P] is true, then there exists an element in [xs] for which [Q] is true. This is analogous to the existing Forall_impl theorem, which, given similar arguments, proves that [Q] is true for all elements in [xs]. Adding Exists_impl fills a natural gap in the existing library.

Forall_inv_tail accepts a predicate, [P], and a list, [x0 :: xs], and proves that if [P] is true for every element in [x0 :: xs], then [P] is true for every element in [xs]. This theorem naturally complements the Forall_inv which takes similar arguments and proves that [P x0] is true. Again, adding Forall_inv_tail fills a natural gap in the existing library.

This is my first contribution to the standard library. I had previously submitted these changes in https://github.com/coq/coq/pull/8757 but had to delete the associated Git branch when a Git rebase command crashed.  Please let me know if there is anything else you need from me.

**Kind:** feature.

- Larry
