### PR TITLE
[coq_makefile] Fail when no `CONF_FILE` is present.

### DIFF
--- a/tools/CoqMakefile.in
+++ b/tools/CoqMakefile.in
@@ -39,9 +39,6 @@ OCAMLFIND         := $(COQMF_OCAMLFIND)
 CAMLFLAGS         := $(COQMF_CAMLFLAGS)
 HASNATDYNLINK     := $(COQMF_HASNATDYNLINK)
 
-@CONF_FILE@: @PROJECT_FILE@
-	@COQ_MAKEFILE_INVOCATION@
-
 # This file can be created by the user to hook into double colon rules or
 # add any other Makefile code he may need
 -include @LOCAL_FILE@


### PR DESCRIPTION
When a `Makefile.conf` file is not present, `coq_makefile` used to try
to re-generate it. This results in #8731.

Instead, we require that the `.conf` file is present, or else we fail;
this means that users cannot distribute generated makefiles
anymore. Indeed, this makes sense as `coq_makefile` writes hardcoded
paths into makefiles.
