### PR TITLE
Fixing printing bug due to using equality wrongly checking hash keys of kernel names (or checking wrong hash keys?)

### DIFF
--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -67,10 +67,7 @@ let print_no_symbol = ref false
 
 (**********************************************************************)
 (* Turning notations and scopes on and off for printing *)
-module IRuleSet = Set.Make(struct
-    type t = interp_rule
-    let compare x y = Pervasives.compare x y
-  end)
+module IRuleSet = InterpRuleSet
 
 let inactive_notations_table =
   Summary.ref ~name:"inactive_notations_table" (IRuleSet.empty)

--- a/interp/notation.mli
+++ b/interp/notation.mli
@@ -210,6 +210,8 @@ type interp_rule =
   | NotationRule of scope_name option * notation
   | SynDefRule of KerName.t
 
+module InterpRuleSet : Set.S with type elt = interp_rule
+
 val declare_notation_interpretation : notation -> scope_name option ->
       interpretation -> notation_location -> onlyprint:bool -> unit
 

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -20,6 +20,12 @@ let on_pi1 f (a,b,c) = (f a,b,c)
 let on_pi2 f (a,b,c) = (a,f b,c)
 let on_pi3 f (a,b,c) = (a,b,f c)
 
+(* Comparing pairs *)
+
+let pair_compare cmpx cmpy (x1,y1 as p1) (x2,y2 as p2) =
+  if p1 == p2 then 0 else
+  let c = cmpx x1 x2 in if c == 0 then cmpy y1 y2 else c
+
 (* Projections from triplets *)
 
 let pi1 (a,_,_) = a

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -17,6 +17,10 @@ val on_fst : ('a -> 'b) -> 'a * 'c -> 'b * 'c
 val on_snd : ('a -> 'b) -> 'c * 'a -> 'c * 'b
 val map_pair : ('a -> 'b) -> 'a * 'a -> 'b * 'b
 
+(** Comparing pairs *)
+
+val pair_compare : ('a -> 'a -> int) -> ('b -> 'b -> int) -> ('a * 'b -> 'a * 'b -> int)
+
 (** Mapping under triple *)
 
 val on_pi1 : ('a -> 'b) -> 'a * 'c * 'd -> 'b * 'c * 'd

--- a/test-suite/output/Notations4.out
+++ b/test-suite/output/Notations4.out
@@ -45,3 +45,5 @@ fun x : nat => (x.-1)%pred
      : Prop
 ##
      : Prop
+Notation Cn := Foo.FooCn
+Expands to: Notation Top.J.Mfoo.Foo.Bar.Cn

--- a/test-suite/output/Notations4.v
+++ b/test-suite/output/Notations4.v
@@ -164,3 +164,20 @@ Open Scope my_scope.
 Check ##.
 
 End H.
+
+(* Fixing a bug reported by G. Gonthier in #9207 *)
+
+Module J.
+
+Module Import Mfoo.
+Module Foo.
+Definition FooCn := 2.
+Module Bar.
+Notation Cn := FooCn.
+End Bar.
+End Foo.
+Export Foo.Bar.
+End Mfoo.
+About Cn.
+
+End J.


### PR DESCRIPTION
**Kind:** bug fix

I have no idea whether there is an underlying bug in hash-consing but a kernel name has hash key `-1` which makes a call to `Pervasives.compare` on kernel names failing. We fix the bug by using the explicit kernel provided equality on kernel names.

Strangely, in the original example (from @ggonthier, last item [here](https://github.com/coq/coq/pull/9207#issuecomment-448204714) as part of #9207 discussion), if we repeat the `About Cn` a second time, the bug does not show up (i.e. the hash key is not anymore `-1`). If it rings a bell to a specialist of hash-consing, don't hesitate to tell if it is just that `Pervasive.compare` is known to be incorrect on kernel names or if you think that there might be a proper underlying bug.

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->



- [X] Added / updated test-suite
