### PR TITLE
[abstract] support evars when closed by the tactic

### DIFF
--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -62,21 +62,6 @@ let finalize ?abort_on_undefined_evars sigma f =
   let sigma = restrict_universe_context sigma !uvars in
   sigma, v
 
-(* flush_and_check_evars fails if an existential is undefined *)
-
-exception Uninstantiated_evar of Evar.t
-
-let rec flush_and_check_evars sigma c =
-  match kind c with
-  | Evar (evk,_ as ev) ->
-      (match existential_opt_value0 sigma ev with
-       | None -> raise (Uninstantiated_evar evk)
-       | Some c -> flush_and_check_evars sigma c)
-  | _ -> Constr.map (flush_and_check_evars sigma) c
-
-let flush_and_check_evars sigma c =
-  flush_and_check_evars sigma (EConstr.Unsafe.to_constr c)
-
 (** Term exploration up to instantiation. *)
 let kind_of_term_upto = EConstr.kind_upto
 

--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -272,6 +272,9 @@ val push_rel_context_to_named_context : ?hypnaming:naming_mode ->
 
 val generalize_evar_over_rels : evar_map -> existential -> types * constr list
 
+val shrink : evar_map -> Evar.Set.t -> evar_map
+(** Keeps only the evars in the input set (and the full UState.t) *)
+
 (** Evar combinators *)
 
 val evd_comb0 : (evar_map -> evar_map * 'a) -> evar_map ref -> 'a

--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -177,10 +177,6 @@ val nf_evar_map_undefined : evar_map -> evar_map
 
 val nf_evars_universes : evar_map -> Constr.constr -> Constr.constr
 
-(** Replacing all evars, possibly raising [Uninstantiated_evar] *)
-exception Uninstantiated_evar of Evar.t
-val flush_and_check_evars :  evar_map -> constr -> Constr.constr
-
 (** [finalize env sigma f] combines universe minimisation,
    evar-and-universe normalisation and universe restriction.
 

--- a/proofs/pfedit.ml
+++ b/proofs/pfedit.ml
@@ -134,8 +134,7 @@ open Decl_kinds
 
 let next = let n = ref 0 in fun () -> incr n; !n
 
-let build_constant_by_tactic id ctx sign ?(goal_kind = Global, false, Proof Theorem) typ tac =
-  let evd = Evd.from_ctx ctx in
+let build_constant_by_tactic id evd sign ?(goal_kind = Global, false, Proof Theorem) typ tac =
   let terminator = Proof_global.make_terminator (fun _ -> ()) in
   let goals = [ (Global.env_of_context sign , typ) ] in
   Proof_global.start_proof evd id goal_kind goals terminator;

--- a/proofs/pfedit.mli
+++ b/proofs/pfedit.mli
@@ -72,12 +72,12 @@ val instantiate_nth_evar_com : int -> Constrexpr.constr_expr -> unit
     tactic. *)
 
 val build_constant_by_tactic :
-  Id.t -> UState.t -> named_context_val -> ?goal_kind:goal_kind ->
+  Id.t -> Evd.evar_map -> named_context_val -> ?goal_kind:goal_kind ->
   EConstr.types -> unit Proofview.tactic -> 
   Safe_typing.private_constants Entries.definition_entry * bool *
     UState.t
 
-val build_by_tactic : ?side_eff:bool -> env -> UState.t -> ?poly:polymorphic ->
+val build_by_tactic : ?side_eff:bool -> env -> Evd.evar_map -> ?poly:polymorphic ->
   EConstr.types -> unit Proofview.tactic -> 
   constr * bool * UState.t
 

--- a/test-suite/bugs/closed/bug_2386.v
+++ b/test-suite/bugs/closed/bug_2386.v
@@ -1,0 +1,5 @@
+
+Goal exists n, n = 1.
+eexists.
+abstract reflexivity.
+Defined.

--- a/vernac/auto_ind_decl.ml
+++ b/vernac/auto_ind_decl.ml
@@ -684,7 +684,7 @@ let make_bl_scheme mode mind =
   let ctx = UState.make (Global.universes ()) in
   let side_eff = side_effect_of_mode mode in
   let bl_goal = EConstr.of_constr bl_goal in
-  let (ans, _, ctx) = Pfedit.build_by_tactic ~side_eff (Global.env()) ctx bl_goal
+  let (ans, _, ctx) = Pfedit.build_by_tactic ~side_eff (Global.env()) (Evd.from_ctx ctx) bl_goal
     (compute_bl_tact mode (!bl_scheme_kind_aux()) (ind, EConstr.EInstance.empty) lnamesparrec nparrec)
   in
   ([|ans|], ctx), eff
@@ -808,7 +808,7 @@ let make_lb_scheme mode mind =
   let ctx = UState.make (Global.universes ()) in
   let side_eff = side_effect_of_mode mode in
   let lb_goal = EConstr.of_constr lb_goal in
-  let (ans, _, ctx) = Pfedit.build_by_tactic ~side_eff (Global.env()) ctx lb_goal
+  let (ans, _, ctx) = Pfedit.build_by_tactic ~side_eff (Global.env()) (Evd.from_ctx ctx) lb_goal
     (compute_lb_tact mode (!lb_scheme_kind_aux()) ind lnamesparrec nparrec)
   in
   ([|ans|], ctx), eff
@@ -979,7 +979,7 @@ let make_eq_decidability mode mind =
   let lnonparrec,lnamesparrec =
     context_chop (nparams-nparrec) mib.mind_params_ctxt in
   let side_eff = side_effect_of_mode mode in
-  let (ans, _, ctx) = Pfedit.build_by_tactic ~side_eff (Global.env()) ctx
+  let (ans, _, ctx) = Pfedit.build_by_tactic ~side_eff (Global.env()) (Evd.from_ctx ctx)
     (EConstr.of_constr (compute_dec_goal (ind,u) lnamesparrec nparrec))
     (compute_dec_tact ind lnamesparrec nparrec)
   in

--- a/vernac/obligations.ml
+++ b/vernac/obligations.ml
@@ -1007,7 +1007,7 @@ and solve_obligation_by_tac prg obls i tac =
         let evd = Evd.from_ctx prg.prg_ctx in
         let evd = Evd.update_sigma_env evd (Global.env ()) in
         match solve_by_tac ?loc:(fst obl.obl_location) obl.obl_name (evar_of_obligation obl) tac
-                (pi2 prg.prg_kind) (Evd.evar_universe_context evd) with
+                (pi2 prg.prg_kind) evd with
         | None -> None
         | Some (t, ty, ctx) ->
           let uctx = UState.const_univ_entry ~poly:(pi2 prg.prg_kind) ctx in

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -506,7 +506,8 @@ let start_proof_and_print ?hook k l =
                   Evarutil.is_ground_term sigma concl)
           then raise Exit;
           let c, _, ctx =
