### PR TITLE
Add support for multiple scope delimiters per scope

### DIFF
--- a/doc/changelog/03-notations/11105-master+fix-same-delimiters.rst
+++ b/doc/changelog/03-notations/11105-master+fix-same-delimiters.rst
@@ -1,0 +1,1 @@
+- Warn if a delimiter in a scope overrides another delimiter in the scope or the same delimiter in another scope (`#11105 <https://github.com/coq/coq/pull/11105>`_, by Hugo Herbelin).

--- a/interp/notation.mli
+++ b/interp/notation.mli
@@ -65,7 +65,7 @@ val find_scope : scope_name -> scope
 (** Declare delimiters for printing *)
 
 val declare_delimiters : scope_name -> delimiters -> unit
-val remove_delimiters : scope_name -> unit
+val remove_delimiters : scope_name -> delimiters option -> unit
 val find_delimiters_scope : ?loc:Loc.t -> delimiters -> scope_name
 
 (** {6 Declare and uses back and forth an interpretation of primitive token } *)

--- a/plugins/ssr/ssrbool.v
+++ b/plugins/ssr/ssrbool.v
@@ -464,6 +464,7 @@ Reserved Notation "[ ==> b1 , b2 , .. , bn => c ]" (at level 0, format
   "'[hv' [ ==> '['  b1 , '/'  b2 , '/'  .. , '/'  bn ']' '/'  =>  c ] ']'").
 
 (**  Shorter delimiter  **)
+Set Warnings "-delimiter-change".
 Delimit Scope bool_scope with B.
 Open Scope bool_scope.
 

--- a/plugins/ssr/ssrbool.v
+++ b/plugins/ssr/ssrbool.v
@@ -463,9 +463,6 @@ Reserved Notation "[ ==> b1 => c ]" (at level 0, only parsing).
 Reserved Notation "[ ==> b1 , b2 , .. , bn => c ]" (at level 0, format
   "'[hv' [ ==> '['  b1 , '/'  b2 , '/'  .. , '/'  bn ']' '/'  =>  c ] ']'").
 
-(**  Shorter delimiter  **)
-Set Warnings "-delimiter-change".
-Delimit Scope bool_scope with B.
 Open Scope bool_scope.
 
 (**  An alternative to xorb that behaves somewhat better wrt simplification. **)

--- a/test-suite/output/Arguments.v
+++ b/test-suite/output/Arguments.v
@@ -46,6 +46,7 @@ About f.
 Record r := { pi :> nat -> bool -> unit }.
 Notation "$" := 3 (only parsing) : foo_scope.
 Notation "$" := true (only parsing) : bar_scope.
+Set Warnings "-delimiter-overriden".
 Delimit Scope bar_scope with B.
 Arguments pi _ _%F _%B.
 Check (forall w : r, pi w $ $ = tt).

--- a/test-suite/output/FloatSyntax.out
+++ b/test-suite/output/FloatSyntax.out
@@ -32,6 +32,8 @@
      : float
 t = 2%flt
      : float
+u = 2%float
+     : float
 t = 2%flt
      : float
 2

--- a/test-suite/output/FloatSyntax.v
+++ b/test-suite/output/FloatSyntax.v
@@ -29,6 +29,7 @@ Check 2%float.
 Delimit Scope float_scope with flt.
 Definition t := 2%float.
 Print t.
+Set Warnings "-delimiter-change".
 Delimit Scope nat_scope with float.
 Print t.
 Check 2.

--- a/test-suite/output/FloatSyntax.v
+++ b/test-suite/output/FloatSyntax.v
@@ -29,7 +29,7 @@ Check 2%float.
 Delimit Scope float_scope with flt.
 Definition t := 2%float.
 Print t.
-Set Warnings "-delimiter-change".
+Set Warnings "-delimiter-overriden".
 Delimit Scope nat_scope with float.
 Print t.
 Check 2.

--- a/test-suite/output/FloatSyntax.v
+++ b/test-suite/output/FloatSyntax.v
@@ -27,8 +27,10 @@ Check 2.
 Check 2%float.
 
 Delimit Scope float_scope with flt.
-Definition t := 2%float.
+Definition t := 2%flt.
 Print t.
