### PR TITLE
[declare] Make `proof_entry` a private type.

### DIFF
--- a/dev/ci/user-overlays/10681-ejgallego-proof+private_entry.sh
+++ b/dev/ci/user-overlays/10681-ejgallego-proof+private_entry.sh
@@ -1,0 +1,6 @@
+if [ "$CI_PULL_REQUEST" = "10681" ] || [ "$CI_BRANCH" = "proof+private_entry" ]; then
+
+    equations_CI_REF=proof+private_entry
+    equations_CI_GITURL=https://github.com/ejgallego/Coq-Equations
+
+fi

--- a/tactics/abstract.mli
+++ b/tactics/abstract.mli
@@ -20,11 +20,3 @@ val cache_term_by_tactic_then
   -> unit Proofview.tactic
 
 val tclABSTRACT : ?opaque:bool -> Id.t option -> unit Proofview.tactic -> unit Proofview.tactic
-
-(* Internal but used in a few places; should likely be made intro a
-   proper library function, or incorporated into the generic constant
-   save path *)
-val shrink_entry
-  :  ('a, 'b) Context.Named.Declaration.pt list
-  -> 'c Declare.proof_entry
-  -> 'c Declare.proof_entry * Constr.t list

--- a/tactics/declare.ml
+++ b/tactics/declare.ml
@@ -446,6 +446,8 @@ module Internal = struct
   let set_opacity ~opaque entry =
     { entry with proof_entry_opaque = opaque }
 
+  let get_fix_exn entry = Future.fix_exn_of entry.proof_entry_body
+
   let rec decompose len c t accu =
     let open Constr in
     let open Context.Rel.Declaration in

--- a/tactics/declare.mli
+++ b/tactics/declare.mli
@@ -135,6 +135,10 @@ module Internal : sig
   (* Overriding opacity is indeed really hacky *)
   val set_opacity : opaque:bool -> 'a proof_entry -> 'a proof_entry
 
+  (* TODO: This is only used in DeclareDef to forward the fix to
+     hooks, should eventually go away *)
+  val get_fix_exn : 'a proof_entry -> Future.fix_exn
+
   val shrink_entry : EConstr.named_context -> 'a proof_entry -> 'a proof_entry * Constr.constr list
 
 end

--- a/tactics/ind_tables.ml
+++ b/tactics/ind_tables.ml
@@ -124,16 +124,7 @@ let define internal role id c poly univs =
   let ctx = UState.minimize univs in
   let c = UnivSubst.nf_evars_and_universes_opt_subst (fun _ -> None) (UState.subst ctx) c in
   let univs = UState.univ_entry ~poly ctx in
-  let entry = {
-    Declare.proof_entry_body =
-      Future.from_val ((c,Univ.ContextSet.empty), ());
-    proof_entry_secctx = None;
-    proof_entry_type = None;
-    proof_entry_universes = univs;
-    proof_entry_opaque = false;
-    proof_entry_inline_code = false;
-    proof_entry_feedback = None;
-  } in
+  let entry = Declare.pure_definition_entry ~univs c in
   let kn, eff = Declare.declare_private_constant ~role ~kind:Decls.(IsDefinition Scheme) ~name:id entry in
   let () = match internal with
     | InternalTacticRequest -> ()

