### PR TITLE
[ssr] compile "=> {}id" as "=> {id}id"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -146,6 +146,7 @@ SSReflect
   - block introduction: => [^ prefix ] [^~ suffix ]
   - fast introduction: => >
   - tactics as views: => /ltac:mytac
+  - replace hypothesis: => {}H
   See the reference manual for the actual documentation.
 
 Changes from 8.8.2 to 8.9+beta1

--- a/doc/sphinx/proof-engine/ssreflect-proof-language.rst
+++ b/doc/sphinx/proof-engine/ssreflect-proof-language.rst
@@ -1559,7 +1559,7 @@ whose general syntax is
    i_view ::= {? %{%} } /@term %| /ltac:( @tactic )
 
 .. prodn::
-   i_pattern ::= @ident %| > %| _ %| ? %| * %| + %| {? @occ_switch } -> %| {? @occ_switch }<- %| [ {?| @i_item } ] %| - %| [: {+ @ident } ]
+   i_pattern ::= {? %{%} } @ident %| > %| _ %| ? %| * %| + %| {? @occ_switch } -> %| {? @occ_switch }<- %| [ {?| @i_item } ] %| - %| [: {+ @ident } ]
 
 .. prodn::
    i_block ::= [^ @ident ] %| [^~ @ident ] %| [^~ @num ]
@@ -1615,6 +1615,10 @@ annotation: views are interpreted opening the ``ssripat`` scope.
   a new constant, fact, or defined constant :token:`ident`, respectively.
   Note that defined constants cannot be introduced when δ-expansion is
   required to expose the top variable or assumption.
+  An empty occurrence switch ``{}`` has the effect of clearing
+  the :token:`ident` before performing the introduction of :token:`ident`.
+  In other words by prefixing the :token:`ident` with ``{}`` one can
+  *replace* the context entry.
 ``>``
   pops every variable occurring in the rest of the stack.
   Type class instances are popped even if they don't occur

--- a/plugins/ssr/ssrparser.mlg
+++ b/plugins/ssr/ssrparser.mlg
@@ -753,6 +753,10 @@ ARGUMENT EXTEND ssripat TYPED AS ssripatrep list PRINTED BY { pr_ssripats }
   | [ "*" ] -> { [IPatAnon All] }
   | [ ">" ] -> { [IPatFastNondep] }
   | [ ident(id) ] -> { [IPatId id] }
+  | [ ssrdocc(occ) ident(id) ] -> { match occ with
+      | Some [], None -> [IPatClear[SsrHyp(Some loc,id)];IPatId id]
+      | Some cl, None -> check_hyps_uniq [] cl; [IPatClear cl;IPatId id]
+      | _ -> CErrors.user_err ~loc (str"Only identifiers are allowed here") }
   | [ "?" ] -> { [IPatAnon (One None)] }
   | [ "+" ] -> { [IPatAnon Temporary] }
   | [ "++" ] -> { [IPatAnon Temporary; IPatAnon Temporary] }

--- a/test-suite/ssr/ipat_replace.v
+++ b/test-suite/ssr/ipat_replace.v
@@ -1,0 +1,17 @@
+Require Import ssreflect.
+
+Lemma test : True.
+Proof.
+have H : True.
+  by [].
+have {}H : True.
+  by apply: H.
+by apply: H.
+Qed.
+
+Lemma test2 (H : True) : False -> False.
+Proof.
+Fail move=> {}W.
+move=> {}H.
+by apply: H.
+Qed.


### PR DESCRIPTION
This change lets one write `=> {}H` instead of `=> {H}H` in order to replace the context entry for `H`.
My main motivation for this patch is to make the idiom `have {H}H` a bit nicer: I was describing it in the MCB and I thought that the `{}` could be accepted there to avoid naming twice the hypothesis.

As of today `{}` is accepted in `rewrite {}H`, `move=> {}/H` with the meaning of "use and then discard". With this patch it is also accepted in `move=> {}H` with a meaning that is not exactly the same, but has some analogies (it more like "discard and then (re)use").

Do you think it is too confusing and not worth it? Do you think it is useful?
@ggonthier @CohenCyril @amahboubi 