### PR TITLE
Refresh Set when defining evars up to cumulativity, flexibly.

### DIFF
--- a/doc/sphinx/language/gallina-extensions.rst
+++ b/doc/sphinx/language/gallina-extensions.rst
@@ -1956,25 +1956,6 @@ Explicit displaying of implicit arguments for pretty-printing
 
 .. seealso:: :flag:`Printing All`.
 
-Interaction with subtyping
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-When an implicit argument can be inferred from the type of more than
-one of the other arguments, then only the type of the first of these
-arguments is taken into account, and not an upper type of all of them.
-As a consequence, the inference of the implicit argument of “=” fails
-in
-
-.. coqtop:: all
-
-   Fail Check nat = Prop.
-
-but succeeds in
-
-.. coqtop:: all
-
-   Check Prop = nat.
-
 
 Deactivation of implicit arguments for parsing
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/pretyping/evarsolve.ml
+++ b/pretyping/evarsolve.ml
@@ -1669,7 +1669,7 @@ and evar_define unify flags ?(choose=false) ?(imitate_defs=true) env evd pbty (e
     (* so we recheck acyclicity *)
     if occur_evar_upto_types evd' evk body then raise (OccurCheckIn (evd',body));
     (* needed only if an inferred type *)
-    let evd', body = refresh_universes pbty env evd' body in
+    let evd', body = refresh_universes ~status:univ_flexible ~refreshset:true pbty env evd' body in
     instantiate_evar unify flags evd' evk body
   with
     | NotEnoughInformationToProgress sols ->

--- a/test-suite/bugs/closed/bug_10035.v
+++ b/test-suite/bugs/closed/bug_10035.v
@@ -1,0 +1,14 @@
+Check (fun b : bool => match b with true => Set  | false => unit end).
+Check (fun b : bool => match b with true => unit | false => Set  end).
+Check (
+  let X : Type@{_} := _ in
+  let a : X := unit in
+  (* already at this point, X := Set *)
+  let b : X := Set in 3).
+Definition foo (b : bool) : Set :=
+  match b return _ with true => unit | false => nat end.
+Definition foo' (b : bool) : Set :=
+  match b with true => unit | false => nat end.
+Definition foo'' (b : bool) : Prop :=
+  match b return _ with true => True | false => False end.
+Check (nat = Set).

--- a/test-suite/bugs/closed/bug_3281.v
+++ b/test-suite/bugs/closed/bug_3281.v
@@ -1,4 +1,4 @@
-Fail Lemma foo : @eq _ nat Type.
+Lemma foo_ : @eq _ nat Type. Admitted.
 Fail Lemma foo : @eq Set nat Type.
 
 Lemma foo : @eq Type nat Type. Admitted.

--- a/test-suite/bugs/closed/bug_5208.v
+++ b/test-suite/bugs/closed/bug_5208.v
@@ -66,9 +66,9 @@ Section poly.
 
   Fixpoint get_member (val : Type@{U}) p {struct p}
   : forall m, fields_get p m = @Some Type@{U} val -> member val m :=
-    match p as p return forall m, fields_get p m = @Some Type@{U} val -> member@{U} val m with
+    match p as p return forall m, fields_get p m = @Some Type@{U} val -> member@{} val m with
       | xH => fun m =>
-        match m as m return fields_get xH m = @Some Type@{U} val -> member@{U} val m with
+        match m as m return fields_get xH m = @Some Type@{U} val -> member@{} val m with
         | pm_Leaf => fun pf : None = @Some Type@{U} _ =>
                        match pf in _ = Z return match Z with
                                                 | Some _ => _
@@ -86,19 +86,19 @@ Section poly.
                                   | eq_refl => tt
                                   end
         | pm_Branch _ (Some x) _ => fun pf : @Some Type@{U} x = @Some Type@{U} val =>
-                                      match eq_sym pf in _ = Z return member@{U} val (pm_Branch _ Z _) with
+                                      match eq_sym pf in _ = Z return member@{} val (pm_Branch _ Z _) with
                                       | eq_refl => pmm_H
                                       end
         end
       | xO p' => fun m =>
-        match m as m return fields_get (xO p') m = @Some Type@{U} val -> member@{U} val m with
+        match m as m return fields_get (xO p') m = @Some Type@{U} val -> member@{} val m with
         | pm_Leaf => fun pf : fields_get p' pm_Leaf = @Some Type@{U} val =>
                        @get_member _ p' pm_Leaf pf
         | pm_Branch l _ _ => fun pf : fields_get p' l = @Some Type@{U} val =>
                        @pmm_L _ _ _ _ (@get_member _ p' l pf)
         end
       | xI p' => fun m =>
-        match m as m return fields_get (xI p') m = @Some Type@{U} val -> member@{U} val m with
+        match m as m return fields_get (xI p') m = @Some Type@{U} val -> member@{} val m with
         | pm_Leaf => fun pf : fields_get p' pm_Leaf = @Some Type@{U} val =>
                        @get_member _ p' pm_Leaf pf
         | pm_Branch l _ r => fun pf : fields_get p' r = @Some Type@{U} val =>

--- a/test-suite/success/polymorphism.v
+++ b/test-suite/success/polymorphism.v
@@ -460,5 +460,5 @@ Module ObligationRegression.
   (** Test for a regression encountered when fixing obligations for
       stronger restriction of universe context. *)
   Require Import CMorphisms.
-  Check trans_co_eq_inv_arrow_morphism@{_ _ _ _ _  _ _ _}.
+  Check trans_co_eq_inv_arrow_morphism@{_ _ _ _ _ _}.
 End ObligationRegression.


### PR DESCRIPTION
Currently, we solve a problem `Set <= ?X` by `X := Set`, which is less general than `X := Type@{i}, Set <= i` for a flexible `i` which can be collapsed to `Set`.

**Kind:** bug fix

Fixes / closes #10035

- [x] Added / updated test-suite
