### PR TITLE
Fixing "is_imported_ref" with respect to the specification the name of this function suggests

### DIFF
--- a/engine/namegen.ml
+++ b/engine/namegen.ml
@@ -62,14 +62,16 @@ let default_generated_non_letter_string = "x"
 (**********************************************************************)
 (* Globality of identifiers *)
 
-let is_imported_modpath = function
-  | MPfile dp ->
-    let rec find_prefix = function
-      |MPfile dp1 -> not (DirPath.equal dp1 dp)
-      |MPdot(mp,_) -> find_prefix mp
-      |MPbound(_) -> false
-    in find_prefix (Lib.current_mp ())
-  | _ -> false
+let rec find_prefix = function
+  | MPfile dp -> Some dp
+  | MPdot (mp,_) -> find_prefix mp
+  | MPbound _ -> None
+
+let is_imported_modpath mp =
+  match find_prefix mp, find_prefix (Lib.current_mp ()) with
+  | _, None -> assert false
+  | None, _ -> false
+  | Some dp, Some dp1 -> not (DirPath.equal dp1 dp)
 
 let is_imported_ref = let open GlobRef in function
   | VarRef _ -> false


### PR DESCRIPTION
**Kind:** bug fix

This is a minimal fix so that #10827 does not rename `R` in the following kind of example:
```
Require Import Reals.
Goal forall R, R=0.
```

There is indeed a strategy to renaming a goal variable when a constant of same name exists in the same file. This strategy relies on a function called `is_imported_ref`. Obviously this test is wrong (wrt the name of the function), when the constant is in a submodule of an imported file. This is what this PR fixes.

My feeling (especially considering the problems raised with goal variable being named differently than what the user demanded, see issue #9593 opened by @SkySkimmer), is that there should be no renaming even when a constant of same name exists in the same module (or at least a warning about the renaming).

But, before going a more drastic way, let's fix the current intended policy.

- [ ] Added / updated test-suite

