### PR TITLE
Optimised generation of fresh names.

### DIFF
--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -268,7 +268,7 @@ val empty_csubst : csubst
 val csubst_subst : csubst -> constr -> constr
 
 type ext_named_context =
-  csubst * Id.Set.t * named_context
+  csubst * Id.AvoidSet.t * named_context
 
 val push_rel_decl_to_named_context : ?hypnaming:naming_mode ->
   evar_map -> rel_declaration -> ext_named_context -> ext_named_context

--- a/engine/namegen.ml
+++ b/engine/namegen.ml
@@ -314,8 +314,8 @@ let next_name_away_in_cases_pattern sigma env_t na avoid =
      name is taken by finding a free subscript starting from 0 *)
 
 let next_ident_away_in_goal id avoid =
-  let id = if Id.Set.mem id avoid then restart_subscript id else id in
-  let bad id = Id.Set.mem id avoid || (is_global id && not (is_section_variable id)) in
+  let id = if  avoid id then restart_subscript id else id in
+  let bad id = avoid id || (is_global id && not (is_section_variable id)) in
   next_ident_away_from id bad
 
 let next_name_away_in_goal na avoid =
@@ -422,7 +422,7 @@ type renaming_flags =
 let next_name_for_display sigma flags =
   match flags with
   | RenamingForCasesPattern env_t -> next_name_away_in_cases_pattern sigma env_t
-  | RenamingForGoal -> next_name_away_in_goal
+  | RenamingForGoal -> fun id avoid -> next_name_away_in_goal id (fun id -> Id.Set.mem id avoid)
   | RenamingElsewhereFor env_t -> next_name_away_for_default_printing sigma env_t
 
 (* Remark: Anonymous var may be dependent in Evar's contexts *)

--- a/engine/namegen.mli
+++ b/engine/namegen.mli
@@ -65,7 +65,7 @@ val it_mkLambda_or_LetIn_name : env -> evar_map -> constr -> rel_context -> cons
    Fresh names *)
 
 (** Avoid clashing with a name satisfying some predicate *)
-val next_ident_away_from : Id.t -> (Id.t -> bool) -> Id.t
+val next_ident_away_from : Id.t -> Id.AvoidSet.t -> Id.t
 
 (** [next_ident_away original_id unwanted_ids] returns a new identifier as close as possible
     to the [original_id] while avoiding all [unwanted_ids].
@@ -83,22 +83,22 @@ val next_ident_away_from : Id.t -> (Id.t -> bool) -> Id.t
     the whole identifier except for the {i subscript}.
 
     E.g. if we take [foo42], then [42] is the {i subscript}, and [foo] is the root. *)
-val next_ident_away : Id.t -> Id.Set.t -> Id.t
+val next_ident_away : Id.t -> Id.AvoidSet.t -> Id.t
 
 (** Avoid clashing with a name already used in current module *)
-val next_ident_away_in_goal : Id.t -> (Id.t -> bool) -> Id.t
+val next_ident_away_in_goal : Id.t -> Id.AvoidSet.t -> Id.t
 
 (** Avoid clashing with a name already used in current module
    but tolerate overwriting section variables, as in goals *)
-val next_global_ident_away : Id.t -> Id.Set.t -> Id.t
+val next_global_ident_away : Id.t -> Id.AvoidSet.t -> Id.t
 
 (** Default is [default_non_dependent_ident] *)
-val next_name_away  : Name.t -> Id.Set.t -> Id.t
+val next_name_away  : Name.t -> Id.AvoidSet.t -> Id.t
 
-val next_name_away_with_default : string -> Name.t -> Id.Set.t -> Id.t
+val next_name_away_with_default : string -> Name.t -> Id.AvoidSet.t -> Id.t
 
 val next_name_away_with_default_using_types : string -> Name.t ->
-  Id.Set.t -> types -> Id.t
+                                              Id.AvoidSet.t -> types -> Id.t
 
 val set_reserved_typed_name : (types -> Name.t) -> unit
 
@@ -113,15 +113,15 @@ type renaming_flags =
 val make_all_name_different : env -> evar_map -> env
 
 val compute_displayed_name_in :
-  evar_map -> renaming_flags -> Id.Set.t -> Name.t -> constr -> Name.t * Id.Set.t
+  evar_map -> renaming_flags -> Id.AvoidSet.t -> Name.t -> constr -> Name.t * Id.AvoidSet.t
 val compute_and_force_displayed_name_in :
-  evar_map -> renaming_flags -> Id.Set.t -> Name.t -> constr -> Name.t * Id.Set.t
+  evar_map -> renaming_flags -> Id.AvoidSet.t -> Name.t -> constr -> Name.t * Id.AvoidSet.t
 val compute_displayed_let_name_in :
-  evar_map -> renaming_flags -> Id.Set.t -> Name.t -> 'a -> Name.t * Id.Set.t
+  evar_map -> renaming_flags -> Id.AvoidSet.t -> Name.t -> 'a -> Name.t * Id.AvoidSet.t
 val rename_bound_vars_as_displayed :
-  evar_map -> Id.Set.t -> Name.t list -> types -> types
+  evar_map -> Id.AvoidSet.t -> Name.t list -> types -> types
 
 (* Generic function expecting a "not occurn" function *)
 val compute_displayed_name_in_gen :
   (evar_map -> int -> 'a -> bool) ->
-  evar_map -> Id.Set.t -> Name.t -> 'a -> Name.t * Id.Set.t
+  evar_map -> Id.AvoidSet.t -> Name.t -> 'a -> Name.t * Id.AvoidSet.t

--- a/engine/namegen.mli
+++ b/engine/namegen.mli
@@ -86,7 +86,7 @@ val next_ident_away_from : Id.t -> (Id.t -> bool) -> Id.t
 val next_ident_away : Id.t -> Id.Set.t -> Id.t
 
 (** Avoid clashing with a name already used in current module *)
-val next_ident_away_in_goal : Id.t -> Id.Set.t -> Id.t
+val next_ident_away_in_goal : Id.t -> (Id.t -> bool) -> Id.t
 
 (** Avoid clashing with a name already used in current module
    but tolerate overwriting section variables, as in goals *)

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -1308,7 +1308,7 @@ let rec glob_of_pat avoid env sigma pat = DAst.make @@ match pat with
        Array.fold_left
          (fun (avoid, env, l) na ->
            let id = Namegen.next_name_away na avoid in
-           (Id.Set.add id avoid, Name id :: env, id::l))
+           (Id.AvoidSet.add id avoid, Name id :: env, id::l))
       (avoid, env, []) lna in
      let n = Array.length tl in
      let v = Array.map3
@@ -1323,7 +1323,7 @@ let rec glob_of_pat avoid env sigma pat = DAst.make @@ match pat with
        Array.fold_left
          (fun (avoid, env, l) na ->
            let id = Namegen.next_name_away na avoid in
-           (Id.Set.add id avoid, Name id :: env, id::l))
+           (Id.AvoidSet.add id avoid, Name id :: env, id::l))
          (avoid, env, []) lna in
      let ntys = Array.length tl in
      let v = Array.map2
@@ -1341,7 +1341,7 @@ let rec glob_of_pat avoid env sigma pat = DAst.make @@ match pat with
   | PFloat f -> GFloat f
 
 let extern_constr_pattern env sigma pat =
-  extern true (InConstrEntrySomeLevel,(None,[])) Id.Set.empty (glob_of_pat Id.Set.empty env sigma pat)
+  extern true (InConstrEntrySomeLevel,(None,[])) Id.Set.empty (glob_of_pat Id.AvoidSet.empty env sigma pat)
 
 let extern_rel_context where env sigma sign =
   let a = detype_rel_context Detyping.Later where Id.Set.empty (names_of_rel_context env,env) sigma sign in

--- a/interp/impargs.ml
+++ b/interp/impargs.ml
@@ -243,7 +243,7 @@ let compute_implicits_names_gen all env sigma t =
        let na',avoid' = find_displayed_name_in sigma all avoid na.Context.binder_name (names,b) in
        aux (push_rel (LocalAssum (na,a)) env) avoid' (na'::names) b
     | _ -> List.rev names
-  in aux env Id.Set.empty [] t
+  in aux env Id.AvoidSet.empty [] t
 
 let compute_implicits_names = compute_implicits_names_gen true
 

--- a/interp/notation_ops.ml
+++ b/interp/notation_ops.ml
@@ -1214,7 +1214,7 @@ let rec match_ inner u alp metas sigma a1 a2 =
   | _b1, NLambda (Name id as na,(NHole _ | NVar _ as t2),b2) when inner ->
       let avoid =
         Id.Set.union (free_glob_vars a1) (* as in Namegen: *) (glob_visible_short_qualid a1) in
