### PR TITLE
Clear patches folder before each windows build run

### DIFF
--- a/dev/build/windows/MakeCoq_MinGW.bat
+++ b/dev/build/windows/MakeCoq_MinGW.bat
@@ -420,6 +420,7 @@ copy "%BATCHDIR%\configure_profile.sh" "%CYGWIN_INSTALLDIR_WFMT%\var\tmp" || GOT
 ECHO ========== BUILD COQ ==========
 
 MKDIR "%CYGWIN_INSTALLDIR_WFMT%\build"
+RMDIR /S /Q "%CYGWIN_INSTALLDIR_WFMT%\build\patches"
 MKDIR "%CYGWIN_INSTALLDIR_WFMT%\build\patches"
 
 COPY "%BATCHDIR%\makecoq_mingw.sh" "%CYGWIN_INSTALLDIR_WFMT%\build" || GOTO ErrorExit


### PR DESCRIPTION
This PR is a "forward-port" of a part of the 8.11 picking PR #11393.

Thsi patch changes the windows build such that the patches folder is cleared before patches are copied. Without this removed patches remain in place during incremental builds. For full builds (as in CI or releases) this has no effect.