### PR TITLE
Fix vernac classification of `Fail Instance`

### DIFF
--- a/stm/vernac_classifier.ml
+++ b/stm/vernac_classifier.ml
@@ -214,6 +214,6 @@ let classify_vernac e =
         | VtQed _, _ ->
             VtProofStep { parallel = `No; proof_block_detection = None },
             VtNow
-        | (VtStartProof _ | VtUnknown), _ -> VtUnknown, VtNow)
+        | (VtStartProof _ | VtUnknown), _ -> VtQuery, VtLater)
   in
   static_control_classifier e


### PR DESCRIPTION
AFAIK `Fail Instance` cannot open a goal, so this is probably a mistake by me when I wrote the `vernac_control` code.