### PR TITLE
Remove monomorphic/polymorphic distinction in the kernel

### DIFF
--- a/checker/checkInductive.ml
+++ b/checker/checkInductive.ml
@@ -27,12 +27,11 @@ let to_entry (mb:mutual_inductive_body) : Entries.mutual_inductive_entry =
     | NotRecord -> None | FakeRecord -> Some None
     | PrimRecord data -> Some (Some (Array.map pi1 data))
   in
-  let mind_entry_universes = match mb.mind_universes with
-    | Monomorphic_ind univs -> Monomorphic_ind_entry univs
-    | Polymorphic_ind auctx -> Polymorphic_ind_entry (AUContext.names auctx, AUContext.repr auctx)
-    | Cumulative_ind auctx ->
-      Cumulative_ind_entry (AUContext.names (ACumulativityInfo.univ_context auctx),
-                            ACumulativityInfo.repr auctx)
+  let mind_entry_universes =
+    let u = mb.mind_universes in
+    { entry_monomorphic_univs = u.monomorphic_univs;
+      entry_poly_univ_names = AUContext.names u.polymorphic_univs;
+      entry_polymorphic_univs = AUContext.repr u.polymorphic_univs; }
   in
   let mind_entry_inds = Array.map_to_list (fun ind ->
       let mind_entry_arity, mind_entry_template = match ind.mind_arity with
@@ -64,6 +63,7 @@ let to_entry (mb:mutual_inductive_body) : Entries.mutual_inductive_entry =
     mind_entry_params = mb.mind_params_ctxt;
     mind_entry_inds;
     mind_entry_universes;
+    mind_entry_variance = mb.mind_variance;
     mind_entry_private = mb.mind_private;
   }
 
@@ -132,7 +132,7 @@ let check_same_record r1 r2 = match r1, r2 with
 let check_inductive env mind mb =
   let entry = to_entry mb in
   let { mind_packets; mind_record; mind_finite; mind_ntypes; mind_hyps;
-        mind_nparams; mind_nparams_rec; mind_params_ctxt; mind_universes;
+        mind_nparams; mind_nparams_rec; mind_params_ctxt; mind_universes; mind_variance;
         mind_private; mind_typing_flags; }
     =
     (* Locally set the oracle for further typechecking *)
@@ -154,6 +154,7 @@ let check_inductive env mind mb =
 
   check "mind_params_ctxt" (Context.Rel.equal Constr.equal mb.mind_params_ctxt mind_params_ctxt);
   ignore mind_universes; (* Indtypes did the necessary checking *)
+  ignore mind_variance; (* Indtypes checked *)
   ignore mind_private; (* passed through Indtypes *)
 
   ignore mind_typing_flags;

--- a/checker/checkInductive.ml
+++ b/checker/checkInductive.ml
@@ -31,7 +31,9 @@ let to_entry (mb:mutual_inductive_body) : Entries.mutual_inductive_entry =
     let u = mb.mind_universes in
     { entry_monomorphic_univs = u.monomorphic_univs;
       entry_poly_univ_names = AUContext.names u.polymorphic_univs;
-      entry_polymorphic_univs = AUContext.repr u.polymorphic_univs; }
+      entry_polymorphic_univs = AUContext.repr u.polymorphic_univs;
+      entry_is_polymorphic = not (AUContext.is_empty u.polymorphic_univs);}
+    (* is_polymorphic doesn't matter but try to be sane regardless *)
   in
   let mind_entry_inds = Array.map_to_list (fun ind ->
       let mind_entry_arity, mind_entry_template = match ind.mind_arity with

--- a/checker/values.ml
+++ b/checker/values.ml
@@ -111,7 +111,6 @@ let v_variance = v_enum "variance" 3
 
 let v_instance = Annot ("instance", Array v_level)
 let v_abs_context = v_tuple "abstract_universe_context" [|Array v_name; v_cstrs|]
-let v_abs_cum_info = v_tuple "cumulativity_info" [|v_abs_context; Array v_variance|]
 let v_context_set = v_tuple "universe_context_set" [|v_hset v_level;v_cstrs|]
 
 (** kernel/term *)
@@ -221,14 +220,14 @@ let v_cst_def =
 let v_typing_flags =
   v_tuple "typing_flags" [|v_bool; v_bool; v_oracle; v_bool; v_bool; v_bool; v_bool|]
 
-let v_const_univs = v_sum "constant_universes" 0 [|[|v_context_set|]; [|v_abs_context|]|]
+let v_univ_decl = v_tuple "universe_decl" [|v_context_set; v_abs_context|]
 
 let v_cb = v_tuple "constant_body"
   [|v_section_ctxt;
     v_cst_def;
     v_constr;
     Any;
-    v_const_univs;
+    v_univ_decl;
     Opt v_context_set;
     v_bool;
     v_typing_flags|]
@@ -271,10 +270,6 @@ let v_record_info =
   v_sum "record_info" 2
     [| [| Array (v_tuple "record" [| v_id; Array v_id; Array v_constr |]) |] |]
 
-let v_ind_pack_univs = 
-  v_sum "abstract_inductive_universes" 0
-    [|[|v_context_set|]; [|v_abs_context|]; [|v_abs_cum_info|]|]
-
 let v_ind_pack = v_tuple "mutual_inductive_body"
   [|Array v_one_ind;
     v_record_info;
@@ -284,7 +279,8 @@ let v_ind_pack = v_tuple "mutual_inductive_body"
     Int;
     Int;
     v_rctxt;
-    v_ind_pack_univs; (* universes *)
+    v_univ_decl;
+    Opt (Array v_variance);
     Opt v_bool;
     v_typing_flags|]
 

--- a/dev/include
+++ b/dev/include
@@ -41,8 +41,6 @@
 #install_printer  (* univ context *) ppuniverse_context;;
 #install_printer  (* univ context future *) ppuniverse_context_future;;
 #install_printer  (* univ context set *) ppuniverse_context_set;;
-#install_printer  (* cumulativity info *) ppcumulativity_info;;
-#install_printer  (* abstract cumulativity info *) ppabstract_cumulativity_info;;
 #install_printer  (* univ set *) ppuniverse_set;;
 #install_printer  (* univ instance *) ppuniverse_instance;;
 #install_printer  (* univ subst *) ppuniverse_subst;;

--- a/dev/top_printers.dbg
+++ b/dev/top_printers.dbg
@@ -62,6 +62,7 @@ install_printer Top_printers.ppuni_level
 install_printer Top_printers.ppuniverse_set
 install_printer Top_printers.ppuniverse_instance
 install_printer Top_printers.ppuniverse_context
+install_printer Top_printers.ppaucontext
 install_printer Top_printers.ppuniverse_context_set
 install_printer Top_printers.ppuniverse_subst
 install_printer Top_printers.ppuniverse_opt_subst
@@ -70,8 +71,6 @@ install_printer Top_printers.ppevar_universe_context
 install_printer Top_printers.ppconstraints
 install_printer Top_printers.ppuniverseconstraints
 install_printer Top_printers.ppuniverse_context_future
-install_printer Top_printers.ppcumulativity_info
-install_printer Top_printers.ppabstract_cumulativity_info
 install_printer Top_printers.ppuniverses
 install_printer Top_printers.ppnamedcontextval
 install_printer Top_printers.ppenv

--- a/dev/top_printers.ml
+++ b/dev/top_printers.ml
@@ -212,6 +212,7 @@ let prlev = UnivNames.pr_with_global_universes
 let ppuniverse_set l = pp (LSet.pr prlev l)
 let ppuniverse_instance l = pp (Instance.pr prlev l)
 let ppuniverse_context l = pp (pr_universe_context prlev l)
+let ppaucontext l = pp (pr_abstract_universe_context prlev l)
 let ppuniverse_context_set l = pp (pr_universe_context_set prlev l)
 let ppuniverse_subst l = pp (Univ.pr_universe_subst l)
 let ppuniverse_opt_subst l = pp (UnivSubst.pr_universe_opt_subst l)
@@ -222,8 +223,6 @@ let ppuniverseconstraints c = pp (UnivProblem.Set.pr c)
 let ppuniverse_context_future c = 
   let ctx = Future.force c in
     ppuniverse_context ctx
-let ppcumulativity_info c = pp (Univ.pr_cumulativity_info Univ.Level.pr c)
-let ppabstract_cumulativity_info c = pp (Univ.pr_abstract_cumulativity_info Univ.Level.pr c)
 let ppuniverses u = pp (UGraph.pr_universes Level.pr u)
 let ppnamedcontextval e =
   let env = Global.env () in

--- a/dev/top_printers.mli
+++ b/dev/top_printers.mli
@@ -137,6 +137,7 @@ val prlev : Univ.Level.t -> Pp.t (* with global names (does this work?) *)
 val ppuniverse_set : Univ.LSet.t -> unit
 val ppuniverse_instance : Univ.Instance.t -> unit
 val ppuniverse_context : Univ.UContext.t -> unit
+val ppaucontext : Univ.AUContext.t -> unit
 val ppuniverse_context_set : Univ.ContextSet.t -> unit
 val ppuniverse_subst : Univ.universe_subst -> unit
 val ppuniverse_opt_subst : UnivSubst.universe_opt_subst -> unit
@@ -145,8 +146,6 @@ val ppevar_universe_context : UState.t -> unit
 val ppconstraints : Univ.Constraint.t -> unit
 val ppuniverseconstraints : UnivProblem.Set.t -> unit
 val ppuniverse_context_future : Univ.UContext.t Future.computation -> unit
-val ppcumulativity_info : Univ.CumulativityInfo.t -> unit
-val ppabstract_cumulativity_info : Univ.ACumulativityInfo.t -> unit
 val ppuniverses : UGraph.t -> unit
 
 val ppnamedcontextval : Environ.named_context_val -> unit

--- a/engine/eConstr.ml
+++ b/engine/eConstr.ml
@@ -403,25 +403,17 @@ let compare_cumulative_instances cv_pb nargs_ok variances u u' cstrs =
 
 let cmp_inductives cv_pb (mind,ind as spec) nargs u1 u2 cstrs =
   let open UnivProblem in
-  match mind.Declarations.mind_universes with
-  | Declarations.Monomorphic_ind _ ->
-    assert (Univ.Instance.length u1 = 0 && Univ.Instance.length u2 = 0);
-    cstrs
-  | Declarations.Polymorphic_ind _ ->
-     enforce_eq_instances_univs false u1 u2 cstrs
-  | Declarations.Cumulative_ind cumi ->
+  match mind.Declarations.mind_variance with
+  | None -> enforce_eq_instances_univs false u1 u2 cstrs
+  | Some variances ->
     let num_param_arity = Reduction.inductive_cumulativity_arguments spec in
-    let variances = Univ.ACumulativityInfo.variance cumi in
     compare_cumulative_instances cv_pb (Int.equal num_param_arity nargs) variances u1 u2 cstrs
 
 let cmp_constructors (mind, ind, cns as spec) nargs u1 u2 cstrs =
   let open UnivProblem in
-  match mind.Declarations.mind_universes with
-  | Declarations.Monomorphic_ind _ ->
-    cstrs
-  | Declarations.Polymorphic_ind _ ->
-    enforce_eq_instances_univs false u1 u2 cstrs
-  | Declarations.Cumulative_ind cumi ->
+  match mind.Declarations.mind_variance with
+  | None -> enforce_eq_instances_univs false u1 u2 cstrs
+  | Some variances ->
     let num_cnstr_args = Reduction.constructor_cumulativity_arguments spec in
     if not (Int.equal num_cnstr_args nargs)
     then enforce_eq_instances_univs false u1 u2 cstrs

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -852,8 +852,7 @@ let universe_context_set d = UState.context_set d.universes
 
 let to_universe_context evd = UState.context evd.universes
 
-let const_univ_entry ~poly evd = UState.const_univ_entry ~poly evd.universes
-let ind_univ_entry ~poly evd = UState.ind_univ_entry ~poly evd.universes
+let univ_entry ~poly evd = UState.univ_entry ~poly evd.universes
 
 let check_univ_decl ~poly evd decl = UState.check_univ_decl ~poly evd.universes decl
 

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -597,12 +597,9 @@ val universes : evar_map -> UGraph.t
     [Univ.ContextSet.to_context]. *)
 val to_universe_context : evar_map -> Univ.UContext.t
 
-val const_univ_entry : poly:bool -> evar_map -> Entries.constant_universes_entry
+val univ_entry : poly:bool -> evar_map -> Entries.universe_entry
 
-(** NB: [ind_univ_entry] cannot create cumulative entries. *)
-val ind_univ_entry : poly:bool -> evar_map -> Entries.inductive_universes
-
-val check_univ_decl : poly:bool -> evar_map -> UState.universe_decl -> Entries.constant_universes_entry
+val check_univ_decl : poly:bool -> evar_map -> UState.universe_decl -> Entries.universe_entry
 
 val merge_universe_context : evar_map -> UState.t -> evar_map
 val set_universe_context : evar_map -> UState.t -> evar_map

--- a/engine/uState.ml
+++ b/engine/uState.ml
@@ -101,6 +101,7 @@ let constraints ctx = snd ctx.uctx_local
 let context ctx = ContextSet.to_context ctx.uctx_local
 
 let univ_entry ~poly uctx =
+  let ispoly = poly in
   let mono, nas, poly =
     if poly then
       let (binders, _) = uctx.uctx_names in
@@ -111,7 +112,8 @@ let univ_entry ~poly uctx =
   in
   Entries.{ entry_monomorphic_univs=mono;
             entry_poly_univ_names=nas;
-            entry_polymorphic_univs=poly; }
+            entry_polymorphic_univs=poly;
+            entry_is_polymorphic=ispoly; }
 
 let of_context_set ctx = { empty with uctx_local = ctx }
 
