### PR TITLE
Ensuring that regular expression filtering in CI (iris) works on MacOS X

### DIFF
--- a/dev/ci/ci-iris-lambda-rust.sh
+++ b/dev/ci/ci-iris-lambda-rust.sh
@@ -8,14 +8,14 @@ install_ssreflect
 # Setup lambdaRust first
 git_download lambdaRust
 
-# Extract required version of Iris
-Iris_CI_REF=$(grep -F coq-iris < "${CI_BUILD_DIR}/lambdaRust/opam" | sed 's/.*"dev\.[0-9.-]\+\.\([0-9a-z]\+\)".*/\1/')
+# Extract required version of Iris (avoiding "+" which does not work on MacOS :( *)
+Iris_CI_REF=$(grep -F coq-iris < "${CI_BUILD_DIR}/lambdaRust/opam" | sed 's/.*"dev\.[0-9][0-9.-]*\.\([0-9a-z][0-9a-z]*\)".*/\1/')
 
 # Setup Iris
 git_download Iris
 
 # Extract required version of std++
-stdpp_CI_REF=$(grep -F coq-stdpp < "${CI_BUILD_DIR}/Iris/opam" | sed 's/.*"dev\.[0-9.-]\+\.\([0-9a-z]\+\)".*/\1/')
+stdpp_CI_REF=$(grep -F coq-stdpp < "${CI_BUILD_DIR}/Iris/opam" | sed 's/.*"dev\.[0-9][0-9.-]*\.\([0-9a-z][0-9a-z]*\)".*/\1/')
 
 # Setup std++
 git_download stdpp


### PR DESCRIPTION
Unfortunately, "+" regular expressions are not supported by default with MacOS X's `sed`. As to be able to run iris ci target on a macos X platform, this PR emulates "+" expressions from "*" expressions.

It is told that it would work with `sed` option `-E` though, but the syntax seems then different and I did not investigate further.

**Kind:**  infrastructure.