### PR TITLE
[Docker] Dedicate a docker image to the v8.11 branch

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ stages:
 variables:
   # Format: $IMAGE-V$DATE [Cache is not used as of today but kept here
   # for reference]
-  CACHEKEY: "bionic_coq-V2019-11-05-V01"
+  CACHEKEY: "bionic_coq-v8.11-V2019-11-08-V01"
   IMAGE: "$CI_REGISTRY_IMAGE:$CACHEKEY"
   # By default, jobs run in the base switch; override to select another switch
   OPAM_SWITCH: "base"

--- a/dev/ci/docker/bionic_coq/Dockerfile
+++ b/dev/ci/docker/bionic_coq/Dockerfile
@@ -1,4 +1,4 @@
-# CACHEKEY: "bionic_coq-V2019-11-05-V01"
+# CACHEKEY: "bionic_coq-v8.11-V2019-11-08-V01"
 # ^^ Update when modifying this file.
 
 FROM ubuntu:bionic


### PR DESCRIPTION
With “v8.11” in its name, this image should not be deleted during a routine clean-up operation.