### PR TITLE
Misc updates to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -274,16 +274,6 @@
 
 /theories/Vectors/        @herbelin
 
-########## Dune  ##########
-
-/.ocamlinit            @ejgallego
-/Makefile.dune         @ejgallego
-/tools/coq_dune*       @ejgallego
-/dune*                 @ejgallego
-/coq.opam              @ejgallego
-/ide/coqide.opam       @ejgallego
-# Secondary maintainer @Zimmi48
-
 ########## Tools ##########
 
 /tools/coqdoc/         @silene
@@ -357,4 +347,11 @@
 
 /dev/tools/update-compat.py @JasonGross
 /test-suite/tools/update-compat/ @JasonGross
+# Secondary maintainer @Zimmi48
+
+########## Dune  ##########
+
+/.ocamlinit            @ejgallego
+*dune*                 @ejgallego
+*.opam                 @ejgallego
 # Secondary maintainer @Zimmi48

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -166,12 +166,9 @@
 /plugins/setoid_ring/   @amahboubi
 # Secondary maintainer @bgregoir
 
-/plugins/ssrmatching/   @gares
-# Secondary maintainer @maximedenes
-
-/plugins/ssr/          @gares
-/test-suite/ssr/       @gares
-# Secondary maintainer @maximedenes
+/plugins/ssrmatching/  @coq/ssreflect-maintainers
+/plugins/ssr/          @coq/ssreflect-maintainers
+/test-suite/ssr/       @coq/ssreflect-maintainers
 
 /plugins/syntax/        @ppedrot
 # Secondary maintainer @maximedenes

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -105,7 +105,7 @@
 
 /ide/             @ppedrot
 /test-suite/ide/  @ppedrot
-# Secondary maintainer @gares
+# Secondary maintainers @gares @herbelin
 
 ########## Interpretation ##########
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -96,11 +96,6 @@
 /engine/uState.* @SkySkimmer
 # Secondary maintainer @mattam82
 
-########## Grammar macros ##########
-
-/grammar/         @ppedrot
-# Secondary maintainer @maximedenes
-
 ########## CoqIDE ##########
 
 /ide/             @ppedrot
@@ -132,8 +127,9 @@
 
 ########## Parser ##########
 
-/parsing/         @herbelin
-# Secondary maintainer @mattam82
+/coqpp/           @coq/parsing-maintainers
+/gramlib/         @coq/parsing-maintainers
+/parsing/         @coq/parsing-maintainers
 
 ########## Plugins ##########
 
@@ -170,8 +166,7 @@
 /plugins/ssr/          @coq/ssreflect-maintainers
 /test-suite/ssr/       @coq/ssreflect-maintainers
 
-/plugins/syntax/        @ppedrot
-# Secondary maintainer @maximedenes
+/plugins/syntax/       @coq/parsing-maintainers
 
 /plugins/rtauto/       @PierreCorbineau
 # Secondary maintainer @herbelin
@@ -306,6 +301,8 @@
 
 /vernac/          @mattam82
 # Secondary maintainer @maximedenes
+
+/vernac/metasyntax.*   @coq/parsing-maintainers
 
 ########## Test suite ##########
 


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** meta.

The main change is the new @coq/parsing-maintainers team (for now consisting of Emilio, Hugo and Pierre-Marie). This follows an idea emitted by @ejgallego and this fixes an absence of code owners for some recently added files.