### PR TITLE
Fix -top for univbinders output test.

### DIFF
--- a/test-suite/output/UnivBinders.v
+++ b/test-suite/output/UnivBinders.v
@@ -1,4 +1,5 @@
-(* coq-prog-args: ("-top" "UnivBinders") *)
+(* -*- coq-prog-args: ("-top" "UnivBinders"); -*- *)
+
 Set Universe Polymorphism.
 Set Printing Universes.
 (* Unset Strict Universe Declaration. *)


### PR DESCRIPTION
It was good enough for the makefile but not for emacs.
