### PR TITLE
Declare initial hint databases in prelude

### DIFF
--- a/dev/ci/user-overlays/08984-vbgl-rm-hardwired-hint-db.sh
+++ b/dev/ci/user-overlays/08984-vbgl-rm-hardwired-hint-db.sh
@@ -1,0 +1,12 @@
+if [ "$CI_PULL_REQUEST" = "8984" ] || [ "$CI_BRANCH" = "rm-hardwired-hint-db" ]; then
+
+    HoTT_CI_REF=rm-hardwired-hint-db
+    HoTT_CI_GITURL=https://github.com/vbgl/HoTT
+
+    ltac2_CI_REF=rm-hardwired-hint-db
+    ltac2_CI_GITURL=https://github.com/vbgl/ltac2
+
+    UniMath_CI_REF=rm-hardwired-hint-db
+    UniMath_CI_GITURL=https://github.com/vbgl/UniMath
+
+fi

--- a/plugins/ltac/g_class.mlg
+++ b/plugins/ltac/g_class.mlg
@@ -84,7 +84,7 @@ TACTIC EXTEND typeclasses_eauto
  | [ "typeclasses" "eauto" int_or_var_opt(d) "with" ne_preident_list(l) ] ->
     { typeclasses_eauto ~depth:d l }
  | [ "typeclasses" "eauto" int_or_var_opt(d) ] -> {
-     typeclasses_eauto ~only_classes:true ~depth:d [Hints.typeclasses_db] }
+     typeclasses_eauto ~only_classes:true ~depth:d [Class_tactics.typeclasses_db] }
 END
 
 TACTIC EXTEND head_of_constr

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -265,8 +265,8 @@ let apply_inference_hook hook env sigma frozen = match frozen with
 
 let apply_heuristics env sigma fail_evar =
   (* Resolve eagerly, potentially making wrong choices *)
-  try solve_unif_constraints_with_heuristics
-        ~flags:(default_flags_of (Typeclasses.classes_transparent_state ())) env sigma
+  let flags = default_flags_of (Typeclasses.classes_transparent_state ()) in
+  try solve_unif_constraints_with_heuristics ~flags env sigma
   with e when CErrors.noncritical e ->
     let e = CErrors.push e in
     if fail_evar then iraise e else sigma

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -33,7 +33,8 @@ open Hints
 
 module NamedDecl = Context.Named.Declaration
 
-(** Hint database named "typeclass_instances", now created directly in Auto *)
+(** Hint database named "typeclass_instances", created in prelude *)
+let typeclasses_db = "typeclass_instances"
 
 (** Options handling *)
 

--- a/tactics/class_tactics.mli
+++ b/tactics/class_tactics.mli
@@ -13,6 +13,8 @@
 open Names
 open EConstr
 
+val typeclasses_db : string
+
 val catchable : exn -> bool
 
 val set_typeclasses_debug : bool -> unit

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -738,16 +738,7 @@ module Hintdbmap = String.Map
 
 type hint_db = Hint_db.t
 
-(** Initially created hint databases, for typeclasses and rewrite *)
-let typeclasses_db = "typeclass_instances"
-let rewrite_db = "rewrite"
-
-let auto_init_db =
-  Hintdbmap.add typeclasses_db (Hint_db.empty TransparentState.full true)
-    (Hintdbmap.add rewrite_db (Hint_db.empty TransparentState.cst_full true)
-       Hintdbmap.empty)
-
-let searchtable = Summary.ref ~name:"searchtable" auto_init_db
+let searchtable = Summary.ref ~name:"searchtable" Hintdbmap.empty
 let statustable = Summary.ref ~name:"statustable" KNmap.empty
 
 let searchtable_map name =

--- a/tactics/hints.mli
+++ b/tactics/hints.mli
@@ -277,11 +277,6 @@ val make_local_hint_db : env -> evar_map -> ?ts:TransparentState.t -> bool -> de
 
 val make_db_list : hint_db_name list -> hint_db list
 
-(** Initially created hint databases, for typeclasses and rewrite *)
-
-val typeclasses_db : hint_db_name
-val rewrite_db : hint_db_name
-
 val wrap_hint_warning : 'a Proofview.tactic -> 'a Proofview.tactic
 (** Use around toplevel calls to hint-using tactics, to enable the tracking of
     non-imported hints. Any tactic calling [run_hint] must be wrapped this

--- a/test-suite/bugs/closed/bug_4527.v
+++ b/test-suite/bugs/closed/bug_4527.v
@@ -10,6 +10,7 @@ Inductive False := .
 Axiom proof_admitted : False.
 Tactic Notation "admit" := case proof_admitted.
 Require Coq.Init.Datatypes.
+Require Import Coq.Init.Tactics.
 
 Import Coq.Init.Notations.
 

--- a/theories/Init/Tactics.v
+++ b/theories/Init/Tactics.v
@@ -332,3 +332,7 @@ Tactic Notation "assert_succeeds" tactic3(tac) :=
   assert_succeeds tac.
 Tactic Notation "assert_fails" tactic3(tac) :=
   assert_fails tac.
+
+Create HintDb rewrite discriminated.
+Hint Variables Opaque : rewrite.
+Create HintDb typeclass_instances discriminated.


### PR DESCRIPTION
Previously, they were hard-wired in the ML code.

This is a preliminary step towards making database names qualified.