### PR TITLE
Convert syntax extensions chapter to prodn

### DIFF
--- a/doc/changelog/02-specification-language/11235-non_maximal_implicit.rst
+++ b/doc/changelog/02-specification-language/11235-non_maximal_implicit.rst
@@ -1,5 +1,5 @@
 - **Added:**
-  Syntax for non maximal implicit arguments in definitions and terms using
+  Syntax for non-maximal implicit arguments in definitions and terms using
   square brackets. The syntax is ``[x : A]``, ``[x]``, ```[A]``
   to be consistent with the command :cmd:`Arguments`.
   (`#11235 <https://github.com/coq/coq/pull/11235>`_,

--- a/doc/changelog/02-specification-language/11368-trailing_implicit_error.rst
+++ b/doc/changelog/02-specification-language/11368-trailing_implicit_error.rst
@@ -1,5 +1,5 @@
 - **Changed:**
-  The warning raised when a trailing implicit is declared to be non maximally
+  The warning raised when a trailing implicit is declared to be non-maximally
   inserted (with the command :cmd:`Arguments`) has been turned into an error.
   This was deprecated since Coq 8.10
   (`#11368 <https://github.com/coq/coq/pull/11368>`_,

--- a/doc/changelog/03-notations/11120-master+refactoring-application-printing.rst
+++ b/doc/changelog/03-notations/11120-master+refactoring-application-printing.rst
@@ -10,7 +10,7 @@
   Herbelin, fixing `#4690 <https://github.com/coq/coq/pull/4690>`_ and
   `#11091 <https://github.com/coq/coq/pull/11091>`_).
 
-- **Changed:** Interpretation scopes are now always inherited in
+- **Changed:** Notation scopes are now always inherited in
   notations binding a partially applied constant, including for
   notations binding an expression of the form :n:`@@qualid`. The latter was
   not the case beforehand

--- a/doc/sphinx/addendum/implicit-coercions.rst
+++ b/doc/sphinx/addendum/implicit-coercions.rst
@@ -37,6 +37,8 @@ In addition to these user-defined classes, we have two built-in classes:
   * ``Funclass``, the class of functions; its objects are all the terms with a functional
     type, i.e. of form :g:`forall x:A,B`.
 
+Formally, the syntax of classes is defined as:
+
    .. insertprodn class class
 
    .. prodn::

--- a/doc/sphinx/addendum/type-classes.rst
+++ b/doc/sphinx/addendum/type-classes.rst
@@ -241,7 +241,7 @@ binders. For example:
 
    Definition lt `{eqa : EqDec A, ! Ord eqa} (x y : A) := andb (le x y) (neqb x y).
 
-The ``!`` modifier switches the way a binder is parsed back to the regular
+The ``!`` modifier switches the way a binder is parsed back to the usual
 interpretation of Coq. In particular, it uses the implicit arguments
 mechanism if available, as shown in the example.
 
@@ -323,7 +323,7 @@ Summary of the commands
 
    .. cmdv:: Existing Class @ident
 
-      This variant declares a class a posteriori from a constant or
+      This variant declares a class from a previously declared constant or
       inductive definition. No methods or instances are defined.
 
       .. warn:: @ident is already declared as a typeclass
@@ -394,7 +394,7 @@ few other commands related to typeclasses.
    :name: typeclasses eauto
 
    This proof search tactic implements the resolution engine that is run
-   implicitly during type-checking. This tactic uses a different resolution
+   implicitly during type checking. This tactic uses a different resolution
    engine than :tacn:`eauto` and :tacn:`auto`. The main differences are the
    following:
 

--- a/doc/sphinx/changes.rst
+++ b/doc/sphinx/changes.rst
@@ -326,7 +326,7 @@ Changes in 8.11+beta1
   the documentation by Théo Zimmermann and Jim Fehrle).
 - **Added:**
   Ltac2 tactic notations with “constr” arguments can specify the
-  interpretation scope for these arguments;
+  notation scope for these arguments;
   see :ref:`ltac2_notations` for details
   (`#10289 <https://github.com/coq/coq/pull/10289>`_,
   by Vincent Laporte).
@@ -1562,8 +1562,7 @@ changes:
     attribute.
 
   - Removed deprecated commands ``Arguments Scope`` and ``Implicit
-    Arguments`` in favor of :cmd:`Arguments (scopes)` and
-    :cmd:`Arguments`, with the help of Jasper Hugunin.
+    Arguments`` in favor of :cmd:`Arguments`, with the help of Jasper Hugunin.
 
   - New flag :flag:`Uniform Inductive Parameters` by Jasper Hugunin to
     avoid repeating uniform parameters in constructor declarations.
@@ -2401,9 +2400,9 @@ Tactics
 - Tactic "auto with real" can now discharge comparisons of literals.
 
 - The types of variables in patterns of "match" are now
-  beta-iota-reduced after type-checking. This has an impact on the
+  beta-iota-reduced after type checking. This has an impact on the
   type of the variables that the tactic "refine" introduces in the
-  context, producing types a priori closer to the expectations.
+  context, producing types that should be closer to the expectations.
 
 - In "Tactic Notation" or "TACTIC EXTEND", entry "constr_with_bindings"
   now uses type classes and rejects terms with unresolved holes, like
@@ -3469,7 +3468,7 @@ Tactics
   native_compute now strictly interpret it as the head of a pattern
   starting with this reference.
 
-- The "change p with c" tactic semantics changed, now type-checking
+- The "change p with c" tactic semantics changed, now type checking
   "c" at each matching occurrence "t" of the pattern "p", and
   converting "t" with "c".
 
@@ -4836,7 +4835,7 @@ Type classes
 - Declaring axiomatic type class instances in Module Type should be now
   done via new command "Declare Instance", while the syntax "Instance"
   now always provides a concrete instance, both in and out of Module Type.
-- Use [Existing Class foo] to declare foo as a class a posteriori.
+- Use [Existing Class foo] to declare a preexisting object [foo] as a class.
   [foo] can be an inductive type or a constant definition. No
   projections or instances are defined.
 - Various bug fixes and improvements: support for defined fields,
@@ -4846,7 +4845,7 @@ Type classes
 Vernacular commands
 
 - New command "Timeout <n> <command>." interprets a command and a timeout
-  interrupts the interpretation after <n> seconds.
+  interrupts the execution after <n> seconds.
 - New command "Compute <expr>." is a shortcut for "Eval vm_compute in <expr>".
 - New command "Fail <command>." interprets a command and is successful iff
   the command fails on an error (but not an anomaly). Handy for tests and
@@ -6031,7 +6030,7 @@ main motivations were
    syntax.
 
 Together with the revision of the concrete syntax, a new mechanism of
-*interpretation scopes* permits to reuse the same symbols (typically +,
+*notation scopes* permits to reuse the same symbols (typically +,
 -, \*, /, <, <=) in various mathematical theories without any
 ambiguities for |Coq|, leading to a largely improved readability of |Coq|
 scripts. New commands to easily add new symbols are also provided.
@@ -6069,7 +6068,7 @@ translator from old to new syntax released with |Coq| is also their work
 with contributions by Olivier Desmettre.
 
 Hugo Herbelin is the main designer and implementer of the notion of
-interpretation scopes and of the commands for easily adding new
+notation scopes and of the commands for easily adding new
 notations.
 
 Hugo Herbelin is the main implementer of the restructured standard library.
@@ -6291,12 +6290,12 @@ Syntax extensions
 - "Grammar" for terms disappears
 - "Grammar" for tactics becomes "Tactic Notation"
 - "Syntax" disappears
-- Introduction of a notion of interpretation scope allowing to use the
+- Introduction of a notion of notation scope allowing to use the
   same notations in various contexts without using specific delimiters
   (e.g the same expression "4<=3+x" is interpreted either in "nat",
   "positive", "N" (previously "entier"), "Z", "R", depending on which
-  interpretation scope is currently open) [see documentation for details]
-- Notation now mandatorily requires a precedence and associativity
+  Notation scope is currently open) [see documentation for details]
+- Notation now requires a precedence and associativity
   (default was to set precedence to 1 and associativity to none)
 
 Revision of the standard library
@@ -6373,7 +6372,7 @@ New syntax
   with no dependency of t1 and t2 in the arguments of the constructors;
   this may cause incompatibilities for files translated using coq 8.0beta
 
-Interpretation scopes
+Notation scopes
 
 - Delimiting key %bool for bool_scope added
 - Import no more needed to activate argument scopes from a module

--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -183,18 +183,9 @@ todo_include_todos = False
 nitpicky = True
 
 nitpick_ignore = [ ('token', token) for token in [
-    'assums',
     'binders',
     'collection',
-    'dirpath',
-    'ind_body',
     'modpath',
-    'module',
-    'simple_tactic',
-    'symbol',
-    'term_pattern',
-    'term_pattern_string',
-    'toplevel_selector',
 ]]
 
 # -- Options for HTML output ----------------------------------------------

--- a/doc/sphinx/history.rst
+++ b/doc/sphinx/history.rst
@@ -210,7 +210,7 @@ definitions of “inversion predicates”.
 Version 1
 ~~~~~~~~~
 
-This software is a prototype type-checker for a higher-order logical
+This software is a prototype type checker for a higher-order logical
 formalism known as the Theory of Constructions, presented in his PhD
 thesis by Thierry Coquand, with influences from Girard's system F and
 de Bruijn's Automath.  The metamathematical analysis of the system is
@@ -409,7 +409,7 @@ synthesized with the help of tactics, it was entirely re-checked by
 the engine. Thus there was no need to certify the tactics, and the
 system took advantage of this fact by having tactics ignore the
 universe levels, universe consistency check being relegated to the
