### PR TITLE
stdlib Arith: remove use of files mentioned as (mostly) obsolete

### DIFF
--- a/plugins/micromega/Lia.v
+++ b/plugins/micromega/Lia.v
@@ -30,7 +30,7 @@ Ltac zchecker :=
                                 (@find Z Z0 __varmap)).
 
 Ltac lia := PreOmega.zify; xlia zchecker.
-               
+
 Ltac nia := PreOmega.zify; xnlia zchecker.
 
 

--- a/plugins/omega/OmegaLemmas.v
+++ b/plugins/omega/OmegaLemmas.v
@@ -180,7 +180,7 @@ Qed.
 Lemma OMEGA20 x y z : Zne x 0 -> y = 0 -> Zne (x + y * z) 0.
 Proof.
  unfold Zne, not. intros H1 H2 H3; apply H1; rewrite H2 in H3;
- simpl in H3; rewrite Z.add_0_r in H3; trivial with arith.
+ simpl in H3; rewrite Z.add_0_r in H3; trivial.
 Qed.
 
 Definition fast_Zplus_comm (x y : Z) (P : Z -> Prop)

--- a/theories/Arith/Compare.v
+++ b/theories/Arith/Compare.v
@@ -16,7 +16,7 @@ Notation not_eq_sym := not_eq_sym (only parsing).
 
 Implicit Types m n p q : nat.
 
-Require Import Arith_base.
+Require Import PeanoNat.
 Require Import Peano_dec.
 Require Import Compare_dec.
 
@@ -33,23 +33,24 @@ Lemma le_decide : forall n m, n <= m -> lt_or_eq n m.
 Proof le_lt_eq_dec.
 
 Lemma le_le_S_eq : forall n m, n <= m -> S n <= m \/ n = m.
-Proof le_lt_or_eq.
+Proof. apply Nat.lt_eq_cases. Qed.
 
 (* By special request of G. Kahn - Used in Group Theory *)
 Lemma discrete_nat :
   forall n m, n < m -> S n = m \/ (exists r : nat, m = S (S (n + r))).
 Proof.
   intros m n H.
-  lapply (lt_le_S m n); auto with arith.
-  intro H'; lapply (le_lt_or_eq (S m) n); auto with arith.
-  induction 1; auto with arith.
-  right; exists (n - S (S m)); simpl.
-  rewrite (plus_comm m (n - S (S m))).
-  rewrite (plus_n_Sm (n - S (S m)) m).
-  rewrite (plus_n_Sm (n - S (S m)) (S m)).
-  rewrite (plus_comm (n - S (S m)) (S (S m))); auto with arith.
+  inversion H as [ | k H1 H2 ]; auto; subst.
+  right; exists (S k - S (S m)).
+  rewrite (Nat.add_comm m (S k - S (S m))).
+  rewrite (plus_n_Sm (S k - S (S m)) m).
+  rewrite (plus_n_Sm (S k - S (S m)) (S m)).
+  rewrite Nat.sub_add; auto.
+  now apply Nat.succ_le_mono in H1.
 Qed.
 
 Require Export Wf_nat.
 
+(*
 Require Export Min Max.
+*)

--- a/theories/Arith/Compare_dec.v
+++ b/theories/Arith/Compare_dec.v
@@ -8,7 +8,7 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-Require Import Le Lt Gt Decidable PeanoNat.
+Require Import Decidable PeanoNat.
 
 Local Open Scope nat_scope.
 
@@ -16,14 +16,18 @@ Implicit Types m n x y : nat.
 
 Definition zerop n : {n = 0} + {0 < n}.
 Proof.
-  destruct n; auto with arith.
+  destruct n; [left|right]; auto.
+  apply Nat.lt_0_succ.
 Defined.
 
 Definition lt_eq_lt_dec n m : {n < m} + {n = m} + {m < n}.
 Proof.
-  induction n in m |- *; destruct m; auto with arith.
-  destruct (IHn m) as [H|H]; auto with arith.
-  destruct H; auto with arith.
+  induction n in m |- *; destruct m; auto.
+  - left; left; apply Nat.lt_0_succ.
+  - right; apply Nat.lt_0_succ.
+  - destruct (IHn m) as [[H|H]|H]; auto.
+    + left; left; now apply Nat.succ_lt_mono in H.
+    + right; now apply Nat.succ_lt_mono in H.
 Defined.
 
 Definition gt_eq_gt_dec n m : {m > n} + {n = m} + {n > m}.
@@ -34,10 +38,12 @@ Defined.
 Definition le_lt_dec n m : {n <= m} + {m < n}.
 Proof.
   induction n in m |- *.
-  - left; auto with arith.
+  - left; apply Nat.le_0_l.
   - destruct m.
-    + right; auto with arith.
-    + elim (IHn m); [left|right]; auto with arith.
+    + right; apply Nat.lt_0_succ.
+    + elim (IHn m); intros H; [left|right].
+      * now apply Nat.succ_le_mono in H.
+      * now apply Nat.succ_lt_mono in H.
 Defined.
 
 Definition le_le_S_dec n m : {n <= m} + {S m <= n}.
@@ -47,7 +53,8 @@ Defined.
 
 Definition le_ge_dec n m : {n <= m} + {n >= m}.
 Proof.
-  elim (le_lt_dec n m); auto with arith.
+  elim (le_le_S_dec n m); intros H; auto.
+  right; now apply Nat.lt_le_incl.
 Defined.
 
 Definition le_gt_dec n m : {n <= m} + {n > m}.
@@ -57,15 +64,20 @@ Defined.
 
 Definition le_lt_eq_dec n m : n <= m -> {n < m} + {n = m}.
 Proof.
-  intros; destruct (lt_eq_lt_dec n m); auto with arith.
-  intros; absurd (m < n); auto with arith.
+  intros Hlt.
+  destruct (lt_eq_lt_dec n m) as [[H|H]|H]; auto.
+  exfalso.
+  apply (Nat.le_lt_trans _ _ _ Hlt) in H.
+  now apply Nat.lt_irrefl in H.
 Defined.
 
 Theorem le_dec n m : {n <= m} + {~ n <= m}.
 Proof.
   destruct (le_gt_dec n m).
   - now left.
-  - right. now apply gt_not_le.
+  - right; intros Hle.
+    apply (Nat.le_lt_trans _ _ _ Hle) in g.
+    now apply Nat.lt_irrefl in g.
 Defined.
 
 Theorem lt_dec n m : {n < m} + {~ n < m}.

--- a/theories/Arith/EqNat.v
+++ b/theories/Arith/EqNat.v
@@ -27,7 +27,6 @@ Theorem eq_nat_refl n : eq_nat n n.
 Proof.
   induction n; simpl; auto.
 Qed.
-Hint Resolve eq_nat_refl: arith.
 
 (** [eq] restricted to [nat] and [eq_nat] are equivalent *)
 
@@ -48,12 +47,10 @@ Proof.
  apply eq_nat_is_eq.
 Qed.
 
-Hint Immediate eq_eq_nat eq_nat_eq: arith.
-
 Theorem eq_nat_elim :
   forall n (P:nat -> Prop), P n -> forall m, eq_nat n m -> P m.
 Proof.
-  intros; replace m with n; auto with arith.
+  intros; replace m with n; auto. now apply eq_nat_eq.
 Qed.
 
 Theorem eq_nat_decide : forall n m, {eq_nat n m} + {~ eq_nat n m}.
@@ -102,3 +99,8 @@ Proof.
   - discriminate.
   - intros H. case (IHn _ H). reflexivity.
 Defined.
+
+(* Compatibility
+Hint Resolve eq_nat_refl: arith.
+Hint Immediate eq_eq_nat eq_nat_eq: arith.
+*)

--- a/theories/Arith/PeanoNat.v
+++ b/theories/Arith/PeanoNat.v
@@ -223,10 +223,6 @@ Proof.
  reflexivity.
 Qed.
 
-
-(* BUG: Ajout d'un cas * après preuve finie (deuxième niveau +++*** ) :
-    *  --->   Anomaly: Uncaught exception Proofview.IndexOutOfRange(_). Please report. *)
-
 (** ** Minimum, maximum *)
 
 Lemma max_l : forall n m, m <= n -> max n m = n.

--- a/theories/Arith/Peano_dec.v
+++ b/theories/Arith/Peano_dec.v
@@ -23,8 +23,6 @@ Defined.
 
 Notation eq_nat_dec := Nat.eq_dec (only parsing).
 
-Hint Resolve O_or_S eq_nat_dec: arith.
-
 Theorem dec_eq_nat n m : decidable (n = m).
 Proof.
   elim (Nat.eq_dec n m); [left|right]; trivial.
@@ -61,4 +59,8 @@ now rewrite H.
 Qed.
 
 (** For compatibility *)
