### PR TITLE
[CI/Azure/macOS] Update GTK3 to 3.24.11

### DIFF
--- a/Makefile.ide
+++ b/Makefile.ide
@@ -264,7 +264,7 @@ $(COQIDEAPP)/Contents/Resources/loaders: $(COQIDEAPP)/Contents
 
 $(COQIDEAPP)/Contents/Resources/immodules: $(COQIDEAPP)/Contents
 	$(MKDIR) $@
-	$(INSTALLLIB) "$(GTKLIBS)/gtk-3.0/3.0.0/immodules/"*.so $@
+	$(INSTALLLIB) "$(GTKLIBS)/gtk-3.0/3.0.0/immodules/"*.dylib $@
 
 
 $(COQIDEAPP)/Contents/Resources/etc: $(COQIDEAPP)/Contents/Resources/lib
@@ -273,8 +273,8 @@ $(COQIDEAPP)/Contents/Resources/etc: $(COQIDEAPP)/Contents/Resources/lib
 	{ "$(PIXBUFBIN)/gdk-pixbuf-query-loaders" $@/../loaders/*.so |\
 	 sed -e "s!/.*\(/loaders/.*.so\)!@executable_path/../Resources/\1!"; } \
 	> $@/gtk-3.0/gdk-pixbuf.loaders
-	{ "$(GTKBIN)/gtk-query-immodules-3.0" $@/../immodules/*.so |\
-	 sed -e "s!/.*\(/immodules/.*.so\)!@executable_path/../Resources/\1!" |\
+	{ "$(GTKBIN)/gtk-query-immodules-3.0" $@/../immodules/*.dylib |\
+	 sed -e "s!/.*\(/immodules/.*.dylib\)!@executable_path/../Resources/\1!" |\
 	 sed -e "s!/.*\(/share/locale\)!@executable_path/../Resources/\1!"; } \
 	> $@/gtk-3.0/gtk-immodules.loaders
 	$(MKDIR) $@/pango
@@ -283,7 +283,7 @@ $(COQIDEAPP)/Contents/Resources/etc: $(COQIDEAPP)/Contents/Resources/lib
 $(COQIDEAPP)/Contents/Resources/lib: $(COQIDEAPP)/Contents/Resources/immodules $(COQIDEAPP)/Contents/Resources/loaders $(COQIDEAPP)/Contents $(COQIDEINAPP)
 	$(MKDIR) $@
 	macpack -d ../Resources/lib $(COQIDEINAPP)
-	for i in $@/../loaders/*.so $@/../immodules/*.so; \
+	for i in $@/../loaders/*.so $@/../immodules/*.dylib; \
 	do \
 	  macpack -d ../lib $$i; \
 	done

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,8 +58,8 @@ jobs:
     displayName: 'Install system dependencies'
     env:
       HOMEBREW_NO_AUTO_UPDATE: "1"
-      HBCORE_DATE: "2019-06-16"
-      HBCORE_REF: "944a5b7d83e4b81c749d93831b514607bdd2b6a1"
+      HBCORE_DATE: "2019-09-03"
+      HBCORE_REF: "44ee64cf4b9f2d2bf000758d356db0c77425e42e"
 
   - script: |
       set -e


### PR DESCRIPTION
On macOS, the homebrew package set is pinned to include gtk3 at version 3.24.9 because of a build failure with version 3.24.10.

Upstream discussion that is possibly related: https://gitlab.gnome.org/GNOME/gtk/merge_requests/1004

This PR updates the pinning to set gtk3 at version 3.24.11.