-final type-checking pass. This induced a certain puzzlement in early
+final type checking pass. This induced a certain puzzlement in early
 users who saw, after a successful proof search, their ``QED`` followed
 by silence, followed by a failure message due to a universe
 inconsistency…
@@ -1396,7 +1396,7 @@ Tactics
 Extraction (See details in plugins/extraction/CHANGES and README):
 
 - An experimental Scheme extraction is provided.
-- Concerning Ocaml, extracted code is now ensured to always type-check,
+- Concerning OCaml, extracted code is now ensured to always type check,
   thanks to automatic inserting of Obj.magic.
 - Experimental extraction of Coq new modules to Ocaml modules.
 

--- a/doc/sphinx/language/extensions/arguments-command.rst
+++ b/doc/sphinx/language/extensions/arguments-command.rst
@@ -1,0 +1,440 @@
+.. _ArgumentsCommand:
+
+Setting properties of a function's arguments
+++++++++++++++++++++++++++++++++++++++++++++
+
+.. cmd:: Arguments @smart_qualid {* @arg_specs } {* , {* @implicits_alt } } {? : {+, @args_modifier } }
+   :name: Arguments
+
+   .. insertprodn smart_qualid args_modifier
+
+   .. prodn::
+      smart_qualid ::= @qualid
+      | @by_notation
+      by_notation ::= @string {? % @scope_key }
+      argument_spec ::= {? ! } @name {? % @scope_key }
+      arg_specs ::= @argument_spec
+      | /
+      | &
+      | ( {+ @argument_spec } ) {? % @scope_key }
+      | [ {+ @argument_spec } ] {? % @scope_key }
+      | %{ {+ @argument_spec } %} {? % @scope_key }
+      implicits_alt ::= @name
+      | [ {+ @name } ]
+      | %{ {+ @name } %}
+      args_modifier ::= simpl nomatch
+      | simpl never
+      | default implicits
+      | clear implicits
+      | clear scopes
+      | clear bidirectionality hint
+      | rename
+      | assert
+      | extra scopes
+      | clear scopes and implicits
+      | clear implicits and scopes
+
+   Specifies properties of the arguments of a function after the function has already
+   been defined.  It gives fine-grained
+   control over the elaboration process (i.e. the translation of Gallina language
+   extensions into the core language used by the kernel).  The command's effects include:
+
+   * Making arguments implicit. Afterward, implicit arguments
+     must be omitted in any expression that applies :token:`smart_qualid`.
+   * Declaring that some arguments of a given function should
+     be interpreted in a given scope.
+   * Affecting when the :tacn:`simpl` and :tacn:`cbn` tactics unfold the function.
+     See :ref:`Args_effect_on_unfolding`.
+   * Providing bidirectionality hints.  See :ref:`bidirectionality_hints`.
+
+   This command supports the :attr:`local` and :attr:`global` attributes.
+   Default behavior is to limit the effect to the current section but also to
+   extend their effect outside the current module or library file.
+   Applying :attr:`local` limits the effect of the command to the current module if
+   it's not in a section.  Applying :attr:`global` within a section extends the
+   effect outside the current sections and current module in which the command appears.
+
+      `/`
+         the function will be unfolded only if it's applied to at least the
+         arguments appearing before the `/`.  See :ref:`Args_effect_on_unfolding`.
+
+         .. exn:: The / modifier may only occur once.
+            :undocumented:
+
+      `&`
+         tells the type checking algorithm to first type check the arguments
+         before the `&` and then to propagate information from that typing context
+         to type check the remaining arguments. See :ref:`bidirectionality_hints`.
+
+         .. exn:: The & modifier may only occur once.
+            :undocumented:
+
+      :n:`( ... ) {? % @scope }`
+         :n:`(@name__1 @name__2 ...)%@scope` is shorthand for :n:`@name__1%@scope @name__2%@scope ...`
+
+      :n:`[ ... ] {? % @scope }`
+         declares the enclosed names as implicit, non-maximally inserted.
+         :n:`[@name__1 @name__2 ... ]%@scope` is equivalent to :n:`[@name__1]%@scope [@name__2]%@scope ...`
+
+      :n:`%{ ... %} {? % @scope }`
+         declares the enclosed names as implicit, maximally inserted.
+         :n:`%{@name__1 @name__2 ... %}%@scope` is equivalent to :n:`%{@name__1%}%@scope %{@name__2%}%@scope ...`
+
+      `!`
+         the function will be unfolded only if all the arguments marked with `!`
+         evaulate to constructors.  See :ref:`Args_effect_on_unfolding`.
+
+      :n:`@name {? % @scope }`
+         a *formal parameter* of the function :n:`@smart_qualid` (i.e.
+         the parameter name used in the function definition).  Unless `rename` is specified,
+         the list of :n:`@name`\s must be a prefix of the formal parameters, including all implicit
+         arguments.  `_` can be used to skip over a formal parameter.
+         :token:`scope` can be either a scope name or its delimiting key.  See :ref:`binding_to_scope`.
+
+      `clear implicits`
+         makes all implicit arguments into explicit arguments
+      `default implicits`
+         automatically determine the implicit arguments of the object.
+         See :ref:`auto_decl_implicit_args`.
+      `rename`
+         rename implicit arguments for the object.  See the example :ref:`here <renaming_implicit_arguments>`.
+      `assert`
+         assert that the object has the expected number of arguments with the
+         expected names.  See the example here: :ref:`renaming_implicit_arguments`.
+
+         .. warn:: This command is just asserting the names of arguments of @qualid. If this is what you want, add ': assert' to silence the warning. If you want to clear implicit arguments, add ': clear implicits'. If you want to clear notation scopes, add ': clear scopes'
+            :undocumented:
+
+      `clear scopes`
+         clears argument scopes of :n:`@smart_qualid`
+      `extra scopes`
+         defines extra argument scopes, to be used in case of coercion to ``Funclass``
+         (see the :ref:`implicitcoercions` chapter) or with a computed type.
+      `simpl nomatch`
+         prevents performing a simplification step for :n:`@smart_qualid`
+         that would expose a match construct in the head position.  See :ref:`Args_effect_on_unfolding`.
+      `simpl never`
+         prevents performing a simplification step for :n:`@smart_qualid`.  See :ref:`Args_effect_on_unfolding`.
+
+      `clear bidirectionality hint`
+         removes the bidirectionality hint, the `&`
+
+      :n:`@implicits_alt`
+         use to specify alternative implicit argument declarations
+         for functions that can only be
+         applied to a fixed number of arguments (excluding, for instance,
+         functions whose type is polymorphic).
+         For parsing, the longest list of implicit arguments matching the function application
+         is used to select which implicit arguments are inserted.
+         For printing, the alternative with the most implicit arguments is used; the
+         implict arguments will be omitted if :flag:`Printing Implicit` is not set.
+         See the example :ref:`here<example_more_implicits>`.
+
+         .. todo the above feature seems a bit unnatural and doesn't play well with partial
+            application.  See https://github.com/coq/coq/pull/11718#discussion_r408841762
+
+   Use :cmd:`About` to view the current implicit arguments setting for a :token:`smart_qualid`.
+
+   Or use the :cmd:`Print Implicit` command to see the implicit arguments
+   of an object (see :ref:`displaying-implicit-args`).
+
+Manual declaration of implicit arguments
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. example::
+
+   .. coqtop:: reset all
+
+      Inductive list (A : Type) : Type :=
+      | nil : list A
+      | cons : A -> list A -> list A.
+
+      Check (cons nat 3 (nil nat)).
+
+      Arguments cons [A] _ _.
+
+      Arguments nil {A}.
+
+      Check (cons 3 nil).
+
+      Fixpoint map (A B : Type) (f : A -> B) (l : list A) : list B :=
+        match l with nil => nil | cons a t => cons (f a) (map A B f t) end.
+
+      Fixpoint length (A : Type) (l : list A) : nat :=
+        match l with nil => 0 | cons _ m => S (length A m) end.
+
+      Arguments map [A B] f l.
+
+      Arguments length {A} l. (* A has to be maximally inserted *)
+
+      Check (fun l:list (list nat) => map length l).
+
+.. _example_more_implicits:
+
+.. example:: Multiple alternatives with :n:`@implicits_alt`
+
+   .. coqtop:: all
+
+      Arguments map [A B] f l, [A] B f l, A B f l.
+
+      Check (fun l => map length l = map (list nat) nat length l).
+
+.. _auto_decl_implicit_args:
+
+Automatic declaration of implicit arguments
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+   The ":n:`default implicits`" :token:`args_modifier` clause tells |Coq| to automatically determine the
+   implicit arguments of the object.
+
+   Auto-detection is governed by flags specifying whether strict,
+   contextual, or reversible-pattern implicit arguments must be
+   considered or not (see :ref:`controlling-strict-implicit-args`, :ref:`controlling-contextual-implicit-args`,
+   :ref:`controlling-rev-pattern-implicit-args` and also :ref:`controlling-insertion-implicit-args`).
+
+.. example:: Default implicits
+
+   .. coqtop:: reset all
+
+      Inductive list (A:Set) : Set :=
+      | nil : list A
+      | cons : A -> list A -> list A.
+
+      Arguments cons : default implicits.
+
+      Print Implicit cons.
+
+      Arguments nil : default implicits.
+
+      Print Implicit nil.
+
+      Set Contextual Implicit.
+
+      Arguments nil : default implicits.
+
+      Print Implicit nil.
+
+The computation of implicit arguments takes account of the unfolding
+of constants. For instance, the variable ``p`` below has type
+``(Transitivity R)`` which is reducible to
+``forall x,y:U, R x y -> forall z:U, R y z -> R x z``. As the variables ``x``, ``y`` and ``z``
+appear strictly in the body of the type, they are implicit.
+
+.. coqtop:: all
+
+   Parameter X : Type.
+
+   Definition Relation := X -> X -> Prop.
+
+   Definition Transitivity (R:Relation) := forall x y:X, R x y -> forall z:X, R y z -> R x z.
+
+   Parameters (R : Relation) (p : Transitivity R).
+
+   Arguments p : default implicits.
+
+   Print p.
+
+   Print Implicit p.
+
+   Parameters (a b c : X) (r1 : R a b) (r2 : R b c).
+
+   Check (p r1 r2).
+
+
+.. _renaming_implicit_arguments:
+
+Renaming implicit arguments
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. example:: (continued)  Renaming implicit arguments
+
+   .. coqtop:: all
+
+      Arguments p [s t] _ [u] _: rename.
+
+      Check (p r1 (u:=c)).
+
+      Check (p (s:=a) (t:=b) r1 (u:=c) r2).
+
+      Fail Arguments p [s t] _ [w] _ : assert.
+
+.. _binding_to_scope:
+
+Binding arguments to a scope
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+   The following command declares that the first two arguments of :g:`plus_fct`
+   are in the :token:`scope` delimited by the key ``F`` (``Rfun_scope``) and the third
+   argument is in the scope delimited by the key ``R`` (``R_scope``).
+
+      .. coqdoc::
+
+         Arguments plus_fct (f1 f2)%F x%R.
+
+   When interpreting a term, if some of the arguments of :token:`smart_qualid` are built
+   from a notation, then this notation is interpreted in the scope stack
+   extended by the scope bound (if any) to this argument. The effect of
+   the scope is limited to the argument itself. It does not propagate to
+   subterms but the subterms that, after interpretation of the notation,
+   turn to be themselves arguments of a reference are interpreted
+   accordingly to the argument scopes bound to this reference.
+
+.. note::
+
+   In notations, the subterms matching the identifiers of the
+   notations are interpreted in the scope in which the identifiers
+   occurred at the time of the declaration of the notation. Here is an
+   example:
+
+   .. coqtop:: all
+
+      Parameter g : bool -> bool.
+      Declare Scope mybool_scope.
+
+      Notation "@@" := true (only parsing) : bool_scope.
+      Notation "@@" := false (only parsing): mybool_scope.
+
+      Bind Scope bool_scope with bool.
+      Notation "# x #" := (g x) (at level 40).
+      Check # @@ #.
+      Arguments g _%mybool_scope.
+      Check # @@ #.
+      Delimit Scope mybool_scope with mybool.
+      Check # @@%mybool #.
+
+.. _Args_effect_on_unfolding:
+
+Effects of :cmd:`Arguments` on unfolding
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++ `simpl never` indicates that a constant should never be unfolded by :tacn:`cbn`,
+  :tacn:`simpl` or :tacn:`hnf`:
+
+  .. example::
+
+     .. coqtop:: all
+
+        Arguments minus n m : simpl never.
+
+  After that command an expression like :g:`(minus (S x) y)` is left
+  untouched by the tactics :tacn:`cbn` and :tacn:`simpl`.
+
++ A constant can be marked to be unfolded only if it's applied to at least
+  the arguments appearing before the `/` in a :cmd:`Arguments` command.
+
+  .. example::
+
+     .. coqtop:: all
+
+        Definition fcomp A B C f (g : A -> B) (x : A) : C := f (g x).
+        Arguments fcomp {A B C} f g x /.
+        Notation "f \o g" := (fcomp f g) (at level 50).
+
+  After that command the expression :g:`(f \o g)` is left untouched by
+  :tacn:`simpl` while :g:`((f \o g) t)` is reduced to :g:`(f (g t))`.
+  The same mechanism can be used to make a constant volatile, i.e.
+  always unfolded.
+
+  .. example::
+
+     .. coqtop:: all
+
+        Definition volatile := fun x : nat => x.
+        Arguments volatile / x.
+
++ A constant can be marked to be unfolded only if an entire set of
+  arguments evaluates to a constructor. The ``!`` symbol can be used to mark
+  such arguments.
+
+  .. example::
+
+     .. coqtop:: all
+
+        Arguments minus !n !m.
+
+  After that command, the expression :g:`(minus (S x) y)` is left untouched
+  by :tacn:`simpl`, while :g:`(minus (S x) (S y))` is reduced to :g:`(minus x y)`.
+
++ `simpl nomatch` indicates that a constant should not be unfolded if it would expose
+  a `match` construct in the head position.  This affects the :tacn:`cbn`,
+  :tacn:`simpl` and :tacn:`hnf` tactics.
+
+  .. example::
+
+     .. coqtop:: all
+
+        Arguments minus n m : simpl nomatch.
+
+  In this case, :g:`(minus (S (S x)) (S y))` is simplified to :g:`(minus (S x) y)`
+  even if an extra simplification is possible.
+
+  In detail: the tactic :tacn:`simpl` first applies :math:`\beta`:math:`\iota`-reduction. Then, it
+  expands transparent constants and tries to reduce further using :math:`\beta`:math:`\iota`-reduction.
+  But, when no :math:`\iota` rule is applied after unfolding then
+  :math:`\delta`-reductions are not applied. For instance trying to use :tacn:`simpl` on
+  :g:`(plus n O) = n` changes nothing.
+
+
+.. _bidirectionality_hints:
+
+Bidirectionality hints
+~~~~~~~~~~~~~~~~~~~~~~
+
+When type-checking an application, Coq normally does not use information from
+the context to infer the types of the arguments. It only checks after the fact
+that the type inferred for the application is coherent with the expected type.
+Bidirectionality hints make it possible to specify that after type-checking the
+first arguments of an application, typing information should be propagated from
+the context to help inferring the types of the remaining arguments.
+
+.. todo the following text is a start on better wording but not quite complete.
+   See https://github.com/coq/coq/pull/11718#discussion_r410219992
+
+  ..
+  Two common methods to determine the type of a construct are:
+
+  * *type checking*, which is verifying that a construct matches a known type, and
+  * *type inference*, with is inferring the type of a construct by analyzing the construct.
+
+  Methods that combine these approaches are known as *bidirectional typing*.
+  Coq normally uses only the first approach to infer the types of arguments,
+  then later verifies that the inferred type is consistent with the expected type.
+  *Bidirectionality hints* specify to use both methods: after type checking the
+  first arguments of an application (appearing before the `&` in :cmd:`Arguments`),
+  typing information from them is propagated to the remaining arguments to help infer their types.
+
+An :cmd:`Arguments` command containing :n:`@arg_specs__1 & @arg_specs__2`
+provides bidirectionality hints.
+It tells the typechecking algorithm, when type checking
+applications of :n:`@qualid`, to first type check the arguments in
+:n:`@arg_specs__1` and then propagate information from the typing context to
+type check the remaining arguments (in :n:`@arg_specs__2`).
+
+.. example:: Bidirectionality hints
+
+   In a context where a coercion was declared from ``bool`` to ``nat``:
+
+   .. coqtop:: in reset
+
+      Definition b2n (b : bool) := if b then 1 else 0.
+      Coercion b2n : bool >-> nat.
+
+   Coq cannot automatically coerce existential statements over ``bool`` to
+   statements over ``nat``, because the need for inserting a coercion is known
+   only from the expected type of a subterm:
+
+   .. coqtop:: all
+
+      Fail Check (ex_intro _ true _ : exists n : nat, n > 0).
+
+   However, a suitable bidirectionality hint makes the example work:
+
+   .. coqtop:: all
+
+      Arguments ex_intro _ _ & _ _.
+      Check (ex_intro _ true _ : exists n : nat, n > 0).
+
+Coq will attempt to produce a term which uses the arguments you
+provided, but in some cases involving Program mode the arguments after
+the bidirectionality starts may be replaced by convertible but
+syntactically different terms.

