### PR TITLE
Do not export the internals of the prepare_hint function.

### DIFF
--- a/tactics/eauto.ml
+++ b/tactics/eauto.ml
@@ -86,16 +86,13 @@ let rec prolog l n gl =
   let prol = (prolog l (n-1)) in
   (tclFIRST (List.map (fun t -> (tclTHEN t prol)) (one_step l gl))) gl
 
-let out_term env = function
-  | IsConstr (c, _) -> c
-  | IsGlobRef gr -> EConstr.of_constr (fst (UnivGen.fresh_global_instance env gr))
-
 let prolog_tac l n =
   Proofview.V82.tactic begin fun gl ->
   let map c =
     let (sigma, c) = c (pf_env gl) (project gl) in
-    let c = pf_apply (prepare_hint false (false,true)) gl (sigma, c) in
-    out_term (pf_env gl) c
+    (* Dropping the universe context is probably wrong *)
+    let (c, _) = pf_apply (prepare_hint false) gl (sigma, c) in
+    c
   in
   let l = List.map map l in
   try (prolog l n gl)

--- a/tactics/hints.mli
+++ b/tactics/hints.mli
@@ -212,8 +212,7 @@ val interp_hints : poly:bool -> hints_expr -> hints_entry
 val add_hints : local:bool -> hint_db_name list -> hints_entry -> unit
 
 val prepare_hint : bool (* Check no remaining evars *) ->
-  (bool * bool) (* polymorphic or monomorphic, local or global *) ->
-  env -> evar_map -> evar_map * constr -> hint_term
+  env -> evar_map -> evar_map * constr -> (constr * Univ.ContextSet.t)
 
 (** [make_exact_entry info (c, ctyp, ctx)].
    [c] is the term given as an exact proof to solve the goal;


### PR DESCRIPTION
This statically ensures more invariants and moves a global declaration out of this function.
