### PR TITLE
“auto with zarith”: use “lia” rather than “omega”

### DIFF
--- a/doc/changelog/04-tactics/11018-lia-in-auto-with-zarith.rst
+++ b/doc/changelog/04-tactics/11018-lia-in-auto-with-zarith.rst
@@ -1,0 +1,7 @@
+- **Changed:** The :g:`auto with zarith` tactic and variations (including :tacn:`intuition`)
+  may now call the :tacn:`lia` tactic instead of :tacn:`omega`
+  (when the `Omega` module is loaded);
+  more goals may be automatically solved,
+  fewer section variables will be captured spuriously
+  (`#11018 <https://github.com/coq/coq/pull/11018>`_,
+  by Vincent Laporte).

--- a/theories/Numbers/Cyclic/Int31/Cyclic31.v
+++ b/theories/Numbers/Cyclic/Int31/Cyclic31.v
@@ -2226,7 +2226,7 @@ Section Int31_Specs.
       < ([|iter312_sqrt n rec ih il j|] + 1) ^ 2.
  Proof.
  revert rec ih il j; elim n; unfold iter312_sqrt; fold iter312_sqrt; clear n.
- intros rec ih il j Hi Hj Hij Hrec; apply sqrt312_step_correct; auto with zarith.
+ intros rec ih il j Hi Hj Hij Hrec; apply sqrt312_step_correct. 1-3: lia.
  intros; apply Hrec. 2: rewrite Z.pow_0_r. 1-3: lia.
  intros n Hrec rec ih il j Hi Hj Hij HHrec.
  apply sqrt312_step_correct; auto.

--- a/theories/Numbers/Cyclic/Int63/Int63.v
+++ b/theories/Numbers/Cyclic/Int63/Int63.v
@@ -1316,9 +1316,8 @@ Lemma iter_sqrt_correct n rec i j: 0 < φ i -> 0 < φ j ->
   φ (iter_sqrt n rec i j) ^ 2 <= φ i < (φ (iter_sqrt n rec i j) + 1) ^ 2.
 Proof.
  revert rec i j; elim n; unfold iter_sqrt; fold iter_sqrt; clear n.
- intros rec i j Hi Hj Hij H31 Hrec; apply sqrt_step_correct; auto with zarith.
- intros; apply Hrec; auto with zarith.
- rewrite Zpower_0_r; auto with zarith.
+ intros rec i j Hi Hj Hij H31 Hrec; apply sqrt_step_correct. 1-4: lia.
+ intros; apply Hrec; only 2: rewrite Zpower_0_r; auto with zarith.
  intros n Hrec rec i j Hi Hj Hij H31 HHrec.
  apply sqrt_step_correct; auto.
  intros j1 Hj1  Hjp1; apply Hrec; auto with zarith.
@@ -1516,9 +1515,8 @@ Lemma iter2_sqrt_correct n rec ih il j:
       < (φ (iter2_sqrt n rec ih il j) + 1) ^ 2.
 Proof.
  revert rec ih il j; elim n; unfold iter2_sqrt; fold iter2_sqrt; clear n.
- intros rec ih il j Hi Hj Hij Hrec; apply sqrt2_step_correct; auto with zarith.
- intros; apply Hrec; auto with zarith.
- rewrite Zpower_0_r; auto with zarith.
+ intros rec ih il j Hi Hj Hij Hrec; apply sqrt2_step_correct. 1-3: lia.
+ intros; apply Hrec; only 2: rewrite Zpower_0_r; auto with zarith.
  intros n Hrec rec ih il j Hi Hj Hij HHrec.
  apply sqrt2_step_correct; auto.
  intros j1 Hj1  Hjp1; apply Hrec; auto with zarith.

--- a/theories/omega/Omega.v
+++ b/theories/omega/Omega.v
@@ -19,6 +19,7 @@
 Require Export ZArith_base.
 Require Export OmegaLemmas.
 Require Export PreOmega.
+Require Import Lia.
 
 Declare ML Module "omega_plugin".
 
@@ -28,28 +29,28 @@ Hint Resolve Z.le_refl Z.add_comm Z.add_assoc Z.mul_comm Z.mul_assoc Z.add_0_l
 
 Require Export Zhints.
 
-Hint Extern 10 (_ = _ :>nat) => abstract omega: zarith.
-Hint Extern 10 (_ <= _) => abstract omega: zarith.
-Hint Extern 10 (_ < _) => abstract omega: zarith.
-Hint Extern 10 (_ >= _) => abstract omega: zarith.
-Hint Extern 10 (_ > _) => abstract omega: zarith.
+Hint Extern 10 (_ = _ :>nat) => abstract lia: zarith.
+Hint Extern 10 (_ <= _) => abstract lia: zarith.
+Hint Extern 10 (_ < _) => abstract lia: zarith.
+Hint Extern 10 (_ >= _) => abstract lia: zarith.
+Hint Extern 10 (_ > _) => abstract lia: zarith.
 
