### PR TITLE
[dune] [checker] Don't install internal checker library.

### DIFF
--- a/checker/dune
+++ b/checker/dune
@@ -3,8 +3,7 @@
 ; If we don't pack checker we will have a problem here due to
 ; duplicate module names in the whole build.
 (library
- (name checklib)
- (public_name coq.checklib)
+ (name coq_checklib)
  (synopsis "Coq's Standalone Proof Checker")
  (modules :standard \ coqchk votour)
  (wrapped true)
@@ -15,14 +14,14 @@
  (public_name coqchk)
  (package coq)
  (modules coqchk)
- (flags :standard -open Checklib)
- (libraries coq.checklib))
+ (flags :standard -open Coq_checklib)
+ (libraries coq_checklib))
 
 (executable
  (name votour)
  (public_name votour)
  (package coq)
  (modules votour)
- (flags :standard -open Checklib)
- (libraries coq.checklib))
+ (flags :standard -open Coq_checklib)
+ (libraries coq_checklib))
 


### PR DESCRIPTION
This library is private and shouldn't be exposed to plugins.
