### PR TITLE
[dune] [configure] Fix `gramlib` path for hardcoded includes.

### DIFF
--- a/configure.ml
+++ b/configure.ml
@@ -1101,7 +1101,7 @@ let write_configml f =
   pr_b "native_compiler" !prefs.nativecompiler;
 
   let core_src_dirs = [ "config"; "lib"; "clib"; "kernel"; "library";
-                        "engine"; "pretyping"; "interp"; "gramlib/.pack"; "parsing"; "proofs";
+                        "engine"; "pretyping"; "interp"; "gramlib"; "gramlib/.pack"; "parsing"; "proofs";
                         "tactics"; "toplevel"; "printing"; "ide"; "stm"; "vernac" ] in
   let core_src_dirs = List.fold_left (fun acc core_src_subdir -> acc ^ "  \"" ^ core_src_subdir ^ "\";\n")
                                     ""


### PR DESCRIPTION
The regular make build uses a non-standard header path for their files
[as a way to workaround the ugliness of the non-hygienic build]

This breaks in Dune as it uses the regular object file pack, so
`coq_makefile` won't find it. We cherry pick a change from #8729 which
fixes the updated version of bug #9735 , even tho `coq_makefile`
should stop relying on hardcoded paths and use findlib instead.

Closes #9735
