### PR TITLE
[coqlib] Always produce anomalies when required libraries are not loaded.

### DIFF
--- a/library/coqlib.ml
+++ b/library/coqlib.ml
@@ -112,7 +112,7 @@ let check_required_library d =
       | _ -> false
     in
     if not in_current_dir then
-      CErrors.user_err ~hdr:"Coqlib.check_required_library"
+      CErrors.anomaly ~label:"Coqlib.check_required_library"
         (str "Library " ++ DirPath.print dir ++ str " has to be required first.")
 
 (************************************************************************)

--- a/library/coqlib.ml
+++ b/library/coqlib.ml
@@ -8,7 +8,6 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-open CErrors
 open Util
 open Pp
 open Names
@@ -52,7 +51,7 @@ let check_ind_ref s ind =
 let lib_ref s =
   try CString.Map.find s !table
   with Not_found ->
-    user_err Pp.(str "not found in table: " ++ str s)
+    CErrors.anomaly Pp.(str "not found in table: " ++ str s)
 
 let add_ref s c =
   table := CString.Map.add s c !table
@@ -89,11 +88,11 @@ let gen_reference_in_modules locstr dirs s =
   match these with
     | [x] -> x
     | [] ->
-	anomaly ~label:locstr (str "cannot find " ++ str s ++
+      CErrors.anomaly ~label:locstr (str "cannot find " ++ str s ++
 	str " in module" ++ str (if List.length dirs > 1 then "s " else " ") ++
         prlist_with_sep pr_comma DirPath.print dirs ++ str ".")
     | l ->
-      anomaly ~label:locstr
+      CErrors.anomaly ~label:locstr
 	(str "ambiguous name " ++ str s ++ str " can represent " ++
 	   prlist_with_sep pr_comma
 	   (fun x -> Libnames.pr_path (Nametab.path_of_global x)) l ++
@@ -113,7 +112,7 @@ let check_required_library d =
       | _ -> false
     in
     if not in_current_dir then
-      user_err ~hdr:"Coqlib.check_required_library"
+      CErrors.user_err ~hdr:"Coqlib.check_required_library"
         (str "Library " ++ DirPath.print dir ++ str " has to be required first.")
 
 (************************************************************************)
@@ -321,4 +320,4 @@ let coq_or_ref     = Lazy.from_fun build_coq_or
 let coq_iff_ref    = Lazy.from_fun build_coq_iff
 
 (** Deprecated functions that search by library name. *)
-let build_sigma_set () = anomaly (Pp.str "Use build_sigma_type.")
+let build_sigma_set () = CErrors.anomaly (Pp.str "Use build_sigma_type.")

--- a/theories/FSets/FMapList.v
+++ b/theories/FSets/FMapList.v
@@ -14,6 +14,7 @@
  [FMapInterface.S] using lists of pairs ordered (increasing) with respect to
  left projection. *)
 
+Require Import Coq.Logic.JMeq.
 Require Import FunInd FMapInterface.
 
 Set Implicit Arguments.

--- a/theories/FSets/FMapWeakList.v
+++ b/theories/FSets/FMapWeakList.v
@@ -13,6 +13,7 @@
 (** This file proposes an implementation of the non-dependent interface
  [FMapInterface.WS] using lists of pairs, unordered but without redundancy. *)
 
+Require Import Coq.Logic.JMeq.
 Require Import FunInd FMapInterface.
 
 Set Implicit Arguments.

--- a/theories/Init/Datatypes.v
+++ b/theories/Init/Datatypes.v
@@ -197,6 +197,25 @@ Notation "x + y" := (sum x y) : type_scope.
 Arguments inl {A B} _ , [A] B _.
 Arguments inr {A B} _ , A [B] _.
 
+(** [identity A a] is the family of datatypes on [A] whose sole non-empty
+    member is the singleton datatype [identity A a a] whose
+    sole inhabitant is denoted [identity_refl A a] *)
+(** Beware: this inductive actually falls into [Prop], as the sole
+    constructor has no arguments and [-indices-matter] is not
+    activated in the standard library. *)
+
+Inductive identity (A:Type) (a:A) : A -> Type :=
+  identity_refl : identity a a.
+Hint Resolve identity_refl: core.
+
+Arguments identity_ind [A] a P f y i.
+Arguments identity_rec [A] a P f y i.
+Arguments identity_rect [A] a P f y i.
+
+Register identity as core.identity.type.
+Register identity_refl as core.identity.refl.
+Register identity_ind as core.identity.ind.
+
 (** [prod A B], written [A * B], is the product of [A] and [B];
     the pair [pair A B a b] of [a] and [b] is abbreviated [(a,b)] *)
 
@@ -396,25 +415,6 @@ Proof. intros. apply CompareSpec2Type; assumption. Defined.
 
 (******************************************************************)
 (** * Misc Other Datatypes *)
-
-(** [identity A a] is the family of datatypes on [A] whose sole non-empty
-    member is the singleton datatype [identity A a a] whose
-    sole inhabitant is denoted [identity_refl A a] *)
-(** Beware: this inductive actually falls into [Prop], as the sole
-    constructor has no arguments and [-indices-matter] is not
-    activated in the standard library. *)
-
-Inductive identity (A:Type) (a:A) : A -> Type :=
-  identity_refl : identity a a.
-Hint Resolve identity_refl: core.
-
-Arguments identity_ind [A] a P f y i.
-Arguments identity_rec [A] a P f y i.
-Arguments identity_rect [A] a P f y i.
-
-Register identity as core.identity.type.
-Register identity_refl as core.identity.refl.
-Register identity_ind as core.identity.ind.
 
 (** Identity type *)
 

--- a/theories/Logic/EqdepFacts.v
+++ b/theories/Logic/EqdepFacts.v
@@ -52,6 +52,8 @@ Table of contents:
 (************************************************************************)
 (** * Definition of dependent equality and equivalence with equality of dependent pairs *)
 
+Require Import Coq.Setoids.Setoid.
+
 Import EqNotations.
 
 (* Set Universe Polymorphism. *)

--- a/theories/MSets/MSetGenTree.v
+++ b/theories/MSets/MSetGenTree.v
@@ -29,6 +29,7 @@
      - min_elt max_elt choose
 *)
 
+Require Import Coq.Logic.JMeq.
 Require Import FunInd Orders OrdersFacts MSetInterface PeanoNat.
 Local Open Scope list_scope.
 Local Open Scope lazy_bool_scope.


### PR DESCRIPTION
Using `user_err` means that the exception may be recoverable from tactic
code. Maybe we should make `check_required_library` to return an
option type.

Fix in the libraries:

- `EqdepFacts`: `rewrite` requires `Setoid` to be loaded
- `FSet / MSet`: `rewrite` requires the `JMeq` library to be present

Depends on #11006 