### PR TITLE
Recarg cleanup

### DIFF
--- a/dev/ci/user-overlays/09165-ejgallego-recarg-cleanup.sh
+++ b/dev/ci/user-overlays/09165-ejgallego-recarg-cleanup.sh
@@ -1,0 +1,9 @@
+if [ "$CI_PULL_REQUEST" = "9165" ] || [ "$CI_BRANCH" = "recarg-cleanup" ]; then
+
+    elpi_CI_REF=recarg-cleanup
+    elpi_CI_GITURL=https://github.com/ejgallego/coq-elpi
+
+    quickchick_CI_REF=recarg-cleanup
+    quickchick_CI_GITURL=https://github.com/ejgallego/QuickChick
+
+fi

--- a/dev/doc/changes.md
+++ b/dev/doc/changes.md
@@ -83,6 +83,11 @@ Libobject
   * `Libobject.superglobal_object`
   * `Libobject.superglobal_object_nodischarge`
 
+AST
+
+- Minor changes in the AST have been performed, for example
+  https://github.com/coq/coq/pull/9165
+
 Implicit Arguments
 
 - `Impargs.declare_manual_implicits` is restricted to only support declaration

--- a/doc/sphinx/addendum/program.rst
+++ b/doc/sphinx/addendum/program.rst
@@ -194,14 +194,14 @@ Program Fixpoint
    The optional order annotation follows the grammar:
 
    .. productionlist:: orderannot
-      order      : measure `term` (`term`)? | wf `term` `term`
+      order      : measure `term` [ `term` ] | wf `term` `ident`
 
-   + :g:`measure f ( R )` where :g:`f` is a value of type :g:`X` computed on
-     any subset of the arguments and the optional (parenthesised) term
-     ``(R)`` is a relation on ``X``. By default ``X`` defaults to ``nat`` and ``R``
-     to ``lt``.
+   + :g:`measure f R` where :g:`f` is a value of type :g:`X` computed on
+     any subset of the arguments and the optional term
+     :g:`R` is a relation on :g:`X`. :g:`X` defaults to :g:`nat` and :g:`R`
+     to :g:`lt`.
 
-   + :g:`wf R x` which is equivalent to :g:`measure x (R)`.
+   + :g:`wf R x` which is equivalent to :g:`measure x R`.
 
    The structural fixpoint operator behaves just like the one of |Coq| (see
    :cmd:`Fixpoint`), except it may also generate obligations. It works

--- a/interp/constrexpr.ml
+++ b/interp/constrexpr.ml
@@ -134,16 +134,16 @@ and branch_expr =
   (cases_pattern_expr list list * constr_expr) CAst.t
 
 and fix_expr =
-    lident * (lident option * recursion_order_expr) *
+    lident * (recursion_order_expr CAst.t) option *
       local_binder_expr list * constr_expr * constr_expr
 
 and cofix_expr =
     lident * local_binder_expr list * constr_expr * constr_expr
 
 and recursion_order_expr =
-  | CStructRec
-  | CWfRec of constr_expr
-  | CMeasureRec of constr_expr * constr_expr option (** measure, relation *)
+  | CStructRec of lident
+  | CWfRec of lident * constr_expr
+  | CMeasureRec of lident option * constr_expr * constr_expr option (** argument, measure, relation *)
 
 (* Anonymous defs allowed ?? *)
 and local_binder_expr =

--- a/interp/constrexpr.ml
+++ b/interp/constrexpr.ml
@@ -134,16 +134,17 @@ and branch_expr =
   (cases_pattern_expr list list * constr_expr) CAst.t
 
 and fix_expr =
-    lident * (recursion_order_expr CAst.t) option *
+    lident * recursion_order_expr option *
       local_binder_expr list * constr_expr * constr_expr
 
 and cofix_expr =
     lident * local_binder_expr list * constr_expr * constr_expr
 
-and recursion_order_expr =
+and recursion_order_expr_r =
   | CStructRec of lident
   | CWfRec of lident * constr_expr
   | CMeasureRec of lident option * constr_expr * constr_expr option (** argument, measure, relation *)
+and recursion_order_expr = recursion_order_expr_r CAst.t
 
 (* Anonymous defs allowed ?? *)
 and local_binder_expr =

--- a/interp/constrexpr_ops.ml
+++ b/interp/constrexpr_ops.ml
@@ -198,7 +198,7 @@ and branch_expr_eq {CAst.v=(p1, e1)} {CAst.v=(p2, e2)} =
 
 and fix_expr_eq (id1,r1,bl1,a1,b1) (id2,r2,bl2,a2,b2) =
   (eq_ast Id.equal id1 id2) &&
