### PR TITLE
Fix 8922 again

### DIFF
--- a/ide/idetop.ml
+++ b/ide/idetop.ml
@@ -219,7 +219,7 @@ let goals () =
         | Some oldp ->
           let (_,_,_,_,osigma) = Proof.proof oldp in
           (try Some { it = Evar.Map.find ng diff_goal_map; sigma = osigma }
-          with Not_found -> raise (Pp_diff.Diff_Failure "Unable to match goals between old and new proof states (6)"))
+          with Not_found -> None) (* will appear as a new goal *)
         | None -> None
         in
         let (hyps_pp_list, concl_pp) = Proof_diffs.diff_goal_ide og_s ng nsigma in

--- a/parsing/tok.ml
+++ b/parsing/tok.ml
@@ -36,12 +36,24 @@ let equal t1 t2 = match t1, t2 with
 | EOI, EOI -> true
 | _ -> false
 
-let extract_string = function
+let extract_string diff_mode = function
   | KEYWORD s -> s
   | IDENT s -> s
-  | STRING s -> s
+  | STRING s ->
+   if diff_mode then
+    let escape_quotes s =
+      let len = String.length s in
+      let buf = Buffer.create len in
+      for i = 0 to len-1 do
+        let ch = String.get s i in
+        Buffer.add_char buf ch;
+        if ch = '"' then Buffer.add_char buf '"' else ()
+      done;
+      Buffer.contents buf
+    in
+    "\"" ^ (escape_quotes s) ^ "\"" else s
   | PATTERNIDENT s -> s
-  | FIELD s -> s
+  | FIELD s -> if diff_mode then "." ^ s else s
   | INT s -> s
   | LEFTQMARK -> "?"
   | BULLET s -> s

--- a/parsing/tok.mli
+++ b/parsing/tok.mli
@@ -22,7 +22,8 @@ type t =
   | EOI
 
 val equal : t -> t -> bool
-val extract_string : t -> string
+(* pass true for diff_mode *)
+val extract_string : bool -> t -> string
 val to_string : t -> string
 (* Needed to fit Camlp5 signature *)
 val print : Format.formatter -> t -> unit

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -722,11 +722,11 @@ let pr_subgoals ?(pr_first=true) ?(diffs=false) ?os_map
   let get_ogs g =
     match os_map with
     | Some (osigma, _) ->
-      (* if Not_found, returning None treats the goal as new and it will be highlighted;
+      (* if Not_found, returning None treats the goal as new and it will be diff highlighted;
          returning Some { it = g; sigma = sigma } will compare the new goal
          to itself and it won't be highlighted *)
       (try Some { it = GoalMap.find g diff_goal_map; sigma = osigma }
-      with Not_found -> raise (Pp_diff.Diff_Failure "Unable to match goals between old and new proof states (7)"))
+      with Not_found -> None)
     | None -> None
   in
   let rec pr_rec n = function

--- a/printing/proof_diffs.ml
+++ b/printing/proof_diffs.ml
@@ -83,7 +83,7 @@ let tokenize_string s =
     if Tok.(equal e EOI) then
       List.rev acc
     else
-      stream_tok ((Tok.extract_string e) :: acc) str
+      stream_tok ((Tok.extract_string true e) :: acc) str
   in
   let st = CLexer.get_lexer_state () in
   try

--- a/printing/proof_diffs.ml
+++ b/printing/proof_diffs.ml
@@ -138,13 +138,11 @@ let diff_hyps o_line_idents o_map n_line_idents n_map =
     let hyp_diffs = diff_str ~tokenize_string o_line n_line in
     let (has_added, has_removed) = has_changes hyp_diffs in
     if show_removed () && has_removed then begin
-      let o_entry = StringMap.find (List.hd old_ids) o_map in
-      o_entry.done_ <- true;
+      List.iter (fun x -> (StringMap.find x o_map).done_ <- true) old_ids;
       rv := (add_diff_tags `Removed o_pp hyp_diffs) :: !rv;
     end;
     if n_line <> "" then begin
-      let n_entry = StringMap.find (List.hd new_ids) n_map in
-      n_entry.done_ <- true;
+      List.iter (fun x -> (StringMap.find x n_map).done_ <- true) new_ids;
       rv := (add_diff_tags `Added n_pp hyp_diffs) :: !rv
     end
   in
@@ -157,7 +155,7 @@ let diff_hyps o_line_idents o_map n_line_idents n_map =
       if dtype = `Removed then begin
         let o_idents = (StringMap.find ident o_map).idents in
         (* only show lines that have all idents removed here; other removed idents appear later *)
-        if show_removed () &&
+        if show_removed () && not (is_done ident o_map) &&
             List.for_all (fun x -> not (exists x n_map)) o_idents then
           output (List.rev o_idents) []
       end

--- a/printing/proof_diffs.ml
+++ b/printing/proof_diffs.ml
@@ -545,16 +545,22 @@ module GoalMap = Evar.Map
 
 let goal_to_evar g sigma = Id.to_string (Termops.pr_evar_suggested_name g sigma)
 
+open Goal.Set
+
 [@@@ocaml.warning "-32"]
 let db_goal_map op np ng_to_og =
-  Printf.printf "New Goals: ";
-  let (ngoals,_,_,_,nsigma) = Proof.proof np in
-  List.iter (fun ng -> Printf.printf "%d -> %s  " (Evar.repr ng) (goal_to_evar ng nsigma)) ngoals;
+  let pr_goals title prf =
+    Printf.printf "%s: " title;
+    let (goals,_,_,_,sigma) = Proof.proof prf in
+    List.iter (fun g -> Printf.printf "%d -> %s  " (Evar.repr g) (goal_to_evar g sigma)) goals;
+    let gs = diff (Proof.all_goals prf) (List.fold_left (fun s g -> add g s) empty goals) in
+    List.iter (fun g -> Printf.printf "%d  " (Evar.repr g)) (elements gs);
+  in
+
+  pr_goals "New Goals" np;
   (match op with
   | Some op ->
-    let (ogoals,_,_,_,osigma) = Proof.proof op in
-    Printf.printf "\nOld Goals: ";
-    List.iter (fun og -> Printf.printf "%d -> %s  " (Evar.repr og) (goal_to_evar og osigma)) ogoals
+    pr_goals "\nOld Goals" op
   | None -> ());
   Printf.printf "\nGoal map: ";
   GoalMap.iter (fun og ng -> Printf.printf "%d -> %d  " (Evar.repr og) (Evar.repr ng)) ng_to_og;


### PR DESCRIPTION
**Kind:** bug fix

Fixes #8922
Fixes #9091 
Fixes incorrect handling of STRING and FIELD tokens, which would generate errors

In diffs, goals that are unmatched because they don't appear in the Show Proof structure will be highlighted as if they were new.

NOTE: This should be merged into 8.9 after https://github.com/coq/coq/pull/8967.
