### PR TITLE
[ci] [gitlab] [bedrock] Build bedrock with 1 core

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -578,6 +578,8 @@ library:ci-bedrock2:
     name: "$CI_JOB_NAME"
     paths:
       - _build_ci
+  variables:
+    NJOBS: "1"
 
 library:ci-color:
   extends: .ci-template-flambda


### PR DESCRIPTION
Most workers these days have 1 core, and building bedrock with 2 cores
in that setup seems to be too memory stressful.