### PR TITLE
Fixing #10750: "Print Visibility" raises Not_found on only-printing notations

### DIFF
--- a/doc/changelog/03-notations/11276-master+fix10750.rst
+++ b/doc/changelog/03-notations/11276-master+fix10750.rst
@@ -1,0 +1,4 @@
+- **Fixed:**
+  :cmd:`Print Visibility` was failing in the presence of only-printing notations
+  (`#11276 <https://github.com/coq/coq/pull/11276>`_,
+  by Hugo Herbelin, fixing `#10750 <https://github.com/coq/coq/pull/10750>`_).

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -1872,6 +1872,7 @@ let collect_notations stack =
       | SingleNotation ntn ->
           if List.mem_f notation_eq ntn knownntn then (all,knownntn)
           else
+          try
             let { not_interp  = (_, r); not_location = (_, df) } =
               NotationMap.find ntn (find_scope default_scope).notations in
             let all' = match all with
@@ -1879,7 +1880,8 @@ let collect_notations stack =
                   (s,(df,r)::lonelyntn)::rest
               | _ ->
                   (default_scope,[df,r])::all in
-            (all',ntn::knownntn))
+            (all',ntn::knownntn)
+          with Not_found -> (* e.g. if only printing *) (all,knownntn))
     ([],[]) stack)
 
 let pr_visible_in_scope prglob (scope,ntns) =

--- a/test-suite/success/Notations2.v
+++ b/test-suite/success/Notations2.v
@@ -165,3 +165,10 @@ Notation "# x ## t & u" := ((fun x => (x,t)),(fun x => (x,u))) (at level 0, x pa
 Check fun y : nat => # (x,z) ## y & y.
 
 End M17.
+
+Module Bug10750.
+
+Notation "#" := 0 (only printing).
+Print Visibility.
+
+End Bug10750.


### PR DESCRIPTION

**Kind:** bug fix

Fixes / closes #10750

This is a minimal fix. A better support for only-parsing / only-printing notations could be done. #10832 would help for that.

- [X] Added / updated test-suite
- [X] Entry added in the changelog