### PR TITLE
[meta] [dune] Fix discrepancies in plugin names

### DIFF
--- a/META.coq.in
+++ b/META.coq.in
@@ -315,7 +315,7 @@ package "plugins" (
     archive(native)  = "micromega_plugin.cmx"
   )
 
-  package "newring" (
+  package "setoid_ring" (
 
     description = "Coq newring plugin"
     version     = "8.10"
@@ -351,7 +351,7 @@ package "plugins" (
     archive(native)  = "cc_plugin.cmx"
   )
 
-  package "ground" (
+  package "firstorder" (
 
     description = "Coq ground plugin"
     version     = "8.10"
@@ -387,7 +387,7 @@ package "plugins" (
     archive(native)  = "btauto_plugin.cmx"
   )
 
-  package "recdef" (
+  package "funind" (
 
     description = "Coq recdef plugin"
     version     = "8.10"

--- a/plugins/funind/plugin_base.dune
+++ b/plugins/funind/plugin_base.dune
@@ -1,5 +1,5 @@
 (library
  (name recdef_plugin)
- (public_name coq.plugins.recdef)
+ (public_name coq.plugins.funind)
  (synopsis "Coq's functional induction plugin")
  (libraries coq.plugins.extraction))


### PR DESCRIPTION
We have some discrepancy with the package names for plugins in the
META / Dune case. This PR fixes it.

At some point there was a need for plugin package names having to be
named as their directories.

I think this is not true anymore, but taking the "dir_name ==
package_name" convention just in case.

This should go in 8.10