-Hint Extern 10 (_ <> _ :>nat) => abstract omega: zarith.
-Hint Extern 10 (~ _ <= _) => abstract omega: zarith.
-Hint Extern 10 (~ _ < _) => abstract omega: zarith.
-Hint Extern 10 (~ _ >= _) => abstract omega: zarith.
-Hint Extern 10 (~ _ > _) => abstract omega: zarith.
+Hint Extern 10 (_ <> _ :>nat) => abstract lia: zarith.
+Hint Extern 10 (~ _ <= _) => abstract lia: zarith.
+Hint Extern 10 (~ _ < _) => abstract lia: zarith.
+Hint Extern 10 (~ _ >= _) => abstract lia: zarith.
+Hint Extern 10 (~ _ > _) => abstract lia: zarith.
 
-Hint Extern 10 (_ = _ :>Z) => abstract omega: zarith.
-Hint Extern 10 (_ <= _)%Z => abstract omega: zarith.
-Hint Extern 10 (_ < _)%Z => abstract omega: zarith.
-Hint Extern 10 (_ >= _)%Z => abstract omega: zarith.
-Hint Extern 10 (_ > _)%Z => abstract omega: zarith.
+Hint Extern 10 (_ = _ :>Z) => abstract lia: zarith.
+Hint Extern 10 (_ <= _)%Z => abstract lia: zarith.
+Hint Extern 10 (_ < _)%Z => abstract lia: zarith.
+Hint Extern 10 (_ >= _)%Z => abstract lia: zarith.
+Hint Extern 10 (_ > _)%Z => abstract lia: zarith.
 
-Hint Extern 10 (_ <> _ :>Z) => abstract omega: zarith.
-Hint Extern 10 (~ (_ <= _)%Z) => abstract omega: zarith.
-Hint Extern 10 (~ (_ < _)%Z) => abstract omega: zarith.
-Hint Extern 10 (~ (_ >= _)%Z) => abstract omega: zarith.
-Hint Extern 10 (~ (_ > _)%Z) => abstract omega: zarith.
+Hint Extern 10 (_ <> _ :>Z) => abstract lia: zarith.
+Hint Extern 10 (~ (_ <= _)%Z) => abstract lia: zarith.
+Hint Extern 10 (~ (_ < _)%Z) => abstract lia: zarith.
+Hint Extern 10 (~ (_ >= _)%Z) => abstract lia: zarith.
+Hint Extern 10 (~ (_ > _)%Z) => abstract lia: zarith.
 
-Hint Extern 10 False => abstract omega: zarith.
+Hint Extern 10 False => abstract lia: zarith.


### PR DESCRIPTION
This is a breaking step towards the deprecation of “omega”: the standard library relies on these hints (and third-party developments probably do) so we must provide a replacement. Unfortunately, “lia” is slightly stronger than “omega”: this change may thus break proof scripts that rely on failures of “auto with zarith”.

Overlays

 - [x] https://gitlab.inria.fr/flocq/flocq/issues/7
 - [x] https://github.com/mit-plv/kami/pull/13
 - [x] https://github.com/AbsInt/CompCert/pull/321
 - [x] https://github.com/coq/bignums/pull/25
 - [x] https://github.com/thery/coqprime/pull/12
 - [x] https://github.com/adampetcher/fcf/pull/29
 - [x] https://github.com/coq-community/corn/pull/82
 - [x] https://github.com/mit-plv/fiat-crypto/pull/621
 - [x] https://github.com/fblanqui/color/pull/20
 - [x] https://github.com/uwplse/verdi-raft/pull/81
 - [x] https://github.com/mit-plv/cross-crypto/pull/14
 - [x] https://github.com/mit-plv/bedrock2/pull/112
 - [x] https://github.com/coq-community/corn/pull/83
 - [x] https://github.com/thery/coqprime/pull/14
 - [x] https://github.com/adampetcher/fcf/pull/31
 - [x] https://github.com/thery/coqprime/pull/19
 - [x] https://github.com/adampetcher/fcf/pull/32
 - [x] https://github.com/mit-plv/cross-crypto/pull/15
 - [x] https://github.com/thery/coqprime/pull/20
 - [x] https://github.com/fblanqui/color/pull/21
 - [x] https://github.com/coq-community/corn/pull/86
 - [x] https://github.com/coq/bignums/pull/35
 - [x] https://github.com/MetaCoq/metacoq/pull/389

TODO

 - [x] Add a changelog entry
 - [x] #10994
 - [x] #10983
 - [x] #10937