### PR TITLE
Type safe summary & libobject implementation

### DIFF
--- a/library/summary.mli
+++ b/library/summary.mli
@@ -63,7 +63,7 @@ end
     because its unfreeze may load ML code and hence add summary
     entries.  Thus is has to be recognizable, and handled properly.
    *)
-val declare_ml_modules_summary : 'a summary_declaration -> unit
+val declare_ml_modules_summary : (string * string option) list summary_declaration -> unit
 
 (** For global tables registered statically before the end of coqtop
     launch, the following empty [init_function] could be used. *)


### PR DESCRIPTION
For historical reasons we were wrapping the data stored in the summary & libobject values with dynamic type casts. There is no reason to do so since we have a proper Dyn API. Furthermore, this had a small runtime cost when we knew that it was never going to fail.

This also reduces the number of loc and removes useless type declarations.