### PR TITLE
add pow2_sqrt lemma, removed assertion of pow2_sqrt in Rpower

### DIFF
--- a/theories/Reals/R_sqrt.v
+++ b/theories/Reals/R_sqrt.v
@@ -110,6 +110,11 @@ Proof.
   intros x H1; unfold Rsqr; apply (sqrt_sqrt x H1).
 Qed.
 
+Lemma pow2_sqrt : forall x:R, 0 <= x -> (sqrt x) ^ 2 = x.
+Proof.
+  intros; simpl; rewrite Rmult_1_r, sqrt_def; auto.
+Qed.
+
 Lemma sqrt_mult_alt :
   forall x y : R, 0 <= x -> sqrt (x * y) = sqrt x * sqrt y.
 Proof.

--- a/theories/Reals/Rpower.v
+++ b/theories/Reals/Rpower.v
@@ -768,8 +768,6 @@ assert (t: forall x y z, x - z = y -> x - y - z = 0);[ | apply t; clear t].
  intros a b c H; rewrite <- H; ring.
 apply Rmult_eq_reg_l with (2 * (x + sqrt (x ^ 2 + 1)));[ |
  apply Rgt_not_eq, Rmult_lt_0_compat;[apply Rlt_0_2 | assumption]].
-assert (pow2_sqrt : forall x, 0 <= x -> sqrt x ^ 2 = x) by
- (intros; simpl; rewrite Rmult_1_r, sqrt_sqrt; auto).
 field_simplify;[rewrite pow2_sqrt;[field | ] | apply Rgt_not_eq; lra].
 apply Rplus_le_le_0_compat;[simpl; rewrite Rmult_1_r; apply (Rle_0_sqr x)|apply Rlt_le, Rlt_0_1].
 Qed.


### PR DESCRIPTION
I added the only missing variation (out of 6) of (sqrt x) ^ 2 = x. The other 5 variations existed:

Lemma sqrt_def : forall x:R, 0 <= x -> sqrt x * sqrt x = x.
Lemma sqrt_square : forall x:R, 0 <= x -> sqrt (x * x) = x.
Lemma sqrt_Rsqr : forall x:R, 0 <= x -> sqrt (Rsqr x) = x.
Lemma Rsqr_sqrt : forall x:R, 0 <= x -> Rsqr (sqrt x) = x.
Lemma sqrt_pow2 : forall x, 0 <= x -> sqrt (x ^ 2) = x.

I also discovered this lemma as an assertion in Rpower and removed it.

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

<!-- Keep what applies -->
**Kind:** feature / infrastructure.

<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->