### PR TITLE
[misc] Better preserve backtraces in several modules

### DIFF
--- a/dev/ci/user-overlays/11566-ejgallego-exninfo+coercion.sh
+++ b/dev/ci/user-overlays/11566-ejgallego-exninfo+coercion.sh
@@ -1,0 +1,6 @@
+if [ "$CI_PULL_REQUEST" = "11566" ] || [ "$CI_BRANCH" = "exninfo+coercion" ]; then
+
+    mtac2_CI_REF=exninfo+coercion
+    mtac2_CI_GITURL=https://github.com/ejgallego/Mtac2
+
+fi

--- a/interp/constrexpr_ops.ml
+++ b/interp/constrexpr_ops.ml
@@ -618,8 +618,9 @@ let interp_univ_constraints env evd cstrs =
     let cstrs' = Univ.Constraint.add cstr cstrs in
     try let evd = Evd.add_constraints evd (Univ.Constraint.singleton cstr) in
         evd, cstrs'
-    with Univ.UniverseInconsistency e ->
-      CErrors.user_err ~hdr:"interp_constraint"
+    with Univ.UniverseInconsistency e as exn ->
+      let _, info = Exninfo.capture exn in
+      CErrors.user_err ~hdr:"interp_constraint" ~info
         (Univ.explain_universe_inconsistency (Termops.pr_evd_level evd) e)
   in
   List.fold_left interp (evd,Univ.Constraint.empty) cstrs

--- a/interp/smartlocate.ml
+++ b/interp/smartlocate.ml
@@ -56,11 +56,15 @@ let global_inductive_with_alias qid  =
   | ref ->
       user_err ?loc:qid.CAst.loc ~hdr:"global_inductive"
         (pr_qualid qid ++ spc () ++ str "is not an inductive type.")
-  with Not_found -> Nametab.error_global_not_found qid
+  with Not_found as exn ->
+    let _, info = Exninfo.capture exn in
+    Nametab.error_global_not_found ~info qid
 
 let global_with_alias ?head qid =
   try locate_global_with_alias ?head qid
