### PR TITLE
Private universes for opaque polymorphic constants.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -120,6 +120,10 @@ Universes
 - Added `Print Universes Subgraph` variant of `Print Universes`.
   Try for instance `Print Universes Subgraph(sigT2.u1 sigT_of_sigT2.u1 projT3_eq.u1 eq_sigT2_rect.u1).`
 
+- Added private universes for opaque polymorphic constants, see doc
+  for the "Private Polymorphic Universes" option (and Unset it to get
+  the previous behaviour).
+
 Misc
 
 - Option "Typeclasses Axioms Are Instances" is deprecated. Use Declare Instance for axioms which should be instances.

--- a/checker/mod_checking.ml
+++ b/checker/mod_checking.ml
@@ -20,7 +20,13 @@ let check_constant_declaration env kn cb =
     | Monomorphic_const ctx -> false, push_context_set ~strict:true ctx env
     | Polymorphic_const auctx ->
       let ctx = Univ.AUContext.repr auctx in
-      true, push_context ~strict:false ctx env
+      let env = push_context ~strict:false ctx env in
+      true, env
+  in
+  let env' = match cb.const_private_poly_univs, (cb.const_body, poly) with
+    | None, _ -> env'
+    | Some local, (OpaqueDef _, true) -> push_subgraph local env'
+    | Some _, _ -> assert false
   in
   let ty = cb.const_type in
   let _ = infer_type env' ty in

--- a/checker/values.ml
+++ b/checker/values.ml
@@ -227,6 +227,7 @@ let v_cb = v_tuple "constant_body"
     v_constr;
     Any;
     v_const_univs;
+    Opt v_context_set;
     v_bool;
     v_typing_flags|]
 

--- a/dev/ci/user-overlays/08850-poly-local-univs.sh
+++ b/dev/ci/user-overlays/08850-poly-local-univs.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if [ "$CI_PULL_REQUEST" = "8850" ] || [ "$CI_BRANCH" = "poly-local-univs" ]; then
+    formal_topology_CI_REF=poly-local-univs
+    formal_topology_CI_GITURL=https://github.com/SkySkimmer/topology
+
+    paramcoq_CI_REF=poly-local-univs
+    paramcoq_CI_GITURL=https://github.com/SkySkimmer/paramcoq
+fi

--- a/doc/sphinx/addendum/universe-polymorphism.rst
+++ b/doc/sphinx/addendum/universe-polymorphism.rst
@@ -441,3 +441,60 @@ underscore or by omitting the annotation to a polymorphic definition.
    semantics that the first use declares it. In this mode, the universe
    names are not associated with the definition or proof once it has been
    defined. This is meant mainly for debugging purposes.
+
+.. flag:: Private Polymorphic Universes
+
+   This option, on by default, removes universes which appear only in
+   the body of an opaque polymorphic definition from the definition's
+   universe arguments. As such, no value needs to be provided for
+   these universes when instanciating the definition. Universe
+   constraints are automatically adjusted.
+
+   Consider the following definition:
+
+   .. coqtop:: all
+
+      Lemma foo@{i} : Type@{i}.
+      Proof. exact Type. Qed.
+      Print foo.
+
+   The universe :g:`Top.xxx` for the :g:`Type` in the body cannot be accessed, we
+   only care that one exists for any instantiation of the universes
+   appearing in the type of :g:`foo`. This is guaranteed when the
+   transitive constraint ``Set <= Top.xxx < i`` is verified. Then when
+   using the constant we don't need to put a value for the inner
+   universe:
+
+   .. coqtop:: all
+
+      Check foo@{_}.
+
+   and when not looking at the body we don't mention the private
+   universe:
+
+   .. coqtop:: all
+
+      About foo.
+
+   To recover the same behaviour with regard to universes as
+   :g:`Defined`, the option :flag:`Private Polymorphic Universes` may
+   be unset:
+
+   .. coqtop:: all
+
+      Unset Private Polymorphic Universes.
+
+      Lemma bar : Type. Proof. exact Type. Qed.
+      About bar.
+      Fail Check bar@{_}.
+      Check bar@{_ _}.
+
+   Note that named universes are always public.
+
+   .. coqtop:: all
+
+      Set Private Polymorphic Universes.
+      Unset Strict Universe Declaration.
+
+      Lemma baz : Type@{outer}. Proof. exact Type@{inner}. Qed.
+      About baz.

