### PR TITLE
Unconditionally add local universe constraints in unification.

### DIFF
--- a/engine/uState.ml
+++ b/engine/uState.ml
@@ -261,11 +261,13 @@ let process_universe_constraints ctx cstrs =
                     in
                     LSet.fold fold levels local
               else
-                match Univ.Universe.level l with
-                | Some l ->
-                  Univ.Constraint.add (l, Le, r') local
-                | None ->
-                  if UGraph.check_leq univs l r then local else enforce_leq l r local
+                let fold accu (l', n) = match n with
+                | 0 -> Univ.Constraint.add (l', Le, r') accu
+                | 1 -> Univ.Constraint.add (l', Lt, r') accu
+                | n -> raise (UniverseInconsistency (Le, l, r, None))
+                in
+                let l = Univ.Universe.map (fun p -> p) l in
+                List.fold_left fold local l
               end
           | ULub (l, r) ->
               equalize_variables true (Universe.make l) l (Universe.make r) r local


### PR DESCRIPTION
Instead of checking whether the new constraints are already implied by the graph, we always add them to the local set of constraints. The rationale is that checking impliciation is very costly, and that we already add them altogether when the left-hand side is a simple level.

Bench:
```
┌────────────────────────┬─────────────────────────┬─────────────────────────────────────────────┬─────────────────────────────────────────────┬───────────────────────────────┬──────────────────────────┐
│                        │      user time [s]      │                 CPU cycles                  │              CPU instructions               │     max resident mem [KB]     │        mem faults        │
│                        │                         │                                             │                                             │                               │                          │
│           package_name │     NEW     OLD PDIFF   │               NEW               OLD PDIFF   │               NEW               OLD PDIFF   │        NEW        OLD PDIFF   │     NEW     OLD  PDIFF   │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼──────────────────────────┤
│           coq-rewriter │  459.12  472.46 -2.82 % │     1277151758111     1314092099659 -2.81 % │     1866899040245     1902881543623 -1.89 % │     998656     996492 +0.22 % │     229     206 +11.17 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼──────────────────────────┤
│ coq-mathcomp-character │  178.66  182.14 -1.91 % │      496688111520      506701960123 -1.98 % │      660876203296      670649269903 -1.46 % │     800212     859732 -6.92 % │       1      78 -98.72 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼──────────────────────────┤
│        coq-lambda-rust │ 1507.44 1535.74 -1.84 % │     4200979241759     4281144151750 -1.87 % │     5622091963161     5658161114403 -0.64 % │    1214524    1201496 +1.08 % │      55       0   +nan % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼──────────────────────────┤
│            coq-coqutil │   60.22   60.80 -0.95 % │      168030914072      169581736282 -0.91 % │      205506689846      207212534674 -0.82 % │     545172     543236 +0.36 % │       1       1  +0.00 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼──────────────────────────┤
│     coq-mathcomp-field │  228.35  230.00 -0.72 % │      636193082610      641114844043 -0.77 % │      913976078116      916603400588 -0.29 % │     750312     749376 +0.12 % │       0       6 -100.00 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼──────────────────────────┤
│   coq-mathcomp-algebra │  162.58  163.48 -0.55 % │      453502195617      455805528840 -0.51 % │      564324541537      564946827940 -0.11 % │     614128     610800 +0.54 % │      97       9 +977.78 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼──────────────────────────┤
│       coq-math-classes │  213.83  214.79 -0.45 % │      597051483199      600669345116 -0.60 % │      761577820348      763011124416 -0.19 % │     519076     515832 +0.63 % │      55      18 +205.56 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼──────────────────────────┤
│       coq-fiat-parsers │  648.45  651.30 -0.44 % │     1814417515218     1823443298554 -0.49 % │     2736072895310     2742312251750 -0.23 % │    3206908    3207160 -0.01 % │     321     724 -55.66 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼──────────────────────────┤
│               coq-corn │ 1494.30 1500.07 -0.38 % │     4173297227880     4187338405927 -0.34 % │     6145419235486     6148554352481 -0.05 % │     855780     854696 +0.13 % │       1       1  +0.00 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼──────────────────────────┤
│              coq-verdi │  120.78  121.22 -0.36 % │      335969346578      336978813251 -0.30 % │      420631707283      419973398201 +0.16 % │     558636     552116 +1.18 % │      13       6 +116.67 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼──────────────────────────┤
│            coq-unimath │ 4116.27 4125.62 -0.23 % │    11470913162058    11490562113297 -0.17 % │    21046335399220    21041610419382 +0.02 % │    1101516    1101332 +0.02 % │     547     190 +187.89 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼──────────────────────────┤
│           coq-compcert │  776.22  777.43 -0.16 % │     2162451654865     2166791683839 -0.20 % │     2890539547896     2896982558002 -0.22 % │    1068572    1064988 +0.34 % │     271     211 +28.44 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼──────────────────────────┤
│         coq-coquelicot │   77.36   77.44 -0.10 % │      212568388033      212885086408 -0.15 % │      258221019268      257841401003 +0.15 % │     684756     680744 +0.59 % │     213      11 +1836.36 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼──────────────────────────┤
│             coq-geocoq │ 1583.73 1584.22 -0.03 % │     4422930341692     4424603859693 -0.04 % │     6463354101118     6463005577936 +0.01 % │    1367820    1364776 +0.22 % │     112     118  -5.08 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼──────────────────────────┤
│              coq-color │  714.58  714.71 -0.02 % │     1996627818878     1997175619368 -0.03 % │     2370893832955     2366192402273 +0.20 % │    1154616    1155212 -0.05 % │     131     148 -11.49 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼──────────────────────────┤
│ coq-mathcomp-odd-order │ 1449.18 1449.40 -0.02 % │     4039339739276     4039996444675 -0.02 % │     6883685729380     6884907566798 -0.02 % │    1304004    1294376 +0.74 % │     115     171 -32.75 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼──────────────────────────┤
│  coq-mathcomp-solvable │  189.36  189.32 +0.02 % │      527452791030      527963455873 -0.10 % │      705278118459      706071789006 -0.11 % │     794720     787328 +0.94 % │       2       0   +nan % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼──────────────────────────┤
│  coq-mathcomp-fingroup │   51.32   51.27 +0.10 % │      142886319358      143042643017 -0.11 % │      186023702508      185943557147 +0.04 % │     561392     558680 +0.49 % │       2      51 -96.08 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼──────────────────────────┤
│ coq-fiat-crypto-legacy │ 6365.35 6355.58 +0.15 % │    17728683080346    17696063048015 +0.18 % │    28774583484676    28745115576051 +0.10 % │    2429312    2409948 +0.80 % │    1215    1280  -5.08 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼──────────────────────────┤
│          coq-fourcolor │ 2166.37 2162.86 +0.16 % │     6039045564632     6031170195289 +0.13 % │    11349770470257    11367747634190 -0.16 % │     958436     948152 +1.08 % │       1       0   +nan % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼──────────────────────────┤
│              coq-flocq │  250.20  249.62 +0.23 % │      695755896838      694367570760 +0.20 % │      870328083684      867725213074 +0.30 % │    1016228    1016332 -0.01 % │     228      20 +1040.00 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼──────────────────────────┤
│ coq-mathcomp-ssreflect │   40.43   40.32 +0.27 % │      111768651626      111222498678 +0.49 % │      135492663807      134795904317 +0.52 % │     523240     520576 +0.51 % │      22     126 -82.54 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼──────────────────────────┤
│           coq-coqprime │  185.72  185.06 +0.36 % │      515494044540      514455854174 +0.20 % │      917670294545      916677853375 +0.11 % │     812572     813880 -0.16 % │      37       5 +640.00 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼──────────────────────────┤
│          coq-fiat-core │  115.75  115.07 +0.59 % │      328928692001      328071072238 +0.26 % │      410116651413      407751095486 +0.58 % │     513244     509472 +0.74 % │      42      10 +320.00 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼──────────────────────────┤
│         coq-verdi-raft │ 1342.58 1332.22 +0.78 % │     3745184946331     3716969642407 +0.76 % │     5068237310199     5026413510143 +0.83 % │    1828068    1822848 +0.29 % │       0       1 -100.00 % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼──────────────────────────┤
│             coq-sf-plf │   45.42   45.04 +0.84 % │      126389478478      126183851190 +0.16 % │      163251772917      163011658754 +0.15 % │     493660     493700 -0.01 % │      32       0   +nan % │
├────────────────────────┼─────────────────────────┼─────────────────────────────────────────────┼─────────────────────────────────────────────┼───────────────────────────────┼──────────────────────────┤
│            coq-bignums │   70.68   69.80 +1.26 % │      193590976868      192492344394 +0.57 % │      257604689471      256571070330 +0.40 % │     502632     499440 +0.64 % │     135      77 +75.32 % │
└────────────────────────┴─────────────────────────┴─────────────────────────────────────────────┴─────────────────────────────────────────────┴───────────────────────────────┴──────────────────────────┘
```