### PR TITLE
Added the NoDup_cut function and two auxiliary lemmas, In_inv and NoDup_tail

### DIFF
--- a/theories/Lists/List.v
+++ b/theories/Lists/List.v
@@ -698,7 +698,7 @@ Section Elts.
 
   Hypothesis eq_dec : forall x y : A, {x = y}+{x <> y}.
 
-  Definition In_inv (x x0 : A) (xs : list A) (H : In x (x0 :: xs)) : {x0 = x} + {In x xs} :=
+  Definition In_inv (a b : A) (l : list A) (H : In a (b :: l)) : {b = a} + {In a xs} :=
     match eq_dec x0 x with
       | left H0 => left H0
       | right H0 =>


### PR DESCRIPTION
This patch provides a function named `NoDup_cut` and two auxiliary lemmas, `In_inv` and `NoDup_tail`.

The `NoDup_cut` function accepts a value, x, and a list, xs, and cuts xs at x. This is a very natural list operation and allows a number of other important functions and lemmas about element deletion to be derived easily.

Additionally, the `NoDup_cut` function fills a significant gap in the current List module. All of the `NoDup_remove*` functions assume that the given list can be decomposed into the form `xs ++ y :: ys`. For example:

```
Lemma NoDup_remove_1 l l' a : NoDup (l++a::l') -> NoDup (l++l').
```

But, the current module does not provide a function to perform this decomposition. `NoDup_cut` fills this gap by performing this decomposition.

The `In_inv` lemma is a natural analogue of `in_inv` that I have seen implemented independently in a number of projects.

**Kind:** feature.