### PR TITLE
[dune] Add flag to drop dependency of `.vo` files on coqtop.

### DIFF
--- a/dev/doc/build-system.dune.md
+++ b/dev/doc/build-system.dune.md
@@ -144,6 +144,20 @@ files. We hope to solve this in the future.
 The documentation and test suite targets for Coq are still not
 implemented in Dune.
 
+## Avoiding .vo rebuild when `coqc` changes.
+
+All `.v -> .vo` rules have an implicit dependency on the digest of
+`coqc`, for obvious integrity reasons.
+
+However, a common use case to speed up development is to modify `coqc`
+but don't invalidate the previously generated `.vo` files, at the risk
+of the developer and the integrity of the build.
+
+`coq_dune` supports such build scenario by modifying setting the
+`skip_vo_integrity` flag to true. Note that when this flag is enabled,
+you must manually call Dune to build the proper ML targets, such as
+plugins or `coqc`.
+
 ## Planned and Advanced features
 
 Dune supports or will support extra functionality that may result very


### PR DESCRIPTION
In #8900 there was a lot of discussion about having a fast-path that
skips `.vo` integrity checks by allowing to rebuild `coqtop` but not
the `.vo` that depend on it.

We thus add a flag for such adventurous users so they can manually
control the build. Note that using this may create all kind of havoc,
for example if you haven't build `coqtop` Dune could well pick the one
in your PATH, etc...

This can be improved, but in the end it will put a lot of burden on
the user to check for consistency.
