### PR TITLE
Extending to TACTIC EXTEND and Ltac Notation the ability to assign a binding role to an ident in the tactic syntax tree

### DIFF
--- a/doc/changelog/05-tactic-language/11721-master+ltac-ident-genarg-means-binding-ident.rst
+++ b/doc/changelog/05-tactic-language/11721-master+ltac-ident-genarg-means-binding-ident.rst
@@ -1,0 +1,12 @@
+- **Changed:**
+  All uses of ``ident(x)`` or ``intropatterns(pat)`` in a new tactic
+  definition now declare the corresponding variables as binding
+  variables. (If this is not what is intended, one should use ``hyp(x)``,
+  for a variable of the context, or ``reference(x)``, for a global
+  reference, or ``quantified_hypothesis(x)``, for a variable which is
+  either in the context or quantified in the current goal, or
+  ``pre_ident(x)`` for an uninterpreted ident.). Hence :g:`Ltac f := intro x;
+  apply x` now succeeds like :g:`Ltac f := intros x; apply x` always has.
+  This is potentially source of rare incompatibilities
+  (`#11721 <https://github.com/coq/coq/pull/11721>`_,
+  by Hugo Herbelin).

--- a/lib/cAst.ml
+++ b/lib/cAst.ml
@@ -16,6 +16,8 @@ type 'a t = {
 
 let make ?loc v = { v; loc }
 
+let fold_left_map f x n = let x, v = f x n.v in (x,{ n with v })
+
 let map f n = { n with v = f n.v }
 let map_with_loc f n = { n with v = f ?loc:n.loc n.v }
 let map_from_loc f l =

--- a/lib/cAst.mli
+++ b/lib/cAst.mli
@@ -16,6 +16,8 @@ type 'a t = private {
 
 val make : ?loc:Loc.t -> 'a -> 'a t
 
+val fold_left_map : ('c -> 'a -> 'c * 'b) -> 'c -> 'a t -> 'c * 'b t
+
 val map : ('a -> 'b) -> 'a t -> 'b t
 val map_with_loc : (?loc:Loc.t -> 'a -> 'b) -> 'a t -> 'b t
 val map_from_loc : (?loc:Loc.t -> 'a -> 'b) -> 'a Loc.located -> 'b t

--- a/plugins/ltac/tacentries.ml
+++ b/plugins/ltac/tacentries.ml
@@ -716,7 +716,8 @@ match arg.arg_intern with
 | ArgInternFun f -> f
 | ArgInternWit wit ->
   fun ist v ->
-    let ans = Genarg.out_gen (glbwit wit) (Tacintern.intern_genarg ist (Genarg.in_gen (rawwit wit) v)) in
+    let ist, v = Tacintern.intern_genarg ist (Genarg.in_gen (rawwit wit) v) in
+    let ans = Genarg.out_gen (glbwit wit) v in
     (ist, ans)
 
 let subst_fun (type a b c) (arg : (a, b, c) tactic_argument) : b Genintern.subst_fun =

--- a/plugins/ltac/tacintern.mli
+++ b/plugins/ltac/tacintern.mli
@@ -53,7 +53,7 @@ val intern_hyp : glob_sign -> lident -> lident
 
 (** Adds a globalization function for extra generic arguments *)
 
-val intern_genarg : glob_sign -> raw_generic_argument -> glob_generic_argument
+val intern_genarg : glob_sign -> raw_generic_argument -> glob_sign * glob_generic_argument
 
 (** printing *)
 val print_ltac : Libnames.qualid -> Pp.t

--- a/test-suite/output/InvalidDisjunctiveIntro.out
+++ b/test-suite/output/InvalidDisjunctiveIntro.out
@@ -1,7 +1,7 @@
 The command has indeed failed with message:
 Cannot coerce to a disjunctive/conjunctive pattern.
 The command has indeed failed with message:
-Disjunctive/conjunctive introduction pattern expected.
+Cannot coerce to a disjunctive/conjunctive pattern.
 The command has indeed failed with message:
 Cannot coerce to a disjunctive/conjunctive pattern.
 The command has indeed failed with message:

--- a/test-suite/output/InvalidDisjunctiveIntro.v
+++ b/test-suite/output/InvalidDisjunctiveIntro.v
@@ -2,7 +2,7 @@ Theorem test (A:Prop) : A \/ A -> A.
   Fail intros H; destruct H as H.
   (* Cannot coerce to a disjunctive/conjunctive pattern. *)
   Fail intro H; destruct H as H.
