### PR TITLE
New syntax [Inductive Acc A R | x : Prop := ...]

### DIFF
--- a/doc/changelog/02-specification-language/11600-uniform-syntax.rst
+++ b/doc/changelog/02-specification-language/11600-uniform-syntax.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  New syntax :g:`Inductive Acc A R | x : Prop := ...` to specify which
+  parameters of an inductive are uniform.
+  (`#11600 <https://github.com/coq/coq/pull/11600>`_, by Gaëtan Gilbert).

--- a/doc/sphinx/language/gallina-specification-language.rst
+++ b/doc/sphinx/language/gallina-specification-language.rst
@@ -1063,6 +1063,18 @@ Parameterized inductive types
         | cons3 : A -> list3 -> list3.
         End list3.
 
+     For finer control, you can use a ``|`` between the uniform and
+     the non-uniform parameters:
+
+     .. coqtop:: in reset
+
+        Inductive Acc {A:Type} (R:A->A->Prop) | (x:A) : Prop
+          := Acc_in : (forall y, R y x -> Acc y) -> Acc x.
+
+     The flag can then be seen as deciding whether the ``|`` is at the
+     beginning (when the flag is unset) or at the end (when it is set)
+     of the parameters when not explicitly given.
+
 .. seealso::
    Section :ref:`inductive-definitions` and the :tacn:`induction` tactic.
 

--- a/doc/sphinx/language/gallina-specification-language.rst
+++ b/doc/sphinx/language/gallina-specification-language.rst
@@ -1063,9 +1063,6 @@ Parameterized inductive types
         | cons3 : A -> list3 -> list3.
         End list3.
 
-     Attributes ``uniform`` and ``nonuniform`` respectively enable and
-     disable uniform parameters for a single inductive declaration block.
-
 .. seealso::
    Section :ref:`inductive-definitions` and the :tacn:`induction` tactic.
 

--- a/plugins/funind/glob_term_to_relation.ml
+++ b/plugins/funind/glob_term_to_relation.ml
@@ -1476,7 +1476,7 @@ let do_build_inductive
   in
   let rel_ind i ext_rel_constructors =
     ((CAst.make @@ relnames.(i)),
-    rel_params,
+    (rel_params,None),
     Some rel_arities.(i),
     ext_rel_constructors),[]
   in

--- a/test-suite/success/uniform_inductive_parameters.v
+++ b/test-suite/success/uniform_inductive_parameters.v
@@ -1,23 +1,13 @@
-Module Att.
-  #[uniform] Inductive list (A : Type) :=
-  | nil : list
-  | cons : A -> list -> list.
-  Check (list : Type -> Type).
-  Check (cons : forall A, A -> list A -> list A).
-End Att.
-
 Set Uniform Inductive Parameters.
 
 Inductive list (A : Type) :=
