### PR TITLE
[stm] Remove `opacity_guarantee` from the classification.

### DIFF
--- a/plugins/derive/g_derive.mlg
+++ b/plugins/derive/g_derive.mlg
@@ -18,7 +18,7 @@ DECLARE PLUGIN "derive_plugin"
 
 {
 
-let classify_derive_command _ = Vernacextend.(VtStartProof (Doesn'tGuaranteeOpacity,[]))
+let classify_derive_command _ = Vernacextend.(VtStartProof [])
 
 }
 

--- a/plugins/funind/g_indfun.mlg
+++ b/plugins/funind/g_indfun.mlg
@@ -186,7 +186,7 @@ let classify_funind recsl =
   match classify_as_Fixpoint recsl with
   | Vernacextend.VtSideff (ids, _)
     when is_proof_termination_interactively_checked recsl ->
-      Vernacextend.(VtStartProof (GuaranteesOpacity, ids))
+      Vernacextend.(VtStartProof ids)
   | x -> x
 
 let is_interactive recsl =

--- a/plugins/ltac/g_obligations.mlg
+++ b/plugins/ltac/g_obligations.mlg
@@ -83,7 +83,7 @@ open Obligations
 let obligation obl tac = with_tac (fun t -> Obligations.obligation obl t) tac
 let next_obligation obl tac = with_tac (fun t -> Obligations.next_obligation obl t) tac
 
-let classify_obbl _ = Vernacextend.(VtStartProof (Doesn'tGuaranteeOpacity,[]))
+let classify_obbl _ = Vernacextend.(VtStartProof [])
 
 }
 

--- a/plugins/ltac/g_rewrite.mlg
+++ b/plugins/ltac/g_rewrite.mlg
@@ -277,7 +277,7 @@ VERNAC COMMAND EXTEND AddSetoid1 CLASSIFIED AS SIDEFF
          add_setoid atts binders a aeq t n
      }
   | #[ atts = rewrite_attributes; ] ![ open_proof ] [ "Add" "Morphism" constr(m) ":" ident(n) ]
-    => { VtStartProof(GuaranteesOpacity, [n]) }
+    => { VtStartProof [n] }
     -> { if Lib.is_modtype () then
            CErrors.user_err Pp.(str "Add Morphism cannot be used in a module type. Use Parameter Morphism instead.");
          add_morphism_interactive atts m n }
@@ -285,11 +285,11 @@ VERNAC COMMAND EXTEND AddSetoid1 CLASSIFIED AS SIDEFF
     => { VtSideff([n], VtLater) }
     -> { add_morphism_as_parameter atts m n }
   | #[ atts = rewrite_attributes; ] ![ open_proof ] [ "Add" "Morphism" constr(m) "with" "signature" lconstr(s) "as" ident(n) ]
-    => { VtStartProof(GuaranteesOpacity,[n]) }
+    => { VtStartProof [n] }
     -> { add_morphism atts [] m s n }
   | #[ atts = rewrite_attributes; ] ![ open_proof ] [ "Add" "Parametric" "Morphism" binders(binders) ":" constr(m)
         "with" "signature" lconstr(s) "as" ident(n) ]
-    => { VtStartProof(GuaranteesOpacity,[n]) }
+    => { VtStartProof [n] }
     -> { add_morphism atts binders m s n }
 END
 

--- a/stm/vernac_classifier.ml
+++ b/stm/vernac_classifier.ml
@@ -88,41 +88,27 @@ let classify_vernac e =
                       proof_block_detection = Some "curly" }
     (* StartProof *)
     | VernacDefinition ((DoDischarge,_),({v=i},_),ProveBody _) ->
