### PR TITLE
[ci] add metacoq

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -731,9 +731,23 @@ plugin:ci-elpi:
 
 plugin:ci-equations:
   extends: .ci-template
+  artifacts:
+    name: "$CI_JOB_NAME"
+    paths:
+      - _build_ci
 
 plugin:ci-fiat_parsers:
   extends: .ci-template
+
+plugin:ci-metacoq:
+  extends: .ci-template
+  stage: stage-3
+  needs:
+  - build:base
+  - plugin:ci-equations
+  dependencies:
+  - build:base
+  - plugin:ci-equations
 
 plugin:ci-mtac2:
   extends: .ci-template

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -33,6 +33,7 @@ CI_TARGETS= \
     ci-iris-lambda-rust \
     ci-math-classes \
     ci-math-comp \
+    ci-metacoq \
     ci-mtac2 \
     ci-paramcoq \
     ci-perennial \
@@ -71,6 +72,8 @@ ci-fiat-crypto: ci-coqprime ci-rewriter
 
 ci-simple-io: ci-ext-lib
 ci-quickchick: ci-ext-lib ci-simple-io
+
+ci-metacoq: ci-equations
 
 # Generic rule, we use make to ease CI integration
 $(CI_TARGETS): ci-%:

--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -330,3 +330,10 @@
 : "${perennial_CI_REF:=master}"
 : "${perennial_CI_GITURL:=https://github.com/mit-pdos/perennial}"
 : "${perennial_CI_ARCHIVEURL:=${perennial_CI_GITURL}/archive}"
+
+########################################################################
+# metacoq
+########################################################################
+: "${metacoq_CI_REF:=master}"
+: "${metacoq_CI_GITURL:=https://github.com/MetaCoq/metacoq}"
+: "${metacoq_CI_ARCHIVEURL:=${metacoq_CI_GITURL}/archive}"

--- a/dev/ci/ci-equations.sh
+++ b/dev/ci/ci-equations.sh
@@ -5,4 +5,4 @@ ci_dir="$(dirname "$0")"
 
 git_download equations
 
-( cd "${CI_BUILD_DIR}/equations" && ./configure.sh coq && make ci)
+( cd "${CI_BUILD_DIR}/equations" && ./configure.sh coq && make ci && make install )

--- a/dev/ci/ci-metacoq.sh
+++ b/dev/ci/ci-metacoq.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+ci_dir="$(dirname "$0")"
+. "${ci_dir}/ci-common.sh"
+
+git_download metacoq
+
+( cd "${CI_BUILD_DIR}/metacoq" && ./configure.sh local && make ci-local && make install )


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

If you thought we didn't exercise the kernel's interfaces and extraction enough, here's a way to do it. This adds metacoq to the CI. The build is short (~6min) but a bit intricate (it separately builds various packed ocaml libraries depending on each other) and I only tested on Linux Travis instances so it might fail on other platforms.