### PR TITLE
Move non-primitive-record warning to declare_mutual_inductive_with_eliminations

### DIFF
--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -270,12 +270,6 @@ let instantiate_possibly_recursive_type ind u ntypes paramdecls fields =
   let subst' = List.init ntypes (fun i -> mkIndU ((ind, ntypes - i - 1), u)) in
   Termops.substl_rel_context (subst @ subst') fields
 
-let warn_non_primitive_record =
-  CWarnings.create ~name:"non-primitive-record" ~category:"record"
-         (fun (env,indsp) ->
-          (hov 0 (str "The record " ++ Printer.pr_inductive env indsp ++ 
-                    strbrk" could not be defined as a primitive record")))
-
 (* We build projections *)
 let declare_projections indsp ctx ?(kind=StructureComponent) binder_name coers fieldimpls fields =
   let env = Global.env() in
@@ -293,16 +287,9 @@ let declare_projections indsp ctx ?(kind=StructureComponent) binder_name coers f
   let fields = instantiate_possibly_recursive_type (fst indsp) u mib.mind_ntypes paramdecls fields in
   let lifted_fields = Termops.lift_rel_context 1 fields in
   let primitive = 
-    if !primitive_flag then 
-      let is_primitive = 
-	match mib.mind_record with
-        | PrimRecord _ -> true
-        | FakeRecord | NotRecord -> false
-      in
-	if not is_primitive then 
-	  warn_non_primitive_record (env,indsp);
-	is_primitive
-    else false
+    match mib.mind_record with
+    | PrimRecord _ -> true
+    | FakeRecord | NotRecord -> false
   in
   let (_,_,kinds,sp_projs,_) =
     List.fold_left3


### PR DESCRIPTION
This makes it print the warning before the definition message, so if
we run with +non-primitive-record we don't see
"""
defined foo
error could not define foo
"""
