### PR TITLE
[v8.9] Encapsulating declarations of primitive string syntax in a module 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -105,8 +105,9 @@ Standard Library
 
 - Syntax notations for `string`, `ascii`, `Z`, `positive`, `N`, `R`,
   and `int31` are no longer available merely by `Require`ing the files
-  that define the inductives.  You must `Import` `Coq.Strings.String`,
-  `Coq.Strings.Ascii`, `Coq.ZArith.BinIntDef`, `Coq.PArith.BinPosDef`,
+  that define the inductives.  You must `Import` `Coq.Strings.String.StringSyntax`
+  (after `Require` `Coq.Strings.String`), `Coq.Strings.Ascii.AsciiSyntax` (after
+  `Require` `Coq.Strings.Ascii`), `Coq.ZArith.BinIntDef`, `Coq.PArith.BinPosDef`,
   `Coq.NArith.BinNatDef`, `Coq.Reals.Rdefinitions`, and
   `Coq.Numbers.Cyclic.Int31.Int31`, respectively, to be able to use
   these notations.  Note that passing `-compat 8.8` or issuing

--- a/theories/Compat/Coq88.v
+++ b/theories/Compat/Coq88.v
@@ -15,11 +15,10 @@ Require Export Coq.Compat.Coq89.
     [Require].  So we make all of the relevant notations accessible in
     compatibility mode. *)
 Require Coq.Strings.Ascii Coq.Strings.String.
+Export String.StringSyntax Ascii.AsciiSyntax.
 Require Coq.ZArith.BinIntDef Coq.PArith.BinPosDef Coq.NArith.BinNatDef.
 Require Coq.Reals.Rdefinitions.
 Require Coq.Numbers.Cyclic.Int31.Int31.
-Declare ML Module "string_syntax_plugin".
-Declare ML Module "ascii_syntax_plugin".
 Declare ML Module "r_syntax_plugin".
 Declare ML Module "int31_syntax_plugin".
 Numeral Notation BinNums.Z BinIntDef.Z.of_int BinIntDef.Z.to_int : Z_scope.

--- a/theories/Strings/Ascii.v
+++ b/theories/Strings/Ascii.v
@@ -13,7 +13,7 @@
     Adapted to Coq V8 by the Coq Development Team *)
 
 Require Import Bool BinPos BinNat PeanoNat Nnat.
-Declare ML Module "ascii_syntax_plugin".
+Module Export AsciiSyntax. Declare ML Module "ascii_syntax_plugin". End AsciiSyntax.
 
 (** * Definition of ascii characters *)
 

--- a/theories/Strings/String.v
+++ b/theories/Strings/String.v
@@ -15,7 +15,7 @@
 Require Import Arith.
 Require Import Ascii.
 Require Import Bool.
-Declare ML Module "string_syntax_plugin".
+Module Export StringSyntax. Declare ML Module "string_syntax_plugin". End StringSyntax.
 
 (** *** Definition of strings *)
 


### PR DESCRIPTION
A version of #8795 for v8.9

c.f. https://github.com/coq/coq/pull/8795#issuecomment-479549960