### PR TITLE
Camlp5 safe API strikes back

### DIFF
--- a/coqpp/coqpp_main.ml
+++ b/coqpp/coqpp_main.ml
@@ -139,7 +139,7 @@ let print_local fmt ext =
   match locals with
   | [] -> ()
   | e :: locals ->
-    let mk_e fmt e = fprintf fmt "%s.Entry.create \"%s\"" ext.gramext_name e in
+    let mk_e fmt e = fprintf fmt "Pcoq.Entry.create \"%s\"" e in
     let () = fprintf fmt "@[<hv 2>let %s =@ @[%a@]@]@ " e mk_e e in
     let iter e = fprintf fmt "@[<hv 2>and %s =@ @[%a@]@]@ " e mk_e e in
     let () = List.iter iter locals in
@@ -277,16 +277,16 @@ let print_rule fmt r =
   let pr_prd fmt prd = print_list fmt print_prod prd in
   fprintf fmt "@[(%a,@ %a,@ %a)@]" pr_lvl r.grule_label pr_asc r.grule_assoc pr_prd (List.rev r.grule_prods)
 
-let print_entry fmt gram e =
+let print_entry fmt e =
   let print_position_opt fmt pos = print_opt fmt print_position pos in
   let print_rules fmt rules = print_list fmt print_rule rules in
-  fprintf fmt "let () =@ @[%s.gram_extend@ %s@ @[(%a, %a)@]@]@ in@ "
-    gram e.gentry_name print_position_opt e.gentry_pos print_rules e.gentry_rules
+  fprintf fmt "let () =@ @[Pcoq.grammar_extend@ %s@ None@ @[(%a, %a)@]@]@ in@ "
+    e.gentry_name print_position_opt e.gentry_pos print_rules e.gentry_rules
 
 let print_ast fmt ext =
   let () = fprintf fmt "let _ = @[" in
   let () = fprintf fmt "@[<v>%a@]" print_local ext in
-  let () = List.iter (fun e -> print_entry fmt ext.gramext_name e) ext.gramext_entries in
+  let () = List.iter (fun e -> print_entry fmt e) ext.gramext_entries in
   let () = fprintf fmt "()@]@\n" in
   ()
 

--- a/dev/ci/user-overlays/09051-ppedrot-camlp5-safe-api-strikes-back.sh
+++ b/dev/ci/user-overlays/09051-ppedrot-camlp5-safe-api-strikes-back.sh
@@ -1,0 +1,9 @@
+if [ "$CI_PULL_REQUEST" = "9051" ] || [ "$CI_BRANCH" = "camlp5-safe-api-strikes-back" ]; then
+
+    equations_CI_REF=camlp5-safe-api-strikes-back
+    equations_CI_GITURL=https://github.com/ppedrot/Coq-Equations
+
+    ltac2_CI_REF=camlp5-safe-api-strikes-back
+    ltac2_CI_GITURL=https://github.com/ppedrot/ltac2
+
+fi

--- a/gramlib/gramext.ml
+++ b/gramlib/gramext.ml
@@ -149,8 +149,6 @@ let srules rl =
   in
   Stree t
 
-external action : 'a -> g_action = "%identity"
-
 let is_level_labelled n lev =
   match lev.lname with
     Some n1 -> n = n1

