### PR TITLE
Fix #11696: link from refman to stdlib doc is dead.

### DIFF
--- a/doc/sphinx/language/coq-library.rst
+++ b/doc/sphinx/language/coq-library.rst
@@ -23,7 +23,7 @@ These libraries and developments are available
 for download at http://coq.inria.fr (see :ref:`userscontributions`).
 
 This chapter briefly reviews the |Coq| libraries whose contents can
-also be browsed at http://coq.inria.fr/stdlib.
+also be browsed at http://coq.inria.fr/stdlib/.
 
 
 


### PR DESCRIPTION
**Kind:** documentation fix

For a while, URLs without ending slashes for the refman and the stdlib doc have been broken (cf. https://github.com/coq/www/issues/111#issuecomment-547004652) and I've not received help in fixing those yet. So until these URLs start working again, we fix existing links without trailing slashes.