### PR TITLE
Remove useless make_flexible from univ refresh

### DIFF
--- a/pretyping/evarsolve.ml
+++ b/pretyping/evarsolve.ml
@@ -65,10 +65,7 @@ let refresh_universes ?(status=univ_rigid) ?(onlyalg=false) ?(refreshset=false)
 	    | UnivRigid ->
 	       if not onlyalg then refresh_sort status ~direction s
 	       else t
-	    | UnivFlexible alg ->
-	       if onlyalg && alg then
-	         (evdref := Evd.make_flexible_variable !evdref ~algebraic:false l; t)
-	       else t))
+            | UnivFlexible alg -> t))
       | Set when refreshset && not direction ->
        (* Cannot make a universe "lower" than "Set",
           only refreshing when we want higher universes. *)


### PR DESCRIPTION
In this branch we already know that it's flexible, so it's a
noop (make_flexible_variable ~algebraic:false will NOT turn algebraic
into non-algebraic).