-  with Not_found -> Nametab.error_global_not_found qid
+  with Not_found as exn ->
+    let _, info = Exninfo.capture exn in
+    Nametab.error_global_not_found ~info qid
 
 let smart_global ?(head = false) = let open Constrexpr in CAst.with_loc_val (fun ?loc -> function
   | AN r ->

--- a/kernel/cbytegen.ml
+++ b/kernel/cbytegen.ml
@@ -874,8 +874,11 @@ let compile ~fail_on_error ?universes:(universes=0) env c =
     (if !dump_bytecode then
       Feedback.msg_debug (dump_bytecodes init_code !fun_code fv)) ;
     Some (init_code,!fun_code, Array.of_list fv)
-  with TooLargeInductive msg ->
-    let fn = if fail_on_error then CErrors.user_err ?loc:None ~hdr:"compile" else
+  with TooLargeInductive msg as exn ->
+    let _, info = Exninfo.capture exn in
+    let fn = if fail_on_error then
+        CErrors.user_err ?loc:None ~info ~hdr:"compile"
+      else
         (fun x -> Feedback.msg_warning x) in
     fn msg; None
 

--- a/lib/cErrors.ml
+++ b/lib/cErrors.ml
@@ -25,12 +25,17 @@ let _ =
   in
   Printexc.register_printer pr
 
-let anomaly ?loc ?label pp =
-  Loc.raise ?loc (Anomaly (label, pp))
+let anomaly ?loc ?info ?label pp =
+  let info = Option.default Exninfo.null info in
+  let info = Option.cata (Loc.add_loc info) info loc in
+  Exninfo.iraise (Anomaly (label, pp), info)
 
 exception UserError of string option * Pp.t (* User errors *)
 
-let user_err ?loc ?hdr strm = Loc.raise ?loc (UserError (hdr, strm))
+let user_err ?loc ?info ?hdr strm =
+  let info = Option.default Exninfo.null info in
+  let info = Option.cata (Loc.add_loc info) info loc in
+  Exninfo.iraise (UserError (hdr, strm), info)
 
 exception Timeout
 

--- a/lib/cErrors.mli
+++ b/lib/cErrors.mli
@@ -21,7 +21,7 @@ val push : exn -> Exninfo.iexn
  [Anomaly] is used for system errors and [UserError] for the
    user's ones. *)
 
-val anomaly : ?loc:Loc.t -> ?label:string -> Pp.t -> 'a
+val anomaly : ?loc:Loc.t -> ?info:Exninfo.info -> ?label:string -> Pp.t -> 'a
 (** Raise an anomaly, with an optional location and an optional
     label identifying the anomaly. *)
 
@@ -34,7 +34,7 @@ exception UserError of string option * Pp.t
 (** Main error signaling exception. It carries a header plus a pretty printing
     doc *)
 
-val user_err : ?loc:Loc.t -> ?hdr:string -> Pp.t -> 'a
+val user_err : ?loc:Loc.t -> ?info:Exninfo.info -> ?hdr:string -> Pp.t -> 'a
 (** Main error raising primitive. [user_err ?loc ?hdr pp] signals an
     error [pp] with optional header and location [hdr] [loc] *)
 

--- a/library/nametab.mli
+++ b/library/nametab.mli
@@ -91,7 +91,7 @@ end
 exception GlobalizationError of qualid
 
 (** Raises a globalization error *)
-val error_global_not_found : qualid -> 'a
+val error_global_not_found : info:Exninfo.info -> qualid -> 'a
 
 (** {6 Register visibility of things } *)
 

--- a/plugins/extraction/extract_env.ml
+++ b/plugins/extraction/extract_env.ml
@@ -581,7 +581,7 @@ let rec locate_ref = function
         with Nametab.GlobalizationError _ | UserError _ -> None
       in
       match mpo, ro with
-        | None, None -> Nametab.error_global_not_found qid
+        | None, None -> Nametab.error_global_not_found ~info:Exninfo.null qid
         | None, Some r -> let refs,mps = locate_ref l in r::refs,mps
         | Some mp, None -> let refs,mps = locate_ref l in refs,mp::mps
         | Some mp, Some r ->

--- a/pretyping/pretype_errors.ml
+++ b/pretyping/pretype_errors.ml
@@ -69,15 +69,17 @@ let precatchable_exception = function
   | Nametab.GlobalizationError _ -> true
   | _ -> false
 
-let raise_pretype_error ?loc (env,sigma,te) =
-  Loc.raise ?loc (PretypeError(env,sigma,te))
+let raise_pretype_error ?loc ?info (env,sigma,te) =
+  let info = Option.default Exninfo.null info in
+  let info = Option.cata (Loc.add_loc info) info loc in
+  Exninfo.iraise (PretypeError(env,sigma,te),info)
 
 let raise_type_error ?loc (env,sigma,te) =
   Loc.raise ?loc (PretypeError(env,sigma,TypingError te))
 
-let error_actual_type ?loc env sigma {uj_val=c;uj_type=actty} expty reason =
+let error_actual_type ?loc ?info env sigma {uj_val=c;uj_type=actty} expty reason =
   let j = {uj_val=c;uj_type=actty} in
-  raise_pretype_error ?loc
+  raise_pretype_error ?loc ?info
     (env, sigma, ActualTypeNotCoercible (j, expty, reason))
 
 let error_actual_type_core ?loc env sigma {uj_val=c;uj_type=actty} expty =

--- a/pretyping/pretype_errors.mli
+++ b/pretyping/pretype_errors.mli
@@ -75,7 +75,7 @@ val precatchable_exception : exn -> bool
 
 (** Raising errors *)
 val error_actual_type :
-  ?loc:Loc.t -> env -> Evd.evar_map -> unsafe_judgment -> constr ->
+  ?loc:Loc.t -> ?info:Exninfo.info -> env -> Evd.evar_map -> unsafe_judgment -> constr ->
       unification_error -> 'b
 
 val error_actual_type_core :

--- a/user-contrib/Ltac2/tac2core.ml
+++ b/user-contrib/Ltac2/tac2core.ml
@@ -1162,8 +1162,9 @@ let () =
   | Tac2qexpr.QReference qid ->
     let gr =
       try Nametab.locate qid
-      with Not_found ->
-        Nametab.error_global_not_found qid
+      with Not_found as exn ->
+        let _, info = Exninfo.capture exn in
+        Nametab.error_global_not_found ~info qid
     in
     GlbVal gr, gtypref t_reference
   in

--- a/vernac/obligations.ml
+++ b/vernac/obligations.ml
@@ -20,7 +20,7 @@ open DeclareObl
 open DeclareObl.Obligation
 open DeclareObl.ProgramDecl
 
-let pperror cmd = CErrors.user_err ~hdr:"Program" cmd
+let pperror ?info cmd = CErrors.user_err ~hdr:"Program" ?info cmd
 let error s = pperror (str s)
 
 let reduce c =
@@ -92,10 +92,16 @@ let get_any_prog () =
   else raise (NoObligations None)
 
 let get_prog_err n =
-  try get_prog n with NoObligations id -> pperror (explain_no_obligations id)
+  try get_prog n
+  with NoObligations id as exn ->
+    let _, info = Exninfo.capture exn in
+    pperror ~info (explain_no_obligations id)
 
 let get_any_prog_err () =
-  try get_any_prog () with NoObligations id -> pperror (explain_no_obligations id)
+  try get_any_prog ()
+  with NoObligations id as exn ->
+    let _, info = Exninfo.capture exn in
+    pperror ~info (explain_no_obligations id)
 
 let all_programs () =
   ProgMap.fold (fun k p l -> p :: l) (get_prg_info_map ()) []


### PR DESCRIPTION
Re-raising inside exception handlers must be done with care in order
to preserve backtraces; even if newer OCaml versions do a better job
in automatically spilling `%reraise` in places that matter, there is
no guarantee for that to happen.

I've done a best-effort pass of places that were re-raising
incorrectly, hopefully I got the logic right.

There is the special case of `Nametab.error_global_not_found` which is
raised many times in response to a `Not_found` error; IMHO this error
should be converted to something more specific, however the scope of
that change would be huge as to do easily...

Overlay:
- https://github.com/Mtac2/Mtac2/pull/254