### PR TITLE
FIx issue #9188 : Enable VST and aactactics in 8.9

### DIFF
--- a/dev/ci/gitlab.bat
+++ b/dev/ci/gitlab.bat
@@ -54,12 +54,10 @@ call %CI_PROJECT_DIR%\dev\build\windows\MakeCoq_MinGW.bat -threads=1 ^
   -addon=extlib ^
   -addon=quickchick ^
   -addon=coquelicot ^
+  -addon=vst ^
+  -addon=aactactics ^
   -make=N ^
   -setup %CI_PROJECT_DIR%\%SETUP% || GOTO ErrorCopyLogFilesAndExit
-
-REM addons with build issues
-REM -addon=vst ^
-REM -addon=aactactics ^
 
 ECHO "Start Artifact Creation"
 TIME /T


### PR DESCRIPTION
Reenable the VST and aactactics addon for the Windows Installer for 8.9.
See also #9187.