### PR TITLE
Prevent redefinition of Ltac2 types and constructors inside a module

### DIFF
--- a/test-suite/bugs/closed/bug_10097.v
+++ b/test-suite/bugs/closed/bug_10097.v
@@ -1,0 +1,14 @@
+From Ltac2 Require Import Ltac2.
+
+(* #10097 *)
+Ltac2 Type s := [X(int)].
+Fail Ltac2 Type s.
+Fail Ltac2 Type s := [].
+
+Ltac2 Type r := [..].
+Fail Ltac2 Type r := [].
+
+Module Other.
+  Ltac2 Type s.
+  Ltac2 Type r := [].
+End Other.

--- a/test-suite/bugs/closed/bug_10196.v
+++ b/test-suite/bugs/closed/bug_10196.v
@@ -17,10 +17,10 @@ Fail Ltac2 Eval notUppercased2.
 
 (* And the same for open types*)
 Ltac2 Type open_type := [ .. ].
-Fail Ltac2 Type open_type ::= [ notUppercased ].
-Ltac2 Type open_type ::= [ Uppercased ].
+Fail Ltac2 Type open_type ::= [ notUppercased3 ].
+Ltac2 Type open_type ::= [ Uppercased3 ].
 
-Fail Ltac2 Eval notUppercased.
-Ltac2 Eval Uppercased.
+Fail Ltac2 Eval notUppercased3.
+Ltac2 Eval Uppercased3.
 
 Fail Ltac2 Type foo ::= [ | bar1 | bar2 ].

--- a/test-suite/bugs/closed/bug_11046.v
+++ b/test-suite/bugs/closed/bug_11046.v
@@ -1,0 +1,19 @@
+From Ltac2 Require Import Ltac2.
+
+Ltac2 Type t := [..].
+Ltac2 Type t ::= [A(int)].
+
+(* t cannot be extended with two constructors with the same name *)
+Fail Ltac2 Type t ::= [A(bool)].
+Fail Ltac2 Type t ::= [B | B(bool)].
+
+(* constructors cannot be shadowed in the same module *)
+Fail Ltac2 Type s := [A].
+
+(* constructors with the same name can be defined in distinct modules *)
+Module Other.
+  Ltac2 Type t ::= [A(bool)].
+End Other.
+Module YetAnother.
+  Ltac2 Type t' := [A].
+End YetAnother.

--- a/test-suite/bugs/closed/bug_11046.v
+++ b/test-suite/bugs/closed/bug_11046.v
@@ -15,5 +15,5 @@ Module Other.
   Ltac2 Type t ::= [A(bool)].
 End Other.
 Module YetAnother.
-  Ltac2 Type t' := [A].
+  Ltac2 Type t := [A].
 End YetAnother.

--- a/user-contrib/Ltac2/tac2entries.ml
+++ b/user-contrib/Ltac2/tac2entries.ml
@@ -374,6 +374,15 @@ let register_typedef ?(local = false) isrec types =
   | ({loc;v=id}, _) :: _ ->
     user_err ?loc (str "Multiple definition of the type name " ++ Id.print id)
   in
+  let () =
+    let check_existing_type ({v=id},_) =
+      let qid = Libnames.make_qualid (Lib.current_dirpath false) id in
+      try let _ = Tac2env.locate_type qid in
+        user_err (str "Multiple definition of the type name " ++ pr_qualid qid)
+      with Not_found -> ()
+    in
+    List.iter check_existing_type types
+  in
   let check ({loc;v=id}, (params, def)) =
     let same_name {v=id1} {v=id2} = Id.equal id1 id2 in
     let () = match List.duplicates same_name params with

--- a/user-contrib/Ltac2/tac2env.ml
+++ b/user-contrib/Ltac2/tac2env.ml
@@ -196,6 +196,11 @@ let shortest_qualid_of_constructor kn =
   let sp = KNmap.find kn tab.tab_cstr_rev in
   KnTab.shortest_qualid Id.Set.empty sp tab.tab_cstr
 
+let mem_constructor qid =
+  let tab = !nametab in
+  try ignore (KnTab.locate qid tab.tab_cstr) ; true
+  with Not_found -> false
+
 let push_type vis sp kn =
   let tab = !nametab in
   let tab_type = KnTab.push vis sp kn tab.tab_type in

--- a/user-contrib/Ltac2/tac2env.mli
+++ b/user-contrib/Ltac2/tac2env.mli
@@ -83,6 +83,7 @@ val locate_extended_all_ltac : qualid -> tacref list
 val shortest_qualid_of_ltac : tacref -> qualid
 
 val push_constructor : visibility -> full_path -> ltac_constructor -> unit
+val mem_constructor : qualid -> bool
 val locate_constructor : qualid -> ltac_constructor
 val locate_extended_all_constructor : qualid -> ltac_constructor list
 val shortest_qualid_of_constructor : ltac_constructor -> qualid


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** bug fix .


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #10097 #11046 


<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [x] Added / updated test-suite