--- a/doc/sphinx/language/extensions/implicit-arguments.rst
+++ b/doc/sphinx/language/extensions/implicit-arguments.rst
@@ -105,28 +105,26 @@ This corresponds to a class of non-dependent implicit arguments that
 are solved based on the structure of their type only.
 
 
-Maximal or non maximal insertion of implicit arguments
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Maximal and non-maximal insertion of implicit arguments
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In case a function is partially applied, and the next argument to be
-applied is an implicit argument, two disciplines are applicable. In
-the first case, the function is considered to have no arguments
-furtherly: one says that the implicit argument is not maximally
-inserted. In the second case, the function is considered to be
-implicitly applied to the implicit arguments it is waiting for: one
-says that the implicit argument is maximally inserted.
+When a function is partially applied and the next argument to
+apply is an implicit argument, the application can be interpreted in two ways.
+If the next argument is declared as *maximally inserted*, the partial
+application will include that argument.  Otherwise, the argument is
+*non-maximally inserted* and the partial application will not include that argument.
 
 Each implicit argument can be declared to be inserted maximally or non
-maximally. In Coq, maximally-inserted implicit arguments are written between curly braces
-"{ }" and non-maximally-inserted implicit arguments are written in square brackets "[ ]".
+maximally. In Coq, maximally inserted implicit arguments are written between curly braces
+"{ }" and non-maximally inserted implicit arguments are written in square brackets "[ ]".
 
 .. seealso:: :flag:`Maximal Implicit Insertion`
 
 Trailing Implicit Arguments
 +++++++++++++++++++++++++++
 
-An implicit argument is considered trailing when all following arguments are declared
-implicit. Trailing implicit arguments cannot be declared non maximally inserted,
+An implicit argument is considered *trailing* when all following arguments are
+implicit. Trailing implicit arguments must be declared as maximally inserted;
 otherwise they would never be inserted.
 
 .. exn:: Argument @name is a trailing implicit, so it can't be declared non maximal. Please use %{ %} instead of [ ].
