### PR TITLE
add relation-algebra to CI test suite

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -442,6 +442,9 @@ ci-plugin_tutorial:
 ci-quickchick:
   <<: *ci-template-flambda
 
+ci-relation-algebra:
+  <<: *ci-template
+
 ci-sf:
   <<: *ci-template
 

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -39,6 +39,7 @@ CI_TARGETS= \
     ci-paramcoq \
     ci-plugin_tutorial \
     ci-quickchick \
+    ci-relation-algebra \
     ci-sf \
     ci-simple-io \
     ci-tlc \

--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -272,4 +272,4 @@
 ########################################################################
 : "${relation_algebra_CI_REF:=master}"
 : "${relation_algebra_CI_GITURL:=https://github.com/damien-pous/relation-algebra}"
-: "${aac_tactics_CI_ARCHIVEURL:=${relation_algebra_CI_GITURL}/archive}"
+: "${relation_algebra_CI_ARCHIVEURL:=${relation_algebra_CI_GITURL}/archive}"

--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -266,3 +266,10 @@
 : "${paramcoq_CI_REF:=master}"
 : "${paramcoq_CI_GITURL:=https://github.com/coq-community/paramcoq}"
 : "${paramcoq_CI_ARCHIVEURL:=${paramcoq_CI_GITURL}/archive}"
+
+########################################################################
+# relation-algebra
+########################################################################
+: "${relation_algebra_CI_REF:=master}"
+: "${relation_algebra_CI_GITURL:=https://github.com/damien-pous/relation-algebra}"
+: "${aac_tactics_CI_ARCHIVEURL:=${relation_algebra_CI_GITURL}/archive}"

--- a/dev/ci/ci-relation-algebra.sh
+++ b/dev/ci/ci-relation-algebra.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+ci_dir="$(dirname "$0")"
+. "${ci_dir}/ci-common.sh"
+
+git_download relation_algebra
+
+( cd "${CI_BUILD_DIR}/relation_algebra" && make && make install )


### PR DESCRIPTION
This adds the master branch of Damien Pous' [relation-algebra](https://github.com/damien-pous/relation-algebra) libraries to the CI suite. 

I tried to follow [`README-users.md`](https://github.com/chdoc/coq/blob/master/dev/ci/README-users.md), but, obviously, I cannot test this. So feel free to fix anything that's broken.

<!-- Keep what applies -->
**Kind:** infrastructure.
