### PR TITLE
Fixing status reporting for complexity tests

### DIFF
--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -530,14 +530,16 @@ $(addsuffix .log,$(wildcard complexity/*.v)): %.v.log: %.v $(PREREQUISITELOG)
 	$(HIDE){ \
 	  echo $(call log_intro,$<); \
 	  true "extract effective user time"; \
-	  res=`$(coqc_interactive) "$<" $(call get_coq_prog_args,"$<") 2>&1 | sed -n -e "s/Finished transaction in .*(\([0-9]*\.[0-9]*\)u.*)/\1/p" | head -1 | sed "s/\r//g"`; \
+	  res=`$(coqc_interactive) "$<" $(call get_coq_prog_args,"$<") 2>&1 | sed -n -e "s/Finished .*transaction in .*(\([0-9]*\.[0-9]*\)u.*)/\1/p" | head -1 | sed "s/\r//g"`; \
 	  R=$$?; times; \
 	  if [ $$R != 0 ]; then \
 	    echo $(log_failure); \
 	    echo "    $<...Error! (should be accepted)" ; \
+	    $(FAIL); \
 	  elif [ "$$res" = "" ]; then \
 	    echo $(log_failure); \
 	    echo "    $<...Error! (couldn't find a time measure)"; \
+	    $(FAIL); \
 	  else \
 	    true "express effective time in centiseconds"; \
 	    resorig="$$res"; \


### PR DESCRIPTION
**Kind:** infrastructure fix

The regexp parsing the time was incomplete and not all cases of failures were reported.

Note: In relation to the lack of accuracy of time measure, the usefulness of complexity tests is questioned. My own experience is however that the tests are useful to detect complexity jumps. For instance, the revert of optimizations checked by some complexity tests indeed detected the change of complexity. Thus, my conclusion is that this PR is not irrelevant, even, if for sure, the time measures are approximative and better ways of testing complexity are desirable.