### PR TITLE
Discharge inductive types without rechecking them

### DIFF
--- a/checker/checkInductive.ml
+++ b/checker/checkInductive.ml
@@ -139,7 +139,7 @@ let check_inductive env mind mb =
   let entry = to_entry mb in
   let { mind_packets; mind_record; mind_finite; mind_ntypes; mind_hyps;
         mind_nparams; mind_nparams_rec; mind_params_ctxt;
-        mind_universes; mind_variance;
+        mind_universes; mind_variance; mind_sec_variance;
         mind_private; mind_typing_flags; }
     =
     (* Locally set typing flags for further typechecking *)
@@ -148,7 +148,7 @@ let check_inductive env mind mb =
                                                                   check_positive = mb_flags.check_positive;
                                                                   check_universes = mb_flags.check_universes;
                                                                   conv_oracle = mb_flags.conv_oracle} env in
-    Indtypes.check_inductive env mind entry
+    Indtypes.check_inductive env ~sec_univs:None mind entry
   in
   let check = check mind in
 
@@ -165,7 +165,9 @@ let check_inductive env mind mb =
 
   check "mind_params_ctxt" (Context.Rel.equal Constr.equal mb.mind_params_ctxt mind_params_ctxt);
   ignore mind_universes; (* Indtypes did the necessary checking *)
-  ignore mind_variance; (* Indtypes did the necessary checking *)
+  check "mind_variance" (Option.equal (Array.equal Univ.Variance.equal)
+                           mb.mind_variance mind_variance);
+  check "mind_sec_variance" (Option.is_empty mind_sec_variance);
   ignore mind_private; (* passed through Indtypes *)
 
   ignore mind_typing_flags;

--- a/checker/checkInductive.ml
+++ b/checker/checkInductive.ml
@@ -73,7 +73,7 @@ let check_arity env ar1 ar2 = match ar1, ar2 with
     List.equal (Option.equal Univ.Level.equal) ar.template_param_levels template_param_levels &&
     UGraph.check_leq (universes env) template_level ar.template_level
     (* template_level is inferred by indtypes, so functor application can produce a smaller one *)
-  | (RegularArity _ | TemplateArity _), _ -> false
+  | (RegularArity _ | TemplateArity _), _ -> assert false
 
 let check_kelim k1 k2 = Sorts.family_leq k1 k2
 

--- a/checker/values.ml
+++ b/checker/values.ml
@@ -299,6 +299,7 @@ let v_ind_pack = v_tuple "mutual_inductive_body"
     v_rctxt;
     v_univs; (* universes *)
     Opt (Array v_variance);
+    Opt (Array v_variance);
     Opt v_bool;
     v_typing_flags|]
 

--- a/kernel/cooking.mli
+++ b/kernel/cooking.mli
@@ -31,7 +31,7 @@ val cook_constr : Opaqueproof.cooking_info list ->
   (constr * unit Opaqueproof.delayed_universes) -> (constr * unit Opaqueproof.delayed_universes)
 
 val cook_inductive :
-  Opaqueproof.cooking_info -> mutual_inductive_body -> Entries.mutual_inductive_entry
+  Opaqueproof.cooking_info -> mutual_inductive_body -> mutual_inductive_body
 
 (** {6 Utility functions used in module [Discharge]. } *)
 

