### PR TITLE
[extraction] Fix #7191: Avoid unsound eta-reduction

### DIFF
--- a/plugins/extraction/mlutil.ml
+++ b/plugins/extraction/mlutil.ml
@@ -779,7 +779,7 @@ let eta_red e =
 	else e
     | _ -> e
 
-(* Performs an eta-reduction when the core is atomic,
+(* Performs an eta-reduction when the core is atomic and value,
    or otherwise returns None *)
 
 let atomic_eta_red e =
@@ -789,7 +789,7 @@ let atomic_eta_red e =
   | MLapp (f,a) when test_eta_args_lift 0 n a ->
      (match f with
       | MLrel k when k>n -> Some (MLrel (k-n))
-      | MLglob _ | MLexn _ | MLdummy _ -> Some f
+      | MLglob _ | MLdummy _ -> Some f
       | _ -> None)
   | _ -> None
 

--- a/test-suite/output/bug7191.out
+++ b/test-suite/output/bug7191.out
@@ -1,0 +1,9 @@
+
+type unit0 =
+| Tt
+
+(** val f : unit0 -> unit0 **)
+
+let f _ =
+  assert false (* absurd case *)
+

--- a/test-suite/output/bug7191.v
+++ b/test-suite/output/bug7191.v
@@ -1,0 +1,3 @@
+Require Extraction.
+Definition f (x : False) : unit -> unit := match x with end.
+Recursive Extraction f.


### PR DESCRIPTION
`Mlutil.simpl` and `Mlutil.atomic_eta_red` did some unsound eta-reductions as follows:
```
(fun x0 ... xn => MLexn x0 ... xn)  ->eta  MLexn.
```
https://github.com/coq/coq/blob/b8477fb38842016c226ba9d7be8f60486411a2ee/plugins/extraction/mlutil.ml#L782-L794 https://github.com/coq/coq/blob/b8477fb38842016c226ba9d7be8f60486411a2ee/plugins/extraction/mlutil.ml#L1080-L1083

In OCaml extraction, `MLexn` is translated to `assert false`, raises an exception, and thus is not a value. So the above simplification may change the behavior of extracted programs. This problem was introduced by #1124 as an ad-hoc fix for #4852. This patch restricts `atomic_eta_red` to eta-redexes whose core is both atomic and value.

**Kind:** bug fix.

Fixes / closes #7191

- [x] Added / updated test-suite