### PR TITLE
Fix #10413 (CI failure on tags).

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -376,6 +376,9 @@ pkg:nix:deploy:channel:
     name: cachix
     url: https://coq.cachix.org
   only:
+    refs: # Repeat conditions from pkg:nix:deploy
+      - master
+      - /^v.*\..*$/
     variables:
       - $CACHIX_DEPLOYMENT_KEY
   dependencies: []


### PR DESCRIPTION
On tags, the pkg:nix:deploy:channel job was run even though the required pkg:nix:deploy was not.  We repeat the same conditions regarding refs as in pkg:nix:deploy.  Cf. GitLab's doc on the meaning of several only conditions: https://docs.gitlab.com/ee/ci/yaml/README.html#onlyexcept-advanced

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** infrastructure.


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #10413 