### PR TITLE
[proof] optimize proof always works on incomplete proofs

### DIFF
--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -39,7 +39,7 @@ let proofview p =
 
 let compact el ({ solution } as pv) =
   let nf c = Evarutil.nf_evar solution c in
-  let nf0 c = EConstr.(to_constr solution (of_constr c)) in
+  let nf0 c = EConstr.(to_constr ~abort_on_undefined_evars:false solution (of_constr c)) in
   let size = Evd.fold (fun _ _ i -> i+1) solution 0 in
   let new_el = List.map (fun (t,ty) -> nf t, nf ty) el in
   let pruned_solution = Evd.drop_all_defined solution in

--- a/test-suite/bugs/closed/bug_9451.v
+++ b/test-suite/bugs/closed/bug_9451.v
@@ -1,0 +1,8 @@
+Goal False.
+cut True.
+assert False.
+evar (x : True).
+let v := open_constr:(_) in idtac. all: exfalso; clear.
+Optimize Proof.
+(* Error: Anomaly "grounding a non evar-free term" *)
+Abort All.


### PR DESCRIPTION
Fix #9451 