### PR TITLE
CI: Don't fail validate:quick when build:quick failed

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -167,7 +167,7 @@ after_script:
   dependencies:
     - not-a-real-job
   script:
-    - cd _install_ci
+    - cd _install_ci || exit 0 # maybe no artifacts from allow_failure dep on build:quick
     - find lib/coq/ -name '*.vo' -print0 > vofiles
     - for regexp in 's/.vo//' 's:lib/coq/plugins:Coq:' 's:lib/coq/theories:Coq:' 's:/:.:g'; do sed -z -i "$regexp" vofiles; done
     - xargs -0 --arg-file=vofiles bin/coqchk -silent -o -m -coqlib lib/coq/


### PR DESCRIPTION
(since build:quick is allow_failure)