### PR TITLE
Ignore the hidden boolean when comparing projections and fix micromega/lia/psatz wrt projections

### DIFF
--- a/doc/changelog/01-kernel/09897-constr_eq-primproj.rst
+++ b/doc/changelog/01-kernel/09897-constr_eq-primproj.rst
@@ -1,0 +1,3 @@
+- Term (constr) comparison ignores whether primitive projections are unfolded
+  or not (`#9897 <https://github.com/coq/coq/pull/9897>`_,
+  by Vincent Laporte).

--- a/doc/changelog/04-tactics/09897-fix-micromega-wrt-projections.rst
+++ b/doc/changelog/04-tactics/09897-fix-micromega-wrt-projections.rst
@@ -1,0 +1,3 @@
+- Micromega tactics (:tacn:`lia`, :tacn:`nia`, etc) are no longer confused by
+  primitive projections (`#9897 <https://github.com/coq/coq/pull/9897>`_,
+  by Vincent Laporte).

--- a/kernel/constr.ml
+++ b/kernel/constr.ml
@@ -861,7 +861,7 @@ let compare_head_gen_leq_with kind1 kind2 leq_universes leq_sorts eq leq nargs t
     let len = Array.length l1 in
     Int.equal len (Array.length l2) &&
     leq (nargs+len) c1 c2 && Array.equal_norefl (eq 0) l1 l2
-  | Proj (p1,c1), Proj (p2,c2) -> Projection.equal p1 p2 && eq 0 c1 c2
+  | Proj (p1,c1), Proj (p2,c2) -> Projection.repr_equal p1 p2 && eq 0 c1 c2
   | Evar (e1,l1), Evar (e2,l2) -> Evar.equal e1 e2 && Array.equal (eq 0) l1 l2
   | Const (c1,u1), Const (c2,u2) ->
     (* The args length currently isn't used but may as well pass it. *)

--- a/plugins/micromega/coq_micromega.ml
+++ b/plugins/micromega/coq_micromega.ml
@@ -745,7 +745,7 @@ struct
     (** [eq_constr gl x y] returns an updated [gl] if x and y can be unified *)
     let eq_constr gl x y =
       let evd = gl.sigma in
-      match EConstr.eq_constr_universes gl.env evd x y with
+      match EConstr.eq_constr_universes_proj gl.env evd x y with
       | Some csts ->
          let csts = UnivProblem.to_constraints ~force_weak:false (Evd.universes evd) csts in
          begin
@@ -769,15 +769,16 @@ struct
     ({vars=vars';gl=gl'}, CamlToCoq.positive n)
 
    let get_rank env v =
-     let evd = env.gl.sigma in
+     let gl = env.gl in
 
      let rec _get_rank env n =
        match env with
        | [] -> raise (Invalid_argument "get_rank")
       | e::l ->
-         if EConstr.eq_constr evd e v
-         then n
-         else  _get_rank l (n+1)  in
+        match eq_constr gl e v with
+        | Some _ -> n
+        | None -> _get_rank l (n+1)
+     in
      _get_rank env.vars 1
 
    let elements env = env.vars

--- a/test-suite/bugs/closed/bug_3656.v
+++ b/test-suite/bugs/closed/bug_3656.v
@@ -48,7 +48,3 @@ Goal setT = setT.
     | _ => idtac
   end. (* should not fail *)
 Abort.
-
-Goal forall h, setT h = setT h.
-Proof. intro. progress unfold setT.
-Abort.

--- a/test-suite/bugs/closed/bug_9512.v
+++ b/test-suite/bugs/closed/bug_9512.v
@@ -1,0 +1,35 @@
+Require Import Coq.ZArith.BinInt Coq.omega.Omega Coq.micromega.Lia.
+
+Set Primitive Projections.
+Record params := { width : Z }.
+Definition p : params := Build_params 64.
+
+Set Printing All.
+
+Goal width p = 0%Z -> width p = 0%Z.
+  intros.
+
+  assert_succeeds (enough True; [omega|]).
+  assert_succeeds (enough True; [lia|]).
+
+(*   H : @eq Z (width p) Z0 *)
+(*   ============================ *)
+(*   @eq Z (width p) Z0 *)
+
+  change tt with tt in H.
+
+(*   H : @eq Z (width p) Z0 *)
+(*   ============================ *)
+(*   @eq Z (width p) Z0 *)
+
+  assert_succeeds (enough True; [lia|]).
+  (* Tactic failure: <tactic closure> fails. *)
+  (* assert_succeeds (enough True; [omega|]). *)
+  (* Tactic failure: <tactic closure> fails. *)
+
+  (* omega. *)
+  (* Error: Omega can't solve this system *)
+
+  lia.
+  (* Tactic failure:  Cannot find witness. *)
+Qed.

--- a/test-suite/bugs/closed/bug_9892.v
+++ b/test-suite/bugs/closed/bug_9892.v
@@ -1,0 +1,13 @@
+Require Import Lia.
+Require Import Omega.
+Set Primitive Projections.
+
+Record foo (a: unit) := { field: nat }.
+
+Notation goal := (forall x, field tt x = 1 -> field tt x = 1).
+
+Lemma test_omega : goal.
+Proof. intros. cbv [field]. omega. Qed.
+
+Lemma test_lia : goal.
+Proof. intros. cbv [field]. lia. Qed.


### PR DESCRIPTION
Fixes #9892.

This breaks one test case, that was introduced there: https://github.com/coq/coq/commit/b6e39ade125862ba41ca17b06b8e35726b9b0d7d

However, since this is the only thing that seems to break, I’ve amended the test ;-) Ping @mattam82 