### PR TITLE
[gramlib] [pcoq] Don't delete levels on rule removal.

### DIFF
--- a/parsing/pcoq.mli
+++ b/parsing/pcoq.mli
@@ -227,12 +227,8 @@ type 'a grammar_command
 (** Type of synchronized parsing extensions. The ['a] type should be
     marshallable. *)
 
-type gram_reinit = Gramlib.Gramext.g_assoc * Gramlib.Gramext.position
-(** Type of reinitialization data *)
-
 type extend_rule =
 | ExtendRule : 'a Entry.t * 'a extend_statement -> extend_rule
-| ExtendRuleReinit : 'a Entry.t * gram_reinit * 'a extend_statement -> extend_rule
 
 type 'a grammar_extension = 'a -> GramState.t -> extend_rule list * GramState.t
 (** Grammar extension entry point. Given some ['a] and a current grammar state,


### PR DESCRIPTION
As requested by @herbelin, this is an experiment to keep the level
when removing the last rule.

This should avoid the need to workaround the level deletion on rule
removal by re-creating it.

The changes in gramext are likely wrong as we may want to do some extra operation.

I don't still understand the error in the test suite [see below] but at least this is not a catastrophic failure so far:
```
File "./success/Notations.v", line 21, characters 0-58:
Error:
Level 8 is already declared right associative while it is now expected to be left associative.
```
Note that level 8 is one of the levels that where destroyed originally.