### PR TITLE
[native compiler] Allow to set the output directory for cmx objects

### DIFF
--- a/kernel/nativelib.mli
+++ b/kernel/nativelib.mli
@@ -13,7 +13,7 @@ open Nativecode
 used by the native compiler. *)
 
 (* Directory where compiled files are stored *)
-val output_dir : string
+val output_dir : CUnix.physical_path option ref
 
 val get_load_paths : (unit -> string list) ref
 

--- a/toplevel/coqargs.mli
+++ b/toplevel/coqargs.mli
@@ -42,6 +42,8 @@ type t = {
 
   set_options : (Goptions.option_name * option_command) list;
 
+  native_output_dir : CUnix.physical_path option;
+
   stm_flags   : Stm.AsyncOpts.stm_opt;
   debug       : bool;
   diffs_set   : bool;

--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -232,6 +232,9 @@ let init_toplevel ~help ~init custom_init arglist =
 
   set_options opts.set_options;
 
+  (* Native output dir *)
+  Nativelib.output_dir := opts.native_output_dir;
+
   (* Allow the user to load an arbitrary state here *)
   inputstate opts;
 

--- a/toplevel/usage.ml
+++ b/toplevel/usage.ml
@@ -85,6 +85,7 @@ let print_usage_common co command =
 \n                          for full Gc stats dump)\
 \n  -bytecode-compiler (yes|no)        enable the vm_compute reduction machine\
 \n  -native-compiler (yes|no|ondemand) enable the native_compute reduction machine\
+\n  -native-output-dir     (none|<directory>) set the output directory for native objects\
 \n  -h, -help, --help      print this list of options\
 \n";
   List.iter (fun (name, text) ->


### PR DESCRIPTION
This is useful in order to implement native support in Dune for
example, which as of today as strict target rules.

Hopefully this option could go away; it is really internal, but I've
chosen to document it.
