### PR TITLE
coq_makefile: ml4 -> mlg in usage (since ml4 files are rejected).

### DIFF
--- a/tools/coq_makefile.ml
+++ b/tools/coq_makefile.ml
@@ -34,7 +34,7 @@ let rec print_prefix_list sep = function
 let usage_coq_makefile () =
   output_string stderr "Usage summary:\
 \n\
-\ncoq_makefile .... [file.v] ... [file.ml[i4]?] ... [file.ml{lib,pack}]\
+\ncoq_makefile .... [file.v] ... [file.ml[ig]?] ... [file.ml{lib,pack}]\
 \n  ... [any] ... [-extra[-phony] result dependencies command]\
 \n  ... [-I dir] ... [-R physicalpath logicalpath]\
 \n  ... [-Q physicalpath logicalpath] ... [VARIABLE = value]\
@@ -45,7 +45,7 @@ let usage_coq_makefile () =
 \nFull list of options:\
 \n\
 \n[file.v]: Coq file to be compiled\
-\n[file.ml[i4]?]: Objective Caml file to be compiled\
+\n[file.ml[ig]?]: Objective Caml file to be compiled\
 \n[file.ml{lib,pack}]: ocamlbuild-style file that describes a Objective Caml\
 \n  library/module\
 \n[any] : subdirectory that should be \"made\" and has a Makefile itself\


### PR DESCRIPTION
**Kind:** bug fix

Fixes #11190, as told by @jasongross.

From 8.10, `coq_makefile` refuses to take `.ml4` files as arguments, but the usage is still referring to `.ml4`. We change usage so that it refers to `.mlg`.

Incidentally, the reference manual is sometimes referring to `CoqMakefile` (as obtained by `coq_makefile -f _CoqProject -o CoqMakefile` and sometimes referring to `Makefile`. It is a bit confusing and a choice should be made, I feel. Shall we try to use `Makefile` everywhere (so that there is no need to call `make` with option `-o CoqMakefile`)?

Relevant for 8.10.3 is there one, and otherwise to 8.11+beta.

- [ ] Entry to add in the changelog??

PS: I just finished porting a plugin to 8.10. The suggestions made by `@@ocaml.deprecated` are very useful and the doc for Coq changes is good. That's great.