### PR TITLE
[ci] elpi 1.10.2

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ stages:
 variables:
   # Format: $IMAGE-V$DATE [Cache is not used as of today but kept here
   # for reference]
-  CACHEKEY: "bionic_coq-V2019-03-01-V33"
+  CACHEKEY: "bionic_coq-V2019-03-01-V43"
   IMAGE: "$CI_REGISTRY_IMAGE:$CACHEKEY"
   # By default, jobs run in the base switch; override to select another switch
   OPAM_SWITCH: "base"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ stages:
 variables:
   # Format: $IMAGE-V$DATE [Cache is not used as of today but kept here
   # for reference]
-  CACHEKEY: "bionic_coq-V2019-12-08-V82"
+  CACHEKEY: "bionic_coq-V2019-03-01-V33"
   IMAGE: "$CI_REGISTRY_IMAGE:$CACHEKEY"
   # By default, jobs run in the base switch; override to select another switch
   OPAM_SWITCH: "base"

--- a/dev/ci/docker/bionic_coq/Dockerfile
+++ b/dev/ci/docker/bionic_coq/Dockerfile
@@ -1,4 +1,4 @@
-# CACHEKEY: "bionic_coq-V2019-12-08-V82"
+# CACHEKEY: "bionic_coq-V2019-03-01-V33"
 # ^^ Update when modifying this file.
 
 FROM ubuntu:bionic
@@ -37,7 +37,7 @@ ENV COMPILER="4.05.0"
 # Common OPAM packages.
 # `num` does not have a version number as the right version to install varies
 # with the compiler version.
-ENV BASE_OPAM="num ocamlfind.1.8.1 dune.2.0.0 ounit.2.0.8 odoc.1.4.2" \
+ENV BASE_OPAM="num ocamlfind.1.8.1 dune.2.0.1 ounit.2.0.8 odoc.1.4.2" \
     CI_OPAM="menhir.20190626 ocamlgraph.1.8.8" \
     BASE_ONLY_OPAM="elpi.1.8.0"
 

--- a/dev/ci/docker/bionic_coq/Dockerfile
+++ b/dev/ci/docker/bionic_coq/Dockerfile
@@ -1,4 +1,4 @@
-# CACHEKEY: "bionic_coq-V2019-03-01-V33"
+# CACHEKEY: "bionic_coq-V2019-03-01-V43"
 # ^^ Update when modifying this file.
 
 FROM ubuntu:bionic
@@ -39,7 +39,7 @@ ENV COMPILER="4.05.0"
 # with the compiler version.
 ENV BASE_OPAM="num ocamlfind.1.8.1 dune.2.0.1 ounit.2.0.8 odoc.1.4.2" \
     CI_OPAM="menhir.20190626 ocamlgraph.1.8.8" \
-    BASE_ONLY_OPAM="elpi.1.8.0"
+    BASE_ONLY_OPAM="elpi.1.10.2"
 
 # BASE switch; CI_OPAM contains Coq's CI dependencies.
 ENV COQIDE_OPAM="cairo2.0.6.1 lablgtk3-sourceview3.3.0.beta6"

--- a/dev/ci/user-overlays/11051-gares-elpi-1.8.sh
+++ b/dev/ci/user-overlays/11051-gares-elpi-1.8.sh
@@ -1,6 +1,0 @@
-if [ "$CI_PULL_REQUEST" = "11051" ] || [ "$CI_BRANCH" = "elpi-1.8" ]; then
-
-    elpi_CI_REF="coq-master+v1.2"
-    elpi_CI_GITURL=https://github.com/LPCIC/coq-elpi
-
-fi

--- a/dev/ci/user-overlays/11708-gares-elpi-1.10.sh
+++ b/dev/ci/user-overlays/11708-gares-elpi-1.10.sh
@@ -1,0 +1,6 @@
+if [ "$CI_PULL_REQUEST" = "11708" ] || [ "$CI_BRANCH" = " elpi-1.10+coq-elpi-1.3" ]; then
+
+    elpi_CI_REF="coq-master+coq-elpi-1.3"
+    elpi_CI_GITURL=https://github.com/LPCIC/coq-elpi
+
+fi


### PR DESCRIPTION
This PR bumps elpi to 1.10.2 and the overlay moves coq-elpi/coq-master forward

*̶I̶m̶p̶o̶r̶t̶a̶n̶t̶*̶:̶ ̶t̶h̶i̶s̶ ̶P̶R̶ ̶a̶l̶s̶o̶ ̶b̶u̶m̶p̶s̶ ̶o̶c̶a̶m̶l̶ ̶t̶o̶ ̶4̶.̶0̶7̶.̶1̶ ̶a̶n̶d̶ ̶d̶u̶n̶e̶ ̶t̶o̶ ̶2̶.̶0̶.̶1̶ ̶(̶t̶h̶e̶ ̶p̶r̶e̶v̶i̶o̶u̶s̶ ̶d̶o̶c̶k̶e̶r̶ ̶f̶i̶l̶e̶s̶ ̶d̶o̶e̶s̶ ̶n̶o̶t̶ ̶w̶o̶r̶k̶ ̶a̶n̶y̶m̶o̶r̶e̶,̶ ̶s̶e̶e̶ ̶c̶o̶m̶m̶e̶n̶t̶s̶ ̶b̶e̶l̶o̶w̶)̶