### PR TITLE
Add module ZifyPow to avoid compatibility issue with 8.11.

### DIFF
--- a/doc/changelog/04-tactics/11362-micromega-fix-11191.rst
+++ b/doc/changelog/04-tactics/11362-micromega-fix-11191.rst
@@ -1,5 +1,8 @@
 - **Fixed:**
-  Regression of :tacn:`lia` due to more powerful :tacn:`zify`
+  :tacn:`zify` now handles :g:`Z.pow_pos` by default.
+  In Coq 8.11, this was the case only when loading module
+  :g:`ZifyPow` because this triggered a regression of :tacn:`lia`.
+  The regression is now fixed, and the module kept only for compatibility
   (`#11362 <https://github.com/coq/coq/pull/11362>`_,
   fixes `#11191 <https://github.com/coq/coq/issues/11191>`_,
   by Frédéric Besson).

--- a/doc/stdlib/hidden-files
+++ b/doc/stdlib/hidden-files
@@ -50,6 +50,7 @@ theories/micromega/ZifyInst.v
 theories/micromega/ZifyBool.v
 theories/micromega/ZifyComparison.v
 theories/micromega/ZifyClasses.v
+theories/micromega/ZifyPow.v
 theories/micromega/Zify.v
 theories/nsatz/Nsatz.v
 theories/omega/Omega.v

--- a/theories/micromega/ZifyPow.v
+++ b/theories/micromega/ZifyPow.v
@@ -1,0 +1,1 @@
+Require Export ZifyInst.


### PR DESCRIPTION
**Kind:** documentation / bug fix / compatibility.

`ZifyPow` was introduced in 8.11 as a temporary workaround, but this module still has to exist in 8.12+ for compatibility.

Also tweak the changelog entry to explain what changed between 8.11 and 8.12.

@fajb This PR is less urgent to review than #11440.