### PR TITLE
Allow to override build date with SOURCE_DATE_EPOCH

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -152,6 +152,10 @@ INSTALLATION PROCEDURE IN DETAILS (NORMAL USERS).
 
         c.f. https://caml.inria.fr/mantis/view.php?id=7630
 
+   If you want your build to be reproducible, ensure that the
+   SOURCE_DATE_EPOCH environment variable is set as documented in
+   https://reproducible-builds.org/specs/source-date-epoch/
+
 4- Still in the root directory, do
 
 	make

--- a/configure.ml
+++ b/configure.ml
@@ -194,6 +194,12 @@ let which prog =
 let program_in_path prog =
   try let _ = which prog in true with Not_found -> false
 
+let build_date =
+  try
+    float_of_string (Sys.getenv "SOURCE_DATE_EPOCH")
+  with
+    Not_found -> Unix.time ()
+
 (** * Date *)
 
 (** The short one is displayed when starting coqtop,
@@ -204,7 +210,7 @@ let months =
     "July";"August";"September";"October";"November";"December" |]
 
 let get_date () =
-  let now = Unix.localtime (Unix.time ()) in
+  let now = Unix.gmtime build_date in
   let year = 1900+now.Unix.tm_year in
   let month = months.(now.Unix.tm_mon) in
   sprintf "%s %d" month year,

--- a/doc/changelog/11-infrastructure-and-dependencies/11227-date.rst
+++ b/doc/changelog/11-infrastructure-and-dependencies/11227-date.rst
@@ -1,0 +1,5 @@
+- **Added:**
+  Build date can now be overriden by setting the `SOURCE_DATE_EPOCH`
+  environment variable
+  (`#11227 <https://github.com/coq/coq/pull/11227>`_,
+  by Bernhard M. Wiedemann).


### PR DESCRIPTION
Allow to override build date with `SOURCE_DATE_EPOCH`
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.


<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** documentation / bug fix / feature / performance / infrastructure.


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #11037


<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [ ] Added / updated test-suite
<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [x] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).


This PR was done while working on reproducible builds for openSUSE.