### PR TITLE
Optimise git cloning

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,6 +15,7 @@ variables:
   OPAM_SWITCH: "base"
   # Used to select special compiler switches such as flambda, 32bits, etc...
   OPAM_VARIANT: ""
+  GIT_DEPTH: "1"
 
 docker-boot:
   stage: docker


### PR DESCRIPTION
I'm from GitLab, we noticed some slowdown related to CI processing and Git cloning. While looking over active repos I noticed that we can optimise `git clone` of this repo with the `GIT_DEPTH: "1"`.

Issue for reference: https://gitlab.com/gitlab-com/gl-infra/production/issues/553
