### PR TITLE
Tauto: use Coqlib to locate “not” and “NNPP”

### DIFF
--- a/theories/Logic/Classical_Prop.v
+++ b/theories/Logic/Classical_Prop.v
@@ -26,6 +26,8 @@ unfold not; intros; elim (classic p); auto.
 intro NP; elim (H NP).
 Qed.
 
+Register NNPP as core.nnpp.type.
+
 (** Peirce's law states [forall P Q:Prop, ((P -> Q) -> P) -> P].
     Thanks to [forall P, False -> P], it is equivalent to the
     following form *)


### PR DESCRIPTION
This should make it possible to use the tauto plugin with a different standard library.