### PR TITLE
Make Opaque/Transparent/Strategy import-time instead of require-time

### DIFF
--- a/plugins/setoid_ring/Field_tac.v
+++ b/plugins/setoid_ring/Field_tac.v
@@ -11,6 +11,8 @@
 Require Import Ring_tac BinList Ring_polynom InitialRing.
 Require Export Field_theory.
 
+Strategy expand [PEeval].
+
  (* syntaxification *)
  (* We do not assume that Cst recognizes the rO and rI terms as constants, as *)
  (* the tactic could be used to discriminate occurrences of an opaque *)

--- a/plugins/setoid_ring/Ncring_tac.v
+++ b/plugins/setoid_ring/Ncring_tac.v
@@ -20,6 +20,7 @@ Require Export Ncring.
 Require Import Ncring_polynom.
 Require Import Ncring_initial.
 
+Strategy expand [PEeval].
 
 Set Implicit Arguments.
 

--- a/plugins/setoid_ring/Ring_tac.v
+++ b/plugins/setoid_ring/Ring_tac.v
@@ -17,6 +17,7 @@ Require Export ListTactics.
 Require Import InitialRing.
 Declare ML Module "newring_plugin".
 
+Strategy expand [PEeval].
 
 (* adds a definition t' on the normal form of t and an hypothesis id
    stating that t = t' (tries to produces a proof as small as possible) *)

--- a/tactics/redexpr.ml
+++ b/tactics/redexpr.ml
@@ -126,7 +126,7 @@ type strategy_obj =
 let inStrategy : strategy_obj -> obj =
   declare_object {(default_object "STRATEGY") with
                     cache_function = (fun (_,obj) -> cache_strategy obj);
-                    load_function = (fun _ (_,obj) -> cache_strategy obj);
+                    open_function = (fun i (_,obj) -> if i = 1 then cache_strategy obj);
                     subst_function = subst_strategy;
                     discharge_function = discharge_strategy;
                     classify_function = classify_strategy }


### PR DESCRIPTION
Problem: the test of `ring` in Ring31 loops (or takes a long time)
unless we import Ring_polynom (probably because of the `Strategy
expand [PEeval].` there).

Let's see what CI breaks.

This enables doing something like
~~~coq
Module Transparentify.
Global Transparent foo.
Global Transparent bar.
(* a bunch of others *)
End Transparentify.

Module Opacify
Global Opaque foo.
Global Opaque bar.
(* etc *)
End Opacify

Import Transparentify.
(* work transparently *)
Import Opacify.
(* work opaquly *)
Import Transparentify.
(* back to transparent *)

(* end of file: modules who require us aren't affected *)
~~~