### PR TITLE
Dune: fix build_all_stdlib rule

### DIFF
--- a/dev/shim/dune
+++ b/dev/shim/dune
@@ -4,7 +4,7 @@
   %{bin:coqtop}
   %{project_root}/theories/Init/Prelude.vo)
  (action
-  (with-outputs-to coqtop-prelude
+  (with-stdout-to coqtop-prelude
    (progn
     (echo "#!/usr/bin/env bash\n")
     (bash "echo \"$(pwd)/%{bin:coqtop} -coqlib $(pwd)/%{project_root}\" \\$@")
@@ -16,7 +16,7 @@
   %{bin:coqc}
   %{project_root}/theories/Init/Prelude.vo)
  (action
-  (with-outputs-to coqc-prelude
+  (with-stdout-to coqc-prelude
    (progn
     (echo "#!/usr/bin/env bash\n")
     (bash "echo \"$(pwd)/%{bin:coqc} -coqlib $(pwd)/%{project_root}\" \\$@")
@@ -29,7 +29,7 @@
   %{lib:coq.kernel:../../stublibs/dllbyterun_stubs.so}
   %{project_root}/theories/Init/Prelude.vo)
  (action
-  (with-outputs-to %{targets}
+  (with-stdout-to %{targets}
    (progn
     (echo "#!/usr/bin/env bash\n")
     (bash "echo \"$(pwd)/%{bin:coqtop.byte} -coqlib $(pwd)/%{project_root}\" \\$@")
@@ -45,7 +45,7 @@
   %{project_root}/coqide-server.install
   %{project_root}/coqide.install)
  (action
-  (with-outputs-to coqide-prelude
+  (with-stdout-to coqide-prelude
    (progn
     (echo "#!/usr/bin/env bash\n")
     (bash "echo \"$(pwd)/%{bin:coqide} -coqlib $(pwd)/%{project_root}\" \\$@")

--- a/test-suite/misc/universes/dune
+++ b/test-suite/misc/universes/dune
@@ -1,8 +1,9 @@
 (rule
  (targets all_stdlib.v)
  (deps
+   build_all_stdlib.sh
    (source_tree ../../../theories)
    (source_tree ../../../plugins))
  (action
-   (with-outputs-to all_stdlib.v
+   (with-stdout-to all_stdlib.v
     (bash "./build_all_stdlib.sh"))))


### PR DESCRIPTION
The issue could be reproduced by doing "dune build
test-suite/misc/universes/all_stdlib.v" (from a clean build) which
would error 127 with no message.

- only redirect stdout so that in the future we will see error
  messages

- put the script as a dependency (I guess it sometime succeeded when
  copying the deps for the test suite happened before running it)