--- a/kernel/cooking.mli
+++ b/kernel/cooking.mli
@@ -21,6 +21,7 @@ type result = {
   cook_body : constant_def;
   cook_type : types;
   cook_universes : constant_universes;
+  cook_private_univs : Univ.ContextSet.t option;
   cook_inline : inline;
   cook_context : Constr.named_context option;
 }

--- a/kernel/declarations.ml
+++ b/kernel/declarations.ml
@@ -78,6 +78,7 @@ type constant_body = {
     const_type : types;
     const_body_code : Cemitcodes.to_patch_substituted option;
     const_universes : constant_universes;
+    const_private_poly_univs : Univ.ContextSet.t option;
     const_inline_code : bool;
     const_typing_flags : typing_flags; (** The typing options which
                                            were used for

--- a/kernel/declareops.ml
+++ b/kernel/declareops.ml
@@ -101,6 +101,7 @@ let subst_const_body sub cb =
         const_body_code =
           Option.map (Cemitcodes.subst_to_patch_subst sub) cb.const_body_code;
         const_universes = cb.const_universes;
+        const_private_poly_univs = cb.const_private_poly_univs;
         const_inline_code = cb.const_inline_code;
         const_typing_flags = cb.const_typing_flags }
 
@@ -126,14 +127,20 @@ let hcons_const_universes cbu =
   match cbu with
   | Monomorphic_const ctx -> 
     Monomorphic_const (Univ.hcons_universe_context_set ctx)
-  | Polymorphic_const ctx -> 
+  | Polymorphic_const ctx ->
     Polymorphic_const (Univ.hcons_abstract_universe_context ctx)
+
+let hcons_const_private_univs = function
+  | None -> None
+  | Some univs -> Some (Univ.hcons_universe_context_set univs)
 
 let hcons_const_body cb =
   { cb with
     const_body = hcons_const_def cb.const_body;
     const_type = Constr.hcons cb.const_type;
-    const_universes = hcons_const_universes cb.const_universes }
+    const_universes = hcons_const_universes cb.const_universes;
+    const_private_poly_univs = hcons_const_private_univs cb.const_private_poly_univs;
+  }
 
 (** {6 Inductive types } *)
 

--- a/kernel/environ.ml
+++ b/kernel/environ.ml
@@ -380,6 +380,18 @@ let add_universes_set strict ctx g =
 let push_context_set ?(strict=false) ctx env =
   map_universes (add_universes_set strict ctx) env
 
+let push_subgraph (levels,csts) env =
+  let add_subgraph g =
+    let newg = Univ.LSet.fold (fun v g -> UGraph.add_universe v false g) levels g in
+    let newg = UGraph.merge_constraints csts newg in
+    (if not (Univ.Constraint.is_empty csts) then
+       let restricted = UGraph.constraints_for ~kept:(UGraph.domain g) newg in
+       (if not (UGraph.check_constraints restricted g) then
+          CErrors.anomaly Pp.(str "Local constraints imply new transitive constraints.")));
+    newg
+  in
+  map_universes add_subgraph env
+
 let set_engagement c env = (* Unsafe *)
   { env with env_stratification =
     { env.env_stratification with env_engagement = c } }

--- a/kernel/environ.mli
+++ b/kernel/environ.mli
@@ -268,6 +268,12 @@ val push_context : ?strict:bool -> Univ.UContext.t -> env -> env
 val push_context_set : ?strict:bool -> Univ.ContextSet.t -> env -> env
 val push_constraints_to_env : 'a Univ.constrained -> env -> env
 
+val push_subgraph : Univ.ContextSet.t -> env -> env
+(** [push_subgraph univs env] adds the universes and constraints in
+   [univs] to [env] as [push_context_set ~strict:false univs env], and
+   also checks that they do not imply new transitive constraints
+   between pre-existing universes in [env]. *)
+
 val set_engagement : engagement -> env -> env
 val set_typing_flags : typing_flags -> env -> env
 

--- a/kernel/modops.ml
+++ b/kernel/modops.ml
@@ -338,7 +338,8 @@ let strengthen_const mp_from l cb resolver =
       | Polymorphic_const ctx -> Univ.make_abstract_instance ctx
     in
       { cb with
-	const_body = Def (Mod_subst.from_val (mkConstU (con,u)));
+        const_body = Def (Mod_subst.from_val (mkConstU (con,u)));
+        const_private_poly_univs = None;
 	const_body_code = Some (Cemitcodes.from_val (Cbytegen.compile_alias con)) }
 
 let rec strengthen_mod mp_from mp_to mb =

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -599,7 +599,7 @@ let inline_side_effects env body side_eff =
         let subst = Cmap_env.add c (Inr var) subst in
         let ctx = Univ.ContextSet.union ctx univs in
         (subst, var + 1, ctx, (cname c, b, ty, opaque) :: args)
