### PR TITLE
[pfedit] Remove `start_proof` stub from `Pfedit`

### DIFF
--- a/proofs/pfedit.mli
+++ b/proofs/pfedit.mli
@@ -16,19 +16,6 @@ open Environ
 open Decl_kinds
 
 (** {6 ... } *)
-(** [start_proof s str env t hook tac] starts a proof of name [s] and
-    conclusion [t]; [hook] is optionally a function to be applied at
-    proof end (e.g. to declare the built constructions as a coercion
-    or a setoid morphism); init_tac is possibly a tactic to
-    systematically apply at initialization time (e.g. to start the
-    proof of mutually dependent theorems) *)
-
-val start_proof :
-  Id.t -> ?pl:UState.universe_decl -> goal_kind -> Evd.evar_map -> named_context_val -> EConstr.constr ->
-  ?init_tac:unit Proofview.tactic ->
-  Proof_global.proof_terminator -> unit
-
-(** {6 ... } *)
 (** [get_goal_context n] returns the context of the [n]th subgoal of
    the current focused proof or raises a [UserError] if there is no
    focused proof or if there is no more subgoals *)

--- a/proofs/proof_global.mli
+++ b/proofs/proof_global.mli
@@ -60,14 +60,14 @@ type closed_proof = proof_object * proof_terminator
 val make_terminator : (proof_ending -> unit) -> proof_terminator
 val apply_terminator : proof_terminator -> proof_ending -> unit
 
-(** [start_proof id str pl goals terminator] starts a proof of name [id]
-    with goals [goals] (a list of pairs of environment and
-    conclusion); [str] describes what kind of theorem/definition this
-    is (spiwack: for potential printing, I believe is used only by
-    closing commands and the xml plugin); [terminator] is used at the
-    end of the proof to close the proof. The proof is started in the
-    evar map [sigma] (which can typically contain universe
-    constraints), and with universe bindings pl. *)
+(** [start_proof id str pl goals terminator] starts a proof of name
+   [id] with goals [goals] (a list of pairs of environment and
+   conclusion); [str] describes what kind of theorem/definition this
+   is; [terminator] is used at the end of the proof to close the proof
+   (e.g. to declare the built constructions as a coercion or a setoid
+   morphism). The proof is started in the evar map [sigma] (which can
+   typically contain universe constraints), and with universe bindings
+   pl. *)
 val start_proof :
   Evd.evar_map -> Names.Id.t -> ?pl:UState.universe_decl ->
   Decl_kinds.goal_kind -> (Environ.env * EConstr.types) list  ->

--- a/vernac/lemmas.mli
+++ b/vernac/lemmas.mli
@@ -18,13 +18,13 @@ val call_hook : Future.fix_exn -> declaration_hook -> Decl_kinds.locality -> Glo
 val start_proof : Id.t -> ?pl:UState.universe_decl -> goal_kind -> Evd.evar_map ->
   ?terminator:(Proof_global.lemma_possible_guards -> declaration_hook -> Proof_global.proof_terminator) ->
   ?sign:Environ.named_context_val -> EConstr.types ->
-  ?init_tac:unit Proofview.tactic -> ?compute_guard:Proof_global.lemma_possible_guards ->
+  ?compute_guard:Proof_global.lemma_possible_guards ->
   declaration_hook -> unit
 
 val start_proof_univs : Id.t -> ?pl:UState.universe_decl -> goal_kind -> Evd.evar_map ->
   ?terminator:(Proof_global.lemma_possible_guards -> (UState.t option -> declaration_hook) -> Proof_global.proof_terminator) ->
   ?sign:Environ.named_context_val -> EConstr.types ->
-  ?init_tac:unit Proofview.tactic -> ?compute_guard:Proof_global.lemma_possible_guards ->
+  ?compute_guard:Proof_global.lemma_possible_guards ->
   (UState.t option -> declaration_hook) -> unit
 
 val start_proof_com :


### PR DESCRIPTION
This way we only have 2 `start_proof` entries, in `Lemmas` and
`Proof_global`; which they should be unified / brought closer in the
future.
