### PR TITLE
Move plugin tutorial to team ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -71,7 +71,7 @@ azure-pipelines.yml @coq/ci-maintainers
 /man/             @silene
 # Secondary maintainer @maximedenes
 
-/doc/plugin_tutorial/ @ybertot
+/doc/plugin_tutorial/ @coq/plugin-tutorial-maintainers
 
 ########## Coqchk ##########
 


### PR DESCRIPTION
The team isn't created yet, I guess we could start with people who have commit access to the original tutorial repo (@ybertot @ejgallego @gares @mattam82 @ppedrot @SkySkimmer)