### PR TITLE
[mltop] Remove error handling hacks in favor of default methods.

### DIFF
--- a/topbin/coqtop_byte_bin.ml
+++ b/topbin/coqtop_byte_bin.ml
@@ -8,6 +8,14 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
+(* We register this handler for lower-level toplevel loading code *)
+let _ = CErrors.register_handler (function
+    | Symtable.Error e ->
+      Pp.str (Format.asprintf "%a" Symtable.report_error e)
+    | _ ->
+      raise CErrors.Unhandled
+  )
+
 let drop_setup () =
   begin try
     (* Enable rectypes in the toplevel if it has the directive #rectypes *)

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -1364,7 +1364,6 @@ let explain_exn_default = function
   | Sys_error msg -> hov 0 (str "System error: " ++ quote (str msg))
   | Out_of_memory -> hov 0 (str "Out of memory.")
   | Stack_overflow -> hov 0 (str "Stack overflow.")
-  | Dynlink.Error e -> hov 0 (str "Dynlink error: " ++ str Dynlink.(error_message e))
   | CErrors.Timeout -> hov 0 (str "Timeout!")
   | Sys.Break -> hov 0 (fnl () ++ str "User interrupt.")
   (* Otherwise, not handled here *)


### PR DESCRIPTION
We don't need to handle `Dynlink` errors specially anymore.