### PR TITLE
[CI] Update Mtac2 to master-8.11 branch.

### DIFF
--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -35,7 +35,7 @@
 : "${unicoq_CI_GITURL:=https://github.com/unicoq/unicoq}"
 : "${unicoq_CI_ARCHIVEURL:=${unicoq_CI_GITURL}/archive}"
 
-: "${mtac2_CI_REF:=master}"
+: "${mtac2_CI_REF:=master-8.11}"
 : "${mtac2_CI_GITURL:=https://github.com/Mtac2/Mtac2}"
 : "${mtac2_CI_ARCHIVEURL:=${mtac2_CI_GITURL}/archive}"
 


### PR DESCRIPTION
UniCoq does not (yet?) have a 8.11 branch and is thus kept at master
for now.

**Kind:** infrastructure.
