### PR TITLE
Merge Direct and Indirect nodes in Opaqueproof.

### DIFF
--- a/checker/check.ml
+++ b/checker/check.ml
@@ -359,7 +359,7 @@ let intern_from_file ~intern_mode (dir, f) =
       (* Verification of the unmarshalled values *)
       validate !Flags.debug Values.v_libsum sd;
       validate !Flags.debug Values.v_lib md;
-      validate !Flags.debug Values.(Opt v_opaques) table;
+      validate !Flags.debug Values.(Opt v_opaquetable) table;
       Flags.if_verbose chk_pp (str" done]" ++ fnl ());
       let digest =
         if opaque_csts <> None then Safe_typing.Dvivo (digest,udg)

--- a/checker/values.mli
+++ b/checker/values.mli
@@ -46,5 +46,5 @@ type value =
 val v_univopaques : value
 val v_libsum : value
 val v_lib : value
-val v_opaques : value
+val v_opaquetable : value
 val v_stm_seg : value

--- a/checker/votour.ml
+++ b/checker/votour.ml
@@ -366,7 +366,7 @@ let visit_vo f =
     make_seg "univ constraints of opaque proofs" Values.v_univopaques;
     make_seg "discharging info" (Opt Any);
     make_seg "STM tasks" (Opt Values.v_stm_seg);
-    make_seg "opaque proofs" Values.v_opaques;
+    make_seg "opaque proofs" Values.v_opaquetable;
   |] in
   let repr =
     if Sys.word_size = 64 then (module ReprMem : S) else (module ReprObj : S)

--- a/kernel/cooking.ml
+++ b/kernel/cooking.ml
@@ -239,7 +239,7 @@ let cook_constant { from = cb; info } =
   | Undef _ as x -> x
   | Def cs -> Def (Mod_subst.from_val (map (Mod_subst.force_constr cs)))
   | OpaqueDef o ->
