### PR TITLE
[coqdoc] Nest <a> into <h2> instead of the other way around

### DIFF
--- a/tools/coqdoc/output.ml
+++ b/tools/coqdoc/output.ml
@@ -929,9 +929,9 @@ module Html = struct
  		stop_item ();
 		let ms = match sub with | None -> m | Some s -> m ^ ": " ^ s in
               if ln = "" then
- 	          printf "<a href=\"%s.html\"><h2>%s</h2></a>\n" m ms
+                  printf "<h2><a href=\"%s.html\">%s</a></h2>\n" m ms
               else
- 	          printf "<a href=\"%s.html\"><h2>%s %s</h2></a>\n" m ln ms
+                  printf "<h2><a href=\"%s.html\">%s %s</a></h2>\n" m ln ms
         | Toc_section (n, f, r) ->
   		item n;
   		printf "<a href=\"%s\">" r; f (); printf "</a>\n"


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

**Kind:** bug fix

`<h2>` can only be nested within `<a>` in HTML5 but coqdoc currently produces XHTML (which doesn't allow this), and it's really a weird thing to do in the first place.

<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [ ] Added / updated test-suite
<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [ ] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [ ] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
