### PR TITLE
Remove deprecated compat modifier of Notation / Infix commands.

### DIFF
--- a/doc/changelog/03-notations/11113-remove-compat.rst
+++ b/doc/changelog/03-notations/11113-remove-compat.rst
@@ -1,0 +1,4 @@
+- Removed deprecated ``compat`` modifier of :cmd:`Notation`
+  and :cmd:`Infix` commands
+  (`#11113 <https://github.com/coq/coq/pull/11113>`_,
+  by Théo Zimmermann, with help from Jason Gross).

--- a/lib/flags.ml
+++ b/lib/flags.ml
@@ -57,36 +57,6 @@ let raw_print = ref false
 
 let we_are_parsing = ref false
 
-(* Compatibility mode *)
-
-(* Current means no particular compatibility consideration.
-   For correct comparisons, this constructor should remain the last one. *)
-
-type compat_version = V8_9 | V8_10 | V8_11 | Current
-
-let compat_version = ref Current
-
-let version_compare v1 v2 = match v1, v2 with
-  | V8_9, V8_9 -> 0
-  | V8_9, _ -> -1
-  | _, V8_9 -> 1
-  | V8_10, V8_10 -> 0
-  | V8_10, _ -> -1
-  | _, V8_10 -> 1
-  | V8_11, V8_11 -> 0
-  | V8_11, _ -> -1
-  | _, V8_11 -> 1
-  | Current, Current -> 0
-
-let version_strictly_greater v = version_compare !compat_version v > 0
-let version_less_or_equal v = not (version_strictly_greater v)
-
-let pr_version = function
-  | V8_9 -> "8.9"
-  | V8_10 -> "8.10"
-  | V8_11 -> "8.11"
-  | Current -> "current"
-
 (* Translate *)
 let beautify = ref false
 let beautify_file = ref false

--- a/lib/flags.mli
+++ b/lib/flags.mli
@@ -14,7 +14,7 @@
 
     This file is own its way to deprecation in favor of a purely
    functional state, but meanwhile it will contain options that are
-   truly global to the system such as [compat] or [debug]
+   truly global to the system such as [debug]
 
     If you are thinking about adding a global flag, well, just
    don't. First of all, options make testins exponentially more
@@ -51,13 +51,6 @@ val we_are_parsing : bool ref
 
 (* Set Printing All flag. For some reason it is a global flag *)
 val raw_print : bool ref
-
-type compat_version = V8_9 | V8_10 | V8_11 | Current
-val compat_version : compat_version ref
-val version_compare : compat_version -> compat_version -> int
-val version_strictly_greater : compat_version -> bool
-val version_less_or_equal : compat_version -> bool
-val pr_version : compat_version -> string
 
 (* Beautify command line flags, should move to printing? *)
 val beautify : bool ref

--- a/test-suite/success/NotationDeprecation.v
+++ b/test-suite/success/NotationDeprecation.v
@@ -3,19 +3,11 @@ Module Syndefs.
 #[deprecated(since = "8.9", note = "Do not use.")]
 Notation foo := Prop.
 
-Notation bar := Prop (compat "8.9").
-
-Fail
-#[deprecated(since = "8.9", note = "Do not use.")]
-Notation zar := Prop (compat "8.9").
-
 Check foo.
-Check bar.
 
 Set Warnings "+deprecated".
 
 Fail Check foo.
-Fail Check bar.
 
 End Syndefs.
 
@@ -24,19 +16,11 @@ Module Notations.
 #[deprecated(since = "8.9", note = "Do not use.")]
 Notation "!!" := Prop.
 
-Notation "##" := Prop (compat "8.9").
-
-Fail
-#[deprecated(since = "8.9", note = "Do not use.")]
-Notation "**" := Prop (compat "8.9").
-
 Check !!.
-Check ##.
 
 Set Warnings "+deprecated".
 
 Fail Check !!.
-Fail Check ##.
 
 End Notations.
 
