### PR TITLE
Do not use the constant stack in whd_betaiota_deltazeta_for_iota_state.

### DIFF
--- a/dev/ci/user-overlays/10069-ppedrot-whd-for-evar-conv-no-stack.sh
+++ b/dev/ci/user-overlays/10069-ppedrot-whd-for-evar-conv-no-stack.sh
@@ -1,0 +1,6 @@
+if [ "$CI_PULL_REQUEST" = "10069" ] || [ "$CI_BRANCH" = "whd-for-evar-conv-no-stack" ]; then
+
+    unicoq_CI_REF=whd-for-evar-conv-no-stack
+    unicoq_CI_GITURL=https://github.com/ppedrot/unicoq
+
+fi

--- a/pretyping/evarconv.mli
+++ b/pretyping/evarconv.mli
@@ -144,7 +144,7 @@ val evar_unify : Evarsolve.unifier
 (* For debugging *)
 val evar_eqappr_x : ?rhs_is_already_stuck:bool -> unify_flags ->
   env -> evar_map ->
-    conv_pb -> state * Cst_stack.t -> state * Cst_stack.t ->
+    conv_pb -> state -> state ->
       Evarsolve.unification_result
 
 val occur_rigidly : Evarsolve.unify_flags ->

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -1675,7 +1675,7 @@ let is_sort env sigma t =
 (* reduction to head-normal-form allowing delta/zeta only in argument
    of case/fix (heuristic used by evar_conv) *)
 
-let whd_betaiota_deltazeta_for_iota_state ts env sigma csts s =
+let whd_betaiota_deltazeta_for_iota_state ts env sigma s =
   let refold = false in
   let tactic_mode = false in
   let rec whrec csts s =
@@ -1696,7 +1696,8 @@ let whd_betaiota_deltazeta_for_iota_state ts env sigma csts s =
           whrec Cst_stack.empty (Stack.nth stack_o (Projection.npars p + Projection.arg p), stack'')
 	else s,csts'
       |_, ((Stack.App _|Stack.Cst _|Stack.Primitive _) :: _|[]) -> s,csts'
-  in whrec csts s
+  in
+  fst (whrec Cst_stack.empty s)
 
 let find_conclusion env sigma =
   let rec decrec env c =

--- a/pretyping/reductionops.mli
+++ b/pretyping/reductionops.mli
@@ -312,8 +312,7 @@ val betazetaevar_applist : evar_map -> int -> constr -> constr list -> constr
 (** {6 Heuristic for Conversion with Evar } *)
 
 val whd_betaiota_deltazeta_for_iota_state :
-  TransparentState.t -> Environ.env -> Evd.evar_map -> Cst_stack.t -> state ->
-  state * Cst_stack.t
+  TransparentState.t -> Environ.env -> Evd.evar_map -> state -> state
 
 (** {6 Meta-related reduction functions } *)
 val meta_instance : evar_map -> constr freelisted -> constr

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -489,8 +489,8 @@ let unfold_projection env p stk =
 let expand_key ts env sigma = function
   | Some (IsKey k) -> Option.map EConstr.of_constr (expand_table_key env k)
   | Some (IsProj (p, c)) -> 
-    let red = Stack.zip sigma (fst (whd_betaiota_deltazeta_for_iota_state ts env sigma
-                               Cst_stack.empty (c, unfold_projection env p [])))
+    let red = Stack.zip sigma (whd_betaiota_deltazeta_for_iota_state ts env sigma
+                               (c, unfold_projection env p []))
     in if EConstr.eq_constr sigma (EConstr.mkProj (p, c)) red then None else Some red
   | None -> None
 
@@ -597,8 +597,8 @@ let constr_cmp pb env sigma flags t u =
     None
     
 let do_reduce ts (env, nb) sigma c =
-  Stack.zip sigma (fst (whd_betaiota_deltazeta_for_iota_state
-		  ts env sigma Cst_stack.empty (c, Stack.empty)))
+  Stack.zip sigma (whd_betaiota_deltazeta_for_iota_state
+                  ts env sigma (c, Stack.empty))
 
 let isAllowedEvar sigma flags c = match EConstr.kind sigma c with
   | Evar (evk,_) -> not (Evar.Set.mem evk flags.frozen_evars)


### PR DESCRIPTION
There is no point, it is always called with refolding turned off.

Overlays:
- https://github.com/unicoq/unicoq/pull/27