### PR TITLE
[api] Further refine API between `proofs` and `tactics`

### DIFF
--- a/plugins/firstorder/instances.ml
+++ b/plugins/firstorder/instances.ml
@@ -183,12 +183,12 @@ let right_instance_tac inst continue seq=
 	   [introf;
             Proofview.Goal.enter begin fun gl ->
               let id0 = List.nth (pf_ids_of_hyps gl) 0 in
-              split (Tactypes.ImplicitBindings [mkVar id0])
+              split (Tacbindings.ImplicitBindings [mkVar id0])
             end;
 	    tclSOLVE [wrap 0 true continue (deepen seq)]];
 	 tclTRY assumption]
     | Real ((0,t),_) ->
-        (tclTHEN (split (Tactypes.ImplicitBindings [t]))
+        (tclTHEN (split (Tacbindings.ImplicitBindings [t]))
 	   (tclSOLVE [wrap 0 true continue (deepen seq)]))
     | Real ((m,t),_) ->
 	tclFAIL 0 (Pp.str "not implemented ... yet")

--- a/plugins/funind/indfun.ml
+++ b/plugins/funind/indfun.ml
@@ -1,3 +1,13 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *   INRIA, CNRS and contributors - Copyright 1999-2018       *)
+(* <O___,, *       (see CREDITS file for the list of authors)           *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
 open CErrors
 open Sorts
 open Util
@@ -10,7 +20,7 @@ open Libnames
 open Globnames
 open Glob_term
 open Declarations
-open Tactypes
+open Tacbindings
 open Decl_kinds
 
 module RelDecl = Context.Rel.Declaration

--- a/plugins/funind/indfun.mli
+++ b/plugins/funind/indfun.mli
@@ -1,5 +1,15 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *   INRIA, CNRS and contributors - Copyright 1999-2018       *)
+(* <O___,, *       (see CREDITS file for the list of authors)           *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
 open Names
-open Tactypes
+open Tacbindings
 
 val warn_cannot_define_graph : ?loc:Loc.t -> Pp.t * Pp.t -> unit
 

--- a/plugins/funind/invfun.ml
+++ b/plugins/funind/invfun.ml
@@ -23,6 +23,7 @@ open Tacticals
 open Tactics
 open Indfun_common
 open Tacmach
+open Tacbindings
 open Tactypes
 open Termops
 open Context.Rel.Declaration

--- a/plugins/funind/invfun.mli
+++ b/plugins/funind/invfun.mli
@@ -9,7 +9,7 @@
 (************************************************************************)
 
 val invfun :
-  Tactypes.quantified_hypothesis ->
+  Tacbindings.quantified_hypothesis ->
   Names.GlobRef.t option ->
   Evar.t Evd.sigma -> Evar.t list Evd.sigma
 val derive_correctness :

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -38,7 +38,7 @@ open Glob_term
 open Pretyping
 open Termops
 open Constrintern
-open Tactypes
+open Tacbindings
 open Genredexpr
 
 open Equality

--- a/plugins/ltac/coretactics.mlg
+++ b/plugins/ltac/coretactics.mlg
@@ -12,11 +12,11 @@
 
 open Util
 open Locus
-open Tactypes
 open Genredexpr
 open Stdarg
 open Extraargs
 open Tacarg
+open Tacbindings
 open Names
 open Logic
 

--- a/plugins/ltac/extratactics.mlg
+++ b/plugins/ltac/extratactics.mlg
@@ -27,7 +27,7 @@ open Util
 open Termops
 open Equality
 open Namegen
-open Tactypes
+open Tacbindings
 open Tactics
 open Proofview.Notations
 open Attributes

--- a/plugins/ltac/g_rewrite.mlg
+++ b/plugins/ltac/g_rewrite.mlg
@@ -22,7 +22,7 @@ open Extraargs
 open Tacmach
 open Rewrite
 open Stdarg
-open Tactypes
+open Tacbindings
 open Pcoq.Prim
 open Pcoq.Constr
 open Pvernac.Vernac_

--- a/plugins/ltac/g_tactic.mlg
+++ b/plugins/ltac/g_tactic.mlg
@@ -20,6 +20,7 @@ open Genredexpr
 open Constrexpr
 open Libnames
 open Tok
+open Tacbindings
 open Tactypes
 open Tactics
 open Inv

--- a/plugins/ltac/pltac.mli
+++ b/plugins/ltac/pltac.mli
@@ -15,6 +15,7 @@ open Libnames
 open Constrexpr
 open Tacexpr
 open Genredexpr
+open Tacbindings
 open Tactypes
 
 val open_constr : constr_expr Entry.t

--- a/plugins/ltac/pptactic.ml
+++ b/plugins/ltac/pptactic.ml
@@ -18,6 +18,7 @@ open Genarg
 open Geninterp
 open Stdarg
 open Notation_gram
+open Tacbindings
 open Tactypes
 open Locus
 open Decl_kinds
@@ -389,9 +390,9 @@ let string_of_genarg_arg (ArgumentType arg) =
 
   let pr_as_disjunctive_ipat prc ipatl =
     keyword "as" ++ spc () ++
-      pr_or_var (fun {CAst.loc;v=p} -> Miscprint.pr_or_and_intro_pattern prc p) ipatl
+      pr_or_var (fun {CAst.loc;v=p} -> Pptactypes.pr_or_and_intro_pattern prc p) ipatl
 
-  let pr_eqn_ipat {CAst.v=ipat} = keyword "eqn:" ++ Miscprint.pr_intro_pattern_naming ipat
+  let pr_eqn_ipat {CAst.v=ipat} = keyword "eqn:" ++ Pptactypes.pr_intro_pattern_naming ipat
 
   let pr_with_induction_names prc = function
     | None, None -> mt ()
@@ -401,7 +402,7 @@ let string_of_genarg_arg (ArgumentType arg) =
         hov 1 (pr_as_disjunctive_ipat prc ipat ++ spc () ++ pr_eqn_ipat eqpat)
 
   let pr_as_intro_pattern prc ipat =
-    spc () ++ hov 1 (keyword "as" ++ spc () ++ Miscprint.pr_intro_pattern prc ipat)
+    spc () ++ hov 1 (keyword "as" ++ spc () ++ Pptactypes.pr_intro_pattern prc ipat)
 
   let pr_with_inversion_names prc = function
     | None -> mt ()
@@ -753,7 +754,7 @@ let pr_goal_selector ~toplevel s =
            hov 1 (primitive (if ev then "eintros" else "intros") ++
                     (match p with
                     | [{CAst.v=IntroForthcoming false}] -> mt ()
-                    | _ -> spc () ++ prlist_with_sep spc (Miscprint.pr_intro_pattern pr.pr_dconstr) p))
+                    | _ -> spc () ++ prlist_with_sep spc (Pptactypes.pr_intro_pattern pr.pr_dconstr) p))
         | TacApply (a,ev,cb,inhyp) ->
           hov 1 (
             (if a then mt() else primitive "simple ") ++
@@ -1268,7 +1269,7 @@ let declare_extra_vernac_genarg_pprule wit f =
 
 let pr_intro_pattern_env p = Genprint.TopPrinterNeedsContext (fun env sigma ->
   let print_constr c = let (sigma, c) = c env sigma in pr_econstr_env env sigma c in
-  Miscprint.pr_intro_pattern print_constr p)
+  Pptactypes.pr_intro_pattern print_constr p)
 
 let pr_red_expr_env r = Genprint.TopPrinterNeedsContext (fun env sigma ->
   pr_red_expr (pr_econstr_env env sigma, pr_leconstr_env env sigma,
@@ -1324,8 +1325,8 @@ let () =
   register_basic_print0 wit_var pr_lident pr_lident pr_id;
   register_print0
     wit_intro_pattern
-    (lift (Miscprint.pr_intro_pattern pr_constr_expr))
-    (lift (Miscprint.pr_intro_pattern (fun (c,_) -> pr_glob_constr_pptac c)))
+    (lift (Pptactypes.pr_intro_pattern pr_constr_expr))
+    (lift (Pptactypes.pr_intro_pattern (fun (c,_) -> pr_glob_constr_pptac c)))
     pr_intro_pattern_env;
   Genprint.register_print0
     wit_clause_dft_concl

--- a/plugins/ltac/pptactic.mli
+++ b/plugins/ltac/pptactic.mli
@@ -19,7 +19,7 @@ open Constrexpr
 open Notation_gram
 open Genintern
 open Tacexpr
-open Tactypes
+open Tacbindings
 
 type 'a grammar_tactic_prod_item_expr =
 | TacTerm of string

--- a/plugins/ltac/rewrite.ml
+++ b/plugins/ltac/rewrite.ml
@@ -26,7 +26,7 @@ open Classes
 open Constrexpr
 open Globnames
 open Evd
-open Tactypes
+open Tacbindings
 open Locus
 open Locusops
 open Decl_kinds

--- a/plugins/ltac/rewrite.mli
+++ b/plugins/ltac/rewrite.mli
@@ -14,7 +14,7 @@ open EConstr
 open Constrexpr
 open Evd
 open Genintern
-open Tactypes
+open Tacbindings
 open Tacexpr
 open Tacinterp
 

--- a/plugins/ltac/tacarg.mli
+++ b/plugins/ltac/tacarg.mli
@@ -12,6 +12,7 @@ open Genarg
 open EConstr
 open Constrexpr
 open Genintern
+open Tacbindings
 open Tactypes
 open Tacexpr
 

--- a/plugins/ltac/taccoerce.ml
+++ b/plugins/ltac/taccoerce.ml
@@ -13,6 +13,7 @@ open Names
 open Constr
 open EConstr
 open Namegen
+open Tacbindings
 open Tactypes
 open Genarg
 open Stdarg

--- a/plugins/ltac/taccoerce.mli
+++ b/plugins/ltac/taccoerce.mli
@@ -13,6 +13,7 @@ open Names
 open EConstr
 open Genarg
 open Geninterp
+open Tacbindings
 open Tactypes
 
 (** Coercions from highest level generic arguments to actual data used by Ltac

--- a/plugins/ltac/tacexpr.ml
+++ b/plugins/ltac/tacexpr.ml
@@ -15,6 +15,7 @@ open Libnames
 open Genredexpr
 open Genarg
 open Pattern
+open Tacbindings
 open Tactypes
 open Locus
 

--- a/plugins/ltac/tacexpr.mli
+++ b/plugins/ltac/tacexpr.mli
@@ -16,6 +16,7 @@ open Genredexpr
 open Genarg
 open Pattern
 open Locus
+open Tacbindings
 open Tactypes
 
 type ltac_constant = KerName.t

--- a/plugins/ltac/tacintern.ml
+++ b/plugins/ltac/tacintern.ml
@@ -27,6 +27,7 @@ open Genarg
 open Stdarg
 open Tacarg
 open Namegen
+open Tacbindings
 open Tactypes
 open Tactics
 open Locus

--- a/plugins/ltac/tacintern.mli
+++ b/plugins/ltac/tacintern.mli
@@ -13,7 +13,7 @@ open Tacexpr
 open Genarg
 open Constrexpr
 open Genintern
-open Tactypes
+open Tacbindings
 
 (** Globalization of tactic expressions :
     Conversion from [raw_tactic_expr] to [glob_tactic_expr] *)

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -35,6 +35,7 @@ open Stdarg
 open Tacarg
 open Printer
 open Pretyping
+open Tacbindings
 open Tactypes
 open Tactics
 open Locus

--- a/plugins/ltac/tacinterp.mli
+++ b/plugins/ltac/tacinterp.mli
@@ -14,7 +14,7 @@ open EConstr
 open Tacexpr
 open Genarg
 open Redexpr
-open Tactypes
+open Tacbindings
 
 val ltac_trace_info : ltac_trace Exninfo.t
 

--- a/plugins/ltac/tacsubst.ml
+++ b/plugins/ltac/tacsubst.ml
@@ -14,6 +14,7 @@ open Mod_subst
 open Genarg
 open Stdarg
 open Tacarg
+open Tacbindings
 open Tactypes
 open Tactics
 open Globnames

--- a/plugins/ltac/tacsubst.mli
+++ b/plugins/ltac/tacsubst.mli
@@ -12,7 +12,7 @@ open Tacexpr
 open Mod_subst
 open Genarg
 open Genintern
-open Tactypes
+open Tacbindings
 
 (** Substitution of tactics at module closing time *)
 

--- a/plugins/ltac/tauto.ml
+++ b/plugins/ltac/tauto.ml
@@ -93,7 +93,7 @@ let clear id = Tactics.clear [id]
 
 let assumption = Tactics.assumption
 
-let split = Tactics.split_with_bindings false [Tactypes.NoBindings]
+let split = Tactics.split_with_bindings false [Tacbindings.NoBindings]
 
 (** Test *)
 
@@ -174,7 +174,7 @@ let flatten_contravariant_disj _ ist =
   | Some (_,args) ->
       let map i arg =
         let typ = mkArrow arg c in
-        let ci = Tactics.constructor_tac false None (succ i) Tactypes.NoBindings in
+        let ci = Tactics.constructor_tac false None (succ i) Tacbindings.NoBindings in
         let by = tclTHENLIST [intro; apply hyp; ci; assumption] in
         assert_ ~by typ
       in

--- a/plugins/omega/coq_omega.ml
+++ b/plugins/omega/coq_omega.ml
@@ -29,7 +29,7 @@ open Libnames
 open Globnames
 open Nametab
 open Contradiction
-open Tactypes
+open Tacbindings
 open Context.Named.Declaration
 
 module NamedDecl = Context.Named.Declaration

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -252,7 +252,7 @@ let interp_refine ist gl rc =
 
 
 let interp_open_constr ist gl gc =
-  let (sigma, (c, _)) = Tacinterp.interp_open_constr_with_bindings ist (pf_env gl) (project gl) (gc, Tactypes.NoBindings) in
+  let (sigma, (c, _)) = Tacinterp.interp_open_constr_with_bindings ist (pf_env gl) (project gl) (gc, Tacbindings.NoBindings) in
   (project gl, (sigma, c))
 
 let interp_term ist gl (_, c) = snd (interp_open_constr ist gl c)

--- a/plugins/ssr/ssrelim.ml
+++ b/plugins/ssr/ssrelim.ml
@@ -16,7 +16,7 @@ open Printer
 open Term
 open Constr
 open Termops
-open Tactypes
+open Tacbindings
 open Tacmach
 
 open Ssrmatching_plugin

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -26,7 +26,7 @@ open Tacred
 open Pretype_errors
 open Evarutil
 open Unification
-open Tactypes
+open Tacbindings
 
 (******************************************************************)
 (* Clausal environments *)

--- a/proofs/clenv.mli
+++ b/proofs/clenv.mli
@@ -18,7 +18,7 @@ open Environ
 open Evd
 open EConstr
 open Unification
-open Tactypes
+open Tacbindings
 
 (** {6 The Type of Constructions clausale environments.} *)
 

--- a/proofs/dune
+++ b/proofs/dune
@@ -3,4 +3,5 @@
  (synopsis "Coq's Higher-level Refinement Proof Engine and Top-level Proof Structure")
  (public_name coq.proofs)
  (wrapped false)
+ (modules_without_implementation tacbindings)
  (libraries interp))

--- a/proofs/miscprint.ml
+++ b/proofs/miscprint.ml
@@ -9,39 +9,7 @@
 (************************************************************************)
 
 open Pp
-open Names
-open Tactypes
-
-(** Printing of [intro_pattern] *)
-
-let rec pr_intro_pattern prc {CAst.v=pat} = match pat with
-  | IntroForthcoming true -> str "*"
-  | IntroForthcoming false -> str "**"
-  | IntroNaming p -> pr_intro_pattern_naming p
-  | IntroAction p -> pr_intro_pattern_action prc p
-
-and pr_intro_pattern_naming = let open Namegen in function
-  | IntroIdentifier id -> Id.print id
-  | IntroFresh id -> str "?" ++ Id.print id
-  | IntroAnonymous -> str "?"
-
-and pr_intro_pattern_action prc = function
-  | IntroWildcard -> str "_"
-  | IntroOrAndPattern pll -> pr_or_and_intro_pattern prc pll
-  | IntroInjection pl ->
-      str "[=" ++ hv 0 (prlist_with_sep spc (pr_intro_pattern prc) pl) ++
-      str "]"
-  | IntroApplyOn ({CAst.v=c},pat) -> pr_intro_pattern prc pat ++ str "%" ++ prc c
-  | IntroRewrite true -> str "->"
-  | IntroRewrite false -> str "<-"
-
-and pr_or_and_intro_pattern prc = function
-  | IntroAndPattern pl ->
-      str "(" ++ hv 0 (prlist_with_sep pr_comma (pr_intro_pattern prc) pl) ++ str ")"
-  | IntroOrPattern pll ->
-      str "[" ++
-      hv 0 (prlist_with_sep pr_bar (prlist_with_sep spc (pr_intro_pattern prc)) pll)
-      ++ str "]"
+open Tacbindings
 
 (** Printing of bindings *)
 let pr_binding prc = let open CAst in function

--- a/proofs/miscprint.mli
+++ b/proofs/miscprint.mli
@@ -8,17 +8,7 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-open Tactypes
-
-(** Printing of [intro_pattern] *)
-
-val pr_intro_pattern :
-  ('a -> Pp.t) -> 'a intro_pattern_expr CAst.t -> Pp.t
-
-val pr_or_and_intro_pattern :
-  ('a -> Pp.t) -> 'a or_and_intro_pattern_expr -> Pp.t
-
-val pr_intro_pattern_naming : Namegen.intro_pattern_naming_expr -> Pp.t
+open Tacbindings
 
 (** Printing of [move_location] *)
 

--- a/proofs/tacbindings.mli
+++ b/proofs/tacbindings.mli
@@ -11,24 +11,7 @@
 (** Tactic-related types that are not totally Ltac specific and still used in
     lower API. It's not clear whether this is a temporary API or if this is
     meant to stay. *)
-
 open Names
-
-(** Introduction patterns *)
-
-type 'constr intro_pattern_expr =
-  | IntroForthcoming of bool
-  | IntroNaming of Namegen.intro_pattern_naming_expr
-  | IntroAction of 'constr intro_pattern_action_expr
-and 'constr intro_pattern_action_expr =
-  | IntroWildcard
-  | IntroOrAndPattern of 'constr or_and_intro_pattern_expr
-  | IntroInjection of ('constr intro_pattern_expr) CAst.t list
-  | IntroApplyOn of 'constr CAst.t * 'constr intro_pattern_expr CAst.t
-  | IntroRewrite of bool
-and 'constr or_and_intro_pattern_expr =
-  | IntroOrPattern of ('constr intro_pattern_expr) CAst.t list list
-  | IntroAndPattern of ('constr intro_pattern_expr) CAst.t list
 
 (** Bindings *)
 
@@ -42,13 +25,3 @@ type 'a bindings =
   | NoBindings
 
 type 'a with_bindings = 'a * 'a bindings
-
-type 'a delayed_open = Environ.env -> Evd.evar_map -> Evd.evar_map * 'a
-
-type delayed_open_constr = EConstr.constr delayed_open
-type delayed_open_constr_with_bindings = EConstr.constr with_bindings delayed_open
-
-type intro_pattern = delayed_open_constr intro_pattern_expr CAst.t
-type intro_patterns = delayed_open_constr intro_pattern_expr CAst.t list
-type or_and_intro_pattern = delayed_open_constr or_and_intro_pattern_expr CAst.t
-type intro_pattern_naming = Namegen.intro_pattern_naming_expr CAst.t

--- a/tactics/contradiction.ml
+++ b/tactics/contradiction.ml
@@ -118,7 +118,7 @@ let contradiction_term (c,lbind as cl) =
     else
       Proofview.tclORELSE
         begin
-          if lbind = Tactypes.NoBindings then
+          if lbind = Tacbindings.NoBindings then
             filter_hyp (fun c -> is_negation_of env sigma typ c)
               (fun id -> simplest_elim (mkApp (mkVar id,[|c|])))
           else

--- a/tactics/contradiction.mli
+++ b/tactics/contradiction.mli
@@ -9,7 +9,7 @@
 (************************************************************************)
 
 open EConstr
-open Tactypes
+open Tacbindings
 
 val absurd                      : constr -> unit Proofview.tactic
 val contradiction               : constr with_bindings option -> unit Proofview.tactic

--- a/tactics/dune
+++ b/tactics/dune
@@ -3,4 +3,5 @@
  (synopsis "Coq's Core Tactics [ML implementation]")
  (public_name coq.tactics)
  (wrapped false)
+ (modules_without_implementation tactypes)
  (libraries printing))

--- a/tactics/elim.mli
+++ b/tactics/elim.mli
@@ -11,6 +11,7 @@
 open Names
 open EConstr
 open Tacticals
+open Tacbindings
 open Tactypes
 
 (** Eliminations tactics. *)

--- a/tactics/eqdecide.ml
+++ b/tactics/eqdecide.ml
@@ -27,7 +27,7 @@ open Constr_matching
 open Hipattern
 open Proofview.Notations
 open Tacmach.New
-open Tactypes
+open Tacbindings
 
 (* This file containts the implementation of the tactics ``Decide
    Equality'' and ``Compare''. They can be used to decide the

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -42,7 +42,7 @@ open Ind_tables
 open Eqschemes
 open Locus
 open Locusops
-open Tactypes
+open Tacbindings
 open Proofview.Notations
 open Unification
 open Context.Named.Declaration

--- a/tactics/equality.mli
+++ b/tactics/equality.mli
@@ -15,6 +15,7 @@ open EConstr
 open Environ
 open Ind_tables
 open Locus
+open Tacbindings
 open Tactypes
 open Tactics
 (*i*)

--- a/tactics/inv.ml
+++ b/tactics/inv.ml
@@ -26,6 +26,7 @@ open Tacticals.New
 open Tactics
 open Elim
 open Equality
+open Tacbindings
 open Tactypes
 open Proofview.Notations
 
@@ -297,7 +298,7 @@ let error_too_many_names pats =
   tclZEROMSG ?loc (
     str "Unexpected " ++
     str (String.plural (List.length pats) "introduction pattern") ++
-    str ": " ++ pr_enum (Miscprint.pr_intro_pattern
+    str ": " ++ pr_enum (Pptactypes.pr_intro_pattern
                            (fun c -> Printer.pr_econstr_env env sigma (snd (c env (Evd.from_env env))))) pats ++
     str ".")
 

--- a/tactics/inv.mli
+++ b/tactics/inv.mli
@@ -10,6 +10,7 @@
 
 open Names
 open EConstr
+open Tacbindings
 open Tactypes
 
 type inversion_status = Dep of constr option | NoDep

--- a/tactics/pptactypes.ml
+++ b/tactics/pptactypes.ml
@@ -1,0 +1,43 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *   INRIA, CNRS and contributors - Copyright 1999-2018       *)
+(* <O___,, *       (see CREDITS file for the list of authors)           *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+(** Printing of [intro_pattern] *)
+open Pp
+open Names
+open Tactypes
+
+let rec pr_intro_pattern prc {CAst.v=pat} = match pat with
+  | IntroForthcoming true -> str "*"
+  | IntroForthcoming false -> str "**"
+  | IntroNaming p -> pr_intro_pattern_naming p
+  | IntroAction p -> pr_intro_pattern_action prc p
+
+and pr_intro_pattern_naming = let open Namegen in function
+  | IntroIdentifier id -> Id.print id
+  | IntroFresh id -> str "?" ++ Id.print id
+  | IntroAnonymous -> str "?"
+
+and pr_intro_pattern_action prc = function
+  | IntroWildcard -> str "_"
+  | IntroOrAndPattern pll -> pr_or_and_intro_pattern prc pll
+  | IntroInjection pl ->
+      str "[=" ++ hv 0 (prlist_with_sep spc (pr_intro_pattern prc) pl) ++
+      str "]"
+  | IntroApplyOn ({CAst.v=c},pat) -> pr_intro_pattern prc pat ++ str "%" ++ prc c
+  | IntroRewrite true -> str "->"
+  | IntroRewrite false -> str "<-"
+
+and pr_or_and_intro_pattern prc = function
+  | IntroAndPattern pl ->
+      str "(" ++ hv 0 (prlist_with_sep pr_comma (pr_intro_pattern prc) pl) ++ str ")"
+  | IntroOrPattern pll ->
+      str "[" ++
+      hv 0 (prlist_with_sep pr_bar (prlist_with_sep spc (pr_intro_pattern prc)) pll)
+      ++ str "]"

--- a/tactics/pptactypes.mli
+++ b/tactics/pptactypes.mli
@@ -8,14 +8,14 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-open Names
-open EConstr
-open Constrexpr
-open Tacbindings
+open Tactypes
 
-val lemInv_clause :
-  quantified_hypothesis -> constr -> Id.t list -> unit Proofview.tactic
+(** Printing of [intro_pattern] *)
 
-val add_inversion_lemma_exn : poly:bool ->
-  Id.t -> constr_expr -> Sorts.family -> bool -> (Id.t -> unit Proofview.tactic) ->
-    unit
+val pr_intro_pattern :
+  ('a -> Pp.t) -> 'a intro_pattern_expr CAst.t -> Pp.t
+
+val pr_or_and_intro_pattern :
+  ('a -> Pp.t) -> 'a or_and_intro_pattern_expr -> Pp.t
+
+val pr_intro_pattern_naming : Namegen.intro_pattern_naming_expr -> Pp.t

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -40,6 +40,7 @@ open Pretype_errors
 open Unification
 open Locus
 open Locusops
+open Tacbindings
 open Tactypes
 open Proofview.Notations
 open Context.Named.Declaration
@@ -3096,7 +3097,7 @@ let warn_unused_intro_pattern env sigma =
     (fun names ->
        strbrk"Unused introduction " ++ str (String.plural (List.length names) "pattern") ++
        str": " ++ prlist_with_sep spc
-         (Miscprint.pr_intro_pattern
+         (Pptactypes.pr_intro_pattern
             (fun c -> Printer.pr_econstr_env env sigma (snd (c env sigma)))) names)
 
 let check_unused_names env sigma names =
@@ -4539,7 +4540,7 @@ let induction_gen_l isrec with_evars elim names lc =
     | (c,None) -> c
     | (c,Some{CAst.loc;v=eqname}) ->
       user_err ?loc  (str "Do not know what to do with " ++
-                         Miscprint.pr_intro_pattern_naming eqname)) lc in
+                         Pptactypes.pr_intro_pattern_naming eqname)) lc in
   let rec atomize_list l =
     match l with
       | [] -> Proofview.tclUNIT ()

--- a/tactics/tactics.mli
+++ b/tactics/tactics.mli
@@ -17,6 +17,7 @@ open Clenv
 open Redexpr
 open Pattern
 open Unification
+open Tacbindings
 open Tactypes
 open Locus
 open Ltac_pretype

--- a/tactics/tactics.mllib
+++ b/tactics/tactics.mllib
@@ -6,6 +6,7 @@ Hipattern
 Ind_tables
 Eqschemes
 Elimschemes
+Pptactypes
 Tactics
 Abstract
 Elim

--- a/tactics/tactypes.mli
+++ b/tactics/tactypes.mli
@@ -1,0 +1,42 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *   INRIA, CNRS and contributors - Copyright 1999-2018       *)
+(* <O___,, *       (see CREDITS file for the list of authors)           *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+(** Tactic-related types that are not totally Ltac specific and still used in
+    lower API. It's not clear whether this is a temporary API or if this is
+    meant to stay. *)
+
+open Tacbindings
+
+(** Introduction patterns *)
+
+type 'constr intro_pattern_expr =
+  | IntroForthcoming of bool
+  | IntroNaming of Namegen.intro_pattern_naming_expr
+  | IntroAction of 'constr intro_pattern_action_expr
+and 'constr intro_pattern_action_expr =
+  | IntroWildcard
+  | IntroOrAndPattern of 'constr or_and_intro_pattern_expr
+  | IntroInjection of ('constr intro_pattern_expr) CAst.t list
+  | IntroApplyOn of 'constr CAst.t * 'constr intro_pattern_expr CAst.t
+  | IntroRewrite of bool
+and 'constr or_and_intro_pattern_expr =
+  | IntroOrPattern of ('constr intro_pattern_expr) CAst.t list list
+  | IntroAndPattern of ('constr intro_pattern_expr) CAst.t list
+
+(** Delayed terms *)
+type 'a delayed_open = Environ.env -> Evd.evar_map -> Evd.evar_map * 'a
+
+type delayed_open_constr = EConstr.constr delayed_open
+type delayed_open_constr_with_bindings = EConstr.constr with_bindings delayed_open
+
+type intro_pattern = delayed_open_constr intro_pattern_expr CAst.t
+type intro_patterns = delayed_open_constr intro_pattern_expr CAst.t list
+type or_and_intro_pattern = delayed_open_constr or_and_intro_pattern_expr CAst.t
+type intro_pattern_naming = Namegen.intro_pattern_naming_expr CAst.t

--- a/vernac/auto_ind_decl.ml
+++ b/vernac/auto_ind_decl.ml
@@ -25,6 +25,7 @@ open Inductiveops
 open Tactics
 open Ind_tables
 open Namegen
+open Tacbindings
 open Tactypes
 open Proofview.Notations
 


### PR DESCRIPTION
We isolate the dependency of bindings for proofs in its own file, and
thus we can move the `tactypes` module to `tactics`.
