### PR TITLE
[dune] Minor tweak of dependencies.

### DIFF
--- a/META.coq.in
+++ b/META.coq.in
@@ -22,7 +22,7 @@ package "clib" (
   version     = "8.10"
 
   directory   = "clib"
-  requires    = "num, str, unix, threads"
+  requires    = "str, unix, threads"
 
   archive(byte)    = "clib.cma"
   archive(native)  = "clib.cmxa"
@@ -35,7 +35,7 @@ package "lib" (
 
   directory   = "lib"
 
-  requires    = "coq.clib, coq.config"
+  requires    = "coq.clib, coq.config, dynlink"
 
   archive(byte)   = "lib.cma"
   archive(native) = "lib.cmxa"
@@ -68,7 +68,7 @@ package "kernel" (
 
   directory   = "kernel"
 
-  requires    = "dynlink, coq.lib, coq.vm"
+  requires    = "coq.lib, coq.vm"
 
   archive(byte)    = "kernel.cma"
   archive(native)  = "kernel.cmxa"
@@ -223,7 +223,7 @@ package "toplevel" (
   description = "Coq Toplevel"
   version     = "8.10"
 
-  requires    = "coq.stm"
+  requires    = "num, coq.stm"
   directory   = "toplevel"
 
   archive(byte)    = "toplevel.cma"

--- a/clib/dune
+++ b/clib/dune
@@ -4,5 +4,5 @@
  (public_name coq.clib)
  (wrapped false)
  (modules_without_implementation cSig)
- (libraries threads str unix dynlink))
+ (libraries str unix threads))
 

--- a/kernel/dune
+++ b/kernel/dune
@@ -4,7 +4,7 @@
  (public_name coq.kernel)
  (wrapped false)
  (modules_without_implementation cinstr nativeinstr)
- (libraries clib config lib byterun))
+ (libraries lib byterun))
 
 (rule
  (targets copcodes.ml)

--- a/lib/dune
+++ b/lib/dune
@@ -4,4 +4,4 @@
  (public_name coq.lib)
  (wrapped false)
  (modules_without_implementation xml_datatype)
- (libraries threads coq.clib coq.config))
+ (libraries dynlink coq.clib coq.config))


### PR DESCRIPTION
`clib` doesn't need `dynlink`, but `lib` does, similarly for
`threads`, `num`...

We align Dune and META deps.
