### PR TITLE
Make rapply handle all numbers of underscores

### DIFF
--- a/dev/ci/user-overlays/10760-JasonGross-more-rapply.sh
+++ b/dev/ci/user-overlays/10760-JasonGross-more-rapply.sh
@@ -1,0 +1,7 @@
+if [ "$CI_PULL_REQUEST" = "10760" ] || [ "$CI_BRANCH" = "more-rapply" ]; then
+
+    math_classes_CI_BRANCH=fix-for-more-rapply-10760
+    math_classes_CI_REF=fix-for-more-rapply-10760
+    math_classes_CI_GITURL=https://github.com/JasonGross/math-classes
+
+fi

--- a/dev/ci/user-overlays/10760-JasonGross-more-rapply.sh
+++ b/dev/ci/user-overlays/10760-JasonGross-more-rapply.sh
@@ -1,7 +1,0 @@
-if [ "$CI_PULL_REQUEST" = "10760" ] || [ "$CI_BRANCH" = "more-rapply" ]; then
-
-    math_classes_CI_BRANCH=fix-for-more-rapply-10760
-    math_classes_CI_REF=fix-for-more-rapply-10760
-    math_classes_CI_GITURL=https://github.com/JasonGross/math-classes
-
-fi

--- a/doc/changelog/04-tactics/10760-more-rapply.rst
+++ b/doc/changelog/04-tactics/10760-more-rapply.rst
@@ -1,0 +1,19 @@
+- The tactic :tacn:`rapply` in :g:`Coq.Program.Tactics` now handles
+  arbitrary numbers of underscores and takes in a :g:`uconstr`.  In
+  rare cases where users were relying on :tacn:`rapply` inserting
+  exactly 15 underscores and no more, due to the lemma having a
+  completely unspecified codomain (and thus allowing for any number of
+  underscores), the tactic will now instead loop.  Additional
+  incompatibility may occur in cases where it was important to
+  interpret the lemma passed in to :tacn:`rapply` as a :g:`constr`
+  (thus failing on unresolved holes and resolving typeclasses before
+  adding arguments) before refining with it.  Users may work around
+  this by replacing all invocations of :tacn:`rapply` with the
+  qualified :g:`Tactics.rapply` to get the underlying tactic rather
+  than the tactic notation.  Finally, any users who defined their own
+  tactic :tacn:`rapply` and also imported :g:`Coq.Program.Tactics` may
+  see incompatibilities due to the fact that :g:`Coq.Program.Tactics`
+  now defines an :tacn:`rapply` as a :cmd:`Tactic Notation`.  Users
+  can work around this by defining their :tacn:`rapply` as a
+  :cmd:`Tactic Notation` as well. (`#10760
+  <https://github.com/coq/coq/pull/10760>`_, by Jason Gross)

