### PR TITLE
Addressing #9180 and other fine-tunings of notation printing, including proper support for generic notations of applications

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,6 +49,9 @@ Notations
 - New command `String Notation` to register string syntax for custom
   inductive types.
 
+- Proper support for notations of generic applications (i.e. with
+  flexible head, as in "Notation app f x := (f x).")
+
 Plugins
 
 - The quote plugin (https://coq.inria.fr/distrib/V8.8.1/refman/proof-engine/detailed-tactic-examples.html#quote)

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -464,7 +464,11 @@ and apply_notation_to_pattern ?loc gr ((subst,substlist),(nb_to_drop,more_args))
 		substlist in
 	    let l2 = List.map (extern_cases_pattern_in_scope allscopes vars) more_args in
             let l2' = if Constrintern.get_asymmetric_patterns () || not (List.is_empty ll) then l2
-	      else
+              else if nb_to_drop = Some 0 then
+                (* indicates that notation is bound to some [@ref] *)
+                l2
+              else
+                let nb_to_drop = match nb_to_drop with Some nb_to_drop -> nb_to_drop | None -> 0 in
 		match drop_implicits_in_patt gr nb_to_drop l2 with
 		  |Some true_args -> true_args
 		  |None -> raise No_match
@@ -485,7 +489,11 @@ and apply_notation_to_pattern ?loc gr ((subst,substlist),(nb_to_drop,more_args))
           subst in
       let l2 = List.map (extern_cases_pattern_in_scope allscopes vars) more_args in
       let l2' = if Constrintern.get_asymmetric_patterns () then l2
-	else
+        else if nb_to_drop = Some 0 then
+          (* indicates that notation is bound to some [@ref] *)
+          (assert (l1=[]); l2)
+        else
+          let nb_to_drop = match nb_to_drop with Some nb_to_drop -> nb_to_drop | None -> 0 in
 	  match drop_implicits_in_patt gr (nb_to_drop + List.length l1) l2 with
 	    |Some true_args -> true_args
 	    |None -> raise No_match

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -1084,10 +1084,12 @@ and extern_notation (custom,scopes as allscopes) lonely_seen vars t = function
           (* This deactivates the use of implicit arguments or scopes *)
 	  | GApp (f,args), Some n
 	      when List.length args >= n ->
-	      let args1, args2 = List.chop n args in
-              let subscopes, impls =
-                match DAst.get f with
+                (match DAst.get f with
                 | GRef (ref,us) ->
+                  (* Case of a notation with a ref at head *)
+                  (* We align on the ref and apply scope/impl *)
+                  (* info to extra arguments *)
+                  let args1, args2 = List.chop n args in
 	          let subscopes =
 		    try List.skipn n (find_arguments_scope ref)
                     with Failure _ -> [] in
@@ -1096,10 +1098,11 @@ and extern_notation (custom,scopes as allscopes) lonely_seen vars t = function
 		      select_impargs_size
 		        (List.length args) (implicits_of_global ref) in
 		    try List.skipn n impls with Failure _ -> [] in
-                  subscopes,impls
+                  DAst.make @@ GApp (f,args1), args2, subscopes,impls
                 | _ ->
-                  [], [] in
-              DAst.make @@ GApp (f,args1), args2, subscopes, impls
+                  (* Case of a notation with no ref at head *)
+                  (* We align on the size of arguments of the notation *)
+                  t, [], [], [])
 	  | GApp (f, args), None ->
             begin match DAst.get f with
             | GRef (ref,us) ->

--- a/interp/notation.mli
+++ b/interp/notation.mli
@@ -234,7 +234,7 @@ type notation_rule =
 (** Return the possible notations for a given term *)
 val uninterp_notations : subscopes -> 'a glob_constr_g -> notation_rule list
 val uninterp_cases_pattern_notations : subscopes -> 'a cases_pattern_g -> notation_rule list
-val uninterp_ind_pattern_notations : subscopes -> inductive -> notation_rule list
+val uninterp_ind_pattern_notations : subscopes -> inductive -> 'a cases_pattern_g list -> notation_rule list
 
 (*
 (** Test if a notation is available in the scopes 

--- a/interp/notation.mli
+++ b/interp/notation.mli
@@ -224,7 +224,7 @@ val interp_notation : ?loc:Loc.t -> notation -> subscopes ->
 type notation_rule_core =
     interp_rule (* kind of notation *)
   * interpretation (* pattern associated to the notation *)
-  * int option (* number of expected arguments *)
+  * notation_applicative_structure (* structure of notation if applicative *)
 
 type notation_rule =
     notation_rule_core

--- a/interp/notation_ops.ml
+++ b/interp/notation_ops.ml
@@ -1327,11 +1327,11 @@ let match_cases_pattern_list match_fun metas sigma rest x y iter termin revert =
 
 let rec match_cases_pattern metas (terms,termlists,(),() as sigma) a1 a2 =
  match DAst.get a1, a2 with
-  | r1, NVar id2 when Id.List.mem_assoc id2 metas -> (bind_env_cases_pattern sigma id2 a1),(None,[])
-  | PatVar Anonymous, NHole _ -> sigma,(None,[])
+  | r1, NVar id2 when Id.List.mem_assoc id2 metas -> (bind_env_cases_pattern sigma id2 a1),(NotAppliedRef,[])
+  | PatVar Anonymous, NHole _ -> sigma,(NotAppliedRef,[])
   | PatCstr ((ind,_ as r1),largs,Anonymous), NRef (ConstructRef r2) when eq_constructor r1 r2 ->
       let l = try add_patterns_for_params_remove_local_defs r1 largs with Not_found -> raise No_match in
-      sigma,(None,l)
+      sigma,(NAryApplication 0,l)
   | PatCstr ((ind,_ as r1),args1,Anonymous), NApp (NRef (ConstructRef r2),l2)
       when eq_constructor r1 r2 ->
       let l1 = try add_patterns_for_params_remove_local_defs r1 args1 with Not_found -> raise No_match in
@@ -1341,10 +1341,15 @@ let rec match_cases_pattern metas (terms,termlists,(),() as sigma) a1 a2 =
 	raise No_match
       else
 	let l1',more_args = Util.List.chop le2 l1 in
-        (List.fold_left2 (match_cases_pattern_no_more_args metas) sigma l1' l2),(Some le2,more_args)
+        let k = if le2 = 0 then RefDeactivatingImpls else NAryApplication le2 in
+        (List.fold_left2 (match_cases_pattern_no_more_args metas) sigma l1' l2),(k,more_args)
   | r1, NList (x,y,iter,termin,revert) ->
+      let k = match iter with
+        | NApp (NRef ref,args) -> NAryApplication (List.length args)
+        | NRef _ -> NAryApplication 0
+        | _ -> NotAppliedRef in
       (match_cases_pattern_list (match_cases_pattern_no_more_args)
-        metas (terms,termlists,(),()) a1 x y iter termin revert),(None,[])
+        metas (terms,termlists,(),()) a1 x y iter termin revert),(k,[])
   | _ -> raise No_match
 
 and match_cases_pattern_no_more_args metas sigma a1 a2 =
@@ -1355,7 +1360,7 @@ and match_cases_pattern_no_more_args metas sigma a1 a2 =
 let match_ind_pattern metas sigma ind pats a2 =
   match a2 with
   | NRef (IndRef r2) when eq_ind ind r2 ->
-      sigma,(None,pats)
+      sigma,(NotAppliedRef,pats)
   | NApp (NRef (IndRef r2),l2)
       when eq_ind ind r2 ->
       let le2 = List.length l2 in
@@ -1364,7 +1369,8 @@ let match_ind_pattern metas sigma ind pats a2 =
 	raise No_match
       else
 	let l1',more_args = Util.List.chop le2 pats in
-        (List.fold_left2 (match_cases_pattern_no_more_args metas) sigma l1' l2),(Some le2,more_args)
+        let k = if le2 = 0 then RefDeactivatingImpls else NAryApplication le2 in
+        (List.fold_left2 (match_cases_pattern_no_more_args metas) sigma l1' l2),(k,more_args)
   |_ -> raise No_match
 
 let reorder_canonically_substitution terms termlists metas =

--- a/interp/notation_ops.mli
+++ b/interp/notation_ops.mli
@@ -60,12 +60,12 @@ val match_notation_constr : bool -> 'a glob_constr_g -> interpretation ->
 val match_notation_constr_cases_pattern :
   'a cases_pattern_g -> interpretation ->
   (('a cases_pattern_g * extended_subscopes) list * ('a cases_pattern_g list * extended_subscopes) list) *
-    (int option * 'a cases_pattern_g list)
+    (notation_applicative_structure * 'a cases_pattern_g list)
 
 val match_notation_constr_ind_pattern :
   inductive -> 'a cases_pattern_g list -> interpretation ->
   (('a cases_pattern_g * extended_subscopes) list * ('a cases_pattern_g list * extended_subscopes) list) *
-    (int option * 'a cases_pattern_g list)
+    (notation_applicative_structure * 'a cases_pattern_g list)
 
 (** {5 Matching a notation pattern against a [glob_constr]} *)
 

--- a/interp/notation_ops.mli
+++ b/interp/notation_ops.mli
@@ -60,12 +60,12 @@ val match_notation_constr : bool -> 'a glob_constr_g -> interpretation ->
 val match_notation_constr_cases_pattern :
   'a cases_pattern_g -> interpretation ->
   (('a cases_pattern_g * extended_subscopes) list * ('a cases_pattern_g list * extended_subscopes) list) *
-    (int * 'a cases_pattern_g list)
+    (int option * 'a cases_pattern_g list)
 
 val match_notation_constr_ind_pattern :
   inductive -> 'a cases_pattern_g list -> interpretation ->
   (('a cases_pattern_g * extended_subscopes) list * ('a cases_pattern_g list * extended_subscopes) list) *
-    (int * 'a cases_pattern_g list)
+    (int option * 'a cases_pattern_g list)
 
 (** {5 Matching a notation pattern against a [glob_constr]} *)
 

--- a/interp/notation_term.ml
+++ b/interp/notation_term.ml
@@ -96,3 +96,8 @@ type notation_interp_env = {
   ninterp_var_type : notation_var_internalization_type Id.Map.t;
   ninterp_rec_vars : Id.t Id.Map.t;
 }
+
+type notation_applicative_structure =
+  | NAryApplication of int
+  | RefDeactivatingImpls
+  | NotAppliedRef

--- a/test-suite/output/Inductive.out
+++ b/test-suite/output/Inductive.out
@@ -1,6 +1,6 @@
 The command has indeed failed with message:
 Last occurrence of "list'" must have "A" as 1st argument in
- "A -> list' A -> list' (A * A)".
+ "A -> list' A -> list' (A * A)%type".
 Inductive foo (A : Type) (x : A) (y : A := x) : Prop :=  Foo : foo A x
 
 For foo: Argument scopes are [type_scope _]

--- a/test-suite/output/Inductive.v
+++ b/test-suite/output/Inductive.v
@@ -1,6 +1,9 @@
 Fail Inductive list' (A:Set) : Set :=
 | nil' : list' A
 | cons' : A -> list' A -> list' (A*A).
+  (* Note: There is a printing bug: information that the argument of [list']
+     is a type was known from the parser (constrintern) but is not known
+     from printing (constrextern) *)
 
 (* Check printing of let-ins *)
 #[universes(template)] Inductive foo (A : Type) (x : A) (y := x) := Foo.

--- a/test-suite/output/Notations.out
+++ b/test-suite/output/Notations.out
@@ -72,6 +72,8 @@ Nil
      : forall A : Type, list A
 NIL : list nat
      : list nat
+F Z 0
+     : Z
 (false && I 3)%bool /\ (I 6)%bool
      : Prop
 [|1, 2, 3; 4, 5, 6|]

--- a/test-suite/output/Notations.out
+++ b/test-suite/output/Notations.out
@@ -84,6 +84,8 @@ F Z 0
      : Z * Z * (Z * Z) * (Z * Z) * (Z * bool * (Z * bool) * (Z * bool))
 fun f : Z -> Z -> Z -> Z => {|f; 0; 1; 2|} : Z
      : (Z -> Z -> Z -> Z) -> Z
+{|@id; Z; 0|}
+     : Z
 Init.Nat.add
      : nat -> nat -> nat
 S

--- a/test-suite/output/Notations.out
+++ b/test-suite/output/Notations.out
@@ -99,13 +99,13 @@ Init.Nat.mul
 le
      : nat -> nat -> Prop
 fun x : option Z => match x with
-                    | SOME x0 => x0
-                    | NONE => 0
+                    | SOME3 _ x0 => x0
+                    | NONE3 _ => 0
                     end
      : option Z -> Z
 fun x : option Z => match x with
-                    | SOME2 x0 => x0
-                    | NONE2 => 0
+                    | SOME x0 => x0
+                    | NONE => 0
                     end
      : option Z -> Z
 fun x : option Z => match x with

--- a/test-suite/output/Notations.out
+++ b/test-suite/output/Notations.out
@@ -66,6 +66,8 @@ The command has indeed failed with message:
 Both ends of the recursive pattern are the same.
 SUM (nat * nat) nat
      : Set
+SUM' (nat * nat) nat
+     : Type
 FST (0; 1)
      : Z
 Nil
@@ -113,14 +115,10 @@ fun x : option Z => match x with
                     | NONE2 => 0
                     end
      : option Z -> Z
-fun x : list ?T => match x with
-                   | NIL => NONE2
-                   | (_ :') t => SOME2 t
-                   end
-     : list ?T -> option (list ?T)
-where
-?T : [x : list ?T  x1 : list ?T  x0 := x1 : list ?T |- Type] (x, x1,
-     x0 cannot be used)
+fun x : L => match x with
+             | (_ :') t => t
+             end
+     : L -> nat
 s
      : s
 10

--- a/test-suite/output/Notations.v
+++ b/test-suite/output/Notations.v
@@ -168,8 +168,17 @@ Fail Notation "( x , y , .. , z )" := (pair .. (pair (pair y z) x) .. x).
 (**********************************************************************)
 (* Check preservation of scopes at printing time *)
 
-Notation SUM := sum.
+Module sum.
+
+Notation SUM a b := (sum a b).
 Check SUM (nat*nat) nat.
+
+  (* Alternative example which does not collide with the notation + for sum *)
+Parameter sum' : Type -> Type -> Type.
+Notation SUM' := sum'.
+Check SUM' (nat*nat) nat.
+
+End sum.
 
 (**********************************************************************)
 (* Check preservation of implicit arguments at printing time *)
@@ -266,9 +275,11 @@ Notation NONE2 := (@None _).
 Notation SOME2 := (@Some _).     
 Check (fun x => match x with SOME2 x => x | NONE2 => 0 end).
 
-Notation "a :'" := (cons a) (at level 12).
-
-Check (fun x => match x with | nil => NONE | h :' t => SOME3 _ t end).
+Module E.
+Inductive L := C : nat -> nat -> L.
+Notation "a :'" := (C a) (at level 12).
+Check (fun x => match x with h :' t => t end).
+End E.
 
 (* Check correct matching of "Type" in notations. Of course the
    notation denotes a term that will be reinterpreted with a different

--- a/test-suite/output/Notations.v
+++ b/test-suite/output/Notations.v
@@ -233,12 +233,14 @@ Check [|0*(1,2,3);(4,5,6)*false|].
 
 (**********************************************************************)
 (* Test recursive notations involving applications                    *)
-(* Caveat: does not work for applied constant because constants are   *)
-(* classified as notations for the particular constant while this     *)
-(* generic application notation is classified as generic              *)
+
+Module GenericApp.
 
 Notation "{| f ; x ; .. ; y |}" := ( .. (f x) .. y).
 Check fun f => {| f; 0; 1; 2 |} : Z.
+Check id 0.
+
+End GenericApp.
 
 (**********************************************************************)
 (* Check printing of notations from other modules *)

--- a/test-suite/output/Notations.v
+++ b/test-suite/output/Notations.v
@@ -254,6 +254,10 @@ Check le.
 
 (* Check notations in cases patterns *)
 
+Notation NONE3 := @None.
+Notation SOME3 := @Some.
+Check (fun x => match x with SOME3 _ x => x | NONE3 _ => 0 end).
+
 Notation SOME := Some.
 Notation NONE := None.
 Check (fun x => match x with SOME x => x | NONE => 0 end).
@@ -261,10 +265,6 @@ Check (fun x => match x with SOME x => x | NONE => 0 end).
 Notation NONE2 := (@None _).
 Notation SOME2 := (@Some _).     
 Check (fun x => match x with SOME2 x => x | NONE2 => 0 end).
-
-Notation NONE3 := @None.
-Notation SOME3 := @Some.     
-Check (fun x => match x with SOME3 _ x => x | NONE3 _ => 0 end).
 
 Notation "a :'" := (cons a) (at level 12).
 

--- a/test-suite/output/Notations.v
+++ b/test-suite/output/Notations.v
@@ -187,6 +187,14 @@ Check Nil.
 Notation NIL := nil.
 Check NIL : list nat.
 
+Section D.
+
+Variable f : forall A, A -> A.
+Arguments f {A}.
+Notation F := @f.
+Check f 0.
+
+End D.
 
 (**********************************************************************)
 (* Test printing of notation with coercions in scope of a coercion    *)

--- a/test-suite/output/Notations2.out
+++ b/test-suite/output/Notations2.out
@@ -35,6 +35,8 @@ let' f (x y : nat) (a := 0) (z : nat) (_ : bool) := x + y + z + 1 in f 0 1 2
      : bool -> nat
 λ (f : nat -> nat) (x : nat), f(x) + S(x)
      : (nat -> nat) -> nat -> nat
+λ (f : nat -> nat -> nat) (x : nat), (f(x))(x)
+     : (nat -> nat -> nat) -> nat -> nat
 Notation plus2 n := (S(S(n)))
 λ n : list(nat), match n with
                  | list1 => 0

--- a/test-suite/output/Notations2.v
+++ b/test-suite/output/Notations2.v
@@ -74,6 +74,8 @@ Notation "f ( x )" := (f x) (at level 10, format "f ( x )").
 Open Scope nat_scope.
 Check fun f x => f x + S x.
 
+Check fun (f:nat->nat->nat) x => f x x.
+
 Open Scope list_scope.
 Notation list1 := (1::nil)%list.
 Notation plus2 n := (S (S n)).

--- a/test-suite/output/Notations4.out
+++ b/test-suite/output/Notations4.out
@@ -49,3 +49,22 @@ forall x : nat, x.+1 = x.+1
      : Prop
 Notation Cn := Foo.FooCn
 Expands to: Notation Top.J.Mfoo.Foo.Bar.Cn
+(add.s z) y
+     : nat
+(add.s z).s z
+     : nat
+(add x).s z
+     : nat
+add2 z z
+     : nat
+gxy.s z
+     : nat
+fun (x : forall (x : ?T) (x0 : ?T0), ?T1) (y : forall x0 : ?T, ?T0@{x:=x0})
+  (z : ?T) => app (app x z) (app y z)
+     : (forall (x : ?T) (x0 : ?T0), ?T1) ->
+       forall (y : forall x0 : ?T, ?T0@{x:=x0}) (z : ?T),
+       ?T1@{x:=z; x0:=app y z}
+where
+?T : [ |- Type]
+?T0 : [x : ?T |- Type]
+?T1 : [x : ?T  x0 : ?T0 |- Type]

--- a/test-suite/output/Notations4.out
+++ b/test-suite/output/Notations4.out
@@ -68,3 +68,5 @@ where
 ?T : [ |- Type]
 ?T0 : [x : ?T |- Type]
 ?T1 : [x : ?T  x0 : ?T0 |- Type]
+fun (f : X -> nat) (x y : X) (z t : nat) => f (x + y) = (z + t)%nat
+     : (X -> nat) -> X -> X -> nat -> nat -> Prop

--- a/test-suite/output/Notations4.out
+++ b/test-suite/output/Notations4.out
@@ -45,5 +45,7 @@ fun x : nat => (x.-1)%pred
      : Prop
 ##
      : Prop
+forall x : nat, x.+1 = x.+1
+     : Prop
 Notation Cn := Foo.FooCn
 Expands to: Notation Top.J.Mfoo.Foo.Bar.Cn

--- a/test-suite/output/Notations4.v
+++ b/test-suite/output/Notations4.v
@@ -165,6 +165,18 @@ Check ##.
 
 End H.
 
+(* This addresses #9180: give preference to notations which matches
+   the largest part of an applicative node *)
+
+Module I.
+
+Notation succn := (Datatypes.S).
+Notation "n .+1" := (succn n) (at level 2, left associativity,
+  format "n .+1") : nat_scope.
+Check forall x : nat, x.+1 = x.+1.
+
+End I.
+
 (* Fixing a bug reported by G. Gonthier in #9207 *)
 
 Module J.

--- a/test-suite/output/Notations4.v
+++ b/test-suite/output/Notations4.v
@@ -220,3 +220,17 @@ Notation app f x := (f x).
 Check fun x y z => x z (y z).
 
 End K.
+
+(* Check uses of delimiters when a scope hides another one *)
+
+Module L.
+
+Axiom X : Type.
+Axiom add : X -> X -> X.
+Declare Scope X_scope.
+Notation "x + y" := (add x y) : X_scope.
+Open Scope X_scope.
+Delimit Scope X_scope with X.
+Check fun f x y z t => f (x + y)%X = (z + t)%nat.
+
+End L.

--- a/test-suite/output/Notations4.v
+++ b/test-suite/output/Notations4.v
@@ -193,3 +193,30 @@ End Mfoo.
 About Cn.
 
 End J.
+
+(* This addresses a wish expressed in #9180: proper support for
+   notations of generic forms of applications *)
+
+Module K.
+
+Parameter add : nat -> nat -> nat.
+Parameters x y : nat.
+Parameters z : nat * nat.
+
+Notation "f '.s' x" := (f (fst x)) (at level 10, format "f '.s'  x").
+Check add (fst z) y.
+Check add (fst z) (fst z).
+Check add x (fst z).
+
+Notation add1 x := (add (fst x)).
+Notation add2 x y := (add (fst x) (fst y)).
+Check add2 z z.
+
+Parameter g : nat -> nat -> nat -> nat.
+Notation gxy := (g x y).
+Check gxy.s z.
+
+Notation app f x := (f x).
+Check fun x y z => x z (y z).
+
+End K.


### PR DESCRIPTION

**Kind:** misc bug fix / fine-tuning of #8187

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #9180

This PR implements "fine-tuning" changes to notation printing in relation with the discussion at #9180:
- on applicative nodes, be consistent with the subterm order (applicative nodes are treated specially to accomodate implicit arguments and there was no effort to browse notations in subterm order); this has two consequences:
  - in e.g. `S n`, if there is a notation both for `S n` as a whole and for `S` isolated, the one for `S n` is used first (this addresses #9180)
  - in case of generic notations for an	applicative node (i.e. a notation with a variable at the head of the application), the notation does not	apply any more only to the head of the full (flattened) applicative node; it instead matches the application stepwise as if a nested application (this addresses this [comment](https://github.com/coq/coq/issues/9180#issuecomment-446371111) at #9180)
- in situations like `f n l` where a notation bound to `@f` exists, and no notation capturing a larger subterm exists, use the notation (formerly, this was the case only if `f` had no arguments); the overlook was apparently involontary; a similar uniformization of behavior for notations is done when in position of pattern.

I suspect that this shall be considered as strict improvements. In addition to @anton-trunov and @ggonthier already involved in #9180, I'm informing also other users using notations heavily @beta-ziliani, @JasonGross, @ralfjung, @robbertkrebbers, in case they see a problem with these changes.

I suspect that I should include the above level of precision in the current documentation of notation printing rules (??).

<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [X] Added / updated test-suite
<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [ ] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).

