### PR TITLE
let CI test bedrock2's 'tested' branch instead of 'master'

### DIFF
--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -209,7 +209,7 @@
 ########################################################################
 # bedrock2
 ########################################################################
-: "${bedrock2_CI_REF:=master}"
+: "${bedrock2_CI_REF:=tested}"
 : "${bedrock2_CI_GITURL:=https://github.com/mit-plv/bedrock2}"
 : "${bedrock2_CI_ARCHIVEURL:=${bedrock2_CI_GITURL}/archive}"
 


### PR DESCRIPTION
See https://github.com/mit-plv/bedrock2/issues/121.
This should ensure that Coq's CI only tests bedrock2 commits which have passed bedrock2's CI.