### PR TITLE
[ci] Only build Docker image when Dockerfile changed.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,9 +28,9 @@ docker-boot:
     - if docker pull "$IMAGE"; then echo "Image prebuilt!"; exit 0; fi
     - docker build -t "$IMAGE" .
     - docker push "$IMAGE"
-  except:
-    variables:
-      - $SKIP_DOCKER == "true"
+  only:
+    changes:
+      - dev/ci/docker/*/Dockerfile
   tags:
     - docker
 

--- a/dev/ci/README.md
+++ b/dev/ci/README.md
@@ -193,12 +193,4 @@ loaded by subsequent jobs.
 the `CACHEKEY` variable in [`.gitlab-ci.yml`](../../.gitlab-ci.yml)
 and [`Dockerfile`](docker/bionic_coq/Dockerfile)
 
-The Docker building job reuses the uploaded image if it is available,
-but if you wish to save more time you can skip the job by setting
-`SKIP_DOCKER` to `true`.
-
-This means you will need to change its value when the Docker image
-needs to be updated. You can do so for a single pipeline by starting
-it through the web interface.
-
 See also [`docker/README.md`](docker/README.md).

--- a/dev/ci/docker/README.md
+++ b/dev/ci/docker/README.md
@@ -4,11 +4,6 @@ This directory provides Docker images to be used by Coq's CI. The
 images do support Docker autobuild on `hub.docker.com` and Gitlab's
 private registry.
 
-Gitlab CI will build and tag a Docker by default for every job if the
-`SKIP_DOCKER` variable is not set to `false`. In Coq's CI, this
-variable is usually set to `false` indeed to avoid booting a useless
-job.
-
 ## Manual Building
 
 You can also manually build and push any image:


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** infrastructure.

This allows to get rid of the trick with the `SKIP_DOCKER` variable.
This is using a feature that seems to have been added mainly for this use case:
https://docs.gitlab.com/ee/ci/yaml/README.html#only-changes