### PR TITLE
Add a script to pin CI developments.

### DIFF
--- a/dev/doc/release-process.md
+++ b/dev/doc/release-process.md
@@ -75,7 +75,8 @@ in time.
 - [ ] Pin the versions of libraries and plugins in
   `dev/ci/ci-basic-overlays.sh` to use commit hashes or tag (or, if it
   exists, a branch dedicated to compatibility with the corresponding
-  Coq branch).
+  Coq branch). You can use the `dev/tools/pin-ci.sh` script to do this
+  semi-automatically.
 - [ ] Remove all remaining unmerged feature PRs from the beta milestone.
 - [ ] Start a new project to track PR backporting. The project should
   have a "Request X.X+beta1 inclusion" column for the PRs that were

--- a/dev/tools/pin-ci.sh
+++ b/dev/tools/pin-ci.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# Use this script to pin the commit used by the developments tracked by the CI
+
+OVERLAYS="./dev/ci/ci-basic-overlay.sh"
+
+process_development() {
+  local DEV=$1
+  local REPO_VAR="${DEV}_CI_GITURL"
+  local REPO=${!REPO_VAR}
+  local BRANCH_VAR="${DEV}_CI_REF"
+  local BRANCH=${!BRANCH_VAR}
+  if [[ -z "$BRANCH" ]]
+  then
+    echo "$DEV has no branch set, skipping"
+    return 0
+  fi
+  if [[ $BRANCH =~ ^[a-f0-9]{40}$ ]]
+  then
+    echo "$DEV is already set to hash $BRANCH, skipping"
+    return 0
+  fi
+  echo "Resolving $DEV as $BRANCH from $REPO"
+  local HASH=$(git ls-remote --heads $REPO $BRANCH | cut -f 1)
+  if [[ -z "$HASH" ]]
+  then
+    echo "Could not resolve reference $BRANCH for $DEV (something went wrong), skipping"
+    return 0
+  fi
+  read -p "Expand $DEV from $BRANCH to $HASH? [y/N] " -n 1 -r
+  echo
+  if [[ $REPLY =~ ^[Yy]$ ]]; then
+    # use -i.bak to be compatible with MacOS; see, e.g., https://stackoverflow.com/a/7573438/377022
+    sed -i.bak -e "s/$BRANCH_VAR:=$BRANCH/$BRANCH_VAR:=$HASH/" $OVERLAYS
+  fi
+}
+
+# Execute the script to set the overlay variables
+. $OVERLAYS
+
+# Find all variables declared in the base overlay of the form *_CI_GITURL
+for REPO_VAR in $(compgen -A variable | grep _CI_GITURL)
+do
+  DEV=${REPO_VAR%_CI_GITURL}
+  process_development $DEV
+done


### PR DESCRIPTION
It is useful for the release process, and there is no reason for somebody to lose time reimplementing it again.
