### PR TITLE
Make progress toward #9411: reject new undefined references.

### DIFF
--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -181,7 +181,21 @@ suppress_warnings = ["misc.highlighting_failure"]
 todo_include_todos = False
 
 # Extra warnings, including undefined references
-nitpicky = False
+nitpicky = True
+
+nitpick_ignore = [ ('token', token) for token in [
+    'tactic',
+    # 142 occurrences currently sort of defined in the ltac chapter,
+    # but is it the right place?
+    'module',
+    'redexpr',
+    'modpath',
+    'dirpath',
+    'collection',
+    'term_pattern',
+    'term_pattern_string',
+    'command',
+    'symbol' ]]
 
 # -- Options for HTML output ----------------------------------------------
 


### PR DESCRIPTION
I am tired of being a human type-checker so this PR makes some step towards making more Sphinx warnings fatal.

We fix a number of undefined tokens, and we list the rest (10 of them) explicitly in `doc/sphinx/conf.py` which means that any new unlisted undefined token will produce a fatal warning.

This list should be seen as a TODO. Once it is emptied, #9411 can be closed.

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** documentation / fix / infrastructure.