### PR TITLE
[micromega] fix efficiency regression

### DIFF
--- a/doc/changelog/04-tactics/11263-micromega-fix.rst
+++ b/doc/changelog/04-tactics/11263-micromega-fix.rst
@@ -1,0 +1,6 @@
+- **Fixed**
+  Efficiency regression introduced by  PR `#9725 <https://github.com/coq/coq/pull/9725>`_.
+  (`#11263 <https://github.com/coq/coq/pull/11263>`_,
+  fixes `#11063 <https://github.com/coq/coq/issues/11063>`_,
+  and `#11242 <https://github.com/coq/coq/issues/11242>`_,
+  and `#11270 <https://github.com/coq/coq/issues/11270>`_, by Frédéric Besson).

--- a/doc/stdlib/hidden-files
+++ b/doc/stdlib/hidden-files
@@ -24,6 +24,7 @@ plugins/extraction/Extraction.v
 plugins/funind/FunInd.v
 plugins/funind/Recdef.v
 plugins/ltac/Ltac.v
+plugins/micromega/Ztac.v
 plugins/micromega/DeclConstant.v
 plugins/micromega/Env.v
 plugins/micromega/EnvRing.v

--- a/plugins/micromega/Lia.v
+++ b/plugins/micromega/Lia.v
@@ -23,28 +23,13 @@ Require Coq.micromega.Tauto.
 Declare ML Module "micromega_plugin".
 
 
-Ltac zchange checker :=
+Ltac zchecker :=
   intros __wit __varmap __ff ;
