### PR TITLE
Fixing extra space in front of keywords in Print Grammar

### DIFF
--- a/gramlib/grammar.ml
+++ b/gramlib/grammar.ml
@@ -831,8 +831,9 @@ let rec print_symbol : type s tr r. formatter -> (s, tr, r) ty_symbol -> unit =
       fprintf ppf "LIST1 %a SEP %a%s" print_symbol1 s print_symbol1 t
         (if osep then " OPT_SEP" else "")
   | Sopt s -> fprintf ppf "OPT %a" print_symbol1 s
-  | Stoken p when L.tok_pattern_strings p <> ("", None) ->
+  | Stoken p ->
      begin match L.tok_pattern_strings p with
+     | "", Some s -> print_str ppf s
      | con, Some prm -> fprintf ppf "%s@ %a" con print_str prm
      | con, None -> fprintf ppf "%s" con end
   | Snterml (e, l) ->

--- a/test-suite/output/Notations4.out
+++ b/test-suite/output/Notations4.out
@@ -4,11 +4,11 @@ Entry constr:myconstr is
 [ "6" RIGHTA
   [  ]
 | "5" RIGHTA
-  [ SELF;  "+"; NEXT ]
+  [ SELF; "+"; NEXT ]
 | "4" RIGHTA
-  [ SELF;  "*"; NEXT ]
+  [ SELF; "*"; NEXT ]
 | "3" RIGHTA
-  [  "<"; constr:operconstr LEVEL "10";  ">" ] ]
+  [ "<"; constr:operconstr LEVEL "10"; ">" ] ]
 
 [< b > + < b > * < 2 >]
      : nat


### PR DESCRIPTION
**Kind:** bug fix

`Print Grammar constr` now looks like:
```
...
| "5" RIGHTA
  [ SELF; "+"; NEXT ]
...
```
instead of:
```
...
| "5" RIGHTA
  [ SELF;  "+"; NEXT ]
...
```
This was apparently due to a small mistake in `Gramlib.Grammar` (since the same keyword in recursive position was w/o the extra space).

- [X] Updated test-suite
- [ ] Entry added in the changelog (overkill or needed?)