### PR TITLE
Fix issue #9176 : Windows: change cygwin repo

### DIFF
--- a/dev/build/windows/MakeCoq_MinGW.bat
+++ b/dev/build/windows/MakeCoq_MinGW.bat
@@ -55,7 +55,7 @@ IF DEFINED HTTP_PROXY (
 )
 
 REM see -cygrepo in ReadMe.txt
-SET CYGWIN_REPOSITORY=http://ftp.inf.tu-dresden.de/software/windows/cygwin32
+SET CYGWIN_REPOSITORY=http://mirror.easyname.at/cygwin
 
 REM see -cygcache in ReadMe.txt
 SET CYGWIN_LOCAL_CACHE_WFMT=%BATCHDIR%cygwin_cache


### PR DESCRIPTION
Fixes #9176: This PR updates the cygwin repo mirror for the Windows build to an official mirror. The mirror we are currently using is not longer an official mirror.