### PR TITLE
Expose Typing.judge_of_apply

### DIFF
--- a/pretyping/typing.mli
+++ b/pretyping/typing.mli
@@ -48,6 +48,8 @@ val check_type_fixpoint : ?loc:Loc.t -> env -> evar_map ->
 
 val judge_of_prop : unsafe_judgment
 val judge_of_set : unsafe_judgment
+val judge_of_apply : env -> evar_map -> unsafe_judgment -> unsafe_judgment array ->
+  evar_map * unsafe_judgment
 val judge_of_abstraction : Environ.env -> Name.t ->
   unsafe_type_judgment -> unsafe_judgment -> unsafe_judgment
 val judge_of_product : Environ.env -> Name.t ->


### PR DESCRIPTION
This can be useful to avoid [Typing.type_of (App (f,args))] when
working with universe polymorphism.
