### PR TITLE
[ci] Allow failure in `validate:quick`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -575,6 +575,7 @@ validate:quick:
   only:
     variables:
       - $UNRELIABLE =~ /enabled/
+  allow_failure: true
 
 # Libraries are by convention the projects that depend on Coq
 # but not on its ML API


### PR DESCRIPTION
This is a common failure, moreover, `build:quick` is `allow_failure:
true` so it seems this should be too.
