### PR TITLE
A few nix-related updates

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -74,7 +74,7 @@ stdenv.mkDerivation rec {
     else
       with builtins; filterSource
         (path: _:
-           !elem (baseNameOf path) [".git" "result" "bin" "_build" "_build_ci"]) ./.;
+           !elem (baseNameOf path) [".git" "result" "bin" "_build" "_build_ci" "nix"]) ./.;
 
   preConfigure = ''
     patchShebangs dev/tools/

--- a/dev/ci/nix/bignums.nix
+++ b/dev/ci/nix/bignums.nix
@@ -1,5 +1,5 @@
 { ocamlPackages }:
 
 {
-  buildInputs = with ocamlPackages; [ ocaml findlib camlp5 ];
+  buildInputs = [ ocamlPackages.ocaml ];
 }

--- a/dev/ci/nix/unicoq/unicoq-num.patch
+++ b/dev/ci/nix/unicoq/unicoq-num.patch
@@ -4,19 +4,6 @@ Date:   Thu Nov 29 08:59:22 2018 +0000
 
     Make explicit dependency to num
 
-diff --git a/Make b/Make
-index 550dc6a..8aa1309 100644
---- a/Make
-+++ b/Make
-@@ -9,7 +9,7 @@ src/logger.ml
- src/munify.mli
- src/munify.ml
- src/unitactics.mlg
--src/unicoq.mllib
-+src/unicoq.mlpack
- theories/Unicoq.v
- test-suite/munifytest.v
- test-suite/microtests.v
 diff --git a/Makefile.local b/Makefile.local
 new file mode 100644
 index 0000000..88be365
@@ -24,21 +11,3 @@ index 0000000..88be365
 +++ b/Makefile.local
 @@ -0,0 +1 @@
 +CAMLPKGS += -package num
-diff --git a/src/unicoq.mllib b/src/unicoq.mllib
-deleted file mode 100644
-index 2b84e2d..0000000
---- a/src/unicoq.mllib
-+++ /dev/null
-@@ -1,3 +0,0 @@
--Logger
--Munify
--Unitactics
-diff --git a/src/unicoq.mlpack b/src/unicoq.mlpack
-new file mode 100644
-index 0000000..2b84e2d
---- /dev/null
-+++ b/src/unicoq.mlpack
-@@ -0,0 +1,3 @@
-+Logger
-+Munify
-+Unitactics

--- a/dev/nixpkgs.nix
+++ b/dev/nixpkgs.nix
@@ -1,4 +1,4 @@
 import (fetchTarball {
-  url = "https://github.com/NixOS/nixpkgs/archive/8471ab76242987b11afd4486b82888e1588f8307.tar.gz";
-  sha256 = "06pp6b6x78jlinxifnphkbp79dx58jr990fkm4qziq0ay5klpxd7";
+  url = "https://github.com/NixOS/nixpkgs/archive/bc9df0f66110039e495b6debe3a6cda4a1bb0fed.tar.gz";
+  sha256 = "0y2w259j0vqiwjhjvlbsaqnp1nl2zwz6sbwwhkrqn7k7fmhmxnq1";
 })


### PR DESCRIPTION
 -  Update the reference to `nixpkgs` (includes dune-1.9.2, elpi-1.2.0)
 -  Fixes the patches to Unicoq (used when developing overlays for mtac2)
 -  Do not consider the `nix/` subdirectory as part of the Coq source code when building Coq.