### PR TITLE
Do not check convertibility of pattern types in the kernel

### DIFF
--- a/clib/cArray.ml
+++ b/clib/cArray.ml
@@ -35,6 +35,8 @@ sig
   val fold_left_i : (int -> 'a -> 'b -> 'a) -> 'a -> 'b array -> 'a
   val fold_right2 :
     ('a -> 'b -> 'c -> 'c) -> 'a array -> 'b array -> 'c -> 'c
+  val fold_right3 :
+    ('a -> 'b -> 'c -> 'd -> 'd) -> 'a array -> 'b array -> 'c array -> 'd -> 'd
   val fold_left2 :
     ('a -> 'b -> 'c -> 'a) -> 'a -> 'b array -> 'c array -> 'a
   val fold_left3 :
@@ -251,6 +253,16 @@ let fold_left2_i f a v1 v2 =
   in
   if Array.length v2 <> lv1 then invalid_arg "Array.fold_left2_i";
   fold a 0
+
+let fold_right3 f v1 v2 v3 a =
+  let lv1 = Array.length v1 in
+  let rec fold a n =
+    if n=0 then a
+    else
+      let k = n-1 in
+      fold (f (uget v1 k) (uget v2 k) (uget v3 k) a) k in
+  if Array.length v2 <> lv1 || Array.length v3 <> lv1 then invalid_arg "Array.fold_right3";
+  fold a lv1
 
 let fold_left3 f a v1 v2 v3 =
   let lv1 = Array.length v1 in

--- a/clib/cArray.mli
+++ b/clib/cArray.mli
@@ -58,6 +58,8 @@ sig
   val fold_left_i : (int -> 'a -> 'b -> 'a) -> 'a -> 'b array -> 'a
   val fold_right2 :
     ('a -> 'b -> 'c -> 'c) -> 'a array -> 'b array -> 'c -> 'c
+  val fold_right3 :
+    ('a -> 'b -> 'c -> 'd -> 'd) -> 'a array -> 'b array -> 'c array -> 'd -> 'd
   val fold_left2 :
     ('a -> 'b -> 'c -> 'a) -> 'a -> 'b array -> 'c array -> 'a
   val fold_left3 :

--- a/kernel/reduction.ml
+++ b/kernel/reduction.ml
@@ -288,32 +288,6 @@ let conv_table_key infos k1 k2 cuniv =
   | RelKey n, RelKey n' when Int.equal n n' -> cuniv
   | _ -> raise NotConvertible
 
-let compare_stacks f fmind lft1 stk1 lft2 stk2 cuniv =
-  let rec cmp_rec pstk1 pstk2 cuniv =
-    match (pstk1,pstk2) with
-      | (z1::s1, z2::s2) ->
-          let cu1 = cmp_rec s1 s2 cuniv in
-          (match (z1,z2) with
-            | (Zlapp a1,Zlapp a2) -> 
-	       Array.fold_right2 f a1 a2 cu1
-            | (Zlproj (c1,_l1),Zlproj (c2,_l2)) ->
-              if not (Projection.Repr.equal c1 c2) then
-		raise NotConvertible
-	      else cu1
-            | (Zlfix(fx1,a1),Zlfix(fx2,a2)) ->
-                let cu2 = f fx1 fx2 cu1 in
-                cmp_rec a1 a2 cu2
-            | (Zlcase(ci1,l1,p1,br1),Zlcase(ci2,l2,p2,br2)) ->
-                if not (fmind ci1.ci_ind ci2.ci_ind) then
-		  raise NotConvertible;
-		let cu2 = f (l1,p1) (l2,p2) cu1 in
-                Array.fold_right2 (fun c1 c2 -> f (l1,c1) (l2,c2)) br1 br2 cu2
-            | _ -> assert false)
-      | _ -> cuniv in
-  if compare_stack_shape stk1 stk2 then
-    cmp_rec (pure_stack lft1 stk1) (pure_stack lft2 stk2) cuniv
-  else raise NotConvertible
-
 type conv_tab = {
   cnv_inf : clos_infos;
   lft_tab : clos_tab;
@@ -611,10 +585,31 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
         | FProd _ | FEvar _), _ -> raise NotConvertible
 
 and convert_stacks l2r infos lft1 lft2 stk1 stk2 cuniv =
-  compare_stacks
-    (fun (l1,t1) (l2,t2) cuniv -> ccnv CONV l2r infos l1 l2 t1 t2 cuniv)
-    (eq_ind)
-    lft1 stk1 lft2 stk2 cuniv
+  let f (l1, t1) (l2, t2) cuniv = ccnv CONV l2r infos l1 l2 t1 t2 cuniv in
+  let rec cmp_rec pstk1 pstk2 cuniv =
+    match (pstk1,pstk2) with
+      | (z1::s1, z2::s2) ->
+          let cu1 = cmp_rec s1 s2 cuniv in
+          (match (z1,z2) with
+            | (Zlapp a1,Zlapp a2) ->
+               Array.fold_right2 f a1 a2 cu1
+            | (Zlproj (c1,_l1),Zlproj (c2,_l2)) ->
+              if not (Projection.Repr.equal c1 c2) then
+                raise NotConvertible
+              else cu1
+            | (Zlfix(fx1,a1),Zlfix(fx2,a2)) ->
+                let cu2 = f fx1 fx2 cu1 in
+                cmp_rec a1 a2 cu2
+            | (Zlcase(ci1,l1,p1,br1),Zlcase(ci2,l2,p2,br2)) ->
+                if not (eq_ind ci1.ci_ind ci2.ci_ind) then
+                  raise NotConvertible;
+                let cu2 = f (l1,p1) (l2,p2) cu1 in
+                Array.fold_right2 (fun c1 c2 -> f (l1,c1) (l2,c2)) br1 br2 cu2
+            | _ -> assert false)
+      | _ -> cuniv in
+  if compare_stack_shape stk1 stk2 then
+    cmp_rec (pure_stack lft1 stk1) (pure_stack lft2 stk2) cuniv
+  else raise NotConvertible
 
 and convert_vect l2r infos lft1 lft2 v1 v2 cuniv =
   let lv1 = Array.length v1 in


### PR DESCRIPTION
This PR is a variant of an original idea by @SkySkimmer. It stems from the cleverish observation that since the kernel conversion is assumed to only compare terms living in a common super type (which is a pious lie, but doesn't affect us here) and that the cumulativity rule for product is invariant on the domain, then in the problem `Γ ⊢ (fun x : A₁ => t₁) ≡ (fun x : A₂ => t₂)` it is useless to check for `Γ ⊢ A₁ ≡ A₂`, as it is implied by well-typedness.

@SkySkimmer tried such a trick recently, hoping for great performance gains. For some reason that is probably linked to the breakage of the above invariant, the results were mixed. Some developments were much faster but other much slower. The reason being that if the invariant is broken, not checking for domain types might delay a failure and forces more complex comparisons.

This PR elaborates a variation, by only dropping convertibility checks on *domains of pattern branches in pattern-matching*. In this case, because we check convertibility of the return clause first, we know that the types must agree, so no early failure can happen there.

The fast-path is an approximation: it expects the branches to be all made of λ-abstractions, and falls back to the previous algorithm before. Such a fallback virtually never happens, because it requires having let-bindings in constructors (which is a very rarely used feature) or term-manipulating code to generate teratologic pattern branches (which might happen, but everything is done to try to rule this out, see also https://github.com/coq/ceps/pull/34).

Ladies and gentlemen, now the figures:
```
┌──────────────────────────┬──────────────────────────┬──────────────────────────────────────────────┬──────────────────────────────────────────────┬───────────────────────────────┬───────────────────────────┐
│                          │      user time [s]       │                  CPU cycles                  │               CPU instructions               │     max resident mem [KB]     │        mem faults         │
│                          │                          │                                              │                                              │                               │                           │
│             package_name │     NEW     OLD  PDIFF   │               NEW               OLD  PDIFF   │               NEW               OLD  PDIFF   │        NEW        OLD PDIFF   │     NEW     OLD   PDIFF   │
├──────────────────────────┼──────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼───────────────────────────────┼───────────────────────────┤
│       coq-mathcomp-field │  258.07  452.29 -42.94 % │      717340943563     1257915968189 -42.97 % │     1088795527201     2044170801810 -46.74 % │     750092     800776 -6.33 % │      13       2 +550.00 % │
├──────────────────────────┼──────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼───────────────────────────────┼───────────────────────────┤
│               coq-geocoq │ 2010.84 2842.44 -29.26 % │     5585729046615     7904234675125 -29.33 % │     8105312441881    12578091688688 -35.56 % │    1219376    1290360 -5.50 % │     327     184  +77.72 % │
├──────────────────────────┼──────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼───────────────────────────────┼───────────────────────────┤
│ coq-mathcomp-real-closed │  139.80  182.24 -23.29 % │      389206973712      507218749407 -23.27 % │      560569250758      760582452360 -26.30 % │     800760     828776 -3.38 % │       3       0    +nan % │
├──────────────────────────┼──────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼───────────────────────────────┼───────────────────────────┤
│     coq-mathcomp-algebra │  181.62  207.11 -12.31 % │      504098526894      574349881165 -12.23 % │      688117120998      803145348521 -14.32 % │     637288     640528 -0.51 % │       0     233 -100.00 % │
├──────────────────────────┼──────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼───────────────────────────────┼───────────────────────────┤
│   coq-mathcomp-character │  277.70  295.73  -6.10 % │      772295977437      822241894211  -6.07 % │     1111380872149     1193235123238  -6.86 % │    1086896    1079916 +0.65 % │       3      13  -76.92 % │
├──────────────────────────┼──────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼───────────────────────────────┼───────────────────────────┤
│    coq-mathcomp-solvable │  212.90  221.12  -3.72 % │      590750989038      613671613481  -3.73 % │      840969009767      875516141601  -3.95 % │     853168     855100 -0.23 % │     299       0    +nan % │
├──────────────────────────┼──────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼───────────────────────────────┼───────────────────────────┤
│    coq-mathcomp-fingroup │   82.56   85.68  -3.64 % │      228008737824      237034371948  -3.81 % │      338147190770      352025411019  -3.94 % │     582712     587612 -0.83 % │       1      52  -98.08 % │
├──────────────────────────┼──────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼───────────────────────────────┼───────────────────────────┤
│                  coq-vst │ 1658.12 1712.69  -3.19 % │     4609124908024     4761052130219  -3.19 % │     6234602176763     6504880454907  -4.16 % │    2224968    2220820 +0.19 % │     465     808  -42.45 % │
├──────────────────────────┼──────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼───────────────────────────────┼───────────────────────────┤
│                 coq-corn │ 1525.53 1549.41  -1.54 % │     4234992508497     4301302556091  -1.54 % │     6255923842161     6355079365903  -1.56 % │     866384     814096 +6.42 % │      44      45   -2.22 % │
├──────────────────────────┼──────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼───────────────────────────────┼───────────────────────────┤
│              coq-unimath │ 1309.87 1325.22  -1.16 % │     3634698275201     3679270582364  -1.21 % │     6150477302545     6154240632703  -0.06 % │    1050452    1069100 -1.74 % │     349      19 +1736.84 % │
├──────────────────────────┼──────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼───────────────────────────────┼───────────────────────────┤
│         coq-fiat-parsers │  711.14  717.81  -0.93 % │     1974768061297     1992405658335  -0.89 % │     3033486603587     3053701248764  -0.66 % │    2880200    2909484 -1.01 % │     487     753  -35.33 % │
├──────────────────────────┼──────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼───────────────────────────────┼───────────────────────────┤
│          coq-fiat-crypto │ 6333.30 6390.44  -0.89 % │    17613200914198    17766849859714  -0.86 % │    28967408849688    29110453448795  -0.49 % │    2468860    2455020 +0.56 % │    1693    1336  +26.72 % │
├──────────────────────────┼──────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼───────────────────────────────┼───────────────────────────┤
│                 coq-hott │  338.68  341.63  -0.86 % │      937754178032      946506461869  -0.92 % │     1436116351558     1436686347204  -0.04 % │     600344     600348 -0.00 % │     441       0    +nan % │
├──────────────────────────┼──────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼───────────────────────────────┼───────────────────────────┤
│                coq-sf-lf │   44.75   45.13  -0.84 % │      123387551102      124355264720  -0.78 % │      202111999139      202254193381  -0.07 % │     414128     413900 +0.06 % │     129       0    +nan % │
├──────────────────────────┼──────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼───────────────────────────────┼───────────────────────────┤
│              coq-bignums │   98.56   99.38  -0.83 % │      272845882187      274742807835  -0.69 % │      393758096669      396062144510  -0.58 % │     537448     532644 +0.90 % │     281      17 +1552.94 % │
├──────────────────────────┼──────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼───────────────────────────────┼───────────────────────────┤
│               coq-sf-plf │   74.82   75.42  -0.80 % │      207134732644      207808056697  -0.32 % │      303204449466      303518835519  -0.10 % │     518260     516144 +0.41 % │      15       0    +nan % │
├──────────────────────────┼──────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼───────────────────────────────┼───────────────────────────┤
│           coq-coquelicot │  103.23  103.81  -0.56 % │      285969717370      287718869378  -0.61 % │      386248700210      389499602953  -0.83 % │     710356     710376 -0.00 % │     283      13 +2076.92 % │
├──────────────────────────┼──────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼───────────────────────────────┼───────────────────────────┤
│          coq-lambda-rust │ 2359.97 2367.83  -0.33 % │     6571070758552     6596542587827  -0.39 % │     9061299342784     9085385167482  -0.27 % │    1444204    1454484 -0.71 % │       0      20 -100.00 % │
├──────────────────────────┼──────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼───────────────────────────────┼───────────────────────────┤
│             coq-compcert │  884.58  886.20  -0.18 % │     2450767301480     2456757900861  -0.24 % │     3559707193795     3563791759934  -0.11 % │    1379132    1339964 +2.92 % │     269     431  -37.59 % │
├──────────────────────────┼──────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼───────────────────────────────┼───────────────────────────┤
│                coq-color │  734.25  734.88  -0.09 % │     2035777994213     2036495676605  -0.04 % │     2467841281816     2468275632904  -0.02 % │    1370700    1370536 +0.01 % │      30     232  -87.07 % │
├──────────────────────────┼──────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼───────────────────────────────┼───────────────────────────┤
│   coq-mathcomp-ssreflect │   66.36   66.38  -0.03 % │      182345158884      183180255520  -0.46 % │      260537869480      261401028368  -0.33 % │     535520     535128 +0.07 % │      16       0    +nan % │
├──────────────────────────┼──────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼───────────────────────────────┼───────────────────────────┤
│               coq-sf-vfa │   47.72   47.73  -0.02 % │      132089444141      132420441087  -0.25 % │      212605581372      212717228033  -0.05 % │     535260     534872 +0.07 % │      28       5 +460.00 % │
├──────────────────────────┼──────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼───────────────────────────────┼───────────────────────────┤
│                coq-flocq │  588.63  588.60  +0.01 % │     1637669925651     1638202256634  -0.03 % │     2410488987138     2408247657686  +0.09 % │    1766124    1766448 -0.02 % │     552     615  -10.24 % │
├──────────────────────────┼──────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼───────────────────────────────┼───────────────────────────┤
│      coq-formal-topology │   58.68   58.60  +0.14 % │      159818947795      160233625467  -0.26 % │      242399275650      242781623399  -0.16 % │     477556     477560 -0.00 % │       6       0    +nan % │
├──────────────────────────┼──────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼───────────────────────────────┼───────────────────────────┤
│         coq-math-classes │  249.89  249.48  +0.16 % │      687865074232      687845157121  +0.00 % │      901635047065      902663814196  -0.11 % │     521448     521344 +0.02 % │      85      83   +2.41 % │
├──────────────────────────┼──────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼───────────────────────────────┼───────────────────────────┤
│            coq-fiat-core │  135.71  135.34  +0.27 % │      377090049918      377007835831  +0.02 % │      506377308262      506697746014  -0.06 % │     497208     497384 -0.04 % │     594     166 +257.83 % │
└──────────────────────────┴──────────────────────────┴──────────────────────────────────────────────┴──────────────────────────────────────────────┴───────────────────────────────┴───────────────────────────┘
```

I guess people like @gares and @amahboubi are going to be happy.
