### PR TITLE
Split up stdlib install command (too long)

### DIFF
--- a/Makefile.install
+++ b/Makefile.install
@@ -115,9 +115,18 @@ endif
 install-merlin:
 	$(INSTALLSH) $(FULLCOQLIB) $(wildcard $(INSTALLCMX:.cmx=.cmt) $(INSTALLCMI:.cmi=.cmti) $(MLIFILES) $(MLFILES) $(MERLINFILES))
 
+#NB: some files don't produce native files (eg Ltac2 files) as they
+#don't have any Coq definitions. Makefile can't predict that so we use || true
+#vos build is bugged in -quick mode, see #11195
 install-library:
 	$(MKDIR) $(FULLCOQLIB)
-	$(INSTALLSH) $(FULLCOQLIB) $(LIBFILES)
+	$(INSTALLSH) $(FULLCOQLIB) $(ALLVO:.$(VO)=.vo)
+	$(INSTALLSH) $(FULLCOQLIB) $(ALLVO:.$(VO)=.vos) || true
+ifneq ($(NATIVECOMPUTE),)
+	$(INSTALLSH) $(FULLCOQLIB) $(NATIVEFILES) || true
+endif
+	$(INSTALLSH) $(FULLCOQLIB) $(VFILES)
+	$(INSTALLSH) $(FULLCOQLIB) $(GLOBFILES)
 	$(MKDIR) $(FULLCOQLIB)/user-contrib
 	$(MKDIR) $(FULLCOQLIB)/kernel/byterun
 ifndef CUSTOM

--- a/Makefile.vofiles
+++ b/Makefile.vofiles
@@ -49,7 +49,6 @@ endif
 else
 NATIVEFILES :=
 endif
-LIBFILES:=$(ALLVO:.$(VO)=.vo) $(ALLVO:.$(VO)=.vos) $(NATIVEFILES) $(VFILES) $(GLOBFILES)
 
 # For emacs:
 # Local Variables:


### PR DESCRIPTION
Originally as part of #9185, separated for quicker merge.