### PR TITLE
[rfc] [engine] Remove dependency on `Global` for univgen

### DIFF
--- a/doc/plugin_tutorial/tuto3/src/construction_game.ml
+++ b/doc/plugin_tutorial/tuto3/src/construction_game.ml
@@ -7,7 +7,8 @@ let example_sort sigma =
 (* creating a new sort requires that universes should be recorded
   in the evd datastructure, so this datastructure also needs to be
   passed around. *)
-  let sigma, s = Evd.new_sort_variable Evd.univ_rigid sigma in
+  let dp = Global.current_dirpath () in
+  let sigma, s = Evd.new_sort_variable dp Evd.univ_rigid sigma in
   let new_type = EConstr.mkSort s in
   sigma, new_type
 
@@ -19,8 +20,9 @@ let c_one sigma =
 (* the long name of "S" was found with the command "About S." *)
   let gr_O =
     find_reference "Tuto3" ["Coq"; "Init"; "Datatypes"] "O" in
-  let sigma, c_O = Evarutil.new_global sigma gr_O in
-  let sigma, c_S = Evarutil.new_global sigma gr_S in
+  let dp = Global.current_dirpath () in
+  let sigma, c_O = Evarutil.new_global dp sigma gr_O in
+  let sigma, c_S = Evarutil.new_global dp sigma gr_S in
 (* Here is the construction of a new term by applying functions to argument. *)
   sigma, EConstr.mkApp (c_S, [| c_O |])
 
@@ -39,8 +41,9 @@ let dangling_identity env sigma =
 let dangling_identity2 env sigma =
 (* This example uses directly a function that produces an evar that
   is meant to be a type. *)
+  let dp = Global.current_dirpath () in
   let sigma, (arg_type, type_type) =
-    Evarutil.new_type_evar env sigma Evd.univ_rigid in
+    Evarutil.new_type_evar dp env sigma Evd.univ_rigid in
   sigma, EConstr.mkLambda(nameR (Names.Id.of_string "x"), arg_type,
           EConstr.mkRel 1)
 
@@ -67,43 +70,53 @@ let example_sort_app_lambda () =
 
 let c_S sigma =
   let gr = find_reference "Tuto3" ["Coq"; "Init"; "Datatypes"] "S" in
-  Evarutil.new_global sigma gr
+  let dp = Global.current_dirpath () in
+  Evarutil.new_global dp sigma gr
 
 let c_O sigma =
   let gr = find_reference "Tuto3" ["Coq"; "Init"; "Datatypes"] "O" in
-  Evarutil.new_global sigma gr
+  let dp = Global.current_dirpath () in
+  Evarutil.new_global dp sigma gr
 
 let c_E sigma =
   let gr = find_reference "Tuto3" ["Tuto3"; "Data"] "EvenNat" in
-  Evarutil.new_global sigma gr
+  let dp = Global.current_dirpath () in
+  Evarutil.new_global dp sigma gr
 
 let c_D sigma =
   let gr = find_reference "Tuto3" ["Tuto3"; "Data"] "tuto_div2" in
-  Evarutil.new_global sigma gr
+  let dp = Global.current_dirpath () in
+  Evarutil.new_global dp sigma gr
 
 let c_Q sigma =
   let gr = find_reference "Tuto3" ["Coq"; "Init"; "Logic"] "eq" in
-  Evarutil.new_global sigma gr
+  let dp = Global.current_dirpath () in
+  Evarutil.new_global dp sigma gr
 
 let c_R sigma =
   let gr = find_reference "Tuto3" ["Coq"; "Init"; "Logic"] "eq_refl" in
-  Evarutil.new_global sigma gr
+  let dp = Global.current_dirpath () in
+  Evarutil.new_global dp sigma gr
 
 let c_N sigma =
   let gr = find_reference "Tuto3" ["Coq"; "Init"; "Datatypes"] "nat" in
-  Evarutil.new_global sigma gr
+  let dp = Global.current_dirpath () in
+  Evarutil.new_global dp sigma gr
 
 let c_C sigma =
   let gr = find_reference "Tuto3" ["Tuto3"; "Data"] "C" in
-  Evarutil.new_global sigma gr
+  let dp = Global.current_dirpath () in
+  Evarutil.new_global dp sigma gr
 
 let c_F sigma =
   let gr = find_reference "Tuto3" ["Tuto3"; "Data"] "S_ev" in
-  Evarutil.new_global sigma gr
+  let dp = Global.current_dirpath () in
+  Evarutil.new_global dp sigma gr
 
 let c_P sigma =
   let gr = find_reference "Tuto3" ["Tuto3"; "Data"] "s_half_proof" in
-  Evarutil.new_global sigma gr
+  let dp = Global.current_dirpath () in
+  Evarutil.new_global dp sigma gr
 
 (* If c_S was universe polymorphic, we should have created a new constant
    at each iteration of buildup. *)

--- a/doc/plugin_tutorial/tuto3/src/construction_game.ml
+++ b/doc/plugin_tutorial/tuto3/src/construction_game.ml
@@ -12,7 +12,7 @@ let example_sort sigma =
   let new_type = EConstr.mkSort s in
   sigma, new_type
 
-let c_one sigma =
+let c_one env sigma =
 (* In the general case, global references may refer to universe polymorphic
    objects, and their universe has to be made afresh when creating an instance. *)
   let gr_S =
@@ -21,8 +21,8 @@ let c_one sigma =
   let gr_O =
     find_reference "Tuto3" ["Coq"; "Init"; "Datatypes"] "O" in
   let dp = Global.current_dirpath () in
-  let sigma, c_O = Evarutil.new_global dp sigma gr_O in
-  let sigma, c_S = Evarutil.new_global dp sigma gr_S in
+  let sigma, c_O = Evarutil.new_global dp env sigma gr_O in
+  let sigma, c_S = Evarutil.new_global dp env sigma gr_S in
 (* Here is the construction of a new term by applying functions to argument. *)
   sigma, EConstr.mkApp (c_S, [| c_O |])
 
@@ -50,7 +50,7 @@ let dangling_identity2 env sigma =
 let example_sort_app_lambda () =
     let env = Global.env () in
     let sigma = Evd.from_env env in
-    let sigma, c_v = c_one sigma in
+    let sigma, c_v = c_one env sigma in
 (* dangling_identity and dangling_identity2 can be used interchangeably here *)
     let sigma, c_f = dangling_identity2 env sigma in
     let c_1 = EConstr.mkApp (c_f, [| c_v |]) in
@@ -68,61 +68,61 @@ let example_sort_app_lambda () =
        (Printer.pr_econstr_env env sigma the_type))
 
 
-let c_S sigma =
+let c_S env sigma =
   let gr = find_reference "Tuto3" ["Coq"; "Init"; "Datatypes"] "S" in
   let dp = Global.current_dirpath () in
-  Evarutil.new_global dp sigma gr
+  Evarutil.new_global dp env sigma gr
 
-let c_O sigma =
+let c_O env sigma =
   let gr = find_reference "Tuto3" ["Coq"; "Init"; "Datatypes"] "O" in
   let dp = Global.current_dirpath () in
-  Evarutil.new_global dp sigma gr
+  Evarutil.new_global dp env sigma gr
 
-let c_E sigma =
+let c_E env sigma =
   let gr = find_reference "Tuto3" ["Tuto3"; "Data"] "EvenNat" in
   let dp = Global.current_dirpath () in
-  Evarutil.new_global dp sigma gr
+  Evarutil.new_global dp env sigma gr
 
-let c_D sigma =
+let c_D env sigma =
   let gr = find_reference "Tuto3" ["Tuto3"; "Data"] "tuto_div2" in
   let dp = Global.current_dirpath () in
-  Evarutil.new_global dp sigma gr
+  Evarutil.new_global dp env sigma gr
 
-let c_Q sigma =
+let c_Q env sigma =
   let gr = find_reference "Tuto3" ["Coq"; "Init"; "Logic"] "eq" in
   let dp = Global.current_dirpath () in
-  Evarutil.new_global dp sigma gr
+  Evarutil.new_global dp env sigma gr
 
-let c_R sigma =
+let c_R env sigma =
   let gr = find_reference "Tuto3" ["Coq"; "Init"; "Logic"] "eq_refl" in
   let dp = Global.current_dirpath () in
-  Evarutil.new_global dp sigma gr
+  Evarutil.new_global dp env sigma gr
 
-let c_N sigma =
+let c_N env sigma =
   let gr = find_reference "Tuto3" ["Coq"; "Init"; "Datatypes"] "nat" in
   let dp = Global.current_dirpath () in
-  Evarutil.new_global dp sigma gr
+  Evarutil.new_global dp env sigma gr
 
-let c_C sigma =
+let c_C env sigma =
   let gr = find_reference "Tuto3" ["Tuto3"; "Data"] "C" in
   let dp = Global.current_dirpath () in
-  Evarutil.new_global dp sigma gr
+  Evarutil.new_global dp env sigma gr
 
-let c_F sigma =
+let c_F env sigma =
   let gr = find_reference "Tuto3" ["Tuto3"; "Data"] "S_ev" in
   let dp = Global.current_dirpath () in
-  Evarutil.new_global dp sigma gr
+  Evarutil.new_global dp env sigma gr
 
-let c_P sigma =
+let c_P env sigma =
   let gr = find_reference "Tuto3" ["Tuto3"; "Data"] "s_half_proof" in
   let dp = Global.current_dirpath () in
-  Evarutil.new_global dp sigma gr
+  Evarutil.new_global dp env sigma gr
 
 (* If c_S was universe polymorphic, we should have created a new constant
    at each iteration of buildup. *)
-let mk_nat sigma n =
-  let sigma, c_S = c_S sigma in
-  let sigma, c_O = c_O sigma in
+let mk_nat env sigma n =
+  let sigma, c_S = c_S env sigma in
+  let sigma, c_O = c_O env sigma in
   let rec buildup = function
     | 0 -> c_O
     | n -> EConstr.mkApp (c_S, [| buildup (n - 1) |]) in
@@ -131,13 +131,13 @@ let mk_nat sigma n =
 let example_classes n =
   let env = Global.env () in
   let sigma = Evd.from_env env in
-  let sigma, c_n = mk_nat sigma n in
-  let sigma, n_half = mk_nat sigma (n / 2) in
-  let sigma, c_N = c_N sigma in
-  let sigma, c_div = c_D sigma in
-  let sigma, c_even = c_E sigma in
-  let sigma, c_Q = c_Q sigma in
-  let sigma, c_R = c_R sigma in
+  let sigma, c_n = mk_nat env sigma n in
+  let sigma, n_half = mk_nat env sigma (n / 2) in
+  let sigma, c_N = c_N env sigma in
+  let sigma, c_div = c_D env sigma in
+  let sigma, c_even = c_E env sigma in
+  let sigma, c_Q = c_Q env sigma in
+  let sigma, c_R = c_R env sigma in
   let arg_type = EConstr.mkApp (c_even, [| c_n |]) in
   let sigma0 = sigma in
   let sigma, instance = Evarutil.new_evar env sigma arg_type in
@@ -167,13 +167,13 @@ let example_canonical n =
   let env = Global.env () in
   let sigma = Evd.from_env env in
 (* Construct a natural representation of this integer. *)
-  let sigma, c_n = mk_nat sigma n in
+  let sigma, c_n = mk_nat env sigma n in
 (* terms for "nat", "eq", "S_ev", "eq_refl", "C" *)
