### PR TITLE
Attach the universe polymorphic status to sections.

### DIFF
--- a/dev/ci/user-overlays/10441-ppedrot-static-poly-section.sh
+++ b/dev/ci/user-overlays/10441-ppedrot-static-poly-section.sh
@@ -1,0 +1,6 @@
+if [ "$CI_PULL_REQUEST" = "10441" ] || [ "$CI_BRANCH" = "static-poly-section" ]; then
+
+    ext_lib_CI_REF=static-poly-section
+    ext_lib_CI_GITURL=https://github.com/ppedrot/coq-ext-lib
+
+fi

--- a/doc/changelog/02-specification-language/10441-static-poly-section.rst
+++ b/doc/changelog/02-specification-language/10441-static-poly-section.rst
@@ -1,0 +1,11 @@
+- The universe polymorphism setting now applies from the opening of a section.
+  In particular, it is not possible anymore to mix polymorphic and monomorphic
+  definitions in a section when there are no variables nor universe constraints
+  defined in this section. This makes the behaviour consistent with the
+  documentation. (`#10441 <https://github.com/coq/coq/pull/10441>`_,
+  by Pierre-Marie Pédrot)
+
+- The :cmd:`Section` vernacular command now accepts the "universes" attribute. In
+  addition to setting the section universe polymorphism, it also locally sets
+  the universe polymorphic option inside the section.
+  (`#10441 <https://github.com/coq/coq/pull/10441>`_, by Pierre-Marie Pédrot)

--- a/doc/sphinx/addendum/universe-polymorphism.rst
+++ b/doc/sphinx/addendum/universe-polymorphism.rst
@@ -144,6 +144,8 @@ Many other commands support the ``Polymorphic`` flag, including:
 - ``Lemma``, ``Axiom``, and all the other “definition” keywords support
   polymorphism.
 
+- :cmd:`Section` will locally set the polymorphism flag inside the section.
+
 - ``Variables``, ``Context``, ``Universe`` and ``Constraint`` in a section support
   polymorphism. This means that the universe variables (and associated
   constraints) are discharged polymorphically over definitions that use

--- a/library/lib.mli
+++ b/library/lib.mli
@@ -147,7 +147,7 @@ val library_part :  GlobRef.t -> DirPath.t
 
 (** {6 Sections } *)
 
-val open_section : Id.t -> unit
+val open_section : poly:bool -> Id.t -> unit
 val close_section : unit -> unit
 
 (** {6 We can get and set the state of the operations (used in [States]). } *)

--- a/test-suite/bugs/closed/HoTT_coq_020.v
+++ b/test-suite/bugs/closed/HoTT_coq_020.v
@@ -26,6 +26,7 @@ Ltac present_obj from to :=
            | [ |- context[from ?obj ?C] ] => progress change (from obj C) with (to obj C) in *
          end.
 
+#[universes(polymorphic)]
 Section NaturalTransformationComposition.
   Set Universe Polymorphism.
   Context `(C : @Category objC).
@@ -58,6 +59,7 @@ Polymorphic Definition Cat0 : Category Empty_set
 Polymorphic Definition FunctorFrom0 objC (C : Category objC) : Functor Cat0 C
   := Build_Functor Cat0 C (fun x => match x with end).
 
+#[universes(polymorphic)]
 Section Law0.
   Polymorphic Variable objC : Type.
   Polymorphic Variable C : Category objC.

--- a/test-suite/bugs/closed/HoTT_coq_098.v
+++ b/test-suite/bugs/closed/HoTT_coq_098.v
@@ -21,6 +21,7 @@ Polymorphic Definition GraphIndexingCategory : @SpecializedCategory GraphIndex.
 Admitted.
 
 Module success.
+  #[universes(polymorphic)]
   Section SpecializedFunctor.
     Set Universe Polymorphism.
     Context `(C : @SpecializedCategory objC).
@@ -39,6 +40,7 @@ Module success.
 End success.
 
 Module success2.
+  #[universes(polymorphic)]
   Section SpecializedFunctor.
     Polymorphic Context `(C : @SpecializedCategory objC).
     Polymorphic Context `(D : @SpecializedCategory objD).

