### PR TITLE
test for x[i] notation not breaking Ltac parsing

### DIFF
--- a/test-suite/success/NotationsAndLtac.v
+++ b/test-suite/success/NotationsAndLtac.v
@@ -1,0 +1,52 @@
+(* Test that adding notations that overlap with the tactic grammar does not
+* interfere with Ltac parsing. *)
+
+Module test1.
+  Notation "x [ y ]" := (fst (id x, id y)) (at level 11).
+
+  Goal True \/ (exists x : nat, True /\ True) -> True.
+  Proof.
+  intros [|[a [y z]]]; [idtac|idtac]; try solve [eauto | trivial; [trivial]].
+  Qed.
+End test1.
+
+Module test2.
+  Notation "x [ y ]" := (fst (id x, id y)) (at level 100).
+  Goal True \/ (exists x : nat, True /\ True) -> True.
+  Proof.
+  intros [|[a [y z]]]; [idtac|idtac]; try solve [eauto | trivial; [trivial]].
+  Qed.
+End test2.
+
+Module test3.
+  Notation "x [ y ]" := (fst (id x, id y)) (at level 1).
+  Goal True \/ (exists x : nat, True /\ True) -> True.
+  Proof.
+  intros [|[a [y z]]]; [idtac|idtac]; try solve [eauto | trivial; [trivial]].
+  Qed.
+End test3.
+
+Module test1'.
+  Notation "x [ [ y ] ] " := (fst (id x, id y)) (at level 11).
+
+  Goal True \/ (exists x : nat, True /\ True) -> True.
+  Proof.
+  intros [|[a [y z]]]; [idtac|idtac]; try solve [eauto | trivial; [trivial]].
+  Qed.
+End test1'.
+
+Module test2'.
+  Notation "x [ [ y ] ]" := (fst (id x, id y)) (at level 100).
+  Goal True \/ (exists x : nat, True /\ True) -> True.
+  Proof.
+  intros [|[a [y z]]]; [idtac|idtac]; try solve [eauto | trivial; [trivial]].
+  Qed.
+End test2'.
+
+Module test3'.
+  Notation "x [ [ y ] ]" := (fst (id x, id y)) (at level 1).
+  Goal True \/ (exists x : nat, True /\ True) -> True.
+  Proof.
+  intros [|[a [y z]]]; [idtac|idtac]; try solve [eauto | trivial; [trivial]].
+  Qed.
+End test3'.


### PR DESCRIPTION
**Kind:** test. If I recall correctly, this used to fail a couple of years ago. I don't want it to fail. @JasonGross do you know whether there is some variant that still fails?

(I recalled this when re-reading #9633.)