### PR TITLE
Renaming: update env instead of postprocessing

### DIFF
--- a/interp/arguments_renaming.mli
+++ b/interp/arguments_renaming.mli
@@ -9,17 +9,13 @@
 (************************************************************************)
 
 open Names
-open Environ
-open Constr
 
-val rename_arguments : bool -> GlobRef.t -> Name.t list -> unit
+val rename_arguments : local:bool -> GlobRef.t -> Name.t list -> unit
 
-(** [Not_found] is raised if no names are defined for [r] *)
 val arguments_names : GlobRef.t -> Name.t list
+(** May raise [Not_found].
 
-val rename_type : types -> GlobRef.t -> types
-
-val rename_type_of_constant : env -> pconstant -> types
-val rename_type_of_inductive : env -> pinductive -> types
-val rename_type_of_constructor : env -> pconstructor -> types
-val rename_typing : env -> constr -> unsafe_judgment
+    Used by arguments in a dubious way: suppose constant [c] has type
+   [foo] which reduces to [forall x, ...]. If we rename to [y], the
+   type is not affected but the implicit argument system is, for
+   instance [c (y:=0)] works and [c (x:=0)] stops working.*)

--- a/interp/interp.mllib
+++ b/interp/interp.mllib
@@ -13,6 +13,7 @@ Constrexpr_ops
 Decls
 Dumpglob
 Reserve
+Arguments_renaming
 Impargs
 Implicit_quantifiers
 Constrintern

--- a/kernel/environ.ml
+++ b/kernel/environ.ml
@@ -823,3 +823,82 @@ let set_retroknowledge env r = { env with retroknowledge = r }
 let set_native_symbols env native_symbols = { env with native_symbols }
 let add_native_symbols dir syms env =
   { env with native_symbols = DPmap.add dir syms env.native_symbols }
+
+(** Renaming *)
+
+let rename old = function
+  | Anonymous -> old
+  | Name _ as x -> {old with Context.binder_name=x}
+
+let rec rename_type c = function
+  | [] -> c
+  | name :: rest as renamings ->
+    match kind c with
+    | Prod (old, a, b) -> mkProd (rename old name, a, rename_type b rest)
+    | LetIn (x,a,b,c) -> mkLetIn (x,a,b, rename_type c renamings)
+    | Cast (c,_,_) -> rename_type c renamings (* why not preserve the cast? *)
+    | _ -> c
+
+let mod_globals env f = {env with env_globals = f env.env_globals}
+
+let rename_constant c names env =
+  mod_globals env (fun globals ->
+      {globals with
+       Globals.constants =
+         globals.Globals.constants |>
+         Cmap_env.modify c (fun _ (cb,info) ->
+             {cb with const_type = rename_type cb.const_type names}, info)})
+
+let mod_inductive (mind,i) env f =
+  mod_globals env (fun globals ->
+      {globals with
+       Globals.inductives =
+         globals.Globals.inductives |>
+         Mindmap_env.modify mind (fun _ (mb,info) ->
+             {mb with
+              mind_packets = Array.mapi (fun j packet -> if i = j then f packet else packet)
+                  mb.mind_packets}, info)})
+
+let rec rename_ctx ctx names = match ctx, names with
+  | _, [] -> ctx
+  | (LocalDef _ as elt) :: ctx, _ -> elt :: (rename_ctx ctx names)
+  | (LocalAssum _ as elt)  :: ctx, Anonymous :: names -> elt :: (rename_ctx ctx names)
+  | LocalAssum (x,t) :: ctx, (Name _ as y) :: names ->
+    LocalAssum (rename x y,t) :: (rename_ctx ctx names)
+  | [], _ :: _ -> []
+(* TODO change semantics to error when too many renames *)
+
+(* This works because parameters are included in the inductive_body
+   components. If that changes we will need some other method. *)
+let rename_ind_type names packet =
+  match packet.mind_arity with
+  | RegularArity arity ->
+    let mind_user_arity = rename_type arity.mind_user_arity names in
+    { packet with mind_arity = RegularArity {mind_sort = arity.mind_sort; mind_user_arity} }
+  | TemplateArity _ -> { packet with mind_arity_ctxt = rename_ctx packet.mind_arity_ctxt names }
+
+let rename_ind ind names env =
+  mod_inductive ind env (fun packet -> rename_ind_type names packet)
+
+let rename_ctor (ind,c) names env =
+  mod_inductive ind env (fun packet ->
+      {packet with mind_user_lc = Array.mapi (fun j t ->
+           if j+1 = c then rename_type t names else t) packet.mind_user_lc;})
+
+let rename_var v names env =
+  let map = Id.Map.modify v (fun _ (d,info) ->
+      let d = NamedDecl.map_type (fun t -> rename_type t names) d in
+      d, info)
+      env.env_named_context.env_named_map
+  in
+  let newt = NamedDecl.get_type (fst (Id.Map.get v map)) in
+  let list = CList.Smart.map (fun d -> NamedDecl.map_type (fun _ -> newt) d)
+      env.env_named_context.env_named_ctx
+  in
+  {env with env_named_context = {env_named_map = map; env_named_ctx = list}}
+
+let rename_ref r names env = let open GlobRef in match r with
+  | ConstRef r -> rename_constant r names env
+  | IndRef r -> rename_ind r names env
+  | ConstructRef r -> rename_ctor r names env
+  | VarRef r -> rename_var r names env

