### PR TITLE
[merge-script] Improve warning in case of batch merging.

### DIFF
--- a/dev/tools/merge-pr.sh
+++ b/dev/tools/merge-pr.sh
@@ -132,7 +132,8 @@ if [ "$LOCAL_BRANCH_COMMIT" != "$UPSTREAM_COMMIT" ]; then
 
     if git merge-base --is-ancestor -- "$UPSTREAM_COMMIT" "$LOCAL_BRANCH_COMMIT"; then
         warning "Your branch is ahead of ${REMOTE}."
-        warning "You should see this warning only if you've just merged another PR and did not push yet."
+        warning "On master, GitHub's branch protection rule prevents merging several PRs at once."
+        warning "You should run [git push ${REMOTE}] between each call to the merge script."
         ask_confirmation
     else
         error "Local branch is not up-to-date with ${REMOTE}."


### PR DESCRIPTION
Since we applied branch protection rules for everyone, including core devs, this warning should almost always be considered as an error. The only remaining use case of asking for confirmation is for the RM to merge a batch of vX.X-only PRs.