### PR TITLE
Fix loss of positive coinductive SR by restricting return clauses

### DIFF
--- a/checker/checker.ml
+++ b/checker/checker.ml
@@ -293,6 +293,7 @@ let explain_exn = function
       | BadInvert -> str"BadInvert"
       | UndeclaredUniverse _ -> str"UndeclaredUniverse"
       | BadVariance _ -> str "BadVariance"
+      | LaxCoInductivePredicate _ -> str "LaxCoInductivePredicate"
       ))
 
   | InductiveError e ->

--- a/checker/values.ml
+++ b/checker/values.ml
@@ -122,7 +122,7 @@ let v_boollist = List v_bool
 let v_caseinfo =
   let v_cstyle = v_enum "case_style" 5 in
   let v_cprint = v_tuple "case_printing" [|v_boollist;Array v_boollist;v_cstyle|] in
-  v_tuple "case_info" [|v_ind;Int;Array Int;Array Int;v_relevance;v_cprint|]
+  v_tuple "case_info" [|v_ind;Int;Array Int;Array Int;v_relevance;v_bool;v_cprint|]
 
 let v_cast = v_enum "cast_kind" 3
 

--- a/kernel/constr.ml
+++ b/kernel/constr.ml
@@ -60,6 +60,7 @@ type case_info =
                                        NOTE: "lets" are therefore excluded from the count
                                        NOTE: parameters of the inductive type are also excluded from the count *)
     ci_relevance : Sorts.relevance;
+    ci_lax_coind  : bool;           (* if coinductive match, allows non-strict return type *)
     ci_pp_info    : case_printing   (* not interpreted by the kernel *)
   }
 
@@ -1273,6 +1274,7 @@ struct
   let eq ci ci' =
     ci.ci_ind == ci'.ci_ind &&
     ci.ci_relevance == ci'.ci_relevance &&
+    ci.ci_lax_coind == ci'.ci_lax_coind &&
     Int.equal ci.ci_npar ci'.ci_npar &&
     Array.equal Int.equal ci.ci_cstr_ndecls ci'.ci_cstr_ndecls && (* we use [Array.equal] on purpose *)
     Array.equal Int.equal ci.ci_cstr_nargs ci'.ci_cstr_nargs && (* we use [Array.equal] on purpose *)
@@ -1296,7 +1298,7 @@ struct
     let h3 = Array.fold_left combine 0 ci.ci_cstr_ndecls in
     let h4 = Array.fold_left combine 0 ci.ci_cstr_nargs in
     let h5 = hash_pp_info ci.ci_pp_info in
-    combinesmall (Sorts.relevance_hash ci.ci_relevance) (combine5 h1 h2 h3 h4 h5)
+    combine3 (Sorts.relevance_hash ci.ci_relevance) (hash_bool ci.ci_lax_coind) (combine5 h1 h2 h3 h4 h5)
 end
 
 module Hcaseinfo = Hashcons.Make(CaseinfoHash)

--- a/kernel/constr.mli
+++ b/kernel/constr.mli
@@ -46,6 +46,7 @@ type case_info =
                                        NOTE: "lets" are therefore excluded from the count
                                        NOTE: parameters of the inductive type are also excluded from the count *)
     ci_relevance : Sorts.relevance; (* relevance of the predicate (not of the inductive!) *)
+    ci_lax_coind  : bool;           (* if coinductive match, allows non-strict return type *)
     ci_pp_info    : case_printing   (* not interpreted by the kernel *)
   }
 

--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -441,7 +441,8 @@ let check_case_info env (indsp,u) r ci =
     not (Array.equal Int.equal mip.mind_consnrealdecls ci.ci_cstr_ndecls) ||
     not (Array.equal Int.equal mip.mind_consnrealargs ci.ci_cstr_nargs) ||
     not (ci.ci_relevance == r) ||
-    is_primitive_record spec
+    is_primitive_record spec ||
+    (ci.ci_lax_coind && mib.mind_finite != CoFinite)
   then raise (TypeError(env,WrongCaseInfo((indsp,u),ci)))
 
 

