### PR TITLE
Add CI job building stdlib with `async-proofs on`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -225,6 +225,13 @@ build:egde:dune:dev:
     OPAM_SWITCH: edge
     DUNE_TARGET: world
 
+build:base+async:
+  <<: *build-template
+  stage: test
+  variables:
+    COQ_EXTRA_CONF: "-native-compiler yes -coqide opt"
+    COQUSERFLAGS: "-async-proofs on"
+
 windows64:
   <<: *windows-template
   variables:

--- a/Makefile.build
+++ b/Makefile.build
@@ -44,6 +44,9 @@ NO_RECALC_DEPS ?=
 # Non-empty runs the checker on all produced .vo files:
 VALIDATE ?=
 
+# When non-empty, passed as extra arguments to coqtop/coqc:
+COQUSERFLAGS ?=
+
 # Output file names for timed builds
 TIME_OF_BUILD_FILE               ?= time-of-build.log
 TIME_OF_BUILD_BEFORE_FILE        ?= time-of-build-before.log
@@ -191,7 +194,7 @@ TIMER=$(if $(TIMED), $(STDTIME), $(TIMECMD))
 # the output format of the unix command time. For instance:
 #   TIME="%C (%U user, %S sys, %e total, %M maxres)"
 
-COQOPTS=$(NATIVECOMPUTE) $(COQWARNERROR)
+COQOPTS=$(NATIVECOMPUTE) $(COQWARNERROR) $(COQUSERFLAGS)
 BOOTCOQC=$(TIMER) $(COQTOPBEST) -boot $(COQOPTS) -compile
 
 LOCALINCLUDES=$(addprefix -I ,$(SRCDIRS))

--- a/theories/Strings/BinaryString.v
+++ b/theories/Strings/BinaryString.v
@@ -48,7 +48,7 @@ Module Raw.
               end
        end.
 
-  Fixpoint to_N_of_pos (p : positive) (rest : string) (base : N)
+  Fixpoint to_N_of_pos (p : positive) (rest : string) (base : N) {struct p}
     : to_N (of_pos p rest) base
       = to_N rest match base with
                   | N0 => N.pos p

--- a/theories/Strings/HexString.v
+++ b/theories/Strings/HexString.v
@@ -120,7 +120,7 @@ Module Raw.
               end
        end.
 
-  Fixpoint to_N_of_pos (p : positive) (rest : string) (base : N)
+  Fixpoint to_N_of_pos (p : positive) (rest : string) (base : N) {struct p}
     : to_N (of_pos p rest) base
       = to_N rest match base with
                   | N0 => N.pos p

--- a/theories/Strings/OctalString.v
+++ b/theories/Strings/OctalString.v
@@ -78,7 +78,7 @@ Module Raw.
               end
        end.
 
-  Fixpoint to_N_of_pos (p : positive) (rest : string) (base : N)
+  Fixpoint to_N_of_pos (p : positive) (rest : string) (base : N) {struct p}
     : to_N (of_pos p rest) base
       = to_N rest match base with
                   | N0 => N.pos p


### PR DESCRIPTION
This should be useful to make sure we don't introduce regressions while working on STM improvements.

Based on #9072.