### PR TITLE
Version pinning 8.10

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -279,8 +279,6 @@ windows32:
   extends: .windows-template
   variables:
     ARCH: "32"
-  except:
-    - /^pr-.*$/
 
 lint:
   image: docker:git

--- a/dev/build/windows/patches_coq/VST.patch
+++ b/dev/build/windows/patches_coq/VST.patch
@@ -1,7 +1,7 @@
 diff --git a/Makefile b/Makefile
 --- a/Makefile
 +++ b/Makefile
-@@ -82,8 +82,8 @@ endif
+@@ -76,8 +76,8 @@ endif
 
  COMPCERTDIRS=lib common $(ARCHDIRS) cfrontend flocq exportclight $(BACKEND)
 
@@ -9,6 +9,6 @@ diff --git a/Makefile b/Makefile
 -EXTFLAGS= $(foreach d, $(COMPCERTDIRS), -Q $(COMPCERT)/$(d) compcert.$(d))
 +COMPCERT_R_FLAGS= $(foreach d, $(COMPCERTDIRS), -R $(COMPCERT)/$(d) VST.compcert.$(d))
 +EXTFLAGS= $(foreach d, $(COMPCERTDIRS), -Q $(COMPCERT)/$(d) VST.compcert.$(d))
- # for ITrees
- ifeq ($(wildcard InteractionTrees/the?ries),"InteractionTrees/theories")
- EXTFLAGS:=$(EXTFLAGS) -Q InteractionTrees/theories ITree
+
+ # for SSReflect
+ ifdef MATHCOMP

--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -31,7 +31,7 @@
 ########################################################################
 # Unicoq + Mtac2
 ########################################################################
-: "${unicoq_CI_REF:=da609d64a531cd8069478aa19c29ce88261e3fe5}"
+: "${unicoq_CI_REF:=v1.3-8.10}"
 : "${unicoq_CI_GITURL:=https://github.com/unicoq/unicoq}"
 : "${unicoq_CI_ARCHIVEURL:=${unicoq_CI_GITURL}/archive}"
 

--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -9,22 +9,22 @@
 ########################################################################
 # MathComp
 ########################################################################
-: "${mathcomp_CI_REF:=master}"
+: "${mathcomp_CI_REF:=1bda1dd5621684737c9d993855ae104e8b9d2909}"
 : "${mathcomp_CI_GITURL:=https://github.com/math-comp/math-comp}"
 : "${mathcomp_CI_ARCHIVEURL:=${mathcomp_CI_GITURL}/archive}"
 
-: "${fourcolor_CI_REF:=master}"
+: "${fourcolor_CI_REF:=b0e52e8e6dca3a8a4411a77ac3383968a779a321}"
 : "${fourcolor_CI_GITURL:=https://github.com/math-comp/fourcolor}"
 : "${fourcolor_CI_ARCHIVEURL:=${fourcolor_CI_GITURL}/archive}"
 
-: "${oddorder_CI_REF:=master}"
+: "${oddorder_CI_REF:=ca602a4638a9fe8ac30780095543d861f60fbfa0}"
 : "${oddorder_CI_GITURL:=https://github.com/math-comp/odd-order}"
 : "${oddorder_CI_ARCHIVEURL:=${oddorder_CI_GITURL}/archive}"
 
 ########################################################################
 # UniMath
 ########################################################################
-: "${unimath_CI_REF:=master}"
+: "${unimath_CI_REF:=169999883b7b867ae40071e396045832302695a4}"
 : "${unimath_CI_GITURL:=https://github.com/UniMath/UniMath}"
 : "${unimath_CI_ARCHIVEURL:=${unimath_CI_GITURL}/archive}"
 
@@ -42,11 +42,11 @@
 ########################################################################
 # Mathclasses + Corn
 ########################################################################
-: "${math_classes_CI_REF:=master}"
+: "${math_classes_CI_REF:=4d19c6bf11739a7541c8c3afed871603d2b4395e}"
 : "${math_classes_CI_GITURL:=https://github.com/coq-community/math-classes}"
 : "${math_classes_CI_ARCHIVEURL:=${math_classes_CI_GITURL}/archive}"
 
