### PR TITLE
Show diff highlights in the Show, Show <num> and Show <id> commands.

### DIFF
--- a/printing/printer.mli
+++ b/printing/printer.mli
@@ -163,7 +163,7 @@ val pr_subgoals            : ?pr_first:bool -> ?diffs:bool -> ?os_map:(evar_map 
                              -> seeds:Goal.goal list -> shelf:Goal.goal list -> stack:int list
                              -> unfocused:Goal.goal list -> goals:Goal.goal list -> Pp.t
 
-val pr_subgoal             : int -> evar_map -> Goal.goal list -> Pp.t
+val pr_subgoal             : ?os_map:(evar_map * Goal.goal Evar.Map.t) -> int -> evar_map -> bool -> Goal.goal list -> Pp.t
 
 (** [pr_concl n ~diffs ~og_s sigma g] prints the conclusion of the goal [g] using [sigma].  The output
     is labelled "subgoal [n]".  If [diffs] is true, highlight the differences between the old conclusion,
@@ -178,14 +178,14 @@ val pr_concl               : int -> ?diffs:bool -> ?og_s:(Goal.goal sigma) -> ev
 *)
 val pr_open_subgoals_diff  : ?quiet:bool -> ?diffs:bool -> ?oproof:Proof.t -> Proof.t -> Pp.t
 val pr_open_subgoals       : proof:Proof.t -> Pp.t
-val pr_nth_open_subgoal    : proof:Proof.t -> int -> Pp.t
+val pr_nth_open_subgoal    : Proof.t option -> proof:Proof.t -> int -> bool -> Pp.t
 val pr_evar                : evar_map -> (Evar.t * evar_info) -> Pp.t
 val pr_evars_int           : evar_map -> shelf:Goal.goal list -> given_up:Goal.goal list -> int -> evar_info Evar.Map.t -> Pp.t
 val pr_evars               : evar_map -> evar_info Evar.Map.t -> Pp.t
 val pr_ne_evar_set         : Pp.t -> Pp.t -> evar_map ->
   Evar.Set.t -> Pp.t
 
-val print_and_diff : Proof.t option -> Proof.t option -> unit
+val print_and_diff : Proof.t option -> Proof.t option -> Pp.t
 
 (** Declarations for the "Print Assumption" command *)
 type axiom =
@@ -205,5 +205,5 @@ module ContextObjectMap : CMap.ExtS
 
 val pr_assumptionset : env -> evar_map -> types ContextObjectMap.t -> Pp.t
 
-val pr_goal_by_id : proof:Proof.t -> Id.t -> Pp.t
+val pr_goal_by_id : Proof.t option -> proof:Proof.t -> Id.t -> bool -> Pp.t
 

--- a/toplevel/coqloop.ml
+++ b/toplevel/coqloop.ml
@@ -356,7 +356,7 @@ let top_goal_print ~doc c oldp newp =
                       print_anyway c in
     if not !Flags.quiet && print_goals then begin
       let dproof = Stm.get_prev_proof ~doc (Stm.get_current_state ~doc) in
-      Printer.print_and_diff dproof newp
+      Feedback.msg_notice (Printer.print_and_diff dproof newp)
     end
   with
   | exn ->

--- a/vernac/vernacentries.mli
+++ b/vernac/vernacentries.mli
@@ -19,10 +19,15 @@ val proof_mode_opt_name : string list
 val vernac_require :
   Libnames.qualid option -> bool option -> Libnames.qualid list -> unit
 
-(** The main interpretation function of vernacular expressions *)
+(** The main interpretation function of vernacular expressions
+    The first component of ?xproof is based on Proof_global.closed_proof,
+    which is used throughout the interpreter.  The second component is based
+    on Proof.t, which is old proof for use in computing diffs in the "Show"
+    commands.
+*)
 val interp :
   ?verbosely:bool ->
-  ?proof:Proof_global.closed_proof ->
+  ?xproof:(Proof_global.closed_proof option * (Proof.t option)) ->
   st:Vernacstate.t -> Vernacexpr.vernac_control -> Vernacstate.t
 
 (** Prepare a "match" template for a given inductive type.


### PR DESCRIPTION
**Kind:** feature.

Currently these `Show` commands don't display diff highlights, which they should.  Also, Proof General uses a `Show` when it undoes a proof step, so there are no diff highlights.  That makes the same proof step look different depending on whether you got to that step by going forward or backward.

This PR adds that support.

One wart in this code is the need to create the reference variable Proof_global.get_prev_proof, which is set from Stm.  The problem is that if Vernacentries calls Stm directly, it creates a circular dependency that won't compile or link.  If anyone has a better idea, please let me know.

I hope we can get this into 8.10.