### PR TITLE
Create a maintainer team for the contributing process files.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,17 @@
 # This file describes the maintainers for the main components. See
 # `dev/doc/MERGING.md`.
 
-########## GitHub metadata, including this file ##########
+########## Contributing process ##########
 
-/.github/         @maximedenes
-# Secondary maintainer @Zimmi48
+/.github/                   @coq/contributing-process-maintainers
+
+/CONTRIBUTING.md            @coq/contributing-process-maintainers
+
+/dev/doc/release-process.md @coq/contributing-process-maintainers
+
+/dev/doc/MERGING.md         @coq/pushers
+# This ensures that all members of the @coq/pushers
+# team are notified when the merging doc changes.
 
 ########## Build system ##########
 
@@ -45,18 +52,11 @@ azure-pipelines.yml @coq/ci-maintainers
 /INSTALL*         @Zimmi48
 # Secondary maintainer @maximedenes
 
-/CONTRIBUTING.md  @Zimmi48
-# Secondary maintainer @maximedenes
-
 /CODE_OF_CONDUCT.md    @Zimmi48
 # Secondary maintainer @mattam82
 
 /dev/doc/         @Zimmi48
 # Secondary maintainer @maximedenes
-
-/dev/doc/MERGING.md @coq/pushers
-# This ensures that all members of the @coq/pushers
-# team are notified when the merging doc changes.
 
 /dev/doc/changes.md    @ghost
 # Trick to avoid getting review requests


### PR DESCRIPTION
To improve the efficiency of the review / integration process of the PRs relating to the contributing process (contributing guide, `CODEOWNERS` file, templates, etc.) and following https://github.com/coq/coq/pull/9570#issuecomment-471479885, I propose to move the ownership of `CONTRIBUTING.md`, `.github/`, and `dev/doc/release-process.md` to a new team: @coq/contributing-process-maintainers. I initialized this team with the current maintainers (i.e. @maximedenes + myself) and @ejgallego. If other people would like to join in, I'd gladly add you.