-: "${Corn_CI_REF:=master}"
+: "${Corn_CI_REF:=db29aed4b2d378721715bfff258e59968207331f}"
 : "${Corn_CI_GITURL:=https://github.com/coq-community/corn}"
 : "${Corn_CI_ARCHIVEURL:=${Corn_CI_GITURL}/archive}"
 
@@ -62,14 +62,14 @@
 : "${Iris_CI_GITURL:=https://gitlab.mpi-sws.org/FP/iris-coq}"
 : "${Iris_CI_ARCHIVEURL:=${Iris_CI_GITURL}/-/archive}"
 
-: "${lambdaRust_CI_REF:=master}"
+: "${lambdaRust_CI_REF:=434ec937185e49b1c6ee514f12c0d121a00d3127}"
 : "${lambdaRust_CI_GITURL:=https://gitlab.mpi-sws.org/FP/LambdaRust-coq}"
 : "${lambdaRust_CI_ARCHIVEURL:=${lambdaRust_CI_GITURL}/-/archive}"
 
 ########################################################################
 # HoTT
 ########################################################################
-: "${HoTT_CI_REF:=master}"
+: "${HoTT_CI_REF:=ed714382f980d54c055890f95bef0de4ff6bdc78}"
 : "${HoTT_CI_GITURL:=https://github.com/HoTT/HoTT}"
 : "${HoTT_CI_ARCHIVEURL:=${HoTT_CI_GITURL}/archive}"
 
@@ -90,84 +90,91 @@
 ########################################################################
 # GeoCoq
 ########################################################################
-: "${GeoCoq_CI_REF:=master}"
+: "${GeoCoq_CI_REF:=2b4cf1129fd566e14a64eaa651e941b90b1925e9}"
 : "${GeoCoq_CI_GITURL:=https://github.com/GeoCoq/GeoCoq}"
 : "${GeoCoq_CI_ARCHIVEURL:=${GeoCoq_CI_GITURL}/archive}"
 
 ########################################################################
 # Flocq
 ########################################################################
-: "${Flocq_CI_REF:=master}"
+: "${Flocq_CI_REF:=flocq-3.2.0}"
 : "${Flocq_CI_GITURL:=https://gitlab.inria.fr/flocq/flocq}"
 : "${Flocq_CI_ARCHIVEURL:=${Flocq_CI_GITURL}/-/archive}"
 
 ########################################################################
 # Coquelicot
 ########################################################################
-: "${coquelicot_CI_REF:=master}"
+: "${coquelicot_CI_REF:=b488d25b68759b0ede744079e574f09a339cc894}"
 : "${coquelicot_CI_GITURL:=https://gitlab.inria.fr/coquelicot/coquelicot}"
 : "${coquelicot_CI_ARCHIVEURL:=${coquelicot_CI_GITURL}/-/archive}"
 
 ########################################################################
 # Coq-interval
 ########################################################################
-: "${interval_CI_REF:=master}"
+: "${interval_CI_REF:=interval-3.4.1}"
 : "${interval_CI_GITURL:=https://gitlab.inria.fr/coqinterval/interval}"
 : "${interval_CI_ARCHIVEURL:=${interval_CI_GITURL}/-/archive}"
 
 ########################################################################
 # Gappa stand alone tool
 ########################################################################
-: "${gappa_tool_CI_REF:=master}"
+: "${gappa_tool_CI_REF:=gappa-1.3.5}"
 : "${gappa_tool_CI_GITURL:=https://gitlab.inria.fr/gappa/gappa}"
 : "${gappa_tool_CI_ARCHIVEURL:=${gappa_tool_CI_GITURL}/-/archive}"
 
 ########################################################################
 # Gappa plugin
 ########################################################################