--- a/kernel/environ.mli
+++ b/kernel/environ.mli
@@ -378,3 +378,6 @@ val set_retroknowledge : env -> Retroknowledge.retroknowledge -> env
 
 val set_native_symbols : env -> Nativevalues.symbols DPmap.t -> env
 val add_native_symbols : DirPath.t -> Nativevalues.symbols -> env -> env
+
+(** Renaming *)
+val rename_ref : GlobRef.t -> Name.t list -> env -> env

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -1475,3 +1475,6 @@ Would this be correct with respect to undo's and stuff ?
 let set_strategy k l e = { e with env =
    (Environ.set_oracle e.env
       (Conv_oracle.set_strategy (Environ.oracle e.env) k l)) }
+
+let rename_ref r names senv =
+  { senv with env = Environ.rename_ref r names senv.env }

--- a/kernel/safe_typing.mli
+++ b/kernel/safe_typing.mli
@@ -230,3 +230,12 @@ val register_inductive : inductive -> 'a CPrimitives.prim_ind -> safe_transforme
 
 val set_strategy :
   Names.Constant.t Names.tableKey -> Conv_oracle.level -> safe_transformer0
+
+
+(** Rename in the type of the reference.
+
+    For variables this will impact the type of the values after
+   discharge, including those declared before the rename.
+
+    Otherwise forgotten after section or module end. *)
+val rename_ref : GlobRef.t -> Name.t list -> safe_transformer0

--- a/library/global.ml
+++ b/library/global.ml
@@ -219,3 +219,5 @@ let set_share_reduction b =
 
 let set_VM b = globalize0 (Safe_typing.set_VM b)
 let set_native_compiler b = globalize0 (Safe_typing.set_native_compiler b)
+
+let rename_ref r names = globalize0 (Safe_typing.rename_ref r names)

