### PR TITLE
CoqIDE fixes for windows

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -88,6 +88,9 @@ before_script:
     - echo 'end:coq.install'
 
     - set +e
+  only:
+    variables:
+      - $DISABLED =~ /enabled/
 
 # Template for building Coq + stdlib, typical use: overload the switch
 .dune-template:
@@ -105,6 +108,9 @@ before_script:
     paths:
       - _build/
     expire_in: 1 week
+  only:
+    variables:
+      - $DISABLED =~ /enabled/
 
 .dune-ci-template:
   stage: test

--- a/dev/build/windows/MakeCoq_MinGW.bat
+++ b/dev/build/windows/MakeCoq_MinGW.bat
@@ -380,7 +380,7 @@ IF "%RUNSETUP%"=="Y" (
     -P gettext-devel,libgettextpo-devel ^
     -P libglib2.0-devel,libgdk_pixbuf2.0-devel ^
     -P libfontconfig1 ^
-    -P gtk-update-icon-cache ^
+    -P gtk-update-icon-cache,adwaita-icon-theme ^
     -P libtool,automake ^
     -P intltool ^
     %EXTRAPACKAGES% ^

--- a/dev/build/windows/makecoq_mingw.sh
+++ b/dev/build/windows/makecoq_mingw.sh
@@ -1293,6 +1293,8 @@ function copy_coq_gtk {
     install_glob "$PREFIX/share/gtksourceview-3.0/styles" '*'         "$PREFIXCOQ/share/gtksourceview-3.0/styles"
     install_rec  "$PREFIX/share/themes" '*'                           "$PREFIXCOQ/share/themes"
     install_rec  "$CYGWIN_INSTALLDIR_MFMT/usr/share/icons" '*'        "$PREFIXCOQ/share/icons"
+    mkdir -p "$PREFIXCOQ/share/glib-2.0/schemas"
+    glib-compile-schemas --targetdir="$PREFIXCOQ/share/glib-2.0/schemas" "$PREFIX/share/glib-2.0/schemas/"
 
     # This below item look like a bug in make install
     if [ -d "$PREFIXCOQ/share/coq/" ] ; then

--- a/dev/build/windows/makecoq_mingw.sh
+++ b/dev/build/windows/makecoq_mingw.sh
@@ -1292,6 +1292,7 @@ function copy_coq_gtk {
     install_glob "$PREFIX/share/gtksourceview-3.0/language-specs" '*' "$PREFIXCOQ/share/gtksourceview-3.0/language-specs"
     install_glob "$PREFIX/share/gtksourceview-3.0/styles" '*'         "$PREFIXCOQ/share/gtksourceview-3.0/styles"
     install_rec  "$PREFIX/share/themes" '*'                           "$PREFIXCOQ/share/themes"
+    install_rec  "$CYGWIN_INSTALLDIR_MFMT/usr/share/icons" '*'        "$PREFIXCOQ/share/icons"
 
     # This below item look like a bug in make install
     if [ -d "$PREFIXCOQ/share/coq/" ] ; then


### PR DESCRIPTION
This adds icons to CoqIDE (toolbar…).

It seems to fix some crashes (it is now possible to run “File; Open”) but not all (no file should be selected through the dialog box).