### PR TITLE
Temporarily remove Menhirlib from built addons

### DIFF
--- a/dev/build/windows/makecoq_mingw.sh
+++ b/dev/build/windows/makecoq_mingw.sh
@@ -1765,7 +1765,6 @@ function make_addon_menhirlib {
 function make_addon_compcert {
   installer_addon_dependency_beg compcert
   make_menhir
-  make_addon_menhirlib
   installer_addon_dependency_end
   # Temporary hack for 8.11. See ci-basic-overlays.h
   compcert_CI_REF=v3.6

--- a/dev/ci/gitlab.bat
+++ b/dev/ci/gitlab.bat
@@ -47,7 +47,6 @@ IF "%WINDOWS%" == "enabled_all_addons" (
     -addon=mtac2 ^
     -addon=mathcomp ^
     -addon=menhir ^
-    -addon=menhirlib ^
     -addon=compcert ^
     -addon=extlib ^
     -addon=quickchick ^


### PR DESCRIPTION
Menhirlib was moved to the Menhir repo upstream. Menhirlib is not
actually needed to build CompCert, as it embarks a copy of it.