### PR TITLE
Update doc to reflect that PG now supports Coq-generated proof diffs

### DIFF
--- a/doc/changelog/12-misc/10019-PG-proof-diffs.rst
+++ b/doc/changelog/12-misc/10019-PG-proof-diffs.rst
@@ -1,0 +1,3 @@
+- Proof General can now display Coq-generated diffs between proof steps
+  in color.  (`#10019 <https://github.com/coq/coq/pull/10019>`_ and (in Proof General)
+  `#421 <https://github.com/ProofGeneral/PG/pull/421>`_, by Jim Fehrle).

--- a/doc/sphinx/proof-engine/proof-handling.rst
+++ b/doc/sphinx/proof-engine/proof-handling.rst
@@ -705,9 +705,10 @@ command in CoqIDE.  You can change the background colors shown for diffs from th
 lets you control other attributes of the highlights, such as the foreground
 color, bold, italic, underline and strikeout.
 
-Note: As of this writing (August 2018), Proof General will need minor changes
-to be able to show diffs correctly.  We hope it will support this feature soon.
-See https://github.com/ProofGeneral/PG/issues/381 for the current status.
+As of June 2019, Proof General can also display Coq-generated proof diffs automatically.
+Please see the PG documentation section
+"`Showing Proof Diffs" <https://proofgeneral.github.io/doc/master/userman/Coq-Proof-General#Showing-Proof-Diffs>`_)
+for details.
 
 How diffs are calculated
 ````````````````````````


### PR DESCRIPTION
**Kind:** documentation

Per https://github.com/ProofGeneral/PG/pull/421#issuecomment-496040930, the necessary PG code was merged and is available through MELPA.  Updated PG doc will be posted online by May 31.  No new version number for PG just yet.

Hope we can get this into 8.10.

- [x] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
