### PR TITLE
Elan → Stratego in documentation of `rewrite_strat`.

### DIFF
--- a/doc/sphinx/addendum/generalized-rewriting.rst
+++ b/doc/sphinx/addendum/generalized-rewriting.rst
@@ -714,8 +714,10 @@ Definitions
 
 The generalized rewriting tactic is based on a set of strategies that can be
 combined to obtain custom rewriting procedures. Its set of strategies is based
-on Elan’s rewriting strategies :cite:`Luttik97specificationof`. Rewriting
-strategies are applied using the tactic :n:`rewrite_strat @strategy` where :token:`strategy` is a
+on the programmable rewriting strategies with generic traversals by Visser et al.
+:cite:`Luttik97specificationof` :cite:`Visser98`, which formed the core of
+the Stratego transformation language :cite:`Visser01`. Rewriting strategies
+are applied using the tactic :n:`rewrite_strat @strategy` where :token:`strategy` is a
 strategy expression. Strategies are defined inductively as described by the
 following grammar:
 

--- a/doc/sphinx/biblio.bib
+++ b/doc/sphinx/biblio.bib
@@ -340,6 +340,27 @@ s},
   year = {1997}
 }
 
+@inproceedings{Visser98,
+  author    = {Eelco Visser and
+               Zine{-}El{-}Abidine Benaissa and
+               Andrew P. Tolmach},
+  title     = {Building Program Optimizers with Rewriting Strategies},
+  booktitle = {ICFP},
+  pages     = {13--26},
+  year      = {1998},
+}
+
+@inproceedings{Visser01,
+  author    = {Eelco Visser},
+  title     = {Stratego: {A} Language for Program Transformation Based on Rewriting
+               Strategies},
+  booktitle = {RTA},
+  pages     = {357--362},
+  year      = {2001},
+  series    = {LNCS},
+  volume    = {2051},
+}
+
 @InProceedings{DBLP:conf/types/McBride00,
   author    = {Conor McBride},
   title     = {Elimination with a Motive},


### PR DESCRIPTION
@eelcovisser told me that the strategies in Luttik and Visser 97 were inspired by Elan, but they are not part of Elan. They are part of the Stratego language.

Kind: documentation