### PR TITLE
Fixing #9329: registering empty levels in the order they are computed

### DIFF
--- a/test-suite/bugs/closed/bug_9329.v
+++ b/test-suite/bugs/closed/bug_9329.v
@@ -1,0 +1,12 @@
+(* Declare empty levels in the same order they are computed *)
+
+Notation "< a ; b ; c >1" :=
+  (sum a (sum b c)) (at level 18, a at level 19, b at level 20, c at level 21).
+Notation "< a ; b ; c >2" :=
+  (sum a (sum b c)) (at level 28, a at level 29, c at level 32, b at level 31).
+Notation "< a ; b ; c >3" :=
+  (sum a (sum b c)) (at level 38, c at level 42, a at level 39, b at level 41).
+Notation "< a ; b ; c >4" :=
+  (sum a (sum b c)) (at level 48, c at level 52, b at level 51, a at level 49).
+Notation "< a ; b >" :=
+  (sum a b) (at level 61, a at level 63, b at level 62).

--- a/vernac/egramcoq.ml
+++ b/vernac/egramcoq.ml
@@ -146,7 +146,8 @@ let register_empty_levels accu forpat levels =
       (where, ans) :: rem, save_levels accu where nlev
     else rem, accu
   in
-  filter accu levels
+  let (l,accu) = filter accu levels in
+  List.rev l, accu
 
 let find_position accu custom forpat assoc level =
   let accu, (clev, plev) = find_levels accu custom in


### PR DESCRIPTION


<!-- Keep what applies -->
**Kind:** bug fix 


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #9329


<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [X] Added / updated test-suite

Note that the bug in this form was introduced in #8115. It was absent in 8.6, 8.7 and 8.8 but present in 8.5. In 8.6, 8.7 and 8.8, it is the following variant of the bug with parameters swapped which held:
```
Notation "< a ; b >" :=
  (sum a b) (at level 18, a at level 20, b at level 19).
```
