### PR TITLE
CI: run coqchk without -silent

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -169,7 +169,15 @@ before_script:
     - not-a-real-job
   script:
     - cd _install_ci
-    - find lib/coq/ -name '*.vo' -print0 | xargs -0 bin/coqchk -silent -o -m -coqlib lib/coq/
+    - find lib/coq/ -name '*.vo' -fprint0 vofiles
+    - xargs -0 --arg-file=vofiles bin/coqchk -o -m -coqlib lib/coq/ > ../coqchk.log 2>&1 || touch coqchk.failed
+    - tail -n 1000 ../coqchk.log # the log is too big for gitlab so pipe to a file and display the tail
+    - "[ ! -f coqchk.failed ]" # needs quoting for yml syntax reasons
+  artifacts:
+    name: "$CI_JOB_NAME.logs"
+    paths:
+      - coqchk.log
+    expire_in: 1 month
 
 .ci-template:
   stage: test


### PR DESCRIPTION
Since it's in its own job it won't pollute the log, and that way if
some issue happens it will be easier to tell what's going on.
