### PR TITLE
Revert "Do not allow spliting in res_pf, this is reserved for pretyping"

### DIFF
--- a/proofs/clenvtac.ml
+++ b/proofs/clenvtac.ml
@@ -72,7 +72,7 @@ let clenv_refine ?(with_evars=false) ?(with_classes=true) clenv =
     if with_classes then
       let evd' =
         Typeclasses.resolve_typeclasses ~filter:Typeclasses.all_evars
-          ~fail:(not with_evars) ~split:false clenv.env clenv.evd
+          ~fail:(not with_evars) clenv.env clenv.evd
       in
       Typeclasses.make_unresolvables (fun x -> List.mem_f Evar.equal x evars) evd'
     else clenv.evd

--- a/test-suite/success/Hints.v
+++ b/test-suite/success/Hints.v
@@ -169,7 +169,7 @@ Proof.
 Hint Cut [_* (a_is_b | b_is_c | c_is_d | d_is_e)
                  (a_compose | b_compose | c_compose | d_compose | e_compose)] : typeclass_instances.
 
-Timeout 1 Fail apply _. (* 0.06s *)
+  Timeout 1 Fail apply _. (* 0.06s *)
 Abort.
 End HintCut.
 


### PR DESCRIPTION
This reverts commit 8d8200d4bff3ffc44efc51ad44dccee9eb14ec6a.

Fix #7936

I had conflicts in proofs/clenvtac.ml please check it is ok