### PR TITLE
Bidirectionality hints: preserve user-given term in result

### DIFF
--- a/test-suite/bugs/closed/bug_11140.v
+++ b/test-suite/bugs/closed/bug_11140.v
@@ -1,0 +1,14 @@
+Axiom T : nat -> Prop.
+Axiom f : forall x, T x.
+Arguments f & x.
+
+Fail Check f 3 : T 2.
+
+Lemma test : (f (1 + _) : T 2) = f 2.
+Proof.
+  match goal with
+  | |- (f (1 + 1) = f 2) => idtac
+  | |- (f 2 = f 2) => idtac 1; fail 99 (* Issue 11140 *)
+  end.
+  reflexivity.
+Qed.


### PR DESCRIPTION
Alternative to https://github.com/coq/coq/pull/11147 
#11147 tries to identify which part of the term are from coercions vs user given, but this seems tricky and I'm not certain that it's possible in general. We could try instead to get the coercion system to output a trace of what it does so that we could redo it (alternated with applications) but although I got somewhere with making traces for regular coercions, I don't understand the program mode coercions (https://github.com/coq/coq/blob/d7879b8566e48aabfdbee5c27bd4c29691352233/pretyping/coercion.ml#L154-L351) enough (the program mode coercions also make me fear even more for #11147's approach).

Instead I just save enough information to restart the application pretyping after having unified the result type with the expected type. This seems to work fine. It may do some work twice (especially the final unification), I don't know to what extent this may be avoided.
The code is kinda messy to avoid rewriting the `apply_rec` function, please suggest specific improvements or just push to my branch.