### PR TITLE
[nix] Fix building of the documentation

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -77,7 +77,7 @@ stdenv.mkDerivation rec {
            !elem (baseNameOf path) [".git" "result" "bin" "_build" "_build_ci" "nix"]) ./.;
 
   preConfigure = ''
-    patchShebangs dev/tools/
+    patchShebangs dev/tools/ doc/stdlib
   '';
 
   prefixKey = "-prefix ";


### PR DESCRIPTION
The interpreter directive of “doc/stdlib/make-library-index” must be patched. Otherwise, the build may fail in a sandbox where `/usr/bin/env` is not available.