### PR TITLE
Generate parsing statistics

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -75,6 +75,7 @@ before_script:
       - config/coq_config.py
       - config/coq_config.ml
       - test-suite/misc/universes/all_stdlib.v
+      - "*.stats"
     expire_in: 1 week
   script:
     - set -e
@@ -88,6 +89,8 @@ before_script:
     - echo 'end:coq.config'
 
     - echo 'start:coq.build'
+    # uncomment next line to get statistics
+    # - export COQ_STATS_DIR=$PWD
     - make -j "$NJOBS" byte
     - make -j "$NJOBS" world $EXTRA_TARGET
     - make test-suite/misc/universes/all_stdlib.v
@@ -100,6 +103,8 @@ before_script:
     - echo 'end:coq.install'
 
     - set +e
+  after_script:
+    - if [ `ls *.stats|wc -l` = 1 ]; then mv *.stats $CI_JOB_NAME.stats; fi
 
 # Template for building Coq + stdlib, typical use: overload the switch
 .dune-template:
@@ -240,8 +245,15 @@ before_script:
     - set +e
   needs:
     - build:base
+  after_script:
+    - if [ `ls *.stats|wc -l` = 1 ]; then mv *.stats $CI_JOB_NAME.stats; fi
   dependencies:
     - build:base
+  artifacts:
+    name: "$CI_JOB_NAME"
+    paths:
+      - "*.stats"
+    expire_in: 2 days
 
 .ci-template-flambda:
   extends: .ci-template

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -90,7 +90,7 @@ before_script:
 
     - echo 'start:coq.build'
     # uncomment next line to get statistics
-    # - export COQ_STATS_DIR=$PWD
+    - export COQ_STATS_DIR=$PWD
     - make -j "$NJOBS" byte
     - make -j "$NJOBS" world $EXTRA_TARGET
     - make test-suite/misc/universes/all_stdlib.v

--- a/Makefile.common
+++ b/Makefile.common
@@ -23,6 +23,7 @@ COQTOPBYTE:=bin/coqtop.byte$(EXE)
 COQDEP:=bin/coqdep$(EXE)
 COQPP:=bin/coqpp$(EXE)
 DOC_GRAM:=bin/doc_grammar$(EXE)
+PRINT_STATS:=bin/print_stats$(EXE)
 COQDEPBYTE:=bin/coqdep.byte$(EXE)
 COQMAKEFILE:=bin/coq_makefile$(EXE)
 COQMAKEFILEBYTE:=bin/coq_makefile.byte$(EXE)
@@ -57,7 +58,7 @@ FAKEIDE:=bin/fake_ide$(EXE)
 FAKEIDEBYTE:=bin/fake_ide.byte$(EXE)
 
 # These don't get signed on OSX, and don't need to be separately listed for cleaning
-PRIVATEBINARIES:=$(FAKEIDE) $(OCAMLLIBDEP) $(COQDEPBOOT) $(DOC_GRAM)
+PRIVATEBINARIES:=$(FAKEIDE) $(OCAMLLIBDEP) $(COQDEPBOOT) $(DOC_GRAM) $(PRINT_STATS)
 
 CSDPCERT:=plugins/micromega/csdpcert$(EXE)
 CSDPCERTBYTE:=plugins/micromega/csdpcert.byte$(EXE)

--- a/Makefile.doc
+++ b/Makefile.doc
@@ -264,6 +264,10 @@ doc/tools/docgram/orderedGrammar doc/tools/docgram/updated_rsts: doc/tools/docgr
 
 doc/tools/docgram/updated_rsts: doc/tools/docgram/orderedGrammar
 
+$(PRINT_STATS): clib/stats.cmo tools/print_stats.ml
+	$(SHOW)'OCAMLC -a $@'
+	$(HIDE)$(OCAMLC) -g -I clib -package str $^ -linkall -linkpkg -o $@
+
 .PHONY: doc_gram doc_gram_verify doc_gram_rsts
 
 doc_gram: doc/tools/docgram/fullGrammar

