### PR TITLE
Gramlib: Fixes #9358 (ensuring that requested locations are effectively computed at lexing time)

### DIFF
--- a/gramlib/grammar.ml
+++ b/gramlib/grammar.ml
@@ -1368,6 +1368,9 @@ let parse_parsable entry p =
   let get_loc () =
     try
       let cnt = Stream.count ts in
+      (* Ensure that the token at location cnt has been peeked so that
+         the location function knows about it *)
+      let _ = Stream.peek ts in
       let loc = fun_loc cnt in
       if !token_count - 1 <= cnt then loc
       else Loc.merge loc (fun_loc (!token_count - 1))


### PR DESCRIPTION
**Kind:** bug fix

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #9358

- [ ] Added / updated test-suite (no test added: I don't know at once how to test a parsing error - `Fail` does not capture them)

We take the shortest path. (I thought it would be possible to attach the locations to the tokens, but gramlib is requesting locations without having a token at hand, so that seems difficult to do and I renounce to investigate this further.)