### PR TITLE
Simplify the GitHub issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,18 +1,11 @@
-<!-- Thank you for your contribution.
-     Please complete the following information when reporting a bug. -->
-
-#### Version
-
-<!-- You can get this information by running `coqtop -v`. -->
-
-
-#### Operating system
-
+<!-- Thank you for reporting a bug to Coq! -->
 
 #### Description of the problem
 
-<!-- It is helpful to provide enough information so that we can reproduce the bug.
-     In particular, please include a code example which produces it.
-     If the example is small, you can include it here between ``` ```.
-     Otherwise, please provide a link to a repository, a gist (https://gist.github.com)
-     or drag-and-drop a `.zip` archive. -->
+<!-- If you can, it's helpful to provide self-contained example of some code
+that reproduces the bug. If not, a link to a larger example is also helpful. -->
+
+#### Coq Version
+
+<!-- You can get this information by running `coqtop -v`. If relevant, please
+also include your operating system. -->


### PR DESCRIPTION
Reduce the descriptions to some minimal advice, and in particular put
the description first since it's likely to be the first thing reporters
should worry about.

Remove the operating system section since it doesn't deserve an entire
section and is rarely relevant - the people reporting OS-specific bugs
(eg, Windows users) are likely to report their operating system.

This should also make bug reports easier to parse when reading them.

I know this change might be controversial but I find the current template burdensome, think it focuses on the wrong information (metadata as opposed to the actual issue and expected behaviors), and would like to see it change.