### PR TITLE
Fixing incorrect mention of coercions as being part of the interning phase

### DIFF
--- a/doc/sphinx/user-extensions/syntax-extensions.rst
+++ b/doc/sphinx/user-extensions/syntax-extensions.rst
@@ -70,7 +70,7 @@ associativity rules have to be given.
 
    The right-hand side of a notation is interpreted at the time the notation is
    given. In particular, disambiguation of constants, :ref:`implicit arguments
-   <ImplicitArguments>`, :ref:`coercions <Coercions>`, etc. are resolved at the
+   <ImplicitArguments>` and other notations are resolved at the
    time of the declaration of the notation.
 
 Precedences and associativity


### PR DESCRIPTION

**Kind:** bug fix

This is mini-fix to the documentation of syntax extensions noticed by @ggonthier at [#9207](https://github.com/coq/coq/pull/9207#issuecomment-446595106) (thanks in passing).

PS: shouldn't we start having a 8.9.1 milestone?