### PR TITLE
[ssr] "case/elim: p" don't resolve TC in "p"

### DIFF
--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -499,6 +499,22 @@ let pf_e_type_of gl t =
   let sigma, ty = Typing.type_of env sigma t in
   re_sig it sigma, ty
 
+let pf_resolve_typeclasses ~where ~fail gl =
+  let sigma, env, it = project gl, pf_env gl, sig_it gl in
+  let filter =
+    let evset = Evarutil.undefined_evars_of_term sigma where in
+    fun k _ -> Evar.Set.mem k evset in
+  let sigma = Typeclasses.resolve_typeclasses ~filter ~fail env sigma in
+  re_sig it sigma
+
+let resolve_typeclasses ~where ~fail env sigma =
+  let filter =
+    let evset = Evarutil.undefined_evars_of_term sigma where in
+    fun k _ -> Evar.Set.mem k evset in
+  let sigma = Typeclasses.resolve_typeclasses ~filter ~fail env sigma in
+  sigma
+
+
 let nf_evar sigma t = 
   EConstr.Unsafe.to_constr (Evarutil.nf_evar sigma (EConstr.of_constr t))
 

--- a/plugins/ssr/ssrcommon.mli
+++ b/plugins/ssr/ssrcommon.mli
@@ -335,6 +335,14 @@ val refine_with :
            ?beta:bool ->
            ?with_evars:bool ->
            evar_map * EConstr.t -> v82tac
+
+val pf_resolve_typeclasses :
+  where:EConstr.t ->
+  fail:bool -> Goal.goal Evd.sigma -> Goal.goal Evd.sigma
+val resolve_typeclasses :
+  where:EConstr.t ->
+  fail:bool -> Environ.env -> Evd.evar_map -> Evd.evar_map
+
 (*********************** Wrapped Coq  tactics *****************************)
 
 val rewritetac : ssrdir -> EConstr.t -> tactic

--- a/plugins/ssr/ssrelim.ml
+++ b/plugins/ssr/ssrelim.ml
@@ -353,6 +353,7 @@ let ssrelim ?(ind=ref None) ?(is_case=false) deps what ?elim eqid elim_intro_tac
   ppdebug(lazy Pp.(str"elim_pred_ty=" ++ pp_term gl pty));
   let gl = pf_unify_HO gl pred elim_pred in
   let elim = fire_subst gl elim in
+  let gl = pf_resolve_typeclasses ~where:elim ~fail:false gl in
   let gl, _ = pf_e_type_of gl elim in
   (* check that the patterns do not contain non instantiated dependent metas *)
   let () = 

--- a/plugins/ssr/ssrequality.ml
+++ b/plugins/ssr/ssrequality.ml
@@ -377,6 +377,10 @@ let is_construct_ref sigma c r =
 let is_ind_ref sigma c r = EConstr.isInd sigma c && GlobRef.equal (IndRef (fst(EConstr.destInd sigma c))) r
 
 let rwcltac cl rdx dir sr gl =
+  let sr =
+    let sigma, r = sr in
+    let sigma = resolve_typeclasses ~where:r ~fail:false (pf_env gl) sigma in
+    sigma, r in
   let n, r_n,_, ucst = pf_abs_evars gl sr in
   let r_n' = pf_abs_cterm gl n r_n in
   let r' = EConstr.Vars.subst_var pattern_id r_n' in

--- a/plugins/ssrmatching/ssrmatching.mli
+++ b/plugins/ssrmatching/ssrmatching.mli
@@ -201,7 +201,7 @@ val assert_done : 'a option ref -> 'a
 
 (** Very low level APIs.
     these are calls to evarconv's [the_conv_x] followed by
-    [solve_unif_constraints_with_heuristics] and [resolve_typeclasses].
+    [solve_unif_constraints_with_heuristics].
     In case of failure they raise [NoMatch] *)
 
 val unify_HO : env -> evar_map -> EConstr.constr -> EConstr.constr -> evar_map

--- a/test-suite/ssr/case_TC.v
+++ b/test-suite/ssr/case_TC.v
@@ -1,0 +1,18 @@
+From Coq Require Import ssreflect.
+From Coq Require Import ssrbool.
+
+Set Printing All.
+Set Debug Ssreflect.
+
+Class Class := { sort : Type ; op : sort -> bool }.
+Coercion sort : Class >-> Sortclass.
+Arguments op [_] _.
+
+Section Section.
+  Context (A B: Class) (a: A).
+
+  Goal op a || ~~ op a.
+    by case: op.
+  Abort.
+
+End Section.

--- a/test-suite/ssr/case_TC2.v
+++ b/test-suite/ssr/case_TC2.v
@@ -1,0 +1,20 @@
+From Coq Require Import Bool ssreflect.
+
+Set Printing All.
+Set Debug Ssreflect.
+
+Class Class := { sort : Type ; op : sort -> bool }.
+Coercion sort : Class >-> Sortclass.
+Arguments op [_] _.
+
+Lemma opP (A: Class) (a: A) : reflect True (op a).
+Proof. Admitted.
+
+Section Section.
+  Context (A B: Class) (a: A).
+
+  Goal is_true (op a).
+    by case: opP.
+  Abort.
+
+End Section.

--- a/test-suite/ssr/case_TC3.v
+++ b/test-suite/ssr/case_TC3.v
@@ -1,0 +1,21 @@
+From Coq Require Import Utf8 Bool ssreflect.
+
+Set Printing All.
+Set Debug Ssreflect.
+
+Class Class sort := { op : sort → bool }.
+Arguments op {_ _}.
+Hint Mode Class !.
+
+Lemma opP A (C: Class A) (a: A) : reflect True (op a).
+Proof. Admitted.
+Arguments op {_ _}.
+
+Section Section.
+  Context A B (CA : Class A) (CB : Class B) (a: A).
+
+  Goal is_true (op a).
+    by case: opP.
+  Abort.
+
+End Section.


### PR DESCRIPTION
This fixes a bug reported by private communication.
It comes with a test case.

The bug was coming from the fact that elim unifies the pattern inferred from the (index in the) type of the inductive being eliminated and the one (optionally) provided by the user. Unifying `_` with `op _ _` was succeeding. Unification was performed via `Ssrmatching.unify_HO` that at some point in time was made to resolve TC too. We make this resolution optional.