### PR TITLE
Correcting unintended changelog message for #11090 (coercion+notation regression)

### DIFF
--- a/doc/changelog/03-notations/11090-master+refactoring-application-printing.rst
+++ b/doc/changelog/03-notations/11090-master+refactoring-application-printing.rst
@@ -1,1 +1,3 @@
-- Fixed #11033: regression in not printing coercions to which is also associated a notation (`#11090 <https://github.com/coq/coq/pull/11090>`_, by Hugo Herbelin).
+- Fixed an 8.10 regression related to the printing of coercions associated to notations
+  (`#11090 <https://github.com/coq/coq/pull/11090>`_,
+  fixes ` #11033 <https://github.com/coq/coq/issues/11033>`_, by Hugo Herbelin).


### PR DESCRIPTION
**Kind:** Fixing unintended changelog message in #11090. Sorry.

