### PR TITLE
Lia bugfix 11191

### DIFF
--- a/doc/changelog/04-tactics/11362-micromega-fix-11191.rst
+++ b/doc/changelog/04-tactics/11362-micromega-fix-11191.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  Regression of ``lia`` due to more powerful ``zify``
+  (`#11362 <https://github.com/coq/coq/pull/11362>`_,
+  fixes `#11191 <https://github.com/coq/coq/issues/11191>`_,
+  by Frédéric Besson).

--- a/plugins/micromega/ZifyInst.v
+++ b/plugins/micromega/ZifyInst.v
@@ -523,3 +523,22 @@ Instance SatProdPos : Saturate Z.mul :=
     SatOk := Z.mul_pos_pos
   |}.
 Add Saturate SatProdPos.
+
+Lemma pow_pos_strict :
+  forall a b,
+    0 < a -> 0 < b -> 0 < a ^ b.
+Proof.
+  intros.
+  apply Z.pow_pos_nonneg; auto.
+  apply Z.lt_le_incl;auto.
+Qed.
+
+
+Instance SatPowPos : Saturate Z.pow :=
+  {|
+    PArg1 := fun x => 0 < x;
+    PArg2 := fun y => 0 < y;
+    PRes  := fun r => 0 < r;
+    SatOk := pow_pos_strict
+  |}.
+Add Saturate SatPowPos.

--- a/plugins/micromega/mutils.ml
+++ b/plugins/micromega/mutils.ml
@@ -140,6 +140,25 @@ let saturate p f sys =
     Printexc.print_backtrace stdout;
     raise x
 
+let saturate_bin (f : 'a -> 'a -> 'a option) (l : 'a list) =
+  let rec map_with acc e l =
+    match l with
+    | [] -> acc
+    | e' :: l' -> (
+      match f e e' with
+      | None -> map_with acc e l'
+      | Some r -> map_with (r :: acc) e l' )
+  in
+  let rec map2_with acc l' =
+    match l' with [] -> acc | e' :: l' -> map2_with (map_with acc e' l) l'
+  in
+  let rec iterate acc l' =
+    match map2_with [] l' with
+    | [] -> List.rev_append l' acc
+    | res -> iterate (List.rev_append l' acc) res
+  in
+  iterate [] l
+
 open Num
 open Big_int
 

--- a/plugins/micromega/mutils.mli
+++ b/plugins/micromega/mutils.mli
@@ -116,6 +116,7 @@ val simplify : ('a -> 'a option) -> 'a list -> 'a list option
 val saturate :
   ('a -> 'b option) -> ('b * 'a -> 'a -> 'a option) -> 'a list -> 'a list
 
+val saturate_bin : ('a -> 'a -> 'a option) -> 'a list -> 'a list
 val generate : ('a -> 'b option) -> 'a list -> 'b list
 val app_funs : ('a -> 'b option) list -> 'a -> 'b option
 val command : string -> string array -> 'a -> 'b

--- a/plugins/micromega/polynomial.mli
+++ b/plugins/micromega/polynomial.mli
@@ -224,6 +224,8 @@ module LinPoly : sig
       p is linear in x i.e x does not occur in b and
       a is a constant such that [pred a] *)
 
+  val get_bound : t -> Vect.Bound.t option
+
   val product : t -> t -> t
   (** [product p q]
      @return the product of the polynomial [p*q] *)
@@ -372,4 +374,5 @@ module WithProof : sig
 
   val saturate_subst : bool -> t list -> t list
   val is_substitution : bool -> t -> var option
+  val mul_bound : t -> t -> t option
 end

--- a/test-suite/micromega/bug_11191a.v
+++ b/test-suite/micromega/bug_11191a.v
@@ -1,0 +1,6 @@
+Require Import ZArith Lia.
+
+Goal forall p n, (0 < Z.pos (p ^ n))%Z.
+  intros.
+  lia.
+Qed.

--- a/test-suite/micromega/bug_11191b.v
+++ b/test-suite/micromega/bug_11191b.v
@@ -1,0 +1,6 @@
+Require Import ZArith Lia.
+
+Goal forall p, (0 < Z.pos (p ^ 2))%Z.
+  intros.
+  lia.
+Qed.


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->
This PR solves regressions of lia reported by #11191 regarding Z.pow.

The regression is due to the fact that `zify` is now able to deal with `Pos.pow` and therefore some positivity constraints need to be added explicitly.

When the exponent of Z.pow is a variable, this is solved by adding an instance ZifyInst stating that
`  forall a b,   0 < a -> 0 < b -> 0 < a ^ b.`

When the exponent of Z.pow is a constant, this is actually a product of variables and this is solved by  performing a more aggressive pre-processing step performing interval analysis of monomials.

<!-- Keep what applies -->
**Kind:**  bug fix 

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes #11191

<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [ ] Added test-suite
 