### PR TITLE
[ssr] extended intro patterns (episode 2)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -143,8 +143,10 @@ SSReflect
 
 - New intro patterns:
   - temporary introduction: => +
+  - custom /= and // switches: => /2/ /3=
   - block introduction: => [^ prefix ] [^~ suffix ]
   - fast introduction: => >
+  - dispatch: => ( .. | .. )
   - tactics as views: => /ltac:mytac
   See the reference manual for the actual documentation.
 

--- a/plugins/ssr/ssrparser.mlg
+++ b/plugins/ssr/ssrparser.mlg
@@ -831,7 +831,7 @@ let rec reject_binder crossed_paren k s =
   | Some (Tok.KEYWORD ")") when crossed_paren -> raise Stream.Failure
   | _ -> if crossed_paren then () else raise Stream.Failure
 
-let _test_nobinder = Pcoq.Entry.of_parser "test_nobinder" (reject_binder false 0)
+let test_nobinder = Pcoq.Entry.of_parser "test_nobinder" (reject_binder false 0)
 
 }
 
@@ -854,6 +854,12 @@ GRAMMAR EXTEND Gram
       IPatCase (Block(hat_id)) }
    | test_nohidden; "["; iorpat = ssriorpat; "]" -> {
       IPatCase (Regular iorpat) }
+   | "()" -> {
+      IPatDispatch (false,Regular [[]]) }
+   | test_nobinder; "("; hat = hat; ")" -> {
+      IPatDispatch (false,Block(hat)) }
+   | test_nobinder; "("; iorpat = ssriorpat; ")" -> {
+      IPatDispatch (false,Regular iorpat) }
    | test_nohidden; "[="; iorpat = ssriorpat; "]" -> {
       IPatInj iorpat } ]];
 END

--- a/test-suite/ssr/ipat_dispatch.v
+++ b/test-suite/ssr/ipat_dispatch.v
@@ -1,0 +1,16 @@
+Require Import ssreflect.
+
+Lemma one : True -> True.
+Proof.
+move=> () H; exact H.
+Qed.
+
+Lemma two : True \/ True -> True.
+Proof.
+Fail case => ().
+Abort.
+
+Lemma three (x : nat) : True.
+Proof.
+by elim E: x => (|m IH).
+Qed.

--- a/test-suite/ssr/ipat_simpln.v
+++ b/test-suite/ssr/ipat_simpln.v
@@ -1,0 +1,61 @@
+Require Import ssreflect.
+
+Axiom oops : 3=4.
+
+Ltac ssrdone33 := exact: oops.
+
+Lemma false : 5 = 6.
+Proof.
+congr (S (S _)).
+Fail done.
+move => /33/.
+Qed.
+
+Lemma false2 : 3 = 4 /\ 2 + 3 = 5.
+Proof.
+split => /33/=.
+lazymatch goal with
+| |- 2 + 3 = 5 => fail
+| |- 5 = 5 => done
+end.
+Qed.
+
+Ltac ssrsimpl7 := idtac.
+
+Lemma test2 : 1+1 = 2.
+Proof.
+move=> /7=.
+match goal with |- 1+1=2 => idtac end.
+move=> /=.
+match goal with |- 2=2 => reflexivity end.
+Qed.
+
+Lemma test3 : 1+1 = 2 /\ 3=4.
+Proof.
+split=> /33/7=.
+match goal with |- 1+1=2 => idtac end.
+move=> /=.
+match goal with |- 2=2 => reflexivity end.
+Qed.
+
+Lemma test4 : 1+2 = 4 /\ 4=4.
+Proof.
+split=> //7=.
+match goal with |- 1+2=4 => idtac end.
+move=> /33/.
+Qed.
+
+Lemma test5 : 1=1 /\ 2=2.
+Proof.
+move=> /0/.
+split=> /0/.
+Qed.
+
+Lemma test6 : True.
+Proof. move => //. Qed.
+
+Lemma test7 : 1 + 1 = 2.
+Proof.
+rewrite /7=.
+reflexivity.
+Qed.


### PR DESCRIPTION
Depends on: #6705 

This PR enables `=> ( | )` and `=> /2/` and `/2=` and has been extracted out of #6705 as per https://github.com/coq/coq/pull/6705#issuecomment-446229018