### PR TITLE
[ci/gitlab] Remove after_switch message (not useful anymore).

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -47,9 +47,6 @@ before_script:
   - opam list
   - opam config list
 
-after_script:
-  - echo "The build completed normally (not a runner failure)."
-
 ################ GITLAB CACHING ######################
 # - use artifacts between jobs                       #
 ######################################################


### PR DESCRIPTION
This was put in place for @coqbot to detect runner failures, but, for a good while now, the strategy has been different.

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** infrastructure clean-up.