@@ -141,10 +139,9 @@ otherwise they would never be inserted.
 Casual use of implicit arguments
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In a given expression, if it is clear that some argument of a function
-can be inferred from the type of the other arguments, the user can
-force the given argument to be guessed by replacing it by “_”. If
-possible, the correct argument will be automatically generated.
+If an argument of a function application can be inferred from the type
+of the other arguments, the user can force inference of the argument
+by replacing it with `_`.
 
 .. exn:: Cannot infer a term for this placeholder.
    :name: Cannot infer a term for this placeholder. (Casual use of implicit arguments)
@@ -156,12 +153,8 @@ possible, the correct argument will be automatically generated.
 Declaration of implicit arguments
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In case one wants that some arguments of a given object (constant,
-inductive types, constructors, assumptions, local or not) are always
-inferred by |Coq|, one may declare once and for all which are the
-expected implicit arguments of this object. There are two ways to do
-this, *a priori* and *a posteriori*.
-
+Implicit arguments can be declared when a function is declared or
+afterwards, using the :cmd:`Arguments` command.
 
 Implicit Argument Binders
 +++++++++++++++++++++++++
@@ -172,18 +165,20 @@ Implicit Argument Binders
    implicit_binders ::= %{ {+ @name } {? : @type } %}
    | [ {+ @name } {? : @type } ]
 
-In the first setting, one wants to explicitly give the implicit
-arguments of a declared object as part of its definition. To do this,
-one has to surround the bindings of implicit arguments by curly
-braces or square braces:
+In the context of a function definition, these forms specify that
+:token:`name` is an implicit argument.  The first form, with curly
+braces, makes :token:`name` a maximally inserted implicit argument.  The second
+form, with square brackets, makes :token:`name` a non-maximally inserted implicit argument.
+
+For example:
 
 .. coqtop:: all
 
    Definition id {A : Type} (x : A) : A := x.
 
-This automatically declares the argument A of id as a maximally
-inserted implicit argument. One can then do as-if the argument was
-absent in every situation but still be able to specify it if needed:
+declares the argument `A` of `id` as a maximally
+inserted implicit argument. `A` may be omitted
+in applications of `id` but may be specified if needed:
 
 .. coqtop:: all
 
@@ -191,7 +186,7 @@ absent in every situation but still be able to specify it if needed:
 
    Goal forall A, compose id id = id (A:=A).
 
-For non maximally inserted implicit arguments, use square brackets:
+For non-maximally inserted implicit arguments, use square brackets:
 
 .. coqtop:: all
 
@@ -203,8 +198,7 @@ For non maximally inserted implicit arguments, use square brackets:
 
    Print Implicit map.
 
-The syntax is supported in all top-level definitions:
-:cmd:`Definition`, :cmd:`Fixpoint`, :cmd:`Lemma` and so on. For (co-)inductive datatype
+For (co-)inductive datatype
 declarations, the semantics are the following: an inductive parameter
 declared as an implicit argument need not be repeated in the inductive
 definition and will become implicit for the inductive type and the constructors.
@@ -225,11 +219,12 @@ The syntax is also supported in internal binders. For instance, in the
 following kinds of expressions, the type of each declaration present
 in :token:`binders` can be bracketed to mark the declaration as
 implicit:
-:n:`fun (@ident:forall {* @binder }, @type) => @term`,
-:n:`forall (@ident:forall {* @binder }, @type), @type`,
-:n:`let @ident {* @binder } := @term in @term`,
-:n:`fix @ident {* @binder } := @term in @term` and
-:n:`cofix @ident {* @binder } := @term in @term`.
+* :n:`fun (@ident:forall {* @binder }, @type) => @term`,
+* :n:`forall (@ident:forall {* @binder }, @type), @type`,
+* :n:`let @ident {* @binder } := @term in @term`,
+* :n:`fix @ident {* @binder } := @term in @term` and
+* :n:`cofix @ident {* @binder } := @term in @term`.
+
 Here is an example:
 
 .. coqtop:: all
@@ -258,190 +253,6 @@ Here is an example:
    .. coqtop:: all warn
 
       Check let g {x:nat} (H:x=x) {x} (H:x=x) := x in 0.
-
-
-Declaring Implicit Arguments
-++++++++++++++++++++++++++++
-
-
-
-.. cmd:: Arguments @smart_qualid {* @argument_spec_block } {* , {* @more_implicits_block } } {? : {+, @arguments_modifier } }
-   :name: Arguments
-
-   .. insertprodn smart_qualid arguments_modifier
-
-   .. prodn::
-      smart_qualid ::= @qualid
-      | @by_notation
-      by_notation ::= @string {? % @scope }
-      argument_spec_block ::= @argument_spec
-      | /
-      | &
-      | ( {+ @argument_spec } ) {? % @scope }
-      | [ {+ @argument_spec } ] {? % @scope }
-      | %{ {+ @argument_spec } %} {? % @scope }
-      argument_spec ::= {? ! } @name {? % @scope }
-      more_implicits_block ::= @name
-      | [ {+ @name } ]
-      | %{ {+ @name } %}
-      arguments_modifier ::= simpl nomatch
-      | simpl never
-      | default implicits
-      | clear bidirectionality hint
-      | clear implicits
-      | clear scopes
-      | clear scopes and implicits
-      | clear implicits and scopes
-      | rename
-      | assert
-      | extra scopes
-
-   This command sets implicit arguments *a posteriori*,
-   where the list of :n:`@name`\s is a prefix of the list of
-   arguments of :n:`@smart_qualid`.  Arguments in square
-   brackets are declared as implicit and arguments in curly brackets are declared as
-   maximally inserted.
-
-   After the command is issued, implicit arguments can and must be
-   omitted in any expression that applies :token:`qualid`.
-
-   This command supports the :attr:`local` and :attr:`global` attributes.
-   Default behavior is to limit the effect to the current section but also to
-   extend their effect outside the current module or library file.
-   Applying :attr:`local` limits the effect of the command to the current module if
-   it's not in a section.  Applying :attr:`global` within a section extends the
-   effect outside the current sections and current module if the command occurs.
-
-   A command containing :n:`@argument_spec_block & @argument_spec_block`
-   provides :ref:`bidirectionality_hints`.
-
-   Use the :n:`@more_implicits_block` to specify multiple implicit arguments declarations
-   for names of constants, inductive types, constructors and lemmas that can only be
-   applied to a fixed number of arguments (excluding, for instance,
-   constants whose type is polymorphic).
-   The longest applicable list of implicit arguments will be used to select which
-   implicit arguments are inserted.
-   For printing, the omitted arguments are the ones of the longest list of implicit
-   arguments of the sequence.  See the example :ref:`here<example_more_implicits>`.
-
-   The :n:`@arguments_modifier` values have various effects:
-
-   * :n:`clear implicits` - clears implicit arguments
-   * :n:`default implicits` - automatically determine the implicit arguments of the object.
-     See :ref:`auto_decl_implicit_args`.
-   * :n:`rename` - rename implicit arguments for the object
-   * :n:`assert` - assert that the object has the expected number of arguments with the
-     expected names.  See the example here: :ref:`renaming_implicit_arguments`.
-
-.. exn:: The / modifier may only occur once.
-   :undocumented:
-
-.. exn:: The & modifier may only occur once.
-   :undocumented:
-
-.. example::
-
-    .. coqtop:: reset all
-
-       Inductive list (A : Type) : Type :=
-       | nil : list A
-       | cons : A -> list A -> list A.
-
-       Check (cons nat 3 (nil nat)).
-
-       Arguments cons [A] _ _.
-
-       Arguments nil {A}.
-
-       Check (cons 3 nil).
-
-       Fixpoint map (A B : Type) (f : A -> B) (l : list A) : list B :=
-         match l with nil => nil | cons a t => cons (f a) (map A B f t) end.
-
-       Fixpoint length (A : Type) (l : list A) : nat :=
-         match l with nil => 0 | cons _ m => S (length A m) end.
-
-       Arguments map [A B] f l.
-
-       Arguments length {A} l. (* A has to be maximally inserted *)
-
-       Check (fun l:list (list nat) => map length l).
-
-.. _example_more_implicits:
-
-.. example:: Multiple implicit arguments with :n:`@more_implicits_block`
-
-   .. coqtop:: all
-
-       Arguments map [A B] f l, [A] B f l, A B f l.
-
-       Check (fun l => map length l = map (list nat) nat length l).
-
-.. note::
-   Use the :cmd:`Print Implicit` command to see the implicit arguments
-   of an object (see :ref:`displaying-implicit-args`).
-
-.. _auto_decl_implicit_args:
-
-Automatic declaration of implicit arguments
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-   The :n:`default implicits @arguments_modifier` clause tells |Coq| to automatically determine the
-   implicit arguments of the object.
-
-   Auto-detection is governed by flags specifying whether strict,
-   contextual, or reversible-pattern implicit arguments must be
-   considered or not (see :ref:`controlling-strict-implicit-args`, :ref:`controlling-contextual-implicit-args`,
-   :ref:`controlling-rev-pattern-implicit-args` and also :ref:`controlling-insertion-implicit-args`).
-
-.. example:: Default implicits
-
-   .. coqtop:: reset all
-
-       Inductive list (A:Set) : Set :=
-       | nil : list A
-       | cons : A -> list A -> list A.
-
-       Arguments cons : default implicits.
-
-       Print Implicit cons.
-
-       Arguments nil : default implicits.
-
-       Print Implicit nil.
-
-       Set Contextual Implicit.
-
-       Arguments nil : default implicits.
-
-       Print Implicit nil.
-
-The computation of implicit arguments takes account of the unfolding
-of constants. For instance, the variable ``p`` below has type
-``(Transitivity R)`` which is reducible to
-``forall x,y:U, R x y -> forall z:U, R y z -> R x z``. As the variables ``x``, ``y`` and ``z``
-appear strictly in the body of the type, they are implicit.
-
-.. coqtop:: all
-
-   Parameter X : Type.
-
-   Definition Relation := X -> X -> Prop.
-
-   Definition Transitivity (R:Relation) := forall x y:X, R x y -> forall z:X, R y z -> R x z.
-
-   Parameters (R : Relation) (p : Transitivity R).
-
-   Arguments p : default implicits.
-
-   Print p.
-
-   Print Implicit p.
-
-   Parameters (a b c : X) (r1 : R a b) (r2 : R b c).
-
-   Check (p r1 r2).
-
 
 Mode for automatic declaration of implicit arguments
 ++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -514,7 +325,7 @@ and the automatic declaration mode in on, the manual implicit arguments are adde
 automatically declared ones.
 
 In that case, and when the flag :flag:`Maximal Implicit Insertion` is set to off,
