### PR TITLE
Adding `inj_compr` lemma in ssrfun.

### DIFF
--- a/doc/changelog/06-ssreflect/11136-inj_compr.rst
+++ b/doc/changelog/06-ssreflect/11136-inj_compr.rst
@@ -1,0 +1,1 @@
+- added lemma inj_compr (`#11136 <https://github.com/coq/coq/pull/11136>`_, by Cyril Cohen).

--- a/doc/changelog/06-ssreflect/11136-inj_compr.rst
+++ b/doc/changelog/06-ssreflect/11136-inj_compr.rst
@@ -1,1 +1,2 @@
-- added lemma inj_compr (`#11136 <https://github.com/coq/coq/pull/11136>`_, by Cyril Cohen).
+- Added lemma :g:`inj_compr` to :g:`ssr.ssrfun`
+  (`#11136 <https://github.com/coq/coq/pull/11136>`_, by Cyril Cohen).

--- a/plugins/ssr/ssrfun.v
+++ b/plugins/ssr/ssrfun.v
@@ -675,6 +675,9 @@ Proof. by move=> fK injf' x; apply: injf'. Qed.
 Lemma inj_comp : injective f -> injective h -> injective (f \o h).
 Proof. by move=> injf injh x y /injf; apply: injh. Qed.
 
+Lemma inj_compr : injective (f \o h) -> injective h.
+Proof. by move=> injfh x y /(congr1 f) /injfh. Qed.
+
 Lemma can_comp f' h' : cancel f f' -> cancel h h' -> cancel (f \o h) (h' \o f').
 Proof. by move=> fK hK x; rewrite /= fK hK. Qed.
 


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** feature

I added a missing basic theorem about injectivity to `plugins/ssr/ssrfun.v`.
See math-comp/math-comp#432

<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
