### PR TITLE
[vernac] Remove obsolete Existential and Grab Existential variables.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,6 +44,9 @@ Specification language, type inference
   solved by writing an explicit `return` clause, sometimes even simply
   an explicit `return _` clause.
 
+- The commands `Existential` and `Grab Existential` have been
+  removed. Use XXX in its place.
+
 Kernel
 
 - Added primitive integers

--- a/doc/sphinx/proof-engine/proof-handling.rst
+++ b/doc/sphinx/proof-engine/proof-handling.rst
@@ -247,25 +247,6 @@ Name a set of section hypotheses for ``Proof using``
 
          Collection Many := Fewer - (x y)
 
-
-
-.. cmd:: Existential @num := @term
-
-   This command instantiates an existential variable. :token:`num` is an index in
-   the list of uninstantiated existential variables displayed by :cmd:`Show Existentials`.
-
-   This command is intended to be used to instantiate existential
-   variables when the proof is completed but some uninstantiated
-   existential variables remain. To instantiate existential variables
-   during proof edition, you should use the tactic :tacn:`instantiate`.
-
-.. cmd:: Grab Existential Variables
-
-   This command can be run when a proof has no more goal to be solved but
-   has remaining uninstantiated existential variables. It takes every
-   uninstantiated existential variable and turns it into a goal.
-
-
 Navigation in the proof tree
 --------------------------------
 

--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -1250,17 +1250,9 @@ module V82 = struct
     let (_goals,evd) = Evd.Monad.List.map map comb ps.solution in
     { ps with solution = evd; }
     end
-      
+
   let has_unresolved_evar pv =
     Evd.has_undefined pv.solution
-
-  (* Main function in the implementation of Grab Existential Variables.*)
-  let grab pv =
-    let undef = Evd.undefined_map pv.solution in
-    let goals = CList.rev_map fst (Evar.Map.bindings undef) in
-    { pv with comb = List.map with_empty_state goals }
-      
-    
 
   let top_goals initial { solution=solution; } =
     let goals = CList.map (fun (t,_) -> fst (Constr.destEvar (EConstr.Unsafe.to_constr t))) initial in

--- a/engine/proofview.mli
+++ b/engine/proofview.mli
@@ -580,11 +580,6 @@ module V82 : sig
 
   val has_unresolved_evar : proofview -> bool
 
-  (* Main function in the implementation of Grab Existential Variables.
-     Resets the proofview's goals so that it contains all unresolved evars
-     (in chronological order of insertion). *)
-  val grab : proofview -> proofview
-
   val top_goals : entry -> proofview -> Evar.t list Evd.sigma
 
   (* returns the existential variable used to start the proof *)

--- a/plugins/ltac/extratactics.mlg
+++ b/plugins/ltac/extratactics.mlg
@@ -904,16 +904,6 @@ TACTIC EXTEND is_const
     | _ -> Tacticals.New.tclFAIL 0 (Pp.str "not a constant") }
 END
 
-(* Command to grab the evars left unresolved at the end of a proof. *)
-(* spiwack: I put it in extratactics because it is somewhat tied with
-   the semantics of the LCF-style tactics, hence with the classic tactic
-   mode. *)
-VERNAC COMMAND EXTEND GrabEvars
-| [ "Grab" "Existential" "Variables" ]
-  => { classify_as_proofstep }
-  -> { Proof_global.simple_with_current_proof (fun _ p  -> Proof.V82.grab_evars p) }
-END
-
 (* Shelves all the goals under focus. *)
 TACTIC EXTEND shelve
 | [ "shelve" ] ->

--- a/proofs/pfedit.ml
+++ b/proofs/pfedit.ml
@@ -122,11 +122,6 @@ let solve ?with_end_tac gi info_lvl tac pr =
 
 let by tac = Proof_global.with_current_proof (fun _ -> solve (Goal_select.SelectNth 1) None tac)
 
-let instantiate_nth_evar_com n com = 
-  Proof_global.simple_with_current_proof (fun _ p ->
-      Proof.V82.instantiate_evar Global.(env ())n com p)
-
-
 (**********************************************************************)
 (* Shortcut to build a term using tactics *)
 

--- a/proofs/pfedit.mli
+++ b/proofs/pfedit.mli
@@ -60,13 +60,6 @@ val by : unit Proofview.tactic -> bool
 (** Option telling if unification heuristics should be used. *)
 val use_unification_heuristics : unit -> bool
 
