### PR TITLE
Fix regression of #10637 (-emacs arg should set color to `EMACS)

### DIFF
--- a/test-suite/output/Emacs_and_diffs.v
+++ b/test-suite/output/Emacs_and_diffs.v
@@ -1,0 +1,3 @@
+(* coq-prog-args: ("-emacs") *)
+Set Diffs "on".
+(* verify this does not produce an error message *)

--- a/toplevel/coqargs.ml
+++ b/toplevel/coqargs.ml
@@ -184,7 +184,7 @@ let add_load_vernacular opts verb s =
 (** Options for proof general *)
 let set_emacs opts =
   Printer.enable_goal_tags_printing := true;
-  { opts with config = { opts.config with color = `OFF; print_emacs = true }}
+  { opts with config = { opts.config with color = `EMACS; print_emacs = true }}
 
 let set_logic f oval =
   { oval with config = { oval.config with logic = f oval.config.logic }}


### PR DESCRIPTION
Fixes / closes #10637
