### PR TITLE
Investigations in the initialization of coq binaries and command line (part 1)

### DIFF
--- a/ide/coq.ml
+++ b/ide/coq.ml
@@ -102,7 +102,7 @@ let display_coqtop_answer cmd lines =
 
 let rec filter_coq_opts args =
   let argstr = String.concat " " (List.map Filename.quote args) in
-  let cmd = Filename.quote (coqtop_path ()) ^" -nois -filteropts " ^ argstr in
+  let cmd = Filename.quote (coqtop_path ()) ^" -nois -batch " ^ argstr in
   let cmd = requote cmd in
   let filtered_args = ref [] in
   let errlines = ref [] in

--- a/ide/idetop.ml
+++ b/ide/idetop.ml
@@ -552,11 +552,15 @@ let rec parse = function
        x :: parse rest
   | [] -> []
 
-let () = Usage.add_to_usage "coqidetop" "" "\n\
+let coqidetop_specific_usage = Usage.{
+  executable_name = "coqidetop";
+  extra_args = "";
+  extra_options = "\n\
 coqidetop specific options:\n\
 \n  --xml_formatinclude dir           (idem)\
 \n  --xml_format=Ppcmds    serialize pretty printing messages using the std_ppcmds format\
 \n  --help-XML-protocol    print documentation of the Coq XML protocol\n"
+}
 
 let islave_parse ~opts extra_args =
   let open Coqtop in
@@ -582,7 +586,7 @@ let () =
   let open Coqtop in
   let custom = {
       parse_extra = islave_parse ;
-      help = Usage.print_usage "coqidetop";
+      help = coqidetop_specific_usage;
       init = islave_init;
       run = loop;
       opts = islave_default_opts } in

--- a/ide/idetop.ml
+++ b/ide/idetop.ml
@@ -552,8 +552,10 @@ let rec parse = function
        x :: parse rest
   | [] -> []
 
-let () = Usage.add_to_usage "coqidetop"
-"  --xml_format=Ppcmds    serialize pretty printing messages using the std_ppcmds format\
+let () = Usage.add_to_usage "coqidetop" "" "\n\
+coqidetop specific options:\n\
+\n  --xml_formatinclude dir           (idem)\
+\n  --xml_format=Ppcmds    serialize pretty printing messages using the std_ppcmds format\
 \n  --help-XML-protocol    print documentation of the Coq XML protocol\n"
 
 let islave_parse ~opts extra_args =
@@ -580,7 +582,7 @@ let () =
   let open Coqtop in
   let custom = {
       parse_extra = islave_parse ;
-      help = (fun _ -> output_string stderr "Same options as coqtop");
+      help = Usage.print_usage "coqidetop";
       init = islave_init;
       run = loop;
       opts = islave_default_opts } in

--- a/ide/idetop.ml
+++ b/ide/idetop.ml
@@ -496,7 +496,10 @@ let msg_format = ref (fun () ->
 
 (* The loop ignores the command line arguments as the current model delegates
    its handing to the toplevel container. *)
-let loop ~opts:_ ~state =
+let loop run_mode ~opts:_ state =
+  match run_mode with
+  | Coqtop.Batch -> exit 0
+  | Coqtop.Interactive ->
   let open Vernac.State in
   set_doc state.doc;
   init_signal_handler ();
@@ -563,7 +566,9 @@ let islave_parse ~opts extra_args =
   print_string (String.concat "\n" extra_args);
   run_mode, []
 
-let islave_init ~opts = ()
+let islave_init run_mode ~opts =
+  if run_mode = Coqtop.Batch then Flags.quiet := true;
+  Coqtop.init_toploop opts
 
 let islave_default_opts =
   Coqargs.{ default with

--- a/ide/idetop.ml
+++ b/ide/idetop.ml
@@ -563,8 +563,13 @@ let islave_parse ~opts extra_args =
   print_string (String.concat "\n" extra_args);
   run_mode, []
 
-let islave_init ~opts =
-  CoqworkmgrApi.(init High)
+let islave_init ~opts = ()
+
+let islave_default_opts =
+  Coqargs.{ default with
+    config = { default.config with
+      stm_flags = { default.config.stm_flags with
+         Stm.AsyncOpts.async_proofs_worker_priority = CoqworkmgrApi.High }}}
 
 let () =
   let open Coqtop in
@@ -573,5 +578,5 @@ let () =
       help = (fun _ -> output_string stderr "Same options as coqtop");
       init = islave_init;
       run = loop;
-      opts = Coqargs.default } in
+      opts = islave_default_opts } in
   start_coq custom

--- a/stm/asyncTaskQueue.ml
+++ b/stm/asyncTaskQueue.ml
@@ -155,8 +155,8 @@ module Make(T : Task) () = struct
       let args =
         Array.of_list (set_slave_opt (List.tl (Array.to_list Sys.argv))) in
       let env = Array.append (T.extra_env ()) (Unix.environment ()) in
-    let worker_name = System.get_toplevel_path ("coq" ^ !T.name) in
-    Worker.spawn ~env worker_name args in
+      let worker_name = System.get_toplevel_path ("coq" ^ !T.name) in
+      Worker.spawn ~env worker_name args in
     name, proc, CThread.prepare_in_channel_for_thread_friendly_io ic, oc
 
   let manager cpanel (id, proc, ic, oc) =

--- a/stm/asyncTaskQueue.ml
+++ b/stm/asyncTaskQueue.ml
@@ -125,7 +125,7 @@ module Make(T : Task) () = struct
                  "-async-proofs-worker-priority";
                  CoqworkmgrApi.(string_of_priority !async_proofs_worker_priority)]
         (* Options to discard: 0 arguments *)
