### PR TITLE
Fix #9344, #9348: incorrect unsafe to_constr in vnorm

### DIFF
--- a/pretyping/nativenorm.ml
+++ b/pretyping/nativenorm.ml
@@ -415,7 +415,7 @@ and  nf_predicate env sigma ind mip params v pT =
 and nf_evar env sigma evk args =
   let evi = try Evd.find sigma evk with Not_found -> assert false in
   let hyps = Environ.named_context_of_val (Evd.evar_filtered_hyps evi) in
-  let ty = EConstr.Unsafe.to_constr @@ Evd.evar_concl evi in
+  let ty = EConstr.to_constr ~abort_on_undefined_evars:false sigma @@ Evd.evar_concl evi in
   if List.is_empty hyps then begin
     assert (Int.equal (Array.length args) 0);
     mkEvar (evk, [||]), ty

--- a/pretyping/vnorm.ml
+++ b/pretyping/vnorm.ml
@@ -202,7 +202,7 @@ and nf_univ_args ~nb_univs mk env sigma stk =
 and nf_evar env sigma evk stk =
   let evi = try Evd.find sigma evk with Not_found -> assert false in
   let hyps = Environ.named_context_of_val (Evd.evar_filtered_hyps evi) in
-  let concl = EConstr.Unsafe.to_constr @@ Evd.evar_concl evi in
+  let concl = EConstr.to_constr ~abort_on_undefined_evars:false sigma @@ Evd.evar_concl evi in
   if List.is_empty hyps then
     nf_stk env sigma (mkEvar (evk, [||])) concl stk
   else match stk with

--- a/test-suite/bugs/closed/bug_9344.v
+++ b/test-suite/bugs/closed/bug_9344.v
@@ -1,0 +1,1 @@
+Compute _ I.

--- a/test-suite/bugs/closed/bug_9344.v
+++ b/test-suite/bugs/closed/bug_9344.v
@@ -1,1 +1,2 @@
 Compute _ I.
+Eval native_compute in _ I.

--- a/test-suite/bugs/closed/bug_9348.v
+++ b/test-suite/bugs/closed/bug_9348.v
@@ -1,0 +1,3 @@
+Set Primitive Projections.
+Record r {A} := R {f : A -> A}.
+Compute f _ I.


### PR DESCRIPTION
To github: closes #9348, closes #9354.