### PR TITLE
[nix] Dune-2 and other improvements

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -42,7 +42,6 @@ stdenv.mkDerivation rec {
   buildInputs = [
     hostname
     python3 time # coq-makefile timing tools
-    dune
   ]
   ++ (with ocamlPackages; [ ocaml findlib num ])
   ++ optionals buildIde [
@@ -67,6 +66,7 @@ stdenv.mkDerivation rec {
     [ jq curl gitFull gnupg ] # Dependencies of the merging script
     ++ (with ocamlPackages; [ merlin ocp-indent ocp-index utop ocamlformat ]) # Dev tools
     ++ [ graphviz ] # Useful for STM debugging
+    ++ [ dune_2 ] # Maybe the next build system
   );
 
   src =

--- a/default.nix
+++ b/default.nix
@@ -111,7 +111,7 @@ stdenv.mkDerivation rec {
   setupHook = writeText "setupHook.sh" "
     addCoqPath () {
       if test -d \"$1/lib/coq/${coq-version}/user-contrib\"; then
-        export COQPATH=\"$COQPATH\${COQPATH:+:}$1/lib/coq/${coq-version}/user-contrib/\"
+        export COQPATH=\"\${COQPATH-}\${COQPATH:+:}$1/lib/coq/${coq-version}/user-contrib/\"
       fi
     }
 

--- a/dev/ci/nix/default.nix
+++ b/dev/ci/nix/default.nix
@@ -60,9 +60,23 @@ let iris = (coqPackages.iris.override { inherit coq stdpp; })
 
 let unicoq = callPackage ./unicoq { inherit coq; }; in
 
+let StructTact = coqPackages.StructTact.overrideAttrs (o: {
+    src = fetchTarball "https://github.com/uwplse/StructTact/tarball/master";
+  }); in
+
+let Cheerios = (coqPackages.Cheerios.override { inherit StructTact; })
+  .overrideAttrs (o: {
+    src = fetchTarball "https://github.com/uwplse/cheerios/tarball/master";
+  }); in
+
+let Verdi = (coqPackages.Verdi.override { inherit Cheerios ssreflect; })
+  .overrideAttrs (o: {
+    src = fetchTarball "https://github.com/uwplse/verdi/tarball/master";
+  }); in
+
 let callPackage = newScope { inherit coq
   bignums coq-ext-lib coqprime corn iris math-classes
-  mathcomp simple-io ssreflect stdpp unicoq;
+  mathcomp simple-io ssreflect stdpp unicoq Verdi;
 }; in
 
 # Environments for building CI libraries with this Coq
@@ -89,6 +103,7 @@ let projects = {
   mtac2 = callPackage ./mtac2.nix {};
   oddorder = callPackage ./oddorder.nix {};
   quickchick = callPackage ./quickchick.nix {};
+  verdi-raft = callPackage ./verdi-raft.nix {};
   VST = callPackage ./VST.nix {};
 }; in
 

--- a/dev/ci/nix/fiat_crypto.nix
+++ b/dev/ci/nix/fiat_crypto.nix
@@ -1,6 +1,6 @@
-{ coqprime }:
+{ ocamlPackages }:
 {
-  coqBuildInputs = [ coqprime ];
+  buildInputs = with ocamlPackages; [ ocaml findlib ];
   configure = "git submodule update --init --recursive && ulimit -s 32768";
-  make = "make new-pipeline c-files";
+  make = "make c-files printlite lite && make -j 1 coq";
 }

--- a/dev/ci/nix/verdi-raft.nix
+++ b/dev/ci/nix/verdi-raft.nix
@@ -1,0 +1,5 @@
+{ Verdi }:
+{
+  coqBuildInputs = [ Verdi ];
+  configure = "./configure";
+}

--- a/dev/nixpkgs.nix
+++ b/dev/nixpkgs.nix
@@ -1,4 +1,4 @@
 import (fetchTarball {
-  url = "https://github.com/NixOS/nixpkgs/archive/f4ad230f90ef312695adc26f256036203e9c70af.tar.gz";
-  sha256 = "0cdd275dz3q51sknn7s087js81zvaj5riz8f29id6j6chnyikzjq";
+  url = "https://github.com/NixOS/nixpkgs/archive/8da81465c19fca393a3b17004c743e4d82a98e4f.tar.gz";
+  sha256 = "1f3s27nrssfk413pszjhbs70wpap43bbjx2pf4zq5x2c1kd72l6y";
 })


### PR DESCRIPTION
- Update the reference to nixpkgs to bring a version of dune-2 that works (see #11333).
- A few additions to `dev/ci/nix` related to fiat-crypto (update) and verdi-raft (new).
- Fix the setup-hook (see https://github.com/NixOS/nixpkgs/pull/74153).