-        | ("-emacs"|"-batch")::tl ->
+        | "-emacs"::tl ->
           set_slave_opt tl
         (* Options to discard: 1 argument *)
         | ( "-async-proofs" | "-vio2vo" | "-o"

--- a/stm/asyncTaskQueue.mli
+++ b/stm/asyncTaskQueue.mli
@@ -144,10 +144,10 @@ module MakeQueue(T : Task) () : sig
   (** [queue] is the abstract queue type. *)
   type queue
 
-  (** [create n] will initialize the queue with [n] workers. If [n] is
-      0, the queue won't spawn any process, working in a lazy local
-      manner. [not imposed by the this API] *)
-  val create : int -> queue
+  (** [create n pri] will initialize the queue with [n] workers having
+      priority [pri]. If [n] is 0, the queue won't spawn any process,
+      working in a lazy local manner. [not imposed by the this API] *)
+  val create : int -> CoqworkmgrApi.priority -> queue
 
   (** [destroy q] Deallocates [q], cancelling all pending tasks. *)
   val destroy : queue -> unit
@@ -203,9 +203,9 @@ module MakeQueue(T : Task) () : sig
   (** [clear q] Clears [q], only if the worker prool is empty *)
   val clear : queue -> unit
 
-  (** [with_n_workers n f] create a queue, run the function, destroy
+  (** [with_n_workers n pri f] creates a queue, runs the function, destroys
       the queue. The user should call join *)
-  val with_n_workers : int -> (queue -> 'a) -> 'a
+  val with_n_workers : int -> CoqworkmgrApi.priority -> (queue -> 'a) -> 'a
 
 end
 

--- a/stm/asyncTaskQueue.mli
+++ b/stm/asyncTaskQueue.mli
@@ -68,10 +68,10 @@ module type Task = sig
   type request
   type response
 
-  (** UID of the task kind, for -toploop *)
+  (** UID of the task kind *)
   val name : string ref
 
-  (** Extra arguments of the task kind, for -toploop *)
+  (** Extra arguments of the task kind *)
   val extra_env : unit -> string array
 
   (** {5 Master API, it is run by the master, on a thread} *)

--- a/stm/coqworkmgrApi.ml
+++ b/stm/coqworkmgrApi.ml
@@ -13,7 +13,8 @@ let debug = false
 type priority = Low | High
 
 (* Default priority *)
-let async_proofs_worker_priority = ref Low
+
+let default_async_proofs_worker_priority = Low
 
 let string_of_priority = function Low -> "low" | High -> "high"
 let priority_of_string = function

--- a/stm/coqworkmgrApi.mli
+++ b/stm/coqworkmgrApi.mli
@@ -15,7 +15,7 @@ val string_of_priority : priority -> string
 val priority_of_string : string -> priority
 
 (* Default priority *)
-val async_proofs_worker_priority : priority ref
+val default_async_proofs_worker_priority : priority
 
 (* Connects to a work manager if any. If no worker manager, then
    -async-proofs-j and -async-proofs-tac-j are used *)

--- a/stm/stm.mli
+++ b/stm/stm.mli
@@ -34,6 +34,8 @@ module AsyncOpts : sig
     async_proofs_tac_error_resilience : tac_error_filter;
     async_proofs_cmd_error_resilience : bool;
     async_proofs_delegation_threshold : float;
+
+    async_proofs_worker_priority : CoqworkmgrApi.priority;
   }
 
   val default_opts : stm_opt

--- a/stm/workerPool.mli
+++ b/stm/workerPool.mli
@@ -19,7 +19,8 @@ type 'a cpanel = {
 module type PoolModel = sig
   (* this shall come from a Spawn.* model *)
   type process
-  val spawn : int -> worker_id * process * CThread.thread_ic * out_channel
+  val spawn : int -> CoqworkmgrApi.priority ->
+    worker_id * process * CThread.thread_ic * out_channel
 
   (* this defines the main loop of the manager *)
   type extra
@@ -31,7 +32,7 @@ module Make(Model : PoolModel) : sig
 
   type pool
   
-  val create : Model.extra -> size:int -> pool
+  val create : Model.extra -> size:int -> CoqworkmgrApi.priority -> pool
 
   val is_empty : pool -> bool
   val n_workers : pool -> int

--- a/topbin/coqproofworker_bin.ml
+++ b/topbin/coqproofworker_bin.ml
@@ -11,4 +11,4 @@
 module W = AsyncTaskQueue.MakeWorker(Stm.ProofTask) ()
 
 let () =
-  WorkerLoop.start ~init:W.init_stdout ~loop:W.main_loop
+  WorkerLoop.start ~init:W.init_stdout ~loop:W.main_loop "coqproofworker"

--- a/topbin/coqqueryworker_bin.ml
+++ b/topbin/coqqueryworker_bin.ml
@@ -10,4 +10,4 @@
 
 module W = AsyncTaskQueue.MakeWorker(Stm.QueryTask) ()
 
-let () = WorkerLoop.start ~init:W.init_stdout ~loop:W.main_loop
+let () = WorkerLoop.start ~init:W.init_stdout ~loop:W.main_loop "coqqueryworker"

--- a/topbin/coqtacticworker_bin.ml
+++ b/topbin/coqtacticworker_bin.ml
@@ -10,4 +10,4 @@
 
 module W = AsyncTaskQueue.MakeWorker(Stm.TacTask) ()
 
-let () = WorkerLoop.start ~init:W.init_stdout ~loop:W.main_loop
+let () = WorkerLoop.start ~init:W.init_stdout ~loop:W.main_loop "coqtacticworker"

--- a/toplevel/ccompile.ml
+++ b/toplevel/ccompile.ml
@@ -22,9 +22,9 @@ let fatal_error msg =
 (******************************************************************************)
 
 let load_init_file opts ~state =
-  if opts.load_rcfile then
+  if opts.pre.load_rcfile then
     Topfmt.(in_phase ~phase:LoadingRcFile) (fun () ->
-        Coqinit.load_rcfile ~rcfile:opts.rcfile ~state) ()
+        Coqinit.load_rcfile ~rcfile:opts.config.rcfile ~state) ()
   else begin
     Flags.if_verbose Feedback.msg_info (str"Skipping rcfile loading.");
     state
@@ -39,7 +39,7 @@ let load_vernacular opts ~state =
       if !Flags.beautify
       then Flags.with_option Flags.beautify_file load_vernac f_in
       else load_vernac s
-    ) state (List.rev opts.load_vernacular_list)
+    ) state (List.rev opts.pre.load_vernacular_list)
 
 let load_init_vernaculars opts ~state =
   let state = load_init_file opts ~state in
@@ -102,8 +102,8 @@ let compile opts copts ~echo ~f_in ~f_out =
   in
   let iload_path = build_load_path opts in
   let require_libs = require_libs opts in
-  let stm_options = opts.stm_flags in
-  let output_native_objects = match opts.native_compiler with
+  let stm_options = opts.config.stm_flags in
+  let output_native_objects = match opts.config.native_compiler with
     | NativeOff -> false | NativeOn {ondemand} -> not ondemand
   in
   match copts.compilation_mode with
@@ -118,7 +118,7 @@ let compile opts copts ~echo ~f_in ~f_out =
           Stm.{ doc_type = VoDoc long_f_dot_vo;
                 iload_path; require_libs; stm_options;
               } in
-      let state = { doc; sid; proof = None; time = opts.time } in
+      let state = { doc; sid; proof = None; time = opts.config.time } in
       let state = load_init_vernaculars opts ~state in
       let ldir = Stm.get_ldir ~doc:state.doc in
       Aux_file.(start_aux_file
@@ -164,7 +164,7 @@ let compile opts copts ~echo ~f_in ~f_out =
                 iload_path; require_libs; stm_options;
               } in
 
-      let state = { doc; sid; proof = None; time = opts.time } in
+      let state = { doc; sid; proof = None; time = opts.config.time } in
       let state = load_init_vernaculars opts ~state in
       let ldir = Stm.get_ldir ~doc:state.doc in
       let state = Vernac.load_vernac ~echo ~check:false ~interactive:false ~state long_f_dot_v in

--- a/toplevel/ccompile.ml
+++ b/toplevel/ccompile.ml
@@ -20,6 +20,16 @@ let fatal_error msg =
 (******************************************************************************)
 (* Interactive Load File Simulation                                           *)
 (******************************************************************************)
+
+let load_init_file opts ~state =
+  if opts.load_rcfile then
+    Topfmt.(in_phase ~phase:LoadingRcFile) (fun () ->
+        Coqinit.load_rcfile ~rcfile:opts.rcfile ~state) ()
+  else begin
+    Flags.if_verbose Feedback.msg_info (str"Skipping rcfile loading.");
+    state
+  end
+
 let load_vernacular opts ~state =
   List.fold_left
     (fun state (f_in, echo) ->
@@ -32,16 +42,9 @@ let load_vernacular opts ~state =
     ) state (List.rev opts.load_vernacular_list)
 
 let load_init_vernaculars opts ~state =
