### PR TITLE
Refine Instance returns

### DIFF
--- a/doc/changelog/02-specification-language/10996-refine-instance-returns.rst
+++ b/doc/changelog/02-specification-language/10996-refine-instance-returns.rst
@@ -1,0 +1,4 @@
+- Added ``#[refine]`` attribute for :cmd:`Instance`, a more
+  predictable version of the old ``Refine Instance Mode`` which
+  unconditionally opens a proof (`#10996
+  <https://github.com/coq/coq/pull/10996>`_, by Gaëtan Gilbert).

--- a/doc/sphinx/addendum/type-classes.rst
+++ b/doc/sphinx/addendum/type-classes.rst
@@ -47,9 +47,22 @@ Leibniz equality on some type. An example implementation is:
          | tt, tt => eq_refl tt
          end }.
 
-Using :cmd:`Program Instance`, if one does not give all the members in
-the Instance declaration, Coq generates obligations for the remaining
-fields, e.g.:
+Using the attribute ``refine``, if the term is not sufficient to
+finish the definition (e.g. due to a missing field or non-inferable
+hole) it must be finished in proof mode. If it is sufficient a trivial
+proof mode with no open goals is started.
+
+.. coqtop:: in
+
+   #[refine] Instance unit_EqDec' : EqDec unit := { eqb x y := true }.
+   Proof. intros [] [];reflexivity. Defined.
+
+Note that if you finish the proof with :cmd:`Qed` the entire instance
+will be opaque, including the fields given in the initial term.
+
+Alternatively, in :flag:`Program Mode` if one does not give all the
+members in the Instance declaration, Coq generates obligations for the
+remaining fields, e.g.:
 
 .. coqtop:: in
 

--- a/plugins/ltac/rewrite.ml
+++ b/plugins/ltac/rewrite.ml
@@ -2023,7 +2023,8 @@ let add_morphism atts binders m s n =
   let _id, lemma = Classes.new_instance_interactive
       ~global:atts.global ~poly:atts.polymorphic
       instance_name binders instance_t
-      ~generalize:false ~tac ~hook:(declare_projection n instance_id) Hints.empty_hint_info
+      ~generalize:false ~tac ~hook:(declare_projection n instance_id)
+      Hints.empty_hint_info None
   in
   lemma (* no instance body -> always open proof *)
 

--- a/stm/vernac_classifier.ml
+++ b/stm/vernac_classifier.ml
@@ -183,12 +183,16 @@ let classify_vernac e =
     | VernacDeclareMLModule _
     | VernacContext _ (* TASSI: unsure *) -> VtSideff ([], VtNow)
     | VernacProofMode pm -> VtProofMode pm
-    | VernacInstance ((name,_),_,_,None,_) when not (Attributes.parse_drop_extra Attributes.program atts) ->
-      let polymorphic = Attributes.(parse_drop_extra polymorphic atts) in
-      let guarantee = if polymorphic then Doesn'tGuaranteeOpacity else GuaranteesOpacity in
-      VtStartProof (guarantee, idents_of_name name.CAst.v)
-    | VernacInstance ((name,_),_,_,_,_) ->
-      VtSideff (idents_of_name name.CAst.v, VtLater)
+    | VernacInstance ((name,_),_,_,props,_) ->
+      let program, refine =
+        Attributes.(parse_drop_extra Notations.(program ++ Classes.refine_att) atts)
+      in
+      if program || (props <> None && not refine) then
+        VtSideff (idents_of_name name.CAst.v, VtLater)
+      else
+        let polymorphic = Attributes.(parse_drop_extra polymorphic atts) in
+        let guarantee = if polymorphic then Doesn'tGuaranteeOpacity else GuaranteesOpacity in
+        VtStartProof (guarantee, idents_of_name name.CAst.v)
     (* Stm will install a new classifier to handle these *)
     | VernacBack _ | VernacAbortAll
     | VernacUndoTo _ | VernacUndo _

--- a/test-suite/success/RefineInstance.v
+++ b/test-suite/success/RefineInstance.v
@@ -1,0 +1,23 @@
+
+
+Class Foo := foo { a : nat; b : bool }.
+
+Fail Instance bla : Foo := { b:= true }.
+
+#[refine] Instance bla : Foo := { b:= true }.
+Proof.
+exact 0.
+Defined.
+
+Instance bli : Foo := { a:=1; b := false}.
+Check bli.
+
+Fail #[program, refine] Instance bla : Foo := {b := true}.
+
+#[program] Instance blo : Foo := {b := true}.
+Next Obligation. exact 2. Qed.
+Check blo.
+
+#[refine] Instance xbar : Foo := {a:=4; b:=true}.
+Proof. Qed.
+Check xbar.

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -401,7 +401,7 @@ let do_instance_subst_constructor_and_ty subst k u ctx =
   let term = it_mkLambda_or_LetIn (Option.get app) ctx in
   term, termtype
 
