### PR TITLE
[dune] Only build printers when the ltac plugin is available.

### DIFF
--- a/dev/dune
+++ b/dev/dune
@@ -4,6 +4,7 @@
  (synopsis "Coq's Debug Printers")
  (wrapped false)
  (modules :standard)
+ (optional)
  (libraries coq.toplevel coq.plugins.ltac))
 
 (rule


### PR DESCRIPTION
This fixes a problem reported by @Zimmi48 in #8948, IMHO we should be
able to have a clean build of core Coq.
