### PR TITLE
`Add Field` no longer calls `Add Ring`

### DIFF
--- a/doc/changelog/07-commands-and-options/10734-add-field-no-add-ring.rst
+++ b/doc/changelog/07-commands-and-options/10734-add-field-no-add-ring.rst
@@ -1,0 +1,6 @@
+- **Changed:**
+  The :cmd:`Add Field` no longer declares ring structures. This was
+  undocumented and less flexible than letting the user define her ring
+  instances. Also, user-defined ring instances could be erased by field
+  declarations (`#10734 <https://github.com/coq/coq/pull/10734>`_,
+  by Maxime Dénès).

--- a/plugins/setoid_ring/RealField.v
+++ b/plugins/setoid_ring/RealField.v
@@ -17,7 +17,7 @@ Require Import Raxioms.
 
 Local Open Scope R_scope.
 
-Lemma RTheory : ring_theory 0 1 Rplus Rmult Rminus Ropp (eq (A:=R)).
+Lemma Rring : ring_theory 0 1 Rplus Rmult Rminus Ropp (eq (A:=R)).
 Proof.
 constructor.
  intro; apply Rplus_0_l.
@@ -38,7 +38,7 @@ Qed.
 Lemma Rfield : field_theory 0 1 Rplus Rmult Rminus Ropp Rdiv Rinv (eq(A:=R)).
 Proof.
 constructor.
- exact RTheory.
+ exact Rring.
  exact R1_neq_R0.
  reflexivity.
  exact Rinv_l.
@@ -86,12 +86,12 @@ induction x; simpl; intros.
   rewrite Rplus_comm.
     apply Rlt_n_Sn.
   apply Rplus_lt_compat_l.
-    rewrite <- (Rmul_0_l Rset Rext RTheory 2).
+    rewrite <- (Rmul_0_l Rset Rext Rring 2).
     rewrite Rmult_comm.
     apply Rmult_lt_compat_l.
    apply Rlt_0_2.
    trivial.
- rewrite <- (Rmul_0_l Rset Rext RTheory 2).
+ rewrite <- (Rmul_0_l Rset Rext Rring 2).
    rewrite Rmult_comm.
    apply Rmult_lt_compat_l.
   apply Rlt_0_2.
@@ -153,6 +153,9 @@ Ltac IZR_tac t :=
     end
   | _ => constr:(InitialRing.NotConstant)
   end.
+
+Add Ring RRing : Rring
+   (constants [IZR_tac], power_tac R_power_theory [Rpow_tac]).
 
 Add Field RField : Rfield
    (completeness Zeq_bool_complete, constants [IZR_tac], power_tac R_power_theory [Rpow_tac]).

--- a/plugins/setoid_ring/newring.ml
+++ b/plugins/setoid_ring/newring.ml
@@ -884,8 +884,6 @@ let add_field_theory0 name fth eqth morphth cst_tac inj (pre,post) power sign od
   let (kind,r,zero,one,add,mul,sub,opp,div,inv,req,rth) =
     dest_field env evd fth in
   let (sth,ext) = build_setoid_params env evd r add mul opp req eqth in
-  let eqth = Some(sth,ext) in
-  let _ = add_theory0 name (!evd,rth) eqth morphth cst_tac (None,None) power sign odiv in
   let (pow_tac, pspec) = interp_power env evd power in
   let sspec = interp_sign env evd sign in
   let dspec = interp_div env evd odiv in

--- a/theories/QArith/Qcanon.v
+++ b/theories/QArith/Qcanon.v
@@ -533,6 +533,7 @@ Proof.
   exact Qcmult_inv_l.
 Qed.
 
+Add Ring Qcring : Qcrt.
 Add Field Qcfield : Qcft.
 
 (** A field tactic for rational numbers *)

--- a/theories/QArith/Qfield.v
+++ b/theories/QArith/Qfield.v
@@ -73,6 +73,11 @@ Ltac Qpow_tac t :=
   | _ => NotConstant
   end.
 
+Add Ring Qring : Qsrt
+ (decidable Qeq_bool_eq,
+  constants [Qcst],
+  power_tac Qpower_theory [Qpow_tac]).
+
 Add Field Qfield : Qsft
  (decidable Qeq_bool_eq,
   completeness Qeq_eq_bool,

--- a/theories/Reals/RIneq.v
+++ b/theories/Reals/RIneq.v
@@ -2051,6 +2051,9 @@ apply Zeq_is_eq_bool.
 now apply eq_IZR.
 Qed.
 
+Add Ring Rring : Rring
+  (morphism R_rm, constants [IZR_tac], power_tac R_power_theory [Rpow_tac]).
+
 Add Field RField : Rfield
   (completeness Zeq_bool_IZR, morphism R_rm, constants [IZR_tac], power_tac R_power_theory [Rpow_tac]).
 


### PR DESCRIPTION
This was undocumented and less flexible than letting the user define her
ring instances. Also, user-defined ring instances could be erased by
field declarations.