### PR TITLE
Remove deprecated commands `AddPath`, `AddRecPath` and `DelPath`

### DIFF
--- a/doc/changelog/07-commands-and-options/11187-remove-addpath.rst
+++ b/doc/changelog/07-commands-and-options/11187-remove-addpath.rst
@@ -1,0 +1,5 @@
+- Removed legacy commands ``AddPath``, ``AddRecPath``, and ``DelPath``
+  which were undocumented, broken variants of :cmd:`Add LoadPath`,
+  :cmd:`Add Rec LoadPath`, and :cmd:`Remove LoadPath`
+  (`#11187 <https://github.com/coq/coq/pull/11187>`_,
+  by Maxime Dénès and Théo Zimmermann).

--- a/tools/coqdoc/output.ml
+++ b/tools/coqdoc/output.ml
@@ -30,7 +30,7 @@ let build_table l =
 
 let is_keyword =
   build_table
-    [ "About"; "AddPath"; "Axiom"; "Abort"; "Chapter"; "Check"; "Coercion"; "Compute"; "CoFixpoint";
+    [ "About"; "Axiom"; "Abort"; "Chapter"; "Check"; "Coercion"; "Compute"; "CoFixpoint";
       "CoInductive"; "Corollary"; "Defined"; "Definition"; "End"; "Eval"; "Example";
       "Export"; "Fact"; "Fix"; "Fixpoint"; "From"; "Function"; "Generalizable"; "Global"; "Grammar";
       "Guarded"; "Goal"; "Hint"; "Debug"; "On";

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -939,15 +939,7 @@ GRAMMAR EXTEND Gram
       | IDENT "Remove"; IDENT "LoadPath"; dir = ne_string ->
           { VernacRemoveLoadPath dir }
 
-       (* For compatibility *)
-      | IDENT "AddPath"; dir = ne_string; "as"; alias = as_dirpath ->
-          { VernacAddLoadPath (false, dir, alias) }
-      | IDENT "AddRecPath"; dir = ne_string; "as"; alias = as_dirpath ->
-          { VernacAddLoadPath (true, dir, alias) }
-      | IDENT "DelPath"; dir = ne_string ->
-          { VernacRemoveLoadPath dir }
-
-      (* Type-Checking (pas dans le refman) *)
+      (* Type-Checking *)
       | "Type"; c = lconstr -> { VernacGlobalCheck c }
 
       (* Printing (careful factorization of entries) *)


### PR DESCRIPTION
Fixes #10576

(extracted from #10575)

**Kind:** clean-up

- [ ] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
