### PR TITLE
[API] make declare_variable more uniform wrt declare_axiom

### DIFF
--- a/vernac/comAssumption.mli
+++ b/vernac/comAssumption.mli
@@ -23,14 +23,18 @@ val do_assumptions
   -> (ident_decl list * constr_expr) with_coercion list
   -> unit
 
+(* variables cannot be universe polymorphic, but can mention, in the type,
+   polymorphic universes, hence the ~poly argument *)
 val declare_variable
   : coercion_flag
+  -> poly:bool
   -> kind:Decls.assumption_object_kind
   -> Constr.types
+  -> Univ.ContextSet.t
   -> Impargs.manual_implicits
   -> Glob_term.binding_kind
   -> variable CAst.t
-  -> unit
+  -> GlobRef.t * Univ.Instance.t
 
 val declare_axiom
   : coercion_flag


### PR DESCRIPTION
This commit follows 2cdccb3 by making the deprecation path
`declare_assumption -> [ declare_variable | declare_axiom ]` less error
prone. Before this commit declare_assumption had to be replaced either by
- `declare_axioms`
or
- `Declare.declare_universe_context` + `declare_variable`
which is error prone.

The current API is still unsatisfactory because one has to know if
the universes to be declared are poly or not. At least plugins just
using monomorphic universes can get things right (there is a sanity
check in kerne/section that complain if one passes the wrong poly,
not sure it is worth it).

Rationale of the patch:
I see `ComAssumption` as the entry point for assumptions related commands. It already provides a high level API (taking a constr_expr, called by vernac) and a low level one taking an constr. I'd like the low level one to be "self sufficient", eg you want to declare a variable in a plugin, you do `ComAssumption.declare_variable`. Before this commit `declare_variable` we a bit too low level IMO, since one also had to find the other function in `Declare`.