### PR TITLE
[dune] Build `cmxs` files instead of `cmxa` in "quick" target.

### DIFF
--- a/Makefile.dune
+++ b/Makefile.dune
@@ -44,7 +44,7 @@ COQTOP_FILES=ide/idetop.bc ide/coqide_main.bc checker/coqchk.bc
 PLUGIN_FILES=$(wildcard plugins/*/*.mlpack)
 PRINTER_FILES=dev/top_printers.cma dev/checker_printers.cma
 QUICKBYTE_TARGETS=$(COQTOP_FILES) $(PLUGIN_FILES:.mlpack=.cma) $(PRINTER_FILES) topbin/coqtop_byte_bin.bc
-QUICKOPT_TARGETS=$(COQTOP_FILES:.bc=.exe) $(PLUGIN_FILES:.mlpack=.cmxa) $(PRINTER_FILES:.cma=.cmxa) topbin/coqtop_bin.exe
+QUICKOPT_TARGETS=$(COQTOP_FILES:.bc=.exe) $(PLUGIN_FILES:.mlpack=.cmxs) $(PRINTER_FILES:.cma=.cmxa) topbin/coqtop_bin.exe
 
 quickbyte: voboot
 	dune build $(DUNEOPT) $(QUICKBYTE_TARGETS)


### PR DESCRIPTION
This fixes #8954
