### PR TITLE
[vernac] Refactor control attributes and fix bug #10452

### DIFF
--- a/ide/idetop.ml
+++ b/ide/idetop.ml
@@ -56,7 +56,7 @@ let coqide_known_option table = List.mem table [
   ["Printing";"Unfocused"];
   ["Diffs"]]
 
-let is_known_option cmd = match Vernacprop.under_control cmd with
+let is_known_option cmd = match cmd with
   | VernacSetOption (_, o, OptionSetTrue)
   | VernacSetOption (_, o, OptionSetString _)
   | VernacSetOption (_, o, OptionUnset) -> coqide_known_option o
@@ -64,7 +64,7 @@ let is_known_option cmd = match Vernacprop.under_control cmd with
 
 (** Check whether a command is forbidden in the IDE *)
 
-let ide_cmd_checks ~last_valid ({ CAst.loc; _ } as cmd) =
+let ide_cmd_checks ~last_valid { CAst.loc; v } =
   let user_error s =
     try CErrors.user_err ?loc ~hdr:"IDE" (str s)
     with e ->
@@ -72,14 +72,14 @@ let ide_cmd_checks ~last_valid ({ CAst.loc; _ } as cmd) =
       let info = Stateid.add info ~valid:last_valid Stateid.dummy in
       Exninfo.raise ~info e
   in
-  if is_debug cmd then
+  if is_debug v.expr then
     user_error "Debug mode not available in the IDE"
 
-let ide_cmd_warns ~id ({ CAst.loc; _ } as cmd) =
+let ide_cmd_warns ~id { CAst.loc; v } =
   let warn msg = Feedback.(feedback ~id (Message (Warning, loc, strbrk msg))) in
-  if is_known_option cmd then
+  if is_known_option v.expr then
     warn "Set this option from the IDE menu instead";
-  if is_navigation_vernac cmd || is_undo cmd then
+  if is_navigation_vernac v.expr || is_undo v.expr then
     warn "Use IDE navigation instead"
 
 (** Interpretation (cf. [Ide_intf.interp]) *)

--- a/plugins/funind/g_indfun.mlg
+++ b/plugins/funind/g_indfun.mlg
@@ -180,7 +180,7 @@ let is_proof_termination_interactively_checked recsl =
 
 let classify_as_Fixpoint recsl =
  Vernac_classifier.classify_vernac
-    (Vernacexpr.(CAst.make @@ VernacExpr([], VernacFixpoint(NoDischarge, List.map snd recsl))))
+    (Vernacexpr.(CAst.make @@ { control = []; attrs = []; expr = VernacFixpoint(NoDischarge, List.map snd recsl)}))
 
 let classify_funind recsl =
   match classify_as_Fixpoint recsl with

--- a/plugins/funind/glob_term_to_relation.ml
+++ b/plugins/funind/glob_term_to_relation.ml
@@ -1517,7 +1517,7 @@ let do_build_inductive
 	in
 	let msg =
 	  str "while trying to define"++ spc () ++
-            Ppvernac.pr_vernac Vernacexpr.(CAst.make @@ VernacExpr([], VernacInductive(None,false,Declarations.Finite,repacked_rel_inds)))
+            Ppvernac.pr_vernac (CAst.make Vernacexpr.{ control = []; attrs = []; expr = VernacInductive(None,false,Declarations.Finite,repacked_rel_inds)})
 	    ++ fnl () ++
 	    msg
 	in
@@ -1532,7 +1532,7 @@ let do_build_inductive
 	in
 	let msg =
 	  str "while trying to define"++ spc () ++
