### PR TITLE
[ci] [ocaml] Support OCaml 4.08

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,7 @@ stages:
 variables:
   # Format: $IMAGE-V$DATE [Cache is not used as of today but kept here
   # for reference]
-  CACHEKEY: "bionic_coq-V2019-06-11-V1"
+  CACHEKEY: "bionic_coq-V2019-06-16-V1"
   IMAGE: "$CI_REGISTRY_IMAGE:$CACHEKEY"
   # By default, jobs run in the base switch; override to select another switch
   OPAM_SWITCH: "base"

--- a/INSTALL
+++ b/INSTALL
@@ -31,7 +31,7 @@ WHAT DO YOU NEED ?
 
    - OCaml (version >= 4.05.0)
      (available at https://ocaml.org/)
-     (This version of Coq has been tested up to OCaml 4.07.0)
+     (This version of Coq has been tested up to OCaml 4.08.0)
 
    - The Num package, which used to be part of the OCaml standard library,
      if you are using an OCaml version >= 4.06.0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,7 +67,7 @@ jobs:
       opam list
     displayName: 'Install OCaml dependencies'
     env:
-      COMPILER: "4.07.1"
+      COMPILER: "4.08.0"
       FINDLIB_VER: ".1.8.0"
       OPAMYES: "true"
 

--- a/checker/analyze.ml
+++ b/checker/analyze.ml
@@ -395,8 +395,8 @@ end
 module IChannel =
 struct
   type t = in_channel
-  let input_byte = Pervasives.input_byte
-  let input_binary_int = Pervasives.input_binary_int
+  let input_byte = Stdlib.input_byte
+  let input_binary_int = Stdlib.input_binary_int
 end
 
 module IString =

--- a/checker/check.ml
+++ b/checker/check.ml
@@ -66,7 +66,7 @@ module LibraryOrdered =
   struct
     type t = DirPath.t
     let compare d1 d2 =
-      Pervasives.compare
+      Stdlib.compare
         (List.rev (DirPath.repr d1)) (List.rev (DirPath.repr d2))
   end
 

--- a/dev/ci/azure-opam.sh
+++ b/dev/ci/azure-opam.sh
@@ -2,7 +2,7 @@
 
 set -e -x
 
-OPAM_VARIANT=ocaml-variants.4.07.1+mingw64c
+OPAM_VARIANT=ocaml-variants.4.08.0+mingw64c
 
 wget https://github.com/fdopen/opam-repository-mingw/releases/download/0.0.0.2/opam64.tar.xz -O opam64.tar.xz
 tar -xf opam64.tar.xz
@@ -10,4 +10,4 @@ bash opam64/install.sh
 
 opam init default -a -y "https://github.com/fdopen/opam-repository-mingw.git#opam2" -c $OPAM_VARIANT --disable-sandboxing
 eval "$(opam env)"
-opam install -y num ocamlfind dune ounit
+opam install -y num ocamlfind dune stdlib-shims ounit

--- a/dev/ci/docker/bionic_coq/Dockerfile
+++ b/dev/ci/docker/bionic_coq/Dockerfile
@@ -1,4 +1,4 @@
-# CACHEKEY: "bionic_coq-V2019-06-11-V1"
+# CACHEKEY: "bionic_coq-V2019-06-16-V1"
 # ^^ Update when modifying this file.
 
 FROM ubuntu:bionic
@@ -22,7 +22,7 @@ RUN pip3 install sphinx==1.7.8 sphinx_rtd_theme==0.2.5b2 \
                  antlr4-python3-runtime==4.7.1 sphinxcontrib-bibtex==0.4.0
 
 # We need to install OPAM 2.0 manually for now.
-RUN wget https://github.com/ocaml/opam/releases/download/2.0.3/opam-2.0.3-x86_64-linux -O /usr/bin/opam && chmod 755 /usr/bin/opam
+RUN wget https://github.com/ocaml/opam/releases/download/2.0.4/opam-2.0.4-x86_64-linux -O /usr/bin/opam && chmod 755 /usr/bin/opam
 
 # Basic OPAM setup
 ENV NJOBS="2" \
@@ -55,9 +55,9 @@ RUN opam switch create "${COMPILER}+32bit" && eval $(opam env) && \
     opam install $BASE_OPAM
 
 # EDGE switch
-ENV COMPILER_EDGE="4.07.1" \
-    COQIDE_OPAM_EDGE="cairo2.0.6 lablgtk3-sourceview3.3.0.beta5" \
-    BASE_OPAM_EDGE="dune-release.1.1.0"
+ENV COMPILER_EDGE="4.08.0" \
+    COQIDE_OPAM_EDGE="cairo2.0.6 lablgtk3-sourceview3.3.0.beta6" \
+    BASE_OPAM_EDGE="dune-release.1.3.1"
 
 # EDGE+flambda switch, we install CI_OPAM as to be able to use
 # `ci-template-flambda` with everything.

--- a/dev/doc/README.md
+++ b/dev/doc/README.md
@@ -7,7 +7,7 @@ Assuming one is running Ubuntu (if not, replace `apt` with the package manager o
 ```
 $ sudo apt-get install make opam git
 
-# At the time of writing, <latest-ocaml-version> is 4.07.0.
+# At the time of writing, <latest-ocaml-version> is 4.08.0
 # The latest version number is available at: https://ocaml.org/releases/
 
 $ opam init --comp <latest-ocaml-version>

--- a/dev/dune-workspace.all
+++ b/dev/dune-workspace.all
@@ -3,5 +3,5 @@
 ; Add custom flags here. Default developer profile is `dev`
 (context (opam (switch 4.05.0)))
 (context (opam (switch 4.05.0+32bit)))
-(context (opam (switch 4.07.1)))
-(context (opam (switch 4.07.1+flambda)))
+(context (opam (switch 4.08.0)))
+(context (opam (switch 4.08.0+flambda)))

--- a/engine/logic_monad.ml
+++ b/engine/logic_monad.ml
@@ -41,7 +41,7 @@ let _ = CErrors.register_handler begin function
   | Timeout -> CErrors.user_err ~hdr:"Some timeout function" (Pp.str"Timeout!")
   | Exception e -> CErrors.print e
   | TacticFailure e -> CErrors.print e
-  | _ -> Pervasives.raise CErrors.Unhandled
+  | _ -> Stdlib.raise CErrors.Unhandled
 end
 
 (** {6 Non-logical layer} *)
@@ -70,11 +70,11 @@ struct
     let map f a = (); fun () -> f (a ())
   end)
 
-  type 'a ref = 'a Pervasives.ref
+  type 'a ref = 'a Stdlib.ref
 
   let ignore a = (); fun () -> ignore (a ())
 
-  let ref a = (); fun () -> Pervasives.ref a
+  let ref a = (); fun () -> Stdlib.ref a
 
   (** [Pervasives.(:=)] *)
   let (:=) r a = (); fun () -> r := a
@@ -93,7 +93,7 @@ struct
         let (src, info) = CErrors.push src in
         h (e, info) ()
 
-  let read_line = fun () -> try Pervasives.read_line () with e ->
+  let read_line = fun () -> try Stdlib.read_line () with e ->
     let (e, info) = CErrors.push e in raise ~info e ()
 
   let print_char = fun c -> (); fun () -> print_char c

--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -542,7 +542,7 @@ let tclDISPATCHGEN join tacs =
   let tacs = CList.map branch tacs in
   InfoL.tag (Info.Dispatch) (tclDISPATCHGEN0 join tacs)
 
-let tclDISPATCH tacs = tclDISPATCHGEN Pervasives.ignore tacs
+let tclDISPATCH tacs = tclDISPATCHGEN Stdlib.ignore tacs
 
 let tclDISPATCHL tacs = tclDISPATCHGEN CList.rev tacs
 
@@ -910,7 +910,7 @@ let tclPROGRESS t =
 exception Timeout
 let _ = CErrors.register_handler begin function
   | Timeout -> CErrors.user_err ~hdr:"Proofview.tclTIMEOUT" (Pp.str"Tactic timeout!")
-  | _ -> Pervasives.raise CErrors.Unhandled
+  | _ -> Stdlib.raise CErrors.Unhandled
 end
 
 let tclTIMEOUT n t =

--- a/gramlib/grammar.ml
+++ b/gramlib/grammar.ml
@@ -876,7 +876,7 @@ and print_level : type s. _ -> _ -> s ex_symbols list -> _ =
       (fun sep (ExS rule) ->
          fprintf ppf "%t%a" sep print_rule rule;
          fun ppf -> fprintf ppf "%a| " pp_print_space ())
-      (fun ppf -> ()) rules
+      (fun ppf -> ()) rules ppf
   in
   fprintf ppf " ]@]"
 
@@ -901,7 +901,7 @@ let print_levels ppf elev =
          fprintf ppf "@]@;<1 2>";
          print_level ppf pp_force_newline rules;
          fun ppf -> fprintf ppf "@,| ")
-      (fun ppf -> ()) elev
+      (fun ppf -> ()) elev ppf
   in
   ()
 

--- a/ide/protocol/richpp.ml
+++ b/ide/protocol/richpp.ml
@@ -94,7 +94,7 @@ let rich_pp width ppcmds =
     print_close_tag = ignore;
   } in
 
-  pp_set_formatter_tag_functions ft tag_functions;
+  pp_set_formatter_tag_functions ft tag_functions [@ocaml.alert "-deprecated"];
   pp_set_mark_tags ft true;
 
   (* Setting the formatter *)
@@ -107,9 +107,9 @@ let rich_pp width ppcmds =
   (* The whole output must be a valid document. To that
      end, we nest the document inside <pp> tags. *)
   pp_open_box ft 0;
-  pp_open_tag ft "pp";
+  pp_open_tag ft "pp" [@ocaml.alert "-deprecated"];
   Pp.(pp_with ft ppcmds);
-  pp_close_tag ft ();
+  pp_close_tag ft () [@ocaml.alert "-deprecated"];
   pp_close_box ft ();
 
   (* Get the resulting XML tree. *)

--- a/interp/dumpglob.ml
+++ b/interp/dumpglob.ml
@@ -12,13 +12,13 @@ open Util
 
 (* Dump of globalization (to be used by coqdoc) *)
 
-let glob_file = ref Pervasives.stdout
+let glob_file = ref Stdlib.stdout
 
 let open_glob_file f =
-  glob_file := Pervasives.open_out f
+  glob_file := Stdlib.open_out f
 
 let close_glob_file () =
-  Pervasives.close_out !glob_file
+  Stdlib.close_out !glob_file
 
 type glob_output_t =
     | NoGlob
@@ -37,7 +37,7 @@ let dump_to_dotglob () = glob_output := MultFiles
 
 let dump_into_file f =
   if String.equal f "stdout" then
-    (glob_output := StdOut; glob_file := Pervasives.stdout)
+    (glob_output := StdOut; glob_file := Stdlib.stdout)
   else
     (glob_output := File f; open_glob_file f)
 
@@ -45,7 +45,7 @@ let feedback_glob () = glob_output := Feedback
 
 let dump_string s =
   if dump () && !glob_output != Feedback then 
-    Pervasives.output_string !glob_file s
+    Stdlib.output_string !glob_file s
 
 let start_dump_glob ~vfile ~vofile =
   match !glob_output with

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -593,7 +593,7 @@ let rec rawnum_compare s s' =
    try
      for i = 0 to d-1 do if s.[i] != '0' then raise (Comp 1) done;
      for i = d to l-1 do
-       let c = Pervasives.compare s.[i] s'.[i-d] in
+       let c = Stdlib.compare s.[i] s'.[i-d] in
        if c != 0 then raise (Comp c)
      done;
      0
@@ -1242,7 +1242,7 @@ type entry_coercion = notation list
 module EntryCoercionOrd =
  struct
   type t = notation_entry * notation_entry
-   let compare = Pervasives.compare
+   let compare = Stdlib.compare
  end
 
 module EntryCoercionMap = Map.Make(EntryCoercionOrd)

--- a/kernel/nativecode.ml
+++ b/kernel/nativecode.ml
@@ -157,7 +157,7 @@ let dummy_symb = SymbValue (dummy_value ())
 
 let eq_symbol sy1 sy2 =
   match sy1, sy2 with
-  | SymbValue v1, SymbValue v2 -> Pervasives.(=) v1 v2 (** FIXME: how is this even valid? *)
+  | SymbValue v1, SymbValue v2 -> Stdlib.(=) v1 v2 (** FIXME: how is this even valid? *)
   | SymbSort s1, SymbSort s2 -> Sorts.equal s1 s2
   | SymbName n1, SymbName n2 -> Name.equal n1 n2
   | SymbConst kn1, SymbConst kn2 -> Constant.equal kn1 kn2

--- a/lib/future.ml
+++ b/lib/future.ml
@@ -68,7 +68,7 @@ and 'a computation = 'a comput ref
 let unnamed = "unnamed"
 
 let create ?(name=unnamed) ?(uuid=UUID.fresh ()) f x =
-  ref (Ongoing (name, CEphemeron.create (uuid, f, Pervasives.ref x)))
+  ref (Ongoing (name, CEphemeron.create (uuid, f, Stdlib.ref x)))
 let get x =
   match !x with
   | Finished v -> unnamed, UUID.invalid, id, ref (Val v)

--- a/lib/pp.ml
+++ b/lib/pp.ml
@@ -199,7 +199,7 @@ let pp_with ft pp =
     | Ppcmd_comment coms      -> List.iter (pr_com ft) coms
     | Ppcmd_tag(tag, s)       -> pp_open_tag  ft tag;
                                  pp_cmd s;
-                                 pp_close_tag ft ()
+                                 pp_close_tag ft () [@@ocaml.warning "-3"] (* deprecated, but requires 4.08! *)
   in
   try pp_cmd pp
   with reraise ->

--- a/library/summary.ml
+++ b/library/summary.ml
@@ -153,7 +153,7 @@ let (!) r =
     CEphemeron.get (fst !r)
 
 let ref ?(freeze=fun x -> x) ~name init =
-  let r = Pervasives.ref (CEphemeron.create init, name) in
+  let r = Stdlib.ref (CEphemeron.create init, name) in
   declare_summary name
     { freeze_function = (fun ~marshallable -> freeze !r);
       unfreeze_function = ((:=) r);

--- a/plugins/extraction/common.ml
+++ b/plugins/extraction/common.ml
@@ -125,7 +125,7 @@ module KOrd =
 struct
   type t = kind * string
   let compare (k1, s1) (k2, s2) =
-    let c = Pervasives.compare k1 k2 (* OK *) in
+    let c = Stdlib.compare k1 k2 (* OK *) in
     if c = 0 then String.compare s1 s2
     else c
 end

--- a/plugins/ltac/profile_ltac.ml
+++ b/plugins/ltac/profile_ltac.ml
@@ -376,7 +376,7 @@ let get_local_profiling_results () = List.hd Local.(!stack)
    own. *)
 module DData = struct
     type t = Feedback.doc_id * Stateid.t
-    let compare x y = Pervasives.compare x y
+    let compare x y = Stdlib.compare x y
 end
 
 module SM = Map.Make(DData)

--- a/plugins/ltac/tactic_debug.ml
+++ b/plugins/ltac/tactic_debug.ml
@@ -160,7 +160,7 @@ let rec prompt level =
   begin
     let open Proofview.NonLogical in
     Proofview.NonLogical.print_notice (fnl () ++ str "TcDebug (" ++ int level ++ str ") > ") >>
-    if Pervasives.(!batch) then return (DebugOn (level+1)) else
+    if Stdlib.(!batch) then return (DebugOn (level+1)) else
     let exit = (skip:=0) >> (skipped:=0) >> raise Sys.Break in
     Proofview.NonLogical.catch Proofview.NonLogical.read_line
       begin function (e, info) -> match e with

--- a/plugins/micromega/certificate.ml
+++ b/plugins/micromega/certificate.ml
@@ -93,7 +93,7 @@ let dev_form n_spec  p =
 
 let rec fixpoint f x =
   let y' = f x in
-  if Pervasives.(=) y' x then y'
+  if Stdlib.(=) y' x then y'
   else fixpoint f y'
 
 let  rec_simpl_cone n_spec e = 

--- a/plugins/micromega/coq_micromega.ml
+++ b/plugins/micromega/coq_micromega.ml
@@ -1585,7 +1585,7 @@ let compact_proofs (cnf_ff: 'cst cnf) res (cnf_ff': 'cst cnf) =
   let is_proof_compatible (old_cl:'cst clause) (prf,prover) (new_cl:'cst clause) =
     let hyps_idx = prover.hyps prf in
     let hyps = selecti hyps_idx old_cl in
-      is_sublist Pervasives.(=) hyps new_cl in
+      is_sublist Stdlib.(=) hyps new_cl in
 
 
 
@@ -1953,7 +1953,7 @@ open Persistent_cache
 
 module Cache = PHashtable(struct
   type t = (provername * micromega_polys)
-  let equal = Pervasives.(=)
+  let equal = Stdlib.(=)
   let hash  = Hashtbl.hash
 end)
 

--- a/plugins/micromega/csdpcert.ml
+++ b/plugins/micromega/csdpcert.ml
@@ -136,7 +136,7 @@ let pure_sos  l =
     I should nonetheless be able to try something - over Z  > is equivalent to -1  >= *)
  try
   let l = List.combine l (CList.interval 0 (List.length l -1)) in
-  let (lt,i) =  try (List.find (fun (x,_) -> Pervasives.(=) (snd x) Mc.Strict) l)
+  let (lt,i) =  try (List.find (fun (x,_) -> Stdlib.(=) (snd x) Mc.Strict) l)
    with Not_found -> List.hd l in
   let plt = poly_neg (poly_of_term (expr_to_term (fst lt))) in
   let (n,polys) = sumofsquares plt in (* n * (ci * pi^2) *)

--- a/plugins/micromega/mfourier.ml
+++ b/plugins/micromega/mfourier.ml
@@ -15,7 +15,7 @@ open Vect
 
 let debug = false
 
-let compare_float (p : float) q = Pervasives.compare p q
+let compare_float (p : float) q = Stdlib.compare p q
 
 (** Implementation of intervals *)
 open Itv
@@ -587,7 +587,7 @@ struct
   let optimise vect l =
     (* We add a dummy (fresh) variable for vector *)
     let fresh =
-      List.fold_left (fun fr c -> Pervasives.max fr (Vect.fresh c.coeffs)) 0 l in
+      List.fold_left (fun fr c -> Stdlib.max fr (Vect.fresh c.coeffs)) 0 l in
     let cstr = {
       coeffs = Vect.set fresh (Int (-1)) vect ;
       op = Eq ;

--- a/plugins/micromega/polynomial.ml
+++ b/plugins/micromega/polynomial.ml
@@ -278,7 +278,7 @@ and op = |Eq | Ge | Gt
 
 exception Strict
 
-let is_strict c = Pervasives.(=) c.op  Gt
+let is_strict c = Stdlib.(=) c.op  Gt
 
 let eval_op = function
   | Eq -> (=/)
@@ -785,7 +785,7 @@ module ProofFormat =  struct
       let rec xid_of_hyp i l' =
         match l' with
         | [] -> failwith (Printf.sprintf "id_of_hyp %i %s" hyp (string_of_int_list l))
-        | hyp'::l' -> if Pervasives.(=) hyp hyp' then i else xid_of_hyp (i+1) l' in
+        | hyp'::l' -> if Stdlib.(=) hyp hyp' then i else xid_of_hyp (i+1) l' in
       xid_of_hyp 0 l
 
   end
@@ -873,7 +873,7 @@ module ProofFormat =  struct
        let (p,o) = eval_prf_rule (fun i -> IMap.find i env) prf in
        if is_unsat (p,o) then true
        else
-         if Pervasives.(=) rst Done
+         if Stdlib.(=) rst Done
          then
            begin
              Printf.fprintf stdout "Last inference %a %s\n" LinPoly.pp p (string_of_op o);

--- a/plugins/micromega/simplex.ml
+++ b/plugins/micromega/simplex.ml
@@ -651,7 +651,7 @@ let integer_solver lp =
        match find_cut (!nb mod 2) env cr (*x*) sol vm rst tbl with
        | None -> None
        | Some(cr,((v,op),cut)) ->
-          if Pervasives.(=) op Eq
+          if Stdlib.(=) op Eq
           then (* This is a contradiction *)
             Some(Step(vr,CutPrf cut, Done))
           else

--- a/plugins/micromega/sos_lib.ml
+++ b/plugins/micromega/sos_lib.ml
@@ -13,7 +13,7 @@ open Num
 (* Comparisons that are reflexive on NaN and also short-circuiting.          *)
 (* ------------------------------------------------------------------------- *)
 
-let cmp = Pervasives.compare (** FIXME *)
+let cmp = Stdlib.compare (** FIXME *)
 
 let (=?) = fun x y -> cmp x y = 0;;
 let (<?) = fun x y -> cmp x y < 0;;
@@ -491,21 +491,21 @@ let temp_path = Filename.get_temp_dir_name ();;
 (* ------------------------------------------------------------------------- *)
 
 let strings_of_file filename =
-  let fd = try Pervasives.open_in filename
+  let fd = try Stdlib.open_in filename
            with Sys_error _ ->
              failwith("strings_of_file: can't open "^filename) in
   let rec suck_lines acc =
-    try let l = Pervasives.input_line fd in
+    try let l = Stdlib.input_line fd in
         suck_lines (l::acc)
     with End_of_file -> List.rev acc in
   let data = suck_lines [] in
-  (Pervasives.close_in fd; data);;
+  (Stdlib.close_in fd; data);;
 
 let string_of_file filename =
   String.concat "\n" (strings_of_file filename);;
 
 let file_of_string filename s =
-  let fd = Pervasives.open_out filename in
+  let fd = Stdlib.open_out filename in
   output_string fd s; close_out fd;;
 
 

--- a/plugins/micromega/vect.ml
+++ b/plugins/micromega/vect.ml
@@ -148,7 +148,7 @@ let rec add (ve1:t) (ve2:t)  =
   match ve1 , ve2 with
   | [] , v | v , [] -> v
   | (v1,c1)::l1 , (v2,c2)::l2 ->
-     let cmp = Pervasives.compare v1 v2 in
+     let cmp = Stdlib.compare v1 v2 in
      if cmp == 0 then
        let s = add_num c1 c2 in
        if eq_num (Int 0) s
@@ -163,7 +163,7 @@ let rec xmul_add (n1:num) (ve1:t) (n2:num) (ve2:t) =
   | [] , _ -> mul n2 ve2
   | _ , [] -> mul n1 ve1
   | (v1,c1)::l1 , (v2,c2)::l2 ->
-     let cmp = Pervasives.compare v1 v2 in
+     let cmp = Stdlib.compare v1 v2 in
      if cmp == 0 then
        let s = ( n1 */ c1) +/ (n2 */ c2) in
        if eq_num (Int 0) s

--- a/plugins/omega/coq_omega.ml
+++ b/plugins/omega/coq_omega.ml
@@ -500,7 +500,7 @@ let context sigma operation path (t : constr) =
       | (p, Fix ((_,n as ln),(tys,lna,v))) ->
 	  let l = Array.length v in
 	  let v' = Array.copy v in
-          v'.(n)<- loop (Pervasives.(+) i l) p v.(n); (mkFix (ln,(tys,lna,v')))
+          v'.(n)<- loop (Stdlib.(+) i l) p v.(n); (mkFix (ln,(tys,lna,v')))
       | ((P_TYPE :: p), Prod (n,t,c)) ->
           (mkProd (n,loop i p t,c))
       | ((P_TYPE :: p), Lambda (n,t,c)) ->
@@ -684,7 +684,7 @@ let simpl_coeffs path_init path_k =
           | _ -> assert false)
       | _ -> assert false
   in
-  let n = Pervasives.(-) (List.length path_k) (List.length path_init) in
+  let n = Stdlib.(-) (List.length path_k) (List.length path_init) in
   let newc = context sigma (fun _ t -> loop n t) (List.rev path_init) (pf_concl gl)
   in
   convert_concl ~check:false newc DEFAULTcast
@@ -1000,7 +1000,7 @@ let shrink_pair p f1 f2 =
     | t1,t2 ->
 	begin
 	  oprint t1; print_newline (); oprint t2; print_newline ();
-	  flush Pervasives.stdout; CErrors.user_err Pp.(str "shrink.1")
+          flush Stdlib.stdout; CErrors.user_err Pp.(str "shrink.1")
 	end
 
 let reduce_factor p = function

--- a/plugins/omega/omega.ml
+++ b/plugins/omega/omega.ml
@@ -242,7 +242,7 @@ let add_event, history, clear_history =
   (fun () -> !accu),
   (fun () -> accu := [])
 
-let nf_linear = List.sort (fun x y -> Pervasives.(-) y.v x.v)
+let nf_linear = List.sort (fun x y -> Stdlib.(-) y.v x.v)
 
 let nf ((b : bool),(e,(x : int))) = (b,(nf_linear e,x))
 

--- a/plugins/ssr/ssrview.ml
+++ b/plugins/ssr/ssrview.ml
@@ -26,7 +26,7 @@ module AdaptorDb = struct
 
   module AdaptorKind = struct
     type t = kind
-    let compare = Pervasives.compare
+    let compare = Stdlib.compare
   end
   module AdaptorMap = Map.Make(AdaptorKind)
 

--- a/pretyping/classops.ml
+++ b/pretyping/classops.ml
@@ -58,7 +58,7 @@ let cl_typ_ord t1 t2 = match t1, t2 with
   | CL_CONST c1, CL_CONST c2 -> Constant.CanOrd.compare c1 c2
   | CL_PROJ c1, CL_PROJ c2 -> Projection.Repr.CanOrd.compare c1 c2
   | CL_IND i1, CL_IND i2 -> ind_ord i1 i2
-  | _ -> Pervasives.compare t1 t2 (** OK *)
+  | _ -> Stdlib.compare t1 t2 (** OK *)
 
 module ClTyp = struct
   type t = cl_typ

--- a/printing/prettyp.ml
+++ b/printing/prettyp.ml
@@ -114,7 +114,7 @@ let print_impargs_by_name max = function
 let print_one_impargs_list l =
   let imps = List.filter is_status_implicit l in
   let maximps = List.filter Impargs.maximal_insertion_of imps in
-  let nonmaximps = List.subtract Pervasives.(=) imps maximps in (* FIXME *)
+  let nonmaximps = List.subtract Stdlib.(=) imps maximps in (* FIXME *)
   print_impargs_by_name false nonmaximps @
   print_impargs_by_name true maximps
 

--- a/tactics/btermdn.ml
+++ b/tactics/btermdn.ml
@@ -29,7 +29,7 @@ type term_label =
 
 let compare_term_label t1 t2 = match t1, t2 with
 | GRLabel gr1, GRLabel gr2 -> GlobRef.Ordered.compare gr1 gr2
-| _ -> Pervasives.compare t1 t2 (** OK *)
+| _ -> Stdlib.compare t1 t2 (** OK *)
 
 type 'res lookup_res = 'res Dn.lookup_res = Label of 'res | Nothing | Everything
 

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -257,7 +257,7 @@ let clenv_of_prods poly nprods (c, clenv) gl =
     let sigma = Tacmach.New.project gl in
     let ty = Retyping.get_type_of (Proofview.Goal.env gl) sigma c in
     let diff = nb_prod sigma ty - nprods in
-    if Pervasives.(>=) diff 0 then
+    if Stdlib.(>=) diff 0 then
       (* Was Some clenv... *)
       Some (Some diff,
             mk_clenv_from_n gl (Some diff) (c,ty))

--- a/tactics/redops.ml
+++ b/tactics/redops.ml
@@ -10,7 +10,7 @@
 
 open Genredexpr
 
-let union_consts l1 l2 = Util.List.union Pervasives.(=) l1 l2 (* FIXME *)
+let union_consts l1 l2 = Util.List.union Stdlib.(=) l1 l2 (* FIXME *)
 
 let make_red_flag l =
   let rec add_flag red = function

--- a/tools/coqdep.ml
+++ b/tools/coqdep.ml
@@ -297,7 +297,7 @@ module DAG = DAG(struct type t = string let compare = compare end)
 (** TODO: we should share this code with Coqdep_common *)
 module VData = struct
   type t = string list option * string list
-  let compare = Pervasives.compare
+  let compare = compare
 end
 
 module VCache = Set.Make(VData)

--- a/tools/coqdep_common.ml
+++ b/tools/coqdep_common.ml
@@ -357,7 +357,7 @@ let canonize f =
 
 module VData = struct
   type t = string list option * string list
-  let compare = Pervasives.compare
+  let compare = compare
 end
 
 module VCache = Set.Make(VData)

--- a/tools/coqdoc/main.ml
+++ b/tools/coqdoc/main.ml
@@ -396,7 +396,7 @@ let copy src dst =
   try
     let cout = open_out dst in
     try
-      while true do Pervasives.output_char cout (input_char cin) done
+      while true do Stdlib.output_char cout (input_char cin) done
     with End_of_file ->
       close_out cout;
       close_in cin

--- a/tools/coqdoc/output.ml
+++ b/tools/coqdoc/output.ml
@@ -13,9 +13,9 @@ open Index
 
 (*s Low level output *)
 
-let output_char c = Pervasives.output_char !out_channel c
+let output_char c = Stdlib.output_char !out_channel c
 
-let output_string s = Pervasives.output_string !out_channel s
+let output_string s = Stdlib.output_string !out_channel s
 
 let printf s = Printf.fprintf !out_channel s
 
@@ -527,13 +527,13 @@ module Html = struct
   let header () =
     if !header_trailer then
       if !header_file_spec then
-	let cin = Pervasives.open_in !header_file in
+        let cin = Stdlib.open_in !header_file in
 	  try
 	    while true do
-	      let s = Pervasives.input_line cin in
+              let s = Stdlib.input_line cin in
 		printf "%s\n" s
 	    done
-	  with End_of_file -> Pervasives.close_in cin
+          with End_of_file -> Stdlib.close_in cin
       else
 	begin
 	  printf "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\"\n";
@@ -548,13 +548,13 @@ module Html = struct
 
   let trailer () =
     if !header_trailer && !footer_file_spec then
-	let cin = Pervasives.open_in !footer_file in
+        let cin = Stdlib.open_in !footer_file in
 	  try
 	    while true do
-	      let s = Pervasives.input_line cin in
+              let s = Stdlib.input_line cin in
 		printf "%s\n" s
 	    done
-	  with End_of_file -> Pervasives.close_in cin
+          with End_of_file -> Stdlib.close_in cin
     else
       begin
         if !index && (get_module false) <> "Index" then

--- a/toplevel/coqloop.ml
+++ b/toplevel/coqloop.ml
@@ -315,8 +315,8 @@ let coqloop_feed (fb : Feedback.feedback) = let open Feedback in
 (* Flush in a compatible order with 8.5 *)
 (* This mimics the semantics of the old Pp.flush_all *)
 let loop_flush_all () =
-  Pervasives.flush stderr;
-  Pervasives.flush stdout;
+  Stdlib.flush stderr;
+  Stdlib.flush stdout;
   Format.pp_print_flush !Topfmt.std_ft ();
   Format.pp_print_flush !Topfmt.err_ft ()
 

--- a/vernac/comDefinition.ml
+++ b/vernac/comDefinition.ml
@@ -34,7 +34,7 @@ let check_imps ~impsty ~impsbody =
     try
       List.for_all (fun (key, (va:bool*bool*bool)) ->
           (* Pervasives.(=) is OK for this type *)
-          Pervasives.(=) (List.assoc_f Constrexpr_ops.explicitation_eq key impsty) va)
+          Stdlib.(=) (List.assoc_f Constrexpr_ops.explicitation_eq key impsty) va)
         impsbody
     with Not_found -> false
   in

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -519,7 +519,7 @@ let read_recursive_format sl fmt =
     let sl = skip_var_in_recursive_format fmt in
     try split_format_at_ldots [] sl with Exit -> error_not_same ?loc:(fst (List.last (if sl = [] then fmt else sl))) () in
   let rec get_tail = function
-    | (loc,a) :: sepfmt, (_,b) :: fmt when Pervasives.(=) a b -> get_tail (sepfmt, fmt) (* FIXME *)
+    | (loc,a) :: sepfmt, (_,b) :: fmt when Stdlib.(=) a b -> get_tail (sepfmt, fmt) (* FIXME *)
     | [], tail -> skip_var_in_recursive_format tail
     | (loc,_) :: _, ([] | (_,UnpTerminal _) :: _)-> error_not_same ?loc ()
     | _, (loc,_)::_ -> error_not_same ?loc () in
@@ -953,7 +953,7 @@ let join_auxiliary_recursive_types recvars etyps =
     | None, None -> typs
     | Some _, None -> typs
     | None, Some ytyp -> (x,ytyp)::typs
-    | Some xtyp, Some ytyp when Pervasives.(=) xtyp ytyp -> typs (* FIXME *)
+    | Some xtyp, Some ytyp when Stdlib.(=) xtyp ytyp -> typs (* FIXME *)
     | Some xtyp, Some ytyp ->
 	user_err 
 	  (strbrk "In " ++ Id.print x ++ str " .. " ++ Id.print y ++

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -372,7 +372,7 @@ open Pputils
     | (c,(idl,t))::l ->
       match factorize l with
         | (xl,((c', t') as r))::l'
-            when (c : bool) == c' && Pervasives.(=) t t' ->
+            when (c : bool) == c' && Stdlib.(=) t t' ->
           (* FIXME: we need equality on constr_expr *)
           (idl@xl,r)::l'
         | l' -> (idl,(c,t))::l'

--- a/vernac/search.ml
+++ b/vernac/search.ml
@@ -147,7 +147,7 @@ module ConstrPriority = struct
     -(3*(num_symbols t) + size t)
 
   let compare (_,_,_,p1) (_,_,_,p2) =
-    Pervasives.compare p1 p2
+    Stdlib.compare p1 p2
 end
 
 module PriorityQueue = Heap.Functional(ConstrPriority)

--- a/vernac/topfmt.ml
+++ b/vernac/topfmt.ml
@@ -329,8 +329,10 @@ let init_terminal_output ~color =
       Format.pp_set_print_tags !std_ft true;
       Format.pp_set_print_tags !err_ft true
     end;
-  Format.pp_set_formatter_tag_functions !std_ft (tag_handler !std_ft);
+  Format.pp_set_formatter_tag_functions !std_ft (tag_handler !std_ft)
+    [@ocaml.alert "-deprecated"];
   Format.pp_set_formatter_tag_functions !err_ft (tag_handler !err_ft)
+    [@ocaml.alert "-deprecated"]
 
 (* Rules for emacs:
    - Debug/info: emacs_quote_info


### PR DESCRIPTION
The main change is the renaming of `Pervasives -> Stdlib`.

Some `Format` functions have been deprecated, however we have no
backwards alternative so we need to disable the warnings.

Builds now depend on the `stdlib-shims` package in order to be
compatible with OCaml < 4.07.0.
