### PR TITLE
[elaboration] Bidirectionality hints

### DIFF
--- a/doc/changelog/02-specification-language/10049-bidi-app.rst
+++ b/doc/changelog/02-specification-language/10049-bidi-app.rst
@@ -1,0 +1,6 @@
+- New annotation in `Arguments` for bidirectionality hints: it is now possible
+  to tell type inference to use type information from the context once the `n`
+  first arguments of an application are known. The syntax is:
+  `Arguments foo x y & z`.
+  `#10049 <https://github.com/coq/coq/pull/10049>`_, by Maxime Dénès with
+  help from Enrico Tassi

--- a/doc/sphinx/language/gallina-extensions.rst
+++ b/doc/sphinx/language/gallina-extensions.rst
@@ -2448,3 +2448,45 @@ types and functions of a :g:`Uint63` module. Said module is not produced by
 extraction. Instead, it has to be provided by the user (if they want to compile
 or execute the extracted code). For instance, an implementation of this module
 can be taken from the kernel of Coq.
+
+Bidirectionality hints
+----------------------
+
+When type-checking an application, Coq normally does not use information from
+the context to infer the types of the arguments. It only checks after the fact
+that the type inferred for the application is coherent with the expected type.
+Bidirectionality hints make it possible to specify that after type-checking the
+first arguments of an application, typing information should be propagated from
+the context to help inferring the types of the remaining arguments.
+
+.. cmd:: Arguments @qualid {* @ident__1 } & {* @ident__2}
+   :name: Arguments (bidirectionality hints)
+
+   This commands tells the typechecking algorithm, when type-checking
+   applications of :n:`@qualid`, to first type-check the arguments in
+   :n:`@ident__1` and then propagate information from the typing context to
+   type-check the remaining arguments (in :n:`@ident__2`).
+
+.. example::
+
+   In a context where a coercion was declared from ``bool`` to ``nat``:
+
+   .. coqtop:: in reset
+
+      Definition b2n (b : bool) := if b then 1 else 0.
+      Coercion b2n : bool >-> nat.
+
+   Coq cannot automatically coerce existential statements over ``bool`` to
+   statements over ``nat``, because the need for inserting a coercion is known
+   only from the expected type of a subterm:
+
+   .. coqtop:: all
+
+      Fail Check (ex_intro _ true _ : exists n : nat, n > 0).
+
+   However, a suitable bidirectionality hint makes the example work:
+
+   .. coqtop:: all
+
+      Arguments ex_intro _ _ & _ _.
+      Check (ex_intro _ true _ : exists n : nat, n > 0).

--- a/pretyping/pretyping.mli
+++ b/pretyping/pretyping.mli
@@ -14,11 +14,21 @@
    into elementary ones, insertion of coercions and resolution of
    implicit arguments. *)
 
+open Names
 open Environ
 open Evd
 open EConstr
 open Glob_term
 open Ltac_pretype
+
+val add_bidirectionality_hint : GlobRef.t -> int -> unit
+(** A bidirectionality hint `n` for a global `g` tells the pretyper to use
+    typing information from the context after typing the `n` for arguments of an
+    application of `g`. *)
+
+val get_bidirectionality_hint : GlobRef.t -> int option
+
+val clear_bidirectionality_hint : GlobRef.t -> unit
 
 val interp_known_glob_level : ?loc:Loc.t -> Evd.evar_map ->
   glob_level -> Univ.Level.t

--- a/printing/prettyp.ml
+++ b/printing/prettyp.ml
@@ -304,6 +304,12 @@ let print_inductive_argument_scopes =
   print_args_data_of_inductive_ids
     Notation.find_arguments_scope (Option.has_some) print_argument_scopes
 
+let print_bidi_hints gr =
+  match Pretyping.get_bidirectionality_hint gr with
+  | None -> []
+  | Some nargs ->
+    [str "Using typing information from context after typing the " ++ int nargs ++ str " first arguments"]
+
 (*********************)
 (* "Locate" commands *)
 
@@ -841,7 +847,8 @@ let print_about_any ?loc env sigma k udecl =
 	print_name_infos ref @
 	(if Pp.ismt rb then [] else [rb]) @
 	print_opacity ref @
-	[hov 0 (str "Expands to: " ++ pr_located_qualid k)])
+  print_bidi_hints ref @
+  [hov 0 (str "Expands to: " ++ pr_located_qualid k)])
   | Syntactic kn ->
     let () = match Syntax_def.search_syntactic_definition kn with
     | [],Notation_term.NRef ref -> Dumpglob.add_glob ?loc ref

