### PR TITLE
Fix alphabetical ordering in contributors to 8.10.0.

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -101,6 +101,7 @@ of the Coq Proof assistant during the indicated time:
   Daniel de Rauglaudre (INRIA, 1996-1998, 2012, 2016)
   Olivier Desmettre (INRIA, 2001-2003)
   Gilles Dowek (INRIA, 1991-1994)
+  Jim Fehrle (2018-now)
   Amy Felty (INRIA, 1993)
   Jean-Christophe Filliâtre (ENS Lyon, 1994-1997, LRI, 1997-2008)
   Emilio Jesús Gallego Arias (MINES ParisTech 2015-now)
@@ -116,12 +117,13 @@ of the Coq Proof assistant during the indicated time:
   Matej Košík (INRIA, 2015-2017)
   Leonidas Lampropoulos (University of Pennsylvania, 2018)
   Pierre Letouzey (LRI, 2000-2004, PPS, 2005-2008,
-                   INRIA-PPS then IRIF, 2009-now)
+                   INRIA-PPS then IRIF, 2009-2018)
   Yao Li (ORCID: https://orcid.org/0000-0001-8720-883X,
           University of Pennsylvania, 2018)
   Yishuai Li (ORCID: https://orcid.org/0000-0002-5728-5903
               U. Penn, 2018-2019)
   Patrick Loiseleur (Paris Sud, 1997-1999)
+  Andreas Lynge (Aarhus University, 2019)
   Evgeny Makarov (INRIA, 2007)
   Gregory Malecha (Harvard University 2013-2015,
                    University of California, San Diego 2016)
@@ -140,16 +142,15 @@ of the Coq Proof assistant during the indicated time:
                             LRI, 1997-2006)
   Pierre-Marie Pédrot (INRIA-PPS, 2011-2015, INRIA-Ascola, 2015-2016,
                        University of Ljubljana, 2016-2017,
-                       MPI-SWS, 2017-2018)
-  Clément Pit-Claudel (MIT, 2015-2018)
+                       MPI-SWS, 2017-2018, INRIA 2018-now)
+  Clément Pit-Claudel (MIT, 2015-now)
   Matthias Puech (INRIA-Bologna, 2008-2011)
-  Yann Régis-Gianas (INRIA-PPS then IRIF, 2009-now)
+  Yann Régis-Gianas (INRIA-PPS then IRIF, 2009-2016)
   Clément Renard (INRIA, 2001-2004)
   Talia Ringer (University of Washington, 2019)
-  Andreas Lynge (Aarhus University, 2019)
   Claudio Sacerdoti Coen (INRIA, 2004-2005)
   Amokrane Saïbi (INRIA, 1993-1998)
-  Vincent Semeria (2018)
+  Vincent Semeria (2018-now)
   Vincent Siles (INRIA, 2007)
   Élie Soubiran (INRIA, 2007-2010)
   Matthieu Sozeau (INRIA, 2005-now)

--- a/doc/sphinx/changes.rst
+++ b/doc/sphinx/changes.rst
@@ -198,21 +198,21 @@ Melquiond, Matthieu Sozeau, Enrico Tassi (who migrated it to opam 2)
 with contributions from many users. A list of packages is available at
 https://coq.inria.fr/opam/www/.
 
-The 61 contributors to this version are David A. Dalrymple, Tanaka
-Akira, Benjamin Barenblat, Yves Bertot, Frédéric Besson, Lasse
-Blaauwbroek, Martin Bodin, Joachim Breitner, Tej Chajed, Frédéric
-Chapoton, Arthur Charguéraud, Cyril Cohen, Lukasz Czajka, Christian
-Doczkal, Maxime Dénès, Andres Erbsen, Jim Fehrle, Gaëtan Gilbert, Matěj
-Grabovský, Simon Gregersen, Jason Gross, Samuel Gruetter, Hugo Herbelin,
-Jasper Hugunin, Mirai Ikebuchi, Emilio Jesus Gallego Arias, Chantal
-Keller, Matej Košík, Vincent Laporte, Olivier Laurent, Larry Darryl Lee
-Jr, Pierre Letouzey, Nick Lewycky, Yao Li, Yishuai Li, Xia Li-yao, Assia
-Mahboubi, Simon Marechal, Erik Martin-Dorel, Thierry Martinez, Guillaume
-Melquiond, Kayla Ngan, Sam Pablo Kuper, Karl Palmskog, Clément
-Pit-Claudel, Pierre-Marie Pédrot, Pierre Roux, Kazuhiko Sakaguchi, Ryan
-Scott, Vincent Semeria, Gan Shen, Michael Soegtrop, Matthieu Sozeau,
-Enrico Tassi, Laurent Théry, Kamil Trzciński, whitequark, Théo
-Winterhalter, Beta Ziliani and Théo Zimmermann.
+The 61 contributors to this version are Tanaka Akira, Benjamin
+Barenblat, Yves Bertot, Frédéric Besson, Lasse Blaauwbroek, Martin
+Bodin, Joachim Breitner, Tej Chajed, Frédéric Chapoton, Arthur
+Charguéraud, Cyril Cohen, Lukasz Czajka, David A. Dalrymple, Christian
+Doczkal, Maxime Dénès, Andres Erbsen, Jim Fehrle, Emilio Jesus Gallego
+Arias, Gaëtan Gilbert, Matěj Grabovský, Simon Gregersen, Jason Gross,
+Samuel Gruetter, Hugo Herbelin, Jasper Hugunin, Mirai Ikebuchi,
+Chantal Keller, Matej Košík, Sam Pablo Kuper, Vincent Laporte, Olivier
+Laurent, Larry Darryl Lee Jr, Nick Lewycky, Yao Li, Yishuai Li, Assia
+Mahboubi, Simon Marechal, Erik Martin-Dorel, Thierry Martinez,
+Guillaume Melquiond, Kayla Ngan, Karl Palmskog, Pierre-Marie Pédrot,
+Clément Pit-Claudel, Pierre Roux, Kazuhiko Sakaguchi, Ryan Scott,
+Vincent Semeria, Gan Shen, Michael Soegtrop, Matthieu Sozeau, Enrico
+Tassi, Laurent Théry, Kamil Trzciński, whitequark, Théo Winterhalter,
+Xia Li-yao, Beta Ziliani and Théo Zimmermann.
 
 Many power users helped to improve the design of the new features via
 the issue and pull request system, the |Coq| development mailing list,


### PR DESCRIPTION
And also fix a few dates and places in the CREDITS file.

Issues found while preparing the new Zenodo entry.

**Kind:** documentation fix