### PR TITLE
Stdlib HTML documentation: fix a few absolute URLs

### DIFF
--- a/doc/common/styles/html/coqremote/header.html
+++ b/doc/common/styles/html/coqremote/header.html
@@ -4,12 +4,12 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />
-<link type="text/css" rel="stylesheet" media="all" href="/modules/node/node.css" />
-<link type="text/css" rel="stylesheet" media="all" href="/modules/system/defaults.css" />
-<link type="text/css" rel="stylesheet" media="all" href="/modules/system/system.css" />
-<link type="text/css" rel="stylesheet" media="all" href="/modules/user/user.css" />
-<link type="text/css" rel="stylesheet" media="all" href="/sites/all/themes/coq/style.css" />
-<link type="text/css" rel="stylesheet" media="all" href="/sites/all/themes/coq/coqdoc.css" />
+<link type="text/css" rel="stylesheet" media="all" href="//coq.inria.fr/modules/node/node.css" />
+<link type="text/css" rel="stylesheet" media="all" href="//coq.inria.fr/modules/system/defaults.css" />
+<link type="text/css" rel="stylesheet" media="all" href="//coq.inria.fr/modules/system/system.css" />
+<link type="text/css" rel="stylesheet" media="all" href="//coq.inria.fr/modules/user/user.css" />
+<link type="text/css" rel="stylesheet" media="all" href="//coq.inria.fr/sites/all/themes/coq/style.css" />
+<link type="text/css" rel="stylesheet" media="all" href="//coq.inria.fr/sites/all/themes/coq/coqdoc.css" />
 
 <title>Standard Library | The Coq Proof Assistant</title>
 
@@ -21,20 +21,20 @@
   <div id="headertop">
     <div id="nav">
       <ul class="links-menu">
-        <li><a href="/" class="active">Home</a></li>
-        <li><a href="/about-coq" title="More about coq">About Coq</a></li>
-        <li><a href="/download">Get Coq</a></li>
-        <li><a href="/documentation">Documentation</a></li>
-        <li><a href="/community">Community</a></li>
+        <li><a href="//coq.inria.fr/" class="active">Home</a></li>
+        <li><a href="//coq.inria.fr/about-coq" title="More about coq">About Coq</a></li>
+        <li><a href="//coq.inria.fr/download">Get Coq</a></li>
+        <li><a href="//coq.inria.fr/documentation">Documentation</a></li>
+        <li><a href="//coq.inria.fr/community">Community</a></li>
       </ul>
     </div>
   </div>
 
   <div id="header">
     <div id="logoWrapper">
-      <div id="logo"><a href="/" title="Home"><img src="/files/barron_logo.png" alt="Home" /></a>
+      <div id="logo"><a href="//coq.inria.fr/" title="Home"><img src="//coq.inria.fr/files/barron_logo.png" alt="Home" /></a>
       </div>
-      <div id="siteName"><a href="/" title="Home">The Coq Proof Assistant</a>
+      <div id="siteName"><a href="//coq.inria.fr/" title="Home">The Coq Proof Assistant</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
This fixes the rendering of the HTML documentation of the stdlib when served from a different domain than `coq.inria.fr` (e.g., at https://coq.github.io/doc/master/stdlib/).