### PR TITLE
Fixes #10917: anomaly in building return clause of n-ary pattern-matching problem

### DIFF
--- a/pretyping/cases.ml
+++ b/pretyping/cases.ml
@@ -1817,6 +1817,7 @@ let build_inversion_problem ~program_mode loc env sigma tms t =
         List.rev_append patl patl',acc_sign,acc
     | (t, NotInd (bo,typ)) :: tms ->
       let pat,acc = make_patvar t acc in
+      let typ = lift n typ in
       let d = LocalAssum (annotR (alias_of_pat pat),typ) in
       let patl,acc_sign,acc = aux (n+1) (snd (push_rel ~hypnaming:KeepUserNameAndRenameExistingButSectionNames sigma d env)) (d::acc_sign) tms acc in
       pat::patl,acc_sign,acc in

--- a/test-suite/bugs/closed/bug_10917.v
+++ b/test-suite/bugs/closed/bug_10917.v
@@ -1,0 +1,4 @@
+(* This was raising an anomaly *)
+
+Definition m (h : 0 = 1) P : P 1 -> P 0 :=
+  fun H => match h, H with end.


### PR DESCRIPTION
**Kind:** bug fix

This was a missing lift in building return clause by small inversion.

Fixes / closes #10917

- [X] Added / updated test-suite
- [ ] Entry added in the changelog (is it important enough?)