### PR TITLE
Let pattern_of_constr take an econstr.

### DIFF
--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -584,6 +584,16 @@ let undefined_map d = d.undf_evars
 
 let drop_all_defined d = { d with defn_evars = EvMap.empty }
 
+let reset_non_goal_defined d =
+  let f evk info =
+    match snd info.evar_source with
+    (* These are the two evar kinds used for existing goals *)
+    (* see Proofview.mark_in_evm *)
+    | Evar_kinds.GoalEvar | Evar_kinds.VarInstance _ -> info
+    | _ -> { info with evar_body = Evar_empty } in
+  let defn_evars = EvMap.Smart.mapi f d.defn_evars in
+  { d with defn_evars }
+
 (* spiwack: not clear what folding over an evar_map, for now we shall
     simply fold over the inner evar_map. *)
 let fold f d a =

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -224,6 +224,10 @@ val undefined_map : evar_map -> evar_info Evar.Map.t
 
 val drop_all_defined : evar_map -> evar_map
 
+val reset_non_goal_defined : evar_map -> evar_map
+(* Force all non-GoalEvar non-VarInstance evars to undefined *)
+(* May break typability of types of evars in evar_map, but ok for EConstr.kind *)
+
 val is_maybe_typeclass_hook : (evar_map -> constr -> bool) Hook.t
 
 (** {6 Instantiating partial terms} *)

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -615,7 +615,7 @@ let interp_typed_pattern ist env sigma (_,c,_) =
     interp_gen WithoutTypeConstraint ist true pure_open_constr_flags env sigma c in
   (* FIXME: it is necessary to be unsafe here because of the way we handle
      evars in the pretyper. Sometimes they get solved eagerly. *)
-  pattern_of_constr env sigma (EConstr.Unsafe.to_constr c)
+  pattern_of_constr_preserve_non_goal_evars env sigma c
 
 (* Interprets a constr expression *)
 let interp_constr_in_compound_list inj_fun dest_fun interp_fun ist env sigma l =
@@ -660,7 +660,7 @@ let interp_closed_typed_pattern_with_occurrences ist env sigma (occs, a) =
       try Inl (coerce_to_evaluable_ref env sigma x)
       with CannotCoerceTo _ ->
         let c = coerce_to_closed_constr env x in
-        Inr (pattern_of_constr env sigma (EConstr.to_constr sigma c)) in
+        Inr (pattern_of_constr_preserve_non_goal_evars env sigma c) in
     (try try_interp_ltac_var coerce_eval_ref_or_constr ist (Some (env,sigma)) (make ?loc id)
      with Not_found ->
        Nametab.error_global_not_found (qualid_of_ident ?loc id))

--- a/pretyping/patternops.mli
+++ b/pretyping/patternops.mli
@@ -42,7 +42,7 @@ val head_of_constr_reference : Evd.evar_map -> constr -> GlobRef.t
    a pattern; currently, no destructor (Cases, Fix, Cofix) and no
    existential variable are allowed in [c] *)
 
-val pattern_of_constr : Environ.env -> Evd.evar_map -> Constr.constr -> constr_pattern
+val pattern_of_constr_preserve_non_goal_evars : Environ.env -> Evd.evar_map -> EConstr.constr -> constr_pattern
 
 (** [pattern_of_glob_constr l c] translates a term [c] with metavariables into
    a pattern; variables bound in [l] are replaced by the pattern to which they

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -806,7 +806,7 @@ let make_exact_entry env sigma info ~poly ?(name=PathAny) (c, cty, ctx) =
     match EConstr.kind sigma cty with
     | Prod _ -> failwith "make_exact_entry"
     | _ ->
-        let pat = Patternops.pattern_of_constr env sigma (EConstr.to_constr ~abort_on_undefined_evars:false sigma cty) in
+        let pat = Patternops.pattern_of_constr_preserve_non_goal_evars env sigma cty in
         let hd =
           try head_pattern_bound pat
           with BoundPattern -> failwith "make_exact_entry"
@@ -828,7 +828,7 @@ let make_apply_entry env sigma (eapply,hnf,verbose) info ~poly ?(name=PathAny) (
     let sigma' = Evd.merge_context_set univ_flexible sigma ctx in
     let ce = mk_clenv_from_env env sigma' None (c,cty) in
     let c' = clenv_type (* ~reduce:false *) ce in
-    let pat = Patternops.pattern_of_constr env ce.evd (EConstr.to_constr ~abort_on_undefined_evars:false sigma c') in
+    let pat = Patternops.pattern_of_constr_preserve_non_goal_evars env ce.evd c' in
     let hd =
       try head_pattern_bound pat
       with BoundPattern -> failwith "make_apply_entry" in
@@ -971,7 +971,7 @@ let make_trivial env sigma poly ?(name=PathAny) r =
   let ce = mk_clenv_from_env env sigma None (c,t) in
   (Some hd, { pri=1;
               poly = poly;
-              pat = Some (Patternops.pattern_of_constr env ce.evd (EConstr.to_constr sigma (clenv_type ce)));
+              pat = Some (Patternops.pattern_of_constr_preserve_non_goal_evars env ce.evd (clenv_type ce));
               name = name;
               db = None;
               secvars = secvars_of_constr env sigma c;


### PR DESCRIPTION
We adopt a different approach to preserve not-yet instantiated evars in `econstr`-"unsafe" `pattern_of_constr`. We make it working on `econstr` but using an evar_map whose non-goal defined evars are retracted to undefined status.

It is still fragile but avoiding `EConstr.Unsafe.to_constr` (fragile because relying on a number of invariants such as: only `GoalEvar` and `VarInstance` kinds in a proof state; no expansion of an `Evar` in the internal representation of an `econstr` while pretyping). Moreover the retracted `evar_map` is not necessary typeable (even if does not matter here).

Rename it into `pattern_of_constr_preserve_non_goal_evars` to insist on  non-normalization of non-goal evars.

**Kind:** hack