### PR TITLE
Controlling typing flags

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -55,6 +55,9 @@ Vernacular commands
 - Binders for an `Instance` now act more like binders for a `Theorem`.
   Names may not be repeated, and may not overlap with section variable names.
 
+- New commands and attributes to enable/disable guard checking, positivity checking
+  and universes checking (providing a local `-type-in-type`).
+
 Tools
 
 - The `-native-compiler` flag of `coqc` and `coqtop` now takes an argument which can have three values:

--- a/checker/values.ml
+++ b/checker/values.ml
@@ -229,7 +229,7 @@ let v_cst_def =
     [|[|Opt Int|]; [|v_cstr_subst|]; [|v_lazy_constr|]|]
 
 let v_typing_flags =
-  v_tuple "typing_flags" [|v_bool; v_bool; v_oracle; v_bool; v_bool; v_bool|]
+  v_tuple "typing_flags" [|v_bool; v_bool; v_bool; v_oracle; v_bool; v_bool; v_bool|]
 
 let v_const_univs = v_sum "constant_universes" 0 [|[|v_context_set|]; [|v_abs_context|]|]
 

--- a/doc/sphinx/language/gallina-specification-language.rst
+++ b/doc/sphinx/language/gallina-specification-language.rst
@@ -776,7 +776,7 @@ Simple inductive types
 
       The types of the constructors have to satisfy a *positivity condition*
       (see Section :ref:`positivity`). This condition ensures the soundness of
-      the inductive definition. The positivity checking can be disable using
+      the inductive definition. The positivity checking can be disabled using
       the command :cmd:`Unset Positivity Checking` or the attribute
       ``assume_positive`` (see :ref:`gallina-attributes`).
 

--- a/doc/sphinx/language/gallina-specification-language.rst
+++ b/doc/sphinx/language/gallina-specification-language.rst
@@ -776,7 +776,9 @@ Simple inductive types
 
       The types of the constructors have to satisfy a *positivity condition*
       (see Section :ref:`positivity`). This condition ensures the soundness of
-      the inductive definition.
+      the inductive definition. The positivity checking can be disable using
+      the command :cmd:`Unset Positivity Checking` or the attribute
+      ``assume_positive`` (see :ref:`gallina-attributes`).
 
    .. exn:: The conclusion of @type is not valid; it must be built from @ident.
 
@@ -1500,7 +1502,7 @@ the following attributes names are recognized:
     (see :ref:`programs`).
 
 ``global``, ``local``
-    Take no value, analogous to the ``Global`` and ``Local`` flags
+    Takes no value, analogous to the ``Global`` and ``Local`` flags
     (see :ref:`controlling-locality-of-commands`).
 
 ``deprecated``
@@ -1532,6 +1534,29 @@ the following attributes names are recognized:
         Proof.
           now foo.
         Abort.
+
+``check_guarded``, ``assume_guarded``
+    Takes no value. Enable/disable the guard checking of fixpoints during a
+    definition (see also :ref:`controlling-typing-flags`). Works with
+    :cmd:`Definition`, :cmd:`Fixpoint`, :cmd:`CoFixpoint`, :cmd:`Theorem`
+    (and its variants).
+
+``check_positive``, ``assume_positive``
+    Takes no value. Enable/disable the positivity checking for the declaration
+    of an inductive type or the productivity checking for a coinductive type
+    (see also :ref:`controlling-typing-flags`).
+
+``check_universes``, ``type_in_type``
+    Takes no value. Enable/disable the checking of universes during a definition
+    or the declaration of a (co)inductive type.
+    (see also :ref:`controlling-typing-flags`).
+
+.. example::
+
+   .. coqtop:: all reset
+
+        #[assume_guarded] Fixpoint f (n : nat) : False
+          := f n.
 
 .. [1]
    This is similar to the expression “*entry* :math:`\{` sep *entry*

--- a/doc/sphinx/proof-engine/vernacular-commands.rst
+++ b/doc/sphinx/proof-engine/vernacular-commands.rst
@@ -1202,6 +1202,66 @@ scope of their effect. There are four kinds of commands:
   occurs in a section.  The :cmd:`Set` and :cmd:`Unset` commands belong to this
   category.
 
