### PR TITLE
Remove Keep objects

### DIFF
--- a/checker/check.ml
+++ b/checker/check.ml
@@ -271,7 +271,7 @@ type summary_disk = {
 module Dyn = Dyn.Make ()
 type obj = Dyn.t (* persistent dynamic objects *)
 type lib_objects = (Id.t * obj) list
-type library_objects = lib_objects * lib_objects
+type library_objects = lib_objects
 
 type library_disk = {
   md_compiled : Safe_typing.compiled_library;

--- a/checker/values.ml
+++ b/checker/values.ml
@@ -335,7 +335,7 @@ let v_compiled_lib =
 let v_obj = Dyn
 let v_libobj = Tuple ("libobj", [|v_id;v_obj|])
 let v_libobjs = List v_libobj
-let v_libraryobjs = Tuple ("library_objects",[|v_libobjs;v_libobjs|])
+let v_libraryobjs = v_libobjs
 
 (** STM objects *)
 

--- a/interp/implicit_quantifiers.ml
+++ b/interp/implicit_quantifiers.ml
@@ -57,7 +57,8 @@ let in_generalizable : bool * lident list option -> obj =
   declare_object {(default_object "GENERALIZED-IDENT") with
     load_function = load_generalizable_type;
     cache_function = cache_generalizable_type;
-    classify_function = (fun (local, _ as obj) -> if local then Dispose else Keep obj)
+    subst_function = Libobject.ident_subst_function;
+    classify_function = (fun (local, _ as obj) -> if local then Dispose else Substitute obj);
   }
 
 let declare_generalizable ~local gen =

--- a/library/keys.ml
+++ b/library/keys.ml
@@ -105,7 +105,7 @@ type key_obj = key * key
 let inKeys : key_obj -> obj =
   declare_object @@ superglobal_object "KEYS"
     ~cache:cache_keys
-    ~subst:(Some subst_keys)
+    ~subst:subst_keys
     ~discharge:discharge_keys
 
 let declare_equiv_keys ref ref' =

--- a/library/lib.ml
+++ b/library/lib.ml
@@ -64,24 +64,22 @@ let subst_objects subst seg =
     node :: seg) [] seg)
 *)
 let classify_segment seg =