-| nil : list
-| cons : A -> list -> list.
+  | nil : list
+  | cons : A -> list -> list.
 Check (list : Type -> Type).
 Check (cons : forall A, A -> list A -> list A).
 
 Inductive list2 (A : Type) (A' := prod A A) :=
-| nil2 : list2
-| cons2 : A' -> list2 -> list2.
+  | nil2 : list2
+  | cons2 : A' -> list2 -> list2.
 Check (list2 : Type -> Type).
 Check (cons2 : forall A (A' := prod A A), A' -> list2 A -> list2 A).
-
-#[nonuniform] Inductive bla (n:nat) := c (_ : bla (S n)).

--- a/test-suite/success/uniform_inductive_parameters.v
+++ b/test-suite/success/uniform_inductive_parameters.v
@@ -11,3 +11,12 @@ Inductive list2 (A : Type) (A' := prod A A) :=
   | cons2 : A' -> list2 -> list2.
 Check (list2 : Type -> Type).
 Check (cons2 : forall A (A' := prod A A), A' -> list2 A -> list2 A).
+
+Inductive list3 | A := nil3 | cons3 : A -> list3 (A * A)%type -> list3 A.
+
+Unset Uniform Inductive Parameters.
+
+Inductive list4 A | := nil4 | cons4 : A -> list4 -> list4.
+
+Inductive Acc {A:Type} (R:A->A->Prop) | (x:A) : Prop
+  := Acc_in : (forall y, R y x -> Acc y) -> Acc x.

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -395,9 +395,10 @@ GRAMMAR EXTEND Gram
   ;
   inductive_definition:
     [ [ oc = opt_coercion; id = ident_decl; indpar = binders;
+        extrapar = OPT [ "|"; p = binders -> { p } ];
         c = OPT [ ":"; c = lconstr -> { c } ];
         lc=opt_constructors_or_fields; ntn = decl_notation ->
-           { (((oc,id),indpar,c,lc),ntn) } ] ]
+           { (((oc,id),(indpar,extrapar),c,lc),ntn) } ] ]
   ;
   constructor_list_or_record_decl:
     [ [ "|"; l = LIST1 constructor SEP "|" -> { Constructors l }

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -812,11 +812,12 @@ let string_of_definition_object_kind = let open Decls in function
           | RecordDecl (c,fs) ->
             pr_record_decl c fs
         in
-        let pr_oneind key (((coe,iddecl),indpar,s,lc),ntn) =
+        let pr_oneind key (((coe,iddecl),(indupar,indpar),s,lc),ntn) =
           hov 0 (
             str key ++ spc() ++
               (if coe then str"> " else str"") ++ pr_ident_decl iddecl ++
-              pr_and_type_binders_arg indpar ++
+              pr_and_type_binders_arg indupar ++
+              pr_opt (fun p -> str "|" ++ spc() ++ pr_and_type_binders_arg p) indpar ++
               pr_opt (fun s -> str":" ++ spc() ++ pr_lconstr_expr env sigma s) s ++
               str" :=") ++ pr_constructor_list lc ++
             prlist (pr_decl_notation @@ pr_constr env sigma) ntn

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -709,6 +709,10 @@ let vernac_inductive ~atts cum lo kind indl =
   if Option.has_some is_defclass then
     (* Definitional class case *)
     let (id, bl, c, l) = Option.get is_defclass in
+    let bl = match bl with
+      | bl, None -> bl
+      | _ -> CErrors.user_err Pp.(str "Definitional classes do not support the \"|\" syntax.")
+    in
     let (coe, (lid, ce)) = l in
     let coe' = if coe then Some true else None in
     let f = AssumExpr ((make ?loc:lid.loc @@ Name lid.v), ce),
@@ -729,6 +733,10 @@ let vernac_inductive ~atts cum lo kind indl =
     let () = List.iter check_where indl in
     let unpack ((id, bl, c, decl), _) = match decl with
     | RecordDecl (oc, fs) ->
+      let bl = match bl with
+        | bl, None -> bl
+        | _ -> CErrors.user_err Pp.(str "Records do not support the \"|\" syntax.")
+      in
       (id, bl, c, oc, fs)
     | Constructors _ -> assert false (* ruled out above *)
     in

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -163,12 +163,15 @@ type constructor_expr = (lident * constr_expr) with_coercion
 type constructor_list_or_record_decl_expr =
   | Constructors of constructor_expr list
   | RecordDecl of lident option * (local_decl_expr * record_field_attr) list
+type inductive_params_expr = local_binder_expr list * local_binder_expr list option
+(** If the option is nonempty the "|" marker was used *)
+
 type inductive_expr =
-  ident_decl with_coercion * local_binder_expr list * constr_expr option *
+  ident_decl with_coercion * inductive_params_expr * constr_expr option *
     constructor_list_or_record_decl_expr
 
 type one_inductive_expr =
-  lident * local_binder_expr list * constr_expr option * constructor_expr list
+  lident * inductive_params_expr * constr_expr option * constructor_expr list
 
 type typeclass_constraint = name_decl * Glob_term.binding_kind * constr_expr
 and typeclass_context = typeclass_constraint list


### PR DESCRIPTION
to control uniform parameters.

This replaces the attribute.
