### PR TITLE
[ci] Add mit-pdos/perennial

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -733,6 +733,9 @@ plugin:ci-mtac2:
 plugin:ci-paramcoq:
   extends: .ci-template
 
+plugin:ci-perennial:
+  extends: .ci-template-flambda
+
 plugin:plugin-tutorial:
   stage: stage-1
   dependencies: []

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -35,6 +35,7 @@ CI_TARGETS= \
     ci-math-comp \
     ci-mtac2 \
     ci-paramcoq \
+    ci-perennial \
     ci-quickchick \
     ci-relation_algebra \
     ci-sf \

--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -311,3 +311,10 @@
 : "${argosy_CI_REF:=master}"
 : "${argosy_CI_GITURL:=https://github.com/mit-pdos/argosy}"
 : "${argosy_CI_ARCHIVEURL:=${argosy_CI_GITURL}/archive}"
+
+########################################################################
+# perennial
+########################################################################
+: "${perennial_CI_REF:=master}"
+: "${perennial_CI_GITURL:=https://github.com/mit-pdos/perennial}"
+: "${perennial_CI_ARCHIVEURL:=${perennial_CI_GITURL}/archive}"

--- a/dev/ci/ci-perennial.sh
+++ b/dev/ci/ci-perennial.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+ci_dir="$(dirname "$0")"
+. "${ci_dir}/ci-common.sh"
+
+FORCE_GIT=1
+git_download perennial
+
+# required by Perennial's coqc.py build wrapper
+export LC_ALL=C.UTF-8
+
+( cd "${CI_BUILD_DIR}/perennial" && git submodule update --init --recursive && make TIMED=false )


### PR DESCRIPTION
Add Perennial, a system for verifying concurrent, crash-safe systems. Perennial is built on top of Iris.

Perennial takes about 30 minutes to build, including all the verified examples (a replicated disk, a mail server, as well as some smaller ones).

**Kind:** infrastructure.
