### PR TITLE
Added the List.get function.

### DIFF
--- a/theories/Lists/List.v
+++ b/theories/Lists/List.v
@@ -403,6 +403,18 @@ Section Elts.
       | None => default
     end.
 
+  Fixpoint get (l : list A) : forall n : nat, n < length l -> A
+    := match l return forall n : nat, n < length l -> A with
+         | nil
+           => fun n H => False_rect _ (PeanoNat.Nat.nlt_0_r n H)
+         | y0 :: ys
+           => fun n
+                => match n return n < length (y0 :: ys) -> A with
+                     | O => fun _ => y0
+                     | S m => fun H => get ys (Lt.lt_S_n m (length ys) H)
+                     end
+         end.
+
   Lemma nth_default_eq :
     forall n l (d:A), nth_default d l n = nth n l d.
   Proof.


### PR DESCRIPTION
I added a new function named `get` in List.v. This function accepts three arguments: l, a list; n, a natural number; and H, a proof that n is a valid index for l; and returns the n-th element in l.

The List.v library defines a similar function named `nth`. This function accepts a list, an index, and a default value, and returns either the nth element in the list or the default value. There are several practical difficulties with `nth` that the `get` function addresses.

First, `nth` forces us to select a value to use as a default for invalid indices. This is not always practical. For example, given a polymorphic function that accepts an arbitrary type A and returns a value from a list of type `list A`, it's not clear what this function should pass as the default to `nth`.

Second, `nth` requires us to provide a default value even when we know that the index being passed to it is valid. In this case, the default value is entirely redundant.

The `get` function provides a useful alternative to `nth`, and covers a use case that I believe is common enough to warrant inclusion in List.v. 

- feature