### PR TITLE
[ci] [windows] Use an install path requiring proper quoting.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -60,7 +60,7 @@ after_script:
   artifacts:
     name: "$CI_JOB_NAME"
     paths:
-      - _install_ci
+      - "_install ci"
       - config/Makefile
       - config/coq_config.py
       - test-suite/misc/universes/all_stdlib.v
@@ -73,7 +73,7 @@ after_script:
     - echo 'end:coq.clean'
 
     - echo 'start:coq.config'
-    - ./configure -warn-error yes -prefix "$(pwd)/_install_ci" ${COQ_EXTRA_CONF}"$COQ_EXTRA_CONF_QUOTE"
+    - ./configure -warn-error yes -prefix "$(pwd)/_install ci" ${COQ_EXTRA_CONF}"$COQ_EXTRA_CONF_QUOTE"
     - echo 'end:coq.config'
 
     - echo 'start:coq.build'
@@ -85,7 +85,7 @@ after_script:
     - echo 'start:coq.install'
     - make install install-byte $EXTRA_INSTALL
     - make install-byte
-    - cp bin/fake_ide _install_ci/bin/
+    - cp bin/fake_ide "_install ci/bin/"
     - echo 'end:coq.install'
 
     - set +e
@@ -134,13 +134,13 @@ after_script:
   dependencies:
     - not-a-real-job
   script:
-    - SPHINXENV='COQBIN="'"$PWD"'/_install_ci/bin/"'
+    - SPHINXENV='COQBIN="'"$PWD"'/_install ci/bin/"'
     - make -j "$NJOBS" SPHINXENV="$SPHINXENV" SPHINX_DEPS= refman
     - make install-doc-sphinx
   artifacts:
     name: "$CI_JOB_NAME"
     paths:
-      - _install_ci/share/doc/coq/
+      - "_install ci/share/doc/coq/"
 
 # set dependencies when using
 .test-suite-template: &test-suite-template
@@ -151,9 +151,9 @@ after_script:
     - cd test-suite
     - make clean
     # careful with the ending /
-    - BIN=$(readlink -f ../_install_ci/bin)/
-    - LIB=$(readlink -f ../_install_ci/lib/coq)/
-    - export OCAMLPATH=$(readlink -f ../_install_ci/lib/):"$OCAMLPATH"
+    - BIN=$(readlink -f "../_install ci/bin)/"
+    - LIB=$(readlink -f "../_install ci/lib/coq)/"
+    - export OCAMLPATH=$(readlink -f "../_install ci/lib/"):"$OCAMLPATH"
     - make -j "$NJOBS" BIN="$BIN" COQLIB="$LIB" COQFLAGS="${COQFLAGS}" all
   artifacts:
     name: "$CI_JOB_NAME.logs"
@@ -167,7 +167,7 @@ after_script:
   dependencies:
     - not-a-real-job
   script:
-    - cd _install_ci
+    - cd "_install ci"
     - find lib/coq/ -name '*.vo' -print0 > vofiles
     - for regexp in 's/.vo//' 's:lib/coq/plugins:Coq:' 's:lib/coq/theories:Coq:' 's:/:.:g'; do sed -z -i "$regexp" vofiles; done
     - xargs -0 --arg-file=vofiles bin/coqchk -silent -o -m -coqlib lib/coq/

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ FIND_SKIP_DIRS:='(' \
   -name "$${GIT_DIR}" -o \
   -name '_build' -o \
   -name '_build_ci' -o \
-  -name '_install_ci' -o \
+  -name '_install ci' -o \
   -name 'gramlib' -o \
   -name 'user-contrib' -o \
   -name 'test-suite' -o \

--- a/configure.ml
+++ b/configure.ml
@@ -983,11 +983,11 @@ let config_runtime () =
   | Some flags -> string_split ',' flags
   | _ when use_custom -> [custom_flag]
   | _ when !prefs.local ->
-    ["-dllib";"-lcoqrun";"-dllpath";coqtop/"kernel/byterun"]
+    ["-dllib";"-lcoqrun";"-dllpath";Filename.quote(coqtop/"kernel/byterun")]
   | _ ->
     let ld="CAML_LD_LIBRARY_PATH" in
     build_loadpath := sprintf "export %s:='%s/kernel/byterun':$(%s)" ld coqtop ld;
-    ["-dllib";"-lcoqrun";"-dllpath";coqlib/"kernel/byterun"]
+    ["-dllib";"-lcoqrun";"-dllpath";Filename.quote(coqlib/"kernel/byterun")]
 
 let vmbyteflags = config_runtime ()
 

--- a/dev/build/windows/MakeCoq_MinGW.bat
+++ b/dev/build/windows/MakeCoq_MinGW.bat
@@ -40,7 +40,7 @@ REM see -destcyg in ReadMe.txt
 SET DESTCYG=C:\bin\cygwin_coq
 
 REM see -destcoq in ReadMe.txt
-SET DESTCOQ=C:\bin\coq
+SET DESTCOQ=C:\bin\the coq proof assistant
 
 REM see -setup in ReadMe.txt
 SET SETUP=setup-x86_64.exe

--- a/dev/ci/ci-common.sh
+++ b/dev/ci/ci-common.sh
@@ -8,9 +8,9 @@ export NJOBS
 
 if [ -n "${GITLAB_CI}" ];
 then
-    # Gitlab build, Coq installed into `_install_ci`
-    export OCAMLPATH="$PWD/_install_ci/lib:$OCAMLPATH"
-    export COQBIN="$PWD/_install_ci/bin"
+    # Gitlab build, Coq installed into `_install ci`
+    export OCAMLPATH="$PWD/_install ci/lib:$OCAMLPATH"
+    export COQBIN="$PWD/_install ci/bin"
     export CI_BRANCH="$CI_COMMIT_REF_NAME"
     if [[ ${CI_BRANCH#pr-} =~ ^[0-9]*$ ]]
     then


### PR DESCRIPTION
Current quoting in Coq's infrastructure is not as systematic as it
should; IMHO this is a serious problem as it will make for random failures
would the user work with Coq inside a folder requiring quoting.

This PR switches the CI system as to use a destination directory
containing spaces; while this is still not optimal [the build dir is
free of spaces], it should provide some more assurance of proper
working wrt quoting for the runtime.
