### PR TITLE
Recognize Default Proof Using in STM

### DIFF
--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -2154,6 +2154,7 @@ let collect_proof keep cur hd brkind id =
  let is_defined = function
    | _, { expr = e } -> is_defined_expr e.CAst.v.expr
                         && (not (Vernacprop.has_Fail e)) in
+ let has_default_proof_using = Option.has_some (Proof_using.get_default_proof_using ()) in
  let proof_using_ast = function
    | VernacProof(_,Some _) -> true
    | _ -> false
@@ -2162,7 +2163,7 @@ let collect_proof keep cur hd brkind id =
    | Some (_, v) when proof_using_ast v.expr.CAst.v.expr
                       && (not (Vernacprop.has_Fail v.expr)) -> Some v
    | _ -> None in
- let has_proof_using x = proof_using_ast x <> None in
+ let has_proof_using x = has_default_proof_using || (proof_using_ast x <> None) in
  let proof_no_using = function
    | VernacProof(t,None) -> t
    | _ -> assert false


### PR DESCRIPTION
Treat a Set Default Proof Using call the same as having a syntactic
Proof using ... annotation. This ensures that proofs in sections are
skipped in -vos mode when there are enough annotations to determine the
type of the resulting theorem.

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** bug fix.

Fixes #11342.


<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [ ] Added / updated test-suite
