### PR TITLE
Add support for OCaml 4.10

### DIFF
--- a/doc/changelog/11-infrastructure-and-dependencies/11358-410.rst
+++ b/doc/changelog/11-infrastructure-and-dependencies/11358-410.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  Add support for OCaml 4.10
+  (`#11358 <https://github.com/coq/coq/pull/11358>`_,
+  by Kate Deplaix).

--- a/kernel/byterun/coq_gc.h
+++ b/kernel/byterun/coq_gc.h
@@ -13,12 +13,15 @@
 #include <caml/mlvalues.h>
 #include <caml/alloc.h>
 #include <caml/memory.h>
+#include <caml/version.h>
 
 typedef void (*scanning_action) (value, value *);
 
 
+#if OCAML_VERSION < 41000
 CAMLextern char *young_ptr;
 CAMLextern char *young_limit;
+#endif
 CAMLextern void (*scan_roots_hook) (scanning_action);
 CAMLextern void minor_collection (void);
 
@@ -43,16 +46,16 @@ CAMLextern void minor_collection (void);
 #endif
 
 #define Alloc_small(result, wosize, tag) do{                            \
-  young_ptr -= Bhsize_wosize (wosize);                                  \
-  if (young_ptr < young_limit){                                         \
-    young_ptr += Bhsize_wosize (wosize);                                \
+  caml_young_ptr -= Bhsize_wosize (wosize);                             \
+  if (caml_young_ptr < caml_young_limit){                               \
+    caml_young_ptr += Bhsize_wosize (wosize);                           \
     Setup_for_gc;                                                       \
     minor_collection ();                                                \
     Restore_after_gc;                                                   \
-    young_ptr -= Bhsize_wosize (wosize);                                \
+    caml_young_ptr -= Bhsize_wosize (wosize);                           \
   }                                                                     \
-  Hd_hp (young_ptr) = Make_header ((wosize), (tag), Caml_black);        \
-  (result) = Val_hp (young_ptr);                                        \
+  Hd_hp (caml_young_ptr) = Make_header ((wosize), (tag), Caml_black);   \
+  (result) = Val_hp (caml_young_ptr);                                   \
   }while(0) 
 
 


### PR DESCRIPTION
<!-- Keep what applies -->
**Kind:** feature

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes https://github.com/coq/coq/issues/10726
This PR allows coq and coqide to compile with OCaml 4.10

<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [ ] Added / updated test-suite
<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [ ] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
