### PR TITLE
Printing of coercions to which a notation is associated: a refined version of #8890 which prevents #11033.

### DIFF
--- a/doc/changelog/03-notations/11090-master+refactoring-application-printing.rst
+++ b/doc/changelog/03-notations/11090-master+refactoring-application-printing.rst
@@ -1,0 +1,1 @@
+- Fixed #11033: regression in not printing coercions to which is also associated a notation (`#11090 <https://github.com/coq/coq/pull/11090>`_, by Hugo Herbelin).

--- a/test-suite/output/Notations4.out
+++ b/test-suite/output/Notations4.out
@@ -59,3 +59,5 @@ where
       |- Type] (pat, p0, p cannot be used)
 fun '{| |} => true
      : R -> bool
+b = a
+     : Prop

--- a/test-suite/output/Notations4.v
+++ b/test-suite/output/Notations4.v
@@ -140,3 +140,17 @@ Record R := { n : nat }.
 Check fun '{|n:=x|} => true.
 
 End EmptyRecordSyntax.
+
+Module L.
+
+(* Testing regression #11053 *)
+
+Section Test.
+Variables (A B : Type) (a : A) (b : B).
+Variable c : A -> B.
+Coercion c : A >-> B.
+Notation COERCION := (c).
+Check b = a.
+End Test.
+
+End L.


### PR DESCRIPTION
This is a short fix for #11033 preserving the benefits of #8890: in the presence of removable coercions, the preference order is:
- a notation w/o a delimiter for the expression with coercions skipped, if any
- a notation for a full application of the coercion, if any
- a notation with a delimiter for the expression with coercions skipped, if any

In the 1st and 3rd case, the notation can be for a partial application of the expression

The change wrt #8890 is the "full application" in the 2nd case.

<!-- Keep what applies -->
**Kind:** bug fix / enhancement

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #11033

- [X] Added / updated test-suite
- [X] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).

Relevant for 8.10.2, 8.11.0 and master (though I may propose further refinements for master).