--- a/test-suite/success/BidirectionalityHints.v
+++ b/test-suite/success/BidirectionalityHints.v
@@ -1,0 +1,114 @@
+From Coq Require Import Utf8.
+Set Default Proof Using "Type".
+
+Module SimpleExamples.
+
+Axiom c : bool -> nat.
+Coercion c : bool >-> nat.
+Inductive Boxed A := Box (a : A).
+Arguments Box {A} & a.
+Check Box true : Boxed nat.
+
+(* Here we check that there is no regression due e.g. to refining arguments
+   in the wrong order *)
+Axiom f : forall b : bool, (if b then bool else nat) -> Type.
+Check f true true : Type.
+Arguments f & _ _.
+Check f true true : Type.
+
+End SimpleExamples.
+
+Module Issue7910.
+
+Local Set Universe Polymorphism.
+
+(** Telescopes *)
+Inductive tele : Type :=
+  | TeleO : tele
+  | TeleS {X} (binder : X → tele) : tele.
+
+Arguments TeleS {_} _.
+
+(** The telescope version of Coq's function type *)
+Fixpoint tele_fun (TT : tele) (T : Type) : Type :=
+  match TT with
+  | TeleO => T
+  | TeleS b => ∀ x, tele_fun (b x) T
+  end.
+
+Notation "TT -t> A" :=
+  (tele_fun TT A) (at level 99, A at level 200, right associativity).
+
+(** An eliminator for elements of [tele_fun].
+    We use a [fix] because, for some reason, that makes stuff print nicer
+    in the proofs in iris:bi/lib/telescopes.v *)
+Definition tele_fold {X Y} {TT : tele} (step : ∀ {A : Type}, (A → Y) → Y) (base : X → Y)
+  : (TT -t> X) → Y :=
+  (fix rec {TT} : (TT -t> X) → Y :=
+     match TT as TT return (TT -t> X) → Y with
+     | TeleO => λ x : X, base x
+     | TeleS b => λ f, step (λ x, rec (f x))
+     end) TT.
+Arguments tele_fold {_ _ !_} _ _ _ /.
+
+(** A sigma-like type for an "element" of a telescope, i.e. the data it
+  takes to get a [T] from a [TT -t> T]. *)
+Inductive tele_arg : tele → Type :=
+| TargO : tele_arg TeleO
+(* the [x] is the only relevant data here *)
+| TargS {X} {binder} (x : X) : tele_arg (binder x) → tele_arg (TeleS binder).
+
+Definition tele_app {TT : tele} {T} (f : TT -t> T) : tele_arg TT → T :=
+  λ a, (fix rec {TT} (a : tele_arg TT) : (TT -t> T) → T :=
+     match a in tele_arg TT return (TT -t> T) → T with
+     | TargO => λ t : T, t
+     | TargS x a => λ f, rec a (f x)
+     end) TT a f.
+Arguments tele_app {!_ _} & _ !_ /.
+
+Coercion tele_arg : tele >-> Sortclass.
+Coercion tele_app : tele_fun >-> Funclass.
+
+(** Operate below [tele_fun]s with argument telescope [TT]. *)
+Fixpoint tele_bind {U} {TT : tele} : (TT → U) → TT -t> U :=
+  match TT as TT return (TT → U) → TT -t> U with
+  | TeleO => λ F, F TargO
+  | @TeleS X b => λ (F : TeleS b → U) (x : X), (* b x -t> U *)
+                  tele_bind (λ a, F (TargS x a))
+  end.
+Arguments tele_bind {_ !_} _ /.
+
+(** Telescopic quantifiers *)
+Definition tforall {TT : tele} (Ψ : TT → Prop) : Prop :=
+  tele_fold (λ (T : Type) (b : T → Prop), ∀ x : T, b x) (λ x, x) (tele_bind Ψ).
+Arguments tforall {!_} _ /.
+Definition texist {TT : tele} (Ψ : TT → Prop) : Prop :=
+  tele_fold ex (λ x, x) (tele_bind Ψ).
+Arguments texist {!_} _ /.
+
+Notation "'∀..' x .. y , P" := (tforall (λ x, .. (tforall (λ y, P)) .. ))
+  (at level 200, x binder, y binder, right associativity,
+  format "∀..  x  ..  y ,  P").
+Notation "'∃..' x .. y , P" := (texist (λ x, .. (texist (λ y, P)) .. ))
+  (at level 200, x binder, y binder, right associativity,
+  format "∃..  x  ..  y ,  P").
+
+(** The actual test case *)
+Definition test {TT : tele} (t : TT → Prop) : Prop :=
+  ∀.. x, t x ∧ t x.
+
+Notation "'[TEST' x .. z , P ']'" :=
+  (test (TT:=(TeleS (fun x => .. (TeleS (fun z => TeleO)) ..)))
+        (tele_app (λ x, .. (λ z, P) ..)))
+  (x binder, z binder).
+Notation "'[TEST2' x .. z , P ']'" :=
+  (test (TT:=(TeleS (fun x => .. (TeleS (fun z => TeleO)) ..)))
+        (tele_app (TT:=(TeleS (fun x => .. (TeleS (fun z => TeleO)) ..)))
+                  (λ x, .. (λ z, P) ..)))
+  (x binder, z binder).
+
+Check [TEST (x y : nat), x = y].
+
+Check [TEST2 (x y : nat), x = y].
+
+End Issue7910.

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -752,6 +752,7 @@ GRAMMAR EXTEND Gram
         mods = OPT [ ":"; l = LIST1 arguments_modifier SEP "," -> { l } ] ->
          { let mods = match mods with None -> [] | Some l -> List.flatten l in
          let slash_position = ref None in
+         let ampersand_position = ref None in
          let rec parse_args i = function
            | [] -> []
            | `Id x :: args -> x :: parse_args (i+1) args
@@ -760,10 +761,15 @@ GRAMMAR EXTEND Gram
                 (slash_position := Some i; parse_args i args)
               else
                 user_err Pp.(str "The \"/\" modifier can occur only once")
+           | `Ampersand :: args ->
+             if Option.is_empty !ampersand_position then
+               (ampersand_position := Some i; parse_args i args)
+             else
+               user_err Pp.(str "The \"&\" modifier can occur only once")
          in
          let args = parse_args 0 (List.flatten args) in
          let more_implicits = Option.default [] more_implicits in
-         VernacArguments (qid, args, more_implicits, !slash_position, mods) }
+         VernacArguments (qid, args, more_implicits, !slash_position, !ampersand_position, mods) }
 
       | IDENT "Implicit"; "Type"; bl = reserv_list ->
 	   { VernacReserve bl }
