### PR TITLE
Fix #11515: Ltac2 rewrite on wildcard.

### DIFF
--- a/test-suite/bugs/closed/bug_11515.v
+++ b/test-suite/bugs/closed/bug_11515.v
@@ -1,0 +1,7 @@
+Require Import Ltac2.Ltac2.
+
+Lemma foo :
+  True.
+Proof.
+  Fail rewrite _.
+Abort.

--- a/user-contrib/Ltac2/tac2tactics.ml
+++ b/user-contrib/Ltac2/tac2tactics.ml
@@ -33,6 +33,7 @@ let delayed_of_tactic tac env sigma =
   let _, pv = Proofview.init sigma [] in
   let name, poly = Id.of_string "ltac2_delayed", false in
   let c, pv, _, _ = Proofview.apply ~name ~poly env tac pv in
+  let _, sigma = Proofview.proofview pv in
   (sigma, c)
 
 let delayed_of_thunk r tac env sigma =


### PR DESCRIPTION
There was an evar leak due to an evarmap not being threaded correctly when computing open terms.

Fixes #11515