### PR TITLE
[proof] [abstract] Pass evar_map to functions for constant building.

### DIFF
--- a/proofs/pfedit.ml
+++ b/proofs/pfedit.ml
@@ -130,11 +130,10 @@ open Decl_kinds
 
 let next = let n = ref 0 in fun () -> incr n; !n
 
-let build_constant_by_tactic id ctx sign ?(goal_kind = Global, false, Proof Theorem) typ tac =
-  let evd = Evd.from_ctx ctx in
+let build_constant_by_tactic id sigma sign ?(goal_kind = Global, false, Proof Theorem) typ tac =
   let terminator = Proof_global.make_terminator (fun _ -> ()) in
   let goals = [ (Global.env_of_context sign , typ) ] in
-  Proof_global.start_proof evd id goal_kind goals terminator;
+  Proof_global.start_proof sigma id goal_kind goals terminator;
   try
     let status = by tac in
     let open Proof_global in

--- a/proofs/pfedit.mli
+++ b/proofs/pfedit.mli
@@ -72,13 +72,13 @@ val instantiate_nth_evar_com : int -> Constrexpr.constr_expr -> unit
     tactic. *)
 
 val build_constant_by_tactic :
-  Id.t -> UState.t -> named_context_val -> ?goal_kind:goal_kind ->
-  EConstr.types -> unit Proofview.tactic -> 
+  Id.t -> Evd.evar_map -> named_context_val -> ?goal_kind:goal_kind ->
+  EConstr.types -> unit Proofview.tactic ->
   Safe_typing.private_constants Entries.definition_entry * bool *
     UState.t
 
-val build_by_tactic : ?side_eff:bool -> env -> UState.t -> ?poly:polymorphic ->
-  EConstr.types -> unit Proofview.tactic -> 
+val build_by_tactic : ?side_eff:bool -> env -> Evd.evar_map -> ?poly:polymorphic ->
+  EConstr.types -> unit Proofview.tactic ->
   constr * bool * UState.t
 
 val refine_by_tactic : env -> Evd.evar_map -> EConstr.types -> unit Proofview.tactic ->

--- a/tactics/abstract.ml
+++ b/tactics/abstract.ml
@@ -27,17 +27,17 @@ module NamedDecl = Context.Named.Declaration
 (** d1 is the section variable in the global context, d2 in the goal context *)
 let interpretable_as_section_decl env evd d1 d2 =
   let open Context.Named.Declaration in
-  let e_eq_constr_univs sigma c1 c2 = match eq_constr_universes env !sigma c1 c2 with
+  let i_eq_constr_univs sigma c1 c2 = match eq_constr_universes env sigma c1 c2 with
   | None -> false
   | Some cstr ->
-    try ignore (Evd.add_universe_constraints !sigma cstr); true
+    try ignore (Evd.add_universe_constraints sigma cstr); true
     with UState.UniversesDiffer -> false
   in
   match d2, d1 with
   | LocalDef _, LocalAssum _ -> false
   | LocalDef (_,b1,t1), LocalDef (_,b2,t2) ->
-    e_eq_constr_univs evd b1 b2 && e_eq_constr_univs evd t1 t2
-  | LocalAssum (_,t1), d2 -> e_eq_constr_univs evd t1 (NamedDecl.get_type d2)
+    i_eq_constr_univs evd b1 b2 && i_eq_constr_univs evd t1 t2
+  | LocalAssum (_,t1), d2 -> i_eq_constr_univs evd t1 (NamedDecl.get_type d2)
 
 let rec decompose len c t accu =
   let open Constr in
@@ -96,13 +96,12 @@ let cache_term_by_tactic_then ~opaque ?(goal_type=None) id gk tac tacK =
   let sigma = Proofview.Goal.sigma gl in
   let current_sign = Global.named_context_val ()
   and global_sign = Proofview.Goal.hyps gl in
-  let evdref = ref sigma in
   let sign,secsign =
     List.fold_right
       (fun d (s1,s2) ->
         let id = NamedDecl.get_id d in
         if mem_named_context_val id current_sign &&
-          interpretable_as_section_decl env evdref (lookup_named_val id current_sign) d
+          interpretable_as_section_decl env sigma (lookup_named_val id current_sign) d
         then (s1,push_named_context_val d s2)
         else (Context.Named.add d s1,s2))
       global_sign (Context.Named.empty, Environ.empty_named_context_val) in
@@ -112,21 +111,20 @@ let cache_term_by_tactic_then ~opaque ?(goal_type=None) id gk tac tacK =
               | Some ty -> ty in
   let concl = it_mkNamedProd_or_LetIn concl sign in
   let concl =
-    try flush_and_check_evars !evdref concl
+    try flush_and_check_evars sigma concl
     with Uninstantiated_evar _ ->
       CErrors.user_err Pp.(str "\"abstract\" cannot handle existentials.") in
 
-  let evd, ctx, concl =
+  let sigma, ctx, concl =
     (* FIXME: should be done only if the tactic succeeds *)
-    let evd = Evd.minimize_universes !evdref in
+    let evd = Evd.minimize_universes sigma in
     let ctx = Evd.universe_context_set evd in
       evd, ctx, Evarutil.nf_evars_universes evd concl
   in
   let concl = EConstr.of_constr concl in
   let solve_tac = tclCOMPLETE (tclTHEN (tclDO (List.length sign) Tactics.intro) tac) in
-  let ectx = Evd.evar_universe_context evd in
   let (const, safe, ectx) =
