### PR TITLE
[exninfo] Deprecate aliases for exception re-raising.

### DIFF
--- a/engine/logic_monad.ml
+++ b/engine/logic_monad.ml
@@ -89,12 +89,12 @@ struct
   let catch = fun s h -> ();
     fun () -> try s ()
       with Exception e as src ->
-        let (src, info) = CErrors.push src in
+        let (src, info) = Exninfo.capture src in
         h (e, info) ()
 
   let read_line = fun () -> try read_line () with e ->
-    let (e, info) = CErrors.push e in
-    raise (e, info) ()
+    let (e, info) = Exninfo.capture e in
+    raise (e,info) ()
 
   let print_char = fun c -> (); fun () -> print_char c
 
@@ -104,8 +104,8 @@ struct
   let make f = (); fun () ->
     try f ()
     with e when CErrors.noncritical e ->
-      let (e, info) = CErrors.push e in
-      Util.iraise (Exception e, info)
+      let (e, info) = Exninfo.capture e in
+      Exninfo.iraise (Exception e, info)
 
   (** Use the current logger. The buffer is also flushed. *)
   let print_debug   s = make (fun _ -> Feedback.msg_debug s)
@@ -115,8 +115,8 @@ struct
 
   let run = fun x ->
     try x () with Exception e as src ->
-      let (src, info) = CErrors.push src in
-      Util.iraise (e, info)
+      let (src, info) = Exninfo.capture src in
+      Exninfo.iraise (e, info)
 end
 
 (** {6 Logical layer} *)

--- a/engine/proofview.mli
+++ b/engine/proofview.mli
@@ -14,7 +14,6 @@
     ['a tactic] is the (abstract) type of tactics modifying the proof
     state and returning a value of type ['a]. *)
 
-open Util
 open EConstr
 
 (** Main state of tactics *)
@@ -194,18 +193,18 @@ val tclZERO : ?info:Exninfo.info -> exn -> 'a tactic
     the successes of [t1] have been depleted and it failed with [e],
     then it behaves as [t2 e]. In other words, [tclOR] inserts a
     backtracking point. *)
-val tclOR : 'a tactic -> (iexn -> 'a tactic) -> 'a tactic
+val tclOR : 'a tactic -> (Exninfo.iexn -> 'a tactic) -> 'a tactic
 
 (** [tclORELSE t1 t2] is equal to [t1] if [t1] has at least one
     success or [t2 e] if [t1] fails with [e]. It is analogous to
     [try/with] handler of exception in that it is not a backtracking
     point. *)
-val tclORELSE : 'a tactic -> (iexn -> 'a tactic) -> 'a tactic
+val tclORELSE : 'a tactic -> (Exninfo.iexn -> 'a tactic) -> 'a tactic
 
 (** [tclIFCATCH a s f] is a generalisation of {!tclORELSE}: if [a]
     succeeds at least once then it behaves as [tclBIND a s] otherwise,
     if [a] fails with [e], then it behaves as [f e]. *)
-val tclIFCATCH : 'a tactic -> ('a -> 'b tactic) -> (iexn -> 'b tactic) -> 'b tactic
+val tclIFCATCH : 'a tactic -> ('a -> 'b tactic) -> (Exninfo.iexn -> 'b tactic) -> 'b tactic
 
 (** [tclONCE t] behave like [t] except it has at most one success:
     [tclONCE t] stops after the first success of [t]. If [t] fails
@@ -227,8 +226,8 @@ val tclEXACTLY_ONCE : exn -> 'a tactic -> 'a tactic
     continuation. It is the most general primitive to control
     backtracking. *)
 type 'a case =
