### PR TITLE
Further modularization in dealing with the generic and specific parts of Coq executables

### DIFF
--- a/clib/backtrace.mli
+++ b/clib/backtrace.mli
@@ -54,6 +54,8 @@ val print_frame : frame -> string
 
 (** {5 Exception handling} *)
 
+val is_recording : bool ref
+
 val record_backtrace : bool -> unit
 (** Whether to activate the backtrace recording mechanism. Note that it will
     only work whenever the program was compiled with the [debug] flag. *)

--- a/ide/idetop.ml
+++ b/ide/idetop.ml
@@ -496,10 +496,10 @@ let msg_format = ref (fun () ->
 
 (* The loop ignores the command line arguments as the current model delegates
    its handing to the toplevel container. *)
-let loop run_mode ~opts:_ state =
-  match run_mode with
-  | Coqtop.Batch -> exit 0
-  | Coqtop.Interactive ->
+let loop copts ~opts:_ state =
+  match copts.Coqtopargs.run_mode with
+  | Coqtopargs.Batch -> exit 0
+  | Coqtopargs.Interactive ->
   let open Vernac.State in
   set_doc state.doc;
   init_signal_handler ();
@@ -571,8 +571,8 @@ let islave_parse ~opts extra_args =
   print_string (String.concat "\n" extra_args);
   run_mode, []
 
-let islave_init run_mode ~opts =
-  if run_mode = Coqtop.Batch then Flags.quiet := true;
+let islave_init copts ~opts =
+  if copts.Coqtopargs.run_mode = Coqtopargs.Batch then Flags.quiet := true;
   Coqtop.init_toploop opts
 
 let islave_default_opts =

--- a/ide/idetop.ml
+++ b/ide/idetop.ml
@@ -547,9 +547,8 @@ let rec parse = function
         msg_format := (fun () -> Xmlprotocol.Ppcmds); parse rest
   | x :: rest ->
      if String.length x > 0 && x.[0] = '-' then
-       (prerr_endline ("Unknown option " ^ x); exit 1)
-     else
-       x :: parse rest
+       Coqargs.error_wrong_arg ("Unknown option " ^ x);
+     x :: parse rest
   | [] -> []
 
 let coqidetop_specific_usage = Usage.{

--- a/interp/dumpglob.ml
+++ b/interp/dumpglob.ml
@@ -37,8 +37,9 @@ let dump_string s =
   if dump () && !glob_output != Feedback then
     output_string !glob_file s
 
-let start_dump_glob ~vfile ~vofile =
-  match !glob_output with
+let start_dump_glob ~vfile ~vofile glob_out =
+  glob_output := glob_out;
+  match glob_out with
   | MultFiles ->
       open_glob_file (Filename.chop_extension vofile ^ ".glob");
       output_string !glob_file "DIGEST ";

--- a/interp/dumpglob.mli
+++ b/interp/dumpglob.mli
@@ -8,9 +8,6 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-val start_dump_glob : vfile:string -> vofile:string -> unit
-val end_dump_glob : unit -> unit
-
 val dump : unit -> bool
 
 type glob_output =
@@ -18,6 +15,9 @@ type glob_output =
   | Feedback
   | MultFiles                   (* one glob file per .v file *)
   | File of string              (* Single file for all coqc arguments *)
+
+val start_dump_glob : vfile:string -> vofile:string -> glob_output -> unit
+val end_dump_glob : unit -> unit
 
 (* Default "NoGlob" *)
 val set_glob_output : glob_output -> unit

--- a/stm/vio_checking.ml
+++ b/stm/vio_checking.ml
@@ -11,6 +11,7 @@
 open Util
 
 let check_vio (ts,f_in) =
+  assert (not (Dumpglob.dump ()));
   let _, _, _, tasks, _ = Library.load_library_todo f_in in
   Stm.set_compilation_hints f_in;
   List.fold_left (fun acc ids -> Stm.check_task f_in tasks ids && acc) true ts

--- a/toplevel/ccompile.ml
+++ b/toplevel/ccompile.ml
@@ -136,7 +136,7 @@ let compile opts copts ~echo ~f_in ~f_out =
         ~v_file:long_f_dot_in);
 
       Dumpglob.set_glob_output copts.glob_out;
-      Dumpglob.start_dump_glob ~vfile:long_f_dot_in ~vofile:long_f_dot_out;
+      Dumpglob.start_dump_glob ~vfile:long_f_dot_in ~vofile:long_f_dot_out copts.glob_out;
       Dumpglob.dump_string ("F" ^ Names.DirPath.to_string ldir ^ "\n");
 
       let wall_clock1 = Unix.gettimeofday () in
@@ -157,6 +157,7 @@ let compile opts copts ~echo ~f_in ~f_out =
       Dumpglob.end_dump_glob ()
 
   | BuildVio | BuildVos ->
+      assert (not (Dumpglob.dump ()));
       (* We need to disable error resiliency, otherwise some errors
          will be ignored in batch mode. c.f. #6707
 
@@ -188,6 +189,7 @@ let compile opts copts ~echo ~f_in ~f_out =
 
   | Vio2Vo ->
 
+      assert (not (Dumpglob.dump ()));
       let sum, lib, univs, tasks, proofs =
         Library.load_library_todo long_f_dot_in in
       let univs, proofs = Stm.finish_tasks long_f_dot_out univs proofs tasks in

--- a/toplevel/coqargs.ml
+++ b/toplevel/coqargs.ml
@@ -69,8 +69,8 @@ type coqargs_pre = {
   load_rcfile : bool;
 
   ml_includes : Loadpath.coq_path list;
-  vo_includes : Loadpath.coq_path list;
-  vo_requires : (string * string option * bool option) list;
+  vo_includes : Loadpath.coq_path list; (* = "Add LoadPath" *)
+  vo_requires : (string * string option * bool option) list; (* = "Require [Import|Export]" *)
   (* None = No Import; Some false = Import; Some true = Export *)
 
   load_vernacular_list : (string * bool) list;

--- a/toplevel/coqargs.ml
+++ b/toplevel/coqargs.ml
@@ -486,7 +486,12 @@ let parse_args ~help ~init arglist : t * string list =
         Stm.AsyncOpts.async_proofs_never_reopen_branch = true
       }}}
     |"-test-mode" -> Vernacinterp.test_mode := true; oval
