### PR TITLE
Being explicit on existence of a remote link in stdlib to avoid possible "breach of privacy"

### DIFF
--- a/theories/Logic/Hurkens.v
+++ b/theories/Logic/Hurkens.v
@@ -72,7 +72,7 @@
 
     - [[Geuvers01]] H. Geuvers, "Inconsistency of Classical Logic in Type
       Theory", 2001, revised 2007
-      (see {{http://www.cs.ru.nl/~herman/PUBS/newnote.ps.gz}}).
+      (see external link {{http://www.cs.ru.nl/~herman/PUBS/newnote.ps.gz}}).
 *)
 
 


### PR DESCRIPTION
**Kind:** legal

It was pointed to me by Debian that the presence of http links in the local copy of the html documentation of the standard library present in a coq package might lead to unwanted tracking of the activity of users believing they are working in a purely local way.

Maybe this is overkill but I'm nevertheless somehow sensitive to this argument. The canonical recommended solution is to make explicit that the link is external.