### PR TITLE
Edit release-process.md to ease upcoming releases of Coq in Docker Hub

### DIFF
--- a/dev/doc/release-process.md
+++ b/dev/doc/release-process.md
@@ -92,7 +92,11 @@
 ### These steps are the same for all releases (beta, final, patch-level) ###
 
 - [ ] Send an e-mail on Coqdev announcing that the tag has been put so that
-  package managers can start preparing package updates.
+  package managers can start preparing package updates (including a
+  `coq-bignums` compatible version).
+- [ ] Ping **@erikmd** to update the Docker images in `coqorg/coq`
+  (requires `coq-bignums` in `extra-dev` for a beta / in `released`
+  for a final release).
 - [ ] Draft a release on GitHub.
 - [ ] Get **@maximedenes** to sign the Windows and MacOS packages and
   upload them on GitHub.


### PR DESCRIPTION
**Kind:** documentation / infrastructure.

This PR is a follow-up of coq/bignums#17.

The idea is that preparing a package for `coq-bignums` almost at the same time as for `coq` would make the process smoother for publishing Coq in Docker Hub for upcoming beta and stable releases. 

As this PR only touches the dev doc, I took the opportunity to add the `[ci skip]` tag in the commit message to avoid triggering the CI accordingly, but tell me if this was not a good idea…