### PR TITLE
Deprecate grammar entry "intropattern" in tactic notations in favor of "simple_intropattern"

### DIFF
--- a/doc/sphinx/user-extensions/syntax-extensions.rst
+++ b/doc/sphinx/user-extensions/syntax-extensions.rst
@@ -1716,9 +1716,9 @@ Tactic notations allow to customize the syntax of tactics. They have the followi
         - intro
 
       * - ``simple_intropattern``
-        - intro_pattern
-        - an intro pattern
-        - intros
+        - simple_intropattern
+        - an introduction pattern
+        - assert as
 
       * - ``hyp``
         - identifier

--- a/parsing/pcoq.ml
+++ b/parsing/pcoq.ml
@@ -363,8 +363,21 @@ end
 
 module Grammar = Register(GrammarObj)
 
+let warn_deprecated_intropattern =
+  let open CWarnings in
+  create ~name:"deprecated-intropattern-entry" ~category:"deprecated"
+  (fun () -> Pp.strbrk "Entry name intropattern has been renamed in order \
+  to be consistent with the documented grammar of tactics. Use \
+  \"simple_intropattern\" instead.")
+
+let check_compatibility = function
+  | Genarg.ExtraArg s when ArgT.repr s = "intropattern" -> warn_deprecated_intropattern ()
+  | _ -> ()
+
 let register_grammar = Grammar.register0
-let genarg_grammar = Grammar.obj
+let genarg_grammar x =
+  check_compatibility x;
+  Grammar.obj x
 
 let create_generic_entry (type a) u s (etyp : a raw_abstract_argument_type) : a Entry.t =
   let e = new_entry u s in

--- a/plugins/funind/g_indfun.mlg
+++ b/plugins/funind/g_indfun.mlg
@@ -83,7 +83,7 @@ let out_disjunctive = CAst.map (function
 
 }
 
-ARGUMENT EXTEND with_names TYPED AS intropattern option PRINTED BY { pr_intro_as_pat }
+ARGUMENT EXTEND with_names TYPED AS intro_pattern option PRINTED BY { pr_intro_as_pat }
 | [ "as"  simple_intropattern(ipat) ] -> { Some ipat }
 | []  -> { None }
 END

--- a/plugins/ltac/coretactics.mlg
+++ b/plugins/ltac/coretactics.mlg
@@ -150,7 +150,7 @@ TACTIC EXTEND specialize
 | [ "specialize" constr_with_bindings(c) ] -> {
     Tacticals.New.tclDELAYEDWITHHOLES false c (fun c -> Tactics.specialize c None)
   }
