### PR TITLE
Add a `strategy` tactic

### DIFF
--- a/doc/changelog/04-tactics/11029-add-strategy.rst
+++ b/doc/changelog/04-tactics/11029-add-strategy.rst
@@ -1,0 +1,3 @@
+- New tactic :tacn:`strategy` added which behaves like the command
+  :cmd:`Strategy`, with effects local to a proof.  (`#11029
+  <https://github.com/coq/coq/pull/11029>`_, by Jason Gross).

--- a/doc/sphinx/proofs/writing-proofs/equality.rst
+++ b/doc/sphinx/proofs/writing-proofs/equality.rst
@@ -1142,3 +1142,31 @@ which supports additional fine-tuning.
       tactics to persist information about conversion hints in the
       proof term. See `#12200
       <https://github.com/coq/coq/issues/12200>`_ for more details.
+
+.. tacn:: strategy @strategy_level_or_var [ {+ @smart_qualid } ]
+   :name: strategy
+
+   This tactic allows changing the unfolding behavior of a constant
+   locally within a proof, analogous to the :cmd:`Strategy`
+   command.
+
+   .. note::
+
+      Use this tactic with care, as effects do not persist past the
+      end of the proof script.  Notably, this fine-tuning of the
+      conversion strategy is not in effect during :cmd:`Qed` nor
+      :cmd:`Defined`, so this tactic is most useful either in
+      combination with :tacn:`abstract`, which will check the proof
+      early while the fine-tuning is still in effect, or to guard
+      calls to conversion in tactic automation to ensure that, e.g.,
+      :tacn:`unfold` does not fail just because the user made a
+      constant :cmd:`Opaque`.
+
+   .. note::
+
+      This tactic does not play well with :tacn:`once`.  In
+      particular, if you wrap :tacn:`strategy` in :tacn:`once` and
+      then backtrack across it due to a later failure, the strategy
+      will be reset for the remainder of the current tactic block
+      (until a :g:`.`), but the effect of :tacn:`strategy` will still
+      be in effect for the rest of the proof (after the :g:`.`).

--- a/parsing/g_prim.mlg
+++ b/parsing/g_prim.mlg
@@ -138,4 +138,10 @@ GRAMMAR EXTEND Gram
       | n=integer -> { Conv_oracle.Level n }
       | IDENT "transparent" -> { Conv_oracle.transparent } ] ]
   ;
+  strategy_level:
+    [ [ IDENT "expand" -> { Conv_oracle.Expand }
+      | IDENT "opaque" -> { Conv_oracle.Opaque }
+      | n=integer -> { Conv_oracle.Level n }
+      | IDENT "transparent" -> { Conv_oracle.transparent } ] ]
+  ;
 END

--- a/plugins/ltac/extratactics.mlg
+++ b/plugins/ltac/extratactics.mlg
@@ -728,3 +728,9 @@ TACTIC EXTEND with_strategy
   with_set_strategy [(v, q)] (Tacinterp.tactic_of_value ist tac)
 }
 END
+
+TACTIC EXTEND strategy
+| [ "strategy" strategy_level_or_var(v) "[" ne_smart_global_list(q) "]"  ] -> {
+  set_strategy [(v, q)]
+}
+END

--- a/tactics/tactics.mli
+++ b/tactics/tactics.mli
@@ -437,6 +437,8 @@ val with_set_strategy :
   (Conv_oracle.level * Names.GlobRef.t list) list ->
   'a Proofview.tactic -> 'a Proofview.tactic
 
+val set_strategy : (Conv_oracle.level * Names.GlobRef.t list) list -> unit Proofview.tactic
+
 (** {6 Simple form of basic tactics. } *)
 
 module Simple : sig

--- a/test-suite/output/print_ltac.out
+++ b/test-suite/output/print_ltac.out
@@ -121,6 +121,17 @@ Ltac withstrategy l x :=
   ]
   idtac
 File "./output/print_ltac.v", line 52, characters 29-34:
