### PR TITLE
More portable C flags

### DIFF
--- a/configure.ml
+++ b/configure.ml
@@ -923,7 +923,7 @@ let datadir,datadirsuffix = let (_,_,d,s) = select "DATADIR" in d,s
 
 (** * CC runtime flags *)
 
-let cflags_dflt = "-Wall -Wno-unused -g -O2 -fexcess-precision=standard"
+let cflags_dflt = "-Wall -Wno-unused -g -O2 -std=c99 -fasm"
 
 let cflags_sse2 = "-msse2 -mfpmath=sse"
 


### PR DESCRIPTION
Use -std=c99 instead of the GCC argument -fexcess-precision=standard
This requires the -fasm as the VM is using the asm GNU extension
(also implemented by other compilers).

These flags should be more portable accross C compilers.

Fixes #11426 
