### PR TITLE
[stdlib] Do not put INR_eq in the “real” hint database

### DIFF
--- a/test-suite/output/NoAxiomFromR.out
+++ b/test-suite/output/NoAxiomFromR.out
@@ -1,0 +1,1 @@
+Closed under the global context

--- a/test-suite/output/NoAxiomFromR.v
+++ b/test-suite/output/NoAxiomFromR.v
@@ -1,0 +1,10 @@
+Require Import Psatz.
+
+Inductive TT : Set :=
+| C : nat -> TT.
+
+Lemma lem4 : forall (n m : nat),
+S m <= m -> C (S m) <> C n -> False.
+Proof. firstorder. Qed.
+
+Print Assumptions lem4.

--- a/theories/Reals/RIneq.v
+++ b/theories/Reals/RIneq.v
@@ -1692,7 +1692,6 @@ Proof.
   exact H.
   now apply not_INR in H.
 Qed.
-Hint Resolve INR_eq: real.
 
 Lemma INR_le : forall n m:nat, INR n <= INR m -> (n <= m)%nat.
 Proof.


### PR DESCRIPTION
According to Laurent (@thery) on the [mailing list](https://sympa.inria.fr/sympa/arc/coq-club/2019-01/msg00127.html), the `INR_eq` “has wrongly been put in the hint resolve database of reals.”

- [x] Added / updated test-suite

The test case is the example given by Caitlin D’Abrera (@caitlindabrera).