### PR TITLE
Add a sponsor button with a link to the Consortium page.

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: https://coq.inria.fr/consortium


### PR DESCRIPTION
<!-- Keep what applies -->
**Kind:** documentation / infrastructure.

For reference about sponsor buttons, see https://help.github.com/en/articles/displaying-a-sponsor-button-in-your-repository.
And here is the list of supported funding models (most of them are mostly directed towards individual maintainers):

```
# These are supported funding model platforms

github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
patreon: # Replace with a single Patreon username
open_collective: # Replace with a single Open Collective username
ko_fi: # Replace with a single Ko-fi username
tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
custom: # Replace with a single custom sponsorship URL
```

Note: we could also consider opening an Open Collective https://opencollective.com/ if this helps us get smaller contributions from individuals or companies.