### PR TITLE
CI: fix trunk jobs switch picking

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -436,7 +436,7 @@ test-suite:edge+trunk+make:
     - make -j "$NJOBS" world
     - make -j "$NJOBS" test-suite UNIT_TESTS=
   variables:
-    OPAM_SWITCH: edge
+    OPAM_SWITCH: base
   artifacts:
     name: "$CI_JOB_NAME.logs"
     when: always
@@ -462,7 +462,7 @@ test-suite:edge+trunk+dune:
     - export COQ_UNIT_TEST=noop
     - dune runtest --profile=ocaml409
   variables:
-    OPAM_SWITCH: edge
+    OPAM_SWITCH: base
   artifacts:
     name: "$CI_JOB_NAME.logs"
     when: always


### PR DESCRIPTION
After #9590

Instead of this we could override before_script, either duplicating the debug
prints or just not doing debug prints for the trunk jobs.
