### PR TITLE
Implement customizable ssrmatching blacklisting to address #11118

### DIFF
--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -763,6 +763,14 @@ let mkSsrRef name =
 let mkSsrRRef name = (DAst.make @@ GRef (mkSsrRef name,None)), None
 let mkSsrConst name env sigma =
   EConstr.fresh_global env sigma (mkSsrRef name)
+
+let mkSsrmatchingRef name =
+  let qn = Format.sprintf "plugins.ssrmatching.%s" name in
+  if Coqlib.has_ref qn then Coqlib.lib_ref qn else
+  CErrors.user_err Pp.(str "ssrmatching library not loaded (" ++ str name ++ str ")")
+let mkSsrmatchingConst name env sigma =
+  EConstr.fresh_global env sigma (mkSsrmatchingRef name)
+
 let pf_mkSsrConst name gl =
   let sigma, env, it = project gl, pf_env gl, sig_it gl in
   let (sigma, t) = mkSsrConst name env sigma in

--- a/plugins/ssr/ssrcommon.mli
+++ b/plugins/ssr/ssrcommon.mli
@@ -219,6 +219,10 @@ val mkSsrRRef : string -> Glob_term.glob_constr * 'a option
 val mkSsrConst :
            string ->
            env -> evar_map -> evar_map * EConstr.t
+val mkSsrmatchingConst :
+           string ->
+           env -> evar_map -> evar_map * EConstr.t
+
 val pf_mkSsrConst :
            string ->
            Goal.goal Evd.sigma ->

--- a/plugins/ssr/ssreflect.v
+++ b/plugins/ssr/ssreflect.v
@@ -41,6 +41,9 @@ Declare ML Module "ssreflect_plugin".
                           the ssreflect matching algorithm.
              nosimpl t == t, but on the right-hand side of Definition C :=
                           nosimpl disables expansion of C by /=.
+           nomatch T t == t, (see ssrmatching.v: the first 2 arguments T and t
+                          of this transparent identity function are ignored
+                          by the ssreflect matching algorithm)
               locked t == t, but locked t is not convertible to t.
        locked_with k t == t, but not convertible to t or locked_with k' t
                           unless k = k' (with k : unit). Coq type-checking

--- a/plugins/ssr/ssreflect.v
+++ b/plugins/ssr/ssreflect.v
@@ -538,7 +538,7 @@ Proof. by move=> /(_ P); apply. Qed.
 Require Export ssrunder.
 
 Hint Extern 0 (@Under_rel.Over_rel _ _ _ _) =>
-  solve [ apply: Under_rel.over_rel_done ] : core.
+  solve [ (try unfold ssrmatching.nomatch); apply: Under_rel.over_rel_done ] : core.
 Hint Resolve Under_rel.over_rel_done : core.
 
 Register Under_rel.Under_rel as plugins.ssreflect.Under_rel.
@@ -549,6 +549,7 @@ Definition over := over_rel.
 
 (** Closing tactic *)
 Ltac over :=
+  (try unfold ssrmatching.nomatch);
   by [ apply: Under_rel.under_rel_done
      | rewrite over
      ].

--- a/plugins/ssr/ssrfwd.ml
+++ b/plugins/ssr/ssrfwd.ml
@@ -348,6 +348,8 @@ let intro_lock ipats =
     let sigma, nomatch =
       Ssrcommon.mkSsrmatchingConst "nomatch" env sigma in
     if EConstr.isApp sigma eredex then
+      let () = ppdebug(lazy Pp.(str"under: an evar-redex: " ++
+                         pr_econstr_env env sigma eredex)) in
       let (e, args) = EConstr.destApp sigma eredex in
       if is_app_evar sigma e && Array.length args >= 1 then
         let protect sigma t =

--- a/plugins/ssr/ssrfwd.ml
+++ b/plugins/ssr/ssrfwd.ml
@@ -346,7 +346,10 @@ let intro_lock ipats =
         let sigma, carrier =
           Typing.type_of env sigma args.(lm2) in
         let rel = EConstr.mkApp (hd, Array.sub args 0 lm2) in