-  Option.equal (eq_ast recursion_order_expr_eq) r1 r2 &&
+  Option.equal recursion_order_expr_eq r1 r2 &&
   List.equal local_binder_eq bl1 bl2 &&
   constr_expr_eq a1 a2 &&
   constr_expr_eq b1 b2
@@ -209,7 +209,7 @@ and cofix_expr_eq (id1,bl1,a1,b1) (id2,bl2,a2,b2) =
   constr_expr_eq a1 a2 &&
   constr_expr_eq b1 b2
 
-and recursion_order_expr_eq r1 r2 = match r1, r2 with
+and recursion_order_expr_eq_r r1 r2 = match r1, r2 with
   | CStructRec i1, CStructRec i2 -> eq_ast Id.equal i1 i2
   | CWfRec (i1,e1), CWfRec (i2,e2) ->
     constr_expr_eq e1 e2
@@ -217,6 +217,8 @@ and recursion_order_expr_eq r1 r2 = match r1, r2 with
     Option.equal (eq_ast Id.equal) i1 i2 &&
     constr_expr_eq e1 e2 && Option.equal constr_expr_eq o1 o2
   | _ -> false
+
+and recursion_order_expr_eq r1 r2 = eq_ast recursion_order_expr_eq_r r1 r2
 
 and local_binder_eq l1 l2 = match l1, l2 with
   | CLocalDef (n1, e1, t1), CLocalDef (n2, e2, t2) ->

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -1845,51 +1845,44 @@ let internalize globalenv env pattern_mode (_, ntnvars as lvar) c =
 	in
 	  apply_impargs c env imp subscopes l loc
 
-    | CFix ({ CAst.loc = locid; v = iddef}, dl) ->
+      | CFix ({ CAst.loc = locid; v = iddef}, dl) ->
         let lf = List.map (fun ({CAst.v = id},_,_,_,_) -> id) dl in
         let dl = Array.of_list dl in
-	let n =
-	  try List.index0 Id.equal iddef lf
+        let n =
+          try List.index0 Id.equal iddef lf
           with Not_found ->
