### PR TITLE
Add missing instances for `implb` and `xorb` in ZifyBool.v

### DIFF
--- a/plugins/micromega/ZifyBool.v
+++ b/plugins/micromega/ZifyBool.v
@@ -42,6 +42,16 @@ Instance Op_orb : BinOp orb :=
     TBOpInj := ltac:(destruct n,m; reflexivity)}.
 Add BinOp Op_orb.
 
+Instance Op_implb : BinOp implb :=
+  { TBOp := fun x y => Z.max (1 - x) y;
+    TBOpInj := ltac:(destruct n,m; reflexivity) }.
+Add BinOp Op_implb.
+
+Instance Op_xorb : BinOp xorb :=
+  { TBOp := fun x y => Z.max (x - y) (y - x);
+    TBOpInj := ltac:(destruct n,m; reflexivity) }.
+Add BinOp Op_xorb.
+
 Instance Op_negb : UnOp negb :=
   { TUOp := fun x => 1 - x ; TUOpInj := ltac:(destruct x; reflexivity)}.
 Add UnOp Op_negb.


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** enhancement.

<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [ ] Added / updated test-suite
