### PR TITLE
[ci] Use coq/bignums v8.11 branch

### DIFF
--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -194,7 +194,7 @@
 ########################################################################
 # Bignums
 ########################################################################
-: "${bignums_CI_REF:=master}"
+: "${bignums_CI_REF:=v8.11}"
 : "${bignums_CI_GITURL:=https://github.com/coq/bignums}"
 : "${bignums_CI_ARCHIVEURL:=${bignums_CI_GITURL}/archive}"
 


### PR DESCRIPTION
**Kind:** infrastructure

cf. [coq/bignums#28](https://github.com/coq/bignums/issues/28#issuecomment-555568200)