### PR TITLE
[library] Move library to vernac

### DIFF
--- a/library/coqlib.ml
+++ b/library/coqlib.ml
@@ -104,8 +104,10 @@ let gen_reference_in_modules locstr dirs s =
 
 let check_required_library d =
   let dir = make_dir d in
-  if Library.library_is_loaded dir then ()
-  else
+  try
+    let _ : Declarations.module_body = Global.lookup_module (ModPath.MPfile dir) in
+    ()
+  with Not_found ->
     let in_current_dir = match Lib.current_mp () with
       | MPfile dp -> DirPath.equal dir dp
       | _ -> false

--- a/library/library.mllib
+++ b/library/library.mllib
@@ -6,7 +6,6 @@ Nametab
 Global
 Lib
 Declaremods
-Library
 States
 Kindops
 Goptions

--- a/library/states.ml
+++ b/library/states.ml
@@ -9,7 +9,6 @@
 (************************************************************************)
 
 open Util
-open System
 
 type state = Lib.frozen * Summary.frozen
 
@@ -24,13 +23,6 @@ let freeze ~marshallable =
 let unfreeze (fl,fs) =
   Lib.unfreeze fl;
   Summary.unfreeze_summaries fs
-
-let extern_state s =
-  System.extern_state Coq_config.state_magic_number s (freeze ~marshallable:true)
-
-let intern_state s =
-  unfreeze (with_magic_number_check (System.intern_state Coq_config.state_magic_number) s);
-  Library.overwrite_library_filenames s
 
 (* Rollback. *)
 

--- a/library/states.mli
+++ b/library/states.mli
@@ -15,9 +15,6 @@
   freezing the states of both [Lib] and [Summary]. We provide functions
   to write and restore state to and from a given file. *)
 
-val intern_state : string -> unit
-val extern_state : string -> unit
-
 type state
 val freeze : marshallable:bool -> state
 val unfreeze : state -> unit

--- a/printing/prettyp.mli
+++ b/printing/prettyp.mli
@@ -18,22 +18,41 @@ open Libnames
 val assumptions_for_print : Name.t list -> Termops.names_context
 
 val print_closed_sections : bool ref
-val print_context : env -> Evd.evar_map -> bool -> int option -> Lib.library_segment -> Pp.t
-val print_library_entry : env -> Evd.evar_map -> bool -> (Libobject.object_name * Lib.node) -> Pp.t option
-val print_full_context : env -> Evd.evar_map -> Pp.t
-val print_full_context_typ : env -> Evd.evar_map -> Pp.t
-val print_full_pure_context : env -> Evd.evar_map -> Pp.t
-val print_sec_context : env -> Evd.evar_map -> qualid -> Pp.t
-val print_sec_context_typ : env -> Evd.evar_map -> qualid -> Pp.t
+val print_context
+  : Opaqueproof.indirect_accessor
+  -> env -> Evd.evar_map
+  -> bool -> int option -> Lib.library_segment -> Pp.t
+val print_library_entry
+  : Opaqueproof.indirect_accessor
+  -> env -> Evd.evar_map
+  -> bool -> (Libobject.object_name * Lib.node) -> Pp.t option
+val print_full_context
+ : Opaqueproof.indirect_accessor -> env -> Evd.evar_map -> Pp.t
+val print_full_context_typ
+  : Opaqueproof.indirect_accessor -> env -> Evd.evar_map -> Pp.t
+
+val print_full_pure_context
+  : library_accessor:Opaqueproof.indirect_accessor
+  -> env
+  -> Evd.evar_map
+  -> Pp.t
+
+val print_sec_context
+  : Opaqueproof.indirect_accessor -> env -> Evd.evar_map -> qualid -> Pp.t
+val print_sec_context_typ
+  : Opaqueproof.indirect_accessor -> env -> Evd.evar_map -> qualid -> Pp.t
 val print_judgment : env -> Evd.evar_map -> EConstr.unsafe_judgment -> Pp.t
 val print_safe_judgment : env -> Evd.evar_map -> Safe_typing.judgment -> Pp.t
 val print_eval :
   reduction_function -> env -> Evd.evar_map ->
     Constrexpr.constr_expr -> EConstr.unsafe_judgment -> Pp.t
 
