### PR TITLE
[coercion] fix error message after saturation by typeclass resolution

### DIFF
--- a/pretyping/coercion.ml
+++ b/pretyping/coercion.ml
@@ -534,8 +534,8 @@ let inh_conv_coerce_to_gen ?loc ~program_mode resolve_tc rigidonly flags env evd
               error_actual_type ?loc env best_failed_evd cj t e
             else
               inh_conv_coerce_to_fail ?loc env evd' rigidonly cj.uj_val cj.uj_type t
-          with NoCoercionNoUnifier (_evd,_error) ->
-            error_actual_type ?loc env best_failed_evd cj t e
+          with NoCoercionNoUnifier (evd,error) ->
+            error_actual_type ?loc env evd cj t error
   in
   (evd',{ uj_val = val'; uj_type = t })
 

--- a/test-suite/output/tc_coercion.out
+++ b/test-suite/output/tc_coercion.out
@@ -1,0 +1,3 @@
+The command has indeed failed with message:
+The term "@foo_dependent nat Foo_instance_0 (S O)" has type 
+"True" while it is expected to have type "False".

--- a/test-suite/output/tc_coercion.v
+++ b/test-suite/output/tc_coercion.v
@@ -1,0 +1,8 @@
+Class Foo (A : Type) := { foo_a : A }.
+Hint Mode Foo ! : typeclass_instances.
+Definition foo_dependent {A} {F : Foo A} (x : A) : True := I.
+Set Printing All.
+Instance: Foo nat := { foo_a := 0 }.
+Goal False.
+  Fail refine (foo_dependent 1).
+Abort.


### PR DESCRIPTION
We were returning the old evar map, which doesn't explain the error
after typeclass resolution was tried.

<!-- Keep what applies -->
**Kind:** bug fix

Not really a "bug" but a misfeature. 

- [x] Added / updated test-suite
