### PR TITLE
[Gitlab-CI/macos] Allow gtksourceview to find libffi

### DIFF
--- a/dev/build/osx/make-macos-dmg.sh
+++ b/dev/build/osx/make-macos-dmg.sh
@@ -10,6 +10,7 @@ brew install opam gnu-time gtk+ expat gtksourceview gdk-pixbuf
 brew unlink python@2
 brew link python3
 pip3 install macpack
+export PKG_CONFIG_PATH=/usr/local/opt/libffi/lib/pkgconfig
 opam init -a -y -j 2 --compiler=ocaml-base-compiler.4.07.1 default https://opam.ocaml.org
 opam switch ocaml-base-compiler.4.07.1
 eval $(opam config env)


### PR DESCRIPTION
Trying to run the `make-macos-dmg.sh` script failed while opam-installing lablgtk with:

> === ERROR while compiling conf-gtksourceview.2 ===============================#
>  context              2.0.4 | macos/x86_64 | ocaml-base-compiler.4.07.1 | https://opam.ocaml.org#b5920648
>  path                 ~/.opam/ocaml-base-compiler.4.07.1/.opam-switch/build/conf-gtksourceview.2
>  command              ~/.opam/opam-init/hooks/sandbox.sh build pkg-config --short-errors --print-errors gtksourceview-2.0
>  exit-code            1
>  env-file             ~/.opam/log/conf-gtksourceview-11300-6cc03f.env
>  output-file          ~/.opam/log/conf-gtksourceview-11300-6cc03f.out
> Package 'libffi', required by 'gobject-2.0', not found

This change should fix this issue.