### PR TITLE
Fix #10888: Context import behaviour in modtype

### DIFF
--- a/test-suite/bugs/closed/bug_10888.v
+++ b/test-suite/bugs/closed/bug_10888.v
@@ -1,0 +1,11 @@
+
+Module Type T.
+Context {A:Type}.
+End T.
+
+Module M(X:T).
+  Import X.
+  Check X.A.
+  Check A.
+  Definition B := A.
+End M.

--- a/vernac/comAssumption.ml
+++ b/vernac/comAssumption.ml
@@ -247,8 +247,10 @@ let context_nosection sigma ~poly ctx =
         let entry = Declare.definition_entry ~univs ~types:t b in
         Declare.DefinitionEntry entry
     in
-    (* let local = Declare.ImportNeedQualified in *)
-    let cst = Declare.declare_constant ~name ~kind ~local:Declare.ImportNeedQualified decl in
+    let local = if Lib.is_modtype () then Declare.ImportDefaultBehavior
+      else Declare.ImportNeedQualified
+    in
+    let cst = Declare.declare_constant ~name ~kind ~local decl in
     let () = Declare.assumption_message name in
     let env = Global.env () in
     (* why local when is_modtype? *)


### PR DESCRIPTION
Perennial uses this behaviour significantly https://github.com/mit-pdos/perennial/blob/28822b59b223cf18b611b4b566b5e3aa0b4d1883/src/CSL/RefinementIdempotenceModule.v#L18-L52

Fixes #10888