### PR TITLE
Accept argument names for extra arguments with "extra scopes"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -88,6 +88,8 @@ Vernacular commands
 - The `Automatic Introduction` option has been removed and is now the
   default.
 
+- `Arguments` now accepts names for arguments provided with `extra_scopes`.
+
 Tools
 
 - The `-native-compiler` flag of `coqc` and `coqtop` now takes an argument which can have three values:

--- a/test-suite/output/Arguments.v
+++ b/test-suite/output/Arguments.v
@@ -51,7 +51,7 @@ Arguments pi _ _%F _%B.
 Check (forall w : r, pi w $ $ = tt).
 Fail Check (forall w : r, w $ $ = tt).
 Axiom w : r.
-Arguments w  _%F _%B : extra scopes.
+Arguments w  x%F y%B : extra scopes.
 Check (w $ $ = tt).
 Fail Arguments w  _%F _%B.
 

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1221,11 +1221,9 @@ let vernac_arguments ~section_local reference args more_implicits nargs_for_red 
   let rec check_extra_args extra_args =
     match extra_args with
     | [] -> ()
-    | { notation_scope = None } :: _ -> err_extra_args (names_of extra_args)
-    | { name = Anonymous; notation_scope = Some _ } :: args ->
-       check_extra_args args
-    | _ ->
-       user_err Pp.(str "Extra notation scopes can be set on anonymous and explicit arguments only.")
+    | { notation_scope = None } :: _ ->
+      user_err Pp.(str"Extra arguments should specify a scope.")
+    | { notation_scope = Some _ } :: args -> check_extra_args args
   in
 
   let args, scopes =


### PR DESCRIPTION
The checks were unnecessarily restrictive (since names can be used for
documentation purposes), and the error message was a bit wrong (it
mentioned a restriction on the explicit status of arguments).