### PR TITLE
CI: add mit-pdos/argosy

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -553,6 +553,9 @@ validate:quick:
 # Libraries are by convention the projects that depend on Coq
 # but not on its ML API
 
+library:ci-argosy:
+  extends: .ci-template
+
 library:ci-bedrock2:
   extends: .ci-template
 

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -10,6 +10,7 @@
 
 CI_TARGETS= \
     ci-aac_tactics \
+    ci-argosy \
     ci-bedrock2 \
     ci-bignums \
     ci-color \

--- a/dev/ci/ci-argosy.sh
+++ b/dev/ci/ci-argosy.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+ci_dir="$(dirname "$0")"
+. "${ci_dir}/ci-common.sh"
+
+FORCE_GIT=1
+git_download argosy
+
+( cd "${CI_BUILD_DIR}/argosy" && git submodule update --init --recursive && make )

--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -296,3 +296,10 @@
 : "${stdlib2_CI_REF:=master}"
 : "${stdlib2_CI_GITURL:=https://github.com/coq/stdlib2}"
 : "${stdlib2_CI_ARCHIVEURL:=${stdlib2_CI_GITURL}/archive}"
+
+########################################################################
+# argosy
+########################################################################
+: "${argosy_CI_REF:=master}"
+: "${argosy_CI_GITURL:=https://github.com/mit-pdos/argosy}"
+: "${argosy_CI_ARCHIVEURL:=${argosy_CI_GITURL}/archive}"


### PR DESCRIPTION
Add Argosy, a system for verifying layered storage systems.

Argosy includes an example that extracts to Haskell. The default `make` target runs extraction, but to build the executable the CI machine needs Haskell stack installed. It would also benefit from caching the ~/.stack directory; otherwise all the Haskell dependencies will be re-compiled every build.

<!-- Keep what applies -->
**Kind:**  infrastructure.