### PR TITLE
Reserved Gallina keywords: a new approach in the code and an update in the reference manual

### DIFF
--- a/doc/sphinx/language/gallina-specification-language.rst
+++ b/doc/sphinx/language/gallina-specification-language.rst
@@ -101,7 +101,18 @@ Keywords
     end exists exists2 fix for forall fun if in lazymatch let match
     multimatch return then using where with
 
-  Note that plugins may define additional keywords when they are loaded.
+  Note that plugins and libraries may reserve additional keywords when they
+  are loaded.
+
+  The following identifiers are not reserved keywords but are
+  part of the definition of Gallina::
+
+    Admitted Axioms Class CoInductive Conjecture Conjectures
+    Constraints Corollary Cumulative Defined Example Fact Global
+    Hypotheses Inductive Lemma Let Local Monomorphic NonCumulative
+    Parameters Polymorphic Private Proof Property Proposition Qed
+    Record Register Remark Structure SubClass Universe Universes
+    Variables Variant
 
 Other tokens
   The set of

--- a/doc/sphinx/language/gallina-specification-language.rst
+++ b/doc/sphinx/language/gallina-specification-language.rst
@@ -96,10 +96,8 @@ Keywords
   The following character sequences are reserved keywords that cannot be
   used as identifiers::
 
-    _ Axiom CoFixpoint Definition Fixpoint Hypothesis IF Parameter Prop
-    SProp Set Theorem Type Variable as at by cofix discriminated else
-    end exists exists2 fix for forall fun if in lazymatch let match
-    multimatch return then using where with
+    _ Prop SProp Set Type as at cofix else end fix for forall fun if
+    in let match return then where with
 
   Note that plugins and libraries may reserve additional keywords when they
   are loaded.
@@ -107,11 +105,12 @@ Keywords
   The following identifiers are not reserved keywords but are
   part of the definition of Gallina::
 
-    Admitted Axioms Class CoInductive Conjecture Conjectures
-    Constraints Corollary Cumulative Defined Example Fact Global
-    Hypotheses Inductive Lemma Let Local Monomorphic NonCumulative
-    Parameters Polymorphic Private Proof Property Proposition Qed
-    Record Register Remark Structure SubClass Universe Universes
+    Admitted Axiom Axioms Class CoFixpoint CoInductive Conjecture
+    Conjectures Constraints Corollary Cumulative Defined Definition
+    Example Fact Fixpoint Global Hypotheses Hypothesis Inductive Lemma
+    Let Local Monomorphic NonCumulative Parameter Parameters
+    Polymorphic Private Proof Property Proposition Record Register Qed
+    Remark Structure SubClass Theorem Universe Universes Variable
     Variables Variant
 
 Other tokens

--- a/gramlib/grammar.mli
+++ b/gramlib/grammar.mli
@@ -24,6 +24,7 @@ type mayrec
 module type S = sig
   type te
   type 'c pattern
+  type abstract_pattern = AbstractPattern : 'a pattern -> abstract_pattern
 
   module Parsable : sig
     type t
