### PR TITLE
Fix #8922 (uncaught pp_diff exception)

### DIFF
--- a/lib/pp_diff.ml
+++ b/lib/pp_diff.ml
@@ -86,7 +86,7 @@ let shorten_diff_span dtype diff_list =
       if (get_variant !src) = dtype then begin
         if (lt !dst !src) then
           dst := !src;
-        while (lt !dst len) && (get_variant !dst) <> `Common do
+        while (lt !dst len) && (get_variant !dst) = dtype do
           dst := !dst + incr;
         done;
         if (lt !dst len) && (get_str !src) = (get_str !dst) then begin

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -674,10 +674,6 @@ let pr_subgoals ?(pr_first=true) ?(diffs=false) ?os_map
     | None -> GoalMap.empty
   in
 
-  let map_goal_for_diff ng = (* todo: move to proof_diffs.ml *)
-    try GoalMap.find ng diff_goal_map  with Not_found -> ng
-  in
-
   (** Printing functions for the extra informations. *)
   let rec print_stack a = function
     | [] -> Pp.int a
@@ -713,7 +709,12 @@ let pr_subgoals ?(pr_first=true) ?(diffs=false) ?os_map
 
   let get_ogs g =
     match os_map with
-    | Some (osigma, _) -> Some { it = map_goal_for_diff g; sigma = osigma }
+    | Some (osigma, _) ->
+      (* if Not_found, returning None treats the goal as new and it will be highlighted;
+         returning Some { it = g; sigma = sigma } will compare the new goal
+         to itself and it won't be highlighted *)
+      (try Some { it = GoalMap.find g diff_goal_map; sigma = osigma }
+      with Not_found -> raise (Pp_diff.Diff_Failure "Unable to match goals between old and new proof states (7)"))
     | None -> None
   in
   let rec pr_rec n = function

--- a/proofs/proof.ml
+++ b/proofs/proof.ml
@@ -491,4 +491,6 @@ let all_goals p =
     let set = add goals Goal.Set.empty in
     let set = List.fold_left (fun s gs -> let (g1, g2) = gs in add g1 (add g2 set)) set stack in
     let set = add shelf set in
-    add given_up set
+    let set = add given_up set in
+    let { Evd.it = bgoals ; sigma = bsigma } = V82.background_subgoals p in
+    add bgoals set

--- a/test-suite/unit-tests/printing/proof_diffs_test.ml
+++ b/test-suite/unit-tests/printing/proof_diffs_test.ml
@@ -71,6 +71,13 @@ let _ = add_test "tokenize_string examples" t
 
 open Pp
 
+(* example that was failing from #8922 *)
+let t () =
+  Proof_diffs.write_diffs_option "removed";
+  ignore (diff_str "X : ?Goal" "X : forall x : ?Goal0, ?Goal1");
+  Proof_diffs.write_diffs_option "on"
+let _ = add_test "shorten_diff_span failure from #8922" t
+
 (* note pp_to_string concatenates adjacent strings, could become one token,
 e.g. str " a" ++ str "b " will give a token "ab" *)
 (* checks background is present and correct *)


### PR DESCRIPTION
Fixed several problems exposed by #8922.  Without the change, diffs will omit some output lines when displaying the proof context, making the diff unacceptably unreliable.  While users can turn off diffs, this fix should go into 8.9.

Get hyps and goal the same way Printer does; don't omit info
Allow for new goals that don't map to old goals
Include background_goals in all_goals return value
Fix incorrect change to raw diffs in shorten_diff_span

**Kind:** bug fix

Fixes #8922
