### PR TITLE
[ci] Add Verdi Raft with dependencies to CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -506,6 +506,9 @@ library:ci-sf:
 library:ci-unimath:
   <<: *ci-template-flambda
 
+library:ci-verdi-raft:
+  <<: *ci-template-flambda
+
 library:ci-vst:
   <<: *ci-template-flambda
 

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -44,6 +44,7 @@ CI_TARGETS= \
     ci-simple-io \
     ci-tlc \
     ci-unimath \
+    ci-verdi-raft \
     ci-vst
 
 .PHONY: ci-all $(CI_TARGETS)

--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -273,3 +273,26 @@
 : "${relation_algebra_CI_REF:=master}"
 : "${relation_algebra_CI_GITURL:=https://github.com/damien-pous/relation-algebra}"
 : "${relation_algebra_CI_ARCHIVEURL:=${relation_algebra_CI_GITURL}/archive}"
+
+########################################################################
+# StructTact + InfSeqExt + Cheerios + Verdi + Verdi Raft
+########################################################################
+: "${struct_tact_CI_REF:=master}"
+: "${struct_tact_CI_GITURL:=https://github.com/uwplse/StructTact}"
+: "${struct_tact_CI_ARCHIVEURL:=${struct_tact_CI_GITURL}/archive}"
+
+: "${inf_seq_ext_CI_REF:=master}"
+: "${inf_seq_ext_CI_GITURL:=https://github.com/DistributedComponents/InfSeqExt}"
+: "${inf_seq_ext_CI_ARCHIVEURL:=${inf_seq_ext_CI_GITURL}/archive}"
+
+: "${cheerios_CI_REF:=master}"
+: "${cheerios_CI_GITURL:=https://github.com/uwplse/cheerios}"
+: "${cheerios_CI_ARCHIVEURL:=${cheerios_CI_GITURL}/archive}"
+
+: "${verdi_CI_REF:=master}"
+: "${verdi_CI_GITURL:=https://github.com/uwplse/verdi}"
+: "${verdi_CI_ARCHIVEURL:=${verdi_CI_GITURL}/archive}"
+
+: "${verdi_raft_CI_REF:=master}"
+: "${verdi_raft_CI_GITURL:=https://github.com/uwplse/verdi-raft}"
+: "${verdi_raft_CI_ARCHIVEURL:=${verdi_raft_CI_GITURL}/archive}"

--- a/dev/ci/ci-verdi-raft.sh
+++ b/dev/ci/ci-verdi-raft.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+ci_dir="$(dirname "$0")"
+. "${ci_dir}/ci-common.sh"
+
+git_download struct_tact
+
+( cd "${CI_BUILD_DIR}/struct_tact" && ./configure && make && make install )
+
+git_download inf_seq_ext
+
+( cd "${CI_BUILD_DIR}/inf_seq_ext" && ./configure && make && make install )
+
+git_download cheerios
+
+( cd "${CI_BUILD_DIR}/cheerios" && ./configure && make && make install )
+
+git_download verdi
+
+( cd "${CI_BUILD_DIR}/verdi" && ./configure && make && make install )
+
+git_download verdi_raft
+
+( cd "${CI_BUILD_DIR}/verdi_raft" && ./configure && make )


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** infrastructure.

Note that two of the dependencies (but not Verdi Raft itself) depends on positive co-inductive types. We hope to address this in the near future.