### PR TITLE
Fix #5351: Intuition does not work with universe polymorphism.

### DIFF
--- a/doc/changelog/04-tactics/8905-fix-5351.rst
+++ b/doc/changelog/04-tactics/8905-fix-5351.rst
@@ -1,0 +1,8 @@
+- **Fixed:**
+  the :tacn:`tauto` tactic and its variants now try to match types
+  up to universe unification. This makes them compatible with
+  universe-polymorphic code
+  (`#8905 <https://github.com/coq/coq/pull/8905>`_,
+  fixes `#4721 <https://github.com/coq/coq/issues/4721>`_
+  and `#5351 <https://github.com/coq/coq/issues/5351>`_,
+  by Pierre-Marie Pédrot).

--- a/plugins/ltac/tauto.ml
+++ b/plugins/ltac/tauto.ml
@@ -267,6 +267,10 @@ let warn_auto_with_star_tac _ _ =
       Proofview.tclUNIT()
     end
 
+let is_conv _ ist =
+  let x1 = assoc_var "X1" ist in
+  let x2 = assoc_var "X2" ist in
+  Tactics.convert x1 x2
 
 let register_tauto_tactic tac name0 args =
   let ids = List.map (fun id -> Id.of_string id) args in
@@ -289,3 +293,4 @@ let () = register_tauto_tactic reduction_not_iff "reduction_not_iff" []
 let () = register_tauto_tactic (with_flags tauto_uniform_unit_flags) "with_uniform_flags" ["f"]
 let () = register_tauto_tactic (with_flags tauto_power_flags) "with_power_flags" ["f"]
 let () = register_tauto_tactic warn_auto_with_star_tac "warn_auto_with_star" []
+let () = register_tauto_tactic is_conv "is_conv" ["X1"; "X2"]

--- a/plugins/ltac/tauto.ml
+++ b/plugins/ltac/tauto.ml
@@ -20,6 +20,8 @@ open Util
 open Tacticals
 open Proofview.Notations
 
+module NamedDecl = Context.Named.Declaration
+
 let tauto_plugin = "coq-core.plugins.tauto"
 let () = Mltop.add_known_module tauto_plugin
 
@@ -267,10 +269,43 @@ let warn_auto_with_star_tac _ _ =
       Proofview.tclUNIT()
     end
 
-let is_conv _ ist =
-  let x1 = assoc_var "X1" ist in
-  let x2 = assoc_var "X2" ist in
-  Tactics.convert x1 x2
+let val_of_id id =
+  let open Geninterp in
+  let id = CAst.make @@ Tactypes.IntroNaming (IntroIdentifier id) in
+  Val.inject (val_tag @@ Genarg.topwit Tacarg.wit_intro_pattern) id
+
+let find_cut _ ist =
+  let k = Id.Map.find (Names.Id.of_string "k") ist.lfun in
+  Proofview.Goal.enter begin fun gl ->
+  let sigma = Proofview.Goal.sigma gl in
+  let hyps0 = Proofview.Goal.hyps gl in
+  (* Beware of the relative order of hypothesis picking! *)
+  let rec find_arg = function
+  | [] -> Tacticals.tclFAIL (Pp.str ("No matching clause"))
+  | arg :: hyps ->
+    let typ = NamedDecl.get_type arg in
+    let arg = NamedDecl.get_id arg in
+    let rec find_fun = function
+    | [] -> Tacticals.tclFAIL (Pp.str ("No matching clause"))
+    | fnc :: hyps ->
+      match EConstr.kind sigma (NamedDecl.get_type fnc) with
+      | Prod (na, dom, codom) when EConstr.Vars.noccurn sigma 1 codom ->
+        let f = NamedDecl.get_id fnc in
+        if Id.equal f arg then find_fun hyps
+        else
+          Proofview.tclOR
+            (Proofview.tclUNIT () >>= fun () -> find_fun hyps)
+            (fun _ -> Tactics.convert dom typ <*> Proofview.tclUNIT (f, arg, codom))
+      | _ -> find_fun hyps
+    in
+    Proofview.tclOR (Proofview.tclUNIT () >>= fun () -> find_arg hyps) (fun _ -> find_fun hyps0)
+  in
+  let tac =
+    find_arg hyps0 >>= fun (f, arg, t) ->
+    Tacinterp.Value.apply k [val_of_id f; val_of_id arg; Value.of_constr t]
+  in
+  Proofview.tclONCE tac
+  end
 
 let register_tauto_tactic tac name0 args =
   let ids = List.map (fun id -> Id.of_string id) args in
