### PR TITLE
load .vo when .vos is missing + misc vos changes

### DIFF
--- a/doc/sphinx/practical-tools/coq-commands.rst
+++ b/doc/sphinx/practical-tools/coq-commands.rst
@@ -354,11 +354,11 @@ within a section.
 **Interaction with standard compilation**
 
 When compiling a file ``foo.v`` using ``coqc`` in the standard way (i.e., without
-``-vos`` nor ``-vok``), an empty file ``foo.vos`` is created in addition to the
-regular output file ``foo.vo``. If ``coqc`` is subsequently invoked on some other
-file ``bar.v`` using option ``-vos`` or ``-vok``, and that ``bar.v`` requires
-``foo.v``, if |Coq| finds an empty file ``foo.vos``, then it will load
-``foo.vo`` instead of ``foo.vos``.
+``-vos`` nor ``-vok``), an empty file ``foo.vos`` and an empty file ``foo.vok``
+are created in addition to the regular output file ``foo.vo``.
+If ``coqc`` is subsequently invoked on some other file ``bar.v`` using option
+``-vos`` or ``-vok``, and that ``bar.v`` requires ``foo.v``, if |Coq| finds an
+empty file ``foo.vos``, then it will load ``foo.vo`` instead of ``foo.vos``.
 
 The purpose of this feature is to allow users to benefit from the ``-vos``
 option even if they depend on libraries that were compiled in the traditional

--- a/test-suite/coq-makefile/coqdoc1/run.sh
+++ b/test-suite/coq-makefile/coqdoc1/run.sh
@@ -28,12 +28,10 @@ sort -u > desired <<EOT
 ./test/test.glob
 ./test/test.v
 ./test/test.vo
-./test/test.vos
 ./test/sub
 ./test/sub/testsub.glob
 ./test/sub/testsub.v
 ./test/sub/testsub.vo
-./test/sub/testsub.vos
 ./test/mlihtml
 ./test/mlihtml/index_exceptions.html
 ./test/mlihtml/index.html

--- a/test-suite/coq-makefile/coqdoc2/run.sh
+++ b/test-suite/coq-makefile/coqdoc2/run.sh
@@ -26,12 +26,10 @@ sort -u > desired <<EOT
 ./test/test.glob
 ./test/test.v
 ./test/test.vo
-./test/test.vos
 ./test/sub
 ./test/sub/testsub.glob
 ./test/sub/testsub.v
 ./test/sub/testsub.vo
-./test/sub/testsub.vos
 ./test/mlihtml
 ./test/mlihtml/index_exceptions.html
 ./test/mlihtml/index.html

--- a/test-suite/coq-makefile/mlpack1/run.sh
+++ b/test-suite/coq-makefile/mlpack1/run.sh
@@ -19,6 +19,5 @@ sort > desired <<EOT
 ./test/test_plugin.cmxs
 ./test/test.v
 ./test/test.vo
-./test/test.vos
 EOT
 exec diff -u desired actual

--- a/test-suite/coq-makefile/mlpack2/run.sh
+++ b/test-suite/coq-makefile/mlpack2/run.sh
@@ -19,6 +19,5 @@ sort > desired <<EOT
 ./test/test_plugin.cmxs
 ./test/test.v
 ./test/test.vo
-./test/test.vos
 EOT
 exec diff -u desired actual

--- a/test-suite/coq-makefile/multiroot/run.sh
+++ b/test-suite/coq-makefile/multiroot/run.sh
@@ -29,12 +29,10 @@ sort > desired <<EOT
 ./test/test_plugin.cmxs
 ./test/test.v
 ./test/test.vo
-./test/test.vos
 ./test2
 ./test2/test.glob
 ./test2/test.v
 ./test2/test.vo
-./test2/test.vos
 ./orphan_test_test2_test
 ./orphan_test_test2_test/html
 ./orphan_test_test2_test/html/coqdoc.css

--- a/test-suite/coq-makefile/native1/run.sh
+++ b/test-suite/coq-makefile/native1/run.sh
@@ -22,7 +22,6 @@ sort > desired <<EOT
 ./test/test_plugin.cmxs
 ./test/test.v
 ./test/test.vo
-./test/test.vos
 ./test/.coq-native
 ./test/.coq-native/Ntest_test.cmi
 ./test/.coq-native/Ntest_test.cmx

--- a/test-suite/coq-makefile/plugin1/run.sh
+++ b/test-suite/coq-makefile/plugin1/run.sh
@@ -22,6 +22,5 @@ sort > desired <<EOT
 ./test/test_plugin.cmxs
 ./test/test.v
 ./test/test.vo
