### PR TITLE
Add print_pure_econstr signature

### DIFF
--- a/dev/top_printers.mli
+++ b/dev/top_printers.mli
@@ -161,6 +161,7 @@ val ppobj : Libobject.obj -> unit
 val cast_kind_display : Constr.cast_kind -> string
 val constr_display : Constr.constr -> unit
 val print_pure_constr : Constr.types -> unit
+val print_pure_econstr : EConstr.types -> unit
 
 val pploc : Loc.t -> unit
 


### PR DESCRIPTION
print_pure_econstr was not exported (while print_pure_constr was).

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** bug fix.


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #9503 

