### PR TITLE
Make detyping robust w.r.t. indexed anonymous variables

### DIFF
--- a/dev/ci/user-overlays/10135-maximedenes-detype-anonymous.sh
+++ b/dev/ci/user-overlays/10135-maximedenes-detype-anonymous.sh
@@ -1,0 +1,6 @@
+if [ "$CI_PULL_REQUEST" = "10135" ] || [ "$CI_BRANCH" = "detype-anonymous" ]; then
+
+    unicoq_CI_REF=detype-anonymous
+    unicoq_CI_GITURL=https://github.com/maximedenes/unicoq
+
+fi

--- a/dev/top_printers.ml
+++ b/dev/top_printers.ml
@@ -27,7 +27,6 @@ open Clenv
 let _ = Detyping.print_evar_arguments := true
 let _ = Detyping.print_universes := true
 let _ = Goptions.set_bool_option_value ["Printing";"Matching"] false
-let _ = Detyping.set_detype_anonymous (fun ?loc _ -> raise Not_found)
 
 (* std_ppcmds *)
 let pp   x = Pp.pp_with !Topfmt.std_ft x

--- a/pretyping/detyping.mli
+++ b/pretyping/detyping.mli
@@ -68,9 +68,6 @@ val detype_closed_glob : ?lax:bool -> bool -> Id.Set.t -> env -> evar_map -> clo
 val lookup_name_as_displayed  : env -> evar_map -> constr -> Id.t -> int option
 val lookup_index_as_renamed : env -> evar_map -> constr -> int -> int option
 
-(* XXX: This is a hack and should go away *)
-val set_detype_anonymous : (?loc:Loc.t -> int -> Id.t) -> unit
-
 val force_wildcard : unit -> bool
 val synthetize_type : unit -> bool
 

--- a/test-suite/bugs/closed/bug_10026.v
+++ b/test-suite/bugs/closed/bug_10026.v
@@ -1,0 +1,3 @@
+Require Import Coq.Lists.List.
+Set Debug RAKAM.
+Check fun _ => fold_right (fun A B => prod A B) unit _.

--- a/test-suite/bugs/closed/bug_3754.v
+++ b/test-suite/bugs/closed/bug_3754.v
@@ -281,5 +281,7 @@ Defined.
                                  (factor2 fact)).
       rewrite <- ap_p_pp; rewrite_moveL_Mp_p.
       Set Debug Tactic Unification.
-      Fail rewrite (concat_Ap ff2).
+      rewrite (concat_Ap ff2).
     Abort.
+
+End Factorization.


### PR DESCRIPTION
I don't think there's a reason to treat such variables more severely
than unbound variables. This anomaly is often raised by debug printers
(e.g. when studying complex scenarios using `Set Unification Debug`),
and so makes debugging less convenient.

Incidentally, this fixes #3754 and fixes #10026.