### PR TITLE
Mark SF as allow failure until it gets fixed.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -687,6 +687,7 @@ library:ci-math-comp:
 
 library:ci-sf:
   extends: .ci-template
+  allow_failure: true # Waiting for integration of the fix for #10476
 
 library:ci-stdlib2:
   extends: .ci-template-flambda


### PR DESCRIPTION
Failing CI is BAD.  #10476 should not have been merged without a solution for SF being found, or the test being marked temporarily as allow failure.

Another solution is to re-activate the overlay defined in:

https://github.com/coq/coq/blob/c5ecc185ccb804e02ef78012fc6ae38c092cc80a/dev/ci/user-overlays/10476-maximedenes-rm-library-optim.sh#L3-L5

Note that yet another option is to simply remove SF from CI. We had this discussion before... (cf. #1021).

**Kind:** infrastructure.