### PR TITLE
Show diffs in error messages only if Diffs is enabled

### DIFF
--- a/test-suite/output/Error_msg_diffs.v
+++ b/test-suite/output/Error_msg_diffs.v
@@ -1,4 +1,4 @@
-(* coq-prog-args: ("-color" "on" "-async-proofs" "off") *)
+(* coq-prog-args: ("-color" "on" "-diffs" "on" "-async-proofs" "off") *)
 (* Re: -async-proofs off, see https://github.com/coq/coq/issues/9671 *)
 (* Shows diffs in an error message for an "Unable to unify" error *)
 Require Import Arith List Bool.

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -150,6 +150,7 @@ let explicit_flags =
     [print_universes; print_implicits; print_coercions; print_no_symbol] (* and more! *) ]
 
 let with_diffs pm pn =
+  if not (Proof_diffs.show_diffs ()) then pm, pn else
   try
     let tokenize_string = Proof_diffs.tokenize_string in
     Pp_diff.diff_pp ~tokenize_string pm pn


### PR DESCRIPTION
**Kind:** bug fix

Use this instead of https://github.com/coq/coq/pull/10084