### PR TITLE
coq_makefile: Fix ocamldep ignoring mlg files

### DIFF
--- a/test-suite/coq-makefile/camldep/_CoqProject
+++ b/test-suite/coq-makefile/camldep/_CoqProject
@@ -1,0 +1,4 @@
+-Q . Foo
+-I src
+src/file1.mlg
+src/file2.ml

--- a/test-suite/coq-makefile/camldep/run.sh
+++ b/test-suite/coq-makefile/camldep/run.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -e
+export PATH=$COQBIN:$PATH
+export LC_ALL=C
+
+rm -rf _test
+mkdir _test
+cp _CoqProject _test/
+cd _test
+mkdir src
+
+echo '{ let foo = () }' > src/file1.mlg
+echo 'let bar = File1.foo' > src/file2.ml
+coq_makefile -f _CoqProject -o Makefile
+make src/file2.cmx
+[ -f src/file2.cmx ]

--- a/tools/CoqMakefile.in
+++ b/tools/CoqMakefile.in
@@ -719,6 +719,9 @@ endif
 
 redir_if_ok = > "$@" || ( RV=$$?; rm -f "$@"; exit $$RV )
 
+GENMLFILES:=$(MLGFILES:.mlg=.ml) $(ML4FILES:.ml4=.ml)
+$(addsuffix .d,$(ALLSRCFILES)): $(GENMLFILES)
+
 $(addsuffix .d,$(MLIFILES)): %.mli.d: %.mli
 	$(SHOW)'CAMLDEP $<'
 	$(HIDE)$(CAMLDEP) $(OCAMLLIBS) "$<" $(redir_if_ok)


### PR DESCRIPTION
If you have file1.mlg and file2.ml, with file2 depending on file1,
ocamldep will be run before file1.ml exists so won't generate
[file2.cmx: file1.cmx] (ocamldep is silent on non-found dependencies).

This has been causing nondeterministic failures in quickchick
recently.

I guess it didn't come up in the past because ml4 files tend to be at
the end of the dependency chain.