### PR TITLE
Slightly improving strategy about when to print coercion or explicitly print implicit arguments

### DIFF
--- a/test-suite/output/Implicit.out
+++ b/test-suite/output/Implicit.out
@@ -12,3 +12,8 @@ map id' (1 :: nil)
      : list nat
 map (id'' (A:=nat)) (1 :: nil)
      : list nat
+fix f (x : nat) : option nat := match x with
+                                | 0 => None
+                                | S _ => x
+                                end
+     : nat -> option nat

--- a/test-suite/output/Implicit.v
+++ b/test-suite/output/Implicit.v
@@ -51,3 +51,13 @@ Definition id'' (A:Type) (x:A) := x.
 
 Check map (@id'' nat) (1::nil).
 
+Module MatchBranchesInContext.
+
+Set Implicit Arguments.
+Set Contextual Implicit.
+
+Inductive option A := None | Some (a:A).
+Coercion some_nat := @Some nat.
+Check fix f x := match x with 0 => None | n => some_nat n end.
+
+End MatchBranchesInContext.


### PR DESCRIPTION
These are mini-refinements in deciding when printing is supposed to know type information from above: if a return type is printed in a `match`/`if`/`let`, then we are in context.

The body of a `fix`/`cofix` is also in context.

Also fixed an inconsistency with parsing in the scope used to print the body of a `fix`.

Example:
```coq
Set Implicit Arguments. Set Contextual Implicit.
Inductive option A := None | Some (a:A).
Coercion some_nat := @Some nat.
Check fix f x := match x with 0 => None | n => n end.
(* before:
fix f (x : nat) : option nat :=
  match x with
  | 0 => None (A:=nat)
  | S _ => some_nat x
  end
*)
(* after:
fix f (x : nat) : option nat :=
  match x with
  | 0 => None
  | S _ => x
  end
*)
```

**Kind:** mini-enhancement

- [X] Added / updated test-suite
