### PR TITLE
[CI] Force caching when running test-suite in async mode

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -516,7 +516,7 @@ test-suite:base+async:
   dependencies:
     - build:base
   variables:
-    COQFLAGS: "-async-proofs on"
+    COQFLAGS: "-async-proofs on -async-proofs-cache force"
   allow_failure: true
   only:
     variables:


### PR DESCRIPTION
I thought the test-suite infrastructure was always passing
`-async-proofs-cache force`, but in fact it does it only for interactive
tests.

This should speed up the tests quite a bit.