### PR TITLE
[zify] quick fix of #11191

### DIFF
--- a/doc/changelog/04-tactics/11430-fix-lia-regression.rst
+++ b/doc/changelog/04-tactics/11430-fix-lia-regression.rst
@@ -1,0 +1,5 @@
+- **Fixed**
+  For compatibility reasons, :tacn:`zify` does not support `Z.pow_pos` by default.
+  It can be enabled by loading explicitly the module `ZifyPow`.
+  (`#11430 <https://github.com/coq/coq/pull/11430>`_ by Frédéric Besson
+  fixes `#11191 <https://github.com/coq/coq/issues/11191>`_).

--- a/doc/stdlib/hidden-files
+++ b/doc/stdlib/hidden-files
@@ -45,6 +45,7 @@ plugins/micromega/VarMap.v
 plugins/micromega/ZCoeff.v
 plugins/micromega/ZMicromega.v
 plugins/micromega/ZifyInst.v
+plugins/micromega/ZifyPow.v
 plugins/micromega/ZifyBool.v
 plugins/micromega/ZifyComparison.v
 plugins/micromega/ZifyClasses.v

--- a/plugins/micromega/ZifyInst.v
+++ b/plugins/micromega/ZifyInst.v
@@ -390,9 +390,6 @@ Instance Op_Z_sgn : UnOp Z.sgn :=
   { TUOp := Z.sgn ; TUOpInj := ltac:(reflexivity) }.
 Add UnOp Op_Z_sgn.
 
-Instance Op_Z_pow_pos : BinOp Z.pow_pos :=
-  { TBOp := Z.pow ; TBOpInj := ltac:(reflexivity) }.
-Add BinOp Op_Z_pow_pos.
 
 Lemma of_nat_to_nat_eq : forall x,  Z.of_nat (Z.to_nat x) = Z.max 0 x.
 Proof.

--- a/test-suite/micromega/bug_11191.v
+++ b/test-suite/micromega/bug_11191.v
@@ -1,0 +1,11 @@
+Require Import ZArith Lia.
+
+Goal forall p, (0 < Z.pos (p ^ 2))%Z.
+  intros.
+  lia.
+Qed.
+
+Goal forall p n, (0 < Z.pos (p ^ n))%Z.
+  intros.
+  lia.
+Qed.


### PR DESCRIPTION
This PR solves regressions of lia reported by #11191 regarding Z.pow.

The regression is due to the fact that zify is now able to deal with Pos.pow and therefore some positivity constraints need to be added explicitly.

This is a temporary solution for 8.11 (see https://github.com/coq/coq/pull/11362 for a comprehensive solution).

Here, we simply move the support for `Z.pow_pos` to a separate file that is not loaded by default. 

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:**  bug fix 


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes #11191 


<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [x] Added test-suite
<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->

- [x] Entry added in the changelog 
