### PR TITLE
[dune] [ocamldebug] Improve ocamldebug rules

### DIFF
--- a/dev/doc/build-system.dune.md
+++ b/dev/doc/build-system.dune.md
@@ -119,10 +119,9 @@ dune exec -- dev/dune-dbg checker foo.vo
 (ocd) source dune_db
 ```
 
-Unfortunately, dependency handling here is not fully refined, so you
-need to build enough of Coq once to use this target [it will then
-correctly compute the deps and rebuild if you call the script again]
-This will be fixed in the future.
+Unfortunately, dependency handling is not fully refined / automated,
+you may find the occasional hiccup due to libraries being renamed,
+etc... Please report any issue.
 
 For running in emacs, use `coqdev-ocamldebug` from `coqdev.el`.
 

--- a/dev/dune
+++ b/dev/dune
@@ -9,12 +9,34 @@
 
 (rule
   (targets dune-dbg)
-  (deps dune-dbg.in
-        ../checker/coqchk.bc
-        ../topbin/coqc_bin.bc
-        ../ide/coqide_main.bc
-        %{lib:coq.plugins.ltac:ltac_plugin.cma}
-        ; This is not enough, the call to `ocamlfind` may fail if the
-        ; META file is not yet in place :/
-        top_printers.cma)
+  (deps
+    dune-dbg.in
+    ../checker/coqchk.bc
+    ../topbin/coqc_bin.bc
+    ../ide/coqide_main.bc
+    ; We require all the OCaml libs to be in place and searchable
+    ; by OCamlfind, this is a bit of a hack but until Dune gets
+    ; proper ocamldebug support we have to live with that.
+    %{lib:coq.config:config.cma}
+    %{lib:coq.clib:clib.cma}
+    %{lib:coq.lib:lib.cma}
+    %{lib:coq.kernel:kernel.cma}
+    %{lib:coq.vm:byterun.cma}
+    %{lib:coq.vm:../../stublibs/dllbyterun_stubs.so}
+    %{lib:coq.library:library.cma}
+    %{lib:coq.engine:engine.cma}
+    %{lib:coq.pretyping:pretyping.cma}
+    %{lib:coq.gramlib:gramlib.cma}
+    %{lib:coq.interp:interp.cma}
+    %{lib:coq.proofs:proofs.cma}
+    %{lib:coq.parsing:parsing.cma}
+    %{lib:coq.printing:printing.cma}
+    %{lib:coq.tactics:tactics.cma}
+    %{lib:coq.vernac:vernac.cma}
+    %{lib:coq.stm:stm.cma}
+    %{lib:coq.toplevel:toplevel.cma}
+    %{lib:coq.plugins.ltac:ltac_plugin.cma}
+    %{lib:coq.top_printers:top_printers.cmi}
+    %{lib:coq.top_printers:top_printers.cma}
+    %{lib:coq.top_printers:../META})
   (action (copy dune-dbg.in dune-dbg)))


### PR DESCRIPTION
We provide the closure of the dependencies manually.

This is still a hack, but not so bad given that the `source`'d files
still do contain that duplication too.

Dune should provide this functionality so we can replace both this
rule and the source files. Actually, that's not hard to implement,
`utop` already supports a printer attribute so these are loaded
automatically, so the ocamldebug mode could do the same.

Should fix #11716
