### PR TITLE
Remove :flag: that appears in the doc output

### DIFF
--- a/doc/sphinx/language/gallina-specification-language.rst
+++ b/doc/sphinx/language/gallina-specification-language.rst
@@ -1478,7 +1478,7 @@ Chapter :ref:`Tactics`. The basic assertion command is:
       The name you provided is already defined. You have then to choose
       another name.
 
-   .. exn:: Nested proofs are not allowed unless you turn the :flag:`Nested Proofs Allowed` flag on.
+   .. exn:: Nested proofs are not allowed unless you turn the Nested Proofs Allowed flag on.
 
       You are asserting a new statement while already being in proof editing mode.
       This feature, called nested proofs, is disabled by default.


### PR DESCRIPTION
Fix this glitch:

![image](https://user-images.githubusercontent.com/1253341/71563373-3c3c9480-2a43-11ea-82f2-0de5704932b3.png)
