### PR TITLE
Adding syntax for non maximal implicit args and print implicit arguments

### DIFF
--- a/interp/constrexpr_ops.ml
+++ b/interp/constrexpr_ops.ml
@@ -22,20 +22,15 @@ open Decl_kinds
 (***********************)
 (* For binders parsing *)
 
-let binding_kind_eq bk1 bk2 = match bk1, bk2 with
-| Explicit, Explicit -> true
-| Implicit, Implicit -> true
-| _ -> false
-
 let abstraction_kind_eq ak1 ak2 = match ak1, ak2 with
 | AbsLambda, AbsLambda -> true
 | AbsPi, AbsPi -> true
 | _ -> false
 
 let binder_kind_eq b1 b2 = match b1, b2 with
-| Default bk1, Default bk2 -> binding_kind_eq bk1 bk2
+| Default bk1, Default bk2 -> Glob_ops.binding_kind_eq bk1 bk2
 | Generalized (ck1, b1), Generalized (ck2, b2) ->
-  binding_kind_eq ck1 ck2 &&
+  Glob_ops.binding_kind_eq ck1 ck2 &&
   (if b1 then b2 else not b2)
 | _ -> false
 
@@ -172,7 +167,7 @@ let rec constr_expr_eq e1 e2 =
     | CPrim i1, CPrim i2 ->
       prim_token_eq i1 i2
     | CGeneralization (bk1, ak1, e1), CGeneralization (bk2, ak2, e2) ->
-      binding_kind_eq bk1 bk2 &&
+      Glob_ops.binding_kind_eq bk1 bk2 &&
       Option.equal abstraction_kind_eq ak1 ak2 &&
       constr_expr_eq e1 e2
     | CDelimiters(s1,e1), CDelimiters(s2,e2) ->

--- a/interp/constrexpr_ops.mli
+++ b/interp/constrexpr_ops.mli
@@ -26,9 +26,6 @@ val constr_expr_eq : constr_expr -> constr_expr -> bool
 val local_binder_eq : local_binder_expr -> local_binder_expr -> bool
 (** Equality on [local_binder_expr]. Same properties as [constr_expr_eq]. *)
 
-val binding_kind_eq : Decl_kinds.binding_kind -> Decl_kinds.binding_kind -> bool
-(** Equality on [binding_kind] *)
-
 val binder_kind_eq : binder_kind -> binder_kind -> bool
 (** Equality on [binder_kind] *)
 

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -1004,8 +1004,7 @@ and factorize_prod scopes vars na ?impargs aty c =
         | Some [hd] -> Some hd, None
         | Some (hd::tl) -> Some hd, Some tl
         | _ -> None, None in
