### PR TITLE
[ci/deploy] Fix branch creation when pushing to coq/coq-on-cachix.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -365,7 +365,7 @@ pkg:nix:deploy:channel:
     - echo "$CACHIX_DEPLOYMENT_KEY" | tr -d '\r' | ssh-add - > /dev/null
     - git fetch --unshallow
     - git branch -v
-    - git push git@github.com:coq/coq-on-cachix "${CI_COMMIT_SHA}":"${CI_COMMIT_REF_NAME}"
+    - git push git@github.com:coq/coq-on-cachix "${CI_COMMIT_SHA}":"refs/heads/${CI_COMMIT_REF_NAME}"
 
 pkg:nix:
   extends: .nix-template


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** infrastructure.

If the branch to which we are trying to push does not exist, the current command fails:

```
$ git push git@github.com:coq/coq-on-cachix 2e1aa5c15ad524cffd03c7979992af44ab2bb715:v8.10
error: unable to push to unqualified destination: v8.10
The destination refspec neither matches an existing ref on the remote nor
begins with refs/, and we are unable to guess a prefix based on the source ref.
```

Tested with the new command:

```
$ git push git@github.com:coq/coq-on-cachix 2e1aa5c15ad524cffd03c7979992af44ab2bb715:refs/heads/v8.10
Total 0 (delta 0), reused 0 (delta 0)
To github.com:coq/coq-on-cachix
 * [new branch]            2e1aa5c15ad524cffd03c7979992af44ab2bb715 -> v8.10
```

As the test fixed the missing branch problem for v8.10, there is no need to backport. This fix will be useful when the next stable branch (v8.11) is created.