### PR TITLE
Fix #10090: Ltac1 destruct and Ltac2 destruct should do the same thing.

### DIFF
--- a/user-contrib/Ltac2/Std.v
+++ b/user-contrib/Ltac2/Std.v
@@ -145,7 +145,7 @@ Ltac2 @ external set : evar_flag -> (unit -> ident option * constr) -> clause ->
 Ltac2 @ external remember : evar_flag -> ident option -> (unit -> constr) -> intro_pattern option -> clause -> unit := "ltac2" "tac_remember".
 
 Ltac2 @ external destruct : evar_flag -> induction_clause list ->
-  constr_with_bindings option -> unit := "ltac2" "tac_induction".
+  constr_with_bindings option -> unit := "ltac2" "tac_destruct".
 
 Ltac2 @ external induction : evar_flag -> induction_clause list ->
   constr_with_bindings option -> unit := "ltac2" "tac_induction".


### PR DESCRIPTION
The ML wrapper was wrongly calling induction instead of destruct.

Fixes #10090.
Fixes #10379.