### PR TITLE
Protect some I/O routines from SIGALRM

### DIFF
--- a/clib/cThread.ml
+++ b/clib/cThread.ml
@@ -100,10 +100,10 @@ let thread_friendly_input_value ic =
 (* On the ocaml runtime used in some opam-for-windows version the
  * [Thread.sigmask] API raises Invalid_argument "not implemented",
  * hence we protect the call and turn the exception into a no-op *)
-let protect_sigalrm f x =
+let mask_sigalrm f x =
   begin try ignore(Thread.sigmask Unix.SIG_BLOCK [Sys.sigalrm])
   with Invalid_argument _ -> () end;
   f x
 
 let create f x =
-  Thread.create (protect_sigalrm f) x
+  Thread.create (mask_sigalrm f) x

--- a/ide/idetop.ml
+++ b/ide/idetop.ml
@@ -466,7 +466,7 @@ let print_xml =
   let m = Mutex.create () in
   fun oc xml ->
     Mutex.lock m;
-    try Xml_printer.print oc xml; Mutex.unlock m
+    try Control.protect_sigalrm (Xml_printer.print oc) xml; Mutex.unlock m
     with e -> let e = CErrors.push e in Mutex.unlock m; iraise e
 
 let slave_feeder fmt xml_oc msg =

--- a/lib/control.mli
+++ b/lib/control.mli
@@ -29,3 +29,14 @@ val timeout : int -> ('a -> 'b) -> 'a -> exn -> 'b
    API and it is scheduled to go away. *)
 type timeout = { timeout : 'a 'b. int -> ('a -> 'b) -> 'a -> exn -> 'b }
 val set_timeout : timeout -> unit
+
+(** [protect_sigalrm f x] computes [f x], but if SIGALRM is received during that
+    computation, the signal handler is executed only once the computation is
+    terminated. Otherwise said, it makes the execution of [f] atomic w.r.t.
+    handling of SIGALRM.
+
+    This is useful for example to prevent the implementation of `Timeout` to
+    interrupt I/O routines, generating ill-formed output.
+
+*)
+val protect_sigalrm : ('a -> 'b) -> 'a -> 'b

--- a/stm/asyncTaskQueue.ml
+++ b/stm/asyncTaskQueue.ml
@@ -329,10 +329,12 @@ module Make(T : Task) () = struct
   let main_loop () =
     (* We pass feedback to master *)
     let slave_feeder oc fb =
-      Marshal.to_channel oc (RespFeedback (debug_with_pid fb)) []; flush oc in
+      Control.protect_sigalrm (fun () ->
+          Marshal.to_channel oc (RespFeedback (debug_with_pid fb)) []; flush oc) ()
+    in
     ignore (Feedback.add_feeder (fun x -> slave_feeder (Option.get !slave_oc) x));
     (* We ask master to allocate universe identifiers *)
-    UnivGen.set_remote_new_univ_id (bufferize (fun () ->
+    UnivGen.set_remote_new_univ_id (bufferize @@ Control.protect_sigalrm (fun () ->
       marshal_response (Option.get !slave_oc) RespGetCounterNewUnivLevel;
       match unmarshal_more_data (Option.get !slave_ic) with
       | MoreDataUnivLevel l -> l));


### PR DESCRIPTION
This is necessary to prevent Coq from sending ill-formed output in some
scenarios involving `Timeout`.

Co-authored-by: Enrico Tassi <Enrico.Tassi@inria.fr>