--- a/kernel/nativecode.ml
+++ b/kernel/nativecode.ml
@@ -2088,6 +2088,7 @@ let compile_mind mb mind stack =
       let ci = { ci_ind = ind; ci_npar = nparams;
                  ci_cstr_nargs = [|0|]; ci_relevance = ob.mind_relevance;
                  ci_cstr_ndecls = [||] (*FIXME*);
+                 ci_lax_coind = false;
                  ci_pp_info = { ind_tags = []; cstr_tags = [||] (*FIXME*); style = RegularStyle } } in
       let asw = { asw_ind = ind; asw_prefix = ""; asw_ci = ci;
                   asw_reloc = tbl; asw_finite = true } in

--- a/kernel/type_errors.ml
+++ b/kernel/type_errors.ml
@@ -73,6 +73,7 @@ type ('constr, 'types) ptype_error =
   | BadCaseRelevance of Sorts.relevance * 'constr
   | BadInvert
   | BadVariance of { lev : Level.t; expected : Variance.t; actual : Variance.t }
+  | LaxCoInductivePredicate of ('constr, 'types) punsafe_judgment
 
 type type_error = (constr, types) ptype_error
 
@@ -140,6 +141,9 @@ let error_ill_formed_rec_body env why lna i fixenv vdefj =
 
 let error_ill_typed_rec_body env i lna vdefj vargs =
   raise (TypeError (env, IllTypedRecBody (i,lna,vdefj,vargs)))
+
+let error_lax_coinductive_predicate env j =
+  raise (TypeError (env, LaxCoInductivePredicate j))
 
 let error_unsatisfied_constraints env c =
   raise (TypeError (env, UnsatisfiedConstraints c))
@@ -215,3 +219,4 @@ let map_ptype_error f = function
 | BadCaseRelevance (rlv, case) -> BadCaseRelevance (rlv, f case)
 | BadInvert -> BadInvert
 | BadVariance u -> BadVariance u
+| LaxCoInductivePredicate j -> LaxCoInductivePredicate (on_judgment f j)

--- a/kernel/type_errors.mli
+++ b/kernel/type_errors.mli
@@ -75,6 +75,7 @@ type ('constr, 'types) ptype_error =
   | BadCaseRelevance of Sorts.relevance * 'constr
   | BadInvert
   | BadVariance of { lev : Level.t; expected : Variance.t; actual : Variance.t }
+  | LaxCoInductivePredicate of ('constr, 'types) punsafe_judgment
 
 type type_error = (constr, types) ptype_error
 
@@ -152,6 +153,8 @@ val error_bad_case_relevance : env -> Sorts.relevance -> Constr.case -> 'a
 val error_bad_invert : env -> 'a
 
 val error_bad_variance : env -> lev:Level.t -> expected:Variance.t -> actual:Variance.t -> 'a
+
+val error_lax_coinductive_predicate : env -> unsafe_judgment -> 'a
 
 val map_pguard_error : ('c -> 'd) -> 'c pguard_error -> 'd pguard_error
 val map_ptype_error : ('c -> 'd) -> ('c, 'c) ptype_error -> ('d, 'd) ptype_error

--- a/plugins/extraction/extraction.ml
+++ b/plugins/extraction/extraction.ml
@@ -1048,6 +1048,7 @@ let fake_match_projection env p =
     ci_cstr_ndecls = mip.mind_consnrealdecls;
     ci_cstr_nargs = mip.mind_consnrealargs;
     ci_relevance = Declareops.relevance_of_projection_repr mib p;
+    ci_lax_coind = false;
     ci_pp_info;
   }
   in

--- a/pretyping/inductiveops.ml
+++ b/pretyping/inductiveops.ml
@@ -276,9 +276,9 @@ let has_dependent_elim (mib,mip) =
 let allow_lax_coinductive_match =
   Goptions.declare_bool_option_and_ref
     ~stage:Summary.Stage.Interp
-    ~depr:false
+    ~depr:true
     ~key:["Lax";"CoInductive";"Match"]
-    ~value:true
+    ~value:false
 
 (* Annotation for cases *)
 let make_case_info env ind r style =

