### PR TITLE
Add test that we regenerated doc/sphinx/README.rst to linter

### DIFF
--- a/doc/sphinx/README.rst
+++ b/doc/sphinx/README.rst
@@ -214,7 +214,7 @@ In addition to the objects above, the ``coqrst`` Sphinx plugin defines the follo
 
     Example::
 
-       .. coqtop:: in reset undo
+       .. coqtop:: in undo
 
           Print nat.
           Definition a := 1.
@@ -234,8 +234,7 @@ In addition to the objects above, the ``coqrst`` Sphinx plugin defines the follo
     - Behavior options
 
       - ``reset``: Send a ``Reset Initial`` command before running this block
-      - ``undo``: Send an ``Undo n`` (``n`` = number of sentences) command after
-        running all the commands in this block
+      - ``undo``: Reset state after executing. Not compatible with ``reset``.
 
     ``coqtop``\ 's state is preserved across consecutive ``.. coqtop::`` blocks
     of the same document (``coqrst`` creates a single ``coqtop`` process per

--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -142,6 +142,7 @@ exclude_patterns = [
     'introduction.rst',
     'refman-preamble.rst',
     'README.rst',
+    'README.gen.rst',
     'README.template.rst'
 ] + ["*.{}.rst".format(fmt) for fmt in SUPPORTED_FORMATS]
 

--- a/doc/sphinx/dune
+++ b/doc/sphinx/dune
@@ -1,1 +1,8 @@
 (dirs :standard _static)
+
+(rule (targets README.gen.rst)
+ (deps (source_tree ../tools/coqrst) README.template.rst)
+ (action (run ../tools/coqrst/regen_readme.py %{targets})))
+
+(alias (name refman-html)
+  (action (diff README.rst README.gen.rst)))

--- a/doc/tools/coqrst/regen_readme.py
+++ b/doc/tools/coqrst/regen_readme.py
@@ -10,6 +10,17 @@ SCRIPT_DIR = path.dirname(path.abspath(__file__))
 if __name__ == "__main__" and __package__ is None:
     sys.path.append(path.dirname(SCRIPT_DIR))
 
+SPHINX_DIR = path.join(SCRIPT_DIR, "../../sphinx/")
+README_TEMPLATE_PATH = path.join(SPHINX_DIR, "README.template.rst")
+
+if len(sys.argv) == 1:
+    README_PATH = path.join(SPHINX_DIR, "README.rst")
+elif len(sys.argv) == 2:
+    README_PATH = sys.argv[1]
+else:
+    print ("usage: {} [FILE]".format(sys.argv[0]))
+    sys.exit(1)
+
 import sphinx
 from coqrst import coqdomain
 
@@ -22,10 +33,6 @@ def format_docstring(template, obj, *strs):
     docstring = obj.__doc__.strip()
     strs = strs + (FIRST_LINE_BLANKS.sub(r"\1\n", docstring),)
     return template.format(*strs)
-
-SPHINX_DIR = path.join(SCRIPT_DIR, "../../sphinx/")
-README_PATH = path.join(SPHINX_DIR, "README.rst")
-README_TEMPLATE_PATH = path.join(SPHINX_DIR, "README.template.rst")
 
 def notation_symbol(d):
     return " :black_nib:" if issubclass(d, coqdomain.NotationObject) else ""


### PR DESCRIPTION
We change regen_readme such that when given an argument it outputs
there instead of overwriting the readme. Then the linter calls
regen_readme with a temporary file path and diffs the result with the
readme.

Prompted by me noticing I forgot to regen in #9553.
