### PR TITLE
[Classes] Some refactoring on proof save preparation.

### DIFF
--- a/vernac/classes.mli
+++ b/vernac/classes.mli
@@ -31,6 +31,7 @@ val declare_instance : ?warn:bool -> env -> Evd.evar_map ->
 val existing_instance : bool -> qualid -> Hints.hint_info_expr option -> unit
 (** globality, reference, optional priority and pattern information *)
 
+(* Unused in the main codebase *)
 val declare_instance_constant :
   typeclass ->
   Hints.hint_info_expr (** priority *) ->
@@ -41,8 +42,8 @@ val declare_instance_constant :
   UState.universe_decl ->
   bool (** polymorphic *) ->
   Evd.evar_map (** Universes *) ->
-  Constr.t (** body *) ->
-  Constr.types (** type *) ->
+  EConstr.t (** body *) ->
+  EConstr.types (** type *) ->
   unit
 
 val new_instance :


### PR DESCRIPTION
We still need to tweak a few things, in particular the conditions on
what is allowed to contain evars, but it is time to see if this works.

Note the ugly bug we have on close_proof:
```ocaml
proof_global.ml:278

  let entry_fn p (_, t) =
    let t = EConstr.Unsafe.to_constr t in
    let univstyp, body = make_body t p in
```
which means than arguments of start_proof should be pre-normalized.

This will require a lot of refactoring to be fixed properly.