-  | Fail of iexn
-  | Next of 'a * (iexn -> 'a tactic)
+  | Fail of Exninfo.iexn
+  | Next of 'a * (Exninfo.iexn -> 'a tactic)
 val tclCASE : 'a tactic -> 'a case tactic
 
 (** [tclBREAK p t] is a generalization of [tclONCE t]. Instead of
@@ -236,7 +235,7 @@ val tclCASE : 'a tactic -> 'a case tactic
     failure with an exception [e] such that [p e = Some e'] is raised. At
     which point it drops the remaining successes, failing with [e'].
     [tclONCE t] is equivalent to [tclBREAK (fun e -> Some e) t]. *)
-val tclBREAK : (iexn -> iexn option) -> 'a tactic -> 'a tactic
+val tclBREAK : (Exninfo.iexn -> Exninfo.iexn option) -> 'a tactic -> 'a tactic
 
 
 (** {7 Focusing tactics} *)
@@ -508,8 +507,8 @@ end
 module UnsafeRepr :
 sig
   type state = Proofview_monad.Logical.Unsafe.state
-  val repr : 'a tactic -> ('a, state, state, iexn) Logic_monad.BackState.t
-  val make : ('a, state, state, iexn) Logic_monad.BackState.t -> 'a tactic
+  val repr : 'a tactic -> ('a, state, state, Exninfo.iexn) Logic_monad.BackState.t
+  val make : ('a, state, state, Exninfo.iexn) Logic_monad.BackState.t -> 'a tactic
 end
 
 (** {6 Goal-dependent tactics} *)

--- a/ide/idetop.ml
+++ b/ide/idetop.ml
@@ -69,7 +69,7 @@ let ide_cmd_checks ~last_valid { CAst.loc; v } =
   let user_error s =
     try CErrors.user_err ?loc ~hdr:"IDE" (str s)
     with e ->
-      let (e, info) = CErrors.push e in
+      let (e, info) = Exninfo.capture e in
       let info = Stateid.add info ~valid:last_valid Stateid.dummy in
       Exninfo.iraise (e, info)
   in
@@ -477,7 +477,7 @@ let print_xml =
   fun oc xml ->
     Mutex.lock m;
     try Control.protect_sigalrm (Xml_printer.print oc) xml; Mutex.unlock m
-    with e -> let e = CErrors.push e in Mutex.unlock m; iraise e
+    with e -> let e = Exninfo.capture e in Mutex.unlock m; Exninfo.iraise e
 
 let slave_feeder fmt xml_oc msg =
   let xml = Xmlprotocol.(of_feedback fmt msg) in

--- a/ide/protocol/xmlprotocol.ml
+++ b/ide/protocol/xmlprotocol.ml
@@ -679,7 +679,7 @@ let abstract_eval_call : type a. _ -> a call -> a value = fun handler c ->
     | PrintAst x   -> mkGood (handler.print_ast x)
     | Annotate x   -> mkGood (handler.annotate x)
   with any ->
-    let any = CErrors.push any in
+    let any = Exninfo.capture any in
     Fail (handler.handle_exn any)
 
 (** brain dead code, edit if protocol messages are added/removed *)

--- a/interp/impargs.ml
+++ b/interp/impargs.ml
@@ -77,9 +77,9 @@ let with_implicit_protection f x =
     implicit_args := oflags;
     rslt
   with reraise ->
-    let reraise = CErrors.push reraise in
+    let reraise = Exninfo.capture reraise in
     let () = implicit_args := oflags in
-    iraise reraise
+    Exninfo.iraise reraise
 
 type on_trailing_implicit = Error | Info | Silent
 

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -1959,6 +1959,6 @@ let with_notation_protection f x =
   let fs = freeze ~marshallable:false in
   try let a = f x in unfreeze fs; a
   with reraise ->
-    let reraise = CErrors.push reraise in
+    let reraise = Exninfo.capture reraise in
     let () = unfreeze fs in
-    iraise reraise
+    Exninfo.iraise reraise

--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -962,7 +962,7 @@ let check_one_fix renv recpos trees def =
                 let stack_br = push_stack_args case_spec.(k) stack' in
                 check_rec_call renv stack_br br')
             with (FixGuardError _ as exn) ->
-              let exn = CErrors.push exn in
+              let exn = Exninfo.capture exn in
               (* we try hard to reduce the match away by looking for a
                  constructor in c_0 (we unfold definitions too) *)
               let c_0 = whd_all renv.env c_0 in
@@ -1007,7 +1007,7 @@ let check_one_fix renv recpos trees def =
                   check_nested_fix_body illformed renv' (decrArg+1) arg_sp body
                 else check_rec_call renv' [] body)
             with (FixGuardError _ as exn) ->
-              let exn = CErrors.push exn in
+              let exn = Exninfo.capture exn in
               (* we try hard to reduce the fix away by looking for a
                  constructor in l[decrArg] (we unfold definitions too) *)
               if List.length l <= decrArg then Exninfo.iraise exn;
@@ -1055,7 +1055,7 @@ let check_one_fix renv recpos trees def =
               List.iter (check_rec_call renv []) l;
               check_rec_call renv [] c
             with (FixGuardError _ as exn) ->
-              let exn = CErrors.push exn in
+              let exn = Exninfo.capture exn in
               (* we try hard to reduce the proj away by looking for a
                  constructor in c (we unfold definitions too) *)
               let c = whd_all renv.env c in

--- a/kernel/nativelib.ml
+++ b/kernel/nativelib.ml
@@ -180,8 +180,8 @@ let call_linker ?(fatal=true) env ~prefix f upds =
     if Dynlink.is_native then Dynlink.loadfile f else !load_obj f;
     register_native_file prefix
    with Dynlink.Error _ as exn ->
-     let exn = CErrors.push exn in
-     if fatal then iraise exn
+     let exn = Exninfo.capture exn in
+     if fatal then Exninfo.iraise exn
      else if !Flags.debug then Feedback.msg_debug CErrors.(iprint exn));
   match upds with Some upds -> update_locations upds | _ -> ()
 

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -1262,7 +1262,7 @@ let export ?except ~output_native_objects senv dir =
   let senv =
     try join_safe_environment ?except senv
     with e ->
-      let e = CErrors.push e in
+      let e = Exninfo.capture e in
       CErrors.user_err ~hdr:"export" (CErrors.iprint e)
   in
   assert(senv.future_cst = []);

--- a/lib/cErrors.mli
+++ b/lib/cErrors.mli
@@ -14,7 +14,7 @@
 (** {6 Error handling} *)
 
 val push : exn -> Exninfo.iexn
-(** Alias for [Backtrace.add_backtrace]. *)
+[@@ocaml.deprecated "please use [Exninfo.capture]"]
 
 (** {6 Generic errors.}
 

--- a/lib/future.ml
+++ b/lib/future.ml
@@ -131,7 +131,7 @@ let rec compute ck : 'a value =
         let data = f () in
         c := Val data; `Val data
       with e ->
-        let e = CErrors.push e in
+        let e = Exninfo.capture e in
         let e = fix_exn e in
         match e with
         | (NotReady _, _) -> `Exn e

--- a/lib/system.ml
+++ b/lib/system.ml
@@ -248,9 +248,9 @@ let extern_state magic filename val_0 =
       marshal_out channel val_0;
       close_out channel
     with reraise ->
-      let reraise = CErrors.push reraise in
+      let reraise = Exninfo.capture reraise in
       let () = try_remove filename in
-      iraise reraise
+      Exninfo.iraise reraise
   with Sys_error s ->
     CErrors.user_err ~hdr:"System.extern_state" (str "System error: " ++ str s)
 

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -119,8 +119,10 @@ val delayed_force : 'a delayed -> 'a
 (** {6 Enriched exceptions} *)
 
 type iexn = Exninfo.iexn
+[@@ocaml.deprecated "please use [Exninfo.iexn]"]
 
-val iraise : iexn -> 'a
+val iraise : Exninfo.iexn -> 'a
+[@@ocaml.deprecated "please use [Exninfo.iraise]"]
 
 (** {6 Misc. } *)
 

--- a/library/states.ml
+++ b/library/states.ml
@@ -8,8 +8,6 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-open Util
-
 type state = Lib.frozen * Summary.frozen
 
 let lib_of_state = fst
@@ -31,5 +29,5 @@ let with_state_protection f x =
   try
     let a = f x in unfreeze st; a
   with reraise ->
-    let reraise = CErrors.push reraise in
-    (unfreeze st; iraise reraise)
+    let reraise = Exninfo.capture reraise in
+    (unfreeze st; Exninfo.iraise reraise)

--- a/parsing/pcoq.ml
+++ b/parsing/pcoq.ml
@@ -685,9 +685,9 @@ let with_grammar_rule_protection f x =
   let fs = freeze ~marshallable:false in
   try let a = f x in unfreeze fs; a
   with reraise ->
-    let reraise = CErrors.push reraise in
+    let reraise = Exninfo.capture reraise in
     let () = unfreeze fs in
-    iraise reraise
+    Exninfo.iraise reraise
 
 (** Registering grammar of generic arguments *)
 

--- a/plugins/funind/indfun_common.ml
+++ b/plugins/funind/indfun_common.ml
@@ -520,7 +520,7 @@ let funind_purify f x =
   let st = Vernacstate.freeze_interp_state ~marshallable:false in
   try f x
   with e ->
-    let e = CErrors.push e in
+    let e = Exninfo.capture e in
     Vernacstate.unfreeze_interp_state st;
     Exninfo.iraise e
 

--- a/plugins/ltac/extratactics.mlg
+++ b/plugins/ltac/extratactics.mlg
@@ -670,7 +670,7 @@ let hResolve id c occ t =
       Pretyping.understand env sigma t_hole
     with
       | Pretype_errors.PretypeError (_,_,Pretype_errors.UnsolvableImplicit _) as e ->
-          let (e, info) = CErrors.push e in
+          let (e, info) = Exninfo.capture e in
           let loc_begin = Option.cata (fun l -> fst (Loc.unloc l)) 0 (Loc.get_loc info) in
           resolve_hole (subst_hole_with_term loc_begin c_raw t_hole)
   in

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -165,8 +165,8 @@ let catching_error call_trace fail (e, info) =
 let catch_error call_trace f x =
   try f x
   with e when CErrors.noncritical e ->
-    let e = CErrors.push e in
-    catching_error call_trace iraise e
+    let e = Exninfo.capture e in
+    catching_error call_trace Exninfo.iraise e
 
 let wrap_error tac k =
   if is_traced () then Proofview.tclORELSE tac k else tac
@@ -717,13 +717,13 @@ let interp_may_eval f ist env sigma = function
      try
         f ist env sigma c
      with reraise ->
-       let reraise = CErrors.push reraise in
+       let reraise = Exninfo.capture reraise in
        (* spiwack: to avoid unnecessary modifications of tacinterp, as this
           function already use effect, I call [run] hoping it doesn't mess
           up with any assumption. *)
        Proofview.NonLogical.run (debugging_exception_step ist false (fst reraise) (fun () ->
          str"interpretation of term " ++ pr_glob_constr_env env (fst c)));
-       iraise reraise
+       Exninfo.iraise reraise
 
 (* Interprets a constr expression possibly to first evaluate *)
 let interp_constr_may_eval ist env sigma c =
@@ -731,12 +731,12 @@ let interp_constr_may_eval ist env sigma c =
     try
       interp_may_eval interp_constr ist env sigma c
     with reraise ->
-      let reraise = CErrors.push reraise in
+      let reraise = Exninfo.capture reraise in
       (* spiwack: to avoid unnecessary modifications of tacinterp, as this
           function already use effect, I call [run] hoping it doesn't mess
           up with any assumption. *)
        Proofview.NonLogical.run (debugging_exception_step ist false (fst reraise) (fun () -> str"evaluation of term"));
-      iraise reraise
+      Exninfo.iraise reraise
   in
   begin
     (* spiwack: to avoid unnecessary modifications of tacinterp, as this

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -1095,11 +1095,11 @@ let tclDO n tac =
     try tac gl
     with
     | CErrors.UserError (l, s) as e ->
-        let _, info = CErrors.push e in
-        let e' = CErrors.UserError (l, prefix i ++ s) in
-        Util.iraise (e', info)
+      let _, info = Exninfo.capture e in
+      let e' = CErrors.UserError (l, prefix i ++ s) in
+      Exninfo.iraise (e', info)
     | Gramlib.Ploc.Exc(loc, CErrors.UserError (l, s))  ->
-        raise (Gramlib.Ploc.Exc(loc, CErrors.UserError (l, prefix i ++ s))) in
+      raise (Gramlib.Ploc.Exc(loc, CErrors.UserError (l, prefix i ++ s))) in
   let rec loop i gl =
     if i = n then tac_err_at i gl else
     (tclTHEN (tac_err_at i) (loop (i + 1))) gl in

--- a/pretyping/cases.ml
+++ b/pretyping/cases.ml
@@ -73,11 +73,11 @@ let error_wrong_numarg_inductive ?loc env c n =
 
 let list_try_compile f l =
   let rec aux errors = function
-  | [] -> if errors = [] then anomaly (str "try_find_f.") else iraise (List.last errors)
+  | [] -> if errors = [] then anomaly (str "try_find_f.") else Exninfo.iraise (List.last errors)
   | h::t ->
       try f h
       with UserError _ | TypeError _ | PretypeError _ | PatternMatchingError _ as e ->
-            let e = CErrors.push e in
+            let e = Exninfo.capture e in
             aux (e::errors) t in
   aux [] l
 

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -87,9 +87,9 @@ let search_guard ?loc env possible_indexes fixdefs =
     let fix = ((indexes, 0),fixdefs) in
     (try check_fix env fix
      with reraise ->
-       let (e, info) = CErrors.push reraise in
+       let (e, info) = Exninfo.capture reraise in
        let info = Option.cata (fun loc -> Loc.add_loc info loc) info loc in
-       iraise (e, info));
+       Exninfo.iraise (e, info));
     indexes
   else
     (* we now search recursively among all combinations *)
@@ -266,8 +266,8 @@ let apply_heuristics env sigma fail_evar =
   let flags = default_flags_of (Typeclasses.classes_transparent_state ()) in
   try solve_unif_constraints_with_heuristics ~flags env sigma
   with e when CErrors.noncritical e ->
-    let e = CErrors.push e in
-    if fail_evar then iraise e else sigma
+    let e = Exninfo.capture e in
+    if fail_evar then Exninfo.iraise e else sigma
 
 let check_typeclasses_instances_are_solved ~program_mode env current_sigma frozen =
   (* Naive way, call resolution again with failure flag *)
@@ -753,9 +753,9 @@ struct
           let cofix = (i, fixdecls) in
             (try check_cofix !!env (i, nf_fix sigma fixdecls)
              with reraise ->
-               let (e, info) = CErrors.push reraise in
+               let (e, info) = Exninfo.capture reraise in
                let info = Option.cata (Loc.add_loc info) info loc in
-               iraise (e, info));
+               Exninfo.iraise (e, info));
             make_judge (mkCoFix cofix) ftys.(i)
       in
       discard_trace @@ inh_conv_coerce_to_tycon ?loc ~program_mode resolve_tc env sigma fixj tycon
@@ -946,9 +946,9 @@ struct
       try
         judge_of_product !!env name j j'
       with TypeError _ as e ->
-        let (e, info) = CErrors.push e in
+        let (e, info) = Exninfo.capture e in
         let info = Option.cata (Loc.add_loc info) info loc in
-        iraise (e, info) in
+        Exninfo.iraise (e, info) in
       discard_trace @@ inh_conv_coerce_to_tycon ?loc ~program_mode resolve_tc env sigma resj tycon
 
   let pretype_letin self (name, c1, t, c2) =

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -1465,7 +1465,7 @@ let report_anomaly (e, info) =
       UserError (None, msg)
     else e
   in
-  iraise (e, info)
+  Exninfo.iraise (e, info)
 
 let f_conv ?l2r ?reds env ?evars x y =
   let inj = EConstr.Unsafe.to_constr in

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -1149,10 +1149,9 @@ let rec unify_0_with_initial_metas (sigma,ms,es as subst : subst0) conv_at_top e
     if !debug_unification then Feedback.msg_debug (str "Leaving unification with success");
     a
   with e ->
-    let e = CErrors.push e in
+    let e = Exninfo.capture e in
     if !debug_unification then Feedback.msg_debug (str "Leaving unification with failure");
-    iraise e
-
+    Exninfo.iraise e
 
 let unify_0 env sigma = unify_0_with_initial_metas (sigma,[],[]) true env
 

--- a/proofs/refiner.ml
+++ b/proofs/refiner.ml
@@ -209,8 +209,8 @@ let catch_failerror (e, info) =
   | FailError (0,_) ->
       Control.check_for_interrupt ()
   | FailError (lvl,s) ->
-    iraise (FailError (lvl - 1, s), info)
-  | e -> iraise (e, info)
+    Exninfo.iraise (FailError (lvl - 1, s), info)
+  | e -> Exninfo.iraise (e, info)
   (** FIXME: do we need to add a [Errors.push] here? *)
 
 (* ORELSE0 t1 t2 tries to apply t1 and if it fails, applies t2 *)
@@ -219,7 +219,7 @@ let tclORELSE0 t1 t2 g =
     t1 g
   with (* Breakpoint *)
     | e when CErrors.noncritical e ->
-      let e = CErrors.push e in catch_failerror e; t2 g
+      let e = Exninfo.capture e in catch_failerror e; t2 g
 
 (* ORELSE t1 t2 tries to apply t1 and if it fails or does not progress,
    then applies t2 *)
@@ -232,7 +232,7 @@ let tclORELSE_THEN t1 t2then t2else gls =
   match
     try Some(tclPROGRESS t1 gls)
     with e when CErrors.noncritical e ->
-      let e = CErrors.push e in catch_failerror e; None
+      let e = Exninfo.capture e in catch_failerror e; None
   with
     | None -> t2else gls
     | Some sgl ->

--- a/stm/asyncTaskQueue.ml
+++ b/stm/asyncTaskQueue.ml
@@ -372,7 +372,7 @@ module Make(T : Task) () = struct
   let with_n_workers n priority f =
     let q = create n priority in
     try let rc = f q in destroy q; rc
-    with e -> let e = CErrors.push e in destroy q; iraise e
+    with e -> let e = Exninfo.capture e in destroy q; Exninfo.iraise e
 
   let n_workers { active } = Pool.n_workers active
 

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -1014,7 +1014,7 @@ end = struct (* {{{ *)
       if PG_compat.there_are_pending_proofs () then
         VCS.goals id (PG_compat.get_open_goals ())
     with e ->
-      let (e, info) = CErrors.push e in
+      let (e, info) = Exninfo.capture e in
       let good_id = !cur_id in
       invalidate_cur_state ();
       VCS.reached id;
@@ -1046,7 +1046,7 @@ end = struct (* {{{ *)
       unfreeze st;
       res
     with e ->
-      let e = CErrors.push e in
+      let e = Exninfo.capture e in
       Vernacstate.invalidate_cache ();
       unfreeze st;
       Exninfo.iraise e
@@ -1540,7 +1540,7 @@ end = struct (* {{{ *)
       RespBuiltProof(proof,time)
     with
     | e when CErrors.noncritical e || e = Stack_overflow ->
-        let (e, info) = CErrors.push e in
+        let (e, info) = Exninfo.capture e in
         (* This can happen if the proof is broken.  The error has also been
          * signalled as a feedback, hence we can silently recover *)
         let e_error_at, e_safe_id = match Stateid.get info with
@@ -1687,7 +1687,7 @@ end = struct (* {{{ *)
       `OK proof
       end
     with e ->
-      let (e, info) = CErrors.push e in
+      let (e, info) = Exninfo.capture e in
       (try match Stateid.get info with
       | None ->
         msg_warning Pp.(
@@ -2092,7 +2092,7 @@ end = struct (* {{{ *)
       ignore(stm_vernac_interp r_for st { r_what with verbose = true });
       feedback ~id:r_for Processed
     with e when CErrors.noncritical e ->
-      let e = CErrors.push e in
+      let e = Exninfo.capture e in
       let msg = iprint e     in
       feedback ~id:r_for (Message (Error, None, msg))
 
@@ -2337,7 +2337,7 @@ let known_state ~doc ?(redefine_qed=false) ~cache id =
     else
       try f ()
       with e when CErrors.noncritical e ->
-        let ie = CErrors.push e in
+        let ie = Exninfo.capture e in
         error_absorbing_tactic id blockname ie in
   (* Absorb errors from f x *)
   let resilient_command f x =
@@ -2435,7 +2435,7 @@ let known_state ~doc ?(redefine_qed=false) ~cache id =
                let st = Vernacstate.freeze_interp_state ~marshallable:false in
                ignore(stm_vernac_interp id st x);
             with e when CErrors.noncritical e ->
-              let (e, info) = CErrors.push e in
+              let (e, info) = Exninfo.capture e in
               let info = Stateid.add info ~valid:prev id in
               Exninfo.iraise (e, info));
             wall_clock_last_fork := Unix.gettimeofday ()
@@ -2688,7 +2688,7 @@ let observe ~doc id =
     VCS.print ();
     doc
   with e ->
-    let e = CErrors.push e in
+    let e = Exninfo.capture e in
     VCS.print ();
     VCS.restore vcs;
     Exninfo.iraise e
@@ -2763,7 +2763,7 @@ let finish_tasks name u p (t,rcbackup as tasks) =
     let a, _ = List.fold_left finish_task u (info_tasks tasks) in
     (a,true), p
   with e ->
-    let e = CErrors.push e in
+    let e = Exninfo.capture e in
     msg_warning (str"File " ++ str name ++ str ":" ++ spc () ++ iprint e);
     exit 1
 
@@ -2987,7 +2987,7 @@ let process_transaction ~doc ?(newtip=Stateid.fresh ())
     VCS.print ();
     rc
   with e ->
-    let e = CErrors.push e in
+    let e = Exninfo.capture e in
     handle_failure e vcs
 
 let get_ast ~doc id =
@@ -3197,7 +3197,7 @@ let edit_at ~doc id =
     VCS.print ();
     doc, rc
   with e ->
-    let (e, info) = CErrors.push e in
+    let (e, info) = Exninfo.capture e in
     match Stateid.get info with
     | None ->
         VCS.print ();

--- a/tactics/abstract.ml
+++ b/tactics/abstract.ml
@@ -97,8 +97,8 @@ let cache_term_by_tactic_then ~opaque ~name_op ?(goal_type=None) tac tacK =
        which is an error irrelevant to the proof system (in fact it
        means that [e] comes from [tac] failing to yield enough
        success). Hence it reraises [e]. *)
-    let (_, info) = CErrors.push src in
-    iraise (e, info)
+    let (_, info) = Exninfo.capture src in
+    Exninfo.iraise (e, info)
   in
   let body, effs = Future.force const.Declare.proof_entry_body in
   (* We drop the side-effects from the entry, they already exist in the ambient environment *)

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -236,7 +236,7 @@ let unify_resolve_refine poly flags gl clenv =
          Tacticals.New.tclZEROMSG (str "Unable to unify")
       | e when CErrors.noncritical e ->
          Tacticals.New.tclZEROMSG (str "Unexpected error")
-      | _ -> iraise ie)
+      | _ -> Exninfo.iraise ie)
 
 (** Dealing with goals of the form A -> B and hints of the form
   C -> A -> B.
@@ -770,7 +770,7 @@ module Search = struct
              (fun e' ->
               if CErrors.noncritical (fst e') then
                 (pr_error e'; aux (merge_exceptions e e') tl)
-              else iraise e')
+              else Exninfo.iraise e')
     and aux e = function
       | x :: xs -> onetac e x xs
       | [] ->

--- a/tactics/eauto.ml
+++ b/tactics/eauto.ml
@@ -235,7 +235,7 @@ module SearchProblem = struct
 (* 	      msg (hov 1 (pptac ++ str" gives: \n" ++ pr_goals lgls ++ str"\n")); *)
               (lgls, cost, pptac) :: aux tacl
           with e when CErrors.noncritical e ->
-            let e = CErrors.push e in
+            let e = Exninfo.capture e in
             Refiner.catch_failerror e; aux tacl
     in aux l
 

--- a/tactics/pfedit.ml
+++ b/tactics/pfedit.ml
@@ -130,8 +130,8 @@ let build_constant_by_tactic ~name ?(opaque=Proof_global.Transparent) ctx sign ~
     | _ ->
       CErrors.anomaly Pp.(str "[build_constant_by_tactic] close_proof returned more than one proof term")
   with reraise ->
-    let reraise = CErrors.push reraise in
-    iraise reraise
+    let reraise = Exninfo.capture reraise in
+    Exninfo.iraise reraise
 
 let build_by_tactic ?(side_eff=true) env sigma ~poly typ tac =
   let name = Id.of_string ("temporary_proof"^string_of_int (next())) in
@@ -160,8 +160,8 @@ let refine_by_tactic ~name ~poly env sigma ty tac =
     try Proof.run_tactic env tac prf
     with Logic_monad.TacticFailure e as src ->
       (* Catch the inner error of the monad tactic *)
-      let (_, info) = CErrors.push src in
-      iraise (e, info)
+      let (_, info) = Exninfo.capture src in
+      Exninfo.iraise (e, info)
   in
   (* Plug back the retrieved sigma *)
   let Proof.{ goals; stack; shelf; given_up; sigma; entry } = Proof.data prf in

--- a/tactics/tacticals.mli
+++ b/tactics/tacticals.mli
@@ -144,7 +144,7 @@ module New : sig
 
   (** [catch_failerror e] fails and decreases the level if [e] is an
       Ltac error with level more than 0. Otherwise succeeds. *)
-  val catch_failerror : Util.iexn -> unit tactic
+  val catch_failerror : Exninfo.iexn -> unit tactic
 
   val tclIDTAC : unit tactic
   val tclTHEN : unit tactic -> unit tactic -> unit tactic

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -1848,12 +1848,12 @@ let apply_in_once_main flags innerclause env sigma (loc,d,lbind) =
   let rec aux clause =
     try progress_with_clause flags innerclause clause
     with e when CErrors.noncritical e ->
-    let e' = CErrors.push e in
+    let e' = Exninfo.capture e in
     try aux (clenv_push_prod clause)
     with NotExtensibleClause ->
       match e with
       | UnableToApply -> explain_unable_to_apply_lemma ?loc env sigma thm innerclause
-      | _ -> iraise e'
+      | _ -> Exninfo.iraise e'
   in
   aux (make_clenv_binding env sigma (d,thm) lbind)
 
@@ -1886,7 +1886,7 @@ let apply_in_once ?(respect_opaque = false) with_delta
             tac id
           ])
     with e when with_destruct && CErrors.noncritical e ->
-      let (e, info) = CErrors.push e in
+      let (e, info) = Exninfo.capture e in
         (descend_in_conjunctions (Id.Set.singleton targetid)
            (fun b id -> aux (id::idstoclear) b (mkVar id))
            (e, info) c)
@@ -3155,7 +3155,7 @@ let clear_for_destruct ids =
     (clear_gen (fun env sigma id err inglobal -> raise (ClearDependencyError (id,err,inglobal))) ids)
     (function
      | ClearDependencyError (id,err,inglobal),_ -> warn_cannot_remove_as_expected (id,inglobal); Proofview.tclUNIT ()
-     | e -> iraise e)
+     | e -> Exninfo.iraise e)
 
 (* Either unfold and clear if defined or simply clear if not a definition *)
 let expand_hyp id =

--- a/toplevel/coqinit.ml
+++ b/toplevel/coqinit.ml
@@ -47,9 +47,9 @@ let load_rcfile ~rcfile ~state =
                          " found. Skipping rcfile loading."))
         *)
     with reraise ->
-      let reraise = CErrors.push reraise in
+      let reraise = Exninfo.capture reraise in
       let () = Feedback.msg_info (str"Load of rcfile failed.") in
-      iraise reraise
+      Exninfo.iraise reraise
 
 (* Recursively puts `.v` files in the LoadPath if -nois was not passed *)
 let build_stdlib_vo_path ~unix_path ~coq_path =

--- a/toplevel/coqloop.ml
+++ b/toplevel/coqloop.ml
@@ -265,7 +265,7 @@ let read_sentence ~state input =
   let open Vernac.State in
   try Stm.parse_sentence ~doc:state.doc state.sid ~entry:G_toplevel.vernac_toplevel input
   with reraise ->
-    let reraise = CErrors.push reraise in
+    let reraise = Exninfo.capture reraise in
     discard_to_dot ();
     (* The caller of read_sentence does the error printing now, this
        should be re-enabled once we rely on the feedback error
@@ -360,7 +360,7 @@ let top_goal_print ~doc c oldp newp =
     end
   with
   | exn ->
-    let (e, info) = CErrors.push exn in
+    let (e, info) = Exninfo.capture exn in
     let loc = Loc.get_loc info in
     let msg = CErrors.iprint (e, info) in
     TopErr.print_error_for_buffer ?loc Feedback.Error msg top_buffer
@@ -484,7 +484,7 @@ let read_and_execute ~state =
     TopErr.print_error_for_buffer Feedback.Error msg top_buffer;
     exit 1
   | any ->
-    let (e, info) = CErrors.push any in
+    let (e, info) = Exninfo.capture any in
     let loc = Loc.get_loc info in
     let msg = CErrors.iprint (e, info) in
     TopErr.print_error_for_buffer ?loc Feedback.Error msg top_buffer;

--- a/user-contrib/Ltac2/tac2core.ml
+++ b/user-contrib/Ltac2/tac2core.ml
@@ -573,7 +573,7 @@ let () = define1 "constr_check" constr begin fun c ->
       Proofview.Unsafe.tclEVARS sigma >>= fun () ->
       return (of_result Value.of_constr (Inl c))
     with e when CErrors.noncritical e ->
-      let e = CErrors.push e in
+      let e = Exninfo.capture e in
       return (of_result Value.of_constr (Inr e))
   end
 end
@@ -1079,7 +1079,7 @@ let interp_constr flags ist c =
     Proofview.Unsafe.tclEVARS sigma >>= fun () ->
     Proofview.tclUNIT c
   with e when catchable_exception e ->
-    let (e, info) = CErrors.push e in
+    let (e, info) = Exninfo.capture e in
     set_bt info >>= fun info ->
     match Exninfo.get info fatal_flag with
     | None -> Proofview.tclZERO ~info e

--- a/vernac/declareDef.ml
+++ b/vernac/declareDef.ml
@@ -37,9 +37,9 @@ module Hook = struct
   let call ?hook ?fix_exn x =
     try Option.iter (fun hook -> CEphemeron.get hook x) hook
     with e when CErrors.noncritical e ->
-      let e = CErrors.push e in
+      let e = Exninfo.capture e in
       let e = Option.cata (fun fix -> fix e) e fix_exn in
-      Util.iraise e
+      Exninfo.iraise e
 end
 
 (* Locality stuff *)

--- a/vernac/declaremods.ml
+++ b/vernac/declaremods.ml
@@ -935,9 +935,9 @@ let protect_summaries f =
   try f fs
   with reraise ->
     (* Something wrong: undo the whole process *)
-    let reraise = CErrors.push reraise in
+    let reraise = Exninfo.capture reraise in
     let () = Summary.unfreeze_summaries fs in
-    iraise reraise
+    Exninfo.iraise reraise
 
 let start_module export id args res =
   protect_summaries (RawModOps.start_module export id args res)

--- a/vernac/indschemes.ml
+++ b/vernac/indschemes.ml
@@ -118,7 +118,7 @@ let alarm what internal msg =
 let try_declare_scheme what f internal names kn =
   try f internal names kn
   with e ->
-  let e = CErrors.push e in
+  let e = Exninfo.capture e in
   let rec extract_exn = function Logic_monad.TacticFailure e -> extract_exn e | e -> e in
   let msg = match extract_exn (fst e) with
     | ParameterWithoutEquality cst ->
@@ -166,11 +166,11 @@ let try_declare_scheme what f internal names kn =
     | e when CErrors.noncritical e ->
         alarm what internal
           (str "Unexpected error during scheme creation: " ++ CErrors.print e)
-    | _ -> iraise e
+    | _ -> Exninfo.iraise e
   in
   match msg with
   | None -> ()
-  | Some msg -> iraise (UserError (None, msg), snd e)
+  | Some msg -> Exninfo.iraise (UserError (None, msg), snd e)
 
 let beq_scheme_msg mind =
   let mib = Global.lookup_mind mind in

--- a/vernac/lemmas.ml
+++ b/vernac/lemmas.ml
@@ -375,8 +375,8 @@ let finish_proved env sigma idopt po info =
       (* This takes care of the implicits and hook for the current constant*)
       process_recthms ~fix_exn ?hook env sigma universes ~udecl ~poly ~scope r impargs other_thms
     with e when CErrors.noncritical e ->
-      let e = CErrors.push e in
-      iraise (fix_exn e)
+      let e = Exninfo.capture e in
+      Exninfo.iraise (fix_exn e)
     in ()
   | _ ->
     CErrors.anomaly Pp.(str "[standard_proof_terminator] close_proof returned more than one proof term")

--- a/vernac/library.ml
+++ b/vernac/library.ml
@@ -440,11 +440,11 @@ let save_library_base f sum lib univs tasks proofs =
     System.marshal_out_segment f ch (proofs : seg_proofs);
     close_out ch
   with reraise ->
-    let reraise = CErrors.push reraise in
+    let reraise = Exninfo.capture reraise in
     close_out ch;
     Feedback.msg_warning (str "Removed file " ++ str f);
     Sys.remove f;
-    iraise reraise
+    Exninfo.iraise reraise
 
 type ('document,'counters) todo_proofs =
  | ProofsTodoNone (* for .vo *)

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -1466,9 +1466,9 @@ let with_lib_stk_protection f x =
   let fs = Lib.freeze () in
   try let a = f x in Lib.unfreeze fs; a
   with reraise ->
-    let reraise = CErrors.push reraise in
+    let reraise = Exninfo.capture reraise in
     let () = Lib.unfreeze fs in
-    iraise reraise
+    Exninfo.iraise reraise
 
 let with_syntax_protection f x =
   with_lib_stk_protection

--- a/vernac/obligations.ml
+++ b/vernac/obligations.ml
@@ -428,7 +428,7 @@ let solve_by_tac ?loc name evi t poly ctx =
     Some (body, entry.Declare.proof_entry_type, ctx')
   with
   | Refiner.FailError (_, s) as exn ->
-    let _ = CErrors.push exn in
+    let _ = Exninfo.capture exn in
     user_err ?loc ~hdr:"solve_obligation" (Lazy.force s)
   (* If the proof is open we absorb the error and leave the obligation open *)
   | Proof.OpenProof _ ->

--- a/vernac/topfmt.ml
+++ b/vernac/topfmt.ml
@@ -361,7 +361,7 @@ let in_phase ~phase f x =
   with exn ->
     let iexn = Exninfo.capture exn in
     default_phase := op;
-    Util.iraise iexn
+    Exninfo.iraise iexn
 
 let pr_loc loc =
     let fname = loc.Loc.fname in
@@ -394,7 +394,7 @@ let pr_phase ?loc () =
      None
 
 let print_err_exn any =
-  let (e, info) = CErrors.push any in
+  let (e, info) = Exninfo.capture any in
   let loc = Loc.get_loc info in
   let pre_hdr = pr_phase ?loc () in
   let msg = CErrors.iprint (e, info) ++ fnl () in

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -342,9 +342,9 @@ let dump_universes_gen prl g s =
     close ();
     str "Universes written to file \"" ++ str s ++ str "\"."
   with reraise ->
-    let reraise = CErrors.push reraise in
+    let reraise = Exninfo.capture reraise in
     close ();
-    iraise reraise
+    Exninfo.iraise reraise
 
 let universe_subgraph ?loc g univ =
   let open Univ in

--- a/vernac/vernacextend.ml
+++ b/vernac/vernacextend.ml
@@ -109,11 +109,11 @@ let type_vernac opn converted_args ~atts =
     phase := "Executing command";
     hunk ~atts
   with
-    | reraise ->
-        let reraise = CErrors.push reraise in
-        if !Flags.debug then
-          Feedback.msg_debug (str"Vernac Interpreter " ++ str !phase);
-        iraise reraise
+  | reraise ->
+    let reraise = Exninfo.capture reraise in
+    if !Flags.debug then
+      Feedback.msg_debug (str"Vernac Interpreter " ++ str !phase);
+    Exninfo.iraise reraise
 
 (** VERNAC EXTEND registering *)
 

--- a/vernac/vernacinterp.ml
+++ b/vernac/vernacinterp.ml
@@ -96,7 +96,7 @@ let with_fail f : (Pp.t, unit) result =
   (* Fail Timeout is a common pattern so we need to support it. *)
   | e when CErrors.noncritical e || e = CErrors.Timeout ->
     (* The error has to be printed in the failing state *)
-    Ok CErrors.(iprint (push e))
+    Ok CErrors.(iprint (Exninfo.capture e))
 
 (* We restore the state always *)
 let with_fail ~st f =
@@ -262,10 +262,10 @@ let interp_gen ~verbosely ~st ~interp_fn cmd =
       Vernacstate.freeze_interp_state ~marshallable:false
     ) st
   with exn ->
-    let exn = CErrors.push exn in
+    let exn = Exninfo.capture exn in
     let exn = locate_if_not_already ?loc:cmd.CAst.loc exn in
     Vernacstate.invalidate_cache ();
-    Util.iraise exn
+    Exninfo.iraise exn
 
 (* Regular interp *)
 let interp ?(verbosely=true) ~st cmd =

--- a/vernac/vernacstate.ml
+++ b/vernac/vernacstate.ml
@@ -21,7 +21,7 @@ module Parser = struct
     Flags.with_option Flags.we_are_parsing (fun () ->
       try Pcoq.Entry.parse entry pa
       with e when CErrors.noncritical e ->
-        let (e, info) = CErrors.push e in
+        let (e, info) = Exninfo.capture e in
         Exninfo.iraise (e, info))
     ()
 


### PR DESCRIPTION
We make the primitives for backtrace-enriched exceptions canonical in
the `Exninfo` module, deprecating all other aliases.

At some point dependencies between `CErrors` and `Exninfo` were a bit
complex, after recent clean-ups the roles seem much clearer so we can
have a single place for `iraise` and `capture`.
