### PR TITLE
Add missing build dependency in `coq.opam`

### DIFF
--- a/coq.opam
+++ b/coq.opam
@@ -21,6 +21,7 @@ license: "LGPL-2.1"
 depends: [
   "ocaml"     {         >= "4.05.0" }
   "dune"      { build & >= "1.4.0"  }
+  "ocamlfind" { build }
   "num"
 ]
 


### PR DESCRIPTION
**Kind:** bug fix / infrastructure.

Fixes coq/coq#9956