-      | Polymorphic_const _auctx ->
+      | Polymorphic_const _ ->
         (** Inline the term to emulate universe polymorphism *)
         let subst = Cmap_env.add c (Inl b) subst in
         (subst, var, ctx, args)

--- a/kernel/uGraph.ml
+++ b/kernel/uGraph.ml
@@ -866,6 +866,8 @@ let constraints_for ~kept g =
         arc.ltle csts)
     kept csts
 
+let domain g = LMap.domain g.entries
+
 (** [sort_universes g] builds a totally ordered universe graph.  The
     output graph should imply the input graph (and the implication
     will be strict most of the time), but is not necessarily minimal.

--- a/kernel/uGraph.mli
+++ b/kernel/uGraph.mli
@@ -79,6 +79,9 @@ val constraints_of_universes : t -> Constraint.t * LSet.t list
     eg if [g] is [a <= b <= c] then [constraints_for ~kept:{a, c} g] is [a <= c]. *)
 val constraints_for : kept:LSet.t -> t -> Constraint.t
 
+val domain : t -> LSet.t
+(** Known universes *)
+
 val check_subtype : AUContext.t check_function
 (** [check_subtype univ ctx1 ctx2] checks whether [ctx2] is an instance of
     [ctx1]. *)

--- a/plugins/funind/functional_principles_types.ml
+++ b/plugins/funind/functional_principles_types.ml
@@ -322,7 +322,7 @@ let build_functional_principle (evd:Evd.evar_map ref) interactive_proof old_prin
     (* 	end; *)
 
       let open Proof_global in
-      let { id; entries; persistence } = fst @@ close_proof ~keep_body_ucst_separate:false (fun x -> x) in
+      let { id; entries; persistence } = fst @@ close_proof ~opaque:Transparent ~keep_body_ucst_separate:false (fun x -> x) in
       match entries with
       | [entry] ->
         discard_current ();

--- a/printing/prettyp.ml
+++ b/printing/prettyp.ml
@@ -96,8 +96,9 @@ let print_ref reduce ref udecl =
     then Printer.pr_universe_instance sigma inst
     else mt ()
   in
+  let priv = None in (* We deliberately don't print private univs in About. *)
   hov 0 (pr_global ref ++ inst ++ str " :" ++ spc () ++ pr_letype_env env sigma typ ++ 
-           Printer.pr_abstract_universe_ctx sigma ?variance univs)
+           Printer.pr_abstract_universe_ctx sigma ?variance univs ~priv)
 
 (********************************)
 (** Printing implicit arguments *)
@@ -580,11 +581,11 @@ let print_constant with_values sep sp udecl =
 	str"*** [ " ++
 	print_basename sp ++ print_instance sigma cb ++ str " : " ++ cut () ++ pr_ltype typ ++
 	str" ]" ++
-        Printer.pr_constant_universes sigma univs
+        Printer.pr_constant_universes sigma univs ~priv:cb.const_private_poly_univs
     | Some (c, ctx) ->
 	print_basename sp ++ print_instance sigma cb ++ str sep ++ cut () ++
 	(if with_values then print_typed_body env sigma (Some c,typ) else pr_ltype typ)++
-        Printer.pr_constant_universes sigma univs)
+        Printer.pr_constant_universes sigma univs ~priv:cb.const_private_poly_univs)
 
 let gallina_print_constant_with_infos sp udecl =
   print_constant true " = " sp udecl ++

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -143,7 +143,7 @@ let pr_sort sigma s = pr_glob_sort (extern_sort sigma s)
 let _ = Termops.Internal.set_print_constr
   (fun env sigma t -> pr_lconstr_expr (extern_constr ~lax:true false env sigma t))
 
-let pr_in_comment pr x = str "(* " ++ pr x ++ str " *)"
+let pr_in_comment x = str "(* " ++ x ++ str " *)"
 
 (** Term printers resilient to [Nametab] errors *)
 
