### PR TITLE
[options] Remove string option type.

### DIFF
--- a/ide/idetop.ml
+++ b/ide/idetop.ml
@@ -345,13 +345,11 @@ let export_option_value = function
   | Goptions.BoolValue b   -> Interface.BoolValue b
   | Goptions.IntValue x    -> Interface.IntValue x
   | Goptions.StringValue s -> Interface.StringValue s
-  | Goptions.StringOptValue s -> Interface.StringOptValue s
 
 let import_option_value = function
   | Interface.BoolValue b   -> Goptions.BoolValue b
   | Interface.IntValue x    -> Goptions.IntValue x
   | Interface.StringValue s -> Goptions.StringValue s
-  | Interface.StringOptValue s -> Goptions.StringOptValue s
 
 let export_option_state s = {
   Interface.opt_sync  = true;
@@ -370,8 +368,6 @@ let set_options options =
   | BoolValue b -> Goptions.set_bool_option_value name b
   | IntValue i -> Goptions.set_int_option_value name i
   | StringValue s -> Goptions.set_string_option_value name s
-  | StringOptValue (Some s) -> Goptions.set_string_option_value name s
-  | StringOptValue None -> Goptions.unset_option_value_gen name
   in
   List.iter iter options
 

--- a/ide/protocol/interface.ml
+++ b/ide/protocol/interface.ml
@@ -63,7 +63,6 @@ type option_value =
   | BoolValue   of bool
   | IntValue    of int option
   | StringValue of string
-  | StringOptValue of string option
 
 (** Summary of an option status *)
 type option_state = {

--- a/ide/protocol/xmlprotocol.ml
+++ b/ide/protocol/xmlprotocol.ml
@@ -67,12 +67,11 @@ let of_option_value = function
   | IntValue i -> constructor "option_value" "intvalue" [of_option of_int i]
   | BoolValue b -> constructor "option_value" "boolvalue" [of_bool b]
   | StringValue s -> constructor "option_value" "stringvalue" [of_string s]
-  | StringOptValue s -> constructor "option_value" "stringoptvalue" [of_option of_string s]
+
 let to_option_value = do_match "option_value" (fun s args -> match s with
   | "intvalue" -> IntValue (to_option to_int (singleton args))
   | "boolvalue" -> BoolValue (to_bool (singleton args))
   | "stringvalue" -> StringValue (to_string (singleton args))
-  | "stringoptvalue" -> StringOptValue (to_option to_string (singleton args))
   | x -> raise (Marshal_error("*value",PCData x)))
 
 let of_option_state s =
@@ -425,8 +424,6 @@ end = struct
     | IntValue None -> "none"
     | IntValue (Some i) -> string_of_int i
     | StringValue s -> s
-    | StringOptValue None -> "none"
-    | StringOptValue (Some s) -> s
     | BoolValue b -> if b then "true" else "false"
   let pr_option_state (s : option_state) =
     Printf.sprintf "sync := %b; depr := %b; name := %s; value := %s\n"

--- a/library/goptions.ml
+++ b/library/goptions.ml
@@ -22,7 +22,6 @@ type option_value =
   | BoolValue   of bool
   | IntValue    of int option
   | StringValue of string
-  | StringOptValue of string option
 
 (** Summary of an option status *)
 type option_state = {
@@ -293,11 +292,6 @@ let declare_string_option =
     (fun v -> StringValue v)
     (function StringValue v -> v | _ -> anomaly (Pp.str "async_option."))
     (fun x y -> x^","^y)
-let declare_stringopt_option =
-  declare_option
-    (fun v -> StringOptValue v)
-    (function StringOptValue v -> v | _ -> anomaly (Pp.str "async_option."))
-    (fun _ _ -> anomaly (Pp.str "async_option."))
 
 let declare_bool_option_and_ref ~depr ~name ~key ~(value:bool) =
   let r_opt = ref value in
@@ -331,7 +325,6 @@ let show_value_type = function
   | BoolValue _ -> "bool"
   | IntValue _ -> "int"
   | StringValue _ -> "string"
-  | StringOptValue _ -> "string"
 
 let bad_type_error opt_value actual_type =
   user_err Pp.(str "Bad type of value for this option:" ++ spc() ++
@@ -348,13 +341,11 @@ let check_bool_value v = function
 
 let check_string_value v = function
   | StringValue _ -> StringValue v
-  | StringOptValue _ -> StringOptValue (Some v)
   | optv -> bad_type_error optv "string"
 
 let check_unset_value v = function
   | BoolValue _ -> BoolValue false
   | IntValue _ -> IntValue None
-  | StringOptValue _ -> StringOptValue None
   | optv -> bad_type_error optv "nothing"
 
 (* Nota: For compatibility reasons, some errors are treated as
@@ -390,8 +381,6 @@ let msg_option_value (name,v) =
     | IntValue (Some n) -> int n
     | IntValue None   -> str "undefined"
     | StringValue s   -> quote (str s)
-    | StringOptValue None   -> str"undefined"
-    | StringOptValue (Some s)   -> quote (str s)
 (*     | IdentValue r    -> pr_global_env Id.Set.empty r *)
 
 let print_option_value key =

--- a/library/goptions.mli
+++ b/library/goptions.mli
@@ -128,8 +128,6 @@ val declare_bool_option  : ?preprocess:(bool -> bool) ->
                            bool option_sig   -> unit
 val declare_string_option: ?preprocess:(string -> string) ->
                            string option_sig -> unit
-val declare_stringopt_option: ?preprocess:(string option -> string option) ->
-                              string option option_sig -> unit
 
 (** Helper to declare a reference controlled by an option. Read-only
    as to avoid races. *)
@@ -170,7 +168,6 @@ type option_value =
   | BoolValue   of bool
   | IntValue    of int option
   | StringValue of string
-  | StringOptValue of string option
 
 (** Summary of an option status *)
 type option_state = {

--- a/plugins/micromega/certificate.ml
+++ b/plugins/micromega/certificate.ml
@@ -1004,13 +1004,13 @@ let xlia env0 en red sys =
   else xlia en red sys
 
 
-let dump_file = ref None
+let dump_file = ref ""
 
 let gen_bench (tac, prover) can_enum prfdepth sys =
   let res = prover can_enum prfdepth sys in
   (match !dump_file with
-  | None -> ()
-  | Some file ->
+  | "" -> ()
+  | file ->
      begin
        let o = open_out (Filename.temp_file ~temp_dir:(Sys.getcwd ()) file ".v") in
        let sys = develop_constraints prfdepth z_spec sys in

--- a/plugins/micromega/certificate.mli
+++ b/plugins/micromega/certificate.mli
@@ -25,8 +25,9 @@ type zres = (Mc.zArithProof , (int * Mc.z  list)) res
 type qres = (Mc.q Mc.psatz , (int * Mc.q  list)) res
 
 (** [dump_file] is bound to the Coq option Dump Arith.
-    If set to some [file], arithmetic goals are dumped in filexxx.v *)
-val dump_file : string option ref
+   If set to some [file], arithmetic goals are dumped in filexxx.v,
+   if set to "" no dumping will occur *)
+val dump_file : string ref
 
 (** [q_cert_of_pos prf] converts a Sos proof into a rational Coq proof *)
 val q_cert_of_pos : Sos_types.positivstellensatz -> Mc.q Mc.psatz

--- a/plugins/micromega/coq_micromega.ml
+++ b/plugins/micromega/coq_micromega.ml
@@ -91,7 +91,7 @@ let () =
    } in
 
  let () = declare_bool_option solver_opt in
- let () = declare_stringopt_option dump_file_opt in
+ let () = declare_string_option dump_file_opt in
  let () = declare_int_option (int_opt ["Lra"; "Depth"] lra_proof_depth) in
  let () = declare_int_option (int_opt ["Lia"; "Depth"] lia_proof_depth) in
  let () = declare_bool_option lia_enum_opt in

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -178,8 +178,6 @@ open Pputils
     (* This should not happen because of the grammar *)
       | IntValue (Some n) -> spc() ++ int n
       | StringValue s -> spc() ++ str s
-      | StringOptValue None -> mt()
-      | StringOptValue (Some s) -> spc() ++ str s
       | BoolValue b -> mt()
     in pr_printoption a None ++ pr_opt_value b
 

--- a/vernac/proof_using.ml
+++ b/vernac/proof_using.ml
@@ -169,16 +169,21 @@ let suggest_variable env id =
 
 let value = ref None
 
-let using_to_string us = Pp.string_of_ppcmds (Ppvernac.pr_using us)
-let using_from_string us = Pcoq.Entry.parse G_vernac.section_subset_expr (Pcoq.Parsable.make (Stream.of_string us))
+let using_to_string us =
+  Option.cata (fun us -> Pp.string_of_ppcmds (Ppvernac.pr_using us)) "" us
+
+let using_from_string us =
+  match us with
+  | "" -> None
+  | us -> Some (Pcoq.Entry.parse G_vernac.section_subset_expr (Pcoq.Parsable.make (Stream.of_string us)))
 
 let () =
-  Goptions.(declare_stringopt_option
+  Goptions.(declare_string_option
     { optdepr  = false;
       optname  = "default value for Proof using";
       optkey   = ["Default";"Proof";"Using"];
-      optread  = (fun () -> Option.map using_to_string !value);
-      optwrite = (fun b -> value := Option.map using_from_string b);
+      optread  = (fun () -> using_to_string !value);
+      optwrite = (fun b -> value := using_from_string b);
     })
 
 let get_default_proof_using () = !value

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1708,8 +1708,6 @@ let vernac_set_option0 ~local export key opt =
   let locality = get_option_locality export local in
   match opt with
   | StringValue s -> set_string_option_value_gen ~locality key s
-  | StringOptValue (Some s) -> set_string_option_value_gen ~locality key s
-  | StringOptValue None -> unset_option_value_gen ~locality key
   | IntValue n -> set_int_option_value_gen ~locality key n
   | BoolValue b -> set_bool_option_value_gen ~locality key b
 

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -113,7 +113,6 @@ type option_value = Goptions.option_value =
   | BoolValue of bool
   | IntValue of int option
   | StringValue of string
-  | StringOptValue of string option
 
 type option_ref_value =
   | StringRefValue of string


### PR DESCRIPTION
As discussed in https://github.com/coq/coq/pull/9876 , "string option"
options are problematic in the wider scope of interacting with other
tools.

This is a historical shell problem, in the sense that for an
environment variable `FOO`, it is hard to distinguish whether `FOO` is
unset or `FOO` is set to `""`.

As noted by @Skyskimmer, Coq only uses this type in a couple of
places, which would be better served anyways by different approaches:

- in the case of proof using, the grammar should capture "unset"
- in the case of the dump, dump filename and dump on / off should be
  different options.
