### PR TITLE
[coqlib] Always produce anomalies when a constant doesn't exist.

### DIFF
--- a/library/coqlib.ml
+++ b/library/coqlib.ml
@@ -8,7 +8,6 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-open CErrors
 open Util
 open Pp
 open Names
@@ -52,7 +51,7 @@ let check_ind_ref s ind =
 let lib_ref s =
   try CString.Map.find s !table
   with Not_found ->
-    user_err Pp.(str "not found in table: " ++ str s)
+    CErrors.anomaly Pp.(str "not found in table: " ++ str s)
 
 let add_ref s c =
   table := CString.Map.add s c !table
@@ -89,11 +88,11 @@ let gen_reference_in_modules locstr dirs s =
   match these with
     | [x] -> x
     | [] ->
-        anomaly ~label:locstr (str "cannot find " ++ str s ++
+      CErrors.anomaly ~label:locstr (str "cannot find " ++ str s ++
         str " in module" ++ str (if List.length dirs > 1 then "s " else " ") ++
         prlist_with_sep pr_comma DirPath.print dirs ++ str ".")
     | l ->
-      anomaly ~label:locstr
+      CErrors.anomaly ~label:locstr
         (str "ambiguous name " ++ str s ++ str " can represent " ++
            prlist_with_sep pr_comma
            (fun x -> Libnames.pr_path (Nametab.path_of_global x)) l ++
@@ -113,7 +112,7 @@ let check_required_library d =
       | _ -> false
     in
     if not in_current_dir then
-      user_err ~hdr:"Coqlib.check_required_library"
+      CErrors.user_err ~hdr:"Coqlib.check_required_library"
         (str "Library " ++ DirPath.print dir ++ str " has to be required first.")
 
 (************************************************************************)
@@ -321,4 +320,4 @@ let coq_or_ref     = Lazy.from_fun build_coq_or
 let coq_iff_ref    = Lazy.from_fun build_coq_iff
 
 (** Deprecated functions that search by library name. *)
-let build_sigma_set () = anomaly (Pp.str "Use build_sigma_type.")
+let build_sigma_set () = CErrors.anomaly (Pp.str "Use build_sigma_type.")

--- a/pretyping/program.ml
+++ b/pretyping/program.ml
@@ -8,7 +8,6 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-open CErrors
 open Util
 
 let papp evdref r args =
@@ -41,12 +40,6 @@ let coq_eq_rect     () = Coqlib.lib_ref "core.eq.rect"
 let mk_coq_not sigma x =
   let sigma, notc = Evarutil.new_global sigma Coqlib.(lib_ref "core.not.type") in
   sigma, EConstr.mkApp (notc, [| x |])
-
-let coq_JMeq_ind  () =
-  try Coqlib.lib_ref "core.JMeq.type"
-  with Not_found ->
-    user_err (Pp.str "cannot find Coq.Logic.JMeq.JMeq; maybe library Coq.Logic.JMeq has to be required first.")
-let coq_JMeq_refl () = Coqlib.lib_ref "core.JMeq.refl"
 
 (* let coq_not () = Universes.constr_of_global @@ Coqlib.lib_ref "core.not.type" *)
 (* let coq_and () = Universes.constr_of_global @@ Coqlib.lib_ref "core.and.type" *)

--- a/pretyping/program.mli
+++ b/pretyping/program.mli
@@ -31,9 +31,6 @@ val coq_eq_refl : unit -> GlobRef.t
 val coq_eq_refl_ref : unit -> GlobRef.t
 val coq_eq_rect : unit -> GlobRef.t
 
-val coq_JMeq_ind : unit -> GlobRef.t
-val coq_JMeq_refl : unit -> GlobRef.t
-
 val mk_coq_and : Evd.evar_map -> constr list -> Evd.evar_map * constr
 val mk_coq_not : Evd.evar_map -> constr -> Evd.evar_map * constr
 

--- a/test-suite/success/Discriminate_HoTT.v
+++ b/test-suite/success/Discriminate_HoTT.v
@@ -18,6 +18,8 @@ Notation "x -> y" := (forall (_:x), y) (at level 99, right associativity, y at l
 Cumulative Variant paths {A} (a:A) : A -> Type
   := idpath : paths a a.
 
+Register paths as core.eq.type.
+
 Arguments idpath {A a} , [A] a.
 
 Scheme paths_ind := Induction for paths Sort Type.

--- a/theories/Init/Datatypes.v
+++ b/theories/Init/Datatypes.v
@@ -197,6 +197,25 @@ Notation "x + y" := (sum x y) : type_scope.
 Arguments inl {A B} _ , [A] B _.
 Arguments inr {A B} _ , A [B] _.
 
+(** [identity A a] is the family of datatypes on [A] whose sole non-empty
+    member is the singleton datatype [identity A a a] whose
+    sole inhabitant is denoted [identity_refl A a] *)
+(** Beware: this inductive actually falls into [Prop], as the sole
+    constructor has no arguments and [-indices-matter] is not
+    activated in the standard library. *)
+
+Inductive identity (A:Type) (a:A) : A -> Type :=
+  identity_refl : identity a a.
+Hint Resolve identity_refl: core.
+
+Arguments identity_ind [A] a P f y i.
+Arguments identity_rec [A] a P f y i.
+Arguments identity_rect [A] a P f y i.
+
+Register identity as core.identity.type.
+Register identity_refl as core.identity.refl.
+Register identity_ind as core.identity.ind.
+
 (** [prod A B], written [A * B], is the product of [A] and [B];
     the pair [pair A B a b] of [a] and [b] is abbreviated [(a,b)] *)
 
@@ -396,25 +415,6 @@ Proof. intros. apply CompareSpec2Type; assumption. Defined.
 
 (******************************************************************)
 (** * Misc Other Datatypes *)
-
-(** [identity A a] is the family of datatypes on [A] whose sole non-empty
-    member is the singleton datatype [identity A a a] whose
-    sole inhabitant is denoted [identity_refl A a] *)
-(** Beware: this inductive actually falls into [Prop], as the sole
-    constructor has no arguments and [-indices-matter] is not
-    activated in the standard library. *)
-
-Inductive identity (A:Type) (a:A) : A -> Type :=
-  identity_refl : identity a a.
-Hint Resolve identity_refl: core.
-
-Arguments identity_ind [A] a P f y i.
-Arguments identity_rec [A] a P f y i.
-Arguments identity_rect [A] a P f y i.
-
-Register identity as core.identity.type.
-Register identity_refl as core.identity.refl.
-Register identity_ind as core.identity.ind.
 
 (** Identity type *)
 


### PR DESCRIPTION
Using `user_err` means that the exception may be recoverable from tactic
code. Ideally we would have `lib_ref` to return an option type but
that was pretty invasive w.r.t. codebase.

Fixes #10989

Fix in the libraries:

- `Init.Datatypes`: `core.identity.type` is used by `destruct` or
  `auto` so we had to move it earlier.
