### PR TITLE
When Nix build is finished and pushed to Cachix, update a specific branch.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -209,6 +209,17 @@ after_script:
     variables:
       - $WINDOWS =~ /enabled/
 
+.deploy-template: &deploy-template
+  stage: deploy
+  before_script:
+    - which ssh-agent || ( apt-get update -y && apt-get install openssh-client -y )
+    - eval $(ssh-agent -s)
+    - mkdir -p ~/.ssh
+    - chmod 700 ~/.ssh
+    - ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
+    - git config --global user.name "coqbot"
+    - git config --global user.email "coqbot@users.noreply.github.com"
+
 build:base:
   <<: *build-template
   variables:
@@ -357,7 +368,7 @@ doc:stdlib:dune:
       - _build/default/doc/stdlib/html
 
 doc:refman:deploy:
-  stage: deploy
+  <<: *deploy-template
   environment:
     name: deployment
     url: https://coq.github.io/
@@ -368,14 +379,6 @@ doc:refman:deploy:
     - doc:ml-api:odoc
     - doc:refman:dune
     - doc:stdlib:dune
-  before_script:
-    - which ssh-agent || ( apt-get update -y && apt-get install openssh-client -y )
-    - eval $(ssh-agent -s)
-    - mkdir -p ~/.ssh
-    - chmod 700 ~/.ssh
-    - ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
-    - git config --global user.name "coqbot"
-    - git config --global user.email "coqbot@users.noreply.github.com"
   script:
     - echo "$DOCUMENTATION_DEPLOY_KEY" | tr -d '\r' | ssh-add - > /dev/null
     - git clone git@github.com:coq/doc.git _deploy

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -336,6 +336,21 @@ pkg:nix:deploy:
     - master
     - /^v.*\..*$/
 
+pkg:nix:deploy:channel:
+  <<: *deploy-template
+  environment:
+    name: cachix
+    url: https://coq.cachix.org
+  only:
+    variables:
+      - $CACHIX_DEPLOYMENT_KEY
+  dependencies:
+    - pkg:nix:deploy
+  script:
+    - echo "$CACHIX_DEPLOYMENT_KEY" | tr -d '\r' | ssh-add - > /dev/null
+    - git fetch --unshallow
+    - git push git@github.com:coq/coq-on-cachix "${CI_COMMIT_REF_NAME}"
+
 pkg:nix:
   <<: *nix-template
   except:


### PR DESCRIPTION
This should allow CI jobs that use our Cachix to only test against Coq versions that are already available in Cachix, avoiding very long build and timeouts e.g. in the math-classes CI.

<!-- Keep what applies -->
**Kind:** infrastructure.

I'm opening this PR as an RFC. I have modeled this on the way the refman is deployed. However, I have not yet created the required ssh key and the GITHUB_DEPLOY_KEY environment variable.

The idea is that a job is run in the deploy phase which updates a branch (e.g. master-cachix) to reflect the latest commit that is known to build with Nix and has been deployed to Cachix. Thus, people can rely on this branch instead of master and expect that they will be able to fetch the binary without having to rebuild it.

If people do not like having these additional branches on the Coq repository itself, we could create another repository for this (in the style of https://github.com/NixOS/nixpkgs-channels).

Note: I'm using the draft mode mostly for testing it. It's great news that GitHub decided to add this!