### PR TITLE
Faster renaming of shadowed variables in evar instance creation.

### DIFF
--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -331,21 +331,16 @@ let push_rel_decl_to_named_context
   let map_decl f d =
     NamedDecl.map_constr f d
   in
-  let replace_var_named_declaration id0 id nc =
-    let rec replace = function
-    | [] -> false, []
-    | decl :: nc ->
-      let seen, nc = replace nc in
-      if seen then
-        let vsubst = [id0 , mkVar id] in
-        true, (map_decl (fun c -> replace_vars vsubst c) decl) :: nc
-      else if Id.equal id0 (NamedDecl.get_id decl) then
-        true, (NamedDecl.set_id id decl) :: nc
-      else
-        false, decl :: nc
-    in
-    let (_, nc) = replace nc in
-    nc
+  let rec replace_var_named_declaration id0 id = function
+  | [] -> []
+  | decl :: nc ->
+    if Id.equal id0 (NamedDecl.get_id decl) then
+      (* Stop here, the variable cannot occur before its definition *)
+      (NamedDecl.set_id id decl) :: nc
+    else
+      let nc = replace_var_named_declaration id0 id nc in
+      let vsubst = [id0 , mkVar id] in
+      map_decl (fun c -> replace_vars vsubst c) decl :: nc
   in
   let extract_if_neq id = function
     | Anonymous -> None

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -331,11 +331,21 @@ let push_rel_decl_to_named_context
   let map_decl f d =
     NamedDecl.map_constr f d
   in
-  let replace_var_named_declaration id0 id decl =
-    let id' = NamedDecl.get_id decl in
-    let id' = if Id.equal id0 id' then id else id' in
-    let vsubst = [id0 , mkVar id] in
-    decl |> NamedDecl.set_id id' |> map_decl (replace_vars vsubst)
+  let replace_var_named_declaration id0 id nc =
+    let rec replace = function
+    | [] -> false, []
+    | decl :: nc ->
+      let seen, nc = replace nc in
+      if seen then
+        let vsubst = [id0 , mkVar id] in
+        true, (map_decl (fun c -> replace_vars vsubst c) decl) :: nc
+      else if Id.equal id0 (NamedDecl.get_id decl) then
+        true, (NamedDecl.set_id id decl) :: nc
+      else
+        false, decl :: nc
+    in
+    let (_, nc) = replace nc in
+    nc
   in
   let extract_if_neq id = function
     | Anonymous -> None
@@ -366,7 +376,7 @@ let push_rel_decl_to_named_context
           context. Unless [id] is a section variable. *)
       let subst = update_var id0 id subst in
       let d = decl |> NamedDecl.of_rel_decl (fun _ -> id0) |> map_decl (csubst_subst subst) in
-      let nc = List.map (replace_var_named_declaration id0 id) nc in
+      let nc = replace_var_named_declaration id0 id nc in
       (push_var id0 subst, Id.Set.add id avoid, d :: nc)
   | Some id0 when hypnaming = FailIfConflict ->
        user_err Pp.(Id.print id0 ++ str " is already used.")


### PR DESCRIPTION
Instead of blindly renaming the variables in all the terms in the context, we only do so for those appearing after the variable being renamed. By typing, we know that the other ones cannot refer to the variable being replaced.

Fixes #9992.

I ran a benchmark, out of curiosity. It seems this is a source of a minor slowdown on some devs, but I really don't understand why. Just to be sure, I am rerunning another one to see whether the same slowdown persists or if if was noise.

