### PR TITLE
Add a typing colon in the output of the Search ssreflect vernacular

### DIFF
--- a/plugins/ssr/ssrvernac.mlg
+++ b/plugins/ssr/ssrvernac.mlg
@@ -465,7 +465,7 @@ let interp_modloc mr =
 (* The unified, extended vernacular "Search" command *)
 
 let ssrdisplaysearch gr env t =
-  let pr_res = pr_global gr ++ spc () ++ str " " ++ pr_lconstr_env env Evd.empty t in
+  let pr_res = pr_global gr ++ str ":" ++ spc () ++ pr_lconstr_env env Evd.empty t in
   Feedback.msg_info (hov 2 pr_res ++ fnl ())
 
 }


### PR DESCRIPTION
**Kind:** bug fix

Closes #10000

This issue had been fixed in math-comp/math-comp#73 but not in the SSR plugin shipped in Coq.

Even if this is only a matter of one extra character, this issue has a distracting impact on the readability of the output (notably as it hinders its syntax highlighting when displayed in a ProofGeneral buffer).
So hopefully this small patch could be shipped in the upcoming release of Coq and/or backported.