### PR TITLE
dune: Add byte mode for coqchk and coqide (fix dune-dbg for dune 2)

### DIFF
--- a/checker/dune
+++ b/checker/dune
@@ -12,6 +12,7 @@
 (executable
  (name coqchk)
  (public_name coqchk)
+ (modes exe byte)
  (package coq)
  (modules coqchk)
  (flags :standard -open Coq_checklib)

--- a/ide/dune
+++ b/ide/dune
@@ -48,6 +48,7 @@
  (package coqide)
  (optional)
  (modules coqide_main)
+ (modes exe byte)
  (libraries coqide_gui))
 
 ; Input-method bindings


### PR DESCRIPTION
dune-dbg depends on coqchk.bc and coqide_main.bc, and apparently they
now need explicit modes to be produced.