### PR TITLE
[meta] Add plugin stanza to META so Fl_dynload works for Coq plugins

### DIFF
--- a/META.coq.in
+++ b/META.coq.in
@@ -288,6 +288,8 @@ package "plugins" (
     archive(byte)    = "ltac_plugin.cmo"
     archive(native)  = "ltac_plugin.cmx"
 
+    plugin(byte)    = "ltac_plugin.cmo"
+    plugin(native)  = "ltac_plugin.cmxs"
   )
 
   package "tauto" (
@@ -300,6 +302,9 @@ package "plugins" (
 
     archive(byte)    = "tauto_plugin.cmo"
     archive(native)  = "tauto_plugin.cmx"
+
+    plugin(byte)    = "tauto_plugin.cmo"
+    plugin(native)  = "tauto_plugin.cmxs"
   )
 
   package "omega" (
@@ -312,6 +317,9 @@ package "plugins" (
 
     archive(byte)    = "omega_plugin.cmo"
     archive(native)  = "omega_plugin.cmx"
+
+    plugin(byte)    = "omega_plugin.cmo"
+    plugin(native)  = "omega_plugin.cmxs"
   )
 
   package "micromega" (
@@ -324,6 +332,9 @@ package "plugins" (
 
     archive(byte)    = "micromega_plugin.cmo"
     archive(native)  = "micromega_plugin.cmx"
+
+    plugin(byte)    = "micromega_plugin.cmo"
+    plugin(native)  = "micromega_plugin.cmxs"
   )
 
   package "setoid_ring" (
@@ -336,6 +347,9 @@ package "plugins" (
 
     archive(byte)    = "newring_plugin.cmo"
     archive(native)  = "newring_plugin.cmx"
+
+    plugin(byte)    = "newring_plugin.cmo"
+    plugin(native)  = "newring_plugin.cmxs"
   )
 
   package "extraction" (
@@ -348,6 +362,9 @@ package "plugins" (
 
     archive(byte)    = "extraction_plugin.cmo"
     archive(native)  = "extraction_plugin.cmx"
+
+    plugin(byte)    = "extraction_plugin.cmo"
+    plugin(native)  = "extraction_plugin.cmxs"
   )
 
   package "cc" (
@@ -360,6 +377,9 @@ package "plugins" (
 
     archive(byte)    = "cc_plugin.cmo"
     archive(native)  = "cc_plugin.cmx"
+
+    plugin(byte)    = "cc_plugin.cmo"
+    plugin(native)  = "cc_plugin.cmxs"
   )
 
   package "firstorder" (
@@ -372,6 +392,9 @@ package "plugins" (
 
     archive(byte)    = "ground_plugin.cmo"
     archive(native)  = "ground_plugin.cmx"
+
+    plugin(byte)    = "ground_plugin.cmo"
+    plugin(native)  = "ground_plugin.cmxs"
   )
 
   package "rtauto" (
@@ -384,6 +407,9 @@ package "plugins" (
 
     archive(byte)    = "rtauto_plugin.cmo"
     archive(native)  = "rtauto_plugin.cmx"
+
+    plugin(byte)    = "rtauto_plugin.cmo"
+    plugin(native)  = "rtauto_plugin.cmxs"
   )
 
   package "btauto" (
@@ -396,6 +422,9 @@ package "plugins" (
 
     archive(byte)    = "btauto_plugin.cmo"
     archive(native)  = "btauto_plugin.cmx"
+
+    plugin(byte)    = "btauto_plugin.cmo"
+    plugin(native)  = "btauto_plugin.cmxs"
   )
 
   package "funind" (
@@ -408,6 +437,9 @@ package "plugins" (
 
     archive(byte)    = "recdef_plugin.cmo"
     archive(native)  = "recdef_plugin.cmx"
+
+    plugin(byte)    = "recdef_plugin.cmo"
+    plugin(native)  = "recdef_plugin.cmxs"
   )
 
   package "nsatz" (
@@ -420,6 +452,9 @@ package "plugins" (
 
     archive(byte)    = "nsatz_plugin.cmo"
     archive(native)  = "nsatz_plugin.cmx"
+
+    plugin(byte)    = "nsatz_plugin.cmo"
+    plugin(native)  = "nsatz_plugin.cmxs"
   )
 
   package "rsyntax" (
@@ -432,6 +467,9 @@ package "plugins" (
 
     archive(byte)    = "r_syntax_plugin.cmo"
     archive(native)  = "r_syntax_plugin.cmx"
+
+    plugin(byte)    = "r_syntax_plugin.cmo"
+    plugin(native)  = "r_syntax_plugin.cmxs"
   )
 
   package "int63syntax" (
@@ -444,6 +482,9 @@ package "plugins" (
 
     archive(byte)    = "int63_syntax_plugin.cmo"
     archive(native)  = "int63_syntax_plugin.cmx"
+
+    plugin(byte)    = "int63_syntax_plugin.cmo"
+    plugin(native)  = "int63_syntax_plugin.cmxs"
   )
 
   package "string_notation" (
@@ -456,6 +497,9 @@ package "plugins" (
 
     archive(byte)    = "string_notation_plugin.cmo"
     archive(native)  = "string_notation_plugin.cmx"
+
+    plugin(byte)    = "string_notation_plugin.cmo"
+    plugin(native)  = "string_notation_plugin.cmxs"
   )
 
   package "derive" (
@@ -468,6 +512,9 @@ package "plugins" (
 
     archive(byte)    = "derive_plugin.cmo"
     archive(native)  = "derive_plugin.cmx"
+
+    plugin(byte)    = "derive_plugin.cmo"
+    plugin(native)  = "derive_plugin.cmxs"
   )
 
   package "ssrmatching" (
@@ -480,6 +527,9 @@ package "plugins" (
 
     archive(byte)    = "ssrmatching_plugin.cmo"
     archive(native)  = "ssrmatching_plugin.cmx"
+
+    plugin(byte)    = "ssrmatching_plugin.cmo"
+    plugin(native)  = "ssrmatching_plugin.cmxs"
   )
 
   package "ssreflect" (
@@ -492,5 +542,8 @@ package "plugins" (
 
     archive(byte)    = "ssreflect_plugin.cmo"
     archive(native)  = "ssreflect_plugin.cmx"
+
+    plugin(byte)    = "ssreflect_plugin.cmo"
+    plugin(native)  = "ssreflect_plugin.cmxs"
   )
 )


### PR DESCRIPTION
This should be backported to 8.10.
