### PR TITLE
`assert_succeeds`&`assert_fails`: multisuccess fix

### DIFF
--- a/doc/changelog/04-tactics/10966-assert-succeeds-once.rst
+++ b/doc/changelog/04-tactics/10966-assert-succeeds-once.rst
@@ -4,3 +4,8 @@
   multisuccess tactics with :tacn:`assert_succeeds`.  (`#10966
   <https://github.com/coq/coq/pull/10966>`_ fixes `#10965
   <https://github.com/coq/coq/issues/10965>`_, by Jason Gross).
+
+- The :tacn:`assert_succeeds` and :tacn:`assert_fails` tactics now
+  behave correctly when their tactic fully solves the goal.  (`#10966
+  <https://github.com/coq/coq/pull/10966>`_ fixes `#9114
+  <https://github.com/coq/coq/issues/9114>`_, by Jason Gross).

--- a/doc/changelog/04-tactics/10966-assert-succeeds-once.rst
+++ b/doc/changelog/04-tactics/10966-assert-succeeds-once.rst
@@ -1,0 +1,6 @@
+- The :tacn:`assert_succeeds` and :tacn:`assert_fails` tactics now
+  only run their tactic argument once, even if it has multiple
+  successes.  This prevents blow-up and looping from using
+  multisuccess tactics with :tacn:`assert_succeeds`.  (`#10966
+  <https://github.com/coq/coq/pull/10966>`_ fixes `#10965
+  <https://github.com/coq/coq/issues/10965>`_, by Jason Gross).

--- a/doc/sphinx/proof-engine/ltac.rst
+++ b/doc/sphinx/proof-engine/ltac.rst
@@ -516,7 +516,7 @@ Coq provides a derived tactic to check that a tactic *fails*:
 .. tacn:: assert_fails @ltac_expr
    :name: assert_fails
 
-   This behaves like :n:`tryif @ltac_expr then fail 0 tac "succeeds" else idtac`.
+   This behaves like :n:`tryif once @ltac_expr then fail 0 tac "succeeds" else idtac`.
 
 Checking the success
 ~~~~~~~~~~~~~~~~~~~~

--- a/doc/sphinx/proof-engine/ltac.rst
+++ b/doc/sphinx/proof-engine/ltac.rst
@@ -516,7 +516,9 @@ Coq provides a derived tactic to check that a tactic *fails*:
 .. tacn:: assert_fails @ltac_expr
    :name: assert_fails
 
-   This behaves like :n:`tryif once @ltac_expr then fail 0 tac "succeeds" else idtac`.
+   This behaves like :tacn:`idtac` if :n:`@ltac_expr` fails, and
+   behaves like :n:`fail 0 @ltac_expr "succeeds"` if :n:`@ltac_expr`
+   has at least one success.
 
 Checking the success
 ~~~~~~~~~~~~~~~~~~~~
@@ -528,7 +530,7 @@ success:
    :name: assert_succeeds
 
    This behaves like
-   :n:`tryif (assert_fails tac) then fail 0 tac "fails" else idtac`.
+   :n:`tryif (assert_fails @ltac_expr) then fail 0 @ltac_expr "fails" else idtac`.
 
 Solving
 ~~~~~~~

--- a/test-suite/bugs/closed/bug_9114.v
+++ b/test-suite/bugs/closed/bug_9114.v
@@ -1,0 +1,5 @@
+Goal True.
+  assert_succeeds (exact I).
+  idtac.
+  (* Error: No such goal. *)
+Abort.

--- a/test-suite/output/Tactics.out
+++ b/test-suite/output/Tactics.out
@@ -6,3 +6,4 @@ The command has indeed failed with message:
 H is already used.
 The command has indeed failed with message:
 H is already used.
+a

--- a/test-suite/output/Tactics.v
+++ b/test-suite/output/Tactics.v
@@ -22,3 +22,11 @@ intros H.
 Fail intros [H%myid ?].
 Fail destruct 1 as [H%myid ?].
 Abort.
+
+
+(* Test that assert_succeeds only runs a tactic once *)
+Ltac should_not_loop := idtac + should_not_loop.
+Goal True.
+  assert_succeeds should_not_loop.
+  assert_succeeds (idtac "a" + idtac "b"). (* should only output "a" *)
+Abort.

--- a/theories/Init/Tactics.v
+++ b/theories/Init/Tactics.v
@@ -325,7 +325,7 @@ Ltac time_constr tac :=
 (** Useful combinators *)
 
 Ltac assert_fails tac :=
-  tryif once tac then fail 0 tac "succeeds" else idtac.
+  tryif (enough True as _; [ once tac | ]) then fail 0 tac "succeeds" else idtac.
 Ltac assert_succeeds tac :=
   tryif (assert_fails tac) then fail 0 tac "fails" else idtac.
 Tactic Notation "assert_succeeds" tactic3(tac) :=

--- a/theories/Init/Tactics.v
+++ b/theories/Init/Tactics.v
@@ -325,9 +325,9 @@ Ltac time_constr tac :=
 (** Useful combinators *)
 
 Ltac assert_fails tac :=
-  tryif (enough True as _; [ once tac | ]) then fail 0 tac "succeeds" else idtac.
+  tryif (once tac) then gfail 0 tac "succeeds" else idtac.
 Ltac assert_succeeds tac :=
-  tryif (assert_fails tac) then fail 0 tac "fails" else idtac.
+  tryif (assert_fails tac) then gfail 0 tac "fails" else idtac.
 Tactic Notation "assert_succeeds" tactic3(tac) :=
   assert_succeeds tac.
 Tactic Notation "assert_fails" tactic3(tac) :=

--- a/theories/Init/Tactics.v
+++ b/theories/Init/Tactics.v
@@ -325,7 +325,7 @@ Ltac time_constr tac :=
 (** Useful combinators *)
 
 Ltac assert_fails tac :=
-  tryif tac then fail 0 tac "succeeds" else idtac.
+  tryif once tac then fail 0 tac "succeeds" else idtac.
 Ltac assert_succeeds tac :=
   tryif (assert_fails tac) then fail 0 tac "fails" else idtac.
 Tactic Notation "assert_succeeds" tactic3(tac) :=


### PR DESCRIPTION
These tactics now work correctly with multisuccess tactics by wrapping
the tactic argument in `once`.

**Kind:** bug fix


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #10965
Fixes #9114


<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [x] Added / updated test-suite
- [x] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
