### PR TITLE
fix(*.opam): Add missing version "dev"

### DIFF
--- a/coq-refman.opam
+++ b/coq-refman.opam
@@ -15,6 +15,8 @@ bug-reports: "https://github.com/coq/coq/issues"
 dev-repo: "https://github.com/coq/coq.git"
 license: "Open Publication License"
 
+version: "dev"
+
 depends: [
   "dune"      { build }
   "coq"       { build & = version }

--- a/coq.opam
+++ b/coq.opam
@@ -18,6 +18,8 @@ bug-reports: "https://github.com/coq/coq/issues"
 dev-repo: "git+https://github.com/coq/coq.git"
 license: "LGPL-2.1"
 
+version: "dev"
+
 depends: [
   "ocaml"     {         >= "4.05.0" }
   "dune"      { build & >= "1.10.0"  }

--- a/coqide-server.opam
+++ b/coqide-server.opam
@@ -18,6 +18,8 @@ bug-reports: "https://github.com/coq/coq/issues"
 dev-repo: "git+https://github.com/coq/coq.git"
 license: "LGPL-2.1"
 
+version: "dev"
+
 depends: [
   "dune"      { build & >= "1.10.0" }
   "coq"       {          = version }

--- a/coqide.opam
+++ b/coqide.opam
@@ -16,6 +16,8 @@ bug-reports: "https://github.com/coq/coq/issues"
 dev-repo: "git+https://github.com/coq/coq.git"
 license: "LGPL-2.1"
 
+version: "dev"
+
 depends: [
   "dune"                 { build & >= "1.10.0" }
   "coqide-server"        {          = version }


### PR DESCRIPTION
**Kind:** bug fix / infrastructure.

- [x] ~Added / updated test-suite~ [not relevant]
- [x] ~Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).~ [not relevant]
- [ ] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details). ← is this necessary?

### Description

The opam version string "dev" was not implied, and this can cause the following issues:

```
$ docker run --rm -it coqorg/base:latest

 coq@…:~$ opam update
 coq@…:~$ git clone https://github.com/coq/coq.git
 Cloning into 'coq'...

 coq@…:~$ cd coq
 coq@…:~/coq$ opam pin add -n -k path coq .
 [coq.8.10.1] synchronised from file:///home/coq/coq
 coq is now pinned to file:///home/coq/coq (version 8.10.1)

  # issue 1. opam picks the first version he finds for coq from repos!

 coq@…:~/coq$ mv coq.opam foo.opam
 coq@…:~/coq$ opam pin add -n -k path foo .
 Package foo does not exist, create as a NEW package? [Y/n] y
 [foo.~dev] synchronised from file:///home/coq/coq
 foo is now pinned to file:///home/coq/coq (version ~dev)

  # issue 2. if none is found, opam sticks to some "~dev" version…
```

Hence that PR.