### PR TITLE
[stm] Use Default Proof Using only with Proof

### DIFF
--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -2157,22 +2157,23 @@ let collect_proof keep cur hd brkind id =
  let has_default_proof_using = Option.has_some (Proof_using.get_default_proof_using ()) in
  let proof_using_ast = function
    | VernacProof(_,Some _) -> true
+   | VernacProof(_,None) -> has_default_proof_using
    | _ -> false
  in
  let proof_using_ast = function
    | Some (_, v) when proof_using_ast v.expr.CAst.v.expr
                       && (not (Vernacprop.has_Fail v.expr)) -> Some v
    | _ -> None in
- let has_proof_using x = has_default_proof_using || (proof_using_ast x <> None) in
+ let has_proof_using x = proof_using_ast x <> None in
  let proof_no_using = function
-   | VernacProof(t,None) -> t
+   | VernacProof(t,None) -> if has_default_proof_using then None else t
    | _ -> assert false
  in
  let proof_no_using = function
    | Some (_, v) -> proof_no_using v.expr.CAst.v.expr, v
    | _ -> assert false in
  let has_proof_no_using = function
-   | VernacProof(_,None) -> true
+   | VernacProof(_,None) -> not has_default_proof_using
    | _ -> false
  in
  let has_proof_no_using = function

--- a/test-suite/bugs/closed/bug_11342.v
+++ b/test-suite/bugs/closed/bug_11342.v
@@ -1,0 +1,19 @@
+(* -*- mode: coq; coq-prog-args: ("-vos") -*- *)
+
+Section foo.
+  Context {H:True}.
+  Set Default Proof Using "Type".
+  Theorem test2 : True.
+  Proof.
+    (* BUG: this gets run when compiling with -vos *)
+    fail "proof with default using".
+    exact I.
+  Qed.
+
+  Theorem test3 : True.
+  Proof using Type.
+    (* this isn't run with -vos *)
+    fail "using".
+    exact I.
+  Qed.
+End foo.

--- a/test-suite/output/bug_11342.out
+++ b/test-suite/output/bug_11342.out
@@ -1,0 +1,1 @@
+without using

--- a/test-suite/output/bug_11342.v
+++ b/test-suite/output/bug_11342.v
@@ -1,0 +1,12 @@
+(* -*- mode: coq; coq-prog-args: ("-vos") -*- *)
+
+Section foo.
+  Context {H:True}.
+  Theorem test1 : True.
+  Proof.
+    (* this gets printed with -vos because there's no annotation (either [Set
+    Default Proof Using ...] or an explicit [Proof using ...]) *)
+    idtac "without using".
+    exact I.
+  Qed.
+End foo.

--- a/test-suite/output/bug_11608.out
+++ b/test-suite/output/bug_11608.out
@@ -1,0 +1,1 @@
+creating x without [Proof.]

--- a/test-suite/output/bug_11608.v
+++ b/test-suite/output/bug_11608.v
@@ -1,0 +1,13 @@
+(* -*- mode: coq; coq-prog-args: ("-vos") -*- *)
+
+Set Default Proof Using "Type".
+
+Section foo.
+  Context (A:Type).
+  Definition x : option A.
+    (* this can get printed with -vos since without "Proof." there's no Proof
+    using, even with a default annotation. *)
+    idtac "creating x without [Proof.]".
+    exact None.
+  Qed.
+End foo.


### PR DESCRIPTION
Fixes #11608.

This means -vos doesn't skip proofs for definitions that end with Qed
but don't include Proof and rely on a Set Default Proof Using. However,
this fixes the bug where this pattern would instead hang, due to #11564.

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** bug fix

- [x] Added / updated test-suite
