### PR TITLE
Printing notations with variables used both for binders and terms

### DIFF
--- a/interp/notation_ops.ml
+++ b/interp/notation_ops.ml
@@ -764,16 +764,7 @@ let add_env (alp,alpmetas) (terms,termlists,binders,binderlists) var v =
      ((fun y => P),(fun y => Q))". Then, we keep (z,y) in alpmetas, and we
      have to check that "fun z => ... z ..." denotes the same term as
      "fun x => ... x ... ?var ... x" up to alpha-conversion when [var]
-     is instantiated by [v];
-     Currently, we fail, but, eventually, [x] in [v] could be replaced by [x],
-     and, in match_, when finding "x" in subterm, failing because of a capture,
-     and, in match_, when finding "z" in subterm, replacing it with "x",
-     and, in an even further step, being even more robust, independent of the order, so
-     that e.g. the notation for ex2 works on "x y |- ex2 (fun x => y=x) (fun y => x=y)"
-     by giving, say, "exists2 x0, y=x0 & x=x0", but this would typically require the
-     glob_constr_eq in bind_term_env to be postponed in match_notation_constr, and the
-     choice of exact variable be done there; but again, this would be a non-trivial
-     refinement *)
+     is instantiated by [v] *)
   let v = alpha_rename alpmetas v in
   (* TODO: handle the case of multiple occs in different scopes *)
   ((var,v)::terms,termlists,binders,binderlists)

--- a/test-suite/output/Notations4.out
+++ b/test-suite/output/Notations4.out
@@ -125,3 +125,33 @@ Warning: Notation "_ :=: _" was already used. [notation-overridden,parsing]
      : Prop
 fun x : nat => <{ x; (S x) }>
      : nat -> nat
+Notation Cn := Foo.FooCn
+Expands to: Notation Top.J.Mfoo.Foo.Bar.Cn
+fun y : nat => # (x, z) |-> y & y
+     : forall y : nat,
+       (?T1 * ?T2 -> ?T1 * ?T2 * nat) * (?T * ?T0 -> ?T * ?T0 * nat)
+where
+?T : [y : nat  pat : ?T * ?T0  p0 : ?T * ?T0  p := p0 : ?T * ?T0
+     |- Type] (pat, p0, p cannot be used)
+?T0 : [y : nat  pat : ?T * ?T0  p0 : ?T * ?T0  p := p0 : ?T * ?T0
+      |- Type] (pat, p0, p cannot be used)
+?T1 : [y : nat  pat : ?T1 * ?T2  p0 : ?T1 * ?T2  p := p0 : ?T1 * ?T2
+      |- Type] (pat, p0, p cannot be used)
+?T2 : [y : nat  pat : ?T1 * ?T2  p0 : ?T1 * ?T2  p := p0 : ?T1 * ?T2
+      |- Type] (pat, p0, p cannot be used)
+fun y : nat => # (x, z) |-> (x + y) & (y + z)
+     : forall y : nat,
+       (nat * ?T -> nat * ?T * nat) * (?T0 * nat -> ?T0 * nat * nat)
+where
+?T : [y : nat  pat : nat * ?T  p0 : nat * ?T  p := p0 : nat * ?T
+     |- Type] (pat, p0, p cannot be used)
+?T0 : [y : nat  pat : ?T0 * nat  p0 : ?T0 * nat  p := p0 : ?T0 * nat
+      |- Type] (pat, p0, p cannot be used)
+forall n : nat, foo1 n
+     : Prop
+forall n : nat, foo2 n n
+     : Prop
+forall n : nat, (forall x : nat, x = n) /\ n = 0
+     : Prop
+forall n : nat, (forall x : nat, x = S n) /\ n = 0
+     : Prop

--- a/test-suite/output/Notations4.v
+++ b/test-suite/output/Notations4.v
@@ -313,3 +313,29 @@ Notation "x" := x (in custom com_top at level 90, x custom com at level 90).
 Check fun x => <{ x ; (S x) }>.
 
 End CoercionEntryTransitivity.
+
+Module K.
+
+Notation "# x |-> t & u" := ((fun x => (x,t)),(fun x => (x,u)))
+  (at level 0, x pattern, t, u at level 39).
+Check fun y : nat => # (x,z) |-> y & y.
+Check fun y : nat => # (x,z) |-> (x + y) & (y + z).
+
+End K.
+
+(* Fixing a limitation in printing notations with meta-variables used
+   both in as a binder and as a term (this is needed in MathComp) *)
+
+Module L.
+
+Notation foo1 x := ((forall x, x = 3) /\ x = 2).
+Check forall n, foo1 n.
+
+Notation foo2 x y := ((forall x : nat, x = y) /\ x = 0).
+Check forall n, foo2 n n.
+
+(* Should not use the notation *)
+Check forall n, ((forall x, x = n) /\ n = 0).
+Check forall n, ((forall x, x = S n) /\ n = 0).
+
+End L.


### PR DESCRIPTION
**Kind:** bug fix

~~Depends on #9292 and #9297.~~ Merged.

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
This addresses item `foo1` in the middle of this [comment](https://github.com/coq/coq/pull/9207#issuecomment-448204714) in #9207.

<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [X] Added / updated test-suite

This PR is partial work about a feature which I'm currently not completely sure that it is worth the additional implementation cost. It is about correctly printing a notation containing a variable which is used both in terms and in a binding structure.

Without this PR, the status is that such mixed binding/term notations are printed correctly only when the term comes before the binder. For instance, the following is already working:
```coq
Notation "'incr' x ; P" := (let x := x+1 in P) (at level 200).   
Check fun x => incr x; x=0.
```
but the following is not:
```coq
Notation "'incr' x ; P" := ((fun x => P) (x+1)) (at level 200).   
```
because the term comes after the binder (*).

Other known similar typical examples are:
- From Iris:
  ```coq
  Notation "'tele' x .. z := b" :=
    (fun x => .. (fun z =>
       pack (fr (fun x => .. ( fr (fun z => fb b) ) .. ) )
            (existT _ x .. (existT _ z tt) .. )
                  ) ..)
    (at level 85, x binder, z binder).
  ```
  but when we look more closely at it, we see that it is only about two binding structures intended     to share the same names: the `x` and `z` in `existT` are not free terms, they are bound by the `x` and `z` above them (this is a working case).
- [Example](https://github.com/coq/coq/pull/9207#issuecomment-448204714) `foo1` given by @ggonthier in #9207. I thought that it was a realistic example from MathComp but the discussion at math-comp/math-comp#265 suggests that the real example is different and I'm now a bit confused about whether there are real cases in MathComp.
- One of my other original motivation was to be able to define notations for expressions of the form `Notation "☐_ x P" := (forall x' >= x,  (fun x => P) x')`. But, to be satisfactory, one would like to avoid the beta-expansion and this would require yet another mechanism (e.g. to see `x >= t` as a stand-alone binder, so that, when writing `forall x >= t, P`, `x` binds in `P` but not in `t`).

There is also the question of supporting such mixed terms and binders in abbreviations. @mattam82 expressed a spontaneous perplexity in front of #8808. My answer was not quite right since I was arguing using Iris' example above but 1) Iris' example does finally not require mixing free terms and binders 2) Iris' example does not use an abbreviation but a proper parsing rule. I'm now perplex myself about what kind of interesting abbreviation involving binders, and a fortiori involving both binder and terms, we could do.

What does the PR is to make printing working also in (*), to the price of a non-trivial added complexity. Also, it does not work yet in the more general case where the binder is a pattern. Moreover, it would also require more testing.