-    |"-beautify" -> Flags.beautify := true; oval
+    |"-beautify" ->
+      Flags.beautify := true;
+      (* force non asynchronous mode *)
+      { oval with config = { oval.config with stm_flags = { oval.config.stm_flags with
+        Stm.AsyncOpts.async_proofs_mode = get_async_proofs_mode opt (next())
+      }}}
     |"-bt" -> Backtrace.record_backtrace true; oval
     |"-color" -> set_color oval (next ())
     |"-config"|"--config" -> set_query oval PrintConfig

--- a/toplevel/coqargs.ml
+++ b/toplevel/coqargs.ml
@@ -24,9 +24,6 @@ let error_missing_arg s =
 (******************************************************************************)
 (* Imperative effects! This must be fixed at some point.                      *)
 (******************************************************************************)
-let set_worker_id opt s =
-  assert (s <> "master");
-  Flags.async_proofs_worker_id := s
 
 let set_type_in_type () =
   let typing_flags = Environ.typing_flags (Global.env ()) in
@@ -374,8 +371,6 @@ let parse_args ~help ~init arglist : t * string list =
       { oval with config = { oval.config with stm_flags = { oval.config.stm_flags with
         Stm.AsyncOpts.async_proofs_delegation_threshold = get_float opt (next ())
       }}}
-
-    |"-worker-id" -> set_worker_id opt (next ()); oval
 
     |"-compat" ->
       let v = G_vernac.parse_compat_version (next ()) in

--- a/toplevel/coqargs.ml
+++ b/toplevel/coqargs.ml
@@ -82,6 +82,7 @@ type coqargs_query =
   | PrintTags | PrintWhere | PrintConfig
   | PrintVersion | PrintMachineReadableVersion
   | PrintHelp of Usage.specific_usage
+  | PrintModUid of string list
 
 type coqargs_main =
   | Queries of coqargs_query list
@@ -262,14 +263,6 @@ let get_cache opt = function
   | _ ->
     error_wrong_arg ("Error: force expected after "^opt)
 
-
-let get_native_name s =
-  (* We ignore even critical errors because this mode has to be super silent *)
-  try
-    String.concat "/" [Filename.dirname s;
-      Nativelib.output_dir; Library.native_name_from_filename s]
-  with _ -> ""
-
 let to_opt_key = Str.(split (regexp " +"))
 
 let parse_option_set opt =
@@ -407,7 +400,7 @@ let parse_args ~help ~init arglist : t * string list =
       oval
 
     |"-print-mod-uid" ->
