### PR TITLE
Search: iter through the environment, not libobject

### DIFF
--- a/kernel/environ.mli
+++ b/kernel/environ.mli
@@ -46,8 +46,12 @@ type constant_key = constant_body * (link_info ref * key)
 
 type mind_key = mutual_inductive_body * link_info ref
 
-type globals
-(** globals = constants + projections + inductive types + modules + module-types *)
+type globals = {
+  env_constants : constant_key Cmap_env.t;
+  env_inductives : mind_key Mindmap_env.t;
+  env_modules : module_body MPmap.t;
+  env_modtypes : module_type_body MPmap.t;
+}
 
 type stratification = {
   env_universes : UGraph.t;

--- a/library/declaremods.ml
+++ b/library/declaremods.ml
@@ -969,28 +969,6 @@ let in_import : bool * ModPath.t -> obj =
 let import_module export mp =
   Lib.add_anonymous_leaf (in_import (export,mp))
 
-
-(** {6 Iterators} *)
-
-let iter_all_segments f =
-  let rec apply_obj prefix (id,obj) = match object_tag obj with
-    | "INCLUDE" ->
-      let objs = expand_aobjs (out_include obj) in
-      List.iter (apply_obj prefix) objs
-    | _ -> f (Lib.make_oname prefix id) obj
-  in
-  let apply_mod_obj _ (prefix,substobjs,keepobjs) =
-    List.iter (apply_obj prefix) substobjs;
-    List.iter (apply_obj prefix) keepobjs
-  in
-  let apply_node = function
-    | sp, Lib.Leaf o -> f sp o
-    | _ -> ()
-  in
-  MPmap.iter apply_mod_obj (ModObjs.all ());
-  List.iter apply_node (Lib.contents ())
-
-
 (** {6 Some types used to shorten declaremods.mli} *)
 
 type 'modast module_interpretor =

--- a/library/declaremods.mli
+++ b/library/declaremods.mli
@@ -124,14 +124,6 @@ val declare_include :
   'modast module_interpretor -> ('modast * inline) list -> unit
 
 (** {6 ... } *)
-(** [iter_all_segments] iterate over all segments, the modules'
-    segments first and then the current segment. Modules are presented
-    in an arbitrary order. The given function is applied to all leaves
-    (together with their section path). *)
-
-val iter_all_segments :
-  (Libobject.object_name -> Libobject.obj -> unit) -> unit
-
 
 val debug_print_modtab : unit -> Pp.t
 

--- a/test-suite/output/Search.out
+++ b/test-suite/output/Search.out
@@ -5,9 +5,9 @@ le_n_S: forall n m : nat, n <= m -> S n <= S m
 le_pred: forall n m : nat, n <= m -> Nat.pred n <= Nat.pred m
 le_S_n: forall n m : nat, S n <= S m -> n <= m
 min_l: forall n m : nat, n <= m -> Nat.min n m = n
-max_r: forall n m : nat, n <= m -> Nat.max n m = m
-min_r: forall n m : nat, m <= n -> Nat.min n m = m
 max_l: forall n m : nat, m <= n -> Nat.max n m = n
+min_r: forall n m : nat, m <= n -> Nat.min n m = m
+max_r: forall n m : nat, n <= m -> Nat.max n m = m
 le_ind:
   forall (n : nat) (P : nat -> Prop),
   P n ->
@@ -15,45 +15,45 @@ le_ind:
   forall n0 : nat, n <= n0 -> P n0
 false: bool
 true: bool
-is_true: bool -> Prop
-negb: bool -> bool
 eq_true: bool -> Prop
-implb: bool -> bool -> bool
+negb: bool -> bool
+is_true: bool -> Prop
+xorb: bool -> bool -> bool
 orb: bool -> bool -> bool
 andb: bool -> bool -> bool
-xorb: bool -> bool -> bool
+implb: bool -> bool -> bool
 Nat.even: nat -> bool
 Nat.odd: nat -> bool
 BoolSpec: Prop -> Prop -> bool -> Prop
-Nat.eqb: nat -> nat -> bool
 Nat.testbit: nat -> nat -> bool
 Nat.ltb: nat -> nat -> bool
 Nat.leb: nat -> nat -> bool
+Nat.eqb: nat -> nat -> bool
 Nat.bitwise: (bool -> bool -> bool) -> nat -> nat -> nat -> nat
+eq_true_ind_r:
+  forall (P : bool -> Prop) (b : bool), P b -> eq_true b -> P true
 bool_ind: forall P : bool -> Prop, P true -> P false -> forall b : bool, P b
