### PR TITLE
Turn `Refine instance Mode` off by default

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -98,6 +98,9 @@ Vernacular commands
 
 - `Declare Instance` now requires an instance name.
 
+- Option `Refine Instance Mode` has been turned off by default, meaning that
+  `Instance` no longer opens a proof when a body is provided.
+
 Tools
 
 - The `-native-compiler` flag of `coqc` and `coqtop` now takes an argument which can have three values:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -96,6 +96,8 @@ Vernacular commands
 - Computation of implicit arguments now properly handles local definitions in the
   binders for an `Instance`.
 
+- `Declare Instance` now requires an instance name.
+
 Tools
 
 - The `-native-compiler` flag of `coqc` and `coqtop` now takes an argument which can have three values:

--- a/plugins/ltac/rewrite.ml
+++ b/plugins/ltac/rewrite.ml
@@ -2014,7 +2014,7 @@ let add_morphism atts binders m s n =
   in
   let tac = Tacinterp.interp (make_tactic "add_morphism_tactic") in
   ignore(new_instance ~program_mode:atts.program ~global:atts.global atts.polymorphic binders instance
-           (Some (true, CAst.make @@ CRecord []))
+     None
     ~generalize:false ~tac ~hook:(declare_projection n instance_id) Hints.empty_hint_info)
 
 (** Bind to "rewrite" too *)

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -3006,7 +3006,7 @@ let process_transaction ~doc ?(newtip=Stateid.fresh ())
               let bname = VCS.mk_branch_name x in
               let opacity_of_produced_term = function
                 (* This AST is ambiguous, hence we check it dynamically *)
-                | VernacInstance (false, _,_ , None, _) -> GuaranteesOpacity
+                | VernacInstance (_,_ , None, _) -> GuaranteesOpacity
                 | _ -> Doesn'tGuaranteeOpacity in
               VCS.commit id (Fork (x,bname,opacity_of_produced_term (Vernacprop.under_control x.expr),[]));
               let proof_mode = default_proof_mode () in

--- a/stm/vernac_classifier.ml
+++ b/stm/vernac_classifier.ml
@@ -160,7 +160,7 @@ let classify_vernac e =
     | VernacMemOption _ | VernacPrintOption _
     | VernacGlobalCheck _
     | VernacDeclareReduction _
-    | VernacDeclareClass _ | VernacDeclareInstances _
+    | VernacDeclareClass _ | VernacExistingInstance _
     | VernacRegister _
     | VernacNameSectionHypSet _
     | VernacDeclareCustomEntry _

--- a/stm/vernac_classifier.ml
+++ b/stm/vernac_classifier.ml
@@ -164,7 +164,8 @@ let classify_vernac e =
     | VernacRegister _
     | VernacNameSectionHypSet _
     | VernacDeclareCustomEntry _
-    | VernacComments _ -> VtSideff [], VtLater
+    | VernacComments _
+    | VernacDeclareInstance _ -> VtSideff [], VtLater
     (* Who knows *)
     | VernacLoad _ -> VtSideff [], VtNow
     (* (Local) Notations have to disappear *)

--- a/stm/vernac_classifier.ml
+++ b/stm/vernac_classifier.ml
@@ -160,7 +160,7 @@ let classify_vernac e =
     | VernacMemOption _ | VernacPrintOption _
     | VernacGlobalCheck _
     | VernacDeclareReduction _
-    | VernacDeclareClass _ | VernacExistingInstance _
+    | VernacExistingClass _ | VernacExistingInstance _
     | VernacRegister _
     | VernacNameSectionHypSet _
     | VernacDeclareCustomEntry _

--- a/test-suite/bugs/closed/bug_2830.v
+++ b/test-suite/bugs/closed/bug_2830.v
@@ -194,14 +194,17 @@ Instance skel_equiv A : Equivalence (@skel A).
 Admitted.
 
 Import FunctionalExtensionality.
