### PR TITLE
Fixes #9741: only printing notations do not uselessly reserve parsing keywords

### DIFF
--- a/doc/changelog/03-notations/11590-master+fix9741-only-printing-does-not-reserve-keyword.rst
+++ b/doc/changelog/03-notations/11590-master+fix9741-only-printing-does-not-reserve-keyword.rst
@@ -1,0 +1,4 @@
+- **Fixed:**
+  Notations in onlyprinting mode do not uselessly reserve parsing keywords
+  (`#11590 <https://github.com/coq/coq/pull/11590>`_,
+  by Hugo Herbelin, fixes `#9741 <https://github.com/coq/coq/pull/9741>`_).

--- a/parsing/notation_gram.ml
+++ b/parsing/notation_gram.ml
@@ -37,7 +37,4 @@ type one_notation_grammar = {
   notgram_prods : grammar_constr_prod_item list list;
 }
 
-type notation_grammar = {
-  notgram_onlyprinting : bool;
-  notgram_rules : one_notation_grammar list
-}
+type notation_grammar = one_notation_grammar list

--- a/parsing/notgram_ops.ml
+++ b/parsing/notgram_ops.ml
@@ -15,16 +15,16 @@ open Notation
 open Notation_gram
 
 (* Register the level of notation for parsing and printing
-   (we also register a precomputed parsing rule) *)
+   (also register the parsing rule if not onlyprinting) *)
 
 let notation_level_map = Summary.ref ~name:"notation_level_map" NotationMap.empty
 
-let declare_notation_level ntn ~onlyprint parsing_rule level =
+let declare_notation_level ntn parsing_rule level =
   try
     let _ = NotationMap.find ntn !notation_level_map in
     anomaly (str "Notation " ++ pr_notation ntn ++ str " is already assigned a level.")
   with Not_found ->
-  notation_level_map := NotationMap.add ntn (onlyprint,parsing_rule,level) !notation_level_map
+  notation_level_map := NotationMap.add ntn (parsing_rule,level) !notation_level_map
 
 let level_of_notation ntn =
   NotationMap.find ntn !notation_level_map

--- a/parsing/notgram_ops.mli
+++ b/parsing/notgram_ops.mli
@@ -16,8 +16,8 @@ val level_eq : level -> level -> bool
 
 (** {6 Declare and test the level of a (possibly uninterpreted) notation } *)
 
-val declare_notation_level : notation -> onlyprint:bool -> notation_grammar -> level -> unit
-val level_of_notation : notation -> bool (* = onlyprint *) * notation_grammar * level
+val declare_notation_level : notation -> notation_grammar option -> level -> unit
+val level_of_notation : notation -> notation_grammar option * level
   (** raise [Not_found] if not declared *)
 
 (** Returns notations with defined parsing/printing rules *)

--- a/parsing/ppextend.ml
+++ b/parsing/ppextend.ml
@@ -59,7 +59,8 @@ let rec unparsing_eq unp1 unp2 = match (unp1,unp2) with
   | (UnpMetaVar _ | UnpBinderMetaVar _ | UnpListMetaVar _ |
      UnpBinderListMetaVar _ | UnpTerminal _ | UnpBox _ | UnpCut _), _ -> false
 
-(* Concrete syntax for symbolic-extension table *)
+(* Register generic and specific printing rules *)
+
 let generic_notation_printing_rules =
   Summary.ref ~name:"generic-notation-printing-rules" (NotationMap.empty : (unparsing_rule * bool * extra_unparsing_rules) NotationMap.t)
 

--- a/test-suite/bugs/closed/bug_9741.v
+++ b/test-suite/bugs/closed/bug_9741.v
@@ -1,0 +1,21 @@
+(* This was failing at parsing *)
+
+Notation "'a'" := tt (only printing).
+Goal True. let a := constr:(1+1) in idtac a. Abort.
+
+(* Idem *)
+
+Require Import Coq.Strings.String.
+Require Import Coq.ZArith.ZArith.
+Open Scope string_scope.
+
+Axiom Ox: string -> Z.
+
+Axiom isMMIOAddr: Z -> Prop.
+
+Notation "'Ox' a" := (Ox a) (only printing, at level 10, format "'Ox' a").
+
+Goal False.
+  set (f := isMMIOAddr).
+  set (x := f (Ox "0018")).
+Abort.


### PR DESCRIPTION
**Kind:** bug fix / enhancement

Fixes / closes #9741.

This depends on #10832 (of which it was a part up to now). Only the last two commits are specific.

- [X] Added / updated test-suite
- [X] Entry added in the changelog
