### PR TITLE
Remove many unsafe_type_of uses

### DIFF
--- a/plugins/firstorder/g_ground.mlg
+++ b/plugins/firstorder/g_ground.mlg
@@ -88,7 +88,7 @@ let gen_ground_tac flag taco ids bases =
         Proofview.Goal.enter begin fun gl ->
         let seq=empty_seq !ground_depth in
         let seq, sigma = extend_with_ref_list (pf_env gl) (project gl) ids seq in
-        let seq, sigma = extend_with_auto_hints (pf_env gl) (project gl) bases seq in
+        let seq, sigma = extend_with_auto_hints (pf_env gl) sigma bases seq in
         tclTHEN (Proofview.Unsafe.tclEVARS sigma) (k seq)
         end
       in

--- a/plugins/funind/functional_principles_proofs.ml
+++ b/plugins/funind/functional_principles_proofs.ml
@@ -1573,19 +1573,16 @@ let prove_principle_for_gen
         (List.rev_map (get_name %> Nameops.Name.get_id)
            (princ_info.args@princ_info.branches@princ_info.predicates@princ_info.params)
         );
-      (* observe_tac "" *) Proofview.V82.of_tactic (assert_by
-         (Name acc_rec_arg_id)
-         (mkApp (delayed_force acc_rel,[|input_type;relation;mkVar rec_arg_id|]))
-         (Proofview.V82.tactic prove_rec_arg_acc)
-      );
-(*       observe_tac "reverting" *) (revert (List.rev (acc_rec_arg_id::args_ids)));
-(*       (fun g -> observe (Printer.pr_goal (sig_it g) ++ fnl () ++  *)
-(*                         str "fix arg num" ++ int (List.length args_ids + 1) ); tclIDTAC g); *)
-      (* observe_tac "h_fix " *) (Proofview.V82.of_tactic (fix fix_id (List.length args_ids + 1)));
-(*       (fun g -> observe (Printer.pr_goal (sig_it g) ++ fnl() ++ pr_lconstr_env (pf_env g ) (pf_unsafe_type_of g (mkVar fix_id) )); tclIDTAC g); *)
+      Proofview.V82.of_tactic
+        (assert_by
+           (Name acc_rec_arg_id)
+           (mkApp (delayed_force acc_rel,[|input_type;relation;mkVar rec_arg_id|]))
+           (Proofview.V82.tactic prove_rec_arg_acc));
+      (revert (List.rev (acc_rec_arg_id::args_ids)));
+      (Proofview.V82.of_tactic (fix fix_id (List.length args_ids + 1)));
       h_intros (List.rev (acc_rec_arg_id::args_ids));
       Proofview.V82.of_tactic (Equality.rewriteLR (mkConst eq_ref));
-      (* observe_tac "finish" *) (fun gl' ->
+      (fun gl' ->
          let body =
            let _,args = destApp (project gl') (pf_concl gl') in
            Array.last args

--- a/plugins/funind/functional_principles_proofs.ml
+++ b/plugins/funind/functional_principles_proofs.ml
@@ -475,7 +475,7 @@ let clean_hyp_with_heq ptes_infos eq_hyps hyp_id env sigma =
       tclIDTAC
   in
   try
-    scan_type [] (Typing.unsafe_type_of env sigma (mkVar hyp_id)), [hyp_id]
+    scan_type [] (Typing.type_of_variable env hyp_id), [hyp_id]
   with TOREMOVE ->
     thin [hyp_id],[]
 
@@ -525,7 +525,7 @@ let treat_new_case ptes_infos nb_prod continue_tac term dyn_infos =
         tclMAP (fun id -> Proofview.V82.of_tactic (introduction id)) dyn_infos.rec_hyps;
         observe_tac "after_introduction" (fun g' ->
            (* We get infos on the equations introduced*)
-           let new_term_value_eq = pf_unsafe_type_of g' (mkVar heq_id) in
+           let new_term_value_eq = pf_get_hyp_typ g' heq_id in
            (* compute the new value of the body *)
            let new_term_value =
              match EConstr.kind (project g') new_term_value_eq with
@@ -849,7 +849,7 @@ let generalize_non_dep hyp g =
 (*   observe (str "rec id := " ++ Ppconstr.pr_id hyp); *)
   let hyps = [hyp] in
   let env = Global.env () in
-  let hyp_typ = pf_unsafe_type_of g (mkVar hyp) in
+  let hyp_typ = pf_get_hyp_typ g hyp in
   let to_revert,_ =
     let open Context.Named.Declaration in
     Environ.fold_named_context_reverse (fun (clear,keep) decl ->
@@ -1351,7 +1351,7 @@ let backtrack_eqs_until_hrec hrec eqs : tactic =
     let rewrite =
       tclFIRST (List.map (fun x -> Proofview.V82.of_tactic (Equality.rewriteRL x)) eqs )
     in
-    let _,hrec_concl  = decompose_prod (project gls) (pf_unsafe_type_of gls (mkVar hrec)) in
+    let _,hrec_concl  = decompose_prod (project gls) (pf_get_hyp_typ gls hrec) in
     let f_app = Array.last (snd (destApp (project gls) hrec_concl)) in
     let f =  (fst (destApp (project gls) f_app)) in
     let rec backtrack : tactic =

--- a/plugins/funind/functional_principles_proofs.ml
+++ b/plugins/funind/functional_principles_proofs.ml
@@ -536,22 +536,23 @@ let treat_new_case ptes_infos nb_prod continue_tac term dyn_infos =
                            );
                    anomaly (Pp.str "cannot compute new term value.")
            in
-         let fun_body =
-           mkLambda(make_annot Anonymous Sorts.Relevant,
-                    pf_unsafe_type_of g' term,
-                    Termops.replace_term (project g') term (mkRel 1) dyn_infos.info
-                   )
-         in
-         let new_body = pf_nf_betaiota g' (mkApp(fun_body,[| new_term_value |])) in
-         let new_infos =
-           {dyn_infos with
+           let g', termtyp = tac_type_of g' term in
+           let fun_body =
+             mkLambda(make_annot Anonymous Sorts.Relevant,
+                      termtyp,
+                      Termops.replace_term (project g') term (mkRel 1) dyn_infos.info
+                     )
+           in
+           let new_body = pf_nf_betaiota g' (mkApp(fun_body,[| new_term_value |])) in
+           let new_infos =
+             {dyn_infos with
               info = new_body;
               eq_hyps = heq_id::dyn_infos.eq_hyps
-           }
-         in
-         clean_goal_with_heq ptes_infos continue_tac new_infos  g'
-      )])
-    ]
+             }
+           in
+           clean_goal_with_heq ptes_infos continue_tac new_infos  g'
+          )])
+      ]
       g
 
 
@@ -633,7 +634,7 @@ let build_proof
                   let dyn_infos = {dyn_info' with info =
                       mkCase(ci,ct,t,cb)} in
                   let g_nb_prod = nb_prod (project g) (pf_concl g) in
-                  let type_of_term = pf_unsafe_type_of g t in
+                  let g, type_of_term = tac_type_of g t in
                   let term_eq =
                     make_refl_eq (Lazy.force refl_equal) type_of_term t
                   in

--- a/plugins/funind/gen_principle.ml
+++ b/plugins/funind/gen_principle.ml
@@ -993,7 +993,7 @@ let prove_fun_complete funcs graphs schemes lemmas_types_infos i : Tacmach.tacti
     (* We get the constant and the principle corresponding to this lemma *)
     let f = funcs.(i) in
     let graph_principle = Reductionops.nf_zeta (pf_env g) (project g) (EConstr.of_constr schemes.(i))  in