-      let s = String.concat " " (List.map get_native_name rem) in print_endline s; exit 0
+      set_query oval (PrintModUid rem) (* XXX: add more consistency tests on rem? *)
 
     |"-profile-ltac-cutoff" ->
       Flags.profile_ltac := true;

--- a/toplevel/coqargs.mli
+++ b/toplevel/coqargs.mli
@@ -77,7 +77,10 @@ type t = {
 val default : t
 
 val parse_args : help:Usage.specific_usage -> init:t -> string list -> t * string list
-val error_wrong_arg : string -> unit
+
+val fatal_error : exn -> 'a
+val error_missing_arg : string -> 'a
+val error_wrong_arg : string -> 'a
 
 val require_libs : t -> (string * string option * bool option) list
 val build_load_path : t -> Loadpath.coq_path list

--- a/toplevel/coqargs.mli
+++ b/toplevel/coqargs.mli
@@ -56,6 +56,7 @@ type coqargs_query =
   | PrintTags | PrintWhere | PrintConfig
   | PrintVersion | PrintMachineReadableVersion
   | PrintHelp of Usage.specific_usage
+  | PrintModUid of string list
 
 type coqargs_main =
   | Queries of coqargs_query list

--- a/toplevel/coqc.ml
+++ b/toplevel/coqc.ml
@@ -33,6 +33,8 @@ coqc specific options:\
 \n  -vos                   process statements but ignore opaque proofs, and produce a .vos file\
 \n  -vok                   process the file by loading .vos instead of .vo files for\
 \n                         dependencies, and produce an empty .vok file on success\
+\n  -dump-glob f           dump globalizations in file f (to be used by coqdoc)\
+\n  -noglob                do not dump globalizations\
 \n\
 \nUndocumented:\
 \n  -vio2vo                [see manual]\

--- a/toplevel/coqcargs.ml
+++ b/toplevel/coqcargs.ml
@@ -56,6 +56,8 @@ let check_compilation_output_name_consistency args =
 
 let is_dash_argument s = String.length s > 0 && s.[0] = '-'
 
+let set_no_glob opts = { opts with glob_out = Dumpglob.NoGlob }
+
 let add_compile ?echo copts s =
   if is_dash_argument s then (prerr_endline ("Unknown option " ^ s); exit 1);
   (* make the file name explicit; needed not to break up Coq loadpath stuff. *)
@@ -154,24 +156,24 @@ let parse arglist : t =
         | "-o" ->
           { oval with compilation_output_name = Some (next ()) }
         | "-quick" ->
-          set_compilation_mode oval BuildVio
+          set_no_glob (set_compilation_mode oval BuildVio)
         |"-vos" ->
           Flags.load_vos_libraries := true;
-          { oval with compilation_mode = BuildVos }
+          set_no_glob { oval with compilation_mode = BuildVos }
         |"-vok" ->
           Flags.load_vos_libraries := true;
-          { oval with compilation_mode = BuildVok }
+          set_no_glob { oval with compilation_mode = BuildVok }
 
         | "-check-vio-tasks" ->
           let tno = get_task_list (next ()) in
           let tfile = next () in
-          add_vio_task oval (tno,tfile)
+          add_vio_task (set_no_glob oval) (tno,tfile)
 
         | "-schedule-vio-checking" ->
           let oval = { oval with vio_checking = true } in
           let oval = set_vio_checking_j oval opt (next ()) in
           let oval = add_vio_file oval (next ()) in
-          add_vio_args peek_next next oval
+          add_vio_args peek_next next (set_no_glob oval)
 
         | "-schedule-vio2vo" ->
           let oval = set_vio_checking_j oval opt (next ()) in
@@ -180,7 +182,7 @@ let parse arglist : t =
 
         | "-vio2vo" ->
           let oval = add_compile ~echo:false oval (next ()) in
-          set_compilation_mode oval Vio2Vo
+          set_compilation_mode (set_no_glob oval) Vio2Vo
 
         | "-outputstate" ->
           set_outputstate oval (next ())

--- a/toplevel/coqcargs.ml
+++ b/toplevel/coqcargs.ml
@@ -47,17 +47,6 @@ let default =
 let depr opt =
   Feedback.msg_warning Pp.(seq[str "Option "; str opt; str " is a noop and deprecated"])
 
-(* XXX Remove this duplication with Coqargs *)
-let fatal_error exn =
-  Topfmt.(in_phase ~phase:ParsingCommandLine print_err_exn exn);
-  let exit_code = if (CErrors.is_anomaly exn) then 129 else 1 in
-  exit exit_code
-
-let error_missing_arg s =
-  prerr_endline ("Error: extra argument expected after option "^s);
-  prerr_endline "See -help for the syntax of supported options";
-  exit 1
-
 let check_compilation_output_name_consistency args =
   match args.compilation_output_name, args.compile_list with
   | Some _, _::_::_ ->
@@ -141,7 +130,7 @@ let parse arglist : t =
       args := rem;
       let next () = match !args with
         | x::rem -> args := rem; x
-        | [] -> error_missing_arg opt
+        | [] -> Coqargs.error_missing_arg opt
       in
       let peek_next () = match !args with
         | x::_ -> Some x
@@ -216,7 +205,7 @@ let parse arglist : t =
     let args = List.fold_left add_compile opts extra in
     check_compilation_output_name_consistency args;
     args
-  with any -> fatal_error any
+  with any -> Coqargs.fatal_error any
 
 let parse args =
   let opts = parse args in

--- a/toplevel/coqcargs.ml
+++ b/toplevel/coqcargs.ml
@@ -126,10 +126,9 @@ let set_outputstate opts s =
 let parse arglist : t =
   let echo = ref false in
   let args = ref arglist in
-  let extras = ref [] in
   let rec parse (oval : t) = match !args with
     | [] ->
-      (oval, List.rev !extras)
+      oval
     | opt :: rem ->
       args := rem;
       let next () = match !args with
@@ -199,14 +198,13 @@ let parse arglist : t =
 
         (* Rest *)
         | s ->
-          extras := s :: !extras;
-          oval
+          if is_not_dash_option (Some s) then add_compile oval s
+          else (prerr_endline ("Unknown option " ^ s); exit 1)
       end in
       parse noval
   in
   try
-    let opts, extra = parse default in
-    let args = List.fold_left add_compile opts extra in
+    let args = parse default in
     check_compilation_output_name_consistency args;
     args
   with any -> Coqargs.fatal_error any

--- a/toplevel/coqcargs.ml
+++ b/toplevel/coqcargs.ml
@@ -8,6 +8,8 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
+(** This file is about parsing command-line arguments of coqc *)
+
 type compilation_mode = BuildVo | BuildVio | Vio2Vo | BuildVos | BuildVok
 
 type t =

--- a/toplevel/coqcargs.mli
+++ b/toplevel/coqcargs.mli
@@ -8,6 +8,8 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
+(** This file is about parsing command-line arguments of coqc *)
+
 (** Compilation modes:
   - BuildVo      : process statements and proofs (standard compilation),
                    and also output an empty .vos file

--- a/toplevel/coqloop.ml
+++ b/toplevel/coqloop.ml
@@ -501,6 +501,7 @@ let loop ~opts copts ~state =
   print_emacs := opts.config.print_emacs;
   (* We initialize the console only if we run the toploop_run *)
   let tl_feed = Feedback.add_feeder coqloop_feed in
+  assert (not (Dumpglob.dump ()));
   let _ = loop ~state in
   (* Initialise and launch the Ocaml toplevel *)
   Coqinit.init_ocaml_path();

--- a/toplevel/coqloop.ml
+++ b/toplevel/coqloop.ml
@@ -495,7 +495,7 @@ let rec loop ~state =
 
 let drop_args = ref None
 
-let loop ~opts ~state =
+let loop ~opts copts ~state =
   drop_args := Some opts;
   let open Coqargs in
   print_emacs := opts.config.print_emacs;

--- a/toplevel/coqloop.mli
+++ b/toplevel/coqloop.mli
@@ -34,4 +34,4 @@ val drop_last_doc : Vernac.State.t option ref
 val drop_args : Coqargs.t option ref
 
 (** Main entry point of Coq: read and execute vernac commands. *)
-val loop : opts:Coqargs.t -> state:Vernac.State.t -> unit
+val loop : opts:Coqargs.t -> Coqtopargs.t -> state:Vernac.State.t -> unit

--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -155,6 +155,13 @@ let print_style_tags opts =
   let () = List.iter iter tags in
   flush_all ()
 
+let get_native_name s =
+  (* We ignore even critical errors because this mode has to be super silent *)
+  try
+    String.concat "/" [Filename.dirname s;
+      Nativelib.output_dir; Library.native_name_from_filename s]
+  with _ -> ""
+
 let print_query opts = function
   | PrintVersion -> Usage.version ()
   | PrintMachineReadableVersion -> Usage.machine_readable_version ()
@@ -162,6 +169,8 @@ let print_query opts = function
   | PrintHelp h -> Usage.print_usage stderr h
   | PrintConfig -> Envars.print_config stdout Coq_config.all_src_dirs
   | PrintTags -> print_style_tags opts.config
+  | PrintModUid l ->
+      let s = String.concat " " (List.map get_native_name l) in print_endline s
 
 (** GC tweaking *)
 

--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -299,30 +299,24 @@ let start_coq custom =
 (** ****************************************)
 (** Specific support for coqtop executable *)
 
-type run_mode = Interactive | Batch
-
 let init_toploop opts =
   let state = init_document opts in
   let state = Ccompile.load_init_vernaculars opts ~state in
   state
 
-let coqtop_init run_mode ~opts =
-  if run_mode = Batch then Flags.quiet := true;
+let coqtop_init copts ~opts =
+  if copts.Coqtopargs.run_mode = Coqtopargs.Batch then Flags.quiet := true;
   init_color opts.config;
   Flags.if_verbose print_header ();
   init_toploop opts
 
 let coqtop_parse_extra ~opts extras =
-  let rec parse_extra run_mode = function
-  | "-batch" :: rest -> parse_extra Batch rest
-  | x :: rest ->
-    let run_mode, rest = parse_extra run_mode rest in run_mode, x :: rest
-  | [] -> run_mode, [] in
-  let run_mode, extras = parse_extra Interactive extras in
-  run_mode, extras
+  let coqtopargs, extras = Coqtopargs.parse extras in
+  coqtopargs, extras
 
-let coqtop_run run_mode ~opts state =
-  match run_mode with
+let coqtop_run copts ~opts state =
+  let open Coqtopargs in
+  match copts.run_mode with
   | Interactive -> Coqloop.loop ~opts ~state;
   | Batch -> exit 0
 

--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -317,7 +317,7 @@ let coqtop_parse_extra ~opts extras =
 let coqtop_run copts ~opts state =
   let open Coqtopargs in
   match copts.run_mode with
-  | Interactive -> Coqloop.loop ~opts ~state;
+  | Interactive -> Coqloop.loop ~opts copts ~state;
   | Batch -> exit 0
 
 let coqtop_specific_usage = Usage.{

--- a/toplevel/coqtop.mli
+++ b/toplevel/coqtop.mli
@@ -40,6 +40,4 @@ val init_toploop : Coqargs.t -> Vernac.State.t
 
 (** The specific characterization of the coqtop_toplevel *)
 
-type run_mode = Interactive | Batch
-
-val coqtop_toplevel : (run_mode,Vernac.State.t) custom_toplevel
+val coqtop_toplevel : (Coqtopargs.t,Vernac.State.t) custom_toplevel

--- a/toplevel/coqtopargs.ml
+++ b/toplevel/coqtopargs.ml
@@ -1,0 +1,42 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *   INRIA, CNRS and contributors - Copyright 1999-2018       *)
+(* <O___,, *       (see CREDITS file for the list of authors)           *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+(***************************)
+(* Specific coqtop options *)
+
+type run_mode = Interactive | Batch
+
+type t = {
+  run_mode : run_mode;
+}
+
+let default = {
+  run_mode = Interactive;
+}
+
+let parse arglist =
+  let args = ref arglist in
+  let extras = ref [] in
+  let rec parse (oval : t) = match !args with
+    | [] ->
+      (oval, List.rev !extras)
+    | opt :: rem ->
+      args := rem;
+      let noval : t = begin match opt with
+        | "-batch" -> { run_mode = Batch }
+        | s ->
+          extras := s :: !extras;
+          oval
+      end in
+      parse noval
+  in
+  try
+    parse default
+  with any -> Coqargs.fatal_error any

--- a/toplevel/coqtopargs.mli
+++ b/toplevel/coqtopargs.mli
@@ -1,0 +1,20 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *   INRIA, CNRS and contributors - Copyright 1999-2018       *)
+(* <O___,, *       (see CREDITS file for the list of authors)           *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+(** Specific coqtop options *)
+
+type run_mode = Interactive | Batch
+
+type t = {
+  run_mode : run_mode;
+}
+
+val default : t
+val parse : string list -> t * string list

--- a/toplevel/toplevel.mllib
+++ b/toplevel/toplevel.mllib
@@ -3,6 +3,7 @@ Usage
 Coqinit
 Coqargs
 Coqcargs
+Coqtopargs
 G_toplevel
 Coqloop
 Ccompile

--- a/toplevel/usage.ml
+++ b/toplevel/usage.ml
@@ -75,8 +75,6 @@ let print_usage_common co command =
 \n  -debug                 debug mode (implies -bt)\
 \n  -diffs (on|off|removed) highlight differences between proof steps\
 \n  -stm-debug             STM debug mode (will trace every transaction)\
-\n  -noglob                do not dump globalizations\
-\n  -dump-glob f           dump globalizations in file f (to be used by coqdoc)\
 \n  -impredicative-set     set sort Set impredicative\
 \n  -allow-sprop           allow using the proof irrelevant SProp sort\
 \n  -disallow-sprop        forbid using the proof irrelevant SProp sort\

--- a/toplevel/workerLoop.ml
+++ b/toplevel/workerLoop.ml
@@ -8,9 +8,14 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
+let set_worker_id s =
+  if s = "master" then Coqargs.error_wrong_arg "Error: master is a reserved worker id";
+  Flags.async_proofs_worker_id := s
+
 let rec parse = function
   | "--xml_format=Ppcmds" :: rest -> parse rest
-  | x :: rest -> x :: parse rest
+  | "-worker-id" :: s :: rest -> set_worker_id s; parse rest
+  | x :: rest -> Coqargs.error_wrong_arg ("Don't know what to do with " ^ x)
   | [] -> []
 
 let worker_parse_extra ~opts extra_args =
@@ -25,7 +30,9 @@ let worker_specific_usage name = Usage.{
   executable_name = name;
   extra_args = "";
   extra_options = ("\n" ^ name ^ " specific options:\
-\n  --xml_format=Ppcmds    serialize pretty printing messages using the std_ppcmds format\n");
+\n  --xml_format=Ppcmds    serialize pretty printing messages using the std_ppcmds format\
+\n  -worker-id name        set name of the coq worker\
+\n");
 }
 
 let start ~init ~loop name =

--- a/vernac/mltop.ml
+++ b/vernac/mltop.ml
@@ -46,7 +46,7 @@ open System
    to build a dummy dynlink.cmxa, cf. dev/dynlink.ml. *)
 
 (* This path is where we look for .cmo *)
-let coq_mlpath_copy = ref [Sys.getcwd ()]
+let coq_mlpath_copy = Summary.ref ~name:"mlpath" [Sys.getcwd ()]
 let keep_copy_mlpath path =
   let cpath = CUnix.canonical_path_name path in
   let filter path' = not (String.equal cpath path')

--- a/vernac/staticstate.ml
+++ b/vernac/staticstate.ml
@@ -1,0 +1,60 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *   INRIA, CNRS and contributors - Copyright 1999-2018       *)
+(* <O___,, *       (see CREDITS file for the list of authors)           *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+(* We record the static state of a Coq executable *)
+
+type static_state = {
+  coqlib : string;
+  compat : Flags.compat_version;
+  excluded_dirs : System.unix_path list;
+  profile_ltac : bool;
+  profile_ltac_cutoff : float;
+  record_backtrace : bool;
+  tag_map : (string * Terminal.style) list;
+  term_color : bool;
+  debug : bool;
+  warn : bool
+}
+
+let freeze_static_state () = {
+  coqlib = Envars.coqlib ();
+  compat = !Flags.compat_version;
+  excluded_dirs = !Minisys.skipped_dirnames;
+  profile_ltac = !Flags.profile_ltac;
+  profile_ltac_cutoff = !Flags.profile_ltac_cutoff;
+  record_backtrace = !Backtrace.is_recording;
+  tag_map = Topfmt.dump_tags ();
+  term_color = Proof_diffs.color_enabled ();
+  debug = !Flags.debug;
+  warn = !Flags.warn;
+}
+
+let unfreeze_static_state st =
+  Envars.set_user_coqlib st.coqlib;
+  Flags.compat_version := st.compat;
+  Minisys.skipped_dirnames := st.excluded_dirs;
+  Flags.profile_ltac := st.profile_ltac;
+  Flags.profile_ltac_cutoff := st.profile_ltac_cutoff;
+  Backtrace.is_recording := st.record_backtrace;
+  Topfmt.init_tag_map st.tag_map;
+  Proof_diffs.write_color_enabled st.term_color;
+  Flags.debug := st.debug;
+  Flags.warn := st.warn;
+  ()
+
+(* Do we need to add this:
+-topfile ?
+-test_mode ?
+-async-queries-always-delegate
+-async-proofs-always-delegate
+-async-proofs-never-reopen-branch
+
+-stm_debug: unaccessible here
+*)

--- a/vernac/staticstate.mli
+++ b/vernac/staticstate.mli
@@ -1,0 +1,16 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *   INRIA, CNRS and contributors - Copyright 1999-2018       *)
+(* <O___,, *       (see CREDITS file for the list of authors)           *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+(* Static part of the state of a Coq executable *)
+
+type static_state
+
+val freeze_static_state : unit -> static_state
+val unfreeze_static_state : static_state -> unit

--- a/vernac/topfmt.mli
+++ b/vernac/topfmt.mli
@@ -46,6 +46,7 @@ val emacs_logger : ?pre_hdr:Pp.t -> Feedback.level -> Pp.t -> unit
 val default_styles : unit -> unit
 val parse_color_config : string -> unit
 val dump_tags : unit -> (string * Terminal.style) list
+val init_tag_map : (string * Terminal.style) list -> unit
 val set_emacs_print_strings : unit -> unit
 
 (** Initialization of interpretation of tags *)

--- a/vernac/vernac.mllib
+++ b/vernac/vernac.mllib
@@ -36,8 +36,10 @@ ComFixpoint
 ComProgramFixpoint
 Record
 Assumptions
-Mltop
 Topfmt
+Staticstate
+Vernacstate
+Mltop
 Loadpath
 ComArguments
 Vernacentries

--- a/vernac/vernacstate.ml
+++ b/vernac/vernacstate.ml
@@ -66,7 +66,8 @@ type t = {
   parsing : Parser.state;
   system  : States.state;          (* summary + libstack *)
   lemmas  : LemmaStack.t option;   (* proofs of lemmas currently opened *)
-  shallow : bool                   (* is the state trimmed down (libstack) *)
+  shallow : bool;                  (* is the state trimmed down (libstack) *)
+  static  : Staticstate.static_state;
 }
 
 let s_cache = ref None
@@ -93,12 +94,15 @@ let freeze_interp_state ~marshallable =
     lemmas = !s_lemmas;
     shallow = false;
     parsing = Parser.cur_state ();
+    static = Staticstate.freeze_static_state ();
   }
 