-(** [instantiate_nth_evar_com n c] instantiate the [n]th undefined
-   existential variable of the current focused proof by [c] or raises a
-   UserError if no proof is focused or if there is no such [n]th
-   existential variable *)
-
-val instantiate_nth_evar_com : int -> Constrexpr.constr_expr -> unit
-
 (** [build_by_tactic typ tac] returns a term of type [typ] by calling
     [tac]. The return boolean, if [false] indicates the use of an unsafe
     tactic. *)

--- a/proofs/proof.ml
+++ b/proofs/proof.ml
@@ -472,40 +472,6 @@ module V82 = struct
   let top_evars p =
     Proofview.V82.top_evars p.entry
 
-  let grab_evars p =
-    if not (is_done p) then
-      raise (OpenProof(None, UnfinishedProof))
-    else
-      { p with proofview = Proofview.V82.grab p.proofview }
-
-  (* Main component of vernac command Existential *)
-  let instantiate_evar env n com pr =
-    let tac =
-      Proofview.tclBIND Proofview.tclEVARMAP begin fun sigma ->
-      let (evk, evi) =
-        let evl = Evarutil.non_instantiated sigma in
-        let evl = Evar.Map.bindings evl in
-        if (n <= 0) then
-          CErrors.user_err Pp.(str "incorrect existential variable index")
-        else if CList.length evl < n then
-          CErrors.user_err Pp.(str "not so many uninstantiated existential variables")
-        else
-          CList.nth evl (n-1)
-      in
-      let env = Evd.evar_filtered_env evi in
-      let rawc = Constrintern.intern_constr env sigma com in
-      let ltac_vars = Glob_ops.empty_lvar in
-      let sigma = Evar_refiner.w_refine (evk, evi) (ltac_vars, rawc) sigma in
-      Proofview.Unsafe.tclEVARS sigma
-    end in
-    let ((), proofview, _, _) = Proofview.apply env tac pr.proofview in
-    let shelf =
-      List.filter begin fun g ->
-        Evd.is_undefined (Proofview.return proofview) g
-      end pr.shelf
-    in
-    { pr with proofview ; shelf }
-
 end
 
 let all_goals p =

--- a/proofs/proof.mli
+++ b/proofs/proof.mli
@@ -244,13 +244,6 @@ module V82 : sig
   (* returns the existential variable used to start the proof *)
   val top_evars : t -> Evar.t list
 
-  (* Turns the unresolved evars into goals.
-     Raises [UnfinishedProof] if there are still unsolved goals. *)
-  val grab_evars : t -> t
-
-  (* Implements the Existential command *)
-  val instantiate_evar :
-    Environ.env -> int -> Constrexpr.constr_expr -> t -> t
 end
 
 (* returns the set of all goals in the proof *)

--- a/stm/vernac_classifier.ml
+++ b/stm/vernac_classifier.ml
@@ -81,8 +81,6 @@ let classify_vernac e =
     | VernacSubproof _
     | VernacCheckGuard
     | VernacUnfocused
-    | VernacSolveExistential _ ->
-        VtProofStep { parallel = `No; proof_block_detection = None }, VtLater
     | VernacBullet _ ->
         VtProofStep { parallel = `No; proof_block_detection = Some "bullet" },
         VtLater

--- a/test-suite/bugs/closed/bug_2969.v
+++ b/test-suite/bugs/closed/bug_2969.v
@@ -10,7 +10,7 @@ apply (H n).
 unfold n. clear n.
 eexists.
 reflexivity.
-Grab Existential Variables.
+Unshelve.
 admit.
 Admitted.
 
@@ -23,6 +23,6 @@ evar nat.
 assert (H := eq_refl : n0 = n).
 clearbody n n0.
 exact I.
-Grab Existential Variables.
+Unshelve.
 admit.
 Admitted.

--- a/test-suite/bugs/closed/bug_3531.v
+++ b/test-suite/bugs/closed/bug_3531.v
@@ -46,7 +46,7 @@ Goal forall b, (exists e1 e2 e3,
  eapply piff_trans; [ apply flatten_exists | apply piff_refl ]; intros.
  eapply piff_trans; [ apply flatten_exists | apply piff_refl ]; intros.
  assert (H : False) by (clear; admit); destruct H.
- Grab Existential Variables.
+ Unshelve.
  admit.
  admit.
  admit.

--- a/test-suite/bugs/closed/bug_3647.v
+++ b/test-suite/bugs/closed/bug_3647.v
@@ -648,7 +648,7 @@ Goal    forall (ptest : program) (cond : Condition) (value : bool)
                                       match xs with | nil => default_PointedOPred empOP | _ => Obody initial (nth x xs 0) end);
     simpl projT1; simpl projT2; simpl fst; simpl snd; clear; let H := fresh in assert (H : False) by (clear; admit); destruct H.
 
