### PR TITLE
New lemmas for List.v

### DIFF
--- a/doc/changelog/10-standard-library/10651-new-lemmas-for-lists.rst
+++ b/doc/changelog/10-standard-library/10651-new-lemmas-for-lists.rst
@@ -1,0 +1,4 @@
+- New lemmas on combine, filter, and nodup functions on lists. The lemma
+  filter_app was moved to the List module.
+
+  See `#10651 <https://github.com/coq/coq/pull/10651>`_, by Oliver Nash.

--- a/doc/changelog/10-standard-library/10651-new-lemmas-for-lists.rst
+++ b/doc/changelog/10-standard-library/10651-new-lemmas-for-lists.rst
@@ -1,4 +1,4 @@
-- New lemmas on combine, filter, and nodup functions on lists. The lemma
-  filter_app was moved to the List module.
+- New lemmas on :g:`combine`, :g:`filter`, and :g:`nodup` functions on lists. The lemma
+  :g:`filter_app` was moved to the :g:`List` module.
 
   See `#10651 <https://github.com/coq/coq/pull/10651>`_, by Oliver Nash.

--- a/theories/MSets/MSetRBT.v
+++ b/theories/MSets/MSetRBT.v
@@ -1049,12 +1049,8 @@ Qed.
 
 (** ** Filter *)
 
-Lemma filter_app A f (l l':list A) :
- List.filter f (l ++ l') = List.filter f l ++ List.filter f l'.
-Proof.
- induction l as [|x l IH]; simpl; trivial.
- destruct (f x); simpl; now rewrite IH.
-Qed.
+#[deprecated(since="8.11",note="Lemma filter_app has been moved to module List.")]
+Notation filter_app := List.filter_app.
 
 Lemma filter_aux_elements s f acc :
  filter_aux f s acc = List.filter f (elements s) ++ acc.
@@ -1062,7 +1058,7 @@ Proof.
  revert acc.
  induction s as [|c l IHl x r IHr]; trivial.
  intros acc.
- rewrite elements_node, filter_app. simpl.
+ rewrite elements_node, List.filter_app. simpl.
  destruct (f x); now rewrite IHl, IHr, app_ass.
 Qed.
 


### PR DESCRIPTION
 * filter_app (moved from MSets/MSetRBT.v)
 * filter_map
 * filter_ext_in
 * ext_in_filter
 * filter_ext_in_iff
 * filter_ext
 * concat_filter_map
 * combine_nil
 * combine_firstn_l
 * combine_firstn_r
 * combine_firstn
 * nodup_fixed_point

**Kind:** feature

- [x] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).

Please note that I am essentially a first-time contributor, and as such do not have much insight into what changes are desirable / helpful / worth it. My intention is merely to fill in a few gaps I bumped into while using the standard library; I will not be at all offended if the maintainers feel the best thing would just be for me to close this pull request.