@@ -409,6 +411,7 @@ let check_mono_univ_decl uctx decl =
   uctx.uctx_local
 
 let check_univ_decl ~poly uctx decl =
+  let ispoly = poly in
   let mono, nas, poly =
     let names = decl.univdecl_instance in
     let extensible = decl.univdecl_extensible_instance in
@@ -427,7 +430,8 @@ let check_univ_decl ~poly uctx decl =
       (ContextSet.constraints uctx.uctx_local);
   Entries.{ entry_monomorphic_univs=mono;
             entry_poly_univ_names=nas;
-            entry_polymorphic_univs=poly; }
+            entry_polymorphic_univs=poly;
+            entry_is_polymorphic=ispoly;}
 
 let restrict_universe_context (univs, csts) keep =
   let removed = LSet.diff univs keep in

--- a/engine/uState.mli
+++ b/engine/uState.mli
@@ -64,12 +64,8 @@ val constraints : t -> Univ.Constraint.t
 val context : t -> Univ.UContext.t
 (** Shorthand for {!context_set} with {!Context_set.to_context}. *)
 
-val const_univ_entry : poly:bool -> t -> Entries.constant_universes_entry
+val univ_entry : poly:bool -> t -> Entries.universe_entry
 (** Pick from {!context} or {!context_set} based on [poly]. *)
-
-val ind_univ_entry : poly:bool -> t -> Entries.inductive_universes
-(** Pick from {!context} or {!context_set} based on [poly].
-    Cannot create cumulative entries. *)
 
 (** {5 Constraints handling} *)
 
@@ -177,7 +173,7 @@ val default_univ_decl : universe_decl
    When polymorphic, the universes corresponding to
    [decl.univdecl_instance] come first in the order defined by that
    list. *)
-val check_univ_decl : poly:bool -> t -> universe_decl -> Entries.constant_universes_entry
+val check_univ_decl : poly:bool -> t -> universe_decl -> Entries.universe_entry
 
 val check_mono_univ_decl : t -> universe_decl -> Univ.ContextSet.t
 

--- a/engine/univGen.ml
+++ b/engine/univGen.ml
@@ -77,7 +77,7 @@ let fresh_global_instance ?loc ?names env gr =
   mkRef (gr, u), ctx
 
 let constr_of_monomorphic_global gr =
