### PR TITLE
Let Arguments support anonymous implicit arguments

### DIFF
--- a/doc/changelog/02-specification-language/11098-master+arguments-supports-anonymous-implicit.rst
+++ b/doc/changelog/02-specification-language/11098-master+arguments-supports-anonymous-implicit.rst
@@ -1,0 +1,8 @@
+- **Added:**
+  :cmd:`Arguments <Arguments (implicits)>` now supports setting
+  implicit an anonymous argument, as e.g. in :g:`Arguments id {A} {_}`.
+  (`#11098 <https://github.com/coq/coq/pull/11098>`_,
+  by Hugo Herbelin, fixes `#4696
+  <https://github.com/coq/coq/pull/4696>`_, `#5173
+  <https://github.com/coq/coq/pull/5173>`_, `#9098
+  <https://github.com/coq/coq/pull/9098>`_.).

--- a/doc/sphinx/language/gallina-extensions.rst
+++ b/doc/sphinx/language/gallina-extensions.rst
@@ -1583,7 +1583,7 @@ An implicit argument is considered trailing when all following arguments are dec
 implicit. Trailing implicit arguments cannot be declared non maximally inserted,
 otherwise they would never be inserted.
 
-.. exn:: Argument @ident is a trailing implicit, so it can't be declared non maximal. Please use %{ %} instead of [ ].
+.. exn:: Argument @name is a trailing implicit, so it can't be declared non maximal. Please use %{ %} instead of [ ].
 
    For instance:
 
@@ -1713,11 +1713,11 @@ Declaring Implicit Arguments
 
 
 
-.. cmd:: Arguments @qualid {* {| [ @ident ] | { @ident } | @ident } }
+.. cmd:: Arguments @qualid {* {| [ @name ] | { @name } | @name } }
    :name: Arguments (implicits)
 
    This command is used to set implicit arguments *a posteriori*,
-   where the list of possibly bracketed :token:`ident` is a prefix of the list of
+   where the list of possibly bracketed :token:`name` is a prefix of the list of
    arguments of :token:`qualid` where the ones to be declared implicit are
    surrounded by square brackets and the ones to be declared as maximally
    inserted implicits are surrounded by curly braces.
@@ -1731,20 +1731,20 @@ Declaring Implicit Arguments
 
    This command clears implicit arguments.
 
-.. cmdv:: Global Arguments @qualid {* {| [ @ident ] | { @ident } | @ident } }
+.. cmdv:: Global Arguments @qualid {* {| [ @name ] | { @name } | @name } }
 
    This command is used to recompute the implicit arguments of
    :token:`qualid` after ending of the current section if any, enforcing the
    implicit arguments known from inside the section to be the ones
    declared by the command.
 
-.. cmdv:: Local Arguments @qualid {* {| [ @ident ] | { @ident } | @ident } }
+.. cmdv:: Local Arguments @qualid {* {| [ @name ] | { @name } | @name } }
 
    When in a module, tell not to activate the
    implicit arguments of :token:`qualid` declared by this command to contexts that
    require the module.
 
-.. cmdv:: {? {| Global | Local } } Arguments @qualid {*, {+ {| [ @ident ] | { @ident } | @ident } } }
+.. cmdv:: {? {| Global | Local } } Arguments @qualid {*, {+ {| [ @name ] | { @name } | @name } } }
 
    For names of constants, inductive types,
    constructors, lemmas which can only be applied to a fixed number of

--- a/interp/impargs.ml
+++ b/interp/impargs.ml
@@ -682,7 +682,7 @@ let compute_implicit_statuses autoimps l =
          (strbrk ("Argument number " ^ string_of_int i ^ " (anonymous in original definition) cannot be declared implicit."))
     | autoimps, [] -> List.map (fun _ -> None) autoimps
     | [], _::_ -> assert false
-  in aux 0 (autoimps, l)
+  in aux 1 (autoimps, l)
 
 let set_implicits local ref l =
   let flags = !implicit_args in

--- a/test-suite/output/Arguments_renaming.out
+++ b/test-suite/output/Arguments_renaming.out
@@ -86,8 +86,8 @@ Sequences of implicit arguments must be of different lengths.
 The command has indeed failed with message:
 Some argument names are duplicated: F
 The command has indeed failed with message:
-Argument number 2 (anonymous in original definition) cannot be declared
-implicit.
+Argument number 3 is a trailing implicit, so it can't be declared non
+maximal. Please use { } instead of [ ].
 The command has indeed failed with message:
 Extra arguments: y.
 The command has indeed failed with message:

--- a/test-suite/output/Arguments_renaming.v
+++ b/test-suite/output/Arguments_renaming.v
@@ -49,7 +49,6 @@ Check @myplus.
 Fail Arguments eq_refl {F g}, [H] k.
 Fail Arguments eq_refl {F}, [F] : rename.
 Fail Arguments eq_refl {F F}, [F] F : rename.
-Fail Arguments eq {F} x [z] : rename.
+Fail Arguments eq {A} x [z] : rename.
 Fail Arguments eq {F} x z y.
 Fail Arguments eq {R} s t.
-

--- a/test-suite/success/implicit.v
+++ b/test-suite/success/implicit.v
@@ -169,3 +169,16 @@ Variable eq0le0' : forall (n : nat) {x : n = 0}, n <= 0.
 Axiom eq0le0'' : forall (n : nat) {x : n = 0}, n <= 0.
 Definition eq0le0''' : forall (n : nat) {x : n = 0}, n <= 0. Admitted.
 Fail Axiom eq0le0'''' : forall [n : nat] {x : n = 0}, n <= 0.
+
+Module TestUnnamedImplicit.
+
+Axiom foo : forall A, A -> A.
+
+Arguments foo {A} {_}.
+Check foo (arg_2:=true) : bool.
+Check foo : bool.
+
+Arguments foo {A} {x}.
+Check foo (x:=true) : bool.
+
+End TestUnnamedImplicit.


### PR DESCRIPTION
**Kind:** enhancement

Depends on #10202. 

As noticed by @ejgallego, this fixes #5173, fixes #4696, fixes #9098.

It is possible to declare an anonymous implicit argument using `{ _ }` in the declaration of the object. Type classes also set some anonymous arguments implicit.

By consistency, this PR also let `Arguments` set an anonymous implicit argument as in:
```
Arguments id {A} {_}.
Check id (arg_2:=true).
Check id : bool.
```

Note: the anonymous argument can be made explicit using `arg_XX` where `XX` is the index of the argument among all arguments. I'm not a big fan of this syntax but this PR does not prevent to use it on the newly declared anonymous implicit arguments.

- [X] Added / updated test-suite
- [x] Corresponding documentation was added / updated (this is minor but maybe a word should be said)
- [x] Entry added in the changelog (this is minor but maybe a word should be said)
