### PR TITLE
When parsing a negative integer, ensure that the minus sign is contiguous to the number.

### DIFF
--- a/parsing/g_prim.mlg
+++ b/parsing/g_prim.mlg
@@ -37,6 +37,12 @@ let test_pipe_closedcurly =
     lk_kw "|" >> lk_kw "}" >> check_no_space
   end
 
+let test_minus_nat =
+  let open Pcoq.Lookahead in
+  to_entry "test_minus_nat" begin
+    lk_kw "-" >> lk_nat >> check_no_space
+  end
+
 }
 
 GRAMMAR EXTEND Gram
@@ -122,7 +128,7 @@ GRAMMAR EXTEND Gram
   ;
   integer:
     [ [ i = NUMERAL      -> { my_int_of_string loc (check_int loc i) }
-      | "-"; i = NUMERAL -> { - my_int_of_string loc (check_int loc i) } ] ]
+      | test_minus_nat; "-"; i = NUMERAL -> { - my_int_of_string loc (check_int loc i) } ] ]
   ;
   natural:
     [ [ i = NUMERAL -> { my_int_of_string loc (check_int loc i) } ] ]


### PR DESCRIPTION
**Kind:** enhancement

For instance, formerly, `Set Inline Level - 1` was succeeding. Now only `Set Inline Level -1` succeeds. (Even though a negative value does not make sense for a `Inline Level`, but that's then a semantic issue. Other options may accept negative numbers in general.)

This is a first step in a series of PRs about parsing and interpreting negative numbers, with application to #11561 and #11465. The general idea shall be that for a number to be interpreted as a negative number, the minus sign will have to be glued to the number. Thus, `- 1`, with a space, shall instead be interpreted as the notation `"- _"` applied to the number `1` (in some scopes they coincide, but in other they may differ).

In particular:
- For entries which have both a unary minus and negative numbers (or at least a rule for `-1`), `-1` will be parsed as the negative number and `- 1` as the minus of the positive number `1`. This shall be the case of `constr` (even if not all scopes interpret numeral and/or minus).

- For entries which only have negative numbers, `-1` will be parsed as a negative number and `- 1` will be a syntax error.

- For entries which only have unary minus, both `-1` and `- 1` will be parsed as the minus of the notation for `1`, if ever there is one, and will otherwise raise a syntax error.

Note that `-1` cannot be parsed as a lexeme for the usual reason. In the presence of a binary minus, `x-1` could not be parsed correctly. So, it has to be two lexemes, but we asked at parsing time that these lexemes are contiguous.

My feeling is that this is the intuitive expectation. In programming languages, one does not need to care because it is about values in normal form and both `-1` and the minus of `1` have de facto the same normal form. But in the presence of numeral parsers, they may syntactically differ (for instance, in `Q`, `-1` is the fraction `(-1)/1` but `- 1` is `-(1/1)`).

Note: the general idea will be applied to `constr` and custom entries in subsequent PRs. This PR is only about the `integer` entry which is used in `vernac` (but not in `constr`).