### PR TITLE
Remove cache in Heads

### DIFF
--- a/interp/declare.ml
+++ b/interp/declare.ml
@@ -119,7 +119,6 @@ let set_declare_scheme f = declare_scheme := f
 
 let update_tables c =
   declare_constant_implicits c;
-  Heads.declare_head (EvalConstRef c);
   Notation.declare_ref_arguments_scope Evd.empty (ConstRef c)
 
 let register_side_effect (c, role) =
@@ -257,7 +256,6 @@ let declare_variable id obj =
   let oname = add_leaf id (inVariable (Inr (id,obj))) in
   declare_var_implicits id;
   Notation.declare_ref_arguments_scope Evd.empty (VarRef id);
-  Heads.declare_head (EvalVarRef id);
   oname
 
 (** Declaration of inductive blocks *)

--- a/pretyping/heads.mli
+++ b/pretyping/heads.mli
@@ -8,7 +8,6 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-open Names
 open Constr
 open Environ
 
@@ -16,11 +15,6 @@ open Environ
     head symbol of defined constants and local definitions; it
     provides the function to compute the head symbols and a table to
     store the heads *)
-
-(** [declared_head] computes and registers the head symbol of a
-   possibly evaluable constant or variable *)
-
-val declare_head : evaluable_global_reference -> unit
 
 (** [is_rigid] tells if some term is known to ultimately reduce to a term
     with a rigid head symbol *)


### PR DESCRIPTION
This cache makes the pretyper depend on components that should morally
be higher-level (Libobject and co), so I'd like to see how critical this
cache is before taking any action.