-let do_instance_resolve_TC term termtype sigma env =
+let do_instance_resolve_TC termtype sigma env =
   let sigma = Evarutil.nf_evar_map sigma in
   let sigma = Typeclasses.resolve_typeclasses ~filter:Typeclasses.no_goals_or_obligations ~fail:true env sigma in
   (* Try resolving fields that are typeclasses automatically. *)
@@ -475,7 +475,7 @@ let do_instance_interactive env env' sigma ?hook ~tac ~global ~poly cty k u ctx 
         else
           None, it_mkProd_or_LetIn cty ctx
       in
-      let termtype, sigma = do_instance_resolve_TC term termtype sigma env in
+      let termtype, sigma = do_instance_resolve_TC termtype sigma env in
       term, termtype, sigma
   in
   Flags.silently (fun () ->
@@ -487,7 +487,7 @@ let do_instance env env' sigma ?hook ~global ~poly cty k u ctx ctx' pri decl imp
   let term, termtype, sigma =
     interp_props ~program_mode:false env' cty k u ctx ctx' subst sigma props
   in
-  let termtype, sigma = do_instance_resolve_TC (Some term) termtype sigma env in
+  let termtype, sigma = do_instance_resolve_TC termtype sigma env in
   if Evd.has_undefined sigma then
     CErrors.user_err Pp.(str "Unsolved obligations remaining.")
   else
@@ -504,7 +504,7 @@ let do_instance_program env env' sigma ?hook ~global ~poly cty k u ctx ctx' pri 
       let term, termtype =
         do_instance_subst_constructor_and_ty subst k u (ctx' @ ctx) in
       term, termtype, sigma in
-  let termtype, sigma = do_instance_resolve_TC term termtype sigma env in
+  let termtype, sigma = do_instance_resolve_TC termtype sigma env in
   if not (Evd.has_undefined sigma) && not (Option.is_empty opt_props) then
     declare_instance_constant pri global imps ?hook id decl poly sigma term termtype
   else

--- a/vernac/classes.mli
+++ b/vernac/classes.mli
@@ -35,6 +35,7 @@ val new_instance_interactive
   -> ?tac:unit Proofview.tactic
   -> ?hook:(GlobRef.t -> unit)
   -> Hints.hint_info_expr
+  -> (bool * constr_expr) option
   -> Id.t * Lemmas.t
 
 val new_instance
@@ -84,3 +85,5 @@ val set_typeclass_transparency : evaluable_global_reference -> bool -> bool -> u
 (** For generation on names based on classes only *)
 
 val id_of_class : typeclass -> Id.t
+
+val refine_att : bool Attributes.attribute

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1048,8 +1048,8 @@ let vernac_identity_coercion ~atts id qids qidt =
 
 let vernac_instance_program ~atts name bl t props info =
   Dumpglob.dump_constraint (fst name) false "inst";
-  let (program, locality), poly =
-    Attributes.(parse (Notations.(program ++ locality ++ polymorphic))) atts
+  let locality, poly =
+    Attributes.(parse (Notations.(locality ++ polymorphic))) atts
   in
   let global = not (make_section_locality locality) in
   let _id : Id.t = Classes.new_instance_program ~global ~poly name bl t props info in
@@ -1057,8 +1057,8 @@ let vernac_instance_program ~atts name bl t props info =
 
 let vernac_instance_interactive ~atts name bl t info =
   Dumpglob.dump_constraint (fst name) false "inst";
-  let (program, locality), poly =
-    Attributes.(parse (Notations.(program ++ locality ++ polymorphic))) atts
+  let locality, poly =
+    Attributes.(parse (Notations.(locality ++ polymorphic))) atts
   in
   let global = not (make_section_locality locality) in
   let _id, pstate =
@@ -1067,8 +1067,8 @@ let vernac_instance_interactive ~atts name bl t info =
 
 let vernac_instance ~atts name bl t props info =
   Dumpglob.dump_constraint (fst name) false "inst";
-  let (program, locality), poly =
-    Attributes.(parse (Notations.(program ++ locality ++ polymorphic))) atts
+  let locality, poly =
+    Attributes.(parse (Notations.(locality ++ polymorphic))) atts
   in
   let global = not (make_section_locality locality) in
   let _id : Id.t =
@@ -2094,7 +2094,7 @@ let translate_vernac ~atts v = let open Vernacextend in match v with
 
   (* Type classes *)
   | VernacInstance (name, bl, t, props, info) ->
-    let { DefAttributes.program } = DefAttributes.parse atts in
+    let atts, program = Attributes.(parse_with_extra program) atts in
     if program then
       VtDefault (fun () -> vernac_instance_program ~atts name bl t props info)
     else begin match props with


### PR DESCRIPTION
Return of Refine Instance as an attribute.

We can now do `#[refine] Instance : Bla := bli.` to enter proof mode
with `bli` as a starting refinement.

If `bli` is enough to define the instance we still enter proof mode,
keeping things nicely predictable for the stm.

Closes #10993.