### PR TITLE
Assign ownership of the test-suite compat files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -320,6 +320,8 @@ azure-pipelines.yml @coq/ci-maintainers
 /test-suite/unit-tests/src/ @jfehrle
 # Secondary maintainer      @SkySkimmer
 
+/test-suite/success/Compat*.v @JasonGross
+
 ########## Developer tools ##########
 
 /dev/tools/backport-pr.sh     @Zimmi48


### PR DESCRIPTION
After almost missing https://github.com/coq/coq/pull/10827#pullrequestreview-301428062, I decided I want to be notified when these are changed

**Kind:** infrastructure.

