### PR TITLE
[scheme side effects] Declare most schemes not as a side effect

### DIFF
--- a/plugins/ltac/rewrite.ml
+++ b/plugins/ltac/rewrite.ml
@@ -958,7 +958,7 @@ let fold_match ?(force=false) env sigma c =
     in 
     let exists = Ind_tables.check_scheme sk ci.ci_ind in
       if exists || force then
-	dep, pred, exists, Ind_tables.find_scheme sk ci.ci_ind
+        dep, pred, exists, Ind_tables.find_scheme ~static:false sk ci.ci_ind
       else raise Not_found
   in
   let app =

--- a/tactics/elimschemes.ml
+++ b/tactics/elimschemes.ml
@@ -31,7 +31,7 @@ let optimize_non_type_induction_scheme kind dep sort _ ind =
     (* in case the inductive has a type elimination, generates only one
        induction scheme, the other ones share the same code with the
        apropriate type *)
-    let cte, eff = find_scheme kind ind in
+    let cte, eff = find_scheme ~static:true kind ind in
     let sigma, cte = Evd.fresh_constant_instance env sigma cte in
     let c = mkConstU cte in
     let t = type_of_constant_in (Global.env()) cte in

--- a/tactics/eqschemes.ml
+++ b/tactics/eqschemes.ml
@@ -247,9 +247,9 @@ let sym_scheme_kind =
 (*                                                                    *)
 (**********************************************************************)
 
-let const_of_scheme kind env ind ctx = 
-  let sym_scheme, eff = (find_scheme kind ind) in
-  let sym, ctx = with_context_set ctx 
+let const_of_scheme kind env ind ctx =
+  let sym_scheme, eff = find_scheme ~static:false kind ind in
+  let sym, ctx = with_context_set ctx
     (UnivGen.fresh_constant_instance (Global.env()) sym_scheme) in
     mkConstU sym, ctx, eff
 

--- a/tactics/eqschemes.mli
+++ b/tactics/eqschemes.mli
@@ -24,6 +24,7 @@ val rew_l2r_forward_dep_scheme_kind : individual scheme_kind
 val rew_r2l_dep_scheme_kind : individual scheme_kind
 val rew_r2l_scheme_kind : individual scheme_kind
 
+(*
 val build_r2l_rew_scheme : bool -> env -> inductive -> Sorts.family -> 
   constr Evd.in_evar_universe_context
 val build_l2r_rew_scheme : bool -> env -> inductive -> Sorts.family -> 
@@ -32,6 +33,7 @@ val build_r2l_forward_rew_scheme :
   bool -> env -> inductive -> Sorts.family -> constr Evd.in_evar_universe_context
 val build_l2r_forward_rew_scheme :
   bool -> env -> inductive -> Sorts.family -> constr Evd.in_evar_universe_context
+*)
 
 (** Builds a symmetry scheme for a symmetrical equality type *)
 

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -395,11 +395,10 @@ let find_elim hdcncl lft2rgt dep cls ot =
     | true, _, false -> rew_r2l_forward_dep_scheme_kind
   in
   match EConstr.kind sigma hdcncl with
-  | Ind (ind,u) -> 
-      
-      let c, eff = find_scheme scheme_name ind in 
-      Proofview.tclEFFECTS eff <*>
-        pf_constr_of_global (ConstRef c) 
+  | Ind (ind,u) ->
+    let c, eff = find_scheme ~static:false scheme_name ind in
+    Proofview.tclEFFECTS eff <*>
+    pf_constr_of_global (ConstRef c)
   | _ -> assert false
   end
 
@@ -990,8 +989,8 @@ let ind_scheme_of_eq lbeq =
   let kind =
     if kind == InProp then Elimschemes.ind_scheme_kind_from_prop
     else Elimschemes.ind_scheme_kind_from_type in
-  let c, eff = find_scheme kind (destIndRef lbeq.eq) in
-    ConstRef c, eff
+  let c, eff = find_scheme ~static:false kind (destIndRef lbeq.eq) in
+  ConstRef c, eff
 
 
 let discrimination_pf e (t,t1,t2) discriminator lbeq =
