### PR TITLE
stdlib List: add [remove'] and [count_occ'] that use [filter]

### DIFF
--- a/doc/changelog/10-standard-library/11350-list.rst
+++ b/doc/changelog/10-standard-library/11350-list.rst
@@ -1,0 +1,5 @@
+- **Added:**
+  ``remove'`` and ``count_occ'`` over lists,
+  alternatives to ``remove`` and ``count_occ`` based on ``filter``
+  (`#11350 <https://github.com/coq/coq/pull/11350>`_,
+  by Yishuai Li).

--- a/theories/Lists/List.v
+++ b/theories/Lists/List.v
@@ -1391,6 +1391,31 @@ End Fold_Right_Recursor.
       intros f g H l. rewrite filter_map. apply map_ext. assumption.
     Qed.
 
+    (** Remove by filtering *)
+
+    Hypothesis eq_dec : forall x y : A, {x = y}+{x <> y}.
+
+    Definition remove' (x : A) : list A -> list A :=
+      filter (fun y => if eq_dec x y then false else true).
+
+    Lemma remove_alt (x : A) (l : list A) : remove' x l = remove eq_dec x l.
+    Proof with intuition.
+      induction l...
+      simpl. destruct eq_dec; f_equal...
+    Qed.
+
+    (** Counting occurrences by filtering *)
+
+    Definition count_occ' (l : list A) (x : A) : nat :=
+      length (filter (fun y => if eq_dec y x then true else false) l).
+
+    Lemma count_occ_alt (l : list A) (x : A) :
+      count_occ' l x = count_occ eq_dec l x.
+    Proof with intuition.
+      unfold count_occ'. induction l...
+      simpl; destruct eq_dec; simpl...
+    Qed.
+
   End Filtering.
 
 


### PR DESCRIPTION
## Added
- `remove'` and `count_occ'` functions using `filter`
- Proof of equivalence with `remove` and `count_occ`

<!-- Keep what applies -->
**Kind:** feature.

<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [ ] Added / updated test-suite
<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [ ] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
