### PR TITLE
Fix #10757: Program Fixpoint uses "exists" for telescopes

### DIFF
--- a/doc/changelog/02-specification-language/10758-fix-10757.rst
+++ b/doc/changelog/02-specification-language/10758-fix-10757.rst
@@ -1,0 +1,5 @@
+- ``Program Fixpoint`` now uses ``ex`` and ``sig`` to make telescopes
+  involving ``Prop`` types (`#10758
+  <https://github.com/coq/coq/pull/10758>`_, by Gaëtan Gilbert, fixing
+  `#10757 <https://github.com/coq/coq/issues/10757>`_ reported by
+  Xavier Leroy).

--- a/test-suite/bugs/closed/bug_10757.v
+++ b/test-suite/bugs/closed/bug_10757.v
@@ -1,0 +1,38 @@
+Require Import Program Extraction ExtrOcamlBasic.
+Print sig.
+Section FIXPOINT.
+
+Variable A: Type.
+
+Variable eq: A -> A -> Prop.
+Variable beq: A -> A -> bool.
+Hypothesis beq_eq: forall x y, beq x y = true -> eq x y.
+Hypothesis beq_neq: forall x y, beq x y = false -> ~eq x y.
+
+Variable le: A -> A -> Prop.
+Hypothesis le_trans: forall x y z, le x y -> le y z -> le x z.
+
+Definition gt (x y: A) := le y x /\ ~eq y x.
+Hypothesis gt_wf: well_founded gt.
+
+Variable F: A -> A.
+Hypothesis F_mon: forall x y, le x y -> le (F x) (F y).
+
+Program Fixpoint iterate
+    (x: A) (PRE: le x (F x)) (SMALL: forall z, le (F z) z -> le x z)
+    {wf gt x}
+    : {y : A | eq y (F y) /\ forall z, le (F z) z -> le y z } :=
+  let x' := F x in
+  match beq x x' with
+  | true  => x
+  | false => iterate x' _ _
+  end.
+Next Obligation.
+  split.
+- auto.
+- apply beq_neq. auto.
+Qed.
+
+End FIXPOINT.
+
+Recursive Extraction iterate.

--- a/theories/Init/Logic.v
+++ b/theories/Init/Logic.v
@@ -274,6 +274,22 @@ Inductive ex (A:Type) (P:A -> Prop) : Prop :=
   ex_intro : forall x:A, P x -> ex (A:=A) P.
 
 Register ex as core.ex.type.
+Register ex_intro as core.ex.intro.
+
+Section Projections.
+
+  Variables (A:Prop) (P:A->Prop).
+
+  Definition ex_proj1 (x:ex P) : A :=
+    match x with ex_intro _ a _ => a end.
+
+  Definition ex_proj2 (x:ex P) : P (ex_proj1 x) :=
+    match x with ex_intro _ _ b => b end.
+
+  Register ex_proj1 as core.ex.proj1.
+  Register ex_proj2 as core.ex.proj2.
+
+End Projections.
 
 Inductive ex2 (A:Type) (P Q:A -> Prop) : Prop :=
   ex_intro2 : forall x:A, P x -> Q x -> ex2 (A:=A) P Q.


### PR DESCRIPTION
This helps extraction by not building sigT which can lower to Prop by
template polymorphism.

Bug #10757 can probably still be triggered by using module functors to
hide that we're using Prop from Program Fixpoint but that's probably
unfixable without fixing extraction vs template polymorphism in
general.

In passing we notice that Program doesn't know how to telescope SProp
arguments, we would need a bunch of variants of sigma types to deal
with it (or use Box?) so let's figure it out some other time.

We also reuse the universe instance to avoid generating a bunch of
short-lived universes in the universe polymorphic case.
