### PR TITLE
[refman] Fix typo in local application of tactics

### DIFF
--- a/doc/sphinx/proof-engine/ltac.rst
+++ b/doc/sphinx/proof-engine/ltac.rst
@@ -200,7 +200,7 @@ following form:
    :name: [> ... | ... | ... ] (dispatch)
 
    The expressions :n:`@expr__i` are evaluated to :n:`v__i`, for
-   i = 0, ..., n and all have to be tactics. The :n:`v__i` is applied to the
+   i = 1, ..., n and all have to be tactics. The :n:`v__i` is applied to the
    i-th goal, for i = 1, ..., n. It fails if the number of focused goals is not
    exactly n.
 


### PR DESCRIPTION
**Kind:** documentation

The index of local tactic application `[> expr|* ]` should start from 1. It seems that this typo originates from the old doc for `expr ; [ expr|* ]`.