### PR TITLE
Clean stm flags

### DIFF
--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -2643,13 +2643,14 @@ let new_doc { doc_type ; iload_path; require_libs; stm_options } =
      name by looking at the load path! *)
   List.iter Mltop.add_coq_path iload_path;
 
+  Safe_typing.allow_delayed_constants := !cur_opt.async_proofs_mode <> APoff;
+
   begin match doc_type with
     | Interactive ln ->
       let dp = match ln with
         | TopLogical dp -> dp
         | TopPhysical f -> dirpath_of_file f
       in
-      Safe_typing.allow_delayed_constants := true;
       Declaremods.start_library dp
 
     | VoDoc f ->
@@ -2660,7 +2661,6 @@ let new_doc { doc_type ; iload_path; require_libs; stm_options } =
       set_compilation_hints f
 
     | VioDoc f ->
-      Safe_typing.allow_delayed_constants := true;
       let ldir = dirpath_of_file f in
       check_coq_overwriting ldir;
       let () = Flags.verbosely Declaremods.start_library ldir in

--- a/stm/stm.mli
+++ b/stm/stm.mli
@@ -27,7 +27,6 @@ module AsyncOpts : sig
     async_proofs_mode : async_proofs;
 
     async_proofs_private_flags : string option;
-    async_proofs_full : bool;
     async_proofs_never_reopen_branch : bool;
 
     async_proofs_tac_error_resilience : tac_error_filter;

--- a/stm/stm.mli
+++ b/stm/stm.mli
@@ -16,7 +16,9 @@ open Names
 module AsyncOpts : sig
 
   type cache = Force
-  type async_proofs = APoff | APonLazy | APon
+  type async_proofs = APoff
+                    | APonLazy (* Delays proof checking, but does it in master *)
+                    | APon
   type tac_error_filter = [ `None | `Only of string list | `All ]
 
   type stm_opt = {

--- a/toplevel/ccompile.ml
+++ b/toplevel/ccompile.ml
@@ -119,7 +119,8 @@ let compile opts ~echo ~f_in ~f_out =
       Dumpglob.start_dump_glob ~vfile:long_f_dot_v ~vofile:long_f_dot_vo;
       Dumpglob.dump_string ("F" ^ Names.DirPath.to_string ldir ^ "\n");
       let wall_clock1 = Unix.gettimeofday () in
-      let state = Vernac.load_vernac ~echo ~check:true ~interactive:false ~state long_f_dot_v in
+      let check = Stm.AsyncOpts.(stm_options.async_proofs_mode = APoff) in
+      let state = Vernac.load_vernac ~echo ~check ~interactive:false ~state long_f_dot_v in
       let _doc = Stm.join ~doc:state.doc in
       let wall_clock2 = Unix.gettimeofday () in
       check_pending_proofs ();
@@ -148,6 +149,8 @@ let compile opts ~echo ~f_in ~f_out =
          document anyways. *)
       let stm_options = let open Stm.AsyncOpts in
         { stm_options with
+          async_proofs_mode = APon;
+          async_proofs_n_workers = 0;
           async_proofs_cmd_error_resilience = false;
           async_proofs_tac_error_resilience = `None;
         } in

--- a/toplevel/coqargs.ml
+++ b/toplevel/coqargs.ml
@@ -543,10 +543,6 @@ let parse_args arglist : coq_cmdopts * string list =
     (* Options with zero arg *)
     |"-async-queries-always-delegate"
     |"-async-proofs-always-delegate"
-    |"-async-proofs-full" ->
-      { oval with stm_flags = { oval.stm_flags with
-        Stm.AsyncOpts.async_proofs_full = true;
-      }}
     |"-async-proofs-never-reopen-branch" ->
       { oval with stm_flags = { oval.stm_flags with
         Stm.AsyncOpts.async_proofs_never_reopen_branch = true


### PR DESCRIPTION
This PR is a small clean-up on user-visible STM flags:
- it removes the `-async-proofs-full` flag
- it makes `async-proofs on` have an effect on `coqc`

The second part was probably a bug, fixing it will making it possible to test proof delegation automatically. The first flag had an unclear semantics, tweaking many unrelated STM options. We keep some infrastructure in place (like async queries), but hope to enable them in the default `-async-proofs on` mode, rather than a separate flag. If we fail to do so, we will provide an `-async-proofs full`, which will be cleaner than what we have today, although still not very clear.