### PR TITLE
More precise error messages for `Add Ring`

### DIFF
--- a/plugins/setoid_ring/InitialRing.v
+++ b/plugins/setoid_ring/InitialRing.v
@@ -828,31 +828,31 @@ Ltac ring_elements set ext rspec pspec sspec dspec rk :=
     end in
   ring_elements set ext rspec pspec sspec dspec rk
     ltac:(fun arth ext_r morph p_spec s_spec d_spec =>
-       match type of morph with
+       lazymatch type of morph with
        | @ring_morph ?R ?r0 ?rI ?radd ?rmul ?rsub ?ropp ?req
                ?C ?c0 ?c1 ?cadd ?cmul ?csub ?copp ?ceq_b ?phi =>
           let gen_lemma2_0 :=
               constr:(gen_lemma2 R  r0 rI  radd rmul rsub ropp req set ext_r arth
                                 C  c0 c1 cadd cmul csub copp ceq_b phi morph) in
-          match p_spec with
+          lazymatch p_spec with
           | @mkhypo (power_theory _ _ _ ?Cp_phi ?rpow) ?pp_spec =>
              let gen_lemma2_1 := constr:(gen_lemma2_0 _ Cp_phi rpow pp_spec) in
-             match d_spec with
+             lazymatch d_spec with
              | @mkhypo (div_theory _ _ _ _  ?cdiv) ?dd_spec =>
                 let gen_lemma2_2 := constr:(gen_lemma2_1 cdiv dd_spec) in
-                match s_spec with
+                lazymatch s_spec with
                 | @mkhypo (sign_theory _ _ ?get_sign) ?ss_spec =>
                   let lemma2 := constr:(gen_lemma2_2 get_sign ss_spec) in
                   let lemma1 :=
                     constr:(ring_correct set ext_r arth morph pp_spec dd_spec) in
                   fun f => f arth ext_r morph lemma1 lemma2
-                | _ => fail 4 "ring: bad sign specification"
+                | _ => fail "ring: bad sign specification"
                 end
-             | _ => fail 3 "ring: bad coefficient division specification"
+             | _ => fail "ring: bad coefficient division specification"
              end
-          | _ => fail 2 "ring: bad power specification"
+          | _ => fail "ring: bad power specification"
           end
-       | _ => fail 1 "ring internal error: ring_lemmas, please report"
+       | _ => fail "ring internal error: ring_lemmas, please report"
        end).
 
 (* Tactic for constant *)


### PR DESCRIPTION
Consider this example of four incorrect usages of `Add Ring`:

```coq
Require Import Coq.ZArith.ZArith.
Require Import Coq.setoid_ring.Ring.
Require Import Coq.setoid_ring.Ring_theory.
Open Scope Z_scope.

Axiom T: Type.
Axiom of_Z: Z -> T.
Axiom add: T -> T -> T.
Axiom mul: T -> T -> T.
Axiom sub: T -> T -> T.
Axiom opp: T -> T.
Axiom pow: T -> N -> T.

Axiom T_ring_theory: ring_theory (of_Z 0) (of_Z 1) add mul sub opp Logic.eq.

Axiom T_power_theory:   power_theory (of_Z 1) mul Logic.eq (@id N) pow.
Axiom bad_power_theory: power_theory (of_Z 1) add Logic.eq (@id N) pow.
Axiom T_div_theory: div_theory Logic.eq Z.add Z.mul of_Z Z.div_eucl.
Axiom T_ring_morph: ring_morph (of_Z 0) (of_Z 1) add   mul   sub   opp   Logic.eq
                               0        1        Z.add Z.mul Z.sub Z.opp Zbool.Zeq_bool of_Z.
Axiom bad_ring_morph: ring_morph (of_Z 0) (of_Z 1) mul   add   sub   opp   Logic.eq
                                 0        1        Z.add Z.mul Z.sub Z.opp Zbool.Zeq_bool of_Z.

Axiom bad_ring_morph_for_sign: ring_morph (of_Z 0) (of_Z 1) add   mul   sub   opp   Logic.eq
                                          0        1        Z.add Z.mul Z.sub Z.opp Z.eqb of_Z.
Axiom T_sign_theory: sign_theory Z.opp Zeq_bool get_signZ.

(* sign error: *)
Fail Add Ring myring1: T_ring_theory (morphism bad_ring_morph_for_sign, sign T_sign_theory).
Add Ring myring1: T_ring_theory (morphism T_ring_morph, sign T_sign_theory).

(* div error: *)
Fail Add Ring myring2: T_ring_theory (div T_div_theory).
Add Ring myring2: T_ring_theory (morphism T_ring_morph, div T_div_theory).

(* power_tac error: *)
Fail Add Ring myring3: T_ring_theory (power_tac bad_power_theory [idtac]).
Add Ring myring3: T_ring_theory (power_tac T_power_theory [idtac]).

(* morphism error: *)
Fail Add Ring myring4: T_ring_theory (morphism bad_ring_morph).
Add Ring myring4: T_ring_theory (morphism T_ring_morph).
```

Currently, it's quite hard to find out what the error is, because the error messages are not very precise:

```
Tactic failure: ring: bad sign specification.

Tactic failure: ring: bad coefficient division specification.

Tactic failure: ring: bad power specification.

Tactic failure: ring internal error: ring_lemmas, please report.
```

With this PR, the error messages become much more precise:

```
The term "T_sign_theory" has type "sign_theory Z.opp Zeq_bool get_signZ"
while it is expected to have type "sign_theory Z.opp Z.eqb get_signZ".

The term "T_div_theory" has type "div_theory eq Z.add Z.mul of_Z Z.div_eucl"
while it is expected to have type "div_theory eq Z.add Z.mul (gen_phiZ (of_Z 0) (of_Z 1) add mul opp) Z.div_eucl".

The term "bad_power_theory" has type "power_theory (of_Z 1) add eq id pow"
while it is expected to have type "power_theory (of_Z 1) mul eq id pow".

The term "Eq_ext add mul opp" has type "ring_eq_ext add mul opp eq"
while it is expected to have type "ring_eq_ext mul add opp eq".
```

Doing this change (thanks @JasonGross for the suggestion!) was actually the only way for me to find out what was wrong in the first example above.
