### PR TITLE
[lemmas] Move `Stack` out of Lemmas.

### DIFF
--- a/stm/proofBlockDelimiter.ml
+++ b/stm/proofBlockDelimiter.ml
@@ -49,7 +49,7 @@ let is_focused_goal_simple ~doc id =
   match state_of_id ~doc id with
   | `Expired | `Error _ | `Valid None -> `Not
   | `Valid (Some { Vernacstate.lemmas }) ->
-    Option.cata (Lemmas.Stack.with_top_pstate ~f:(fun proof ->
+    Option.cata (Vernacstate.LemmaStack.with_top_pstate ~f:(fun proof ->
         let proof = Proof_global.get_proof proof in
         let Proof.{ goals=focused; stack=r1; shelf=r2; given_up=r3; sigma } = Proof.data proof in
         let rest = List.(flatten (map (fun (x,y) -> x @ y) r1)) @ r2 @ r3 in

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -881,7 +881,7 @@ end = struct (* {{{ *)
   let invalidate_cur_state () = cur_id := Stateid.dummy
 
   type proof_part =
-    Lemmas.Stack.t option *
+    Vernacstate.LemmaStack.t option *
     int *                                   (* Evarutil.meta_counter_summary_tag *)
     int *                                   (* Evd.evar_counter_summary_tag *)
     DeclareObl.program_info CEphemeron.key Names.Id.Map.t (* Obligations.program_tcc_summary_tag *)
@@ -1168,7 +1168,7 @@ end = struct (* {{{ *)
 
   let get_proof ~doc id =
     match state_of_id ~doc id with
-    | `Valid (Some vstate) -> Option.map (Lemmas.Stack.with_top_pstate ~f:Proof_global.get_proof) vstate.Vernacstate.lemmas
+    | `Valid (Some vstate) -> Option.map (Vernacstate.LemmaStack.with_top_pstate ~f:Proof_global.get_proof) vstate.Vernacstate.lemmas
     | _ -> None
 
   let undo_vernac_classifier v ~doc =

--- a/vernac/lemmas.ml
+++ b/vernac/lemmas.ml
@@ -307,41 +307,6 @@ let initialize_named_context_for_proof () =
       let d = if variable_opacity id then NamedDecl.drop_body d else d in
       Environ.push_named_context_val d signv) sign Environ.empty_named_context_val
 
-module Stack = struct
-
-  type lemma = t
-  type nonrec t = t * t list
-
-  let map f (pf, pfl) = (f pf, List.map f pfl)
-
-  let map_top ~f (pf, pfl) = (f pf, pfl)
-  let map_top_pstate ~f (pf, pfl) = (pf_map f pf, pfl)
-
-  let pop (ps, p) = match p with
-    | [] -> ps, None
-    | pp :: p -> ps, Some (pp, p)
-
-  let with_top (p, _) ~f = f p
-  let with_top_pstate (p, _) ~f = f p.proof
-
-  let push ontop a =
-    match ontop with
-    | None -> a , []
-    | Some (l,ls) -> a, (l :: ls)
-
-  let get_all_proof_names (pf : t) =
-    let prj x = Proof_global.get_proof x in
-    let (pn, pns) = map Proof.(function pf -> (data (prj pf.proof)).name) pf in
-    pn :: pns
-
-  let copy_info ~src ~tgt =
-    let (ps, psl), (ts,tsl) = src, tgt in
-    assert(List.length psl = List.length tsl);
-    { ps with proof = ts.proof },
-    List.map2 (fun op p -> { op with proof = p.proof }) psl tsl
-
-end
-
 (* Starting a goal *)
 let start_lemma ~name ~poly
     ?(udecl=UState.default_univ_decl)

--- a/vernac/lemmas.mli
+++ b/vernac/lemmas.mli
@@ -17,30 +17,11 @@ type t
 (** [Lemmas.t] represents a constant that is being proved, usually
     interactively *)
 
-module Stack : sig
-
-  type lemma = t
-  type t
-
-  val pop : t -> lemma * t option
-  val push : t option -> lemma -> t
-
-  val map_top : f:(lemma -> lemma) -> t -> t
-  val map_top_pstate : f:(Proof_global.t -> Proof_global.t) -> t -> t
-
-  val with_top : t -> f:(lemma -> 'a ) -> 'a
-  val with_top_pstate : t -> f:(Proof_global.t -> 'a ) -> 'a
-
-  val get_all_proof_names : t -> Names.Id.t list
-
-  val copy_info : src:t -> tgt:t -> t
-  (** Gets the current info without checking that the proof has been
-     completed. Useful for the likes of [Admitted]. *)
-
-end
-
 val set_endline_tactic : Genarg.glob_generic_argument -> t -> t
+
 val pf_map : (Proof_global.t -> Proof_global.t) -> t -> t
+(** [pf_map f l] map the underlying proof object *)
+
 val pf_fold : (Proof_global.t -> 'a) -> t -> 'a
 (** [pf_fold f l] fold over the underlying proof object *)
 

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -55,7 +55,7 @@ let vernac_require_open_lemma ~stack f =
 
 let with_pstate ~stack f =
   vernac_require_open_lemma ~stack
-    (fun ~stack -> Stack.with_top_pstate stack ~f:(fun pstate -> f ~pstate))
+    (fun ~stack -> Vernacstate.LemmaStack.with_top_pstate stack ~f:(fun pstate -> f ~pstate))
 
 let get_current_or_global_context ~pstate =
   match pstate with
@@ -645,14 +645,14 @@ let vernac_start_proof ~atts kind l =
 let vernac_end_proof ?stack ?proof = let open Vernacexpr in function
   | Admitted ->
     vernac_require_open_lemma ~stack (fun ~stack ->
-      let lemma, stack = Stack.pop stack in
+      let lemma, stack = Vernacstate.LemmaStack.pop stack in
       save_lemma_admitted ?proof ~lemma;
       stack)
   | Proved (opaque,idopt) ->
     let lemma, stack = match stack with
       | None -> None, None
       | Some stack ->
-        let lemma, stack = Stack.pop stack in
+        let lemma, stack = Vernacstate.LemmaStack.pop stack in
         Some lemma, stack
     in
     save_lemma_proved ?lemma ?proof ~opaque ~idopt;
@@ -2341,15 +2341,15 @@ let interp_typed_vernac c ~stack =
     stack
   | VtCloseProof f ->
     vernac_require_open_lemma ~stack (fun ~stack ->
-        let lemma, stack = Stack.pop stack in
+        let lemma, stack = Vernacstate.LemmaStack.pop stack in
         f ~lemma;
         stack)
   | VtOpenProof f ->
-    Some (Stack.push stack (f ()))
+    Some (Vernacstate.LemmaStack.push stack (f ()))
   | VtModifyProof f ->
-    Option.map (Stack.map_top_pstate ~f:(fun pstate -> f ~pstate)) stack
+    Option.map (Vernacstate.LemmaStack.map_top_pstate ~f:(fun pstate -> f ~pstate)) stack
   | VtReadProofOpt f ->
-    let pstate = Option.map (Stack.with_top_pstate ~f:(fun x -> x)) stack in
+    let pstate = Option.map (Vernacstate.LemmaStack.with_top_pstate ~f:(fun x -> x)) stack in
     f ~pstate;
     stack
   | VtReadProof f ->

--- a/vernac/vernacstate.mli
+++ b/vernac/vernacstate.mli
@@ -18,11 +18,27 @@ module Parser : sig
 
 end
 
+module LemmaStack : sig
+
+  type t
+
+  val pop : t -> Lemmas.t * t option
+  val push : t option -> Lemmas.t -> t
+
+  val map_top_pstate : f:(Proof_global.t -> Proof_global.t) -> t -> t
+  val with_top_pstate : t -> f:(Proof_global.t -> 'a ) -> 'a
+
+end
+
 type t =
   { parsing : Parser.state
-  ; system  : States.state          (* summary + libstack *)
-  ; lemmas  : Lemmas.Stack.t option (* proofs of lemmas currently opened *)
-  ; shallow : bool                  (* is the state trimmed down (libstack) *)
+  (** parsing state [parsing state may not behave 100% functionally yet, beware] *)
+  ; system  : States.state
+  (** summary + libstack *)
+  ; lemmas  : LemmaStack.t option
+  (** proofs of lemmas currently opened *)
+  ; shallow : bool
+  (** is the state trimmed down (libstack) *)
   }
 
 val freeze_interp_state : marshallable:bool -> t
@@ -67,19 +83,16 @@ module Proof_global : sig
 
   val get_all_proof_names : unit -> Names.Id.t list
 
-  val copy_terminators : src:Lemmas.Stack.t option -> tgt:Lemmas.Stack.t option -> Lemmas.Stack.t option
-
-  (* Handling of the imperative state *)
-  type t = Lemmas.Stack.t
+  val copy_terminators : src:LemmaStack.t option -> tgt:LemmaStack.t option -> LemmaStack.t option
 
   (* Low-level stuff *)
-  val get : unit -> t option
-  val set : t option -> unit
+  val get : unit -> LemmaStack.t option
+  val set : LemmaStack.t option -> unit
 
   val get_pstate : unit -> Proof_global.t option
 
-  val freeze : marshallable:bool -> t option
-  val unfreeze : t -> unit
+  val freeze : marshallable:bool -> LemmaStack.t option
+  val unfreeze : LemmaStack.t -> unit
 
 end
 [@@ocaml.deprecated "This module is internal and should not be used, instead, thread the proof state"]


### PR DESCRIPTION
We move the stack of open lemmas from `Lemmas` to `Vernacstate`. The
`Lemmas` module doesn't deal with stacked proofs, so the stack can be
moved to to the proper place; this reduces the size of the API.

Note that `Lemmas` API is still quite imperative, it would be great if
we would return some more information on close proof, for example
about the global environment parts that were modified.
