### PR TITLE
Default disable auto template warning.

### DIFF
--- a/doc/sphinx/language/cic.rst
+++ b/doc/sphinx/language/cic.rst
@@ -1041,6 +1041,12 @@ in :math:`\Type`.
    enabled it will prevail over automatic template polymorphism and
    cause an error when using the ``template`` attribute.
 
+.. warn:: Automatically declaring @ident as template polymorphic.
+
+   Warning ``auto-template`` can be used to find which types are
+   implicitly declared template polymorphic by :flag:`Auto Template
+   Polymorphism`.
+
 If :math:`A` is an arity of some sort and :math:`s` is a sort, we write :math:`A_{/s}`
 for the arity obtained from :math:`A` by replacing its sort with :math:`s`.
 Especially, if :math:`A` is well-typed in some global environment and local

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -35,7 +35,7 @@ module RelDecl = Context.Rel.Declaration
 (* 3b| Mutual inductive definitions *)
 
 let warn_auto_template =
-  CWarnings.create ~name:"auto-template" ~category:"vernacular"
+  CWarnings.create ~name:"auto-template" ~category:"vernacular" ~default:CWarnings.Disabled
     (fun id ->
        Pp.(strbrk "Automatically declaring " ++ Id.print id ++
            strbrk " as template polymorphic. Use attributes or " ++


### PR DESCRIPTION
The situation is too unclear to make it of general use, plus it has
some issues (#9296)
I'm not deleting the warning as it can still be useful to find which
types are template for those who want to experiment.
