### PR TITLE
Desynchronize the type of proof and kernel entries

### DIFF
--- a/dev/ci/user-overlays/10406-ppedrot-desync-entry-proof.sh
+++ b/dev/ci/user-overlays/10406-ppedrot-desync-entry-proof.sh
@@ -1,0 +1,9 @@
+if [ "$CI_PULL_REQUEST" = "10406" ] || [ "$CI_BRANCH" = "desync-entry-proof" ]; then
+
+    equations_CI_REF=desync-entry-proof
+    equations_CI_GITURL=https://github.com/ppedrot/Coq-Equations
+
+    quickchick_CI_REF=desync-entry-proof
+    quickchick_CI_GITURL=https://github.com/ppedrot/QuickChick
+
+fi

--- a/engine/uState.ml
+++ b/engine/uState.ml
@@ -452,9 +452,9 @@ let restrict ctx vars =
   let uctx' = restrict_universe_context ctx.uctx_local vars in
   { ctx with uctx_local = uctx' }
 
-let demote_seff_univs entry uctx =
+let demote_seff_univs universes uctx =
   let open Entries in
-  match entry.const_entry_universes with
+  match universes with
   | Polymorphic_entry _ -> uctx
   | Monomorphic_entry (univs, _) ->
     let seff = LSet.union uctx.uctx_seff_univs univs in

--- a/engine/uState.mli
+++ b/engine/uState.mli
@@ -100,7 +100,7 @@ val restrict_universe_context : ContextSet.t -> LSet.t -> ContextSet.t
    universes are preserved. *)
 val restrict : t -> Univ.LSet.t -> t
 
-val demote_seff_univs : 'a Entries.definition_entry -> t -> t
+val demote_seff_univs : Entries.universes_entry -> t -> t
 
 type rigid = 
   | UnivRigid

--- a/interp/interp.mllib
+++ b/interp/interp.mllib
@@ -17,4 +17,3 @@ Implicit_quantifiers
 Constrintern
 Modintern
 Constrextern
-Declare

--- a/kernel/entries.ml
+++ b/kernel/entries.ml
@@ -85,7 +85,7 @@ type 'a opaque_entry = {
   opaque_entry_feedback : Stateid.t option;
   opaque_entry_type        : types;
   opaque_entry_universes   : universes_entry;
-  opaque_entry_inline_code : bool }
+}
 
 type inline = int option (* inlining level, None for no inlining *)
 

--- a/kernel/entries.ml
+++ b/kernel/entries.ml
@@ -61,7 +61,7 @@ type 'a proof_output = constr Univ.in_universe_context_set * 'a
 type 'a const_entry_body = 'a proof_output Future.computation
 
 type 'a definition_entry = {
-  const_entry_body   : 'a const_entry_body;
+  const_entry_body   : 'a;
   (* List of section variables *)
   const_entry_secctx : Constr.named_context option;
   (* State id on which the completion of type checking is reported *)
@@ -89,8 +89,8 @@ type primitive_entry = {
 }
 
 type 'a constant_entry =
-  | DefinitionEntry of 'a definition_entry
-  | OpaqueEntry of 'a definition_entry
+  | DefinitionEntry of constr Univ.in_universe_context_set definition_entry
+  | OpaqueEntry of 'a const_entry_body definition_entry
   | ParameterEntry of parameter_entry
   | PrimitiveEntry of primitive_entry
 

--- a/kernel/entries.ml
+++ b/kernel/entries.ml
@@ -77,6 +77,16 @@ type section_def_entry = {
   secdef_type : types option;
 }
 
+type 'a opaque_entry = {
+  opaque_entry_body   : 'a;
+  (* List of section variables *)
+  opaque_entry_secctx : Constr.named_context option;
+  (* State id on which the completion of type checking is reported *)
+  opaque_entry_feedback : Stateid.t option;
+  opaque_entry_type        : types option;
+  opaque_entry_universes   : universes_entry;
+  opaque_entry_inline_code : bool }
+
 type inline = int option (* inlining level, None for no inlining *)
 
 type parameter_entry = 
