### PR TITLE
[subsumed] Adding a delimiter for opening a scope only temporarily + applications to notations for ex/sig/sigT

### DIFF
--- a/interp/constrexpr.ml
+++ b/interp/constrexpr.ml
@@ -73,6 +73,8 @@ type abstraction_kind = AbsLambda | AbsPi
 
 type proj_flag = int option (** [Some n] = proj of the n-th visible argument *)
 
+type delimiter_depth = DelimOnlyTmpScope | DelimUnboundedScope
+
 type prim_token =
   | Number of NumTok.Signed.t
   | String of string
@@ -91,7 +93,7 @@ type cases_pattern_expr_r =
                                   applied to arguments l2 *)
   | CPatPrim   of prim_token
   | CPatRecord of (qualid * cases_pattern_expr) list
-  | CPatDelimiters of string * cases_pattern_expr
+  | CPatDelimiters of delimiter_depth * string * cases_pattern_expr
   | CPatCast   of cases_pattern_expr * constr_expr
 and cases_pattern_expr = cases_pattern_expr_r CAst.t
 
@@ -131,7 +133,7 @@ and constr_expr_r =
   | CNotation of notation_with_optional_scope option * notation * constr_notation_substitution
   | CGeneralization of Glob_term.binding_kind * abstraction_kind option * constr_expr
   | CPrim of prim_token
-  | CDelimiters of string * constr_expr
+  | CDelimiters of delimiter_depth * string * constr_expr
   | CArray of instance_expr option * constr_expr array * constr_expr * constr_expr
 and constr_expr = constr_expr_r CAst.t
 

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -280,11 +280,11 @@ module PrintingConstructor = Goptions.MakeRefTable(PrintingRecordConstructor)
 
 let insert_delimiters e = function
   | None -> e
-  | Some sc -> CAst.make @@ CDelimiters (sc,e)
+  | Some sc -> CAst.make @@ CDelimiters (DelimUnboundedScope,sc,e)
 
 let insert_pat_delimiters ?loc p = function
   | None -> p
-  | Some sc -> CAst.make ?loc @@ CPatDelimiters (sc,p)
+  | Some sc -> CAst.make ?loc @@ CPatDelimiters (DelimUnboundedScope,sc,p)
 
 let insert_pat_alias ?loc p = function
   | Anonymous -> p
@@ -885,8 +885,8 @@ let filter_enough_applied nargs l =
 let extern_prim_token_delimiter_if_required n key_n scope_n scopes =
   match availability_of_prim_token n scope_n scopes with
   | Some None -> CPrim n
-  | None -> CDelimiters(key_n, CAst.make (CPrim n))
-  | Some (Some key) -> CDelimiters(key, CAst.make (CPrim n))
+  | None -> CDelimiters(DelimUnboundedScope, key_n, CAst.make (CPrim n))
+  | Some (Some key) -> CDelimiters(DelimUnboundedScope, key, CAst.make (CPrim n))
 
 (**********************************************************************)
 (* mapping decl                                                       *)

--- a/parsing/g_constr.mlg
+++ b/parsing/g_constr.mlg
@@ -171,7 +171,10 @@ GRAMMAR EXTEND Gram
       | c = term; ".("; "@"; f = global;
         args = LIST0 (term LEVEL "9"); ")" ->
         { CAst.make ~loc @@ CAppExpl((Some (List.length args+1),f,None),args@[c]) }
-      | c = term; "%"; key = IDENT -> { CAst.make ~loc @@ CDelimiters (key,c) } ]
+      | c = term; "%"; key = IDENT ->
+        { CAst.make ~loc @@ CDelimiters (DelimUnboundedScope,key,c) }
+      | c = term; "%%"; key = IDENT ->
+        { CAst.make ~loc @@ CDelimiters (DelimOnlyTmpScope,key,c) } ]
     | "0"
       [ c = atomic_constr -> { c }
       | c = term_match -> { c }
@@ -362,7 +365,10 @@ GRAMMAR EXTEND Gram
       | "@"; r = Prim.reference; lp = LIST0 NEXT ->
         { CAst.make ~loc @@ CPatCstr (r, Some lp, []) } ]
     | "1" LEFTA
