### PR TITLE
Ocfnash/stdlib additions

### DIFF
--- a/doc/changelog/10-standard-library/10651-new-lemmas-for-lists.rst
+++ b/doc/changelog/10-standard-library/10651-new-lemmas-for-lists.rst
@@ -1,4 +1,6 @@
-- New lemmas on :g:`combine`, :g:`filter`, and :g:`nodup` functions on lists. The lemma
-  :g:`filter_app` was moved to the :g:`List` module.
+- New lemmas on :g:`combine`, :g:`filter`, :g:`nodup`, :g:`nth`, and
+  :g:`nth_error` functions on lists. The lemma :g:`filter_app` was moved to the
+  :g:`List` module.
 
-  See `#10651 <https://github.com/coq/coq/pull/10651>`_, by Oliver Nash.
+  See `#10651 <https://github.com/coq/coq/pull/10651>`_, and
+  `#10731 <https://github.com/coq/coq/pull/10731>`_, by Oliver Nash.

--- a/theories/Lists/List.v
+++ b/theories/Lists/List.v
@@ -536,6 +536,26 @@ Section Elts.
     simpl in *. apply IHn. auto with arith.
   Qed.
 
+  (** Results directly relating [nth] and [nth_error] *)
+
+  Lemma nth_error_nth : forall (l : list A) (n : nat) (x d : A),
+    nth_error l n = Some x -> nth n l d = x.
+  Proof.
+    intros l n x d H.
+    apply nth_error_split in H. destruct H as [l1 [l2 [H H']]].
+    subst. rewrite app_nth2; [|auto].
+    rewrite Nat.sub_diag. reflexivity.
+  Qed.
+
+  Lemma nth_error_nth' : forall (l : list A) (n : nat) (d : A),
+    n < length l -> nth_error l n = Some (nth n l d).
+  Proof.
+    intros l n d H.
+    apply nth_split with (d:=d) in H. destruct H as [l1 [l2 [H H']]].
+    subst. rewrite H. rewrite nth_error_app2; [|auto].
+    rewrite app_nth2; [| auto]. repeat (rewrite Nat.sub_diag). reflexivity.
+  Qed.
+
   (*****************)
   (** ** Remove    *)
   (*****************)

--- a/theories/Lists/List.v
+++ b/theories/Lists/List.v
@@ -1234,11 +1234,11 @@ End Fold_Right_Recursor.
       destruct (f x); simpl; now rewrite IH.
     Qed.
 
-    Lemma concat_filter_map : forall (l : list (list A)) (f : A -> bool),
+    Lemma concat_filter_map : forall (l : list (list A)),
       concat (map filter l) = filter (concat l).
     Proof.
       induction l as [| v l IHl]; [auto|].
-      simpl. rewrite (IHl f). rewrite filter_app. reflexivity.
+      simpl. rewrite IHl. rewrite filter_app. reflexivity.
     Qed.
 
   (** [find] *)


### PR DESCRIPTION
**Kind:** feature

There are two unrelated changes here, one in each commit:
  1. The first addresses this helpful comment of @anton-trunov https://github.com/coq/coq/pull/10651#discussion_r320171438
  2. The second adds two stdlib lemmas useful for translating between `List.nth` and `List.nth_error`

- [x] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).