### PR TITLE
Fix issue #11595: "Compile > Compile buffer" in CoqIDE fails due to quoting bug

### DIFF
--- a/ide/coqide.ml
+++ b/ide/coqide.ml
@@ -461,7 +461,7 @@ let compile sn =
     |Some f ->
       let args = Coq.get_arguments sn.coqtop in
       let cmd = cmd_coqc#get
-        ^ " " ^ String.concat " " args
+        ^ " " ^ String.concat " " (List.map Filename.quote args)
         ^ " " ^ (Filename.quote f) ^ " 2>&1"
       in
       let buf = Buffer.create 1024 in


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** bug fix

When using "Compile > Compile buffer" in CoqIDE, the arguments given to coq are not quoted.

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #11595
