### PR TITLE
Revert bits of #10947 which broke fiat-crypto-legacy

### DIFF
--- a/tools/CoqMakefile.in
+++ b/tools/CoqMakefile.in
@@ -312,7 +312,7 @@ else
 DO_NATDYNLINK =
 endif
 
-ALLDFILES = $(addsuffix .d,$(ALLSRCFILES)) $(VDFILE)
+ALLDFILES = $(addsuffix .d,$(ALLSRCFILES) $(VDFILE))
 
 # Compilation targets #########################################################
 
@@ -732,7 +732,7 @@ $(addsuffix .d,$(MLPACKFILES)): %.mlpack.d: %.mlpack
 # projects. Note that extra options might be on the command line.
 VDFILE_FLAGS:=$(if @PROJECT_FILE@,-f @PROJECT_FILE@,) $(CMDLINE_COQLIBS) $(CMDLINE_VFILES)
 
-$(VDFILE): $(VFILES)
+$(VDFILE).d: $(VFILES)
 	$(SHOW)'COQDEP VFILES'
 	$(HIDE)$(COQDEP) -dyndep var $(VDFILE_FLAGS) $(redir_if_ok)
 

--- a/tools/coq_makefile.ml
+++ b/tools/coq_makefile.ml
@@ -413,7 +413,7 @@ let _ =
 
   let conf_file = Option.default "CoqMakefile" project.makefile ^ ".conf" in
   let local_file = Option.default "CoqMakefile" project.makefile ^ ".local" in
-  let dep_file = "." ^ Option.default "CoqMakefile" project.makefile ^ ".d" in
+  let dep_file = "." ^ Option.default "CoqMakefile" project.makefile in
 
   if project.extra_targets <> [] then begin
     eprintf "Warning: -extra and -extra-phony are deprecated.\n";
@@ -442,4 +442,3 @@ let _ =
   generate_conf occ project (prog :: args);
   close_out occ;
   exit 0
-


### PR DESCRIPTION
We read `VDFILE` from the generated makefile and use it to compute the
recursive dependency chain.  PR #10947 broke this.

**Kind:** bug fix
