### PR TITLE
Fix #7348: extraction of dependent record projections

### DIFF
--- a/doc/changelog/08-tools/10577-extraction-dependent-projections.rst
+++ b/doc/changelog/08-tools/10577-extraction-dependent-projections.rst
@@ -1,0 +1,9 @@
+- Fix a printing bug of OCaml extraction on dependent record projections, which
+  produced improper `assert false`. This change makes the OCaml extractor
+  internally inline record projections by default; thus the monolithic OCaml
+  extraction (:cmd:`Extraction` and :cmd:`Recursive Extraction`) does not
+  produce record projection constants anymore except for record projections
+  explicitly instructed to extract, and records declared in opaque modules
+  (`#10577 <https://github.com/coq/coq/pull/10577>`_,
+  fixes `#7348 <https://github.com/coq/coq/issues/7348>`_,
+  by Kazuhiko Sakaguchi).

--- a/plugins/extraction/extraction.ml
+++ b/plugins/extraction/extraction.ml
@@ -754,18 +754,6 @@ and extract_cst_app env sg mle mlt kn args =
   let la = List.length args in
   (* The ml arguments, already expunged from known logical ones *)
   let mla = make_mlargs env sg mle s args metas in
-  let mla =
-    if magic1 || lang () != Ocaml then mla
-    else
-      try
-        (* for better optimisations later, we discard dependent args
-           of projections and replace them by fake args that will be
-           removed during final pretty-print. *)
-        let l,l' = List.chop (projection_arity (GlobRef.ConstRef kn)) mla in
-	if not (List.is_empty l') then (List.map (fun _ -> MLexn "Proj Args") l) @ l'
-	else mla
-      with e when CErrors.noncritical e -> mla
-  in
   (* For strict languages, purely logical signatures lead to a dummy lam
      (except when [Kill Ktype] everywhere). So a [MLdummy] is left
      accordingly. *)

--- a/plugins/extraction/mlutil.ml
+++ b/plugins/extraction/mlutil.ml
@@ -1547,6 +1547,7 @@ let inline r t =
   not (to_keep r) (* The user DOES want to keep it *)
   && not (is_inline_custom r)
   && (to_inline r (* The user DOES want to inline it *)
-     || (lang () != Haskell && not (is_projection r) &&
-         (is_recursor r || manual_inline r || inline_test r t)))
+     || (lang () != Haskell &&
+         (is_projection r || is_recursor r ||
+          manual_inline r || inline_test r t)))
 

--- a/plugins/micromega/micromega.ml
+++ b/plugins/micromega/micromega.ml
@@ -1568,14 +1568,6 @@ module PositiveSet =
 
 type q = { qnum : z; qden : positive }
 
-(** val qnum : q -> z **)
-
-let qnum x = x.qnum
-
-(** val qden : q -> positive **)
-
-let qden x = x.qden
-
 (** val qeq_bool : q -> q -> bool **)
 
 let qeq_bool x y =

--- a/plugins/micromega/micromega.mli
+++ b/plugins/micromega/micromega.mli
@@ -446,10 +446,6 @@ module PositiveSet :
 
 type q = { qnum : z; qden : positive }
 
-val qnum : q -> z
-
-val qden : q -> positive
-
 val qeq_bool : q -> q -> bool
 
 val qle_bool : q -> q -> bool

--- a/test-suite/output/bug7348.out
+++ b/test-suite/output/bug7348.out
@@ -1,0 +1,45 @@
+Extracted code successfully compiled
+
+type __ = Obj.t
+
+type unit0 =
+| Tt
+
+type bool =
+| True
+| False
+
+module Case1 =
+ struct
+  type coq_rec = { f : bool }
+
+  (** val f : bool -> coq_rec -> bool **)
+
+  let f _ r =
+    r.f
+
+  (** val silly : bool -> coq_rec -> __ **)
+
+  let silly x b =
+    match x with
+    | True -> Obj.magic b.f
+    | False -> Obj.magic Tt
+ end
+
+module Case2 =
+ struct
+  type coq_rec = { f : (bool -> bool) }
+
+  (** val f : bool -> coq_rec -> bool -> bool **)
+
+  let f _ r =
+    r.f
+
+  (** val silly : bool -> coq_rec -> __ **)
+
+  let silly x b =
+    match x with
+    | True -> Obj.magic b.f False
+    | False -> Obj.magic Tt
+ end
+

--- a/test-suite/output/bug7348.v
+++ b/test-suite/output/bug7348.v
@@ -1,0 +1,25 @@
+Require Extraction.
+
+Extraction Language OCaml.
+Set Extraction KeepSingleton.
+
+Module Case1.
+
+Record rec (x : bool) := { f : bool }.
+
+Definition silly x (b : rec x) :=
+  if x return (if x then bool else unit) then f x b else tt.
+
+End Case1.
+
+Module Case2.
+
+Record rec (x : bool) := { f : bool -> bool }.
+
+Definition silly x (b : rec x) :=
+  if x return (if x then bool else unit) then f x b false else tt.
+
+End Case2.
+
+Extraction TestCompile Case1.silly Case2.silly.
+Recursive Extraction Case1.silly Case2.silly.


### PR DESCRIPTION
The OCaml extraction produces improper assertions `assert false (* Proj Args *)` for record projections involving `MLmagic` (`Obj.magic`) which are introduced here:
https://github.com/coq/coq/blob/c70412ec8b0bb34b7a5607c07d34607a147d834c/plugins/extraction/extraction.ml#L751-L762
As one can see in this comment, this kind of assertions should be removed during final pretty-printing and should not appear in the output. Currently, pretty-printing for record projections is implemented at the following three places: https://github.com/coq/coq/blob/9b7b34702f1134841f7f9408db27074b5479e07d/plugins/extraction/ocaml.ml#L579-L589 https://github.com/coq/coq/blob/9b7b34702f1134841f7f9408db27074b5479e07d/plugins/extraction/ocaml.ml#L317 https://github.com/coq/coq/blob/9b7b34702f1134841f7f9408db27074b5479e07d/plugins/extraction/ocaml.ml#L232-L236

The first one is pretty-printing for the definitions of record projections. The second one, `pp_record_proj` is pretty-printing for *inlined* record projections. The third one is pretty-printing for *non-inlined* record projections, which must erase those assertions; however, it doesn't erase. I think this issue was introduced by the following change which moves `MLmagic` around `MLapp`: https://github.com/coq/coq/commit/0c60735279301d22ac3e03f862f86997cb85bce0#diff-c99051d2f4403f00050d67d4ce4b9781R1039.

I have fixed this issue by
- inlining record projections by default (except Haskell extraction), and
- extending `pp_record_proj` for record projections involving `MLmagic`.

The special pretty-printing treatments for record projections other than `pp_record_proj` are eliminated and reduced to the above fixes. `micromega.ml` had to be changed due to this change of the extraction plugin.

CC: @maximedenes 

**Kind:** bug fix.

Fixes / closes #7348

- [x] Added / updated test-suite