@@ -42,6 +43,8 @@ module type S = sig
     val of_parser : string -> (Plexing.location_function -> te Stream.t -> 'a) -> 'a t
     val parse_token_stream : 'a t -> te Stream.t -> 'a
     val print : Format.formatter -> 'a t -> unit
+    val parse_empty : 'a t -> bool option (* None = Unknown *)
+    val starting_tokens : 'a t -> abstract_pattern list option (* None = Unknown *)
   end
 
   module rec Symbol : sig

--- a/parsing/pcoq.ml
+++ b/parsing/pcoq.ml
@@ -74,6 +74,9 @@ struct
 
 end
 
+let starting_tokens e =
+  Option.map (List.map (function AbstractPattern p -> Tok.pattern_strings p)) (Entry.starting_tokens e)
+
 (** Grammar extensions *)
 
 (** NB: [extend_statement =

--- a/parsing/pcoq.mli
+++ b/parsing/pcoq.mli
@@ -32,6 +32,8 @@ module Lookahead : sig
   val lk_ident_list : t
 end
 
+val starting_tokens : 'a Entry.t -> (string * string option) list option
+
 (** The parser of Coq is built from three kinds of rule declarations:
 
    - dynamic rules declared at the evaluation of Coq files (using

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -204,11 +204,11 @@ GRAMMAR EXTEND Gram
       (* Gallina inductive declarations *)
       | f = finite_token; indl = LIST1 inductive_definition SEP "with" ->
           { VernacInductive (f, indl) }
-      | "Fixpoint"; recs = LIST1 rec_definition SEP "with" ->
+      | IDENT "Fixpoint"; recs = LIST1 rec_definition SEP "with" ->
           { VernacFixpoint (NoDischarge, recs) }
       | IDENT "Let"; "Fixpoint"; recs = LIST1 rec_definition SEP "with" ->
           { VernacFixpoint (DoDischarge, recs) }
-      | "CoFixpoint"; corecs = LIST1 corec_definition SEP "with" ->
+      | IDENT "CoFixpoint"; corecs = LIST1 corec_definition SEP "with" ->
           { VernacCoFixpoint (NoDischarge, corecs) }
       | IDENT "Let"; "CoFixpoint"; corecs = LIST1 corec_definition SEP "with" ->
           { VernacCoFixpoint (DoDischarge, corecs) }
@@ -284,7 +284,7 @@ GRAMMAR EXTEND Gram
     ;
 
   thm_token:
-    [ [ "Theorem" -> { Theorem }
+    [ [ IDENT "Theorem" -> { Theorem }
       | IDENT "Lemma" -> { Lemma }
       | IDENT "Fact" -> { Fact }
       | IDENT "Remark" -> { Remark }
@@ -293,15 +293,15 @@ GRAMMAR EXTEND Gram
       | IDENT "Property" -> { Property } ] ]
   ;
   def_token:
-    [ [ "Definition" -> { (NoDischarge,Definition) }
+    [ [ IDENT "Definition" -> { (NoDischarge,Definition) }
       | IDENT "Example" -> { (NoDischarge,Example) }
       | IDENT "SubClass" -> { (NoDischarge,SubClass) } ] ]
   ;
   assumption_token:
-    [ [ "Hypothesis" -> { (DoDischarge, Logical) }
-      | "Variable" -> { (DoDischarge, Definitional) }
-      | "Axiom" -> { (NoDischarge, Logical) }
-      | "Parameter" -> { (NoDischarge, Definitional) }
+    [ [ IDENT "Hypothesis" -> { (DoDischarge, Logical) }
+      | IDENT "Variable" -> { (DoDischarge, Definitional) }
+      | IDENT "Axiom" -> { (NoDischarge, Logical) }
+      | IDENT "Parameter" -> { (NoDischarge, Definitional) }
       | IDENT "Conjecture" -> { (NoDischarge, Conjectural) } ] ]
   ;
   assumptions_token:


### PR DESCRIPTION
**Kind:** documentation / enhancement

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes #11097.

This PR does mainly two things:
- First, it renounces to the arbitrary distinction made between words such as `Theorem` or `Fixpoint` which are keywords, and words such as `Lemma` or `Inductive` which are not keywords: with the PR, words starting Gallina sentences are _reserved identifiers_ but not keywords. In particular, `Theorem`, `Fixpoint` and a few others lose their keyword status. Since these reserved identifiers are used only in the beginning of a sentence (or after well-identified adjectives), it should be enough to forbid defining Ltac/Ltac2 functions or tactic notations with same name as a Gallina reserved identifier. [Edited to take into account @skyskimmer [comment](https://github.com/coq/coq/pull/11117#issuecomment-553580963).]
- Second, the Gallina chapter of the reference manual is updated accordingly; [Edited] the following was moved to #12229: ~~incidentally~~, keywords such as `discriminated` and `(bfs)`/`(dfs)` are turned into normal identifiers (they were actually not needed as keywords); keywords such as `using` or `by` relevant only for tactics are now mentioned in the tactics chapter.

I believe this solves in a relatively smooth way the rather arbitrary choice of keywords we had.

TODO:
- [ ] Forbid the new class of reserved identifiers to be used in `TACTIC EXTEND` and `VERNAC EXTEND`, `Tactic Notation` and `Ltac`.
- [ ] Decide whether non-strictly-Gallina command identifiers such as `Combined`, `Scheme`, etc. are declared also a reserved identifiers.
- [ ] There may still be an issue to address with words such as `Module` or `Ltac` which may appear in position of an arbitrary ident, as in `Print Module foo`.
- [ ] ~Add a special `coqpp` token to automatically register reserved identifiers on the fly.~ see rather [below](https://github.com/coq/coq/pull/11117#discussion_r347027450)
- [ ] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