The bench:
```
┌────────────────────────┬─────────────────────────┬─────────────────────────────────────────────┬─────────────────────────────────────────────┬───────────────────────────────┬───────────────────────────┐
│                        │      user time [s]      │                 CPU cycles                  │              CPU instructions               │     max resident mem [KB]     │        mem faults         │
│                        │                         │                                             │                                             │                               │                           │
│           package_name │     NEW     OLD PDIFF   │               NEW               OLD PDIFF   │               NEW               OLD PDIFF   │        NEW        OLD PDIFF   │     NEW    OLD    PDIFF   │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼───────────────────────────┤
│           coq-compcert │ 1017.92 1029.75 -1.15 % │     2838629398265     2870010534074 -1.09 % │     4398734522869     4398386343121 +0.01 % │    1042472    1042152 +0.03 % │     173    176    -1.70 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼───────────────────────────┤
│              coq-flocq │  594.41  598.68 -0.71 % │     1654497349546     1665527718808 -0.66 % │     2330472681838     2330545900381 -0.00 % │    1243812    1243808 +0.00 % │     266    169   +57.40 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼───────────────────────────┤
│          coq-fourcolor │ 2543.17 2560.05 -0.66 % │     7091795744469     7140113831384 -0.68 % │    12956147896432    12956760628646 -0.00 % │     971716     922328 +5.35 % │       1      0     +nan % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼───────────────────────────┤
│            coq-unimath │ 2713.70 2729.28 -0.57 % │     7558146865237     7602670138999 -0.59 % │    13602904345751    13607996488978 -0.04 % │     911896     910288 +0.18 % │     275    446   -38.34 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼───────────────────────────┤
│  coq-mathcomp-fingroup │   55.46   55.71 -0.45 % │      154549453239      155145726882 -0.38 % │      202488711203      203493878543 -0.49 % │     578896     579408 -0.09 % │       5      7   -28.57 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼───────────────────────────┤
│  coq-mathcomp-solvable │  203.66  204.26 -0.29 % │      567379259912      570190010916 -0.49 % │      761811320977      767171576386 -0.70 % │     805640     805316 +0.04 % │      13     79   -83.54 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼───────────────────────────┤
│     coq-mathcomp-field │  240.30  240.64 -0.14 % │      669115484275      670576973554 -0.22 % │      961149192077      961512248254 -0.04 % │     771412     771684 -0.04 % │       2     13   -84.62 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼───────────────────────────┤
│             coq-geocoq │ 1999.56 2001.89 -0.12 % │     5580578552925     5588121745411 -0.13 % │     8119312339557     8119396483858 -0.00 % │    1202692    1202780 -0.01 % │     177    180    -1.67 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼───────────────────────────┤
│   coq-mathcomp-algebra │  174.86  174.82 +0.02 % │      487356123090      487452703455 -0.02 % │      609889926562      609977733281 -0.01 % │     634780     634500 +0.04 % │      15      5  +200.00 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼───────────────────────────┤
│        coq-lambda-rust │ 2084.53 2083.77 +0.04 % │     5810844696456     5802229268967 +0.15 % │     7986567546429     7986457486494 +0.00 % │    1380572    1406400 -1.84 % │       0      0     +nan % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼───────────────────────────┤
│ coq-mathcomp-character │  204.88  204.34 +0.26 % │      570283786160      569429027562 +0.15 % │      765175485665      765434103302 -0.03 % │    1080340    1066488 +1.30 % │     125     16  +681.25 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼───────────────────────────┤
│             coq-sf-plf │   41.90   41.78 +0.29 % │      117853545776      117753124130 +0.09 % │      150556609037      151226224808 -0.44 % │     493976     494132 -0.03 % │     151     22  +586.36 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼───────────────────────────┤
│              coq-color │  708.53  706.30 +0.32 % │     1981829522251     1972038621471 +0.50 % │     2373166104107     2373057749522 +0.00 % │    1342736    1391300 -3.49 % │     164    156    +5.13 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼───────────────────────────┤
│        coq-fiat-crypto │ 4171.38 4156.73 +0.35 % │    11594090954607    11543746418731 +0.44 % │    18412505646860    18439879778737 -0.15 % │    2631392    2655144 -0.89 % │    1133    816   +38.85 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼───────────────────────────┤
│         coq-coquelicot │   75.27   74.99 +0.37 % │      206694603230      206519559191 +0.08 % │      248732878628      248945200144 -0.09 % │     680736     680896 -0.02 % │     373    117  +218.80 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼───────────────────────────┤
│              coq-verdi │  123.85  123.38 +0.38 % │      343904032370      342952583333 +0.28 % │      443470161835      443672920658 -0.05 % │     594872     596400 -0.26 % │       8      8    +0.00 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼───────────────────────────┤
│          coq-fiat-core │  109.58  109.06 +0.48 % │      312706797389      311484398334 +0.39 % │      391923477311      391977148091 -0.01 % │     503484     503508 -0.00 % │     330    199   +65.83 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼───────────────────────────┤
│       coq-math-classes │  219.58  218.40 +0.54 % │      614211264544      611122459058 +0.51 % │      777671292944      777891162946 -0.03 % │     519548     519368 +0.03 % │      42     19  +121.05 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼───────────────────────────┤
│       coq-fiat-parsers │  700.17  696.31 +0.55 % │     1958764008875     1947282662979 +0.59 % │     2984649715744     2987269045209 -0.09 % │    2838720    2849280 -0.37 % │     274    645   -57.52 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼───────────────────────────┤
│         coq-verdi-raft │ 1366.26 1357.85 +0.62 % │     3811892697077     3788678762471 +0.61 % │     5175524452109     5178428901324 -0.06 % │    1829864    1830020 -0.01 % │       0      0     +nan % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼───────────────────────────┤
│            coq-bignums │   72.50   71.86 +0.89 % │      201774501585      200218349643 +0.78 % │      267273071830      267026322993 +0.09 % │     500628     500720 -0.02 % │     181    145   +24.83 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼───────────────────────────┤
│               coq-hott │  346.86  343.74 +0.91 % │      943438638433      934592253647 +0.95 % │     1429018389746     1429110935613 -0.01 % │     479832     479832 +0.00 % │     475    260   +82.69 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼───────────────────────────┤
│ coq-mathcomp-odd-order │ 1546.89 1530.65 +1.06 % │     4311489145928     4266900145240 +1.04 % │     7241250219237     7277321008106 -0.50 % │    1257032    1342080 -6.34 % │      41    102   -59.80 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼───────────────────────────┤
│ coq-mathcomp-ssreflect │   40.69   40.26 +1.07 % │      112017983042      111421037170 +0.54 % │      134547898577      134563830436 -0.01 % │     529920     529824 +0.02 % │     142     10 +1320.00 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼───────────────────────────┤
│               coq-corn │ 1503.65 1486.52 +1.15 % │     4198530329877     4149247182495 +1.19 % │     6204234294760     6206912745638 -0.04 % │     836944     836816 +0.02 % │       1      1    +0.00 % │
└────────────────────────┴─────────────────────────┴─────────────────────────────────────────────┴─────────────────────────────────────────────┴───────────────────────────────┴───────────────────────────┘
```