### PR TITLE
Helping issue #11659 by leaving only the Cast hack in the grammar.

### DIFF
--- a/test-suite/output/PatternsInBinders.out
+++ b/test-suite/output/PatternsInBinders.out
@@ -4,7 +4,7 @@ fun '(x, y) => (y, x)
      : A * B -> B * A
 forall '(x, y), swap (x, y) = (y, x)
      : Prop
-proj_informative = fun '(exist _ x _) => x : A
+proj_informative = fun '(exist _ x _) => x
      : {x : A | P x} -> A
 foo = fun '(Bar n b tt p) => if b then n + p else n - p
      : Foo -> nat
@@ -29,8 +29,7 @@ exists '(x, y) '(z, w), swap (x, y) = (z, w)
 ∀ '(x, y), swap (x, y) = (y, x)
      : Prop
 both_z = 
-fun pat : nat * nat =>
-let '(n, p) as x := pat return (F x) in (Z n, Z p) : F (n, p)
+fun pat : nat * nat => let '(n, p) as x := pat return (F x) in (Z n, Z p)
      : forall pat : nat * nat, F pat
 fun '(x, y) '(z, t) => swap (x, y) = (z, t)
      : A * B -> B * A -> Prop

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -348,25 +348,11 @@ GRAMMAR EXTEND Gram
   (* Simple definitions *)
   def_body:
     [ [ bl = binders; ":="; red = reduce; c = lconstr ->
-      { if List.exists (function CLocalPattern _ -> true | _ -> false) bl
-      then
-        (* FIXME: "red" will be applied to types in bl and Cast with remain *)
-        let c = mkLambdaCN ~loc bl c in
-        DefineBody ([], red, c, None)
-      else
-        (match c with
-        | { CAst.v = CCast(c, CastConv t) } -> DefineBody (bl, red, c, Some t)
-        | _ -> DefineBody (bl, red, c, None)) }
+        { match c.CAst.v with
+          | CCast(c, Glob_term.CastConv t) -> DefineBody (bl, red, c, Some t)
+          | _ -> DefineBody (bl, red, c, None) }
     | bl = binders; ":"; t = lconstr; ":="; red = reduce; c = lconstr ->
-        { let ((bl, c), tyo) =
-          if List.exists (function CLocalPattern _ -> true | _ -> false) bl
-          then
-            (* FIXME: "red" will be applied to types in bl and Cast with remain *)
-            let c = CAst.make ~loc @@ CCast (c, CastConv t) in
-            (([],mkLambdaCN ~loc bl c), None)
-          else ((bl, c), Some t)
-        in
-        DefineBody (bl, red, c, tyo) }
+        { DefineBody (bl, red, c, Some t) }
     | bl = binders; ":"; t = lconstr ->
         { ProveBody (bl, t) } ] ]
   ;


### PR DESCRIPTION
The `CLocalPattern` hack is moved to `comDefinition.ml`.

**Kind:** clean-up.

Closes #11659

(prepared by @herbelin)