### PR TITLE
[contributing] [changes] Improve accuracy of credits.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ OCaml and dependencies
 
 - Coq 8.10 requires OCaml >= 4.05.0, bumped from 4.02.3 See the
   INSTALL file for more information on dependencies.
+  (@ejgallego #7522, review by @gares, @Skyskimmer, and @Zimmi48)
 
 - Coq 8.10 doesn't need Camlp5 to build anymore. It now includes a
   fork of the core parsing library that Coq uses, which is a small
@@ -14,11 +15,13 @@ OCaml and dependencies
 
   The Coq developers would like to thank Daniel de Rauglaudre for many
   years of continued support.
+  (@ejgallego @ppedrot @Skyskimmer #8667 #8945 #8985, review by @gares)
 
 Coqide
 
 - CoqIDE now properly sets the module name for a given file based on
   its path, see -topfile change entry for more details.
+  (@Skyskimmer #8991, review by @ejgallego, @gares, and @ppedrot)
 
 Coqtop
 
@@ -26,6 +29,7 @@ Coqtop
   (à la -top) based on the filename passed, taking into account the
   proper -R/-Q options. For example, given -R Foo foolib using
   -topfile foolib/bar.v will set the module name to Foo.Bar.
+  (@Skyskimmer #8991, review by @ejgallego, @gares, and @ppedrot)
 
 Specification language, type inference
 
@@ -134,7 +138,8 @@ Universes
 
 Misc
 
-- Option "Typeclasses Axioms Are Instances" is deprecated. Use Declare Instance for axioms which should be instances.
+- Option "Typeclasses Axioms Are Instances" is deprecated. Use Declare
+  Instance for axioms which should be instances.
 
 Changes from 8.8.2 to 8.9+beta1
 ===============================
@@ -171,6 +176,7 @@ Tactics
   deprecated in 8.8 have been removed from Ltac's syntax; please use
   `fix ident N/cofix ident` to explicitly name the (co)fixpoint
   hypothesis to be introduced.
+  (@ejgallego #7196 #7200, review by @herbelin, @ppedrot, and @Zimmi48)
 
 - Introduction tactics `intro`/`intros` on a goal that is an
   existential variable now force a refinement of the goal into a
@@ -289,6 +295,12 @@ Vernacular Commands
   overwritting the opacity set of the hint database.
 - Added generic syntax for "attributes", as in:
   `#[local] Lemma foo : bar.`
+
+  (@vbgl, initial discussion at CEP#31 by @spiwak, initial
+   implementation design by @ejgallego @maximedenes, many other
+   reviews and contributions from @gares @herbelin @ppedrot
+   @SkySkimmer @Zimmi48)
+
 - Added the `Numeral Notation` command for registering decimal numeral
   notations for custom types
 - The `Set SsrHave NoTCResolution` command no longer has special global
@@ -307,6 +319,7 @@ Coq binaries and process model
   particular `coqidetop` is the CoqIDE language server, and
   `coq{proof,tactic,query}worker` are in charge of task-specific and
   parallel proof checking.
+  (@ejgallego #6859, review by @gares, @Skyskimmer, and @Zimmi48)
 
 SSReflect
 
@@ -341,6 +354,8 @@ Display diffs between proof steps
   `Set Diffs "on"/"off"/"removed"` command. Please see the documentation for
   details.  Showing diffs in Proof General requires small changes to PG
   (under discussion).
+  (@jfehrle #6801 #8247 #8301, review and design feedback by
+   @ejgallego, additional review by @gares, @herbelin, @ppedrot)
 
 Notations
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,19 @@ Here are a few tags Coq developers may add to your PR and what they mean. In gen
 To learn more about the merging process, you can read the
 [merging documentation for Coq maintainers](dev/doc/MERGING.md).
 
+### Writing a CHANGES.md entry
+
+If your pull request includes a user-facing change, you should update
+the CHANGES.md file. Format of the file is for now pretty free form,
+but you are encouraged to sign you change entry with your name, pull
+request number, issues fixes, and additional acknowledgements such as
+reviews and design contributions. Example:
+
+```
+- Added tactic 'foobar', which will apply the foo solver to derive bar-conditions.
+  (@greatest_developer #1234, review by @coq_superuser and @coq_infrauser)
+```
+
 ## Documentation
 
 Currently the process for contributing to the documentation is the same as for changing anything else in Coq, so please submit a pull request as described above.

--- a/dev/doc/changes.md
+++ b/dev/doc/changes.md
@@ -1,5 +1,12 @@
 ## Changes between Coq 8.9 and Coq 8.10
 
+### Build system
+
+  Coq can now be built using Dune (https://github.com/ocaml/dune);
+  this offers interesting possibilities including a fast build mode.
+  For more details check the docs at ./build-system.dune.md
+  (@ejgallego @Zimmi48 @rgrinberg)
+
 ### ML4 Pre Processing
 
 - Support for `.ml4` files, processed by camlp5 has been removed in


### PR DESCRIPTION
It has been a while that I am not very happy with our current system
to record changes and credits. I see several problems:

- imprecise credit for many features, for example, reviewers are not
  acknowledged [and are sometimes crucial for the design, etc...],
- dissociation of credits and change entries,
- lack of categorization / systematization.

This is indeed a hard problem to solve (cc: #8180) ; in this PR I have
a very modest proposal improve accuracy and traceability by adapting
the model used in OCaml.

In this model, every change entry includes the name of the author, the
PR numbers, and a list of additional acknowledgements, where revievers
are usually mandatory.

I have filled in the information for a few entries I am responsible
of; please let me know what you think.