@@ -1348,7 +1347,7 @@ let inject_if_homogenous_dependent_pair ty =
     check_required_library ["Coq";"Logic";"Eqdep_dec"];
     let new_eq_args = [|pf_unsafe_type_of gl ar1.(3);ar1.(3);ar2.(3)|] in
     let inj2 = lib_ref "core.eqdep_dec.inj_pair2" in
-    let c, eff = find_scheme (!eq_dec_scheme_kind_name()) ind in
+    let c, eff = find_scheme ~static:false (!eq_dec_scheme_kind_name()) ind in
     (* cut with the good equality and prove the requested goal *)
     tclTHENLIST
       [Proofview.tclEFFECTS eff;

--- a/tactics/ind_tables.mli
+++ b/tactics/ind_tables.mli
@@ -23,6 +23,7 @@ type 'a scheme_kind
 
 type mutual_scheme_object_function =
   internal_flag -> MutInd.t -> constr array Evd.in_evar_universe_context * Safe_typing.private_constants
+
 type individual_scheme_object_function =
   internal_flag -> inductive -> constr Evd.in_evar_universe_context * Safe_typing.private_constants
 
@@ -37,17 +38,29 @@ val declare_individual_scheme_object : string -> ?aux:string ->
 
 (** Force generation of a (mutually) scheme with possibly user-level names *)
 
-val define_individual_scheme : individual scheme_kind -> 
-  internal_flag (** internal *) ->
-  Id.t option -> inductive -> Constant.t * Safe_typing.private_constants
+val define_individual_scheme
+  :  static:bool
+  -> individual scheme_kind
+  -> internal_flag (** internal *)
+  -> Id.t option
+  -> inductive -> Constant.t * Safe_typing.private_constants
 
-val define_mutual_scheme : mutual scheme_kind -> internal_flag (** internal *) ->
-  (int * Id.t) list -> MutInd.t -> Constant.t array * Safe_typing.private_constants
+val define_mutual_scheme
+  :  static:bool
+  -> mutual scheme_kind
+  -> internal_flag (** internal *)
+  -> (int * Id.t) list
+  -> MutInd.t
+  -> Constant.t array * Safe_typing.private_constants
 
 (** Main function to retrieve a scheme in the cache or to generate it *)
-val find_scheme : ?mode:internal_flag -> 'a scheme_kind -> inductive -> Constant.t * Safe_typing.private_constants
+val find_scheme
+  :  ?mode:internal_flag
+  -> static:bool                (* whether the scheme has been generated dynamically *)
+  -> 'a scheme_kind
+  -> inductive
+  -> Constant.t * Safe_typing.private_constants
 
 val check_scheme : 'a scheme_kind -> inductive -> bool
-
 
 val pr_scheme_kind : 'a scheme_kind -> Pp.t

--- a/vernac/auto_ind_decl.ml
+++ b/vernac/auto_ind_decl.ml
@@ -211,7 +211,8 @@ let build_beq_scheme mode kn =
             else begin
               try
                 let eq, eff =
-                  let c, eff = find_scheme ~mode (!beq_scheme_kind_aux()) (kn',i) in
+                  let c, eff =
+                    find_scheme ~static:true ~mode (!beq_scheme_kind_aux()) (kn',i) in
                   mkConst c, eff in
                 let eqa, eff =
                   let eqa, effs = List.split (List.map aux a) in
@@ -401,7 +402,7 @@ let do_replace_lb mode lb_scheme_key aavoid narg p q =
     let u,v = destruct_ind env sigma type_of_pq
     in let lb_type_of_p =
         try
-          let c, eff = find_scheme ~mode lb_scheme_key (fst u) (*FIXME*) in
+          let c, eff = find_scheme ~static:true ~mode lb_scheme_key (fst u) (*FIXME*) in
           Proofview.tclUNIT (mkConst c, eff)
         with Not_found ->
           (* spiwack: the format of this error message should probably
@@ -471,7 +472,7 @@ let do_replace_bl mode bl_scheme_key (ind,u as indu) aavoid narg lft rgt =
              else (
                let bl_t1, eff =
                try 
-                 let c, eff = find_scheme bl_scheme_key (fst u) (*FIXME*) in
+                 let c, eff = find_scheme ~static:true bl_scheme_key (fst u) (*FIXME*) in
                  mkConst c, eff
                with Not_found ->
 		 (* spiwack: the format of this error message should probably
@@ -548,7 +549,7 @@ let eqI ind l =
   let eA = Array.of_list((List.map (fun (s,_,_,_) -> mkVar s) list_id)@
                            (List.map (fun (_,seq,_,_)-> mkVar seq) list_id ))
   and e, eff = 
-    try let c, eff = find_scheme beq_scheme_kind ind in mkConst c, eff 
+    try let c, eff = find_scheme ~static:true beq_scheme_kind ind in mkConst c, eff
     with Not_found -> user_err ~hdr:"AutoIndDecl.eqI"
       (str "The boolean equality on " ++ Printer.pr_inductive (Global.env ()) ind ++ str " is needed.");
   in (if Array.equal Constr.equal eA [||] then e else mkApp(e,eA)), eff
@@ -927,13 +928,13 @@ let compute_dec_tact ind lnamesparrec nparrec =
   let arfresh = Array.of_list fresh_first_intros in
   let xargs = Array.sub arfresh 0 (2*nparrec) in
   begin try
-          let c, eff = find_scheme bl_scheme_kind ind in
+          let c, eff = find_scheme ~static:true bl_scheme_kind ind in
           Proofview.tclUNIT (mkConst c,eff) with
     Not_found ->
       Tacticals.New.tclZEROMSG (str "Error during the decidability part, boolean to leibniz equality is required.")
   end >>= fun (blI,eff') ->
   begin try
-          let c, eff = find_scheme lb_scheme_kind ind in
+          let c, eff = find_scheme ~static:true lb_scheme_kind ind in
           Proofview.tclUNIT (mkConst c,eff) with
     Not_found ->
       Tacticals.New.tclZEROMSG (str "Error during the decidability part, leibniz to boolean equality is required.")

--- a/vernac/indschemes.ml
+++ b/vernac/indschemes.ml
@@ -121,7 +121,7 @@ let define ~poly id internal sigma c t =
 (* Boolean equality *)
 
 let declare_beq_scheme_gen internal names kn =
-  ignore (define_mutual_scheme beq_scheme_kind internal names kn)
+  ignore (define_mutual_scheme ~static:true beq_scheme_kind internal names kn)
 
 let alarm what internal msg =
   let debug = false in
@@ -221,7 +221,7 @@ let declare_one_case_analysis_scheme ind =
        induction scheme, the other ones share the same code with the
        apropriate type *)
   if Sorts.List.mem InType kelim then
-    ignore (define_individual_scheme dep UserAutomaticRequest None ind)
+    ignore (define_individual_scheme ~static:true dep UserAutomaticRequest None ind)
 
 (* Induction/recursion schemes *)
 
@@ -258,7 +258,7 @@ let declare_one_induction_scheme ind =
       (if from_prop then kinds_from_prop
        else if depelim then kinds_from_type
        else nondep_kinds_from_type) in
-  List.iter (fun kind -> ignore (define_individual_scheme kind UserAutomaticRequest None ind))
+  List.iter (fun kind -> ignore (define_individual_scheme ~static:true kind UserAutomaticRequest None ind))
     elims
 
 let declare_induction_schemes kn =
@@ -274,7 +274,7 @@ let declare_induction_schemes kn =
 let declare_eq_decidability_gen internal names kn =
   let mib = Global.lookup_mind kn in
   if mib.mind_finite <> Declarations.CoFinite then
-    ignore (define_mutual_scheme eq_dec_scheme_kind internal names kn)
+    ignore (define_mutual_scheme ~static:true eq_dec_scheme_kind internal names kn)
 
 let eq_dec_scheme_msg ind = (* TODO: mutual inductive case *)
   str "Decidable equality on " ++ quote (Printer.pr_inductive (Global.env()) ind)
@@ -294,17 +294,17 @@ let ignore_error f x =
 
 let declare_rewriting_schemes ind =
   if Hipattern.is_inductive_equality ind then begin
-    ignore (define_individual_scheme rew_r2l_scheme_kind UserAutomaticRequest None ind);
-    ignore (define_individual_scheme rew_r2l_dep_scheme_kind UserAutomaticRequest None ind);
-    ignore (define_individual_scheme rew_r2l_forward_dep_scheme_kind
+    ignore (define_individual_scheme ~static:true rew_r2l_scheme_kind UserAutomaticRequest None ind);
+    ignore (define_individual_scheme ~static:true rew_r2l_dep_scheme_kind UserAutomaticRequest None ind);
+    ignore (define_individual_scheme ~static:true rew_r2l_forward_dep_scheme_kind
       UserAutomaticRequest None ind);
     (* These ones expect the equality to be symmetric; the first one also *)
     (* needs eq *)
-    ignore_error (define_individual_scheme rew_l2r_scheme_kind UserAutomaticRequest None) ind;
+    ignore_error (define_individual_scheme ~static:true rew_l2r_scheme_kind UserAutomaticRequest None) ind;
     ignore_error
-      (define_individual_scheme rew_l2r_dep_scheme_kind UserAutomaticRequest None) ind;
+      (define_individual_scheme ~static:true rew_l2r_dep_scheme_kind UserAutomaticRequest None) ind;
     ignore_error
-      (define_individual_scheme rew_l2r_forward_dep_scheme_kind UserAutomaticRequest None) ind
+      (define_individual_scheme ~static:true rew_l2r_forward_dep_scheme_kind UserAutomaticRequest None) ind
   end
 
 let warn_cannot_build_congruence =
@@ -320,7 +320,7 @@ let declare_congr_scheme ind =
       try Coqlib.check_required_library Coqlib.logic_module_name; true
       with e when CErrors.noncritical e -> false
     then
-      ignore (define_individual_scheme congr_scheme_kind UserAutomaticRequest None ind)
+      ignore (define_individual_scheme ~static:true congr_scheme_kind UserAutomaticRequest None ind)
     else
       warn_cannot_build_congruence ()
   end
@@ -328,7 +328,7 @@ let declare_congr_scheme ind =
 let declare_sym_scheme ind =
   if Hipattern.is_inductive_equality ind then
     (* Expect the equality to be symmetric *)
-    ignore_error (define_individual_scheme sym_scheme_kind UserAutomaticRequest None) ind
+    ignore_error (define_individual_scheme ~static:true sym_scheme_kind UserAutomaticRequest None) ind
 
 (* Scheme command *)
 


### PR DESCRIPTION
This PR is also an experimental draft and basically separates
declaration of schemes "on the fly" from those being declared as part
of a vernacular command, and thus not inside a proof.

Let's see what the CI says, if successful, we should reify the types
as to eliminate the extra `eff` parameter from many places and make
dynamic and static versions.

Current "real" dynamic effects for the stdlib are:
```
adding seff [scheme]: Coq.Logic.EqdepFacts.internal_eq_rew_r_dep
adding seff [scheme]: Coq.Logic.Hurkens.TypeNeqSmallType.internal_eq_rew_dep
adding seff [scheme]: Coq.setoid_ring.Ring_polynom.internal_True_rew_r
adding seff [scheme]: Coq.micromega.EnvRing.internal_True_rew_r
adding seff [scheme]: Coq.Logic.ChoiceFacts.internal_eq_rew_dep
adding seff [scheme]: Coq.setoid_ring.Field_theory.internal_True_rew_r
adding seff [scheme]: Coq.btauto.Algebra.internal_null_rew
```
Most of them seem to appear due to
`Indschemes.declare_rewriting_schemes` not triggering for the concrete
case at hand, this seems like a bug indeed in `Equality.find_elim`.
