### PR TITLE
[libobject] Separate "named" objects from anonymous ones.

### DIFF
--- a/interp/syntax_def.ml
+++ b/interp/syntax_def.ml
@@ -68,7 +68,7 @@ let classify_syntax_constant (local,_ as o) =
   if local then Dispose else Substitute o
 
 let in_syntax_constant : (bool * syndef) -> obj =
-  declare_object {(default_object "SYNDEF") with
+  declare_object_named {(default_object "SYNDEF") with
     cache_function = cache_syntax_constant;
     load_function = load_syntax_constant;
     open_function = open_syntax_constant;

--- a/library/libobject.mli
+++ b/library/libobject.mli
@@ -70,16 +70,14 @@ type 'a substitutivity =
    can be substituted and a "syntactic" [full_path] which can be printed
 *)
 
-type object_name = full_path * Names.KerName.t
-
-type 'a object_declaration = {
+type ('a,'n) object_declaration = {
   object_name : string;
-  cache_function : object_name * 'a -> unit;
-  load_function : int -> object_name * 'a -> unit;
-  open_function : int -> object_name * 'a -> unit;
+  cache_function : 'n * 'a -> unit;
+  load_function : int -> 'n * 'a -> unit;
+  open_function : int -> 'n * 'a -> unit;
   classify_function : 'a -> 'a substitutivity;
   subst_function :  substitution * 'a -> 'a;
-  discharge_function : object_name * 'a -> 'a option;
+  discharge_function : 'n * 'a -> 'a option;
   rebuild_function : 'a -> 'a }
 
 (** The default object is a "Keep" object with empty methods.
@@ -91,7 +89,7 @@ type 'a object_declaration = {
 
 *)
 
-val default_object : string -> 'a object_declaration
+val default_object : string -> ('a,'n) object_declaration
 
 (** the identity substitution function *)
 val ident_subst_function : substitution * 'a -> 'a
@@ -100,6 +98,8 @@ val ident_subst_function : substitution * 'a -> 'a
 (** Given an object declaration, the function [declare_object_full]
    will hand back two functions, the "injection" and "projection"
    functions for dynamically typed library-objects. *)
+
+type object_name = full_path * Names.KerName.t
 
 type obj
 
@@ -120,10 +120,16 @@ and objects = (Names.Id.t * t) list
 and substitutive_objects = Names.MBId.t list * algebraic_objects
 
 val declare_object_full :
-  'a object_declaration -> ('a -> obj) * (obj -> 'a)
+  ('a,unit) object_declaration -> ('a -> obj) * (obj -> 'a)
 
 val declare_object :
-  'a object_declaration -> ('a -> obj)
+  ('a,unit) object_declaration -> ('a -> obj)
+
+val declare_object_full_named :
+  ('a,object_name) object_declaration -> ('a -> obj) * (obj -> 'a)
+
+val declare_object_named :
+  ('a,object_name) object_declaration -> ('a -> obj)
 
 val object_tag : obj -> string
 
@@ -150,35 +156,35 @@ variants.
 *)
 
 val local_object : string ->
-  cache:(object_name * 'a -> unit) ->
-  discharge:(object_name * 'a -> 'a option) ->
-  'a object_declaration
+  cache:(unit * 'a -> unit) ->
+  discharge:(unit * 'a -> 'a option) ->
+  ('a,unit) object_declaration
 
 val local_object_nodischarge : string ->
-  cache:(object_name * 'a -> unit) ->
-  'a object_declaration
+  cache:(unit * 'a -> unit) ->
+  ('a,unit) object_declaration
 
 val global_object : string ->
-  cache:(object_name * 'a -> unit) ->
+  cache:(unit * 'a -> unit) ->
   subst:(Mod_subst.substitution * 'a -> 'a) option ->
-  discharge:(object_name * 'a -> 'a option) ->
-  'a object_declaration
+  discharge:(unit * 'a -> 'a option) ->
+  ('a,unit) object_declaration
 
 val global_object_nodischarge : string ->
-  cache:(object_name * 'a -> unit) ->
+  cache:('n * 'a -> unit) ->
   subst:(Mod_subst.substitution * 'a -> 'a) option ->
-  'a object_declaration
+  ('a,'n) object_declaration
 
 val superglobal_object : string ->
-  cache:(object_name * 'a -> unit) ->
+  cache:(unit * 'a -> unit) ->
   subst:(Mod_subst.substitution * 'a -> 'a) option ->
-  discharge:(object_name * 'a -> 'a option) ->
-  'a object_declaration
+  discharge:(unit * 'a -> 'a option) ->
+  ('a,unit) object_declaration
 
 val superglobal_object_nodischarge : string ->
-  cache:(object_name * 'a -> unit) ->
+  cache:(unit * 'a -> unit) ->
   subst:(Mod_subst.substitution * 'a -> 'a) option ->
-  'a object_declaration
+  ('a,unit) object_declaration
 
 (** {6 Debug} *)
 

--- a/plugins/ltac/tacenv.ml
+++ b/plugins/ltac/tacenv.ml
@@ -179,7 +179,7 @@ let classify_md (local, _, _, _, _ as o) = Substitute o
 
 let inMD : bool * ltac_constant option * bool * glob_tactic_expr *
            Deprecation.t option -> obj =
-  declare_object {(default_object "TAC-DEFINITION") with
+  declare_object_named {(default_object "TAC-DEFINITION") with
      cache_function  = cache_md;
      load_function   = load_md;
      open_function   = open_md;

--- a/plugins/setoid_ring/newring.ml
+++ b/plugins/setoid_ring/newring.ml
@@ -404,7 +404,7 @@ let subst_th (subst,th) =
 
 let theory_to_obj : ring_info -> obj =
   let cache_th (name,th) = add_entry name th in
-  declare_object @@ global_object_nodischarge "tactic-new-ring-theory"
+  declare_object_named @@ global_object_nodischarge "tactic-new-ring-theory"
     ~cache:cache_th
     ~subst:(Some subst_th)
 
@@ -856,7 +856,7 @@ let subst_th (subst,th) =
 
 let ftheory_to_obj : field_info -> obj =
   let cache_th (name,th) = add_field_entry name th in
-  declare_object @@ global_object_nodischarge "tactic-new-field-theory"
+  declare_object_named @@ global_object_nodischarge "tactic-new-field-theory"
     ~cache:cache_th
     ~subst:(Some subst_th)
 

--- a/tactics/declare.ml
+++ b/tactics/declare.ml
@@ -135,7 +135,7 @@ let dummy_constant cst = {
 let classify_constant cst = Substitute (dummy_constant cst)
 
 let (inConstant : constant_obj -> obj) =
-  declare_object { (default_object "CONSTANT") with
+  declare_object_named { (default_object "CONSTANT") with
     cache_function = cache_constant;
     load_function = load_constant;
     open_function = open_constant;
@@ -401,7 +401,7 @@ let discharge_inductive ((sp, kn), names) =
   Some names
 
 let inInductive : inductive_obj -> obj =
-  declare_object {(default_object "INDUCTIVE") with
+  declare_object_named {(default_object "INDUCTIVE") with
     cache_function = cache_inductive;
     load_function = load_inductive;
     open_function = open_inductive;
@@ -561,7 +561,7 @@ let discharge_univ_names = function
   | _, ((QualifiedUniv _ | UnqualifiedUniv), _ as x) -> Some x
 
 let input_univ_names : universe_name_decl -> Libobject.obj =
-  declare_object
+  declare_object_named
     { (default_object "Global universe name state") with
       cache_function = cache_univ_names;
       load_function = load_univ_names;

--- a/user-contrib/Ltac2/tac2entries.ml
+++ b/user-contrib/Ltac2/tac2entries.ml
@@ -87,7 +87,7 @@ let subst_tacdef (subst, def) =
 let classify_tacdef o = Substitute o
 
 let inTacDef : tacdef -> obj =
-  declare_object {(default_object "TAC2-DEFINITION") with
+  declare_object_named {(default_object "TAC2-DEFINITION") with
      cache_function  = cache_tacdef;
      load_function   = load_tacdef;
      open_function   = open_tacdef;
@@ -194,7 +194,7 @@ let subst_typdef (subst, def) =
 let classify_typdef o = Substitute o
 
 let inTypDef : typdef -> obj =
-  declare_object {(default_object "TAC2-TYPE-DEFINITION") with
+  declare_object_named {(default_object "TAC2-TYPE-DEFINITION") with
      cache_function  = cache_typdef;
      load_function   = load_typdef;
      open_function   = open_typdef;
@@ -264,7 +264,7 @@ let subst_typext (subst, e) =
 let classify_typext o = Substitute o
 
 let inTypExt : typext -> obj =
-  declare_object {(default_object "TAC2-TYPE-EXTENSION") with
+  declare_object_named {(default_object "TAC2-TYPE-EXTENSION") with
      cache_function  = cache_typext;
      load_function   = load_typext;
      open_function   = open_typext;
@@ -649,7 +649,7 @@ let subst_abbreviation (subst, abbr) =
 let classify_abbreviation o = Substitute o
 
 let inTac2Abbreviation : abbreviation -> obj =
-  declare_object {(default_object "TAC2-ABBREVIATION") with
+  declare_object_named {(default_object "TAC2-ABBREVIATION") with
      cache_function  = cache_abbreviation;
      load_function   = load_abbreviation;
      open_function   = open_abbreviation;


### PR DESCRIPTION
This is a tiny first step to reify "named" objects, in particular, to
have the handlers register with the nametab.

A big question is what to do with the int parameter, why do anonymous
objects need to access it? Should the logic there be reified?
