### PR TITLE
Issue #9175, #9190, #9191 (various minor Windows build issues)

### DIFF
--- a/dev/build/windows/makecoq_mingw.sh
+++ b/dev/build/windows/makecoq_mingw.sh
@@ -1779,7 +1779,7 @@ function make_addon_compcert {
   make_menhir
   make_addon_menhirlib
   installer_addon_dependency_end
-  if build_prep_overlay CompCert; then
+  if build_prep_overlay compcert; then
     installer_addon_section compcert "CompCert" "ATTENTION: THIS IS NOT OPEN SOURCE! CompCert verified C compiler and Clightgen (required for using VST for your own code)" "off"
     logn configure ./configure -ignore-coq-version -clightgen -prefix "$PREFIXCOQ" -coqdevdir "$PREFIXCOQ/lib/coq/user-contrib/compcert" x86_32-cygwin
     log1 make
@@ -1829,7 +1829,7 @@ function vst_patch_compcert_refs {
 
 function make_addon_vst {
   installer_addon_dependency vst
-  if build_prep_overlay VST; then
+  if build_prep_overlay vst; then
     installer_addon_section vst "VST" "ATTENTION: SOME INCLUDED COMPCERT PARTS ARE NOT OPEN SOURCE! Verified Software Toolchain for verifying C code" "off"
     # log1 coq_set_timeouts_1000
     log1 vst_patch_compcert_refs
@@ -1859,7 +1859,7 @@ function make_addon_coquelicot {
 
 function make_addon_aactactics {
   installer_addon_dependency aac
-  if build_prep_overlay aactactics; then
+  if build_prep_overlay aac_tactics; then
     installer_addon_section aac "AAC" "Coq plugin for extensible associative and commutative rewriting" ""
     log1 make
     log2 make install

--- a/dev/build/windows/makecoq_mingw.sh
+++ b/dev/build/windows/makecoq_mingw.sh
@@ -701,7 +701,7 @@ function coq_set_timeouts_1000 {
 function make_sed {
   if build_prep https://ftp.gnu.org/gnu/sed/  sed-4.2.2  tar.gz ; then
     logn configure ./configure
-    log1 make
+    log1 make $MAKE_OPT
     log2 make install
     log2 make clean
     build_post
@@ -1107,7 +1107,7 @@ function make_ocamlbuild {
   make_ocaml
   if build_prep https://github.com/ocaml/ocamlbuild/archive 0.12.0 tar.gz 1 ocamlbuild-0.12.0; then
     log2 make configure OCAML_NATIVE=true OCAMLBUILD_PREFIX=$PREFIXOCAML OCAMLBUILD_BINDIR=$PREFIXOCAML/bin OCAMLBUILD_LIBDIR=$PREFIXOCAML/lib
-    log1 make
+    log1 make $MAKE_OPT
     log2 make install
     build_post
   fi
@@ -1634,7 +1634,7 @@ function make_addon_bignums {
     installer_addon_section bignums "Bignums" "Coq library for fast arbitrary size numbers" ""
     # To make command lines shorter :-(
     echo 'COQ_SRC_SUBDIRS:=$(filter-out plugins/%,$(COQ_SRC_SUBDIRS)) plugins/syntax' >> Makefile.coq.local
-    log1 make all
+    log1 make $MAKE_OPT all
     log2 make install
     build_post
   fi
@@ -1650,7 +1650,7 @@ function make_addon_equations {
     # Note: PATH is automatically saved/restored by build_prep / build_post
     PATH=$COQBIN:$PATH
     logn coq_makefile ${COQBIN}coq_makefile -f _CoqProject -o Makefile
-    log1 make
+    log1 make $MAKE_OPT
     log2 make install
     build_post
   fi
@@ -1696,7 +1696,7 @@ function make_addon_ltac2 {
   installer_addon_dependency ltac2
   if build_prep_overlay ltac2; then
     installer_addon_section ltac2 "Ltac-2" "Coq plugin with the Ltac-2 enhanced tactic language" ""
-    log1 make all
+    log1 make $MAKE_OPT all
     log2 make install
     build_post
   fi
@@ -1709,7 +1709,7 @@ function make_addon_unicoq {
   if build_prep_overlay unicoq; then
     installer_addon_section unicoq "Unicoq" "Coq plugin for an enhanced unification algorithm" ""
     log1 coq_makefile -f Make -o Makefile
-    log1 make
+    log1 make $MAKE_OPT
     log2 make install
     build_post
   fi
@@ -1724,7 +1724,7 @@ function make_addon_mtac2 {
   if build_prep_overlay mtac2; then
     installer_addon_section mtac2 "Mtac-2" "Coq plugin for a typed tactic language for Coq." ""
     log1 coq_makefile -f _CoqProject -o Makefile
-    log1 make
+    log1 make $MAKE_OPT
     log2 make install
     build_post
   fi
@@ -1766,7 +1766,7 @@ function make_addon_menhirlib {
     echo -R . MenhirLib > _CoqProject
     ls -1 *.v >> _CoqProject
     log1 coq_makefile -f _CoqProject -o Makefile.coq
-    log1 make -f Makefile.coq all
+    log1 make -f Makefile.coq $MAKE_OPT all
     logn make-install make -f Makefile.coq install
     build_post
   fi
@@ -1782,7 +1782,7 @@ function make_addon_compcert {
   if build_prep_overlay compcert; then
     installer_addon_section compcert "CompCert" "ATTENTION: THIS IS NOT OPEN SOURCE! CompCert verified C compiler and Clightgen (required for using VST for your own code)" "off"
     logn configure ./configure -ignore-coq-version -clightgen -prefix "$PREFIXCOQ" -coqdevdir "$PREFIXCOQ/lib/coq/user-contrib/compcert" x86_32-cygwin
-    log1 make
+    log1 make $MAKE_OPT
     log2 make install
     logn install-license-1 install -D -T  "LICENSE" "$PREFIXCOQ/lib/coq/user-contrib/compcert/LICENSE"
     logn install-license-2 install -D -T  "LICENSE" "$PREFIXCOQ/lib/compcert/LICENSE"
@@ -1861,7 +1861,7 @@ function make_addon_aactactics {
   installer_addon_dependency aac
   if build_prep_overlay aac_tactics; then
     installer_addon_section aac "AAC" "Coq plugin for extensible associative and commutative rewriting" ""
-    log1 make
+    log1 make $MAKE_OPT
     log2 make install
     build_post
   fi
@@ -1902,7 +1902,7 @@ function make_addon_quickchick {
   installer_addon_dependency_end
   if build_prep_overlay quickchick; then
     installer_addon_section quickchick "QuickChick" "Coq plugin for randomized testing and counter example search" ""
-    log1 make
+    log1 make $MAKE_OPT
     log2 make install
     build_post
   fi

--- a/dev/build/windows/patches_coq/VST.patch
+++ b/dev/build/windows/patches_coq/VST.patch
@@ -1,0 +1,15 @@
+diff --git a/Makefile b/Makefile
+index 4a119042..fdfac13e 100755
+--- a/Makefile
++++ b/Makefile
+@@ -76,8 +76,8 @@ endif
+
+ COMPCERTDIRS=lib common $(ARCHDIRS) cfrontend flocq exportclight $(BACKEND)
+
+-COMPCERT_R_FLAGS= $(foreach d, $(COMPCERTDIRS), -R $(COMPCERT)/$(d) compcert.$(d))
+-EXTFLAGS= $(foreach d, $(COMPCERTDIRS), -Q $(COMPCERT)/$(d) compcert.$(d))
++COMPCERT_R_FLAGS= $(foreach d, $(COMPCERTDIRS), -R $(COMPCERT)/$(d) VST.compcert.$(d))
++EXTFLAGS= $(foreach d, $(COMPCERTDIRS), -Q $(COMPCERT)/$(d) VST.compcert.$(d))
+
+ # for SSReflect
+ ifdef MATHCOMP

--- a/dev/ci/gitlab.bat
+++ b/dev/ci/gitlab.bat
@@ -49,10 +49,9 @@ IF "%WINDOWS%" == "enabled_all_addons" (
     -addon=compcert ^
     -addon=extlib ^
     -addon=quickchick ^
-    -addon=coquelicot
-  REM addons with build issues
-  REM -addon=vst ^
-  REM -addon=aactactics ^
+    -addon=coquelicot ^
+    -addon=vst ^
+    -addon=aactactics
 ) ELSE (
   SET "EXTRA_ADDONS= "
 )


### PR DESCRIPTION
The PR fixes issues

#9175: VST addon does not work if CompCert is also installed
#9190: Windows: overlay names changed in ci-basic-overlay.sh but have not been adjusted in make_coq_mingw.sh
#9191: Windows: parallel build is not enabled for some modules which support it

For v8.9 there is a separate PR #9188 for #9175. The other commits are not required for v8.9.