### PR TITLE
[CI/Azure/macOS] Unshallow the homebrew-core repository

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,7 +58,7 @@ jobs:
     displayName: 'Install system dependencies'
     env:
       HOMEBREW_NO_AUTO_UPDATE: "1"
-      HBCORE_DATE: "2019-06-18"
+      HBCORE_DATE: "2019-06-16"
       HBCORE_REF: "944a5b7d83e4b81c749d93831b514607bdd2b6a1"
 
   - script: |


### PR DESCRIPTION
Make the macOS job in Azure CI a bit more robust.

Fixes: #10544.