-      [ c = pattern; "%"; key = IDENT -> { CAst.make ~loc @@ CPatDelimiters (key,c) } ]
+      [ c = pattern; "%"; key = IDENT ->
+        { CAst.make ~loc @@ CPatDelimiters (DelimUnboundedScope,key,c) }
+      | c = pattern; "%%"; key = IDENT ->
+        { CAst.make ~loc @@ CPatDelimiters (DelimOnlyTmpScope,key,c) } ]
     | "0"
       [ r = Prim.reference                -> { CAst.make ~loc @@ CPatAtom (Some r) }
       | "{|"; pat = record_patterns; bar_cbrace -> { CAst.make ~loc @@ CPatRecord pat }

--- a/parsing/g_constr.mlg
+++ b/parsing/g_constr.mlg
@@ -172,9 +172,9 @@ GRAMMAR EXTEND Gram
         args = LIST0 (term LEVEL "9"); ")" ->
         { CAst.make ~loc @@ CAppExpl((Some (List.length args+1),f,None),args@[c]) }
       | c = term; "%"; key = IDENT ->
-        { CAst.make ~loc @@ CDelimiters (DelimUnboundedScope,key,c) }
+        { CAst.make ~loc @@ CDelimiters (DelimOnlyTmpScope,key,c) }
       | c = term; "%%"; key = IDENT ->
-        { CAst.make ~loc @@ CDelimiters (DelimOnlyTmpScope,key,c) } ]
+        { CAst.make ~loc @@ CDelimiters (DelimUnboundedScope,key,c) } ]
     | "0"
       [ c = atomic_constr -> { c }
       | c = term_match -> { c }

--- a/plugins/ssr/ssrview.ml
+++ b/plugins/ssr/ssrview.ml
@@ -163,7 +163,7 @@ let is_tac_in_term ?extra_scope { annotation; body; glob_env; interp_env } =
     let body =
       match extra_scope with
       | None -> body
-      | Some s -> CAst.make (Constrexpr.CDelimiters(s,body))
+      | Some s -> CAst.make Constrexpr.(CDelimiters(DelimUnboundedScope,s,body))
     in
     (* We unravel notations *)
     let g = intern_constr_expr ist sigma body in

--- a/printing/ppconstr.ml
+++ b/printing/ppconstr.ml
@@ -132,8 +132,9 @@ let tag_var = tag Tag.variable
     let { notation_printing_unparsing = unpl; notation_printing_level = level } = find_notation_printing_rule which s in
     print_hunks level pr pr_patt pr_binders env unpl, level
 
-  let pr_delimiters key strm =
-    strm ++ str ("%"^key)
+  let pr_delimiters depth key strm =
+    let d = match depth with DelimOnlyTmpScope -> "%%" | DelimUnboundedScope -> "%" in
+    strm ++ str (d^key)
 
   let pr_generalization bk ak c =
     let hd, tl =
@@ -320,8 +321,8 @@ let tag_var = tag Tag.variable
       | CPatPrim p ->
         pr_prim_token p, latom
 
-      | CPatDelimiters (k,p) ->
-        pr_delimiters k (pr_patt mt pr lsimplepatt p), 1
+      | CPatDelimiters (depth,k,p) ->
+        pr_delimiters depth k (pr_patt mt pr lsimplepatt p), 1
 
       | CPatCast (p,t) ->
         (pr_patt mt pr lpatcast p ++ spc () ++ str ":" ++ ws 1 ++ pr t), 1
@@ -684,8 +685,8 @@ let tag_var = tag Tag.variable
         return (pr_generalization bk ak (pr mt ltop c), latom)
       | CPrim p ->
         return (pr_prim_token p, prec_of_prim_token p)
-      | CDelimiters (sc,a) ->
-        return (pr_delimiters sc (pr mt (LevelLe ldelim) a), ldelim)
+      | CDelimiters (depth,sc,a) ->
+        return (pr_delimiters depth sc (pr mt (LevelLe ldelim) a), ldelim)
       | CArray(u, t,def,ty) ->
         hov 0 (str "[| " ++ prvect_with_sep (fun () -> str "; ") (pr mt ltop) t ++
                (if not (Array.is_empty t) then str " " else mt()) ++

--- a/printing/ppconstr.ml
+++ b/printing/ppconstr.ml
@@ -133,7 +133,7 @@ let tag_var = tag Tag.variable
     print_hunks level pr pr_patt pr_binders env unpl, level
 
   let pr_delimiters depth key strm =
-    let d = match depth with DelimOnlyTmpScope -> "%%" | DelimUnboundedScope -> "%" in
+    let d = match depth with DelimOnlyTmpScope -> "%" | DelimUnboundedScope -> "%%" in
     strm ++ str (d^key)
 
   let pr_generalization bk ak c =

--- a/printing/proof_diffs.ml
+++ b/printing/proof_diffs.ml
@@ -545,7 +545,7 @@ let match_goals ot nt =
     | CGeneralization (b,a,c), CGeneralization (b2,a2,c2) ->
       constr_expr ogname c c2
     | CPrim p, CPrim p2 -> ()
-    | CDelimiters (key,e), CDelimiters (key2,e2) ->
+    | CDelimiters (depth,key,e), CDelimiters (depth2,key2,e2) ->
       constr_expr ogname e e2
     | CArray(u,t,def,ty), CArray(u2,t2,def2,ty2) ->
       constr_arr ogname t t2;

--- a/test-suite/output/Notations3.out
+++ b/test-suite/output/Notations3.out
@@ -229,10 +229,10 @@ fun l : list nat => match l with
      : list nat -> list nat
 
 Arguments foo _%list_scope
-Notation "'exists' x .. y , p" := (ex (fun x => .. (ex (fun y => p)) ..))
+Notation "'exists' x .. y , P" := (ex (fun x => .. (ex (fun y => P)) ..))
   : type_scope (default interpretation)
-Notation "'exists' ! x .. y , p" :=
-  (ex (unique (fun x => .. (ex (unique (fun y => p))) ..))) : type_scope
+Notation "'exists' ! x .. y , P" :=
+  (ex (unique (fun x => .. (ex (unique (fun y => P))) ..))) : type_scope
   (default interpretation)
 Notation "( x , y , .. , z )" := (pair .. (pair x y) .. z) : core_scope
   (default interpretation)

--- a/test-suite/output/Notations4.out
+++ b/test-suite/output/Notations4.out
@@ -215,3 +215,9 @@ Some MyNone+
      : option (option ?A)
 where
 ?A : [ |- Type]
+Notation Cn := Foo.FooCn
+Expands to: Notation Notations4.J.Mfoo.Foo.Bar.Cn
+let v := 0%test17 in v : myint63
+     : myint63
+fun P Q : nat -> Type => {x : nat & P x * Q x}
+     : (nat -> Type) -> (nat -> Type) -> Type

--- a/test-suite/output/Notations4.v
+++ b/test-suite/output/Notations4.v
@@ -483,3 +483,24 @@ Check MyNone+.
 Check Some MyNone+.
 
 End LeadingIdent.
+
+Require Import Coq.Numbers.Cyclic.Int63.Int63.
+Module NumeralNotations.
+  Module Test17.
+    (** Test int63 *)
+    Declare Scope test17_scope.
+    Delimit Scope test17_scope with test17.
+    Local Set Primitive Projections.
+    Record myint63 := of_int { to_int : int }.
+    Numeral Notation myint63 of_int to_int : test17_scope.
+    Check let v := 0%test17 in v : myint63.
+  End Test17.
+End NumeralNotations.
+
+(* Test interpretation of types in "{ x | P }" as a type *)
+
+Module K.
+
+Check fun P Q => { x : nat & P x * Q x }.
+
+End K.

--- a/theories/Classes/RelationPairs.v
+++ b/theories/Classes/RelationPairs.v
@@ -50,8 +50,8 @@ Typeclasses Opaque RelCompFun.
 
 Infix "@@" := RelCompFun (at level 30, right associativity) : signature_scope.
 
-Notation "R @@1" := (R @@ Fst)%signature (at level 30) : signature_scope.
-Notation "R @@2" := (R @@ Snd)%signature (at level 30) : signature_scope.
+Notation "R @@1" := (R @@ Fst)%%signature (at level 30) : signature_scope.
+Notation "R @@2" := (R @@ Snd)%%signature (at level 30) : signature_scope.
 
 (** We declare measures to the system using the [Measure] class.
    Otherwise the instances would easily introduce loops,

--- a/theories/Floats/FloatLemmas.v
+++ b/theories/Floats/FloatLemmas.v
@@ -34,7 +34,7 @@ Theorem ldexp_spec : forall f e, Prim2SF (ldexp f e) = SFldexp prec emax (Prim2S
   destruct (Prim2SF f); auto.
   unfold SFldexp.
   unfold binary_round.
-  assert (Hmod_elim :  forall e, (φ (of_Z (Z.max (Z.min e (emax - emin)) (emin - emax - 1) + shift))%uint63 - shift = Z.max (Z.min e (emax - emin)) (emin - emax - 1))%Z).
+  assert (Hmod_elim :  forall e, (φ (of_Z (Z.max (Z.min e (emax - emin)) (emin - emax - 1) + shift))%uint63 - shift = Z.max (Z.min e (emax - emin)) (emin - emax - 1))%%Z).
   {
     intro e1.
     rewrite of_Z_spec, shift_value.

--- a/theories/Floats/FloatOps.v
+++ b/theories/Floats/FloatOps.v
@@ -20,7 +20,7 @@ Definition shift := 2101%Z. (** [= 2*emax + prec] *)
 
 Definition frexp f :=
   let (m, se) := frshiftexp f in
-  (m, (φ se - shift)%Z%uint63).
+  (m, (φ se - shift)%Z%%uint63).
 
 Definition ldexp f e :=
   let e' := Z.max (Z.min e (emax - emin)) (emin - emax - 1) in

--- a/theories/Init/Logic.v
+++ b/theories/Init/Logic.v
@@ -321,23 +321,23 @@ Definition all (A:Type) (P:A -> Prop) := forall x:A, P x.
 
 (* Rule order is important to give printing priority to fully typed exists *)
 
-Notation "'exists' x .. y , p" := (ex (fun x => .. (ex (fun y => p)) ..))
+Notation "'exists' x .. y , P" := (ex (fun x => .. (ex (fun y => P%%type)) ..))
   (at level 200, x binder, right associativity,
-   format "'[' 'exists'  '/  ' x  ..  y ,  '/  ' p ']'")
+   format "'[' 'exists'  '/  ' x  ..  y ,  '/  ' P ']'")
   : type_scope.
 
-Notation "'exists2' x , p & q" := (ex2 (fun x => p) (fun x => q))
-  (at level 200, x name, p at level 200, right associativity) : type_scope.
-Notation "'exists2' x : A , p & q" := (ex2 (A:=A) (fun x => p) (fun x => q))
-  (at level 200, x name, A at level 200, p at level 200, right associativity,
-    format "'[' 'exists2'  '/  ' x  :  A ,  '/  ' '[' p  &  '/' q ']' ']'")
+Notation "'exists2' x , P & Q" := (ex2 (fun x => P%%type) (fun x => Q%%type))
+  (at level 200, x name, P at level 200, right associativity) : type_scope.
+Notation "'exists2' x : A , P & Q" := (ex2 (A:=A) (fun x => P%%type) (fun x => Q%%type))
+  (at level 200, x name, A at level 200, P at level 200, right associativity,
+    format "'[' 'exists2'  '/  ' x  :  A ,  '/  ' '[' P  &  '/' Q ']' ']'")
   : type_scope.
 
-Notation "'exists2' ' x , p & q" := (ex2 (fun x => p) (fun x => q))
-  (at level 200, x strict pattern, p at level 200, right associativity) : type_scope.
-Notation "'exists2' ' x : A , p & q" := (ex2 (A:=A) (fun x => p) (fun x => q))
-  (at level 200, x strict pattern, A at level 200, p at level 200, right associativity,
-    format "'[' 'exists2'  '/  ' ' x  :  A ,  '/  ' '[' p  &  '/' q ']' ']'")
+Notation "'exists2' ' x , P & Q" := (ex2 (fun x => P%%type) (fun x => Q%%type))
+  (at level 200, x strict pattern, P at level 200, right associativity) : type_scope.
+Notation "'exists2' ' x : A , P & Q" := (ex2 (A:=A) (fun x => P%%type) (fun x => Q%%type))
+  (at level 200, x strict pattern, A at level 200, P at level 200, right associativity,
+    format "'[' 'exists2'  '/  ' ' x  :  A ,  '/  ' '[' P  &  '/' Q ']' ']'")
   : type_scope.
 
 (** Derived rules for universal quantification *)
@@ -773,10 +773,10 @@ Definition uniqueness (A:Type) (P:A->Prop) := forall x y, P x -> P y -> x = y.
 
 (** Unique existence *)
 
-Notation "'exists' ! x .. y , p" :=
-  (ex (unique (fun x => .. (ex (unique (fun y => p))) ..)))
+Notation "'exists' ! x .. y , P" :=
+  (ex (unique (fun x => .. (ex (unique (fun y => P%%type))) ..)))
   (at level 200, x binder, right associativity,
-   format "'[' 'exists'  !  '/  ' x  ..  y ,  '/  ' p ']'")
+   format "'[' 'exists'  !  '/  ' x  ..  y ,  '/  ' P ']'")
   : type_scope.
 
 Lemma unique_existence : forall (A:Type) (P:A->Prop),

--- a/theories/Init/Logic.v
+++ b/theories/Init/Logic.v
@@ -321,21 +321,21 @@ Definition all (A:Type) (P:A -> Prop) := forall x:A, P x.
 
 (* Rule order is important to give printing priority to fully typed exists *)
 
-Notation "'exists' x .. y , P" := (ex (fun x => .. (ex (fun y => P%%type)) ..))
+Notation "'exists' x .. y , P" := (ex (fun x => .. (ex (fun y => P%type)) ..))
   (at level 200, x binder, right associativity,
    format "'[' 'exists'  '/  ' x  ..  y ,  '/  ' P ']'")
   : type_scope.
 
-Notation "'exists2' x , P & Q" := (ex2 (fun x => P%%type) (fun x => Q%%type))
+Notation "'exists2' x , P & Q" := (ex2 (fun x => P%type) (fun x => Q%type))
   (at level 200, x name, P at level 200, right associativity) : type_scope.
-Notation "'exists2' x : A , P & Q" := (ex2 (A:=A) (fun x => P%%type) (fun x => Q%%type))
+Notation "'exists2' x : A , P & Q" := (ex2 (A:=A) (fun x => P%type) (fun x => Q%type))
   (at level 200, x name, A at level 200, P at level 200, right associativity,
     format "'[' 'exists2'  '/  ' x  :  A ,  '/  ' '[' P  &  '/' Q ']' ']'")
   : type_scope.
 
-Notation "'exists2' ' x , P & Q" := (ex2 (fun x => P%%type) (fun x => Q%%type))
+Notation "'exists2' ' x , P & Q" := (ex2 (fun x => P%type) (fun x => Q%type))
   (at level 200, x strict pattern, P at level 200, right associativity) : type_scope.
-Notation "'exists2' ' x : A , P & Q" := (ex2 (A:=A) (fun x => P%%type) (fun x => Q%%type))
+Notation "'exists2' ' x : A , P & Q" := (ex2 (A:=A) (fun x => P%type) (fun x => Q%type))
   (at level 200, x strict pattern, A at level 200, P at level 200, right associativity,
     format "'[' 'exists2'  '/  ' ' x  :  A ,  '/  ' '[' P  &  '/' Q ']' ']'")
   : type_scope.
@@ -774,7 +774,7 @@ Definition uniqueness (A:Type) (P:A->Prop) := forall x y, P x -> P y -> x = y.
 (** Unique existence *)
 
 Notation "'exists' ! x .. y , P" :=
-  (ex (unique (fun x => .. (ex (unique (fun y => P%%type))) ..)))
+  (ex (unique (fun x => .. (ex (unique (fun y => P%type))) ..)))
   (at level 200, x binder, right associativity,
    format "'[' 'exists'  !  '/  ' x  ..  y ,  '/  ' P ']'")
   : type_scope.

--- a/theories/Init/Specif.v
+++ b/theories/Init/Specif.v
@@ -59,26 +59,26 @@ Arguments sig2 (A P Q)%type.
 Arguments sigT (A P)%type.
 Arguments sigT2 (A P Q)%type.
 
-Notation "{ x | P }" := (sig (fun x => P%%type)) : type_scope.
-Notation "{ x | P & Q }" := (sig2 (fun x => P%%type) (fun x => Q%%type)) : type_scope.
-Notation "{ x : A | P }" := (sig (A:=A) (fun x => P%%type)) : type_scope.
-Notation "{ x : A | P & Q }" := (sig2 (A:=A) (fun x => P%%type) (fun x => Q%%type)) :
+Notation "{ x | P }" := (sig (fun x => P%type)) : type_scope.
+Notation "{ x | P & Q }" := (sig2 (fun x => P%type) (fun x => Q%type)) : type_scope.
+Notation "{ x : A | P }" := (sig (A:=A) (fun x => P%type)) : type_scope.
+Notation "{ x : A | P & Q }" := (sig2 (A:=A) (fun x => P%type) (fun x => Q%type)) :
   type_scope.
-Notation "{ x & P }" := (sigT (fun x => P%%type)) : type_scope.
-Notation "{ x & P & Q }" := (sigT2 (fun x => P%%type) (fun x => Q%%type)) : type_scope.
-Notation "{ x : A & P }" := (sigT (A:=A) (fun x => P%%type)) : type_scope.
-Notation "{ x : A & P & Q }" := (sigT2 (A:=A) (fun x => P%%type) (fun x => Q%%type)) :
+Notation "{ x & P }" := (sigT (fun x => P%type)) : type_scope.
+Notation "{ x & P & Q }" := (sigT2 (fun x => P%type) (fun x => Q%type)) : type_scope.
+Notation "{ x : A & P }" := (sigT (A:=A) (fun x => P%type)) : type_scope.
+Notation "{ x : A & P & Q }" := (sigT2 (A:=A) (fun x => P%type) (fun x => Q%type)) :
   type_scope.
 
-Notation "{ ' pat | P }" := (sig (fun pat => P%%type)) : type_scope.
-Notation "{ ' pat | P & Q }" := (sig2 (fun pat => P%%type) (fun pat => Q%%type)) : type_scope.
-Notation "{ ' pat : A | P }" := (sig (A:=A) (fun pat => P%%type)) : type_scope.
-Notation "{ ' pat : A | P & Q }" := (sig2 (A:=A) (fun pat => P%%type) (fun pat => Q%%type)) :
+Notation "{ ' pat | P }" := (sig (fun pat => P%type)) : type_scope.
+Notation "{ ' pat | P & Q }" := (sig2 (fun pat => P%type) (fun pat => Q%type)) : type_scope.
+Notation "{ ' pat : A | P }" := (sig (A:=A) (fun pat => P%type)) : type_scope.
+Notation "{ ' pat : A | P & Q }" := (sig2 (A:=A) (fun pat => P%type) (fun pat => Q%type)) :
   type_scope.
-Notation "{ ' pat & P }" := (sigT (fun pat => P%%type)) : type_scope.
-Notation "{ ' pat & P & Q }" := (sigT2 (fun pat => P%%type) (fun pat => Q%%type)) : type_scope.
-Notation "{ ' pat : A & P }" := (sigT (A:=A) (fun pat => P%%type)) : type_scope.
-Notation "{ ' pat : A & P & Q }" := (sigT2 (A:=A) (fun pat => P%%type) (fun pat => Q%%type)) :
+Notation "{ ' pat & P }" := (sigT (fun pat => P%type)) : type_scope.
+Notation "{ ' pat & P & Q }" := (sigT2 (fun pat => P%type) (fun pat => Q%type)) : type_scope.
+Notation "{ ' pat : A & P }" := (sigT (A:=A) (fun pat => P%type)) : type_scope.
+Notation "{ ' pat : A & P & Q }" := (sigT2 (A:=A) (fun pat => P%type) (fun pat => Q%type)) :
   type_scope.
 
 Add Printing Let sig.

--- a/theories/Init/Specif.v
+++ b/theories/Init/Specif.v
@@ -59,26 +59,26 @@ Arguments sig2 (A P Q)%type.
 Arguments sigT (A P)%type.
 Arguments sigT2 (A P Q)%type.
 
-Notation "{ x | P }" := (sig (fun x => P)) : type_scope.
-Notation "{ x | P & Q }" := (sig2 (fun x => P) (fun x => Q)) : type_scope.
-Notation "{ x : A | P }" := (sig (A:=A) (fun x => P)) : type_scope.
-Notation "{ x : A | P & Q }" := (sig2 (A:=A) (fun x => P) (fun x => Q)) :
+Notation "{ x | P }" := (sig (fun x => P%%type)) : type_scope.
+Notation "{ x | P & Q }" := (sig2 (fun x => P%%type) (fun x => Q%%type)) : type_scope.
+Notation "{ x : A | P }" := (sig (A:=A) (fun x => P%%type)) : type_scope.
+Notation "{ x : A | P & Q }" := (sig2 (A:=A) (fun x => P%%type) (fun x => Q%%type)) :
   type_scope.
-Notation "{ x & P }" := (sigT (fun x => P)) : type_scope.
-Notation "{ x & P & Q }" := (sigT2 (fun x => P) (fun x => Q)) : type_scope.
-Notation "{ x : A & P }" := (sigT (A:=A) (fun x => P)) : type_scope.
-Notation "{ x : A & P & Q }" := (sigT2 (A:=A) (fun x => P) (fun x => Q)) :
+Notation "{ x & P }" := (sigT (fun x => P%%type)) : type_scope.
+Notation "{ x & P & Q }" := (sigT2 (fun x => P%%type) (fun x => Q%%type)) : type_scope.
+Notation "{ x : A & P }" := (sigT (A:=A) (fun x => P%%type)) : type_scope.
+Notation "{ x : A & P & Q }" := (sigT2 (A:=A) (fun x => P%%type) (fun x => Q%%type)) :
   type_scope.
 
-Notation "{ ' pat | P }" := (sig (fun pat => P)) : type_scope.
-Notation "{ ' pat | P & Q }" := (sig2 (fun pat => P) (fun pat => Q)) : type_scope.
-Notation "{ ' pat : A | P }" := (sig (A:=A) (fun pat => P)) : type_scope.
-Notation "{ ' pat : A | P & Q }" := (sig2 (A:=A) (fun pat => P) (fun pat => Q)) :
+Notation "{ ' pat | P }" := (sig (fun pat => P%%type)) : type_scope.
+Notation "{ ' pat | P & Q }" := (sig2 (fun pat => P%%type) (fun pat => Q%%type)) : type_scope.
+Notation "{ ' pat : A | P }" := (sig (A:=A) (fun pat => P%%type)) : type_scope.
+Notation "{ ' pat : A | P & Q }" := (sig2 (A:=A) (fun pat => P%%type) (fun pat => Q%%type)) :
   type_scope.
-Notation "{ ' pat & P }" := (sigT (fun pat => P)) : type_scope.
-Notation "{ ' pat & P & Q }" := (sigT2 (fun pat => P) (fun pat => Q)) : type_scope.
-Notation "{ ' pat : A & P }" := (sigT (A:=A) (fun pat => P)) : type_scope.
-Notation "{ ' pat : A & P & Q }" := (sigT2 (A:=A) (fun pat => P) (fun pat => Q)) :
+Notation "{ ' pat & P }" := (sigT (fun pat => P%%type)) : type_scope.
+Notation "{ ' pat & P & Q }" := (sigT2 (fun pat => P%%type) (fun pat => Q%%type)) : type_scope.
+Notation "{ ' pat : A & P }" := (sigT (A:=A) (fun pat => P%%type)) : type_scope.
+Notation "{ ' pat : A & P & Q }" := (sigT2 (A:=A) (fun pat => P%%type) (fun pat => Q%%type)) :
   type_scope.
 
 Add Printing Let sig.

--- a/theories/Numbers/Cyclic/Abstract/NZCyclic.v
+++ b/theories/Numbers/Cyclic/Abstract/NZCyclic.v
@@ -154,7 +154,7 @@ Theorem Zbounded_induction :
   (forall Q : Z -> Prop, forall b : Z,
     Q 0 ->
     (forall n, 0 <= n -> n < b - 1 -> Q n -> Q (n + 1)) ->
-      forall n, 0 <= n -> n < b -> Q n)%Z.
+      forall n, 0 <= n -> n < b -> Q n)%%Z.
 Proof.
 intros Q b Q0 QS.
 set (Q' := fun n => (n < b /\ Q n) \/ (b <= n)).

--- a/theories/Numbers/Cyclic/Int31/Cyclic31.v
+++ b/theories/Numbers/Cyclic/Int31/Cyclic31.v
@@ -715,7 +715,7 @@ Section Basics.
  Qed.
 
  Lemma EqShiftL_incrbis : forall n k x y, n<=size ->
-  (n+k=S size)%nat ->
+  (n+k=S size)%%nat ->
   EqShiftL k x y ->
   EqShiftL k (incrbis_aux n x) (incrbis_aux n y).
  Proof.
@@ -986,7 +986,7 @@ Section Basics.
     [positive_to_int31]. *)
 
  Lemma double_twice_firstl : forall x, firstl x = D0 ->
-  (Twon*x = twice x)%int31.
+  (Twon*x = twice x)%%int31.
  Proof.
  intros.
  unfold mul31.
@@ -994,7 +994,7 @@ Section Basics.
  Qed.
 
  Lemma double_twice_plus_one_firstl : forall x, firstl x = D0 ->
-  (Twon*x+In = twice_plus_one x)%int31.
+  (Twon*x+In = twice_plus_one x)%%int31.
  Proof.
  intros.
  rewrite double_twice_firstl; auto.
@@ -1987,8 +1987,8 @@ Section Int31_Specs.
 
  Lemma sqrt31_step_def rec i j:
    sqrt31_step rec i j =
-   match (fst (i/j) ?= j)%int31 with
-     Lt => rec i (fst ((j + fst(i/j))/2))%int31
+   match (fst (i/j) ?= j)%%int31 with
+     Lt => rec i (fst ((j + fst(i/j))/2))%%int31
    | _ =>  j
    end.
  Proof.
@@ -2090,7 +2090,7 @@ Section Int31_Specs.
        match (fst (div3121 ih il j) ?= j)%int31 with
          Lt => let m := match j +c fst (div3121 ih il j) with
                        C0 m1 => fst (m1/2)%int31
-                     | C1 m1 => (fst (m1/2) + v30)%int31
+                     | C1 m1 => (fst (m1/2) + v30)%%int31
                      end in rec ih il m
        | _ =>  j
        end

--- a/theories/Numbers/Cyclic/Int63/Uint63.v
+++ b/theories/Numbers/Cyclic/Int63/Uint63.v
@@ -677,13 +677,13 @@ Proof.
 Qed.
 
 (* ADD *)
-Lemma add_assoc x y z: (x + (y + z) = (x + y) + z)%uint63.
+Lemma add_assoc x y z: (x + (y + z) = (x + y) + z)%%uint63.
 Proof.
  apply to_Z_inj; rewrite !add_spec.
  rewrite -> Zplus_mod_idemp_l, Zplus_mod_idemp_r, Zplus_assoc; auto.
 Qed.
 
-Lemma add_comm x y: (x + y = y + x)%uint63.
+Lemma add_comm x y: (x + y = y + x)%%uint63.
 Proof.
  apply to_Z_inj; rewrite -> !add_spec, Zplus_comm; auto.
 Qed.
@@ -708,7 +708,7 @@ Proof.
  apply sym_equal; rewrite leb_spec, H1; auto with zarith.
 Qed.
 
-Lemma add_cancel_l x y z : (x + y = x + z)%uint63 -> y = z.
+Lemma add_cancel_l x y z : (x + y = x + z)%%uint63 -> y = z.
 Proof.
   intros h; apply int_eqm in h; rewrite !add_spec in h; apply eqm_mod, eqm_sub in h.
   replace (_ + _ - _) with (φ(y) - φ(z)) in h by lia.
@@ -716,7 +716,7 @@ Proof.
   apply eqmI, h.
 Qed.
 
-Lemma add_cancel_r x y z : (y + x = z + x)%uint63 -> y = z.
+Lemma add_cancel_r x y z : (y + x = z + x)%%uint63 -> y = z.
 Proof.
   rewrite !(fun t => add_comm t x); intros Hl; apply (add_cancel_l x); auto.
 Qed.
@@ -730,12 +730,12 @@ Proof. apply to_Z_inj; rewrite lsr_spec; reflexivity. Qed.
 Lemma lsr_0_r i: i >> 0 = i.
 Proof. apply to_Z_inj; rewrite lsr_spec, Zdiv_1_r; exact eq_refl. Qed.
 
-Lemma lsr_1 n : 1 >> n = (n =? 0)%uint63.
+Lemma lsr_1 n : 1 >> n = (n =? 0)%%uint63.
 Proof.
   case eqbP.
     intros h; rewrite (to_Z_inj _ _ h), lsr_0_r; reflexivity.
  intros Hn.
- assert (H1n : (1 >> n = 0)%uint63); auto.
+ assert (H1n : (1 >> n = 0)%%uint63); auto.
  apply to_Z_inj; rewrite lsr_spec.
  apply Zdiv_small; rewrite to_Z_1; split; auto with zarith.
  change 1%Z with (2^0)%Z.
@@ -745,7 +745,7 @@ Proof.
  lia.
 Qed.
 
-Lemma lsr_add i m n: ((i >> m) >> n = if n <=? m + n then i >> (m + n) else 0)%uint63.
+Lemma lsr_add i m n: ((i >> m) >> n = if n <=? m + n then i >> (m + n) else 0)%%uint63.
 Proof.
  case (to_Z_bounded m); intros H1m H2m.
  case (to_Z_bounded n); intros H1n H2n.
@@ -780,7 +780,7 @@ Proof.
  apply (f_equal2 Zmod); auto with zarith.
 Qed.
 
-Lemma lsr_M_r x i (H: (digits <=? i = true)%uint63) : x >> i = 0%uint63.
+Lemma lsr_M_r x i (H: (digits <=? i = true)%%uint63) : x >> i = 0%uint63.
 Proof.
  apply to_Z_inj.
  rewrite lsr_spec, to_Z_0.
@@ -826,7 +826,7 @@ Proof.
  now case eqbP.
 Qed.
 
-Lemma bit_split i : ( i = (i >> 1 ) << 1 + bit i 0)%uint63.
+Lemma bit_split i : ( i = (i >> 1 ) << 1 + bit i 0)%%uint63.
 Proof.
  apply to_Z_inj.
  rewrite -> add_spec, lsl_spec, lsr_spec, bit_0_spec, Zplus_mod_idemp_l.
@@ -836,7 +836,7 @@ Proof.
 Qed.
 
 Lemma bit_lsr x i j :
- (bit (x >> i) j = if j <=? i + j then bit x (i + j) else false)%uint63.
+ (bit (x >> i) j = if j <=? i + j then bit x (i + j) else false)%%uint63.
 Proof.
   unfold bit; rewrite lsr_add; case (_ ≤? _); auto.
 Qed.
@@ -876,10 +876,10 @@ Proof.
   case bit; discriminate.
 Qed.
 
-Lemma bit_M i n (H: (digits <=? n = true)%uint63): bit i n = false.
+Lemma bit_M i n (H: (digits <=? n = true)%%uint63): bit i n = false.
 Proof. unfold bit; rewrite lsr_M_r; auto. Qed.
 
-Lemma bit_half i n (H: (n <? digits = true)%uint63) : bit (i>>1) n = bit i (n+1).
+Lemma bit_half i n (H: (n <? digits = true)%%uint63) : bit (i>>1) n = bit i (n+1).
 Proof.
  unfold bit.
  rewrite lsr_add.
@@ -915,7 +915,7 @@ Proof.
 Qed.
 
 Lemma bit_lsl x i j : bit (x << i) j =
-(if (j <? i) || (digits <=? j) then false else bit x (j - i))%uint63.
+(if (j <? i) || (digits <=? j) then false else bit x (j - i))%%uint63.
 Proof.
  assert (F1: 1 >= 0) by discriminate.
  case_eq (digits <=? j)%uint63; intros H.

--- a/theories/Numbers/DecimalString.v
+++ b/theories/Numbers/DecimalString.v
@@ -40,7 +40,7 @@ Definition uint_of_char (a:ascii)(d:option uint) :=
     | "9" => Some (D9 d)
     | _ => None
     end
-  end%char.
+  end%%char.
 
 Lemma uint_of_char_spec c d d' :
   uint_of_char c (Some d) = Some d' ->
@@ -53,7 +53,7 @@ Lemma uint_of_char_spec c d d' :
   c = "6" /\ d' = D6 d \/
   c = "7" /\ d' = D7 d \/
   c = "8" /\ d' = D8 d \/
-  c = "9" /\ d' = D9 d)%char.
+  c = "9" /\ d' = D9 d)%%char.
 Proof.
   destruct c as [[|] [|] [|] [|] [|] [|] [|] [|]];
   intros [= <-]; intuition.

--- a/theories/Numbers/HexadecimalString.v
+++ b/theories/Numbers/HexadecimalString.v
@@ -49,7 +49,7 @@ Definition uint_of_char (a:ascii)(d:option uint) :=
     | "f" => Some (Df d)
     | _ => None
     end
-  end%char.
+  end%%char.
 
 Lemma uint_of_char_spec c d d' :
   uint_of_char c (Some d) = Some d' ->
@@ -68,7 +68,7 @@ Lemma uint_of_char_spec c d d' :
   c = "c" /\ d' = Dc d \/
   c = "d" /\ d' = Dd d \/
   c = "e" /\ d' = De d \/
-  c = "f" /\ d' = Df d)%char.
+  c = "f" /\ d' = Df d)%%char.
 Proof.
   destruct c as [[|] [|] [|] [|] [|] [|] [|] [|]];
   intros [= <-]; intuition.

--- a/theories/PArith/BinPos.v
+++ b/theories/PArith/BinPos.v
@@ -1484,7 +1484,7 @@ Qed.
 Lemma size_nat_monotone p q : p<q -> (size_nat p <= size_nat q)%nat.
 Proof.
   assert (le0 : forall n, (0<=n)%nat) by (intro n; induction n; auto).
-  assert (leS : forall n m, (n<=m -> S n <= S m)%nat) by (induction 1; auto).
+  assert (leS : forall n m, (n<=m -> S n <= S m)%%nat) by (induction 1; auto).
   revert q.
   induction p as [p IHp|p IHp|]; intro q; destruct q as [q|q|];
    simpl; intros H; auto; easy || apply leS;

--- a/theories/QArith/Qpower.v
+++ b/theories/QArith/Qpower.v
@@ -126,7 +126,7 @@ Notation Qpower_decomp := Qpower_decomp_positive (only parsing).
 
 (** ** Values of Qpower for specific arguments *)
 
-Lemma Qpower_0 : forall n, (n<>0)%Z -> 0^n == 0.
+Lemma Qpower_0 : forall n, (n<>0)%%Z -> 0^n == 0.
 Proof.
   intros [|n|n] Hn; try (elim Hn; reflexivity); simpl;
   rewrite Qpower_positive_0; reflexivity.
@@ -256,7 +256,7 @@ case Pos.compare_spec; intros H0; simpl; subst;
  assumption.
 Qed.
 
-Lemma Qpower_plus' : forall a n m, (n+m <> 0)%Z -> a^(n+m) == a^n*a^m.
+Lemma Qpower_plus' : forall a n m, (n+m <> 0)%%Z -> a^(n+m) == a^n*a^m.
 Proof.
 intros a n m H.
 destruct (Qeq_dec a 0)as [X|X].

--- a/theories/Reals/Abstract/ConstructiveLUB.v
+++ b/theories/Reals/Abstract/ConstructiveLUB.v
@@ -167,7 +167,7 @@ Qed.
 Record DedekindDecCut : Type :=
   {
     DDupcut : Q -> Prop;
-    DDproper : forall q r : Q, (q == r -> DDupcut q -> DDupcut r)%Q;
+    DDproper : forall q r : Q, (q == r -> DDupcut q -> DDupcut r)%%Q;
     DDlow : Q;
     DDhigh : Q;
     DDdec : forall q:Q, { DDupcut q } + { ~DDupcut q };

--- a/theories/Reals/Abstract/ConstructiveLimits.v
+++ b/theories/Reals/Abstract/ConstructiveLimits.v
@@ -95,7 +95,7 @@ Proof.
   { apply (CR_cv_extens (fun n => CRminus R (xn n) (xn n))).
     intro n. unfold CRminus. apply CRplus_opp_r.
     apply CR_cv_plus. exact H0. apply CR_cv_opp, H. }
-  assert (forall q r : Q, 0 < q -> / q < r -> 1 < q * r)%Q.
+  assert (forall q r : Q, 0 < q -> / q < r -> 1 < q * r)%%Q.
   { intros. apply (Qmult_lt_l _ _ q) in H3.
     rewrite Qmult_inv_r in H3. exact H3. intro abs.
     rewrite abs in H2. exact (Qlt_irrefl 0 H2). exact H2. }

--- a/theories/Reals/Cauchy/ConstructiveCauchyRealsMult.v
+++ b/theories/Reals/Cauchy/ConstructiveCauchyRealsMult.v
@@ -98,7 +98,7 @@ Proof.
   intros x y n p q Hp Hq.
   unfold CReal_mult_seq.
 
-  assert(forall xp xq yp yq : Q, xp * yp - xq * yq == (xp - xq) * yp + xq * (yp - yq))%Q
+  assert(forall xp xq yp yq : Q, xp * yp - xq * yq == (xp - xq) * yp + xq * (yp - yq))%%Q
     as H by (intros; ring).
   rewrite H; clear H.
 
@@ -282,10 +282,10 @@ Proof.
     Qabs (
       seq x (n - Z.max (scale y') (scale z') - 2) * seq y' (n - scale x - 2)
     - seq x (n - scale y' - 2) * seq y' (n - scale x - 2))
-  <= 2 ^ n )%Q as Hdiffbnd.
+  <= 2 ^ n )%%Q as Hdiffbnd.
   {
     intros y' z'.
-    assert (forall a b c : Q, a*c-b*c==(a-b)*c)%Q as H by (intros; ring).
+    assert (forall a b c : Q, a*c-b*c==(a-b)*c)%%Q as H by (intros; ring).
     rewrite H; clear H.
     pose proof cauchy x (n - (scale y') - 2)%Z (n - Z.max (scale y') (scale z') - 2)%Z (n - scale y' - 2)%Z
       ltac:(lia) ltac:(lia) as Hxbnd.
@@ -356,7 +356,7 @@ Proof.
 
   (* Rearrange the goal such that it used only scale and cauchy bounds *)
   (* Todo: it is also a bug in ring_simplify that the seq terms are not sorted by the first variable *)
-  assert (forall a1 a2 b c1 c2 : Q, a1*b*c1+(-1)*b*a2*c2==(a1*c1-a2*c2)*b)%Q as H by (intros; ring).
+  assert (forall a1 a2 b c1 c2 : Q, a1*b*c1+(-1)*b*a2*c2==(a1*c1-a2*c2)*b)%%Q as H by (intros; ring).
   rewrite H; clear H.
   remember (seq x (n - scale y - scale z - 1) - seq x (n - scale y - scale z - 2))%Q as dx eqn:Heqdx.
   remember (seq z (n - scale x - scale y - 1) - seq z (n - scale x - scale y - 2))%Q as dz eqn:Heqdz.
@@ -672,14 +672,14 @@ Proof.
   unfold CReal_inv_pos_cm; remember (CRealLowerBound x Hxpos) as k.
 
   (* These auxilliary lemmas are required a few times below *)
-  assert (forall m:Z, (2^k < seq x (Z.min k (m + 2 * k))))%Q as AuxAppart.
+  assert (forall m:Z, (2^k < seq x (Z.min k (m + 2 * k))))%%Q as AuxAppart.
   {
     intros m.
     pose proof CRealLowerBoundSpec x Hxpos (Z.min k (m + 2 * k))%Z ltac:(lia) as H1.
     rewrite Heqk at 1.
     lra.
   }
-  assert (forall m:Z, (0 < seq x (Z.min k (m + 2 * k))))%Q as AuxPos.
+  assert (forall m:Z, (0 < seq x (Z.min k (m + 2 * k))))%%Q as AuxPos.
   {
     intros m.
     pose proof AuxAppart m as H1.

--- a/theories/Reals/Cauchy/ConstructiveRcomplete.v
+++ b/theories/Reals/Cauchy/ConstructiveRcomplete.v
@@ -481,7 +481,7 @@ Proof.
 Qed.
 
 Lemma Qabs_Qgt_condition: forall x y : Q,
-  (x < Qabs y)%Q <-> (x < y \/ x < -y)%Q.
+  (x < Qabs y)%Q <-> (x < y \/ x < -y)%%Q.
 Proof.
  intros x y.
  apply Qabs_case; lra.
@@ -593,7 +593,7 @@ Proof.
   apply CReal_plus_le_compat.
   2: { apply (CReal_le_trans _ _ _ H). apply inject_Q_le.
        rewrite Qpower_minus_pos.
-       assert(forall (n:Z) (p q : positive), n#(p*q) == (n#p) * (1#q))%Q as Aux
+       assert(forall (n:Z) (p q : positive), n#(p*q) == (n#p) * (1#q))%%Q as Aux
          by ( intros; unfold Qeq, Qmult, Qnum, Qden; ring ); rewrite Aux; clear Aux.
        rewrite Qmult_comm; apply Qmult_le_l; [lra|].
        pose proof Qpower_2powneg_le_inv p.
@@ -627,7 +627,7 @@ Proof.
     change (Z.neg (p + 1))%Z with (Z.neg p - 1)%Z.
     ring_simplify (Z.neg p - 1 - 2)%Z.
     rewrite Qpower_minus_pos.
-    assert(forall (n:Z) (p q : positive), n#(p*q) == (n#p) * (1#q))%Q as Aux
+    assert(forall (n:Z) (p q : positive), n#(p*q) == (n#p) * (1#q))%%Q as Aux
       by ( intros; unfold Qeq, Qmult, Qnum, Qden; ring ); rewrite Aux; clear Aux.
     pose proof Qpower_2powneg_le_inv p.
     pose proof Qpower_0_lt 2 (Z.neg p)%Z; lra.
@@ -696,7 +696,7 @@ Lemma CRealLtDisjunctEpsilon : forall a b c d : CReal,
 Proof.
   intros.
   (* Combine both existentials into one *)
-  assert (exists n : Z, 2*2^n < seq b n - seq a n \/ 2*2^n < seq d n - seq c n)%Q.
+  assert (exists n : Z, 2*2^n < seq b n - seq a n \/ 2*2^n < seq d n - seq c n)%%Q.
   { destruct H.
     - destruct H as [n maj]. exists n. left. apply maj.
     - destruct H as [n maj]. exists n. right. apply maj. }

--- a/theories/Reals/Cauchy/PosExtra.v
+++ b/theories/Reals/Cauchy/PosExtra.v
@@ -3,10 +3,10 @@ Require Import ZArith.
 Require Import Lia.
 
 Lemma Pos_pow_1_r: forall p : positive,
-  (1^p = 1)%positive.
+  (1^p = 1)%%positive.
 Proof.
   intros p.
-  assert (forall q:positive, Pos.iter id 1 q = 1)%positive as H1.
+  assert (forall q:positive, Pos.iter id 1 q = 1)%%positive as H1.
   { intros q; apply Pos.iter_invariant; tauto. }
   induction p.
   - cbn; rewrite IHp, H1; reflexivity.

--- a/theories/Reals/Ratan.v
+++ b/theories/Reals/Ratan.v
@@ -134,7 +134,7 @@ intros [ | N] Npos n decr to0 cv nN.
    unfold tg_alt at 2; rewrite pow_1_odd; lra.
  rewrite Nodd; destruct (alternated_series_ineq _ _ p decr to0 cv) as [B _].
  destruct (alternated_series_ineq _ _ (S p) decr to0 cv) as [_ C].
- assert (keep : (2 * S p = S (S ( 2 * p)))%nat) by ring.
+ assert (keep : (2 * S p = S (S ( 2 * p)))%%nat) by ring.
  case (even_odd_cor n) as [p' [neven | nodd]].
    rewrite neven;
    destruct (alternated_series_ineq _ _ p' decr to0 cv) as [D E].

--- a/theories/Reals/Rfunctions.v
+++ b/theories/Reals/Rfunctions.v
@@ -722,7 +722,7 @@ Proof.
     now rewrite <- Pos2Z.opp_pos, <- positive_nat_Z.
 Qed.
 
-Lemma powerRZ_inv x alpha : (x <> 0)%R -> powerRZ (/ x) alpha = Rinv (powerRZ x alpha).
+Lemma powerRZ_inv x alpha : (x <> 0)%%R -> powerRZ (/ x) alpha = Rinv (powerRZ x alpha).
 Proof.
   intros; destruct (intP alpha).
   - now simpl; rewrite Rinv_1.
@@ -744,8 +744,8 @@ Proof.
 Qed.
 
 Lemma powerRZ_mult_distr :
-  forall m x y, ((0 <= m)%Z \/ (x * y <> 0)%R) ->
-           (powerRZ (x*y) m = powerRZ x m * powerRZ y m)%R.
+  forall m x y, ((0 <= m)%Z \/ (x * y <> 0)%%R) ->
+           (powerRZ (x*y) m = powerRZ x m * powerRZ y m)%%R.
 Proof.
   intros m x0 y0 Hmxy.
   destruct (intP m) as [ | | n Hm ].
@@ -755,8 +755,8 @@ Proof.
     + assert(m = 0) as -> by
       (destruct n; [assumption| subst; simpl in H; lia_contr]).
       now rewrite <- Hm, Rmult_1_l.
-    + assert(x0 <> 0)%R by now intros ->; apply H; rewrite Rmult_0_l.
-      assert(y0 <> 0)%R by now intros ->; apply H; rewrite Rmult_0_r.
+    + assert(x0 <> 0)%%R by now intros ->; apply H; rewrite Rmult_0_l.
+      assert(y0 <> 0)%%R by now intros ->; apply H; rewrite Rmult_0_r.
       rewrite !powerRZ_neg by assumption.
       rewrite Rinv_mult_distr by assumption.
       now rewrite <- !pow_powerRZ, Rpow_mult_distr.

--- a/theories/Reals/Rlogic.v
+++ b/theories/Reals/Rlogic.v
@@ -29,7 +29,7 @@ Hypothesis HP : forall n, {P n} + {~P n}.
 
 Lemma sig_forall_dec : {n | ~P n} + {forall n, P n}.
 Proof.
-assert (Hi: (forall n, 0 < INR n + 1)%R).
+assert (Hi: (forall n, 0 < INR n + 1)%%R).
   intros n.
   apply Rle_lt_0_plus_1, pos_INR.
 set (u n := (if HP n then 0 else / (INR n + 1))%R).
@@ -71,12 +71,12 @@ assert (H1l: (1 <= /l)%R).
   apply Rinv_le_contravar with (1 := Hl).
   apply lub.
   now intros y [m ->].
-assert (HN: (INR N + 1 = IZR (up (/ l)) - 1)%R).
+assert (HN: (INR N + 1 = IZR (up (/ l)) - 1)%%R).
   unfold N.
   rewrite INR_IZR_INZ.
   rewrite inj_Zabs_nat.
   replace (IZR (up (/ l)) - 1)%R with (IZR (up (/ l) - 2) + 1)%R.
-  apply (f_equal (fun v => IZR v + 1)%R).
+  apply (f_equal (fun v => IZR v + 1)%%R).
   apply Z.abs_eq.
   apply Zle_minus_le_0.
   apply (Zlt_le_succ 1).

--- a/theories/Reals/Rseries.v
+++ b/theories/Reals/Rseries.v
@@ -398,7 +398,7 @@ Qed.
 Lemma CV_shift : 
   forall f k l, Un_cv (fun n => f (n + k)%nat) l -> Un_cv f l.
 intros f' k l cvfk eps ep; destruct (cvfk eps ep) as [N Pn].
-exists (N + k)%nat; intros n nN; assert (tmp: (n = (n - k) + k)%nat).
+exists (N + k)%nat; intros n nN; assert (tmp: (n = (n - k) + k)%%nat).
  rewrite Nat.sub_add;[ | apply le_trans with (N + k)%nat]; auto with arith.
 rewrite tmp; apply Pn; apply Nat.le_add_le_sub_r; assumption.
 Qed.

--- a/theories/Strings/BinaryString.v
+++ b/theories/Strings/BinaryString.v
@@ -20,7 +20,7 @@ Local Open Scope string_scope.
 Definition ascii_to_digit (ch : ascii) : option N
   := (if ascii_dec ch "0" then Some 0
       else if ascii_dec ch "1" then Some 1
-      else None)%N.
+      else None)%%N.
 
 Fixpoint pos_bin_app (p q:positive) : positive :=
   match q with

--- a/theories/Strings/HexString.v
+++ b/theories/Strings/HexString.v
@@ -36,7 +36,7 @@ Definition ascii_to_digit (ch : ascii) : option N
       else if ascii_dec ch "d" || ascii_dec ch "D" then Some 13
       else if ascii_dec ch "e" || ascii_dec ch "E" then Some 14
       else if ascii_dec ch "f" || ascii_dec ch "F" then Some 15
-      else None)%N.
+      else None)%%N.
 
 Fixpoint pos_hex_app (p q:positive) : positive :=
   match q with

--- a/theories/Strings/OctalString.v
+++ b/theories/Strings/OctalString.v
@@ -26,7 +26,7 @@ Definition ascii_to_digit (ch : ascii) : option N
       else if ascii_dec ch "5" then Some 5
       else if ascii_dec ch "6" then Some 6
       else if ascii_dec ch "7" then Some 7
-      else None)%N.
+      else None)%%N.
 
 Fixpoint pos_oct_app (p q:positive) : positive :=
   match q with

--- a/theories/Structures/OrdersEx.v
+++ b/theories/Structures/OrdersEx.v
@@ -49,7 +49,7 @@ Module PairOrderedType(O1 O2:OrderedType) <: OrderedType.
  Include PairDecidableType O1 O2.
 
  Definition lt :=
-   (relation_disjunction (O1.lt @@1) (O1.eq * O2.lt))%signature.
+   (relation_disjunction (O1.lt @@1) (O1.eq * O2.lt))%%signature.
 
 #[global]
  Instance lt_strorder : StrictOrder lt.

--- a/theories/ZArith/BinInt.v
+++ b/theories/ZArith/BinInt.v
@@ -140,7 +140,7 @@ Lemma pos_sub_discr p q :
   | Z0 => p = q
   | pos k => p = q + k
   | neg k => q = p + k
-  end%positive.
+  end%%positive.
 Proof.
  rewrite pos_sub_spec.
  case Pos.compare_spec; auto; intros;
@@ -230,7 +230,7 @@ Proof.
    now rewrite H, Pos.add_sub.
  - (* q < r *)
    rewrite pos_sub_spec.
-   assert (Hr : (r = (r-q)+q)%positive) by (now rewrite Pos.sub_add).
+   assert (Hr : (r = (r-q)+q)%%positive) by (now rewrite Pos.sub_add).
    rewrite Hr at 1. rewrite Pos.add_compare_mono_r.
    case Pos.compare_spec; intros E1; trivial; f_equal.
    rewrite Pos.add_comm. apply Pos.sub_add_distr.

--- a/theories/ZArith/BinIntDef.v
+++ b/theories/ZArith/BinIntDef.v
@@ -75,7 +75,7 @@ Fixpoint pos_sub (x y:positive) {struct y} : Z :=
     | 1, q~1 => neg q~0
     | 1, q~0 => neg (Pos.pred_double q)
     | 1, 1 => Z0
-  end%positive.
+  end%%positive.
 
 (** ** Addition *)
 

--- a/theories/micromega/RMicromega.v
+++ b/theories/micromega/RMicromega.v
@@ -313,7 +313,7 @@ Proof.
     destruct DEF ; auto with arith.
 Qed.
 
-Lemma Qpower0 : forall z, (z <> 0)%Z -> (0 ^ z == 0)%Q.
+Lemma Qpower0 : forall z, (z <> 0)%%Z -> (0 ^ z == 0)%Q.
 Proof.
   unfold Qpower.
   destruct z;intros.

--- a/theories/micromega/ZMicromega.v
+++ b/theories/micromega/ZMicromega.v
@@ -979,7 +979,7 @@ Section MaxVar.
   Lemma max_var_nformulae_mono_aux :
     forall l v acc,
       (v <= acc ->
-       v <= fold_left F l acc)%positive.
+       v <= fold_left F l acc)%%positive.
   Proof.
     intros l; induction l as [|a l IHl] ; simpl ; [easy|].
     intros.
@@ -992,7 +992,7 @@ Section MaxVar.
   Lemma max_var_nformulae_mono_aux' :
     forall l acc acc',
       (acc <= acc' ->
-       fold_left F l acc <= fold_left F l acc')%positive.
+       fold_left F l acc <= fold_left F l acc')%%positive.
   Proof.
     intros l; induction l as [|a l IHl]; simpl ; [easy|].
     intros.
@@ -1005,7 +1005,7 @@ Section MaxVar.
 
 
   Lemma max_var_nformulae_correct_aux : forall l p o v,
-      In (p,o) l -> In v (vars xH p) -> Pos.le v (fold_left F l 1)%positive.
+      In (p,o) l -> In v (vars xH p) -> Pos.le v (fold_left F l 1)%%positive.
   Proof.
   intros l p o v H H0.
   generalize 1%positive as acc.
@@ -1395,7 +1395,7 @@ Qed.
 
 
 Lemma max_var_acc : forall p i j,
-    (max_var (i + j) p = max_var i p + j)%positive.
+    (max_var (i + j) p = max_var i p + j)%%positive.
 Proof.
   intros p; induction p as [|? ? IHp|? IHp1 ? ? IHp2]; simpl.
   - reflexivity.

--- a/theories/micromega/ZifySint63.v
+++ b/theories/micromega/ZifySint63.v
@@ -9,7 +9,7 @@ Proof. now apply to_Z_bounded. Qed.
 
 #[global]
 Instance Inj_int_Z : InjTyp int Z :=
-  mkinj _ _ to_Z (fun x => -4611686018427387904 <= x <= 4611686018427387903)%Z
+  mkinj _ _ to_Z (fun x => -4611686018427387904 <= x <= 4611686018427387903)%%Z
     to_Z_bounded.
 Add Zify InjTyp Inj_int_Z.
 
@@ -131,7 +131,7 @@ Add Zify BinOp Op_mod.
 
 #[global]
 Instance Op_asr : BinOp asr :=
-  {| TBOp := fun x y => x / 2^ y ; TBOpInj := asr_spec |}%Z.
+  {| TBOp := fun x y => x / 2^ y ; TBOpInj := asr_spec |}%%Z.
 Add Zify BinOp Op_asr.
 
 Definition quots (x d : Z) : Z :=
@@ -159,7 +159,7 @@ Add Zify BinOp Op_div.
 
 Lemma quots_spec (x y : Z) :
   ((x = -4611686018427387904 /\ y = -1 /\ quots x y = -4611686018427387904)
-  \/ ((x <> -4611686018427387904 \/ y <> -1) /\ quots x y = Z.quot x y))%Z.
+  \/ ((x <> -4611686018427387904 \/ y <> -1) /\ quots x y = Z.quot x y))%%Z.
 Proof.
   unfold quots; case andb eqn: eq_min_m1.
   - now left; rewrite Bool.andb_true_iff, !Z.eqb_eq in eq_min_m1.
@@ -170,7 +170,7 @@ Qed.
 Instance quotsSpec : BinOpSpec quots :=
   {| BPred := fun x d r : Z =>
        ((x = -4611686018427387904 /\ d = -1 /\ r = -4611686018427387904)
-       \/ ((x <> -4611686018427387904 \/ d <> -1) /\ r = Z.quot x d))%Z;
+       \/ ((x <> -4611686018427387904 \/ d <> -1) /\ r = Z.quot x d))%%Z;
      BSpec := quots_spec |}.
 Add Zify BinOpSpec quotsSpec.
 

--- a/theories/micromega/ZifyUint63.v
+++ b/theories/micromega/ZifyUint63.v
@@ -8,7 +8,7 @@ Proof. apply to_Z_bounded. Qed.
 
 #[global]
 Instance Inj_int_Z : InjTyp int Z :=
-  mkinj _ _ to_Z (fun x => 0 <= x < 9223372036854775808)%Z to_Z_bounded.
+  mkinj _ _ to_Z (fun x => 0 <= x < 9223372036854775808)%%Z to_Z_bounded.
 Add Zify InjTyp Inj_int_Z.
 
 #[global]
@@ -72,7 +72,7 @@ Instance Op_eqb : BinOp eqb :=
   {| TBOp := Z.eqb; TBOpInj := eqb_eq |}.
 Add Zify BinOp Op_eqb.
 
-Lemma eq_int_inj : forall  n m : int, n = m <-> (φ  n = φ m)%uint63.
+Lemma eq_int_inj : forall  n m : int, n = m <-> (φ  n = φ m)%%uint63.
 Proof.
   split; intro H.
   rewrite H ; reflexivity.
@@ -86,37 +86,37 @@ Add Zify BinRel Op_eq.
 
 #[global]
 Instance Op_add : BinOp add :=
-  {| TBOp := fun x y => (x + y) mod 9223372036854775808%Z; TBOpInj := add_spec |}%Z.
+  {| TBOp := fun x y => (x + y) mod 9223372036854775808%Z; TBOpInj := add_spec |}%%Z.
 Add Zify BinOp Op_add.
 
 #[global]
 Instance Op_sub : BinOp sub :=
-  {| TBOp := fun x y => (x - y) mod 9223372036854775808%Z; TBOpInj := sub_spec |}%Z.
+  {| TBOp := fun x y => (x - y) mod 9223372036854775808%Z; TBOpInj := sub_spec |}%%Z.
 Add Zify BinOp Op_sub.
 
 #[global]
 Instance Op_opp : UnOp Uint63.opp :=
-  {| TUOp := (fun x => (- x) mod 9223372036854775808)%Z; TUOpInj := (sub_spec 0) |}%Z.
+  {| TUOp := (fun x => (- x) mod 9223372036854775808)%Z; TUOpInj := (sub_spec 0) |}%%Z.
 Add Zify UnOp Op_opp.
 
 #[global]
 Instance Op_oppcarry : UnOp oppcarry :=
-  {| TUOp := (fun x => 2^63 -  x - 1)%Z; TUOpInj := oppcarry_spec |}%Z.
+  {| TUOp := (fun x => 2^63 -  x - 1)%Z; TUOpInj := oppcarry_spec |}%%Z.
 Add Zify UnOp Op_oppcarry.
 
 #[global]
 Instance Op_succ : UnOp succ :=
-  {| TUOp := (fun x => (x + 1) mod 2^63)%Z; TUOpInj := succ_spec |}%Z.
+  {| TUOp := (fun x => (x + 1) mod 2^63)%Z; TUOpInj := succ_spec |}%%Z.
 Add Zify UnOp Op_succ.
 
 #[global]
 Instance Op_pred : UnOp Uint63.pred :=
-  {| TUOp := (fun x => (x - 1) mod 2^63)%Z; TUOpInj := pred_spec |}%Z.
+  {| TUOp := (fun x => (x - 1) mod 2^63)%Z; TUOpInj := pred_spec |}%%Z.
 Add Zify UnOp Op_pred.
 
 #[global]
 Instance Op_mul : BinOp mul :=
-  {| TBOp := fun x y => (x * y) mod 9223372036854775808%Z; TBOpInj := mul_spec |}%Z.
+  {| TBOp := fun x y => (x * y) mod 9223372036854775808%Z; TBOpInj := mul_spec |}%%Z.
 Add Zify BinOp Op_mul.
 
 #[global]
@@ -131,22 +131,22 @@ Add Zify BinOp Op_mod.
 
 #[global]
 Instance Op_subcarry : BinOp subcarry :=
-  {| TBOp := (fun x y => (x - y - 1) mod 2^63)%Z ; TBOpInj := subcarry_spec |}.
+  {| TBOp := (fun x y => (x - y - 1) mod 2^63)%%Z ; TBOpInj := subcarry_spec |}.
 Add Zify BinOp Op_subcarry.
 
 #[global]
 Instance Op_addcarry : BinOp addcarry :=
-  {| TBOp := (fun x y => (x + y + 1) mod 2^63)%Z ; TBOpInj := addcarry_spec |}.
+  {| TBOp := (fun x y => (x + y + 1) mod 2^63)%%Z ; TBOpInj := addcarry_spec |}.
 Add Zify BinOp Op_addcarry.
 
 #[global]
 Instance Op_lsr : BinOp lsr :=
-  {| TBOp := (fun x y => x / 2^ y)%Z ; TBOpInj := lsr_spec |}.
+  {| TBOp := (fun x y => x / 2^ y)%%Z ; TBOpInj := lsr_spec |}.
 Add Zify BinOp Op_lsr.
 
 #[global]
 Instance Op_lsl : BinOp lsl :=
-  {| TBOp := (fun x y => (x  * 2^ y) mod 2^ 63)%Z ; TBOpInj := lsl_spec |}.
+  {| TBOp := (fun x y => (x  * 2^ y) mod 2^ 63)%%Z ; TBOpInj := lsl_spec |}.
 Add Zify BinOp Op_lsl.
 
 #[global]
@@ -176,7 +176,7 @@ Add Zify BinOp Op_bit.
 
 #[global]
 Instance Op_of_Z : UnOp of_Z :=
-  { TUOp := (fun x => x mod 9223372036854775808)%Z; TUOpInj := of_Z_spec }.
+  { TUOp := (fun x => x mod 9223372036854775808)%%Z; TUOpInj := of_Z_spec }.
 Add Zify UnOp Op_of_Z.
 
 #[global]

--- a/theories/setoid_ring/Field_theory.v
+++ b/theories/setoid_ring/Field_theory.v
@@ -568,7 +568,7 @@ Fixpoint PExpr_eq (e e' : PExpr C) {struct e} : bool :=
   | - e, - e' => PExpr_eq e e'
   | e ^ n, e' ^ n' => N.eqb n n' &&& PExpr_eq e e'
   | _, _ => false
- end%poly.
+ end%%poly.
 
 Lemma if_true (a b : bool) : a &&& b = true -> a = true /\ b = true.
 Proof.
@@ -681,7 +681,7 @@ Fixpoint NPEmul (x y : PExpr C) {struct x} : PExpr C :=
   | _, PEc c => if (c =? 1)%coef then x else if (c =? 0)%coef then 0 else x * y
   | e1 ^ n1, e2 ^ n2 => if (n1 =? n2)%N then (NPEmul e1 e2)^^n1 else x * y
   | _, _ => x * y
-  end%poly.
+  end%%poly.
 Infix "**" := NPEmul (at level 40, left associativity).
 
 Theorem NPEmul_ok e1 e2 : (e1 ** e2 === e1 * e2)%poly.
@@ -707,7 +707,7 @@ Fixpoint PEsimp (e : PExpr C) : PExpr C :=
   | - e1 => NPEopp (PEsimp e1)
   | e1 ^ n1 => (PEsimp e1) ^^ n1
   | _ => e
- end%poly.
+ end%%poly.
 
 Theorem PEsimp_ok e : (PEsimp e === e)%poly.
 Proof.
@@ -854,7 +854,7 @@ Fixpoint isIn e1 p1 e2 p2 {struct e2}: option (N * PExpr C) :=
   | e3 ^ N0 => None
   | e3 ^ Npos p3 => isIn e1 p1 e3 (Pos.mul p3 p2)
   | _ => default_isIn e1 p1 e2 p2
-   end%poly.
+   end%%poly.
 
  Definition ZtoN z := match z with Zpos p => Npos p | _ => N0 end.
  Definition NtoZ n := match n with Npos p => Zpos p | _ => Z0 end.
@@ -972,7 +972,7 @@ Fixpoint split_aux e1 p e2 {struct e1}: rsplit :=
        | Some (Npos q, e3) => mk_rsplit (e1 ^^ Npos q) (e1 ^^ Npos (p - q)) e3
        | None => mk_rsplit (e1 ^^ Npos p) 1 e2
        end
-  end%poly.
+  end%%poly.
 
 Lemma split_aux_ok1 e1 p e2 :
   (let res := match isIn e1 p e2 1 with
@@ -982,7 +982,7 @@ Lemma split_aux_ok1 e1 p e2 :
        end
   in
   e1 ^ Npos p === left res * common res
-  /\ e2 === right res * common res)%poly.
+  /\ e2 === right res * common res)%%poly.
 Proof.
  Opaque NPEpow NPEmul.
  intros res. unfold res;clear res; generalize (isIn_ok e1 p e2 xH).
@@ -1000,7 +1000,7 @@ Qed.
 
 Theorem split_aux_ok: forall e1 p e2,
   (e1 ^ Npos p === left (split_aux e1 p e2) * common (split_aux e1 p e2)
-  /\ e2 === right (split_aux e1 p e2) * common (split_aux e1 p e2))%poly.
+  /\ e2 === right (split_aux e1 p e2) * common (split_aux e1 p e2))%%poly.
 Proof.
 intro e1;induction e1 as [| |?|?|? IHe1_1 ? IHe1_2|? IHe1_1 ? IHe1_2|e1_1 IHe1_1 ? IHe1_2|? IHe1|? IHe1 n];
  intros k e2; try refine (split_aux_ok1 _ k e2);simpl.
@@ -1018,13 +1018,13 @@ Qed.
 Definition split e1 e2 := split_aux e1 xH e2.
 
 Theorem split_ok_l e1 e2 :
-  (e1 === left (split e1 e2) * common (split e1 e2))%poly.
+  (e1 === left (split e1 e2) * common (split e1 e2))%%poly.
 Proof.
 destruct (split_aux_ok e1 xH e2) as (H,_). now rewrite <- H, PEpow_1_r.
 Qed.
 
 Theorem split_ok_r e1 e2 :
-  (e2 === right (split e1 e2) * common (split e1 e2))%poly.
+  (e2 === right (split e1 e2) * common (split e1 e2))%%poly.
 Proof.
 destruct (split_aux_ok e1 xH e2) as (_,H). trivial.
 Qed.

--- a/theories/ssr/ssrfun.v
+++ b/theories/ssr/ssrfun.v
@@ -516,7 +516,7 @@ Arguments Tagged2 [I i].
 Prenex Implicits tag tagged Tagged tag2 tagged2 tagged2' Tagged2.
 
 Coercion tag_of_tag2 I T_ U_ (w : @sigT2 I T_ U_) :=
-  Tagged (fun i => T_ i * U_ i)%type (tagged2 w, tagged2' w).
+  Tagged (fun i => (T_ i * U_ i)%type) (tagged2 w, tagged2' w).
 
 Lemma all_tag I T U :
    (forall x : I, {y : T x & U x y}) ->

--- a/user-contrib/Ltac2/tac2quote.ml
+++ b/user-contrib/Ltac2/tac2quote.ml
@@ -106,7 +106,7 @@ let quote_constr ?delimiters c =
   let loc = Constrexpr_ops.constr_loc c in
   Option.cata
     (List.fold_left (fun c d ->
-          CAst.make ?loc @@ Constrexpr.CDelimiters(Id.to_string d, c))
+          CAst.make ?loc @@ Constrexpr.(CDelimiters(DelimUnboundedScope, Id.to_string d, c))) (* ?? *)
         c)
     c delimiters
 


### PR DESCRIPTION
**Kind:** feature

This adds a syntax `term%%scope` to tell to activate scope `scope` only for the immediate subterm. This allows for instance do define notations which activate `type_scope` only temporarily as in:
```
Notation "{ x  |  P }" := (sig (fun x => P%%type)) : type_scope.
Check fun P Q => { x : nat & P x * Q x }.
```

Note: We may want this to apply also to `Arguments`. Unfortunately, in `Arguments`, `%` has already the meaning of this new `%%`. I don't know what transition path could be adopted to eventually have the effect of `%` in terms and in `Arguments` matches.

<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [ ] Added / updated test-suite
<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [ ] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [ ] Entry added in CHANGES.md.
