### PR TITLE
Standardize handling of Automatic Introduction.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -52,6 +52,9 @@ Vernacular commands
 - `Combined Scheme` can now work when inductive schemes are generated in sort
   `Type`. It used to be limited to sort `Prop`.
 
+- Binders for an `Instance` now act more like binders for a `Theorem`.
+  Names may not be repeated, and may not overlap with section variable names.
+
 Tools
 
 - The `-native-compiler` flag of `coqc` and `coqtop` now takes an argument which can have three values:

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -1062,6 +1062,12 @@ let intros_replacing ids =
       (Tacticals.New.tclMAP (fun (id,pos) -> intro_move (Some id) pos) posl)
   end
 
+(* The standard for implementing Automatic Introduction *)
+let auto_intros_tac ids =
+  Tacticals.New.tclMAP (function
+      | Name id -> intro_mustbe_force id
+      | Anonymous -> intro) (List.rev ids)
+
 (* User-level introduction tactics *)
 
 let lookup_hypothesis_as_renamed env sigma ccl = function

--- a/tactics/tactics.mli
+++ b/tactics/tactics.mli
@@ -70,6 +70,9 @@ val intros_using         : Id.t list -> unit Proofview.tactic
 val intros_replacing     : Id.t list -> unit Proofview.tactic
 val intros_possibly_replacing : Id.t list -> unit Proofview.tactic
 
+(** [auto_intros_tac names] handles Automatic Introduction of binders *)
+val auto_intros_tac : Names.Name.t list -> unit Proofview.tactic
+
 val intros               : unit Proofview.tactic
 
 (** [depth_of_quantified_hypothesis b h g] returns the index of [h] in

--- a/test-suite/bugs/closed/bug_8791.v
+++ b/test-suite/bugs/closed/bug_8791.v
@@ -1,0 +1,9 @@
+Class Inhabited (A : Type) : Type := populate { inhabitant : A }.
+
+Definition A := 42.
+
+Instance foo (A: Type): Inhabited (list A).
+Check A.
+Abort.
+
+Fail Instance foo (A : nat) (A : Type) : Inhabited nat.

--- a/vernac/lemmas.ml
+++ b/vernac/lemmas.ml
@@ -368,10 +368,7 @@ let rec_tac_initializer finite guard thms snl =
        | _ -> assert false
 
 let start_proof_with_initialization kind sigma decl recguard thms snl hook =
-  let intro_tac (_, (_, (ids, _))) =
-    Tacticals.New.tclMAP (function
-    | Name id -> Tactics.intro_mustbe_force id
-    | Anonymous -> Tactics.intro) (List.rev ids) in
+  let intro_tac (_, (_, (ids, _))) = Tactics.auto_intros_tac ids in
   let init_tac,guard = match recguard with
   | Some (finite,guard,init_tac) ->
       let rec_tac = rec_tac_initializer finite guard thms snl in


### PR DESCRIPTION
This fixes #8791.
We explicitly specify for `intro` the names of binders which are given by the user. This still can suffer from spurious collisions, see #8819. The implementation is factored out of `Lemmas.start_proof_with_initialization`.

**Kind:** bug fix

- [x] Added / updated test-suite
