### PR TITLE
Kernel transparent definition entries have no body universes.

### DIFF
--- a/kernel/entries.ml
+++ b/kernel/entries.ml
@@ -57,17 +57,15 @@ type mutual_inductive_entry = {
 }
 
 (** {6 Constants (Definition/Axiom) } *)
-type 'a proof_output = constr Univ.in_universe_context_set * 'a
-type 'a const_entry_body = 'a proof_output Future.computation
 
 type definition_entry = {
-  const_entry_body   : constr Univ.in_universe_context_set;
+  const_entry_body : constr;
   (* List of section variables *)
   const_entry_secctx : Constr.named_context option;
   (* State id on which the completion of type checking is reported *)
   const_entry_feedback : Stateid.t option;
-  const_entry_type        : types option;
-  const_entry_universes   : universes_entry;
+  const_entry_type : types option;
+  const_entry_universes : universes_entry;
   const_entry_inline_code : bool }
 
 type section_def_entry = {
@@ -97,6 +95,9 @@ type primitive_entry = {
   prim_entry_univs : Univ.ContextSet.t; (* always monomorphic *)
   prim_entry_content : CPrimitives.op_or_type;
 }
+
+type 'a proof_output = constr Univ.in_universe_context_set * 'a
+type 'a const_entry_body = 'a proof_output Future.computation
 
 type 'a constant_entry =
   | DefinitionEntry of definition_entry

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -698,7 +698,7 @@ let constant_entry_of_side_effect eff =
   }
   else
   DefinitionEntry {
-    const_entry_body = (p, Univ.ContextSet.empty);
+    const_entry_body = p;
     const_entry_secctx = Some cb.const_hyps;
     const_entry_feedback = None;
     const_entry_type = Some cb.const_type;


### PR DESCRIPTION
Not sure if we can ever have body universes at the
Declare.cast_proof_entry level. Let's see what CI says if we forbid
it.