### PR TITLE
Remove the dependency in float.cmo and uint63.cmo for building votour

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -536,7 +536,7 @@ $(FAKEIDEBYTE): $(FAKEIDECMO) | $(IDETOPBYTE)
 
 # votour: a small vo explorer (based on the checker)
 
-VOTOURCMO:=clib/cObj.cmo kernel/uint63.cmo kernel/float64.cmo checker/analyze.cmo checker/values.cmo checker/votour.cmo
+VOTOURCMO:=clib/cObj.cmo checker/analyze.cmo checker/values.cmo checker/votour.cmo
 
 bin/votour: $(call bestobj, $(VOTOURCMO)) $(LIBCOQRUN)
 	$(SHOW)'OCAMLBEST -o $@'


### PR DESCRIPTION
This was useless since #11247 and is a cause of failure in bytecode compilation on some exotic architectures (such as "armel"), as reported by Debian maintainers (cc: @treinen).

**Kind:** bug fix

- [ ] Entry added in the changelog (is it worth??)
