### PR TITLE
[coqdep] Exit with error code on exception.

### DIFF
--- a/tools/coqdep.ml
+++ b/tools/coqdep.ml
@@ -563,4 +563,5 @@ let _ =
   try
     coqdep ()
   with CoqlibError msg ->
-    eprintf "*** Error: %s@\n%!" msg
+    eprintf "*** Error: %s@\n%!" msg;
+    exit 1


### PR DESCRIPTION
This turns out to confuse many tools otherwise.
