### PR TITLE
[ci] Add coqutil to the ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -640,6 +640,9 @@ library:ci-compcert:
 library:ci-coquelicot:
   extends: .ci-template
 
+library:ci-coqutil:
+  extends: .ci-template
+
 library:ci-cross-crypto:
   extends: .ci-template
 

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -17,6 +17,7 @@ CI_TARGETS= \
     ci-compcert \
     ci-coq_dpdgraph \
     ci-coquelicot \
+    ci-coqutil \
     ci-corn \
     ci-cross-crypto \
     ci-elpi \

--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -199,6 +199,13 @@
 : "${bignums_CI_ARCHIVEURL:=${bignums_CI_GITURL}/archive}"
 
 ########################################################################
+# coqutil
+########################################################################
+: "${coqutil_CI_REF:=master}"
+: "${coqutil_CI_GITURL:=https://github.com/mit-plv/coqutil}"
+: "${coqutil_CI_ARCHIVEURL:=${coqutil_CI_GITURL}/archive}"
+
+########################################################################
 # bedrock2
 ########################################################################
 : "${bedrock2_CI_REF:=master}"

--- a/dev/ci/ci-coqutil.sh
+++ b/dev/ci/ci-coqutil.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+ci_dir="$(dirname "$0")"
+. "${ci_dir}/ci-common.sh"
+
+FORCE_GIT=1
+git_download coqutil
+
+( cd "${CI_BUILD_DIR}/coqutil" && make )


### PR DESCRIPTION
fiat-crypto will probably soon depend on part of bedrock2, and I'm
planning to split apart the bedrock2 job so that fiat-crypto doesn't
have to depend on all of it.  coqutil is one of the dependencies, and I
figured I'd add it now.

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** infrastructure.

