### PR TITLE
Ltac2: substitution in notations

### DIFF
--- a/doc/changelog/05-tactic-language/10633-ltac2+substitution-for-notations.rst
+++ b/doc/changelog/05-tactic-language/10633-ltac2+substitution-for-notations.rst
@@ -1,0 +1,4 @@
+- Implements substitution for notations using Ltac2 tactic-in-terms
+  (`#10633 <https://github.com/coq/coq/pull/10633>`_,
+  fixes `#10615 <https://github.com/coq/coq/issues/10615>`_,
+  by Vincent Laporte).

--- a/test-suite/ltac2/bug_10615.v
+++ b/test-suite/ltac2/bug_10615.v
@@ -1,0 +1,21 @@
+From Ltac2
+Require Import Ltac2.
+
+Notation "[ n ]" := ltac2:(Control.refine (fun n => constr:(n)))
+  (only parsing).
+
+Check (eq_refl : [ 0 ] = 0).
+Check (eq_refl : [ nat ] = nat).
+
+Notation "n .+2" := ltac2:(Control.refine (fun n => constr:(S (S n))))
+  (at level 20, only parsing).
+
+Definition four := Eval cbv in 2.+2.
+
+Check (eq_refl : four = 4).
+
+Notation ".< a | b .>" :=
+  ltac2:(Control.refine (fun a => open_constr:(a + _ + b)))
+  (only parsing).
+
+Check .< 1 | 2 .>.

--- a/user-contrib/Ltac2/ltac2_plugin.mlpack
+++ b/user-contrib/Ltac2/ltac2_plugin.mlpack
@@ -2,10 +2,10 @@ Tac2dyn
 Tac2ffi
 Tac2env
 Tac2print
-Tac2quote
 Tac2intern
 Tac2interp
 Tac2entries
+Tac2quote
 Tac2match
 Tac2core
 Tac2extffi

--- a/user-contrib/Ltac2/ltac2_plugin.mlpack
+++ b/user-contrib/Ltac2/ltac2_plugin.mlpack
@@ -2,10 +2,10 @@ Tac2dyn
 Tac2ffi
 Tac2env
 Tac2print
+Tac2quote
 Tac2intern
 Tac2interp
 Tac2entries
-Tac2quote
 Tac2match
 Tac2core
 Tac2extffi

--- a/user-contrib/Ltac2/tac2core.ml
+++ b/user-contrib/Ltac2/tac2core.ml
@@ -1031,16 +1031,23 @@ let interp_constr flags ist c =
     | Some () -> throw ~info e
   end
 
+let prepend_let_bindings subst c =
+  List.fold_left (fun c (n, v) ->
+      DAst.make @@ Glob_term.GLetIn (n, v, None, c)
+    ) c subst
+
 let () =
   let intern = intern_constr in
   let interp ist c = interp_constr (constr_flags ()) ist c in
   let print env c = str "constr:(" ++ Printer.pr_lglob_constr_env env c ++ str ")" in
   let subst subst c = Detyping.subst_glob_constr (Global.env()) subst c in
+  let ntn_subst subst c = prepend_let_bindings subst c in
   let obj = {
     ml_intern = intern;
     ml_subst = subst;
     ml_interp = interp;
     ml_print = print;
+    ml_ntn_subst = ntn_subst;
   } in
   define_ml_object Tac2quote.wit_constr obj
 
@@ -1049,11 +1056,13 @@ let () =
   let interp ist c = interp_constr (open_constr_no_classes_flags ()) ist c in
   let print env c = str "open_constr:(" ++ Printer.pr_lglob_constr_env env c ++ str ")" in
   let subst subst c = Detyping.subst_glob_constr (Global.env()) subst c in
+  let ntn_subst subst c = prepend_let_bindings subst c in
   let obj = {
     ml_intern = intern;
     ml_subst = subst;
     ml_interp = interp;
     ml_print = print;
+    ml_ntn_subst = ntn_subst;
   } in
   define_ml_object Tac2quote.wit_open_constr obj
 
