### PR TITLE
[declare] Remove declare_scheme hook in Declare

### DIFF
--- a/tactics/declare.ml
+++ b/tactics/declare.ml
@@ -139,9 +139,6 @@ let (inConstant : constant_obj -> obj) =
     subst_function = ident_subst_function;
     discharge_function = discharge_constant }
 
-let declare_scheme = ref (fun _ _ -> assert false)
-let set_declare_scheme f = declare_scheme := f
-
 let update_tables c =
   Impargs.declare_constant_implicits c;
   Notation.declare_ref_arguments_scope Evd.empty (GlobRef.ConstRef c)
@@ -159,7 +156,7 @@ let register_side_effect (c, role) =
   let () = register_constant c Decls.(IsProof Theorem) ImportDefaultBehavior in
   match role with
   | None -> ()
-  | Some (Evd.Schema (ind, kind)) -> !declare_scheme kind [|ind,c|]
+  | Some (Evd.Schema (ind, kind)) -> DeclareScheme.declare_scheme kind [|ind,c|]
 
 let record_aux env s_ty s_bo =
   let open Environ in

--- a/tactics/declare.mli
+++ b/tactics/declare.mli
@@ -117,11 +117,6 @@ val inline_private_constants
   -> Evd.side_effects proof_entry
   -> Constr.t * UState.t
 
-(** Since transparent constants' side effects are globally declared, we
- *  need that *)
-val set_declare_scheme :
-  (string -> (inductive * Constant.t) array -> unit) -> unit
-
 (** Declaration messages *)
 
 val definition_message : Id.t -> unit

--- a/tactics/declareScheme.ml
+++ b/tactics/declareScheme.ml
@@ -1,0 +1,42 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *   INRIA, CNRS and contributors - Copyright 1999-2019       *)
+(* <O___,, *       (see CREDITS file for the list of authors)           *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+open Names
+
+let scheme_map = Summary.ref Indmap.empty ~name:"Schemes"
+
+let cache_one_scheme kind (ind,const) =
+  let map = try Indmap.find ind !scheme_map with Not_found -> CString.Map.empty in
+  scheme_map := Indmap.add ind (CString.Map.add kind const map) !scheme_map
+
+let cache_scheme (_,(kind,l)) =
+  Array.iter (cache_one_scheme kind) l
+
+let subst_one_scheme subst (ind,const) =
+  (* Remark: const is a def: the result of substitution is a constant *)
+  (Mod_subst.subst_ind subst ind, Mod_subst.subst_constant subst const)
+
+let subst_scheme (subst,(kind,l)) =
+  (kind, CArray.Smart.map (subst_one_scheme subst) l)
+
+let discharge_scheme (_,(kind,l)) =
+  Some (kind, l)
+
+let inScheme : string * (inductive * Constant.t) array -> Libobject.obj =
+  let open Libobject in
+  declare_object @@ superglobal_object "SCHEME"
+    ~cache:cache_scheme
+    ~subst:(Some subst_scheme)
+    ~discharge:discharge_scheme
+
+let declare_scheme kind indcl =
+  Lib.add_anonymous_leaf (inScheme (kind,indcl))
+
+let lookup_scheme kind ind = CString.Map.find kind (Indmap.find ind !scheme_map)

--- a/tactics/declareScheme.mli
+++ b/tactics/declareScheme.mli
@@ -1,0 +1,12 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *   INRIA, CNRS and contributors - Copyright 1999-2019       *)
+(* <O___,, *       (see CREDITS file for the list of authors)           *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+val declare_scheme : string -> (Names.inductive * Names.Constant.t) array -> unit
+val lookup_scheme : string -> Names.inductive -> Names.Constant.t

--- a/tactics/ind_tables.mli
+++ b/tactics/ind_tables.mli
@@ -30,7 +30,9 @@ type mutual_scheme_object_function =
 type individual_scheme_object_function =
   internal_flag -> inductive -> constr Evd.in_evar_universe_context * Evd.side_effects
 
-(** Main functions to register a scheme builder *)
+(** Main functions to register a scheme builder. Note these functions
+   are not safe to be used by plugins as their effects won't be undone
+   on backtracking *)
 
 val declare_mutual_scheme_object : string -> ?aux:string ->
   mutual_scheme_object_function -> mutual scheme_kind

--- a/tactics/tactics.mllib
+++ b/tactics/tactics.mllib
@@ -1,3 +1,4 @@
+DeclareScheme
 Declare
 Proof_global
 Pfedit


### PR DESCRIPTION
We introduce a new module that registers the scheme information that
side-effects need, thus removing the hook from `Declare`.

As we may want to deprecate scheme side effects, there is no need to
design a general mechanism for this kind of registration for now.

Would we remove the scheme side-effects the scheme code could become
self-contained again.
