### PR TITLE
[nix] python2 -> python3

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     hostname
-    python2 time # coq-makefile timing tools
+    python3 time # coq-makefile timing tools
     dune
   ]
   ++ (with ocamlPackages; [ ocaml findlib num ])


### PR DESCRIPTION
We are not supposed to have any script depending specifically on python2.

**Kind:** infrastructure.

It's well over time.

I'm just not sure how this will interact with the `python3.withPackages` doc dependency, but I guess CI will tell.