### PR TITLE
[dune] [ide] Install data files.

### DIFF
--- a/ide/dune
+++ b/ide/dune
@@ -43,3 +43,14 @@
  (package coqide)
  (modules coqide_main)
  (libraries coqide.gui))
+
+; FIXME: we should install those in share/coqide. We better do this
+; once the make-based system has been phased out.
+(install
+ (section share_root)
+ (package coqide)
+ (files
+  (coq.png as coq/coq.png)
+  (coq_style.xml as coq/coq_style.xml)
+  (coq.lang as coq/coq.lang)
+  (coq-ssreflect.lang as coq/coq-ssreflect.lang)))


### PR DESCRIPTION
We should install the files in `share/coqide` instead of the current
`coq` location; but we defer this change until we are more advanced in
the make-phase out.

Fixes: #8953
