### PR TITLE
Fix #10283: clearer dependency documentation for building CoqIDE.

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -53,12 +53,12 @@ WHAT DO YOU NEED ?
    Debian / Ubuntu users can get the necessary system packages for
    CoqIDE with:
 
-   $ sudo apt-get install libgtk-3-dev libgtksourceview-3.0-dev
+   $ sudo apt-get install libgtksourceview-3.0-dev
 
    Opam (https://opam.ocaml.org/) is recommended to install OCaml and
    the corresponding packages.
 
-   $ opam install num ocamlfind lablgtk3 lablgtk3-sourceview3
+   $ opam install num ocamlfind lablgtk3-sourceview3
 
    should get you a reasonable OCaml environment to compile Coq.
 

--- a/INSTALL
+++ b/INSTALL
@@ -50,10 +50,15 @@ WHAT DO YOU NEED ?
    findlib/ocamlfind as Coq's makefile will use it to locate the
    libraries during the build.
 
+   Debian / Ubuntu users can get the necessary system packages for
+   CoqIDE with:
+
+   $ sudo apt-get install libgtk-3-dev libgtksourceview-3.0-dev
+
    Opam (https://opam.ocaml.org/) is recommended to install OCaml and
    the corresponding packages.
 
-   $ opam install num ocamlfind lablgtk conf-gtksourceview
+   $ opam install num ocamlfind lablgtk3 lablgtk3-sourceview3
 
    should get you a reasonable OCaml environment to compile Coq.
 

--- a/doc/sphinx/changes.rst
+++ b/doc/sphinx/changes.rst
@@ -120,7 +120,9 @@ reference manual. Here are the most important user-visible changes:
 
 - CoqIDE:
 
-  - CoqIDE now depends on gtk+3 and lablgtk3 instead of gtk+2 and lablgtk2
+  - CoqIDE now depends on gtk+3 and lablgtk3 instead of gtk+2 and lablgtk2.
+    The INSTALL file available in the Coq sources has been updated to list
+    the new dependencies
     (`#9279 <https://github.com/coq/coq/pull/9279>`_,
     by Hugo Herbelin, with help from Jacques Garrigue,
     Emilio Jesús Gallego Arias, Michael Sogetrop and Vincent Laporte).


### PR DESCRIPTION
**Kind:** documentation

Fix #10283.

@charguer I didn't know about a dependency on `libexpat1-dev` so I didn't list it yet. Are you sure about it?
@ejgallego I am not sure what is the difference between `conf-gtksourceview` and `lablgtk3-sourceview3`. Does it make any difference? In any case, it seems good to list package names with explicit versions.