-Instance set_cat : Category Type (fun A B => A -> B) := {
+
+Instance set_cat : Category Type (fun A B => A -> B).
+refine {|
   id := fun A => fun x => x
   ; comp c b a f g := fun x => f (g x)
   ; eqv := fun A B => @skel (A -> B)
-}.
+|}.
 intros. compute. symmetry. apply eta_expansion.
 intros. compute. symmetry. apply eta_expansion.
-intros. compute. reflexivity. Defined.
+intros. compute. reflexivity.
+Defined.
 
 (* The [list] type constructor is a Functor. *)
 

--- a/test-suite/bugs/closed/bug_3495.v
+++ b/test-suite/bugs/closed/bug_3495.v
@@ -1,7 +1,7 @@
 Require Import RelationClasses.
 
 Axiom R : Prop -> Prop -> Prop.
-Declare Instance : Reflexive R.
+Declare Instance R_refl : Reflexive R.
 
 Class bar := { x : False }.
 Record foo := { a : Prop ; b : bar }.

--- a/test-suite/bugs/closed/bug_4498.v
+++ b/test-suite/bugs/closed/bug_4498.v
@@ -19,6 +19,6 @@ Class Category := {
 
 Require Export Coq.Setoids.Setoid.
 
-Add Parametric Morphism `{C : Category} {A B C} : (@compose _ A B C) with
+Add Parametric Morphism `{Category} {A B C} : (@compose _ A B C) with
   signature equiv ==> equiv ==> equiv as compose_mor.
 Proof. apply comp_respects. Qed.

--- a/test-suite/bugs/opened/bug_3890.v
+++ b/test-suite/bugs/opened/bug_3890.v
@@ -3,7 +3,9 @@ Set Nested Proofs Allowed.
 Class Foo.
 Class Bar := b : Type.
 
+Set Refine Instance Mode.
 Instance foo : Foo := _.
+Unset Refine Instance Mode.
 (* 1 subgoals, subgoal 1 (ID 4)
 
   ============================

--- a/test-suite/success/Typeclasses.v
+++ b/test-suite/success/Typeclasses.v
@@ -198,7 +198,9 @@ Module UniqueInstances.
       for it. *)
   Set Typeclasses Unique Instances.
   Class Eq (A : Type) : Set.
+    Set Refine Instance Mode.
     Instance eqa : Eq nat := _. constructor. Qed.
+    Unset Refine Instance Mode.
     Instance eqb : Eq nat := {}.
     Class Foo (A : Type) (e : Eq A) : Set.
     Instance fooa : Foo _ eqa := {}.

--- a/theories/Compat/Coq89.v
+++ b/theories/Compat/Coq89.v
@@ -12,3 +12,4 @@
 Local Set Warnings "-deprecated".
 
 Unset Private Polymorphic Universes.
+Set Refine Instance Mode.

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -105,8 +105,6 @@ let id_of_class cl =
 	  mip.(0).Declarations.mind_typename
     | _ -> assert false
 
-open Pp
-
 let instance_hook k info global imps ?hook cst =
   Impargs.maybe_declare_manual_implicits false cst ~enriching:false imps;
   let info = intern_info info in
@@ -330,11 +328,7 @@ let new_instance ?(global=false) ?(refine= !refine_instance) ~program_mode
   in
   let id =
     match instid with
-      Name id ->
-      let sp = Lib.make_path id in
-      if Nametab.exists_cci sp then
-        user_err ~hdr:"new_instance" (Id.print id ++ Pp.str " already exists.");
-      id
+    | Name id -> id
     | Anonymous ->
       let i = Nameops.add_suffix (id_of_class k) "_instance_0" in
       Namegen.next_global_ident_away i (Termops.vars_of_env env)

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -28,7 +28,7 @@ module RelDecl = Context.Rel.Declaration
 open Decl_kinds
 open Entries
 
-let refine_instance = ref true
+let refine_instance = ref false
 
 let () = Goptions.(declare_bool_option {
   optdepr  = false;

--- a/vernac/classes.mli
+++ b/vernac/classes.mli
@@ -40,7 +40,6 @@ val declare_instance_constant :
   unit
 
 val new_instance :
-  ?abstract:bool (** Not abstract by default. *) ->
   ?global:bool (** Not global by default. *) ->
   ?refine:bool (** Allow refinement *) ->
   program_mode:bool ->
@@ -53,6 +52,14 @@ val new_instance :
   ?hook:(GlobRef.t -> unit) ->
   Hints.hint_info_expr ->
   Id.t
+
+val declare_new_instance :
+  ?global:bool (** Not global by default. *) ->
+  Decl_kinds.polymorphic ->
+  local_binder_expr list ->
+  ident_decl * Decl_kinds.binding_kind * constr_expr ->
+  Hints.hint_info_expr ->
+  unit
 
 (** Setting opacity *)
 

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -687,13 +687,13 @@ GRAMMAR EXTEND Gram
 
       | IDENT "Existing"; IDENT "Instance"; id = global;
           info = hint_info ->
-	  { VernacDeclareInstances [id, info] }
+	  { VernacExistingInstance [id, info] }
 
       | IDENT "Existing"; IDENT "Instances"; ids = LIST1 global;
         pri = OPT [ "|"; i = natural -> { i } ] ->
          { let info = { Typeclasses.hint_priority = pri; hint_pattern = None } in
          let insts = List.map (fun i -> (i, info)) ids in
-	  VernacDeclareInstances insts }
+	  VernacExistingInstance insts }
 
       | IDENT "Existing"; IDENT "Class"; is = global -> { VernacDeclareClass is }
 

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -683,7 +683,7 @@ GRAMMAR EXTEND Gram
 	 info = hint_info ;
 	 props = [ ":="; "{"; r = record_declaration; "}" -> { Some (true,r) } |
 	     ":="; c = lconstr -> { Some (false,c) } | -> { None } ] ->
-	   { VernacInstance (false,snd namesup,(fst namesup,expl,t),props,info) }
+	   { VernacInstance (snd namesup,(fst namesup,expl,t),props,info) }
 
       | IDENT "Existing"; IDENT "Instance"; id = global;
           info = hint_info ->
@@ -844,10 +844,10 @@ GRAMMAR EXTEND Gram
     [ [ IDENT "Comments"; l = LIST0 comment -> { VernacComments l }
 
       (* Hack! Should be in grammar_ext, but camlp5 factorizes badly *)
-      | IDENT "Declare"; IDENT "Instance"; namesup = instance_name; ":";
+      | IDENT "Declare"; IDENT "Instance"; id = ident_decl; bl = binders; ":";
 	 expl = [ "!" -> { Decl_kinds.Implicit } | -> { Decl_kinds.Explicit } ] ; t = operconstr LEVEL "200";
 	 info = hint_info ->
-	   { VernacInstance (true, snd namesup, (fst namesup, expl, t), None, info) }
+	   { VernacDeclareInstance (bl, (id, expl, t), info) }
 
       (* Should be in syntax, but camlp5 would not factorize *)
       | IDENT "Declare"; IDENT "Scope"; sc = IDENT ->

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -695,7 +695,7 @@ GRAMMAR EXTEND Gram
          let insts = List.map (fun i -> (i, info)) ids in
 	  VernacExistingInstance insts }
 
-      | IDENT "Existing"; IDENT "Class"; is = global -> { VernacDeclareClass is }
+      | IDENT "Existing"; IDENT "Class"; is = global -> { VernacExistingClass is }
 
       (* Arguments *)
       | IDENT "Arguments"; qid = smart_global; 

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -809,9 +809,8 @@ GRAMMAR EXTEND Gram
       | IDENT "transparent" -> { Conv_oracle.transparent } ] ]
   ;
   instance_name:
-    [ [ name = ident_decl; sup = OPT binders ->
-          { (CAst.map (fun id -> Name id) (fst name), snd name),
-          (Option.default [] sup) }
+    [ [ name = ident_decl; bl = binders ->
+          { (CAst.map (fun id -> Name id) (fst name), snd name), bl }
       | -> { ((CAst.make ~loc Anonymous), None), []  } ] ]
   ;
   hint_info:

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -912,7 +912,7 @@ open Pputils
             keyword "Context" ++ pr_and_type_binders_arg l)
         )
 
-      | VernacDeclareInstances insts ->
+      | VernacExistingInstance insts ->
          let pr_inst (id, info) =
            pr_qualid id ++ pr_hint_info pr_constr_pattern_expr info
          in

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -887,10 +887,9 @@ open Pputils
               spc() ++ pr_class_rawexpr c2)
         )
 
