### PR TITLE
[vernac] Deprecate the unqualified “Print” command

### DIFF
--- a/doc/changelog/07-commands-and-options/10710-deprecate-print.rst
+++ b/doc/changelog/07-commands-and-options/10710-deprecate-print.rst
@@ -1,0 +1,5 @@
+- Deprecate the unqualified :cmd:`Print` command;
+  use :cmd:`Print Term` instead
+  (`#10710 <https://github.com/coq/coq/pull/10710>`_,
+  fixes `#10708 <https://github.com/coq/coq/issues/10708>`_,
+  by Vincent Laporte).

--- a/doc/sphinx/addendum/extended-pattern-matching.rst
+++ b/doc/sphinx/addendum/extended-pattern-matching.rst
@@ -131,7 +131,7 @@ This is compiled into:
 .. coqtop:: all
 
    Unset Printing Matching.
-   Print even.
+   Print Term even.
 
 .. coqtop:: none
 

--- a/doc/sphinx/addendum/implicit-coercions.rst
+++ b/doc/sphinx/addendum/implicit-coercions.rst
@@ -386,7 +386,7 @@ We give now an example using identity coercions.
 
   Definition D' (b:bool) := D 1 b.
   Identity Coercion IdD'D : D' >-> D.
-  Print IdD'D.
+  Print Term IdD'D.
   Parameter d' : D' true.
   Check (T d').
   Set Printing Coercions.

--- a/doc/sphinx/addendum/miscellaneous-extensions.rst
+++ b/doc/sphinx/addendum/miscellaneous-extensions.rst
@@ -49,7 +49,7 @@ it provides the following command:
 
      End P.
 
-     Print p.
+     Print Term p.
      Check h.
 
 Any property can be used as `term`, not only an equation. In particular,

--- a/doc/sphinx/addendum/ring.rst
+++ b/doc/sphinx/addendum/ring.rst
@@ -687,11 +687,12 @@ for |Coq|’s type checker. Let us see why:
 
   Require Import ZArith.
   Open Scope Z_scope.
-  Goal forall x y z : Z, 
+  Lemma foo (x y z : Z) :
          x + 3 + y + y * z = x + 3 + y + z * y.
-  intros; rewrite (Zmult_comm y z); reflexivity.
-  Save foo.
-  Print foo.
+  Proof.
+    rewrite (Zmult_comm y z); reflexivity.
+  Defined.
+  Print Term foo.
 
 At each step of rewriting, the whole context is duplicated in the
 proof term. Then, a tactic that does hundreds of rewriting generates

--- a/doc/sphinx/addendum/universe-polymorphism.rst
+++ b/doc/sphinx/addendum/universe-polymorphism.rst
@@ -65,7 +65,7 @@ different. This can be seen when the :flag:`Printing Universes` flag is on:
 
 .. coqtop:: all
 
-   Print selfpid.
+   Print Term selfpid.
 
 Now :g:`pidentity` is used at two different levels: at the head of the
 application it is instantiated at ``Top.3`` while in the argument position
@@ -92,7 +92,7 @@ is given by monoids:
 
 .. coqtop:: in
 
-   Print Monoid.
+   Print Term Monoid.
 
 The Monoid's carrier universe is polymorphic, hence it is possible to
 instantiate it for example with :g:`Monoid` itself. First we build the
@@ -114,7 +114,7 @@ From this we can build a definition for the monoid of :g:`Set`\-monoids
 
 .. coqtop:: all
 
-   Print monoid_monoid.
+   Print Term monoid_monoid.
 
 As one can see from the constraints, this monoid is “large”, it lives
 in a universe strictly higher than :g:`Set`.
@@ -194,7 +194,7 @@ Consider the examples below.
 
 .. coqtop:: all
 
-   Print list.
+   Print Term list.
 
 When printing :g:`list`, the universe context indicates the subtyping
 constraints by prefixing the level names with symbols.
@@ -345,7 +345,7 @@ Consider the following example:
 
 .. coqtop:: all
 
-   Print id0.
+   Print Term id0.
 
 This definition is elaborated by minimizing the universe of :g:`id0` to
 level :g:`Set` while the more general definition would keep the fresh level
@@ -414,7 +414,7 @@ introduced by a definition uses the following syntax:
 
 .. coqtop:: all
 
-   Print le.
+   Print Term le.
 
 During refinement we find that :g:`j` must be larger or equal than :g:`i`, as we
 are using :g:`A : Type@{i} <= Type@{j}`, hence the generated constraint. At the
@@ -468,7 +468,7 @@ underscore or by omitting the annotation to a polymorphic definition.
 
       Lemma foo@{i} : Type@{i}.
       Proof. exact Type. Qed.
-      Print foo.
+      Print Term foo.
 
    The universe :g:`Top.xxx` for the :g:`Type` in the body cannot be accessed, we
    only care that one exists for any instantiation of the universes

--- a/doc/sphinx/language/cic.rst
+++ b/doc/sphinx/language/cic.rst
@@ -1460,7 +1460,7 @@ type.
 
    .. coqtop:: all
 
-      Print eq_rec.
+      Print Term eq_rec.
       Require Extraction.
       Extraction eq_rec.
 
@@ -1723,20 +1723,20 @@ command and show the internal representation.
       | S p => S (plus p m)
       end.
 
-      Print plus.
+      Print Term plus.
       Fixpoint lgth (A:Set) (l:list A) {struct l} : nat :=
       match l with
       | nil _ => O
       | cons _ a l' => S (lgth A l')
       end.
-      Print lgth.
+      Print Term lgth.
       Fixpoint sizet (t:tree) : nat := let (f) := t in S (sizef f)
       with sizef (f:forest) : nat :=
       match f with
       | emptyf => O
       | consf t f => plus (sizet t) (sizef f)
       end.
-      Print sizet.
+      Print Term sizet.
 
 .. _Reduction-rule:
 

--- a/doc/sphinx/language/gallina-extensions.rst
+++ b/doc/sphinx/language/gallina-extensions.rst
@@ -574,7 +574,7 @@ This example emphasizes what the printing options offer.
 
        Test Printing Let for prod.
 
-       Print snd.
+       Print Term snd.
 
        Remove Printing Let prod.
 
@@ -582,7 +582,7 @@ This example emphasizes what the printing options offer.
 
        Unset Printing Wildcard.
 
-       Print snd.
+       Print Term snd.
 
 .. _advanced-recursive-functions:
        
@@ -788,13 +788,13 @@ Sections create local contexts which can be shared across multiple definitions.
 
    .. coqtop:: all
 
-      Print x'.
-      Print x''.
+      Print Term x'.
+      Print Term x''.
 
       End s1.
 
-      Print x'.
-      Print x''.
+      Print Term x'.
+      Print Term x''.
 
    Notice the difference between the value of :g:`x'` and :g:`x''` inside section
    :g:`s1` and outside.
@@ -1075,7 +1075,7 @@ module can be accessed using the dot notation:
 
 .. coqtop:: all
 
-   Print M.x.
+   Print Term M.x.
 
 A simple module type:
 
