### PR TITLE
[opam] [dune] Fix opam build by correctly setting prefix.

### DIFF
--- a/coq.opam
+++ b/coq.opam
@@ -25,11 +25,8 @@ depends: [
   "num"
 ]
 
-build-env: [
-  [ COQ_CONFIGURE_PREFIX = "%{prefix}" ]
-]
-
 build: [
+  [ "./configure" "-prefix" prefix "-native-compiler" "no" ]
   [ "dune" "build" "@vodeps" ]
   [ "dune" "exec" "coq_dune" "_build/default/.vfiles.d" ]
   [ "dune" "build" "-p" name "-j" jobs ]


### PR DESCRIPTION
The OPAM build has been broken it seems since almost the beginning as
OPAM doesn't substitute variables in the almost undocumented
`build-env` form.

Packages built this way worked as Coq used a different method to
locate `coqlib`, however the value for `coqlib` was incorrect.

We set instead the right prefix using an explicit configure call.
