### PR TITLE
Add non-utf8 timing test

### DIFF
--- a/test-suite/coq-makefile/timing/precomputed-time-tests/run.sh
+++ b/test-suite/coq-makefile/timing/precomputed-time-tests/run.sh
@@ -9,3 +9,4 @@ export COQLIB
 
 ./001-correct-diff-sorting-order/run.sh
 ./002-single-file-sorting/run.sh
+./003-non-utf8/run.sh


### PR DESCRIPTION
This should have been running already, but it was forgotten in #9872

**Kind:** bug fix / infrastructure.

- [x] Added / updated test-suite
- [ ] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).  (Does this need a changelog entry?)
