### PR TITLE
Fix generated documentation for Declare Implicit Tactic.

### DIFF
--- a/doc/sphinx/proof-engine/tactics.rst
+++ b/doc/sphinx/proof-engine/tactics.rst
@@ -3800,7 +3800,7 @@ Setting implicit automation tactics
 
       .. example::
 
-         .. coqtop:: all
+         .. coqtop:: reset all
 
             Parameter quo : nat -> forall n:nat, n<>0 -> nat.
             Notation "x // y" := (quo x y _) (at level 40).


### PR DESCRIPTION
8.9 only, as the tactic no longer exists on master.