### PR TITLE
[doc] fix typo & update release-process.md for opam/docker packaging

### DIFF
--- a/dev/doc/release-process.md
+++ b/dev/doc/release-process.md
@@ -127,9 +127,9 @@ in time.
 - [ ] Send an e-mail on Coqdev announcing that the tag has been put so that
   package managers can start preparing package updates (including a
   `coq-bignums` compatible version).
-- [ ] Ping `@erikmd` to update the Docker images in `coqorg/coq`
-  (requires `coq-bignums` in `extra-dev` for a beta / in `released`
-  for a final release).
+- [ ] When opening the corresponding PR for `coq` in the opam repository ([`coq/opam-coq-archive`](https://github.com/coq/opam-coq-archive) or [`ocaml/opam-repository`](https://github.com/ocaml/opam-repository)),
+  the package managers can Cc `@erikmd` to request that he prepare the necessary configuration for the Docker release in [`coqorg/coq`](https://hub.docker.com/r/coqorg/coq)
+  (namely, he'll need to make sure a `coq-bignums` opam package is available in [`extra-dev`](https://github.com/coq/opam-coq-archive/tree/master/extra-dev), respectively [`released`](https://github.com/coq/opam-coq-archive/tree/master/released), so the Docker image gathering `coq` and `coq-bignums` can be built).
 - [ ] Draft a release on GitHub.
 - [ ] Get `@maximedenes` to sign the Windows and MacOS packages and
   upload them on GitHub.

--- a/dev/doc/release-process.md
+++ b/dev/doc/release-process.md
@@ -127,11 +127,11 @@ in time.
 - [ ] Send an e-mail on Coqdev announcing that the tag has been put so that
   package managers can start preparing package updates (including a
   `coq-bignums` compatible version).
-- [ ] Ping **@erikmd** to update the Docker images in `coqorg/coq`
+- [ ] Ping `@erikmd` to update the Docker images in `coqorg/coq`
   (requires `coq-bignums` in `extra-dev` for a beta / in `released`
   for a final release).
 - [ ] Draft a release on GitHub.
-- [ ] Get **@maximedenes** to sign the Windows and MacOS packages and
+- [ ] Get `@maximedenes` to sign the Windows and MacOS packages and
   upload them on GitHub.
 - [ ] Prepare a page of news on the website with the link to the GitHub release
   (see [coq/www#63](https://github.com/coq/www/pull/63)).
@@ -139,8 +139,6 @@ in time.
   *TODO: setup some continuous deployment for this.*
 - [ ] Merge the website update, publish the release
   and send announcement e-mails.
-- [ ] Ping **@Zimmi48** to publish a new version on Zenodo.
-  *TODO: automate this.*
 - [ ] Close the milestone
 
 ## At the final release time ##
@@ -160,7 +158,10 @@ in time.
 
 Repeat the generic process documented above for all releases.
 
+Ping `@Zimmi48` to:
+
 - [ ] Switch the default version of the reference manual on the website.
+- [ ] Publish a new version on Zenodo.
 
 ## At the patch-level release time ##
 

--- a/test-suite/README.md
+++ b/test-suite/README.md
@@ -67,7 +67,7 @@ See [`test-suite/Makefile`](Makefile) for more information.
 ## Adding a test
 
 Regression tests for closed bugs should be added to
-[`bugs/closed`](bugs/closed), as `1234.v` where `1234` is the bug number.
+[`bugs/closed`](bugs/closed), as `bug_1234.v` where `1234` is the bug number.
 Files in this directory are tested for successful compilation.
 When you fix a bug, you should usually add a regression test here as well.
 


### PR DESCRIPTION
**Kind:** documentation

Just a change in `test-suite/README.md` (that was missing in https://github.com/coq/coq/pull/8630) and a rework of one item in `dev/doc/release-process.md`, adding hyperlinks for completeness.

Depends-on: PR https://github.com/coq/coq/pull/11450