+(*
+Hint Resolve O_or_S eq_nat_dec: arith.
+
 Require Import Le Lt.
+*)

--- a/theories/Arith/Plus.v
+++ b/theories/Arith/Plus.v
@@ -187,5 +187,6 @@ Hint Immediate lt_plus_trans : arith.
 Hint Resolve plus_lt_compat_l plus_lt_compat_r : arith.
 
 (** For compatibility, we "Require" the same files as before *)
-
+(*
 Require Import Le Lt.
+*)

--- a/theories/Arith/Wf_nat.v
+++ b/theories/Arith/Wf_nat.v
@@ -10,7 +10,7 @@
 
 (** Well-founded relations and natural numbers *)
 
-Require Import PeanoNat Lt.
+Require Import PeanoNat.
 
 Local Open Scope nat_scope.
 
@@ -28,10 +28,10 @@ Theorem well_founded_ltof : well_founded ltof.
 Proof.
   assert (H : forall n (a:A), f a < n -> Acc ltof a).
   { induction n.
-    - intros; absurd (f a < 0); auto with arith.
+    - intros; absurd (f a < 0); auto. apply Nat.nlt_0_r.
     - intros a Ha. apply Acc_intro. unfold ltof at 1. intros b Hb.
-      apply IHn. apply Nat.lt_le_trans with (f a); auto with arith. }
-  intros a. apply (H (S (f a))). auto with arith.
+      apply IHn. apply Nat.lt_le_trans with (f a); auto. now apply Nat.succ_le_mono. }
+  intros a. apply (H (S (f a))). apply Nat.lt_succ_diag_r.
 Defined.
 
 Theorem well_founded_gtof : well_founded gtof.
@@ -68,10 +68,10 @@ Proof.
   intros P F.
   assert (H : forall n (a:A), f a < n -> P a).
   { induction n.
-    - intros; absurd (f a < 0); auto with arith.
+    - intros; absurd (f a < 0); auto. apply Nat.nlt_0_r.
     - intros a Ha. apply F. unfold ltof. intros b Hb.
-      apply IHn. apply Nat.lt_le_trans with (f a); auto with arith. }
-  intros a. apply (H (S (f a))). auto with arith.
+      apply IHn. apply Nat.lt_le_trans with (f a); auto. now apply Nat.succ_le_mono. }
+  intros a. apply (H (S (f a))). apply Nat.lt_succ_diag_r.
 Defined.
 
 Theorem induction_gtof1 :
@@ -106,10 +106,10 @@ Theorem well_founded_lt_compat : well_founded R.
 Proof.
   assert (H : forall n (a:A), f a < n -> Acc R a).
   { induction n.
-    - intros; absurd (f a < 0); auto with arith.
+    - intros; absurd (f a < 0); auto. apply Nat.nlt_0_r.
     - intros a Ha. apply Acc_intro. intros b Hb.
-      apply IHn. apply Nat.lt_le_trans with (f a); auto with arith. }
-  intros a. apply (H (S (f a))). auto with arith.
+      apply IHn. apply Nat.lt_le_trans with (f a); auto. now apply Nat.succ_le_mono. }
+  intros a. apply (H (S (f a))). apply Nat.lt_succ_diag_r.
 Defined.
 
 End Well_founded_Nat.
@@ -134,7 +134,7 @@ Defined.
 Lemma lt_wf_ind :
   forall n (P:nat -> Prop), (forall n, (forall m, m < n -> P m) -> P n) -> P n.
 Proof.
-  intro p; intros; elim (lt_wf p); auto with arith.
+  intro p; intros; elim (lt_wf p); auto.
 Qed.
 
 Lemma gt_wf_rec :
@@ -154,7 +154,7 @@ Lemma lt_wf_double_rec :
      (forall p, p < m -> P n p) -> P n m) -> forall n m, P n m.
 Proof.
   intros P Hrec p; pattern p; apply lt_wf_rec.
-  intros n H q; pattern q; apply lt_wf_rec; auto with arith.
+  intros n H q; pattern q; apply lt_wf_rec; auto.
 Defined.
 
 Lemma lt_wf_double_ind :
@@ -164,11 +164,8 @@ Lemma lt_wf_double_ind :
       (forall p, p < m -> P n p) -> P n m) -> forall n m, P n m.
 Proof.
   intros P Hrec p; pattern p; apply lt_wf_ind.
-  intros n H q; pattern q; apply lt_wf_ind; auto with arith.
+  intros n H q; pattern q; apply lt_wf_ind; auto.
 Qed.
-
-Hint Resolve lt_wf: arith.
-Hint Resolve well_founded_lt_compat: arith.
 
 Section LT_WF_REL.
   Variable A : Set.
@@ -209,10 +206,6 @@ Qed.
 
 Set Implicit Arguments.
 
-Require Import Le.
-Require Import Compare_dec.
-Require Import Decidable.
-
 Definition has_unique_least_element (A:Type) (R:A->A->Prop) (P:A->Prop) :=
   exists! x, P x /\ forall x', P x' -> R x x'.
 
@@ -227,9 +220,9 @@ Proof.
   { induction n.
     - right. intros. apply Nat.le_0_l.
     - destruct IHn as [(n' & IH1 & IH2)|IH].
-      + left. exists n'; auto with arith.
+      + left. exists n'; auto.
       + destruct (Pdec n) as [HP|HP].
-        * left. exists n; auto with arith.
+        * left. exists n; auto.
         * right. intros n' Hn'.
           apply Nat.le_neq; split; auto. intros <-. auto. }
   destruct (H n0) as [(n & H1 & H2 & H3)|H0]; [exists n | exists n0];
@@ -240,3 +233,8 @@ Qed.
 Unset Implicit Arguments.
 
 Notation iter_nat n A f x := (nat_rect (fun _ => A) x (fun _ => f) n) (only parsing).
+
+(* Compatibility
+Hint Resolve lt_wf: arith.
+Hint Resolve well_founded_lt_compat: arith.
+*)

--- a/theories/Bool/Zerob.v
+++ b/theories/Bool/Zerob.v
@@ -8,7 +8,6 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-Require Import Arith.
 Require Import Bool.
 
 Local Open Scope nat_scope.

--- a/theories/FSets/FMapAVL.v
+++ b/theories/FSets/FMapAVL.v
@@ -18,7 +18,7 @@
     See the comments at the beginning of FSetAVL for more details.
 *)
 
-Require Import FunInd FMapInterface FMapList ZArith Int.
+Require Import FunInd FMapInterface FMapList PeanoNat BinInt Int.
 
 Set Implicit Arguments.
 Unset Strict Implicit.
@@ -2203,4 +2203,3 @@ Module Make_ord (X: OrderedType)(D: OrderedType)
  <: Sord with Module Data := D
             with Module MapS.E := X
  :=IntMake_ord(Z_as_Int)(X)(D).
-

--- a/theories/FSets/FMapFullAVL.v
+++ b/theories/FSets/FMapFullAVL.v
@@ -27,8 +27,7 @@
 
 *)
 
-Require Import FunInd Recdef FMapInterface FMapList ZArith Int FMapAVL Lia.
-
+Require Import FunInd Recdef FMapInterface FMapList PeanoNat BinInt Int FMapAVL Lia.
 Set Implicit Arguments.
 Unset Strict Implicit.
 
@@ -671,7 +670,8 @@ Module IntMake_ord (I:Int)(X: OrderedType)(D : OrderedType) <:
    cardinal_e (Raw.cons m e) = (Raw.cardinal m + cardinal_e e)%nat.
   Proof.
    induction m; simpl; intros; auto.
-   rewrite IHm1; simpl; rewrite <- plus_n_Sm; auto with arith.
+   rewrite IHm1; simpl; rewrite <- plus_n_Sm.
+   now rewrite Nat.add_assoc.
   Qed.
 
   Definition cardinal_e_2 ee :=

--- a/theories/FSets/FSetPositive.v
+++ b/theories/FSets/FSetPositive.v
@@ -18,7 +18,7 @@
    Sandrine Blazy (used for building certified compilers).
 *)
 
-Require Import Bool BinPos OrderedType OrderedTypeEx FSetInterface.
+Require Import Bool PeanoNat BinPos OrderedType OrderedTypeEx FSetInterface.
 
 Set Implicit Arguments.
 Local Open Scope lazy_bool_scope.
@@ -780,13 +780,11 @@ Module PositiveSet <: S with Module E:=PositiveOrderedTypeBits.
     unfold elements.
     assert (H: forall s j acc,
                 (cardinal s + length acc)%nat = length (xelements s j acc)).
