### PR TITLE
Update README.md / add SUPPORT.md file.

### DIFF
--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,0 +1,28 @@
+# Support #
+
+Get in touch with the user community and ask questions about Coq on
+our [Discourse forum][]. Posts in other languages than English are
+explicitly welcome there. There is also a historic mailing list called
+the [Coq-Club][] which has lots of subscribers, and an IRC channel
+(`irc://irc.freenode.net/#coq`).
+
+In addition, you may also ask questions about Coq on [Stack
+Overflow][] (use the tag [coq][Stack Overflow tag]) or on the
+meta-theory of Coq on the [TCS Stack Exchange][] (which also has a
+[coq][TCS SE tag] tag).
+
+You can reach the Coq development team through the [development
+category][] of the above mentioned Discourse forum, the [Gitter
+channel][], and of course the bug tracker.
+
+See also [coq.inria.fr/community](https://coq.inria.fr/community.html).
+
+[Discourse forum]: https://coq.discourse.group
+[Coq-Club]: https://sympa.inria.fr/sympa/arc/coq-club
+[Stack Overflow]: https://stackoverflow.com
+[Stack Overflow tag]: https://stackoverflow.com/questions/tagged/coq
+[TCS Stack Exchange]: https://cstheory.stackexchange.com/
+[TCS SE tag]: https://cstheory.stackexchange.com/questions/tagged/coq
+[development category]: https://coq.discourse.group/c/coq-development
+[Gitter channel]: https://gitter.im/coq/coq
+[bug tracker]: https://github.com/coq/coq/issues

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ environment for semi-interactive development of machine-checked proofs.
 [![Arch package][arch-badge]][arch-link]
 [![Chocolatey package][chocolatey-badge]][chocolatey-link]
 [![Homebrew package][homebrew-badge]][homebrew-link]
-[![MacPorts package][macports-badge]][macports-link]
 [![nixpkgs unstable package][nixpkgs-badge]][nixpkgs-link]
 
 [repology-badge]: https://repology.org/badge/latest-versions/coq.svg
@@ -88,7 +87,7 @@ development team:
 
 See also [coq.inria.fr/community](https://coq.inria.fr/community.html).
 
-## Bugs report
+## Bug reports
 
 Please report any bug / feature request in [our issue tracker](https://github.com/coq/coq/issues).
 


### PR DESCRIPTION
**Kind:** documentation / infrastructure.

- Remove MacPorts link / badge from README (not updated since 8.8.2).
- Add SUPPORT.md file.

  A link to this file will be displayed when people start opening an issue, and maybe in some other places.

  See also: https://help.github.com/en/articles/adding-support-resources-to-your-project