### PR TITLE
Fix #5351: Intuition does not work with universe polymorphism.

### DIFF
--- a/test-suite/bugs/closed/bug_5351.v
+++ b/test-suite/bugs/closed/bug_5351.v
@@ -1,0 +1,18 @@
+Polymorphic Inductive T:Type := t.
+Polymorphic Definition general_ok (pre: T -> Prop) := forall v, pre v.
+Polymorphic Definition ok := general_ok (fun _ => True).
+
+Definition ok' := True.
+
+Theorem ok_equiv : ok <-> ok'.
+  unfold ok, ok', general_ok.
+  intuition.
+Qed.
+
+Corollary ok_equiv' (H:ok) : False.
+Proof.
+  destruct ok_equiv; intuition.
+  try match goal with
+      | [ H: _ -> _, H': _ |- _ ] =>
+        specialize (H H'); fail 10 "bad"
+      end.

--- a/theories/Init/Tauto.v
+++ b/theories/Init/Tauto.v
@@ -14,7 +14,7 @@ Local Ltac axioms flags :=
   match reverse goal with
     | |- ?X1 => is_unit_or_eq flags X1; constructor 1
     | _:?X1 |- _ => is_empty flags X1; elimtype X1; assumption
-    | _:?X1 |- ?X1 => assumption
+    | _:?X1 |- ?X2 => constr_eq X1 X2; assumption
   end.
 
 Local Ltac simplif flags :=
@@ -25,10 +25,11 @@ Local Ltac simplif flags :=
       | id: (Coq.Init.Logic.iff _ _) |- _ => elim id; do 2 intro; clear id
       | id: (Coq.Init.Logic.not _) |- _ => red in id
       | id: ?X1 |- _ => is_disj flags X1; elim id; intro; clear id
-      | id0: (forall (_: ?X1), ?X2), id1: ?X1|- _ =>
+      | id0: (forall (_: ?X1), ?X2), id1: ?X3|- _ =>
     (* generalize (id0 id1); intro; clear id0 does not work
        (see Marco Maggiesi's BZ#301)
     so we instead use Assert and exact. *)
+    constr_eq X1 X3;
     assert X2; [exact (id0 id1) | clear id0]
       | id: forall (_ : ?X1), ?X2|- _ =>
         is_unit_or_eq flags X1; cut X2;


### PR DESCRIPTION
Instead of using non-linear pattern-matching in tauto, we use constr_eq so as to add the missing universe constraints.

Fixes / closes #5351.

- [x] Added / updated test-suite
