### PR TITLE
[ci] [dune] Updates to dune builds artifacts.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ TAGS
 bin/
 _build_ci
 _build
+_build_boot
 config/Makefile
 config/coq_config.ml
 config/coq_config.py

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -103,13 +103,16 @@ before_script:
     - set -e
     - make -f Makefile.dune world
     - set +e
+    - tar cfj _build.tar.bz2 _build
   variables:
     OPAM_SWITCH: edge
     OPAM_VARIANT: "+flambda"
   artifacts:
     name: "$CI_JOB_NAME"
+    when: always
     paths:
-      - _build/
+      - _build/log
+      - _build.tar.bz2
     expire_in: 1 week
 
 .dune-ci-template:
@@ -119,6 +122,7 @@ before_script:
   dependencies:
     - build:edge+flambda:dune:dev
   script:
+    - tar xfj _build.tar.bz2
     - set -e
     - echo 'start:coq.test'
     - make -f Makefile.dune "$DUNE_TARGET"
@@ -128,6 +132,7 @@ before_script:
     OPAM_SWITCH: edge
     OPAM_VARIANT: "+flambda"
   artifacts:
+    when: always
     name: "$CI_JOB_NAME"
     expire_in: 2 months
 
@@ -409,6 +414,7 @@ doc:refman:dune:
     DUNE_TARGET: refman-html
   artifacts:
     paths:
+      - _build/log
       - _build/default/doc/sphinx_build/html
 
 doc:stdlib:dune:
@@ -417,6 +423,7 @@ doc:stdlib:dune:
     DUNE_TARGET: stdlib-html
   artifacts:
     paths:
+      - _build/log
       - _build/default/doc/stdlib/html
 
 doc:refman:deploy:
@@ -456,6 +463,7 @@ doc:ml-api:odoc:
     DUNE_TARGET: apidoc
   artifacts:
     paths:
+      - _build/log
       - _build/default/_doc/
 
 test-suite:base:
@@ -486,13 +494,15 @@ test-suite:edge+flambda:
     OPAM_VARIANT: "+flambda"
   only: *full-ci
 
-test-suite:egde:dune:dev:
+test-suite:edge:dune:dev:
   stage: stage-2
   dependencies:
     - build:edge+flambda:dune:dev
   needs:
     - build:edge+flambda:dune:dev
-  script: make -f Makefile.dune test-suite
+  script:
+    - tar xfj _build.tar.bz2
+    - make -f Makefile.dune test-suite
   variables:
     OPAM_SWITCH: edge
     OPAM_VARIANT: "+flambda"

--- a/Makefile.dune
+++ b/Makefile.dune
@@ -11,7 +11,8 @@
 # use DUNEOPT=--display=short for a more verbose build
 # DUNEOPT=--display=short
 
-BUILD_CONTEXT=_build/default
+BOOT_DIR=_build_boot
+BOOT_CONTEXT=$(BOOT_DIR)/default
 
 help:
 	@echo "Welcome to Coq's Dune-based build system. Targets are:"
@@ -45,8 +46,8 @@ plugins/ltac/dune:
 	@echo "(library (name ltac_plugin) (public_name coq.plugins.ltac) (modules_without_implementation extraargs extratactics))" > plugins/ltac/dune
 
 voboot: plugins/ltac/dune
-	dune build $(DUNEOPT) @vodeps
-	dune exec ./tools/coq_dune.exe $(BUILD_CONTEXT)/.vfiles.d
+	dune build --build-dir=$(BOOT_DIR) $(DUNEOPT) @vodeps
+	dune exec --build-dir=$(BOOT_DIR) -- ./tools/coq_dune.exe $(BOOT_CONTEXT)/.vfiles.d
 
 states: voboot
 	dune build --display=short $(DUNEOPT) dev/shim/coqtop-prelude
@@ -104,8 +105,8 @@ ocheck: voboot
 
 ireport:
 	dune clean
-	dune build $(DUNEOPT) @vodeps --profile=ireport
-	dune exec coq_dune $(BUILD_CONTEXT)/.vfiles.d --profile=ireport
+	dune build --build-dir=$(BOOT_DIR) $(DUNEOPT) @vodeps
+	dune exec --build-dir=$(BOOT_DIR) -- ./tools/coq_dune.exe $(BOOT_CONTEXT)/.vfiles.d
 	dune build $(DUNEOPT) @install --profile=ireport
 
 clean:

--- a/Makefile.make
+++ b/Makefile.make
@@ -56,6 +56,7 @@ FIND_SKIP_DIRS:='(' \
   -name "$${GIT_DIR}" -o \
   -name '_build' -o \
   -name '_build_ci' -o \
+  -name '_build_boot' -o \
   -name '_install_ci' -o \
   -name 'gramlib' -o \
   -name 'user-contrib' -o \


### PR DESCRIPTION
Closes #10694

We modify handling of artifacts for dune builds:
- we preserve `_build/log` log as artifact for ci-builds,
- we use a tar.gz as to preserve file permissions which is necessary
  in order to reuse the artifacts in an incremental build.

Dune uses this rule to digest a file:

```
  Digest.generic (file_contents f, f.stats.st_perm land 0o100 (* Only take USR_X in account *))
```

Since a few releases, Gitlab CI uses `.zip` as the storage format for
artifacts, this means that files in `_build` will get the executable
bit set when they did not have it originally, making all the digest
cache to miss. This caused #10694 .

See https://gitlab.com/gitlab-org/gitlab/issues/18711
