### PR TITLE
Try allowing minimization to change Prop <= i into i := Set.

### DIFF
--- a/engine/uState.ml
+++ b/engine/uState.ml
@@ -621,7 +621,8 @@ let is_trivial_leq (l,d,r) =
 
 (* Prop < i <-> Set+1 <= i <-> Set < i *)
 let translate_cstr (l,d,r as cstr) =
-  if Level.equal Level.prop l && d == Lt && not (Level.equal Level.set r) then
+  let open Univ in
+  if Level.equal Level.prop l && d != Eq && not (Level.equal Level.set r) then
     (Level.set, d, r)
   else cstr
 

--- a/test-suite/success/cumulativity.v
+++ b/test-suite/success/cumulativity.v
@@ -123,11 +123,11 @@ Definition bar := foo.
 
 (* The universe on mkfoo is flexible and should be unified with i. *)
 Definition foo1@{i} : foo@{i} := let x := mkfoo in x. (* fast path for conversion *)
-Definition foo2@{i} : bar@{i} := let x := mkfoo in x. (* must reduce *)
+Definition foo2@{i} : bar@{} := let x := mkfoo in x. (* must reduce *)
 
 (* Rigid universes however should not be unified unnecessarily. *)
 Definition foo3@{i j|} : foo@{i} := let x := mkfoo@{j} in x.
-Definition foo4@{i j|} : bar@{i} := let x := mkfoo@{j} in x.
+Definition foo4@{i j|} : bar@{} := let x := mkfoo@{j} in x.
 
 (* Constructors for an inductive with indices *)
 Module WithIndex.

--- a/test-suite/success/polymorphism.v
+++ b/test-suite/success/polymorphism.v
@@ -462,3 +462,9 @@ Module ObligationRegression.
   Require Import CMorphisms.
   Check trans_co_eq_inv_arrow_morphism@{_ _ _ _ _  _ _ _}.
 End ObligationRegression.
+
+Axiom poly@{i} : forall(A : Type@{i}) (a : A), unit.
+Set Printing Universes.
+
+Definition nonpoly := @poly True Logic.I.
+Definition check := nonpoly@{}.

--- a/test-suite/success/polymorphism.v
+++ b/test-suite/success/polymorphism.v
@@ -460,7 +460,7 @@ Module ObligationRegression.
   (** Test for a regression encountered when fixing obligations for
       stronger restriction of universe context. *)
   Require Import CMorphisms.
-  Check trans_co_eq_inv_arrow_morphism@{_ _ _ _ _  _ _ _}.
+  Check trans_co_eq_inv_arrow_morphism@{_ _ _ _ _  _ _}.
 End ObligationRegression.
 
 Axiom poly@{i} : forall(A : Type@{i}) (a : A), unit.


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

We relax minimization such that Prop <= i constraints coming from Typing for a fresh "i" will ultimately instantiate i to Set, as is done for Set <= i. Alternative solution would be i := Prop which can't be done yet due to the restriction of polymorphism to not instantiate universe binders with Prop. I first need some feedback from CI to see if that's reasonably compatible.

**Kind:**  bug fix / feature

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #????

- [x] Added / updated test-suite