@@ -199,27 +199,25 @@ let safe_pr_constr_env = safe_gen pr_constr_env
 
 let pr_universe_ctx_set sigma c =
   if !Detyping.print_universes && not (Univ.ContextSet.is_empty c) then
-    fnl()++pr_in_comment (fun c -> v 0
-      (Univ.pr_universe_context_set (Termops.pr_evd_level sigma) c)) c
+    fnl()++pr_in_comment (v 0 (Univ.pr_universe_context_set (Termops.pr_evd_level sigma) c))
   else
     mt()
 
 let pr_universe_ctx sigma ?variance c =
   if !Detyping.print_universes && not (Univ.UContext.is_empty c) then
-    fnl()++pr_in_comment (fun c -> v 0 
-      (Univ.pr_universe_context (Termops.pr_evd_level sigma) ?variance c)) c
+    fnl()++pr_in_comment (v 0 (Univ.pr_universe_context (Termops.pr_evd_level sigma) ?variance c))
   else
     mt()
 
 let pr_abstract_universe_ctx sigma ?variance c ~priv =
   let open Univ in
   let priv = Option.default Univ.ContextSet.empty priv in
-  if !Detyping.print_universes && not (Univ.AUContext.is_empty c && Univ.ContextSet.is_empty priv) then
-    let local = if ContextSet.is_empty priv then mt() else
-        str "local: " ++ Univ.pr_universe_context_set (Termops.pr_evd_level sigma) priv
-    in
-    fnl()++pr_in_comment (fun c -> v 0
-      (Univ.pr_abstract_universe_context (Termops.pr_evd_level sigma) ?variance c) ++ v 0 local) c
+  let has_priv = not (ContextSet.is_empty priv) in
+  if !Detyping.print_universes && (not (Univ.AUContext.is_empty c) || has_priv) then
+    let prlev u = Termops.pr_evd_level sigma u in
+    let pub = (if has_priv then str "Public universes:" ++ fnl() else mt()) ++ v 0 (Univ.pr_abstract_universe_context prlev ?variance c) in
+    let priv = if has_priv then fnl() ++ str "Private universes:" ++ fnl() ++ v 0 (Univ.pr_universe_context_set prlev priv) else mt() in
+    fnl()++pr_in_comment (pub ++ priv)
   else
     mt()
 
@@ -230,16 +228,14 @@ let pr_constant_universes sigma ~priv = function
 let pr_cumulativity_info sigma cumi =
   if !Detyping.print_universes 
   && not (Univ.UContext.is_empty (Univ.CumulativityInfo.univ_context cumi)) then
-    fnl()++pr_in_comment (fun uii -> v 0 
-      (Univ.pr_cumulativity_info (Termops.pr_evd_level sigma) uii)) cumi
+    fnl()++pr_in_comment (v 0 (Univ.pr_cumulativity_info (Termops.pr_evd_level sigma) cumi))
   else
     mt()
 
 let pr_abstract_cumulativity_info sigma cumi =
   if !Detyping.print_universes
   && not (Univ.AUContext.is_empty (Univ.ACumulativityInfo.univ_context cumi)) then
-    fnl()++pr_in_comment (fun uii -> v 0
-      (Univ.pr_abstract_cumulativity_info (Termops.pr_evd_level sigma) uii)) cumi
+    fnl()++pr_in_comment (v 0 (Univ.pr_abstract_cumulativity_info (Termops.pr_evd_level sigma) cumi))
   else
     mt()
 

--- a/printing/printer.mli
+++ b/printing/printer.mli
@@ -87,10 +87,10 @@ val pr_universe_instance   : evar_map -> Univ.Instance.t -> Pp.t
 val pr_universe_instance_constraints : evar_map -> Univ.Instance.t -> Univ.Constraint.t -> Pp.t
 val pr_universe_ctx        : evar_map -> ?variance:Univ.Variance.t array ->
   Univ.UContext.t -> Pp.t
-val pr_abstract_universe_ctx        : evar_map -> ?variance:Univ.Variance.t array ->
-  Univ.AUContext.t -> Pp.t
+val pr_abstract_universe_ctx : evar_map -> ?variance:Univ.Variance.t array ->
+  Univ.AUContext.t -> priv:Univ.ContextSet.t option -> Pp.t
 val pr_universe_ctx_set    : evar_map -> Univ.ContextSet.t -> Pp.t
