### PR TITLE
[Gitlab-CI] Target macOS version 10.11

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -259,6 +259,7 @@ build:macOS:
   script:
     - dev/build/osx/make-macos-dmg.sh
   variables:
+    MACOSX_DEPLOYMENT_TARGET: '10.11'
     NJOBS: "2"
   only:
     variables:


### PR DESCRIPTION
This enables installing and running Coq 8.9.1 on macOS 10.11.