-      | VernacInstance (abst, sup, (instid, bk, cl), props, info) ->
+      | VernacInstance (sup, (instid, bk, cl), props, info) ->
         return (
           hov 1 (
-            (if abst then keyword "Declare" ++ spc () else mt ()) ++
             keyword "Instance" ++
             (match instid with
              | {loc; v = Name id}, l -> spc () ++ pr_ident_decl (CAst.(make ?loc id),l) ++ spc ()
@@ -904,6 +903,16 @@ open Pputils
                 | Some (true,_) -> assert false
                 | Some (false,p) -> spc () ++ str":=" ++ spc () ++ pr_constr p
                 | None -> mt()))
+        )
+
+      | VernacDeclareInstance (sup, (instid, bk, cl), info) ->
+        return (
+          hov 1 (
+            keyword "Declare Instance" ++ spc () ++ pr_ident_decl instid ++ spc () ++
+            pr_and_type_binders_arg sup ++
+              str":" ++ spc () ++
+              (match bk with Implicit -> str "! " | Explicit -> mt ()) ++
+              pr_constr cl ++ pr_hint_info pr_constr_pattern_expr info)
         )
 
       | VernacContext l ->

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -922,7 +922,7 @@ open Pputils
                  spc () ++ prlist_with_sep (fun () -> str", ") pr_inst insts)
         )
 
