### PR TITLE
Miscellaneous typos

### DIFF
--- a/doc/sphinx/addendum/universe-polymorphism.rst
+++ b/doc/sphinx/addendum/universe-polymorphism.rst
@@ -529,8 +529,8 @@ sections, except in the following ways:
        Polymorphic Universe i.
        Fail Constraint i = i.
 
-  This includes constraints implictly declared by commands such as
-  :cmd:`Variable`, which may as a such need to be used with universe
+  This includes constraints implicitly declared by commands such as
+  :cmd:`Variable`, which may need to be used with universe
   polymorphism activated (locally by attribute or globally by option):
 
   .. coqtop:: all

--- a/kernel/univ.mli
+++ b/kernel/univ.mli
@@ -322,7 +322,7 @@ val in_punivs : 'a -> 'a puniverses
 val eq_puniverses : ('a -> 'a -> bool) -> 'a puniverses -> 'a puniverses -> bool
 
 (** A vector of universe levels with universe Constraint.t,
-    representiong local universe variables and associated Constraint.t *)
+    representing local universe variables and associated Constraint.t *)
 
 module UContext :
 sig

--- a/tactics/declare.ml
+++ b/tactics/declare.ml
@@ -362,7 +362,7 @@ let inVariable : unit -> obj =
     classify_function = (fun () -> Dispose)}
 
 let declare_variable ~name ~kind d =
-  (* Constr raisonne sur les noms courts *)
+  (* Variables are distinguished by only short names *)
   if Decls.variable_exists name then
     raise (AlreadyDeclared (None, name));
 

--- a/vernac/declareUniv.ml
+++ b/vernac/declareUniv.ml
@@ -72,7 +72,7 @@ let declare_univ_binders gr pl =
         CErrors.anomaly ~label:"declare_univ_binders" Pp.(str "declare_univ_binders on variable " ++ Id.print id ++ str".")
       | ConstructRef _ ->
         CErrors.anomaly ~label:"declare_univ_binders"
-          Pp.(str "declare_univ_binders on an constructor reference")
+          Pp.(str "declare_univ_binders on a constructor reference")
     in
     let univs = Id.Map.fold (fun id univ univs ->
         match Univ.Level.name univ with


### PR DESCRIPTION
**Kind:** typos

These are a few typos found in passing (in doc, comments, or anomaly message).