-| [ "specialize" constr_with_bindings(c) "as" intropattern(ipat) ] -> {
+| [ "specialize" constr_with_bindings(c) "as" simple_intropattern(ipat) ] -> {
     Tacticals.New.tclDELAYEDWITHHOLES false c (fun c -> Tactics.specialize c (Some ipat))
   }
 END

--- a/plugins/ltac/extraargs.mlg
+++ b/plugins/ltac/extraargs.mlg
@@ -35,7 +35,7 @@ let () = create_generic_quotation "ident" Pcoq.Prim.ident Stdarg.wit_ident
 let () = create_generic_quotation "reference" Pcoq.Prim.reference Stdarg.wit_ref
 let () = create_generic_quotation "uconstr" Pcoq.Constr.lconstr Stdarg.wit_uconstr
 let () = create_generic_quotation "constr" Pcoq.Constr.lconstr Stdarg.wit_constr
-let () = create_generic_quotation "ipattern" Pltac.simple_intropattern wit_intro_pattern
+let () = create_generic_quotation "ipattern" Pltac.simple_intropattern wit_simple_intropattern
 let () = create_generic_quotation "open_constr" Pcoq.Constr.lconstr Stdarg.wit_open_constr
 let () =
   let inject (loc, v) = Tacexpr.Tacexp v in
@@ -46,7 +46,7 @@ let () =
 let () =
   let register name entry = Tacentries.register_tactic_notation_entry name entry in
   register "hyp" wit_var;
-  register "simple_intropattern" wit_intro_pattern;
+  register "simple_intropattern" wit_simple_intropattern;
   register "integer" wit_integer;
   register "reference" wit_ref;
   ()

--- a/plugins/ltac/extratactics.mlg
+++ b/plugins/ltac/extratactics.mlg
@@ -174,15 +174,15 @@ TACTIC EXTEND einjection
 | [ "einjection" destruction_arg(c) ] -> { mytclWithHoles (injClause None None) true c }
 END
 TACTIC EXTEND injection_as
-| [ "injection" "as" intropattern_list(ipat)] ->
+| [ "injection" "as" simple_intropattern_list(ipat)] ->
     { injClause None (Some (decode_inj_ipat ipat)) false None }
-| [ "injection" destruction_arg(c) "as" intropattern_list(ipat)] ->
+| [ "injection" destruction_arg(c) "as" simple_intropattern_list(ipat)] ->
     { mytclWithHoles (injClause None (Some (decode_inj_ipat ipat))) false c }
 END
 TACTIC EXTEND einjection_as
-| [ "einjection" "as" intropattern_list(ipat)] ->
+| [ "einjection" "as" simple_intropattern_list(ipat)] ->
     { injClause None (Some (decode_inj_ipat ipat)) true None }
-| [ "einjection" destruction_arg(c) "as" intropattern_list(ipat)] ->
+| [ "einjection" destruction_arg(c) "as" simple_intropattern_list(ipat)] ->
     { mytclWithHoles (injClause None (Some (decode_inj_ipat ipat))) true c }
 END
 TACTIC EXTEND simple_injection

--- a/plugins/ltac/g_ltac.mlg
+++ b/plugins/ltac/g_ltac.mlg
@@ -38,7 +38,7 @@ let arg_of_expr = function
 
 let genarg_of_unit () = in_gen (rawwit Stdarg.wit_unit) ()
 let genarg_of_int n = in_gen (rawwit Stdarg.wit_int) n
-let genarg_of_ipattern pat = in_gen (rawwit Tacarg.wit_intro_pattern) pat
+let genarg_of_ipattern pat = in_gen (rawwit Tacarg.wit_simple_intropattern) pat
 let genarg_of_uconstr c = in_gen (rawwit Stdarg.wit_uconstr) c
 let in_tac tac = in_gen (rawwit Tacarg.wit_ltac) tac
 

--- a/plugins/ltac/pltac.ml
+++ b/plugins/ltac/pltac.ml
@@ -52,7 +52,9 @@ let () =
   let open Stdarg in
   let open Tacarg in
   register_grammar wit_int_or_var (int_or_var);
-  register_grammar wit_intro_pattern (simple_intropattern);
+  register_grammar wit_intro_pattern (simple_intropattern); (* To remove at end of deprecation phase *)
+(* register_grammar wit_intropattern (intropattern); *) (* To be added at end of deprecation phase *)
+  register_grammar wit_simple_intropattern (simple_intropattern);
   register_grammar wit_quant_hyp (quantified_hypothesis);
   register_grammar wit_uconstr (uconstr);
   register_grammar wit_open_constr (open_constr);

--- a/plugins/ltac/pptactic.ml
+++ b/plugins/ltac/pptactic.ml
@@ -1314,6 +1314,12 @@ let pr_glob_constr_pptac env sigma c =
 let pr_lglob_constr_pptac env sigma c =
   pr_lglob_constr_env env c
 
+let pr_raw_intro_pattern =
+  lift_env (fun env sigma -> Miscprint.pr_intro_pattern @@ pr_constr_expr env sigma)
+
+let pr_glob_intro_pattern =
+  lift_env (fun env sigma -> Miscprint.pr_intro_pattern (fun (c,_) -> pr_glob_constr_pptac env sigma c))
+
 let () =
   let pr_bool b = if b then str "true" else str "false" in
   let pr_unit _ = str "()" in
@@ -1323,11 +1329,8 @@ let () =
     pr_qualid (pr_or_var (pr_located pr_global)) pr_global;
   register_basic_print0 wit_ident pr_id pr_id pr_id;
   register_basic_print0 wit_var pr_lident pr_lident pr_id;
-  register_print0
-    wit_intro_pattern
-    (lift_env (fun env sigma -> Miscprint.pr_intro_pattern @@ pr_constr_expr env sigma))
-    (lift_env (fun env sigma -> Miscprint.pr_intro_pattern (fun (c,_) -> pr_glob_constr_pptac env sigma c)))
-    pr_intro_pattern_env;
+  register_print0 wit_intropattern pr_raw_intro_pattern pr_glob_intro_pattern pr_intro_pattern_env [@warning "-3"];
+  register_print0 wit_simple_intropattern pr_raw_intro_pattern pr_glob_intro_pattern pr_intro_pattern_env;
   Genprint.register_print0
     wit_clause_dft_concl
     (lift (pr_clauses (Some true) pr_lident))

--- a/plugins/ltac/tacarg.ml
+++ b/plugins/ltac/tacarg.ml
@@ -19,13 +19,19 @@ let make0 ?dyn name =
   let () = Geninterp.register_val0 wit dyn in
   wit
 
-let wit_intro_pattern = make0 "intropattern"
+let wit_intropattern = make0 "intropattern" (* To keep after deprecation phase but it will get a different parsing semantics (Tactic Notation and TACTIC EXTEND) in pltac.ml *)
+let wit_simple_intropattern = make0 "simple_intropattern"
 let wit_quant_hyp = make0 "quant_hyp"
 let wit_constr_with_bindings = make0 "constr_with_bindings"
 let wit_open_constr_with_bindings = make0 "open_constr_with_bindings"
 let wit_bindings = make0 "bindings"
 let wit_quantified_hypothesis = wit_quant_hyp
-let wit_intropattern = wit_intro_pattern
+
+(* A convenient common part to simple_intropattern and intropattern
+   usable when no parsing rule is concerned: indeed
+   simple_intropattern and intropattern are in the same type and have
+   the same interp/intern/subst methods *)
+let wit_intro_pattern = wit_intropattern
 
 let wit_tactic : (raw_tactic_expr, glob_tactic_expr, Val.t) genarg_type =
   make0 "tactic"

--- a/plugins/ltac/tacarg.mli
+++ b/plugins/ltac/tacarg.mli
@@ -16,6 +16,12 @@ open Tactypes
 open Tacexpr
 
 (** Tactic related witnesses, could also live in tactics/ if other users *)
+(* To keep after deprecation phase but it will get a different parsing semantics in pltac.ml *)
+val wit_intropattern : (constr_expr intro_pattern_expr CAst.t, glob_constr_and_expr intro_pattern_expr CAst.t, intro_pattern) genarg_type
+[@@ocaml.deprecated "Use wit_simple_intropattern"]
+
+val wit_simple_intropattern : (constr_expr intro_pattern_expr CAst.t, glob_constr_and_expr intro_pattern_expr CAst.t, intro_pattern) genarg_type
+
 val wit_intro_pattern : (constr_expr intro_pattern_expr CAst.t, glob_constr_and_expr intro_pattern_expr CAst.t, intro_pattern) genarg_type
 
 val wit_quant_hyp : quantified_hypothesis uniform_genarg_type
@@ -36,7 +42,6 @@ val wit_bindings :
   constr bindings delayed_open) genarg_type
 
 val wit_quantified_hypothesis : quantified_hypothesis uniform_genarg_type
