### PR TITLE
Expose set interface to option tables

### DIFF
--- a/kernel/names.ml
+++ b/kernel/names.ml
@@ -671,6 +671,7 @@ module InductiveOrdered_env = struct
   let compare = ind_user_ord
 end
 
+module Indset = Set.Make(InductiveOrdered)
 module Indmap = Map.Make(InductiveOrdered)
 module Indmap_env = Map.Make(InductiveOrdered_env)
 

--- a/kernel/names.mli
+++ b/kernel/names.mli
@@ -481,6 +481,7 @@ type constructor = inductive   (* designates the inductive type *)
                  * int         (* the index of the constructor
                                   BEWARE: indexing starts from 1. *)
 
+module Indset : CSig.SetS with type elt = inductive
 module Indmap : CSig.MapS with type key = inductive
 module Constrmap : CSig.MapS with type key = constructor
 module Indmap_env : CSig.MapS with type key = inductive

--- a/library/goptions.mli
+++ b/library/goptions.mli
@@ -70,8 +70,8 @@ module MakeStringTable :
        val member_message : string -> bool -> Pp.t
      end) ->
 sig
+  val v : unit -> CString.Set.t
   val active : string -> bool
-  val elements : unit -> string list
 end
 
 (** The functor [MakeRefTable] declares a new table of objects of type
@@ -87,19 +87,19 @@ end
 module MakeRefTable :
   functor
     (A : sig
-           type t
-           val compare : t -> t -> int
-           val encode : Environ.env -> qualid -> t
-           val subst : substitution -> t -> t
-           val printer : t -> Pp.t
-           val key : option_name
-           val title : string
-           val member_message : t -> bool -> Pp.t
-         end) ->
-    sig
-      val active : A.t -> bool
-      val elements : unit -> A.t list
-    end
+       type t
+       module Set : CSig.SetS with type elt = t
+       val encode : Environ.env -> qualid -> t
+       val subst : substitution -> t -> t
+       val printer : t -> Pp.t
+       val key : option_name
+       val title : string
+       val member_message : t -> bool -> Pp.t
+     end) ->
+sig
+  val v : unit -> A.Set.t
+  val active : A.t -> bool
+end
 
 
 (** {6 Options. } *)

--- a/pretyping/classops.ml
+++ b/pretyping/classops.ml
@@ -441,7 +441,7 @@ let coercion_of_reference r =
 module CoercionPrinting =
   struct
     type t = coe_typ
-    let compare = GlobRef.Ordered.compare
+    module Set = GlobRef.Set
     let encode _env = coercion_of_reference
     let subst = subst_coe_typ
     let printer x = Nametab.pr_global_env Id.Set.empty x

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -182,7 +182,7 @@ module PrintingInductiveMake =
   end) ->
   struct
     type t = inductive
-    let compare = ind_ord
+    module Set = Indset
     let encode = Test.encode
     let subst subst obj = subst_ind subst obj
     let printer ind = Nametab.pr_global_env Id.Set.empty (IndRef ind)

--- a/pretyping/detyping.mli
+++ b/pretyping/detyping.mli
@@ -91,7 +91,7 @@ module PrintingInductiveMake :
   end) ->
     sig
       type t = Names.inductive
-      val compare : t -> t -> int
+      module Set = Indset
       val encode : Environ.env -> Libnames.qualid -> Names.inductive
       val subst : substitution -> t -> t
       val printer : t -> Pp.t


### PR DESCRIPTION
This lets us avoid having to cache the SearchBlacklist.elements call
in search as we can just use the set module's for_all function.
