### PR TITLE
Replace custom timeout logic with new GitLab's per-job timeout keyword.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -67,8 +67,6 @@ before_script:
       - config/coq_config.py
       - test-suite/misc/universes/all_stdlib.v
     expire_in: 1 week
-  variables:
-    timeout: ""
   script:
     - set -e
 
@@ -81,8 +79,8 @@ before_script:
     - echo 'end:coq.config'
 
     - echo 'start:coq.build'
-    - $timeout make -j "$NJOBS" byte
-    - $timeout make -j "$NJOBS" world $EXTRA_TARGET
+    - make -j "$NJOBS" byte
+    - make -j "$NJOBS" world $EXTRA_TARGET
     - make test-suite/misc/universes/all_stdlib.v
     - echo 'end:coq:build'
 
@@ -161,7 +159,7 @@ before_script:
     - BIN=$(readlink -f ../_install_ci/bin)/
     - LIB=$(readlink -f ../_install_ci/lib/coq)/
     - export OCAMLPATH=$(readlink -f ../_install_ci/lib/):"$OCAMLPATH"
-    - $timeout make -j "$NJOBS" BIN="$BIN" COQLIB="$LIB" COQFLAGS="${COQFLAGS}" all
+    - make -j "$NJOBS" BIN="$BIN" COQLIB="$LIB" COQFLAGS="${COQFLAGS}" all
   artifacts:
     name: "$CI_JOB_NAME.logs"
     when: on_failure
@@ -169,8 +167,6 @@ before_script:
       - test-suite/logs
     # Gitlab doesn't support yet "expire_in: never" so we use the instance default
     # expire_in: never
-  variables:
-    timeout: ""
 
 # set dependencies when using
 .validate-template:
@@ -276,7 +272,7 @@ build:base+async:
   variables:
     COQ_EXTRA_CONF: "-native-compiler yes -coqide opt"
     COQUSERFLAGS: "-async-proofs on"
-    timeout: "timeout 100m"
+  timeout: 100m
   allow_failure: true # See https://github.com/coq/coq/issues/9658
   only:
     variables:
@@ -287,7 +283,7 @@ build:quick:
   variables:
     COQ_EXTRA_CONF: "-native-compiler no"
     QUICK: "1"
-    timeout: "timeout 100m"
+  timeout: 100m
   allow_failure: true # See https://github.com/coq/coq/issues/9637
   only:
     variables:
@@ -568,7 +564,7 @@ test-suite:base+async:
     - build:base
   variables:
     COQFLAGS: "-async-proofs on -async-proofs-cache force"
-    timeout: "timeout 100m"
+  timeout: 100m
   allow_failure: true
   only:
     variables:


### PR DESCRIPTION
Cf. https://docs.gitlab.com/ee/ci/yaml/#timeout.

**Kind:** infrastructure.

For now, this PR keeps the timeouts that were defined and does not add new ones (GitLab does not yet support setting a default timeout and overriding it for jobs that take longer to build).