### PR TITLE
Notations declared independently in only printing and only parsing mode should agree on levels

### DIFF
--- a/doc/changelog/03-notations/11591-master+onlyprinting-onparsing-agree-on-levels.rst
+++ b/doc/changelog/03-notations/11591-master+onlyprinting-onparsing-agree-on-levels.rst
@@ -1,0 +1,5 @@
+- **Changed:**
+  The same notation with interpretation separately declared in only
+  parsing and only printing modes should refer to the same levels
+  (`#11591 <https://github.com/coq/coq/pull/11591>`_,
+  by Hugo Herbelin).

--- a/test-suite/bugs/closed/bug_8106.v
+++ b/test-suite/bugs/closed/bug_8106.v
@@ -1,4 +1,4 @@
 (* Was raising an anomaly "already assigned a level" on the second line *)
 
 Notation "c1 ; c2" := (c1 + c2) (only printing, at level 76, right associativity, c1 at level 76, c2 at level 76).
-Notation "c1 ; c2" := (c1 + c2) (only parsing, at level 76, right associativity, c2 at level 76).
+Fail Notation "c1 ; c2" := (c1 + c2) (only parsing, at level 76, right associativity, c2 at level 76).

--- a/test-suite/output/onlyprinting.out
+++ b/test-suite/output/onlyprinting.out
@@ -1,2 +1,6 @@
 0:-) 0
      : nat
+The command has indeed failed with message:
+Notation "_ :-) _" is already defined at level 50 with arguments constr
+at next level, constr at next level while it is now required to be
+at level 45 with arguments constr at next level, constr at next level.

--- a/test-suite/output/onlyprinting.v
+++ b/test-suite/output/onlyprinting.v
@@ -3,3 +3,5 @@ Reserved Notation "x :-) y" (at level 50, only printing).
 Notation "x :-) y" := (plus x y).
 
 Check 0 + 0.
+
+Fail Notation "x :-) y" := (x * y) (at level 45).

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -828,7 +828,7 @@ let check_and_extend_constr_grammar ntn rule =
     if notation_eq ntn ntn_for_grammar then raise Not_found;
     let prec = rule.notgram_level in
     let oldparsing,oldprec = Notgram_ops.level_of_notation ntn_for_grammar in
-    if not (Notgram_ops.level_eq prec oldprec) && oldparsing <> None then error_parsing_incompatible_level ntn ntn_for_grammar oldprec prec;
+    if not (Notgram_ops.level_eq prec oldprec) then error_parsing_incompatible_level ntn ntn_for_grammar oldprec prec;
     if oldparsing = None then raise Not_found
   with Not_found ->
     Egramcoq.extend_constr_grammar rule
@@ -840,7 +840,7 @@ let cache_one_syntax_extension (pa_se,pp_se) =
   let oldparsing =
     try
       let oldparsing,oldprec = Notgram_ops.level_of_notation ntn in
-      if not (Notgram_ops.level_eq prec oldprec) && (oldparsing <> None || pa_se.synext_notgram = None) then error_incompatible_level ntn oldprec prec;
+      if not (Notgram_ops.level_eq prec oldprec) then error_incompatible_level ntn oldprec prec;
       oldparsing
     with Not_found ->
       (* Declare the level and the precomputed parsing rule *)


### PR DESCRIPTION
**Kind:** design

Depends on #10832 (merged) and #11590 (merged). 

The same notation with interpretations separately declared in `only parsing` and `only printing` modes, or with extra `only printing` interpretations, should refer to the same levels.

This was initially part of #10832 but it has an impact on CI (in perennial) so I single it out so that it can be discussed independently.

This adds constraints on the symmetry between parsing and printing, even when the rules are given independently.

Such cases can be found e.g. in perennial (file `goose_lang/typing.v`):
```
Notation "⊢ v : A" := (base_lit_hasTy v%V A%ht) (at level 90, only printing) : heap_types.
Notation "⊢ e : A" := (val_hasTy ∅ e%V A%ht) (at level 90, e at next level, A at next level) : heap_types.
```
with purpose to write `⊢ v : A` for two kinds of judgements (even if parsing has only one interpretation).

I don't know if it is legitimate to require that it is instead:
```
Notation "⊢ v : A" := (base_lit_hasTy v%V A%ht) (at level 90, v at next level, A at next level, only printing) : heap_types.
Notation "⊢ e : A" := (val_hasTy ∅ e%V A%ht) (at level 90, e at next level, A at next level) : heap_types.
```

More generally, this seems to question whether we would want to support different expressions having the same printing rule in the same scope, and whether we want such only printing notations to share their level structure.

- [X] Added / updated test-suite
- [X] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
