### PR TITLE
Do not Export the init modules

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -93,6 +93,10 @@ Standard Library
 
 - Added `ByteVector` type that can convert to and from [string].
 
+- The prelude used to be automatically Exported and is now only
+  Imported. This should be relevant only when importing files which
+  don't use -noinit into files which do.
+
 Changes from 8.8.2 to 8.9+beta1
 ===============================
 

--- a/test-suite/success/Require.v
+++ b/test-suite/success/Require.v
@@ -1,3 +1,8 @@
+(* -*- coq-prog-args: ("-noinit"); -*- *)
+
 Require Import Coq.Arith.Plus.
 Require Coq.Arith.Minus.
 Locate Library Coq.Arith.Minus.
+
+(* Check that Init didn't get exported by the import above *)
+Fail Check nat.

--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -107,7 +107,7 @@ let load_init_vernaculars cur_feeder opts ~state =
 (* Startup LoadPath and Modules                                               *)
 (******************************************************************************)
 (* prelude_data == From Coq Require Export Prelude. *)
-let prelude_data = "Prelude", Some "Coq", Some true
+let prelude_data = "Prelude", Some "Coq", Some false
 
 let require_libs opts =
   if opts.load_init then prelude_data :: opts.vo_requires else opts.vo_requires


### PR DESCRIPTION
It seems we started doing the export silently in
47804492bd09c8b13b5aac45800d067dbdf04d00.

I think it's surprising and undesired behaviour so changing it back.