### PR TITLE
Document unshelve (#3225)

### DIFF
--- a/doc/sphinx/proof-engine/tactics.rst
+++ b/doc/sphinx/proof-engine/tactics.rst
@@ -4724,6 +4724,12 @@ Non-logical tactics
    from the shelf into focus, by appending them to the end of the current
    list of focused goals.
 
+.. tacn:: unshelve @tactic
+   :name: unshelve
+
+   Performs :n:`@tactic`, then unshelves existential variables added to the
+   shelf by the execution of :n:`@tactic`, prepending them to the current goal.
+
 .. tacn:: give_up
    :name: give_up
 


### PR DESCRIPTION
I believe this is the appropriate place for users to read about this, even tho `unshelve` is maybe technically a tactical (but then, is `intuition` a tactical as well?).

This example was explicitly requested in #3225 and is commonly used in both
Iris (and was documented in the changelog at the time).

**Fixes:** #4508.

**Kind:** documentation.