### PR TITLE
[coqdep] Remove support for `-c` ocamldep replacement.

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -42,17 +42,17 @@ COQTIME_FILE_MAKER:=tools/TimeFileMaker.py
 COQMAKE_BOTH_TIME_FILES:=tools/make-both-time-files.py
 COQMAKE_BOTH_SINGLE_TIMING_FILES:=tools/make-both-single-timing-files.py
 VOTOUR:=bin/votour
+OCAMLLIBDEP:=bin/ocamllibdep$(EXE)
+OCAMLLIBDEPBYTE:=bin/ocamllibdep.byte$(EXE)
 
 # these get installed!
 TOOLS:=$(COQDEP) $(COQMAKEFILE) $(COQTEX) $(COQWC) $(COQDOC) $(COQC)\
-	$(COQWORKMGR) $(COQPP) $(VOTOUR)
+	$(COQWORKMGR) $(COQPP) $(VOTOUR) $(OCAMLLIBDEP)
 TOOLS_HELPERS:=tools/CoqMakefile.in $(COQMAKE_ONE_TIME_FILE) $(COQTIME_FILE_MAKER)\
 	$(COQMAKE_BOTH_TIME_FILES) $(COQMAKE_BOTH_SINGLE_TIMING_FILES)
 
 COQDEPBOOT:=bin/coqdep_boot$(EXE)
 COQDEPBOOTBYTE:=bin/coqdep_boot.byte$(EXE)
-OCAMLLIBDEP:=bin/ocamllibdep$(EXE)
-OCAMLLIBDEPBYTE:=bin/ocamllibdep.byte$(EXE)
 FAKEIDE:=bin/fake_ide$(EXE)
 FAKEIDEBYTE:=bin/fake_ide.byte$(EXE)
 

--- a/doc/sphinx/practical-tools/utilities.rst
+++ b/doc/sphinx/practical-tools/utilities.rst
@@ -545,7 +545,7 @@ Computing Module dependencies
 In order to compute module dependencies (to be used by ``make`` or
 ``dune``), |Coq| provides the ``coqdep`` tool.
 
-``coqdep`` computes inter-module dependencies for |Coq| and |OCaml|
+``coqdep`` computes inter-module dependencies for |Coq|
 programs, and prints the dependencies on the standard output in a
 format readable by make. When a directory is given as argument, it is
 recursively looked at.
@@ -553,11 +553,6 @@ recursively looked at.
 Dependencies of |Coq| modules are computed by looking at ``Require``
 commands (``Require``, ``Require Export``, ``Require Import``), but also at the
 command ``Declare ML Module``.
-
-Dependencies of |OCaml| modules are computed by looking at
-`open` commands and the dot notation *module.value*. However, this is
-done approximately and you are advised to use ``ocamldep`` instead for the
-|OCaml| module dependencies.
 
 See the man page of ``coqdep`` for more details and options.
 

