### PR TITLE
Fixes #9166: no deprecation warning on aliases used as pattern variables

### DIFF
--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -1527,8 +1527,8 @@ let drop_notations_pattern looked_for genv =
     try
       match Nametab.locate_extended qid with
       | SynDef sp ->
-	let (vars,a) = Syntax_def.search_syntactic_definition sp in
-	(match a with
+        let filter (vars,a) =
+        try match a with
 	| NRef g ->
           (* Convention: do not deactivate implicit arguments and scopes for further arguments *)
 	  test_kind top g;
@@ -1549,7 +1549,9 @@ let drop_notations_pattern looked_for genv =
               let idspl1 = List.map (in_not false qid.loc scopes (subst, Id.Map.empty) []) args in
 	      let (_,argscs) = find_remaining_scopes pats1 pats2 g in
 	      Some (g, idspl1, List.map2 (in_pat_sc scopes) argscs pats2)
-	| _ -> raise Not_found)
+        | _ -> raise Not_found
+        with Not_found -> None in
+        Syntax_def.search_filtered_syntactic_definition filter sp
       | TrueGlobal g ->
 	  test_kind top g;
           Dumpglob.add_glob ?loc:qid.loc g;

--- a/interp/syntax_def.ml
+++ b/interp/syntax_def.ml
@@ -105,3 +105,10 @@ let search_syntactic_definition ?loc kn =
   let def = out_pat pat in
   verbose_compat ?loc kn def v;
   def
+
+let search_filtered_syntactic_definition ?loc filter kn =
+  let pat,v = KNmap.find kn !syntax_table in
+  let def = out_pat pat in
+  let res = filter def in
+  (match res with Some _ -> verbose_compat ?loc kn def v | None -> ());
+  res

--- a/interp/syntax_def.mli
+++ b/interp/syntax_def.mli
@@ -19,3 +19,6 @@ val declare_syntactic_definition : bool -> Id.t ->
   Flags.compat_version option -> syndef_interpretation -> unit
 
 val search_syntactic_definition : ?loc:Loc.t -> KerName.t -> syndef_interpretation
+
+val search_filtered_syntactic_definition : ?loc:Loc.t ->
+  (syndef_interpretation -> 'a option) -> KerName.t -> 'a option

--- a/test-suite/bugs/closed/bug_9166.v
+++ b/test-suite/bugs/closed/bug_9166.v
@@ -1,0 +1,9 @@
+Set Warnings "+deprecated".
+
+Notation bar := option (compat "8.7").
+
+Definition foo (x: nat) : nat :=
+  match x with
+  | 0 => 0
+  | S bar => bar
+  end.


### PR DESCRIPTION

**Kind:** bug fix 


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #9166

A rather ad hoc fix though.

<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [X] Added / updated test-suite