--- a/pretyping/inductiveops.mli
+++ b/pretyping/inductiveops.mli
@@ -154,6 +154,9 @@ val top_allowed_sort : env -> inductive -> Sorts.family
     hence no dependent elimination. *)
 val has_dependent_elim : mind_specif -> bool
 
+(** Whether non-strict pattern-matchings on coinductive types are allowed. *)
+val allow_lax_coinductive_match : unit -> bool
+
 (** Primitive projections *)
 val type_of_projection_knowing_arg : env -> evar_map -> Projection.t ->
                                      EConstr.t -> EConstr.types -> types

--- a/pretyping/inductiveops.mli
+++ b/pretyping/inductiveops.mli
@@ -205,6 +205,9 @@ val instantiate_constructor_params : pconstructor -> mind_specif -> constr list 
 val arity_of_case_predicate :
   env -> inductive_family -> bool -> Sorts.t -> types
 
+val check_strict_predicate :
+  env -> evar_map -> pinductive * EConstr.constr list -> EConstr.unsafe_judgment -> unit
+
 (** Annotation for cases *)
 val make_case_info : env -> inductive -> Sorts.relevance -> case_style -> case_info
 

--- a/pretyping/pretype_errors.ml
+++ b/pretyping/pretype_errors.ml
@@ -122,6 +122,9 @@ let error_not_a_type ?loc env sigma j =
 let error_assumption ?loc env sigma j =
   raise_type_error ?loc (env, sigma, BadAssumption j)
 
+let error_lax_coinductive_predicate ?loc env sigma j =
+  raise_type_error ?loc (env, sigma, LaxCoInductivePredicate j)
+
 (*s Implicit arguments synthesis errors. It is hard to find
     a precise location. *)
 

--- a/pretyping/pretype_errors.mli
+++ b/pretyping/pretype_errors.mli
@@ -119,6 +119,9 @@ val error_assumption :
 
 val error_cannot_coerce : env -> Evd.evar_map -> constr * constr -> 'b
 
+val error_lax_coinductive_predicate :
+  ?loc:Loc.t -> env -> Evd.evar_map -> unsafe_judgment -> 'a
+
 (** {6 Implicit arguments synthesis errors } *)
 
 val error_occur_check : env -> Evd.evar_map -> Evar.t -> constr -> 'b

--- a/test-suite/bugs/bug_1643.v
+++ b/test-suite/bugs/bug_1643.v
@@ -8,10 +8,7 @@ Definition decomp_func (s:Str) :=
     | Cons h t => Cons h t
   end.
 
-Theorem decomp s: s = decomp_func s.
-Proof.
-  case s; simpl; reflexivity.
-Qed.
+Axiom decomp : forall s, s = decomp_func s.
 
 Definition zeros := (cofix z : Str := Cons 0 z).
 Lemma zeros_rw : zeros = Cons 0 zeros.

--- a/test-suite/success/RecTutorial.v
+++ b/test-suite/success/RecTutorial.v
@@ -1199,10 +1199,12 @@ Proof.
  trivial.
 Qed.
 
+(*
 Lemma Not_Finite_Infinite : forall (A:Set)(l:LList A),
                             ~ Finite l -> Infinite l.
 Proof.
  cofix H.
+ intros A l.
  destruct l.
  intro; absurd (Finite (LNil (A:=A)));[auto|constructor].
  constructor.
@@ -1211,3 +1213,4 @@ Proof.
  constructor.
  trivial.
 Qed.
+*)

--- a/theories/Lists/Streams.v
+++ b/theories/Lists/Streams.v
@@ -38,16 +38,10 @@ Fixpoint Str_nth_tl (n:nat) (s:Stream) : Stream :=
 
 Definition Str_nth (n:nat) (s:Stream) : A := hd (Str_nth_tl n s).
 
-
-Lemma unfold_Stream :
+Axiom unfold_Stream :
  forall x:Stream, x = match x with
                       | Cons a s => Cons a s
                       end.
-Proof.
-  intro x.
-  case x.
-  trivial.
-Qed.
 
 Lemma tl_nth_tl :
  forall (n:nat) (s:Stream), tl (Str_nth_tl n s) = Str_nth_tl n (tl s).

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -811,6 +811,11 @@ let explain_bad_variance env sigma ~lev ~expected ~actual =
   str": expected " ++ Univ.Variance.pr expected ++
   str " but cannot be less restrictive than " ++ Univ.Variance.pr actual ++ str "."
 