+Definition u := 2%float.
+Print u.
 Set Warnings "-delimiter-overriden".
 Delimit Scope nat_scope with float.
 Print t.

--- a/test-suite/output/Int63Syntax.out
+++ b/test-suite/output/Int63Syntax.out
@@ -24,6 +24,8 @@ overflow in int63 literal: 9223372036854775808
      : int
 t = 2%i63
      : int
+u = 2%int63
+     : int
 t = 2%i63
      : int
 2

--- a/test-suite/output/Int63Syntax.v
+++ b/test-suite/output/Int63Syntax.v
@@ -15,8 +15,10 @@ Open Scope nat_scope.
 Check 2. (* : nat *)
 Check 2%int63.
 Delimit Scope int63_scope with i63.
-Definition t := 2%int63.
+Definition t := 2%i63.
 Print t.
+Definition u := 2%int63.
+Print u.
 Set Warnings "-delimiter-overriden".
 Delimit Scope nat_scope with int63.
 Print t.

--- a/test-suite/output/Int63Syntax.v
+++ b/test-suite/output/Int63Syntax.v
@@ -17,7 +17,7 @@ Check 2%int63.
 Delimit Scope int63_scope with i63.
 Definition t := 2%int63.
 Print t.
-Set Warnings "-delimiter-change".
+Set Warnings "-delimiter-overriden".
 Delimit Scope nat_scope with int63.
 Print t.
 Check 2.

--- a/test-suite/output/Int63Syntax.v
+++ b/test-suite/output/Int63Syntax.v
@@ -17,6 +17,7 @@ Check 2%int63.
 Delimit Scope int63_scope with i63.
 Definition t := 2%int63.
 Print t.
+Set Warnings "-delimiter-change".
 Delimit Scope nat_scope with int63.
 Print t.
 Check 2.

--- a/test-suite/output/Notations4.out
+++ b/test-suite/output/Notations4.out
@@ -59,3 +59,11 @@ where
       |- Type] (pat, p0, p cannot be used)
 fun '{| |} => true
      : R -> bool
+The command has indeed failed with message:
+Overriding previous binding of delimiter sc to scope sc1_scope.
+[delimiter-overriden,parsing]
+File "stdin", line 152, characters 0-32:
+Warning: Overriding previous binding of delimiter sc to scope sc1_scope.
+[delimiter-overriden,parsing]
+n
+     : nat

--- a/test-suite/output/Notations4.out
+++ b/test-suite/output/Notations4.out
@@ -67,3 +67,7 @@ Warning: Overriding previous binding of delimiter sc to scope sc1_scope.
 [delimiter-overriden,parsing]
 n
      : nat
+(true || true)%bool
+     : bool
+(true || true)%B
+     : bool

--- a/test-suite/output/Notations4.v
+++ b/test-suite/output/Notations4.v
@@ -156,3 +156,10 @@ Notation "#" := n : sc1_scope.
 Check n.
 
 End OverrideDelimiter.
+
+Module LastUsedDelimiter.
+
+Check (true || true)%bool.
+Check (true || true)%B.
+
+End LastUsedDelimiter.

--- a/test-suite/output/Notations4.v
+++ b/test-suite/output/Notations4.v
@@ -140,3 +140,19 @@ Record R := { n : nat }.
 Check fun '{|n:=x|} => true.
 
 End EmptyRecordSyntax.
+
+Module OverrideDelimiter.
+
+Declare Scope sc1_scope.
+Delimit Scope sc1_scope with sc.
+Declare Scope sc2_scope.
+Set Warnings "+delimiter-overriden".
+Fail Delimit Scope sc2_scope with sc.
+Set Warnings "delimiter-overriden".
+Delimit Scope sc2_scope with sc.
+
+Axiom n : nat.
+Notation "#" := n : sc1_scope.
+Check n.
+
+End OverrideDelimiter.

--- a/theories/Init/Datatypes.v
+++ b/theories/Init/Datatypes.v
@@ -38,7 +38,8 @@ Inductive bool : Set :=
 Add Printing If bool.
 
 Declare Scope bool_scope.
