### PR TITLE
Revert "[ci] Pin CI_REF to plugin_tutorial to use not yet merged commit."

### DIFF
--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -238,7 +238,7 @@
 ########################################################################
 # plugin_tutorial
 ########################################################################
-: "${plugin_tutorial_CI_REF:=14b2976cdf67db788b79d9421ce1e89bd15c7313}"
+: "${plugin_tutorial_CI_REF:=master}"
 : "${plugin_tutorial_CI_GITURL:=https://github.com/ybertot/plugin_tutorials}"
 : "${plugin_tutorial_CI_ARCHIVEURL:=${plugin_tutorial_CI_GITURL}/archive}"
 


### PR DESCRIPTION

This reverts commit df69c44af03f2587b3f1706a805d0e2728c1f1dc.

Should be merged before any PR with plugin tutorial overlays, or we
can just merge the vendor PR instead.