-      VtStartProof(Doesn'tGuaranteeOpacity, idents_of_name i)
+      VtStartProof(idents_of_name i)
 
     | VernacDefinition (_,({v=i},_),ProveBody _) ->
-      let polymorphic = Attributes.(parse_drop_extra polymorphic atts) in
-      let guarantee = if polymorphic then Doesn'tGuaranteeOpacity else GuaranteesOpacity in
-      VtStartProof(guarantee, idents_of_name i)
+      VtStartProof(idents_of_name i)
     | VernacStartTheoremProof (_,l) ->
-      let polymorphic = Attributes.(parse_drop_extra polymorphic atts) in
       let ids = List.map (fun (({v=i}, _), _) -> i) l in
-      let guarantee = if polymorphic then Doesn'tGuaranteeOpacity else GuaranteesOpacity in
-      VtStartProof (guarantee,ids)
+      VtStartProof ids
     | VernacFixpoint (discharge,l) ->
-      let polymorphic = Attributes.(parse_drop_extra polymorphic atts) in
-       let guarantee =
-         if discharge = DoDischarge || polymorphic then Doesn'tGuaranteeOpacity
-         else GuaranteesOpacity
-       in
-        let ids, open_proof =
-          List.fold_left (fun (l,b) {Vernacexpr.fname={CAst.v=id}; body_def} ->
+      let ids, open_proof =
+        List.fold_left (fun (l,b) {Vernacexpr.fname={CAst.v=id}; body_def} ->
             id::l, b || body_def = None) ([],false) l in
-        if open_proof
-        then VtStartProof (guarantee,ids)
-        else VtSideff (ids, VtLater)
+      if open_proof
+      then VtStartProof ids
+      else VtSideff (ids, VtLater)
     | VernacCoFixpoint (discharge,l) ->
-      let polymorphic = Attributes.(parse_drop_extra polymorphic atts) in
-       let guarantee =
-         if discharge = DoDischarge || polymorphic then Doesn'tGuaranteeOpacity
-         else GuaranteesOpacity
-       in
-        let ids, open_proof =
-          List.fold_left (fun (l,b) { Vernacexpr.fname={CAst.v=id}; body_def } ->
+      let ids, open_proof =
+        List.fold_left (fun (l,b) { Vernacexpr.fname={CAst.v=id}; body_def } ->
             id::l, b || body_def = None) ([],false) l in
-        if open_proof
-        then VtStartProof (guarantee,ids)
-        else VtSideff (ids, VtLater)
+      if open_proof
+      then VtStartProof ids
+      else VtSideff (ids, VtLater)
     (* Sideff: apply to all open branches. usually run on master only *)
     | VernacAssumption (_,_,l) ->
         let ids = List.flatten (List.map (fun (_,(l,_)) -> List.map (fun (id, _) -> id.v) l) l) in
@@ -184,9 +170,7 @@ let classify_vernac e =
     | VernacContext _ (* TASSI: unsure *) -> VtSideff ([], VtNow)
     | VernacProofMode pm -> VtProofMode pm
     | VernacInstance ((name,_),_,_,None,_) when not (Attributes.parse_drop_extra Attributes.program atts) ->
-      let polymorphic = Attributes.(parse_drop_extra polymorphic atts) in
-      let guarantee = if polymorphic then Doesn'tGuaranteeOpacity else GuaranteesOpacity in
-      VtStartProof (guarantee, idents_of_name name.CAst.v)
+      VtStartProof (idents_of_name name.CAst.v)
     | VernacInstance ((name,_),_,_,_,_) ->
       VtSideff (idents_of_name name.CAst.v, VtLater)
     (* Stm will install a new classifier to handle these *)

--- a/vernac/vernacextend.ml
+++ b/vernac/vernacextend.ml
@@ -40,11 +40,8 @@ type vernac_classification =
   | VtProofMode of string
   (* To be removed *)
   | VtMeta
-and vernac_start = opacity_guarantee * Names.Id.t list
+and vernac_start = Names.Id.t list
 and vernac_sideff_type = Names.Id.t list * vernac_when
-and opacity_guarantee =
-  | GuaranteesOpacity (** Only generates opaque terms at [Qed] *)
-  | Doesn'tGuaranteeOpacity (** May generate transparent terms even with [Qed].*)
 
 and solving_tac = bool (** a terminator *)
 

--- a/vernac/vernacextend.mli
+++ b/vernac/vernacextend.mli
@@ -56,11 +56,8 @@ type vernac_classification =
   | VtProofMode of string
   (* To be removed *)
   | VtMeta
-and vernac_start = opacity_guarantee * Names.Id.t list
+and vernac_start = Names.Id.t list
 and vernac_sideff_type = Names.Id.t list * vernac_when
-and opacity_guarantee =
-  | GuaranteesOpacity (** Only generates opaque terms at [Qed] *)
-  | Doesn'tGuaranteeOpacity (** May generate transparent terms even with [Qed].*)
 
 and solving_tac = bool (** a terminator *)
 


### PR DESCRIPTION
Semantics of this flag is really weird, as in particular, it is
overriding the core opacity setting in `Proof_global`.

However thanks to some recent changes in the core proof API we can use a more precise heuristic for delegation now, let's see.