### PR TITLE
Cleanup some globref related manipulations

### DIFF
--- a/engine/eConstr.ml
+++ b/engine/eConstr.ml
@@ -119,6 +119,20 @@ let isVarId sigma id c =
 let isRelN sigma n c =
   match kind sigma c with Rel n' -> Int.equal n n' | _ -> false
 
+let isRef sigma c = match kind sigma c with
+  | Const _ | Ind _ | Construct _ | Var _ -> true
+  | _ -> false
+
+let isRefX sigma x c =
+  let open GlobRef in
+  match x, kind sigma c with
+  | ConstRef c, Const (c', _) -> Constant.equal c c'
+  | IndRef i, Ind (i', _) -> eq_ind i i'
+  | ConstructRef i, Construct (i', _) -> eq_constructor i i'
+  | VarRef id, Var id' -> Id.equal id id'
+  | _ -> false
+
+
 let destRel sigma c = match kind sigma c with
 | Rel p -> p
 | _ -> raise DestKO
@@ -723,8 +737,7 @@ let fresh_global ?loc ?rigid ?names env sigma reference =
   let (evd,t) = Evd.fresh_global ?loc ?rigid ?names env sigma reference in
   evd, t
 
-let is_global sigma gr c =
-  Globnames.is_global gr (to_constr sigma c)
+let is_global = isRefX
 
 module Unsafe =
 struct

--- a/engine/eConstr.mli
+++ b/engine/eConstr.mli
@@ -152,6 +152,7 @@ val mkNamedProd_or_LetIn : named_declaration -> types -> types
 val isRel  : Evd.evar_map -> t -> bool
 val isVar  : Evd.evar_map -> t -> bool
 val isInd  : Evd.evar_map -> t -> bool
+val isRef : Evd.evar_map -> t -> bool
 val isEvar : Evd.evar_map -> t -> bool
 val isMeta : Evd.evar_map -> t -> bool
 val isSort : Evd.evar_map -> t -> bool
@@ -175,6 +176,7 @@ val isArity : Evd.evar_map -> t -> bool
 
 val isVarId  : Evd.evar_map -> Id.t -> t -> bool
 val isRelN : Evd.evar_map -> int -> t -> bool
+val isRefX : Evd.evar_map -> GlobRef.t -> t -> bool
 
 val destRel : Evd.evar_map -> t -> int
 val destMeta : Evd.evar_map -> t -> metavariable
@@ -319,6 +321,7 @@ val fresh_global :
   Evd.evar_map -> GlobRef.t -> Evd.evar_map * t
 
 val is_global : Evd.evar_map -> GlobRef.t -> t -> bool
+[@@ocaml.deprecated "Use [EConstr.isRefX] instead."]
 
 (** {5 Extra} *)
 

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -555,7 +555,7 @@ let rec check_and_clear_in_constr env evdref err ids global c =
         let () = if global then
           let check id' =
             if Id.Set.mem id' ids then
-              raise (ClearDependencyError (id',err,Some (Globnames.global_of_constr c)))
+              raise (ClearDependencyError (id',err,Some (fst @@ destRef c)))
           in
           Id.Set.iter check (Environ.vars_of_global env (fst @@ destRef c))
         in

--- a/engine/termops.ml
+++ b/engine/termops.ml
@@ -1066,19 +1066,9 @@ let global_of_constr sigma c =
   | Var id -> VarRef id, EConstr.EInstance.empty
   | _ -> raise Not_found
 
-let is_global sigma c t =
-  let open GlobRef in
-  match c, EConstr.kind sigma t with
-  | ConstRef c, Const (c', _) -> Constant.equal c c'
-  | IndRef i, Ind (i', _) -> eq_ind i i'
-  | ConstructRef i, Construct (i', _) -> eq_constructor i i'
-  | VarRef id, Var id' -> Id.equal id id'
-  | _ -> false
+let is_global = EConstr.isRefX
 
-let isGlobalRef sigma c =
-  match EConstr.kind sigma c with
-  | Const _ | Ind _ | Construct _ | Var _ -> true
-  | _ -> false
+let isGlobalRef = EConstr.isRef
 
 let is_template_polymorphic_ind env sigma f =
   match EConstr.kind sigma f with

--- a/engine/termops.mli
+++ b/engine/termops.mli
@@ -264,10 +264,13 @@ val dependency_closure : env -> Evd.evar_map -> named_context -> Id.Set.t -> Id.
 val is_section_variable : Id.t -> bool
 
 val global_of_constr : Evd.evar_map -> constr -> GlobRef.t * EInstance.t
+[@@ocaml.deprecated "Use [EConstr.destRef] instead (throws DestKO instead of Not_found)."]
 
 val is_global : Evd.evar_map -> GlobRef.t -> constr -> bool
+[@@ocaml.deprecated "Use [EConstr.isRefX] instead."]
 
 val isGlobalRef : Evd.evar_map -> constr -> bool
+[@@ocaml.deprecated "Use [EConstr.isRef] instead."]
 
 val is_template_polymorphic_ind : env -> Evd.evar_map -> constr -> bool
 

--- a/interp/reserve.ml
+++ b/interp/reserve.ml
@@ -104,8 +104,8 @@ let declare_reserved_type idl t =
 let find_reserved_type id = Id.Map.find (root_of_id id) !reserve_table
 
 let constr_key c =
-  try RefKey (canonical_gr (global_of_constr (fst (Constr.decompose_app c))))
-  with Not_found -> Oth
+  try RefKey (canonical_gr (fst @@ Constr.destRef (fst (Constr.decompose_app c))))
+  with Constr.DestKO -> Oth
 
 let revert_reserved_type t =
   try

--- a/kernel/constr.ml
+++ b/kernel/constr.ml
@@ -253,7 +253,7 @@ let mkFloat f = Float f
    least one argument and the function is not itself an applicative
    term *)
 
-let kind c = c
+let kind (c:t) = c
 
 let rec kind_nocast_gen kind c =
   match kind c with
@@ -337,6 +337,19 @@ let isCase c =  match kind c with Case _ -> true | _ -> false
 let isProj c =  match kind c with Proj _ -> true | _ -> false
 let isFix c =  match kind c with Fix _ -> true | _ -> false
 let isCoFix c =  match kind c with CoFix _ -> true | _ -> false
+
+let isRef c = match kind c with
+  | Const _ | Ind _ | Construct _ | Var _ -> true
+  | _ -> false
+
+let isRefX x c =
+  let open GlobRef in
+  match x, kind c with
+  | ConstRef c, Const (c', _) -> Constant.equal c c'
+  | IndRef i, Ind (i', _) -> eq_ind i i'
+  | ConstructRef i, Construct (i', _) -> eq_constructor i i'
+  | VarRef id, Var id' -> Id.equal id id'
+  | _ -> false
 
 (* Destructs a de Bruijn index *)
 let destRel c = match kind c with

--- a/kernel/constr.mli
+++ b/kernel/constr.mli
@@ -256,6 +256,8 @@ val isRel  : constr -> bool
 val isRelN : int -> constr -> bool
 val isVar  : constr -> bool
 val isVarId : Id.t -> constr -> bool
+val isRef : constr -> bool
+val isRefX : GlobRef.t -> constr -> bool
 val isInd  : constr -> bool
 val isEvar : constr -> bool
 val isMeta : constr -> bool

--- a/kernel/type_errors.ml
+++ b/kernel/type_errors.ml
@@ -48,7 +48,7 @@ type ('constr, 'types) ptype_error =
   | UnboundVar of variable
   | NotAType of ('constr, 'types) punsafe_judgment
   | BadAssumption of ('constr, 'types) punsafe_judgment
-  | ReferenceVariables of Id.t * 'constr
+  | ReferenceVariables of Id.t * GlobRef.t
   | ElimArity of pinductive * 'constr * ('constr, 'types) punsafe_judgment
       * (Sorts.family * Sorts.family * Sorts.family * arity_error) option
   | CaseNotInductive of ('constr, 'types) punsafe_judgment
@@ -182,7 +182,7 @@ let map_ptype_error f = function
 | UnboundVar id -> UnboundVar id
 | NotAType j -> NotAType (on_judgment f j)
 | BadAssumption j -> BadAssumption (on_judgment f j)
-| ReferenceVariables (id, c) -> ReferenceVariables (id, f c)
+| ReferenceVariables (id, c) -> ReferenceVariables (id, c)
 | ElimArity (pi, c, j, ar) -> ElimArity (pi, f c, on_judgment f j, ar)
 | CaseNotInductive j -> CaseNotInductive (on_judgment f j)
 | WrongCaseInfo (pi, ci) -> WrongCaseInfo (pi, ci)

--- a/kernel/type_errors.mli
+++ b/kernel/type_errors.mli
@@ -49,7 +49,7 @@ type ('constr, 'types) ptype_error =
   | UnboundVar of variable
   | NotAType of ('constr, 'types) punsafe_judgment
   | BadAssumption of ('constr, 'types) punsafe_judgment
-  | ReferenceVariables of Id.t * 'constr
+  | ReferenceVariables of Id.t * GlobRef.t
   | ElimArity of pinductive * 'constr * ('constr, 'types) punsafe_judgment
       * (Sorts.family * Sorts.family * Sorts.family * arity_error) option
   | CaseNotInductive of ('constr, 'types) punsafe_judgment
@@ -102,7 +102,7 @@ val error_not_type : env -> unsafe_judgment -> 'a
 
 val error_assumption : env -> unsafe_judgment -> 'a
 
-val error_reference_variables : env -> Id.t -> constr -> 'a
+val error_reference_variables : env -> Id.t -> GlobRef.t -> 'a
 
 val error_elim_arity :
   env -> pinductive -> constr -> unsafe_judgment ->

--- a/kernel/typeops.mli
+++ b/kernel/typeops.mli
@@ -111,7 +111,7 @@ val type_of_global_in_context : env -> GlobRef.t -> types * Univ.AUContext.t
 
 (** Check that hyps are included in env and fails with error otherwise *)
 val check_hyps_inclusion : env -> ?evars:((existential->constr option) * UGraph.t) ->
-  ('a -> constr) -> 'a -> Constr.named_context -> unit
+  GlobRef.t -> Constr.named_context -> unit
 
 val check_primitive_type : env -> CPrimitives.op_or_type -> types -> unit
 

--- a/library/globnames.ml
+++ b/library/globnames.ml
@@ -73,13 +73,7 @@ let global_of_constr c = match kind c with
   | Var id -> VarRef id
   |  _ -> raise Not_found
 
-let is_global c t =
-  match c, kind t with
-  | ConstRef c, Const (c', _) -> Constant.equal c c'
-  | IndRef i, Ind (i', _) -> eq_ind i i'
-  | ConstructRef i, Construct (i', _) -> eq_constructor i i'
-  | VarRef id, Var id' -> Id.equal id id'
-  | _ -> false
+let is_global = Constr.isRefX
 
 let printable_constr_of_global = function
   | VarRef id -> mkVar id

--- a/library/globnames.mli
+++ b/library/globnames.mli
@@ -32,6 +32,7 @@ val destIndRef : GlobRef.t -> inductive
 val destConstructRef : GlobRef.t -> constructor
 
 val is_global : GlobRef.t -> constr -> bool
+[@@ocaml.deprecated "Use [Constr.isRefX] instead."]
 
 val subst_constructor : substitution -> constructor -> constructor
 val subst_global : substitution -> GlobRef.t -> GlobRef.t * constr Univ.univ_abstracted option
@@ -44,6 +45,7 @@ val printable_constr_of_global : GlobRef.t -> constr
 (** Turn a construction denoting a global reference into a global reference;
    raise [Not_found] if not a global reference *)
 val global_of_constr : constr -> GlobRef.t
+[@@ocaml.deprecated "Use [Constr.destRef] instead (throws DestKO instead of Not_found)."]
 
 (** {6 Extended global references } *)
 

--- a/plugins/firstorder/sequent.ml
+++ b/plugins/firstorder/sequent.ml
@@ -209,11 +209,11 @@ let extend_with_auto_hints env sigma l seq =
     | Res_pf (c,_) | Give_exact (c,_)
     | Res_pf_THEN_trivial_fail (c,_) ->
       let (c, _, _) = c in
-      (try
-         let (gr, _) = Termops.global_of_constr sigma c in
+      (match  EConstr.destRef sigma c with
+       | exception Constr.DestKO -> seq, sigma
+       | gr, _ ->
          let sigma, typ = Typing.type_of env sigma c in
-         add_formula env sigma Hint gr typ seq, sigma
-       with Not_found -> seq, sigma)
+         add_formula env sigma Hint gr typ seq, sigma)
     | _ -> seq, sigma
   in
   let h acc dbname =

--- a/plugins/ltac/rewrite.ml
+++ b/plugins/ltac/rewrite.ml
@@ -289,18 +289,18 @@ end) = struct
     if Int.equal n 0 then c
     else
       match EConstr.kind sigma c with
-      | App (f, [| a; b; relb |]) when Termops.is_global sigma (pointwise_relation_ref ()) f ->
+      | App (f, [| a; b; relb |]) when isRefX sigma (pointwise_relation_ref ()) f ->
         decomp_pointwise sigma (pred n) relb
-      | App (f, [| a; b; arelb |]) when Termops.is_global sigma (forall_relation_ref ()) f ->
+      | App (f, [| a; b; arelb |]) when isRefX sigma (forall_relation_ref ()) f ->
         decomp_pointwise sigma (pred n) (Reductionops.beta_applist sigma (arelb, [mkRel 1]))
       | _ -> invalid_arg "decomp_pointwise"
 
   let rec apply_pointwise sigma rel = function
     | arg :: args ->
       (match EConstr.kind sigma rel with
-      | App (f, [| a; b; relb |]) when Termops.is_global sigma (pointwise_relation_ref ()) f ->
+      | App (f, [| a; b; relb |]) when isRefX sigma (pointwise_relation_ref ()) f ->
         apply_pointwise sigma relb args
-      | App (f, [| a; b; arelb |]) when Termops.is_global sigma (forall_relation_ref ()) f ->
+      | App (f, [| a; b; arelb |]) when isRefX sigma (forall_relation_ref ()) f ->
         apply_pointwise sigma (Reductionops.beta_applist sigma (arelb, [arg])) args
       | _ -> invalid_arg "apply_pointwise")
     | [] -> rel
@@ -357,7 +357,7 @@ end) = struct
     match EConstr.kind sigma t with
     | App (c, args) when Array.length args >= 2 ->
       let head = if isApp sigma c then fst (destApp sigma c) else c in
-        if Termops.is_global sigma (coq_eq_ref ()) head then None
+        if isRefX sigma (coq_eq_ref ()) head then None
         else
           (try
            let params, args = Array.chop (Array.length args - 2) args in
@@ -1880,13 +1880,13 @@ let declare_projection n instance_id r =
       let rec aux t =
         match EConstr.kind sigma t with
         | App (f, [| a ; a' ; rel; rel' |])
-            when Termops.is_global sigma (PropGlobal.respectful_ref ()) f ->
+            when isRefX sigma (PropGlobal.respectful_ref ()) f ->
           succ (aux rel')
         | _ -> 0
       in
       let init =
         match EConstr.kind sigma typ with
-            App (f, args) when Termops.is_global sigma (PropGlobal.respectful_ref ()) f  ->
+            App (f, args) when isRefX sigma (PropGlobal.respectful_ref ()) f  ->
               mkApp (f, fst (Array.chop (Array.length args - 2) args))
           | _ -> typ
       in aux init

--- a/plugins/ltac/taccoerce.ml
+++ b/plugins/ltac/taccoerce.ml
@@ -341,8 +341,8 @@ let coerce_to_reference sigma v =
   match Value.to_constr v with
   | Some c ->
     begin
-      try fst (Termops.global_of_constr sigma c)
-      with Not_found -> raise (CannotCoerceTo "a reference")
+      try fst (EConstr.destRef sigma c)
+      with DestKO -> raise (CannotCoerceTo "a reference")
     end
   | None -> raise (CannotCoerceTo "a reference")
 

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -34,7 +34,6 @@ open Tacinterp
 open Pretyping
 open Ppconstr
 open Printer
-open Globnames
 open Namegen
 open Evar_kinds
 open Constrexpr
@@ -464,7 +463,7 @@ let nb_cs_proj_args pc f u =
   | Sort s -> na (Sort_cs (Sorts.family s))
   | Const (c',_) when Constant.equal c' pc -> nargs_of_proj u.up_f
   | Proj (c',_) when Constant.equal (Projection.constant c') pc -> nargs_of_proj u.up_f
-  | Var _ | Ind _ | Construct _ | Const _ -> na (Const_cs (global_of_constr f))
+  | Var _ | Ind _ | Construct _ | Const _ -> na (Const_cs (fst @@ destRef f))
   | _ -> -1
   with Not_found -> -1
 

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -269,7 +269,7 @@ let check_conv_record env sigma (t1,sk1) (t2,sk2) =
         let sk2 = Stack.append_app args sk2 in
         lookup_canonical_conversion (proji, Const_cs c2), sk2
       | _ ->
-        let (c2, _) = Termops.global_of_constr sigma t2 in
+        let (c2, _) = try destRef sigma t2 with DestKO -> raise Not_found in
           lookup_canonical_conversion (proji, Const_cs c2),sk2
     with Not_found ->
       let (c, cs) = lookup_canonical_conversion (proji,Default_cs) in

--- a/pretyping/inductiveops.ml
+++ b/pretyping/inductiveops.ml
@@ -28,14 +28,14 @@ open Context.Rel.Declaration
 
 let type_of_inductive env (ind,u) =
  let (mib,_ as specif) = Inductive.lookup_mind_specif env ind in
- Typeops.check_hyps_inclusion env mkInd ind mib.mind_hyps;
+ Typeops.check_hyps_inclusion env (GlobRef.IndRef ind) mib.mind_hyps;
  Inductive.type_of_inductive env (specif,u)
 
 (* Return type as quoted by the user *)
 let type_of_constructor env (cstr,u) =
  let (mib,_ as specif) =
    Inductive.lookup_mind_specif env (inductive_of_constructor cstr) in
- Typeops.check_hyps_inclusion env mkConstruct cstr mib.mind_hyps;
+ Typeops.check_hyps_inclusion env (GlobRef.ConstructRef cstr) mib.mind_hyps;
  Inductive.type_of_constructor (cstr,u) specif
 
 (* Return constructor types in user form *)

--- a/pretyping/recordops.ml
+++ b/pretyping/recordops.ml
@@ -189,7 +189,7 @@ let rec cs_pattern_of_constr env t =
     let _, params = Inductive.find_rectype env ty in
     Const_cs (GlobRef.ConstRef (Projection.constant p)), None, params @ [c]
   | Sort s -> Sort_cs (Sorts.family s), None, []
-  | _ -> Const_cs (Globnames.global_of_constr t) , None, []
+  | _ -> Const_cs (fst @@ destRef t) , None, []
 
 let warn_projection_no_head_constant =
   CWarnings.create ~name:"projection-no-head-constant" ~category:"typechecker"
@@ -234,7 +234,7 @@ let compute_canonical_projections env ~warn (gref,ind) =
               ((GlobRef.ConstRef proji_sp, (patt, t)),
                { o_ORIGIN = gref ; o_DEF ; o_CTX ; o_INJ ; o_TABS ; o_TPARAMS ; o_NPARAMS ; o_TCOMPS })
               :: acc
-            | exception Not_found ->
+            | exception DestKO ->
               if warn then warn_projection_no_head_constant (sign, env, t, gref, proji_sp);
               acc
           ) acc spopt

--- a/pretyping/tacred.ml
+++ b/pretyping/tacred.ml
@@ -1311,11 +1311,9 @@ let reduce_to_ref_gen allow_product env sigma ref t =
           else
             error_cannot_recognize ref
       | _ ->
-          try
-            if GlobRef.equal (fst (global_of_constr sigma c)) ref
-            then it_mkProd_or_LetIn t l
-            else raise Not_found
-          with Not_found ->
+        if isRefX sigma ref c
+        then it_mkProd_or_LetIn t l
+        else
           try
             let t' = nf_betaiota env sigma (one_step_reduce env sigma t) in
             elimrec env t' l

--- a/pretyping/typeclasses.ml
+++ b/pretyping/typeclasses.ml
@@ -107,9 +107,9 @@ let class_info env sigma c =
     not_a_class env sigma (EConstr.of_constr (printable_constr_of_global c))
 
 let global_class_of_constr env sigma c =
-  try let gr, u = Termops.global_of_constr sigma c in
+  try let gr, u = EConstr.destRef sigma c in
     GlobRef.Map.find gr !classes, u
-  with Not_found -> not_a_class env sigma c
+  with DestKO | Not_found -> not_a_class env sigma c
 
 let dest_class_app env sigma c =
   let cl, args = EConstr.decompose_app sigma c in
@@ -125,9 +125,9 @@ let class_of_constr env sigma c =
   with e when CErrors.noncritical e -> None
 
 let is_class_constr sigma c =
-  try let gr, u = Termops.global_of_constr sigma c in
+  try let gr, u = EConstr.destRef sigma c in
     GlobRef.Map.mem gr !classes
-  with Not_found -> false
+  with DestKO | Not_found -> false
 
 let rec is_class_type evd c =
   let c, _ = Termops.decompose_app_vect evd c in
@@ -140,9 +140,9 @@ let is_class_evar evd evi =
   is_class_type evd evi.Evd.evar_concl
 
 let is_class_constr sigma c =
-  try let gr, u = Termops.global_of_constr sigma c in
+  try let gr, u = EConstr.destRef sigma c in
     GlobRef.Map.mem gr !classes
-  with Not_found -> false
+  with DestKO | Not_found -> false
 
 let rec is_maybe_class_type evd c =
   let c, _ = Termops.decompose_app_vect evd c in

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -356,7 +356,7 @@ let find_elim hdcncl lft2rgt dep cls ot =
   Proofview.Goal.enter_one begin fun gl ->
   let sigma = project gl in
   let is_global_exists gr c =
-    Coqlib.has_ref gr && Termops.is_global sigma (Coqlib.lib_ref gr) c
+    Coqlib.has_ref gr && isRefX sigma (Coqlib.lib_ref gr) c
   in
   let inccl = Option.is_empty cls in
   let env = Proofview.Goal.env gl in
@@ -1339,11 +1339,11 @@ let inject_if_homogenous_dependent_pair ty =
     let existTconstr = Coqlib.lib_ref    "core.sigT.intro" in
     (* check whether the equality deals with dep pairs or not *)
     let eqTypeDest = fst (decompose_app sigma t) in
-    if not (Termops.is_global sigma sigTconstr eqTypeDest) then raise Exit;
+    if not (isRefX sigma sigTconstr eqTypeDest) then raise Exit;
     let hd1,ar1 = decompose_app_vect sigma t1 and
         hd2,ar2 = decompose_app_vect sigma t2 in
-    if not (Termops.is_global sigma existTconstr hd1) then raise Exit;
-    if not (Termops.is_global sigma existTconstr hd2) then raise Exit;
+    if not (isRefX sigma existTconstr hd1) then raise Exit;
+    if not (isRefX sigma existTconstr hd2) then raise Exit;
     let (ind, _), _ = try pf_apply find_mrectype gl ar1.(0) with Not_found -> raise Exit in
     (* check if the user has declared the dec principle *)
     (* and compare the fst arguments of the dep pair *)
@@ -1692,8 +1692,8 @@ let () =
       optwrite = (:=) regular_subst_tactic }
 
 let restrict_to_eq_and_identity eq = (* compatibility *)
-  if not (is_global (lib_ref "core.eq.type") eq) &&
-    not (is_global (lib_ref "core.identity.type") eq)
+  if not (Constr.isRefX (lib_ref "core.eq.type") eq) &&
+    not (Constr.isRefX (lib_ref "core.identity.type") eq)
   then raise Constr_matching.PatternMatchingFailure
 
 exception FoundHyp of (Id.t * constr * bool)

--- a/tactics/hipattern.ml
+++ b/tactics/hipattern.ml
@@ -431,10 +431,10 @@ let match_eq sigma eqn (ref, hetero) =
   in
   match EConstr.kind sigma eqn with
   | App (c, [|t; x; y|]) ->
-    if not hetero && Termops.is_global sigma ref c then PolymorphicLeibnizEq (t, x, y)
+    if not hetero && isRefX sigma ref c then PolymorphicLeibnizEq (t, x, y)
     else raise PatternMatchingFailure
   | App (c, [|t; x; t'; x'|]) ->
-    if hetero && Termops.is_global sigma ref c then HeterogenousEq (t, x, t', x')
+    if hetero && isRefX sigma ref c then HeterogenousEq (t, x, t', x')
     else raise PatternMatchingFailure
   | _ -> raise PatternMatchingFailure
 
@@ -479,9 +479,9 @@ let find_this_eq_data_decompose env sigma eqn =
 
 let match_sigma env sigma ex =
   match EConstr.kind sigma ex with
-  | App (f, [| a; p; car; cdr |]) when Termops.is_global sigma (lib_ref "core.sig.intro") f ->
+  | App (f, [| a; p; car; cdr |]) when isRefX sigma (lib_ref "core.sig.intro") f ->
       build_sigma (), (snd (destConstruct sigma f), a, p, car, cdr)
-  | App (f, [| a; p; car; cdr |]) when Termops.is_global sigma (lib_ref "core.sigT.intro") f ->
+  | App (f, [| a; p; car; cdr |]) when isRefX sigma (lib_ref "core.sigT.intro") f ->
     build_sigma_type (), (snd (destConstruct sigma f), a, p, car, cdr)
   | _ -> raise PatternMatchingFailure
 

--- a/tactics/inv.ml
+++ b/tactics/inv.ml
@@ -352,7 +352,7 @@ let dest_nf_eq env sigma t = match EConstr.kind sigma t with
 | App (r, [| t; x; y |]) ->
   let open Reductionops in
   let eq = Coqlib.lib_ref "core.eq.type" in
-  if EConstr.is_global sigma eq r then
+  if isRefX sigma eq r then
     (t, whd_all env sigma x, whd_all env sigma y)
   else user_err Pp.(str "Not an equality.")
 | _ ->

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -3955,7 +3955,7 @@ let specialize_eqs id =
     match EConstr.kind !evars ty with
     | Prod (na, t, b) ->
         (match EConstr.kind !evars t with
-        | App (eq, [| eqty; x; y |]) when EConstr.is_global !evars Coqlib.(lib_ref "core.eq.type") eq ->
+        | App (eq, [| eqty; x; y |]) when isRefX !evars Coqlib.(lib_ref "core.eq.type") eq ->
             let c = if noccur_between !evars 1 (List.length ctx) x then y else x in
             let pt = mkApp (eq, [| eqty; c; c |]) in
             let ind = destInd !evars eq in
@@ -3963,7 +3963,7 @@ let specialize_eqs id =
               if unif (push_rel_context ctx env) evars pt t then
                 aux true ctx (mkApp (acc, [| p |])) (subst1 p b)
               else acc, in_eqs, ctx, ty
-        | App (heq, [| eqty; x; eqty'; y |]) when EConstr.is_global !evars (Lazy.force coq_heq_ref) heq ->
+        | App (heq, [| eqty; x; eqty'; y |]) when isRefX !evars (Lazy.force coq_heq_ref) heq ->
             let eqt, c = if noccur_between !evars 1 (List.length ctx) x then eqty', y else eqty, x in
             let pt = mkApp (heq, [| eqt; c; eqt; c |]) in
             let ind = destInd !evars heq in
@@ -4134,8 +4134,8 @@ let compute_elim_sig sigma ?elimc elimt =
       | Some (LocalDef _) -> error_ind_scheme ""
       | Some (LocalAssum (_,ind)) ->
           let indhd,indargs = decompose_app sigma ind in
-          try {!res with indref = Some (fst (Termops.global_of_constr sigma indhd)) }
-          with e when CErrors.noncritical e ->
+          try {!res with indref = Some (fst (destRef sigma indhd)) }
+          with DestKO ->
             error "Cannot find the inductive type of the inductive scheme."
 
 let compute_scheme_signature evd scheme names_info ind_type_guess =

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -201,9 +201,7 @@ let explain_bad_assumption env sigma j =
   str "because this term is not a type."
 
 let explain_reference_variables sigma id c =
-  (* c is intended to be a global reference *)
-  let pc = pr_global (fst (Termops.global_of_constr sigma c)) in
-  pc ++ strbrk " depends on the variable " ++ Id.print id ++
+  pr_global c ++ strbrk " depends on the variable " ++ Id.print id ++
   strbrk " which is not declared in the context."
 
 let rec pr_disjunction pr = function


### PR DESCRIPTION
- the kernel error ReferenceVariables (for check_hyps_inclusion) now contains a globref instead of a constr 
- standardize some aliases to `destRef`/`isRef`/`isRefX` (the later 2 are new, mimicking `isRel`/`isRelN`)