### PR TITLE
Swap parsing precedence of `::` and `,` ; Fix #10116

### DIFF
--- a/test-suite/bugs/closed/bug_10116.v
+++ b/test-suite/bugs/closed/bug_10116.v
@@ -1,0 +1,3 @@
+From Ltac2 Require Import Ltac2.
+
+Ltac2 Eval true :: [], false.

--- a/user-contrib/Ltac2/g_ltac2.mlg
+++ b/user-contrib/Ltac2/g_ltac2.mlg
@@ -175,13 +175,13 @@ GRAMMAR EXTEND Gram
         { CAst.make ~loc @@ CTacCse (e, bl) }
       ]
     | "4" LEFTA [ ]
+    | [ e0 = SELF; ","; el = LIST1 NEXT SEP "," ->
+        { let el = e0 :: el in
+          CAst.make ~loc @@ CTacApp (CAst.make ~loc @@ CTacCst (AbsKn (Tuple (List.length el))), el) } ]
     | "::" RIGHTA
       [ e1 = tac2expr; "::"; e2 = tac2expr ->
         { CAst.make ~loc @@ CTacApp (CAst.make ~loc @@ CTacCst (AbsKn (Other Tac2core.Core.c_cons)), [e1; e2]) }
       ]
-    | [ e0 = SELF; ","; el = LIST1 NEXT SEP "," ->
-        { let el = e0 :: el in
-          CAst.make ~loc @@ CTacApp (CAst.make ~loc @@ CTacCst (AbsKn (Tuple (List.length el))), el) } ]
     | "1" LEFTA
       [ e = tac2expr; el = LIST1 tac2expr LEVEL "0" ->
         { CAst.make ~loc @@ CTacApp (e, el) }


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** bug fix 



<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #10116


<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [x] Added / updated test-suite
