### PR TITLE
Fail: don't catch critical errors

### DIFF
--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -2204,7 +2204,7 @@ let with_fail ~st f =
     try let _ = f () in raise HasNotFailed
     with
     | HasNotFailed as e -> raise e
-    | e ->
+    | e when CErrors.noncritical e || e = Timeout ->
       let e = CErrors.push e in
       raise (HasFailed (CErrors.iprint
                           (ExplainErr.process_vernac_interp_error ~allow_uncaught:false e)))


### PR DESCRIPTION
Not sure why we didn't. Fail didn't catch anomalies almost by accident.