### PR TITLE
Architectural design questions in the computation of manual implicit arguments

### DIFF
--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -320,8 +320,8 @@ let mkGLambda ?loc (na,bk,t) body = DAst.make ?loc @@ GLambda (na, bk, t, body)
 (* Utilities for binders                                              *)
 let build_impls = function
   |Implicit -> (function
-		  |Name id ->  Some (id, Impargs.Manual, (true,true))
-		  |Anonymous -> Some (Id.of_string "_", Impargs.Manual, (true,true)))
+                  |Name id ->  Some (ExplByName id, Impargs.Manual, (true,true))
+                  |Anonymous -> Some (ExplByName (Id.of_string "_"), Impargs.Manual, (true,true)))
   |Explicit -> fun _ -> None
 
 let impls_type_list ?(args = []) =

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -1845,7 +1845,7 @@ let internalize globalenv env pattern_mode (_, ntnvars as lvar) c =
 	in
 	  apply_impargs c env imp subscopes l loc
 
-      | CFix ({ CAst.loc = locid; v = iddef}, dl) ->
+    | CFix ({ CAst.loc = locid; v = iddef}, dl) ->
         let lf = List.map (fun ({CAst.v = id},_,_,_,_) -> id) dl in
         let dl = Array.of_list dl in
         let n =

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -372,6 +372,9 @@ let check_hidden_implicit_parameters ?loc id impls =
       strbrk "a parameter of the inductive type; bound variables in " ++
       strbrk "the type of a constructor shall use a different name.")
 
+let pure_push_name_env (id,implargs) env =
+  {env with ids = Id.Set.add id env.ids; impls = Id.Map.add id implargs env.impls}
+
 let push_name_env ?(global_level=false) ntnvars implargs env =
   let open CAst in
   function
@@ -386,7 +389,16 @@ let push_name_env ?(global_level=false) ntnvars implargs env =
       set_var_scope ?loc id false (env.tmp_scope,env.scopes) ntnvars;
       if global_level then Dumpglob.dump_definition CAst.(make ?loc id) true "var"
       else Dumpglob.dump_binding ?loc id;
-      {env with ids = Id.Set.add id env.ids; impls = Id.Map.add id implargs env.impls}
+      pure_push_name_env (id,implargs) env
+
+let remember_binders_impargs env bl =
+  List.map_filter (fun (na,_,_,_) ->
+      match na with
+      | Anonymous -> None
+      | Name id -> Some (id,Id.Map.find id env.impls)) bl
+
+let restore_binders_impargs env l =
+  List.fold_right pure_push_name_env l env
 
 let intern_generalized_binder ?(global_level=false) intern_type ntnvars
     env {loc;v=na} b' t ty =
@@ -1867,14 +1879,18 @@ let internalize globalenv env pattern_mode (_, ntnvars as lvar) c =
                    rbefore) recarg in
                let (env',rbl) = List.fold_left intern_local_binder (env',rbefore) after in
                let bl = List.rev (List.map glob_local_binder_of_extended rbl) in
