### PR TITLE
Compromise between elegance and precision in reporting location about a product/function made of a subset of binders

### DIFF
--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -570,6 +570,7 @@ let rec expand_binders ?loc mk bl c =
   match bl with
   | [] -> c
   | b :: bl ->
+     let loc = Loc.scissor_opt loc (b.CAst.loc) in
      match DAst.get b with
      | GLocalDef (n, bk, b, oty) ->
         expand_binders ?loc mk bl (DAst.make ?loc @@ GLetIn (n, b, oty, c))

--- a/interp/notation_ops.ml
+++ b/interp/notation_ops.ml
@@ -274,11 +274,6 @@ let split_at_recursive_part c =
   | GVar v when Id.equal v ldots_var -> (* Not enough context *) raise Not_found
   | _ -> outer_iterator, c
 
-let subtract_loc loc1 loc2 =
-  let l1 = fst (Option.cata Loc.unloc (0,0) loc1) in
-  let l2 = fst (Option.cata Loc.unloc (0,0) loc2) in
-  Some (Loc.make_loc (l1,l2-1))
-
 let check_is_hole id t = match DAst.get t with GHole _ -> () | _ ->
   user_err ?loc:(loc_of_glob_constr t)
    (strbrk "In recursive notation with binders, " ++ Id.print id ++
@@ -365,7 +360,7 @@ let compare_recursive_parts recvars found f f' (iterator,subc) =
         let loc1 = loc_of_glob_constr iterator in
         let loc2 = loc_of_glob_constr (Option.get !terminator) in
         (* Here, we would need a loc made of several parts ... *)
-        user_err ?loc:(subtract_loc loc1 loc2)
+        user_err ?loc:(Loc.subtract_opt loc1 loc2)
           (str "Both ends of the recursive pattern are the same.")
     | Some (x,y,RecursiveTerms revert) ->
         (* By arbitrary convention, we use the second variable of the pair

--- a/lib/loc.ml
+++ b/lib/loc.ml
@@ -80,7 +80,7 @@ let merge loc1 loc2 =
 
 let subtract loc1 loc2 =
   if not (same_file loc1 loc2) then
-    failwith "Trying to merge unmergeable locations.";
+    failwith "Trying to subtract locations from different files.";
   if loc2.bp < loc1.ep then failwith "Non disjoint locations.";
   let line_nb_last,bol_pos_last =
     if loc2.bol_pos > 0 then loc2.line_nb, loc2.bol_pos - 1
@@ -88,6 +88,15 @@ let subtract loc1 loc2 =
       loc2.line_nb, loc2.bol_pos in
   let ep = loc2.bp - 1 in
   { loc1 with line_nb_last; bol_pos_last; ep }
+
+(* We go from the beginning of the second location to the end of the first location *)
+
+let scissor loc1 loc2 =
+  if not (same_file loc1 loc2) then
+    failwith "Trying to scissor locations from different files.";
+  if loc1.ep < loc2.bp then
+    failwith "Second location must start before first location ends.";
+  { loc1 with line_nb = loc2.line_nb; bol_pos = loc2.bol_pos; bp = loc2.bp }
 
 let combine_opt f l1 l2 = match l1, l2 with
   | None, None    -> None
@@ -97,6 +106,7 @@ let combine_opt f l1 l2 = match l1, l2 with
 
 let subtract_opt = combine_opt subtract
 let merge_opt = combine_opt merge
+let scissor_opt = combine_opt scissor
 
 let finer l1 l2 = match l1, l2 with
   | None, _    -> false

--- a/lib/loc.mli
+++ b/lib/loc.mli
@@ -50,6 +50,11 @@ val subtract_opt : t option -> t option -> t option
 (** Extend the first location up to the position preceding the second
     location assumed to be disjoint and further *)
 
+val scissor : t -> t -> t
+val scissor_opt : t option -> t option -> t option
+(** Build a location from the beginning of the second location to the
+    end of the first location *)
+
 val finer : t option -> t option -> bool
 (** Answers [true] when the first location is more defined, or, when
     both defined, included in the second one *)

--- a/lib/loc.mli
+++ b/lib/loc.mli
@@ -45,6 +45,11 @@ val merge : t -> t -> t
 val merge_opt : t option -> t option -> t option
 (** Merge locations, usually generating the largest possible span *)
 
+val subtract : t -> t -> t
+val subtract_opt : t option -> t option -> t option
+(** Extend the first location up to the position preceding the second
+    location assumed to be disjoint and further *)
+
 val finer : t option -> t option -> bool
 (** Answers [true] when the first location is more defined, or, when
     both defined, included in the second one *)


### PR DESCRIPTION
**Kind:** cleanup, question

In the following:
```
> Check  nat_ind (fun A B => True).
>                 ^^^^^^^^^^^^^^^
Error: The type of this term is a product while it is expected to be Prop.
```
The location of the error is a bit difficult to grasp because only `B` is involved. An alternative location (provided by this PR) could be:
```
> Check  nat_ind (fun A B => True).
>                       ^^^^^^^^^
Error: The type of this term is a product while it is expected to be Prop.
```
But I don't find it very elegant.

Maybe, it is the error message which instead should be changed into `The type of "fun B => True" is a product while it is expected to be Prop` ?

Or an underlining made of several parts, as in:
```
> Check  nat_ind (fun A B => True).
>                 ^^^   ^^^^^^^^^
Error: The type of this term is a product while it is expected to be Prop.
```
could be used??? Any ideas?

Incidentally, the two first commits make a small cleaning of `loc.ml`.