### PR TITLE
Deprecate `Refine Instance Mode` option

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -153,6 +153,9 @@ Vernacular commands
 
 - The `Show Script` command has been deprecated.
 
+- Option `Refine Instance Mode` has been deprecated and will be removed in
+  the next version.
+
 Tools
 
 - The `-native-compiler` flag of `coqc` and `coqtop` now takes an argument which can have three values:

--- a/doc/sphinx/addendum/type-classes.rst
+++ b/doc/sphinx/addendum/type-classes.rst
@@ -561,6 +561,8 @@ Settings
 
 .. flag:: Refine Instance Mode
 
+   .. deprecated:: 8.10
+
    This flag allows to switch the behavior of instance declarations made through
    the Instance command.
 

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -31,7 +31,7 @@ open Entries
 let refine_instance = ref false
 
 let () = Goptions.(declare_bool_option {
-  optdepr  = false;
+  optdepr  = true;
   optname  = "definition of instances by refining";
   optkey   = ["Refine";"Instance";"Mode"];
   optread  = (fun () -> !refine_instance);


### PR DESCRIPTION
This is in view of the 8.10 release, after which we will remove the
option and the `VtUnknown` classification.

See #9530.