### PR TITLE
CoqIDE: fix open-file dialog and icons on macOS

### DIFF
--- a/Makefile.ide
+++ b/Makefile.ide
@@ -68,6 +68,7 @@ GTKBIN=$(shell pkg-config --variable=prefix gtk+-3.0)/bin
 GTKLIBS=$(shell pkg-config --variable=libdir gtk+-3.0)
 PIXBUFBIN=$(shell pkg-config --variable=prefix gdk-pixbuf-2.0)/bin
 SOURCEVIEWSHARE=$(shell pkg-config --variable=prefix gtksourceview-3.0)/share
+ADWAITASHARE=$(shell ls -d /usr/local/Cellar/adwaita-icon-theme/*)/share
 
 ###########################################################################
 # CoqIde special targets
@@ -257,6 +258,7 @@ $(COQIDEAPP)/Contents/Resources/share: $(COQIDEAPP)/Contents
 	cp -R "$(GTKSHARE)/"themes $@
 	$(MKDIR) $@/glib-2.0/schemas
 	glib-compile-schemas --targetdir=$@/glib-2.0/schemas "$(GTKSHARE)/"glib-2.0/schemas/
+	cp -R "$(ADWAITASHARE)/"icons $@
 
 $(COQIDEAPP)/Contents/Resources/loaders: $(COQIDEAPP)/Contents
 	$(MKDIR) $@

--- a/Makefile.ide
+++ b/Makefile.ide
@@ -255,6 +255,8 @@ $(COQIDEAPP)/Contents/Resources/share: $(COQIDEAPP)/Contents
 	$(INSTALLLIB) "$(SOURCEVIEWSHARE)/"gtksourceview-3.0/styles/{styles.rng,classic.xml} $@/gtksourceview-3.0/styles/
 	cp -R "$(GTKSHARE)/"locale $@
 	cp -R "$(GTKSHARE)/"themes $@
+	$(MKDIR) $@/glib-2.0/schemas
+	glib-compile-schemas --targetdir=$@/glib-2.0/schemas "$(GTKSHARE)/"glib-2.0/schemas/
 
 $(COQIDEAPP)/Contents/Resources/loaders: $(COQIDEAPP)/Contents
 	$(MKDIR) $@

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,7 +52,7 @@ jobs:
   - script: |
       set -e
       brew update
-      brew install gnu-time opam pkg-config gtksourceview3
+      brew install gnu-time opam pkg-config gtksourceview3 adwaita-icon-theme
       pip3 install macpack
     displayName: 'Install system dependencies'
 


### PR DESCRIPTION
This fixes a few known issues of CoqIDE from the macOS “app”: crashes when using GTK+ dialogs (file open, choose background color…) and missing icons.