### PR TITLE
[dune] Build coqc.byte executable.

### DIFF
--- a/topbin/dune
+++ b/topbin/dune
@@ -28,6 +28,11 @@
  (libraries coq.toplevel)
  (link_flags -linkall))
 
+(install
+ (section bin)
+ (package coq)
+ (files (coqc_bin.bc as coqc.byte)))
+
 ; Workers
 (executables
  (names coqqueryworker_bin coqtacticworker_bin coqproofworker_bin)


### PR DESCRIPTION
This may be useful in a few cases, like testing compilation with
byte-plugins; I chose to install it globally tho it is more of a
developer target.
