### PR TITLE
[gitlab/ci] Prevent Corn from running if Bignums has failed.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,8 +8,11 @@ stages:
   - stage-4 # Only dependencies in stage 1, 2 and 3
   - deploy
 
-# When a job has no dependencies, it goes to stage 1.
-# Otherwise, we set "needs" and "dependencies" to the same value.
+# When a job has no dependencies, it goes to stage 1.  Otherwise, we
+# set both "needs" and "dependencies". "needs" is a superset of
+# "dependencies" that should include all the transitive dependencies.
+# "dependencies" only list the previous jobs whose artifact we need to
+# keep.
 
 # some default values
 variables:
@@ -654,6 +657,7 @@ library:ci-corn:
   stage: stage-4
   needs:
   - build:edge+flambda
+  - plugin:ci-bignums
   - library:ci-math-classes
   dependencies:
   - build:edge+flambda


### PR DESCRIPTION
The `needs` keyword needs to include all the transitive dependencies.
Otherwise, we risk stage-3 being skipped but stage-4 being run as in https://gitlab.com/coq/coq/pipelines/78119475.

The reason why we don't need to include bignums in the dependencies of corn is because the artifact for math-classes is the directory where both bignums and math-classes were built.

**Kind:** infrastructure.