--- a/doc/changelog/04-tactics/10760-more-rapply.rst
+++ b/doc/changelog/04-tactics/10760-more-rapply.rst
@@ -3,17 +3,5 @@
   rare cases where users were relying on :tacn:`rapply` inserting
   exactly 15 underscores and no more, due to the lemma having a
   completely unspecified codomain (and thus allowing for any number of
-  underscores), the tactic will now instead loop.  Additional
-  incompatibility may occur in cases where it was important to
-  interpret the lemma passed in to :tacn:`rapply` as a :g:`constr`
-  (thus failing on unresolved holes and resolving typeclasses before
-  adding arguments) before refining with it.  Users may work around
-  this by replacing all invocations of :tacn:`rapply` with the
-  qualified :g:`Tactics.rapply` to get the underlying tactic rather
-  than the tactic notation.  Finally, any users who defined their own
-  tactic :tacn:`rapply` and also imported :g:`Coq.Program.Tactics` may
-  see incompatibilities due to the fact that :g:`Coq.Program.Tactics`
-  now defines an :tacn:`rapply` as a :cmd:`Tactic Notation`.  Users
-  can work around this by defining their :tacn:`rapply` as a
-  :cmd:`Tactic Notation` as well. (`#10760
+  underscores), the tactic will now instead loop. (`#10760
   <https://github.com/coq/coq/pull/10760>`_, by Jason Gross)

--- a/doc/sphinx/proof-engine/tactics.rst
+++ b/doc/sphinx/proof-engine/tactics.rst
@@ -692,11 +692,17 @@ Applying theorems
       uses the proof engine of :tacn:`refine` for dealing with
       existential variables, holes, and conversion problems.  This may
       result in slightly different behavior regarding which conversion
-      problems are solvable.  Note that :tacn:`rapply` prefers to
-      instantiate as many hypotheses of :n:`@term` as possible.  As a
-      result, if it is possible to apply :n:`@term` to arbitrarily
-      many arguments without getting a type error, :tacn:`rapply` will
-      loop.
+      problems are solvable.  However, like :tacn:`apply` but unlike
+      :tacn:`eapply`, :tacn:`rapply` will fail if there are any holes
+      which remain in :n:`@term` itself after typechecking and
+      typeclass resolution but before unification with the goal.  More
+      technically, :n:`@term` is first parsed as a
+      :production:`constr` rather than as a :production:`uconstr` or
+      :production:`open_constr` before being applied to the goal. Note
+      that :tacn:`rapply` prefers to instantiate as many hypotheses of
+      :n:`@term` as possible.  As a result, if it is possible to apply
+      :n:`@term` to arbitrarily many arguments without getting a type
+      error, :tacn:`rapply` will loop.
 
       Note that you need to :n:`Require Import Coq.Program.Tactics` to
       make use of :tacn:`rapply`.

--- a/doc/sphinx/proof-engine/tactics.rst
+++ b/doc/sphinx/proof-engine/tactics.rst
@@ -685,6 +685,22 @@ Applying theorems
       instantiate (see :ref:`Existential-Variables`). The instantiation is
       intended to be found later in the proof.
 
+   .. tacv:: rapply @term
+      :name: rapply
+
+      The tactic :tacn:`rapply` behaves like :tacn:`eapply` but it
+      uses the proof engine of :tacn:`refine` for dealing with
+      existential variables, holes, and conversion problems.  This may
+      result in slightly different behavior regarding which conversion
+      problems are solvable.  Note that :tacn:`rapply` prefers to
+      instantiate as many hypotheses of :n:`@term` as possible.  As a
+      result, if it is possible to apply :n:`@term` to arbitrarily
+      many arguments without getting a type error, :tacn:`rapply` will
+      loop.
+
+      Note that you need to :n:`Require Import Coq.Program.Tactics` to
+      make use of :tacn:`rapply`.
+
    .. tacv:: simple apply @term.
 
       This behaves like :tacn:`apply` but it reasons modulo conversion only on subterms

--- a/test-suite/success/rapply.v
+++ b/test-suite/success/rapply.v
@@ -1,0 +1,22 @@
+Require Import Coq.Program.Tactics.
+
+Ltac test n :=
+  (*let __ := match goal with _ => idtac n end in*)
+  lazymatch n with
+  | O => let __ := match goal with _ => assert True by rapply I; clear end in
+         uconstr:(fun _ => I)
+  | S ?n'
+    => let lem := test n' in
+       let __ := match goal with _ => assert True by (unshelve rapply lem; try exact I); clear end in
+       uconstr:(fun _ : True => lem)
+  end.
+
+Goal True.
+  assert True by rapply I.
+  assert True by (unshelve rapply (fun _ => I); try exact I).
+  assert True by (unshelve rapply (fun _ _ => I); try exact I).
+  assert True by (unshelve rapply (fun _ _ _ => I); try exact I).
+  clear.
+  Time let __ := test 50 in idtac.
+  rapply I.
+Qed.

--- a/test-suite/success/rapply.v
+++ b/test-suite/success/rapply.v
@@ -1,22 +1,27 @@
 Require Import Coq.Program.Tactics.
 
+(** We make a version of [rapply] that takes [uconstr]; we do not
+currently test what scope [rapply] interprets terms in. *)
+
+Tactic Notation "urapply" uconstr(p) := rapply p.
+
 Ltac test n :=
   (*let __ := match goal with _ => idtac n end in*)
   lazymatch n with
-  | O => let __ := match goal with _ => assert True by rapply I; clear end in
+  | O => let __ := match goal with _ => assert True by urapply I; clear end in
          uconstr:(fun _ => I)
   | S ?n'
     => let lem := test n' in
-       let __ := match goal with _ => assert True by (unshelve rapply lem; try exact I); clear end in
+       let __ := match goal with _ => assert True by (unshelve urapply lem; try exact I); clear end in
        uconstr:(fun _ : True => lem)
   end.
 
 Goal True.
-  assert True by rapply I.
-  assert True by (unshelve rapply (fun _ => I); try exact I).
-  assert True by (unshelve rapply (fun _ _ => I); try exact I).
-  assert True by (unshelve rapply (fun _ _ _ => I); try exact I).
+  assert True by urapply I.
+  assert True by (unshelve urapply (fun _ => I); try exact I).
+  assert True by (unshelve urapply (fun _ _ => I); try exact I).
+  assert True by (unshelve urapply (fun _ _ _ => I); try exact I).
   clear.
   Time let __ := test 50 in idtac.
-  rapply I.
+  urapply I.
 Qed.

--- a/theories/Program/Tactics.v
+++ b/theories/Program/Tactics.v
@@ -178,9 +178,6 @@ Ltac rapply p :=
    rapply uconstr:(p _))
   || refine p.
 
