### PR TITLE
Fix #9851: anomaly when unsolved evar in Add Ring

### DIFF
--- a/plugins/setoid_ring/newring.ml
+++ b/plugins/setoid_ring/newring.ml
@@ -139,8 +139,8 @@ let _ = add_tacdef false ((Loc.ghost,Id.of_string"ring_closed_term"
 let ic c =
   let env = Global.env() in
   let sigma = Evd.from_env env in
-  let sigma, c = Constrintern.interp_open_constr env sigma c in
-  (sigma, c)
+  let c, uctx = Constrintern.interp_constr env sigma c in
+  (Evd.from_ctx uctx, c)
 
 let ic_unsafe c = (*FIXME remove *)
   let env = Global.env() in

--- a/test-suite/bugs/closed/bug_9851.v
+++ b/test-suite/bugs/closed/bug_9851.v
@@ -1,0 +1,18 @@
+Require Import Ring_base.
+Record word : Type := Build_word
+  { rep : Type;
+    zero : rep; one: rep;
+    add : rep -> rep -> rep;
+    sub : rep -> rep -> rep;
+    opp : rep -> rep;
+    mul : rep -> rep -> rep;
+    }.
+Axiom rth
+     : forall (word : word ),
+       @ring_theory (@rep word)
+         (@zero word)
+         (@one word) (@add word)
+         (@mul word) (@sub word)
+         (@opp word) (@eq (@rep word)).
+
+Fail Add Ring wring: (@rth _).


### PR DESCRIPTION
AFAICT there is no reason to use interp_open_constr

I used Evd.from_ctx to keep passing evar maps around but maybe we
should be passing ustates instead?

Fixes #9851