### PR TITLE
Mark primitive integers as able to participate in reductions (fixes #10560).

### DIFF
--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -1075,7 +1075,7 @@ module FNativeEntries =
 
     let mkInt env i =
       check_int env;
-      { mark = mark Norm KnownR; term = FInt i }
+      { mark = mark Cstr KnownR; term = FInt i }
 
     let mkBool env b =
       check_bool env;

--- a/test-suite/bugs/closed/bug_10560.v
+++ b/test-suite/bugs/closed/bug_10560.v
@@ -1,0 +1,9 @@
+From Coq Require Import Int63.
+Open Scope int63_scope.
+
+Lemma foo :
+  let n := opp 0 in add n 0 = n.
+Proof.
+cbv.
+apply eq_refl.
+Qed.


### PR DESCRIPTION
The documentation states:
- Norm means the term is fully normalized and cannot create a redex when substituted
- Cstr means the term is in head normal form and that it can create a redex when substituted (i.e. constructor, fix, lambda)