-        let rel_args = Array.sub args lm2 2 in
+        let sigma, nomatch =
+          Ssrcommon.mkSsrmatchingConst "nomatch" env sigma in
+        let rel_args = [|args.(lm2);
+                         EConstr.mkApp(nomatch, [|carrier; args.(lm2 + 1)|])|] in
         let sigma, under_rel =
           Ssrcommon.mkSsrConst "Under_rel" env sigma in
         let sigma, under_from_rel =

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -534,7 +534,7 @@ let dont_impact_evars_in sigma0 cl =
     try let _ = Evd.find_undefined sigma k in true
     with Not_found -> false) evs_in_cl
 
-(* Adapted from plugins/ssr/ssrcommon.ml *)
+(* Copy from plugins/ssr/ssrcommon.ml *)
 let mkSsrmatchingRef name =
   let qn = Format.sprintf "plugins.ssrmatching.%s" name in
   if Coqlib.has_ref qn then Coqlib.lib_ref qn else

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -556,7 +556,10 @@ let match_upats_FO upats env sigma0 ise orig_c =
     let f, a = splay_app ise c in let i0 = ref (-1) in
     let nomatch =
       is_const_ref sigma0 (EConstr.of_constr f) (mkSsrmatchingRef "nomatch") in
-    let maybe2 = if nomatch then min 2 (Array.length a) else 0 in
+    let maybe2 = if nomatch then
+                   let () = pp(lazy Pp.(str"ssrmatch-1: nomatch")) in
+                   min 2 (Array.length a)
+                 else 0 in
     let a' =
       if nomatch then Array.sub a maybe2 (Array.length a - maybe2) else a in
     let fpats =
@@ -605,7 +608,10 @@ let match_upats_HO ~on_instance upats env sigma0 ise c =
   let f, a = splay_app ise c in let i0 = ref (-1) in
   let nomatch =
     is_const_ref sigma0 (EConstr.of_constr f) (mkSsrmatchingRef "nomatch") in
