### PR TITLE
Fix #11195 and add other improvements: try loading .vio (and not just…

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -840,7 +840,7 @@ theories/Init/%.vo theories/Init/%.glob: theories/Init/%.v $(VO_TOOLS_DEP)
 
 theories/Init/%.vio: theories/Init/%.v $(VO_TOOLS_DEP)
 	$(SHOW)'COQC -quick -noinit $<'
-	$(HIDE)$(BOOTCOQC) $< -noinit -R theories Coq -quick -noglob
+	$(HIDE)$(BOOTCOQC) $< -noinit -R theories Coq -vio -noglob
 
 # The general rule for building .vo files :
 
@@ -855,8 +855,8 @@ ifdef VALIDATE
 endif
 
 %.vio: %.v theories/Init/Prelude.vio $(VO_TOOLS_DEP)
-	$(SHOW)'COQC -quick $<'
-	$(HIDE)$(BOOTCOQC) $< -quick -noglob
+	$(SHOW)'COQC -vio $<'
+	$(HIDE)$(BOOTCOQC) $< -vio -noglob
 
 %.v.timing.diff: %.v.before-timing %.v.after-timing
 	$(SHOW)PYTHON TIMING-DIFF $<

--- a/doc/changelog/08-tools/11280-bugfix-11195-vos-vio-interaction.rst
+++ b/doc/changelog/08-tools/11280-bugfix-11195-vos-vio-interaction.rst
@@ -1,0 +1,4 @@
+- **Deprecated:**
+  The ``-quick`` command is renamed to ``-vio``, for consistency with the new ``-vos`` and ``-vok`` flags. Usage of ``-quick`` is now deprecated.
+  (`#11280 <https://github.com/coq/coq/pull/11280>`_,
+  by charguer).

--- a/doc/sphinx/addendum/parallel-proof-processing.rst
+++ b/doc/sphinx/addendum/parallel-proof-processing.rst
@@ -154,6 +154,18 @@ to a worker process. The threshold can be configured with
 Batch mode
 ---------------
 
+   .. warning::
+
+      The ``-vio`` flag is subsumed, for most practical usage, by the
+      the more recent ``-vos`` flag. See :ref:`compiled-interfaces`.
+
+   .. warning::
+
+      When working with ``.vio`` files, do not use the ``-vos`` option at
+      the same time, otherwise stale files might get loaded when executing
+      a ``Require``. Indeed, the loading of a nonempty ``.vos`` file is
+      assigned higher priority than the loading of a ``.vio`` file.
+
 When |Coq| is used as a batch compiler by running ``coqc``, it produces
 a ``.vo`` file for each ``.v`` file. A ``.vo`` file contains, among other
 things, theorem statements and proofs. Hence to produce a .vo |Coq|
@@ -161,10 +173,10 @@ need to process all the proofs of the ``.v`` file.
 
 The asynchronous processing of proofs can decouple the generation of a
 compiled file (like the ``.vo`` one) that can be loaded by ``Require`` from the
-generation and checking of the proof objects. The ``-quick`` flag can be
+generation and checking of the proof objects. The ``-vio`` flag can be
 passed to ``coqc`` to produce, quickly, ``.vio`` files.
 Alternatively, when using a Makefile produced by ``coq_makefile``,
-the ``quick`` target can be used to compile all files using the ``-quick`` flag.
+the ``vio`` target can be used to compile all files using the ``-vio`` flag.
 
 A ``.vio`` file can be loaded using ``Require`` exactly as a ``.vo`` file but
 proofs will not be available (the Print command produces an error).
@@ -173,7 +185,7 @@ inconsistencies might go unnoticed. A ``.vio`` file does not contain proof
 objects, but proof tasks, i.e. what a worker process can transform
 into a proof object.
 
-Compiling a set of files with the ``-quick`` flag allows one to work,
+Compiling a set of files with the ``-vio`` flag allows one to work,
 interactively, on any file without waiting for all the proofs to be
 checked.
 

