### PR TITLE
[ci] [appveyor] Move Appveyor to OPAM 2.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,8 +2,7 @@ version: '{branch}~{build}'
 clone_depth: 10
 
 cache:
-  - C:\cygwin64 -> dev\ci\appveyor.bat
-  - C:\cygwin64\home\appveyor\.opam -> dev\ci\appveyor.sh
+  - C:\cygwin64 -> dev\ci\appveyor.bat, dev\ci\appveyor.sh
 
 platform:
 - x64

--- a/dev/ci/appveyor.sh
+++ b/dev/ci/appveyor.sh
@@ -2,14 +2,15 @@
 
 set -e -x
 
-APPVEYOR_OPAM_SWITCH=4.07.0+mingw64c
+APPVEYOR_OPAM_VARIANT=ocaml-variants.4.07.1+mingw64c
 
-wget https://github.com/fdopen/opam-repository-mingw/releases/download/0.0.0.1/opam64.tar.xz
+wget https://github.com/fdopen/opam-repository-mingw/releases/download/0.0.0.2/opam64.tar.xz -O opam64.tar.xz
 tar -xf opam64.tar.xz
 bash opam64/install.sh
 
-opam init -a mingw https://github.com/fdopen/opam-repository-mingw.git --comp $APPVEYOR_OPAM_SWITCH --switch $APPVEYOR_OPAM_SWITCH
-eval "$(opam config env)"
+opam init default -a -y "https://github.com/fdopen/opam-repository-mingw.git#opam2" -c $APPVEYOR_OPAM_VARIANT --disable-sandboxing
+eval "$(opam env)"
 opam install -y num ocamlfind ounit
 
+# Full regular Coq Build
 cd "$APPVEYOR_BUILD_FOLDER" && ./configure -local && make && make byte && make -C test-suite all INTERACTIVE= # && make validate


### PR DESCRIPTION
We update the Appveyor configuration so it uses OPAM 2.0, and thus it
can install newer packages.
