### PR TITLE
Dune: run coqc with -w +default

### DIFF
--- a/tools/coq_dune.ml
+++ b/tools/coq_dune.ml
@@ -128,6 +128,7 @@ module Options = struct
   [ { enabled = false; cmd = "-debug"; }
   ; { enabled = false; cmd = "-native_compiler"; }
   ; { enabled = true; cmd = "-allow-sprop"; }
+  ; { enabled = true; cmd = "-w +default"; }
   ]
 
   let build_coq_flags () =


### PR DESCRIPTION
This matches the makefile build with -warn-error.