-: "${gappa_plugin_CI_REF:=master}"
+: "${gappa_plugin_CI_REF:=gappalib-coq-1.4.2}"
 : "${gappa_plugin_CI_GITURL:=https://gitlab.inria.fr/gappa/coq}"
 : "${gappa_plugin_CI_ARCHIVEURL:=${gappa_plugin_CI_GITURL}/-/archive}"
 
 ########################################################################
 # CompCert
 ########################################################################
-: "${compcert_CI_REF:=master}"
+# CompCert tag v3.5 fails with:
+# compcert-v3.5-make_err.txt: File ".\flocq/Core/Fcore_Zaux.v", line 28, characters 18-21:
+# compcert-v3.5-make_err.txt: Error: The reference Zle was not found in the current environment.
+# Hash 415c5a5a28ac7035cfa33e5753af841a450bfab0 = "Fix compatibility with Coq 8.10 (#303)".
+# Hash 98858317be25deed815c7a8b5d4e9d6b512f5de5 = "Make configure resistant to Windows EOL and paths"
+: "${compcert_CI_REF:=98858317be25deed815c7a8b5d4e9d6b512f5de5}"
 : "${compcert_CI_GITURL:=https://github.com/AbsInt/CompCert}"
 : "${compcert_CI_ARCHIVEURL:=${compcert_CI_GITURL}/archive}"
 
 ########################################################################
 # VST
 ########################################################################
-: "${vst_CI_REF:=master}"
+# Latest tag 2.4 does not compile with Coq 8.10 cause of changes in field
+# cb633f1e7b5fdf7b4893ea7bc016f9304edce8c1 is latest as of July 7th.
+: "${vst_CI_REF:=cb633f1e7b5fdf7b4893ea7bc016f9304edce8c1}"
 : "${vst_CI_GITURL:=https://github.com/PrincetonUniversity/VST}"
 : "${vst_CI_ARCHIVEURL:=${vst_CI_GITURL}/archive}"
 
 ########################################################################
 # cross-crypto
 ########################################################################
-: "${cross_crypto_CI_REF:=master}"
+: "${cross_crypto_CI_REF:=ab65a8834528d677f8f59477a4e15d8ee4f2560e}"
 : "${cross_crypto_CI_GITURL:=https://github.com/mit-plv/cross-crypto}"
 : "${cross_crypto_CI_ARCHIVEURL:=${cross_crypto_CI_GITURL}/archive}"
 
 ########################################################################
 # fiat_parsers
 ########################################################################
-: "${fiat_parsers_CI_REF:=master}"
+: "${fiat_parsers_CI_REF:=492cfa4171f39f084953978322a01aae2c6ee6b8}"
 : "${fiat_parsers_CI_GITURL:=https://github.com/mit-plv/fiat}"
 : "${fiat_parsers_CI_ARCHIVEURL:=${fiat_parsers_CI_GITURL}/archive}"
 
 ########################################################################
 # fiat_crypto
 ########################################################################
-: "${fiat_crypto_CI_REF:=master}"
+: "${fiat_crypto_CI_REF:=8517e5f3afe079e7b42220088ca0c8e79e5e4343}"
 : "${fiat_crypto_CI_GITURL:=https://github.com/mit-plv/fiat-crypto}"
 : "${fiat_crypto_CI_ARCHIVEURL:=${fiat_crypto_CI_GITURL}/archive}"
 
 ########################################################################
 # fiat_crypto_legacy
 ########################################################################
-: "${fiat_crypto_legacy_CI_REF:=sp2019latest}"
+: "${fiat_crypto_legacy_CI_REF:=847b18bf8f38f7262331181f25ca96aee0423f52}"
 : "${fiat_crypto_legacy_CI_GITURL:=https://github.com/mit-plv/fiat-crypto}"
 : "${fiat_crypto_legacy_CI_ARCHIVEURL:=${fiat_crypto_legacy_CI_GITURL}/archive}"
 
@@ -181,7 +188,7 @@
 ########################################################################
 # CoLoR
 ########################################################################
-: "${color_CI_REF:=master}"
+: "${color_CI_REF:=b6c9486a8a6379a5faad8f47afda3dc3f7fcbb15}"
 : "${color_CI_GITURL:=https://github.com/fblanqui/color}"
 : "${color_CI_ARCHIVEURL:=${color_CI_GITURL}/archive}"
 
