### PR TITLE
[omega] Deprecate the omega tactic

### DIFF
--- a/plugins/omega/g_omega.mlg
+++ b/plugins/omega/g_omega.mlg
@@ -45,13 +45,15 @@ let omega_tactic l =
     (Tacticals.New.tclREPEAT (Tacticals.New.tclTHENLIST tacs))
     (omega_solver)
 
+let omega_deprecation = Deprecation.make ~since:"v8.11" ~note:"please use the `lia` tactic" ()
+
 }
 
-TACTIC EXTEND omega
+TACTIC EXTEND omega DEPRECATED { omega_deprecation }
 |  [ "omega" ] -> { omega_tactic [] }
 END
 
-TACTIC EXTEND omega'
+TACTIC EXTEND omega' DEPRECATED { omega_deprecation }
 | [ "omega" "with" ne_ident_list(l) ] ->
     { omega_tactic (List.map Names.Id.to_string l) }
 | [ "omega" "with" "*" ] ->


### PR DESCRIPTION
This prepares for its removal in 8.12, IMHO it is important as to
allow us to get rid of omega for 8.12 too.

The warning can be a bit annoying as it happens per-omega invocation,
but on the other hand if we are going to do this we should be verbose.

**Kind:** documentation / bug fix / compatibility

Fixes / closes #????

- [ ] Added / updated test-suite
- [ ] Corresponding documentation was added / updated 
- [ ] Entry added in the changelog