### PR TITLE
Simplifying the code declaring the constants bound to primitive projections

### DIFF
--- a/test-suite/output/Projections.out
+++ b/test-suite/output/Projections.out
@@ -1,2 +1,17 @@
 fun S : store => S.(store_funcs)
      : store -> host_func
+a = 
+fun A : Type =>
+let B := A in fun (C : Type) (u : U A C) => (A, B, C, c _ _ u)
+     : forall A : Type,
+       let B := A in
+       forall C : Type, U A C -> Type * Type * Type * (B * A * C)
+
+Arguments a (_ _)%type_scope
+b = 
+fun A : Type => let B := A in fun (C : Type) (u : U A C) => b _ _ u
+     : forall A : Type,
+       let B := A in
+       forall (C : Type) (u : U A C), (A, B, C, c _ _ u) = (A, B, C, c _ _ u)
+
+Arguments b (_ _)%type_scope

--- a/test-suite/output/Projections.v
+++ b/test-suite/output/Projections.v
@@ -10,3 +10,12 @@ Section store.
 End store.
 
 Check (fun (S:@store nat) => S.(store_funcs)).
+
+Module LocalDefUnfolding.
+
+Unset Printing Projections.
+Record U A (B:=A) C := {c:B*A*C;a:=(A,B,C,c);b:a=a}.
+Print a.
+Print b.
+
+End LocalDefUnfolding.

--- a/vernac/declareInd.mli
+++ b/vernac/declareInd.mli
@@ -30,3 +30,6 @@ type inductive_obj
 val objInductive : inductive_obj Libobject.Dyn.tag
 
 end
+
+val declare_primitive_projection :
+  Names.Projection.Repr.t -> Names.Constant.t -> unit


### PR DESCRIPTION
**Kind:** cleanup

Added: overlay [rewriter PR#3](https://github.com/mit-plv/rewriter/pull/3) (not needed anymore)

We factorize code from `declareInd.ml` and `inductiveops.ml` with code essentially already existing in `record.ml`.

This moves the declarations of constants bound to projections from `DeclareInd.declare_mutual_inductive_with_eliminations` to `Record.declare_projections` and the gain is the factorization with the code used for non-primitive projections. 

Maybe some further simplifications are possible?

I made one semantic change: in this PR, projecting constants are declared for local definitions of primitive records, the same way as they are declared for non-primitive records. As a consequence, in `Set Primitive Projections. Record T := {a:=0;b:a=a}. Print b.`, the type of `b` is now `forall t, a t = a t`. [Added: This change is finally removed, see last messages of the discussion.]
