### PR TITLE
[ci] [gitlab] Add test-suite test for OCaml 4.10 and 4.11

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ stages:
 variables:
   # Format: $IMAGE-V$DATE [Cache is not used as of today but kept here
   # for reference]
-  CACHEKEY: "bionic_coq-V2020-03-19-V29"
+  CACHEKEY: "bionic_coq-V2020-03-27-V12"
   IMAGE: "$CI_REGISTRY_IMAGE:$CACHEKEY"
   # By default, jobs run in the base switch; override to select another switch
   OPAM_SWITCH: "base"
@@ -533,6 +533,30 @@ test-suite:edge:dune:dev:
       - _build/default/test-suite/logs
     # Gitlab doesn't support yet "expire_in: never" so we use the instance default
     # expire_in: never
+
+test-suite:edge+4.11+trunk+dune:
+  stage: stage-1
+  dependencies: []
+  script:
+    - opam switch create 4.11.0 --empty
+    - eval $(opam env)
+    - opam repo add ocaml-beta https://github.com/ocaml/ocaml-beta-repository.git
+    - opam update
+    - opam install ocaml-variants=4.11.0+trunk
+    - opam install dune num
+    - eval $(opam env)
+    - export COQ_UNIT_TEST=noop
+    - make -f Makefile.dune test-suite
+  variables:
+    OPAM_SWITCH: base
+  artifacts:
+    name: "$CI_JOB_NAME.logs"
+    when: always
+    paths:
+      - _build/log
+      - _build/default/test-suite/logs
+    expire_in: 2 week
+  allow_failure: true
 
 test-suite:base+async:
   extends: .test-suite-template

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -7,7 +7,7 @@ Build Requirements
 To compile Coq yourself, you need:
 
 - [OCaml](https://ocaml.org/) (version >= 4.05.0)
-  (This version of Coq has been tested up to OCaml 4.09.1)
+  (This version of Coq has been tested up to OCaml 4.10.0)
 
 - The [num](https://github.com/ocaml/num) library; note that it is
   included in the OCaml distribution for OCaml versions < 4.06.0
@@ -45,7 +45,7 @@ CoqIDE with:
 Opam (https://opam.ocaml.org/) is recommended to install OCaml and
 the corresponding packages.
 
-    $ opam switch create coq 4.09.1+flambda
+    $ opam switch create coq 4.10.0+flambda
     $ eval $(opam env)
     $ opam install num ocamlfind lablgtk3-sourceview3
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,7 +72,7 @@ jobs:
       opam list
     displayName: 'Install OCaml dependencies'
     env:
-      COMPILER: "4.09.1"
+      COMPILER: "4.10.0"
       FINDLIB_VER: ".1.8.1"
       OPAMYES: "true"
 

--- a/configure.ml
+++ b/configure.ml
@@ -616,8 +616,9 @@ let camltag = match caml_version_list with
     45: "open" shadowing a label or constructor: see 44
     48: implicit elimination of optional arguments: too common
     58: "no cmx file was found in path": See https://github.com/ocaml/num/issues/9
+    67: "unused functor parameter" seems totally bogus
 *)
-let coq_warnings = "-w +a-4-9-27-41-42-44-45-48-58"
+let coq_warnings = "-w +a-4-9-27-41-42-44-45-48-58-67"
 let coq_warn_error =
     if !prefs.warn_error
     then "-warn-error +a"

--- a/dev/ci/azure-opam.sh
+++ b/dev/ci/azure-opam.sh
@@ -2,7 +2,7 @@
 
 set -e -x
 
-OPAM_VARIANT=ocaml-variants.4.09.1+mingw64c
+OPAM_VARIANT=ocaml-variants.4.10.0+mingw64c
 
 wget https://github.com/fdopen/opam-repository-mingw/releases/download/0.0.0.2/opam64.tar.xz -O opam64.tar.xz
 tar -xf opam64.tar.xz

--- a/dev/ci/docker/bionic_coq/Dockerfile
+++ b/dev/ci/docker/bionic_coq/Dockerfile
@@ -1,4 +1,4 @@
-# CACHEKEY: "bionic_coq-V2020-03-19-V29"
+# CACHEKEY: "bionic_coq-V2020-03-27-V12"
 # ^^ Update when modifying this file.
 
 FROM ubuntu:bionic
@@ -56,7 +56,7 @@ RUN opam switch create "${COMPILER}+32bit" && eval $(opam env) && \
     opam install $BASE_OPAM
 
 # EDGE switch
-ENV COMPILER_EDGE="4.09.1" \
+ENV COMPILER_EDGE="4.10.0" \
     BASE_OPAM_EDGE="dune-release.1.3.3 ocamlformat.0.13.0"
 
 # EDGE+flambda switch, we install CI_OPAM as to be able to use

--- a/dev/dune-workspace.all
+++ b/dev/dune-workspace.all
@@ -3,5 +3,5 @@
 ; Add custom flags here. Default developer profile is `dev`
 (context (opam (switch 4.05.0)))
 (context (opam (switch 4.05.0+32bit)))
-(context (opam (switch 4.09.1)))
-(context (opam (switch 4.09.1+flambda)))
+(context (opam (switch 4.10.0)))
+(context (opam (switch 4.10.0+flambda)))

--- a/doc/changelog/11-infrastructure-and-dependencies/11131-ci+back_to_ocaml_410.rst
+++ b/doc/changelog/11-infrastructure-and-dependencies/11131-ci+back_to_ocaml_410.rst
@@ -1,0 +1,7 @@
+- **Added:**
+  Bump official OCaml support and CI testing to 4.10.0
+  (`#11131 <https://github.com/coq/coq/pull/11131>`_,
+  `#11123 <https://github.com/coq/coq/pull/11123>`_,
+  `#11102 <https://github.com/coq/coq/pull/11123>`_,
+  by Emilio Jesus Gallego Arias, Jacques-Henri Jourdan,
+  Guillaume Melquiond, and Guillaume Munch-Maccagnoni).


### PR DESCRIPTION
After the great work on #11123 and #11102 we can build on 4.10 and maybe in 4.11 again; this restores the experimental CI testing.