### PR TITLE
Remove leftover code that used to handle ml4 files.

### DIFF
--- a/lib/coqProject_file.ml
+++ b/lib/coqProject_file.ml
@@ -24,7 +24,6 @@ type project = {
 
   v_files : string sourced list;
   mli_files : string sourced list;
-  ml4_files : string sourced list;
   mlg_files : string sourced list;
   ml_files : string sourced list;
   mllib_files : string sourced list;
@@ -62,7 +61,6 @@ let mk_project project_file makefile install_kind use_ocamlopt = {
 
   v_files = [];
   mli_files = [];
-  ml4_files = [];
   mlg_files = [];
   ml_files = [];
   mllib_files = [];
@@ -220,7 +218,9 @@ let process_cmd_line ~warning_fn orig_dir proj args =
           | ".v" ->
             { proj with v_files = proj.v_files @ [sourced f] }
         | ".ml" -> { proj with ml_files = proj.ml_files @ [sourced f] }
-        | ".ml4" -> { proj with ml4_files = proj.ml4_files @ [sourced f] }
+        | ".ml4" ->
+          let msg = Printf.sprintf "camlp5 macro files not supported anymore, please port %s to coqpp" f in
+          raise (Parsing_error msg)
         | ".mlg" -> { proj with mlg_files = proj.mlg_files @ [sourced f] }
         | ".mli" -> { proj with mli_files = proj.mli_files @ [sourced f] }
         | ".mllib" -> { proj with mllib_files = proj.mllib_files @ [sourced f] }
@@ -248,9 +248,9 @@ let rec find_project_file ~from ~projfile_name =
     else find_project_file ~from:newdir ~projfile_name
 ;;
 
-let all_files { v_files; ml_files; mli_files; ml4_files; mlg_files;
+let all_files { v_files; ml_files; mli_files; mlg_files;
                 mllib_files; mlpack_files } =
-  v_files @ mli_files @ ml4_files @ mlg_files @ ml_files @ mllib_files @ mlpack_files
+  v_files @ mli_files @ mlg_files @ ml_files @ mllib_files @ mlpack_files
 
 let map_sourced_list f l = List.map (fun x -> f x.thing) l
 ;;

--- a/lib/coqProject_file.mli
+++ b/lib/coqProject_file.mli
@@ -22,7 +22,6 @@ type project = {
 
   v_files : string sourced list;
   mli_files : string sourced list;
-  ml4_files : string sourced list;
   mlg_files : string sourced list;
   ml_files : string sourced list;
   mllib_files : string sourced list;

--- a/tools/CoqMakefile.in
+++ b/tools/CoqMakefile.in
@@ -102,7 +102,7 @@ CAMLOPTC    ?= "$(OCAMLFIND)" opt      -c
 CAMLLINK    ?= "$(OCAMLFIND)" ocamlc   -linkpkg -dontlink $(CAMLDONTLINK)
 CAMLOPTLINK ?= "$(OCAMLFIND)" opt      -linkpkg -dontlink $(CAMLDONTLINK)
 CAMLDOC     ?= "$(OCAMLFIND)" ocamldoc
-CAMLDEP     ?= "$(OCAMLFIND)" ocamldep -slash -ml-synonym .ml4 -ml-synonym .mlpack
+CAMLDEP     ?= "$(OCAMLFIND)" ocamldep -slash -ml-synonym .mlpack
 
 # DESTDIR is prepended to all installation paths
 DESTDIR ?=
@@ -226,7 +226,6 @@ COQTOPINSTALL = $(call concat_path,$(DESTDIR),$(COQLIB)toploop)
 VDFILE := .coqdeps
 
 ALLSRCFILES := \
-	$(ML4FILES) \
 	$(MLGFILES) \
 	$(MLFILES) \
 	$(MLPACKFILES) \
@@ -248,7 +247,6 @@ BEAUTYFILES = $(addsuffix .beautified,$(VFILES))
 TEXFILES = $(VFILES:.v=.tex)
 GTEXFILES = $(VFILES:.v=.g.tex)
 CMOFILES = \
-	$(ML4FILES:.ml4=.cmo) \
 	$(MLGFILES:.mlg=.cmo) \
 	$(MLFILES:.ml=.cmo) \
 	$(MLPACKFILES:.mlpack=.cmo)
@@ -265,7 +263,7 @@ CMXSFILES = \
 	$(MLPACKFILES:.mlpack=.cmxs) \
 	$(CMXAFILES:.cmxa=.cmxs) \
 	$(if $(MLPACKFILES)$(CMXAFILES),,\
-		$(ML4FILES:.ml4=.cmxs) $(MLGFILES:.mlg=.cmxs) $(MLFILES:.ml=.cmxs))
+		$(MLGFILES:.mlg=.cmxs) $(MLFILES:.ml=.cmxs))
 
 # files that are packed into a plugin (no extension)
 PACKEDFILES = \
@@ -583,14 +581,6 @@ $(MLIFILES:.mli=.cmi): %.cmi: %.mli
 	$(SHOW)'CAMLC -c $<'
 	$(HIDE)$(CAMLC) $(CAMLDEBUG) $(CAMLFLAGS) $(CAMLPKGS) $<
 
-$(ML4FILES:.ml4=.cmo): %.cmo: %.ml4
-	$(SHOW)'CAMLC -pp -c $<'
-	$(HIDE)$(CAMLC) $(CAMLDEBUG) $(CAMLFLAGS) $(CAMLPKGS) $(PP) -impl $<
-
-$(ML4FILES:.ml4=.cmx): %.cmx: %.ml4
-	$(SHOW)'CAMLOPT -pp -c $(FOR_PACK) $<'
-	$(HIDE)$(CAMLOPTC) $(CAMLDEBUG) $(CAMLFLAGS) $(CAMLPKGS) $(PP) $(FOR_PACK) -impl $<
-
 $(MLGFILES:.mlg=.ml): %.ml: %.mlg
 	$(SHOW)'COQPP $<'
 	$(HIDE)$(COQPP) $<
@@ -642,7 +632,7 @@ $(MLPACKFILES:.mlpack=.cmx): %.cmx: | %.mlpack
 	$(HIDE)$(CAMLOPTLINK) $(CAMLDEBUG) $(CAMLFLAGS) -pack -o $@ $^
 
 # This rule is for _CoqProject with no .mllib nor .mlpack
-$(filter-out $(MLLIBFILES:.mllib=.cmxs) $(MLPACKFILES:.mlpack=.cmxs) $(addsuffix .cmxs,$(PACKEDFILES)) $(addsuffix .cmxs,$(LIBEDFILES)),$(MLFILES:.ml=.cmxs) $(ML4FILES:.ml4=.cmxs) $(MLGFILES:.mlg=.cmxs)): %.cmxs: %.cmx
+$(filter-out $(MLLIBFILES:.mllib=.cmxs) $(MLPACKFILES:.mlpack=.cmxs) $(addsuffix .cmxs,$(PACKEDFILES)) $(addsuffix .cmxs,$(LIBEDFILES)),$(MLFILES:.ml=.cmxs) $(MLGFILES:.mlg=.cmxs)): %.cmxs: %.cmx
 	$(SHOW)'[deprecated,use-mllib-or-mlpack] CAMLOPT -shared -o $@'
 	$(HIDE)$(CAMLOPTLINK) $(CAMLDEBUG) $(CAMLFLAGS) $(CAMLPKGS) \
 		-shared -o $@ $<
@@ -703,16 +693,12 @@ endif
 
 redir_if_ok = > "$@" || ( RV=$$?; rm -f "$@"; exit $$RV )
 
-GENMLFILES:=$(MLGFILES:.mlg=.ml) $(ML4FILES:.ml4=.ml)
+GENMLFILES:=$(MLGFILES:.mlg=.ml)
 $(addsuffix .d,$(ALLSRCFILES)): $(GENMLFILES)
 
 $(addsuffix .d,$(MLIFILES)): %.mli.d: %.mli
 	$(SHOW)'CAMLDEP $<'
 	$(HIDE)$(CAMLDEP) $(OCAMLLIBS) "$<" $(redir_if_ok)
-
-$(addsuffix .d,$(ML4FILES)): %.ml4.d: %.ml4
-	$(SHOW)'CAMLDEP -pp $<'
-	$(HIDE)$(CAMLDEP) $(OCAMLLIBS) $(PP) -impl "$<" $(redir_if_ok)
 
 $(addsuffix .d,$(MLGFILES)): %.mlg.d: %.ml
 	$(SHOW)'CAMLDEP $<'

--- a/tools/coq_makefile.ml
+++ b/tools/coq_makefile.ml
@@ -218,7 +218,7 @@ let generate_conf_coq_config oc =
 ;;
 
 let generate_conf_files oc
-  { v_files; mli_files; ml4_files; mlg_files; ml_files; mllib_files; mlpack_files; }
+  { v_files; mli_files; mlg_files; ml_files; mllib_files; mlpack_files; }
 =
   let module S = String in
   let map = map_sourced_list in
@@ -226,7 +226,6 @@ let generate_conf_files oc
   fprintf oc "COQMF_VFILES = %s\n"      (S.concat " " (map quote v_files));
   fprintf oc "COQMF_MLIFILES = %s\n"    (S.concat " " (map quote mli_files));
   fprintf oc "COQMF_MLFILES = %s\n"     (S.concat " " (map quote ml_files));
-  fprintf oc "COQMF_ML4FILES = %s\n"    (S.concat " " (map quote ml4_files));
   fprintf oc "COQMF_MLGFILES = %s\n"    (S.concat " " (map quote mlg_files));
   fprintf oc "COQMF_MLPACKFILES = %s\n" (S.concat " " (map quote mlpack_files));
   fprintf oc "COQMF_MLLIBFILES = %s\n"  (S.concat " " (map quote mllib_files));
@@ -284,7 +283,7 @@ let generate_conf oc project args  =
 
 let ensure_root_dir
   ({ ml_includes; r_includes; q_includes;
-     v_files; ml_files; mli_files; ml4_files; mlg_files;
+     v_files; ml_files; mli_files; mlg_files;
      mllib_files; mlpack_files } as project)
   =
   let exists f = List.exists (forget_source > f) in
@@ -294,7 +293,7 @@ let ensure_root_dir
   || exists (fun ({ canonical_path = x },_) -> is_prefix x here) r_includes
   || exists (fun ({ canonical_path = x },_) -> is_prefix x here) q_includes
   || (not_tops v_files &&
-      not_tops mli_files && not_tops ml4_files && not_tops mlg_files &&
+      not_tops mli_files && not_tops mlg_files &&
       not_tops ml_files && not_tops mllib_files && not_tops mlpack_files)
   then
     project

--- a/tools/coqdep_common.ml
+++ b/tools/coqdep_common.ml
@@ -62,7 +62,7 @@ let basename_noext filename =
 (** ML Files specified on the command line. In the entries:
     - the first string is the basename of the file, without extension nor
       directory part
-    - the second string of [mlAccu] is the extension (either .ml or .ml4)
+    - the second string of [mlAccu] is the extension (either .ml or .mlg)
     - the [dir] part is the directory, with None used as the current directory
 *)
 
@@ -496,9 +496,9 @@ let rec suffixes = function
 
 let add_caml_known phys_dir _ f =
   let basename,suff =
-    get_extension f [".ml";".mli";".ml4";".mlg";".mllib";".mlpack"] in
+    get_extension f [".ml";".mli";".mlg";".mllib";".mlpack"] in
   match suff with
-    | ".ml"|".ml4"|".mlg" -> add_ml_known basename (Some phys_dir) suff
+    | ".ml"|".mlg" -> add_ml_known basename (Some phys_dir) suff
     | ".mli" -> add_mli_known basename (Some phys_dir) suff
     | ".mllib" -> add_mllib_known basename (Some phys_dir) suff
     | ".mlpack" -> add_mlpack_known basename (Some phys_dir) suff
@@ -584,12 +584,12 @@ let rec treat_file old_dirname old_name =
 	   in
            Array.iter (treat_file (Some newdirname)) (Sys.readdir complete_name))
     | S_REG ->
-        (match get_extension name [".v";".ml";".mli";".ml4";".mlg";".mllib";".mlpack"] with
+        (match get_extension name [".v";".ml";".mli";".mlg";".mllib";".mlpack"] with
 	   | (base,".v") ->
 	       let name = file_name base dirname
 	       and absname = absolute_file_name base dirname in
 	       addQueue vAccu (name, absname)
-           | (base,(".ml"|".ml4"|".mlg" as ext)) -> addQueue mlAccu (base,ext,dirname)
+           | (base,(".ml"|".mlg" as ext)) -> addQueue mlAccu (base,ext,dirname)
 	   | (base,".mli") -> addQueue mliAccu (base,dirname)
 	   | (base,".mllib") -> addQueue mllibAccu (base,dirname)
 	   | (base,".mlpack") -> addQueue mlpackAccu (base,dirname)

--- a/tools/ocamllibdep.mll
+++ b/tools/ocamllibdep.mll
@@ -145,9 +145,9 @@ let mllibAccu = ref ([] : (string * dir) list)
 let mlpackAccu = ref ([] : (string * dir) list)
 
 let add_caml_known phys_dir f =
-  let basename,suff = get_extension f [".ml";".ml4";".mlg";".mlpack"] in
+  let basename,suff = get_extension f [".ml";".mlg";".mlpack"] in
   match suff with
-    | ".ml"|".ml4"|".mlg" -> add_ml_known basename (Some phys_dir) suff
+    | ".ml"|".mlg" -> add_ml_known basename (Some phys_dir) suff
     | ".mlpack" -> add_mlpack_known basename (Some phys_dir) suff
     | _ -> ()
 


### PR DESCRIPTION
In the build system, mostly.