### PR TITLE
Fix #7632: Change syntax of autoapply according to the documentation.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -97,6 +97,9 @@ Tactics
 
 - Ltac backtraces can be turned on using the "Ltac Backtrace" option.
 
+- The syntax of the `autoapply` tactic was fixed to conform with preexisting
+  documentation: it now takes a `with` clause instead of a `using` clause.
+
 Vernacular commands
 
 - `Combined Scheme` can now work when inductive schemes are generated in sort

--- a/plugins/ltac/g_class.mlg
+++ b/plugins/ltac/g_class.mlg
@@ -99,8 +99,19 @@ TACTIC EXTEND is_ground
 | [ "is_ground" constr(ty) ] -> { is_ground ty }
 END
 
+{
+let deprecated_autoapply_using =
+  CWarnings.create
+    ~name:"autoapply-using" ~category:"deprecated"
+    (fun () -> Pp.str "The syntax [autoapply ... using] is deprecated. Use [autoapply ... with] instead.")
+}
+
 TACTIC EXTEND autoapply
-| [ "autoapply" constr(c) "using" preident(i) ] -> { autoapply c i }
+| [ "autoapply" constr(c) "using" preident(i) ] -> {
+    deprecated_autoapply_using ();
+    autoapply c i
+  }
+| [ "autoapply" constr(c) "with" preident(i) ] -> { autoapply c i }
 END
 
 {

--- a/theories/Classes/Init.v
+++ b/theories/Classes/Init.v
@@ -23,7 +23,7 @@ Typeclasses Opaque id const flip compose arrow impl iff not all.
 
 (** Apply using the same opacity information as typeclass proof search. *)
 
-Ltac class_apply c := autoapply c using typeclass_instances.
+Ltac class_apply c := autoapply c with typeclass_instances.
 
 (** The unconvertible typeclass, to test that two objects of the same type are
    actually different. *)


### PR DESCRIPTION
The documented syntax was using a `with` clause which is more standard with a hint database than the `using` clause that was actually implemented.

I deprecated the old syntax but I don't know how to make the deprecation warning behave as the deprecated attribute, i.e. only warn for direct uses of the tactic, not indirect ones.

Fixes #7632

**Kind:** bug fix

- [x] Entry added in CHANGES.md.
