### PR TITLE
Prepare support for -Q semantics for plugins

### DIFF
--- a/config/coq_config.mli
+++ b/config/coq_config.mli
@@ -38,6 +38,7 @@ val compile_date : string (* compile date *)
 val vo_magic_number : int
 val state_magic_number : int
 
+val plugins_dirs : string list
 val all_src_dirs : string list
 
 val exec_extension : string (* "" under Unix, ".exe" under MS-windows *)

--- a/configure.ml
+++ b/configure.ml
@@ -1117,11 +1117,11 @@ let write_configml f =
   Array.iter
     (fun f ->
       let f' = "plugins/"^f in
-      if Sys.is_directory f' && f.[0] <> '.' then pr "  %S;\n" f')
+      if Sys.is_directory f' && f.[0] <> '.' then pr "  %S;\n" f)
     plugins;
   pr "]\n";
 
-  pr "\nlet all_src_dirs = core_src_dirs @ plugins_dirs\n";
+  pr "\nlet all_src_dirs = core_src_dirs @ List.map (fun s -> %S^s) plugins_dirs\n" "plugins/";
 
   close_out o;
   Unix.chmod f 0o444

--- a/tools/coqdep.ml
+++ b/tools/coqdep.ml
@@ -526,14 +526,14 @@ let coqdep () =
   (* NOTE: These directories are searched from last to first *)
   if !option_boot then begin
     add_rec_dir_import add_known "theories" ["Coq"];
-    add_rec_dir_import add_known "plugins" ["Coq"];
+    List.iter (fun p -> add_rec_dir_import add_known ("plugins"//p) [p;"Coq"]) Coq_config.plugins_dirs;
     add_rec_dir_import (fun _ -> add_caml_known) "theories" ["Coq"];
     add_rec_dir_import (fun _ -> add_caml_known) "plugins" ["Coq"];
   end else begin
     Envars.set_coqlib ~fail:(fun msg -> raise (CoqlibError msg));
     let coqlib = Envars.coqlib () in
     add_rec_dir_import add_coqlib_known (coqlib//"theories") ["Coq"];
-    add_rec_dir_import add_coqlib_known (coqlib//"plugins") ["Coq"];
+    List.iter (fun p -> add_rec_dir_import add_known ("plugins"//p) [p;"Coq"]) Coq_config.plugins_dirs;
     let user = coqlib//"user-contrib" in
     if Sys.file_exists user then add_rec_dir_no_import add_coqlib_known user [];
     List.iter (fun s -> add_rec_dir_no_import add_coqlib_known s [])

--- a/toplevel/coqinit.ml
+++ b/toplevel/coqinit.ml
@@ -91,6 +91,11 @@ let libs_init_load_path ~load_init =
   let xdg_dirs = Envars.xdg_dirs ~warn:(fun x -> Feedback.msg_warning (str x)) in
   let coqpath = Envars.coqpath in
   let coq_path = Names.DirPath.make [Libnames.coq_root] in
+  let plugin_path p =
+    let unix_path = coqlib / "plugins" / p in
+    let coq_path = Names.DirPath.make [Names.Id.of_string p;Libnames.coq_root] in
+    build_stdlib_path ~load_init ~unix_path ~coq_path ~with_ml:true
+  in
 
   (* current directory (not recursively!) *)
   [ { recursive = false;
@@ -101,8 +106,9 @@ let libs_init_load_path ~load_init =
     } ] @
 
   (* then standard library and plugins *)
-  [build_stdlib_path ~load_init ~unix_path:(coqlib/"theories") ~coq_path ~with_ml:false;
-   build_stdlib_path ~load_init ~unix_path:(coqlib/"plugins")  ~coq_path ~with_ml:true ] @
+  [build_stdlib_path ~load_init ~unix_path:(coqlib/"theories") ~coq_path ~with_ml:false] @
+
+  List.map plugin_path Coq_config.plugins_dirs @
 
   (* then user-contrib *)
   (if Sys.file_exists user_contrib then

--- a/vernac/mltop.ml
+++ b/vernac/mltop.ml
@@ -215,7 +215,7 @@ let add_vo_path ~recursive lp =
     let () = match lp.has_ml with
       | AddNoML -> ()
       | AddTopML -> add_ml_dir unix_path
-      | AddRecML -> List.iter (fun (lp,_) -> add_ml_dir lp) dirs in
+      | AddRecML -> List.iter (fun (lp,_) -> add_ml_dir lp) dirs; add_ml_dir unix_path in
     let add (path, dir) =
       Loadpath.add_load_path path ~implicit dir in
     let () = List.iter add dirs in


### PR DESCRIPTION
We make the computation of the load path a bit more fine grained, to prepare support for loading some plugins using `-Q` (notably Ltac2 if we ship it with Coq).