@@ -293,4 +328,4 @@ let () = register_tauto_tactic reduction_not_iff "reduction_not_iff" []
 let () = register_tauto_tactic (with_flags tauto_uniform_unit_flags) "with_uniform_flags" ["f"]
 let () = register_tauto_tactic (with_flags tauto_power_flags) "with_power_flags" ["f"]
 let () = register_tauto_tactic warn_auto_with_star_tac "warn_auto_with_star" []
-let () = register_tauto_tactic is_conv "is_conv" ["X1"; "X2"]
+let () = register_tauto_tactic find_cut "find_cut" ["k"]

--- a/test-suite/bugs/bug_4721.v
+++ b/test-suite/bugs/bug_4721.v
@@ -1,0 +1,12 @@
+Variables S1 S2 : Set.
+
+Goal @eq Type S1 S2 -> @eq Type S1 S2.
+intro H.
+tauto.
+Qed.
+
+(*This is in 8.5pl1, and Matthieq Sozeau says: "That's a regression in tauto indeed, which now requires exact equality of the universes, through a non linear goal pattern matching:
+match goal with ?X1 |- ?X1 forces both instances of X1 to be convertible,
+with no additional universe constraints currently, but the two types are
+initially different. This can be fixed easily to allow the same flexibility
+as in 8.4 (or assumption) to unify the universes as well."*)

--- a/test-suite/bugs/bug_5351.v
+++ b/test-suite/bugs/bug_5351.v
@@ -1,0 +1,19 @@
+Polymorphic Inductive T:Type := t.
+Polymorphic Definition general_ok (pre: T -> Prop) := forall v, pre v.
+Polymorphic Definition ok := general_ok (fun _ => True).
+
+Definition ok' := True.
+
+Theorem ok_equiv : ok <-> ok'.
+  unfold ok, ok', general_ok.
+  intuition.
+Qed.
+
+Corollary ok_equiv' (H:ok) : False.
+Proof.
+  destruct ok_equiv; intuition.
+  try match goal with
+      | [ H: _ -> _, H': _ |- _ ] =>
+        specialize (H H'); fail 10 "bad"
+      end.
+Abort.

--- a/theories/Init/Tauto.v
+++ b/theories/Init/Tauto.v
@@ -38,10 +38,11 @@ Local Ltac simplif flags :=
       | id: (Coq.Init.Logic.iff _ _) |- _ => elim id; do 2 intro; clear id
       | id: (Coq.Init.Logic.not _) |- _ => red in id
       | id: ?X1 |- _ => is_disj flags X1; elim id; intro; clear id
-      | id0: (forall (_: ?X1), ?X2), id1: ?X1|- _ =>
+      | id0: (forall (_: ?X1), ?X2), id1: ?X3|- _ =>
     (* generalize (id0 id1); intro; clear id0 does not work
        (see Marco Maggiesi's BZ#301)
     so we instead use Assert and exact. *)
+    is_conv X1 X3;
     assert X2; [exact (id0 id1) | clear id0]
       | id: forall (_ : ?X1), ?X2|- _ =>
         is_unit_or_eq flags X1; cut X2;

--- a/theories/Init/Tauto.v
+++ b/theories/Init/Tauto.v
@@ -38,12 +38,15 @@ Local Ltac simplif flags :=
       | id: (Coq.Init.Logic.iff _ _) |- _ => elim id; do 2 intro; clear id
       | id: (Coq.Init.Logic.not _) |- _ => red in id
       | id: ?X1 |- _ => is_disj flags X1; elim id; intro; clear id
-      | id0: (forall (_: ?X1), ?X2), id1: ?X3|- _ =>
-    (* generalize (id0 id1); intro; clear id0 does not work
-       (see Marco Maggiesi's BZ#301)
-    so we instead use Assert and exact. *)
-    is_conv X1 X3;
-    assert X2; [exact (id0 id1) | clear id0]
+      | _ =>
+        (* behaves as matching [ id0: ?X1 -> ?X2, id1: ?X1 |- _ ] with
+           universe-aware conversion *)
+        find_cut ltac:(fun id0 id1 X2 =>
+          (* generalize (id0 id1); intro; clear id0 does not work
+             (see Marco Maggiesi's BZ#301)
+          so we instead use Assert and exact. *)
+          assert X2; [exact (id0 id1) | clear id0]
+          )
       | id: forall (_ : ?X1), ?X2|- _ =>
         is_unit_or_eq flags X1; cut X2;
     [ intro; clear id


### PR DESCRIPTION
Instead of using non-linear pattern-matching in tauto, we use a tauto-specific conversion function so as to add the missing universe constraints. We cannot use constr_eq as the current implementation of non-linear matching uses conversion rather than syntactic equality.

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #4721.
Fixes / closes #5351.

- [x] Added / updated test-suite
