### PR TITLE
Automatic deployment of the user manual to GH-Pages

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,6 +4,7 @@ stages:
   - docker
   - build
   - test
+  - deploy
 
 # some default values
 variables:
@@ -346,6 +347,35 @@ doc:refman:dune:
     <<: *dune-ci-template-artifacts
     paths:
       - _build/default/doc/sphinx_build/html
+
+doc:refman:deploy:
+  stage: deploy
+  environment:
+    name: deployment
+    url: https://coq.github.io/
+  only:
+    variables:
+      - $DOCUMENTATION_DEPLOY_KEY
+  dependencies:
+    - doc:refman:dune
+  before_script:
+    - which ssh-agent || ( apt-get update -y && apt-get install openssh-client -y )
+    - eval $(ssh-agent -s)
+    - echo "$DOCUMENTATION_DEPLOY_KEY" | tr -d '\r' | ssh-add - > /dev/null
+    - mkdir -p ~/.ssh
+    - chmod 700 ~/.ssh
+    - ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
+    - git config --global user.name "coqbot"
+    - git config --global user.email "coqbot@users.noreply.github.com"
+  script:
+    - git clone git@github.com:coq/doc.git _deploy
+    - rm -rf _deploy/$CI_COMMIT_REF_NAME/refman # NB: won’t work if branch name has ‘/’ in it
+    - mkdir -p _deploy/$CI_COMMIT_REF_NAME
+    - cp -rv _build/default/doc/sphinx_build/html _deploy/$CI_COMMIT_REF_NAME/refman
+    - cd _deploy/$CI_COMMIT_REF_NAME/refman
+    - git add .
+    - git commit -m "User manual of branch “$CI_COMMIT_REF_NAME” at $CI_COMMIT_SHORT_SHA"
+    - git push # TODO: rebase and retry on failure
 
 doc:ml-api:odoc:
   <<: *dune-ci-template


### PR DESCRIPTION
We can take advantage of Gitlab-CI to automatically deploy the current version of the user manual.

This PR adds a `deploy` stage with only one job. This job commits to the https://github.com/coq/manual/ repository the manual as built in the previous stage. For technical reasons, directories whose name starts with an underscore need to be renamed.

This automatic deployment only happen when the private key (allowed to write to that repository) is present.

Said key is dedicated to this task and currently stored on a private CI/CD mirror of this repository, and only made available to *protected* branches (e.g., `master`, as opposed to pull requests).