-  if not (Global.is_polymorphic gr) then
+  if not (Decls.is_polymorphic gr) then
     fst (fresh_global_instance (Global.env ()) gr)
   else CErrors.user_err ~hdr:"constr_of_global"
       Pp.(str "globalization of polymorphic reference " ++ Nametab.pr_global_env Id.Set.empty gr ++

--- a/interp/declare.ml
+++ b/interp/declare.ml
@@ -454,8 +454,8 @@ let declare_universe_context poly ctx =
   if poly then
     (Global.push_context_set true ctx; Lib.add_section_context ctx)
   else
-    Lib.check_monomorphic_context ctx;
-    Lib.add_anonymous_leaf (input_universe_context ctx)
+    (Lib.check_monomorphic_context ctx;
+     Lib.add_anonymous_leaf (input_universe_context ctx))
 
 (** Global universes are not substitutive objects but global objects
    bound at the *library* or *module* level. The polymorphic flag is

--- a/interp/declare.mli
+++ b/interp/declare.mli
@@ -24,7 +24,7 @@ open Decl_kinds
 
 type section_variable_entry =
   | SectionLocalDef of Safe_typing.private_constants definition_entry
-  | SectionLocalAssum of types Univ.in_universe_context_set * polymorphic * bool (** Implicit status *)
+  | SectionLocalAssum of types * Lib.var_universes * bool (** Implicit status *)
 
 type variable_declaration = DirPath.t * section_variable_entry * logical_kind
 
@@ -43,7 +43,7 @@ type internal_flag =
 (* Defaut definition entries, transparent with no secctx or proj information *)
 val definition_entry : ?fix_exn:Future.fix_exn ->
   ?opaque:bool -> ?inline:bool -> ?types:types ->
-  ?univs:Entries.constant_universes_entry ->
+  ?univs:Entries.universe_entry ->
   ?eff:Safe_typing.private_constants -> constr -> Safe_typing.private_constants definition_entry
 
 (** [declare_constant id cd] declares a global declaration
@@ -58,7 +58,10 @@ val declare_constant :
 val declare_definition : 
   ?internal:internal_flag -> ?opaque:bool -> ?kind:definition_object_kind ->
   ?local:bool -> Id.t -> ?types:constr ->
-  constr Entries.in_constant_universes_entry -> Constant.t
+  Entries.universe_entry ->
+  constr -> Constant.t
+
+val empty_univ_entry : Entries.universe_entry
 
 (** Since transparent constants' side effects are globally declared, we
  *  need that *)

--- a/interp/discharge.ml
+++ b/interp/discharge.ml
@@ -71,24 +71,26 @@ let refresh_polymorphic_type_of_inductive (_,mip) =
     let ctx = List.rev mip.mind_arity_ctxt in
       mkArity (List.rev ctx, Type ar.template_level), true
 
+let dummy_variance mib univs =
+  match mib.mind_variance with
+  | None -> None
+  | Some _ ->
+    Some (Array.make (Univ.UContext.size univs.entry_polymorphic_univs)
+            Univ.Variance.Invariant)
+
+let discharge_univs info univs =
+  let auctx = univs.polymorphic_univs in
+  let subst, auctx = Lib.discharge_abstract_universe_context info auctx in
+  let nas = Univ.AUContext.names auctx in
+  let auctx = Univ.AUContext.repr auctx in
+  subst, { entry_monomorphic_univs = univs.monomorphic_univs;
+           entry_poly_univ_names = nas;
+           entry_polymorphic_univs = auctx; }
+
 let process_inductive info modlist mib =
   let section_decls = Lib.named_of_variable_context info.Lib.abstr_ctx in
   let nparamdecls = Context.Rel.length mib.mind_params_ctxt in
-  let subst, ind_univs =
-    match mib.mind_universes with
-    | Monomorphic_ind ctx -> Univ.empty_level_subst, Monomorphic_ind_entry ctx
-    | Polymorphic_ind auctx ->
-      let subst, auctx = Lib.discharge_abstract_universe_context info auctx in
-      let nas = Univ.AUContext.names auctx in
-      let auctx = Univ.AUContext.repr auctx in
-      subst, Polymorphic_ind_entry (nas, auctx)
-    | Cumulative_ind cumi ->
-      let auctx = Univ.ACumulativityInfo.univ_context cumi in
-      let subst, auctx = Lib.discharge_abstract_universe_context info auctx in
-      let nas = Univ.AUContext.names auctx in
-      let auctx = Univ.AUContext.repr auctx in
-      subst, Cumulative_ind_entry (nas, Univ.CumulativityInfo.from_universe_context auctx)
-  in
+  let subst, ind_univs = discharge_univs info mib.mind_universes in
   let discharge c = Vars.subst_univs_level_constr subst (expmod_constr modlist c) in
   let inds =
     Array.map_to_list
@@ -114,6 +116,7 @@ let process_inductive info modlist mib =
     mind_entry_params = params';
     mind_entry_inds = inds';
     mind_entry_private = mib.mind_private;
-    mind_entry_universes = ind_univs
+    mind_entry_universes = ind_univs;
+    mind_entry_variance = dummy_variance mib ind_univs;
   }
 

--- a/interp/discharge.ml
+++ b/interp/discharge.ml
@@ -78,19 +78,22 @@ let dummy_variance mib univs =
     Some (Array.make (Univ.UContext.size univs.entry_polymorphic_univs)
             Univ.Variance.Invariant)
 
-let discharge_univs info univs =
+let discharge_univs ~ispoly info univs =
   let auctx = univs.polymorphic_univs in
   let subst, auctx = Lib.discharge_abstract_universe_context info auctx in
   let nas = Univ.AUContext.names auctx in
   let auctx = Univ.AUContext.repr auctx in
   subst, { entry_monomorphic_univs = univs.monomorphic_univs;
            entry_poly_univ_names = nas;
-           entry_polymorphic_univs = auctx; }
+           entry_polymorphic_univs = auctx;
+           entry_is_polymorphic = ispoly; }
 
-let process_inductive info modlist mib =
+let process_inductive info modlist mind =
+  let mib = Global.lookup_mind mind in
+  let ispoly = Decls.mind_is_polymorphic mind in
   let section_decls = Lib.named_of_variable_context info.Lib.abstr_ctx in
   let nparamdecls = Context.Rel.length mib.mind_params_ctxt in
-  let subst, ind_univs = discharge_univs info mib.mind_universes in
+  let subst, ind_univs = discharge_univs ~ispoly info mib.mind_universes in
   let discharge c = Vars.subst_univs_level_constr subst (expmod_constr modlist c) in
   let inds =
     Array.map_to_list

--- a/interp/discharge.mli
+++ b/interp/discharge.mli
@@ -8,9 +8,8 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-open Declarations
 open Entries
 open Opaqueproof
 
 val process_inductive :
-  Lib.abstr_info -> work_list -> mutual_inductive_body -> mutual_inductive_entry
+  Lib.abstr_info -> work_list -> Names.MutInd.t -> mutual_inductive_entry

--- a/kernel/cbytegen.ml
+++ b/kernel/cbytegen.ml
@@ -906,11 +906,7 @@ let compile_constant_body ~fail_on_error env univs = function
   | Undef _ | OpaqueDef _ -> Some BCconstant
   | Def sb ->
       let body = Mod_subst.force_constr sb in
-      let instance_size =
-        match univs with
-        | Monomorphic_const _ -> 0
-        | Polymorphic_const univ -> Univ.AUContext.size univ
-      in
+      let instance_size = Univ.AUContext.size univs.polymorphic_univs in
       match kind body with
 	| Const (kn',u) when is_univ_copy instance_size u ->
 	    (* we use the canonical name of the constant*)

--- a/kernel/cbytegen.mli
+++ b/kernel/cbytegen.mli
@@ -20,7 +20,7 @@ val compile : fail_on_error:bool ->
 (** init, fun, fv *)
 
 val compile_constant_body : fail_on_error:bool ->
-			    env -> constant_universes -> constant_def -> body_code option
+                            env -> universe_decl -> constant_def -> body_code option
 
 (** Shortcut of the previous function used during module strengthening *)
 

--- a/kernel/cooking.mli
+++ b/kernel/cooking.mli
@@ -20,7 +20,7 @@ type inline = bool
 type result = {
   cook_body : constant_def;
   cook_type : types;
-  cook_universes : constant_universes;
+  cook_universes : universe_decl;
   cook_private_univs : Univ.ContextSet.t option;
   cook_inline : inline;
   cook_context : Constr.named_context option;

--- a/kernel/declareops.ml
+++ b/kernel/declareops.ml
@@ -56,9 +56,6 @@ let hcons_template_arity ar =
 
 (** {6 Constants } *)
 
-let constant_is_polymorphic cb =
-  not (Univ.AUContext.is_empty cb.const_universes.polymorphic_univs)
-
 let constant_has_body cb = match cb.const_body with
   | Undef _ -> false
   | Def _ | OpaqueDef _ -> true
@@ -127,7 +124,7 @@ let hcons_const_def = function
 
 let hcons_universe_decl cbu =
   { monomorphic_univs = Univ.hcons_universe_context_set cbu.monomorphic_univs;
-    polymorphic_univs = Univ.hcons_abstract_universe_context cbu.polymorphic_univs; }
+    polymorphic_univs = Univ.hcons_abstract_universe_context cbu.polymorphic_univs;}
 
 let hcons_const_private_univs = function
   | None -> None
@@ -242,9 +239,6 @@ let subst_mind_body sub mib =
 
 let inductive_polymorphic_context mib =
   mib.mind_universes.polymorphic_univs
-
-let inductive_is_polymorphic mib =
-  not (Univ.AUContext.is_empty mib.mind_universes.polymorphic_univs)
 
 let inductive_is_cumulative mib = Option.has_some mib.mind_variance
 

--- a/kernel/declareops.mli
+++ b/kernel/declareops.mli
@@ -15,6 +15,8 @@ open Univ
 (** Operations concerning types in [Declarations] :
     [constant_body], [mutual_inductive_body], [module_body] ... *)
 
+val empty_univ_decl : universe_decl
+
 (** {6 Arities} *)
 
 val map_decl_arity : ('a -> 'c) -> ('b -> 'd) ->

--- a/kernel/declareops.mli
+++ b/kernel/declareops.mli
@@ -33,8 +33,6 @@ val constant_has_body : constant_body -> bool
 val constant_polymorphic_context : constant_body -> AUContext.t
 
 (** Is the constant polymorphic? *)
-val constant_is_polymorphic : constant_body -> bool
-
 (** Return the universe context, in case the definition is polymorphic, otherwise
     the context is empty. *)
 
@@ -58,8 +56,6 @@ val subst_mind_body : substitution -> mutual_inductive_body -> mutual_inductive_
 
 val inductive_polymorphic_context : mutual_inductive_body -> AUContext.t
 
-(** Is the inductive polymorphic? *)
-val inductive_is_polymorphic : mutual_inductive_body -> bool
 (** Is the inductive cumulative? *)
 val inductive_is_cumulative : mutual_inductive_body -> bool
 

--- a/kernel/entries.ml
+++ b/kernel/entries.ml
@@ -28,10 +28,11 @@ then, in i{^ th} block, [mind_entry_params] is [xn:Xn;...;x1:X1];
 [mind_entry_lc] is [Ti1;...;Tini], defined in context [[A'1;...;A'p;x1:X1;...;xn:Xn]] where [A'i] is [Ai] generalized over [[x1:X1;...;xn:Xn]].
 *)
 
-type inductive_universes =
-  | Monomorphic_ind_entry of Univ.ContextSet.t
-  | Polymorphic_ind_entry of Name.t array * Univ.UContext.t
-  | Cumulative_ind_entry of Name.t array * Univ.CumulativityInfo.t
+type universe_entry = {
+  entry_monomorphic_univs : Univ.ContextSet.t;
+  entry_poly_univ_names : Name.t array;
+  entry_polymorphic_univs : Univ.UContext.t;
+}
 
 type one_inductive_entry = {
   mind_entry_typename : Id.t;
@@ -48,21 +49,21 @@ type mutual_inductive_entry = {
   mind_entry_finite : Declarations.recursivity_kind;
   mind_entry_params : Constr.rel_context;
   mind_entry_inds : one_inductive_entry list;
-  mind_entry_universes : inductive_universes;
+  mind_entry_universes : universe_entry;
+  mind_entry_variance : Univ.Variance.t array option;
   (* universe constraints and the constraints for subtyping of
      inductive types in the block. *)
   mind_entry_private : bool option;
 }
 
 (** {6 Constants (Definition/Axiom) } *)
-type 'a proof_output = constr Univ.in_universe_context_set * 'a
+type proof_body = {
+  proof_body : constr;
+  proof_univs : Univ.ContextSet.t;
+  proof_priv_univs : Univ.ContextSet.t; (* should be empty if transparent constant *)
+}
+type 'a proof_output = proof_body * 'a
 type 'a const_entry_body = 'a proof_output Future.computation
-
-type constant_universes_entry =
-  | Monomorphic_const_entry of Univ.ContextSet.t
-  | Polymorphic_const_entry of Name.t array * Univ.UContext.t
-
-type 'a in_constant_universes_entry = 'a * constant_universes_entry
 
 type 'a definition_entry = {
   const_entry_body   : 'a const_entry_body;
@@ -71,7 +72,7 @@ type 'a definition_entry = {
   (* State id on which the completion of type checking is reported *)
   const_entry_feedback : Stateid.t option;
   const_entry_type        : types option;
-  const_entry_universes   : constant_universes_entry;
+  const_entry_universes   : universe_entry;
   const_entry_opaque      : bool;
   const_entry_inline_code : bool }
 
@@ -85,7 +86,7 @@ type section_def_entry = {
 type inline = int option (* inlining level, None for no inlining *)
 
 type parameter_entry = 
-    Constr.named_context option * types in_constant_universes_entry * inline
+    Constr.named_context option * universe_entry * types * inline
 
 type 'a constant_entry =
   | DefinitionEntry of 'a definition_entry

--- a/kernel/entries.ml
+++ b/kernel/entries.ml
@@ -32,6 +32,7 @@ type universe_entry = {
   entry_monomorphic_univs : Univ.ContextSet.t;
   entry_poly_univ_names : Name.t array;
   entry_polymorphic_univs : Univ.UContext.t;
+  entry_is_polymorphic : bool; (* ignored by the kernel *)
 }
 
 type one_inductive_entry = {

--- a/kernel/environ.ml
+++ b/kernel/environ.ml
@@ -505,13 +505,6 @@ let evaluable_constant kn env =
     | OpaqueDef _ -> false
     | Undef _ -> false
 
-let polymorphic_constant cst env =
-  Declareops.constant_is_polymorphic (lookup_constant cst env)
-
-let polymorphic_pconstant (cst,u) env =
-  if Univ.Instance.is_empty u then false
-  else polymorphic_constant cst env
-
 let type_in_type_constant cst env =
   not (lookup_constant cst env).const_typing_flags.check_universes
 
@@ -535,13 +528,6 @@ let get_projections env ind =
   Declareops.inductive_make_projections ind mib
 
 (* Mutual Inductives *)
-let polymorphic_ind (mind,_i) env =
-  Declareops.inductive_is_polymorphic (lookup_mind mind env)
-
-let polymorphic_pind (ind,u) env =
-  if Univ.Instance.is_empty u then false
-  else polymorphic_ind ind env
-
 let type_in_type_ind (mind,_i) env =
   not (lookup_mind mind env).mind_typing_flags.check_universes
 
@@ -717,14 +703,6 @@ let remove_hyps ids check_context check_value ctxt =
   fst (remove_hyps ctxt)
 
 (* A general request *)
-
-let is_polymorphic env r =
-  let open Names.GlobRef in
-  match r with
-  | VarRef _id -> false
-  | ConstRef c -> polymorphic_constant c env
-  | IndRef ind -> polymorphic_ind ind env
-  | ConstructRef cstr -> polymorphic_ind (inductive_of_constructor cstr) env
 
 let is_template_polymorphic env r =
   let open Names.GlobRef in

--- a/kernel/environ.ml
+++ b/kernel/environ.ml
@@ -582,14 +582,13 @@ let constant_context env c =
   let cb = lookup_constant c env in
   Declareops.constant_polymorphic_context cb
 
-let universes_of_global env r =
-  let open GlobRef in
-    match r with
-    | VarRef _ -> Univ.AUContext.empty
-    | ConstRef c -> constant_context env c
+let univ_decl_of_global env = let open GlobRef in function
+    | VarRef _ -> Declareops.empty_univ_decl
+    | ConstRef c -> (lookup_constant c env).const_universes
     | IndRef (mind,_) | ConstructRef ((mind,_),_) ->
-      let mib = lookup_mind mind env in
-      Declareops.inductive_polymorphic_context mib
+      (lookup_mind mind env).mind_universes
+
+let universes_of_global env r = (univ_decl_of_global env r).polymorphic_univs
 
 (* Returns the list of global variables in a term *)
 

--- a/kernel/environ.mli
+++ b/kernel/environ.mli
@@ -283,6 +283,8 @@ val set_typing_flags : typing_flags -> env -> env
 
 val universes_of_global : env -> GlobRef.t -> AUContext.t
 
+val univ_decl_of_global : env -> GlobRef.t -> universe_decl
+
 (** {6 Sets of referred section variables }
    [global_vars_set env c] returns the list of [id]'s occurring either
    directly as [Var id] in [c] or indirectly as a section variable

--- a/kernel/environ.mli
+++ b/kernel/environ.mli
@@ -188,9 +188,6 @@ val lookup_constant_key :  Constant.t -> env -> constant_key
 val lookup_constant    : Constant.t -> env -> constant_body
 val evaluable_constant : Constant.t -> env -> bool
 
-(** New-style polymorphism *)
-val polymorphic_constant  : Constant.t -> env -> bool
-val polymorphic_pconstant : pconstant -> env -> bool
 val type_in_type_constant : Constant.t -> env -> bool
 
 (** {6 ... } *)
@@ -240,9 +237,6 @@ val add_mind : MutInd.t -> mutual_inductive_body -> env -> env
    raises [Not_found] if the required path is not found *)
 val lookup_mind : MutInd.t -> env -> mutual_inductive_body
 
-(** New-style polymorphism *)
-val polymorphic_ind  : inductive -> env -> bool
-val polymorphic_pind : pinductive -> env -> bool
 val type_in_type_ind : inductive -> env -> bool
 
 (** Old-style polymorphism *)
@@ -332,7 +326,6 @@ val apply_to_hyp : named_context_val -> variable ->
 
 val remove_hyps : Id.Set.t -> (Constr.named_declaration -> Constr.named_declaration) -> (lazy_val -> lazy_val) -> named_context_val -> named_context_val
 
-val is_polymorphic : env -> Names.GlobRef.t -> bool
 val is_template_polymorphic : env -> GlobRef.t -> bool
 val is_type_in_type : env -> GlobRef.t -> bool
 

--- a/kernel/indTyping.ml
+++ b/kernel/indTyping.ml
@@ -247,7 +247,8 @@ let abstract_inductive_universes univs =
   let ctx = univs.entry_polymorphic_univs in
   let (inst, auctx) = Univ.abstract_universes univs.entry_poly_univ_names ctx in
   let inst = Univ.make_instance_subst inst in
-  inst, {monomorphic_univs=univs.entry_monomorphic_univs; polymorphic_univs=auctx}
+  inst, {monomorphic_univs=univs.entry_monomorphic_univs;
+         polymorphic_univs=auctx;}
 
 let typecheck_inductive env (mie:mutual_inductive_entry) =
   let () = match mie.mind_entry_inds with

--- a/kernel/indTyping.mli
+++ b/kernel/indTyping.mli
@@ -24,7 +24,7 @@ open Declarations
  *)
 val typecheck_inductive : env -> mutual_inductive_entry ->
   env
-  * abstract_inductive_universes
+  * universe_decl * Univ.Variance.t array option
   * Constr.rel_context
   * ((inductive_arity * Constr.types array) *
      (Constr.rel_context * (Constr.rel_context * Constr.types) array) *

--- a/kernel/indtypes.ml
+++ b/kernel/indtypes.ml
@@ -414,11 +414,7 @@ exception UndefinableExpansion
     a substitution of the form [params, x : ind params] *)
 let compute_projections (kn, i as ind) mib =
   let pkt = mib.mind_packets.(i) in
-  let u = match mib.mind_universes with
-  | Monomorphic_ind _ -> Univ.Instance.empty
-  | Polymorphic_ind auctx -> Univ.make_abstract_instance auctx
-  | Cumulative_ind acumi -> Univ.make_abstract_instance (Univ.ACumulativityInfo.univ_context acumi)
-  in
+  let u = Univ.make_abstract_instance mib.mind_universes.polymorphic_univs in
   let subst = List.init mib.mind_ntypes (fun i -> mkIndU ((kn, mib.mind_ntypes - i - 1), u)) in
   let rctx, _ = decompose_prod_assum (substl subst pkt.mind_nf_lc.(0)) in
   let ctx, paramslet = List.chop pkt.mind_consnrealdecls.(0) rctx in
@@ -471,7 +467,7 @@ let compute_projections (kn, i as ind) mib =
     Array.of_list (List.rev labs),
     Array.of_list (List.rev pbs)
 
-let build_inductive env names prv univs paramsctxt kn isrecord isfinite inds nmr recargs =
+let build_inductive env names prv univs variance paramsctxt kn isrecord isfinite inds nmr recargs =
   let ntypes = Array.length inds in
   (* Compute the set of used section variables *)
   let hyps = used_section_variables env inds in
@@ -529,6 +525,7 @@ let build_inductive env names prv univs paramsctxt kn isrecord isfinite inds nmr
       mind_params_ctxt = paramsctxt;
       mind_packets = packets;
       mind_universes = univs;
+      mind_variance = variance;
       mind_private = prv;
       mind_typing_flags = Environ.typing_flags env;
     }
@@ -559,7 +556,7 @@ let build_inductive env names prv univs paramsctxt kn isrecord isfinite inds nmr
 
 let check_inductive env kn mie =
   (* First type-check the inductive definition *)
-  let (env_ar_par, univs, paramsctxt, inds) = IndTyping.typecheck_inductive env mie in
+  let (env_ar_par, univs, variance, paramsctxt, inds) = IndTyping.typecheck_inductive env mie in
   (* Then check positivity conditions *)
   let chkpos = (Environ.typing_flags env).check_guarded in
   let names = Array.map_of_list (fun entry -> entry.mind_entry_typename, entry.mind_entry_consnames)
@@ -570,6 +567,6 @@ let check_inductive env kn mie =
       (Array.map (fun ((_,lc),(indices,_),_) -> Context.Rel.nhyps indices,lc) inds)
   in
   (* Build the inductive packets *)
-    build_inductive env names mie.mind_entry_private univs
+    build_inductive env names mie.mind_entry_private univs variance
       paramsctxt kn mie.mind_entry_record mie.mind_entry_finite
       inds nmr recargs

--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -56,12 +56,7 @@ let inductive_paramdecls (mib,u) =
   Vars.subst_instance_context u mib.mind_params_ctxt
 
 let instantiate_inductive_constraints mib u =
-  let process auctx =  Univ.AUContext.instantiate u auctx in
-  match mib.mind_universes with
-  | Monomorphic_ind _ -> Univ.Constraint.empty
-  | Polymorphic_ind auctx -> process auctx
-  | Cumulative_ind cumi -> process (Univ.ACumulativityInfo.univ_context cumi)
-
+  Univ.AUContext.instantiate u mib.mind_universes.polymorphic_univs
 
 (************************************************************************)
 

--- a/kernel/mod_typing.ml
+++ b/kernel/mod_typing.ml
@@ -98,7 +98,10 @@ let rec check_with_def env struc (idl,(c,ctx)) mp equiv =
             Univ.Level.is_var l || Univ.Level.is_var r)
             cst
         then error_incorrect_with_constraint lab;
-        c', {monomorphic_univs=Univ.ContextSet.empty; polymorphic_univs=ctx}, cst
+        let univs = {monomorphic_univs=Univ.ContextSet.empty;
+                     polymorphic_univs=ctx;}
+        in
+        c', univs, cst
       in
       let def = Def (Mod_subst.from_val c') in
       let code = Option.map Cemitcodes.from_val

--- a/kernel/modops.ml
+++ b/kernel/modops.ml
@@ -37,8 +37,6 @@ type signature_mismatch_error =
   | NotConvertibleConstructorField of Id.t
   | NotConvertibleBodyField
   | NotConvertibleTypeField of env * types * types
-  | CumulativeStatusExpected of bool
-  | PolymorphicStatusExpected of bool
   | NotSameConstructorNamesField
   | NotSameInductiveNameInBlockField
   | FiniteInductiveFieldExpected of bool
@@ -332,14 +330,10 @@ let strengthen_const mp_from l cb resolver =
   |_ ->
     let kn = KerName.make mp_from l in
     let con = constant_of_delta_kn resolver kn in
-    let u =
-      match cb.const_universes with
-      | Monomorphic_const _ -> Univ.Instance.empty
-      | Polymorphic_const ctx -> Univ.make_abstract_instance ctx
-    in
+    let u = Univ.make_abstract_instance cb.const_universes.polymorphic_univs in
       { cb with
         const_body = Def (Mod_subst.from_val (mkConstU (con,u)));
-        const_private_poly_univs = None;
+        const_private_univs = None;
 	const_body_code = Some (Cemitcodes.from_val (Cbytegen.compile_alias con)) }
 
 let rec strengthen_mod mp_from mp_to mb =

--- a/kernel/modops.mli
+++ b/kernel/modops.mli
@@ -96,8 +96,6 @@ type signature_mismatch_error =
   | NotConvertibleConstructorField of Id.t
   | NotConvertibleBodyField
   | NotConvertibleTypeField of env * types * types
-  | CumulativeStatusExpected of bool
-  | PolymorphicStatusExpected of bool
   | NotSameConstructorNamesField
   | NotSameInductiveNameInBlockField
   | FiniteInductiveFieldExpected of bool

--- a/kernel/nativecode.ml
+++ b/kernel/nativecode.ml
@@ -1893,11 +1893,7 @@ and compile_named env sigma univ auxdefs id =
       Glet(Gnamed id, MLprimitive (Mk_var id))::auxdefs
 
 let compile_constant env sigma prefix ~interactive con cb =
-     let no_univs =
-       match cb.const_universes with
-       | Monomorphic_const _ -> true
-       | Polymorphic_const ctx -> Int.equal (Univ.AUContext.size ctx) 0
-     in
+    let no_univs = Univ.AUContext.size cb.const_universes.polymorphic_univs = 0 in
     begin match cb.const_body with
     | Def t ->
       let t = Mod_subst.force_constr t in

--- a/kernel/reduction.ml
+++ b/kernel/reduction.ml
@@ -233,18 +233,14 @@ let inductive_cumulativity_arguments (mind,ind) =
   mind.Declarations.mind_packets.(ind).Declarations.mind_nrealargs
 
 let convert_inductives_gen cmp_instances cmp_cumul cv_pb (mind,ind) nargs u1 u2 s =
-  match mind.Declarations.mind_universes with
-  | Declarations.Monomorphic_ind _ ->
-    assert (Univ.Instance.length u1 = 0 && Univ.Instance.length u2 = 0);
-    s
-  | Declarations.Polymorphic_ind _ ->
-    cmp_instances u1 u2 s
-  | Declarations.Cumulative_ind cumi ->
+  match mind.Declarations.mind_variance with
+  | None -> cmp_instances u1 u2 s
+  | Some variance ->
     let num_param_arity = inductive_cumulativity_arguments (mind,ind) in
     if not (Int.equal num_param_arity nargs) then
       cmp_instances u1 u2 s
     else
-      cmp_cumul cv_pb (Univ.ACumulativityInfo.variance cumi) u1 u2 s
+      cmp_cumul cv_pb variance u1 u2 s
 
 let convert_inductives cv_pb ind nargs u1 u2 (s, check) =
   convert_inductives_gen (check.compare_instances ~flex:false) check.compare_cumul_instances
@@ -255,13 +251,9 @@ let constructor_cumulativity_arguments (mind, ind, ctor) =
   mind.Declarations.mind_packets.(ind).Declarations.mind_consnrealargs.(ctor - 1)
 
 let convert_constructors_gen cmp_instances cmp_cumul (mind, ind, cns) nargs u1 u2 s =
-  match mind.Declarations.mind_universes with
-  | Declarations.Monomorphic_ind _ ->
-    assert (Univ.Instance.length u1 = 0 && Univ.Instance.length u2 = 0);
-    s
-  | Declarations.Polymorphic_ind _ ->
-    cmp_instances u1 u2 s
-  | Declarations.Cumulative_ind _cumi ->
+  match mind.Declarations.mind_variance with
+  | None -> cmp_instances u1 u2 s
+  | Some _ ->
     let num_cnstr_args = constructor_cumulativity_arguments (mind,ind,cns) in
     if not (Int.equal num_cnstr_args nargs) then
       cmp_instances u1 u2 s

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -692,7 +692,9 @@ let constant_entry_of_side_effect cb u =
     let auctx = univs.polymorphic_univs in
     { entry_monomorphic_univs=univs.monomorphic_univs;
       entry_poly_univ_names=Univ.AUContext.names auctx;
-      entry_polymorphic_univs=Univ.AUContext.repr auctx; }
+      entry_polymorphic_univs=Univ.AUContext.repr auctx;
+      entry_is_polymorphic=not (Univ.AUContext.is_empty auctx);}
+    (* is_polymorphic doesn't matter but try to be sane regardless *)
   in
   let body, bunivs =
     match cb.const_body, u with

--- a/kernel/safe_typing.mli
+++ b/kernel/safe_typing.mli
@@ -56,6 +56,7 @@ val concat_private : private_constants -> private_constants -> private_constants
 val private_con_of_con : safe_environment -> Constant.t -> private_constants
 val private_con_of_scheme : kind:string -> safe_environment -> (inductive * Constant.t) list -> private_constants
 
+val make_proof : ?global:Univ.ContextSet.t -> ?priv:Univ.ContextSet.t -> Constr.t -> Entries.proof_body
 val mk_pure_proof : Constr.constr -> private_constants Entries.proof_output
 val inline_private_constants_in_constr :
   Environ.env -> Constr.constr -> private_constants -> Constr.constr
@@ -76,9 +77,7 @@ val is_joined_environment : safe_environment -> bool
 
 (** Insertion of local declarations (Local or Variables) *)
 
-val push_named_assum :
-  (Id.t * Constr.types * bool (* polymorphic *))
-    Univ.in_universe_context_set -> safe_transformer0
+val push_named_assum : Id.t * Constr.types -> safe_transformer0
 
 (** Returns the full universe context necessary to typecheck the definition
   (futures are forced) *)

--- a/kernel/univ.mli
+++ b/kernel/univ.mli
@@ -57,6 +57,8 @@ sig
 
   val var : int -> t
 
+  val is_var : t -> bool
+
   val var_index : t -> int option
 
   val name : t -> UGlobal.t option
@@ -368,45 +370,6 @@ type 'a univ_abstracted = {
 
 val map_univ_abstracted : ('a -> 'b) -> 'a univ_abstracted -> 'b univ_abstracted
 
-(** Universe info for cumulative inductive types: A context of
-   universe levels with universe constraints, representing local
-   universe variables and constraints, together with an array of
-   Variance.t.
-
-    This data structure maintains the invariant that the variance
-   array has the same length as the universe instance. *)
-module CumulativityInfo :
-sig
-  type t
-
-  val make : UContext.t * Variance.t array -> t
-
-  val empty : t
-  val is_empty : t -> bool
-
-  val univ_context : t -> UContext.t
-  val variance : t -> Variance.t array
-
-  (** This function takes a universe context representing constraints
-     of an inductive and produces a CumulativityInfo.t with the
-     trivial subtyping relation. *)
-  val from_universe_context : UContext.t -> t
-
-  val leq_constraints : t -> Instance.t constraint_function
-  val eq_constraints : t -> Instance.t constraint_function
-end
-
-module ACumulativityInfo :
-sig
-  type t
-
-  val repr : t -> CumulativityInfo.t
-  val univ_context : t -> AUContext.t
-  val variance : t -> Variance.t array
-  val leq_constraints : t -> Instance.t constraint_function
-  val eq_constraints : t -> Instance.t constraint_function
-end
-
 (** Universe contexts (as sets) *)
 
 (** A set of universes with universe Constraint.t.
@@ -487,7 +450,6 @@ val make_instance_subst : Instance.t -> universe_level_subst
 val make_inverse_instance_subst : Instance.t -> universe_level_subst
 
 val abstract_universes : Names.Name.t array -> UContext.t -> Instance.t * AUContext.t
-val abstract_cumulativity_info : Names.Name.t array -> CumulativityInfo.t -> Instance.t * ACumulativityInfo.t
 (** TODO: move universe abstraction out of the kernel *)
 
 val make_abstract_instance : AUContext.t -> Instance.t
@@ -505,10 +467,8 @@ val pr_constraint_type : constraint_type -> Pp.t
 val pr_constraints : (Level.t -> Pp.t) -> Constraint.t -> Pp.t
 val pr_universe_context : (Level.t -> Pp.t) -> ?variance:Variance.t array ->
   UContext.t -> Pp.t
-val pr_cumulativity_info : (Level.t -> Pp.t) -> CumulativityInfo.t -> Pp.t
 val pr_abstract_universe_context : (Level.t -> Pp.t) -> ?variance:Variance.t array ->
   AUContext.t -> Pp.t
-val pr_abstract_cumulativity_info : (Level.t -> Pp.t) -> ACumulativityInfo.t -> Pp.t
 val pr_universe_context_set : (Level.t -> Pp.t) -> ContextSet.t -> Pp.t
 val explain_universe_inconsistency : (Level.t -> Pp.t) ->
   univ_inconsistency -> Pp.t
@@ -524,5 +484,3 @@ val hcons_universe_set : LSet.t -> LSet.t
 val hcons_universe_context : UContext.t -> UContext.t
 val hcons_abstract_universe_context : AUContext.t -> AUContext.t
 val hcons_universe_context_set : ContextSet.t -> ContextSet.t
-val hcons_cumulativity_info : CumulativityInfo.t -> CumulativityInfo.t
-val hcons_abstract_cumulativity_info : ACumulativityInfo.t -> ACumulativityInfo.t

--- a/kernel/vconv.ml
+++ b/kernel/vconv.ml
@@ -86,15 +86,11 @@ and conv_atom env pb k a1 stk1 a2 stk2 cu =
   match a1, a2 with
   | Aind ((mi,_i) as ind1) , Aind ind2 ->
     if eq_ind ind1 ind2 && compare_stack stk1 stk2 then
-      if Environ.polymorphic_ind ind1 env then
-        let mib = Environ.lookup_mind mi env in
-	let ulen = 
-          match mib.Declarations.mind_universes with
-          | Declarations.Monomorphic_ind ctx -> Univ.ContextSet.size ctx
-          | Declarations.Polymorphic_ind auctx -> Univ.AUContext.size auctx
-          | Declarations.Cumulative_ind cumi -> 
-            Univ.AUContext.size (Univ.ACumulativityInfo.univ_context cumi)
-        in
+      let mib = Environ.lookup_mind mi env in
+      let ulen = Univ.AUContext.size Declarations.(mib.mind_universes.polymorphic_univs) in
+      if ulen = 0 then (* XXX not sure if this optimisation is worth the bother *)
+        conv_stack env k stk1 stk2 cu
+      else
         match stk1 , stk2 with
 	| [], [] -> assert (Int.equal ulen 0); cu
         | Zapp args1 :: stk1' , Zapp args2 :: stk2' ->
@@ -108,8 +104,6 @@ and conv_atom env pb k a1 stk1 a2 stk2 cu =
           conv_arguments env ~from:ulen k args1 args2
 	    (conv_stack env k stk1' stk2' cu)
         | _, _ -> assert false (* Should not happen if problem is well typed *)
-      else
-	conv_stack env k stk1 stk2 cu
     else raise NotConvertible
   | Aid ik1, Aid ik2 ->
     if Vmvalues.eq_id_key ik1 ik2 && compare_stack stk1 stk2 then

--- a/library/decls.ml
+++ b/library/decls.ml
@@ -18,18 +18,16 @@ open Libnames
 (** Datas associated to section variables and local definitions *)
 
 type variable_data =
-  DirPath.t * bool (* opacity *) * Univ.ContextSet.t * polymorphic * logical_kind
+  DirPath.t * bool (* opacity *) * logical_kind
 
 let vartab =
   Summary.ref (Id.Map.empty : variable_data Id.Map.t) ~name:"VARIABLE"
 
 let add_variable_data id o = vartab := Id.Map.add id o !vartab
 
-let variable_path id = let (p,_,_,_,_) = Id.Map.find id !vartab in p
-let variable_opacity id = let (_,opaq,_,_,_) = Id.Map.find id !vartab in opaq
-let variable_kind id = let (_,_,_,_,k) = Id.Map.find id !vartab in k
-let variable_context id = let (_,_,ctx,_,_) = Id.Map.find id !vartab in ctx
-let variable_polymorphic id = let (_,_,_,p,_) = Id.Map.find id !vartab in p
+let variable_path id = let (p,_,_) = Id.Map.find id !vartab in p
+let variable_opacity id = let (_,opaq,_) = Id.Map.find id !vartab in opaq
+let variable_kind id = let (_,_,k) = Id.Map.find id !vartab in k
 
 let variable_secpath id =
   let dir = drop_dirpath_prefix (Lib.library_dp()) (variable_path id) in

--- a/library/decls.mli
+++ b/library/decls.mli
@@ -32,3 +32,8 @@ val variable_exists : variable -> bool
 
 val add_constant_kind : Constant.t -> logical_kind -> unit
 val constant_kind : Constant.t -> logical_kind
+
+val register_poly_const : Constant.t -> bool -> unit
+val register_poly_mind : MutInd.t -> bool -> unit
+val is_polymorphic : GlobRef.t -> bool
+val mind_is_polymorphic : MutInd.t -> bool

--- a/library/decls.mli
+++ b/library/decls.mli
@@ -19,15 +19,13 @@ open Decl_kinds
 (** Registration and access to the table of variable *)
 
 type variable_data =
-  DirPath.t * bool (* opacity *) * Univ.ContextSet.t * polymorphic * logical_kind
+  DirPath.t * bool (* opacity *) * logical_kind
 
 val add_variable_data : variable -> variable_data -> unit
 val variable_path : variable -> DirPath.t
 val variable_secpath : variable -> qualid
 val variable_kind : variable -> logical_kind
 val variable_opacity : variable -> bool
-val variable_context : variable -> Univ.ContextSet.t
-val variable_polymorphic : variable -> polymorphic
 val variable_exists : variable -> bool
 
 (** Registration and access to the table of constants *)

--- a/library/global.ml
+++ b/library/global.ml
@@ -159,8 +159,6 @@ let type_of_global_in_context = Typeops.type_of_global_in_context
 let universes_of_global gr = 
   universes_of_global (env ()) gr
 
-let is_polymorphic r = Environ.is_polymorphic (env()) r
-
 let is_template_polymorphic r = is_template_polymorphic (env ()) r
 
 let is_type_in_type r = is_type_in_type (env ()) r

--- a/library/global.mli
+++ b/library/global.mli
@@ -35,7 +35,7 @@ val typing_flags : unit -> Declarations.typing_flags
 
 (** Variables, Local definitions, constants, inductive types *)
 
-val push_named_assum : (Id.t * Constr.types * bool) Univ.in_universe_context_set -> unit
+val push_named_assum : Id.t * Constr.types -> unit
 val push_named_def   : (Id.t * Entries.section_def_entry) -> unit
 
 val export_private_constants : in_section:bool ->

--- a/library/global.mli
+++ b/library/global.mli
@@ -124,7 +124,6 @@ val env_of_context : Environ.named_context_val -> Environ.env
 val join_safe_environment : ?except:Future.UUIDSet.t -> unit -> unit
 val is_joined_environment : unit -> bool
 
-val is_polymorphic : GlobRef.t -> bool
 val is_template_polymorphic : GlobRef.t -> bool
 val is_type_in_type : GlobRef.t -> bool
 

--- a/library/lib.mli
+++ b/library/lib.mli
@@ -180,15 +180,31 @@ val variable_section_segment_of_reference : GlobRef.t -> variable_context
 val section_instance : GlobRef.t -> Univ.Instance.t * Id.t array
 val is_in_section : GlobRef.t -> bool
 
-val add_section_variable : Id.t -> Decl_kinds.binding_kind -> Decl_kinds.polymorphic -> Univ.ContextSet.t -> unit
+type var_universes = { var_monomorphic_univs : Univ.ContextSet.t;
+                       var_polymorphic_univs : Univ.ContextSet.t; }
+
+(** The universes are only the polymorphic ones. *)
+val add_section_variable : Id.t -> Decl_kinds.binding_kind -> var_universes -> unit
 val add_section_context : Univ.ContextSet.t -> unit
-val add_section_constant : Decl_kinds.polymorphic ->
-  Constant.t -> Constr.named_context -> unit
-val add_section_kn : Decl_kinds.polymorphic ->
-  MutInd.t -> Constr.named_context -> unit
+val add_section_constant : Constant.t -> Constr.named_context -> unit
+val add_section_kn : MutInd.t -> Constr.named_context -> unit
 val replacement_context : unit -> Opaqueproof.work_list
 
-val is_polymorphic_univ : Univ.Level.t -> bool
+val check_monomorphic_context : Univ.ContextSet.t -> unit
+(** Monomorphic constraints are not allowed to refer to polymorphic
+    section universes. This function errors if called on such a
+    monomorphic context.
+
+    Note that we can't fully check this for opaque constants.
+    TODO check what happens if body constraints refer to polymorphic section univs.
+*)
+
+val variable_monomorphic_univs : Id.t -> Univ.ContextSet.t
+(** Returns the monomorphic universes and constraints for a variable
+   in the current section. raises [Not_found] for other variables. *)
+
+val entry_to_var_univs : Entries.universe_entry -> var_universes
+(** Forgets the names and order of polymorphic universes *)
 
 (** {6 Discharge: decrease the section level if in the current section } *)
 

--- a/plugins/derive/derive.ml
+++ b/plugins/derive/derive.ml
@@ -12,10 +12,9 @@ open Constr
 open Context.Named.Declaration
 
 let map_const_entry_body (f:constr->constr) (x:Safe_typing.private_constants Entries.const_entry_body)
-    : Safe_typing.private_constants Entries.const_entry_body =
-  Future.chain x begin fun ((b,ctx),fx) ->
-    (f b , ctx) , fx
-  end
+  : Safe_typing.private_constants Entries.const_entry_body =
+  Future.chain x (fun (proof,fx) ->
+      Entries.{proof with proof_body=f proof.proof_body} , fx)
 
 (** [start_deriving f suchthat lemma] starts a proof of [suchthat]
     (which can contain references to [f]) in the context extended by

--- a/plugins/funind/functional_principles_types.ml
+++ b/plugins/funind/functional_principles_types.ml
@@ -364,7 +364,7 @@ let generate_functional_principle (evd: Evd.evar_map ref)
         let evd',value = change_property_sort evd' s new_principle_type new_princ_name in
         let evd' = fst (Typing.type_of ~refresh:true (Global.env ()) evd' (EConstr.of_constr value)) in
         (* Pp.msgnl (str "new principle := " ++ pr_lconstr value); *)
-        let univs = Evd.const_univ_entry ~poly:false evd' in
+        let univs = Evd.univ_entry ~poly:false evd' in
         let ce = Declare.definition_entry ~univs value in
         ignore(
 	  Declare.declare_constant
@@ -579,7 +579,7 @@ let make_scheme evd (fas : (pconstant*Sorts.family) list) : Safe_typing.private_
       List.map (compute_new_princ_type_from_rel funs sorts) other_princ_types
     in
     let first_princ_body,first_princ_type = const.const_entry_body, const.const_entry_type in
-    let ctxt,fix = decompose_lam_assum (fst(fst(Future.force first_princ_body))) in (* the principle has for forall ...., fix .*)
+    let ctxt,fix = decompose_lam_assum (fst(Future.force first_princ_body)).proof_body in (* the principle has for forall ...., fix .*)
     let (idxs,_),(_,ta,_ as decl) = destFix fix in
     let other_result =
       List.map (* we can now compute the other principles *)

--- a/plugins/funind/invfun.ml
+++ b/plugins/funind/invfun.ml
@@ -785,7 +785,9 @@ let derive_correctness make_scheme (funs: pconstant list) (graphs:inductive list
 	  Array.of_list
 	    (List.map
 	       (fun entry ->
-		  (EConstr.of_constr (fst (fst(Future.force entry.Entries.const_entry_body))), EConstr.of_constr (Option.get entry.Entries.const_entry_type ))
+                  (EConstr.of_constr
+                     (fst(Future.force entry.Entries.const_entry_body)).Entries.proof_body,
+                   EConstr.of_constr (Option.get entry.Entries.const_entry_type ))
 	       )
 	       (make_scheme evd (Array.map_to_list (fun const -> const,Sorts.InType) funs))
 	    )

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -1545,7 +1545,7 @@ let recursive_definition is_mes function_name rec_impls type_of_f r rec_arg_num 
   let functional_id =  add_suffix function_name "_F" in
   let term_id = add_suffix function_name "_terminate" in
   let functional_ref =
-    let univs = Entries.Monomorphic_const_entry (Evd.universe_context_set evd) in
+    let univs = Evd.univ_entry ~poly:false evd in
     declare_fun functional_id (IsDefinition Decl_kinds.Definition) ~univs res
   in
   (* Refresh the global universes, now including those of _F *)

--- a/plugins/ltac/rewrite.ml
+++ b/plugins/ltac/rewrite.ml
@@ -1861,7 +1861,7 @@ let proper_projection sigma r ty =
     it_mkLambda_or_LetIn app ctx
 
 let declare_projection n instance_id r =
-  let poly = Global.is_polymorphic r in
+  let poly = Decls.is_polymorphic r in
   let env = Global.env () in
   let sigma = Evd.from_env env in
   let sigma,c = Evd.fresh_global env sigma r in

--- a/plugins/ltac/rewrite.ml
+++ b/plugins/ltac/rewrite.ml
@@ -1889,7 +1889,7 @@ let declare_projection n instance_id r =
     in it_mkProd_or_LetIn ccl ctx
   in
   let typ = it_mkProd_or_LetIn typ ctx in
-  let univs = Evd.const_univ_entry ~poly sigma in
+  let univs = Evd.univ_entry ~poly sigma in
   let typ = EConstr.to_constr sigma typ in
   let term = EConstr.to_constr sigma term in
   let cst = 
@@ -1975,10 +1975,10 @@ let add_morphism_infer atts m n =
   let evd = Evd.from_env env in
   let uctx, instance = build_morphism_signature env evd m in
     if Lib.is_modtype () then
-      let uctx = UState.const_univ_entry ~poly:atts.polymorphic uctx in
+      let uctx = UState.univ_entry ~poly:atts.polymorphic uctx in
       let cst = Declare.declare_constant ~internal:Declare.InternalTacticRequest instance_id
 				(Entries.ParameterEntry 
-                                 (None,(instance,uctx),None),
+                                 (None,uctx,instance,None),
 				 Decl_kinds.IsAssumption Decl_kinds.Logical)
       in
 	add_instance (Typeclasses.new_instance 

--- a/plugins/setoid_ring/newring.ml
+++ b/plugins/setoid_ring/newring.ml
@@ -155,7 +155,8 @@ let decl_constant na univs c =
   let univs = UState.restrict_universe_context univs vars in
   let univs = { entry_monomorphic_univs = univs;
                 entry_poly_univ_names = [| |];
-                entry_polymorphic_univs = Univ.UContext.empty; }
+                entry_polymorphic_univs = Univ.UContext.empty;
+                entry_is_polymorphic=false; }
   in
   mkConst(declare_constant (Id.of_string na) 
             (DefinitionEntry (definition_entry ~opaque:true ~univs c),

--- a/plugins/setoid_ring/newring.ml
+++ b/plugins/setoid_ring/newring.ml
@@ -153,7 +153,10 @@ let decl_constant na univs c =
   let open Constr in
   let vars = CVars.universes_of_constr c in
   let univs = UState.restrict_universe_context univs vars in
-  let univs = Monomorphic_const_entry univs in
+  let univs = { entry_monomorphic_univs = univs;
+                entry_poly_univ_names = [| |];
+                entry_polymorphic_univs = Univ.UContext.empty; }
+  in
   mkConst(declare_constant (Id.of_string na) 
             (DefinitionEntry (definition_entry ~opaque:true ~univs c),
 	     IsProof Lemma))

--- a/pretyping/classops.ml
+++ b/pretyping/classops.ml
@@ -320,8 +320,8 @@ let different_class_params i =
     if (snd ci).cl_param > 0 then true
     else 
       match fst ci with
-      | CL_IND i -> Global.is_polymorphic (IndRef i)
-      | CL_CONST c -> Global.is_polymorphic (ConstRef c)
+      | CL_IND i -> Decls.is_polymorphic (IndRef i)
+      | CL_CONST c -> Decls.is_polymorphic (ConstRef c)
       | _ -> false
 
 let add_coercion_in_graph (ic,source,target) =

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -467,18 +467,16 @@ and evar_eqappr_x ?(rhs_is_already_stuck = false) ts env evd pbty
         else
           let u = EInstance.kind evd u and u' = EInstance.kind evd u' in
           let mind = Environ.lookup_mind mi env in
-          let open Declarations in
-          begin match mind.mind_universes with
-            | Monomorphic_ind _ -> assert false
-            | Polymorphic_ind _ -> check_strict evd u u'
-            | Cumulative_ind cumi ->
+          begin match mind.Declarations.mind_variance with
+            | None -> check_strict evd u u'
+            | Some variances ->
               let nparamsaplied = Stack.args_size sk in
               let nparamsaplied' = Stack.args_size sk' in
               let needed = Reduction.inductive_cumulativity_arguments (mind,i) in
               if not (Int.equal nparamsaplied needed && Int.equal nparamsaplied' needed)
               then check_strict evd u u'
               else
-                compare_cumulative_instances evd (Univ.ACumulativityInfo.variance cumi) u u'
+                compare_cumulative_instances evd variances u u'
           end
       | Ind _, Ind _ -> UnifFailure (evd, NotSameHead)
       | Construct (((mi,ind),ctor as cons), u), Construct (cons', u')
@@ -487,11 +485,9 @@ and evar_eqappr_x ?(rhs_is_already_stuck = false) ts env evd pbty
         else
           let u = EInstance.kind evd u and u' = EInstance.kind evd u' in
           let mind = Environ.lookup_mind mi env in
-          let open Declarations in
-          begin match mind.mind_universes with
-            | Monomorphic_ind _ -> assert false
-            | Polymorphic_ind _ -> check_strict evd u u'
-            | Cumulative_ind cumi ->
+          begin match mind.Declarations.mind_variance with
+            | None -> check_strict evd u u'
+            | Some _ ->
               let nparamsaplied = Stack.args_size sk in
               let nparamsaplied' = Stack.args_size sk' in
               let needed = Reduction.constructor_cumulativity_arguments (mind,ind,ctor) in

--- a/pretyping/inductiveops.ml
+++ b/pretyping/inductiveops.ml
@@ -453,12 +453,7 @@ let build_branch_type env sigma dep p cs =
 let compute_projections env (kn, i as ind) =
   let open Term in
   let mib = Environ.lookup_mind kn env in
-  let u = match mib.mind_universes with
-  | Monomorphic_ind _ -> Instance.empty
-  | Polymorphic_ind auctx -> make_abstract_instance auctx
-  | Cumulative_ind acumi ->
-    make_abstract_instance (ACumulativityInfo.univ_context acumi)
-  in
+  let u = make_abstract_instance mib.mind_universes.polymorphic_univs in
   let x = match mib.mind_record with
   | NotRecord | FakeRecord ->
     anomaly Pp.(str "Trying to build primitive projections for a non-primitive record")

--- a/pretyping/inferCumulativity.mli
+++ b/pretyping/inferCumulativity.mli
@@ -10,3 +10,9 @@
 
 val infer_inductive : Environ.env -> Entries.mutual_inductive_entry ->
   Entries.mutual_inductive_entry
+(** If the entry has non-[None] [mind_entry_variance] then it is reinferred from scratch.
+    Otherwise this function is a noop. *)
+
+val dummy_variance : Entries.universe_entry -> Univ.Variance.t array
+(** Convenient way to produce a valid [mind_entry_variance] in
+   anticipation of passing it to [infer_inductive]. *)

--- a/pretyping/typeclasses.ml
+++ b/pretyping/typeclasses.ml
@@ -388,7 +388,7 @@ let is_local_for_hint i =
      itself *)
 
 let add_instance check inst =
-  let poly = Global.is_polymorphic inst.is_impl in
+  let poly = Decls.is_polymorphic inst.is_impl in
   let local = is_local_for_hint inst in
   add_instance_hint (IsGlobal inst.is_impl) [inst.is_impl] local
     inst.is_info poly;

--- a/printing/prettyp.ml
+++ b/printing/prettyp.ml
@@ -88,7 +88,7 @@ let print_ref reduce ref udecl =
       (Environ.lookup_mind ind env).mind_variance
   in
   let inst =
-    if Global.is_polymorphic ref
+    if Decls.is_polymorphic ref
     then Printer.pr_universe_instance sigma inst
     else mt ()
   in
@@ -222,7 +222,7 @@ let print_if_is_coercion ref =
 (* *)
 
 let print_polymorphism ref =
-  let poly = Global.is_polymorphic ref in
+  let poly = Decls.is_polymorphic ref in
   let template_poly = Global.is_template_polymorphic ref in
   [ pr_global ref ++ str " is " ++ str
       (if poly then "universe polymorphic"
@@ -541,8 +541,8 @@ let print_body env evd = function
 let print_typed_body env evd (val_0,typ) =
   (print_body env evd val_0 ++ fnl () ++ str "     : " ++ pr_ltype_env env evd typ)
 
-let print_instance sigma cb =
-  if Declareops.constant_is_polymorphic cb then
+let print_instance sigma c cb =
+  if Decls.is_polymorphic (ConstRef c) then
     let univs = Declareops.constant_polymorphic_context cb in
     let inst = Univ.make_abstract_instance univs in
     pr_universe_instance sigma inst
@@ -572,11 +572,11 @@ let print_constant with_values sep sp udecl =
     match val_0 with
     | None ->
 	str"*** [ " ++
-	print_basename sp ++ print_instance sigma cb ++ str " : " ++ cut () ++ pr_ltype typ ++
+        print_basename sp ++ print_instance sigma sp cb ++ str " : " ++ cut () ++ pr_ltype typ ++
 	str" ]" ++
         Printer.pr_universe_decl sigma univs ~priv:cb.const_private_univs
     | Some (c, ctx) ->
-	print_basename sp ++ print_instance sigma cb ++ str sep ++ cut () ++
+        print_basename sp ++ print_instance sigma sp cb ++ str sep ++ cut () ++
 	(if with_values then print_typed_body env sigma (Some c,typ) else pr_ltype typ)++
         Printer.pr_universe_decl sigma univs ~priv:cb.const_private_univs)
 

--- a/printing/printer.mli
+++ b/printing/printer.mli
@@ -85,12 +85,13 @@ val pr_universe_instance   : evar_map -> Univ.Instance.t -> Pp.t
 val pr_universe_instance_constraints : evar_map -> Univ.Instance.t -> Univ.Constraint.t -> Pp.t
 val pr_universe_ctx        : evar_map -> ?variance:Univ.Variance.t array ->
   Univ.UContext.t -> Pp.t
-val pr_abstract_universe_ctx : evar_map -> ?variance:Univ.Variance.t array ->
-  Univ.AUContext.t -> priv:Univ.ContextSet.t option -> Pp.t
 val pr_universe_ctx_set    : evar_map -> Univ.ContextSet.t -> Pp.t
-val pr_constant_universes  : evar_map -> priv:Univ.ContextSet.t option -> Declarations.constant_universes -> Pp.t
-val pr_cumulativity_info   : evar_map -> Univ.CumulativityInfo.t -> Pp.t
-val pr_abstract_cumulativity_info   : evar_map -> Univ.ACumulativityInfo.t -> Pp.t
+
+val pr_universe_decl  : evar_map -> ?variance:Univ.Variance.t array ->
+  priv:Univ.ContextSet.t option ->
+  Declarations.universe_decl -> Pp.t
+(** Should be called in an evar map which already has the names for
+    the polymorphic universes. *)
 
 (** Printing global references using names as short as possible *)
 

--- a/printing/printmod.ml
+++ b/printing/printmod.ml
@@ -100,7 +100,7 @@ let print_one_inductive env sigma mib ((_,i) as ind) =
   let cstrtypes = Array.map (fun c -> hnf_prod_applist_assum env nparamdecls c args) cstrtypes in
   let envpar = push_rel_context params env in
   let inst =
-    if Declareops.inductive_is_polymorphic mib then
+    if Decls.is_polymorphic (IndRef ind) then
       Printer.pr_universe_instance sigma u
     else mt ()
   in

--- a/printing/printmod.ml
+++ b/printing/printmod.ml
@@ -126,10 +126,7 @@ let print_mutual_inductive env mind mib udecl =
   hov 0 (def keyword ++ spc () ++
          prlist_with_sep (fun () -> fnl () ++ str"  with ")
            (print_one_inductive env sigma mib) inds ++
-         match mib.mind_universes with
-         | Monomorphic_ind _ | Polymorphic_ind _ -> str ""
-         | Cumulative_ind cumi ->
-           Printer.pr_abstract_cumulativity_info sigma cumi)
+        Printer.pr_universe_decl sigma ?variance:mib.mind_variance ~priv:None mib.mind_universes)
 
 let get_fields =
   let rec prodec_rec l subst c =
@@ -178,11 +175,7 @@ let print_record env mind mib udecl =
         (fun (id,b,c) ->
           Id.print id ++ str (if b then " : " else " := ") ++
           Printer.pr_lconstr_env envpar sigma c) fields) ++ str" }" ++
-    match mib.mind_universes with
-    | Monomorphic_ind _ | Polymorphic_ind _ -> str ""
-    | Cumulative_ind cumi ->
-      Printer.pr_abstract_cumulativity_info sigma cumi
-  )
+    Printer.pr_universe_decl sigma ?variance:mib.mind_variance ~priv:None mib.mind_universes)
 
 let pr_mutual_inductive_body env mind mib udecl =
   if mib.mind_record != NotRecord && not !Flags.raw_print then
@@ -301,8 +294,7 @@ let print_body is_impl extent env mp (l,body) =
 		spc () ++
 		hov 2 (str ":= " ++
                        Printer.pr_lconstr_env env sigma (Mod_subst.force_constr l))
-	      | _ -> mt ()) ++ str "." ++
-            Printer.pr_abstract_universe_ctx sigma ctx ~priv:cb.const_private_poly_univs)
+              | _ -> mt ()) ++ str ".")
     | SFBmind mib ->
       match extent with
       | WithContents ->