--- a/gramlib/gramext.mli
+++ b/gramlib/gramext.mli
@@ -59,7 +59,6 @@ val levels_of_rules :
       list ->
     'te g_level list
 val srules : ('te g_symbol list * g_action) list -> 'te g_symbol
-external action : 'a -> g_action = "%identity"
 val eq_symbol : 'a g_symbol -> 'a g_symbol -> bool
 
 val delete_rule_in_level_list :

--- a/gramlib/grammar.mli
+++ b/gramlib/grammar.mli
@@ -35,7 +35,6 @@ module type S =
         val of_parser : string -> (te Stream.t -> 'a) -> 'a e
         val parse_token_stream : 'a e -> te Stream.t -> 'a
         val print : Format.formatter -> 'a e -> unit
-        external obj : 'a e -> te Gramext.g_entry = "%identity"
       end
     type ('self, 'a) ty_symbol
     type ('self, 'f, 'r) ty_rule
@@ -66,18 +65,11 @@ module type S =
         val gram_reinit : te Plexing.lexer -> unit
         val clear_entry : 'a Entry.e -> unit
       end
-    val extend :
-      'a Entry.e -> Gramext.position option ->
-        (string option * Gramext.g_assoc option *
-           (te Gramext.g_symbol list * Gramext.g_action) list)
-          list ->
-        unit
     val safe_extend :
       'a Entry.e -> Gramext.position option ->
         (string option * Gramext.g_assoc option * 'a ty_production list)
           list ->
         unit
-    val delete_rule : 'a Entry.e -> te Gramext.g_symbol list -> unit
     val safe_delete_rule : 'a Entry.e -> ('a, 'f, 'r) ty_rule -> unit
   end
    (** Signature type of the functor [Grammar.GMake]. The types and

--- a/parsing/g_constr.mlg
+++ b/parsing/g_constr.mlg
@@ -81,7 +81,7 @@ let err () = raise Stream.Failure
 (* Hack to parse "(x:=t)" as an explicit argument without conflicts with the *)
 (* admissible notation "(x t)" *)
 let lpar_id_coloneq =
-  Gram.Entry.of_parser "test_lpar_id_coloneq"
+  Pcoq.Entry.of_parser "test_lpar_id_coloneq"
     (fun strm ->
       match stream_nth 0 strm with
         | KEYWORD "(" ->
@@ -96,7 +96,7 @@ let lpar_id_coloneq =
         | _ -> err ())
 
 let impl_ident_head =
-  Gram.Entry.of_parser "impl_ident_head"
+  Pcoq.Entry.of_parser "impl_ident_head"
     (fun strm ->
       match stream_nth 0 strm with
 	| KEYWORD "{" ->
@@ -109,7 +109,7 @@ let impl_ident_head =
 	| _ -> err ())
 
 let name_colon =
-  Gram.Entry.of_parser "name_colon"
+  Pcoq.Entry.of_parser "name_colon"
     (fun strm ->
       match stream_nth 0 strm with
 	| IDENT s ->

--- a/parsing/g_prim.mlg
+++ b/parsing/g_prim.mlg
@@ -13,7 +13,6 @@
 open Names
 open Libnames
 
-open Pcoq
 open Pcoq.Prim
 
 let prim_kw = ["{"; "}"; "["; "]"; "("; ")"; "'"]

--- a/parsing/pcoq.mli
+++ b/parsing/pcoq.mli
@@ -17,17 +17,6 @@ open Gramlib
 
 (** The parser of Coq *)
 
-(** DO NOT USE EXTENSION FUNCTIONS IN THIS MODULE.
-    We only have it here to work with Camlp5. Handwritten grammar extensions
-    should use the safe [Pcoq.grammar_extend] function below. *)
-module Gram : sig
-
-  include Grammar.S with type te = Tok.t
-
-  val gram_extend : 'a Entry.e -> 'a Extend.extend_statement -> unit
-
-end with type 'a Entry.e = 'a Grammar.GMake(CLexer).Entry.e
-
 module Parsable :
 sig
   type t
@@ -41,6 +30,9 @@ module Entry : sig
   val create : string -> 'a t
   val parse : 'a t -> Parsable.t -> 'a
   val print : Format.formatter -> 'a t -> unit
+  val of_parser : string -> (Tok.t Stream.t -> 'a) -> 'a t
+  val parse_token_stream : 'a t -> Tok.t Stream.t -> 'a
+  val name : 'a t -> string
 end
 
 (** The parser of Coq is built from three kinds of rule declarations:

--- a/plugins/funind/g_indfun.mlg
+++ b/plugins/funind/g_indfun.mlg
@@ -145,7 +145,6 @@ END
 
 {
 
-module Gram = Pcoq.Gram
 module Vernac = Pvernac.Vernac_
 module Tactic = Pltac
 

--- a/plugins/ltac/extraargs.mlg
+++ b/plugins/ltac/extraargs.mlg
@@ -332,7 +332,7 @@ END
 
 let local_test_lpar_id_colon =
   let err () = raise Stream.Failure in
-  Pcoq.Gram.Entry.of_parser "lpar_id_colon"
+  Pcoq.Entry.of_parser "lpar_id_colon"
     (fun strm ->
       match Util.stream_nth 0 strm with
         | Tok.KEYWORD "(" ->

--- a/plugins/ltac/g_ltac.mlg
+++ b/plugins/ltac/g_ltac.mlg
@@ -70,7 +70,7 @@ let _ =
 
 (* Hack to parse "[ id" without dropping [ *)
 let test_bracket_ident =
-  Gram.Entry.of_parser "test_bracket_ident"
+  Pcoq.Entry.of_parser "test_bracket_ident"
     (fun strm ->
       match stream_nth 0 strm with
         | KEYWORD "[" ->

--- a/plugins/ltac/g_obligations.mlg
+++ b/plugins/ltac/g_obligations.mlg
@@ -45,7 +45,6 @@ let with_tac f tac =
  * Subtac. These entries are named Subtac.<foo>
  *)
 
-module Gram = Pcoq.Gram
 module Tactic = Pltac
 
 open Pcoq

--- a/plugins/ltac/g_rewrite.mlg
+++ b/plugins/ltac/g_rewrite.mlg
@@ -226,8 +226,6 @@ let () =
   let raw_printer _ _ _ l = Pp.pr_non_empty_arg Ppconstr.pr_binders l in
   Pptactic.declare_extra_vernac_genarg_pprule wit_binders raw_printer
 
-open Pcoq
-
 }
 
 GRAMMAR EXTEND Gram

--- a/plugins/ltac/g_tactic.mlg
+++ b/plugins/ltac/g_tactic.mlg
@@ -39,7 +39,7 @@ let err () = raise Stream.Failure
 (* Hack to parse "(x:=t)" as an explicit argument without conflicts with the *)
 (* admissible notation "(x t)" *)
 let test_lpar_id_coloneq =
-  Gram.Entry.of_parser "lpar_id_coloneq"
+  Pcoq.Entry.of_parser "lpar_id_coloneq"
     (fun strm ->
       match stream_nth 0 strm with
         | KEYWORD "(" ->
@@ -53,7 +53,7 @@ let test_lpar_id_coloneq =
 
 (* Hack to recognize "(x)" *)
 let test_lpar_id_rpar =
-  Gram.Entry.of_parser "lpar_id_coloneq"
+  Pcoq.Entry.of_parser "lpar_id_coloneq"
     (fun strm ->
       match stream_nth 0 strm with
         | KEYWORD "(" ->
@@ -67,7 +67,7 @@ let test_lpar_id_rpar =
 
 (* idem for (x:=t) and (1:=t) *)
 let test_lpar_idnum_coloneq =
-  Gram.Entry.of_parser "test_lpar_idnum_coloneq"
+  Pcoq.Entry.of_parser "test_lpar_idnum_coloneq"
     (fun strm ->
       match stream_nth 0 strm with
         | KEYWORD "(" ->
@@ -84,7 +84,7 @@ open Extraargs
 
 (* idem for (x1..xn:t) [n^2 complexity but exceptional use] *)
 let check_for_coloneq =
-  Gram.Entry.of_parser "lpar_id_colon"
+  Pcoq.Entry.of_parser "lpar_id_colon"
     (fun strm ->
       let rec skip_to_rpar p n =
 	match List.last (Stream.npeek n strm) with
@@ -108,7 +108,7 @@ let check_for_coloneq =
       | _ -> err ())
 
 let lookup_at_as_comma =
-  Gram.Entry.of_parser "lookup_at_as_comma"
+  Pcoq.Entry.of_parser "lookup_at_as_comma"
     (fun strm ->
       match stream_nth 0 strm with
 	| KEYWORD (","|"at"|"as") -> ()

--- a/plugins/ssr/ssrparser.mlg
+++ b/plugins/ssr/ssrparser.mlg
@@ -268,16 +268,16 @@ let negate_parser f x =
   | Some _ -> raise Stream.Failure 
 
 let test_not_ssrslashnum =
-  Pcoq.Gram.Entry.of_parser
+  Pcoq.Entry.of_parser
     "test_not_ssrslashnum" (negate_parser test_ssrslashnum10)
 let test_ssrslashnum00 =
-  Pcoq.Gram.Entry.of_parser "test_ssrslashnum01" test_ssrslashnum00
+  Pcoq.Entry.of_parser "test_ssrslashnum01" test_ssrslashnum00
 let test_ssrslashnum10 =
-  Pcoq.Gram.Entry.of_parser "test_ssrslashnum10" test_ssrslashnum10
+  Pcoq.Entry.of_parser "test_ssrslashnum10" test_ssrslashnum10
 let test_ssrslashnum11 =
-  Pcoq.Gram.Entry.of_parser "test_ssrslashnum11" test_ssrslashnum11
+  Pcoq.Entry.of_parser "test_ssrslashnum11" test_ssrslashnum11
 let test_ssrslashnum01 =
-  Pcoq.Gram.Entry.of_parser "test_ssrslashnum01" test_ssrslashnum01
+  Pcoq.Entry.of_parser "test_ssrslashnum01" test_ssrslashnum01
 
 }
 
@@ -470,7 +470,7 @@ let input_ssrtermkind strm = match Util.stream_nth 0 strm with
   | Tok.KEYWORD "@" -> xWithAt
   | _ -> xNoFlag
 
-let ssrtermkind = Pcoq.Gram.Entry.of_parser "ssrtermkind" input_ssrtermkind
+let ssrtermkind = Pcoq.Entry.of_parser "ssrtermkind" input_ssrtermkind
 
 (* New kinds of terms *)
 
@@ -481,7 +481,7 @@ let input_term_annotation strm =
   | Tok.KEYWORD "@" :: _ -> `At
   | _ -> `None
 let term_annotation =
-  Gram.Entry.of_parser "term_annotation" input_term_annotation
+  Pcoq.Entry.of_parser "term_annotation" input_term_annotation
 
 (* terms *)
 
@@ -800,7 +800,7 @@ let reject_ssrhid strm =
       | _ -> ())
   | _ -> ()
 
-let test_nohidden = Pcoq.Gram.Entry.of_parser "test_ssrhid" reject_ssrhid
+let test_nohidden = Pcoq.Entry.of_parser "test_ssrhid" reject_ssrhid
 
 }
 
@@ -961,7 +961,7 @@ let accept_ssrfwdid strm =
   | Tok.IDENT id -> accept_before_syms_or_any_id [":"; ":="; "("] strm
   | _ -> raise Stream.Failure
 
-let test_ssrfwdid = Gram.Entry.of_parser "test_ssrfwdid" accept_ssrfwdid
+let test_ssrfwdid = Pcoq.Entry.of_parser "test_ssrfwdid" accept_ssrfwdid
 
 }
 
@@ -1540,7 +1540,7 @@ let accept_ssrseqvar strm =
      accept_before_syms_or_ids ["["] ["first";"last"] strm
   | _ -> raise Stream.Failure
 
-let test_ssrseqvar = Gram.Entry.of_parser "test_ssrseqvar" accept_ssrseqvar
+let test_ssrseqvar = Pcoq.Entry.of_parser "test_ssrseqvar" accept_ssrseqvar
 
 let swaptacarg (loc, b) = (b, []), Some (TacId [])
 
@@ -1628,7 +1628,7 @@ let ssr_id_of_string loc s =
   ^ "Scripts with explicit references to anonymous variables are fragile."))
     end; Id.of_string s
 
-let ssr_null_entry = Gram.Entry.of_parser "ssr_null" (fun _ -> ())
+let ssr_null_entry = Pcoq.Entry.of_parser "ssr_null" (fun _ -> ())
 
 }
 
@@ -1955,7 +1955,7 @@ let accept_ssreqid strm =
                       accept_before_syms [":"] strm
   | _ -> raise Stream.Failure
 
-let test_ssreqid = Gram.Entry.of_parser "test_ssreqid" accept_ssreqid
+let test_ssreqid = Pcoq.Entry.of_parser "test_ssreqid" accept_ssreqid
 
 }
 
@@ -2373,7 +2373,7 @@ let test_ssr_rw_syntax =
     match Util.stream_nth 0 strm with
     | Tok.KEYWORD key when List.mem key.[0] [lbrace; '['; '/'] -> ()
     | _ -> raise Stream.Failure in
-  Gram.Entry.of_parser "test_ssr_rw_syntax" test
+  Pcoq.Entry.of_parser "test_ssr_rw_syntax" test
 
 }
 
@@ -2583,7 +2583,7 @@ let accept_idcomma strm =
   | Tok.IDENT _ | Tok.KEYWORD "_" -> accept_before_syms [","] strm
   | _ -> raise Stream.Failure
 
-let test_idcomma = Gram.Entry.of_parser "test_idcomma" accept_idcomma
+let test_idcomma = Pcoq.Entry.of_parser "test_idcomma" accept_idcomma
 
 }
 

--- a/plugins/ssrmatching/g_ssrmatching.mlg
+++ b/plugins/ssrmatching/g_ssrmatching.mlg
@@ -68,7 +68,7 @@ let input_ssrtermkind strm = match Util.stream_nth 0 strm with
   | Tok.KEYWORD "(" -> '('
   | Tok.KEYWORD "@" -> '@'
   | _ -> ' '
-let ssrtermkind = Pcoq.Gram.Entry.of_parser "ssrtermkind" input_ssrtermkind
+let ssrtermkind = Pcoq.Entry.of_parser "ssrtermkind" input_ssrtermkind
 
 }
 

--- a/plugins/ssrmatching/g_ssrmatching.mlg
+++ b/plugins/ssrmatching/g_ssrmatching.mlg
@@ -11,7 +11,6 @@
 {
 
 open Ltac_plugin
-open Pcoq
 open Pcoq.Constr
 open Ssrmatching
 open Ssrmatching.Internal

--- a/toplevel/coqloop.ml
+++ b/toplevel/coqloop.ml
@@ -245,7 +245,7 @@ let parse_to_dot =
     | Tok.EOI -> raise Stm.End_of_input
     | _ -> dot st
   in
-  Pcoq.Gram.Entry.of_parser "Coqtoplevel.dot" dot
+  Pcoq.Entry.of_parser "Coqtoplevel.dot" dot
 
 (* If an error occurred while parsing, we try to read the input until a dot
    token is encountered.

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -474,7 +474,7 @@ END
 {
 
 let only_starredidentrefs =
-  Gram.Entry.of_parser "test_only_starredidentrefs"
+  Pcoq.Entry.of_parser "test_only_starredidentrefs"
     (fun strm ->
       let rec aux n =
       match Util.stream_nth n strm with

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -58,7 +58,7 @@ let pr_registered_grammar name =
   | None -> user_err Pp.(str "Unknown or unprintable grammar entry.")
   | Some entries ->
     let pr_one (Pcoq.AnyEntry e) =
-      str "Entry " ++ str (Pcoq.Gram.Entry.name e) ++ str " is" ++ fnl () ++
+      str "Entry " ++ str (Pcoq.Entry.name e) ++ str " is" ++ fnl () ++
       pr_entry e
     in
     prlist pr_one entries

--- a/vernac/pvernac.ml
+++ b/vernac/pvernac.ml
@@ -41,8 +41,8 @@ module Vernac_ =
 
     let command_entry_ref = ref noedit_mode
     let command_entry =
-      Gram.Entry.of_parser "command_entry"
-        (fun strm -> Gram.Entry.parse_token_stream !command_entry_ref strm)
+      Pcoq.Entry.of_parser "command_entry"
+        (fun strm -> Pcoq.Entry.parse_token_stream !command_entry_ref strm)
 
   end
 

--- a/vernac/vernacextend.ml
+++ b/vernac/vernacextend.ml
@@ -190,7 +190,7 @@ let vernac_extend ~command ?classifier ?entry ext =
     | None ->
       let e = match entry with
       | None -> "COMMAND"
-      | Some e -> Pcoq.Gram.Entry.name e
+      | Some e -> Pcoq.Entry.name e
       in
       let msg = Printf.sprintf "\
         Vernac entry \"%s\" misses a classifier. \


### PR DESCRIPTION
Revival of the cleaning part of #8923 and further removal of all unsafe camlp5 exported API.