+Ltac setstrategy l x :=
+  let idx := smart_global:(id) in
+  let tl := strategy_level:(transparent) in
+  strategy 1 [ id id ]; strategy l [ id id ]; strategy tl [ id id ]; strategy
+   transparent [ id id ]; strategy transparent [ id id ]; strategy opaque [
+   id id ]; strategy expand [ id id ]; strategy transparent [ idx ]; strategy
+   transparent [ id x ]; strategy transparent [ x id ]; strategy transparent
+   [ id ]; strategy transparent [ id x ]; strategy transparent [ id id ];
+   strategy transparent [ id id x ]; strategy transparent [ id ]; strategy
+   transparent [ id x ]; strategy transparent [ id id ]; strategy transparent
+   [ id id x ]
 The command has indeed failed with message:
 idnat is bound to a notation that does not denote a reference.
 Ltac withstrategy l x :=
@@ -234,6 +245,17 @@ Ltac withstrategy l x :=
   x
   ]
   idtac
+Ltac setstrategy l x :=
+  let idx := smart_global:(id) in
+  let tl := strategy_level:(transparent) in
+  strategy 1 [ id id ]; strategy l [ id id ]; strategy tl [ id id ]; strategy
+   transparent [ id id ]; strategy transparent [ id id ]; strategy opaque [
+   id id ]; strategy expand [ id id ]; strategy transparent [ idx ]; strategy
+   transparent [ id x ]; strategy transparent [ x id ]; strategy transparent
+   [ id ]; strategy transparent [ id x ]; strategy transparent [ id id ];
+   strategy transparent [ id id x ]; strategy transparent [ id ]; strategy
+   transparent [ id x ]; strategy transparent [ id id ]; strategy transparent
+   [ id id x ]
 Ltac FE.withstrategy l x :=
   let idx := smart_global:(FE.id) in
   let tl := strategy_level:(transparent) in
@@ -345,3 +367,15 @@ Ltac FE.withstrategy l x :=
   x
   ]
   idtac
+Ltac FE.setstrategy l x :=
+  let idx := smart_global:(FE.id) in
+  let tl := strategy_level:(transparent) in
+  strategy 1 [ FE.id FE.id ]; strategy l [ FE.id FE.id ]; strategy tl [ FE.id
+   FE.id ]; strategy transparent [ FE.id FE.id ]; strategy transparent [
+   FE.id FE.id ]; strategy opaque [ FE.id FE.id ]; strategy expand [ FE.id
+   FE.id ]; strategy transparent [ idx ]; strategy transparent [ FE.id x ];
+   strategy transparent [ x FE.id ]; strategy transparent [ FE.id ]; strategy
+   transparent [ FE.id x ]; strategy transparent [ FE.id FE.id ]; strategy
+   transparent [ FE.id FE.id x ]; strategy transparent [ FE.id ]; strategy
+   transparent [ FE.id x ]; strategy transparent [ FE.id FE.id ]; strategy
+   transparent [ FE.id FE.id x ]

--- a/test-suite/output/print_ltac.v
+++ b/test-suite/output/print_ltac.v
@@ -42,6 +42,29 @@ Ltac withstrategy l x :=
     )))))))))))))))))).
 Print Ltac withstrategy.
 
+Ltac setstrategy l x :=
+  let idx := smart_global:(id) in
+  let tl := strategy_level:(transparent) in
+  strategy 1 [id id];
+  strategy l [id id];
+  strategy tl [id id];
+  strategy 0 [id id];
+  strategy transparent [id id];
+  strategy opaque [id id];
+  strategy expand [id id];
+  strategy 0 [idx];
+  strategy 0 [id x];
+  strategy 0 [x id];
+  strategy 0 [idn];
+  strategy 0 [idn x];
+  strategy 0 [idn id];
+  strategy 0 [idn id x];
+  strategy 0 [idan];
+  strategy 0 [idan x];
+  strategy 0 [idan id];
+  strategy 0 [idan id x].
+Print Ltac setstrategy.
+
 Module Type Empty. End Empty.
 Module E. End E.
 Module F (E : Empty).
@@ -76,7 +99,31 @@ Module F (E : Empty).
     idtac
       )))))))))))))))))).
   Print Ltac withstrategy.
