### PR TITLE
[gramlib] Minor cleanups:

### DIFF
--- a/coqpp/coqpp_main.ml
+++ b/coqpp/coqpp_main.ml
@@ -146,16 +146,16 @@ let print_local fmt ext =
     fprintf fmt "in@ "
 
 let print_position fmt pos = match pos with
-| First -> fprintf fmt "Extend.First"
-| Last -> fprintf fmt "Extend.Last"
-| Before s -> fprintf fmt "Extend.Before@ \"%s\"" s
-| After s -> fprintf fmt "Extend.After@ \"%s\"" s
-| Level s -> fprintf fmt "Extend.Level@ \"%s\"" s
+| First -> fprintf fmt "Gramlib.Gramext.First"
+| Last -> fprintf fmt "Gramlib.Gramext.Last"
+| Before s -> fprintf fmt "Gramlib.Gramext.Before@ \"%s\"" s
+| After s -> fprintf fmt "Gramlib.Gramext.After@ \"%s\"" s
+| Level s -> fprintf fmt "Gramlib.Gramext.Level@ \"%s\"" s
 
 let print_assoc fmt = function
-| LeftA -> fprintf fmt "Extend.LeftA"
-| RightA -> fprintf fmt "Extend.RightA"
-| NonA -> fprintf fmt "Extend.NonA"
+| LeftA -> fprintf fmt "Gramlib.Gramext.LeftA"
+| RightA -> fprintf fmt "Gramlib.Gramext.RightA"
+| NonA -> fprintf fmt "Gramlib.Gramext.NonA"
 
 let is_token s = match string_split s with
 | [s] -> is_uident s

--- a/gramlib/gramext.mli
+++ b/gramlib/gramext.mli
@@ -53,13 +53,13 @@ type position =
   | Like of string
   | Level of string
 
