### PR TITLE
[gitlab-ci] Increase git depth.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,7 +15,7 @@ variables:
   OPAM_SWITCH: "base"
   # Used to select special compiler switches such as flambda, 32bits, etc...
   OPAM_VARIANT: ""
-  GIT_DEPTH: "1"
+  GIT_DEPTH: "10"
 
 docker-boot:
   stage: docker


### PR DESCRIPTION
To avoid massive failures in second stage of CI build when a new PR has been merged
in master since then. Example: https://gitlab.com/coq/coq/pipelines/38528858.

Refines #8927.