@@ -90,7 +100,7 @@ type primitive_entry = {
 
 type 'a constant_entry =
   | DefinitionEntry of constr Univ.in_universe_context_set definition_entry
-  | OpaqueEntry of 'a const_entry_body definition_entry
+  | OpaqueEntry of 'a const_entry_body opaque_entry
   | ParameterEntry of parameter_entry
   | PrimitiveEntry of primitive_entry
 

--- a/kernel/entries.ml
+++ b/kernel/entries.ml
@@ -60,8 +60,8 @@ type mutual_inductive_entry = {
 type 'a proof_output = constr Univ.in_universe_context_set * 'a
 type 'a const_entry_body = 'a proof_output Future.computation
 
-type 'a definition_entry = {
-  const_entry_body   : 'a;
+type definition_entry = {
+  const_entry_body   : constr Univ.in_universe_context_set;
   (* List of section variables *)
   const_entry_secctx : Constr.named_context option;
   (* State id on which the completion of type checking is reported *)
@@ -99,7 +99,7 @@ type primitive_entry = {
 }
 
 type 'a constant_entry =
-  | DefinitionEntry of constr Univ.in_universe_context_set definition_entry
+  | DefinitionEntry of definition_entry
   | OpaqueEntry of 'a const_entry_body opaque_entry
   | ParameterEntry of parameter_entry
   | PrimitiveEntry of primitive_entry

--- a/kernel/entries.ml
+++ b/kernel/entries.ml
@@ -83,7 +83,7 @@ type 'a opaque_entry = {
   opaque_entry_secctx : Constr.named_context option;
   (* State id on which the completion of type checking is reported *)
   opaque_entry_feedback : Stateid.t option;
-  opaque_entry_type        : types option;
+  opaque_entry_type        : types;
   opaque_entry_universes   : universes_entry;
   opaque_entry_inline_code : bool }
 

--- a/kernel/entries.ml
+++ b/kernel/entries.ml
@@ -68,7 +68,6 @@ type 'a definition_entry = {
   const_entry_feedback : Stateid.t option;
   const_entry_type        : types option;
   const_entry_universes   : universes_entry;
-  const_entry_opaque      : bool;
   const_entry_inline_code : bool }
 
 type section_def_entry = {
@@ -91,6 +90,7 @@ type primitive_entry = {
 
 type 'a constant_entry =
   | DefinitionEntry of 'a definition_entry
+  | OpaqueEntry of 'a definition_entry
   | ParameterEntry of parameter_entry
   | PrimitiveEntry of primitive_entry
 

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -690,12 +690,12 @@ let constant_entry_of_side_effect eff =
     | _ -> assert false in
   if Declareops.is_opaque cb then
   OpaqueEntry {
-    const_entry_body = Future.from_val ((p, Univ.ContextSet.empty), ());
-    const_entry_secctx = None;
-    const_entry_feedback = None;
-    const_entry_type = Some cb.const_type;
-    const_entry_universes = univs;
-    const_entry_inline_code = cb.const_inline_code }
+    opaque_entry_body = Future.from_val ((p, Univ.ContextSet.empty), ());
+    opaque_entry_secctx = None;
+    opaque_entry_feedback = None;
+    opaque_entry_type = Some cb.const_type;
+    opaque_entry_universes = univs;
+    opaque_entry_inline_code = cb.const_inline_code }
   else
   DefinitionEntry {
     const_entry_body = (p, Univ.ContextSet.empty);

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -688,13 +688,21 @@ let constant_entry_of_side_effect eff =
     | OpaqueDef b -> b
     | Def b -> Mod_subst.force_constr b
     | _ -> assert false in
+  if Declareops.is_opaque cb then
+  OpaqueEntry {
+    const_entry_body = Future.from_val ((p, Univ.ContextSet.empty), ());
+    const_entry_secctx = None;
+    const_entry_feedback = None;
+    const_entry_type = Some cb.const_type;
+    const_entry_universes = univs;
+    const_entry_inline_code = cb.const_inline_code }
+  else
   DefinitionEntry {
     const_entry_body = Future.from_val ((p, Univ.ContextSet.empty), ());
     const_entry_secctx = None;
     const_entry_feedback = None;
     const_entry_type = Some cb.const_type;
     const_entry_universes = univs;
-    const_entry_opaque = Declareops.is_opaque cb;
     const_entry_inline_code = cb.const_inline_code }
 
 let export_eff eff =

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -698,7 +698,7 @@ let constant_entry_of_side_effect eff =
     const_entry_inline_code = cb.const_inline_code }
   else
   DefinitionEntry {
-    const_entry_body = Future.from_val ((p, Univ.ContextSet.empty), ());
+    const_entry_body = (p, Univ.ContextSet.empty);
     const_entry_secctx = None;
     const_entry_feedback = None;
     const_entry_type = Some cb.const_type;

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -693,7 +693,7 @@ let constant_entry_of_side_effect eff =
     opaque_entry_body = Future.from_val ((p, Univ.ContextSet.empty), ());
     opaque_entry_secctx = None;
     opaque_entry_feedback = None;
-    opaque_entry_type = Some cb.const_type;
+    opaque_entry_type = cb.const_type;
     opaque_entry_universes = univs;
     opaque_entry_inline_code = cb.const_inline_code }
   else

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -695,7 +695,7 @@ let constant_entry_of_side_effect eff =
     opaque_entry_feedback = None;
     opaque_entry_type = cb.const_type;
     opaque_entry_universes = univs;
-    opaque_entry_inline_code = cb.const_inline_code }
+  }
   else
   DefinitionEntry {
     const_entry_body = (p, Univ.ContextSet.empty);

--- a/kernel/term_typing.ml
+++ b/kernel/term_typing.ml
@@ -196,13 +196,9 @@ let infer_declaration (type a) ~(trust : a trust) env (dcl : a constant_entry) =
   (** Other definitions have to be processed immediately. *)
   | DefinitionEntry c ->
       let { const_entry_type = typ; _ } = c in
-      let { const_entry_body = body; const_entry_feedback = feedback_id; _ } = c in
-      (* Opaque constants must be provided with a non-empty const_entry_type,
-         and thus should have been treated above. *)
-      let body, ctx = match trust with
-      | Pure ->
-        let (body, ctx), () = Future.join body in
-        body, ctx
+      let { const_entry_body = (body, ctx); const_entry_feedback = feedback_id; _ } = c in
+      let () = match trust with
+      | Pure -> ()
       | SideEffects _ -> assert false
       in
       let env, usubst, univs = match c.const_entry_universes with
@@ -366,7 +362,7 @@ let translate_recipe env _kn r =
 
 let translate_local_def env _id centry =
   let open Cooking in
-  let body = Future.from_val ((centry.secdef_body, Univ.ContextSet.empty), ()) in
+  let body = (centry.secdef_body, Univ.ContextSet.empty) in
   let centry = {
     const_entry_body = body;
     const_entry_secctx = centry.secdef_secctx;

--- a/kernel/term_typing.ml
+++ b/kernel/term_typing.ml
@@ -117,7 +117,6 @@ let infer_declaration (type a) ~(trust : a trust) env (dcl : a constant_entry) =
 
   | OpaqueEntry ({ opaque_entry_type = typ;
                        opaque_entry_universes = Monomorphic_entry univs; _ } as c) ->
-      let typ = match typ with None -> assert false | Some typ -> typ in
       let env = push_context_set ~strict:true univs env in
       let { opaque_entry_body = body; opaque_entry_feedback = feedback_id; _ } = c in
       let tyj = Typeops.infer_type env typ in
@@ -159,7 +158,6 @@ let infer_declaration (type a) ~(trust : a trust) env (dcl : a constant_entry) =
 
   | OpaqueEntry ({ opaque_entry_type = typ;
                        opaque_entry_universes = Polymorphic_entry (nas, uctx); _ } as c) ->
-      let typ = match typ with None -> assert false | Some typ -> typ in
       let { opaque_entry_body = body; opaque_entry_feedback = feedback_id; _ } = c in
       let env = push_context ~strict:false uctx env in
       let tj = Typeops.infer_type env typ in

--- a/kernel/term_typing.ml
+++ b/kernel/term_typing.ml
@@ -115,11 +115,11 @@ let infer_declaration (type a) ~(trust : a trust) env (dcl : a constant_entry) =
   (** Definition [c] is opaque (Qed), non polymorphic and with a specified type,
       so we delay the typing and hash consing of its body. *)
 
-  | OpaqueEntry ({ const_entry_type = typ;
-                       const_entry_universes = Monomorphic_entry univs; _ } as c) ->
+  | OpaqueEntry ({ opaque_entry_type = typ;
+                       opaque_entry_universes = Monomorphic_entry univs; _ } as c) ->
       let typ = match typ with None -> assert false | Some typ -> typ in
       let env = push_context_set ~strict:true univs env in
-      let { const_entry_body = body; const_entry_feedback = feedback_id; _ } = c in
+      let { opaque_entry_body = body; opaque_entry_feedback = feedback_id; _ } = c in
       let tyj = Typeops.infer_type env typ in
       let proofterm =
         Future.chain body begin fun ((body,uctx),side_eff) ->
@@ -151,16 +151,16 @@ let infer_declaration (type a) ~(trust : a trust) env (dcl : a constant_entry) =
         cook_type = tyj.utj_val;
         cook_universes = Monomorphic univs;
         cook_relevance = Sorts.relevance_of_sort tyj.utj_type;
-        cook_inline = c.const_entry_inline_code;
-        cook_context = c.const_entry_secctx;
+        cook_inline = c.opaque_entry_inline_code;
+        cook_context = c.opaque_entry_secctx;
       }
 
   (** Similar case for polymorphic entries. *)
 
-  | OpaqueEntry ({ const_entry_type = typ;
-                       const_entry_universes = Polymorphic_entry (nas, uctx); _ } as c) ->
+  | OpaqueEntry ({ opaque_entry_type = typ;
+                       opaque_entry_universes = Polymorphic_entry (nas, uctx); _ } as c) ->
       let typ = match typ with None -> assert false | Some typ -> typ in
-      let { const_entry_body = body; const_entry_feedback = feedback_id; _ } = c in
+      let { opaque_entry_body = body; opaque_entry_feedback = feedback_id; _ } = c in
       let env = push_context ~strict:false uctx env in
       let tj = Typeops.infer_type env typ in
       let sbst, auctx = Univ.abstract_universes nas uctx in
@@ -189,8 +189,8 @@ let infer_declaration (type a) ~(trust : a trust) env (dcl : a constant_entry) =
         cook_type = typ;
         cook_universes = Polymorphic auctx;
         cook_relevance = Sorts.relevance_of_sort tj.utj_type;
-        cook_inline = c.const_entry_inline_code;
-        cook_context = c.const_entry_secctx;
+        cook_inline = c.opaque_entry_inline_code;
+        cook_context = c.opaque_entry_secctx;
       }
 
   (** Other definitions have to be processed immediately. *)

