### PR TITLE
Remove deprecated Typeclasses Axioms Are Instances.

### DIFF
--- a/doc/changelog/07-commands-and-options/11185-remove-typeclasses-axioms-instances.rst
+++ b/doc/changelog/07-commands-and-options/11185-remove-typeclasses-axioms-instances.rst
@@ -1,0 +1,3 @@
+- **Removed:** ``Typeclasses Axioms Are Instances`` flag, deprecated since 8.10.
+  Use :cmd:`Declare Instance` for axioms which should be instances
+  (`#11185 <https://github.com/coq/coq/pull/11185>`_, by Théo Zimmermann).

--- a/doc/sphinx/addendum/type-classes.rst
+++ b/doc/sphinx/addendum/type-classes.rst
@@ -576,14 +576,6 @@ Settings
    of goals.  Setting this option to 1 or 2 turns on the :flag:`Typeclasses Debug` flag; setting this
    option to 0 turns that flag off.
 
-.. flag:: Typeclasses Axioms Are Instances
-
-   .. deprecated:: 8.10
-
-   This flag (off by default since 8.8) automatically declares axioms
-   whose type is a typeclass at declaration time as instances of that
-   class.
-
 Typeclasses eauto `:=`
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/test-suite/success/LocalDefinition.v
+++ b/test-suite/success/LocalDefinition.v
@@ -26,28 +26,12 @@ Module TestAdmittedVisibility.
   Fail Check d2.
 End TestAdmittedVisibility.
 
-(* Test consistent behavior of Local Definition wrt automatic declaration of instances *)
-
 Module TestVariableAsInstances.
-  Module Test1.
-    Set Typeclasses Axioms Are Instances.
-    Class U.
-    Local Parameter b : U.
-    Definition testU := _ : U. (* _ resolved *)
+  Class U.
+  Local Parameter b : U.
+  Fail Definition testU := _ : U. (* _ unresolved *)
 
-    Class T.
-    Variable a : T.  (* warned to be the same as "Local Parameter" *)
-    Definition testT := _ : T. (* _ resolved *)
-  End Test1.
-
-  Module Test2.
-    Unset Typeclasses Axioms Are Instances.
-    Class U.
-    Local Parameter b : U.
-    Fail Definition testU := _ : U. (* _ unresolved *)
-
-    Class T.
-    Variable a : T.  (* warned to be the same as "Local Parameter" thus should not be an instance *)
-    Fail Definition testT := _ : T. (* used to succeed *)
-  End Test2.
+  Class T.
+  Variable a : T.  (* warned to be the same as "Local Parameter" thus should not be an instance *)
+  Fail Definition testT := _ : T. (* used to succeed *)
 End TestVariableAsInstances.

--- a/test-suite/success/Typeclasses.v
+++ b/test-suite/success/Typeclasses.v
@@ -241,13 +241,8 @@ Module IterativeDeepening.
 
 End IterativeDeepening.
 
-Module AxiomsAreInstances.
-  Set Typeclasses Axioms Are Instances.
-  Class TestClass1 := {}.
-  Axiom testax1 : TestClass1.
-  Definition testdef1 : TestClass1 := _.
+Module AxiomsAreNotInstances.
 
-  Unset Typeclasses Axioms Are Instances.
   Class TestClass2 := {}.
   Axiom testax2 : TestClass2.
   Fail Definition testdef2 : TestClass2 := _.
@@ -256,4 +251,4 @@ Module AxiomsAreInstances.
   Existing Instance testax2.
   Definition testdef2 : TestClass2 := _.
 
-End AxiomsAreInstances.
+End AxiomsAreNotInstances.


### PR DESCRIPTION
**Kind:** clean-up

- [x] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
