### PR TITLE
[dumpglob] API simplification.

### DIFF
--- a/interp/dumpglob.mli
+++ b/interp/dumpglob.mli
@@ -8,19 +8,16 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-val start_dump_glob : vfile:string -> vofile:string -> unit
-val end_dump_glob : unit -> unit
-
-val dump : unit -> bool
-
 type glob_output =
-  | NoGlob
   | Feedback
-  | MultFiles                   (* one glob file per .v file *)
-  | File of string              (* Single file for all coqc arguments *)
+  | File of string
 
-(* Default "NoGlob" *)
-val set_glob_output : glob_output -> unit
+val start_dump_glob
+  :  v_file:CUnix.physical_path
+  -> output:glob_output
+  -> ldir:Names.DirPath.t -> unit
+
+val end_dump_glob : unit -> unit
 
 val pause : unit -> unit
 val continue : unit -> unit
@@ -42,8 +39,6 @@ val dump_notation :
   Notation_term.scope_name option -> bool -> unit
 
 val dump_constraint : Names.lname -> bool -> string -> unit
-
-val dump_string : string -> unit
 
 val type_of_global_ref : Names.GlobRef.t -> string
 

--- a/toplevel/coqcargs.ml
+++ b/toplevel/coqcargs.ml
@@ -24,7 +24,8 @@ type t =
   ; echo : bool
 
   ; outputstate : string option
-  ; glob_out    : Dumpglob.glob_output
+  ; glob_out    : Dumpglob.glob_output option option
+  (** None = No output ; Some None = Default output ; Some (Some file) *)
   }
 
 let default =
@@ -41,7 +42,7 @@ let default =
   ; echo = false
 
   ; outputstate = None
-  ; glob_out = Dumpglob.MultFiles
+  ; glob_out = Some None
   }
 
 let depr opt =
@@ -206,11 +207,11 @@ let parse arglist : t =
 
         (* Glob options *)
         |"-no-glob" | "-noglob" ->
-          { oval with glob_out = Dumpglob.NoGlob }
+          { oval with glob_out = None }
 
         |"-dump-glob" ->
           let file = next () in
-          { oval with glob_out = Dumpglob.File file }
+          { oval with glob_out = Some (Some (Dumpglob.File file)) }
 
         (* Rest *)
         | s ->

--- a/toplevel/coqcargs.mli
+++ b/toplevel/coqcargs.mli
@@ -38,7 +38,8 @@ type t =
   ; echo : bool
 
   ; outputstate : string option
-  ; glob_out    : Dumpglob.glob_output
+  ; glob_out    : Dumpglob.glob_output option option
+  (** None = No output ; Some None = Default output ; Some (Some file) *)
   }
 
 val default : t

--- a/vernac/comPrimitive.ml
+++ b/vernac/comPrimitive.ml
@@ -11,7 +11,7 @@
 let do_primitive id prim typopt =
   if Global.sections_are_opened () then
     CErrors.user_err Pp.(str "Declaring a primitive is not allowed in sections.");
-  if Dumpglob.dump () then Dumpglob.dump_definition id false "ax";
+  Dumpglob.dump_definition id false "ax";
   let env = Global.env () in
   let evd = Evd.from_env env in
   let evd, typopt = Option.fold_left_map


### PR DESCRIPTION
We simplify and cleanup dumpglob API to try to enforce better
bracketing. In particular:

- we manage the dumping state internally, glob dumping must be enabled
  with the right parameter first.
- it is not necessary to guard against `Dumpglob.dump ()` anymore

No user-visible change thus no changelog.
