### PR TITLE
missing " in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -483,7 +483,7 @@ We have a linter that checks a few different things:
   to build every commit, and in principle even the test-suite should
   pass on every commit (but this isn't tested in CI because it would
   take too long).  A good way to test this is to use `git rebase
-  master --exec "make -f Makefile.dune check`.
+  master --exec "make -f Makefile.dune check"`.
 - **No tabs or end-of-line spaces on updated lines**.  We are trying
   to get rid of all tabs and all end-of-line spaces from the code base
   (except in some very special files that need them).  This checks not


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** documentation.

There is a missing " in [CONTRIBUTING.md](https://github.com/coq/coq/blob/master/CONTRIBUTING.md#linter-failures).