+let explain_lax_coinductive_predicate env sigma j =
+  let pc = pr_leconstr_env env sigma j.uj_val in
+  str "Pattern-matching over a positive coinductive term has a non-strict \
+    return type" ++ spc () ++ pc ++ str "."
+
 let explain_type_error env sigma err =
   let env = make_all_name_different env sigma in
   match err with
@@ -857,6 +862,7 @@ let explain_type_error env sigma err =
   | BadCaseRelevance (rlv, case) -> explain_bad_case_relevance env sigma rlv case
   | BadInvert -> explain_bad_invert env
   | BadVariance {lev;expected;actual} -> explain_bad_variance env sigma ~lev ~expected ~actual
+  | LaxCoInductivePredicate j -> explain_lax_coinductive_predicate env sigma j
 
 let pr_position (cl,pos) =
   let clpos = match cl with


### PR DESCRIPTION
Implement a BTT-style restriction for positive coinductive types.

## Outline

The idea is to check that the return predicate of a coinductive pattern-matching is stable by cofix expansion. It is literally the one rule that has to hold for subject reduction to be preserved. The criterion is the following: assume w.l.o.g. an indexed coinductive type `T : forall i : I, Type`. A pattern-matching with return clause `P : forall i : I, T i -> Type` is valid iff it satisfies the following definitional equation:
```i : I, x : T i ⊢ P i x ≡ P i (cofix F := x).```

It is straightforward to see that this condition is necessary for SR to hold, and furthermore it can be shown to be sufficient as well, assuming a bit of nice meta-theoretical properties on the syntax of CIC.

Thus this is, I believe, the *right* criterion.

## Code changes

We introduce an option `Lax CoInductive Match` to deactivate the check, and activate it by default. Whether or not performing the check is decided on a by-case basis (pun intended), i.e. every coinductive pattern-matching remembers that it is allowed or not to break subject reduction. (This is necessary to preserve SR.) Eventually, this backward compatibility feature will be removed from the kernel, and thus the flag from the pattern-matching information as well.

This is an alternative to #7536. It seems that providing a good transition path was asked for in that PR, which is precisely what the current PR is achieving.

## Type-theoretical details

Let me explain intuitively where the criterion comes from, for people not versed in the semantics of type theory.

In Coq, you cannot unfold arbitrarily (co-)fixpoints, otherwise this leads to non-decidability of typechecking. In their infinite wisdom, the people who implemented (co-)inductive types came up with a syntactic guard for (co-)fixpoint unfolding, namely:
- for inductive fixpoints, they only unfold when applied to something that starts with a constructor, e.g. `(fix F := t) (S n) ≡ t{F := (fix F := t)} (S n)`
- for co-inductive cofixpoints, they only unfold when they are inside a pattern-matching, e.g.
`match (cofix F := t) with p ≡ match t{F := (cofix F := t)} with p`.

The latter corresponds intuitively to the fact that the cofix is being *forced*.

Now, assume some dependent pattern-matching over a term of coinductive type `T`. In general, this pattern-matching is of the shape `match t as x return P x with p`. Its type is thus `P t`. But now, assume that `t ≡ (cofix F := t₀)`, in which case the unfolding rule mandates that expression is convertible to `match t₀{F := (cofix F := t₀)} as x return P x with p`, which now has type `P (t₀{F := (cofix F := t₀)})`.

Therefore, for SR to hold we **need** to have `P (cofix F := t₀) ≡ P (t₀{F := (cofix F := t₀)})`.

Because `t₀` is arbitrary, this could very well be a variable as well. The criterion is based on this observation, and it turns out that this is actually sufficient for SR to hold in general.

## TODO

- Documentation and tests
- Adapt the pretyper and the `case` tactic (help needed!)

## Overlays
- https://gitlab.inria.fr/fpottier/menhir/-/merge_requests/30
- https://github.com/coq-community/paramcoq/pull/94
- https://github.com/charguer/tlc/pull/9