### PR TITLE
Fixing residual bug of #11120: inheritance of maximal implicit arguments for non-applied notations

### DIFF
--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -2057,7 +2057,9 @@ let internalize globalenv env pattern_mode (_, ntnvars as lvar) c =
        intern env (CAst.make ?loc @@ CPrim (Numeral (SMinus,p)))
     | CNotation (_,(InConstrEntrySomeLevel,"( _ )"),([a],[],[],[])) -> intern env a
     | CNotation (_,ntn,args) ->
-        intern_notation intern env ntnvars loc ntn args
+        let c = intern_notation intern env ntnvars loc ntn args in
+        let x, impl, scopes, l = find_appl_head_data c in
+        apply_impargs x env impl scopes l loc
     | CGeneralization (b,a,c) ->
         intern_generalization intern env ntnvars loc b a c
     | CPrim p ->

--- a/test-suite/success/Notations2.v
+++ b/test-suite/success/Notations2.v
@@ -194,3 +194,11 @@ Notation q := @p.
 Check fun A n => q (A * A) (n * n). (* check that argument scopes are propagated *)
 
 End InheritanceArgumentScopes.
+
+Module InheritanceMaximalImplicitPureNotation.
+
+Definition id {A B:Type} (a:B) := a.
+Notation "#" := (@id nat).
+Check # = (fun a:nat => a). (* # should inherit its maximal implicit argument *)
+
+End InheritanceMaximalImplicitPureNotation.


### PR DESCRIPTION
This is a follow-up to #11120: On the principle that a notation to a constant inherits the implicit arguments of the constant, a non-applied notation should inherit its next maximal implicit arguments.

**Kind:** fixing missing case in previous PR

- [X] Added / updated test-suite
