### PR TITLE
Encoding string list as a string with application to the parsing of coqtop arguments in coqide

### DIFF
--- a/ide/ideutils.mli
+++ b/ide/ideutils.mli
@@ -102,3 +102,19 @@ val run_command :
 (* Checks if an error message is printable, it not replaces it with
  * a printable error *)
 val validate : Pp.t -> Pp.t
+
+(** [encode_string_list l] encodes a list of strings into a single
+    string using a "shell"-like encoding: it quotes strings
+    containing space by surrounding them with single quotes, and,
+    outside quoted strings, quotes both single quote and backslash
+    by prefixing them with backslash; the encoding tries to be
+    minimalistic. *)
+
+val encode_string_list : string list -> string
+
+(** [decode_string_list l] decodes the encoding of a string list as
+    a string; it fails with a Failure if a single quote is unmatched
+    or if a backslash in unquoted part is not followed by a single
+    quote or another backslash. *)
+
+val decode_string_list : string -> string list


### PR DESCRIPTION

**Kind:** bug fix

This is a part of #11595.

We experiment an intuitive encoding of the list of strings representing the command line into a unique string, for the purpose of the coqtop arguments window in coqide.

The basic strategy is to minimize the number of single quotes. Maximal substrings with spaces but no single quotes in them are surrounded by single quotes. In the residual, single quotes and backslashes are protected by adding a backslash in front of them.

This is shell-compatible encoding, in the sense that using the shell to decode the encoded string into a list of arguments gives the original list of strings (under the assumption of the absence of other shell-interpreted symbols such as $, |, etc.).

I'm not really satisfied. An alternative would have been to change the UI and propose instead a window proposing a list of strings to edit (or, even better a list of list of strings, since a command line is made of list of sequences of options with arguments).

More generally, command line arguments and shell interpretation strategy are close to a nightmare. I wish that, one day, we are able to define types which allow to know exactly about what we are talking at any time: when is a `-I` an option, and when it is a filename (as in `-I '\-I'`), when is `$PWD` a variable and when it is a filename (as in `$PWD/'$PWD'`), etc. Sympathetizing in passing with the study of [the parsing of shell scripts](https://hal.archives-ouvertes.fr/hal-01513750) by @treinen, @yurug and @niols.