### PR TITLE
[boot] Don't initialize coqlib when `-boot` is passed.

### DIFF
--- a/toplevel/coqargs.ml
+++ b/toplevel/coqargs.ml
@@ -582,6 +582,10 @@ let require_libs opts =
   if opts.pre.load_init then prelude_data :: opts.pre.vo_requires else opts.pre.vo_requires
 
 let build_load_path opts =
-  let ml_path, vo_path = if opts.pre.boot then [],[] else Coqinit.libs_init_load_path () in
+  let ml_path, vo_path =
+    if opts.pre.boot then [],[]
+    else
+      let coqlib = Envars.coqlib () in
+      Coqinit.libs_init_load_path ~coqlib in
   ml_path @ opts.pre.ml_includes ,
   vo_path @ opts.pre.vo_includes

--- a/toplevel/coqinit.ml
+++ b/toplevel/coqinit.ml
@@ -65,21 +65,10 @@ let build_userlib_path ~unix_path =
   ; recursive = true
   }
 
-let ml_path_if c p =
-  if c then p else []
-
-(* LoadPath for developers *)
-let toplevel_init_load_path () =
-  let coqlib = Envars.coqlib () in
-  (* NOTE: These directories are searched from last to first *)
-  (* first, developer specific directory to open *)
-  ml_path_if Coq_config.local [coqlib/"dev"]
-
 (* LoadPath for Coq user libraries *)
-let libs_init_load_path () =
+let libs_init_load_path ~coqlib =
 
   let open Loadpath in
-  let coqlib = Envars.coqlib () in
   let user_contrib = coqlib/"user-contrib" in
   let xdg_dirs = Envars.xdg_dirs ~warn:(fun x -> Feedback.msg_warning (str x)) in
   let coqpath = Envars.coqpath in
@@ -107,12 +96,3 @@ let libs_init_load_path () =
 
   (* then directories in XDG_DATA_DIRS and XDG_DATA_HOME and COQPATH *)
   List.map (fun s -> build_userlib_path ~unix_path:s) (xdg_dirs @ coqpath)
-
-(* Initialises the Ocaml toplevel before launching it, so that it can
-   find the "include" file in the *source* directory *)
-let init_ocaml_path () =
-  let add_subdir dl =
-    Mltop.add_ml_dir (List.fold_left (/) (Envars.coqlib()) [dl])
-  in
-  Mltop.add_ml_dir (Envars.coqlib ());
-  List.iter add_subdir Coq_config.all_src_dirs

--- a/toplevel/coqinit.mli
+++ b/toplevel/coqinit.mli
@@ -14,10 +14,7 @@ val set_debug : unit -> unit
 
 val load_rcfile : rcfile:(string option) -> state:Vernac.State.t -> Vernac.State.t
 
-val init_ocaml_path : unit -> unit
-
-(* LoadPath for toploop toplevels *)
-val toplevel_init_load_path : unit -> CUnix.physical_path list
-
 (* LoadPath for Coq user libraries *)
-val libs_init_load_path : unit -> CUnix.physical_path list * Loadpath.vo_path list
+val libs_init_load_path
+  : coqlib:CUnix.physical_path
+  -> CUnix.physical_path list * Loadpath.vo_path list


### PR DESCRIPTION
We refactor handling of `-boot` so the "coqlib" guessing routine,
`Envars.coqlib ()` is not called when bootstrapping.

In compositional builds involving Coq's prelude we don't want for this
guessing to happen, as the heuristics to locate the prelude will fail
due to different build layout choices.

Thus after this patch Coq does not do any guessing when `-boot` is
passed, leaving the location of libraries to the usual command line
parameters.

Note that some other tooling still calls `Envars.coqlib`, however this
should happen late enough as for it to be safe; we will fix that
eventually when we consolidate the library for library handling among
tools.

Ideally, we would also remove `Envars.coqlib` altogether, as we want
to avoid clients accessing the Coq filesystem in a non-controlled way.

