### PR TITLE
Remove `unsafe_type_of` from `Coercion`

### DIFF
--- a/dev/ci/user-overlays/10204-rm-unsafe-type-of-coercion.sh
+++ b/dev/ci/user-overlays/10204-rm-unsafe-type-of-coercion.sh
@@ -1,0 +1,6 @@
+if [ "$CI_PULL_REQUEST" = "10204" ] || [ "$CI_BRANCH" = "rm-unsafe-type-of-coercion" ]; then
+
+    paramcoq_CI_REF=fix-papp
+    paramcoq_CI_GITURL=https://github.com/maximedenes/paramcoq
+
+fi

--- a/pretyping/cases.ml
+++ b/pretyping/cases.ml
@@ -2126,11 +2126,6 @@ let eq_id avoid id =
   let hid' = next_ident_away hid avoid in
     hid'
 
-let papp sigma gr args =
-  let evdref = ref sigma in
-  let ans = papp evdref gr args in
-  !evdref, ans
-
 let mk_eq sigma typ x y = papp sigma coq_eq_ind [| typ; x ; y |]
 let mk_eq_refl sigma typ x = papp sigma coq_eq_refl [| typ; x |]
 let mk_JMeq sigma typ x typ' y =

--- a/pretyping/program.ml
+++ b/pretyping/program.ml
@@ -11,12 +11,11 @@
 open CErrors
 open Util
 
-let papp evdref r args =
+let papp sigma r args =
   let open EConstr in
   let gr = delayed_force r in
-  let evd, hd = Evarutil.new_global !evdref gr in
-  evdref := evd;
-  mkApp (hd, args)
+  let evd, hd = Evarutil.new_global sigma gr in
+  sigma, mkApp (hd, args)
 
 let sig_typ   () = Coqlib.lib_ref "core.sig.type"
 let sig_intro () = Coqlib.lib_ref "core.sig.intro"

--- a/pretyping/program.mli
+++ b/pretyping/program.mli
@@ -10,6 +10,7 @@
 
 open Names
 open EConstr
+open Evd
 
 (** A bunch of Coq constants used by Program *)
 
@@ -38,7 +39,7 @@ val mk_coq_and : Evd.evar_map -> constr list -> Evd.evar_map * constr
 val mk_coq_not : Evd.evar_map -> constr -> Evd.evar_map * constr
 
 (** Polymorphic application of delayed references *)
-val papp : Evd.evar_map ref -> (unit -> GlobRef.t) -> constr array -> constr
+val papp : evar_map -> (unit -> GlobRef.t) -> constr array -> evar_map * constr
 
 val get_proofs_transparency : unit -> bool
 val is_program_cases : unit -> bool


### PR DESCRIPTION
We thread explicitly the evar map everywhere for this purpose.

https://github.com/coq-community/paramcoq/pull/48