### PR TITLE
[library] Remove `-boot` option.

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -201,7 +201,7 @@ COQOPTS=$(NATIVECOMPUTE) $(COQWARNERROR) $(COQUSERFLAGS)
 # Beware this depends on the makefile being in a particular dir, we
 # should pass an absolute path here but windows is tricky
 # c.f. https://github.com/coq/coq/pull/9560
-BOOTCOQC=$(TIMER) $(COQC) -coqlib . -boot $(COQOPTS)
+BOOTCOQC=$(TIMER) $(COQC) -coqlib . -q $(COQOPTS)
 
 LOCALINCLUDES=$(addprefix -I ,$(SRCDIRS))
 MLINCLUDES=$(LOCALINCLUDES)

--- a/checker/checker.ml
+++ b/checker/checker.ml
@@ -192,7 +192,6 @@ let print_usage_channel co command =
 \n  -coqlib dir            set coqchk's standard library location\
 \n  -where                 print coqchk's standard library location and exit\
 \n  -v                     print coqchk version and exit\
-\n  -boot                  boot mode\
 \n  -o, --output-context   print the list of assumptions\
 \n  -m, --memory           print the maximum heap size\
 \n  -silent                disable trace of constants being checked\
@@ -320,8 +319,6 @@ let explain_exn = function
 let deprecated flag =
   Feedback.msg_warning (str "Deprecated flag " ++ quote (str flag))
 
-let boot_opt = ref false
-
 let parse_args argv =
   let rec parse = function
     | [] -> ()
@@ -358,7 +355,6 @@ let parse_args argv =
     | ("-?"|"-h"|"-H"|"-help"|"--help") :: _ -> usage ()
 
     | ("-v"|"--version") :: _ -> version ()
-    | "-boot" :: rem -> boot_opt := true; parse rem
     | ("-m" | "--memory") :: rem -> Check_stat.memory_stat := true; parse rem
     | ("-o" | "--output-context") :: rem ->
         Check_stat.output_context := true; parse rem

--- a/man/coqide.1
+++ b/man/coqide.1
@@ -100,15 +100,6 @@ Skip loading of rcfile.
 Set the rcfile to
 .IR f .
 .TP
-.B \-batch
-Batch mode (exits just after arguments parsing).
-.TP
-.B \-boot
-Boot mode (implies
-.B \-q
-and
-.BR \-batch ).
-.TP
 .B \-emacs
 Tells Coq it is executed under Emacs.
 .TP

--- a/man/coqtop.1
+++ b/man/coqtop.1
@@ -106,12 +106,6 @@ set the rcfile to
 batch mode (exits just after arguments parsing)
 
 .TP
-.B \-boot
-boot mode (implies
-.B \-q
-)
-
-.TP
 .B \-emacs
 tells Coq it is executed under Emacs
 

--- a/stm/stm.mli
+++ b/stm/stm.mli
@@ -67,10 +67,6 @@ type stm_init_options = {
      some point. *)
   doc_type     : stm_doc_type;
 
-  (* Allow compiling modules in the Coq prefix. Irrelevant in
-     interactive mode. *)
-  allow_coq_overwrite : bool;
-
   (* Initial load path in scope for the document. Usually extracted
      from -R options / _CoqProject *)
   iload_path   : Mltop.coq_path list;

--- a/test-suite/bugs/closed/bug_5198.v
+++ b/test-suite/bugs/closed/bug_5198.v
@@ -1,4 +1,4 @@
-(* -*- mode: coq; coq-prog-args: ("-boot" "-nois") -*- *)
+(* -*- mode: coq; coq-prog-args: ("-nois") -*- *)
 (* File reduced by coq-bug-finder from original input, then from 286 lines to
 27 lines, then from 224 lines to 53 lines, then from 218 lines to 56 lines,
 then from 269 lines to 180 lines, then from 132 lines to 48 lines, then from

--- a/tools/coq_dune.ml
+++ b/tools/coq_dune.ml
@@ -186,7 +186,7 @@ let pp_vo_dep dir fmt vo =
   (* We explicitly include the location of coqlib to avoid tricky issues with coqlib location *)
   let libflag = "-coqlib %{project_root}" in
   (* The final build rule *)
-  let action = sprintf "(chdir %%{project_root} (run coqc -boot %s %s %s %s))" libflag eflag cflag source in
+  let action = sprintf "(chdir %%{project_root} (run coqc -q %s %s %s %s))" libflag eflag cflag source in
   let all_targets = gen_coqc_targets vo in
   pp_rule fmt all_targets deps action
 

--- a/tools/coq_tex.ml
+++ b/tools/coq_tex.ml
@@ -259,8 +259,6 @@ let parse_cl () =
 	"           Coq parts are written between 2 horizontal lines";
 	"-small", Arg.Set small,
 	"           Coq parts are written in small font";
-	"-boot", Arg.Set boot,
-	"            Launch coqtop with the -boot option"
       ]
       (fun s -> files := s :: !files)
       "coq-tex [options] file ..."
