### PR TITLE
Notations: do not assign a delimiter to a scope if the delimiter is already used for another scope

### DIFF
--- a/doc/changelog/03-notations/11105-master+fix-same-delimiters.rst
+++ b/doc/changelog/03-notations/11105-master+fix-same-delimiters.rst
@@ -1,0 +1,1 @@
+- Warn if a delimiter in a scope overrides another delimiter in the scope or the same delimiter in another scope (`#11105 <https://github.com/coq/coq/pull/11105>`_, by Hugo Herbelin).

--- a/plugins/ssr/ssrbool.v
+++ b/plugins/ssr/ssrbool.v
@@ -464,6 +464,7 @@ Reserved Notation "[ ==> b1 , b2 , .. , bn => c ]" (at level 0, format
   "'[hv' [ ==> '['  b1 , '/'  b2 , '/'  .. , '/'  bn ']' '/'  =>  c ] ']'").
 
 (**  Shorter delimiter  **)
+Set Warnings "-delimiter-change".
 Delimit Scope bool_scope with B.
 Open Scope bool_scope.
 

--- a/test-suite/output/Arguments.v
+++ b/test-suite/output/Arguments.v
@@ -46,6 +46,8 @@ About f.
 Record r := { pi :> nat -> bool -> unit }.
 Notation "$" := 3 (only parsing) : foo_scope.
 Notation "$" := true (only parsing) : bar_scope.
+Set Warnings "-delimiter-overriden".
+Set Warnings "-delimiter-change".
 Delimit Scope bar_scope with B.
 Arguments pi _ _%F _%B.
 Check (forall w : r, pi w $ $ = tt).

--- a/test-suite/output/FloatSyntax.out
+++ b/test-suite/output/FloatSyntax.out
@@ -32,7 +32,7 @@
      : float
 t = 2%flt
      : float
-t = 2%flt
+t = 2%float
      : float
 2
      : nat

--- a/test-suite/output/FloatSyntax.v
+++ b/test-suite/output/FloatSyntax.v
@@ -26,9 +26,11 @@ Open Scope nat_scope.
 Check 2.
 Check 2%float.
 
+Set Warnings "-delimiter-change".
 Delimit Scope float_scope with flt.
 Definition t := 2%float.
 Print t.
+Set Warnings "-delimiter-overriden".
 Delimit Scope nat_scope with float.
 Print t.
 Check 2.

--- a/test-suite/output/Int63Syntax.out
+++ b/test-suite/output/Int63Syntax.out
@@ -24,7 +24,7 @@ overflow in int63 literal: 9223372036854775808
      : int
 t = 2%i63
      : int
-t = 2%i63
+t = 2%int63
      : int
 2
      : nat

--- a/test-suite/output/Int63Syntax.v
+++ b/test-suite/output/Int63Syntax.v
@@ -14,9 +14,11 @@ Fail Check 9223372036854775808.
 Open Scope nat_scope.
 Check 2. (* : nat *)
 Check 2%int63.
+Set Warnings "-delimiter-change".
 Delimit Scope int63_scope with i63.
 Definition t := 2%int63.
 Print t.
+Set Warnings "-delimiter-overriden".
 Delimit Scope nat_scope with int63.
 Print t.
 Check 2.

--- a/test-suite/output/Notations4.out
+++ b/test-suite/output/Notations4.out
@@ -59,3 +59,11 @@ where
       |- Type] (pat, p0, p cannot be used)
 fun '{| |} => true
      : R -> bool
+The command has indeed failed with message:
+Overriding previous binding of delimiter sc to scope sc1_scope.
+[delimiter-overriden,parsing]
+File "stdin", line 152, characters 0-32:
+Warning: Overriding previous binding of delimiter sc to scope sc1_scope.
+[delimiter-overriden,parsing]
+n
+     : nat

--- a/test-suite/output/Notations4.v
+++ b/test-suite/output/Notations4.v
@@ -140,3 +140,19 @@ Record R := { n : nat }.
 Check fun '{|n:=x|} => true.
 
 End EmptyRecordSyntax.
+
+Module OverrideDelimiter.
+
+Declare Scope sc1_scope.
+Delimit Scope sc1_scope with sc.
+Declare Scope sc2_scope.
+Set Warnings "+delimiter-overriden".
+Fail Delimit Scope sc2_scope with sc.
+Set Warnings "delimiter-overriden".
+Delimit Scope sc2_scope with sc.
+
+Axiom n : nat.
+Notation "#" := n : sc1_scope.
+Check n.
+
+End OverrideDelimiter.

--- a/test-suite/output/ssr_explain_match.out
+++ b/test-suite/output/ssr_explain_match.out
@@ -1,4 +1,7 @@
 File "stdin", line 12, characters 0-61:
+Warning: Overriding previous delimiter key bool in scope bool_scope.
+[delimiter-change,parsing]
+File "stdin", line 12, characters 0-61:
 Warning: Notation "_ - _" was already used in scope nat_scope.
 [notation-overridden,parsing]
 File "stdin", line 12, characters 0-61:


### PR DESCRIPTION
**Kind:** bug fix

This removes the possibility of using for printing a delimiter which has been overriden and cannot be reparsed.

- [X] Added / updated test-suite
- [X] Entry (now) added in the changelog