--- a/Makefile.make
+++ b/Makefile.make
@@ -234,6 +234,7 @@ indepclean:
 	rm -f glob.dump
 	rm -f config/revision.ml revision
 	rm -f plugins/micromega/.micromega.ml.generated
+	rm -f $(DOCGRAM) $(PRINT_STATS)
 	$(MAKE) -C test-suite clean
 
 docclean:

--- a/clib/clib.mllib
+++ b/clib/clib.mllib
@@ -37,3 +37,4 @@ Terminal
 Monad
 
 Diff2
+Stats

--- a/clib/stats.ml
+++ b/clib/stats.ml
@@ -1,0 +1,169 @@
+(** Gather and combine statistics across coqc runs
+
+See description in dev/doc/statistics.md *)
+
+let stats_enabled = ref false
+let stats_dir = ref ""
+let infiles = ref []
+
+
+(*** statistics gathering callbacks and data structures ***)
+(* modify this section to handle new statistics *)
+
+(* production id *)
+type pid = {
+  file : string;
+  char : int;
+}
+
+let pid_compare pid1 pid2 =
+  let scmp = String.compare pid1.file pid2.file in
+  if scmp <> 0 then scmp else compare pid1.char pid2.char
+
+module PidOrd = struct type t = pid let compare = pid_compare end
+module ProdMap = Map.Make(PidOrd)
+module StringMap = Map.Make(String)
+
+let prod_cnt_map = ref ProdMap.empty (* counters *)
+
+let add_prod_count key n map =
+  let count = try ProdMap.find key map with Not_found -> 0 in
+  ProdMap.add key (count+n) map
+
+(* callback for parser actions in GRAMMAR EXTEND *)
+let parser_action file char =
+  if !stats_enabled then
+    prod_cnt_map := add_prod_count { file; char } 1 !prod_cnt_map
+
+type extid = {
+  plugin : string;
+  etype : string;  (* use defined const *)
+  ename : string;
+  num : int;
+}
+
+let extid_compare extid1 extid2 =
+  let scmp = String.compare extid1.plugin extid2.plugin in
+  if scmp <> 0 then scmp else begin
+    let scmp = String.compare extid1.etype extid2.etype in
+    if scmp <> 0 then scmp else begin
+      let scmp = String.compare extid1.ename extid2.ename in
+      if scmp <> 0 then scmp else compare extid1.num extid2.num
+    end
+  end
+
+module ExtOrd = struct type t = extid let compare = extid_compare end
+module ExtMap = Map.Make(ExtOrd)
+
+let ext_cnt_map = ref ExtMap.empty
+
+let add_ext_count key n map =
+  let count = try ExtMap.find key map with Not_found -> 0 in
+  ExtMap.add key (count+n) map
+
+(* callback for parser actions in GRAMMAR EXTEND *)
+let parser_ext plugin etype ename num =
+  if !stats_enabled then
+    ext_cnt_map := add_ext_count { plugin; etype; ename; num } 1 !ext_cnt_map
+
+
+type stats = {
+  prod_cnt_map : int ProdMap.t;
+  ext_cnt_map : int ExtMap.t;
+}
+
+let marshal outch =
+  Marshal.to_channel outch { prod_cnt_map = (!prod_cnt_map); ext_cnt_map = (!ext_cnt_map) } []
+
+let unmarshal inch =
+  (Marshal.from_channel inch : stats)
+
+let read_parser_stats_file file =
+  let inch = open_in_bin file in
+  let stats = unmarshal inch in
+  close_in inch;
+  stats
+
+let combine_parser_stats_file file =
+  let stats = read_parser_stats_file file in
+  prod_cnt_map := ProdMap.fold (fun key c cnt_map -> add_prod_count key c cnt_map)
+    stats.prod_cnt_map !prod_cnt_map;
+  ext_cnt_map := ExtMap.fold (fun key c cnt_map -> add_ext_count key c cnt_map)
+    stats.ext_cnt_map !ext_cnt_map
+
+(* main routine for "print_stats" command for printing results after the run *)
+let print_stats ()  =
+  Printexc.record_backtrace true;
+  let print_zeros = true in
+  let dir s = "doc/tools/docgram/" ^ s in  (* todo: should share path with doc_grammar.ml *)
+  let inch = open_in_bin (dir "prodmap") in
+  let prod_map = (Marshal.from_channel inch : string ProdMap.t) in
+  let ext_map = (Marshal.from_channel inch : pid ExtMap.t) in
+  let numfiles = List.fold_left (fun n file ->
+      try
+        combine_parser_stats_file file; n+1
+      with
+      | Failure fail -> Printf.eprintf "Failure '%s' reading %s (skipped)\n" fail file; n
+      | Sys_error err -> Printf.eprintf "Sys_error '%s' reading %s (skipped)\n" err file; n
+      | End_of_file -> Printf.eprintf "End of file reading %s (skipped)\n" file; n)
+    0 (List.tl (Array.to_list Sys.argv)) in
+  if numfiles > 0 then begin
+    ExtMap.iter (fun k c ->
+        try
+          prod_cnt_map := add_prod_count (ExtMap.find k ext_map) c !prod_cnt_map
+        with Not_found -> Printf.eprintf "Can't find extension key '%s' %s %s %d\n" k.plugin k.etype k.ename k.num)
+      !ext_cnt_map;
+    close_in inch;
+    let rev_map = ProdMap.fold (fun l p rmap -> StringMap.add p l rmap) prod_map StringMap.empty in
+    StringMap.iter (fun p l ->
+        let c = try ProdMap.find l !prod_cnt_map with Not_found -> 0 in
+        if c > 0 || print_zeros then Printf.printf "%7d  %s\n" c p)
+      rev_map
+  end
+
+
+(*** common stats infrastructure ***)
+
+(* reads and combines any "*.stats" files in COQ_STATS_DIR, writes a new file.
+ Called when coqc exits *)
+let save_parser_stats combine () =
+  (* include any other existing files *)
+  let inDir = Filename.concat !stats_dir in
+  let files = Sys.readdir !stats_dir in
+  let stats_regexp = Str.regexp ".*\\.v\\.stats$" in
+  Array.iter (fun file ->
+      if Str.string_match stats_regexp file 0 then begin
+        try
+          let temp_name = inDir (file ^ (string_of_int (Unix.getpid ()))) in
+          Sys.rename (inDir file) temp_name;  (* assume this is atomic *)
+          combine temp_name;
+          Sys.remove temp_name
+        with Sys_error _ -> ()  (* another process grabbed the file *)
+      end)
+    files;
+
+  let base_name =
+    match !infiles with
+    | f :: tl -> f
+    | [] -> "??.v" in
+  let file = Str.global_replace (Str.regexp_string "/") "_" base_name ^ ".stats" in
+  let temp_file = inDir (file ^ ".temp") in
+  let outch = open_out_bin temp_file in
+  marshal outch;
+  close_out outch;
+  Sys.rename temp_file (inDir file)
+
+
+(* check whether stats are enabled *)
+let get_stats_enabled () = !stats_enabled
+
+(* initialize statistics *)
+let init () =
+  stats_dir := (try Sys.getenv "COQ_STATS_DIR" with Not_found -> "");
+  stats_enabled := !stats_dir <> "";
+  if get_stats_enabled () then
+    at_exit (save_parser_stats combine_parser_stats_file)
+
+(* called to pass input filenames from coqc command-line parameters *)
+let set_infiles files =
+  infiles := files

