### PR TITLE
Rename local nonterminal names that are reused in other .mlg files

### DIFF
--- a/parsing/g_constr.mlg
+++ b/parsing/g_constr.mlg
@@ -450,7 +450,7 @@ GRAMMAR EXTEND Gram
 	{ (fun na -> CLocalAssum ([na],Default Implicit,c)) }
     ] ]
   ;
-  fixannot:
+  fixannot2:
     [ [ "{"; IDENT "struct"; id=identref; "}" -> { CAst.make ~loc @@ CStructRec id }
     | "{"; IDENT "wf"; rel=constr; id=identref; "}" -> { CAst.make ~loc @@ CWfRec(id,rel) }
     | "{"; IDENT "measure"; m=constr; id=OPT identref;
@@ -463,7 +463,7 @@ GRAMMAR EXTEND Gram
   binders_fixannot:
     [ [ na = impl_name_head; assum = impl_ident_tail; bl = binders_fixannot ->
           { (assum na :: fst bl), snd bl }
-      | f = fixannot -> { [], Some f }
+      | f = fixannot2 -> { [], Some f }
       | b = binder; bl = binders_fixannot -> { b @ fst bl, snd bl }
       | -> { [], None }
     ] ]

--- a/plugins/ltac/extraargs.mlg
+++ b/plugins/ltac/extraargs.mlg
@@ -66,9 +66,6 @@ let pr_orient _prc _prlc _prt = function
 }
 
 ARGUMENT EXTEND orient TYPED AS bool PRINTED BY { pr_orient }
-| [ "->" ] -> { true }
-| [ "<-" ] -> { false }
-| [ ] -> { true }
 END
 
 {

--- a/plugins/ltac/g_tactic.mlg
+++ b/plugins/ltac/g_tactic.mlg
@@ -224,7 +224,7 @@ open Pvernac.Vernac_
 
 GRAMMAR EXTEND Gram
   GLOBAL: simple_tactic constr_with_bindings quantified_hypothesis
-  bindings red_expr int_or_var open_constr uconstr
+  bindings red_expr int_or_var open_constr uconstr orient
   simple_intropattern in_clause clause_dft_concl hypident destruction_arg;
 
   int_or_var:

--- a/user-contrib/Ltac2/g_ltac2.mlg
+++ b/user-contrib/Ltac2/g_ltac2.mlg
@@ -626,7 +626,7 @@ GRAMMAR EXTEND Gram
   q_conversion:
     [ [ c = conversion -> { c } ] ]
   ;
-  orient:
+  orient2:
     [ [ "->" -> { CAst.make ~loc (Some true) }
       | "<-" -> { CAst.make ~loc (Some false) }
       | -> { CAst.make ~loc None }
@@ -648,7 +648,7 @@ GRAMMAR EXTEND Gram
       ] ]
   ;
   oriented_rewriter:
-    [ [ b = orient; r = rewriter ->
+    [ [ b = orient2; r = rewriter ->
       { let (m, c) = r in
         CAst.make ~loc @@ {
         rew_orient = b;

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -386,9 +386,9 @@ GRAMMAR EXTEND Gram
       | id = identref ; c = constructor_type; "|"; l = LIST0 constructor SEP "|" ->
 	  { Constructors ((c id)::l) }
       | id = identref ; c = constructor_type -> { Constructors [ c id ] }
-      | cstr = identref; "{"; fs = record_fields; "}" ->
+      | cstr = identref; "{"; fs = record_fields2; "}" ->
 	  { RecordDecl (Some cstr,fs) }
-      | "{";fs = record_fields; "}" -> { RecordDecl (None,fs) }
+      | "{";fs = record_fields2; "}" -> { RecordDecl (None,fs) }
       |  -> { Constructors [] } ] ]
   ;
 (*
@@ -404,19 +404,19 @@ GRAMMAR EXTEND Gram
   rec_definition:
     [ [ id_decl = ident_decl;
 	bl = binders_fixannot;
-        rtype = type_cstr;
+        rtype = type_cstr2;
         body_def = OPT [":="; def = lconstr -> { def } ]; notations = decl_notation ->
           { let binders, rec_order = bl in
             {fname = fst id_decl; univs = snd id_decl; rec_order; binders; rtype; body_def; notations}
           } ] ]
   ;
   corec_definition:
-    [ [ id_decl = ident_decl; binders = binders; rtype = type_cstr;
+    [ [ id_decl = ident_decl; binders = binders; rtype = type_cstr2;
         body_def = OPT [":="; def = lconstr -> { def }]; notations = decl_notation ->
         { {fname = fst id_decl; univs = snd id_decl; rec_order = (); binders; rtype; body_def; notations}
         } ]]
   ;
-  type_cstr:
+  type_cstr2:
     [ [ ":"; c=lconstr -> { c }
       | -> { CAst.make ~loc @@ CHole (None, IntroAnonymous, None) } ] ]
   ;
@@ -457,8 +457,8 @@ GRAMMAR EXTEND Gram
       let rf_subclass, rf_decl = bd in
       rf_decl, { rf_subclass ; rf_priority ; rf_notation ; rf_canonical } } ] ]
   ;
-  record_fields:
-    [ [ f = record_field; ";"; fs = record_fields -> { f :: fs }
+  record_fields2:
+    [ [ f = record_field; ";"; fs = record_fields2 -> { f :: fs }
       | f = record_field; ";" -> { [f] }
       | f = record_field -> { [f] }
       | -> { [] }
@@ -1103,11 +1103,11 @@ GRAMMAR EXTEND Gram
   positive_search_mark:
     [ [ "-" -> { false } | -> { true } ] ]
   ;
-  scope:
+  scope2:
     [ [ "%"; key = IDENT -> { key } ] ]
   ;
   searchabout_query:
-    [ [ b = positive_search_mark; s = ne_string; sc = OPT scope ->
+    [ [ b = positive_search_mark; s = ne_string; sc = OPT scope2 ->
             { (b, SearchString (s,sc)) }
       | b = positive_search_mark; p = constr_pattern ->
             { (b, SearchSubPattern p) }


### PR DESCRIPTION
There are a few local nonterminal names that are used in multiple .mlg files.  We want to have globally unique NT names in the documentation and the simplest way to do that is to rename them once in the .mlg files.  Probably less confusing for developers, too.

`orient` had identical definitions in 2 files.  I made the symbol global and removed the second one.  There is a third one in the ltac2 plugin, which I renamed.

`scope` had two identical definitions in one file.  I couldn't figure out how to combine them into one, so I renamed one of them.