### PR TITLE
Implementing postponed constraints in TC resolution

### DIFF
--- a/doc/changelog/02-specification-language/10858-stuck-classed.md
+++ b/doc/changelog/02-specification-language/10858-stuck-classed.md
@@ -1,0 +1,12 @@
+- **Changed:**
+  Typeclass resolution, accessible through :tacn:`typeclasses eauto`,
+  now suspends constraints according to their modes
+  instead of failing. If a typeclass constraint does not match
+  any of the declared modes for its class, the constraint is postponed, and
+  the proof search continues on other goals. Proof search does a fixed point
+  computation to try to solve them at a later stage of resolution. It does
+  not fail if there remain only stuck constraints at the end of resolution.
+  This makes typeclasses with declared modes more robust with respect to the
+  order of resolution.
+  (`#10858 <https://github.com/coq/coq/pull/10858>`_,
+  fixes `#9058 <https://github.com/coq/coq/issues/9058>_`, by Matthieu Sozeau).

--- a/doc/sphinx/addendum/type-classes.rst
+++ b/doc/sphinx/addendum/type-classes.rst
@@ -385,8 +385,10 @@ few other commands related to typeclasses.
 .. tacn:: typeclasses eauto
    :name: typeclasses eauto
 
-   This tactic uses a different resolution engine than :tacn:`eauto` and
-   :tacn:`auto`. The main differences are the following:
+   This proof search tactic implements the resolution engine that is run
+   implicitly during type-checking. This tactic uses a different resolution
+   engine than :tacn:`eauto` and :tacn:`auto`. The main differences are the
+   following:
 
    + Contrary to :tacn:`eauto` and :tacn:`auto`, the resolution is done entirely in
      the new proof engine (as of Coq 8.6), meaning that backtracking is
@@ -421,6 +423,17 @@ few other commands related to typeclasses.
      constants as the first argument of ``typeclasses eauto`` hence makes
      resolution with the local hypotheses use full conversion during
      unification.
+
+   + The mode hints (see :cmd:`Hint Mode`) associated to a class are
+     taken into account by :tacn:`typeclasses eauto`. When a goal
+     does not match any of the declared modes for its head (if any),
+     instead of failing like :tacn:`eauto`, the goal is suspended and
+     resolution proceeds on the remaining goals.
+     If after one run of resolution, there remains suspended goals,
+     resolution is launched against on them, until it reaches a fixed
+     point when the set of remaining suspended goals does not change.
+     Using `solve [typeclasses eauto]` can be used to ensure that
+     no suspended goals remain.
 
    + When considering local hypotheses, we use the union of all the modes
      declared in the given databases.

--- a/tactics/class_tactics.mli
+++ b/tactics/class_tactics.mli
@@ -66,4 +66,6 @@ module Search : sig
     -> Hints.hint_db list
     (** The list of hint databases to use *)
     -> unit Proofview.tactic
+    (** Note: there might be stuck goals due to mode declarations
+      remaining even in case of success of the tactic. *)
 end

--- a/tactics/eauto.ml
+++ b/tactics/eauto.ml
@@ -124,7 +124,10 @@ let hintmap_of sigma secvars hdc concl =
   | None -> fun db -> Hint_db.map_none ~secvars db
   | Some hdc ->
      if occur_existential sigma concl then
-       (fun db -> Hint_db.map_existential sigma ~secvars hdc concl db)
+       (fun db ->
+          match Hint_db.map_existential sigma ~secvars hdc concl db with
+          | ModeMatch l -> l
+          | ModeMismatch -> [])
      else (fun db -> Hint_db.map_auto sigma ~secvars hdc concl db)
    (* FIXME: should be (Hint_db.map_eauto hdc concl db) *)
 

--- a/tactics/hints.mli
+++ b/tactics/hints.mli
@@ -125,6 +125,10 @@ val glob_hints_path_atom :
 val glob_hints_path :
   Libnames.qualid hints_path_gen -> GlobRef.t hints_path_gen
 
