### PR TITLE
[errors] remove "is_handled" logic, turn unhandled into anomalies

### DIFF
--- a/lib/cErrors.mli
+++ b/lib/cErrors.mli
@@ -89,7 +89,3 @@ val iprint_no_report : Exninfo.iexn -> Pp.t
     Typical example: [Sys.Break], [Assert_failure], [Anomaly] ...
 *)
 val noncritical : exn -> bool
-
-(** Check whether an exception is handled by some toplevel printer. The
-    [Anomaly] exception is never handled. *)
-val handled : exn -> bool

--- a/toplevel/coqargs.ml
+++ b/toplevel/coqargs.ml
@@ -10,7 +10,7 @@
 
 let fatal_error exn =
   Topfmt.(in_phase ~phase:ParsingCommandLine print_err_exn exn);
-  let exit_code = if CErrors.(is_anomaly exn || not (handled exn)) then 129 else 1 in
+  let exit_code = if (CErrors.is_anomaly exn) then 129 else 1 in
   exit exit_code
 
 let error_wrong_arg msg =

--- a/toplevel/coqc.ml
+++ b/toplevel/coqc.ml
@@ -62,7 +62,5 @@ let main () =
     flush_all();
     Topfmt.print_err_exn exn;
     flush_all();
-    let exit_code =
-      if CErrors.(is_anomaly exn || not (handled exn)) then 129 else 1
-    in
+    let exit_code = if (CErrors.is_anomaly exn) then 129 else 1 in
     exit exit_code

--- a/toplevel/coqcargs.ml
+++ b/toplevel/coqcargs.ml
@@ -48,7 +48,7 @@ let depr opt =
 (* XXX Remove this duplication with Coqargs *)
 let fatal_error exn =
   Topfmt.(in_phase ~phase:ParsingCommandLine print_err_exn exn);
-  let exit_code = if CErrors.(is_anomaly exn || not (handled exn)) then 129 else 1 in
+  let exit_code = if (CErrors.is_anomaly exn) then 129 else 1 in
   exit exit_code
 
 let error_missing_arg s =

--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -103,7 +103,7 @@ let fatal_error_exn exn =
   Topfmt.(in_phase ~phase:Initialization print_err_exn exn);
   flush_all ();
   let exit_code =
-    if CErrors.(is_anomaly exn || not (handled exn)) then 129 else 1
+    if (CErrors.is_anomaly exn) then 129 else 1
   in
   exit exit_code
 

--- a/user-contrib/Ltac2/tac2print.ml
+++ b/user-contrib/Ltac2/tac2print.ml
@@ -473,7 +473,7 @@ end
 
 let () = register_init "err" begin fun _ _ e ->
   let e = to_ext val_exn e in
-  let (e, _) = ExplainErr.process_vernac_interp_error ~allow_uncaught:true e in
+  let (e, _) = ExplainErr.process_vernac_interp_error e in
   str "err:(" ++ CErrors.print_no_report e ++ str ")"
 end
 

--- a/vernac/explainErr.mli
+++ b/vernac/explainErr.mli
@@ -13,7 +13,7 @@ exception EvaluatedError of Pp.t * exn option
 
 (** Pre-explain a vernac interpretation error *)
 
-val process_vernac_interp_error : ?allow_uncaught:bool -> Util.iexn -> Util.iexn
+val process_vernac_interp_error : Util.iexn -> Util.iexn
 
 (** General explain function. Should not be used directly now,
     see instead function [Errors.print] and variants *)

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -2308,8 +2308,7 @@ let with_fail ~st f =
     | HasNotFailed as e -> raise e
     | e when CErrors.noncritical e || e = Timeout ->
       let e = CErrors.push e in
-      raise (HasFailed (CErrors.iprint
-                          (ExplainErr.process_vernac_interp_error ~allow_uncaught:false e)))
+      raise (HasFailed (CErrors.iprint (ExplainErr.process_vernac_interp_error e)))
   with e when CErrors.noncritical e ->
     (* Restore the previous state XXX Careful here with the cache! *)
     Vernacstate.invalidate_cache ();


### PR DESCRIPTION
We place the check for unhandled exceptions in the `is_anomaly`
function, and consider all the exceptions non-handled by the printers
always anomalies.

This reworks the solution implemented in
ea39094 , in particular
`allow_uncaught` cannot be used anymore, all exceptions must install a
printer.

In order to pass the test-suite CI we also had to register some
printers, that were not registered for no reason, forcing clients to
call a post-processing step on errors.