-
-    induction s as [|l IHl b r IHr]; intros j acc; simpl; trivial. destruct b.
-      rewrite <- IHl. simpl. rewrite <- IHr.
-       rewrite <- plus_n_Sm, Plus.plus_assoc. reflexivity.
-      rewrite <- IHl, <- IHr. rewrite Plus.plus_assoc. reflexivity.
-
-    intros. rewrite <- H. simpl. rewrite Plus.plus_comm. reflexivity.
+    - induction s as [|l IHl b r IHr]; intros j acc; simpl; trivial. destruct b.
+      + rewrite <- IHl. simpl. rewrite <- IHr.
+        rewrite <- plus_n_Sm, Nat.add_assoc. reflexivity.
+      + rewrite <- IHl, <- IHr. rewrite Nat.add_assoc. reflexivity.
+    - intros. rewrite <- H. simpl. rewrite Nat.add_comm. reflexivity.
   Qed.
 
   (** Specification of [filter] *)

--- a/theories/FSets/FSetProperties.v
+++ b/theories/FSets/FSetProperties.v
@@ -17,7 +17,7 @@
     [Equal s s'] instead of [equal s s'=true], etc. *)
 
 Require Export FSetInterface.
-Require Import DecidableTypeEx FSetFacts FSetDecide.
+Require Import PeanoNat DecidableTypeEx FSetFacts FSetDecide.
 Set Implicit Arguments.
 Unset Strict Implicit.
 