-      let id' = Namegen.next_ident_away id avoid in
+      let id' = Namegen.next_ident_away id (Id.AvoidSet.of_set avoid) in
       let t1 = DAst.make @@ GHole(Evar_kinds.BinderType (Name id'),IntroAnonymous,None) in
       let sigma = match t2 with
       | NHole _ -> sigma

--- a/kernel/environ.ml
+++ b/kernel/environ.ml
@@ -30,6 +30,7 @@ open Vars
 open Declarations
 open Context.Rel.Declaration
 
+module RelDecl = Context.Rel.Declaration
 module NamedDecl = Context.Named.Declaration
 
 (* The type of environments. *)
@@ -319,11 +320,26 @@ let fold_rel_context f env ~init =
         f env rd (fold_right env)
   in fold_right env
 
+
+let mem_var env =
+  let s =  (named_context_val env).env_named_map in
+  if List.is_empty (rel_context env) then (fun id -> Id.Map.mem id s)
+  else
+    let s' =    Context.Rel.fold_inside
+    (fun s decl  -> match RelDecl.get_name decl with Name id -> Id.Set.add id s | _ -> s)
+    (rel_context env) ~init:Id.Set.empty
+    in
+    fun id -> Id.Map.mem id s || Id.Set.mem id s'
+
+
+
 (* Named context *)
 
 let named_context_of_val c = c.env_named_ctx
 
 let ids_of_named_context_val c = Id.Map.domain c.env_named_map
+
+let mem_var_val id c = Id.Map.mem id c.env_named_map
 
 let empty_named_context = Context.Named.empty
 

--- a/kernel/environ.mli
+++ b/kernel/environ.mli
@@ -145,7 +145,11 @@ val named_context_of_val : named_context_val -> Constr.named_context
 val val_of_named_context : Constr.named_context -> named_context_val
 val empty_named_context_val : named_context_val
 val ids_of_named_context_val : named_context_val -> Id.Set.t
+val mem_var_val : Id.t -> named_context_val -> bool
 
+(** [mem_var e] pre-computes a predicate [p] such that [p id] holds
+    if [id] is either in the [rel_context] or in the [named_context_val]. *)
+val mem_var : env -> (Id.t -> bool)
 
 (** [map_named_val f ctxt] apply [f] to the body and the type of
    each declarations.

--- a/kernel/names.ml
+++ b/kernel/names.ml
@@ -68,6 +68,9 @@ struct
   end
 
   module Set = Set.Make(Self)
+
+  module AvoidSet = AvoidSet.Make(Set)
+
   module Map = CMap.Make(Self)
 
   module Pred = Predicate.Make(Self)

--- a/kernel/names.mli
+++ b/kernel/names.mli
@@ -62,6 +62,9 @@ sig
   module Set : Set.S with type elt = t
   (** Finite sets of identifiers. *)
 
+  module AvoidSet : AvoidSet.S with type elt = t and type set = Set.t
+  (** Sets of identifiers that can be built and queried *)
+
   module Map : Map.ExtS with type key = t and module Set := Set
   (** Finite maps of identifiers. *)
 

--- a/lib/avoidSet.ml
+++ b/lib/avoidSet.ml
@@ -1,0 +1,86 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *   INRIA, CNRS and contributors - Copyright 1999-2019       *)
+(* <O___,, *       (see CREDITS file for the list of authors)           *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+module type Set =
+  sig
+    type elt
+    type t
+
+    val empty : t
+    val add   : elt -> t -> t
+    val singleton : elt -> t
+    val union : t -> t -> t
+    val mem   : elt -> t -> bool
+  end
+
+module type S =
+  sig
+    type elt
+    type set
+    type t
+    val empty : t
+    val singleton : elt -> t
+    val of_pred : (elt -> bool) -> t
+    val of_set : set -> t
+    val add : elt -> t -> t
+    val union : t -> t -> t
+    val mem : elt -> t -> bool
+  end
+
+module Make(S : Set) =
+  struct
+    type elt = S.elt
+    type set = S.t
+
+    type t =
+      {
+        pred : elt -> bool;
+        set  : S.t;
+      }
+
+    let of_pred p =
+      {
+        pred = p;
+        set  = S.empty
+      }
+
+    let of_set s =
+      {
+        pred = (fun _ -> false);
+        set  = s
+      }
+
+    let singleton id =
+      {
+        pred = (fun _ -> false);
+        set  = S.singleton id
+      }
+
+
+    let union {pred=p1; set = s1}
+          {pred=p2; set = s2} =
+      {pred = (fun id -> p1 id || p2 id);
+       set  = S.union s1 s2
+      }
+
+
+    let add e {pred ; set} =
+      {
+        pred = pred;
+        set  = S.add e set
+      }
+
+    let empty = {pred = (fun _ -> false) ; set = S.empty}
+
+
+    let mem id {pred ; set} =
+      pred id || S.mem id set
+
+end

--- a/lib/avoidSet.mli
+++ b/lib/avoidSet.mli
@@ -1,0 +1,38 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *   INRIA, CNRS and contributors - Copyright 1999-2019       *)
+(* <O___,, *       (see CREDITS file for the list of authors)           *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+module type Set =
+  sig
+    type elt
+    type t
+
+    val empty : t
+    val add   : elt -> t -> t
+    val singleton : elt -> t
+    val union : t -> t -> t
+    val mem   : elt -> t -> bool
+  end
+
+module type S =
+  sig
+    type elt
+    type set
+    type t
+    val empty : t
+    val singleton : elt -> t
+    val of_pred : (elt -> bool) -> t
+    val of_set : set -> t
+    val add : elt -> t -> t
+    val union : t -> t -> t
+    val mem : elt -> t -> bool
+  end
+
+
+module Make(S : Set) : (S with type elt = S.elt and type set = S.t)

--- a/lib/lib.mllib
+++ b/lib/lib.mllib
@@ -1,3 +1,4 @@
+AvoidSet
 Hook
 Flags
 Control

--- a/plugins/cc/ccalgo.ml
+++ b/plugins/cc/ccalgo.ml
@@ -801,8 +801,8 @@ let one_step state =
 let __eps__ = Id.of_string "_eps_"
 
 let new_state_var typ state =
-  let ids = Environ.ids_of_named_context_val (Environ.named_context_val state.env) in
-  let id = Namegen.next_ident_away __eps__ ids in
+  let avoid id = Environ.mem_var_val id (Environ.named_context_val state.env) in
+  let id = Namegen.next_ident_away __eps__ (Id.AvoidSet.of_pred avoid) in
   let r = Sorts.Relevant in (* TODO relevance *)
   state.env<- EConstr.push_named (Context.Named.Declaration.LocalAssum (make_annot id r,typ)) state.env;
   id

--- a/plugins/extraction/common.ml
+++ b/plugins/extraction/common.ml
@@ -401,7 +401,7 @@ let ref_renaming_fun (k,r) =
     match l with
     | [""] -> (* this happens only at toplevel of the monolithic case *)
       let globs = get_global_ids () in
-      let id = next_ident_away (kindcase_id k idg) globs in
+      let id = next_ident_away (kindcase_id k idg) (Id.AvoidSet.of_set globs) in
       Id.to_string id
     | _ -> modular_rename k idg
   in

--- a/plugins/extraction/extraction.ml
+++ b/plugins/extraction/extraction.ml
@@ -176,7 +176,7 @@ let make_typvar n vl =
     if not (String.contains s '\'') && Unicode.is_basic_ascii s then id
     else id_of_name Anonymous
   in
-  let vl = Id.Set.of_list vl in
+  let vl = Id.AvoidSet.of_set (Id.Set.of_list vl) in
   next_ident_away id' vl
 
 let rec type_sign_vl env sg c =

--- a/plugins/extraction/table.ml
+++ b/plugins/extraction/table.ml
@@ -751,7 +751,7 @@ let string_of_modfile mp =
   try MPmap.find mp !modfile_mps
   with Not_found ->
     let id = Id.of_string (raw_string_of_modfile mp) in
-    let id' = next_ident_away id !modfile_ids in
+    let id' = next_ident_away id (Id.AvoidSet.of_set !modfile_ids) in
     let s' = Id.to_string id' in
     modfile_ids := Id.Set.add id' !modfile_ids;
     modfile_mps := MPmap.add mp s' !modfile_mps;

--- a/plugins/firstorder/instances.ml
+++ b/plugins/firstorder/instances.ml
@@ -116,8 +116,8 @@ let mk_open_instance env evmap id idc m t =
       let nid=(fresh_id_in_env avoid var_id env) in
       let (evmap, (c, _)) = Evarutil.new_type_evar env evmap Evd.univ_flexible in
       let decl = LocalAssum (Context.make_annot (Name nid) Sorts.Relevant, c) in
-        aux (n-1) (Id.Set.add nid avoid) (EConstr.push_rel decl env) evmap (decl::decls) in
-  let evmap, decls = aux m Id.Set.empty env evmap [] in
+        aux (n-1) (Id.AvoidSet.add nid avoid) (EConstr.push_rel decl env) evmap (decl::decls) in
+  let evmap, decls = aux m Id.AvoidSet.empty env evmap [] in
   (evmap, decls, revt)
 
 (* tactics   *)

--- a/plugins/funind/functional_principles_proofs.ml
+++ b/plugins/funind/functional_principles_proofs.ml
@@ -1541,11 +1541,12 @@ let prove_principle_for_gen
 (*   in *)
   let tcc_list = ref [] in
   let start_tac gls =
-    let hyps = pf_ids_of_hyps gls in
-      let hid =
+    let hyps =  pf_ids_of_hyps gls in
+    let shyps = Id.Set.of_list hyps in
+    let hid =
         next_ident_away_in_goal
           (Id.of_string "prov")
-          (Id.Set.of_list hyps)
+          (fun id -> Id.Set.mem id shyps)
       in
       tclTHENLIST
         [

--- a/plugins/funind/functional_principles_proofs.ml
+++ b/plugins/funind/functional_principles_proofs.ml
@@ -517,7 +517,7 @@ let treat_new_case ptes_infos nb_prod continue_tac term dyn_infos =
     tclTHENLIST
       [
         (* We first introduce the variables *)
-        tclDO nb_first_intro (Proofview.V82.of_tactic (intro_avoiding (Id.Set.of_list dyn_infos.rec_hyps)));
+        tclDO nb_first_intro (Proofview.V82.of_tactic (intro_avoiding (Id.AvoidSet.of_set (Id.Set.of_list dyn_infos.rec_hyps))));
         (* Then the equation itself *)
         Proofview.V82.of_tactic (intro_using heq_id);
         onLastHypId (fun heq_id -> tclTHENLIST [
@@ -1542,11 +1542,10 @@ let prove_principle_for_gen
   let tcc_list = ref [] in
   let start_tac gls =
     let hyps =  pf_ids_of_hyps gls in
-    let shyps = Id.Set.of_list hyps in
+    let shyps = Id.AvoidSet.of_pred (pf_mem_ids_of_hyps gls) in
     let hid =
         next_ident_away_in_goal
-          (Id.of_string "prov")
-          (fun id -> Id.Set.mem id shyps)
+          (Id.of_string "prov") shyps
       in
       tclTHENLIST
         [

--- a/plugins/funind/functional_principles_types.ml
+++ b/plugins/funind/functional_principles_types.ml
@@ -48,7 +48,7 @@ let compute_new_princ_type_from_rel rel_to_fun sorts princ_type =
     | decl :: predicates ->
        (match Context.Rel.Declaration.get_name decl with
         | Name x ->
-           let id = Namegen.next_ident_away x (Id.Set.of_list avoid) in
+           let id = Namegen.next_ident_away x (Id.AvoidSet.of_set (Id.Set.of_list avoid)) in
            Hashtbl.add tbl id x;
            RelDecl.set_name (Name id) decl :: change_predicates_names (id::avoid) predicates
         | Anonymous -> anomaly (Pp.str "Anonymous property binder."))

--- a/plugins/funind/gen_principle.ml
+++ b/plugins/funind/gen_principle.ml
@@ -177,7 +177,7 @@ let build_functional_principle ?(opaque=Proof_global.Transparent) (evd:Evd.evar_
   (*    let time2 = System.get_time ()  in *)
   (*    Pp.msgnl (str "computing principle type := " ++ System.fmt_time_difference time1 time2); *)
   let new_princ_name =
-    Namegen.next_ident_away_in_goal (Id.of_string "___________princ_________") (fun id -> false)
+    Namegen.next_ident_away_in_goal (Id.of_string "___________princ_________") Id.AvoidSet.empty
   in
   let sigma, _ = Typing.type_of ~refresh:true (Global.env ()) !evd (EConstr.of_constr new_principle_type) in
   evd := sigma;
@@ -460,10 +460,10 @@ let generate_type evd g_to_f f graph i =
     | Name id -> Some id
     | Anonymous -> None
   in
-  let named_ctxt = Id.Set.of_list (List.map_filter filter fun_ctxt) in
-  let res_id = Namegen.next_ident_away_in_goal (Id.of_string "_res") (fun id -> Id.Set.mem id named_ctxt) in
-  let avoid_id = Id.Set.add res_id named_ctxt in
-  let fv_id = Namegen.next_ident_away_in_goal (Id.of_string "fv") (fun id -> Id.Set.mem id avoid_id) in
+  let named_ctxt = Id.AvoidSet.of_set (Id.Set.of_list (List.map_filter filter fun_ctxt)) in
+  let res_id = Namegen.next_ident_away_in_goal (Id.of_string "_res") named_ctxt in
+  let avoid_id = Id.AvoidSet.add res_id named_ctxt in
+  let fv_id = Namegen.next_ident_away_in_goal (Id.of_string "fv")  avoid_id in
   (*i we can then type the argument to be applied to the function [f] i*)
   let args_as_rels = Array.of_list (args_from_decl 1 [] fun_ctxt) in
   (*i
@@ -543,8 +543,8 @@ let rec generate_fresh_id x avoid i =
   if i == 0
   then []
   else
-    let sid = Id.Set.of_list avoid in
-    let id = Namegen.next_ident_away_in_goal x (fun id -> Id.Set.mem id sid) in
+    let sid = Id.AvoidSet.of_set (Id.Set.of_list avoid) in
+    let id = Namegen.next_ident_away_in_goal x  sid in
     id::(generate_fresh_id x (id::avoid) (pred i))
 
 let prove_fun_correct evd funs_constr graphs_constr schemes lemmas_types_infos i : Tacmach.tactic =
@@ -575,8 +575,8 @@ let prove_fun_correct evd funs_constr graphs_constr schemes lemmas_types_infos i
        environment and due to the bug #1174, we will need to pose the principle
        using a name
     *)
-    let sids = Id.Set.of_list ids in
-    let principle_id = Namegen.next_ident_away_in_goal (Id.of_string "princ") (fun id -> Id.Set.mem id sids) in
+    let sids = Id.AvoidSet.of_set (Id.Set.of_list ids) in
+    let principle_id = Namegen.next_ident_away_in_goal (Id.of_string "princ") sids in
     let ids = principle_id :: ids in
     (* We get the branches of the principle *)
     let branches = List.rev princ_infos.Tactics.branches in
@@ -732,7 +732,7 @@ let prove_fun_correct evd funs_constr graphs_constr schemes lemmas_types_infos i
       let params_bindings,avoid =
         List.fold_left2
           (fun (bindings,avoid) decl p ->
-             let id = Namegen.next_ident_away (Nameops.Name.get_id (RelDecl.get_name decl)) (Id.Set.of_list avoid) in
+             let id = Namegen.next_ident_away (Nameops.Name.get_id (RelDecl.get_name decl)) (Id.AvoidSet.of_set (Id.Set.of_list avoid)) in
              p::bindings,id::avoid
           )
           ([],pf_ids_of_hyps g)
@@ -742,7 +742,7 @@ let prove_fun_correct evd funs_constr graphs_constr schemes lemmas_types_infos i
       let lemmas_bindings =
         List.rev (fst  (List.fold_left2
                           (fun (bindings,avoid) decl p ->
-                             let id = Namegen.next_ident_away (Nameops.Name.get_id (RelDecl.get_name decl)) (Id.Set.of_list avoid) in
+                             let id = Namegen.next_ident_away (Nameops.Name.get_id (RelDecl.get_name decl)) (Id.AvoidSet.of_set (Id.Set.of_list avoid)) in
                              (Reductionops.nf_zeta (pf_env g) (project g) p)::bindings,id::avoid)
                           ([],avoid)
                           princ_infos.predicates

--- a/plugins/funind/glob_term_to_relation.ml
+++ b/plugins/funind/glob_term_to_relation.ml
@@ -152,7 +152,7 @@ let apply_args ctxt body args =
   let next_name_away (na:Name.t) (mapping: Id.t Id.Map.t) (avoid: Id.Set.t) =
     match na with
        | Name id when Id.Set.mem id avoid ->
-           let new_id = Namegen.next_ident_away id avoid in
+           let new_id = Namegen.next_ident_away id (Id.AvoidSet.of_set avoid) in
            Name new_id,Id.Map.add id new_id mapping,Id.Set.add new_id avoid
        | _ -> na,mapping,avoid
   in
@@ -182,7 +182,7 @@ let apply_args ctxt body args =
             if need_convert_id avoid id
             then
               let new_avoid =  Id.Set.add id avoid in
-              let new_id = Namegen.next_ident_away id new_avoid in
+              let new_id = Namegen.next_ident_away id (Id.AvoidSet.of_set new_avoid) in
               let new_avoid' = Id.Set.add new_id new_avoid in
               let mapping = Id.Map.add id new_id Id.Map.empty in
               let new_ctxt' = change_vars_in_binder mapping ctxt' in
@@ -556,7 +556,7 @@ let rec build_entry_lc env sigma funnames avoid rt : glob_constr build_entry_ret
                   match n with
                     | Name id when List.exists (is_free_in id) args ->
                         (* need to alpha-convert the name *)
-                        let new_id = Namegen.next_ident_away id (Id.Set.of_list avoid) in
+                        let new_id = Namegen.next_ident_away id (Id.AvoidSet.of_set (Id.Set.of_list avoid)) in
                         let new_avoid = id:: avoid in
                         let new_b =
                           replace_var_by_term

--- a/plugins/funind/glob_termops.ml
+++ b/plugins/funind/glob_termops.ml
@@ -139,7 +139,7 @@ let rec alpha_pat excluded pat =
     | PatVar(Name id) ->
         if Id.List.mem id excluded
         then
-          let new_id = Namegen.next_ident_away id (Id.Set.of_list excluded) in
+          let new_id = Namegen.next_ident_away id (Id.AvoidSet.of_set (Id.Set.of_list excluded)) in
           (DAst.make ?loc @@ PatVar(Name new_id)),(new_id::excluded),
         (Id.Map.add id new_id Id.Map.empty)
         else pat, excluded,Id.Map.empty
@@ -147,7 +147,7 @@ let rec alpha_pat excluded pat =
         let new_na,new_excluded,map =
           match na with
             | Name id when Id.List.mem id excluded ->
-                let new_id = Namegen.next_ident_away id (Id.Set.of_list excluded) in
+                let new_id = Namegen.next_ident_away id (Id.AvoidSet.of_set (Id.Set.of_list excluded)) in
                 Name new_id,new_id::excluded, Id.Map.add id new_id Id.Map.empty
             | _ -> na,excluded,Id.Map.empty
         in
@@ -202,7 +202,7 @@ let rec alpha_rt excluded rt =
     match DAst.get rt with
       | GRef _ | GVar _ | GEvar _ | GPatVar _ as rt -> rt
       | GLambda(Anonymous,k,t,b) ->
-          let new_id = Namegen.next_ident_away (Id.of_string "_x") (Id.Set.of_list excluded) in
+          let new_id = Namegen.next_ident_away (Id.of_string "_x") (Id.AvoidSet.of_set (Id.Set.of_list excluded)) in
           let new_excluded = new_id :: excluded in
           let new_t = alpha_rt new_excluded t in
           let new_b = alpha_rt new_excluded b in
@@ -217,7 +217,7 @@ let rec alpha_rt excluded rt =
         let new_c = alpha_rt excluded c in
         GLetIn(Anonymous,new_b,new_t,new_c)
     | GLambda(Name id,k,t,b) ->
-        let new_id = Namegen.next_ident_away id (Id.Set.of_list excluded) in
+        let new_id = Namegen.next_ident_away id (Id.AvoidSet.of_set (Id.Set.of_list excluded)) in
         let t,b =
           if Id.equal new_id id
           then t, b
@@ -230,7 +230,7 @@ let rec alpha_rt excluded rt =
         let new_b = alpha_rt new_excluded b in
         GLambda(Name new_id,k,new_t,new_b)
     | GProd(Name id,k,t,b) ->
-        let new_id = Namegen.next_ident_away id (Id.Set.of_list excluded) in
+        let new_id = Namegen.next_ident_away id (Id.AvoidSet.of_set (Id.Set.of_list excluded)) in
         let new_excluded = new_id::excluded in
         let t,b =
           if Id.equal new_id id
@@ -243,7 +243,7 @@ let rec alpha_rt excluded rt =
         let new_b = alpha_rt new_excluded b in
         GProd(Name new_id,k,new_t,new_b)
     | GLetIn(Name id,b,t,c) ->
-        let new_id = Namegen.next_ident_away id (Id.Set.of_list excluded) in
+        let new_id = Namegen.next_ident_away id (Id.AvoidSet.of_set (Id.Set.of_list excluded)) in
         let c =
           if Id.equal new_id id then c
           else change_vars (Id.Map.add id new_id Id.Map.empty) c
@@ -261,7 +261,7 @@ let rec alpha_rt excluded rt =
                match na with
                  | Anonymous -> (na::nal,excluded,mapping)
                  | Name id ->
-                     let new_id = Namegen.next_ident_away id (Id.Set.of_list excluded) in
+                     let new_id = Namegen.next_ident_away id (Id.AvoidSet.of_set (Id.Set.of_list excluded)) in
                      if Id.equal new_id id
                      then
                        na::nal,id::excluded,mapping

--- a/plugins/funind/indfun_common.ml
+++ b/plugins/funind/indfun_common.ml
@@ -10,7 +10,9 @@ let mk_correct_id id = Nameops.add_suffix (mk_rel_id id) "_correct"
 let mk_complete_id id = Nameops.add_suffix (mk_rel_id id) "_complete"
 let mk_equation_id id = Nameops.add_suffix id "_equation"
 
-let fresh_id avoid s = Namegen.next_ident_away_in_goal (Id.of_string s) (Id.Set.of_list avoid)
+let fresh_id avoid s =
+  let savoid = Id.Set.of_list avoid in
+  Namegen.next_ident_away_in_goal (Id.of_string s) (fun id -> Id.Set.mem id savoid)
 
 let fresh_name avoid s = Name (fresh_id avoid s)
 

--- a/plugins/funind/indfun_common.ml
+++ b/plugins/funind/indfun_common.ml
@@ -11,8 +11,8 @@ let mk_complete_id id = Nameops.add_suffix (mk_rel_id id) "_complete"
 let mk_equation_id id = Nameops.add_suffix id "_equation"
 
 let fresh_id avoid s =
-  let savoid = Id.Set.of_list avoid in
-  Namegen.next_ident_away_in_goal (Id.of_string s) (fun id -> Id.Set.mem id savoid)
+  let savoid = Id.AvoidSet.of_set (Id.Set.of_list avoid) in
+  Namegen.next_ident_away_in_goal (Id.of_string s) savoid
 
 let fresh_name avoid s = Name (fresh_id avoid s)
 

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -108,7 +108,8 @@ let pf_get_new_ids idl g =
     []
 
 let next_ident_away_in_goal ids avoid =
-  next_ident_away_in_goal ids (Id.Set.of_list avoid)
+  let savoid = Id.Set.of_list avoid in
+  next_ident_away_in_goal ids (fun id -> Id.Set.mem id savoid)
 
 let compute_renamed_type gls c =
   rename_bound_vars_as_displayed (project gls) (*no avoid*) Id.Set.empty (*no rels*) []

--- a/plugins/ltac/evar_tactics.ml
+++ b/plugins/ltac/evar_tactics.ml
@@ -92,7 +92,7 @@ let let_evar name typ =
     let id = match name with
     | Name.Anonymous ->
       let id = Namegen.id_of_name_using_hdchar env sigma typ name in
-      Namegen.next_ident_away_in_goal id (Environ.mem_var env)
+      Namegen.next_ident_away_in_goal id (Id.AvoidSet.of_pred (Environ.mem_var env))
     | Name.Name id -> id
     in
     let (sigma, evar) = Evarutil.new_evar env sigma ~src ~naming:(Namegen.IntroFresh id) typ in

--- a/plugins/ltac/evar_tactics.ml
+++ b/plugins/ltac/evar_tactics.ml
@@ -92,7 +92,7 @@ let let_evar name typ =
     let id = match name with
     | Name.Anonymous ->
       let id = Namegen.id_of_name_using_hdchar env sigma typ name in
-      Namegen.next_ident_away_in_goal id (Termops.vars_of_env env)
+      Namegen.next_ident_away_in_goal id (Environ.mem_var env)
     | Name.Name id -> id
     in
     let (sigma, evar) = Evarutil.new_evar env sigma ~src ~naming:(Namegen.IntroFresh id) typ in

--- a/plugins/ltac/extratactics.mlg
+++ b/plugins/ltac/extratactics.mlg
@@ -760,7 +760,7 @@ let case_eq_intros_rewrite x =
       mkCaseEq x;
     Proofview.Goal.enter begin fun gl ->
       let concl = Proofview.Goal.concl gl in
-      let hyps = Tacmach.New.pf_ids_set_of_hyps gl in
+      let hyps = Id.AvoidSet.of_pred (Tacmach.New.pf_mem_ids_of_hyps gl) in
       let n' = nb_prod (Tacmach.New.project gl) concl in
       let h = fresh_id_in_env hyps (Id.of_string "heq") (Proofview.Goal.env gl)  in
       Tacticals.New.tclTHENLIST [

--- a/plugins/ltac/pptactic.ml
+++ b/plugins/ltac/pptactic.ml
@@ -717,7 +717,7 @@ let pr_goal_selector ~toplevel s =
               (fun ln na -> match na with { CAst.v=Name id } -> Id.Set.add id ln | _ -> ln)
               ln nal)
             Id.Set.empty bll in
-        let idarg,bll = set_nth_name names n bll in
+        let idarg,bll = set_nth_name (Id.AvoidSet.of_set names) n bll in
         let annot =
           if Int.equal (Id.Set.cardinal names) 1 then
             mt ()

--- a/plugins/ltac/rewrite.ml
+++ b/plugins/ltac/rewrite.ml
@@ -676,7 +676,7 @@ type rewrite_result =
 
 type 'a strategy_input = { state : 'a ; (* a parameter: for instance, a state *)
                            env : Environ.env ;
-                           unfresh : Id.Set.t; (* Unfresh names *)
+                           unfresh : Id.AvoidSet.t; (* Unfresh names *)
                            term1 : constr ;
                            ty1 : types ; (* first term and its type (convertible to rew_from) *)
                            cstr : (bool (* prop *) * constr option) ;
@@ -1628,7 +1628,7 @@ let cl_rewrite_clause_newtac ?abs ?origsigma ~progress strat clause =
     in
     try
       let res =
-        cl_rewrite_clause_aux ?abs strat env Id.Set.empty sigma ty clause
+        cl_rewrite_clause_aux ?abs strat env Id.AvoidSet.empty sigma ty clause
       in
       let sigma = match origsigma with None -> sigma | Some sigma -> sigma in
       treat sigma res <*>

--- a/plugins/ltac/rewrite.mli
+++ b/plugins/ltac/rewrite.mli
@@ -134,7 +134,7 @@ val setoid_transitivity : constr option -> unit Proofview.tactic
 val apply_strategy :
   strategy ->
   Environ.env ->
-  Names.Id.Set.t ->
+  Id.AvoidSet.t ->
   constr ->
   bool * constr ->
   evars -> rewrite_result

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -466,7 +466,7 @@ let interp_fresh_id ist env sigma l =
   | None -> Id.Set.empty
   | Some l -> l
   in
-  let avoid = extract_ids ids ist.lfun avoid in
+  let avoid = Id.AvoidSet.of_set (extract_ids ids ist.lfun avoid) in
   let id =
     if List.is_empty l then default_fresh_id
     else

--- a/plugins/micromega/coq_micromega.ml
+++ b/plugins/micromega/coq_micromega.ml
@@ -1865,7 +1865,7 @@ let micromega_gen parse_arith pre_process cnf spec dumpexpr prover tac =
           let intro_props = Tacticals.New.tclTHENLIST (List.map intro props) in
           (*       let ipat_of_name id = Some (CAst.make @@ IntroNaming (Namegen.IntroIdentifier id)) in*)
           let goal_name =
-            fresh_id Id.Set.empty (Names.Id.of_string "__arith") gl
+            fresh_id Id.AvoidSet.empty (Names.Id.of_string "__arith") gl
           in
           let env' = List.map (fun (id, i) -> (EConstr.mkVar id, i)) vars in
           let tac_arith =
@@ -2000,7 +2000,7 @@ let micromega_genr prover tac =
             Some (CAst.make @@ IntroNaming (Namegen.IntroIdentifier id))
           in
           let goal_name =
-            fresh_id Id.Set.empty (Names.Id.of_string "__arith") gl
+            fresh_id Id.AvoidSet.empty (Names.Id.of_string "__arith") gl
           in
           let env' = List.map (fun (id, i) -> (EConstr.mkVar id, i)) vars in
           let tac_arith =

--- a/plugins/micromega/zify.ml
+++ b/plugins/micromega/zify.ml
@@ -574,7 +574,7 @@ module CstrTable = struct
               if has_hyp types then Tacticals.New.tclIDTAC
               else
                 let n =
-                  Tactics.fresh_id_in_env Id.Set.empty
+                  Tactics.fresh_id_in_env Id.AvoidSet.empty
                     (Names.Id.of_string "cstr")
                     env
                 in
@@ -907,9 +907,9 @@ let trans_hyp h t =
       Proofview.Goal.enter (fun gl ->
           let env = Tacmach.New.pf_env gl in
           let n =
-            fresh_id_in_env Id.Set.empty (Names.Id.of_string "__zify") env
+            fresh_id_in_env Id.AvoidSet.empty (Names.Id.of_string "__zify") env
           in
-          let h' = fresh_id_in_env Id.Set.empty h env in
+          let h' = fresh_id_in_env Id.AvoidSet.empty h env in
           tclTHENLIST
             [ letin_tac None (Names.Name n) t None
                 Locus.{onhyps = None; concl_occs = NoOccurrences}
@@ -1050,7 +1050,7 @@ let sat_constr c d =
           match (find_hyp evd h1 hyps, find_hyp evd h2 hyps) with
           | Some h1, Some h2 ->
             let n =
-              Tactics.fresh_id_in_env Id.Set.empty
+              Tactics.fresh_id_in_env Id.AvoidSet.empty
                 (Names.Id.of_string "__sat")
                 env
             in

--- a/plugins/omega/coq_omega.ml
+++ b/plugins/omega/coq_omega.ml
@@ -1698,7 +1698,7 @@ let onClearedName id tac =
   tclTHEN
     (tclTRY (clear [id]))
     (Proofview.Goal.enter begin fun gl ->
-     let id = fresh_id Id.Set.empty id gl in
+     let id = fresh_id Id.AvoidSet.empty id gl in
      tclTHEN (introduction id) (tac id)
     end)
 
@@ -1706,8 +1706,8 @@ let onClearedName2 id tac =
   tclTHEN
     (tclTRY (clear [id]))
     (Proofview.Goal.enter begin fun gl ->
-     let id1 = fresh_id Id.Set.empty (add_suffix id "_left") gl in
-     let id2 = fresh_id Id.Set.empty (add_suffix id "_right") gl in
+     let id1 = fresh_id Id.AvoidSet.empty (add_suffix id "_left") gl in
+     let id2 = fresh_id Id.AvoidSet.empty (add_suffix id "_right") gl in
       tclTHENLIST [ introduction id1; introduction id2; tac id1 id2 ]
     end)
 
@@ -1725,7 +1725,7 @@ let destructure_hyps =
          try
            match destructurate_type env sigma typ with
            | Kapp(Nat,_) | Kapp(Z,_) ->
-              let hid = fresh_id Id.Set.empty (add_suffix i.binder_name "_eqn") gl in
+              let hid = fresh_id Id.AvoidSet.empty (add_suffix i.binder_name "_eqn") gl in
               let hty = mk_gen_eq typ (mkVar i.binder_name) body in
               tclTHEN
                 (assert_by (Name hid) hty reflexivity)

--- a/pretyping/cases.mli
+++ b/pretyping/cases.mli
@@ -51,16 +51,16 @@ val constr_of_pat :
            Evd.evar_map ->
            rel_context ->
            Glob_term.cases_pattern ->
-           Names.Id.Set.t ->
+           Id.AvoidSet.t ->
            Evd.evar_map * Glob_term.cases_pattern *
            (rel_context * constr *
             (types * constr list) * Glob_term.cases_pattern) *
-           Names.Id.Set.t
+             Id.AvoidSet.t
 
 type 'a rhs =
     { rhs_env    : GlobEnv.t;
       rhs_vars   : Id.Set.t;
-      avoid_ids  : Id.Set.t;
+      avoid_ids  : Id.AvoidSet.t;
       it         : 'a option}
 
 type 'a equation =

--- a/pretyping/coercion.ml
+++ b/pretyping/coercion.ml
@@ -205,7 +205,7 @@ let coerce ?loc env evdref (x : EConstr.constr) (y : EConstr.constr)
             {name' with
              binder_name =
                Name (Namegen.next_ident_away
-                       Namegen.default_dependent_ident (Termops.vars_of_env env))}
+                       Namegen.default_dependent_ident (Id.AvoidSet.of_pred (Environ.mem_var env)))}
           in
           let env' = push_rel (LocalAssum (name', a')) env in
           let c1 = coerce_unify env' (lift 1 a') (lift 1 a) in

--- a/pretyping/detyping.mli
+++ b/pretyping/detyping.mli
@@ -56,9 +56,9 @@ val detype_rel_context : 'a delay -> ?lax:bool -> constr option -> Id.Set.t -> (
   evar_map -> rel_context -> 'a glob_decl_g list
 
 val share_pattern_names :
-  (Id.Set.t -> names_context -> 'c -> Pattern.constr_pattern -> 'a) -> int ->
+  (Id.AvoidSet.t -> names_context -> 'c -> Pattern.constr_pattern -> 'a) -> int ->
   (Name.t * binding_kind * 'b option * 'a) list ->
-  Id.Set.t -> names_context -> 'c -> Pattern.constr_pattern ->
+  Id.AvoidSet.t -> names_context -> 'c -> Pattern.constr_pattern ->
   Pattern.constr_pattern ->
   (Name.t * binding_kind * 'b option * 'a) list * 'a * 'a
 

--- a/pretyping/evardefine.ml
+++ b/pretyping/evardefine.ml
@@ -77,7 +77,7 @@ let define_pure_evar_as_product env evd evk =
   let open Context.Named.Declaration in
   let evi = Evd.find_undefined evd evk in
   let evenv = evar_env env evi in
-  let id = next_ident_away idx (Environ.ids_of_named_context_val evi.evar_hyps) in
+  let id = next_ident_away idx (Id.AvoidSet.of_pred (fun id -> Environ.mem_var_val id evi.evar_hyps)) in
   let concl = Reductionops.whd_all evenv evd evi.evar_concl in
   let s = destSort evd concl in
   let evksrc = evar_source evk evd in
@@ -135,9 +135,9 @@ let define_pure_evar_as_lambda env evd evk =
   | Prod (na,dom,rng) -> (evd,(na,dom,rng))
   | Evar ev' -> let evd,typ = define_evar_as_product env evd ev' in evd,destProd evd typ
   | _ -> error_not_product env evd typ in
-  let avoid = Environ.ids_of_named_context_val evi.evar_hyps in
+  let avoid id = Environ.mem_var_val id evi.evar_hyps in
   let id =
-    map_annot (fun na -> next_name_away_with_default_using_types "x" na avoid
+    map_annot (fun na -> next_name_away_with_default_using_types "x" na (Id.AvoidSet.of_pred avoid)
       (Reductionops.whd_evar evd dom)) na
   in
   let newenv = push_named (LocalAssum (id, dom)) evenv in

--- a/pretyping/evarsolve.ml
+++ b/pretyping/evarsolve.ml
@@ -722,13 +722,13 @@ let materialize_evar define_fun env evd k (evk1,args1) ty_in_env =
   let filter1 = evar_filter evi1 in
   let src = subterm_source evk1 evi1.evar_source in
   let ids1 = List.map get_id (named_context_of_val sign1) in
-  let avoid = Environ.ids_of_named_context_val sign1 in
+  let avoid id = Environ.mem_var_val id sign1 in
   let inst_in_sign = List.map mkVar (Filter.filter_list filter1 ids1) in
   let open Context.Rel.Declaration in
   let (sign2,filter2,inst2_in_env,inst2_in_sign,_,evd,_) =
     List.fold_right (fun d (sign,filter,inst_in_env,inst_in_sign,env,evd,avoid) ->
       let LocalAssum (na,t_in_env) | LocalDef (na,_,t_in_env) = d in
-      let id = map_annot (fun na -> next_name_away na avoid) na in
+      let id = map_annot (fun na -> next_name_away na  avoid) na in
       let evd,t_in_sign =
         let s = Retyping.get_sort_of env evd t_in_env in
         let evd,ty_t_in_sign = refresh_universes
@@ -744,9 +744,9 @@ let materialize_evar define_fun env evd k (evk1,args1) ty_in_env =
       (push_named_context_val d' sign, Filter.extend 1 filter,
        (mkRel 1)::(List.map (lift 1) inst_in_env),
        (mkRel 1)::(List.map (lift 1) inst_in_sign),
-       push_rel d env,evd,Id.Set.add id.binder_name avoid))
+       push_rel d env,evd,Id.AvoidSet.add id.binder_name avoid))
       rel_sign
-      (sign1,filter1,Array.to_list args1,inst_in_sign,env1,evd,avoid)
+      (sign1,filter1,Array.to_list args1,inst_in_sign,env1,evd,Id.AvoidSet.of_pred avoid)
   in
   let evd,ev2ty_in_sign =
     let s = Retyping.get_sort_of env evd ty_in_env in

--- a/pretyping/globEnv.ml
+++ b/pretyping/globEnv.ml
@@ -40,9 +40,9 @@ type t = {
 
 let make ~hypnaming env sigma lvar =
   let get_extra env sigma =
-    let avoid = Environ.ids_of_named_context_val (Environ.named_context_val env) in
+    let avoid id = Environ.mem_var_val id (Environ.named_context_val env) in
     Context.Rel.fold_outside (fun d acc -> push_rel_decl_to_named_context ~hypnaming sigma d acc)
-      (rel_context env) ~init:(empty_csubst, avoid, named_context env) in
+      (rel_context env) ~init:(empty_csubst, Id.AvoidSet.of_pred avoid, named_context env) in
   {
     static_env = env;
     renamed_env = env;
@@ -54,6 +54,12 @@ let env env = env.static_env
 
 let vars_of_env env =
   Id.Set.union (Id.Map.domain env.lvar.ltac_genargs) (vars_of_env env.static_env)
+
+let mem_var env =
+  let mem_var_env = Environ.mem_var env.static_env in
+  (fun id -> Id.Map.mem id env.lvar.ltac_genargs || mem_var_env id)
+
+
 
 let ltac_interp_id { ltac_idents ; ltac_genargs } id =
   try Id.Map.find id ltac_idents

--- a/pretyping/globEnv.mli
+++ b/pretyping/globEnv.mli
@@ -46,6 +46,8 @@ val env : t -> env
 
 val vars_of_env : t -> Id.Set.t
 
+val mem_var : t -> (Id.t -> bool)
+
 (** Push to the environment, returning the declaration(s) with interpreted names *)
 
 val push_rel : hypnaming:naming_mode -> evar_map -> rel_declaration -> t -> rel_declaration * t

--- a/pretyping/glob_ops.ml
+++ b/pretyping/glob_ops.ml
@@ -417,12 +417,12 @@ let test_id l id = if collide_id l id then raise UnsoundRenaming
 let test_na l na = Name.iter (test_id l) na
 
 let update_subst na l =
-  let in_range id l = List.exists (fun (_,id') -> Id.equal id id') l in
+  let in_range l id = List.exists (fun (_,id') -> Id.equal id id') l in
   let l' = Name.fold_right Id.List.remove_assoc na l in
   Name.fold_right
     (fun id _ ->
-     if in_range id l' then
-       let id' = Namegen.next_ident_away_from id (fun id' -> in_range id' l') in
+     if in_range l' id then
+       let id' = Namegen.next_ident_away_from id (Id.AvoidSet.of_pred (in_range l')) in
        Name id', (id,id')::l
      else na,l)
     na (na,l)

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -1655,7 +1655,7 @@ let make_abstraction_core name (test,out) env sigma c ty occs check_occs concl =
   let id =
     let t = match ty with Some t -> t | None -> get_type_of env sigma c in
     let x = id_of_name_using_hdchar env sigma t name in
-    let ids = Environ.ids_of_named_context_val (named_context_val env) in
+    let ids = fun id -> Environ.mem_var_val id (named_context_val env) in
     if name == Anonymous then next_ident_away_in_goal x ids else
     if mem_named_context_val x (named_context_val env) then
       user_err ~hdr:"Unification.make_abstraction_core"

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -1656,7 +1656,7 @@ let make_abstraction_core name (test,out) env sigma c ty occs check_occs concl =
     let t = match ty with Some t -> t | None -> get_type_of env sigma c in
     let x = id_of_name_using_hdchar env sigma t name in
     let ids = fun id -> Environ.mem_var_val id (named_context_val env) in
-    if name == Anonymous then next_ident_away_in_goal x ids else
+    if name == Anonymous then next_ident_away_in_goal x (Id.AvoidSet.of_pred ids) else
     if mem_named_context_val x (named_context_val env) then
       user_err ~hdr:"Unification.make_abstraction_core"
         (str "The variable " ++ Id.print x ++ str " is already declared.")

--- a/printing/printmod.ml
+++ b/printing/printmod.ml
@@ -65,7 +65,7 @@ let get_new_id locals id =
       if not (Nametab.exists_dir dir) then
         id
       else
-        get_id (Id.Set.add id l) (Namegen.next_ident_away id l)
+        get_id (Id.Set.add id l) (Namegen.next_ident_away id (Id.AvoidSet.of_set l))
   in
   let avoid = List.fold_left (fun accu (_, id) -> Id.Set.add id accu) Id.Set.empty locals in
     get_id avoid id
@@ -271,7 +271,7 @@ let nametab_register_modparam ~mod_ops mbid mtb =
       (* Otherwise, we try to play with the nametab ourselves *)
       let mp = MPbound mbid in
       let check id = Nametab.exists_dir (DirPath.make [id]) in
-      let id = Namegen.next_ident_away_from id check in
+      let id = Namegen.next_ident_away_from id (Id.AvoidSet.of_pred check) in
       let dir = DirPath.make [id] in
       nametab_register_dir mp;
       List.iter (nametab_register_body mp dir) struc;

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -555,7 +555,7 @@ let make_clenv_binding_gen hyps_only n env sigma (c,t) = function
       let clause = mk_clenv_from_env env sigma n (c,t) in
       clenv_constrain_dep_args hyps_only largs clause
   | ExplicitBindings lbind ->
-      let t = rename_bound_vars_as_displayed sigma Id.Set.empty [] t in
+      let t = rename_bound_vars_as_displayed sigma Id.AvoidSet.empty [] t in
       let clause = mk_clenv_from_env env sigma n
         (c, t)
       in clenv_match_args lbind clause
@@ -603,7 +603,7 @@ let make_evar_clause env sigma ?len t =
   | Some n -> assert (0 <= n); n
   in
   (* FIXME: do the renaming online *)
-  let t = rename_bound_vars_as_displayed sigma Id.Set.empty [] t in
+  let t = rename_bound_vars_as_displayed sigma Id.AvoidSet.empty [] t in
   let rec clrec (sigma, holes) inst n t =
     if n = 0 then (sigma, holes, t)
     else match EConstr.kind sigma t with

--- a/proofs/tacmach.mli
+++ b/proofs/tacmach.mli
@@ -33,6 +33,7 @@ val pf_hyps_types         : Goal.goal sigma -> (Id.t Context.binder_annot * type
 val pf_nth_hyp_id         : Goal.goal sigma -> int -> Id.t
 val pf_last_hyp           : Goal.goal sigma -> named_declaration
 val pf_ids_of_hyps        : Goal.goal sigma -> Id.t list
+val pf_mem_ids_of_hyps    : Goal.goal sigma -> Id.t -> bool
 val pf_unsafe_type_of     : Goal.goal sigma -> constr -> types
 val pf_type_of            : Goal.goal sigma -> constr -> evar_map * types
 val pf_hnf_type_of        : Goal.goal sigma -> constr -> types
@@ -96,6 +97,7 @@ module New : sig
   val pf_get_new_id  : Id.t -> Proofview.Goal.t -> Id.t
   val pf_ids_of_hyps : Proofview.Goal.t -> Id.t list
   val pf_ids_set_of_hyps : Proofview.Goal.t -> Id.Set.t
+  val pf_mem_ids_of_hyps : Proofview.Goal.t -> Id.t -> bool
   val pf_hyps_types : Proofview.Goal.t -> (Id.t * types) list
 
   val pf_get_hyp : Id.t -> Proofview.Goal.t -> named_declaration

--- a/tactics/abstract.ml
+++ b/tactics/abstract.ml
@@ -71,7 +71,7 @@ let cache_term_by_tactic_then ~opaque ~name_op ?(goal_type=None) tac tacK =
         then (s1,push_named_context_val d s2)
         else (Context.Named.add d s1,s2))
       global_sign (Context.Named.empty, Environ.empty_named_context_val) in
-  let name = Namegen.next_global_ident_away name (pf_ids_set_of_hyps gl) in
+  let name = Namegen.next_global_ident_away name (Names.Id.AvoidSet.of_pred (pf_mem_ids_of_hyps gl)) in
   let concl = match goal_type with
               | None ->  Proofview.Goal.concl gl
               | Some ty -> ty in

--- a/tactics/eqdecide.ml
+++ b/tactics/eqdecide.ml
@@ -74,7 +74,7 @@ let generalize_right mk typ c1 c2 =
   Proofview.Goal.enter begin fun gl ->
     let env = Proofview.Goal.env gl in
   Refine.refine ~typecheck:false begin fun sigma ->
-    let na = Name (next_name_away_with_default "x" Anonymous (Termops.vars_of_env env)) in
+    let na = Name (next_name_away_with_default "x" Anonymous (Id.AvoidSet.of_pred (Environ.mem_var env))) in
     let r = Retyping.relevance_of_type env sigma typ in
     let newconcl = mkProd (make_annot na r, typ, mk typ c1 (mkRel 1)) in
     let (sigma, x) = Evarutil.new_evar env sigma ~principal:true newconcl in
@@ -122,7 +122,7 @@ let idx = Id.of_string "x"
 let idy = Id.of_string "y"
 
 let mkGenDecideEqGoal rectype ops g =
-  let hypnames = pf_ids_set_of_hyps g in
+  let hypnames = Id.AvoidSet.of_pred (pf_mem_ids_of_hyps g) in
   let xname    = next_ident_away idx hypnames
   and yname    = next_ident_away idy hypnames in
   (mkNamedProd (make_annot xname Sorts.Relevant) rectype

--- a/tactics/eqschemes.ml
+++ b/tactics/eqschemes.ml
@@ -68,7 +68,7 @@ module RelDecl = Context.Rel.Declaration
 let hid = Id.of_string "H"
 let xid = Id.of_string "X"
 let default_id_of_sort = function InSProp | InProp | InSet -> hid | InType -> xid
-let fresh env id = next_global_ident_away id Id.Set.empty
+let fresh env id = next_global_ident_away id Id.AvoidSet.empty
 let with_context_set ctx (b, ctx') =
   (b, Univ.ContextSet.union ctx ctx')
 

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -1032,7 +1032,7 @@ let discr_positions env sigma (lbeq,eqn,(t,t1,t2)) eq_clause cpath dirn =
   build_coq_False () >>= fun false_0 ->
   let false_ty = Retyping.get_type_of env sigma false_0 in
   let false_kind = Retyping.get_sort_family_of env sigma false_0 in
-  let e = next_ident_away eq_baseid (vars_of_env env) in
+  let e = next_ident_away eq_baseid (Id.AvoidSet.of_pred (Environ.mem_var env)) in
   let e_env = push_named (Context.Named.Declaration.LocalAssum (make_annot e Sorts.Relevant,t)) env in
   let discriminator =
     try
@@ -1391,7 +1391,7 @@ let simplify_args env sigma t =
     | _ -> t
 
 let inject_at_positions env sigma l2r (eq,_,(t,t1,t2)) eq_clause posns tac =
-  let e = next_ident_away eq_baseid (vars_of_env env) in
+  let e = next_ident_away eq_baseid (Id.AvoidSet.of_pred (Environ.mem_var env)) in
   let e_env = push_named (LocalAssum (make_annot e Sorts.Relevant,t)) env in
   let evdref = ref sigma in
   let filter (cpath, t1', t2') =

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -1283,7 +1283,7 @@ let prepare_hint check env init (sigma,c) =
   let rec iter c =
     try find_next_evar c; c
     with Found (evar,t) ->
-      let id = next_ident_away_from default_prepare_hint_ident (fun id -> Id.Set.mem id !vars) in
+      let id = next_ident_away_from default_prepare_hint_ident  (Id.AvoidSet.of_set !vars) in
       vars := Id.Set.add id !vars;
       subst := (evar,mkVar id)::!subst;
       mkNamedLambda (make_annot id Sorts.Relevant) t (iter (replace_term sigma evar (mkVar id) c)) in

--- a/tactics/ind_tables.ml
+++ b/tactics/ind_tables.ml
@@ -83,7 +83,7 @@ let is_visible_name id =
 
 let compute_name internal id =
   if internal then
-    Namegen.next_ident_away_from (add_prefix "internal_" id) is_visible_name
+    Namegen.next_ident_away_from (add_prefix "internal_" id) (Id.AvoidSet.of_pred is_visible_name)
   else id
 
 let define internal role id c poly univs =

--- a/tactics/inv.ml
+++ b/tactics/inv.ml
@@ -411,7 +411,7 @@ let rewrite_equations as_mode othin neqns names ba =
   Proofview.Goal.enter begin fun gl ->
   let (depids,nodepids) = split_dep_and_nodep ba.Tacticals.assums gl in
   let first_eq = ref Logic.MoveLast in
-  let avoid = if as_mode then Id.Set.of_list (List.map NamedDecl.get_id nodepids) else Id.Set.empty in
+  let avoid = Id.AvoidSet.of_set (if as_mode then Id.Set.of_list (List.map NamedDecl.get_id nodepids) else Id.Set.empty) in
   match othin with
     | Some thin ->
         tclTHENLIST

--- a/tactics/leminv.ml
+++ b/tactics/leminv.ml
@@ -142,7 +142,7 @@ let rec add_prods_sign env sigma t =
 
 let compute_first_inversion_scheme env sigma ind sort dep_option =
   let indf,realargs = dest_ind_type ind in
-  let allvars = vars_of_env env in
+  let allvars = Id.AvoidSet.of_pred (Environ.mem_var env) in
   let p = next_ident_away (Id.of_string "P") allvars in
   let pty,goal =
     if dep_option  then
@@ -212,7 +212,7 @@ let inversion_scheme ~name ~poly env sigma t sort dep_option inv_op =
          else Context.Named.add d sign)
       invEnv ~init:Context.Named.empty
   end in
-  let avoid = ref Id.Set.empty in
+  let avoid = ref Id.AvoidSet.empty in
   let Proof.{sigma} = Proof.data pf in
   let sigma = Evd.minimize_universes sigma in
   let rec fill_holes c =
@@ -220,7 +220,7 @@ let inversion_scheme ~name ~poly env sigma t sort dep_option inv_op =
     | Evar (e,args) ->
         let h = next_ident_away (Id.of_string "H") !avoid in
         let ty,inst = Evarutil.generalize_evar_over_rels sigma (e,args) in
-        avoid := Id.Set.add h !avoid;
+        avoid := Id.AvoidSet.add h !avoid;
         ownSign := Context.Named.add (LocalAssum (make_annot h Sorts.Relevant,ty)) !ownSign;
         applist (mkVar h, inst)
     | _ -> EConstr.map sigma fill_holes c

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -344,9 +344,9 @@ let rename_hyp repl =
 (**************************************************************)
 
 let fresh_id_in_env avoid id env =
-  let avoid' = ids_of_named_context_val (named_context_val env) in
-  let avoid = if Id.Set.is_empty avoid then avoid' else Id.Set.union avoid' avoid in
+  let avoid id = Id.Set.mem id avoid || mem_var_val id (named_context_val env) in
   next_ident_away_in_goal id avoid
+
 
 let fresh_id avoid id gl =
   fresh_id_in_env avoid id (pf_env gl)
@@ -2751,7 +2751,7 @@ let pose_tac na c =
       id
     | Anonymous ->
       let id = id_of_name_using_hdchar env sigma t Anonymous in
-      next_ident_away_in_goal id (ids_of_named_context_val hyps)
+      next_ident_away_in_goal id (fun id -> mem_var_val id hyps)
     in
     Proofview.Unsafe.tclEVARS sigma <*>
     Refine.refine ~typecheck:false begin fun sigma ->

--- a/tactics/tactics.mli
+++ b/tactics/tactics.mli
@@ -50,18 +50,18 @@ val convert_leq     : constr -> constr -> unit Proofview.tactic
 
 (** {6 Introduction tactics. } *)
 
-val fresh_id_in_env : Id.Set.t -> Id.t -> env -> Id.t
-val fresh_id : Id.Set.t -> Id.t -> Goal.goal sigma -> Id.t
+val fresh_id_in_env : Id.AvoidSet.t -> Id.t -> env -> Id.t
+val fresh_id : Id.AvoidSet.t -> Id.t -> Goal.goal sigma -> Id.t
 val find_intro_names : rel_context -> Goal.goal sigma -> Id.t list
 
 val intro                : unit Proofview.tactic
 val introf               : unit Proofview.tactic
 val intro_move        : Id.t option -> Id.t Logic.move_location -> unit Proofview.tactic
-val intro_move_avoid  : Id.t option -> Id.Set.t -> Id.t Logic.move_location -> unit Proofview.tactic
+val intro_move_avoid  : Id.t option -> Id.AvoidSet.t -> Id.t Logic.move_location -> unit Proofview.tactic
 
   (** [intro_avoiding idl] acts as intro but prevents the new Id.t
      to belong to [idl] *)
-val intro_avoiding       : Id.Set.t -> unit Proofview.tactic
+val intro_avoiding       : Id.AvoidSet.t -> unit Proofview.tactic
 
 val intro_replacing      : Id.t -> unit Proofview.tactic
 val intro_using          : Id.t -> unit Proofview.tactic

--- a/user-contrib/Ltac2/tac2core.ml
+++ b/user-contrib/Ltac2/tac2core.ml
@@ -910,7 +910,7 @@ let () = define1 "fresh_free_of_constr" constr begin fun c ->
 end
 
 let () = define2 "fresh_fresh" (repr_ext val_free) ident begin fun avoid id ->
-  let nid = Namegen.next_ident_away_from id (fun id -> Id.Set.mem id avoid) in
+  let nid = Namegen.next_ident_away_from id  (Id.AvoidSet.of_set avoid) in
   return (Value.of_ident nid)
 end
 

--- a/user-contrib/Ltac2/tac2entries.ml
+++ b/user-contrib/Ltac2/tac2entries.ml
@@ -279,7 +279,7 @@ let fresh_var avoid x =
     Id.Set.mem id avoid ||
     (try ignore (Tac2env.locate_ltac (qualid_of_ident id)); true with Not_found -> false)
   in
-  Namegen.next_ident_away_from (Id.of_string x) bad
+  Namegen.next_ident_away_from (Id.of_string x) (Id.AvoidSet.of_pred bad)
 
 let extract_pattern_type ({loc;v=p} as pat) = match p with
 | CPatCnv (pat, ty) -> pat, Some ty

--- a/user-contrib/Ltac2/tac2intern.ml
+++ b/user-contrib/Ltac2/tac2intern.ml
@@ -596,7 +596,7 @@ let fresh_var avoid =
     Id.Set.mem id avoid ||
     (try ignore (locate_ltac (qualid_of_ident id)); true with Not_found -> false)
   in
-  Namegen.next_ident_away_from (Id.of_string "p") bad
+  Namegen.next_ident_away_from (Id.of_string "p") (Id.AvoidSet.of_pred bad)
 
 let add_name accu = function
 | Name id -> Id.Set.add id accu

--- a/vernac/auto_ind_decl.ml
+++ b/vernac/auto_ind_decl.ml
@@ -561,7 +561,7 @@ open Namegen
 let compute_bl_goal ind lnamesparrec nparrec =
   let eqI, eff = eqI ind lnamesparrec in
   let list_id = list_id lnamesparrec in
-  let avoid = List.fold_right (Nameops.Name.fold_right (fun id l -> Id.Set.add id l)) (List.map RelDecl.get_name lnamesparrec) Id.Set.empty in
+  let avoid = Id.AvoidSet.of_set (List.fold_right (Nameops.Name.fold_right (fun id l -> Id.Set.add id l)) (List.map RelDecl.get_name lnamesparrec) Id.Set.empty) in
   let create_input c =
     let x = next_ident_away (Id.of_string "x") avoid and
         y = next_ident_away (Id.of_string "y") avoid in
@@ -611,7 +611,7 @@ let compute_bl_tact mode bl_scheme_key ind lnamesparrec nparrec =
         ( List.map (fun (_,_,sbl,_ ) -> sbl) list_id )
       in
       let fresh_id s gl =
-          let fresh = fresh_id_in_env (Id.Set.of_list !avoid) s (Proofview.Goal.env gl) in
+          let fresh = fresh_id_in_env (Id.AvoidSet.of_set (Id.Set.of_list !avoid)) s (Proofview.Goal.env gl) in
           avoid := fresh::(!avoid); fresh
       in
       Proofview.Goal.enter begin fun gl ->
@@ -709,7 +709,7 @@ let _ = bl_scheme_kind_aux := fun () -> bl_scheme_kind
 let compute_lb_goal ind lnamesparrec nparrec =
   let list_id = list_id lnamesparrec in
   let eq = eq () and tt = tt () and bb = bb () in
-  let avoid = List.fold_right (Nameops.Name.fold_right (fun id l -> Id.Set.add id l)) (List.map RelDecl.get_name lnamesparrec) Id.Set.empty in
+  let avoid = Id.AvoidSet.of_set (List.fold_right (Nameops.Name.fold_right (fun id l -> Id.Set.add id l)) (List.map RelDecl.get_name lnamesparrec) Id.Set.empty) in
   let eqI, eff = eqI ind lnamesparrec in
     let create_input c =
       let x = next_ident_away (Id.of_string "x") avoid and
@@ -761,7 +761,7 @@ let compute_lb_tact mode lb_scheme_key ind lnamesparrec nparrec =
         ( List.map (fun (_,_,_,slb) -> slb) list_id )
       in
       let fresh_id s gl =
-          let fresh = fresh_id_in_env (Id.Set.of_list !avoid) s (Proofview.Goal.env gl) in
+          let fresh = fresh_id_in_env (Id.AvoidSet.of_set (Id.Set.of_list !avoid)) s (Proofview.Goal.env gl) in
           avoid := fresh::(!avoid); fresh
       in
       Proofview.Goal.enter begin fun gl ->
@@ -845,7 +845,7 @@ let compute_dec_goal ind lnamesparrec nparrec =
   check_not_is_defined ();
   let eq = eq () and tt = tt () and bb = bb () in
   let list_id = list_id lnamesparrec in
-  let avoid = List.fold_right (Nameops.Name.fold_right (fun id l -> Id.Set.add id l)) (List.map RelDecl.get_name lnamesparrec) Id.Set.empty in
+  let avoid = Id.AvoidSet.of_set (List.fold_right (Nameops.Name.fold_right (fun id l -> Id.Set.add id l)) (List.map RelDecl.get_name lnamesparrec) Id.Set.empty) in
     let create_input c =
       let x = next_ident_away (Id.of_string "x") avoid and
           y = next_ident_away (Id.of_string "y") avoid in
@@ -915,7 +915,7 @@ let compute_dec_tact ind lnamesparrec nparrec =
       ( List.map (fun (_,_,_,slb) -> slb) list_id )
   in
   let fresh_id s gl =
-      let fresh = fresh_id_in_env (Id.Set.of_list !avoid) s (Proofview.Goal.env gl) in
+      let fresh = fresh_id_in_env (Id.AvoidSet.of_set (Id.Set.of_list !avoid)) s (Proofview.Goal.env gl) in
       avoid := fresh::(!avoid); fresh
   in
   Proofview.Goal.enter begin fun gl ->

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -548,7 +548,7 @@ let new_instance_common ~program_mode ~generalize env instid ctx cl =
     | Name id -> id
     | Anonymous ->
       let i = Nameops.add_suffix (id_of_class k) "_instance_0" in
-      Namegen.next_global_ident_away i (Termops.vars_of_env env)
+      Namegen.next_global_ident_away i (Id.AvoidSet.of_pred (Environ.mem_var env))
   in
   let env' = push_rel_context ctx env in
   id, env', sigma, k, u, cty, ctx', ctx, imps, subst, decl

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -589,8 +589,8 @@ let make_cases ind =
          | RelDecl.LocalDef _ :: l -> "_" :: rename avoid l
          | RelDecl.LocalAssum (n, _)::l ->
            let n' = Namegen.next_name_away_with_default (Id.to_string Namegen.default_dependent_ident) n.Context.binder_name avoid in
-           Id.to_string n' :: rename (Id.Set.add n' avoid) l in
-       let al' = rename Id.Set.empty al in
+           Id.to_string n' :: rename (Id.AvoidSet.add n' avoid) l in
+       let al' = rename Id.AvoidSet.empty al in
        let consref = GlobRef.ConstructRef (ith_constructor_of_inductive ind (i + 1)) in
        (Libnames.string_of_qualid (Nametab.shortest_qualid_of_global Id.Set.empty consref) :: al') :: l)
     mip.mind_nf_lc []

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -1552,7 +1552,7 @@ let inject_var x = CAst.make @@ CRef (qualid_of_ident x,None)
 let add_infix ~local deprecation env ({CAst.loc;v=inf},modifiers) pr sc =
   check_infix_modifiers modifiers;
   (* check the precedence *)
-  let vars = names_of_constr_expr pr in
+  let vars = Id.AvoidSet.of_set (names_of_constr_expr pr) in
   let x = Namegen.next_ident_away (Id.of_string "x") vars in
   let y = Namegen.next_ident_away (Id.of_string "y") vars in
   let metas = [inject_var x; inject_var y] in

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -506,7 +506,7 @@ let declare_class def cumulative ubinders univs id idbuild paramimpls params uni
     let impls = implicits_of_context params in
       List.map (fun x -> impls @ x) fieldimpls
   in
-  let binder_name = Namegen.next_ident_away id (Termops.vars_of_env (Global.env())) in
+  let binder_name = Namegen.next_ident_away id (Id.AvoidSet.of_pred (Environ.mem_var (Global.env()))) in
   let data =
     match fields with
     | [LocalAssum ({binder_name=Name proj_name} as binder, field)

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -537,7 +537,7 @@ let vernac_definition_hook ~canonical_instance ~local ~poly = let open Decls in 
 | _ -> None
 
 let fresh_name_for_anonymous_theorem () =
-  Namegen.next_global_ident_away Lemmas.default_thm_id Id.Set.empty
+  Namegen.next_global_ident_away Lemmas.default_thm_id Id.AvoidSet.empty
 
 let vernac_definition_name lid local =
   let lid =


### PR DESCRIPTION
The current `Tactics.fresh_id_in_env` calls
`ids_of_named_context_val : ids_of_named_context_val : named_context_val -> Id.Set.t`
which is a linear operation.

Instead, we pass the predicate
`val ids_of_named_context_val_mem : named_context_val -> Id.t -> bool`
which checks whether an identifier is within the map.

The rest of the modifications are consequences of the API change.

In Termpops, we still explicitly constructs an intermediate Id.Set.t in
`vars_of_env(_mem)` for the `rel_context` but replace
`Context.Rel.fold_outside` by `Context.Rel.fold_inside`.

**Kind:** performance 