### PR TITLE
Lazy substitution of section contexts in opaque proofs

### DIFF
--- a/checker/check.ml
+++ b/checker/check.ml
@@ -337,7 +337,6 @@ let intern_from_file ~intern_mode (dir, f) =
       let (sd:summary_disk), _, digest = marshal_in_segment f ch in
       let (md:library_disk), _, digest = marshal_in_segment f ch in
       let (opaque_csts:seg_univ option), _, udg = marshal_in_segment f ch in
-      let (discharging:'a option), _, _ = marshal_in_segment f ch in
       let (tasks:'a option), _, _ = marshal_in_segment f ch in
       let (table:seg_proofs option), pos, checksum =
         marshal_or_skip ~intern_mode f ch in
@@ -350,7 +349,7 @@ let intern_from_file ~intern_mode (dir, f) =
       if dir <> sd.md_name then
         user_err ~hdr:"intern_from_file"
           (name_clash_message dir sd.md_name f);
-      if tasks <> None || discharging <> None then
+      if tasks <> None then
         user_err ~hdr:"intern_from_file"
           (str "The file "++str f++str " contains unfinished tasks");
       if opaque_csts <> None then begin

--- a/checker/check.ml
+++ b/checker/check.ml
@@ -51,7 +51,7 @@ let pr_path sp =
 type compilation_unit_name = DirPath.t
 
 type seg_univ = Univ.ContextSet.t * bool
-type seg_proofs = (Opaqueproof.cooking_info list * int * Constr.constr) option array
+type seg_proofs = (Opaqueproof.cooking_info list * int * Constr.constr option) array
 
 type library_t = {
   library_name : compilation_unit_name;
@@ -98,9 +98,10 @@ let access_opaque_table dp i =
     with Not_found -> assert false
   in
   assert (i < Array.length t);
-  match t.(i) with
+  let (info, n, c) = t.(i) in
+  match c with
   | None -> None
-  | Some (info, n, c) -> Some (Cooking.cook_constr info n c)
+  | Some c -> Some (Cooking.cook_constr info n c)
 
 let access_discharge = Cooking.cook_constr
 

--- a/checker/mod_checking.ml
+++ b/checker/mod_checking.ml
@@ -8,12 +8,12 @@ open Environ
 
 (** {6 Checking constants } *)
 
-let get_proof = ref (fun _ _ -> assert false)
-let set_indirect_accessor f = get_proof := f
-
-let indirect_accessor = {
-  Opaqueproof.access_proof = (fun dp n -> !get_proof dp n);
+let indirect_accessor = ref {
+  Opaqueproof.access_proof = (fun _ _ -> assert false);
+  Opaqueproof.access_discharge = (fun _ _ _ -> assert false);
 }
+
+let set_indirect_accessor f = indirect_accessor := f
 
 let check_constant_declaration env kn cb =
   Flags.if_verbose Feedback.msg_notice (str "  checking cst:" ++ Constant.print kn);
@@ -40,7 +40,7 @@ let check_constant_declaration env kn cb =
   let body = match cb.const_body with
   | Undef _ | Primitive _ -> None
   | Def c -> Some (Mod_subst.force_constr c)
-  | OpaqueDef o -> Some (Opaqueproof.force_proof indirect_accessor otab o)
+  | OpaqueDef o -> Some (Opaqueproof.force_proof !indirect_accessor otab o)
   in
   let () =
     match body with

--- a/checker/mod_checking.mli
+++ b/checker/mod_checking.mli
@@ -8,6 +8,6 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-val set_indirect_accessor : (Names.DirPath.t -> int -> Constr.t option) -> unit
+val set_indirect_accessor : Opaqueproof.indirect_accessor -> unit
 
 val check_module : Environ.env -> Names.ModPath.t -> Declarations.module_body -> unit

--- a/checker/values.ml
+++ b/checker/values.ml
@@ -399,6 +399,6 @@ let v_abstract =
 let v_cooking_info =
   Tuple ("cooking_info", [|v_work_list; v_abstract|])
 
-let v_opaques = Array (Opt (Tuple ("opaque", [| List v_cooking_info; Int; v_constr |])))
+let v_opaques = Array (Tuple ("opaque", [| List v_cooking_info; Int; Opt v_constr |]))
 let v_univopaques =
   Opt (Tuple ("univopaques",[|v_context_set;v_bool|]))

--- a/checker/values.ml
+++ b/checker/values.ml
@@ -131,7 +131,7 @@ let v_proj = v_tuple "projection" [|v_proj_repr; v_bool|]
 let rec v_constr =
   Sum ("constr",0,[|
     [|Int|]; (* Rel *)
-    [|Fail "Var"|]; (* Var *)
+    [|v_id|]; (* Var *)
     [|Fail "Meta"|]; (* Meta *)
     [|Fail "Evar"|]; (* Evar *)
     [|v_sort|]; (* Sort *)
@@ -383,6 +383,22 @@ let v_libsum =
 let v_lib =
   Tuple ("library",[|v_compiled_lib;v_libraryobjs|])
 
-let v_opaques = Array (Opt v_constr)
+let v_ndecl = v_sum "named_declaration" 0
+    [| [|v_binder_annot v_id; v_constr|];               (* LocalAssum *)
+       [|v_binder_annot v_id; v_constr; v_constr|] |]   (* LocalDef *)
+
+let v_nctxt = List v_ndecl
+
+let v_work_list =
+  let v_abstr = v_pair v_instance (Array v_id) in
+  Tuple ("work_list", [|v_hmap v_cst v_abstr; v_hmap v_cst v_abstr|])
+
+let v_abstract =
+  Tuple ("abstract", [| v_nctxt; v_instance; v_abs_context |])
+
+let v_cooking_info =
+  Tuple ("cooking_info", [|v_work_list; v_abstract|])
+
+let v_opaques = Array (Opt (Tuple ("opaque", [| List v_cooking_info; Int; v_constr |])))
 let v_univopaques =
   Opt (Tuple ("univopaques",[|v_context_set;v_bool|]))

--- a/kernel/cooking.mli
+++ b/kernel/cooking.mli
@@ -28,7 +28,7 @@ type 'opaque result = {
 }
 
 val cook_constant : recipe -> Opaqueproof.opaque result
-val cook_constr : Opaqueproof.cooking_info -> constr -> constr
+val cook_constr : Opaqueproof.cooking_info list -> int -> constr -> constr
 
 val cook_inductive :
   Opaqueproof.cooking_info -> mutual_inductive_body -> Entries.mutual_inductive_entry

--- a/kernel/opaqueproof.ml
+++ b/kernel/opaqueproof.ml
@@ -129,7 +129,7 @@ let get_direct_constraints = function
 module FMap = Future.UUIDMap
 
 let dump ?(except = Future.UUIDSet.empty) { opaque_val = otab; opaque_len = n; _ } =
-  let opaque_table = Array.make n None in
+  let opaque_table = Array.make n ([], 0, None) in
   let disch_table = Array.make n [] in
   let f2t_map = ref FMap.empty in
   let iter n (univs, d, cu) =
@@ -137,7 +137,7 @@ let dump ?(except = Future.UUIDSet.empty) { opaque_val = otab; opaque_len = n; _
     let () = f2t_map := FMap.add (Future.uuid cu) n !f2t_map in
     if Future.is_val cu then
       let (c, _) = Future.force cu in
-      opaque_table.(n) <- Some (d, univs, c)
+      opaque_table.(n) <- (d, univs, Some c)
     else if Future.UUIDSet.mem uid except then
       (* Only monomorphic constraints can be delayed currently *)
       let () = assert (Int.equal univs 0) in

--- a/kernel/opaqueproof.mli
+++ b/kernel/opaqueproof.mli
@@ -66,5 +66,4 @@ val join_opaque : ?except:Future.UUIDSet.t -> opaquetab -> opaque -> unit
 
 val dump : ?except:Future.UUIDSet.t -> opaquetab ->
   (cooking_info list * int * Constr.t option) array *
-  cooking_info list array *
   int Future.UUIDMap.t

--- a/kernel/opaqueproof.mli
+++ b/kernel/opaqueproof.mli
@@ -28,15 +28,23 @@ type opaque
 val empty_opaquetab : opaquetab
 
 (** From a [proofterm] to some [opaque]. *)
-val create : proofterm -> opaque
+val create : univs:int -> proofterm -> opaque
 
 (** Turn a direct [opaque] into an indirect one. It is your responsibility to
   hashcons the inner term beforehand. The integer is an hint of the maximum id
   used so far *)
 val turn_indirect : DirPath.t -> opaque -> opaquetab -> opaque * opaquetab
 
+type work_list = (Univ.Instance.t * Id.t array) Cmap.t *
+  (Univ.Instance.t * Id.t array) Mindmap.t
+
+type cooking_info = {
+  modlist : work_list;
+  abstract : Constr.named_context * Univ.Instance.t * Univ.AUContext.t }
+
 type indirect_accessor = {
   access_proof : DirPath.t -> int -> constr option;
+  access_discharge : cooking_info list -> int -> constr -> constr;
 }
 (** When stored indirectly, opaque terms are indexed by their library
     dirpath and an integer index. The two functions above activate
@@ -51,23 +59,12 @@ val get_direct_constraints : opaque -> Univ.ContextSet.t Future.computation
 
 val subst_opaque : substitution -> opaque -> opaque
 
-type work_list = (Univ.Instance.t * Id.t array) Cmap.t * 
-  (Univ.Instance.t * Id.t array) Mindmap.t
-
-type cooking_info = { 
-  modlist : work_list; 
-  abstract : Constr.named_context * Univ.Instance.t * Univ.AUContext.t }
-
-(* The type has two caveats:
-   1) cook_constr is defined after
-   2) we have to store the input in the [opaque] in order to be able to
-      discharge it when turning a .vi into a .vo *)
 val discharge_direct_opaque :
-  cook_constr:(constr -> constr) -> cooking_info -> opaque -> opaque
+  cooking_info -> opaque -> opaque
 
 val join_opaque : ?except:Future.UUIDSet.t -> opaquetab -> opaque -> unit
 
 val dump : ?except:Future.UUIDSet.t -> opaquetab ->
-  Constr.t option array *
+  (cooking_info list * int * Constr.t) option array *
   cooking_info list array *
   int Future.UUIDMap.t

--- a/kernel/opaqueproof.mli
+++ b/kernel/opaqueproof.mli
@@ -65,6 +65,6 @@ val discharge_direct_opaque :
 val join_opaque : ?except:Future.UUIDSet.t -> opaquetab -> opaque -> unit
 
 val dump : ?except:Future.UUIDSet.t -> opaquetab ->
-  (cooking_info list * int * Constr.t) option array *
+  (cooking_info list * int * Constr.t option) array *
   cooking_info list array *
   int Future.UUIDMap.t

--- a/library/library.ml
+++ b/library/library.ml
@@ -276,11 +276,11 @@ let in_import_library : DirPath.t list * bool -> obj =
 (** Delayed / available tables of opaque terms *)
 
 type 'a table_status =
-  | ToFetch of 'a option array delayed
-  | Fetched of 'a option array
+  | ToFetch of 'a array delayed
+  | Fetched of 'a array
 
 let opaque_tables =
-  ref (LibraryMap.empty : ((Opaqueproof.cooking_info list * int * Constr.constr) table_status) LibraryMap.t)
+  ref (LibraryMap.empty : ((Opaqueproof.cooking_info list * int * Constr.constr option) table_status) LibraryMap.t)
 
 let add_opaque_table dp st =
   opaque_tables := LibraryMap.add dp st !opaque_tables
@@ -306,10 +306,10 @@ let access_table what tables dp i =
 
 let access_opaque_table dp i =
   let what = "opaque proofs" in
-  let ans = access_table what opaque_tables dp i in
-  match ans with
+  let (info, n, c) = access_table what opaque_tables dp i in
+  match c with
   | None -> None
-  | Some (info, n, c) -> Some (Cooking.cook_constr info n c)
+  | Some c -> Some (Cooking.cook_constr info n c)
 
 let indirect_accessor = {
   Opaqueproof.access_proof = access_opaque_table;
@@ -324,7 +324,7 @@ type seg_lib = library_disk
 type seg_univ = (* true = vivo, false = vi *)
   Univ.ContextSet.t * bool
 type seg_discharge = Opaqueproof.cooking_info list array
-type seg_proofs = (Opaqueproof.cooking_info list * int * Constr.t) option array
+type seg_proofs = (Opaqueproof.cooking_info list * int * Constr.t option) array
 
 let mk_library sd md digests univs =
   {

--- a/library/library.mli
+++ b/library/library.mli
@@ -36,7 +36,7 @@ type seg_lib
 type seg_univ = (* all_cst, finished? *)
   Univ.ContextSet.t * bool
 type seg_discharge = Opaqueproof.cooking_info list array
-type seg_proofs = Constr.constr option array
+type seg_proofs = (Opaqueproof.cooking_info list * int * Constr.t) option array
 
 (** Open a module (or a library); if the boolean is true then it's also
    an export otherwise just a simple import *)

--- a/library/library.mli
+++ b/library/library.mli
@@ -36,7 +36,7 @@ type seg_lib
 type seg_univ = (* all_cst, finished? *)
   Univ.ContextSet.t * bool
 type seg_discharge = Opaqueproof.cooking_info list array
-type seg_proofs = (Opaqueproof.cooking_info list * int * Constr.t) option array
+type seg_proofs = (Opaqueproof.cooking_info list * int * Constr.t option) array
 
 (** Open a module (or a library); if the boolean is true then it's also
    an export otherwise just a simple import *)

--- a/library/library.mli
+++ b/library/library.mli
@@ -35,7 +35,6 @@ type seg_sum
 type seg_lib
 type seg_univ = (* all_cst, finished? *)
   Univ.ContextSet.t * bool
-type seg_discharge = Opaqueproof.cooking_info list array
 type seg_proofs = (Opaqueproof.cooking_info list * int * Constr.t option) array
 
 (** Open a module (or a library); if the boolean is true then it's also
@@ -51,7 +50,7 @@ val save_library_to :
 
 val load_library_todo
   :  CUnix.physical_path
-  -> seg_sum * seg_lib * seg_univ * seg_discharge * 'tasks * seg_proofs
+  -> seg_sum * seg_lib * seg_univ * 'tasks * seg_proofs
 
 val save_library_raw : string -> seg_sum -> seg_lib -> seg_univ -> seg_proofs -> unit
 

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -1732,7 +1732,6 @@ end = struct (* {{{ *)
     | `ERROR_ADMITTED -> cst, false
     | `OK_ADMITTED -> cst, false
     | `OK (po,_) ->
-        let discharge c = List.fold_right Cooking.cook_constr d.(bucket) c in
         let con =
           Nametab.locate_constant
             (Libnames.qualid_of_ident po.Proof_global.id) in
@@ -1744,12 +1743,11 @@ end = struct (* {{{ *)
            the call to [check_task_aux] above. *)
         let uc = Opaqueproof.force_constraints Library.indirect_accessor (Global.opaque_tables ()) o in
         let uc = Univ.hcons_universe_context_set uc in
+        let (pr, ctx) = Option.get (Global.body_of_constant_body Library.indirect_accessor c) in
         (* We only manipulate monomorphic terms here. *)
-        let map (c, ctx) = assert (Univ.AUContext.is_empty ctx); c in
-        let pr = map (Option.get (Global.body_of_constant_body Library.indirect_accessor c)) in
-        let pr = discharge pr in
+        let () = assert (Univ.AUContext.is_empty ctx) in
         let pr = Constr.hcons pr in
-        p.(bucket) <- Some pr;
+        p.(bucket) <- Some (d.(bucket), Univ.AUContext.size ctx, pr);
         Univ.ContextSet.union cst uc, false
 
   let check_task name l i =

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -1747,7 +1747,7 @@ end = struct (* {{{ *)
         (* We only manipulate monomorphic terms here. *)
         let () = assert (Univ.AUContext.is_empty ctx) in
         let pr = Constr.hcons pr in
-        p.(bucket) <- Some (d.(bucket), Univ.AUContext.size ctx, pr);
+        p.(bucket) <- d.(bucket), Univ.AUContext.size ctx, Some pr;
         Univ.ContextSet.union cst uc, false
 
   let check_task name l i =

--- a/stm/stm.mli
+++ b/stm/stm.mli
@@ -167,7 +167,7 @@ type tasks
 val check_task : string -> tasks -> int -> bool
 val info_tasks : tasks -> (string * float * int) list
 val finish_tasks : string ->
-  Library.seg_univ -> Library.seg_discharge -> Library.seg_proofs ->
+  Library.seg_univ -> Library.seg_proofs ->
     tasks -> Library.seg_univ * Library.seg_proofs
 
 (* Id of the tip of the current branch *)

--- a/stm/vio_checking.ml
+++ b/stm/vio_checking.ml
@@ -12,7 +12,7 @@ open Util
 
 let check_vio (ts,f_in) =
   Dumpglob.noglob ();
-  let _, _, _, _, tasks, _ = Library.load_library_todo f_in in
+  let _, _, _, tasks, _ = Library.load_library_todo f_in in
   Stm.set_compilation_hints f_in;
   List.fold_left (fun acc ids -> Stm.check_task f_in tasks ids && acc) true ts
 
@@ -29,7 +29,7 @@ let schedule_vio_checking j fs =
   if j < 1 then CErrors.user_err Pp.(str "The number of workers must be bigger than 0");
   let jobs = ref [] in
   List.iter (fun long_f_dot_vio ->
-    let _,_,_,_, tasks, _ = Library.load_library_todo long_f_dot_vio in
+    let _,_,_, tasks, _ = Library.load_library_todo long_f_dot_vio in
     Stm.set_compilation_hints long_f_dot_vio;
     let infos = Stm.info_tasks tasks in
     let eta = List.fold_left (fun a (_,t,_) -> a +. t) 0.0 infos in

--- a/toplevel/ccompile.ml
+++ b/toplevel/ccompile.ml
@@ -176,9 +176,9 @@ let compile opts copts ~echo ~f_in ~f_out =
       Dumpglob.noglob ();
       let long_f_dot_vio, long_f_dot_vo =
         ensure_exists_with_prefix f_in f_out ".vio" ".vo" in
-      let sum, lib, univs, disch, tasks, proofs =
+      let sum, lib, univs, tasks, proofs =
         Library.load_library_todo long_f_dot_vio in
-      let univs, proofs = Stm.finish_tasks long_f_dot_vo univs disch proofs tasks in
+      let univs, proofs = Stm.finish_tasks long_f_dot_vo univs proofs tasks in
       Library.save_library_raw long_f_dot_vo sum lib univs proofs
 
 let compile opts copts ~echo ~f_in ~f_out =


### PR DESCRIPTION
Do not substitute opaque constants when discharging.
    
Instead we do that on a by-need basis by reusing the section info already stored in the opaque proof. The justification is that we almost never observe the opaque proof, so that paying upfront for substitution is not worthwhile.

The trade-off is obviously that now accessing it is more expensive, as it recomputes it every time. Note that this was already the case with functor substitution, so this is similar in spirit. This is costly for printing and extraction. The former shouldn't appear in a compilation unit, and the interactive cost doesn't matter, and the latter is at most evaluated once, which doesn't change from the current situation.

This change allows to remove the discharging segment of vo files, as well as some simplifications in vio2vo compilation.

Bench:
```
┌────────────────────────┬─────────────────────────┬─────────────────────────────────────────────┬─────────────────────────────────────────────┬────────────────────────────────┬─────────────────────────┐
│                        │      user time [s]      │                 CPU cycles                  │              CPU instructions               │     max resident mem [KB]      │       mem faults        │
│                        │                         │                                             │                                             │                                │                         │
│           package_name │     NEW     OLD PDIFF   │               NEW               OLD PDIFF   │               NEW               OLD PDIFF   │        NEW        OLD  PDIFF   │     NEW     OLD PDIFF   │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼─────────────────────────┤
│ coq-mathcomp-character │  180.03  187.36 -3.91 % │      501267509115      521892036871 -3.95 % │      661217572750      693454806277 -4.65 % │     843716    1106060 -23.72 % │       0       0  +nan % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼─────────────────────────┤
│ coq-mathcomp-odd-order │ 1426.04 1459.44 -2.29 % │     3974841201267     4061996857131 -2.15 % │     6850317367128     6975355019723 -1.79 % │    1255300    1267412  -0.96 % │       2       0  +nan % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼─────────────────────────┤
│              coq-verdi │  116.78  118.75 -1.66 % │      324934290828      329991871942 -1.53 % │      416473719361      421245350947 -1.13 % │     559504     572588  -2.29 % │      10       6 +66.67 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼─────────────────────────┤
│   coq-mathcomp-algebra │  164.00  166.45 -1.47 % │      456997060421      463454210943 -1.39 % │      564011234925      573915362922 -1.73 % │     606892     628532  -3.44 % │       0      24 -100.00 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼─────────────────────────┤
│  coq-mathcomp-solvable │  187.33  189.54 -1.17 % │      521623490510      528749104078 -1.35 % │      696123185189      707049659643 -1.55 % │     785888     824084  -4.63 % │      81       5 +1520.00 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼─────────────────────────┤
│        coq-lambda-rust │ 1581.32 1599.76 -1.15 % │     4408811761811     4457420693968 -1.09 % │     5871054265070     5945091683196 -1.25 % │    1476820    1616452  -8.64 % │      46       0  +nan % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼─────────────────────────┤
│ coq-mathcomp-ssreflect │   39.58   40.00 -1.05 % │      109324981340      110378465606 -0.95 % │      132556473929      133984456342 -1.07 % │     521520     529096  -1.43 % │      14       6 +133.33 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼─────────────────────────┤
│     coq-mathcomp-field │  228.19  230.32 -0.92 % │      635700734747      641747471645 -0.94 % │      910198387060      918474042090 -0.90 % │     743872     755516  -1.54 % │      14       0  +nan % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼─────────────────────────┤
│  coq-mathcomp-fingroup │   51.06   51.39 -0.64 % │      142255175671      143391540246 -0.79 % │      185026646637      186936908442 -1.02 % │     560712     568008  -1.28 % │      22      96 -77.08 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼─────────────────────────┤
│         coq-verdi-raft │ 1313.05 1321.10 -0.61 % │     3664754458085     3682836002020 -0.49 % │     4983617616845     4999204307029 -0.31 % │    1811904    1822268  -0.57 % │       0       2 -100.00 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼─────────────────────────┤
│            coq-unimath │ 2580.19 2587.07 -0.27 % │     7186996642207     7207426976850 -0.28 % │    12941966598896    12995820418800 -0.41 % │    1257636    1672260 -24.79 % │     494     179 +175.98 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼─────────────────────────┤
│          coq-fourcolor │ 2163.53 2168.05 -0.21 % │     6029237980445     6042455523409 -0.22 % │    11345676020674    11362965172307 -0.15 % │     929348     929352  -0.00 % │       4       5 -20.00 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼─────────────────────────┤
│            coq-bignums │   68.75   68.80 -0.07 % │      191882109013      191952420948 -0.04 % │      252389769613      253653017032 -0.50 % │     491052     491104  -0.01 % │     157       6 +2516.67 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼─────────────────────────┤
│              coq-flocq │  461.20  461.42 -0.05 % │     1282900933406     1283846996996 -0.07 % │     1771772554257     1776857569890 -0.29 % │    1116780    1292348 -13.59 % │     199      14 +1321.43 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼─────────────────────────┤
│        coq-fiat-crypto │ 3779.20 3779.64 -0.01 % │    10497786931926    10492857084677 +0.05 % │    16457653767575    16516411072632 -0.36 % │    2339500    2655540 -11.90 % │    1058    1063 -0.47 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼─────────────────────────┤
│           coq-compcert │  960.80  960.83 -0.00 % │     2678991677044     2677960715260 +0.04 % │     3978557709653     3989459269938 -0.27 % │    1032932    1032756  +0.02 % │     119      90 +32.22 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼─────────────────────────┤
│       coq-fiat-parsers │  634.23  633.71 +0.08 % │     1777029433775     1773387832257 +0.21 % │     2684628063174     2688958650585 -0.16 % │    3233324    3235996  -0.08 % │     104     642 -83.80 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼─────────────────────────┤
│               coq-corn │ 1448.76 1446.51 +0.16 % │     4041510570499     4039788679767 +0.04 % │     5998896757250     6015966198500 -0.28 % │     892612     894644  -0.23 % │       1       1 +0.00 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼─────────────────────────┤
│             coq-geocoq │ 1940.31 1937.15 +0.16 % │     5412559623791     5407445888265 +0.09 % │     7825064912029     7842488002816 -0.22 % │    1256364    1251356  +0.40 % │     134      84 +59.52 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼─────────────────────────┤
│       coq-math-classes │  216.63  216.16 +0.22 % │      605645120207      604678705199 +0.16 % │      766458556937      767743626177 -0.17 % │     513432     514556  -0.22 % │      15      13 +15.38 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼─────────────────────────┤
│             coq-sf-plf │   43.65   43.54 +0.25 % │      122480714828      122306500398 +0.14 % │      158261532308      158268221567 -0.00 % │     481532     488840  -1.49 % │      39       0  +nan % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼─────────────────────────┤
│              coq-color │  697.40  694.60 +0.40 % │     1949305327790     1941711575695 +0.39 % │     2322441737010     2325920870475 -0.15 % │    1383904    1341296  +3.18 % │       8       1 +700.00 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼─────────────────────────┤
│          coq-fiat-core │  108.36  107.74 +0.58 % │      308510344565      307465754825 +0.34 % │      385091008101      385438974091 -0.09 % │     485340     485204  +0.03 % │     106     104 +1.92 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼─────────────────────────┤
│               coq-hott │  334.40  332.18 +0.67 % │      907242806138      904225020605 +0.33 % │     1378701848241     1376580130312 +0.15 % │     477900     478024  -0.03 % │     376       0  +nan % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼─────────────────────────┤
│ coq-fiat-crypto-legacy │ 6302.16 6189.63 +1.82 % │    17543790541723    17235361110028 +1.79 % │    28419215133629    28106002364887 +1.11 % │    2360712    2577960  -8.43 % │     867     892 -2.80 % │
└────────────────────────┴─────────────────────────┴─────────────────────────────────────────────┴─────────────────────────────────────────────┴────────────────────────────────┴─────────────────────────┘
```

The fiat-crypto-legacy slowdown is entirely due to calls to `Print Assumptions`. Apart from being a legacy development, I don't think this should be taken into consideration for efficiency purposes.