-  change (@Tauto.eval_bf _ (Zeval_formula (@find Z Z0 __varmap)) __ff) ;
-  apply (checker __ff __wit).
-
-Ltac zchecker_no_abstract checker :=
-  zchange checker ; vm_compute ; reflexivity.
-
-Ltac zchecker_abstract checker :=
-  abstract (zchange checker ; vm_cast_no_check (eq_refl true)).
-
-Ltac zchecker := zchecker_no_abstract ZTautoChecker_sound.
-
-(*Ltac zchecker_ext := zchecker_no_abstract ZTautoCheckerExt_sound.*)
-
-Ltac zchecker_ext :=
-  intros __wit __varmap __ff ;
-  exact (ZTautoCheckerExt_sound __ff __wit
-                                (@eq_refl bool true <: @eq bool (ZTautoCheckerExt __ff __wit) true)
+  exact (ZTautoChecker_sound __ff __wit
+                                (@eq_refl bool true <: @eq bool (ZTautoChecker __ff __wit) true)
                                 (@find Z Z0 __varmap)).
 
-Ltac lia := PreOmega.zify; xlia zchecker_ext.
+Ltac lia := PreOmega.zify; xlia zchecker.
                
 Ltac nia := PreOmega.zify; xnlia zchecker.
 

--- a/plugins/micromega/MExtraction.v
+++ b/plugins/micromega/MExtraction.v
@@ -56,7 +56,7 @@ Extract Constant Rinv   => "fun x -> 1 / x".
 (*Extraction "micromega.ml"
            Tauto.mapX Tauto.foldA Tauto.collect_annot Tauto.ids_of_formula Tauto.map_bformula
            Tauto.abst_form
-           ZMicromega.cnfZ ZMicromega.bound_problem_fr ZMicromega.Zeval_const QMicromega.cnfQ
+           ZMicromega.cnfZ  ZMicromega.Zeval_const QMicromega.cnfQ
            List.map simpl_cone (*map_cone  indexes*)
            denorm Qpower vm_add
    normZ normQ normQ n_of_Z N.of_nat ZTautoChecker ZWeakChecker QTautoChecker RTautoChecker find.

--- a/plugins/micromega/RMicromega.v
+++ b/plugins/micromega/RMicromega.v
@@ -17,12 +17,12 @@
 Require Import OrderedRing.
 Require Import RingMicromega.
 Require Import Refl.
-Require Import Raxioms Rfunctions RIneq Rpow_def DiscrR.
+Require Import Raxioms Rfunctions RIneq Rpow_def.
 Require Import QArith.
 Require Import Qfield.
 Require Import Qreals.
 Require Import DeclConstant.
-Require Import Lia.
+Require Import Ztac.
 
 Require Setoid.
 (*Declare ML Module "micromega_plugin".*)
@@ -334,15 +334,16 @@ Proof.
       apply Qeq_bool_eq in C2.
       rewrite C2.
       simpl.
-      rewrite Qpower0 by lia.
+      rewrite Qpower0.
       apply Q2R_0.
+      intro ; subst ; slia C1 C1.
     + rewrite Q2RpowerRZ.
       rewrite IHc.
       reflexivity.
       rewrite andb_false_iff in C.
       destruct C.
       simpl. apply Z.ltb_ge in H.
-      lia.
+      right ; normZ. slia H H0.
       left ; apply Qeq_bool_neq; auto.
     + simpl.
       rewrite <- IHc.

--- a/plugins/micromega/RingMicromega.v
+++ b/plugins/micromega/RingMicromega.v
@@ -856,7 +856,7 @@ Proof.
       simpl.
       tauto.
     +
-      rewrite <- eval_cnf_cons_iff with (1:= fun env (term:Formula Z) => True) .
+      rewrite <- eval_cnf_cons_iff.
       simpl.
       unfold eval_tt. simpl.
       rewrite IHl.
@@ -940,7 +940,7 @@ Proof.
   destruct (check_inconsistent f) eqn:U.
   - destruct f as [e op].
     assert (US := check_inconsistent_sound _ _ U env).
-    rewrite eval_cnf_ff with (1:= eval_nformula).
+    rewrite eval_cnf_ff.
     tauto.
   - intros. rewrite cnf_of_list_correct.
     now apply xnormalise_correct.
@@ -956,7 +956,7 @@ Proof.
   -
     destruct f as [e o].
     assert (US := check_inconsistent_sound _  _ U env).
-    rewrite eval_cnf_tt with (1:= eval_nformula).
+    rewrite eval_cnf_tt.
     tauto.
   - rewrite cnf_of_list_correct.
     apply xnegate_correct.

--- a/plugins/micromega/Tauto.v
+++ b/plugins/micromega/Tauto.v
@@ -938,8 +938,6 @@ Section S.
       Qed.
 
 
-    Variable eval  : Env -> Term -> Prop.
-
     Variable eval'  : Env -> Term' -> Prop.
 
     Variable no_middle_eval' : forall env d, (eval' env d) \/ ~ (eval' env d).
@@ -1202,7 +1200,7 @@ Section S.
   Qed.
 
 
-
+  Variable eval  : Env -> Term -> Prop.
 
   Variable normalise_correct : forall env t tg, eval_cnf  env (normalise t tg) -> eval env t.
 

--- a/plugins/micromega/Ztac.v
+++ b/plugins/micromega/Ztac.v
@@ -1,0 +1,140 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *   INRIA, CNRS and contributors - Copyright 1999-2019       *)
+(* <O___,, *       (see CREDITS file for the list of authors)           *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+(** Tactics for doing arithmetic proofs.
+    Useful to bootstrap lia.
+ *)
+
+Require Import ZArithRing.
+Require Import ZArith_base.
+Local Open Scope Z_scope.
+
+Lemma eq_incl :
+  forall (x y:Z), x = y -> x <= y /\ y <= x.
+Proof.
+  intros; split;
+  apply Z.eq_le_incl; auto.
+Qed.
+
+Lemma elim_concl_eq :
+  forall x y, (x < y \/ y < x -> False) -> x = y.
+Proof.
+  intros.
+  destruct (Z_lt_le_dec x y).
+  exfalso. apply H ; auto.
+  destruct (Zle_lt_or_eq y x);auto.
+  exfalso.
+  apply H ; auto.
+Qed.
+
+Lemma elim_concl_le :
+  forall x y, (y < x -> False) -> x <= y.
+Proof.
+  intros.
+  destruct (Z_lt_le_dec y x).
+  exfalso ; auto.
+  auto.
+Qed.
+
+Lemma elim_concl_lt :
+  forall x y, (y <= x -> False) -> x < y.
+Proof.
+  intros.
+  destruct (Z_lt_le_dec x y).
+  auto.
+  exfalso ; auto.
+Qed.
+
+
+
+Lemma Zlt_le_add_1 : forall n m : Z, n < m -> n + 1 <= m.
+Proof. exact (Zlt_le_succ). Qed.
+
+
+Ltac normZ :=
+  repeat
+  match goal with
+  | H : _ < _ |- _ =>  apply Zlt_le_add_1 in H
+  | H : ?Y <= _ |- _ =>
+    lazymatch Y with
+    | 0 => fail
+    | _ => apply Zle_minus_le_0 in H
+    end
+  | H : _ >= _ |- _ => apply Z.ge_le in H
+  | H : _ > _  |- _ => apply Z.gt_lt in H
+  | H : _ = _  |- _ => apply eq_incl in H ; destruct H
+  | |- @eq Z _ _  => apply elim_concl_eq ; let H := fresh "HZ" in intros [H|H]
+  | |- _ <= _ => apply elim_concl_le ; intros
+  | |- _ < _ => apply elim_concl_lt ; intros
+  | |- _ >= _ => apply Z.le_ge
+  end.
+
+
+Inductive proof :=
+| Hyp (e : Z) (prf : 0 <= e)
+| Add (p1 p2: proof)
+| Mul (p1 p2: proof)
+| Cst (c : Z)
+.
+
+Lemma add_le : forall e1 e2, 0 <= e1 -> 0 <= e2 -> 0 <= e1+e2.
+Proof.
+  intros.
+  change 0 with (0+ 0).
+  apply Z.add_le_mono; auto.
+Qed.
+
+Lemma mul_le : forall e1 e2, 0 <= e1 -> 0 <= e2 -> 0 <= e1*e2.
+Proof.
+  intros.
+  change 0 with (0* e2).
+  apply Zmult_le_compat_r; auto.
+Qed.
+
+Fixpoint eval_proof (p : proof) : { e : Z | 0 <= e} :=
+  match p with
+  | Hyp e prf => exist _ e prf
+  | Add p1 p2 => let (e1,p1) := eval_proof p1 in
+                 let (e2,p2) := eval_proof p2 in
+                 exist _ _ (add_le _ _ p1 p2)
+  | Mul p1 p2  => let (e1,p1) := eval_proof p1 in
+                 let (e2,p2) := eval_proof p2 in
+                 exist _ _ (mul_le _ _ p1 p2)
+  | Cst c      =>  match Z_le_dec 0 c with
+                   | left prf => exist _ _ prf
+                   |  _       => exist _ _ Z.le_0_1
+                 end
+  end.
+
+Ltac lia_step p :=
+  let H := fresh in
+  let prf := (eval cbn - [Z.le Z.mul Z.opp Z.sub Z.add] in (eval_proof p)) in
+  match prf with
+  | @exist _ _ _ ?P =>  pose proof P as H
+  end ; ring_simplify in H.
+
+Ltac lia_contr :=
+  match goal with
+  | H : 0 <= - (Zpos _) |- _ =>
+    rewrite <- Z.leb_le in H;
+    compute in H ; discriminate
+  | H : 0 <= (Zneg _) |- _ =>
+    rewrite <- Z.leb_le in H;
+    compute in H ; discriminate
+  end.
+
+
+Ltac lia p :=
+  lia_step p ; lia_contr.
+
+Ltac slia H1 H2 :=
+  normZ ; lia (Add (Hyp _ H1) (Hyp _ H2)).
+
+Arguments Hyp {_} prf.

--- a/plugins/micromega/micromega.mli
+++ b/plugins/micromega/micromega.mli
@@ -47,6 +47,8 @@ module Coq_Pos : sig
   val size_nat : positive -> nat
   val compare_cont : comparison -> positive -> positive -> comparison
   val compare : positive -> positive -> comparison
+  val max : positive -> positive -> positive
+  val leb : positive -> positive -> bool
   val gcdn : nat -> positive -> positive -> positive
   val gcd : positive -> positive -> positive
   val of_succ_nat : nat -> positive
@@ -624,10 +626,6 @@ val simpl_cone :
   -> 'a1 psatz
   -> 'a1 psatz
 
-module PositiveSet : sig
-  type tree = Leaf | Node of tree * bool * tree
-end
-
 type q = {qnum : z; qden : positive}
 
 val qeq_bool : q -> q -> bool
@@ -672,6 +670,7 @@ type zArithProof =
   | RatProof of zWitness * zArithProof
   | CutProof of zWitness * zArithProof
   | EnumProof of zWitness * zWitness * zArithProof list
+  | ExProof of positive * zArithProof
 
 val zgcdM : z -> z -> z
 val zgcd_pol : z polC -> z * z
@@ -682,40 +681,10 @@ val nformula_of_cutting_plane : (z polC * z) * op1 -> z nFormula
 val is_pol_Z0 : z polC -> bool
 val eval_Psatz0 : z nFormula list -> zWitness -> z nFormula option
 val valid_cut_sign : op1 -> bool
-
-module Vars : sig
-  type elt = positive
-  type tree = PositiveSet.tree = Leaf | Node of tree * bool * tree
-  type t = tree
-
-  val empty : t
-  val add : elt -> t -> t
-  val singleton : elt -> t
-  val union : t -> t -> t
-  val rev_append : elt -> elt -> elt
-  val rev : elt -> elt
-  val xfold : (elt -> 'a1 -> 'a1) -> t -> 'a1 -> elt -> 'a1
-  val fold : (elt -> 'a1 -> 'a1) -> t -> 'a1 -> 'a1
-end
-
-val vars_of_pexpr : z pExpr -> Vars.t
-val vars_of_formula : z formula -> Vars.t
-val vars_of_bformula : (z formula, 'a1, 'a2, 'a3) gFormula -> Vars.t
 val bound_var : positive -> z formula
 val mk_eq_pos : positive -> positive -> positive -> z formula
-
-val bound_vars :
-     (positive -> positive -> bool option -> 'a2)
-  -> positive
-  -> Vars.t
-  -> (z formula, 'a1, 'a2, 'a3) gFormula
-
-val bound_problem_fr :
-     (positive -> positive -> bool option -> 'a2)
-  -> positive
-  -> (z formula, 'a1, 'a2, 'a3) gFormula
-  -> (z formula, 'a1, 'a2, 'a3) gFormula
-
+val max_var : positive -> z pol -> positive
+val max_var_nformulae : z nFormula list -> positive
 val zChecker : z nFormula list -> zArithProof -> bool
 val zTautoChecker : z formula bFormula -> zArithProof list -> bool
 

--- a/plugins/micromega/mutils.ml
+++ b/plugins/micromega/mutils.ml
@@ -294,7 +294,7 @@ end
   *)
 
 module type Tag = sig
-  type t
+  type t = int
 
   val from : int -> t
   val next : t -> t
@@ -319,7 +319,9 @@ end
   * MODULE: Ordered sets of tags.
   *)
 
-module TagSet = Set.Make (Tag)
+module TagSet = struct
+  include Set.Make (Tag)
+end
 
 (** As for Unix.close_process, our Unix.waipid will ignore all EINTR *)
 

--- a/plugins/micromega/polynomial.mli
+++ b/plugins/micromega/polynomial.mli
@@ -23,6 +23,9 @@ module Monomial : sig
   (** [fold f m acc]
        folds over the variables with multiplicities *)
 
+  val degree : t -> int
+  (** [degree m] is the sum of the degrees of each variable *)
+
   val const : t
   (** [const]
       @return the empty monomial i.e. without any variable *)
@@ -32,6 +35,10 @@ module Monomial : sig
   val var : var -> t
   (** [var x]
       @return the monomial x^1 *)
+
+  val prod : t -> t -> t
+  (** [prod n m]
+      @return the monomial n*m *)
 
   val sqrt : t -> t option
   (** [sqrt m]
@@ -142,6 +149,12 @@ module LinPoly : sig
     val clear : unit -> unit
     (** [clear ()] clears the mapping. *)
 
+    val reserve : int -> unit
+    (** [reserve i] reserves the integer i *)
+
+    val get_fresh : unit -> int
+    (** [get_fresh ()] return the first fresh variable *)
+
     val retrieve : int -> Monomial.t
     (** [retrieve x]
         @return the monomial corresponding to the variable [x] *)
@@ -225,6 +238,14 @@ module LinPoly : sig
       @return a mapping m such that m[s] = s^2
       for every s^2 that is a monomial of [p] *)
 
+  val monomials : t -> ISet.t
+  (** [monomials p]
+      @return the set of monomials. *)
+
+  val degree : t -> int
+  (** [degree p]
+      @return return the maximum degree *)
+
   val pp_var : out_channel -> var -> unit
   (** [pp_var o v] pretty-prints a monomial indexed by v. *)
 
@@ -260,6 +281,9 @@ module ProofFormat : sig
     | Done
     | Step of int * prf_rule * proof
     | Enum of int * prf_rule * Vect.t * prf_rule * proof list
+    | ExProof of int * int * int * var * var * var * proof
+
+  (* x = z - t, z >= 0, t >= 0 *)
 
   val pr_size : prf_rule -> Num.num
   val pr_rule_max_id : prf_rule -> int

--- a/plugins/micromega/vect.mli
+++ b/plugins/micromega/vect.mli
@@ -25,6 +25,8 @@ type t
            are not represented.
         *)
 
+type vector = t
+
 (** {1 Generic functions}  *)
 
 (** [hash] [equal] and [compare] so that Vect.t can be used as
@@ -135,6 +137,9 @@ val mul : num -> t -> t
 val mul_add : num -> t -> num -> t -> t
 (** [mul_add c1 v1 c2 v2] returns the linear combination c1.v1+c2.v2 *)
 
+val subst : int -> t -> t -> t
+(** [subst x v v'] replaces x by v in vector v' *)
+
 val div : num -> t -> t
 (** [div c1 v1] returns the mutiplication by the inverse of c1 i.e (1/c1).v1 *)
 
@@ -170,3 +175,10 @@ val dotproduct : t -> t -> num
 val map : (var -> num -> 'a) -> t -> 'a list
 val abs_min_elt : t -> (var * num) option
 val partition : (var -> num -> bool) -> t -> t * t
+
+module Bound : sig
+  type t = {cst : num; var : var; coeff : num}
+  (** represents a0 + ai.xi  *)
+
+  val of_vect : vector -> t option
+end

--- a/test-suite/micromega/bug_11270.v
+++ b/test-suite/micromega/bug_11270.v
@@ -1,0 +1,6 @@
+Require Import Psatz.
+Theorem foo : forall a b, 1 <= S (a + a * S b).
+Proof.
+intros.
+lia.
+Qed.

--- a/test-suite/output/MExtraction.v
+++ b/test-suite/output/MExtraction.v
@@ -1,6 +1,6 @@
 (************************************************************************)
 (*         *   The Coq Proof Assistant / The Coq Development Team       *)
-(*  v      *   INRIA, CNRS and contributors - Copyright 1999-2018       *)
+(*  v      *   INRIA, CNRS and contributors - Copyright 1999-2019       *)
 (* <O___,, *       (see CREDITS file for the list of authors)           *)
 (*   \VV/  **************************************************************)
 (*    //   *    This file is distributed under the terms of the         *)
@@ -56,10 +56,11 @@ Extract Constant Rinv   => "fun x -> 1 / x".
 Recursive Extraction
            Tauto.mapX Tauto.foldA Tauto.collect_annot Tauto.ids_of_formula Tauto.map_bformula
            Tauto.abst_form
-           ZMicromega.cnfZ ZMicromega.bound_problem_fr ZMicromega.Zeval_const QMicromega.cnfQ
+           ZMicromega.cnfZ  ZMicromega.Zeval_const QMicromega.cnfQ
            List.map simpl_cone (*map_cone  indexes*)
            denorm Qpower vm_add
    normZ normQ normQ n_of_Z N.of_nat ZTautoChecker ZWeakChecker QTautoChecker RTautoChecker find.
+
 (* Local Variables: *)
 (* coding: utf-8 *)
 (* End: *)

--- a/theories/MSets/MSetEqProperties.v
+++ b/theories/MSets/MSetEqProperties.v
@@ -18,6 +18,8 @@
     [equal s s'=true] instead of [Equal s s'], etc. *)
 
 Require Import MSetProperties Zerob Sumbool Lia DecidableTypeEx.
+Require  FSetEqProperties.
+
 
 Module WEqPropertiesOn (Import E:DecidableType)(M:WSetsOn E).
 Module Import MP := WPropertiesOn E M.
@@ -857,7 +859,7 @@ intros.
 rewrite <- (fold_equal _ _ _ _ fc ft 0 _ _ H).
 rewrite <- (fold_equal _ _ _ _ gc gt 0 _ _ H).
 rewrite <- (fold_equal _ _ _ _ fgc fgt 0 _ _ H); auto.
-intros. do 3 (rewrite fold_add; auto with fset). lia.
+intros. do 3 (rewrite fold_add by auto with fset). lia.
 do 3 rewrite fold_empty;auto.
 Qed.
 

--- a/theories/QArith/Qreals.v
+++ b/theories/QArith/Qreals.v
@@ -8,7 +8,7 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-Require Export Rbase.
+Require Import Rdefinitions Raxioms RIneq.
 Require Export QArith_base.
 
 (** Injection of rational numbers into real numbers. *)
@@ -48,7 +48,7 @@ set (Y1 := IZR y1) in *; assert (Y2nz := IZR_nz y2);
  set (Y2 := IZR (Zpos y2)) in *.
 assert ((X1 * Y2)%R = (Y1 * X2)%R).
  unfold X1, X2, Y1, Y2; do 2 rewrite <- mult_IZR.
- apply IZR_eq; auto.
+f_equal; auto.
 clear H.
 field_simplify_eq; auto.
 rewrite H0; ring.

--- a/theories/Reals/ArithProp.v
+++ b/theories/Reals/ArithProp.v
@@ -8,7 +8,7 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-Require Import Rbase.
+Require Import Rdefinitions Raxioms RIneq.
 Require Import Rbasic_fun.
 Require Import Even.
 Require Import Div2.
@@ -85,7 +85,7 @@ Proof.
   assert (H1 := le_INR _ _ H).
   do 2 rewrite mult_INR in H1.
   apply Rmult_le_reg_l with (INR 2).
-  replace (INR 2) with 2; [ prove_sup0 | reflexivity ].
+  apply lt_0_INR. apply Nat.lt_0_2.
   assumption.
 Qed.
 

--- a/theories/Reals/RIneq.v
+++ b/theories/Reals/RIneq.v
@@ -19,7 +19,7 @@ Require Export Raxioms.
 Require Import Rpow_def.
 Require Import Zpower.
 Require Export ZArithRing.
-Require Import Lia.
+Require Import Ztac.
 Require Export RealField.
 
 Local Open Scope Z_scope.
@@ -1875,7 +1875,7 @@ Lemma eq_IZR : forall n m:Z, IZR n = IZR m -> n = m.
 Proof.
   intros z1 z2 H; generalize (Rminus_diag_eq (IZR z1) (IZR z2) H);
     rewrite (Z_R_minus z1 z2); intro; generalize (eq_IZR_R0 (z1 - z2) H0);
-      intro; lia.
+      apply Zminus_eq.
 Qed.
 
 (**********)
@@ -1913,21 +1913,24 @@ Qed.
 Lemma IZR_ge : forall n m:Z, (n >= m)%Z -> IZR n >= IZR m.
 Proof.
   intros m n H; apply Rnot_lt_ge; red; intro.
-  generalize (lt_IZR m n H0); intro; lia.
+  generalize (lt_IZR m n H0); intro.
+  slia H H1.
 Qed.
 
 Lemma IZR_le : forall n m:Z, (n <= m)%Z -> IZR n <= IZR m.
 Proof.
   intros m n H; apply Rnot_gt_le; red; intro.
-  unfold Rgt in H0; generalize (lt_IZR n m H0); intro; lia.
+  unfold Rgt in H0; generalize (lt_IZR n m H0); intro.
+  slia H H1.
 Qed.
 
 Lemma IZR_lt : forall n m:Z, (n < m)%Z -> IZR n < IZR m.
 Proof.
   intros m n H; cut (m <= n)%Z.
   intro H0; elim (IZR_le m n H0); intro; auto.
-  generalize (eq_IZR m n H1); intro; exfalso; lia.
-  lia.
+  generalize (eq_IZR m n H1); intro; exfalso.
+  slia H H3.
+  normZ. slia H H0.
 Qed.
 
 Lemma IZR_neq : forall z1 z2:Z, z1 <> z2 -> IZR z1 <> IZR z2.
@@ -1954,7 +1957,7 @@ Lemma one_IZR_r_R1 :
   forall r (n m:Z), r < IZR n <= r + 1 -> r < IZR m <= r + 1 -> n = m.
 Proof.
   intros r z x [H1 H2] [H3 H4].
-  cut ((z - x)%Z = 0%Z). lia.
+  apply Zminus_eq.
   apply one_IZR_lt1.
   rewrite <- Z_R_minus; split.
   replace (-1) with (r - (r + 1)).

--- a/theories/Reals/R_Ifp.v
+++ b/theories/Reals/R_Ifp.v
@@ -13,8 +13,8 @@
 (*                                                        *)
 (**********************************************************)
 
-Require Import Rbase.
-Require Import Lia.
+Require Import Rdefinitions Raxioms RIneq.
+Require Import Ztac.
 Local Open Scope R_scope.
 
 (*********************************************************)
@@ -60,7 +60,7 @@ Proof.
   apply lt_IZR in H1.
   rewrite <- minus_IZR in H2.
   apply le_IZR in H2.
-  lia.
+  normZ. slia H2 HZ. slia H1 HZ.
 Qed.
 
 (**********)
@@ -229,8 +229,8 @@ Proof.
                                                                                                                     rewrite (Z_R_minus (Int_part r1) (Int_part r2)) in H.
     rewrite <- (plus_IZR (Int_part r1 - Int_part r2) 1) in H;
       generalize (up_tech (r1 - r2) (Int_part r1 - Int_part r2) H0 H);
-        intros; clear H H0; unfold Int_part at 1;
-          lia.
+        intros; clear H H0; unfold Int_part at 1.
+    normZ. slia H HZ. slia H0 HZ.
 Qed.
 
 (**********)
@@ -322,8 +322,8 @@ Proof.
           generalize (Rlt_le (IZR (Int_part r1 - Int_part r2 - 1)) (r1 - r2) H);
             intro; clear H;
               generalize (up_tech (r1 - r2) (Int_part r1 - Int_part r2 - 1) H1 H0);
-                intros; clear H0 H1; unfold Int_part at 1;
-                  lia.
+                intros; clear H0 H1; unfold Int_part at 1.
+  normZ.  slia H HZ. slia H0 HZ.
 Qed.
 
 (**********)
@@ -437,7 +437,8 @@ Proof.
           rewrite <- (plus_IZR (Int_part r1 + Int_part r2) 1) in H0;
             rewrite <- (plus_IZR (Int_part r1 + Int_part r2 + 1) 1) in H0;
               generalize (up_tech (r1 + r2) (Int_part r1 + Int_part r2 + 1) H H0);
-                intro; clear H H0; unfold Int_part at 1; lia.
+              intro; clear H H0; unfold Int_part at 1.
+    normZ. slia H HZ. slia H0 HZ.
 Qed.
 
 (**********)
@@ -498,8 +499,8 @@ Proof.
       rewrite <- (plus_IZR (Int_part r1) (Int_part r2)) in H1;
         rewrite <- (plus_IZR (Int_part r1 + Int_part r2) 1) in H1;
           generalize (up_tech (r1 + r2) (Int_part r1 + Int_part r2) H0 H1);
-            intro; clear H0 H1; unfold Int_part at 1;
-              lia.
+            intro; clear H0 H1; unfold Int_part at 1.
+    normZ. slia H HZ. slia H0 HZ.
 Qed.
 
 (**********)

--- a/theories/Reals/R_sqr.v
+++ b/theories/Reals/R_sqr.v
@@ -8,7 +8,7 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-Require Import Rbase.
+Require Import Rdefinitions Raxioms RIneq.
 Require Import Rbasic_fun.
 Local Open Scope R_scope.
 

--- a/theories/Reals/Rbasic_fun.v
+++ b/theories/Reals/Rbasic_fun.v
@@ -13,7 +13,7 @@
 (*                                                       *)
 (*********************************************************)
 
-Require Import Rbase.
+Require Import Rdefinitions Raxioms RIneq.
 Require Import R_Ifp.
 Local Open Scope R_scope.
 

--- a/theories/Reals/Rfunctions.v
+++ b/theories/Reals/Rfunctions.v
@@ -17,7 +17,7 @@
 (********************************************************)
 Require Export ArithRing.
 
-Require Import Rbase.
+Require Import Rdefinitions Raxioms RIneq.
 Require Export Rpow_def.
 Require Export R_Ifp.
 Require Export Rbasic_fun.
@@ -25,8 +25,8 @@ Require Export R_sqr.
 Require Export SplitAbsolu.
 Require Export SplitRmult.
 Require Export ArithProp.
-Require Import Lia.
 Require Import Zpower.
+Require Import Ztac.
 Local Open Scope nat_scope.
 Local Open Scope R_scope.
 
@@ -122,7 +122,7 @@ Hint Resolve pow_lt: real.
 Lemma Rlt_pow_R1 : forall (x:R) (n:nat), 1 < x -> (0 < n)%nat -> 1 < x ^ n.
 Proof.
   intros x n; elim n; simpl; auto with real.
-  intros H' H'0; exfalso; lia.
+  intros H' H'0; exfalso. apply (Nat.lt_irrefl 0); assumption.
   intros n0; case n0.
   simpl; rewrite Rmult_1_r; auto.
   intros n1 H' H'0 H'1.
@@ -262,14 +262,14 @@ Proof.
   elim (IZN (up (b * / (Rabs x - 1))) H2); intros; exists x0;
     apply
       (Rge_trans (INR x0) (IZR (up (b * / (Rabs x - 1)))) (b * / (Rabs x - 1))).
-  rewrite INR_IZR_INZ; apply IZR_ge; lia.
+  rewrite INR_IZR_INZ; apply IZR_ge. normZ. slia H3 H5.
   unfold Rge; left; assumption.
   exists 0%nat;
     apply
       (Rge_trans (INR 0) (IZR (up (b * / (Rabs x - 1)))) (b * / (Rabs x - 1))).
-  rewrite INR_IZR_INZ; apply IZR_ge; simpl; lia.
+  rewrite INR_IZR_INZ; apply IZR_ge; simpl. normZ. slia H2 H3.
   unfold Rge; left; assumption.
-  lia.
+  apply Z.le_ge_cases.
 Qed.
 
 Lemma pow_ne_zero : forall n:nat, n <> 0%nat -> 0 ^ n = 0.
@@ -745,7 +745,8 @@ Proof.
   - now simpl; rewrite Rmult_1_l.
   - now rewrite <- !pow_powerRZ, Rpow_mult_distr.
   - destruct Hmxy as [H|H].
-    + assert(m = 0) as -> by now lia.
+    + assert(m = 0) as -> by
+      (destruct n; [assumption| subst; simpl in H; lia_contr]).
       now rewrite <- Hm, Rmult_1_l.
     + assert(x0 <> 0)%R by now intros ->; apply H; rewrite Rmult_0_l.
       assert(y0 <> 0)%R by now intros ->; apply H; rewrite Rmult_0_r.
@@ -808,7 +809,7 @@ Proof.
   ring.
   rewrite Rmult_plus_distr_r; rewrite Hrecn; cut ((n + 1)%nat = S n).
   intro H; rewrite H; simpl; ring.
-  lia.
+  apply Nat.add_1_r.
 Qed.
 
 Lemma sum_f_R0_triangle :

--- a/theories/Reals/SplitRmult.v
+++ b/theories/Reals/SplitRmult.v
@@ -11,7 +11,7 @@
 (*i Lemma mult_non_zero :(r1,r2:R)``r1<>0`` /\ ``r2<>0`` -> ``r1*r2<>0``. i*)
 
 
-Require Import Rbase.
+Require Import Rdefinitions Raxioms RIneq.
 
 Ltac split_Rmult :=
   match goal with


### PR DESCRIPTION
PR #9725 fixes completness bugs introduces some inefficiency. The
current PR intends to fix the inefficiency while retaining
completness. The fix removes a pre-processing step and instead relies
on a more elaborate proof format introducing positivity constraints on
the fly.

Solve bootstrapping issues: RMicromega <-> Rbase <-> lia.

Fixes #11063 and fixes #11242 
