### PR TITLE
Correct dependencies in the micromega pack

### DIFF
--- a/plugins/micromega/coq_micromega.mli
+++ b/plugins/micromega/coq_micromega.mli
@@ -20,3 +20,9 @@ val sos_Q : unit Proofview.tactic -> unit Proofview.tactic
 val sos_R : unit Proofview.tactic -> unit Proofview.tactic
 val lra_Q : unit Proofview.tactic -> unit Proofview.tactic
 val lra_R : unit Proofview.tactic -> unit Proofview.tactic
+
+
+(** {5 Use Micromega independently from tactics. } *)
+
+(** [dump_proof_term] generates the Coq representation of a Micromega proof witness *)
+val dump_proof_term : Micromega.zArithProof -> EConstr.t

--- a/plugins/micromega/micromega_plugin.mlpack
+++ b/plugins/micromega/micromega_plugin.mlpack
@@ -1,8 +1,8 @@
+Micromega
 Mutils
 Itv
 Vect
 Sos_types
-Micromega
 Polynomial
 Mfourier
 Simplex


### PR DESCRIPTION
**Kind:** bug fix

Fixes #9768

Remark: it would be great to backport it to Coq-8.9.1 (there are less modules in micromega_plugin but it still applies).