@@ -195,13 +202,13 @@
 ########################################################################
 # TLC
 ########################################################################
-: "${tlc_CI_REF:=master}"
+: "${tlc_CI_REF:=6dc379c6c7a306be6b7ef1b3774bdb9ea2c94330}"
 : "${tlc_CI_GITURL:=https://gforge.inria.fr/git/tlc/tlc}"
 
 ########################################################################
 # Bignums
 ########################################################################
-: "${bignums_CI_REF:=master}"
+: "${bignums_CI_REF:=V8.10+beta1}"
 : "${bignums_CI_GITURL:=https://github.com/coq/bignums}"
 : "${bignums_CI_ARCHIVEURL:=${bignums_CI_GITURL}/archive}"
 
@@ -222,21 +229,21 @@
 ########################################################################
 # Elpi
 ########################################################################
-: "${elpi_CI_REF:=coq-v8.10}"
+: "${elpi_CI_REF:=c3ae99fb7b423a403846f2f823b7356083d9705d}"
 : "${elpi_CI_GITURL:=https://github.com/LPCIC/coq-elpi}"
 : "${elpi_CI_ARCHIVEURL:=${elpi_CI_GITURL}/archive}"
 
 ########################################################################
 # fcsl-pcm
 ########################################################################
-: "${fcsl_pcm_CI_REF:=master}"
+: "${fcsl_pcm_CI_REF:=581d17078eb2e813cda3db42070b8d0c67beba53}"
 : "${fcsl_pcm_CI_GITURL:=https://github.com/imdea-software/fcsl-pcm}"
 : "${fcsl_pcm_CI_ARCHIVEURL:=${fcsl_pcm_CI_GITURL}/archive}"
 
 ########################################################################
 # ext-lib
 ########################################################################
-: "${ext_lib_CI_REF:=f53ffbfc0fd137e774f4a20457b12fca44cc58ca}"
+: "${ext_lib_CI_REF:=v0.10.2}"
 : "${ext_lib_CI_GITURL:=https://github.com/coq-ext-lib/coq-ext-lib}"
 : "${ext_lib_CI_ARCHIVEURL:=${ext_lib_CI_GITURL}/archive}"
 
@@ -250,28 +257,30 @@
 ########################################################################
 # quickchick
 ########################################################################
-: "${quickchick_CI_REF:=8.10}"
+: "${quickchick_CI_REF:=44f483f644f462379653bee6153b2339f94ba3c5}"
 : "${quickchick_CI_GITURL:=https://github.com/QuickChick/QuickChick}"
 : "${quickchick_CI_ARCHIVEURL:=${quickchick_CI_GITURL}/archive}"
 
 ########################################################################
 # menhirlib
 ########################################################################
-: "${menhirlib_CI_REF:=master}"
+# The latest hash as of June 29 does not work with CompCert
+# The library name did change some time later
+: "${menhirlib_CI_REF:=f0842e17a90366c8e328e9a2c2f089013887edc5}"
 : "${menhirlib_CI_GITURL:=https://gitlab.inria.fr/fpottier/coq-menhirlib}"
 : "${menhirlib_CI_ARCHIVEURL:=${menhirlib_CI_GITURL}/-/archive}"
 
 ########################################################################
 # aac_tactics
 ########################################################################
-: "${aac_tactics_CI_REF:=v8.10}"
+: "${aac_tactics_CI_REF:=86eef5cfefe32406e29d40fd81b130d985d6bccf}"
 : "${aac_tactics_CI_GITURL:=https://github.com/coq-community/aac-tactics}"
 : "${aac_tactics_CI_ARCHIVEURL:=${aac_tactics_CI_GITURL}/archive}"
 
 ########################################################################
 # paramcoq
 ########################################################################
