### PR TITLE
Rename `VDFILE` from `.coqdeps.d` to `.<CoqMakefile>.d` in `coq_makefile`

### DIFF
--- a/doc/changelog/08-tools/10947-coq-makefile-dep.rst
+++ b/doc/changelog/08-tools/10947-coq-makefile-dep.rst
@@ -1,0 +1,5 @@
+- Renamed `VDFILE` from `.coqdeps.d` to `.<CoqMakefile>.d` in the `coq_makefile`
+  utility, where `<CoqMakefile>` is the name of the output file given by the
+  `-o` option. In this way two generated makefiles can coexist in the same
+  directory.
+  (`#10947 <https://github.com/coq/coq/pull/10947>`_, by Kazuhiko Sakaguchi).

--- a/tools/CoqMakefile.in
+++ b/tools/CoqMakefile.in
@@ -226,7 +226,7 @@ COQTOPINSTALL = $(call concat_path,$(DESTDIR),$(COQLIB)/toploop)
 # We here define a bunch of variables about the files being part of the
 # Coq project in order to ease the writing of build target and build rules
 
-VDFILE := .coqdeps
+VDFILE := @DEP_FILE@
 
 ALLSRCFILES := \
 	$(MLGFILES) \
@@ -312,7 +312,7 @@ else
 DO_NATDYNLINK =
 endif
 
-ALLDFILES = $(addsuffix .d,$(ALLSRCFILES) $(VDFILE))
+ALLDFILES = $(addsuffix .d,$(ALLSRCFILES)) $(VDFILE)
 
 # Compilation targets #########################################################
 
@@ -732,7 +732,7 @@ $(addsuffix .d,$(MLPACKFILES)): %.mlpack.d: %.mlpack
 # projects. Note that extra options might be on the command line.
 VDFILE_FLAGS:=$(if @PROJECT_FILE@,-f @PROJECT_FILE@,) $(CMDLINE_COQLIBS) $(CMDLINE_VFILES)
 
-$(VDFILE).d: $(VFILES)
+$(VDFILE): $(VFILES)
 	$(SHOW)'COQDEP VFILES'
 	$(HIDE)$(COQDEP) -dyndep var $(VDFILE_FLAGS) $(redir_if_ok)
 

--- a/tools/coq_makefile.ml
+++ b/tools/coq_makefile.ml
@@ -122,7 +122,7 @@ let read_whole_file s =
 
 let quote s = if String.contains s ' ' || CString.is_empty s then "'" ^ s ^ "'" else s
 
-let generate_makefile oc conf_file local_file args project =
+let generate_makefile oc conf_file local_file dep_file args project =
   let coqlib = Envars.coqlib () in
   let makefile_template =
     let template = Filename.concat "tools" "CoqMakefile.in" in
@@ -133,6 +133,7 @@ let generate_makefile oc conf_file local_file args project =
     (fun s (k,v) -> Str.global_substitute (Str.regexp_string k) (fun _ -> v) s) s
     [ "@CONF_FILE@", conf_file;
       "@LOCAL_FILE@", local_file;
+      "@DEP_FILE@", dep_file;
       "@COQ_VERSION@", Coq_config.version;
       "@PROJECT_FILE@", (Option.default "" project.project_file);
       "@COQ_MAKEFILE_INVOCATION@",String.concat " " (List.map quote args);
@@ -412,6 +413,7 @@ let _ =
 
   let conf_file = Option.default "CoqMakefile" project.makefile ^ ".conf" in
   let local_file = Option.default "CoqMakefile" project.makefile ^ ".local" in
+  let dep_file = "." ^ Option.default "CoqMakefile" project.makefile ^ ".d" in
 
   if project.extra_targets <> [] then begin
     eprintf "Warning: -extra and -extra-phony are deprecated.\n";
@@ -434,7 +436,7 @@ let _ =
   Envars.set_coqlib ~fail:(fun x -> Printf.eprintf "Error: %s\n" x; exit 1);
 
   let ocm = Option.cata open_out stdout project.makefile in
-  generate_makefile ocm conf_file local_file (prog :: args) project;
+  generate_makefile ocm conf_file local_file dep_file (prog :: args) project;
   close_out ocm;
   let occ = open_out conf_file in
   generate_conf occ project (prog :: args);


### PR DESCRIPTION
The `coq_makefile` utility and `Makefile`s generated by it generate and include some files: `<CoqMakefile>.conf`, `<CoqMakefile>.local`, and the dependency file `.coqdep.d`, where `<CoqMakefile>` is the name of the output file given by the `-o` option.  Out of these, only the name of the dependency file `.coqdep.d` is fixed to a constant. This seems to be a potential pitfall when we place multiple `Makefile`s generated by `coq_makefile` in the same directory. This patch renames `.coqdeps.d` to `.<CoqMakefile>.d`.

**Kind:** enhancement.

Fixes / closes #10839 (also addresses #10565 but it's closed)

- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
