### PR TITLE
[configure] [dune] Fix configure under Dune in 32bit builds.

### DIFF
--- a/config/dune
+++ b/config/dune
@@ -9,5 +9,9 @@
 (rule
  (targets coq_config.ml coq_config.py Makefile dune.c_flags)
  (mode fallback)
- (deps %{project_root}/configure.ml %{project_root}/dev/ocamldebug-coq.run (env_var COQ_CONFIGURE_PREFIX))
+ (deps
+   %{project_root}/configure.ml
+   %{project_root}/dev/ocamldebug-coq.run
+   %{project_root}/dev/header.c
+  (env_var COQ_CONFIGURE_PREFIX))
  (action (chdir %{project_root} (run %{ocaml} configure.ml -no-ask -native-compiler no))))


### PR DESCRIPTION
`dev/header.c` is not registered as a dependency, so the configure
step under dune fails in 32bit builds.

Note we didn't detect the problem earlier due to dubious code in configure
ignoring stderr messages on process calls.