-some trailing implicit arguments can be inferred to be non maximally inserted. In
+some trailing implicit arguments can be inferred to be non-maximally inserted. In
 this case, they are converted to maximally inserted ones.
 
 .. example::
@@ -546,27 +357,16 @@ the hiding of implicit arguments for a single function application using the
 
     .. coqtop:: all
 
+       Parameter X : Type.
+       Definition Relation := X -> X -> Prop.
+       Definition Transitivity (R:Relation) := forall x y:X, R x y -> forall z:X, R y z -> R x z.
+       Parameters (R : Relation) (p : Transitivity R).
+       Arguments p : default implicits.
+       Print Implicit p.
+       Parameters (a b c : X) (r1 : R a b) (r2 : R b c).
        Check (p r1 (z:=c)).
 
        Check (p (x:=a) (y:=b) r1 (z:=c) r2).
-
-
-.. _renaming_implicit_arguments:
-
-Renaming implicit arguments
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. example:: (continued)  Renaming implicit arguments
-
-   .. coqtop:: all
-
-      Arguments p [s t] _ [u] _: rename.
-
-      Check (p r1 (u:=c)).
-
-      Check (p (s:=a) (t:=b) r1 (u:=c) r2).
-
-      Fail Arguments p [s t] _ [w] _ : assert.
 
 .. _displaying-implicit-args:
 
@@ -668,7 +468,7 @@ in :ref:`canonicalstructures`; here only a simple example is given.
 
       Here is an example.
 
-      .. coqtop:: all
+      .. coqtop:: all reset
 
          Require Import Relations.
 
@@ -827,7 +627,7 @@ surrounding it with \`{ }, or \`[ ] or \`( ).
 
 Terms surrounded by \`{ } introduce their free variables as maximally
 inserted implicit arguments, terms surrounded by \`[ ] introduce them as
-non maximally inserted implicit arguments and terms surrounded by \`( )
+non-maximally inserted implicit arguments and terms surrounded by \`( )
 introduce them as explicit arguments.
 
 Generalizing binders always introduce their free variables as

--- a/doc/sphinx/language/extensions/index.rst
+++ b/doc/sphinx/language/extensions/index.rst
@@ -20,6 +20,7 @@ language presented in the :ref:`previous chapter <core-language>`.
    implicit-arguments
    ../../addendum/extended-pattern-matching
    ../../user-extensions/syntax-extensions
+   arguments-command
    ../../addendum/implicit-coercions
    ../../addendum/type-classes
    ../../addendum/canonical-structures

--- a/doc/sphinx/language/gallina-extensions.rst
+++ b/doc/sphinx/language/gallina-extensions.rst
@@ -316,10 +316,10 @@ together, as well as a means of massive abstraction.
    parameters given by the :n:`@module_binder`\s.  (A *functor* is a function
    from modules to modules.)
 
-   .. todo: would like to find a better term than "interactive", not very descriptive
-
    :n:`@of_module_type` specifies the module type.  :n:`{+ <: @module_type_inl }`
    starts a module that satisfies each :n:`@module_type_inl`.
+
+   .. todo: would like to find a better term than "interactive", not very descriptive
 
    :n:`:= {+<+ @module_expr_inl }` specifies the body of a module or functor
    definition.  If it's not specified, then the module is defined *interactively*,
@@ -606,11 +606,8 @@ module can be accessed using the dot notation:
       Parameter x : T.
       End SIG.
 
-The following definition of :g:`N` using the module type expression :g:`SIG` with
+The definition of :g:`N` using the module type expression :g:`SIG` with
 :g:`Definition T := nat` is equivalent to the following one:
-
-.. todo: what is other definition referred to above?
-   "Module N' : SIG with Definition T := nat. End N`." is not it.
 
 .. coqtop:: in
 
@@ -855,7 +852,7 @@ Printing constructions in full
 .. flag:: Printing All
 
    Coercions, implicit arguments, the type of pattern matching, but also
-   notations (see :ref:`syntaxextensionsandinterpretationscopes`) can obfuscate the behavior of some
+   notations (see :ref:`syntaxextensionsandnotationscopes`) can obfuscate the behavior of some
    tactics (typically the tactics applying to occurrences of subterms are
    sensitive to the implicit arguments). Turning this flag on
    deactivates all high-level printing features such as coercions,
@@ -865,6 +862,16 @@ Printing constructions in full
    :flag:`Printing Implicit`, :flag:`Printing Coercions`, :flag:`Printing Synth`,
    :flag:`Printing Projections`, and :flag:`Printing Notations`. To reactivate
    the high-level printing features, use the command ``Unset Printing All``.
+
+   .. note:: In some cases, setting :flag:`Printing All` may display terms
+      that are so big they become very hard to read.  One technique to work around
+      this is use :cmd:`Undelimit Scope` and/or :cmd:`Close Scope` to turn off the
+      printing of notations bound to particular scope(s).  This can be useful when
+      notations in a given scope are getting in the way of understanding
+      a goal, but turning off all notations with :flag:`Printing All` would make
+      the goal unreadable.
+
+      .. see a contrived example here: https://github.com/coq/coq/pull/11718#discussion_r415481854
 
 .. _printing-universes:
 
@@ -1099,51 +1106,3 @@ Literal values (of type :g:`Float64.t`) are extracted to literal OCaml
 values (of type :g:`float`) written in hexadecimal notation and
 wrapped into the :g:`Float64.of_float` constructor, e.g.:
 :g:`Float64.of_float (0x1p+0)`.
-
-.. _bidirectionality_hints:
-
-Bidirectionality hints
-----------------------
-
-When type-checking an application, Coq normally does not use information from
-the context to infer the types of the arguments. It only checks after the fact
-that the type inferred for the application is coherent with the expected type.
-Bidirectionality hints make it possible to specify that after type-checking the
-first arguments of an application, typing information should be propagated from
-the context to help inferring the types of the remaining arguments.
-
-An :cmd:`Arguments` command containing :n:`@argument_spec_block__1 & @argument_spec_block__2`
-provides :ref:`bidirectionality_hints`.
-It tells the typechecking algorithm, when type-checking
-applications of :n:`@qualid`, to first type-check the arguments in
-:n:`@argument_spec_block__1` and then propagate information from the typing context to
-type-check the remaining arguments (in :n:`@argument_spec_block__2`).
-
-.. example:: Bidirectionality hints
-
-   In a context where a coercion was declared from ``bool`` to ``nat``:
-
-   .. coqtop:: in reset
-
-      Definition b2n (b : bool) := if b then 1 else 0.
-      Coercion b2n : bool >-> nat.
-
-   Coq cannot automatically coerce existential statements over ``bool`` to
-   statements over ``nat``, because the need for inserting a coercion is known
-   only from the expected type of a subterm:
-
-   .. coqtop:: all
-
-      Fail Check (ex_intro _ true _ : exists n : nat, n > 0).
-
-   However, a suitable bidirectionality hint makes the example work:
-
-   .. coqtop:: all
-
-      Arguments ex_intro _ _ & _ _.
-      Check (ex_intro _ true _ : exists n : nat, n > 0).
-
-Coq will attempt to produce a term which uses the arguments you
-provided, but in some cases involving Program mode the arguments after
-the bidirectionality starts may be replaced by convertible but
-syntactically different terms.

--- a/doc/sphinx/language/gallina-specification-language.rst
+++ b/doc/sphinx/language/gallina-specification-language.rst
@@ -139,7 +139,7 @@ The following grammars describe the basic syntax of the terms of the
 *Calculus of Inductive Constructions* (also called Cic). The formal
 presentation of Cic is given in Chapter :ref:`calculusofinductiveconstructions`. Extensions of this syntax
 are given in Chapter :ref:`extensionsofgallina`. How to customize the syntax
-is described in Chapter :ref:`syntaxextensionsandinterpretationscopes`.
+is described in Chapter :ref:`syntaxextensionsandnotationscopes`.
 
 .. insertprodn term field_def
 
@@ -161,7 +161,7 @@ is described in Chapter :ref:`syntaxextensionsandinterpretationscopes`.
    one_term ::= @term1
    | @ @qualid {? @univ_annot }
    term1 ::= @term_projection
-   | @term0 % @scope
+   | @term0 % @scope_key
    | @term0
    term0 ::= @qualid {? @univ_annot }
    | @sort
@@ -225,7 +225,7 @@ Numerals and strings
 
 Numerals and strings have no predefined semantics in the calculus. They are
 merely notations that can be bound to objects through the notation mechanism