--- a/kernel/term_typing.ml
+++ b/kernel/term_typing.ml
@@ -150,7 +150,7 @@ let infer_declaration (type a) ~(trust : a trust) env (dcl : a constant_entry) =
         cook_type = tyj.utj_val;
         cook_universes = Monomorphic univs;
         cook_relevance = Sorts.relevance_of_sort tyj.utj_type;
-        cook_inline = c.opaque_entry_inline_code;
+        cook_inline = false;
         cook_context = c.opaque_entry_secctx;
       }
 
@@ -187,7 +187,7 @@ let infer_declaration (type a) ~(trust : a trust) env (dcl : a constant_entry) =
         cook_type = typ;
         cook_universes = Polymorphic auctx;
         cook_relevance = Sorts.relevance_of_sort tj.utj_type;
-        cook_inline = c.opaque_entry_inline_code;
+        cook_inline = false;
         cook_context = c.opaque_entry_secctx;
       }
 

--- a/plugins/funind/functional_principles_types.mli
+++ b/plugins/funind/functional_principles_types.mli
@@ -34,7 +34,7 @@ val generate_functional_principle :
 exception No_graph_found
 
 val make_scheme :   Evd.evar_map ref ->
- (pconstant*Sorts.family) list -> Evd.side_effects Entries.definition_entry list
+ (pconstant*Sorts.family) list -> Evd.side_effects Proof_global.proof_entry list
 
 val build_scheme : (Id.t*Libnames.qualid*Sorts.family) list ->  unit
 val build_case_scheme : (Id.t*Libnames.qualid*Sorts.family)  ->  unit

--- a/plugins/funind/indfun_common.ml
+++ b/plugins/funind/indfun_common.ml
@@ -118,14 +118,13 @@ let refl_equal = lazy(EConstr.of_constr (coq_constant "eq_refl"))
 (* Copy of the standard save mechanism but without the much too  *)
 (* slow reduction function                                       *)
 (*****************************************************************)
-open Entries
 open Decl_kinds
 open Declare
 
 let definition_message = Declare.definition_message
 
 let save id const ?hook uctx (locality,_,kind) =
-  let fix_exn = Future.fix_exn_of const.const_entry_body in
+  let fix_exn = Future.fix_exn_of const.Proof_global.proof_entry_body in
   let r = match locality with
     | Discharge ->
         let k = Kindops.logical_kind_of_goal_kind kind in
@@ -134,7 +133,7 @@ let save id const ?hook uctx (locality,_,kind) =
         VarRef id
     | Global local ->
         let k = Kindops.logical_kind_of_goal_kind kind in
-        let kn = declare_constant id ~local (DefinitionEntry const, k) in
+        let kn = declare_constant id ~local (Declare.DefinitionEntry const, k) in
         ConstRef kn
   in
   DeclareDef.Hook.call ?hook ~fix_exn uctx [] locality r;

--- a/plugins/funind/indfun_common.mli
+++ b/plugins/funind/indfun_common.mli
@@ -44,7 +44,7 @@ val jmeq_refl : unit -> EConstr.constr
 
 val save
   :  Id.t
-  -> Evd.side_effects Entries.definition_entry
+  -> Evd.side_effects Proof_global.proof_entry
   -> ?hook:DeclareDef.Hook.t
   -> UState.t
   -> Decl_kinds.goal_kind