-val wit_intropattern : (constr_expr intro_pattern_expr CAst.t, glob_constr_and_expr intro_pattern_expr CAst.t, intro_pattern) genarg_type
 
 (** Generic arguments based on Ltac. *)
 

--- a/plugins/ltac/tacintern.ml
+++ b/plugins/ltac/tacintern.ml
@@ -795,7 +795,8 @@ let () =
     let ist = { ist with ltacvars = !lf } in
     (ist, ans)
   in
-  Genintern.register_intern0 wit_intro_pattern intern_intro_pattern
+  Genintern.register_intern0 wit_intropattern intern_intro_pattern [@warning "-3"];
+  Genintern.register_intern0 wit_simple_intropattern intern_intro_pattern
 
 let () =
   let intern_clause ist cl =

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -2029,7 +2029,8 @@ let () =
   register_interp0 wit_pre_ident (lift interp_pre_ident);
   register_interp0 wit_ident (lift interp_ident);
   register_interp0 wit_var (lift interp_hyp);
-  register_interp0 wit_intro_pattern (lifts interp_intro_pattern);
+  register_interp0 wit_intropattern (lifts interp_intro_pattern) [@warning "-3"];
+  register_interp0 wit_simple_intropattern (lifts interp_intro_pattern);
   register_interp0 wit_clause_dft_concl (lift interp_clause);
   register_interp0 wit_constr (lifts interp_constr);
   register_interp0 wit_tacvalue (fun ist v -> Ftactic.return v);

--- a/plugins/ltac/tacsubst.ml
+++ b/plugins/ltac/tacsubst.ml
@@ -287,7 +287,8 @@ let () =
   Genintern.register_subst0 wit_pre_ident (fun _ v -> v);
   Genintern.register_subst0 wit_ident (fun _ v -> v);
   Genintern.register_subst0 wit_var (fun _ v -> v);
-  Genintern.register_subst0 wit_intro_pattern (fun _ v -> v);
+  Genintern.register_subst0 wit_intropattern subst_intro_pattern [@warning "-3"];
+  Genintern.register_subst0 wit_simple_intropattern subst_intro_pattern;
   Genintern.register_subst0 wit_tactic subst_tactic;
   Genintern.register_subst0 wit_ltac subst_tactic;
   Genintern.register_subst0 wit_constr subst_glob_constr;


### PR DESCRIPTION
This is to prevent confusing `intropattern` in `TACTIC EXTEND` and `Tactic Notation` with the terminology used in the grammar of tactics in the reference manual (in the former it is only what is called `simple_intropattern` in the reference manual.)

<!-- Keep what applies -->
**Kind:** fixing naming

This is a proposal in reaction to the discussion at [#9288](https://github.com/coq/coq/pull/9288#issuecomment-495723706).

Note: An alternative would be to silently change the semantics of `intropattern` in `TACTIC EXTEND` and `Tactic Notation` so that it means the same as `intropattern` in the reference manual. This would probably not be a problem in practice.