### PR TITLE
[canonical structures] declaring multiple instances at once

### DIFF
--- a/doc/changelog/02-specification-language/10984-multi-canonical.rst
+++ b/doc/changelog/02-specification-language/10984-multi-canonical.rst
@@ -1,0 +1,4 @@
+- The `Canonical` command can declare multiple instances at once, see
+  :ref:`canonical_instance_declaration`
+  (`#10984 <https://github.com/coq/coq/pull/10984>`_, by Cyril Cohen,
+  Enrico Tassi and Gaëtan Gilbert).

--- a/doc/changelog/02-specification-language/10984-multi-canonical.rst
+++ b/doc/changelog/02-specification-language/10984-multi-canonical.rst
@@ -1,4 +1,4 @@
-- The `Canonical` command can declare multiple instances at once, see
+- The :cmd:`Canonical` command can declare multiple instances at once, see
   :ref:`canonical_instance_declaration`
   (`#10984 <https://github.com/coq/coq/pull/10984>`_, by Cyril Cohen,
   Enrico Tassi and Gaëtan Gilbert).

--- a/doc/sphinx/language/gallina-extensions.rst
+++ b/doc/sphinx/language/gallina-extensions.rst
@@ -2089,16 +2089,18 @@ in :ref:`canonicalstructures`; here only a simple example is given.
 
       .. example::
 
-      .. coqtop:: all
+        .. coqtop:: all
 
-         Structure Ordered := { Carrier :> Set; Leq : relation Carrier;
-                                     Prf_ord : order Carrier Leq}.
+           Require Import ZArith.
+           Structure Ordered := { OrdCarrier :> Set; Leq : relation OrdCarrier;
+                                       Prf_ord : order OrdCarrier Leq}.
 
-         Axiom leq_nat_order : order nat leq_nat.
+           Axiom eq_Z_equiv : equivalence Z Z.eq.
+           Axiom leq_Z_order : order Z Z.le.
 
-         Definition nat_multi := (Build_Setoid eq_nat_equiv, Build_Ordered leq_nat_order).
+           Definition Z_multi := (Build_Setoid eq_Z_equiv, Build_Ordered leq_Z_order).
 
-         Canonical nat_multi.
+           Canonical Z_multi.
 
    .. note::
       The :cmd:`Canonical` command considers as a pairing construct any polymorphic

--- a/doc/sphinx/language/gallina-extensions.rst
+++ b/doc/sphinx/language/gallina-extensions.rst
@@ -2006,6 +2006,8 @@ Deactivation of implicit arguments for parsing
    to be given as if no arguments were implicit. By symmetry, this also
    affects printing.
 
+.. _canonical_instance_declaration:
+
 Canonical structures
 ~~~~~~~~~~~~~~~~~~~~
 
@@ -2080,6 +2082,30 @@ in :ref:`canonicalstructures`; here only a simple example is given.
             #[canonical(false)] Prf_equiv : equivalence Carrier Equal
 
       See :ref:`canonicalstructures` for a more realistic example.
+
+   When :token:`qualid` denotes an iterated pair of :g:`struct` instances
+   each of them is given a name, by suffixing :token:`qualid` with a number,
+   and declared canonical.
+
+      .. example::
+
+      .. coqtop:: all
+
+         Structure Ordered := { Carrier :> Set; Leq : relation Carrier;
+                                     Prf_ord : order Carrier Leq}.
+
+         Axiom leq_nat_order : order nat leq_nat.
+
+         Definition nat_multi := (Build_Setoid eq_nat_equiv, Build_Ordered leq_nat_order).
+
+         Canonical nat_multi.
+
+   .. note::
+      The :n:`Canonical` command considers as a pairing construct any polymorphic
+      inductive with two parameters whose constructor is registered as
+      "core.CS.prod.intro".
+
+      .. seealso:: :ref:`exposing-constants-to-ocaml-libraries`.
 
    .. cmdv:: Canonical {? Structure } @ident {? : @type } := @term
 

--- a/doc/sphinx/language/gallina-extensions.rst
+++ b/doc/sphinx/language/gallina-extensions.rst
@@ -2101,7 +2101,7 @@ in :ref:`canonicalstructures`; here only a simple example is given.
          Canonical nat_multi.
 
    .. note::
-      The :n:`Canonical` command considers as a pairing construct any polymorphic
+      The :cmd:`Canonical` command considers as a pairing construct any polymorphic
       inductive with two parameters whose constructor is registered as
       "core.CS.prod.intro".
 

--- a/pretyping/recordops.mli
+++ b/pretyping/recordops.mli
@@ -95,4 +95,9 @@ val is_open_canonical_projection :
 val canonical_projections : unit ->
   ((GlobRef.t * cs_pattern) * obj_typ) list
 
-val check_and_decompose_canonical_structure : Environ.env -> Evd.evar_map -> GlobRef.t -> Constant.t * inductive
+type canonical_declaration =
+  | SingleNamedCanonicalInstance of Constant.t * inductive
+  | MultipleAnonymousCanonicalInstances of Id.t * Evd.evar_map * (EConstr.t * inductive) list
+
+val check_and_decompose_canonical_structure :
+  Environ.env -> Evd.evar_map -> GlobRef.t -> canonical_declaration

--- a/test-suite/output/ErrorInCanonicalStructures.out
+++ b/test-suite/output/ErrorInCanonicalStructures.out
@@ -1,4 +1,4 @@
 File "stdin", line 3, characters 0-24:
 Error: Could not declare a canonical structure Foo.
-Expected an instance of a record or structure.
+Expected a transparent definition.
 

--- a/test-suite/success/canonical_multi.v
+++ b/test-suite/success/canonical_multi.v
@@ -1,0 +1,19 @@
+Record R1 := mkR1 { r1 : bool }.
+Set Universe Polymorphism.
+
+Record R2@{i} := mkR2 { r2 : nat; _ : Type@{i} }.
+
+Definition builder@{i j} := ( mkR1 true , mkR2@{j} 0 Type@{i} ).
+
+Canonical xx := builder.
+
+Check xx0@{}. Check xx1@{_ _}. Check xx@{_ _}.
+
+Check refl_equal : r1 _ = true.
+Check refl_equal : r2 _ = 0.
+
+About xx.
+About xx0.
+About xx1.
+
+Print Universes.

--- a/theories/Init/Datatypes.v
+++ b/theories/Init/Datatypes.v
@@ -216,6 +216,8 @@ Register prod as core.prod.type.
 Register pair as core.prod.intro.
 Register prod_rect as core.prod.rect.
 
+Register pair as core.CS.prod.intro. (* Canonical Structure pairing *)
+
 Section projections.
   Context {A : Type} {B : Type}.
 

--- a/vernac/canonical.mli
+++ b/vernac/canonical.mli
@@ -9,4 +9,5 @@
 (************************************************************************)
 open Names
 
-val declare_canonical_structure : GlobRef.t -> unit
+val declare_canonical_structure :
+  poly:bool -> scope:DeclareDef.locality -> GlobRef.t -> unit


### PR DESCRIPTION
Design question:
- `Canonical xxx := multiple` declares global constants named `xxx0`, `xxx1`... is this naming OK?