### PR TITLE
coqdoc: Add a new `details' environment for coqdoc

### DIFF
--- a/doc/changelog/08-tools/10592-coqdoc-details.rst
+++ b/doc/changelog/08-tools/10592-coqdoc-details.rst
@@ -1,0 +1,5 @@
+- **Added:**
+  A new documentation environment ``details`` to make certain portion
+  of a Coq document foldable.  See :ref:`coqdoc`
+  (`#10592 <https://github.com/coq/coq/pull/10592>`_,
+  by Thomas Letan).

--- a/doc/sphinx/using/tools/coqdoc.rst
+++ b/doc/sphinx/using/tools/coqdoc.rst
@@ -248,6 +248,27 @@ shown using such comments:
 The latter cannot be used around some inner parts of a proof, but can
 be used around a whole proof.
 
+Lastly, it is possible to adopt a middle-ground approach when the
+desired output is HTML, where a given snippet of Coq material is
+hidden by default, but can be made visible with user interaction.
+
+::
+
+
+    (* begin details *)
+     *some Coq material*
+    (* end details *)
+
+
+There is also an alternative syntax available.
+
+::
+
+
+    (* begin details : Some summary describing the snippet *)
+     *some Coq material*
+    (* end details *)
+
 
 Usage
 ~~~~~

--- a/tools/coqdoc/output.ml
+++ b/tools/coqdoc/output.ml
@@ -469,6 +469,11 @@ module Latex = struct
 
   let stop_emph () = printf "}"
 
+  let start_details _ = ()
+
+  let stop_details () = ()
+
+
   let start_comment () = printf "\\begin{coqdoccomment}\n"
 
   let end_comment () = printf "\\end{coqdoccomment}\n"
@@ -739,6 +744,12 @@ module Html = struct
   let start_emph () = printf "<i>"
 
   let stop_emph () = printf "</i>"
+
+  let start_details = function
+    | Some s -> printf "<details><summary>%s</summary>" s
+    | _ -> printf "<details>"
+
+  let stop_details () = printf "</details>"
 
   let start_comment () = printf "<span class=\"comment\">(*"
 
@@ -1053,6 +1064,9 @@ module TeXmacs = struct
   let start_emph () = printf "<with|font shape|italic|"
   let stop_emph () = printf ">"
 
+  let start_details _ = ()
+  let stop_details () = ()
+
   let start_comment () = ()
   let end_comment () = ()
 
@@ -1158,6 +1172,9 @@ module Raw = struct
 
   let start_emph () = printf "_"
   let stop_emph () = printf "_"
+
+  let start_details _ = ()
+  let stop_details () = ()
 
   let start_comment () = printf "(*"
   let end_comment () = printf "*)"
@@ -1271,6 +1288,11 @@ let start_emph =
   select Latex.start_emph Html.start_emph TeXmacs.start_emph Raw.start_emph
 let stop_emph =
   select Latex.stop_emph Html.stop_emph TeXmacs.stop_emph Raw.stop_emph
+
+let start_details =
+  select Latex.start_details Html.start_details TeXmacs.start_details Raw.start_details
+let stop_details =
+  select Latex.stop_details Html.stop_details TeXmacs.stop_details Raw.stop_details
 
 let start_latex_math =
   select Latex.start_latex_math Html.start_latex_math TeXmacs.start_latex_math Raw.start_latex_math

--- a/tools/coqdoc/output.mli
+++ b/tools/coqdoc/output.mli
@@ -29,6 +29,9 @@ val start_module : unit -> unit
 val start_doc : unit -> unit
 val end_doc : unit -> unit
 
+val start_details : string option -> unit
+val stop_details : unit -> unit
+
 val start_emph : unit -> unit
 val stop_emph : unit -> unit
 


### PR DESCRIPTION
Dear Coq developers,

I open this PR not because the code is ready, but rather to gather feedback about a patch I have written for `coqdoc` this week-end.

The main idea is the following: in between `hide` and `show`, there are some code that I don’t want to see totally remove from my documentation, yet easy to skip. I believe the HTML `<details>` tag provides just that.

As a consequence, I have been doing a small experiment to update `coqdoc` to add this new “environment.”

For instance, here a screenshot of FreeSpec documentation, using the new environment; first folded…

![coqdoc output, with folded section](https://files.mastodon.social/media_attachments/files/017/066/093/original/e63b724f24a9e662.png)

… then unfolded.

![coqdoc output, with unfolded section](https://files.mastodon.social/media_attachments/files/017/066/109/original/df602dca37d7a595.png)

I need to work a bit on the CSS (I have a better looking example, with a custom `coqdoc.css`, but nothing just yet for the vanilla coqdoc.css).

The default syntax is as follows:

```coq
(* begin details *)

(** One can have documentation *)

Definition and_code_alike_here : unit := tt.

(* end details *)
```

It is also possible to provide a small summary of the folded code:

```coq
(* begin details : Auxiliary function *)
Fixpoint my_aux (l acc : list nat) : nat := (* ... *).
(* end details *)

Definition my (l : list nat) : nat := my_aux l nil.
```

There is not yet any support for *e.g.*, LaTeX (I consider the use of appendixes for this, but fear it will probably be harder to handle properly). This wouldn’t be the only coqdoc construction available only for one output in particular, and in the meantime it is treated as `show` afaik.

Before going any further, I am curious to know if this would have a chance to be merged or not.

Thanks!

---------------------

<!-- Keep what applies -->
**Kind:** feature

<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [x] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
