### PR TITLE
Remove outdated CI sanity check from merge script.

### DIFF
--- a/dev/tools/merge-pr.sh
+++ b/dev/tools/merge-pr.sh
@@ -141,24 +141,6 @@ if [ "$LOCAL_BRANCH_COMMIT" != "$UPSTREAM_COMMIT" ]; then
     fi
 fi
 
-# Sanity check: PR has an outdated version of CI
-
-BASE_COMMIT=$(echo "$PRDATA" | jq -r '.base.sha')
-CI_FILES=(".gitlab-ci.yml" "azure-pipelines.yml")
-
-if ! git diff --quiet "$BASE_COMMIT" "$LOCAL_BRANCH_COMMIT" -- "${CI_FILES[@]}"
-then
-    warning "This PR didn't run with the latest version of CI."
-    warning "It is probably a good idea to ask for a rebase."
-    read -p "Do you want to see the diff? [Y/n] " $QUICK_CONF -r
-    echo
-    if [[ ! $REPLY =~ ^[Nn]$ ]]
-    then
-        git diff "$BASE_COMMIT" "$LOCAL_BRANCH_COMMIT" -- "${CI_FILES[@]}"
-    fi
-    ask_confirmation
-fi
-
 # Sanity check: CI failed
 
 STATUS=$(curl -s "$API/commits/$COMMIT/status")


### PR DESCRIPTION
This check has been way too frequent and mostly ignored when it was relevant, so it is completely useless. It was based anyway on a very shaky heuristics. The only good solution to this problem is a bors-like workflow, which itself is a work-in-progress.

We don't want annoying useless checks to encourage mergers to bypass checks more often than they should.

**Kind:** infrastructure.