### PR TITLE
Disable warning 40

### DIFF
--- a/configure.ml
+++ b/configure.ml
@@ -610,6 +610,7 @@ let camltag = match caml_version_list with
     4: fragile pattern matching: too common in the code and too annoying to avoid in general
     9: missing fields in a record pattern: too common in the code and not worth the bother
     27: innocuous unused variable: innocuous
+    40: Constructor or label name used out of scope: counterproductive
     41: ambiguous constructor or label: too common
     42: disambiguated counstructor or label: too common
     44: "open" shadowing already defined identifier: too common, especially when some are aliases
@@ -617,7 +618,7 @@ let camltag = match caml_version_list with
     48: implicit elimination of optional arguments: too common
     58: "no cmx file was found in path": See https://github.com/ocaml/num/issues/9
 *)
-let coq_warnings = "-w +a-4-9-27-41-42-44-45-48-58"
+let coq_warnings = "-w +a-4-9-27-40-41-42-44-45-48-58"
 let coq_warn_error =
     if !prefs.warn_error
     then "-warn-error +a"

--- a/dune
+++ b/dune
@@ -1,9 +1,9 @@
 ; Default flags for all Coq libraries.
 (env
- (dev     (flags :standard -rectypes -w -9-27+40+60 \ -short-paths))
+ (dev     (flags :standard -rectypes -w -9-27+60 \ -short-paths))
  (release (flags :standard -rectypes)
           (ocamlopt_flags -O3 -unbox-closures))
- (ireport (flags :standard -rectypes -w -9-27-40+60)
+ (ireport (flags :standard -rectypes -w -9-27+60)
           (ocamlopt_flags :standard -O3 -unbox-closures -inlining-report)))
 
 ; Information about flags for release mode:


### PR DESCRIPTION
It keeps getting in my way and AFAICT it provides no benefit.
Disabling it while working on the lean importer was a great experience.
