### PR TITLE
Warn about duplicate names in toplevel binders

### DIFF
--- a/test-suite/output/Naming.out
+++ b/test-suite/output/Naming.out
@@ -76,3 +76,24 @@ Warning: Ignoring implicit binder declaration in unexpected position.
 File "./output/Naming.v", line 112, characters 30-31:
 Warning: Ignoring implicit binder declaration in unexpected position.
 [unexpected-implicit-declaration,syntax]
+File "stdin", line 119, characters 23-24:
+Warning: x occurs twice in the same block of arguments eventually leading to
+ambiguities when referring to arguments by name. [distinct-name,syntax]
+File "stdin", line 120, characters 30-31:
+Warning: x occurs twice in the same block of arguments eventually leading to
+ambiguities when referring to arguments by name. [distinct-name,syntax]
+File "stdin", line 121, characters 38-39:
+Warning: x occurs twice in the same block of arguments eventually leading to
+ambiguities when referring to arguments by name. [distinct-name,syntax]
+File "stdin", line 123, characters 41-42:
+Warning: x occurs twice in the same block of arguments eventually leading to
+ambiguities when referring to arguments by name. [distinct-name,syntax]
+File "stdin", line 123, characters 77-78:
+Warning: x occurs twice in the same block of arguments eventually leading to
+ambiguities when referring to arguments by name. [distinct-name,syntax]
+File "stdin", line 126, characters 30-31:
+Warning: x occurs twice in the same block of arguments eventually leading to
+ambiguities when referring to arguments by name. [distinct-name,syntax]
+File "stdin", line 129, characters 58-59:
+Warning: x occurs twice in the same block of arguments eventually leading to
+ambiguities when referring to arguments by name. [distinct-name,syntax]

--- a/test-suite/output/Naming.v
+++ b/test-suite/output/Naming.v
@@ -112,3 +112,31 @@ Notation "∀ x .. y , P" := (forall x, .. (forall y, P) ..)
 Definition l1 := ∀ {x:nat} {y:nat}, x=0.
 
 End B.
+
+Module C.
+
+(* Check double occurrence *)
+Definition h1 (x:nat) (x:bool) := x.
+Definition h2 (x:nat) := fun (x:bool) => x.
+Definition h3 := fun (x:bool) => fun (x:nat) => x.
+
+Definition h4 : forall (x:bool), forall (x:nat), nat := fun (x:bool) => fun (x:nat) => x.
+  (* TODO: no need to warn on the "fun" since there is cast *)
+
+Fixpoint h5 (x:nat) y := fun (x:bool) => match y with 0 => 0 | S y => h5 0 y true end.
+
+Inductive I1 (x:nat) : forall x, Type := C1 : I1 x 0.
+Inductive I2 : nat -> nat -> Type := C2 (x:bool) : forall x, I2 x 0.
+
+Definition k1 := ex (fun x => ex (fun x => x=0) -> x=0).
+Definition k2 := exists x, (exists x, x=0) -> x=0.
+Axiom k3 : forall x, (forall x, x = 0) -> x=0.
+
+Notation "∀ x .. y , P" := (forall x, .. (forall y, P) ..)
+  (at level 200, x binder, y binder, right associativity,
+  format "'[  ' '[  ' ∀  x  ..  y ']' ,  '/' P ']'") : type_scope.
+
+(* TODO: recognize the redundancy *)
+Definition l1 := ∀ (x:nat) (x:nat), x=0.
+
+End C.

--- a/theories/FSets/FMapList.v
+++ b/theories/FSets/FMapList.v
@@ -450,7 +450,7 @@ Proof with auto with ordered_type.
 Qed.
 
 
-Lemma equal_2 : forall m (Hm:Sort m) m' (Hm:Sort m') cmp,
+Lemma equal_2 : forall m (Hm:Sort m) m' (Hm':Sort m') cmp,
   equal cmp m m' = true -> Equivb cmp m m'.
 Proof with auto with ordered_type.
  intros m Hm m' Hm' cmp; generalize Hm Hm'; clear Hm Hm'.

--- a/theories/FSets/FMapWeakList.v
+++ b/theories/FSets/FMapWeakList.v
@@ -614,7 +614,7 @@ Definition combine (m:t elt)(m':t elt') : t oee' :=
 
 Lemma fold_right_pair_NoDup :
   forall l r (Hl: NoDupA (eqk (elt:=oee')) l)
-    (Hl: NoDupA (eqk (elt:=oee')) r),
+    (Hr: NoDupA (eqk (elt:=oee')) r),
     NoDupA (eqk (elt:=oee')) (fold_right_pair (add (elt:=oee')) r l).
 Proof.
  induction l; simpl; auto.

--- a/theories/Numbers/Natural/Abstract/NIso.v
+++ b/theories/Numbers/Natural/Abstract/NIso.v
@@ -86,8 +86,8 @@ Local Notation h21 := Hom21.natural_isomorphism.
 
 Definition isomorphism (f1 : N1.t -> N2.t) (f2 : N2.t -> N1.t) : Prop :=
   Hom12.homomorphism f1 /\ Hom21.homomorphism f2 /\
-  forall n, N1.eq (f2 (f1 n)) n /\
-  forall n, N2.eq (f1 (f2 n)) n.
+  (forall n, N1.eq (f2 (f1 n)) n) /\
+  (forall n, N2.eq (f1 (f2 n)) n).
 
 Theorem iso_nat_iso : isomorphism h12 h21.
 Proof.


### PR DESCRIPTION
**Kind:** feature

This checks that toplevel names of a declaration (i.e. the names to which `Arguments` applies) are distinct. This is in particular to address #6785 (thus "closes #6785").

This is done at interpretation level but this is complicated and not working well in the presence of notations. I will probably move this to `impargs` once the cleaning done in #11272 is merged.

Note that it revealed two typos and an undetected incorrect parsing in the stdlib (parentheses were missing in `(forall n, N1.eq (f2 (f1 n)) n) /\ forall n, N2.eq (f1 (f2 n)) n` which was wrongly parsed as `forall n, (N1.eq (f2 (f1 n)) n /\ forall n, N2.eq (f1 (f2 n)) n)`).

Note also a case where control of names is difficult: in ``Definition foo `(some class with args) (H:T) := ...``), the `` `(...) `` is internally using a `H` which forces the later `H` to be renamed.

- [X] Added / updated test-suite
- [ ] Entry added in the changelog
