### PR TITLE
Implement the unsupported attribute error using the warning system

### DIFF
--- a/doc/changelog/02-specification-language/10997-unsupport-atts-warn.rst
+++ b/doc/changelog/02-specification-language/10997-unsupport-atts-warn.rst
@@ -1,0 +1,3 @@
+- The unsupported attribute error is now an error-by-default warning,
+  meaning it can be disabled (`#10997
+  <https://github.com/coq/coq/pull/10997>`_, by Gaëtan Gilbert).

--- a/doc/sphinx/language/gallina-specification-language.rst
+++ b/doc/sphinx/language/gallina-specification-language.rst
@@ -1556,6 +1556,11 @@ the following attributes names are recognized:
           now foo.
         Abort.
 
+.. warn:: Unsupported attribute
+
+   This warning is an error by default. It is caused by using a
+   command with some attribute it does not understand.
+
 .. [1]
    This is similar to the expression “*entry* :math:`\{` sep *entry*
    :math:`\}`” in standard BNF, or “*entry* :math:`(` sep *entry*

--- a/vernac/attributes.ml
+++ b/vernac/attributes.ml
@@ -18,13 +18,17 @@ and vernac_flag_value =
   | VernacFlagLeaf of string
   | VernacFlagList of vernac_flags
 
+let warn_unsupported_attributes =
+  CWarnings.create ~name:"unsupported-attributes" ~category:"parsing" ~default:CWarnings.AsError
+    (fun atts ->
+       let keys = List.map fst atts in
+       let keys = List.sort_uniq String.compare keys in
+       let conj = match keys with [_] -> "this attribute: " | _ -> "these attributes: " in
+       Pp.(str "This command does not support " ++ str conj ++ prlist str keys ++ str"."))
+
 let unsupported_attributes = function
   | [] -> ()
-  | atts ->
-    let keys = List.map fst atts in
-    let keys = List.sort_uniq String.compare keys in
-    let conj = match keys with [_] -> "this attribute: " | _ -> "these attributes: " in
-    user_err Pp.(str "This command does not support " ++ str conj ++ prlist str keys ++ str".")
+  | atts -> warn_unsupported_attributes atts
 
 type 'a key_parser = 'a option -> vernac_flag_value -> 'a
 


### PR DESCRIPTION
This means we can disable it to ignore unsupported attributes. For
instance this would be useful if we change some behaviour of `Cmd` and add an
attribute `att` to restore the old behaviour, then `#[att] Cmd` is
backwards compatible if the warning is disabled.
