### PR TITLE
Do not rely on the user settings but on the actual window size. (Fixes #10956)

### DIFF
--- a/ide/coqide.ml
+++ b/ide/coqide.ml
@@ -966,6 +966,8 @@ let build_ui () =
     with _ -> ()
   in
   let _ = w#event#connect#delete ~callback:(fun _ -> File.quit ~parent:w (); true) in
+  let _ = w#misc#connect#size_allocate
+            ~callback:(fun rect -> window_size := (rect.Gtk.width, rect.Gtk.height)) in
   let _ = set_drag w#drag in
 
   let vbox = GPack.vbox ~homogeneous:false ~packing:w#add () in

--- a/ide/session.ml
+++ b/ide/session.ml
@@ -432,6 +432,8 @@ let kill (sn:session) =
   sn.script#destroy ();
   Coq.close_coqtop sn.coqtop
 
+let window_size = ref (window_width#get, window_height#get)
+
 let build_layout (sn:session) =
   let session_paned = GPack.paned `VERTICAL () in
   let session_box =
@@ -514,9 +516,9 @@ let build_layout (sn:session) =
      iteration of the loop *)
   let () =
     (* 14 is the estimated size for vertical borders *)
-    let estimated_vertical_handle_position = (window_width#get - 14) / 2 in
+    let estimated_vertical_handle_position = (fst !window_size - 14) / 2 in
     (* 169 is the estimated size for menus, command line, horizontal border *)
-    let estimated_horizontal_handle_position = (window_height#get - 169) / 2 in
+    let estimated_horizontal_handle_position = (snd !window_size - 169) / 2 in
     if estimated_vertical_handle_position > 0 then
       eval_paned#set_position estimated_vertical_handle_position;
     if estimated_horizontal_handle_position > 0 then

--- a/ide/session.mli
+++ b/ide/session.mli
@@ -51,3 +51,5 @@ val kill : session -> unit
 
 val build_layout : session ->
   GObj.widget option * GObj.widget option * GObj.widget
+
+val window_size : (int * int) ref


### PR DESCRIPTION
This should fix the issue when creating new session panes. The initial
session panes, however, might still be wrongly sized, as we do not yet
know, at the time they are created, if the window manager will respect the
user settings fixing the window size.

Fixes #10956