### PR TITLE
[ci] [appveyor] Temporally disable test suite on Appveyor.

### DIFF
--- a/dev/ci/appveyor.sh
+++ b/dev/ci/appveyor.sh
@@ -13,4 +13,4 @@ eval "$(opam env)"
 opam install -y num ocamlfind ounit
 
 # Full regular Coq Build
-cd "$APPVEYOR_BUILD_FOLDER" && ./configure -local && make && make byte && make -C test-suite all INTERACTIVE= # && make validate
+cd "$APPVEYOR_BUILD_FOLDER" && ./configure -local && make && make byte # && make -C test-suite all INTERACTIVE= # && make validate


### PR DESCRIPTION
Hopefully we will re-enable it back soon, I am preparing a refactoring
that should make it more robust w.r.t paths and changes on Windows
which will enable to use a faster build system.

But now it is timing out 100% of the times [due to #8655] so it is not
useful.
