### PR TITLE
Fix #11654: syntax of inductive declaration.

### DIFF
--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -402,7 +402,7 @@ GRAMMAR EXTEND Gram
   ;
   constructor_list_or_record_decl:
     [ [ "|"; l = LIST1 constructor SEP "|" -> { Constructors l }
-      | id = identref ; c = constructor_type; "|"; l = LIST0 constructor SEP "|" ->
+      | id = identref ; c = constructor_type; "|"; l = LIST1 constructor SEP "|" ->
           { Constructors ((c id)::l) }
       | id = identref ; c = constructor_type -> { Constructors [ c id ] }
       | cstr = identref; "{"; fs = record_fields; "}" ->


### PR DESCRIPTION
`Inductive foo := Bar |.` was accepted but it shouldn't have.

**Kind:** bug fix

Fixes / closes #11654

Since this is really just a bug fix, I don't think it deserves a changelog entry.