-      | VernacDeclareClass id ->
+      | VernacExistingClass id ->
         return (
           hov 1 (keyword "Existing" ++ spc () ++ keyword "Class" ++ spc () ++ pr_qualid id)
         )

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1020,7 +1020,7 @@ let vernac_existing_instance ~section_local insts =
   let glob = not section_local in
   List.iter (fun (id, info) -> Classes.existing_instance glob id (Some info)) insts
 
-let vernac_declare_class id =
+let vernac_existing_class id =
   Record.declare_existing_class (Nametab.global id)
 
 (***********)
@@ -2231,7 +2231,7 @@ let interp ?proof ~atts ~st c =
       vernac_instance ~atts abst sup inst props info
   | VernacContext sup -> vernac_context ~poly:(only_polymorphism atts) sup
   | VernacExistingInstance insts -> with_section_locality ~atts vernac_existing_instance insts
-  | VernacDeclareClass id -> unsupported_attributes atts; vernac_declare_class id
+  | VernacExistingClass id -> unsupported_attributes atts; vernac_existing_class id
 
   (* Solving *)
   | VernacSolveExistential (n,c) -> unsupported_attributes atts; vernac_solve_existential n c

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1016,7 +1016,7 @@ let vernac_instance ~atts abst sup inst props pri =
 let vernac_context ~poly l =
   if not (Classes.context poly l) then Feedback.feedback Feedback.AddedAxiom
 
-let vernac_declare_instances ~section_local insts =
+let vernac_existing_instance ~section_local insts =
   let glob = not section_local in
   List.iter (fun (id, info) -> Classes.existing_instance glob id (Some info)) insts
 
@@ -2230,7 +2230,7 @@ let interp ?proof ~atts ~st c =
   | VernacInstance (abst, sup, inst, props, info) ->
       vernac_instance ~atts abst sup inst props info
   | VernacContext sup -> vernac_context ~poly:(only_polymorphism atts) sup
