### PR TITLE
Fix gitattributes for Makefile.dune

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,10 +11,6 @@
 # chunk, so we disable blank-at-eof.
 * -whitespace
 
-# tabs are allowed in Makefiles.
-Makefile* whitespace=blank-at-eol
-tools/CoqMakefile.in whitespace=blank-at-eol
-
 # in general we don't want tabs.
 *.asciidoc whitespace=blank-at-eol,tab-in-indent
 *.bib whitespace=blank-at-eol,tab-in-indent
@@ -58,6 +54,10 @@ dune* whitespace=blank-at-eol,tab-in-indent
 .gitattributes whitespace=blank-at-eol,tab-in-indent
 _CoqProject whitespace=blank-at-eol,tab-in-indent
 Dockerfile whitespace=blank-at-eol,tab-in-indent
+
+# tabs are allowed in Makefiles.
+Makefile* whitespace=blank-at-eol
+tools/CoqMakefile.in whitespace=blank-at-eol
 
 # CR is desired for these Windows files.
 *.bat whitespace=cr-at-eol,blank-at-eol,tab-in-indent


### PR DESCRIPTION
Since it matches *.dune and Makefile* the later needs to come second
in the gitattributes file.
