### PR TITLE
Fix issue #9722 pkg-config not found

### DIFF
--- a/dev/build/windows/MakeCoq_MinGW.bat
+++ b/dev/build/windows/MakeCoq_MinGW.bat
@@ -373,7 +373,8 @@ IF "%RUNSETUP%"=="Y" (
     -P make,unzip ^
     -P gdb,liblzma5 ^
     -P patch,automake1.14 ^
-    -P mingw64-%ARCH%-binutils,mingw64-%ARCH%-gcc-core,mingw64-%ARCH%-gcc-g++,mingw64-%ARCH%-pkg-config,mingw64-%ARCH%-windows_default_manifest ^
+    -P pkg-config ^
+    -P mingw64-%ARCH%-binutils,mingw64-%ARCH%-gcc-core,mingw64-%ARCH%-gcc-g++,mingw64-%ARCH%-windows_default_manifest ^
     -P mingw64-%ARCH%-headers,mingw64-%ARCH%-runtime,mingw64-%ARCH%-pthreads,mingw64-%ARCH%-zlib ^
     -P libiconv-devel,libunistring-devel,libncurses-devel ^
     -P gettext-devel,libgettextpo-devel ^

--- a/dev/build/windows/makecoq_mingw.sh
+++ b/dev/build/windows/makecoq_mingw.sh
@@ -1205,7 +1205,7 @@ function make_lablgtk {
   make_gtk_sourceview2
   if build_prep https://forge.ocamlcore.org/frs/download.php/1726 lablgtk-2.18.6 tar.gz 1 ; then
     # configure should be fixed to search for $TARGET_ARCH-pkg-config.exe
-    cp "/bin/$TARGET_ARCH-pkg-config.exe"  bin_special/pkg-config.exe
+    cp "/bin/$TARGET_ARCH-pkg-config"  bin_special/pkg-config
     logn configure ./configure --build="$BUILD" --host="$HOST" --target="$TARGET" --prefix="$PREFIXOCAML"
 
     # lablgtk shows occasional errors with -j, so don't pass $MAKE_OPT


### PR DESCRIPTION
This is a backport of PR #9728 to fix #9722.

The issue is caused by a change in cygwin and needs to be backported to all active branches - otherwise Gitlab Windows CI will fail.