### PR TITLE
Fix off-by-one error in nat syntax warnings

### DIFF
--- a/test-suite/bugs/closed/bug_9453.v
+++ b/test-suite/bugs/closed/bug_9453.v
@@ -1,0 +1,7 @@
+(* check compatibility with 8.8 and earlier for lack of warnings on the nat 5000 *)
+Set Warnings Append "+large-nat,+abstract-large-number".
+Fail Check 5001.
+Check 5000.
+(* Error:
+To avoid stack overflow, large numbers in nat are interpreted as applications of
+Nat.of_uint. *)

--- a/theories/Init/Prelude.v
+++ b/theories/Init/Prelude.v
@@ -38,7 +38,7 @@ Numeral Notation Decimal.int Decimal.int_of_int Decimal.int_of_int
   : dec_int_scope.
 
 (* Parsing / printing of [nat] numbers *)
-Numeral Notation nat Nat.of_uint Nat.to_uint : nat_scope (abstract after 5000).
+Numeral Notation nat Nat.of_uint Nat.to_uint : nat_scope (abstract after 5001).
 
 (* Printing/Parsing of bytes *)
 Export Byte.ByteSyntaxNotations.


### PR DESCRIPTION
Fixes #9453

**Kind:** bug fix

- [x] Added / updated test-suite
- [ ] Entry added in CHANGES.md. (Do we need one?)