@@ -1065,6 +1074,7 @@ let () =
     ml_interp = interp;
     ml_subst = (fun _ id -> id);
     ml_print = print;
+    ml_ntn_subst = (fun _ id -> id);
   } in
   define_ml_object Tac2quote.wit_ident obj
 
@@ -1083,11 +1093,13 @@ let () =
   in
   let print env pat = str "pattern:(" ++ Printer.pr_lconstr_pattern_env env Evd.empty pat ++ str ")" in
   let interp _ c = return (Value.of_pattern c) in
+  let ntn_subst _subst _c = assert false in
   let obj = {
     ml_intern = intern;
     ml_interp = interp;
     ml_subst = subst;
     ml_print = print;
+    ml_ntn_subst = ntn_subst;
   } in
   define_ml_object Tac2quote.wit_pattern obj
 
@@ -1114,6 +1126,7 @@ let () =
     ml_subst = subst;
     ml_interp = interp;
     ml_print = print;
+    ml_ntn_subst = (fun _ gr -> gr);
   } in
   define_ml_object Tac2quote.wit_reference obj
 
@@ -1160,11 +1173,13 @@ let () =
     in
     str "ltac1:(" ++ ids ++ Ltac_plugin.Pptactic.pr_glob_tactic env tac ++ str ")"
   in
+  let ntn_subst _subst _c = assert false in
   let obj = {
     ml_intern = intern;
     ml_subst = subst;
     ml_interp = interp;
     ml_print = print;
+    ml_ntn_subst = ntn_subst;
   } in
   define_ml_object Tac2quote.wit_ltac1 obj
 
@@ -1209,11 +1224,13 @@ let () =
     in
     str "ltac1val:(" ++ ids++ Ltac_plugin.Pptactic.pr_glob_tactic env tac ++ str ")"
   in
+  let ntn_subst _subst _c = assert false in
   let obj = {
     ml_intern = intern;
     ml_subst = subst;
     ml_interp = interp;
     ml_print = print;
+    ml_ntn_subst = ntn_subst;
   } in
   define_ml_object Tac2quote.wit_ltac1val obj
 

--- a/user-contrib/Ltac2/tac2core.ml
+++ b/user-contrib/Ltac2/tac2core.ml
@@ -1031,23 +1031,16 @@ let interp_constr flags ist c =
     | Some () -> throw ~info e
   end
 
-let prepend_let_bindings subst c =
-  List.fold_left (fun c (n, v) ->
-      DAst.make @@ Glob_term.GLetIn (n, v, None, c)
-    ) c subst
-
 let () =
   let intern = intern_constr in
   let interp ist c = interp_constr (constr_flags ()) ist c in
   let print env c = str "constr:(" ++ Printer.pr_lglob_constr_env env c ++ str ")" in
   let subst subst c = Detyping.subst_glob_constr (Global.env()) subst c in
-  let ntn_subst = prepend_let_bindings in
   let obj = {
     ml_intern = intern;
     ml_subst = subst;
     ml_interp = interp;
     ml_print = print;
-    ml_ntn_subst = ntn_subst
   } in
   define_ml_object Tac2quote.wit_constr obj
 
@@ -1056,26 +1049,22 @@ let () =
   let interp ist c = interp_constr (open_constr_no_classes_flags ()) ist c in
   let print env c = str "open_constr:(" ++ Printer.pr_lglob_constr_env env c ++ str ")" in
   let subst subst c = Detyping.subst_glob_constr (Global.env()) subst c in
-  let ntn_subst = prepend_let_bindings in
   let obj = {
     ml_intern = intern;
     ml_subst = subst;
     ml_interp = interp;
     ml_print = print;
-    ml_ntn_subst = ntn_subst
   } in
   define_ml_object Tac2quote.wit_open_constr obj
 
 let () =
   let interp _ id = return (Value.of_ident id) in
   let print _ id = str "ident:(" ++ Id.print id ++ str ")" in
