### PR TITLE
Fix #9076 (warning appears when running test suite)

### DIFF
--- a/test-suite/modules/Nat.v
+++ b/test-suite/modules/Nat.v
@@ -2,7 +2,7 @@ Definition T := nat.
 
 Definition le := le.
 
-Hint Unfold le.
+Hint Unfold le : core.
 
 Lemma le_refl : forall n : nat, le n n.
   auto.


### PR DESCRIPTION
I'm not quite sure why running the test suite shows the output on this precise file but not others.