### PR TITLE
EConstr-aware functions to produce kernel entries

### DIFF
--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -50,6 +50,18 @@ let new_global evd x =
 (* Expanding/testing/exposing existential variables *)
 (****************************************************)
 
+let finalize ?abort_on_undefined_evars sigma f =
+  let sigma = minimize_universes sigma in
+  let uvars = ref Univ.LSet.empty in
+  let v = f (fun c ->
+      let varsc = EConstr.universes_of_constr sigma c in
+      let c = EConstr.to_constr ?abort_on_undefined_evars sigma c in
+      uvars := Univ.LSet.union !uvars varsc;
+      c)
+  in
+  let sigma = restrict_universe_context sigma !uvars in
+  sigma, v
+
 (* flush_and_check_evars fails if an existential is undefined *)
 
 exception Uninstantiated_evar of Evar.t

--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -181,6 +181,19 @@ val nf_evars_universes : evar_map -> Constr.constr -> Constr.constr
 exception Uninstantiated_evar of Evar.t
 val flush_and_check_evars :  evar_map -> constr -> Constr.constr
 
+(** [finalize env sigma f] combines universe minimisation,
+   evar-and-universe normalisation and universe restriction.
+
+    It minimizes universes in [sigma], calls [f] a normalisation
+   function with respect to the updated [sigma] and restricts the
+   local universes of [sigma] to those encountered while running [f].
+
+    Note that the normalizer passed to [f] holds some imperative state
+   in its closure. *)
+val finalize : ?abort_on_undefined_evars:bool -> evar_map ->
+  ((EConstr.t -> Constr.t) -> 'a) ->
+  evar_map * 'a
+
 (** {6 Term manipulation up to instantiation} *)
 
 (** Like {!Constr.kind} except that [kind_of_term sigma t] exposes [t]

--- a/vernac/declareDef.mli
+++ b/vernac/declareDef.mli
@@ -23,3 +23,13 @@ val declare_fix : ?opaque:bool -> definition_kind ->
   Id.t -> Safe_typing.private_constants Entries.proof_output ->
   Constr.types -> Impargs.manual_implicits ->
   GlobRef.t
+
+val prepare_definition : allow_evars:bool ->
+  ?opaque:bool -> ?inline:bool -> poly:bool ->
+  Evd.evar_map -> UState.universe_decl ->
+  types:EConstr.t option -> body:EConstr.t ->
+  Evd.evar_map * Safe_typing.private_constants Entries.definition_entry
+
+val prepare_parameter : allow_evars:bool ->
+  poly:bool -> Evd.evar_map -> UState.universe_decl -> EConstr.types ->
+  Evd.evar_map * Entries.parameter_entry


### PR DESCRIPTION
This is in some way similar to #7530 (evarutil.finalize) but more high level / less flexible. As such it is used in less places (eg fixpoints are not ported).
Hopefully it doesn't have the perf issues appearing in #7530.