### PR TITLE
Fixes #8910: typo in nameops.ml

### DIFF
--- a/engine/nameops.ml
+++ b/engine/nameops.ml
@@ -69,7 +69,7 @@ let root_of_id id =
    [bar0]  ↦ [bar1]
    [bar00] ↦ [bar01]
    [bar1]  ↦ [bar2]
-   [bar01] ↦ [bar01]
+   [bar01] ↦ [bar02]
    [bar9]  ↦ [bar10]
    [bar09] ↦ [bar10]
    [bar99] ↦ [bar100]


### PR DESCRIPTION
**Kind:** documentation / bug fix

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #8910

Canonical documentation fix (ci skip).