### PR TITLE
[refman] Give an example of contradiction when positivity checking is disabled.

### DIFF
--- a/doc/sphinx/language/cic.rst
+++ b/doc/sphinx/language/cic.rst
@@ -1067,7 +1067,8 @@ between universes for inductive types in the Type hierarchy.
 
    .. coqtop:: all
 
-      Definition I_not_I '(not_I_I not_I : I) : ~ I := not_I.
+      Definition I_not_I : I -> ~ I := fun i =>
+        match i with not_I_I not_I => not_I end.
 
    .. coqtop:: in
 

--- a/doc/sphinx/language/cic.rst
+++ b/doc/sphinx/language/cic.rst
@@ -1074,10 +1074,13 @@ between universes for inductive types in the Type hierarchy.
 
       Lemma contradiction : False.
       Proof.
-      enough (I /\ ~ I) as [] by contradiction.
-      split.
-      apply not_I_I; intro; now apply I_not_I.
-      intro; now apply I_not_I.
+        enough (I /\ ~ I) as [] by contradiction.
+        split.
+        - apply not_I_I.
+          intro.
+          now apply I_not_I.
+        - intro.
+          now apply I_not_I.
       Qed.
 
 .. example:: Negative occurrence (second example)

--- a/doc/sphinx/language/cic.rst
+++ b/doc/sphinx/language/cic.rst
@@ -1046,6 +1046,38 @@ between universes for inductive types in the Type hierarchy.
       exT_intro : forall X:Type, P X -> exType P.
 
 
+.. example:: Negative occurrence
+
+   The following inductive definition is rejected because it does not
+   satisfy the positivity condition:
+
+   .. coqtop:: all
+
+      Fail Inductive I : Prop := not_I_I (not_I : I -> False) : I.
+
+   If we were to accept such definition, we could derive a
+   contradiction from it (we can test this by disabling the
+   :flag:`Positivity Checking` flag):
+
+   .. coqtop:: none
+
+      Unset Positivity Checking.
+      Inductive I : Prop := not_I_I (not_I : I -> False) : I.
+      Set Positivity Checking.
+
+   .. coqtop:: all
+
+      Definition I_not_I '(not_I_I not_I : I) : ~ I := not_I.
+
+   .. coqtop:: in
+
+      Lemma contradiction : False.
+      Proof.
+      enough (I /\ ~ I) as [] by contradiction.
+      split.
+      apply not_I_I; intro; now apply I_not_I.
+      intro; now apply I_not_I.
+      Qed.
 
 .. _Template-polymorphism:
 

--- a/doc/sphinx/language/cic.rst
+++ b/doc/sphinx/language/cic.rst
@@ -1046,7 +1046,7 @@ between universes for inductive types in the Type hierarchy.
       exT_intro : forall X:Type, P X -> exType P.
 
 
-.. example:: Negative occurrence
+.. example:: Negative occurrence (first example)
 
    The following inductive definition is rejected because it does not
    satisfy the positivity condition:
@@ -1078,6 +1078,31 @@ between universes for inductive types in the Type hierarchy.
       apply not_I_I; intro; now apply I_not_I.
       intro; now apply I_not_I.
       Qed.
+
+.. example:: Negative occurrence (second example)
+
+   Here is another example of an inductive definition which is
+   rejected because it does not satify the positivity condition:
+
+   .. coqtop:: all
+
+      Fail Inductive Lam := lam (_ : Lam -> Lam).
+
+   Again, if we were to accept it, we could derive a contradiction
+   (this time through a non-terminating recursive function):
+
+   .. coqtop:: none
+
+      Unset Positivity Checking.
+      Inductive Lam := lam (_ : Lam -> Lam).
+      Set Positivity Checking.
+
+   .. coqtop:: all
+
+      Fixpoint infinite_loop l : False :=
+        match l with lam x => infinite_loop (x l) end.
+
+      Check infinite_loop (lam (@id Lam)) : False.
 
 .. _Template-polymorphism:
 


### PR DESCRIPTION
**Kind:** documentation

This addition relies on the positivity check disabling recently introduced by @SimonBoulier.