### PR TITLE
 Remove ad-hoc `Anticipate` objects

### DIFF
--- a/library/lib.mli
+++ b/library/lib.mli
@@ -42,11 +42,11 @@ val subst_atomic_objects : Mod_subst.substitution -> lib_atomic_objects -> lib_a
 
 (** [classify_segment seg] verifies that there are no OpenedThings,
    clears ClosedSections and FrozenStates and divides Leafs according
-   to their answers to the [classify_object] function in three groups:
-   [Substitute], [Keep], [Anticipate] respectively.  The order of each
-   returned list is the same as in the input list. *)
+   to their answers to the [classify_object] function in two groups:
+   [Substitute] and [Keep] respectively. The order of each returned list is
+   the same as in the input list. *)
 val classify_segment :
-  library_segment -> lib_objects * lib_objects * Libobject.t list
+  library_segment -> lib_objects * lib_objects
 
 (** [segment_of_objects prefix objs] forms a list of Leafs *)
 val segment_of_objects :

--- a/library/libobject.ml
+++ b/library/libobject.ml
@@ -14,7 +14,7 @@ open Names
 module Dyn = Dyn.Make ()
 
 type 'a substitutivity =
-    Dispose | Substitute of 'a | Keep of 'a | Anticipate of 'a
+    Dispose | Substitute of 'a | Keep of 'a
 
 type object_name = Libnames.full_path * Names.KerName.t
 
@@ -107,7 +107,6 @@ let declare_object_full odecl =
   | Dispose -> Dispose
   | Substitute atomic_obj -> Substitute (infun atomic_obj)
   | Keep atomic_obj -> Keep (infun atomic_obj)
-  | Anticipate (atomic_obj) -> Anticipate (infun atomic_obj)
   and discharge (oname,lobj) =
     Option.map infun (odecl.discharge_function (oname,outfun lobj))
   and rebuild lobj = infun (odecl.rebuild_function (outfun lobj))

--- a/library/libobject.mli
+++ b/library/libobject.mli
@@ -36,9 +36,6 @@ open Mod_subst
                   the module name must be updated
      Keep       - the object is not substitutive, but survives module
                   closing
-     Anticipate - this is for objects that have to be explicitly
-                  managed by the [end_module] function (like Require
-                  and Read markers)
 
      The classification function is also an occasion for a cleanup
      (if this function returns Keep or Substitute of some object, the
@@ -64,7 +61,7 @@ open Mod_subst
 *)
 
 type 'a substitutivity =
-    Dispose | Substitute of 'a | Keep of 'a | Anticipate of 'a
+    Dispose | Substitute of 'a | Keep of 'a
 
 (** Both names are passed to objects: a "semantic" [kernel_name], which
    can be substituted and a "syntactic" [full_path] which can be printed

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -985,14 +985,11 @@ let vernac_end_segment ({v=id} as lid) =
 
 (* Libraries *)
 
-let warn_require_in_section =
-  let name = "require-in-section" in
-  let category = "deprecated" in
-  CWarnings.create ~name ~category
-    (fun () -> strbrk "Use of “Require” inside a section is deprecated.")
-
 let vernac_require from import qidl =
-  if Lib.sections_are_opened () then warn_require_in_section ();
+  if Lib.is_module_or_modtype () then
+    CErrors.user_err Pp.(str "The \"Require\" command is not supported inside modules or module types.");
+  if Lib.sections_are_opened () then
+    CErrors.user_err Pp.(str "The \"Require\" command is not supported inside sections.");
   let root = match from with
   | None -> None
   | Some from ->


### PR DESCRIPTION
We drop support for `Require` inside modules. Was already deprecated.