### PR TITLE
[ci] Fix Coquelicot build

### DIFF
--- a/dev/ci/ci-coquelicot.sh
+++ b/dev/ci/ci-coquelicot.sh
@@ -7,4 +7,4 @@ install_ssreflect
 
 git_download coquelicot
 
-( cd "${CI_BUILD_DIR}/coquelicot" && ./autogen.sh && ./configure && ./remake "-j${NJOBS}" )
+( cd "${CI_BUILD_DIR}/coquelicot" && autoreconf -i -s && ./configure && ./remake "-j${NJOBS}" )


### PR DESCRIPTION
New versions did remove the autogen.sh script in favor of plain
`autoreconf`

Note that the Coquelicot build documentation seems incorrect.