-  let sigma, c_N = c_N sigma in
-  let sigma, c_F = c_F sigma in
-  let sigma, c_R = c_R sigma in
-  let sigma, c_C = c_C sigma in
-  let sigma, c_P = c_P sigma in
+  let sigma, c_N = c_N env sigma in
+  let sigma, c_F = c_F env sigma in
+  let sigma, c_R = c_R env sigma in
+  let sigma, c_C = c_C env sigma in
+  let sigma, c_P = c_P env sigma in
 (* the last argument of C *)
   let refl_term = EConstr.mkApp (c_R, [|c_N; c_n |]) in
 (* Now we build two existential variables, for the value of the half and for

--- a/doc/plugin_tutorial/tuto3/src/g_tuto3.mlg
+++ b/doc/plugin_tutorial/tuto3/src/g_tuto3.mlg
@@ -15,7 +15,8 @@ VERNAC COMMAND EXTEND ShowTypeConstruction CLASSIFIED AS QUERY
 | [ "Tuto3_1" ] ->
   { let env = Global.env () in
     let sigma = Evd.from_env env in
-    let sigma, s = Evd.new_sort_variable Evd.univ_rigid sigma in
+    let dp = Global.current_dirpath () in
+    let sigma, s = Evd.new_sort_variable dp Evd.univ_rigid sigma in
     let new_type_2 = EConstr.mkSort s in
     let sigma, _ =
       Typing.type_of (Global.env()) (Evd.from_env (Global.env())) new_type_2 in

--- a/doc/plugin_tutorial/tuto3/src/tuto_tactic.ml
+++ b/doc/plugin_tutorial/tuto3/src/tuto_tactic.ml
@@ -15,7 +15,8 @@ let collect_constants () =
     let gr_R = find_reference "Tuto3" ["Coq"; "Init"; "Datatypes"] "pair" in
     let gr_P = find_reference "Tuto3" ["Coq"; "Init"; "Datatypes"] "prod" in
     let gr_U = find_reference "Tuto3" ["Tuto3"; "Data"] "uncover" in
-    constants := List.map (fun x -> of_constr (constr_of_monomorphic_global x))
+    let dp = Global.current_dirpath () in
+    constants := List.map (fun x -> of_constr (constr_of_monomorphic_global dp x))
       [gr_H; gr_M; gr_R; gr_P; gr_U];
     !constants
   else

--- a/doc/plugin_tutorial/tuto3/src/tuto_tactic.ml
+++ b/doc/plugin_tutorial/tuto3/src/tuto_tactic.ml
@@ -16,7 +16,7 @@ let collect_constants () =
     let gr_P = find_reference "Tuto3" ["Coq"; "Init"; "Datatypes"] "prod" in
     let gr_U = find_reference "Tuto3" ["Tuto3"; "Data"] "uncover" in
     let dp = Global.current_dirpath () in
-    constants := List.map (fun x -> of_constr (constr_of_monomorphic_global dp x))
+    constants := List.map (fun x -> of_constr (constr_of_monomorphic_global dp (Global.env ()) x))
       [gr_H; gr_M; gr_R; gr_P; gr_U];
     !constants
   else

--- a/engine/eConstr.ml
+++ b/engine/eConstr.ml
@@ -718,8 +718,8 @@ let map_rel_context_in_env f env sign =
   in
   aux env [] (List.rev sign)
 
-let fresh_global ?loc ?rigid ?names env sigma reference =
-  let (evd,t) = Evd.fresh_global ?loc ?rigid ?names env sigma reference in
+let fresh_global ?loc ?rigid ?names dp env sigma reference =
+  let (evd,t) = Evd.fresh_global ?loc ?rigid ?names dp env sigma reference in
   evd, t
 
 let is_global sigma gr c =

--- a/engine/eConstr.mli
+++ b/engine/eConstr.mli
@@ -314,7 +314,7 @@ val map_rel_context_in_env :
 
 (* XXX Missing Sigma proxy *)
 val fresh_global :
-  ?loc:Loc.t -> ?rigid:Evd.rigid -> ?names:Univ.Instance.t -> Environ.env ->
+  ?loc:Loc.t -> ?rigid:Evd.rigid -> ?names:Univ.Instance.t -> DirPath.t -> Environ.env ->
   Evd.evar_map -> GlobRef.t -> Evd.evar_map * t
 
 val is_global : Evd.evar_map -> GlobRef.t -> t -> bool

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -26,8 +26,8 @@ let safe_evar_value sigma ev =
   try Some (EConstr.Unsafe.to_constr @@ Evd.existential_value sigma ev)
   with NotInstantiatedEvar | Not_found -> None
 
-let new_global evd x =
-  let (evd, c) = Evd.fresh_global (Global.env()) evd x in
+let new_global dp evd x =
+  let (evd, c) = Evd.fresh_global dp (Global.env()) evd x in
   (evd, c)
 
 (****************************************************)
@@ -467,14 +467,14 @@ let new_evar ?src ?filter ?abstract_arguments ?candidates ?naming ?typeclass_can
   new_evar_instance sign evd typ' ?src ?filter ?abstract_arguments ?candidates ?naming
     ?typeclass_candidate ?principal instance
 
-let new_type_evar ?src ?filter ?naming ?principal ?hypnaming env evd rigid =
-  let (evd', s) = new_sort_variable rigid evd in
+let new_type_evar ?src ?filter ?naming ?principal ?hypnaming dp env evd rigid =
+  let (evd', s) = new_sort_variable dp rigid evd in
   let (evd', e) = new_evar env evd' ?src ?filter ?naming ~typeclass_candidate:false ?principal ?hypnaming (EConstr.mkSort s) in
   evd', (e, s)
 
-let new_Type ?(rigid=Evd.univ_flexible) evd =
+let new_Type ?(rigid=Evd.univ_flexible) dp evd =
   let open EConstr in
-  let (evd, s) = new_sort_variable rigid evd in
+  let (evd, s) = new_sort_variable dp rigid evd in
   (evd, mkSort s)
 
 (* Safe interface to unification problems *)
@@ -817,9 +817,9 @@ let occur_evar_upto sigma n c =
 (* We don't try to guess in which sort the type should be defined, since
    any type has type Type. May cause some trouble, but not so far... *)
 
-let judge_of_new_Type evd =
+let judge_of_new_Type dp evd =
   let open EConstr in
-  let (evd', s) = new_univ_variable univ_rigid evd in
+  let (evd', s) = new_univ_variable dp univ_rigid evd in
   (evd', { uj_val = mkType s; uj_type = mkType (Univ.super s) })
 
 let subterm_source evk ?where (loc,k) =

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -26,8 +26,8 @@ let safe_evar_value sigma ev =
   try Some (EConstr.Unsafe.to_constr @@ Evd.existential_value sigma ev)
   with NotInstantiatedEvar | Not_found -> None
 
-let new_global dp evd x =
-  let (evd, c) = Evd.fresh_global dp (Global.env()) evd x in
+let new_global dp env evd x =
+  let (evd, c) = Evd.fresh_global dp env evd x in
   (evd, c)
 
 (****************************************************)

--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -71,7 +71,7 @@ val new_Type : ?rigid:rigid -> DirPath.t -> evar_map -> evar_map * constr
 
 (** Polymorphic constants *)
 
-val new_global : DirPath.t -> evar_map -> GlobRef.t -> evar_map * constr
+val new_global : DirPath.t -> env -> evar_map -> GlobRef.t -> evar_map * constr
 
 (** Create a fresh evar in a context different from its definition context:
    [new_evar_instance sign evd ty inst] creates a new evar of context

--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -64,14 +64,14 @@ val new_type_evar :
   ?src:Evar_kinds.t Loc.located -> ?filter:Filter.t ->
   ?naming:intro_pattern_naming_expr ->
   ?principal:bool -> ?hypnaming:naming_mode ->
-  env -> evar_map -> rigid ->
+  DirPath.t -> env -> evar_map -> rigid ->
   evar_map * (constr * Sorts.t)
 
-val new_Type : ?rigid:rigid -> evar_map -> evar_map * constr
+val new_Type : ?rigid:rigid -> DirPath.t -> evar_map -> evar_map * constr
 
 (** Polymorphic constants *)
 
-val new_global : evar_map -> GlobRef.t -> evar_map * constr
+val new_global : DirPath.t -> evar_map -> GlobRef.t -> evar_map * constr
 
 (** Create a fresh evar in a context different from its definition context:
    [new_evar_instance sign evd ty inst] creates a new evar of context
@@ -150,7 +150,7 @@ val occur_evar_upto : evar_map -> Evar.t -> constr -> bool
 
 (** {6 Value/Type constraints} *)
 
-val judge_of_new_Type : evar_map -> evar_map * unsafe_judgment
+val judge_of_new_Type : DirPath.t -> evar_map -> evar_map * unsafe_judgment
 
 (***********************************************************)
 

--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -266,7 +266,7 @@ type ext_named_context =
   csubst * Id.Set.t * named_context
 
 val push_rel_decl_to_named_context : ?hypnaming:naming_mode ->
-  evar_map -> rel_declaration -> ext_named_context -> ext_named_context
+  env -> evar_map -> rel_declaration -> ext_named_context -> ext_named_context
 
 val push_rel_context_to_named_context : ?hypnaming:naming_mode ->
   Environ.env -> evar_map -> types ->

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -859,16 +859,16 @@ let merge_universe_subst evd subst =
 let with_context_set ?loc rigid d (a, ctx) =
   (merge_context_set ?loc rigid d ctx, a)
 
-let new_univ_level_variable ?loc ?name rigid evd =
-  let uctx', u = UState.new_univ_variable ?loc rigid name evd.universes in
+let new_univ_level_variable ?loc ?name dp rigid evd =
+  let uctx', u = UState.new_univ_variable ?loc dp rigid name evd.universes in
     ({evd with universes = uctx'}, u)
 
-let new_univ_variable ?loc ?name rigid evd =
-  let uctx', u = UState.new_univ_variable ?loc rigid name evd.universes in
+let new_univ_variable ?loc ?name dp rigid evd =
+  let uctx', u = UState.new_univ_variable ?loc dp rigid name evd.universes in
     ({evd with universes = uctx'}, Univ.Universe.make u)
 
-let new_sort_variable ?loc ?name rigid d =
-  let (d', u) = new_univ_variable ?loc rigid ?name d in
+let new_sort_variable ?loc ?name dp rigid d =
+  let (d', u) = new_univ_variable ?loc dp rigid ?name d in
     (d', Sorts.sort_of_univ u)
 
 let add_global_univ d u =
@@ -885,20 +885,20 @@ let make_nonalgebraic_variable evd u =
 (* Operations on constants              *)
 (****************************************)
 
-let fresh_sort_in_family ?loc ?(rigid=univ_flexible) evd s =
-  with_context_set ?loc rigid evd (UnivGen.fresh_sort_in_family s)
+let fresh_sort_in_family ?loc ?(rigid=univ_flexible) dp evd s =
+  with_context_set ?loc rigid evd (UnivGen.fresh_sort_in_family dp s)
 
-let fresh_constant_instance ?loc env evd c =
-  with_context_set ?loc univ_flexible evd (UnivGen.fresh_constant_instance env c)
+let fresh_constant_instance ?loc dp env evd c =
+  with_context_set ?loc univ_flexible evd (UnivGen.fresh_constant_instance dp env c)
 
-let fresh_inductive_instance ?loc env evd i =
-  with_context_set ?loc univ_flexible evd (UnivGen.fresh_inductive_instance env i)
+let fresh_inductive_instance ?loc dp env evd i =
+  with_context_set ?loc univ_flexible evd (UnivGen.fresh_inductive_instance dp env i)
 
-let fresh_constructor_instance ?loc env evd c =
-  with_context_set ?loc univ_flexible evd (UnivGen.fresh_constructor_instance env c)
+let fresh_constructor_instance ?loc dp env evd c =
+  with_context_set ?loc univ_flexible evd (UnivGen.fresh_constructor_instance dp env c)
 
-let fresh_global ?loc ?(rigid=univ_flexible) ?names env evd gr =
-  with_context_set ?loc rigid evd (UnivGen.fresh_global_instance ?loc ?names env gr)
+let fresh_global ?loc ?(rigid=univ_flexible) ?names dp env evd gr =
+  with_context_set ?loc rigid evd (UnivGen.fresh_global_instance ?loc ?names dp env gr)
 
 let is_sort_variable evd s = UState.is_sort_variable evd.universes s
 
@@ -969,7 +969,7 @@ let set_leq_sort env evd s1 s2 =
      if not (type_in_type env) then
        add_universe_constraints evd (UnivProblem.Set.singleton (UnivProblem.ULe (u1,u2)))
      else evd
-	    
+
 let check_eq evd s s' =
   UGraph.check_eq (UState.ugraph evd.universes) s s'
 
@@ -982,10 +982,10 @@ let check_constraints evd csts =
 let fix_undefined_variables evd =
   { evd with universes = UState.fix_undefined_variables evd.universes }
 
-let refresh_undefined_universes evd =
-  let uctx', subst = UState.refresh_undefined_univ_variables evd.universes in
+let refresh_undefined_universes dp evd =
+  let uctx', subst = UState.refresh_undefined_univ_variables dp evd.universes in
   let evd' = cmap (subst_univs_level_constr subst) {evd with universes = uctx'} in
-    evd', subst
+  evd', subst
 
 let nf_univ_variables evd =
   let subst, uctx' = UState.normalize_variables evd.universes in

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -200,13 +200,14 @@ let evar_filtered_hyps evi = match Filter.repr (evar_filter evi) with
   in
   make_hyps filter (evar_context evi)
 
-let evar_env evi = Global.env_of_context evi.evar_hyps
+let evar_env env evi =
+  reset_with_named_context evi.evar_hyps env
 
-let evar_filtered_env evi = match Filter.repr (evar_filter evi) with
-| None -> evar_env evi
+let evar_filtered_env env evi = match Filter.repr (evar_filter evi) with
+| None -> evar_env env evi
 | Some filter ->
   let rec make_env filter ctxt = match filter, ctxt with
-  | [], [] -> reset_context (Global.env ())
+  | [], [] -> reset_context env
   | false :: filter, _ :: ctxt -> make_env filter ctxt
   | true :: filter, decl :: ctxt ->
     let env = make_env filter ctxt in

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -125,8 +125,8 @@ val evar_filtered_hyps : evar_info -> named_context_val
 val evar_body : evar_info -> evar_body
 val evar_candidates : evar_info -> constr list option
 val evar_filter : evar_info -> Filter.t
-val evar_env :  evar_info -> env
-val evar_filtered_env :  evar_info -> env
+val evar_env :  env -> evar_info -> env
+val evar_filtered_env : env -> evar_info -> env
 
 val map_evar_body : (econstr -> econstr) -> evar_body -> evar_body
 val map_evar_info : (econstr -> econstr) -> evar_info -> evar_info

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -567,9 +567,9 @@ val universe_of_name : evar_map -> Id.t -> Univ.Level.t
 
 val universe_binders : evar_map -> UnivNames.universe_binders
 
-val new_univ_level_variable : ?loc:Loc.t -> ?name:Id.t -> rigid -> evar_map -> evar_map * Univ.Level.t
-val new_univ_variable : ?loc:Loc.t -> ?name:Id.t -> rigid -> evar_map -> evar_map * Univ.Universe.t
-val new_sort_variable : ?loc:Loc.t -> ?name:Id.t -> rigid -> evar_map -> evar_map * Sorts.t
+val new_univ_level_variable : ?loc:Loc.t -> ?name:Id.t -> DirPath.t -> rigid -> evar_map -> evar_map * Univ.Level.t
+val new_univ_variable : ?loc:Loc.t -> ?name:Id.t -> DirPath.t -> rigid -> evar_map -> evar_map * Univ.Universe.t
+val new_sort_variable : ?loc:Loc.t -> ?name:Id.t -> DirPath.t -> rigid -> evar_map -> evar_map * Sorts.t
 
 val add_global_univ : evar_map -> Univ.Level.t -> evar_map
 
@@ -628,7 +628,7 @@ val nf_univ_variables : evar_map -> evar_map * Univ.universe_subst
 
 val fix_undefined_variables : evar_map -> evar_map
 
-val refresh_undefined_universes : evar_map -> evar_map * Univ.universe_level_subst
+val refresh_undefined_universes : DirPath.t -> evar_map -> evar_map * Univ.universe_level_subst
 
 (** Universe minimization *)
 val minimize_universes : evar_map -> evar_map
@@ -637,12 +637,12 @@ val update_sigma_env : evar_map -> env -> evar_map
 
 (** Polymorphic universes *)
 
-val fresh_sort_in_family : ?loc:Loc.t -> ?rigid:rigid -> evar_map -> Sorts.family -> evar_map * Sorts.t
-val fresh_constant_instance : ?loc:Loc.t -> env -> evar_map -> Constant.t -> evar_map * pconstant
-val fresh_inductive_instance : ?loc:Loc.t -> env -> evar_map -> inductive -> evar_map * pinductive
-val fresh_constructor_instance : ?loc:Loc.t -> env -> evar_map -> constructor -> evar_map * pconstructor
+val fresh_sort_in_family : ?loc:Loc.t -> ?rigid:rigid -> DirPath.t -> evar_map -> Sorts.family -> evar_map * Sorts.t
+val fresh_constant_instance : ?loc:Loc.t -> DirPath.t -> env -> evar_map -> Constant.t -> evar_map * pconstant
+val fresh_inductive_instance : ?loc:Loc.t -> DirPath.t -> env -> evar_map -> inductive -> evar_map * pinductive
+val fresh_constructor_instance : ?loc:Loc.t -> DirPath.t -> env -> evar_map -> constructor -> evar_map * pconstructor
 
-val fresh_global : ?loc:Loc.t -> ?rigid:rigid -> ?names:Univ.Instance.t -> env ->
+val fresh_global : ?loc:Loc.t -> ?rigid:rigid -> ?names:Univ.Instance.t -> DirPath.t -> env ->
   evar_map -> GlobRef.t -> evar_map * econstr
 
 (********************************************************************)

--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -824,10 +824,10 @@ let tclENV = Env.get
 let emit_side_effects eff x =
   { x with solution = Evd.emit_side_effects eff x.solution }
 
-let tclEFFECTS eff =
+let tclEFFECTS env eff =
   let open Proof in
   return () >>= fun () -> (* The Global.env should be taken at exec time *)
-  Env.set (Global.env ()) >>
+  Env.set env >>
   Pv.modify (fun initial -> emit_side_effects eff initial)
 
 let mark_as_unsafe = Status.put false

--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -1035,8 +1035,10 @@ let (>>=) = tclBIND
 (** {6 Goal-dependent tactics} *)
 
 let goal_env evars gl =
+  (* XXX *)
+  let env = Global.env () in
   let evi = Evd.find evars gl in
-  Evd.evar_filtered_env evi
+  Evd.evar_filtered_env env evi
 
 let goal_nf_evar sigma gl =
   let evi = Evd.find sigma gl in

--- a/engine/proofview.mli
+++ b/engine/proofview.mli
@@ -381,7 +381,7 @@ val tclENV : Environ.env tactic
 (** {7 Put-like primitives} *)
 
 (** [tclEFFECTS eff] add the effects [eff] to the current state. *)
-val tclEFFECTS : Safe_typing.private_constants -> unit tactic
+val tclEFFECTS : Environ.env -> Safe_typing.private_constants -> unit tactic
 
 (** [mark_as_unsafe] declares the current tactic is unsafe. *)
 val mark_as_unsafe : unit tactic

--- a/engine/termops.ml
+++ b/engine/termops.ml
@@ -34,7 +34,7 @@ let set_print_constr f = term_printer := f
 
 module EvMap = Evar.Map
 
-let evar_suggested_name evk sigma =
+let evar_suggested_name env evk sigma =
   let open Evd in
   let base_id evk' evi =
   match evar_ident evk' sigma with
@@ -45,8 +45,8 @@ let evar_suggested_name evk sigma =
   | _,Evar_kinds.QuestionMark {Evar_kinds.qm_name = Name id} -> id
   | _,Evar_kinds.GoalEvar -> Id.of_string "Goal"
   | _ ->
-      let env = reset_with_named_context evi.evar_hyps (Global.env()) in
-      Namegen.id_of_name_using_hdchar env sigma evi.evar_concl Anonymous
+    let env = reset_with_named_context evi.evar_hyps env in
+    Namegen.id_of_name_using_hdchar env sigma evi.evar_concl Anonymous
   in
   let names = EvMap.mapi base_id (undefined_map sigma) in
   let id = EvMap.find evk names in
@@ -59,13 +59,13 @@ let evar_suggested_name evk sigma =
   let (_, n) = EvMap.fold fold names (false, 0) in
   if n = 0 then id else Nameops.add_suffix id (string_of_int (pred n))
 
-let pr_existential_key sigma evk =
-let open Evd in
-match evar_ident evk sigma with
-| None ->
-  str "?" ++ Id.print (evar_suggested_name evk sigma)
-| Some id ->
-  str "?" ++ Id.print id
+let pr_existential_key env sigma evk =
+  let open Evd in
+  match evar_ident evk sigma with
+  | None ->
+    str "?" ++ Id.print (evar_suggested_name env evk sigma)
+  | Some id ->
+    str "?" ++ Id.print id
 
 let pr_instance_status (sc,typ) =
   let open Evd in
@@ -316,7 +316,7 @@ let pr_evar_list env sigma l =
       str "==" ++ pr_evar_info env sigma evi ++
       pr_restrict ev ++
       (if evi.evar_body == Evar_empty
-       then str " {" ++ pr_existential_key sigma ev ++ str "}"
+       then str " {" ++ pr_existential_key env sigma ev ++ str "}"
        else mt ()))
   in
   h 0 (prlist_with_sep fnl pr l)
@@ -1053,8 +1053,8 @@ let ids_of_context env =
 let names_of_rel_context env =
   List.map RelDecl.get_name (rel_context env)
 
-let is_section_variable id =
-  try let _ = Global.lookup_named id in true
+let is_section_variable env id =
+  try let _ = Environ.lookup_named id env in true
   with Not_found -> false
 
 let global_of_constr sigma c =

--- a/engine/termops.mli
+++ b/engine/termops.mli
@@ -261,7 +261,7 @@ val global_app_of_constr : Evd.evar_map -> constr -> (GlobRef.t * EInstance.t) *
 val dependency_closure : env -> Evd.evar_map -> named_context -> Id.Set.t -> Id.t list
 
 (** Test if an identifier is the basename of a global reference *)
-val is_section_variable : Id.t -> bool
+val is_section_variable : Environ.env -> Id.t -> bool
 
 val global_of_constr : Evd.evar_map -> constr -> GlobRef.t * EInstance.t
 
@@ -281,9 +281,9 @@ val reference_of_level : Evd.evar_map -> Univ.Level.t -> Libnames.qualid option
 
 open Evd
 
-val pr_existential_key : evar_map -> Evar.t -> Pp.t
+val pr_existential_key : env -> evar_map -> Evar.t -> Pp.t
 
-val evar_suggested_name : Evar.t -> evar_map -> Id.t
+val evar_suggested_name : env -> Evar.t -> evar_map -> Id.t
 
 val pr_evar_info : env -> evar_map -> evar_info -> Pp.t
 val pr_evar_constraints : evar_map -> evar_constraint list -> Pp.t

--- a/engine/uState.ml
+++ b/engine/uState.ml
@@ -524,9 +524,9 @@ let emit_side_effects eff u =
   let uctxs = Safe_typing.universes_of_private eff in
   List.fold_left (merge ~sideff:true ~extend:false univ_rigid) u uctxs
 
-let new_univ_variable ?loc rigid name
+let new_univ_variable ?loc dp rigid name
   ({ uctx_local = ctx; uctx_univ_variables = uvars; uctx_univ_algebraic = avars} as uctx) =
-  let u = UnivGen.fresh_level () in
+  let u = UnivGen.fresh_level dp in
   let ctx' = ContextSet.add_universe u ctx in
   let uctx', pred =
     match rigid with
@@ -551,11 +551,11 @@ let new_univ_variable ?loc rigid name
                 uctx_initial_universes = initial}
   in uctx', u
 
-let make_with_initial_binders e us =
+let make_with_initial_binders dp e us =
   let uctx = make e in
   List.fold_left
     (fun uctx { CAst.loc; v = id } ->
-       fst (new_univ_variable ?loc univ_rigid (Some id) uctx))
+       fst (new_univ_variable ?loc dp univ_rigid (Some id) uctx))
     uctx us
 
 let add_global_univ uctx u =
@@ -664,8 +664,8 @@ let fix_undefined_variables uctx =
   { uctx with uctx_univ_variables = vars';
     uctx_univ_algebraic = algs' }
 
-let refresh_undefined_univ_variables uctx =
-  let subst, ctx' = UnivGen.fresh_universe_context_set_instance uctx.uctx_local in
+let refresh_undefined_univ_variables dp uctx =
+  let subst, ctx' = UnivGen.fresh_universe_context_set_instance dp uctx.uctx_local in
   let subst_fn u = subst_univs_level_level subst u in
   let alg = LSet.fold (fun u acc -> LSet.add (subst_fn u) acc)
     uctx.uctx_univ_algebraic LSet.empty

--- a/engine/uState.mli
+++ b/engine/uState.mli
@@ -27,7 +27,7 @@ val empty : t
 
 val make : UGraph.t -> t
 
-val make_with_initial_binders : UGraph.t -> lident list -> t
+val make_with_initial_binders : DirPath.t -> UGraph.t -> lident list -> t
 
 val is_empty : t -> bool
 
@@ -114,7 +114,7 @@ val merge : ?loc:Loc.t -> sideff:bool -> extend:bool -> rigid -> t -> Univ.Conte
 val merge_subst : t -> UnivSubst.universe_opt_subst -> t
 val emit_side_effects : Safe_typing.private_constants -> t -> t
 
-val new_univ_variable : ?loc:Loc.t -> rigid -> Id.t option -> t -> t * Univ.Level.t
+val new_univ_variable : ?loc:Loc.t -> DirPath.t -> rigid -> Id.t option -> t -> t * Univ.Level.t
 val add_global_univ : t -> Univ.Level.t -> t
 
 (** [make_flexible_variable g algebraic l]
@@ -146,7 +146,7 @@ val abstract_undefined_variables : t -> t
 
 val fix_undefined_variables : t -> t
 
-val refresh_undefined_univ_variables : t -> t * Univ.universe_level_subst
+val refresh_undefined_univ_variables : DirPath.t -> t -> t * Univ.universe_level_subst
 
 (** Universe minimization *)
 val minimize : t -> t

--- a/engine/univGen.ml
+++ b/engine/univGen.ml
@@ -19,14 +19,11 @@ let new_univ_id, set_remote_new_univ_id =
   RemoteCounter.new_counter ~name:"Universes" 0 ~incr:((+) 1)
     ~build:(fun n -> n)
 
-let new_univ_global () =
-  Univ.Level.UGlobal.make (Global.current_dirpath ()) (new_univ_id ())
+let new_univ_global dp = Univ.Level.UGlobal.make dp (new_univ_id ())
+let fresh_level dp = Univ.Level.make (new_univ_global dp)
 
-let fresh_level () =
-  Univ.Level.make (new_univ_global ())
-
-let fresh_instance auctx =
-  let inst = Array.init (AUContext.size auctx) (fun _ -> fresh_level()) in
+let fresh_instance dp auctx =
+  let inst = Array.init (AUContext.size auctx) (fun _ -> fresh_level dp) in
   let ctx = Array.fold_right LSet.add inst LSet.empty in
   let inst = Instance.of_array inst in
   inst, (ctx, AUContext.instantiate inst auctx)
@@ -42,45 +39,45 @@ let existing_instance ?loc auctx inst =
   in
   inst, (LSet.empty, AUContext.instantiate inst auctx)
 
-let fresh_instance_from ?loc ctx = function
+let fresh_instance_from ?loc dp ctx = function
   | Some inst -> existing_instance ?loc ctx inst
-  | None -> fresh_instance ctx
+  | None -> fresh_instance dp ctx
 
 (** Fresh universe polymorphic construction *)
 
 open Globnames
 
-let fresh_global_instance ?loc ?names env gr =
+let fresh_global_instance ?loc ?names dp env gr =
   let auctx = Environ.universes_of_global env gr in
-  let u, ctx = fresh_instance_from ?loc auctx names in
+  let u, ctx = fresh_instance_from ?loc dp auctx names in
   u, ctx
 
-let fresh_constant_instance env c =
-  let u, ctx = fresh_global_instance env (ConstRef c) in
+let fresh_constant_instance dp env c =
+  let u, ctx = fresh_global_instance dp env (ConstRef c) in
   (c, u), ctx
 
-let fresh_inductive_instance env ind =
-  let u, ctx = fresh_global_instance env (IndRef ind) in
+let fresh_inductive_instance dp env ind =
+  let u, ctx = fresh_global_instance dp env (IndRef ind) in
   (ind, u), ctx
 
-let fresh_constructor_instance env c =
-  let u, ctx = fresh_global_instance env (ConstructRef c) in
+let fresh_constructor_instance dp env c =
+  let u, ctx = fresh_global_instance dp env (ConstructRef c) in
   (c, u), ctx
 
-let fresh_global_instance ?loc ?names env gr =
-  let u, ctx = fresh_global_instance ?loc ?names env gr in
+let fresh_global_instance ?loc ?names dp env gr =
+  let u, ctx = fresh_global_instance ?loc ?names dp env gr in
   mkRef (gr, u), ctx
 
-let constr_of_monomorphic_global gr =
+let constr_of_monomorphic_global dp gr =
   if not (Global.is_polymorphic gr) then
-    fst (fresh_global_instance (Global.env ()) gr)
+    fst (fresh_global_instance dp (Global.env ()) gr)
   else CErrors.user_err ~hdr:"constr_of_global"
       Pp.(str "globalization of polymorphic reference " ++ Nametab.pr_global_env Id.Set.empty gr ++
           str " would forget universes.")
 
-let fresh_global_or_constr_instance env = function
+let fresh_global_or_constr_instance dp env = function
   | IsConstr c -> c, ContextSet.empty
-  | IsGlobal gr -> fresh_global_instance env gr
+  | IsGlobal gr -> fresh_global_instance dp env gr
 
 let global_of_constr c =
   match kind c with
@@ -90,25 +87,25 @@ let global_of_constr c =
   | Var id -> VarRef id, Instance.empty
   | _ -> raise Not_found
 
-let fresh_sort_in_family = function
+let fresh_sort_in_family dp = function
   | InSProp -> Sorts.sprop, ContextSet.empty
   | InProp -> Sorts.prop, ContextSet.empty
   | InSet -> Sorts.set, ContextSet.empty
   | InType ->
-    let u = fresh_level () in
+    let u = fresh_level dp in
       sort_of_univ (Univ.Universe.make u), ContextSet.singleton u
 
-let new_global_univ () =
-  let u = fresh_level () in
+let new_global_univ dp =
+  let u = fresh_level dp in
   (Univ.Universe.make u, ContextSet.singleton u)
 
-let fresh_universe_context_set_instance ctx =
+let fresh_universe_context_set_instance dp ctx =
   if ContextSet.is_empty ctx then LMap.empty, ctx
   else
     let (univs, cst) = ContextSet.levels ctx, ContextSet.constraints ctx in
     let univs',subst = LSet.fold
       (fun u (univs',subst) ->
-        let u' = fresh_level () in
+        let u' = fresh_level dp in
           (LSet.add u' univs', LMap.add u u' subst))
       univs (LSet.empty, LMap.empty)
     in

--- a/engine/univGen.ml
+++ b/engine/univGen.ml
@@ -68,9 +68,9 @@ let fresh_global_instance ?loc ?names dp env gr =
   let u, ctx = fresh_global_instance ?loc ?names dp env gr in
   mkRef (gr, u), ctx
 
-let constr_of_monomorphic_global dp gr =
-  if not (Global.is_polymorphic gr) then
-    fst (fresh_global_instance dp (Global.env ()) gr)
+let constr_of_monomorphic_global dp env gr =
+  if not (Environ.is_polymorphic env gr) then
+    fst (fresh_global_instance dp env gr)
   else CErrors.user_err ~hdr:"constr_of_global"
       Pp.(str "globalization of polymorphic reference " ++ Nametab.pr_global_env Id.Set.empty gr ++
           str " would forget universes.")

--- a/engine/univGen.mli
+++ b/engine/univGen.mli
@@ -62,4 +62,4 @@ val global_of_constr : constr -> GlobRef.t puniverses
     the constraints should be properly added to an evd.
     See Evd.fresh_global, Evarutil.new_global, and pf_constr_of_global for
     the proper way to get a fresh copy of a polymorphic global reference. *)
-val constr_of_monomorphic_global : DirPath.t -> GlobRef.t -> constr
+val constr_of_monomorphic_global : DirPath.t -> env -> GlobRef.t -> constr

--- a/engine/univGen.mli
+++ b/engine/univGen.mli
@@ -21,37 +21,37 @@ val new_univ_id : unit -> univ_unique_id (** for the stm *)
 
 (** Side-effecting functions creating new universe levels. *)
 
-val new_univ_global : unit -> Level.UGlobal.t
-val fresh_level : unit -> Level.t
+val new_univ_global : DirPath.t -> Level.UGlobal.t
+val fresh_level : DirPath.t -> Level.t
 
-val new_global_univ : unit -> Universe.t in_universe_context_set
+val new_global_univ : DirPath.t -> Universe.t in_universe_context_set
 
 (** Build a fresh instance for a given context, its associated substitution and
     the instantiated constraints. *)
 
-val fresh_instance : AUContext.t -> Instance.t in_universe_context_set
+val fresh_instance : DirPath.t -> AUContext.t -> Instance.t in_universe_context_set
 
-val fresh_instance_from : ?loc:Loc.t -> AUContext.t -> Instance.t option ->
+val fresh_instance_from : ?loc:Loc.t -> DirPath.t -> AUContext.t -> Instance.t option ->
   Instance.t in_universe_context_set
 
-val fresh_sort_in_family : Sorts.family ->
+val fresh_sort_in_family : DirPath.t -> Sorts.family ->
   Sorts.t in_universe_context_set
-val fresh_constant_instance : env -> Constant.t ->
+val fresh_constant_instance : DirPath.t -> env -> Constant.t ->
   pconstant in_universe_context_set
-val fresh_inductive_instance : env -> inductive ->
+val fresh_inductive_instance : DirPath.t -> env -> inductive ->
   pinductive in_universe_context_set
-val fresh_constructor_instance : env -> constructor ->
+val fresh_constructor_instance : DirPath.t -> env -> constructor ->
   pconstructor in_universe_context_set
 
-val fresh_global_instance : ?loc:Loc.t -> ?names:Univ.Instance.t -> env -> GlobRef.t ->
+val fresh_global_instance : ?loc:Loc.t -> ?names:Univ.Instance.t -> DirPath.t -> env -> GlobRef.t ->
   constr in_universe_context_set
 
-val fresh_global_or_constr_instance : env -> Globnames.global_reference_or_constr ->
+val fresh_global_or_constr_instance : DirPath.t -> env -> Globnames.global_reference_or_constr ->
   constr in_universe_context_set
 
 (** Get fresh variables for the universe context.
     Useful to make tactics that manipulate constrs in universe contexts polymorphic. *)
-val fresh_universe_context_set_instance : ContextSet.t ->
+val fresh_universe_context_set_instance : DirPath.t -> ContextSet.t ->
   universe_level_subst * ContextSet.t
 
 (** Raises [Not_found] if not a global reference. *)
@@ -62,4 +62,4 @@ val global_of_constr : constr -> GlobRef.t puniverses
     the constraints should be properly added to an evd.
     See Evd.fresh_global, Evarutil.new_global, and pf_constr_of_global for
     the proper way to get a fresh copy of a polymorphic global reference. *)
-val constr_of_monomorphic_global : GlobRef.t -> constr
+val constr_of_monomorphic_global : DirPath.t -> GlobRef.t -> constr

--- a/ide/idetop.ml
+++ b/ide/idetop.ml
@@ -248,7 +248,7 @@ let evars () =
     let pfts = Vernacstate.Proof_global.give_me_the_proof () in
     let Proof.{ sigma } = Proof.data pfts in
     let exl = Evar.Map.bindings (Evd.undefined_map sigma) in
-    let map_evar ev = { Interface.evar_info = string_of_ppcmds (pr_evar sigma ev); } in
+    let map_evar ev = { Interface.evar_info = string_of_ppcmds (pr_evar (Global.env ()) sigma ev); } in
     let el = List.map map_evar exl in
     Some el
   with Vernacstate.Proof_global.NoCurrentProof -> None

--- a/interp/constrexpr_ops.ml
+++ b/interp/constrexpr_ops.ml
@@ -631,7 +631,8 @@ let interp_univ_constraints env evd cstrs =
 let interp_univ_decl env decl =
   let open UState in
   let pl : lident list = decl.univdecl_instance in
-  let evd = Evd.from_ctx (UState.make_with_initial_binders (Environ.universes env) pl) in
+  let dp = Global.current_dirpath () in
+  let evd = Evd.from_ctx (UState.make_with_initial_binders dp (Environ.universes env) pl) in
   let evd, cstrs = interp_univ_constraints env evd decl.univdecl_constraints in
   let decl = { univdecl_instance = pl;
     univdecl_extensible_instance = decl.univdecl_extensible_instance;

--- a/interp/declare.ml
+++ b/interp/declare.ml
@@ -549,7 +549,8 @@ let do_universe poly l =
       user_err ~hdr:"Constraint"
                    (str"Cannot declare polymorphic universes outside sections")
   in
-  let l = List.map (fun {CAst.v=id} -> (id, UnivGen.new_univ_global ())) l in
+  let dp = Global.current_dirpath () in
+  let l = List.map (fun {CAst.v=id} -> (id, UnivGen.new_univ_global dp)) l in
   let ctx = List.fold_left (fun ctx (_,qid) -> Univ.LSet.add (Univ.Level.make qid) ctx)
       Univ.LSet.empty l, Univ.Constraint.empty
   in

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -492,11 +492,13 @@ exception NotAValidPrimToken
 
 let rec constr_of_glob env sigma g = match DAst.get g with
   | Glob_term.GRef (ConstructRef c, _) ->
-      let sigma,c = Evd.fresh_constructor_instance env sigma c in
-      sigma,mkConstructU c
+    let dp = Global.current_dirpath () in
+    let sigma,c = Evd.fresh_constructor_instance dp env sigma c in
+    sigma,mkConstructU c
   | Glob_term.GRef (IndRef c, _) ->
-      let sigma,c = Evd.fresh_inductive_instance env sigma c in
-      sigma,mkIndU c
+    let dp = Global.current_dirpath () in
+    let sigma,c = Evd.fresh_inductive_instance dp env sigma c in
+    sigma,mkIndU c
   | Glob_term.GApp (gc, gcl) ->
       let sigma,c = constr_of_glob env sigma gc in
       let sigma,cl = List.fold_left_map (constr_of_glob env) sigma gcl in
@@ -536,7 +538,8 @@ let uninterp_option c =
 let uninterp to_raw o (Glob_term.AnyGlobConstr n) =
   let env = Global.env () in
   let sigma = Evd.from_env env in
-  let sigma,of_ty = Evd.fresh_global env sigma o.of_ty in
+  let dp = Global.current_dirpath () in
+  let sigma,of_ty = Evd.fresh_global dp env sigma o.of_ty in
   let of_ty = EConstr.Unsafe.to_constr of_ty in
   try
     let sigma,n = constr_of_glob env sigma n in
@@ -799,7 +802,8 @@ let interp o ?loc n =
   in
   let env = Global.env () in
   let sigma = Evd.from_env env in
-  let sigma,to_ty = Evd.fresh_global env sigma o.to_ty in
+  let dp = Global.current_dirpath () in
+  let sigma,to_ty = Evd.fresh_global dp env sigma o.to_ty in
   let to_ty = EConstr.Unsafe.to_constr to_ty in
   match o.warning, snd o.to_kind with
   | Abstract threshold, Direct
@@ -907,7 +911,8 @@ let interp o ?loc n =
   in
   let env = Global.env () in
   let sigma = Evd.from_env env in
-  let sigma,to_ty = Evd.fresh_global env sigma o.to_ty in
+  let dp = Global.current_dirpath () in
+  let sigma,to_ty = Evd.fresh_global dp env sigma o.to_ty in
   let to_ty = EConstr.Unsafe.to_constr to_ty in
   let res = eval_constr_app env sigma to_ty c in
   match snd o.to_kind with

--- a/plugins/btauto/refl_btauto.ml
+++ b/plugins/btauto/refl_btauto.ml
@@ -12,7 +12,7 @@ open Constr
 
 let bt_lib_constr n = lazy (
   let dp = Global.current_dirpath () in
-  UnivGen.constr_of_monomorphic_global dp @@ Coqlib.lib_ref n)
+  UnivGen.constr_of_monomorphic_global dp (Global.env ()) @@ Coqlib.lib_ref n)
 
 let decomp_term sigma (c : Constr.t) =
   Constr.kind (EConstr.Unsafe.to_constr (Termops.strip_outer_cast sigma (EConstr.of_constr c)))

--- a/plugins/btauto/refl_btauto.ml
+++ b/plugins/btauto/refl_btauto.ml
@@ -10,7 +10,9 @@
 
 open Constr
 
-let bt_lib_constr n = lazy (UnivGen.constr_of_monomorphic_global @@ Coqlib.lib_ref n)
+let bt_lib_constr n = lazy (
+  let dp = Global.current_dirpath () in
+  UnivGen.constr_of_monomorphic_global dp @@ Coqlib.lib_ref n)
 
 let decomp_term sigma (c : Constr.t) =
   Constr.kind (EConstr.Unsafe.to_constr (Termops.strip_outer_cast sigma (EConstr.of_constr c)))

--- a/plugins/derive/derive.ml
+++ b/plugins/derive/derive.ml
@@ -31,7 +31,8 @@ let start_deriving f suchthat name : Lemmas.t =
   (* create a sort variable for the type of [f] *)
   (* spiwack: I don't know what the rigidity flag does, picked the one
      that looked the most general. *)
-  let (sigma,f_type_sort) = Evd.new_sort_variable Evd.univ_flexible_alg sigma in
+  let dp = Global.current_dirpath () in
+  let (sigma,f_type_sort) = Evd.new_sort_variable dp Evd.univ_flexible_alg sigma in
   let f_type_type = EConstr.mkSort f_type_sort in
   (* create the initial goals for the proof: |- Type ; |- ?1 ; f:=?2 |- suchthat *)
   let goals =

--- a/plugins/extraction/extraction.ml
+++ b/plugins/extraction/extraction.ml
@@ -437,7 +437,8 @@ and extract_really_ind env kn mib =
     let packets =
       Array.mapi
 	(fun i mip ->
-           let (_,u),_ = UnivGen.fresh_inductive_instance env (kn,i) in
+           let dp = Global.current_dirpath () in
+           let (_,u),_ = UnivGen.fresh_inductive_instance dp env (kn,i) in
 	   let ar = Inductive.type_of_inductive env ((mib,mip),u) in
            let ar = EConstr.of_constr ar in
            let info = (fst (flag_of_type env sg ar) = Info) in

--- a/plugins/firstorder/instances.ml
+++ b/plugins/firstorder/instances.ml
@@ -114,7 +114,8 @@ let mk_open_instance env evmap id idc m t =
   let rec aux n avoid env evmap decls =
     if Int.equal n 0 then evmap, decls else
       let nid=(fresh_id_in_env avoid var_id env) in
-      let (evmap, (c, _)) = Evarutil.new_type_evar env evmap Evd.univ_flexible in
+      let dp = Global.current_dirpath () in
+      let (evmap, (c, _)) = Evarutil.new_type_evar dp env evmap Evd.univ_flexible in
       let decl = LocalAssum (Context.make_annot (Name nid) Sorts.Relevant, c) in
 	aux (n-1) (Id.Set.add nid avoid) (EConstr.push_rel decl env) evmap (decl::decls) in
   let evmap, decls = aux m Id.Set.empty env evmap [] in

--- a/plugins/firstorder/sequent.ml
+++ b/plugins/firstorder/sequent.ml
@@ -196,7 +196,8 @@ let expand_constructor_hints =
 let extend_with_ref_list env sigma l seq =
   let l = expand_constructor_hints l in
   let f gr (seq, sigma) =
-    let sigma, c = Evd.fresh_global env sigma gr in
+    let dp = Global.current_dirpath () in
+    let sigma, c = Evd.fresh_global dp env sigma gr in
     let sigma, typ= Typing.type_of env sigma c in
       (add_formula env sigma Hyp gr typ seq, sigma) in
     List.fold_right f l (seq, sigma)

--- a/plugins/funind/functional_principles_proofs.ml
+++ b/plugins/funind/functional_principles_proofs.ml
@@ -928,7 +928,7 @@ let generalize_non_dep hyp g =
       if Id.List.mem hyp hyps
         || List.exists (Termops.occur_var_in_decl env (project g) hyp) keep
 	|| Termops.occur_var env (project g) hyp hyp_typ
-	|| Termops.is_section_variable hyp (* should be dangerous *)
+        || Termops.is_section_variable env hyp (* should be dangerous *)
       then (clear,decl::keep)
       else (hyp::clear,keep))
       ~init:([],[]) (pf_env g)

--- a/plugins/funind/functional_principles_proofs.ml
+++ b/plugins/funind/functional_principles_proofs.ml
@@ -409,9 +409,10 @@ let rewrite_until_var arg_num eq_ids : tactic =
 
 let rec_pte_id = Id.of_string "Hrec"
 let clean_hyp_with_heq ptes_infos eq_hyps hyp_id env sigma =
-  let coq_False = EConstr.of_constr (UnivGen.constr_of_monomorphic_global @@ Coqlib.lib_ref "core.False.type") in
-  let coq_True = EConstr.of_constr (UnivGen.constr_of_monomorphic_global @@ Coqlib.lib_ref "core.True.type") in
-  let coq_I = EConstr.of_constr (UnivGen.constr_of_monomorphic_global @@ Coqlib.lib_ref "core.True.I") in
+  let dp = Global.current_dirpath () in
+  let coq_False = EConstr.of_constr (UnivGen.constr_of_monomorphic_global dp @@ Coqlib.lib_ref "core.False.type") in
+  let coq_True = EConstr.of_constr (UnivGen.constr_of_monomorphic_global dp @@ Coqlib.lib_ref "core.True.type") in
+  let coq_I = EConstr.of_constr (UnivGen.constr_of_monomorphic_global dp @@ Coqlib.lib_ref "core.True.I") in
   let rec scan_type  context type_of_hyp : tactic =
     if isLetIn sigma type_of_hyp then
       let real_type_of_hyp = it_mkProd_or_LetIn type_of_hyp context in
@@ -1030,7 +1031,8 @@ let do_replace (evd:Evd.evar_map ref) params rec_arg_num rev_args_id f fun_num a
       in
       (* let res = Constrintern.construct_reference (pf_hyps g) equation_lemma_id in *)
       let evd',res =
-	Evd.fresh_global
+        let dp = Global.current_dirpath () in
+        Evd.fresh_global dp
 	  (Global.env ()) !evd
 	  (Constrintern.locate_reference (qualid_of_ident equation_lemma_id))
       in
@@ -1589,7 +1591,9 @@ let prove_principle_for_gen
     match !tcc_lemma_ref with
      | Undefined -> user_err Pp.(str "No tcc proof !!")
      | Value lemma -> EConstr.of_constr lemma
-     | Not_needed -> EConstr.of_constr (UnivGen.constr_of_monomorphic_global @@ Coqlib.lib_ref "core.True.I")
+     | Not_needed ->
+       let dp = Global.current_dirpath () in
+       EConstr.of_constr (UnivGen.constr_of_monomorphic_global dp @@ Coqlib.lib_ref "core.True.I")
   in
 (*   let rec list_diff del_list check_list = *)
 (*     match del_list with *)

--- a/plugins/funind/functional_principles_proofs.ml
+++ b/plugins/funind/functional_principles_proofs.ml
@@ -410,9 +410,9 @@ let rewrite_until_var arg_num eq_ids : tactic =
 let rec_pte_id = Id.of_string "Hrec"
 let clean_hyp_with_heq ptes_infos eq_hyps hyp_id env sigma =
   let dp = Global.current_dirpath () in
-  let coq_False = EConstr.of_constr (UnivGen.constr_of_monomorphic_global dp @@ Coqlib.lib_ref "core.False.type") in
-  let coq_True = EConstr.of_constr (UnivGen.constr_of_monomorphic_global dp @@ Coqlib.lib_ref "core.True.type") in
-  let coq_I = EConstr.of_constr (UnivGen.constr_of_monomorphic_global dp @@ Coqlib.lib_ref "core.True.I") in
+  let coq_False = EConstr.of_constr (UnivGen.constr_of_monomorphic_global dp (Global.env ()) @@ Coqlib.lib_ref "core.False.type") in
+  let coq_True = EConstr.of_constr (UnivGen.constr_of_monomorphic_global dp (Global.env ()) @@ Coqlib.lib_ref "core.True.type") in
+  let coq_I = EConstr.of_constr (UnivGen.constr_of_monomorphic_global dp (Global.env ()) @@ Coqlib.lib_ref "core.True.I") in
   let rec scan_type  context type_of_hyp : tactic =
     if isLetIn sigma type_of_hyp then
       let real_type_of_hyp = it_mkProd_or_LetIn type_of_hyp context in
@@ -1593,7 +1593,7 @@ let prove_principle_for_gen
      | Value lemma -> EConstr.of_constr lemma
      | Not_needed ->
        let dp = Global.current_dirpath () in
-       EConstr.of_constr (UnivGen.constr_of_monomorphic_global dp @@ Coqlib.lib_ref "core.True.I")
+       EConstr.of_constr (UnivGen.constr_of_monomorphic_global dp (Global.env ()) @@ Coqlib.lib_ref "core.True.I")
   in
 (*   let rec list_diff del_list check_list = *)
 (*     match del_list with *)

--- a/plugins/funind/functional_principles_types.ml
+++ b/plugins/funind/functional_principles_types.ml
@@ -276,7 +276,8 @@ let change_property_sort evd toSort princ princName =
     )
   in
   let evd,princName_as_constr =
-    Evd.fresh_global
+    let dp = Global.current_dirpath () in
+    Evd.fresh_global dp
       (Global.env ()) evd (Constrintern.locate_reference (Libnames.qualid_of_ident princName)) in
   let init =
     let nargs =  (princ_info.nparams + (List.length  princ_info.predicates)) in
@@ -339,7 +340,8 @@ let generate_functional_principle (evd: Evd.evar_map ref)
   try
 
   let f = funs.(i) in
-  let sigma, type_sort = Evd.fresh_sort_in_family !evd InType in
+  let dp = Global.current_dirpath () in
+  let sigma, type_sort = Evd.fresh_sort_in_family dp !evd InType in
   evd := sigma;
   let new_sorts =
     match sorts with
@@ -361,7 +363,8 @@ let generate_functional_principle (evd: Evd.evar_map ref)
       (*     let id_of_f = Label.to_id (con_label f) in *)
       let register_with_sort fam_sort =
         let evd' = Evd.from_env (Global.env ()) in
-        let evd',s = Evd.fresh_sort_in_family evd' fam_sort in
+        let dp = Global.current_dirpath () in
+        let evd',s = Evd.fresh_sort_in_family dp evd' fam_sort in
         let name = Indrec.make_elimination_ident base_new_princ_name fam_sort in
         let evd',value = change_property_sort evd' s new_principle_type new_princ_name in
         let evd' = fst (Typing.type_of ~refresh:true (Global.env ()) evd' (EConstr.of_constr value)) in
@@ -508,7 +511,8 @@ let make_scheme evd (fas : (pconstant*Sorts.family) list) : Safe_typing.private_
   let i = ref (-1) in
   let sorts =
     List.rev_map (fun (_,x) ->
-        let sigma, fs = Evd.fresh_sort_in_family !evd x in
+        let dp = Global.current_dirpath () in
+        let sigma, fs = Evd.fresh_sort_in_family dp !evd x in
         evd := sigma; fs
       )
       fas
@@ -616,7 +620,8 @@ let build_scheme fas =
                 user_err ~hdr:"FunInd.build_scheme"
                   (str "Cannot find " ++ Libnames.pr_qualid f)
 	    in
-            let evd',f = Evd.fresh_global (Global.env ()) !evd f_as_constant in
+            let dp = Global.current_dirpath () in
+            let evd',f = Evd.fresh_global dp (Global.env ()) !evd f_as_constant in
             let _ = evd := evd' in 
             let sigma, _ = Typing.type_of ~refresh:true (Global.env ()) !evd f in
             evd := sigma;
@@ -659,7 +664,8 @@ let build_case_scheme fa =
     with Not_found ->
       user_err ~hdr:"FunInd.build_case_scheme"
         (str "Cannot find " ++ Libnames.pr_qualid f) in
-  let sigma, (_,u) = Evd.fresh_constant_instance env sigma funs in
+  let dp = Global.current_dirpath () in
+  let sigma, (_,u) = Evd.fresh_constant_instance dp env sigma funs in
   let first_fun = funs in
   let funs_mp = Constant.modpath first_fun in
   let first_fun_kn = try fst (find_Function_infos  first_fun).graph_ind with Not_found -> raise No_graph_found in
@@ -680,7 +686,8 @@ let build_case_scheme fa =
   let scheme_type = EConstr.Unsafe.to_constr ((Typing.unsafe_type_of env sigma) (EConstr.of_constr scheme)) in
   let sorts =
     (fun (_,_,x) ->
-       fst @@ UnivGen.fresh_sort_in_family x
+       let dp = Global.current_dirpath () in
+       fst @@ UnivGen.fresh_sort_in_family dp x
     )
       fa
   in

--- a/plugins/funind/indfun_common.ml
+++ b/plugins/funind/indfun_common.ml
@@ -104,7 +104,7 @@ let const_of_id id =
 [@@@ocaml.warning "-3"]
 let coq_constant s =
   let dp = Global.current_dirpath () in
-  UnivGen.constr_of_monomorphic_global dp @@
+  UnivGen.constr_of_monomorphic_global dp (Global.env ()) @@
   Coqlib.gen_reference_in_modules "RecursiveDefinition"
     Coqlib.init_modules s;;
 
@@ -408,7 +408,7 @@ let jmeq () =
     let dp = Global.current_dirpath () in
     Coqlib.check_required_library Coqlib.jmeq_module_name;
     EConstr.of_constr @@
-    UnivGen.constr_of_monomorphic_global dp @@
+    UnivGen.constr_of_monomorphic_global dp (Global.env ()) @@
       Coqlib.lib_ref "core.JMeq.type"
   with e when CErrors.noncritical e -> raise (ToShow e)
 
@@ -417,7 +417,7 @@ let jmeq_refl () =
     let dp = Global.current_dirpath () in
     Coqlib.check_required_library Coqlib.jmeq_module_name;
     EConstr.of_constr @@
-    UnivGen.constr_of_monomorphic_global dp @@
+    UnivGen.constr_of_monomorphic_global dp (Global.env ()) @@
       Coqlib.lib_ref "core.JMeq.refl"
   with e when CErrors.noncritical e -> raise (ToShow e)
 
@@ -433,7 +433,7 @@ let acc_inv_id = function () -> EConstr.of_constr (coq_constant "Acc_inv")
 [@@@ocaml.warning "-3"]
 let well_founded_ltof () =
   let dp = Global.current_dirpath () in
-  EConstr.of_constr @@ UnivGen.constr_of_monomorphic_global dp @@
+  EConstr.of_constr @@ UnivGen.constr_of_monomorphic_global dp (Global.env ()) @@
   Coqlib.find_reference "IndFun" ["Coq"; "Arith";"Wf_nat"] "well_founded_ltof"
 [@@@ocaml.warning "+3"]
 

--- a/plugins/funind/indfun_common.ml
+++ b/plugins/funind/indfun_common.ml
@@ -103,7 +103,8 @@ let const_of_id id =
 
 [@@@ocaml.warning "-3"]
 let coq_constant s =
-  UnivGen.constr_of_monomorphic_global @@
+  let dp = Global.current_dirpath () in
+  UnivGen.constr_of_monomorphic_global dp @@
   Coqlib.gen_reference_in_modules "RecursiveDefinition"
     Coqlib.init_modules s;;
 
@@ -404,17 +405,19 @@ exception ToShow of exn
 
 let jmeq () =
   try
+    let dp = Global.current_dirpath () in
     Coqlib.check_required_library Coqlib.jmeq_module_name;
     EConstr.of_constr @@
-    UnivGen.constr_of_monomorphic_global @@
+    UnivGen.constr_of_monomorphic_global dp @@
       Coqlib.lib_ref "core.JMeq.type"
   with e when CErrors.noncritical e -> raise (ToShow e)
 
 let jmeq_refl () =
   try
+    let dp = Global.current_dirpath () in
     Coqlib.check_required_library Coqlib.jmeq_module_name;
     EConstr.of_constr @@
-    UnivGen.constr_of_monomorphic_global @@
+    UnivGen.constr_of_monomorphic_global dp @@
       Coqlib.lib_ref "core.JMeq.refl"
   with e when CErrors.noncritical e -> raise (ToShow e)
 
@@ -428,8 +431,10 @@ let acc_rel = function () -> EConstr.of_constr (coq_constant "Acc")
 let acc_inv_id = function () -> EConstr.of_constr (coq_constant "Acc_inv")
 
 [@@@ocaml.warning "-3"]
-let well_founded_ltof () = EConstr.of_constr @@ UnivGen.constr_of_monomorphic_global @@
-    Coqlib.find_reference "IndFun" ["Coq"; "Arith";"Wf_nat"] "well_founded_ltof"
+let well_founded_ltof () =
+  let dp = Global.current_dirpath () in
+  EConstr.of_constr @@ UnivGen.constr_of_monomorphic_global dp @@
+  Coqlib.find_reference "IndFun" ["Coq"; "Arith";"Wf_nat"] "well_founded_ltof"
 [@@@ocaml.warning "+3"]
 
 let ltof_ref = function  () -> (find_reference ["Coq";"Arith";"Wf_nat"] "ltof")

--- a/plugins/funind/invfun.ml
+++ b/plugins/funind/invfun.ml
@@ -77,7 +77,7 @@ let thin ids gl = Proofview.V82.of_tactic (Tactics.clear ids) gl
 let make_eq () =
   try
     let dp = Global.current_dirpath () in
-    EConstr.of_constr (UnivGen.constr_of_monomorphic_global dp (Coqlib.lib_ref "core.eq.type"))
+    EConstr.of_constr (UnivGen.constr_of_monomorphic_global dp (Global.env ()) (Coqlib.lib_ref "core.eq.type"))
   with _ -> assert false
 
 (* [generate_type g_to_f f graph i] build the completeness (resp. correctness) lemma type if [g_to_f = true]
@@ -510,7 +510,7 @@ and intros_with_rewrite_aux : Tacmach.tactic =
 			    intros_with_rewrite
 			  ] g
 			end
-                  | Ind _ when EConstr.eq_constr sigma t (EConstr.of_constr (UnivGen.constr_of_monomorphic_global dp @@ Coqlib.lib_ref "core.False.type")) ->
+                  | Ind _ when EConstr.eq_constr sigma t (EConstr.of_constr (UnivGen.constr_of_monomorphic_global dp (Global.env ()) @@ Coqlib.lib_ref "core.False.type")) ->
 		      Proofview.V82.of_tactic tauto g
 		  | Case(_,_,v,_) ->
 		      tclTHENLIST[

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -53,7 +53,7 @@ open Context.Rel.Declaration
 [@@@ocaml.warning "-3"]
 let coq_constant m s =
   let dp = Global.current_dirpath () in
-  EConstr.of_constr @@ UnivGen.constr_of_monomorphic_global dp @@
+  EConstr.of_constr @@ UnivGen.constr_of_monomorphic_global dp (Global.env ()) @@
   Coqlib.find_reference "RecursiveDefinition" m s
 
 let arith_Nat = ["Coq"; "Arith";"PeanoNat";"Nat"]
@@ -62,7 +62,7 @@ let arith_Lt  = ["Coq"; "Arith";"Lt"]
 let coq_init_constant s =
   let dp = Global.current_dirpath () in
   EConstr.of_constr (
-    UnivGen.constr_of_monomorphic_global dp @@
+    UnivGen.constr_of_monomorphic_global dp (Global.env ()) @@
     Coqlib.gen_reference_in_modules "RecursiveDefinition" Coqlib.init_modules s)
 [@@@ocaml.warning "+3"]
 
@@ -99,7 +99,7 @@ let type_of_const sigma t =
 
 let constant sl s =
   let dp = Global.current_dirpath () in
-  UnivGen.constr_of_monomorphic_global dp (find_reference sl s)
+  UnivGen.constr_of_monomorphic_global dp (Global.env ()) (find_reference sl s)
 
 let const_of_ref = function
     ConstRef kn -> kn
@@ -139,7 +139,7 @@ let iter_ref () =
   with Not_found -> user_err Pp.(str "module Recdef not loaded")
 let iter_rd = function () -> (
   let dp = Global.current_dirpath () in
-  constr_of_monomorphic_global dp (delayed_force iter_ref))
+  constr_of_monomorphic_global dp (Global.env ()) (delayed_force iter_ref))
 let eq = function () -> (coq_init_constant "eq")
 let le_lt_SS = function () -> (constant ["Recdef"] "le_lt_SS")
 let le_lt_n_Sm = function () -> (coq_constant arith_Lt "le_lt_n_Sm")
@@ -154,7 +154,7 @@ let lt_n_O = function () -> (coq_constant arith_Nat "nlt_0_r")
 let max_ref = function () -> (find_reference ["Recdef"] "max")
 let max_constr = function () ->
   let dp = Global.current_dirpath () in
-  EConstr.of_constr (constr_of_monomorphic_global dp (delayed_force max_ref))
+  EConstr.of_constr (constr_of_monomorphic_global dp (Global.env ()) (delayed_force max_ref))
 
 let f_S t = mkApp(delayed_force coq_S, [|t|]);;
 
@@ -1052,13 +1052,13 @@ let compute_terminate_type nb_args func =
   let open CVars in
   let dp = Global.current_dirpath () in
   let _,a_arrow_b,_ =
-    destLambda(def_of_const (constr_of_monomorphic_global dp func)) in
+    destLambda(def_of_const (constr_of_monomorphic_global dp (Global.env ()) func)) in
   let rev_args,b = decompose_prod_n nb_args a_arrow_b in
   let left =
     mkApp(delayed_force iter_rd,
 	  Array.of_list
 	    (lift 5 a_arrow_b:: mkRel 3::
-               constr_of_monomorphic_global dp func::mkRel 1::
+               constr_of_monomorphic_global dp (Global.env ()) func::mkRel 1::
 	       List.rev (List.map_i (fun i _ -> mkRel (6+i)) 0 rev_args)
 	    )
 	 )
@@ -1076,7 +1076,7 @@ let compute_terminate_type nb_args func =
 		  delayed_force nat,
                   (mkProd (make_annot (Name k_id) Sorts.Relevant, delayed_force nat,
                            mkArrow cond Sorts.Relevant result))))|])in
-  let value = mkApp(constr_of_monomorphic_global dp (Util.delayed_force coq_sig_ref),
+  let value = mkApp(constr_of_monomorphic_global dp (Global.env ()) (Util.delayed_force coq_sig_ref),
 		    [|b;
                       (mkLambda (make_annot (Name v_id) Sorts.Relevant, b, nb_iter))|]) in
   compose_prod rev_args value
@@ -1173,7 +1173,7 @@ let whole_start (concl_tac:tactic) nb_args is_mes func input_type relation rec_a
       let dp = Global.current_dirpath () in
       let sigma = project g in
       let ids = Termops.ids_of_named_context (pf_hyps g) in
-      let func_body = (def_of_const (constr_of_monomorphic_global dp func)) in
+      let func_body = (def_of_const (constr_of_monomorphic_global dp (Global.env ()) func)) in
       let func_body = EConstr.of_constr func_body in
       let (f_name, _, body1) = destLambda sigma func_body in
       let f_id =
@@ -1240,7 +1240,7 @@ let get_current_subgoals_types pstate =
 exception EmptySubgoals
 let build_and_l sigma l =
   let dp = Global.current_dirpath () in
-  let and_constr =  UnivGen.constr_of_monomorphic_global dp @@ Coqlib.lib_ref "core.and.type" in
+  let and_constr =  UnivGen.constr_of_monomorphic_global dp (Global.env ()) @@ Coqlib.lib_ref "core.and.type" in
   let conj_constr = Coqlib.build_coq_conj () in
   let mk_and p1 p2 =
     mkApp(EConstr.of_constr and_constr,[|p1;p2|]) in
@@ -1266,7 +1266,7 @@ let build_and_l sigma l =
 	let c,tac,nb = f pl in
 	mk_and p1 c,
 	tclTHENS
-          (Proofview.V82.of_tactic (apply (EConstr.of_constr (constr_of_monomorphic_global (Global.current_dirpath ()) conj_constr))))
+          (Proofview.V82.of_tactic (apply (EConstr.of_constr (constr_of_monomorphic_global (Global.current_dirpath ()) (Global.env ()) conj_constr))))
 	  [tclIDTAC;
 	   tac
 	  ],nb+1
@@ -1448,7 +1448,7 @@ let start_equation (f:GlobRef.t) (term_f:GlobRef.t)
   (cont_tactic:Id.t list -> tactic) g =
   let sigma = project g in
   let ids = pf_ids_of_hyps g in
-  let terminate_constr = constr_of_monomorphic_global (Global.current_dirpath ()) term_f in
+  let terminate_constr = constr_of_monomorphic_global (Global.current_dirpath ()) (Global.env ()) term_f in
   let terminate_constr = EConstr.of_constr terminate_constr in
   let nargs = nb_prod (project g) (EConstr.of_constr (type_of_const sigma terminate_constr)) in
   let x = n_x_id ids nargs in
@@ -1468,7 +1468,7 @@ let com_eqn sign uctx nb_arg eq_name functional_ref f_ref terminate_ref equation
 	| _ -> anomaly ~label:"terminate_lemma" (Pp.str "not a constant.")
     in
     let evd = Evd.from_ctx uctx in
-    let f_constr = constr_of_monomorphic_global (Global.current_dirpath ()) f_ref in
+    let f_constr = constr_of_monomorphic_global (Global.current_dirpath ()) (Global.env ()) f_ref in
     let equation_lemma_type = subst1 f_constr equation_lemma_type in
     let lemma = Lemmas.start_lemma eq_name (Global ImportDefaultBehavior, false, Proof Lemma) ~sign evd
        (EConstr.of_constr equation_lemma_type) in
@@ -1477,12 +1477,12 @@ let com_eqn sign uctx nb_arg eq_name functional_ref f_ref terminate_ref equation
 	  (fun  x ->
 	     prove_eq (fun _ -> tclIDTAC)
 	       {nb_arg=nb_arg;
-                f_terminate = EConstr.of_constr (constr_of_monomorphic_global (Global.current_dirpath ()) terminate_ref);
+                f_terminate = EConstr.of_constr (constr_of_monomorphic_global (Global.current_dirpath ()) (Global.env ()) terminate_ref);
 	        f_constr = EConstr.of_constr f_constr; 
 		concl_tac = tclIDTAC;
 		func=functional_ref;
 		info=(instantiate_lambda Evd.empty
-                        (EConstr.of_constr (def_of_const (constr_of_monomorphic_global (Global.current_dirpath ()) functional_ref)))
+                        (EConstr.of_constr (def_of_const (constr_of_monomorphic_global (Global.current_dirpath ()) (Global.env ()) functional_ref)))
 	       		(EConstr.of_constr f_constr::List.map mkVar x)
 		);
 		is_main_branch = true;
@@ -1580,9 +1580,9 @@ let recursive_definition ~interactive_proof ~is_mes function_name rec_impls type
     if not stop
     then
       let eq_ref = Nametab.locate (qualid_of_ident equation_id ) in
-      let f_ref = destConst (constr_of_monomorphic_global (Global.current_dirpath ()) f_ref)
-      and functional_ref = destConst (constr_of_monomorphic_global (Global.current_dirpath ()) functional_ref)
-      and eq_ref = destConst (constr_of_monomorphic_global (Global.current_dirpath ()) eq_ref) in
+      let f_ref = destConst (constr_of_monomorphic_global (Global.current_dirpath ()) (Global.env ()) f_ref)
+      and functional_ref = destConst (constr_of_monomorphic_global (Global.current_dirpath ()) (Global.env ()) functional_ref)
+      and eq_ref = destConst (constr_of_monomorphic_global (Global.current_dirpath ()) (Global.env ()) eq_ref) in
       generate_induction_principle f_ref tcc_lemma_constr
         functional_ref eq_ref rec_arg_num
         (EConstr.of_constr rec_arg_type)

--- a/plugins/ltac/evar_tactics.ml
+++ b/plugins/ltac/evar_tactics.ml
@@ -27,8 +27,9 @@ module NamedDecl = Context.Named.Declaration
 (* The instantiate tactic *)
 
 let instantiate_evar evk (ist,rawc) sigma =
+  let env = Global.env () in
   let evi = Evd.find sigma evk in
-  let filtered = Evd.evar_filtered_env evi in
+  let filtered = Evd.evar_filtered_env env evi in
   let constrvars = Tacinterp.extract_ltac_constr_values ist filtered in
   let lvar = {
     ltac_constrs = constrvars;

--- a/plugins/ltac/rewrite.ml
+++ b/plugins/ltac/rewrite.ml
@@ -75,10 +75,11 @@ type evars = evar_map * Evar.Set.t (* goal evars, constraint evars *)
 
 let find_global dir s =
   let dp = Global.current_dirpath () in
+  let env = Global.env () in
   let gr = lazy (find_reference dir s) in
     fun (evd,cstrs) ->
-      let (evd, c) = Evarutil.new_global dp evd (Lazy.force gr) in
-	(evd, cstrs), c
+      let (evd, c) = Evarutil.new_global dp env evd (Lazy.force gr) in
+      (evd, cstrs), c
 
 (** Utility for dealing with polymorphic applications *)
 
@@ -187,14 +188,16 @@ end) = struct
 
   let proper_type env (sigma,cstrs) =
     let dp = Global.current_dirpath () in
+    let env = Global.env () in
     let l = (proper_class env sigma).cl_impl in
-    let (sigma, c) = Evarutil.new_global dp sigma l in
+    let (sigma, c) = Evarutil.new_global dp env sigma l in
     (sigma, cstrs), c
 
   let proper_proxy_type env (sigma,cstrs) =
     let dp = Global.current_dirpath () in
+    let env = Global.env () in
     let l = (proper_proxy_class env sigma).cl_impl in
-    let (sigma, c) = Evarutil.new_global dp sigma l in
+    let (sigma, c) = Evarutil.new_global dp env sigma l in
     (sigma, cstrs), c
 
   let proper_proof env evars carrier relation x =
@@ -758,7 +761,8 @@ let get_opt_rew_rel = function RewPrf (rel, prf) -> Some rel | _ -> None
 
 let new_global (evars, cstrs) gr =
   let dp = Global.current_dirpath () in
-  let (sigma,c) = Evarutil.new_global dp evars gr in
+  let env = Global.env () in
+  let (sigma,c) = Evarutil.new_global dp env evars gr in
   (sigma, cstrs), c
 
 let make_eq sigma =

--- a/plugins/micromega/coq_micromega.ml
+++ b/plugins/micromega/coq_micromega.ml
@@ -207,7 +207,7 @@ struct
     * ZMicromega.v
     *)
 
-  let gen_constant_in_modules s m n = EConstr.of_constr (UnivGen.constr_of_monomorphic_global @@ Coqlib.gen_reference_in_modules s m n)
+  let gen_constant_in_modules s m n = EConstr.of_constr (UnivGen.constr_of_monomorphic_global (Global.current_dirpath ()) @@ Coqlib.gen_reference_in_modules s m n)
   let init_constant = gen_constant_in_modules "ZMicromega" Coqlib.init_modules
   [@@@ocaml.warning "+3"]
 

--- a/plugins/micromega/coq_micromega.ml
+++ b/plugins/micromega/coq_micromega.ml
@@ -207,7 +207,8 @@ struct
     * ZMicromega.v
     *)
 
-  let gen_constant_in_modules s m n = EConstr.of_constr (UnivGen.constr_of_monomorphic_global (Global.current_dirpath ()) @@ Coqlib.gen_reference_in_modules s m n)
+  let gen_constant_in_modules s m n =
+    EConstr.of_constr (UnivGen.constr_of_monomorphic_global (Global.current_dirpath ()) (Global.env ()) @@ Coqlib.gen_reference_in_modules s m n)
   let init_constant = gen_constant_in_modules "ZMicromega" Coqlib.init_modules
   [@@@ocaml.warning "+3"]
 

--- a/plugins/nsatz/nsatz.ml
+++ b/plugins/nsatz/nsatz.ml
@@ -135,7 +135,7 @@ let mul = function
   | (Const n,q) when eq_num n num_1 -> q
   | (p,q) -> Mul(p,q)
 
-let gen_constant n = lazy (UnivGen.constr_of_monomorphic_global (Global.current_dirpath ()) (Coqlib.lib_ref n))
+let gen_constant n = lazy (UnivGen.constr_of_monomorphic_global (Global.current_dirpath ()) (Global.env ()) (Coqlib.lib_ref n))
 
 let tpexpr  = gen_constant "plugins.setoid_ring.pexpr"
 let ttconst = gen_constant "plugins.setoid_ring.const"
@@ -540,7 +540,7 @@ let nsatz lpol =
 
 let return_term t =
   let a =
-    mkApp (UnivGen.constr_of_monomorphic_global (Global.current_dirpath ()) @@ Coqlib.lib_ref "core.eq.refl",[|tllp ();t|]) in
+    mkApp (Lazy.force (gen_constant "core.eq.refl"),[|tllp ();t|]) in
   let a = EConstr.of_constr a in
   generalize [a]
 

--- a/plugins/nsatz/nsatz.ml
+++ b/plugins/nsatz/nsatz.ml
@@ -135,7 +135,7 @@ let mul = function
   | (Const n,q) when eq_num n num_1 -> q
   | (p,q) -> Mul(p,q)
 
-let gen_constant n = lazy (UnivGen.constr_of_monomorphic_global (Coqlib.lib_ref n))
+let gen_constant n = lazy (UnivGen.constr_of_monomorphic_global (Global.current_dirpath ()) (Coqlib.lib_ref n))
 
 let tpexpr  = gen_constant "plugins.setoid_ring.pexpr"
 let ttconst = gen_constant "plugins.setoid_ring.const"
@@ -540,7 +540,7 @@ let nsatz lpol =
 
 let return_term t =
   let a =
-    mkApp (UnivGen.constr_of_monomorphic_global @@ Coqlib.lib_ref "core.eq.refl",[|tllp ();t|]) in
+    mkApp (UnivGen.constr_of_monomorphic_global (Global.current_dirpath ()) @@ Coqlib.lib_ref "core.eq.refl",[|tllp ();t|]) in
   let a = EConstr.of_constr a in
   generalize [a]
 

--- a/plugins/omega/coq_omega.ml
+++ b/plugins/omega/coq_omega.ml
@@ -187,7 +187,7 @@ let reset_all () =
  To use the constant Zplus, one must type "Lazy.force coq_Zplus"
  This is the right way to access to Coq constants in tactics ML code *)
 
-let gen_constant k = lazy (k |> Coqlib.lib_ref |> UnivGen.constr_of_monomorphic_global (Global.current_dirpath ())
+let gen_constant k = lazy (k |> Coqlib.lib_ref |> UnivGen.constr_of_monomorphic_global (Global.current_dirpath ()) (Global.env ())
                            |> EConstr.of_constr)
 
 

--- a/plugins/omega/coq_omega.ml
+++ b/plugins/omega/coq_omega.ml
@@ -187,7 +187,7 @@ let reset_all () =
  To use the constant Zplus, one must type "Lazy.force coq_Zplus"
  This is the right way to access to Coq constants in tactics ML code *)
 
-let gen_constant k = lazy (k |> Coqlib.lib_ref |> UnivGen.constr_of_monomorphic_global
+let gen_constant k = lazy (k |> Coqlib.lib_ref |> UnivGen.constr_of_monomorphic_global (Global.current_dirpath ())
                            |> EConstr.of_constr)
 
 

--- a/plugins/rtauto/refl_tauto.ml
+++ b/plugins/rtauto/refl_tauto.ml
@@ -26,11 +26,11 @@ let step_count = ref 0
 
 let node_count = ref 0
 
-let li_False = lazy (destInd (UnivGen.constr_of_monomorphic_global @@ Coqlib.lib_ref "core.False.type"))
-let li_and   = lazy (destInd (UnivGen.constr_of_monomorphic_global @@ Coqlib.lib_ref "core.and.type"))
-let li_or    = lazy (destInd (UnivGen.constr_of_monomorphic_global @@ Coqlib.lib_ref "core.or.type"))
+let li_False = lazy (destInd (UnivGen.constr_of_monomorphic_global (Global.current_dirpath ()) @@ Coqlib.lib_ref "core.False.type"))
+let li_and   = lazy (destInd (UnivGen.constr_of_monomorphic_global (Global.current_dirpath ()) @@ Coqlib.lib_ref "core.and.type"))
+let li_or    = lazy (destInd (UnivGen.constr_of_monomorphic_global (Global.current_dirpath ()) @@ Coqlib.lib_ref "core.or.type"))
 
-let gen_constant n = lazy (UnivGen.constr_of_monomorphic_global (Coqlib.lib_ref n))
+let gen_constant n = lazy (UnivGen.constr_of_monomorphic_global (Global.current_dirpath ()) (Coqlib.lib_ref n))
 
 let l_xI = gen_constant "num.pos.xI"
 let l_xO = gen_constant "num.pos.xO"

--- a/plugins/rtauto/refl_tauto.ml
+++ b/plugins/rtauto/refl_tauto.ml
@@ -26,11 +26,12 @@ let step_count = ref 0
 
 let node_count = ref 0
 
-let li_False = lazy (destInd (UnivGen.constr_of_monomorphic_global (Global.current_dirpath ()) @@ Coqlib.lib_ref "core.False.type"))
-let li_and   = lazy (destInd (UnivGen.constr_of_monomorphic_global (Global.current_dirpath ()) @@ Coqlib.lib_ref "core.and.type"))
-let li_or    = lazy (destInd (UnivGen.constr_of_monomorphic_global (Global.current_dirpath ()) @@ Coqlib.lib_ref "core.or.type"))
+let gen_constant n = lazy (UnivGen.constr_of_monomorphic_global (Global.current_dirpath ()) (Global.env ()) (Coqlib.lib_ref n))
+let mk_refind s = lazy (destInd (Lazy.force (gen_constant s)))
 
-let gen_constant n = lazy (UnivGen.constr_of_monomorphic_global (Global.current_dirpath ()) (Coqlib.lib_ref n))
+let li_False = mk_refind "core.False.type"
+let li_and   = mk_refind "core.and.type"
+let li_or    = mk_refind "core.or.type"
 
 let l_xI = gen_constant "num.pos.xI"
 let l_xO = gen_constant "num.pos.xO"

--- a/plugins/setoid_ring/newring.ml
+++ b/plugins/setoid_ring/newring.ml
@@ -208,7 +208,7 @@ let exec_tactic env evd n f args =
   let nf c = constr_of evd c in
   Array.map nf !tactic_res, Evd.universe_context_set evd
 
-let gen_constant n = lazy (EConstr.of_constr (UnivGen.constr_of_monomorphic_global (Global.current_dirpath ()) (Coqlib.lib_ref n)))
+let gen_constant n = lazy (EConstr.of_constr (UnivGen.constr_of_monomorphic_global (Global.current_dirpath ()) (Global.env ()) (Coqlib.lib_ref n)))
 let gen_reference n = lazy (Coqlib.lib_ref n)
 
 let coq_mk_Setoid = gen_constant "plugins.setoid_ring.Build_Setoid_Theory"
@@ -254,7 +254,7 @@ let plugin_modules =
     ]
 
 let my_constant c =
-  lazy (EConstr.of_constr (UnivGen.constr_of_monomorphic_global (Global.current_dirpath ()) @@ Coqlib.gen_reference_in_modules "Ring" plugin_modules c))
+  lazy (EConstr.of_constr (UnivGen.constr_of_monomorphic_global (Global.current_dirpath ()) (Global.env ()) @@ Coqlib.gen_reference_in_modules "Ring" plugin_modules c))
     [@@ocaml.warning "-3"]
 let my_reference c =
   lazy (Coqlib.gen_reference_in_modules "Ring" plugin_modules c)
@@ -925,7 +925,7 @@ let ftheory_to_obj : field_info -> obj =
 let field_equality evd r inv req =
   match EConstr.kind !evd req with
     | App (f, [| _ |]) when eq_constr_nounivs !evd f (Lazy.force coq_eq) ->
-        let c = UnivGen.constr_of_monomorphic_global (Global.current_dirpath ()) Coqlib.(lib_ref "core.eq.congr") in
+        let c = UnivGen.constr_of_monomorphic_global (Global.current_dirpath ()) (Global.env ()) Coqlib.(lib_ref "core.eq.congr") in
         let c = EConstr.of_constr c in
         mkApp(c,[|r;r;inv|])
     | _ ->

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -53,7 +53,7 @@ let hyp_id (SsrHyp (_, id)) = id
 let hyp_err ?loc msg id =
   CErrors.user_err ?loc ~hdr:"ssrhyp" Pp.(str msg ++ Id.print id)
 
-let not_section_id id = not (Termops.is_section_variable id)
+let not_section_id id = not (Termops.is_section_variable (Global.env ()) id)
 
 let hyps_ids = List.map hyp_id
 

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -1164,7 +1164,7 @@ let genclrtac cl cs clr =
       (fun type_err gl ->
          tclTHEN
            (tclTHEN (Proofview.V82.of_tactic (Tactics.elim_type (EConstr.of_constr
-             (UnivGen.constr_of_monomorphic_global dp @@ Coqlib.(lib_ref "core.False.type"))))) (old_cleartac clr))
+             (UnivGen.constr_of_monomorphic_global dp (Global.env ()) @@ Coqlib.(lib_ref "core.False.type"))))) (old_cleartac clr))
            (fun gl -> raise type_err)
            gl))
     (old_cleartac clr)

--- a/plugins/ssr/ssrequality.ml
+++ b/plugins/ssr/ssrequality.ml
@@ -447,7 +447,7 @@ let lz_setoid_relation =
   | _ ->
     let srel =
       let dp = Global.current_dirpath () in
-       try Some (UnivGen.constr_of_monomorphic_global dp @@
+       try Some (UnivGen.constr_of_monomorphic_global dp (Global.env ()) @@
                  Coqlib.find_reference "Class_setoid" ("Coq"::sdir) "RewriteRelation" [@ocaml.warning "-3"])
        with _ -> None in
     last_srel := Some (env, srel); srel
@@ -493,7 +493,7 @@ let rwprocess_rule dir rule gl =
           | _ ->
             let sigma, pi2 = Evd.fresh_global dp env sigma coq_prod.Coqlib.proj2 in
             EConstr.mkApp (pi2, ra), sigma in
-        if EConstr.eq_constr sigma a.(0) (EConstr.of_constr (UnivGen.constr_of_monomorphic_global dp @@ Coqlib.(lib_ref "core.True.type"))) then
+        if EConstr.eq_constr sigma a.(0) (EConstr.of_constr (UnivGen.constr_of_monomorphic_global dp (Global.env ()) @@ Coqlib.(lib_ref "core.True.type"))) then
          let s, sigma = sr sigma 2 in
          loop (converse_dir d) sigma s a.(1) rs 0
         else

--- a/plugins/ssr/ssrequality.ml
+++ b/plugins/ssr/ssrequality.ml
@@ -446,7 +446,8 @@ let lz_setoid_relation =
   | Some (env', srel) when env' == env -> srel
   | _ ->
     let srel =
-       try Some (UnivGen.constr_of_monomorphic_global @@
+      let dp = Global.current_dirpath () in
+       try Some (UnivGen.constr_of_monomorphic_global dp @@
                  Coqlib.find_reference "Class_setoid" ("Coq"::sdir) "RewriteRelation" [@ocaml.warning "-3"])
        with _ -> None in
     last_srel := Some (env, srel); srel
@@ -466,6 +467,7 @@ let closed0_check cl p gl =
 let dir_org = function L2R -> 1 | R2L -> 2
 
 let rwprocess_rule dir rule gl =
+  let dp = Global.current_dirpath () in
   let env = pf_env gl in
   let coq_prod = lz_coq_prod () in
   let is_setoid = ssr_is_setoid env in
@@ -486,12 +488,12 @@ let rwprocess_rule dir rule gl =
           fun i -> ra.(i + 1), sigma
         | _ -> let ra = Array.append a [|r|] in
           function 1 ->
-            let sigma, pi1 = Evd.fresh_global env sigma coq_prod.Coqlib.proj1 in
+            let sigma, pi1 = Evd.fresh_global dp env sigma coq_prod.Coqlib.proj1 in
             EConstr.mkApp (pi1, ra), sigma
           | _ ->
-            let sigma, pi2 = Evd.fresh_global env sigma coq_prod.Coqlib.proj2 in
+            let sigma, pi2 = Evd.fresh_global dp env sigma coq_prod.Coqlib.proj2 in
             EConstr.mkApp (pi2, ra), sigma in
-        if EConstr.eq_constr sigma a.(0) (EConstr.of_constr (UnivGen.constr_of_monomorphic_global @@ Coqlib.(lib_ref "core.True.type"))) then
+        if EConstr.eq_constr sigma a.(0) (EConstr.of_constr (UnivGen.constr_of_monomorphic_global dp @@ Coqlib.(lib_ref "core.True.type"))) then
          let s, sigma = sr sigma 2 in
          loop (converse_dir d) sigma s a.(1) rs 0
         else

--- a/pretyping/coercion.ml
+++ b/pretyping/coercion.ml
@@ -147,7 +147,7 @@ let mu env evdref t =
 	let p = hnf_nodelta env !evdref p in
 	  (Some (fun x ->
 		   app_opt env evdref 
-                     f (papp dp evdref sig_proj1 [| u; p; x |])),
+                     f (papp dp env evdref sig_proj1 [| u; p; x |])),
 	   ct)
       | None -> (None, v)
   in aux t
@@ -193,9 +193,9 @@ and coerce ?loc env evdref (x : EConstr.constr) (y : EConstr.constr)
 		in
 		let args = List.rev (restargs @ mkRel 1 :: List.map (lift 1) tele) in
                 let pred = mkLambda (n, eqT, applist (lift 1 c, args)) in
-                let eq = papp dp evdref coq_eq_ind [| eqT; hdx; hdy |] in
+                let eq = papp dp env evdref coq_eq_ind [| eqT; hdx; hdy |] in
                 let evar = make_existential ?loc n.binder_name env evdref eq in
-                let eq_app x = papp dp evdref coq_eq_rect
+                let eq_app x = papp dp env evdref coq_eq_rect
 		  [| eqT; hdx; pred; x; hdy; evar|] 
 		in
 		  aux (hdy :: tele) (subst1 hdx restT) 
@@ -284,12 +284,12 @@ and coerce ?loc env evdref (x : EConstr.constr) (y : EConstr.constr)
 			   Some
 			     (fun x ->
 				let x, y =
-                                  app_opt env' evdref c1 (papp dp evdref sigT_proj1
+                                  app_opt env' evdref c1 (papp dp env evdref sigT_proj1
 							    [| a; pb; x |]),
-                                  app_opt env' evdref c2 (papp dp evdref sigT_proj2
+                                  app_opt env' evdref c2 (papp dp env evdref sigT_proj2
 							  [| a; pb; x |])
 				in
-                                  papp dp evdref sigT_intro [| a'; pb'; x ; y |])
+                                  papp dp env evdref sigT_intro [| a'; pb'; x ; y |])
 		   end
 		 else
 		   begin
@@ -304,12 +304,12 @@ and coerce ?loc env evdref (x : EConstr.constr) (y : EConstr.constr)
 			   Some
 			     (fun x ->
 				let x, y =
-                                  app_opt env evdref c1 (papp dp evdref prod_proj1
+                                  app_opt env evdref c1 (papp dp env evdref prod_proj1
 							   [| a; b; x |]),
-                                  app_opt env evdref c2 (papp dp evdref prod_proj2
+                                  app_opt env evdref c2 (papp dp env evdref prod_proj2
 							   [| a; b; x |])
 				in
-                                  papp dp evdref prod_intro [| a'; b'; x ; y |])
+                                  papp dp env evdref prod_intro [| a'; b'; x ; y |])
 		   end
 	       else
 		 if eq_ind i i' && Int.equal len (Array.length l') then
@@ -337,7 +337,7 @@ and coerce ?loc env evdref (x : EConstr.constr) (y : EConstr.constr)
     Some (u, p) ->
       let c = coerce_unify env u y in
       let f x =
-        app_opt env evdref c (papp dp evdref sig_proj1 [| u; p; x |])
+        app_opt env evdref c (papp dp env evdref sig_proj1 [| u; p; x |])
       in Some f
     | None ->
 	match disc_subset !evdref y with
@@ -348,7 +348,7 @@ and coerce ?loc env evdref (x : EConstr.constr) (y : EConstr.constr)
 		 let cx = app_opt env evdref c x in
 		 let evar = make_existential ?loc Anonymous env evdref (mkApp (p, [| cx |]))
 		 in
-                   (papp dp evdref sig_intro [| u; p; cx; evar |]))
+                   (papp dp env evdref sig_intro [| u; p; cx; evar |]))
 	| None ->
 	    raise NoSubtacCoercion
   in coerce_unify env x y
@@ -380,7 +380,7 @@ let apply_coercion env sigma p hj typ_cl =
            let isid = i.coe_is_identity in
            let isproj = i.coe_is_projection in
            let dp = Global.current_dirpath () in
-           let sigma, c = new_global dp sigma i.coe_value in
+           let sigma, c = new_global dp env sigma i.coe_value in
            let typ = Retyping.get_type_of env sigma c in
            let fv = make_judge c typ in
 	  let argl = (class_args_of env sigma typ_cl)@[ja.uj_val] in

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -807,7 +807,7 @@ and detype_r d flags avoid env sigma t =
       let id,l =
         try
           let id = match Evd.evar_ident evk sigma with
-          | None -> Termops.evar_suggested_name evk sigma
+          | None -> Termops.evar_suggested_name (Global.env ()) evk sigma
           | Some id -> id
           in
           let l = Evd.evar_instance_array bound_to_itself_or_letin (Evd.find sigma evk) cl in

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -1338,8 +1338,10 @@ let second_order_matching flags env_rhs evd (evk,args) (test,argoccs) rhs =
   try
   let evi = Evd.find_undefined evd evk in
   let evi = nf_evar_info evd evi in
-  let env_evar_unf = evar_env evi in
-  let env_evar = evar_filtered_env evi in
+  (* XXX why not env? *)
+  let genv = Global.env () in
+  let env_evar_unf = evar_env genv evi in
+  let env_evar = evar_filtered_env genv evi in
   let sign = named_context_val env_evar in
   let ctxt = evar_filtered_context evi in
   if !debug_ho_unification then
@@ -1483,7 +1485,7 @@ let second_order_matching flags env_rhs evd (evk,args) (test,argoccs) rhs =
          else
            ((if !debug_ho_unification then
                let evi = Evd.find evd evk in
-               let env = Evd.evar_env evi in
+               let env = Evd.evar_env genv evi in
                Feedback.msg_debug Pp.(str"evar is defined: " ++
                  int (Evar.repr evk) ++ spc () ++
                  prc env evd (match evar_body evi with Evar_defined c -> c
@@ -1499,7 +1501,7 @@ let second_order_matching flags env_rhs evd (evk,args) (test,argoccs) rhs =
        (if !debug_ho_unification then
           begin
             let evi = Evd.find evd evk in
-            let evenv = evar_env evi in
+            let evenv = evar_env genv evi in
             let body = match evar_body evi with Evar_empty -> assert false | Evar_defined c -> c in
             Feedback.msg_debug Pp.(str"evar was defined already as: " ++ prc evenv evd body)
           end;
@@ -1507,7 +1509,7 @@ let second_order_matching flags env_rhs evd (evk,args) (test,argoccs) rhs =
      else
        try
          let evi = Evd.find_undefined evd evk in
-         let evenv = evar_env evi in
+         let evenv = evar_env genv evi in
          let rhs' = nf_evar evd rhs' in
            if !debug_ho_unification then
              Feedback.msg_debug Pp.(str"abstracted type before second solve_evars: " ++

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -71,8 +71,9 @@ let () = Goptions.(declare_bool_option {
 (* Functions to deal with impossible cases *)
 (*******************************************)
 let impossible_default_case env =
+  let dp = Global.current_dirpath () in
   let type_of_id = Coqlib.lib_ref "core.IDProp.type" in
-  let c, ctx = UnivGen.fresh_global_instance env (Coqlib.(lib_ref "core.IDProp.idProp")) in
+  let c, ctx = UnivGen.fresh_global_instance dp env (Coqlib.(lib_ref "core.IDProp.idProp")) in
   let (_, u) = Constr.destRef c in
   Some (c, Constr.mkRef (type_of_id, u), ctx)
 
@@ -297,7 +298,8 @@ let check_conv_record env sigma (t1,sk1) (t2,sk2) =
       else match (Stack.strip_n_app (l_us-1) sk2_effective) with
       | None -> raise Not_found
       | Some (l',el,s') -> (l'@Stack.append_app [|el|] Stack.empty,s') in
-  let u, ctx' = UnivGen.fresh_instance_from ctx None in
+  let dp = Global.current_dirpath () in
+  let u, ctx' = UnivGen.fresh_instance_from dp ctx None in
   let subst = Univ.make_inverse_instance_subst u in
   let c = EConstr.of_constr c in
   let c' = subst_univs_level_constr subst c in

--- a/pretyping/evardefine.ml
+++ b/pretyping/evardefine.ml
@@ -82,8 +82,9 @@ let define_pure_evar_as_product env evd evk =
   let s = destSort evd concl in
   let evksrc = evar_source evk evd in
   let src = subterm_source evk ~where:Domain evksrc in
+  let dp = Global.current_dirpath () in
   let evd1,(dom,u1) =
-    new_type_evar evenv evd univ_flexible_alg ~src ~filter:(evar_filter evi)
+    new_type_evar dp evenv evd univ_flexible_alg ~src ~filter:(evar_filter evi)
   in
   let rdom = Sorts.Relevant in (* TODO relevance *)
   let evd2,rng =
@@ -96,7 +97,7 @@ let define_pure_evar_as_product env evd evk =
       else
 	let status = univ_flexible_alg in
 	let evd3, (rng, srng) =
-          new_type_evar newenv evd1 status ~src ~filter
+          new_type_evar dp newenv evd1 status ~src ~filter
         in
 	let prods = Univ.sup (univ_of_sort u1) (univ_of_sort srng) in
         let evd3 = Evd.set_leq_sort evenv evd3 (Sorts.sort_of_univ prods) (ESorts.kind evd1 s) in
@@ -168,7 +169,8 @@ let rec evar_absorb_arguments env evd (evk,args as ev) = function
 (* Refining an evar to a sort *)
 
 let define_evar_as_sort env evd (ev,args) =
-  let evd, s = new_sort_variable univ_rigid evd in
+  let dp = Global.current_dirpath () in
+  let evd, s = new_sort_variable dp univ_rigid evd in
   let evi = Evd.find_undefined evd ev in 
   let concl = Reductionops.whd_all (evar_env evi) evd evi.evar_concl in
   let sort = destSort evd concl in

--- a/pretyping/evardefine.ml
+++ b/pretyping/evardefine.ml
@@ -76,7 +76,9 @@ let idx = Namegen.default_dependent_ident
 let define_pure_evar_as_product env evd evk =
   let open Context.Named.Declaration in
   let evi = Evd.find_undefined evd evk in
-  let evenv = evar_env evi in
+  (* XXX why not env ? *)
+  let genv = Global.env () in
+  let evenv = evar_env genv evi in
   let id = next_ident_away idx (Environ.ids_of_named_context_val evi.evar_hyps) in
   let concl = Reductionops.whd_all evenv evd evi.evar_concl in
   let s = destSort evd concl in
@@ -130,7 +132,9 @@ let define_evar_as_product env evd (evk,args) =
 let define_pure_evar_as_lambda env evd evk =
   let open Context.Named.Declaration in
   let evi = Evd.find_undefined evd evk in
-  let evenv = evar_env evi in
+  (* XXX why not env ? *)
+  let genv = Global.env () in
+  let evenv = evar_env genv evi in
   let typ = Reductionops.whd_all evenv evd (evar_concl evi) in
   let evd1,(na,dom,rng) = match EConstr.kind evd typ with
   | Prod (na,dom,rng) -> (evd,(na,dom,rng))
@@ -171,8 +175,10 @@ let rec evar_absorb_arguments env evd (evk,args as ev) = function
 let define_evar_as_sort env evd (ev,args) =
   let dp = Global.current_dirpath () in
   let evd, s = new_sort_variable dp univ_rigid evd in
-  let evi = Evd.find_undefined evd ev in 
-  let concl = Reductionops.whd_all (evar_env evi) evd evi.evar_concl in
+  let evi = Evd.find_undefined evd ev in
+  (* XXX why not env ? *)
+  let genv = Global.env () in
+  let concl = Reductionops.whd_all (evar_env genv evi) evd evi.evar_concl in
   let sort = destSort evd concl in
   let evd' = Evd.define ev (mkSort s) evd in
   Evd.set_leq_sort env evd' (Sorts.super s) (ESorts.kind evd' sort), s

--- a/pretyping/evarsolve.ml
+++ b/pretyping/evarsolve.ml
@@ -89,7 +89,8 @@ let refresh_universes ?(status=univ_rigid) ?(onlyalg=false) ?(refreshset=false)
   (* direction: true for fresh universes lower than the existing ones *)
   let refresh_sort status ~direction s =
     let s = ESorts.kind !evdref s in
-    let sigma, s' = new_sort_variable status !evdref in
+    let dp = Global.current_dirpath () in
+    let sigma, s' = new_sort_variable dp status !evdref in
     evdref := sigma;
     let evd = 
       if direction then set_leq_sort env !evdref s' s
@@ -1349,7 +1350,8 @@ let solve_evar_evar ?(force=false) f unify flags env evd pbty (evk1,args1 as ev1
           let t1 = it_mkProd_or_LetIn (mkSort j) ctx1 in
           downcast evk1 t1 evd
 	else
-	  let evd, k = Evd.new_sort_variable univ_flexible_alg evd in
+          let dp = Global.current_dirpath () in
+          let evd, k = Evd.new_sort_variable dp univ_flexible_alg evd in
           let t1 = it_mkProd_or_LetIn (mkSort k) ctx1 in
           let t2 = it_mkProd_or_LetIn (mkSort k) ctx2 in
 	  let evd = Evd.set_leq_sort env (Evd.set_leq_sort env evd k i) k j in

--- a/pretyping/globEnv.ml
+++ b/pretyping/globEnv.ml
@@ -105,7 +105,8 @@ let new_evar env sigma ?src ?naming typ =
   new_evar_instance sign sigma typ' ?src ?naming instance
 
 let new_type_evar env sigma ~src =
-  let sigma, s = Evd.new_sort_variable Evd.univ_flexible_alg sigma in
+  let dp = Global.current_dirpath () in
+  let sigma, s = Evd.new_sort_variable dp Evd.univ_flexible_alg sigma in
   new_evar env sigma ~src (EConstr.mkSort s)
 
 let hide_variable env expansion id =

--- a/pretyping/globEnv.ml
+++ b/pretyping/globEnv.ml
@@ -41,7 +41,7 @@ type t = {
 let make ~hypnaming env sigma lvar =
   let get_extra env sigma =
     let avoid = Environ.ids_of_named_context_val (Environ.named_context_val env) in
-    Context.Rel.fold_outside (fun d acc -> push_rel_decl_to_named_context ~hypnaming sigma d acc)
+    Context.Rel.fold_outside (fun d acc -> push_rel_decl_to_named_context ~hypnaming env sigma d acc)
       (rel_context env) ~init:(empty_csubst, avoid, named_context env) in
   {
     static_env = env;
@@ -71,7 +71,7 @@ let push_rel ~hypnaming sigma d env =
   let env = {
     static_env = push_rel d env.static_env;
     renamed_env = push_rel d' env.renamed_env;
-    extra = lazy (push_rel_decl_to_named_context ~hypnaming:hypnaming sigma d' (Lazy.force env.extra));
+    extra = lazy (push_rel_decl_to_named_context ~hypnaming:hypnaming (Global.env ()) sigma d' (Lazy.force env.extra));
     lvar = env.lvar;
     } in
   d', env
@@ -83,7 +83,7 @@ let push_rel_context ~hypnaming ?(force_names=false) sigma ctx env =
   let env = {
     static_env = push_rel_context ctx env.static_env;
     renamed_env = push_rel_context ctx' env.renamed_env;
-    extra = lazy (List.fold_right (fun d acc -> push_rel_decl_to_named_context ~hypnaming:hypnaming sigma d acc) ctx' (Lazy.force env.extra));
+    extra = lazy (List.fold_right (fun d acc -> push_rel_decl_to_named_context ~hypnaming:hypnaming (Global.env ()) sigma d acc) ctx' (Lazy.force env.extra));
     lvar = env.lvar;
     } in
   ctx', env

--- a/pretyping/indrec.ml
+++ b/pretyping/indrec.ml
@@ -84,10 +84,11 @@ let mis_make_case_com dep env sigma (ind, u as pind) (mib,mip as specif) kind =
 
   let () = if Option.is_empty projs then check_privacy_block mib in
   let () = 
+    let dp = Global.current_dirpath () in
     if not (Sorts.family_leq kind (elim_sort specif)) then
       raise
 	(RecursionSchemeError
-           (env, NotAllowedCaseAnalysis (false, fst (UnivGen.fresh_sort_in_family kind), pind)))
+           (env, NotAllowedCaseAnalysis (false, fst (UnivGen.fresh_sort_in_family dp kind), pind)))
   in
   let ndepar = mip.mind_nrealdecls + 1 in
 
@@ -139,7 +140,8 @@ let mis_make_case_com dep env sigma (ind, u as pind) (mib,mip as specif) kind =
       mkLambda_string "f" relevance t
         (add_branch (push_rel (LocalAssum (make_annot Anonymous relevance, t)) env) (k+1))
   in
-  let (sigma, s) = Evd.fresh_sort_in_family ~rigid:Evd.univ_flexible_alg sigma kind in
+  let dp = Global.current_dirpath () in
+  let (sigma, s) = Evd.fresh_sort_in_family ~rigid:Evd.univ_flexible_alg dp sigma kind in
   let typP = make_arity env' sigma dep indf s in
   let typP = EConstr.Unsafe.to_constr typP in
   let c = 
@@ -463,9 +465,10 @@ let mis_make_indrec env sigma ?(force_mutual=false) listdepkind mib u =
     in
     let rec put_arity env i = function
       | ((indi,u),_,_,dep,kinds)::rest ->
+          let dp = Global.current_dirpath () in
 	  let indf = make_ind_family ((indi,u), Context.Rel.to_extended_list mkRel i lnamesparrec) in
-	  let s = 
-            let sigma, res = Evd.fresh_sort_in_family ~rigid:Evd.univ_flexible_alg !evdref kinds in
+          let s =
+            let sigma, res = Evd.fresh_sort_in_family ~rigid:Evd.univ_flexible_alg dp !evdref kinds in
             evdref := sigma; res
 	  in
 	  let typP = make_arity env !evdref dep indf s in
@@ -558,9 +561,10 @@ let check_arities env listdepkind =
   let _ = List.fold_left
     (fun ln (((_,ni as mind),u),mibi,mipi,dep,kind) ->
        let kelim = elim_sort (mibi,mipi) in
+       let dp = Global.current_dirpath () in
        if not (Sorts.family_leq kind kelim) then raise
 	 (RecursionSchemeError
-          (env, NotAllowedCaseAnalysis (true, fst (UnivGen.fresh_sort_in_family kind),(mind,u))))
+          (env, NotAllowedCaseAnalysis (true, fst (UnivGen.fresh_sort_in_family dp kind),(mind,u))))
        else if Int.List.mem ni ln then raise
          (RecursionSchemeError (env, NotMutualInScheme (mind,mind)))
        else ni::ln)

--- a/pretyping/inductiveops.ml
+++ b/pretyping/inductiveops.ml
@@ -669,7 +669,8 @@ let rec instantiate_universes env evdref scl is = function
           scl (* constrained sort: replace by scl *)
         else
           (* unconstrained sort: replace by fresh universe *)
-          let evm, s = Evd.new_sort_variable Evd.univ_flexible !evdref in
+          let dp = Global.current_dirpath () in
+          let evm, s = Evd.new_sort_variable dp Evd.univ_flexible !evdref in
           let evm = Evd.set_leq_sort env evm s (Sorts.sort_of_univ u) in
             evdref := evm; s
       in

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -1043,7 +1043,7 @@ and pretype_instance ~program_mode ~poly resolve_tc env sigma loc hyps evk updat
       | Some b, Some c ->
          if not (is_conv !!env sigma b c) then
            user_err ?loc  (str "Cannot interpret " ++
-             pr_existential_key sigma evk ++
+             pr_existential_key (Global.env ()) sigma evk ++
              strbrk " in current context: binding for " ++ Id.print id ++
              strbrk " is not convertible to its expected definition (cannot unify " ++
              quote (Termops.Internal.print_constr_env !!env sigma b) ++
@@ -1052,14 +1052,14 @@ and pretype_instance ~program_mode ~poly resolve_tc env sigma loc hyps evk updat
              str ").")
       | Some b, None ->
            user_err ?loc  (str "Cannot interpret " ++
-             pr_existential_key sigma evk ++
+             pr_existential_key (Global.env ()) sigma evk ++
              strbrk " in current context: " ++ Id.print id ++
              strbrk " should be bound to a local definition.")
       | None, _ -> () in
     let check_type sigma id t' =
       if not (is_conv !!env sigma t t') then
         user_err ?loc  (str "Cannot interpret " ++
-          pr_existential_key sigma evk ++
+          pr_existential_key (Global.env ()) sigma evk ++
           strbrk " in current context: binding for " ++ Id.print id ++
           strbrk " is not well-typed.") in
     let sigma, c, update =
@@ -1082,7 +1082,7 @@ and pretype_instance ~program_mode ~poly resolve_tc env sigma loc hyps evk updat
         sigma, mkVar id, update
       with Not_found ->
         user_err ?loc  (str "Cannot interpret " ++
-          pr_existential_key sigma evk ++
+          pr_existential_key (Global.env ()) sigma evk ++
           str " in current context: no binding for " ++ Id.print id ++ str ".") in
     ((id,c)::subst, update, sigma) in
   let subst,inst,sigma = List.fold_right f hyps ([],update,sigma) in

--- a/pretyping/program.ml
+++ b/pretyping/program.ml
@@ -11,10 +11,10 @@
 open CErrors
 open Util
 
-let papp evdref r args = 
+let papp dp evdref r args =
   let open EConstr in
   let gr = delayed_force r in
-  let evd, hd = Evarutil.new_global !evdref gr in
+  let evd, hd = Evarutil.new_global dp !evdref gr in
   evdref := evd;
   mkApp (hd, args)
 
@@ -38,8 +38,8 @@ let coq_eq_refl     () = Coqlib.lib_ref "core.eq.refl"
 let coq_eq_refl_ref () = Coqlib.lib_ref "core.eq.refl"
 let coq_eq_rect     () = Coqlib.lib_ref "core.eq.rect"
 
-let mk_coq_not sigma x =
-  let sigma, notc = Evarutil.new_global sigma Coqlib.(lib_ref "core.not.type") in
+let mk_coq_not dp sigma x =
+  let sigma, notc = Evarutil.new_global dp sigma Coqlib.(lib_ref "core.not.type") in
   sigma, EConstr.mkApp (notc, [| x |])
 
 let coq_JMeq_ind  () =
@@ -55,8 +55,8 @@ let unsafe_fold_right f = function
     hd :: tl -> List.fold_right f tl hd
   | [] -> invalid_arg "unsafe_fold_right"
 
-let mk_coq_and sigma l =
-  let sigma, and_typ = Evarutil.new_global sigma Coqlib.(lib_ref "core.and.type") in
+let mk_coq_and dp sigma l =
+  let sigma, and_typ = Evarutil.new_global dp sigma Coqlib.(lib_ref "core.and.type") in
   sigma, unsafe_fold_right
       (fun c conj ->
          EConstr.(mkApp (and_typ, [| c ; conj |])))

--- a/pretyping/program.ml
+++ b/pretyping/program.ml
@@ -11,10 +11,10 @@
 open CErrors
 open Util
 
-let papp dp evdref r args =
+let papp dp env evdref r args =
   let open EConstr in
   let gr = delayed_force r in
-  let evd, hd = Evarutil.new_global dp !evdref gr in
+  let evd, hd = Evarutil.new_global dp env !evdref gr in
   evdref := evd;
   mkApp (hd, args)
 
@@ -38,8 +38,8 @@ let coq_eq_refl     () = Coqlib.lib_ref "core.eq.refl"
 let coq_eq_refl_ref () = Coqlib.lib_ref "core.eq.refl"
 let coq_eq_rect     () = Coqlib.lib_ref "core.eq.rect"
 
-let mk_coq_not dp sigma x =
-  let sigma, notc = Evarutil.new_global dp sigma Coqlib.(lib_ref "core.not.type") in
+let mk_coq_not dp env sigma x =
+  let sigma, notc = Evarutil.new_global dp env sigma Coqlib.(lib_ref "core.not.type") in
   sigma, EConstr.mkApp (notc, [| x |])
 
 let coq_JMeq_ind  () =
@@ -55,8 +55,8 @@ let unsafe_fold_right f = function
     hd :: tl -> List.fold_right f tl hd
   | [] -> invalid_arg "unsafe_fold_right"
 
-let mk_coq_and dp sigma l =
-  let sigma, and_typ = Evarutil.new_global dp sigma Coqlib.(lib_ref "core.and.type") in
+let mk_coq_and dp env sigma l =
+  let sigma, and_typ = Evarutil.new_global dp env sigma Coqlib.(lib_ref "core.and.type") in
   sigma, unsafe_fold_right
       (fun c conj ->
          EConstr.(mkApp (and_typ, [| c ; conj |])))

--- a/pretyping/program.mli
+++ b/pretyping/program.mli
@@ -34,11 +34,11 @@ val coq_eq_rect : unit -> GlobRef.t
 val coq_JMeq_ind : unit -> GlobRef.t
 val coq_JMeq_refl : unit -> GlobRef.t
 
-val mk_coq_and : DirPath.t -> Evd.evar_map -> constr list -> Evd.evar_map * constr
-val mk_coq_not : DirPath.t -> Evd.evar_map -> constr -> Evd.evar_map * constr
+val mk_coq_and : DirPath.t -> Environ.env -> Evd.evar_map -> constr list -> Evd.evar_map * constr
+val mk_coq_not : DirPath.t -> Environ.env -> Evd.evar_map -> constr -> Evd.evar_map * constr
 
 (** Polymorphic application of delayed references *)
-val papp : DirPath.t -> Evd.evar_map ref -> (unit -> GlobRef.t) -> constr array -> constr
+val papp : DirPath.t -> Environ.env -> Evd.evar_map ref -> (unit -> GlobRef.t) -> constr array -> constr
 
 val get_proofs_transparency : unit -> bool
 val is_program_cases : unit -> bool

--- a/pretyping/program.mli
+++ b/pretyping/program.mli
@@ -34,11 +34,11 @@ val coq_eq_rect : unit -> GlobRef.t
 val coq_JMeq_ind : unit -> GlobRef.t
 val coq_JMeq_refl : unit -> GlobRef.t
 
-val mk_coq_and : Evd.evar_map -> constr list -> Evd.evar_map * constr
-val mk_coq_not : Evd.evar_map -> constr -> Evd.evar_map * constr
+val mk_coq_and : DirPath.t -> Evd.evar_map -> constr list -> Evd.evar_map * constr
+val mk_coq_not : DirPath.t -> Evd.evar_map -> constr -> Evd.evar_map * constr
 
 (** Polymorphic application of delayed references *)
-val papp : Evd.evar_map ref -> (unit -> GlobRef.t) -> constr array -> constr
+val papp : DirPath.t -> Evd.evar_map ref -> (unit -> GlobRef.t) -> constr array -> constr
 
 val get_proofs_transparency : unit -> bool
 val is_program_cases : unit -> bool

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -725,7 +725,8 @@ let magicaly_constant_of_fixbody env sigma reference bd = function
     try
       let (cst_mod,_) = Constant.repr2 reference in
       let cst = Constant.make2 cst_mod (Label.of_id id) in
-      let (cst, u), ctx = UnivGen.fresh_constant_instance env cst in
+      let dp = Global.current_dirpath () in
+      let (cst, u), ctx = UnivGen.fresh_constant_instance dp env cst in
       match constant_opt_value_in env (cst,u) with
       | None -> bd
       | Some t ->

--- a/pretyping/typeclasses.ml
+++ b/pretyping/typeclasses.ml
@@ -173,8 +173,9 @@ let build_subclasses ~check env sigma glob { hint_priority = pri } =
       (fun () -> incr i;
         Nameops.add_suffix _id ("_subinstance_" ^ string_of_int !i))
   in
+  let dp = Global.current_dirpath () in
   let ty, ctx = Typeops.type_of_global_in_context env glob in
-  let inst, ctx = UnivGen.fresh_instance_from ctx None in
+  let inst, ctx = UnivGen.fresh_instance_from dp ctx None in
   let ty = Vars.subst_instance_constr inst ty in
   let ty = EConstr.of_constr ty in
   let sigma = Evd.merge_context_set Evd.univ_rigid sigma ctx in

--- a/pretyping/typing.ml
+++ b/pretyping/typing.ml
@@ -139,7 +139,8 @@ let is_correct_arity env sigma c pj ind specif params =
         then error ()
         else sigma, s
     | Evar (ev,_), [] ->
-        let sigma, s = Evd.fresh_sort_in_family sigma (max_sort allowed_sorts) in
+        let dp = Global.current_dirpath () in
+        let sigma, s = Evd.fresh_sort_in_family dp sigma (max_sort allowed_sorts) in
         let sigma = Evd.define ev (mkSort s) sigma in
         sigma, s
     | _, (LocalDef _ as d)::ar' ->

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -497,7 +497,9 @@ let pr_concl n ?(diffs=false) ?og_s sigma g =
 
 (* display evar type: a context and a type *)
 let pr_evgl_sign sigma evi =
-  let env = evar_env evi in
+  (* XXX why not env ? *)
+  let genv = Global.env () in
+  let env = evar_env genv evi in
   let ps = pr_named_context_of env sigma in
   let _, l = match Filter.repr (evar_filter evi) with
   | None -> [], []

--- a/printing/printer.mli
+++ b/printing/printer.mli
@@ -98,7 +98,7 @@ val pr_global_env          : Id.Set.t -> GlobRef.t -> Pp.t
 val pr_global              : GlobRef.t -> Pp.t
 
 val pr_constant            : env -> Constant.t -> Pp.t
-val pr_existential_key     : evar_map -> Evar.t -> Pp.t
+val pr_existential_key     : env -> evar_map -> Evar.t -> Pp.t
 val pr_existential         : env -> evar_map -> existential -> Pp.t
 val pr_constructor         : env -> constructor -> Pp.t
 val pr_inductive           : env -> inductive -> Pp.t
@@ -159,11 +159,20 @@ val pr_goal                : ?diffs:bool -> ?og_s:(Goal.goal sigma) -> Goal.goal
    there are non-instantiated existential variables.  [stack] is used to print summary info on unfocused
    goals.
 *)
-val pr_subgoals            : ?pr_first:bool -> ?diffs:bool -> ?os_map:(evar_map * Goal.goal Evar.Map.t) -> Pp.t option -> evar_map
-                             -> seeds:Goal.goal list -> shelf:Goal.goal list -> stack:int list
-                             -> unfocused:Goal.goal list -> goals:Goal.goal list -> Pp.t
+val pr_subgoals
+  :  ?pr_first:bool
+  -> ?diffs:bool
+  -> ?os_map:(evar_map * Goal.goal Evar.Map.t)
+  -> Pp.t option
+  -> env
+  -> evar_map
+  -> seeds:Goal.goal list
+  -> shelf:Goal.goal list
+  -> stack:int list
+  -> unfocused:Goal.goal list
+  -> goals:Goal.goal list -> Pp.t
 
-val pr_subgoal             : int -> evar_map -> Goal.goal list -> Pp.t
+val pr_subgoal             : int -> env -> evar_map -> Goal.goal list -> Pp.t
 
 (** [pr_concl n ~diffs ~og_s sigma g] prints the conclusion of the goal [g] using [sigma].  The output
     is labelled "subgoal [n]".  If [diffs] is true, highlight the differences between the old conclusion,
@@ -179,11 +188,10 @@ val pr_concl               : int -> ?diffs:bool -> ?og_s:(Goal.goal sigma) -> ev
 val pr_open_subgoals_diff  : ?quiet:bool -> ?diffs:bool -> ?oproof:Proof.t -> Proof.t -> Pp.t
 val pr_open_subgoals       : proof:Proof.t -> Pp.t
 val pr_nth_open_subgoal    : proof:Proof.t -> int -> Pp.t
-val pr_evar                : evar_map -> (Evar.t * evar_info) -> Pp.t
-val pr_evars_int           : evar_map -> shelf:Goal.goal list -> given_up:Goal.goal list -> int -> evar_info Evar.Map.t -> Pp.t
-val pr_evars               : evar_map -> evar_info Evar.Map.t -> Pp.t
-val pr_ne_evar_set         : Pp.t -> Pp.t -> evar_map ->
-  Evar.Set.t -> Pp.t
+val pr_evar                : env -> evar_map -> (Evar.t * evar_info) -> Pp.t
+val pr_evars_int           : env -> evar_map -> shelf:Goal.goal list -> given_up:Goal.goal list -> int -> evar_info Evar.Map.t -> Pp.t
+val pr_evars               : env -> evar_map -> evar_info Evar.Map.t -> Pp.t
+val pr_ne_evar_set         : Pp.t -> Pp.t -> env -> evar_map -> Evar.Set.t -> Pp.t
 
 val print_and_diff : Proof.t option -> Proof.t option -> unit
 

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -52,7 +52,8 @@ let refresh_undefined_univs clenv =
   | Var _ -> clenv, Univ.empty_level_subst
   | App (f, args) when isVar clenv.evd f -> clenv, Univ.empty_level_subst
   | _ ->  
-    let evd', subst = Evd.refresh_undefined_universes clenv.evd in
+    let dp = Global.current_dirpath () in
+    let evd', subst = Evd.refresh_undefined_universes dp clenv.evd in
     let map_freelisted f = { f with rebus = subst_univs_level_constr subst f.rebus } in
       { clenv with evd = evd'; templval = map_freelisted clenv.templval;
 	templtyp = map_freelisted clenv.templtyp }, subst

--- a/proofs/evar_refiner.ml
+++ b/proofs/evar_refiner.ml
@@ -47,7 +47,8 @@ let define_and_solve_constraints evk c env evd =
 let w_refine (evk,evi) (ltac_var,rawc) sigma =
   if Evd.is_defined sigma evk then
     user_err Pp.(str "Instantiate called on already-defined evar");
-  let env = Evd.evar_filtered_env evi in
+  let genv = Global.env () in
+  let env = Evd.evar_filtered_env genv evi in
   let sigma',typed_c =
     let flags = {
       Pretyping.use_typeclasses = true;

--- a/proofs/evar_refiner.ml
+++ b/proofs/evar_refiner.ml
@@ -64,6 +64,6 @@ let w_refine (evk,evi) (ltac_var,rawc) sigma =
       let loc = Glob_ops.loc_of_glob_constr rawc in
       user_err ?loc 
                 (str "Instance is not well-typed in the environment of " ++
-                 Termops.pr_existential_key sigma evk ++ str ".")
+                 Termops.pr_existential_key env sigma evk ++ str ".")
   in
   define_and_solve_constraints evk typed_c env (evars_reset_evd sigma' sigma)

--- a/proofs/goal.ml
+++ b/proofs/goal.ml
@@ -31,8 +31,9 @@ module V82 = struct
 
   (* Old style env primitive *)
   let env evars gl =
+    let env = Global.env () in
     let evi = Evd.find evars gl in
-    Evd.evar_filtered_env evi
+    Evd.evar_filtered_env env evi
 
   (* Old style hyps primitive *)
   let hyps evars gl =

--- a/proofs/proof.ml
+++ b/proofs/proof.ml
@@ -447,7 +447,9 @@ module V82 = struct
         else
           CList.nth evl (n-1)
       in
-      let env = Evd.evar_filtered_env evi in
+      (* XXX why not env ? *)
+      let genv = Global.env () in
+      let env = Evd.evar_filtered_env genv evi in
       let rawc = intern env sigma in
       let ltac_vars = Glob_ops.empty_lvar in
       let sigma = Evar_refiner.w_refine (evk, evi) (ltac_vars, rawc) sigma in

--- a/tactics/abstract.ml
+++ b/tactics/abstract.ml
@@ -177,7 +177,7 @@ let cache_term_by_tactic_then ~opaque ~name_op ?(goal_type=None) tac tacK =
   let effs = concat_private eff
     Entries.(snd (Future.force const.const_entry_body)) in
   let solve =
-    Proofview.tclEFFECTS effs <*>
+    Proofview.tclEFFECTS (Global.env ()) effs <*>
     tacK lem args
   in
   let tac = if not safe then Proofview.mark_as_unsafe <*> solve else solve in

--- a/tactics/auto.ml
+++ b/tactics/auto.ml
@@ -79,7 +79,8 @@ let connect_hint_clenv poly (c, _, ctx) clenv gl =
   let clenv, c =
     if poly then
       (* Refresh the instance of the hint *)
-      let (subst, ctx) = UnivGen.fresh_universe_context_set_instance ctx in
+      let dp = Global.current_dirpath () in
+      let (subst, ctx) = UnivGen.fresh_universe_context_set_instance dp ctx in
       let emap c = Vars.subst_univs_level_constr subst c in
       let evd = Evd.merge_context_set Evd.univ_flexible evd ctx in
       (* Only metas are mentioning the old universes. *)

--- a/tactics/autorewrite.ml
+++ b/tactics/autorewrite.ml
@@ -95,7 +95,8 @@ let one_base general_rewrite_maybe_in tac_main bas =
   let try_rewrite dir ctx c tc =
   Proofview.Goal.enter begin fun gl ->
     let sigma = Proofview.Goal.sigma gl in
-    let subst, ctx' = UnivGen.fresh_universe_context_set_instance ctx in
+    let dp = Global.current_dirpath () in
+    let subst, ctx' = UnivGen.fresh_universe_context_set_instance dp ctx in
     let c' = Vars.subst_univs_level_constr subst c in
     let sigma = Evd.merge_context_set Evd.univ_flexible sigma ctx' in
     Proofview.tclTHEN (Proofview.Unsafe.tclEVARS sigma)

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -214,13 +214,14 @@ let unify_resolve poly flags = begin fun gls (c,_,clenv) ->
 
 (** Application of a lemma using [refine] instead of the old [w_unify] *)
 let unify_resolve_refine poly flags gls ((c, t, ctx),n,clenv) =
+  let dp = Global.current_dirpath () in
   let open Clenv in
   let env = Proofview.Goal.env gls in
   let concl = Proofview.Goal.concl gls in
   Refine.refine ~typecheck:false begin fun sigma ->
       let sigma, term, ty =
         if poly then
-          let (subst, ctx) = UnivGen.fresh_universe_context_set_instance ctx in
+          let (subst, ctx) = UnivGen.fresh_universe_context_set_instance dp ctx in
           let map c = Vars.subst_univs_level_constr subst c in
           let sigma = Evd.merge_context_set Evd.univ_flexible sigma ctx in
           sigma, map c, map t

--- a/tactics/eauto.ml
+++ b/tactics/eauto.ml
@@ -88,7 +88,9 @@ let rec prolog l n gl =
 
 let out_term env = function
   | IsConstr (c, _) -> c
-  | IsGlobRef gr -> EConstr.of_constr (fst (UnivGen.fresh_global_instance env gr))
+  | IsGlobRef gr ->
+    let dp = Global.current_dirpath () in
+    EConstr.of_constr (fst (UnivGen.fresh_global_instance dp env gr))
 
 let prolog_tac l n =
   Proofview.V82.tactic begin fun gl ->

--- a/tactics/elimschemes.ml
+++ b/tactics/elimschemes.ml
@@ -26,13 +26,14 @@ open Ind_tables
 
 let optimize_non_type_induction_scheme kind dep sort _ ind =
   let env = Global.env () in
+  let dp = Global.current_dirpath () in
   let sigma = Evd.from_env env in
   if check_scheme kind ind then
     (* in case the inductive has a type elimination, generates only one
        induction scheme, the other ones share the same code with the
        appropriate type *)
     let cte, eff = find_scheme kind ind in
-    let sigma, cte = Evd.fresh_constant_instance env sigma cte in
+    let sigma, cte = Evd.fresh_constant_instance dp env sigma cte in
     let c = mkConstU cte in
     let t = type_of_constant_in (Global.env()) cte in
     let (mib,mip) = Global.lookup_inductive ind in
@@ -44,19 +45,20 @@ let optimize_non_type_induction_scheme kind dep sort _ ind =
 	mib.mind_nparams_rec
       else
 	mib.mind_nparams in
-    let sigma, sort = Evd.fresh_sort_in_family sigma sort in
+    let sigma, sort = Evd.fresh_sort_in_family dp sigma sort in
     let sigma, t', c' = weaken_sort_scheme env sigma false sort npars c t in
     let sigma = Evd.minimize_universes sigma in
     (Evarutil.nf_evars_universes sigma c', Evd.evar_universe_context sigma), eff
   else
-    let sigma, pind = Evd.fresh_inductive_instance env sigma ind in
+    let sigma, pind = Evd.fresh_inductive_instance dp env sigma ind in
     let sigma, c = build_induction_scheme env sigma pind dep sort in
       (c, Evd.evar_universe_context sigma), Safe_typing.empty_private_constants
 
 let build_induction_scheme_in_type dep sort ind =
+  let dp = Global.current_dirpath () in
   let env = Global.env () in
   let sigma = Evd.from_env env in
-  let sigma, pind = Evd.fresh_inductive_instance env sigma ind in
+  let sigma, pind = Evd.fresh_inductive_instance dp env sigma ind in
   let sigma, c = build_induction_scheme env sigma pind dep sort in
     c, Evd.evar_universe_context sigma
 
@@ -122,9 +124,10 @@ let nondep_elim_scheme from_kind to_kind =
 (* Case analysis *)
 
 let build_case_analysis_scheme_in_type dep sort ind =
+  let dp = Global.current_dirpath () in
   let env = Global.env () in
   let sigma = Evd.from_env env in
-  let (sigma, indu) = Evd.fresh_inductive_instance env sigma ind in
+  let (sigma, indu) = Evd.fresh_inductive_instance dp env sigma ind in
   let (sigma, c) = build_case_analysis_scheme env sigma indu dep sort in
     c, Evd.evar_universe_context sigma
 

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -398,7 +398,7 @@ let find_elim hdcncl lft2rgt dep cls ot =
   | Ind (ind,u) -> 
       
       let c, eff = find_scheme scheme_name ind in 
-      Proofview.tclEFFECTS eff <*>
+      Proofview.tclEFFECTS (Global.env ()) eff <*>
         pf_constr_of_global (ConstRef c) 
   | _ -> assert false
   end
@@ -995,7 +995,7 @@ let ind_scheme_of_eq lbeq to_kind =
 let discrimination_pf e (t,t1,t2) discriminator lbeq to_kind =
   build_coq_I () >>= fun i ->
   let eq_elim, eff = ind_scheme_of_eq lbeq to_kind in
-  Proofview.tclEFFECTS eff <*>
+  Proofview.tclEFFECTS (Global.env ()) eff <*>
     pf_constr_of_global eq_elim >>= fun eq_elim ->
     Proofview.tclUNIT
        (applist (eq_elim, [t;t1;mkNamedLambda (make_annot e Sorts.Relevant) t discriminator;i;t2]))
@@ -1352,7 +1352,7 @@ let inject_if_homogenous_dependent_pair ty =
     let c, eff = find_scheme (!eq_dec_scheme_kind_name()) ind in
     (* cut with the good equality and prove the requested goal *)
     tclTHENLIST
-      [Proofview.tclEFFECTS eff;
+      [Proofview.tclEFFECTS (Global.env ()) eff;
        intro;
        onLastHyp (fun hyp ->
         Tacticals.New.pf_constr_of_global Coqlib.(lib_ref "core.eq.type") >>= fun ceq ->

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -875,10 +875,11 @@ let warn_polymorphic_hint =
                         strbrk" use Polymorphic Hint to use it polymorphically.")
 
 let fresh_global_or_constr env sigma poly cr =
+  let dp = Global.current_dirpath () in
   let isgr, (c, ctx) =
     match cr with
     | IsGlobRef gr ->
-      let (c, ctx) = UnivGen.fresh_global_instance env gr in
+      let (c, ctx) = UnivGen.fresh_global_instance dp env gr in
        true, (EConstr.of_constr c, ctx)
     | IsConstr (c, ctx) -> false, (c, ctx)
   in
@@ -1290,12 +1291,13 @@ let prepare_hint check (poly,local) env init (sigma,c) =
 	  IsConstr (c', Univ.ContextSet.empty))
 
 let project_hint ~poly pri l2r r =
+  let dp = Global.current_dirpath () in
   let open EConstr in
   let open Coqlib in
   let gr = Smartlocate.global_with_alias r in
   let env = Global.env() in
   let sigma = Evd.from_env env in
-  let sigma, c = Evd.fresh_global env sigma gr in
+  let sigma, c = Evd.fresh_global dp env sigma gr in
   let t = Retyping.get_type_of env sigma c in
   let t =
     Tacred.reduce_to_quantified_ref env sigma (lib_ref "core.iff.type") t in
@@ -1305,7 +1307,7 @@ let project_hint ~poly pri l2r r =
     | _ -> assert false in
   let p =
     if l2r then lib_ref "core.iff.proj1" else lib_ref "core.iff.proj2" in
-  let sigma, p = Evd.fresh_global env sigma p in
+  let sigma, p = Evd.fresh_global dp env sigma p in
   let c = Reductionops.whd_beta sigma (mkApp (c, Context.Rel.to_extended_vect mkRel 0 sign)) in
   let c = it_mkLambda_or_LetIn
     (mkApp (p,[|mkArrow a Sorts.Relevant (lift 1 b);mkArrow b Sorts.Relevant (lift 1 a);c|])) sign in

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -782,7 +782,7 @@ let with_uid c = { obj = c; uid = fresh_key () }
 
 let secvars_of_idset s =
   Id.Set.fold (fun id p ->
-      if is_section_variable id then
+      if is_section_variable (Global.env ()) id then
         Id.Pred.add id p
       else p) s Id.Pred.empty
 

--- a/tactics/inv.ml
+++ b/tactics/inv.ml
@@ -80,6 +80,7 @@ let compute_eqn env sigma n i ai =
   (mkRel (n-i),get_type_of env sigma (mkRel (n-i)))
 
 let make_inv_predicate env evd indf realargs id status concl =
+  let dp = Global.current_dirpath () in
   let nrealargs = List.length realargs in
   let (hyps,concl) =
     match status with
@@ -100,7 +101,7 @@ let make_inv_predicate env evd indf realargs id status concl =
               | Some concl -> concl (*assumed it's some [x1..xn,H:I(x1..xn)]C*)
               | None ->
 		let sort = get_sort_family_of env !evd concl in
-                let sort = evd_comb1 Evd.fresh_sort_in_family evd sort in
+                let sort = evd_comb1 (Evd.fresh_sort_in_family dp) evd sort in
 		let p = make_arity env !evd true indf sort in
 		let evd',(p,ptyp) = Unification.abstract_list_all env
                   !evd p concl (realargs@[mkVar id])
@@ -130,11 +131,11 @@ let make_inv_predicate env evd indf realargs id status concl =
 	      evd := sigma; res
 	in
         let eq_term = eqdata.Coqlib.eq in
-        let eq = evd_comb1 (Evd.fresh_global env) evd eq_term in
+        let eq = evd_comb1 (Evd.fresh_global dp env) evd eq_term in
         let eqn = applist (eq,[eqnty;lhs;rhs]) in
         let eqns = (make_annot Anonymous Sorts.Relevant, lift n eqn) :: eqns in
         let refl_term = eqdata.Coqlib.refl in
-        let refl_term = evd_comb1 (Evd.fresh_global env) evd refl_term in
+        let refl_term = evd_comb1 (Evd.fresh_global dp env) evd refl_term in
         let refl = mkApp (refl_term, [|eqnty; rhs|]) in
         let _ = evd_comb1 (Typing.type_of env) evd refl in
         let args = refl :: args in

--- a/tactics/leminv.ml
+++ b/tactics/leminv.ml
@@ -248,7 +248,8 @@ let add_inversion_lemma_exn ~poly na com comsort bool tac =
   let env = Global.env () in
   let sigma = Evd.from_env env in
   let sigma, c = Constrintern.interp_type_evars ~program_mode:false env sigma com in
-  let sigma, sort = Evd.fresh_sort_in_family ~rigid:univ_rigid sigma comsort in
+  let dp = Global.current_dirpath () in
+  let sigma, sort = Evd.fresh_sort_in_family ~rigid:univ_rigid dp sigma comsort in
   try
     add_inversion_lemma ~poly na env sigma c sort bool tac
   with

--- a/tactics/tacticals.ml
+++ b/tactics/tacticals.ml
@@ -251,7 +251,8 @@ let pf_with_evars glsev k gls =
     tclTHEN (Refiner.tclEVARS evd) (k a) gls
 
 let pf_constr_of_global gr k =
-  pf_with_evars (fun gls -> pf_apply Evd.fresh_global gls gr) k
+  let dp = Global.current_dirpath () in
+  pf_with_evars (fun gls -> pf_apply (Evd.fresh_global dp) gls gr) k
 
 (** Tacticals of Ltac defined directly in term of Proofview *)
 module New = struct
@@ -698,7 +699,8 @@ module New = struct
   let gl_make_elim ind = begin fun gl ->
     let env = Proofview.Goal.env gl in
     let gr = Indrec.lookup_eliminator env (fst ind) (elimination_sort_of_goal gl) in
-    let (sigma, c) = pf_apply Evd.fresh_global gl gr in
+    let dp = Global.current_dirpath () in
+    let (sigma, c) = pf_apply (Evd.fresh_global dp) gl gr in
     (sigma, c)
   end
 
@@ -756,9 +758,10 @@ module New = struct
     general_elim_then_using gl_make_case_nodep false
 
   let pf_constr_of_global ref =
+    let dp = Global.current_dirpath () in
     Proofview.tclEVARMAP >>= fun sigma ->
     Proofview.tclENV >>= fun env ->
-    let (sigma, c) = Evd.fresh_global env sigma ref in
+    let (sigma, c) = Evd.fresh_global dp env sigma ref in
     Proofview.Unsafe.tclEVARS sigma <*> Proofview.tclUNIT c
 
 end

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -3610,28 +3610,28 @@ let error_ind_scheme s =
   let s = if not (String.is_empty s) then s^" " else s in
   user_err ~hdr:"Tactics" (str "Cannot recognize " ++ str s ++ str "an induction scheme.")
 
-let coq_eq sigma       = Evarutil.new_global (Global.current_dirpath()) sigma Coqlib.(lib_ref "core.eq.type")
-let coq_eq_refl sigma  = Evarutil.new_global (Global.current_dirpath()) sigma Coqlib.(lib_ref "core.eq.refl")
+let coq_eq      env sigma  = Evarutil.new_global (Global.current_dirpath()) env sigma Coqlib.(lib_ref "core.eq.type")
+let coq_eq_refl env sigma  = Evarutil.new_global (Global.current_dirpath()) env sigma Coqlib.(lib_ref "core.eq.refl")
 
-let coq_heq_ref        = lazy (Coqlib.lib_ref "core.JMeq.type")
-let coq_heq sigma      = Evarutil.new_global (Global.current_dirpath()) sigma (Lazy.force coq_heq_ref)
-let coq_heq_refl sigma = Evarutil.new_global (Global.current_dirpath()) sigma (Coqlib.lib_ref "core.JMeq.refl")
+let coq_heq_ref            = lazy (Coqlib.lib_ref "core.JMeq.type")
+let coq_heq      env sigma = Evarutil.new_global (Global.current_dirpath()) env sigma (Lazy.force coq_heq_ref)
+let coq_heq_refl env sigma = Evarutil.new_global (Global.current_dirpath()) env sigma (Coqlib.lib_ref "core.JMeq.refl")
 (* let coq_heq_refl = lazy (glob (lib_ref "core.JMeq.refl")) *)
 
-let mkEq sigma t x y =
-  let sigma, eq = coq_eq sigma in
+let mkEq env sigma t x y =
+  let sigma, eq = coq_eq env sigma in
   sigma, mkApp (eq, [| t; x; y |])
 
-let mkRefl sigma t x =
-  let sigma, refl = coq_eq_refl sigma in
+let mkRefl env sigma t x =
+  let sigma, refl = coq_eq_refl env sigma in
   sigma, mkApp (refl, [| t; x |])
 
-let mkHEq sigma t x u y =
-  let sigma, c = coq_heq sigma in
+let mkHEq env sigma t x u y =
+  let sigma, c = coq_heq env sigma in
   sigma, mkApp (c,[| t; x; u; y |])
 
-let mkHRefl sigma t x =
-  let sigma, c = coq_heq_refl sigma in
+let mkHRefl env sigma t x =
+  let sigma, c = coq_heq_refl env sigma in
   sigma, mkApp (c, [| t; x |])
 
 let lift_togethern n l =
@@ -3672,12 +3672,12 @@ let decompose_indapp sigma f args =
 
 let mk_term_eq homogeneous env sigma ty t ty' t' =
   if homogeneous then
-    let sigma, eq = mkEq sigma ty t t' in
-    let sigma, refl = mkRefl sigma ty' t' in
+    let sigma, eq = mkEq env sigma ty t t' in
+    let sigma, refl = mkRefl env sigma ty' t' in
     sigma, (eq, refl)
   else
-    let sigma, heq = mkHEq sigma ty t ty' t' in
-    let sigma, hrefl = mkHRefl sigma ty' t' in
+    let sigma, heq = mkHEq env sigma ty t ty' t' in
+    let sigma, hrefl = mkHRefl env sigma ty' t' in
     sigma, (heq, hrefl)
 
 let make_abstract_generalize env id typ concl dep ctx body c eqs args refls =
@@ -3801,12 +3801,12 @@ let abstract_args gl generalize_vars dep id defined f args =
 	  let liftarg = lift (List.length ctx) arg in
 	  let eq, refl =
 	    if leq then
-	      let sigma', eq = mkEq !sigma (lift 1 ty) (mkRel 1) liftarg in
-              let sigma', refl = mkRefl sigma' (lift (-lenctx) ty) arg in
+              let sigma', eq = mkEq env !sigma (lift 1 ty) (mkRel 1) liftarg in
+              let sigma', refl = mkRefl env sigma' (lift (-lenctx) ty) arg in
               sigma := sigma'; eq, refl
 	    else
-	      let sigma', eq = mkHEq !sigma (lift 1 ty) (mkRel 1) liftargty liftarg in
-              let sigma', refl = mkHRefl sigma' argty arg in
+              let sigma', eq = mkHEq env !sigma (lift 1 ty) (mkRel 1) liftargty liftarg in
+              let sigma', refl = mkHRefl env sigma' argty arg in
               sigma := sigma'; eq, refl
 	  in
 	  let eqs = eq :: lift_list eqs in

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -208,7 +208,7 @@ let clear_dependency_msg env sigma id err inglobal =
       Printer.pr_existential env sigma ev ++ str"."
   | Evarutil.NoCandidatesLeft ev ->
       str "Cannot remove " ++ Id.print id ++ str " as it would leave the existential " ++
-      Printer.pr_existential_key sigma ev ++ str" without candidates."
+      Printer.pr_existential_key env sigma ev ++ str" without candidates."
 
 let error_clear_dependency env sigma id err inglobal =
   user_err (clear_dependency_msg env sigma id err inglobal)
@@ -227,7 +227,7 @@ let replacing_dependency_msg env sigma id err inglobal =
       Printer.pr_existential env sigma ev ++ str"."
   | Evarutil.NoCandidatesLeft ev ->
       str "Cannot change " ++ Id.print id ++ str " as it would leave the existential " ++
-      Printer.pr_existential_key sigma ev ++ str" without candidates."
+      Printer.pr_existential_key env sigma ev ++ str" without candidates."
 
 let error_replacing_dependency env sigma id err inglobal =
   user_err (replacing_dependency_msg env sigma id err inglobal)

--- a/user-contrib/Ltac2/tac2core.ml
+++ b/user-contrib/Ltac2/tac2core.ml
@@ -554,6 +554,7 @@ let () = define2 "constr_constructor" (repr_ext val_inductive) int begin fun (in
 end
 
 let () = define3 "constr_in_context" ident constr closure begin fun id t c ->
+  let dp = Global.current_dirpath () in
   Proofview.Goal.goals >>= function
   | [gl] ->
     gl >>= fun gl ->
@@ -570,7 +571,7 @@ let () = define3 "constr_in_context" ident constr closure begin fun id t c ->
     else
       let open Context.Named.Declaration in
       let nenv = EConstr.push_named (LocalAssum (Context.make_annot id Sorts.Relevant, t)) env in
-      let (sigma, (evt, _)) = Evarutil.new_type_evar nenv sigma Evd.univ_flexible in
+      let (sigma, (evt, _)) = Evarutil.new_type_evar dp nenv sigma Evd.univ_flexible in
       let (sigma, evk) = Evarutil.new_pure_evar (Environ.named_context_val nenv) sigma evt in
       Proofview.Unsafe.tclEVARS sigma >>= fun () ->
       Proofview.Unsafe.tclSETGOALS [Proofview.with_empty_state evk] >>= fun () ->
@@ -898,9 +899,10 @@ let () = define1 "env_path" reference begin fun r ->
 end
 
 let () = define1 "env_instantiate" reference begin fun r ->
+  let dp = Global.current_dirpath () in
   Proofview.tclENV >>= fun env ->
   Proofview.tclEVARMAP >>= fun sigma ->
-  let (sigma, c) = Evd.fresh_global env sigma r in
+  let (sigma, c) = Evd.fresh_global dp env sigma r in
   Proofview.Unsafe.tclEVARS sigma >>= fun () ->
   return (Value.of_constr c)
 end

--- a/vernac/auto_ind_decl.ml
+++ b/vernac/auto_ind_decl.ml
@@ -66,21 +66,21 @@ exception DecidabilityIndicesNotSupported
 (* Some pre declaration of constant we are going to use *)
 let andb_prop = fun _ ->
   let dp = Global.current_dirpath () in
-  UnivGen.constr_of_monomorphic_global dp (Coqlib.lib_ref "core.bool.andb_prop")
+  UnivGen.constr_of_monomorphic_global dp (Global.env ()) (Coqlib.lib_ref "core.bool.andb_prop")
 
 let andb_true_intro = fun _ ->
   let dp = Global.current_dirpath () in
-  UnivGen.constr_of_monomorphic_global dp
+  UnivGen.constr_of_monomorphic_global dp (Global.env ())
     (Coqlib.lib_ref "core.bool.andb_true_intro")
 
 (* We avoid to use lazy as the binding of constants can change *)
-let bb () = UnivGen.constr_of_monomorphic_global (Global.current_dirpath ()) (Coqlib.lib_ref "core.bool.type")
-let tt () = UnivGen.constr_of_monomorphic_global (Global.current_dirpath ()) (Coqlib.lib_ref "core.bool.true")
-let ff () = UnivGen.constr_of_monomorphic_global (Global.current_dirpath ()) (Coqlib.lib_ref "core.bool.false")
-let eq () = UnivGen.constr_of_monomorphic_global (Global.current_dirpath ()) (Coqlib.lib_ref "core.eq.type")
+let bb () = UnivGen.constr_of_monomorphic_global (Global.current_dirpath ()) (Global.env ()) (Coqlib.lib_ref "core.bool.type")
+let tt () = UnivGen.constr_of_monomorphic_global (Global.current_dirpath ()) (Global.env ()) (Coqlib.lib_ref "core.bool.true")
+let ff () = UnivGen.constr_of_monomorphic_global (Global.current_dirpath ()) (Global.env ()) (Coqlib.lib_ref "core.bool.false")
+let eq () = UnivGen.constr_of_monomorphic_global (Global.current_dirpath ()) (Global.env ()) (Coqlib.lib_ref "core.eq.type")
 
-let sumbool () = UnivGen.constr_of_monomorphic_global (Global.current_dirpath ()) (Coqlib.lib_ref "core.sumbool.type")
-let andb = fun _ -> UnivGen.constr_of_monomorphic_global (Global.current_dirpath ()) (Coqlib.lib_ref "core.bool.andb")
+let sumbool () = UnivGen.constr_of_monomorphic_global (Global.current_dirpath ()) (Global.env ()) (Coqlib.lib_ref "core.sumbool.type")
+let andb = fun _ -> UnivGen.constr_of_monomorphic_global (Global.current_dirpath ()) (Global.env ()) (Coqlib.lib_ref "core.bool.andb")
 
 let induct_on  c = induction false None c None None
 let destruct_on c = destruct false None c None None
@@ -898,7 +898,7 @@ let compute_dec_goal ind lnamesparrec nparrec =
         create_input (
           mkNamedProd (make_annot n Sorts.Relevant) (mkFullInd ind (2*nparrec)) (
             mkNamedProd (make_annot m Sorts.Relevant) (mkFullInd ind (2*nparrec+1)) (
-              mkApp(sumbool(),[|eqnm;mkApp (UnivGen.constr_of_monomorphic_global (Global.current_dirpath ()) @@ Coqlib.lib_ref "core.not.type",[|eqnm|])|])
+              mkApp(sumbool(),[|eqnm;mkApp (UnivGen.constr_of_monomorphic_global (Global.current_dirpath ()) (Global.env ()) @@ Coqlib.lib_ref "core.not.type",[|eqnm|])|])
           )
         )
       )

--- a/vernac/auto_ind_decl.ml
+++ b/vernac/auto_ind_decl.ml
@@ -64,20 +64,23 @@ exception ConstructorWithNonParametricInductiveType of inductive
 exception DecidabilityIndicesNotSupported
 
 (* Some pre declaration of constant we are going to use *)
-let andb_prop = fun _ -> UnivGen.constr_of_monomorphic_global (Coqlib.lib_ref "core.bool.andb_prop")
+let andb_prop = fun _ ->
+  let dp = Global.current_dirpath () in
+  UnivGen.constr_of_monomorphic_global dp (Coqlib.lib_ref "core.bool.andb_prop")
 
 let andb_true_intro = fun _ ->
-  UnivGen.constr_of_monomorphic_global
+  let dp = Global.current_dirpath () in
+  UnivGen.constr_of_monomorphic_global dp
     (Coqlib.lib_ref "core.bool.andb_true_intro")
 
 (* We avoid to use lazy as the binding of constants can change *)
-let bb () = UnivGen.constr_of_monomorphic_global (Coqlib.lib_ref "core.bool.type")
-let tt () = UnivGen.constr_of_monomorphic_global (Coqlib.lib_ref "core.bool.true")
-let ff () = UnivGen.constr_of_monomorphic_global (Coqlib.lib_ref "core.bool.false")
-let eq () = UnivGen.constr_of_monomorphic_global (Coqlib.lib_ref "core.eq.type")
+let bb () = UnivGen.constr_of_monomorphic_global (Global.current_dirpath ()) (Coqlib.lib_ref "core.bool.type")
+let tt () = UnivGen.constr_of_monomorphic_global (Global.current_dirpath ()) (Coqlib.lib_ref "core.bool.true")
+let ff () = UnivGen.constr_of_monomorphic_global (Global.current_dirpath ()) (Coqlib.lib_ref "core.bool.false")
+let eq () = UnivGen.constr_of_monomorphic_global (Global.current_dirpath ()) (Coqlib.lib_ref "core.eq.type")
 
-let sumbool () = UnivGen.constr_of_monomorphic_global (Coqlib.lib_ref "core.sumbool.type")
-let andb = fun _ -> UnivGen.constr_of_monomorphic_global (Coqlib.lib_ref "core.bool.andb")
+let sumbool () = UnivGen.constr_of_monomorphic_global (Global.current_dirpath ()) (Coqlib.lib_ref "core.sumbool.type")
+let andb = fun _ -> UnivGen.constr_of_monomorphic_global (Global.current_dirpath ()) (Coqlib.lib_ref "core.bool.andb")
 
 let induct_on  c = induction false None c None None
 let destruct_on c = destruct false None c None None
@@ -895,7 +898,7 @@ let compute_dec_goal ind lnamesparrec nparrec =
         create_input (
           mkNamedProd (make_annot n Sorts.Relevant) (mkFullInd ind (2*nparrec)) (
             mkNamedProd (make_annot m Sorts.Relevant) (mkFullInd ind (2*nparrec+1)) (
-              mkApp(sumbool(),[|eqnm;mkApp (UnivGen.constr_of_monomorphic_global @@ Coqlib.lib_ref "core.not.type",[|eqnm|])|])
+              mkApp(sumbool(),[|eqnm;mkApp (UnivGen.constr_of_monomorphic_global (Global.current_dirpath ()) @@ Coqlib.lib_ref "core.not.type",[|eqnm|])|])
           )
         )
       )

--- a/vernac/auto_ind_decl.ml
+++ b/vernac/auto_ind_decl.ml
@@ -428,7 +428,7 @@ let do_replace_lb mode lb_scheme_key aavoid narg p q =
                        then lb_type_of_p else mkApp (lb_type_of_p,lb_args)
            in
            Tacticals.New.tclTHENLIST [
-             Proofview.tclEFFECTS eff;
+             Proofview.tclEFFECTS (Global.env ()) eff;
              Equality.replace p q ; apply app ; Auto.default_auto]
   end
 
@@ -497,7 +497,7 @@ let do_replace_bl mode bl_scheme_key (ind,u as indu) aavoid narg lft rgt =
                            then bl_t1 else mkApp (bl_t1,bl_args)
                 in
                 Tacticals.New.tclTHENLIST [
-                  Proofview.tclEFFECTS eff;
+                  Proofview.tclEFFECTS (Global.env ()) eff;
                   Equality.replace_by t1 t2
                     (Tacticals.New.tclTHEN (apply app) (Auto.default_auto)) ;
                   aux q1 q2 ]
@@ -943,7 +943,7 @@ let compute_dec_tact ind lnamesparrec nparrec =
   end >>= fun (lbI,eff'') ->
   let eff = (Safe_typing.concat_private eff'' (Safe_typing.concat_private eff' eff)) in
   Tacticals.New.tclTHENLIST [
-        Proofview.tclEFFECTS eff;
+        Proofview.tclEFFECTS (Global.env ()) eff;
         intros_using fresh_first_intros;
         intros_using [freshn;freshm];
 	(*we do this so we don't have to prove the same goal twice *)

--- a/vernac/class.ml
+++ b/vernac/class.ml
@@ -178,10 +178,11 @@ let error_not_transparent source =
     (pr_class source ++ str " must be a transparent constant.")
 
 let build_id_coercion idf_opt source poly =
+  let dp = Global.current_dirpath () in
   let env = Global.env () in
   let sigma = Evd.from_env env in
   let sigma, vs = match source with
-    | CL_CONST sp -> Evd.fresh_global env sigma (ConstRef sp)
+    | CL_CONST sp -> Evd.fresh_global dp env sigma (ConstRef sp)
     | _ -> error_not_transparent source in
   let vs = EConstr.Unsafe.to_constr vs in
   let c = match constant_opt_value_in env (destConst vs) with

--- a/vernac/comFixpoint.ml
+++ b/vernac/comFixpoint.ml
@@ -165,9 +165,9 @@ type recursive_preentry =
 
 (* Wellfounded definition *)
 
-let fix_proto sigma =
+let fix_proto env sigma =
   let dp = Global.current_dirpath () in
-  Evarutil.new_global dp sigma (Coqlib.lib_ref "program.tactic.fix_proto")
+  Evarutil.new_global dp env sigma (Coqlib.lib_ref "program.tactic.fix_proto")
 
 let interp_recursive ~program_mode ~cofix fixl notations =
   let open Context.Named.Declaration in
@@ -207,7 +207,7 @@ let interp_recursive ~program_mode ~cofix fixl notations =
            let sigma, sort = Typing.type_of ~refresh:true env sigma t in
            let sigma, fixprot =
              try
-               let sigma, h_term = fix_proto sigma in
+               let sigma, h_term = fix_proto env sigma in
                let app = mkApp (h_term, [|sort; t|]) in
                Typing.solve_evars env sigma app
              with e when CErrors.noncritical e -> sigma, t

--- a/vernac/comFixpoint.ml
+++ b/vernac/comFixpoint.ml
@@ -166,7 +166,8 @@ type recursive_preentry =
 (* Wellfounded definition *)
 
 let fix_proto sigma =
-  Evarutil.new_global sigma (Coqlib.lib_ref "program.tactic.fix_proto")
+  let dp = Global.current_dirpath () in
+  Evarutil.new_global dp sigma (Coqlib.lib_ref "program.tactic.fix_proto")
 
 let interp_recursive ~program_mode ~cofix fixl notations =
   let open Context.Named.Declaration in

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -293,11 +293,11 @@ let explain_unification_error env sigma p1 p2 = function
   | Some e ->
      let rec aux p1 p2 = function
      | OccurCheck (evk,rhs) ->
-        [str "cannot define " ++ quote (pr_existential_key sigma evk) ++
+        [str "cannot define " ++ quote (pr_existential_key env sigma evk) ++
 	strbrk " with term " ++ pr_leconstr_env env sigma rhs ++
         strbrk " that would depend on itself"]
      | NotClean ((evk,args),env,c) ->
-        [str "cannot instantiate " ++ quote (pr_existential_key sigma evk)
+        [str "cannot instantiate " ++ quote (pr_existential_key env sigma evk)
         ++ strbrk " because " ++ pr_leconstr_env env sigma c ++
 	strbrk " is not in its scope" ++
         (if Array.is_empty args then mt() else
@@ -315,13 +315,13 @@ let explain_unification_error env sigma p1 p2 = function
           [str "cannot unify " ++ t1 ++ strbrk " and " ++ t2]
         else []
      | MetaOccurInBody evk ->
-        [str "instance for " ++ quote (pr_existential_key sigma evk) ++
+        [str "instance for " ++ quote (pr_existential_key env sigma evk) ++
 	strbrk " refers to a metavariable - please report your example" ++
         strbrk "at " ++ str Coq_config.wwwbugtracker ++ str "."]
      | InstanceNotSameType (evk,env,t,u) ->
         let t, u = pr_explicit env sigma t u in
         [str "unable to find a well-typed instantiation for " ++
-        quote (pr_existential_key sigma evk) ++
+        quote (pr_existential_key env sigma evk) ++
         strbrk ": cannot ensure that " ++
         t ++ strbrk " is a subtype of " ++ u]
      | UnifUnivInconsistency p ->
@@ -539,7 +539,7 @@ let explain_cant_find_case_type env sigma c =
 let explain_occur_check env sigma ev rhs =
   let env = make_all_name_different env sigma in
   let pt = pr_leconstr_env env sigma rhs in
-  str "Cannot define " ++ pr_existential_key sigma ev ++ str " with term" ++
+  str "Cannot define " ++ pr_existential_key env sigma ev ++ str " with term" ++
   brk(1,1) ++ pt ++ spc () ++ str "that would depend on itself."
 
 let pr_trailing_ne_context_of env sigma =
@@ -596,7 +596,7 @@ let rec explain_evar_kind env sigma evk ty =
       | Evar_defined c -> pr_leconstr_env env sigma c
       | Evar_empty -> assert false in
       let ty' = evi.evar_concl in
-      pr_existential_key sigma evk ++
+      pr_existential_key env sigma evk ++
       strbrk " in the partial instance " ++ pc ++
       strbrk " found for " ++
       explain_evar_kind env sigma evk
@@ -642,7 +642,7 @@ let explain_var_not_found env id =
 let explain_evar_not_found env sigma id =
   let undef = Evar.Map.domain (Evd.undefined_map sigma) in
   let all_undef_evars = Evar.Set.elements undef in
-  let f ev = Id.equal id (Termops.evar_suggested_name ev sigma) in
+  let f ev = Id.equal id (Termops.evar_suggested_name env ev sigma) in
   if List.exists f all_undef_evars then
     (* The name is used for printing but is not user-given *)
     str "?" ++ Id.print id ++
@@ -827,7 +827,7 @@ let pr_constraints printenv env sigma evars cstrs =
       in
       let evs =
         prlist
-        (fun (ev, evi) -> fnl () ++ pr_existential_key sigma ev ++
+        (fun (ev, evi) -> fnl () ++ pr_existential_key env sigma ev ++
             str " : " ++ pr_leconstr_env env' sigma evi.evar_concl ++ fnl ()) l
       in
       h 0 (pe ++ evs ++ pr_evar_constraints sigma cstrs)

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -605,7 +605,9 @@ let rec explain_evar_kind env sigma evk ty =
 let explain_typeclass_resolution env sigma evi k =
   match Typeclasses.class_of_constr env sigma evi.evar_concl with
   | Some _ ->
-    let env = Evd.evar_filtered_env evi in
+    (* XXX why not env? *)
+    let genv = Global.env () in
+    let env = Evd.evar_filtered_env genv evi in
       fnl () ++ str "Could not find an instance for " ++
       pr_leconstr_env env sigma evi.evar_concl ++
       pr_trailing_ne_context_of env sigma
@@ -621,8 +623,10 @@ let explain_placeholder_kind env sigma c e =
       | _ -> mt ()
 
 let explain_unsolvable_implicit env sigma evk explain =
+  (* XXX why not env? *)
+  let genv = Global.env () in
   let evi = Evarutil.nf_evar_info sigma (Evd.find_undefined sigma evk) in
-  let env = Evd.evar_filtered_env evi in
+  let env = Evd.evar_filtered_env genv evi in
   let type_of_hole = pr_leconstr_env env sigma evi.evar_concl in
   let pe = pr_trailing_ne_context_of env sigma in
   strbrk "Cannot infer " ++

--- a/vernac/indschemes.ml
+++ b/vernac/indschemes.ml
@@ -466,11 +466,11 @@ let fold_left' f = function
     [] -> invalid_arg "fold_left'"
   | hd :: tl -> List.fold_left f hd tl
 
-let mk_coq_and sigma = Evarutil.new_global (Global.current_dirpath()) sigma (Coqlib.lib_ref "core.and.type")
-let mk_coq_conj sigma = Evarutil.new_global (Global.current_dirpath()) sigma (Coqlib.lib_ref "core.and.conj")
+let mk_coq_and  env sigma = Evarutil.new_global (Global.current_dirpath()) env sigma (Coqlib.lib_ref "core.and.type")
+let mk_coq_conj env sigma = Evarutil.new_global (Global.current_dirpath()) env sigma (Coqlib.lib_ref "core.and.conj")
 
-let mk_coq_prod sigma = Evarutil.new_global (Global.current_dirpath()) sigma (Coqlib.lib_ref "core.prod.type")
-let mk_coq_pair sigma = Evarutil.new_global (Global.current_dirpath()) sigma (Coqlib.lib_ref "core.prod.intro")
+let mk_coq_prod env sigma = Evarutil.new_global (Global.current_dirpath()) env sigma (Coqlib.lib_ref "core.prod.type")
+let mk_coq_pair env sigma = Evarutil.new_global (Global.current_dirpath()) env sigma (Coqlib.lib_ref "core.prod.intro")
 
 let build_combined_scheme env schemes =
   let dp = Global.current_dirpath () in
@@ -507,8 +507,8 @@ let build_combined_scheme env schemes =
   in
   (* Number of clauses, including the predicates quantification *)
   let prods = nb_prod sigma (EConstr.of_constr t) - (nargs + 1) in
-  let sigma, coqand  = mk_and sigma in
-  let sigma, coqconj = mk_conj sigma in
+  let sigma, coqand  = mk_and env sigma in
+  let sigma, coqconj = mk_conj env sigma in
   let relargs = rel_vect 0 prods in
   let concls = List.rev_map
     (fun (cst, t) ->

--- a/vernac/indschemes.ml
+++ b/vernac/indschemes.ml
@@ -387,6 +387,7 @@ requested
 	| EqualityScheme  x -> l1,((None,smart_global_inductive x)::l2)
 
 let do_mutual_induction_scheme ?(force_mutual=false) lnamedepindsort =
+  let dp = Global.current_dirpath () in
   let lrecnames = List.map (fun ({CAst.v},_,_,_) -> v) lnamedepindsort
   and env0 = Global.env() in
   let sigma, lrecspec, _ =
@@ -396,7 +397,7 @@ let do_mutual_induction_scheme ?(force_mutual=false) lnamedepindsort =
 	 match inst with
 	 | None ->
             let _, ctx = Typeops.type_of_global_in_context env0 (IndRef ind) in
-            let u, ctx = UnivGen.fresh_instance_from ctx None in
+            let u, ctx = UnivGen.fresh_instance_from dp ctx None in
             let evd = Evd.from_ctx (UState.of_context_set ctx) in
 	      evd, (ind,u), Some u
 	 | Some ui -> evd, (ind, ui), inst
@@ -465,16 +466,17 @@ let fold_left' f = function
     [] -> invalid_arg "fold_left'"
   | hd :: tl -> List.fold_left f hd tl
 
-let mk_coq_and sigma = Evarutil.new_global sigma (Coqlib.lib_ref "core.and.type")
-let mk_coq_conj sigma = Evarutil.new_global sigma (Coqlib.lib_ref "core.and.conj")
+let mk_coq_and sigma = Evarutil.new_global (Global.current_dirpath()) sigma (Coqlib.lib_ref "core.and.type")
+let mk_coq_conj sigma = Evarutil.new_global (Global.current_dirpath()) sigma (Coqlib.lib_ref "core.and.conj")
 
-let mk_coq_prod sigma = Evarutil.new_global sigma (Coqlib.lib_ref "core.prod.type")
-let mk_coq_pair sigma = Evarutil.new_global sigma (Coqlib.lib_ref "core.prod.intro")
+let mk_coq_prod sigma = Evarutil.new_global (Global.current_dirpath()) sigma (Coqlib.lib_ref "core.prod.type")
+let mk_coq_pair sigma = Evarutil.new_global (Global.current_dirpath()) sigma (Coqlib.lib_ref "core.prod.intro")
 
 let build_combined_scheme env schemes =
+  let dp = Global.current_dirpath () in
   let sigma = Evd.from_env env in
   let sigma, defs = List.fold_left_map (fun sigma cst ->
-    let sigma, c = Evd.fresh_constant_instance env sigma cst in
+    let sigma, c = Evd.fresh_constant_instance dp env sigma cst in
     sigma, (c, Typeops.type_of_constant_in env c)) sigma schemes in
   let find_inductive ty =
     let (ctx, arity) = decompose_prod ty in

--- a/vernac/lemmas.ml
+++ b/vernac/lemmas.ml
@@ -242,7 +242,7 @@ let default_thm_id = Id.of_string "Unnamed_thm"
 
 let check_name_freshness locality {CAst.loc;v=id} : unit =
   (* We check existence here: it's a bit late at Qed time *)
-  if Nametab.exists_cci (Lib.make_path id) || is_section_variable id ||
+  if Nametab.exists_cci (Lib.make_path id) || is_section_variable (Global.env ()) id ||
      locality <> Discharge && Nametab.exists_cci (Lib.make_path_except_section id)
   then
     user_err ?loc  (Id.print id ++ str " already exists.")

--- a/vernac/obligations.ml
+++ b/vernac/obligations.ml
@@ -256,7 +256,7 @@ let eterm_obligations env name evm fs ?status t ty =
 let hide_obligation () =
   Coqlib.check_required_library ["Coq";"Program";"Tactics"];
   let dp = Global.current_dirpath () in
-  UnivGen.constr_of_monomorphic_global dp (Coqlib.lib_ref "program.tactics.obligation")
+  UnivGen.constr_of_monomorphic_global dp (Global.env ()) (Coqlib.lib_ref "program.tactics.obligation")
 
 let pperror cmd = CErrors.user_err ~hdr:"Program" cmd
 let error s = pperror (str s)

--- a/vernac/obligations.ml
+++ b/vernac/obligations.ml
@@ -255,7 +255,8 @@ let eterm_obligations env name evm fs ?status t ty =
 
 let hide_obligation () =
   Coqlib.check_required_library ["Coq";"Program";"Tactics"];
-  UnivGen.constr_of_monomorphic_global (Coqlib.lib_ref "program.tactics.obligation")
+  let dp = Global.current_dirpath () in
+  UnivGen.constr_of_monomorphic_global dp (Coqlib.lib_ref "program.tactics.obligation")
 
 let pperror cmd = CErrors.user_err ~hdr:"Program" cmd
 let error s = pperror (str s)

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -142,7 +142,8 @@ let typecheck_params_and_fields finite def poly pl ps records =
 	 | _ -> user_err ?loc:(constr_loc t) (str"Sort expected."))
     | None -> 
       let uvarkind = Evd.univ_flexible_alg in
-      let sigma, s = Evd.new_sort_variable uvarkind sigma in
+      let dp = Global.current_dirpath () in
+      let sigma, s = Evd.new_sort_variable dp uvarkind sigma in
       (sigma, template), (EConstr.mkSort s, s)
   in
   let (sigma, template), typs = List.fold_left_map fold (sigma, true) records in

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -561,10 +561,11 @@ let start_proof_and_print ~program_mode ?hook k l =
   let inference_hook =
     if program_mode then
       let hook env sigma ev =
+        let genv = Global.env () in
         let tac = !Obligations.default_tactic in
         let evi = Evd.find sigma ev in
         let evi = Evarutil.nf_evar_info sigma evi in
-        let env = Evd.evar_filtered_env evi in
+        let env = Evd.evar_filtered_env genv evi in
         try
           let concl = evi.Evd.evar_concl in
           if not (Evarutil.is_ground_env sigma env &&

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -131,7 +131,7 @@ let show_proof ~pstate =
 let show_top_evars ~proof =
   (* spiwack: new as of Feb. 2010: shows goal evars in addition to non-goal evars. *)
   let Proof.{goals;shelf;given_up;sigma} = Proof.data proof in
-  pr_evars_int sigma ~shelf ~given_up 1 (Evd.undefined_map sigma)
+  pr_evars_int (Global.env ()) sigma ~shelf ~given_up 1 (Evd.undefined_map sigma)
 
 let show_universes ~proof =
   let Proof.{goals;sigma} = Proof.data proof in
@@ -1917,7 +1917,7 @@ let vernac_check_may_eval ~pstate ~atts redexp glopt rc =
         let l = Evar.Set.union (evars_of_term j.Environ.uj_val) (evars_of_term j.Environ.uj_type) in
         let j = { j with Environ.uj_type = Reductionops.nf_betaiota env sigma j.Environ.uj_type } in
         print_judgment env sigma j ++
-        pr_ne_evar_set (fnl () ++ str "where" ++ fnl ()) (mt ()) sigma l
+        pr_ne_evar_set (fnl () ++ str "where" ++ fnl ()) (mt ()) (Global.env ()) sigma l
     | Some r ->
         let (sigma,r_interp) = Hook.get f_interp_redexp env sigma r in
 	let redfun env evm c =


### PR DESCRIPTION
This is one of the most impactful changes on the codebase when trying
to make `engine` not to use `Global`.

This patch just showcases the impact, but IMO it is clear that we want
to add the current dirpath to the evar map, or to some other place.

However note that this deserves some thinking, as for example that
would impact `Evd.from_env` etc... so we must discuss how to organize
things.
