### PR TITLE
[dune] Enable optimization options in the compilation of the VM.

### DIFF
--- a/dune
+++ b/dune
@@ -8,6 +8,13 @@
  (ocaml409
   (flags :standard -strict-sequence -strict-formats -keep-locs -rectypes -w -9-27+40+60 -warn-error -5 -alert --deprecated)))
 
+; Information about flags for release mode:
+;
+; In #9665 we tried to add (c_flags -O3) to the release setup,
+; unfortunately the resulting VM seems to be slower [5% slower on
+; fourcolor, thus we keep the default C flags for now, which seem to
+; be -O2.
+
 ; The _ profile could help factoring the above, however it doesn't
 ; seem to work like we'd expect/like:
 ;

--- a/topbin/dune
+++ b/topbin/dune
@@ -26,6 +26,8 @@
  (package coq)
  (modules coqc_bin)
  (libraries coq.toplevel)
+ ; Adding -ccopt -flto to links options could be interesting, however,
+ ; it doesn't work on Windows
  (link_flags -linkall))
 
 (install


### PR DESCRIPTION
As we were waiting for better control of the optimisation flags in
Dune [likely coming in 1.8], we didn't setup optimization flags for
the VM in the Dune build.

However time has come to experiment with such flags, we try -O3 and
enable -flto in the final binary build. This should provide pretty
good results, and hopefully be stable.

Does anyone have a good benchmark for the VM reduction machine?

Maybe @JasonGross ?
