### PR TITLE
Show clear warning for experimental features

### DIFF
--- a/doc/sphinx/addendum/extraction.rst
+++ b/doc/sphinx/addendum/extraction.rst
@@ -213,12 +213,16 @@ principles of extraction (logical parts and types).
 
 .. cmd:: Extraction Implicit @qualid [ {+ @ident } ]
 
-   This experimental command allows declaring some arguments of
-   :token:`qualid` as implicit, i.e. useless in extracted code and hence to
-   be removed by extraction. Here :token:`qualid` can be any function or
-   inductive constructor, and the given :token:`ident` are the names of
-   the concerned arguments. In fact, an argument can also be referred
-   by a number indicating its position, starting from 1.
+   .. warning::
+
+      The status of this command is experimental.
+
+   This command allows declaring some arguments of :token:`qualid` as
+   implicit, i.e. useless in extracted code and hence to be removed by
+   extraction. Here :token:`qualid` can be any function or inductive
+   constructor, and the given :token:`ident` are the names of the concerned
+   arguments. In fact, an argument can also be referred by a number
+   indicating its position, starting from 1.
 
 When an actual extraction takes place, an error is normally raised if the
 :cmd:`Extraction Implicit` declarations cannot be honored, that is

--- a/doc/sphinx/addendum/micromega.rst
+++ b/doc/sphinx/addendum/micromega.rst
@@ -194,10 +194,11 @@ a proof.
 .. tacn:: nra
    :name: nra
 
-   This tactic is an *experimental* proof procedure for non-linear
-   arithmetic. The tactic performs a limited amount of non-linear
-   reasoning before running the linear prover of :tacn:`lra`. This pre-processing
-   does the following:
+   The status of this tactic is experimental.
+
+   This tactic is a proof procedure for non-linear arithmetic. The tactic
+   performs a limited amount of non-linear reasoning before running the
+   linear prover of :tacn:`lra`. This pre-processing does the following:
 
 
 + If the context contains an arithmetic expression of the form

--- a/doc/sphinx/addendum/universe-polymorphism.rst
+++ b/doc/sphinx/addendum/universe-polymorphism.rst
@@ -279,6 +279,8 @@ Cumulativity Weak Constraints
 
 .. flag:: Cumulativity Weak Constraints
 
+   .. warning:: The status of this flag is experimental
+
    When set, which is the default, causes "weak" constraints to be produced
    when comparing universes in an irrelevant position. Processing weak
    constraints is delayed until minimization time. A weak constraint

--- a/doc/sphinx/language/gallina-extensions.rst
+++ b/doc/sphinx/language/gallina-extensions.rst
@@ -592,9 +592,11 @@ This example emphasizes what the printing options offer.
 Advanced recursive functions
 ----------------------------
 
-The following experimental command is available when the ``FunInd`` library has been loaded via ``Require Import FunInd``:
+The following command is available when the ``FunInd`` library has been loaded via ``Require Import FunInd``:
 
 .. cmd:: Function @ident {* @binder} { @decrease_annot } : @type := @term
+
+   .. warning:: The status of this command is experimental.
 
    This command can be seen as a generalization of ``Fixpoint``. It is actually a wrapper
    for several ways of defining a function *and other useful related

--- a/doc/sphinx/practical-tools/utilities.rst
+++ b/doc/sphinx/practical-tools/utilities.rst
@@ -472,6 +472,10 @@ Building a |Coq| project with Dune
    maintained upstream; please refer to the `Dune manual
    <https://dune.readthedocs.io/>`_ for up-to-date information.
 
+.. warning::
+
+   The status of this feature is experimental.
+
 Building a Coq project with Dune requires setting up a Dune project
 for your files. This involves adding a ``dune-project`` and
 ``pkg.opam`` file to the root (``pkg.opam`` can be empty), and then

--- a/doc/sphinx/proof-engine/ltac.rst
+++ b/doc/sphinx/proof-engine/ltac.rst
@@ -685,8 +685,7 @@ A tactic execution can be timed:
 Timing a tactic that evaluates to a term
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Tactic expressions that produce terms can be timed with the experimental
-tactic
+Tactic expressions that produce terms can be timed with the tactic
 
 .. tacn:: time_constr @ltac_expr
    :name: time_constr
@@ -694,6 +693,10 @@ tactic
    which evaluates :n:`@ltac_expr ()` and displays the time the tactic expression
    evaluated, assuming successful evaluation. Time is in seconds and is
    machine-dependent.
+
+   .. warning::
+
+      The status of this tactic is experimental.
 
    This tactic currently does not support nesting, and will report times
    based on the innermost execution. This is due to the fact that it is

--- a/doc/sphinx/proof-engine/ltac2.rst
+++ b/doc/sphinx/proof-engine/ltac2.rst
@@ -25,11 +25,16 @@ that features at least the following:
 - a typing system
 - standard programming facilities (i.e. datatypes)
 
-This new language, called Ltac2, is described in this chapter. It is still
-experimental but we encourage nonetheless users to start testing it,
-especially wherever an advanced tactic language is needed. The previous
-implementation of Ltac, described in the previous chapter, will be referred to
-as Ltac1.
+This new language, called Ltac2, is described in this chapter.
+
+.. warning::
+
+   The status of Ltac2 is still experimental but we encourage nonetheless
+   users to start testing it, especially wherever an advanced tactic language
+   is needed.
+
+The previous implementation of Ltac, described in the previous chapter, will
+be referred to as Ltac1.
 
 .. _ltac2_design:
 

--- a/doc/sphinx/proof-engine/tactics.rst
+++ b/doc/sphinx/proof-engine/tactics.rst
@@ -1992,17 +1992,20 @@ analysis on inductive or co-inductive objects (see :ref:`inductive-definitions`)
 .. tacn:: dependent induction @ident
    :name: dependent induction
 
