### PR TITLE
map directory read error to empty directory

### DIFF
--- a/lib/system.ml
+++ b/lib/system.ml
@@ -53,8 +53,9 @@ module StrSet = Set.Make(StrMod)
 let dirmap = ref StrMap.empty
 
 let make_dir_table dir =
+  let entries = try Sys.readdir dir with Sys_error _ -> Array.of_list [] in
   let filter_dotfiles s f = if f.[0] = '.' then s else StrSet.add f s in
-  Array.fold_left filter_dotfiles StrSet.empty (Sys.readdir dir)
+  Array.fold_left filter_dotfiles StrSet.empty entries
 
 (** Don't trust in interactive mode (the default) *)
 let trust_file_cache = ref false


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
bug fix

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes #10629
