### PR TITLE
Fixes #10894 regression: uconstr was not anymore typed in the Ltac-substituted environment

### DIFF
--- a/doc/changelog/05-tactic-language/10899-master+fix10894-regression-ltac-uconstr-typing.rst
+++ b/doc/changelog/05-tactic-language/10899-master+fix10894-regression-ltac-uconstr-typing.rst
@@ -1,0 +1,1 @@
+- Fixed bug #10894: Ltac1 regression in binding free names in uconstr (`#10899 <https://github.com/coq/coq/pull/10899>`_, by Hugo Herbelin).

--- a/pretyping/globEnv.ml
+++ b/pretyping/globEnv.ml
@@ -166,7 +166,7 @@ let interp_ltac_variable ?loc typing_fun env sigma id : Evd.evar_map * unsafe_ju
        here, as the call to the main pretyping function is caught
        inside the try but I want to avoid refactoring this function
        too much for now. *)
-    typing_fun {env with lvar} term
+    typing_fun {env with lvar; static_env = env.renamed_env} term
   with Not_found ->
   (* Check if [id] is a ltac variable not bound to a term *)
   (* and build a nice error message *)

--- a/test-suite/bugs/closed/bug_10894.v
+++ b/test-suite/bugs/closed/bug_10894.v
@@ -1,0 +1,12 @@
+(* Check that uconstrs are interpreted in the ltac-substituted environment *)
+(* Was a regression introduced in 4dab4fc (#7288) *)
+
+Tactic Notation "bind" hyp(x) "in" uconstr(f) "as" ident(h) :=
+   set (h := fun x => f).
+
+Fact test : nat -> nat.
+Proof.
+  intros n.
+  bind n in (n*n) as f.
+  assert (f 0 = 0) by reflexivity.
+Abort.


### PR DESCRIPTION
**Kind:** bug fix

Fixes #10894.

In the refactoring made in #7288 (4dab4fc), the computation of the Ltac-substituted environment was done at a different time and I forgot to take it into account in the case of interpreting `uconstr`s.

- [X] Added / updated test-suite

@Zimmi48 : should I add a changelog entry for a bug fix?
