### PR TITLE
Fix a problem with -mangle-names and inductive definitions.

### DIFF
--- a/interp/constrintern.mli
+++ b/interp/constrintern.mli
@@ -48,9 +48,9 @@ type var_internalization_data =
       (* type of the "free" variable, for coqdoc, e.g. while typing the
          constructor of JMeq, "JMeq" behaves as a variable of type Inductive *)
 
-    Id.t list *
+    (Id.t * Id.t) list *
       (* impargs to automatically add to the variable, e.g. for "JMeq A a B b"
-         in implicit mode, this is [A;B] and this adds (A:=A) and (B:=B) *)
+         in implicit mode, this is [(arg_1,A);(arg_2,B)] and this adds (arg_1:=A) and (arg_2:=B) *)
 
     Impargs.implicit_status list * (* signature of impargs of the variable *)
     Notation_term.scope_name option list (* subscopes of the args of the variable *)

--- a/test-suite/bugs/closed/bug_8790.v
+++ b/test-suite/bugs/closed/bug_8790.v
@@ -1,0 +1,5 @@
+Set Mangle Names.
+
+Inductive TCForall {A} (P : A -> Prop) : list A -> Prop :=
+| TCForall_nil : TCForall P nil
+| TCForall_cons x xs : P x -> TCForall P xs -> TCForall P (cons x xs).


### PR DESCRIPTION
We track separately the argument name and parameter name, and insert explicit applications of the form `(arg_1 := A)` rather than `(arg_1 := arg_1)`. Usually argument names agree with user-given parameter names in the absence of repeated parameter names, but `-mangle-names` breaks this invariant, so while default argument names need to be refreshed, this change is useful.

With `-mangle-names`, the default argument names will still be mangled, so need an explicit `Arguments` command to fix the names, but this at least removes a confusing error case.

**Kind:** bug fix

Fixes / closes #8790

- [x] Added / updated test-suite
