### PR TITLE
Move \def\plus and \def\tri to refman-preamble.sty.

### DIFF
--- a/doc/sphinx/language/cic.rst
+++ b/doc/sphinx/language/cic.rst
@@ -1719,13 +1719,11 @@ possible:
 .. math::
    :nowrap:
 
-   {\def\plus{\mathsf{plus}}
-    \def\tri{\triangleright_\iota}
-    \begin{eqnarray*}
-    \plus~(\nS~(\nS~\nO))~(\nS~\nO) & \tri & \nS~(\plus~(\nS~\nO)~(\nS~\nO))\\
-                                   & \tri & \nS~(\nS~(\plus~\nO~(\nS~\nO)))\\
-                                   & \tri & \nS~(\nS~(\nS~\nO))\\
-    \end{eqnarray*}}
+   \begin{eqnarray*}
+   \plus~(\nS~(\nS~\nO))~(\nS~\nO)~& \trii & \nS~(\plus~(\nS~\nO)~(\nS~\nO))\\
+                                   & \trii & \nS~(\nS~(\plus~\nO~(\nS~\nO)))\\
+                                   & \trii & \nS~(\nS~(\nS~\nO))\\
+   \end{eqnarray*}
 
 .. _Mutual-induction:
 

--- a/doc/sphinx/refman-preamble.sty
+++ b/doc/sphinx/refman-preamble.sty
@@ -56,6 +56,7 @@
 \newcommand{\oddS}{\textsf{odd}_\textsf{S}}
 \newcommand{\ovl}[1]{\overline{#1}}
 \newcommand{\Pair}{\textsf{pair}}
+\newcommand{\plus}{\mathsf{plus}}
 \newcommand{\Prod}{\textsf{prod}}
 \newcommand{\Prop}{\textsf{Prop}}
 \newcommand{\return}{\kw{return}}
@@ -68,6 +69,7 @@
 \newcommand{\subst}[3]{#1\{#2/#3\}}
 \newcommand{\tl}{\textsf{tl}}
 \newcommand{\tree}{\textsf{tree}}
+\newcommand{\trii}{\triangleright_\iota}
 \newcommand{\true}{\textsf{true}}
 \newcommand{\Type}{\textsf{Type}}
 \newcommand{\unfold}{\textsf{unfold}}


### PR DESCRIPTION
The definition of \plus and \tri in cic.rst is not effective
for HTML output.

The definition itself is shown in
https://coq.inria.fr/refman/language/cic.html#reduction-rule
as:

```
{\def\plus{\mathsf{plus}} \def\tri{\triangleright_\iota}
\plus (𝖲 (𝖲 𝖮)) (𝖲 𝖮)\tri\tri\tri𝖲 (\plus (𝖲 𝖮) (𝖲 𝖮))𝖲 (𝖲 (\plus 𝖮 (𝖲 𝖮)))𝖲 (𝖲 (𝖲 𝖮))
\plus (S (S O)) (S O)\triS (\plus (S O) (S O))\triS (S (\plus O (S O)))\triS (S (S O))
}
```

So, move the definitions into refman-preamble.sty.

Also, \tri is renamed to \trii to express
the suffix of "\triangleright_\iota".

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** documentation