-  let state =
-    if opts.load_rcfile then
-      Topfmt.(in_phase ~phase:LoadingRcFile) (fun () ->
-          Coqinit.load_rcfile ~rcfile:opts.rcfile ~state) ()
-    else begin
-      Flags.if_verbose Feedback.msg_info (str"Skipping rcfile loading.");
-      state
-    end in
-
-  load_vernacular opts ~state
+  let state = load_init_file opts ~state in
+  let state = load_vernacular opts ~state in
+  state
 
 (******************************************************************************)
 (* File Compilation                                                           *)

--- a/toplevel/coqargs.ml
+++ b/toplevel/coqargs.ml
@@ -81,7 +81,7 @@ type coqargs_pre = {
 type coqargs_query =
   | PrintTags | PrintWhere | PrintConfig
   | PrintVersion | PrintMachineReadableVersion
-  | PrintHelp of (unit -> unit)
+  | PrintHelp of (out_channel -> unit)
 
 type coqargs_main =
   | Queries of coqargs_query list
@@ -290,6 +290,7 @@ let usage_no_coqlib = CWarnings.create ~name:"usage-no-coqlib" ~category:"filesy
 
 exception NoCoqLib
 
+(* Is this still useful for displaying help? *)
 let usage help =
   begin
     try Envars.set_coqlib ~fail:(fun x -> raise NoCoqLib)
@@ -298,7 +299,7 @@ let usage help =
   let lp = Coqinit.toplevel_init_load_path () in
   (* Necessary for finding the toplevels below *)
   List.iter Loadpath.add_coq_path lp;
-  help ()
+  help
 
 (* Main parsing routine *)
 let parse_args ~help ~init arglist : t * string list =
@@ -554,7 +555,8 @@ let parse_args ~help ~init arglist : t * string list =
     |"-type-in-type" -> set_type_in_type (); oval
     |"-unicode" -> add_vo_require oval "Utf8_core" None (Some false)
     |"-where" -> set_query oval PrintWhere
-    |"-h"|"-H"|"-?"|"-help"|"--help" -> set_query oval (PrintHelp (fun () -> usage help))
+    |"-h"|"-H"|"-?"|"-help"|"--help" ->
+     set_query oval (PrintHelp (fun co -> usage (help co)))
     |"-v"|"--version" -> set_query oval PrintVersion
     |"-print-version"|"--print-version" -> set_query oval PrintMachineReadableVersion
 

--- a/toplevel/coqargs.ml
+++ b/toplevel/coqargs.ml
@@ -78,18 +78,13 @@ type coqargs_pre = {
   inputstate  : string option;
 }
 
-type coqargs_base_query =
+type coqargs_query =
   | PrintTags | PrintWhere | PrintConfig
   | PrintVersion | PrintMachineReadableVersion
   | PrintHelp of (unit -> unit)
 
-type coqargs_queries = {
-  queries : coqargs_base_query list;
-  filteropts : string list option;
-}
-
 type coqargs_main =
-  | Queries of coqargs_queries
+  | Queries of coqargs_query list
   | Run
 
 type coqargs_post = {
@@ -147,10 +142,7 @@ let default_pre = {
   inputstate   = None;
 }
 
-let default_queries = {
-  queries = [];
-  filteropts = None;
-}
+let default_queries = []
 
 let default_post = {
   memory_stat  = false;
@@ -204,22 +196,10 @@ let set_color opts = function
   | _ ->
     error_wrong_arg ("Error: on/off/auto expected after option color")
 
-let add_query { queries; filteropts } q =
-  { queries = queries@[q]; filteropts }
-
 let set_query opts q =
   { opts with main = match opts.main with
-  | Run -> Queries (add_query default_queries q)
-  | Queries queries -> Queries (add_query queries q)
-  }
-
-let add_filteropts { queries } =
-  { queries; filteropts = Some [] }
-
-let set_filteropts opts =
-  { opts with main = match opts.main with
-  | Run -> Queries (add_filteropts default_queries)
-  | Queries queries -> Queries (add_filteropts queries)
+  | Run -> Queries (default_queries@[q])
+  | Queries queries -> Queries (queries@[q])
   }
 
 let warn_deprecated_inputstate =
@@ -553,7 +533,6 @@ let parse_args ~help ~init arglist : t * string list =
                   { oval with config = { oval.config with diffs_set = true }}
     |"-stm-debug" -> Stm.stm_debug := true; oval
     |"-emacs" -> set_emacs oval
-    |"-filteropts" -> set_filteropts oval
     |"-impredicative-set" ->
       set_logic (fun o -> { o with impredicative_set = Declarations.ImpredicativeSet }) oval
     |"-allow-sprop" -> set_logic (fun o -> { o with allow_sprop = true }) oval

--- a/toplevel/coqargs.ml
+++ b/toplevel/coqargs.ml
@@ -386,8 +386,9 @@ let parse_args ~help ~init arglist : t * string list =
       }}}
 
     |"-async-proofs-worker-priority" ->
