### PR TITLE
[Classes] Use prepare_parameter from DeclareDef.

### DIFF
--- a/vernac/comAssumption.ml
+++ b/vernac/comAssumption.ml
@@ -173,6 +173,11 @@ let do_assumptions ~pstate ~program_mode kind nl l =
       uvars, (coe,t,imps))
       Univ.LSet.empty l
   in
+  (* XXX: Using `DeclareDef.prepare_parameter` here directly is not
+     possible as we indeed declare several parameters; however,
+     restrict_universe_context should be called in a centralized place
+     IMO, thus I think we should adapt `prepare_parameter` to handle
+     this case too. *)
   let sigma = Evd.restrict_universe_context sigma uvars in
   let uctx = Evd.check_univ_decl ~poly:(pi2 kind) sigma udecl in
   let ubinders = Evd.universe_binders sigma in


### PR DESCRIPTION
This code was originally part of #8811, authored by Gaëtan Gilbert.

It seems we are not very consistent on what we do when we use
`ParameterEntry`, specially w.r.t. universes but as code cleanup
progresses we will have a better view.

Co-authored-by: Gaëtan Gilbert <gaetan.gilbert@skyskimmer.net>
