### PR TITLE
Discard argument names of section variables on section close

### DIFF
--- a/pretyping/arguments_renaming.ml
+++ b/pretyping/arguments_renaming.ml
@@ -43,7 +43,7 @@ let subst_rename_args (subst, (_, (r, names as orig))) =
   if r==r' then orig else (r', names)
 
 let discharge_rename_args = function
-  | _, (ReqGlobal (c, names), _ as req) ->
+  | _, (ReqGlobal (c, names), _ as req) when not (isVarRef c && Lib.is_in_section c) ->
      (try 
        let vars = Lib.variable_section_segment_of_reference c in
        let var_names = List.map (fst %> NamedDecl.get_id %> Name.mk_name) vars in

--- a/test-suite/bugs/closed/bug_9367.v
+++ b/test-suite/bugs/closed/bug_9367.v
@@ -1,0 +1,12 @@
+Section foo.
+Variable f : forall n : nat, nat.
+Arguments f {_}.
+Check f (n := 3).
+Global Arguments f {bar} : rename.
+End foo.
+
+Section foo.
+Variable f : forall n : nat, nat.
+Arguments f {_}.
+Fail Check f (bar := 3).
+End foo.


### PR DESCRIPTION
**Kind:** bug fix

Fixes / closes #9367

- [x] Added / updated test-suite
