### PR TITLE
Fix #9272: `Unset Nested Proofs Allowed` does not capture nested `Ins…

### DIFF
--- a/test-suite/bugs/opened/bug_3890.v
+++ b/test-suite/bugs/opened/bug_3890.v
@@ -1,3 +1,5 @@
+Set Nested Proofs Allowed.
+
 Class Foo.
 Class Bar := b : Type.
 


### PR DESCRIPTION
…tance` proofs.

We forbid commands that may open proofs inside proofs.

TODO
- [ ] Add a test case