-let unfreeze_interp_state { system; lemmas; parsing } =
+let unfreeze_interp_state { system; lemmas; parsing; static } =
   do_if_not_cached s_cache States.unfreeze system;
   s_lemmas := lemmas;
-  Pcoq.unfreeze parsing
+  Pcoq.unfreeze parsing;
+  Staticstate.unfreeze_static_state static;
+  ()
 
 let make_shallow st =
   let lib = States.lib_of_state st.system in

--- a/vernac/vernacstate.mli
+++ b/vernac/vernacstate.mli
@@ -39,6 +39,8 @@ type t =
   (** proofs of lemmas currently opened *)
   ; shallow : bool
   (** is the state trimmed down (libstack) *)
+  ; static  : Staticstate.static_state
+  (* static part of a Coq process *)
   }
 
 val freeze_interp_state : marshallable:bool -> t


### PR DESCRIPTION
**Kind:** bug fix / cleaning

@ejgallego: inspired by your work on `coqc`/`coqtop`, I tried to continue with the same kind of cleaning with a PR addressing design questions and local improvements/fix.

This is work in progress and a long header which I publish to poll a bit about how to go on.

#### Design questions

- Issues mentioned in #9585:

  It tries to clarifies the three roles of `coqtop`:
    - interactive mode: we initialize and run the read-eval-loop
    - batch mode: we interpret the command line and quit
    - query mode (`-config`, `-tags`, `-where`, `-print-mod-ui`, `--version`, `--help`): we report about some data and nothing else

  It tries to make more apparent the phase 1 (general initialization) / phase 2 (configuration) / phase 3 (environment loading) of the initialization of a coq process (it seems to me to make understanding of the flow easier to read, but maybe this is personal; I wonder about the opinion of others).

