### PR TITLE
[ssr] ipat replace

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -160,6 +160,7 @@ SSReflect
   - block introduction: => [^ prefix ] [^~ suffix ]
   - fast introduction: => >
   - tactics as views: => /ltac:mytac
+  - replace hypothesis: => {}H
   See the reference manual for the actual documentation.
 
 Changes from 8.8.2 to 8.9+beta1

--- a/doc/sphinx/proof-engine/ssreflect-proof-language.rst
+++ b/doc/sphinx/proof-engine/ssreflect-proof-language.rst
@@ -1559,7 +1559,7 @@ whose general syntax is
    i_view ::= {? %{%} } /@term %| /ltac:( @tactic )
 
 .. prodn::
-   i_pattern ::= @ident %| > %| _ %| ? %| * %| + %| {? @occ_switch } -> %| {? @occ_switch }<- %| [ {?| @i_item } ] %| - %| [: {+ @ident } ]
+   i_pattern ::= {? %{%} } @ident %| > %| _ %| ? %| * %| + %| {? @occ_switch } -> %| {? @occ_switch }<- %| [ {?| @i_item } ] %| - %| [: {+ @ident } ]
 
 .. prodn::
    i_block ::= [^ @ident ] %| [^~ @ident ] %| [^~ @num ]
@@ -1615,6 +1615,10 @@ annotation: views are interpreted opening the ``ssripat`` scope.
   a new constant, fact, or defined constant :token:`ident`, respectively.
   Note that defined constants cannot be introduced when δ-expansion is
   required to expose the top variable or assumption.
+  An empty occurrence switch ``{}`` has the effect of clearing
+  the :token:`ident` before performing the introduction of :token:`ident`.
+  In other words by prefixing the :token:`ident` with ``{}`` one can
+  *replace* the context entry.
 ``>``
   pops every variable occurring in the rest of the stack.
   Type class instances are popped even if they don't occur

--- a/plugins/ssr/ssrast.mli
+++ b/plugins/ssr/ssrast.mli
@@ -67,7 +67,7 @@ type ssrview = ast_closure_term list
 type id_block = Prefix of Id.t | SuffixId of Id.t | SuffixNum of int
 
 (* Only [One] forces an introduction, possibly reducing the goal. *)
-type anon_iter =
+type anon_kind =
   | One of string option (* name hint *)
   | Drop
   | All
@@ -76,25 +76,23 @@ type anon_iter =
 type ssripat =
   | IPatNoop
   | IPatId of Id.t
-  | IPatAnon of anon_iter (* inaccessible name *)
-(* TODO  | IPatClearMark *)
-  | IPatDispatch of bool (* ssr exception: accept a dispatch on the empty list even when there are subgoals *) * ssripatss_or_block (* (..|..) *)
-  | IPatCase of (* ipats_mod option * *) ssripatss_or_block (* this is not equivalent to /case /[..|..] if there are already multiple goals *)
+  | IPatAnon of anon_kind (* inaccessible name *)
+  | IPatDispatch of ssripatss_or_block (* (..|..) *)
+  | IPatCase of ssripatss_or_block (* [..|..] *)
   | IPatInj of ssripatss
   | IPatRewrite of (*occurrence option * rewrite_pattern **) ssrocc * ssrdir
-  | IPatView of bool * ssrview (* {}/view (true if the clear is present) *)
+  | IPatView of ssrview (* /view *)
   | IPatClear of ssrclear (* {H1 H2} *)
   | IPatSimpl of ssrsimpl
   | IPatAbstractVars of Id.t list
   | IPatFastNondep
-  | IPatEqGen of unit Proofview.tactic (* internal use: generation of eqn *)
 
 and ssripats = ssripat list
 and ssripatss = ssripats list
 and ssripatss_or_block =
   | Block of id_block
   | Regular of ssripats list
