### PR TITLE
[rfc] [draft] Moving global to the upper layers

### DIFF
--- a/engine/engine.mllib
+++ b/engine/engine.mllib
@@ -1,4 +1,5 @@
 UnivNames
+Global
 UnivGen
 UnivSubst
 UnivProblem

--- a/engine/global.ml
+++ b/engine/global.ml
@@ -201,10 +201,10 @@ let is_type_in_type r = is_type_in_type (env ()) r
 let current_modpath () =
   Safe_typing.current_modpath (safe_env ())
 
-let current_dirpath () = 
+let current_dirpath () =
   Safe_typing.current_dirpath (safe_env ())
 
-let with_global f = 
+let with_global f =
   let (a, ctx) = f (env ()) (current_dirpath ()) in
     push_context_set false ctx; a
 

--- a/engine/global.mli
+++ b/engine/global.mli
@@ -105,7 +105,7 @@ val lookup_named     : variable -> Constr.named_declaration
 val lookup_constant  : Constant.t -> Opaqueproof.opaque Declarations.constant_body
 val lookup_inductive : inductive ->
   Declarations.mutual_inductive_body * Declarations.one_inductive_body
-val lookup_pinductive : Constr.pinductive -> 
+val lookup_pinductive : Constr.pinductive ->
   Declarations.mutual_inductive_body * Declarations.one_inductive_body
 val lookup_mind      : MutInd.t -> Declarations.mutual_inductive_body
 val lookup_module    : ModPath.t -> Declarations.module_body

--- a/library/library.mllib
+++ b/library/library.mllib
@@ -3,9 +3,7 @@ Globnames
 Libobject
 Summary
 Nametab
-Global
 Lib
 States
 Kindops
 Goptions
-Coqlib

--- a/pretyping/coqlib.ml
+++ b/pretyping/coqlib.ml
@@ -89,15 +89,15 @@ let gen_reference_in_modules locstr dirs s =
   match these with
     | [x] -> x
     | [] ->
-	anomaly ~label:locstr (str "cannot find " ++ str s ++
-	str " in module" ++ str (if List.length dirs > 1 then "s " else " ") ++
+        anomaly ~label:locstr (str "cannot find " ++ str s ++
+        str " in module" ++ str (if List.length dirs > 1 then "s " else " ") ++
         prlist_with_sep pr_comma DirPath.print dirs ++ str ".")
     | l ->
       anomaly ~label:locstr
-	(str "ambiguous name " ++ str s ++ str " can represent " ++
-	   prlist_with_sep pr_comma
-	   (fun x -> Libnames.pr_path (Nametab.path_of_global x)) l ++
-	   str " in module" ++ str (if List.length dirs > 1 then "s " else " ") ++
+        (str "ambiguous name " ++ str s ++ str " can represent " ++
+           prlist_with_sep pr_comma
+           (fun x -> Libnames.pr_path (Nametab.path_of_global x)) l ++
+           str " in module" ++ str (if List.length dirs > 1 then "s " else " ") ++
            prlist_with_sep pr_comma DirPath.print dirs ++ str ".")
 
 (* For tactics/commands requiring vernacular libraries *)

--- a/pretyping/coqlib.mli
+++ b/pretyping/coqlib.mli
@@ -210,9 +210,9 @@ val build_coq_f_equal2 : GlobRef.t delayed
 type coq_inversion_data = {
   inv_eq   : GlobRef.t; (** : forall params, args -> Prop *)
   inv_ind  : GlobRef.t; (** : forall params P (H : P params) args, eq params args
-			 ->  P args *)
+                         ->  P args *)
   inv_congr: GlobRef.t  (** : forall params B (f:t->B) args, eq params args ->
-			 f params = f args *)
+                         f params = f args *)
 }
 
 val build_coq_inversion_eq_data : coq_inversion_data delayed

--- a/pretyping/pretyping.mllib
+++ b/pretyping/pretyping.mllib
@@ -14,6 +14,7 @@ Evardefine
 Evarsolve
 Recordops
 Heads
+Coqlib
 Evarconv
 Typing
 Miscops


### PR DESCRIPTION
This PR is a sketch on an idea we have discussed a few times, and proposed in this form by @maximedenes , namely, moving global to the upper layers. #9917 was a first try, but now I have gone beyond and built this sketch, that while not finished, should be merge-able with some more effort if we want.

After the experiments I am now convinced that we could push `Global` to the `pretyping` layer or even to the `interp / proofs / tactics` layer without too much effort. `interp` does look scary, and `tactics` too.

The real challenge anyways is `vernac`, would we reach there we could start migrating things out of the global env for real.

So what do you think folks? Should we finish this PR and try to cleanup `engine / pretyping` after?

Things to fix if we want to merge [all easy]:
- printers
- coqlib
- read state from disk