### PR TITLE
Add Set NativeCompute Timing

### DIFF
--- a/doc/changelog/04-tactics/11023-nativecompute-timing.rst
+++ b/doc/changelog/04-tactics/11023-nativecompute-timing.rst
@@ -1,0 +1,7 @@
+- The :flag:`NativeCompute Timing` flag causes calls to
+  :tacn:`native_compute` (as well as kernel calls to the native
+  compiler) to emit separate timing information about compilation,
+  execution, and reification.  It replaces the timing information
+  previously emitted when the `-debug` flag was set, and allows more
+  fine-grained timing of the native compiler.  (`#11023
+  <https://github.com/coq/coq/pull/11023>`_, by Jason Gross).

--- a/doc/sphinx/proof-engine/tactics.rst
+++ b/doc/sphinx/proof-engine/tactics.rst
@@ -3113,6 +3113,12 @@ the conversion in hypotheses :n:`{+ @ident}`.
    compilation cost is higher, so it is worth using only for intensive
    computations.
 
+   .. flag:: NativeCompute Timing
+
+      This flag causes all calls to the native compiler to print
+      timing information for the compilation, execution, and
+      reification phases of native compilation.
+
    .. flag:: NativeCompute Profiling
 
       On Linux, if you have the ``perf`` profiler installed, this flag makes

--- a/pretyping/nativenorm.mli
+++ b/pretyping/nativenorm.mli
@@ -20,6 +20,9 @@ val set_profile_filename : string -> unit
 val get_profiling_enabled : unit -> bool
 val set_profiling_enabled : bool -> unit
 
+val get_timing_enabled : unit -> bool
+val set_timing_enabled : bool -> unit
+
 
 val native_norm : env -> evar_map -> constr -> types -> constr
 

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1448,6 +1448,14 @@ let () =
       optread  = Nativenorm.get_profiling_enabled;
       optwrite = Nativenorm.set_profiling_enabled }
 
+let () =
+  declare_bool_option
+    { optdepr  = false;
+      optname  = "enable native compute timing";
+      optkey   = ["NativeCompute"; "Timing"];
+      optread  = Nativenorm.get_timing_enabled;
+      optwrite = Nativenorm.set_timing_enabled }
+
 let _ =
   declare_bool_option
     { optdepr  = false;


### PR DESCRIPTION
The command `Set NativeCompute Timing` causes calls to `native_compute`
(as well as kernel calls to the native compiler) to emit separate timing
information about compilation, execution, and reification.  This allows
more fine-grained timing of the native compiler without needing to set
the `-debug` flag.

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** feature 

- [ ] Added / updated test-suite
- [x] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).

Not sure what the right test-case for the test-suite for this is; perhaps none is needed?