### PR TITLE
Fix dune runtest invocation

### DIFF
--- a/Makefile.dune
+++ b/Makefile.dune
@@ -53,7 +53,7 @@ quickopt: voboot
 	dune build $(DUNEOPT) $(QUICKOPT_TARGETS)
 
 test-suite: voboot
-	dune $(DUNEOPT) runtest
+	dune runtest $(DUNEOPT)
 
 release: voboot
 	dune build $(DUNEOPT) -p coq


### PR DESCRIPTION
`dune --display=short runtest` would error with "too many arguments", ie the --display option needs to be after the `runtest` subcommand.