### PR TITLE
[kernel] termination checking: backtrack on stuck case, fix, proj

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -48,6 +48,13 @@ Kernel
 
 - Added primitive integers
 
+- Unfolding heuristic in termination checking made more complete.
+  In particular Coq is now more aggressive in unfolding constants
+  when it looks for a iota redex. Performance regression may occur
+  in Fixpoint declarations without an explicit {struct} annotation,
+  since guessing the decreasing argument can now be more expensive.
+  (PR #9602)
+
 Notations
 
 - New command `Declare Scope` to explicitly declare a scope name

--- a/dev/ci/user-overlays/09602-gares-more-delta-in-termination-checking.sh
+++ b/dev/ci/user-overlays/09602-gares-more-delta-in-termination-checking.sh
@@ -1,0 +1,6 @@
+if [ "$CI_PULL_REQUEST" = "9602" ] || [ "$CI_BRANCH" = "more-delta-in-termination-checking" ]; then
+
+    equations_CI_REF=more-delta-in-termination-checking
+    equations_CI_GITURL=https://github.com/gares/Coq-Equations
+
+fi

--- a/test-suite/bugs/closed/bug_9598.v
+++ b/test-suite/bugs/closed/bug_9598.v
@@ -9,3 +9,15 @@ Module case.
   Fixpoint rec_ko (x : nat) : nat := fst (alias_K 0 (rec_ko x)).
 
 End case.
+
+Module fixpoint.
+
+  Inductive pair := K (n1 : nat) (n2 : nat).
+  Fixpoint fst (p : pair) : nat := match p with K n _ => n end.
+
+  Definition alias_K a b := K a b.
+
+  Fixpoint rec (x : nat) : nat := fst (K 0 (rec x)).
+  Fixpoint rec_ko (x : nat) : nat := fst (alias_K 0 (rec_ko x)).
+
+End fixpoint.

--- a/test-suite/bugs/closed/bug_9598.v
+++ b/test-suite/bugs/closed/bug_9598.v
@@ -21,3 +21,16 @@ Module fixpoint.
   Fixpoint rec_ko (x : nat) : nat := fst (alias_K 0 (rec_ko x)).
 
 End fixpoint.
+
+Module primproj.
+
+  Set Primitive Projections.
+
+  Inductive pair := K { fst : nat; snd : nat }.
+
+  Definition alias_K a b := K a b.
+
+  Fixpoint rec (x : nat) : nat := fst (K 0 (rec x)).
+  Fixpoint rec_ko (x : nat) : nat := fst (alias_K 0 (rec_ko x)).
+
+End primproj.

--- a/test-suite/bugs/closed/bug_9598.v
+++ b/test-suite/bugs/closed/bug_9598.v
@@ -1,0 +1,11 @@
+Module case.
+
+  Inductive pair := K (n1 : nat) (n2 : nat).
+  Definition fst (p : pair) : nat := match p with K n _ => n end.
+
+  Definition alias_K a b := K a b.
+
+  Fixpoint rec (x : nat) : nat := fst (K 0 (rec x)).
+  Fixpoint rec_ko (x : nat) : nat := fst (alias_K 0 (rec_ko x)).
+
+End case.


### PR DESCRIPTION
Unfolding heuristic in termination checking made more complete.
In particular Coq is now more aggressive in unfolding constants
when it looks for a iota redex. Performance regression may occur
in Fixpoint declarations without an explicit {struct} annotation,
since guessing the decreasing argument can now be more expensive.

Fix #9598 