### PR TITLE
Use the obligation evar flag

### DIFF
--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -483,6 +483,8 @@ let is_typeclass_evar evd evk =
   let flags = evd.evar_flags in
   Evar.Set.mem evk flags.typeclass_evars
 
+let get_obligation_evars evd = evd.evar_flags.obligation_evars
+
 let set_obligation_evar evd evk =
   let flags = evd.evar_flags in
   let evar_flags = { flags with obligation_evars = Evar.Set.add evk flags.obligation_evars } in

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -262,6 +262,9 @@ val get_typeclass_evars : evar_map -> Evar.Set.t
 val is_typeclass_evar : evar_map -> Evar.t -> bool
 (** Is the evar declared resolvable for typeclass resolution *)
 
+val get_obligation_evars : evar_map -> Evar.Set.t
+(** The set of obligation evars *)
+
 val set_obligation_evar : evar_map -> Evar.t -> evar_map
 (** Declare an evar as an obligation *)
 

--- a/engine/termops.ml
+++ b/engine/termops.ml
@@ -371,12 +371,18 @@ let pr_evar_map_gen with_univs pr_evars sigma =
     else
       str "TYPECLASSES:" ++ brk (0, 1) ++
       prlist_with_sep spc Evar.print (Evar.Set.elements evars) ++ fnl ()
+  and obligations =
+    let evars = Evd.get_obligation_evars sigma in
+    if Evar.Set.is_empty evars then mt ()
+    else
+      str "OBLIGATIONS:" ++ brk (0, 1) ++
+      prlist_with_sep spc Evar.print (Evar.Set.elements evars) ++ fnl ()
   and metas =
     if List.is_empty (Evd.meta_list sigma) then mt ()
     else
       str "METAS:" ++ brk (0, 1) ++ pr_meta_map sigma
   in
-  evs ++ svs ++ cstrs ++ typeclasses ++ metas
+  evs ++ svs ++ cstrs ++ typeclasses ++ obligations ++ metas
 
 let pr_evar_list sigma l =
   let open Evd in

--- a/pretyping/coercion.ml
+++ b/pretyping/coercion.ml
@@ -104,6 +104,7 @@ let make_existential ?loc ?(opaque = not (get_proofs_transparency ())) na env ev
       Evar_kinds.qm_name=na;
   }) in
   let evd, v = Evarutil.new_evar env !evdref ~src c in
+  let evd = Evd.set_obligation_evar evd (fst (destEvar evd v)) in
   evdref := evd;
   v
 

--- a/pretyping/evarsolve.ml
+++ b/pretyping/evarsolve.ml
@@ -1240,9 +1240,9 @@ let check_evar_instance evd evk1 body conv_algo =
 
 let update_evar_info ev1 ev2 evd =
   (* We update the source of obligation evars during evar-evar unifications. *)
-  let loc, evs2 = evar_source ev2 evd in
-  let evi = Evd.find evd ev1 in
-  Evd.add evd ev1 {evi with evar_source = loc, evs2}
+  let loc, evs1 = evar_source ev1 evd in
+  let evi = Evd.find evd ev2 in
+  Evd.add evd ev2 {evi with evar_source = loc, evs1}
 
 let solve_evar_evar_l2r force f g env evd aliases pbty ev1 (evk2,_ as ev2) =
   try

--- a/test-suite/bugs/closed/bug_8848.v
+++ b/test-suite/bugs/closed/bug_8848.v
@@ -1,0 +1,18 @@
+Require Import Program.
+Set Implicit Arguments.
+Unset Strict Implicit.
+
+Definition def (a : nat) := a = a.
+
+Structure record {a : nat} {D : def a} :=
+  inR { prop : Prop }.
+
+Program
+Canonical Structure ins (a : nat) (rec : @record a _) :=
+  @inR a _ (prop rec).
+Next Obligation.
+  exact eq_refl.
+Defined.
+Next Obligation.
+  exact eq_refl.
+Defined.

--- a/vernac/comProgramFixpoint.ml
+++ b/vernac/comProgramFixpoint.ml
@@ -178,7 +178,8 @@ let build_wellfounded (recname,pl,n,bl,arityc,body) poly r measure notation =
     let sigma, h_e_term = Evarutil.new_evar env sigma
         ~src:(Loc.tag @@ Evar_kinds.QuestionMark {
             Evar_kinds.default_question_mark with Evar_kinds.qm_obligation=Evar_kinds.Define false;
-        }) wf_proof in
+          }) wf_proof in
+    let sigma = Evd.set_obligation_evar sigma (fst (destEvar sigma h_e_term)) in
     sigma, mkApp (h_a_term, [| argtyp ; wf_rel ; h_e_term; prop |])
   in
   let sigma, def = Typing.solve_evars env sigma def in

--- a/vernac/obligations.ml
+++ b/vernac/obligations.ml
@@ -37,13 +37,11 @@ let succfix (depth, fixrels) =
 
 let check_evars env evm =
   Evar.Map.iter
-  (fun key evi ->
-   let (loc,k) = evar_source key evm in
-     match k with
-     | Evar_kinds.QuestionMark _
-     | Evar_kinds.ImplicitArg (_,_,false) -> ()
-     | _ ->
-       Pretype_errors.error_unsolvable_implicit ?loc env evm key None)
+    (fun key evi ->
+       if Evd.is_obligation_evar evm key then ()
+       else
+         let (loc,k) = evar_source key evm in
+         Pretype_errors.error_unsolvable_implicit ?loc env evm key None)
   (Evd.undefined_map evm)
 
 type oblinfo =


### PR DESCRIPTION
This stops using evar sources to determine what is an obligation and what isn't, rather relying on explicit declaration of obligation evars by Program/coercion. It should not change anything from the user point of view. Also added an [Evd.get_obligation_evars] to print the obligation evars associated to an evar_map for debugging purposes.

<!-- Keep what applies -->
**Kind:** cleanup

EDIT: depends on ~~#8849~~.