-      CoqworkmgrApi.async_proofs_worker_priority := get_priority opt (next ());
-      oval
+      { oval with config = { oval.config with stm_flags = { oval.config.stm_flags with
+        Stm.AsyncOpts.async_proofs_worker_priority = get_priority opt (next ())
+      }}}
 
     |"-async-proofs-private-flags" ->
       { oval with config = { oval.config with stm_flags = { oval.config.stm_flags with

--- a/toplevel/coqargs.mli
+++ b/toplevel/coqargs.mli
@@ -16,57 +16,76 @@ type native_compiler = NativeOff | NativeOn of { ondemand : bool }
 
 type option_command = OptionSet of string option | OptionUnset
 
-type t = {
-
-  load_init   : bool;
-  load_rcfile : bool;
-  rcfile      : string option;
-
-  ml_includes : Loadpath.coq_path list;
-  vo_includes : Loadpath.coq_path list;
-  vo_requires : (string * string option * bool option) list;
-
-  toplevel_name : Stm.interactive_top;
-
-  load_vernacular_list : (string * bool) list;
-  batch : bool;
-
-  color : color;
-
+type coqargs_logic_config = {
   impredicative_set : Declarations.set_predicativity;
-  indices_matter : bool;
-  enable_VM : bool;
+  indices_matter    : bool;
+  toplevel_name     : Stm.interactive_top;
+  allow_sprop       : bool;
+  cumulative_sprop  : bool;
+}
+
+type coqargs_config = {
+  logic       : coqargs_logic_config;
+  rcfile      : string option;
+  coqlib      : string option;
+  color       : color;
+  enable_VM   : bool;
   native_compiler : native_compiler;
-  allow_sprop : bool;
-  cumulative_sprop : bool;
-
-  set_options : (Goptions.option_name * option_command) list;
-
   stm_flags   : Stm.AsyncOpts.stm_opt;
   debug       : bool;
   diffs_set   : bool;
   time        : bool;
-
-  filter_opts : bool;
-
   glob_opt    : bool;
-
-  memory_stat : bool;
-  print_tags  : bool;
-  print_where : bool;
-  print_config: bool;
-  output_context : bool;
-
   print_emacs : bool;
+  set_options : (Goptions.option_name * option_command) list;
+}
 
+type coqargs_pre = {
+  load_init   : bool;
+  load_rcfile : bool;
+
+  ml_includes : Loadpath.coq_path list;
+  vo_includes : Loadpath.coq_path list;
+  vo_requires : (string * string option * bool option) list;
+  (* None = No Import; Some false = Import; Some true = Export *)
+
+  load_vernacular_list : (string * bool) list;
   inputstate  : string option;
+}
+
+type coqargs_base_query =
+  | PrintTags | PrintWhere | PrintConfig
+  | PrintVersion | PrintMachineReadableVersion
+  | PrintHelp of (unit -> unit)
+
+type coqargs_queries = {
+  queries : coqargs_base_query list;
+  filteropts : bool;
+}
+
+type coqargs_interactive = Interactive | Batch
+
+type coqargs_main =
+  | Queries of coqargs_queries
+  | Run of coqargs_interactive
+
+type coqargs_post = {
+  memory_stat : bool;
+  output_context : bool;
+}
+
+type t = {
+  config : coqargs_config;
+  pre : coqargs_pre;
+  main : coqargs_main;
+  post : coqargs_post;
 }
 
 (* Default options *)
 val default : t
 
 val parse_args : help:(unit -> unit) -> init:t -> string list -> t * string list
-val exitcode : t -> int
+val error_wrong_arg : string -> unit
 
 val require_libs : t -> (string * string option * bool option) list
 val build_load_path : t -> Loadpath.coq_path list

--- a/toplevel/coqargs.mli
+++ b/toplevel/coqargs.mli
@@ -53,18 +53,13 @@ type coqargs_pre = {
   inputstate  : string option;
 }
 
-type coqargs_base_query =
+type coqargs_query =
   | PrintTags | PrintWhere | PrintConfig
   | PrintVersion | PrintMachineReadableVersion
   | PrintHelp of (unit -> unit)
 
-type coqargs_queries = {
-  queries : coqargs_base_query list;
-  filteropts : string list option;
-}
-
 type coqargs_main =
-  | Queries of coqargs_queries
+  | Queries of coqargs_query list
   | Run
 
 type coqargs_post = {

--- a/toplevel/coqargs.mli
+++ b/toplevel/coqargs.mli
@@ -60,14 +60,12 @@ type coqargs_base_query =
 
 type coqargs_queries = {
   queries : coqargs_base_query list;
-  filteropts : bool;
+  filteropts : string list option;
 }
-
-type coqargs_interactive = Interactive | Batch
 
 type coqargs_main =
   | Queries of coqargs_queries
-  | Run of coqargs_interactive
+  | Run
 
 type coqargs_post = {
   memory_stat : bool;

--- a/toplevel/coqargs.mli
+++ b/toplevel/coqargs.mli
@@ -56,7 +56,7 @@ type coqargs_pre = {
 type coqargs_query =
   | PrintTags | PrintWhere | PrintConfig
   | PrintVersion | PrintMachineReadableVersion
-  | PrintHelp of (unit -> unit)
+  | PrintHelp of (out_channel -> unit)
 
 type coqargs_main =
   | Queries of coqargs_query list
@@ -77,7 +77,7 @@ type t = {
 (* Default options *)
 val default : t
 
-val parse_args : help:(unit -> unit) -> init:t -> string list -> t * string list
+val parse_args : help:(out_channel -> unit) -> init:t -> string list -> t * string list
 val error_wrong_arg : string -> unit
 
 val require_libs : t -> (string * string option * bool option) list

--- a/toplevel/coqargs.mli
+++ b/toplevel/coqargs.mli
@@ -56,7 +56,7 @@ type coqargs_pre = {
 type coqargs_query =
   | PrintTags | PrintWhere | PrintConfig
   | PrintVersion | PrintMachineReadableVersion
-  | PrintHelp of (out_channel -> unit)
+  | PrintHelp of Usage.specific_usage
 
 type coqargs_main =
   | Queries of coqargs_query list
@@ -77,7 +77,7 @@ type t = {
 (* Default options *)
 val default : t
 
-val parse_args : help:(out_channel -> unit) -> init:t -> string list -> t * string list
+val parse_args : help:Usage.specific_usage -> init:t -> string list -> t * string list
 val error_wrong_arg : string -> unit
 
 val require_libs : t -> (string * string option * bool option) list

--- a/toplevel/coqc.ml
+++ b/toplevel/coqc.ml
@@ -28,11 +28,11 @@ let coqc_main () =
   in
   let opts, extras =
     Topfmt.(in_phase ~phase:Initialization)
-      Coqtop.(init_toplevel ~help:Usage.print_usage_coqc ~init:Coqargs.default coqc_init) List.(tl (Array.to_list Sys.argv)) in
+      Coqtop.(init_batch_toplevel ~help:Usage.print_usage_coqc ~init:Coqargs.default coqc_init) List.(tl (Array.to_list Sys.argv)) in
 
   let copts = Coqcargs.parse extras in
 
-  if not opts.Coqargs.glob_opt then Dumpglob.dump_to_dotglob ();
+  if not opts.Coqargs.config.Coqargs.glob_opt then Dumpglob.dump_to_dotglob ();
 
   Topfmt.(in_phase ~phase:CompilationPhase)
     Ccompile.compile_files opts copts;
@@ -47,7 +47,7 @@ let coqc_main () =
 
   flush_all();
 
-  if opts.Coqargs.output_context then begin
+  if opts.Coqargs.post.Coqargs.output_context then begin
     let sigma, env = let e = Global.env () in Evd.from_env e, e in
     Feedback.msg_notice Pp.(Flags.(with_option raw_print (Prettyp.print_full_pure_context env) sigma) ++ fnl ())
   end;

--- a/toplevel/coqc.ml
+++ b/toplevel/coqc.ml
@@ -30,11 +30,9 @@ let coqc_main () =
       init = coqc_init;
       parse_extra = (fun ~opts extras -> Coqcargs.parse extras, []);
     } in
-  let opts, extras =
+  let opts, copts =
     Topfmt.(in_phase ~phase:Initialization)
-      Coqtop.(init_batch_toplevel ~help:Usage.print_usage_coqc ~init:Coqargs.default (fun ~opts extras -> coqc_init ~opts; (opts, extras))) List.(tl (Array.to_list Sys.argv)) in
-
-  let copts, extras = custom_coqc.Coqtop.parse_extra ~opts extras in
+      Coqtop.init_toplevel custom_coqc in
 
   if not opts.Coqargs.config.Coqargs.glob_opt then Dumpglob.dump_to_dotglob ();
 

--- a/toplevel/coqc.ml
+++ b/toplevel/coqc.ml
@@ -19,6 +19,21 @@ let coqc_init _copts ~opts =
   Coqtop.init_color opts.Coqargs.config;
   if not opts.Coqargs.config.Coqargs.glob_opt then Dumpglob.dump_to_dotglob ()
 
+let () = Usage.add_to_usage "coqc" "file..." "\n\
+coqc specific options:\
+\n  -o f.vo                use f.vo as the output file name\
+\n  -verbose               compile and output the input file\
+\n  -quick                 quickly compile .v files to .vio files (skip proofs)\
+\n  -schedule-vio2vo j f1..fn   run up to j instances of Coq to turn each fi.vio\
+\n                         into fi.vo\
+\n  -schedule-vio-checking j f1..fn   run up to j instances of Coq to check all\
+\n                         proofs in each fi.vio\
+\n\
+\nUndocumented:\
+\n  -vio2vo                [see manual]\
+\n  -check-vio-tasks       [see manual]\
+\n"
+
 let coqc_main copts ~opts =
   Topfmt.(in_phase ~phase:CompilationPhase)
     Ccompile.compile_files opts copts;
@@ -53,7 +68,7 @@ let coqc_run copts ~opts () =
 
 let custom_coqc = Coqtop.{
   parse_extra = (fun ~opts extras -> Coqcargs.parse extras, []);
-  help = Usage.print_usage_coqc;
+  help = Usage.print_usage "coqc";
   init = coqc_init;
   run = coqc_run;
   opts = Coqargs.default;

--- a/toplevel/coqc.ml
+++ b/toplevel/coqc.ml
@@ -19,7 +19,10 @@ let coqc_init _copts ~opts =
   Coqtop.init_color opts.Coqargs.config;
   if not opts.Coqargs.config.Coqargs.glob_opt then Dumpglob.dump_to_dotglob ()
 
-let () = Usage.add_to_usage "coqc" "file..." "\n\
+let coqc_specific_usage = Usage.{
+  executable_name = "coqc";
+  extra_args = "file...";
+  extra_options = "\n\
 coqc specific options:\
 \n  -o f.vo                use f.vo as the output file name\
 \n  -verbose               compile and output the input file\
@@ -33,6 +36,7 @@ coqc specific options:\
 \n  -vio2vo                [see manual]\
 \n  -check-vio-tasks       [see manual]\
 \n"
+}
 
 let coqc_main copts ~opts =
   Topfmt.(in_phase ~phase:CompilationPhase)
@@ -68,7 +72,7 @@ let coqc_run copts ~opts () =
 
 let custom_coqc = Coqtop.{
   parse_extra = (fun ~opts extras -> Coqcargs.parse extras, []);
-  help = Usage.print_usage "coqc";
+  help = coqc_specific_usage;
   init = coqc_init;
   run = coqc_run;
   opts = Coqargs.default;

--- a/toplevel/coqloop.ml
+++ b/toplevel/coqloop.ml
@@ -444,7 +444,7 @@ let drop_args = ref None
 let loop ~opts ~state =
   drop_args := Some opts;
   let open Coqargs in
-  print_emacs := opts.print_emacs;
+  print_emacs := opts.config.print_emacs;
   (* We initialize the console only if we run the toploop_run *)
   let tl_feed = Feedback.add_feeder coqloop_feed in
   if Dumpglob.dump () then begin

--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -155,22 +155,13 @@ let print_style_tags opts =
   let () = List.iter iter tags in
   flush_all ()
 
-let print_queries opts q =
-  let print_query = function
-    | PrintVersion -> Usage.version ()
-    | PrintMachineReadableVersion -> Usage.machine_readable_version ()
-    | PrintWhere -> print_endline (Envars.coqlib ())
-    | PrintHelp f -> f ()
-    | PrintConfig -> Envars.print_config stdout Coq_config.all_src_dirs
-    | PrintTags -> print_style_tags opts.config in
-  List.iter print_query q.queries;
-  match q.filteropts with
-  | Some extras ->
-    if q.queries <> [] && extras <> [] then
-      error_wrong_arg "Queries are exclusive of other arguments"
-    else
-      print_string (String.concat "\n" extras)
-  | None -> ()
+let print_query opts = function
+  | PrintVersion -> Usage.version ()
+  | PrintMachineReadableVersion -> Usage.machine_readable_version ()
+  | PrintWhere -> print_endline (Envars.coqlib ())
+  | PrintHelp f -> f ()
+  | PrintConfig -> Envars.print_config stdout Coq_config.all_src_dirs
+  | PrintTags -> print_style_tags opts.config
 
 (** GC tweaking *)
 
@@ -268,7 +259,7 @@ let init_toplevel custom =
   let () = init_setup opts.config.coqlib in
   (* Querying or running? *)
   match opts.main with
-  | Queries q -> print_queries opts q; exit 0
+  | Queries q -> List.iter (print_query opts) q; exit 0
   | Run ->
     let customstate = init_execution opts (custom.init customopts) in
     opts, customopts, customstate

--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -233,6 +233,7 @@ let init_execution opts custom_init =
   let top_lp = Coqinit.toplevel_init_load_path () in
   List.iter Loadpath.add_coq_path top_lp;
   custom_init ~opts;
+  CoqworkmgrApi.(init opts.config.stm_flags.Stm.AsyncOpts.async_proofs_worker_priority);
   Mltop.init_known_plugins ();
   (* Configuration *)
   Global.set_engagement opts.config.logic.impredicative_set;
@@ -315,7 +316,6 @@ let start_coq custom =
 
 let coqtop_init ~opts =
   init_color opts.config;
-  CoqworkmgrApi.(init !async_proofs_worker_priority);
   Flags.if_verbose print_header ()
 
 let coqtop_parse_extra ~opts extras =

--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -30,23 +30,18 @@ let print_header () =
   Feedback.msg_notice (str "Welcome to Coq " ++ str ver ++ str " (" ++ str rev ++ str ")");
   flush_all ()
 
-let memory_stat = ref false
 let print_memory_stat () =
-  begin (* -m|--memory from the command-line *)
-    if !memory_stat then
-    Feedback.msg_notice
-      (str "total heap size = " ++ int (CObj.heap_size_kb ()) ++ str " kbytes" ++ fnl ());
-  end;
-  begin
-    (* operf-macro interface:
-       https://github.com/OCamlPro/operf-macro *)
-    try
-      let fn = Sys.getenv "OCAML_GC_STATS" in
-      let oc = open_out fn in
-      Gc.print_stat oc;
-      close_out oc
-    with _ -> ()
-  end
+  (* -m|--memory from the command-line *)
+  Feedback.msg_notice
+    (str "total heap size = " ++ int (CObj.heap_size_kb ()) ++ str " kbytes" ++ fnl ());
+  (* operf-macro interface:
+     https://github.com/OCamlPro/operf-macro *)
+  try
+    let fn = Sys.getenv "OCAML_GC_STATS" in
+    let oc = open_out fn in
+    Gc.print_stat oc;
+    close_out oc
+  with _ -> ()
 
 let interp_set_option opt v old =
   let open Goptions in

--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -159,7 +159,7 @@ let print_query opts = function
   | PrintVersion -> Usage.version ()
   | PrintMachineReadableVersion -> Usage.machine_readable_version ()
   | PrintWhere -> print_endline (Envars.coqlib ())
-  | PrintHelp f -> f stderr
+  | PrintHelp h -> Usage.print_usage stderr h
   | PrintConfig -> Envars.print_config stdout Coq_config.all_src_dirs
   | PrintTags -> print_style_tags opts.config
 
@@ -246,7 +246,7 @@ type 'a extra_args_fn = opts:Coqargs.t -> string list -> 'a * string list
 
 type ('a,'b) custom_toplevel =
   { parse_extra : 'a extra_args_fn
-  ; help : out_channel -> unit
+  ; help : Usage.specific_usage
   ; init : 'a -> opts:Coqargs.t -> 'b
   ; run : 'a -> opts:Coqargs.t -> 'b -> unit
   ; opts : Coqargs.t
@@ -324,14 +324,18 @@ let coqtop_run run_mode ~opts state =
   | Interactive -> Coqloop.loop ~opts ~state;
   | Batch -> exit 0
 
-let () = Usage.add_to_usage "coqtop" "" "\n\
+let coqtop_specific_usage = Usage.{
+  executable_name = "coqtop";
+  extra_args = "";
+  extra_options = "\n\
 coqtop specific options:\n\
 \n  -batch                 batch mode (exits after interpretation of command line)\
 \n"
+}
 
 let coqtop_toplevel =
   { parse_extra = coqtop_parse_extra
-  ; help = Usage.print_usage "coqtop"
+  ; help = coqtop_specific_usage
   ; init = coqtop_init
   ; run = coqtop_run
   ; opts = Coqargs.default

--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -257,8 +257,7 @@ type custom_toplevel =
   ; opts : Coqargs.t
   }
 
-
-let init_toploop opts =
+let init_document opts =
   let iload_path = build_load_path opts in
   let require_libs = require_libs opts in
   let stm_options = opts.stm_flags in
@@ -268,8 +267,12 @@ let init_toploop opts =
            { doc_type = Interactive opts.toplevel_name;
              iload_path; require_libs; stm_options;
            }) in
-  let state = { doc; sid; proof = None; time = opts.time } in
-  Ccompile.load_init_vernaculars opts ~state, opts
+  { doc; sid; proof = None; time = opts.time }
+
+let init_toploop opts =
+  let state = init_document opts in
+  let state = Ccompile.load_init_vernaculars opts ~state in
+  state
 
 let coqtop_init ~opts extra =
   init_color opts;
@@ -297,7 +300,7 @@ let start_coq custom =
         prerr_endline "See -help for the list of supported options";
         exit 1
       end;
-      init_toploop opts
+      init_toploop opts, opts
     with any ->
       flush_all();
       fatal_error_exn any in

--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -159,7 +159,7 @@ let print_query opts = function
   | PrintVersion -> Usage.version ()
   | PrintMachineReadableVersion -> Usage.machine_readable_version ()
   | PrintWhere -> print_endline (Envars.coqlib ())
-  | PrintHelp f -> f ()
+  | PrintHelp f -> f stderr
   | PrintConfig -> Envars.print_config stdout Coq_config.all_src_dirs
   | PrintTags -> print_style_tags opts.config
 
@@ -246,7 +246,7 @@ type 'a extra_args_fn = opts:Coqargs.t -> string list -> 'a * string list
 
 type ('a,'b) custom_toplevel =
   { parse_extra : 'a extra_args_fn
-  ; help : unit -> unit
+  ; help : out_channel -> unit
   ; init : 'a -> opts:Coqargs.t -> 'b
   ; run : 'a -> opts:Coqargs.t -> 'b -> unit
   ; opts : Coqargs.t
@@ -324,9 +324,14 @@ let coqtop_run run_mode ~opts state =
   | Interactive -> Coqloop.loop ~opts ~state;
   | Batch -> exit 0
 
+let () = Usage.add_to_usage "coqtop" "" "\n\
+coqtop specific options:\n\
+\n  -batch                 batch mode (exits after interpretation of command line)\
+\n"
+
 let coqtop_toplevel =
   { parse_extra = coqtop_parse_extra
-  ; help = Usage.print_usage_coqtop
+  ; help = Usage.print_usage "coqtop"
   ; init = coqtop_init
   ; run = coqtop_run
   ; opts = Coqargs.default

--- a/toplevel/coqtop.mli
+++ b/toplevel/coqtop.mli
@@ -17,7 +17,7 @@ type 'a extra_args_fn = opts:Coqargs.t -> string list -> 'a * string list
 
 type ('a,'b) custom_toplevel =
   { parse_extra : 'a extra_args_fn
-  ; help : out_channel -> unit
+  ; help : Usage.specific_usage
   ; init : 'a -> opts:Coqargs.t -> 'b
   ; run : 'a -> opts:Coqargs.t -> 'b -> unit
   ; opts : Coqargs.t

--- a/toplevel/coqtop.mli
+++ b/toplevel/coqtop.mli
@@ -25,19 +25,16 @@ type 'a custom_toplevel =
 
 (** [init_toplevel custom]
     Customized Coq initialization and argument parsing *)
-val init_batch_toplevel
-  :  help:(unit -> unit)
-  -> init:Coqargs.t
-  -> Coqargs.t extra_args_fn
-  -> string list
-  -> Coqargs.t * string list
+val init_toplevel : 'a custom_toplevel -> Coqargs.t * 'a
 
-val coqtop_toplevel : Coqargs.t custom_toplevel
+type run_mode = Interactive | Batch
 
-(** The Coq main module. [start custom] will parse the command line,
+(** The generic Coq main module. [start custom] will parse the command line,
    print the banner, initialize the load path, load the input state,
    load the files given on the command line, load the resource file,
    produce the output state if any, and finally will launch
    [custom.run]. *)
+val start_coq : run_mode custom_toplevel -> unit
 
-val start_coq : Coqargs.t custom_toplevel -> unit
+(** The specific characterization of the coqtop_toplevel *)
+val coqtop_toplevel : run_mode custom_toplevel

--- a/toplevel/coqtop.mli
+++ b/toplevel/coqtop.mli
@@ -17,7 +17,7 @@ type 'a extra_args_fn = opts:Coqargs.t -> string list -> 'a * string list
 
 type ('a,'b) custom_toplevel =
   { parse_extra : 'a extra_args_fn
-  ; help : unit -> unit
+  ; help : out_channel -> unit
   ; init : 'a -> opts:Coqargs.t -> 'b
   ; run : 'a -> opts:Coqargs.t -> 'b -> unit
   ; opts : Coqargs.t

--- a/toplevel/coqtop.mli
+++ b/toplevel/coqtop.mli
@@ -23,7 +23,7 @@ type custom_toplevel =
 
 (** [init_toplevel ~help ~init custom_init arg_list]
     Common Coq initialization and argument parsing *)
-val init_toplevel
+val init_batch_toplevel
   :  help:(unit -> unit)
   -> init:Coqargs.t
   -> init_fn

--- a/toplevel/coqtop.mli
+++ b/toplevel/coqtop.mli
@@ -15,26 +15,31 @@
 
 type 'a extra_args_fn = opts:Coqargs.t -> string list -> 'a * string list
 
-type 'a custom_toplevel =
+type ('a,'b) custom_toplevel =
   { parse_extra : 'a extra_args_fn
   ; help : unit -> unit
-  ; init : opts:Coqargs.t -> unit
-  ; run : opts:Coqargs.t -> state:Vernac.State.t -> unit
+  ; init : 'a -> opts:Coqargs.t -> 'b
+  ; run : 'a -> opts:Coqargs.t -> 'b -> unit
   ; opts : Coqargs.t
   }
-
-(** [init_toplevel custom]
-    Customized Coq initialization and argument parsing *)
-val init_toplevel : 'a custom_toplevel -> Coqargs.t * 'a
-
-type run_mode = Interactive | Batch
 
 (** The generic Coq main module. [start custom] will parse the command line,
    print the banner, initialize the load path, load the input state,
    load the files given on the command line, load the resource file,
    produce the output state if any, and finally will launch
    [custom.run]. *)
-val start_coq : run_mode custom_toplevel -> unit
+val start_coq : ('a,'b) custom_toplevel -> unit
+
+(** Initializer color for output *)
+
+val init_color : Coqargs.coqargs_config -> unit
+
+(** Prepare state for interactive loop *)
+
+val init_toploop : Coqargs.t -> Vernac.State.t
 
 (** The specific characterization of the coqtop_toplevel *)
-val coqtop_toplevel : run_mode custom_toplevel
+
+type run_mode = Interactive | Batch
+
+val coqtop_toplevel : (run_mode,Vernac.State.t) custom_toplevel

--- a/toplevel/coqtop.mli
+++ b/toplevel/coqtop.mli
@@ -13,24 +13,26 @@
     [run] launches a custom toplevel.
 *)
 
-type init_fn = opts:Coqargs.t -> string list -> Coqargs.t * string list
+type 'a extra_args_fn = opts:Coqargs.t -> string list -> 'a * string list
 
-type custom_toplevel =
-  { init : init_fn
+type 'a custom_toplevel =
+  { parse_extra : 'a extra_args_fn
+  ; help : unit -> unit
+  ; init : opts:Coqargs.t -> unit
   ; run : opts:Coqargs.t -> state:Vernac.State.t -> unit
   ; opts : Coqargs.t
   }
 
-(** [init_toplevel ~help ~init custom_init arg_list]
-    Common Coq initialization and argument parsing *)
+(** [init_toplevel custom]
+    Customized Coq initialization and argument parsing *)
 val init_batch_toplevel
   :  help:(unit -> unit)
   -> init:Coqargs.t
-  -> init_fn
+  -> Coqargs.t extra_args_fn
   -> string list
   -> Coqargs.t * string list
 
-val coqtop_toplevel : custom_toplevel
+val coqtop_toplevel : Coqargs.t custom_toplevel
 
 (** The Coq main module. [start custom] will parse the command line,
    print the banner, initialize the load path, load the input state,
@@ -38,4 +40,4 @@ val coqtop_toplevel : custom_toplevel
    produce the output state if any, and finally will launch
    [custom.run]. *)
 
-val start_coq : custom_toplevel -> unit
+val start_coq : Coqargs.t custom_toplevel -> unit

--- a/toplevel/usage.ml
+++ b/toplevel/usage.ml
@@ -19,10 +19,6 @@ let machine_readable_version () =
 
 (* print the usage of coqtop (or coqc) on channel co *)
 
-let extra_usage = ref []
-let add_to_usage name extra text =
-  extra_usage := (name,(extra,text)) :: !extra_usage
-
 let print_usage_common co command =
   output_string co command;
   output_string co "Coq options are:\n";
@@ -103,9 +99,12 @@ let print_usage_common co command =
 
 (* print the usage *)
 
-let print_usage binfile co =
-  let extra, text =
-    try List.assoc binfile !extra_usage
-    with Not_found -> ("","") in
-  print_usage_common co ("Usage: " ^ binfile ^ " <options> " ^ extra ^ "\n\n");
-  output_string co text
+type specific_usage = {
+  executable_name : string;
+  extra_args : string;
+  extra_options : string;
+}
+
+let print_usage co { executable_name; extra_args; extra_options } =
+  print_usage_common co ("Usage: " ^ executable_name ^ " <options> " ^ extra_args ^ "\n\n");
+  output_string co extra_options

--- a/toplevel/usage.ml
+++ b/toplevel/usage.ml
@@ -8,15 +8,14 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-let version ret =
+let version () =
   Printf.printf "The Coq Proof Assistant, version %s (%s)\n"
     Coq_config.version Coq_config.date;
-  Printf.printf "compiled on %s with OCaml %s\n" Coq_config.compile_date Coq_config.caml_version;
-  exit ret
-let machine_readable_version ret =
+  Printf.printf "compiled on %s with OCaml %s\n" Coq_config.compile_date Coq_config.caml_version
+
+let machine_readable_version () =
   Printf.printf "%s %s\n"
-    Coq_config.version Coq_config.caml_version;
-  exit ret
+    Coq_config.version Coq_config.caml_version
 
 (* print the usage of coqtop (or coqc) on channel co *)
 

--- a/toplevel/usage.ml
+++ b/toplevel/usage.ml
@@ -20,7 +20,8 @@ let machine_readable_version () =
 (* print the usage of coqtop (or coqc) on channel co *)
 
 let extra_usage = ref []
-let add_to_usage name text = extra_usage := (name,text) :: !extra_usage
+let add_to_usage name extra text =
+  extra_usage := (name,(extra,text)) :: !extra_usage
 
 let print_usage_common co command =
   output_string co command;
@@ -98,42 +99,13 @@ let print_usage_common co command =
 \n  -bytecode-compiler (yes|no)        enable the vm_compute reduction machine\
 \n  -native-compiler (yes|no|ondemand) enable the native_compute reduction machine\
 \n  -h, -help, --help      print this list of options\
-\n";
-  List.iter (fun (name, text) ->
-    output_string co
-     ("\nWith the flag '-toploop "^name^
-        "' these extra option are also available:\n"^
-      text^"\n"))
-    !extra_usage
+\n"
 
-(* print the usage on standard error *)
+(* print the usage *)
 
-let print_usage_coqtop () =
-  print_usage_common stderr "Usage: coqtop <options>\n\n";
-  output_string stderr "\n\
-coqtop specific options:\
-\n\
-\n  -batch                 batch mode (exits just after argument parsing)\
-\n";
-  flush stderr ;
-  exit 1
-
-let print_usage_coqc () =
-  print_usage_common stderr "Usage: coqc <options> <Coq options> file...\n\n";
-  output_string stderr "\n\
-coqc specific options:\
-\n\
-\n  -o f.vo                use f.vo as the output file name\
-\n  -verbose               compile and output the input file\
-\n  -quick                 quickly compile .v files to .vio files (skip proofs)\
-\n  -schedule-vio2vo j f1..fn   run up to j instances of Coq to turn each fi.vio\
-\n                         into fi.vo\
-\n  -schedule-vio-checking j f1..fn   run up to j instances of Coq to check all\
-\n                         proofs in each fi.vio\
-\n\
-\nUndocumented:\
-\n  -vio2vo                [see manual]\
-\n  -check-vio-tasks       [see manual]\
-\n";
-  flush stderr ;
-  exit 1
+let print_usage binfile co =
+  let extra, text =
+    try List.assoc binfile !extra_usage
+    with Not_found -> ("","") in
+  print_usage_common co ("Usage: " ^ binfile ^ " <options> " ^ extra ^ "\n\n");
+  output_string co text

--- a/toplevel/usage.mli
+++ b/toplevel/usage.mli
@@ -13,10 +13,17 @@
 val version : unit -> unit
 val machine_readable_version : unit -> unit
 
-(** {6 [add_to_usage name extra_args extra_options] tell what extra
-     arguments or options to print when asking usage for command [name]. } *)
-val add_to_usage : string -> string -> string -> unit
+(** {6 extra arguments or options to print when asking usage for a
+     given executable. } *)
 
-(** {6 Prints the usage on the error output. } *)
-val print_usage : string -> out_channel -> unit
+type specific_usage = {
+  executable_name : string;
+  extra_args : string;
+  extra_options : string;
+}
+
+(** {6 Prints the generic part and specific part of usage for a
+       given executable. } *)
+
+val print_usage : out_channel -> specific_usage -> unit
 

--- a/toplevel/usage.mli
+++ b/toplevel/usage.mli
@@ -13,10 +13,10 @@
 val version : unit -> unit
 val machine_readable_version : unit -> unit
 
-(** {6 Enable toploop plugins to insert some text in the usage message. } *)
-val add_to_usage : string -> string -> unit
+(** {6 [add_to_usage name extra_args extra_options] tell what extra
+     arguments or options to print when asking usage for command [name]. } *)
+val add_to_usage : string -> string -> string -> unit
 
 (** {6 Prints the usage on the error output. } *)
-val print_usage_coqtop : unit -> unit
-val print_usage_coqc : unit -> unit
+val print_usage : string -> out_channel -> unit
 

--- a/toplevel/usage.mli
+++ b/toplevel/usage.mli
@@ -8,10 +8,10 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(** {6 Prints the version number on the standard output and exits (with 0). } *)
+(** {6 Prints the version number on the standard output. } *)
 
-val version : int -> 'a
-val machine_readable_version : int -> 'a
+val version : unit -> unit
+val machine_readable_version : unit -> unit
 
 (** {6 Enable toploop plugins to insert some text in the usage message. } *)
 val add_to_usage : string -> string -> unit

--- a/toplevel/workerLoop.ml
+++ b/toplevel/workerLoop.ml
@@ -21,11 +21,13 @@ let worker_init init () ~opts =
   init ();
   Coqtop.init_toploop opts
 
-let start ~init ~loop =
+let start ~init ~loop name =
+  let _ = Usage.add_to_usage name "" ("\n" ^ name ^ " specific options:\
+\n  --xml_format=Ppcmds    serialize pretty printing messages using the std_ppcmds format\n") in
   let open Coqtop in
   let custom = {
     parse_extra = worker_parse_extra;
-    help = (fun _ -> output_string stderr "Same options as coqtop");
+    help = Usage.print_usage name;
     opts = Coqargs.default;
     init = worker_init init;
     run = (fun () ~opts:_ _state (* why is state not used *) -> loop ());

--- a/toplevel/workerLoop.ml
+++ b/toplevel/workerLoop.ml
@@ -14,7 +14,7 @@ let rec parse = function
   | [] -> []
 
 let worker_parse_extra ~opts extra_args =
-  opts, parse extra_args
+  Coqtop.Interactive, parse extra_args
 
 let worker_init init ~opts =
   Flags.quiet := true;

--- a/toplevel/workerLoop.ml
+++ b/toplevel/workerLoop.ml
@@ -18,8 +18,7 @@ let worker_parse_extra ~opts extra_args =
 
 let worker_init init ~opts =
   Flags.quiet := true;
-  init ();
-  CoqworkmgrApi.(init !async_proofs_worker_priority)
+  init ()
 
 let start ~init ~loop =
   let open Coqtop in

--- a/toplevel/workerLoop.ml
+++ b/toplevel/workerLoop.ml
@@ -14,11 +14,12 @@ let rec parse = function
   | [] -> []
 
 let worker_parse_extra ~opts extra_args =
-  Coqtop.Interactive, parse extra_args
+  (), parse extra_args
 
-let worker_init init ~opts =
+let worker_init init () ~opts =
   Flags.quiet := true;
-  init ()
+  init ();
+  Coqtop.init_toploop opts
 
 let start ~init ~loop =
   let open Coqtop in
@@ -27,6 +28,6 @@ let start ~init ~loop =
     help = (fun _ -> output_string stderr "Same options as coqtop");
     opts = Coqargs.default;
     init = worker_init init;
-    run = (fun ~opts:_ ~state:_ -> loop ());
+    run = (fun () ~opts:_ _state (* why is state not used *) -> loop ());
   } in
   start_coq custom

--- a/toplevel/workerLoop.ml
+++ b/toplevel/workerLoop.ml
@@ -21,13 +21,18 @@ let worker_init init () ~opts =
   init ();
   Coqtop.init_toploop opts
 
+let worker_specific_usage name = Usage.{
+  executable_name = name;
+  extra_args = "";
+  extra_options = ("\n" ^ name ^ " specific options:\
+\n  --xml_format=Ppcmds    serialize pretty printing messages using the std_ppcmds format\n");
+}
+
 let start ~init ~loop name =
-  let _ = Usage.add_to_usage name "" ("\n" ^ name ^ " specific options:\
-\n  --xml_format=Ppcmds    serialize pretty printing messages using the std_ppcmds format\n") in
   let open Coqtop in
   let custom = {
     parse_extra = worker_parse_extra;
-    help = Usage.print_usage name;
+    help = worker_specific_usage name;
     opts = Coqargs.default;
     init = worker_init init;
     run = (fun () ~opts:_ _state (* why is state not used *) -> loop ());

--- a/toplevel/workerLoop.mli
+++ b/toplevel/workerLoop.mli
@@ -8,7 +8,7 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(* Register a STM worker *)
+(* Register a STM worker of a given executable name *)
 val start :
   init:(unit -> unit) ->
-  loop:(unit -> unit) -> unit
+  loop:(unit -> unit) -> string -> unit


### PR DESCRIPTION
**Kind:** architecture of command line and coq binaries initialization

This is the first part of a split of #10147 into smaller reviewable components. If this is too many commits, I can split even further.

I copy below the relevant part of #10147.

---
- Issues mentioned in #9585:

  - It tries to clarify the three roles of `coqtop` (in `coqargs.ml`)
     - interactive mode: we initialize and run the read-eval-loop
     - batch mode: we interpret the command line and quit
     - query mode (`-config`, `-tags`, `-where`, `-print-mod-ui`, `--version`, `--help`): we report about some data and nothing else

    Note that I don't see this splitting as absolutely necessary. I see it as a way to help us structuring options of the command line better. So, it is really more about internal design only.

  - It tries to make more apparent the phase 1 (general initialization) / phase 2 (configuration) / phase 3 (environment loading) of the initialization of a coq process (it seems to me to make understanding of the flow easier to read, but this is somehow also subjective).

- Extension of the parametrization of `Coqtop.init_toplevel` via a set of `custom` methods specific to each binary:
---

Note the discussion in #9585: I'm more and more considering that it would make more sense to see the command line as an ordered sequence of vernac commands than checking what combinations or repetitions in the command line are meaningful. However, this PR does not step in this direction.