### PR TITLE
Update the deprecation doc of `Shrink Obligations`

### DIFF
--- a/doc/sphinx/addendum/program.rst
+++ b/doc/sphinx/addendum/program.rst
@@ -341,7 +341,7 @@ optional tactic is replaced by the default one if not specified.
 
 .. flag:: Shrink Obligations
 
-   *Deprecated since 8.7*
+   .. deprecated:: 8.7
 
    This option (on by default) controls whether obligations should have
    their context minimized to the set of variables used in the proof of


### PR DESCRIPTION
Now it uses `.. deprecated` like all the other deprecation notices in
the manual.

**Kind:** documentation fix