### PR TITLE
add tlc to ci; please proof read very carefully and test. thanks

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -639,6 +639,9 @@ library:ci-sf:
 library:ci-stdlib2:
   extends: .ci-template-flambda
 
+library:ci-tlc:
+  extends: .ci-template
+
 library:ci-unimath:
   extends: .ci-template-flambda
 

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -41,6 +41,7 @@ CI_TARGETS= \
     ci-sf \
     ci-simple-io \
     ci-stdlib2 \
+    ci-tlc \
     ci-unimath \
     ci-verdi-raft \
     ci-vst

--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -188,8 +188,9 @@
 ########################################################################
 # TLC
 ########################################################################
-: "${tlc_CI_REF:=master}"
-: "${tlc_CI_GITURL:=https://gforge.inria.fr/git/tlc/tlc}"
+: "${tlc_CI_REF:=master-for-coq-ci}"
+: "${tlc_CI_GITURL:=https://github.com/charguer/tlc}"
+: "${tlc_CI_ARCHIVEURL:=${tlc_CI_GITURL}/archive}"
 
 ########################################################################
 # Bignums

--- a/dev/ci/ci-tlc.sh
+++ b/dev/ci/ci-tlc.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+ci_dir="$(dirname "$0")"
+. "${ci_dir}/ci-common.sh"
+
+git_download tlc
+
+( cd "${CI_BUILD_DIR}/tlc" && make && make install )


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

Add TLC, which is now hosted on github and compiles against Coq master, to the CI.

Note that the CI should use the branch called "master-for-coq-ci" from TLC, as this is the one that I will ensure stable enough for CI to work well.

I included data for opam package creation. It is intended to subsume the existing coq-tlc opam package.

<!-- Keep what applies -->
**Kind:** infrastructure.