-  let maybe2 = if nomatch then min 2 (Array.length a) else 0 in
+  let maybe2 = if nomatch then
+                 let () = pp(lazy Pp.(str"ssrmatch-2: nomatch")) in
+                 min 2 (Array.length a)
+               else 0 in
   let a' =
     if nomatch then Array.sub a maybe2 (Array.length a - maybe2) else a in
   let fpats = List.fold_right (filter_upat i0 f (Array.length a')) upats [] in
@@ -775,7 +781,10 @@ let rec uniquize = function
     let f, a = splay_app sigma c' in
     let nomatch =
       is_const_ref sigma (EConstr.of_constr f) (mkSsrmatchingRef "nomatch") in
-    let maybe2 = if nomatch then min 2 (Array.length a) else 0 in
+    let maybe2 = if nomatch then
+                   let () = pp(lazy Pp.(str"ssrmatch-3: nomatch")) in
+                   min 2 (Array.length a)
+                 else 0 in
     let a' =
       if nomatch then Array.sub a maybe2 (Array.length a - maybe2) else a in
     if Array.length a' >= pn && match_EQ f && unif_EQ_args env sigma pa a' then

--- a/plugins/ssrmatching/ssrmatching.v
+++ b/plugins/ssrmatching/ssrmatching.v
@@ -12,6 +12,20 @@
 
 Declare ML Module "ssrmatching_plugin".
 
+(**
+ This file is the Gallina part of the ssreflect matching implementation.
+
+ In particular, it defines:
+
+        nomatch T t == t, but the first two arguments T and t
+                       of this transparent identity function are ignored
+                       by the ssreflect matching algorithm.                  **)
+
+(* Definition used in the implementatin of the under tactic,
+   see also coq/coq#11118 *)
+Definition nomatch T (t : T) := t.
+Register nomatch as plugins.ssrmatching.nomatch.
+
 Module SsrMatchingSyntax.
 
 (* Reserve the notation for rewrite patterns so that the user is not allowed  *)

--- a/test-suite/bugs/closed/bug_11118.v
+++ b/test-suite/bugs/closed/bug_11118.v
@@ -13,13 +13,3 @@ under map_ext => a.
   over. (* was failing with: No applicable tactic. *)
 done.
 Admitted.
-
-(* The regression test below goes beyond reproducing the bug *)
-Lemma no_rhs' (A: list (nat * nat)) (f: nat -> nat) :
-  map (fun (a: nat * nat) => fst (let '(x, y) := a in (f x, f y))) A = map (fun (a: nat * nat) => f (fst a)) A.
-Proof.
-under map_ext => a.
-  Fail rewrite [in X in @Under_rel _ _ _ X](surjective_pairing a).
-  unfold ssrmatching.nomatch.
-  rewrite [in X in @Under_rel _ _ _ X](surjective_pairing a).
-Abort.

--- a/test-suite/bugs/closed/bug_11118.v
+++ b/test-suite/bugs/closed/bug_11118.v
@@ -1,0 +1,25 @@
+(* cf. https://github.com/coq/coq/issues/11118 *)
+
+From Coq Require Import ssreflect.
+From Coq Require Import List.
+
+Set Debug SsrMatching.
+
+Lemma no_rhs (A: list (nat * nat)) (f: nat -> nat) :
+  map (fun (a: nat * nat) => fst (let '(x, y) := a in (f x, f y))) A = map (fun (a: nat * nat) => f (fst a)) A.
+Proof.
+under map_ext => a.
+  rewrite (surjective_pairing a).
+  over. (* was failing with: No applicable tactic. *)
+done.
+Admitted.
+
+(* The regression test below goes beyond reproducing the bug *)
+Lemma no_rhs' (A: list (nat * nat)) (f: nat -> nat) :
+  map (fun (a: nat * nat) => fst (let '(x, y) := a in (f x, f y))) A = map (fun (a: nat * nat) => f (fst a)) A.
+Proof.
+under map_ext => a.
+  Fail rewrite [in X in @Under_rel _ _ _ X](surjective_pairing a).
+  unfold ssrmatching.nomatch.
+  rewrite [in X in @Under_rel _ _ _ X](surjective_pairing a).
+Abort.

--- a/test-suite/ssr/ssr_nomatch.v
+++ b/test-suite/ssr/ssr_nomatch.v
@@ -1,0 +1,34 @@
+(* see also test-suite/bugs/closed/bug_11118.v *)
+
+From Coq Require Import ssreflect.
+From Coq Require Import List.
+
+Set Debug SsrMatching.
+
+Lemma test1 (A: list (nat * nat)) (f: nat -> nat) :
+  map (fun (a: nat * nat) => fst (let '(x, y) := a in (f x, f y))) A = map (fun (a: nat * nat) => f (fst a)) A.
+Proof.
+under map_ext => a.
+  Fail rewrite [in X in @Under_rel _ _ _ X](surjective_pairing a).
+  unfold ssrmatching.nomatch.
+  rewrite [in X in @Under_rel _ _ _ X](surjective_pairing a).
+Abort.
+
+Section Test_nomatch.
+Variables (P Q : Prop) (H : P = Q) (ok : Q).
+
+Lemma test2 : ssrmatching.nomatch Prop P.
+Fail rewrite H.
+unfold ssrmatching.nomatch.
+rewrite H.
+exact ok.
+Qed.
+
+Lemma test3 : ssrmatching.nomatch (Prop -> Prop) (fun _ => P) P.
+Fail rewrite {2}H.
+rewrite H.
+hnf.
+Fail exact ok.
+Abort.
+
+End Test_nomatch.

--- a/test-suite/ssr/under.v
+++ b/test-suite/ssr/under.v
@@ -108,6 +108,8 @@ Lemma test_big_2cond_0intro (F : nat -> nat) (m : nat) :
   \sum_(0 <= i < m | odd (i + 1)) (i + 2) >= 0.
 Proof.
 (* in interactive mode *)
+Set Debug Ssreflect.
+(* FIXME: "protect_subgoal" fails to protect the goal when there is no =>ipat *)
 under eq_big.
 { move=> n; rewrite (addnC n 1); over. }
 { move=> i Hi; rewrite (addnC i 2); over. }


### PR DESCRIPTION
**Kind:** enhancement that prevents a distracting issue with `under`

Closes #11118 
Cc @mrhaandi FYI

This implements the feature suggested by @gares in #11118.
I also added some coqdoc documentation and a few regression tests.

- [x] Added / updated test-suite
- [ ] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details) ← is a changelog entry relevant?