### PR TITLE
[exn] Keep information from multiple extra exn handlers

### DIFF
--- a/lib/cErrors.mli
+++ b/lib/cErrors.mli
@@ -75,5 +75,5 @@ val noncritical : exn -> bool
    exceptions. This method is fragile and should be considered
    deprecated *)
 val register_additional_error_info
-  :  (Exninfo.info -> (Pp.t option Loc.located) option)
+  :  (Exninfo.info -> Pp.t Loc.located option)
   -> unit

--- a/plugins/ltac/tactic_debug.ml
+++ b/plugins/ltac/tactic_debug.ml
@@ -418,7 +418,7 @@ let extract_ltac_trace ?loc trace =
     (* We entered a user-defined tactic,
        we display the trace with location of the call *)
     let msg = hov 0 (explain_ltac_call_trace c tail loc ++ fnl()) in
-    (if Loc.finer loc tloc then loc else tloc), Some msg
+    (if Loc.finer loc tloc then loc else tloc), msg
   else
     (* We entered a primitive tactic, we don't display trace but
        report on the finest location *)
@@ -434,7 +434,7 @@ let extract_ltac_trace ?loc trace =
              aux best_loc tail
         | [] -> best_loc in
         aux loc trace in
-    best_loc, None
+    best_loc, mt ()
 
 let get_ltac_trace info =
   let ltac_trace = Exninfo.get info ltac_trace_info in

--- a/plugins/ltac/tactic_debug.mli
+++ b/plugins/ltac/tactic_debug.mli
@@ -79,4 +79,4 @@ val db_breakpoint : debug_info ->
   lident message_token list -> unit Proofview.NonLogical.t
 
 val extract_ltac_trace :
-  ?loc:Loc.t -> Tacexpr.ltac_trace -> Pp.t option Loc.located
+  ?loc:Loc.t -> Tacexpr.ltac_trace -> Pp.t Loc.located

--- a/user-contrib/Ltac2/tac2entries.ml
+++ b/user-contrib/Ltac2/tac2entries.ml
@@ -862,7 +862,7 @@ let () = CErrors.register_additional_error_info begin fun info ->
     let bt =
       str "Backtrace:" ++ fnl () ++ prlist_with_sep fnl pr_frame bt ++ fnl ()
     in
-    Some (Loc.tag @@ Some bt)
+    Some (Loc.tag bt)
   else None
 end
 


### PR DESCRIPTION
This fixes #11547 ; note that it is hard to register such handlers in
the `Summary` due to layering issues; there are potential anomalies here
depending on how plugins do register their data structures.
