### PR TITLE
Add test-suite to Paramcoq CI

### DIFF
--- a/dev/ci/ci-paramcoq.sh
+++ b/dev/ci/ci-paramcoq.sh
@@ -5,4 +5,4 @@ ci_dir="$(dirname "$0")"
 
 git_download paramcoq
 
-( cd "${CI_BUILD_DIR}/paramcoq" && make && make install )
+( cd "${CI_BUILD_DIR}/paramcoq" && make && make install && cd test-suite && make examples)


### PR DESCRIPTION
CI for paramcoq was only compiling the OCaml module but not actually testing it.

For instance, https://github.com/coq/coq/pull/8817 did break the testsuite (now fixed).
