### PR TITLE
Fix #10611, Change version of CompCert to v3.5+cherry picks

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,7 @@ stages:
 variables:
   # Format: $IMAGE-V$DATE [Cache is not used as of today but kept here
   # for reference]
-  CACHEKEY: "bionic_coq-v8.10-V2019-07-08-V1"
+  CACHEKEY: "bionic_coq-v8.10-V2019-06-24-V1"
   IMAGE: "$CI_REGISTRY_IMAGE:$CACHEKEY"
   # By default, jobs run in the base switch; override to select another switch
   OPAM_SWITCH: "base"

--- a/dev/build/windows/makecoq_mingw.sh
+++ b/dev/build/windows/makecoq_mingw.sh
@@ -1147,8 +1147,8 @@ function make_menhir {
   make_ocaml
   make_findlib
   make_ocamlbuild
-  # This is the version required by latest CompCert
-  if build_prep https://gitlab.inria.fr/fpottier/menhir/-/archive/20190626 menhir-20190626 tar.gz 1 ; then
+  # This is the version required by CompCert
+  if build_prep https://gitlab.inria.fr/fpottier/menhir/-/archive/20181113 menhir-20181113 tar.gz 1 ; then
     # Note: menhir doesn't support -j 8, so don't pass MAKE_OPT
     log2 make all PREFIX="$PREFIXOCAML"
     log2 make install PREFIX="$PREFIXOCAML"

--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -132,13 +132,11 @@
 ########################################################################
 # CompCert
 ########################################################################
-# CompCert tag v3.5 fails with:
-# compcert-v3.5-make_err.txt: File ".\flocq/Core/Fcore_Zaux.v", line 28, characters 18-21:
-# compcert-v3.5-make_err.txt: Error: The reference Zle was not found in the current environment.
-# Hash 415c5a5a28ac7035cfa33e5753af841a450bfab0 = "Fix compatibility with Coq 8.10 (#303)".
-# Hash 98858317be25deed815c7a8b5d4e9d6b512f5de5 = "Make configure resistant to Windows EOL and paths"
-: "${compcert_CI_REF:=98858317be25deed815c7a8b5d4e9d6b512f5de5}"
-: "${compcert_CI_GITURL:=https://github.com/AbsInt/CompCert}"
+# This is v3.5 patched up for compatibility with Coq 8.10.
+# See https://github.com/AbsInt/CompCert/pull/305
+# See https://github.com/coq/coq/issues/10611
+: "${compcert_CI_REF:=v3.5_coq_8.10}"
+: "${compcert_CI_GITURL:=https://github.com/MSoegtropIMC/CompCert}"
 : "${compcert_CI_ARCHIVEURL:=${compcert_CI_GITURL}/archive}"
 
 ########################################################################

--- a/dev/ci/docker/bionic_coq/Dockerfile
+++ b/dev/ci/docker/bionic_coq/Dockerfile
@@ -1,4 +1,4 @@
-# CACHEKEY: "bionic_coq-v8.10-V2019-07-08-V1"
+# CACHEKEY: "bionic_coq-v8.10-V2019-06-24-V1"
 # ^^ Update when modifying this file.
 
 FROM ubuntu:bionic
@@ -38,7 +38,7 @@ ENV COMPILER="4.05.0"
 # `num` does not have a version number as the right version to install varies
 # with the compiler version.
 ENV BASE_OPAM="num ocamlfind.1.8.0 dune.1.6.2 ounit.2.0.8 odoc.1.4.0" \
-    CI_OPAM="menhir.20190626 elpi.1.4.0 ocamlgraph.1.8.8"
+    CI_OPAM="menhir.20181113 elpi.1.4.0 ocamlgraph.1.8.8"
 
 # BASE switch; CI_OPAM contains Coq's CI dependencies.
 ENV COQIDE_OPAM="cairo2.0.6 lablgtk3-sourceview3.3.0.beta5"


### PR DESCRIPTION
This fixes issue #10611 

CompCert has been remapped to a fork because the cherry picked commits suggested by the CompCert Team are very large.

The branch has been created with (in a CompCert git clone):
```
git checkout v3.5 -b compcert_picking_810
git cherry-pick 0f919eb26c68d3882e612a1b3a9df45bee6d3624
git cherry-pick e9c136508ee6e51f26d280ac17370d724b05bf41
```
