### PR TITLE
gitlab: Install stdlib doc in build:base

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -82,7 +82,7 @@ after_script:
     - echo 'end:coq:build'
 
     - echo 'start:coq.install'
-    - make install
+    - make install install-byte $EXTRA_INSTALL
     - make install-byte
     - cp bin/fake_ide _install_ci/bin/
     - echo 'end:coq.install'
@@ -196,6 +196,7 @@ build:base:
     COQ_EXTRA_CONF: "-native-compiler yes -coqide opt"
     # coqdoc for stdlib, until we know how to build it from installed Coq
     EXTRA_TARGET: "stdlib"
+    EXTRA_INSTALL: "install-doc-stdlib-html install-doc-printable"
 
 # no coqide for 32bit: libgtk installation problems
 build:base+32bit:

--- a/dev/ci/README.md
+++ b/dev/ci/README.md
@@ -179,7 +179,7 @@ Currently available artifacts are:
   + Coq's Reference Manual [master branch]
     https://gitlab.com/coq/coq/-/jobs/artifacts/master/file/_install_ci/share/doc/coq/sphinx/html/index.html?job=doc:refman
   + Coq's Standard Library Documentation [master branch]
-    https://gitlab.com/coq/coq/-/jobs/artifacts/master/file/_install_ci/share/doc/coq/html/stdlib/index.html?job=doc:refman
+    https://gitlab.com/coq/coq/-/jobs/artifacts/master/file/_install_ci/share/doc/coq/html/stdlib/index.html?job=build:base
   + Coq's ML API Documentation [master branch]
     https://gitlab.com/coq/coq/-/jobs/artifacts/master/file/_build/default/_doc/_html/index.html?job=doc:ml-api:odoc
 


### PR DESCRIPTION
Looks like we forgot to adapt this when we split off the sphinx job
and stopped using -with-doc yes.