### PR TITLE
Remove uses of Global in Evd API.

### DIFF
--- a/dev/ci/user-overlays/11338-ppedrot-rm-global-uses-evd.sh
+++ b/dev/ci/user-overlays/11338-ppedrot-rm-global-uses-evd.sh
@@ -1,0 +1,9 @@
+if [ "$CI_PULL_REQUEST" = "11338" ] || [ "$CI_BRANCH" = "rm-global-uses-evd" ]; then
+
+    unicoq_CI_REF=rm-global-uses-evd
+    unicoq_CI_GITURL=https://github.com/ppedrot/unicoq
+
+    equations_CI_REF=rm-global-uses-evd
+    equations_CI_GITURL=https://github.com/ppedrot/Coq-Equations
+
+fi

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -200,13 +200,14 @@ let evar_filtered_hyps evi = match Filter.repr (evar_filter evi) with
   in
   make_hyps filter (evar_context evi)
 
-let evar_env evi = Global.env_of_context evi.evar_hyps
+let evar_env env evi =
+  Environ.reset_with_named_context evi.evar_hyps env
 
-let evar_filtered_env evi = match Filter.repr (evar_filter evi) with
-| None -> evar_env evi
+let evar_filtered_env env evi = match Filter.repr (evar_filter evi) with
+| None -> evar_env env evi
 | Some filter ->
   let rec make_env filter ctxt = match filter, ctxt with
-  | [], [] -> reset_context (Global.env ())
+  | [], [] -> reset_context env
   | false :: filter, _ :: ctxt -> make_env filter ctxt
   | true :: filter, decl :: ctxt ->
     let env = make_env filter ctxt in

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -125,8 +125,8 @@ val evar_filtered_hyps : evar_info -> named_context_val
 val evar_body : evar_info -> evar_body
 val evar_candidates : evar_info -> constr list option
 val evar_filter : evar_info -> Filter.t
-val evar_env :  evar_info -> env
-val evar_filtered_env :  evar_info -> env
+val evar_env : env -> evar_info -> env
+val evar_filtered_env : env -> evar_info -> env
 
 val map_evar_body : (econstr -> econstr) -> evar_body -> evar_body
 val map_evar_info : (econstr -> econstr) -> evar_info -> evar_info

--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -1039,9 +1039,9 @@ let (>>=) = tclBIND
 
 (** {6 Goal-dependent tactics} *)
 
-let goal_env evars gl =
+let goal_env env evars gl =
   let evi = Evd.find evars gl in
-  Evd.evar_filtered_env evi
+  Evd.evar_filtered_env env evi
 
 let goal_nf_evar sigma gl =
   let evi = Evd.find sigma gl in
@@ -1256,9 +1256,10 @@ module V82 = struct
 
   let of_tactic t gls =
     try
+      let env = Global.env () in
       let init = { shelf = []; solution = gls.Evd.sigma ; comb = [with_empty_state gls.Evd.it] } in
       let name, poly = Names.Id.of_string "legacy_pe", false in
-      let (_,final,_,_) = apply ~name ~poly (goal_env gls.Evd.sigma gls.Evd.it) t init in
+      let (_,final,_,_) = apply ~name ~poly (goal_env env gls.Evd.sigma gls.Evd.it) t init in
       { Evd.sigma = final.solution ; it = CList.map drop_state final.comb }
     with Logic_monad.TacticFailure e as src ->
       let (_, info) = CErrors.push src in

--- a/pretyping/evardefine.ml
+++ b/pretyping/evardefine.ml
@@ -76,7 +76,7 @@ let idx = Namegen.default_dependent_ident
 let define_pure_evar_as_product env evd evk =
   let open Context.Named.Declaration in
   let evi = Evd.find_undefined evd evk in
-  let evenv = evar_env evi in
+  let evenv = evar_env env evi in
   let id = next_ident_away idx (Environ.ids_of_named_context_val evi.evar_hyps) in
   let concl = Reductionops.whd_all evenv evd evi.evar_concl in
   let s = destSort evd concl in
@@ -129,7 +129,7 @@ let define_evar_as_product env evd (evk,args) =
 let define_pure_evar_as_lambda env evd evk =
   let open Context.Named.Declaration in
   let evi = Evd.find_undefined evd evk in
-  let evenv = evar_env evi in
+  let evenv = evar_env env evi in
   let typ = Reductionops.whd_all evenv evd (evar_concl evi) in
   let evd1,(na,dom,rng) = match EConstr.kind evd typ with
   | Prod (na,dom,rng) -> (evd,(na,dom,rng))
@@ -170,7 +170,7 @@ let rec evar_absorb_arguments env evd (evk,args as ev) = function
 let define_evar_as_sort env evd (ev,args) =
   let evd, s = new_sort_variable univ_rigid evd in
   let evi = Evd.find_undefined evd ev in
-  let concl = Reductionops.whd_all (evar_env evi) evd evi.evar_concl in
+  let concl = Reductionops.whd_all (evar_env env evi) evd evi.evar_concl in
   let sort = destSort evd concl in
   let evd' = Evd.define ev (mkSort s) evd in
   Evd.set_leq_sort env evd' (Sorts.super s) (ESorts.kind evd' sort), s

--- a/pretyping/evarsolve.mli
+++ b/pretyping/evarsolve.mli
@@ -77,7 +77,7 @@ type conversion_check = unify_flags -> unification_kind ->
     - [c] does not contain any Meta(_)
  *)
 
