### PR TITLE
Show apostrophes and backticks in HTML doc, too.

### DIFF
--- a/doc/tools/coqrst/notations/sphinx.py
+++ b/doc/tools/coqrst/notations/sphinx.py
@@ -80,9 +80,11 @@ class TacticNotationsToSphinxVisitor(TacticNotationsVisitor):
         while atom != "":
             if atom[0] == "'":
                 node += nodes.raw("\\textquotesingle{}", "\\textquotesingle{}", format="latex")
+                node += nodes.raw("'", "'", format="html")
                 atom = atom[1:]
             elif atom[0] == "`":
                 node += nodes.raw("\\`{}", "\\`{}", format="latex")
+                node += nodes.raw("`", "`", format="html")
                 atom = atom[1:]
             else:
                 index_ap = atom.find("'")


### PR DESCRIPTION
The earlier change fixing the pdf appearance inadvertently drops apostrophes and backticks in notations in the HTML doc, like this:

![image](https://user-images.githubusercontent.com/1253341/74612985-35cfae00-50bf-11ea-852c-07137ef5aba6.png)

that should look like this:

![image](https://user-images.githubusercontent.com/1253341/74613023-8fd07380-50bf-11ea-90d8-0cc52bd11032.png)