--- a/proofs/pfedit.ml
+++ b/proofs/pfedit.ml
@@ -166,9 +166,12 @@ let build_by_tactic ?(side_eff=true) env sigma ?(poly=false) typ tac =
     else { ce with
       const_entry_body = Future.chain ce.const_entry_body
         (fun (pt, _) -> pt, ()) } in
-  let (cb, ctx), () = Future.force ce.const_entry_body in
-  let univs = UState.merge ~sideff:side_eff ~extend:true Evd.univ_rigid univs ctx in
-  cb, status, univs
+  let proof, () = Future.force ce.const_entry_body in
+  assert (Univ.ContextSet.is_empty proof.proof_priv_univs);
+  let univs = UState.merge ~sideff:side_eff ~extend:true Evd.univ_rigid univs
+      proof.proof_univs
+  in
+  proof.proof_body, status, univs
 
 let refine_by_tactic ~name ~poly env sigma ty tac =
   (* Save the initial side-effects to restore them afterwards. We set the

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -1309,9 +1309,9 @@ let project_hint ~poly pri l2r r =
   let id =
     Nameops.add_suffix (Nametab.basename_of_global gr) ("_proj_" ^ (if l2r then "l2r" else "r2l"))
   in
-  let ctx = Evd.const_univ_entry ~poly sigma in
+  let univs = Evd.univ_entry ~poly sigma in
   let c = EConstr.to_constr sigma c in
-  let c = Declare.declare_definition ~internal:Declare.InternalTacticRequest id (c,ctx) in
+  let c = Declare.declare_definition ~internal:Declare.InternalTacticRequest id univs c in
   let info = {Typeclasses.hint_priority = pri; hint_pattern = None} in
     (info,false,true,PathAny, IsGlobRef (Globnames.ConstRef c))
 

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -1359,13 +1359,12 @@ let interp_hints poly =
   | HintsConstructors lqid ->
       let constr_hints_of_ind qid =
         let ind = global_inductive_with_alias qid in
-	let mib,_ = Global.lookup_inductive ind in
         Dumpglob.dump_reference ?loc:qid.CAst.loc "<>" (string_of_qualid qid) "ind";
           List.init (nconstructors ind) 
 	    (fun i -> let c = (ind,i+1) in
 		      let gr = ConstructRef c in
 			empty_hint_info, 
-                        (Declareops.inductive_is_polymorphic mib), true,
+                        (Decls.mind_is_polymorphic (fst ind)), true,
 			PathHints [gr], IsGlobRef gr)
       in HintsResolveEntry (List.flatten (List.map constr_hints_of_ind lqid))
   | HintsExtern (pri, patcom, tacexp) ->

--- a/tactics/ind_tables.ml
+++ b/tactics/ind_tables.ml
@@ -121,11 +121,9 @@ let define internal id c poly univs =
   let id = compute_name internal id in
   let ctx = UState.minimize univs in
   let c = UnivSubst.nf_evars_and_universes_opt_subst (fun _ -> None) (UState.subst ctx) c in
-  let univs = UState.const_univ_entry ~poly ctx in
+  let univs = UState.univ_entry ~poly ctx in
   let entry = {
-    const_entry_body =
-      Future.from_val ((c,Univ.ContextSet.empty),
-                       Safe_typing.empty_private_constants);
+    const_entry_body = Future.from_val (Safe_typing.mk_pure_proof c);
     const_entry_secctx = None;
     const_entry_type = None;
     const_entry_universes = univs;

--- a/tactics/ind_tables.ml
+++ b/tactics/ind_tables.ml
@@ -144,7 +144,7 @@ let define_individual_scheme_base kind suff f mode idopt (mind,i as ind) =
   let id = match idopt with
     | Some id -> id
     | None -> add_suffix mib.mind_packets.(i).mind_typename suff in
-  let const = define mode id c (Declareops.inductive_is_polymorphic mib) ctx in
+  let const = define mode id c (Decls.mind_is_polymorphic mind) ctx in
   declare_scheme kind [|ind,const|];
   const, Safe_typing.concat_private
      (Safe_typing.private_con_of_scheme ~kind (Global.safe_env()) [ind,const]) eff
@@ -162,7 +162,7 @@ let define_mutual_scheme_base kind suff f mode names mind =
       try Int.List.assoc i names
       with Not_found -> add_suffix mib.mind_packets.(i).mind_typename suff) in
   let consts = Array.map2 (fun id cl -> 
-     define mode id cl (Declareops.inductive_is_polymorphic mib) ctx) ids cl in
+     define mode id cl (Decls.mind_is_polymorphic mind) ctx) ids cl in
   let schemes = Array.mapi (fun i cst -> ((mind,i),cst)) consts in
   declare_scheme kind schemes;
   consts,

