### PR TITLE
Fix #11254: "coqtop --version" working even in the middle of an installation process

### DIFF
--- a/doc/changelog/08-tools/11255-master+fix11254-coqtop-version.rst
+++ b/doc/changelog/08-tools/11255-master+fix11254-coqtop-version.rst
@@ -1,0 +1,4 @@
+- **Fixed:**
+  ``coqtop --version`` was broken when called in the middle of an installation process
+  (`#11255 <https://github.com/coq/coq/pull/11255>`_, by Hugo Herbelin, fixing
+  `#11254 <https://github.com/coq/coq/pull/11254>`_).


### PR DESCRIPTION
**Kind:** bug fix

Fixes #11254  

As a side remark, the semantics of the command line remains a bit unsatisfactory in general. For instance, is it obvious that we'd like `bin/coqtop -coqlib foo -where -coqlib bar` to return `bar`. I wonder if the list of options shouldn't be either clearly processed sequentially (like in a v-file) or, at worst, clearly preventing redundancy (see also #9585).

- [X] Entry added in the changelog
