### PR TITLE
replace RList by list R in all files where it is used in this directory

### DIFF
--- a/doc/changelog/10-standard-library/11404-removeRList.rst
+++ b/doc/changelog/10-standard-library/11404-removeRList.rst
@@ -1,0 +1,15 @@
+- **Removed:**
+  Type `RList` has been removed.  All uses have been replaced by `list R`.
+  Functions from `RList` named `In`, `Rlength`, `cons_Rlist`, `app_Rlist`
+  have also been removed as they are essentially the same as `In`, `length`,
+  `app`, and `map` from `List`, modulo the following changes:
+
+    - `RList.In x (RList.cons a l)` used to be convertible to
+      `(x = a) \\/ RList.In x l`,
+      but `List.In x (a :: l)` is convertible to
+      `(a = x) \\/ List.In l`.
+      The equality is reversed.
+    - `app_Rlist` and `List.map` take arguments in different order.
+
+  (`#11404 <https://github.com/coq/coq/pull/11404>`_,
+  by Yves Bertot).

--- a/theories/Reals/RList.v
+++ b/theories/Reals/RList.v
@@ -8,47 +8,67 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
+Require Import List.
 Require Import Rbase.
 Require Import Rfunctions.
 Local Open Scope R_scope.
 
-Inductive Rlist : Type :=
-| nil : Rlist
-| cons : R -> Rlist -> Rlist.
 
-Fixpoint In (x:R) (l:Rlist) : Prop :=
-  match l with
-    | nil => False
-    | cons a l' => x = a \/ In x l'
-  end.
+#[deprecated(since="8.12",note="use (list R) instead")]
+Notation Rlist := (list R).
 
-Fixpoint Rlength (l:Rlist) : nat :=
-  match l with
-    | nil => 0%nat
-    | cons a l' => S (Rlength l')
-  end.
+#[deprecated(since="8.12",note="use List.length instead")]
+Notation Rlength := List.length.
 
-Fixpoint MaxRlist (l:Rlist) : R :=
+Fixpoint MaxRlist (l:list R) : R :=
   match l with
     | nil => 0
-    | cons a l1 =>
+    | a :: l1 =>
       match l1 with
         | nil => a
-        | cons a' l2 => Rmax a (MaxRlist l1)
+        | a' :: l2 => Rmax a (MaxRlist l1)
       end
   end.
 
-Fixpoint MinRlist (l:Rlist) : R :=
+Fixpoint MinRlist (l:list R) : R :=
   match l with
     | nil => 1
-    | cons a l1 =>
+    | a :: l1 =>
       match l1 with
         | nil => a
-        | cons a' l2 => Rmin a (MinRlist l1)
+        | a' :: l2 => Rmin a (MinRlist l1)
       end
   end.
 
-Lemma MaxRlist_P1 : forall (l:Rlist) (x:R), In x l -> x <= MaxRlist l.
+Lemma MaxRlist_P1 : forall (l:list R) (x:R), In x l -> x <= MaxRlist l.
+Proof.
+  intros; induction  l as [| r l Hrecl].
+  simpl in H; elim H.
+  induction  l as [| r0 l Hrecl0].
+  simpl in H; elim H; intro.
+  simpl; right; symmetry; assumption.
+  elim H0.
+  replace (MaxRlist (r :: r0 :: l)) with (Rmax r (MaxRlist (r0 :: l))).
+  simpl in H; decompose [or] H.
+  rewrite H0; apply RmaxLess1.
+  unfold Rmax; case (Rle_dec r (MaxRlist (r0 :: l))); intro.
+  apply Hrecl; simpl; tauto.
+  apply Rle_trans with (MaxRlist (r0 :: l));
+    [ apply Hrecl; simpl; tauto | left; auto with real ].
+  unfold Rmax; case (Rle_dec r (MaxRlist (r0 :: l))); intro.
+  apply Hrecl; simpl; tauto.
+  apply Rle_trans with (MaxRlist (r0 :: l));
+    [ apply Hrecl; simpl; tauto | left; auto with real ].
+  reflexivity.
+Qed.
+
+Fixpoint AbsList (l:list R) (x:R) : list R :=
+  match l with
+    | nil => nil
+    | a :: l' => (Rabs (a - x) / 2) :: (AbsList l' x)
+  end.
+
+Lemma MinRlist_P1 : forall (l:list R) (x:R), In x l -> MinRlist l <= x.
 Proof.
   intros; induction  l as [| r l Hrecl].
   simpl in H; elim H.
@@ -56,50 +76,22 @@ Proof.
   simpl in H; elim H; intro.
   simpl; right; assumption.
   elim H0.
-  replace (MaxRlist (cons r (cons r0 l))) with (Rmax r (MaxRlist (cons r0 l))).
-  simpl in H; decompose [or] H.
-  rewrite H0; apply RmaxLess1.
-  unfold Rmax; case (Rle_dec r (MaxRlist (cons r0 l))); intro.
-  apply Hrecl; simpl; tauto.
-  apply Rle_trans with (MaxRlist (cons r0 l));
-    [ apply Hrecl; simpl; tauto | left; auto with real ].
-  unfold Rmax; case (Rle_dec r (MaxRlist (cons r0 l))); intro.
-  apply Hrecl; simpl; tauto.
-  apply Rle_trans with (MaxRlist (cons r0 l));
-    [ apply Hrecl; simpl; tauto | left; auto with real ].
-  reflexivity.
-Qed.
-
-Fixpoint AbsList (l:Rlist) (x:R) : Rlist :=
-  match l with
-    | nil => nil
-    | cons a l' => cons (Rabs (a - x) / 2) (AbsList l' x)
-  end.
-
-Lemma MinRlist_P1 : forall (l:Rlist) (x:R), In x l -> MinRlist l <= x.
-Proof.
-  intros; induction  l as [| r l Hrecl].
-  simpl in H; elim H.
-  induction  l as [| r0 l Hrecl0].
-  simpl in H; elim H; intro.
-  simpl; right; symmetry ; assumption.
-  elim H0.
-  replace (MinRlist (cons r (cons r0 l))) with (Rmin r (MinRlist (cons r0 l))).
+  replace (MinRlist (r :: r0 :: l)) with (Rmin r (MinRlist (r0 :: l))).
   simpl in H; decompose [or] H.
   rewrite H0; apply Rmin_l.
-  unfold Rmin; case (Rle_dec r (MinRlist (cons r0 l))); intro.
-  apply Rle_trans with (MinRlist (cons r0 l)).
+  unfold Rmin; case (Rle_dec r (MinRlist (r0 :: l))); intro.
+  apply Rle_trans with (MinRlist (r0 :: l)).
   assumption.
   apply Hrecl; simpl; tauto.
   apply Hrecl; simpl; tauto.
-  apply Rle_trans with (MinRlist (cons r0 l)).
+  apply Rle_trans with (MinRlist (r0 :: l)).
   apply Rmin_r.
   apply Hrecl; simpl; tauto.
   reflexivity.
 Qed.
 
 Lemma AbsList_P1 :
-  forall (l:Rlist) (x y:R), In y l -> In (Rabs (y - x) / 2) (AbsList l x).
+  forall (l:list R) (x y:R), In y l -> In (Rabs (y - x) / 2) (AbsList l x).
 Proof.
   intros; induction  l as [| r l Hrecl].
   elim H.
@@ -109,21 +101,21 @@ Proof.
 Qed.
 
 Lemma MinRlist_P2 :
-  forall l:Rlist, (forall y:R, In y l -> 0 < y) -> 0 < MinRlist l.
+  forall l:list R, (forall y:R, In y l -> 0 < y) -> 0 < MinRlist l.
 Proof.
   intros; induction  l as [| r l Hrecl].
   apply Rlt_0_1.
   induction  l as [| r0 l Hrecl0].
   simpl; apply H; simpl; tauto.
