### PR TITLE
Universe Polymorphism with Prop (WIP)

### DIFF
--- a/dev/base_include
+++ b/dev/base_include
@@ -185,7 +185,7 @@ let qid = Libnames.qualid_of_string;;
 
 let parse_constr = Pcoq.parse_string Pcoq.Constr.constr;;
 let parse_vernac = Pcoq.parse_string Pvernac.Vernac_.vernac_control;;
-let parse_tac    = Pcoq.parse_string Ltac_plugin.Pltac.tactic;;
+(*let parse_tac    = Pcoq.parse_string Ltac_plugin.Pltac.tactic;;*)
 
 (* build a term of type glob_constr without type-checking or resolution of 
    implicit syntax *)

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -674,7 +674,7 @@ let empty = {
 }
 
 let from_env e = 
-  { empty with universes = UState.make (Environ.universes e) }
+  { empty with universes = UState.make ~lbound:(Environ.universes_lbound e) (Environ.universes e) }
 
 let from_ctx ctx = { empty with universes = ctx }
 

--- a/engine/uState.ml
+++ b/engine/uState.ml
@@ -33,6 +33,7 @@ type t =
    (** The subset of unification variables that can be instantiated with
         algebraic universes as they appear in inferred types only. *)
    uctx_universes : UGraph.t; (** The current graph extended with the local constraints *)
+   uctx_universes_lbound : Univ.Level.t; (** The lower bound on universes (e.g. Set or Prop) *)
    uctx_initial_universes : UGraph.t; (** The graph at the creation of the evar_map *)
    uctx_weak_constraints : UPairSet.t
  }
@@ -44,12 +45,15 @@ let empty =
     uctx_univ_variables = Univ.LMap.empty;
     uctx_univ_algebraic = Univ.LSet.empty;
     uctx_universes = UGraph.initial_universes;
+    uctx_universes_lbound = Univ.Level.prop;
     uctx_initial_universes = UGraph.initial_universes;
     uctx_weak_constraints = UPairSet.empty; }
 
-let make u =
+let make ~lbound u =
     { empty with 
-      uctx_universes = u; uctx_initial_universes = u}
+      uctx_universes = u;
+      uctx_universes_lbound = lbound;
+      uctx_initial_universes = u}
 
 let is_empty ctx =
   Univ.ContextSet.is_empty ctx.uctx_local && 
@@ -75,7 +79,7 @@ let union ctx ctx' =
     let newus = Univ.LSet.diff newus (Univ.LMap.domain ctx.uctx_univ_variables) in
     let weak = UPairSet.union ctx.uctx_weak_constraints ctx'.uctx_weak_constraints in
     let declarenew g =
-      Univ.LSet.fold (fun u g -> UGraph.add_universe u false g) newus g
+      Univ.LSet.fold (fun u g -> UGraph.add_universe ~lbound:ctx.uctx_universes_lbound ~strict:false u g) newus g
     in
     let names_rev = Univ.LMap.union (snd ctx.uctx_names) (snd ctx'.uctx_names) in
       { uctx_names = (names, names_rev);
@@ -91,6 +95,7 @@ let union ctx ctx' =
            else
              let cstrsr = Univ.ContextSet.constraints ctx'.uctx_local in
              UGraph.merge_constraints cstrsr (declarenew ctx.uctx_universes));
+        uctx_universes_lbound = ctx.uctx_universes_lbound;
         uctx_weak_constraints = weak}
 
 let context_set ctx = ctx.uctx_local
@@ -444,7 +449,8 @@ let restrict_universe_context (univs, csts) keep =
   else
   let allunivs = Constraint.fold (fun (u,_,v) all -> LSet.add u (LSet.add v all)) csts univs in
   let g = UGraph.initial_universes in
-  let g = LSet.fold (fun v g -> if Level.is_small v then g else UGraph.add_universe v false g) allunivs g in
+  let g = LSet.fold (fun v g -> if Level.is_small v then g else
+                        UGraph.add_universe v ~lbound:Univ.Level.set ~strict:false g) allunivs g in
   let g = UGraph.merge_constraints csts g in
   let allkept = LSet.union (UGraph.domain UGraph.initial_universes) (LSet.diff allunivs removed) in
   let csts = UGraph.constraints_for ~kept:allkept g in
@@ -505,7 +511,7 @@ let merge ?loc ~sideff ~extend rigid uctx ctx' =
     else ContextSet.append ctx' uctx.uctx_local in
   let declare g =
     LSet.fold (fun u g ->
-               try UGraph.add_universe u false g
+               try UGraph.add_universe ~lbound:uctx.uctx_universes_lbound ~strict:false u g
                with UGraph.AlreadyDeclared when sideff -> g)
               levels g
   in