-bool_rec: forall P : bool -> Set, P true -> P false -> forall b : bool, P b
-eq_true_rec:
-  forall P : bool -> Set, P true -> forall b : bool, eq_true b -> P b
-bool_rect: forall P : bool -> Type, P true -> P false -> forall b : bool, P b
 eq_true_rect_r:
   forall (P : bool -> Type) (b : bool), P b -> eq_true b -> P true
 eq_true_rec_r:
   forall (P : bool -> Set) (b : bool), P b -> eq_true b -> P true
 eq_true_rect:
   forall P : bool -> Type, P true -> forall b : bool, eq_true b -> P b
+bool_rect: forall P : bool -> Type, P true -> P false -> forall b : bool, P b
+bool_rec: forall P : bool -> Set, P true -> P false -> forall b : bool, P b
 eq_true_ind:
   forall P : bool -> Prop, P true -> forall b : bool, eq_true b -> P b
-eq_true_ind_r:
-  forall (P : bool -> Prop) (b : bool), P b -> eq_true b -> P true
+eq_true_rec:
+  forall P : bool -> Set, P true -> forall b : bool, eq_true b -> P b
 Byte.to_bits:
   Byte.byte ->
   bool * (bool * (bool * (bool * (bool * (bool * (bool * bool))))))
 Byte.of_bits:
   bool * (bool * (bool * (bool * (bool * (bool * (bool * bool)))))) ->
   Byte.byte
+andb_prop: forall a b : bool, (a && b)%bool = true -> a = true /\ b = true
 andb_true_intro:
   forall b1 b2 : bool, b1 = true /\ b2 = true -> (b1 && b2)%bool = true
-andb_prop: forall a b : bool, (a && b)%bool = true -> a = true /\ b = true
 BoolSpec_ind:
   forall (P Q : Prop) (P0 : bool -> Prop),
   (P -> P0 true) ->
@@ -66,15 +66,15 @@ bool_choice:
   forall (S : Set) (R1 R2 : S -> Prop),
   (forall x : S, {R1 x} + {R2 x}) ->
   {f : S -> bool | forall x : S, f x = true /\ R1 x \/ f x = false /\ R2 x}
-mult_n_O: forall n : nat, 0 = n * 0
-plus_O_n: forall n : nat, 0 + n = n
 plus_n_O: forall n : nat, n = n + 0
-n_Sn: forall n : nat, n <> S n
+plus_O_n: forall n : nat, 0 + n = n
+mult_n_O: forall n : nat, 0 = n * 0
 pred_Sn: forall n : nat, n = Nat.pred (S n)
+n_Sn: forall n : nat, n <> S n
 O_S: forall n : nat, 0 <> S n
-f_equal_pred: forall x y : nat, x = y -> Nat.pred x = Nat.pred y
-eq_S: forall x y : nat, x = y -> S x = S y
 eq_add_S: forall n m : nat, S n = S m -> n = m
+eq_S: forall x y : nat, x = y -> S x = S y
+f_equal_pred: forall x y : nat, x = y -> Nat.pred x = Nat.pred y
 min_r: forall n m : nat, m <= n -> Nat.min n m = m
 min_l: forall n m : nat, n <= m -> Nat.min n m = n
 max_r: forall n m : nat, n <= m -> Nat.max n m = m
@@ -84,10 +84,10 @@ plus_n_Sm: forall n m : nat, S (n + m) = n + S m
 f_equal_nat: forall (B : Type) (f : nat -> B) (x y : nat), x = y -> f x = f y
 not_eq_S: forall n m : nat, n <> m -> S n <> S m
 mult_n_Sm: forall n m : nat, n * m + n = n * S m
-f_equal2_plus:
-  forall x1 y1 x2 y2 : nat, x1 = y1 -> x2 = y2 -> x1 + x2 = y1 + y2
 f_equal2_mult:
   forall x1 y1 x2 y2 : nat, x1 = y1 -> x2 = y2 -> x1 * x2 = y1 * y2
+f_equal2_plus:
+  forall x1 y1 x2 y2 : nat, x1 = y1 -> x2 = y2 -> x1 + x2 = y1 + y2
 f_equal2_nat:
   forall (B : Type) (f : nat -> nat -> B) (x1 y1 x2 y2 : nat),
   x1 = y1 -> x2 = y2 -> f x1 x2 = f y1 y2

