### PR TITLE
Fix pretty-printing of primitive integers

### DIFF
--- a/test-suite/output/Int63Syntax.out
+++ b/test-suite/output/Int63Syntax.out
@@ -1,3 +1,7 @@
+2%int63
+     : int
+(2 + 2)%int63
+     : int
 2
      : int
 9223372036854775807
@@ -14,3 +18,15 @@ The command has indeed failed with message:
 int63 are only non-negative numbers.
 The command has indeed failed with message:
 overflow in int63 literal: 9223372036854775808
+2
+     : nat
+2%int63
+     : int
+t = 2%i63
+     : int
+t = 2%i63
+     : int
+2
+     : nat
+2
+     : int

--- a/test-suite/output/Int63Syntax.v
+++ b/test-suite/output/Int63Syntax.v
@@ -1,5 +1,7 @@
 Require Import Int63 Cyclic63.
 
+Check 2%int63.
+Check (2 + 2)%int63.
 Open Scope int63_scope.
 Check 2.
 Check 9223372036854775807.
@@ -9,4 +11,15 @@ Eval vm_compute in 2+2.
 Eval vm_compute in 65675757 * 565675998.
 Fail Check -1.
 Fail Check 9223372036854775808.
+Open Scope nat_scope.
+Check 2. (* : nat *)
+Check 2%int63.
+Delimit Scope int63_scope with i63.
+Definition t := 2%int63.
+Print t.
+Delimit Scope nat_scope with int63.
+Print t.
+Check 2.
+Close Scope nat_scope.
+Check 2.
 Close Scope int63_scope.


### PR DESCRIPTION
**Kind:** bug fix

Fixes #9888

* A scope delimiter was missing for primitive integers constants.
* Add related regression tests.
* Make the fix "optimal" with respect to the scope environment, see example below.

```coq
Require Import Int63.
Check 2%int63.
2%int63
     : int
Check (2 + 2)%int63.
(2 + 2)%int63
     : int
```

- [x] Added / updated test-suite