### PR TITLE
The Release Plan wiki page has been removed.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -773,8 +773,7 @@ of a limitation of GitHub).
 Coq's major release cycles generally span about six months, with about
 4-5 months of development, and 1-2 months of stabilization /
 beta-releases.  The release manager (RM) role is a rolling position
-among core developers.  The [release plan][release-plan] is published
-on the wiki.
+among core developers.
 
 Development of new features, refactorings, deprecations and clean-ups
 always happens on `master`.  Stabilization starts by branching

--- a/README.md
+++ b/README.md
@@ -103,8 +103,6 @@ used, and include a complete source example leading to the bug.
 
 Guidelines for contributing to Coq in various ways are listed in the [contributor's guide](CONTRIBUTING.md).
 
-Information about the next release is at https://github.com/coq/coq/wiki/Release-Plan
-
 ## Supporting Coq
 
 Help the Coq community grow and prosper by becoming a sponsor! The [Coq


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** documentation fix

@mattam82 and @ppedrot: I'll let you decide whether you want to merge this PR, or if it made sense to have those links and you want to recreate the page. In any case, we cannot leave broken links like that.