### PR TITLE
Cleanup the handling of the shelf in refine

### DIFF
--- a/dev/ci/user-overlays/07825-reachable-from-evars.sh
+++ b/dev/ci/user-overlays/07825-reachable-from-evars.sh
@@ -1,0 +1,9 @@
+if [ "$CI_PULL_REQUEST" = "7825" ] || [ "$CI_BRANCH" = "reachable-from-evars" ]; then
+
+    fiat_crypto_legacy_CI_REF=fix-simple-refine
+    fiat_crypto_legacy_CI_GITURL=https://github.com/maximedenes/fiat-crypto
+
+    compcert_CI_REF=fix-refine-order
+    compcert_CI_GITURL=https://github.com/maximedenes/CompCert
+
+fi

--- a/dev/ci/user-overlays/07825-reachable-from-evars.sh
+++ b/dev/ci/user-overlays/07825-reachable-from-evars.sh
@@ -1,8 +1,5 @@
 if [ "$CI_PULL_REQUEST" = "7825" ] || [ "$CI_BRANCH" = "reachable-from-evars" ]; then
 
-    fiat_crypto_legacy_CI_REF=fix-simple-refine
-    fiat_crypto_legacy_CI_GITURL=https://github.com/maximedenes/fiat-crypto
-
     compcert_CI_REF=fix-refine-order
     compcert_CI_GITURL=https://github.com/maximedenes/CompCert
 

--- a/doc/changelog/02-specification-language/07825-rechable-from-evars.rst
+++ b/doc/changelog/02-specification-language/07825-rechable-from-evars.rst
@@ -1,0 +1,8 @@
+- In `refine`, new existential variables unified with existing ones are no
+  longer considered as fresh. The behavior of `simple refine` no longer depend on
+  the orientation of evar-evar unification problems, and new existential variables
+  are always turned into (unshelved) goals. This can break compatibility in
+  some cases (`#7825 <https://github.com/coq/coq/pull/7825>`_, by Matthieu
+  Sozeau, with help from Maxime Dénès, review by Pierre-Marie Pédrot and
+  Enrico Tassi, fixes `#4095 <https://github.com/coq/coq/issues/4095>`_ and
+  `#4413 <https://github.com/coq/coq/issues/4413>`_).

--- a/doc/changelog/02-specification-language/07825-rechable-from-evars.rst
+++ b/doc/changelog/02-specification-language/07825-rechable-from-evars.rst
@@ -1,5 +1,6 @@
-- In `refine`, new existential variables unified with existing ones are no
-  longer considered as fresh. The behavior of `simple refine` no longer depend on
+- **Changed:**
+  In :tacn:`refine`, new existential variables unified with existing ones are no
+  longer considered as fresh. The behavior of :tacn:`simple refine` no longer depends on
   the orientation of evar-evar unification problems, and new existential variables
   are always turned into (unshelved) goals. This can break compatibility in
   some cases (`#7825 <https://github.com/coq/coq/pull/7825>`_, by Matthieu

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -533,14 +533,7 @@ let restrict_evar evd evk filter ?src candidates =
   let candidates = Option.map (filter_effective_candidates evd evar_info filter) candidates in
   match candidates with
   | Some [] -> raise (ClearDependencyError (*FIXME*)(Id.of_string "blah", (NoCandidatesLeft evk), None))
-  | _ ->
-     let evd, evk' = Evd.restrict evk filter ?candidates ?src evd in
-     (* Mark new evar as future goal, removing previous one,
-        circumventing Proofview.advance but making Proof.run_tactic catch these. *)
-     let future_goals = Evd.save_future_goals evd in
-     let future_goals = Evd.filter_future_goals (fun evk' -> not (Evar.equal evk evk')) future_goals in
-     let evd = Evd.restore_future_goals evd future_goals in
-     (Evd.declare_future_goal evk' evd, evk')
+  | _ -> Evd.restrict evk filter ?candidates ?src evd
 
 let rec check_and_clear_in_constr env evdref err ids global c =
   (* returns a new constr where all the evars have been 'cleaned'

--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -128,6 +128,10 @@ val gather_dependent_evars : evar_map -> Evar.t list -> (Evar.Set.t option) Evar
     solved. *)
 val advance : evar_map -> Evar.t -> Evar.t option
 