+type 'a with_mode =
+  | ModeMatch of 'a
+  | ModeMismatch
+
 module Hint_db :
   sig
     type t
@@ -140,16 +144,20 @@ module Hint_db :
     val map_all : secvars:Id.Pred.t -> GlobRef.t -> t -> full_hint list
 
     (** All hints associated to the reference, respecting modes if evars appear in the
-        arguments, _not_ using the discrimination net. *)
+        arguments, _not_ using the discrimination net.
+        Returns a [ModeMismatch] if there are declared modes and none matches.
+        *)
     val map_existential : evar_map -> secvars:Id.Pred.t ->
-      (GlobRef.t * constr array) -> constr -> t -> full_hint list
+      (GlobRef.t * constr array) -> constr -> t -> full_hint list with_mode
 
     (** All hints associated to the reference, respecting modes if evars appear in the
-        arguments and using the discrimination net. *)
-    val map_eauto : evar_map -> secvars:Id.Pred.t -> (GlobRef.t * constr array) -> constr -> t -> full_hint list
+        arguments and using the discrimination net.
+        Returns a [ModeMismatch] if there are declared modes and none matches. *)
+    val map_eauto : evar_map -> secvars:Id.Pred.t -> (GlobRef.t * constr array) -> constr -> t -> full_hint list with_mode
 
-    (** All hints associated to the reference, respecting modes if evars appear in the
-        arguments. *)
+    (** All hints associated to the reference.
+        Precondition: no evars should appear in the arguments, so no modes
+        are checked. *)
     val map_auto : evar_map -> secvars:Id.Pred.t ->
        (GlobRef.t * constr array) -> constr -> t -> full_hint list
 

--- a/test-suite/bugs/closed/bug_9058.v
+++ b/test-suite/bugs/closed/bug_9058.v
@@ -1,0 +1,16 @@
+Class A (X : Type) := {}.
+Hint Mode A ! : typeclass_instances.
+
+Class B X {aX: A X} Y := { opB: X -> Y -> Y }.
+Hint Mode B - - ! : typeclass_instances.
+
+Section Section.
+
+Context X {aX: A X} Y {bY: B X Y}.
+
+(* Set Typeclasses Debug. *)
+
+Let ok := fun (x : X) (y : Y) => opB x y.
+Let ok' := fun x (y : Y) => opB x y.
+
+End Section.

--- a/test-suite/success/HintMode.v
+++ b/test-suite/success/HintMode.v
@@ -1,0 +1,20 @@
+Module Postponing.
+
+Class In A T := { IsIn : A -> T -> Prop }.
+Class Empty T := { empty : T }.
+Class EmptyIn (A T : Type) `{In A T} `{Empty T} :=
+ { isempty : forall x, IsIn x empty -> False }.
+
+Hint Mode EmptyIn ! ! - - : typeclass_instances.
+Hint Mode Empty ! : typeclass_instances.
+Hint Mode In ! - : typeclass_instances.
+Existing Class IsIn.
+Goal forall A T `{In A T} `{Empty T} `{EmptyIn A T}, forall x : A, IsIn x empty -> False.
+ Proof.
+   intros.
+   eapply @isempty. (* Second goal needs to be solved first, to un-stuck the first one
+   (hence the Existing Class IsIn to allow finding the assumption of IsIn here)  *)
+   all:typeclasses eauto.
+Qed.
+
+End Postponing.


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:**  feature

A constraint can be stuck if it does not match any of the declared modes
for its head (if there are any). In that case, the subgoal is postponed
and the next ones are tried. We do a fixed point computation until there
are no stuck subgoals or the set does not change (it is impossible to
make it grow, as asserted in the code, because it is always a subset of
the initial goals)

This allows constraints on classes with modes to be treated as if they were
in any order (yay for stability of solutions!). Also, ultimately it should
free us to launch resolutions more agressively (avoiding issues like the
ones seen in PR #10762).


<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [x] Added / updated test-suite
<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [x] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
