### PR TITLE
[make install] Do not install the sphinx doctrees

### DIFF
--- a/Makefile.doc
+++ b/Makefile.doc
@@ -209,10 +209,11 @@ install-doc-printable:
 
 install-doc-sphinx:
 	$(MKDIR) $(FULLDOCDIR)/sphinx
-	(for f in `cd doc/sphinx/_build; find . -type f`; do \
-		$(MKDIR) $$(dirname $(FULLDOCDIR)/sphinx/$$f);\
-		$(INSTALLLIB) doc/sphinx/_build/$$f $(FULLDOCDIR)/sphinx/$$f;\
-	done)
+	(for d in html latex; do \
+	for f in `cd doc/sphinx/_build/$$d && find . -type f`; do \
+		$(MKDIR) $$(dirname $(FULLDOCDIR)/sphinx/$$d/$$f);\
+		$(INSTALLLIB) doc/sphinx/_build/$$d/$$f $(FULLDOCDIR)/sphinx/$$d/$$f;\
+	done; done)
 
 # For emacs:
 # Local Variables:


### PR DESCRIPTION
I don’t know what these doctree files are and what they are used for. They refer to `python` (the interpreter) hence make the nix closure of Coq include python, sphinx etc. This is annoying for CI jobs which must download all this closure.

Ping @cpitclaudel.