### PR TITLE
[Windows CI] Do not build any addon if WINDOWS is not enabled_all_addons.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -229,7 +229,6 @@ windows64:
   <<: *windows-template
   variables:
     ARCH: "64"
-  allow_failure: true
 
 windows32:
   <<: *windows-template
@@ -237,7 +236,6 @@ windows32:
     ARCH: "32"
   except:
     - /^pr-.*$/
-  allow_failure: true
 
 pkg:opam:
   stage: test

--- a/dev/build/windows/makecoq_mingw.sh
+++ b/dev/build/windows/makecoq_mingw.sh
@@ -1905,6 +1905,9 @@ function make_addon_quickchick {
 function make_addons {
   # Note: ':' is the empty command, which does not produce any output
   : > "/build/filelists/addon_dependencies.nsh"
+  : > "/build/filelists/addon_strings.nsh"
+  : > "/build/filelists/addon_descriptions.nsh"
+  : > "/build/filelists/addon_sections.nsh"
 
   for addon in $COQ_ADDONS; do
     "make_addon_$addon"

--- a/dev/ci/gitlab.bat
+++ b/dev/ci/gitlab.bat
@@ -39,6 +39,10 @@ SET PATH=%PATH%;C:\Program Files\7-Zip\;C:\Program Files\Microsoft SDKs\Windows\
 
 IF "%WINDOWS%" == "enabled_all_addons" (
   SET EXTRA_ADDONS=^
+    -addon=bignums ^
+    -addon=equations ^
+    -addon=ltac2 ^
+    -addon=mtac2 ^
     -addon=mathcomp ^
     -addon=menhir ^
     -addon=menhirlib ^
@@ -56,10 +60,6 @@ IF "%WINDOWS%" == "enabled_all_addons" (
 call %CI_PROJECT_DIR%\dev\build\windows\MakeCoq_MinGW.bat -threads=1 ^
   -arch=%ARCH% -installer=Y -coqver=%CI_PROJECT_DIR_CFMT% ^
   -destcyg=%CYGROOT% -destcoq=%DESTCOQ% -cygcache=%CYGCACHE% ^
-  -addon=bignums ^
-  -addon=equations ^
-  -addon=ltac2 ^
-  -addon=mtac2 ^
   %EXTRA_ADDONS% ^
   -make=N ^
   -setup %CI_PROJECT_DIR%\%SETUP% || GOTO ErrorCopyLogFilesAndExit


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** infrastructure.


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #9040.