### PR TITLE
add regression test for lia

### DIFF
--- a/test-suite/micromega/evars_loops_in_8_10_fixed_8_11.v
+++ b/test-suite/micromega/evars_loops_in_8_10_fixed_8_11.v
@@ -1,0 +1,4 @@
+Require Import Lia.
+Goal forall n (B: n >= 0), exists Goal1 Goal2 Goal3,
+  (0 * (Goal1 * Goal2 + Goal1) <> Goal3 * 0 * (Goal1 * S Goal2)).
+Proof. eexists _, _, _. Fail lia. Abort.


### PR DESCRIPTION
**Kind:** regression test. Minimized from frap.

Since the bug is not present in the latest release (just 8.10), I will not put more effort into tracking it down. A cursory search suggests it has not been reported.