-(see Chapter :ref:`syntaxextensionsandinterpretationscopes` for details).
+(see Chapter :ref:`syntaxextensionsandnotationscopes` for details).
 Initially, numerals are bound to Peano’s representation of natural
 numbers (see :ref:`datatypes`).
 
@@ -456,7 +456,7 @@ Definition by cases: match
    pattern10 ::= @pattern1 as @name
    | @pattern1 {* @pattern1 }
    | @ @qualid {* @pattern1 }
-   pattern1 ::= @pattern0 % @scope
+   pattern1 ::= @pattern0 % @scope_key
    | @pattern0
    pattern0 ::= @qualid
    | %{%| {* @qualid := @pattern } %|%}
@@ -1246,7 +1246,7 @@ The ability to define co-inductive types by constructors, hereafter called
 a bit long: this is due to dependent pattern-matching which implies
 propositional η-equality, which itself would require full η-conversion for
 subject reduction to hold, but full η-conversion is not acceptable as it would
-make type-checking undecidable.
+make type checking undecidable.
 
 Since the introduction of primitive records in Coq 8.5, an alternative
 presentation is available, called *negative co-inductive types*. This consists

--- a/doc/sphinx/practical-tools/coqide.rst
+++ b/doc/sphinx/practical-tools/coqide.rst
@@ -219,7 +219,7 @@ Displaying Unicode symbols
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You just need to define suitable notations as described in the chapter
-:ref:`syntaxextensionsandinterpretationscopes`. For example, to use the
+:ref:`syntaxextensionsandnotationscopes`. For example, to use the
 mathematical symbols ∀ and ∃, you may define:
 
 .. coqtop:: in

--- a/doc/sphinx/proof-engine/ltac.rst
+++ b/doc/sphinx/proof-engine/ltac.rst
@@ -474,7 +474,7 @@ Soft cut
 ~~~~~~~~
 
 Another way of restricting backtracking is to restrict a tactic to a
-single success *a posteriori*:
+single success:
 
 .. tacn:: once @ltac_expr
    :name: once

--- a/doc/sphinx/proof-engine/ltac2.rst
+++ b/doc/sphinx/proof-engine/ltac2.rst
@@ -510,9 +510,9 @@ Static semantics
 ****************
 
 During internalization, Coq variables are resolved and antiquotations are
-type-checked as Ltac2 terms, effectively producing a ``glob_constr`` in Coq
+type checked as Ltac2 terms, effectively producing a ``glob_constr`` in Coq
 implementation terminology. Note that although it went through the
-type-checking of **Ltac2**, the resulting term has not been fully computed and
+type checking of **Ltac2**, the resulting term has not been fully computed and
 is potentially ill-typed as a runtime **Coq** term.
 
 .. example::
@@ -523,12 +523,12 @@ is potentially ill-typed as a runtime **Coq** term.
 
       Ltac2 myconstr () := constr:(nat -> 0).
 
-Term antiquotations are type-checked in the enclosing Ltac2 typing context
+Term antiquotations are type checked in the enclosing Ltac2 typing context
 of the corresponding term expression.
 
 .. example::
 
-   The following will type-check, with type `constr`.
+   The following will type check, with type `constr`.
 
    .. coqdoc::
 
@@ -539,7 +539,7 @@ expanded by the Coq binders from the term.
 
   .. example::
 
-     The following Ltac2 expression will **not** type-check::
+     The following Ltac2 expression will **not** type check::
 
      `constr:(fun x : nat => ltac2:(exact x))`
      `(* Error: Unbound variable 'x' *)`
@@ -583,7 +583,7 @@ Dynamic semantics
 *****************
 
 During evaluation, a quoted term is fully evaluated to a kernel term, and is
-in particular type-checked in the current environment.
+in particular type checked in the current environment.
 
 Evaluation of a quoted term goes as follows.
 
@@ -602,7 +602,7 @@ whole expression will thus evaluate to the term :g:`fun H : nat => H`.
 
 `let tac () := hyp @H in constr:(fun H : nat => ltac2:(tac ()))`
 
-Many standard tactics perform type-checking of their argument before going
+Many standard tactics perform type checking of their argument before going
 further. It is your duty to ensure that terms are well-typed when calling
 such tactics. Failure to do so will result in non-recoverable exceptions.
 
@@ -700,7 +700,7 @@ The following scopes are built-in.
 
   + parses :n:`c = @term` and produces :n:`constr:(c)`
 
-  This scope can be parameterized by a list of delimiting keys of interpretation
+  This scope can be parameterized by a list of delimiting keys of notation
   scopes (as described in :ref:`LocalInterpretationRulesForNotations`),
   describing how to interpret the parsed term. For instance, :n:`constr(A, B)`
   parses :n:`c = @term` and produces :n:`constr:(c%A%B)`.

--- a/doc/sphinx/proof-engine/tactics.rst
+++ b/doc/sphinx/proof-engine/tactics.rst
@@ -3187,6 +3187,7 @@ the conversion in hypotheses :n:`{+ @ident}`.
    head normal form according to the :math:`\beta`:math:`\delta`:math:`\iota`:math:`\zeta`-reduction rules, i.e. it
    reduces the head of the goal until it becomes a product or an
    irreducible term. All inner :math:`\beta`:math:`\iota`-redexes are also reduced.
+   The behavior of both :tacn:`hnf` can be tuned using the :cmd:`Arguments` command.
 
    Example: The term :g:`fun n : nat => S n + S n` is not reduced by :n:`hnf`.
 
@@ -3213,76 +3214,10 @@ the conversion in hypotheses :n:`{+ @ident}`.
 
    The :tacn:`cbn` tactic accepts the same flags as :tacn:`cbv` and
    :tacn:`lazy`. The behavior of both :tacn:`simpl` and :tacn:`cbn`
-   can be tuned using the Arguments vernacular command as follows:
+   can be tuned using the :cmd:`Arguments` command.
 
-   + A constant can be marked to be never unfolded by :tacn:`cbn` or
-     :tacn:`simpl`:
-
-     .. example::
-
-        .. coqtop:: all
-
-           Arguments minus n m : simpl never.
-
-     After that command an expression like :g:`(minus (S x) y)` is left
-     untouched by the tactics :tacn:`cbn` and :tacn:`simpl`.
-
-   + A constant can be marked to be unfolded only if applied to enough
-     arguments. The number of arguments required can be specified using the
-     ``/`` symbol in the argument list of the :cmd:`Arguments` command.
-
-     .. example::
-
-        .. coqtop:: all
-
-           Definition fcomp A B C f (g : A -> B) (x : A) : C := f (g x).
-           Arguments fcomp {A B C} f g x /.
-           Notation "f \o g" := (fcomp f g) (at level 50).
-
-     After that command the expression :g:`(f \o g)` is left untouched by
-     :tacn:`simpl` while :g:`((f \o g) t)` is reduced to :g:`(f (g t))`.
-     The same mechanism can be used to make a constant volatile, i.e.
-     always unfolded.
-
-     .. example::
-
-        .. coqtop:: all
-
-           Definition volatile := fun x : nat => x.
-           Arguments volatile / x.
-
-   + A constant can be marked to be unfolded only if an entire set of
-     arguments evaluates to a constructor. The ``!`` symbol can be used to mark
-     such arguments.
-
-     .. example::
-
-        .. coqtop:: all
-
-           Arguments minus !n !m.
-
-     After that command, the expression :g:`(minus (S x) y)` is left untouched
-     by :tacn:`simpl`, while :g:`(minus (S x) (S y))` is reduced to :g:`(minus x y)`.
-
-   + A special heuristic to determine if a constant has to be unfolded
-     can be activated with the following command:
-
-     .. example::
-
-        .. coqtop:: all
-
-           Arguments minus n m : simpl nomatch.
-
-     The heuristic avoids to perform a simplification step that would expose a
-     match construct in head position. For example the expression
-     :g:`(minus (S (S x)) (S y))` is simplified to :g:`(minus (S x) y)`
-     even if an extra simplification is possible.
-
-   In detail, the tactic :tacn:`simpl` first applies :math:`\beta`:math:`\iota`-reduction. Then, it
-   expands transparent constants and tries to reduce further using :math:`\beta`:math:`\iota`-reduction.
-   But, when no :math:`\iota` rule is applied after unfolding then
-   :math:`\delta`-reductions are not applied. For instance trying to use :tacn:`simpl` on
-   :g:`(plus n O) = n` changes nothing.
+   .. todo add "See <subsection about controlling the behavior of reduction strategies>"
+      to TBA section
 
    Notice that only transparent constants whose name can be reused in the
    recursive calls are possibly unfolded by :tacn:`simpl`. For instance a

--- a/doc/sphinx/proof-engine/vernacular-commands.rst
+++ b/doc/sphinx/proof-engine/vernacular-commands.rst
@@ -181,7 +181,8 @@ to accessible objects.  (see Section :ref:`invocation-of-tactics`).
    or an accessible theorem, axiom, etc.:
    its kind (module, constant, assumption, inductive,
    constructor, abbreviation, …), long name, type, implicit arguments and
-   argument scopes. It does not print the body of definitions or proofs.
+   argument scopes (as set in the definition of :token:`smart_qualid` or
+   subsequently with the :cmd:`Arguments` command). It does not print the body of definitions or proofs.
 
 .. cmd:: Check @term
 
@@ -210,7 +211,7 @@ to accessible objects.  (see Section :ref:`invocation-of-tactics`).
 
    .. prodn::
       search_item ::= @one_term
-      | @string {? % @scope }
+      | @string {? % @scope_key }
 
    Displays the name and type of all hypotheses of the
    selected goal (if any) and theorems of the current context

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -224,8 +224,16 @@ IDENT: [
 | ident
 ]
 