-  replace (MinRlist (cons r (cons r0 l))) with (Rmin r (MinRlist (cons r0 l))).
-  unfold Rmin; case (Rle_dec r (MinRlist (cons r0 l))); intro.
+  replace (MinRlist (r :: r0 :: l)) with (Rmin r (MinRlist (r0 :: l))).
+  unfold Rmin; case (Rle_dec r (MinRlist (r0 :: l))); intro.
   apply H; simpl; tauto.
   apply Hrecl; intros; apply H; simpl; simpl in H0; tauto.
   reflexivity.
 Qed.
 
 Lemma AbsList_P2 :
-  forall (l:Rlist) (x y:R),
+  forall (l:list R) (x y:R),
     In y (AbsList l x) ->  exists z : R, In z l /\ y = Rabs (z - x) / 2.
 Proof.
   intros; induction  l as [| r l Hrecl].
@@ -131,47 +123,48 @@ Proof.
   elim H; intro.
   exists r; split.
   simpl; tauto.
+  symmetry.
   assumption.
   assert (H1 := Hrecl H0); elim H1; intros; elim H2; clear H2; intros;
     exists x0; simpl; simpl in H2; tauto.
 Qed.
 
 Lemma MaxRlist_P2 :
-  forall l:Rlist, (exists y : R, In y l) -> In (MaxRlist l) l.
+  forall l:list R, (exists y : R, In y l) -> In (MaxRlist l) l.
 Proof.
   intros; induction  l as [| r l Hrecl].
   simpl in H; elim H; trivial.
   induction  l as [| r0 l Hrecl0].
   simpl; left; reflexivity.
-  change (In (Rmax r (MaxRlist (cons r0 l))) (cons r (cons r0 l)));
-    unfold Rmax; case (Rle_dec r (MaxRlist (cons r0 l)));
+  change (In (Rmax r (MaxRlist (r0 :: l))) (r :: r0 :: l));
+    unfold Rmax; case (Rle_dec r (MaxRlist (r0 :: l)));
       intro.
   right; apply Hrecl; exists r0; left; reflexivity.
   left; reflexivity.
 Qed.
 
-Fixpoint pos_Rl (l:Rlist) (i:nat) : R :=
+Fixpoint pos_Rl (l:list R) (i:nat) : R :=
   match l with
     | nil => 0
-    | cons a l' => match i with
+    | a :: l' => match i with
                      | O => a
                      | S i' => pos_Rl l' i'
                    end
   end.
 
 Lemma pos_Rl_P1 :
-  forall (l:Rlist) (a:R),
-    (0 < Rlength l)%nat ->
-    pos_Rl (cons a l) (Rlength l) = pos_Rl l (pred (Rlength l)).
+  forall (l:list R) (a:R),
+    (0 < length l)%nat ->
+    pos_Rl (a :: l) (length l) = pos_Rl l (pred (length l)).
 Proof.
   intros; induction  l as [| r l Hrecl];
     [ elim (lt_n_O _ H)
-      | simpl; case (Rlength l); [ reflexivity | intro; reflexivity ] ].
+      | simpl; case (length l); [ reflexivity | intro; reflexivity ] ].
 Qed.
 
 Lemma pos_Rl_P2 :
-  forall (l:Rlist) (x:R),
-    In x l <-> (exists i : nat, (i < Rlength l)%nat /\ x = pos_Rl l i).
+  forall (l:list R) (x:R),
+    In x l <-> (exists i : nat, (i < length l)%nat /\ x = pos_Rl l i).
 Proof.
   intros; induction  l as [| r l Hrecl].
   split; intro;
@@ -179,12 +172,12 @@ Proof.
   split; intro.
   elim H; intro.
   exists 0%nat; split;
-    [ simpl; apply lt_O_Sn | simpl; apply H0 ].
+    [ simpl; apply lt_O_Sn | simpl; symmetry; apply H0 ].
   elim Hrecl; intros; assert (H3 := H1 H0); elim H3; intros; elim H4; intros;
     exists (S x0); split;
       [ simpl; apply lt_n_S; assumption | simpl; assumption ].
   elim H; intros; elim H0; intros; destruct (zerop x0) as [->|].
-  simpl in H2; left; assumption.
+  simpl in H2; left; symmetry; assumption.
   right; elim Hrecl; intros H4 H5; apply H5; assert (H6 : S (pred x0) = x0).
   symmetry ; apply S_pred with 0%nat; assumption.
   exists (pred x0); split;
@@ -193,21 +186,21 @@ Proof.
 Qed.
 
 Lemma Rlist_P1 :
-  forall (l:Rlist) (P:R -> R -> Prop),
+  forall (l:list R) (P:R -> R -> Prop),
     (forall x:R, In x l ->  exists y : R, P x y) ->
-    exists l' : Rlist,
-      Rlength l = Rlength l' /\
-      (forall i:nat, (i < Rlength l)%nat -> P (pos_Rl l i) (pos_Rl l' i)).
+    exists l' : list R,
+      length l = length l' /\
+      (forall i:nat, (i < length l)%nat -> P (pos_Rl l i) (pos_Rl l' i)).
 Proof.
   intros; induction  l as [| r l Hrecl].
   exists nil; intros; split;
     [ reflexivity | intros; simpl in H0; elim (lt_n_O _ H0) ].
-  assert (H0 : In r (cons r l)).
+  assert (H0 : In r (r :: l)).
   simpl; left; reflexivity.
   assert (H1 := H _ H0);
     assert (H2 : forall x:R, In x l ->  exists y : R, P x y).
   intros; apply H; simpl; right; assumption.
-  assert (H3 := Hrecl H2); elim H1; intros; elim H3; intros; exists (cons x x0);
+  assert (H3 := Hrecl H2); elim H1; intros; elim H3; intros; exists (x :: x0);
     intros; elim H5; clear H5; intros; split.
   simpl; rewrite H5; reflexivity.
   intros; destruct (zerop i) as [->|].
@@ -218,57 +211,45 @@ Proof.
     assumption.
 Qed.
 
-Definition ordered_Rlist (l:Rlist) : Prop :=
-  forall i:nat, (i < pred (Rlength l))%nat -> pos_Rl l i <= pos_Rl l (S i).
+Definition ordered_Rlist (l:list R) : Prop :=
+  forall i:nat, (i < pred (length l))%nat -> pos_Rl l i <= pos_Rl l (S i).
 
-Fixpoint insert (l:Rlist) (x:R) : Rlist :=
+Fixpoint insert (l:list R) (x:R) : list R :=
   match l with
-    | nil => cons x nil
-    | cons a l' =>
+    | nil => x :: nil
+    | a :: l' =>
       match Rle_dec a x with
-        | left _ => cons a (insert l' x)
-        | right _ => cons x l
+        | left _ => a :: (insert l' x)
+        | right _ => x :: l
       end
   end.
 
-Fixpoint cons_Rlist (l k:Rlist) : Rlist :=
-  match l with
-    | nil => k
-    | cons a l' => cons a (cons_Rlist l' k)
-  end.
-
-Fixpoint cons_ORlist (k l:Rlist) : Rlist :=
+Fixpoint cons_ORlist (k l:list R) : list R :=
   match k with
     | nil => l
-    | cons a k' => cons_ORlist k' (insert l a)
+    | a :: k' => cons_ORlist k' (insert l a)
   end.
 
-Fixpoint app_Rlist (l:Rlist) (f:R -> R) : Rlist :=
+Fixpoint mid_Rlist (l:list R) (x:R) : list R :=
   match l with
     | nil => nil
-    | cons a l' => cons (f a) (app_Rlist l' f)
+    | a :: l' => ((x + a) / 2) :: (mid_Rlist l' a)
   end.
 
-Fixpoint mid_Rlist (l:Rlist) (x:R) : Rlist :=
+Definition Rtail (l:list R) : list R :=
   match l with
     | nil => nil
-    | cons a l' => cons ((x + a) / 2) (mid_Rlist l' a)
+    |  a :: l' => l'
   end.
 
-Definition Rtail (l:Rlist) : Rlist :=
+Definition FF (l:list R) (f:R -> R) : list R :=
   match l with
     | nil => nil
