### PR TITLE
Move code ownership of reals library to new maintainer team.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -240,8 +240,7 @@ azure-pipelines.yml @coq/ci-maintainers
 
 /theories/QArith/         @herbelin
 
-/theories/Reals/          @silene
-# Secondary maintainer @ppedrot
+/theories/Reals/          @coq/reals-library-maintainers
 
 /theories/Relations/      @mattam82
 # Secondary maintainer @ppedrot


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** meta / infrastructure.


Follow-up of the proposal in #9803.

The current member of @coq/reals-library-maintainers are @MSoegtropIMC @silene @thery.