### PR TITLE
[CI/Azure/macOS] Fix install of OCaml through OPAM

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -59,8 +59,8 @@ jobs:
   - script: |
       set -e
       export PKG_CONFIG_PATH=/usr/local/opt/libffi/lib/pkgconfig
-      opam init -a -j "$NJOBS" --compiler=$COMPILER
-      opam switch set $COMPILER
+      opam init -a -j "$NJOBS" --compiler=ocaml-base-compiler.$COMPILER
+      opam switch set ocaml-base-compiler.$COMPILER
       eval $(opam env)
       opam update
       opam install -j "$NJOBS" num ocamlfind${FINDLIB_VER} ounit lablgtk3-sourceview3


### PR DESCRIPTION
Build currently fails with:

> [ERROR] Compiler selection '4.07.1' is ambiguous. matching packages: { ocaml.4.07.1, ocaml-base-compiler.4.07.1 }