--- a/kernel/declarations.ml
+++ b/kernel/declarations.ml
@@ -224,7 +224,9 @@ type mutual_inductive_body = {
     mind_variance : Univ.Variance.t array option; (** Variance info, [None] when non-cumulative. *)
 
     mind_sec_variance : Univ.Variance.t array option;
-    (** Variance info for section polymorphic universes. [None] outside sections. *)
+    (** Variance info for section polymorphic universes. [None]
+       outside sections. The final variance once all sections are
+       discharged is [mind_sec_variance ++ mind_variance]. *)
 
     mind_private : bool option; (** allow pattern-matching: Some true ok, Some false blocked *)
 

--- a/kernel/declarations.ml
+++ b/kernel/declarations.ml
@@ -223,6 +223,9 @@ type mutual_inductive_body = {
 
     mind_variance : Univ.Variance.t array option; (** Variance info, [None] when non-cumulative. *)
 
+    mind_sec_variance : Univ.Variance.t array option;
+    (** Variance info for section polymorphic universes. [None] outside sections. *)
+
     mind_private : bool option; (** allow pattern-matching: Some true ok, Some false blocked *)
 
     mind_typing_flags : typing_flags; (** typing flags at the time of the inductive creation *)

--- a/kernel/declareops.ml
+++ b/kernel/declareops.ml
@@ -248,6 +248,7 @@ let subst_mind_body sub mib =
     mind_packets = Array.Smart.map (subst_mind_packet sub) mib.mind_packets ;
     mind_universes = mib.mind_universes;
     mind_variance = mib.mind_variance;
+    mind_sec_variance = mib.mind_sec_variance;
     mind_private = mib.mind_private;
     mind_typing_flags = mib.mind_typing_flags;
   }

--- a/kernel/indTyping.ml
+++ b/kernel/indTyping.ml
@@ -276,7 +276,7 @@ let abstract_packets ~template_check univs usubst params ((arity,lc),(indices,sp
   let kelim = allowed_sorts univ_info in
   (arity,lc), (indices,splayed_lc), kelim
 
-let typecheck_inductive env (mie:mutual_inductive_entry) =
+let typecheck_inductive env ~sec_univs (mie:mutual_inductive_entry) =
   let () = match mie.mind_entry_inds with
   | [] -> CErrors.anomaly Pp.(str "empty inductive types declaration.")
   | _ -> ()
@@ -341,7 +341,12 @@ let typecheck_inductive env (mie:mutual_inductive_entry) =
         CErrors.user_err Pp.(str "Inductive cannot be both monomorphic and universe cumulative.")
       | Polymorphic_entry (_,uctx) ->
         let univs = Instance.to_array @@ UContext.instance uctx in
-        Some (InferCumulativity.infer_inductive ~env_params univs mie.mind_entry_inds)
+        let univs = match sec_univs with
+          | None -> univs
+          | Some sec_univs -> Array.append sec_univs univs
+        in
+        let variances = InferCumulativity.infer_inductive ~env_params univs mie.mind_entry_inds in
+        Some variances
   in
 
   (* Abstract universes *)

--- a/kernel/indTyping.mli
+++ b/kernel/indTyping.mli
@@ -17,6 +17,7 @@ open Declarations
     - environment with inductives + parameters in rel context
     - abstracted universes
     - checked variance info
+      (variance for section universes is at the beginning of the array)
     - record entry (checked to be OK)
     - parameters
     - for each inductive,
@@ -24,9 +25,11 @@ open Declarations
       * (indices * splayed constructor types) (both without params)
       * top allowed elimination
  *)
-val typecheck_inductive : env -> mutual_inductive_entry ->
-  env
-  * universes * Univ.Variance.t array option
+val typecheck_inductive : env -> sec_univs:Univ.Level.t array option
+  -> mutual_inductive_entry
+  -> env
+  * universes
+  * Univ.Variance.t array option
   * Names.Id.t array option option
   * Constr.rel_context
   * ((inductive_arity * Constr.types array) *

--- a/kernel/indtypes.mli
+++ b/kernel/indtypes.mli
@@ -14,4 +14,5 @@ open Environ
 open Entries
 
 (** Check an inductive. *)
-val check_inductive : env -> MutInd.t -> mutual_inductive_entry -> mutual_inductive_body
+val check_inductive : env -> sec_univs:Univ.Level.t array option
+  -> MutInd.t -> mutual_inductive_entry -> mutual_inductive_body

--- a/kernel/inferCumulativity.mli
+++ b/kernel/inferCumulativity.mli
@@ -8,5 +8,14 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-val infer_inductive : Environ.env -> Entries.mutual_inductive_entry ->
-  Univ.Variance.t array option
+val infer_inductive
+  : env_params:Environ.env
+  (** Environment containing the polymorphic universes and the
+     parameters. *)
+  -> Univ.Level.t array
+  (** Universes whose cumulativity we want to infer. *)
+  -> Entries.one_inductive_entry list
+  (** The inductive block data we want to infer cumulativity for.
+      NB: we ignore the template bool and the names, only the terms
+      are used. *)
+  -> Univ.Variance.t array

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -908,16 +908,19 @@ let check_mind mie lab =
     (* The label and the first inductive type name should match *)
     assert (Id.equal (Label.to_id lab) oie.mind_entry_typename)
 
+let add_checked_mind kn mib senv =
+  let mib =
+    match mib.mind_hyps with [] -> Declareops.hcons_mind mib | _ -> mib
+  in
+  add_field (MutInd.label kn,SFBmind mib) (I kn) senv
+
 let add_mind l mie senv =
   let () = check_mind mie l in
   let kn = MutInd.make2 senv.modpath l in
   let sec_univs = Option.map Section.all_poly_univs  senv.sections
   in
   let mib = Indtypes.check_inductive senv.env ~sec_univs kn mie in
-  let mib =
-    match mib.mind_hyps with [] -> Declareops.hcons_mind mib | _ -> mib
-  in
-  kn, add_field (l,SFBmind mib) (I kn) senv
+  kn, add_checked_mind kn mib senv
 
 (** Insertion of module types *)
 
@@ -1016,9 +1019,8 @@ let close_section senv =
     add_constant_aux senv (kn, cb)
   | `Inductive (ind, mib) ->
     let info = cooking_info (Section.segment_of_inductive env0 ind sections0) in
-    let mie = Cooking.cook_inductive info mib in
-    let _, senv = add_mind (MutInd.label ind) mie senv in
-    senv
+    let mib = Cooking.cook_inductive info mib in
+    add_checked_mind ind mib senv
   in
   List.fold_left fold senv redo
 

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -911,7 +911,9 @@ let check_mind mie lab =
 let add_mind l mie senv =
   let () = check_mind mie l in
   let kn = MutInd.make2 senv.modpath l in
-  let mib = Indtypes.check_inductive senv.env kn mie in
+  let sec_univs = Option.map Section.all_poly_univs  senv.sections
+  in
+  let mib = Indtypes.check_inductive senv.env ~sec_univs kn mie in
   let mib =
     match mib.mind_hyps with [] -> Declareops.hcons_mind mib | _ -> mib
   in

--- a/kernel/section.mli
+++ b/kernel/section.mli
@@ -57,6 +57,14 @@ val push_inductive : poly:bool -> MutInd.t -> 'a t -> 'a t
 
 (** {6 Retrieving section data} *)
 
+val all_poly_univs : 'a t -> Univ.Level.t array
+(** Returns all polymorphic universes, including those from previous
+   sections. Earlier sections are earlier in the array.
+
+    NB: even if the array is empty there may be polymorphic
+   constraints about monomorphic universes, which prevent declaring
+   monomorphic globals. *)
+
 type abstr_info = private {
   abstr_ctx : Constr.named_context;
   (** Section variables of this prefix *)

--- a/kernel/univ.ml
+++ b/kernel/univ.ml
@@ -755,6 +755,10 @@ struct
     | Invariant, _ | _, Invariant -> Invariant
     | Covariant, Covariant -> Covariant
 
+  let equal a b = match a,b with
+    | Irrelevant, Irrelevant | Covariant, Covariant | Invariant, Invariant -> true
+    | (Irrelevant | Covariant | Invariant), _ -> false
+
   let check_subtype x y = match x, y with
   | (Irrelevant | Covariant | Invariant), Irrelevant -> true
   | Irrelevant, Covariant -> false

--- a/kernel/univ.mli
+++ b/kernel/univ.mli
@@ -263,6 +263,8 @@ sig
 
   val pr : t -> Pp.t
 
+  val equal : t -> t -> bool
+
 end
 
 (** {6 Universe instances} *)

--- a/test-suite/success/Inductive.v
+++ b/test-suite/success/Inductive.v
@@ -204,3 +204,19 @@ End NonRecLetIn.
 
 Fail Inductive foo (T : Type) : let T := Type in T :=
   { r : forall x : T, x = x }.
+
+Module Discharge.
+  (* discharge test *)
+  Section S.
+    Let x := Prop.
+    Inductive foo : x := bla : foo.
+  End S.
+  Check bla:foo.
+
+  Section S.
+    Variables (A:Type).
+    (* ensure params are scanned for needed section variables even with template arity *)
+    #[universes(template)] Inductive bar (d:A) := .
+  End S.
+  Check @bar nat 0.
+End Discharge.


### PR DESCRIPTION
Needs a bit of cleanup (penultimate commit should be squashed into 2nd commit), also there is a possibility that I made a mistake.
Cleanups unlocked by this (ie the section univ redeclaration issue) have not yet been attempted.

Also fix checker checking variance forgotten in #11027 
Also minor cleanup template_polymorphic_univs: check_levels returns bool, done while looking at this part of the code to see what needs to be done at discharge time
Also cleanup: do not use recargs when computing the reloc table for ctors done while I was reading this part of the code to understand if we need to recompute this stuff on discharge (we don't AFAICT)