-(** The tactic [rapply] is a tactic notation so that it takes in uconstrs by default *)
-Tactic Notation "rapply" uconstr(p) := rapply p.
-
 (** Tactical [on_call f tac] applies [tac] on any application of [f] in the hypothesis or goal. *)
 
 Ltac on_call f tac :=

--- a/theories/Program/Tactics.v
+++ b/theories/Program/Tactics.v
@@ -61,12 +61,12 @@ Ltac destruct_pairs := repeat (destruct_one_pair).
 
 Ltac destruct_one_ex :=
   let tac H := let ph := fresh "H" in (destruct H as [H ph]) in
-  let tac2 H := let ph := fresh "H" in let ph' := fresh "H" in 
-    (destruct H as [H ph ph']) 
+  let tac2 H := let ph := fresh "H" in let ph' := fresh "H" in
+    (destruct H as [H ph ph'])
   in
   let tacT H := let ph := fresh "X" in (destruct H as [H ph]) in
-  let tacT2 H := let ph := fresh "X" in let ph' := fresh "X" in 
-    (destruct H as [H ph ph']) 
+  let tacT2 H := let ph := fresh "X" in let ph' := fresh "X" in
+    (destruct H as [H ph ph'])
   in
     match goal with
       | [H : (ex _) |- _] => tac H
@@ -140,7 +140,7 @@ Ltac clear_dups := repeat clear_dup.
 
 (** Try to clear everything except some hyp *)
 
-Ltac clear_except hyp := 
+Ltac clear_except hyp :=
   repeat match goal with [ H : _ |- _ ] =>
            match H with
              | hyp => fail 1

--- a/theories/Program/Tactics.v
+++ b/theories/Program/Tactics.v
@@ -173,22 +173,13 @@ Ltac on_application f tac T :=
 (** A variant of [apply] using [refine], doing as much conversion as necessary. *)
 
 Ltac rapply p :=
-  refine (p _ _ _ _ _ _ _ _ _ _ _ _ _ _ _) ||
-  refine (p _ _ _ _ _ _ _ _ _ _ _ _ _ _) ||
-  refine (p _ _ _ _ _ _ _ _ _ _ _ _ _) ||
-  refine (p _ _ _ _ _ _ _ _ _ _ _ _) ||
-  refine (p _ _ _ _ _ _ _ _ _ _ _) ||
-  refine (p _ _ _ _ _ _ _ _ _ _) ||
-  refine (p _ _ _ _ _ _ _ _ _) ||
-  refine (p _ _ _ _ _ _ _ _) ||
-  refine (p _ _ _ _ _ _ _) ||
-  refine (p _ _ _ _ _ _) ||
-  refine (p _ _ _ _ _) ||
-  refine (p _ _ _ _) ||
-  refine (p _ _ _) ||
-  refine (p _ _) ||
-  refine (p _) ||
-  refine p.
+  (** before we try to add more underscores, first ensure that adding such underscores is valid *)
+  (assert_succeeds (idtac; let __ := open_constr:(p _) in idtac);
+   rapply uconstr:(p _))
+  || refine p.
+
+(** The tactic [rapply] is a tactic notation so that it takes in uconstrs by default *)
+Tactic Notation "rapply" uconstr(p) := rapply p.
 
 (** Tactical [on_call f tac] applies [tac] on any application of [f] in the hypothesis or goal. *)
 


### PR DESCRIPTION
**Kind:** enhancement.

Closes #10004


Also add a tactic notation so that it takes in uconstrs by default.

Also add some basic tests for `rapply`.

I made this PR because I hit a case where I needed 16 underscores (the existing `rapply` only gives me 15).

- [x] Added / updated test-suite
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
