### PR TITLE
Improved handling of micromega caches

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -581,7 +581,7 @@ bin/votour.byte: $(VOTOURCMO)
 ###########################################################################
 
 CSDPCERTCMO:=clib/clib.cma $(addprefix plugins/micromega/, \
-  mutils.cmo 	micromega.cmo \
+  micromega.cmo mutils.cmo 	 \
   sos_types.cmo sos_lib.cmo sos.cmo 	csdpcert.cmo )
 
 $(CSDPCERT): $(call bestobj, $(CSDPCERTCMO))

--- a/doc/changelog/04-tactics/10765-micromega-caches.rst
+++ b/doc/changelog/04-tactics/10765-micromega-caches.rst
@@ -1,3 +1,3 @@
 - Introduction of flags :flag:`Lia Cache`, :flag:`Nia Cache` and :flag:`Nra Cache`.
   (see `#10772 <https://github.com/coq/coq/issues/10772>`_ for use case)
-(`#10765 <https://github.com/coq/coq/pull/10765>`_ fixes `#10772 <https://github.com/coq/coq/issues/10772>`_ , by Frédéric Besson).
+  (`#10765 <https://github.com/coq/coq/pull/10765>`_ fixes `#10772 <https://github.com/coq/coq/issues/10772>`_ , by Frédéric Besson).

--- a/doc/changelog/04-tactics/10765-micromega-caches.rst
+++ b/doc/changelog/04-tactics/10765-micromega-caches.rst
@@ -1,0 +1,3 @@
+- Introduction of flags :flag:`Lia Cache`, :flag:`Nia Cache` and :flag:`Nra Cache`.
+  (see `#10772 <https://github.com/coq/coq/issues/10772>`_ for use case)
+(`#10765 <https://github.com/coq/coq/pull/10765>`_ fixes `#10772 <https://github.com/coq/coq/issues/10772>`_ , by Frédéric Besson).

--- a/doc/sphinx/addendum/micromega.rst
+++ b/doc/sphinx/addendum/micromega.rst
@@ -35,6 +35,18 @@ tactics for solving arithmetic goals over :math:`\mathbb{Q}`,
    use the Simplex method for solving linear goals. If it is not set,
    the decision procedures are using Fourier elimination.
 
+.. flag:: Lia Cache
+
+   This option (set by default) instructs :tacn:`lia` to cache its results in the file `.lia.cache`
+
+.. flag:: Nia Cache
+
+   This option (set by default) instructs :tacn:`nia` to cache its results in the file `.nia.cache`
+
+.. flag:: Nra Cache
+
+   This option (set by default) instructs :tacn:`nra` to cache its results in the file `.nra.cache`
+
 
 The tactics solve propositional formulas parameterized by atomic
 arithmetic expressions interpreted over a domain :math:`D \in \{\mathbb{Z},\mathbb{Q},\mathbb{R}\}`.

--- a/plugins/micromega/mutils.mli
+++ b/plugins/micromega/mutils.mli
@@ -67,13 +67,45 @@ end
 module CoqToCaml : sig
 
   val z_big_int : Micromega.z -> Big_int.big_int
-  val q_to_num : Micromega.q -> Num.num
-  val positive : Micromega.positive -> int
-  val n : Micromega.n -> int
-  val nat : Micromega.nat -> int
-  val index : Micromega.positive -> int
+  val z         : Micromega.z -> int
+  val q_to_num  : Micromega.q -> Num.num
+  val positive  : Micromega.positive -> int
+  val n         : Micromega.n -> int
+  val nat       : Micromega.nat -> int
+  val index     : Micromega.positive -> int
 
 end
+
+module Hash : sig
+
+  val eq_op1      : Micromega.op1 -> Micromega.op1 -> bool
+
+  val eq_positive : Micromega.positive -> Micromega.positive -> bool
+
+  val eq_z : Micromega.z -> Micromega.z -> bool
+
+  val eq_q : Micromega.q -> Micromega.q -> bool
+
+  val eq_pol  : ('a -> 'a -> bool) -> 'a Micromega.pol -> 'a Micromega.pol -> bool
+
+  val eq_pair : ('a -> 'a -> bool) -> ('b -> 'b -> bool) -> 'a * 'b -> 'a * 'b -> bool
+
+  val hash_op1 : int -> Micromega.op1 -> int
+
+  val hash_pol  : (int -> 'a -> int) -> int -> 'a Micromega.pol -> int
+
+  val hash_pair : (int -> 'a -> int) -> (int -> 'b -> int) -> int -> 'a * 'b -> int
+
+  val hash_z   : int -> Micromega.z -> int
+
+  val hash_q   : int -> Micromega.q -> int
+
+  val hash_string : int -> string -> int
+
+  val hash_elt : ('a -> int) -> int -> 'a -> int
+
+end
+
 
 val ppcm : Big_int.big_int -> Big_int.big_int -> Big_int.big_int
 

--- a/plugins/micromega/persistent_cache.ml
+++ b/plugins/micromega/persistent_cache.ml
@@ -127,7 +127,7 @@ let open_in f =
     match read_key_elem inch with
       | None -> ()
       | Some (key,elem) ->
-          Table.replace htbl key elem ;
+          Table.add htbl key elem ;
 	  xload () in
     try
       (* Locking of the (whole) file while reading *)
@@ -164,7 +164,7 @@ let add t k e =
     else
       let fd = descr_of_out_channel outch in
       begin
-       Table.replace tbl k e ;
+       Table.add tbl k e ;
        do_under_lock Write fd 
         (fun _ -> 
          Marshal.to_channel outch (k,e) [Marshal.No_sharing] ;


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->
The micromega caches are using the default Hashtbl.hash functions.
This PR is using a specialised hash function which traverses the whole key.
The hope is to reduce the amount of collisions that can be costly in certain extreme cases.
(The issue was identified as a side-effect of  #10743) 
The efficiency impact on common workloads needs to be assessed... 

The PR also adds options to disable caches.



<!-- Keep what applies -->
**Kind:**  performance 

Fixes #10772