- Extension of the parametrization of `Coqtop.init_toplevel` via a set of `custom` methods specific to each binary:

- Testing the interest of a file `coqtopargs.ml` to parse options specific to `coqtop`. I listed only  `-emacs` and `-batch`, so this is maybe overkill.

I don't know what everyone is planning to do in this part of the code. Are there conflicts with ongoing works (and if yes, I can withdraw some parts). Somehow, a lot remains to do to make the system even more modular (for instance the general init function of `coqtop.ml` could go to `coqinit.ml` so that `coqtop.ml` is strictly about the `coqtop` executable.

But see also the whole discussion at #9585.

#### Local fix/improvements in the command line

The PR fixes a couple of minor issues with the command line:
- ~~miscellaneous formatting bugs in options `-h`~~ (moved to #10160)
- ~~more robust parsing of some options (avoiding some `failwith`)~~ (moved to #10160)
- ~~uniformly accepting files of the form `foo.v` or `foo.vio` as compilation arguments (was not the case for instance for `-vio2vo`)~~ (moved to #10160)
- moving options `-worker-id` to the coq workers (`workerLoop.ml`)
- moving `dumpglob` options to `coqc`
- ~~avoid names of the form `-nonexistingoption` to be taken as a file in `coqide`~~ (moved to #10160)
- adding specific `--help` for coq workers and `coqidetop`
- adding options `-require-import`, `-require-export`,  `-require-import-from`, `-require-export-from` and shortcuts `-ri`, `-re`, `-rifrom`, `-refrom`, ... for consistency with what the vernacular allows.

Some other open questions:
- I allowed combining different queries such as `-where`, `-config`, `-tags`. I don't know if this is very natural. Maybe only one at a time should be accepted.
- What should be documented for coq workers binary? I documented `--xml_format=Ppcmds` and `-worker-id` but maybe only the second should really matters?
- Should the `--help` of `coqide` display on stdout or in a window?

@gares: of the following options found in `coqargs.ml`, are all of them relevant to `coqtop`, or should some be only for `coqidetop` or the `coq*worker`s?
- `-async-proofs` (*)
- `-async-proofs-j` (*)
- `-async-proofs-cache`
- `-async-proofs-tac-j` (*)
- `-async-proofs-worker-priority`
- `-async-proofs-private-flags`
- `-async-proofs-tactic-error-resilience` (*)
- `-async-proofs-command-error-resilience` (*)
- `-async-proofs-delegation-threshold` (*)
- `-async-queries-always-delegate`, `-async-proofs-always-delegate`, `-async-proofs-never-reopen-branch`
- `-worker-id`
- `-main-channel`
- `-control-channel`
Those with a `(*)` are documented for use with CoqIDE (thus `coqidetop` if I interpret correctly). Among the other ones, which ones are of internal use only and which ones should be documented?

Also, are the following for internal use and not to be documented?
- `-print-mod-uid`
- `-profile-ltac-cutoff`
- `-test-mode`
- `-disallow-sprop`

The following is not documented but I would not because it just requires `Utf8_core` and we can think at more ambitious than that (e.g. that all notations have an utf8 alternative which is activated by this flag):
- `-unicode`

The following are not documented but I would say that it is mostly for debugging purpose:
- `-output-context`
- `-feedback-glob`

The following is not documented but I would not document it yet until it is seriously maintained and tested:
- `-beautify`

I did not touch to the discrepancy in "usage" between toggles documented as `on`/`off` and toggles documented as `yes`/`no`. This looks to me like an inconsistency but maybe can it be seen also as a sign of openness to the diversity of origins of contributions. (As a matter of fact, this is also a general remark on the implementation.) Any opinion on what is preferrable?

@gares: the `set_slave_opt` seems fragile (dependent on the exact list of names of accepted options, needs change any time the command line syntax changes). What about passing e.g. the result `Coqargs.t` of the parsing of the command line rather than reconstructing it?

- [ ] Added / updated test-suite (a test checking how option `-h` is rendered might be good)
- [ ] Continue to clarify which options are really used by which executable rather than silently ignoring them (e.g. `-l` is silently ignored by `coqc`)
- [ ] State problem with multiple files `coqc` to be fixed: the second fails on ltac syntax (see also #9585)

I'm not sure it is worth an entry in changes (fixes are in corner cases), except for the addition of options `-require-import`, and co.

I have no idea about how to eventually split this PR into smaller enough parts so that it is easy to review once a consensus is obtained. In any case, @gares and @ejgallego, your help is highly needed.