### PR TITLE
[vernac] Small cleanup to remove assert false.

### DIFF
--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -2077,7 +2077,7 @@ end = struct (* {{{ *)
       let rec find ~time ~batch ~fail = function
         | VernacTime (batch,{CAst.v=e}) -> find ~time:true ~batch ~fail e
         | VernacRedirect (_,{CAst.v=e}) -> find ~time ~batch ~fail e
-        | VernacFail e -> find ~time ~batch ~fail:true e
+        | VernacFail {CAst.v=e} -> find ~time ~batch ~fail:true e
         | e -> e, time, batch, fail in
       find ~time:false ~batch:false ~fail:false e in
     let st = Vernacstate.freeze_interp_state ~marshallable:false in

--- a/stm/vernac_classifier.ml
+++ b/stm/vernac_classifier.ml
@@ -206,10 +206,10 @@ let classify_vernac e =
     | VernacExpr (f, e) ->
       let poly = Attributes.(parse_drop_extra polymorphic_nowarn f) in
       static_classifier ~poly e
-    | VernacTimeout (_,e) -> static_control_classifier e
+    | VernacTimeout (_,{v=e}) -> static_control_classifier e
     | VernacTime (_,{v=e}) | VernacRedirect (_, {v=e}) ->
        static_control_classifier e
-    | VernacFail e -> (* Fail Qed or Fail Lemma must not join/fork the DAG *)
+    | VernacFail {v=e} -> (* Fail Qed or Fail Lemma must not join/fork the DAG *)
         (match static_control_classifier e with
         | ( VtQuery | VtProofStep _ | VtSideff _
           | VtMeta), _ as x -> x

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -80,8 +80,8 @@ GRAMMAR EXTEND Gram
   vernac_control: FIRST
     [ [ IDENT "Time"; c = located_vernac -> { VernacTime (false,c) }
       | IDENT "Redirect"; s = ne_string; c = located_vernac -> { VernacRedirect (s, c) }
-      | IDENT "Timeout"; n = natural; v = vernac_control -> { VernacTimeout(n,v) }
-      | IDENT "Fail"; v = vernac_control -> { VernacFail v }
+      | IDENT "Timeout"; n = natural; v = located_vernac -> { VernacTimeout(n,v) }
+      | IDENT "Fail"; v = located_vernac -> { VernacFail v }
       | v = decorated_vernac -> { let (f, v) = v in VernacExpr(f, v) } ]
     ]
   ;

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -1277,9 +1277,9 @@ let pr_vernac_attributes =
       return (keyword "Time" ++ spc() ++ pr_vernac_control v)
     | VernacRedirect (s, {v}) ->
       return (keyword "Redirect" ++ spc() ++ qs s ++ spc() ++ pr_vernac_control v)
-    | VernacTimeout(n,v) ->
+    | VernacTimeout(n,{v}) ->
       return (keyword "Timeout " ++ int n ++ spc() ++ pr_vernac_control v)
-    | VernacFail v ->
+    | VernacFail {v} ->
       return (keyword "Fail" ++ spc() ++ pr_vernac_control v)
 
     let pr_vernac v =

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -405,11 +405,5 @@ type vernac_control =
      the flag is used to print differently in `-time` vs `Time foo` *)
   | VernacTime of bool * vernac_control CAst.t
   | VernacRedirect of string * vernac_control CAst.t
-  | VernacTimeout of int * vernac_control
-  | VernacFail of vernac_control
-
-(** Deprecated *)
-
-type vernac_implicit_status = Impargs.implicit_kind =
-  | Implicit [@ocaml.deprecated] | MaximallyImplicit [@ocaml.deprecated] | NotImplicit [@ocaml.deprecated]
-[@@ocaml.deprecated "Use [Impargs.implicit_kind]"]
+  | VernacTimeout of int * vernac_control CAst.t
+  | VernacFail of vernac_control CAst.t

--- a/vernac/vernacprop.ml
+++ b/vernac/vernacprop.ml
@@ -17,14 +17,14 @@ let rec under_control = function
   | VernacExpr (_, c) -> c
   | VernacRedirect (_,{CAst.v=c})
   | VernacTime (_,{CAst.v=c})
-  | VernacFail c
-  | VernacTimeout (_,c) -> under_control c
+  | VernacFail {CAst.v=c}
+  | VernacTimeout (_,{CAst.v=c}) -> under_control c
 
 let rec has_Fail = function
   | VernacExpr _ -> false
   | VernacRedirect (_,{CAst.v=c})
   | VernacTime (_,{CAst.v=c})
-  | VernacTimeout (_,c) -> has_Fail c
+  | VernacTimeout (_,{CAst.v=c}) -> has_Fail c
   | VernacFail _ -> true
 
 (* Navigation commands are allowed in a coqtop session but not in a .v file *)
@@ -41,7 +41,7 @@ let is_navigation_vernac c =
 let rec is_deep_navigation_vernac = function
   | VernacTime (_,{CAst.v=c}) -> is_deep_navigation_vernac c
   | VernacRedirect (_, {CAst.v=c})
-  | VernacTimeout (_,c) | VernacFail c -> is_navigation_vernac c
+  | VernacTimeout (_,{CAst.v=c}) | VernacFail {CAst.v=c} -> is_navigation_vernac c
   | VernacExpr _ -> false
 
 (* NB: Reset is now allowed again as asked by A. Chlipala *)


### PR DESCRIPTION
This is a fairly small cleanup on the `vernac_interp` function, which
makes code cleaner and for example would allow to have `Load` inside
`Load`. [Not that we would ever want that]