+
+  Ltac setstrategy l x :=
+    let idx := smart_global:(id) in
+    let tl := strategy_level:(transparent) in
+    strategy 1 [id id];
+    strategy l [id id];
+    strategy tl [id id];
+    strategy 0 [id id];
+    strategy transparent [id id];
+    strategy opaque [id id];
+    strategy expand [id id];
+    strategy 0 [idx];
+    strategy 0 [id x];
+    strategy 0 [x id];
+    strategy 0 [idn];
+    strategy 0 [idn x];
+    strategy 0 [idn id];
+    strategy 0 [idn id x];
+    strategy 0 [idan];
+    strategy 0 [idan x];
+    strategy 0 [idan id];
+    strategy 0 [idan id x].
+  Print Ltac setstrategy.
 End F.
 
 Module FE := F E.
 Print Ltac FE.withstrategy.
+Print Ltac FE.setstrategy.

--- a/test-suite/success/strategy.v
+++ b/test-suite/success/strategy.v
@@ -85,3 +85,429 @@ Goal id 0 = 0.
   assert_succeeds unfold_id.
   reflexivity.
 Qed.
+Opaque id.
+Goal id 0 = 0.
+  strategy opaque [id].
+  strategy opaque [id id].
+  assert_fails unfold_id.
+  strategy transparent [id].
+  assert_succeeds unfold_id.
+  strategy opaque [id].
+  strategy 0 [id].
+  assert_succeeds unfold_id.
+  strategy 1 [id].
+  assert_succeeds unfold_id.
+  strategy -1 [id].
+  assert_succeeds unfold_id.
+  strategy opaque [id].
+  assert_fails unfold_id.
+  strategy transparent [id].
+  assert_succeeds unfold_id.
+  strategy opaque [id].
+  strategy expand [id].
+  assert_succeeds unfold_id.
+  let l := strategy_level:(expand) in
+  strategy l [id].
+  let idx := smart_global:(id) in
+  cbv [idx].
+  (* This should succeed, but doesn't, basically due to https://github.com/coq/coq/issues/11202 *)
+  Fail let idx := smart_global:(id) in
+       strategy expand [idx].
+  reflexivity.
+Qed.
+Goal id 0 = 0.
+  strategy opaque [aid].
+  assert_fails unfold_id.
+  strategy transparent [aid].
+  assert_succeeds unfold_id.
+  strategy opaque [aid].
+  strategy 0 [aid].
+  assert_succeeds unfold_id.
+  strategy 1 [aid].
+  assert_succeeds unfold_id.
+  strategy -1 [aid].
+  assert_succeeds unfold_id.
+  strategy opaque [aid].
+  assert_fails unfold_id.
+  strategy transparent [aid].
+  assert_succeeds unfold_id.
+  strategy opaque [aid].
+  strategy expand [aid].
+  assert_succeeds unfold_id.
+  reflexivity.
+Qed.
+Goal id 0 = 0.
+  strategy opaque [idn].
+  assert_fails unfold_id.
+  strategy transparent [idn].
+  assert_succeeds unfold_id.
+  strategy opaque [idn].
+  strategy 0 [idn].
+  assert_succeeds unfold_id.
+  strategy 1 [idn].
+  assert_succeeds unfold_id.
+  strategy -1 [idn].
+  assert_succeeds unfold_id.
+  strategy opaque [idn].
+  assert_fails unfold_id.
+  strategy transparent [idn].
+  assert_succeeds unfold_id.
+  strategy opaque [idn].
+  strategy expand [idn].
+  assert_succeeds unfold_id.
+  reflexivity.
+Qed.
+
+(* test that strategy tactic does not persist after the proof *)
+Opaque id.
+Goal id 0 = 0.
+  strategy transparent [id].
+  assert_succeeds unfold_id.
+  reflexivity.
+Qed.
+Goal id 0 = 0.
+  assert_fails unfold_id.
+  reflexivity.
+Qed.
+
+(* test that the strategy tactic does persist through abstract *)
+Opaque id.
+Goal id 0 = 0.
+  strategy expand [id].
+  Time Timeout 5 assert (id (fact 100) = fact 100) by abstract reflexivity.
+  reflexivity.
+Time Timeout 5 Defined.
+
+(* test that [strategy] plays well with [;] *)
+Goal id 0 = 0.
+  Fail let id' := id in unfold id'.
+  try (tryif (let id' := id in
+              strategy expand [id]; unfold id') then fail else fail 1).
+  Fail let id' := id in unfold id'.
+  assert_succeeds (let id' := id in strategy expand [id]; unfold id').
+  (* [unfold id] should fail, but does not, because [strategy] plays poorly with [assert_succeeds] *)
+  Fail Fail unfold id.
+  reflexivity.
+Defined.
+Opaque id.
+Goal id 0 = 0.
+  Time Timeout 5 (strategy expand [id];
+                 assert (id (fact 100) = fact 100) by abstract reflexivity).
+  reflexivity.
+Time Timeout 5 Defined.
+
+(* check that module substitutions happen correctly *)
+Module F.
+  Definition id {T} := @id T.
+  Opaque id.
+  Ltac transparent_id := strategy transparent [id].
+End F.
+Opaque F.id.
+
+Goal F.id 0 = F.id 0.
+  Fail unfold F.id.
+  F.transparent_id.
+  progress unfold F.id.
+Abort.
+
+Module Type Empty. End Empty.
+Module E. End E.
+Module F2F (E : Empty).
+  Definition id {T} := @id T.
+  Opaque id.
+  Ltac transparent_id := strategy transparent [id].
+End F2F.
+Module F2 := F2F E.
+Opaque F2.id.
+
+Goal F2.id 0 = F2.id 0.
+  Fail unfold F2.id.
+  F2.transparent_id.
+  progress unfold F2.id.
+Abort.
+
+(* test the tactic notation entries *)
+Tactic Notation "set_strategy0" strategy_level(l) "[" ne_smart_global_list(v) "]" := strategy l [ v ].
+Tactic Notation "set_strategy1" strategy_level_or_var(l) "[" ne_smart_global_list(v) "]" := strategy l [ v ].
+Tactic Notation "set_strategy2" strategy_level(l) "[" constr(v) "]" := strategy l [ v ].
+Tactic Notation "set_strategy3" strategy_level_or_var(l) "[" constr(v) "]" := strategy l [ v ].
+
+(* [set_strategy0] should work, but it doesn't, due to a combination of https://github.com/coq/coq/issues/11202 and https://github.com/coq/coq/issues/11209 *)
+Opaque id.
+Goal id 0 = 0.
+  Fail (* should work, not Fail *) set_strategy0 opaque [id].
+  Fail (* should work, not Fail *) set_strategy0 opaque [id id].
+  assert_fails unfold_id.
+  Fail (* should work, not Fail *) set_strategy0 transparent [id].
+  Fail (* should work, not Fail *) assert_succeeds unfold_id.
+  Fail (* should work, not Fail *) set_strategy0 opaque [id].
+  Fail (* should work, not Fail *) set_strategy0 0 [id].
+  Fail (* should work, not Fail *) assert_succeeds unfold_id.
+  Fail (* should work, not Fail *) set_strategy0 1 [id].
+  Fail (* should work, not Fail *) assert_succeeds unfold_id.
+  Fail (* should work, not Fail *) set_strategy0 -1 [id].
+  Fail (* should work, not Fail *) assert_succeeds unfold_id.
+  Fail (* should work, not Fail *) set_strategy0 opaque [id].
+  assert_fails unfold_id.
+  Fail (* should work, not Fail *) set_strategy0 transparent [id].
+  Fail (* should work, not Fail *) assert_succeeds unfold_id.
+  Fail (* should work, not Fail *) set_strategy0 opaque [id].
+  Fail (* should work, not Fail *) set_strategy0 expand [id].
+  Fail (* should work, not Fail *) assert_succeeds unfold_id.
+  (* This should succeed, but doesn't, basically due to https://github.com/coq/coq/issues/11202 *)
+  Fail let idx := smart_global:(id) in
+       set_strategy0 expand [idx].
+  reflexivity.
+Qed.
+Goal id 0 = 0.
+  Fail (* should work, not Fail *) set_strategy0 opaque [aid].
+  assert_fails unfold_id.
+  Fail (* should work, not Fail *) set_strategy0 transparent [aid].
+  Fail (* should work, not Fail *) assert_succeeds unfold_id.
+  Fail (* should work, not Fail *) set_strategy0 opaque [aid].
+  Fail (* should work, not Fail *) set_strategy0 0 [aid].
+  Fail (* should work, not Fail *) assert_succeeds unfold_id.
+  Fail (* should work, not Fail *) set_strategy0 1 [aid].
+  Fail (* should work, not Fail *) assert_succeeds unfold_id.
+  Fail (* should work, not Fail *) set_strategy0 -1 [aid].
+  Fail (* should work, not Fail *) assert_succeeds unfold_id.
+  Fail (* should work, not Fail *) set_strategy0 opaque [aid].
+  assert_fails unfold_id.
+  Fail (* should work, not Fail *) set_strategy0 transparent [aid].
+  Fail (* should work, not Fail *) assert_succeeds unfold_id.
+  Fail (* should work, not Fail *) set_strategy0 opaque [aid].
+  Fail (* should work, not Fail *) set_strategy0 expand [aid].
+  Fail (* should work, not Fail *) assert_succeeds unfold_id.
+  reflexivity.
+Qed.
+Goal id 0 = 0.
+  Fail (* should work, not Fail *) set_strategy0 opaque [idn].
+  assert_fails unfold_id.
+  Fail (* should work, not Fail *) set_strategy0 transparent [idn].
+  Fail (* should work, not Fail *) assert_succeeds unfold_id.
+  Fail (* should work, not Fail *) set_strategy0 opaque [idn].
+  Fail (* should work, not Fail *) set_strategy0 0 [idn].
+  Fail (* should work, not Fail *) assert_succeeds unfold_id.
+  Fail (* should work, not Fail *) set_strategy0 1 [idn].
+  Fail (* should work, not Fail *) assert_succeeds unfold_id.
+  Fail (* should work, not Fail *) set_strategy0 -1 [idn].
+  Fail (* should work, not Fail *) assert_succeeds unfold_id.
+  Fail (* should work, not Fail *) set_strategy0 opaque [idn].
+  assert_fails unfold_id.
+  Fail (* should work, not Fail *) set_strategy0 transparent [idn].
+  Fail (* should work, not Fail *) assert_succeeds unfold_id.
+  Fail (* should work, not Fail *) set_strategy0 opaque [idn].
+  Fail (* should work, not Fail *) set_strategy0 expand [idn].
+  Fail (* should work, not Fail *) assert_succeeds unfold_id.
+  reflexivity.
+Qed.
+
+(* [set_strategy1] should work, but it doesn't, due to a combination of https://github.com/coq/coq/issues/11202 and https://github.com/coq/coq/issues/11209 *)
+Opaque id.
+Goal id 0 = 0.
+  Fail (* should work, not Fail *) set_strategy1 opaque [id].
+  Fail (* should work, not Fail *) set_strategy1 opaque [id id].
+  assert_fails unfold_id.
+  Fail (* should work, not Fail *) set_strategy1 transparent [id].
+  Fail (* should work, not Fail *) assert_succeeds unfold_id.
+  Fail (* should work, not Fail *) set_strategy1 opaque [id].
+  Fail (* should work, not Fail *) set_strategy1 0 [id].
+  Fail (* should work, not Fail *) assert_succeeds unfold_id.
+  Fail (* should work, not Fail *) set_strategy1 1 [id].
+  Fail (* should work, not Fail *) assert_succeeds unfold_id.
+  Fail (* should work, not Fail *) set_strategy1 -1 [id].
+  Fail (* should work, not Fail *) assert_succeeds unfold_id.
+  Fail (* should work, not Fail *) set_strategy1 opaque [id].
+  assert_fails unfold_id.
+  Fail (* should work, not Fail *) set_strategy1 transparent [id].
+  Fail (* should work, not Fail *) assert_succeeds unfold_id.
+  Fail (* should work, not Fail *) set_strategy1 opaque [id].
+  Fail (* should work, not Fail *) set_strategy1 expand [id].
+  Fail (* should work, not Fail *) assert_succeeds unfold_id.
+  Fail (* should work, not Fail *) let l := strategy_level:(expand) in
+                                   set_strategy1 l [id].
+  (* This should succeed, but doesn't, basically due to https://github.com/coq/coq/issues/11202 *)
+  Fail let idx := smart_global:(id) in
+       set_strategy1 expand [idx].
+  reflexivity.
+Qed.
+Goal id 0 = 0.
+  Fail (* should work, not Fail *) set_strategy1 opaque [aid].
+  assert_fails unfold_id.
+  Fail (* should work, not Fail *) set_strategy1 transparent [aid].
+  Fail (* should work, not Fail *) assert_succeeds unfold_id.
+  Fail (* should work, not Fail *) set_strategy1 opaque [aid].
+  Fail (* should work, not Fail *) set_strategy1 0 [aid].
+  Fail (* should work, not Fail *) assert_succeeds unfold_id.
+  Fail (* should work, not Fail *) set_strategy1 1 [aid].
+  Fail (* should work, not Fail *) assert_succeeds unfold_id.
+  Fail (* should work, not Fail *) set_strategy1 -1 [aid].
+  Fail (* should work, not Fail *) assert_succeeds unfold_id.
+  Fail (* should work, not Fail *) set_strategy1 opaque [aid].
+  assert_fails unfold_id.
+  Fail (* should work, not Fail *) set_strategy1 transparent [aid].
+  Fail (* should work, not Fail *) assert_succeeds unfold_id.
+  Fail (* should work, not Fail *) set_strategy1 opaque [aid].
+  Fail (* should work, not Fail *) set_strategy1 expand [aid].
+  Fail (* should work, not Fail *) assert_succeeds unfold_id.
+  reflexivity.
+Qed.
+Goal id 0 = 0.
+  Fail (* should work, not Fail *) set_strategy1 opaque [idn].
+  assert_fails unfold_id.
+  Fail (* should work, not Fail *) set_strategy1 transparent [idn].
+  Fail (* should work, not Fail *) assert_succeeds unfold_id.
+  Fail (* should work, not Fail *) set_strategy1 opaque [idn].
+  Fail (* should work, not Fail *) set_strategy1 0 [idn].
+  Fail (* should work, not Fail *) assert_succeeds unfold_id.
+  Fail (* should work, not Fail *) set_strategy1 1 [idn].
+  Fail (* should work, not Fail *) assert_succeeds unfold_id.
+  Fail (* should work, not Fail *) set_strategy1 -1 [idn].
+  Fail (* should work, not Fail *) assert_succeeds unfold_id.
+  Fail (* should work, not Fail *) set_strategy1 opaque [idn].
+  assert_fails unfold_id.
+  Fail (* should work, not Fail *) set_strategy1 transparent [idn].
+  Fail (* should work, not Fail *) assert_succeeds unfold_id.
+  Fail (* should work, not Fail *) set_strategy1 opaque [idn].
+  Fail (* should work, not Fail *) set_strategy1 expand [idn].
+  Fail (* should work, not Fail *) assert_succeeds unfold_id.
+  reflexivity.
+Qed.
+
+Opaque id.
+Goal id 0 = 0.
+  set_strategy2 opaque [id].
+  assert_fails unfold_id.
+  set_strategy2 transparent [id].
+  assert_succeeds unfold_id.
+  set_strategy2 opaque [id].
+  set_strategy2 0 [id].
+  assert_succeeds unfold_id.
+  set_strategy2 1 [id].
+  assert_succeeds unfold_id.
+  set_strategy2 -1 [id].
+  assert_succeeds unfold_id.
+  set_strategy2 opaque [id].
+  assert_fails unfold_id.
+  set_strategy2 transparent [id].
+  assert_succeeds unfold_id.
+  set_strategy2 opaque [id].
+  set_strategy2 expand [id].
+  assert_succeeds unfold_id.
+  (* This should succeed, but doesn't, basically due to https://github.com/coq/coq/issues/11202 *)
+  Fail let idx := smart_global:(id) in
+       set_strategy2 expand [idx].
+  reflexivity.
+Qed.
+Goal id 0 = 0.
+  set_strategy2 opaque [aid].
+  assert_fails unfold_id.
+  set_strategy2 transparent [aid].
+  assert_succeeds unfold_id.
+  set_strategy2 opaque [aid].
+  set_strategy2 0 [aid].
+  assert_succeeds unfold_id.
+  set_strategy2 1 [aid].
+  assert_succeeds unfold_id.
+  set_strategy2 -1 [aid].
+  assert_succeeds unfold_id.
+  set_strategy2 opaque [aid].
+  assert_fails unfold_id.
+  set_strategy2 transparent [aid].
+  assert_succeeds unfold_id.
+  set_strategy2 opaque [aid].
+  set_strategy2 expand [aid].
+  assert_succeeds unfold_id.
+  reflexivity.
+Qed.
+Goal id 0 = 0.
+  set_strategy2 opaque [idn].
+  assert_fails unfold_id.
+  set_strategy2 transparent [idn].
+  assert_succeeds unfold_id.
+  set_strategy2 opaque [idn].
+  set_strategy2 0 [idn].
+  assert_succeeds unfold_id.
+  set_strategy2 1 [idn].
+  assert_succeeds unfold_id.
+  set_strategy2 -1 [idn].
+  assert_succeeds unfold_id.
+  set_strategy2 opaque [idn].
+  assert_fails unfold_id.
+  set_strategy2 transparent [idn].
+  assert_succeeds unfold_id.
+  set_strategy2 opaque [idn].
+  set_strategy2 expand [idn].
+  assert_succeeds unfold_id.
+  reflexivity.
+Qed.
+
+Opaque id.
+Goal id 0 = 0.
+  set_strategy3 opaque [id].
+  assert_fails unfold_id.
+  set_strategy3 transparent [id].
+  assert_succeeds unfold_id.
+  set_strategy3 opaque [id].
+  set_strategy3 0 [id].
+  assert_succeeds unfold_id.
+  set_strategy3 1 [id].
+  assert_succeeds unfold_id.
+  set_strategy3 -1 [id].
+  assert_succeeds unfold_id.
+  set_strategy3 opaque [id].
+  assert_fails unfold_id.
+  set_strategy3 transparent [id].
+  assert_succeeds unfold_id.
+  set_strategy3 opaque [id].
+  set_strategy3 expand [id].
+  assert_succeeds unfold_id.
+  let l := strategy_level:(expand) in
+  set_strategy3 l [id].
+  (* This should succeed, but doesn't, basically due to https://github.com/coq/coq/issues/11202 *)
+  Fail let idx := smart_global:(id) in
+       set_strategy3 expand [idx].
+  reflexivity.
+Qed.
+Goal id 0 = 0.
+  set_strategy3 opaque [aid].
+  assert_fails unfold_id.
+  set_strategy3 transparent [aid].
+  assert_succeeds unfold_id.
+  set_strategy3 opaque [aid].
+  set_strategy3 0 [aid].
+  assert_succeeds unfold_id.
+  set_strategy3 1 [aid].
+  assert_succeeds unfold_id.
+  set_strategy3 -1 [aid].
+  assert_succeeds unfold_id.
+  set_strategy3 opaque [aid].
+  assert_fails unfold_id.
+  set_strategy3 transparent [aid].
+  assert_succeeds unfold_id.
+  set_strategy3 opaque [aid].
+  set_strategy3 expand [aid].
+  assert_succeeds unfold_id.
+  reflexivity.
+Qed.
+Goal id 0 = 0.
+  set_strategy3 opaque [idn].
+  assert_fails unfold_id.
+  set_strategy3 transparent [idn].
+  assert_succeeds unfold_id.
+  set_strategy3 opaque [idn].
+  set_strategy3 0 [idn].
+  assert_succeeds unfold_id.
+  set_strategy3 1 [idn].
+  assert_succeeds unfold_id.
+  set_strategy3 -1 [idn].
+  assert_succeeds unfold_id.
+  set_strategy3 opaque [idn].
+  assert_fails unfold_id.
+  set_strategy3 transparent [idn].
+  assert_succeeds unfold_id.
+  set_strategy3 opaque [idn].
+  set_strategy3 expand [idn].
+  assert_succeeds unfold_id.
+  reflexivity.
+Qed.


### PR DESCRIPTION
Useful for guarding calls to `unfold` or `cbv` to ensure that, e.g.,
`Opaque foo` doesn't break some automation which tries to unfold `foo`.

**Kind:** feature

- [x] Added / updated test-suite
- [x] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).

<strike>I'm confused about `gec_gen` vs `Entry.create` vs `make_gen_entry`, and also I'm getting
```
File "./theories/Init/Notations.v", line 128, characters 0-32:
Error: Anomaly "grammar function not found: strategy_level."
Please report at http://coq.inria.fr/bugs/.
```
and don't know how to fix it...</strike>