-    try Pfedit.build_constant_by_tactic ~goal_kind:gk id ectx secsign concl solve_tac
+    try Pfedit.build_constant_by_tactic ~goal_kind:gk id sigma secsign concl solve_tac
     with Logic_monad.TacticFailure e as src ->
     (* if the tactic [tac] fails, it reports a [TacticFailure e],
        which is an error irrelevant to the proof system (in fact it
@@ -157,7 +155,7 @@ let cache_term_by_tactic_then ~opaque ?(goal_type=None) id gk tac tacK =
     EInstance.make (Univ.UContext.instance ctx)
   in
   let lem = mkConstU (cst, inst) in
-  let evd = Evd.set_universe_context evd ectx in
+  let sigma = Evd.set_universe_context sigma ectx in
   let open Safe_typing in
   let eff = private_con_of_con (Global.safe_env ()) cst in
   let effs = concat_private eff
@@ -167,7 +165,7 @@ let cache_term_by_tactic_then ~opaque ?(goal_type=None) id gk tac tacK =
     tacK lem args
   in
   let tac = if not safe then Proofview.mark_as_unsafe <*> solve else solve in
-  Proofview.tclTHEN (Proofview.Unsafe.tclEVARS evd) tac
+  Proofview.tclTHEN (Proofview.Unsafe.tclEVARS sigma) tac
   end
 
 let abstract_subproof ~opaque id gk tac =

--- a/vernac/auto_ind_decl.ml
+++ b/vernac/auto_ind_decl.ml
@@ -681,10 +681,10 @@ let make_bl_scheme mode mind =
   let lnonparrec,lnamesparrec = (* TODO subst *)
     context_chop (nparams-nparrec) mib.mind_params_ctxt in
   let bl_goal, eff = compute_bl_goal ind lnamesparrec nparrec in
-  let ctx = UState.make (Global.universes ()) in
   let side_eff = side_effect_of_mode mode in
   let bl_goal = EConstr.of_constr bl_goal in
-  let (ans, _, ctx) = Pfedit.build_by_tactic ~side_eff (Global.env()) ctx bl_goal
+  let env, sigma = (let e = Global.env () in e, Evd.from_env e) in
+  let (ans, _, ctx) = Pfedit.build_by_tactic ~side_eff env sigma bl_goal
     (compute_bl_tact mode (!bl_scheme_kind_aux()) (ind, EConstr.EInstance.empty) lnamesparrec nparrec)
   in
   ([|ans|], ctx), eff
@@ -805,10 +805,10 @@ let make_lb_scheme mode mind =
   let lnonparrec,lnamesparrec =
     context_chop (nparams-nparrec) mib.mind_params_ctxt in
   let lb_goal, eff = compute_lb_goal ind lnamesparrec nparrec in
-  let ctx = UState.make (Global.universes ()) in
   let side_eff = side_effect_of_mode mode in
   let lb_goal = EConstr.of_constr lb_goal in
-  let (ans, _, ctx) = Pfedit.build_by_tactic ~side_eff (Global.env()) ctx lb_goal
+  let env, sigma = (let e = Global.env () in e, Evd.from_env e) in
+  let (ans, _, ctx) = Pfedit.build_by_tactic ~side_eff env sigma lb_goal
     (compute_lb_tact mode (!lb_scheme_kind_aux()) ind lnamesparrec nparrec)
   in
   ([|ans|], ctx), eff
@@ -975,11 +975,11 @@ let make_eq_decidability mode mind =
   let nparams = mib.mind_nparams in
   let nparrec = mib.mind_nparams_rec in
   let u = Univ.Instance.empty in
-  let ctx = UState.make (Global.universes ()) in
   let lnonparrec,lnamesparrec =
     context_chop (nparams-nparrec) mib.mind_params_ctxt in
   let side_eff = side_effect_of_mode mode in
-  let (ans, _, ctx) = Pfedit.build_by_tactic ~side_eff (Global.env()) ctx
+  let env, sigma = (let e = Global.env () in e, Evd.from_env e) in
+  let (ans, _, ctx) = Pfedit.build_by_tactic ~side_eff env sigma
     (EConstr.of_constr (compute_dec_goal (ind,u) lnamesparrec nparrec))
     (compute_dec_tact ind lnamesparrec nparrec)
   in

--- a/vernac/obligations.ml
+++ b/vernac/obligations.ml
@@ -1018,7 +1018,7 @@ and solve_obligation_by_tac prg obls i tac =
         let evd = Evd.from_ctx prg.prg_ctx in
         let evd = Evd.update_sigma_env evd (Global.env ()) in
         match solve_by_tac ?loc:(fst obl.obl_location) obl.obl_name (evar_of_obligation obl) tac
-                (pi2 prg.prg_kind) (Evd.evar_universe_context evd) with
+                (pi2 prg.prg_kind) evd with
         | None -> None
         | Some (t, ty, ctx) ->
           let uctx = UState.const_univ_entry ~poly:(pi2 prg.prg_kind) ctx in

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -489,7 +489,7 @@ let start_proof_and_print k l hook =
                   Evarutil.is_ground_term sigma concl)
           then raise Exit;
           let c, _, ctx =
-            Pfedit.build_by_tactic env (Evd.evar_universe_context sigma) concl tac
+            Pfedit.build_by_tactic env sigma concl tac
           in Evd.set_universe_context sigma ctx, EConstr.of_constr c
         with Logic_monad.TacticFailure e when Logic.catchable_exception e ->
           user_err Pp.(str "The statement obligations could not be resolved \


### PR DESCRIPTION
This improves #9037, however it is not clear if we want to do this as
it would allow proof bodies to potentially depend on evars from
outside; anyways such proof bodies should be properly grounded before
abstraction so this could work.
