### PR TITLE
8.10: Enable all addons for Windows build and enable Windows 32 build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -279,8 +279,6 @@ windows32:
   extends: .windows-template
   variables:
     ARCH: "32"
-  except:
-    - /^pr-.*$/
 
 lint:
   image: docker:git

--- a/dev/ci/gitlab.bat
+++ b/dev/ci/gitlab.bat
@@ -37,6 +37,9 @@ SET CI_PROJECT_DIR_CFMT=%CI_PROJECT_DIR_MFMT:C:/=/cygdrive/c/%
 SET COQREGTESTING=Y
 SET PATH=%PATH%;C:\Program Files\7-Zip\;C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin
 
+REM ENable all addons on release branch
+SET WINDOWS=enabled_all_addons
+
 IF "%WINDOWS%" == "enabled_all_addons" (
   SET EXTRA_ADDONS=^
     -addon=bignums ^


### PR DESCRIPTION
This PR enables all add-ons in the Windows build and also the 32 bit Windows build.

This PR should be merged after the pinning PR #10500 to ensure things continue to compile.

Note: on 8.9 this was done in a different way - the `dev/ci/gitlab.bat` file didn't check the WINDOWS variable there. I think this is more elegant - fewer changes and all in one file - although it might have the effect that completely switching of the Windows build now no longer works (not sure about the exact logic of the file `.gitlab-ci.yml` file). I guess this doesn't matter much since one anyway doesn't want to do this.