### PR TITLE
[library] Better sizing for libobject hashtbl.

### DIFF
--- a/library/libobject.ml
+++ b/library/libobject.ml
@@ -65,7 +65,7 @@ type dynamic_object_declaration = {
 let object_tag (Dyn.Dyn (t, _)) = Dyn.repr t
 
 let cache_tab =
-  (Hashtbl.create 17 : (string,dynamic_object_declaration) Hashtbl.t)
+  (Hashtbl.create 223 : (string,dynamic_object_declaration) Hashtbl.t)
 
 let declare_object_full odecl =
   let na = odecl.object_name in


### PR DESCRIPTION
17 is a very small number as files in the stdlib will routinely pass
size 190.

As this is done only on startup, it seems wise to provide a bit more
space.
