### PR TITLE
[parser] initialization based on Loc.t rather than Loc.source

### DIFF
--- a/gramlib/grammar.ml
+++ b/gramlib/grammar.ml
@@ -15,7 +15,7 @@ module type S =
   sig
     type te
     type parsable
-    val parsable : char Stream.t -> parsable
+    val parsable : ?loc:Loc.t -> char Stream.t -> parsable
     val tokens : string -> (string * int) list
     module Entry :
       sig
@@ -1398,8 +1398,8 @@ let clear_entry e =
     Dlevels _ -> e.edesc <- Dlevels []
   | Dparser _ -> ()
 
-    let parsable cs =
-      let (ts, lf) = L.lexer.Plexing.tok_func cs in
+    let parsable ?loc cs =
+      let (ts, lf) = L.lexer.Plexing.tok_func ?loc cs in
       {pa_chr_strm = cs; pa_tok_strm = ts; pa_loc_func = lf}
     module Entry =
       struct

--- a/gramlib/grammar.mli
+++ b/gramlib/grammar.mli
@@ -23,7 +23,7 @@ module type S =
   sig
     type te
     type parsable
-    val parsable : char Stream.t -> parsable
+    val parsable : ?loc:Loc.t -> char Stream.t -> parsable
     val tokens : string -> (string * int) list
     module Entry :
       sig

--- a/gramlib/plexing.ml
+++ b/gramlib/plexing.ml
@@ -5,7 +5,7 @@
 type pattern = string * string
 
 type location_function = int -> Loc.t
-type 'te lexer_func = char Stream.t -> 'te Stream.t * location_function
+type 'te lexer_func = ?loc:Loc.t -> char Stream.t -> 'te Stream.t * location_function
 
 type 'te lexer =
   { tok_func : 'te lexer_func;

--- a/gramlib/plexing.mli
+++ b/gramlib/plexing.mli
@@ -28,7 +28,7 @@ type 'te lexer =
     tok_match : pattern -> 'te -> string;
     tok_text : pattern -> string;
   }
-and 'te lexer_func = char Stream.t -> 'te Stream.t * location_function
+and 'te lexer_func = ?loc:Loc.t -> char Stream.t -> 'te Stream.t * location_function
 and location_function = int -> Loc.t
   (** The type of a function giving the location of a token in the
       source from the token number in the stream (starting from zero). *)

--- a/lib/loc.ml
+++ b/lib/loc.ml
@@ -29,6 +29,8 @@ let create fname line_nb bol_pos bp ep = {
   line_nb_last = line_nb; bol_pos_last = bol_pos; bp = bp; ep = ep;
 }
 
+let initial source = create source 1 0 0 0
+
 let make_loc (bp, ep) = {
   fname = ToplevelInput; line_nb = -1; bol_pos = 0; line_nb_last = -1; bol_pos_last = 0;
   bp = bp; ep = ep;

--- a/lib/loc.mli
+++ b/lib/loc.mli
@@ -32,6 +32,9 @@ val create : source -> int -> int -> int -> int -> t
 (** Create a location from a filename, a line number, a position of the
     beginning of the line, a start and end position *)
 
+val initial : source -> t
+(** Create a location corresponding to the beginning of the given source *)
+
 val unloc : t -> int * int
 (** Return the start and end position of a location *)
 

--- a/parsing/cLexer.mli
+++ b/parsing/cLexer.mli
@@ -51,7 +51,7 @@ end
 (* Mainly for comments state, etc... *)
 type lexer_state
 
-val init_lexer_state : Loc.source -> lexer_state
+val init_lexer_state : unit -> lexer_state
 val set_lexer_state : lexer_state -> unit
 val get_lexer_state : unit -> lexer_state
 val drop_lexer_state : unit -> unit

--- a/parsing/pcoq.ml
+++ b/parsing/pcoq.ml
@@ -59,7 +59,7 @@ module type S =
 
   type coq_parsable
 
-  val coq_parsable : ?file:Loc.source -> char Stream.t -> coq_parsable
+  val coq_parsable : ?loc:Loc.t -> char Stream.t -> coq_parsable
   val entry_create : string -> 'a entry
   val entry_parse : 'a entry -> coq_parsable -> 'a
 
@@ -71,10 +71,10 @@ end with type 'a Entry.e = 'a Extend.entry = struct
 
   type coq_parsable = parsable * CLexer.lexer_state ref
 
-  let coq_parsable ?(file=Loc.ToplevelInput) c =
-    let state = ref (CLexer.init_lexer_state file) in
+  let coq_parsable ?loc c =
+    let state = ref (CLexer.init_lexer_state ()) in
     CLexer.set_lexer_state !state;
-    let a = parsable c in
+    let a = parsable ?loc c in
     state := CLexer.get_lexer_state ();
     (a,state)
 
@@ -320,8 +320,9 @@ let map_entry f en =
 (* Parse a string, does NOT check if the entire string was read
    (use eoi_entry) *)
 
-let parse_string f x =
-  let strm = Stream.of_string x in Gram.entry_parse f (Gram.coq_parsable strm)
+let parse_string f ?loc x =
+  let strm = Stream.of_string x in
+  Gram.entry_parse f (Gram.coq_parsable ?loc strm)
 
 type gram_universe = string
 

--- a/parsing/pcoq.mli
+++ b/parsing/pcoq.mli
@@ -19,7 +19,7 @@ open Libnames
 module Parsable :
 sig
   type t
-  val make : ?file:Loc.source -> char Stream.t -> t
+  val make : ?loc:Loc.t -> char Stream.t -> t
   (* Get comment parsing information from the Lexer *)
   val comment_state : t -> ((int * int) * string) list
 end
@@ -121,7 +121,7 @@ end
 
 (** Parse a string *)
 
-val parse_string : 'a Entry.t -> string -> 'a
+val parse_string : 'a Entry.t -> ?loc:Loc.t -> string -> 'a
 val eoi_entry : 'a Entry.t -> 'a Entry.t
 val map_entry : ('a -> 'b) -> 'a Entry.t -> 'b Entry.t
 

--- a/toplevel/vernac.ml
+++ b/toplevel/vernac.ml
@@ -91,7 +91,8 @@ let load_vernac_core ~echo ~check ~interactive ~state file =
   let input_cleanup () = close_in in_chan; Option.iter close_in in_echo in
 
   let in_pa =
-    Pcoq.Parsable.make ~file:(Loc.InFile file) (Stream.of_channel in_chan) in
+    Pcoq.Parsable.make ~loc:(Loc.initial (Loc.InFile file))
+      (Stream.of_channel in_chan) in
   let open State in
 
   (* ids = For beautify, list of parsed sids *)

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -2175,7 +2175,7 @@ let vernac_load ~st interp fname =
   let input =
     let longfname = Loadpath.locate_file fname in
     let in_chan = open_utf8_file_in longfname in
-    Pcoq.Parsable.make ~file:(Loc.InFile longfname) (Stream.of_channel in_chan) in
+    Pcoq.Parsable.make ~loc:(Loc.initial (Loc.InFile longfname)) (Stream.of_channel in_chan) in
   let rec load_loop ~pstate =
     try
       let proof_mode = Option.map (fun _ -> get_default_proof_mode ()) pstate in


### PR DESCRIPTION
In this way one can also set the current offsets in a file,
useful if you are parsing a Coq fragment within a file instead
of a full file starting from the first line.