### PR TITLE
[pretyping] [bidir hints] preserve arguments as written by the user 

### DIFF
--- a/clib/cArray.ml
+++ b/clib/cArray.ml
@@ -57,6 +57,7 @@ sig
   val map_left : ('a -> 'b) -> 'a array -> 'b array
   val iter2_i : (int -> 'a -> 'b -> unit) -> 'a array -> 'b array -> unit
   val fold_left_map : ('a -> 'b -> 'a * 'c) -> 'a -> 'b array -> 'a * 'c array
+  val fold_left_map_i : (int -> 'a -> 'b -> 'a * 'c) -> 'a -> 'b array -> 'a * 'c array
   val fold_right_map : ('a -> 'c -> 'b * 'c) -> 'a array -> 'c -> 'b array * 'c
   val fold_left2_map : ('a -> 'b -> 'c -> 'a * 'd) -> 'a -> 'b array -> 'c array -> 'a * 'd array
   val fold_left2_map_i : (int -> 'a -> 'b -> 'c -> 'a * 'd) -> 'a -> 'b array -> 'c array -> 'a * 'd array
@@ -409,6 +410,11 @@ else
 let fold_left_map f e v =
   let e' = ref e in
   let v' = Array.map (fun x -> let (e,y) = f !e' x in e' := e; y) v in
+  (!e',v')
+
+let fold_left_map_i f e v =
+  let e' = ref e in
+  let v' = Array.mapi (fun i x -> let (e,y) = f i !e' x in e' := e; y) v in
   (!e',v')
 
 let fold_right2_map f v1 v2 e =

--- a/clib/cArray.mli
+++ b/clib/cArray.mli
@@ -96,6 +96,8 @@ sig
   (** [fold_left_map f e_0 [|l_1...l_n|] = e_n,[|k_1...k_n|]]
     where [(e_i,k_i)=f e_{i-1} l_i]; see also [Smart.fold_left_map] *)
 
+  val fold_left_map_i : (int -> 'a -> 'b -> 'a * 'c) -> 'a -> 'b array -> 'a * 'c array
+
   val fold_right_map : ('a -> 'c -> 'b * 'c) -> 'a array -> 'c -> 'b array * 'c
   (** Same, folding on the right *)
 

--- a/pretyping/classops.mli
+++ b/pretyping/classops.mli
@@ -92,6 +92,9 @@ val declare_coercion : env -> evar_map -> coercion -> unit
 (** {6 Access to coercions infos } *)
 val coercion_exists : coe_typ -> bool
 
+(** @raise Not_found if the given argument is not a coercion *)
+val coercion_info : coe_typ -> coe_info_typ
+
 (** {6 Lookup functions for coercion paths } *)
 
 (** @raise Not_found in the following functions when no path exists *)

--- a/test-suite/success/BidirectionalityHints.v
+++ b/test-suite/success/BidirectionalityHints.v
@@ -112,3 +112,19 @@ Check [TEST (x y : nat), x = y].
 Check [TEST2 (x y : nat), x = y].
 
 End Issue7910.
+
+Module Issue11140.
+
+Axiom T : nat -> Prop.
+Axiom f : forall x, T x.
+Arguments f & x.
+
+Lemma test : (f (1 + _) : T 2) = f 2.
+match goal with
+| |- (f (1 + 1) = f 2) => idtac
+| |- (f 2 = f 2) => idtac 1; fail 99 (* Issue 11140 *)
+| |- _ => idtac 2; fail 99
+end.
+Abort.
+
+End Issue11140.


### PR DESCRIPTION
Fix #11140 

The code is still a POC, especially wrt primitive projections, and the coercion case is untested. Little point in reviewing the ml code right now.

@Janno please have a look at the change in the test suite, I believe this is the source of your problem, but the example is totally made up.