### PR TITLE
Fixes #9412: Context command ignored implicit binders

### DIFF
--- a/dev/ci/user-overlays/11390-herbelin-master+fix-9412-context-implicits.sh
+++ b/dev/ci/user-overlays/11390-herbelin-master+fix-9412-context-implicits.sh
@@ -1,0 +1,9 @@
+if [ "$CI_PULL_REQUEST" = "11390" ] || [ "$CI_BRANCH" = "master+fix-9412-context-implicits" ]; then
+
+    fiat_crypto_legacy_CI_REF=master+adapt-coq-pr9412-ignored-implicit-context
+    fiat_crypto_legacy_CI_GITURL=https://github.com/herbelin/fiat-crypto
+
+    fiat_parsers_CI_REF=master+change-coq-pr9412-ignored-implicit-context
+    fiat_parsers_CI_GITURL=https://github.com/herbelin/fiat
+
+fi

--- a/doc/changelog/02-specification-language/11390-master+fix-9412-context-implicits.rst
+++ b/doc/changelog/02-specification-language/11390-master+fix-9412-context-implicits.rst
@@ -1,0 +1,16 @@
+- **Fixed:**
+  Implicit arguments were ignored in :cmd:`Context`
+
+  .. warning::
+
+     This has been observed to be a breaking change in a couple of
+     projects. This can be fixed either by removing the implicit
+     argument annotations, or by taking into account the new presence of
+     implicit arguments for the corresponding declarations. The first
+     approach provides backward compatibility. If needed, the second
+     approach can be made backward compatible too by adding an extra
+     (eventually superflous) :n:`Local Arguments` declaration right
+     after :cmd:`Context`.
+
+  (`#11390 <https://github.com/coq/coq/pull/11390>`_,
+  by Hugo Herbelin, fixing `#9412 <https://github.com/coq/coq/pull/9412>`_).

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -192,6 +192,9 @@ let compute_internalization_env env sigma ?(impls=empty_internalization_env) ty 
 let extend_internalization_data (r, impls, scopes, uid) impl scope =
   (r, impls@[impl], scopes@[scope], uid)
 
+let implicits_of_decl_in_internalization_env id (int_env:internalization_env) =
+  let (_, impls, _, _) = Id.Map.find id int_env in impls
+
 (**********************************************************************)
 (* Contracting "{ _ }" in notations *)
 

--- a/interp/constrintern.mli
+++ b/interp/constrintern.mli
@@ -65,6 +65,9 @@ val compute_internalization_env : env -> evar_map -> ?impls:internalization_env 
 val extend_internalization_data :
   var_internalization_data -> Impargs.implicit_status -> scope_name option -> var_internalization_data
 
+val implicits_of_decl_in_internalization_env :
+  Id.t -> internalization_env -> Impargs.implicit_status list
+
 type ltac_sign = {
   ltac_vars : Id.Set.t;
   (** Variables of Ltac which may be bound to a term *)

--- a/test-suite/bugs/closed/bug_9412.v
+++ b/test-suite/bugs/closed/bug_9412.v
@@ -1,0 +1,18 @@
+Module A.
+Context (H : forall {n:nat}, n=n -> True).
+Check H (n := 1).
+Check H eq_refl.
+Context (L := fun {x:nat} (H:x=x) => H).
+About L.
+Check L (x := 1).
+Check L eq_refl.
+End A.
+
+Section S.
+Context (H : forall {n:nat}, n=n -> True).
+Check H (n := 1).
+Check H eq_refl.
+Context (L := fun {x:nat} (H:x=x) => H).
+Check L (x := 1).
+Check L eq_refl.
+End S.

--- a/test-suite/success/setoid_test.v
+++ b/test-suite/success/setoid_test.v
@@ -138,14 +138,14 @@ Qed.
 Section mult.
   Context (fold : forall {A} {B}, (A -> B) -> A -> B).
   Context (add : forall A, A -> A).
-  Context (fold_lemma : forall {A B f} {eqA : relation B} x, eqA (fold A B f (add A x)) (fold _ _ f x)).
+  Context (fold_lemma : forall {A B f} {eqA : relation B} x, eqA (fold f (add A x)) (fold f x)).
   Context (ab : forall B, A -> B).
   Context (anat : forall A, nat -> A).
 
-Goal forall x, (fold _ _ (fun x => ab A x) (add A x) = anat _ (fold _ _ (ab nat) (add _ x))). 
+Goal forall x, (fold (fun x => ab A x) (add A x) = anat _ (fold (ab nat) (add _ x))).
 Proof. intros.
   setoid_rewrite fold_lemma. 
-  change (fold A A (fun x0 : A => ab A x0) x = anat A (fold A nat (ab nat) x)).
+  change (fold (fun x0 : A => ab A x0) x = anat A (fold (ab nat) x)).
 Abort.
 
 End mult.

--- a/vernac/comAssumption.mli
+++ b/vernac/comAssumption.mli
@@ -66,4 +66,4 @@ val interp_context
   :  Environ.env
   -> Evd.evar_map
   -> local_binder_expr list
-  -> Evd.evar_map * (Id.t * Constr.t option * Constr.t * Glob_term.binding_kind) list
+  -> Evd.evar_map * Constrintern.internalization_env * (Id.t * Constr.t option * Constr.t * Glob_term.binding_kind) list

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1535,6 +1535,9 @@ let vernac_declare_instance ~atts id bl inst pri =
   in
   Classes.declare_new_instance ~program_mode:program ~locality ~poly id bl inst pri
 
+let vernac_context ~atts sup =
+  ComAssumption.do_context ~poly:(only_polymorphism atts) sup
+
 let vernac_existing_instance ~atts insts =
   let locality = Attributes.parse Classes.instance_locality atts in
   List.iter (fun (id, info) -> Classes.existing_instance locality id (Some info)) insts
@@ -2444,7 +2447,7 @@ let translate_vernac ?loc ~atts v = let open Vernacextend in match v with
   | VernacDeclareInstance (id, bl, inst, info) ->
     vtdefault(fun () -> vernac_declare_instance ~atts id bl inst info)
   | VernacContext sup ->
-    vtdefault(fun () -> ComAssumption.do_context ~poly:(only_polymorphism atts) sup)
+    vtdefault(fun () -> vernac_context ~atts sup)
   | VernacExistingInstance insts ->
     vtdefault(fun () -> vernac_existing_instance ~atts insts)
   | VernacExistingClass id ->


### PR DESCRIPTION
**Kind:** bug fix 

Fixes / closes #9412

This is a quick fix (which will have to be adapted on top of #12272).

- [X] Added / updated test-suite
- [X] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
