### PR TITLE
[coqdoc] Simplify regex for identifiers in comments

### DIFF
--- a/tools/coqdoc/cpretty.mll
+++ b/tools/coqdoc/cpretty.mll
@@ -940,7 +940,7 @@ and escaped_coq = parse
       { (* likely to be a syntax error: we escape *) backtrack lexbuf }
   | eof
       { Tokens.flush_sublexer () }
-  | (identifier '.')* identifier
+  | identifier
       { Tokens.flush_sublexer();
         Output.ident (lexeme lexbuf) None;
         escaped_coq lexbuf }


### PR DESCRIPTION
**Kind:** performance / refactoring

`identifier` already matches dot-separated names.