--- a/man/coqdep.1
+++ b/man/coqdep.1
@@ -12,9 +12,6 @@ coqdep \- Compute inter-module dependencies for Coq and Caml programs
 .BI \-coqlib \ directory
 ]
 [
-.BI \-c
-]
-[
 .BI \-i
 ]
 [
@@ -51,10 +48,6 @@ directives and the dot notation
 
 .SH OPTIONS
 
-.TP
-.BI \-c
-Prints the dependencies of Caml modules.
-(On Caml modules, the behaviour is exactly the same as ocamldep).
 .TP
 .BI \-f \ file
 Read filenames and options -I, -R and -Q from a _CoqProject FILE.
@@ -152,29 +145,8 @@ example% coqdep \-I . *.v
 .fi
 .RE
 .br
-.ne 7
-.LP
-To get only the Caml dependencies:
-.IP
-.B
-example% coqdep \-c \-I . *.ml
-.RS
-.sp .5
-.nf
-.B D.cmo: D.ml ./A.cmo ./B.cmo ./C.cmo
-.B D.cmx: D.ml ./A.cmx ./B.cmx ./C.cmx
-.B C.cmo: C.ml
-.B C.cmx: C.ml
-.B B.cmo: B.ml
-.B B.cmx: B.ml
-.B A.cmo: A.ml
-.B A.cmx: A.ml
-.fi
-.RE
-.br
-.ne 7
 
 .SH BUGS
 
 Please report any bug to
-.B coq\-bugs@pauillac.inria.fr
+.B https://github.com/coq/coq/issues

--- a/tools/CoqMakefile.in
+++ b/tools/CoqMakefile.in
@@ -455,13 +455,13 @@ all.ps: $(VFILES)
 	$(SHOW)'COQDOC -ps $(GAL)'
 	$(HIDE)$(COQDOC) \
 		-toc $(COQDOCFLAGS) -ps $(GAL) $(COQDOCLIBS) \
-		-o $@ `$(COQDEP) -sort -suffix .v $(VFILES)`
+		-o $@ `$(COQDEP) -sort $(VFILES)`
 
 all.pdf: $(VFILES)
 	$(SHOW)'COQDOC -pdf $(GAL)'
 	$(HIDE)$(COQDOC) \
 		-toc $(COQDOCFLAGS) -pdf $(GAL) $(COQDOCLIBS) \
-		-o $@ `$(COQDEP) -sort -suffix .v $(VFILES)`
+		-o $@ `$(COQDEP) -sort $(VFILES)`
 
 # FIXME: not quite right, since the output name is different
 gallinahtml: GAL=-g

--- a/tools/CoqMakefile.in
+++ b/tools/CoqMakefile.in
@@ -91,6 +91,7 @@ COQDEP   ?= "$(COQBIN)coqdep"
 COQDOC   ?= "$(COQBIN)coqdoc"
 COQPP    ?= "$(COQBIN)coqpp"
 COQMKFILE ?= "$(COQBIN)coq_makefile"
+OCAMLLIBDEP ?= "$(COQBIN)ocamllibdep"
 
 # Timing scripts
 COQMAKE_ONE_TIME_FILE ?= "$(COQLIB)/tools/make-one-time-file.py"
@@ -747,12 +748,12 @@ $(addsuffix .d,$(MLFILES)): %.ml.d: %.ml
 	$(HIDE)$(CAMLDEP) $(OCAMLLIBS) "$<" $(redir_if_ok)
 
 $(addsuffix .d,$(MLLIBFILES)): %.mllib.d: %.mllib
-	$(SHOW)'COQDEP $<'
-	$(HIDE)$(COQDEP) $(OCAMLLIBS) -c "$<" $(redir_if_ok)
+	$(SHOW)'OCAMLLIBDEP $<'
+	$(HIDE)$(OCAMLLIBDEP) -c $(OCAMLLIBS) "$<" $(redir_if_ok)
 
 $(addsuffix .d,$(MLPACKFILES)): %.mlpack.d: %.mlpack
-	$(SHOW)'COQDEP $<'
-	$(HIDE)$(COQDEP) $(OCAMLLIBS) -c "$<" $(redir_if_ok)
+	$(SHOW)'OCAMLLIBDEP $<'
+	$(HIDE)$(OCAMLLIBDEP) -c $(OCAMLLIBS) "$<" $(redir_if_ok)
 
 # If this makefile is created using a _CoqProject we have coqdep get
 # options from it. This avoids argument length limits for pathological

--- a/tools/coqdep.ml
+++ b/tools/coqdep.ml
@@ -31,7 +31,6 @@ let option_sort = ref false
 let usage () =
   eprintf " usage: coqdep [options] <filename>+\n";
   eprintf " options:\n";
-  eprintf "  -c : Also print the dependencies of caml modules (=ocamldep).\n";
   eprintf "  -boot : For coq developers, prints dependencies over coq library files (omitted by default).\n";
   eprintf "  -sort : output the given file name ordered by dependencies\n";
   eprintf "  -noglob | -no-glob : \n";
@@ -44,7 +43,6 @@ let usage () =
   eprintf "  -vos : also output dependencies about .vos files\n";
   eprintf "  -exclude-dir dir : skip subdirectories named 'dir' during -R/-Q search\n";
   eprintf "  -coqlib dir : set the coq standard library directory\n";
-  eprintf "  -slash : deprecated, no effect\n";
   eprintf "  -dyndep (opt|byte|both|no|var) : set how dependencies over ML modules are printed\n";
   exit 1
 
@@ -64,8 +62,6 @@ let treat_coqproject f =
   iter_sourced (fun f -> treat_file None f) (all_files project)
 
 let rec parse = function
-  (* TODO, deprecate option -c *)
-  | "-c" :: ll -> option_c := true; parse ll
   | "-boot" :: ll -> option_boot := true; parse ll
   | "-sort" :: ll -> option_sort := true; parse ll
   | "-vos" :: ll -> write_vos := true; parse ll
@@ -111,11 +107,7 @@ let coqdep () =
       (Envars.xdg_dirs ~warn:(fun x -> coqdep_warning "%s" x));
     List.iter (fun s -> add_rec_dir_no_import add_coqlib_known s []) Envars.coqpath;
   end;
-  List.iter (fun (f,d) -> add_mli_known f d ".mli") !mliAccu;
-  List.iter (fun (f,d) -> add_mllib_known f d ".mllib") !mllibAccu;
-  List.iter (fun (f,suff,d) -> add_ml_known f d suff) !mlAccu;
   if !option_sort then begin sort (); exit 0 end;
-  if !option_c then mL_dependencies ();
   coq_dependencies ();
   ()
 

--- a/tools/coqdep.ml
+++ b/tools/coqdep.ml
@@ -44,7 +44,6 @@ let usage () =
   eprintf "  -vos : also output dependencies about .vos files\n";
   eprintf "  -exclude-dir dir : skip subdirectories named 'dir' during -R/-Q search\n";
   eprintf "  -coqlib dir : set the coq standard library directory\n";
-  eprintf "  -suffix s : \n";
   eprintf "  -slash : deprecated, no effect\n";
   eprintf "  -dyndep (opt|byte|both|no|var) : set how dependencies over ML modules are printed\n";
   exit 1
@@ -81,8 +80,6 @@ let rec parse = function
   | "-exclude-dir" :: [] -> usage ()
   | "-coqlib" :: r :: ll -> Envars.set_user_coqlib r; parse ll
   | "-coqlib" :: [] -> usage ()
-  | "-suffix" :: s :: ll -> suffixe := s ; parse ll
-  | "-suffix" :: [] -> usage ()
   | "-dyndep" :: "no" :: ll -> option_dynlink := No; parse ll
   | "-dyndep" :: "opt" :: ll -> option_dynlink := Opt; parse ll
   | "-dyndep" :: "byte" :: ll -> option_dynlink := Byte; parse ll

--- a/tools/coqdep_common.ml
+++ b/tools/coqdep_common.ml
@@ -38,8 +38,6 @@ let option_boot = ref false
 
 let norec_dirs = ref StrSet.empty
 
-let suffixe = ref ".vo"
-
 type dir = string option
 
 (** [get_extension f l] checks whether [f] has one of the extensions
@@ -498,10 +496,10 @@ let coq_dependencies () =
   List.iter
     (fun (name,_) ->
        let ename = escape name in
-       let glob = if !option_noglob then "" else " "^ename^".glob" in
+       let glob = if !option_noglob then "" else ename^".glob " in
        let deps = find_dependencies name in
-       printf "%s%s%s %s.v.beautified %s.required_vo: %s.v %s\n" ename !suffixe glob ename ename ename
-        (string_of_dependency_list !suffixe deps);
+       printf "%s.vo %s%s.v.beautified %s.required_vo: %s.v %s\n" ename glob ename ename ename
+        (string_of_dependency_list ".vo" deps);
        printf "%s.vio: %s.v %s\n" ename ename
          (string_of_dependency_list ".vio" deps);
        if !write_vos then
@@ -639,7 +637,7 @@ let sort () =
         done
       with Fin_fichier ->
         close_in cin;
-        printf "%s%s " file !suffixe
+        printf "%s.v " file
     end
   in
   List.iter (fun (name,_) -> loop name) !vAccu

--- a/tools/coqdep_common.mli
+++ b/tools/coqdep_common.mli
@@ -21,7 +21,6 @@ val coqdep_warning : ('a, Format.formatter, unit, unit) format4 -> 'a
 val find_dir_logpath: string -> string list
 
 (** Options *)
-val option_c : bool ref
 val option_noglob : bool ref
 val option_boot : bool ref
 val write_vos : bool ref
@@ -35,18 +34,11 @@ type dir = string option
 val treat_file : dir -> string -> unit
 
 (** ML-related manipulation *)
-val mlAccu : (string * string * dir) list ref
-val mliAccu : (string * dir) list ref
-val mllibAccu : (string * dir) list ref
-val add_ml_known : string -> dir -> string -> unit
-val add_mli_known : string -> dir -> string -> unit
-val add_mllib_known : string -> dir -> string -> unit
-val mL_dependencies : unit -> unit
-
 val coq_dependencies : unit -> unit
 val add_known : bool -> string -> string list -> string -> unit
 val add_coqlib_known : bool -> string -> string list -> string -> unit
 
+(* Used to locate plugins for [Declare ML Module] *)
 val add_caml_dir : string -> unit
 
 (** Simply add this directory and imports it, no subdirs. This is used

--- a/tools/coqdep_common.mli
+++ b/tools/coqdep_common.mli
@@ -25,7 +25,6 @@ val option_c : bool ref
 val option_noglob : bool ref
 val option_boot : bool ref
 val write_vos : bool ref
-val suffixe : string ref
 
 type dynlink = Opt | Byte | Both | No | Variable
 val option_dynlink : dynlink ref

--- a/tools/coqdep_lexer.mli
+++ b/tools/coqdep_lexer.mli
@@ -8,12 +8,10 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-type mL_token = Use_module of string
-
 type qualid = string list
 
 type coq_token =
-    Require of qualid option * qualid list
+  | Require of qualid option * qualid list
   | Declare of string list
   | Load of string
   | AddLoadPath of string
@@ -23,6 +21,3 @@ exception Fin_fichier
 exception Syntax_error of int * int
 
 val coq_action : Lexing.lexbuf -> coq_token
-val caml_action : Lexing.lexbuf -> mL_token
-val mllib_list : Lexing.lexbuf -> string list
-val ocamldep_parse : Lexing.lexbuf -> string list

--- a/tools/dune
+++ b/tools/dune
@@ -29,7 +29,15 @@
  (modules coqdep_lexer coqdep_common coqdep)
  (libraries coq.lib))
 
-(ocamllex coqdep_lexer)
+; Bare-bones mllib/mlpack parser
+(executable
+ (name ocamllibdep)
+ (public_name ocamllibdep)
+ (modules ocamllibdep)
+ (package coq)
+ (libraries unix))
+
+(ocamllex coqdep_lexer ocamllibdep)
 
 (executable
  (name coqwc)

--- a/tools/ocamllibdep.mll
+++ b/tools/ocamllibdep.mll
@@ -195,6 +195,14 @@ let mllib_dependencies () =
        flush stdout)
     (List.rev !mllibAccu)
 
+let coq_makefile_mode = ref false
+
+let print_for_pack modname d =
+  if !coq_makefile_mode then
+    printf "%s.cmx : FOR_PACK=-for-pack %s\n" d modname
+  else
+    printf "%s_FORPACK:= -for-pack %s\n" d modname
+
 let mlpack_dependencies () =
   List.iter
     (fun (name,dirname) ->
@@ -204,7 +212,7 @@ let mlpack_dependencies () =
        let sdeps = String.concat " " deps in
        let efullname = escape fullname in
        printf "%s_MLPACK_DEPENDENCIES:=%s\n" efullname sdeps;
-       List.iter (fun d -> printf "%s_FORPACK:= -for-pack %s\n" d modname) deps;
+       List.iter (print_for_pack modname) deps;
        printf "%s.cmo:$(addsuffix .cmo,$(%s_MLPACK_DEPENDENCIES))\n"
          efullname efullname;
        printf "%s.cmx:$(addsuffix .cmx,$(%s_MLPACK_DEPENDENCIES))\n"
@@ -213,6 +221,7 @@ let mlpack_dependencies () =
     (List.rev !mlpackAccu)
 
 let rec parse = function
+  | "-c" :: r -> coq_makefile_mode := true; parse r
   | "-I" :: r :: ll ->
        (* To solve conflict (e.g. same filename in kernel and checker)
           we allow to state an explicit order *)


### PR DESCRIPTION
There is not need for coqdep to ship an `ocamldep` replacement, in
particular:

- not used in the main build since a long time
- not tested
- not kept up to date with upstream

This allows for a significant reduction of `coqdep` code, including
some duplicated code from `ocamllibdep`.

`coq_makefile` now uses `ocamllibdep` to process `mllib/mlpack` files,
so it has then to be installed.

We also remove the residual `-slash` option.

**Kind:** infrastructure.

- [x] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [ ] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
