### PR TITLE
Remove unused CEphemeron.iter_opt, cleanup comments

### DIFF
--- a/clib/cEphemeron.ml
+++ b/clib/cEphemeron.ml
@@ -103,8 +103,4 @@ let default (typ, boxkey) default =
   try (EHashtbl.find values boxkey).get typ
   with Not_found -> default
 
-let iter_opt (typ, boxkey) f =
-  try f ((EHashtbl.find values boxkey).get typ)
-  with Not_found -> ()
-
 let clean () = EHashtbl.clean values

--- a/clib/cEphemeron.mli
+++ b/clib/cEphemeron.mli
@@ -43,12 +43,12 @@ type 'a key
 
 val create : 'a -> 'a key
 
-(* May raise InvalidKey *)
 exception InvalidKey
-val get : 'a key -> 'a
 
-(* These never fail. *)
+val get : 'a key -> 'a
+(** May raise InvalidKey *)
+
 val default : 'a key -> 'a -> 'a
-val iter_opt : 'a key -> ('a -> unit) -> unit
+(** Never fails. *)
 
 val clean : unit -> unit


### PR DESCRIPTION
iter_opt is suspicious since it catched Not_found from the passed closure, but rather than changing it we may as well remove it.