### PR TITLE
Fix flambda instructions (tentative)

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -127,20 +127,11 @@ INSTALLATION PROCEDURE IN DETAILS (NORMAL USERS).
         to tweak the flambda backend; for maximum performance we
         recommend using
 
-        -flambda-opts `-O3 -unbox-closures`
+        -native-compiler no -flambda-opts `-O3 -unbox-closures`
 
         but of course you are free to try with a different combination
         of flags. You can read more at
         https://caml.inria.fr/pub/docs/manual-ocaml/flambda.html
-
-        There is a known problem with certain OCaml versions and
-        `native_compute`, that will make compilation to require
-        a large amount of RAM (>= 10GiB) in some particular files.
-
-        We recommend disabling native compilation (`-native-compiler no`)
-        with flambda unless you use OCaml >= 4.07.0.
-
-        c.f. https://caml.inria.fr/mantis/view.php?id=7630
 
 4- Still in the root directory, do
 


### PR DESCRIPTION
EDIT: regard this as an issue — we'll turn it into one soon, see discussion.

**Kind:** documentation / performance.

Apparently, `-native-compiler no` might be needed to actually get the speedup, based on [forum discussion](https://coq.discourse.group/t/does-flambda-slow-down-coq/484/6?u=blaisorblade).
However, I still don't understand why that'd happen, according to the documentation I found. The default `-native-compiler ondemand` command-line setting should mean that, when compiling `.v` code, no slowdown should happen.

Finally, instructions should point out the downsides of `-native-compiler no`, directly or indirectly. Documenting that flag properly, and referring and to such docs could do.