### PR TITLE
Transfer maintenance of appveyor infrastructure to the CI team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,10 +30,9 @@
 # Trick to avoid getting review requests
 # each time someone adds an overlay
 
-/appveyor.yml          @maximedenes
-/dev/ci/appveyor.*     @maximedenes
-/dev/ci/*.bat          @maximedenes
-# Secondary maintainer @SkySkimmer
+/appveyor.yml          @coq/ci-maintainers
+/dev/ci/appveyor.*     @coq/ci-maintainers
+/dev/ci/*.bat          @coq/ci-maintainers
 
 *.nix             @coq/nix-maintainers
 


### PR DESCRIPTION
I think we could do the same for the gitlab Windows build scripts. @MSoegtropIMC, what do you think? Of course, we would add you to the CI maintainers team, if you are not already there.