@@ -552,16 +558,17 @@ let new_univ_variable ?loc rigid name
     | None -> add_uctx_loc u loc uctx.uctx_names
   in
   let initial =
-    UGraph.add_universe u false uctx.uctx_initial_universes
+    UGraph.add_universe ~lbound:uctx.uctx_universes_lbound ~strict:false u uctx.uctx_initial_universes
   in                                                 
   let uctx' =
     {uctx' with uctx_names = names; uctx_local = ctx';
-                uctx_universes = UGraph.add_universe u false uctx.uctx_universes;
+                uctx_universes = UGraph.add_universe ~lbound:uctx.uctx_universes_lbound ~strict:false
+                    u uctx.uctx_universes;
                 uctx_initial_universes = initial}
   in uctx', u
 
-let make_with_initial_binders e us =
-  let uctx = make e in
+let make_with_initial_binders ~lbound e us =
+  let uctx = make ~lbound e in
   List.fold_left
     (fun uctx { CAst.loc; v = id } ->
        fst (new_univ_variable ?loc univ_rigid (Some id) uctx))
@@ -569,10 +576,10 @@ let make_with_initial_binders e us =
 
 let add_global_univ uctx u =
   let initial =
-    UGraph.add_universe u true uctx.uctx_initial_universes
+    UGraph.add_universe ~lbound:Univ.Level.set ~strict:true u uctx.uctx_initial_universes
   in
   let univs = 
-    UGraph.add_universe u true uctx.uctx_universes
+    UGraph.add_universe ~lbound:Univ.Level.set ~strict:true u uctx.uctx_universes
   in
   { uctx with uctx_local = Univ.ContextSet.add_universe u uctx.uctx_local;
                                      uctx_initial_universes = initial;
@@ -689,7 +696,8 @@ let refresh_undefined_univ_variables uctx =
       uctx.uctx_univ_variables Univ.LMap.empty
   in
   let weak = UPairSet.fold (fun (u,v) acc -> UPairSet.add (subst_fn u, subst_fn v) acc) uctx.uctx_weak_constraints UPairSet.empty in
-  let declare g = Univ.LSet.fold (fun u g -> UGraph.add_universe u false g)
+  let lbound = uctx.uctx_universes_lbound in
+  let declare g = Univ.LSet.fold (fun u g -> UGraph.add_universe ~lbound ~strict:false u g)
                                    (Univ.ContextSet.levels ctx') g in
   let initial = declare uctx.uctx_initial_universes in
   let univs = declare UGraph.initial_universes in
@@ -698,14 +706,16 @@ let refresh_undefined_univ_variables uctx =
                uctx_seff_univs = uctx.uctx_seff_univs;
                uctx_univ_variables = vars; uctx_univ_algebraic = alg;
                uctx_universes = univs;
+               uctx_universes_lbound = lbound;
                uctx_initial_universes = initial;
                uctx_weak_constraints = weak; } in
     uctx', subst
 
 let minimize uctx =
   let open UnivMinim in
+  let lbound = uctx.uctx_universes_lbound in
   let ((vars',algs'), us') =
-    normalize_context_set uctx.uctx_universes uctx.uctx_local uctx.uctx_univ_variables
+    normalize_context_set ~lbound uctx.uctx_universes uctx.uctx_local uctx.uctx_univ_variables
       uctx.uctx_univ_algebraic uctx.uctx_weak_constraints
   in
   if Univ.ContextSet.equal us' uctx.uctx_local then uctx
@@ -719,6 +729,7 @@ let minimize uctx =
         uctx_univ_variables = vars'; 
         uctx_univ_algebraic = algs';
         uctx_universes = universes;
+        uctx_universes_lbound = lbound;
         uctx_initial_universes = uctx.uctx_initial_universes;
         uctx_weak_constraints = UPairSet.empty; (* weak constraints are consumed *) }
 

--- a/engine/uState.ml
+++ b/engine/uState.ml
@@ -442,7 +442,7 @@ let check_univ_decl ~poly uctx decl =
       (Univ.ContextSet.constraints uctx.uctx_local);
   ctx
 
-let restrict_universe_context (univs, csts) keep =
+let restrict_universe_context lbound (univs, csts) keep =
   let open Univ in
   let removed = LSet.diff univs keep in
   if LSet.is_empty removed then univs, csts
@@ -450,12 +450,12 @@ let restrict_universe_context (univs, csts) keep =
   let allunivs = Constraint.fold (fun (u,_,v) all -> LSet.add u (LSet.add v all)) csts univs in
   let g = UGraph.initial_universes in
   let g = LSet.fold (fun v g -> if Level.is_small v then g else
-                        UGraph.add_universe v ~lbound:Univ.Level.set ~strict:false g) allunivs g in
+                        UGraph.add_universe v ~lbound ~strict:false g) allunivs g in
   let g = UGraph.merge_constraints csts g in
   let allkept = LSet.union (UGraph.domain UGraph.initial_universes) (LSet.diff allunivs removed) in
   let csts = UGraph.constraints_for ~kept:allkept g in
   let csts = Constraint.filter (fun (l,d,r) ->
-      not ((Level.is_set l && d == Le) || (Level.is_prop l && d == Lt && Level.is_set r))) csts in
+      not ((Level.equal l lbound && d == Le) || (Level.is_prop l && d == Lt && Level.is_set r))) csts in
   (LSet.inter univs keep, csts)
 
 let restrict ctx vars =
