### PR TITLE
Skip submodules in HoTT CI script.

### DIFF
--- a/dev/ci/ci-hott.sh
+++ b/dev/ci/ci-hott.sh
@@ -5,4 +5,4 @@ ci_dir="$(dirname "$0")"
 
 git_download HoTT
 
-( cd "${CI_BUILD_DIR}/HoTT" && ./autogen.sh && ./configure && make && make validate )
+( cd "${CI_BUILD_DIR}/HoTT" && ./autogen.sh -skip-submodules && ./configure && make && make validate )


### PR DESCRIPTION
Avoid downloading Coq.