### PR TITLE
Fix part of #8224: grounding open term in fixpoints

### DIFF
--- a/test-suite/bugs/closed/bug_8224.v
+++ b/test-suite/bugs/closed/bug_8224.v
@@ -1,0 +1,9 @@
+(* Checking that terms are evar-free before being grounded *)
+
+(* This used to raise an anomaly in 8.9 beta *)
+
+Fail Fixpoint restrict f n :=
+  match n with
+  | O => nil
+  | S n => cons (f n) (restrict f n)
+  end.

--- a/vernac/comFixpoint.mli
+++ b/vernac/comFixpoint.mli
@@ -51,7 +51,7 @@ val interp_recursive :
   (* env / signature / univs / evar_map *)
   (Environ.env * EConstr.named_context * UState.universe_decl * Evd.evar_map) *
   (* names / defs / types *)
-  (Id.t list * Constr.constr option list * Constr.types list) *
+  (Id.t list * EConstr.constr option list * EConstr.types list) *
   (* ctx per mutual def / implicits / struct annotations *)
   (EConstr.rel_context * Impargs.manual_explicitation list * int option) list
 

--- a/vernac/comProgramFixpoint.ml
+++ b/vernac/comProgramFixpoint.ml
@@ -1,3 +1,13 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *   INRIA, CNRS and contributors - Copyright 1999-2018       *)
+(* <O___,, *       (see CREDITS file for the list of authors)           *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
 open Pp
 open CErrors
 open Util
@@ -251,10 +261,10 @@ let do_program_recursive local poly fixkind fixl ntns =
   let collect_evars id def typ imps =
     (* Generalize by the recursive prototypes  *)
     let def =
-      EConstr.to_constr ~abort_on_undefined_evars:false evd (Termops.it_mkNamedLambda_or_LetIn (EConstr.of_constr def) rec_sign)
+      EConstr.to_constr ~abort_on_undefined_evars:false evd (Termops.it_mkNamedLambda_or_LetIn def rec_sign)
     and typ =
       (* Worrying... *)
-      EConstr.to_constr ~abort_on_undefined_evars:false evd (Termops.it_mkNamedProd_or_LetIn (EConstr.of_constr typ) rec_sign)
+      EConstr.to_constr ~abort_on_undefined_evars:false evd (Termops.it_mkNamedProd_or_LetIn typ rec_sign)
     in
     let evm = collect_evars_of_term evd def typ in
     let evars, _, def, typ =
@@ -268,6 +278,9 @@ let do_program_recursive local poly fixkind fixl ntns =
   let defs = List.map4 collect_evars fixnames fixdefs fixtypes fiximps in
   let () = if not cofix then begin
       let possible_indexes = List.map ComFixpoint.compute_possible_guardness_evidences info in
+      (* XXX: are we allowed to have evars here? *)
+      let fixtypes = List.map (EConstr.to_constr ~abort_on_undefined_evars:false evd) fixtypes in
+      let fixdefs = List.map (EConstr.to_constr ~abort_on_undefined_evars:false evd) fixdefs in
       let fixdecls = Array.of_list (List.map (fun x -> Name x) fixnames),
         Array.of_list fixtypes,
         Array.of_list (List.map (subst_vars (List.rev fixnames)) fixdefs)


### PR DESCRIPTION
**Kind:** bug fix

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes [part](https://github.com/coq/coq/issues/8224#issuecomment-435213334) of #8224

Turning an econstr `Fixpoint` to a constr was done too early. One should first check that all evars are resolved.

- [X] Added / updated test-suite