-Delimit Scope bool_scope with bool.
+Delimit Scope bool_scope with B. (* shorter delimiter *)
+Delimit Scope bool_scope with bool. (* more explicit delimiter *)
 Bind Scope bool_scope with bool.
 
 Register bool as core.bool.type.

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -1209,9 +1209,11 @@ GRAMMAR EXTEND Gram
          { VernacOpenCloseScope (false,sc) }
 
      | IDENT "Delimit"; IDENT "Scope"; sc = IDENT; "with"; key = IDENT ->
-	 { VernacDelimiters (sc, Some key) }
+         { VernacDelimiters (AddDelimiter (sc,key)) }
      | IDENT "Undelimit"; IDENT "Scope"; sc = IDENT ->
-	 { VernacDelimiters (sc, None) }
+         { VernacDelimiters (UndelimitScope sc) }
+     | IDENT "Remove"; IDENT "Delimiter"; key = IDENT; IDENT "from"; sc = IDENT ->
+         { VernacDelimiters (RemoveDelimiter (sc,key)) }
 
      | IDENT "Bind"; IDENT "Scope"; sc = IDENT; "with";
        refl = LIST1 class_rawexpr -> { VernacBindScope (sc,refl) }

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -1590,8 +1590,8 @@ let add_infix ~local deprecation env ({CAst.loc;v=inf},modifiers) pr sc =
 
 type scope_command =
   | ScopeDeclare
-  | ScopeDelimAdd of string
-  | ScopeDelimRemove
+  | ScopeDelimAdd of delimiters
+  | ScopeDelimRemove of delimiters option
   | ScopeClasses of scope_class list
 
 let load_scope_command_common silently_define_scope_if_undefined _ (_,(local,scope,o)) =