--- a/doc/sphinx/practical-tools/coq-commands.rst
+++ b/doc/sphinx/practical-tools/coq-commands.rst
@@ -253,6 +253,7 @@ and ``coqtop``, unless stated otherwise:
 :-h, --help: Print a short usage and exit.
 
 
+.. _compiled-interfaces:
 
 Compiled interfaces (produced using ``-vos``)
 ----------------------------------------------

--- a/lib/future.ml
+++ b/lib/future.ml
@@ -12,13 +12,13 @@ let not_ready_msg = ref (fun name ->
       Pp.strbrk("The value you are asking for ("^name^") is not ready yet. "^
                 "Please wait or pass "^
                 "the \"-async-proofs off\" option to CoqIDE to disable "^
-                "asynchronous script processing and don't pass \"-quick\" to "^
+                "asynchronous script processing and don't pass \"-vio\" to "^
                 "coqc."))
 let not_here_msg = ref (fun name ->
       Pp.strbrk("The value you are asking for ("^name^") is not available "^
                 "in this process. If you really need this, pass "^
                 "the \"-async-proofs off\" option to CoqIDE to disable "^
-                "asynchronous script processing and don't pass \"-quick\" to "^
+                "asynchronous script processing and don't pass \"-vio\" to "^
                 "coqc."))
 
 let customize_not_ready_msg f = not_ready_msg := f

