### PR TITLE
[meta] Update CODEOWNERS for @parsing-maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -132,8 +132,14 @@
 
 ########## Parser ##########
 
-/parsing/         @herbelin
+/parsing/         @parsing-maintainers
 # Secondary maintainer @mattam82
+
+/gramlib/         @parsing-maintainers
+# Secondary maintainer @nobody
+
+/vernac/metasyntax.* @parsing-maintainers
+# Secondary maintainer @mattam82 @maximedenes
 
 ########## Plugins ##########
 


### PR DESCRIPTION
`parsing` and `gramlib` are clear; metasyntax could be split up so
the parsing parts would live in parsing and the `Notation` command
parts would live in `vernac`.

For now it seems more appropriate to have it owned by @coq/parsing-maintainers.