### PR TITLE
Add Map.find_opt

### DIFF
--- a/clib/cSig.mli
+++ b/clib/cSig.mli
@@ -83,6 +83,7 @@ sig
     val choose: 'a t -> (key * 'a)
     val split: key -> 'a t -> 'a t * 'a option * 'a t
     val find: key -> 'a t -> 'a
+    val find_opt : key -> 'a t -> 'a option
     val map: ('a -> 'b) -> 'a t -> 'b t
     val mapi: (key -> 'a -> 'b) -> 'a t -> 'b t
 end

--- a/clib/hMap.ml
+++ b/clib/hMap.ml
@@ -353,6 +353,12 @@ struct
     let m = Int.Map.find h s in
     Map.find k m
 
+  let find_opt k s =
+    let h = M.hash k in
+    match Int.Map.find_opt h s with
+    | None -> None
+    | Some m -> Map.find_opt k m
+
   let get k s = try find k s with Not_found -> assert false
 
   let split k s = assert false (** Cannot be implemented efficiently *)

--- a/clib/int.ml
+++ b/clib/int.ml
@@ -41,6 +41,13 @@ struct
     if i < k then find i l
     else if i = k then v
     else find i r
+
+  let rec find_opt i s = match map_prj s with
+  | MEmpty -> None
+  | MNode (l, k, v, r, h) ->
+    if i < k then find_opt i l
+    else if i = k then Some v
+    else find_opt i r
 end
 
 module List = struct

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -601,19 +601,19 @@ let is_defined d e = EvMap.mem e d.defn_evars
 
 let is_undefined d e = EvMap.mem e d.undf_evars
 
-let existential_value d (n, args) =
-  let info = find d n in
-  match evar_body info with
-  | Evar_defined c ->
-    instantiate_evar_array info c args
-  | Evar_empty ->
-    raise NotInstantiatedEvar
+let existential_opt_value d (n, args) =
+  match EvMap.find_opt n d.defn_evars with
+  | None -> None
+  | Some info ->
+    match evar_body info with
+    | Evar_defined c -> Some (instantiate_evar_array info c args)
+    | Evar_empty -> None (* impossible but w/e *)
+
+let existential_value d ev = match existential_opt_value d ev with
+  | None -> raise NotInstantiatedEvar
+  | Some v -> v
 
 let existential_value0 = existential_value
-
-let existential_opt_value d ev =
-  try Some (existential_value d ev)
-  with NotInstantiatedEvar -> None
 
 let existential_opt_value0 = existential_opt_value
 


