### PR TITLE
Postpone the computation of relative constraints in universe unification

### DIFF
--- a/engine/uState.ml
+++ b/engine/uState.ml
@@ -244,9 +244,7 @@ let process_universe_constraints ctx cstrs =
             | Some r' ->
               if Level.is_small r' then
                   if not (Universe.is_levels l)
-                  then
-                    if UGraph.check_leq univs l r then local
-                    else
+                  then (* l contains a +1 and r=r' small so l <= r impossible *)
                     raise (UniverseInconsistency (Le, l, r, None))
                   else
                     if UGraph.check_leq univs l r then match Univ.Universe.level l with


### PR DESCRIPTION
Should be 1:1 equivalent to the previous code, this is semantics preserving factorization.

Hopefully should help for a performance-preserving #8905.

Bench:
```
┌────────────────────────┬─────────────────────────┬─────────────────────────────────────────────┬─────────────────────────────────────────────┬───────────────────────────────┬────────────────────────────┐
│                        │      user time [s]      │                 CPU cycles                  │              CPU instructions               │     max resident mem [KB]     │         mem faults         │
│                        │                         │                                             │                                             │                               │                            │
│           package_name │     NEW     OLD PDIFF   │               NEW               OLD PDIFF   │               NEW               OLD PDIFF   │        NEW        OLD PDIFF   │     NEW     OLD    PDIFF   │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼────────────────────────────┤
│             coq-sf-plf │   44.54   45.20 -1.46 % │      124864627998      125981726057 -0.89 % │      161799743027      162335486033 -0.33 % │     492592     485792 +1.40 % │      35      12  +191.67 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼────────────────────────────┤
│   coq-mathcomp-algebra │  163.22  165.50 -1.38 % │      455301712006      461910515633 -1.43 % │      565517289887      569636679352 -0.72 % │     633944     633508 +0.07 % │      83       0     +nan % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼────────────────────────────┤
│        coq-lambda-rust │ 1532.86 1552.54 -1.27 % │     4274367034272     4326796403688 -1.21 % │     5649183396122     5673126688444 -0.42 % │    1410504    1426976 -1.15 % │      50       0     +nan % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼────────────────────────────┤
│       coq-math-classes │  215.76  218.39 -1.20 % │      602448970908      610401106840 -1.30 % │      766346047092      770600904180 -0.55 % │     515564     515064 +0.10 % │      17      15   +13.33 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼────────────────────────────┤
│     coq-mathcomp-field │  229.00  231.53 -1.09 % │      638349123156      644877986344 -1.01 % │      914434669324      917518337656 -0.34 % │     740312     741420 -0.15 % │       0       2  -100.00 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼────────────────────────────┤
│  coq-mathcomp-solvable │  188.33  190.10 -0.93 % │      525123390834      529188988854 -0.77 % │      703604261244      705531445461 -0.27 % │     786064     774196 +1.53 % │      15       0     +nan % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼────────────────────────────┤
│ coq-mathcomp-character │  181.37  183.06 -0.92 % │      505110524444      510089217291 -0.98 % │      668464998469      670976693850 -0.37 % │     896152     894248 +0.21 % │       0       1  -100.00 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼────────────────────────────┤
│          coq-fiat-core │  113.72  114.77 -0.91 % │      323607660828      324836333633 -0.38 % │      403288807926      403704188027 -0.10 % │     499104     499880 -0.16 % │     347     107  +224.30 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼────────────────────────────┤
│ coq-mathcomp-ssreflect │   40.24   40.54 -0.74 % │      111062055826      111910967596 -0.76 % │      135086074009      135500268911 -0.31 % │     527712     527720 -0.00 % │      27      67   -59.70 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼────────────────────────────┤
│  coq-mathcomp-fingroup │   51.19   51.57 -0.74 % │      143312678379      144049550213 -0.51 % │      186779653147      187225794425 -0.24 % │     566276     563792 +0.44 % │       1      35   -97.14 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼────────────────────────────┤
│               coq-corn │ 1488.73 1498.16 -0.63 % │     4155412157463     4181501432084 -0.62 % │     6118741360959     6129853270878 -0.18 % │     872512     872616 -0.01 % │       5      39   -87.18 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼────────────────────────────┤
│ coq-mathcomp-odd-order │ 1434.02 1442.89 -0.61 % │     3997282621471     4021891628069 -0.61 % │     6853070702474     6860105070713 -0.10 % │    1213084    1258912 -3.64 % │      16      14   +14.29 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼────────────────────────────┤
│       coq-fiat-parsers │  650.72  654.74 -0.61 % │     1821709786497     1829764615840 -0.44 % │     2736727147322     2742642397142 -0.22 % │    3193008    3182004 +0.35 % │     195     668   -70.81 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼────────────────────────────┤
│ coq-fiat-crypto-legacy │ 6232.54 6268.71 -0.58 % │    17352286368976    17446423561520 -0.54 % │    28267990592804    28372368448550 -0.37 % │    2515504    2400660 +4.78 % │    1191    1106    +7.69 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼────────────────────────────┤
│              coq-color │  704.63  707.91 -0.46 % │     1969948041622     1978175897740 -0.42 % │     2335472233763     2337274551087 -0.08 % │    1131580    1142104 -0.92 % │      18      56   -67.86 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼────────────────────────────┤
│             coq-geocoq │ 1578.87 1585.70 -0.43 % │     4407067306523     4427662165997 -0.47 % │     6435428081101     6443103201178 -0.12 % │    1364792    1364852 -0.00 % │      44     120   -63.33 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼────────────────────────────┤
│              coq-verdi │  120.33  120.82 -0.41 % │      334071731154      335493758413 -0.42 % │      418897117399      420104517162 -0.29 % │     564540     562188 +0.42 % │       9       8   +12.50 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼────────────────────────────┤
│         coq-verdi-raft │ 1328.06 1333.42 -0.40 % │     3704949171302     3715903663602 -0.29 % │     5003140855826     5014455068625 -0.23 % │    1817188    1817052 +0.01 % │       0       3  -100.00 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼────────────────────────────┤
│          coq-fourcolor │ 2165.67 2173.36 -0.35 % │     6037947512339     6059893668994 -0.36 % │    11356912095654    11360686930066 -0.03 % │     930588     930752 -0.02 % │       1       1    +0.00 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼────────────────────────────┤
│              coq-flocq │  246.70  247.47 -0.31 % │      685790933068      687548500255 -0.26 % │      864554883974      865020954100 -0.05 % │    1014668    1014276 +0.04 % │     223      51  +337.25 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼────────────────────────────┤
│         coq-coquelicot │   77.21   77.33 -0.16 % │      211186360647      212229016848 -0.49 % │      255979323816      256602801080 -0.24 % │     672564     673424 -0.13 % │     217      17 +1176.47 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼────────────────────────────┤
│            coq-unimath │ 4081.76 4086.89 -0.13 % │    11375092384311    11390125634492 -0.13 % │    20905830370969    20881983884565 +0.11 % │    1727520    1725724 +0.10 % │     521     281   +85.41 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼────────────────────────────┤
│            coq-bignums │   69.06   69.14 -0.12 % │      189678279616      190287318028 -0.32 % │      252217860231      252580567708 -0.14 % │     495644     496644 -0.20 % │     138      63  +119.05 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼────────────────────────────┤
│               coq-hott │  389.80  390.18 -0.10 % │     1061892126097     1063424684667 -0.14 % │     1612247230949     1613733630566 -0.09 % │     584808     584616 +0.03 % │     398      17 +2241.18 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼────────────────────────────┤
│           coq-compcert │  777.16  777.12 +0.01 % │     2163133258646     2165625858244 -0.12 % │     2888424450095     2893489046251 -0.18 % │    1070828    1071372 -0.05 % │     259     138   +87.68 % │
└────────────────────────┴─────────────────────────┴─────────────────────────────────────────────┴─────────────────────────────────────────────┴───────────────────────────────┴────────────────────────────┘
```
