### PR TITLE
Do not rename implicit argument names.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,10 @@ Specification language, type inference
   solved by writing an explicit `return` clause, sometimes even simply
   an explicit `return _` clause.
 
+- The automatic names for implicit arguments now never differ from those
+  given by the user, but we set fewer arguments to be implicit when using
+  the option `Implicit Arguments`.
+
 Notations
 
 - New command `Declare Scope` to explicitly declare a scope name

--- a/test-suite/bugs/closed/bug_8790.v
+++ b/test-suite/bugs/closed/bug_8790.v
@@ -1,0 +1,5 @@
+Set Mangle Names.
+
+Inductive TCForall {A} (P : A -> Prop) : list A -> Prop :=
+  | TCForall_nil : TCForall P nil
+  | TCForall_cons x xs : P x -> TCForall P xs -> TCForall P (cons x xs).


### PR DESCRIPTION
Automatic implicit arguments get the name given by the user,
if they are inferable and no previous binder used the same name.
Otherwise, they are marked uninferable, because the current system
requires all implicit arguments to have a name.

This changes the implicit status of the motive in `ex_ind`, for example,
because the motive is rigid but is not given a name (the most obvious
name, `P`, also conflicts with the second argument of `ex`).
The hope is that this sort of change is unusual enough that CI has few problems.

Allowing anonymous implicit arguments would be a step forward, fixing
this case and others, but is more disruptive and could introduce other
incompatibilities.

If necessary, a compatibility option could be introduced which uses the old naming algorithm in `find_displayed_name_in`, at the expense of keeping the `all` parameter around for a while.

**Kind:** bug fix

Fixes #8790
Fixes #6785

Removes the immediate need for #7254, which got stuck. I still think the basic idea is good, but I obviously underestimated how difficult it would be.

- [x] Added / updated test-suite
- [x] Entry added in CHANGES.md.
