### PR TITLE
[ci] Add rewriter plugin to the ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -696,3 +696,6 @@ plugin:ci-quickchick:
 
 plugin:ci-relation_algebra:
   extends: .ci-template
+
+plugin:ci-rewriter:
+  extends: .ci-template

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -38,6 +38,7 @@ CI_TARGETS= \
     ci-perennial \
     ci-quickchick \
     ci-relation_algebra \
+    ci-rewriter \
     ci-sf \
     ci-simple-io \
     ci-stdlib2 \

--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -276,6 +276,13 @@
 : "${relation_algebra_CI_ARCHIVEURL:=${relation_algebra_CI_GITURL}/archive}"
 
 ########################################################################
+# rewriter
+########################################################################
+: "${rewriter_CI_REF:=master}"
+: "${rewriter_CI_GITURL:=https://github.com/mit-plv/rewriter}"
+: "${rewriter_CI_ARCHIVEURL:=${rewriter_CI_GITURL}/archive}"
+
+########################################################################
 # StructTact + InfSeqExt + Cheerios + Verdi + Verdi Raft
 ########################################################################
 : "${struct_tact_CI_REF:=master}"

--- a/dev/ci/ci-rewriter.sh
+++ b/dev/ci/ci-rewriter.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+ci_dir="$(dirname "$0")"
+. "${ci_dir}/ci-common.sh"
+
+FORCE_GIT=1
+git_download rewriter
+
+( cd "${CI_BUILD_DIR}/rewriter" && make && make install )


### PR DESCRIPTION
fiat-crypto will soon depend on it, and I don't want changes to Coq
master to break this anymore in the meantime.

**Kind:** infrastructure.

Note that this currently doesn't build on master, because #10862 broke it.  It compiles immediately before #10862.  I'm willing to wait a bit to merge the change into fiat-crypto that makes it depend on this, but I'd like some help with getting master working with this plugin again.

cc @SkySkimmer 