-            Pfedit.build_by_tactic env (Evd.evar_universe_context sigma) concl tac
+            let ctx = Evd.evar_universe_context sigma in
+            Pfedit.build_by_tactic env (Evd.from_ctx ctx) concl tac
           in Evd.set_universe_context sigma ctx, EConstr.of_constr c
         with Logic_monad.TacticFailure e when Logic.catchable_exception e ->
           user_err Pp.(str "The statement obligations could not be resolved \


### PR DESCRIPTION
Fix #2386 and hence enables #9290 to proceed

For the reviewers:
- we generalize `build_*_by_tac` to take an evar map rather than just a universe context (and then forging an empty evar map out of this context). It is now the client that passes an evar map, always empty but for the call in abstract where we exploit the new API
- we provide an API to copy a (transitively) closed subset of an evar map (the undefined part). The UState.t is kept as is, the rest of the evar map is flushed.
- `abstract t` runs `t` in an evar map large enough to type check the goal (built using the API above), and then unifies the type of the obtained proof term with the type of the original goal. The main tactic and `t` run in different evar maps, the instantiations done by `t` are recovered by unifying the types (the one built by `t` is closed, so it makes sense to use it in the evar map of the main proof).

Bench at: https://ci.inria.fr/coq/job/benchmark-part-of-the-branch/621/