### PR TITLE
Disable Ltac backtraces

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -95,7 +95,7 @@ Tactics
   by posing the specifying equation for `Z.div` and `Z.modulo` before
   replacing them with atoms.
 
-- Ltac backtraces can be turned off using the "Ltac Backtrace" option.
+- Ltac backtraces can be turned on using the "Ltac Backtrace" option.
 
 Vernacular commands
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -95,6 +95,8 @@ Tactics
   by posing the specifying equation for `Z.div` and `Z.modulo` before
   replacing them with atoms.
 
+- Ltac backtraces can be turned off using the "Ltac Backtrace" option.
+
 Vernacular commands
 
 - `Combined Scheme` can now work when inductive schemes are generated in sort

--- a/doc/sphinx/proof-engine/ltac.rst
+++ b/doc/sphinx/proof-engine/ltac.rst
@@ -1154,6 +1154,15 @@ Printing |Ltac| tactics
 Debugging |Ltac| tactics
 ------------------------
 
+Backtraces
+~~~~~~~~~~
+
+.. flag:: Ltac Backtrace
+
+   Setting this flag displays a backtrace on Ltac failures that can be useful
+   to find out what went wrong. It is disabled by default for performance
+   reasons.
+
 Info trace
 ~~~~~~~~~~
 

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -117,7 +117,7 @@ let combine_appl appl1 appl2 =
 let of_tacvalue v = in_gen (topwit wit_tacvalue) v
 let to_tacvalue v = out_gen (topwit wit_tacvalue) v
 
-let log_trace = ref true
+let log_trace = ref false
 
 let is_traced () =
   !log_trace || !Flags.profile_ltac

--- a/test-suite/output/Errors.v
+++ b/test-suite/output/Errors.v
@@ -1,6 +1,8 @@
 (* coq-prog-args: ("-top" "Errors") *)
 (* Test error messages *)
 
+Set Ltac Backtrace.
+
 (* Test non-regression of bug fixed in r13486 (bad printer for module names) *)
 
 Module Type S.

--- a/test-suite/output/FunExt.out
+++ b/test-suite/output/FunExt.out
@@ -1,19 +1,12 @@
 The command has indeed failed with message:
-Ltac call to "extensionality in (var)" failed.
 Tactic failure: Not an extensional equality.
 The command has indeed failed with message:
-Ltac call to "extensionality in (var)" failed.
 Tactic failure: Not an extensional equality.
 The command has indeed failed with message:
-Ltac call to "extensionality in (var)" failed.
 Tactic failure: Not an extensional equality.
 The command has indeed failed with message:
-Ltac call to "extensionality in (var)" failed.
 Tactic failure: Not an extensional equality.
 The command has indeed failed with message:
-Ltac call to "extensionality in (var)" failed.
 Tactic failure: Already an intensional equality.
 The command has indeed failed with message:
-In nested Ltac calls to "extensionality in (var)" and
-"clearbody (ne_var_list)", last call failed.
 Hypothesis e depends on the body of H'

--- a/test-suite/output/TypeclassDebug.out
+++ b/test-suite/output/TypeclassDebug.out
@@ -14,5 +14,4 @@ Debug: 1.1-1.1-1.1-1.1-1: looking for foo without backtracking
 Debug: 1.1-1.1-1.1-1.1-1.1: simple apply H on foo, 1 subgoal(s)
 Debug: 1.1-1.1-1.1-1.1-1.1-1 : foo
 The command has indeed failed with message:
-Ltac call to "typeclasses eauto (int_or_var_opt) with (ne_preident_list)" failed.
 Tactic failure: Proof search reached its limit.

--- a/test-suite/output/bug5778.v
+++ b/test-suite/output/bug5778.v
@@ -1,3 +1,4 @@
+Set Ltac Backtrace.
 Ltac a _ := pose (I : I).
 Ltac b _ := a ().
 Ltac abs _ := abstract b ().

--- a/test-suite/output/bug6404.v
+++ b/test-suite/output/bug6404.v
@@ -1,3 +1,4 @@
+Set Ltac Backtrace.
 Ltac a _ := pose (I : I).
 Ltac b _ := a ().
 Ltac abs _ := transparent_abstract b ().

--- a/test-suite/output/ltac.v
+++ b/test-suite/output/ltac.v
@@ -1,3 +1,5 @@
+Set Ltac Backtrace.
+
 (* This used to refer to b instead of z sometimes between 8.4 and 8.5beta3 *)
 Goal True.
 Fail let T := constr:((fun a b : nat => a+b) 1 1) in

--- a/test-suite/output/ltac_missing_args.v
+++ b/test-suite/output/ltac_missing_args.v
@@ -1,3 +1,5 @@
+Set Ltac Backtrace.
+
 Ltac foo x := idtac x.
 Ltac bar x := fun y _ => idtac x y.
 Ltac baz := foo.

--- a/test-suite/output/ssr_clear.out
+++ b/test-suite/output/ssr_clear.out
@@ -1,3 +1,2 @@
 The command has indeed failed with message:
-Ltac call to "move (ssrmovearg) (ssrclauses)" failed.
 No assumption is named NO_SUCH_NAME

--- a/test-suite/output/ssr_explain_match.out
+++ b/test-suite/output/ssr_explain_match.out
@@ -51,5 +51,4 @@ instance: (addnC y x) matches: (x + y)
 instance: (addnC y x) matches: (x + y)
 END INSTANCES
 The command has indeed failed with message:
-Ltac call to "ssrinstancesoftpat (cpattern)" failed.
 Not supported


### PR DESCRIPTION
Add an option to selectively enable Ltac backtraces. Due to the performance implications in the bug it fixes, we also unset it by default.

Fixes #7769: Better control over ltac backtraces.
Fixes #7385: Tactic allocates gigabytes of RAM.