-./test/test.vos
 EOT
 exec diff -u desired actual

--- a/test-suite/coq-makefile/plugin2/run.sh
+++ b/test-suite/coq-makefile/plugin2/run.sh
@@ -22,6 +22,5 @@ sort > desired <<EOT
 ./test/test_plugin.cmxs
 ./test/test.v
 ./test/test.vo
-./test/test.vos
 EOT
 exec diff -u desired actual

--- a/test-suite/coq-makefile/plugin3/run.sh
+++ b/test-suite/coq-makefile/plugin3/run.sh
@@ -22,6 +22,5 @@ sort > desired <<EOT
 ./test/test_plugin.cmxs
 ./test/test.v
 ./test/test.vo
-./test/test.vos
 EOT
 exec diff -u desired actual

--- a/tools/CoqMakefile.in
+++ b/tools/CoqMakefile.in
@@ -249,7 +249,6 @@ VO = vo
 VOS = vos
 
 VOFILES = $(VFILES:.v=.$(VO))
-VOSFILES = $(VFILES:.v=.$(VOS))
 GLOBFILES = $(VFILES:.v=.glob)
 HTMLFILES = $(VFILES:.v=.html)
 GHTMLFILES = $(VFILES:.v=.g.html)
@@ -300,7 +299,6 @@ ALLNATIVEFILES = \
 NATIVEFILES = $(wildcard $(ALLNATIVEFILES))
 FILESTOINSTALL = \
 	$(VOFILES) \
-	$(VOSFILES) \
 	$(VFILES) \
 	$(GLOBFILES) \
 	$(NATIVEFILES) \

--- a/toplevel/ccompile.ml
+++ b/toplevel/ccompile.ml
@@ -150,8 +150,11 @@ let compile opts copts ~echo ~f_in ~f_out =
       Aux_file.record_in_aux_at "vo_compile_time"
         (Printf.sprintf "%.3f" (wall_clock2 -. wall_clock1));
       Aux_file.stop_aux_file ();
-      (* Produce an empty .vos file when producing a .vo in standard mode *)
-      if mode = BuildVo then create_empty_file (long_f_dot_out ^ "s");
+      (* Produce an empty .vos file and an empty .vok file when producing a .vo in standard mode *)
+      if mode = BuildVo then begin
+        create_empty_file (long_f_dot_out ^ "s");
+        create_empty_file (long_f_dot_out ^ "k");
+      end;
       (* Produce an empty .vok file when in -vok mode *)
       if mode = BuildVok then create_empty_file (long_f_dot_out);
       Dumpglob.end_dump_glob ()

--- a/toplevel/coqcargs.mli
+++ b/toplevel/coqcargs.mli
@@ -10,7 +10,7 @@
 
 (** Compilation modes:
   - BuildVo      : process statements and proofs (standard compilation),
-                   and also output an empty .vos file
+                   and also output an empty .vos file and .vok file
   - BuildVio     : process statements, delay proofs in futures
   - Vio2Vo       : load delayed proofs and process them
   - BuildVos     : process statements, and discard proofs,

--- a/vernac/loadpath.ml
+++ b/vernac/loadpath.ml
@@ -140,12 +140,10 @@ let select_vo_file ~warn loadpath base =
     with Not_found -> None in
   if !Flags.load_vos_libraries then begin
     (* If the .vos file exists and is not empty, it describes the library.
-       If the .vos file exists and is empty, then load the .vo file.
-       If the .vos file is missing, then fail. *)
+       Otherwise, load the .vo file, or fail if is missing. *)
     match find ".vos" with
-    | None -> Error LibNotFound
-    | Some (_, vos as resvos) ->
-        if (Unix.stat vos).Unix.st_size > 0 then Ok resvos else
+    | Some (_, vos as resvos) when (Unix.stat vos).Unix.st_size > 0 -> Ok resvos
+    | _ ->
         match find ".vo" with
         | None -> Error LibNotFound
         | Some resvo -> Ok resvo


### PR DESCRIPTION
**Kind:** bug fix 
Fixes #11057 

This PR contains three commits.
- From CoqIDE or -vos or -vok compilation, load .vo when .vos is missing.
- No longer install .vos files in user contribs from coq_makefile.
- Compilation of a .vo touches an empty .vok file in addition to the .vos file (we might later choose to produce none of them, and let the build system touch these two files, however it seems a bad idea to have an asymmetry between touching .vos and .vok).


