### PR TITLE
Refactor arguments libobject

### DIFF
--- a/interp/notation.mli
+++ b/interp/notation.mli
@@ -248,8 +248,7 @@ val exists_notation_in_scope : scope_name option -> notation ->
       bool -> interpretation -> bool
 
 (** Declares and looks for scopes associated to arguments of a global ref *)
-val declare_arguments_scope :
-  bool (** true=local *) -> GlobRef.t -> scope_name option list -> unit
+val declare_arguments_scope : GlobRef.t -> scope_name option list -> unit
 
 val find_arguments_scope : GlobRef.t -> scope_name option list
 

--- a/pretyping/arguments_renaming.ml
+++ b/pretyping/arguments_renaming.ml
@@ -16,7 +16,6 @@ open Constr
 open Context
 open Environ
 open Util
-open Libobject
 
 module NamedDecl = Context.Named.Declaration
 (*i*)
@@ -25,48 +24,18 @@ let name_table =
   Summary.ref (GlobRef.Map.empty : Name.t list GlobRef.Map.t)
     ~name:"rename-arguments"
 
-type req =
-  | ReqLocal
-  | ReqGlobal of GlobRef.t * Name.t list
-
-let load_rename_args _ (_, (_, (r, names))) =
-  name_table := GlobRef.Map.add r names !name_table
-
-let cache_rename_args o = load_rename_args 1 o
-
-let classify_rename_args = function
-  | ReqLocal, _ -> Dispose
-  | ReqGlobal _, _ as o -> Substitute o
-
-let subst_rename_args (subst, (_, (r, names as orig))) = 
-  ReqLocal,
-  let r' = fst (subst_global subst r) in 
-  if r==r' then orig else (r', names)
-
 let discharge_rename_args = function
-  | _, (ReqGlobal (c, names), _ as req) when not (isVarRef c && Lib.is_in_section c) ->
-     (try 
+  | (c, names as orig) when not (isVarRef c && Lib.is_in_section c) ->
+     (try
        let vars = Lib.variable_section_segment_of_reference c in
        let var_names = List.map (fst %> NamedDecl.get_id %> Name.mk_name) vars in
        let names' = var_names @ names in
-       Some (ReqGlobal (c, names), (c, names'))
-     with Not_found -> Some req)
+       Some (c, names')
+     with Not_found -> Some orig)
   | _ -> None
 
-let rebuild_rename_args x = x
-
-let inRenameArgs = declare_object { (default_object "RENAME-ARGUMENTS" ) with
-  load_function = load_rename_args;
-  cache_function = cache_rename_args;
-  classify_function = classify_rename_args;
-  subst_function = subst_rename_args;
-  discharge_function = discharge_rename_args;
-  rebuild_function = rebuild_rename_args;
-}
-
-let rename_arguments local r names =
-  let req = if local then ReqLocal else ReqGlobal (r, names) in
-  Lib.add_anonymous_leaf (inRenameArgs (req, (r, names)))       
+let rename_arguments r names =
+  name_table := GlobRef.Map.add r names !name_table
 
 let arguments_names r = GlobRef.Map.find r !name_table
 

--- a/pretyping/arguments_renaming.mli
+++ b/pretyping/arguments_renaming.mli
@@ -12,7 +12,8 @@ open Names
 open Environ
 open Constr
 
-val rename_arguments : bool -> GlobRef.t -> Name.t list -> unit
+val rename_arguments : GlobRef.t -> Name.t list -> unit
+val discharge_rename_args : (GlobRef.t * Name.t list) -> (GlobRef.t * Name.t list) option
 
 (** [Not_found] is raised if no names are defined for [r] *)
 val arguments_names : GlobRef.t -> Name.t list

--- a/pretyping/reductionops.mli
+++ b/pretyping/reductionops.mli
@@ -25,9 +25,12 @@ module ReductionBehaviour : sig
   type t = NeverUnfold | UnfoldWhen of when_flags | UnfoldWhenNoMatch of when_flags
   and when_flags = { recargs : int list ; nargs : int option }
 
-  val set : local:bool -> GlobRef.t -> t -> unit
+  val set : GlobRef.t -> t -> unit
   val get : GlobRef.t -> t option
   val print : GlobRef.t -> Pp.t
+
+  val discharge : GlobRef.t * t -> t
+  val rebuild : GlobRef.t * t -> t
 end
 
 (** {6 Support for reduction effects } *)


### PR DESCRIPTION
We factorize 3 of the 4 libobjects on which `Arguments` depend. The remaining one is the one of implicit arguments, and will require specific treatment (and more cleaning).

The motivation for this change is:
- To make #10049 possible without introducing yet another libobject in the backend of `Arguments`
- To fix various bugs in the code of discharge and substitution of these libobjects
- To move vernac-related notions (like the scope of commands) to `vernac`