### PR TITLE
Fix dependencies of new test file and fix macOS issues.

### DIFF
--- a/test-suite/dune
+++ b/test-suite/dune
@@ -22,6 +22,7 @@
    ../doc/stdlib/index-list.html.template
    ; For the changelog test
    ../config/coq_config.py
+   (source_tree doc/changelog)
    (package coq)
    ; For fake_ide
    (package coqide-server)

--- a/test-suite/misc/changelog.sh
+++ b/test-suite/misc/changelog.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 if grep -q -F "is_a_released_version = False" ../config/coq_config.py; then
     echo "This is not a released version: nothing to test."
@@ -7,7 +7,8 @@ fi
 
 for d in ../doc/changelog/*; do
   if [ -d "$d" ]; then
-    if [ "$(ls $d/*.rst | wc -l)" != "1" ]; then
+    files=("$d"/*.rst)
+    if [ "${#files[@]}" != 1 ]; then
       echo "Fatal: unreleased changelog entries remain in ${d#../}/"
       echo "Include them in doc/sphinx/changes.rst and remove them from doc/changelog/"
       exit 1


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** bug fix

I have no idea if this is responsible for the failure observed on macOS in #10159. On Linux, the consequence of this bug is to make the test-suite pass if the documentation was not built first.

~~Now depends on #10211~~ (merged)