### PR TITLE
[funind] Use new proof engine.

### DIFF
--- a/engine/proofview.mli
+++ b/engine/proofview.mli
@@ -601,6 +601,7 @@ module V82 : sig
      should be avoided as much as possible.  It should work as
      expected for a tactic obtained from {!V82.tactic} though. *)
   val of_tactic : 'a tactic -> tac
+  (* [@@ocaml.deprecated "use new tactic"] *)
 
   (* marks as unsafe if the argument is [false] *)
   val put_status : bool -> unit tactic

--- a/plugins/funind/functional_principles_proofs.ml
+++ b/plugins/funind/functional_principles_proofs.ml
@@ -8,9 +8,9 @@ open Vars
 open Namegen
 open Names
 open Pp
-open Tacmach
+open Tacmach.New
 open Termops
-open Tacticals
+open Tacticals.New
 open Tactics
 open Indfun_common
 open Libnames
@@ -18,77 +18,11 @@ open Globnames
 open Context.Rel.Declaration
 
 module RelDecl = Context.Rel.Declaration
+module PV = Proofview
+module PG = Proofview.Goal
 
-(* let msgnl = Pp.msgnl *)
-
-(*
-let observe strm =
-  if do_observe ()
-  then Pp.msg_debug strm
-  else ()
-
-let do_observe_tac s tac g =
- try let v = tac g in (* msgnl (goal ++ fnl () ++ (str s)++(str " ")++(str "finished")); *) v
- with e ->
-   let e = ExplainErr.process_vernac_interp_error e in
-   let goal = begin try (Printer.pr_goal g) with _ -> assert false end in
-   msg_debug (str "observation "++ s++str " raised exception " ++
-            Errors.print e ++ str " on goal " ++ goal );
-   raise e;;
-
-let observe_tac_stream s tac g =
-  if do_observe ()
-  then do_observe_tac  s tac g
-  else tac g
-
-let observe_tac s tac g = observe_tac_stream (str s) tac g
-  *)
-
-
-let debug_queue = Stack.create ()
-
-let rec print_debug_queue e =
-  if  not (Stack.is_empty debug_queue)
-  then
-    begin
-      let lmsg,goal = Stack.pop debug_queue in
-      let _ =
-        match e with
-        | Some e ->
-           Feedback.msg_debug (hov 0 (lmsg ++ (str " raised exception " ++ CErrors.print e) ++ str " on goal" ++ fnl() ++ goal))
-        | None ->
-           begin
-             Feedback.msg_debug (str " from " ++ lmsg ++ str " on goal" ++ fnl() ++ goal);
-           end in
-      print_debug_queue None ;
-    end
-
-let observe strm =
-  if do_observe ()
-  then Feedback.msg_debug strm
-  else ()
-
-let do_observe_tac s tac g =
-  let goal = Printer.pr_goal g in
-  let lmsg = (str "observation : ") ++ s in
-  Stack.push (lmsg,goal) debug_queue;
-  try
-    let v = tac g in
-    ignore(Stack.pop debug_queue);
-    v
-  with reraise ->
-    let reraise = CErrors.push reraise in
-    if not (Stack.is_empty debug_queue)
-    then print_debug_queue (Some (fst (ExplainErr.process_vernac_interp_error reraise)));
-    iraise reraise
-
-let observe_tac_stream s tac g =
-  if do_observe ()
-  then do_observe_tac s tac g
-  else tac g
-
-let observe_tac s = observe_tac_stream (str s)
-
+let observe = Indfun_common.observe
+let observe_tac = Indfun_common.observe_tac ~header:Pp.(str "fp_proofs")
 
 let list_chop ?(msg="") n l =
   try
@@ -102,12 +36,10 @@ let make_refl_eq constructor type_of_t t  =
 (*   let refl_equal_term = Lazy.force refl_equal in *)
   mkApp(constructor,[|type_of_t;t|])
 
-
 type pte_info =
-    {
-      proving_tac : (Id.t list -> Tacmach.tactic);
-      is_valid : constr -> bool
-    }
+  { proving_tac : (Id.t list -> unit PV.tactic)
+  ; is_valid : constr -> bool
+  }
 
 type ptes_info = pte_info Id.Map.t
 
@@ -122,15 +54,12 @@ type 'a dynamic_info =
 type body_info = constr dynamic_info
 
 
-let finish_proof dynamic_infos g =
-  observe_tac "finish"
-    (Proofview.V82.of_tactic assumption)
-    g
+let finish_proof dynamic_infos =
+  observe_tac (fun _ _ -> str "finish") assumption
 
+let refine c = Refine.refine ~typecheck:true (fun evd -> evd,c)
 
-let refine c = Refiner.refiner ~check:true EConstr.Unsafe.(to_constr c)
-
-let thin l = Proofview.V82.of_tactic (Tactics.clear l)
+let thin l = Tactics.clear l
 
 let eq_constr sigma u v = EConstr.eq_constr_nounivs sigma u v
 
@@ -172,19 +101,21 @@ let is_incompatible_eq env sigma t =
         | _ -> false
     with e when CErrors.noncritical e -> false
   in
-  if res then   observe (str "is_incompatible_eq " ++ pr_leconstr_env env sigma t);
+  if res then observe (str "is_incompatible_eq " ++ pr_leconstr_env env sigma t);
   res
 
-let change_hyp_with_using msg hyp_id t tac : tactic =
-  fun g ->
-    let prov_id = pf_get_new_id hyp_id g in
+let change_hyp_with_using msg hyp_id t tac =
+  PG.enter begin fun gl ->
+    let prov_id = pf_get_new_id hyp_id gl in
     tclTHENS
-      ((* observe_tac msg *) Proofview.V82.of_tactic (assert_by (Name prov_id) t (Proofview.V82.tactic (tclCOMPLETE tac))))
+      ( (* observe_tac msg *)
+        assert_by (Name prov_id) t (tclCOMPLETE tac))
       [tclTHENLIST
-      [
-        (* observe_tac "change_hyp_with_using thin" *) (thin [hyp_id]);
-        (* observe_tac "change_hyp_with_using rename " *) (Proofview.V82.of_tactic (rename_hyp [prov_id,hyp_id]))
-      ]] g
+         [
+           (* observe_tac "change_hyp_with_using thin" *) (thin [hyp_id]);
+           (* observe_tac "change_hyp_with_using rename " *) (rename_hyp [prov_id,hyp_id])
+         ]]
+  end
 
 exception TOREMOVE
 
@@ -192,22 +123,21 @@ exception TOREMOVE
 let prove_trivial_eq h_id context (constructor,type_of_term,term) =
   let nb_intros = List.length context in
   tclTHENLIST
-    [
-      tclDO nb_intros (Proofview.V82.of_tactic intro); (* introducing context *)
-      (fun g ->
-         let context_hyps =
-           fst (list_chop ~msg:"prove_trivial_eq : " nb_intros (pf_ids_of_hyps g))
-         in
-         let context_hyps' =
-           (mkApp(constructor,[|type_of_term;term|]))::
-             (List.map mkVar context_hyps)
-         in
-         let to_refine = applist(mkVar h_id,List.rev context_hyps') in
-         refine to_refine g
-      )
+    [ tclDO nb_intros intro
+    (* introducing context *)
+    ; PG.enter begin fun gl ->
+        let ids = pf_ids_of_hyps gl in
+        let context_hyps =
+          fst (list_chop ~msg:"prove_trivial_eq : " nb_intros ids)
+        in
+        let context_hyps' =
+          (mkApp(constructor,[|type_of_term;term|]))::
+          (List.map mkVar context_hyps)
+        in
+        let to_refine = applist(mkVar h_id,List.rev context_hyps') in
+        refine to_refine
+      end
     ]
-
-
 
 let find_rectype env sigma c =
   let (t, l) = decompose_app sigma (Reductionops.whd_betaiotazeta sigma c) in
@@ -309,8 +239,7 @@ let change_eq env sigma hyp_id (context:rel_context) x t end_of_type  =
            try
              let witness = Int.Map.find i sub in
              if is_local_def decl then anomaly (Pp.str "can not redefine a rel!");
-      (pop end_of_type,ctxt_size,mkLetIn (RelDecl.get_annot decl,
-                                            witness, RelDecl.get_type decl, witness_fun))
+             (pop end_of_type,ctxt_size,mkLetIn (RelDecl.get_annot decl, witness, RelDecl.get_type decl, witness_fun))
            with Not_found  ->
              (mkProd_or_LetIn decl end_of_type, ctxt_size + 1, mkLambda_or_LetIn decl witness_fun)
         )
@@ -323,16 +252,16 @@ let change_eq env sigma hyp_id (context:rel_context) x t end_of_type  =
     let new_ctxt,new_end_of_type =
       decompose_prod_n_assum sigma ctxt_size new_type_of_hyp
     in
-    let prove_new_hyp : tactic =
+    let prove_new_hyp  =
       tclTHEN
-        (tclDO ctxt_size (Proofview.V82.of_tactic intro))
-        (fun g ->
-           let all_ids = pf_ids_of_hyps g in
-           let new_ids,_  = list_chop ctxt_size all_ids in
-           let to_refine = applist(witness_fun,List.rev_map mkVar new_ids) in
-           let evm, _ = pf_apply Typing.type_of g to_refine in
-             tclTHEN (Refiner.tclEVARS evm) (refine to_refine) g
-        )
+        (tclDO ctxt_size intro)
+        (PG.enter begin fun gl ->
+            let all_ids = pf_ids_of_hyps gl in
+            let new_ids,_  = list_chop ctxt_size all_ids in
+            let to_refine = applist(witness_fun,List.rev_map mkVar new_ids) in
+            let evm, _ = pf_apply Typing.type_of gl to_refine in
+            tclTHEN (PV.Unsafe.tclEVARS evm) (refine to_refine)
+          end)
     in
     let simpl_eq_tac =
       change_hyp_with_using "prove_pattern_simplification" hyp_id new_type_of_hyp prove_new_hyp
@@ -373,16 +302,14 @@ let isLetIn sigma t =
     | _ -> false
 
 
-let h_reduce_with_zeta cl =
-  Proofview.V82.of_tactic (reduce
+let h_reduce_with_zeta =
+  reduce
     (Genredexpr.Cbv
        {Redops.all_flags
         with Genredexpr.rDelta = false;
-       }) cl)
+       })
 
