### PR TITLE
Fix numeral notations test in async mode.

### DIFF
--- a/test-suite/output/NumeralNotations.out
+++ b/test-suite/output/NumeralNotations.out
@@ -82,10 +82,6 @@ function (of_uint) targets an option type.
 The command has indeed failed with message:
 The 'abstract after' directive has no effect when the parsing function
 (of_uint) targets an option type. [abstract-large-number-no-op,numbers]
-The command has indeed failed with message:
-The reference of_uint was not found in the current environment.
-The command has indeed failed with message:
-The reference of_uint was not found in the current environment.
 let v := of_uint (Decimal.D1 Decimal.Nil) in v : unit
      : unit
 let v := 0%test13 in v : unit

--- a/test-suite/output/NumeralNotations.v
+++ b/test-suite/output/NumeralNotations.v
@@ -207,21 +207,6 @@ Module Test10.
   Numeral Notation unit of_any_uint to_uint : unit2_scope (abstract after 1).
 End Test10.
 
-Module Test11.
-  (* Test that numeral notations don't work on proof-local variables, especially not ones containing evars *)
-  Inductive unit11 := tt11.
-  Declare Scope unit11_scope.
-  Delimit Scope unit11_scope with unit11.
-  Goal True.
-    evar (to_uint : unit11 -> Decimal.uint).
-    evar (of_uint : Decimal.uint -> unit11).
-    Fail Numeral Notation unit11 of_uint to_uint : uint11_scope.
-    exact I.
-    Unshelve.
-    all: solve [ constructor ].
-  Qed.
-End Test11.
-
 Module Test12.
   (* Test for numeral notations on context variables *)
   Declare Scope test12_scope.

--- a/test-suite/success/NumeralNotationsNoLocal.v
+++ b/test-suite/success/NumeralNotationsNoLocal.v
@@ -1,0 +1,12 @@
+(* Test that numeral notations don't work on proof-local variables, especially not ones containing evars *)
+Inductive unit11 := tt11.
+Declare Scope unit11_scope.
+Delimit Scope unit11_scope with unit11.
+Goal True.
+  evar (to_uint : unit11 -> Decimal.uint).
+  evar (of_uint : Decimal.uint -> unit11).
+  Fail Numeral Notation unit11 of_uint to_uint : uint11_scope.
+  exact I.
+  Unshelve.
+  all: solve [ constructor ].
+Qed.


### PR DESCRIPTION
Async causes output reordering in one test. Since we don't care about
the output of that test (it's just a [Fail]) we move it to success/.
