### PR TITLE
[opam] Don't disable native compute in opam.dev file

### DIFF
--- a/coq.opam
+++ b/coq.opam
@@ -28,7 +28,7 @@ depends: [
 ]
 
 build: [
-  [ "./configure" "-prefix" prefix "-native-compiler" "no" ]
+  [ "./configure" "-prefix" prefix ]
   [ "make" "-f" "Makefile.dune" "voboot" ]
   [ "dune" "build" "-p" name "-j" jobs ]
 ]


### PR DESCRIPTION
See discussion in https://github.com/coq/bignums/issues/26 and #11476

We still disable it in developer fast builds as the speed up is
considerable, it can be enabled by just calling `./configure`