+
+.. _controlling-typing-flags:
+
+Controlling Typing Flags
+----------------------------
+
+.. cmd:: Set Guard Checking
+.. cmd:: Unset Guard Checking
+
+   Enable/Disable the guard checking of fixpoints. Warning: this can break the
+   consistency of the system, use at your own risk. Decreasing argument can
+   still be specified but the decrease is not checked anymore. Unchecked
+   fixpoint are printed by :cmd:`Print Assumptions`.
+
+.. cmd:: Set Positivity Checking
+.. cmd:: Unset Positivity Checking
+
+   Enable/Disable the positivity checking of inductive types and the productivity
+   checking of coinductive types. Warning: this can break the consistency of the
+   system, use at your own risk. Unchecked (co)inductive types are printed by
+   :cmd:`Print Assumptions`.
+
+.. cmd:: Set Universes Checking
+.. cmd:: Unset Universes Checking
+
+   Enable/Disable the checking of universes, providing a form of "type in type".
+   Warning: this breaks the consistency of the system, use at your own risk.
+   Constants relying on "type in type" are printed by :cmd:`Print Assumptions`.
+
+.. cmd:: Print Typing Flags
+
+   Print the status of the three typing flags: check of guard, check of positivity
+   and check of universes.
+
+.. example::
+
+   .. coqtop:: all reset
+
+        Unset Guard Checking.
+
+        Print Typing Flags.
+
+        Fixpoint f (n : nat) : False
+          := f n.
+
+        Fixpoint ackermann (m n : nat) {struct m} : nat :=
+          match m with
+          | 0 => S n
+          | S m =>
+            match n with
+            | 0 => ackermann m 1
+            | S n => ackermann m (ackermann (S m) n)
+            end
+          end.
+
+        Print Assumptions ackermann.
+
+   Note that the proper way to define the Ackermann function is to use
+   well-founded recursion (see :cmd:`Program Fixpoint`).
+
 .. _exposing-constants-to-ocaml-libraries:
 
 Exposing constants to OCaml libraries

