### PR TITLE
[engine] Remove UnivGen.global_of_constr

### DIFF
--- a/dev/doc/changes.md
+++ b/dev/doc/changes.md
@@ -2,6 +2,8 @@
 
 ### ML API
 
+- Function UnivGen.global_of_constr has been removed.
+
 - Functions and types deprecated in 8.10 have been removed in Coq
   8.11.
 

--- a/engine/univGen.ml
+++ b/engine/univGen.ml
@@ -82,14 +82,6 @@ let fresh_global_or_constr_instance env = function
   | IsConstr c -> c, ContextSet.empty
   | IsGlobal gr -> fresh_global_instance env gr
 
-let global_of_constr c =
-  match kind c with
-  | Const (c, u) -> GlobRef.ConstRef c, u
-  | Ind (i, u) -> GlobRef.IndRef i, u
-  | Construct (c, u) -> GlobRef.ConstructRef c, u
-  | Var id -> GlobRef.VarRef id, Instance.empty
-  | _ -> raise Not_found
-
 let fresh_sort_in_family = function
   | InSProp -> Sorts.sprop, ContextSet.empty
   | InProp -> Sorts.prop, ContextSet.empty

--- a/engine/univGen.mli
+++ b/engine/univGen.mli
@@ -54,9 +54,6 @@ val fresh_global_or_constr_instance : env -> Globnames.global_reference_or_const
 val fresh_universe_context_set_instance : ContextSet.t ->
   universe_level_subst * ContextSet.t
 
-(** Raises [Not_found] if not a global reference. *)
-val global_of_constr : constr -> GlobRef.t puniverses
-
 (** Create a fresh global in the global environment, without side effects.
     BEWARE: this raises an error on polymorphic constants/inductives:
     the constraints should be properly added to an evd.


### PR DESCRIPTION
This function is never used across the code base. Is has been introduced in #7384 (cc @SkySkimmer), moving around what had been introduced in a4043608f704f026de7eb5167a109ca48e00c221.

Its name and implementation are very similar to `Globnames.global_of_constr` except that this last one drops universes.

Keeping one of these two functions seems enough. I’ve chosen to remove the one that is not used, but this may be wrong.

TODO:
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
