### PR TITLE
Avoid double universe declarations from sections

### DIFF
--- a/kernel/section.mli
+++ b/kernel/section.mli
@@ -26,9 +26,13 @@ val depth : 'a t -> int
 
 (** {6 Manipulating sections} *)
 
-type section_entry =
+type section_global_entry =
 | SecDefinition of Constant.t
 | SecInductive of MutInd.t
+
+type section_entry =
+| SecGlobal of section_global_entry
+| SecUnivs of ContextSet.t
 
 val open_section : custom:'a -> 'a t -> 'a t
 (** Open a new section with the provided universe polymorphic status. Sections
@@ -36,10 +40,9 @@ val open_section : custom:'a -> 'a t -> 'a t
     inside a monomorphic one. A custom data can be attached to this section,
     that will be returned by {!close_section}. *)
 
-val close_section : 'a t -> 'a t * section_entry list * ContextSet.t * 'a
-(** Close the current section and returns the entries defined inside, the set
-    of global monomorphic constraints added in this section, and the custom data
-    provided at the opening of the section. *)
+val close_section : 'a t -> 'a t * section_entry list * 'a
+(** Close the current section and returns the entries defined inside
+    and the custom data provided at the opening of the section. *)
 
 (** {6 Extending sections} *)
 


### PR DESCRIPTION
Before, when declaring a constant in a section, we go
add_constant -> add_constant_aux -> add_field ->
Safe_typing.push_context_set -> Section.push_constraints
then when closing the section we put back the constraints then
add_constant_aux again

Because we fully recheck inductives after discharge (hopefully this
will change in the future) we need all universes declared before an
inductive to be present, but we don't want the universes from the
inductive itself (double declaration). So we have to declare universes
in order with the globals.

To do this add a kind of section_entry for free floating universes
instead of putting them in an unordered blob sec_mono_univs, and avoid
putting universes of globals in there.

We could also try to avoid having add_constant_aux/add_field pushing
universes and declare them separately but this is more difficult.