--- a/tactics/pfedit.ml
+++ b/tactics/pfedit.ml
@@ -114,14 +114,14 @@ let by tac = Proof_global.map_fold_proof (solve (Goal_select.SelectNth 1) None t
 
 let next = let n = ref 0 in fun () -> incr n; !n
 
-let build_constant_by_tactic ~name ctx sign ~poly typ tac =
+let build_constant_by_tactic ~name ?(opaque=Proof_global.Transparent) ctx sign ~poly typ tac =
   let evd = Evd.from_ctx ctx in
   let goals = [ (Global.env_of_context sign , typ) ] in
   let pf = Proof_global.start_proof ~name ~poly ~udecl:UState.default_univ_decl evd goals in
   try
     let pf, status = by tac pf in
     let open Proof_global in
-    let { entries; universes } = close_proof ~opaque:Transparent ~keep_body_ucst_separate:false (fun x -> x) pf in
+    let { entries; universes } = close_proof ~opaque ~keep_body_ucst_separate:false (fun x -> x) pf in
     match entries with
     | [entry] ->
       entry, status, universes

--- a/tactics/pfedit.mli
+++ b/tactics/pfedit.mli
@@ -59,6 +59,7 @@ val use_unification_heuristics : unit -> bool
 
 val build_constant_by_tactic
   :  name:Id.t
+  -> ?opaque:Proof_global.opacity_flag
   -> UState.t
   -> named_context_val
   -> poly:bool

--- a/tactics/proof_global.ml
+++ b/tactics/proof_global.ml
@@ -238,18 +238,10 @@ let close_proof ~opaque ~keep_body_ucst_separate ?feedback_id ~now
     let t = EConstr.Unsafe.to_constr t in
     let univstyp, body = make_body t p in
     let univs, typ = Future.force univstyp in
-    let open Declare in
-    {
-      proof_entry_body = body;
-      proof_entry_secctx = section_vars;
-      proof_entry_feedback = feedback_id;
-      proof_entry_type  = Some typ;
-      proof_entry_inline_code = false;
-      proof_entry_opaque = opaque;
-      proof_entry_universes = univs; }
+    Declare.delayed_definition_entry ~opaque ?feedback_id ?section_vars ~univs ~types:typ body
   in
-  let entries = Future.map2 entry_fn fpl Proofview.(initial_goals entry) in
-  { name; entries = entries; poly; universes; udecl }
+  let entries = Future.map2 entry_fn fpl (Proofview.initial_goals entry) in
+  { name; entries; poly; universes; udecl }
 
 let return_proof ?(allow_partial=false) ps =
  let { proof } = ps in

--- a/vernac/declareDef.ml
+++ b/vernac/declareDef.ml
@@ -44,7 +44,7 @@ end
 
 (* Locality stuff *)
 let declare_definition ~name ~scope ~kind ?hook_data udecl ce imps =
-  let fix_exn = Future.fix_exn_of ce.proof_entry_body in
+  let fix_exn = Declare.Internal.get_fix_exn ce in
   let gr = match scope with
   | Discharge ->
       let () =

--- a/vernac/declareDef.mli
+++ b/vernac/declareDef.mli
@@ -62,11 +62,16 @@ val declare_fix
   -> Impargs.manual_implicits
   -> GlobRef.t
 
-val prepare_definition : allow_evars:bool ->
-  ?opaque:bool -> ?inline:bool -> poly:bool ->
-  Evd.evar_map -> UState.universe_decl ->
-  types:EConstr.t option -> body:EConstr.t ->
-  Evd.evar_map * Evd.side_effects Declare.proof_entry
+val prepare_definition
+  :  allow_evars:bool
+  -> ?opaque:bool
+  -> ?inline:bool
+  -> poly:bool
+  -> Evd.evar_map
+  -> UState.universe_decl
+  -> types:EConstr.t option
+  -> body:EConstr.t
+  -> Evd.evar_map * Evd.side_effects Declare.proof_entry
 
 val prepare_parameter : allow_evars:bool ->
   poly:bool -> Evd.evar_map -> UState.universe_decl -> EConstr.types ->

--- a/vernac/lemmas.ml
+++ b/vernac/lemmas.ml
@@ -384,17 +384,14 @@ let adjust_guardness_conditions const = function
   | possible_indexes ->
     (* Try all combinations... not optimal *)
     let env = Global.env() in
-    { const with
-      Declare.proof_entry_body =
-        Future.chain const.Declare.proof_entry_body
-          (fun ((body, ctx), eff) ->
-             match Constr.kind body with
-             | Fix ((nv,0),(_,_,fixdefs as fixdecls)) ->
-               let env = Safe_typing.push_private_constants env eff.Evd.seff_private in
-               let indexes = search_guard env possible_indexes fixdecls in
-               (mkFix ((indexes,0),fixdecls), ctx), eff
-             | _ -> (body, ctx), eff)
-    }
+    Declare.Internal.map_entry_body const
+      ~f:(fun ((body, ctx), eff) ->
+          match Constr.kind body with
+          | Fix ((nv,0),(_,_,fixdefs as fixdecls)) ->
+            let env = Safe_typing.push_private_constants env eff.Evd.seff_private in
+            let indexes = search_guard env possible_indexes fixdecls in
+            (mkFix ((indexes,0),fixdecls), ctx), eff
+          | _ -> (body, ctx), eff)
 
 let finish_proved env sigma idopt po info =
   let open Proof_global in
@@ -452,7 +449,7 @@ let finish_derived ~f ~name ~idopt ~entries =
   in
   (* The opacity of [f_def] is adjusted to be [false], as it
      must. Then [f] is declared in the global environment. *)
-  let f_def = { f_def with Declare.proof_entry_opaque = false } in
+  let f_def = Declare.Internal.set_opacity ~opaque:false f_def in
   let f_kind = Decls.(IsDefinition Definition) in
   let f_def = Declare.DefinitionEntry f_def in
   let f_kn = Declare.declare_constant ~name:f ~kind:f_kind f_def in
@@ -463,20 +460,15 @@ let finish_derived ~f ~name ~idopt ~entries =
      performs this precise action. *)
   let substf c = Vars.replace_vars [f,f_kn_term] c in
   (* Extracts the type of the proof of [suchthat]. *)