-               (n, bl, intern_type env' ty, env')) dl in
-        let idl = Array.map2 (fun (_,_,_,_,bd) (a,b,c,env') ->
-            let env'' = List.fold_left_i (fun i en name ->
-                let (_,bli,tyi,_) = idl_temp.(i) in
-                let fix_args = (List.map (fun (na, bk, _, _) -> (build_impls bk na)) bli) in
-                push_name_env ntnvars (impls_type_list ~args:fix_args tyi)
-                  en (CAst.make @@ Name name)) 0 env' lf in
-            (a,b,c,intern {env'' with tmp_scope = None} bd)) dl idl_temp in
+               let bl_impls = remember_binders_impargs env' bl in
+               (n, bl, intern_type env' ty, bl_impls)) dl in
+        (* We add the recursive functions to the environment *)
+        let env_rec = List.fold_left_i (fun i en name ->
+           let (_,bli,tyi,_) = idl_temp.(i) in
+           let fix_args = (List.map (fun (na, bk, _, _) -> build_impls bk na) bli) in
+           push_name_env ntnvars (impls_type_list ~args:fix_args tyi)
+           en (CAst.make @@ Name name)) 0 env lf in
+        let idl = Array.map2 (fun (_,_,_,_,bd) (n,bl,ty,before_impls) ->
+            (* We add the binders common to body and type to the environment *)
+            let env_body = restore_binders_impargs env_rec before_impls in
+            (n,bl,ty,intern {env_body with tmp_scope = None} bd)) dl idl_temp in
         DAst.make ?loc @@
         GRec (GFix
                 (Array.map (fun (ro,_,_,_) -> ro) idl,n),
@@ -1894,15 +1910,18 @@ let internalize globalenv env pattern_mode (_, ntnvars as lvar) c =
         let idl_tmp = Array.map
           (fun ({ CAst.loc; v = id },bl,ty,_) ->
             let (env',rbl) = List.fold_left intern_local_binder (env,[]) bl in
-            (List.rev (List.map glob_local_binder_of_extended rbl),
-             intern_type env' ty,env')) dl in
-	let idl = Array.map2 (fun (_,_,_,bd) (b,c,env') ->
-	     let env'' = List.fold_left_i (fun i en name ->
-					     let (bli,tyi,_) = idl_tmp.(i) in
-					     let cofix_args =  List.map (fun (na, bk, _, _) -> (build_impls bk na)) bli in
-	       push_name_env ntnvars (impls_type_list ~args:cofix_args tyi)
-                                            en (CAst.make @@ Name name)) 0 env' lf in
-             (b,c,intern {env'' with tmp_scope = None} bd)) dl idl_tmp in
+            let bl = List.rev (List.map glob_local_binder_of_extended rbl) in
+            let bl_impls = remember_binders_impargs env' bl in
+            (bl,intern_type env' ty,bl_impls)) dl in
+        let env_rec = List.fold_left_i (fun i en name ->
+          let (bli,tyi,_) = idl_tmp.(i) in
+          let cofix_args =  List.map (fun (na, bk, _, _) -> build_impls bk na) bli in
+          push_name_env ntnvars (impls_type_list ~args:cofix_args tyi)
+            en (CAst.make @@ Name name)) 0 env lf in
+        let idl = Array.map2 (fun (_,_,_,bd) (b,c,bl_impls) ->
+          (* We add the binders common to body and type to the environment *)
+          let env_body = restore_binders_impargs env_rec bl_impls in
+          (b,c,intern {env_body with tmp_scope = None} bd)) dl idl_tmp in
 	DAst.make ?loc @@
 	GRec (GCoFix n,
               Array.of_list lf,

--- a/interp/constrintern.mli
+++ b/interp/constrintern.mli
@@ -87,6 +87,10 @@ val intern_gen : typing_constraint -> env -> evar_map ->
   ?impls:internalization_env -> ?pattern_mode:bool -> ?ltacvars:ltac_sign ->
   constr_expr -> glob_constr
 
+val intern_gen_with_implicits : typing_constraint -> env -> evar_map ->
+  ?impls:internalization_env -> ?pattern_mode:bool -> ?ltacvars:ltac_sign ->
+  constr_expr -> glob_constr * Impargs.manual_implicits
+
 val intern_pattern : env -> cases_pattern_expr ->
   lident list * (Id.t Id.Map.t * cases_pattern) list
 

--- a/interp/impargs.ml
+++ b/interp/impargs.ml
@@ -758,6 +758,11 @@ let lift_implicits n =
 	ExplByPos (k, id) -> ExplByPos (k + n, id), snd x
       | _ -> x)
 
+let lift_implicits2 n =
+  List.map (CAst.map (function
+      | Some (ExplByPos (k, id), m, c) -> Some (ExplByPos (k + n, id), m, c)
+      | x -> x))
+
 let make_implicits_list l = [DefaultImpArgs, l]
 
 let rec drop_first_implicits p l =

--- a/interp/impargs.mli
+++ b/interp/impargs.mli
@@ -133,6 +133,8 @@ val extract_impargs_data :
 
 val lift_implicits : int -> manual_implicits -> manual_implicits
 
+val lift_implicits2 : int -> implicit_status CAst.t list -> implicit_status CAst.t list
+
 val make_implicits_list : implicit_status list -> implicits_list list
 
 val drop_first_implicits : int -> implicits_list -> implicits_list

--- a/interp/impargs.mli
+++ b/interp/impargs.mli
@@ -68,7 +68,7 @@ type maximal_insertion = bool (** true = maximal contextual insertion *)
 
 type force_inference = bool (** true = always infer, never turn into evar/subgoal *)
 
-type implicit_status = (Id.t * implicit_explanation * 
+type implicit_status = (Constrexpr.explicitation * implicit_explanation *
 			  (maximal_insertion * force_inference)) option
     (** [None] = Not implicit *)
 

--- a/pretyping/glob_ops.ml
+++ b/pretyping/glob_ops.ml
@@ -156,6 +156,14 @@ let mk_glob_constr_eq f c1 c2 = match DAst.get c1, DAst.get c2 with
 
 let rec glob_constr_eq c = mk_glob_constr_eq glob_constr_eq c
 
+(** Mapping [fold_cast_type] *)
+
+let map_fold_cast_type f = function
+  | CastConv a -> let (e,a) = f a in (Some e, CastConv a)
+  | CastVM a -> let (e,a) = f a in (Some e, CastVM a)
+  | CastCoerce -> (None, CastCoerce)
+  | CastNative a -> let (e,a) = f a in (Some e, CastNative a)
+
 (** Mapping [cast_type] *)
 
 let map_cast_type f = function

--- a/test-suite/bugs/closed/bug_10197.v
+++ b/test-suite/bugs/closed/bug_10197.v
@@ -1,0 +1,16 @@
+(* Some check about implicit arguments in fix *)
+
+Check fix f {f:nat} := match f with 0 => true | _ => false end.
+
+CoInductive stream := { this : nat ; next : option stream }.
+
+Check cofix f {f:nat} := {| this := f ; next := None |}.
+
+(* The following was ok from 8.4, just checking that the order is not
+   mixed up accidentally *)
+
+Check fix f (x : nat) (x : forall {a:nat}, a = 0 -> nat) :=
+   match x eq_refl with 0 => true | _ => false end.
+
+Check fix f (x : forall {a:nat}, a = 0 -> bool) (x : nat) :=
+   match x with 0 => true | _ => false end.

--- a/test-suite/bugs/closed/bug_3810.v
+++ b/test-suite/bugs/closed/bug_3810.v
@@ -1,0 +1,6 @@
+Class Foo.
+
+Fixpoint test (H : Foo) (n : nat) {A : Type} {struct n} : A.
+Admitted.
+
+Check fun (x:Foo) => test x 0.

--- a/test-suite/bugs/opened/bug_3357.v
+++ b/test-suite/bugs/opened/bug_3357.v
@@ -1,4 +1,7 @@
-Notation D1 := (forall {T : Type} ( x : T ) , Type).
+(* See discussion in #668 for whether manual implicit arguments should
+   be allowed in notations or not *)
+
+Fail Notation D1 := (forall {T : Type} ( x : T ) , Type).
 
 Definition DD1 ( A : forall {T : Type} (x : T), Type ) := A 1.
 Fail Definition DD1' ( A : D1 ) := A 1. (* Toplevel input, characters 32-33:

--- a/test-suite/success/implicit.v
+++ b/test-suite/success/implicit.v
@@ -143,3 +143,13 @@ Check let f := fun {x:nat} y => y=true in f false.
 (* Isn't the name "arg_0" a bit fragile, here? *)
 
 Check fun f : forall {_:nat}, nat => f (arg_0:=0).
+
+(* Check consistency of manual implicit arguments between term and type *)
+
+Fail Definition g := fix f (a:nat) : forall (b:nat), b=0 -> Type := fun {c} e =>
+  match a with
+  | 0 => True
+  | S n => f n eq_refl
+  end.
+
+Fail Check let f : forall (b:nat), b=0 -> Type := fun {c} e => c = c in f eq_refl.

--- a/test-suite/success/implicit.v
+++ b/test-suite/success/implicit.v
@@ -124,3 +124,22 @@ Inductive I3 {A} (x:=0) (a:A) : forall {n:nat}, Prop :=
 (* Check global implicit declaration over ref not in section *)
 
 Section D. Global Arguments eq [A] _ _. End D.
+
+(* Check local manual implicit arguments *)
+(* Gives a warning and make the second x anonymous *)
+(* Isn't the name "arg_1" a bit fragile though? *)
+
+Check fun f : forall {x:nat} {x:bool} (x:unit), unit => f (x:=1) (arg_1:=true) tt.
+
+(* Test failure when implicit arguments are mentioned in subterms
+   which are not types of variables *)
+
+Fail Check (id (forall {a}, a)).
+
+(* Miscellaneous tests *)
+
+Check let f := fun {x:nat} y => y=true in f false.
+
+(* Isn't the name "arg_0" a bit fragile, here? *)
+
+Check fun f : forall {_:nat}, nat => f (arg_0:=0).

--- a/theories/Init/Logic.v
+++ b/theories/Init/Logic.v
@@ -795,6 +795,7 @@ Section ex.
     destruct q; simpl in *.
     destruct p; reflexivity.
   Qed.
+About eq_ex_uncurried.
 
   Definition eq_ex {A : Type} {P : A -> Prop} (u1 v1 : A) (u2 : P u1) (v2 : P v1)
              (p : u1 = v1) (q : rew p in u2 = v2)

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -141,8 +141,7 @@ let make_conclusion_flexible sigma = function
      | _ -> sigma)
 
 let interp_ind_arity env sigma ind =
-  let c = intern_gen IsType env sigma ind.ind_arity in
-  let impls = Implicit_quantifiers.implicits_of_glob_constr ~with_products:true c in
+  let c,impls = intern_gen_with_implicits IsType env sigma ind.ind_arity in
   let sigma,t = understand_tcc env sigma ~expected_type:IsType c in
   let pseudo_poly = check_anonymous_type c in
   match Reductionops.sort_of_arity env sigma t with

--- a/vernac/comProgramFixpoint.ml
+++ b/vernac/comProgramFixpoint.ml
@@ -176,7 +176,7 @@ let build_wellfounded (recname,pl,bl,arityc,body) poly r measure notation =
         Constrintern.Recursive full_arity impls
     in
     let newimpls = Id.Map.singleton recname
-        (r, l, impls @ [(Some (Id.of_string "recproof", Impargs.Manual, (true, false)))],
+        (r, l, impls @ [Some (ExplByName (Id.of_string "recproof"), Impargs.Manual, (true, false))],
          scopes @ [None]) in
     interp_casted_constr_evars ~program_mode:true (push_rel_context ctx env) sigma
       ~impls:newimpls body (lift 1 top_arity)


### PR DESCRIPTION
**Kind:** bug fix / infrastructure.

This draft PR was initially motivated by #7975 (making manual implicit possible beyond a `fun 'pat`) and by making manual implicit arguments more robustness in general (see the various discussions raised by @jashug). It derived to a more  general question of architectural design which I present here.

#### Initial motivations (for the record)

- Depending on cases, manual implicit arguments were computed in different functions:
  - after internalization in `Implicit_quantifiers.implicits_of_glob_constr`
  - while interning in `Constrintern.impls_binder_list`, `impls_type_list`, `impls_term_list`

  As a result, extensions (such as #7975) had to be done in several places.

- No consistency check of manual implicit arguments were done:
  - `{x:foo}` was silently ignored in places where it does not make sense (e.g. in `id (forall {x}, x)`) (see also #3357 whose related open questions could now be answered)
  - Inconsistent manual implicit arguments between a type and a body are silently accepted (in let-in or (co-)/fix). Actually, which of body and type has precedence is inconsistent between the `constrintern.ml` algorithm and the `implicit_quantifiers.ml` algorithm (see #10223).

See also #6785

#### Design questions it leads to before continuing

Two strategies are possible:
- We compute implicit positions in two (interleaved) phases: we first `intern`, then compute the implicit positions on the resulting `glob_constr` (as it is done now)
  - the pros are that we have a better algorithm separation of concerns (which can be welcome considering that `constrintern.ml` is already complex)
  - the cons are that we keep useless marks `Implicit`/`Explicit` in `glob_constr`

  Otherwise said, we trade off a better separation of phases in the algorithm by keeping morally-useless information in the syntax.

- We compute implicit positions on the fly while interning, and, in particular:
  - pros: we don't need to keep the `Implicit`/`Explicit` flag any more in `glob_constr`
  - a cons is that interning is not anymore a pure translation but a translation with side effects (i.e. a `fold_map` and not anymore a `map`): this is because interning now produces both a `glob_constr` and the implicit positions of the leading binders of the term at the same time

So, before going further, is there any opinion (@mattam82, @ppedrot, @ejgallego, @jashug, ...) on the architectural direction we'd like to favor for the future: better seperation of concerns in the internalization phases or better separation of concerns in the data structures?

#### Notes

The PR as it is does not compile the library. It experiments option 2 (one phase) but stopped on the way (it still needs `instantiate_notation_constr` to move to a `fold_map` model + miscellaneous cleaning).
