### PR TITLE
Do so that an error message follows the "Error:" header on the same line

### DIFF
--- a/lib/cErrors.ml
+++ b/lib/cErrors.ml
@@ -112,7 +112,7 @@ let iprint_no_report (e, info) =
 
 let _ = register_handler begin function
   | UserError(s, pps) ->
-    hov 0 (where s ++ pps)
+    where s ++ pps
   | _ -> raise Unhandled
 end
 

--- a/test-suite/output/ErrorInCanonicalStructures.out
+++ b/test-suite/output/ErrorInCanonicalStructures.out
@@ -1,5 +1,4 @@
 File "stdin", line 3, characters 0-24:
-Error:
-Could not declare a canonical structure Foo.
+Error: Could not declare a canonical structure Foo.
 Expected an instance of a record or structure.
 

--- a/test-suite/output/ErrorInCanonicalStructures2.out
+++ b/test-suite/output/ErrorInCanonicalStructures2.out
@@ -1,5 +1,4 @@
 File "stdin", line 3, characters 0-24:
-Error:
-Could not declare a canonical structure bar.
+Error: Could not declare a canonical structure bar.
 Expected an instance of a record or structure.
 


### PR DESCRIPTION
This PR is proposing to follow a common usage and to display the error message on the same line after the `Error:`  header (when in terminal mode).

This is probably mostly a subjective question, but if ever by chance, it'd happen that a consensus may emerge, why not...

Example:
```
Goal exists x : nat, x = x.
eexists. (* ?x = ?x *)
set (v := ?x).
```
produces
```
Error: ?x is a generated name. Only user-given names for existential
variables can be referenced. To give a user name to an existential variable,
introduce it with the ?[name] syntax.
```
rather than:
```
Error:
?x is a generated name. Only user-given names for existential variables can
be referenced. To give a user name to an existential variable, introduce it
with the ?[name] syntax.
```

Note that this implicitly means following the policy of not using an extra `hbox` when calling `UserError` (because there is already one in `Topfmt.make_body`), but the policy seems to be followed.