-scope: [
+scope_key: [
 | IDENT
+]
+
+scope_name: [
+| IDENT
+]
+
+scope: [
+| scope_name | scope_key
 ]
 
 operconstr100: [
@@ -250,7 +258,7 @@ operconstr1: [
 | REPLACE operconstr0 ".(" global LIST0 appl_arg ")"
 | WITH    operconstr0 ".(" global LIST0 appl_arg ")" (* huh? *)
 | REPLACE operconstr0 "%" IDENT
-| WITH operconstr0 "%" scope
+| WITH operconstr0 "%" scope_key
 | MOVETO term_projection operconstr0 ".(" global LIST0 appl_arg ")"
 | MOVETO term_projection operconstr0 ".(" "@" global LIST0 ( operconstr9 ) ")"
 ]
@@ -376,7 +384,7 @@ pattern10: [
 
 pattern1: [
 | REPLACE pattern0 "%" IDENT
-| WITH pattern0 "%" scope
+| WITH pattern0 "%" scope_key
 ]
 
 pattern0: [
@@ -879,9 +887,14 @@ bar_cbrace: [
 ]
 
 printable: [
+| REPLACE "Scope" IDENT
+| WITH "Scope" scope_name
+| REPLACE "Visibility" OPT IDENT
+| WITH "Visibility" OPT scope_name
 | REPLACE [ "Sorted" | ] "Universes" OPT printunivs_subgraph OPT ne_string
 | WITH OPT "Sorted" "Universes" OPT printunivs_subgraph OPT ne_string
 | DELETE "Term" smart_global OPT univ_name_list  (* readded in commands *)
+
 | INSERTALL "Print"
 ]
 
@@ -1012,25 +1025,58 @@ command: [
 | REPLACE "Print" smart_global OPT univ_name_list
 | WITH "Print" OPT "Term" smart_global OPT univ_name_list
 
+| REPLACE "Declare" "Scope" IDENT
+| WITH "Declare" "Scope" scope_name
+
+(* odd that these are in command while other notation-related ones are in syntax *)
+| REPLACE "Numeral" "Notation" reference reference reference ":" ident numnotoption
+| WITH "Numeral" "Notation" reference reference reference ":" scope_name numnotoption
+| REPLACE "String" "Notation" reference reference reference ":" ident
+| WITH "String" "Notation" reference reference reference ":" scope_name
+
 ]
 
 option_setting: [
 | OPTINREF
 ]
 
-only_parsing: [
-| OPTINREF
-]
-
 syntax: [
+| REPLACE "Open" "Scope" IDENT
+| WITH "Open" "Scope" scope
+| REPLACE "Close" "Scope" IDENT
+| WITH "Close" "Scope" scope
+| REPLACE "Delimit" "Scope" IDENT; "with" IDENT
+| WITH "Delimit" "Scope" scope_name; "with" scope_key
+| REPLACE "Undelimit" "Scope" IDENT
+| WITH "Undelimit" "Scope" scope_name
+| REPLACE "Bind" "Scope" IDENT; "with" LIST1 class_rawexpr
+| WITH "Bind" "Scope" scope_name; "with" LIST1 class_rawexpr
 | REPLACE "Infix" ne_lstring ":=" constr [ "(" LIST1 syntax_modifier SEP "," ")" | ]   OPT [ ":" IDENT ]
-| WITH    "Infix" ne_lstring ":=" constr OPT [ "(" LIST1 syntax_modifier SEP "," ")" ] OPT [ ":" IDENT ]
+| WITH    "Infix" ne_lstring ":=" constr OPT [ "(" LIST1 syntax_modifier SEP "," ")" ] OPT [ ":" scope_name ]
 | REPLACE "Notation" lstring ":=" constr [ "(" LIST1 syntax_modifier SEP "," ")" | ]   OPT [ ":" IDENT ]
-| WITH    "Notation" lstring ":=" constr OPT [ "(" LIST1 syntax_modifier SEP "," ")" ] OPT [ ":" IDENT ]
+| WITH    "Notation" lstring ":=" constr OPT [ "(" LIST1 syntax_modifier SEP "," ")" ] OPT [ ":" scope_name ]
 | REPLACE "Reserved" "Infix" ne_lstring [ "(" LIST1 syntax_modifier SEP "," ")" | ]
 | WITH    "Reserved" "Infix" ne_lstring OPT [ "(" LIST1 syntax_modifier SEP "," ")" ]
 | REPLACE "Reserved" "Notation" ne_lstring [ "(" LIST1 syntax_modifier SEP "," ")" | ]
 | WITH    "Reserved" "Notation" ne_lstring OPT [ "(" LIST1 syntax_modifier SEP "," ")" ]
+]
+
+syntax_modifier: [
+| DELETE "in" "custom" IDENT
+| REPLACE "in" "custom" IDENT; "at" "level" natural
+| WITH "in" "custom" IDENT OPT ( "at" "level" natural )
+| REPLACE IDENT; "," LIST1 IDENT SEP "," "at" level
+| WITH LIST1 IDENT SEP "," "at" level
+]
+
+syntax_extension_type: [
+| REPLACE "strict" "pattern" "at" "level" natural
+| WITH "strict" "pattern" OPT ( "at" "level" natural )
+| DELETE "strict" "pattern"
+| DELETE "pattern"
+| REPLACE "pattern" "at" "level" natural
+| WITH "pattern" OPT ( "at" "level" natural )
+| DELETE "constr"    (* covered by another prod *)
 ]
 
 numnotoption: [
@@ -1407,12 +1453,12 @@ positive_search_mark: [
 
 by_notation: [
 | REPLACE ne_string OPT [ "%" IDENT ]
-| WITH ne_string OPT [ "%" scope ]
+| WITH ne_string OPT [ "%" scope_key ]
 ]
 
 scope_delimiter: [
 | REPLACE "%" IDENT
-| WITH "%" scope
+| WITH "%" scope_key
 ]
 
 (* Don't show these details *)
@@ -1420,6 +1466,23 @@ DELETE: [
 | register_token
 | register_prim_token
 | register_type_token
+]
+
+
+decl_notation: [
+| REPLACE ne_lstring ":=" constr only_parsing OPT [ ":" IDENT ]
+| WITH ne_lstring ":=" constr only_parsing OPT [ ":" scope_name ]
+]
+
+
+only_parsing: [
+| OPTINREF
+]
+
+ltac_production_item: [
+| REPLACE ident "(" ident OPT ltac_production_sep ")"
+| WITH ident OPT ( "(" ident OPT ltac_production_sep ")" )
+| DELETE ident
 ]
 
 SPLICE: [
@@ -1588,6 +1651,7 @@ SPLICE: [
 | searchabout_queries
 | locatable
 | scope_delimiter
+| bignat
 | one_import_filter_name
 ] (* end SPLICE *)
 
@@ -1640,6 +1704,12 @@ RENAME: [
 | smart_global smart_qualid
 | searchabout_query search_item
 | option_table setting_name
+| argument_spec_block arg_specs
+| more_implicits_block implicits_alt
+| arguments_modifier args_modifier
+| constr_as_binder_kind binder_interp
+| syntax_extension_type explicit_subentry
+| numnotoption numeral_modifier
 ]
 
 (* todo: positive_search_mark is a lousy name for OPT "-" *)

--- a/doc/tools/docgram/doc_grammar.ml
+++ b/doc/tools/docgram/doc_grammar.ml
@@ -1771,11 +1771,13 @@ let process_rst g file args seen tac_prods cmd_prods =
     "doc/sphinx/language/core/records.rst";
     "doc/sphinx/language/core/sections.rst";
     "doc/sphinx/language/extensions/implicit-arguments.rst";
+    "doc/sphinx/language/extensions/arguments-command.rst";
     "doc/sphinx/language/using/libraries/funind.rst";
 
     "doc/sphinx/language/gallina-specification-language.rst";
     "doc/sphinx/language/gallina-extensions.rst";
-    "doc/sphinx/proof-engine/vernacular-commands.rst"
+    "doc/sphinx/proof-engine/vernacular-commands.rst";
+    "doc/sphinx/user-extensions/syntax-extensions.rst"
   ]
   in
 

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -47,7 +47,7 @@ one_term: [
 
 term1: [
 | term_projection
-| term0 "%" scope
+| term0 "%" scope_key
 | term0
 ]
 
@@ -343,7 +343,7 @@ pattern10: [
 ]
 
 pattern1: [
-| pattern0 "%" scope
+| pattern0 "%" scope_key
 | pattern0
 ]
 
@@ -370,14 +370,6 @@ subprf: [
 
 fix_definition: [
 | ident_decl LIST0 binder OPT fixannot OPT ( ":" type ) OPT [ ":=" term ] OPT decl_notations
-]
-
-decl_notations: [
-| "where" decl_notation LIST0 ( "and" decl_notation )
-]
-
-decl_notation: [
-| string ":=" one_term OPT ( "(" "only" "parsing" ")" ) OPT [ ":" ident ]
 ]
 
 thm_token: [
@@ -571,43 +563,52 @@ smart_qualid: [
 ]
 
 by_notation: [
-| string OPT [ "%" scope ]
-]
-
-argument_spec_block: [
-| argument_spec
-| "/"
-| "&"
-| "(" LIST1 argument_spec ")" OPT ( "%" scope )
-| "[" LIST1 argument_spec "]" OPT ( "%" scope )
-| "{" LIST1 argument_spec "}" OPT ( "%" scope )
+| string OPT [ "%" scope_key ]
 ]
 
 argument_spec: [
-| OPT "!" name OPT ( "%" scope )
+| OPT "!" name OPT ( "%" scope_key )
 ]
 
-more_implicits_block: [
+arg_specs: [
+| argument_spec
+| "/"
+| "&"
+| "(" LIST1 argument_spec ")" OPT ( "%" scope_key )
+| "[" LIST1 argument_spec "]" OPT ( "%" scope_key )
+| "{" LIST1 argument_spec "}" OPT ( "%" scope_key )
+]
+
+implicits_alt: [
 | name
 | "[" LIST1 name "]"
 | "{" LIST1 name "}"
 ]
 
-arguments_modifier: [
+args_modifier: [
 | "simpl" "nomatch"
 | "simpl" "never"
 | "default" "implicits"
-| "clear" "bidirectionality" "hint"
 | "clear" "implicits"
 | "clear" "scopes"
-| "clear" "scopes" "and" "implicits"
-| "clear" "implicits" "and" "scopes"
+| "clear" "bidirectionality" "hint"
 | "rename"
 | "assert"
 | "extra" "scopes"
+| "clear" "scopes" "and" "implicits"
+| "clear" "implicits" "and" "scopes"
 ]
 
 scope: [
+| scope_name
+| scope_key
+]
+
+scope_name: [
+| ident
+]
+
+scope_key: [
 | ident
 ]
 
@@ -629,7 +630,6 @@ simple_reserv: [
 
 command: [
 | "Goal" term
-| "Declare" "Scope" ident
 | "Pwd"
 | "Cd" OPT string
 | "Load" OPT "Verbose" [ string | ident ]
@@ -669,8 +669,8 @@ command: [
 | "Print" "Hint" "*"
 | "Print" "HintDb" ident
 | "Print" "Scopes"
-| "Print" "Scope" ident
-| "Print" "Visibility" OPT ident
+| "Print" "Scope" scope_name
+| "Print" "Visibility" OPT scope_name
 | "Print" "Implicit" smart_qualid
 | "Print" OPT "Sorted" "Universes" OPT ( "Subgraph" "(" LIST0 qualid ")" ) OPT string
 | "Print" "Assumptions" smart_qualid
@@ -728,6 +728,7 @@ command: [
 | "Hint" hint OPT ( ":" LIST1 ident )
 | "Comments" LIST0 comment
 | "Declare" "Instance" ident_decl LIST0 binder ":" term OPT hint_info
+| "Declare" "Scope" scope_name
 | "Obligation" int OPT ( "of" ident ) OPT ( ":" term OPT ( "with" ltac_expr ) )
 | "Next" "Obligation" OPT ( "of" ident ) OPT ( "with" ltac_expr )
 | "Solve" "Obligation" int OPT ( "of" ident ) "with" ltac_expr
@@ -821,8 +822,8 @@ command: [
 | "Print" "Rings"      (* setoid_ring plugin *)
 | "Add" "Field" ident ":" one_term OPT ( "(" LIST1 field_mod SEP "," ")" )      (* setoid_ring plugin *)
 | "Print" "Fields"      (* setoid_ring plugin *)
-| "Numeral" "Notation" qualid qualid qualid ":" ident OPT numnotoption
-| "String" "Notation" qualid qualid qualid ":" ident
+| "Numeral" "Notation" qualid qualid qualid ":" scope_name OPT numeral_modifier
+| "String" "Notation" qualid qualid qualid ":" scope_name
 | "SubClass" ident_decl def_body
 | thm_token ident_decl LIST0 binder ":" type LIST0 [ "with" ident_decl LIST0 binder ":" type ]
 | assumption_token OPT ( "Inline" OPT ( "(" num ")" ) ) [ LIST1 ( "(" assumpt ")" ) | assumpt ]
@@ -871,19 +872,19 @@ command: [
 | "Existing" "Instance" qualid OPT hint_info
 | "Existing" "Instances" LIST1 qualid OPT [ "|" num ]
 | "Existing" "Class" qualid
-| "Arguments" smart_qualid LIST0 argument_spec_block LIST0 [ "," LIST0 more_implicits_block ] OPT [ ":" LIST1 arguments_modifier SEP "," ]
+| "Arguments" smart_qualid LIST0 arg_specs LIST0 [ "," LIST0 implicits_alt ] OPT [ ":" LIST1 args_modifier SEP "," ]
 | "Implicit" [ "Type" | "Types" ] reserv_list
 | "Generalizable" [ [ "Variable" | "Variables" ] LIST1 ident | "All" "Variables" | "No" "Variables" ]
 | "Set" setting_name OPT [ int | string ]
 | "Unset" setting_name
-| "Open" "Scope" ident
-| "Close" "Scope" ident
-| "Delimit" "Scope" ident "with" ident
-| "Undelimit" "Scope" ident
-| "Bind" "Scope" ident "with" LIST1 class
-| "Infix" string ":=" one_term OPT [ "(" LIST1 syntax_modifier SEP "," ")" ] OPT [ ":" ident ]
+| "Open" "Scope" scope
+| "Close" "Scope" scope
+| "Delimit" "Scope" scope_name "with" scope_key
+| "Undelimit" "Scope" scope_name
+| "Bind" "Scope" scope_name "with" LIST1 class
+| "Infix" string ":=" one_term OPT [ "(" LIST1 syntax_modifier SEP "," ")" ] OPT [ ":" scope_name ]
 | "Notation" ident LIST0 ident ":=" one_term OPT ( "(" "only" "parsing" ")" )
-| "Notation" string ":=" one_term OPT [ "(" LIST1 syntax_modifier SEP "," ")" ] OPT [ ":" ident ]
+| "Notation" string ":=" one_term OPT [ "(" LIST1 syntax_modifier SEP "," ")" ] OPT [ ":" scope_name ]
 | "Format" "Notation" string string string
 | "Reserved" "Infix" string OPT [ "(" LIST1 syntax_modifier SEP "," ")" ]
 | "Reserved" "Notation" string OPT [ "(" LIST1 syntax_modifier SEP "," ")" ]
@@ -940,10 +941,6 @@ dirpath: [
 | LIST0 ( ident "." ) ident
 ]
 
-bignat: [
-| numeral
-]
-
 setting_name: [
 | LIST1 ident
 ]
@@ -956,7 +953,7 @@ comment: [
 
 search_item: [
 | one_term
-| string OPT ( "%" scope )
+| string OPT ( "%" scope_key )
 ]
 
 univ_name_list: [
@@ -987,13 +984,7 @@ tacdef_body: [
 
 ltac_production_item: [
 | string
-| ident "(" ident OPT ( "," string ) ")"
-| ident
-]
-
-numnotoption: [
-| "(" "warning" "after" bignat ")"
-| "(" "abstract" "after" bignat ")"
+| ident OPT ( "(" ident OPT ( "," string ) ")" )
 ]
 
 int_or_id: [
@@ -1033,6 +1024,11 @@ field_mod: [
 | "completeness" one_term      (* setoid_ring plugin *)
 ]
 
+numeral_modifier: [
+| "(" "warning" "after" numeral ")"
+| "(" "abstract" "after" numeral ")"
+]
+
 hints_path: [
 | "(" hints_path ")"
 | hints_path "*"
@@ -1050,46 +1046,50 @@ class: [
 | smart_qualid
 ]
 
-level: [
-| "level" num
-| "next" "level"
-]
-
 syntax_modifier: [
 | "at" "level" num
-| "in" "custom" ident
-| "in" "custom" ident "at" "level" num
+| "in" "custom" ident OPT ( "at" "level" num )
+| LIST1 ident SEP "," "at" level
+| ident "at" level OPT binder_interp
+| ident explicit_subentry
+| ident binder_interp
 | "left" "associativity"
 | "right" "associativity"
 | "no" "associativity"
-| "only" "printing"
 | "only" "parsing"
+| "only" "printing"
 | "format" string OPT string
-| ident "," LIST1 ident SEP "," "at" level
-| ident "at" level OPT constr_as_binder_kind
-| ident constr_as_binder_kind
-| ident syntax_extension_type
 ]
 
-constr_as_binder_kind: [
+explicit_subentry: [
+| "ident"
+| "global"
+| "bigint"
+| "strict" "pattern" OPT ( "at" "level" num )
+| "binder"
+| "closed" "binder"
+| "constr" OPT ( "at" level ) OPT binder_interp
+| "custom" ident OPT ( "at" level ) OPT binder_interp
+| "pattern" OPT ( "at" "level" num )
+]
+
+binder_interp: [
 | "as" "ident"
 | "as" "pattern"
 | "as" "strict" "pattern"
 ]
 
-syntax_extension_type: [
-| "ident"
-| "global"
-| "bigint"
-| "binder"
-| "constr"
-| "constr" OPT ( "at" level ) OPT constr_as_binder_kind
-| "pattern"
-| "pattern" "at" "level" num
-| "strict" "pattern"
-| "strict" "pattern" "at" "level" num
-| "closed" "binder"
-| "custom" ident OPT ( "at" level ) OPT constr_as_binder_kind
+level: [
+| "level" num
+| "next" "level"
+]
+
+decl_notations: [
+| "where" decl_notation LIST0 ( "and" decl_notation )
+]
+
+decl_notation: [
+| string ":=" one_term OPT ( "(" "only" "parsing" ")" ) OPT [ ":" scope_name ]
 ]
 
 simple_tactic: [


### PR DESCRIPTION
@Zimmi48 would you initially focus your review on:
- syntax
- the todo's I added
- restructuring of the `Arguments` command
  -  For now, I combined the argument descriptions in `implict-arguments.rst`.  Still some text in syntax-extensions and maybe the Bidirectionality hints section, to later move to a new section in `gallina-extensions` in this PR.  (Or should it be a new file?)
  -  Likely we should add more description of the 4 actions of `Arguments` and maybe have subsections for each of them

It's less confusing if we minimize the number of open points as we proceed with the review.

Fix #9765