### PR TITLE
[lexer] correctly update line number when lexing QUOTATION (fix #10350)

### DIFF
--- a/test-suite/misc/quotation_token.sh
+++ b/test-suite/misc/quotation_token.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -e
+
+export COQBIN=$BIN
+export PATH=$COQBIN:$PATH
+
+cd misc/quotation_token/
+
+coq_makefile -f _CoqProject -o Makefile
+
+make clean
+
+make src/quotation_plugin.cma
+
+TMP=`mktemp`
+
+if make > $TMP 2>&1; then
+  echo "should fail"
+  rm $TMP
+  exit 1
+fi
+
+if grep "File.*quotation.v., line 12, characters 6-30" $TMP; then
+  rm $TMP
+  exit 0
+else
+  echo "wong loc: `grep File.*quotation.v $TMP`"
+  rm $TMP
+  exit 1
+fi

--- a/test-suite/misc/quotation_token/.gitignore
+++ b/test-suite/misc/quotation_token/.gitignore
@@ -1,0 +1,2 @@
+/Makefile*
+/src/quotation.ml

--- a/test-suite/misc/quotation_token/_CoqProject
+++ b/test-suite/misc/quotation_token/_CoqProject
@@ -1,0 +1,6 @@
+-Q theories Quotation
+-I src
+
+src/quotation.mlg
+src/quotation_plugin.mlpack
+theories/quotation.v

--- a/test-suite/misc/quotation_token/src/quotation.mlg
+++ b/test-suite/misc/quotation_token/src/quotation.mlg
@@ -1,0 +1,12 @@
+{
+open Pcoq.Constr
+}
+GRAMMAR EXTEND Gram
+  GLOBAL: operconstr;
+
+  operconstr: LEVEL "0"
+    [ [ s = QUOTATION "foobar:" ->
+        {
+          CAst.make ~loc Constrexpr.(CSort Glob_term.(UNamed [GProp,0])) } ] ]
+  ;
+END

--- a/test-suite/misc/quotation_token/src/quotation_plugin.mlpack
+++ b/test-suite/misc/quotation_token/src/quotation_plugin.mlpack
@@ -1,0 +1,1 @@
+Quotation

--- a/test-suite/misc/quotation_token/theories/quotation.v
+++ b/test-suite/misc/quotation_token/theories/quotation.v
@@ -1,0 +1,13 @@
+
+Declare ML Module "quotation_plugin".
+
+Definition x := foobar:{{ hello
+  there
+}}.
+
+Definition y := foobar:{{ another
+  multi line
+  thing
+}}.
+Check foobar:{{ oops
+ ips }} y.


### PR DESCRIPTION
a `kwd:{{quoted text}}` can spawn on multiple lines. We were not updating the loc wrt the line number (only wrt the characters numbers)