### PR TITLE
Allow large eliminations in successor universes

### DIFF
--- a/pretyping/cases.ml
+++ b/pretyping/cases.ml
@@ -2082,9 +2082,9 @@ let prepare_predicate ?loc ~program_mode typing_fun env sigma tomatchs arsign ty
     | Some rtntyp ->
       (* We extract the signature of the arity *)
       let building_arsign,envar = List.fold_right_map (push_rel_context ~hypnaming:KeepUserNameAndRenameExistingButSectionNames sigma) arsign env in
-      let sigma, newt = new_sort_variable univ_flexible sigma in
-      let sigma, predcclj = typing_fun (mk_tycon (mkSort newt)) envar sigma rtntyp in
-      let predccl = nf_evar sigma predcclj.uj_val in
+      let sigma, predcclj = typing_fun None envar sigma rtntyp in
+      let sigma, predccltj = Coercion.inh_coerce_to_sort ?loc !!envar sigma predcclj in
+      let predccl = nf_evar sigma predccltj.utj_val in
       [sigma, predccl, building_arsign]
   in
   List.map

--- a/test-suite/bugs/closed/bug_10015.v
+++ b/test-suite/bugs/closed/bug_10015.v
@@ -1,0 +1,12 @@
+Set Universe Polymorphism.
+Fixpoint type_vector@{i} (n : nat) : Type@{i+1} :=
+  match n return Type@{i+1} with O => unit | S m => type_vector m * Type@{i} end.
+Definition bar@{i j} (b : bool) : Type@{max(i+1,j+1)} :=
+  match b return Type@{max(i+1,j+1)} with
+  | true => Type@{i}
+  | false => Type@{j}
+  end.
+Check (fun (b : bool) (x : False) =>
+  match x
+  return match b with true => unit | false => Set end
+  with end).


### PR DESCRIPTION
Fixes #10015.

Kind: fix

Another look at #10034 (closed and couldn't reopen because I force-pushed in between)

When given a return annotation, rather than inventing a new level `newt` and checking that `T : Type@{newt}`, we pretype `T` without a type hint, then coerce the result to be a type, which doesn't invent a new level if the type of `T` is already inferred to be a sort.

There is a regression in that `return (match b in bool with true => unit | false => Set end)` no longer works (the inner match is inferred to `return Set` from the first branch, and that fails when checking the second branch, while before the hint "this should be in Type@{i}" was enough to make this go through).
See also #10035.

- [x] Added test to test-suite