### PR TITLE
[aux files] Remove dot from aux files.

### DIFF
--- a/lib/aux_file.ml
+++ b/lib/aux_file.ml
@@ -20,7 +20,7 @@ let version = 1
 let oc = ref None
 
 let aux_file_name_for vfile =
-  dirname vfile ^ "/." ^ chop_extension(basename vfile) ^ ".aux"
+  dirname vfile ^ "/" ^ chop_extension(basename vfile) ^ ".aux"
 
 let mk_absolute vfile =
   let vfile = CUnix.remove_path_dot vfile in

--- a/tools/coq_dune.ml
+++ b/tools/coq_dune.ml
@@ -171,7 +171,8 @@ let pp_rule fmt targets deps action =
 let gen_coqc_targets vo =
   [ vo.target
   ; replace_ext ~file:vo.target ~newext:".glob"
-  ; "." ^ replace_ext ~file:vo.target ~newext:".aux"]
+  ; replace_ext ~file:vo.target ~newext:".aux"
+  ]
 
 (* Generate the dune rule: *)
 let pp_vo_dep dir fmt vo =


### PR DESCRIPTION
It seems to me that the convention for such kind of files is not to
have a dot, `.glob` files don't, and OCaml's helper files neither.
