### PR TITLE
Correct dependencies in the micromega pack

### DIFF
--- a/plugins/micromega/micromega_plugin.mlpack
+++ b/plugins/micromega/micromega_plugin.mlpack
@@ -1,8 +1,8 @@
+Micromega
 Mutils
 Itv
 Vect
 Sos_types
-Micromega
 Polynomial
 Mfourier
 Simplex


### PR DESCRIPTION
**Kind:** bug fix

Fixes #9768

Remark: it would be great to backport it to Coq-8.9.1 (there are less modules in micromega_plugin but it still applies).