### PR TITLE
Fix #10054: Numeral Notations without the ltac plugin.

### DIFF
--- a/plugins/syntax/g_numeral.mlg
+++ b/plugins/syntax/g_numeral.mlg
@@ -16,18 +16,17 @@ open Notation
 open Numeral
 open Pp
 open Names
-open Ltac_plugin
 open Stdarg
 open Pcoq.Prim
 
-let pr_numnot_option _ _ _ = function
+let pr_numnot_option = function
   | Nop -> mt ()
   | Warning n -> str "(warning after " ++ str n ++ str ")"
   | Abstract n -> str "(abstract after " ++ str n ++ str ")"
 
 }
 
-ARGUMENT EXTEND numnotoption
+VERNAC ARGUMENT EXTEND numnotoption
   PRINTED BY { pr_numnot_option }
 | [ ] -> { Nop }
 | [ "(" "warning" "after" bigint(waft) ")" ] -> { Warning waft }

--- a/plugins/syntax/plugin_base.dune
+++ b/plugins/syntax/plugin_base.dune
@@ -3,7 +3,7 @@
  (public_name coq.plugins.numeral_notation)
  (synopsis "Coq numeral notation plugin")
  (modules g_numeral numeral)
- (libraries coq.plugins.ltac))
+ (libraries coq.vernac))
 
 (library
  (name string_notation_plugin)


### PR DESCRIPTION
It was fairly easy, the plugin defined an argument that was only used in a vernacular extension. Thus marking it as VERNAC was enough not to link to Ltac.