-	    raise (InternalizationError (locid,UnboundFixName (false,iddef)))
-	in
-	let idl_temp = Array.map
-          (fun (id,(n,order),bl,ty,_) ->
-	     let intern_ro_arg f =
-	       let before, after = split_at_annot bl n in
-	       let (env',rbefore) = List.fold_left intern_local_binder (env,[]) before in
-	       let ro = f (intern env') in
-	       let n' = Option.map (fun _ -> List.count (fun c -> match DAst.get c with
-                                                                  | GLocalAssum _ -> true
-                                                                  | _ -> false (* remove let-ins *))
-                        rbefore) n in
-		 n', ro, List.fold_left intern_local_binder (env',rbefore) after
-	     in
-	     let n, ro, (env',rbl) =
-	       match order with
-	       | CStructRec ->
-		   intern_ro_arg (fun _ -> GStructRec)
-	       | CWfRec c ->
-		   intern_ro_arg (fun f -> GWfRec (f c))
-	       | CMeasureRec (m,r) ->
-		   intern_ro_arg (fun f -> GMeasureRec (f m, Option.map f r))
-	     in
-	     let bl = List.rev (List.map glob_local_binder_of_extended rbl) in
-             ((n, ro), bl, intern_type env' ty, env')) dl in
+            raise (InternalizationError (locid,UnboundFixName (false,iddef)))
+        in
+        let idl_temp = Array.map
+            (fun (id,recarg,bl,ty,_) ->
+               let recarg = Option.map (function { CAst.v = v } -> match v with
+                 | CStructRec i -> i
+                 | _ -> anomaly Pp.(str "Non-structural recursive argument in non-program fixpoint")) recarg
+               in
+               let before, after = split_at_annot bl recarg in
+               let (env',rbefore) = List.fold_left intern_local_binder (env,[]) before in
+               let n = Option.map (fun _ -> List.count (fun c -> match DAst.get c with
+                   | GLocalAssum _ -> true
+                   | _ -> false (* remove let-ins *))
+                   rbefore) recarg in
+               let (env',rbl) = List.fold_left intern_local_binder (env',rbefore) after in
+               let bl = List.rev (List.map glob_local_binder_of_extended rbl) in
+               (n, bl, intern_type env' ty, env')) dl in
         let idl = Array.map2 (fun (_,_,_,_,bd) (a,b,c,env') ->
-	     let env'' = List.fold_left_i (fun i en name -> 
-					     let (_,bli,tyi,_) = idl_temp.(i) in
-					     let fix_args = (List.map (fun (na, bk, _, _) -> (build_impls bk na)) bli) in
-					       push_name_env ntnvars (impls_type_list ~args:fix_args tyi)
-                                            en (CAst.make @@ Name name)) 0 env' lf in
-             (a,b,c,intern {env'' with tmp_scope = None} bd)) dl idl_temp in
-	DAst.make ?loc @@
-          GRec (GFix
-	      (Array.map (fun (ro,_,_,_) -> ro) idl,n),
+            let env'' = List.fold_left_i (fun i en name ->
+                let (_,bli,tyi,_) = idl_temp.(i) in
+                let fix_args = (List.map (fun (na, bk, _, _) -> (build_impls bk na)) bli) in
+                push_name_env ntnvars (impls_type_list ~args:fix_args tyi)
+                  en (CAst.make @@ Name name)) 0 env' lf in
+            (a,b,c,intern {env'' with tmp_scope = None} bd)) dl idl_temp in
+        DAst.make ?loc @@
+        GRec (GFix
+                (Array.map (fun (ro,_,_,_) -> ro) idl,n),
               Array.of_list lf,
               Array.map (fun (_,bl,_,_) -> bl) idl,
               Array.map (fun (_,_,ty,_) -> ty) idl,
               Array.map (fun (_,_,_,bd) -> bd) idl)
+
     | CCoFix ({ CAst.loc = locid; v = iddef }, dl) ->
         let lf = List.map (fun ({CAst.v = id},_,_,_) -> id) dl in
         let dl = Array.of_list dl in

--- a/interp/notation_ops.ml
+++ b/interp/notation_ops.ml
@@ -957,7 +957,7 @@ let match_fix_kind fk1 fk2 =
   match (fk1,fk2) with
   | GCoFix n1, GCoFix n2 -> Int.equal n1 n2
   | GFix (nl1,n1), GFix (nl2,n2) ->
-      let test (n1, _) (n2, _) = match n1, n2 with
+      let test n1 n2 = match n1, n2 with
       | _, None -> true
       | Some id1, Some id2 -> Int.equal id1 id2
       | _ -> false

--- a/interp/notation_term.ml
+++ b/interp/notation_term.ml
@@ -38,7 +38,7 @@ type notation_constr =
       notation_constr * notation_constr
   | NIf of notation_constr * (Name.t * notation_constr option) *
       notation_constr * notation_constr
-  | NRec of fix_kind * Id.t array *
+  | NRec of glob_fix_kind * Id.t array *
       (Name.t * notation_constr option * notation_constr) list array *
       notation_constr array * notation_constr array
   | NSort of glob_sort

--- a/parsing/g_constr.mlg
+++ b/parsing/g_constr.mlg
@@ -440,10 +440,10 @@ GRAMMAR EXTEND Gram
     ] ]
   ;
   fixannot:
-    [ [ "{"; IDENT "struct"; id=identref; "}" -> { CStructRec id }
-    | "{"; IDENT "wf"; rel=constr; id=identref; "}" -> { CWfRec(id,rel) }
+    [ [ "{"; IDENT "struct"; id=identref; "}" -> { CAst.make ~loc @@ CStructRec id }
+    | "{"; IDENT "wf"; rel=constr; id=identref; "}" -> { CAst.make ~loc @@ CWfRec(id,rel) }
     | "{"; IDENT "measure"; m=constr; id=OPT identref;
-        rel=OPT constr; "}" -> { CMeasureRec (id,m,rel) }
+        rel=OPT constr; "}" -> { CAst.make ~loc @@ CMeasureRec (id,m,rel) }
     ] ]
   ;
   impl_name_head:
@@ -452,7 +452,7 @@ GRAMMAR EXTEND Gram
   binders_fixannot:
     [ [ na = impl_name_head; assum = impl_ident_tail; bl = binders_fixannot ->
           { (assum na :: fst bl), snd bl }
-      | f = fixannot -> { [], Some (CAst.make ~loc f) }
+      | f = fixannot -> { [], Some f }
       | b = binder; bl = binders_fixannot -> { b @ fst bl, snd bl }
       | -> { [], None }
     ] ]

--- a/parsing/g_constr.mlg
+++ b/parsing/g_constr.mlg
@@ -56,10 +56,10 @@ let mk_fixb (id,bl,ann,body,(loc,tyc)) : fix_expr =
   (id,ann,bl,ty,body)
 
 let mk_cofixb (id,bl,ann,body,(loc,tyc)) : cofix_expr =
-  let _ = Option.map (fun { CAst.loc = aloc } ->
+  Option.iter (fun { CAst.loc = aloc } ->
     CErrors.user_err ?loc:aloc
       ~hdr:"Constr:mk_cofixb"
-      (Pp.str"Annotation forbidden in cofix expression.")) (fst ann) in
+      (Pp.str"Annotation forbidden in cofix expression.")) ann;
   let ty = match tyc with
       Some ty -> ty
     | None -> CAst.make @@ CHole (None, IntroAnonymous, None) in
@@ -440,10 +440,10 @@ GRAMMAR EXTEND Gram
     ] ]
   ;
   fixannot:
