### PR TITLE
Changed Gitlab CI runner tag for Windows to windows-inria

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -234,7 +234,7 @@ before_script:
     expire_in: 1 week
   dependencies: []
   tags:
-    - windows
+    - windows-inria
   before_script: []
   script:
     - call dev/ci/gitlab.bat


### PR DESCRIPTION
Since Gitlab started to have their own free runners with tag "windows" and since these are not compatible with our scripts, we had to change the tag for the INRIA runners to "windows-inria". This change adjusts the `.gitlab-ci.yml` file accordingly.