### PR TITLE
Fix #10903: type-in-type allows fixpoints on sprop inductives

### DIFF
--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -1119,9 +1119,10 @@ let inductive_of_mutfix env ((nvect,bodynum),(names,types,bodies as recdef)) =
         | _ -> raise_err env i NotEnoughAbstractionInFixBody
     in
     let ((ind, _), _) as res = check_occur fixenv 1 def in
-    let _, ind = lookup_mind_specif env ind in
+    let _, mip = lookup_mind_specif env ind in
     (* recursive sprop means non record with projections -> squashed *)
-    if Sorts.Irrelevant == ind.mind_relevance
+    if mip.mind_relevance == Sorts.Irrelevant &&
+       not (Environ.is_type_in_type env (GlobRef.IndRef ind))
     then
       begin
         if names.(i).Context.binder_relevance == Sorts.Relevant

--- a/test-suite/bugs/closed/bug_10903.v
+++ b/test-suite/bugs/closed/bug_10903.v
@@ -1,0 +1,3 @@
+(* -*- coq-prog-args: ("-type-in-type"); -*- *)
+
+Inductive Ind : SProp := C : Ind -> Ind.


### PR DESCRIPTION
I still don't know why it produces a Not_found instead of a regular
error in coqtop but let's forget about it.
