### PR TITLE
Remove latex files that should be regenerated by make

### DIFF
--- a/Makefile.doc
+++ b/Makefile.doc
@@ -71,7 +71,10 @@ refman-%: $(SPHINX_DEPS) doc/unreleased.rst
 	$(HIDE)$(SPHINXENV) $(SPHINXBUILD) -b $* \
 		$(ALLSPHINXOPTS) doc/sphinx $(SPHINXBUILDDIR)/$*
 
+COQREFMAN_FILES := $(wildcard $(SPHINXBUILDDIR)/latex/CoqRefMan*)
+LATEX_REMOVE_FILES := $(filter-out $(SPHINXBUILDDIR)/latex/CoqRefMan.tex, $(COQREFMAN_FILES))
 refman-pdf: refman-latex
+	rm -f $(LATEX_REMOVE_FILES)
 	+$(MAKE) -C $(SPHINXBUILDDIR)/latex
 
 refman: $(SPHINX_DEPS)


### PR DESCRIPTION
If these files are present in the latex directory, "make refman-pdf" may fail to generate CoqRefMan.pdf.  That may happen if someone runs this make more than once on their local machine.  Shouldn't affect CI.

Fixes / closes #11218 (first bullet point; 2nd-4th bullet points are just questions; last bullet point is still a problem but not something I can fix.  I do get a pdf file even with this message though the index and links are broken.)

Adding into 8.11, 8.11.1 or 8.12 would be fine.