@@ -463,7 +463,7 @@ let restrict ctx vars =
   let vars = Names.Id.Map.fold (fun na l vars -> Univ.LSet.add l vars)
       (fst ctx.uctx_names) vars
   in
-  let uctx' = restrict_universe_context ctx.uctx_local vars in
+  let uctx' = restrict_universe_context ctx.uctx_universes_lbound ctx.uctx_local vars in
   { ctx with uctx_local = uctx' }
 
 let demote_seff_univs entry uctx =

--- a/engine/uState.mli
+++ b/engine/uState.mli
@@ -25,9 +25,9 @@ type t
 
 val empty : t
 
-val make : UGraph.t -> t
+val make : lbound:Univ.Level.t -> UGraph.t -> t
 
-val make_with_initial_binders : UGraph.t -> lident list -> t
+val make_with_initial_binders : lbound:Univ.Level.t -> UGraph.t -> lident list -> t
 
 val is_empty : t -> bool
 

--- a/engine/uState.mli
+++ b/engine/uState.mli
@@ -92,11 +92,11 @@ val universe_of_name : t -> Id.t -> Univ.Level.t
 
 (** {5 Unification} *)
 
-(** [restrict_universe_context (univs,csts) keep] restricts [univs] to
+(** [restrict_universe_context lbound (univs,csts) keep] restricts [univs] to
    the universes in [keep]. The constraints [csts] are adjusted so
    that transitive constraints between remaining universes (those in
    [keep] and those not in [univs]) are preserved. *)
-val restrict_universe_context : ContextSet.t -> LSet.t -> ContextSet.t
+val restrict_universe_context : Univ.Level.t -> ContextSet.t -> LSet.t -> ContextSet.t
 
 (** [restrict uctx ctx] restricts the local universes of [uctx] to
    [ctx] extended by local named universes and side effect universes

--- a/engine/univMinim.ml
+++ b/engine/univMinim.ml
@@ -268,7 +268,7 @@ let minimize_univ_variables ctx us algs left right cstrs =
 module UPairs = OrderedType.UnorderedPair(Univ.Level)
 module UPairSet = Set.Make (UPairs)
 
-let normalize_context_set g ctx us algs weak =
+let normalize_context_set ~lbound g ctx us algs weak =
   let (ctx, csts) = ContextSet.levels ctx, ContextSet.constraints ctx in
   (* Keep the Prop/Set <= i constraints separate for minimization *)
   let smallles, csts =
@@ -281,12 +281,12 @@ let normalize_context_set g ctx us algs weak =
   let csts, partition =
     (* We first put constraints in a normal-form: all self-loops are collapsed
        to equalities. *)
-    let g = LSet.fold (fun v g -> UGraph.add_universe v false g)
+    let g = LSet.fold (fun v g -> UGraph.add_universe ~lbound ~strict:false v g)
                            ctx UGraph.initial_universes
     in
     let add_soft u g =
       if not (Level.is_small u || LSet.mem u ctx)
-      then try UGraph.add_universe u false g with UGraph.AlreadyDeclared -> g
+      then try UGraph.add_universe ~lbound ~strict:false u g with UGraph.AlreadyDeclared -> g
       else g
     in
     let g = Constraint.fold

--- a/engine/univMinim.ml
+++ b/engine/univMinim.ml
@@ -272,7 +272,7 @@ let normalize_context_set ~lbound g ctx us algs weak =
   let (ctx, csts) = ContextSet.levels ctx, ContextSet.constraints ctx in
   (* Keep the Prop/Set <= i constraints separate for minimization *)
   let smallles, csts =
-    Constraint.partition (fun (l,d,r) -> d == Le && Level.is_small l) csts
+    Constraint.partition (fun (l,d,r) -> d == Le && Level.equal l lbound) csts
   in
   let smallles = if get_set_minimization ()
     then Constraint.filter (fun (l,d,r) -> LSet.mem r ctx) smallles
@@ -299,7 +299,7 @@ let normalize_context_set ~lbound g ctx us algs weak =
   (* We ignore the trivial Prop/Set <= i constraints. *)
   let noneqs =
     Constraint.filter
-      (fun (l,d,r) -> not ((d == Le && Level.is_small l) ||
+      (fun (l,d,r) -> not ((d == Le && Level.equal l lbound) ||
                            (Level.is_prop l && d == Lt && Level.is_set r)))
       csts
   in

--- a/engine/univMinim.mli
+++ b/engine/univMinim.mli
@@ -25,7 +25,7 @@ module UPairSet : CSet.S with type elt = (Level.t * Level.t)
     (a global one if there is one) and transitively saturate
     the constraints w.r.t to the equalities. *)
 
-val normalize_context_set : UGraph.t -> ContextSet.t ->
+val normalize_context_set : lbound:Univ.Level.t -> UGraph.t -> ContextSet.t ->
   universe_opt_subst (* The defined and undefined variables *) ->
   LSet.t (* univ variables that can be substituted by algebraics *) ->
   UPairSet.t (* weak equality constraints *) ->

--- a/engine/univops.mli
+++ b/engine/univops.mli
@@ -15,5 +15,5 @@ open Univ
 val universes_of_constr : constr -> LSet.t
 [@@ocaml.deprecated "Use [Vars.universes_of_constr]"]
 
-val restrict_universe_context : ContextSet.t -> LSet.t -> ContextSet.t
+val restrict_universe_context : Univ.Level.t -> ContextSet.t -> LSet.t -> ContextSet.t
 [@@ocaml.deprecated "Use [UState.restrict_universe_context]"]

--- a/interp/constrexpr_ops.ml
+++ b/interp/constrexpr_ops.ml
@@ -627,7 +627,8 @@ let interp_univ_constraints env evd cstrs =
 let interp_univ_decl env decl =
   let open UState in
   let pl : lident list = decl.univdecl_instance in
-  let evd = Evd.from_ctx (UState.make_with_initial_binders (Environ.universes env) pl) in
+  let evd = Evd.from_ctx (UState.make_with_initial_binders ~lbound:(Environ.universes_lbound env)
+                            (Environ.universes env) pl) in
   let evd, cstrs = interp_univ_constraints env evd decl.univdecl_constraints in
   let decl = { univdecl_instance = pl;
     univdecl_extensible_instance = decl.univdecl_extensible_instance;

--- a/interp/declare.ml
+++ b/interp/declare.ml
@@ -538,9 +538,13 @@ let do_universe poly l =
   in
   let l = List.map (fun {CAst.v=id} -> (id, UnivGen.new_univ_global ())) l in
   let ctx = List.fold_left (fun ctx (_,qid) -> Univ.LSet.add (Univ.Level.make qid) ctx)
-      Univ.LSet.empty l, Univ.Constraint.empty
+      Univ.LSet.empty l
   in
-  let () = declare_universe_context poly ctx in
+  let cst = Univ.LSet.fold (fun l acc ->
+      if poly then Univ.Constraint.add (Univ.Level.set, Univ.Le, l) acc
+      else Univ.Constraint.add (Univ.Level.set, Univ.Lt, l) acc) ctx Univ.Constraint.empty
+  in
+  let () = declare_universe_context poly (ctx, cst) in
   let src = if poly then BoundUniv else UnqualifiedUniv in
   Lib.add_anonymous_leaf (input_univ_names (src, l))
 

--- a/kernel/environ.mli
+++ b/kernel/environ.mli
@@ -51,6 +51,7 @@ type globals
 
 type stratification = {
   env_universes : UGraph.t;
+  env_universes_lbound : Univ.Level.t;
   env_engagement : engagement
 }
 
@@ -83,6 +84,7 @@ val eq_named_context_val : named_context_val -> named_context_val -> bool
 val empty_env : env
 
 val universes     : env -> UGraph.t
+val universes_lbound : env -> Univ.Level.t
 val rel_context   : env -> Constr.rel_context
 val named_context : env -> Constr.named_context
 val named_context_val : env -> named_context_val

--- a/kernel/mod_typing.ml
+++ b/kernel/mod_typing.ml
@@ -91,7 +91,8 @@ let rec check_with_def env struc (idl,(c,ctx)) mp equiv =
           c', Monomorphic_const Univ.ContextSet.empty, cst
         | Polymorphic_const uctx, Some ctx ->
           let () =
-            if not (UGraph.check_subtype (Environ.universes env) uctx ctx) then
+            if not (UGraph.check_subtype ~lbound:(Environ.universes_lbound env)
+                      (Environ.universes env) uctx ctx) then
               error_incorrect_with_constraint lab
           in
           (** Terms are compared in a context with De Bruijn universe indices *)

--- a/kernel/reduction.ml
+++ b/kernel/reduction.ml
@@ -726,7 +726,7 @@ let infer_cmp_universes env pb s0 s1 univs =
     | Prop, (Set | Type _) -> if not (is_cumul pb) then raise NotConvertible else univs
     | Set, Prop -> raise NotConvertible
     | Set, Type u -> infer_pb Univ.type0_univ u
-    | Type _u, Prop -> raise NotConvertible
+    | Type u, Prop -> infer_pb u Univ.type0m_univ
     | Type u, Set -> infer_pb u Univ.type0_univ
     | Type u0, Type u1 -> infer_pb u0 u1
 

--- a/kernel/subtyping.ml
+++ b/kernel/subtyping.ml
@@ -93,7 +93,8 @@ let check_conv_error error why cst poly f env a1 a2 =
      | Univ.UniverseInconsistency e -> error (IncompatibleUniverses e)
 
 let check_polymorphic_instance error env auctx1 auctx2 =
-  if not (UGraph.check_subtype (Environ.universes env) auctx2 auctx1) then
+  if not (UGraph.check_subtype ~lbound:(Environ.universes_lbound env)
+            (Environ.universes env) auctx2 auctx1) then
     error (IncompatibleConstraints { got = auctx1; expect = auctx2; } )
   else
     Environ.push_context ~strict:false (Univ.AUContext.repr auctx2) env

--- a/kernel/uGraph.ml
+++ b/kernel/uGraph.ml
@@ -124,10 +124,10 @@ let enforce_leq_alg u v g =
   cg
 
 exception AlreadyDeclared = G.AlreadyDeclared
-let add_universe u strict g =
+let add_universe u ~lbound ~strict g =
   let g = G.add u g in
   let d = if strict then Lt else Le in
-  enforce_constraint (Level.set,d,u) g
+  enforce_constraint (lbound,d,u) g
 
 let add_universe_unconstrained u g = G.add u g
 
@@ -139,11 +139,11 @@ let constraints_for = G.constraints_for
 
 (** Subtyping of polymorphic contexts *)
 
-let check_subtype univs ctxT ctx =
+let check_subtype ~lbound univs ctxT ctx =
   if AUContext.size ctxT == AUContext.size ctx then
     let (inst, cst) = UContext.dest (AUContext.repr ctx) in
     let cstT = UContext.constraints (AUContext.repr ctxT) in
-    let push accu v = add_universe v false accu in
+    let push accu v = add_universe v ~lbound ~strict:false accu in
     let univs = Array.fold_left push univs (Instance.to_array inst) in
     let univs = merge_constraints cstT univs in
     check_constraints cst univs

--- a/kernel/uGraph.mli
+++ b/kernel/uGraph.mli
@@ -45,7 +45,7 @@ val enforce_leq_alg : Universe.t -> Universe.t -> t -> Constraint.t * t
 
 exception AlreadyDeclared
 
-val add_universe : Level.t -> bool -> t -> t
+val add_universe : Level.t -> lbound:Level.t -> strict:bool -> t -> t
 
 (** Add a universe without (Prop,Set) <= u *)
 val add_universe_unconstrained : Level.t -> t -> t
@@ -83,7 +83,7 @@ val constraints_for : kept:LSet.t -> t -> Constraint.t
 val domain : t -> LSet.t
 (** Known universes *)
 
-val check_subtype : AUContext.t check_function
+val check_subtype : lbound:Level.t -> AUContext.t check_function
 (** [check_subtype univ ctx1 ctx2] checks whether [ctx2] is an instance of
     [ctx1]. *)
 

--- a/kernel/univ.ml
+++ b/kernel/univ.ml
@@ -844,9 +844,7 @@ struct
     else if Array.length y = 0 then x 
     else Array.append x y
 
-  let of_array a =
-    assert(Array.for_all (fun x -> not (Level.is_prop x)) a);
-    a
+  let of_array a = a
 
   let to_array a = a
 

--- a/library/global.ml
+++ b/library/global.ml
@@ -112,6 +112,7 @@ let add_module_parameter mbid mte inl =
 (** Queries on the global environment *)
 
 let universes () = universes (env())
+let universes_lbound () = universes_lbound (env())
 let named_context () = named_context (env())
 let named_context_val () = named_context_val (env())
 

--- a/library/global.mli
+++ b/library/global.mli
@@ -22,6 +22,7 @@ val env : unit -> Environ.env
 val env_is_initial : unit -> bool
 
 val universes : unit -> UGraph.t
+val universes_lbound : unit -> Univ.Level.t
 val named_context_val : unit -> Environ.named_context_val
 val named_context : unit -> Constr.named_context
 

--- a/plugins/setoid_ring/newring.ml
+++ b/plugins/setoid_ring/newring.ml
@@ -152,7 +152,7 @@ let ic_unsafe c = (*FIXME remove *)
 let decl_constant na univs c =
   let open Constr in
   let vars = CVars.universes_of_constr c in
-  let univs = UState.restrict_universe_context univs vars in
+  let univs = UState.restrict_universe_context (Global.universes_lbound ()) univs vars in
   let univs = Monomorphic_const_entry univs in
   mkConst(declare_constant (Id.of_string na) 
             (DefinitionEntry (definition_entry ~opaque:true ~univs c),

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -408,7 +408,10 @@ let interp_instance ?loc evd l =
          (evd, l :: univs)) (evd, [])
       l
   in
-  if List.exists (fun l -> Univ.Level.is_prop l) l' then
+  let lbound = Global.universes_lbound () in
+  if List.exists (fun l -> Univ.Level.is_prop l &&
+                           Evd.check_leq evd (Univ.Universe.super (Univ.Universe.make l))
+                             (Univ.Universe.make lbound)) l' then
     user_err ?loc ~hdr:"pretype"
       (str "Universe instances cannot contain Prop, polymorphic" ++
        str " universe instances must be greater or equal to Set.");

--- a/test-suite/bugs/closed/HoTT_coq_120.v
+++ b/test-suite/bugs/closed/HoTT_coq_120.v
@@ -3,14 +3,14 @@ Require Import TestSuite.admit.
 Set Universe Polymorphism.
 Generalizable All Variables.
 Reserved Notation "g 'o' f" (at level 40, left associativity).
-Inductive paths {A : Type} (a : A) : A -> Type :=
+Inductive paths@{i} {A : Type@{i}} (a : A) : A -> Type@{i} :=
   idpath : paths a a.
 Arguments idpath {A a} , [A] a.
 Notation "x = y" := (@paths _ x y) : type_scope.
 
-Class IsEquiv {A B : Type} (f : A -> B) := {}.
+Class IsEquiv@{i j k | Set <= i, Set <= j, Set <= k} {A : Type@{i}} {B : Type@{j}} (f : A -> B) : Type@{k} := {}.
 
-Class Contr_internal (A : Type) := BuildContr {
+Class Contr_internal@{i | Set <= i} (A : Type@{i}) := BuildContr {
                                        center : A ;
                                        contr : (forall y : A, center = y)
                                      }.
@@ -72,7 +72,7 @@ Arguments compose [!C s d d'] m1 m2 : rename.
 
 Infix "o" := compose : morphism_scope.
 Local Open Scope morphism_scope.
-
+Set Printing Universes.
 Class IsEpimorphism {C} {x y} (m : morphism C x y) :=
   is_epimorphism : forall z (m1 m2 : morphism C y z),
                      m1 o m = m2 o m

--- a/test-suite/bugs/closed/bug_4287.v
+++ b/test-suite/bugs/closed/bug_4287.v
@@ -104,15 +104,15 @@ Qed.
 End Hurkens.
 
 Polymorphic Record box (T : Type) := wrap {unwrap : T}.
-
+Set Printing Universes.
 (* Here we instantiate to Set *)
 
-Fail Definition down (x : Type) : Prop := box x.
+Definition down (x : Type) : Prop := box x.
 Definition up (x : Prop) : Type := x.
 
-Fail Definition back A : up (down A) -> A := unwrap A.
+Definition back A : up (down A) -> A := unwrap A.
 
-Fail Definition forth A : A -> up (down A) := wrap A.
+Definition forth A : A -> up (down A) := wrap A.
 
 Definition id {A : Type} (a : A) := a.
 Definition setlt (A : Type@{i}) :=
@@ -122,6 +122,6 @@ Definition setle (B : Type@{i}) :=
   let foo (A : Type@{j}) := A in foo B.
 
 Fail Check @setlt@{j Prop}.
-Fail Definition foo := @setle@{j Prop}.
+Definition foo := @setle@{j Prop}.
 Check setlt@{Set i}.
 Check setlt@{Set j}.

--- a/test-suite/bugs/closed/bug_4301.v
+++ b/test-suite/bugs/closed/bug_4301.v
@@ -9,5 +9,5 @@ Module Lower (X : Foo with Definition U := True : Type).
 End Lower.
 
 Module M : Foo.
-  Definition U := nat : Type@{i}.
+  Definition U := True : Type@{i}.
 End M.

--- a/test-suite/bugs/closed/bug_8951.v
+++ b/test-suite/bugs/closed/bug_8951.v
@@ -3,7 +3,7 @@ Module Type T.
 End T.
 
 Module M.
-  Polymorphic Definition t@{i} := nat.
+  Polymorphic Definition t@{i} := True.
 End M.
 
 Module Make (X:T).
@@ -12,3 +12,20 @@ Module Make (X:T).
 End Make.
 
 Module P := Make M.
+
+
+
+Module Type T'.
+  Polymorphic Parameter Inline t@{i | Set <= i} : Type@{i}.
+End T'.
+
+Module M'.
+  Polymorphic Definition t@{i} := nat.
+End M'.
+
+Module Make' (X:T').
+  Include X.
+
+End Make'.
+
+Module P' := Make' M'.

--- a/test-suite/bugs/closed/bug_9294.v
+++ b/test-suite/bugs/closed/bug_9294.v
@@ -1,0 +1,29 @@
+Set Printing Universes.
+
+Inductive Foo@{i} (A:Type@{i}) : Type := foo : (Set:Type@{i}) -> Foo A.
+Arguments foo {_} _.
+Print Universes Subgraph (Foo.i).
+Definition bar : Foo True -> Set := fun '(foo x) => x.
+
+Definition foo_bar (n : Foo True) : foo (bar n) = n.
+Proof. destruct n;reflexivity. Qed.
+
+Definition bar_foo (n : Set) : bar (foo n) = n.
+Proof. reflexivity. Qed.
+
+Require Import Hurkens.
+
+Inductive box (A : Set) : Prop := Box : A -> box A.
+
+Definition Paradox : False.
+Proof.
+Fail unshelve refine (
+  NoRetractFromSmallPropositionToProp.paradox
+  (Foo True)
+  (fun A => foo A)
+  (fun A => box (bar A))
+  _
+  _
+  False
+).
+Abort.

--- a/test-suite/output/PrintUnivsSubgraph.out
+++ b/test-suite/output/PrintUnivsSubgraph.out
@@ -1,4 +1,6 @@
 Prop < Set
+     < i
+     < j
 Set < i
     < j
 i < j

--- a/test-suite/output/UnivBinders.out
+++ b/test-suite/output/UnivBinders.out
@@ -112,16 +112,17 @@ insec@{v} = Type@{u} -> Type@{v}
 Inductive insecind@{k} : Type@{k+1} :=  inseccstr : Type@{k} -> insecind@{k}
 
 For inseccstr: Argument scope is [type_scope]
-insec@{u v} = Type@{u} -> Type@{v}
+insec@{u v} = 
+Type@{u} -> Type@{v}
      : Type@{max(u+1,v+1)}
-(* u v |=  *)
+(* u v |= Set <= u *)
 Inductive insecind@{u k} : Type@{k+1} :=
     inseccstr : Type@{k} -> insecind@{u k}
 
 For inseccstr: Argument scope is [type_scope]
 insec2@{u} = Prop
      : Type@{Set+1}
-(* u |=  *)
+(* u |= Set <= u *)
 inmod@{u} = Type@{u}
      : Type@{u+1}
 (* u |=  *)

--- a/test-suite/success/Inductive.v
+++ b/test-suite/success/Inductive.v
@@ -172,15 +172,15 @@ Module TemplateProp.
 
 End TemplateProp.
 
-Module PolyNoLowerProp.
+Module PolyLowerProp.
 
-  (** Check lowering of a general universe polymorphic inductive to Prop is _failing_ *)
+  (** Check lowering of a general universe polymorphic inductive to Prop is _succeeding_ *)
   
   Polymorphic Inductive Foo (A : Type) : Type := foo : A -> Foo A.
-  
-  Fail Check Foo True : Prop.
 
-End PolyNoLowerProp.
+  Check Foo True : Prop.
+
+End PolyLowerProp.
 
 (* Test building of elimination scheme with noth let-ins and
    non-recursively uniform parameters *)

--- a/test-suite/success/private_univs.v
+++ b/test-suite/success/private_univs.v
@@ -31,7 +31,7 @@ Proof.
   exact bar.
 Qed.
 
-Definition private_transitivity'@{i j|i < j} := private_transitivity@{i j}.
+Definition private_transitivity'@{i j|i < j, Set < j} := private_transitivity@{i j}.
 Fail Definition dummy@{i j|j <= i +} := private_transitivity@{i j}.
 
 Unset Private Polymorphic Universes.

--- a/vernac/auto_ind_decl.ml
+++ b/vernac/auto_ind_decl.ml
@@ -341,7 +341,7 @@ let build_beq_scheme mode kn =
           Vars.substl subst cores.(i)
         in
         create_input fix),
-       UState.make (Global.universes ())),
+       UState.make ~lbound:(Global.universes_lbound ()) (Global.universes ())),
       !eff
 
 let beq_scheme_kind = declare_mutual_scheme_object "_beq" build_beq_scheme
@@ -681,7 +681,7 @@ let make_bl_scheme mode mind =
   let lnonparrec,lnamesparrec = (* TODO subst *)
     context_chop (nparams-nparrec) mib.mind_params_ctxt in
   let bl_goal, eff = compute_bl_goal ind lnamesparrec nparrec in
-  let ctx = UState.make (Global.universes ()) in
+  let ctx = UState.make ~lbound:(Global.universes_lbound ()) (Global.universes ()) in
   let side_eff = side_effect_of_mode mode in
   let bl_goal = EConstr.of_constr bl_goal in
   let (ans, _, ctx) = Pfedit.build_by_tactic ~side_eff (Global.env()) ctx bl_goal
@@ -805,7 +805,7 @@ let make_lb_scheme mode mind =
   let lnonparrec,lnamesparrec =
     context_chop (nparams-nparrec) mib.mind_params_ctxt in
   let lb_goal, eff = compute_lb_goal ind lnamesparrec nparrec in
-  let ctx = UState.make (Global.universes ()) in
+  let ctx = UState.make ~lbound:(Global.universes_lbound ()) (Global.universes ()) in
   let side_eff = side_effect_of_mode mode in
   let lb_goal = EConstr.of_constr lb_goal in
   let (ans, _, ctx) = Pfedit.build_by_tactic ~side_eff (Global.env()) ctx lb_goal
@@ -975,7 +975,7 @@ let make_eq_decidability mode mind =
   let nparams = mib.mind_nparams in
   let nparrec = mib.mind_nparams_rec in
   let u = Univ.Instance.empty in
-  let ctx = UState.make (Global.universes ()) in
+  let ctx = UState.make ~lbound:(Global.universes_lbound ()) (Global.universes ()) in
   let lnonparrec,lnamesparrec =
     context_chop (nparams-nparrec) mib.mind_params_ctxt in
   let side_eff = side_effect_of_mode mode in

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -187,11 +187,6 @@ let extract_level env evd min tys =
       sign_level env evd (LocalAssum (Anonymous, concl) :: ctx)) tys
   in sup_list min sorts
 
-let is_flexible_sort evd u =
-  match Univ.Universe.level u with
-  | Some l -> Evd.is_flexible_level evd l
-  | None -> false
-
 (**********************************************************************)
 (* Tools for template polymorphic inductive types                         *)
 
@@ -319,10 +314,7 @@ let inductive_levels env evd poly arities inds =
         in
         let duu = Sorts.univ_of_sort du in
         let evd =
-          if not (Univ.is_small_univ duu) && Univ.Universe.equal cu duu then
-            if is_flexible_sort evd duu && not (Evd.check_leq evd Univ.type0_univ duu) then
-              Evd.set_eq_sort env evd Prop du
-            else evd
+          if Univ.Universe.equal cu duu then evd
           else Evd.set_eq_sort env evd (Type cu) du
         in
           (evd, arity :: arities))

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -253,7 +253,7 @@ let solve_constraints_system levels level_bounds =
   done;
   v
 
-let inductive_levels env evd poly arities inds =
+let inductive_levels env evd arities inds =
   let destarities = List.map (fun x -> x, Reduction.dest_arity env x) arities in
   let levels = List.map (fun (x,(ctx,a)) ->
     if a = Prop then None
@@ -411,7 +411,7 @@ let interp_mutual_inductive_gen env0 ~template udecl (uparamsl,paramsl,indl) not
   let constructors = List.map (fun (idl,cl,impsl) -> (idl,List.map nf cl,impsl)) constructors in
   let arities = List.map EConstr.(to_constr sigma) arities in
   let sigma = List.fold_left make_conclusion_flexible sigma arityconcl in
-  let sigma, arities = inductive_levels env_ar_params sigma poly arities constructors in
+  let sigma, arities = inductive_levels env_ar_params sigma arities constructors in
   let sigma = Evd.minimize_universes sigma in
   let nf = Evarutil.nf_evars_universes sigma in
   let arities = List.map nf arities in

--- a/vernac/obligations.ml
+++ b/vernac/obligations.ml
@@ -893,7 +893,7 @@ let obligation_terminator ?univ_hook name num guard auto pf =
            declares the univs of the constant,
            each subsequent obligation declares its own additional
            universes and constraints if any *)
-        if defined then UState.make (Global.universes ())
+        if defined then UState.make ~lbound:(Global.universes_lbound ()) (Global.universes ())
         else ctx
     in
     let prg = { prg with prg_ctx } in


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

This branch explores a redesign of universes supporting to instantiate polymorphic universe binders with Prop and using this to fix (not yet done) #9294 The easy part is allowing Prop, and this works already. The harder part is emulating template-polymorphism using cumulative inductives while keeping compatibility as much as possible.

<!-- Keep what applies -->
**Kind:** bug fix / feature


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #????

Current setup:
- First, allow to set a global lower bound on universes (Prop for standard Coq, can be set to Set for HoTT). This allows i such that Prop < i < Set. At least without Set impredicative, I don't see any issue with that (Set is just a name for a specific level).
- Adapt minimization etc... to comply with this (done)
- Try and emulate template-polymorphic inductives with cumulative ones (WIP).

<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [ ] Added / updated test-suite
<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [ ] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [ ] Entry added in CHANGES.md.
