### PR TITLE
[ci] Disable fiat-crypto-legacy

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -589,8 +589,8 @@ library:ci-fcsl-pcm:
 library:ci-fiat-crypto:
   extends: .ci-template-flambda
 
-library:ci-fiat-crypto-legacy:
-  extends: .ci-template-flambda
+# library:ci-fiat-crypto-legacy:
+#   extends: .ci-template-flambda
 
 library:ci-flocq:
   extends: .ci-template


### PR DESCRIPTION
The target has been taking 3h hours and failing consistently, so let's
disable it for now.