+(** [reachable_from_evars sigma seeds] computes the descendents of
+    evars in [seeds] by restriction or evar-evar unifications in [sigma]. *)
+val reachable_from_evars : evar_map -> Evar.Set.t -> Evar.Set.t
+
 (** The following functions return the set of undefined evars
     contained in the object, the defined evars being traversed.
     This is roughly a combination of the previous functions and
@@ -250,8 +254,8 @@ exception ClearDependencyError of Id.t * clear_dependency_error * GlobRef.t opti
 
 (** Restrict an undefined evar according to a (sub)filter and candidates.
     The evar will be defined if there is only one candidate left,
-@raise ClearDependencyError NoCandidatesLeft if the filter turns the candidates
-  into an empty list. *)
+    @raise ClearDependencyError NoCandidatesLeft if the filter turns the candidates
+    into an empty list. *)
 
 val restrict_evar : evar_map -> Evar.t -> Filter.t ->
   ?src:Evar_kinds.t Loc.located -> constr list option -> evar_map * Evar.t

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -331,6 +331,22 @@ val eval_side_effects : evar_map -> side_effects
 val drop_side_effects : evar_map -> evar_map
 (** This should not be used. For hacking purposes. *)
 
+(** {5 Shelved evars}
+
+  The shelved status is used to communicate with the proofview:
+  the shelved evar status information is used during unification to
+  promote any evar being unified with a shelved evar to the shelf itself.
+  I.e. shelved has priority over non-shelved (regular goal) status.
+*)
+
+val add_shelved_evars : Evar.Set.t -> evar_map -> evar_map
+(** Add the given evars to the shelved evars. This must be used when calling
+  typechecking functions using the evar_map from tactics to carry around the
+  global shelving information. *)
+
+val is_shelved_evar : evar_map -> Evar.t -> bool
+(** Test is an evar is shelved *)
+
 (** {5 Future goals} *)
 
 type goal_kind = ToShelve | ToGiveUp

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -263,8 +263,11 @@ val restrict : Evar.t-> Filter.t -> ?candidates:econstr list ->
     possibly limiting the instances to a set of candidates (candidates
     are filtered according to the filter) *)
 
