### PR TITLE
Fix #10864: add missing dependencies to build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ GRAMMLFILES := $(addsuffix .ml, $(GRAMFILES)) $(addsuffix .mli, $(GRAMFILES))
 GENGRAMFILES := $(GRAMMLFILES) gramlib/.pack/gramlib.ml
 GENMLFILES:=$(LEXFILES:.mll=.ml) $(YACCFILES:.mly=.ml) $(GENMLGFILES)  ide/coqide_os_specific.ml kernel/copcodes.ml kernel/uint63.ml
 GENHFILES:=kernel/byterun/coq_instruct.h kernel/byterun/coq_jumptbl.h
-GENFILES:=$(GENMLFILES) $(GENMLIFILES) $(GENHFILES)
+GENFILES:=$(GENMLFILES) $(GENMLIFILES) $(GENHFILES) $(GENGRAMFILES)
 COQ_EXPORTED += GRAMFILES GRAMMLFILES GENGRAMFILES GENMLFILES GENHFILES GENFILES
 
 ## More complex file lists


### PR DESCRIPTION
**Kind:** infrastructure.

Fixes / closes #10864

<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [ ] Added / updated test-suite: not yet, not sure how.

- [ ] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details): seems not relevant.

Manual testing:
`make -j8` didn't work for me to reproduce the bug, but I've tested this with (dangerous) commands `make -j` and `make -j gramlib/.pack/gramlib.cmo` (BEWARE they might overload and crash your machine, but my Mac seems fine).

TODO: somebody should forward-port to master. I'd like a review on this branch, as it'd be useful to add as a patch to ocaml/opam-repository#15017.
EDIT: I added it as a patch there, since their CI detects this Heisenbug better than the tests here.