### PR TITLE
More precise type for export and inlining of private constants

### DIFF
--- a/kernel/safe_typing.mli
+++ b/kernel/safe_typing.mli
@@ -49,10 +49,8 @@ val concat_private : private_constants -> private_constants -> private_constants
     [e1] must be more recent than those of [e2]. *)
 
 val mk_pure_proof : Constr.constr -> private_constants Entries.proof_output
-val inline_private_constants_in_constr :
-  Environ.env -> Constr.constr -> private_constants -> Constr.constr
-val inline_private_constants_in_definition_entry :
-  Environ.env -> private_constants Entries.definition_entry -> unit Entries.definition_entry
+val inline_private_constants :
+  Environ.env -> private_constants Entries.proof_output -> Constr.constr Univ.in_universe_context_set
 
 val push_private_constants : Environ.env -> private_constants -> Environ.env
 (** Push the constants in the environment if not already there. *)
@@ -93,8 +91,8 @@ type exported_private_constant =
   Constant.t * Entries.side_effect_role
 
 val export_private_constants : in_section:bool ->
-  private_constants Entries.definition_entry ->
-  (unit Entries.definition_entry * exported_private_constant list) safe_transformer
+  private_constants Entries.proof_output ->
+  (Constr.constr Univ.in_universe_context_set * exported_private_constant list) safe_transformer
 
 (** returns the main constant plus a list of auxiliary constants (empty
     unless one requires the side effects to be exported) *)

--- a/library/global.mli
+++ b/library/global.mli
@@ -42,8 +42,8 @@ val push_named_assum : (Id.t * Constr.types * bool) Univ.in_universe_context_set
 val push_named_def   : (Id.t * Entries.section_def_entry) -> unit
 
 val export_private_constants : in_section:bool ->
-  Safe_typing.private_constants Entries.definition_entry ->
-  unit Entries.definition_entry * Safe_typing.exported_private_constant list
+  Safe_typing.private_constants Entries.proof_output ->
+  Constr.constr Univ.in_universe_context_set * Safe_typing.exported_private_constant list
 
 val add_constant :
   ?role:Entries.side_effect_role -> in_section:bool -> Id.t -> Safe_typing.global_declaration -> Constant.t * Safe_typing.private_constants

--- a/vernac/obligations.ml
+++ b/vernac/obligations.ml
@@ -820,8 +820,8 @@ let solve_by_tac ?loc name evi t poly ctx =
       Pfedit.build_constant_by_tactic
         id ~goal_kind:(goal_kind poly) ctx evi.evar_hyps evi.evar_concl t in
     let env = Global.env () in
-    let entry = Safe_typing.inline_private_constants_in_definition_entry env entry in
-    let body, () = Future.force entry.const_entry_body in
+    let body = Future.force entry.const_entry_body in
+    let body = Safe_typing.inline_private_constants env body in
     let ctx' = Evd.merge_context_set ~sideff:true Evd.univ_rigid (Evd.from_ctx ctx') (snd body) in
     Inductiveops.control_only_guard env ctx' (EConstr.of_constr (fst body));
     Some (fst body, entry.const_entry_type, Evd.evar_universe_context ctx')
@@ -844,9 +844,9 @@ let obligation_terminator ?hook name num guard auto pf =
   | Admitted _ -> apply_terminator term pf
   | Proved (opq, id, { entries=[entry]; universes=uctx } ) -> begin
     let env = Global.env () in
-    let entry = Safe_typing.inline_private_constants_in_definition_entry env entry in
     let ty = entry.Entries.const_entry_type in
-    let (body, cstr), () = Future.force entry.Entries.const_entry_body in
+    let body = Future.force entry.const_entry_body in
+    let (body, cstr) = Safe_typing.inline_private_constants env body in
     let sigma = Evd.from_ctx uctx in
     let sigma = Evd.merge_context_set ~sideff:true Evd.univ_rigid sigma cstr in
     Inductiveops.control_only_guard (Global.env ()) sigma (EConstr.of_constr body);


### PR DESCRIPTION
We get rid of the future wrappers, as all callers are immediately forcing the result.
