### PR TITLE
ocaml 4.08 does not allow dynamic loading of already present pr_dump.cmo

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -262,7 +262,7 @@ endef
 CAMLP5DEPS:=grammar/grammar.cma
 CAMLP5USE=pa_extend.cmo q_MLast.cmo pa_macro.cmo -D$(CAMLVERSION)
 
-PR_O := $(if $(READABLE_ML4),pr_o.cmo,pr_dump.cmo)
+PR_O := $(if $(READABLE_ML4),pr_o.cmo,)
 
 # Main packages linked by Coq.
 SYSMOD:=-package num,str,unix,dynlink,threads


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:**  bug fix


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #10403

The suspected cause is a change of behavior in ocaml 4.08, which causes failure when one tries to dynamically load an already present module.
Here the problem is that one cannot load `pr_dump.cmo` in `camlp5o`, because it is already included.

This fix would need to be propagated to all packagers, either as a patch or a new release.


<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
