### PR TITLE
Register proof_irrelevance

### DIFF
--- a/theories/Logic/ProofIrrelevance.v
+++ b/theories/Logic/ProofIrrelevance.v
@@ -14,6 +14,8 @@ Require Import ProofIrrelevanceFacts.
 
 Axiom proof_irrelevance : forall (P:Prop) (p1 p2:P), p1 = p2.
 
+Register proof_irrelevance as core.proof_irrelevance.
+
 Module PI. Definition proof_irrelevance := proof_irrelevance. End PI.
 
 Module ProofIrrelevanceTheory := ProofIrrelevanceTheory(PI).


### PR DESCRIPTION
This would enable to remove a deprecated call to `Coqlib.coq_reference` in https://github.com/coq-community/paramcoq
