### PR TITLE
CoqIDE: recognize qualified identifiers as words.

### DIFF
--- a/ide/gtk_parsing.ml
+++ b/ide/gtk_parsing.ml
@@ -10,11 +10,11 @@
 
 let underscore = Glib.Utf8.to_unichar "_" ~pos:(ref 0)
 let prime = Glib.Utf8.to_unichar "'" ~pos:(ref 0)
-
+let dot = Glib.Utf8.to_unichar "." ~pos:(ref 0)
 
 (* TODO: avoid num and prime at the head of a word *)
 let is_word_char c =
-  Glib.Unichar.isalnum c || c = underscore || c = prime
+  Glib.Unichar.isalnum c || c = underscore || c = prime || c = dot
 
 
 let starts_word (it:GText.iter) =


### PR DESCRIPTION
Fixes coq/coq#10062.
The implementation is rough, and does not deal with leading, trailing, or doubled periods, but the same can be said of the current handling of leading numbers or primes.

This has been a recurring pain point in my development workflow when dealing with unimported modules.

**Kind:** feature
