### PR TITLE
Fix #8937: inductive conversion in coqchk subtyping

### DIFF
--- a/test-suite/coqchk/bug_8937.v
+++ b/test-suite/coqchk/bug_8937.v
@@ -1,0 +1,21 @@
+(* -*- coq-prog-args: ("-noinit"); -*- *)
+
+Unset Elimination Schemes.
+Module Type S.
+
+Inductive foo : Prop :=.
+Definition bar (x:foo) : Prop := match x with end.
+
+End S.
+
+Module M.
+
+Inductive foo : Prop :=.
+Definition bar (x:foo) : Prop := match x with end.
+
+End M.
+
+Module MS : S := M.
+
+Module F (Z:S) := Z.
+Module MS' : S := F M.


### PR DESCRIPTION
As far as I can tell this is similar to what coqtop does. Delta
resolvers are complicated so I may be mistaken.

The important part is to avoid losing the modified delta resolver
returned by strengthen_and_subst in check_mexpr.
