### PR TITLE
Small API additions to kernel/univ

### DIFF
--- a/kernel/uGraph.ml
+++ b/kernel/uGraph.ml
@@ -128,7 +128,7 @@ let enforce_leq_alg u v g =
          | exception (UniverseInconsistency _ as e) -> Inr e)
   in
   (* max(us) <= max(vs) <-> forall u in us, exists v in vs, u <= v *)
-  let c = Universe.map (fun u -> Universe.map (fun v -> (u,v)) v) u in
+  let c = List.map (fun u -> List.map (fun v -> (u,v)) (Universe.repr v)) (Universe.repr u) in
   let c = List.cartesians enforce_one (Inl (Constraint.empty,g)) c in
   (* We pick a best constraint: smallest number of constraints, not an error if possible. *)
   let order x y = match x, y with

--- a/kernel/univ.mli
+++ b/kernel/univ.mli
@@ -16,6 +16,7 @@ sig
     type t
 
     val make : Names.DirPath.t -> int -> t
+    val repr : t -> Names.DirPath.t * int
     val equal : t -> t -> bool
     val hash : t -> int
     val compare : t -> t -> int
@@ -138,8 +139,10 @@ sig
 
   val exists : (Level.t * int -> bool) -> t -> bool
   val for_all : (Level.t * int -> bool) -> t -> bool
+  val repr : t -> (Level.t * int) list
 
-  val map : (Level.t * int -> 'a) -> t -> 'a list
+  module Set : CSet.S with type elt  = t
+  module Map : CMap.ExtS with type key = t and module Set := Set
 
 end
 

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -696,7 +696,7 @@ let detype_universe sigma u =
       if Univ.Level.is_set l then GSet else
       GType (hack_qualid_of_univ_level sigma l) in
     (s, n) in
-  Univ.Universe.map fn u
+  List.map fn (Univ.Universe.repr u)
 
 let detype_sort sigma = function
   | SProp -> UNamed [GSProp,0]


### PR DESCRIPTION
- allow viewing the internal representation of uglobal and universe
  (with universe, this replaces the "map" function. I kept exists and
  for_all as they felt somewhat convenient)
- add universe set and map modules (currently unused but they're natural)
