### PR TITLE
[ssreflect] Better use of Coqlib

### DIFF
--- a/library/coqlib.ml
+++ b/library/coqlib.ml
@@ -227,8 +227,7 @@ type coq_eq_data = {
 
 (* Leibniz equality on Type *)
 
-let build_eqdata_gen lib str =
-  let _ = check_required_library lib in {
+let build_eqdata_gen str = {
   eq    = lib_ref ("core." ^ str ^ ".type");
   ind   = lib_ref ("core." ^ str ^ ".ind");
   refl  = lib_ref ("core." ^ str ^ ".refl");
@@ -237,9 +236,9 @@ let build_eqdata_gen lib str =
   congr = lib_ref ("core." ^ str ^ ".congr");
   }
 
-let build_coq_eq_data       () = build_eqdata_gen logic_module_name "eq"
-let build_coq_jmeq_data     () = build_eqdata_gen jmeq_module_name  "JMeq"
-let build_coq_identity_data () = build_eqdata_gen datatypes_module_name "identity"
+let build_coq_eq_data       () = build_eqdata_gen "eq"
+let build_coq_jmeq_data     () = build_eqdata_gen "JMeq"
+let build_coq_identity_data () = build_eqdata_gen "identity"
 
 (* Inversion data... *)
 

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -730,13 +730,10 @@ let pf_abs_prod name gl c cl = pf_mkprod gl c ~name (Termops.subst_term (project
 (** look up a name in the ssreflect internals module *)
 let ssrdirpath = DirPath.make [Id.of_string "ssreflect"]
 let ssrqid name = Libnames.make_qualid ssrdirpath (Id.of_string name) 
-let ssrtopqid name = Libnames.qualid_of_ident (Id.of_string name) 
-let locate_reference qid =
-  Smartlocate.global_of_extended_global (Nametab.locate_extended qid)
 let mkSsrRef name =
-  try locate_reference (ssrqid name) with Not_found ->
-  try locate_reference (ssrtopqid name) with Not_found ->
-  CErrors.user_err (Pp.str "Small scale reflection library not loaded")
+  let qn = Format.sprintf "plugins.ssreflect.%s" name in
+  if Coqlib.has_ref qn then Coqlib.lib_ref qn else
+  CErrors.user_err Pp.(str "Small scale reflection library not loaded (" ++ str name ++ str ")")
 let mkSsrRRef name = (DAst.make @@ GRef (mkSsrRef name,None)), None
 let mkSsrConst name env sigma =
   EConstr.fresh_global env sigma (mkSsrRef name)

--- a/plugins/ssr/ssrcommon.mli
+++ b/plugins/ssr/ssrcommon.mli
@@ -212,8 +212,7 @@ val pf_abs_prod :
            EConstr.t -> Goal.goal Evd.sigma * EConstr.types
 
 val mkSsrRRef : string -> Glob_term.glob_constr * 'a option
-val mkSsrRef : string -> GlobRef.t
-val mkSsrConst : 
+val mkSsrConst :
            string ->
            env -> evar_map -> evar_map * EConstr.t
 val pf_mkSsrConst :

--- a/plugins/ssr/ssreflect.v
+++ b/plugins/ssr/ssreflect.v
@@ -159,6 +159,10 @@ Definition abstract (statement : Type) (id : nat) (lock : abstract_lock) :=
 Notation "<hidden n >" := (abstract _ n _).
 Notation "T (* n *)" := (abstract T n abstract_key).
 
+Register abstract_lock as plugins.ssreflect.abstract_lock.
+Register abstract_key as plugins.ssreflect.abstract_key.
+Register abstract as plugins.ssreflect.abstract.
+
 (* Constants for tactic-views *)
 Inductive external_view : Type := tactic_view of Type.
 
@@ -287,6 +291,8 @@ Variant phant (p : Type) := Phant.
 
 Definition protect_term (A : Type) (x : A) : A := x.
 
+Register protect_term as plugins.ssreflect.protect_term.
+
 (* The ssreflect idiom for a non-keyed pattern:                               *)
 (*  - unkeyed t wiil match any subterm that unifies with t, regardless of     *)
 (*    whether it displays the same head symbol as t.                          *)
@@ -335,6 +341,9 @@ Notation nosimpl t := (let: tt := tt in t).
 
 Lemma master_key : unit. Proof. exact tt. Qed.
 Definition locked A := let: tt := master_key in fun x : A => x.
+
+Register master_key as plugins.ssreflect.master_key.
+Register locked as plugins.ssreflect.locked.
 
 Lemma lock A x : x = locked x :> A. Proof. unlock; reflexivity. Qed.
 
@@ -395,11 +404,17 @@ Definition ssr_have_let Pgoal Plemma step
   (rest : let x : Plemma := step in Pgoal) : Pgoal := rest.
 Arguments ssr_have_let [Pgoal].
 
+Register ssr_have as plugins.ssreflect.ssr_have.
+Register ssr_have_let as plugins.ssreflect.ssr_have_let.
+
 Definition ssr_suff Plemma Pgoal step (rest : Plemma) : Pgoal := step rest.
 Arguments ssr_suff Plemma [Pgoal].
 
 Definition ssr_wlog := ssr_suff.
 Arguments ssr_wlog Plemma [Pgoal].
+
+Register ssr_suff as plugins.ssreflect.ssr_suff.
+Register ssr_wlog as plugins.ssreflect.ssr_wlog.
 
 (* Internal N-ary congruence lemmas for the congr tactic.                     *)
 
@@ -424,6 +439,9 @@ Qed.
 Lemma ssr_congr_arrow Plemma Pgoal : Plemma = Pgoal -> Plemma -> Pgoal.
 Proof. by move->. Qed.
 Arguments ssr_congr_arrow : clear implicits.
+
+Register nary_congruence as plugins.ssreflect.nary_congruence.
+Register ssr_congr_arrow as plugins.ssreflect.ssr_congr_arrow.
 
 (* View lemmas that don't use reflection.                                     *)
 


### PR DESCRIPTION
This is part of the work on stdlib2: it enables to load the `ssreflect` plug-in and to use some tactics without depending too much on the current Coq standard library and prelude.