### PR TITLE
checkdeps.py: add missing dep & report deps all at once

### DIFF
--- a/doc/tools/coqrst/checkdeps.py
+++ b/doc/tools/coqrst/checkdeps.py
@@ -37,3 +37,8 @@ try:
     import bs4
 except:
     missing_dep('beautifulsoup4')
+
+try:
+    import sphinxcontrib.bibtex
+except:
+    missing_dep('sphinxcontrib-bibtex')

--- a/doc/tools/coqrst/checkdeps.py
+++ b/doc/tools/coqrst/checkdeps.py
@@ -10,13 +10,20 @@
 from __future__ import print_function
 import sys
 
+missing_deps = []
+
 def eprint(*args, **kwargs):
     print(*args, file=sys.stderr, **kwargs)
 
 def missing_dep(dep):
-    eprint('Cannot find %s (needed to build documentation)' % dep)
-    eprint('You can run `pip3 install %s` to install it.' % dep)
-    sys.exit(1)
+    missing_deps.append(dep)
+
+def report_missing_deps():
+    if len(missing_deps) > 0:
+        deps = " ".join(missing_deps)
+        eprint('Cannot find package(s) `%s` (needed to build documentation)' % deps)
+        eprint('You can run `pip3 install %s` to install it/them.' % deps)
+        sys.exit(1)
 
 try:
     import sphinx_rtd_theme
@@ -42,3 +49,5 @@ try:
     import sphinxcontrib.bibtex
 except:
     missing_dep('sphinxcontrib-bibtex')
+
+report_missing_deps()


### PR DESCRIPTION
**Kind:** infrastructure.

Beware my Python is awful; I tested this manually.

Sample output:
```
$ python3 doc/tools/coqrst/checkdeps.py
Cannot find package(s) `antlr4-python3-runtime sphinxcontrib-bibtex` (needed to build documentation)
You can run `pip3 install antlr4-python3-runtime sphinxcontrib-bibtex` to install it/them.
```