--- a/test-suite/bugs/closed/bug_3314.v
+++ b/test-suite/bugs/closed/bug_3314.v
@@ -24,10 +24,10 @@ Fail Eval compute in Lift nat : Prop.
 (*      = nat
      : Prop *)
 
-Section Hurkens.
+Monomorphic Definition Type2 := Type.
+Monomorphic Definition Type1 := Type : Type2.
 
-  Monomorphic Definition Type2 := Type.
-  Monomorphic Definition Type1 := Type : Type2.
+Section Hurkens.
 
   (** Assumption of a retract from Type into Prop *)
 

--- a/test-suite/bugs/closed/bug_4503.v
+++ b/test-suite/bugs/closed/bug_4503.v
@@ -5,6 +5,7 @@ Class PreOrder (A : Type) (r : A -> A -> Type) : Type :=
 
 (* FAILURE 1 *)
 
+#[universes(polymorphic)]
 Section foo.
   Polymorphic Universes A.
   Polymorphic Context {A : Type@{A}} {rA : A -> A -> Prop} {PO : PreOrder A rA}.
@@ -30,6 +31,7 @@ End ILogic.
 Set Printing Universes.
 
 (* There is still a problem if the class is universe polymorphic *)
+#[universes(polymorphic)]
 Section Embed_ILogic_Pre.
   Polymorphic Universes A T.
   Fail Context {A : Type@{A}} {ILA: ILogic.ILogic@{A} A}.

--- a/test-suite/bugs/closed/bug_4503.v
+++ b/test-suite/bugs/closed/bug_4503.v
@@ -10,7 +10,7 @@ Section foo.
   Polymorphic Universes A.
   Polymorphic Context {A : Type@{A}} {rA : A -> A -> Prop} {PO : PreOrder A rA}.
 
-  Fail Definition foo := PO.
+  Fail Monomorphic Definition foo := PO.
 End foo.
 
 
@@ -34,6 +34,6 @@ Set Printing Universes.
 #[universes(polymorphic)]
 Section Embed_ILogic_Pre.
   Polymorphic Universes A T.
-  Fail Context {A : Type@{A}} {ILA: ILogic.ILogic@{A} A}.
+  Fail Monomorphic Context {A : Type@{A}} {ILA: ILogic.ILogic@{A} A}.
 
 End Embed_ILogic_Pre.

--- a/test-suite/bugs/closed/bug_4816.v
+++ b/test-suite/bugs/closed/bug_4816.v
@@ -1,3 +1,4 @@
+#[universes(polymorphic)]
 Section foo.
 Polymorphic Universes A B.
 Fail Constraint A <= B.
@@ -5,12 +6,14 @@ End foo.
 (* gives an anomaly Universe undefined *)
 
 Universes X Y.
+#[universes(polymorphic)]
 Section Foo.
   Polymorphic Universes Z W.
   Polymorphic Constraint W < Z.
 
   Fail Definition bla := Type@{W}.
   Polymorphic Definition bla := Type@{W}.
+  #[universes(polymorphic)]
   Section Bar.
     Fail Constraint X <= Z.
   End Bar.
@@ -21,8 +24,10 @@ Require Coq.Classes.RelationClasses.
 Class PreOrder (A : Type) (r : A -> A -> Type) : Type :=
 { refl : forall x, r x x }.
 
+#[universes(polymorphic)]
 Section qux.
   Polymorphic Universes A.
+  #[universes(polymorphic)]
   Section bar.
     Fail Context {A : Type@{A}} {rA : A -> A -> Prop} {PO : PreOrder A rA}.
   End bar.

--- a/test-suite/bugs/closed/bug_4816.v
+++ b/test-suite/bugs/closed/bug_4816.v
@@ -1,7 +1,7 @@
 #[universes(polymorphic)]
 Section foo.
 Polymorphic Universes A B.
-Fail Constraint A <= B.
+Fail Monomorphic Constraint A <= B.
 End foo.
 (* gives an anomaly Universe undefined *)
 
@@ -11,11 +11,11 @@ Section Foo.
   Polymorphic Universes Z W.
   Polymorphic Constraint W < Z.
 
-  Fail Definition bla := Type@{W}.
+  Fail Monomorphic Definition bla := Type@{W}.
   Polymorphic Definition bla := Type@{W}.
   #[universes(polymorphic)]
   Section Bar.