-type ssrhpats = ((ssrclear * ssripats) * ssripats) * ssripats
+type ssrhpats = ((ssrclear option * ssripats) * ssripats) * ssripats
 type ssrhpats_wtransp = bool * ssrhpats
 
 (* tac => inpats *)

--- a/plugins/ssr/ssrfwd.mli
+++ b/plugins/ssr/ssrfwd.mli
@@ -22,7 +22,7 @@ val ssrposetac : Id.t * (ssrfwdfmt * ast_closure_term) -> v82tac
 
 val havetac : ist ->
            bool *
-           ((((Ssrast.ssrclear * Ssrast.ssripat list) * Ssrast.ssripats) *
+           ((((Ssrast.ssrclear option * Ssrast.ssripat list) * Ssrast.ssripats) *
              Ssrast.ssripats) *
             (((Ssrast.ssrfwdkind * 'a) * ast_closure_term) *
              (bool * Tacinterp.Value.t option list))) ->
@@ -35,7 +35,7 @@ val basecuttac :
 
 val wlogtac :
   Ltac_plugin.Tacinterp.interp_sign ->
-  ((Ssrast.ssrhyps * Ssrast.ssripats) * 'a) * 'b ->
+  ((Ssrast.ssrclear option * Ssrast.ssripats) * 'a) * 'b ->
   (Ssrast.ssrhyps *
      ((Ssrast.ssrhyp_or_id * string) *
         Ssrmatching_plugin.Ssrmatching.cpattern option)
@@ -50,7 +50,7 @@ val wlogtac :
 
 val sufftac :
   Ssrast.ist ->
-  (((Ssrast.ssrhyps * Ssrast.ssripats) * Ssrast.ssripat list) *
+  (((Ssrast.ssrclear option * Ssrast.ssripats) * Ssrast.ssripat list) *
      Ssrast.ssripat list) *
     (('a *
         ast_closure_term) *

--- a/plugins/ssr/ssripats.ml
+++ b/plugins/ssr/ssripats.ml
@@ -529,6 +529,8 @@ let tclCompileIPats l =
       (IOpView(Some [],v)) :: elab rest
   | (IPatClear cl) :: (IPatView v) :: rest ->
       (IOpView(None,v)) :: IOpClear cl :: elab rest
+  | (IPatClear []) :: (IPatId id) :: rest ->
+      (IOpClear [SsrHyp(None,id)]) :: IOpId id :: elab rest
 
   (* boring code *)
   | [] -> []

--- a/plugins/ssr/ssripats.mli
+++ b/plugins/ssr/ssripats.mli
@@ -19,8 +19,44 @@
 
 open Ssrast
 
+(* Atomic operations for the IPat machine. Use this if you are "patching" an
+ * ipat written by the user, since patching it at he AST level and then
+ * compiling it may have tricky effects, eg adding a clear in front of a view
+ * also has the effect of disposing the view (the compilation phase takes case
+ * of this, by using the compiled ipats you can be more precise *)
+type ssriop =
+  | IOpId of Names.Id.t
+  | IOpDrop
+  | IOpTemporay
+  | IOpInaccessible of string option
+  | IOpInaccessibleAll
+  | IOpAbstractVars of Names.Id.t list
+  | IOpFastNondep
+
+  | IOpInj of ssriops list
+
+  | IOpDispatchBlock of id_block
+  | IOpDispatchBranches of ssriops list
+
+  | IOpCaseBlock of id_block
+  | IOpCaseBranches of ssriops list
+
+  | IOpRewrite of ssrocc * ssrdir
+  | IOpView of ssrclear option * ssrview (* extra clears to be performed *)
+
+  | IOpClear of ssrclear
+  | IOpSimpl of ssrsimpl
+
+  | IOpEqGen of unit Proofview.tactic (* generation of eqn *)
+
+  | IOpNoop
+
+and ssriops = ssriop list
+
+val tclCompileIPats : ssripats -> ssriops
+
 (* The => tactical *)
-val tclIPAT : ssripats -> unit Proofview.tactic
+val tclIPAT : ssriops -> unit Proofview.tactic
 
 (* As above but with the SSR exception: first case is dispatch *)
 val tclIPATssr : ssripats -> unit Proofview.tactic

--- a/plugins/ssr/ssrparser.mlg
+++ b/plugins/ssr/ssrparser.mlg
@@ -635,11 +635,10 @@ let rec map_ipat map_id map_ssrhyp map_ast_closure_term = function
   | IPatClear clr -> IPatClear (List.map map_ssrhyp clr)
   | IPatCase (Regular iorpat) -> IPatCase (Regular (List.map (List.map (map_ipat map_id map_ssrhyp map_ast_closure_term)) iorpat))
   | IPatCase (Block(hat)) -> IPatCase (Block(map_block map_id hat))
-  | IPatDispatch (s, Regular iorpat) -> IPatDispatch (s, Regular (List.map (List.map (map_ipat map_id map_ssrhyp map_ast_closure_term)) iorpat))
-  | IPatDispatch (s, Block (hat)) -> IPatDispatch (s, Block(map_block map_id hat))
+  | IPatDispatch (Regular iorpat) -> IPatDispatch (Regular (List.map (List.map (map_ipat map_id map_ssrhyp map_ast_closure_term)) iorpat))
+  | IPatDispatch (Block (hat)) -> IPatDispatch (Block(map_block map_id hat))
   | IPatInj iorpat -> IPatInj (List.map (List.map (map_ipat map_id map_ssrhyp map_ast_closure_term)) iorpat)
-  | IPatView (clr,v) -> IPatView (clr,List.map map_ast_closure_term v)
-  | IPatEqGen _ -> assert false (*internal usage only *)
+  | IPatView v -> IPatView (List.map map_ast_closure_term v)
 and map_block map_id = function
   | Prefix id -> Prefix (map_id id)
   | SuffixId id -> SuffixId (map_id id)
@@ -715,22 +714,22 @@ let interp_ipat ist gl =
       if not (ltacvar id) then hyp :: hyps else
       add_intro_pattern_hyps CAst.(make ?loc (interp_introid ist gl id)) hyps in
     let clr' = List.fold_right add_hyps clr [] in
-    check_hyps_uniq [] clr'; IPatClear clr'
+    check_hyps_uniq [] clr';
+    IPatClear clr'
   | IPatCase(Regular iorpat) ->
       IPatCase(Regular(List.map (List.map interp) iorpat))
   | IPatCase(Block(hat)) -> IPatCase(Block(interp_block hat))
 
-  | IPatDispatch(s,Regular iorpat) ->
-      IPatDispatch(s,Regular (List.map (List.map interp) iorpat))
-  | IPatDispatch(s,Block(hat)) -> IPatDispatch(s,Block(interp_block hat))
+  | IPatDispatch(Regular iorpat) ->
+      IPatDispatch(Regular (List.map (List.map interp) iorpat))
+  | IPatDispatch(Block(hat)) -> IPatDispatch(Block(interp_block hat))
 
   | IPatInj iorpat -> IPatInj (List.map (List.map interp) iorpat)
   | IPatAbstractVars l ->
      IPatAbstractVars (List.map get_intro_id (List.map (interp_introid ist gl) l))
-  | IPatView (clr,l) -> IPatView (clr,List.map (fun x -> snd(interp_ast_closure_term ist
+  | IPatView l -> IPatView (List.map (fun x -> snd(interp_ast_closure_term ist
      gl x)) l)
   | (IPatSimpl _ | IPatAnon _ | IPatRewrite _ | IPatNoop | IPatFastNondep) as x -> x
-  | IPatEqGen _ -> assert false (*internal usage only *)
     in
   interp
 
@@ -753,6 +752,17 @@ ARGUMENT EXTEND ssripat TYPED AS ssripatrep list PRINTED BY { pr_ssripats }
   | [ "*" ] -> { [IPatAnon All] }
   | [ ">" ] -> { [IPatFastNondep] }
   | [ ident(id) ] -> { [IPatId id] }
+(*
+  | [ ssrdocc(occ) ident(id) ] -> { match occ with
+      | Some [], None -> [IPatClear[SsrHyp(Some loc,id)];IPatId id]
+      | Some cl, None ->
+          check_hyps_uniq [] cl;
+          let cl =
+            if CList.mem_f Id.equal id (List.map hyp_id cl)
+            then cl else (SsrHyp(Some loc,id) :: cl) in
+          [IPatClear cl;IPatId id]
+      | _ -> CErrors.user_err ~loc (str"Only identifiers are allowed here") }
+*)
   | [ "?" ] -> { [IPatAnon (One None)] }
   | [ "+" ] -> { [IPatAnon Temporary] }
   | [ "++" ] -> { [IPatAnon Temporary; IPatAnon Temporary] }
@@ -765,10 +775,6 @@ ARGUMENT EXTEND ssripat TYPED AS ssripatrep list PRINTED BY { pr_ssripats }
       | Some [], _ -> CErrors.user_err ~loc (str"occ_switch expected")
       | None, occ ->  [IPatRewrite (occ, R2L)]
       | Some clr, _ -> [IPatClear clr; IPatRewrite (allocc, R2L)] }
-  | [ ssrdocc(occ) ssrfwdview(v) ] -> { match occ with
-      | Some [], _ -> [IPatView (true,v)]
-      | Some cl, _ -> check_hyps_uniq [] cl; [IPatClear cl;IPatView (false,v)]
-      | _ -> CErrors.user_err ~loc (str"Only identifiers are allowed here") }
   | [ ssrdocc(occ) ] -> { match occ with
       | Some cl, _ -> check_hyps_uniq [] cl; [IPatClear cl]
       | _ -> CErrors.user_err ~loc (str"Only identifiers are allowed here") }
@@ -786,7 +792,7 @@ ARGUMENT EXTEND ssripat TYPED AS ssripatrep list PRINTED BY { pr_ssripats }
   | [ "-/" integer(n) "/=" ] -> { [IPatNoop;IPatSimpl(SimplCut (n,~-1))] }
   | [ "-/" integer(n) "/" integer (m) "=" ] ->
       { [IPatNoop;IPatSimpl(SimplCut(n,m))] }
-  | [ ssrfwdview(v) ] -> { [IPatView (false,v)] }
+  | [ ssrfwdview(v) ] -> { [IPatView v] }
   | [ "[" ":" ident_list(idl) "]" ] -> { [IPatAbstractVars idl] }
   | [ "[:" ident_list(idl) "]" ] -> { [IPatAbstractVars idl] }
 END
@@ -875,11 +881,12 @@ ARGUMENT EXTEND ssripats_ne TYPED AS ssripat PRINTED BY { pr_ssripats }
 let check_ssrhpats loc w_binders ipats =
   let err_loc s = CErrors.user_err ~loc ~hdr:"ssreflect" s in
   let clr, ipats =
+    let opt_app = function None -> fun l -> Some l
+      | Some l1 -> fun l2 -> Some (l1 @ l2) in 
     let rec aux clr = function
-      | IPatClear cl :: tl -> aux (clr @ cl) tl
-(*      | IPatSimpl (cl, sim) :: tl -> clr @ cl, IPatSimpl ([], sim) :: tl *)
+      | IPatClear cl :: tl -> aux (opt_app clr cl) tl
       | tl -> clr, tl
-    in aux [] ipats in
+    in aux None ipats in
   let simpl, ipats = 
     match List.rev ipats with
     | IPatSimpl _ as s :: tl -> [s], List.rev tl
@@ -903,27 +910,29 @@ let check_ssrhpats loc w_binders ipats =
     in loop [] ipats in
   ((clr, ipat), binders), simpl
 
+let pr_clear_opt sep = function None -> mt () | Some x -> pr_clear sep x
+
 let pr_hpats (((clr, ipat), binders), simpl) =
-   pr_clear mt clr ++ pr_ipats ipat ++ pr_ipats binders ++ pr_ipats simpl
+   pr_clear_opt mt clr ++ pr_ipats ipat ++ pr_ipats binders ++ pr_ipats simpl
 let pr_ssrhpats _ _ _ = pr_hpats
 let pr_ssrhpats_wtransp _ _ _ (_, x) = pr_hpats x
 
 }
 
-ARGUMENT EXTEND ssrhpats TYPED AS (((ssrclear * ssripat) * ssripat) * ssripat)
+ARGUMENT EXTEND ssrhpats TYPED AS (((ssrclear option * ssripat) * ssripat) * ssripat)
 PRINTED BY { pr_ssrhpats }
   | [ ssripats(i) ] -> { check_ssrhpats loc true i }
 END
 
 ARGUMENT EXTEND ssrhpats_wtransp
-  TYPED AS (bool * (((ssrclear * ssripats) * ssripats) * ssripats))
+  TYPED AS (bool * (((ssrclear option * ssripats) * ssripats) * ssripats))
   PRINTED BY { pr_ssrhpats_wtransp }
   | [ ssripats(i) ] -> { false,check_ssrhpats loc true i }
   | [ ssripats(i) "@" ssripats(j) ] -> { true,check_ssrhpats loc true (i @ j) }
 END
 
 ARGUMENT EXTEND ssrhpats_nobs 
-TYPED AS (((ssrclear * ssripats) * ssripats) * ssripats) PRINTED BY { pr_ssrhpats }
+TYPED AS (((ssrclear option * ssripats) * ssripats) * ssripats) PRINTED BY { pr_ssrhpats }
   | [ ssripats(i) ] -> { check_ssrhpats loc false i }
 END
 
@@ -2051,7 +2060,7 @@ END
 (* We just add a numeric version that clears the n top assumptions. *)
 
 TACTIC EXTEND ssrclear
-  | [ "clear" natural(n) ] -> { tclIPAT (List.init n (fun _ -> IPatAnon Drop)) }
+  | [ "clear" natural(n) ] -> { tclIPAT (List.init n (fun _ -> IOpDrop)) }
 END
 
 (** The "move" tactic *)
@@ -2090,10 +2099,10 @@ let movearg_of_parsed_movearg (v,(eq,(dg,ip))) =
 
 TACTIC EXTEND ssrmove
 | [ "move" ssrmovearg(arg) ssrrpat(pat) ] ->
-  { ssrmovetac (movearg_of_parsed_movearg arg) <*> tclIPAT [pat] }
+  { ssrmovetac (movearg_of_parsed_movearg arg) <*> tclIPAT (tclCompileIPats [pat]) }
 | [ "move" ssrmovearg(arg) ssrclauses(clauses) ] ->
   { tclCLAUSES (ssrmovetac (movearg_of_parsed_movearg arg)) clauses }
-| [ "move" ssrrpat(pat) ] -> { tclIPAT [pat] }
+| [ "move" ssrrpat(pat) ] -> { tclIPAT (tclCompileIPats [pat]) }
 | [ "move" ] -> { ssrsmovetac }
 END
 
@@ -2632,7 +2641,11 @@ END
 
 {
 
-let augment_preclr clr1 (((clr0, x),y),z) = (((clr1 @ clr0, x),y),z)
+let augment_preclr clr1 (((clr0, x),y),z) =
+  let cl = match clr0 with
+    | None -> if clr1 = [] then None else Some clr1
+    | Some clr0 -> Some (clr1 @ clr0) in
+  (((cl, x),y),z)
 
 }
 

--- a/plugins/ssr/ssrprinters.ml
+++ b/plugins/ssr/ssrprinters.ml
@@ -74,7 +74,7 @@ let pr_occ = function
   | None -> str "{}"
 
 let pr_clear_ne clr = str "{" ++ pr_hyps clr ++ str "}"
-let pr_clear sep clr = if clr = [] then mt () else sep () ++ pr_clear_ne clr
+let pr_clear sep clr = sep () ++ pr_clear_ne clr
 
 let pr_dir = function L2R -> str "->" | R2L -> str "<-"
 
@@ -102,20 +102,18 @@ let rec pr_ipat p =
   | IPatClear clr -> pr_clear mt clr
   | IPatCase (Regular iorpat) -> hov 1 (str "[" ++ pr_iorpat iorpat ++ str "]")
   | IPatCase (Block m) -> hov 1 (str"[" ++ pr_block m ++ str"]")
-  | IPatDispatch(_,Regular iorpat) -> hov 1 (str "(" ++ pr_iorpat iorpat ++ str ")")
-  | IPatDispatch (_,Block m) -> hov 1 (str"(" ++ pr_block m ++ str")")
+  | IPatDispatch(Regular iorpat) -> hov 1 (str "(" ++ pr_iorpat iorpat ++ str ")")
+  | IPatDispatch (Block m) -> hov 1 (str"(" ++ pr_block m ++ str")")
   | IPatInj iorpat -> hov 1 (str "[=" ++ pr_iorpat iorpat ++ str "]")
   | IPatRewrite (occ, dir) -> pr_occ occ ++ pr_dir dir
   | IPatAnon All -> str "*"
   | IPatAnon Drop -> str "_"
   | IPatAnon (One _) -> str "?"
-  | IPatView (false,v) -> pr_view2 v
-  | IPatView (true,v) -> str"{}" ++ pr_view2 v
+  | IPatView v -> pr_view2 v
   | IPatAnon Temporary -> str "+"
   | IPatNoop -> str "-"
   | IPatAbstractVars l -> str "[:" ++ pr_list spc Id.print l ++ str "]"
   | IPatFastNondep -> str">"
-  | IPatEqGen _ -> str "<tac>"
 and pr_ipats ipats = pr_list spc pr_ipat ipats
 and pr_iorpat iorpat = pr_list pr_bar pr_ipats iorpat
 and pr_block = function (Prefix id) -> str"^" ++ Id.print id

--- a/plugins/ssr/ssrprinters.mli
+++ b/plugins/ssr/ssrprinters.mli
@@ -43,6 +43,7 @@ val pr_view2 : ast_closure_term list -> Pp.t
 val pr_ipat : ssripat -> Pp.t
 val pr_ipats : ssripats -> Pp.t
 val pr_iorpat : ssripatss -> Pp.t
+val pr_block : id_block -> Pp.t
 
 val pr_hyp : ssrhyp -> Pp.t
 val pr_hyps : ssrhyps -> Pp.t

--- a/test-suite/ssr/ipat_replace.v
+++ b/test-suite/ssr/ipat_replace.v
@@ -1,0 +1,17 @@
+Require Import ssreflect.
+
+Lemma test : True.
+Proof.
+have H : True.
+  by [].
+have {}H : True.
+  by apply: H.
+by apply: H.
+Qed.
+
+Lemma test2 (H : True) : False -> False.
+Proof.
+Fail move=> {}W.
+move=> {}H.
+by apply: H.
+Qed.


### PR DESCRIPTION
sub pull request of #9341 (the part shat should not break existing code)

For the reviewers:
The cleanup commit introduces a new data type `ipatops` interpreted by the ipat machine.
So now you have `ssripats -- tclCompileIPat --> ssriops -- tclIPAT --> unit tactic`.
The need is motivated by the fact that the "compilation" phase takes into account multiple items, eg a clear followed by a intro.

This makes sense on the input of the user (ssripat), while it is not always desirable on intro patters generated internally. Eg. prefixing an `ipats` with a `IPatClear` changes  meaning when the first `ipat` is an `IPatId` (it now means replace, eg one extra clear) while prefixing an `iops` with a `IOpClear` does not have this effect. Hence internally tactics patch `iops`, so that they can do it compositionally.