### PR TITLE
Hypothesis conversion allocates a single evar

### DIFF
--- a/plugins/ltac/g_auto.mlg
+++ b/plugins/ltac/g_auto.mlg
@@ -184,7 +184,7 @@ END
 
 
 TACTIC EXTEND convert_concl_no_check
-| ["convert_concl_no_check" constr(x) ] -> { Tactics.convert_concl_no_check x DEFAULTcast }
+| ["convert_concl_no_check" constr(x) ] -> { Tactics.convert_concl ~check:false x DEFAULTcast }
 END
 
 {

--- a/plugins/ltac/rewrite.ml
+++ b/plugins/ltac/rewrite.ml
@@ -1596,7 +1596,7 @@ let cl_rewrite_clause_newtac ?abs ?origsigma ~progress strat clause =
 	    tclTHENFIRST (assert_replacing id newt tac) (beta_hyp id)
 	| Some id, None ->
             Proofview.Unsafe.tclEVARS undef <*>
-            convert_hyp_no_check (LocalAssum (make_annot id Sorts.Relevant, newt)) <*>
+            convert_hyp ~check:false (LocalAssum (make_annot id Sorts.Relevant, newt)) <*>
             beta_hyp id
 	| None, Some p ->
             Proofview.Unsafe.tclEVARS undef <*>
@@ -1610,7 +1610,7 @@ let cl_rewrite_clause_newtac ?abs ?origsigma ~progress strat clause =
             end
 	| None, None ->
             Proofview.Unsafe.tclEVARS undef <*>
-            convert_concl_no_check newt DEFAULTcast
+            convert_concl ~check:false newt DEFAULTcast
   in
   Proofview.Goal.enter begin fun gl ->
     let concl = Proofview.Goal.concl gl in

--- a/plugins/omega/coq_omega.ml
+++ b/plugins/omega/coq_omega.ml
@@ -535,7 +535,7 @@ let focused_simpl path =
   let open Tacmach.New in
   Proofview.Goal.enter begin fun gl ->
   let newc = context (project gl) (fun i t -> pf_nf gl t) (List.rev path) (pf_concl gl) in
-  convert_concl_no_check newc DEFAULTcast
+  convert_concl ~check:false newc DEFAULTcast
   end
 
 let focused_simpl path = focused_simpl path
@@ -687,7 +687,7 @@ let simpl_coeffs path_init path_k =
   let n = Pervasives.(-) (List.length path_k) (List.length path_init) in
   let newc = context sigma (fun _ t -> loop n t) (List.rev path_init) (pf_concl gl)
   in
-  convert_concl_no_check newc DEFAULTcast
+  convert_concl ~check:false newc DEFAULTcast
   end
 
 let rec shuffle p (t1,t2) =
@@ -1849,12 +1849,12 @@ let destructure_hyps =
                     match destructurate_type env sigma typ with
 		    | Kapp(Nat,_) ->
                         (tclTHEN
-			   (convert_hyp_no_check (NamedDecl.set_type (mkApp (Lazy.force coq_neq, [| t1;t2|]))
+                           (Tactics.convert_hyp ~check:false (NamedDecl.set_type (mkApp (Lazy.force coq_neq, [| t1;t2|]))
                                                                      decl))
 			   (loop lit))
 		    | Kapp(Z,_) ->
                         (tclTHEN
-			   (convert_hyp_no_check (NamedDecl.set_type (mkApp (Lazy.force coq_Zne, [| t1;t2|]))
+                           (Tactics.convert_hyp ~check:false (NamedDecl.set_type (mkApp (Lazy.force coq_Zne, [| t1;t2|]))
                                                                      decl))
 			   (loop lit))
 		    | _ -> loop lit

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -426,7 +426,7 @@ let mk_anon_id t gl_ids =
     (set s i (Char.chr (Char.code (get s i) + 1)); s) in
   Id.of_string_soft (Bytes.to_string (loop (n - 1)))
 
-let convert_concl_no_check t = Tactics.convert_concl_no_check t DEFAULTcast
+let convert_concl_no_check t = Tactics.convert_concl ~check:false t DEFAULTcast
 let convert_concl t = Tactics.convert_concl t DEFAULTcast
 
 let rename_hd_prod orig_name_ref gl =
@@ -1408,8 +1408,6 @@ let tclINTRO_ANON ?seed () =
   | Some seed -> tclINTRO ~id:(Seed seed) ~conclusion:return
 
 let tclRENAME_HD_PROD name = Goal.enter begin fun gl ->
-  let convert_concl_no_check t =
-    Tactics.convert_concl_no_check t DEFAULTcast in
   let concl = Goal.concl gl in
   let sigma = Goal.sigma gl in
   match EConstr.kind sigma concl with

--- a/plugins/ssr/ssrtacticals.ml
+++ b/plugins/ssr/ssrtacticals.ml
@@ -110,7 +110,7 @@ let endclausestac id_map clseq gl_id cl0 gl =
   | _ -> EConstr.map (project gl) unmark c in
   let utac hyp =
     Proofview.V82.of_tactic 
-     (Tactics.convert_hyp_no_check (NamedDecl.map_constr unmark hyp)) in
+     (Tactics.convert_hyp ~check:false (NamedDecl.map_constr unmark hyp)) in
   let utacs = List.map utac (pf_hyps gl) in
   let ugtac gl' =
     Proofview.V82.of_tactic

--- a/tactics/eauto.ml
+++ b/tactics/eauto.ml
@@ -515,6 +515,6 @@ let autounfold_one db cl =
     if did then
       match cl with
       | Some hyp -> change_in_hyp None (make_change_arg c') hyp
-      | None -> convert_concl_no_check c' DEFAULTcast
+      | None -> convert_concl ~check:false c' DEFAULTcast
     else Tacticals.New.tclFAIL 0 (str "Nothing to unfold")
   end

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -697,7 +697,7 @@ let bind_red_expr_occurrences occs nbcl redexp =
 
 let reduct_in_concl (redfun,sty) =
   Proofview.Goal.enter begin fun gl ->
-    convert_concl_no_check (Tacmach.New.pf_apply redfun gl (Tacmach.New.pf_concl gl)) sty
+    convert_concl ~check:false (Tacmach.New.pf_apply redfun gl (Tacmach.New.pf_concl gl)) sty
   end
 
 let reduct_in_hyp ?(check=false) redfun (id,where) =
@@ -756,7 +756,7 @@ let e_change_in_concl (redfun,sty) =
     let sigma = Proofview.Goal.sigma gl in
     let (sigma, c) = redfun (Proofview.Goal.env gl) sigma (Proofview.Goal.concl gl) in
     Proofview.tclTHEN (Proofview.Unsafe.tclEVARS sigma)
-    (convert_concl_no_check c sty)
+    (convert_concl ~check:false c sty)
   end
 
 let e_pf_change_decl (redfun : bool -> e_reduction_function) where decl env sigma =
@@ -2174,7 +2174,7 @@ let constructor_tac with_evars expctdnumopt i lbind =
     let nconstr = Array.length (snd (Global.lookup_inductive ind)).mind_consnames in
     check_number_of_constructors expctdnumopt i nconstr;
     Tacticals.New.tclTHENLIST [
-      convert_concl_no_check redcl DEFAULTcast;
+      convert_concl ~check:false redcl DEFAULTcast;
       intros;
       constructor_core with_evars (ind, i) lbind
     ]
@@ -2203,7 +2203,7 @@ let any_constructor with_evars tacopt =
       Array.length (snd (Global.lookup_inductive ind)).mind_consnames in
     if Int.equal nconstr 0 then error "The type has no constructors.";
     Tacticals.New.tclTHENLIST [
-      convert_concl_no_check redcl DEFAULTcast;
+      convert_concl ~check:false redcl DEFAULTcast;
       intros;
       any_constr ind nconstr 1 ()
     ]
@@ -2647,9 +2647,9 @@ let letin_tac_gen with_eq (id,depdecls,lastlhyp,ccl,c) ty =
     in
       Tacticals.New.tclTHENLIST
       [ Proofview.Unsafe.tclEVARS sigma;
-        convert_concl_no_check newcl DEFAULTcast;
+        convert_concl ~check:false newcl DEFAULTcast;
         intro_gen (NamingMustBe (CAst.make id)) (decode_hyp lastlhyp) true false;
-        Tacticals.New.tclMAP convert_hyp_no_check depdecls;
+        Tacticals.New.tclMAP (convert_hyp ~check:false) depdecls;
         eq_tac ]
   end
 
@@ -4799,7 +4799,7 @@ let symmetry_red allowred =
   match with_eqn with
   | Some eq_data,_,_ ->
       Tacticals.New.tclTHEN
-        (convert_concl_no_check concl DEFAULTcast)
+        (convert_concl ~check:false concl DEFAULTcast)
         (Tacticals.New.pf_constr_of_global eq_data.sym >>= apply)
   | None,eq,eq_kind -> prove_symmetry eq eq_kind
   end
@@ -4894,7 +4894,7 @@ let transitivity_red allowred t =
   match with_eqn with
   | Some eq_data,_,_ ->
       Tacticals.New.tclTHEN
-        (convert_concl_no_check concl DEFAULTcast)
+        (convert_concl ~check:false concl DEFAULTcast)
         (match t with
 	  | None -> Tacticals.New.pf_constr_of_global eq_data.trans >>= eapply
 	  | Some t -> Tacticals.New.pf_constr_of_global eq_data.trans >>= fun trans -> apply_list [trans; t])

--- a/tactics/tactics.mli
+++ b/tactics/tactics.mli
@@ -154,8 +154,8 @@ type change_arg = patvar_map -> env -> evar_map -> evar_map * constr
 val make_change_arg   : constr -> change_arg
 val reduct_in_hyp     : ?check:bool -> tactic_reduction -> hyp_location -> unit Proofview.tactic
 val reduct_option     : ?check:bool -> tactic_reduction * cast_kind -> goal_location -> unit Proofview.tactic
-val reduct_in_concl   : tactic_reduction * cast_kind -> unit Proofview.tactic
-val e_reduct_in_concl   : check:bool -> e_tactic_reduction * cast_kind -> unit Proofview.tactic
+val reduct_in_concl   : ?check:bool -> tactic_reduction * cast_kind -> unit Proofview.tactic
+val e_reduct_in_concl   : ?check:bool -> e_tactic_reduction * cast_kind -> unit Proofview.tactic
 val change_in_concl   : (occurrences * constr_pattern) option -> change_arg -> unit Proofview.tactic
 val change_concl      : constr -> unit Proofview.tactic
 val change_in_hyp     : (occurrences * constr_pattern) option -> change_arg ->

--- a/tactics/tactics.mli
+++ b/tactics/tactics.mli
@@ -36,7 +36,9 @@ val introduction    : Id.t -> unit Proofview.tactic
 val convert_concl   : ?check:bool -> types -> cast_kind -> unit Proofview.tactic
 val convert_hyp     : ?check:bool -> named_declaration -> unit Proofview.tactic
 val convert_concl_no_check : types -> cast_kind -> unit Proofview.tactic
+[@@ocaml.deprecated "use [Tactics.convert_concl]"]
 val convert_hyp_no_check : named_declaration -> unit Proofview.tactic
+[@@ocaml.deprecated "use [Tactics.convert_hyp]"]
 val mutual_fix      :
   Id.t -> int -> (Id.t * int * constr) list -> int -> unit Proofview.tactic
 val fix             : Id.t -> int -> unit Proofview.tactic


### PR DESCRIPTION
This PR implements an optimization in conversion tactics applied to several hypotheses at the same time, e.g. `change foo in *` or `cbv in H1, H2`. Instead of performing the various conversions as separate refining steps, they are now computed in one pass and result in only one evar creation, when the previous implementation generated as many intermediate evars as hypotheses touched by the tactic.

I observed this source of slowness as a minor part of #9919, although the current PR does not solve the underlying algorithmic issue of #9919.

The benchmark is quite impressive:
```

┌────────────────────────┬──────────────────────────┬──────────────────────────────────────────────┬──────────────────────────────────────────────┬────────────────────────────────┬───────────────────────────┐
│                        │      user time [s]       │                  CPU cycles                  │               CPU instructions               │     max resident mem [KB]      │        mem faults         │
│                        │                          │                                              │                                              │                                │                           │
│           package_name │     NEW     OLD  PDIFF   │               NEW               OLD  PDIFF   │               NEW               OLD  PDIFF   │        NEW        OLD  PDIFF   │     NEW     OLD   PDIFF   │
├────────────────────────┼──────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼────────────────────────────────┼───────────────────────────┤
│              coq-flocq │  578.60  681.56 -15.11 % │     1609959867437     1898503125257 -15.20 % │     2275244154088     2691813564071 -15.48 % │    1243780    1727464 -28.00 % │     222      86 +158.14 % │
├────────────────────────┼──────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼────────────────────────────────┼───────────────────────────┤
│           coq-compcert │ 1019.58 1051.48  -3.03 % │     2841579245796     2928180397362  -2.96 % │     4408487836554     4455107687850  -1.05 % │    1041172    1296968 -19.72 % │     281     265   +6.04 % │
├────────────────────────┼──────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼────────────────────────────────┼───────────────────────────┤
│               coq-hott │  340.82  348.49  -2.20 % │      925742712764      948989511343  -2.45 % │     1415640597553     1433423926287  -1.24 % │     478856     478984  -0.03 % │     457      52 +778.85 % │
├────────────────────────┼──────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼────────────────────────────────┼───────────────────────────┤
│       coq-fiat-parsers │  697.51  709.75  -1.72 % │     1953015178386     1984982158619  -1.61 % │     2994724931243     3002096393187  -0.25 % │    3023148    3033588  -0.34 % │     310     650  -52.31 % │
├────────────────────────┼──────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼────────────────────────────────┼───────────────────────────┤
│             coq-sf-plf │   41.74   42.45  -1.67 % │      117242258261      118622549230  -1.16 % │      150216367148      151129445062  -0.60 % │     486488     497672  -2.25 % │      11      19  -42.11 % │
├────────────────────────┼──────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼────────────────────────────────┼───────────────────────────┤
│         coq-verdi-raft │ 1375.20 1397.35  -1.59 % │     3836050862036     3898355790346  -1.60 % │     5238896713757     5291982771895  -1.00 % │    1816496    1811396  +0.28 % │       2       1 +100.00 % │
├────────────────────────┼──────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼────────────────────────────────┼───────────────────────────┤
│        coq-fiat-crypto │ 4199.60 4262.97  -1.49 % │    11669488870709    11844441811091  -1.48 % │    18662524761098    18763980936223  -0.54 % │    2636220    2636768  -0.02 % │    1093    1003   +8.97 % │
├────────────────────────┼──────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼────────────────────────────────┼───────────────────────────┤
│             coq-geocoq │ 2006.20 2030.74  -1.21 % │     5596426397888     5666674570981  -1.24 % │     8125965585621     8184445934128  -0.71 % │    1197252    1219436  -1.82 % │     104     219  -52.51 % │
├────────────────────────┼──────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼────────────────────────────────┼───────────────────────────┤
│              coq-verdi │  124.08  125.19  -0.89 % │      345262769307      348847823932  -1.03 % │      445185075708      447605745284  -0.54 % │     598216     609720  -1.89 % │       5       8  -37.50 % │
├────────────────────────┼──────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼────────────────────────────────┼───────────────────────────┤
│          coq-fiat-core │  109.64  110.55  -0.82 % │      312138940089      313970683910  -0.58 % │      391437250554      392447210436  -0.26 % │     503564     505572  -0.40 % │     405     191 +112.04 % │
├────────────────────────┼──────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼────────────────────────────────┼───────────────────────────┤
│       coq-math-classes │  216.48  218.24  -0.81 % │      604943415906      610331559939  -0.88 % │      771334336659      771820451664  -0.06 % │     513944     514312  -0.07 % │      33      16 +106.25 % │
├────────────────────────┼──────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼────────────────────────────────┼───────────────────────────┤
│        coq-lambda-rust │ 2077.32 2094.16  -0.80 % │     5789741281266     5836544548957  -0.80 % │     8001511399442     8009755885571  -0.10 % │    1387004    1391464  -0.32 % │      54       5 +980.00 % │
├────────────────────────┼──────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼────────────────────────────────┼───────────────────────────┤
│              coq-color │  705.17  710.66  -0.77 % │     1971129030980     1987776783042  -0.84 % │     2357213612264     2363526181253  -0.27 % │    1343072    1347892  -0.36 % │      96     113  -15.04 % │
├────────────────────────┼──────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼────────────────────────────────┼───────────────────────────┤
│ coq-mathcomp-character │  204.91  206.38  -0.71 % │      571236458263      575445327053  -0.73 % │      765428771584      765478230683  -0.01 % │    1064084    1063940  +0.01 % │       9      91  -90.11 % │
├────────────────────────┼──────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼────────────────────────────────┼───────────────────────────┤
│               coq-corn │ 1495.37 1505.80  -0.69 % │     4174392878181     4202571653844  -0.67 % │     6196846970364     6195998419980  +0.01 % │     836728     836996  -0.03 % │       1       1   +0.00 % │
├────────────────────────┼──────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼────────────────────────────────┼───────────────────────────┤
│     coq-mathcomp-field │  237.40  239.05  -0.69 % │      661536439971      666001761043  -0.67 % │      954447172681      954429337856  +0.00 % │     756128     757168  -0.14 % │       1       1   +0.00 % │
├────────────────────────┼──────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼────────────────────────────────┼───────────────────────────┤
│   coq-mathcomp-algebra │  174.84  175.97  -0.64 % │      487048557628      489793547077  -0.56 % │      610545447520      610449259065  +0.02 % │     637012     636268  +0.12 % │      11       2 +450.00 % │
├────────────────────────┼──────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼────────────────────────────────┼───────────────────────────┤
│            coq-unimath │ 2090.63 2103.95  -0.63 % │     5820833473549     5855451285801  -0.59 % │    10214003051224    10222422939328  -0.08 % │     917000     910272  +0.74 % │     275     383  -28.20 % │
├────────────────────────┼──────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼────────────────────────────────┼───────────────────────────┤
│            coq-bignums │   72.18   72.55  -0.51 % │      201184204877      202119583332  -0.46 % │      266869657749      267030803814  -0.06 % │     498956     503412  -0.89 % │     167     158   +5.70 % │
├────────────────────────┼──────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼────────────────────────────────┼───────────────────────────┤
│         coq-coquelicot │   75.14   75.47  -0.44 % │      206495265534      208265700331  -0.85 % │      248806328874      249737284232  -0.37 % │     680420     707804  -3.87 % │     205      17 +1105.88 % │
├────────────────────────┼──────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼────────────────────────────────┼───────────────────────────┤
│ coq-mathcomp-odd-order │ 1426.97 1433.02  -0.42 % │     3978158360176     3994587729286  -0.41 % │     6605427689134     6610300038509  -0.07 % │    1272448    1272480  -0.00 % │     104      82  +26.83 % │
├────────────────────────┼──────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼────────────────────────────────┼───────────────────────────┤
│  coq-mathcomp-solvable │  201.26  201.90  -0.32 % │      561774649944      562795766336  -0.18 % │      752078407042      751813887587  +0.04 % │     805104     805596  -0.06 % │       4       0    +nan % │
├────────────────────────┼──────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼────────────────────────────────┼───────────────────────────┤
│ coq-mathcomp-ssreflect │   40.21   40.24  -0.07 % │      111045377668      111170246740  -0.11 % │      133549598759      133488834448  +0.05 % │     530108     530404  -0.06 % │      93      62  +50.00 % │
├────────────────────────┼──────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼────────────────────────────────┼───────────────────────────┤
│  coq-mathcomp-fingroup │   55.76   55.69  +0.13 % │      155029629934      155398482548  -0.24 % │      203245654046      203169972445  +0.04 % │     579528     577416  +0.37 % │       6       2 +200.00 % │
└────────────────────────┴──────────────────────────┴──────────────────────────────────────────────┴──────────────────────────────────────────────┴────────────────────────────────┴───────────────────────────┘
```
I don't know why Flocq is impacted that much by that change, but it is remarkable (@silene ?)

This PR is somewhat self contained and could be considered as a fix somehow. If @vbgl would like so, I can provide a backport to 8.10 that doesn't touch the API. (I deprecated some functions and added flags as part of an implementation cleanup, but it is not strictly necessary for the performance gain.)