-
-
-let rewrite_until_var arg_num eq_ids : tactic =
+let rewrite_until_var arg_num eq_ids =
   (* tests if the declares recursive argument is neither a Constructor nor
      an applied Constructor since such a form for the recursive argument
      will break the Guard when trying to save the Lemma.
@@ -392,17 +319,18 @@ let rewrite_until_var arg_num eq_ids : tactic =
     let _,args = destApp sigma (pf_concl g) in
     not ((isConstruct sigma args.(arg_num)) || isAppConstruct sigma args.(arg_num))
   in
-  let rec do_rewrite eq_ids g  =
-    if test_var g
-    then tclIDTAC g
-    else
-      match eq_ids with
+  let rec do_rewrite eq_ids =
+    PG.enter begin fun gl ->
+      if test_var gl
+      then tclIDTAC
+      else
+        match eq_ids with
         | [] -> anomaly (Pp.str "Cannot find a way to prove recursive property.");
         | eq_id::eq_ids ->
-            tclTHEN
-              (tclTRY (Proofview.V82.of_tactic (Equality.rewriteRL (mkVar eq_id))))
-              (do_rewrite eq_ids)
-              g
+          tclTHEN
+            (tclTRY (Equality.rewriteRL (mkVar eq_id)))
+            (do_rewrite eq_ids)
+    end
   in
   do_rewrite eq_ids
 
@@ -412,7 +340,7 @@ let clean_hyp_with_heq ptes_infos eq_hyps hyp_id env sigma =
   let coq_False = EConstr.of_constr (UnivGen.constr_of_monomorphic_global @@ Coqlib.lib_ref "core.False.type") in
   let coq_True = EConstr.of_constr (UnivGen.constr_of_monomorphic_global @@ Coqlib.lib_ref "core.True.type") in
   let coq_I = EConstr.of_constr (UnivGen.constr_of_monomorphic_global @@ Coqlib.lib_ref "core.True.I") in
-  let rec scan_type  context type_of_hyp : tactic =
+  let rec scan_type  context type_of_hyp =
     if isLetIn sigma type_of_hyp then
       let real_type_of_hyp = it_mkProd_or_LetIn type_of_hyp context in
       let reduced_type_of_hyp = Reductionops.nf_betaiotazeta env sigma real_type_of_hyp in
@@ -437,77 +365,73 @@ let clean_hyp_with_heq ptes_infos eq_hyps hyp_id env sigma =
             let prove_new_type_of_hyp =
               let context_length = List.length context in
               tclTHENLIST
-                [
-                  tclDO context_length (Proofview.V82.of_tactic intro);
-                  (fun g ->
-                     let context_hyps_ids =
-                       fst (list_chop ~msg:"rec hyp : context_hyps"
-                              context_length (pf_ids_of_hyps g))
-                     in
-                     let rec_pte_id = pf_get_new_id rec_pte_id g in
-                     let to_refine =
-                       applist(mkVar hyp_id,
-                               List.rev_map mkVar (rec_pte_id::context_hyps_ids)
-                              )
-                     in
-(*                   observe_tac "rec hyp " *)
-                       (tclTHENS
-                       (Proofview.V82.of_tactic (assert_before (Name rec_pte_id) t_x))
+                [ tclDO context_length intro
+                ; PG.enter begin fun gl ->
+                    let context_hyps_ids =
+                      fst (list_chop ~msg:"rec hyp : context_hyps"
+                             context_length (pf_ids_of_hyps gl))
+                    in
+                    let rec_pte_id = pf_get_new_id rec_pte_id gl in
+                    let to_refine =
+                      applist(mkVar hyp_id,
+                              List.rev_map mkVar (rec_pte_id::context_hyps_ids))
+                    in
+                    (*                   observe_tac "rec hyp " *)
+                    (tclTHENS
+                       (assert_before (Name rec_pte_id) t_x)
                        [
                          (* observe_tac "prove rec hyp" *) (prove_rec_hyp eq_hyps);
-(*                      observe_tac "prove rec hyp" *)
-                          (refine to_refine)
+                         (*                      observe_tac "prove rec hyp" *)
+                         (refine to_refine)
                        ])
-                       g
-                  )
+                  end
                 ]
             in
             tclTHENLIST
-              [
-(*              observe_tac "hyp rec"  *)
-                  (change_hyp_with_using "rec_hyp_tac" hyp_id real_type_of_hyp prove_new_type_of_hyp);
-                scan_type context popped_t'
+              (*              observe_tac "hyp rec"  *)
+              [ (change_hyp_with_using "rec_hyp_tac" hyp_id real_type_of_hyp prove_new_type_of_hyp)
+              ; scan_type context popped_t'
               ]
           end
         else if eq_constr sigma t_x coq_False then
           begin
-(*          observe (str "Removing : "++ Ppconstr.pr_id hyp_id++  *)
-(*                     str " since it has False in its preconds " *)
-(*                  ); *)
+            (*          observe (str "Removing : "++ Ppconstr.pr_id hyp_id++  *)
+            (*                     str " since it has False in its preconds " *)
+            (*                  ); *)
             raise TOREMOVE;  (* False -> .. useless *)
           end
         else if is_incompatible_eq env sigma t_x then raise TOREMOVE (* t_x := C1 ... =  C2 ... *)
         else if eq_constr sigma t_x coq_True  (* Trivial => we remove this precons *)
         then
-(*          observe (str "In "++Ppconstr.pr_id hyp_id++  *)
-(*                     str " removing useless precond True" *)
-(*                  );  *)
+          (*          observe (str "In "++Ppconstr.pr_id hyp_id++  *)
+          (*                     str " removing useless precond True" *)
+          (*                  );  *)
           let popped_t' = pop t' in
           let real_type_of_hyp =
             it_mkProd_or_LetIn popped_t' context
           in
           let prove_trivial =
             let nb_intro = List.length context in
-            tclTHENLIST [
-              tclDO nb_intro (Proofview.V82.of_tactic intro);
-              (fun g ->
-                 let context_hyps =
-                   fst (list_chop ~msg:"removing True : context_hyps "nb_intro (pf_ids_of_hyps g))
-                 in
-                 let to_refine =
-                   applist (mkVar hyp_id,
-                            List.rev (coq_I::List.map mkVar context_hyps)
-                           )
-                 in
-                 refine to_refine g
-              )
-            ]
+            tclTHENLIST
+              [ tclDO nb_intro intro
+              ; PG.enter begin fun gl ->
+                  let context_hyps =
+                    fst (list_chop ~msg:"removing True : context_hyps "nb_intro (pf_ids_of_hyps gl))
+                  in
+                  let to_refine =
+                    applist (mkVar hyp_id,
+                             List.rev (coq_I::List.map mkVar context_hyps)
+                            )
+                  in
+                  refine to_refine
+                end
+              ]
           in
-          tclTHENLIST[
-            change_hyp_with_using "prove_trivial" hyp_id real_type_of_hyp
-              ((* observe_tac "prove_trivial" *) prove_trivial);
-            scan_type context popped_t'
-          ]
+          tclTHENLIST
+            [ change_hyp_with_using "prove_trivial" hyp_id real_type_of_hyp
+                ((* observe_tac "prove_trivial" *) prove_trivial)
+            ; scan_type context popped_t'
+            ]
         else if is_trivial_eq sigma t_x
         then (*  t_x :=  t = t   => we remove this precond *)
           let popped_t' = pop t' in
@@ -521,19 +445,18 @@ let clean_hyp_with_heq ptes_infos eq_hyps hyp_id env sigma =
             else (jmeq_refl (),args.(0),args.(1))
           in
           tclTHENLIST
-            [
-              change_hyp_with_using
+            [ change_hyp_with_using
                 "prove_trivial_eq"
                 hyp_id
                 real_type_of_hyp
                 ((* observe_tac "prove_trivial_eq" *)
-                  (prove_trivial_eq hyp_id context (get_args hd args)));
-              scan_type context popped_t'
+                  (prove_trivial_eq hyp_id context (get_args hd args)))
+            ; scan_type context popped_t'
             ]
         else
           begin
             try
-              let new_context,new_t',tac = change_eq env sigma hyp_id context x t_x t' in
+              let new_context,new_t', tac = change_eq env sigma hyp_id context x t_x t' in
               tclTHEN
                 tac
                 (scan_type new_context new_t')
@@ -550,11 +473,10 @@ let clean_hyp_with_heq ptes_infos eq_hyps hyp_id env sigma =
   with TOREMOVE ->
     thin [hyp_id],[]
 
-
 let clean_goal_with_heq ptes_infos continue_tac (dyn_infos:body_info) =
-  fun g ->
-    let env = pf_env g
-    and sigma = project g
+  PG.enter begin fun gl ->
+    let env = pf_env gl
+    and sigma = project gl
     in
     let tac,new_hyps =
       List.fold_left (
@@ -574,94 +496,74 @@ let clean_goal_with_heq ptes_infos continue_tac (dyn_infos:body_info) =
       }
     in
     tclTHENLIST
-      [
-        tac ;
-        (* observe_tac "clean_hyp_with_heq continue" *) (continue_tac new_infos)
+      [ tac
+      ; (* observe_tac "clean_hyp_with_heq continue" *) (continue_tac new_infos)
       ]
-      g
+  end
 
 let heq_id = Id.of_string "Heq"
 
 let treat_new_case ptes_infos nb_prod continue_tac term dyn_infos =
-  fun g ->
     let nb_first_intro = nb_prod - 1 - dyn_infos.nb_rec_hyps in
     tclTHENLIST
-      [
-        (* We first introduce the variables *)
-        tclDO nb_first_intro (Proofview.V82.of_tactic (intro_avoiding (Id.Set.of_list dyn_infos.rec_hyps)));
-        (* Then the equation itself *)
-        Proofview.V82.of_tactic (intro_using heq_id);
-        onLastHypId (fun heq_id -> tclTHENLIST [
-        (* Then the new hypothesis *)
-        tclMAP (fun id -> Proofview.V82.of_tactic (introduction id)) dyn_infos.rec_hyps;
-        observe_tac "after_introduction" (fun g' ->
-           (* We get infos on the equations introduced*)
-           let new_term_value_eq = pf_unsafe_type_of g' (mkVar heq_id) in
-           (* compute the new value of the body *)
-           let new_term_value =
-             match EConstr.kind (project g') new_term_value_eq with
-               | App(f,[| _;_;args2 |]) -> args2
-               | _ ->
-                   observe (str "cannot compute new term value : " ++ pr_gls g' ++ fnl () ++ str "last hyp is" ++
-                              pr_leconstr_env (pf_env g') (project g') new_term_value_eq
-                           );
-                   anomaly (Pp.str "cannot compute new term value.")
-           in
-         let fun_body =
-           mkLambda(make_annot Anonymous Sorts.Relevant,
-                    pf_unsafe_type_of g' term,
-                    Termops.replace_term (project g') term (mkRel 1) dyn_infos.info
-                   )
-         in
-         let new_body = pf_nf_betaiota g' (mkApp(fun_body,[| new_term_value |])) in
-         let new_infos =
-           {dyn_infos with
-              info = new_body;
-              eq_hyps = heq_id::dyn_infos.eq_hyps
-           }
-         in
-         clean_goal_with_heq ptes_infos continue_tac new_infos  g'
-      )])
-    ]
-      g
+      (* We first introduce the variables *)
+      [ tclDO nb_first_intro (intro_avoiding (Id.Set.of_list dyn_infos.rec_hyps))
+      (* Then the equation itself *)
+      ; intro_using heq_id;
+        onLastHypId (fun heq_id ->
+            tclTHENLIST
+              (* Then the new hypothesis *)
+              [ tclMAP (fun id -> introduction id) dyn_infos.rec_hyps
+              ; observe_tac (fun _ _ -> str "after_introduction") (
+                  (* We get infos on the equations introduced*)
+                  PG.enter begin fun gl ->
+                    let new_term_value_eq = pf_unsafe_type_of gl (mkVar heq_id) in
+                    (* compute the new value of the body *)
+                    let new_term_value =
+                      match EConstr.kind (project gl) new_term_value_eq with
+                      | App(f,[| _;_;args2 |]) -> args2
+                      | _ ->
+                        observe (str "cannot compute new term value : " ++ (* Tacmach.pr_gls gl ++ *) fnl () ++ str "last hyp is" ++
+                                 pr_leconstr_env (pf_env gl) (project gl) new_term_value_eq
+                                );
+                        anomaly (Pp.str "cannot compute new term value.")
+                    in
+                    let fun_body =
+                      mkLambda(annotR Anonymous,
+                               pf_unsafe_type_of gl term,
+                               Termops.replace_term (project gl) term (mkRel 1) dyn_infos.info
+                              )
+                    in
+                    let new_body = pf_nf_betaiota (mkApp(fun_body,[| new_term_value |])) in
+                    let new_infos =
+                      {dyn_infos with
+                       info = new_body;
+                       eq_hyps = heq_id::dyn_infos.eq_hyps
+                      }
+                    in
+                    clean_goal_with_heq ptes_infos continue_tac new_infos
+                  end
+                )])
+      ]
 
-
-let my_orelse tac1 tac2 g =
-  try
-    tac1 g
-  with e when CErrors.noncritical e ->
-(*     observe (str "using snd tac since : " ++ CErrors.print e); *)
-    tac2 g
-
-let instantiate_hyps_with_args (do_prove:Id.t list -> tactic) hyps args_id =
+let instantiate_hyps_with_args (do_prove : Id.t list -> unit Proofview.tactic) hyps args_id =
   let args = Array.of_list (List.map mkVar  args_id) in
   let instantiate_one_hyp hid =
-    my_orelse
+    tclORELSE
       ( (* we instantiate the hyp if possible  *)
-        fun g ->
-          let prov_hid = pf_get_new_id hid g in
-          let c = mkApp(mkVar hid,args) in
-          let evm, _ = pf_apply Typing.type_of g c in
-          tclTHENLIST[
-            Refiner.tclEVARS evm;
-            Proofview.V82.of_tactic (pose_proof (Name prov_hid) c);
-            thin [hid];
-            Proofview.V82.of_tactic (rename_hyp [prov_hid,hid])
-          ] g
+        PG.enter begin fun gl ->
+        let prov_hid = pf_get_new_id hid gl in
+        let c = mkApp(mkVar hid,args) in
+        let evm, _ = pf_apply Typing.type_of gl c in
+        tclTHENLIST
+          [ Proofview.Unsafe.tclEVARS evm
+          ; pose_proof (Name prov_hid) c
+          ; thin [hid]
+          ; rename_hyp [prov_hid,hid]
+          ]
+        end
       )
-      ( (*
-          if not then we are in a mutual function block
-          and this hyp is a recursive hyp on an other function.
-
-          We are not supposed to use it while proving this
-          principle so that we can trash it
-
-        *)
-        (fun g ->
-(*         observe (str "Instantiation: removing hyp " ++ Ppconstr.pr_id hid); *)
-           thin [hid] g
-        )
-      )
+      (thin [hid])
   in
   if List.is_empty args_id
   then
@@ -671,216 +573,206 @@ let instantiate_hyps_with_args (do_prove:Id.t list -> tactic) hyps args_id =
     ]
   else
     tclTHENLIST
-      [
-        tclMAP (fun hyp_id -> h_reduce_with_zeta (Locusops.onHyp hyp_id)) hyps;
-        tclMAP instantiate_one_hyp hyps;
-        (fun g ->
-           let all_g_hyps_id =
-             List.fold_right Id.Set.add (pf_ids_of_hyps g) Id.Set.empty
-           in
-           let remaining_hyps =
-             List.filter (fun id -> Id.Set.mem id all_g_hyps_id) hyps
-           in
-           do_prove remaining_hyps g
-          )
+      [ tclMAP (fun hyp_id -> h_reduce_with_zeta (Locusops.onHyp hyp_id)) hyps
+      ; tclMAP instantiate_one_hyp hyps
+      ; PG.enter begin fun gl ->
+          let all_g_hyps_id =
+            List.fold_right Id.Set.add (pf_ids_of_hyps gl) Id.Set.empty
+          in
+          let remaining_hyps =
+            List.filter (fun id -> Id.Set.mem id all_g_hyps_id) hyps
+          in
+          do_prove remaining_hyps
+        end
       ]
 
 let build_proof
     (interactive_proof:bool)
     (fnames:Constant.t list)
     ptes_infos
-    dyn_infos
-    : tactic =
-  let rec build_proof_aux do_finalize dyn_infos : tactic =
-    fun g ->
-        let env = pf_env g in
-        let sigma = project g in
-(*      observe (str "proving on " ++ Printer.pr_lconstr_env (pf_env g) term);*)
-        match EConstr.kind sigma dyn_infos.info with
-          | Case(ci,ct,t,cb) ->
-              let do_finalize_t dyn_info' =
-                fun g ->
-                  let t = dyn_info'.info in
-                  let dyn_infos = {dyn_info' with info =
-                      mkCase(ci,ct,t,cb)} in
-                  let g_nb_prod = nb_prod (project g) (pf_concl g) in
-                  let type_of_term = pf_unsafe_type_of g t in
-                  let term_eq =
-                    make_refl_eq (Lazy.force refl_equal) type_of_term t
-                  in
-                  tclTHENLIST
-                    [
-                      Proofview.V82.of_tactic (generalize (term_eq::(List.map mkVar dyn_infos.rec_hyps)));
-                      thin dyn_infos.rec_hyps;
-                      Proofview.V82.of_tactic (pattern_option [Locus.AllOccurrencesBut [1],t] None);
-                      (fun g -> observe_tac "toto" (
-                         tclTHENLIST [Proofview.V82.of_tactic (Simple.case t);
-                                     (fun g' ->
-                                        let g'_nb_prod = nb_prod (project g') (pf_concl g') in
-                                        let nb_instantiate_partial = g'_nb_prod - g_nb_prod in
-                                        observe_tac "treat_new_case"
-                                          (treat_new_case
-                                             ptes_infos
-                                             nb_instantiate_partial
-                                             (build_proof do_finalize)
-                                             t
-                                             dyn_infos)
-                                          g'
-                                     )
-
-                                    ]) g
-                      )
-                    ]
-                    g
-              in
-              build_proof do_finalize_t {dyn_infos with info = t} g
-          | Lambda(n,t,b) ->
-              begin
-                match EConstr.kind sigma (pf_concl g) with
-                  | Prod _ ->
-                      tclTHEN
-                        (Proofview.V82.of_tactic intro)
-                        (fun g' ->
-                           let open Context.Named.Declaration in
-                           let id = pf_last_hyp g' |> get_id in
-                           let new_term =
-                             pf_nf_betaiota g'
-                               (mkApp(dyn_infos.info,[|mkVar id|]))
-                           in
-                           let new_infos = {dyn_infos with info = new_term} in
-                           let do_prove new_hyps =
-                             build_proof do_finalize
-                               {new_infos with
-                                  rec_hyps = new_hyps;
-                                  nb_rec_hyps  = List.length new_hyps
-                               }
-                           in
-(*                         observe_tac "Lambda" *) (instantiate_hyps_with_args do_prove new_infos.rec_hyps [id]) g'
-                             (*                            build_proof do_finalize new_infos g' *)
-                        ) g
-                  | _ ->
-                      do_finalize dyn_infos g
-              end
-          | Cast(t,_,_) ->
-              build_proof do_finalize {dyn_infos with info = t} g
-          | Const _ | Var _ | Meta _ | Evar _ | Sort _ | Construct _ | Ind _ | Int _ ->
-              do_finalize dyn_infos g
-          | App(_,_) ->
-              let f,args = decompose_app sigma dyn_infos.info in
-              begin
-                match EConstr.kind sigma f with
-      | Int _ -> user_err Pp.(str "integer cannot be applied")
-                  | App _ -> assert false (* we have collected all the app in decompose_app *)
-                  | Proj _ -> assert false (*FIXME*)
-                  | Var _ | Construct _ | Rel _ | Evar _ | Meta _  | Ind _ | Sort _ | Prod _ ->
-                      let new_infos =
-                        { dyn_infos with
-                            info = (f,args)
-                        }
-                      in
-                      build_proof_args env sigma do_finalize new_infos  g
-                  | Const (c,_) when not (List.mem_f Constant.equal c fnames) ->
-                      let new_infos =
-                        { dyn_infos with
-                            info = (f,args)
-                        }
-                      in
-(*                    Pp.msgnl (str "proving in " ++ pr_lconstr_env (pf_env g) dyn_infos.info); *)
-                      build_proof_args env sigma do_finalize new_infos g
-                  | Const _ ->
-                      do_finalize dyn_infos  g
-                  | Lambda _ ->
-                      let new_term =
-                        Reductionops.nf_beta env sigma dyn_infos.info in
-                      build_proof do_finalize {dyn_infos with info = new_term}
-                        g
-                  | LetIn _ ->
-                      let new_infos =
-                        { dyn_infos with info = Reductionops.nf_betaiotazeta env sigma dyn_infos.info }
-                      in
-
-                      tclTHENLIST
-                        [tclMAP
-                           (fun hyp_id ->
-                             h_reduce_with_zeta (Locusops.onHyp hyp_id))
-                           dyn_infos.rec_hyps;
-                         h_reduce_with_zeta Locusops.onConcl;
-                         build_proof do_finalize new_infos
-                        ]
-                        g
-                  | Cast(b,_,_) ->
-                      build_proof do_finalize {dyn_infos with info = b } g
-                  | Case _ | Fix _ | CoFix _ ->
-                      let new_finalize dyn_infos =
-                        let new_infos =
-                          { dyn_infos with
-                              info = dyn_infos.info,args
-                          }
-                        in
-                        build_proof_args env sigma do_finalize new_infos
-                      in
-                      build_proof new_finalize {dyn_infos  with info = f } g
-              end
-          | Fix _ | CoFix _ ->
-              user_err Pp.(str ( "Anonymous local (co)fixpoints are not handled yet"))
-
-
-          | Proj _ -> user_err Pp.(str "Prod")
-          | Prod _ -> do_finalize dyn_infos g
-          | LetIn _ ->
-              let new_infos =
-                { dyn_infos with
-                    info = Reductionops.nf_betaiotazeta env sigma dyn_infos.info
-                }
-              in
-
+    dyn_infos =
+  let rec build_proof_aux do_finalize dyn_infos =
+    let open PV.Notations in
+    PV.tclEVARMAP >>= fun sigma ->
+    PV.tclENV >>= fun env ->
+    (*      observe (str "proving on " ++ Printer.pr_lconstr_env (pf_env g) term);*)
+    match EConstr.kind sigma dyn_infos.info with
+    | Case(ci,ct,t,cb) ->
+      let do_finalize_t dyn_info' =
+        PG.enter begin fun gl ->
+        let t = dyn_info'.info in
+        let dyn_infos = {dyn_info' with
+                         info = mkCase(ci,ct,t,cb)} in
+        let g_nb_prod = nb_prod (project gl) (pf_concl gl) in
+        let type_of_term = pf_unsafe_type_of gl t in
+        let term_eq =
+          make_refl_eq (Lazy.force refl_equal) type_of_term t
+        in
+        tclTHENLIST
+          [ generalize (term_eq::(List.map mkVar dyn_infos.rec_hyps))
+          ; thin dyn_infos.rec_hyps
+          ; pattern_option [Locus.AllOccurrencesBut [1],t] None
+          ; observe_tac (fun _ _ -> Pp.str "toto") (
+              PG.enter begin fun gl' ->
               tclTHENLIST
-                [tclMAP
-                   (fun hyp_id -> h_reduce_with_zeta (Locusops.onHyp hyp_id))
-                   dyn_infos.rec_hyps;
-                 h_reduce_with_zeta Locusops.onConcl;
-                 build_proof do_finalize new_infos
-                ] g
-          | Rel _ -> anomaly (Pp.str "Free var in goal conclusion!")
-  and build_proof do_finalize dyn_infos g =
-(*     observe (str "proving with "++Printer.pr_lconstr dyn_infos.info++ str " on goal " ++ pr_gls g); *)
-    observe_tac_stream (str "build_proof with " ++ pr_leconstr_env (pf_env g) (project g) dyn_infos.info ) (build_proof_aux do_finalize dyn_infos) g
-  and build_proof_args env sigma do_finalize dyn_infos (* f_args'  args *) :tactic =
-    fun g ->
-      let (f_args',args) = dyn_infos.info in
-      let tac : tactic =
-        fun g ->
-          match args with
-            | []  ->
-              do_finalize {dyn_infos with info = f_args'} g
-            | arg::args ->
-              (*                observe (str "build_proof_args with arg := "++ pr_lconstr_env (pf_env g) arg++ *)
-              (*                        fnl () ++  *)
-              (*                        pr_goal (Tacmach.sig_it g) *)
-              (*                        ); *)
-              let do_finalize dyn_infos =
-                let new_arg = dyn_infos.info in
-                (*              tclTRYD *)
-                (build_proof_args env sigma
-                   do_finalize
-                   {dyn_infos with info = (mkApp(f_args',[|new_arg|])), args}
-                )
-              in
-              build_proof do_finalize
-                {dyn_infos with info = arg }
-                g
+                [ Simple.case t
+                ; let g'_nb_prod = nb_prod (project gl') (pf_concl gl') in
+                  let nb_instantiate_partial = g'_nb_prod - g_nb_prod in
+                  observe_tac (fun _ _ -> str "treat_new_case")
+                    (treat_new_case
+                       ptes_infos
+                       nb_instantiate_partial
+                       (build_proof do_finalize)
+                       t
+                       dyn_infos)
+              ] end)
+          ] end
       in
-      (* observe_tac "build_proof_args" *) (tac ) g
+      build_proof do_finalize_t {dyn_infos with info = t}
+    | Lambda(n,t,b) ->
+      PG.enter begin fun gl ->
+        match EConstr.kind sigma (pf_concl gl) with
+        | Prod _ ->
+          tclTHEN
+            intro
+            (let open Context.Named.Declaration in
+             PG.enter begin fun gl' ->
+             let id = pf_last_hyp gl' |> get_id in
+             let new_term =
+               pf_nf_betaiota gl'
+                 (mkApp(dyn_infos.info,[|mkVar id|]))
+             in
+             let new_infos = {dyn_infos with info = new_term} in
+             let do_prove new_hyps =
+               build_proof do_finalize
+                 {new_infos with
+                  rec_hyps = new_hyps;
+                  nb_rec_hyps  = List.length new_hyps
+                 }
+             in
+             (*                         observe_tac "Lambda" *)
+             instantiate_hyps_with_args do_prove new_infos.rec_hyps [id]
+             (*                            build_proof do_finalize new_infos g' *)
+             end)
+        | _ ->
+          do_finalize dyn_infos
+      end
+    | Cast(t,_,_) ->
+      build_proof do_finalize {dyn_infos with info = t}
+    | Const _ | Var _ | Meta _ | Evar _ | Sort _ | Construct _ | Ind _ ->
+      do_finalize dyn_infos
+    | App(_,_) ->
+      let f,args = decompose_app sigma dyn_infos.info in
+      begin
+        match EConstr.kind sigma f with
+        | App _ -> assert false (* we have collected all the app in decompose_app *)
+        | Proj _ -> assert false (*FIXME*)
+        | Int _ -> assert false (*FIXME*)
+        | Var _ | Construct _ | Rel _ | Evar _ | Meta _  | Ind _ | Sort _ | Prod _ ->
+          let new_infos =
+            { dyn_infos with
+              info = (f,args)
+            }
+          in
+          build_proof_args do_finalize new_infos
+        | Const (c,_) when not (List.mem_f Constant.equal c fnames) ->
+          let new_infos =
+            { dyn_infos with
+              info = (f,args)
+            }
+          in
+          (*                    Pp.msgnl (str "proving in " ++ pr_lconstr_env (pf_env g) dyn_infos.info); *)
+          build_proof_args do_finalize new_infos
+        | Const _ ->
+          do_finalize dyn_infos
+        | Lambda _ ->
+          let new_term =
+            Reductionops.nf_beta env sigma dyn_infos.info in
+          build_proof do_finalize {dyn_infos with info = new_term}
+        | LetIn _ ->
+          let new_infos =
+            { dyn_infos with info = Reductionops.nf_betaiotazeta env sigma dyn_infos.info }
+          in
+          tclTHENLIST
+            [tclMAP
+               (fun hyp_id ->
+                  h_reduce_with_zeta (Locusops.onHyp hyp_id))
+               dyn_infos.rec_hyps;
+             h_reduce_with_zeta Locusops.onConcl;
+             build_proof do_finalize new_infos
+            ]
+        | Cast(b,_,_) ->
+          build_proof do_finalize {dyn_infos with info = b }
+        | Case _ | Fix _ | CoFix _ ->
+          let new_finalize dyn_infos =
+            let new_infos =
+              { dyn_infos with
+                info = dyn_infos.info,args
+              }
+            in
+            build_proof_args do_finalize new_infos
+          in
+          build_proof new_finalize {dyn_infos  with info = f }
+      end
+    | Fix _ | CoFix _ ->
+      user_err Pp.(str ( "Anonymous local (co)fixpoints are not handled yet"))
+
+
+    | Proj _ -> user_err Pp.(str "Prod")
+    | Int _ -> user_err Pp.(str "Int")
+    | Prod _ -> do_finalize dyn_infos
+    | LetIn _ ->
+      let new_infos =
+        { dyn_infos with
+          info = Reductionops.nf_betaiotazeta env sigma dyn_infos.info
+        }
+      in
+      tclTHENLIST
+        [tclMAP
+           (fun hyp_id -> h_reduce_with_zeta (Locusops.onHyp hyp_id))
+           dyn_infos.rec_hyps;
+         h_reduce_with_zeta Locusops.onConcl;
+         build_proof do_finalize new_infos
+        ]
+    | Rel _ -> anomaly (Pp.str "Free var in goal conclusion!")
+  and build_proof do_finalize dyn_infos =
+    (*     observe (str "proving with "++Printer.pr_lconstr dyn_infos.info++ str " on goal " ++ pr_gls g); *)
+    (* observe_tac_stream (str "build_proof with " ++ pr_leconstr_fp dyn_infos.info ) *)
+    build_proof_aux do_finalize dyn_infos
+  and build_proof_args do_finalize dyn_infos (* f_args'  args *) =
+    let (f_args',args) = dyn_infos.info in
+    let tac : unit Proofview.tactic =
+      match args with
+      | []  ->
+        do_finalize {dyn_infos with info = f_args'}
+      | arg::args ->
+        (*                observe (str "build_proof_args with arg := "++ pr_lconstr_env (pf_env g) arg++ *)
+        (*                        fnl () ++  *)
+        (*                        pr_goal (Tacmach.sig_it g) *)
+        (*                        ); *)
+        let do_finalize dyn_infos =
+          let new_arg = dyn_infos.info in
+          (*              tclTRYD *)
+          (build_proof_args
+             do_finalize
+             {dyn_infos with info = (mkApp(f_args',[|new_arg|])), args}
+          )
+        in
+        build_proof do_finalize
+          {dyn_infos with info = arg }
+    in
+    tac
+    (* observe_tac "build_proof_args" *)
   in
   let do_finish_proof dyn_infos =
-     (* tclTRYD *) (clean_goal_with_heq
-                      ptes_infos
-                      finish_proof dyn_infos)
+    (* tclTRYD *)
+    (clean_goal_with_heq
+       ptes_infos
+       finish_proof dyn_infos)
   in
-    (* observe_tac "build_proof" *)
-  fun g ->
-    build_proof (clean_goal_with_heq ptes_infos do_finish_proof) dyn_infos g
 
+  (* observe_tac "build_proof" *)
+  build_proof (clean_goal_with_heq ptes_infos do_finish_proof) dyn_infos
 
 (* Proof of principles from structural functions *)
 
@@ -895,18 +787,16 @@ type static_fix_info =
       num_in_block : int
     }
 
-
-
-let prove_rec_hyp_for_struct fix_info =
-      (fun  eq_hyps -> tclTHEN
-        (rewrite_until_var (fix_info.idx) eq_hyps)
-        (fun g ->
-           let _,pte_args = destApp (project g) (pf_concl g) in
-           let rec_hyp_proof =
-             mkApp(mkVar fix_info.name,array_get_start pte_args)
-           in
-           refine rec_hyp_proof g
-        ))
+let prove_rec_hyp_for_struct fix_info eq_hyps =
+  tclTHEN
+    (rewrite_until_var (fix_info.idx) eq_hyps)
+    PG.(enter begin fun gl ->
+        let _, pte_args = destApp (project gl) (pf_concl gl) in
+        let rec_hyp_proof =
+          mkApp(mkVar fix_info.name,array_get_start pte_args)
+        in
+        refine rec_hyp_proof
+      end)
 
 let prove_rec_hyp fix_info  =
   { proving_tac = prove_rec_hyp_for_struct fix_info
@@ -914,36 +804,34 @@ let prove_rec_hyp fix_info  =
     is_valid = fun _ -> true
   }
 
-let generalize_non_dep hyp g =
+let generalize_non_dep hyp =
 (*   observe (str "rec id := " ++ Ppconstr.pr_id hyp); *)
   let hyps = [hyp] in
   let env = Global.env () in
-  let hyp_typ = pf_unsafe_type_of g (mkVar hyp) in
+  PG.enter begin fun gl ->
+  let hyp_typ = pf_unsafe_type_of gl (mkVar hyp) in
   let to_revert,_ =
     let open Context.Named.Declaration in
     Environ.fold_named_context_reverse (fun (clear,keep) decl ->
       let decl = map_named_decl EConstr.of_constr decl in
       let hyp = get_id decl in
       if Id.List.mem hyp hyps
-        || List.exists (Termops.occur_var_in_decl env (project g) hyp) keep
-        || Termops.occur_var env (project g) hyp hyp_typ
+        || List.exists (Termops.occur_var_in_decl env (project gl) hyp) keep
+        || Termops.occur_var env (project gl) hyp hyp_typ
         || Termops.is_section_variable hyp (* should be dangerous *)
       then (clear,decl::keep)
       else (hyp::clear,keep))
-      ~init:([],[]) (pf_env g)
+      ~init:([],[]) (pf_env gl)
   in
 (*   observe (str "to_revert := " ++ prlist_with_sep spc Ppconstr.pr_id to_revert); *)
   tclTHEN
-    ((* observe_tac "h_generalize" *) (Proofview.V82.of_tactic (generalize  (List.map mkVar to_revert) )))
+    ((* observe_tac "h_generalize" *) (generalize  (List.map mkVar to_revert) ))
     ((* observe_tac "thin" *) (thin to_revert))
-    g
+  end
 
 let id_of_decl = RelDecl.get_name %> Nameops.Name.get_id
 let var_of_decl = id_of_decl %> mkVar
-let revert idl =
-  tclTHEN
-    (Proofview.V82.of_tactic (generalize (List.map mkVar idl)))
-    (thin idl)
+let revert idl = tclTHEN (generalize (List.map mkVar idl)) (thin idl)
 
 let generate_equation_lemma evd fnames f fun_num nb_params nb_args rec_args_num =
 (*   observe (str "nb_args := " ++ str (string_of_int nb_args)); *)
@@ -979,14 +867,15 @@ let generate_equation_lemma evd fnames f fun_num nb_params nb_args rec_args_num 
   let prove_replacement =
     tclTHENLIST
       [
-        tclDO (nb_params + rec_args_num + 1) (Proofview.V82.of_tactic intro);
-        observe_tac "" (fun g ->
-           let rec_id = pf_nth_hyp_id g 1 in
-           tclTHENLIST
-             [observe_tac "generalize_non_dep in generate_equation_lemma" (generalize_non_dep rec_id);
-              observe_tac "h_case" (Proofview.V82.of_tactic (simplest_case (mkVar rec_id)));
-              (Proofview.V82.of_tactic intros_reflexivity)] g
-        )
+        tclDO (nb_params + rec_args_num + 1) intro;
+        observe_tac (fun _ _ -> str "") (
+          PG.enter begin fun gl ->
+          let rec_id = pf_nth_hyp_id gl 1 in
+          tclTHENLIST
+            [ observe_tac (fun _ _ -> str "generalize_non_dep in generate_equation_lemma") (generalize_non_dep rec_id)
+            ; observe_tac (fun _ _ -> str "h_case") (simplest_case (mkVar rec_id))
+            ; intros_reflexivity]
+          end)
       ]
   in
   (* Pp.msgnl (str "lemma type (2) " ++ Printer.pr_lconstr_env (Global.env ()) evd lemma_type); *)
@@ -999,11 +888,11 @@ let generate_equation_lemma evd fnames f fun_num nb_params nb_args rec_args_num 
     evd
   lemma_type
   in
-  let lemma,_ = Lemmas.by (Proofview.V82.tactic prove_replacement) lemma in
+  let lemma,_ = Lemmas.by prove_replacement lemma in
   let () = Lemmas.save_lemma_proved ?proof:None ~lemma ~opaque:Proof_global.Transparent ~idopt:None in
   evd
 
-let do_replace (evd:Evd.evar_map ref) params rec_arg_num rev_args_id f fun_num all_funs g =
+let do_replace (evd:Evd.evar_map ref) params rec_arg_num rev_args_id f fun_num all_funs =
   let equation_lemma =
     try
       let finfos = find_Function_infos (fst (destConst !evd f)) (*FIXME*) in
@@ -1039,20 +928,21 @@ let do_replace (evd:Evd.evar_map ref) params rec_arg_num rev_args_id f fun_num a
       evd := sigma;
       res
   in
-  let nb_intro_to_do = nb_prod (project g) (pf_concl g) in
+  PG.enter begin fun gl ->
+  let nb_intro_to_do = nb_prod (project gl) (pf_concl gl) in
     tclTHEN
-      (tclDO nb_intro_to_do (Proofview.V82.of_tactic intro))
+      (tclDO nb_intro_to_do intro)
       (
-        fun g' ->
-          let just_introduced = nLastDecls nb_intro_to_do g' in
-          let open Context.Named.Declaration in
-          let just_introduced_id = List.map get_id just_introduced in
-          tclTHEN (Proofview.V82.of_tactic (Equality.rewriteLR equation_lemma))
-                  (revert just_introduced_id) g'
+        PG.enter begin fun gl' ->
+        let just_introduced = nLastDecls gl' nb_intro_to_do in
+        let open Context.Named.Declaration in
+        let just_introduced_id = List.map get_id just_introduced in
+        tclTHEN (Equality.rewriteLR equation_lemma) (revert just_introduced_id)
+        end
       )
-      g
+  end
 
-let prove_princ_for_struct (evd:Evd.evar_map ref) interactive_proof fun_num fnames all_funs _nparams : tactic =
+let prove_princ_for_struct (evd:Evd.evar_map ref) interactive_proof fun_num fnames all_funs _nparams =
   fun g ->
   let princ_type = pf_concl g in
   (* Pp.msgnl (str "princ_type " ++ Printer.pr_lconstr princ_type); *)
@@ -1213,36 +1103,35 @@ let prove_princ_for_struct (evd:Evd.evar_map ref) interactive_proof fun_num fnam
         | _ ->
            Id.Map.empty,[]
     in
-    let mk_fixes : tactic =
+    let mk_fixes =
       let pre_info,infos = list_chop fun_num infos in
       match pre_info,infos with
-        | _,[] -> tclIDTAC
-        | _, this_fix_info::others_infos ->
-            let other_fix_infos =
-              List.map
-                (fun fi -> fi.name,fi.idx + 1 ,fi.types)
-                (pre_info@others_infos)
-            in
-            if List.is_empty other_fix_infos
-            then
-              if this_fix_info.idx + 1 = 0
-              then tclIDTAC (* Someone  tries to defined a principle on a fully parametric definition declared as a fixpoint (strange but ....) *)
-              else
-                observe_tac_stream (str "h_fix " ++ int (this_fix_info.idx +1) ) (Proofview.V82.of_tactic (fix this_fix_info.name (this_fix_info.idx +1)))
-            else
-              Proofview.V82.of_tactic (Tactics.mutual_fix this_fix_info.name (this_fix_info.idx + 1)
-                other_fix_infos 0)
+      | _,[] -> tclIDTAC
+      | _, this_fix_info::others_infos ->
+        let other_fix_infos =
+          List.map
+            (fun fi -> fi.name,fi.idx + 1 ,fi.types)
+            (pre_info@others_infos)
+        in
+        if List.is_empty other_fix_infos
+        then
+          if this_fix_info.idx + 1 = 0
+          then tclIDTAC (* Someone  tries to defined a principle on a fully parametric definition declared as a fixpoint (strange but ....) *)
+          else
+            observe_tac (fun _ _ -> str "h_fix " ++ int (this_fix_info.idx +1) ) (fix this_fix_info.name (this_fix_info.idx +1))
+        else
+          Tactics.mutual_fix this_fix_info.name (this_fix_info.idx + 1) other_fix_infos 0
     in
-    let first_tac : tactic = (* every operations until fix creations *)
+    let first_tac = (* every operations until fix creations *)
       tclTHENLIST
-        [ observe_tac "introducing params" (Proofview.V82.of_tactic (intros_using (List.rev_map id_of_decl princ_info.params)));
-          observe_tac "introducing predictes" (Proofview.V82.of_tactic (intros_using (List.rev_map id_of_decl princ_info.predicates)));
-          observe_tac "introducing branches" (Proofview.V82.of_tactic (intros_using (List.rev_map id_of_decl princ_info.branches)));
-          observe_tac "building fixes" mk_fixes;
+        [ observe_tac (fun _ _ -> str "introducing params") (intros_using (List.rev_map id_of_decl princ_info.params));
+          observe_tac (fun _ _ -> str "introducing predictes") (intros_using (List.rev_map id_of_decl princ_info.predicates));
+          observe_tac (fun _ _ -> str "introducing branches") (intros_using (List.rev_map id_of_decl princ_info.branches));
+          observe_tac (fun _ _ -> str "building fixes") mk_fixes;
         ]
     in
-    let intros_after_fixes : tactic =
-      fun gl ->
+    let intros_after_fixes =
+      PG.enter begin fun gl ->
         let ctxt,pte_app =  (decompose_prod_assum (project gl) (pf_concl gl)) in
         let pte,pte_args = (decompose_app (project gl) pte_app) in
         try
@@ -1254,9 +1143,9 @@ let prove_princ_for_struct (evd:Evd.evar_map ref) interactive_proof fun_num fnam
           let nb_args = fix_info.nb_realargs in
           tclTHENLIST
             [
-              (* observe_tac ("introducing args") *) (tclDO nb_args (Proofview.V82.of_tactic intro));
-              (fun g -> (* replacement of the function by its body *)
-                 let args = nLastDecls nb_args g in
+              (* observe_tac ("introducing args") *) (tclDO nb_args intro);
+              ((* replacement of the function by its body *)
+                 let args = nLastDecls g nb_args in
                  let fix_body = fix_info.body_with_param in
 (*               observe (str "fix_body := "++ pr_lconstr_env (pf_env gl) fix_body); *)
                  let open Context.Named.Declaration in
@@ -1273,7 +1162,7 @@ let prove_princ_for_struct (evd:Evd.evar_map ref) interactive_proof fun_num fnam
                  in
                  tclTHENLIST
                    [
-                     observe_tac "do_replace"
+                     observe_tac (fun _ _ -> str "do_replace")
                        (do_replace evd
                           full_params
                           (fix_info.idx + List.length princ_params)
@@ -1295,7 +1184,7 @@ let prove_princ_for_struct (evd:Evd.evar_map ref) interactive_proof fun_num fnam
                             nb_rec_hyps = List.length branches
                          }
                        in
-                       observe_tac "cleaning" (clean_goal_with_heq
+                       observe_tac (fun _ _ -> str "cleaning") (clean_goal_with_heq
                          (Id.Map.map prove_rec_hyp ptes_to_fix)
                          do_prove
                          dyn_infos)
@@ -1309,16 +1198,15 @@ let prove_princ_for_struct (evd:Evd.evar_map ref) interactive_proof fun_num fnam
                        (List.rev_map id_of_decl princ_info.branches)
                        (List.rev args_id))
                    ]
-                   g
               );
-            ] gl
+            ]
         with Not_found ->
           let nb_args = min (princ_info.nargs) (List.length ctxt) in
           tclTHENLIST
             [
-              tclDO nb_args (Proofview.V82.of_tactic intro);
-              (fun g -> (* replacement of the function by its body *)
-                 let args = nLastDecls nb_args g in
+              tclDO nb_args intro;
+              ( (* replacement of the function by its body *)
+                 let args = nLastDecls g nb_args in
                  let open Context.Named.Declaration in
                  let args_id = List.map get_id args in
                  let dyn_infos =
@@ -1336,7 +1224,7 @@ let prove_princ_for_struct (evd:Evd.evar_map ref) interactive_proof fun_num fnam
                  in
                  let fname = destConst (project g) (fst (decompose_app (project g) (List.hd (List.rev pte_args)))) in
                  tclTHENLIST
-                   [Proofview.V82.of_tactic (unfold_in_concl [(Locus.AllOccurrences, Names.EvalConstRef (fst fname))]);
+                   [unfold_in_concl [(Locus.AllOccurrences, Names.EvalConstRef (fst fname))];
                     let do_prove =
                       build_proof
                         interactive_proof
@@ -1359,20 +1247,13 @@ let prove_princ_for_struct (evd:Evd.evar_map ref) interactive_proof fun_num fnam
                        (List.rev_map id_of_decl princ_info.branches)
                       (List.rev args_id)
                    ]
-                   g
               )
             ]
-          gl
+      end
     in
     tclTHEN
       first_tac
       intros_after_fixes
-      g
-
-
-
-
-
 
 (* Proof of principles of general functions *)
 (* let  hrec_id = Recdef.hrec_id *)
@@ -1383,109 +1264,92 @@ let prove_princ_for_struct (evd:Evd.evar_map ref) interactive_proof fun_num fnam
 (* and list_rewrite = Recdef.list_rewrite *)
 (* and evaluable_of_global_reference = Recdef.evaluable_of_global_reference *)
 
-
-
-
-
-let prove_with_tcc tcc_lemma_constr eqs : tactic =
+let prove_with_tcc tcc_lemma_constr eqs : unit Proofview.tactic =
   match !tcc_lemma_constr with
   | Undefined -> anomaly (Pp.str "No tcc proof !!")
   | Value lemma ->
-        fun gls ->
 (*        let hid = next_ident_away_in_goal h_id (pf_ids_of_hyps gls) in *)
 (*        let ids = hid::pf_ids_of_hyps gls in  *)
-          tclTHENLIST
-            [
+    tclTHENLIST
+      [
 (*            generalize [lemma]; *)
 (*            h_intro hid; *)
 (*            Elim.h_decompose_and (mkVar hid); *)
-              tclTRY(list_rewrite true eqs);
+        tclTRY(list_rewrite true eqs);
 (*            (fun g ->  *)
 (*               let ids' = pf_ids_of_hyps g in  *)
 (*               let ids = List.filter (fun id -> not (List.mem id ids)) ids' in  *)
 (*               rewrite *)
 (*            ) *)
-              Proofview.V82.of_tactic (Eauto.gen_eauto (false,5) [] (Some []))
-            ]
-            gls
+        Eauto.gen_eauto (false,5) [] (Some [])
+      ]
   | Not_needed -> tclIDTAC
 
-let backtrack_eqs_until_hrec hrec eqs : tactic =
-  fun gls ->
-    let eqs = List.map mkVar eqs in
-    let rewrite =
-      tclFIRST (List.map (fun x -> Proofview.V82.of_tactic (Equality.rewriteRL x)) eqs )
-    in
-    let _,hrec_concl  = decompose_prod (project gls) (pf_unsafe_type_of gls (mkVar hrec)) in
-    let f_app = Array.last (snd (destApp (project gls) hrec_concl)) in
-    let f =  (fst (destApp (project gls) f_app)) in
-    let rec backtrack : tactic =
-      fun g ->
-        let f_app = Array.last (snd (destApp (project g) (pf_concl g))) in
-        match EConstr.kind (project g) f_app with
-          | App(f',_) when eq_constr (project g) f' f -> tclIDTAC g
-          | _ -> tclTHEN rewrite backtrack g
-    in
-    backtrack gls
-
+let backtrack_eqs_until_hrec hrec eqs : unit Proofview.tactic =
+  PG.enter begin fun gl ->
+  let eqs = List.map mkVar eqs in
+  let rewrite =
+    tclFIRST (List.map (fun x -> Equality.rewriteRL x) eqs )
+  in
+  let _,hrec_concl  = decompose_prod (project gl) (pf_unsafe_type_of gl (mkVar hrec)) in
+  let f_app = Array.last (snd (destApp (project gl) hrec_concl)) in
+  let f =  (fst (destApp (project gl) f_app)) in
+  let rec backtrack () : unit Proofview.tactic =
+    PG.enter begin fun gl ->
+      let f_app = Array.last (snd (destApp (project gl) (pf_concl gl))) in
+      match EConstr.kind (project gl) f_app with
+      | App(f',_) when eq_constr (project gl) f' f -> tclIDTAC
+      | _ -> tclTHEN rewrite (backtrack ())
+    end
+  in
+  backtrack ()
+  end
 
 let rec rewrite_eqs_in_eqs eqs =
   match eqs with
-    | [] -> tclIDTAC
-    | eq::eqs ->
+  | [] ->
+    tclIDTAC
+  | eq::eqs ->
+    tclTHEN
+      (tclMAP
+         (fun id ->
+            observe_tac
+              (fun _ _ -> str @@ Format.sprintf "rewrite %s in %s " (Id.to_string eq) (Id.to_string id))
+              (tclTRY (Equality.general_rewrite_in true Locus.AllOccurrences
+                         true (* dep proofs also: *) true id (mkVar eq) false)))
+         eqs
+      )
+      (rewrite_eqs_in_eqs eqs)
 
-          tclTHEN
-            (tclMAP
-               (fun id gl ->
-                  observe_tac
-                    (Format.sprintf "rewrite %s in %s " (Id.to_string eq) (Id.to_string id))
-                    (tclTRY (Proofview.V82.of_tactic (Equality.general_rewrite_in true Locus.AllOccurrences
-                               true (* dep proofs also: *) true id (mkVar eq) false)))
-                    gl
-               )
-               eqs
-            )
-            (rewrite_eqs_in_eqs eqs)
-
-let new_prove_with_tcc is_mes acc_inv hrec tcc_hyps eqs : tactic =
-  fun gls ->
-    (tclTHENLIST
-       [
-         backtrack_eqs_until_hrec hrec eqs;
-         (* observe_tac ("new_prove_with_tcc ( applying "^(Id.to_string hrec)^" )" ) *)
-         (tclTHENS  (* We must have exactly ONE subgoal !*)
-            (Proofview.V82.of_tactic (apply (mkVar hrec)))
-            [ tclTHENLIST
-                [
-                  (Proofview.V82.of_tactic (keep (tcc_hyps@eqs)));
-                  (Proofview.V82.of_tactic (apply (Lazy.force acc_inv)));
-                  (fun g ->
-                     if is_mes
-                     then
-                       Proofview.V82.of_tactic (unfold_in_concl [(Locus.AllOccurrences, evaluable_of_global_reference (delayed_force ltof_ref))]) g
-                     else tclIDTAC g
-                  );
-                  observe_tac "rew_and_finish"
-                    (tclTHENLIST
-                       [tclTRY(list_rewrite false (List.map (fun v -> (mkVar v,true)) eqs));
-                        observe_tac "rewrite_eqs_in_eqs" (rewrite_eqs_in_eqs eqs);
-                         (observe_tac "finishing using"
-                           (
-                            tclCOMPLETE(
-                                    Eauto.eauto_with_bases
-                                      (true,5)
-                                      [(fun _ sigma -> (sigma, Lazy.force refl_equal))]
-                                      [Hints.Hint_db.empty TransparentState.empty false]
-                                  )
-                           )
+let new_prove_with_tcc is_mes acc_inv hrec tcc_hyps eqs : unit Proofview.tactic =
+  tclTHENLIST
+    [
+      backtrack_eqs_until_hrec hrec eqs;
+      (* observe_tac ("new_prove_with_tcc ( applying "^(Id.to_string hrec)^" )" ) *)
+      (tclTHENS  (* We must have exactly ONE subgoal !*)
+         (apply (mkVar hrec))
+         [ tclTHENLIST
+             [ keep (tcc_hyps@eqs)
+             ; apply (Lazy.force acc_inv)
+             ; if is_mes
+               then unfold_in_concl [(Locus.AllOccurrences, evaluable_of_global_reference (delayed_force ltof_ref))]
+               else tclIDTAC
+             ; observe_tac (fun _ _ -> str "rew_and_finish")
+                 (tclTHENLIST
+                    [ tclTRY (list_rewrite false (List.map (fun v -> (mkVar v,true)) eqs))
+                    ; observe_tac (fun _ _ -> str "rewrite_eqs_in_eqs") (rewrite_eqs_in_eqs eqs)
+                    ; observe_tac (fun _ _ -> str "finishing using")
+                        (tclCOMPLETE Proofview.V82.(tactic
+                           Eauto.(eauto_with_bases
+                                    (true,5)
+                                    [(fun _ sigma -> (sigma, Lazy.force refl_equal))]
+                                    [Hints.Hint_db.empty TransparentState.empty false]))
                         )
-                       ]
-                    )
-                ]
-            ])
-       ])
-      gls
-
+                    ]
+                 )
+             ]
+         ])
+    ]
 
 let is_valid_hypothesis sigma predicates_name =
   let predicates_name = List.fold_right Id.Set.add predicates_name Id.Set.empty in
@@ -1564,25 +1428,16 @@ let prove_principle_for_gen
     Nameops.Name.get_id (fresh_id (Name (Id.of_string ("Acc_"^(Id.to_string rec_arg_id)))))
   in
   let revert l =
-    tclTHEN (Proofview.V82.of_tactic (Tactics.generalize (List.map mkVar l))) (Proofview.V82.of_tactic (clear l))
+    tclTHEN (Tactics.generalize (List.map mkVar l)) (clear l)
   in
   let fix_id = Nameops.Name.get_id (fresh_id (Name hrec_id)) in
-  let prove_rec_arg_acc g =
-      ((* observe_tac "prove_rec_arg_acc"  *)
-         (tclCOMPLETE
-            (tclTHEN
-               (Proofview.V82.of_tactic (assert_by (Name wf_thm_id)
-                  (mkApp (delayed_force well_founded,[|input_type;relation|]))
-                  (Proofview.V82.tactic (fun g -> (* observe_tac "prove wf" *) (tclCOMPLETE (wf_tac is_mes)) g))))
-               (
-                 (* observe_tac  *)
-(*                 "apply wf_thm"  *)
-                 Proofview.V82.of_tactic (Tactics.Simple.apply (mkApp(mkVar wf_thm_id,[|mkVar rec_arg_id|])))
-               )
-            )
-         )
-      )
-      g
+  let prove_rec_arg_acc =
+    tclCOMPLETE
+      (tclTHEN
+         (assert_by (Name wf_thm_id)
+            (mkApp (delayed_force well_founded,[|input_type;relation|]))
+            (tclCOMPLETE (wf_tac is_mes)))
+         (Tactics.Simple.apply (mkApp(mkVar wf_thm_id,[|mkVar rec_arg_id|]))))
   in
   let args_ids = List.map (get_name %> Nameops.Name.get_id) princ_info.args in
   let lemma =
@@ -1602,124 +1457,120 @@ let prove_principle_for_gen
 (*                f::(list_diff r check_list) *)
 (*   in *)
   let tcc_list = ref [] in
-  let start_tac gls =
-    let hyps = pf_ids_of_hyps gls in
+  let start_tac =
+    PG.enter begin fun gl ->
+    let hyps = pf_ids_of_hyps gl in
       let hid =
         next_ident_away_in_goal
           (Id.of_string "prov")
           (Id.Set.of_list hyps)
       in
       tclTHENLIST
-        [
-          Proofview.V82.of_tactic (generalize [lemma]);
-          Proofview.V82.of_tactic (Simple.intro hid);
-          Proofview.V82.of_tactic (Elim.h_decompose_and (mkVar hid));
-          (fun g ->
-             let new_hyps = pf_ids_of_hyps g in
-             tcc_list := List.rev (List.subtract Id.equal new_hyps (hid::hyps));
-             if List.is_empty !tcc_list
-             then
-               begin
-                 tcc_list := [hid];
-                 tclIDTAC g
-               end
-             else thin [hid] g
-          )
-          ]
-          gls
+        [ generalize [lemma]
+        ; Simple.intro hid
+        ; Elim.h_decompose_and (mkVar hid)
+        ; PG.enter begin fun gl' ->
+          let new_hyps = pf_ids_of_hyps gl' in
+          tcc_list := List.rev (List.subtract Id.equal new_hyps (hid::hyps));
+          if List.is_empty !tcc_list
+          then
+            begin
+              tcc_list := [hid];
+              tclIDTAC
+            end
+          else thin [hid]
+          end
+        ]
+    end
   in
   tclTHENLIST
-    [
-      observe_tac "start_tac" start_tac;
-      h_intros
+    [ observe_tac (fun _ _ -> str "start_tac") start_tac
+    ; h_intros
         (List.rev_map (get_name %> Nameops.Name.get_id)
            (princ_info.args@princ_info.branches@princ_info.predicates@princ_info.params)
         );
-      (* observe_tac "" *) Proofview.V82.of_tactic (assert_by
-         (Name acc_rec_arg_id)
-         (mkApp (delayed_force acc_rel,[|input_type;relation;mkVar rec_arg_id|]))
-         (Proofview.V82.tactic prove_rec_arg_acc)
-      );
-(*       observe_tac "reverting" *) (revert (List.rev (acc_rec_arg_id::args_ids)));
-(*       (fun g -> observe (Printer.pr_goal (sig_it g) ++ fnl () ++  *)
-(*                         str "fix arg num" ++ int (List.length args_ids + 1) ); tclIDTAC g); *)
-      (* observe_tac "h_fix " *) (Proofview.V82.of_tactic (fix fix_id (List.length args_ids + 1)));
-(*       (fun g -> observe (Printer.pr_goal (sig_it g) ++ fnl() ++ pr_lconstr_env (pf_env g ) (pf_unsafe_type_of g (mkVar fix_id) )); tclIDTAC g); *)
-      h_intros (List.rev (acc_rec_arg_id::args_ids));
-      Proofview.V82.of_tactic (Equality.rewriteLR (mkConst eq_ref));
-      (* observe_tac "finish" *) (fun gl' ->
-         let body =
-           let _,args = destApp (project gl') (pf_concl gl') in
-           Array.last args
-         in
-         let body_info rec_hyps =
-           {
-             nb_rec_hyps = List.length rec_hyps;
-             rec_hyps = rec_hyps;
-             eq_hyps = [];
-             info = body
-           }
-         in
-         let acc_inv =
-           lazy (
-             mkApp (
-               delayed_force acc_inv_id,
-               [|input_type;relation;mkVar rec_arg_id|]
-             )
-           )
-         in
-         let acc_inv = lazy (mkApp(Lazy.force acc_inv, [|mkVar  acc_rec_arg_id|])) in
-         let predicates_names =
-           List.map (get_name %> Nameops.Name.get_id) princ_info.predicates
-         in
-         let pte_info =
-           { proving_tac =
-               (fun eqs ->
-(*                msgnl (str "tcc_list := "++ prlist_with_sep spc Ppconstr.pr_id  !tcc_list); *)
-(*                msgnl (str "princ_info.args := "++ prlist_with_sep spc Ppconstr.pr_id  (List.map  (fun (na,_,_) -> (Nameops.Name.get_id na)) princ_info.args)); *)
-(*                msgnl (str "princ_info.params := "++ prlist_with_sep spc Ppconstr.pr_id  (List.map  (fun (na,_,_) -> (Nameops.Name.get_id na)) princ_info.params)); *)
-(*                msgnl (str "acc_rec_arg_id := "++  Ppconstr.pr_id acc_rec_arg_id); *)
-(*                msgnl (str "eqs := "++ prlist_with_sep spc Ppconstr.pr_id  eqs); *)
+      assert_by
+        (Name acc_rec_arg_id)
+        (mkApp (delayed_force acc_rel,[|input_type;relation;mkVar rec_arg_id|]))
+        (prove_rec_arg_acc)
+    (*       observe_tac "reverting" *)
+    ; (revert (List.rev (acc_rec_arg_id::args_ids)))
+    (*       (fun g -> observe (Printer.pr_goal (sig_it g) ++ fnl () ++  *)
+    (*                         str "fix arg num" ++ int (List.length args_ids + 1) ); tclIDTAC g); *)
+    (* observe_tac "h_fix " *)
+    ; (fix fix_id (List.length args_ids + 1))
+    (* (fun g -> observe (Printer.pr_goal (sig_it g) ++ fnl() ++ pr_lconstr_env (pf_env g ) (pf_unsafe_type_of g (mkVar fix_id) )); tclIDTAC g); *)
+    ; h_intros (List.rev (acc_rec_arg_id::args_ids))
+    ; Equality.rewriteLR (mkConst eq_ref)
+    (* observe_tac "finish" *)
+    ; PG.enter begin fun gl' ->
+      let body =
+        let _,args = destApp (project gl') (pf_concl gl') in
+        Array.last args
+      in
+      let body_info rec_hyps =
+        {
+          nb_rec_hyps = List.length rec_hyps;
+          rec_hyps = rec_hyps;
+          eq_hyps = [];
+          info = body
+        }
+      in
+      let acc_inv =
+        lazy (
+          mkApp (
+            delayed_force acc_inv_id,
+            [|input_type;relation;mkVar rec_arg_id|]
+          )
+        )
+      in
+      let acc_inv = lazy (mkApp(Lazy.force acc_inv, [|mkVar  acc_rec_arg_id|])) in
+      let predicates_names =
+        List.map (get_name %> Nameops.Name.get_id) princ_info.predicates
+      in
+      let pte_info =
+        { proving_tac =
+            (fun eqs ->
+               (*                msgnl (str "tcc_list := "++ prlist_with_sep spc Ppconstr.pr_id  !tcc_list); *)
+               (*                msgnl (str "princ_info.args := "++ prlist_with_sep spc Ppconstr.pr_id  (List.map  (fun (na,_,_) -> (Nameops.Name.get_id na)) princ_info.args)); *)
+               (*                msgnl (str "princ_info.params := "++ prlist_with_sep spc Ppconstr.pr_id  (List.map  (fun (na,_,_) -> (Nameops.Name.get_id na)) princ_info.params)); *)
+               (*                msgnl (str "acc_rec_arg_id := "++  Ppconstr.pr_id acc_rec_arg_id); *)
+               (*                msgnl (str "eqs := "++ prlist_with_sep spc Ppconstr.pr_id  eqs); *)
 
-                  (* observe_tac "new_prove_with_tcc"  *)
-                    (new_prove_with_tcc
-                       is_mes acc_inv fix_id
+               (* observe_tac "new_prove_with_tcc"  *)
+               (new_prove_with_tcc
+                  is_mes acc_inv fix_id
 
-                       (!tcc_list@(List.map
-                           (get_name %> Nameops.Name.get_id)
-                           (princ_info.args@princ_info.params)
-                        )@ ([acc_rec_arg_id])) eqs
-                    )
-
-               );
-             is_valid = is_valid_hypothesis (project gl') predicates_names
-           }
-         in
-         let ptes_info : pte_info Id.Map.t =
-           List.fold_left
-             (fun map pte_id ->
-                Id.Map.add pte_id
-                  pte_info
-                  map
-             )
-             Id.Map.empty
-             predicates_names
-         in
-         let make_proof rec_hyps =
-           build_proof
-             false
-             [f_ref]
-             ptes_info
-             (body_info rec_hyps)
-         in
-         (* observe_tac "instantiate_hyps_with_args"  *)
-           (instantiate_hyps_with_args
-              make_proof
-              (List.map (get_name %> Nameops.Name.get_id) princ_info.branches)
-              (List.rev args_ids)
-           )
-           gl'
+                  (!tcc_list@(List.map
+                                (get_name %> Nameops.Name.get_id)
+                                (princ_info.args@princ_info.params)
+                             )@ ([acc_rec_arg_id])) eqs
+               ))
+        ; is_valid = is_valid_hypothesis (project gl') predicates_names
+        }
+      in
+      let ptes_info : pte_info Id.Map.t =
+        List.fold_left
+          (fun map pte_id ->
+             Id.Map.add pte_id
+               pte_info
+               map
+          )
+          Id.Map.empty
+          predicates_names
+      in
+      let make_proof rec_hyps =
+        build_proof
+          false
+          [f_ref]
+          ptes_info
+          (body_info rec_hyps)
+      in
+      (* observe_tac "instantiate_hyps_with_args"  *)
+      (instantiate_hyps_with_args
+         make_proof
+         (List.map (get_name %> Nameops.Name.get_id) princ_info.branches)
+         (List.rev args_ids)
       )
-
+      end
     ]
-    gl

--- a/plugins/funind/g_indfun.mlg
+++ b/plugins/funind/g_indfun.mlg
@@ -91,7 +91,7 @@ END
 {
 
 let functional_induction b c x pat =
-  Proofview.V82.tactic (functional_induction true c x (Option.map out_disjunctive pat))
+  functional_induction true c x (Option.map out_disjunctive pat)
 
 }
 
@@ -99,9 +99,9 @@ TACTIC EXTEND newfunind
 | ["functional" "induction" ne_constr_list(cl) fun_ind_using(princl) with_names(pat)] ->
      {
        let c = match cl with
-	 | [] -> assert false
-	 | [c] -> c
-	 | c::cl -> EConstr.applist(c,cl)
+         | [] -> assert false
+         | [c] -> c
+         | c::cl -> EConstr.applist(c,cl)
        in
        Extratactics.onSomeWithHoles (fun x -> functional_induction true c x pat) princl }
 END
@@ -110,9 +110,9 @@ TACTIC EXTEND snewfunind
 | ["soft" "functional" "induction" ne_constr_list(cl) fun_ind_using(princl) with_names(pat)] ->
      {
        let c = match cl with
-	 | [] -> assert false
-	 | [c] -> c
-	 | c::cl -> EConstr.applist(c,cl)
+         | [] -> assert false
+         | [c] -> c
+         | c::cl -> EConstr.applist(c,cl)
        in
        Extratactics.onSomeWithHoles (fun x -> functional_induction false c x pat) princl }
 END
@@ -263,7 +263,7 @@ VERNAC COMMAND EXTEND NewFunctionalScheme
                   let names = List.map (fun (_,na,_) -> na) fas in
                   warning_error names e
               end
-	      | _ -> assert false (* we can only have non empty  list *)
+              | _ -> assert false (* we can only have non empty  list *)
           end
         | e when CErrors.noncritical e ->
           let names = List.map (fun (_,na,_) -> na) fas in

--- a/plugins/funind/indfun.mli
+++ b/plugins/funind/indfun.mli
@@ -12,11 +12,11 @@ val do_generate_principle_interactive :
   (Vernacexpr.fixpoint_expr * Vernacexpr.decl_notation list) list ->
   Lemmas.t
 
-val functional_induction :
-  bool ->
-  EConstr.constr ->
-  (EConstr.constr * EConstr.constr bindings) option ->
-  Ltac_plugin.Tacexpr.or_and_intro_pattern option ->
-  Goal.goal Evd.sigma -> Goal.goal list Evd.sigma
+val functional_induction
+  :  bool
+  -> EConstr.constr
+  -> (EConstr.constr * EConstr.constr bindings) option
+  -> Ltac_plugin.Tacexpr.or_and_intro_pattern option
+  -> unit Proofview.tactic
 
 val make_graph : GlobRef.t -> unit

--- a/plugins/funind/indfun_common.mli
+++ b/plugins/funind/indfun_common.mli
@@ -87,6 +87,12 @@ val pr_table : Environ.env -> Evd.evar_map -> Pp.t
 val do_observe : unit -> bool
 val do_rewrite_dependent : unit -> bool
 
+val observe : Pp.t -> unit
+val observe_tac
+  :  header:Pp.t
+  -> (Environ.env -> Evd.evar_map -> Pp.t)
+  -> unit Proofview.tactic -> unit Proofview.tactic
+
 (* To localize pb *)
 exception Building_graph of exn
 exception Defining_principle of exn
@@ -94,7 +100,7 @@ exception ToShow of exn
 
 val is_strict_tcc : unit -> bool
 
-val h_intros: Names.Id.t list -> Tacmach.tactic
+val h_intros: Names.Id.t list -> unit Proofview.tactic
 val h_id :  Names.Id.t
 val hrec_id :  Names.Id.t
 val acc_inv_id :  EConstr.constr Util.delayed
@@ -103,7 +109,7 @@ val well_founded_ltof : EConstr.constr Util.delayed
 val acc_rel : EConstr.constr Util.delayed
 val well_founded : EConstr.constr Util.delayed
 val evaluable_of_global_reference : GlobRef.t -> Names.evaluable_global_reference
-val list_rewrite : bool -> (EConstr.constr*bool) list -> Tacmach.tactic
+val list_rewrite : bool -> (EConstr.constr*bool) list -> unit Proofview.tactic
 
 val decompose_lam_n : Evd.evar_map -> int -> EConstr.t ->
   (Names.Name.t Context.binder_annot * EConstr.t) list * EConstr.t

--- a/plugins/funind/invfun.ml
+++ b/plugins/funind/invfun.ml
@@ -20,51 +20,22 @@ open EConstr
 open Vars
 open Pp
 open Globnames
-open Tacticals
+open Tacticals.New
 open Tactics
 open Indfun_common
-open Tacmach
+open Tacmach.New
 open Tactypes
 open Termops
 open Context.Rel.Declaration
 
 module RelDecl = Context.Rel.Declaration
 
-(* The local debugging mechanism *)
-(* let msgnl = Pp.msgnl *)
+module PN = Proofview.Notations
+module PG = Proofview.Goal
 
-let observe strm =
-  if do_observe ()
-  then Feedback.msg_debug strm
-  else ()
+let observe_tac = Indfun_common.observe_tac ~header:Pp.(str "invfun")
 
-(*let observennl strm =
-  if do_observe ()
-  then begin Pp.msg strm;Pp.pp_flush () end
-  else ()*)
-
-
-let do_observe_tac s tac g =
-  let goal =
-    try Printer.pr_goal g
-    with e when CErrors.noncritical e -> assert false
-  in
-  try
-    let v = tac g in
-    msgnl (goal ++ fnl () ++ s ++(str " ")++(str "finished")); v
-  with reraise ->
-    let reraise = CErrors.push reraise in
-    let e = ExplainErr.process_vernac_interp_error reraise in
-    observe (hov 0 (str "observation "++ s++str " raised exception " ++
-             CErrors.iprint e ++ str " on goal" ++ fnl() ++ goal ));
-    iraise reraise;;
-
-let observe_tac s tac g =
-  if do_observe ()
-  then do_observe_tac (str s) tac g
-  else tac g
-
-let thin ids gl = Proofview.V82.of_tactic (Tactics.clear ids) gl
+let thin ids = Tactics.clear ids
 
 (* (\* [id_to_constr id] finds the term associated to [id] in the global environment *\) *)
 (* let id_to_constr id = *)
@@ -89,7 +60,7 @@ let make_eq () =
    [generate_type false f i] returns
    \[\forall (x_1:t_1)\ldots(x_n:t_n), let fv := f x_1\ldots x_n in, forall res,
    res = fv \rightarrow graph\ x_1\ldots x_n\ res\] decomposed as the context and the conclusion
- *)
+*)
 
 let generate_type evd g_to_f f graph i =
   (*i we deduce the number of arguments of the function and its returned type from the graph i*)
@@ -102,21 +73,21 @@ let generate_type evd g_to_f f graph i =
   let ctxt,_ = decompose_prod_assum !evd graph_arity in
   let fun_ctxt,res_type =
     match ctxt with
-      | [] | [_] -> anomaly (Pp.str "Not a valid context.")
-      | decl :: fun_ctxt -> fun_ctxt, RelDecl.get_type decl
+    | [] | [_] -> anomaly (Pp.str "Not a valid context.")
+    | decl :: fun_ctxt -> fun_ctxt, RelDecl.get_type decl
   in
   let rec args_from_decl i accu = function
-  | [] -> accu
-  | LocalDef _ :: l ->
-    args_from_decl (succ i) accu l
-  | _ :: l ->
-    let t = mkRel i in
-    args_from_decl (succ i) (t :: accu) l
+    | [] -> accu
+    | LocalDef _ :: l ->
+      args_from_decl (succ i) accu l
+    | _ :: l ->
+      let t = mkRel i in
+      args_from_decl (succ i) (t :: accu) l
   in
   (*i We need to name the vars [res] and [fv] i*)
   let filter = fun decl -> match RelDecl.get_name decl with
-                           | Name id -> Some id
-                           | Anonymous -> None
+    | Name id -> Some id
+    | Anonymous -> None
   in
   let named_ctxt = Id.Set.of_list (List.map_filter filter fun_ctxt) in
   let res_id = Namegen.next_ident_away_in_goal (Id.of_string "_res") named_ctxt in
@@ -164,12 +135,12 @@ let find_induction_principle evd f =
   in
   let infos = find_Function_infos f_as_constant in
   match infos.rect_lemma with
-    | None -> raise Not_found
-    | Some rect_lemma ->
-       let evd',rect_lemma = Evd.fresh_global  (Global.env ()) !evd  (Globnames.ConstRef rect_lemma) in
-       let evd',typ = Typing.type_of ~refresh:true (Global.env ()) evd' rect_lemma in
-       evd:=evd';
-       rect_lemma,typ
+  | None -> raise Not_found
+  | Some rect_lemma ->
+    let evd',rect_lemma = Evd.fresh_global  (Global.env ()) !evd  (Globnames.ConstRef rect_lemma) in
+    let evd',typ = Typing.type_of ~refresh:true (Global.env ()) evd' rect_lemma in
+    evd:=evd';
+    rect_lemma,typ
 
 
 let rec generate_fresh_id x avoid i =
@@ -203,13 +174,13 @@ let rec generate_fresh_id x avoid i =
    \end{enumerate}
 
 *)
-let prove_fun_correct evd funs_constr graphs_constr schemes lemmas_types_infos i : Tacmach.tactic =
-  fun g ->
-    (* first of all we recreate the lemmas types to be used as predicates of the induction principle
+let prove_fun_correct evd funs_constr graphs_constr schemes lemmas_types_infos i =
+  (* first of all we recreate the lemmas types to be used as predicates of the induction principle
        that is~:
        \[fun (x_1:t_1)\ldots(x_n:t_n)=> fun  fv => fun res => res = fv \rightarrow graph\ x_1\ldots x_n\ res\]
-    *)
-    (* we the get the definition of the graphs block *)
+  *)
+  (* we the get the definition of the graphs block *)
+  PG.enter begin fun gl ->
     let graph_ind,u = destInd evd graphs_constr.(i) in
     let kn = fst graph_ind in
     let mib,_ = Global.lookup_inductive graph_ind in
@@ -218,9 +189,9 @@ let prove_fun_correct evd funs_constr graphs_constr schemes lemmas_types_infos i
     let princ_type = Reductionops.nf_zeta (Global.env ()) evd princ_type in
     let princ_infos = Tactics.compute_elim_sig evd princ_type in
     (* The number of args of the function is then easily computable *)
-    let nb_fun_args = nb_prod (project g) (pf_concl g) - 2 in
+    let nb_fun_args = nb_prod (project gl) (pf_concl gl) - 2 in
     let args_names = generate_fresh_id (Id.of_string "x") [] nb_fun_args in
-    let ids = args_names@(pf_ids_of_hyps g) in
+    let ids = args_names@(pf_ids_of_hyps gl) in
     (* Since we cannot ensure that the functional principle is defined in the
        environment and due to the bug #1174, we will need to pose the principle
        using a name
@@ -246,14 +217,14 @@ let prove_fun_correct evd funs_constr graphs_constr schemes lemmas_types_infos i
     let ind_number = ref 0
     and min_constr_number = ref 0 in
     (* The tactic to prove the ith branch of the principle *)
-    let prove_branche i g =
+    let prove_branche i =
       (* We get the identifiers of this branch *)
       let pre_args =
         List.fold_right
           (fun {CAst.v=pat} acc ->
              match pat with
-               | IntroNaming (Namegen.IntroIdentifier id) -> id::acc
-               | _ -> anomaly (Pp.str "Not an identifier.")
+             | IntroNaming (Namegen.IntroIdentifier id) -> id::acc
+             | _ -> anomaly (Pp.str "Not an identifier.")
           )
           (List.nth intro_pats (pred i))
           []
@@ -266,35 +237,35 @@ let prove_fun_correct evd funs_constr graphs_constr schemes lemmas_types_infos i
          [ fv (hid fv (refl_equal fv)) ].
          If [hid] has another type the corresponding argument of the constructor is [hid]
       *)
-      let constructor_args g =
+      let constructor_args gl =
         List.fold_right
           (fun hid acc ->
-             let type_of_hid = pf_unsafe_type_of g (mkVar hid) in
-             let sigma = project g in
+             let type_of_hid = pf_unsafe_type_of gl (mkVar hid) in
+             let sigma = project gl in
              match EConstr.kind sigma type_of_hid with
-               | Prod(_,_,t') ->
+             | Prod(_,_,t') ->
+               begin
+                 match EConstr.kind sigma t' with
+                 | Prod(_,t'',t''') ->
                    begin
-                     match EConstr.kind sigma t' with
-                       | Prod(_,t'',t''') ->
-                           begin
-                             match EConstr.kind sigma t'',EConstr.kind sigma t''' with
-                               | App(eq,args), App(graph',_)
-                                   when
-                                     (EConstr.eq_constr sigma eq eq_ind) &&
-                                       Array.exists  (EConstr.eq_constr_nounivs sigma graph') graphs_constr ->
-                                   (args.(2)::(mkApp(mkVar hid,[|args.(2);(mkApp(eq_construct,[|args.(0);args.(2)|]))|]))
-                                    ::acc)
-                               | _ -> mkVar hid ::  acc
-                           end
-                       | _ -> mkVar hid :: acc
+                     match EConstr.kind sigma t'',EConstr.kind sigma t''' with
+                     | App(eq,args), App(graph',_)
+                       when
+                         (EConstr.eq_constr sigma eq eq_ind) &&
+                         Array.exists  (EConstr.eq_constr_nounivs sigma graph') graphs_constr ->
+                       (args.(2)::(mkApp(mkVar hid,[|args.(2);(mkApp(eq_construct,[|args.(0);args.(2)|]))|]))
+                        ::acc)
+                     | _ -> mkVar hid ::  acc
                    end
-               | _ -> mkVar hid :: acc
+                 | _ -> mkVar hid :: acc
+               end
+             | _ -> mkVar hid :: acc
           ) pre_args []
       in
       (* in fact we must also add the parameters to the constructor args *)
-      let constructor_args g =
+      let constructor_args gl =
         let params_id = fst (List.chop princ_infos.nparams args_names) in
-        (List.map mkVar params_id)@((constructor_args g))
+        (List.map mkVar params_id)@(constructor_args gl)
       in
       (* We then get the constructor corresponding to this branch and
          modifies the references has needed i.e.
@@ -318,44 +289,42 @@ let prove_fun_correct evd funs_constr graphs_constr schemes lemmas_types_infos i
           end
       in
       (* we can then build the final proof term *)
-      let app_constructor g = applist((mkConstructU(constructor,u)),constructor_args g) in
+      let app_constructor gl = applist((mkConstructU(constructor,u)),constructor_args gl) in
       (* an apply the tactic *)
       let res,hres =
         match generate_fresh_id (Id.of_string "z") (ids(* @this_branche_ids *)) 2 with
-          | [res;hres] -> res,hres
-          | _ -> assert false
+        | [res;hres] -> res,hres
+        | _ -> assert false
       in
       (* observe (str "constructor := " ++ Printer.pr_lconstr_env (pf_env g) app_constructor); *)
       (
         tclTHENLIST
-          [
-            observe_tac("h_intro_patterns ")  (let l = (List.nth intro_pats (pred i)) in
-                                               match l with
-                                                 | [] -> tclIDTAC
-                                                 | _ -> Proofview.V82.of_tactic (intro_patterns false l));
-            (* unfolding of all the defined variables introduced by this branch *)
+          [ observe_tac (fun _ _ -> Pp.str "h_intro_patterns ")
+              (let l = (List.nth intro_pats (pred i)) in
+               match l with
+               | [] -> tclIDTAC
+               | _ -> intro_patterns false l
+              )
+          ; (* unfolding of all the defined variables introduced by this branch *)
             (* observe_tac "unfolding" pre_tac; *)
             (* $zeta$ normalizing of the conclusion *)
-            Proofview.V82.of_tactic (reduce
+            reduce
               (Genredexpr.Cbv
                  { Redops.all_flags with
-                     Genredexpr.rDelta = false ;
-                     Genredexpr.rConst = []
+                   Genredexpr.rDelta = false
+                 ; Genredexpr.rConst = []
                  }
               )
-              Locusops.onConcl);
-            observe_tac ("toto ") tclIDTAC;
-
-            (* introducing the result of the graph and the equality hypothesis *)
-            observe_tac "introducing" (tclMAP (fun x -> Proofview.V82.of_tactic (Simple.intro x)) [res;hres]);
-            (* replacing [res] with its value *)
-            observe_tac "rewriting res value" (Proofview.V82.of_tactic (Equality.rewriteLR (mkVar hres)));
-            (* Conclusion *)
-            observe_tac "exact" (fun g ->
-                                 Proofview.V82.of_tactic (exact_check (app_constructor g)) g)
+              Locusops.onConcl
+          ; observe_tac (fun _ _ -> Pp.str "toto ") tclIDTAC
+          ; (* introducing the result of the graph and the equality hypothesis *)
+            observe_tac (fun _ _ -> Pp.str "introducing") ((tclMAP Simple.intro) [res;hres])
+          ; (* replacing [res] with its value *)
+            observe_tac (fun _ _ -> Pp.str "rewriting res value") (Equality.rewriteLR (mkVar hres))
+          ; (* Conclusion *)
+            observe_tac (fun _ _ -> Pp.str "exact") (PG.enter (fun gl -> exact_check (app_constructor gl)))
           ]
       )
-        g
     in
     (* end of branche proof *)
     let lemmas =
@@ -377,218 +346,221 @@ let prove_fun_correct evd funs_constr graphs_constr schemes lemmas_types_infos i
     (* The bindings of the principle
        that is the params of the principle and the different lemma types
     *)
-    let bindings =
+    let bindings gl =
       let params_bindings,avoid =
         List.fold_left2
           (fun (bindings,avoid) decl p ->
              let id = Namegen.next_ident_away (Nameops.Name.get_id (RelDecl.get_name decl)) (Id.Set.of_list avoid) in
              p::bindings,id::avoid
           )
-          ([],pf_ids_of_hyps g)
+          ([],pf_ids_of_hyps gl)
           princ_infos.params
           (List.rev params)
       in
-      let lemmas_bindings =
+      let lemmas_bindings gl =
         List.rev (fst  (List.fold_left2
-          (fun (bindings,avoid) decl p ->
-             let id = Namegen.next_ident_away (Nameops.Name.get_id (RelDecl.get_name decl)) (Id.Set.of_list avoid) in
-             (Reductionops.nf_zeta (pf_env g) (project g) p)::bindings,id::avoid)
-          ([],avoid)
-          princ_infos.predicates
-          (lemmas)))
+                          (fun (bindings,avoid) decl p ->
+                             let id = Namegen.next_ident_away (Nameops.Name.get_id (RelDecl.get_name decl)) (Id.Set.of_list avoid) in
+                             (Reductionops.nf_zeta (pf_env gl) (project gl) p)::bindings,id::avoid)
+                          ([],avoid)
+                          princ_infos.predicates
+                          (lemmas)))
       in
-      (params_bindings@lemmas_bindings)
+      (params_bindings@lemmas_bindings gl)
     in
     tclTHENLIST
-      [
-        observe_tac "principle" (Proofview.V82.of_tactic (assert_by
-          (Name principle_id)
-          princ_type
-          (exact_check f_principle)));
-        observe_tac "intro args_names" (tclMAP (fun id -> Proofview.V82.of_tactic (Simple.intro id)) args_names);
-        (* observe_tac "titi" (pose_proof (Name (Id.of_string "__")) (Reductionops.nf_beta Evd.empty  ((mkApp (mkVar principle_id,Array.of_list bindings))))); *)
-        observe_tac "idtac" tclIDTAC;
+      [ observe_tac (fun _ _ -> Pp.str "principle")
+          (assert_by
+             (Name principle_id)
+             princ_type
+             (exact_check f_principle))
+      ; observe_tac (fun _ _ -> Pp.str "intro args_names")
+          (tclMAP (fun id -> (Simple.intro id)) args_names)
+      ; (* observe_tac "titi" (pose_proof (Name (Id.of_string "__")) (Reductionops.nf_beta Evd.empty  ((mkApp (mkVar principle_id,Array.of_list bindings))))); *)
+        observe_tac (fun _ _ -> Pp.str "idtac") tclIDTAC;
         tclTHEN_i
           (observe_tac
-             "functional_induction" (
-               (fun gl ->
-                let term = mkApp (mkVar principle_id,Array.of_list bindings) in
-                let gl', _ty = pf_eapply (Typing.type_of ~refresh:true)  gl term in
-                Proofview.V82.of_tactic (apply term) gl')
-           ))
-          (fun i g -> observe_tac ("proving branche "^string_of_int i) (prove_branche i) g )
+             (fun _ _ -> Pp.str "functional_induction")
+             (PG.enter (fun gl ->
+                  let term = mkApp (mkVar principle_id,Array.of_list (bindings gl)) in
+                  let _gl', _ty = pf_eapply (Typing.type_of ~refresh:true) gl term in
+                  apply term
+                )
+             )
+          )
+          (fun i -> observe_tac (fun _ _ -> Pp.(str "proving branche " ++ int i)) (prove_branche i))
       ]
-      g
-
-
-
+  end
 
 (* [generalize_dependent_of x hyp g]
    generalize every hypothesis which depends of [x] but [hyp]
 *)
-let generalize_dependent_of x hyp g =
+let generalize_dependent_of x hyp =
   let open Context.Named.Declaration in
-  tclMAP
-    (function
-       | LocalAssum ({binder_name=id},t) when not (Id.equal id hyp) &&
-           (Termops.occur_var (pf_env g) (project g) x t) -> tclTHEN (Proofview.V82.of_tactic (Tactics.generalize [mkVar id])) (thin [id])
-       | _ -> tclIDTAC
+  PG.(enter begin fun gl ->
+      tclMAP
+        (function
+          | LocalAssum ({binder_name=id},t)
+            when not (Id.equal id hyp) &&
+                 (Termops.occur_var (pf_env gl) (project gl) x t) ->
+            tclTHEN (Tactics.generalize [mkVar id]) (thin [id])
+          | _ -> tclIDTAC
+        )
+        (hyps gl) end
     )
-    (pf_hyps g)
-    g
-
 
 (* [intros_with_rewrite] do the intros in each branch and treat each new hypothesis
        (unfolding, substituting, destructing cases \ldots)
- *)
+*)
 let tauto =
   let dp = List.map Id.of_string ["Tauto" ; "Init"; "Coq"] in
   let mp = ModPath.MPfile (DirPath.make dp) in
   let kn = KerName.make mp (Label.make "tauto") in
-  Proofview.tclBIND (Proofview.tclUNIT ()) begin fun () ->
-    let body = Tacenv.interp_ltac kn in
-    Tacinterp.eval_tactic body
+  let body = Tacenv.interp_ltac kn in
+  Tacinterp.eval_tactic body
+
+let rec intros_with_rewrite () = observe_tac Pp.(fun _ _ -> str "intros_with_rewrite") (intros_with_rewrite_aux ())
+and intros_with_rewrite_aux () =
+  let eq_ind = make_eq () in
+  PG.enter begin fun gl ->
+    let sigma = project gl in
+    match EConstr.kind sigma (pf_concl gl) with
+    | Prod(_,t,t') ->
+      begin
+        match EConstr.kind sigma t with
+        | App(eq,args) when (EConstr.eq_constr sigma eq eq_ind)  ->
+          if Reductionops.is_conv (pf_env gl) (project gl) args.(1) args.(2)
+          then
+            let id = pf_get_new_id (Id.of_string "y") gl in
+            tclTHENLIST
+              [ Simple.intro id
+              ; thin [id]
+              ; intros_with_rewrite ()
+              ]
+          else if isVar sigma args.(1) && (Environ.evaluable_named (destVar sigma args.(1)) (pf_env gl))
+          then tclTHENLIST
+              [ unfold_in_concl [(Locus.AllOccurrences, Names.EvalVarRef (destVar sigma args.(1)))]
+              ; tclMAP (fun id -> tclTRY(unfold_in_hyp [(Locus.AllOccurrences, Names.EvalVarRef (destVar sigma args.(1)))]
+                                           ((destVar sigma args.(1)),Locus.InHyp)))
+                  (pf_ids_of_hyps gl)
+              ; intros_with_rewrite ()
+              ]
+          else if isVar sigma args.(2) && (Environ.evaluable_named (destVar sigma args.(2)) (pf_env gl))
+          then tclTHENLIST
+              [ unfold_in_concl [(Locus.AllOccurrences, Names.EvalVarRef (destVar sigma args.(2)))]
+              ; tclMAP (fun id -> tclTRY
+                           (unfold_in_hyp [(Locus.AllOccurrences, Names.EvalVarRef (destVar sigma args.(2)))] ((destVar sigma args.(2)),Locus.InHyp)))
+                  (pf_ids_of_hyps gl)
+              ; intros_with_rewrite ()
+              ]
+          else if isVar sigma args.(1)
+          then
+            let id = pf_get_new_id (Id.of_string "y") gl in
+            tclTHENLIST [ Simple.intro id
+                        ; generalize_dependent_of (destVar sigma args.(1)) id
+                        ; tclTRY (Equality.rewriteLR (mkVar id))
+                        ; intros_with_rewrite ()
+                        ]
+          else if isVar sigma args.(2)
+          then
+            let id = pf_get_new_id (Id.of_string "y") gl  in
+            tclTHENLIST [ Simple.intro id
+                        ; generalize_dependent_of (destVar sigma args.(2)) id
+                        ; tclTRY (Equality.rewriteRL (mkVar id))
+                        ; intros_with_rewrite ()
+                        ]
+          else
+            begin
+              let id = pf_get_new_id (Id.of_string "y") gl  in
+              tclTHENLIST
+                [ Simple.intro id
+                ; tclTRY (Equality.rewriteLR (mkVar id))
+                ; intros_with_rewrite ()
+                ]
+            end
+        | Ind _ when EConstr.eq_constr sigma t (EConstr.of_constr (UnivGen.constr_of_monomorphic_global @@ Coqlib.lib_ref "core.False.type")) ->
+          tauto
+        | Case(_,_,v,_) ->
+          tclTHENLIST
+            [ simplest_case v
+            ; intros_with_rewrite ()
+            ]
+        | LetIn _ ->
+          tclTHENLIST
+            [ reduce (Genredexpr.Cbv
+                        {Redops.all_flags
+                         with Genredexpr.rDelta = false;
+                        })
+                Locusops.onConcl
+            ; intros_with_rewrite ()
+            ]
+        | _ ->
+          let id = pf_get_new_id (Id.of_string "y") gl in
+          tclTHENLIST
+            [ Simple.intro id
+            ; intros_with_rewrite ()
+            ]
+      end
+    | LetIn _ ->
+      tclTHENLIST
+        [ reduce (Genredexpr.Cbv { Redops.all_flags with Genredexpr.rDelta = false; }) Locusops.onConcl
+        ; intros_with_rewrite ()
+        ]
+    | _ -> tclIDTAC
   end
 
-let  rec intros_with_rewrite g =
-  observe_tac "intros_with_rewrite" intros_with_rewrite_aux g
-and intros_with_rewrite_aux : Tacmach.tactic =
-  fun g ->
-    let eq_ind = make_eq () in
-    let sigma = project g in
-    match EConstr.kind sigma (pf_concl g) with
-          | Prod(_,t,t') ->
-              begin
-                match EConstr.kind sigma t with
-                  | App(eq,args) when (EConstr.eq_constr sigma eq eq_ind)  ->
-                      if Reductionops.is_conv (pf_env g) (project g) args.(1) args.(2)
-                      then
-                        let id = pf_get_new_id (Id.of_string "y") g  in
-                        tclTHENLIST [ Proofview.V82.of_tactic (Simple.intro id); thin [id]; intros_with_rewrite ] g
-                      else if isVar sigma args.(1) && (Environ.evaluable_named (destVar sigma args.(1)) (pf_env g))
-                      then tclTHENLIST[
-                        Proofview.V82.of_tactic (unfold_in_concl [(Locus.AllOccurrences, Names.EvalVarRef (destVar sigma args.(1)))]);
-                        tclMAP (fun id -> tclTRY(Proofview.V82.of_tactic (unfold_in_hyp [(Locus.AllOccurrences, Names.EvalVarRef (destVar sigma args.(1)))] ((destVar sigma args.(1)),Locus.InHyp) )))
-                          (pf_ids_of_hyps g);
-                        intros_with_rewrite
-                      ] g
-                      else if isVar sigma args.(2) && (Environ.evaluable_named (destVar sigma args.(2)) (pf_env g))
-                      then tclTHENLIST[
-                        Proofview.V82.of_tactic (unfold_in_concl [(Locus.AllOccurrences, Names.EvalVarRef (destVar sigma args.(2)))]);
-                        tclMAP (fun id -> tclTRY(Proofview.V82.of_tactic (unfold_in_hyp [(Locus.AllOccurrences, Names.EvalVarRef (destVar sigma args.(2)))] ((destVar sigma args.(2)),Locus.InHyp) )))
-                          (pf_ids_of_hyps g);
-                        intros_with_rewrite
-                      ] g
-                      else if isVar sigma args.(1)
-                      then
-                        let id = pf_get_new_id (Id.of_string "y") g  in
-                        tclTHENLIST [ Proofview.V82.of_tactic (Simple.intro id);
-                                     generalize_dependent_of (destVar sigma args.(1)) id;
-                                     tclTRY (Proofview.V82.of_tactic (Equality.rewriteLR (mkVar id)));
-                                     intros_with_rewrite
-                                   ]
-                          g
-                      else if isVar sigma args.(2)
-                      then
-                        let id = pf_get_new_id (Id.of_string "y") g  in
-                        tclTHENLIST [ Proofview.V82.of_tactic (Simple.intro id);
-                                     generalize_dependent_of (destVar sigma args.(2)) id;
-                                     tclTRY (Proofview.V82.of_tactic (Equality.rewriteRL (mkVar id)));
-                                     intros_with_rewrite
-                                   ]
-                          g
-                      else
-                        begin
-                          let id = pf_get_new_id (Id.of_string "y") g  in
-                          tclTHENLIST[
-                            Proofview.V82.of_tactic (Simple.intro id);
-                            tclTRY (Proofview.V82.of_tactic (Equality.rewriteLR (mkVar id)));
-                            intros_with_rewrite
-                          ] g
-                        end
-                  | Ind _ when EConstr.eq_constr sigma t (EConstr.of_constr (UnivGen.constr_of_monomorphic_global @@ Coqlib.lib_ref "core.False.type")) ->
-                      Proofview.V82.of_tactic tauto g
-                  | Case(_,_,v,_) ->
-                      tclTHENLIST[
-                        Proofview.V82.of_tactic (simplest_case v);
-                        intros_with_rewrite
-                      ] g
-                  | LetIn _ ->
-                      tclTHENLIST[
-                        Proofview.V82.of_tactic (reduce
-                          (Genredexpr.Cbv
-                             {Redops.all_flags
-                              with Genredexpr.rDelta = false;
-                             })
-                          Locusops.onConcl)
-                        ;
-                        intros_with_rewrite
-                      ] g
-                  | _ ->
-                      let id = pf_get_new_id (Id.of_string "y") g  in
-                      tclTHENLIST [ Proofview.V82.of_tactic (Simple.intro id);intros_with_rewrite] g
-              end
-          | LetIn _ ->
-              tclTHENLIST[
-                Proofview.V82.of_tactic (reduce
-                  (Genredexpr.Cbv
-                     {Redops.all_flags
-                      with Genredexpr.rDelta = false;
-                     })
-                  Locusops.onConcl)
-                ;
-                intros_with_rewrite
-              ] g
-          | _ -> tclIDTAC g
-
-let rec reflexivity_with_destruct_cases g =
+let rec reflexivity_with_destruct_cases () =
   let destruct_case () =
     try
-      match EConstr.kind (project g) (snd (destApp (project g) (pf_concl g))).(2) with
+      PG.enter begin fun gl ->
+        match EConstr.kind (project gl) (snd (destApp (project gl) (pf_concl gl))).(2) with
         | Case(_,_,v,_) ->
-            tclTHENLIST[
-              Proofview.V82.of_tactic (simplest_case v);
-              Proofview.V82.of_tactic intros;
-              observe_tac "reflexivity_with_destruct_cases" reflexivity_with_destruct_cases
+          tclTHENLIST
+            [ simplest_case v
+            ; intros
+            ; observe_tac Pp.(fun _ _ -> str "reflexivity_with_destruct_cases") (reflexivity_with_destruct_cases ())
             ]
-        | _ -> Proofview.V82.of_tactic reflexivity
-    with e when CErrors.noncritical e -> Proofview.V82.of_tactic reflexivity
+        | _ -> reflexivity
+      end
+    with e when CErrors.noncritical e -> reflexivity
   in
   let eq_ind = make_eq () in
   let my_inj_flags = Some {
-    Equality.keep_proof_equalities = false;
-    injection_in_context = false; (* for compatibility, necessary *)
-    injection_pattern_l2r_order = false; (* probably does not matter; except maybe with dependent hyps *)
-  } in
+      Equality.keep_proof_equalities = false;
+      injection_in_context = false; (* for compatibility, necessary *)
+      injection_pattern_l2r_order = false; (* probably does not matter; except maybe with dependent hyps *)
+    } in
   let discr_inject =
-    Tacticals.onAllHypsAndConcl (
-       fun sc g ->
-         match sc with
-             None -> tclIDTAC g
-           | Some id ->
-               match EConstr.kind (project g) (pf_unsafe_type_of g (mkVar id)) with
-                 | App(eq,[|_;t1;t2|]) when EConstr.eq_constr (project g) eq eq_ind ->
-                     if Equality.discriminable (pf_env g) (project g) t1 t2
-                     then Proofview.V82.of_tactic (Equality.discrHyp id) g
-                     else if Equality.injectable (pf_env g) (project g) ~keep_proofs:None t1 t2
-                     then tclTHENLIST [Proofview.V82.of_tactic (Equality.injHyp my_inj_flags None id);thin [id];intros_with_rewrite]  g
-                     else tclIDTAC g
-                 | _ -> tclIDTAC g
+    (* XXX missing *)
+    Tacticals.New.onAllHypsAndConcl (
+      fun sc ->
+        PG.enter (fun gl ->
+        match sc with
+          None -> tclIDTAC
+        | Some id ->
+          match EConstr.kind (project gl) (pf_unsafe_type_of gl (mkVar id)) with
+          | App(eq,[|_;t1;t2|]) when EConstr.eq_constr (project gl) eq eq_ind ->
+            if Equality.discriminable (pf_env gl) (project gl) t1 t2
+            then Equality.discrHyp id
+            else if Equality.injectable (pf_env gl) (project gl) ~keep_proofs:None t1 t2
+            then tclTHENLIST [Equality.injHyp my_inj_flags None id; thin [id]; intros_with_rewrite ()]
+            else tclIDTAC
+          | _ -> tclIDTAC
+          )
     )
   in
   (tclFIRST
-    [ observe_tac "reflexivity_with_destruct_cases : reflexivity" (Proofview.V82.of_tactic reflexivity);
-      observe_tac "reflexivity_with_destruct_cases : destruct_case" ((destruct_case ()));
-      (*  We reach this point ONLY if
-          the same value is matched (at least) two times
-          along binding path.
-          In this case, either we have a discriminable hypothesis and we are done,
-          either at least an injectable one and we do the injection before continuing
-      *)
-      observe_tac "reflexivity_with_destruct_cases : others" (tclTHEN (tclPROGRESS discr_inject ) reflexivity_with_destruct_cases)
-    ])
-    g
-
+     [ observe_tac (fun _ _ -> Pp.str "reflexivity_with_destruct_cases : reflexivity") reflexivity
+     ; observe_tac (fun _ _ -> Pp.str "reflexivity_with_destruct_cases : destruct_case") (destruct_case ())
+     ; (*  We reach this point ONLY if
+           the same value is matched (at least) two times
+           along binding path.
+           In this case, either we have a discriminable hypothesis and we are done,
+           either at least an injectable one and we do the injection before continuing
+       *)
+       observe_tac (fun _ _ -> Pp.str "reflexivity_with_destruct_cases : others")
+         (tclTHEN (tclPROGRESS discr_inject ) (reflexivity_with_destruct_cases ()))
+     ])
 
 (* [prove_fun_complete funs graphs schemes lemmas_types_infos i]
    is the tactic used to prove completeness lemma.
@@ -617,124 +589,121 @@ let rec reflexivity_with_destruct_cases g =
 
 *)
 
-
-let prove_fun_complete funcs graphs schemes lemmas_types_infos i : Tacmach.tactic =
-  fun g ->
-    (* We compute the types of the different mutually recursive lemmas
-       in $\zeta$ normal form
-    *)
-    let lemmas =
-      Array.map
-        (fun (_,(ctxt,concl)) -> Reductionops.nf_zeta (pf_env g) (project g) (EConstr.it_mkLambda_or_LetIn concl ctxt))
-        lemmas_types_infos
+let prove_fun_complete funcs graphs schemes lemmas_types_infos i =
+  (* We compute the types of the different mutually recursive lemmas
+     in $\zeta$ normal form
+  *)
+  PG.enter (fun gl ->
+  let lemmas =
+    Array.map
+      (fun (_,(ctxt,concl)) -> Reductionops.nf_zeta (pf_env gl) (project gl) (EConstr.it_mkLambda_or_LetIn concl ctxt))
+      lemmas_types_infos
+  in
+  (* We get the constant and the principle corresponding to this lemma *)
+  let f = funcs.(i) in
+  let graph_principle = Reductionops.nf_zeta (pf_env gl) (project gl) (EConstr.of_constr schemes.(i))  in
+  let princ_type = pf_unsafe_type_of gl graph_principle in
+  let princ_infos = Tactics.compute_elim_sig (project gl) princ_type in
+  (* Then we get the number of argument of the function
+     and compute a fresh name for each of them
+  *)
+  let nb_fun_args = nb_prod (project gl) (pf_concl gl) - 2 in
+  let args_names = generate_fresh_id (Id.of_string "x") [] nb_fun_args in
+  let ids = args_names@(pf_ids_of_hyps gl) in
+  (* and fresh names for res H and the principle (cf bug bug #1174) *)
+  let res,hres,graph_principle_id =
+    match generate_fresh_id (Id.of_string "z") ids 3 with
+    | [res;hres;graph_principle_id] -> res,hres,graph_principle_id
+    | _ -> assert false
+  in
+  let ids = res::hres::graph_principle_id::ids in
+  (* we also compute fresh names for each hyptohesis of each branch
+     of the principle *)
+  let branches = List.rev princ_infos.branches in
+  let intro_pats =
+    List.map
+      (fun decl ->
+         List.map
+           (fun id -> id)
+           (generate_fresh_id (Id.of_string "y") ids (nb_prod (project gl) (RelDecl.get_type decl)))
+      )
+      branches
+  in
+  (* We will need to change the function by its body
+     using [f_equation] if it is recursive (that is the graph is infinite
+     or unfold if the graph is finite
+  *)
+  let rewrite_tac j ids =
+    let graph_def = graphs.(j) in
+    let infos =
+      try find_Function_infos (fst (destConst (project gl) funcs.(j)))
+      with Not_found ->  user_err Pp.(str "No graph found")
     in
-    (* We get the constant and the principle corresponding to this lemma *)
-    let f = funcs.(i) in
-    let graph_principle = Reductionops.nf_zeta (pf_env g) (project g) (EConstr.of_constr schemes.(i))  in
-    let princ_type = pf_unsafe_type_of g graph_principle in
-    let princ_infos = Tactics.compute_elim_sig (project g) princ_type in
-    (* Then we get the number of argument of the function
-       and compute a fresh name for each of them
-    *)
-    let nb_fun_args = nb_prod (project g) (pf_concl g) - 2 in
-    let args_names = generate_fresh_id (Id.of_string "x") [] nb_fun_args in
-    let ids = args_names@(pf_ids_of_hyps g) in
-    (* and fresh names for res H and the principle (cf bug bug #1174) *)
-    let res,hres,graph_principle_id =
-      match generate_fresh_id (Id.of_string "z") ids 3 with
-        | [res;hres;graph_principle_id] -> res,hres,graph_principle_id
-        | _ -> assert false
-    in
-    let ids = res::hres::graph_principle_id::ids in
-    (* we also compute fresh names for each hyptohesis of each branch
-       of the principle *)
-    let branches = List.rev princ_infos.branches in
-    let intro_pats =
-      List.map
-        (fun decl ->
-           List.map
-             (fun id -> id)
-             (generate_fresh_id (Id.of_string "y") ids (nb_prod (project g) (RelDecl.get_type decl)))
-        )
-        branches
-    in
-    (* We will need to change the function by its body
-       using [f_equation] if it is recursive (that is the graph is infinite
-       or unfold if the graph is finite
-    *)
-    let rewrite_tac j ids : Tacmach.tactic =
-      let graph_def = graphs.(j) in
-      let infos =
-        try find_Function_infos (fst (destConst (project g) funcs.(j)))
-        with Not_found ->  user_err Pp.(str "No graph found")
+    if infos.is_general
+    || Rtree.is_infinite Declareops.eq_recarg graph_def.mind_recargs
+    then
+      let eq_lemma =
+        try Option.get (infos).equation_lemma
+        with Option.IsNone -> anomaly (Pp.str "Cannot find equation lemma.")
       in
-      if infos.is_general
-        || Rtree.is_infinite Declareops.eq_recarg graph_def.mind_recargs
-      then
-        let eq_lemma =
-          try Option.get (infos).equation_lemma
-          with Option.IsNone -> anomaly (Pp.str "Cannot find equation lemma.")
-        in
-        tclTHENLIST[
-          tclMAP (fun id -> Proofview.V82.of_tactic (Simple.intro id)) ids;
-          Proofview.V82.of_tactic (Equality.rewriteLR (mkConst eq_lemma));
-          (* Don't forget to $\zeta$ normlize the term since the principles
+      tclTHENLIST
+        [ tclMAP (fun id -> Simple.intro id) ids
+        ; Equality.rewriteLR (mkConst eq_lemma)
+        ; (* Don't forget to $\zeta$ normlize the term since the principles
              have been $\zeta$-normalized *)
-          Proofview.V82.of_tactic (reduce
+          reduce
             (Genredexpr.Cbv
-               {Redops.all_flags
-                with Genredexpr.rDelta = false;
+               { Redops.all_flags with
+                 Genredexpr.rDelta = false
                })
-            Locusops.onConcl)
-          ;
-          Proofview.V82.of_tactic (generalize (List.map mkVar ids));
-          thin ids
+            Locusops.onConcl
+        ; generalize (List.map mkVar ids)
+        ; thin ids
         ]
+    else
+      unfold_in_concl [(Locus.AllOccurrences, Names.EvalConstRef (fst (destConst (project gl) f)))]
+  in
+  (* The proof of each branche itself *)
+  let ind_number = ref 0 in
+  let min_constr_number = ref 0 in
+  let prove_branche i =
+    (* we fist compute the inductive corresponding to the branch *)
+    let this_ind_number =
+      let constructor_num = i - !min_constr_number in
+      let length = Array.length (graphs.(!ind_number).Declarations.mind_consnames) in
+      if constructor_num <= length
+      then !ind_number
       else
-        Proofview.V82.of_tactic (unfold_in_concl [(Locus.AllOccurrences, Names.EvalConstRef (fst (destConst (project g) f)))])
+        begin
+          incr ind_number;
+          min_constr_number := !min_constr_number + length;
+          !ind_number
+        end
     in
-    (* The proof of each branche itself *)
-    let ind_number = ref 0 in
-    let min_constr_number = ref 0 in
-    let prove_branche i g =
-      (* we fist compute the inductive corresponding to the branch *)
-      let this_ind_number =
-        let constructor_num = i - !min_constr_number in
-        let length = Array.length (graphs.(!ind_number).Declarations.mind_consnames) in
-        if constructor_num <= length
-        then !ind_number
-        else
-          begin
-            incr ind_number;
-            min_constr_number := !min_constr_number + length;
-            !ind_number
-          end
-      in
-      let this_branche_ids = List.nth intro_pats (pred i) in
-      tclTHENLIST[
-        (* we expand the definition of the function *)
-        observe_tac "rewrite_tac" (rewrite_tac this_ind_number this_branche_ids);
-        (* introduce hypothesis with some rewrite *)
-        observe_tac "intros_with_rewrite (all)" intros_with_rewrite;
-        (* The proof is (almost) complete *)
-        observe_tac "reflexivity" (reflexivity_with_destruct_cases)
-      ]
-        g
-    in
-    let params_names = fst (List.chop princ_infos.nparams args_names) in
-    let open EConstr in
-    let params = List.map mkVar params_names in
-    tclTHENLIST
-      [ tclMAP (fun id -> Proofview.V82.of_tactic (Simple.intro id)) (args_names@[res;hres]);
-        observe_tac "h_generalize"
-        (Proofview.V82.of_tactic (generalize [mkApp(applist(graph_principle,params),Array.map (fun c -> applist(c,params)) lemmas)]));
-        Proofview.V82.of_tactic (Simple.intro graph_principle_id);
-        observe_tac "" (tclTHEN_i
-          (observe_tac "elim" (Proofview.V82.of_tactic (elim false None (mkVar hres,NoBindings) (Some (mkVar graph_principle_id,NoBindings)))))
-          (fun i g -> observe_tac "prove_branche" (prove_branche i) g ))
-      ]
-      g
-
+    let this_branche_ids = List.nth intro_pats (pred i) in
+    tclTHENLIST[
+      (* we expand the definition of the function *)
+      observe_tac (fun _ _ -> Pp.str "rewrite_tac") (rewrite_tac this_ind_number this_branche_ids);
+      (* introduce hypothesis with some rewrite *)
+      observe_tac (fun _ _ -> Pp.str "intros_with_rewrite (all)") (intros_with_rewrite ());
+      (* The proof is (almost) complete *)
+      observe_tac (fun _ _ -> Pp.str "reflexivity") (reflexivity_with_destruct_cases ())
+    ]
+  in
+  let params_names = fst (List.chop princ_infos.nparams args_names) in
+  let open EConstr in
+  let params = List.map mkVar params_names in
+  tclTHENLIST
+    [ tclMAP (fun id -> Simple.intro id) (args_names@[res;hres])
+    ; observe_tac (fun _ _ -> Pp.str "h_generalize")
+        (generalize [mkApp(applist(graph_principle,params),Array.map (fun c -> applist(c,params)) lemmas)])
+    ; Simple.intro graph_principle_id
+    ; observe_tac (fun _ _ -> Pp.mt ())
+        (tclTHEN_i
+           (observe_tac (fun _ _ -> Pp.str "elim") (elim false None (mkVar hres,NoBindings) (Some (mkVar graph_principle_id,NoBindings))))
+           (fun i -> observe_tac (fun _ _ -> Pp.str "prove_branche") (prove_branche i)))
+    ]
+    )
 
 (* [derive_correctness make_scheme funs graphs] create correctness and completeness
    lemmas for each function in [funs] w.r.t. [graphs]
@@ -751,134 +720,134 @@ let derive_correctness make_scheme (funs: pconstant list) (graphs:inductive list
   (* XXX STATE Why do we need this... why is the toplevel protection not enough *)
   funind_purify
     (fun () ->
-     let env = Global.env () in
-     let evd = ref (Evd.from_env env) in
-     let graphs_constr = Array.map mkInd graphs in
-     let lemmas_types_infos =
-       Util.Array.map2_i
-         (fun i f_constr graph ->
-         (* let const_of_f,u = destConst f_constr in *)
-         let (type_of_lemma_ctxt,type_of_lemma_concl,graph) =
-           generate_type evd false f_constr graph i
-         in
-         let type_info = (type_of_lemma_ctxt,type_of_lemma_concl) in
-         graphs_constr.(i) <- graph;
-         let type_of_lemma = EConstr.it_mkProd_or_LetIn type_of_lemma_concl type_of_lemma_ctxt in
-         let sigma, _ = Typing.type_of (Global.env ()) !evd type_of_lemma in
-         evd := sigma;
-           let type_of_lemma = Reductionops.nf_zeta (Global.env ()) !evd type_of_lemma in
-           observe (str "type_of_lemma := " ++ Printer.pr_leconstr_env (Global.env ()) !evd type_of_lemma);
-           type_of_lemma,type_info
-        )
-        funs_constr
-        graphs_constr
-    in
-    let schemes =
-      (* The functional induction schemes are computed and not saved if there is more that one function
-         if the block contains only one function we can safely reuse [f_rect]
-       *)
-      try
-        if not (Int.equal (Array.length funs_constr) 1) then raise Not_found;
-        [| find_induction_principle evd funs_constr.(0) |]
-      with Not_found ->
-        (
-
-          Array.of_list
-            (List.map
-               (fun entry ->
-                  (EConstr.of_constr (fst (fst(Future.force entry.Entries.const_entry_body))), EConstr.of_constr (Option.get entry.Entries.const_entry_type ))
-               )
-               (make_scheme evd (Array.map_to_list (fun const -> const,Sorts.InType) funs))
-            )
-        )
-    in
-    let proving_tac =
-      prove_fun_correct !evd funs_constr graphs_constr schemes lemmas_types_infos
-    in
-    Array.iteri
-      (fun i f_as_constant ->
-         let f_id = Label.to_id (Constant.label (fst f_as_constant)) in
-         (*i The next call to mk_correct_id is valid since we are constructing the lemma
-             Ensures by: obvious
-         i*)
-         let lem_id = mk_correct_id f_id in
-         let (typ,_) = lemmas_types_infos.(i) in
-         let lemma = Lemmas.start_lemma
-           lem_id
-           Decl_kinds.(Global ImportDefaultBehavior,false,Proof Theorem)
-           !evd
-           typ in
-         let lemma = fst @@ Lemmas.by
-                   (Proofview.V82.tactic (observe_tac ("prove correctness ("^(Id.to_string f_id)^")")
-                                                      (proving_tac i))) lemma in
-         let () = Lemmas.save_lemma_proved ?proof:None ~lemma ~opaque:Proof_global.Transparent ~idopt:None in
-         let finfo = find_Function_infos (fst f_as_constant) in
-         (* let lem_cst = fst (destConst (Constrintern.global_reference lem_id)) in *)
-         let _,lem_cst_constr = Evd.fresh_global
-                                  (Global.env ()) !evd (Constrintern.locate_reference (Libnames.qualid_of_ident lem_id)) in
-         let (lem_cst,_) = destConst !evd lem_cst_constr in
-         update_Function {finfo with correctness_lemma = Some lem_cst};
-
-      )
-      funs;
-    let lemmas_types_infos =
-      Util.Array.map2_i
-        (fun i f_constr graph ->
-         let (type_of_lemma_ctxt,type_of_lemma_concl,graph)   =
-           generate_type evd true f_constr graph i
-         in
-         let type_info = (type_of_lemma_ctxt,type_of_lemma_concl) in
-         graphs_constr.(i) <- graph;
-         let type_of_lemma =
-           EConstr.it_mkProd_or_LetIn type_of_lemma_concl type_of_lemma_ctxt
-         in
-         let type_of_lemma = Reductionops.nf_zeta env !evd type_of_lemma in
-         observe (str "type_of_lemma := " ++ Printer.pr_leconstr_env env !evd type_of_lemma);
-         type_of_lemma,type_info
-        )
-        funs_constr
-        graphs_constr
-    in
-
-    let (kn,_) as graph_ind,u  = (destInd !evd graphs_constr.(0)) in
-    let mib,mip = Global.lookup_inductive graph_ind in
-    let sigma, scheme =
-        (Indrec.build_mutual_induction_scheme (Global.env ()) !evd
-           (Array.to_list
-              (Array.mapi
-                 (fun i _ -> ((kn,i), EInstance.kind !evd u),true,InType)
-                 mib.Declarations.mind_packets
-              )
+       let env = Global.env () in
+       let evd = ref (Evd.from_env env) in
+       let graphs_constr = Array.map mkInd graphs in
+       let lemmas_types_infos =
+         Util.Array.map2_i
+           (fun i f_constr graph ->
+              (* let const_of_f,u = destConst f_constr in *)
+              let (type_of_lemma_ctxt,type_of_lemma_concl,graph) =
+                generate_type evd false f_constr graph i
+              in
+              let type_info = (type_of_lemma_ctxt,type_of_lemma_concl) in
+              graphs_constr.(i) <- graph;
+              let type_of_lemma = EConstr.it_mkProd_or_LetIn type_of_lemma_concl type_of_lemma_ctxt in
+              let sigma, _ = Typing.type_of (Global.env ()) !evd type_of_lemma in
+              evd := sigma;
+              let type_of_lemma = Reductionops.nf_zeta (Global.env ()) !evd type_of_lemma in
+              observe (str "type_of_lemma := " ++ Printer.pr_leconstr_env (Global.env ()) !evd type_of_lemma);
+              type_of_lemma,type_info
            )
-        )
-    in
-    let schemes =
-      Array.of_list scheme
-    in
-    let proving_tac =
-      prove_fun_complete funs_constr mib.Declarations.mind_packets schemes lemmas_types_infos
-    in
-    Array.iteri
-      (fun i f_as_constant ->
-         let f_id = Label.to_id (Constant.label (fst f_as_constant)) in
-         (*i The next call to mk_complete_id is valid since we are constructing the lemma
-             Ensures by: obvious
-           i*)
-         let lem_id = mk_complete_id f_id in
-         let lemma = Lemmas.start_lemma lem_id
-           Decl_kinds.(Global ImportDefaultBehavior,false,Proof Theorem) sigma
-         (fst lemmas_types_infos.(i)) in
-         let lemma = fst (Lemmas.by
-           (Proofview.V82.tactic (observe_tac ("prove completeness ("^(Id.to_string f_id)^")")
-              (proving_tac i))) lemma) in
-         let () = Lemmas.save_lemma_proved ?proof:None ~lemma ~opaque:Proof_global.Transparent ~idopt:None in
-         let finfo = find_Function_infos (fst f_as_constant) in
-         let _,lem_cst_constr = Evd.fresh_global
-                                  (Global.env ()) !evd (Constrintern.locate_reference (Libnames.qualid_of_ident lem_id)) in
-         let (lem_cst,_) = destConst !evd lem_cst_constr in
-         update_Function {finfo with completeness_lemma = Some lem_cst}
-      )
-      funs)
+           funs_constr
+           graphs_constr
+       in
+       let schemes =
+         (* The functional induction schemes are computed and not saved if there is more that one function
+            if the block contains only one function we can safely reuse [f_rect]
+         *)
+         try
+           if not (Int.equal (Array.length funs_constr) 1) then raise Not_found;
+           [| find_induction_principle evd funs_constr.(0) |]
+         with Not_found ->
+           (
+
+             Array.of_list
+               (List.map
+                  (fun entry ->
+                     (EConstr.of_constr (fst (fst(Future.force entry.Entries.const_entry_body))), EConstr.of_constr (Option.get entry.Entries.const_entry_type ))
+                  )
+                  (make_scheme evd (Array.map_to_list (fun const -> const,Sorts.InType) funs))
+               )
+           )
+       in
+       let proving_tac =
+         prove_fun_correct !evd funs_constr graphs_constr schemes lemmas_types_infos
+       in
+       Array.iteri
+         (fun i f_as_constant ->
+            let f_id = Label.to_id (Constant.label (fst f_as_constant)) in
+            (*i The next call to mk_correct_id is valid since we are constructing the lemma
+                Ensures by: obvious
+              i*)
+            let lem_id = mk_correct_id f_id in
+            let (typ,_) = lemmas_types_infos.(i) in
+            let lemma = Lemmas.start_lemma
+                lem_id
+                Decl_kinds.(Global ImportDefaultBehavior,false,Proof Theorem)
+                !evd
+                typ in
+            let lemma = fst @@ Lemmas.by
+                (observe_tac (fun _ _ -> Pp.(str "prove correctness (" ++ Id.print f_id ++ str ")"))
+                   (proving_tac i)) lemma in
+            let () = Lemmas.save_lemma_proved ?proof:None ~lemma ~opaque:Proof_global.Transparent ~idopt:None in
+            let finfo = find_Function_infos (fst f_as_constant) in
+            (* let lem_cst = fst (destConst (Constrintern.global_reference lem_id)) in *)
+            let _,lem_cst_constr = Evd.fresh_global
+                (Global.env ()) !evd (Constrintern.locate_reference (Libnames.qualid_of_ident lem_id)) in
+            let (lem_cst,_) = destConst !evd lem_cst_constr in
+            update_Function {finfo with correctness_lemma = Some lem_cst};
+
+         )
+         funs;
+       let lemmas_types_infos =
+         Util.Array.map2_i
+           (fun i f_constr graph ->
+              let (type_of_lemma_ctxt,type_of_lemma_concl,graph)   =
+                generate_type evd true f_constr graph i
+              in
+              let type_info = (type_of_lemma_ctxt,type_of_lemma_concl) in
+              graphs_constr.(i) <- graph;
+              let type_of_lemma =
+                EConstr.it_mkProd_or_LetIn type_of_lemma_concl type_of_lemma_ctxt
+              in
+              let type_of_lemma = Reductionops.nf_zeta env !evd type_of_lemma in
+              observe (str "type_of_lemma := " ++ Printer.pr_leconstr_env env !evd type_of_lemma);
+              type_of_lemma,type_info
+           )
+           funs_constr
+           graphs_constr
+       in
+
+       let (kn,_) as graph_ind,u  = (destInd !evd graphs_constr.(0)) in
+       let mib,mip = Global.lookup_inductive graph_ind in
+       let sigma, scheme =
+         (Indrec.build_mutual_induction_scheme (Global.env ()) !evd
+            (Array.to_list
+               (Array.mapi
+                  (fun i _ -> ((kn,i), EInstance.kind !evd u),true,InType)
+                  mib.Declarations.mind_packets
+               )
+            )
+         )
+       in
+       let schemes =
+         Array.of_list scheme
+       in
+       let proving_tac =
+         prove_fun_complete funs_constr mib.Declarations.mind_packets schemes lemmas_types_infos
+       in
+       Array.iteri
+         (fun i f_as_constant ->
+            let f_id = Label.to_id (Constant.label (fst f_as_constant)) in
+            (*i The next call to mk_complete_id is valid since we are constructing the lemma
+                Ensures by: obvious
+              i*)
+            let lem_id = mk_complete_id f_id in
+            let lemma = Lemmas.start_lemma lem_id
+                Decl_kinds.(Global ImportDefaultBehavior,false,Proof Theorem) sigma
+                (fst lemmas_types_infos.(i)) in
+            let lemma = fst (Lemmas.by
+                               (observe_tac (fun _ _ -> Pp.(str "prove completeness (" ++ Id.print f_id ++ str ")"))
+                                  (proving_tac i)) lemma) in
+            let () = Lemmas.save_lemma_proved ?proof:None ~lemma ~opaque:Proof_global.Transparent ~idopt:None in
+            let finfo = find_Function_infos (fst f_as_constant) in
+            let _,lem_cst_constr = Evd.fresh_global
+                (Global.env ()) !evd (Constrintern.locate_reference (Libnames.qualid_of_ident lem_id)) in
+            let (lem_cst,_) = destConst !evd lem_cst_constr in
+            update_Function {finfo with completeness_lemma = Some lem_cst}
+         )
+         funs)
     ()
 
 (***********************************************)
@@ -889,38 +858,36 @@ let derive_correctness make_scheme (funs: pconstant list) (graphs:inductive list
 
    if the type of hypothesis has not this form or if we cannot find the completeness lemma then we do nothing
 *)
-let revert_graph kn post_tac hid g =
-    let sigma = project g in
-    let typ = pf_unsafe_type_of g (mkVar hid) in
-    match EConstr.kind sigma typ with
-      | App(i,args) when isInd sigma i ->
-          let ((kn',num) as ind'),u = destInd sigma i in
-          if MutInd.equal kn kn'
-          then (* We have generated a graph hypothesis so that we must change it if we can *)
-            let info =
-              try find_Function_of_graph ind'
-              with Not_found -> (* The graphs are mutually recursive but we cannot find one of them !*)
-                anomaly (Pp.str "Cannot retrieve infos about a mutual block.")
-            in
-            (* if we can find a completeness lemma for this function
-               then we can come back to the functional form. If not, we do nothing
-            *)
-            match info.completeness_lemma with
-              | None -> tclIDTAC g
-              | Some f_complete ->
-                  let f_args,res = Array.chop (Array.length args - 1) args in
-                  tclTHENLIST
-                    [
-                      Proofview.V82.of_tactic (generalize [applist(mkConst f_complete,(Array.to_list f_args)@[res.(0);mkVar hid])]);
-                      thin [hid];
-                      Proofview.V82.of_tactic (Simple.intro hid);
-                      post_tac hid
-                    ]
-                    g
-
-          else tclIDTAC g
-      | _ -> tclIDTAC g
-
+let revert_graph kn post_tac hid =
+  PG.enter (fun gl ->
+  let sigma = project gl in
+  let typ = pf_unsafe_type_of gl (mkVar hid) in
+  match EConstr.kind sigma typ with
+  | App(i,args) when isInd sigma i ->
+    let ((kn',num) as ind'),u = destInd sigma i in
+    if MutInd.equal kn kn'
+    then (* We have generated a graph hypothesis so that we must change it if we can *)
+      let info =
+        try find_Function_of_graph ind'
+        with Not_found -> (* The graphs are mutually recursive but we cannot find one of them !*)
+          anomaly (Pp.str "Cannot retrieve infos about a mutual block.")
+      in
+      (* if we can find a completeness lemma for this function
+         then we can come back to the functional form. If not, we do nothing
+      *)
+      match info.completeness_lemma with
+      | None -> tclIDTAC
+      | Some f_complete ->
+        let f_args,res = Array.chop (Array.length args - 1) args in
+        tclTHENLIST
+          [ generalize [applist(mkConst f_complete,(Array.to_list f_args)@[res.(0);mkVar hid])]
+          ; thin [hid]
+          ; Simple.intro hid
+          ; post_tac hid
+          ]
+    else tclIDTAC
+  | _ -> tclIDTAC
+  )
 
 (*
    [functional_inversion hid fconst f_correct ] is the functional version of [inversion]
@@ -939,101 +906,98 @@ let revert_graph kn post_tac hid g =
    \end{enumerate}
 *)
 
-let functional_inversion kn hid fconst f_correct : Tacmach.tactic =
-  fun g ->
-    let old_ids = List.fold_right Id.Set.add  (pf_ids_of_hyps g) Id.Set.empty in
-    let sigma = project g in
-    let type_of_h = pf_unsafe_type_of g (mkVar hid) in
-    match EConstr.kind sigma type_of_h with
-      | App(eq,args) when EConstr.eq_constr sigma eq (make_eq ())  ->
-          let pre_tac,f_args,res =
-            match EConstr.kind sigma args.(1),EConstr.kind sigma args.(2) with
-              | App(f,f_args),_ when EConstr.eq_constr sigma f fconst ->
-                  ((fun hid -> Proofview.V82.of_tactic (intros_symmetry (Locusops.onHyp hid))),f_args,args.(2))
-              |_,App(f,f_args) when EConstr.eq_constr sigma f fconst ->
-                 ((fun hid -> tclIDTAC),f_args,args.(1))
-              | _ -> (fun hid -> tclFAIL 1 (mt ())),[||],args.(2)
-          in
-          tclTHENLIST [
-            pre_tac hid;
-            Proofview.V82.of_tactic (generalize [applist(f_correct,(Array.to_list f_args)@[res;mkVar hid])]);
-            thin [hid];
-            Proofview.V82.of_tactic (Simple.intro hid);
-            Proofview.V82.of_tactic (Inv.inv Inv.FullInversion None (NamedHyp hid));
-            (fun g ->
-               let new_ids = List.filter (fun id -> not (Id.Set.mem id old_ids)) (pf_ids_of_hyps g) in
-               tclMAP (revert_graph kn pre_tac)  (hid::new_ids)  g
-            );
-          ] g
-      | _ -> tclFAIL 1 (mt ()) g
-
+let functional_inversion kn hid fconst f_correct =
+  PG.enter (fun gl ->
+  let old_ids = List.fold_right Id.Set.add  (pf_ids_of_hyps gl) Id.Set.empty in
+  let sigma = project gl in
+  let type_of_h = pf_unsafe_type_of gl (mkVar hid) in
+  match EConstr.kind sigma type_of_h with
+  | App(eq,args) when EConstr.eq_constr sigma eq (make_eq ())  ->
+    let pre_tac,f_args,res =
+      match EConstr.kind sigma args.(1),EConstr.kind sigma args.(2) with
+      | App(f,f_args),_ when EConstr.eq_constr sigma f fconst ->
+        ((fun hid -> intros_symmetry (Locusops.onHyp hid))),f_args,args.(2)
+      |_,App(f,f_args) when EConstr.eq_constr sigma f fconst ->
+        ((fun hid -> tclIDTAC),f_args,args.(1))
+      | _ -> (fun hid -> tclFAIL 1 (mt ())),[||],args.(2)
+    in
+    tclTHENLIST
+      [ PN.(
+            generalize [applist(f_correct,(Array.to_list f_args)@[res;mkVar hid])] >>= fun () ->
+            pre_tac hid)
+      ; thin [hid]
+      ; Simple.intro hid
+      ; Inv.inv Inv.FullInversion None (NamedHyp hid)
+      ; PG.enter (fun gl ->
+            let new_ids = List.filter (fun id -> not (Id.Set.mem id old_ids)) (pf_ids_of_hyps gl) in
+            tclMAP (revert_graph kn pre_tac)  (hid::new_ids)
+          )
+      ]
+  | _ -> tclFAIL 1 (mt ())
+  )
 
 let error msg = user_err Pp.(str msg)
 
 let invfun qhyp f  =
   let f =
     match f with
-      | ConstRef f -> f
-      | _ -> raise (CErrors.UserError(None,str "Not a function"))
+    | ConstRef f -> f
+    | _ -> raise (CErrors.UserError(None,str "Not a function"))
   in
   try
     let finfos = find_Function_infos f in
     let f_correct = mkConst(Option.get finfos.correctness_lemma)
     and kn = fst finfos.graph_ind
     in
-    Proofview.V82.of_tactic (
-      Tactics.try_intros_until (fun hid -> Proofview.V82.tactic (functional_inversion kn hid (mkConst f)  f_correct)) qhyp
-    )
+    Tactics.try_intros_until (fun hid -> functional_inversion kn hid (mkConst f) f_correct) qhyp
   with
-    | Not_found ->  error "No graph found"
-    | Option.IsNone  -> error "Cannot use equivalence with graph!"
+  | Not_found ->  error "No graph found"
+  | Option.IsNone  -> error "Cannot use equivalence with graph!"
 
 exception NoFunction
-let invfun qhyp f g =
+
+let invfun qhyp f =
   match f with
-    | Some f -> invfun qhyp f g
-    | None ->
-       Proofview.V82.of_tactic begin
-        Tactics.try_intros_until
-          (fun hid -> Proofview.V82.tactic begin fun g ->
-            let sigma = project g in
-             let hyp_typ = pf_unsafe_type_of g (mkVar hid)  in
-             match EConstr.kind sigma hyp_typ with
-               | App(eq,args) when EConstr.eq_constr sigma eq (make_eq ()) ->
-                   begin
-                     let f1,_ = decompose_app sigma args.(1) in
-                     try
-                       if not (isConst sigma f1) then raise NoFunction;
-                       let finfos = find_Function_infos (fst (destConst sigma f1)) in
-                       let f_correct = mkConst(Option.get finfos.correctness_lemma)
-                       and kn = fst finfos.graph_ind
-                       in
-                       functional_inversion kn hid f1 f_correct g
-                     with | NoFunction | Option.IsNone | Not_found ->
-                       try
-                         let f2,_ = decompose_app sigma args.(2) in
-                         if not (isConst sigma f2) then raise NoFunction;
-                         let finfos = find_Function_infos (fst (destConst sigma f2)) in
-                         let f_correct = mkConst(Option.get finfos.correctness_lemma)
-                         and kn = fst finfos.graph_ind
-                         in
-                         functional_inversion kn hid  f2 f_correct g
-                       with
-                         | NoFunction ->
-                             user_err  (str "Hypothesis " ++ Ppconstr.pr_id hid ++ str " must contain at least one Function")
-                         | Option.IsNone  ->
-                             if do_observe ()
-                             then
-                               error "Cannot use equivalence with graph for any side of the equality"
-                             else user_err  (str "Cannot find inversion information for hypothesis " ++ Ppconstr.pr_id hid)
-                         | Not_found ->
-                             if do_observe ()
-                             then
-                               error "No graph found for any side of equality"
-                             else user_err  (str "Cannot find inversion information for hypothesis " ++ Ppconstr.pr_id hid)
-                   end
-               | _ -> user_err  (Ppconstr.pr_id hid ++ str " must be an equality ")
-          end)
-          qhyp
-          end
-          g
+  | Some f -> invfun qhyp f
+  | None ->
+    Tactics.try_intros_until
+      (fun hid -> PG.enter begin fun g ->
+           let sigma = project g in
+           let hyp_typ = pf_unsafe_type_of g (mkVar hid)  in
+           match EConstr.kind sigma hyp_typ with
+           | App(eq,args) when EConstr.eq_constr sigma eq (make_eq ()) ->
+             begin
+               let f1,_ = decompose_app sigma args.(1) in
+               try
+                 if not (isConst sigma f1) then raise NoFunction;
+                 let finfos = find_Function_infos (fst (destConst sigma f1)) in
+                 let f_correct = mkConst(Option.get finfos.correctness_lemma)
+                 and kn = fst finfos.graph_ind
+                 in
+                 functional_inversion kn hid f1 f_correct
+               with | NoFunction | Option.IsNone | Not_found ->
+               try
+                 let f2,_ = decompose_app sigma args.(2) in
+                 if not (isConst sigma f2) then raise NoFunction;
+                 let finfos = find_Function_infos (fst (destConst sigma f2)) in
+                 let f_correct = mkConst(Option.get finfos.correctness_lemma)
+                 and kn = fst finfos.graph_ind
+                 in
+                 functional_inversion kn hid  f2 f_correct
+               with
+               | NoFunction ->
+                 user_err  (str "Hypothesis " ++ Ppconstr.pr_id hid ++ str " must contain at least one Function")
+               | Option.IsNone  ->
+                 if do_observe ()
+                 then
+                   error "Cannot use equivalence with graph for any side of the equality"
+                 else user_err  (str "Cannot find inversion information for hypothesis " ++ Ppconstr.pr_id hid)
+               | Not_found ->
+                 if do_observe ()
+                 then
+                   error "No graph found for any side of equality"
+                 else user_err  (str "Cannot find inversion information for hypothesis " ++ Ppconstr.pr_id hid)
+             end
+           | _ -> user_err  (Ppconstr.pr_id hid ++ str " must be an equality ")
+         end)
+      qhyp

--- a/plugins/funind/recdef.mli
+++ b/plugins/funind/recdef.mli
@@ -1,10 +1,10 @@
 open Constr
 
-val tclUSER_if_not_mes :
-  Tacmach.tactic ->
-  bool ->
-  Names.Id.t list option ->
-  Tacmach.tactic
+val tclUSER_if_not_mes
+  :  unit Proofview.tactic
+  -> bool
+  -> Names.Id.t list option
+  -> unit Proofview.tactic
 
 val recursive_definition
   :  interactive_proof:bool

--- a/tactics/tacticals.ml
+++ b/tactics/tacticals.ml
@@ -166,7 +166,7 @@ let check_or_and_pattern_size ?loc check_and names branchsigns =
     user_err ?loc  (str "Expects " ++ msg p1 p2 ++ str ".") in
   let errn n =
     user_err ?loc  (str "Expects a disjunctive pattern with " ++ int n
-	++ str " branches.") in
+        ++ str " branches.") in
   let err1' p1 p2 =
     user_err ?loc  (strbrk "Expects a disjunctive pattern with 1 branch or " ++ msg p1 p2 ++ str ".") in
   let errforthcoming ?loc =
@@ -566,11 +566,11 @@ module New = struct
   let nthHypId m gl =
     (* We only use [id] *)
     nthDecl m gl |> NamedDecl.get_id
-  let nthHyp m gl = 
+  let nthHyp m gl =
     mkVar (nthHypId m gl)
 
   let onNthHypId m tac =
-    Proofview.Goal.enter begin fun gl -> tac (nthHypId m gl) end 
+    Proofview.Goal.enter begin fun gl -> tac (nthHypId m gl) end
   let onNthHyp m tac =
     Proofview.Goal.enter begin fun gl -> tac (nthHyp m gl) end
 
@@ -593,6 +593,17 @@ module New = struct
     end
 
   let onHyps find tac = Proofview.Goal.enter begin fun gl -> tac (find gl) end
+
+  let onNLastHypsId n tac =
+    let nLastDecls n gl =
+      let hyps =
+        try List.firstn n Proofview.Goal.(hyps gl)
+        with Failure _ -> user_err Pp.(str "Not enough hypotheses in the goal.")
+      in
+      List.map Context.Named.Declaration.get_id hyps
+      (* Proofview.Monad.List.iter tac hyps *)
+    in
+    onHyps (nLastDecls n) tac
 
   let afterHyp id tac =
     Proofview.Goal.enter begin fun gl ->
@@ -643,12 +654,12 @@ module New = struct
       match EConstr.kind elimclause.evd p with
       | Meta p -> p
       | _ ->
-	  let name_elim =
-	    match EConstr.kind sigma elim with
+          let name_elim =
+            match EConstr.kind sigma elim with
             | Const _ | Var _ -> str " " ++ Printer.pr_econstr_env (pf_env gl) sigma elim
             | _ -> mt ()
-	  in
-	  user_err ~hdr:"Tacticals.general_elim_then_using"
+          in
+          user_err ~hdr:"Tacticals.general_elim_then_using"
             (str "The elimination combinator " ++ name_elim ++ str " is unknown.")
     in
     let elimclause' = clenv_fchain ~with_univs:false indmv elimclause indclause in

--- a/tactics/tacticals.mli
+++ b/tactics/tacticals.mli
@@ -230,6 +230,7 @@ module New : sig
   val onLastHypId      : (Id.t -> unit tactic) -> unit tactic
   val onLastHyp        : (constr -> unit tactic) -> unit tactic
   val onLastDecl       : (named_declaration -> unit tactic) -> unit tactic
+  val onNLastHypsId    : int -> (Id.t list -> unit tactic) -> unit tactic
 
   val onHyps      : (Proofview.Goal.t -> named_context) ->
                     (named_context -> unit tactic) -> unit tactic


### PR DESCRIPTION
Right in time for the spring!

Main user of the legacy engine now is ssreflect.

The PR is almost ready [modulo who knows what bugs, this was written quite a while ago so the rebases may have introduced strange stuff], however there are a few nits to solve, and I would enjoy help:

- missing `tclTHEN_i`
- `Recdef.mkDestructEq` had a strange type
- `pf_nf_betaiota` is missing
- `pf_nth_hyp_id`

Question: does the proof engine provide similar facilities to the
pervasive `observe` used here?