-  let rec clean ((substl,keepl,anticipl) as acc) = function
+  let rec clean ((substl,anticipl) as acc) = function
     | (_,CompilingLibrary _) :: _ | [] -> acc
     | ((sp,kn),Leaf o) :: stk ->
 	let id = Names.Label.to_id (Names.KerName.label kn) in
 	  (match classify_object o with
 	     | Dispose -> clean acc stk
-	     | Keep o' ->
-		 clean (substl, (id,o')::keepl, anticipl) stk
 	     | Substitute o' ->
-		 clean ((id,o')::substl, keepl, anticipl) stk
+                 clean ((id,o')::substl, anticipl) stk
 	     | Anticipate o' ->
-		 clean (substl, keepl, o'::anticipl) stk)
+                 clean (substl, o'::anticipl) stk)
     | (_,OpenedSection _) :: _ -> user_err Pp.(str "there are still opened sections")
     | (_,OpenedModule (ty,_,_,_)) :: _ ->
       user_err ~hdr:"Lib.classify_segment"
         (str "there are still opened " ++ str (module_kind ty) ++ str "s")
   in
-    clean ([],[],[]) (List.rev seg)
+    clean ([],[]) (List.rev seg)
 
 
 let segment_of_objects prefix =

--- a/library/lib.mli
+++ b/library/lib.mli
@@ -44,7 +44,7 @@ val subst_objects : Mod_subst.substitution -> lib_objects -> lib_objects
    [Substitute], [Keep], [Anticipate] respectively.  The order of each
    returned list is the same as in the input list. *)
 val classify_segment :
-  library_segment -> lib_objects * lib_objects * Libobject.obj list
+  library_segment -> lib_objects * Libobject.obj list
 
 (** [segment_of_objects prefix objs] forms a list of Leafs *)
 val segment_of_objects :

--- a/library/libobject.ml
+++ b/library/libobject.ml
@@ -13,7 +13,7 @@ open Pp
 module Dyn = Dyn.Make ()
 
 type 'a substitutivity =
-    Dispose | Substitute of 'a | Keep of 'a | Anticipate of 'a
+    Dispose | Substitute of 'a | Anticipate of 'a
 
 type object_name = Libnames.full_path * Names.KerName.t
 
@@ -34,7 +34,7 @@ let default_object s = {
   open_function = (fun _ _ -> ());
   subst_function = (fun _ ->
     CErrors.anomaly (str "The object " ++ str s ++ str " does not know how to substitute!"));
-  classify_function = (fun obj -> Keep obj);
+  classify_function = (fun obj -> Dispose);
   discharge_function = (fun _ -> None);
   rebuild_function = (fun x -> x)}
 
@@ -78,7 +78,6 @@ let declare_object_full odecl =
   and classifier lobj = match odecl.classify_function (outfun lobj) with
   | Dispose -> Dispose
   | Substitute obj -> Substitute (infun obj)
-  | Keep obj -> Keep (infun obj)
   | Anticipate (obj) -> Anticipate (infun obj)
   and discharge (oname,lobj) =
     Option.map infun (odecl.discharge_function (oname,outfun lobj))
@@ -145,12 +144,8 @@ let global_object_nodischarge s ~cache ~subst =
   { (default_object s) with
     cache_function = cache;
     open_function = import;
-    subst_function = (match subst with
-        | None -> fun _ -> CErrors.anomaly (str "The object " ++ str s ++ str " does not know how to substitute!")
-        | Some subst -> subst;
-      );
-    classify_function =
-      if Option.has_some subst then (fun o -> Substitute o) else (fun o -> Keep o);
+    subst_function = subst;
+    classify_function = fun o -> Substitute o;
   }
 
 let global_object s ~cache ~subst ~discharge =
@@ -161,12 +156,8 @@ let superglobal_object_nodischarge s ~cache ~subst =
   { (default_object s) with
     load_function = (fun _ x -> cache x);
     cache_function = cache;
-    subst_function = (match subst with
-        | None -> fun _ -> CErrors.anomaly (str "The object " ++ str s ++ str " does not know how to substitute!")
-        | Some subst -> subst;
-      );
-    classify_function =
-      if Option.has_some subst then (fun o -> Substitute o) else (fun o -> Keep o);
+    subst_function = subst;
+    classify_function = fun o -> Substitute o;
   }
 
 let superglobal_object s ~cache ~subst ~discharge =

--- a/library/libobject.mli
+++ b/library/libobject.mli
@@ -34,8 +34,6 @@ open Mod_subst
      Dispose    - the object dies at the end of the module
      Substitute - meaning the object is substitutive and
                   the module name must be updated
-     Keep       - the object is not substitutive, but survives module
-                  closing
      Anticipate - this is for objects that have to be explicitly
                   managed by the [end_module] function (like Require
                   and Read markers)
@@ -64,7 +62,7 @@ open Mod_subst
 *)
 
 type 'a substitutivity =
-    Dispose | Substitute of 'a | Keep of 'a | Anticipate of 'a
+    Dispose | Substitute of 'a | Anticipate of 'a
 
 (** Both names are passed to objects: a "semantic" [kernel_name], which
    can be substituted and a "syntactic" [full_path] which can be printed
@@ -144,24 +142,24 @@ val local_object_nodischarge : string ->
 
 val global_object : string ->
   cache:(object_name * 'a -> unit) ->
-  subst:(Mod_subst.substitution * 'a -> 'a) option ->
+  subst:(Mod_subst.substitution * 'a -> 'a) ->
   discharge:(object_name * 'a -> 'a option) ->
   'a object_declaration
 
 val global_object_nodischarge : string ->
   cache:(object_name * 'a -> unit) ->
-  subst:(Mod_subst.substitution * 'a -> 'a) option ->
+  subst:(Mod_subst.substitution * 'a -> 'a) ->
   'a object_declaration
 
 val superglobal_object : string ->
   cache:(object_name * 'a -> unit) ->
-  subst:(Mod_subst.substitution * 'a -> 'a) option ->
+  subst:(Mod_subst.substitution * 'a -> 'a) ->
   discharge:(object_name * 'a -> 'a option) ->
   'a object_declaration
 
 val superglobal_object_nodischarge : string ->
   cache:(object_name * 'a -> unit) ->
-  subst:(Mod_subst.substitution * 'a -> 'a) option ->
+  subst:(Mod_subst.substitution * 'a -> 'a) ->
   'a object_declaration
 
 (** {6 Debug} *)

--- a/plugins/extraction/table.ml
+++ b/plugins/extraction/table.ml
@@ -623,7 +623,7 @@ let lang () = !lang_ref
 let extr_lang : lang -> obj =
   declare_object @@ superglobal_object_nodischarge "Extraction Lang"
     ~cache:(fun (_,l) -> lang_ref := l)
-    ~subst:None
+    ~subst:Libobject.ident_subst_function
 
 let extraction_language x = Lib.add_anonymous_leaf (extr_lang x)
 
@@ -649,7 +649,7 @@ let add_inline_entries b l =
 let inline_extraction : bool * GlobRef.t list -> obj =
   declare_object @@ superglobal_object "Extraction Inline"
     ~cache:(fun (_,(b,l)) -> add_inline_entries b l)
-    ~subst:(Some (fun (s,(b,l)) -> (b,(List.map (fun x -> fst (subst_global s x)) l))))
+    ~subst:(fun (s,(b,l)) -> (b,(List.map (fun x -> fst (subst_global s x)) l)))
     ~discharge:(fun (_,x) -> Some x)
 
 (* Grammar entries. *)
@@ -681,7 +681,7 @@ let print_extraction_inline () =
 let reset_inline : unit -> obj =
   declare_object @@ superglobal_object_nodischarge "Reset Extraction Inline"
     ~cache:(fun (_,_)-> inline_table :=  empty_inline_table)
-    ~subst:None
+    ~subst:(Libobject.ident_subst_function)
 
 let reset_extraction_inline () = Lib.add_anonymous_leaf (reset_inline ())
 
@@ -726,7 +726,7 @@ let add_implicits r l =
 let implicit_extraction : GlobRef.t * int_or_id list -> obj =
   declare_object @@ superglobal_object_nodischarge "Extraction Implicit"
     ~cache:(fun (_,(r,l)) -> add_implicits r l)
-    ~subst:(Some (fun (s,(r,l)) -> (fst (subst_global s r), l)))
+    ~subst:(fun (s,(r,l)) -> (fst (subst_global s r), l))
 
 (* Grammar entries. *)
 
@@ -775,7 +775,7 @@ let add_blacklist_entries l =
 let blacklist_extraction : string list -> obj =
   declare_object @@ superglobal_object_nodischarge "Extraction Blacklist"
     ~cache:(fun (_,l) -> add_blacklist_entries l)
-    ~subst:None
+    ~subst:Libobject.ident_subst_function
 
 (* Grammar entries. *)
 
@@ -793,7 +793,7 @@ let print_extraction_blacklist () =
 let reset_blacklist : unit -> obj =
   declare_object @@ superglobal_object_nodischarge "Reset Extraction Blacklist"
     ~cache:(fun (_,_)-> blacklist_table := Id.Set.empty)
-    ~subst:None
+    ~subst:Libobject.ident_subst_function
 
 let reset_extraction_blacklist () = Lib.add_anonymous_leaf (reset_blacklist ())
 
@@ -839,12 +839,12 @@ let find_custom_match pv =
 let in_customs : GlobRef.t * string list * string -> obj =
   declare_object @@ superglobal_object_nodischarge "ML extractions"
     ~cache:(fun (_,(r,ids,s)) -> add_custom r ids s)
-    ~subst:(Some (fun (s,(r,ids,str)) -> (fst (subst_global s r), ids, str)))
+    ~subst:(fun (s,(r,ids,str)) -> (fst (subst_global s r), ids, str))
 
 let in_custom_matchs : GlobRef.t * string -> obj =
   declare_object @@ superglobal_object_nodischarge "ML extractions custom matchs"
     ~cache:(fun (_,(r,s)) -> add_custom_match r s)
-    ~subst:(Some (fun (subs,(r,s)) -> (fst (subst_global subs r), s)))
+    ~subst:(fun (subs,(r,s)) -> (fst (subst_global subs r), s))
 
 (* Grammar entries. *)
 

--- a/plugins/funind/indfun_common.ml
+++ b/plugins/funind/indfun_common.ml
@@ -301,7 +301,7 @@ let in_Function : function_info -> Libobject.obj =
   let open Libobject in
   declare_object @@ superglobal_object "FUNCTIONS_DB"
     ~cache:cache_Function
-    ~subst:(Some subst_Function)
+    ~subst:subst_Function
     ~discharge:discharge_Function
 
 

--- a/plugins/ltac/extratactics.mlg
+++ b/plugins/ltac/extratactics.mlg
@@ -533,7 +533,7 @@ let subst_transitivity_lemma (subst,(b,ref)) = (b,subst_mps subst ref)
 let inTransitivity : bool * Constr.t -> obj =
   declare_object @@ global_object_nodischarge "TRANSITIVITY-STEPS"
     ~cache:cache_transitivity_lemma
-    ~subst:(Some subst_transitivity_lemma)
+    ~subst:subst_transitivity_lemma
 
 (* Main entry points *)
 

--- a/plugins/setoid_ring/newring.ml
+++ b/plugins/setoid_ring/newring.ml
@@ -396,7 +396,7 @@ let theory_to_obj : ring_info -> obj =
   let cache_th (name,th) = add_entry name th in
   declare_object @@ global_object_nodischarge "tactic-new-ring-theory"
     ~cache:cache_th
-    ~subst:(Some subst_th)
+    ~subst:subst_th
 
 let setoid_of_relation env evd a r =
   try
@@ -889,7 +889,7 @@ let ftheory_to_obj : field_info -> obj =
   let cache_th (name,th) = add_field_entry name th in
   declare_object @@ global_object_nodischarge "tactic-new-field-theory"
     ~cache:cache_th
-    ~subst:(Some subst_th)
+    ~subst:subst_th
 
 let field_equality evd r inv req =
   match EConstr.kind !evd req with

--- a/plugins/ssr/ssrview.ml
+++ b/plugins/ssr/ssrview.ml
@@ -49,7 +49,7 @@ module AdaptorDb = struct
     let open Libobject in
     declare_object @@ global_object_nodischarge "VIEW_ADAPTOR_DB"
       ~cache:cache_adaptor
-      ~subst:(Some subst_adaptor)
+      ~subst:subst_adaptor
 
   let declare kind terms =
     List.iter (fun term -> Lib.add_anonymous_leaf (in_db (kind,term)))

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -71,7 +71,7 @@ let subst_reduction_effect (subst,(con,funkey)) =
 let inReductionEffect : Constant.t * string -> obj =
   declare_object @@ global_object_nodischarge "REDUCTION-EFFECT"
     ~cache:cache_reduction_effect
-    ~subst:(Some subst_reduction_effect)
+    ~subst:subst_reduction_effect
 
 let declare_reduction_effect funkey f =
   if String.Map.mem funkey !effect_table then

--- a/tactics/autorewrite.ml
+++ b/tactics/autorewrite.ml
@@ -201,7 +201,7 @@ let inHintRewrite : string * HintDN.t -> Libobject.obj =
   let open Libobject in
   declare_object @@ superglobal_object_nodischarge "HINT_REWRITE"
     ~cache:cache_hintrewrite
-    ~subst:(Some subst_hintrewrite)
+    ~subst:subst_hintrewrite
 
 open Clenv
 

--- a/tactics/ind_tables.ml
+++ b/tactics/ind_tables.ml
@@ -61,7 +61,7 @@ let discharge_scheme (_,(kind,l)) =
 let inScheme : string * (inductive * Constant.t) array -> obj =
   declare_object @@ superglobal_object "SCHEME"
     ~cache:cache_scheme
-    ~subst:(Some subst_scheme)
+    ~subst:subst_scheme
     ~discharge:discharge_scheme
 
 (**********************************************************************)

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -35,7 +35,7 @@ let cache_token (_,s) = CLexer.add_keyword s
 let inToken : string -> obj =
   declare_object @@ global_object_nodischarge "TOKEN"
     ~cache:cache_token
-    ~subst:(Some Libobject.ident_subst_function)
+    ~subst:Libobject.ident_subst_function
 
 let add_token_obj s = Lib.add_anonymous_leaf (inToken s)
 


### PR DESCRIPTION
This is a step towards simplifying the libobject API.

I'm not sure to grasp 100% of the subtleties of Keep vs Substitute, but for the part
I understand, this change should be ok. Let's rely on testing.