### PR TITLE
Exposes Coq_micromega.dump_proof_term to allow a use independent from tactics

### DIFF
--- a/plugins/micromega/coq_micromega.mli
+++ b/plugins/micromega/coq_micromega.mli
@@ -20,3 +20,9 @@ val sos_Q : unit Proofview.tactic -> unit Proofview.tactic
 val sos_R : unit Proofview.tactic -> unit Proofview.tactic
 val lra_Q : unit Proofview.tactic -> unit Proofview.tactic
 val lra_R : unit Proofview.tactic -> unit Proofview.tactic
+
+
+(** {5 Use Micromega independently from tactics. } *)
+
+(** [dump_proof_term] generates the Coq representation of a Micromega proof witness *)
+val dump_proof_term : Micromega.zArithProof -> EConstr.t


### PR DESCRIPTION
**Kind:** feature / infrastructure.

Closes #9749 