### PR TITLE
Fix issue #11396 : Rlist hides standard list constructors cons and nil

### DIFF
--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -97,8 +97,11 @@
 ########################################################################
 # Coquelicot
 ########################################################################
-: "${coquelicot_CI_REF:=master}"
-: "${coquelicot_CI_GITURL:=https://gitlab.inria.fr/coquelicot/coquelicot}"
+# Modified until https://gitlab.inria.fr/coquelicot/coquelicot/merge_requests/2 is merged
+: "${coquelicot_CI_REF:=fix-rlist-import}"
+: "${coquelicot_CI_GITURL:=https://gitlab.inria.fr/pedrot/coquelicot}"
+# : "${coquelicot_CI_REF:=master}"
+# : "${coquelicot_CI_GITURL:=https://gitlab.inria.fr/coquelicot/coquelicot}"
 : "${coquelicot_CI_ARCHIVEURL:=${coquelicot_CI_GITURL}/-/archive}"
 
 ########################################################################

--- a/doc/changelog/10-standard-library/11396-issue_11396_Rlist.rst
+++ b/doc/changelog/10-standard-library/11396-issue_11396_Rlist.rst
@@ -1,0 +1,4 @@
+- **Removed:**
+  Export of module ``RList`` in ``Ranalysis.v`` and ``Ranalysis_reg.v``. Module ``RList`` is still there but must be imported explicitly where required.
+  (`#11396 <https://github.com/coq/coq/pull/11396>`_,
+  by Michael Soegtrop).

--- a/theories/Reals/Ranalysis.v
+++ b/theories/Reals/Ranalysis.v
@@ -24,7 +24,6 @@ Require Export Rsqrt_def.
 Require Export R_sqrt.
 Require Export Rtrigo_calc.
 Require Export Rgeom.
-Require Export RList.
 Require Export Sqrt_reg.
 Require Export Ranalysis4.
 Require Export Rpower.

--- a/theories/Reals/Ranalysis_reg.v
+++ b/theories/Reals/Ranalysis_reg.v
@@ -24,7 +24,6 @@ Require Export Rsqrt_def.
 Require Export R_sqrt.
 Require Export Rtrigo_calc.
 Require Export Rgeom.
-Require Export RList.
 Require Export Sqrt_reg.
 Require Export Ranalysis4.
 Require Export Rpower.

--- a/theories/Reals/RiemannInt.v
+++ b/theories/Reals/RiemannInt.v
@@ -15,6 +15,7 @@ Require Import Ranalysis_reg.
 Require Import Rbase.
 Require Import RiemannInt_SF.
 Require Import Max.
+Require Import RList.
 Local Open Scope R_scope.
 
 Set Implicit Arguments.

--- a/theories/Reals/RiemannInt_SF.v
+++ b/theories/Reals/RiemannInt_SF.v
@@ -12,6 +12,7 @@ Require Import Rbase.
 Require Import Rfunctions.
 Require Import Ranalysis_reg.
 Require Import Classical_Prop.
+Require Import RList.
 Local Open Scope R_scope.
 
 Set Implicit Arguments.


### PR DESCRIPTION
This PR fixes the hiding of the standard list cons and nil constructors by Rlist cons and nil when Reals is imported. This is done by not exporting Rlist from Reals and instead importing it (in the two places) where it is needed as suggested by @ppedrot.

Fixes #11396