### PR TITLE
[coqdoc] Add the From keyword

### DIFF
--- a/tools/coqdoc/cpretty.mll
+++ b/tools/coqdoc/cpretty.mll
@@ -409,6 +409,7 @@ let set_kw =
 let gallina_kw_to_hide =
     "Implicit" space+ "Arguments"
   | ("Local" space+)? "Ltac"
+  | "From"
   | "Require"
   | "Import"
   | "Export"

--- a/tools/coqdoc/output.ml
+++ b/tools/coqdoc/output.ml
@@ -32,7 +32,7 @@ let is_keyword =
   build_table
     [ "About"; "AddPath"; "Axiom"; "Abort"; "Chapter"; "Check"; "Coercion"; "Compute"; "CoFixpoint";
       "CoInductive"; "Corollary"; "Defined"; "Definition"; "End"; "Eval"; "Example";
-      "Export"; "Fact"; "Fix"; "Fixpoint"; "Function"; "Generalizable"; "Global"; "Grammar";
+      "Export"; "Fact"; "Fix"; "Fixpoint"; "From"; "Function"; "Generalizable"; "Global"; "Grammar";
       "Guarded"; "Goal"; "Hint"; "Debug"; "On";
       "Hypothesis"; "Hypotheses";
       "Resolve"; "Unfold"; "Immediate"; "Extern"; "Constructors"; "Rewrite";


### PR DESCRIPTION
In gallina mode (-g, skip proofs), coqdoc was skipping `Require` lines beginning with `From`.
A common solution was to put the `From` and `Require` on successive lines

```coq
From Coq
Require Import ZArith.
```

producing after processing by coqdoc

```coq
Require Import ZArith.
```

This PR offers to keep both lines.
