### PR TITLE
Fixed typo in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,7 +169,7 @@ People are generally happy to help and very reactive.
 
 ["Watching" this repository](https://github.com/coq/coq/subscription)
 can result in a very large number of notifications. We advise that if
-you do, either [confifure your mailbox](https://blog.github.com/2017-07-18-managing-large-numbers-of-github-notifications/#prioritize-the-notifications-you-receive)
+you do, either [configure your mailbox](https://blog.github.com/2017-07-18-managing-large-numbers-of-github-notifications/#prioritize-the-notifications-you-receive)
 to handle incoming notifications efficiently, or you read your
 notifications within a web browser. You can configure how you receive
 notifications in [your GitHub settings](https://github.com/settings/notifications),


### PR DESCRIPTION
I fixed a typo in `CONTRIBUTING.md`. It was an extremely minor change, but I did search through the issues for typos and it didn't appear to have been previously reported, so I am not including a fix number here.

This pull request changes literally nothing else to make this change as straightforward as possible.

**Kind:** documentation
