### PR TITLE
Allow large eliminations in successor universes

### DIFF
--- a/pretyping/cases.ml
+++ b/pretyping/cases.ml
@@ -2082,9 +2082,9 @@ let prepare_predicate ?loc ~program_mode typing_fun env sigma tomatchs arsign ty
     | Some rtntyp ->
       (* We extract the signature of the arity *)
       let building_arsign,envar = List.fold_right_map (push_rel_context ~hypnaming:KeepUserNameAndRenameExistingButSectionNames sigma) arsign env in
-      let sigma, newt = new_sort_variable univ_flexible sigma in
-      let sigma, predcclj = typing_fun (mk_tycon (mkSort newt)) envar sigma rtntyp in
-      let predccl = nf_evar sigma predcclj.uj_val in
+      let sigma, predcclj = typing_fun None envar sigma rtntyp in
+      let sigma, predccltj = Coercion.inh_coerce_to_sort ?loc !!envar sigma predcclj in
+      let predccl = nf_evar sigma predccltj.utj_val in
       [sigma, predccl, building_arsign]
   in
   List.map

--- a/pretyping/evarsolve.ml
+++ b/pretyping/evarsolve.ml
@@ -1669,7 +1669,7 @@ and evar_define unify flags ?(choose=false) ?(imitate_defs=true) env evd pbty (e
     (* so we recheck acyclicity *)
     if occur_evar_upto_types evd' evk body then raise (OccurCheckIn (evd',body));
     (* needed only if an inferred type *)
-    let evd', body = refresh_universes pbty env evd' body in
+    let evd', body = refresh_universes ~status:univ_flexible ~refreshset:true pbty env evd' body in
     instantiate_evar unify flags evd' evk body
   with
     | NotEnoughInformationToProgress sols ->

--- a/test-suite/bugs/closed/bug_10015.v
+++ b/test-suite/bugs/closed/bug_10015.v
@@ -1,0 +1,12 @@
+Set Universe Polymorphism.
+Fixpoint type_vector@{i} (n : nat) : Type@{i+1} :=
+  match n return Type@{i+1} with O => unit | S m => type_vector m * Type@{i} end.
+Definition bar@{i j} (b : bool) : Type@{max(i+1,j+1)} :=
+  match b return Type@{max(i+1,j+1)} with
+  | true => Type@{i}
+  | false => Type@{j}
+  end.
+Check (fun (b : bool) (x : False) =>
+  match x
+  return match b with true => unit | false => Set end
+  with end).

--- a/test-suite/bugs/closed/bug_10035.v
+++ b/test-suite/bugs/closed/bug_10035.v
@@ -1,0 +1,13 @@
+Check (fun b : bool => match b with true => Set  | false => unit end).
+Check (fun b : bool => match b with true => unit | false => Set  end).
+Check (
+  let X : Type@{_} := _ in
+  let a : X := unit in
+  (* already at this point, X := Set *)
+  let b : X := Set in 3).
+Definition foo (b : bool) : Set :=
+  match b return _ with true => unit | false => nat end.
+Definition foo' (b : bool) : Set :=
+  match b with true => unit | false => nat end.
+Definition foo'' (b : bool) : Prop :=
+  match b return _ with true => True | false => False end.


### PR DESCRIPTION
Fixes #10015.

Kind: fix

When given a return annotation, rather than inventing a new level `newt` and checking that `T : Type@{newt}`, we pretype `T` without a type hint, then coerce the result to be a type, which doesn't invent a new level if the type of `T` is already inferred to be a sort.
An alternative approach would be to support an `IsType` constraint in `pretype` or to have cases take both `pretype` and `pretype_type` as arguments rather than just `pretype`.

The `coerce_to_sort` call is enough to not regress on the `return _` cases in the test suite, but there is a regression in that `return (match b in bool with true => unit | false => Set end)` no longer works (the inner match is inferred to `return Set` from the first branch, and that fails when checking the second branch, while before the hint "this should be in Type@{i}" was enough to make this go through). I'll investigate how hard it is to have `match b with true => unit | false => Set end` always work before making this a non-draft PR.

- [x] Added test to test-suite