### PR TITLE
[Pretyping] Do not restrict a solved evar

### DIFF
--- a/test-suite/bugs/closed/bug_10300.v
+++ b/test-suite/bugs/closed/bug_10300.v
@@ -1,0 +1,14 @@
+Set Implicit Arguments.
+
+Definition hprop := nat -> Prop.
+
+Definition himpl := fun H1 H2 : hprop => forall (h : nat), H1 h -> H2 h.
+
+Parameter himpl_refl : forall H : hprop, himpl H H.
+
+Parameter hstar : hprop -> hprop -> hprop.
+
+Parameter hpure : hprop.
+
+Lemma test : (forall (H:hprop), himpl (hstar H H) hpure -> True) -> True.
+Proof. intros M. eapply M. apply himpl_refl. Abort.


### PR DESCRIPTION
Fixes #10300. Also addresses #10285: rather than an anomaly, that example produces a regular error message.

> Unable to unify "?M163 tt x" with "Ref (list A) nil r x".
