### PR TITLE
Revert "Fix bug #5710"

### DIFF
--- a/ide/coqOps.ml
+++ b/ide/coqOps.ml
@@ -732,7 +732,6 @@ object(self)
       let start = self#get_start_of_input in
       let stop = self#get_end_of_input in
       Minilib.log(Printf.sprintf "cleanup tags %d %d" start#offset stop#offset);
-      buffer#remove_tag Tags.Script.sentence ~start ~stop;
       buffer#remove_tag Tags.Script.tooltip ~start ~stop;
       buffer#remove_tag Tags.Script.processed ~start ~stop;
       buffer#remove_tag Tags.Script.incomplete ~start ~stop;


### PR DESCRIPTION
This reverts commit 6d0083bb07528d7cd7ad2f8815d06a4e41deb16c.

CoqIDE does not work correctly. As Pierre-Marie describes:

> step to reproduce:

> Goal True.
Proof.
exact I.

> go two steps with Mod+Down
one up with Mod+Up
then try going down again
good luck
(going fully up resets the buffer)

cc/ @ppedrot @Zimmi48 @cstolze