-  let ntn_subst _ _ = assert false in
   let obj = {
     ml_intern = (fun _ _ id -> GlbVal id, gtypref t_ident);
     ml_interp = interp;
     ml_subst = (fun _ id -> id);
     ml_print = print;
-    ml_ntn_subst = ntn_subst
   } in
   define_ml_object Tac2quote.wit_ident obj
 
@@ -1094,13 +1083,11 @@ let () =
   in
   let print env pat = str "pattern:(" ++ Printer.pr_lconstr_pattern_env env Evd.empty pat ++ str ")" in
   let interp _ c = return (Value.of_pattern c) in
-  let ntn_subst _ _ = assert false in
   let obj = {
     ml_intern = intern;
     ml_interp = interp;
     ml_subst = subst;
     ml_print = print;
-    ml_ntn_subst = ntn_subst;
   } in
   define_ml_object Tac2quote.wit_pattern obj
 
@@ -1122,13 +1109,11 @@ let () =
   | GlobRef.VarRef id -> str "reference:(" ++ str "&" ++ Id.print id ++ str ")"
   | r -> str "reference:(" ++ Printer.pr_global r ++ str ")"
   in
-  let ntn_subst _ _ = assert false in
   let obj = {
     ml_intern = intern;
     ml_subst = subst;
     ml_interp = interp;
     ml_print = print;
-    ml_ntn_subst = ntn_subst;
   } in
   define_ml_object Tac2quote.wit_reference obj
 
@@ -1175,13 +1160,11 @@ let () =
     in
     str "ltac1:(" ++ ids ++ Ltac_plugin.Pptactic.pr_glob_tactic env tac ++ str ")"
   in
-  let ntn_subst _ _ = assert false in
   let obj = {
     ml_intern = intern;
     ml_subst = subst;
     ml_interp = interp;
     ml_print = print;
-    ml_ntn_subst = ntn_subst;
   } in
   define_ml_object Tac2quote.wit_ltac1 obj
 
@@ -1226,13 +1209,11 @@ let () =
     in
     str "ltac1val:(" ++ ids++ Ltac_plugin.Pptactic.pr_glob_tactic env tac ++ str ")"
   in
-  let ntn_subst _ _ = assert false in
   let obj = {
     ml_intern = intern;
     ml_subst = subst;
     ml_interp = interp;
     ml_print = print;
-    ml_ntn_subst = ntn_subst;
   } in
   define_ml_object Tac2quote.wit_ltac1val obj
 

--- a/user-contrib/Ltac2/tac2env.ml
+++ b/user-contrib/Ltac2/tac2env.ml
@@ -249,6 +249,7 @@ type ('a, 'b) ml_object = {
   ml_subst : Mod_subst.substitution -> 'b -> 'b;
   ml_interp : environment -> 'b -> valexpr Proofview.tactic;
   ml_print : Environ.env -> 'b -> Pp.t;
+  ml_ntn_subst: (Name.t * Glob_term.glob_constr) list -> 'b -> 'b;
 }
 
 module MLTypeObj =

--- a/user-contrib/Ltac2/tac2env.ml
+++ b/user-contrib/Ltac2/tac2env.ml
@@ -249,7 +249,6 @@ type ('a, 'b) ml_object = {
   ml_subst : Mod_subst.substitution -> 'b -> 'b;
   ml_interp : environment -> 'b -> valexpr Proofview.tactic;
   ml_print : Environ.env -> 'b -> Pp.t;
-  ml_ntn_subst: (Name.t * Glob_term.glob_constr) list -> 'b -> 'b;
 }
 
 module MLTypeObj =

