### PR TITLE
[default.nix] Add coq-version and setupHook.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -23,8 +23,8 @@
 
 { pkgs ?
     (import (fetchTarball {
-      url = "https://github.com/NixOS/nixpkgs/archive/06613c189eebf4d6167d2d010a59cf38b43b6ff4.tar.gz";
-      sha256 = "13grhy3cvdwr7wql1rm5d7zsfpvp44cyjhiain4zs70r90q3swdg";
+      url = "https://github.com/NixOS/nixpkgs/archive/69522a0acf8e840e8b6ac0a9752a034ab74eb3c0.tar.gz";
+      sha256 = "12k80gd4lkw9h9y1szvmh0jmh055g3b6wnphmx4ab1qdwlfaylnx";
     }) {})
 , ocamlPackages ? pkgs.ocaml-ng.ocamlPackages_4_06
 , buildIde ? true


### PR DESCRIPTION
Closes #8227 by solving remaining differences.

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** infrastructure.

I'm not fully sure what should be the value of the `coq-version` attribute. For now I put `git` which means that it won't have to be updated. It could also be some version number coming from a `VERSION` file (`builtins.readFile ./VERSION`) but it's not clear whether we are going to have such a file or if we are going to use tags and git describe instead.
Note that in nixpkgs, the `coq-version` attribute is a value of the form `8.X`. This makes sense because a Coq package compiled with Coq 8.X.Y should work with Coq 8.X.Z without issue. However, this makes less sense in the case of beta releases (we do change magic numbers between a beta and a final release, which means that a package compiled for Coq 8.X+betaY won't work for Coq 8.X.Z. Finally, there is no expectation of compatibility between packages built with various development versions.