-      let bk = if Option.cata is_status_implicit false impargs_hd
-        then Implicit else Explicit in
+      let bk = Option.cata binding_kind_of_status Explicit impargs_hd in
       let c = extern_typ scopes ?impargs:impargs_tl vars c in
       match na, c.v with
       | Name id, CProdN (CLocalAssum(nal,Default bk',ty)::bl,b)

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -1008,7 +1008,7 @@ and factorize_prod scopes vars na ?impargs aty c =
       let c = extern_typ scopes ?impargs:impargs_tl vars c in
       match na, c.v with
       | Name id, CProdN (CLocalAssum(nal,Default bk',ty)::bl,b)
-           when (* binding_kind_eq bk bk' &&  *)constr_expr_eq aty ty
+           when binding_kind_eq bk bk' && constr_expr_eq aty ty
                 && not (occur_var_constr_expr id ty) (* avoid na in ty escapes scope *) ->
          CProdN (CLocalAssum(make na::nal,Default bk,aty)::bl,b)
       | _, CProdN (bl,b) ->

--- a/interp/constrextern.mli
+++ b/interp/constrextern.mli
@@ -25,7 +25,7 @@ open Ltac_pretype
 
 val extern_cases_pattern : Id.Set.t -> 'a cases_pattern_g -> cases_pattern_expr
 val extern_glob_constr : Id.Set.t -> 'a glob_constr_g -> constr_expr
-val extern_glob_type : Id.Set.t -> 'a glob_constr_g -> constr_expr
+val extern_glob_type : Id.Set.t -> ?impargs:Impargs.implicit_status list -> 'a glob_constr_g -> constr_expr
 val extern_constr_pattern : names_context -> Evd.evar_map ->
   constr_pattern -> constr_expr
 val extern_closed_glob : ?lax:bool -> bool -> env -> Evd.evar_map -> closed_glob_constr -> constr_expr
@@ -39,7 +39,7 @@ val extern_closed_glob : ?lax:bool -> bool -> env -> Evd.evar_map -> closed_glob
 val extern_constr : ?lax:bool -> bool -> env -> Evd.evar_map -> constr -> constr_expr
 val extern_constr_in_scope : bool -> scope_name -> env -> Evd.evar_map -> constr -> constr_expr
 val extern_reference : ?loc:Loc.t -> Id.Set.t -> GlobRef.t -> qualid
-val extern_type : bool -> env -> Evd.evar_map -> types -> constr_expr
+val extern_type : bool -> env -> Evd.evar_map -> ?impargs:Impargs.implicit_status list -> types -> constr_expr
 val extern_sort : Evd.evar_map -> Sorts.t -> glob_sort
 val extern_rel_context : constr option -> env -> Evd.evar_map ->
   rel_context -> local_binder_expr list

--- a/interp/declare.ml
+++ b/interp/declare.ml
@@ -216,7 +216,7 @@ let cache_variable ((sp,_),o) =
   let impl,opaq,poly,ctx = match d with (* Fails if not well-typed *)
     | SectionLocalAssum ((ty,ctx),poly,impl) ->
       let () = Global.push_named_assum ((id,ty,poly),ctx) in
-      let impl = if impl then Implicit else Explicit in
+      let impl = if impl then MaxImplicit else Explicit in
         impl, true, poly, ctx
     | SectionLocalDef (de) ->
       (* The body should already have been forced upstream because it is a

--- a/interp/impargs.mli
+++ b/interp/impargs.mli
@@ -77,6 +77,7 @@ type implicit_side_condition
 type implicits_list = implicit_side_condition * implicit_status list
 
 val is_status_implicit : implicit_status -> bool
+val binding_kind_of_status : implicit_status -> Decl_kinds.binding_kind
 val is_inferable_implicit : bool -> int -> implicit_status -> bool
 val name_of_implicit : implicit_status -> Id.t
 val maximal_insertion_of : implicit_status -> bool
@@ -119,12 +120,10 @@ val declare_manual_implicits : bool -> GlobRef.t -> ?enriching:bool ->
 val maybe_declare_manual_implicits : bool -> GlobRef.t -> ?enriching:bool ->
   manual_implicits -> unit
 
-type implicit_kind = Implicit | MaximallyImplicit | NotImplicit
-
 (** [set_implicits local ref l]
    Manual declaration of implicit arguments.
   `l` is a list of possible sequences of implicit statuses. *)
-val set_implicits : bool -> GlobRef.t -> implicit_kind list list -> unit
+val set_implicits : bool -> GlobRef.t -> Decl_kinds.binding_kind list list -> unit
 
 val implicits_of_global : GlobRef.t -> implicits_list list
 

--- a/library/decl_kinds.ml
+++ b/library/decl_kinds.ml
@@ -14,7 +14,7 @@ type discharge = DoDischarge | NoDischarge
 
 type locality = Discharge | Local | Global
 
-type binding_kind = Explicit | Implicit
+type binding_kind = Explicit | NonMaxImplicit | MaxImplicit
 
 type polymorphic = bool
 

--- a/parsing/g_constr.mlg
+++ b/parsing/g_constr.mlg
@@ -237,7 +237,7 @@ GRAMMAR EXTEND Gram
       | "{"; c = binder_constr ; "}" ->
           { CAst.make ~loc @@ CNotation((InConstrEntrySomeLevel,"{ _ }"),([c],[],[],[])) }
       | "`{"; c = operconstr LEVEL "200"; "}" ->
-	  { CAst.make ~loc @@ CGeneralization (Implicit, None, c) }
+          { CAst.make ~loc @@ CGeneralization (MaxImplicit, None, c) }
       | "`("; c = operconstr LEVEL "200"; ")" ->
 	  { CAst.make ~loc @@ CGeneralization (Explicit, None, c) }
       ] ]
@@ -431,15 +431,15 @@ GRAMMAR EXTEND Gram
       | s = string -> { CAst.make ~loc @@ CPatPrim (String s) } ] ]
   ;
   impl_ident_tail:
-    [ [ "}" -> { binder_of_name Implicit }
+    [ [ "}" -> { binder_of_name MaxImplicit }
     | nal=LIST1 name; ":"; c=lconstr; "}" ->
-        { (fun na -> CLocalAssum (na::nal,Default Implicit,c)) }
+        { (fun na -> CLocalAssum (na::nal,Default MaxImplicit,c)) }
     | nal=LIST1 name; "}" ->
-        { (fun na -> CLocalAssum (na::nal,Default Implicit,
+        { (fun na -> CLocalAssum (na::nal,Default MaxImplicit,
                                 CAst.make ?loc:(Loc.merge_opt na.CAst.loc (Some loc)) @@
                                 CHole (Some (Evar_kinds.BinderType na.CAst.v), IntroAnonymous, None))) }
     | ":"; c=lconstr; "}" ->
-	{ (fun na -> CLocalAssum ([na],Default Implicit,c)) }
+        { (fun na -> CLocalAssum ([na],Default MaxImplicit,c)) }
     ] ]
   ;
   fixannot:
@@ -495,17 +495,27 @@ GRAMMAR EXTEND Gram
       | "("; id=name; ":"; t=lconstr; ":="; c=lconstr; ")" ->
           { [CLocalDef (id,c,Some t)] }
       | "{"; id=name; "}" ->
-          { [CLocalAssum ([id],Default Implicit, CAst.make ~loc @@ CHole (None, IntroAnonymous, None))] }
+          { [CLocalAssum ([id],Default MaxImplicit, CAst.make ~loc @@ CHole (None, IntroAnonymous, None))] }
       | "{"; id=name; idl=LIST1 name; ":"; c=lconstr; "}" ->
-          { [CLocalAssum (id::idl,Default Implicit,c)] }
+          { [CLocalAssum (id::idl,Default MaxImplicit,c)] }
       | "{"; id=name; ":"; c=lconstr; "}" ->
-          { [CLocalAssum ([id],Default Implicit,c)] }
+          { [CLocalAssum ([id],Default MaxImplicit,c)] }
       | "{"; id=name; idl=LIST1 name; "}" ->
-          { List.map (fun id -> CLocalAssum ([id],Default Implicit, CAst.make ~loc @@ CHole (None, IntroAnonymous, None))) (id::idl) }
+          { List.map (fun id -> CLocalAssum ([id],Default MaxImplicit, CAst.make ~loc @@ CHole (None, IntroAnonymous, None))) (id::idl) }
+      | "["; id=name; "]" ->
+          { [CLocalAssum ([id],Default NonMaxImplicit, CAst.make ~loc @@ CHole (None, IntroAnonymous, None))] }
+      | "["; id=name; idl=LIST1 name; ":"; c=lconstr; "]" ->
+          { [CLocalAssum (id::idl,Default NonMaxImplicit,c)] }
+      | "["; id=name; ":"; c=lconstr; "]" ->
+          { [CLocalAssum ([id],Default NonMaxImplicit,c)] }
+      | "["; id=name; idl=LIST1 name; "]" ->
+          { List.map (fun id -> CLocalAssum ([id],Default NonMaxImplicit, CAst.make ~loc @@ CHole (None, IntroAnonymous, None))) (id::idl) }
       | "`("; tc = LIST1 typeclass_constraint SEP "," ; ")" ->
           { List.map (fun (n, b, t) -> CLocalAssum ([n], Generalized (Explicit, b), t)) tc }
       | "`{"; tc = LIST1 typeclass_constraint SEP "," ; "}" ->
-          { List.map (fun (n, b, t) -> CLocalAssum ([n], Generalized (Implicit, b), t)) tc }
+          { List.map (fun (n, b, t) -> CLocalAssum ([n], Generalized (MaxImplicit, b), t)) tc }
+      | "`["; tc = LIST1 typeclass_constraint SEP "," ; "]" ->
+          { List.map (fun (n, b, t) -> CLocalAssum ([n], Generalized (NonMaxImplicit, b), t)) tc }
       | "'"; p = pattern LEVEL "0" ->
           { let (p, ty) =
             match p.CAst.v with

--- a/plugins/ssr/ssrvernac.mlg
+++ b/plugins/ssr/ssrvernac.mlg
@@ -152,7 +152,7 @@ let declare_one_prenex_implicit locality f =
     with _ -> errorstrm (pr_qualid f ++ str " is not declared") in
   let rec loop = function
   | a :: args' when Impargs.is_status_implicit a ->
-    Impargs.MaximallyImplicit :: loop args'
+    MaxImplicit :: loop args'
   | args' when List.exists Impargs.is_status_implicit args' ->
       errorstrm (str "Expected prenex implicits for " ++ pr_qualid f)
   | _ -> [] in

--- a/pretyping/glob_ops.ml
+++ b/pretyping/glob_ops.ml
@@ -62,8 +62,9 @@ let glob_sort_family = let open Sorts in function
 
 let binding_kind_eq bk1 bk2 = match bk1, bk2 with
   | Decl_kinds.Explicit, Decl_kinds.Explicit -> true
-  | Decl_kinds.Implicit, Decl_kinds.Implicit -> true
-  | (Decl_kinds.Explicit | Decl_kinds.Implicit), _ -> false
+  | Decl_kinds.NonMaxImplicit, Decl_kinds.NonMaxImplicit -> true
+  | Decl_kinds.MaxImplicit, Decl_kinds.MaxImplicit -> true
+  | (Decl_kinds.Explicit | Decl_kinds.NonMaxImplicit | Decl_kinds.MaxImplicit), _ -> false
 
 let case_style_eq s1 s2 = let open Constr in match s1, s2 with
   | LetStyle, LetStyle -> true

--- a/pretyping/glob_ops.mli
+++ b/pretyping/glob_ops.mli
@@ -17,6 +17,9 @@ val glob_sort_eq : Glob_term.glob_sort -> Glob_term.glob_sort -> bool
 
 val glob_sort_family : 'a glob_sort_gen -> Sorts.family
 
+val binding_kind_eq : Decl_kinds.binding_kind -> Decl_kinds.binding_kind -> bool
+(** Equality on [binding_kind] *)
+
 val cases_pattern_eq : 'a cases_pattern_g -> 'a cases_pattern_g -> bool
 
 val alias_of_pat : 'a cases_pattern_g -> Name.t

--- a/printing/ppconstr.ml
+++ b/printing/ppconstr.ml
@@ -144,7 +144,8 @@ let tag_var = tag Tag.variable
   let pr_generalization bk ak c =
     let hd, tl =
       match bk with
-        | Implicit -> "{", "}"
+        | NonMaxImplicit -> "[", "]"
+        | MaxImplicit -> "{", "}"
         | Explicit -> "(", ")"
     in (* TODO: syntax Abstraction Kind *)
     str "`" ++ str hd ++ c ++ str tl
@@ -331,12 +332,14 @@ let tag_var = tag Tag.variable
   let surround_impl k p =
     match k with
       | Explicit -> str"(" ++ p ++ str")"
-      | Implicit -> str"{" ++ p ++ str"}"
+      | NonMaxImplicit -> str"[" ++ p ++ str"]"
+      | MaxImplicit -> str"{" ++ p ++ str"}"
 
   let surround_implicit k p =
     match k with
       | Explicit -> p
-      | Implicit -> (str"{" ++ p ++ str"}")
+      | NonMaxImplicit -> str"[" ++ p ++ str"]"
+      | MaxImplicit -> (str"{" ++ p ++ str"}")
 
   let pr_binder many pr (nal,k,t) =
     match k with

--- a/printing/prettyp.ml
+++ b/printing/prettyp.ml
@@ -82,6 +82,7 @@ let print_ref reduce ref udecl =
       let ctx,ccl = Reductionops.splay_prod_assum env sigma typ
       in EConstr.it_mkProd_or_LetIn ccl ctx
     else typ in
+  let impargs = select_stronger_impargs (implicits_of_global ref) in
   let variance = match ref with
     | VarRef _ | ConstRef _ -> None
     | IndRef (ind,_) | ConstructRef ((ind,_),_) ->
@@ -94,7 +95,7 @@ let print_ref reduce ref udecl =
     else mt ()
   in
   let priv = None in (* We deliberately don't print private univs in About. *)
-  hov 0 (pr_global ref ++ inst ++ str " :" ++ spc () ++ pr_letype_env env sigma typ ++ 
+  hov 0 (pr_global ref ++ inst ++ str " :" ++ spc () ++ pr_letype_env env sigma ~impargs typ ++
          Printer.pr_abstract_universe_ctx sigma ?variance univs ?priv)
 
 (********************************)

--- a/printing/prettyp.mli
+++ b/printing/prettyp.mli
@@ -15,6 +15,8 @@ open Libnames
 
 (** A Pretty-Printer for the Calculus of Inductive Constructions. *)
 
+val print_ref : bool -> Names.GlobRef.t -> UnivNames.univ_name_list option -> Pp.t
+
 val assumptions_for_print : Name.t list -> Termops.names_context
 
 val print_closed_sections : bool ref

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -115,7 +115,7 @@ let pr_ltype_env env sigma c = pr_letype_core false env sigma (EConstr.of_constr
 let pr_type_env env sigma c = pr_etype_core false env sigma (EConstr.of_constr c)
 
 let pr_etype_env env sigma c = pr_etype_core false env sigma c
-let pr_letype_env env sigma c = pr_letype_core false env sigma c
+let pr_letype_env env sigma ?impargs c = pr_letype_core false env sigma ?impargs c
 let pr_goal_concl_style_env env sigma c = pr_letype_core true env sigma c
 
 let pr_ljudge_env env sigma j =

--- a/printing/printer.mli
+++ b/printing/printer.mli
@@ -47,7 +47,7 @@ val pr_leconstr_env     : env -> evar_map -> EConstr.t -> Pp.t
 val pr_econstr_n_env    : env -> evar_map -> Notation_gram.tolerability -> EConstr.t -> Pp.t
 
 val pr_etype_env           : env -> evar_map -> EConstr.types -> Pp.t
-val pr_letype_env           : env -> evar_map -> EConstr.types -> Pp.t
+val pr_letype_env           : env -> evar_map -> ?impargs:Impargs.implicit_status list -> EConstr.types -> Pp.t
 
 val pr_open_constr_env     : env -> evar_map -> open_constr -> Pp.t
 

--- a/printing/proof_diffs.ml
+++ b/printing/proof_diffs.ml
@@ -245,8 +245,8 @@ let process_goal sigma g : EConstr.t reified_goal =
   let hyps      = List.map to_tuple hyps in
   { name; ty; hyps; env; sigma };;
 
-let pr_letype_core goal_concl_style env sigma t =
-  Ppconstr.pr_lconstr_expr env sigma (Constrextern.extern_type goal_concl_style env sigma t)
+let pr_letype_core goal_concl_style env sigma ?impargs t =
+  Ppconstr.pr_lconstr_expr env sigma (Constrextern.extern_type goal_concl_style env sigma ?impargs t)
 
 let pp_of_type env sigma ty =
   pr_letype_core true env sigma ty

--- a/printing/proof_diffs.mli
+++ b/printing/proof_diffs.mli
@@ -54,7 +54,7 @@ val diff_goal : ?og_s:(Goal.goal sigma) -> Goal.goal -> Evd.evar_map -> Pp.t
 (** Convert a string to a list of token strings using the lexer *)
 val tokenize_string : string -> string list
 
-val pr_letype_core         : bool -> Environ.env -> Evd.evar_map -> EConstr.types -> Pp.t
+val pr_letype_core         : bool -> Environ.env -> Evd.evar_map -> ?impargs:Impargs.implicit_status list -> EConstr.types -> Pp.t
 val pr_leconstr_core       : bool -> Environ.env -> Evd.evar_map -> EConstr.constr -> Pp.t
 val pr_lconstr_env         : env -> evar_map -> constr -> Pp.t
 

--- a/test-suite/success/ImplicitArguments.v
+++ b/test-suite/success/ImplicitArguments.v
@@ -1,7 +1,24 @@
-Inductive vector {A : Type} : nat -> Type :=
+
+Axiom foo : forall (x y z t : nat), nat.
+
+Arguments foo {_} _ [z] {t}.
+Check (foo 1).
+Arguments foo {_} _ [z] [t].
+Check (foo 1).
+
+Definition foo1 n [m] := n + m.
+Check (foo1 1).
+
+Definition foo2 [n] := n + n.
+Check foo2.
+Arguments foo2 {n}.
+Check foo2.
+
+Inductive vector [A : Type] : nat -> Type :=
 | vnil : vector 0
 | vcons : A -> forall {n'}, vector n' -> vector (S n').
 
+Check vector.
 Arguments vector A : clear implicits.
 
 

--- a/test-suite/success/ImplicitArguments.v
+++ b/test-suite/success/ImplicitArguments.v
@@ -4,6 +4,9 @@ Inductive vector {A : Type} : nat -> Type :=
 
 Arguments vector A : clear implicits.
 
+
+Definition foo6 (x:=1) : forall {n:nat}, n=n := fun n => eq_refl.
+
 Require Import Coq.Program.Program.
 
 Program Definition head {A : Type} {n : nat} (v : vector A (S n)) : vector A n :=

--- a/test-suite/success/ImplicitArguments.v
+++ b/test-suite/success/ImplicitArguments.v
@@ -21,6 +21,20 @@ Inductive vector [A : Type] : nat -> Type :=
 Check vector.
 Arguments vector A : clear implicits.
 
+Axiom bla : `{nat} -> Set.
+
+Axiom foo' : forall (x y a z t : nat), x + y + z = t.
+
+Set Printing All.
+
+Arguments foo' {_} _ {_} [z] {t}.
+Check (foo' 1).
+Arguments foo' {_} {_} _ [z] [t].
+
+
+Check (foo 1).
+
+
 
 Definition foo6 (x:=1) : forall {n:nat}, n=n := fun n => eq_refl.
 

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -497,7 +497,7 @@ let do_instance ~pstate env env' sigma ?hook ~tac ~global ~poly ~program_mode ct
 let interp_instance_context ~program_mode env ctx ?(generalize=false) pl tclass =
   let sigma, decl = Constrexpr_ops.interp_univ_decl_opt env pl in
   let tclass =
-    if generalize then CAst.make @@ CGeneralization (Implicit, Some AbsPi, tclass)
+    if generalize then CAst.make @@ CGeneralization (MaxImplicit, Some AbsPi, tclass)
     else tclass
   in
   let sigma, (impls, ((env', ctx), imps)) = interp_context_evars ~program_mode env sigma ctx in

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -16,7 +16,6 @@ open Util
 open Names
 open Glob_term
 open Vernacexpr
-open Impargs
 open Constrexpr
 open Constrexpr_ops
 open Extend
@@ -815,7 +814,7 @@ GRAMMAR EXTEND Gram
       { let name, recarg_like, notation_scope = item in
       [`Id { name=name; recarg_like=recarg_like;
              notation_scope=notation_scope;
-             implicit_status = NotImplicit}] }
+             implicit_status = Explicit}] }
     | "/" -> { [`Slash] }
     | "&" -> { [`Ampersand] }
     | "("; items = LIST1 argument_spec; ")"; sc = OPT scope ->
@@ -825,7 +824,7 @@ GRAMMAR EXTEND Gram
        List.map (fun (name,recarg_like,notation_scope) ->
            `Id { name=name; recarg_like=recarg_like;
                  notation_scope=f notation_scope;
-                 implicit_status = NotImplicit}) items }
+                 implicit_status = Explicit}) items }
     | "["; items = LIST1 argument_spec; "]"; sc = OPT scope ->
        { let f x = match sc, x with
          | None, x -> x | x, None -> Option.map (fun y -> CAst.make ~loc y) x
@@ -833,7 +832,7 @@ GRAMMAR EXTEND Gram
        List.map (fun (name,recarg_like,notation_scope) ->
            `Id { name=name; recarg_like=recarg_like;
                  notation_scope=f notation_scope;
-                 implicit_status = Implicit}) items }
+                 implicit_status = NonMaxImplicit}) items }
     | "{"; items = LIST1 argument_spec; "}"; sc = OPT scope ->
        { let f x = match sc, x with
          | None, x -> x | x, None -> Option.map (fun y -> CAst.make ~loc y) x
@@ -841,16 +840,16 @@ GRAMMAR EXTEND Gram
        List.map (fun (name,recarg_like,notation_scope) ->
            `Id { name=name; recarg_like=recarg_like;
                  notation_scope=f notation_scope;
-                 implicit_status = MaximallyImplicit}) items }
+                 implicit_status = MaxImplicit}) items }
     ]
   ];
   (* Same as [argument_spec_block], but with only implicit status and names *)
   more_implicits_block: [
-    [ name = name -> { [(name.CAst.v, NotImplicit)] }
+    [ name = name -> { [(name.CAst.v, Explicit)] }
     | "["; items = LIST1 name; "]" ->
-       { List.map (fun name -> (name.CAst.v, Impargs.Implicit)) items }
+       { List.map (fun name -> (name.CAst.v, NonMaxImplicit)) items }
     | "{"; items = LIST1 name; "}" ->
-       { List.map (fun name -> (name.CAst.v, MaximallyImplicit)) items }
+       { List.map (fun name -> (name.CAst.v, MaxImplicit)) items }
     ]
   ];
   strategy_level:

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -1054,9 +1054,9 @@ open Pputils
               let pr_s = function None -> str"" | Some {v=s} -> str "%" ++ str s in
               let pr_if b x = if b then x else str "" in
               let pr_br imp x = match imp with
-                | Impargs.Implicit -> str "[" ++ x ++ str "]"
-                | Impargs.MaximallyImplicit -> str "{" ++ x ++ str "}"
-                | Impargs.NotImplicit -> x in
+                | NonMaxImplicit -> str "[" ++ x ++ str "]"
+                | MaxImplicit -> str "{" ++ x ++ str "}"
+                | Explicit -> x in
               let rec print_arguments n nbidi l =
                 match n, nbidi, l with
                   | Some 0, _, l -> spc () ++ str"/" ++ print_arguments None nbidi l

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -2056,8 +2056,9 @@ let vernac_search ~pstate ~atts s gopt r =
     let pp = if !search_output_name_only
       then pr
       else begin
-        let pc = pr_lconstr_env env Evd.(from_env env) c in
-        hov 2 (pr ++ str":" ++ spc () ++ pc)
+        Prettyp.print_ref false ref None
+        (* let pc = pr_lconstr_env env Evd.(from_env env) c in *)
+        (* hov 2 (pr ++ str":" ++ spc () ++ pc) *)
       end
     in Feedback.msg_notice pp
   in

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1397,7 +1397,7 @@ let vernac_arguments ~section_local reference args more_implicits nargs_for_red 
 
   let implicits = List.map (List.map snd) implicits in
   let implicits_specified = match implicits with
-    | [l] -> List.exists (function Impargs.NotImplicit -> false | _ -> true) l
+    | [l] -> List.exists (function Explicit -> false | _ -> true) l
     | _ -> true in
 
   if implicits_specified && clear_implicits_flag then

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -245,7 +245,7 @@ type vernac_argument_status = {
   name : Name.t;
   recarg_like : bool;
   notation_scope : string CAst.t option;
-  implicit_status : Impargs.implicit_kind;
+  implicit_status : Decl_kinds.binding_kind;
 }
 
 type extend_name =
@@ -359,7 +359,7 @@ type nonrec vernac_expr =
       onlyparsing_flag
   | VernacArguments of qualid or_by_notation *
       vernac_argument_status list (* Main arguments status list *) *
-        (Name.t * Impargs.implicit_kind) list list (* Extra implicit status lists *) *
+        (Name.t * Decl_kinds.binding_kind) list list (* Extra implicit status lists *) *
       int option (* Number of args to trigger reduction *) *
       int option (* Number of args before bidirectional typing *) *
         [ `ReductionDontExposeCase | `ReductionNeverUnfold | `Rename |


### PR DESCRIPTION
This PR is not finished (no doc but it compiles and first examples work). I open it so that it starts being discussed. The PR is two folds:

1. It adds a syntax for non maximal implicit arguments with square brackets `[` `]`. E.g.

```
Definition foo {n} [m] := n + m.
  -> n is maximal and m is not

Inductive vector [A : Type] : nat -> Type := ...
  -> A not maximal
```

2. It change the printing of global references in commands like `About` or `Search`. Now, implicit arguments are printed between brackets (`[` or `{` depending on maximality). E.g. `Search "refl"` outputs:
```
iff_refl : forall A : Prop, A <-> A
identity_refl : forall [A : Type] (a : A), identity a a
eq_refl : forall {A : Type} {x : A}, x = x
eq_trans_refl_l : forall [A : Type] [x y : A] (e : x = y), eq_trans eq_refl e = e
eq_trans_refl_r : forall [A : Type] [x y : A] (e : x = y), eq_trans e eq_refl = e
eq_refl_map_distr :
forall [A B : Type] (x : A) (f : A -> B), f_equal f eq_refl = eq_refl
```
If several choices of implicit arguments have been declared with `Arguments` the one with the maximal number of implicits is chosen. This will be documented in the manual.

Does this road seems correct to you?

**Kind:** feature

<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [ ] Added / updated test-suite
<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [ ] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [ ] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
