### PR TITLE
Fixes a small bug exposing an _ANONYMOUS_REL in a unification error message

### DIFF
--- a/test-suite/output/unification.out
+++ b/test-suite/output/unification.out
@@ -1,0 +1,11 @@
+The command has indeed failed with message:
+In environment
+x : T
+T : Type
+a : T
+Unable to unify "T" with "?X@{x0:=x; x:=C a}" (cannot instantiate 
+"?X" because "T" is not in its scope: available arguments are 
+"x" "C a").
+The command has indeed failed with message:
+The term "id" has type "ID" while it is expected to have type 
+"Type -> ?T" (cannot instantiate "?T" because "A" is not in its scope).

--- a/test-suite/output/unification.v
+++ b/test-suite/output/unification.v
@@ -1,0 +1,12 @@
+(* Unification error tests *)
+
+Module A.
+
+(* Check regression of an UNBOUND_REL bug *)
+Inductive T := C : forall {A}, A -> T.
+Fail Check fun x => match x return ?[X] with C a => a end.
+
+(* Bug #3634 *)
+Fail Check (id:Type -> _).
+
+End A.

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -297,6 +297,7 @@ let explain_unification_error env sigma p1 p2 = function
         strbrk " with term " ++ pr_leconstr_env env sigma rhs ++
         strbrk " that would depend on itself"]
      | NotClean ((evk,args),env,c) ->
+        let env = make_all_name_different env sigma in
         [str "cannot instantiate " ++ quote (pr_existential_key sigma evk)
         ++ strbrk " because " ++ pr_leconstr_env env sigma c ++
         strbrk " is not in its scope" ++


### PR DESCRIPTION
**Kind:** bug fix

This fixes the following:
```
Inductive T := C : forall {A}, A -> T.
Check fun x => match x return ?[X] with C a => a end.
(* Unable to unify "T" with "?X@{x0:=x; x:=C a}" (cannot instantiate 
"?X" because "_ANONYMOUS_REL_2" is not in its scope: available arguments are
"x" "C a"). *)
```

- [X] Added / updated test-suite
