### PR TITLE
Fixing #9428 in 8.9: missing newline in reporting about locating notations

### DIFF
--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -1585,7 +1585,7 @@ let locate_notation prglob ntn scope =
     str "Notation" ++ fnl () ++
     prlist_with_sep fnl (fun (ntn,l) ->
       let scope = find_default ntn scopes in
-      prlist
+      prlist_with_sep fnl
 	(fun (sc,r,(_,df)) ->
 	  hov 0 (
 	    pr_notation_info prglob df r ++

--- a/test-suite/output/locate.out
+++ b/test-suite/output/locate.out
@@ -1,0 +1,3 @@
+Notation
+"b1 && b2" := if b1 then b2 else false (default interpretation)
+"x && y" := andb x y : bool_scope

--- a/test-suite/output/locate.v
+++ b/test-suite/output/locate.v
@@ -1,0 +1,3 @@
+Set Printing Width 400.
+Notation "b1 && b2" := (if b1 then b2 else false).
+Locate "&&".


### PR DESCRIPTION
**Kind:** bug fix

Fixes / closes #9428

This was already fixed in master, so this is a backport of 4b02fbd92 to v8.9.

- [X] Added / updated test-suite