--- a/user-contrib/Ltac2/tac2env.mli
+++ b/user-contrib/Ltac2/tac2env.mli
@@ -122,7 +122,6 @@ type ('a, 'b) ml_object = {
   ml_subst : Mod_subst.substitution -> 'b -> 'b;
   ml_interp : environment -> 'b -> valexpr Proofview.tactic;
   ml_print : Environ.env -> 'b -> Pp.t;
-  ml_ntn_subst: (Name.t * Glob_term.glob_constr) list -> 'b -> 'b;
 }
 
 val define_ml_object : ('a, 'b) Tac2dyn.Arg.tag -> ('a, 'b) ml_object -> unit

--- a/user-contrib/Ltac2/tac2env.mli
+++ b/user-contrib/Ltac2/tac2env.mli
@@ -122,6 +122,7 @@ type ('a, 'b) ml_object = {
   ml_subst : Mod_subst.substitution -> 'b -> 'b;
   ml_interp : environment -> 'b -> valexpr Proofview.tactic;
   ml_print : Environ.env -> 'b -> Pp.t;
+  ml_ntn_subst: (Name.t * Glob_term.glob_constr) list -> 'b -> 'b;
 }
 
 val define_ml_object : ('a, 'b) Tac2dyn.Arg.tag -> ('a, 'b) ml_object -> unit

--- a/user-contrib/Ltac2/tac2intern.ml
+++ b/user-contrib/Ltac2/tac2intern.ml
@@ -1523,10 +1523,25 @@ let () =
 let () = Genintern.register_subst0 wit_ltac2 subst_expr
 
 (* Used for tactic-in-term in notations *)
+let prepend_let_bindings subst c =
+  List.fold_left (fun c (n, v) ->
+      DAst.make @@ Glob_term.GLetIn (n, v, None, c)
+    ) c subst
+
+let subst_tacext : type u a . ((Name.t * Glob_term.glob_constr) list lazy_t) -> (u, a) Tac2dyn.Arg.tag -> a -> a =
+  fun subst tag arg ->
+  match Tac2dyn.Arg.eq tag Tac2quote.wit_constr with
+  | Some Refl -> prepend_let_bindings (Lazy.force subst) arg
+  | None ->
+  match Tac2dyn.Arg.eq tag Tac2quote.wit_open_constr with
+  | Some Refl -> prepend_let_bindings (Lazy.force subst) arg
+  | None ->
+    arg
+
 let subst_tacexpr (bindings: Genintern.glob_constr_and_expr Id.Map.t) (e: glb_tacexpr) : glb_tacexpr =
-  let substitution = Lazy.from_fun (fun () ->
-      Id.Map.fold (fun id (c,  _) accu -> (Name.Name id, c) :: accu)
-        bindings [])
+  let substitution = lazy (
+    Id.Map.fold (fun id (c,  _) accu -> (Name.Name id, c) :: accu)
+      bindings [])
   in
   let rec subst e =
   match e with
@@ -1576,8 +1591,7 @@ let subst_tacexpr (bindings: Genintern.glob_constr_and_expr Id.Map.t) (e: glb_ta
     if m' == m && d' == d && br' == br then e
     else GTacWth { opn_match = m' ; opn_branch = br' ; opn_default = d' }
   | GTacExt (tag, arg) ->
-    let tpe = interp_ml_object tag in
-    let arg' = tpe.ml_ntn_subst (Lazy.force substitution) arg in
+    let arg' = subst_tacext substitution tag arg in
     if arg' == arg then e else GTacExt (tag, arg')
   | GTacPrm (n, el) ->
     let el' = List.Smart.map subst el in


### PR DESCRIPTION
This implements substitution for notations using ltac2 tactic-in-terms. Substitution only occurs within `constr:` and `open_constr:` antiquotiations; in particular it cannot occur in plain Ltac2 code so substitution under (Ltac2) bindings is safe.

Substitution itself is not implemented here: we only insert let-bindings.

Suggestions welcome on what to do about the few “assert false”.

Fixes #10615 

- [x] Added / updated test-suite
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).

cc/ @ppedrot