--- a/clib/stats.mli
+++ b/clib/stats.mli
@@ -1,0 +1,16 @@
+val init : unit -> unit
+val set_infiles : string list -> unit
+val get_stats_enabled : unit -> bool
+
+val print_stats : unit -> unit
+
+(* callbacks for generating statistics *)
+val parser_action : string -> int -> unit
+val parser_ext : string -> string -> string -> int -> unit
+
+type pid = {
+  file : string;
+  char : int;
+}
+
+val pid_compare : pid -> pid -> int

--- a/dev/doc/statistics.md
+++ b/dev/doc/statistics.md
@@ -1,0 +1,111 @@
+Gathering Statistics
+====================
+
+Stats.ml provides a simple mechanism for developers to gather statistics across
+multiple runs of `coqc`, whether in a local build or in CI.  The initial
+version counts how many times each parser production is invoked.  The code can
+be adapted to gather other statistics.
+
+When enabled, each `coqc` process generates a `<.v-filename>.stats` file in the
+`$COQ_STATS_DIR` directory.  In addition, each `coqc` combines its data with
+any other `*.stats` file it finds in that directory.  The end result after
+multiple `coqc` runs is a single `*.stats` file.
+
+The code uses file renaming to ensure correct results when multiple `coqc`
+processes are running simultaneously.  The `<.v-filename>` prefix (which is
+qualified relative to the current directory) is used as a convenient unique
+filename.
+
+Sample output (excerpt)
+-----------------------
+
+```
+      0  simple_tactic:  "abstract" ssrdgens
+   3224  simple_tactic:  "absurd" constr
+     31  simple_tactic:  "admit"
+    186  simple_tactic:  "apply"
+ 608313  simple_tactic:  "apply" LIST1 constr_with_bindings_arg SEP "," in_hyp_as
+   2108  simple_tactic:  "apply" ssrapplyarg
+```
+
+How to run locally
+------------------
+
+  - `export COQ_STATS_DIR=.` - set the output directory for statistics files
+  - delete any existing `*.stats` files in `$COQ_STATS_DIR` lest they be
+    incorrectly added into the totals
+  - run `coqc` on one or more `.v` files.  This could be a full make/dune build
+    if you wish.
+  - `make doc_gram` - generates a file `doc/tools/docgram/prodmap` needed for
+    printing results (do this once per source tree or after changing the
+    grammar in the `*.mlg` files).
+  - `bin/print_stats <*.stats files>` - sums the named files and print results.
+    This assumes it's run in the root directory of a local build tree so it can
+    access the `prodmap` file.
+
+How to run with CI
+------------------
+
+  - In `.gitlab-ci.yml`, uncomment the line `# - export COQ_STATS_DIR=$PWD`.
+  - Statistics are currently generated for selected jobs (build:*, library:*
+    and plugin:*).  Configuration is described below.
+  - Do a push, wait for CI to complete.
+  - Get the pipeline number from the GUI (not a job number!).
+  - Run `tools/fetch_stats.sh $PIPELINE` to download statistics files
+  - `bin/print_stats <*.stats files>`
+
+Configuring which jobs are included in the statistics
+-----------------------------------------------------
+
+There are 3 places that filter which jobs are included in your statistics:
+  - CI generates a `$CI_JOB_NAME.stats` file for each job that has or inherits
+    these settings in `.gitlab-ci.yml`:
+
+  ```
+    script:
+      - export COQ_STATS_DIR=$PWD
+    after_script:
+      - if [ `ls *.stats|wc -l` = 1 ]; then mv *.stats $CI_JOB_NAME.stats; fi
+    artifacts:
+      paths:
+        - "*.stats"
+  ```
+
+  - `fetch_stats.sh` currently filters out jobnames that include `+` so it only
+    fetches one of the 5 `build` jobs.
+  - You can filter in the call to `print_stats` or delete some files
+
+Parsing statistics
+------------------
+
+The instrumentation counts how many times each production in the `*.mlg` files
+is recognized.  The set of `.mlg` files included is $DOC_MLGS, defined in
+`Makefile.build` (which omits, for example, `g_ltac2.mlg`).
+The productions include anonymous productions nested inside named
+productions, for example:
+
+```
+  type_cstr:
+    [ [ c=OPT [":"; c=lconstr -> { c } ] -> { Loc.tag ~loc c } ] ]
+```
+
+has the nested production `[":"; c=lconstr -> { c } ]`.  This appears as
+`(type_cstr : 537):  ":" lconstr` in the output.  `537` is the line number in
+the `.mlg`.
+
+Notations add productions to the grammar at run time.  These are not currently
+included in the statistics.
+
+The output doesn't distinguish between keywords and identifiers.
+
+
+Gathering other statistics
+--------------------------
+
+Create new routines in `Stats` to handle other statistics.  Eventually we may
+need a mechanism to configure what statistics to collect rather than, say,
+relying on source code changes to configure statistics.  We'll see whether
+statistics-gathering is popular enough to merit the additional effort.
+
+`Marshal.from_channel` calls are not inherently type-safe.  Make sure you
+correctly update the returned type for the one in `Stats.unmarshal`.

