### PR TITLE
Better dune ocamldebug integration

### DIFF
--- a/dev/doc/build-system.dune.md
+++ b/dev/doc/build-system.dune.md
@@ -108,14 +108,14 @@ automatically.
 You can use `ocamldebug` with Dune; after a build, do:
 
 ```
-dune exec dev/dune-dbg
+dune exec dev/dune-dbg /path/to/foo.v
 (ocd) source dune_db
 ```
 
 or
 
 ```
-dune exec dev/dune-dbg checker
+dune exec dev/dune-dbg checker Foo
 (ocd) source dune_db
 ```
 
@@ -123,6 +123,8 @@ for the checker. Unfortunately, dependency handling here is not fully
 refined, so you need to build enough of Coq once to use this target
 [it will then correctly compute the deps and rebuild if you call the
 script again] This will be fixed in the future.
+
+For running in emacs, use `coqdev-ocamldebug` from `coqdev.el`.
 
 ## Dropping from coqtop:
 

--- a/dev/dune
+++ b/dev/dune
@@ -3,7 +3,7 @@
  (public_name coq.top_printers)
  (synopsis "Coq's Debug Printers")
  (wrapped false)
- (modules :standard)
+ (modules top_printers)
  (optional)
  (libraries coq.toplevel coq.plugins.ltac))
 
@@ -11,7 +11,7 @@
   (targets dune-dbg)
   (deps dune-dbg.in
         ../checker/coqchk.bc
-        ../topbin/coqtop_byte_bin.bc
+        ../topbin/coqc_bin.bc
         ; This is not enough as the call to `ocamlfind` will fail :/
         top_printers.cma)
   (action (copy dune-dbg.in dune-dbg)))

--- a/dev/dune-dbg.in
+++ b/dev/dune-dbg.in
@@ -3,11 +3,14 @@
 # Run in a proper install dune env.
 case $1 in
     checker)
+        shift
         exe=_build/default/checker/coqchk.bc
         ;;
     *)
-        exe=_build/default/topbin/coqtop_byte_bin.bc
+        exe=_build/default/topbin/coqc_bin.bc
         ;;
 esac
 
-ocamldebug $(ocamlfind query -recursive -i-format coq.top_printers) -I +threads -I dev $exe
+emacs="${INSIDE_EMACS:+-emacs}"
+
+ocamldebug $emacs $(ocamlfind query -recursive -i-format coq.top_printers) -I +threads -I dev $exe "$@"


### PR DESCRIPTION
- use coqc instead of coqtop (since -compile doesn't work anymore this
  is better)
- pass through extra arguments to dune-dbg
- auto detect the need to pass -emacs to ocamldebug
- instructions for emacs users

The dune-dbg dependencies are still broken ;_;