-            Ppvernac.pr_vernac Vernacexpr.(CAst.make @@ VernacExpr([], VernacInductive(None,false,Declarations.Finite,repacked_rel_inds)))
+            Ppvernac.pr_vernac (CAst.make @@ Vernacexpr.{ control = []; attrs = []; expr = VernacInductive(None,false,Declarations.Finite,repacked_rel_inds)})
 	    ++ fnl () ++
 	    CErrors.print reraise
 	in

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -571,7 +571,7 @@ end = struct (* {{{ *)
     vcs := rewrite_merge !vcs id ~ours ~theirs:Noop ~at branch
   let reachable id = reachable !vcs id
   let mk_branch_name { expr = x } = Branch.make
-    (match Vernacprop.under_control x with
+    (match x.CAst.v.Vernacexpr.expr with
     | VernacDefinition (_,({CAst.v=Name i},_),_) -> Id.to_string i
     | VernacStartTheoremProof (_,[({CAst.v=i},_),_]) -> Id.to_string i
     | VernacInstance (({CAst.v=Name i},_),_,_,_,_) -> Id.to_string i
@@ -1078,7 +1078,7 @@ let stm_vernac_interp ?route id st { verbose; expr } : Vernacstate.t =
     | _ -> false
   in
   (* XXX unsupported attributes *)
-  let cmd = Vernacprop.under_control expr in
+  let cmd = expr.CAst.v.expr in
   if is_filtered_command cmd then
     (stm_pperr_endline Pp.(fun () -> str "ignoring " ++ Ppvernac.pr_vernac expr); st)
   else begin
@@ -1141,7 +1141,7 @@ end = struct (* {{{ *)
           | { step = `Fork ((_,_,_,l),_) } -> l, false,0
           | { step = `Cmd { cids = l; ctac } } -> l, ctac,0
           | { step = `Alias (_,{ expr }) } when not (Vernacprop.has_Fail expr) ->
-          begin match Vernacprop.under_control expr with
+          begin match expr.CAst.v.expr with
                 | VernacUndo n -> [], false, n
                 | _ -> [],false,0
           end
@@ -1171,7 +1171,7 @@ end = struct (* {{{ *)
     if not (VCS.is_interactive ()) && !cur_opt.async_proofs_cache <> Some Force
     then undo_costly_in_batch_mode v;
     try
-      match Vernacprop.under_control v with
+      match v.CAst.v.expr with
       | VernacResetInitial ->
           Stateid.initial
       | VernacResetName {CAst.v=name} ->
@@ -1977,13 +1977,14 @@ end = struct (* {{{ *)
   let vernac_interp ~solve ~abstract ~cancel_switch nworkers priority safe_id id
     { indentation; verbose; expr = e; strlen } : unit
   =
-    let e, time, batch, fail =
-      let rec find ~time ~batch ~fail v = CAst.with_loc_val (fun ?loc -> function
-        | VernacTime (batch,e) -> find ~time:true ~batch ~fail e
-        | VernacRedirect (_,e) -> find ~time ~batch ~fail e
-        | VernacFail e -> find ~time ~batch ~fail:true e
-        | e -> CAst.make ?loc e, time, batch, fail) v in
-      find ~time:false ~batch:false ~fail:false e in
+    let cl, time, batch, fail =
+      let rec find ~time ~batch ~fail cl = match cl with
+        | ControlTime batch :: cl -> find ~time:true ~batch ~fail cl
+        | ControlRedirect _ :: cl -> find ~time ~batch ~fail cl
+        | ControlFail :: cl -> find ~time ~batch ~fail:true cl
+        | cl -> cl, time, batch, fail in
+      find ~time:false ~batch:false ~fail:false e.CAst.v.control in
+    let e = CAst.map (fun cmd -> { cmd with control = cl }) e in
     let st = Vernacstate.freeze_interp_state ~marshallable:false in
     stm_fail ~st fail (fun () ->
     (if time then System.with_time ~batch ~header:(Pp.mt ()) else (fun x -> x)) (fun () ->
@@ -2151,14 +2152,14 @@ let collect_proof keep cur hd brkind id =
    | VernacEndProof (Proved (Proof_global.Transparent,_)) -> true
    | _ -> false in
  let is_defined = function
-   | _, { expr = e } -> is_defined_expr (Vernacprop.under_control e)
+   | _, { expr = e } -> is_defined_expr e.CAst.v.expr
                         && (not (Vernacprop.has_Fail e)) in
  let proof_using_ast = function
    | VernacProof(_,Some _) -> true
    | _ -> false
  in
  let proof_using_ast = function
-   | Some (_, v) when proof_using_ast (Vernacprop.under_control v.expr)
+   | Some (_, v) when proof_using_ast v.expr.CAst.v.expr
                       && (not (Vernacprop.has_Fail v.expr)) -> Some v
    | _ -> None in
  let has_proof_using x = proof_using_ast x <> None in
@@ -2167,14 +2168,14 @@ let collect_proof keep cur hd brkind id =
    | _ -> assert false
  in
  let proof_no_using = function
-   | Some (_, v) -> proof_no_using (Vernacprop.under_control v.expr), v
+   | Some (_, v) -> proof_no_using v.expr.CAst.v.expr, v
    | _ -> assert false in
  let has_proof_no_using = function
    | VernacProof(_,None) -> true
    | _ -> false
  in
  let has_proof_no_using = function
-   | Some (_, v) -> has_proof_no_using (Vernacprop.under_control v.expr)
+   | Some (_, v) -> has_proof_no_using v.expr.CAst.v.expr
                     && (not (Vernacprop.has_Fail v.expr))
    | _ -> false in
  let too_complex_to_delegate = function
@@ -2191,7 +2192,7 @@ let collect_proof keep cur hd brkind id =
     let view = VCS.visit id in
     match view.step with
     | (`Sideff (ReplayCommand x,_) | `Cmd { cast = x })
-      when too_complex_to_delegate (Vernacprop.under_control x.expr) ->
+      when too_complex_to_delegate x.expr.CAst.v.expr ->
        `Sync(no_name,`Print)
     | `Cmd { cast = x } -> collect (Some (id,x)) (id::accn) view.next
     | `Sideff (ReplayCommand x,_) -> collect (Some (id,x)) (id::accn) view.next
@@ -2212,7 +2213,7 @@ let collect_proof keep cur hd brkind id =
         (try
           let name, hint = name ids, get_hint_ctx loc  in
           let t, v = proof_no_using last in
-          v.expr <- CAst.map (fun _ -> VernacExpr([], VernacProof(t, Some hint))) v.expr;
+          v.expr <- CAst.map (fun _ -> { control = []; attrs = []; expr = VernacProof(t, Some hint)}) v.expr;
           `ASync (parent last,accn,name,delegate name)
         with Not_found ->
           let name = name ids in
@@ -2235,7 +2236,7 @@ let collect_proof keep cur hd brkind id =
    | _ -> false
  in
  match cur, (VCS.visit id).step, brkind with
- | (parent, x), `Fork _, _ when is_vernac_exact (Vernacprop.under_control x.expr)
+ | (parent, x), `Fork _, _ when is_vernac_exact x.expr.CAst.v.expr
                                 && (not (Vernacprop.has_Fail x.expr)) ->
      `Sync (no_name,`Immediate)
  | _, _, { VCS.kind = `Edit _ }  -> check_policy (collect (Some cur) [] id)
@@ -2350,7 +2351,7 @@ let known_state ~doc ?(redefine_qed=false) ~cache id =
      term.` could also fail in this case, however that'd be a bug I do
      believe as proof injection shouldn't happen here. *)
   let extract_pe (x : aast) =
-    match Vernacprop.under_control x.expr with
+    match x.expr.CAst.v.expr with
     | VernacEndProof pe -> pe
     | _ -> CErrors.anomaly Pp.(str "Non-qed command classified incorrectly") in
 
@@ -2873,7 +2874,7 @@ let process_transaction ~doc ?(newtip=Stateid.fresh ())
           let queue =
             if VCS.is_vio_doc () &&
                VCS.((get_branch head).kind = `Master) &&
-               may_pierce_opaque (Vernacprop.under_control x.expr)
+               may_pierce_opaque x.expr.CAst.v.expr
             then `SkipQueue
             else `MainQueue in
           VCS.commit id (mkTransCmd x [] false queue);
@@ -2939,7 +2940,7 @@ let process_transaction ~doc ?(newtip=Stateid.fresh ())
               VCS.commit id (mkTransCmd x l true `MainQueue);
               (* We can't replay a Definition since universes may be differently
                * inferred.  This holds in Coq >= 8.5 *)
-              let action = match Vernacprop.under_control x.expr with
+              let action = match x.expr.CAst.v.expr with
                 | VernacDefinition(_, _, DefineBody _) -> CherryPickEnv
                 | _ -> ReplayCommand x in
               VCS.propagate_sideff ~action

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -1056,7 +1056,7 @@ end (* }}} *)
 (* Wrapper for the proof-closing special path for Qed *)
 let stm_qed_delay_proof ?route ~proof ~info ~id ~st ~loc ~control pending : Vernacstate.t =
   set_id_for_feedback ?route dummy_doc id;
-  Vernacentries.interp_qed_delayed_proof ~proof ~info ~st ?loc:loc ~control pending
+  Vernacentries.interp_qed_delayed_proof ~proof ~info ~st ~control (CAst.make ?loc pending)
 
 (* Wrapper for Vernacentries.interp to set the feedback id *)
 (* It is currently called 19 times, this number should be certainly

--- a/toplevel/coqloop.ml
+++ b/toplevel/coqloop.ml
@@ -340,8 +340,8 @@ let print_anyway_opts = [
 
 let print_anyway c =
   let open Vernacexpr in
-  match c with
-  | VernacExpr (_, VernacSetOption (_, opt, _)) -> List.mem opt print_anyway_opts
+  match c.expr with
+  | VernacSetOption (_, opt, _) -> List.mem opt print_anyway_opts
   | _ -> false
 
 (* We try to behave better when goal printing raises an exception

--- a/toplevel/vernac.ml
+++ b/toplevel/vernac.ml
@@ -20,13 +20,9 @@ open Vernacprop
    Use the module Coqtoplevel, which catches these exceptions
    (the exceptions are explained only at the toplevel). *)
 
-let checknav_simple ({ CAst.loc; _ } as cmd) =
-  if is_navigation_vernac cmd && not (is_reset cmd) then
+let checknav { CAst.loc; v = { expr } }  =
+  if is_navigation_vernac expr && not (is_reset expr) then
     CErrors.user_err ?loc (str "Navigation commands forbidden in files.")
-
-let checknav_deep ({ CAst.loc; _ } as cmd) =
-  if is_deep_navigation_vernac cmd then
-    CErrors.user_err ?loc (str "Navigation commands forbidden in nested commands.")
 
 (* Echo from a buffer based on position.
    XXX: Should move to utility file. *)
@@ -60,7 +56,7 @@ let interp_vernac ~check ~interactive ~state ({CAst.loc;_} as com) =
          due to the way it prints. *)
       let com = if state.time
         then begin
-          CAst.make ?loc @@ VernacTime(state.time,com)
+          CAst.map (fun cmd -> { cmd with control = ControlTime state.time :: cmd.control }) com
         end else com in
       let doc, nsid, ntip = Stm.add ~doc:state.doc ~ontop:state.sid (not !Flags.quiet) com in
 
@@ -108,7 +104,7 @@ let load_vernac_core ~echo ~check ~interactive ~state file =
       (* Printing of AST for -compile-verbose *)
       Option.iter (vernac_echo ?loc:ast.CAst.loc) in_echo;
 
-      checknav_simple ast;
+      checknav ast;
 
       let state =
         Flags.silently (interp_vernac ~check ~interactive ~state) ast in
@@ -122,7 +118,6 @@ let load_vernac_core ~echo ~check ~interactive ~state file =
     iraise (e, info)
 
 let process_expr ~state loc_ast =
-  checknav_deep loc_ast;
   interp_vernac ~interactive:true ~check:true ~state loc_ast
 
 (******************************************************************************)

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -72,16 +72,29 @@ let parse_compat_version = let open Flags in function
     CErrors.user_err ~hdr:"get_compat_version"
       Pp.(str "Unknown compatibility version \"" ++ str s ++ str "\".")
 
+(* For now we just keep the top-level location of the whole
+   vernacular, that is to say, including attributes and control flags;
+   this is not very convenient for advanced clients tho, so in the
+   future it'd be cool to actually locate the attributes and control
+   flags individually too. *)
+let add_control_flag ~loc ~flag { CAst.v = cmd } =
+  CAst.make ~loc { cmd with control = flag :: cmd.control }
+
 }
 
 GRAMMAR EXTEND Gram
   GLOBAL: vernac_control quoted_attributes gallina_ext noedit_mode subprf;
   vernac_control: FIRST
-    [ [ IDENT "Time"; c = vernac_control -> { CAst.make ~loc @@ VernacTime (false,c) }
-      | IDENT "Redirect"; s = ne_string; c = vernac_control -> { CAst.make ~loc @@ VernacRedirect (s, c) }
-      | IDENT "Timeout"; n = natural; v = vernac_control -> { CAst.make ~loc @@ VernacTimeout(n,v) }
-      | IDENT "Fail"; v = vernac_control -> { CAst.make ~loc @@ VernacFail v }
-      | v = decorated_vernac -> { let (f, v) = v in CAst.make ~loc @@ VernacExpr(f, v) } ]
+    [ [ IDENT "Time"; c = vernac_control ->
+        { add_control_flag ~loc ~flag:(ControlTime false) c }
+      | IDENT "Redirect"; s = ne_string; c = vernac_control ->
+        { add_control_flag ~loc ~flag:(ControlRedirect s) c }
+      | IDENT "Timeout"; n = natural; c = vernac_control ->
+        { add_control_flag ~loc ~flag:(ControlTimeout n) c }
+      | IDENT "Fail"; c = vernac_control ->
+        { add_control_flag ~loc ~flag:ControlFail c }
+      | v = decorated_vernac ->
+        { let (attrs, expr) = v in CAst.make ~loc { control = []; attrs; expr = expr } } ]
     ]
   ;
   decorated_vernac:

--- a/vernac/vernacentries.mli
+++ b/vernac/vernacentries.mli
@@ -18,6 +18,7 @@ val interp_qed_delayed_proof
   -> info:Lemmas.Info.t
   -> st:Vernacstate.t
   -> ?loc:Loc.t
+  -> control:Vernacexpr.control_flag list
   -> Vernacexpr.proof_end
   -> Vernacstate.t
 

--- a/vernac/vernacentries.mli
+++ b/vernac/vernacentries.mli
@@ -17,9 +17,8 @@ val interp_qed_delayed_proof
   :  proof:Proof_global.proof_object
   -> info:Lemmas.Info.t
   -> st:Vernacstate.t
-  -> ?loc:Loc.t
   -> control:Vernacexpr.control_flag list
-  -> Vernacexpr.proof_end
+  -> Vernacexpr.proof_end CAst.t
   -> Vernacstate.t
 
 (** [with_fail ~st f] runs [f ()] and expects it to fail, otherwise it fails. *)

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -414,12 +414,17 @@ type nonrec vernac_expr =
   (* For extension *)
   | VernacExtend of extend_name * Genarg.raw_generic_argument list
 
-type vernac_control_r =
-  | VernacExpr of Attributes.vernac_flags * vernac_expr
+type control_flag =
+  | ControlTime of bool
   (* boolean is true when the `-time` batch-mode command line flag was set.
      the flag is used to print differently in `-time` vs `Time foo` *)
-  | VernacTime of bool * vernac_control
-  | VernacRedirect of string * vernac_control
-  | VernacTimeout of int * vernac_control
-  | VernacFail of vernac_control
+  | ControlRedirect of string
+  | ControlTimeout of int
+  | ControlFail
+
+type vernac_control_r =
+  { control : control_flag list
+  ; attrs : Attributes.vernac_flags
+  ; expr : vernac_expr
+  }
 and vernac_control = vernac_control_r CAst.t

--- a/vernac/vernacprop.ml
+++ b/vernac/vernacprop.ml
@@ -13,47 +13,26 @@
 
 open Vernacexpr
 
-let rec under_control v = v |> CAst.with_val (function
-  | VernacExpr (_, c) -> c
-  | VernacRedirect (_,c)
-  | VernacTime (_,c)
-  | VernacFail c
-  | VernacTimeout (_,c) -> under_control c
-  )
-
-let rec has_Fail v = v |> CAst.with_val (function
-  | VernacExpr _ -> false
-  | VernacRedirect (_,c)
-  | VernacTime (_,c)
-  | VernacTimeout (_,c) -> has_Fail c
-  | VernacFail _ -> true)
+(* Does this vernacular involve Fail? *)
+let has_Fail { CAst.v } = List.mem ControlFail v.control
 
 (* Navigation commands are allowed in a coqtop session but not in a .v file *)
-let is_navigation_vernac_expr = function
+let is_navigation_vernac = function
   | VernacResetInitial
   | VernacResetName _
   | VernacBack _ -> true
   | _ -> false
 
-let is_navigation_vernac c =
-  is_navigation_vernac_expr (under_control c)
-
-let rec is_deep_navigation_vernac v = v |> CAst.with_val (function
-  | VernacTime (_,c) -> is_deep_navigation_vernac c
-  | VernacRedirect (_, c)
-  | VernacTimeout (_, c) | VernacFail c -> is_navigation_vernac c
-  | VernacExpr _ -> false)
-
 (* NB: Reset is now allowed again as asked by A. Chlipala *)
-let is_reset = CAst.with_val (function
-  | VernacExpr ( _, VernacResetInitial)
-  | VernacExpr (_, VernacResetName _) -> true
-  | _ -> false)
+let is_reset = function
+  | VernacResetInitial
+  | VernacResetName _ -> true
+  | _ -> false
 
-let is_debug cmd = match under_control cmd with
+let is_debug = function
   | VernacSetOption (_, ["Ltac";"Debug"], _) -> true
   | _ -> false
 
-let is_undo cmd = match under_control cmd with
+let is_undo = function
   | VernacUndo _ | VernacUndoTo _ -> true
   | _ -> false

--- a/vernac/vernacprop.mli
+++ b/vernac/vernacprop.mli
@@ -13,16 +13,9 @@
 
 open Vernacexpr
 
-(* Return the vernacular command below control (Time, Timeout, Redirect, Fail).
-   Beware that Fail can change many properties of the underlying command, since
-   a success of Fail means the command was backtracked over. *)
-val under_control : vernac_control -> vernac_expr
-
 val has_Fail : vernac_control -> bool
-
-val is_navigation_vernac : vernac_control -> bool
-val is_deep_navigation_vernac : vernac_control -> bool
-val is_reset : vernac_control -> bool
-val is_debug : vernac_control -> bool
-val is_undo : vernac_control -> bool
+val is_navigation_vernac : vernac_expr -> bool
+val is_reset : vernac_expr -> bool
+val is_debug : vernac_expr -> bool
+val is_undo : vernac_expr -> bool
 


### PR DESCRIPTION
We place control attribute information in its own data structure; this allows to pass the control attributes to the delayed proof functions, fixing #10345 , introduced in #10337
