### PR TITLE
[api] [proof] Alert users that `Vernacstate.Proof_global` is not to be used.

### DIFF
--- a/dev/top_printers.ml
+++ b/dev/top_printers.ml
@@ -65,6 +65,7 @@ let get_current_context () =
   with Vernacstate.Proof_global.NoCurrentProof ->
     let env = Global.env() in
     Evd.from_env env, env
+  [@@ocaml.warning "-3"]
 
 (* term printers *)
 let envpp pp = let sigma,env = get_current_context () in pp env sigma

--- a/ide/idetop.ml
+++ b/ide/idetop.ml
@@ -238,7 +238,8 @@ let goals () =
       Some (export_pre_goals Proof.(data newp) (process_goal_diffs diff_goal_map oldp))
     end else
       Some (export_pre_goals Proof.(data newp) process_goal)
-  with Vernacstate.Proof_global.NoCurrentProof -> None;;
+  with Vernacstate.Proof_global.NoCurrentProof -> None
+  [@@ocaml.warning "-3"];;
 
 let evars () =
   try
@@ -251,6 +252,7 @@ let evars () =
     let el = List.map map_evar exl in
     Some el
   with Vernacstate.Proof_global.NoCurrentProof -> None
+  [@@ocaml.warning "-3"]
 
 let hints () =
   try
@@ -264,7 +266,7 @@ let hints () =
       let hint_hyps = List.rev (Environ.fold_named_context get_hint_hyp env ~init: []) in
       Some (hint_hyps, concl_next_tac)
   with Vernacstate.Proof_global.NoCurrentProof -> None
-
+  [@@ocaml.warning "-3"]
 
 (** Other API calls *)
 
@@ -297,6 +299,7 @@ let status force =
     Interface.status_allproofs = allproofs;
     Interface.status_proofnum = Stm.current_proof_depth ~doc:(get_doc ());
   }
+  [@@ocaml.warning "-3"]
 
 let export_coq_object t = {
   Interface.coq_object_prefix = t.Search.coq_object_prefix;
@@ -340,6 +343,7 @@ let search flags =
   List.map export_coq_object (Search.interface_search ?pstate (
     List.map (fun (c, b) -> (import_search_constraint c, b)) flags)
   )
+  [@@ocaml.warning "-3"]
 
 let export_option_value = function
   | Goptions.BoolValue b   -> Interface.BoolValue b

--- a/toplevel/ccompile.ml
+++ b/toplevel/ccompile.ml
@@ -85,7 +85,7 @@ let ensure_exists f =
 let compile opts copts ~echo ~f_in ~f_out =
   let open Vernac.State in
   let check_pending_proofs () =
-    let pfs = Vernacstate.Proof_global.get_all_proof_names () in
+    let pfs = Vernacstate.Proof_global.get_all_proof_names () [@ocaml.warning "-3"] in
     if not (CList.is_empty pfs) then
       fatal_error (str "There are pending proofs: "
                     ++ (pfs

--- a/toplevel/coqloop.ml
+++ b/toplevel/coqloop.ml
@@ -194,6 +194,7 @@ let make_prompt () =
     (Names.Id.to_string (Vernacstate.Proof_global.get_current_proof_name ())) ^ " < "
   with Vernacstate.Proof_global.NoCurrentProof ->
     "Coq < "
+  [@@ocaml.warning "-3"]
 
 (* the coq prompt added to the default one when in emacs mode
    The prompt contains the current state label [n] (for global
@@ -365,6 +366,7 @@ let top_goal_print ~doc c oldp newp =
     let loc = Loc.get_loc info in
     let msg = CErrors.iprint (e, info) in
     TopErr.print_error_for_buffer ?loc Feedback.Error msg top_buffer
+  [@@ocaml.warning "-3"]
 
 let exit_on_error =
   let open Goptions in

--- a/toplevel/vernac.ml
+++ b/toplevel/vernac.ml
@@ -70,7 +70,7 @@ let interp_vernac ~check ~interactive ~state ({CAst.loc;_} as com) =
 
       (* Force the command  *)
       let ndoc = if check then Stm.observe ~doc nsid else doc in
-      let new_proof = Vernacstate.Proof_global.give_me_the_proof_opt () in
+      let new_proof = Vernacstate.Proof_global.give_me_the_proof_opt () [@ocaml.warning "-3"] in
       { state with doc = ndoc; sid = nsid; proof = new_proof; }
     with reraise ->
       (* XXX: In non-interactive mode edit_at seems to do very weird

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -2632,7 +2632,7 @@ let interp ?(verbosely=true) ?proof ~st cmd =
   try vernac_timeout (fun st ->
       let v_mod = if verbosely then Flags.verbosely else Flags.silently in
       let pstate = v_mod (interp_control ?proof ~st) cmd in
-      Vernacstate.Proof_global.set pstate;
+      Vernacstate.Proof_global.set pstate [@ocaml.warning "-3"];
       Vernacstate.freeze_interp_state ~marshallable:false
     ) st
   with exn ->

--- a/vernac/vernacstate.mli
+++ b/vernac/vernacstate.mli
@@ -82,3 +82,4 @@ module Proof_global : sig
   val copy_terminators : src:t option -> tgt:t option -> t option
 
 end
+[@@ocaml.deprecated "This module is internal and should not be used, instead, thread the proof state"]


### PR DESCRIPTION
We alert users that `Vernacstate.Proof_global` is a Coq internal
module and should not be used to workaround lack of state threading.