-   The *experimental* tactic dependent induction performs induction-
-   inversion on an instantiated inductive predicate. One needs to first
-   require the Coq.Program.Equality module to use this tactic. The tactic
-   is based on the BasicElim tactic by Conor McBride
-   :cite:`DBLP:conf/types/McBride00` and the work of Cristina Cornes around
-   inversion :cite:`DBLP:conf/types/CornesT95`. From an instantiated
-   inductive predicate and a goal, it generates an equivalent goal where
-   the hypothesis has been generalized over its indexes which are then
-   constrained by equalities to be the right instances. This permits to
-   state lemmas without resorting to manually adding these equalities and
-   still get enough information in the proofs.
+   .. warning::
+
+      The status of this tactic is experimental.
+
+   This tactic performs induction-inversion on an instantiated inductive
+   predicate. One needs to first require the Coq.Program.Equality module to
+   use this tactic. The tactic is based on the BasicElim tactic by Conor
+   McBride :cite:`DBLP:conf/types/McBride00` and the work of Cristina Cornes
+   around inversion :cite:`DBLP:conf/types/CornesT95`. From an instantiated
+   inductive predicate and a goal, it generates an equivalent goal where the
+   hypothesis has been generalized over its indexes which are then
+   constrained by equalities to be the right instances. This permits to state
+   lemmas without resorting to manually adding these equalities and still get
+   enough information in the proofs.
 
 .. example::
 
@@ -4212,10 +4215,14 @@ some incompatibilities.
 .. tacn:: firstorder
    :name: firstorder
 
-   The tactic :tacn:`firstorder` is an experimental extension of :tacn:`tauto` to
-   first- order reasoning, written by Pierre Corbineau. It is not restricted to
-   usual logical connectives but instead may reason about any first-order class
-   inductive definition.
+   .. warning::
+
+      The status of this tactic is experimental.
+
+   The tactic :tacn:`firstorder` is an extension of :tacn:`tauto` to
+   first-order reasoning, written by Pierre Corbineau. It is not restricted
+   to usual logical connectives but instead may reason about any first-order
+   class inductive definition.
 
 .. opt:: Firstorder Solver @tactic
    :name: Firstorder Solver
@@ -4809,7 +4816,11 @@ Delaying solving unification constraints
 Proof maintenance
 -----------------
 
-*Experimental.*  Many tactics, such as :tacn:`intros`, can automatically generate names, such
+.. warning::
+
+   The status of this feature is experimental.
+
+Many tactics, such as :tacn:`intros`, can automatically generate names, such
 as "H0" or "H1" for a new hypothesis introduced from a goal.  Subsequent proof steps
 may explicitly refer to these names.  However, future versions of Coq may not assign
 names exactly the same way, which could cause the proof to fail because the

--- a/doc/sphinx/proof-engine/vernacular-commands.rst
+++ b/doc/sphinx/proof-engine/vernacular-commands.rst
@@ -986,13 +986,17 @@ Controlling display
 .. opt:: Warnings "{+, {? {| - | + } } @ident }"
    :name: Warnings
 
-   This option configures the display of warnings. It is experimental, and
-   expects, between quotes, a comma-separated list of warning names or
-   categories. Adding - in front of a warning or category disables it, adding +
-   makes it an error. It is possible to use the special categories all and
-   default, the latter containing the warnings enabled by default. The flags are
-   interpreted from left to right, so in case of an overlap, the flags on the
-   right have higher priority, meaning that `A,-A` is equivalent to `-A`.
+   .. warning::
+
+      The status of this option is experimental.
+
+   This option configures the display of warnings. It expects, between
+   quotes, a comma-separated list of warning names or categories. Adding - in
+   front of a warning or category disables it, adding + makes it an error. It
+   is possible to use the special categories all and default, the latter
+   containing the warnings enabled by default. The flags are interpreted from
+   left to right, so in case of an overlap, the flags on the right have
+   higher priority, meaning that `A,-A` is equivalent to `-A`.
 
 .. flag:: Search Output Name Only
 

--- a/doc/sphinx/user-extensions/proof-schemes.rst
+++ b/doc/sphinx/user-extensions/proof-schemes.rst
@@ -198,14 +198,17 @@ Generation of induction principles with ``Functional`` ``Scheme``
 
 .. cmd:: Functional Scheme @ident__0 := Induction for @ident' Sort @sort {* with @ident__i := Induction for @ident__i' Sort @sort}
 
-   This command is a high-level experimental tool for
-   generating automatically induction principles corresponding to
-   (possibly mutually recursive) functions. First, it must be made
-   available via ``Require Import FunInd``.
-   Each :n:`@ident__i` is a different mutually defined function
-   name (the names must be in the same order as when they were defined). This
-   command generates the induction principle for each :n:`@ident__i`, following
-   the recursive structure and case analyses of the corresponding function
+   .. warning::
+
+      The status of this command is experimental.
+
+   This command is a high-level tool for generating automatically induction
+   principles corresponding to (possibly mutually recursive) functions.
+   First, it must be made available via ``Require Import FunInd``. Each
+   :n:`@ident__i` is a different mutually defined function name (the names
+   must be in the same order as when they were defined). This command
+   generates the induction principle for each :n:`@ident__i`, following the
+   recursive structure and case analyses of the corresponding function
    :n:`@ident__i'`.
 
 .. warning::


### PR DESCRIPTION
I tried to make the way some features are marked as experimental more uniform in the manual.

Maybe this is also a good opportunity to ask what "experimental" means. Looking at what is considered experimental today, it's not easy to recognize a pattern.