-    OpaqueDef (Opaqueproof.discharge_direct_opaque info o)
+    OpaqueDef (Opaqueproof.discharge_opaque info o)
   | Primitive _ -> CErrors.anomaly (Pp.str "Primitives cannot be cooked")
   in
   let const_hyps =

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -1743,9 +1743,9 @@ end = struct (* {{{ *)
           assert (Univ.ContextSet.is_empty uctx)
         in
         let pr = Constr.hcons pr in
-        let (ci, dummy) = p.(bucket) in
+        let dummy = p.(bucket) in
         let () = assert (Option.is_empty dummy) in
-        p.(bucket) <- ci, Some (pr, priv);
+        p.(bucket) <- Some (pr, priv);
         Univ.ContextSet.union cst uc, false
 
   let check_task name l i =


### PR DESCRIPTION
While seemingly innocuous, this has severe consequences on hashconsing. After this PR, an opaque proof reaching the kernel is hashconsed *once and only once* and *right at that time*.

- Before #10198, the kernel would sometimes hashcons haphazardly opaque proofs, leading to occasional duplication or failure of hashconsing.
- After #10198 and before the current PR, the kernel would only hashcons opaque proofs when exiting a section. This meant that inside a section, an opaque proof could gobble up memory that would only be reclaimed at section closing time.
- After this PR, the kernel hashconses a proof exactly when it receives it, regardless of the section status. This is simply making the call sooner, so there is no observable difference for compilation time of complete files, but it is indeed observable for memory, which is also reclaimed earlier.

This PR is part of the realization of CEP40.

I didn't check but it's likely to help with #10684 (@andres-erbsen ?).

Bench (note memory usage of lambda-rust and unimath):
```
┌────────────────────────┬─────────────────────────┬─────────────────────────────────────────────┬─────────────────────────────────────────────┬────────────────────────────────┬─────────────────────────┐
│                        │      user time [s]      │                 CPU cycles                  │              CPU instructions               │     max resident mem [KB]      │       mem faults        │
│                        │                         │                                             │                                             │                                │                         │
│           package_name │     NEW     OLD PDIFF   │               NEW               OLD PDIFF   │               NEW               OLD PDIFF   │        NEW        OLD  PDIFF   │     NEW    OLD  PDIFF   │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼─────────────────────────┤
│ coq-mathcomp-ssreflect │   40.01   40.46 -1.11 % │      111356560668      111700062177 -0.31 % │      134787768350      135326451462 -0.40 % │     520072     527888  -1.48 % │      61     58  +5.17 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼─────────────────────────┤
│  coq-mathcomp-fingroup │   51.52   51.89 -0.71 % │      143348546500      144292707686 -0.65 % │      186127034790      187117258270 -0.53 % │     557608     565604  -1.41 % │       5     10 -50.00 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼─────────────────────────┤
│              coq-verdi │  120.40  121.24 -0.69 % │      334815061800      336465173439 -0.49 % │      419746062945      420021780104 -0.07 % │     550960     562340  -2.02 % │      12      9 +33.33 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼─────────────────────────┤
│   coq-mathcomp-algebra │  164.82  165.81 -0.60 % │      459557439483      462078071851 -0.55 % │      567854429103      569516621556 -0.29 % │     617992     633652  -2.47 % │      15      9 +66.67 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼─────────────────────────┤
│ coq-mathcomp-character │  182.36  183.30 -0.51 % │      508156788412      510839589959 -0.53 % │      671266227469      670920321426 +0.05 % │     859592     894472  -3.90 % │      44      6 +633.33 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼─────────────────────────┤
│        coq-lambda-rust │ 1547.55 1554.62 -0.45 % │     4312176941951     4332988775905 -0.48 % │     5675114933888     5674781217433 +0.01 % │    1137760    1426996 -20.27 % │     183     40 +357.50 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼─────────────────────────┤
│  coq-mathcomp-solvable │  189.20  189.83 -0.33 % │      528063804328      529378208783 -0.25 % │      706030405015      705174676250 +0.12 % │     786772     774312  +1.61 % │       0     54 -100.00 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼─────────────────────────┤
│             coq-geocoq │ 1577.09 1582.03 -0.31 % │     4403834840984     4417790102622 -0.32 % │     6447068099018     6442779948077 +0.07 % │    1364072    1364692  -0.05 % │     468    488  -4.10 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼─────────────────────────┤
│         coq-verdi-raft │ 1328.73 1332.70 -0.30 % │     3707113395112     3718066730259 -0.29 % │     5015800498813     5014115422037 +0.03 % │    1818944    1817084  +0.10 % │       0      1 -100.00 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼─────────────────────────┤
│           coq-compcert │  777.08  779.37 -0.29 % │     2165318302236     2172211592837 -0.32 % │     2892540025667     2893463308919 -0.03 % │    1061116    1071496  -0.97 % │     369    430 -14.19 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼─────────────────────────┤
│     coq-mathcomp-field │  230.92  231.38 -0.20 % │      643610460193      644426886284 -0.13 % │      920271011902      917406507157 +0.31 % │     752172     741348  +1.46 % │      93     38 +144.74 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼─────────────────────────┤
│       coq-math-classes │  217.90  218.19 -0.13 % │      609180772853      610441152792 -0.21 % │      771829116690      770456798226 +0.18 % │     518844     515152  +0.72 % │     118     40 +195.00 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼─────────────────────────┤
│          coq-fourcolor │ 2165.23 2167.59 -0.11 % │     6036128384441     6045703437530 -0.16 % │    11367702758588    11360452986719 +0.06 % │     947324     930576  +1.80 % │       1      0   +nan % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼─────────────────────────┤
│              coq-color │  708.34  708.72 -0.05 % │     1979465888329     1980264249152 -0.04 % │     2339626112346     2337149526973 +0.11 % │    1150732    1141740  +0.79 % │     449    364 +23.35 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼─────────────────────────┤
│            coq-unimath │ 4071.33 4070.54 +0.02 % │    11344451707870    11339262352591 +0.05 % │    20970589932492    20883401873815 +0.42 % │    1113596    1725712 -35.47 % │     514    188 +173.40 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼─────────────────────────┤
│ coq-mathcomp-odd-order │ 1443.00 1441.58 +0.10 % │     4022744417343     4018510256773 +0.11 % │     6882152332122     6859689687407 +0.33 % │    1297004    1258780  +3.04 % │      51    246 -79.27 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼─────────────────────────┤
│       coq-fiat-parsers │  653.81  653.07 +0.11 % │     1829144364791     1830272325880 -0.06 % │     2744314051425     2742672117044 +0.06 % │    3175520    3141520  +1.08 % │     410    677 -39.44 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼─────────────────────────┤
│               coq-corn │ 1499.78 1497.85 +0.13 % │     4185919931338     4182788986750 +0.07 % │     6152205322201     6129836865301 +0.36 % │     855068     872712  -2.02 % │       1     48 -97.92 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼─────────────────────────┤
│         coq-coquelicot │   77.52   77.24 +0.36 % │      212421355749      212396350229 +0.01 % │      257202745429      256455967969 +0.29 % │     681084     673392  +1.14 % │     213     13 +1538.46 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼─────────────────────────┤
│             coq-sf-plf │   45.00   44.80 +0.45 % │      125977837262      125910043142 +0.05 % │      162598565740      162202897848 +0.24 % │     493424     485780  +1.57 % │      45      0   +nan % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼─────────────────────────┤
│               coq-hott │  391.76  389.56 +0.56 % │     1066256153689     1062286069281 +0.37 % │     1614180860518     1610210545830 +0.25 % │     585200     584616  +0.10 % │     466    266 +75.19 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼─────────────────────────┤
│              coq-flocq │  249.20  247.46 +0.70 % │      692351709792      687401835581 +0.72 % │      870422201566      864886849255 +0.64 % │    1016448    1014336  +0.21 % │     250    134 +86.57 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼─────────────────────────┤
│ coq-fiat-crypto-legacy │ 6312.96 6263.94 +0.78 % │    17570009075792    17429914243080 +0.80 % │    28586499934355    28361315582167 +0.79 % │    2391016    2400856  -0.41 % │    1201    900 +33.44 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼─────────────────────────┤
│          coq-fiat-core │  114.76  113.85 +0.80 % │      325399254595      324911638954 +0.15 % │      404793944805      403552707718 +0.31 % │     510340     499768  +2.12 % │     503    265 +89.81 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼────────────────────────────────┼─────────────────────────┤
│            coq-bignums │   70.26   69.42 +1.21 % │      192913278176      190485445829 +1.27 % │      257072334837      252401453313 +1.85 % │     499656     496932  +0.55 % │     177    153 +15.69 % │
└────────────────────────┴─────────────────────────┴─────────────────────────────────────────────┴─────────────────────────────────────────────┴────────────────────────────────┴─────────────────────────┘
```

Fixes #10684.