-  let lemma_pretype =
-    match lemma_def.Declare.proof_entry_type with
-    | Some t -> t
+  let lemma_pretype typ =
+    match typ with
+    | Some t -> Some (substf t)
     | None -> assert false (* Proof_global always sets type here. *)
   in
   (* The references of [f] are subsituted appropriately. *)
-  let lemma_type = substf lemma_pretype in
+  let lemma_def = Declare.Internal.map_entry_type lemma_def ~f:lemma_pretype in
   (* The same is done in the body of the proof. *)
-  let lemma_body = Future.chain lemma_def.Declare.proof_entry_body (fun ((b,ctx),fx) -> (substf b, ctx), fx) in
-  let lemma_def =
-    { lemma_def with
-      Declare.proof_entry_body = lemma_body;
-      proof_entry_type = Some lemma_type }
-  in
+  let lemma_def = Declare.Internal.map_entry_body lemma_def ~f:(fun ((b,ctx),fx) -> (substf b, ctx), fx) in
   let lemma_def = Declare.DefinitionEntry lemma_def in
   let _ : Names.Constant.t = Declare.declare_constant ~name ~kind:Decls.(IsProof Proposition) lemma_def in
   ()
@@ -491,7 +483,7 @@ let finish_proved_equations lid kind proof_obj hook i types wits sigma0 =
           | Some id -> id
           | None -> let n = !obls in incr obls; add_suffix i ("_obligation_" ^ string_of_int n)
         in
-        let entry, args = Abstract.shrink_entry local_context entry in
+        let entry, args = Declare.Internal.shrink_entry local_context entry in
         let cst = Declare.declare_constant ~name:id ~kind (Declare.DefinitionEntry entry) in
         let sigma, app = Evarutil.new_global sigma (GlobRef.ConstRef cst) in
         let sigma = Evd.define ev (EConstr.applist (app, List.map EConstr.of_constr args)) sigma in

--- a/vernac/lemmas.ml
+++ b/vernac/lemmas.ml
@@ -401,7 +401,7 @@ let finish_proved env sigma idopt po info =
     let name = match idopt with
       | None -> name
       | Some { CAst.v = save_id } -> check_anonymity name save_id; save_id in
-    let fix_exn = Future.fix_exn_of const.Declare.proof_entry_body in
+    let fix_exn = Declare.Internal.get_fix_exn const in
     let () = try
       let const = adjust_guardness_conditions const compute_guard in
       let should_suggest = const.Declare.proof_entry_opaque &&


### PR DESCRIPTION
Proof entries are low-level objects and should not be manipulated by
users directly, in particular as we want to unify all the code
around declaration of constants.

This patch doesn't bring by itself a lot of improvement, other than
setting the base where to extend the interface, however it already
points out some points of interest, and in particular the manipulation
of opacity done by `Derive` which can be quite problematic, and of
course the handling of delayed proofs.

So while this is a first step, IMHO it doesn't harm a lot having it in
place, but a lot more work will be needed, in particular regarding the
handling of delayed proofs.

To make `proof_entry` a fully abstract type, the remaining work is
focused on `abstract` and obligations, both of which do quite a few
hackery that will have to be migrated to the `Declare` API.

Overlays:
- https://github.com/mattam82/Coq-Equations/pull/244

D̶e̶p̶e̶n̶d̶s̶ ̶o̶n̶ ̶#̶1̶0̶6̶7̶4̶ ̶