### PR TITLE
Fixing #11114: anomaly with Extraction Implicit on records.

### DIFF
--- a/doc/changelog/12-misc/11329-master+fix11114-extraction-anomaly-implicit-record.rst
+++ b/doc/changelog/12-misc/11329-master+fix11114-extraction-anomaly-implicit-record.rst
@@ -1,0 +1,4 @@
+- **Fixed:**
+  :cmd:`Extraction Implicit` on the constructor of a record was leading to an anomaly
+  (`#11329 <https://github.com/coq/coq/pull/11329>`_,
+  by Hugo Herbelin, fixes `#11114 <https://github.com/coq/coq/pull/11114>`_).

--- a/test-suite/bugs/closed/bug_11114.v
+++ b/test-suite/bugs/closed/bug_11114.v
@@ -1,0 +1,17 @@
+Require Extraction.
+
+Inductive t (sig: list nat) :=
+| T (k: nat).
+
+Record pkg :=
+  { _sig: list nat;
+    _t : t _sig }.
+
+Definition map (f: nat -> nat) (p: pkg) :=
+  {| _sig := p.(_sig);
+     _t := match p.(_t) with
+          | T _ k => T p.(_sig) (f k)
+          end |}.
+
+Extraction Implicit Build_pkg [_sig].
+Extraction TestCompile map.


### PR DESCRIPTION
**Kind:** bug fix

Fixes / closes #11114

This was due to an inconsistency in handling implicit arguments in the fields and in the constructor of a record. We fix it by porting code used in function `Extraction.extract_inductive` to function `Extraction.extract_really_ind`.

- [X] Added / updated test-suite
- [X] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
