### PR TITLE
Add Flocq, CoqInterval, Gappa tool and Gappa plugin to the Windows Installer (Issue #9351)

### DIFF
--- a/dev/build/windows/MakeCoq_MinGW.bat
+++ b/dev/build/windows/MakeCoq_MinGW.bat
@@ -376,6 +376,7 @@ IF "%RUNSETUP%"=="Y" (
     -P pkg-config ^
     -P mingw64-%ARCH%-binutils,mingw64-%ARCH%-gcc-core,mingw64-%ARCH%-gcc-g++,mingw64-%ARCH%-windows_default_manifest ^
     -P mingw64-%ARCH%-headers,mingw64-%ARCH%-runtime,mingw64-%ARCH%-pthreads,mingw64-%ARCH%-zlib ^
+    -P mingw64-%ARCH%-gmp,mingw64-%ARCH%-mpfr ^
     -P libiconv-devel,libunistring-devel,libncurses-devel ^
     -P gettext-devel,libgettextpo-devel ^
     -P libglib2.0-devel,libgdk_pixbuf2.0-devel ^
@@ -383,6 +384,7 @@ IF "%RUNSETUP%"=="Y" (
     -P gtk-update-icon-cache ^
     -P libtool,automake ^
     -P intltool ^
+    -P bison,flex ^
     %EXTRAPACKAGES% ^
     || GOTO ErrorExit
 

--- a/dev/build/windows/MakeCoq_MinGW.bat
+++ b/dev/build/windows/MakeCoq_MinGW.bat
@@ -373,7 +373,8 @@ IF "%RUNSETUP%"=="Y" (
     -P make,unzip ^
     -P gdb,liblzma5 ^
     -P patch,automake1.14 ^
-    -P mingw64-%ARCH%-binutils,mingw64-%ARCH%-gcc-core,mingw64-%ARCH%-gcc-g++,mingw64-%ARCH%-pkg-config,mingw64-%ARCH%-windows_default_manifest ^
+    -P pkg-config ^
+    -P mingw64-%ARCH%-binutils,mingw64-%ARCH%-gcc-core,mingw64-%ARCH%-gcc-g++,mingw64-%ARCH%-windows_default_manifest ^
     -P mingw64-%ARCH%-headers,mingw64-%ARCH%-runtime,mingw64-%ARCH%-pthreads,mingw64-%ARCH%-zlib ^
     -P libiconv-devel,libunistring-devel,libncurses-devel ^
     -P gettext-devel,libgettextpo-devel ^

--- a/dev/build/windows/makecoq_mingw.sh
+++ b/dev/build/windows/makecoq_mingw.sh
@@ -1205,7 +1205,7 @@ function make_lablgtk {
   make_gtk_sourceview2
   if build_prep https://forge.ocamlcore.org/frs/download.php/1726 lablgtk-2.18.6 tar.gz 1 ; then
     # configure should be fixed to search for $TARGET_ARCH-pkg-config.exe
-    cp "/bin/$TARGET_ARCH-pkg-config.exe"  bin_special/pkg-config.exe
+    cp "/bin/$TARGET_ARCH-pkg-config"  bin_special/pkg-config
     logn configure ./configure --build="$BUILD" --host="$HOST" --target="$TARGET" --prefix="$PREFIXOCAML"
 
     # lablgtk shows occasional errors with -j, so don't pass $MAKE_OPT

--- a/dev/build/windows/patches_coq/Flocq.patch
+++ b/dev/build/windows/patches_coq/Flocq.patch
@@ -1,0 +1,27 @@
+diff/patch file created on Sun, Jan 20, 2019 11:55:04 AM with:
+difftar-folder.sh tarballs/Flocq-c006474201a8e9ce084c126e3a69a82e14f7cc7e.tar.gz Flocq-c006474201a8e9ce084c126e3a69a82e14f7cc7e 1
+TARFILE= tarballs/Flocq-c006474201a8e9ce084c126e3a69a82e14f7cc7e.tar.gz
+FOLDER= Flocq-c006474201a8e9ce084c126e3a69a82e14f7cc7e
+TARSTRIP= 1
+TARPREFIX= flocq-c006474201a8e9ce084c126e3a69a82e14f7cc7e/
+ORIGFOLDER= Flocq-c006474201a8e9ce084c126e3a69a82e14f7cc7e.orig
+--- Flocq-c006474201a8e9ce084c126e3a69a82e14f7cc7e.orig/configure.in	2019-01-11 15:52:30.000000000 +0100
++++ Flocq-c006474201a8e9ce084c126e3a69a82e14f7cc7e/configure.in	2019-01-20 11:51:49.474668300 +0100
+@@ -10,7 +10,7 @@
+ 
+ m4_divert_push([HELP_ENABLE])
+ Fine tuning of the installation directory:
+-AS_HELP_STRING([--libdir=DIR], [library @<:@DIR=`$COQC -where`/user-contrib/Flocq@:>@])
++AS_HELP_STRING([--libdir=DIR], [library @<:@DIR=`$COQC -where | tr -d '\r' | tr '\\' '/'`/user-contrib/Flocq@:>@])
+ m4_divert_pop([HELP_ENABLE])
+ 
+ AC_PROG_CXX
+@@ -51,7 +51,7 @@
+ AC_MSG_RESULT([$COQDOC])
+ 
+ if test "$libdir" = '${exec_prefix}/lib'; then
+-  libdir="`$COQC -where`/user-contrib/Flocq"
++  libdir="`$COQC -where | tr -d '\r' | tr '\\' '/'`/user-contrib/Flocq"
+ fi
+ 
+ AC_MSG_NOTICE([building remake...])

--- a/dev/build/windows/patches_coq/Gappa_Plugin.patch
+++ b/dev/build/windows/patches_coq/Gappa_Plugin.patch
@@ -1,0 +1,86 @@
+diff/patch file created on Sat, Jan 19, 2019  5:10:57 PM with:
+difftar-folder.sh tarballs/Gappa_Plugin-gappalib-coq-1.4.0.tar.gz Gappa_Plugin-gappalib-coq-1.4.0/ 1
+TARFILE= tarballs/Gappa_Plugin-gappalib-coq-1.4.0.tar.gz
+FOLDER= Gappa_Plugin-gappalib-coq-1.4.0/
+TARSTRIP= 1
+TARPREFIX= gappalib-coq-1.4.0/
+ORIGFOLDER= Gappa_Plugin-gappalib-coq-1.4.0/.orig
+--- Gappa_Plugin-gappalib-coq-1.4.0/.orig/configure.in	2018-07-18 12:39:18.000000000 +0200
++++ Gappa_Plugin-gappalib-coq-1.4.0//configure.in	2019-01-19 17:08:05.943511300 +0100
+@@ -50,7 +50,17 @@
+ AC_MSG_CHECKING([for camlpXo])
+ if test ! "$CAMLP4O"; then
+   CAMLP4O=`$COQC -config | sed -n -e 's/^CAMLP.O=\(.*\)/\1/p'`
+-  CAMLP4O=`which $CAMLP4O`
++  case `uname -s` in
++    CYGWIN*)
++      case "$CAMLP4O" in
++        *:*) CAMLP4O=`cygpath -m "$CAMLP4O"` ;;
++        *)   CAMLP4O=`cygpath -u "$CAMLP4O"` ;;
++      esac
++      ;;
++    *)
++      CAMLP4O=`which $CAMLP4O`
++      ;;
++  esac
+ fi
+ AC_MSG_RESULT([$CAMLP4O])
+
+@@ -78,10 +88,10 @@
+ rm -f conftest.v conftest.vo conftest.err
+
+ AC_SUBST(OCAMLLIB)
+-OCAMLLIB=`$OCAMLC -where`
++OCAMLLIB=`$OCAMLC -where | tr -d '\r' | tr '\\' '/'`
+
+ AC_SUBST(COQLIB)
+-COQLIB=`$COQC -where`
++COQLIB=`$COQC -where | tr -d '\r' | tr '\\' '/'`
+
+ if test "$libdir" = '${exec_prefix}/lib'; then
+   libdir="$COQLIB/user-contrib/Gappa"
+--- Gappa_Plugin-gappalib-coq-1.4.0/.orig/configure	2018-07-18 12:39:18.000000000 +0200
++++ Gappa_Plugin-gappalib-coq-1.4.0//configure	2019-01-19 17:08:36.979358700 +0100
+@@ -2409,7 +2397,17 @@
+ $as_echo_n "checking for camlpXo... " >&6; }
+ if test ! "$CAMLP4O"; then
+   CAMLP4O=`$COQC -config | sed -n -e 's/^CAMLP.O=\(.*\)/\1/p'`
+-  CAMLP4O=`which $CAMLP4O`
++  case `uname -s` in
++    CYGWIN*)
++      case "$CAMLP4O" in
++        *:*) CAMLP4O=`cygpath -m "$CAMLP4O"` ;;
++        *)   CAMLP4O=`cygpath -u "$CAMLP4O"` ;;
++      esac
++      ;;
++    *)
++      CAMLP4O=`which $CAMLP4O`
++      ;;
++  esac
+ fi
+ { $as_echo "$as_me:${as_lineno-$LINENO}: result: $CAMLP4O" >&5
+ $as_echo "$CAMLP4O" >&6; }
+@@ -2456,10 +2454,10 @@
+ rm -f conftest.v conftest.vo conftest.err
+
+
+-OCAMLLIB=`$OCAMLC -where`
++OCAMLLIB=`$OCAMLC -where | tr -d '\r' | tr '\\' '/'`
+
+
+-COQLIB=`$COQC -where`
++COQLIB=`$COQC -where | tr -d '\r' | tr '\\' '/'`
+
+ if test "$libdir" = '${exec_prefix}/lib'; then
+   libdir="$COQLIB/user-contrib/Gappa"
+--- Gappa_Plugin-gappalib-coq-1.4.0/.orig/Remakefile.in	2018-07-18 12:39:18.000000000 +0200
++++ Gappa_Plugin-gappalib-coq-1.4.0//Remakefile.in	2019-01-19 15:43:12.430269600 +0100
+@@ -43,7 +43,7 @@
+ 	@COQC@ -R src Gappa -I src $<
+
+ COQSUBTREES = clib engine kernel interp intf lib library ltac parsing pretyping printing proofs tactics toplevel vernac plugins/ltac
+-COQINCLUDES = $(addprefix -I @COQLIB@/, $(COQSUBTREES))
++COQINCLUDES = $(addprefix -I "@COQLIB@"/, $(COQSUBTREES))
+
+ src/gappatac.cmo: src/gappatac.ml
+ 	@OCAMLC@ -pp "@CAMLP4O@ @COQPPLIBS@ pa_macro.cmo -D@COQDEFINE@" -rectypes $(COQINCLUDES) -c $< -o $@

