### PR TITLE
Do not exclude "opened" bugs from report

### DIFF
--- a/test-suite/report.sh
+++ b/test-suite/report.sh
@@ -15,7 +15,7 @@ mkdir "$SAVEDIR"
 FAILMARK="==========> FAILURE <=========="
 
 FAILED=$(mktemp /tmp/coq-check-XXXXXX)
-find . '(' -path ./bugs/opened -prune ')' -o '(' -name '*.log' -exec grep "$FAILMARK" -q '{}' ';' -print0 ')' > "$FAILED"
+find . '(' -name '*.log' -exec grep "$FAILMARK" -q '{}' ';' -print0 ')' > "$FAILED"
 
 rsync -a --from0 --files-from="$FAILED" . "$SAVEDIR"
 cp summary.log "$SAVEDIR"/


### PR DESCRIPTION
I don't know why they were excluded, but it prevents their storage as artifacts, which is inconvenient.