-val print_name : env -> Evd.evar_map -> qualid Constrexpr.or_by_notation ->
-  UnivNames.univ_name_list option -> Pp.t
-val print_opaque_name : env -> Evd.evar_map -> qualid -> Pp.t
+val print_name
+  : Opaqueproof.indirect_accessor
+  -> env -> Evd.evar_map -> qualid Constrexpr.or_by_notation
+  -> UnivNames.univ_name_list option -> Pp.t
+val print_opaque_name
+  : Opaqueproof.indirect_accessor -> env -> Evd.evar_map -> qualid -> Pp.t
 val print_about : env -> Evd.evar_map -> qualid Constrexpr.or_by_notation ->
   UnivNames.univ_name_list option -> Pp.t
 val print_impargs : qualid Constrexpr.or_by_notation -> Pp.t
@@ -50,7 +69,7 @@ val print_typeclasses : unit -> Pp.t
 val print_instances : GlobRef.t -> Pp.t
 val print_all_instances : unit -> Pp.t
 
-val inspect : env -> Evd.evar_map -> int -> Pp.t
+val inspect : Opaqueproof.indirect_accessor -> env -> Evd.evar_map -> int -> Pp.t
 
 (** {5 Locate} *)
 
@@ -83,14 +102,14 @@ val print_located_other : string -> qualid -> Pp.t
 
 type object_pr = {
   print_inductive           : MutInd.t -> UnivNames.univ_name_list option -> Pp.t;
-  print_constant_with_infos : Constant.t -> UnivNames.univ_name_list option -> Pp.t;
+  print_constant_with_infos : Opaqueproof.indirect_accessor -> Constant.t -> UnivNames.univ_name_list option -> Pp.t;
   print_section_variable    : env -> Evd.evar_map -> variable -> Pp.t;
   print_syntactic_def       : env -> KerName.t -> Pp.t;
   print_module              : bool -> ModPath.t -> Pp.t;
   print_modtype             : ModPath.t -> Pp.t;
   print_named_decl          : env -> Evd.evar_map -> Constr.named_declaration -> Pp.t;
-  print_library_entry       : env -> Evd.evar_map -> bool -> (Libobject.object_name * Lib.node) -> Pp.t option;
-  print_context             : env -> Evd.evar_map -> bool -> int option -> Lib.library_segment -> Pp.t;
+  print_library_entry       : Opaqueproof.indirect_accessor -> env -> Evd.evar_map -> bool -> (Libobject.object_name * Lib.node) -> Pp.t option;
+  print_context             : Opaqueproof.indirect_accessor -> env -> Evd.evar_map -> bool -> int option -> Lib.library_segment -> Pp.t;
   print_typed_value_in_env  : Environ.env -> Evd.evar_map -> EConstr.constr * EConstr.types -> Pp.t;
   print_eval                : Reductionops.reduction_function -> env -> Evd.evar_map -> Constrexpr.constr_expr -> EConstr.unsafe_judgment -> Pp.t;
 }

--- a/toplevel/coqc.ml
+++ b/toplevel/coqc.ml
@@ -11,7 +11,7 @@
 let outputstate opts =
   Option.iter (fun ostate_file ->
     let fname = CUnix.make_suffix ostate_file ".coq" in
-    States.extern_state fname) opts.Coqcargs.outputstate
+    Library.extern_state fname) opts.Coqcargs.outputstate
 
 let coqc_init _copts ~opts =
   Flags.quiet := true;
@@ -53,7 +53,8 @@ let coqc_main copts ~opts =
 
   if opts.Coqargs.post.Coqargs.output_context then begin
     let sigma, env = let e = Global.env () in Evd.from_env e, e in
-    Feedback.msg_notice Pp.(Flags.(with_option raw_print (Prettyp.print_full_pure_context env) sigma) ++ fnl ())
+    let library_accessor = Library.indirect_accessor in
+    Feedback.msg_notice Pp.(Flags.(with_option raw_print (Prettyp.print_full_pure_context ~library_accessor env) sigma) ++ fnl ())
   end;
   CProfile.print_profile ()
 

--- a/toplevel/coqtop.ml
+++ b/toplevel/coqtop.ml
@@ -87,7 +87,7 @@ let set_options = List.iter set_option
 let inputstate opts =
   Option.iter (fun istate_file ->
     let fname = Loadpath.locate_file (CUnix.make_suffix istate_file ".coq") in
-    States.intern_state fname) opts.inputstate
+    Library.intern_state fname) opts.inputstate
 
 (******************************************************************************)
 (* Fatal Errors                                                               *)

--- a/vernac/library.ml
+++ b/vernac/library.ml
@@ -474,10 +474,10 @@ let require_library_from_dirpath ~lib_resolver modrefl export =
     if Lib.is_module_or_modtype () then
       begin
         warn_require_in_module ();
