### PR TITLE
Forbid Include inside sections

### DIFF
--- a/test-suite/bugs/closed/bug_10060.v
+++ b/test-suite/bugs/closed/bug_10060.v
@@ -1,0 +1,15 @@
+Module Type T.
+  Parameter b : Set.
+End T.
+
+Module M1(N : T).
+End M1.
+
+Module M2.
+End M2.
+
+Section S.
+  Variable a : Set.
+  Definition b := a.
+  Fail Include M1.
+End S.

--- a/vernac/declaremods.ml
+++ b/vernac/declaremods.ml
@@ -972,6 +972,8 @@ let declare_modtype id args mtys mty_l =
   protect_summaries declare_mt
 
 let declare_include me_asts =
+  if Global.sections_are_opened () then
+    user_err Pp.(str "Include is not allowed inside sections.");
   protect_summaries (fun _ -> RawIncludeOps.declare_include me_asts)
 
 


### PR DESCRIPTION
This probably does not work well in general, and specifically avoids
an anomaly: close https://github.com/coq/coq/issues/10060
