### PR TITLE
[dune] [refman] Generate coq-refman.install file.

### DIFF
--- a/Makefile.dune
+++ b/Makefile.dune
@@ -87,7 +87,7 @@ test-suite: voboot
 	dune runtest --no-buffer $(DUNEOPT)
 
 refman-html: voboot
-	dune build @refman-html
+	dune build $(DUNEOPT) @refman-html
 
 stdlib-html: voboot
 	dune build @stdlib-html

--- a/doc/dune
+++ b/doc/dune
@@ -15,6 +15,19 @@
  (action
   (run env COQLIB=%{project_root} sphinx-build -j4 %{env:SPHINXWARNOPT=-W} -b html -d sphinx_build/doctrees sphinx sphinx_build/html)))
 
+(include refman-install.inc)
+
+(rule
+ (targets refman-install.gen)
+ (action
+  (with-stdout-to %{targets}
+    (run %{project_root}/tools/gen_install.exe coq-refman doc sphinx_build/html refman/html))))
+
+(alias
+ (name refman-html)
+ (action
+  (diff refman-install.inc refman-install.gen)))
+
 (alias
  (name refman-html)
  (deps sphinx_build))

--- a/doc/refman-install.inc
+++ b/doc/refman-install.inc
@@ -1,0 +1,9 @@
+(rule
+ (targets sphinx_build/html/index.html)
+ (deps sphinx_build)
+ (action (run true)))
+
+(install
+ (section doc)
+ (package coq-refman)
+ (files ("sphinx_build/html/index.html" as "refman/html/index.html")))

--- a/tools/coq_dune.ml
+++ b/tools/coq_dune.ml
@@ -57,11 +57,6 @@ module Aux = struct
       | x::xs, y::ys -> let r = f x y in if r = 0 then lc xs ys else r
     in lc
 
-  let rec pp_list pp sep fmt l = match l with
-    | []  -> ()
-    | [l] -> fprintf fmt "%a" pp l
-    | x::xs -> fprintf fmt "%a%a%a" pp x sep () (pp_list pp sep) xs
-
   let rec pmap f l = match l with
     | []  -> []
     | x :: xs ->
@@ -70,7 +65,7 @@ module Aux = struct
         | Some r -> r :: pmap f xs
       end
 
-  let sep fmt () = fprintf fmt "@;"
+  let pp_sep fmt () = fprintf fmt "@;"
 
   (* Creation of paths, aware of the platform separator. *)
   let bpath l = String.concat Filename.dir_sep l
@@ -154,13 +149,13 @@ let gen_sub n =
 
 let pp_rule fmt targets deps action =
   (* Special printing of the first rule *)
-  let ppl = pp_list pp_print_string sep in
+  let ppl = pp_print_list ~pp_sep pp_print_string in
   let pp_deps fmt l = match l with
     | [] ->
       ()
     | x :: xs ->
-      fprintf fmt "(:pp-file %s)%a" x sep ();
-      pp_list pp_print_string sep fmt xs
+      fprintf fmt "(:pp-file %s)%a" x pp_sep ();
+      pp_print_list ~pp_sep pp_print_string fmt xs
   in
   fprintf fmt
     "@[(rule@\n @[(targets @[%a@])@\n(deps @[%a@])@\n(action @[%a@])@])@]@\n"
@@ -204,7 +199,7 @@ let out_install fmt dir ff =
   let ff = List.concat @@ pmap (function | VO vo -> Some (gen_coqc_targets vo) | _ -> None) ff in
   let pp_ispec fmt tg = fprintf fmt "(%s as coq/%s)" tg (bpath [itarget;tg]) in
   fprintf fmt "(install@\n @[(section lib_root)@\n(package coq)@\n(files @[%a@])@])@\n"
-    (pp_list pp_ispec sep) ff
+    (pp_print_list ~pp_sep pp_ispec) ff
 
 (* For each directory, we must record two things, the build rules and
    the install specification. *)

--- a/tools/dune
+++ b/tools/dune
@@ -46,3 +46,7 @@
  (package coq)
  (modules coq_tex coq_dune)
  (libraries str))
+
+(executable
+ (name gen_install)
+ (modules gen_install))

--- a/tools/gen_install.ml
+++ b/tools/gen_install.ml
@@ -1,0 +1,52 @@
+(* Little utility to gen the install file for a directory *)
+open Format
+
+type install_info =
+  { from : string
+  ; dest : string
+  }
+
+let pp_sep fmt () = fprintf fmt "@;"
+
+let pp_install_info fmt ii =
+  Format.fprintf fmt "@[(\"%s\" as \"%s\")@]" ii.from ii.dest
+
+let pp_install fmt ~package ~section files =
+  Format.fprintf fmt
+    "(install@\n @[(section %s)@\n(package %s)@\n(files @[%a@])@])@\n"
+    section package
+    (Format.pp_print_list ~pp_sep pp_install_info) files
+
+let rec scan_directory directory =
+  if Sys.is_directory directory then
+    let files = List.(map Filename.(concat directory) Array.(to_list Sys.(readdir directory))) in
+    List.(concat (map scan_directory files))
+  else
+    [directory]
+
+(* Base case *)
+let scan_directory directory =
+  Sys.chdir directory;
+  let files = Array.to_list Sys.(readdir ".") in
+  List.(concat (map scan_directory files))
+
+let gen_install ppf ~package ~section ~directory ~target =
+  let files = scan_directory directory in
+  let files = List.map (fun from ->
+      { from = Filename.concat directory from
+      ; dest = Filename.concat target from
+      } ) files in
+  Format.fprintf ppf "@[%a@]%!" (pp_install ~package ~section) files
+
+let _ =
+  Printexc.record_backtrace true;
+  if Array.length Sys.argv <> 5 then
+    begin
+      Format.eprintf "[usage] gen_install package section directory target@\n%!";
+      exit 1
+    end;
+  let package = Sys.argv.(1) in
+  let section = Sys.argv.(2) in
+  let directory = Sys.argv.(3) in
+  let target = Sys.argv.(4) in
+  gen_install Format.std_formatter ~package ~section ~directory ~target


### PR DESCRIPTION
We generate a coq-refman install file manually as Dune still doesn't
have install rules for directories.

This should be solved upstream soon tho, but it is useful for some
cases now.