-val instantiate_evar : unifier -> unify_flags -> evar_map ->
+val instantiate_evar : unifier -> unify_flags -> env -> evar_map ->
   Evar.t -> constr -> evar_map
 
 (** [evar_define choose env ev c] try to instantiate [ev] with [c] (typed in [env]),
@@ -125,7 +125,7 @@ exception IllTypedInstance of env * types * types
 
 (* May raise IllTypedInstance if types are not convertible *)
 val check_evar_instance : unifier -> unify_flags ->
-  evar_map -> Evar.t -> constr -> evar_map
+  env -> evar_map -> Evar.t -> constr -> evar_map
 
 val remove_instance_local_defs :
   evar_map -> Evar.t -> 'a array -> 'a list

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -490,8 +490,8 @@ let pr_concl n ?(diffs=false) ?og_s sigma g =
   header ++ str " is:" ++ cut () ++ str" "  ++ pc
 
 (* display evar type: a context and a type *)
-let pr_evgl_sign sigma evi =
-  let env = evar_env evi in
+let pr_evgl_sign env sigma evi =
+  let env = evar_env env evi in
   let ps = pr_named_context_of env sigma in
   let _, l = match Filter.repr (evar_filter evi) with
   | None -> [], []
@@ -517,7 +517,8 @@ let pr_evgl_sign sigma evi =
 (* Print an existential variable *)
 
 let pr_evar sigma (evk, evi) =
-  let pegl = pr_evgl_sign sigma evi in
+  let env = Global.env () in
+  let pegl = pr_evgl_sign env sigma evi in
   hov 0 (pr_existential_key sigma evk ++ str " : " ++ pegl)
 
 (* Print an enumerated list of existential variables *)

--- a/proofs/evar_refiner.ml
+++ b/proofs/evar_refiner.ml
@@ -44,10 +44,10 @@ let define_and_solve_constraints evk c env evd =
     | Success evd -> evd
     | UnifFailure _ -> user_err Pp.(str "Instance does not satisfy the constraints.")
 
-let w_refine (evk,evi) (ltac_var,rawc) sigma =
+let w_refine (evk,evi) (ltac_var,rawc) env sigma =
   if Evd.is_defined sigma evk then
     user_err Pp.(str "Instantiate called on already-defined evar");
-  let env = Evd.evar_filtered_env evi in
+  let env = Evd.evar_filtered_env env evi in
   let sigma',typed_c =
     let flags = {
       Pretyping.use_typeclasses = true;

--- a/proofs/evar_refiner.mli
+++ b/proofs/evar_refiner.mli
@@ -17,4 +17,4 @@ open Ltac_pretype
 type glob_constr_ltac_closure = ltac_var_map * glob_constr
 
 val w_refine : Evar.t * evar_info ->
-  glob_constr_ltac_closure -> evar_map -> evar_map
+  glob_constr_ltac_closure -> Environ.env -> evar_map -> evar_map

--- a/proofs/goal.ml
+++ b/proofs/goal.ml
@@ -31,8 +31,9 @@ module V82 = struct
 
   (* Old style env primitive *)
   let env evars gl =
+    let env = Global.env () in
     let evi = Evd.find evars gl in
-    Evd.evar_filtered_env evi
+    Evd.evar_filtered_env env evi
 
   (* Old style hyps primitive *)
   let hyps evars gl =

--- a/proofs/proof.ml
+++ b/proofs/proof.ml
@@ -434,10 +434,10 @@ module V82 = struct
         else
           CList.nth evl (n-1)
       in
-      let env = Evd.evar_filtered_env evi in
+      let env = Evd.evar_filtered_env env evi in
       let rawc = intern env sigma in
       let ltac_vars = Glob_ops.empty_lvar in
-      let sigma = Evar_refiner.w_refine (evk, evi) (ltac_vars, rawc) sigma in
+      let sigma = Evar_refiner.w_refine (evk, evi) (ltac_vars, rawc) env sigma in
       Proofview.Unsafe.tclEVARS sigma
     end in
     let { name; poly } = pr in

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -605,7 +605,7 @@ let rec explain_evar_kind env sigma evk ty =
 let explain_typeclass_resolution env sigma evi k =
   match Typeclasses.class_of_constr env sigma evi.evar_concl with
   | Some _ ->
-    let env = Evd.evar_filtered_env evi in
+    let env = Evd.evar_filtered_env env evi in
       fnl () ++ str "Could not find an instance for " ++
       pr_leconstr_env env sigma evi.evar_concl ++
       pr_trailing_ne_context_of env sigma
@@ -622,7 +622,7 @@ let explain_placeholder_kind env sigma c e =
 
 let explain_unsolvable_implicit env sigma evk explain =
   let evi = Evarutil.nf_evar_info sigma (Evd.find_undefined sigma evk) in
-  let env = Evd.evar_filtered_env evi in
+  let env = Evd.evar_filtered_env env evi in
   let type_of_hole = pr_leconstr_env env sigma evi.evar_concl in
   let pe = pr_trailing_ne_context_of env sigma in
   strbrk "Cannot infer " ++

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -474,7 +474,7 @@ let program_inference_hook env sigma ev =
   let tac = !Obligations.default_tactic in
   let evi = Evd.find sigma ev in
   let evi = Evarutil.nf_evar_info sigma evi in
-  let env = Evd.evar_filtered_env evi in
+  let env = Evd.evar_filtered_env env evi in
   try
     let concl = evi.Evd.evar_concl in
     if not (Evarutil.is_ground_env sigma env &&


### PR DESCRIPTION
Namely, Evd.evar_env and Evd.evar_filtered_env now take an additional environment instead of querying the imperative global one. We percolate this change as higher up as possible.

Fixes #6523

Overlays:
- https://github.com/mattam82/Coq-Equations/pull/256
- https://github.com/unicoq/unicoq/pull/33