### PR TITLE
[dune] Fix states target to depend on installed libraries.

### DIFF
--- a/Makefile.dune
+++ b/Makefile.dune
@@ -43,7 +43,7 @@ voboot:
 	dune exec coq_dune $(BUILD_CONTEXT)/.vfiles.d
 
 states: voboot
-	dune build $(DUNEOPT) theories/Init/Prelude.vo
+	dune build $(DUNEOPT) @states
 
 world: voboot
 	dune build $(DUNEOPT) @install

--- a/dune
+++ b/dune
@@ -42,3 +42,20 @@
  (name runtest)
  (package coqide-server)
  (deps test-suite/summary.log))
+
+; This is an ugly hack, we should use
+; %{lib_root:coq/theories/Init/Prelude.vo} when Dune supports it.
+(library
+ (name root)
+ (public_name coq.root))
+
+(alias
+ (name states)
+ (deps
+   %{lib:coq.root:../theories/Init/Prelude.vo}
+   %{lib:coq.plugins.ltac:ltac_plugin.cmxs}
+   %{lib:coq.plugins.tauto:tauto_plugin.cmxs}
+   %{lib:coq.plugins.cc:cc_plugin.cmxs}
+   %{lib:coq.plugins.firstorder:ground_plugin.cmxs}
+   %{lib:coq.plugins.numeral_notation:numeral_notation_plugin.cmxs}
+   %{lib:coq.plugins.string_notation:string_notation_plugin.cmxs}))

--- a/tools/coq_dune.ml
+++ b/tools/coq_dune.ml
@@ -171,6 +171,11 @@ let gen_coqc_targets vo =
   ; replace_ext ~file:vo.target ~newext:".glob"
   ; "." ^ replace_ext ~file:vo.target ~newext:".aux"]
 
+let amend_install_dir sdir s =
+  match Filename.extension s with
+  | ".vo" -> "%{lib:coq.root:../" ^ s ^ "}"
+  | _ -> bpath [sdir;s]
+
 (* Generate the dune rule: *)
 let pp_vo_dep dir fmt vo =
   let depth = List.length dir in
@@ -179,8 +184,9 @@ let pp_vo_dep dir fmt vo =
   let eflag, edep = if List.tl dir = ["Init"] then "-noinit -R theories Coq", [] else "", [bpath ["theories";"Init";"Prelude.vo"]] in
   (* Coq flags *)
   let cflag = Options.build_coq_flags () in
-  (* Correct path from global to local "theories/Init/Decimal.vo" -> "../../theories/Init/Decimal.vo" *)
-  let deps = List.map (fun s -> bpath [sdir;s]) (edep @ vo.deps) in
+  (* Correct path from global to local "theories/Init/Decimal.vo" -> "../../theories/Init/Decimal.vo"
+     except for vo files *)
+  let deps = List.map (amend_install_dir sdir) (edep @ vo.deps) in
   (* The source file is also corrected as we will call coqtop from the top dir *)
   let source = bpath (dir @ [replace_ext ~file:vo.target ~newext:".v"]) in
   (* We explicitly include the location of coqlib to avoid tricky issues with coqlib location *)


### PR DESCRIPTION
Until proper Coq support comes to Dune, this is a workaround and an
alternative to #9047 so `dune build @states` will build a working
`coqtop`.

In the end the shim path seems better to me, and this is the way `dune
coqtop` will work [and it will allow to obtain a context with
arbitrary libraries], however this is an interesting option to
consider.
