### PR TITLE
Fix dev/doc/README.md by removing redundant, outdated info.

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,31 +1,9 @@
-
-            INSTALLATION PROCEDURE
-            ----------------------
+            INSTALLING FROM SOURCES
+            -----------------------
 
 
 WHAT DO YOU NEED ?
 ==================
-
-   Your OS may already contain Coq under the form of a precompiled
-   package or ready-to-compile port. In this case, and if the supplied
-   version suits you, follow the usual procedure for your OS to
-   install it. E.g.:
-
-   - Debian GNU/Linux derivatives (or Debian GNU/k*BSD or ...):
-
-     aptitude install coq
-
-   - Gentoo GNU/Linux:
-
-     emerge sci-mathematics/coq
-
-   - Fedora GNU/Linux:
-
-     urpmi coq
-
-   - MacPorts for MacOS X
-
-     port install coq
 
    To compile Coq yourself, you need:
 

--- a/dev/doc/README.md
+++ b/dev/doc/README.md
@@ -2,27 +2,9 @@
 
 ## Getting dependencies
 
-Assuming one is running Ubuntu (if not, replace `apt` with the package manager of choice)
-
-```
-$ sudo apt-get install make opam git
-
-# At the time of writing, <latest-ocaml-version> is 4.07.0.
-# The latest version number is available at: https://ocaml.org/releases/
-
-$ opam init --comp <latest-ocaml-version>
-
-# Then follow the advice displayed at the end as how to update your
-  ~/.bashrc and ~/.ocamlinit files.
-
-$ source ~/.bashrc
-
-# needed if you want to build "coqide" target
-
-$ sudo apt-get install liblablgtksourceview2-ocaml-dev \
-  libgtk2.0-dev libgtksourceview2.0-dev
-$ opam install lablgtk
-```
+See the first section of [`INSTALL`](../../INSTALL).  Developers are
+recommended to use a recent OCaml version, which they can get through
+opam or Nix, in particular.
 
 ## Building `coqtop`
 The general workflow is to first setup a development environment with


### PR DESCRIPTION
**Kind:** documentation clean-up / fix

The information on how to get the dependencies in the "beginner's guide to hacking Coq" is bound to get outdated and inaccurate. I noticed this while refactoring the contributing guide. Given that this is mostly a repetition of what is in `INSTALL` (which we keep up-to-date), I just add a link to it instead of repeating its content.

I also cleaned the `INSTALL` file from a useless reminder of the procedure to install using a package manager, that is also bound to become outdated as package managers change, and that has not been updated for very long (e.g. today installing through Homebrew seems to be preferred over MacPorts on macOS).