### PR TITLE
[ci] [fiat-crypto] Use the pinned bedrock2

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -632,13 +632,11 @@ library:ci-fiat-crypto:
   stage: stage-4
   needs:
   - build:edge+flambda
-  - library:ci-bedrock2
   - library:ci-coqprime
   - plugin:ci-bignums
   - plugin:ci-rewriter
   dependencies:
   - build:edge+flambda
-  - library:ci-bedrock2
   - library:ci-coqprime
   - plugin:ci-rewriter
 

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -65,7 +65,7 @@ ci-math-classes: ci-bignums
 
 ci-corn: ci-math-classes
 
-ci-fiat-crypto: ci-bedrock2 ci-coqprime ci-rewriter
+ci-fiat-crypto: ci-coqprime ci-rewriter
 
 ci-simple-io: ci-ext-lib
 ci-quickchick: ci-ext-lib ci-simple-io

--- a/dev/ci/ci-fiat-crypto.sh
+++ b/dev/ci/ci-fiat-crypto.sh
@@ -9,11 +9,15 @@ git_download fiat_crypto
 # We need a larger stack size to not overflow ocamlopt+flambda when
 # building the executables.
 # c.f. https://github.com/coq/coq/pull/8313#issuecomment-416650241
+fiat_crypto_CI_STACKSIZE=32768
 
-fiat_crypto_CI_MAKE_ARGS="EXTERNAL_DEPENDENCIES=1"
+# fiat-crypto is not guaranteed to build with the latest version of
+# bedrock2, so we use the pinned version of bedrock2, but the external
+# version of other developments
+fiat_crypto_CI_MAKE_ARGS="EXTERNAL_REWRITER=1 EXTERNAL_COQPRIME=1"
 fiat_crypto_CI_TARGETS1="${fiat_crypto_CI_MAKE_ARGS} standalone-ocaml c-files rust-files printlite lite"
 fiat_crypto_CI_TARGETS2="${fiat_crypto_CI_MAKE_ARGS} all"
 
 ( cd "${CI_BUILD_DIR}/fiat_crypto" && git submodule update --init --recursive && \
-        ulimit -s 32768 && \
+        ulimit -s ${fiat_crypto_CI_STACKSIZE} && \
         make ${fiat_crypto_CI_TARGETS1} && make -j 1 ${fiat_crypto_CI_TARGETS2} )


### PR DESCRIPTION
Fiat-Crypto does not guarantee compatibility with the tip of bedrock2,
only with the pinned version, and bedrock2 is still relatively unstable.
So we make the CI not have Fiat-Crypto depend on bedrock2, and instead
use the pinned submodule, by using `EXTERNAL_REWRITER=1
EXTERNAL_COQPRIME=1` rather than `EXTERNAL_DEPENDENCIES=1`.

**Kind:** bug fix / infrastructure.

Fixes: the fact that fiat-crypto currently fails on the CI
