### PR TITLE
Include all relevant paths in call to ocamldebug (dune)

### DIFF
--- a/dev/dune-dbg.in
+++ b/dev/dune-dbg.in
@@ -16,4 +16,11 @@ esac
 
 emacs="${INSIDE_EMACS:+-emacs}"
 
-ocamldebug $emacs $(ocamlfind query -recursive -i-format coq.top_printers) -I +threads -I dev $exe "$@"
+# Note: when doing a local dune build, ocamlfind won't work unless you do
+# export OCAMLPATH=<coq_root>/_build/install/default/lib
+# dune exports this automatically to child processes (e.g. this script).
+
+list_coq_packages="$(ocamlfind list | sed 's/ *(.*)//' | grep '^coq')"
+list_coq_include_args=$(ocamlfind query -recursive -i-format $list_coq_packages | sort | uniq)
+
+ocamldebug $emacs $list_coq_include_args -I +threads -I dev $exe "$@"


### PR DESCRIPTION
The dune debug wrapper `dev/dune-dbg.in` does not pass all relevant paths for coq modules to ocamldebug, so that ocamldebug cannot find some modules. This patch uses ocamlfind first to find all coq packages and then in a second step creates `-I` options for all of them.