### PR TITLE
We improve a little bit in printing universe constraints signature mismatch

### DIFF
--- a/kernel/univ.ml
+++ b/kernel/univ.ml
@@ -570,9 +570,9 @@ struct
   include S
 
   let pr prl c =
-    fold (fun (u1,op,u2) pp_std ->
-      pp_std ++ prl u1 ++ pr_constraint_type op ++
-	prl u2 ++ fnl () )  c (str "")
+    v 0 (prlist_with_sep spc (fun (u1,op,u2) ->
+      hov 0 (prl u1 ++ pr_constraint_type op ++ prl u2))
+       (elements c))
 
 end
 

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -895,7 +895,7 @@ let explain_not_match_error = function
       str "compared to " ++ spc () ++
       quote (Printer.safe_pr_lconstr_env env (Evd.from_env env) t2)
   | IncompatibleConstraints cst ->
-    str " the expected (polymorphic) constraints do not imply " ++
+    str "the expected (polymorphic) constraints do not imply " ++
       let cst = Univ.UContext.constraints (Univ.AUContext.repr cst) in
       (** FIXME: provide a proper naming for the bound variables *)
       quote (Univ.pr_constraints (Termops.pr_evd_level Evd.empty) cst)


### PR DESCRIPTION
**Kind:** bug fix

We use a vertical box rather than newlines to ensure that the box is aligned even if it is not displayed at the first character of the line. We use a `prlist_with_sep` so that there are breaking points only inbetween the elements and none at the end of the list.

For instance, this gives:

```coq
Module Type T.
  Polymorphic Parameter X@{i j k l} : Type@{i} -> Type@{j} -> Type@{k} * Type@{l}.
End T.

Module M : T.
  Polymorphic Definition X@{i j k l} := fun x : Type@{i} => fun y : Type@{j} => (x : Type@{k}, y : Type@{l}).
End M.
(*
Error: Signature components for label X do not match:
the expected (polymorphic) constraints do not imply 
"Var(2) < Coq.Init.Datatypes.23
 Var(3) < Coq.Init.Datatypes.24
 Var(0) <= Var(2)
 Var(1) <= Var(3)".
*)
```
I did not know how to use the internal names rather than the `Var` though.

There are plenty of possible variations, please ask if you have other suggestions for improvement.