### PR TITLE
Coqchk: encapsulating an anomaly NotConvertible into a proper user-level typing error

### DIFF
--- a/checker/mod_checking.ml
+++ b/checker/mod_checking.ml
@@ -33,7 +33,8 @@ let check_constant_declaration env kn cb =
     match Environ.body_of_constant_body env cb with
     | Some bd ->
       let j = infer env' (fst bd) in
-      conv_leq env' j.uj_type ty
+      (try conv_leq env' j.uj_type ty
+       with NotConvertible -> Type_errors.error_actual_type env j ty)
     | None -> ()
   in
   let env =


### PR DESCRIPTION
This was incidentally detected in the "validate" check for #8893 (artifact currently [here](https://gitlab.com/coq/coq/-/jobs/206921816))

Note that the corresponding configuration can happen only when the checker disagrees with the kernel, which is hopefully not the case. Better have a proper error anyway.

**Kind:** bug fix
