### PR TITLE
Native compute: cleanup temporary files on program exit

### DIFF
--- a/clib/cUnix.mli
+++ b/clib/cUnix.mli
@@ -65,3 +65,5 @@ val waitpid_non_intr : int -> Unix.process_status
 (** Check if two file names refer to the same (existing) file *)
 val same_file : string -> string -> bool
 
+(** Like [Stdlib.Filename.temp_file] but producing a directory. *)
+val mktemp_dir : ?temp_dir:string -> string -> string -> string

--- a/doc/changelog/01-kernel/11081-native-cleanup.rst
+++ b/doc/changelog/01-kernel/11081-native-cleanup.rst
@@ -1,0 +1,4 @@
+- **Changed:** the native compilation (:tacn:`native_compute`) now
+  creates a directory to contain temporary files instead of putting
+  them in the root of the system temporary directory. (`#11081
+  <https://github.com/coq/coq/pull/11081>`_, by Gaëtan Gilbert).


### PR DESCRIPTION
We make a temporary directory for these files and cleanup at process
exit. The temporary directory means we don't have to guess what
extensions ocaml will produce, we can just delete everything there.

We use Lazy to avoid spamming unused directories when ahead-of-time
compiling without actually using native casts / nativenorm (typically
stdlib files).

Sadly ocaml has "create temp file" but not "create temp dir", so we
have to copy the name generation code.

Fix #10495