### PR TITLE
[merge script] Never bypass outdated branch sanity check.

### DIFF
--- a/dev/tools/merge-pr.sh
+++ b/dev/tools/merge-pr.sh
@@ -137,7 +137,8 @@ if [ "$LOCAL_BRANCH_COMMIT" != "$UPSTREAM_COMMIT" ]; then
     else
         error "Local branch is not up-to-date with ${REMOTE}."
         error "Pull before merging."
-        ask_confirmation
+        # This check should never be bypassed.
+        exit 1
     fi
 fi
 


### PR DESCRIPTION
The message was confusing and the prompt let one reviewer think the merge script would take care of doing the pull, which it doesn't. (See discussion starting at https://github.com/coq/coq/pull/11317#issuecomment-571587857.)

**Kind:** infrastructure.