--- a/dev/build/windows/patches_coq/Gappa_Tool.patch
+++ b/dev/build/windows/patches_coq/Gappa_Tool.patch
@@ -1,0 +1,49 @@
+diff/patch file created on Sat, Mar 16, 2019  3:58:16 PM with:
+difftar-folder.sh tarballs/Gappa_Tool-gappa-1.3.4.tar.gz Gappa_Tool-gappa-1.3.4 1
+TARFILE= tarballs/Gappa_Tool-gappa-1.3.4.tar.gz
+FOLDER= Gappa_Tool-gappa-1.3.4
+TARSTRIP= 1
+TARPREFIX= gappa-1.3.4/
+ORIGFOLDER= Gappa_Tool-gappa-1.3.4.orig
+--- Gappa_Tool-gappa-1.3.4.orig/src/proofs/property.hpp	2019-03-01 10:08:10.000000000 +0100
++++ Gappa_Tool-gappa-1.3.4/src/proofs/property.hpp	2019-03-16 15:50:26.467975800 +0100
+@@ -54,7 +54,7 @@
+ class property {
+   union store_t {
+     char _bnd[sizeof(interval)];
+-    long _int;
++    intptr_t _int;
+   };
+   store_t store;
+   interval       &_bnd()       { return *reinterpret_cast< interval       * >(&store); }
+@@ -65,16 +65,16 @@
+   { assert(real.pred_bnd()); return _bnd(); }
+   interval const &bnd() const
+   { assert(real.pred_bnd()); return _bnd(); }
+-  long &cst()
++  intptr_t &cst()
+   { assert(real.pred_cst()); return store._int; }
+-  long const &cst() const
++  intptr_t const &cst() const
+   { assert(real.pred_cst()); return store._int; }
+   property();
+   property(ast_real const *);
+   property(ast_real const *, interval const &);
+   property(predicated_real const &);
+   property(predicated_real const &, interval const &);
+-  property(predicated_real const &, long);
++  property(predicated_real const &, intptr_t);
+   property(property const &);
+   property &operator=(property const &);
+   ~property();
+--- Gappa_Tool-gappa-1.3.4.orig/src/proofs/property.cpp	2019-03-01 10:08:10.000000000 +0100
++++ Gappa_Tool-gappa-1.3.4/src/proofs/property.cpp	2019-03-16 15:50:23.198718900 +0100
+@@ -44,7 +44,7 @@
+   new(&store) interval(i);
+ }
+ 
+-property::property(predicated_real const &r, long i): real(r)
++property::property(predicated_real const &r, intptr_t i): real(r)
+ {
+   assert(r.pred_cst());
+   store._int = i;

--- a/dev/build/windows/patches_coq/Interval.patch
+++ b/dev/build/windows/patches_coq/Interval.patch
@@ -1,0 +1,27 @@
+diff/patch file created on Sun, Mar 10, 2019 10:58:15 AM with:
+difftar-folder.sh tarballs/Interval-interval-3.4.0.tar.gz Interval-interval-3.4.0 1
+TARFILE= tarballs/Interval-interval-3.4.0.tar.gz
+FOLDER= Interval-interval-3.4.0
+TARSTRIP= 1
+TARPREFIX= interval-3.4.0/
+ORIGFOLDER= Interval-interval-3.4.0.orig
+--- Interval-interval-3.4.0.orig/configure.in	2018-05-09 15:42:24.000000000 +0200
++++ Interval-interval-3.4.0/configure.in	2019-03-10 10:54:20.590429700 +0100
+@@ -10,7 +10,7 @@
+ 
+ m4_divert_push([HELP_ENABLE])
+ Fine tuning of the installation directory:
+-AS_HELP_STRING([--libdir=DIR], [library @<:@DIR=`$COQC -where`/user-contrib/Interval@:>@])
++AS_HELP_STRING([--libdir=DIR], [library @<:@DIR=`$COQC -where | tr -d '\r' | tr '\\' '/'`/user-contrib/Interval@:>@])
+ m4_divert_pop([HELP_ENABLE])
+ 
+ AC_PROG_CXX
+@@ -79,7 +79,7 @@
+ rm -f conftest.v conftest.vo conftest.err
+ 
+ if test "$libdir" = '${exec_prefix}/lib'; then
+-  libdir="`$COQC -where`/user-contrib/Interval"
++  libdir="`$COQC -where | tr -d '\r' | tr '\\' '/'`/user-contrib/Interval"
+ fi
+ 
+ AC_MSG_NOTICE([building remake...])

--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -109,10 +109,41 @@
 # See https://gforge.inria.fr/scm/browser.php?group_id=3599
 # Since this URL doesn't fit to our standard mechanism and since Coquelicot doesn't seem to change frequently,
 # we use a fixed version, which has a download path which does fit to our standard mechanism.
-# ATTENTION: The archive URL might depend on the version!
+# ATTENTION: The archive URL does depend on the version - see notes om Gappa_Tool!
 : "${Coquelicot_CI_REF:=coquelicot-3.0.2}"
 : "${Coquelicot_CI_GITURL:=https://scm.gforge.inria.fr/anonscm/git/coquelicot/coquelicot}"
 : "${Coquelicot_CI_ARCHIVEURL:=https://gforge.inria.fr/frs/download.php/file/37523}"
+
+########################################################################
+# Coq-interval
+########################################################################
+# Here the same applies as for Coquelicot => we are using a fixed version URL
+: "${Interval_CI_REF:=interval-3.4.0}"
+: "${Interval_CI_GITURL:=https://scm.gforge.inria.fr/anonscm/git/coq-interval/coq-interval}"
+: "${Interval_CI_ARCHIVEURL:=https://gforge.inria.fr/frs/download.php/file/37524}"
+
+########################################################################
+# Gappa stand alone tool
+########################################################################
+# Here the same applies as for Coquelicot => we are using a fixed version URL
+# ATTENTION: The archive URL does depend on the version e.g.
+# https://gforge.inria.fr/frs/download.php/file/37624/gappa-1.3.3.tar.gz
+# https://gforge.inria.fr/frs/download.php/file/37918/gappa-1.3.4.tar.gz
+# ATTENTION: Mixing paths, e.g.
+# https://gforge.inria.fr/frs/download.php/file/37624/gappa-1.3.4.tar.gz
+# Doesn't give an error, but one gets a wrong file (1.3.3 in the example above)
+: "${Gappa_Tool_CI_REF:=gappa-1.3.4}"
+: "${Gappa_Tool_CI_GITURL:=https://scm.gforge.inria.fr/anonscm/git/gappa/gappa}"
+: "${Gappa_Tool_CI_ARCHIVEURL:=https://gforge.inria.fr/frs/download.php/file/37918}"
+
+########################################################################
+# Gappa plugin
+########################################################################
+# Here the same applies as for Coquelicot => we are using a fixed version URL
+# ATTENTION: The archive URL does depend on the version - see notes om Gappa_Tool!
+: "${Gappa_Plugin_CI_REF:=gappalib-coq-1.4.1}"
+: "${Gappa_Plugin_CI_GITURL:=https://scm.gforge.inria.fr/anonscm/git/gappa/coq}"
+: "${Gappa_Plugin_CI_ARCHIVEURL:=https://gforge.inria.fr/frs/download.php/file/37917}"
 
 ########################################################################
 # CompCert

--- a/dev/ci/gitlab.bat
+++ b/dev/ci/gitlab.bat
@@ -56,6 +56,10 @@ call %CI_PROJECT_DIR%\dev\build\windows\MakeCoq_MinGW.bat -threads=1 ^
   -addon=coquelicot ^
   -addon=vst ^
   -addon=aactactics ^
+  -addon=flocq ^
+  -addon=interval ^
+  -addon=gappa_tool ^
+  -addon=gappa ^
   -make=N ^
   -setup %CI_PROJECT_DIR%\%SETUP% || GOTO ErrorCopyLogFilesAndExit
 


### PR DESCRIPTION
This PR Implements Issue #9351 and adds these new plugins to the Windows Installer

- Flocq (as independent library)
- CoqInterval
- Gappa stand alone executable for MinGW
- Gappa Coq plugin

This is work in progress - I don't plan to have it merged before @silene pushed the patches to the respective repos, but I want to start testing CI now.

A note on Flocq: this is already included as part of CompCert, but this version is quite different. I need to discuss this with @xavierleroy and @silene. In the end this makes it very hard to verify numerical C programs using VST if VST (via CompCert) uses a different version of Flocq than CoqInterval and Gappa.