### PR TITLE
Add PairUsualDecidableTypeFull

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -45,6 +45,8 @@ Unreleased changes
 
 **Standard library**
 
+- Added Coq.Structures.EqualitiesFacts.PairUsualDecidableTypeFull
+
 
 **Infrastructure and dependencies**
 

--- a/theories/Structures/EqualitiesFacts.v
+++ b/theories/Structures/EqualitiesFacts.v
@@ -212,3 +212,14 @@ Module PairUsualDecidableType(D1 D2:UsualDecidableType) <: UsualDecidableType.
  Defined.
 
 End PairUsualDecidableType.
+
+(** And also for pairs of UsualDecidableTypeFull *)
+
+Module PairUsualDecidableTypeFull (D1 D2:UsualDecidableTypeFull)
+  <: UsualDecidableTypeFull.
+
+ Module M := PairUsualDecidableType D1 D2.
+ Include Backport_DT (M).
+ Include HasEqDec2Bool.
+
+End PairUsualDecidableTypeFull.


### PR DESCRIPTION
A module type allowing the user to build a UsualDecidableTypeFull from a pair
of such, exactly analogous to the extant PairDecidableType and
PairUsualDecidableType module types.

**Kind:** feature.

- [x] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [x] Entry added in CHANGES.md.

Some remarks:
  * This is not my work; these changes were provided in an [answer](https://stackoverflow.com/a/55761358/5342944) to a question I asked on StackOverflow.
  * My reading of the remarks about updating **CREDITS** in **CONTRIBUTING.md**, indicates that this is not required for changes to the standard library. Please let me know if I am in error.
  * The documentation for the standard library is generated automatically, and so there is nothing for me to update. I have ticked the documentation box above after noting that [here](https://coq.gitlab.io/-/coq/-/jobs/201550501/artifacts/_install_ci/share/doc/coq/html/stdlib/Coq.Structures.EqualitiesFacts.html) that this process seems to have worked.