### PR TITLE
Amending sphinx-on-windows fix in #9819 so that it does not trigger a warning on MacOS X (and other BSD systems).

### DIFF
--- a/Makefile.doc
+++ b/Makefile.doc
@@ -31,8 +31,8 @@ DVIPS:=dvips
 HTMLSTYLE:=coqremote
 
 # Sphinx-related variables
-OSNAME:=$(shell uname -o)
-ifeq ($(OSNAME),Cygwin)
+OSNAME:=$(shell uname -s)
+ifeq ($(findstring CYGWIN,$(OSNAME)),CYGWIN)
 WIN_CURDIR:=$(shell cygpath -w $(CURDIR))
 SPHINXENV:=COQBIN="$(CURDIR)/bin/" COQLIB="$(WIN_CURDIR)"
 else


### PR DESCRIPTION
**Kind:** bug fix 

63e7fb56923 in #9819 was fixing `make sphinx` on Windows but it introduces a warning on MacOS X and more generally on all BSD-based systems. This is because BSD `uname` does not support the `-o` option.

The alternative fix we propose is based on the following resources about `uname` compatility:
- https://stackoverflow.com/questions/3466166/how-to-check-if-running-in-cygwin-mac-or-linux
- https://en.wikipedia.org/wiki/Uname
