### PR TITLE
Fix Locate printing regression

### DIFF
--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -1836,7 +1836,7 @@ let locate_notation prglob ntn scope =
     str "Notation" ++ fnl () ++
     prlist_with_sep fnl (fun (ntn,l) ->
       let scope = find_default ntn scopes in
-      prlist
+      prlist_with_sep fnl
 	(fun (sc,r,(_,df)) ->
 	  hov 0 (
 	    pr_notation_info prglob df r ++

--- a/test-suite/output/locate.out
+++ b/test-suite/output/locate.out
@@ -1,0 +1,3 @@
+Notation
+"b1 && b2" := if b1 then b2 else false (default interpretation)
+"x && y" := andb x y : bool_scope

--- a/test-suite/output/locate.v
+++ b/test-suite/output/locate.v
@@ -1,0 +1,3 @@
+Set Printing Width 400.
+Notation "b1 && b2" := (if b1 then b2 else false).
+Locate "&&".


### PR DESCRIPTION

**Kind:** bug fix.

Fixes / closes #9428
(Again.)
Corrects a 8.9.1 → 8.10.0 regression.

This is a cherry-pick of 68927ac4 / 4b02fbd9 bugfixes, because 0251c800 reverted them.



<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [x] Added / updated test-suite
<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [ ] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [ ] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).

