### PR TITLE
Fix signal polling for OCaml 4.10

### DIFF
--- a/kernel/byterun/coq_interp.c
+++ b/kernel/byterun/coq_interp.c
@@ -522,8 +522,13 @@ value coq_interprete
 #else
       if (caml_signals_are_pending) {
         /* If there's a Ctrl-C, we reset the vm */
-        if (caml_pending_signals[SIGINT]) { coq_sp = coq_stack_high; }
+        intnat sigint = caml_pending_signals[SIGINT];
+        if (sigint) { coq_sp = coq_stack_high; }
         caml_process_pending_signals();
+        if (sigint) {
+          caml_failwith("Coq VM: Fatal error: SIGINT signal detected "
+                        "but no exception was raised");
+        }
       }
 #endif
       Next;

--- a/kernel/byterun/coq_interp.c
+++ b/kernel/byterun/coq_interp.c
@@ -1763,7 +1763,7 @@ value coq_interprete
 #ifndef THREADED_CODE
     default:
       /*fprintf(stderr, "%d\n", *pc);*/
-      failwith("Coq VM: Fatal error: bad opcode");
+      caml_failwith("Coq VM: Fatal error: bad opcode");
     }
   }
 #endif

--- a/kernel/byterun/coq_values.c
+++ b/kernel/byterun/coq_values.c
@@ -40,7 +40,7 @@ value coq_closure_arity(value clos) {
     c++;
     if (Is_instruction(c,GRAB)) return Val_int(3 + c[1] - Wosize_val(clos));
     else {
-      if (Wosize_val(clos) != 2) failwith("Coq Values : coq_closure_arity");
+      if (Wosize_val(clos) != 2) caml_failwith("Coq Values : coq_closure_arity");
       return Val_int(1);
     }
   }


### PR DESCRIPTION
**Kind:** bug fix

Fixes / closes #10603 

It would be nice to test it thoroughly with OCaml 4.10 so that we get a chance to catch bugs before it is released. For this you also need the patch at #11102, without which Coq does not compile.