### PR TITLE
Looking for notation both before or after removal of top coercion

### DIFF
--- a/test-suite/output/Notations4.out
+++ b/test-suite/output/Notations4.out
@@ -17,3 +17,7 @@ end
      : Expr -> Expr
 [(1 + 1)]
      : Expr
+Let "x" e1 e2
+     : expr
+Let "x" e1 e2
+     : expr

--- a/test-suite/output/Notations4.v
+++ b/test-suite/output/Notations4.v
@@ -70,3 +70,27 @@ Notation "( x )" := x (in custom expr at level 0, x at level 2).
 Check [1 + 1].
 
 End C.
+
+(* An example of interaction between coercion and notations from
+   Robbert Krebbers. *)
+
+Require Import String.
+
+Module D.
+
+Inductive expr :=
+  | Var : string -> expr
+  | Lam : string -> expr -> expr
+  | App : expr -> expr -> expr.
+
+Notation Let x e1 e2 := (App (Lam x e2) e1).
+
+Parameter e1 e2 : expr.
+
+Check (Let "x" e1 e2).
+
+Coercion App : expr >-> Funclass.
+
+Check (Let "x" e1 e2).
+
+End D.


### PR DESCRIPTION
**Kind:** experiment in prevision of further code simplification

For primitive tokens, in a situation like `Zpos some_constant : Z` and `Zpos` is a removable coercion, there is a heuristic which looks for a notation for `Zpos some_constant` and `some_constant` independently, then prefers the second one unless it requires a delimiter. (This was initially motivated by an example in the four color theorem, see e1c8e5ca2).

We apply this heuristic also for ordinary notations. I don't have realistic examples of application but this will help to do some factorization in the code.
