### PR TITLE
Fix computation of implicit arguments when names collide in local fix/cofix (#10197)

### DIFF
--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -1845,7 +1845,7 @@ let internalize globalenv env pattern_mode (_, ntnvars as lvar) c =
 	in
 	  apply_impargs c env imp subscopes l loc
 
-      | CFix ({ CAst.loc = locid; v = iddef}, dl) ->
+    | CFix ({ CAst.loc = locid; v = iddef}, dl) ->
         let lf = List.map (fun ({CAst.v = id},_,_,_,_) -> id) dl in
         let dl = Array.of_list dl in
         let n =

--- a/test-suite/bugs/closed/bug_10197.v
+++ b/test-suite/bugs/closed/bug_10197.v
@@ -1,0 +1,16 @@
+(* Some check about implicit arguments in fix *)
+
+Check fix f {f:nat} := match f with 0 => true | _ => false end.
+
+CoInductive stream := { this : nat ; next : option stream }.
+
+Check cofix f {f:nat} := {| this := f ; next := None |}.
+
+(* The following was ok from 8.4, just checking that the order is not
+   mixed up accidentally *)
+
+Check fix f (x : nat) (x : forall {a:nat}, a = 0 -> nat) :=
+   match x eq_refl with 0 => true | _ => false end.
+
+Check fix f (x : forall {a:nat}, a = 0 -> bool) (x : nat) :=
+   match x with 0 => true | _ => false end.

--- a/test-suite/bugs/closed/bug_3810.v
+++ b/test-suite/bugs/closed/bug_3810.v
@@ -1,0 +1,6 @@
+Class Foo.
+
+Fixpoint test (H : Foo) (n : nat) {A : Type} {struct n} : A.
+Admitted.
+
+Check fun (x:Foo) => test x 0.


### PR DESCRIPTION
**Kind:** bug fix

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #10197

The implicit arguments were not pushed in the environment in the right order. See commit log of last commit for more details.

- [X] Added / updated test-suite
