### PR TITLE
[meta] Add ltac2 information to META.

### DIFF
--- a/META.coq.in
+++ b/META.coq.in
@@ -561,4 +561,19 @@ package "plugins" (
     plugin(byte)    = "ssreflect_plugin.cmo"
     plugin(native)  = "ssreflect_plugin.cmxs"
   )
+
+  package "ltac2" (
+
+    description = "Coq Ltac2 Plugin"
+    version     = "8.12"
+
+    requires    = "coq.plugins.ltac"
+    directory   = "../user-contrib/Ltac2"
+
+    archive(byte)    = "ltac2_plugin.cmo"
+    archive(native)  = "ltac2_plugin.cmx"
+
+    plugin(byte)    = "ltac2_plugin.cmo"
+    plugin(native)  = "ltac2_plugin.cmxs"
+  )
 )


### PR DESCRIPTION
Closes #11225 , we use a bit of a hack due to the way the Makefile
installs this plugin.
