### PR TITLE
[Record] Use a record to gather field declaration attributes

### DIFF
--- a/stm/vernac_classifier.ml
+++ b/stm/vernac_classifier.ml
@@ -137,7 +137,7 @@ let classify_vernac e =
         | Constructors l -> List.map (fun (_,({v=id},_)) -> id) l
         | RecordDecl (oid,l) -> (match oid with Some {v=x} -> [x] | _ -> []) @
            CList.map_filter (function
-            | ((_,AssumExpr({v=Names.Name n},_)),_),_ -> Some n
+            | AssumExpr({v=Names.Name n},_), _ -> Some n
             | _ -> None) l) l in
         VtSideff (List.flatten ids), VtLater
     | VernacScheme l ->

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -447,8 +447,10 @@ GRAMMAR EXTEND Gram
 *)
   (* ... with coercions *)
   record_field:
-  [ [ bd = record_binder; pri = OPT [ "|"; n = natural -> { n } ];
-      ntn = decl_notation -> { (bd,pri),ntn } ] ]
+  [ [ bd = record_binder; rf_priority = OPT [ "|"; n = natural -> { n } ];
+      rf_notation = decl_notation -> {
+      let rf_subclass, rf_decl = bd in
+      rf_decl, { rf_subclass ; rf_priority ; rf_notation } } ] ]
   ;
   record_fields:
     [ [ f = record_field; ";"; fs = record_fields -> { f :: fs }

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -446,15 +446,15 @@ open Pputils
     | Some true -> str" :>"
     | Some false -> str" :>>"
 
-  let pr_record_field ((x, pri), ntn) =
+  let pr_record_field (x, { rf_subclass = oc ; rf_priority = pri ; rf_notation = ntn }) =
     let env = Global.env () in
     let sigma = Evd.from_env env in
     let prx = match x with
-      | (oc,AssumExpr (id,t)) ->
+      | AssumExpr (id,t) ->
         hov 1 (pr_lname id ++
                  pr_oc oc ++ spc() ++
                  pr_lconstr_expr env sigma t)
-      | (oc,DefExpr(id,b,opt)) -> (match opt with
+      | DefExpr(id,b,opt) -> (match opt with
           | Some t ->
             hov 1 (pr_lname id ++
                      pr_oc oc ++ spc() ++

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -699,8 +699,7 @@ let definition_structure udecl kind ~template cum poly finite records =
     let map impls = implpars @ Impargs.lift_implicits (succ (List.length params)) impls in
     let data = List.map (fun (arity, implfs, fields) -> (arity, List.map map implfs, fields)) data in
     let map (arity, implfs, fields) (is_coe, id, _, cfs, idbuild, _) =
-      let coers = List.map (fun (((coe, _), _), _) -> coe) cfs in
-      let coe = List.map (fun coe -> not (Option.is_empty coe)) coers in
+      let coe = List.map (fun (((coe, _), _), _) -> not (Option.is_empty coe)) cfs in
       id.CAst.v, idbuild, arity, implfs, fields, is_coe, coe
     in
     let data = List.map2 map data records in

--- a/vernac/record.mli
+++ b/vernac/record.mli
@@ -33,7 +33,7 @@ val definition_structure :
   (coercion_flag *
   Names.lident *
   local_binder_expr list *
-  (local_decl_expr with_instance with_priority with_notation) list *
+  (local_decl_expr * record_field_attr) list *
   Id.t * constr_expr option) list ->
   GlobRef.t list
 

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -684,7 +684,7 @@ let vernac_record ~template udecl cum k poly finite records =
     let () =
       if Dumpglob.dump () then
         let () = Dumpglob.dump_definition id false "rec" in
-        let iter (((_, x), _), _) = match x with
+        let iter (x, _) = match x with
         | Vernacexpr.AssumExpr ({loc;v=Name id}, _) ->
           Dumpglob.dump_definition (make ?loc id) false "proj"
         | _ -> ()
@@ -743,7 +743,8 @@ let vernac_inductive ~atts cum lo finite indl =
     let (id, bl, c, l) = Option.get is_defclass in
     let (coe, (lid, ce)) = l in
     let coe' = if coe then Some true else None in
-    let f = (((coe', AssumExpr ((make ?loc:lid.loc @@ Name lid.v), ce)), None), []) in
+    let f = AssumExpr ((make ?loc:lid.loc @@ Name lid.v), ce),
+            { rf_subclass = coe' ; rf_priority = None ; rf_notation = [] } in
     vernac_record ~template udecl cum (Class true) poly finite [id, bl, c, None, [f]]
   else if List.for_all is_record indl then
     (* Mutual record case *)

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -143,13 +143,16 @@ type decl_notation = lstring * constr_expr * scope_name option
 type simple_binder = lident list  * constr_expr
 type class_binder = lident * constr_expr list
 type 'a with_coercion = coercion_flag * 'a
-type 'a with_instance = instance_flag * 'a
-type 'a with_notation = 'a * decl_notation list
-type 'a with_priority = 'a * int option
+(* Attributes of a record field declaration *)
+type record_field_attr = {
+  rf_subclass: instance_flag; (* the projection is an implicit coercion or an instance *)
+  rf_priority: int option; (* priority of the instance, if relevant *)
+  rf_notation: decl_notation list;
+  }
 type constructor_expr = (lident * constr_expr) with_coercion
 type constructor_list_or_record_decl_expr =
   | Constructors of constructor_expr list
-  | RecordDecl of lident option * local_decl_expr with_instance with_priority with_notation list
+  | RecordDecl of lident option * (local_decl_expr * record_field_attr) list
 type inductive_expr =
   ident_decl with_coercion * local_binder_expr list * constr_expr option * inductive_kind *
     constructor_list_or_record_decl_expr


### PR DESCRIPTION
This is a first cleaning step towards a fix for #4796 (the ability to selectively disable the fact that a projection is *canonical*).

Field declarations come with a lot of decorations, as in the [PreOrder class](https://github.com/coq/coq/blob/45dcc1248cd2bdf00a2bcead69d6b2ed78afc51d/theories/Classes/RelationClasses.v#L63):
> PreOrder_Reflexive :> Reflexive R | 2 ;

or in the [PreCategory example](https://github.com/coq/coq/blob/45dcc1248cd2bdf00a2bcead69d6b2ed78afc51d/test-suite/bugs/closed/HoTT_coq_061.v#L34):
> Compose : forall s d d', Morphism d d' -> Morphism s d -> Morphism s d' where "f 'o' g" := (Compose f g)

As I easily get confused with nested tuples of boolean option lists, this PR introduces a record with named fields.

The first two commits are a minor cleaning refactoring that should avoid the creation of unnecessary intermediate lists.