### PR TITLE
Remove the CoqIDE "Revert all Buffers" command.

### DIFF
--- a/doc/changelog/09-coqide/11415-remove-ide-revert-all-buffers.rst
+++ b/doc/changelog/09-coqide/11415-remove-ide-revert-all-buffers.rst
@@ -1,0 +1,4 @@
+- **Removed:**
+  Removed the "Revert all buffers" command from CoqIDE which had been broken for a long time
+  (`#11415 <https://github.com/coq/coq/pull/11415>`_,
+  by Pierre-Marie Pédrot).

--- a/ide/coqide.ml
+++ b/ide/coqide.ml
@@ -996,8 +996,6 @@ let build_ui () =
     item "Save" ~callback:(File.save ~parent:w) ~stock:`SAVE ~tooltip:"Save current buffer";
     item "Save as" ~label:"S_ave as" ~stock:`SAVE_AS ~callback:(File.saveas ~parent:w);
     item "Save all" ~label:"Sa_ve all" ~callback:File.saveall;
-    item "Revert all buffers" ~label:"_Revert all buffers"
-      ~callback:(File.revert_all ~parent:w) ~stock:`REVERT_TO_SAVED;
     item "Close buffer" ~label:"_Close buffer" ~stock:`CLOSE
       ~callback:(File.close_buffer ~parent:w) ~tooltip:"Close current buffer";
     item "Print..." ~label:"_Print..."

--- a/ide/coqide_ui.ml
+++ b/ide/coqide_ui.ml
@@ -36,7 +36,6 @@ let init () =
 \n    <menuitem action='Save' />\
 \n    <menuitem action='Save as' />\
 \n    <menuitem action='Save all' />\
-\n    <menuitem action='Revert all buffers' />\
 \n    <menuitem action='Close buffer' />\
 \n    <menuitem action='Print...' />\
 \n    <menu action='Export to'>\


### PR DESCRIPTION
Fixes #3907: CoqIDE File->Revert all buffers does not work.

- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