-    Fail Constraint X <= Z.
+    Fail Monomorphic Constraint X <= Z.
   End Bar.
 End Foo.
 
@@ -29,6 +29,6 @@ Section qux.
   Polymorphic Universes A.
   #[universes(polymorphic)]
   Section bar.
-    Fail Context {A : Type@{A}} {rA : A -> A -> Prop} {PO : PreOrder A rA}.
+    Fail Monomorphic Context {A : Type@{A}} {rA : A -> A -> Prop} {PO : PreOrder A rA}.
   End bar.
 End qux.

--- a/test-suite/success/namedunivs.v
+++ b/test-suite/success/namedunivs.v
@@ -6,6 +6,7 @@
 
 Unset Strict Universe Declaration.
 
+#[universes(polymorphic)]
 Section lift_strict.
 Polymorphic Definition liftlt := 
   let t := Type@{i} : Type@{k} in

--- a/test-suite/success/polymorphism.v
+++ b/test-suite/success/polymorphism.v
@@ -122,8 +122,6 @@ Fail Definition id1impred := ((forall A : Type1, A) : Type1).
 
 End Hierarchy.
 
-Section structures.
-
 Record hypo : Type := mkhypo {
    hypo_type : Type;
    hypo_proof : hypo_type
@@ -153,9 +151,6 @@ Definition projnested2 := dyn_type nested2.
 Polymorphic Definition nest (d : dyn) := {| dyn_proof := d |}.
 
 Polymorphic Definition twoprojs (d : dyn) := dyn_proof d = dyn_proof d.
-
-End structures.
-
 
 Module binders.
 
@@ -201,7 +196,8 @@ Module binders.
   Definition with_mono@{u|u < M} : Type@{M} := Type@{u}.
 
 End binders.
-    
+
+#[universes(polymorphic)]
 Section cats.
   Local Set Universe Polymorphism.
   Require Import Utf8.
@@ -307,6 +303,7 @@ Fail Check (let A := Set in fooS (id A)).
 Fail Check (let A := Prop in fooS (id A)).
 
 (* Some tests of sort-polymorphisme *)
+#[universes(polymorphic)]
 Section S.
 Polymorphic Variable A:Type.
 (*

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -963,9 +963,9 @@ let vernac_include l =
 
 (* Sections *)
 
-let vernac_begin_section ({v=id} as lid) =
+let vernac_begin_section ~poly ({v=id} as lid) =
   Dumpglob.dump_definition lid true "sec";
-  Lib.open_section id
+  Lib.open_section ~poly id
 
 let vernac_end_section {CAst.loc} =
   Dumpglob.dump_reference ?loc
@@ -2396,8 +2396,7 @@ let rec translate_vernac ~atts v = let open Vernacextend in match v with
   (* Gallina extensions *)
   | VernacBeginSection lid ->
     VtNoProof(fun () ->
-        unsupported_attributes atts;
-        vernac_begin_section lid)
+        vernac_begin_section ~poly:(only_polymorphism atts) lid)
   | VernacEndSegment lid ->
     VtNoProof(fun () ->
         unsupported_attributes atts;

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -965,7 +965,8 @@ let vernac_include l =
 
 let vernac_begin_section ~poly ({v=id} as lid) =
   Dumpglob.dump_definition lid true "sec";
-  Lib.open_section ~poly id
+  Lib.open_section ~poly id;
+  set_bool_option_value_gen ~locality:OptLocal ["Universe"; "Polymorphism"] poly
 
 let vernac_end_section {CAst.loc} =
   Dumpglob.dump_reference ?loc


### PR DESCRIPTION
The previous implementation allowed to dynamically decide whether a section would be monomorphic or polymorphic at the first definition of a variable or a constraint. Instead of relying on this delayed decision, we set the universe polymorphic property directly at the time of the section definition.

This is **required** for a future kernel implementation of sections.

And inb4 "make sections great again", sections are out of the kernel but part of the TCB, and their implementation is literally bonkers. Anybody claiming they want to mix polymorphic and monomorphic definitions in a section *provided there is no previous variable nor constraint declaration* deserves at best a few strokes of soundness whipping.

See #8090 for a related discussion that withered away.

- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).

Overlays:
- https://github.com/coq-ext-lib/coq-ext-lib/pull/65