### PR TITLE
Revert "Update behavior of -emacs to support showing diffs in ProofGeneral (master branch)"

### DIFF
--- a/toplevel/coqargs.ml
+++ b/toplevel/coqargs.ml
@@ -34,7 +34,7 @@ let set_type_in_type () =
 
 (******************************************************************************)
 
-type color = [`ON | `AUTO | `EMACS | `OFF]
+type color = [`ON | `AUTO | `OFF]
 
 type native_compiler = NativeOff | NativeOn of { ondemand : bool }
 
@@ -171,7 +171,7 @@ let add_load_vernacular opts verb s =
 (** Options for proof general *)
 let set_emacs opts =
   Printer.enable_goal_tags_printing := true;
-  { opts with color = `EMACS; print_emacs = true }
+  { opts with color = `OFF; print_emacs = true }
 
 let set_color opts = function
 | "yes" | "on" -> { opts with color = `ON }

--- a/toplevel/coqargs.mli
+++ b/toplevel/coqargs.mli
@@ -8,7 +8,7 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-type color = [`ON | `AUTO | `EMACS | `OFF]
+type color = [`ON | `AUTO | `OFF]
 
 val default_toplevel : Names.DirPath.t
 

--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -113,7 +113,6 @@ let fatal_error_exn exn =
 let init_color opts =
   let has_color = match opts.color with
   | `OFF -> false
-  | `EMACS -> false
   | `ON -> true
   | `AUTO ->
     Terminal.has_style Unix.stdout &&
@@ -134,13 +133,10 @@ let init_color opts =
       Topfmt.default_styles (); false                 (* textual markers, no color *)
     end
   in
-  if opts.color = `EMACS then
-    Topfmt.set_emacs_print_strings ()
-  else if not term_color then begin
-      Proof_diffs.write_color_enabled term_color;
-    if Proof_diffs.show_diffs () then
-      (prerr_endline "Error: -diffs requires enabling -color"; exit 1)
-  end;
+  if not term_color then
+    Proof_diffs.write_color_enabled term_color;
+  if Proof_diffs.show_diffs () && not term_color then
+    (prerr_endline "Error: -diffs requires enabling -color"; exit 1);
   Topfmt.init_terminal_output ~color:term_color
 
 let print_style_tags opts =

--- a/vernac/topfmt.ml
+++ b/vernac/topfmt.ml
@@ -196,18 +196,6 @@ let init_tag_map styles =
 let default_styles () =
   init_tag_map (default_tag_map ())
 
-let set_emacs_print_strings () =
-  let open Terminal in
-  let diff = "diff." in
-  List.iter (fun b ->
-      let (name, attrs) = b in
-      if diff = (String.sub name 0 (String.length diff)) then
-        tag_map := CString.Map.add name
-          { attrs with prefix = Some (Printf.sprintf "<%s>" name);
-                       suffix = Some (Printf.sprintf "</%s>" name) }
-          !tag_map)
-    (CString.Map.bindings !tag_map)
-
 let parse_color_config str =
   let styles = Terminal.parse str in
   init_tag_map styles
@@ -276,13 +264,13 @@ let make_printing_functions () =
     let (tpfx, ttag) = split_tag tag in
     if tpfx <> end_pfx then
       let style = get_style ttag in
-      match style.Terminal.prefix with Some s -> Format.pp_print_as ft 0 s | None -> () in
+      match style.Terminal.prefix with Some s -> Format.pp_print_string ft s | None -> () in
 
   let print_suffix ft tag =
     let (tpfx, ttag) = split_tag tag in
     if tpfx <> start_pfx then
       let style = get_style ttag in
-      match style.Terminal.suffix with Some s -> Format.pp_print_as ft 0 s | None -> () in
+      match style.Terminal.suffix with Some s -> Format.pp_print_string ft s | None -> () in
 
   print_prefix, print_suffix
 

--- a/vernac/topfmt.mli
+++ b/vernac/topfmt.mli
@@ -46,7 +46,6 @@ val emacs_logger : ?pre_hdr:Pp.t -> Feedback.level -> Pp.t -> unit
 val default_styles : unit -> unit
 val parse_color_config : string -> unit
 val dump_tags : unit -> (string * Terminal.style) list
-val set_emacs_print_strings : unit -> unit
 
 (** Initialization of interpretation of tags *)
 val init_terminal_output : color:bool -> unit


### PR DESCRIPTION

This reverts commit 6ef5a36a69e9116344af7fae4434a487be9c3b0e.

PR #10019 said:
>Since these tags are generated only when -emacs is passed and diffs
are on, it shouldn't present any compatibility issues.

This is incorrect, PG is seeing <diff.added> etc without any special
setting (try eg "Fail Check nat + nat."). Please resubmit the PR once
this is fixed.

