### PR TITLE
Fix a De Bruijn bug in the computation of term relevance in the kernel.

### DIFF
--- a/dev/doc/critical-bugs
+++ b/dev/doc/critical-bugs
@@ -250,6 +250,17 @@ Conversion machines
   exploit: test-suite/bugs/closed/bug_9684.v
   GH issue number: #9684
 
+  component: lazy machine
+  summary: incorrect De Bruijn handling when inferring the relevance mark for a lambda
+  introduced: 2019-03-15, 23f84f37c674a07e925925b7e0d50d7ee8414093 and 71b9ad8526155020c8451dd326a52e391a9a8585, SkySkimmer
+  impacted released versions: 8.10.0
+  impacted coqchk versions: 8.10.0
+  found by: ppedrot investigating unexpected conversion failures with SProp
+  exploit: test-suite/bugs/closed/bug_10904.v
+  GH issue number: #10904
+  risk: none without using -allow-sprop (off by default in 8.10.0),
+        otherwise could be exploited by mistake
+
 Conflicts with axioms in library
 
   component: library of real numbers

--- a/doc/changelog/01-kernel/10904-fix-debruijn-sprop-rel.rst
+++ b/doc/changelog/01-kernel/10904-fix-debruijn-sprop-rel.rst
@@ -1,0 +1,3 @@
+- Fix proof of False when using |SProp| (incorrect De Bruijn handling
+  when inferring the relevance mark of a function) (`#10904
+  <https://github.com/coq/coq/pull/10904>`_, by Pierre-Marie Pédrot).

--- a/doc/sphinx/refman-preamble.rst
+++ b/doc/sphinx/refman-preamble.rst
@@ -70,7 +70,11 @@
 .. |p_i| replace:: `p`\ :math:`_{i}`
 .. |p_n| replace:: `p`\ :math:`_{n}`
 .. |Program| replace:: :strong:`Program`
+.. |Prop| replace:: :math:`\Prop`
+.. |SProp| replace:: :math:`\SProp`
+.. |Set| replace:: :math:`\Set`
 .. |SSR| replace:: :smallcaps:`SSReflect`
+.. |Type| replace:: :math:`\Type`
 .. |t_1| replace:: `t`\ :math:`_{1}`
 .. |t_i| replace:: `t`\ :math:`_{i}`
 .. |t_m| replace:: `t`\ :math:`_{m}`

--- a/kernel/retypeops.ml
+++ b/kernel/retypeops.ml
@@ -71,6 +71,7 @@ let rec relevance_of_fterm env extra lft f =
       | FLambda (len, tys, bdy, e) ->
         let extra = List.rev_append (List.map (fun (x,_) -> binder_relevance x) tys) extra in
         let lft = Esubst.el_liftn len lft in
+        let e = Esubst.subs_liftn len e in
         relevance_of_term_extra env extra lft e bdy
       | FLetIn (x, _, _, bdy, e) ->
         relevance_of_term_extra env (x.binder_relevance :: extra)

--- a/test-suite/bugs/closed/bug_10904.v
+++ b/test-suite/bugs/closed/bug_10904.v
@@ -1,0 +1,8 @@
+Definition a := fun (P:SProp) (p:P) => p.
+
+Lemma foo : (let k := a in let k' := a in fun (x:nat) y => x) = (let k := a in fun x y => y).
+Proof.
+  Fail reflexivity.
+  match goal with |- ?l = _ => exact_no_check (eq_refl l) end.
+Fail Qed.
+Abort.


### PR DESCRIPTION
Opening up a lambda should always lift the substitution attached to it. You can probably weaponize this to a proof of False.