### PR TITLE
[gramlib] Remove dead code

### DIFF
--- a/gramlib/gramext.ml
+++ b/gramlib/gramext.ml
@@ -284,39 +284,6 @@ let get_level ~warning entry position levs =
         lev :: levs -> [], change_lev ~warning lev "<top>", levs
       | [] -> [], empty_lev, []
 
-let rec check_gram entry =
-  function
-    Snterm e ->
-      if e.egram != entry.egram then
-        begin
-          eprintf "\
-Error: entries \"%s\" and \"%s\" do not belong to the same grammar.\n"
-            entry.ename e.ename;
-          flush stderr;
-          failwith "Grammar.extend error"
-        end
-  | Snterml (e, _) ->
-      if e.egram != entry.egram then
-        begin
-          eprintf "\
-Error: entries \"%s\" and \"%s\" do not belong to the same grammar.\n"
-            entry.ename e.ename;
-          flush stderr;
-          failwith "Grammar.extend error"
-        end
-  | Slist0sep (s, t, _) -> check_gram entry t; check_gram entry s
-  | Slist1sep (s, t, _) -> check_gram entry t; check_gram entry s
-  | Slist0 s -> check_gram entry s
-  | Slist1 s -> check_gram entry s
-  | Sopt s -> check_gram entry s
-  | Stree t -> tree_check_gram entry t
-  | Snext | Sself | Stoken _ -> ()
-and tree_check_gram entry =
-  function
-    Node {node = n; brother = bro; son = son} ->
-      check_gram entry n; tree_check_gram entry bro; tree_check_gram entry son
-  | LocAct (_, _) | DeadEnd -> ()
-
 let change_to_self entry =
   function
     Snterm e when e == entry -> Sself
@@ -373,7 +340,6 @@ let levels_of_rules ~warning entry position rules =
              List.fold_left
                (fun lev (symbols, action) ->
                   let symbols = List.map (change_to_self entry) symbols in
-                  List.iter (check_gram entry) symbols;
                   let (e1, symbols) = get_initial entry symbols in
                   insert_tokens entry.egram symbols;
                   insert_level ~warning entry.ename e1 symbols action lev)

--- a/gramlib/gramext.ml
+++ b/gramlib/gramext.ml
@@ -52,7 +52,6 @@ type position =
   | Last
   | Before of string
   | After of string
-  | Like of string
   | Level of string
 
 let rec derive_eps =
@@ -154,27 +153,6 @@ let is_level_labelled n lev =
     Some n1 -> n = n1
   | None -> false
 
-let rec token_exists_in_level f lev =
-  token_exists_in_tree f lev.lprefix || token_exists_in_tree f lev.lsuffix
-and token_exists_in_tree f =
-  function
-    Node n ->
-      token_exists_in_symbol f n.node || token_exists_in_tree f n.brother ||
-      token_exists_in_tree f n.son
-  | LocAct (_, _) | DeadEnd -> false
-and token_exists_in_symbol f =
-  function
-  | Slist0 sy -> token_exists_in_symbol f sy
-  | Slist0sep (sy, sep, _) ->
-      token_exists_in_symbol f sy || token_exists_in_symbol f sep
-  | Slist1 sy -> token_exists_in_symbol f sy
-  | Slist1sep (sy, sep, _) ->
-      token_exists_in_symbol f sy || token_exists_in_symbol f sep
-  | Sopt sy -> token_exists_in_symbol f sy
-  | Stoken tok -> f tok
-  | Stree t -> token_exists_in_tree f t
-  | Snterm _ | Snterml (_, _) | Snext | Sself -> false
-
 let insert_level ~warning entry_name e1 symbols action slev =
   match e1 with
     true ->
@@ -261,20 +239,6 @@ let get_level ~warning entry position levs =
             failwith "Grammar.extend"
         | lev :: levs ->
             if is_level_labelled n lev then [lev], empty_lev, levs
-            else
-              let (levs1, rlev, levs2) = get levs in lev :: levs1, rlev, levs2
-      in
-      get levs
-  | Some (Like n) ->
-      let f (tok, prm) = n = tok || n = prm in
-      let rec get =
-        function
-          [] ->
-            eprintf "No level with \"%s\" in entry \"%s\"\n" n entry.ename;
-            flush stderr;
-            failwith "Grammar.extend"
-        | lev :: levs ->
-            if token_exists_in_level f lev then [], change_lev ~warning lev n, levs
             else
               let (levs1, rlev, levs2) = get levs in lev :: levs1, rlev, levs2
       in