--- a/plugins/funind/invfun.ml
+++ b/plugins/funind/invfun.ml
@@ -786,7 +786,7 @@ let derive_correctness make_scheme (funs: pconstant list) (graphs:inductive list
           Array.of_list
             (List.map
                (fun entry ->
-                  (EConstr.of_constr (fst (fst(Future.force entry.Entries.const_entry_body))), EConstr.of_constr (Option.get entry.Entries.const_entry_type ))
+                  (EConstr.of_constr (fst (fst(Future.force entry.Proof_global.proof_entry_body))), EConstr.of_constr (Option.get entry.Proof_global.proof_entry_type ))
                )
                (make_scheme evd (Array.map_to_list (fun const -> const,Sorts.InType) funs))
             )

--- a/plugins/funind/invfun.mli
+++ b/plugins/funind/invfun.mli
@@ -15,5 +15,5 @@ val invfun :
 val derive_correctness :
   (Evd.evar_map ref ->
    (Constr.pconstant * Sorts.family) list ->
-   'a Entries.definition_entry list) ->
+   'a Proof_global.proof_entry list) ->
    Constr.pconstant list -> Names.inductive list -> unit

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -17,7 +17,6 @@ open EConstr
 open Vars
 open Namegen
 open Environ
-open Entries
 open Pp
 open Names
 open Libnames

--- a/plugins/ltac/rewrite.ml
+++ b/plugins/ltac/rewrite.ml
@@ -1902,7 +1902,7 @@ let declare_projection n instance_id r =
     Declare.definition_entry ~types:typ ~univs term
   in
     ignore(Declare.declare_constant n 
-	   (Entries.DefinitionEntry cst, Decl_kinds.IsDefinition Decl_kinds.Definition))
+           (Declare.DefinitionEntry cst, Decl_kinds.IsDefinition Decl_kinds.Definition))
 
 let build_morphism_signature env sigma m =
   let m,ctx = Constrintern.interp_constr env sigma m in
@@ -1979,7 +1979,7 @@ let add_morphism_as_parameter atts m n : unit =
   let uctx, instance = build_morphism_signature env evd m in
   let uctx = UState.univ_entry ~poly:atts.polymorphic uctx in
   let cst = Declare.declare_constant ~internal:Declare.InternalTacticRequest instance_id
-      (Entries.ParameterEntry
+      (Declare.ParameterEntry
          (None,(instance,uctx),None),
        Decl_kinds.IsAssumption Decl_kinds.Logical)
   in

--- a/proofs/pfedit.ml
+++ b/proofs/pfedit.ml
@@ -11,7 +11,6 @@
 open Pp
 open Util
 open Names
-open Entries
 open Environ
 open Evd
 
@@ -127,7 +126,7 @@ let build_constant_by_tactic id ctx sign ?(goal_kind = Global ImportDefaultBehav
     let { entries; universes } = close_proof ~opaque:Transparent ~keep_body_ucst_separate:false (fun x -> x) pf in
     match entries with
     | [entry] ->
-      let univs = UState.demote_seff_univs entry universes in
+      let univs = UState.demote_seff_univs entry.Proof_global.proof_entry_universes universes in
       entry, status, univs
     | _ ->
       CErrors.anomaly Pp.(str "[build_constant_by_tactic] close_proof returned more than one proof term")
@@ -141,7 +140,7 @@ let build_by_tactic ?(side_eff=true) env sigma ?(poly=false) typ tac =
   let gk = Global ImportDefaultBehavior, poly, Proof Theorem in
   let ce, status, univs =
     build_constant_by_tactic id sigma sign ~goal_kind:gk typ tac in
-  let body, eff = Future.force ce.const_entry_body in
+  let body, eff = Future.force ce.Proof_global.proof_entry_body in
   let (cb, ctx) =
     if side_eff then Safe_typing.inline_private_constants env (body, eff.Evd.seff_private)
     else body

--- a/proofs/pfedit.mli
+++ b/proofs/pfedit.mli
@@ -61,7 +61,7 @@ val use_unification_heuristics : unit -> bool
 val build_constant_by_tactic :
   Id.t -> UState.t -> named_context_val -> ?goal_kind:goal_kind ->
   EConstr.types -> unit Proofview.tactic -> 
-  Evd.side_effects Entries.definition_entry * bool *
+  Evd.side_effects Proof_global.proof_entry * bool *
     UState.t
 
 val build_by_tactic : ?side_eff:bool -> env -> UState.t -> ?poly:polymorphic ->

--- a/proofs/proof_global.mli
+++ b/proofs/proof_global.mli
@@ -31,9 +31,21 @@ val compact_the_proof : t -> t
     function which takes a [proof_object] together with a [proof_end]
     (i.e. an proof ending command) and registers the appropriate
     values. *)
+type 'a proof_entry = {
+  proof_entry_body   : 'a Entries.const_entry_body;
+  (* List of section variables *)
+  proof_entry_secctx : Constr.named_context option;
+  (* State id on which the completion of type checking is reported *)
+  proof_entry_feedback : Stateid.t option;
+  proof_entry_type        : Constr.types option;
+  proof_entry_universes   : Entries.universes_entry;
+  proof_entry_opaque      : bool;
+  proof_entry_inline_code : bool;
+}
+
 type proof_object = {
   id : Names.Id.t;
-  entries : Evd.side_effects Entries.definition_entry list;
+  entries : Evd.side_effects proof_entry list;
   persistence : Decl_kinds.goal_kind;
   universes: UState.t;
 }

--- a/tactics/abstract.ml
+++ b/tactics/abstract.ml
@@ -70,19 +70,19 @@ let rec shrink ctx sign c t accu =
 | _ -> assert false
 
 let shrink_entry sign const =
-  let open Entries in
-  let typ = match const.const_entry_type with
+  let open Proof_global in
+  let typ = match const.proof_entry_type with
   | None -> assert false
   | Some t -> t
   in
   (* The body has been forced by the call to [build_constant_by_tactic] *)
-  let () = assert (Future.is_over const.const_entry_body) in
-  let ((body, uctx), eff) = Future.force const.const_entry_body in
+  let () = assert (Future.is_over const.proof_entry_body) in
+  let ((body, uctx), eff) = Future.force const.proof_entry_body in
   let (body, typ, ctx) = decompose (List.length sign) body typ [] in
   let (body, typ, args) = shrink ctx sign body typ [] in
   let const = { const with
-    const_entry_body = Future.from_val ((body, uctx), eff);
-    const_entry_type = Some typ;
+    proof_entry_body = Future.from_val ((body, uctx), eff);
+    proof_entry_type = Some typ;
   } in
   (const, args)
 
@@ -152,7 +152,7 @@ let cache_term_by_tactic_then ~opaque ~name_op ?(goal_type=None) tac tacK =
   in
   let const, args = shrink_entry sign const in
   let args = List.map EConstr.of_constr args in
-  let cd = Entries.DefinitionEntry { const with Entries.const_entry_opaque = opaque } in
+  let cd = Declare.DefinitionEntry { const with Proof_global.proof_entry_opaque = opaque } in
   let decl = (cd, if opaque then IsProof Lemma else IsDefinition Definition) in
   let cst () =
     (* do not compute the implicit arguments, it may be costly *)
@@ -161,20 +161,20 @@ let cache_term_by_tactic_then ~opaque ~name_op ?(goal_type=None) tac tacK =
     Declare.declare_private_constant ~internal:Declare.InternalTacticRequest ~local:ImportNeedQualified id decl
   in
   let cst, eff = Impargs.with_implicit_protection cst () in
-  let inst = match const.Entries.const_entry_universes with
+  let inst = match const.Proof_global.proof_entry_universes with
   | Entries.Monomorphic_entry _ -> EInstance.empty
   | Entries.Polymorphic_entry (_, ctx) ->
     (* We mimic what the kernel does, that is ensuring that no additional
        constraints appear in the body of polymorphic constants. Ideally this
        should be enforced statically. *)
-    let (_, body_uctx), _ = Future.force const.Entries.const_entry_body in
+    let (_, body_uctx), _ = Future.force const.Proof_global.proof_entry_body in
     let () = assert (Univ.ContextSet.is_empty body_uctx) in
     EInstance.make (Univ.UContext.instance ctx)
   in
   let lem = mkConstU (cst, inst) in
   let evd = Evd.set_universe_context evd ectx in
   let effs = Evd.concat_side_effects eff
-    Entries.(snd (Future.force const.const_entry_body)) in
+    Proof_global.(snd (Future.force const.proof_entry_body)) in
   let solve =
     Proofview.tclEFFECTS effs <*>
     tacK lem args

--- a/tactics/abstract.mli
+++ b/tactics/abstract.mli
@@ -26,5 +26,5 @@ val tclABSTRACT : ?opaque:bool -> Id.t option -> unit Proofview.tactic -> unit P
    save path *)
 val shrink_entry
   :  ('a, 'b) Context.Named.Declaration.pt list