-    | cons a l' => l'
-  end.
-
-Definition FF (l:Rlist) (f:R -> R) : Rlist :=
-  match l with
-    | nil => nil
-    | cons a l' => app_Rlist (mid_Rlist l' a) f
+    | a :: l' => map f (mid_Rlist l' a)
   end.
 
 Lemma RList_P0 :
-  forall (l:Rlist) (a:R),
+  forall (l:list R) (a:R),
     pos_Rl (insert l a) 0 = a \/ pos_Rl (insert l a) 0 = pos_Rl l 0.
 Proof.
   intros; induction  l as [| r l Hrecl];
@@ -278,7 +259,7 @@ Proof.
 Qed.
 
 Lemma RList_P1 :
-  forall (l:Rlist) (a:R), ordered_Rlist l -> ordered_Rlist (insert l a).
+  forall (l:list R) (a:R), ordered_Rlist l -> ordered_Rlist (insert l a).
 Proof.
   intros; induction  l as [| r l Hrecl].
   simpl; unfold ordered_Rlist; intros; simpl in H0;
@@ -286,8 +267,8 @@ Proof.
   simpl; case (Rle_dec r a); intro.
   assert (H1 : ordered_Rlist l).
   unfold ordered_Rlist; unfold ordered_Rlist in H; intros;