@@ -813,7 +813,9 @@ Module WProperties_fun (Import E : DecidableType)(M : WSfun E).
   intros.
   rewrite <- (diff_inter_cardinal s' s).
   rewrite (inter_sym s' s).
-  rewrite (inter_subset_equal H); auto with arith.
+  rewrite (inter_subset_equal H).
+  rewrite Nat.add_comm.
+  apply Nat.le_add_r.
   Qed.
 
   Lemma subset_cardinal_lt :
@@ -828,8 +830,8 @@ Module WProperties_fun (Import E : DecidableType)(M : WSfun E).
   intro H2; destruct (H2 Logic.eq_refl x).
   set_iff; auto.
   intros _.
-  change (0 + cardinal s < S n + cardinal s).
-  apply Plus.plus_lt_le_compat; auto with arith.
+  rewrite plus_Sn_m, plus_n_Sm, Nat.add_comm.
+  apply Nat.le_add_r.
   Qed.
 
   Theorem union_inter_cardinal :
@@ -846,15 +848,14 @@ Module WProperties_fun (Import E : DecidableType)(M : WSfun E).
   Proof.
   intros.
   rewrite <- union_inter_cardinal.
-  rewrite Plus.plus_comm.
-  auto with arith.
+  now rewrite Nat.add_sub.
   Qed.
 
   Lemma union_cardinal_le :
    forall s s', cardinal (union s s') <= cardinal s  + cardinal s'.
   Proof.
    intros; generalize (union_inter_cardinal s s').
-   intros; rewrite <- H; auto with arith.
+   intros; rewrite <- H. apply Nat.le_add_r.
   Qed.
 
   Lemma add_cardinal_1 :

--- a/theories/Logic/ChoiceFacts.v
+++ b/theories/Logic/ChoiceFacts.v
@@ -944,7 +944,7 @@ Qed.
 (** * Choice => Dependent choice => Countable choice *)
 (* The implications below are standard *)
 
-Require Import Arith.
+Require Import PeanoNat.
 
 Theorem functional_choice_imp_functional_dependent_choice :
    FunctionalChoice -> FunctionalDependentChoice.

--- a/theories/Logic/ConstructiveEpsilon.v
+++ b/theories/Logic/ConstructiveEpsilon.v
@@ -42,7 +42,7 @@ For the first one we provide explicit and short proof terms. *)
 
 (* Direct version *)
 
-Require Import Arith.
+Require Import PeanoNat.
 
 Section ConstructiveIndefiniteGroundDescription_Direct.
 
@@ -94,10 +94,10 @@ Proof.
   - (* P start, k cannot exist *)
     intros. assert (proj1_sig (linear_search start pr) = start).
     { unfold linear_search. destruct pr; rewrite -> Pstart; reflexivity. }
-    rewrite -> H0 in H. destruct H. apply (le_lt_trans start k) in H1.
-    apply lt_irrefl in H1. contradiction. assumption.
+    rewrite -> H0 in H. destruct H. apply (Nat.le_lt_trans start k) in H1.
+    apply Nat.lt_irrefl in H1. contradiction. assumption.
   - (* ~P start, step once in the search and use induction hypothesis *)
-    destruct pr. contradiction. destruct H. apply le_lt_or_eq in H. destruct H.
+    destruct pr. contradiction. destruct H. apply Nat.lt_eq_cases in H. destruct H.
     apply (linear_search_smallest (S start) pr). split. assumption.
     simpl in H0. rewrite -> Pstart in H0. assumption. subst. assumption.
 Defined.
@@ -154,13 +154,13 @@ intros x n; generalize x; clear x; induction n as [|n IH]; simpl.
 apply P_implies_acc.
 intros x H. constructor. intros y [fxy _].
 apply IH. rewrite fxy.
-replace (n + S x) with (S (n + x)); auto with arith.
+replace (n + S x) with (S (n + x)); auto.
 Defined.
 
 Corollary P_eventually_implies_acc_ex : (exists n : nat, P n) -> acc 0.
 Proof.
 intros H; elim H. intros x Px. apply P_eventually_implies_acc with (n := x).
-replace (x + 0) with x; auto with arith.
+replace (x + 0) with x; auto.
 Defined.
 
 (** In the following statement, we use the trick with recursion on

--- a/theories/Logic/FinFun.v
+++ b/theories/Logic/FinFun.v
@@ -13,7 +13,7 @@
 (** Main result : for functions [f:A->A] with finite [A],
     f injective <-> f bijective <-> f surjective. *)
 
-Require Import List Compare_dec EqNat Decidable ListDec. Require Fin.
+Require Import PeanoNat List Decidable ListDec. Require Fin.
 Set Implicit Arguments.
 
 (** General definitions *)
@@ -252,24 +252,27 @@ Definition n2f_ext : forall x n h h', n2f h = n2f h' := @Fin.of_nat_ext.
 Definition f2n_inj : forall n x y, f2n x = f2n y -> x = y := @Fin.to_nat_inj.
 
 Definition extend n (f:Fin.t n -> Fin.t n) : (nat->nat) :=
- fun x =>
-   match le_lt_dec n x with
-     | left _ => 0
-     | right h => f2n (f (n2f h))
-   end.
+  fun x => (match CompareSpec2Type (Nat.compare_spec x n) with
+            | CompLtT _ _ H => f2n (f (n2f H))
+            | _ => 0
+            end).
 
 Definition restrict n (f:nat->nat)(hf : bFun n f) : (Fin.t n -> Fin.t n) :=
  fun x => let (x',h) := Fin.to_nat x in n2f (hf _ h).
 
 Ltac break_dec H :=
- let H' := fresh "H" in
- destruct le_lt_dec as [H'|H'];
-  [elim (Lt.le_not_lt _ _ H' H)
-  |try rewrite (n2f_ext H' H) in *; try clear H'].
+ match type of H with
+ | ?x < ?n => destruct (Nat.compare_spec x n) as [H'|H'|H']; simpl;
+              [ exfalso; rewrite H' in H; now apply Nat.lt_irrefl in H
+              | try rewrite (n2f_ext H' H) in *; try clear H'
+              | exfalso; apply (Nat.lt_trans _ _ _ H) in H'; now apply Nat.lt_irrefl in H' ]
+ | _ => fail
+ end.
 
 Lemma extend_ok n f : bFun n (@extend n f).
 Proof.
- intros x h. unfold extend. break_dec h. apply f2n_ok.
+ intros x h. unfold extend.
+ break_dec h. apply f2n_ok.
 Qed.
 
 Lemma extend_f2n n f (x:Fin.t n) : extend f (f2n x) = f2n (f x).

--- a/theories/MSets/MSetGenTree.v
+++ b/theories/MSets/MSetGenTree.v
@@ -1136,13 +1136,13 @@ Lemma maxdepth_log_cardinal s : s <> Leaf ->
  Nat.log2 (cardinal s) < maxdepth s.
 Proof.
  intros H.
- apply Nat.log2_lt_pow2. destruct s; simpl; intuition.
+ apply Nat.log2_lt_pow2. destruct s; simpl; intuition. apply Nat.lt_0_succ.
  apply maxdepth_cardinal.
 Qed.
 
 Lemma mindepth_log_cardinal s : mindepth s <= Nat.log2 (S (cardinal s)).
 Proof.
- apply Nat.log2_le_pow2. auto with arith.
+ apply Nat.log2_le_pow2. apply Nat.lt_0_succ.
  apply mindepth_cardinal.
 Qed.
 

--- a/theories/MSets/MSetPositive.v
+++ b/theories/MSets/MSetPositive.v
@@ -18,7 +18,7 @@
    Sandrine Blazy (used for building certified compilers).
 *)
 
-Require Import Bool BinPos Orders OrdersEx MSetInterface.
+Require Import Bool PeanoNat BinPos Orders OrdersEx MSetInterface.
 
 Set Implicit Arguments.
 Local Open Scope lazy_bool_scope.
@@ -715,10 +715,10 @@ Module PositiveSet <: S with Module E:=PositiveOrderedTypeBits.
 
     induction s as [|l IHl b r IHr]; intros j acc; simpl; trivial. destruct b.
       rewrite <- IHl. simpl. rewrite <- IHr.
-       rewrite <- plus_n_Sm, Plus.plus_assoc. reflexivity.
-      rewrite <- IHl, <- IHr. rewrite Plus.plus_assoc. reflexivity.
+       rewrite <- plus_n_Sm, Nat.add_assoc. reflexivity.
+      rewrite <- IHl, <- IHr. rewrite Nat.add_assoc. reflexivity.
 
-    intros. rewrite <- H. simpl. rewrite Plus.plus_comm. reflexivity.
+    intros. rewrite <- H. simpl. rewrite Nat.add_comm. reflexivity.
   Qed.
 
   (** Specification of [filter] *)

--- a/theories/MSets/MSetProperties.v
+++ b/theories/MSets/MSetProperties.v
@@ -17,7 +17,7 @@
     [Equal s s'] instead of [equal s s'=true], etc. *)
 
 Require Export MSetInterface.
-Require Import DecidableTypeEx OrdersLists MSetFacts MSetDecide.
+Require Import PeanoNat DecidableTypeEx OrdersLists MSetFacts MSetDecide.
 Set Implicit Arguments.
 Unset Strict Implicit.
 
@@ -821,7 +821,7 @@ Module WPropertiesOn (Import E : DecidableType)(M : WSetsOn E).
   intros.
   rewrite <- (diff_inter_cardinal s' s).
   rewrite (inter_sym s' s).
-  rewrite (inter_subset_equal H); auto with arith.
+  rewrite (inter_subset_equal H). rewrite Nat.add_comm. apply Nat.le_add_r.
   Qed.
 
   Lemma subset_cardinal_lt :
@@ -836,8 +836,8 @@ Module WPropertiesOn (Import E : DecidableType)(M : WSetsOn E).
   intro H2; destruct (H2 (eq_refl _) x).
   set_iff; auto.
   intros _.
-  change (0 + cardinal s < S n + cardinal s).
-  apply Plus.plus_lt_le_compat; auto with arith.
+  rewrite plus_Sn_m, plus_n_Sm, Nat.add_comm.
+  apply Nat.le_add_r.
   Qed.
 
   Theorem union_inter_cardinal :
@@ -855,15 +855,14 @@ Module WPropertiesOn (Import E : DecidableType)(M : WSetsOn E).
   Proof.
   intros.
   rewrite <- union_inter_cardinal.
-  rewrite Plus.plus_comm.
-  auto with arith.
+  now rewrite Nat.add_sub.
   Qed.
 
   Lemma union_cardinal_le :
    forall s s', cardinal (union s s') <= cardinal s  + cardinal s'.
   Proof.
    intros; generalize (union_inter_cardinal s s').
-   intros; rewrite <- H; auto with arith.
+   intros; rewrite <- H. apply Nat.le_add_r.
   Qed.
 
   Lemma add_cardinal_1 :

--- a/theories/MSets/MSetRBT.v
+++ b/theories/MSets/MSetRBT.v
@@ -978,10 +978,11 @@ Proof.
  specialize (Hf acc).
  destruct (f acc) as (t1,acc1).
  destruct Hf as (Hf1,Hf2).
-  { transitivity size; trivial. subst. auto with arith. }
+  { transitivity size; trivial. subst. rewrite plus_n_Sm. apply Nat.le_add_r. }
  destruct acc1 as [|x acc1].
   { exfalso. revert LE. apply Nat.lt_nge. subst.
-    rewrite app_nil_r, <- elements_cardinal; auto with arith. }
+    rewrite app_nil_r, <- elements_cardinal.
+    apply (Nat.succ_le_mono (cardinal t1)), Nat.le_add_r. }
  specialize (Hg acc1).
  destruct (g acc1) as (t2,acc2).
  destruct Hg as (Hg1,Hg2).
@@ -1547,7 +1548,7 @@ Proof.
  - simpl. rewrite <- Nat.succ_le_mono.
    apply Nat.max_lub; eapply Nat.le_trans; eauto;
    [destree l | destree r]; simpl;
-   rewrite !Nat.add_0_r, ?Nat.add_1_r; auto with arith.
+   rewrite !Nat.add_0_r, ?Nat.add_1_r, ?Nat.add_succ_r; auto.
 Qed.
 
 Lemma rb_mindepth s n : rbt n s -> n + redcarac s <= mindepth s.
@@ -1560,7 +1561,11 @@ Proof.
    replace (redcarac r) with 0 in * by now destree r.
    now apply Nat.min_glb.
  - apply -> Nat.succ_le_mono. rewrite Nat.add_0_r.
-   apply Nat.min_glb; eauto with arith.
+   apply Nat.min_glb.
+   + refine (Nat.le_trans _ _ _ _ IHrbt1).
+     apply Nat.le_add_r.
+   + refine (Nat.le_trans _ _ _ _ IHrbt2).
+     apply Nat.le_add_r.
 Qed.
 
 Lemma maxdepth_upperbound s : Rbt s ->
@@ -1571,7 +1576,7 @@ Proof.
  transitivity (2*(n+redcarac s)).
  - rewrite Nat.mul_add_distr_l. apply Nat.add_le_mono_l.
    rewrite <- Nat.mul_1_l at 1. apply Nat.mul_le_mono_r.
-   auto with arith.
+   auto.
  - apply Nat.mul_le_mono_l.
    transitivity (mindepth s).
    + now apply rb_mindepth.
@@ -1812,10 +1817,12 @@ Proof.
  unfold treeify_cont.
  specialize (Hf acc).
  destruct (f acc) as (l, acc1). simpl in *.
- destruct Hf as (Hf1, Hf2). { subst. eauto with arith. }
+ destruct Hf as (Hf1, Hf2).
+ { subst. refine (Nat.le_trans _ _ _ _ Hacc).
+   rewrite plus_n_Sm. apply Nat.le_add_r. }
  destruct acc1 as [|x acc2]; simpl in *.
  - exfalso. revert Hacc. apply Nat.lt_nge. rewrite H, <- Hf2.
-   auto with arith.
+   rewrite <- plus_n_O. apply (Nat.succ_le_mono size1), Nat.le_add_r.
  - specialize (Hg acc2).
    destruct (g acc2) as (r, acc3). simpl in *.
    destruct Hg as (Hg1, Hg2).

--- a/theories/NArith/Ndigits.v
+++ b/theories/NArith/Ndigits.v
@@ -129,7 +129,7 @@ Proof.
  rewrite Nshiftl_nat_S.
  destruct m.
  - destruct (N.shiftl_nat a n); trivial.
- - apply Lt.lt_S_n in H.
+ - apply Nat.succ_lt_mono in H.
    specialize (IHn m H).
    destruct (N.shiftl_nat a n); trivial.
 Qed.
@@ -671,10 +671,10 @@ Lemma Bnth_Nbit : forall n (bv:Bvector n) p (H:p<n),
   Bnth bv H = N.testbit_nat (Bv2N _ bv) p.
 Proof.
 induction bv; intros.
-inversion H.
-destruct p ; simpl.
-  destruct (Bv2N n bv); destruct h; simpl in *; auto.
-  specialize IHbv with p (Lt.lt_S_n _ _ H).
+- inversion H.
+- destruct p ; simpl.
+  + destruct (Bv2N n bv); destruct h; simpl in *; auto.
+  + specialize IHbv with p (proj2 (Nat.succ_lt_mono _ _) H).
     simpl in * ; destruct (Bv2N n bv); destruct h; simpl in *; auto.
 Qed.
 
@@ -691,9 +691,9 @@ Lemma Nbit_Bth: forall n p (H:p < N.size_nat n),
   N.testbit_nat n p = Bnth (N2Bv n) H.
 Proof.
 destruct n as [|n].
-inversion H.
-induction n ; destruct p ; unfold Vector.nth_order in *; simpl in * ; auto.
-intros H ; destruct (Lt.lt_n_O _ (Lt.lt_S_n _ _ H)).
+- inversion H.
+- induction n ; destruct p ; unfold Vector.nth_order in *; simpl in * ; auto.
+  intros H ; destruct (Nat.nlt_0_r _ (proj2 (Nat.succ_lt_mono _ _) H)).
 Qed.
 
 (** Binary bitwise operations are the same in the two worlds. *)

--- a/theories/Numbers/NatInt/NZDomain.v
+++ b/theories/Numbers/NatInt/NZDomain.v
@@ -9,7 +9,7 @@
 (************************************************************************)
 
 Require Export NumPrelude NZAxioms.
-Require Import NZBase NZOrder NZAddOrder Plus Minus.
+Require Import NZBase NZOrder NZAddOrder PeanoNat.
 
 (** In this file, we investigate the shape of domains satisfying
     the [NZDomainSig] interface. In particular, we define a
@@ -291,20 +291,21 @@ Proof.
 induction n as [|n IH]; destruct m; repeat rewrite ofnat_zero; split.
 intro H; elim (lt_irrefl _ H).
 inversion 1.
-auto with arith.
+intros _; apply Nat.lt_0_succ.
 intros; apply ofnat_S_gt_0.
 intro H; elim (lt_asymm _ _ H); apply ofnat_S_gt_0.
 inversion 1.
-rewrite !ofnat_succ, <- succ_lt_mono, IH; auto with arith.
-rewrite !ofnat_succ, <- succ_lt_mono, IH; auto with arith.
+rewrite !ofnat_succ, <- succ_lt_mono, IH; apply Nat.succ_lt_mono.
+rewrite !ofnat_succ, <- succ_lt_mono, IH; apply Nat.succ_lt_mono.
 Qed.
 
 Lemma ofnat_le : forall n m : nat, [n]<=[m] <-> (n<=m)%nat.
 Proof.
 intros. rewrite lt_eq_cases, ofnat_lt, ofnat_eq.
 split.
-destruct 1; subst; auto with arith.
-apply Lt.le_lt_or_eq.
+destruct 1; subst; auto.
+now apply Nat.lt_le_incl.
+apply Nat.lt_eq_cases.
 Qed.
 
 End NZOfNatOrd.
@@ -335,7 +336,7 @@ Lemma ofnat_mul : forall n m, [n*m] == [n]*[m].
 Proof.
  induction n; simpl; intros.
  symmetry. apply mul_0_l.
- rewrite plus_comm.
+ rewrite Nat.add_comm.
  rewrite ofnat_add, mul_succ_l.
  now f_equiv.
 Qed.
@@ -351,14 +352,14 @@ Lemma ofnat_sub : forall n m, m<=n -> [n-m] == [n]-[m].
 Proof.
  intros n m H. rewrite ofnat_sub_r.
  revert n H. induction m. intros.
- rewrite <- minus_n_O. now simpl.
+ rewrite Nat.sub_0_r. now simpl.
  intros.
  destruct n.
  inversion H.
  rewrite nat_rect_succ_r.
  simpl.
- etransitivity. apply IHm. auto with arith.
-    eapply nat_rect_wd; [symmetry;apply pred_succ|apply pred_wd].
+ etransitivity. apply IHm. now apply Nat.succ_le_mono.
+ eapply nat_rect_wd; [symmetry;apply pred_succ|apply pred_wd].
 Qed.
 
 End NZOfNatOps.

--- a/theories/PArith/BinPos.v
+++ b/theories/PArith/BinPos.v
@@ -11,7 +11,7 @@
 
 Require Export BinNums.
 Require Import Eqdep_dec EqdepFacts RelationClasses Morphisms Setoid
- Equalities Orders OrdersFacts GenericMinMax Le Plus.
+ Equalities Orders OrdersFacts GenericMinMax PeanoNat.
 
 Require Export BinPosDef.
 
@@ -1799,17 +1799,17 @@ Proof.
  destruct a, b; simpl; try case compare_spec; simpl; auto.
  (* Lt *)
  intros LT LE p Hp1 Hp2. apply IHn; clear IHn; trivial.
- apply le_S_n in LE. eapply Le.le_trans; [|eapply LE].
- rewrite plus_comm, <- plus_n_Sm, <- plus_Sn_m.
- apply plus_le_compat; trivial.
+ apply le_S_n in LE. eapply Nat.le_trans; [|eapply LE].
+ rewrite Nat.add_comm, <- plus_n_Sm, <- plus_Sn_m.
+ apply Nat.add_le_mono; trivial.
  apply size_nat_monotone, sub_decr, LT.
  apply divide_xO_xI with a; trivial.
  apply (divide_add_cancel_l p _ a~1); trivial.
  now rewrite <- sub_xI_xI, sub_add.
  (* Gt *)
  intros LT LE p Hp1 Hp2. apply IHn; clear IHn; trivial.
- apply le_S_n in LE. eapply Le.le_trans; [|eapply LE].
- apply plus_le_compat; trivial.
+ apply le_S_n in LE. eapply Nat.le_trans; [|eapply LE].
+ apply Nat.add_le_mono; trivial.
  apply size_nat_monotone, sub_decr, LT.
  apply divide_xO_xI with b; trivial.
  apply (divide_add_cancel_l p _ b~1); trivial.
@@ -1828,12 +1828,14 @@ Proof.
  change (gcdn n a b)~0 with (2*(gcdn n a b)).
  apply divide_mul_r.
  apply IHn; clear IHn.
- apply le_S_n in LE. apply le_Sn_le. now rewrite plus_n_Sm.
+ apply le_S_n in LE. refine (Nat.le_trans _ _ _ _ LE).
+ apply Nat.add_le_mono_l; auto.
  apply divide_xO_xI with p; trivial. now exists 1.
  apply divide_xO_xI with p; trivial. now exists 1.
  apply divide_xO_xO.
  apply IHn; clear IHn.
- apply le_S_n in LE. apply le_Sn_le. now rewrite plus_n_Sm.
+ apply le_S_n in LE. refine (Nat.le_trans _ _ _ _ LE).
+ apply Nat.add_le_mono_l; auto.
  now apply divide_xO_xO.
  now apply divide_xO_xO.
  exists (gcdn n a b)~0. now rewrite mul_1_r.

--- a/theories/PArith/Pnat.v
+++ b/theories/PArith/Pnat.v
@@ -73,7 +73,7 @@ Qed.
 
 Lemma is_pos p : 0 < to_nat p.
 Proof.
- destruct (is_succ p) as (n,->). auto with arith.
+ destruct (is_succ p) as (n,->). apply Nat.lt_0_succ.
 Qed.
 
 (** [Pos.to_nat] is a bijection between [positive] and

--- a/theories/Sets/Multiset.v
+++ b/theories/Sets/Multiset.v
@@ -10,8 +10,7 @@
 
 (* G. Huet 1-9-95 *)
 
-Require Import Permut Setoid.
-Require Plus. (* comm. and ass. of plus *)
+Require Import Permut Setoid PeanoNat.
 
 Set Implicit Arguments.
 
@@ -73,14 +72,14 @@ Section multiset_defs.
   Lemma munion_comm : forall x y:multiset, meq (munion x y) (munion y x).
   Proof.
     unfold meq; unfold multiplicity; unfold munion.
-    destruct x; destruct y; auto with arith.
+    destruct x; destruct y; intros; apply Nat.add_comm.
   Qed.
 
   Lemma munion_ass :
     forall x y z:multiset, meq (munion (munion x y) z) (munion x (munion y z)).
   Proof.
     unfold meq; unfold munion; unfold multiplicity.
-    destruct x; destruct y; destruct z; auto with arith.
+    destruct x; destruct y; destruct z; intros; now rewrite Nat.add_assoc.
   Qed.
 
   Lemma meq_left :
@@ -88,7 +87,7 @@ Section multiset_defs.
   Proof.
     unfold meq; unfold munion; unfold multiplicity.
     destruct x; destruct y; destruct z.
-    intros; elim H; auto with arith.
+    intros; elim H; reflexivity.
   Qed.
 
   Lemma meq_right :

--- a/theories/Sorting/PermutEq.v
+++ b/theories/Sorting/PermutEq.v
@@ -41,7 +41,7 @@ Section Perm.
   Proof.
     intros l a; rewrite multiplicity_In;
       destruct (multiplicity (list_contents l) a); auto.
-    destruct 1; auto with arith.
+    destruct 1; lia.
   Qed.
 
   Lemma multiplicity_In_S :
@@ -54,26 +54,23 @@ Section Perm.
     forall l, NoDup l <-> (forall a, multiplicity (list_contents l) a <= 1).
   Proof.
     induction l.
-    simpl.
-    split; auto with arith.
-    intros; apply NoDup_nil.
-    split; simpl.
-    inversion_clear 1.
-    rewrite IHl in H1.
-    intros; destruct (eq_dec a a0) as [H2|H2]; simpl; auto.
-    subst a0.
-    rewrite multiplicity_In_O; auto.
-    intros; constructor.
-    rewrite multiplicity_In.
-    generalize (H a).
-    destruct (eq_dec a a) as [H0|H0].
-    destruct (multiplicity (list_contents l) a); auto with arith.
-    simpl; inversion 1.
-    inversion H3.
-    destruct H0; auto.
-    rewrite IHl; intros.
-    generalize (H a0); auto with arith.
-    destruct (eq_dec a a0); simpl; auto with arith.
+    - simpl.
+      split; auto.
+      intros; apply NoDup_nil.
+    - split; simpl.
+      + inversion_clear 1.
+        rewrite IHl in H1.
+        intros; destruct (eq_dec a a0) as [H2|H2]; simpl; auto.
+        subst a0.
+        rewrite multiplicity_In_O; auto.
+      + intros; constructor.
+        * rewrite multiplicity_In.
+          generalize (H a).
+          destruct (eq_dec a a) as [H0|H0].
+          -- destruct (multiplicity (list_contents l) a); lia.
+          -- destruct H0; auto.
+        * rewrite IHl; intros.
+          generalize (H a0); lia.
   Qed.
 
   Lemma NoDup_permut :
@@ -223,4 +220,3 @@ Section Perm.
   Qed.
 
 End Perm.
-

--- a/theories/Sorting/PermutSetoid.v
+++ b/theories/Sorting/PermutSetoid.v
@@ -122,7 +122,7 @@ Proof.
   specialize H0 with a0.
   repeat rewrite list_contents_app in *; simpl in *.
   destruct (eqA_dec a a0) as [Ha|Ha]; rewrite H in Ha;
-    decide (eqA_dec a' a0) with Ha; simpl; auto with arith.
+    decide (eqA_dec a' a0) with Ha; simpl; auto.
   do 2 rewrite <- plus_n_Sm; f_equal; auto.
 Qed.
 
@@ -135,7 +135,7 @@ Proof.
   generalize (H a0); clear H.
   do 4 rewrite list_contents_app.
   simpl.
-  destruct (eqA_dec a a0); simpl; auto with arith.
+  destruct (eqA_dec a a0); simpl; auto.
   do 2 rewrite <- plus_n_Sm; f_equal; auto.
 Qed.
 
@@ -170,8 +170,7 @@ Lemma permut_sym_app :
 Proof.
   intros l1 l2;
     unfold permutation, meq;
-	intro a; do 2 rewrite list_contents_app; simpl;
-	  auto with arith.
+        intro a; do 2 rewrite list_contents_app; simpl; lia.
 Qed.
 
 Lemma permut_rev :
@@ -248,7 +247,8 @@ Qed.
 Fact if_eqA_refl : forall a (B:Type)(b b':B),
  (if eqA_dec a a then b else b') = b.
 Proof.
-  intros; apply (decide_left (eqA_dec a a)); auto with *.
+  intros; apply (decide_left (eqA_dec a a)); auto.
+  reflexivity.
 Qed.
 
 (** PL: Inutilisable dans un rewrite sans un change prealable. *)
@@ -259,8 +259,8 @@ Proof.
  intros x x' Hxx' y y' Hyy'.
  intros; destruct (eqA_dec x y) as [H|H];
   destruct (eqA_dec x' y') as [H'|H']; auto.
- contradict H'; transitivity x; auto with *; transitivity y; auto with *.
- contradict H; transitivity x'; auto with *; transitivity y'; auto with *.
+ contradict H'; transitivity x; intuition; transitivity y; auto.
+ contradict H; transitivity x'; auto; transitivity y'; intuition.
 Qed.
 
 Fact if_eqA_rewrite_l : forall a1 a1' a2 (B:Type)(b b':B),
@@ -269,8 +269,8 @@ Fact if_eqA_rewrite_l : forall a1 a1' a2 (B:Type)(b b':B),
 Proof.
  intros; destruct (eqA_dec a1 a2) as [A1|A1];
   destruct (eqA_dec a1' a2) as [A1'|A1']; auto.
- contradict A1'; transitivity a1; eauto with *.
- contradict A1; transitivity a1'; eauto with *.
+ contradict A1'; transitivity a1; intuition.
+ contradict A1; transitivity a1'; auto.
 Qed.
 
 Fact if_eqA_rewrite_r : forall a1 a2 a2' (B:Type)(b b':B),
@@ -279,8 +279,8 @@ Fact if_eqA_rewrite_r : forall a1 a2 a2' (B:Type)(b b':B),
 Proof.
  intros; destruct (eqA_dec a1 a2) as [A2|A2];
   destruct (eqA_dec a1 a2') as [A2'|A2']; auto.
- contradict A2'; transitivity a2; eauto with *.
- contradict A2; transitivity a2'; eauto with *.
+ contradict A2'; transitivity a2; intuition.
+ contradict A2; transitivity a2'; intuition.
 Qed.
 
 
@@ -300,23 +300,23 @@ Proof.
   split; inversion 1.
   simpl.
   intros a'; split; intros H. inversion_clear H.
-  apply (decide_left (eqA_dec a a')); auto with *.
-  destruct (eqA_dec a a'); auto with *. simpl; rewrite <- IHl; auto.
-  destruct (eqA_dec a a'); auto with *. right. rewrite IHl; auto.
+  apply (decide_left (eqA_dec a a')); intuition.
+  destruct (eqA_dec a a'); intuition. simpl; rewrite <- IHl; auto.
+  destruct (eqA_dec a a'); intuition. right. rewrite IHl; auto.
 Qed.
 
 Lemma multiplicity_InA_O :
   forall l a, ~ InA eqA a l -> multiplicity (list_contents l) a = 0.
 Proof.
   intros l a; rewrite multiplicity_InA;
-    destruct (multiplicity (list_contents l) a); auto with arith.
-  destruct 1; auto with arith.
+    destruct (multiplicity (list_contents l) a); auto.
+  destruct 1; lia.
 Qed.
 
 Lemma multiplicity_InA_S :
   forall l a, InA eqA a l -> multiplicity (list_contents l) a >= 1.
 Proof.
-  intros l a; rewrite multiplicity_InA; auto with arith.
+  intros l a; rewrite multiplicity_InA; auto.
 Qed.
 
 Lemma multiplicity_NoDupA : forall l,
@@ -324,11 +324,11 @@ Lemma multiplicity_NoDupA : forall l,
 Proof.
   induction l.
   simpl.
-  split; auto with arith.
+  split; auto.
   split; simpl.
   inversion_clear 1.
   rewrite IHl in H1.
-  intros; destruct (eqA_dec a a0) as [EQ|NEQ]; simpl; auto with *.
+  intros; destruct (eqA_dec a a0) as [EQ|NEQ]; simpl; auto.
   rewrite <- EQ.
   rewrite multiplicity_InA_O; auto.
   intros; constructor.
@@ -353,7 +353,7 @@ Qed.
 Lemma permut_cons_InA :
   forall l1 l2 e, permutation (e :: l1) l2 -> InA eqA e l2.
 Proof.
-  intros; apply (permut_InA_InA (e:=e) H); auto with *.
+  intros; apply (permut_InA_InA (e:=e) H); intuition.
 Qed.
 
 (** Permutation of an empty list. *)
@@ -361,7 +361,7 @@ Lemma permut_nil :
   forall l, permutation l [] -> l = [].
 Proof.
   intro l; destruct l as [ | e l ]; trivial.
-  assert (InA eqA e (e::l)) by (auto with *).
+  assert (InA eqA e (e::l)) by (intuition).
   intro Abs; generalize (permut_InA_InA Abs H).
   inversion 1.
 Qed.
@@ -466,8 +466,8 @@ Proof.
   intros; f_equal; auto.
   destruct (eqB_dec (f b) a0) as [H2|H2];
     destruct (eqB_dec (f a) a0) as [H3|H3]; auto.
-  destruct H3; transitivity (f b); auto with *.
-  destruct H2; transitivity (f a); auto with *.
+  destruct H3; transitivity (f b); auto.
+  destruct H2; transitivity (f a); intuition.
   apply permut_add_cons_inside.
   rewrite <- map_app.
   apply IHl1; auto.

--- a/theories/Strings/BinaryString.v
+++ b/theories/Strings/BinaryString.v
@@ -8,7 +8,7 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-Require Import Ascii String.
+Require Import BinInt Ascii String.
 Require Import BinNums.
 Import BinNatDef.
 Import BinIntDef.

--- a/theories/Strings/HexString.v
+++ b/theories/Strings/HexString.v
@@ -8,7 +8,7 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-Require Import Ascii String.
+Require Import BinInt Ascii String.
 Require Import BinNums.
 Import BinNatDef.
 Import BinIntDef.

--- a/theories/Strings/OctalString.v
+++ b/theories/Strings/OctalString.v
@@ -8,7 +8,7 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-Require Import Ascii String.
+Require Import BinInt Ascii String.
 Require Import BinNums.
 Import BinNatDef.
 Import BinIntDef.

--- a/theories/Strings/String.v
+++ b/theories/Strings/String.v
@@ -12,9 +12,7 @@
 (** Contributed by Laurent Théry (INRIA);
     Adapted to Coq V8 by the Coq Development Team *)
 
-Require Import Arith.
-Require Import Ascii.
-Require Import Bool.
+Require Import PeanoNat Ascii Bool List.
 Require Import Coq.Strings.Byte.
 
 (** *** Definition of strings *)
@@ -138,7 +136,7 @@ intros s1; elim s1; simpl; auto.
 intros s2 n H; inversion H.
 intros a s1' Rec s2 n; case n; simpl; auto.
 intros n0 H; apply Rec; auto.
-apply lt_S_n; auto.
+apply Nat.succ_lt_mono; auto.
 Qed.
 
 (** The last elements of [s1 ++ s2] are the ones of [s2] *)
@@ -148,10 +146,10 @@ Theorem append_correct2 :
  get n s2 = get (n + length s1) (s1 ++ s2).
 Proof.
 intros s1; elim s1; simpl; auto.
-intros s2 n; rewrite plus_comm; simpl; auto.
+intros s2 n; rewrite Nat.add_comm; simpl; auto.
 intros a s1' Rec s2 n; case n; simpl; auto.
 generalize (Rec s2 O); simpl; auto. intros.
-rewrite <- Plus.plus_Snm_nSm; auto.
+rewrite <- Peano.plus_n_Sm. apply Rec.
 Qed.
 
 (** *** Substrings *)
@@ -183,8 +181,8 @@ intros m; case m; simpl; auto.
 intros p H; inversion H.
 intros m' p; case p; simpl; auto.
 intros n0 H; apply Rec; simpl; auto.
-apply Lt.lt_S_n; auto.
-intros n' m p H; rewrite <- Plus.plus_Snm_nSm; simpl; auto.
+apply Nat.succ_lt_mono; auto.
+intros n' m p H; rewrite <- Peano.plus_n_Sm; simpl; auto.
 Qed.
 
 (** The substring has at most [m] elements *)
@@ -200,7 +198,7 @@ intros m; case m; simpl; auto.
 intros m' p; case p; simpl; auto.
 intros H; inversion H.
 intros n0 H; apply Rec; simpl; auto.
-apply Le.le_S_n; auto.
+apply Nat.succ_le_mono; auto.
 Qed.
 
 (** *** Concatenating lists of strings *)
@@ -321,39 +319,39 @@ Theorem index_correct2 :
 Proof.
 intros n m s1 s2; generalize n m s1; clear n m s1; elim s2; simpl;
  auto.
-intros n; case n; simpl; auto.
-intros m s1; case s1; simpl; auto.
-intros [= <-].
-intros p H0 H2; inversion H2.
-intros; discriminate.
-intros; discriminate.
-intros b s2' Rec n m s1.
-case n; simpl; auto.
-generalize (prefix_correct s1 (String b s2'));
- case (prefix s1 (String b s2')).
-intros H0 [= <-]; auto.
-intros p H2 H3; inversion H3.
-case m; simpl; auto.
-case (index 0 s1 s2'); intros; discriminate.
-intros m'; generalize (Rec O m' s1); case (index 0 s1 s2'); auto.
-intros x H H0 H1 p; try case p; simpl; auto.
-intros H2 H3; red; intros H4; case H0.
-intros H5 H6; absurd (false = true); auto with bool.
-intros n0 H2 H3; apply H; auto.
-injection H1; auto.
-apply Le.le_O_n.
-apply Lt.lt_S_n; auto.
-intros; discriminate.
-intros n'; case m; simpl; auto.
-case (index n' s1 s2'); intros; discriminate.
-intros m'; generalize (Rec n' m' s1); case (index n' s1 s2'); auto.
-intros x H H0 p; case p; simpl; auto.
-intros H1; inversion H1; auto.
-intros n0 H1 H2; apply H; auto.
-injection H0; auto.
-apply Le.le_S_n; auto.
-apply Lt.lt_S_n; auto.
-intros; discriminate.
+- intros n; case n; simpl; auto.
+  + intros m s1; case s1; simpl; auto.
+    * intros [= <-].
+      intros p H0 H2; inversion H2.
+    * intros; discriminate.
+  + intros; discriminate.
+- intros b s2' Rec n m s1.
+  case n; simpl; auto.
+  + generalize (prefix_correct s1 (String b s2'));
+      case (prefix s1 (String b s2')).
+    * intros H0 [= <-]; auto.
+      intros p H2 H3; inversion H3.
+    * case m; simpl; auto.
+      -- case (index 0 s1 s2'); intros; discriminate.
+      -- intros m'; generalize (Rec O m' s1); case (index 0 s1 s2'); auto.
+         ++ intros x H H0 H1 p; try case p; simpl; auto.
+            ** intros H2 H3; red; intros H4; case H0.
+               intros H5 H6; absurd (false = true); auto with bool.
+            ** intros n0 H2 H3; apply H; auto.
+               --- injection H1; auto.
+               --- apply Nat.le_0_l.
+               --- apply Nat.succ_lt_mono; auto.
+         ++ intros; discriminate.
+  + intros n'; case m; simpl; auto.
+    * case (index n' s1 s2'); intros; discriminate.
+    * intros m'; generalize (Rec n' m' s1); case (index n' s1 s2'); auto.
+      -- intros x H H0 p; case p; simpl; auto.
+         ** intros H1; inversion H1; auto.
+         ** intros n0 H1 H2; apply H; auto.
+            --- injection H0; auto.
+            --- apply Nat.succ_le_mono; auto.
+            --- apply Nat.succ_lt_mono; auto.
+      -- intros; discriminate.
 Qed.
 
 (** If the result of [index] is [None], [s1] does not occur in [s2]
@@ -364,35 +362,34 @@ Theorem index_correct3 :
  index n s1 s2 = None ->
  s1 <> EmptyString -> n <= m -> substring m (length s1) s2 <> s1.
 Proof.
-intros n m s1 s2; generalize n m s1; clear n m s1; elim s2; simpl;
- auto.
-intros n; case n; simpl; auto.
-intros m s1; case s1; simpl; auto.
-case m; intros; red; intros; discriminate.
-intros n' m; case m; auto.
-intros s1; case s1; simpl; auto.
-intros b s2' Rec n m s1.
-case n; simpl; auto.
-generalize (prefix_correct s1 (String b s2'));
- case (prefix s1 (String b s2')).
-intros; discriminate.
-case m; simpl; auto with bool.
-case s1; simpl; auto.
-intros a s H H0 H1 H2; red; intros H3; case H.
-intros H4 H5; absurd (false = true); auto with bool.
-case s1; simpl; auto.
-intros a s n0 H H0 H1 H2;
- change (substring n0 (length (String a s)) s2' <> String a s);
- apply (Rec O); auto.
-generalize H0; case (index 0 (String a s) s2'); simpl; auto; intros;
- discriminate.
-apply Le.le_O_n.
-intros n'; case m; simpl; auto.
-intros H H0 H1; inversion H1.
-intros n0 H H0 H1; apply (Rec n'); auto.
-generalize H; case (index n' s1 s2'); simpl; auto; intros;
- discriminate.
-apply Le.le_S_n; auto.
+intros n m s1 s2; generalize n m s1; clear n m s1; elim s2; simpl; auto.
+- intros n; case n; simpl; auto.
+  + intros m s1; case s1; simpl; auto.
+    case m; intros; red; intros; discriminate.
+  + intros n' m; case m; auto.
+    intros s1; case s1; simpl; auto.
+- intros b s2' Rec n m s1.
+  case n; simpl; auto.
+  + generalize (prefix_correct s1 (String b s2'));
+      case (prefix s1 (String b s2')).
+    * intros; discriminate.
+    * case m; simpl; auto with bool.
+      -- case s1; simpl; auto.
+         intros a s H H0 H1 H2; red; intros H3; case H.
+         intros H4 H5; absurd (false = true); auto with bool.
+      -- case s1; simpl; auto.
+         intros a s n0 H H0 H1 H2;
+           change (substring n0 (length (String a s)) s2' <> String a s);
+           apply (Rec O); auto.
+         ++ generalize H0; case (index 0 (String a s) s2'); simpl; auto; intros;
+              discriminate.
+         ++ apply Nat.le_0_l.
+  + intros n'; case m; simpl; auto.
+    * intros H H0 H1; inversion H1.
+    * intros n0 H H0 H1; apply (Rec n'); auto.
+      -- generalize H; case (index n' s1 s2'); simpl; auto; intros;
+           discriminate.
+      -- apply Nat.succ_le_mono; auto.
 Qed.
 
 (* Back to normal for prefix *)
@@ -408,13 +405,13 @@ Proof.
 intros n s; generalize n; clear n; elim s; simpl; auto.
 intros n; case n; simpl; auto.
 intros; discriminate.
-intros; apply Lt.lt_O_Sn.
+intros; apply Nat.lt_0_succ.
 intros a s' H n; case n; simpl; auto.
 intros; discriminate.
 intros n'; generalize (H n'); case (index n' EmptyString s'); simpl;
  auto.
 intros; discriminate.
-intros H0 H1; apply Lt.lt_n_S; auto.
+intros H0 H1; apply H0 in H1; apply Nat.succ_lt_mono in H1; auto.
 Qed.
 
 (** Same as [index] but with no optional type, we return [0] when it

--- a/theories/Structures/OrderedTypeEx.v
+++ b/theories/Structures/OrderedTypeEx.v
@@ -9,10 +9,10 @@
 (************************************************************************)
 
 Require Import OrderedType.
-Require Import ZArith_base.
-Require Import PeanoNat.
+Require Import BinInt.
+Require Import PeanoNat Peano_dec.
 Require Import Ascii String.
-Require Import NArith Ndec.
+Require Import BinNat.
 Require Import Compare_dec.
 
 (** * Examples of Ordered Type structures. *)
@@ -51,7 +51,7 @@ Module Nat_as_OT <: UsualOrderedType.
   Definition lt := lt.
 
   Lemma lt_trans : forall x y z : t, lt x y -> lt y z -> lt x z.
-  Proof. unfold lt; intros; apply lt_trans with y; auto. Qed.
+  Proof. unfold lt; intros; apply Nat.lt_trans with y; auto. Qed.
 
   Lemma lt_not_eq : forall x y : t, lt x y -> ~ eq x y.
   Proof. unfold lt, eq; intros ? ? LT ->; revert LT; apply Nat.lt_irrefl. Qed.
@@ -350,7 +350,7 @@ Module String_as_OT <: UsualOrderedType.
   Proof.
     intro H; inversion H; subst; auto.
     remember (nat_of_ascii a) as x.
-    apply lt_irrefl in H1; inversion H1.
+    apply Nat.lt_irrefl in H1; inversion H1.
   Qed.
 
   Lemma lt_trans : forall x y z : t, lt x y -> lt y z -> lt x z.
@@ -363,7 +363,7 @@ Module String_as_OT <: UsualOrderedType.
       + constructor. eapply IHx; eauto.
       + constructor; assumption.
       + constructor; assumption.
-      + constructor. eapply lt_trans; eassumption.
+      + constructor. eapply Nat.lt_trans; eassumption.
   Qed.
 
   Lemma lt_not_eq : forall x y : t, lt x y -> ~ eq x y.

--- a/theories/Vectors/VectorDef.v
+++ b/theories/Vectors/VectorDef.v
@@ -18,7 +18,7 @@
 Names should be "caml name in list.ml" if exists and order of arguments
 have to be the same. complain if you see mistakes ... *)
 
-Require Import Arith_base.
+Require Import PeanoNat.
 Require Vectors.Fin.
 Import EqNotations.
 Local Open Scope nat_scope.
@@ -168,16 +168,16 @@ Lemma trunc : forall {A} {n} (p:nat), n > p -> t A n
   -> t A (n - p).
 Proof.
   induction p as [| p f]; intros H v.
-  rewrite <- minus_n_O.
+  rewrite Nat.sub_0_r.
   exact v.
 
   apply shiftout.
 
-  rewrite minus_Sn_m.
+  rewrite <- Nat.sub_succ_l.
   apply f.
-  auto with *.
+  now apply Nat.lt_le_incl.
   exact v.
-  auto with *.
+  now apply Nat.lt_le_incl.
 Defined.
 
 (** Concatenation of two vectors *)
@@ -204,7 +204,7 @@ reverses the first one *)
 
 (** This one has the exact expected computational behavior *)
 Fixpoint rev_append_tail {A n p} (v : t A n) (w: t A p)
-  : t A (tail_plus n p) :=
+  : t A (Nat.tail_add n p) :=
   match v with
   | [] => w
   | a :: v' => rev_append_tail v' (a :: w)
@@ -215,7 +215,7 @@ Import EqdepFacts.
 (** This one has a better type *)
 Definition rev_append {A n p} (v: t A n) (w: t A p)
   :t A (n + p) :=
-  rew <- (plus_tail_plus n p) in (rev_append_tail v w).
+  rew (Nat.tail_add_spec n p) in (rev_append_tail v w).
 
 (** rev [a₁ ; a₂ ; .. ; an] is [an ; a{n-1} ; .. ; a₁]
 

--- a/theories/ZArith/ZArith_dec.v
+++ b/theories/ZArith/ZArith_dec.v
@@ -74,7 +74,7 @@ Section decidability.
 
   Definition Z_le_gt_dec : {x <= y} + {x > y}.
   Proof.
-    elim Z_le_dec; auto with arith.
+    elim Z_le_dec; auto.
     intro. right. Z.swap_greater. now apply Z.nle_gt.
   Defined.
 
@@ -85,17 +85,17 @@ Section decidability.
 
   Definition Z_ge_lt_dec : {x >= y} + {x < y}.
   Proof.
-    elim Z_ge_dec; auto with arith.
+    elim Z_ge_dec; auto.
     intro. right. Z.swap_greater. now apply Z.lt_nge.
   Defined.
 
   Definition Z_le_lt_eq_dec : x <= y -> {x < y} + {x = y}.
   Proof.
     intro H.
-    apply Zcompare_rec with (n := x) (m := y).
-    intro. right. elim (Z.compare_eq_iff x y); auto with arith.
-    intro. left. elim (Z.compare_eq_iff x y); auto with arith.
-    intro H1. absurd (x > y); auto with arith.
+    apply Zcompare_rec with (n := x) (m := y); intro.
+    - right. elim (Z.compare_eq_iff x y); auto.
+    - left. elim (Z.compare_eq_iff x y); auto.
+    - absurd (x > y); auto.
   Defined.
 
 End decidability.

--- a/theories/ZArith/Zgcd_alt.v
+++ b/theories/ZArith/Zgcd_alt.v
@@ -234,8 +234,7 @@ Open Scope Z_scope.
   simpl Zgcd_bound in *.
   remember (Pos.size_nat a+Pos.size_nat a)%nat as m.
   assert (1 < m)%nat.
-  { rewrite Heqm; destruct a; simpl; rewrite 1?plus_comm;
-    auto with arith. }
+  { rewrite Heqm; destruct a; simpl; rewrite 1?plus_comm; lia. }
   destruct m as [ |m]; [inversion H0; auto| ].
   destruct n as [ |n]; [inversion H; auto| ].
   simpl Zgcdn.

--- a/theories/ZArith/Znat.v
+++ b/theories/ZArith/Znat.v
@@ -11,7 +11,7 @@
 
 (** Binary Integers (Pierre Crégut, CNET, Lannion, France) *)
 
-Require Export Arith_base.
+Require Export PeanoNat Compare_dec.
 Require Import BinPos BinInt BinNat Pnat Nnat.
 
 Local Open Scope Z_scope.
@@ -1031,7 +1031,8 @@ Notation Zabs_N_mult := Zabs2N.inj_mul (only parsing).
 
 Theorem inj_minus2 : forall n m:nat, (m > n)%nat -> Z.of_nat (n - m) = 0.
 Proof.
- intros. rewrite not_le_minus_0; auto with arith.
+ intros. rewrite <- Nat2Z.inj_0, Nat2Z.inj_iff, Nat.sub_0_le.
+ now apply Nat.lt_le_incl.
 Qed.
 
 Register inj_minus2 as plugins.omega.inj_minus2.

--- a/theories/ZArith/Zwf.v
+++ b/theories/ZArith/Zwf.v
@@ -49,8 +49,9 @@ Section wf_proof.
     unfold Zwf in H1.
     case (Z.le_gt_cases c y); intro. 2: lia.
     left.
-    apply lt_le_trans with (f a); auto with arith.
+    apply lt_le_trans with (f a).
     unfold f.
+    lia.
     lia.
     apply (H (S (f a))); auto.
   Qed.


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

This is a tentative of clarifying the different uses of properties of `nat` in the standard library by relying mostly on Arith.PeanoNat and not anymore on files mentioned to be (mostly) obsolete such as Arith.Plus Arith.Le Arith.Even, etc. and thus also (by transitivity) Arith.Arith_base and Arith.Arith for example.

I am not sure this is really useful, but it could lead to a more formal deprecation of some old parts of stdlib dealing with (natural) numbers.