--- a/kernel/declarations.ml
+++ b/kernel/declarations.ml
@@ -63,6 +63,8 @@ type constant_universes =
 type typing_flags = {
   check_guarded : bool; (** If [false] then fixed points and co-fixed
                             points are assumed to be total. *)
+  check_positive : bool; (** If [false] then inductive types are assumed positive
+                               and co-inductive types are assumed productive. *)
   check_universes : bool; (** If [false] universe constraints are not checked *)
   conv_oracle : Conv_oracle.oracle; (** Unfolding strategies for conversion *)
   share_reduction : bool; (** Use by-need reduction algorithm *)

--- a/kernel/declareops.ml
+++ b/kernel/declareops.ml
@@ -19,6 +19,7 @@ module RelDecl = Context.Rel.Declaration
 
 let safe_flags oracle = {
   check_guarded = true;
+  check_positive = true;
   check_universes = true;
   conv_oracle = oracle;
   share_reduction = true;

--- a/kernel/environ.ml
+++ b/kernel/environ.ml
@@ -233,6 +233,13 @@ let set_oracle env o =
 let engagement env = env.env_stratification.env_engagement
 let typing_flags env = env.env_typing_flags
 
+let update_check_guarded flags opt =
+  Option.cata (fun b -> {flags with check_guarded = b}) flags opt
+let update_check_positive flags opt =
+  Option.cata (fun b -> {flags with check_positive = b}) flags opt
+let update_check_universes flags opt =
+  Option.cata (fun b -> {flags with check_universes = b}) flags opt
+
 let is_impredicative_set env = 
   match engagement env with
   | ImpredicativeSet -> true

--- a/kernel/environ.mli
+++ b/kernel/environ.mli
@@ -93,6 +93,9 @@ val set_opaque_tables : env -> Opaqueproof.opaquetab -> env
 
 val engagement    : env -> engagement
 val typing_flags    : env -> typing_flags
+val update_check_guarded : typing_flags -> bool option -> typing_flags
+val update_check_positive : typing_flags -> bool option -> typing_flags
+val update_check_universes : typing_flags -> bool option -> typing_flags
 val is_impredicative_set : env -> bool
 val type_in_type : env -> bool
 val deactivated_guard : env -> bool

--- a/kernel/indtypes.ml
+++ b/kernel/indtypes.ml
@@ -973,7 +973,7 @@ let check_inductive env kn mie =
   (* First type-check the inductive definition *)
   let (env_ar, env_ar_par, paramsctxt, inds) = typecheck_inductive env mie in
   (* Then check positivity conditions *)
-  let chkpos = (Environ.typing_flags env).check_guarded in
+  let chkpos = (Environ.typing_flags env).check_positive in
   let (nmr,recargs) = check_positivity ~chkpos kn env_ar_par paramsctxt mie.mind_entry_finite inds in
   (* Build the inductive packets *)
     build_inductive env mie.mind_entry_private mie.mind_entry_universes

--- a/library/global.ml
+++ b/library/global.ml
@@ -90,6 +90,16 @@ let push_context_set b c = globalize0 (Safe_typing.push_context_set b c)
 let set_engagement c = globalize0 (Safe_typing.set_engagement c)
 let set_typing_flags c = globalize0 (Safe_typing.set_typing_flags c)
 let typing_flags () = Environ.typing_flags (env ())
+let update_check_guarded = function
+  | Some b -> set_typing_flags {(typing_flags ()) with Declarations.check_guarded = b}
+  | None -> ()
+let update_check_positive = function
+  | Some b -> set_typing_flags {(typing_flags ()) with Declarations.check_positive = b}
+  | None -> ()
+let update_check_universes = function
+  | Some b -> set_typing_flags {(typing_flags ()) with Declarations.check_universes = b}
+  | None -> ()
+
 let export_private_constants ~in_section cd = globalize (Safe_typing.export_private_constants ~in_section cd)
 let add_constant ~in_section id d = globalize (Safe_typing.add_constant ~in_section (i2l id) d)
 let add_mind id mie = globalize (Safe_typing.add_mind (i2l id) mie)

--- a/library/global.mli
+++ b/library/global.mli
@@ -32,6 +32,11 @@ val set_engagement : Declarations.engagement -> unit
 val set_typing_flags : Declarations.typing_flags -> unit
 val typing_flags : unit -> Declarations.typing_flags
 
+(** Changing some typing flags (does nothing if None) *)
+val update_check_guarded : bool option -> unit
+val update_check_positive : bool option -> unit
+val update_check_universes : bool option -> unit
+
 (** Variables, Local definitions, constants, inductive types *)
 
 val push_named_assum : (Id.t * Constr.types * bool) Univ.in_universe_context_set -> unit

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -995,3 +995,8 @@ let print_and_diff oldp newp =
         pr_open_subgoals ~proof
     in
     Feedback.msg_notice output;;
+
+let pr_typing_flags flags =
+  str "check_guarded: " ++ bool flags.check_guarded ++ fnl ()
+  ++ str "check_positive: " ++ bool flags.check_positive ++ fnl ()
+  ++ str "check_universes: " ++ bool flags.check_universes

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -911,9 +911,9 @@ let pr_assumptionset env sigma s =
       | Constant kn ->
           safe_pr_constant env kn ++ safe_pr_ltype env sigma typ
       | Positive m ->
-          hov 2 (safe_pr_inductive env m ++ spc () ++ strbrk"is positive.")
+          hov 2 (safe_pr_inductive env m ++ spc () ++ strbrk"is assumed to be positive.")
       | Guarded kn ->
-          hov 2 (safe_pr_constant env kn ++ spc () ++ strbrk"is positive.")
+          hov 2 (safe_pr_constant env kn ++ spc () ++ strbrk"is assumed to be guarded.")
     in
     let fold t typ accu =
       let (v, a, o, tr) = accu in

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -838,6 +838,7 @@ type axiom =
   | Constant of Constant.t (* An axiom or a constant. *)
   | Positive of MutInd.t (* A mutually inductive definition which has been assumed positive. *)
   | Guarded of Constant.t (* a constant whose (co)fixpoints have been assumed to be guarded *)
+  | TypeInType of Constant.t (* a which relies on type in type *)
 
 type context_object =
   | Variable of Id.t (* A section variable or a Let definition *)
@@ -914,6 +915,8 @@ let pr_assumptionset env sigma s =
           hov 2 (safe_pr_inductive env m ++ spc () ++ strbrk"is assumed to be positive.")
       | Guarded kn ->
           hov 2 (safe_pr_constant env kn ++ spc () ++ strbrk"is assumed to be guarded.")
+      | TypeInType kn ->
+         hov 2 (safe_pr_constant env kn ++ spc () ++ strbrk"relies on an unsafe hierarchy.")
     in
     let fold t typ accu =
       let (v, a, o, tr) = accu in

--- a/printing/printer.mli
+++ b/printing/printer.mli
@@ -193,6 +193,7 @@ type axiom =
   | Constant of Constant.t (* An axiom or a constant. *)
   | Positive of MutInd.t (* A mutually inductive definition which has been assumed positive. *)
   | Guarded of Constant.t (* a constant whose (co)fixpoints have been assumed to be guarded *)
+  | TypeInType of Constant.t (* a which relies on type in type *)
 
 type context_object =
   | Variable of Id.t (* A section variable or a Let definition *)

--- a/printing/printer.mli
+++ b/printing/printer.mli
@@ -208,3 +208,4 @@ val pr_assumptionset : env -> evar_map -> types ContextObjectMap.t -> Pp.t
 
 val pr_goal_by_id : proof:Proof.t -> Id.t -> Pp.t
 
+val pr_typing_flags : Declarations.typing_flags -> Pp.t

--- a/test-suite/success/typing_flags.v
+++ b/test-suite/success/typing_flags.v
@@ -37,6 +37,9 @@ Fail #[check_guarded] Definition e := fix e (n : nat) : nat := e n.
 Definition e := fix e (n : nat) : nat := e n.
 Set Guard Checking.
 
+#[assumed_positive] Inductive T :=
+y : (T -> T) -> T.
+
 Unset Positivity Checking.
 Inductive Cor :=
 | Over : Cor

--- a/test-suite/success/typing_flags.v
+++ b/test-suite/success/typing_flags.v
@@ -1,0 +1,79 @@
+
+(* Print Typing Flags. *)
+#[type_in_type, assume_guarded] Fixpoint f' (n : nat) : nat := f' n.
+
+#[assume_guarded, local] Fixpoint f (n : nat) : nat.
+Proof.
+  exact (f n).
+(* Print Typing Flags. *)
+Defined.
+
+(* Print Typing Flags. *)
+
+Unset Universes Checking.
+
+(* Print Tables. *)
+(* Test Universes Checking. *)
+
+Definition T := Type.
+Fixpoint g (n : nat) : T := T.
+
+(* Print Typing Flags. *)
+Set Universes Checking.
+
+#[type_in_type] Fixpoint g1 (n : nat) : T.
+Proof.
+  (* Print Typing Flags. *)
+  exact T.
+Defined.
+Set Universes Checking.
+
+Fail Definition g2 (n : nat) : T := T.
+#[type_in_type] Definition g2 (n : nat) : T := T.
+(* Print Typing Flags. *)
+
+Unset Guard Checking.
+Fail #[check_guarded] Definition e := fix e (n : nat) : nat := e n.
+Definition e := fix e (n : nat) : nat := e n.
+Set Guard Checking.
+
+Unset Positivity Checking.
+Inductive Cor :=
+| Over : Cor
+| Next : ((Cor -> list nat) -> list nat) -> Cor.
+Set Positivity Checking.
+(* Print Typing Flags. *)
+(* Print Assumptions Cor. *)
+
+
+
+#[check_universes, assume_guarded] Definition e2 : nat -> nat.
+Proof.
+  exact (fix e (n : nat) : nat := e n).
+Defined.
+(* Print Typing Flags. *)
+Section b.
+  Unset Universes Checking.
+  Variable T : let t := Type in (t : t).
+  Definition T' := T.
+  (* Print Assumptions T'. *)
+  (* Print Typing Flags. *)
+End b.
+(* Print Typing Flags. *)
+Set Universes Checking.
+(* Print Assumptions T'. *)
+
+(* Unset Universes Checking. *)
+#[type_in_type] Inductive T4  := a : let t := Type in (t : t) -> T4.
+Module b.
+  Unset Guard Checking.
+  Global Unset Universes Checking.
+  (* Disable Type In Type. *)
+  Definition T := let t := Type in (t : t).
+  (* Print Typing Flags. *)
+End b.
+(* Print Typing Flags. *)
+Import b.
+(* Print Typing Flags. *)
+(* About T. *)
+(* Print Assumptions T. *)

--- a/vernac/assumptions.ml
+++ b/vernac/assumptions.ml
@@ -326,7 +326,7 @@ let assumptions ?(add_opaque=false) ?(add_transparent=false) st gr t =
       accu
   | IndRef (m,_) | ConstructRef ((m,_),_) ->
       let mind = lookup_mind m in
-      if mind.mind_typing_flags.check_guarded then
+      if mind.mind_typing_flags.check_positive then
         accu
       else
         let l = try GlobRef.Map_env.find obj ax2ty with Not_found -> [] in

--- a/vernac/assumptions.ml
+++ b/vernac/assumptions.ml
@@ -312,7 +312,13 @@ let assumptions ?(add_opaque=false) ?(add_transparent=false) st gr t =
           let l = try GlobRef.Map_env.find obj ax2ty with Not_found -> [] in
           ContextObjectMap.add (Axiom (Guarded kn, l)) Constr.mkProp accu
       in
-    if not (Declareops.constant_has_body cb) || not cb.const_typing_flags.check_universes then
+      let accu =
+        if cb.const_typing_flags.check_universes then accu
+        else
+          let l = try GlobRef.Map_env.find obj ax2ty with Not_found -> [] in
+          ContextObjectMap.add (Axiom (TypeInType kn, l)) Constr.mkProp accu
+      in
+    if not (Declareops.constant_has_body cb) then
       let t = type_of_constant cb in
       let l = try GlobRef.Map_env.find obj ax2ty with Not_found -> [] in
       ContextObjectMap.add (Axiom (Constant kn,l)) t accu

--- a/vernac/attributes.ml
+++ b/vernac/attributes.ml
@@ -73,6 +73,9 @@ let mk_deprecation ?(since=None) ?(note=None) () =
 
 type t = {
   locality : bool option;
+  (* check_guard : bool option; *)
+  (* check_positivity : bool option; *)
+  (* check_universes : bool option; *)
   polymorphic : bool;
   template : bool option;
   program : bool;
@@ -133,6 +136,12 @@ let program = program_opt >>= function
   | None -> return (Flags.is_program_mode())
 
 let locality = bool_attribute ~name:"Locality" ~on:"local" ~off:"global"
+
+let check_guard = bool_attribute ~name:"Check Guard" ~on:"check_guarded" ~off:"assume_guarded"
+
+let check_positivity = bool_attribute ~name:"Check Positivity" ~on:"check_positive" ~off:"assume_positive"
+
+let check_universes = bool_attribute ~name:"Check Universes" ~on:"check_universes" ~off:"type_in_type"
 
 let warn_unqualified_univ_attr =
   CWarnings.create ~name:"unqualified-univ-attr" ~category:"deprecated"
@@ -205,6 +214,10 @@ let attributes_of_flags f =
     parse (locality ++ deprecation ++ universe_poly_template ++ program) f
   in
   { polymorphic; program; locality; template; deprecated }
+  (* let (((((locality, check_guard), check_positivity), check_universes), deprecated), (polymorphic, template)), program = *)
+  (*   parse (locality ++ check_guard ++ check_positivity ++ check_universes ++ deprecation ++ universe_poly_template ++ program) f *)
+  (* in *)
+  (* { locality; check_guard; check_positivity; check_universes; deprecated; polymorphic; template; program } *)
 
 let only_locality atts = parse locality atts
 

--- a/vernac/attributes.mli
+++ b/vernac/attributes.mli
@@ -45,6 +45,9 @@ val polymorphic : bool attribute
 val program : bool attribute
 val universe_poly_template : (bool * bool option) attribute
 val locality : bool option attribute
+val check_guard : bool option attribute
+val check_positivity : bool option attribute
+val check_universes : bool option attribute
 val deprecation : deprecation option attribute
 
 val program_opt : bool option attribute
@@ -52,6 +55,9 @@ val program_opt : bool option attribute
 
 type t = {
   locality : bool option;
+  (* check_guard : bool option; (\* None -> use global env typing flags ; Some -> override *\) *)
+  (* check_positivity : bool option; (\* None -> use global env typing flags ; Some -> override *\) *)
+  (* check_universes : bool option; (\* None -> use global env typing flags ; Some -> override *\) *)
   polymorphic : bool;
   template : bool option;
   program : bool;

--- a/vernac/comFixpoint.mli
+++ b/vernac/comFixpoint.mli
@@ -19,12 +19,10 @@ open Vernacexpr
 (** Entry points for the vernacular commands Fixpoint and CoFixpoint *)
 
 val do_fixpoint :
-  (* When [false], assume guarded. *)
-  locality -> polymorphic -> (fixpoint_expr * decl_notation list) list -> unit
+  ?check_guard:bool -> ?check_universes:bool -> locality -> polymorphic -> (fixpoint_expr * decl_notation list) list -> unit
 
 val do_cofixpoint :
-  (* When [false], assume guarded. *)
-  locality -> polymorphic -> (cofixpoint_expr * decl_notation list) list -> unit
+  ?check_guard:bool -> ?check_universes:bool -> locality -> polymorphic -> (cofixpoint_expr * decl_notation list) list -> unit
 
 (************************************************************************)
 (** Internal API  *)
@@ -80,12 +78,13 @@ val interp_fixpoint :
 (** Registering fixpoints and cofixpoints in the environment *)
 (** [Not used so far] *)
 val declare_fixpoint :
-  locality -> polymorphic ->
+  Declarations.typing_flags -> locality -> polymorphic ->
   recursive_preentry * UState.universe_decl * UState.t *
   (Constr.rel_context * Impargs.manual_implicits * int option) list ->
   Proof_global.lemma_possible_guards -> decl_notation list -> unit
 
-val declare_cofixpoint : locality -> polymorphic ->
+val declare_cofixpoint :
+  Declarations.typing_flags -> locality -> polymorphic ->
   recursive_preentry * UState.universe_decl * UState.t *
   (Constr.rel_context * Impargs.manual_implicits * int option) list ->
   decl_notation list -> unit

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -572,4 +572,4 @@ let do_mutual_inductive ~template udecl indl cum poly prv ~uniform finite =
   (* Declare the coercions *)
   List.iter (fun qid -> Class.try_add_new_coercion (Nametab.locate qid) ~local:false poly) coes;
   (* If positivity is assumed declares itself as unsafe. *)
-  if Environ.deactivated_guard (Global.env ()) then Feedback.feedback Feedback.AddedAxiom else ()
+  if not (typing_flags (Global.env ())).Declarations.check_positive then Feedback.feedback Feedback.AddedAxiom else ()

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -979,6 +979,7 @@ GRAMMAR EXTEND Gram
       | IDENT "Coercion"; IDENT "Paths"; s = class_rawexpr; t = class_rawexpr
          -> { PrintCoercionPaths (s,t) }
       | IDENT "Canonical"; IDENT "Projections" -> { PrintCanonicalConversions }
+      | IDENT "Typing"; IDENT "Flags" -> { PrintTypingFlags }
       | IDENT "Tables" -> { PrintTables }
       | IDENT "Options" -> { PrintTables (* A Synonymous to Tables *) }
       | IDENT "Hint" -> { PrintHintGoal }

--- a/vernac/indschemes.ml
+++ b/vernac/indschemes.ml
@@ -542,7 +542,7 @@ let declare_default_schemes kn =
   let mib = Global.lookup_mind kn in
   let n = Array.length mib.mind_packets in
   if !elim_flag && (mib.mind_finite <> Declarations.BiFinite || !bifinite_elim_flag)
-     && mib.mind_typing_flags.check_guarded then
+     && mib.mind_typing_flags.check_positive then
     declare_induction_schemes kn;
   if !case_flag then map_inductive_block declare_one_case_analysis_scheme kn n;
   if is_eq_flag() then try_declare_beq_scheme kn;

--- a/vernac/lemmas.ml
+++ b/vernac/lemmas.ml
@@ -36,6 +36,8 @@ module NamedDecl = Context.Named.Declaration
 
 type declaration_hook = Decl_kinds.locality -> GlobRef.t -> unit
 let mk_hook hook = hook
+let compose_hook h1 h2 =
+  fun l r -> h1 l r; h2 l r
 let call_hook fix_exn hook l c =
   try hook l c
   with e when CErrors.noncritical e ->

--- a/vernac/lemmas.mli
+++ b/vernac/lemmas.mli
@@ -13,6 +13,9 @@ open Decl_kinds
 
 type declaration_hook
 val mk_hook : (Decl_kinds.locality -> GlobRef.t -> unit) -> declaration_hook
+
+(** [compose_hook h1 h2] is [h1; h2]*)
+val compose_hook : declaration_hook -> declaration_hook -> declaration_hook
 val call_hook : Future.fix_exn -> declaration_hook -> Decl_kinds.locality -> GlobRef.t -> unit
 
 val start_proof : Id.t -> ?pl:UState.universe_decl -> goal_kind -> Evd.evar_map ->

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -482,6 +482,8 @@ open Pputils
       ++ pr_class_rawexpr t
     | PrintCanonicalConversions ->
       keyword "Print Canonical Structures"
+    | PrintTypingFlags ->
+      keyword "Print Typing Flags"
     | PrintTables ->
       keyword "Print Tables"
     | PrintHintGoal ->

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1625,6 +1625,30 @@ let _ =
       optread  = Nativenorm.get_profiling_enabled;
       optwrite = Nativenorm.set_profiling_enabled }
 
+let _ =
+  declare_bool_option
+    { optdepr  = false;
+      optname  = "guard checking";
+      optkey   = ["Guard"; "Checking"];
+      optread  = (fun () -> (Global.typing_flags ()).Declarations.check_guarded);
+      optwrite = (fun b -> Global.update_check_guarded (Some b)) }
+
+let _ =
+  declare_bool_option
+    { optdepr  = false;
+      optname  = "positivity/productivity checking";
+      optkey   = ["Positivity"; "Checking"];
+      optread  = (fun () -> (Global.typing_flags ()).Declarations.check_positive);
+      optwrite = (fun b -> Global.update_check_positive (Some b)) }
+
+let _ =
+  declare_bool_option
+    { optdepr  = false;
+      optname  = "universes checking";
+      optkey   = ["Universes"; "Checking"];
+      optread  = (fun () -> (Global.typing_flags ()).Declarations.check_universes);
+      optwrite = (fun b -> Global.update_check_universes (Some b)) }
+
 let vernac_set_strategy ~local l =
   let local = Option.default false local in
   let glob_ref r =

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1802,6 +1802,7 @@ let print_about_hyp_globs ?loc ref_or_by_not udecl glopt =
 
 let vernac_print ~atts env sigma =
   function
+  | PrintTypingFlags -> pr_typing_flags (Environ.typing_flags (Global.env ()))
   | PrintTables -> print_tables ()
   | PrintFullContext-> print_full_context_typ env sigma
   | PrintSectionContext qid -> print_sec_context_typ env sigma qid

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -24,6 +24,7 @@ type goal_reference =
   | GoalId of Id.t
 
 type printable =
+  | PrintTypingFlags
   | PrintTables
   | PrintFullContext
   | PrintSectionContext of qualid


### PR DESCRIPTION
This PR allows to locally (with attributes) / globally (with Set/Unset commands) enable and disable:
  - the guard checking
  - the positivity checking
  - the check of universes (providing "type in type")

For this, the `check_guarded` typing flag is split  into `check_guarded` and `check_positive`.

For the moment the syntax of commands is: `Set Guard Checking`, `Unset Guard Checking`, `Set/Unset Positivity Checking`, `Set/Unset Universes Checking`.
And for attributes: `check_guarded`, `assume_guarded`, `check_positive`, `assume_positive`, `check_universes`, `type_in_type`.

This PR also adds a `Print Typing Flags` command which prints the status of those three flags, and improves a bit the output of `Print Assumptions`.

E.g.
```
#[type_in_type] Definition T := let t := Type in (t : t).

Unset Guard Checking.
Fixpoint e (n : nat) : nat := e n.

Print Typing Flags.
```

<!-- Keep what applies -->
**Kind:** feature

<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [x] Added / updated test-suite
<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [x] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [x] Entry added in CHANGES.md.

Any comment welcome.