### PR TITLE
Install byte version of coqidetop.

### DIFF
--- a/ide/dune
+++ b/ide/dune
@@ -23,6 +23,11 @@
  (libraries coq.toplevel coqide-server.protocol)
  (link_flags -linkall))
 
+(install
+ (section bin)
+ (package coqide-server)
+ (files (idetop.bc as coqidetop.byte)))
+
 ; IDE Client
 (library
  (name coqide_gui)


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** infrastructure.


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #10039

I applied the suggestions by @MSoegtropIMC in #10039 for more consistency in naming of executable files.

I am still left wondering about the need to install `fake_ide` (I think we had discussed it earlier). If it needs to be installed, then it should have a `coq` prefix I think.