### PR TITLE
BinInt: 3 lemmas about testbit, mod _ 2^, ones

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -175,6 +175,8 @@ Standard Library
 
 - The `Coq.Numbers.Cyclic.Int31` library is deprecated.
 
+- Added lemmas about `Z.testbit`, `Z.ones`, and `Z.modulo`.
+
 Universes
 
 - Added `Print Universes Subgraph` variant of `Print Universes`.

--- a/theories/ZArith/BinInt.v
+++ b/theories/ZArith/BinInt.v
@@ -1259,6 +1259,30 @@ Proof.
  f_equal. now rewrite <- add_assoc, add_opp_diag_r, add_0_r.
 Qed.
 
+(** * [testbit] in terms of comparision. *)
+
+Lemma testbit_mod_pow2 a n i (H : 0 <= n)
+  : testbit (a mod 2 ^ n) i = ((i <? n) && testbit a i)%bool.
+Proof.
+  destruct (ltb_spec i n); rewrite
+    ?mod_pow2_bits_low, ?mod_pow2_bits_high by auto; auto.
+Qed.
+
+Lemma testbit_ones n i (H : 0 <= n)
+  : testbit (ones n) i = ((0 <=? i) && (i <? n))%bool.
+Proof.
+  destruct (leb_spec 0 i), (ltb_spec i n); cbn;
+    rewrite ?testbit_neg_r, ?ones_spec_low, ?ones_spec_high by auto; trivial.
+Qed.
+
+Lemma testbit_ones_nonneg n i (Hn : 0 <= n) (Hi: 0 <= i)
+  : testbit (ones n) i = (i <? n).
+Proof.
+  rewrite testbit_ones by auto.
+  destruct (leb_spec 0 i); cbn; solve
+   [ trivial | destruct (proj1 (Z.le_ngt _ _) Hi ltac:(eassumption)) ].
+Qed.
+
 End Z.
 
 Bind Scope Z_scope with Z.t Z.


### PR DESCRIPTION
**Kind:** feature
- [x] Entry added in CHANGES.md. 

Here are three lemmas about `Z.testbit` that I have needed to copy-paste into multiple projects. For example, they appear [here in Word/Properties.v](https://github.com/mit-plv/coqutil/blob/master/src/Word/Properties.v#L8). I am proposing placing them into `BinInt.v` right after the dependencies become available.

The lemma statements are as follows:

```coq
Z.testbit_mod_pow2 : forall a n i : Z, 0 <= n -> Z.testbit (a mod 2 ^ n) i = ((i <? n) && Z.testbit a i)%bool
Z.testbit_ones : forall n i : Z, 0 <= n -> Z.testbit (Z.ones n) i = ((0 <=? i) && (i <? n))%bool
Z.testbit_ones_nonneg : forall n i : Z, 0 <= n -> 0 <= i -> Z.testbit (Z.ones n) i = (i <? n)
```