### PR TITLE
Make the string argument of `time` print correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,7 @@ test-suite/coqdoc/Coqdoc.*
 test-suite/coqdoc/index.html
 test-suite/coqdoc/coqdoc.css
 test-suite/output/MExtraction.out
+test-suite/output/*.out.real
 test-suite/oUnit-anon.cache
 test-suite/unit-tests/**/*.test
 

--- a/doc/changelog/04-tactics/11203-fix-time-printing.rst
+++ b/doc/changelog/04-tactics/11203-fix-time-printing.rst
@@ -1,0 +1,4 @@
+- The optional string argument to :tacn:`time` is now properly quoted
+  under :cmd:`Print Ltac` (`#11203
+  <https://github.com/coq/coq/pull/11203>`_, fixes `#10971
+  <https://github.com/coq/coq/issues/10971>`_, by Jason Gross)

--- a/plugins/ltac/pptactic.ml
+++ b/plugins/ltac/pptactic.ml
@@ -971,7 +971,7 @@ let pr_goal_selector ~toplevel s =
             | TacTime (s,t) ->
               hov 1 (
                 keyword "time"
-                ++ pr_opt str s ++ spc ()
+                ++ pr_opt qstring s ++ spc ()
                 ++ pr_tac (ltactical,E) t),
               ltactical
             | TacRepeat t ->

--- a/test-suite/output/print_ltac.out
+++ b/test-suite/output/print_ltac.out
@@ -1,0 +1,8 @@
+Ltac t1 := time "my tactic" idtac
+Ltac t2 := let x := string:("my tactic") in
+           idtac
+           x
+Ltac t3 := idtacstr "my tactic"
+Ltac t4 x := match x with
+             | ?A => (A, A)
+             end

--- a/test-suite/output/print_ltac.v
+++ b/test-suite/output/print_ltac.v
@@ -1,0 +1,12 @@
+(* Testing of various things about Print Ltac *)
+(* https://github.com/coq/coq/issues/10971 *)
+Ltac t1 := time "my tactic" idtac.
+Print Ltac t1.
+Ltac t2 := let x := string:("my tactic") in idtac x.
+Print Ltac t2.
+Tactic Notation "idtacstr" string(str) := idtac str.
+Ltac t3 := idtacstr "my tactic".
+Print Ltac t3.
+(* https://github.com/coq/coq/issues/9716 *)
+Ltac t4 x := match x with ?A => constr:((A, A)) end.
+Print Ltac t4.


### PR DESCRIPTION
**Kind:** bug fix

Fixes #10971

- [x] Added / updated test-suite
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