--- a/gramlib/gramext.ml
+++ b/gramlib/gramext.ml
@@ -8,7 +8,7 @@ type 'a parser_t = 'a Stream.t -> Obj.t
 
 type 'te grammar =
   { gtokens : (Plexing.pattern, int ref) Hashtbl.t;
-    mutable glexer : 'te Plexing.lexer }
+    glexer : 'te Plexing.lexer }
 
 type 'te g_entry =
   { egram : 'te grammar;

--- a/gramlib/gramext.mli
+++ b/gramlib/gramext.mli
@@ -6,7 +6,7 @@ type 'a parser_t = 'a Stream.t -> Obj.t
 
 type 'te grammar =
   { gtokens : (Plexing.pattern, int ref) Hashtbl.t;
-    mutable glexer : 'te Plexing.lexer }
+    glexer : 'te Plexing.lexer }
 
 type 'te g_entry =
   { egram : 'te grammar;

--- a/gramlib/gramext.mli
+++ b/gramlib/gramext.mli
@@ -50,7 +50,6 @@ type position =
   | Last
   | Before of string
   | After of string
-  | Like of string
   | Level of string
 
 val levels_of_rules : warning:(string -> unit) option ->

--- a/gramlib/grammar.ml
+++ b/gramlib/grammar.ml
@@ -794,8 +794,6 @@ let tokens g con =
     g.gtokens;
   !list
 
-let glexer g = g.glexer
-
 type 'te gen_parsable =
   { pa_chr_strm : char Stream.t;
     pa_tok_strm : 'te Stream.t;
@@ -851,7 +849,6 @@ module type S =
     type parsable
     val parsable : char Stream.t -> parsable
     val tokens : string -> (string * int) list
-    val glexer : te Plexing.lexer
     module Entry :
       sig
         type 'a e
@@ -906,7 +903,6 @@ module GMake (L : GLexerType) =
       let (ts, lf) = L.lexer.Plexing.tok_func cs in
       {pa_chr_strm = cs; pa_tok_strm = ts; pa_loc_func = lf}
     let tokens = tokens gram
-    let glexer = glexer gram
     module Entry =
       struct
         type 'a e = te g_entry

--- a/gramlib/grammar.ml
+++ b/gramlib/grammar.ml
@@ -186,84 +186,6 @@ and name_of_tree_failed entry =
       end
   | DeadEnd | LocAct (_, _) -> "???"
 
-let search_tree_in_entry prev_symb tree =
-  function
-    Dlevels levels ->
-      let rec search_levels =
-        function
-          [] -> tree
-        | level :: levels ->
-            match search_level level with
-              Some tree -> tree
-            | None -> search_levels levels
-      and search_level level =
-        match search_tree level.lsuffix with
-          Some t -> Some (Node {node = Sself; son = t; brother = DeadEnd})
-        | None -> search_tree level.lprefix
-      and search_tree t =
-        if tree <> DeadEnd && t == tree then Some t
-        else
-          match t with
-            Node n ->
-              begin match search_symbol n.node with
-                Some symb ->
-                  Some (Node {node = symb; son = n.son; brother = DeadEnd})
-              | None ->
-                  match search_tree n.son with
-                    Some t ->
-                      Some (Node {node = n.node; son = t; brother = DeadEnd})
-                  | None -> search_tree n.brother
-              end
-          | LocAct (_, _) | DeadEnd -> None
-      and search_symbol symb =
-        match symb with
-          Snterm _ | Snterml (_, _) | Slist0 _ | Slist0sep (_, _, _) |
-          Slist1 _ | Slist1sep (_, _, _) | Sopt _ | Stoken _ | Stree _
-          when symb == prev_symb ->
-            Some symb
-        | Slist0 symb ->
-            begin match search_symbol symb with
-              Some symb -> Some (Slist0 symb)
-            | None -> None
-            end
-        | Slist0sep (symb, sep, b) ->
-            begin match search_symbol symb with
-              Some symb -> Some (Slist0sep (symb, sep, b))
-            | None ->
-                match search_symbol sep with
-                  Some sep -> Some (Slist0sep (symb, sep, b))
-                | None -> None
-            end
-        | Slist1 symb ->
-            begin match search_symbol symb with
-              Some symb -> Some (Slist1 symb)
-            | None -> None
-            end
-        | Slist1sep (symb, sep, b) ->
-            begin match search_symbol symb with
-              Some symb -> Some (Slist1sep (symb, sep, b))
-            | None ->
-                match search_symbol sep with
-                  Some sep -> Some (Slist1sep (symb, sep, b))
-                | None -> None
-            end
-        | Sopt symb ->
-            begin match search_symbol symb with
-              Some symb -> Some (Sopt symb)
-            | None -> None
-            end
-        | Stree t ->
-            begin match search_tree t with
-              Some t -> Some (Stree t)
-            | None -> None
-            end
-        | _ -> None
-      in
-      search_levels levels
-  | Dparser _ -> tree
-
-let error_verbose = ref false
-
 let tree_failed entry prev_symb_result prev_symb tree =
   let txt = name_of_tree_failed entry tree in
   let txt =
@@ -295,18 +217,6 @@ let tree_failed entry prev_symb_result prev_symb tree =
     | Sopt _ | Stree _ -> txt ^ " expected"
     | _ -> txt ^ " expected after " ^ name_of_symbol_failed entry prev_symb
   in
-  if !error_verbose then
-    begin let tree = search_tree_in_entry prev_symb tree entry.edesc in
-      let ppf = err_formatter in
-      fprintf ppf "@[<v 0>@,";
-      fprintf ppf "----------------------------------@,";
-      fprintf ppf "Parse error in entry [%s], rule:@;<0 2>" entry.ename;
-      fprintf ppf "@[";
-      print_level ppf pp_force_newline (flatten_tree tree);
-      fprintf ppf "@]@,";
-      fprintf ppf "----------------------------------@,";
-      fprintf ppf "@]@."
-    end;
   txt ^ " (in [" ^ entry.ename ^ "])"
 
 let symb_failed entry prev_symb_result prev_symb symb =
@@ -374,11 +284,8 @@ let do_recover parser_of_tree entry nlevn alevn bp a s son
         continue entry bp a s son (parser_of_tree entry nlevn alevn son)
           strm__
 
-let strict_parsing = ref false
-
 let recover parser_of_tree entry nlevn alevn bp a s son strm =
-  if !strict_parsing then raise (Stream.Error (tree_failed entry a s son))
-  else do_recover parser_of_tree entry nlevn alevn bp a s son strm
+  do_recover parser_of_tree entry nlevn alevn bp a s son strm
 
 let token_count = ref 0
 

--- a/gramlib/grammar.mli
+++ b/gramlib/grammar.mli
@@ -25,7 +25,6 @@ module type S =
     type parsable
     val parsable : char Stream.t -> parsable
     val tokens : string -> (string * int) list
-    val glexer : te Plexing.lexer
     module Entry :
       sig
         type 'a e

--- a/gramlib/plexing.ml
+++ b/gramlib/plexing.ml
@@ -15,4 +15,4 @@ type 'te lexer =
     tok_removing : pattern -> unit;
     tok_match : pattern -> 'te -> string;
     tok_text : pattern -> string;
-    tok_comm : Loc.t list option }
+  }

--- a/gramlib/plexing.ml
+++ b/gramlib/plexing.ml
@@ -13,6 +13,6 @@ type 'te lexer =
   { tok_func : 'te lexer_func;
     tok_using : pattern -> unit;
     tok_removing : pattern -> unit;
-    mutable tok_match : pattern -> 'te -> string;
+    tok_match : pattern -> 'te -> string;
     tok_text : pattern -> string;
-    mutable tok_comm : Loc.t list option }
+    tok_comm : Loc.t list option }

--- a/gramlib/plexing.mli
+++ b/gramlib/plexing.mli
@@ -30,7 +30,7 @@ type 'te lexer =
     tok_removing : pattern -> unit;
     tok_match : pattern -> 'te -> string;
     tok_text : pattern -> string;
-    tok_comm : Loc.t list option }
+  }
 and 'te lexer_func = char Stream.t -> 'te Stream.t * location_function
 and location_function = int -> Loc.t
   (** The type of a function giving the location of a token in the

--- a/gramlib/plexing.mli
+++ b/gramlib/plexing.mli
@@ -28,9 +28,9 @@ type 'te lexer =
   { tok_func : 'te lexer_func;
     tok_using : pattern -> unit;
     tok_removing : pattern -> unit;
-    mutable tok_match : pattern -> 'te -> string;
+    tok_match : pattern -> 'te -> string;
     tok_text : pattern -> string;
-    mutable tok_comm : Loc.t list option }
+    tok_comm : Loc.t list option }
 and 'te lexer_func = char Stream.t -> 'te Stream.t * location_function
 and location_function = int -> Loc.t
   (** The type of a function giving the location of a token in the

--- a/parsing/cLexer.ml
+++ b/parsing/cLexer.ml
@@ -763,7 +763,6 @@ let lexer = {
        | _ -> ());
   Plexing.tok_removing = (fun _ -> ());
   Plexing.tok_match = Tok.match_pattern;
-  Plexing.tok_comm = None;
   Plexing.tok_text = token_text }
 
 (** Terminal symbols interpretation *)


### PR DESCRIPTION
This removes dead code from gramlib, that is sometimes non-trivially dead. Notably, some dynamic checks are made useless by the use of the functorial API, and some dynamic flags are useless, e.g. `warning_verbose` that should always be turned off in Coq (non-wrapped uses are oversights).