### PR TITLE
Deprecate the "prolog" tactic.

### DIFF
--- a/plugins/ltac/g_auto.mlg
+++ b/plugins/ltac/g_auto.mlg
@@ -114,7 +114,7 @@ END
 
 (** Eauto *)
 
-TACTIC EXTEND prolog
+TACTIC EXTEND prolog DEPRECATED { Deprecation.make ~note:"Use eauto instead" () }
 | [ "prolog" "[" uconstr_list(l) "]" int_or_var(n) ] ->
     { Eauto.prolog_tac (eval_uconstrs ist l) n }
 END
@@ -253,4 +253,3 @@ VERNAC COMMAND EXTEND HintCut CLASSIFIED AS SIDEFF
           (match dbnames with None -> ["core"] | Some l -> l) entry;
  }
 END
-


### PR DESCRIPTION
It was not documented, I do not think it is used in the wild, and it relies on legacy code. As solid conjunction of reasons that support its deprecation.

(Does this deserve a changelog?)