### PR TITLE
Expose toplevel functionality

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -103,6 +103,8 @@ of the Coq Proof assistant during the indicated time:
   Gilles Dowek (INRIA, 1991-1994)
   Amy Felty (INRIA, 1993)
   Jean-Christophe Filliâtre (ENS Lyon, 1994-1997, LRI, 1997-2008)
+  Mario Frank (ORCID: http://orcid.org/0000-0001-8888-7475,
+               University of Potsdam, 2019)
   Emilio Jesús Gallego Arias (MINES ParisTech 2015-now)
   Gaetan Gilbert (INRIA-Galinette, 2016-now)
   Eduardo Giménez (ENS Lyon, 1993-1996, INRIA, 1997-1998)

--- a/toplevel/ccompile.ml
+++ b/toplevel/ccompile.ml
@@ -31,15 +31,16 @@ let load_vernacular opts ~state =
       else load_vernac s
     ) state (List.rev opts.load_vernacular_list)
 
+let load_rc_file opts ~state =
+  if opts.load_rcfile then
+    Topfmt.(in_phase ~phase:LoadingRcFile) (fun () -> Coqinit.load_rcfile ~rcfile:opts.rcfile ~state) ()
+  else begin
+    Flags.if_verbose Feedback.msg_info (str"Skipping rcfile loading.");
+    state
+  end
+
 let load_init_vernaculars opts ~state =
-  let state =
-    if opts.load_rcfile then
-      Topfmt.(in_phase ~phase:LoadingRcFile) (fun () ->
-          Coqinit.load_rcfile ~rcfile:opts.rcfile ~state) ()
-    else begin
-      Flags.if_verbose Feedback.msg_info (str"Skipping rcfile loading.");
-      state
-    end in
+  let state = load_rc_file opts ~state in
 
   load_vernacular opts ~state
 

--- a/toplevel/ccompile.mli
+++ b/toplevel/ccompile.mli
@@ -8,8 +8,12 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
+(** [load_rc_file args sid] Load vernaculars from
+   the init (rc) file. *)
+val load_rc_file : Coqargs.t -> state:Vernac.State.t-> Vernac.State.t
+
 (** [load_init_vernaculars opts ~state] Load vernaculars from
-   the init (rc) file *)
+   the init (rc) file and also the files specified in the options. *)
 val load_init_vernaculars : Coqargs.t -> state:Vernac.State.t-> Vernac.State.t
 
 (** [compile_files opts] compile files specified in [opts] *)

--- a/toplevel/coqtop.mli
+++ b/toplevel/coqtop.mli
@@ -8,6 +8,10 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
+(** Prints info which is either an error or an anomaly and then exits
+    with the appropriate error code. *)
+val fatal_error_exn : exn -> Vernac.State.t * Coqargs.t
+
 (** Definition of custom toplevels.
     [init] is used to do custom command line argument parsing.
     [run] launches a custom toplevel.

--- a/toplevel/vernac.mli
+++ b/toplevel/vernac.mli
@@ -20,6 +20,11 @@ module State : sig
 
 end
 
+
+(** [checknav_simple ctrl] Throws an error if the current command
+    in the AST is a navigation command. *)
+val checknav_simple : Vernacexpr.vernac_control -> unit
+
 (** [process_expr sid cmd] Executes vernac command [cmd]. Callers are
     expected to handle and print errors in form of exceptions, however
     care is taken so the state machine is left in a consistent
@@ -31,3 +36,11 @@ val process_expr : state:State.t -> Vernacexpr.vernac_control -> State.t
     and print errors in form of exceptions. *)
 val load_vernac : echo:bool -> check:bool -> interactive:bool ->
   state:State.t -> string -> State.t
+
+(** [interp_vernac check interactive sid ctrl] Interprets the current
+    command in the AST and this way sets the state given by [sid] to
+    a new state. If [check] is set, the stm will check the execution.
+    If [interactive] is set, the underlying document of the AST [ast]
+    is edited. *)
+val interp_vernac : check:bool -> interactive:bool -> state:State.t ->
+  Vernacexpr.vernac_control -> State.t


### PR DESCRIPTION
Expose Vernac.checknav_simple, Vernac.interp_vernac and Coqtop.fatal_error_exn and modularise Ccompile.load_init_vernaculars. The changes on Vernac and Coqtop are relevalt for reuse of AST/file handling primitives by tools that work mostly identical to coqtop.

<!-- Keep what applies -->
**Kind:** infrastructure.