@@ -1603,7 +1603,7 @@ let load_scope_command_common silently_define_scope_if_undefined _ (_,(local,sco
   (* When the default shall be to require that a scope already exists *)
   (* the call to declare_scope_if_needed will have to be removed below *)
   | ScopeDelimAdd dlm -> declare_scope_if_needed scope
-  | ScopeDelimRemove -> declare_scope_if_needed scope
+  | ScopeDelimRemove _ -> declare_scope_if_needed scope
   | ScopeClasses cl -> declare_scope_if_needed scope
 
 let load_scope_command =
@@ -1614,7 +1614,7 @@ let open_scope_command i (_,(local,scope,o)) =
     match o with
     | ScopeDeclare -> ()
     | ScopeDelimAdd dlm -> Notation.declare_delimiters scope dlm
-    | ScopeDelimRemove -> Notation.remove_delimiters scope
+    | ScopeDelimRemove keyopt -> Notation.remove_delimiters scope keyopt
     | ScopeClasses cl -> List.iter (Notation.declare_scope_class scope) cl
 
 let cache_scope_command o =
@@ -1647,8 +1647,8 @@ let declare_scope local scope =
 let add_delimiters local scope key =
   Lib.add_anonymous_leaf (inScopeCommand(local,scope,ScopeDelimAdd key))
 
-let remove_delimiters local scope =
-  Lib.add_anonymous_leaf (inScopeCommand(local,scope,ScopeDelimRemove))
+let remove_delimiters local scope keyopt =
+  Lib.add_anonymous_leaf (inScopeCommand(local,scope,ScopeDelimRemove keyopt))
 
 let add_class_scope local scope cl =
   Lib.add_anonymous_leaf (inScopeCommand(local,scope,ScopeClasses cl))

--- a/vernac/metasyntax.mli
+++ b/vernac/metasyntax.mli
@@ -30,8 +30,8 @@ val add_notation_extra_printing_rule : string -> string -> string -> unit
 (** Declaring scopes, delimiter keys and default scopes *)
 
 val declare_scope : locality_flag -> scope_name -> unit
-val add_delimiters : locality_flag -> scope_name -> string -> unit
-val remove_delimiters : locality_flag -> scope_name -> unit
+val add_delimiters : locality_flag -> scope_name -> delimiters -> unit
+val remove_delimiters : locality_flag -> scope_name -> delimiters option -> unit
 val add_class_scope : locality_flag -> scope_name -> scope_class list -> unit
 
 (** Add only the interpretation of a notation that already has pa/pp rules *)

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -688,14 +688,18 @@ let string_of_definition_object_kind = let open Decls in function
         return (
           keyword "Declare Scope" ++ spc () ++ str sc
         )
-      | VernacDelimiters (sc,Some key) ->
+      | VernacDelimiters (AddDelimiter (sc,key)) ->
         return (
           keyword "Delimit Scope" ++ spc () ++ str sc ++
             spc() ++ keyword "with" ++ spc () ++ str key
         )
-      | VernacDelimiters (sc, None) ->
+      | VernacDelimiters (UndelimitScope sc) ->
         return (
           keyword "Undelimit Scope" ++ spc () ++ str sc
+        )
+      | VernacDelimiters (RemoveDelimiter (sc,key)) ->
+        return (
+          keyword "Remove Delimiter" ++ spc () ++ str key ++ spc () ++ str "from" ++ str sc
         )
       | VernacBindScope (sc,cll) ->
         return (

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -438,10 +438,11 @@ let vernac_syntax_extension ~module_local infix l =
 let vernac_declare_scope ~module_local sc =
   Metasyntax.declare_scope module_local sc
 
-let vernac_delimiters ~module_local sc action =
+let vernac_delimiters ~module_local action =
   match action with
-  | Some lr -> Metasyntax.add_delimiters module_local sc lr
-  | None -> Metasyntax.remove_delimiters module_local sc
+  | AddDelimiter (sc,lr) -> Metasyntax.add_delimiters module_local sc lr
+  | UndelimitScope sc -> Metasyntax.remove_delimiters module_local sc None
+  | RemoveDelimiter (sc,lr) -> Metasyntax.remove_delimiters module_local sc (Some lr)
 
 let vernac_bind_scope ~module_local sc cll =
   Metasyntax.add_class_scope module_local sc (List.map scope_class_of_qualid cll)
@@ -1975,8 +1976,8 @@ let translate_vernac ~atts v = let open Vernacextend in match v with
     VtDefault(fun () -> with_module_locality ~atts vernac_syntax_extension infix sl)
   | VernacDeclareScope sc ->
     VtDefault(fun () -> with_module_locality ~atts vernac_declare_scope sc)
-  | VernacDelimiters (sc,lr) ->
-    VtDefault(fun () -> with_module_locality ~atts vernac_delimiters sc lr)
+  | VernacDelimiters action ->
+    VtDefault(fun () -> with_module_locality ~atts vernac_delimiters action)
   | VernacBindScope (sc,rl) ->
     VtDefault(fun () -> with_module_locality ~atts vernac_bind_scope sc rl)
   | VernacOpenCloseScope (b, s) ->

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -187,6 +187,11 @@ type syntax_modifier =
   | SetCompatVersion of Flags.compat_version
   | SetFormat of string * lstring
 
+type delimiters_action =
+  | AddDelimiter of scope_name * Notation.delimiters
+  | UndelimitScope of scope_name
+  | RemoveDelimiter of scope_name * Notation.delimiters
+
 type proof_end =
   | Admitted
   (*                         name in `Save ident` when closing goal *)
@@ -285,7 +290,7 @@ type nonrec vernac_expr =
   | VernacSyntaxExtension of bool * (lstring * syntax_modifier list)
   | VernacOpenCloseScope of bool * scope_name
   | VernacDeclareScope of scope_name
-  | VernacDelimiters of scope_name * string option
+  | VernacDelimiters of delimiters_action
   | VernacBindScope of scope_name * class_rawexpr list
   | VernacInfix of (lstring * syntax_modifier list) *
       constr_expr * scope_name option


### PR DESCRIPTION
**Kind:** enhancement, feature

This depends on #11105. 

This PR adds support for several delimiters per scope. This allows for instance to support `ssrbool.v` declaring `B` as an alternative key for `bool_scope`. It also adds a command `Remove Delimiter key from scope` to remove a delimiter.

It is advocated in file `ssrbool.v` that `B` is shorter than `bool`, which is a somehow convincing argument, so a second commit experiments adding `B` as an alternative delimiter for `bool_scope` in `Datatypes.v` for users who would like to have `B` by default as an alternative key for `bool`.

Finally, in the presence of several delimiters, a third commit assumes that users want to see at printing time the same delimiters they used at parsing time, so a printing priority among delimiters is given to the delimiter used last at parsing time.

- [X] Added / updated test-suite
- [ ] Add test for command `Remove Delimiter key from scope`
- [ ] Corresponding documentation was added / updated
- [ ] Entry added in the changelog