### PR TITLE
coq_makefile install target: error if any file is missing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -227,6 +227,8 @@ Tools
   `coqc`/`make` as well as printing to stdout, on both python2 and
   python3.
 
+- coq_makefile's install target now errors if any file to install is missing.
+
 Standard Library
 
 - Added lemmas about monotonicity of `N.double` and `N.succ_double`, and about

--- a/test-suite/coq-makefile/missing-install/run.sh
+++ b/test-suite/coq-makefile/missing-install/run.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+. ../template/init.sh
+
+rm -rf _test; mkdir _test; cd _test
+
+cat > _CoqProject <<EOF
+-R theories Test
+theories/a.v
+theories/b.v
+EOF
+mkdir theories
+touch theories/a.v theories/b.v
+
+coq_makefile -f _CoqProject -o Makefile
+make theories/b.vo
+if make install; then exit 1; fi

--- a/tools/CoqMakefile.in
+++ b/tools/CoqMakefile.in
@@ -468,6 +468,9 @@ beautify: $(BEAUTYFILES)
 # Extensions can't assume when they run.
 
 install:
+	$(HIDE)code=0; for f in $(FILESTOINSTALL); do\
+	 if ! [ -f "$$f" ]; then >&2 echo $$f does not exist; code=1; fi \
+	done; exit $$code
 	$(HIDE)for f in $(FILESTOINSTALL); do\
 	 df="`$(COQMKFILE) -destination-of "$$f" $(COQLIBS)`";\
 	 if [ "$$?" != "0" -o -z "$$df" ]; then\


### PR DESCRIPTION
This makes failure reliable instead of failing when the last file to install based on the _CoqProject order is missing and succeeding otherwise even if other files are missing.