@@ -1096,11 +1096,11 @@ specification: the y component is dropped as well as the body of x.
 
    Module N : SIG with Definition T := nat := M.
 
-   Print N.T.
+   Print Term N.T.
 
-   Print N.x.
+   Print Term N.x.
 
-   Fail Print N.y.
+   Fail Print Term N.y.
 
 .. reset to remove N (undo in last coqtop block doesn't seem to do that), invisibly redefine M, SIG
 .. coqtop:: none reset
@@ -1150,7 +1150,7 @@ transparent constraint
 
    Module P <: SIG := M.
 
-   Print P.y.
+   Print Term P.y.
 
 Now let us create a functor, i.e. a parametric module
 
@@ -1641,7 +1641,7 @@ inductive only, not the inductive type itself. For example:
    | nil : list
    | cons : A -> list -> list.
 
-   Print list.
+   Print Term list.
 
 One can always specify the parameter if it is not uniform using the
 usual implicit arguments disambiguation syntax.
@@ -1804,7 +1804,7 @@ appear strictly in the body of the type, they are implicit.
 
    Arguments p : default implicits.
 
-   Print p.
+   Print Term p.
 
    Print Implicit p.
 
@@ -2166,7 +2166,7 @@ equality argument are explicit.
 
    Definition sym `(x:A) : `(x = y -> y = x) := fun _ p => eq_sym p.
 
-   Print sym.
+   Print Term sym.
 
 Dually to normal binders, the name is optional but the type is required:
 

--- a/doc/sphinx/proof-engine/vernacular-commands.rst
+++ b/doc/sphinx/proof-engine/vernacular-commands.rst
@@ -11,8 +11,8 @@ Displaying
 
 .. _Print:
 
-.. cmd:: Print @qualid
-   :name: Print
+.. cmd:: Print Term @qualid
+   :name: Print Term
 
    This command displays on the screen information about the declared or
    defined object referred by :n:`@qualid`.
@@ -29,11 +29,14 @@ Displaying
       :undocumented:
 
 
-   .. cmdv:: Print Term @qualid
-      :name: Print Term
+   .. cmdv:: Print @qualid
+      :name: Print
 
-      This is a synonym of :cmd:`Print` :n:`@qualid` when :n:`@qualid`
-      denotes a global constant.
+      This is a deprecated synonym of :cmd:`Print Term` :n:`@qualid`.
+
+      .. deprecated:: 8.10
+
+         Use :cmd:`Print Term` :n:`@qualid` instead.
 
    .. cmdv:: Print {? Term } @qualid\@@name
 

--- a/test-suite/bugs/closed/bug_2164.v
+++ b/test-suite/bugs/closed/bug_2164.v
@@ -2,7 +2,7 @@
 Inductive type: Set
    := | int: type
       | pointer: type -> type.
-Print type.
+Print Term type.
 
 Parameter value_set
    : type -> Set.
@@ -19,7 +19,7 @@ Inductive lvalue (t: type): Set
 with rvalue (t: type): Set
    := | value_of: lvalue t -> rvalue t (* variable as value *)
       | mk_rvalue: value_set t -> rvalue t. (* literal value *)
-Print lvalue.
+Print Term lvalue.
 
 Inductive statement: Set
    := | void_stat: statement

--- a/test-suite/bugs/closed/bug_2362.v
+++ b/test-suite/bugs/closed/bug_2362.v
@@ -19,12 +19,12 @@ Instance Pointed_FPair B neutral:
  { creturn := fun A (a:A) => (a,> neutral) }.
 Definition blah_fail (x:bool) : FPair bool nat O :=
   creturn x.
-Set Printing All. Print blah_fail.
+Set Printing All. Print Term blah_fail.
 
 Definition blah_explicit (x:bool) : FPair bool nat O :=
   @creturn _ (Pointed_FPair _ ) _ x.
 
-Print blah_explicit.
+Print Term blah_explicit.
 
 
 Instance Pointed_FPair_mono:

--- a/test-suite/bugs/closed/bug_2378.v
+++ b/test-suite/bugs/closed/bug_2378.v
@@ -503,7 +503,7 @@ Proof.
 Qed.
 
 Require Export Coq.Logic.FunctionalExtensionality.
-Print PLanguage.
+Print Term PLanguage.
 
 Program Definition PTransfo l1 l2 (tr: Transformation l1 l2) (h: isSharedTransfo l1 l2 tr):
 Transformation (PLanguage l1) (PLanguage l2) :=

--- a/test-suite/bugs/closed/bug_2584.v
+++ b/test-suite/bugs/closed/bug_2584.v
@@ -22,7 +22,7 @@ with area : Type :=
   | Stored : ftyp -> area
 .
 
-Print ftyp.
+Print Term ftyp.
 (* yields:
 Inductive ftyp : Type (* Top.27429 *) :=
     Funit : ftyp | Ffun : list ftyp -> ftyp | Fref : area -> ftyp
@@ -51,7 +51,7 @@ with tc_wf_area (ar:area): res unit :=
 
 End FOO.
 
-Print ftyp.
+Print Term ftyp.
 (* yields:
 Inductive ftyp : Type (* Top.27465 *) :=
     Funit : ftyp | Ffun : list ftyp -> ftyp | Fref : area -> ftyp

--- a/test-suite/bugs/closed/bug_3481.v
+++ b/test-suite/bugs/closed/bug_3481.v
@@ -27,7 +27,7 @@ Local Set Primitive Projections.
 Record prod (A B : Type) : Type :=
   pair { fst : A; snd : B }.
 
-Print prod_rect.
+Print Term prod_rect.
 
 (* What I really want: *)
 Definition prod_rect' A B (P : prod A B -> Type) (u : forall (fst : A) (snd : B), P (pair fst snd))

--- a/test-suite/bugs/closed/bug_3690.v
+++ b/test-suite/bugs/closed/bug_3690.v
@@ -2,7 +2,7 @@ Unset Strict Universe Declaration.
 Set Printing Universes.
 Set Universe Polymorphism.
 Definition foo (a := Type) (b := Type) (c := Type) := Type.
-Print foo.
+Print Term foo.
 (* foo@{Top.2 Top.3 Top.5 Top.6 Top.8 Top.9 Top.10} =
 let a := Type@{Top.2} in let b := Type@{Top.5} in let c := Type@{Top.8} in Type@{Top.10}
      : Type@{Top.10+1}
@@ -34,7 +34,7 @@ Top.41}
                                   Top.40 < Top.38
                                   Top.41 < Top.40
                                    *) *)
-Print qux. (* qux@{Top.34 Top.35 Top.36 Top.37} =
+Print Term qux. (* qux@{Top.34 Top.35 Top.36 Top.37} =
 Type@{Top.34} -> Type@{Top.37}
      : Type@{max(Top.34+1, Top.37+1)}
 (* Top.34 Top.35 Top.36 Top.37 |= Top.34 < Top.35

--- a/test-suite/bugs/closed/bug_3746.v
+++ b/test-suite/bugs/closed/bug_3746.v
@@ -38,7 +38,7 @@ Module InclWorkaround.
 End InclWorkaround.
 
 Compute InclWorkaround.p.
-Print InclWorkaround.p.
+Print Term InclWorkaround.p.
 Print Assumptions InclWorkaround.p. (* Closed under the global context *)
 
 
@@ -72,7 +72,7 @@ Module InclSigOpaque.
 End InclSigOpaque.
 
 Compute InclSigOpaque.p.
-Print InclSigOpaque.p.
+Print Term InclSigOpaque.p.
 Print Assumptions InclSigOpaque.p. (* Closed *)
 
 
@@ -88,5 +88,5 @@ Module InclFunctOpa.
 End InclFunctOpa.
 
 Compute InclFunctOpa.p.
-Print InclFunctOpa.p.
+Print Term InclFunctOpa.p.
 Print Assumptions InclFunctOpa.p. (* Closed *)

--- a/test-suite/bugs/closed/bug_3911.v
+++ b/test-suite/bugs/closed/bug_3911.v
@@ -23,4 +23,4 @@ Definition bcwa (C:cat) (B:setoid) :Type := nat.
 Record temp {C}{B} (e:bcwa C B) :=
   { fld : base (obj C) }.
 
-Print temp_rect.
+Print Term temp_rect.

--- a/test-suite/bugs/closed/bug_3975.v
+++ b/test-suite/bugs/closed/bug_3975.v
@@ -3,7 +3,7 @@ Module Type S. End S.
 Module M (X:S). End M.
 
 Module Type P (X : S).
-  Print M.
+  Print Term M.
   (* Used to say: Anomaly: X already exists. Please report. *)
   (* Should rather : print something :-) *)
 End P.

--- a/test-suite/bugs/closed/bug_4273.v
+++ b/test-suite/bugs/closed/bug_4273.v
@@ -6,4 +6,4 @@ Theorem onefiber' (q : total2 (fun y => y = 0)) : True.
 Proof. assert (foo:=pr2 _ q). simpl in foo.
        destruct foo. (* Error: q is used in conclusion. *) exact I. Qed.
 
-Print onefiber'.
+Print Term onefiber'.

--- a/test-suite/bugs/closed/bug_4375.v
+++ b/test-suite/bugs/closed/bug_4375.v
@@ -78,15 +78,15 @@ End E.
 Polymorphic Fixpoint g@{i} (t : Type@{i}) (n : nat) : Type@{i} :=
   t.
 
-Print g.
+Print Term g.
 
 Polymorphic Fixpoint a@{i} (t : Type@{i}) (n : nat) : Type@{i} :=
   t
 with b@{i} (t : Type@{i}) (n : nat) : Type@{i} :=
   t.
 
-Print a.
-Print b.
+Print Term a.
+Print Term b.
 *)
 
 Polymorphic CoInductive foo@{i} (T : Type@{i}) : Type@{i} :=
@@ -95,12 +95,12 @@ Polymorphic CoInductive foo@{i} (T : Type@{i}) : Type@{i} :=
 Polymorphic CoFixpoint cg@{i} (t : Type@{i}) : foo@{i} t :=
   @A@{i} t (cg t).
 
-Print cg.
+Print Term cg.
 
 Polymorphic CoFixpoint ca@{i} (t : Type@{i}) : foo@{i} t :=
   @A@{i} t (cb t)
 with cb@{i} (t : Type@{i}) : foo@{i} t :=
   @A@{i} t (ca t).
 
-Print ca.
-Print cb.
+Print Term ca.
+Print Term cb.

--- a/test-suite/bugs/closed/bug_4519.v
+++ b/test-suite/bugs/closed/bug_4519.v
@@ -5,7 +5,7 @@ Section foo.
   Definition qux@{i} (baz : Type@{i}) := foo -> bar.
 End foo.
 Set Printing Universes.
-Print qux. (* qux@{Top.42 Top.43} =
+Print Term qux. (* qux@{Top.42 Top.43} =
 fun foo bar _ : Type@{Top.42} => foo -> bar
      : Type@{Top.42} -> Type@{Top.42} -> Type@{Top.42} -> Type@{Top.42}
 (* Top.42 Top.43 |=  *)

--- a/test-suite/bugs/closed/bug_4661.v
+++ b/test-suite/bugs/closed/bug_4661.v
@@ -7,5 +7,5 @@ Module Type Func (T:Test).
 End Func.
 
 Module Shortest_path (T : Test).
-Print Func.
+Print Term Func.
 End Shortest_path.

--- a/test-suite/bugs/closed/bug_4764.v
+++ b/test-suite/bugs/closed/bug_4764.v
@@ -1,5 +1,5 @@
 Notation prop_fun x y := (fun (x : Prop) => y).
 Definition foo := fun (p : Prop) => p.
 Definition bar := fun (_ : Prop) => O.
-Print foo.
-Print bar.
+Print Term foo.
+Print Term bar.

--- a/test-suite/bugs/closed/bug_4904.v
+++ b/test-suite/bugs/closed/bug_4904.v
@@ -5,7 +5,7 @@ Notation nat := nat.
 End B.
 End A.
 
-Print A.B.nat. (* Notation A.B.nat := nat *)
+Print Term A.B.nat. (* Notation A.B.nat := nat *)
 Import A.
-Print B.mynat.
-Print B.nat.
+Print Term B.mynat.
+Print Term B.nat.

--- a/test-suite/bugs/closed/bug_4932.v
+++ b/test-suite/bugs/closed/bug_4932.v
@@ -29,16 +29,16 @@ Check fun '((y,z):nat*nat) => pack (fr (fun '((y,z):nat*nat) => fb tt))
 
 Example test := tele (t : Type) := tt.
 Example test' := test nat.
-Print test.
+Print Term test.
 
 Example test2 := tele (t : Type) (x:t) := tt.
 Example test2' := test2 nat 0.
-Print test2.
+Print Term test2.
 
 Example test3 := tele (t : Type) (y:=0) (x:t) := tt.
 Example test3' := test3 nat 0.
-Print test3.
+Print Term test3.
 
 Example test4 := tele (t : Type) '((y,z):nat*nat) (x:t) := tt.
 Example test4' := test4 nat (1,2) 3.
-Print test4.
+Print Term test4.

--- a/test-suite/bugs/closed/bug_5434.v
+++ b/test-suite/bugs/closed/bug_5434.v
@@ -10,7 +10,7 @@ Definition foo := @proj2_sig_map feBW' (fun  H  => True = f' _) (fun H =>
  g True = g (f' H))
                                  (fun (a : feBW') (p : (fun H : feBW' => True =
  f' H) a) => @f_equal Prop Prop g True (f' a) p).
-Print foo.
+Print Term foo.
 Goal True.
   lazymatch type of foo with
   | sig (fun a : ?A => ?P) -> _

--- a/test-suite/bugs/closed/bug_5608.v
+++ b/test-suite/bugs/closed/bug_5608.v
@@ -30,4 +30,4 @@ Definition foo :=
   (fun x3 =>
      (LetIn (Var x3) (fun x18 : var TZ
                       => (Pair (Var x18) (Var x18))))).
-Print foo.
+Print Term foo.

--- a/test-suite/bugs/closed/bug_6661.v
+++ b/test-suite/bugs/closed/bug_6661.v
@@ -236,7 +236,7 @@ Section isweqcontrtounit.
 
      from this print statement: *)
 
-         Print isweqcontrtounit.
+         Print Term isweqcontrtounit.
 
   (*
 

--- a/test-suite/bugs/closed/bug_7900.v
+++ b/test-suite/bugs/closed/bug_7900.v
@@ -33,7 +33,7 @@ Proof.
   apply ALL.
   Show Universes.
 Qed.
-Print quote_mult_obligation_1.
+Print Term quote_mult_obligation_1.
 (* quote_mult_obligation_1@{} =
 let Top_internal_eq_rew_dep :=
   fun (A : Type@{Coq.Init.Logic.8}) (x : A) (P : forall a : A, x = a -> Type@{Top.5} (* <- XXX *))

--- a/test-suite/complexity/lettuple.v
+++ b/test-suite/complexity/lettuple.v
@@ -26,4 +26,4 @@ Definition f (x : nat * nat) :=
   let (a,b) := x in
   0.
 
-Timeout 5 Time Print f.
+Timeout 5 Time Print Term f.

--- a/test-suite/ideal-features/implicit_binders.v
+++ b/test-suite/ideal-features/implicit_binders.v
@@ -95,7 +95,7 @@ Admitted.
    `{ }. *)
 
 Definition baz := `{x + y + z = x + (y + z)}.
-Print baz.
+Print Term baz.
 
 (** Proposition d'Arthur C.: déclarer les noms de variables généralisables à la [Implicit Types]
    pour plus de robustesse (cela vaudrait aussi pour les lieurs). Les typos du genre de l'exemple suivant

--- a/test-suite/modules/Demo.v
+++ b/test-suite/modules/Demo.v
@@ -3,7 +3,7 @@ Module M.
   Definition x := 0.
 End M.
 
-Print M.t.
+Print Term M.t.
 
 
 Module Type SIG.
@@ -24,19 +24,19 @@ End F.
 
 Module N := F M.
 
-Print N.t.
+Print Term N.t.
 Eval compute in N.t.
 
 
 Module N' : SIG := N.
 
-Print N'.t.
+Print Term N'.t.
 Eval compute in N'.t.
 
 
 Module N'' <: SIG := F N.
 
-Print N''.t.
+Print Term N''.t.
 Eval compute in N''.t.
 
 Eval compute in N''.x.
@@ -44,12 +44,12 @@ Eval compute in N''.x.
 
 Module N''' : SIG with Definition t := nat -> nat := N.
 
-Print N'''.t.
+Print Term N'''.t.
 Eval compute in N'''.t.
 
-Print N'''.x.
+Print Term N'''.x.
 
 
 Import N'''.
 
-Print t.
+Print Term t.

--- a/test-suite/modules/obj.v
+++ b/test-suite/modules/obj.v
@@ -3,24 +3,24 @@ Unset Strict Implicit.
 
 Module M.
   Definition a (s : Set) := s.
-  Print a.
+  Print Term a.
 End M.
 
-Print M.a.
+Print Term M.a.
 
 Module K.
   Definition app (A B : Set) (f : A -> B) (x : A) := f x.
   Module N.
     Definition apap (A B : Set) := app (app (A:=A) (B:=B)).
-    Print app.
-    Print apap.
+    Print Term app.
+    Print Term apap.
   End N.
-  Print N.apap.
+  Print Term N.apap.
 End K.
 
-Print K.app.
-Print K.N.apap.
+Print Term K.app.
+Print Term K.N.apap.
 
 Module W := K.N.
 
-Print W.apap.
+Print Term W.apap.

--- a/test-suite/output/Arguments_renaming.v
+++ b/test-suite/output/Arguments_renaming.v
@@ -6,7 +6,7 @@ Arguments eq_refl {B y}, [B] y : rename.
 
 Check @eq_refl.
 Check (eq_refl (B := nat)).
-Print eq_refl.
+Print Term eq_refl.
 About eq_refl.
 
 Goal 3 = 3.
@@ -25,7 +25,7 @@ Variable A : Type.
 Inductive myEq B (x : A) : A -> Prop := myrefl : B -> myEq B x x.
 
 Global Arguments myrefl {C} x _ : rename.
-Print myrefl.
+Print Term myrefl.
 About myrefl.
 
 Fixpoint myplus T (t : T) (n m : nat) {struct n} :=
@@ -33,16 +33,16 @@ Fixpoint myplus T (t : T) (n m : nat) {struct n} :=
 
 Global Arguments myplus {Z} !t !n m : rename.
 
-Print myplus.
+Print Term myplus.
 About myplus.
 Check @myplus.
 
 End Test1.
-Print myrefl.
+Print Term myrefl.
 About myrefl.
 Check myrefl.
 
-Print myplus.
+Print Term myplus.
 About myplus.
 Check @myplus.
 

--- a/test-suite/output/Binder.v
+++ b/test-suite/output/Binder.v
@@ -1,7 +1,7 @@
 Definition foo '(x,y) := x + y.
-Print foo.
+Print Term foo.
 Check forall '(a,b), a /\ b.
 
 Require Import Utf8.
-Print foo.
+Print Term foo.
 Check forall '(a,b), a /\ b.

--- a/test-suite/output/Cases.v
+++ b/test-suite/output/Cases.v
@@ -5,7 +5,7 @@ Unset Printing Allow Match Default Clause.
 Inductive t : Set :=
     k : let x := t in x -> x.
 
-Print t_rect.
+Print Term t_rect.
 
 Record TT : Type := CTT { f1 := 0 : nat; f2: nat; f3 : f1=f1 }.
 
@@ -26,7 +26,7 @@ Definition proj (x y:nat) (P:nat -> Type) (def:P x) (prf:P y) : P y :=
   | _ => prf
  end.
 
-Print proj.
+Print Term proj.
 
 (* Use notations even below aliases *)
 
@@ -39,7 +39,7 @@ Fixpoint foo (A:Type) (l:list A) : option A :=
   | x0 :: (x1 :: xs) as l0 => foo A l0
   end.
 
-Print foo.
+Print Term foo.
 
 (* Accept and use notation with binded parameters *)
 
@@ -52,7 +52,7 @@ match x with
  | x <: _ => x
 end.
 
-Print uncast.
+Print Term uncast.
 
 (* Do not duplicate the matched term *)
 
@@ -64,7 +64,7 @@ Definition foo' :=
     | x => x
   end.
 
-Print foo'.
+Print Term foo'.
 
 (* Was bug #3293 (eta-expansion at "match" printing time was failing because
    of let-in's interpreted as being part of the expansion)  *)
@@ -79,7 +79,7 @@ intros [x].
 destruct b as [|] ; exact Logic.I.
 Defined.
 
-Print f.
+Print Term f.
 
 (* Was enhancement request #5142 (error message reported on the most
    general return clause heuristic) *)
@@ -135,7 +135,7 @@ let z := fresh "cc" in
 let k := fresh "dd" in
 refine (fun k : nat * nat => match k as x return x = x with (y,z) => eq_refl end).
 Qed.
-Print lem1.
+Print Term lem1.
 
 Lemma lem2 : forall k, k=k :> bool.
 let x := fresh "aa" in
@@ -144,7 +144,7 @@ let z := fresh "cc" in
 let k := fresh "dd" in
 refine (fun k => if k as x return x = x then eq_refl else eq_refl).
 Qed.
-Print lem2.
+Print Term lem2.
 
 Lemma lem3 : forall k, k=k :>nat * nat.
 let x := fresh "aa" in
@@ -153,7 +153,7 @@ let z := fresh "cc" in
 let k := fresh "dd" in
 refine (fun k : nat * nat => let (y,z) as x return x = x := k in eq_refl).
 Qed.
-Print lem3.
+Print Term lem3.
 
 Lemma lem4 x : x+0=0.
 match goal with |- ?y = _ => pose (match y with 0 => 0 | S n => 0 end) end.

--- a/test-suite/output/Implicit.v
+++ b/test-suite/output/Implicit.v
@@ -16,7 +16,7 @@ Check (ex_intro (P:=fun _ => True) (x:=0) I).
 Definition d1 y x (h : x = y :>nat) := h.
 Definition d2 x := d1 (y:=x).
 
-Print d2.
+Print Term d2.
 
 Set Strict Implicit.
 Unset Implicit Arguments.

--- a/test-suite/output/Inductive.v
+++ b/test-suite/output/Inductive.v
@@ -4,4 +4,4 @@ Fail Inductive list' (A:Set) : Set :=
 
 (* Check printing of let-ins *)
 #[universes(template)] Inductive foo (A : Type) (x : A) (y := x) := Foo.
-Print foo.
+Print Term foo.

--- a/test-suite/output/InitSyntax.v
+++ b/test-suite/output/InitSyntax.v
@@ -1,4 +1,4 @@
 (* Soumis par Pierre *)
-Print sig2.
+Print Term sig2.
 Check (exists x : nat, x = x).
 Check (fun b : bool => if b then b else b).

--- a/test-suite/output/Int63Syntax.v
+++ b/test-suite/output/Int63Syntax.v
@@ -16,9 +16,9 @@ Check 2. (* : nat *)
 Check 2%int63.
 Delimit Scope int63_scope with i63.
 Definition t := 2%int63.
-Print t.
+Print Term t.
 Delimit Scope nat_scope with int63.
-Print t.
+Print Term t.
 Check 2.
 Close Scope nat_scope.
 Check 2.

--- a/test-suite/output/Load.v
+++ b/test-suite/output/Load.v
@@ -1,7 +1,7 @@
 Load "output/load/Load_noproof.v".
-Print f.
+Print Term f.
 
 Load "output/load/Load_proof.v".
-Print u.
+Print Term u.
 
 Fail Load "output/load/Load_openproof.v".

--- a/test-suite/output/Notations2.v
+++ b/test-suite/output/Notations2.v
@@ -77,7 +77,7 @@ Open Scope list_scope.
 Notation list1 := (1::nil)%list.
 Notation plus2 n := (S (S n)).
 (* plus2 was not correctly printed in the two following tests in 8.3pl1 *)
-Print plus2.
+Print Term plus2.
 Check fun n => match n with list1 => 0 | _ => 2 end.
 Unset Printing Allow Match Default Clause.
 Check fun n => match n with list1 => 0 | _ => 2 end.

--- a/test-suite/output/Notations3.v
+++ b/test-suite/output/Notations3.v
@@ -378,7 +378,7 @@ Definition foo (l : list nat) :=
   | a :: (b :: l) as l1 => l1
   | _ => l
 end.
-Print foo.
+Print Term foo.
 End Issue7110.
 
 Module LocateNotations.

--- a/test-suite/output/PatternsInBinders.v
+++ b/test-suite/output/PatternsInBinders.v
@@ -6,27 +6,27 @@ Require Coq.Unicode.Utf8.
 Parameters (A B : Type) (P:A->Prop).
 
 Definition swap '((x,y) : A*B) := (y,x).
-Print swap.
+Print Term swap.
 
 Check fun '((x,y) : A*B) => (y,x).
 
 Check forall '(x,y), swap (x,y) = (y,x).
 
 Definition proj_informative '(exist _ x _ : { x:A | P x }) : A := x.
-Print proj_informative.
+Print Term proj_informative.
 
 Inductive Foo := Bar : nat -> bool -> unit -> nat -> Foo.
 Definition foo '(Bar n b tt p) :=
   if b then n+p else n-p.
-Print foo.
+Print Term foo.
 
 Definition baz '(Bar n1 b1 tt p1) '(Bar n2 b2 tt p2) := n1+p1.
-Print baz.
+Print Term baz.
 
 Module WithParameters.
 
 Definition swap {A B} '((x,y) : A*B) := (y,x).
-Print swap.
+Print Term swap.
 
 Check fun (A B:Type) '((x,y) : A*B) => swap (x,y) = (y,x).
 Check forall (A B:Type) '((x,y) : A*B), swap (x,y) = (y,x).
@@ -56,7 +56,7 @@ Module Suboptimal.
 #[universes(template)] Inductive Fin (n:nat) := Z : Fin n.
 Definition F '(n,p) : Type := (Fin n * Fin p)%type.
 Definition both_z '(n,p) : F (n,p) := (Z _,Z _).
-Print both_z.
+Print Term both_z.
 
 (** Test factorization of binders *)
 
@@ -70,5 +70,5 @@ Check fun pat => fun '(x,y) => x+y = pat.
 
 (** Test name in degenerate case *)
 Definition f 'x := x+x.
-Print f.
+Print Term f.
 Check fun 'x => x+x.

--- a/test-suite/output/PrintInfos.v
+++ b/test-suite/output/PrintInfos.v
@@ -1,36 +1,36 @@
 (* coq-prog-args: ("-top" "PrintInfos") *)
 About existT.
-Print existT.
+Print Term existT.
 Print Implicit existT.
 
-Print eq_refl.
+Print Term eq_refl.
 About eq_refl.
 Print Implicit eq_refl.
 
-Print Nat.add.
+Print Term Nat.add.
 About Nat.add.
 Print Implicit Nat.add.
 
 About plus_n_O.
 
 Arguments le_S {n} [m] _.
-Print le_S.
+Print Term le_S.
 
 About comparison.
-Print comparison.
+Print Term comparison.
 
 Definition foo := forall x, x = 0.
 Parameter bar : foo.
 
 Arguments bar {x}.
 About bar.
-Print bar.
+Print Term bar.
 
 About Peano. (* Module *)
 About sym_eq. (* Notation *)
 
 Arguments eq_refl {A} {x}, {A} x.
-Print eq_refl.
+Print Term eq_refl.
 
 
 Definition newdef := fun x:nat => x.

--- a/test-suite/output/PrintModule.v
+++ b/test-suite/output/PrintModule.v
@@ -56,7 +56,7 @@ Module Type Func (T:Test).
 End Func.
 
 Module Shortest_path (T : Test).
-Print Func.
+Print Term Func.
 End Shortest_path.
 
 End QUX.

--- a/test-suite/output/StringSyntax.v
+++ b/test-suite/output/StringSyntax.v
@@ -9,9 +9,9 @@ Close Scope char_scope.
 Close Scope string_scope.
 
 Open Scope byte_scope.
-Print byte_rect.
-Print byte_rec.
-Print byte_ind.
+Print Term byte_rect.
+Print Term byte_rec.
+Print Term byte_ind.
 Check "000".
 Check "a".
 Check "127".

--- a/test-suite/output/TranspModtype.v
+++ b/test-suite/output/TranspModtype.v
@@ -16,7 +16,7 @@ Module OpaqueId (X: SIG) : SIG with Definition A := X.A := X.
 Module TrM := TranspId M.
 Module OpM := OpaqueId M.
 
-Print TrM.A.
-Print OpM.A.
-Print TrM.B.
-Print OpM.B.
+Print Term TrM.A.
+Print Term OpM.A.
+Print Term TrM.B.
+Print Term OpM.B.

--- a/test-suite/output/UnivBinders.v
+++ b/test-suite/output/UnivBinders.v
@@ -6,32 +6,32 @@ Set Printing Universes.
 
 (* universe binders on inductive types and record projections *)
 Inductive Empty@{u} : Type@{u} := .
-Print Empty.
+Print Term Empty.
 
 Set Primitive Projections.
 Record PWrap@{u} (A:Type@{u}) := pwrap { punwrap : A }.
-Print PWrap.
-Print punwrap.
+Print Term PWrap.
+Print Term punwrap.
 
 Unset Primitive Projections.
 Record RWrap@{u} (A:Type@{u}) := rwrap { runwrap : A }.
-Print RWrap.
-Print runwrap.
+Print Term RWrap.
+Print Term runwrap.
 
 (* universe binders also go on the constants for operational typeclasses. *)
 Class Wrap@{u} (A:Type@{u}) := wrap : A.
-Print Wrap.
-Print wrap.
+Print Term Wrap.
+Print Term wrap.
 
 (* Instance in lemma mode used to ignore the binders. *)
 Instance bar@{u} : Wrap@{u} Set. Proof. exact nat. Qed.
-Print bar.
+Print Term bar.
 
 Unset Strict Universe Declaration.
 (* The universes in the binder come first, then the extra universes in
    order of appearance. *)
 Definition foo@{u +} := Type -> Type@{v} -> Type@{u}.
-Print foo.
+Print Term foo.
 
 Check Type@{i} -> Type@{j}.
 
@@ -41,7 +41,7 @@ Set Strict Universe Declaration.
 
 (* Binders even work with monomorphic definitions! *)
 Monomorphic Definition mono@{u} := Type@{u}.
-Print mono.
+Print Term mono.
 Check mono.
 Check Type@{mono.u}.
 
@@ -77,30 +77,30 @@ Module SecLet.
     Let ff : Type@{u}. Proof. exact Type@{v}. Qed. (* names disappear into space *)
     Definition bobmorane := tt -> ff.
   End foo.
-  Print bobmorane.
+  Print Term bobmorane.
 End SecLet.
 
 (* fun x x => foo is nonsense with local binders *)
 Fail Definition fo@{u u} := Type@{u}.
 
 (* Using local binders for printing. *)
-Print foo@{E M N}.
+Print Term foo@{E M N}.
 (* Underscores discard the name if there's one. *)
-Print foo@{_ _ _}.
+Print Term foo@{_ _ _}.
 
 (* Also works for inductives and records. *)
-Print Empty@{E}.
-Print PWrap@{E}.
+Print Term Empty@{E}.
+Print Term PWrap@{E}.
 
 (* Also works for About. *)
 About punwrap@{K}.
 
 (* Instance length check. *)
-Fail Print foo@{E}.
-Fail Print mono@{E}.
+Fail Print Term foo@{E}.
+Fail Print Term mono@{E}.
 
 (* Not everything can be printed with custom universe names. *)
-Fail Print Coq.Init.Logic@{E}.
+Fail Print Term Coq.Init.Logic@{E}.
 
 (* Nice error when constraints are impossible. *)
 Monomorphic Universes gU gV. Monomorphic Constraint gU < gV.
@@ -108,40 +108,40 @@ Fail Lemma foo@{u v|u < gU, gV < v, v < u} : nat.
 
 (* Universe binders survive through compilation, sections and modules. *)
 Require TestSuite.bind_univs.
-Print bind_univs.mono.
-Print bind_univs.poly.
+Print Term bind_univs.mono.
+Print Term bind_univs.poly.
 
 Section SomeSec.
   Universe u.
   Definition insec@{v} := Type@{u} -> Type@{v}.
-  Print insec.
+  Print Term insec.
 
   Inductive insecind@{k} := inseccstr : Type@{k} -> insecind.
-  Print insecind.
+  Print Term insecind.
 End SomeSec.
-Print insec.
-Print insecind.
+Print Term insec.
+Print Term insecind.
 
 Section SomeSec2.
   Universe u.
   Definition insec2@{} := Prop.
 End SomeSec2.
-Print insec2.
+Print Term insec2.
 
 Module SomeMod.
   Definition inmod@{u} := Type@{u}.
-  Print inmod.
+  Print Term inmod.
 End SomeMod.
-Print SomeMod.inmod.
+Print Term SomeMod.inmod.
 Import SomeMod.
-Print inmod.
+Print Term inmod.
 
 Module Type SomeTyp. Definition inmod := Type. End SomeTyp.
 Module SomeFunct (In : SomeTyp).
   Definition infunct@{u v} := In.inmod@{u} -> Type@{v}.
 End SomeFunct.
 Module Applied := SomeFunct(SomeMod).
-Print Applied.infunct.
+Print Term Applied.infunct.
 
 (* Multi-axiom declaration
 

--- a/test-suite/output/goal_output.v
+++ b/test-suite/output/goal_output.v
@@ -3,8 +3,8 @@
    - https://coq.inria.fr/bugs/show_bug.cgi?id=5537
  *)
 
-Print Nat.t.
-Timeout 1 Print Nat.t.
+Print Term Nat.t.
+Timeout 1 Print Term Nat.t.
 
 Lemma toto: False.
 Set Printing All.

--- a/test-suite/output/inference.v
+++ b/test-suite/output/inference.v
@@ -11,7 +11,7 @@ Definition P (e:option L) :=
   | Some cl => Some cl
   end.
 
-Print P.
+Print Term P.
 
 (* Check that the heuristic to solve constraints is not artificially
    dependent on the presence of a let-in, and in particular that the

--- a/test-suite/success/LetPat.v
+++ b/test-suite/success/LetPat.v
@@ -2,16 +2,16 @@
 Variable A B : Type.
 
 Definition l1 (t : A * B * B) : A := let '(x, y, z) := t in x.
-Print l1.
+Print Term l1.
 Definition l2 (t : (A * B) * B) : A := let '((x, y), z) := t in x.
 Definition l3 (t : A * (B * B)) : A := let '(x, (y, z)) := t in x.
-Print l3.
+Print Term l3.
 
 Record someT (A : Type) := mkT { a : nat; b: A }.
 
 Definition l4 A (t : someT A) : nat := let 'mkT _ x y := t in x.
-Print l4.
-Print sigT.
+Print Term l4.
+Print Term sigT.
 
 Definition l5 A (B : A -> Type) (t : sigT B) : B (projT1 t) :=
   let 'existT _ x y := t return B (projT1 t) in y.

--- a/test-suite/success/Mod_type.v
+++ b/test-suite/success/Mod_type.v
@@ -28,4 +28,4 @@ Module C.
   Notation "! x" := (c2 x) (at level 50).
 End C.
 
-Print C. (* Should print test_rect without failing *)
+Print Term C. (* Should print test_rect without failing *)

--- a/test-suite/success/ProgramWf.v
+++ b/test-suite/success/ProgramWf.v
@@ -9,7 +9,7 @@ Require Import ZArith Zwf.
 
 Set Implicit Arguments.
 (* Set Printing All. *)
-Print sigT_rect.
+Print Term sigT_rect.
 Obligation Tactic := program_simplify ; auto with *.
 About MR.
 
@@ -19,11 +19,11 @@ Program Fixpoint merge (n m : nat) {measure (n + m) lt} : nat :=
     | S n' => merge n' m
   end.
 
-Print merge.
+Print Term merge.
 
 
-Print Z.lt.
-Print Zwf.
+Print Term Z.lt.
+Print Term Zwf.
 
 Local Open Scope Z_scope.
 
@@ -44,7 +44,7 @@ Program Fixpoint merge_wf (n m : nat) {wf lt m} : nat :=
     | S n' => merge n' m
   end.
 
-Print merge_wf.
+Print Term merge_wf.
 
 Program Fixpoint merge_one (n : nat) {measure n} : nat :=
   match n with
@@ -53,7 +53,7 @@ Program Fixpoint merge_one (n : nat) {measure n} : nat :=
   end.
 
 Print Hint well_founded.
-Print merge_one. Eval cbv delta [merge_one] beta zeta in merge_one.
+Print Term merge_one. Eval cbv delta [merge_one] beta zeta in merge_one.
 
 Import WfExtensionality.
 
@@ -67,7 +67,7 @@ Proof. intros. unfold merge at 1. unfold merge_func.
   simpl. destruct n ; reflexivity. 
 Qed.
 
-Print merge.
+Print Term merge.
 
 Require Import Arith.
 Unset Implicit Arguments.

--- a/test-suite/success/RecTutorial.v
+++ b/test-suite/success/RecTutorial.v
@@ -9,10 +9,10 @@ Check S.
 
 End LocalNat.
 
-Print nat.
+Print Term nat.
 
 
-Print le.
+Print Term le.
 
 Theorem zero_leq_three: 0 <= 3.
 
@@ -24,7 +24,7 @@ Proof.
 
 Qed.
 
-Print zero_leq_three.
+Print Term zero_leq_three.
 
 
 Lemma zero_leq_three': 0 <= 3.
@@ -41,7 +41,7 @@ Qed.
 
 Require Import List.
 
-Print list.
+Print Term list.
 
 Check list.
 
@@ -58,7 +58,7 @@ Check (cons 3 (cons 2 nil)).
 
 Require Import Bvector.
 
-Print Vector.t.
+Print Term Vector.t.
 
 Check (Vector.nil nat).
 
@@ -82,13 +82,13 @@ Lemma eq_3_3 : 2 + 1 = 3.
 Proof.
  reflexivity.
 Qed.
-Print eq_3_3.
+Print Term eq_3_3.
 
 Lemma eq_proof_proof : refl_equal (2*6) = refl_equal (3*4).
 Proof.
  reflexivity.
 Qed.
-Print eq_proof_proof.
+Print Term eq_proof_proof.
 
 Lemma eq_lt_le : ( 2 < 4) = (3 <= 4).
 Proof.
@@ -121,14 +121,14 @@ reflexivity.
 Qed.
 
 
-Print or.
+Print Term or.
 
-Print and.
+Print Term and.
 
 
-Print sumbool.
+Print Term sumbool.
 
-Print ex.
+Print Term ex.
 
 Require Import ZArith.
 Require Import Compare_dec.
@@ -220,7 +220,7 @@ end.
   unfold pred_spec; intro n0;exists n0; auto.
  Defined.
 
-Print predecessor.
+Print Term predecessor.
 
 Extraction predecessor.
 
@@ -507,7 +507,7 @@ Elimination of an inductive object of sort "Prop"
 is not allowed on a predicate in sort "Type"
 because proofs can be eliminated only to build proofs
 *)
-Print prop_inject.
+Print Term prop_inject.
 
 (*
 prop_inject =
@@ -855,7 +855,7 @@ Definition eq_nat_dec' : forall n p:nat, {n=p}+{n <> p}.
  decide equality.
 Defined.
 
-Print Acc.
+Print Term Acc.
 
 
 Require Import Minus.
@@ -909,7 +909,7 @@ Proof.
  apply Hz; apply minus_smaller_positive; assumption.
 Defined.
 
-Print minus_decrease.
+Print Term minus_decrease.
 
 
 
@@ -923,7 +923,7 @@ Fixpoint div_aux (x y:nat)(H: Acc lt x):nat.
 Defined.
 
 
-Print div_aux.
+Print Term div_aux.
 (*
 div_aux =
 (fix div_aux (x y : nat) (H : Acc lt x) {struct H} : nat :=

--- a/test-suite/success/Typeclasses.v
+++ b/test-suite/success/Typeclasses.v
@@ -127,7 +127,7 @@ Record Monad {m : Type -> Type} := {
   bind_unit_left : forall {α β} (a : α) (f : α -> m β), return a >>= f = f a }.
 
 Print Visibility.
-Print unit.
+Print Term unit.
 Arguments unit {m m0 α}.
 Arguments Monad : clear implicits.
 Notation "'return' t" := (unit t).

--- a/test-suite/success/bteauto.v
+++ b/test-suite/success/bteauto.v
@@ -30,7 +30,7 @@ Module Backtracking.
     Show Proof.  
   Qed.
 
-  Print find42.
+  Print Term find42.
   
   Hint Extern 0 (_ = _) => reflexivity : equality.
   

--- a/test-suite/success/coercions.v
+++ b/test-suite/success/coercions.v
@@ -153,7 +153,7 @@ Module TestPropAsSourceCoercion.
 
   Definition test := heap_single 4 5 \* (5 <> 4) \* heap_single 2 4 \* (True).
 
-  (* Print test. -- reveals [hpure] coercions *)
+  (* Print Term test. -- reveals [hpure] coercions *)
 
 End TestPropAsSourceCoercion.
 

--- a/test-suite/success/polymorphism.v
+++ b/test-suite/success/polymorphism.v
@@ -104,7 +104,7 @@ Module Easy.
   Polymorphic Inductive sum (A B:Type) : Type :=
   | inl : A -> sum A B
   | inr : B -> sum A B.
-  Print sum.
+  Print Term sum.
   Check (sum nat nat).
 
 End Easy.
@@ -318,7 +318,7 @@ End S.
 Check f nat nat : Set.
 *)
 Definition foo' := I nat nat.
-Print Universes. Print foo. Set Printing Universes. Print foo.
+Print Universes. Print Term foo. Set Printing Universes. Print Term foo.
 
 (* Polymorphic axioms: *)
 Polymorphic Axiom funext : forall (A B : Type) (f g : A -> B), 

--- a/test-suite/success/unicode_utf8.v
+++ b/test-suite/success/unicode_utf8.v
@@ -99,7 +99,4 @@ intros _.
 exists x; auto.
 Defined.
 
-Print pred.
-
-
-
+Print Term pred.

--- a/test-suite/success/vm_univ_poly_match.v
+++ b/test-suite/success/vm_univ_poly_match.v
@@ -22,7 +22,7 @@ Global Instance Applicative_option : Applicative@{Uo Ua} option :=
 
 Definition foo := ap (ap (pure plus) (pure 1)) (pure 1).
 
-Print foo.
+Print Term foo.
 
 
 Eval vm_compute in foo.

--- a/test-suite/typeclasses/NewSetoid.v
+++ b/test-suite/typeclasses/NewSetoid.v
@@ -29,12 +29,12 @@ Defined.
 
 Definition reduced_thm := Eval compute in Unnamed_thm.
 
-(* Print reduced_thm. *)
+(* Print Term reduced_thm. *)
 
 Lemma foo [ Setoid a R ] : True. (* forall x y, R x y -> x -> y. *)
 Proof.
   intros.
-  Print respect2.
+  Print Term respect2.
   pose setoid_morphism.
   pose (respect2 (b0:=b)).
   simpl in b0.
@@ -52,7 +52,7 @@ Qed.
 Goal forall A B C (H : A <-> B) (H' : B <-> C), A /\ B <-> B /\ C.
   intros.
   Set Printing All.
-  Print iff_morphism.
+  Print Term iff_morphism.
   clrewrite H.
   clrewrite H'.
   reflexivity.
@@ -68,7 +68,5 @@ Defined.
 Require Import Setoid_tac.
 Require Import Setoid_Prop.
 
-(* Print Unnamed_thm0. *)
-(* Print Unnamed_thm1. *)
-
-
+(* Print Term Unnamed_thm0. *)
+(* Print Term Unnamed_thm1. *)

--- a/test-suite/typeclasses/clrewrite.v
+++ b/test-suite/typeclasses/clrewrite.v
@@ -41,7 +41,7 @@ Section Equiv.
 
   Opaque complement.
 
-  Print iff_inverse_impl_binary_morphism.
+  Print Term iff_inverse_impl_binary_morphism.
 
   Goal eqA x y -> eqA x y -> eqA x y.
     intros H.

--- a/test-suite/vio/print.v
+++ b/test-suite/vio/print.v
@@ -4,7 +4,7 @@ idtac.
 exact I.
 Qed.
 
-Print a.
+Print Term a.
 
 Lemma b : False.
 Admitted.

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -953,7 +953,7 @@ GRAMMAR EXTEND Gram
 
       (* Printing (careful factorization of entries) *)
       | IDENT "Print"; p = printable -> { VernacPrint p }
-      | IDENT "Print"; qid = smart_global; l = OPT univ_name_list -> { VernacPrint (PrintName (qid,l)) }
+      | IDENT "Print"; qid = smart_global; l = OPT univ_name_list -> { VernacPrint (PrintName (true, qid, l)) }
       | IDENT "Print"; IDENT "Module"; "Type"; qid = global ->
 	  { VernacPrint (PrintModuleType qid) }
       | IDENT "Print"; IDENT "Module"; qid = global ->
@@ -1023,7 +1023,7 @@ GRAMMAR EXTEND Gram
       ] ]
   ;
   printable:
-    [ [ IDENT "Term"; qid = smart_global; l = OPT univ_name_list -> { PrintName (qid,l) }
+    [ [ IDENT "Term"; qid = smart_global; l = OPT univ_name_list -> { PrintName (false, qid, l) }
       | IDENT "All" -> { PrintFullContext }
       | IDENT "Section"; s = global -> { PrintSectionContext s }
       | IDENT "Grammar"; ent = IDENT ->

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -533,8 +533,8 @@ let string_of_theorem_kind = let open Decls in function
       in
       let pr_subgraph = prlist_with_sep spc pr_qualid in
       keyword cmd ++ pr_opt pr_subgraph g ++ pr_opt str fopt
-    | PrintName (qid,udecl) ->
-      keyword "Print" ++ spc()  ++ pr_smart_global qid ++ pr_univ_name_list udecl
+    | PrintName (_, qid, udecl) ->
+      keyword "Print Term" ++ spc()  ++ pr_smart_global qid ++ pr_univ_name_list udecl
     | PrintModuleType qid ->
       keyword "Print Module Type" ++ spc() ++ pr_qualid qid
     | PrintModule qid ->

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1949,6 +1949,12 @@ let print_about_hyp_globs ~pstate ?loc ref_or_by_not udecl glopt =
     let sigma, env = get_current_or_global_context ~pstate in
     print_about env sigma ref_or_by_not udecl
 
+let warn_unqualified_print =
+  let name = "unqualified-print" in
+  let category = "deprecated" in
+  CWarnings.create ~name ~category
+    (fun () -> strbrk "Use of “Print qualid” is deprecated: use “Print Term qualid” instead.")
+
 let vernac_print ~pstate ~atts =
   let sigma, env = get_current_or_global_context ~pstate in
   function
@@ -1967,7 +1973,8 @@ let vernac_print ~pstate ~atts =
   | PrintMLLoadPath -> Mltop.print_ml_path ()
   | PrintMLModules -> Mltop.print_ml_modules ()
   | PrintDebugGC -> Mltop.print_gc ()
-  | PrintName (qid,udecl) ->
+  | PrintName (d, qid,udecl) ->
+    if d then warn_unqualified_print ();
     dump_global qid;
     print_name env sigma qid udecl
   | PrintGraph -> Prettyp.print_graph ()

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -39,7 +39,7 @@ type printable =
   | PrintMLLoadPath
   | PrintMLModules
   | PrintDebugGC
-  | PrintName of qualid or_by_notation * UnivNames.univ_name_list option
+  | PrintName of bool (* use deprecated form *) * qualid or_by_notation * UnivNames.univ_name_list option
   | PrintGraph
   | PrintClasses
   | PrintTypeClasses


### PR DESCRIPTION
Using “Print qualid” sometimes produces strange errors, as reported in #10708. 

- [x] Added / updated test-suite
- [x] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [ ] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