--- a/library/global.mli
+++ b/library/global.mli
@@ -179,3 +179,5 @@ val current_dirpath : unit -> DirPath.t
 val with_global : (Environ.env -> DirPath.t -> 'a Univ.in_universe_context_set) -> 'a
 
 val global_env_summary_tag : Safe_typing.safe_environment Summary.Dyn.tag
+
+val rename_ref : GlobRef.t -> Name.t list -> unit

--- a/plugins/ssr/ssrelim.ml
+++ b/plugins/ssr/ssrelim.ml
@@ -160,17 +160,6 @@ let ssrelim ?(is_case=false) deps what ?elim eqid elim_intro_tac =
     match elim with
     | Some elim ->
       let gl, elimty = pf_e_type_of gl elim in
-      let elimty =
-        let rename_elimty r =
-          EConstr.of_constr
-            (Arguments_renaming.rename_type
-              (EConstr.to_constr ~abort_on_undefined_evars:false (project gl)
-                elimty) r) in
-        match EConstr.kind (project gl) elim with
-        | Constr.Var kn -> rename_elimty (GlobRef.VarRef kn)
-        | Constr.Const (kn,_) -> rename_elimty (GlobRef.ConstRef kn)
-        | _ -> elimty
-      in
       let pred_id, n_elim_args, is_rec, elim_is_dep, n_pred_args,ctx_concl =
         analyze_eliminator elimty env (project gl) in
       let seed = subgoals_tys (project gl) ctx_concl in
@@ -213,8 +202,6 @@ let ssrelim ?(is_case=false) deps what ?elim eqid elim_intro_tac =
             Array.mapi (fun j (ctx, cty) ->
               let t = Term.it_mkProd_or_LetIn cty ctx in
                     ppdebug(lazy Pp.(str "Search" ++ Printer.pr_constr_env env (project gl) t));
-              let t = Arguments_renaming.rename_type t
-                (GlobRef.ConstructRef((kn,i),j+1)) in
               ppdebug(lazy Pp.(str"Done Search " ++ Printer.pr_constr_env env (project gl) t));
                 t)
             tys

--- a/pretyping/pretyping.mllib
+++ b/pretyping/pretyping.mllib
@@ -4,7 +4,6 @@ Locusops
 Pretype_errors
 Reductionops
 Inductiveops
-Arguments_renaming
 Retyping
 Vnorm
 Nativenorm

--- a/pretyping/retyping.ml
+++ b/pretyping/retyping.ml
@@ -22,7 +22,6 @@ open Environ
 open Termops
 open EConstr
 open Vars
-open Arguments_renaming
 open Context.Rel.Declaration
 
 module RelDecl = Context.Rel.Declaration
@@ -107,10 +106,16 @@ let retype ?(polyprop=true) sigma =
         let ty = RelDecl.get_type (lookup_rel n env) in
         lift n ty
     | Var id -> type_of_var env id
-    | Const (cst, u) -> EConstr.of_constr (rename_type_of_constant env (cst, EInstance.kind sigma u))
+    | Const (cst, u) ->
+      let u = EInstance.kind sigma u in
+      EConstr.of_constr (Typeops.type_of_constant_in env (cst, u))
     | Evar ev -> existential_type sigma ev
-    | Ind (ind, u) -> EConstr.of_constr (rename_type_of_inductive env (ind, EInstance.kind sigma u))
-    | Construct (cstr, u) -> EConstr.of_constr (rename_type_of_constructor env (cstr, EInstance.kind sigma u))
+    | Ind (ind, u) ->
+      let u = EInstance.kind sigma u in
+      EConstr.of_constr (Inductiveops.type_of_inductive env (ind, u))
+    | Construct (cstr, u) ->
+      let u = EInstance.kind sigma u in
+      EConstr.of_constr (Inductiveops.type_of_constructor env (cstr, u))
     | Case (_,p,c,lf) ->
         let Inductiveops.IndType(indf,realargs) =
           let t = type_of env c in

--- a/pretyping/typing.ml
+++ b/pretyping/typing.ml
@@ -23,7 +23,6 @@ open Reductionops
 open Inductive
 open Inductiveops
 open Typeops
-open Arguments_renaming
 open Pretype_errors
 open Context.Rel.Declaration
 
@@ -296,7 +295,7 @@ let type_of_constant env sigma (c,u) =
   let u = EInstance.kind sigma u in
   let ty, csts = Environ.constant_type env (c,u) in
   let sigma = Evd.add_constraints sigma csts in
-  sigma, (EConstr.of_constr (rename_type ty (Names.GlobRef.ConstRef c)))
+  sigma, (EConstr.of_constr ty)
 
 let type_of_inductive env sigma (ind,u) =
   let open Declarations in
@@ -305,7 +304,7 @@ let type_of_inductive env sigma (ind,u) =
   let u = EInstance.kind sigma u in
   let ty, csts = Inductive.constrained_type_of_inductive env (specif,u) in
   let sigma = Evd.add_constraints sigma csts in
-  sigma, (EConstr.of_constr (rename_type ty (Names.GlobRef.IndRef ind)))
+  sigma, (EConstr.of_constr ty)
 
 let type_of_constructor env sigma ((ind,_ as ctor),u) =
   let open Declarations in
@@ -314,7 +313,7 @@ let type_of_constructor env sigma ((ind,_ as ctor),u) =
   let u = EInstance.kind sigma u in
   let ty, csts = Inductive.constrained_type_of_constructor (ctor,u) specif in
   let sigma = Evd.add_constraints sigma csts in
-  sigma, (EConstr.of_constr (rename_type ty (Names.GlobRef.ConstructRef ctor)))
+  sigma, (EConstr.of_constr ty)
 
 let judge_of_int env v =
   Environ.on_judgment EConstr.of_constr (judge_of_int env v)

--- a/vernac/comArguments.ml
+++ b/vernac/comArguments.ml
@@ -270,7 +270,7 @@ let vernac_arguments ~section_local reference args more_implicits flags =
   (* Actions *)
 
   if renaming_specified then begin
-    Arguments_renaming.rename_arguments section_local sr names
+     Arguments_renaming.rename_arguments ~local:section_local sr names
   end;
 
   if scopes_specified || clear_scopes_flag then begin

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1588,7 +1588,7 @@ let vernac_check_may_eval ~pstate ~atts redexp glopt rc =
     else
       let c = EConstr.to_constr sigma c in
       (* OK to call kernel which does not support evars *)
-      Environ.on_judgment EConstr.of_constr (Arguments_renaming.rename_typing env c)
+      Environ.on_judgment EConstr.of_constr (Typeops.infer env c)
   in
   let pp = match redexp with
     | None ->


### PR DESCRIPTION
This means people can look at the result of lookup_constant or
constant_type_in without worrying about getting incorrect names.

We also get to move arguments_renaming up to interp.

test suite broken: renaming an anonymous argument then making it
implicit is accepted (with non-investigated consequences). I'm not sure what to do about this.

(+ output changes as About now prints the renamed arguments, not the
original)

A previous version, done partially (constants only) gave 2% time gain
on odd-order (bench 819).
