### PR TITLE
Remove the delayed universe table from object files.

### DIFF
--- a/checker/mod_checking.ml
+++ b/checker/mod_checking.ml
@@ -13,7 +13,6 @@ let set_indirect_accessor f = get_proof := f
 
 let indirect_accessor = {
   Opaqueproof.access_proof = (fun dp n -> !get_proof dp n);
-  Opaqueproof.access_constraints = (fun _ _ -> assert false);
 }
 
 let check_constant_declaration env kn cb =

--- a/checker/values.ml
+++ b/checker/values.ml
@@ -385,4 +385,4 @@ let v_lib =
 
 let v_opaques = Array (Opt v_constr)
 let v_univopaques =
-  Opt (Tuple ("univopaques",[|Array (Opt v_context_set);v_context_set;v_bool|]))
+  Opt (Tuple ("univopaques",[|v_context_set;v_bool|]))

--- a/kernel/opaqueproof.mli
+++ b/kernel/opaqueproof.mli
@@ -37,7 +37,6 @@ val turn_indirect : DirPath.t -> opaque -> opaquetab -> opaque * opaquetab
 
 type indirect_accessor = {
   access_proof : DirPath.t -> int -> constr option;
-  access_constraints : DirPath.t -> int -> Univ.ContextSet.t option;
 }
 (** When stored indirectly, opaque terms are indexed by their library
     dirpath and an integer index. The two functions above activate
@@ -70,6 +69,5 @@ val join_opaque : ?except:Future.UUIDSet.t -> opaquetab -> opaque -> unit
 
 val dump : ?except:Future.UUIDSet.t -> opaquetab ->
   Constr.t option array *
-  Univ.ContextSet.t option array *
   cooking_info list array *
   int Future.UUIDMap.t

--- a/library/library.mli
+++ b/library/library.mli
@@ -33,8 +33,8 @@ val require_library_from_dirpath
 (** Segments of a library *)
 type seg_sum
 type seg_lib
-type seg_univ = (* cst, all_cst, finished? *)
-  Univ.ContextSet.t option array * Univ.ContextSet.t * bool
+type seg_univ = (* all_cst, finished? *)
+  Univ.ContextSet.t * bool
 type seg_discharge = Opaqueproof.cooking_info list array
 type seg_proofs = Constr.constr option array
 


### PR DESCRIPTION
This was virtually dead code. The only place really accessing this data was the user pretty-printer, but actually the tables were not installed for vanilla vo files.

In practice, that meant that the only case where an access to this table could have been triggered would have been to print a term coming from a vio file, or a vo file generated via vio2vo. In all other cases, the printer would not have displayed the internal universes. While the latter might be considered a bug, I am instead convinced that this notion of user-facing internal universes needs to be handled by another mechanism, the current one making little sense. The fact it was broken all along without anybody noticing proves my point.
