### PR TITLE
[dune] Don't have `lib` depend on `dynlink`

### DIFF
--- a/kernel/dune
+++ b/kernel/dune
@@ -4,7 +4,7 @@
  (public_name coq.kernel)
  (wrapped false)
  (modules (:standard \ genOpcodeFiles uint63_x86 uint63_amd64 write_uint63))
- (libraries lib byterun))
+ (libraries lib byterun dynlink))
 
 (executable
   (name genOpcodeFiles)

--- a/lib/dune
+++ b/lib/dune
@@ -4,4 +4,4 @@
  (public_name coq.lib)
  (wrapped false)
  (modules_without_implementation xml_datatype)
- (libraries dynlink coq.clib coq.config))
+ (libraries coq.clib coq.config))

--- a/lib/system.ml
+++ b/lib/system.ml
@@ -304,7 +304,7 @@ let with_time ~batch ~header f x =
     raise e
 
 (* We use argv.[0] as we don't want to resolve symlinks *)
-let get_toplevel_path ?(byte=not Dynlink.is_native) top =
+let get_toplevel_path ?(byte=Sys.(backend_type = Bytecode)) top =
   let open Filename in
   let dir = if String.equal (basename Sys.argv.(0)) Sys.argv.(0)
             then "" else dirname Sys.argv.(0) ^ dir_sep in


### PR DESCRIPTION
This is convenient for the bootstrap of `coqdep`
