### PR TITLE
[ci] Remove dead code.

### DIFF
--- a/Makefile.ci
+++ b/Makefile.ci
@@ -18,7 +18,6 @@ CI_TARGETS= \
     ci-coq_dpdgraph \
     ci-coquelicot \
     ci-corn \
-    ci-cpdt \
     ci-cross-crypto \
     ci-elpi \
     ci-ext-lib \
@@ -41,7 +40,6 @@ CI_TARGETS= \
     ci-sf \
     ci-simple-io \
     ci-stdlib2 \
-    ci-tlc \
     ci-unimath \
     ci-verdi-raft \
     ci-vst

--- a/dev/ci/ci-cpdt.sh
+++ b/dev/ci/ci-cpdt.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-ci_dir="$(dirname "$0")"
-. "${ci_dir}/ci-common.sh"
-
-wget http://adam.chlipala.net/cpdt/cpdt.tgz
-tar xvfz cpdt.tgz
-
-( cd cpdt && make clean && make )

--- a/dev/ci/ci-tlc.sh
+++ b/dev/ci/ci-tlc.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-ci_dir="$(dirname "$0")"
-. "${ci_dir}/ci-common.sh"
-
-FORCE_GIT=1
-git_download tlc
-
-( cd "${CI_BUILD_DIR}/tlc" && make )


### PR DESCRIPTION
TLC and CPDT are not actually tested. No point in keeping them as if they were.

**Kind:** infrastructure.