-: "${paramcoq_CI_REF:=v8.10}"
+: "${paramcoq_CI_REF:=f48072b8223f8ae9e190cf0e98ba1c30f733b07d}"
 : "${paramcoq_CI_GITURL:=https://github.com/coq-community/paramcoq}"
 : "${paramcoq_CI_ARCHIVEURL:=${paramcoq_CI_GITURL}/archive}"
 
@@ -285,23 +294,23 @@
 ########################################################################
 # StructTact + InfSeqExt + Cheerios + Verdi + Verdi Raft
 ########################################################################
-: "${struct_tact_CI_REF:=master}"
+: "${struct_tact_CI_REF:=4b9229f9678c7360d07a9e96318950800b369257}"
 : "${struct_tact_CI_GITURL:=https://github.com/uwplse/StructTact}"
 : "${struct_tact_CI_ARCHIVEURL:=${struct_tact_CI_GITURL}/archive}"
 
-: "${inf_seq_ext_CI_REF:=master}"
+: "${inf_seq_ext_CI_REF:=dd91f4eb8be379bb1591fc565b376727ef97abe6}"
 : "${inf_seq_ext_CI_GITURL:=https://github.com/DistributedComponents/InfSeqExt}"
 : "${inf_seq_ext_CI_ARCHIVEURL:=${inf_seq_ext_CI_GITURL}/archive}"
 
-: "${cheerios_CI_REF:=master}"
+: "${cheerios_CI_REF:=f512bfcb9c8d0b211a72b9f2b195ad46ced7df76}"
 : "${cheerios_CI_GITURL:=https://github.com/uwplse/cheerios}"
 : "${cheerios_CI_ARCHIVEURL:=${cheerios_CI_GITURL}/archive}"
 
-: "${verdi_CI_REF:=master}"
+: "${verdi_CI_REF:=163b9d0039ba6de2c72b77728136e45ba3f93623}"
 : "${verdi_CI_GITURL:=https://github.com/uwplse/verdi}"
 : "${verdi_CI_ARCHIVEURL:=${verdi_CI_GITURL}/archive}"
 
-: "${verdi_raft_CI_REF:=master}"
+: "${verdi_raft_CI_REF:=3fc8d5223865e80e97d6f90ff39700f8977a1eae}"
 : "${verdi_raft_CI_GITURL:=https://github.com/uwplse/verdi-raft}"
 : "${verdi_raft_CI_ARCHIVEURL:=${verdi_raft_CI_GITURL}/archive}"
 
@@ -315,6 +324,6 @@
 ########################################################################
 # argosy
 ########################################################################
-: "${argosy_CI_REF:=master}"
+: "${argosy_CI_REF:=68674f1c36c812b088d4429792446d018dc27dc2}"
 : "${argosy_CI_GITURL:=https://github.com/mit-pdos/argosy}"
 : "${argosy_CI_ARCHIVEURL:=${argosy_CI_GITURL}/archive}"

--- a/dev/ci/gitlab.bat
+++ b/dev/ci/gitlab.bat
@@ -37,6 +37,9 @@ SET CI_PROJECT_DIR_CFMT=%CI_PROJECT_DIR_MFMT:C:/=/cygdrive/c/%
 SET COQREGTESTING=Y
 SET PATH=%PATH%;C:\Program Files\7-Zip\;C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin
 
+REM ENable all addons on release branch
+SET WINDOWS=enabled_all_addons
+
 IF "%WINDOWS%" == "enabled_all_addons" (
   SET EXTRA_ADDONS=^
     -addon=bignums ^


### PR DESCRIPTION
This PR does

- pin versions of all add-ons and plugins for the Windows installer (and everything else in CI)
- added plugins added in 8.9.1 (Gappa and Coq Interval)

I am not sure if this PR can stay like this because it mixes adding Interval and Gappa, patching some add-ons to work and pinning the plugins. The latter needs to be undone (or maybe not - see discussion in coqdev). It came out like this because doing this is an iterative process which is way hard to do in separate steps. But of cause I could reset the branch and then merge in the changes in logical groups one and provide separated commits.

Anyway - I did the PR now because I don't have much time until Wednesday and at least wanted to see what CI and reviewers say.