-    assert (H1 : (S i < pred (Rlength (cons r l)))%nat);
-      [ simpl; replace (Rlength l) with (S (pred (Rlength l)));
+    assert (H1 : (S i < pred (length (r :: l)))%nat);
+      [ simpl; replace (length l) with (S (pred (length l)));
         [ apply lt_n_S; assumption
           | symmetry ; apply S_pred with 0%nat; apply neq_O_lt; red;
             intro; rewrite <- H1 in H0; simpl in H0; elim (lt_n_O _ H0) ]
@@ -300,18 +281,18 @@ Proof.
     [ simpl; assumption
       | rewrite H4; apply (H 0%nat); simpl; apply lt_O_Sn ].
   simpl; apply H2; simpl in H0; apply lt_S_n;
-    replace (S (pred (Rlength (insert l a)))) with (Rlength (insert l a));
+    replace (S (pred (length (insert l a)))) with (length (insert l a));
     [ assumption
       | apply S_pred with 0%nat; apply neq_O_lt; red; intro;
         rewrite <- H3 in H0; elim (lt_n_O _ H0) ].
   unfold ordered_Rlist; intros; induction  i as [| i Hreci];
     [ simpl; auto with real
-      | change (pos_Rl (cons r l) i <= pos_Rl (cons r l) (S i)); apply H;
+      | change (pos_Rl (r :: l) i <= pos_Rl (r :: l) (S i)); apply H;
         simpl in H0; simpl; apply (lt_S_n _ _ H0) ].
 Qed.
 
 Lemma RList_P2 :
-  forall l1 l2:Rlist, ordered_Rlist l2 -> ordered_Rlist (cons_ORlist l1 l2).
+  forall l1 l2:list R, ordered_Rlist l2 -> ordered_Rlist (cons_ORlist l1 l2).
 Proof.
   simple induction l1;
     [ intros; simpl; apply H
@@ -319,36 +300,36 @@ Proof.
 Qed.
 
 Lemma RList_P3 :
-  forall (l:Rlist) (x:R),
-    In x l <-> (exists i : nat, x = pos_Rl l i /\ (i < Rlength l)%nat).
+  forall (l:list R) (x:R),
+    In x l <-> (exists i : nat, x = pos_Rl l i /\ (i < length l)%nat).
 Proof.
   intros; split; intro;
     [ induction  l as [| r l Hrecl] | induction  l as [| r l Hrecl] ].
   elim H.
   elim H; intro;
-    [ exists 0%nat; split; [ apply H0 | simpl; apply lt_O_Sn ]
+    [ exists 0%nat; split; [ symmetry; apply H0 | simpl; apply lt_O_Sn ]
       | elim (Hrecl H0); intros; elim H1; clear H1; intros; exists (S x0); split;
         [ apply H1 | simpl; apply lt_n_S; assumption ] ].
   elim H; intros; elim H0; intros; elim (lt_n_O _ H2).
   simpl; elim H; intros; elim H0; clear H0; intros;
     induction  x0 as [| x0 Hrecx0];
-      [ left; apply H0
+      [ left; symmetry; apply H0
         | right; apply Hrecl; exists x0; split;
           [ apply H0 | simpl in H1; apply lt_S_n; assumption ] ].
 Qed.
 
 Lemma RList_P4 :
-  forall (l1:Rlist) (a:R), ordered_Rlist (cons a l1) -> ordered_Rlist l1.
+  forall (l1:list R) (a:R), ordered_Rlist (a :: l1) -> ordered_Rlist l1.
 Proof.
   intros; unfold ordered_Rlist; intros; apply (H (S i)); simpl;
-    replace (Rlength l1) with (S (pred (Rlength l1)));
+    replace (length l1) with (S (pred (length l1)));
     [ apply lt_n_S; assumption
       | symmetry ; apply S_pred with 0%nat; apply neq_O_lt; red;
         intro; rewrite <- H1 in H0; elim (lt_n_O _ H0) ].
 Qed.
 
 Lemma RList_P5 :
-  forall (l:Rlist) (x:R), ordered_Rlist l -> In x l -> pos_Rl l 0 <= x.
+  forall (l:list R) (x:R), ordered_Rlist l -> In x l -> pos_Rl l 0 <= x.
 Proof.
   intros; induction  l as [| r l Hrecl];
     [ elim H0
@@ -361,14 +342,14 @@ Proof.
 Qed.
 
 Lemma RList_P6 :
-  forall l:Rlist,
+  forall l:list R,
     ordered_Rlist l <->
     (forall i j:nat,
-      (i <= j)%nat -> (j < Rlength l)%nat -> pos_Rl l i <= pos_Rl l j).
+      (i <= j)%nat -> (j < length l)%nat -> pos_Rl l i <= pos_Rl l j).
 Proof.
-  simple induction l; split; intro.
+  induction l as [ | r r0 H]; split; intro.
   intros; right; reflexivity.
-  unfold ordered_Rlist; intros; simpl in H0; elim (lt_n_O _ H0).
+  unfold ordered_Rlist;intros; simpl in H0; elim (lt_n_O _ H0).
   intros; induction  i as [| i Hreci];
     [ induction  j as [| j Hrecj];
       [ right; reflexivity
@@ -391,14 +372,14 @@ Proof.
 Qed.
 
 Lemma RList_P7 :
-  forall (l:Rlist) (x:R),
-    ordered_Rlist l -> In x l -> x <= pos_Rl l (pred (Rlength l)).
+  forall (l:list R) (x:R),
+    ordered_Rlist l -> In x l -> x <= pos_Rl l (pred (length l)).
 Proof.
   intros; assert (H1 := RList_P6 l); elim H1; intros H2 _; assert (H3 := H2 H);
     clear H1 H2; assert (H1 := RList_P3 l x); elim H1;
       clear H1; intros; assert (H4 := H1 H0); elim H4; clear H4;
         intros; elim H4; clear H4; intros; rewrite H4;
-          assert (H6 : Rlength l = S (pred (Rlength l))).
+          assert (H6 : length l = S (pred (length l))).
   apply S_pred with 0%nat; apply neq_O_lt; red; intro;
     rewrite <- H6 in H5; elim (lt_n_O _ H5).
   apply H3;
@@ -408,52 +389,55 @@ Proof.
 Qed.
 
 Lemma RList_P8 :
-  forall (l:Rlist) (a x:R), In x (insert l a) <-> x = a \/ In x l.
+  forall (l:list R) (a x:R), In x (insert l a) <-> x = a \/ In x l.
 Proof.
-  simple induction l.
-  intros; split; intro; simpl in H; apply H.
-  intros; split; intro;
-    [ simpl in H0; generalize H0; case (Rle_dec r a); intros;
-      [ simpl in H1; elim H1; intro;
-        [ right; left; assumption
-          | elim (H a x); intros; elim (H3 H2); intro;
-            [ left; assumption | right; right; assumption ] ]
-        | simpl in H1; decompose [or] H1;
-          [ left; assumption
-            | right; left; assumption
-            | right; right; assumption ] ]
-      | simpl; case (Rle_dec r a); intro;
-        [ simpl in H0; decompose [or] H0;
-          [ right; elim (H a x); intros; apply H3; left
-            | left
-            | right; elim (H a x); intros; apply H3; right ]
-          | simpl in H0; decompose [or] H0; [ left | right; left | right; right ] ];
-        assumption ].
+  induction l as [ | r r0 H].
+  intros; split; intro; destruct H as [ax | []]; left; symmetry; exact ax.
+  intros; split; intro.
+    simpl in H0; generalize H0; case (Rle_dec r a); intros.
+      simpl in H1; elim H1; intro.
+        right; left; assumption.
+        elim (H a x); intros; elim (H3 H2); intro.
+            left; assumption.
+            right; right; assumption.
+      simpl in H1; decompose [or] H1.
+          left; symmetry; assumption.
+          right; left; assumption.
+          right; right; assumption.
+      simpl; case (Rle_dec r a); intro.
+        simpl in H0; decompose [or] H0.
+          right; elim (H a x); intros; apply H3; left.  assumption.
+          left. assumption.
+          right; elim (H a x); intros; apply H3; right; assumption.
+        simpl in H0; decompose [or] H0; [ left | right; left | right; right];
+        trivial; symmetry; assumption.
 Qed.
 
 Lemma RList_P9 :
-  forall (l1 l2:Rlist) (x:R), In x (cons_ORlist l1 l2) <-> In x l1 \/ In x l2.
+  forall (l1 l2:list R) (x:R), In x (cons_ORlist l1 l2) <-> In x l1 \/ In x l2.
 Proof.
-  simple induction l1.
+  induction l1 as [ | r r0 H].
   intros; split; intro;
     [ simpl in H; right; assumption
       | simpl; elim H; intro; [ elim H0 | assumption ] ].
   intros; split.
   simpl; intros; elim (H (insert l2 r) x); intros; assert (H3 := H1 H0);
-    elim H3; intro;
-      [ left; right; assumption
-        | elim (RList_P8 l2 r x); intros H5 _; assert (H6 := H5 H4); elim H6; intro;
-          [ left; left; assumption | right; assumption ] ].
+    elim H3; intro.
+      left; right; assumption.
+      elim (RList_P8 l2 r x); intros H5 _; assert (H6 := H5 H4); elim H6; intro.
+          left; left; symmetry; assumption.
+          right; assumption.
   intro; simpl; elim (H (insert l2 r) x); intros _ H1; apply H1;
-    elim H0; intro;
-      [ elim H2; intro;
-        [ right; elim (RList_P8 l2 r x); intros _ H4; apply H4; left; assumption
-          | left; assumption ]
-        | right; elim (RList_P8 l2 r x); intros _ H3; apply H3; right; assumption ].
+    elim H0; intro.
+      elim H2; intro.
+        right; elim (RList_P8 l2 r x); intros _ H4; apply H4; left.
+        symmetry; assumption.
+        left; assumption.
+      right; elim (RList_P8 l2 r x); intros _ H3; apply H3; right; assumption.
 Qed.
 
 Lemma RList_P10 :
-  forall (l:Rlist) (a:R), Rlength (insert l a) = S (Rlength l).
+  forall (l:list R) (a:R), length (insert l a) = S (length l).
 Proof.
   intros; induction  l as [| r l Hrecl];
     [ reflexivity
@@ -462,10 +446,10 @@ Proof.
 Qed.
 
 Lemma RList_P11 :
-  forall l1 l2:Rlist,
-    Rlength (cons_ORlist l1 l2) = (Rlength l1 + Rlength l2)%nat.
+  forall l1 l2:list R,
+    length (cons_ORlist l1 l2) = (length l1 + length l2)%nat.
 Proof.
-  simple induction l1;
+  induction l1 as [ | r r0 H];
     [ intro; reflexivity
       | intros; simpl; rewrite (H (insert l2 r)); rewrite RList_P10;
         apply INR_eq; rewrite S_INR; do 2 rewrite plus_INR;
@@ -473,8 +457,8 @@ Proof.
 Qed.
 
 Lemma RList_P12 :
-  forall (l:Rlist) (i:nat) (f:R -> R),
-    (i < Rlength l)%nat -> pos_Rl (app_Rlist l f) i = f (pos_Rl l i).
+  forall (l:list R) (i:nat) (f:R -> R),
+    (i < length l)%nat -> pos_Rl (map f l) i = f (pos_Rl l i).
 Proof.
   simple induction l;
     [ intros; elim (lt_n_O _ H)
@@ -483,30 +467,30 @@ Proof.
 Qed.
 
 Lemma RList_P13 :
-  forall (l:Rlist) (i:nat) (a:R),
-    (i < pred (Rlength l))%nat ->
+  forall (l:list R) (i:nat) (a:R),
+    (i < pred (length l))%nat ->
     pos_Rl (mid_Rlist l a) (S i) = (pos_Rl l i + pos_Rl l (S i)) / 2.
 Proof.
-  simple induction l.
+  induction l as [ | r r0 H].
   intros; simpl in H; elim (lt_n_O _ H).
-  simple induction r0.
+  induction r0 as [ | r1 r2 H0].
   intros; simpl in H0; elim (lt_n_O _ H0).
   intros; simpl in H1; induction  i as [| i Hreci].
   reflexivity.
   change
-    (pos_Rl (mid_Rlist (cons r1 r2) r) (S i) =
-      (pos_Rl (cons r1 r2) i + pos_Rl (cons r1 r2) (S i)) / 2)
-   ; apply H0; simpl; apply lt_S_n; assumption.
+    (pos_Rl (mid_Rlist (r1 :: r2) r) (S i) =
+      (pos_Rl (r1 :: r2) i + pos_Rl (r1 :: r2) (S i)) / 2).
+    apply H; simpl; apply lt_S_n; assumption.
 Qed.
 
-Lemma RList_P14 : forall (l:Rlist) (a:R), Rlength (mid_Rlist l a) = Rlength l.
+Lemma RList_P14 : forall (l:list R) (a:R), length (mid_Rlist l a) = length l.
 Proof.
-  simple induction l; intros;
+  induction l as [ | r r0 H]; intros;
     [ reflexivity | simpl; rewrite (H r); reflexivity ].
 Qed.
 
 Lemma RList_P15 :
-  forall l1 l2:Rlist,
+  forall l1 l2:list R,
     ordered_Rlist l1 ->
     ordered_Rlist l2 ->
     pos_Rl l1 0 = pos_Rl l2 0 -> pos_Rl (cons_ORlist l1 l2) 0 = pos_Rl l1 0.
@@ -514,10 +498,10 @@ Proof.
   intros; apply Rle_antisym.
   induction  l1 as [| r l1 Hrecl1];
     [ simpl; simpl in H1; right; symmetry ; assumption
-      | elim (RList_P9 (cons r l1) l2 (pos_Rl (cons r l1) 0)); intros;
+      | elim (RList_P9 (r :: l1) l2 (pos_Rl (r :: l1) 0)); intros;
         assert
           (H4 :
-            In (pos_Rl (cons r l1) 0) (cons r l1) \/ In (pos_Rl (cons r l1) 0) l2);
+            In (pos_Rl (r :: l1) 0) (r :: l1) \/ In (pos_Rl (r :: l1) 0) l2);
           [ left; left; reflexivity
             | assert (H5 := H3 H4); apply RList_P5;
               [ apply RList_P2; assumption | assumption ] ] ].
@@ -525,25 +509,25 @@ Proof.
     [ simpl; simpl in H1; right; assumption
       | assert
         (H2 :
-          In (pos_Rl (cons_ORlist (cons r l1) l2) 0) (cons_ORlist (cons r l1) l2));
+          In (pos_Rl (cons_ORlist (r :: l1) l2) 0) (cons_ORlist (r :: l1) l2));
         [ elim
-          (RList_P3 (cons_ORlist (cons r l1) l2)
-            (pos_Rl (cons_ORlist (cons r l1) l2) 0));
+          (RList_P3 (cons_ORlist (r :: l1) l2)
+            (pos_Rl (cons_ORlist (r :: l1) l2) 0));
           intros; apply H3; exists 0%nat; split;
             [ reflexivity | rewrite RList_P11; simpl; apply lt_O_Sn ]
-          | elim (RList_P9 (cons r l1) l2 (pos_Rl (cons_ORlist (cons r l1) l2) 0));
+          | elim (RList_P9 (r :: l1) l2 (pos_Rl (cons_ORlist (r :: l1) l2) 0));
             intros; assert (H5 := H3 H2); elim H5; intro;
               [ apply RList_P5; assumption
                 | rewrite H1; apply RList_P5; assumption ] ] ].
 Qed.
 
 Lemma RList_P16 :
-  forall l1 l2:Rlist,
+  forall l1 l2:list R,
     ordered_Rlist l1 ->
     ordered_Rlist l2 ->
-    pos_Rl l1 (pred (Rlength l1)) = pos_Rl l2 (pred (Rlength l2)) ->
-    pos_Rl (cons_ORlist l1 l2) (pred (Rlength (cons_ORlist l1 l2))) =
-    pos_Rl l1 (pred (Rlength l1)).
+    pos_Rl l1 (pred (length l1)) = pos_Rl l2 (pred (length l2)) ->
+    pos_Rl (cons_ORlist l1 l2) (pred (length (cons_ORlist l1 l2))) =
+    pos_Rl l1 (pred (length l1)).
 Proof.
   intros; apply Rle_antisym.
   induction  l1 as [| r l1 Hrecl1].
@@ -551,99 +535,99 @@ Proof.
   assert
     (H2 :
       In
-      (pos_Rl (cons_ORlist (cons r l1) l2)
-        (pred (Rlength (cons_ORlist (cons r l1) l2))))
-      (cons_ORlist (cons r l1) l2));
+      (pos_Rl (cons_ORlist (r :: l1) l2)
+        (pred (length (cons_ORlist (r :: l1) l2))))
+      (cons_ORlist (r :: l1) l2));
     [ elim
-      (RList_P3 (cons_ORlist (cons r l1) l2)
-        (pos_Rl (cons_ORlist (cons r l1) l2)
-          (pred (Rlength (cons_ORlist (cons r l1) l2)))));
-      intros; apply H3; exists (pred (Rlength (cons_ORlist (cons r l1) l2)));
+      (RList_P3 (cons_ORlist (r :: l1) l2)
+        (pos_Rl (cons_ORlist (r :: l1) l2)
+          (pred (length (cons_ORlist (r :: l1) l2)))));
+      intros; apply H3; exists (pred (length (cons_ORlist (r :: l1) l2)));
         split; [ reflexivity | rewrite RList_P11; simpl; apply lt_n_Sn ]
       | elim
-        (RList_P9 (cons r l1) l2
-          (pos_Rl (cons_ORlist (cons r l1) l2)
-            (pred (Rlength (cons_ORlist (cons r l1) l2)))));
+        (RList_P9 (r :: l1) l2
+          (pos_Rl (cons_ORlist (r :: l1) l2)
+            (pred (length (cons_ORlist (r :: l1) l2)))));
         intros; assert (H5 := H3 H2); elim H5; intro;
           [ apply RList_P7; assumption | rewrite H1; apply RList_P7; assumption ] ].
   induction  l1 as [| r l1 Hrecl1].
   simpl; simpl in H1; right; assumption.
   elim
-    (RList_P9 (cons r l1) l2 (pos_Rl (cons r l1) (pred (Rlength (cons r l1)))));
+    (RList_P9 (r :: l1) l2 (pos_Rl (r :: l1) (pred (length (r :: l1))))).
     intros;
       assert
         (H4 :
-          In (pos_Rl (cons r l1) (pred (Rlength (cons r l1)))) (cons r l1) \/
-          In (pos_Rl (cons r l1) (pred (Rlength (cons r l1)))) l2);
-        [ left; change (In (pos_Rl (cons r l1) (Rlength l1)) (cons r l1));
-          elim (RList_P3 (cons r l1) (pos_Rl (cons r l1) (Rlength l1)));
-            intros; apply H5; exists (Rlength l1); split;
+          In (pos_Rl (r :: l1) (pred (length (r :: l1)))) (r :: l1) \/
+          In (pos_Rl (r :: l1) (pred (length (r :: l1)))) l2);
+        [ left; change (In (pos_Rl (r :: l1) (length l1)) (r :: l1));
+          elim (RList_P3 (r :: l1) (pos_Rl (r :: l1) (length l1)));
+            intros; apply H5; exists (length l1); split;
               [ reflexivity | simpl; apply lt_n_Sn ]
           | assert (H5 := H3 H4); apply RList_P7;
             [ apply RList_P2; assumption
               | elim
-                (RList_P9 (cons r l1) l2
-                  (pos_Rl (cons r l1) (pred (Rlength (cons r l1)))));
+                (RList_P9 (r :: l1) l2
+                  (pos_Rl (r :: l1) (pred (length (r :: l1)))));
                 intros; apply H7; left;
                   elim
-                    (RList_P3 (cons r l1)
-                      (pos_Rl (cons r l1) (pred (Rlength (cons r l1)))));
-                    intros; apply H9; exists (pred (Rlength (cons r l1)));
+                    (RList_P3 (r :: l1)
+                      (pos_Rl (r :: l1) (pred (length (r :: l1)))));
+                    intros; apply H9; exists (pred (length (r :: l1)));
                       split; [ reflexivity | simpl; apply lt_n_Sn ] ] ].
 Qed.
 
 Lemma RList_P17 :
-  forall (l1:Rlist) (x:R) (i:nat),
+  forall (l1:list R) (x:R) (i:nat),
     ordered_Rlist l1 ->
     In x l1 ->
-    pos_Rl l1 i < x -> (i < pred (Rlength l1))%nat -> pos_Rl l1 (S i) <= x.
+    pos_Rl l1 i < x -> (i < pred (length l1))%nat -> pos_Rl l1 (S i) <= x.
 Proof.
-  simple induction l1.
+  induction l1 as [ | r r0 H].
   intros; elim H0.
   intros; induction  i as [| i Hreci].
   simpl; elim H1; intro;
     [ simpl in H2; rewrite H4 in H2; elim (Rlt_irrefl _ H2)
       | apply RList_P5; [ apply RList_P4 with r; assumption | assumption ] ].
   simpl; simpl in H2; elim H1; intro.
-  rewrite H4 in H2; assert (H5 : r <= pos_Rl r0 i);
+  rewrite <- H4 in H2; assert (H5 : r <= pos_Rl r0 i);
     [ apply Rle_trans with (pos_Rl r0 0);
       [ apply (H0 0%nat); simpl; simpl in H3; apply neq_O_lt;
         red; intro; rewrite <- H5 in H3; elim (lt_n_O _ H3)
         | elim (RList_P6 r0); intros; apply H5;
           [ apply RList_P4 with r; assumption
             | apply le_O_n
-            | simpl in H3; apply lt_S_n; apply lt_trans with (Rlength r0);
+            | simpl in H3; apply lt_S_n; apply lt_trans with (length r0);
               [ apply H3 | apply lt_n_Sn ] ] ]
       | elim (Rlt_irrefl _ (Rle_lt_trans _ _ _ H5 H2)) ].
   apply H; try assumption;
     [ apply RList_P4 with r; assumption
       | simpl in H3; apply lt_S_n;
-        replace (S (pred (Rlength r0))) with (Rlength r0);
+        replace (S (pred (length r0))) with (length r0);
         [ apply H3
           | apply S_pred with 0%nat; apply neq_O_lt; red; intro;
             rewrite <- H5 in H3; elim (lt_n_O _ H3) ] ].
 Qed.
 
 Lemma RList_P18 :
-  forall (l:Rlist) (f:R -> R), Rlength (app_Rlist l f) = Rlength l.
+  forall (l:list R) (f:R -> R), length (map f l) = length l.
 Proof.
   simple induction l; intros;
     [ reflexivity | simpl; rewrite H; reflexivity ].
 Qed.
 
 Lemma RList_P19 :
-  forall l:Rlist,
-    l <> nil ->  exists r : R, (exists r0 : Rlist, l = cons r r0).
+  forall l:list R,
+    l <> nil ->  exists r : R, (exists r0 : list R, l = r :: r0).
 Proof.
   intros; induction  l as [| r l Hrecl];
     [ elim H; reflexivity | exists r; exists l; reflexivity ].
 Qed.
 
 Lemma RList_P20 :
-  forall l:Rlist,
-    (2 <= Rlength l)%nat ->
+  forall l:list R,
+    (2 <= length l)%nat ->
     exists r : R,
-      (exists r1 : R, (exists l' : Rlist, l = cons r (cons r1 l'))).
+      (exists r1 : R, (exists l' : list R, l = r :: r1 :: l')).
 Proof.
   intros; induction  l as [| r l Hrecl];
     [ simpl in H; elim (le_Sn_O _ H)
@@ -652,40 +636,32 @@ Proof.
           | exists r; exists r0; exists l; reflexivity ] ].
 Qed.
 
-Lemma RList_P21 : forall l l':Rlist, l = l' -> Rtail l = Rtail l'.
+Lemma RList_P21 : forall l l':list R, l = l' -> Rtail l = Rtail l'.
 Proof.
   intros; rewrite H; reflexivity.
 Qed.
 
 Lemma RList_P22 :
-  forall l1 l2:Rlist, l1 <> nil -> pos_Rl (cons_Rlist l1 l2) 0 = pos_Rl l1 0.
+  forall l1 l2:list R, l1 <> nil -> pos_Rl (app l1 l2) 0 = pos_Rl l1 0.
 Proof.
   simple induction l1; [ intros; elim H; reflexivity | intros; reflexivity ].
 Qed.
 
-Lemma RList_P23 :
-  forall l1 l2:Rlist,
-    Rlength (cons_Rlist l1 l2) = (Rlength l1 + Rlength l2)%nat.
-Proof.
-  simple induction l1;
-    [ intro; reflexivity | intros; simpl; rewrite H; reflexivity ].
-Qed.
-
 Lemma RList_P24 :
-  forall l1 l2:Rlist,
+  forall l1 l2:list R,
     l2 <> nil ->
-    pos_Rl (cons_Rlist l1 l2) (pred (Rlength (cons_Rlist l1 l2))) =
-    pos_Rl l2 (pred (Rlength l2)).
+    pos_Rl (app l1 l2) (pred (length (app l1 l2))) =
+    pos_Rl l2 (pred (length l2)).
 Proof.
-  simple induction l1.
+  induction l1 as [ | r r0 H].
   intros; reflexivity.
   intros; rewrite <- (H l2 H0); induction  l2 as [| r1 l2 Hrecl2].
   elim H0; reflexivity.
-  do 2 rewrite RList_P23;
-    replace (Rlength (cons r r0) + Rlength (cons r1 l2))%nat with
-    (S (S (Rlength r0 + Rlength l2)));
-    [ replace (Rlength r0 + Rlength (cons r1 l2))%nat with
-      (S (Rlength r0 + Rlength l2));
+  do 2 rewrite app_length;
+    replace (length (r :: r0) + length (r1 :: l2))%nat with
+    (S (S (length r0 + length l2)));
+    [ replace (length r0 + length (r1 :: l2))%nat with
+      (S (length r0 + length l2));
       [ reflexivity
         | simpl; apply INR_eq; rewrite S_INR; do 2 rewrite plus_INR;
           rewrite S_INR; ring ]
@@ -694,39 +670,39 @@ Proof.
 Qed.
 
 Lemma RList_P25 :
-  forall l1 l2:Rlist,
+  forall l1 l2:list R,
     ordered_Rlist l1 ->
     ordered_Rlist l2 ->
-    pos_Rl l1 (pred (Rlength l1)) <= pos_Rl l2 0 ->
-    ordered_Rlist (cons_Rlist l1 l2).
+    pos_Rl l1 (pred (length l1)) <= pos_Rl l2 0 ->
+    ordered_Rlist (app l1 l2).
 Proof.
-  simple induction l1.
+  induction l1 as [ | r r0 H].
   intros; simpl; assumption.
-  simple induction r0.
+  induction r0 as [ | r1 r2 H0].
   intros; simpl; simpl in H2; unfold ordered_Rlist; intros;
     simpl in H3.
   induction  i as [| i Hreci].
   simpl; assumption.
   change (pos_Rl l2 i <= pos_Rl l2 (S i)); apply (H1 i); apply lt_S_n;
-    replace (S (pred (Rlength l2))) with (Rlength l2);
+    replace (S (pred (length l2))) with (length l2);
     [ assumption
       | apply S_pred with 0%nat; apply neq_O_lt; red; intro;
         rewrite <- H4 in H3; elim (lt_n_O _ H3) ].
-  intros; clear H; assert (H : ordered_Rlist (cons_Rlist (cons r1 r2) l2)).
-  apply H0; try assumption.
+  intros; assert (H4 : ordered_Rlist (app (r1 :: r2) l2)).
+  apply H; try assumption.
   apply RList_P4 with r; assumption.
-  unfold ordered_Rlist; intros; simpl in H4;
+  unfold ordered_Rlist; intros i H5; simpl in H5.
     induction  i as [| i Hreci].
   simpl; apply (H1 0%nat); simpl; apply lt_O_Sn.
   change
-    (pos_Rl (cons_Rlist (cons r1 r2) l2) i <=
-      pos_Rl (cons_Rlist (cons r1 r2) l2) (S i));
-    apply (H i); simpl; apply lt_S_n; assumption.
+    (pos_Rl (app (r1 :: r2) l2) i <=
+      pos_Rl (app (r1 :: r2) l2) (S i));
+    apply (H4 i); simpl; apply lt_S_n; assumption.
 Qed.
 
 Lemma RList_P26 :
-  forall (l1 l2:Rlist) (i:nat),
-    (i < Rlength l1)%nat -> pos_Rl (cons_Rlist l1 l2) i = pos_Rl l1 i.
+  forall (l1 l2:list R) (i:nat),
+    (i < length l1)%nat -> pos_Rl (app l1 l2) i = pos_Rl l1 i.
 Proof.
   simple induction l1.
   intros; elim (lt_n_O _ H).
@@ -735,49 +711,41 @@ Proof.
   apply (H l2 i); simpl in H0; apply lt_S_n; assumption.
 Qed.
 
-Lemma RList_P27 :
-  forall l1 l2 l3:Rlist,
-    cons_Rlist l1 (cons_Rlist l2 l3) = cons_Rlist (cons_Rlist l1 l2) l3.
-Proof.
-  simple induction l1; intros;
-    [ reflexivity | simpl; rewrite (H l2 l3); reflexivity ].
-Qed.
-
-Lemma RList_P28 : forall l:Rlist, cons_Rlist l nil = l.
-Proof.
-  simple induction l;
-    [ reflexivity | intros; simpl; rewrite H; reflexivity ].
-Qed.
-
 Lemma RList_P29 :
-  forall (l2 l1:Rlist) (i:nat),
-    (Rlength l1 <= i)%nat ->
-    (i < Rlength (cons_Rlist l1 l2))%nat ->
-    pos_Rl (cons_Rlist l1 l2) i = pos_Rl l2 (i - Rlength l1).
+  forall (l2 l1:list R) (i:nat),
+    (length l1 <= i)%nat ->
+    (i < length (app l1 l2))%nat ->
+    pos_Rl (app l1 l2) i = pos_Rl l2 (i - length l1).
 Proof.
-  simple induction l2.
-  intros; rewrite RList_P28 in H0; elim (lt_irrefl _ (le_lt_trans _ _ _ H H0)).
+  induction l2 as [ | r r0 H].
+  intros; rewrite app_nil_r in H0; elim (lt_irrefl _ (le_lt_trans _ _ _ H H0)).
   intros;
-    replace (cons_Rlist l1 (cons r r0)) with
-    (cons_Rlist (cons_Rlist l1 (cons r nil)) r0).
+    replace (app l1 (r :: r0)) with
+    (app (app l1 (r :: nil)) r0).
   inversion H0.
   rewrite <- minus_n_n; simpl; rewrite RList_P26.
-  clear l2 r0 H i H0 H1 H2; induction  l1 as [| r0 l1 Hrecl1].
+  clear r0 H i H0 H1 H2; induction  l1 as [| r0 l1 Hrecl1].
   reflexivity.
   simpl; assumption.
-  rewrite RList_P23; rewrite plus_comm; simpl; apply lt_n_Sn.
-  replace (S m - Rlength l1)%nat with (S (S m - S (Rlength l1))).
+  rewrite app_length; rewrite plus_comm; simpl; apply lt_n_Sn.
+  replace (S m - length l1)%nat with (S (S m - S (length l1))).
   rewrite H3; simpl;
-    replace (S (Rlength l1)) with (Rlength (cons_Rlist l1 (cons r nil))).
-  apply (H (cons_Rlist l1 (cons r nil)) i).
-  rewrite RList_P23; rewrite plus_comm; simpl; rewrite <- H3;
+    replace (S (length l1)) with (length (app l1 (r :: nil))).
+  apply (H (app l1 (r :: nil)) i).
+  rewrite app_length; rewrite plus_comm; simpl; rewrite <- H3;
     apply le_n_S; assumption.
-  repeat rewrite RList_P23; simpl; rewrite RList_P23 in H1;
-    rewrite plus_comm in H1; simpl in H1; rewrite (plus_comm (Rlength l1));
+  repeat rewrite app_length; simpl; rewrite app_length in H1;
+    rewrite plus_comm in H1; simpl in H1; rewrite (plus_comm (length l1));
       simpl; rewrite plus_comm; apply H1.
-  rewrite RList_P23; rewrite plus_comm; reflexivity.
-  change (S (m - Rlength l1) = (S m - Rlength l1)%nat);
+  rewrite app_length; rewrite plus_comm; reflexivity.
+  change (S (m - length l1) = (S m - length l1)%nat);
     apply minus_Sn_m; assumption.
-  replace (cons r r0) with (cons_Rlist (cons r nil) r0);
-  [ symmetry ; apply RList_P27 | reflexivity ].
+  replace (r :: r0) with (app (r :: nil) r0);
+  [ symmetry ; apply app_assoc | reflexivity ].
 Qed.
+
+#[deprecated(since="8.12",note="use List.cons instead")]
+Notation cons := List.cons.
+
+#[deprecated(since="8.12",note="use List.nil instead")]
+Notation nil := List.nil.

--- a/theories/Reals/RiemannInt.v
+++ b/theories/Reals/RiemannInt.v
@@ -464,7 +464,7 @@ Proof.
                       elim (Rlt_irrefl _ H7) ] ].
 Qed.
 
-Fixpoint SubEquiN (N:nat) (x y:R) (del:posreal) : Rlist :=
+Fixpoint SubEquiN (N:nat) (x y:R) (del:posreal) : list R :=
   match N with
     | O => cons y nil
     | S p => cons x (SubEquiN p (x + del) y del)
@@ -473,7 +473,7 @@ Fixpoint SubEquiN (N:nat) (x y:R) (del:posreal) : Rlist :=
 Definition max_N (a b:R) (del:posreal) (h:a < b) : nat :=
   let (N,_) := maxN del h in N.
 
-Definition SubEqui (a b:R) (del:posreal) (h:a < b) : Rlist :=
+Definition SubEqui (a b:R) (del:posreal) (h:a < b) : list R :=
   SubEquiN (S (max_N del h)) a b del.
 
 Lemma Heine_cor1 :
@@ -566,25 +566,25 @@ Qed.
 
 Lemma SubEqui_P2 :
   forall (a b:R) (del:posreal) (h:a < b),
-    pos_Rl (SubEqui del h) (pred (Rlength (SubEqui del h))) = b.
+    pos_Rl (SubEqui del h) (pred (length (SubEqui del h))) = b.
 Proof.
   intros; unfold SubEqui; destruct (maxN del h)as (x,_).
     cut
       (forall (x:nat) (a:R) (del:posreal),
         pos_Rl (SubEquiN (S x) a b del)
-        (pred (Rlength (SubEquiN (S x) a b del))) = b);
+        (pred (length (SubEquiN (S x) a b del))) = b);
       [ intro; apply H
         | simple induction x0;
           [ intros; reflexivity
             | intros;
               change
                 (pos_Rl (SubEquiN (S n) (a0 + del0) b del0)
-                  (pred (Rlength (SubEquiN (S n) (a0 + del0) b del0))) = b)
+                  (pred (length (SubEquiN (S n) (a0 + del0) b del0))) = b)
                ; apply H ] ].
 Qed.
 
 Lemma SubEqui_P3 :
-  forall (N:nat) (a b:R) (del:posreal), Rlength (SubEquiN N a b del) = S N.
+  forall (N:nat) (a b:R) (del:posreal), length (SubEquiN N a b del) = S N.
 Proof.
   simple induction N; intros;
     [ reflexivity | simpl; rewrite H; reflexivity ].
@@ -605,7 +605,7 @@ Qed.
 
 Lemma SubEqui_P5 :
   forall (a b:R) (del:posreal) (h:a < b),
-    Rlength (SubEqui del h) = S (S (max_N del h)).
+    length (SubEqui del h) = S (S (max_N del h)).
 Proof.
   intros; unfold SubEqui; apply SubEqui_P3.
 Qed.
@@ -623,7 +623,7 @@ Proof.
   intros; unfold ordered_Rlist; intros; rewrite SubEqui_P5 in H;
     simpl in H; inversion H.
   rewrite (SubEqui_P6 del h (i:=(max_N del h))).
-  replace (S (max_N del h)) with (pred (Rlength (SubEqui del h))).
+  replace (S (max_N del h)) with (pred (length (SubEqui del h))).
   rewrite SubEqui_P2; unfold max_N; case (maxN del h) as (?&?&?); left;
     assumption.
   rewrite SubEqui_P5; reflexivity.
@@ -639,7 +639,7 @@ Qed.
 
 Lemma SubEqui_P8 :
   forall (a b:R) (del:posreal) (h:a < b) (i:nat),
-    (i < Rlength (SubEqui del h))%nat -> a <= pos_Rl (SubEqui del h) i <= b.
+    (i < length (SubEqui del h))%nat -> a <= pos_Rl (SubEqui del h) i <= b.
 Proof.
   intros; split.
   pattern a at 1; rewrite <- (SubEqui_P1 del h); apply RList_P5.
@@ -657,7 +657,7 @@ Lemma SubEqui_P9 :
     { g:StepFun a b |
       g b = f b /\
       (forall i:nat,
-        (i < pred (Rlength (SubEqui del h)))%nat ->
+        (i < pred (length (SubEqui del h)))%nat ->
         constant_D_eq g
         (co_interval (pos_Rl (SubEqui del h) i)
           (pos_Rl (SubEqui del h) (S i)))
@@ -713,7 +713,7 @@ Proof.
           a <= t <= b ->
           t = b \/
           (exists i : nat,
-            (i < pred (Rlength (SubEqui del H)))%nat /\
+            (i < pred (length (SubEqui del H)))%nat /\
             co_interval (pos_Rl (SubEqui del H) i) (pos_Rl (SubEqui del H) (S i))
             t)).
   intro; elim (H8 _ H7); intro.
@@ -722,7 +722,7 @@ Proof.
   elim H9; clear H9; intros I [H9 H10]; assert (H11 := H6 I H9 t H10);
     rewrite H11; left; apply H4.
   assumption.
-  apply SubEqui_P8; apply lt_trans with (pred (Rlength (SubEqui del H))).
+  apply SubEqui_P8; apply lt_trans with (pred (length (SubEqui del H))).
   assumption.
   apply lt_pred_n_n; apply neq_O_lt; red; intro; rewrite <- H12 in H9;
     elim (lt_n_O _ H9).
@@ -734,7 +734,7 @@ Proof.
     (t - pos_Rl (SubEqui del H) (max_N del H))) with t;
   [ idtac | ring ]; apply Rlt_le_trans with b.
   rewrite H14 in H12;
-    assert (H13 : S (max_N del H) = pred (Rlength (SubEqui del H))).
+    assert (H13 : S (max_N del H) = pred (length (SubEqui del H))).
   rewrite SubEqui_P5; reflexivity.
   rewrite H13 in H12; rewrite SubEqui_P2 in H12; apply H12.
   rewrite SubEqui_P6.
@@ -785,7 +785,7 @@ Proof.
   apply H5.
   assumption.
   inversion H7.
-  replace (S (max_N del H)) with (pred (Rlength (SubEqui del H))).
+  replace (S (max_N del H)) with (pred (length (SubEqui del H))).
   rewrite (SubEqui_P2 del H); elim H8; intros.
   elim H11; intro.
   assumption.
@@ -1753,7 +1753,7 @@ Proof.
   rewrite <- H5; elim (RList_P6 l); intros; apply H10.
   assumption.
   apply le_O_n.
-  apply lt_trans with (pred (Rlength l)); [ assumption | apply lt_pred_n_n ].
+  apply lt_trans with (pred (length l)); [ assumption | apply lt_pred_n_n ].
   apply neq_O_lt; intro; rewrite <- H12 in H6; discriminate.
   unfold Rmin; decide (Rle_dec a b) with H; reflexivity.
   assert (H11 : pos_Rl l (S i) <= b).
@@ -1960,7 +1960,7 @@ Proof.
   replace b with (Rmin b c).
   rewrite <- H5; elim (RList_P6 l1); intros; apply H10; try assumption.
   apply le_O_n.
-  apply lt_trans with (pred (Rlength l1)); try assumption; apply lt_pred_n_n;
+  apply lt_trans with (pred (length l1)); try assumption; apply lt_pred_n_n;
     apply neq_O_lt; red; intro; rewrite <- H12 in H6;
       discriminate.
   unfold Rmin; decide (Rle_dec b c) with Hyp2;
@@ -1991,7 +1991,7 @@ Proof.
   replace a with (Rmin a b).
   rewrite <- H5; elim (RList_P6 l1); intros; apply H11; try assumption.
   apply le_O_n.
-  apply lt_trans with (pred (Rlength l1)); try assumption; apply lt_pred_n_n;
+  apply lt_trans with (pred (length l1)); try assumption; apply lt_pred_n_n;
     apply neq_O_lt; red; intro; rewrite <- H13 in H6;
       discriminate.
   unfold Rmin; decide (Rle_dec a b) with Hyp1; reflexivity.
@@ -2018,7 +2018,7 @@ Proof.
   replace a with (Rmin a b).
   rewrite <- H5; elim (RList_P6 l1); intros; apply H11; try assumption.
   apply le_O_n.
-  apply lt_trans with (pred (Rlength l1)); try assumption; apply lt_pred_n_n;
+  apply lt_trans with (pred (length l1)); try assumption; apply lt_pred_n_n;
     apply neq_O_lt; red; intro; rewrite <- H13 in H6;
       discriminate.
   unfold Rmin; decide (Rle_dec a b) with Hyp1; reflexivity.
@@ -2037,7 +2037,7 @@ Proof.
   replace b with (Rmin b c).
   rewrite <- H5; elim (RList_P6 l1); intros; apply H10; try assumption.
   apply le_O_n.
-  apply lt_trans with (pred (Rlength l1)); try assumption; apply lt_pred_n_n;
+  apply lt_trans with (pred (length l1)); try assumption; apply lt_pred_n_n;
     apply neq_O_lt; red; intro; rewrite <- H12 in H6;
       discriminate.
   unfold Rmin; decide (Rle_dec b c) with Hyp2; reflexivity.

--- a/theories/Reals/Rtopology.v
+++ b/theories/Reals/Rtopology.v
@@ -12,6 +12,7 @@ Require Import Rbase.
 Require Import Rfunctions.
 Require Import Ranalysis1.
 Require Import RList.
+Require Import List.
 Require Import Classical_Prop.
 Require Import Classical_Pred_Type.
 Local Open Scope R_scope.
@@ -388,7 +389,7 @@ Record family : Type := mkfamily
 Definition family_open_set (f:family) : Prop := forall x:R, open_set (f x).
 
 Definition domain_finite (D:R -> Prop) : Prop :=
-  exists l : Rlist, (forall x:R, D x <-> In x l).
+  exists l : list R, (forall x:R, D x <-> In x l).
 
 Definition family_finite (f:family) : Prop := domain_finite (ind f).
 
@@ -669,7 +670,7 @@ Proof.
   intro H14; simpl in H14; unfold intersection_domain in H14;
     specialize H13 with x0; destruct H13 as (H13,H15);
     destruct (Req_dec x0 y0) as [H16|H16].
-  simpl; left; apply H16.
+  simpl; left. symmetry; apply H16.
   simpl; right; apply H13.
   simpl; unfold intersection_domain; unfold Db in H14;
     decompose [and or] H14.
@@ -678,8 +679,8 @@ Proof.
   intro H14; simpl in H14; destruct H14 as [H15|H15]; simpl;
     unfold intersection_domain.
   split.
-  apply (cond_fam f0); rewrite H15; exists b; apply H6.
-  unfold Db; right; assumption.
+  apply (cond_fam f0); rewrite <- H15; exists b; apply H6.
+  unfold Db; right; symmetry; assumption.
   simpl; unfold intersection_domain; elim (H13 x0).
   intros _ H16; assert (H17 := H16 H15); simpl in H17;
     unfold intersection_domain in H17; split.
@@ -750,15 +751,15 @@ Proof.
   intro H14; simpl in H14; unfold intersection_domain in H14;
     specialize (H13 x0); destruct H13 as (H13,H15);
     destruct (Req_dec x0 y0) as [Heq|Hneq].
-  simpl; left; apply Heq.
+  simpl; left; symmetry; apply Heq.
   simpl; right; apply H13; simpl;
     unfold intersection_domain; unfold Db in H14;
       decompose [and or] H14.
   split; assumption.
   elim Hneq; assumption.
   intros [H15|H15]. split.
-  apply (cond_fam f0); rewrite H15; exists m; apply H6.
-  unfold Db; right; assumption.
+  apply (cond_fam f0); rewrite <- H15; exists m; apply H6.
+  unfold Db; right; symmetry; assumption.
   elim (H13 x0); intros _ H16.
   assert (H17 := H16 H15).
   simpl in H17.
@@ -810,9 +811,10 @@ Proof.
   unfold family_finite; unfold domain_finite;
     exists (cons y0 nil); intro; split.
   simpl; unfold intersection_domain; intros (H3,H4).
-    unfold D' in H4; left; apply H4.
+    unfold D' in H4; left; symmetry; apply H4.
   simpl; unfold intersection_domain; intros [H4|[]].
-  split; [ rewrite H4; apply (cond_fam f0); exists a; apply H2 | apply H4 ].
+  split; [ rewrite <- H4; apply (cond_fam f0); exists a; apply H2 |
+           symmetry; apply H4 ].
   split; [ right; reflexivity | apply Hle ].
   apply compact_eqDom with (fun c:R => False).
   apply compact_EMP.


### PR DESCRIPTION
This is a first step, ideally In should be List.In, Rlength should be
 List.length, etc.

Nameless intros were only transformed into named intros where necessary
for the proof to resist the change of default names.  Only one instance
of generated name was being re-used in a modified tactic.  In this case,
the culprit name was added explicitely in the corresponding intro.

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** documentation / bug fix / feature / performance / infrastructure.


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes #6607
Fixes / closes #11396


<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [ ] Added / updated test-suite
<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [ ] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
