### PR TITLE
coqdep: only output vos when passed -vos

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -897,7 +897,7 @@ endif
 
 $(VDFILE).d: $(D_DEPEND_BEFORE_SRC) $(VFILES) $(D_DEPEND_AFTER_SRC) $(COQDEPBOOT)
 	$(SHOW)'COQDEP    VFILES'
-	$(HIDE)$(COQDEPBOOT) -boot $(DYNDEP) -Q user-contrib "" $(USERCONTRIBINCLUDES) $(VFILES) $(TOTARGET)
+	$(HIDE)$(COQDEPBOOT) -vos -boot $(DYNDEP) -Q user-contrib "" $(USERCONTRIBINCLUDES) $(VFILES) $(TOTARGET)
 
 ###########################################################################
 

--- a/tools/CoqMakefile.in
+++ b/tools/CoqMakefile.in
@@ -753,7 +753,7 @@ VDFILE_FLAGS:=$(if @PROJECT_FILE@,-f @PROJECT_FILE@,) $(CMDLINE_COQLIBS) $(CMDLI
 
 $(VDFILE): $(VFILES)
 	$(SHOW)'COQDEP VFILES'
-	$(HIDE)$(COQDEP) -dyndep var $(VDFILE_FLAGS) $(redir_if_ok)
+	$(HIDE)$(COQDEP) -vos -dyndep var $(VDFILE_FLAGS) $(redir_if_ok)
 
 # Misc ########################################################################
 

--- a/tools/coqdep.ml
+++ b/tools/coqdep.ml
@@ -486,6 +486,7 @@ let rec parse = function
   | "-w" :: ll -> option_w := true; parse ll
   | "-boot" :: ll -> option_boot := true; parse ll
   | "-sort" :: ll -> option_sort := true; parse ll
+  | "-vos" :: ll -> write_vos := true; parse ll
   | ("-noglob" | "-no-glob") :: ll -> option_noglob := true; parse ll
   | "-f" :: f :: ll -> treat_coqproject f; parse ll
   | "-I" :: r :: ll -> add_caml_dir r; parse ll

--- a/tools/coqdep_common.ml
+++ b/tools/coqdep_common.ml
@@ -517,6 +517,8 @@ let mL_dependencies () =
        printf "%!")
     (List.rev !mlpackAccu)
 
+let write_vos = ref false
+
 let coq_dependencies () =
   List.iter
     (fun (name,_) ->
@@ -526,9 +528,10 @@ let coq_dependencies () =
        printf "%s%s%s %s.v.beautified %s.required_vo: %s.v %s\n" ename !suffixe glob ename ename ename
         (string_of_dependency_list !suffixe deps);
        printf "%s.vio: %s.v %s\n" ename ename
-        (string_of_dependency_list ".vio" deps);
-       printf "%s.vos %s.vok %s.required_vos: %s.v %s\n" ename ename ename ename
-        (string_of_dependency_list ".vos" deps);
+         (string_of_dependency_list ".vio" deps);
+       if !write_vos then
+         printf "%s.vos %s.vok %s.required_vos: %s.v %s\n" ename ename ename ename
+           (string_of_dependency_list ".vos" deps);
        printf "%!")
     (List.rev !vAccu)
 

--- a/tools/coqdep_common.mli
+++ b/tools/coqdep_common.mli
@@ -24,6 +24,9 @@ val option_c : bool ref
 val option_noglob : bool ref
 val option_boot : bool ref
 
+val write_vos : bool ref
+(** output vos and vok dependencies *)
+
 type dynlink = Opt | Byte | Both | No | Variable
 
 val option_dynlink : dynlink ref


### PR DESCRIPTION
This fixes dune. TBH the problem is that dune is too strict, but we
can't go back in time to change it.