### PR TITLE
Allow projections to be declared as classes.

### DIFF
--- a/doc/changelog/02-specification-language/9711-primitive-projection-classes.rst
+++ b/doc/changelog/02-specification-language/9711-primitive-projection-classes.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  Ability to declare primitive projections as class, for dependent typeclass resolutions
+  (fixes `#12975 <https://github.com/coq/coq/issues/12975>`_, `#9711 <https://github.com/coq/coq/pull/9711>`_,
+  by Matthieu Sozeau).

--- a/test-suite/bugs/closed/bug_12975.v
+++ b/test-suite/bugs/closed/bug_12975.v
@@ -1,0 +1,32 @@
+Record foo :=
+{
+  myprop : Type;
+}.
+
+Set Primitive Projections.
+
+Record bar :=
+{
+  myotherprop : Type ;
+  someprop : myotherprop;
+  somefn : myotherprop -> myotherprop
+}.
+
+
+Existing Class myprop.
+Existing Class myotherprop.
+
+Instance : forall O, myprop O. Abort.
+Instance : forall (O : bar), myotherprop O.
+Proof.
+  intros O. destruct O; cbn. exact someprop0.
+Defined.
+
+Definition bar_nat : bar := {| myotherprop := nat; someprop := 0; somefn x := x |}.
+
+Definition overloaded {b : bar} (o : myotherprop b) : myotherprop b :=
+  somefn _ (someprop _).
+
+Global Instance defaultbar_nat : myotherprop bar_nat := 0.
+
+Type (_ : myotherprop bar_nat).


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

<!-- Keep what applies -->
**Kind:** feature

This fixes an arbitrary limitation of typeclasses, which didn't allow primitive projections
to be declared as class heads. They can usefully be used as proxys. In our use case:

```coq

Class UR A B := {
  ur : A -> B -> Type 
}.
```

We want to declare `ur` as a type class head, as in all instances of `UR`, `ur` is itself defined by a type-class. We can use a hint to unfold the `ur` projection when applied to a particular `UR` instance to simplify the goal to a new typeclass constraint. This allows a kind of `dependent` type-class resolution. 

As long as users did not try to do `Existing Class ur` for some primitive projection `ur`, which had no effect previously, this should be backwards compatible.

Fix #12975, fix #8994.

- [x] Added / updated test-suite
- [x] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
