### PR TITLE
Don't save expected failure logs from opened/ bugs.

### DIFF
--- a/test-suite/report.sh
+++ b/test-suite/report.sh
@@ -11,11 +11,8 @@ SAVEDIR="logs"
 rm -rf "$SAVEDIR"
 mkdir "$SAVEDIR"
 
-# keep this synced with test-suite/Makefile
-FAILMARK="==========> FAILURE <=========="
-
 FAILED=$(mktemp /tmp/coq-check-XXXXXX)
-find . '(' -name '*.log' -exec grep "$FAILMARK" -q '{}' ';' -print0 ')' > "$FAILED"
+find . '(' -name '*.log' -exec grep -q -F "Error!" '{}' ';' -print0 ')' > "$FAILED"
 
 rsync -a --from0 --files-from="$FAILED" . "$SAVEDIR"
 cp summary.log "$SAVEDIR"/


### PR DESCRIPTION
Grepping for "Error!" is how we decide if we exit with failure or not.
I don't remember why I used the "==> FAILURE <==" string in the
save-logs script but it was an error.