-	add_anonymous_leaf (in_require (needed,modrefl,None));
-	Option.iter (fun exp ->
-	  add_anonymous_leaf (in_import_library (modrefl,exp)))
-	  export
+        add_anonymous_leaf (in_require (needed,modrefl,None));
+        Option.iter (fun exp ->
+          add_anonymous_leaf (in_import_library (modrefl,exp)))
+          export
       end
     else
       add_anonymous_leaf (in_require (needed,modrefl,export));
@@ -547,7 +547,7 @@ let current_deps () =
 let current_reexports () = !libraries_exports_list
 
 let error_recursively_dependent_library dir =
-  user_err 
+  user_err
     (strbrk "Unable to use logical name " ++ DirPath.print dir ++
      strbrk " to save current library because" ++
      strbrk " it already depends on a library of this name.")
@@ -640,3 +640,12 @@ let get_used_load_paths () =
        StringSet.empty !libraries_loaded_list)
 
 let _ = Nativelib.get_load_paths := get_used_load_paths
+
+(* These commands may not be very safe due to ML-side plugin loading
+   etc... use at your own risk *)
+let extern_state s =
+  System.extern_state Coq_config.state_magic_number s (States.freeze ~marshallable:true)
+
+let intern_state s =
+  States.unfreeze (System.with_magic_number_check (System.intern_state Coq_config.state_magic_number) s);
+  overwrite_library_filenames s

--- a/vernac/library.mli
+++ b/vernac/library.mli
@@ -75,3 +75,7 @@ val native_name_from_filename : string -> string
 
 (** {6 Opaque accessors} *)
 val indirect_accessor : Opaqueproof.indirect_accessor
+
+(** Low-level state overwriting, not very safe *)
+val intern_state : string -> unit
+val extern_state : string -> unit

--- a/vernac/vernac.mllib
+++ b/vernac/vernac.mllib
@@ -16,6 +16,7 @@ DeclareDef
 DeclareObl
 Canonical
 RecLemmas
+Library
 Lemmas
 Class
 Auto_ind_decl

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1161,11 +1161,11 @@ let vernac_chdir = function
 
 let vernac_write_state file =
   let file = CUnix.make_suffix file ".coq" in
-  States.extern_state file
+  Library.extern_state file
 
 let vernac_restore_state file =
   let file = Loadpath.locate_file (CUnix.make_suffix file ".coq") in
-  States.intern_state file
+  Library.intern_state file
 
 (************)
 (* Commands *)
@@ -1954,9 +1954,9 @@ let vernac_print ~pstate ~atts =
   function
   | PrintTypingFlags -> pr_typing_flags (Environ.typing_flags (Global.env ()))
   | PrintTables -> print_tables ()
-  | PrintFullContext-> print_full_context_typ env sigma
-  | PrintSectionContext qid -> print_sec_context_typ env sigma qid
-  | PrintInspect n -> inspect env sigma n
+  | PrintFullContext-> print_full_context_typ Library.indirect_accessor env sigma
+  | PrintSectionContext qid -> print_sec_context_typ Library.indirect_accessor env sigma qid
+  | PrintInspect n -> inspect Library.indirect_accessor env sigma n
   | PrintGrammar ent -> Metasyntax.pr_grammar ent
   | PrintCustomGrammar ent -> Metasyntax.pr_custom_grammar ent
   | PrintLoadPath dir -> (* For compatibility ? *) print_loadpath dir
@@ -1969,7 +1969,7 @@ let vernac_print ~pstate ~atts =
   | PrintDebugGC -> Mltop.print_gc ()
   | PrintName (qid,udecl) ->
     dump_global qid;
-    print_name env sigma qid udecl
+    print_name Library.indirect_accessor env sigma qid udecl
   | PrintGraph -> Prettyp.print_graph ()
   | PrintClasses -> Prettyp.print_classes()
   | PrintTypeClasses -> Prettyp.print_typeclasses()


### PR DESCRIPTION
This is step 1 on removing library state from the lower layers.

Here we move library loading to the vernacular layer; few things
depend on it:

- printers: we add a parameter for those that need to access on-disk data,

- coqlib: indeed a few tactics do try to check that a particular
  library is loaded; this is a tricky part. I've replaced that for a
  module name check, but indeed this may not be fully equivalent due to
  side-effects of `Require`. We may want to think what to do here.

A few other minor code movements were needed, but there are
self-explanatory.
