### PR TITLE
Fix complexity test-suite failure reporting on Win

### DIFF
--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -71,6 +71,9 @@ get_coq_prog_args_in_parens = $(subst $(SINGLE_QUOTE),,$(if $(call get_coq_prog_
 get_set_impredicativity= $(filter "-impredicative-set",$(call get_coq_prog_args,$(1)))
 
 bogomips:=
+ifeq (win32,$(ARCH))
+  $(warning windows detected: skipping complexity tests)
+else
 ifneq (,$(wildcard /proc/cpuinfo))
   sedbogo := -e "s/bogomips.*: \([0-9]*\).*/\1/p" # i386, ppc
   sedbogo += -e "s/Cpu0Bogo.*: \([0-9]*\).*/\1/p" # sparc
@@ -80,6 +83,7 @@ endif
 
 ifeq (,$(bogomips))
   $(warning cannot run complexity tests (no bogomips found))
+endif
 endif
 
 # keep these synced with test-suite/save-logs.sh

--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -530,7 +530,7 @@ $(addsuffix .log,$(wildcard complexity/*.v)): %.v.log: %.v $(PREREQUISITELOG)
 	$(HIDE){ \
 	  echo $(call log_intro,$<); \
 	  true "extract effective user time"; \
-	  res=`$(coqc_interactive) "$<" $(call get_coq_prog_args,"$<") 2>&1 | sed -n -e "s/Finished transaction in .*(\([0-9]*\.[0-9]*\)u.*)/\1/p" | head -1`; \
+	  res=`$(coqc_interactive) "$<" $(call get_coq_prog_args,"$<") 2>&1 | sed -n -e "s/Finished transaction in .*(\([0-9]*\.[0-9]*\)u.*)/\1/p" | head -1 | sed "s/\r//g"`; \
 	  R=$$?; times; \
 	  if [ $$R != 0 ]; then \
 	    echo $(log_failure); \

--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -540,19 +540,25 @@ $(addsuffix .log,$(wildcard complexity/*.v)): %.v.log: %.v $(PREREQUISITELOG)
 	    echo "    $<...Error! (couldn't find a time measure)"; \
 	  else \
 	    true "express effective time in centiseconds"; \
+	    resorig="$$res"; \
 	    res=`echo "$$res"00 | sed -n -e "s/\([0-9]*\)\.\([0-9][0-9]\).*/\1\2/p"`; \
-	    true "find expected time * 100"; \
-	    exp=`sed -n -e "s/(\*.*Expected time < \([0-9]\).\([0-9][0-9]\)s.*\*)/\1\2/p" "$<"`; \
-	    true "compute corrected effective time, rounded up"; \
-	    rescorrected=`expr \( $$res \* $(bogomips) + 6120 - 1 \) / 6120`; \
-	    ok=`expr \( $$res \* $(bogomips) \) "<" \( $$exp \* 6120 \)`; \
-	    if [ "$$ok" = 1 ]; then \
-	      echo $(log_success); \
-	      echo "    $<...Ok"; \
-	    else \
+	    if [ "$$res" = "" ]; then \
 	      echo $(log_failure); \
-	      echo "    $<...Error! (should run faster ($$rescorrected >= $$exp))"; \
-	      $(FAIL); \
+	      echo "    $<...Error! (invalid time measure: $$resorig)"; \
+	    else \
+	      true "find expected time * 100"; \
+	      exp=`sed -n -e "s/(\*.*Expected time < \([0-9]\).\([0-9][0-9]\)s.*\*)/\1\2/p" "$<"`; \
+	      true "compute corrected effective time, rounded up"; \
+	      rescorrected=`expr \( $$res \* $(bogomips) + 6120 - 1 \) / 6120`; \
+	      ok=`expr \( $$res \* $(bogomips) \) "<" \( $$exp \* 6120 \)`; \
+	      if [ "$$ok" = 1 ]; then \
+	        echo $(log_success); \
+	        echo "    $<...Ok"; \
+	      else \
+	        echo $(log_failure); \
+	        echo "    $<...Error! (should run faster ($$rescorrected >= $$exp))"; \
+	        $(FAIL); \
+	      fi; \
 	    fi; \
 	  fi; \
 	} > "$@"

--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -544,7 +544,7 @@ $(addsuffix .log,$(wildcard complexity/*.v)): %.v.log: %.v $(PREREQUISITELOG)
 	    true "find expected time * 100"; \
 	    exp=`sed -n -e "s/(\*.*Expected time < \([0-9]\).\([0-9][0-9]\)s.*\*)/\1\2/p" "$<"`; \
 	    true "compute corrected effective time, rounded up"; \
-	    rescorrected=`expr \( $$res \* $(bogomips) \+ 6120 \- 1 \) \/ 6120`; \
+	    rescorrected=`expr \( $$res \* $(bogomips) + 6120 - 1 \) / 6120`; \
 	    ok=`expr \( $$res \* $(bogomips) \) "<" \( $$exp \* 6120 \)`; \
 	    if [ "$$ok" = 1 ]; then \
 	      echo $(log_success); \

--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -71,9 +71,6 @@ get_coq_prog_args_in_parens = $(subst $(SINGLE_QUOTE),,$(if $(call get_coq_prog_
 get_set_impredicativity= $(filter "-impredicative-set",$(call get_coq_prog_args,$(1)))
 
 bogomips:=
-ifeq (win32,$(ARCH))
-  $(warning windows detected: skipping complexity tests)
-else
 ifneq (,$(wildcard /proc/cpuinfo))
   sedbogo := -e "s/bogomips.*: \([0-9]*\).*/\1/p" # i386, ppc
   sedbogo += -e "s/Cpu0Bogo.*: \([0-9]*\).*/\1/p" # sparc
@@ -83,7 +80,6 @@ endif
 
 ifeq (,$(bogomips))
   $(warning cannot run complexity tests (no bogomips found))
-endif
 endif
 
 # keep these synced with test-suite/save-logs.sh


### PR DESCRIPTION
Apparently `expr 1 \+ 1` is fine on Linux but not cygwin/Windows, where
it fails with "syntax error".  Similarly for `-` and `/`.

**Kind:** bug fix / infrastructure.

Apparently the `expr` expression I wrote in #11198 only worked on Linux.  I think this does not need a changelog entry, especially since #11198 is targeted to the same milestone as this PR.

Note that this should also fix #11303 and close #11312, by properly handling trailing `\r` on Windows.