### PR TITLE
Don't redeclare constraints of fields in Include

### DIFF
--- a/test-suite/misc/quick-include.sh
+++ b/test-suite/misc/quick-include.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+
+$coqc -R misc/quick-include/ QuickInclude -quick misc/quick-include/file1.v
+$coqc -R misc/quick-include/ QuickInclude -quick misc/quick-include/file2.v

--- a/test-suite/misc/quick-include/file1.v
+++ b/test-suite/misc/quick-include/file1.v
@@ -1,0 +1,18 @@
+
+Module Type E. End E.
+
+Module M.
+  Lemma x : True.
+  Proof. trivial. Qed.
+End M.
+
+
+Module Type T.
+  Lemma x : True.
+  Proof. trivial. Qed.
+End T.
+
+Module F(A:E).
+  Lemma x : True.
+  Proof. trivial. Qed.
+End F.

--- a/test-suite/misc/quick-include/file2.v
+++ b/test-suite/misc/quick-include/file2.v
@@ -1,0 +1,6 @@
+
+From QuickInclude Require file1.
+
+Module M. Include file1.M. End M.
+Module T. Include file1.T. End T.
+Module F. Include file1.F. End F.


### PR DESCRIPTION
This avoids forcing foreign opaques when including a module type or functor into a regular module.