### PR TITLE
Dune: remove -short-paths flag.

### DIFF
--- a/dune
+++ b/dune
@@ -1,12 +1,12 @@
 ; Default flags for all Coq libraries.
 (env
- (dev     (flags :standard -rectypes -w -9-27+40+60))
+ (dev     (flags :standard -rectypes -w -9-27+40+60 \ -short-paths))
  (release (flags :standard -rectypes)
           (ocamlopt_flags -O3 -unbox-closures))
  (ireport (flags :standard -rectypes -w -9-27-40+60)
           (ocamlopt_flags :standard -O3 -unbox-closures -inlining-report))
  (ocaml409
-  (flags :standard -strict-sequence -strict-formats -short-paths -keep-locs -rectypes -w -9-27+40+60 -warn-error -5 -alert --deprecated)))
+  (flags :standard -strict-sequence -strict-formats -keep-locs -rectypes -w -9-27+40+60 -warn-error -5 -alert --deprecated)))
 
 ; The _ profile could help factoring the above, however it doesn't
 ; seem to work like we'd expect/like:


### PR DESCRIPTION
Take this example:
~~~ocaml
module M = struct
  type a
  let f (x:a) = x
end

type b = M.a

let _ = M.f 2
~~~
With this PR get this error message:

    Error: This expression has type int but an expression was expected of type M.a

instead of the following one:

    Error: This expression has type int but an expression was expected of type b

The first error message is best because we have numerous aliases in Coq's source code (eg for backward compatibility, of for documentation, eg `module_ident = Id.t` in names). Of course you don't want to see `module_ident` wherever an `Id.t` is used.

See https://github.com/ocaml/dune/issues/1794 https://caml.inria.fr/mantis/view.php?id=7911