-  | VernacDeclareInstances insts -> with_section_locality ~atts vernac_declare_instances insts
+  | VernacExistingInstance insts -> with_section_locality ~atts vernac_existing_instance insts
   | VernacDeclareClass id -> unsupported_attributes atts; vernac_declare_class id
 
   (* Solving *)

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1005,13 +1005,20 @@ let vernac_identity_coercion ~atts id qids qidt =
 
 (* Type classes *)
 
-let vernac_instance ~atts abst sup inst props pri =
+let vernac_instance ~atts sup inst props pri =
   let open DefAttributes in
   let atts = parse atts in
   let global = not (make_section_locality atts.locality) in
   Dumpglob.dump_constraint (fst (pi1 inst)) false "inst";
   let program_mode = Flags.is_program_mode () in
-  ignore(Classes.new_instance ~program_mode ~abstract:abst ~global atts.polymorphic sup inst props pri)
+  ignore(Classes.new_instance ~program_mode ~global atts.polymorphic sup inst props pri)
+
+let vernac_declare_instance ~atts sup inst pri =
+  let open DefAttributes in
+  let atts = parse atts in
+  let global = not (make_section_locality atts.locality) in
+  Dumpglob.dump_definition (fst (pi1 inst)) false "inst";
+  Classes.declare_new_instance ~global atts.polymorphic sup inst pri
 
 let vernac_context ~poly l =
   if not (Classes.context poly l) then Feedback.feedback Feedback.AddedAxiom
@@ -2227,8 +2234,10 @@ let interp ?proof ~atts ~st c =
       vernac_identity_coercion ~atts id s t
 
   (* Type classes *)
-  | VernacInstance (abst, sup, inst, props, info) ->
-      vernac_instance ~atts abst sup inst props info
+  | VernacInstance (sup, inst, props, info) ->
+      vernac_instance ~atts sup inst props info
+  | VernacDeclareInstance (sup, inst, info) ->
+      vernac_declare_instance ~atts sup inst info
   | VernacContext sup -> vernac_context ~poly:(only_polymorphism atts) sup
   | VernacExistingInstance insts -> with_section_locality ~atts vernac_existing_instance insts
   | VernacExistingClass id -> unsupported_attributes atts; vernac_existing_class id

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -308,7 +308,7 @@ type nonrec vernac_expr =
 
   | VernacContext of local_binder_expr list
 
-  | VernacDeclareInstances of
+  | VernacExistingInstance of
     (qualid * Hints.hint_info_expr) list (* instances names, priorities and patterns *)
 
   | VernacDeclareClass of qualid (* inductive or definition name *)

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -300,10 +300,14 @@ type nonrec vernac_expr =
 
   (* Type classes *)
   | VernacInstance of
-      bool * (* abstract instance *)
       local_binder_expr list * (* super *)
         typeclass_constraint * (* instance name, class name, params *)
         (bool * constr_expr) option * (* props *)
+        Hints.hint_info_expr
+
+  | VernacDeclareInstance of
+      local_binder_expr list * (* super *)
+        (ident_decl * Decl_kinds.binding_kind * constr_expr) * (* instance name, class name, params *)
         Hints.hint_info_expr
 
   | VernacContext of local_binder_expr list

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -311,7 +311,7 @@ type nonrec vernac_expr =
   | VernacExistingInstance of
     (qualid * Hints.hint_info_expr) list (* instances names, priorities and patterns *)
 
-  | VernacDeclareClass of qualid (* inductive or definition name *)
+  | VernacExistingClass of qualid (* inductive or definition name *)
 
   (* Modules and Module Types *)
   | VernacDeclareModule of bool option * lident *


### PR DESCRIPTION
This PR cleans up some code related to `Instance`, and turns the `Refine Instance Mode` option off by default.

This is the first of two steps to be able to tell statically which commands open proofs, which is a desirable property for the vernac IMHO.

The second step will be to make `Instance` without a body always open a proof.