### PR TITLE
Fix issue #9175 Windows: VST addon does not work if CompCert is also installed.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -174,7 +174,7 @@ after_script:
     - call dev/ci/gitlab.bat
   only:
     variables:
-      - $WINDOWS == "enabled"
+      - $WINDOWS =~ /enabled/
 
 build:base:
   <<: *build-template

--- a/dev/build/windows/patches_coq/VST.patch
+++ b/dev/build/windows/patches_coq/VST.patch
@@ -1,0 +1,15 @@
+diff --git a/Makefile b/Makefile
+index 4a119042..fdfac13e 100755
+--- a/Makefile
++++ b/Makefile
+@@ -76,8 +76,8 @@ endif
+
+ COMPCERTDIRS=lib common $(ARCHDIRS) cfrontend flocq exportclight $(BACKEND)
+
+-COMPCERT_R_FLAGS= $(foreach d, $(COMPCERTDIRS), -R $(COMPCERT)/$(d) compcert.$(d))
+-EXTFLAGS= $(foreach d, $(COMPCERTDIRS), -Q $(COMPCERT)/$(d) compcert.$(d))
++COMPCERT_R_FLAGS= $(foreach d, $(COMPCERTDIRS), -R $(COMPCERT)/$(d) VST.compcert.$(d))
++EXTFLAGS= $(foreach d, $(COMPCERTDIRS), -Q $(COMPCERT)/$(d) VST.compcert.$(d))
+
+ # for SSReflect
+ ifdef MATHCOMP

--- a/dev/ci/README.md
+++ b/dev/ci/README.md
@@ -172,6 +172,11 @@ If your repository has access to runners tagged `windows`, setting the
 secret variable `WINDOWS` to `enabled` will add jobs building Windows
 versions of Coq (32bit and 64bit).
 
+If the secret variable `WINDOWS` is set to `enabled_all_addons`,
+an extended set of addons will be added to the Windows installer.
+This leads to a considerable runtime in CI so this is not enabled
+by default for pipelines for pull requests.
+
 The Windows jobs are enabled on Coq's repository, where pipelines for
 pull requests run.
 

--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -125,8 +125,8 @@
 ########################################################################
 # VST
 ########################################################################
-# Latest commit on master as of Sep 27, 2018
-: "${VST_CI_REF:=7d41c087a20bd7937def5adf6fe562182de080d5}"
+# Latest commit on master as of Dec 10, 2018
+: "${VST_CI_REF:=f6afb456db69df66c366c36b2d0218d92813f546}"
 : "${VST_CI_GITURL:=https://github.com/PrincetonUniversity/VST}"
 : "${VST_CI_ARCHIVEURL:=${VST_CI_GITURL}/archive}"
 

--- a/dev/ci/gitlab.bat
+++ b/dev/ci/gitlab.bat
@@ -54,12 +54,10 @@ call %CI_PROJECT_DIR%\dev\build\windows\MakeCoq_MinGW.bat -threads=1 ^
   -addon=extlib ^
   -addon=quickchick ^
   -addon=coquelicot ^
+  -addon=vst ^
+  -addon=aactactics ^
   -make=N ^
   -setup %CI_PROJECT_DIR%\%SETUP% || GOTO ErrorCopyLogFilesAndExit
-
-REM addons with build issues
-REM -addon=vst ^
-REM -addon=aactactics ^
 
 ECHO "Start Artifact Creation"
 TIME /T


### PR DESCRIPTION
This fixes issue #9175.

The solution chosen to resolve the name conflicts between VST and compcert is to use the name "VST.compcert" for the VST copy of compcert files. This is done by patching all VST files (with sed) and a small patch to the VST makefile.

I will discuss with the VST team if they take this patch upstream. This is a bit problematic, because e.g. the compcert references in .v files generated by compcert clightgen must then be patched. Also this makes it harder to switch between using the VST copy or the original compcert files harder, which researchers might want to do.

For the educational and evaluation purposes for which the Windows installer is intended, I think this is a good solution.