### PR TITLE
Add support for instantiating non dependent implicit arguments by position

### DIFF
--- a/clib/cList.ml
+++ b/clib/cList.ml
@@ -22,6 +22,7 @@ sig
   val mem_f : 'a eq -> 'a -> 'a list -> bool
   val for_all_i : (int -> 'a -> bool) -> int -> 'a list -> bool
   val for_all2eq : ('a -> 'b -> bool) -> 'a list -> 'b list -> bool
+  val exists_i : (int -> 'a -> bool) -> int -> 'a list -> bool
   val prefix_of : 'a eq -> 'a list -> 'a list -> bool
   val same_length : 'a list -> 'b list -> bool
   val interval : int -> int -> int list
@@ -195,6 +196,13 @@ let for_all_i p =
 
 let for_all2eq f l1 l2 =
   try List.for_all2 f l1 l2 with Invalid_argument _ -> false
+
+let exists_i p =
+  let rec exists_p i = function
+    | [] -> false
+    | a::l -> p i a || exists_p (i+1) l
+  in
+  exists_p
 
 let prefix_of cmp prefl l =
   let rec prefrec = function

--- a/clib/cList.mli
+++ b/clib/cList.mli
@@ -38,6 +38,9 @@ sig
   val for_all2eq : ('a -> 'b -> bool) -> 'a list -> 'b list -> bool
   (** Same as [List.for_all2] but returning [false] when of different length *)
 
+  val exists_i : (int -> 'a -> bool) -> int -> 'a list -> bool
+  (** Same as [List.exists] but with an index *)
+
   val prefix_of : 'a eq -> 'a list eq
   (** [prefix_of eq l1 l2] returns [true] if [l1] is a prefix of [l2], [false]
       otherwise. It uses [eq] to compare elements *)

--- a/doc/changelog/02-specification-language/11099-master+instantiate-non-dependent-arguments-by-position.rst
+++ b/doc/changelog/02-specification-language/11099-master+instantiate-non-dependent-arguments-by-position.rst
@@ -1,0 +1,7 @@
+- **Added:**
+  Non-dependent implicit arguments can be provided explicitly using
+  the syntax :n:`(@natural := @term)` where :token:`natural` is the index
+  of the implicit argument among all non-dependent arguments of the
+  function, starting from 1
+  (`#11099 <https://github.com/coq/coq/pull/11099>`_,
+  by Hugo Herbelin).

--- a/doc/sphinx/language/core/assumptions.rst
+++ b/doc/sphinx/language/core/assumptions.rst
@@ -112,6 +112,7 @@ Function application
    term_application ::= @term1 {+ @arg }
    | @ @qualid_annotated {+ @term1 }
    arg ::= ( @ident := @term )
+   | ( @natural := @term )
    | @term1
 
 :n:`@term__fun @term` denotes applying the function :n:`@term__fun` to :token:`term`.
@@ -121,8 +122,8 @@ Function application
 equivalent to :n:`( … ( @term__fun @term__1 ) … ) @term__n`:
 associativity is to the left.
 
-The notation :n:`(@ident := @term)` for arguments is used for making
-explicit the value of implicit arguments (see
+The notations :n:`(@ident := @term)` and :n:`(@natural := @term)`
+for arguments are used for making explicit the value of implicit arguments (see
 Section :ref:`explicit-applications`).
 
 .. _gallina-assumptions:

--- a/doc/sphinx/language/extensions/implicit-arguments.rst
+++ b/doc/sphinx/language/extensions/implicit-arguments.rst
@@ -347,9 +347,18 @@ Explicit applications
 In presence of non-strict or contextual arguments, or in presence of
 partial applications, the synthesis of implicit arguments may fail, so
 one may have to explicitly give certain implicit arguments of an
-application. Use the :n:`(@ident := @term)` form of :token:`arg` to do so,
+application.
+
+To instantiate a dependent implicit arguments, use the :n:`(@ident := @term)` form of :token:`arg`,
 where :token:`ident` is the name of the implicit argument and :token:`term`
-is its corresponding explicit term. Alternatively, one can deactivate
+is its corresponding explicit term.
+
+To instantiate a non-dependent implicit arguments, use the :n:`(@natural := @term)` form of :token:`arg`,
+where :token:`natural` is the index of the implicit argument among all
+non-dependent arguments of the function (implicit or not, and starting
+from 1) and :token:`term` is its corresponding explicit term.
+
+Alternatively, one can deactivate
 the hiding of implicit arguments for a single function application using the
 :n:`@@qualid_annotated {+ @term1 }` form of :token:`term_application`.
 
@@ -367,6 +376,24 @@ the hiding of implicit arguments for a single function application using the
        Check (p r1 (z:=c)).
 
        Check (p (x:=a) (y:=b) r1 (z:=c) r2).
+
+.. exn:: Wrong argument name
+   :undocumented:
+
+.. exn:: Wrong argument position
+   :undocumented:
+
+.. exn:: Argument at position :n:`@natural` is mentioned more than once
+   :undocumented:
+
+.. exn:: Arguments given by name or position not supported in explicit mode
+   :undocumented:
+
+.. exn:: Not enough non implicit arguments to accept the argument bound to :n:`@ident`
+   :undocumented:
+
+.. exn:: Not enough non implicit arguments to accept the argument bound to :n:`@natural`
+   :undocumented:
 
 .. _displaying-implicit-args:
 

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -155,6 +155,7 @@ DELETE: [
 | test_id_colon
 | test_lpar_id_colon
 | test_lpar_id_coloneq  (* todo: grammar seems incorrect, repeats the "(" IDENT ":=" *)
+| test_lpar_nat_coloneq
 | test_lpar_id_rpar
 | test_lpar_idnum_coloneq
 | test_show_goal

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -164,6 +164,7 @@ binder_constr: [
 
 arg: [
 | test_lpar_id_coloneq "(" identref ":=" lconstr ")"
+| test_lpar_nat_coloneq "(" natural ":=" lconstr ")"
 | term9
 ]
 

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -81,6 +81,7 @@ term_application: [
 
 arg: [
 | "(" ident ":=" term ")"
+| "(" natural ":=" term ")"
 | term1
 ]
 

--- a/engine/eConstr.ml
+++ b/engine/eConstr.ml
@@ -446,6 +446,10 @@ let fold sigma f acc c =
   let f acc c = f acc (of_constr c) in
   Constr.fold f acc (unsafe_to_constr (whd_evar sigma c))
 
+let fold_with_binders sigma g f acc e c =
+  let f e acc c = f e acc (of_constr c) in
+  Constr.fold_constr_with_binders g f acc e (unsafe_to_constr (whd_evar sigma c))
+
 let compare_gen k eq_inst eq_sort eq_constr nargs c1 c2 =
   (c1 == c2) || Constr.compare_head_gen_with k k eq_inst eq_sort eq_constr nargs c1 c2
 

--- a/engine/eConstr.mli
+++ b/engine/eConstr.mli
@@ -262,6 +262,7 @@ val iter : Evd.evar_map -> (t -> unit) -> t -> unit
 val iter_with_binders : Evd.evar_map -> ('a -> 'a) -> ('a -> t -> unit) -> 'a -> t -> unit
 val iter_with_full_binders : Environ.env -> Evd.evar_map -> (rel_declaration -> 'a -> 'a) -> ('a -> t -> unit) -> 'a -> t -> unit
 val fold : Evd.evar_map -> ('a -> t -> 'a) -> 'a -> t -> 'a
+val fold_with_binders : Evd.evar_map -> ('a -> 'a) -> ('a -> 'b -> t -> 'b) -> 'a -> 'b -> t -> 'b
 
 (** Gather the universes transitively used in the term, including in the
    type of evars appearing in it. *)

--- a/engine/termops.mli
+++ b/engine/termops.mli
@@ -99,6 +99,10 @@ val local_occur_var_in_decl : Evd.evar_map -> Id.t -> named_declaration -> bool
 
 val free_rels : Evd.evar_map -> constr -> Int.Set.t
 
+(* Return the list of unbound rels and unqualified reference (same
+   strategy as in Namegen) *)
+val free_rels_and_unqualified_refs : Evd.evar_map -> constr -> Int.Set.t * Id.Set.t
+
 (** [dependent m t] tests whether [m] is a subterm of [t] *)
 val dependent : Evd.evar_map -> constr -> constr -> bool
 val dependent_no_evar : Evd.evar_map -> constr -> constr -> bool

--- a/interp/constrexpr.ml
+++ b/interp/constrexpr.ml
@@ -60,8 +60,8 @@ type 'a or_by_notation = 'a or_by_notation_r CAst.t
    but this formulation avoids a useless dependency. *)
 
 type explicitation =
-  | ExplByPos of int * Id.t option (* a reference to the n-th product starting from left *)
   | ExplByName of Id.t
+  | ExplByPos of int (* a reference to the n-th non-dependent implicit starting from left *)
 
 type binder_kind =
   | Default of Glob_term.binding_kind

--- a/interp/constrexpr_ops.ml
+++ b/interp/constrexpr_ops.ml
@@ -66,12 +66,10 @@ let prim_token_eq t1 t2 = match t1, t2 with
 | String s1, String s2 -> String.equal s1 s2
 | (Number _ | String _), _ -> false
 
-let explicitation_eq ex1 ex2 = match ex1, ex2 with
-| ExplByPos (i1, id1), ExplByPos (i2, id2) ->
-  Int.equal i1 i2 && Option.equal Id.equal id1 id2
-| ExplByName id1, ExplByName id2 ->
-  Id.equal id1 id2
-| _ -> false
+let explicitation_eq pos1 pos2 = match pos1, pos2 with
+| ExplByName id1, ExplByName id2 -> Id.equal id1 id2
+| ExplByPos n1, ExplByPos n2 -> Int.equal n1 n2
+| (ExplByName _ | ExplByPos _), _ -> false
 
 let rec cases_pattern_expr_eq p1 p2 =
   if CAst.(p1.v == p2.v) then true

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -677,7 +677,7 @@ let adjust_implicit_arguments inctx n args impl =
            is_significant_implicit (Lazy.force a))
         in
         if visible then
-          (Lazy.force a,Some (make @@ ExplByName (name_of_implicit imp))) :: tail
+          (Lazy.force a,Some (make @@ explicitation imp)) :: tail
         else
           tail
     | a::args, _::impl -> (Lazy.force a,None) :: exprec (args,impl)

--- a/interp/impargs.mli
+++ b/interp/impargs.mli
@@ -68,7 +68,9 @@ type maximal_insertion = bool (** true = maximal contextual insertion *)
 
 type force_inference = bool (** true = always infer, never turn into evar/subgoal *)
 
-type implicit_status = (Constrexpr.explicitation * implicit_explanation *
+type implicit_position = Name.t * int * int option
+
+type implicit_status = (implicit_position * implicit_explanation *
                           (maximal_insertion * force_inference)) option
     (** [None] = Not implicit *)
 
@@ -80,8 +82,11 @@ val is_status_implicit : implicit_status -> bool
 val binding_kind_of_status : implicit_status -> Glob_term.binding_kind
 val is_inferable_implicit : bool -> int -> implicit_status -> bool
 val name_of_implicit : implicit_status -> Id.t
+val match_implicit : implicit_status -> Constrexpr.explicitation -> bool
 val maximal_insertion_of : implicit_status -> bool
 val force_inference_of : implicit_status -> bool
+val is_nondep_implicit : int -> implicit_status list -> bool
+val explicitation : implicit_status -> Constrexpr.explicitation
 
 val positions_of_implicits : implicits_list -> int list
 
@@ -90,7 +95,7 @@ type manual_implicits = (Name.t * bool) option CAst.t list
 val compute_implicits_with_manual : env -> Evd.evar_map -> types -> bool ->
   manual_implicits -> implicit_status list
 
-val compute_implicits_names : env -> Evd.evar_map -> types -> Name.t list
+val compute_implicits_names : env -> Evd.evar_map -> types -> implicit_position list
 
 (** {6 Computation of implicits (done using the global environment). } *)
 

--- a/parsing/g_constr.mlg
+++ b/parsing/g_constr.mlg
@@ -53,6 +53,14 @@ let test_lpar_id_coloneq =
     lk_kw "(" >> lk_ident >> lk_kw ":="
   end
 
+(* Hack to parse "(n:=t)" as an explicit argument without conflicts with the *)
+(* syntax "(n t)" *)
+let test_lpar_nat_coloneq =
+  let open Pcoq.Lookahead in
+  to_entry "test_lpar_id_coloneq" begin
+    lk_kw "(" >> lk_nat >> lk_kw ":="
+  end
+
 let ensure_fixannot =
   let open Pcoq.Lookahead in
   to_entry "check_fixannot" begin
@@ -261,6 +269,7 @@ GRAMMAR EXTEND Gram
   ;
   arg:
     [ [ test_lpar_id_coloneq; "("; id = identref; ":="; c = lconstr; ")" -> { (c,Some (CAst.make ?loc:id.CAst.loc @@ ExplByName id.CAst.v)) }
+      | test_lpar_nat_coloneq; "("; n = natural; ":="; c = lconstr; ")" -> { (c,Some (CAst.make ~loc @@ ExplByPos n)) }
       | c=term LEVEL "9" -> { (c,None) } ] ]
   ;
   atomic_constr:

--- a/printing/ppconstr.ml
+++ b/printing/ppconstr.ml
@@ -214,10 +214,11 @@ let tag_var = tag Tag.variable
   let pr_expl_args pr (a,expl) =
     match expl with
       | None -> pr (LevelLt lapp) a
-      | Some {v=ExplByPos (n,_id)} ->
-        anomaly (Pp.str "Explicitation by position not implemented.")
-      | Some {v=ExplByName id} ->
-        str "(" ++ pr_id id ++ str ":=" ++ pr ltop a ++ str ")"
+      | Some {v=pos} ->
+        let pr_pos = function
+          | ExplByName id -> pr_id id
+          | ExplByPos p -> int p in
+        str "(" ++ pr_pos pos ++ str ":=" ++ pr ltop a ++ str ")"
 
   let pr_opt_type_spc pr = function
     | { CAst.v = CHole (_,IntroAnonymous,_) } -> mt ()

--- a/test-suite/success/implicit.v
+++ b/test-suite/success/implicit.v
@@ -176,9 +176,14 @@ Axiom foo : forall A, A -> A.
 
 Arguments foo {A} {_}.
 Check foo (arg_2:=true) : bool.
+Check foo (1:=true) : bool.
 Check foo : bool.
 
 Arguments foo {A} {x}.
 Check foo (x:=true) : bool.
+
+Axiom bar : forall A, A -> nat -> forall B, B -> A * B.
+Arguments bar {A} {x} _ {B} {y}.
+Check bar (1:=true) 0 (3:=false).
 
 End TestUnnamedImplicit.

--- a/vernac/comArguments.ml
+++ b/vernac/comArguments.ml
@@ -103,7 +103,7 @@ let vernac_arguments ~section_local reference args more_implicits flags =
   let sr = smart_global reference in
   let inf_names =
     let ty, _ = Typeops.type_of_global_in_context env sr in
-    Impargs.compute_implicits_names env sigma (EConstr.of_constr ty)
+    List.map pi1 (Impargs.compute_implicits_names env sigma (EConstr.of_constr ty))
   in
   let prev_names =
     try Arguments_renaming.arguments_names sr with Not_found -> inf_names

--- a/vernac/comProgramFixpoint.ml
+++ b/vernac/comProgramFixpoint.ml
@@ -199,7 +199,7 @@ let build_wellfounded pm (recname,pl,bl,arityc,body) poly ?typing_flags ?using r
     in
     let newimpls = Id.Map.singleton recname
         (Constrintern.extend_internalization_data interning_data
-           (Some (ExplByName (Id.of_string "recproof"), Impargs.Manual, (true, false)))
+           (Some ((Name (Id.of_string "recproof"),1,None), Impargs.Manual, (true, false)))
            None) in
     interp_casted_constr_evars ~program_mode:true (push_rel_context ctx env) sigma
       ~impls:newimpls body (lift 1 top_arity)

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -252,13 +252,9 @@ let needs_extra_scopes ref scopes =
   let ty, _ctx = Typeops.type_of_global_in_context env ref in
   aux env ty scopes
 
-let implicit_name_of_pos = function
-  | Constrexpr.ExplByName id -> Name id
-  | Constrexpr.ExplByPos (n,k) -> Anonymous
-
 let implicit_kind_of_status = function
   | None -> Anonymous, Glob_term.Explicit
-  | Some (pos,_,(maximal,_)) -> implicit_name_of_pos pos, if maximal then Glob_term.MaxImplicit else Glob_term.NonMaxImplicit
+  | Some ((na,_,_),_,(maximal,_)) -> na, if maximal then Glob_term.MaxImplicit else Glob_term.NonMaxImplicit
 
 let extra_implicit_kind_of_status imp =
   let _,imp = implicit_kind_of_status imp in
@@ -266,10 +262,10 @@ let extra_implicit_kind_of_status imp =
 
 let dummy = {
   Vernacexpr.implicit_status = Glob_term.Explicit;
-  name = Anonymous;
-  recarg_like = false;
-  notation_scope = None;
-}
+   name = Anonymous;
+   recarg_like = false;
+   notation_scope = None;
+ }
 
 let is_dummy = function
   | Vernacexpr.(RealArg {implicit_status; name; recarg_like; notation_scope}) ->
@@ -328,7 +324,7 @@ let print_arguments ref =
     with Not_found ->
       let env = Global.env () in
       let ty, _ = Typeops.type_of_global_in_context env ref in
-      Impargs.compute_implicits_names env (Evd.from_env env) (EConstr.of_constr ty), true in
+      List.map pi1 (Impargs.compute_implicits_names env (Evd.from_env env) (EConstr.of_constr ty)), true in
   let scopes = Notation.find_arguments_scope ref in
   let flags = if needs_extra_scopes ref scopes then `ExtraScopes::flags else flags in
   let impls = Impargs.extract_impargs_data (Impargs.implicits_of_global ref) in


### PR DESCRIPTION
**Kind:** enhancement

Depends on #10202 (merged) and #11098 (merged).

This PR adds a syntax of the form `(1:=term)` to instantiate explicitly a non-dependent implicit argument. Example:
```
Arguments id {A} {_}.
Check id (1:=true).
```

Deprecation of the undocumented notation `(arg_XX:=term)` will be done in another PR. 

- [x] Added / updated test-suite
- [x] Corresponding documentation was added / updated
- [x] Entry added in the changelog
