### PR TITLE
Example of including rst files as 2nd level nodes in the table of contents

### DIFF
--- a/doc/sphinx/index.html.rst
+++ b/doc/sphinx/index.html.rst
@@ -9,6 +9,7 @@ Contents
 
 .. toctree::
    :caption: Indexes
+   :maxdepth: 5
 
    genindex
    coq-cmdindex
@@ -31,9 +32,7 @@ Contents
 
    language/gallina-specification-language
    language/gallina-extensions
-   language/coq-library
-   language/cic
-   language/module-system
+   language/sub
 
 .. toctree::
    :caption: The proof engine

--- a/doc/sphinx/language/sub.rst
+++ b/doc/sphinx/language/sub.rst
@@ -1,0 +1,11 @@
+==========================
+Junk
+==========================
+
+.. toctree::
+   :hidden:
+   :caption: Preamble
+
+   coq-library
+   cic
+   module-system


### PR DESCRIPTION
This looks like a workable approach for breaking the HTML documentation into more and smaller pages.  If `sub.rst` has no content (i.e., if I remove the header "Junk"), the TOC will be unchanged and will look like it is in master.

![image](https://user-images.githubusercontent.com/1253341/69468695-fbfe3e00-0d41-11ea-98c2-a5f8940e9b53.png)

@Zimmi48 What do you think?