### PR TITLE
Azure CI MacOS: build byte target first

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -81,6 +81,7 @@ jobs:
 
       eval $(opam env)
       ./configure -prefix '$(Build.BinariesDirectory)' -warn-error yes -native-compiler no -coqide opt
+      make -j "$NJOBS" byte
       make -j "$NJOBS"
     displayName: 'Build Coq'
 


### PR DESCRIPTION
It looks like the recent spurious failures are because it somehow
wants to build gramlib byte and opt at the same time and the old race
condition causes the error.

Having failed to debug the makefile, we work around by building byte first.