--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -635,7 +635,7 @@ vio: $(patsubst %.v,%.vio.log,$(wildcard vio/*.v))
 %.vio.log:%.v
 	@echo "TEST      $<"
 	$(HIDE){ \
-	  $(coqc) -quick -R vio vio $* 2>&1 && \
+	  $(coqc) -vio -R vio vio $* 2>&1 && \
 	  $(coqc) -R vio vio -vio2vo $*.vio 2>&1 && \
 	  $(coqchk) -R vio vio -norec $(subst /,.,$*) 2>&1; \
 	  if [ $$? = 0 ]; then \

--- a/test-suite/misc/quick-include.sh
+++ b/test-suite/misc/quick-include.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 set -e
 
-$coqc -R misc/quick-include/ QuickInclude -quick misc/quick-include/file1.v
-$coqc -R misc/quick-include/ QuickInclude -quick misc/quick-include/file2.v
+$coqc -R misc/quick-include/ QuickInclude -vio misc/quick-include/file1.v
+$coqc -R misc/quick-include/ QuickInclude -vio misc/quick-include/file2.v

--- a/test-suite/output/ErrorInModule.v
+++ b/test-suite/output/ErrorInModule.v
@@ -1,4 +1,4 @@
-(* -*- mode: coq; coq-prog-args: ("-quick") -*- *)
+(* -*- mode: coq; coq-prog-args: ("-vio") -*- *)
 Module M.
   Definition foo := nonexistent.
 End M.

--- a/test-suite/output/ErrorInSection.v
+++ b/test-suite/output/ErrorInSection.v
@@ -1,4 +1,4 @@
-(* -*- mode: coq; coq-prog-args: ("-quick") -*- *)
+(* -*- mode: coq; coq-prog-args: ("-vio") -*- *)
 Section S.
   Definition foo := nonexistent.
 End S.

--- a/tools/CoqMakefile.in
+++ b/tools/CoqMakefile.in
@@ -389,7 +389,11 @@ optfiles: $(if $(DO_NATDYNLINK),$(CMXSFILES))
 .PHONY: optfiles
 
 # FIXME, see Ralf's bugreport
-quick: $(VOFILES:.vo=.vio)
+# quick is deprecated, now renamed vio
+vio: $(VOFILES:.vo=.vio)
+.PHONY: vio
+quick: vio
+	$(warning "'make quick' is deprecated, use 'make vio' or consider using 'vos' files")
 .PHONY: quick
 
 vio2vo:
@@ -397,8 +401,9 @@ vio2vo:
 		-schedule-vio2vo $(J) $(VOFILES:%.vo=%.vio)
 .PHONY: vio2vo
 
+# quick2vo is undocumented
 quick2vo:
-	$(HIDE)make -j $(J) quick
+	$(HIDE)make -j $(J) vio
 	$(HIDE)VIOFILES=$$(for vofile in $(VOFILES); do \
 	  viofile="$$(echo "$$vofile" | sed "s/\.vo$$/.vio/")"; \
 	  if [ "$$vofile" -ot "$$viofile" -o ! -e "$$vofile" ]; then printf "$$viofile "; fi; \
@@ -677,8 +682,8 @@ $(GLOBFILES): %.glob: %.v
 	$(TIMER) $(COQC) $(COQDEBUG) $(COQFLAGS) $(COQLIBS) $<
 
 $(VFILES:.v=.vio): %.vio: %.v
-	$(SHOW)COQC -quick $<
-	$(HIDE)$(TIMER) $(COQC) -quick $(COQDEBUG) $(COQFLAGS) $(COQLIBS) $<
+	$(SHOW)COQC -vio $<
+	$(HIDE)$(TIMER) $(COQC) -vio $(COQDEBUG) $(COQFLAGS) $(COQLIBS) $<
 
 $(VFILES:.v=.vos): %.vos: %.v
 	$(SHOW)COQC -vos $<

--- a/toplevel/coqc.ml
+++ b/toplevel/coqc.ml
@@ -25,7 +25,6 @@ let coqc_specific_usage = Usage.{
 coqc specific options:\
 \n  -o f.vo                use f.vo as the output file name\
 \n  -verbose               compile and output the input file\
-\n  -quick                 quickly compile .v files to .vio files (skip proofs)\
 \n  -schedule-vio2vo j f1..fn   run up to j instances of Coq to turn each fi.vio\
 \n                         into fi.vo\
 \n  -schedule-vio-checking j f1..fn   run up to j instances of Coq to check all\
@@ -33,8 +32,10 @@ coqc specific options:\
 \n  -vos                   process statements but ignore opaque proofs, and produce a .vos file\
 \n  -vok                   process the file by loading .vos instead of .vo files for\
 \n                         dependencies, and produce an empty .vok file on success\
+\n  -vio                   process statements and suspend opaque proofs, and produce a .vio file\
 \n\
 \nUndocumented:\
+\n  -quick                 (deprecated) alias for -vio\
 \n  -vio2vo                [see manual]\
 \n  -check-vio-tasks       [see manual]\
 \n"

--- a/toplevel/coqcargs.ml
+++ b/toplevel/coqcargs.ml
@@ -98,7 +98,7 @@ let set_compilation_mode opts mode =
   match opts.compilation_mode with
   | BuildVo -> { opts with compilation_mode = mode }
   | mode' when mode <> mode' ->
-    prerr_endline "Options -quick and -vio2vo are exclusive";
+    prerr_endline "Options -vio and -vio2vo are exclusive";
     exit 1
   | _ -> opts
 
@@ -125,6 +125,11 @@ let warn_deprecated_outputstate =
   CWarnings.create ~name:"deprecated-outputstate" ~category:"deprecated"
          (fun () ->
           Pp.strbrk "The outputstate option is deprecated and discouraged.")
+
+let warn_deprecated_quick =
+  CWarnings.create ~name:"deprecated-quick" ~category:"deprecated"
+         (fun () ->
+          Pp.strbrk "The -quick option is renamed -vio. Please consider using the -vos feature instead.")
 
 let set_outputstate opts s =
   warn_deprecated_outputstate ();
@@ -165,6 +170,9 @@ let parse arglist : t =
         | "-o" ->
           { oval with compilation_output_name = Some (next ()) }
         | "-quick" ->
+          warn_deprecated_quick();
+          set_compilation_mode oval BuildVio
+        | "-vio" ->
           set_compilation_mode oval BuildVio
         |"-vos" ->
           Flags.load_vos_libraries := true;


### PR DESCRIPTION
Fix #11195 and add other improvements: try loading .vio (and not just .vo) if the .vos file is empty, rename -quick to -vio, dump empty .vos when producing .vio, dump empty .vos and .vok files when producing .vo from .vio.