### PR TITLE
Improve SProp error message to mention the Allow StrictProp flag.

### DIFF
--- a/doc/sphinx/addendum/sprop.rst
+++ b/doc/sphinx/addendum/sprop.rst
@@ -19,6 +19,9 @@ known as strict propositions). To use :math:`\SProp` you must pass
    initial value depends on whether you used the command line
    ``-allow-sprop``.
 
+.. exn:: SProp not allowed, you need to Set Allow StrictProp or to use the -allow-sprop command-line-flag.
+   :undocumented:
+
 .. coqtop:: none
 
    Set Allow StrictProp.

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -731,7 +731,9 @@ let explain_undeclared_universe env sigma l =
     spc () ++ str "(maybe a bugged tactic)."
 
 let explain_disallowed_sprop () =
-  Pp.(str "SProp not allowed, you need to use -allow-sprop.")
+  Pp.(strbrk "SProp not allowed, you need to "
+      ++ str "Set Allow StrictProp"
+      ++ strbrk " or to use the -allow-sprop command-line-flag.")
 
 let explain_bad_relevance env =
   strbrk "Bad relevance (maybe a bugged tactic)."


### PR DESCRIPTION
And document the error message.

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** user message.
