### PR TITLE
[lib] Remove leftover flag `print_mod_uid`

### DIFF
--- a/lib/flags.ml
+++ b/lib/flags.ml
@@ -123,8 +123,5 @@ let get_inline_level () = !inline_level
 (* Native code compilation for conversion and normalization *)
 let output_native_objects = ref false
 
-(* Print the mod uid associated to a vo file by the native compiler *)
-let print_mod_uid = ref false
-
 let profile_ltac = ref false
 let profile_ltac_cutoff = ref 2.0

--- a/lib/flags.mli
+++ b/lib/flags.mli
@@ -119,8 +119,6 @@ val default_inline_level : int
 (** When producing vo objects, also compile the native-code version *)
 val output_native_objects : bool ref
 
-(** Print the mod uid associated to a vo file by the native compiler *)
-val print_mod_uid : bool ref
-
+(** Global profile_ltac flag  *)
 val profile_ltac : bool ref
 val profile_ltac_cutoff : float ref


### PR DESCRIPTION
The whole `native_name_from_filename` business seems quite strange tho.
