### PR TITLE
[VM] Fix compilation of int31 eliminators

### DIFF
--- a/test-suite/bugs/closed/bug_8885.v
+++ b/test-suite/bugs/closed/bug_8885.v
@@ -1,0 +1,8 @@
+From Coq Require Import Cyclic31.
+
+Definition Nat `(int31) := nat.
+Definition Zero (_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _: digits) := 0.
+
+Check (eq_refl (int31_rect Nat Zero 1) : 0 = 0).
+Check (eq_refl (int31_rect Nat Zero 1) <: 0 = 0).
+Check (eq_refl (int31_rect Nat Zero 1) <<: 0 = 0).

--- a/theories/Numbers/Cyclic/Int31/Int31.v
+++ b/theories/Numbers/Cyclic/Int31/Int31.v
@@ -15,6 +15,8 @@ Require Import Wf_nat.
 Require Export ZArith.
 Require Export DoubleType.
 
+Local Unset Elimination Schemes.
+
 (** * 31-bit integers *)
 
 (** This file contains basic definitions of a 31-bit integer
@@ -47,6 +49,10 @@ Inductive int31 : Type := I31 : digits31 int31.
    occur when they are applied to one non-closed term and one closed term). *)
 Register digits as int31.bits.
 Register int31 as int31.type.
+
+Scheme int31_ind := Induction for int31 Sort Prop.
+Scheme int31_rec := Induction for int31 Sort Set.
+Scheme int31_rect := Induction for int31 Sort Type.
 
 Declare Scope int31_scope.
 Declare ML Module "int31_syntax_plugin".


### PR DESCRIPTION
The compilation to bytecode of the elimination schemes for int31 must
happen after the int31 type is registered to the retroknowledge.
Otherwise, the “decompint” instruction is not emitted.

Fixes #8885.

- [x] Added / updated test-suite