-    let princ_type = pf_unsafe_type_of g graph_principle in
+    let g, princ_type = tac_type_of g graph_principle in
     let princ_infos = Tactics.compute_elim_sig (project g) princ_type in
     (* Then we get the number of argument of the function
        and compute a fresh name for each of them
@@ -1210,7 +1210,7 @@ let make_scheme evd (fas : (Constr.pconstant * Sorts.family) list) : Evd.side_ef
   in
   let _ = evd := sigma in
   let l_schemes =
-    List.map (EConstr.of_constr %> Typing.unsafe_type_of env sigma %> EConstr.Unsafe.to_constr) schemes
+    List.map (EConstr.of_constr %> Retyping.get_type_of env sigma %> EConstr.Unsafe.to_constr) schemes
   in
   let i = ref (-1) in
   let sorts =
@@ -2051,7 +2051,7 @@ let build_case_scheme fa =
   let (sigma, scheme) =
       Indrec.build_case_analysis_scheme_default env sigma ind sf
   in
-  let scheme_type = EConstr.Unsafe.to_constr ((Typing.unsafe_type_of env sigma) (EConstr.of_constr scheme)) in
+  let scheme_type = EConstr.Unsafe.to_constr ((Retyping.get_type_of env sigma) (EConstr.of_constr scheme)) in
   let sorts =
     (fun (_,_,x) ->
        fst @@ UnivGen.fresh_sort_in_family x

--- a/plugins/funind/gen_principle.ml
+++ b/plugins/funind/gen_principle.ml
@@ -617,7 +617,7 @@ let prove_fun_correct evd funs_constr graphs_constr schemes lemmas_types_infos i
       let constructor_args g =
         List.fold_right
           (fun hid acc ->
-             let type_of_hid = pf_unsafe_type_of g (mkVar hid) in
+             let type_of_hid = pf_get_hyp_typ g hid in
              let sigma = project g in
              match EConstr.kind sigma type_of_hid with
              | Prod(_,_,t') ->
@@ -953,7 +953,7 @@ let rec reflexivity_with_destruct_cases g =
         match sc with
           None -> tclIDTAC g
         | Some id ->
-          match EConstr.kind (project g) (pf_unsafe_type_of g (mkVar id)) with
+          match EConstr.kind (project g) (pf_get_hyp_typ g id) with
           | App(eq,[|_;t1;t2|]) when EConstr.eq_constr (project g) eq eq_ind ->
             if Equality.discriminable (pf_env g) (project g) t1 t2
             then Proofview.V82.of_tactic (Equality.discrHyp id) g

--- a/plugins/funind/glob_term_to_relation.ml
+++ b/plugins/funind/glob_term_to_relation.ml
@@ -769,9 +769,7 @@ and build_entry_lc_from_case_term env sigma types funname make_discr patterns_to
                  let env_with_pat_ids = add_pat_variables sigma pat typ new_env in
                    List.fold_right
                      (fun id acc ->
-                        let typ_of_id =
-                          Typing.unsafe_type_of env_with_pat_ids (Evd.from_env env) (EConstr.mkVar id)
-                        in
+                        let typ_of_id = Typing.type_of_variable env_with_pat_ids id in
                         let raw_typ_of_id =
                           Detyping.detype Detyping.Now false Id.Set.empty
                             env_with_pat_ids (Evd.from_env env) typ_of_id
@@ -832,7 +830,7 @@ and build_entry_lc_from_case_term env sigma types funname make_discr patterns_to
                    (fun id  acc ->
                       if Id.Set.mem id this_pat_ids
                       then (Prod (Name id),
-                      let typ_of_id = Typing.unsafe_type_of new_env (Evd.from_env env) (EConstr.mkVar id) in
+                      let typ_of_id = Typing.type_of_variable new_env id in
                       let raw_typ_of_id =
                         Detyping.detype Detyping.Now false Id.Set.empty new_env (Evd.from_env env) typ_of_id
                       in

--- a/plugins/funind/glob_term_to_relation.ml
+++ b/plugins/funind/glob_term_to_relation.ml
@@ -514,8 +514,9 @@ let rec build_entry_lc env sigma funnames avoid rt : glob_constr build_entry_ret
                    a pseudo value "v1 ... vn".
                    The "value" of this branch is then simply [res]
                 *)
+                (* XXX here and other [understand] calls drop the ctx *)
                 let rt_as_constr,ctx = Pretyping.understand env (Evd.from_env env) rt in
-                let rt_typ = Typing.unsafe_type_of env (Evd.from_env env) rt_as_constr in
+                let rt_typ = Retyping.get_type_of env (Evd.from_env env) rt_as_constr in
                 let res_raw_type = Detyping.detype Detyping.Now false Id.Set.empty env (Evd.from_env env) rt_typ in
                 let res = fresh_id args_res.to_avoid "_res" in
                 let new_avoid = res::args_res.to_avoid in
@@ -629,7 +630,7 @@ let rec build_entry_lc env sigma funnames avoid rt : glob_constr build_entry_ret
         let v = match typ with None -> v | Some t -> DAst.make ?loc:rt.loc @@ GCast (v,CastConv t) in
         let v_res = build_entry_lc env sigma funnames avoid v in
         let v_as_constr,ctx = Pretyping.understand env (Evd.from_env env) v in
-        let v_type = Typing.unsafe_type_of env (Evd.from_env env) v_as_constr in
+        let v_type = Retyping.get_type_of env (Evd.from_env env) v_as_constr in
         let v_r = Sorts.Relevant in (* TODO relevance *)
         let new_env =
           match n with
@@ -646,7 +647,7 @@ let rec build_entry_lc env sigma funnames avoid rt : glob_constr build_entry_ret
         build_entry_lc_from_case env sigma funnames make_discr el brl avoid
     | GIf(b,(na,e_option),lhs,rhs) ->
         let b_as_constr,ctx = Pretyping.understand env (Evd.from_env env) b in
-        let b_typ = Typing.unsafe_type_of env (Evd.from_env env) b_as_constr in
+        let b_typ = Retyping.get_type_of env (Evd.from_env env) b_as_constr in
         let (ind,_) =
           try Inductiveops.find_inductive env (Evd.from_env env) b_typ
           with Not_found ->
@@ -678,7 +679,7 @@ let rec build_entry_lc env sigma funnames avoid rt : glob_constr build_entry_ret
               nal
           in
           let b_as_constr,ctx = Pretyping.understand env (Evd.from_env env) b in
-          let b_typ = Typing.unsafe_type_of env (Evd.from_env env) b_as_constr in
+          let b_typ = Retyping.get_type_of env (Evd.from_env env) b_as_constr in
           let (ind,_) =
             try Inductiveops.find_inductive env (Evd.from_env env) b_typ
             with Not_found ->
@@ -723,7 +724,7 @@ and build_entry_lc_from_case env sigma funname make_discr
         let types =
           List.map (fun (case_arg,_) ->
                       let case_arg_as_constr,ctx = Pretyping.understand env (Evd.from_env env) case_arg in
-                      EConstr.Unsafe.to_constr (Typing.unsafe_type_of env (Evd.from_env env) case_arg_as_constr)
+                      EConstr.Unsafe.to_constr (Retyping.get_type_of env (Evd.from_env env) case_arg_as_constr)
                    ) el
         in
         (****** The next works only if the match is not dependent ****)
@@ -1164,7 +1165,7 @@ let rec rebuild_cons env nb_args relname args crossed_types depth rt =
           let evd = (Evd.from_env env) in
           let t',ctx = Pretyping.understand env evd t in
           let evd = Evd.from_ctx ctx in
-          let type_t' = Typing.unsafe_type_of env evd t' in
+          let type_t' = Retyping.get_type_of env evd t' in
           let t' = EConstr.Unsafe.to_constr t' in
           let type_t' = EConstr.Unsafe.to_constr type_t' in
           let new_env = Environ.push_rel (LocalDef (make_annot n Sorts.Relevant,t',type_t')) env in

--- a/plugins/funind/indfun_common.ml
+++ b/plugins/funind/indfun_common.ml
@@ -526,3 +526,7 @@ let funind_purify f x =
     let e = CErrors.push e in
     Vernacstate.unfreeze_interp_state st;
     Exninfo.iraise e
+
+let tac_type_of g c =
+  let sigma, t = Tacmach.pf_type_of g c in
+  {g with Evd.sigma}, t

--- a/plugins/funind/indfun_common.mli
+++ b/plugins/funind/indfun_common.mli
@@ -119,3 +119,5 @@ type tcc_lemma_value =
   | Not_needed
 
 val funind_purify : ('a -> 'b) -> ('a -> 'b)
+
+val tac_type_of : Goal.goal Evd.sigma -> EConstr.constr -> Goal.goal Evd.sigma * EConstr.types

--- a/plugins/funind/invfun.ml
+++ b/plugins/funind/invfun.ml
@@ -28,7 +28,7 @@ open Indfun_common
 *)
 let revert_graph kn post_tac hid = Proofview.Goal.enter (fun gl ->
   let sigma = project gl in
-  let typ = pf_unsafe_type_of gl (mkVar hid) in
+  let typ = pf_get_hyp_typ hid gl in
   match EConstr.kind sigma typ with
   | App(i,args) when isInd sigma i ->
     let ((kn',num) as ind'),u = destInd sigma i in
@@ -77,7 +77,7 @@ let revert_graph kn post_tac hid = Proofview.Goal.enter (fun gl ->
 let functional_inversion kn hid fconst f_correct = Proofview.Goal.enter (fun gl ->
   let old_ids = List.fold_right Id.Set.add  (pf_ids_of_hyps gl) Id.Set.empty in
   let sigma = project gl in
-  let type_of_h = pf_unsafe_type_of gl (mkVar hid) in
+  let type_of_h = pf_get_hyp_typ hid gl in
   match EConstr.kind sigma type_of_h with
   | App(eq,args) when EConstr.eq_constr sigma eq (make_eq ())  ->
     let pre_tac,f_args,res =
@@ -128,7 +128,7 @@ let invfun qhyp f =
   | None ->
     let tac_action hid gl =
       let sigma = project gl in
-      let hyp_typ = pf_unsafe_type_of gl (mkVar hid)  in
+      let hyp_typ = pf_get_hyp_typ hid gl  in
       match EConstr.kind sigma hyp_typ with
       | App(eq,args) when EConstr.eq_constr sigma eq (make_eq ()) ->
         begin

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -370,7 +370,7 @@ let treat_case forbid_new_ids to_intros finalize_tac nb_lam e infos : tactic =
             Proofview.V82.of_tactic (clear to_intros);
             h_intros to_intros;
             (fun g' ->
-              let ty_teq = pf_unsafe_type_of g' (mkVar heq) in
+              let ty_teq = pf_get_hyp_typ g' heq in
               let teq_lhs,teq_rhs =
                 let _,args = try destApp (project g') ty_teq with DestKO -> assert false in
                 args.(1),args.(2)
@@ -487,13 +487,13 @@ let rec prove_lt hyple g =
       in
       let h =
         List.find (fun id ->
-          match decompose_app sigma (pf_unsafe_type_of g (mkVar id)) with
+          match decompose_app sigma (pf_get_hyp_typ g id) with
             | _, t::_ -> EConstr.eq_constr sigma t varx
             | _ -> false
         ) hyple
       in
       let y =
-        List.hd (List.tl (snd (decompose_app sigma (pf_unsafe_type_of g (mkVar h))))) in
+        List.hd (List.tl (snd (decompose_app sigma (pf_get_hyp_typ g h)))) in
       observe_tclTHENLIST (fun _ _ -> str "prove_lt1")[
         Proofview.V82.of_tactic (apply (mkApp(le_lt_trans (),[|varx;y;varz;mkVar h|])));
         observe_tac (fun _ _ -> str "prove_lt") (prove_lt hyple)

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -31,7 +31,6 @@ open Tactics
 open Nametab
 open Declare
 open Tacred
-open Goal
 open Glob_term
 open Pretyping
 open Termops
@@ -110,9 +109,10 @@ let pf_get_new_ids idl g =
 let next_ident_away_in_goal ids avoid =
   next_ident_away_in_goal ids (Id.Set.of_list avoid)
 
-let compute_renamed_type gls c =
+let compute_renamed_type gls id =
   rename_bound_vars_as_displayed (project gls) (*no avoid*) Id.Set.empty (*no rels*) []
-    (pf_unsafe_type_of gls c)
+    (pf_get_hyp_typ gls id)
+
 let h'_id = Id.of_string "h'"
 let teq_id = Id.of_string "teq"
 let ano_id = Id.of_string "anonymous"
@@ -645,9 +645,7 @@ let pf_typel l tac =
   modified hypotheses are generalized in the process and should be
   introduced back later; the result is the pair of the tactic and the
   list of hypotheses that have been generalized and cleared. *)
-let mkDestructEq :
-  Id.t list -> constr -> goal Evd.sigma -> tactic * Id.t list =
-  fun not_on_hyp expr g ->
+let mkDestructEq not_on_hyp expr g =
   let hyps = pf_hyps g in
   let to_revert =
     Util.List.map_filter
@@ -657,9 +655,9 @@ let mkDestructEq :
         if Id.List.mem id not_on_hyp || not (Termops.dependent (project g) expr (get_type decl))
         then None else Some id) hyps in
   let to_revert_constr = List.rev_map mkVar to_revert in
-  let type_of_expr = pf_unsafe_type_of g expr in
-  let new_hyps = mkApp(Lazy.force refl_equal, [|type_of_expr; expr|])::
-           to_revert_constr in
+  let g, type_of_expr = tac_type_of g expr in
+  let new_hyps = mkApp(Lazy.force refl_equal, [|type_of_expr; expr|])::to_revert_constr in
+  let tac =
     pf_typel new_hyps (fun _ ->
     observe_tclTHENLIST (fun _ _ -> str "mkDestructEq")
      [Proofview.V82.of_tactic (generalize new_hyps);
@@ -668,7 +666,9 @@ let mkDestructEq :
           pattern_occs [Locus.AllOccurrencesBut [1], expr] (pf_env g2) sigma (pf_concl g2)
         in
         Proofview.V82.of_tactic (change_in_concl ~check:true None changefun) g2);
-      Proofview.V82.of_tactic (simplest_case expr)]), to_revert
+      Proofview.V82.of_tactic (simplest_case expr)])
+  in
+  g, tac, to_revert
 
 let terminate_case next_step (ci,a,t,l) expr_info continuation_tac infos g =
   let sigma = project g in
@@ -686,7 +686,7 @@ let terminate_case next_step (ci,a,t,l) expr_info continuation_tac infos g =
       info = mkCase(ci,t,a',l);
       is_main_branch = expr_info.is_main_branch;
       is_final = expr_info.is_final} in
-  let destruct_tac,rev_to_thin_intro =
+  let g,destruct_tac,rev_to_thin_intro =
     mkDestructEq [expr_info.rec_arg_id] a' g in
   let to_thin_intro = List.rev rev_to_thin_intro in
   observe_tac (fun _ _ -> str "treating cases (" ++ int (Array.length l) ++ str")" ++ spc () ++ Printer.pr_leconstr_env (pf_env g) sigma a')
@@ -842,7 +842,7 @@ let rec make_rewrite_list expr_info max = function
       (observe_tac (fun _ _ -> str "rewrite heq on " ++ Id.print p ) (
         (fun g ->
           let sigma = project g in
-          let t_eq = compute_renamed_type g (mkVar hp) in
+          let t_eq = compute_renamed_type g hp in
           let k,def =
             let k_na,_,t = destProd sigma t_eq in
             let _,_,t  = destProd sigma t in
@@ -868,7 +868,7 @@ let make_rewrite expr_info l hp max =
     (observe_tac (fun _ _ -> str "make_rewrite") (tclTHENS
        (fun g ->
           let sigma = project g in
-          let t_eq = compute_renamed_type g (mkVar hp) in
+          let t_eq = compute_renamed_type g hp in
           let k,def =
             let k_na,_,t = destProd sigma t_eq in
             let _,_,t  = destProd sigma t in

--- a/plugins/ltac/extratactics.mlg
+++ b/plugins/ltac/extratactics.mlg
@@ -794,7 +794,7 @@ let destauto t =
 
 let destauto_in id =
   Proofview.Goal.enter begin fun gl ->
-  let ctype = Tacmach.New.pf_unsafe_type_of gl (mkVar id) in
+  let ctype = Tacmach.New.pf_get_type_of gl (mkVar id) in
 (*  Pp.msgnl (Printer.pr_lconstr (mkVar id)); *)
 (*  Pp.msgnl (Printer.pr_lconstr (ctype)); *)
   destauto ctype

--- a/plugins/ltac/extratactics.mlg
+++ b/plugins/ltac/extratactics.mlg
@@ -736,7 +736,7 @@ let refl_equal () = Coqlib.lib_ref "core.eq.type"
   call it before it is defined. *)
 let  mkCaseEq a  : unit Proofview.tactic =
   Proofview.Goal.enter begin fun gl ->
-    let type_of_a = Tacmach.New.pf_unsafe_type_of gl a in
+    let type_of_a = Tacmach.New.pf_get_type_of gl a in
     Tacticals.New.pf_constr_of_global (delayed_force refl_equal) >>= fun req ->
     Tacticals.New.tclTHENLIST
          [Tactics.generalize [(mkApp(req, [| type_of_a; a|]))];

--- a/plugins/ltac/rewrite.ml
+++ b/plugins/ltac/rewrite.ml
@@ -789,7 +789,8 @@ let resolve_morphism env avoid oldt m ?(fnewt=fun x -> x) args args' (b,cstr) ev
     let morphargs, morphobjs = Array.chop first args in
     let morphargs', morphobjs' = Array.chop first args' in
     let appm = mkApp(m, morphargs) in
-    let appmtype = Typing.unsafe_type_of env (goalevars evars) appm in
+    let evd, appmtype = Typing.type_of env (goalevars evars) appm in
+    let evars = evd, snd evars in
     let cstrs = List.map
       (Option.map (fun r -> r.rew_car, get_opt_rew_rel r.rew_prf))
       (Array.to_list morphobjs')

--- a/plugins/ltac/rewrite.ml
+++ b/plugins/ltac/rewrite.ml
@@ -1907,7 +1907,7 @@ let declare_projection n instance_id r =
 let build_morphism_signature env sigma m =
   let m,ctx = Constrintern.interp_constr env sigma m in
   let sigma = Evd.from_ctx ctx in
-  let t = Typing.unsafe_type_of env sigma m in
+  let t = Retyping.get_type_of env sigma m in
   let cstrs =
     let rec aux t =
       match EConstr.kind sigma t with

--- a/plugins/ltac/rewrite.ml
+++ b/plugins/ltac/rewrite.ml
@@ -2196,10 +2196,10 @@ let setoid_transitivity c =
     (transitivity_red true c)
 
 let setoid_symmetry_in id =
-  let open Tacmach.New in
   Proofview.Goal.enter begin fun gl ->
-  let sigma = project gl in
-  let ctype = pf_unsafe_type_of gl (mkVar id) in
+  let env = Proofview.Goal.env gl in
+  let sigma = Proofview.Goal.sigma gl in
+  let ctype = Retyping.get_type_of env sigma (mkVar id) in
   let binders,concl = decompose_prod_assum sigma ctype in
   let (equiv, args) = decompose_app sigma concl in
   let rec split_last_two = function

--- a/plugins/ltac/rewrite.ml
+++ b/plugins/ltac/rewrite.ml
@@ -1937,7 +1937,7 @@ let build_morphism_signature env sigma m =
 let default_morphism sign m =
   let env = Global.env () in
   let sigma = Evd.from_env env in
-  let t = Typing.unsafe_type_of env sigma m in
+  let t = Retyping.get_type_of env sigma m in
   let evars, _, sign, cstrs =
     PropGlobal.build_signature (sigma, Evar.Set.empty) env t (fst sign) (snd sign)
   in

--- a/plugins/ltac/rewrite.ml
+++ b/plugins/ltac/rewrite.ml
@@ -483,7 +483,7 @@ let rec decompose_app_rel env evd t =
   | App (f, [||]) -> assert false
   | App (f, [|arg|]) ->
     let (f', argl, argr) = decompose_app_rel env evd arg in
-    let ty = Typing.unsafe_type_of env evd argl in
+    let ty = Retyping.get_type_of env evd argl in
     let r = Retyping.relevance_of_type env evd ty in
     let f'' = mkLambda (make_annot (Name default_dependent_ident) r, ty,
       mkLambda (make_annot (Name (Id.of_string "y")) r, lift 1 ty,

--- a/plugins/omega/coq_omega.ml
+++ b/plugins/omega/coq_omega.ml
@@ -1713,7 +1713,6 @@ let onClearedName2 id tac =
 
 let destructure_hyps =
   Proofview.Goal.enter begin fun gl ->
-  let type_of = Tacmach.New.pf_unsafe_type_of gl in
   let env = Proofview.Goal.env gl in
   let sigma = Proofview.Goal.sigma gl in
   let decidability = decidability env sigma in
@@ -1759,7 +1758,7 @@ let destructure_hyps =
           | Kimp(t1,t2) ->
               (* t1 and t2 might be in Type rather than Prop.
                  For t1, the decidability check will ensure being Prop. *)
-              if Termops.is_Prop sigma (type_of t2)
+              if Termops.is_Prop sigma (Retyping.get_type_of env sigma t2)
               then
                 let d1 = decidability t1 in
                 tclTHENLIST [

--- a/pretyping/cases.ml
+++ b/pretyping/cases.ml
@@ -2164,7 +2164,7 @@ let constr_of_pat env sigma arsign pat avoid =
         let IndType (indf, _) =
           try find_rectype env sigma (lift (-(List.length realargs)) ty)
           with Not_found -> error_case_not_inductive env sigma
-            {uj_val = ty; uj_type = Typing.unsafe_type_of env sigma ty}
+            {uj_val = ty; uj_type = Retyping.get_type_of env sigma ty}
         in
         let (ind,u), params = dest_ind_family indf in
         let params = List.map EConstr.of_constr params in

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -446,7 +446,7 @@ let pretype_ref ?loc sigma env ref us =
          Pretype_errors.error_var_not_found ?loc !!env sigma id)
   | ref ->
     let sigma, c = pretype_global ?loc univ_flexible env sigma ref us in
-    let ty = unsafe_type_of !!env sigma c in
+    let sigma, ty = type_of !!env sigma c in
     sigma, make_judge c ty
 
 let interp_sort ?loc evd : glob_sort -> _ = function

--- a/pretyping/tacred.ml
+++ b/pretyping/tacred.ml
@@ -1197,7 +1197,7 @@ let abstract_scheme env sigma (locc,a) (c, sigma) =
 let pattern_occs loccs_trm = begin fun env sigma c ->
   let abstr_trm, sigma = List.fold_right (abstract_scheme env sigma) loccs_trm (c,sigma) in
   try
-    let _ = Typing.unsafe_type_of env sigma abstr_trm in
+    let sigma, _ = Typing.type_of env sigma abstr_trm in
     (sigma, applist(abstr_trm, List.map snd loccs_trm))
   with Type_errors.TypeError (env',t) ->
     raise (ReductionTacticError (InvalidAbstraction (env,sigma,abstr_trm,(env',t))))

--- a/pretyping/typing.ml
+++ b/pretyping/typing.ml
@@ -253,6 +253,9 @@ let judge_of_type u =
 let judge_of_relative env v =
   Environ.on_judgment EConstr.of_constr (judge_of_relative env v)
 
+let type_of_variable env id =
+  EConstr.of_constr (type_of_variable env id)
+
 let judge_of_variable env id =
   Environ.on_judgment EConstr.of_constr (judge_of_variable env id)
 

--- a/pretyping/typing.mli
+++ b/pretyping/typing.mli
@@ -30,6 +30,9 @@ val sort_of : env -> evar_map -> types -> evar_map * Sorts.t
 (** Typecheck a term has a given type (assuming the type is OK) *)
 val check : env -> evar_map -> constr -> types -> evar_map
 
+(** Type of a variable. *)
+val type_of_variable : env -> variable -> types
+
 (** Returns the instantiated type of a metavariable *)
 val meta_type : evar_map -> metavariable -> types
 

--- a/pretyping/unification.ml
+++ b/pretyping/unification.ml
@@ -1274,12 +1274,14 @@ let applyHead env evd n c  =
     else
       match EConstr.kind evd (whd_all env evd cty) with
       | Prod (_,c1,c2) ->
-        let (evd',evar) =
-      Evarutil.new_evar env evd ~src:(Loc.tag Evar_kinds.GoalEvar) c1 in
-      apprec (n-1) (mkApp(c,[|evar|])) (subst1 evar c2) evd'
+        let (evd,evar) =
+          Evarutil.new_evar env evd ~src:(Loc.tag Evar_kinds.GoalEvar) c1
+        in
+        apprec (n-1) (mkApp(c,[|evar|])) (subst1 evar c2) evd
       | _ -> user_err Pp.(str "Apply_Head_Then")
   in
-    apprec n c (Typing.unsafe_type_of env evd c) evd
+  let evd, t = Typing.type_of env evd c in
+  apprec n c t evd
 
 let is_mimick_head sigma ts f =
   match EConstr.kind sigma f with

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -128,7 +128,11 @@ let mk_clenv_from_n gls n (c,cty) =
 
 let mk_clenv_from gls = mk_clenv_from_n gls None
 
-let mk_clenv_type_of gls t = mk_clenv_from gls (t,Tacmach.New.pf_unsafe_type_of gls t)
+let mk_clenv_type_of gls t =
+  let env = Proofview.Goal.env gls in
+  let sigma = Tacmach.New.project gls in
+  let sigma, tt = Typing.type_of env sigma t in
+  mk_clenv_from_env env sigma None (t,tt)
 
 (******************************************************************)
 

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -128,12 +128,6 @@ let mk_clenv_from_n gls n (c,cty) =
 
 let mk_clenv_from gls = mk_clenv_from_n gls None
 
-let mk_clenv_type_of gls t =
-  let env = Proofview.Goal.env gls in
-  let sigma = Tacmach.New.project gls in
-  let sigma, tt = Typing.type_of env sigma t in
-  mk_clenv_from_env env sigma None (t,tt)
-
 (******************************************************************)
 
 (* [mentions clenv mv0 mv1] is true if mv1 is defined and mentions

--- a/proofs/clenv.mli
+++ b/proofs/clenv.mli
@@ -46,7 +46,6 @@ val clenv_meta_type : clausenv -> metavariable -> types
 val mk_clenv_from : Proofview.Goal.t -> EConstr.constr * EConstr.types -> clausenv
 val mk_clenv_from_n :
   Proofview.Goal.t -> int option -> EConstr.constr * EConstr.types -> clausenv
-val mk_clenv_type_of : Proofview.Goal.t -> EConstr.constr -> clausenv
 val mk_clenv_from_env : env -> evar_map -> int option -> EConstr.constr * EConstr.types -> clausenv
 
 (** Refresh the universes in a clenv *)

--- a/proofs/logic.ml
+++ b/proofs/logic.ml
@@ -79,7 +79,7 @@ let check = ref false
 let with_check = Flags.with_option check
 
 let check_typability env sigma c =
-  if !check then let _ = unsafe_type_of env sigma (EConstr.of_constr c) in ()
+  if !check then fst (type_of env sigma (EConstr.of_constr c)) else sigma
 
 (************************************************************************)
 (************************************************************************)
@@ -363,7 +363,7 @@ let rec mk_refgoals sigma goal goalacc conclty trm =
           gl::goalacc, conclty, sigma, ev
 
       | Cast (t,k, ty) ->
-        check_typability env sigma ty;
+        let sigma = check_typability env sigma ty in
         let sigma = check_conv_leq_goal env sigma trm ty conclty in
         let res = mk_refgoals sigma goal goalacc ty t in
         (* we keep the casts (in particular VMcast and NATIVEcast) except
@@ -430,13 +430,13 @@ and mk_hdgoals sigma goal goalacc trm =
     Goal.V82.mk_goal sigma hyps concl in
   match kind trm with
     | Cast (c,_, ty) when isMeta c ->
-        check_typability env sigma ty;
+        let sigma = check_typability env sigma ty in
         let (gl,ev,sigma) = mk_goal hyps (nf_betaiota env sigma (EConstr.of_constr ty)) in
         let ev = EConstr.Unsafe.to_constr ev in
         gl::goalacc,ty,sigma,ev
 
     | Cast (t,_, ty) ->
-        check_typability env sigma ty;
+        let sigma = check_typability env sigma ty in
         mk_refgoals sigma goal goalacc ty t
 
     | App (f,l) ->

--- a/tactics/autorewrite.ml
+++ b/tactics/autorewrite.ml
@@ -238,7 +238,7 @@ let decompose_applied_relation metas env sigma c ctype left2right =
     in
       try
         let others,(c1,c2) = split_last_two args in
-        let ty1, ty2 = Typing.unsafe_type_of env eqclause.evd c1, Typing.unsafe_type_of env eqclause.evd c2 in
+        let ty1, ty2 = Retyping.get_type_of env eqclause.evd c1, Retyping.get_type_of env eqclause.evd c2 in
         (* XXX: It looks like mk_clenv_from_env should be fixed instead? *)
         let open EConstr in
         let hyp_ty = Unsafe.to_constr ty in
@@ -261,7 +261,7 @@ let decompose_applied_relation metas env sigma c ctype left2right =
         | None -> None
 
 let find_applied_relation ?loc metas env sigma c left2right =
-  let ctype = Typing.unsafe_type_of env sigma (EConstr.of_constr c) in
+  let ctype = Retyping.get_type_of env sigma (EConstr.of_constr c) in
     match decompose_applied_relation metas env sigma c ctype left2right with
     | Some c -> c
     | None ->

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -1202,10 +1202,9 @@ let autoapply c i =
   in
   let flags = auto_unif_flags
     (Hints.Hint_db.transparent_state hintdb) in
-  let cty = Tacmach.New.pf_unsafe_type_of gl c in
+  let cty = Tacmach.New.pf_get_type_of gl c in
   let ce = mk_clenv_from gl (c,cty) in
-    unify_e_resolve false flags gl
-                                 ((c,cty,Univ.ContextSet.empty),0,ce) <*>
+    unify_e_resolve false flags gl ((c,cty,Univ.ContextSet.empty),0,ce) <*>
       Proofview.tclEVARMAP >>= (fun sigma ->
       let sigma = Typeclasses.make_unresolvables
           (fun ev -> Typeclasses.all_goals ev (Lazy.from_val (snd (Evd.find sigma ev).evar_source))) sigma in

--- a/tactics/contradiction.ml
+++ b/tactics/contradiction.ml
@@ -110,8 +110,7 @@ let contradiction_term (c,lbind as cl) =
   Proofview.Goal.enter begin fun gl ->
     let sigma = Tacmach.New.project gl in
     let env = Proofview.Goal.env gl in
-    let type_of = Tacmach.New.pf_unsafe_type_of gl in
-    let typ = type_of c in
+    let typ = Tacmach.New.pf_get_type_of gl c in
     let _, ccl = splay_prod env sigma typ in
     if is_empty_type env sigma ccl then
       Tacticals.New.tclTHEN

--- a/tactics/eauto.ml
+++ b/tactics/eauto.ml
@@ -32,11 +32,13 @@ let eauto_unif_flags = auto_flags_of_state TransparentState.full
 
 let e_give_exact ?(flags=eauto_unif_flags) c =
   Proofview.Goal.enter begin fun gl ->
-  let t1 = Tacmach.New.pf_unsafe_type_of gl c in
+  let sigma, t1 = Tacmach.New.pf_type_of gl c in
   let t2 = Tacmach.New.pf_concl gl in
-  let sigma = Tacmach.New.project gl in
   if occur_existential sigma t1 || occur_existential sigma t2 then
-     Tacticals.New.tclTHEN (Clenvtac.unify ~flags t1) (exact_no_check c)
+    Tacticals.New.tclTHENLIST
+      [Proofview.Unsafe.tclEVARS sigma;
+       Clenvtac.unify ~flags t1;
+       exact_no_check c]
   else exact_check c
   end
 

--- a/tactics/elim.ml
+++ b/tactics/elim.ml
@@ -80,14 +80,11 @@ let up_to_delta = ref false (* true *)
 
 let general_decompose recognizer c =
   Proofview.Goal.enter begin fun gl ->
-  let type_of = pf_unsafe_type_of gl in
-  let env = pf_env gl in
-  let sigma = project gl in
-  let typc = type_of c in
+  let typc = pf_get_type_of gl c in
   tclTHENS (cut typc)
     [ tclTHEN (intro_using tmphyp_name)
          (onLastHypId
-            (ifOnHyp (recognizer env sigma) (general_decompose_aux (recognizer env sigma))
+            (ifOnHyp recognizer (general_decompose_aux recognizer)
               (fun id -> clear [id])));
        exact_no_check c ]
   end

--- a/tactics/elim.ml
+++ b/tactics/elim.ml
@@ -133,7 +133,7 @@ let induction_trailer abs_i abs_j bargs =
     (onLastHypId
        (fun id ->
           Proofview.Goal.enter begin fun gl ->
-          let idty = pf_unsafe_type_of gl (mkVar id) in
+          let idty = pf_get_type_of gl (mkVar id) in
           let fvty = global_vars (pf_env gl) (project gl) idty in
           let possible_bring_hyps =
             (List.tl (nLastDecls gl (abs_j - abs_i))) @ bargs.Tacticals.assums

--- a/tactics/eqdecide.ml
+++ b/tactics/eqdecide.ml
@@ -195,13 +195,13 @@ let rec solveArg hyps eqonleft mk largs rargs = match largs, rargs with
   ]
 | a1 :: largs, a2 :: rargs ->
   Proofview.Goal.enter begin fun gl ->
-  let rectype = pf_unsafe_type_of gl a1 in
+  let sigma, rectype = pf_type_of gl a1 in
   let decide = mk rectype a1 a2 in
   let tac hyp = solveArg (hyp :: hyps) eqonleft mk largs rargs in
   let subtacs =
     if eqonleft then [eqCase tac;diseqCase hyps eqonleft;default_auto]
     else [diseqCase hyps eqonleft;eqCase tac;default_auto] in
-  (tclTHENS (elim_type decide) subtacs)
+  tclTHEN (Proofview.Unsafe.tclEVARS sigma) (tclTHENS (elim_type decide) subtacs)
   end
 | _ -> invalid_arg "List.fold_right2"
 
@@ -274,11 +274,12 @@ let compare c1 c2 =
   pf_constr_of_global (lib_ref "core.eq.type") >>= fun eqc ->
   pf_constr_of_global (lib_ref "core.not.type") >>= fun notc ->
   Proofview.Goal.enter begin fun gl ->
-  let rectype = pf_unsafe_type_of gl c1 in
+  let sigma, rectype = pf_type_of gl c1 in
   let ops = (opc,eqc,notc) in
   let decide = mkDecideEqGoal true ops rectype c1 c2 in
-  (tclTHENS (cut decide)
-            [(tclTHEN  intro
-             (tclTHEN (onLastHyp simplest_case) clear_last));
-             decideEquality rectype ops])
+  tclTHEN (Proofview.Unsafe.tclEVARS sigma)
+    (tclTHENS (cut decide)
+       [(tclTHEN  intro
+           (tclTHEN (onLastHyp simplest_case) clear_last));
+        decideEquality rectype ops])
   end

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -1311,7 +1311,7 @@ let make_iterated_tuple env sigma dflt (z,zty) =
     sigma, (tuple,tuplety,dfltval)
 
 let rec build_injrec env sigma dflt c = function
-  | [] -> make_iterated_tuple env sigma dflt (c,unsafe_type_of env sigma c)
+  | [] -> make_iterated_tuple env sigma dflt (c,get_type_of env sigma c)
   | ((sp,cnum),argnum)::l ->
     try
       let (cnum_nlams,cnum_env,kont) = descend_then env sigma c cnum in

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -1352,7 +1352,7 @@ let inject_if_homogenous_dependent_pair ty =
     if not (Ind_tables.check_scheme (!eq_dec_scheme_kind_name()) ind &&
       pf_apply is_conv gl ar1.(2) ar2.(2)) then raise Exit;
     check_required_library ["Coq";"Logic";"Eqdep_dec"];
-    let new_eq_args = [|pf_unsafe_type_of gl ar1.(3);ar1.(3);ar2.(3)|] in
+    let new_eq_args = [|pf_get_type_of gl ar1.(3);ar1.(3);ar2.(3)|] in
     let inj2 = lib_ref "core.eqdep_dec.inj_pair2" in
     let c, eff = find_scheme (!eq_dec_scheme_kind_name()) ind in
     (* cut with the good equality and prove the requested goal *)

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -26,7 +26,6 @@ open Libnames
 open Smartlocate
 open Termops
 open Inductiveops
-open Typing
 open Typeclasses
 open Pattern
 open Patternops
@@ -966,16 +965,17 @@ let make_mode ref m =
 let make_trivial env sigma poly ?(name=PathAny) r =
   let c,ctx = fresh_global_or_constr env sigma poly r in
   let sigma = Evd.merge_context_set univ_flexible sigma ctx in
-  let t = hnf_constr env sigma (unsafe_type_of env sigma c) in
+  let t = hnf_constr env sigma (Retyping.get_type_of env sigma c) in
   let hd = head_constr sigma t in
   let ce = mk_clenv_from_env env sigma None (c,t) in
-  (Some hd, { pri=1;
-              poly = poly;
-              pat = Some (Patternops.pattern_of_constr env ce.evd (EConstr.to_constr sigma (clenv_type ce)));
-              name = name;
-              db = None;
-              secvars = secvars_of_constr env sigma c;
-              code= with_uid (Res_pf_THEN_trivial_fail(c,t,ctx)) })
+  (Some hd,
+   { pri=1;
+     poly = poly;
+     pat = Some (Patternops.pattern_of_constr env ce.evd (EConstr.to_constr sigma (clenv_type ce)));
+     name = name;
+     db = None;
+     secvars = secvars_of_constr env sigma c;
+     code= with_uid (Res_pf_THEN_trivial_fail(c,t,ctx)) })
 
 
 

--- a/tactics/hints.mli
+++ b/tactics/hints.mli
@@ -160,6 +160,8 @@ module Hint_db :
     val iter : (GlobRef.t option ->
                 hint_mode array list -> full_hint list -> unit) -> t -> unit
 
+    val fold : (GlobRef.t option -> hint_mode array list -> full_hint list -> 'a -> 'a) -> t -> 'a -> 'a
+
     val use_dn : t -> bool
     val transparent_state : t -> TransparentState.t
     val set_transparent_state : t -> TransparentState.t -> t

--- a/tactics/hipattern.ml
+++ b/tactics/hipattern.ml
@@ -19,7 +19,6 @@ open Inductiveops
 open Constr_matching
 open Coqlib
 open Declarations
-open Tacmach.New
 open Context.Rel.Declaration
 
 module RelDecl = Context.Rel.Declaration
@@ -452,26 +451,26 @@ let find_eq_data sigma eqn = (* fails with PatternMatchingFailure *)
   let hd,u = destInd sigma (fst (destApp sigma eqn)) in
     d,u,k
 
-let extract_eq_args gl = function
+let extract_eq_args env sigma = function
   | MonomorphicLeibnizEq (e1,e2) ->
-      let t = pf_unsafe_type_of gl e1 in (t,e1,e2)
+      let t = Typing.unsafe_type_of env sigma e1 in (t,e1,e2)
   | PolymorphicLeibnizEq (t,e1,e2) -> (t,e1,e2)
   | HeterogenousEq (t1,e1,t2,e2) ->
-      if pf_conv_x gl t1 t2 then (t1,e1,e2)
+      if Reductionops.is_conv env sigma t1 t2 then (t1,e1,e2)
       else raise PatternMatchingFailure
 
-let find_eq_data_decompose gl eqn =
-  let (lbeq,u,eq_args) = find_eq_data (project gl) eqn in
-  (lbeq,u,extract_eq_args gl eq_args)
+let find_eq_data_decompose env sigma eqn =
+  let (lbeq,u,eq_args) = find_eq_data sigma eqn in
+  (lbeq,u,extract_eq_args env sigma eq_args)
 
-let find_this_eq_data_decompose gl eqn =
+let find_this_eq_data_decompose env sigma eqn =
   let (lbeq,u,eq_args) =
     try (*first_match (match_eq eqn) inversible_equalities*)
-      find_eq_data (project gl) eqn
+      find_eq_data sigma eqn
     with PatternMatchingFailure ->
       user_err  (str "No primitive equality found.") in
   let eq_args =
-    try extract_eq_args gl eq_args
+    try extract_eq_args env sigma eq_args
     with PatternMatchingFailure ->
       user_err Pp.(str "Don't know what to do with JMeq on arguments not of same type.") in
   (lbeq,u,eq_args)

--- a/tactics/hipattern.ml
+++ b/tactics/hipattern.ml
@@ -453,7 +453,7 @@ let find_eq_data sigma eqn = (* fails with PatternMatchingFailure *)
 
 let extract_eq_args env sigma = function
   | MonomorphicLeibnizEq (e1,e2) ->
-      let t = Typing.unsafe_type_of env sigma e1 in (t,e1,e2)
+      let t = Retyping.get_type_of env sigma e1 in (t,e1,e2)
   | PolymorphicLeibnizEq (t,e1,e2) -> (t,e1,e2)
   | HeterogenousEq (t1,e1,t2,e2) ->
       if Reductionops.is_conv env sigma t1 t2 then (t1,e1,e2)

--- a/tactics/hipattern.mli
+++ b/tactics/hipattern.mli
@@ -122,11 +122,11 @@ val match_with_equation:
 
 (** Match terms [eq A t u], [identity A t u] or [JMeq A t A u]
    Returns associated lemmas and [A,t,u] or fails PatternMatchingFailure *)
-val find_eq_data_decompose : Proofview.Goal.t -> constr ->
+val find_eq_data_decompose : Environ.env -> evar_map -> constr ->
       coq_eq_data * EInstance.t * (types * constr * constr)
 
 (** Idem but fails with an error message instead of PatternMatchingFailure *)
-val find_this_eq_data_decompose : Proofview.Goal.t -> constr ->
+val find_this_eq_data_decompose : Environ.env -> evar_map -> constr ->
       coq_eq_data * EInstance.t * (types * constr * constr)
 
 (** A variant that returns more informative structure on the equality found *)

--- a/tactics/inv.ml
+++ b/tactics/inv.ml
@@ -464,7 +464,7 @@ let raw_inversion inv_kind id status names =
     let concl = Proofview.Goal.concl gl in
     let c = mkVar id in
     let (ind, t) =
-      try pf_apply Tacred.reduce_to_atomic_ind gl (pf_unsafe_type_of gl c)
+      try pf_apply Tacred.reduce_to_atomic_ind gl (pf_get_type_of gl c)
       with UserError _ ->
         let msg = str "The type of " ++ Id.print id ++ str " is not inductive." in
         CErrors.user_err  msg

--- a/tactics/leminv.ml
+++ b/tactics/leminv.ml
@@ -259,7 +259,7 @@ let add_inversion_lemma_exn ~poly na com comsort bool tac =
 let lemInv id c =
   Proofview.Goal.enter begin fun gls ->
   try
-    let clause = mk_clenv_from_env (pf_env gls) (project gls) None (c, pf_unsafe_type_of gls c) in
+    let clause = mk_clenv_from_env (pf_env gls) (project gls) None (c, pf_get_type_of gls c) in
     let clause = clenv_constrain_last_binding (EConstr.mkVar id) clause in
     Clenvtac.res_pf clause ~flags:(Unification.elim_flags ()) ~with_evars:false
   with

--- a/tactics/tacticals.ml
+++ b/tactics/tacticals.ml
@@ -741,7 +741,7 @@ module New = struct
 
   let elimination_then tac c =
     Proofview.Goal.enter begin fun gl ->
-    let (ind,t) = pf_reduce_to_quantified_ind gl (pf_unsafe_type_of gl c) in
+    let (ind,t) = pf_reduce_to_quantified_ind gl (pf_get_type_of gl c) in
     let isrec,mkelim =
       match (Global.lookup_mind (fst (fst ind))).mind_record with
       | NotRecord -> true,gl_make_elim

--- a/tactics/tacticals.ml
+++ b/tactics/tacticals.ml
@@ -587,7 +587,7 @@ module New = struct
   let ifOnHyp pred tac1 tac2 id =
     Proofview.Goal.enter begin fun gl ->
     let typ = Tacmach.New.pf_get_hyp_typ id gl in
-    if pred (id,typ) then
+    if pf_apply pred gl (id,typ) then
       tac1 id
     else
       tac2 id

--- a/tactics/tacticals.ml
+++ b/tactics/tacticals.ml
@@ -633,7 +633,7 @@ module New = struct
     (Proofview.Goal.enter begin fun gl ->
     let indclause = mk_clenv_from gl (c, t) in
     (* applying elimination_scheme just a little modified *)
-    let elimclause = mk_clenv_from gl (elim,Tacmach.New.pf_unsafe_type_of gl elim)  in
+    let elimclause = mk_clenv_from gl (elim,Tacmach.New.pf_get_type_of gl elim)  in
     let indmv =
       match EConstr.kind elimclause.evd (last_arg elimclause.evd elimclause.templval.Evd.rebus) with
       | Meta mv -> mv

--- a/tactics/tacticals.mli
+++ b/tactics/tacticals.mli
@@ -222,7 +222,7 @@ module New : sig
 
   val nLastDecls  : Proofview.Goal.t -> int -> named_context
 
-  val ifOnHyp     : (Id.t * types -> bool) ->
+  val ifOnHyp : (Environ.env -> evar_map -> Id.t * types -> bool) ->
     (Id.t -> unit Proofview.tactic) -> (Id.t -> unit Proofview.tactic) ->
     Id.t -> unit Proofview.tactic
 

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -4772,7 +4772,10 @@ let destruct ev clr c l e =
 
 let elim_scheme_type elim t =
   Proofview.Goal.enter begin fun gl ->
-  let clause = mk_clenv_type_of gl elim in
+  let env = Proofview.Goal.env gl in
+  let sigma = Proofview.Goal.sigma gl in
+  let sigma, elimt = Typing.type_of env sigma elim in
+  let clause = mk_clenv_from_env env sigma None (elim,elimt) in
   match EConstr.kind clause.evd (last_arg clause.evd clause.templval.rebus) with
     | Meta mv ->
         let clause' =

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -151,11 +151,12 @@ let convert_concl ~check ty k =
     Refine.refine ~typecheck:false begin fun sigma ->
       let sigma =
         if check then begin
-          ignore (Typing.unsafe_type_of env sigma ty);
+          let sigma, _ = Typing.type_of env sigma ty in
           match Reductionops.infer_conv env sigma ty conclty with
           | None -> error "Not convertible."
           | Some sigma -> sigma
-        end else sigma in
+        end else sigma
+      in
       let (sigma, x) = Evarutil.new_evar env sigma ~principal:true ty in
       let ans = if k == DEFAULTcast then x else mkCast(x,k,conclty) in
       (sigma, ans)

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -4274,7 +4274,7 @@ let get_elim_signature elim hyp0 gl =
 
 let is_functional_induction elimc gl =
   let sigma = Tacmach.New.project gl in
-  let scheme = compute_elim_sig sigma ~elimc (Tacmach.New.pf_unsafe_type_of gl (fst elimc)) in
+  let scheme = compute_elim_sig sigma ~elimc (Tacmach.New.pf_get_type_of gl (fst elimc)) in
   (* The test is not safe: with non-functional induction on non-standard
      induction scheme, this may fail *)
   Option.is_empty scheme.indarg

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -3399,8 +3399,9 @@ let atomize_param_of_ind_then (indref,nparams,_) hyp0 tac =
             let id = match EConstr.kind sigma c with
             | Var id -> id
             | _ ->
-            let type_of = Tacmach.New.pf_unsafe_type_of gl in
-            id_of_name_using_hdchar env sigma (type_of c) Anonymous in
+              let type_of = Tacmach.New.pf_get_type_of gl in
+              id_of_name_using_hdchar env sigma (type_of c) Anonymous
+            in
             let x = fresh_id_in_env avoid id env in
             Tacticals.New.tclTHEN
               (letin_tac None (Name x) c None allHypsAndConcl)

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -850,12 +850,13 @@ let change_on_subterm ~check cv_pb deep t where env sigma c =
             change_and_check Reduction.CONV mayneedglobalcheck true (t subst)
           else
             fun env sigma _c -> t subst env sigma) env sigma c in
-  if !mayneedglobalcheck then
+  let sigma = if !mayneedglobalcheck then
     begin
-      try ignore (Typing.unsafe_type_of env sigma c)
+      try fst (Typing.type_of env sigma c)
       with e when catchable_exception e ->
         error "Replacement would lead to an ill-typed term."
-    end;
+    end else sigma
+  in
   (sigma, c)
 
 let change_in_concl ~check occl t =

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -4231,8 +4231,8 @@ let guess_elim isrec dep s hyp0 gl =
         let ind = EConstr.of_constr ind in
         (sigma, ind)
   in
-  let elimt = Typing.unsafe_type_of env sigma elimc in
-    sigma, ((elimc, NoBindings), elimt), mkIndU (mind, u)
+  let sigma, elimt = Typing.type_of env sigma elimc in
+  sigma, ((elimc, NoBindings), elimt), mkIndU (mind, u)
 
 let given_elim hyp0 (elimc,lbind as e) gl =
   let sigma = Tacmach.New.project gl in

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -4238,8 +4238,8 @@ let given_elim hyp0 (elimc,lbind as e) gl =
   let sigma = Tacmach.New.project gl in
   let tmptyp0 = Tacmach.New.pf_get_hyp_typ hyp0 gl in
   let ind_type_guess,_ = decompose_app sigma (snd (decompose_prod sigma tmptyp0)) in
-  let elimt = Tacmach.New.pf_unsafe_type_of gl elimc in
-  Tacmach.New.project gl, (e, elimt), ind_type_guess
+  let sigma, elimt = Tacmach.New.pf_type_of gl elimc in
+  sigma, (e, elimt), ind_type_guess
 
 type scheme_signature =
     (Id.Set.t * (elim_arg_kind * bool * bool * Id.t) list) array

--- a/vernac/auto_ind_decl.ml
+++ b/vernac/auto_ind_decl.ml
@@ -395,7 +395,7 @@ let do_replace_lb mode lb_scheme_key aavoid narg p q =
 
   in
   Proofview.Goal.enter begin fun gl ->
-    let type_of_pq = Tacmach.New.pf_unsafe_type_of gl p in
+    let type_of_pq = Tacmach.New.pf_get_type_of gl p in
     let sigma = Tacmach.New.project gl in
     let env = Tacmach.New.pf_env gl in
     let u,v = destruct_ind env sigma type_of_pq
@@ -458,11 +458,11 @@ let do_replace_bl bl_scheme_key (ind,u as indu) aavoid narg lft rgt =
     match (l1,l2) with
     | (t1::q1,t2::q2) ->
         Proofview.Goal.enter begin fun gl ->
-        let tt1 = Tacmach.New.pf_unsafe_type_of gl t1 in
         let sigma = Tacmach.New.project gl in
         let env = Tacmach.New.pf_env gl in
         if EConstr.eq_constr sigma t1 t2 then aux q1 q2
         else (
+          let tt1 = Tacmach.New.pf_get_type_of gl t1 in
           let u,v = try destruct_ind env sigma tt1
           (* trick so that the good sequence is returned*)
                 with e when CErrors.noncritical e -> indu,[||]

--- a/vernac/comCoercion.ml
+++ b/vernac/comCoercion.ml
@@ -198,10 +198,9 @@ let build_id_coercion idf_opt source poly =
       lams
   in
   (* juste pour verification *)
-  let _ =
-    if not
-      (Reductionops.is_conv_leq env sigma
-        (Typing.unsafe_type_of env sigma (EConstr.of_constr val_f)) (EConstr.of_constr typ_f))
+  let sigma, val_t = Typing.type_of env sigma (EConstr.of_constr val_f) in
+  let () =
+    if not (Reductionops.is_conv_leq env sigma val_t (EConstr.of_constr typ_f))
     then
       user_err  (strbrk
         "Cannot be defined as coercion (maybe a bad number of arguments).")

--- a/vernac/comProgramFixpoint.ml
+++ b/vernac/comProgramFixpoint.ml
@@ -127,7 +127,7 @@ let build_wellfounded (recname,pl,bl,arityc,body) poly r measure notation =
   let binders = letbinders @ [arg] in
   let binders_env = push_rel_context binders_rel env in
   let sigma, (rel, _) = interp_constr_evars_impls ~program_mode:true env sigma r in
-  let relty = Typing.unsafe_type_of env sigma rel in
+  let relty = Retyping.get_type_of env sigma rel in
   let relargty =
     let error () =
       user_err ?loc:(constr_loc r)


### PR DESCRIPTION
This leaves the ones in coercion.ml (see https://github.com/coq/coq/pull/10204) and about a quarter hundred uses in the Fun Induction plugin.

I tried to use retyping when reasonable and may have made mistakes both by using it when I shouldn't and by not using it when I could have.