### PR TITLE
[ci] Install `finmap` for CI users of `ssralg`

### DIFF
--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -21,6 +21,10 @@
 : "${oddorder_CI_GITURL:=https://github.com/math-comp/odd-order}"
 : "${oddorder_CI_ARCHIVEURL:=${oddorder_CI_GITURL}/archive}"
 
+: "${finmap_CI_REF:=master}"
+: "${finmap_CI_GITURL:=https://github.com/math-comp/finmap}"
+: "${finmap_CI_ARCHIVEURL:=${finmap_CI_GITURL}/archive}"
+
 ########################################################################
 # UniMath
 ########################################################################

--- a/dev/ci/ci-common.sh
+++ b/dev/ci/ci-common.sh
@@ -129,4 +129,8 @@ install_ssralg()
     make -C algebra && \
     make -C algebra install )
 
+  git_download finmap
+
+  ( cd "${CI_BUILD_DIR}/finmap" && make && make install )
+
 }


### PR DESCRIPTION
This broke for example GeoCoq; IMHO it is better to add finmap to all
scripts that require algebra as it will be merged soon into the main
repos IIUC.