-val pr_constant_universes  : evar_map -> Declarations.constant_universes -> Pp.t
+val pr_constant_universes  : evar_map -> priv:Univ.ContextSet.t option -> Declarations.constant_universes -> Pp.t
 val pr_cumulativity_info   : evar_map -> Univ.CumulativityInfo.t -> Pp.t
 val pr_abstract_cumulativity_info   : evar_map -> Univ.ACumulativityInfo.t -> Pp.t
 

--- a/printing/printmod.ml
+++ b/printing/printmod.ml
@@ -310,7 +310,7 @@ let print_body is_impl extent env mp (l,body) =
 		hov 2 (str ":= " ++
                        Printer.pr_lconstr_env env sigma (Mod_subst.force_constr l))
 	      | _ -> mt ()) ++ str "." ++
-            Printer.pr_abstract_universe_ctx sigma ctx)
+            Printer.pr_abstract_universe_ctx sigma ctx ~priv:cb.const_private_poly_univs)
     | SFBmind mib ->
       match extent with
       | WithContents ->

--- a/proofs/pfedit.ml
+++ b/proofs/pfedit.ml
@@ -138,7 +138,7 @@ let build_constant_by_tactic id ctx sign ?(goal_kind = Global, false, Proof Theo
   try
     let status = by tac in
     let open Proof_global in
-    let { entries; universes } = fst @@ close_proof ~keep_body_ucst_separate:false (fun x -> x) in
+    let { entries; universes } = fst @@ close_proof ~opaque:Transparent ~keep_body_ucst_separate:false (fun x -> x) in
     match entries with
     | [entry] ->
       discard_current ();

--- a/proofs/proof_global.mli
+++ b/proofs/proof_global.mli
@@ -86,7 +86,7 @@ val update_global_env : unit -> unit
 
 (* Takes a function to add to the exceptions data relative to the
    state in which the proof was built *)
-val close_proof : keep_body_ucst_separate:bool -> Future.fix_exn -> closed_proof
+val close_proof : opaque:opacity_flag -> keep_body_ucst_separate:bool -> Future.fix_exn -> closed_proof
 
 (* Intermediate step necessary to delegate the future.
  * Both access the current proof state. The former is supposed to be
@@ -97,7 +97,7 @@ type closed_proof_output = (Constr.t * Safe_typing.private_constants) list * USt
 (* If allow_partial is set (default no) then an incomplete proof
  * is allowed (no error), and a warn is given if the proof is complete. *)
 val return_proof : ?allow_partial:bool -> unit -> closed_proof_output
-val close_future_proof : feedback_id:Stateid.t ->
+val close_future_proof : opaque:opacity_flag -> feedback_id:Stateid.t ->
   closed_proof_output Future.computation -> closed_proof
 
 (** Gets the current terminator without checking that the proof has

--- a/stm/vernac_classifier.ml
+++ b/stm/vernac_classifier.ml
@@ -26,7 +26,7 @@ let string_of_vernac_type = function
   | VtUnknown -> "Unknown"
   | VtStartProof _ -> "StartProof"
   | VtSideff _ -> "Sideff"
-  | VtQed VtKeep -> "Qed(keep)"
+  | VtQed (VtKeep _) -> "Qed(keep)"
   | VtQed VtKeepAsAxiom -> "Qed(admitted)"
   | VtQed VtDrop -> "Qed(drop)"
   | VtProofStep { parallel; proof_block_detection } ->
@@ -66,7 +66,8 @@ let classify_vernac e =
     (* Qed *)
     | VernacAbort _ -> VtQed VtDrop, VtLater
     | VernacEndProof Admitted -> VtQed VtKeepAsAxiom, VtLater
-    | VernacEndProof _ | VernacExactProof _ -> VtQed VtKeep, VtLater
+    | VernacEndProof (Proved (opaque,_)) -> VtQed (VtKeep opaque), VtLater
+    | VernacExactProof _ -> VtQed (VtKeep Proof_global.Opaque), VtLater
     (* Query *)
     | VernacShow _ | VernacPrint _ | VernacSearch _ | VernacLocate _
     | VernacCheckMayEval _ -> VtQuery, VtLater

--- a/test-suite/success/polymorphism.v
+++ b/test-suite/success/polymorphism.v
@@ -165,19 +165,13 @@ Module binders.
     exact A.
   Defined.
 
-  Definition nomoreu@{i j | i < j +} (A : Type@{i}) : Type@{j}.
-    pose(foo:=Type).
-    exact A.
-    Fail Defined.
-  Abort.
+  Polymorphic Lemma hidden_strict_type : Type.
+  Proof.
+    exact Type.
+  Qed.
+  Check hidden_strict_type@{_}.
+  Fail Check hidden_strict_type@{Set}.
 
-  Polymorphic Definition moreu@{i j +} (A : Type@{i}) : Type@{j}.
-    pose(foo:=Type).
-    exact A.
-  Defined.
-
-  Check moreu@{_ _ _ _}.
-  
   Fail Definition morec@{i j|} (A : Type@{i}) : Type@{j} := A.
 
   (* By default constraints are extensible *)

--- a/test-suite/success/private_univs.v
+++ b/test-suite/success/private_univs.v
@@ -1,0 +1,50 @@
+Set Universe Polymorphism. Set Printing Universes.
+
+Definition internal_defined@{i j | i < j +} (A : Type@{i}) : Type@{j}.
+  pose(foo:=Type). (* 1 universe for the let body + 1 for the type *)
+  exact A.
+  Fail Defined.
+Abort.
+
+Definition internal_defined@{i j +} (A : Type@{i}) : Type@{j}.
+pose(foo:=Type).
+exact A.
+Defined.
+Check internal_defined@{_ _ _ _}.
+
+Module M.
+Lemma internal_qed@{i j|i<=j} (A:Type@{i}) : Type@{j}.
+Proof.
+  pose (foo := Type).
+  exact A.
+Qed.
+Check internal_qed@{_ _}.
+End M.
+Include M.
+(* be careful to remove const_private_univs in Include! will be coqchk'd *)
+
+Unset Strict Universe Declaration.
+Lemma private_transitivity@{i j} (A:Type@{i}) : Type@{j}.
+Proof.
+  pose (bar := Type : Type@{j}).
+  pose (foo := Type@{i} : bar).
+  exact bar.
+Qed.
+
+Definition private_transitivity'@{i j|i < j} := private_transitivity@{i j}.
+Fail Definition dummy@{i j|j <= i +} := private_transitivity@{i j}.
+
+Unset Private Polymorphic Universes.
+Lemma internal_noprivate_qed@{i j|i<=j} (A:Type@{i}) : Type@{j}.
+Proof.
+  pose (foo := Type).
+  exact A.
+  Fail Qed.
+Abort.
+
+Lemma internal_noprivate_qed@{i j +} (A:Type@{i}) : Type@{j}.
+Proof.
+  pose (foo := Type).
+  exact A.
+Qed.
+Check internal_noprivate_qed@{_ _ _ _}.

--- a/theories/Compat/Coq89.v
+++ b/theories/Compat/Coq89.v
@@ -10,3 +10,5 @@
 
 (** Compatibility file for making Coq act similar to Coq v8.9 *)
 Local Set Warnings "-deprecated".
+
+Unset Private Polymorphic Universes.

--- a/vernac/lemmas.ml
+++ b/vernac/lemmas.ml
@@ -311,7 +311,7 @@ let universe_proof_terminator compute_guard hook =
       | Transparent -> false, true
       | Opaque      -> true, false
     in
-    let const = {const with const_entry_opaque = is_opaque} in
+    assert (is_opaque == const.const_entry_opaque);
     let id = match idopt with
       | None -> id
       | Some { CAst.v = save_id } -> check_anonymity id save_id; save_id in
@@ -498,13 +498,13 @@ let save_proof ?proof = function
             Admitted(id,k,(sec_vars, (typ, ctx), None), universes)
       in
       Proof_global.apply_terminator (Proof_global.get_terminator ()) pe
-  | Vernacexpr.Proved (is_opaque,idopt) ->
+  | Vernacexpr.Proved (opaque,idopt) ->
       let (proof_obj,terminator) =
         match proof with
         | None ->
-            Proof_global.close_proof ~keep_body_ucst_separate:false (fun x -> x)
+            Proof_global.close_proof ~opaque ~keep_body_ucst_separate:false (fun x -> x)
         | Some proof -> proof
       in
       (* if the proof is given explicitly, nothing has to be deleted *)
       if Option.is_empty proof then Proof_global.discard_current ();
-      Proof_global.(apply_terminator terminator (Proved (is_opaque,idopt,proof_obj)))
+      Proof_global.(apply_terminator terminator (Proved (opaque,idopt,proof_obj)))

--- a/vernac/vernacextend.ml
+++ b/vernac/vernacextend.ml
@@ -12,10 +12,9 @@ open Util
 open Pp
 open CErrors
 
-type vernac_qed_type =
-  | VtKeep of Proof_global.opacity_flag
-  | VtKeepAsAxiom
-  | VtDrop
+type vernac_keep_as = VtKeepAxiom | VtKeepDefined | VtKeepOpaque
+
+type vernac_qed_type = VtKeep of vernac_keep_as | VtDrop
 
 type vernac_type =
   (* Start of a proof *)

--- a/vernac/vernacextend.ml
+++ b/vernac/vernacextend.ml
@@ -12,6 +12,11 @@ open Util
 open Pp
 open CErrors
 
+type vernac_qed_type =
+  | VtKeep of Proof_global.opacity_flag
+  | VtKeepAsAxiom
+  | VtDrop
+
 type vernac_type =
   (* Start of a proof *)
   | VtStartProof of vernac_start
@@ -33,7 +38,6 @@ type vernac_type =
   (* To be removed *)
   | VtMeta
   | VtUnknown
-and vernac_qed_type = VtKeep | VtKeepAsAxiom | VtDrop (* Qed/Admitted, Abort *)
 and vernac_start = string * opacity_guarantee * Names.Id.t list
 and vernac_sideff_type = Names.Id.t list
 and opacity_guarantee =

--- a/vernac/vernacextend.mli
+++ b/vernac/vernacextend.mli
@@ -27,6 +27,12 @@
    considered safe to delegate to a worker.
 
 *)
+
+type vernac_qed_type =
+  | VtKeep of Proof_global.opacity_flag (** Defined/Qed *)
+  | VtKeepAsAxiom (** Admitted *)
+  | VtDrop (** Abort *)
+
 type vernac_type =
   (* Start of a proof *)
   | VtStartProof of vernac_start
@@ -48,7 +54,6 @@ type vernac_type =
   (* To be removed *)
   | VtMeta
   | VtUnknown
-and vernac_qed_type = VtKeep | VtKeepAsAxiom | VtDrop (* Qed/Admitted, Abort *)
 and vernac_start = string * opacity_guarantee * Names.Id.t list
 and vernac_sideff_type = Names.Id.t list
 and opacity_guarantee =

--- a/vernac/vernacextend.mli
+++ b/vernac/vernacextend.mli
@@ -28,10 +28,9 @@
 
 *)
 
-type vernac_qed_type =
-  | VtKeep of Proof_global.opacity_flag (** Defined/Qed *)
-  | VtKeepAsAxiom (** Admitted *)
-  | VtDrop (** Abort *)
+type vernac_keep_as = VtKeepAxiom | VtKeepDefined | VtKeepOpaque
+
+type vernac_qed_type = VtKeep of vernac_keep_as | VtDrop
 
 type vernac_type =
   (* Start of a proof *)


### PR DESCRIPTION
This lets opaque polymorphic constants have universes which are needed for the body but which do not need to be provided when using the constant (because we guarantee that some acceptable universe always exists, and since the constant is opaque it can't be observed).
For instance, 
~~~coq
Set Printing Universes.
Set Universe Polymorphism.
Lemma foo : Type.
Proof. exact (forall _ : Type, Type).
Qed.

Print foo.
(*
foo@{Top.1} = 
Type@{Top.2} -> Type@{Top.3}
     : Type@{Top.1}
(* Top.1 |= Prop < Set
            Set < Top.1
            local: {Top.3 Top.2} |= Top.2 < Top.1
                                    Top.3 < Top.1
                                     *)

foo is universe polymorphic
*)
Definition bar@{i|Set < i} := foo@{i}.
~~~

This is compatibility breaking for those using explicit universe instances (unless they have no opaque definitions I guess). I didn't make the others yet but see the HoTT overlay at https://github.com/SkySkimmer/HoTT/commit/2d4bf3814b1c2a72fb910f072e714c9c1e792b45 for what it gives us in the wild. For instance removing the need to pass around upper bound universes like https://github.com/SkySkimmer/HoTT/commit/2d4bf3814b1c2a72fb910f072e714c9c1e792b45#diff-e2b7e5e83439b62c3f9c1764d6f5eaf1L391 and removing lots of manually minimizing universes.

This can be disabled by unsetting `Private Polymorphic Universes`, such that `Qed` has no semantic difference other than blocking unfolding.

TODO:
- improve printing? `local` is indented strangely in the example above