-  -> 'c Entries.definition_entry
-  -> 'c Entries.definition_entry * Constr.t list
+  -> 'c Proof_global.proof_entry
+  -> 'c Proof_global.proof_entry * Constr.t list

--- a/tactics/declare.ml
+++ b/tactics/declare.ml
@@ -175,12 +175,12 @@ let cast_proof_entry e =
 let cast_opaque_proof_entry e =
   let open Proof_global in
   {
-    const_entry_body = e.proof_entry_body;
-    const_entry_secctx = e.proof_entry_secctx;
-    const_entry_feedback = e.proof_entry_feedback;
-    const_entry_type = e.proof_entry_type;
-    const_entry_universes = e.proof_entry_universes;
-    const_entry_inline_code = e.proof_entry_inline_code;
+    opaque_entry_body = e.proof_entry_body;
+    opaque_entry_secctx = e.proof_entry_secctx;
+    opaque_entry_feedback = e.proof_entry_feedback;
+    opaque_entry_type = e.proof_entry_type;
+    opaque_entry_universes = e.proof_entry_universes;
+    opaque_entry_inline_code = e.proof_entry_inline_code;
   }
 
 let get_roles export eff =

--- a/tactics/declare.ml
+++ b/tactics/declare.ml
@@ -174,11 +174,15 @@ let cast_proof_entry e =
 
 let cast_opaque_proof_entry e =
   let open Proof_global in
+  let typ = match e.proof_entry_type with
+  | None -> assert false
+  | Some typ -> typ
+  in
   {
     opaque_entry_body = e.proof_entry_body;
     opaque_entry_secctx = e.proof_entry_secctx;
     opaque_entry_feedback = e.proof_entry_feedback;
-    opaque_entry_type = e.proof_entry_type;
+    opaque_entry_type = typ;
     opaque_entry_universes = e.proof_entry_universes;
     opaque_entry_inline_code = e.proof_entry_inline_code;
   }

--- a/tactics/declare.ml
+++ b/tactics/declare.ml
@@ -184,7 +184,6 @@ let cast_opaque_proof_entry e =
     opaque_entry_feedback = e.proof_entry_feedback;
     opaque_entry_type = typ;
     opaque_entry_universes = e.proof_entry_universes;
-    opaque_entry_inline_code = e.proof_entry_inline_code;
   }
 
 let get_roles export eff =

--- a/tactics/declare.ml
+++ b/tactics/declare.ml
@@ -303,18 +303,18 @@ let inductive_names sp kn mie =
   let names, _ =
     List.fold_left
       (fun (names, n) ind ->
-	 let ind_p = (kn,n) in
-	 let names, _ =
-	   List.fold_left
-	     (fun (names, p) l ->
-		let sp =
-		  Libnames.make_path dp l
-		in
-		  ((sp, ConstructRef (ind_p,p)) :: names, p+1))
-	     (names, 1) ind.mind_entry_consnames in
-	 let sp = Libnames.make_path dp ind.mind_entry_typename
-	 in
-	   ((sp, IndRef ind_p) :: names, n+1))
+         let ind_p = (kn,n) in
+         let names, _ =
+           List.fold_left
+             (fun (names, p) l ->
+                let sp =
+                  Libnames.make_path dp l
+                in
+                  ((sp, ConstructRef (ind_p,p)) :: names, p+1))
+             (names, 1) ind.mind_entry_consnames in
+         let sp = Libnames.make_path dp ind.mind_entry_typename
+         in
+           ((sp, IndRef ind_p) :: names, n+1))
       ([], 0) mie.mind_entry_inds
   in names
 