-  (* Disjunctive/conjunctive introduction pattern expected. *)
+  (* Cannot coerce to a disjunctive/conjunctive pattern. *)
   Fail let H := fresh in intro H; destruct H as H.
   (* Cannot coerce to a disjunctive/conjunctive pattern. *)
   Fail let H := fresh in intros H; destruct H as H.

--- a/test-suite/success/intros.v
+++ b/test-suite/success/intros.v
@@ -152,3 +152,29 @@ Definition d := ltac:(intro x; exact (x*x)).
 Definition d' : nat -> _ := ltac:(intros;exact 0).
 
 End Evar.
+
+Module Ltac.
+
+(* Binding made by an intro propagate to ";" *)
+Ltac f := intro x; apply x.
+Ltac g := injection as [= H]; apply H.
+
+(* Binding made by an intro does not escape a "let" *)
+Fail Ltac h := let a := intro x in a ; apply x.
+
+(* Binding made in a multiple "then" clause does not escape the n-ary clause *)
+Fail Ltac h := idtac; [intro x]; apply x.
+
+(* An amazing interaction with fresh *)
+
+Ltac h x :=
+  let n := fresh "n" in
+  intros n.
+
+Goal nat -> nat -> nat.
+intro n; clear n; h n.
+(* formerly was giving: n0:nat |- nat *)
+exact n.
+Qed.
+
+End Ltac.


### PR DESCRIPTION
**Kind:** enhancement

#### General presentation

In Ltac interpretation, some arguments of tactics are recognized as declaring binding variables. This is e.g. the case of `intros x [H1|H2]` which declares `x`, `H1` and `H2` as binding variable in the continuation of the tactic expression, where the "continuation" is defined to be the `; tac` continuation of the tactic if any.

This interpretation was hard-wired for tactics primitively in the abstract syntax tree for tactics. This PR extends the support to `TACTIC EXTEND` and `Tactic Notation`, that is, all uses of `ident(x)` or `intropatterns(pat)` in a new tactic definition are now declaring the corresponding variables as binding variables. (If this is not what is intended, one should use `hyp(x)`, for a variable of the context, or `ref(x)`/`reference(x)`, for a global reference, or `quantified_hypothesis(x)`, for a variable which is either in the context or quantified in the current goal, or `pre_ident(x)` for an uninterpreted ident.)

It allows for instance to have `Ltac f := intro x; apply x` working, the same way as `Ltac f := intros x; apply x` was already working, removing a surprising inconsistency.

Combined with #11679, it will also allow to do a stricter check on `ltac:()` quotations, meaning that it will be able to recognize the binding role of `x` in `ltac:(intro x; apply x)`. (Currently, `strict_check` is off for `ltac:()` notations which are not themselves parts of a bigger `Ltac` definition.)

Of course, we could go further. In an `intro x`, we indeed do two things: binding an ltac variable `x` to a name `x` and adding the name `x` in the environment. We could also recognize `clear x` as having the side effect of altering the second effect (i.e. `x` is still an ltac variable, so that we can do `clear x; intro x` reusing the same name as a binding name, but `x` is known to be no longer usable as a bound variable, thus rejecting e.g. `clear x; apply x`). For such analysis to scale, so that e.g. `let f x := clear x in f x; apply x` fails, this would need some effectful typing though, hence rather targetting Ltac2.

#### Summary 

This PR is modest wrt what could be done further. It basically aims at:
- fixing the inconstency between the failing `Ltac f := intro x; apply x` and the succeeding `Ltac f := intros x; apply x`; this is because ` x` was not recognized as binding in `intro x` due to `intro` not being primitive but defined by `TACTIC EXTEND`;
- later allowing a strict check on `ltac:()`, knowing that the CI for #11679 showed that the only instances of `ltac:()` tested in CI which are not compatible with a strict check are in `micromega` and in the test-suite, and, for the latter, precisely related to this limitation of `TACTIC EXTEND`.

#### Relation with Ltac2

Another way to look at this PR is that it basically tells to interpret `intro x ; apply x` as `let x := ipat:(x) in intro x ; apply x`, the same way as it was already doing for `intros` (where the dual role of `x` as a tactic language name and as constr name is made explicit). As it is, Ltac2 makes an explicit difference between the two roles so I believe that this does not apply but I may be wrong and if it can apply, I would gladly port it to Ltac2.

- [X] Added / updated test-suite (further tests could be done when #11679 will allow to pass the strict_check flag as an argument to the tactic interpreter)
- [ ] Thinking about a minimal documentation about this semantics of `ident`.