-val is_restricted_evar : evar_map -> Evar.t -> Evar.t option
-(** Tell if an evar comes from restriction of another evar, and if yes, which *)
+val get_aliased_evars : evar_map -> Evar.t Evar.Map.t
+(** The map of aliased evars *)
+
+val is_aliased_evar : evar_map -> Evar.t -> Evar.t option
+(** Tell if an evar has been aliased to another evar, and if yes, which *)
 
 val set_typeclass_evars : evar_map -> Evar.Set.t -> evar_map
 (** Mark the given set of evars as available for resolution.

--- a/engine/proofview.mli
+++ b/engine/proofview.mli
@@ -462,8 +462,11 @@ module Unsafe : sig
   (** [tclSETSHELF gls] sets goals [gls] as the current shelf. *)
   val tclSETSHELF : Evar.t list -> unit tactic
 
-  (** [tclGETSHELF] returns the list of goals on the shelf. *)
+  (** [tclGETSHELF] returns the list of goals on the local shelf. *)
   val tclGETSHELF : Evar.t list tactic
+
+  (** [tclGETGLOBALSHELF] returns the list of goals on the global shelf. *)
+  val tclGETGLOBALSHELF : Evar.t list tactic
 
   (** [tclPUTSHELF] appends goals to the shelf. *)
   val tclPUTSHELF : Evar.t list -> unit tactic
@@ -476,6 +479,9 @@ module Unsafe : sig
 
   (** Clears the future goals store in the proof view. *)
   val reset_future_goals : proofview -> proofview
+
+  (** Sets the global shelved goals. *)
+  val set_global_shelf : Evar.t list -> proofview -> proofview
 
   (** Give the evars the status of a goal (changes their source location
       and makes them unresolvable for type classes. *)

--- a/engine/proofview_monad.mli
+++ b/engine/proofview_monad.mli
@@ -79,11 +79,12 @@ val with_empty_state : goal -> goal_with_state
 val map_goal_with_state : (goal -> goal) -> goal_with_state -> goal_with_state
 
 (** Type of proof views: current [evar_map] together with the list of
-    focused goals. *)
+    focused goals, locally shelved goals and globally shelved goals. *)
 type proofview = {
   solution : Evd.evar_map;
   comb : goal_with_state list;
-  shelf : goal list;
+  local_shelf : goal list;
+  global_shelf: goal list;
 }
 
 (** {6 Instantiation of the logic monad} *)
@@ -116,6 +117,10 @@ module type State = sig
   val set : t -> unit Logical.t
   val modify : (t->t) -> unit Logical.t
 end
+module type Reader = sig
+  type t
+  val get : t Logical.t
+end
 
 module type Writer = sig
   type t
@@ -140,6 +145,10 @@ module Status : Writer with type t := bool
 (** Lens to the list of goals which have been shelved during the
     execution of the tactic. *)
 module Shelf : State with type t = goal list
+
+(** Lens to the list of goals which are globally shelved at the
+  start of the tactic. *)
+module Global_Shelf : Reader with type t = goal list
 
 (** Lens to the list of goals which were given up during the execution
     of the tactic. *)

--- a/engine/termops.ml
+++ b/engine/termops.ml
@@ -306,15 +306,15 @@ let pr_evar_map_gen with_univs pr_evars env sigma =
 
 let pr_evar_list env sigma l =
   let open Evd in
-  let pr_restrict ev =
-    match is_restricted_evar sigma ev with
+  let pr_alias ev =
+    match is_aliased_evar sigma ev with
     | None -> mt ()
-    | Some ev' -> str " (restricted to " ++ Evar.print ev' ++ str ")"
+    | Some ev' -> str " (aliased to " ++ Evar.print ev' ++ str ")"
   in
   let pr (ev, evi) =
     h 0 (Evar.print ev ++
       str "==" ++ pr_evar_info env sigma evi ++
-      pr_restrict ev ++
+      pr_alias ev ++
       (if evi.evar_body == Evar_empty
        then str " {" ++ pr_existential_key sigma ev ++ str "}"
        else mt ()))

--- a/proofs/proof.ml
+++ b/proofs/proof.ml
@@ -360,7 +360,7 @@ let compact p =
 
 let run_tactic env tac pr =
   let open Proofview.Notations in
-  let sp = pr.proofview in
+  let sp = Proofview.Unsafe.set_global_shelf pr.shelf pr.proofview in
   let undef sigma l = List.filter (fun g -> Evd.is_undefined sigma g) l in
   let tac =
     tac >>= fun result ->

--- a/tactics/tacticals.ml
+++ b/tactics/tacticals.ml
@@ -491,6 +491,8 @@ module New = struct
   (* Check that holes in arguments have been resolved *)
 
   let check_evars env sigma extsigma origsigma =
+    let reachable = lazy (Evarutil.reachable_from_evars sigma
+                            (Evar.Map.domain (Evd.undefined_map origsigma))) in
     let rec is_undefined_up_to_restriction sigma evk =
       if Evd.mem origsigma evk then None else
       let evi = Evd.find sigma evk in
@@ -506,7 +508,12 @@ module New = struct
     let rest =
       Evd.fold_undefined (fun evk evi acc ->
         match is_undefined_up_to_restriction sigma evk with
-        | Some (evk',evi) -> (evk',evi)::acc
+        | Some (evk',evi) ->
+           (* If [evk'] descends from [evk] which descends itself from
+              an originally undefined evar in [origsigma], it is a not
+              a fresh undefined hole from [sigma]. *)
+           if Evar.Set.mem evk (Lazy.force reachable) then acc
+           else (evk',evi)::acc
         | _ -> acc)
         extsigma []
     in

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -5055,14 +5055,14 @@ end
 
 (** Tacticals defined directly in term of Proofview *)
 module New = struct
-  open Genredexpr
-  open Locus
-
   let reduce_after_refine =
-    reduce
-      (Lazy {rBeta=true;rMatch=true;rFix=true;rCofix=true;
-             rZeta=false;rDelta=false;rConst=[]})
-      {onhyps = Some []; concl_occs = AllOccurrences }
+    (* For backward compatibility reasons, we do not contract let-ins, but we unfold them. *)
+    let redfun env t =
+      let open CClosure in
+      let flags = RedFlags.red_add_transparent allnolet TransparentState.empty in
+      clos_norm_flags flags env t
+    in
+    reduct_in_concl ~check:false (redfun,DEFAULTcast)
 
   let refine ~typecheck c =
     Refine.refine ~typecheck c <*>

--- a/test-suite/bugs/closed/bug_10298.v
+++ b/test-suite/bugs/closed/bug_10298.v
@@ -21,7 +21,7 @@ Parameter ID : forall (G:Prop), G -> G.
 Parameter EID : forall A (EA:Enc A) (F:FORM) (Q:A->Prop),
   F _ _ Q ->
   F _ _ Q.
-
+Set Printing Implicit.
 Lemma bla : forall F,
   (forall A (EA:Enc A), IDF F EA (fun (X:A) => True) -> True) ->
   True.
@@ -31,5 +31,6 @@ Proof.
   notypeclasses refine (EID _ _ _ _).
   eapply (ID _).
   Unshelve.
-  + apply FORM_intro.
+  (* Should be 3 goals: the Enc typeclass should not have been resolved *)
+  3:refine (FORM_intro _).
 Qed.

--- a/test-suite/bugs/closed/bug_4095.v
+++ b/test-suite/bugs/closed/bug_4095.v
@@ -71,7 +71,8 @@ Goal forall (T : Type) (O0 : T -> OPred) (O1 : T -> PointedOPred)
     refine (P _ _)
   end.
   Undo.
-  Fail lazymatch goal with
+  Set Typeclasses Debug.
+  lazymatch goal with
   | |- ?R (?f ?a ?b) (?f ?a' ?b') =>
     let P := constr:(fun H H' => Morphisms.proper_prf a a' H b b' H') in
     set(p:=P)

--- a/test-suite/bugs/closed/bug_4413.v
+++ b/test-suite/bugs/closed/bug_4413.v
@@ -1,0 +1,8 @@
+
+(* Regression wrt v8.4 related to the change of order of resolution of evar-evar unification problems. *)
+Goal exists x, x=1 -> True.
+eexists. intro H.
+pose proof (f_equal (fun k => k) H).
+Undo.
+pose (@f_equal _ _ S _ _ H).
+Abort.

--- a/test-suite/bugs/closed/bug_7825.v
+++ b/test-suite/bugs/closed/bug_7825.v
@@ -1,0 +1,25 @@
+Record T (x : nat) := { t : x = x }.
+
+Set Debug  Refine.
+
+Goal exists x, T x.
+  refine (ex_intro _ _ _).
+  Show Existentials.
+  simple refine {| t := _ |}.
+  reflexivity.
+  Unshelve. exact 0.
+Qed.
+
+(** Fine if the new evar is defined as the originally shelved evar:  we do nothing.
+  In the other direction we promote the non-shelved new goal to a shelved one:
+  shelved status has priority over goal status. *)
+
+Goal forall a : nat,  exists x, T x.
+   evar (x : nat). subst x. Show Existentials.
+   intros a. simple refine (ex_intro ?[x0] _ _). shelve. simpl.
+   (** Here ?x := ?x0 which is shelved, so ?x becomes shelved even if it would
+   not be by default (refine ?x and _ produce non-shelved evars by default)*)
+   simple refine (Build_T ?x _).
+   reflexivity.
+   Unshelve. exact 0.
+Qed.


### PR DESCRIPTION
Should wait for #7825 to be merged first.

**Kind:** bug fix

Refine can put on the shelf evars that are already globally shelved, so run_tactic ends up with a shelf that contains duplicates. We avoid this by clearing already shelved evars from the `newshelft` produced by refine. This ensures we see a consistent `(n shelved goals)` annotation in PG for example. Luckily, `Unshelve` is immune to this problem so this does not affect execution of tactics, only display AFAIK.

Really hard to test (needs PG I think), and not sure this really deserves a mention in the changelog. A bench will be useful though, as this introduces quite a few allocations and calls to filter in refine.