### PR TITLE
Use standard float and integer datatypes in Votour representation.

### DIFF
--- a/checker/analyze.mli
+++ b/checker/analyze.mli
@@ -7,8 +7,8 @@ type data =
 
 type obj =
 | Struct of int * data array (* tag × data *)
-| Int63 of Uint63.t (* Primitive integer *)
-| Float64 of Float64.t (* Primitive float *)
+| Int64 of Int64.t (* Primitive integer *)
+| Float64 of float (* Primitive float *)
 | String of string
 
 module LargeArray :

--- a/checker/votour.ml
+++ b/checker/votour.ml
@@ -100,7 +100,7 @@ struct
             init_size seen (fun n -> fold (succ i) (accu + 1 + n) k) os.(i)
         in
         fold 0 1 (fun size -> let () = LargeArray.set !sizes p size in k size)
-      | Int63 _ -> k 0
+      | Int64 _ -> k 0
       | Float64 _ -> k 0
       | String s ->
         let size = 2 + (String.length s / ws) in
@@ -118,7 +118,7 @@ struct
   | Ptr p ->
     match LargeArray.get !memory p with
     | Struct (tag, os) -> BLOCK (tag, os)
-    | Int63 _ -> OTHER (* TODO: pretty-print int63 values *)
+    | Int64 _ -> OTHER (* TODO: pretty-print int63 values *)
     | Float64 _ -> OTHER (* TODO: pretty-print float64 values *)
     | String s -> STRING s
 


### PR DESCRIPTION
It seems this passed under my radar, but the change of implementation of the safe demarshaller introduced by native integers and floating point numbers is dangerous.

For floats, it makes the demarshaller depend on float kernel representation. This is just an alias to the standard OCaml float type, so this is currently not problematic, but this makes the code fragile if ever we decide to change it there. This would trigger unsound object casts without any complaint from the type-checker. Furthermore, having such a low-level library depend on the kernel library sounds like a anti-feature to me.

For native integers, the situation is direr. The demarshaller turns unconditionally 64-bits integers into their Int63 representation, which depends on the architecture. This means that when parsing vo files from a architecture where these types are not the same, we are guaranteed to get into unsound casts. Some of them *might* get caught by the value representation checker, yet it is a footgun. The demarshaller should only deal with OCaml representations and not try to mess with Coq specific data types, otherwise we are going to face desynchronization and thus unsound casts.