### PR TITLE
[CoqProject] Abstract warning function for CoqProject readers.

### DIFF
--- a/dev/ci/user-overlays/08914-ejgallego-lib+better_boot_coqproject.sh
+++ b/dev/ci/user-overlays/08914-ejgallego-lib+better_boot_coqproject.sh
@@ -1,0 +1,6 @@
+if [ "$CI_PULL_REQUEST" = "8914" ] || [ "$CI_BRANCH" = "lib+better_boot_coqproject" ]; then
+
+    quickchick_CI_REF=lib+better_boot_coqproject
+    quickchick_CI_GITURL=https://github.com/ejgallego/QuickChick
+
+fi

--- a/ide/coqide.ml
+++ b/ide/coqide.ml
@@ -103,7 +103,8 @@ let make_coqtop_args fname =
         with
         | None -> "", base_args
         | Some proj ->
-          proj, coqtop_args_from_project (read_project_file proj) @ base_args
+          let warning_fn x = Feedback.msg_warning Pp.(str x) in
+          proj, coqtop_args_from_project (read_project_file ~warning_fn proj) @ base_args
   in
   let args = match fname with
     | None -> args
@@ -112,7 +113,6 @@ let make_coqtop_args fname =
       else "-topfile"::fname::args
   in
   proj, args
-;;
 
 (** Setting drag & drop on widgets *)
 
@@ -1355,7 +1355,8 @@ let read_coqide_args argv =
       if project_files <> None then
         (output_string stderr "Error: multiple -f options"; exit 1);
       let d = CUnix.canonical_path_name (Filename.dirname file) in
-      let p = CoqProject_file.read_project_file file in
+      let warning_fn x = Format.eprintf "%s@\n%!" x in
+      let p = CoqProject_file.read_project_file ~warning_fn file in
       filter_coqtop coqtop (Some (d,p)) out args
     |"-f" :: [] ->
       output_string stderr "Error: missing project file name"; exit 1

--- a/lib/coqProject_file.mli
+++ b/lib/coqProject_file.mli
@@ -51,8 +51,8 @@ and install =
   | TraditionalInstall
   | UserInstall
 
-val cmdline_args_to_project : curdir:string -> string list -> project
-val read_project_file : string -> project
+val cmdline_args_to_project : warning_fn:(string -> unit) -> curdir:string -> string list -> project
+val read_project_file : warning_fn:(string -> unit) -> string -> project
 val coqtop_args_from_project : project -> string list
 val find_project_file : from:string -> projfile_name:string -> string option
 

--- a/tools/coq_makefile.ml
+++ b/tools/coq_makefile.ml
@@ -396,8 +396,9 @@ let _ =
     | "-destination-of" :: tgt :: rest -> Some tgt, rest
     | _ -> None, args in
 
-  let project = 
-    try cmdline_args_to_project ~curdir:Filename.current_dir_name args
+  let project =
+    let warning_fn x = Format.eprintf "%s@\n%!" x in
+    try cmdline_args_to_project ~warning_fn ~curdir:Filename.current_dir_name args
     with Parsing_error s -> prerr_endline s; usage_coq_makefile () in
 
   if only_destination <> None then begin

--- a/tools/coqdep.ml
+++ b/tools/coqdep.ml
@@ -473,7 +473,8 @@ let add_r_include path l = add_rec_dir_import add_known path (split_period l)
 let treat_coqproject f =
   let open CoqProject_file in
   let iter_sourced f = List.iter (fun {thing} -> f thing) in
-  let project = read_project_file f in
+  let warning_fn x = coqdep_warning "%s" x in
+  let project = read_project_file ~warning_fn f in
   iter_sourced (fun { path } -> add_caml_dir path) project.ml_includes;
   iter_sourced (fun ({ path }, l) -> add_q_include path l) project.q_includes;
   iter_sourced (fun ({ path }, l) -> add_r_include path l) project.r_includes;


### PR DESCRIPTION
`CoqProject_file` uses the feedback system, however this is not very
convenient in some scenarios such as `coqdep` that has to be run very
early in the build process [and thus in "boot" mode].

We thus make the warning function a paramater.

Should fix #8913.

This will also help in speeding up the Dune build considerably, as it removes one dependency of `coqdep` on `lib`.