### PR TITLE
coercion functions are never called without a term to coerce

### DIFF
--- a/pretyping/coercion.mli
+++ b/pretyping/coercion.mli
@@ -54,13 +54,6 @@ val inh_conv_coerce_rigid_to : ?loc:Loc.t -> program_mode:bool ->bool ->
   env -> evar_map -> ?flags:Evarconv.unify_flags ->
   unsafe_judgment -> types -> evar_map * unsafe_judgment
 
-(** [inh_conv_coerces_to loc env isevars t t'] checks if an object of type [t]
-    is coercible to an object of type [t'] adding evar constraints if needed;
-    it fails if no coercion exists *)
-val inh_conv_coerces_to : ?loc:Loc.t ->
-  env -> evar_map -> ?flags:Evarconv.unify_flags ->
-  types -> types -> evar_map
-
 (** [inh_pattern_coerce_to loc env isevars pat ind1 ind2] coerces the Cases
     pattern [pat] typed in [ind1] into a pattern typed in [ind2];
     raises [Not_found] if no coercion found *)


### PR DESCRIPTION
(inh_conv_coerces_to is unused so we remove it)

This makes the code simpler, removing dead match branches and Option.maps/gets