-  Grab Existential Variables.
+  Unshelve.
   subst_body; simpl.
   Fail refine (all_behead (projT2 _)).
   Unset Solve Unification Constraints. refine (all_behead (projT2 _)).

--- a/test-suite/success/apply.v
+++ b/test-suite/success/apply.v
@@ -396,7 +396,8 @@ Goal exists f:nat->nat, forall x y, x = y -> f x = f y.
 intros; eexists; intros.
 simple eapply (@f_equal nat).
 assumption.
-Existential 1 := fun x => x.
+Unshelve.
+refine (fun x => x).
 Qed.
 
 (* The following worked in 8.2 but was not accepted from r12229 to
@@ -407,7 +408,8 @@ Qed.
 Goal exists f:nat->nat, forall x y, x = y -> f x = f y.
 intros; eexists; intros.
 eauto.
-Existential 1 := fun x => x.
+Unshelve.
+refine (fun x => x).
 Qed.
 
 (* The following was accepted before r12612 but is still not accepted in r12658
@@ -545,7 +547,7 @@ Lemma bar (X: nat -> nat -> Prop) (foo:forall x, X x x) (a: unit) (H: tt = a):
 Proof.
 intros; eexists; eexists ?[y]; case H.
 apply (foo ?y).
-Grab Existential Variables.
+Unshelve.
 exact 0.
 Qed.
 

--- a/vernac/g_proofs.mlg
+++ b/vernac/g_proofs.mlg
@@ -62,8 +62,6 @@ GRAMMAR EXTEND Gram
       | IDENT "Abort" -> { VernacAbort None }
       | IDENT "Abort"; IDENT "All" -> { VernacAbortAll }
       | IDENT "Abort"; id = identref -> { VernacAbort (Some id) }
-      | IDENT "Existential"; n = natural; c = constr_body ->
-	  { VernacSolveExistential (n,c) }
       | IDENT "Admitted" -> { VernacEndProof Admitted }
       | IDENT "Qed" -> { VernacEndProof (Proved (Opaque,None)) }
       | IDENT "Save"; id = identref ->

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -969,9 +969,6 @@ open Pputils
           hov 2 (keyword "Include" ++ spc() ++
                    prlist_with_sep (fun () -> str " <+ ") pr_m mexprs)
         )
-      (* Solving *)
-      | VernacSolveExistential (i,c) ->
-        return (keyword "Existential" ++ spc () ++ int i ++ pr_lconstrarg c)
 
       (* Auxiliary file and library management *)
       | VernacAddLoadPath (fl,s,d) ->

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1064,8 +1064,6 @@ let focus_command_cond = Proof.no_cond command_focus
      there are no more goals to solve. It cannot be a tactic since
      all tactics fail if there are no further goals to prove. *)
 
-let vernac_solve_existential = Pfedit.instantiate_nth_evar_com
-
 let vernac_set_end_tac tac =
   let env = Genintern.empty_glob_sign (Global.env ()) in
   let _, tac = Genintern.generic_intern env tac in
@@ -2277,9 +2275,6 @@ let interp ?proof ~atts ~st c =
   | VernacContext sup -> vernac_context ~poly:(only_polymorphism atts) sup
   | VernacExistingInstance insts -> with_section_locality ~atts vernac_existing_instance insts
   | VernacExistingClass id -> unsupported_attributes atts; vernac_existing_class id
-
-  (* Solving *)
-  | VernacSolveExistential (n,c) -> unsupported_attributes atts; vernac_solve_existential n c
 
   (* Auxiliary file and library management *)
   | VernacAddLoadPath (isrec,s,alias) -> unsupported_attributes atts; vernac_add_loadpath isrec s alias

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -326,10 +326,6 @@ type nonrec vernac_expr =
       module_binder list * module_ast_inl list * module_ast_inl list
   | VernacInclude of module_ast_inl list
 
-  (* Solving *)
-
-  | VernacSolveExistential of int * constr_expr
-
   (* Auxiliary file and library management *)
   | VernacAddLoadPath of rec_flag * string * DirPath.t option
   | VernacRemoveLoadPath of string


### PR DESCRIPTION
This is a proposal to eventually remove the commands `Existential` and
`Grab Existential`. To my understanding these commands are supposed to
be deprecated and scheduled to removal, but not 100% sure so we would
need to confirm.

This would of course need a deprecation phase, let's see the impact on
CI first.