@@ -45,18 +29,10 @@ Module Infix.
 #[deprecated(since = "8.9", note = "Do not use.")]
 Infix "!!" := plus (at level 1).
 
-Infix "##" := plus (at level 1, compat "8.9").
-
-Fail
-#[deprecated(since = "8.9", note = "Do not use.")]
-Infix "**" := plus (at level 1, compat "8.9").
-
 Check (_ !! _).
-Check (_ ## _).
 
 Set Warnings "+deprecated".
 
 Fail Check (_ !! _).
-Fail Check (_ ## _).
 
 End Infix.

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -62,18 +62,6 @@ let make_bullet s =
   | '*' -> Star n
   | _ -> assert false
 
-let parse_compat_version = let open Flags in function
-  | "8.12" -> Current
-  | "8.11" -> V8_11
-  | "8.10" -> V8_10
-  | "8.9" -> V8_9
-  | ("8.8" | "8.7" | "8.6" | "8.5" | "8.4" | "8.3" | "8.2" | "8.1" | "8.0") as s ->
-    CErrors.user_err ~hdr:"get_compat_version"
-      Pp.(str "Compatibility with version " ++ str s ++ str " not supported.")
-  | s ->
-    CErrors.user_err ~hdr:"get_compat_version"
-      Pp.(str "Unknown compatibility version \"" ++ str s ++ str "\".")
-
 (* For now we just keep the top-level location of the whole
    vernacular, that is to say, including attributes and control flags;
    this is not very convenient for advanced clients tho, so in the
@@ -1192,7 +1180,7 @@ GRAMMAR EXTEND Gram
      | IDENT "Notation"; id = identref;
          idl = LIST0 ident; ":="; c = constr; b = only_parsing ->
            { VernacSyntacticDefinition
-             (id,(idl,c),b) }
+             (id,(idl,c),{ onlyparsing = b }) }
      | IDENT "Notation"; s = lstring; ":=";
          c = constr;
          modl = [ "("; l = LIST1 syntax_modifier SEP ","; ")" -> { l } | -> { [] } ];
@@ -1216,11 +1204,8 @@ GRAMMAR EXTEND Gram
   ] ]
   ;
   only_parsing:
-    [ [ "("; IDENT "only"; IDENT "parsing"; ")" ->
-         { Some Flags.Current }
-      | "("; IDENT "compat"; s = STRING; ")" ->
-         { Some (parse_compat_version s) }
-      | -> { None } ] ]
+    [ [ "("; IDENT "only"; IDENT "parsing"; ")" -> { true }
+      | -> { false } ] ]
   ;
   level:
     [ [ IDENT "level"; n = natural -> { NumLevel n }
@@ -1236,8 +1221,6 @@ GRAMMAR EXTEND Gram
       | IDENT "no"; IDENT "associativity" -> { SetAssoc Gramlib.Gramext.NonA }
       | IDENT "only"; IDENT "printing" -> { SetOnlyPrinting }
       | IDENT "only"; IDENT "parsing" -> { SetOnlyParsing }
-      | IDENT "compat"; s = STRING ->
-        { SetCompatVersion (parse_compat_version s) }
       | IDENT "format"; s1 = [s = STRING -> { CAst.make ~loc s } ];
                         s2 = OPT [s = STRING -> { CAst.make ~loc s } ] ->
           { begin match s1, s2 with

--- a/vernac/metasyntax.mli
+++ b/vernac/metasyntax.mli
@@ -52,7 +52,7 @@ val add_syntax_extension :
 (** Add a syntactic definition (as in "Notation f := ...") *)
 
 val add_syntactic_definition : local:bool -> Deprecation.t option -> env ->
-  Id.t -> Id.t list * constr_expr -> Flags.compat_version option -> unit
+  Id.t -> Id.t list * constr_expr -> onlyparsing_flag -> unit
 
 (** Print the Camlp5 state of a grammar *)
 

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -412,7 +412,6 @@ let string_of_theorem_kind = let open Decls in function
     | SetEntryType (x,typ) -> str x ++ spc() ++ pr_set_simple_entry_type typ
     | SetOnlyPrinting -> keyword "only printing"
     | SetOnlyParsing -> keyword "only parsing"
-    | SetCompatVersion v -> keyword("compat \"" ^ Flags.pr_version v ^ "\"")
     | SetFormat("text",s) -> keyword "format " ++ pr_ast qs s
     | SetFormat(k,s) -> keyword "format " ++ qs k ++ spc() ++ pr_ast qs s
 
@@ -1059,16 +1058,12 @@ let string_of_definition_object_kind = let open Decls in function
         )
       | VernacHints (dbnames,h) ->
         return (pr_hints dbnames h (pr_constr env sigma) (pr_constr_pattern_expr env sigma))
-      | VernacSyntacticDefinition (id,(ids,c),compat) ->
+      | VernacSyntacticDefinition (id,(ids,c),{onlyparsing}) ->
         return (
           hov 2
             (keyword "Notation" ++ spc () ++ pr_lident id ++ spc () ++
                prlist_with_sep spc pr_id ids ++ str":=" ++ pr_constrarg c ++
-               pr_syntax_modifiers
-               (match compat with
-                | None -> []
-                | Some Flags.Current -> [SetOnlyParsing]
-                | Some v -> [SetCompatVersion v]))
+               pr_syntax_modifiers (if onlyparsing then [SetOnlyParsing] else []))
         )
       | VernacArguments (q, args, more_implicits, mods) ->
         return (

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1206,10 +1206,10 @@ let vernac_hints ~atts dbnames h =
   let local = enforce_module_locality local in
   Hints.add_hints ~local dbnames (Hints.interp_hints ~poly h)
 
-let vernac_syntactic_definition ~atts lid x compat =
+let vernac_syntactic_definition ~atts lid x only_parsing =
   let module_local, deprecation = Attributes.(parse Notations.(module_locality ++ deprecation) atts) in
   Dumpglob.dump_definition lid false "syndef";
-  Metasyntax.add_syntactic_definition ~local:module_local deprecation (Global.env()) lid.v x compat
+  Metasyntax.add_syntactic_definition ~local:module_local deprecation (Global.env()) lid.v x only_parsing
 
 let default_env () = {
   Notation_term.ninterp_var_type = Id.Map.empty;

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -105,7 +105,7 @@ type instance_flag  = bool option
   (* Some true = Backward instance; Some false = Forward instance, None = NoInstance *)
 type export_flag    = bool (* true = Export;        false = Import         *)
 type inductive_flag = Declarations.recursivity_kind
-type onlyparsing_flag = Flags.compat_version option
+type onlyparsing_flag = { onlyparsing : bool }
  (* Some v = Parse only;  None = Print also.
     If v<>Current, it contains the name of the coq version
     which this notation is trying to be compatible with *)
@@ -185,7 +185,6 @@ type syntax_modifier =
   | SetEntryType of string * Extend.simple_constr_prod_entry_key
   | SetOnlyParsing
   | SetOnlyPrinting
-  | SetCompatVersion of Flags.compat_version
   | SetFormat of string * lstring
 
 type proof_end =


### PR DESCRIPTION
The removal of the deprecated `compat` modifier in the `Notation` and `Infix` commands is an opportunity to remove most of the complexity of the compat infrastructure, which only becomes about loading the `Compat.CoqXY` module when `-compat X.Y` is passed. Since the semantics had already been changed, this simplification could actually have happened before.

@JasonGross I didn't change the `dev/tools/update-compat.sh` script because I thought that you would be in a better position to do it. This is probably going to remove most of the complexity from this script as well. Sorry that this removal didn't happen before, as it would have mean less work for you.

- [x] Added / updated test-suite
- ~~Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).~~ (N/A)
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
