### PR TITLE
[gitlab] [ci] Move windows jobs to allow_failure: true

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -241,6 +241,7 @@ before_script:
   only:
     variables:
       - $WINDOWS =~ /enabled/
+  allow_failure: true
 
 .deploy-template:
   stage: deploy


### PR DESCRIPTION
Windows workers are currently broken; to be reverted when the fix to
the CI script is committed.

IMO the noise of the failures is not worth it; IIUC the windows jobs
have been not very useful to predict real problems, also we still keep
the azure jobs.
