### PR TITLE
Preliminary refactoring for `.vos` files support

### DIFF
--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -308,10 +308,11 @@ end (* }}} *)
 
 type interactive_top = TopLogical of DirPath.t | TopPhysical of string
 
+type compilation_mode = BuildVo | BuildVio | Vio2Vo
+
 (* The main document type associated to a VCS *)
 type stm_doc_type =
-  | VoDoc       of string
-  | VioDoc      of string
+  | Batch of compilation_mode * string
   | Interactive of interactive_top
 
 (* Dummy until we land the functional interp patch + fixed start_library *)
@@ -549,7 +550,7 @@ end = struct (* {{{ *)
 
   let is_vio_doc () =
     match !doc_type with
-    | VioDoc _ -> true
+    | Batch (BuildVio, _) -> true
     | _ -> false
 
   let current_branch () = current_branch !vcs
@@ -2645,17 +2646,12 @@ let new_doc { doc_type ; iload_path; require_libs; stm_options } =
       in
       Declaremods.start_library dp
 
-    | VoDoc f ->
+    | Batch (_, f) ->
       let ldir = dirpath_of_file f in
       let () = Flags.verbosely Declaremods.start_library ldir in
       VCS.set_ldir ldir;
       set_compilation_hints f
 
-    | VioDoc f ->
-      let ldir = dirpath_of_file f in
-      let () = Flags.verbosely Declaremods.start_library ldir in
-      VCS.set_ldir ldir;
-      set_compilation_hints f
   end;
 
   (* Import initial libraries. *)

--- a/stm/stm.mli
+++ b/stm/stm.mli
@@ -44,12 +44,13 @@ end
 
 type interactive_top = TopLogical of DirPath.t | TopPhysical of string
 
+type compilation_mode = BuildVo | BuildVio | Vio2Vo
+
 (** The STM document type [stm_doc_type] determines some properties
    such as what uncompleted proofs are allowed and what gets recorded
    to aux files. *)
 type stm_doc_type =
-  | VoDoc       of string       (* file path *)
-  | VioDoc      of string       (* file path *)
+  | Batch of compilation_mode * string (* file path *)
   | Interactive of interactive_top    (* module path *)
 
 (** Coq initialization options:

--- a/stm/stm.mli
+++ b/stm/stm.mli
@@ -42,20 +42,9 @@ module AsyncOpts : sig
 
 end
 
-type interactive_top = TopLogical of DirPath.t | TopPhysical of string
+(** Coq initalization options:
 
-type compilation_mode = BuildVo | BuildVio | Vio2Vo
-
-(** The STM document type [stm_doc_type] determines some properties
-   such as what uncompleted proofs are allowed and what gets recorded
-   to aux files. *)
-type stm_doc_type =
-  | Batch of compilation_mode * string (* file path *)
-  | Interactive of interactive_top    (* module path *)
-
-(** Coq initialization options:
-
- - [doc_type]: Type of document being created.
+ - [library_mode]: Type of document being created.
 
  - [require_libs]: list of libraries/modules to be pre-loaded at
    startup. A tuple [(modname,modfrom,import)] is equivalent to [From
@@ -64,11 +53,15 @@ type stm_doc_type =
    the module, [Some true] will additionally export it.
 
 *)
+type top_path = TopLogical of DirPath.t | TopPhysical of string
+
 type stm_init_options = {
   (* The STM will set some internal flags differently depending on the
-     specified [doc_type]. This distinction should disappear at some
-     some point. *)
-  doc_type     : stm_doc_type;
+     specified [library_info]. This distinction should disappear at some
+     point. *)
+  library_mode     : Declaremods.library_mode;
+
+  top_path : top_path;
 
   (* Initial load path in scope for the document. Usually extracted
      from -R options / _CoqProject *)
@@ -177,7 +170,6 @@ val finish_tasks : string ->
 
 (* Id of the tip of the current branch *)
 val get_current_state : doc:doc -> Stateid.t
-val get_ldir : doc:doc -> Names.DirPath.t
 
 (* This returns the node at that position *)
 val get_ast : doc:doc -> Stateid.t -> Vernacexpr.vernac_control option

--- a/toplevel/ccompile.ml
+++ b/toplevel/ccompile.ml
@@ -107,18 +107,19 @@ let compile opts copts ~echo ~f_in ~f_out =
     | NativeOff -> false | NativeOn {ondemand} -> not ondemand
   in
   match copts.compilation_mode with
-  | Stm.BuildVo ->
+  | Declaremods.BuildVo ->
       let long_f_dot_v, long_f_dot_vo =
         ensure_exists_with_prefix f_in f_out ".v" ".vo" in
 
       let doc, sid = Topfmt.(in_phase ~phase:LoadingPrelude)
           Stm.new_doc
-          Stm.{ doc_type = Batch(BuildVo, long_f_dot_vo);
+          Stm.{ library_mode = Declaremods.(Batch BuildVo);
+                top_path = TopPhysical long_f_dot_vo;
                 iload_path; require_libs; stm_options;
               } in
       let state = { doc; sid; proof = None; time = opts.config.time } in
       let state = load_init_vernaculars opts ~state in
-      let ldir = Stm.get_ldir ~doc:state.doc in
+      let ldir = Declaremods.((get_current_library_info ()).library_path) in
       Aux_file.(start_aux_file
         ~aux_file:(aux_file_name_for long_f_dot_vo)
         ~v_file:long_f_dot_v);
@@ -139,7 +140,7 @@ let compile opts copts ~echo ~f_in ~f_out =
       Aux_file.stop_aux_file ();
       Dumpglob.end_dump_glob ()
 
-  | Stm.BuildVio ->
+  | Declaremods.BuildVio ->
       let long_f_dot_v, long_f_dot_vio =
         ensure_exists_with_prefix f_in f_out ".v" ".vio" in
 
@@ -158,20 +159,21 @@ let compile opts copts ~echo ~f_in ~f_out =
 
       let doc, sid = Topfmt.(in_phase ~phase:LoadingPrelude)
           Stm.new_doc
-          Stm.{ doc_type = Batch(BuildVio, long_f_dot_vio);
+          Stm.{ library_mode = Declaremods.(Batch BuildVio);
+                top_path = TopPhysical long_f_dot_vio;
                 iload_path; require_libs; stm_options;
               } in
 
       let state = { doc; sid; proof = None; time = opts.config.time } in
       let state = load_init_vernaculars opts ~state in
-      let ldir = Stm.get_ldir ~doc:state.doc in
+      let ldir = Declaremods.((get_current_library_info ()).library_path) in
       let state = Vernac.load_vernac ~echo ~check:false ~interactive:false ~state long_f_dot_v in
       let doc = Stm.finish ~doc:state.doc in
       check_pending_proofs ();
       let () = ignore (Stm.snapshot_vio ~doc ~output_native_objects ldir long_f_dot_vio) in
       Stm.reset_task_queue ()
 
-  | Stm.Vio2Vo ->
+  | Declaremods.Vio2Vo ->
       let long_f_dot_vio, long_f_dot_vo =
         ensure_exists_with_prefix f_in f_out ".vio" ".vo" in
       let sum, lib, univs, tasks, proofs =

--- a/toplevel/ccompile.ml
+++ b/toplevel/ccompile.ml
@@ -107,13 +107,13 @@ let compile opts copts ~echo ~f_in ~f_out =
     | NativeOff -> false | NativeOn {ondemand} -> not ondemand
   in
   match copts.compilation_mode with
-  | BuildVo ->
+  | Stm.BuildVo ->
       let long_f_dot_v, long_f_dot_vo =
         ensure_exists_with_prefix f_in f_out ".v" ".vo" in
 
       let doc, sid = Topfmt.(in_phase ~phase:LoadingPrelude)
           Stm.new_doc
-          Stm.{ doc_type = VoDoc long_f_dot_vo;
+          Stm.{ doc_type = Batch(BuildVo, long_f_dot_vo);
                 iload_path; require_libs; stm_options;
               } in
       let state = { doc; sid; proof = None; time = opts.config.time } in
@@ -139,7 +139,7 @@ let compile opts copts ~echo ~f_in ~f_out =
       Aux_file.stop_aux_file ();
       Dumpglob.end_dump_glob ()
 
-  | BuildVio ->
+  | Stm.BuildVio ->
       let long_f_dot_v, long_f_dot_vio =
         ensure_exists_with_prefix f_in f_out ".v" ".vio" in
 
@@ -158,7 +158,7 @@ let compile opts copts ~echo ~f_in ~f_out =
 
       let doc, sid = Topfmt.(in_phase ~phase:LoadingPrelude)
           Stm.new_doc
-          Stm.{ doc_type = VioDoc long_f_dot_vio;
+          Stm.{ doc_type = Batch(BuildVio, long_f_dot_vio);
                 iload_path; require_libs; stm_options;
               } in
 
@@ -171,7 +171,7 @@ let compile opts copts ~echo ~f_in ~f_out =
       let () = ignore (Stm.snapshot_vio ~doc ~output_native_objects ldir long_f_dot_vio) in
       Stm.reset_task_queue ()
 
-  | Vio2Vo ->
+  | Stm.Vio2Vo ->
       let long_f_dot_vio, long_f_dot_vo =
         ensure_exists_with_prefix f_in f_out ".vio" ".vo" in
       let sum, lib, univs, tasks, proofs =

--- a/toplevel/coqargs.ml
+++ b/toplevel/coqargs.ml
@@ -47,7 +47,7 @@ type option_command = OptionSet of string option | OptionUnset
 type coqargs_logic_config = {
   impredicative_set : Declarations.set_predicativity;
   indices_matter    : bool;
-  toplevel_name     : Stm.interactive_top;
+  top_path          : Stm.top_path;
   allow_sprop       : bool;
   cumulative_sprop  : bool;
 }
@@ -112,7 +112,7 @@ let default_native =
 let default_logic_config = {
   impredicative_set = Declarations.PredicativeSet;
   indices_matter = false;
-  toplevel_name = Stm.TopLogical default_toplevel;
+  top_path = Stm.TopLogical default_toplevel;
   allow_sprop = false;
   cumulative_sprop = false;
 }
@@ -440,10 +440,10 @@ let parse_args ~help ~init arglist : t * string list =
       let topname = Libnames.dirpath_of_string (next ()) in
       if Names.DirPath.is_empty topname then
         CErrors.user_err Pp.(str "Need a non empty toplevel module name");
-      { oval with config = { oval.config with logic = { oval.config.logic with toplevel_name = Stm.TopLogical topname }}}
+      { oval with config = { oval.config with logic = { oval.config.logic with top_path = Stm.TopLogical topname }}}
 
     |"-topfile" ->
-      { oval with config = { oval.config with logic = { oval.config.logic with toplevel_name = Stm.TopPhysical (next()) }}}
+      { oval with config = { oval.config with logic = { oval.config.logic with top_path = Stm.TopPhysical (next()) }}}
 
     |"-main-channel" ->
       Spawned.main_channel := get_host_port opt (next()); oval

--- a/toplevel/coqargs.mli
+++ b/toplevel/coqargs.mli
@@ -19,7 +19,7 @@ type option_command = OptionSet of string option | OptionUnset
 type coqargs_logic_config = {
   impredicative_set : Declarations.set_predicativity;
   indices_matter    : bool;
-  toplevel_name     : Stm.interactive_top;
+  top_path          : Stm.top_path;
   allow_sprop       : bool;
   cumulative_sprop  : bool;
 }

--- a/toplevel/coqcargs.ml
+++ b/toplevel/coqcargs.ml
@@ -8,10 +8,8 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-type compilation_mode = BuildVo | BuildVio | Vio2Vo
-
 type t =
-  { compilation_mode : compilation_mode
+  { compilation_mode : Stm.compilation_mode
 
   ; compile_list: (string * bool) list  (* bool is verbosity  *)
   ; compilation_output_name : string option
@@ -28,7 +26,7 @@ type t =
   }
 
 let default =
-  { compilation_mode = BuildVo
+  { compilation_mode = Stm.BuildVo
 
   ; compile_list = []
   ; compilation_output_name = None
@@ -96,7 +94,7 @@ let set_vio_checking_j opts opt j =
 
 let set_compilation_mode opts mode =
   match opts.compilation_mode with
-  | BuildVo -> { opts with compilation_mode = mode }
+  | Stm.BuildVo -> { opts with compilation_mode = mode }
   | mode' when mode <> mode' ->
     prerr_endline "Options -quick and -vio2vo are exclusive";
     exit 1
@@ -165,7 +163,7 @@ let parse arglist : t =
         | "-o" ->
           { oval with compilation_output_name = Some (next ()) }
         | "-quick" ->
-          set_compilation_mode oval BuildVio
+          set_compilation_mode oval Stm.BuildVio
         | "-check-vio-tasks" ->
           let tno = get_task_list (next ()) in
           let tfile = next () in
@@ -184,7 +182,7 @@ let parse arglist : t =
 
         | "-vio2vo" ->
           let oval = add_compile ~echo:false oval (next ()) in
-          set_compilation_mode oval Vio2Vo
+          set_compilation_mode oval Stm.Vio2Vo
 
         | "-outputstate" ->
           set_outputstate oval (next ())

--- a/toplevel/coqcargs.ml
+++ b/toplevel/coqcargs.ml
@@ -9,7 +9,7 @@
 (************************************************************************)
 
 type t =
-  { compilation_mode : Stm.compilation_mode
+  { compilation_mode : Declaremods.compilation_mode
 
   ; compile_list: (string * bool) list  (* bool is verbosity  *)
   ; compilation_output_name : string option
@@ -26,7 +26,7 @@ type t =
   }
 
 let default =
-  { compilation_mode = Stm.BuildVo
+  { compilation_mode = Declaremods.BuildVo
 
   ; compile_list = []
   ; compilation_output_name = None
@@ -94,7 +94,7 @@ let set_vio_checking_j opts opt j =
 
 let set_compilation_mode opts mode =
   match opts.compilation_mode with
-  | Stm.BuildVo -> { opts with compilation_mode = mode }
+  | Declaremods.BuildVo -> { opts with compilation_mode = mode }
   | mode' when mode <> mode' ->
     prerr_endline "Options -quick and -vio2vo are exclusive";
     exit 1
@@ -163,7 +163,7 @@ let parse arglist : t =
         | "-o" ->
           { oval with compilation_output_name = Some (next ()) }
         | "-quick" ->
-          set_compilation_mode oval Stm.BuildVio
+          set_compilation_mode oval Declaremods.BuildVio
         | "-check-vio-tasks" ->
           let tno = get_task_list (next ()) in
           let tfile = next () in
@@ -182,7 +182,7 @@ let parse arglist : t =
 
         | "-vio2vo" ->
           let oval = add_compile ~echo:false oval (next ()) in
-          set_compilation_mode oval Stm.Vio2Vo
+          set_compilation_mode oval Declaremods.Vio2Vo
 
         | "-outputstate" ->
           set_outputstate oval (next ())

--- a/toplevel/coqcargs.mli
+++ b/toplevel/coqcargs.mli
@@ -9,7 +9,7 @@
 (************************************************************************)
 
 type t =
-  { compilation_mode : Stm.compilation_mode
+  { compilation_mode : Declaremods.compilation_mode
 
   ; compile_list: (string * bool) list  (* bool is verbosity  *)
   ; compilation_output_name : string option

--- a/toplevel/coqcargs.mli
+++ b/toplevel/coqcargs.mli
@@ -8,10 +8,8 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-type compilation_mode = BuildVo | BuildVio | Vio2Vo
-
 type t =
-  { compilation_mode : compilation_mode
+  { compilation_mode : Stm.compilation_mode
 
   ; compile_list: (string * bool) list  (* bool is verbosity  *)
   ; compilation_output_name : string option

--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -277,7 +277,8 @@ let init_document opts =
   let open Vernac.State in
   let doc, sid =
     Stm.(new_doc
-           { doc_type = Interactive opts.config.logic.toplevel_name;
+           { library_mode = Declaremods.Interactive;
+             top_path = opts.config.logic.top_path;
              iload_path; require_libs; stm_options;
            }) in
   { doc; sid; proof = None; time = opts.config.time }

--- a/vernac/declaremods.ml
+++ b/vernac/declaremods.ml
@@ -642,6 +642,27 @@ let build_subtypes env mp args mtys =
   in
   (ans, cst)
 
+(** {6 Current library information} *)
+
+type compilation_mode = BuildVo | BuildVio | Vio2Vo
+
+type library_mode =
+  | Batch of compilation_mode
+  | Interactive
+
+type library_info =
+  { library_path: DirPath.t;
+    library_mode: library_mode;
+  }
+
+let default_library_info =
+  { library_path = Libnames.default_library;
+    library_mode = Interactive;
+  }
+
+let library_info = Summary.ref default_library_info ~name:"LIBRARY-INFO"
+
+let get_current_library_info () = !library_info
 
 (** {6 Current module information}
 
@@ -1001,10 +1022,11 @@ let register_library dir cenv (objs:library_objects) digest univ =
   let sobjs,keepobjs = objs in
   do_module false load_objects 1 dir mp ([],Objs sobjs) keepobjs
 
-let start_library dir =
-  let mp = Global.start_library dir in
+let start_library info =
+  let mp = Global.start_library info.library_path in
+  library_info := info;
   openmod_info := default_module_info;
-  Lib.start_compilation dir mp
+  Lib.start_compilation info.library_path mp
 
 let end_library_hook = ref ignore
 let append_end_library_hook f =

--- a/vernac/declaremods.mli
+++ b/vernac/declaremods.mli
@@ -82,7 +82,20 @@ val register_library :
   Safe_typing.compiled_library -> library_objects -> Safe_typing.vodigest ->
   Univ.ContextSet.t -> unit
 
-val start_library : library_name -> unit
+type compilation_mode = BuildVo | BuildVio | Vio2Vo
+
+type library_mode =
+  | Batch of compilation_mode
+  | Interactive
+
+type library_info =
+  { library_path: DirPath.t;
+    library_mode: library_mode;
+  }
+
+val get_current_library_info : unit -> library_info
+
+val start_library : library_info -> unit
 
 val end_library :
   ?except:Future.UUIDSet.t -> output_native_objects:bool -> library_name ->


### PR DESCRIPTION
This is meant to make #8642 easier, in particular avoiding the introduction of a global flag governing the semantics of `Require`.

The approach we take is to make explicit the link between the compilation target and the semantics of `Require`.

We do introduce one semantic change: when producing a `.vo` file, we no longer look for `.vio` files. @gares can you confirm this is the desired behavior?