### PR TITLE
Update pretyping to catch Not_found in empty env and evar_map

### DIFF
--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -443,7 +443,11 @@ let pretype_global ?loc rigid env evd gr us =
     | None -> evd, None
     | Some l -> interp_instance ?loc evd l
   in
-  Evd.fresh_global ?loc ~rigid ?names:instance !!env evd gr
+  try
+    Evd.fresh_global ?loc ~rigid ?names:instance !!env evd gr
+  with Not_found ->
+    let qid = Libnames.qualid_of_path ?loc (Nametab.path_of_global gr) in
+    Nametab.error_global_not_found qid
 
 let pretype_ref ?loc sigma env ref us =
   match ref with


### PR DESCRIPTION
If you pass in an empty environment and `evar_map` and then intern something that Coq has already determined to be global, like `nat`, then the error that is raised at the top level is `Not_found`.

While obviously one should never pass an empty environment and `evar_map` to intern, in practice, plugins that call intern should not have to catch `Not_found` when they mess up. Currently, this means that if you define a command like `Cmd3` in [tuto1](https://github.com/coq/coq/tree/master/doc/plugin_tutorial/tuto1), if you call it on `a` you get a nice user error, but if you call it on `nat` you get `Not_found` (see [the comment in tuto1](https://github.com/coq/coq/blob/master/doc/plugin_tutorial/tuto1/src/g_tuto1.mlg) by @ybertot).

This fixes that so that it throws the same error for both `a` and `nat` without the plugin writer having to worry about catching `Not_found`.
