### PR TITLE
Miscellaneous micro-improvements of the syntax of records

### DIFF
--- a/parsing/g_constr.mlg
+++ b/parsing/g_constr.mlg
@@ -393,7 +393,6 @@ GRAMMAR EXTEND Gram
   ;
   record_patterns:
     [ [ p = record_pattern; ";"; ps = record_patterns -> { p :: ps }
-      | p = record_pattern; ";" -> { [p] }
       | p = record_pattern-> { [p] }
       | -> { [] }
     ] ]

--- a/printing/ppconstr.ml
+++ b/printing/ppconstr.ml
@@ -249,7 +249,8 @@ let tag_var = tag Tag.variable
         let pp (c, p) =
           pr_reference c ++ spc() ++ str ":=" ++ pr_patt spc (lpatrec, Any) p
         in
-        str "{| " ++ prlist_with_sep pr_semicolon pp l ++ str " |}", lpatrec
+        (if l = [] then str "{| |}"
+         else str "{| " ++ prlist_with_sep pr_semicolon pp l ++ str " |}"), lpatrec
 
       | CPatAlias (p, na) ->
         pr_patt mt (las,E) p ++ str " as " ++ pr_lname na, las

--- a/test-suite/output/Notations4.out
+++ b/test-suite/output/Notations4.out
@@ -57,3 +57,5 @@ where
      |- Type] (pat, p0, p cannot be used)
 ?T0 : [y : nat  pat : ?T0 * nat  p0 : ?T0 * nat  p := p0 : ?T0 * nat
       |- Type] (pat, p0, p cannot be used)
+fun '{| |} => true
+     : R -> bool

--- a/test-suite/output/Notations4.v
+++ b/test-suite/output/Notations4.v
@@ -133,3 +133,10 @@ Check fun y : nat => # (x,z) |-> y & y.
 Check fun y : nat => # (x,z) |-> (x + y) & (y + z).
 
 End K.
+
+Module EmptyRecordSyntax.
+
+Record R := { n : nat }.
+Check fun '{|n:=x|} => true.
+
+End EmptyRecordSyntax.


### PR DESCRIPTION
Two micro-improvements:
- only one space instead of two when printing `{| |}`
- removing a redundant clause in the grammar of `record_patterns` in `g_constr.mlg`

**Kind:** enhancement, cleanup

- [X] Added / updated test-suite