--- a/test-suite/output/SearchHead.out
+++ b/test-suite/output/SearchHead.out
@@ -2,38 +2,38 @@ le_n: forall n : nat, n <= n
 le_0_n: forall n : nat, 0 <= n
 le_S: forall n m : nat, n <= m -> n <= S m
 le_pred: forall n m : nat, n <= m -> Nat.pred n <= Nat.pred m
-le_n_S: forall n m : nat, n <= m -> S n <= S m
 le_S_n: forall n m : nat, S n <= S m -> n <= m
+le_n_S: forall n m : nat, n <= m -> S n <= S m
 false: bool
 true: bool
 negb: bool -> bool
-implb: bool -> bool -> bool
-orb: bool -> bool -> bool
-andb: bool -> bool -> bool
 xorb: bool -> bool -> bool
+implb: bool -> bool -> bool
+andb: bool -> bool -> bool
+orb: bool -> bool -> bool
 Nat.even: nat -> bool
 Nat.odd: nat -> bool
-Nat.leb: nat -> nat -> bool
 Nat.ltb: nat -> nat -> bool
-Nat.testbit: nat -> nat -> bool
+Nat.leb: nat -> nat -> bool
 Nat.eqb: nat -> nat -> bool
-mult_n_O: forall n : nat, 0 = n * 0
-plus_O_n: forall n : nat, 0 + n = n
+Nat.testbit: nat -> nat -> bool
 plus_n_O: forall n : nat, n = n + 0
+plus_O_n: forall n : nat, 0 + n = n
+mult_n_O: forall n : nat, 0 = n * 0
 pred_Sn: forall n : nat, n = Nat.pred (S n)
-f_equal_pred: forall x y : nat, x = y -> Nat.pred x = Nat.pred y
 eq_add_S: forall n m : nat, S n = S m -> n = m
 eq_S: forall x y : nat, x = y -> S x = S y
-max_r: forall n m : nat, n <= m -> Nat.max n m = m
+f_equal_pred: forall x y : nat, x = y -> Nat.pred x = Nat.pred y
 max_l: forall n m : nat, m <= n -> Nat.max n m = n
 min_r: forall n m : nat, m <= n -> Nat.min n m = m
+max_r: forall n m : nat, n <= m -> Nat.max n m = m
 min_l: forall n m : nat, n <= m -> Nat.min n m = n
-plus_n_Sm: forall n m : nat, S (n + m) = n + S m
 plus_Sn_m: forall n m : nat, S n + m = S (n + m)
+plus_n_Sm: forall n m : nat, S (n + m) = n + S m
 mult_n_Sm: forall n m : nat, n * m + n = n * S m
-f_equal2_plus:
-  forall x1 y1 x2 y2 : nat, x1 = y1 -> x2 = y2 -> x1 + x2 = y1 + y2
 f_equal2_mult:
   forall x1 y1 x2 y2 : nat, x1 = y1 -> x2 = y2 -> x1 * x2 = y1 * y2
+f_equal2_plus:
+  forall x1 y1 x2 y2 : nat, x1 = y1 -> x2 = y2 -> x1 + x2 = y1 + y2
 h: newdef n
 h: P n

--- a/test-suite/output/SearchPattern.out
+++ b/test-suite/output/SearchPattern.out
@@ -1,73 +1,73 @@
 false: bool
 true: bool
 negb: bool -> bool
-implb: bool -> bool -> bool
-orb: bool -> bool -> bool
-andb: bool -> bool -> bool
 xorb: bool -> bool -> bool
+implb: bool -> bool -> bool
+andb: bool -> bool -> bool
+orb: bool -> bool -> bool
 Nat.even: nat -> bool
 Nat.odd: nat -> bool
-Nat.leb: nat -> nat -> bool
 Nat.ltb: nat -> nat -> bool
-Nat.testbit: nat -> nat -> bool
+Nat.leb: nat -> nat -> bool
 Nat.eqb: nat -> nat -> bool
-Nat.two: nat
-Nat.one: nat
+Nat.testbit: nat -> nat -> bool
 Nat.zero: nat
 O: nat
-Nat.div2: nat -> nat
-Nat.log2: nat -> nat
-Nat.succ: nat -> nat
-Nat.sqrt: nat -> nat
-Nat.pred: nat -> nat
+Nat.two: nat
+Nat.one: nat
 Nat.double: nat -> nat
+Nat.pred: nat -> nat
+Nat.sqrt: nat -> nat
+Nat.div2: nat -> nat
 Nat.square: nat -> nat
+Nat.succ: nat -> nat
 S: nat -> nat
