### PR TITLE
Fixing wrong comments in context.ml

### DIFF
--- a/kernel/context.ml
+++ b/kernel/context.ml
@@ -196,12 +196,10 @@ struct
   (** Return a new rel-context enriched by with a given inner-most declaration. *)
   let add d ctx = d :: ctx
 
-  (** Return the number of {e local declarations} in a given context. *)
+  (** Return the number of {e local declarations} in a given rel-context. *)
   let length = List.length
 
-  (** [extended_rel_list n Γ] builds an instance [args] such that [Γ,Δ ⊢ args:Γ]
-      with n = |Δ| and with the local definitions of [Γ] skipped in
-      [args]. Example: for [x:T,y:=c,z:U] and [n]=2, it gives [Rel 5, Rel 3]. *)
+  (** Return the number of {e local assumptions} in a given rel-context. *)
   let nhyps ctx =
     let open Declaration in
     let rec nhyps acc = function
@@ -413,7 +411,7 @@ struct
   (** empty named-context *)
   let empty = []
 
-  (** empty named-context *)
+  (** Return a new named-context enriched by with a given inner-most declaration. *)
   let add d ctx = d :: ctx
 
   (** Return the number of {e local declarations} in a given named-context. *)

--- a/kernel/context.mli
+++ b/kernel/context.mli
@@ -129,7 +129,7 @@ sig
   (** Return a new rel-context enriched by with a given inner-most declaration. *)
   val add : ('c, 't) Declaration.pt -> ('c, 't) pt -> ('c, 't) pt
 
-  (** Return the number of {e local declarations} in a given context. *)
+  (** Return the number of {e local declarations} in a given rel-context. *)
   val length : ('c, 't) pt -> int
 
   (** Check whether given two rel-contexts are equal. *)


### PR DESCRIPTION
**Kind:** fixes in the documentation of ocaml code

Two canonical fixes in the documentation of `Context.Rel.Declaration.nhyps` and `Context.Named.add` in the ml file. We copy what is done in the mli file, e.g, in the case of `nhyps` `(** Return the number of {e local assumptions} in a given rel-context. *)`. At the same time, we add `rel-` in a similar comment, for consistency of the documentation.