### PR TITLE
[toplevel] Allow to specify default options.

### DIFF
--- a/ide/idetop.ml
+++ b/ide/idetop.ml
@@ -537,5 +537,5 @@ let islave_init ~opts extra_args =
 
 let () =
   let open Coqtop in
-  let custom = { init = islave_init; run = loop; } in
+  let custom = { init = islave_init; run = loop; opts = Coqargs.default_opts } in
   start_coq custom

--- a/toplevel/coqargs.ml
+++ b/toplevel/coqargs.ml
@@ -90,7 +90,7 @@ type coq_cmdopts = {
 
 let default_toplevel = Names.(DirPath.make [Id.of_string "Top"])
 
-let init_args = {
+let default_opts = {
 
   load_init   = true;
   load_rcfile = true;
@@ -137,6 +137,8 @@ let init_args = {
 
   print_emacs = false;
 
+  (* Quiet / verbosity options should be here *)
+
   inputstate  = None;
   outputstate = None;
 }
@@ -161,6 +163,7 @@ let add_compat_require opts v =
   | Flags.Current -> add_vo_require opts "Coq.Compat.Coq89" None (Some false)
 
 let set_batch_mode opts =
+  (* XXX: This should be in the argument record *)
   Flags.quiet := true;
   System.trust_file_cache := true;
   { opts with batch_mode = true }
@@ -320,7 +323,7 @@ let usage batch =
   else Usage.print_usage_coqtop ()
 
 (* Main parsing routine *)
-let parse_args arglist : coq_cmdopts * string list =
+let parse_args init_opts arglist : coq_cmdopts * string list =
   let args = ref arglist in
   let extras = ref [] in
   let rec parse oval = match !args with
@@ -595,5 +598,5 @@ let parse_args arglist : coq_cmdopts * string list =
     parse noval
   in
   try
-    parse init_args
+    parse init_opts
   with any -> fatal_error any

--- a/toplevel/coqargs.mli
+++ b/toplevel/coqargs.mli
@@ -62,10 +62,15 @@ type coq_cmdopts = {
 
   print_emacs : bool;
 
+  (* Quiet / verbosity options should be here *)
+
   inputstate  : string option;
   outputstate : string option;
 
 }
 
-val parse_args : string list -> coq_cmdopts * string list
+(* Default options *)
+val default_opts : coq_cmdopts
+
+val parse_args : coq_cmdopts -> string list -> coq_cmdopts * string list
 val exitcode : coq_cmdopts -> int

--- a/toplevel/coqtop.mli
+++ b/toplevel/coqtop.mli
@@ -12,10 +12,13 @@
     [init] is used to do custom command line argument parsing.
     [run] launches a custom toplevel.
 *)
-type custom_toplevel = {
-  init : opts:Coqargs.coq_cmdopts -> string list -> Coqargs.coq_cmdopts * string list;
-  run  : opts:Coqargs.coq_cmdopts -> state:Vernac.State.t -> unit;
-}
+open Coqargs
+
+type custom_toplevel =
+  { init : opts:coq_cmdopts -> string list -> coq_cmdopts * string list
+  ; run : opts:coq_cmdopts -> state:Vernac.State.t -> unit
+  ; opts : Coqargs.coq_cmdopts
+  }
 
 val coqtop_toplevel : custom_toplevel
 

--- a/toplevel/workerLoop.ml
+++ b/toplevel/workerLoop.ml
@@ -23,6 +23,7 @@ let arg_init init ~opts extra_args =
 let start ~init ~loop =
   let open Coqtop in
   let custom = {
+    opts = Coqargs.default_opts;
     init = arg_init init;
     run = (fun ~opts:_ ~state:_ -> loop ());
   } in


### PR DESCRIPTION
In some cases, toplevel ML clients may want to modify the default set
of flags that is passed to the main initalization routine. This is for
example useful for `idetop` to suppress some undesired printing at
startup.

I would say that clients ought to have more
control, but I do expect that PRs such as #8690 will help providing a
better separation thus a mode orthogonal API.