-Nat.ldiff: nat -> nat -> nat
+Nat.log2: nat -> nat
 Nat.tail_add: nat -> nat -> nat
-Nat.land: nat -> nat -> nat
 Nat.tail_mul: nat -> nat -> nat
-Nat.div: nat -> nat -> nat
+Nat.land: nat -> nat -> nat
 Nat.lor: nat -> nat -> nat
-Nat.gcd: nat -> nat -> nat
-Nat.modulo: nat -> nat -> nat
-Nat.max: nat -> nat -> nat
+Nat.lxor: nat -> nat -> nat
 Nat.sub: nat -> nat -> nat
 Nat.mul: nat -> nat -> nat
-Nat.lxor: nat -> nat -> nat
-Nat.add: nat -> nat -> nat
-Nat.min: nat -> nat -> nat
+Nat.ldiff: nat -> nat -> nat
+Nat.max: nat -> nat -> nat
+Nat.modulo: nat -> nat -> nat
+Nat.gcd: nat -> nat -> nat
+Nat.div: nat -> nat -> nat
 Nat.pow: nat -> nat -> nat
+Nat.min: nat -> nat -> nat
+Nat.add: nat -> nat -> nat
 Nat.of_uint: Decimal.uint -> nat
 Nat.tail_addmul: nat -> nat -> nat -> nat
 Nat.of_uint_acc: Decimal.uint -> nat -> nat
-Nat.log2_iter: nat -> nat -> nat -> nat -> nat
 Nat.sqrt_iter: nat -> nat -> nat -> nat -> nat
+Nat.log2_iter: nat -> nat -> nat -> nat -> nat
 length: forall A : Type, list A -> nat
 Nat.bitwise: (bool -> bool -> bool) -> nat -> nat -> nat -> nat
-Nat.div2: nat -> nat
-Nat.sqrt: nat -> nat
-Nat.log2: nat -> nat
-Nat.double: nat -> nat
-Nat.pred: nat -> nat
 Nat.square: nat -> nat
+Nat.double: nat -> nat
+Nat.sqrt: nat -> nat
 Nat.succ: nat -> nat
+Nat.div2: nat -> nat
+Nat.pred: nat -> nat
+Nat.log2: nat -> nat
 S: nat -> nat
-Nat.ldiff: nat -> nat -> nat
-Nat.pow: nat -> nat -> nat
-Nat.land: nat -> nat -> nat
-Nat.lxor: nat -> nat -> nat
-Nat.div: nat -> nat -> nat
-Nat.lor: nat -> nat -> nat
-Nat.tail_mul: nat -> nat -> nat
-Nat.modulo: nat -> nat -> nat
-Nat.sub: nat -> nat -> nat
 Nat.mul: nat -> nat -> nat
-Nat.gcd: nat -> nat -> nat
-Nat.max: nat -> nat -> nat
+Nat.lxor: nat -> nat -> nat
+Nat.pow: nat -> nat -> nat
+Nat.tail_mul: nat -> nat -> nat
 Nat.tail_add: nat -> nat -> nat
-Nat.add: nat -> nat -> nat
+Nat.land: nat -> nat -> nat
 Nat.min: nat -> nat -> nat
+Nat.max: nat -> nat -> nat
+Nat.lor: nat -> nat -> nat
+Nat.gcd: nat -> nat -> nat
+Nat.div: nat -> nat -> nat
+Nat.sub: nat -> nat -> nat
+Nat.modulo: nat -> nat -> nat
+Nat.ldiff: nat -> nat -> nat
+Nat.add: nat -> nat -> nat
 Nat.tail_addmul: nat -> nat -> nat -> nat
 Nat.of_uint_acc: Decimal.uint -> nat -> nat
 Nat.log2_iter: nat -> nat -> nat -> nat -> nat
@@ -75,8 +75,8 @@ Nat.sqrt_iter: nat -> nat -> nat -> nat -> nat
 Nat.bitwise: (bool -> bool -> bool) -> nat -> nat -> nat -> nat
 mult_n_Sm: forall n m : nat, n * m + n = n * S m
 iff_refl: forall A : Prop, A <-> A
-le_n: forall n : nat, n <= n
 identity_refl: forall (A : Type) (a : A), identity a a
+le_n: forall n : nat, n <= n
 eq_refl: forall (A : Type) (x : A), x = x
 Nat.divmod: nat -> nat -> nat -> nat -> nat * nat
 conj: forall A B : Prop, A -> B -> A /\ B


### PR DESCRIPTION
The order of stuff produced by Search is changed, this is OK.