### PR TITLE
Fix #11552: Ltac2 breaks query commands during proofs.

### DIFF
--- a/test-suite/bugs/closed/bug_11552.v
+++ b/test-suite/bugs/closed/bug_11552.v
@@ -1,0 +1,9 @@
+From Ltac2 Require Import Ltac2.
+
+Goal True.
+Proof.
+  Search unit.
+  (* Unbound constructor Search *)
+  Check tt.
+  (* Unbound constructor Check *)
+Abort.

--- a/user-contrib/Ltac2/g_ltac2.mlg
+++ b/user-contrib/Ltac2/g_ltac2.mlg
@@ -948,6 +948,12 @@ VERNAC { tac2mode } EXTEND VernacLtac2
   fun ~pstate -> Tac2entries.call ~pstate ~default t }
 END
 
+GRAMMAR EXTEND Gram
+  GLOBAL: tac2mode;
+  tac2mode:
+    [ [ tac = G_vernac.query_command -> { tac None } ] ];
+END
+
 {
 
 open Stdarg


### PR DESCRIPTION
Actually, callers of the Pvernac.register_proof_mode function have to manually register the parsing of vernacular queries themselves. This probably qualifies as an oversight from myself.

Fixes #11552.