### PR TITLE
Remove formal-topology from CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -485,7 +485,7 @@ library:ci-fiat-crypto-legacy:
 library:ci-flocq:
   <<: *ci-template
 
-library:ci-formal-topology:
+library:ci-corn:
   <<: *ci-template-flambda
 
 library:ci-geocoq:

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -27,7 +27,6 @@ CI_TARGETS= \
     ci-fiat-crypto-legacy \
     ci-fiat-parsers \
     ci-flocq \
-    ci-formal-topology \
     ci-geocoq \
     ci-coqhammer \
     ci-hott \
@@ -62,8 +61,6 @@ ci-corn: ci-math-classes
 
 ci-simple-io: ci-ext-lib
 ci-quickchick: ci-ext-lib ci-simple-io
-
-ci-formal-topology: ci-corn
 
 # Generic rule, we use make to ease CI integration
 $(CI_TARGETS): ci-%:

--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -150,13 +150,6 @@
 : "${fiat_crypto_CI_ARCHIVEURL:=${fiat_crypto_CI_GITURL}/archive}"
 
 ########################################################################
-# formal-topology
-########################################################################
-: "${formal_topology_CI_REF:=ci}"
-: "${formal_topology_CI_GITURL:=https://github.com/bmsherman/topology}"
-: "${formal_topology_CI_ARCHIVEURL:=${formal_topology_CI_GITURL}/archive}"
-
-########################################################################
 # coq_dpdgraph
 ########################################################################
 : "${coq_dpdgraph_CI_REF:=coq-master}"

--- a/dev/ci/ci-formal-topology.sh
+++ b/dev/ci/ci-formal-topology.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-ci_dir="$(dirname "$0")"
-. "${ci_dir}/ci-common.sh"
-
-git_download formal_topology
-
-( cd "${CI_BUILD_DIR}/formal_topology" && make )


### PR DESCRIPTION
This was suggested by the author. See https://github.com/bmsherman/topology/issues/23

 Note that this has been blocking #8094 for quite a while, which is in turn blocking important libobject cleanups.

Maybe we can consider adding it back later it it is moved to coq-community and the deprecation warnings are addressed.