### PR DESCRIPTION
And use it a bit in evd.
https://ci.inria.fr/coq/view/benchmarking/job/benchmark-part-of-the-branch/608/console
~~~
┌────────────────────────┬─────────────────────────┬─────────────────────────────────────────────┬─────────────────────────────────────────────┬────────────────────────────────┬───────────────────────────┐
│                        │      user time [s]      │                 CPU cycles                  │              CPU instructions               │     max resident mem [KB]      │        mem faults         │
│                        │                         │                                             │                                             │                                │                           │
│           package_name │     NEW     OLD PDIFF   │               NEW               OLD PDIFF   │               NEW               OLD PDIFF   │        NEW        OLD  PDIFF   │     NEW     OLD   PDIFF   │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼───────────────────────────┤
│ coq-mathcomp-ssreflect │   69.45   70.17 -1.03 % │      192228150531      193522911514 -0.67 % │      277763164769      277644782264 +0.04 % │     537968     537824  +0.03 % │      17       0    +nan % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼───────────────────────────┤
│ coq-mathcomp-odd-order │ 1399.79 1413.54 -0.97 % │     3899620418339     3937507701068 -0.96 % │     6545850855718     6547102147719 -0.02 % │    1370868    1369084  +0.13 % │      36     277  -87.00 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼───────────────────────────┤
│             coq-geocoq │ 2046.06 2057.66 -0.56 % │     5683217506835     5713069134584 -0.52 % │     8293545882061     8287752032015 +0.07 % │    1228004    1248356  -1.63 % │     610     480  +27.08 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼───────────────────────────┤
│               coq-hott │  332.50  334.20 -0.51 % │      922478789293      925969177210 -0.38 % │     1409558464129     1409206004879 +0.03 % │     474924     475008  -0.02 % │     479       0    +nan % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼───────────────────────────┤
│             coq-sf-vfa │   51.51   51.77 -0.50 % │      142869646139      143184284461 -0.22 % │      230994498110      230969056778 +0.01 % │     540464     540444  +0.00 % │      31      36  -13.89 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼───────────────────────────┤
│       coq-math-classes │  256.19  257.34 -0.45 % │      706030634107      709377572533 -0.47 % │      938636681987      935580727216 +0.33 % │     533248     533136  +0.02 % │     167      90  +85.56 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼───────────────────────────┤
│               coq-corn │ 1545.68 1552.44 -0.44 % │     4291730752414     4309310543492 -0.41 % │     6346889762031     6339837296182 +0.11 % │     876184     875460  +0.08 % │      45      47   -4.26 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼───────────────────────────┤
│              coq-color │  746.72  749.64 -0.39 % │     2071885651971     2078785212231 -0.33 % │     2520803913829     2519979241207 +0.03 % │    1409672    1437260  -1.92 % │     420     325  +29.23 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼───────────────────────────┤
│          coq-fiat-core │  140.36  140.90 -0.38 % │      390973492434      392589245699 -0.41 % │      528372411290      528390324382 -0.00 % │     506904     507464  -0.11 % │     356     191  +86.39 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼───────────────────────────┤
│                coq-vst │ 3165.93 3176.68 -0.34 % │     8804760041858     8834342949098 -0.33 % │    12293570233475    12297408366918 -0.03 % │    2215708    2221096  -0.24 % │    1731    1716   +0.87 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼───────────────────────────┤
│     coq-mathcomp-field │  252.62  253.47 -0.34 % │      702414741047      704893396031 -0.35 % │     1052140446982     1052602126792 -0.04 % │     762448     761504  +0.12 % │      14       2 +600.00 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼───────────────────────────┤
│         coq-coquelicot │  108.44  108.79 -0.32 % │      300478088608      301022118589 -0.18 % │      408582989273      408409060553 +0.04 % │     711944     711600  +0.05 % │     283     113 +150.44 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼───────────────────────────┤
│              coq-flocq │  594.16  595.96 -0.30 % │     1651265573158     1658543863013 -0.44 % │     2438510471224     2432598332131 +0.24 % │    1587864    1776844 -10.64 % │     439     761  -42.31 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼───────────────────────────┤
│           coq-compcert │  897.26  899.65 -0.27 % │     2488763073014     2494594702326 -0.23 % │     3627269275824     3624184171928 +0.09 % │    1314988    1309216  +0.44 % │     391     385   +1.56 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼───────────────────────────┤
│   coq-mathcomp-algebra │  186.68  187.07 -0.21 % │      518134506233      519220544084 -0.21 % │      702872548378      702724725787 +0.02 % │     645684     646312  -0.10 % │       5     186  -97.31 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼───────────────────────────┤
│  coq-mathcomp-solvable │  223.56  223.98 -0.19 % │      621110219821      622343143737 -0.20 % │      875657790003      874630553657 +0.12 % │     853092     869224  -1.86 % │     299       5 +5880.00 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼───────────────────────────┤
│            coq-unimath │ 2204.34 2208.30 -0.18 % │     6128201598594     6140783631678 -0.20 % │    10674451072706    10655100089465 +0.18 % │    2940308    3039000  -3.25 % │     346     135 +156.30 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼───────────────────────────┤
│ coq-mathcomp-character │  283.49  283.96 -0.17 % │      787714738328      789724578568 -0.25 % │     1125450135025     1126167423887 -0.06 % │    1089800    1073816  +1.49 % │       1       2  -50.00 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼───────────────────────────┤
│        coq-lambda-rust │ 2391.17 2394.97 -0.16 % │     6661185106748     6672911518815 -0.18 % │     9027681049734     9015836211538 +0.13 % │    1465176    1445224  +1.38 % │       6      36  -83.33 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼───────────────────────────┤
│        coq-fiat-crypto │ 6632.19 6638.47 -0.09 % │    18448324640770    18466119207156 -0.10 % │    30275261139796    30242933972316 +0.11 % │    2492644    2496272  -0.15 % │    1757    1336  +31.51 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼───────────────────────────┤
│             coq-sf-plf │   80.06   80.13 -0.09 % │      220755993698      221532187989 -0.35 % │      324698402901      324602834455 +0.03 % │     521512     521544  -0.01 % │      15      23  -34.78 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼───────────────────────────┤
│  coq-mathcomp-fingroup │   87.30   87.37 -0.08 % │      241395876424      241993429932 -0.25 % │      357841280645      358071637309 -0.06 % │     592580     590624  +0.33 % │       0     101 -100.00 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼───────────────────────────┤
│       coq-fiat-parsers │  728.35  728.87 -0.07 % │     2017999381013     2020988673052 -0.15 % │     3084628347435     3081795810334 +0.09 % │    2922848    2948520  -0.87 % │     818     699  +17.02 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼───────────────────────────┤
│    coq-formal-topology │   61.74   61.73 +0.02 % │      169049798158      169014291223 +0.02 % │      258317405325      258291906756 +0.01 % │     485184     485320  -0.03 % │     202       0    +nan % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼───────────────────────────┤
│            coq-bignums │  102.82  102.77 +0.05 % │      284275724219      284989028552 -0.25 % │      413326782108      413447272109 -0.03 % │     540956     541144  -0.03 % │     294      43 +583.72 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼───────────────────────────┤
│              coq-sf-lf │   49.13   48.71 +0.86 % │      135149832706      134703069618 +0.33 % │      220762574173      220768715099 -0.00 % │     431144     430932  +0.05 % │     139     167  -16.77 % │
└────────────────────────┴─────────────────────────┴─────────────────────────────────────────────┴─────────────────────────────────────────────┴────────────────────────────────┴───────────────────────────┘
~~~