### PR TITLE
Unfortunate Coq 8.10 bug with "cofix with" tactic syntax

### DIFF
--- a/doc/changelog/05-tactic-language/11241-master+bug-cofix-with-8.10.rst
+++ b/doc/changelog/05-tactic-language/11241-master+bug-cofix-with-8.10.rst
@@ -1,0 +1,4 @@
+- **Fixed:**
+  Syntax of tactic `cofix ... with ...` was broken from Coq 8.10.
+  (`#11241 <https://github.com/coq/coq/pull/11241>`_,
+  by Hugo Herbelin).

--- a/plugins/ltac/g_tactic.mlg
+++ b/plugins/ltac/g_tactic.mlg
@@ -135,7 +135,7 @@ let mk_cofix_tac (loc,id,bl,ann,ty) =
       ~hdr:"Constr:mk_cofix_tac"
       (Pp.str"Annotation forbidden in cofix expression.")) ann in
   let bl = List.map (fun (nal,bk,t) -> CLocalAssum (nal,bk,t)) bl in
-  (id,CAst.make ~loc @@ CProdN(bl,ty))
+  (id,if bl = [] then ty else CAst.make ~loc @@ CProdN(bl,ty))
 
 (* Functions overloaded by quotifier *)
 let destruction_arg_of_constr (c,lbind as clbind) = match lbind with

--- a/test-suite/success/RecTutorial.v
+++ b/test-suite/success/RecTutorial.v
@@ -1210,7 +1210,3 @@ Proof.
  constructor.
  trivial.
 Qed.
-
-
-
-

--- a/test-suite/success/cofixtac.v
+++ b/test-suite/success/cofixtac.v
@@ -1,0 +1,10 @@
+CoInductive stream :=
+| C : content -> stream
+with content :=
+| D : nat -> stream -> content.
+
+Lemma one : stream.
+cofix c with (d : content).
+- constructor. apply d.
+- constructor. exact 1. apply c.
+Defined.


### PR DESCRIPTION
Coq 8.10 added an internal invariant that `bl` is non empty is `CProdN(bl,c)`. Unfortunately, the `cofix with` tactic was not respecting this invariant.

This fixes the issue.

**Kind:**  bug fix

- [X] Added / updated test-suite
- [X] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).

May it be ported to 8.10?