### PR TITLE
[exn] remove `raise` taking optional exception information argument

### DIFF
--- a/clib/exninfo.ml
+++ b/clib/exninfo.ml
@@ -81,16 +81,6 @@ let iraise (e,i) =
   | Some bt ->
     Printexc.raise_with_backtrace e bt
 
-let raise ?info e = match info with
-| None ->
-  let () = Mutex.lock lock in
-  let id = Thread.id (Thread.self ()) in
-  let () = current := remove_assoc id !current in
-  let () = Mutex.unlock lock in
-  raise e
-| Some i ->
-  iraise (e,i)
-
 let find_and_remove () =
   let () = Mutex.lock lock in
   let id = Thread.id (Thread.self ()) in

--- a/clib/exninfo.mli
+++ b/clib/exninfo.mli
@@ -79,6 +79,3 @@ val capture : exn -> iexn
 
 val iraise : iexn -> 'a
 (** Raise the given enriched exception. *)
-
-val raise : ?info:info -> exn -> 'a
-(** Raise the given exception with additional information. *)

--- a/engine/logic_monad.ml
+++ b/engine/logic_monad.ml
@@ -83,7 +83,7 @@ struct
 
   (** [Pervasives.raise]. Except that exceptions are wrapped with
       {!Exception}. *)
-  let raise ?info = fun e -> (); fun () -> Exninfo.raise ?info (Exception e)
+  let raise (e, info) () = Exninfo.iraise (Exception e, info)
 
   (** [try ... with ...] but restricted to {!Exception}. *)
   let catch = fun s h -> ();
@@ -93,7 +93,8 @@ struct
         h (e, info) ()
 
   let read_line = fun () -> try read_line () with e ->
-    let (e, info) = CErrors.push e in raise ~info e ()
+    let (e, info) = CErrors.push e in
+    raise (e, info) ()
 
   let print_char = fun c -> (); fun () -> print_char c
 

--- a/engine/logic_monad.mli
+++ b/engine/logic_monad.mli
@@ -70,7 +70,7 @@ module NonLogical : sig
 
   (** [Pervasives.raise]. Except that exceptions are wrapped with
       {!Exception}. *)
-  val raise : ?info:Exninfo.info -> exn -> 'a t
+  val raise : Exninfo.iexn -> 'a t
 
   (** [try ... with ...] but restricted to {!Exception}. *)
   val catch : 'a t -> (Exninfo.iexn -> 'a t) -> 'a t

--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -937,7 +937,7 @@ let tclTIMEOUT n t =
           return (Util.Inr (Logic_monad.Tac_Timeout, info))
         | Logic_monad.TacticFailure e ->
           return (Util.Inr (e, info))
-        | e -> Logic_monad.NonLogical.raise ~info e
+        | e -> Logic_monad.NonLogical.raise (e, info)
       end
   end >>= function
     | Util.Inl (res,s,m,i) ->

--- a/ide/idetop.ml
+++ b/ide/idetop.ml
@@ -70,7 +70,7 @@ let ide_cmd_checks ~last_valid { CAst.loc; v } =
     with e ->
       let (e, info) = CErrors.push e in
       let info = Stateid.add info ~valid:last_valid Stateid.dummy in
-      Exninfo.raise ~info e
+      Exninfo.iraise (e, info)
   in
   if is_debug v.expr then
     user_error "Debug mode not available in the IDE"

--- a/user-contrib/Ltac2/tac2core.ml
+++ b/user-contrib/Ltac2/tac2core.ml
@@ -161,7 +161,7 @@ let set_bt info =
 let throw ?(info = Exninfo.null) e =
   set_bt info >>= fun info ->
   let info = Exninfo.add info fatal_flag () in
-  Proofview.tclLIFT (Proofview.NonLogical.raise ~info e)
+  Proofview.tclLIFT (Proofview.NonLogical.raise (e, info))
 
 let fail ?(info = Exninfo.null) e =
   set_bt info >>= fun info ->


### PR DESCRIPTION
This was redundant with `iraise`; exceptions in the logic monad now
are forced to attach `info` to `Proofview.NonLogical.raise`
