### PR TITLE
Test for #5617: Primitive projections confuse the termination checker.

### DIFF
--- a/test-suite/bugs/closed/bug_5617.v
+++ b/test-suite/bugs/closed/bug_5617.v
@@ -1,0 +1,8 @@
+Set Primitive Projections.
+Record T X := { F : X }.
+
+Fixpoint f (n : nat) : nat :=
+match n with
+| 0 => 0
+| S m => F _ {| F := f |} m
+end.


### PR DESCRIPTION
Fixes #5617.

As of 1c1c04d0e3e02ce461fb953f08e2d8c68e52ee63 the bug was already fixed.