@@ -448,15 +448,15 @@ let fixpoint_message indexes l =
   | [] -> anomaly (Pp.str "no recursive definition.")
   | [id] -> Id.print id ++ str " is recursively defined" ++
       (match indexes with
-	 | Some [|i|] -> str " (decreasing on "++pr_rank i++str " argument)"
-	 | _ -> mt ())
+         | Some [|i|] -> str " (decreasing on "++pr_rank i++str " argument)"
+         | _ -> mt ())
   | l -> hov 0 (prlist_with_sep pr_comma Id.print l ++
-		  spc () ++ str "are recursively defined" ++
-		  match indexes with
-		    | Some a -> spc () ++ str "(decreasing respectively on " ++
-			prvect_with_sep pr_comma pr_rank a ++
-			str " arguments)"
-		    | None -> mt ()))
+                  spc () ++ str "are recursively defined" ++
+                  match indexes with
+                    | Some a -> spc () ++ str "(decreasing respectively on " ++
+                        prvect_with_sep pr_comma pr_rank a ++
+                        str " arguments)"
+                    | None -> mt ()))
 
 let cofixpoint_message l =
   Flags.if_verbose Feedback.msg_info (match l with

--- a/tactics/declare.ml
+++ b/tactics/declare.ml
@@ -162,6 +162,18 @@ let definition_entry ?fix_exn ?(opaque=false) ?(inline=false) ?types
 
 let cast_proof_entry e =
   let open Proof_global in
+  let (body, ctx), () = Future.force e.proof_entry_body in
+  {
+    const_entry_body = (body, ctx);
+    const_entry_secctx = e.proof_entry_secctx;
+    const_entry_feedback = e.proof_entry_feedback;
+    const_entry_type = e.proof_entry_type;
+    const_entry_universes = e.proof_entry_universes;
+    const_entry_inline_code = e.proof_entry_inline_code;
+  }
+
+let cast_opaque_proof_entry e =
+  let open Proof_global in
   {
     const_entry_body = e.proof_entry_body;
     const_entry_secctx = e.proof_entry_secctx;
@@ -198,7 +210,7 @@ let define_constant ~side_effect ?(export_seff=false) id cd =
       let export = get_roles export eff in
       let de = { de with proof_entry_body = Future.from_val (body, ()) } in
       let cd = match de.proof_entry_opaque with
-      | true -> Entries.OpaqueEntry (cast_proof_entry de)
+      | true -> Entries.OpaqueEntry (cast_opaque_proof_entry de)
       | false -> Entries.DefinitionEntry (cast_proof_entry de)
       in
       export, ConstantEntry (PureEntry, cd)
@@ -207,7 +219,7 @@ let define_constant ~side_effect ?(export_seff=false) id cd =
       let map (body, eff) = body, eff.Evd.seff_private in
       let body = Future.chain de.proof_entry_body map in
       let de = { de with proof_entry_body = body } in
-      let de = cast_proof_entry de in
+      let de = cast_opaque_proof_entry de in
       [], ConstantEntry (EffectEntry, Entries.OpaqueEntry de)
     | ParameterEntry e ->
       [], ConstantEntry (PureEntry, Entries.ParameterEntry e)

--- a/tactics/declare.mli
+++ b/tactics/declare.mli
@@ -23,8 +23,13 @@ open Decl_kinds
 (** Declaration of local constructions (Variable/Hypothesis/Local) *)
 
 type section_variable_entry =
-  | SectionLocalDef of Evd.side_effects definition_entry
+  | SectionLocalDef of Evd.side_effects Proof_global.proof_entry
   | SectionLocalAssum of types Univ.in_universe_context_set * polymorphic * bool (** Implicit status *)
+
+type 'a constant_entry =
+  | DefinitionEntry of 'a Proof_global.proof_entry
+  | ParameterEntry of parameter_entry
+  | PrimitiveEntry of primitive_entry
 
 type variable_declaration = DirPath.t * section_variable_entry * logical_kind
 
@@ -44,7 +49,7 @@ type internal_flag =
 val definition_entry : ?fix_exn:Future.fix_exn ->
   ?opaque:bool -> ?inline:bool -> ?types:types ->
   ?univs:Entries.universes_entry ->
-  ?eff:Evd.side_effects -> constr -> Evd.side_effects definition_entry
+  ?eff:Evd.side_effects -> constr -> Evd.side_effects Proof_global.proof_entry
 
 (** [declare_constant id cd] declares a global declaration
    (constant/parameter) with name [id] in the current section; it returns

--- a/tactics/declare.mli
+++ b/tactics/declare.mli
@@ -30,7 +30,7 @@ type variable_declaration = DirPath.t * section_variable_entry * logical_kind
 
 val declare_variable : variable -> variable_declaration -> Libobject.object_name
 
-(** Declaration of global constructions 
+(** Declaration of global constructions
    i.e. Definition/Theorem/Axiom/Parameter/... *)
 
 type constant_declaration = Evd.side_effects constant_entry * logical_kind
@@ -58,7 +58,7 @@ val declare_constant :
 val declare_private_constant :
   ?role:Evd.side_effect_role -> ?internal:internal_flag -> ?local:import_status -> Id.t -> constant_declaration -> Constant.t * Evd.side_effects
 
-val declare_definition : 
+val declare_definition :
   ?internal:internal_flag -> ?opaque:bool -> ?kind:definition_object_kind ->
   ?local:import_status -> Id.t -> ?types:constr ->
   constr Entries.in_universes_entry -> Constant.t

--- a/tactics/ind_tables.ml
+++ b/tactics/ind_tables.ml
@@ -23,7 +23,6 @@ open Constr
 open CErrors
 open Util
 open Declare
-open Entries
 open Decl_kinds
 open Pp
 
@@ -122,15 +121,15 @@ let define internal role id c poly univs =
   let c = UnivSubst.nf_evars_and_universes_opt_subst (fun _ -> None) (UState.subst ctx) c in
   let univs = UState.univ_entry ~poly ctx in
   let entry = {
-    const_entry_body =
+    Proof_global.proof_entry_body =
       Future.from_val ((c,Univ.ContextSet.empty),
                        Evd.empty_side_effects);
-    const_entry_secctx = None;
-    const_entry_type = None;
-    const_entry_universes = univs;
-    const_entry_opaque = false;
-    const_entry_inline_code = false;
-    const_entry_feedback = None;
+    proof_entry_secctx = None;
+    proof_entry_type = None;
+    proof_entry_universes = univs;
+    proof_entry_opaque = false;
+    proof_entry_inline_code = false;
+    proof_entry_feedback = None;
   } in
   let kn, eff = declare_private_constant ~role ~internal id (DefinitionEntry entry, Decl_kinds.IsDefinition Scheme) in
   let () = match internal with

--- a/tactics/leminv.ml
+++ b/tactics/leminv.ml
@@ -22,7 +22,6 @@ open Namegen
 open Evd
 open Printer
 open Reductionops
-open Entries
 open Inductiveops
 open Tacmach.New
 open Clenv

--- a/tactics/tactics.mllib
+++ b/tactics/tactics.mllib
@@ -1,3 +1,4 @@
+Declare
 Dnet
 Dn
 Btermdn

--- a/test-suite/misc/poly-capture-global-univs/src/evilImpl.ml
+++ b/test-suite/misc/poly-capture-global-univs/src/evilImpl.ml
@@ -11,7 +11,7 @@ let evil t f =
   let te = Declare.definition_entry
       ~univs:(Monomorphic_entry (ContextSet.singleton u)) tu
   in
-  let tc = Declare.declare_constant t (DefinitionEntry te, k) in
+  let tc = Declare.declare_constant t (Declare.DefinitionEntry te, k) in
   let tc = mkConst tc in
 
   let fe = Declare.definition_entry
@@ -19,4 +19,4 @@ let evil t f =
       ~types:(Term.mkArrowR tc tu)
       (mkLambda (Context.nameR (Id.of_string "x"), tc, mkRel 1))
   in
-  ignore (Declare.declare_constant f (DefinitionEntry fe, k))
+  ignore (Declare.declare_constant f (Declare.DefinitionEntry fe, k))

--- a/vernac/class.ml
+++ b/vernac/class.ml
@@ -17,7 +17,6 @@ open Constr
 open Context
 open Vars
 open Termops
-open Entries
 open Environ
 open Classops
 open Declare

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -29,7 +29,6 @@ module NamedDecl = Context.Named.Declaration
 (*i*)
 
 open Decl_kinds
-open Entries
 
 let set_typeclass_transparency c local b = 
   Hints.add_hints ~local [typeclasses_db]
@@ -324,7 +323,7 @@ let declare_instance_constant info global imps ?hook id decl poly sigma term ter
   in
   let uctx = Evd.check_univ_decl ~poly sigma decl in
   let entry = Declare.definition_entry ~types:termtype ~univs:uctx term in
-  let cdecl = (DefinitionEntry entry, kind) in
+  let cdecl = (Declare.DefinitionEntry entry, kind) in
   let kn = Declare.declare_constant id cdecl in
   Declare.definition_message id;
   Declare.declare_univ_binders (ConstRef kn) (Evd.universe_binders sigma);
@@ -339,7 +338,7 @@ let do_declare_instance sigma ~global ~poly k u ctx ctx' pri decl imps subst id 
   let termtype = it_mkProd_or_LetIn ty_constr (ctx' @ ctx) in
   let sigma, entry = DeclareDef.prepare_parameter ~allow_evars:false ~poly sigma decl termtype in
   let cst = Declare.declare_constant ~internal:Declare.InternalTacticRequest id
-      (ParameterEntry entry, Decl_kinds.IsAssumption Decl_kinds.Logical) in
+      (Declare.ParameterEntry entry, Decl_kinds.IsAssumption Decl_kinds.Logical) in
   Declare.declare_univ_binders (ConstRef cst) (Evd.universe_binders sigma);
   instance_hook pri global imps (ConstRef cst)
 

--- a/vernac/comAssumption.ml
+++ b/vernac/comAssumption.ml
@@ -68,7 +68,7 @@ match local with
     | DefaultInline -> Some (Flags.get_inline_level())
     | InlineAt i -> Some i
   in
-  let decl = (ParameterEntry (None,(c,ctx),inl), IsAssumption kind) in
+  let decl = (Declare.ParameterEntry (None,(c,ctx),inl), IsAssumption kind) in
   let kn = declare_constant ident ~local decl in
   let gr = ConstRef kn in
   let () = maybe_declare_manual_implicits false gr imps in
@@ -273,10 +273,10 @@ let context poly l =
       (* Declare the universe context once *)
       let decl = match b with
       | None ->
-        (ParameterEntry (None,(t,univs),None), IsAssumption Logical)
+        (Declare.ParameterEntry (None,(t,univs),None), IsAssumption Logical)
       | Some b ->
         let entry = Declare.definition_entry ~univs ~types:t b in
-        (DefinitionEntry entry, IsAssumption Logical)
+        (Declare.DefinitionEntry entry, IsAssumption Logical)
       in
       let cst = Declare.declare_constant ~internal:Declare.InternalTacticRequest id decl in
       let env = Global.env () in

--- a/vernac/comDefinition.ml
+++ b/vernac/comDefinition.ml
@@ -10,7 +10,6 @@
 
 open Pp
 open Util
-open Entries
 open Redexpr
 open Constrintern
 open Pretyping
@@ -86,12 +85,12 @@ let do_definition ~program_mode ?hook ident k univdecl bl red_option c ctypopt =
   in
   if program_mode then
     let env = Global.env () in
-    let (c,ctx), sideff = Future.force ce.const_entry_body in
+    let (c,ctx), sideff = Future.force ce.Proof_global.proof_entry_body in
     assert(Safe_typing.empty_private_constants = sideff.Evd.seff_private);
     assert(Univ.ContextSet.is_empty ctx);
     Obligations.check_evars env evd;
     let c = EConstr.of_constr c in
-    let typ = match ce.const_entry_type with
+    let typ = match ce.Proof_global.proof_entry_type with
       | Some t -> EConstr.of_constr t
       | None -> Retyping.get_type_of env evd c
     in

--- a/vernac/comDefinition.mli
+++ b/vernac/comDefinition.mli
@@ -9,7 +9,6 @@
 (************************************************************************)
 
 open Names
-open Entries
 open Decl_kinds
 open Redexpr
 open Constrexpr
@@ -41,5 +40,5 @@ val interp_definition
   -> red_expr option
   -> constr_expr
   -> constr_expr option
-  -> Evd.side_effects definition_entry *
+  -> Evd.side_effects Proof_global.proof_entry *
      Evd.evar_map * UState.universe_decl * Impargs.manual_implicits

--- a/vernac/comProgramFixpoint.ml
+++ b/vernac/comProgramFixpoint.ml
@@ -13,7 +13,6 @@ open CErrors
 open Util
 open Constr
 open Context
-open Entries
 open Vars
 open Declare
 open Names

--- a/vernac/declareDef.ml
+++ b/vernac/declareDef.ml
@@ -10,7 +10,6 @@
 
 open Decl_kinds
 open Declare
-open Entries
 open Globnames
 open Impargs
 
@@ -38,7 +37,7 @@ end
 
 (* Locality stuff *)
 let declare_definition ident (local, p, k) ?hook_data ce pl imps =
-  let fix_exn = Future.fix_exn_of ce.const_entry_body in
+  let fix_exn = Future.fix_exn_of ce.Proof_global.proof_entry_body in
   let gr = match local with
   | Discharge ->
       let _ = declare_variable ident (Lib.cwd(), SectionLocalDef ce, IsDefinition k) in

--- a/vernac/declareDef.mli
+++ b/vernac/declareDef.mli
@@ -43,7 +43,7 @@ val declare_definition
   : Id.t
   -> definition_kind
   -> ?hook_data:(Hook.t * UState.t * (Id.t * Constr.t) list)
-  -> Evd.side_effects Entries.definition_entry
+  -> Evd.side_effects Proof_global.proof_entry
   -> UnivNames.universe_binders
   -> Impargs.manual_implicits
   -> GlobRef.t
@@ -64,7 +64,7 @@ val prepare_definition : allow_evars:bool ->
   ?opaque:bool -> ?inline:bool -> poly:bool ->
   Evd.evar_map -> UState.universe_decl ->
   types:EConstr.t option -> body:EConstr.t ->
-  Evd.evar_map * Evd.side_effects Entries.definition_entry
+  Evd.evar_map * Evd.side_effects Proof_global.proof_entry
 
 val prepare_parameter : allow_evars:bool ->
   poly:bool -> Evd.evar_map -> UState.universe_decl -> EConstr.types ->

--- a/vernac/declareObl.ml
+++ b/vernac/declareObl.ml
@@ -155,18 +155,18 @@ let declare_obligation prg obl body ty uctx =
       ((body, Univ.ContextSet.empty), Evd.empty_side_effects)
     in
     let ce =
-      { const_entry_body = Future.from_val ~fix_exn:(fun x -> x) body
-      ; const_entry_secctx = None
-      ; const_entry_type = ty
-      ; const_entry_universes = uctx
-      ; const_entry_opaque = opaque
-      ; const_entry_inline_code = false
-      ; const_entry_feedback = None }
+      Proof_global.{ proof_entry_body = Future.from_val ~fix_exn:(fun x -> x) body
+      ; proof_entry_secctx = None
+      ; proof_entry_type = ty
+      ; proof_entry_universes = uctx
+      ; proof_entry_opaque = opaque
+      ; proof_entry_inline_code = false
+      ; proof_entry_feedback = None }
     in
     (* ppedrot: seems legit to have obligations as local *)
     let constant =
       Declare.declare_constant obl.obl_name ~local:ImportNeedQualified
-        (DefinitionEntry ce, IsProof Property)
+        (Declare.DefinitionEntry ce, IsProof Property)
     in
     if not opaque then
       add_hint (Locality.make_section_locality None) prg constant;
@@ -498,8 +498,8 @@ let obligation_terminator opq entries uctx { name; num; auto } =
   match entries with
   | [entry] ->
     let env = Global.env () in
-    let ty = entry.Entries.const_entry_type in
-    let body, eff = Future.force entry.const_entry_body in
+    let ty = entry.proof_entry_type in
+    let body, eff = Future.force entry.proof_entry_body in
     let (body, cstr) = Safe_typing.inline_private_constants env (body, eff.Evd.seff_private) in
     let sigma = Evd.from_ctx uctx in
     let sigma = Evd.merge_context_set ~sideff:true Evd.univ_rigid sigma cstr in

--- a/vernac/declareObl.mli
+++ b/vernac/declareObl.mli
@@ -78,7 +78,7 @@ type obligation_qed_info =
 
 val obligation_terminator
   :  Proof_global.opacity_flag
-  -> Evd.side_effects Entries.definition_entry list
+  -> Evd.side_effects Proof_global.proof_entry list
   -> UState.t
   -> obligation_qed_info -> unit
 (** [obligation_terminator] part 2 of saving an obligation *)

--- a/vernac/indschemes.ml
+++ b/vernac/indschemes.ml
@@ -21,7 +21,6 @@ open CErrors
 open Util
 open Names
 open Declarations
-open Entries
 open Term
 open Constr
 open Inductive
@@ -104,15 +103,16 @@ let () =
 let define ~poly id internal sigma c t =
   let f = declare_constant ~internal in
   let univs = Evd.univ_entry ~poly sigma in
+  let open Proof_global in
   let kn = f id
     (DefinitionEntry
-      { const_entry_body = c;
-        const_entry_secctx = None;
-        const_entry_type = t;
-	const_entry_universes = univs;
-        const_entry_opaque = false;
-        const_entry_inline_code = false;
-        const_entry_feedback = None;
+      { proof_entry_body = c;
+        proof_entry_secctx = None;
+        proof_entry_type = t;
+        proof_entry_universes = univs;
+        proof_entry_opaque = false;
+        proof_entry_inline_code = false;
+        proof_entry_feedback = None;
       },
       Decl_kinds.IsDefinition Scheme) in
   definition_message id;

--- a/vernac/obligations.ml
+++ b/vernac/obligations.ml
@@ -9,7 +9,6 @@
 (************************************************************************)
 
 open Printf
-open Entries
 open Decl_kinds
 
 (**
@@ -418,11 +417,11 @@ let solve_by_tac ?loc name evi t poly ctx =
       Pfedit.build_constant_by_tactic
         id ~goal_kind:(goal_kind poly) ctx evi.evar_hyps evi.evar_concl t in
     let env = Global.env () in
-    let (body, eff) = Future.force entry.const_entry_body in
+    let (body, eff) = Future.force entry.Proof_global.proof_entry_body in
     let body = Safe_typing.inline_private_constants env (body, eff.Evd.seff_private) in
     let ctx' = Evd.merge_context_set ~sideff:true Evd.univ_rigid (Evd.from_ctx ctx') (snd body) in
     Inductiveops.control_only_guard env ctx' (EConstr.of_constr (fst body));
-    Some (fst body, entry.const_entry_type, Evd.evar_universe_context ctx')
+    Some (fst body, entry.Proof_global.proof_entry_type, Evd.evar_universe_context ctx')
   with
   | Refiner.FailError (_, s) as exn ->
     let _ = CErrors.push exn in
@@ -682,7 +681,7 @@ let admit_prog prg =
             let x = subst_deps_obl obls x in
             let ctx = UState.univ_entry ~poly:false prg.prg_ctx in
             let kn = Declare.declare_constant x.obl_name ~local:ImportNeedQualified
-              (ParameterEntry (None,(x.obl_type,ctx),None), IsAssumption Conjectural)
+              (Declare.ParameterEntry (None,(x.obl_type,ctx),None), IsAssumption Conjectural)
             in
               assumption_message x.obl_name;
               obls.(i) <- { x with obl_body = Some (DefinedObl (kn, Univ.Instance.empty)) }

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -342,16 +342,17 @@ let declare_projections indsp ctx ?(kind=StructureComponent) binder_name flags f
 		let projtyp =
                   it_mkProd_or_LetIn (mkProd (x,rp,ccl)) paramdecls in
 	        try
+                  let open Proof_global in
 		  let entry = {
-		    const_entry_body =
+                    proof_entry_body =
                       Future.from_val ((proj, Univ.ContextSet.empty), Evd.empty_side_effects);
-		    const_entry_secctx = None;
-		    const_entry_type = Some projtyp;
-                    const_entry_universes = ctx;
-		    const_entry_opaque = false;
-		    const_entry_inline_code = false;
-		    const_entry_feedback = None } in
-		  let k = (DefinitionEntry entry,IsDefinition kind) in
+                    proof_entry_secctx = None;
+                    proof_entry_type = Some projtyp;
+                    proof_entry_universes = ctx;
+                    proof_entry_opaque = false;
+                    proof_entry_inline_code = false;
+                    proof_entry_feedback = None } in
+                  let k = (Declare.DefinitionEntry entry,IsDefinition kind) in
 		  let kn = declare_constant ~internal:InternalTacticRequest fid k in
 		  let constr_fip =
 		    let proj_args = (*Rel 1 refers to "x"*) paramargs@[mkRel 1] in


### PR DESCRIPTION
We use a different type for kernel-facing and proof-facing entries. This allows to enforce more invariants statically, some of which were implemented in this PR as well.

See #10363 for a related discussion.

Overlays:
- https://github.com/mattam82/Coq-Equations/pull/223
- https://github.com/QuickChick/QuickChick/pull/170