@@ -785,6 +791,7 @@ GRAMMAR EXTEND Gram
       | IDENT "default"; IDENT "implicits" -> { [`DefaultImplicits] }
       | IDENT "clear"; IDENT "implicits" -> { [`ClearImplicits] }
       | IDENT "clear"; IDENT "scopes" -> { [`ClearScopes] }
+      | IDENT "clear"; IDENT "bidirectionality"; IDENT "hint" -> { [`ClearBidiHint] }
       | IDENT "rename" -> { [`Rename] }
       | IDENT "assert" -> { [`Assert] }
       | IDENT "extra"; IDENT "scopes" -> { [`ExtraScopes] }
@@ -810,6 +817,7 @@ GRAMMAR EXTEND Gram
              notation_scope=notation_scope;
              implicit_status = NotImplicit}] }
     | "/" -> { [`Slash] }
+    | "&" -> { [`Ampersand] }
     | "("; items = LIST1 argument_spec; ")"; sc = OPT scope ->
        { let f x = match sc, x with
          | None, x -> x | x, None -> Option.map (fun y -> CAst.make ~loc y) x

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -362,8 +362,9 @@ type nonrec vernac_expr =
       vernac_argument_status list (* Main arguments status list *) *
         (Name.t * Impargs.implicit_kind) list list (* Extra implicit status lists *) *
       int option (* Number of args to trigger reduction *) *
+      int option (* Number of args before bidirectional typing *) *
         [ `ReductionDontExposeCase | `ReductionNeverUnfold | `Rename |
-          `ExtraScopes | `Assert | `ClearImplicits | `ClearScopes |
+          `ExtraScopes | `Assert | `ClearImplicits | `ClearScopes | `ClearBidiHint |
           `DefaultImplicits ] list
   | VernacReserve of simple_binder list
   | VernacGeneralizable of (lident list) option


### PR DESCRIPTION
This feature makes it possible to tell type inference to type
applications of a global `foo` using typing information from the context
once the `n` first arguments are known.

The syntax is: `Arguments foo x y | z`.

Closes #7910.
Closes #5767.