@@ -279,7 +277,6 @@ let find_coqtop () =
 let _ =
   parse_cl ();
   if !image = "" then image := Filename.quote (find_coqtop ());
-  if !boot then image := !image ^ " -boot";
   if Sys.command (!image ^ " -batch -silent") <> 0 then begin
     Printf.printf "Error: ";
     let _ = Sys.command (!image ^ " -batch") in

--- a/toplevel/ccompile.ml
+++ b/toplevel/ccompile.ml
@@ -112,7 +112,6 @@ let compile opts copts ~echo ~f_in ~f_out =
       let doc, sid = Topfmt.(in_phase ~phase:LoadingPrelude)
           Stm.new_doc
           Stm.{ doc_type = VoDoc long_f_dot_vo;
-                allow_coq_overwrite = opts.boot;
                 iload_path; require_libs; stm_options;
               } in
       let state = { doc; sid; proof = None; time = opts.time } in
@@ -163,7 +162,6 @@ let compile opts copts ~echo ~f_in ~f_out =
       let doc, sid = Topfmt.(in_phase ~phase:LoadingPrelude)
           Stm.new_doc
           Stm.{ doc_type = VioDoc long_f_dot_vio;
-                allow_coq_overwrite = opts.boot;
                 iload_path; require_libs; stm_options;
               } in
 

--- a/toplevel/coqargs.ml
+++ b/toplevel/coqargs.ml
@@ -40,8 +40,6 @@ type native_compiler = NativeOff | NativeOn of { ondemand : bool }
 
 type t = {
 
-  boot : bool;
-
   load_init   : bool;
   load_rcfile : bool;
   rcfile      : string option;
@@ -92,8 +90,6 @@ let default_native =
   else NativeOff
 
 let default = {
-
-  boot = false;
 
   load_init   = true;
   load_rcfile = true;
@@ -178,6 +174,10 @@ let set_color opts = function
 let warn_deprecated_inputstate =
   CWarnings.create ~name:"deprecated-inputstate" ~category:"deprecated"
          (fun () -> Pp.strbrk "The inputstate option is deprecated and discouraged.")
+
+let warn_deprecated_boot =
+  CWarnings.create ~name:"deprecated-boot" ~category:"noop"
+         (fun () -> Pp.strbrk "The -boot option is deprecated, please use -q and/or -coqlib options instead.")
 
 let set_inputstate opts s =
   warn_deprecated_inputstate ();
@@ -459,7 +459,9 @@ let parse_args ~help ~init arglist : t * string list =
       { oval with batch = true }
     |"-test-mode" -> Flags.test_mode := true; oval
     |"-beautify" -> Flags.beautify := true; oval
-    |"-boot" -> { oval with boot = true; load_rcfile = false; }
+    |"-boot" ->
+      warn_deprecated_boot ();
+      { oval with load_rcfile = false; }
     |"-bt" -> Backtrace.record_backtrace true; oval
     |"-color" -> set_color oval (next ())
     |"-config"|"--config" -> { oval with print_config = true }

--- a/toplevel/coqargs.mli
+++ b/toplevel/coqargs.mli
@@ -16,8 +16,6 @@ type native_compiler = NativeOff | NativeOn of { ondemand : bool }
 
 type t = {
 
-  boot : bool;
-
   load_init   : bool;
   load_rcfile : bool;
   rcfile      : string option;

--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -221,7 +221,6 @@ let init_toploop opts =
   let doc, sid =
     Stm.(new_doc
            { doc_type = Interactive opts.toplevel_name;
-             allow_coq_overwrite = true; (* irrelevant *)
              iload_path; require_libs; stm_options;
            }) in
   let state = { doc; sid; proof = None; time = opts.time } in

--- a/toplevel/usage.ml
+++ b/toplevel/usage.ml
@@ -62,7 +62,6 @@ let print_usage_common co command =
 \n\
 \n  -q                     skip loading of rcfile\
 \n  -init-file f           set the rcfile to f\
-\n  -boot                  boot mode (allows to overload the `Coq` library prefix, implies -q)\
 \n  -bt                    print backtraces (requires configure debug flag)\
 \n  -debug                 debug mode (implies -bt)\
 \n  -diffs (on|off|removed) highlight differences between proof steps\


### PR DESCRIPTION
The `-boot` option was used to:

- suppress loading of the rc_file
- allow to save modules with prefix `Coq`

There is no good reason disable saving of modules with `Coq` prefix by
default, thus we remove this option.

Fixes: #9575
D̶e̶p̶e̶n̶d̶s̶ ̶o̶n̶:̶ ̶#̶9̶5̶6̶0̶ ̶