--- a/plugins/ltac/extratactics.mlg
+++ b/plugins/ltac/extratactics.mlg
@@ -855,7 +855,7 @@ TACTIC EXTEND has_evar
 }
 END
 
-TACTIC EXTEND is_hyp
+TACTIC EXTEND is_var
 | [ "is_var" constr(x) ] -> {
   Proofview.tclEVARMAP >>= fun sigma ->
   match EConstr.kind sigma x with

--- a/plugins/ltac/g_ltac.mlg
+++ b/plugins/ltac/g_ltac.mlg
@@ -151,8 +151,23 @@ GRAMMAR EXTEND Gram
           l = LIST0 message_token -> { TacFail (g,n,l) }
       | st = simple_tactic -> { st }
       | a = tactic_arg -> { TacArg(CAst.make ~loc a) }
-      | r = reference; la = LIST0 tactic_arg_compat ->
-        { TacArg(CAst.make ~loc @@ TacCall (CAst.make ~loc (r,la))) } ]
+      | r = reference; la = LIST0 tactic_arg_compat -> {
+        if Stats.get_stats_enabled () then begin
+          (* special case of TACTIC EXTEND *)
+          (* todo: completely ad-hoc.  assumes that the extension name (what I want to pass)
+            is the same as the first identifier in the tactic (e.g. "is_var" should be under
+            TACTIC EXTEND is_var, not under is_hyp *)
+          try let tac = Tacenv.locate_tactic r in
+            let pfx = "Coq.Init.Notations." in
+            let kername = KerName.to_string tac in
+            if CString.string_contains ~what:pfx ~where:kername then begin
+              let pfx_len = String.length pfx in
+              let tactic = (String.sub kername pfx_len ((String.length kername) - pfx_len)) in
+              Stats.parser_ext "" "T" tactic 0;  (* plugin name is unknown *)
+            end
+          with Not_found -> ()
+        end;
+        TacArg(CAst.make ~loc @@ TacCall (CAst.make ~loc (r,la))) } ]
     | "0"
       [ "("; a = tactic_expr; ")" -> { a }
       | "["; ">"; tg = tactic_then_gen; "]" -> {

--- a/plugins/ltac/tacentries.ml
+++ b/plugins/ltac/tacentries.ml
@@ -176,6 +176,14 @@ let add_tactic_entry (kn, ml, tg) state =
       else
         TacGeneric arg
     in
+    if Stats.get_stats_enabled () then begin
+      let open Tacenv in
+      (match (interp_alias kn).alias_body with
+      | TacML { CAst.v=( entry, _) } ->
+        let name = entry.mltac_name in
+        Stats.parser_ext name.mltac_plugin "T" name.mltac_tactic entry.mltac_index
+      | _ -> ())
+    end;
     let l = List.map map l in
     (TacAlias (CAst.make ~loc (kn,l)):raw_tactic_expr)
   in

--- a/tools/fetch_stats.sh
+++ b/tools/fetch_stats.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# fetch and stats files from CI
+
+RED="\033[31m"
+RESET="\033[0m"
+error() {
+  echo -e "${RED}error:${RESET} $1 ${RESET}"
+}
+
+if [ $# != 1 ]; then
+  error "usage: $0 pipeline-number"
+  exit 1
+fi
+
+if [[ "$1" =~ ^[1-9][0-9]*$ ]]; then
+  PIPELINE=$1
+else
+  error "$1 is not a number"
+  exit 1
+fi
+
+echo Removing existing "*.stats" files...
+rm *.stats
+echo Downloading "*.stats" files...
+TMPFILE=$(mktemp /tmp/fetch_stats.XXXXXX)
+curl -s "https://gitlab.com/coq/coq/pipelines/$PIPELINE.json" >$TMPFILE
+
+mapfile -t JNAMES < <( jq -r '.details.artifacts[].name' <$TMPFILE )
+mapfile -t APATHS < <( jq -r '.details.artifacts[].path' <$TMPFILE )
+rm "$TMPFILE"
+
+for ((n = 0; n < ${#JNAMES[@]}; n++)); do
+  JNAME=${JNAMES[$n]}
+  # skip variants such as build:base+32bit
+  if [[ ! $JNAME =~ "+" ]]; then
+    APATH=${APATHS[$n]}
+    URL=https://gitlab.com${APATH/download/raw}/$JNAME.stats
+    if curl -s --fail -O $URL; then
+      echo $URL
+    fi
+  fi
+done
+echo Now run \"bin/print_stats.sh *.stats\"

--- a/tools/print_stats.ml
+++ b/tools/print_stats.ml
@@ -1,0 +1,1 @@
+let () = Stats.print_stats  ()

--- a/toplevel/coqc.ml
+++ b/toplevel/coqc.ml
@@ -16,7 +16,8 @@ let outputstate opts =
 let coqc_init _copts ~opts =
   Flags.quiet := true;
   System.trust_file_cache := true;
-  Coqtop.init_color opts.Coqargs.config
+  Coqtop.init_color opts.Coqargs.config;
+  Stats.init ()
 
 let coqc_specific_usage = Usage.{
   executable_name = "coqc";

--- a/toplevel/coqcargs.ml
+++ b/toplevel/coqcargs.ml
@@ -221,6 +221,7 @@ let parse arglist : t =
   in
   try
     let opts, extra = parse default in
+    Stats.set_infiles extra;
     let args = List.fold_left add_compile opts extra in
     check_compilation_output_name_consistency args;
     args

--- a/vernac/egramml.ml
+++ b/vernac/egramml.ml
@@ -88,6 +88,9 @@ let get_extend_vernac_rule (s, i) =
 let extend_vernac_command_grammar s nt gl =
   let nt = Option.default Pvernac.Vernac_.command nt in
   vernac_exts := (s,gl) :: !vernac_exts;
-  let mkact loc l = VernacExtend (s, l) in
+  let (entry, index) = s in
+  let mkact loc l =
+    Stats.parser_ext "" "C" entry index;
+    VernacExtend (s, l) in
   let rules = [make_rule mkact gl] in
   grammar_extend nt { pos=None; data=[None, None, rules]}


### PR DESCRIPTION
This PR provides a simple mechanism for developers to gather statistics across multiple runs of `coqc`, whether in a local build or in CI.  The initial version counts how many times each parser production is invoked.  The code can be adapted to gather other statistics.

See `statistics.md` for more detail.

I did this to get an idea of the most commonly used tactics and commands to help decide what should be documented first.  The parsing statistics may help identify obsolete or unused constructs that might be removed in future releases.  Or, with a bit more packaging, it could help users identify how often they use deprecated constructs.

Full sample output across most of the CI jobs is here: https://github.com/coq/coq/wiki/Use-counts-for-parser-productions.

Some background discussion here: https://github.com/coq/coq/issues/10675