### PR TITLE
coq_makefile: don't use CAMLPKGS when building cmxa of mllib

### DIFF
--- a/doc/changelog/08-tools/11357-master.rst
+++ b/doc/changelog/08-tools/11357-master.rst
@@ -1,0 +1,4 @@
+- **Fixed:**
+  ``coq_makefile`` does not break when using the ``CAMLPKGS`` variable
+  together with an unpacked (``mllib``) plugin. (`#11357
+  <https://github.com/coq/coq/pull/11357>`_, by Gaëtan Gilbert).

--- a/test-suite/coq-makefile/findlib-package-unpacked/Makefile.local
+++ b/test-suite/coq-makefile/findlib-package-unpacked/Makefile.local
@@ -1,0 +1,1 @@
+CAMLPKGS   += -package foo

--- a/test-suite/coq-makefile/findlib-package-unpacked/_CoqProject
+++ b/test-suite/coq-makefile/findlib-package-unpacked/_CoqProject
@@ -1,0 +1,10 @@
+-R src test
+-R theories test
+-I src
+
+src/test_plugin.mllib
+src/test.mlg
+src/test.mli
+src/test_aux.ml
+src/test_aux.mli
+theories/test.v

--- a/test-suite/coq-makefile/findlib-package-unpacked/findlib/foo/META
+++ b/test-suite/coq-makefile/findlib-package-unpacked/findlib/foo/META
@@ -1,0 +1,4 @@
+archive(byte)="foo.cma"
+archive(native)="foo.cmxa"
+linkopts="-linkall"
+requires="str"

--- a/test-suite/coq-makefile/findlib-package-unpacked/findlib/foo/Makefile
+++ b/test-suite/coq-makefile/findlib-package-unpacked/findlib/foo/Makefile
@@ -1,0 +1,14 @@
+-include ../../Makefile.conf
+
+CO="$(COQMF_OCAMLFIND)" opt
+CB="$(COQMF_OCAMLFIND)" ocamlc
+
+all:
+	$(CO) -c foolib.ml
+	$(CO) -a foolib.cmx -o foo.cmxa
+	$(CB) -c foolib.ml
+	$(CB) -a foolib.cmo -o foo.cma
+	$(CB) -c foo.mli # empty .mli file, to be understood
+
+clean:
+	rm -f *.cmo *.cma *.cmx *.cmxa *.cmi *.o *.a

--- a/test-suite/coq-makefile/findlib-package-unpacked/findlib/foo/foolib.ml
+++ b/test-suite/coq-makefile/findlib-package-unpacked/findlib/foo/foolib.ml
@@ -1,0 +1,2 @@
+let foo () =
+  assert(Str.search_forward (Str.regexp "foo") "barfoobar" 0 = 3)

--- a/test-suite/coq-makefile/findlib-package-unpacked/run.sh
+++ b/test-suite/coq-makefile/findlib-package-unpacked/run.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+. ../template/init.sh
+mv src/test_plugin.mlpack src/test_plugin.mllib
+
+echo "let () = Foolib.foo ();;" >> src/test_aux.ml
+export OCAMLPATH=$OCAMLPATH:$PWD/findlib
+if which cygpath 2>/dev/null; then
+  # the only way I found to pass OCAMLPATH on win is to have it contain
+  # only one entry
+  OCAMLPATH=$(cygpath -w "$PWD"/findlib)
+  export OCAMLPATH
+fi
+make -C findlib/foo clean
+coq_makefile -f _CoqProject -o Makefile
+cat Makefile.conf
+cat Makefile.local
+make -C findlib/foo
+make
+make byte

--- a/tools/CoqMakefile.in
+++ b/tools/CoqMakefile.in
@@ -632,7 +632,7 @@ $(MLLIBFILES:.mllib=.cma): %.cma: | %.mllib
 
 $(MLLIBFILES:.mllib=.cmxa): %.cmxa: | %.mllib
 	$(SHOW)'CAMLOPT -a -o $@'
-	$(HIDE)$(CAMLOPTLINK) $(CAMLDEBUG) $(CAMLFLAGS) $(CAMLPKGS) -a -o $@ $^
+	$(HIDE)$(CAMLOPTLINK) $(CAMLDEBUG) $(CAMLFLAGS) -a -o $@ $^
 
 
 $(MLPACKFILES:.mlpack=.cmxs): %.cmxs: %.cmxa


### PR DESCRIPTION
It seems broken according to unicoq experiences https://gitter.im/coq/coq?at=5e0e3e0005298604982ac3f7

Building cmxa of mlpack is already this way.
