### PR TITLE
Allow universe annotations in record projections.

### DIFF
--- a/parsing/g_constr.mlg
+++ b/parsing/g_constr.mlg
@@ -218,11 +218,11 @@ GRAMMAR EXTEND Gram
           { CAst.make ~loc @@ CAppExpl ((None, (qualid_of_ident ~loc ldots_var), None),[c]) } ]
     | "8" [ ]
     | "1" LEFTA
-      [ c=operconstr; ".("; f=global; args=LIST0 appl_arg; ")" ->
-	{ CAst.make ~loc @@ CApp((Some (List.length args+1), CAst.make @@ CRef (f,None)),args@[c,None]) }
-      | c=operconstr; ".("; "@"; f=global;
+      [ c=operconstr; ".("; f=global; i=instance; args=LIST0 appl_arg; ")" ->
+        { CAst.make ~loc @@ CApp((Some (List.length args+1), CAst.make @@ CRef (f,i)),args@[c,None]) }
+      | c=operconstr; ".("; "@"; f=global; i=instance;
         args=LIST0 (operconstr LEVEL "9"); ")" ->
-        { CAst.make ~loc @@ CAppExpl((Some (List.length args+1),f,None),args@[c]) }
+        { CAst.make ~loc @@ CAppExpl((Some (List.length args+1),f,i),args@[c]) }
       | c=operconstr; "%"; key=IDENT -> { CAst.make ~loc @@ CDelimiters (key,c) } ]
     | "0"
       [ c=atomic_constr -> { c }


### PR DESCRIPTION
For consistency with the function application syntax.

I'm submitting this patch as a PR because Hugo thinks it makes sense. I can use the example from #11054 in the test-suite and documentation, but maybe someone who is an actual user of universes has a better example to propose.

**Kind:** enhancement.

Fixes / closes #11054

<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [ ] Added / updated test-suite
<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [ ] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [ ] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