--- a/tactics/leminv.ml
+++ b/tactics/leminv.ml
@@ -237,8 +237,7 @@ let inversion_scheme ~name ~poly env sigma t sort dep_option inv_op =
 
 let add_inversion_lemma ~poly name env sigma t sort dep inv_op =
   let invProof, sigma = inversion_scheme ~name ~poly env sigma t sort dep inv_op in
-  let univs =
-    Evd.const_univ_entry ~poly sigma
+  let univs = Evd.univ_entry ~poly sigma
   in
   let entry = definition_entry ~univs invProof in
   let _ = declare_constant name (DefinitionEntry entry, IsProof Lemma) in

--- a/test-suite/bugs/closed/HoTT_coq_014.v
+++ b/test-suite/bugs/closed/HoTT_coq_014.v
@@ -27,7 +27,7 @@ Polymorphic Definition GeneralizeCategory `(C : @SpecializedCategory obj) : Cate
   refine {| CObject := C.(Object) |}; auto.
 Defined.
 
-Polymorphic Coercion GeneralizeCategory : SpecializedCategory >-> Category.
+Coercion GeneralizeCategory : SpecializedCategory >-> Category.
 
 
 
@@ -46,7 +46,7 @@ Section SpecializedFunctor.
   }.
 End SpecializedFunctor.
 
-Global Polymorphic Coercion ObjectOf' : SpecializedFunctor >-> Funclass.
+Global Coercion ObjectOf' : SpecializedFunctor >-> Funclass.
 Set Universe Polymorphism.
 Section Functor.
   Variable C D : Category.
@@ -57,7 +57,7 @@ Unset Universe Polymorphism.
 
 Polymorphic Identity Coercion Functor_SpecializedFunctor_Id : Functor >-> SpecializedFunctor.
 Polymorphic Definition GeneralizeFunctor objC C objD D (F : @SpecializedFunctor objC C objD D) : Functor C D := F.
-Polymorphic Coercion GeneralizeFunctor : SpecializedFunctor >-> Functor.
+Coercion GeneralizeFunctor : SpecializedFunctor >-> Functor.
 
 Arguments SpecializedFunctor {objC} C {objD} D.
 
@@ -72,7 +72,7 @@ Polymorphic Definition GeneralizeSmallCategory `(C : @SmallSpecializedCategory o
   refine {| SObject := obj |}; destruct C; econstructor; eassumption.
 Defined.
 
-Polymorphic Coercion GeneralizeSmallCategory : SmallSpecializedCategory >-> SmallCategory.
+Coercion GeneralizeSmallCategory : SmallSpecializedCategory >-> SmallCategory.
 
 Bind Scope category_scope with SmallCategory.
 

--- a/test-suite/bugs/closed/bug_4503.v
+++ b/test-suite/bugs/closed/bug_4503.v
@@ -9,9 +9,9 @@ Section foo.
   Polymorphic Universes A.
   Polymorphic Context {A : Type@{A}} {rA : A -> A -> Prop} {PO : PreOrder A rA}.
 
-  Fail Definition foo := PO.
+  Definition foo := PO.
 End foo.
-
+Check foo@{_}. (* foo takes a universe even though it's marked monomorphic *)
 
 Module ILogic.
 

--- a/test-suite/bugs/closed/bug_4816.v
+++ b/test-suite/bugs/closed/bug_4816.v
@@ -9,7 +9,7 @@ Section Foo.
   Polymorphic Universes Z W.
   Polymorphic Constraint W < Z.
 
-  Fail Definition bla := Type@{W}.
+  Definition blu := Type@{W}.
   Polymorphic Definition bla := Type@{W}.
   Section Bar.
     Fail Constraint X <= Z.

--- a/test-suite/misc/poly-capture-global-univs/src/evilImpl.ml
+++ b/test-suite/misc/poly-capture-global-univs/src/evilImpl.ml
@@ -5,7 +5,9 @@ open Univ
 let make_entry ?(mono=ContextSet.empty) ?(poly=UContext.empty) () =
   { entry_monomorphic_univs = mono;
     entry_poly_univ_names = Array.make (UContext.size poly) Anonymous;
-    entry_polymorphic_univs = poly; }
+    entry_polymorphic_univs = poly;
+    entry_is_polymorphic = not (UContext.is_empty poly);
+  }
 
 let evil t f =
   let open Decl_kinds in

--- a/test-suite/misc/poly-capture-global-univs/src/evilImpl.ml
+++ b/test-suite/misc/poly-capture-global-univs/src/evilImpl.ml
@@ -1,21 +1,26 @@
 open Names
+open Entries
+open Univ
+
+let make_entry ?(mono=ContextSet.empty) ?(poly=UContext.empty) () =
+  { entry_monomorphic_univs = mono;
+    entry_poly_univ_names = Array.make (UContext.size poly) Anonymous;
+    entry_polymorphic_univs = poly; }
 
 let evil t f =
-  let open Univ in
-  let open Entries in
   let open Decl_kinds in
   let open Constr in
   let k = IsDefinition Definition in
   let u = Level.var 0 in
   let tu = mkType (Universe.make u) in
   let te = Declare.definition_entry
-      ~univs:(Monomorphic_const_entry (ContextSet.singleton u)) tu
+      ~univs:(make_entry ~mono:(ContextSet.singleton u) ()) tu
   in
   let tc = Declare.declare_constant t (DefinitionEntry te, k) in
   let tc = mkConst tc in
 
   let fe = Declare.definition_entry
-      ~univs:(Polymorphic_const_entry ([|Anonymous|], UContext.make (Instance.of_array [|u|],Constraint.empty)))
+      ~univs:(make_entry ~poly:(UContext.make (Instance.of_array [|u|],Constraint.empty)) ())
       ~types:(Term.mkArrow tc tu)
       (mkLambda (Name.Name (Id.of_string "x"), tc, mkRel 1))
   in

--- a/test-suite/modules/polymorphism2.v
+++ b/test-suite/modules/polymorphism2.v
@@ -1,4 +1,5 @@
 Set Universe Polymorphism.
+Set Printing Universes.
 
 (** Tests for module subtyping of polymorphic terms *)
 
@@ -10,7 +11,7 @@ Universes i j.
 Constraint i <= j.
 
 Inductive foo : Type@{i} -> Type@{j} :=.
-
+About foo_rect.
 End Foo.
 
 End S.

--- a/test-suite/output/UnivBinders.out
+++ b/test-suite/output/UnivBinders.out
@@ -1,5 +1,7 @@
 Inductive Empty@{u} : Type@{u} :=  
+(* u |=  *)
 Record PWrap (A : Type@{u}) : Type@{u} := pwrap { punwrap : A }
+(* u |=  *)
 
 PWrap has primitive projections with eta conversion.
 For PWrap: Argument scope is [type_scope]
@@ -12,6 +14,7 @@ fun (A : Type@{u}) (p : PWrap@{u} A) => punwrap _ p
 punwrap is universe polymorphic
 Argument scopes are [type_scope _]
 Record RWrap (A : Type@{u}) : Type@{u} := rwrap { runwrap : A }
+(* u |=  *)
 
 For RWrap: Argument scope is [type_scope]
 For rwrap: Argument scopes are [type_scope _]
@@ -95,7 +98,9 @@ Type@{UnivBinders.17} -> Type@{v} -> Type@{u}
 
 foo is universe polymorphic
 Inductive Empty@{E} : Type@{E} :=  
+(* E |=  *)
 Record PWrap (A : Type@{E}) : Type@{E} := pwrap { punwrap : A }
+(* E |=  *)
 
 PWrap has primitive projections with eta conversion.
 For PWrap: Argument scope is [type_scope]
@@ -131,7 +136,9 @@ insec@{v} = Type@{u} -> Type@{v}
 (* v |=  *)
 
 insec is universe polymorphic
-Inductive insecind@{k} : Type@{k+1} :=  inseccstr : Type@{k} -> insecind@{k}
+Inductive insecind@{k} : Type@{k+1} :=
+    inseccstr : Type@{k} -> insecind@{k}
+(* k |=  *)
 
 For inseccstr: Argument scope is [type_scope]
 insec@{u v} = Type@{u} -> Type@{v}
@@ -141,6 +148,7 @@ insec@{u v} = Type@{u} -> Type@{v}
 insec is universe polymorphic
 Inductive insecind@{u k} : Type@{k+1} :=
     inseccstr : Type@{k} -> insecind@{u k}
+(* u k |=  *)
 
 For inseccstr: Argument scope is [type_scope]
 insec2@{u} = Prop
@@ -184,6 +192,7 @@ axbar is universe polymorphic
 Argument scope is [type_scope]
 Expands to: Constant UnivBinders.axbar
 axfoo' : Type@{axbar'.u0} -> Type@{axbar'.i}
+(* {axbar'.u0 axbar'.i} |=  *)
 
 axfoo' is not universe polymorphic
 Argument scope is [type_scope]

--- a/vernac/class.mli
+++ b/vernac/class.mli
@@ -16,13 +16,11 @@ open Classops
 (** [try_add_new_coercion_with_target ref s src tg] declares [ref] as a coercion
    from [src] to [tg] *)
 val try_add_new_coercion_with_target : GlobRef.t -> local:bool ->
-  Decl_kinds.polymorphic ->
   source:cl_typ -> target:cl_typ ->  unit
 
 (** [try_add_new_coercion ref s] declares [ref], assumed to be of type
    [(x1:T1)...(xn:Tn)src->tg], as a coercion from [src] to [tg] *)
-val try_add_new_coercion : GlobRef.t -> local:bool ->
-  Decl_kinds.polymorphic -> unit
+val try_add_new_coercion : GlobRef.t -> local:bool -> unit
 
 (** [try_add_new_coercion_subclass cst s] expects that [cst] denotes a
    transparent constant which unfolds to some class [tg]; it declares
@@ -34,7 +32,7 @@ val try_add_new_coercion_subclass : cl_typ -> local:bool ->
 (** [try_add_new_coercion_with_source ref s src] declares [ref] as a coercion
    from [src] to [tg] where the target is inferred from the type of [ref] *)
 val try_add_new_coercion_with_source : GlobRef.t -> local:bool ->
-  Decl_kinds.polymorphic -> source:cl_typ -> unit
+  source:cl_typ -> unit
 
 (** [try_add_new_identity_coercion id s src tg] enriches the
    environment with a new definition of name [id] declared as an
@@ -42,7 +40,7 @@ val try_add_new_coercion_with_source : GlobRef.t -> local:bool ->
 val try_add_new_identity_coercion : Id.t -> local:bool -> 
   Decl_kinds.polymorphic -> source:cl_typ -> target:cl_typ -> unit
 
-val add_coercion_hook : Decl_kinds.polymorphic -> Lemmas.declaration_hook
+val add_coercion_hook : Lemmas.declaration_hook
 
 val add_subclass_hook : Decl_kinds.polymorphic -> Lemmas.declaration_hook
 

--- a/vernac/comAssumption.mli
+++ b/vernac/comAssumption.mli
@@ -29,7 +29,7 @@ val do_assumptions : locality * polymorphic * assumption_object_kind ->
 (** returns [false] if the assumption is neither local to a section,
     nor in a module type and meant to be instantiated. *)
 val declare_assumption : coercion_flag -> assumption_kind ->
-  types in_constant_universes_entry ->
+  universe_entry -> types ->
   UnivNames.universe_binders -> Impargs.manual_implicits ->
   bool (** implicit *) -> Declaremods.inline -> variable CAst.t ->
   GlobRef.t * Univ.Instance.t * bool

--- a/vernac/comDefinition.ml
+++ b/vernac/comDefinition.ml
@@ -96,9 +96,8 @@ let do_definition ~program_mode ?hook ident k univdecl bl red_option c ctypopt =
   in
     if program_mode then
       let env = Global.env () in
-      let (c,ctx), sideff = Future.force ce.const_entry_body in
+      let {proof_body=c}, sideff = Future.force ce.const_entry_body in
       assert(Safe_typing.empty_private_constants = sideff);
-      assert(Univ.ContextSet.is_empty ctx);
       let typ = match ce.const_entry_type with
         | Some t -> t
         | None -> EConstr.to_constr ~abort_on_undefined_evars:false evd (Retyping.get_type_of env evd (EConstr.of_constr c))

--- a/vernac/comFixpoint.ml
+++ b/vernac/comFixpoint.ml
@@ -276,7 +276,6 @@ let declare_fixpoint local poly ((fixnames,fixdefs,fixtypes),pl,ctx,fiximps) ind
     let evd = Evd.restrict_universe_context evd vars in
     let ctx = Evd.check_univ_decl ~poly evd pl in
     let pl = Evd.universe_binders evd in
-    let fixdecls = List.map Safe_typing.mk_pure_proof fixdecls in
     ignore (List.map4 (DeclareDef.declare_fix (local, poly, Fixpoint) pl ctx)
               fixnames fixdecls fixtypes fiximps);
     (* Declare the recursive definitions *)
@@ -303,7 +302,6 @@ let declare_cofixpoint local poly ((fixnames,fixdefs,fixtypes),pl,ctx,fiximps) n
     let fixdecls = prepare_recursive_declaration fixnames fixtypes fixdefs in
     let fixdecls = List.map_i (fun i _ -> mkCoFix (i,fixdecls)) 0 fixnames in
     let vars = Vars.universes_of_constr (List.hd fixdecls) in
-    let fixdecls = List.map Safe_typing.mk_pure_proof fixdecls in
     let fiximps = List.map (fun (len,imps,idx) -> imps) fiximps in
     let evd = Evd.from_ctx ctx in
     let evd = Evd.restrict_universe_context evd vars in

--- a/vernac/declareDef.ml
+++ b/vernac/declareDef.ml
@@ -51,8 +51,8 @@ let declare_definition ident (local, p, k) ?hook ce pl imps =
   let () = definition_message ident in
   Lemmas.call_hook ~fix_exn ?hook local gr; gr
 
-let declare_fix ?(opaque = false) (_,poly,_ as kind) pl univs f ((def,_),eff) t imps =
-  let ce = definition_entry ~opaque ~types:t ~univs ~eff def in
+let declare_fix ?(opaque = false) (_,poly,_ as kind) pl univs f def t imps =
+  let ce = definition_entry ~opaque ~types:t ~univs def in
   declare_definition f kind ce pl imps
 
 let check_definition_evars ~allow_evars sigma =
@@ -73,4 +73,4 @@ let prepare_parameter ~allow_evars ~poly sigma udecl typ =
       sigma (fun nf -> nf typ)
   in
   let univs = Evd.check_univ_decl ~poly sigma udecl in
-  sigma, (None(*proof using*), (typ, univs), None(*inline*))
+  sigma, (None(*proof using*), univs, typ, None(*inline*))

--- a/vernac/declareDef.mli
+++ b/vernac/declareDef.mli
@@ -19,8 +19,8 @@ val declare_definition : Id.t -> definition_kind ->
   GlobRef.t
 
 val declare_fix : ?opaque:bool -> definition_kind ->
-  UnivNames.universe_binders -> Entries.constant_universes_entry ->
-  Id.t -> Safe_typing.private_constants Entries.proof_output ->
+  UnivNames.universe_binders -> Entries.universe_entry ->
+  Id.t -> Constr.t ->
   Constr.types -> Impargs.manual_implicits ->
   GlobRef.t
 

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -875,14 +875,6 @@ let explain_not_match_error = function
     pr_enum (function Name id -> Id.print id | _ -> str "_") nal
   | NotEqualInductiveAliases ->
     str "Aliases to inductive types do not match"
-  | CumulativeStatusExpected b ->
-    let status b = if b then str"cumulative" else str"non-cumulative" in
-      str "a " ++ status b ++ str" declaration was expected, but a " ++ 
-	status (not b) ++ str" declaration was found"
-  | PolymorphicStatusExpected b ->
-    let status b = if b then str"polymorphic" else str"monomorphic" in
-      str "a " ++ status b ++ str" declaration was expected, but a " ++ 
-	status (not b) ++ str" declaration was found"
   | IncompatibleUniverses incon ->
     str"the universe constraints are inconsistent: " ++
       Univ.explain_universe_inconsistency UnivNames.pr_with_global_universes incon

--- a/vernac/indschemes.ml
+++ b/vernac/indschemes.ml
@@ -396,7 +396,7 @@ let do_mutual_induction_scheme ?(force_mutual=false) lnamedepindsort =
     (* NB: build_mutual_induction_scheme forces nonempty list of mutual inductives
        (force_mutual is about the generated schemes) *)
     let _,_,ind,_ = List.hd lnamedepindsort in
-    Global.is_polymorphic (IndRef ind)
+    Decls.is_polymorphic (IndRef ind)
   in
   let declare decl fi lrecref =
     let decltype = Retyping.get_type_of env0 sigma (EConstr.of_constr decl) in
@@ -530,7 +530,7 @@ let do_combined_scheme name schemes =
      polymorphism of the inductive block). In that case if they want
      some other polymorphism they can also manually define the
      combined scheme. *)
-  let poly = Global.is_polymorphic (ConstRef (List.hd csts)) in
+  let poly = Decls.is_polymorphic (ConstRef (List.hd csts)) in
   ignore (define ~poly name.v UserIndividualRequest sigma proof_output (Some typ));
   fixpoint_message None [name.v]
 

--- a/vernac/indschemes.ml
+++ b/vernac/indschemes.ml
@@ -103,7 +103,7 @@ let () =
 
 let define ~poly id internal sigma c t =
   let f = declare_constant ~internal in
-  let univs = Evd.const_univ_entry ~poly sigma in
+  let univs = Evd.univ_entry ~poly sigma in
   let kn = f id
     (DefinitionEntry
       { const_entry_body = c;
@@ -401,7 +401,7 @@ let do_mutual_induction_scheme ?(force_mutual=false) lnamedepindsort =
   let declare decl fi lrecref =
     let decltype = Retyping.get_type_of env0 sigma (EConstr.of_constr decl) in
     let decltype = EConstr.to_constr sigma decltype in
-    let proof_output = Future.from_val ((decl,Univ.ContextSet.empty),Safe_typing.empty_private_constants) in
+    let proof_output = Future.from_val (Safe_typing.mk_pure_proof decl) in
     let cst = define ~poly fi UserIndividualRequest sigma proof_output (Some decltype) in
     ConstRef cst :: lrecref
   in
@@ -523,7 +523,7 @@ let do_combined_scheme name schemes =
       schemes
   in
   let sigma,body,typ = build_combined_scheme (Global.env ()) csts in
-  let proof_output = Future.from_val ((body,Univ.ContextSet.empty),Safe_typing.empty_private_constants) in
+  let proof_output = Future.from_val (Safe_typing.mk_pure_proof body) in
   (* It is possible for the constants to have different universe
      polymorphism from each other, however that is only when the user
      manually defined at least one of them (as Scheme would pick the

--- a/vernac/record.mli
+++ b/vernac/record.mli
@@ -16,7 +16,7 @@ val primitive_flag : bool ref
 
 val declare_projections :
   inductive ->
-  Entries.constant_universes_entry ->
+  Entries.universe_entry ->
   ?kind:Decl_kinds.definition_object_kind ->
   Id.t ->
   bool list ->

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -518,7 +518,7 @@ let start_proof_and_print ?hook k l =
 
 let vernac_definition_hook p = function
 | Coercion ->
-  Some (Class.add_coercion_hook p)
+  Some Class.add_coercion_hook
 | CanonicalStructure ->
   Some (Lemmas.mk_hook (fun _ -> Recordops.declare_canonical_structure))
 | SubClass ->
@@ -988,12 +988,12 @@ let vernac_canonical r =
   Recordops.declare_canonical_structure (smart_global r)
 
 let vernac_coercion ~atts ref qids qidt =
-  let local, polymorphic = Attributes.(parse Notations.(locality ++ polymorphic) atts) in
+  let local = only_locality atts in
   let local = enforce_locality local in
   let target = cl_of_qualid qidt in
   let source = cl_of_qualid qids in
   let ref' = smart_global ref in
-  Class.try_add_new_coercion_with_target ref' ~local polymorphic ~source ~target;
+  Class.try_add_new_coercion_with_target ref' ~local ~source ~target;
   Flags.if_verbose Feedback.msg_info (pr_global ref' ++ str " is now a coercion")
 
 let vernac_identity_coercion ~atts id qids qidt =


### PR DESCRIPTION
We still have to track polymorphism outside the kernel for the following:
~~~coq
Polymorphic Inductive foo : Set := bar.
~~~
The universe of the predicate in `foo_rect` should be polymorphic. In current master this is done by imitating the polymorphism of the inductive. If we don't track polymorphism then there is no trace of having used `Polymorphic` (foo has no universes).
We could try passing the polymorphism attribute explicitly to scheme functions but that gets pretty heavy, see unfinished commit 24a59c4a262ab770e85e606dc5c8a3df147c143f
We could revert having to access the polymorphism option through an attribute, but that's kinda messy.
We could try just making all _rect universes polymorphic. If we just pass poly:true in schemes we get an assertion failure from https://github.com/SkySkimmer/coq/blob/bd96a3ff6e906f828530f3aa5f68a838dee533ec/kernel/term_typing.ml#L52 so I'm not sure how feasible it would be.

Some other places are calling is_polymorphic, they didn't have an issue with the implementation `= not (is_empty polymorphic_univs)` but I haven't reviewed them.

I put XXX/TODO in various places which need a look, I'll point them out later through the github UI.

Backward compat seems fine (aside from the usual plugin breaking).

This probably introduces bugs when the ability to combine monomorphic and polymorphic universes is used, especially in sections. Accordingly I'm not sure if we want to do this.