### PR TITLE
CI: Run Mtac2 tests.

### DIFF
--- a/dev/ci/ci-mtac2.sh
+++ b/dev/ci/ci-mtac2.sh
@@ -9,4 +9,4 @@ git_download unicoq
 
 git_download mtac2
 
-( cd "${CI_BUILD_DIR}/mtac2" && coq_makefile -f _CoqProject -o Makefile && make )
+( cd "${CI_BUILD_DIR}/mtac2" && coq_makefile -f _CoqProject -o Makefile && make && make test )


### PR DESCRIPTION
`make` does not run tests in Mtac2. That requires `make test`.

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** infrastructure.
