### PR TITLE
Workaround for CI not having enough RAM for bedrock2: `-async-proofs-tac-j 1`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -524,7 +524,6 @@ validate:quick:
 
 library:ci-bedrock2:
   <<: *ci-template
-  allow_failure: true
 
 library:ci-color:
   <<: *ci-template-flambda

--- a/dev/ci/ci-bedrock2.sh
+++ b/dev/ci/ci-bedrock2.sh
@@ -6,4 +6,4 @@ ci_dir="$(dirname "$0")"
 FORCE_GIT=1
 git_download bedrock2
 
-( cd "${CI_BUILD_DIR}/bedrock2" && git submodule update --init --recursive && make )
+( cd "${CI_BUILD_DIR}/bedrock2" && git submodule update --init --recursive && COQMF_ARGS='-arg "-async-proofs-tac-j 1"' VERBOSE=1 make )

--- a/dev/ci/ci-bedrock2.sh
+++ b/dev/ci/ci-bedrock2.sh
@@ -6,4 +6,4 @@ ci_dir="$(dirname "$0")"
 FORCE_GIT=1
 git_download bedrock2
 
-( cd "${CI_BUILD_DIR}/bedrock2" && git submodule update --init --recursive && COQMF_ARGS='-arg "-async-proofs-tac-j 1"' VERBOSE=1 make )
+( cd "${CI_BUILD_DIR}/bedrock2" && git submodule update --init --recursive && COQMF_ARGS='-arg "-async-proofs-tac-j 1"' make )


### PR DESCRIPTION
`COQMF_ARGS` is a bedrock2-specific name to pass extra arguments to `coq_makefile`,
and we use `VERBOSE=1` for better debuggability.

Works around https://github.com/coq/coq/issues/9484
