### PR TITLE
Allow passing --real to timing scripts

### DIFF
--- a/tools/make-both-single-timing-files.py
+++ b/tools/make-both-single-timing-files.py
@@ -5,7 +5,7 @@ from TimeFileMaker import *
 if __name__ == '__main__':
     USAGE = 'Usage: %s [--sort-by=auto|absolute|diff] AFTER_FILE_NAME BEFORE_FILE_NAME [OUTPUT_FILE_NAME ..]' % sys.argv[0]
     HELP_STRING = r'''Formats timing information from the output of two invocations of `coqc -time` into a sorted table'''
-    sort_by, args = parse_args(sys.argv, USAGE, HELP_STRING)
+    sort_by, args = parse_args(sys.argv, USAGE, HELP_STRING, allow_real=False)
     left_dict = get_single_file_times(args[1])
     right_dict = get_single_file_times(args[2])
     table = make_diff_table_string(left_dict, right_dict, tag="Code", sort_by=sort_by)

--- a/tools/make-both-time-files.py
+++ b/tools/make-both-time-files.py
@@ -3,14 +3,16 @@ import sys
 from TimeFileMaker import *
 
 if __name__ == '__main__':
-    USAGE = 'Usage: %s [--sort-by=auto|absolute|diff] AFTER_FILE_NAME BEFORE_FILE_NAME [OUTPUT_FILE_NAME ..]' % sys.argv[0]
+    USAGE = 'Usage: %s [--sort-by=auto|absolute|diff] [--real] AFTER_FILE_NAME BEFORE_FILE_NAME [OUTPUT_FILE_NAME ..]' % sys.argv[0]
     HELP_STRING = r'''Formats timing information from the output of two invocations of `make TIMED=1` into a sorted table.
 
 The input is expected to contain lines in the format:
 FILE_NAME (...user: NUMBER_IN_SECONDS...)
+If --real is passed, then the lines are instead expected in the format:
+FILE_NAME (...real: NUMBER_IN_SECONDS...)
 '''
-    sort_by, args = parse_args(sys.argv, USAGE, HELP_STRING)
-    left_dict = get_times(args[1])
-    right_dict = get_times(args[2])
+    sort_by, use_real, args = parse_args(sys.argv, USAGE, HELP_STRING)
+    left_dict = get_times(args[1], use_real=use_real)
+    right_dict = get_times(args[2], use_real=use_real)
     table = make_diff_table_string(left_dict, right_dict, sort_by=sort_by)
     print_or_write_table(table, args[3:])

--- a/tools/make-one-time-file.py
+++ b/tools/make-one-time-file.py
@@ -3,19 +3,15 @@ import sys
 from TimeFileMaker import *
 
 if __name__ == '__main__':
-    USAGE = 'Usage: %s FILE_NAME [OUTPUT_FILE_NAME ..]' % sys.argv[0]
+    USAGE = 'Usage: %s FILE_NAME [--real] [OUTPUT_FILE_NAME ..]' % sys.argv[0]
     HELP_STRING = r'''Formats timing information from the output of `make TIMED=1` into a sorted table.
 
 The input is expected to contain lines in the format:
 FILE_NAME (...user: NUMBER_IN_SECONDS...)
+If --real is passed, then the lines are instead expected in the format:
+FILE_NAME (...real: NUMBER_IN_SECONDS...)
 '''
-    if len(sys.argv) < 2 or '--help' in sys.argv[1:] or '-h' in sys.argv[1:]:
-        print(USAGE)
-        if '--help' in sys.argv[1:] or '-h' in sys.argv[1:]:
-            print(HELP_STRING)
-            if len(sys.argv) == 2: sys.exit(0)
-        sys.exit(1)
-    else:
-        times_dict = get_times(sys.argv[1])
-        table = make_table_string(times_dict)
-        print_or_write_table(table, sys.argv[2:])
+    use_real, args = parse_args(sys.argv, USAGE, HELP_STRING, allow_sort_by=False, min_arg_count=2)
+    times_dict = get_times(args[1], use_real=use_real)
+    table = make_table_string(times_dict)
+    print_or_write_table(table, args[2:])


### PR DESCRIPTION
This allows easily comparing real times instead of user ones.

**Kind:** feature

- [ ] Corresponding documentation was added / updated (including any warning and error messages
- [ ] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).

Does this need a changelog entry?  (I don't think there's any documentation to be updated, though I did update the help strings on the python scripts themselves.)