-val levels_of_rules : warning:bool ->
+val levels_of_rules : warning:(string -> unit) option ->
   'te g_entry -> position option ->
     (string option * g_assoc option * ('te g_symbol list * g_action) list)
       list ->
     'te g_level list
 
-val srules : warning:bool -> ('te g_symbol list * g_action) list -> 'te g_symbol
+val srules : warning:(string -> unit) option -> ('te g_symbol list * g_action) list -> 'te g_symbol
 val eq_symbol : 'a g_symbol -> 'a g_symbol -> bool
 
 val delete_rule_in_level_list :

--- a/gramlib/gramext.mli
+++ b/gramlib/gramext.mli
@@ -53,15 +53,14 @@ type position =
   | Like of string
   | Level of string
 
-val levels_of_rules :
+val levels_of_rules : warning:bool ->
   'te g_entry -> position option ->
     (string option * g_assoc option * ('te g_symbol list * g_action) list)
       list ->
     'te g_level list
-val srules : ('te g_symbol list * g_action) list -> 'te g_symbol
+
+val srules : warning:bool -> ('te g_symbol list * g_action) list -> 'te g_symbol
 val eq_symbol : 'a g_symbol -> 'a g_symbol -> bool
 
 val delete_rule_in_level_list :
   'te g_entry -> 'te g_symbol list -> 'te g_level list -> 'te g_level list
-
-val warning_verbose : bool ref

--- a/gramlib/grammar.ml
+++ b/gramlib/grammar.ml
@@ -841,8 +841,6 @@ let clear_entry e =
     Dlevels _ -> e.edesc <- Dlevels []
   | Dparser _ -> ()
 
-let gram_reinit g glexer = Hashtbl.clear g.gtokens; g.glexer <- glexer
-
 (* Functorial interface *)
 
 module type GLexerType = sig type te val lexer : te Plexing.lexer end
@@ -881,7 +879,7 @@ module type S =
     val s_self : ('self, 'self) ty_symbol
     val s_next : ('self, 'self) ty_symbol
     val s_token : Plexing.pattern -> ('self, string) ty_symbol
-    val s_rules : warning:bool -> 'a ty_production list -> ('self, 'a) ty_symbol
+    val s_rules : warning:(string -> unit) option -> 'a ty_production list -> ('self, 'a) ty_symbol
     val r_stop : ('self, 'r, 'r) ty_rule
     val r_next :
       ('self, 'a, 'r) ty_rule -> ('self, 'b) ty_symbol ->
@@ -889,10 +887,9 @@ module type S =
     val production : ('a, 'f, Ploc.t -> 'a) ty_rule * 'f -> 'a ty_production
     module Unsafe :
       sig
-        val gram_reinit : te Plexing.lexer -> unit
         val clear_entry : 'a Entry.e -> unit
       end
-    val safe_extend : warning:bool ->
+    val safe_extend : warning:(string -> unit) option ->
       'a Entry.e -> Gramext.position option ->
         (string option * Gramext.g_assoc option * 'a ty_production list)
           list ->
@@ -953,7 +950,6 @@ module GMake (L : GLexerType) =
       Obj.magic p
     module Unsafe =
       struct
-        let gram_reinit = gram_reinit gram
         let clear_entry = clear_entry
       end
     let safe_extend ~warning e pos

--- a/gramlib/grammar.ml
+++ b/gramlib/grammar.ml
@@ -755,9 +755,9 @@ let init_entry_functions entry =
        let f = continue_parser_of_entry entry in
        entry.econtinue <- f; f lev bp a strm)
 
-let extend_entry entry position rules =
+let extend_entry ~warning entry position rules =
   try
-    let elev = Gramext.levels_of_rules entry position rules in
+    let elev = Gramext.levels_of_rules ~warning entry position rules in
     entry.edesc <- Dlevels elev; init_entry_functions entry
   with Plexing.Error s ->
     Printf.eprintf "Lexer initialization error:\n- %s\n" s;
@@ -881,7 +881,7 @@ module type S =
     val s_self : ('self, 'self) ty_symbol
     val s_next : ('self, 'self) ty_symbol
     val s_token : Plexing.pattern -> ('self, string) ty_symbol
-    val s_rules : 'a ty_production list -> ('self, 'a) ty_symbol
+    val s_rules : warning:bool -> 'a ty_production list -> ('self, 'a) ty_symbol
     val r_stop : ('self, 'r, 'r) ty_rule
     val r_next :
       ('self, 'a, 'r) ty_rule -> ('self, 'b) ty_symbol ->
@@ -892,7 +892,7 @@ module type S =
         val gram_reinit : te Plexing.lexer -> unit
         val clear_entry : 'a Entry.e -> unit
       end
-    val safe_extend :
+    val safe_extend : warning:bool ->
       'a Entry.e -> Gramext.position option ->
         (string option * Gramext.g_assoc option * 'a ty_production list)
           list ->
@@ -945,7 +945,7 @@ module GMake (L : GLexerType) =
     let s_self = Sself
     let s_next = Snext
     let s_token tok = Stoken tok
-    let s_rules (t : Obj.t ty_production list) = Gramext.srules (Obj.magic t)
+    let s_rules ~warning (t : Obj.t ty_production list) = Gramext.srules ~warning (Obj.magic t)
     let r_stop = []
     let r_next r s = r @ [s]
     let production
@@ -956,12 +956,10 @@ module GMake (L : GLexerType) =
         let gram_reinit = gram_reinit gram
         let clear_entry = clear_entry
       end
-    let extend = extend_entry
-    let safe_extend e pos
+    let safe_extend ~warning e pos
         (r :
          (string option * Gramext.g_assoc option * Obj.t ty_production list)
            list) =
-      extend e pos (Obj.magic r)
-    let delete_rule e r = delete_rule (Entry.obj e) r
-    let safe_delete_rule = delete_rule
+      extend_entry ~warning e pos (Obj.magic r)
+    let safe_delete_rule e r = delete_rule (Entry.obj e) r
   end

--- a/gramlib/grammar.mli
+++ b/gramlib/grammar.mli
@@ -53,7 +53,7 @@ module type S =
     val s_self : ('self, 'self) ty_symbol
     val s_next : ('self, 'self) ty_symbol
     val s_token : Plexing.pattern -> ('self, string) ty_symbol
-    val s_rules : 'a ty_production list -> ('self, 'a) ty_symbol
+    val s_rules : warning:bool -> 'a ty_production list -> ('self, 'a) ty_symbol
     val r_stop : ('self, 'r, 'r) ty_rule
     val r_next :
       ('self, 'a, 'r) ty_rule -> ('self, 'b) ty_symbol ->
@@ -65,7 +65,7 @@ module type S =
         val gram_reinit : te Plexing.lexer -> unit
         val clear_entry : 'a Entry.e -> unit
       end
-    val safe_extend :
+    val safe_extend : warning:bool ->
       'a Entry.e -> Gramext.position option ->
         (string option * Gramext.g_assoc option * 'a ty_production list)
           list ->

--- a/gramlib/grammar.mli
+++ b/gramlib/grammar.mli
@@ -53,7 +53,7 @@ module type S =
     val s_self : ('self, 'self) ty_symbol
     val s_next : ('self, 'self) ty_symbol
     val s_token : Plexing.pattern -> ('self, string) ty_symbol
-    val s_rules : warning:bool -> 'a ty_production list -> ('self, 'a) ty_symbol
+    val s_rules : warning:(string -> unit) option -> 'a ty_production list -> ('self, 'a) ty_symbol
     val r_stop : ('self, 'r, 'r) ty_rule
     val r_next :
       ('self, 'a, 'r) ty_rule -> ('self, 'b) ty_symbol ->
@@ -62,10 +62,9 @@ module type S =
 
     module Unsafe :
       sig
-        val gram_reinit : te Plexing.lexer -> unit
         val clear_entry : 'a Entry.e -> unit
       end
-    val safe_extend : warning:bool ->
+    val safe_extend : warning:(string -> unit) option ->
       'a Entry.e -> Gramext.position option ->
         (string option * Gramext.g_assoc option * 'a ty_production list)
           list ->

--- a/parsing/extend.ml
+++ b/parsing/extend.ml
@@ -14,17 +14,8 @@ type 'a entry = 'a Gramlib.Grammar.GMake(CLexer).Entry.e
 
 type side = Left | Right
 
-type gram_assoc = NonA | RightA | LeftA
-
-type gram_position =
-  | First
-  | Last
-  | Before of string
-  | After of string
-  | Level of string
-
 type production_position =
-  | BorderProd of side * gram_assoc option
+  | BorderProd of side * Gramlib.Gramext.g_assoc option
   | InternalProd
 
 type production_level =
@@ -116,11 +107,11 @@ type 'a production_rule =
 type 'a single_extend_statement =
   string option *
   (** Level *)
-  gram_assoc option *
+  Gramlib.Gramext.g_assoc option *
   (** Associativity *)
   'a production_rule list
   (** Symbol list with the interpretation function *)
 
 type 'a extend_statement =
-  gram_position option *
+  Gramlib.Gramext.position option *
   'a single_extend_statement list

--- a/parsing/notation_gram.ml
+++ b/parsing/notation_gram.ml
@@ -32,7 +32,7 @@ type grammar_constr_prod_item =
 
 type one_notation_grammar = {
   notgram_level : level;
-  notgram_assoc : Extend.gram_assoc option;
+  notgram_assoc : Gramlib.Gramext.g_assoc option;
   notgram_notation : Constrexpr.notation;
   notgram_prods : grammar_constr_prod_item list list;
 }

--- a/parsing/pcoq.mli
+++ b/parsing/pcoq.mli
@@ -110,10 +110,6 @@ end
 
 *)
 
-(** Temporarily activate camlp5 verbosity *)
-
-val camlp5_verbosity : bool -> ('a -> unit) -> 'a -> unit
-
 (** Parse a string *)
 
 val parse_string : 'a Entry.t -> string -> 'a
@@ -202,7 +198,7 @@ val epsilon_value : ('a -> 'self) -> ('self, 'a) Extend.symbol -> 'self option
 
 (** {5 Extending the parser without synchronization} *)
 
-type gram_reinit = gram_assoc * gram_position
+type gram_reinit = Gramlib.Gramext.g_assoc * Gramlib.Gramext.position
 (** Type of reinitialization data *)
 
 val grammar_extend : 'a Entry.t -> gram_reinit option ->

--- a/parsing/pcoq.mli
+++ b/parsing/pcoq.mli
@@ -26,7 +26,7 @@ sig
 end
 
 module Entry : sig
-  type 'a t = 'a Grammar.GMake(CLexer).Entry.e
+  type 'a t = 'a Extend.entry
   val create : string -> 'a t
   val parse : 'a t -> Parsable.t -> 'a
   val print : Format.formatter -> 'a t -> unit

--- a/plugins/ltac/tacentries.ml
+++ b/plugins/ltac/tacentries.ml
@@ -119,7 +119,7 @@ let get_tactic_entry n =
   else if Int.equal n 5 then
     Pltac.binder_tactic, None
   else if 1<=n && n<5 then
-    Pltac.tactic_expr, Some (Extend.Level (string_of_int n))
+    Pltac.tactic_expr, Some (Gramlib.Gramext.Level (string_of_int n))
   else
     user_err Pp.(str ("Invalid Tactic Notation level: "^(string_of_int n)^"."))
 

--- a/vernac/egramcoq.ml
+++ b/vernac/egramcoq.ml
@@ -33,24 +33,24 @@ open Pcoq
 let constr_level = string_of_int
 
 let default_levels =
-  [200,Extend.RightA,false;
-   100,Extend.RightA,false;
-   99,Extend.RightA,true;
-   90,Extend.RightA,true;
-   10,Extend.LeftA,false;
-   9,Extend.RightA,false;
-   8,Extend.RightA,true;
-   1,Extend.LeftA,false;
-   0,Extend.RightA,false]
+  [200,Gramlib.Gramext.RightA,false;
+   100,Gramlib.Gramext.RightA,false;
+   99,Gramlib.Gramext.RightA,true;
+   90,Gramlib.Gramext.RightA,true;
+   10,Gramlib.Gramext.LeftA,false;
+   9,Gramlib.Gramext.RightA,false;
+   8,Gramlib.Gramext.RightA,true;
+   1,Gramlib.Gramext.LeftA,false;
+   0,Gramlib.Gramext.RightA,false]
 
 let default_pattern_levels =
-  [200,Extend.RightA,true;
-   100,Extend.RightA,false;
-   99,Extend.RightA,true;
-   90,Extend.RightA,true;
-   10,Extend.LeftA,false;
-   1,Extend.LeftA,false;
-   0,Extend.RightA,false]
+  [200,Gramlib.Gramext.RightA,true;
+   100,Gramlib.Gramext.RightA,false;
+   99,Gramlib.Gramext.RightA,true;
+   90,Gramlib.Gramext.RightA,true;
+   10,Gramlib.Gramext.LeftA,false;
+   1,Gramlib.Gramext.LeftA,false;
+   0,Gramlib.Gramext.RightA,false]
 
 let default_constr_levels = (default_levels, default_pattern_levels)
 
@@ -70,28 +70,28 @@ let save_levels levels custom lev =
 (* first LeftA, then RightA and NoneA together *)
 
 let admissible_assoc = function
-  | Extend.LeftA, Some (Extend.RightA | Extend.NonA) -> false
-  | Extend.RightA, Some Extend.LeftA -> false
+  | Gramlib.Gramext.LeftA, Some (Gramlib.Gramext.RightA | Gramlib.Gramext.NonA) -> false
+  | Gramlib.Gramext.RightA, Some Gramlib.Gramext.LeftA -> false
   | _ -> true
 
 let create_assoc = function
-  | None -> Extend.RightA
+  | None -> Gramlib.Gramext.RightA
   | Some a -> a
 
 let error_level_assoc p current expected =
   let open Pp in
   let pr_assoc = function
-    | Extend.LeftA -> str "left"
-    | Extend.RightA -> str "right"
-    | Extend.NonA -> str "non" in
+    | Gramlib.Gramext.LeftA -> str "left"
+    | Gramlib.Gramext.RightA -> str "right"
+    | Gramlib.Gramext.NonA -> str "non" in
   user_err 
     (str "Level " ++ int p ++ str " is already declared " ++
      pr_assoc current ++ str " associative while it is now expected to be " ++
      pr_assoc expected ++ str " associative.")
 
 let create_pos = function
-  | None -> Extend.First
-  | Some lev -> Extend.After (constr_level lev)
+  | None -> Gramlib.Gramext.First
+  | Some lev -> Gramlib.Gramext.After (constr_level lev)
 
 let find_position_gen current ensure assoc lev =
   match lev with
@@ -121,13 +121,13 @@ let find_position_gen current ensure assoc lev =
 	   updated, (Some (create_pos !after), Some assoc, Some (constr_level n), None)
         | _ ->
 	  (* The reinit flag has been updated *)
-	   updated, (Some (Extend.Level (constr_level n)), None, None, !init)
+           updated, (Some (Gramlib.Gramext.Level (constr_level n)), None, None, !init)
         end
       with
 	  (* Nothing has changed *)
           Exit ->
 	    (* Just inherit the existing associativity and name (None) *)
-	    current, (Some (Extend.Level (constr_level n)), None, None, None)
+            current, (Some (Gramlib.Gramext.Level (constr_level n)), None, None, None)
 
 let rec list_mem_assoc_triple x = function
   | [] -> false
@@ -186,15 +186,18 @@ let find_position accu custom forpat assoc level =
 (* Binding constr entry keys to entries                               *)
 
 (* Camlp5 levels do not treat NonA: use RightA with a NEXT on the left *)
-let camlp5_assoc = function
-  | Some NonA | Some RightA -> RightA
-  | None | Some LeftA -> LeftA
+let camlp5_assoc =
+  let open Gramlib.Gramext in function
+    | Some NonA | Some RightA -> RightA
+    | None | Some LeftA -> LeftA
 
-let assoc_eq al ar = match al, ar with
-| NonA, NonA
-| RightA, RightA
-| LeftA, LeftA -> true
-| _, _ -> false
+let assoc_eq al ar =
+  let open Gramlib.Gramext in
+  match al, ar with
+  | NonA, NonA
+  | RightA, RightA
+  | LeftA, LeftA -> true
+  | _, _ -> false
 
 (* [adjust_level assoc from prod] where [assoc] and [from] are the name
    and associativity of the level where to add the rule; the meaning of
@@ -204,7 +207,7 @@ let assoc_eq al ar = match al, ar with
      Some None = NEXT
      Some (Some (n,cur)) = constr LEVEL n
          s.t. if [cur] is set then [n] is the same as the [from] level *)
-let adjust_level assoc from = function
+let adjust_level assoc from = let open Gramlib.Gramext in function
 (* Associativity is None means force the level *)
   | (NumLevel n,BorderProd (_,None)) -> Some (Some (n,true))
 (* Compute production name on the right side *)

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -1175,9 +1175,9 @@ GRAMMAR EXTEND Gram
       | "in"; IDENT "custom"; x = IDENT -> { SetCustomEntry (x,None) }
       | "in"; IDENT "custom"; x = IDENT; "at"; IDENT "level"; n = natural ->
          { SetCustomEntry (x,Some n) }
-      | IDENT "left"; IDENT "associativity" -> { SetAssoc LeftA }
-      | IDENT "right"; IDENT "associativity" -> { SetAssoc RightA }
-      | IDENT "no"; IDENT "associativity" -> { SetAssoc NonA }
+      | IDENT "left"; IDENT "associativity" -> { SetAssoc Gramlib.Gramext.LeftA }
+      | IDENT "right"; IDENT "associativity" -> { SetAssoc Gramlib.Gramext.RightA }
+      | IDENT "no"; IDENT "associativity" -> { SetAssoc Gramlib.Gramext.NonA }
       | IDENT "only"; IDENT "printing" -> { SetOnlyPrinting }
       | IDENT "only"; IDENT "parsing" -> { SetOnlyParsing }
       | IDENT "compat"; s = STRING ->

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -287,7 +287,7 @@ let pr_notation_entry = function
   | InConstrEntry -> str "constr"
   | InCustomEntry s -> str "custom " ++ str s
 
-let prec_assoc = function
+let prec_assoc = let open Gramlib.Gramext in function
   | RightA -> (L,E)
   | LeftA -> (E,L)
   | NonA -> (L,L)
@@ -685,7 +685,7 @@ let border = function
   | (_,(ETConstr(_,_,(_,BorderProd (_,a))))) :: _ -> a
   | _ -> None
 
-let recompute_assoc typs =
+let recompute_assoc typs = let open Gramlib.Gramext in
   match border typs, border (List.rev typs) with
     | Some LeftA, Some RightA -> assert false
     | Some LeftA, _ -> Some LeftA
@@ -802,7 +802,7 @@ let inSyntaxExtension : syntax_extension_obj -> obj =
 module NotationMods = struct
 
 type notation_modifier = {
-  assoc         : gram_assoc option;
+  assoc         : Gramlib.Gramext.g_assoc option;
   level         : int option;
   custom        : notation_entry;
   etyps         : (Id.t * simple_constr_prod_entry_key) list;
@@ -1230,7 +1230,7 @@ let compute_syntax_data local df modifiers =
   let onlyprint = mods.only_printing in
   let onlyparse = mods.only_parsing in
   if onlyprint && onlyparse then user_err (str "A notation cannot be both 'only printing' and 'only parsing'.");
-  let assoc = Option.append mods.assoc (Some NonA) in
+  let assoc = Option.append mods.assoc (Some Gramlib.Gramext.NonA) in
   let (recvars,mainvars,symbols) = analyze_notation_tokens ~onlyprint df in
   let _ = check_useless_entry_types recvars mainvars mods.etyps in
   let _ = check_binder_type recvars mods.etyps in

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -380,7 +380,7 @@ open Pputils
 
   let pr_thm_token k = keyword (Kindops.string_of_theorem_kind k)
 
-  let pr_syntax_modifier = function
+  let pr_syntax_modifier = let open Gramlib.Gramext in function
     | SetItemLevel (l,bko,n) ->
       prlist_with_sep sep_v2 str l ++ spc () ++ pr_at_level_opt n ++
       pr_opt pr_constr_as_binder_kind bko

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -167,7 +167,7 @@ type syntax_modifier =
   | SetItemLevel of string list * Notation_term.constr_as_binder_kind option * Extend.production_level option
   | SetLevel of int
   | SetCustomEntry of string * int option
-  | SetAssoc of Extend.gram_assoc
+  | SetAssoc of Gramlib.Gramext.g_assoc
   | SetEntryType of string * Extend.simple_constr_prod_entry_key
   | SetOnlyParsing
   | SetOnlyPrinting


### PR DESCRIPTION
- remove duplicate type definitions `gram_assoc`, `gram_position`,
- make global `warning_verbose` variable into a parameter,
- remove redundant `entry` type, make type-flow clearer.
