### PR TITLE
Ltac2: Add notation for enough and eenough

### DIFF
--- a/doc/changelog/05-tactic-language/11740-ltac2-enough.rst
+++ b/doc/changelog/05-tactic-language/11740-ltac2-enough.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  Ltac2 notations for enough an eenough
+  (`#11740 <https://github.com/coq/coq/pull/11740>`_,
+  by Michael Soegtrop).

--- a/test-suite/ltac2/example2.v
+++ b/test-suite/ltac2/example2.v
@@ -261,6 +261,25 @@ assert (H : 0 + 0 = 0) by reflexivity.
 intros x; exact x.
 Qed.
 
+Goal True.
+Proof.
+enough (H := 0 + 0).
+constructor.
+Qed.
+
+Goal True.
+Proof.
+enough (exists n, n = 0) as [n Hn].
++ exact I.
++ exists 0; reflexivity.
+Qed.
+
+Goal True -> True.
+Proof.
+enough (H : 0 + 0 = 0) by (intros x; exact x).
+reflexivity.
+Qed.
+
 Goal 1 + 1 = 2.
 Proof.
 change (?a + 1 = 2) with (2 = $a + 1).

--- a/user-contrib/Ltac2/Notations.v
+++ b/user-contrib/Ltac2/Notations.v
@@ -265,6 +265,19 @@ Ltac2 Notation "assert" ast(thunk(assert)) := assert0 false ast.
 
 Ltac2 Notation "eassert" ast(thunk(assert)) := assert0 true ast.
 
+Ltac2 enough_from_assertion(a : Std.assertion) :=
+  match a with
+  | Std.AssertType ip_opt term tac_opt => Std.enough term (Some tac_opt) ip_opt
+  | Std.AssertValue ident constr => Std.pose (Some ident) constr
+  end.
+
+Ltac2 enough0 ev ast :=
+  enter_h ev (fun _ ast => enough_from_assertion ast) ast.
+
+Ltac2 Notation "enough" ast(thunk(assert)) := enough0 false ast.
+
+Ltac2 Notation "eenough" ast(thunk(assert)) := enough0 true ast.
+
 Ltac2 default_everywhere cl :=
 match cl with
 | None => { Std.on_hyps := None; Std.on_concl := Std.AllOccurrences }


### PR DESCRIPTION
This PR adds notations for `enough` and `eenough`. I reused the parser for assert which extends the syntax for enough to also accept a pose via `enough (H:=witness)` but I don't see a good reason why this should be possible in assert and not in enough. `enough by` is supported in the traditional tactic language, which has similar semantics to `enough (H:=witness)` and there is also no difference between `assert by` and `enough by`.

<!-- Keep what applies -->
**Kind:** feature

<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [x] Added / updated test-suite

<!-- (Otherwise, remove these lines.) -->
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
