### PR TITLE
CoqIDE: Fix not escaping coqtop arguments when compiling

### DIFF
--- a/configure.ml
+++ b/configure.ml
@@ -975,7 +975,7 @@ let config_runtime () =
   | Some flags -> string_split ',' flags
   | _ when use_custom -> [custom_flag]
   | _ when !prefs.local ->
-    ["-dllib";"-lcoqrun";"-dllpath";coqtop/"kernel/byterun"]
+    ["-dllib";"-lcoqrun";"-dllpath";("\"" ^ coqtop ^ "/kernel/byterun\"")]
   | _ ->
     let ld="CAML_LD_LIBRARY_PATH" in
     build_loadpath := sprintf "export %s:='%s/kernel/byterun':$(%s)" ld coqtop ld;

--- a/doc/changelog/09-coqide/10008-snyke7+escape_spaces.rst
+++ b/doc/changelog/09-coqide/10008-snyke7+escape_spaces.rst
@@ -1,0 +1,4 @@
+- **Fixed:**
+  Fix file paths containing spaces when compiling
+  (`#10008 <https://github.com/coq/coq/pull/10008>`_,
+  by snyke7, fixing `#11595 <https://github.com/coq/coq/pull/11595>`_).

--- a/ide/coqide.ml
+++ b/ide/coqide.ml
@@ -460,7 +460,7 @@ let compile sn =
     |Some f ->
       let args = Coq.get_arguments sn.coqtop in
       let cmd = cmd_coqc#get
-        ^ " " ^ String.concat " " args
+        ^ " " ^ String.concat " " (List.map Filename.quote args)
         ^ " " ^ (Filename.quote f) ^ " 2>&1"
       in
       let buf = Buffer.create 1024 in
@@ -474,7 +474,7 @@ let compile sn =
           flash_info (f ^ " successfully compiled")
         else begin
           flash_info (f ^ " failed to compile");
-          sn.messages#default_route#set (Pp.str "Compilation output:\n");
+          sn.messages#default_route#set (Pp.str ("Compilation output:\n" ^ cmd ^ "\n"));
           sn.messages#default_route#add (Pp.str (Buffer.contents buf));
         end
       in

--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -33,10 +33,10 @@ include ../Makefile.common
 #######################################################################
 
 ifneq ($(wildcard ../_build),)
-BIN:=$(shell cd ..; pwd)/_build/install/default/bin/
-COQLIB:=$(shell cd ..; pwd)/_build/install/default/lib/coq
+BIN:='$(shell cd ..; pwd)'/_build/install/default/bin/
+COQLIB:='$(shell cd ..; pwd)'/_build/install/default/lib/coq
 else
-BIN := $(shell cd ..; pwd)/bin/
+BIN := '$(shell cd ..; pwd)'/bin/
 
 COQLIB?=
 ifeq ($(COQLIB),)
@@ -602,10 +602,10 @@ $(patsubst %.sh,%.log,$(wildcard misc/*.sh)): %.log: %.sh $(PREREQUISITELOG)
 	@echo "TEST      $<"
 	$(HIDE){ \
 	  echo $(call log_intro,$<); \
-	  export BIN="$(BIN)"; \
-	  export coqc="$(coqc)"; \
-	  export coqtop="$(coqc)"; \
-	  export coqdep="$(coqdep)"; \
+	  export BIN=$(BIN); \
+	  export coqc="eval $(coqc)"; \
+	  export coqtop="eval $(coqc)"; \
+	  export coqdep="eval $(coqdep)"; \
 	  "$<" 2>&1; R=$$?; times; \
 	  if [ $$R = 0 ]; then \
 	    echo $(log_success); \

--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -32,11 +32,15 @@ include ../Makefile.common
 # Variables
 #######################################################################
 
+# Using quotes to anticipate the possibility of spaces in the directory name
+# Note that this will later need an eval in shell to interpret the quotes
+ROOT='$(shell cd ..; pwd)'
+
 ifneq ($(wildcard ../_build),)
-BIN:='$(shell cd ..; pwd)'/_build/install/default/bin/
-COQLIB:='$(shell cd ..; pwd)'/_build/install/default/lib/coq
+BIN:=$(ROOT)/_build/install/default/bin/
+COQLIB:=$(ROOT)/_build/install/default/lib/coq
 else
-BIN := '$(shell cd ..; pwd)'/bin/
+BIN := $(ROOT)/bin/
 
 COQLIB?=
 ifeq ($(COQLIB),)


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** Bug fix/feature.

Fixes #11595 

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes compilation failure when pressing 'Compile buffer', when the arguments to coqtop contain spaces. This happens, for example, when a _CoqProject file is loaded and contains the option `-R relativepath name` and the absolute path contains a space.

Ideally the coqtop arguments dialog screen should also accept arguments containing spaces, but that is not as easy. The arguments are presented concatenated by a space and then split by spaces when pressing okay. Not splitting when apostrophes are present is possible, but not a complete solution (escaped apostrophes!) and somewhat complex.

When running `make test-suite` I ran into some more problems caused by a path containing spaces. These were all relatively simple to fix, except for the misc tests containing scripts. Here it was necessary to replace `export coqc="$(coqc)"` with `export coqc="eval $(coqc)"`since `BIN='/absolute path'/bin/`, and so `coqc='/absolute path'/bin/coqc -q -R prerequisite TestSuite`. Note the apostrophes around absolute path: these cause `make` to work properly, but the shell scripts interpret these apostrophes literally. Putting eval in front makes it work again, and requires no changes in the individual shell scripts.


<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [ ] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [x] Entry added in CHANGES.md.
