### PR TITLE
[STM] Fix semantics of `cur_id` w.r.t. error states

### DIFF
--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -869,7 +869,6 @@ end = struct (* {{{ *)
        cur_id := id
 
     | { state = Error ie } ->
-       cur_id := id;
        Exninfo.iraise ie
 
     | _ ->


### PR DESCRIPTION
Installing an error state should not update `cur_id`.