-    [ [ "{"; IDENT "struct"; id=identref; "}" -> { (Some id, CStructRec) }
-    | "{"; IDENT "wf"; rel=constr; id=OPT identref; "}" -> { (id, CWfRec rel) }
+    [ [ "{"; IDENT "struct"; id=identref; "}" -> { CStructRec id }
+    | "{"; IDENT "wf"; rel=constr; id=identref; "}" -> { CWfRec(id,rel) }
     | "{"; IDENT "measure"; m=constr; id=OPT identref;
-	rel=OPT constr; "}" -> { (id, CMeasureRec (m,rel)) }
+        rel=OPT constr; "}" -> { CMeasureRec (id,m,rel) }
     ] ]
   ;
   impl_name_head:
@@ -452,9 +452,9 @@ GRAMMAR EXTEND Gram
   binders_fixannot:
     [ [ na = impl_name_head; assum = impl_ident_tail; bl = binders_fixannot ->
           { (assum na :: fst bl), snd bl }
-      | f = fixannot -> { [], f }
+      | f = fixannot -> { [], Some (CAst.make ~loc f) }
       | b = binder; bl = binders_fixannot -> { b @ fst bl, snd bl }
-      | -> { [], (None, CStructRec) }
+      | -> { [], None }
     ] ]
   ;
   open_binders:

--- a/parsing/pcoq.mli
+++ b/parsing/pcoq.mli
@@ -191,7 +191,7 @@ module Constr :
     val binder : local_binder_expr list Entry.t (* closed_binder or variable *)
     val binders : local_binder_expr list Entry.t (* list of binder *)
     val open_binders : local_binder_expr list Entry.t
-    val binders_fixannot : (local_binder_expr list * recursion_order_expr CAst.t option) Entry.t
+    val binders_fixannot : (local_binder_expr list * recursion_order_expr option) Entry.t
     val typeclass_constraint : (lname * bool * constr_expr) Entry.t
     val record_declaration : constr_expr Entry.t
     val appl_arg : (constr_expr * explicitation CAst.t option) Entry.t

--- a/parsing/pcoq.mli
+++ b/parsing/pcoq.mli
@@ -191,7 +191,7 @@ module Constr :
     val binder : local_binder_expr list Entry.t (* closed_binder or variable *)
     val binders : local_binder_expr list Entry.t (* list of binder *)
     val open_binders : local_binder_expr list Entry.t
-    val binders_fixannot : (local_binder_expr list * (lident option * recursion_order_expr)) Entry.t
+    val binders_fixannot : (local_binder_expr list * recursion_order_expr CAst.t option) Entry.t
     val typeclass_constraint : (lname * bool * constr_expr) Entry.t
     val record_declaration : constr_expr Entry.t
     val appl_arg : (constr_expr * explicitation CAst.t option) Entry.t

--- a/plugins/funind/g_indfun.mlg
+++ b/plugins/funind/g_indfun.mlg
@@ -179,8 +179,10 @@ let () =
 VERNAC COMMAND EXTEND Function
 | ![ proof ] ["Function" ne_function_rec_definition_loc_list_sep(recsl,"with")]
     => { let hard = List.exists (function
-           | _,((_,(_,(CMeasureRec _|CWfRec _)),_,_,_),_) -> true
-           | _,((_,(_,CStructRec),_,_,_),_) -> false) recsl in
+           | _,((_,(Some { CAst.v = CMeasureRec _ }
+             | Some { CAst.v = CWfRec _}),_,_,_),_) -> true
+           | _,((_,Some { CAst.v = CStructRec _ },_,_,_),_)
+           | _,((_,None,_,_,_),_) -> false) recsl in
          match
            Vernac_classifier.classify_vernac
              (Vernacexpr.(VernacExpr([], VernacFixpoint(Decl_kinds.NoDischarge, List.map snd recsl))))

--- a/plugins/ssr/ssrparser.mlg
+++ b/plugins/ssr/ssrparser.mlg
@@ -1200,7 +1200,7 @@ let rec format_constr_expr h0 c0 = let open CAst in match h0, c0 with
   | [BFcast], { v = CCast (c, Glob_term.CastConv t) } ->
     [Bcast t], c
   | BFrec (has_str, has_cast) :: h, 
-    { v = CFix ( _, [_, (Some locn, CStructRec), bl, t, c]) } ->
+    { v = CFix ( _, [_, Some {CAst.v = CStructRec locn}, bl, t, c]) } ->
     let bs = format_local_binders h bl in
     let bstr = if has_str then [Bstruct (Name locn.CAst.v)] else [] in
     bs @ bstr @ (if has_cast then [Bcast t] else []), c 
@@ -1424,7 +1424,7 @@ ARGUMENT EXTEND ssrfixfwd TYPED AS (ident * ssrfwd) PRINTED BY { pr_ssrfixfwd }
           | [] -> CErrors.user_err (Pp.str "Bad structural argument") in
         loop (names_of_local_assums lb) in
       let h' = BFrec (has_struct, has_cast) :: binders_fmts bs in
-      let fix = CAst.make ~loc @@ CFix (lid, [lid, (Some i, CStructRec), lb, t', c']) in
+      let fix = CAst.make ~loc @@ CFix (lid, [lid, (Some (CAst.make (CStructRec i))), lb, t', c']) in
       id, ((fk, h'),  { ac with body = fix }) }
 END
 

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -653,7 +653,7 @@ let detype_fix detype flags avoid env sigma (vn,_ as nvn) (names,tys,bodies) =
   let v = Array.map3
     (fun c t i -> share_names detype flags (i+1) [] def_avoid def_env sigma c (lift n t))
     bodies tys vn in
-  GRec(GFix (Array.map (fun i -> Some i, GStructRec) (fst nvn), snd nvn),Array.of_list (List.rev lfi),
+  GRec(GFix (Array.map (fun i -> Some i) (fst nvn), snd nvn),Array.of_list (List.rev lfi),
        Array.map (fun (bl,_,_) -> bl) v,
        Array.map (fun (_,_,ty) -> ty) v,
        Array.map (fun (_,bd,_) -> bd) v)

--- a/pretyping/glob_ops.ml
+++ b/pretyping/glob_ops.ml
@@ -106,19 +106,9 @@ let glob_decl_eq f (na1, bk1, c1, t1) (na2, bk2, c2, t2) =
   Name.equal na1 na2 && binding_kind_eq bk1 bk2 &&
   Option.equal f c1 c2 && f t1 t2
 
-let fix_recursion_order_eq f o1 o2 = match o1, o2 with
-  | GStructRec, GStructRec -> true
-  | GWfRec c1, GWfRec c2 -> f c1 c2
-  | GMeasureRec (c1, o1), GMeasureRec (c2, o2) ->
-    f c1 c2 && Option.equal f o1 o2
-  | (GStructRec | GWfRec _ | GMeasureRec _), _ -> false
-
-let fix_kind_eq f k1 k2 = match k1, k2 with
+let fix_kind_eq k1 k2 = match k1, k2 with
   | GFix (a1, i1), GFix (a2, i2) ->
-    let eq (i1, o1) (i2, o2) =
-      Option.equal Int.equal i1 i2 && fix_recursion_order_eq f o1 o2
-    in
-    Int.equal i1 i2 && Array.equal eq a1 a2
+    Int.equal i1 i2 && Array.equal (Option.equal Int.equal) a1 a2
   | GCoFix i1, GCoFix i2 -> Int.equal i1 i2
   | (GFix _ | GCoFix _), _ -> false
 
@@ -150,7 +140,7 @@ let mk_glob_constr_eq f c1 c2 = match DAst.get c1, DAst.get c2 with
     f m1 m2 && Name.equal pat1 pat2 &&
     Option.equal f p1 p2 && f c1 c2 && f t1 t2
   | GRec (kn1, id1, decl1, t1, c1), GRec (kn2, id2, decl2, t2, c2) ->
-    fix_kind_eq f kn1 kn2 && Array.equal Id.equal id1 id2 &&
+    fix_kind_eq kn1 kn2 && Array.equal Id.equal id1 id2 &&
     Array.equal (fun l1 l2 -> List.equal (glob_decl_eq f) l1 l2) decl1 decl2 &&
     Array.equal f c1 c2 && Array.equal f t1 t2
   | GSort s1, GSort s2 -> glob_sort_eq s1 s2

--- a/pretyping/glob_term.ml
+++ b/pretyping/glob_term.ml
@@ -41,6 +41,12 @@ type glob_constraint = glob_level * Univ.constraint_type * glob_level
 type sort_info = (Libnames.qualid * int) option list
 type glob_sort = sort_info glob_sort_gen
 
+type glob_recarg = int option
+
+and glob_fix_kind =
+  | GFix of (glob_recarg array * int)
+  | GCoFix of int
+
 (** Casts *)
 
 type 'a cast_type =
@@ -78,7 +84,7 @@ type 'a glob_constr_r =
       (** [GCases(style,r,tur,cc)] = "match 'tur' return 'r' with 'cc'" (in [MatchStyle]) *)
   | GLetTuple of Name.t list * (Name.t * 'a glob_constr_g option) * 'a glob_constr_g * 'a glob_constr_g
   | GIf   of 'a glob_constr_g * (Name.t * 'a glob_constr_g option) * 'a glob_constr_g * 'a glob_constr_g
-  | GRec  of 'a fix_kind_g * Id.t array * 'a glob_decl_g list array *
+  | GRec  of glob_fix_kind * Id.t array * 'a glob_decl_g list array *
              'a glob_constr_g array * 'a glob_constr_g array
   | GSort of glob_sort
   | GHole of Evar_kinds.t * Namegen.intro_pattern_naming_expr * Genarg.glob_generic_argument option
@@ -87,15 +93,6 @@ type 'a glob_constr_r =
 and 'a glob_constr_g = ('a glob_constr_r, 'a) DAst.t
 
 and 'a glob_decl_g = Name.t * binding_kind * 'a glob_constr_g option * 'a glob_constr_g
-
-and 'a fix_recursion_order_g =
-  | GStructRec
-  | GWfRec of 'a glob_constr_g
-  | GMeasureRec of 'a glob_constr_g * 'a glob_constr_g option
-
-and 'a fix_kind_g =
-  | GFix of ((int option * 'a fix_recursion_order_g) array * int)
-  | GCoFix of int
 
 and 'a predicate_pattern_g =
     Name.t * (inductive * Name.t list) CAst.t option
@@ -117,9 +114,7 @@ type tomatch_tuples = [ `any ] tomatch_tuples_g
 type cases_clause = [ `any ] cases_clause_g
 type cases_clauses = [ `any ] cases_clauses_g
 type glob_decl = [ `any ] glob_decl_g
-type fix_kind = [ `any ] fix_kind_g
 type predicate_pattern = [ `any ] predicate_pattern_g
-type fix_recursion_order = [ `any ] fix_recursion_order_g
 
 type any_glob_constr = AnyGlobConstr : 'r glob_constr_g -> any_glob_constr
 

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -607,10 +607,10 @@ let rec pretype ~program_mode ~poly k0 resolve_tc (tycon : type_constraint) (env
 		 fixpoints ?) *)
 	  let possible_indexes =
 	    Array.to_list (Array.mapi
-			     (fun i (n,_) -> match n with
+                             (fun i annot -> match annot with
 			     | Some n -> [n]
 			     | None -> List.map_i (fun i _ -> i) 0 ctxtv.(i))
-			     vn)
+           vn)
 	  in
           let fixdecls = (names,ftys,fdefs) in
           let indexes = esearch_guard ?loc !!env sigma possible_indexes fixdecls in

--- a/printing/ppconstr.ml
+++ b/printing/ppconstr.ml
@@ -403,7 +403,7 @@ let tag_var = tag Tag.variable
     match ro with
       | None -> mt ()
       | Some {loc; v = ro} ->
-        match (ro : Constrexpr.recursion_order_expr) with
+        match ro with
           | CStructRec { v = id } ->
             let names_of_binder = function
               | CLocalAssum (nal,_,_) -> nal

--- a/printing/ppconstr.ml
+++ b/printing/ppconstr.ml
@@ -399,12 +399,12 @@ let tag_var = tag Tag.variable
       pr_opt_type_spc pr t ++ str " :=" ++
       pr_sep_com (fun () -> brk(1,2)) (pr_body ltop) c
 
-  let pr_guard_annot pr_aux bl (n,ro) =
-    match n with
+  let pr_guard_annot pr_aux bl ro =
+    match ro with
       | None -> mt ()
-      | Some {loc; v = id} ->
+      | Some {loc; v = ro} ->
         match (ro : Constrexpr.recursion_order_expr) with
-          | CStructRec ->
+          | CStructRec { v = id } ->
             let names_of_binder = function
               | CLocalAssum (nal,_,_) -> nal
               | CLocalDef (_,_,_) -> []
@@ -413,10 +413,11 @@ let tag_var = tag Tag.variable
                if List.length ids > 1 then
                  spc() ++ str "{" ++ keyword "struct" ++ spc () ++ pr_id id ++ str"}"
                else mt()
-          | CWfRec c ->
-            spc() ++ str "{" ++ keyword "wf" ++ spc () ++ pr_aux c ++ spc() ++ pr_id id ++ str"}"
-          | CMeasureRec (m,r) ->
-            spc() ++ str "{" ++ keyword "measure" ++ spc () ++ pr_aux m ++ spc() ++ pr_id id++
+          | CWfRec (id,c) ->
+            spc() ++ str "{" ++ keyword "wf" ++ spc () ++ pr_aux c ++ spc() ++ pr_lident id ++ str"}"
+          | CMeasureRec (id,m,r) ->
+            spc() ++ str "{" ++ keyword "measure" ++ spc () ++ pr_aux m ++
+            match id with None -> mt() | Some id -> spc () ++ pr_lident id ++
               (match r with None -> mt() | Some r -> str" on " ++ pr_aux r) ++ str"}"
 
   let pr_fixdecl pr prd dangling_with_for ({v=id},ro,bl,t,c) =

--- a/printing/ppconstr.mli
+++ b/printing/ppconstr.mli
@@ -37,7 +37,7 @@ val pr_glob_level : Glob_term.glob_level -> Pp.t
 val pr_glob_sort : Glob_term.glob_sort -> Pp.t
 val pr_guard_annot : (constr_expr -> Pp.t) ->
   local_binder_expr list ->
-  lident option * recursion_order_expr ->
+  recursion_order_expr CAst.t option ->
   Pp.t
 
 val pr_record_body : (qualid * constr_expr) list -> Pp.t

--- a/printing/ppconstr.mli
+++ b/printing/ppconstr.mli
@@ -35,10 +35,11 @@ val pr_patvar : Pattern.patvar -> Pp.t
 
 val pr_glob_level : Glob_term.glob_level -> Pp.t
 val pr_glob_sort : Glob_term.glob_sort -> Pp.t
-val pr_guard_annot : (constr_expr -> Pp.t) ->
-  local_binder_expr list ->
-  recursion_order_expr CAst.t option ->
-  Pp.t
+val pr_guard_annot
+  :  (constr_expr -> Pp.t)
+  -> local_binder_expr list
+  -> recursion_order_expr option
+  -> Pp.t
 
 val pr_record_body : (qualid * constr_expr) list -> Pp.t
 val pr_binders : Environ.env -> Evd.evar_map -> local_binder_expr list -> Pp.t

--- a/printing/proof_diffs.ml
+++ b/printing/proof_diffs.ml
@@ -438,18 +438,18 @@ let match_goals ot nt =
       | _, _ -> raise (Diff_Failure "Unable to match goals between old and new proof states (2)")
     in
     let recursion_order_expr ogname exp exp2 =
-      match exp, exp2 with
-      | CStructRec, CStructRec -> ()
-      | CWfRec c, CWfRec c2 ->
+      match exp.CAst.v, exp2.CAst.v with
+      | CStructRec _, CStructRec _ -> ()
+      | CWfRec (_,c), CWfRec (_,c2) ->
         constr_expr ogname c c2
-      | CMeasureRec (m,r), CMeasureRec (m2,r2) ->
+      | CMeasureRec (_,m,r), CMeasureRec (_,m2,r2) ->
         constr_expr ogname m m2;
         constr_expr_opt ogname r r2
       | _, _ -> raise (Diff_Failure "Unable to match goals between old and new proof states (3)")
     in
     let fix_expr ogname exp exp2 =
-      let (l,(lo,ro),lb,ce1,ce2), (l2,(lo2,ro2),lb2,ce12,ce22) = exp,exp2 in
-        recursion_order_expr ogname ro ro2;
+      let (l,ro,lb,ce1,ce2), (l2,ro2,lb2,ce12,ce22) = exp,exp2 in
+        Option.iter2 (recursion_order_expr ogname) ro ro2;
         iter2 (local_binder_expr ogname) lb lb2;
         constr_expr ogname ce1 ce12;
         constr_expr ogname ce2 ce22

--- a/test-suite/success/ProgramWf.v
+++ b/test-suite/success/ProgramWf.v
@@ -101,5 +101,5 @@ Next Obligation. simpl in *; intros.
 Qed.
 
 Program Fixpoint check_n'  (n : nat) (m : {m:nat | m = n}) (p : nat) (q:{q : nat | q = p})
-  {measure (p - n) p} : nat :=
+  {measure (p - n)} : nat :=
   _.

--- a/test-suite/success/ProgramWf.v
+++ b/test-suite/success/ProgramWf.v
@@ -13,7 +13,7 @@ Print sigT_rect.
 Obligation Tactic := program_simplify ; auto with *.
 About MR.
 
-Program Fixpoint merge (n m : nat) {measure (n + m) (lt)} : nat :=
+Program Fixpoint merge (n m : nat) {measure (n + m) lt} : nat :=
   match n with
     | 0 => 0
     | S n' => merge n' m

--- a/vernac/comFixpoint.mli
+++ b/vernac/comFixpoint.mli
@@ -62,7 +62,7 @@ val interp_recursive :
 (** Extracting the semantical components out of the raw syntax of
    (co)fixpoints declarations *)
 
-val extract_fixpoint_components : bool ->
+val extract_fixpoint_components : structonly:bool ->
   (fixpoint_expr * decl_notation list) list ->
     structured_fixpoint_expr list * decl_notation list
 

--- a/vernac/obligations.ml
+++ b/vernac/obligations.ml
@@ -295,7 +295,7 @@ type obligation =
 type obligations = (obligation array * int)
 
 type fixpoint_kind =
-  | IsFixpoint of (lident option * Constrexpr.recursion_order_expr) list
+  | IsFixpoint of lident option list
   | IsCoFixpoint
 
 type notations = (lstring * Constrexpr.constr_expr * Notation_term.scope_name option) list
@@ -486,7 +486,7 @@ let rec lam_index n t acc =
 	lam_index n b (succ acc)
     | _ -> raise Not_found
 
-let compute_possible_guardness_evidences (n,_) fixbody fixtype =
+let compute_possible_guardness_evidences n fixbody fixtype =
   match n with
   | Some { CAst.loc; v = n } -> [lam_index n fixbody 0]
   | None ->

--- a/vernac/obligations.mli
+++ b/vernac/obligations.mli
@@ -70,7 +70,7 @@ type notations =
     (lstring * Constrexpr.constr_expr * Notation_term.scope_name option) list
 
 type fixpoint_kind =
-  | IsFixpoint of (lident option * Constrexpr.recursion_order_expr) list
+  | IsFixpoint of lident option list
   | IsCoFixpoint
 
 val add_mutual_definitions :

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -129,7 +129,7 @@ type definition_expr =
       * constr_expr option
 
 type fixpoint_expr =
-    ident_decl * recursion_order_expr CAst.t option * local_binder_expr list * constr_expr * constr_expr option
+    ident_decl * recursion_order_expr option * local_binder_expr list * constr_expr * constr_expr option
 
 type cofixpoint_expr =
     ident_decl * local_binder_expr list * constr_expr * constr_expr option

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -129,7 +129,7 @@ type definition_expr =
       * constr_expr option
 
 type fixpoint_expr =
-    ident_decl * (lident option * recursion_order_expr) * local_binder_expr list * constr_expr * constr_expr option
+    ident_decl * recursion_order_expr CAst.t option * local_binder_expr list * constr_expr * constr_expr option
 
 type cofixpoint_expr =
     ident_decl * local_binder_expr list * constr_expr * constr_expr option


### PR DESCRIPTION
We make clearer which arguments are optional and which are mandatory.
Some of these representations are tricky because of small differences
between Program and Function, which share the same infrastructure.

As a side-effect of this cleanup, Program Fixpoint can now be used with
e.g. {measure (m + n) R}. Previously, parentheses were required around
R.

- https://github.com/LPCIC/coq-elpi/pull/53
- https://github.com/QuickChick/QuickChick/pull/157