### PR TITLE
Register commonly used names from the Reals library for plugins (e.g. gappa)

### DIFF
--- a/doc/stdlib/index-list.html.template
+++ b/doc/stdlib/index-list.html.template
@@ -595,6 +595,7 @@ through the <tt>Require Import</tt> command.</p>
     theories/Reals/SeqSeries.v
     theories/Reals/Sqrt_reg.v
     theories/Reals/Rlogic.v
+    theories/Reals/Rregisternames.v
     (theories/Reals/Reals.v)
     theories/Reals/Runcountable.v
   </dd>

--- a/theories/Reals/Rregisternames.v
+++ b/theories/Reals/Rregisternames.v
@@ -1,0 +1,30 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *   INRIA, CNRS and contributors - Copyright 1999-2020       *)
+(* <O___,, *       (see CREDITS file for the list of authors)           *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+Require Import Reals.
+
+(*****************************************************************)
+(**           Register names for use in plugins                  *)
+(*****************************************************************)
+
+Register R as reals.R.type.
+Register R0 as reals.R.R0.
+Register R1 as reals.R.R1.
+Register Rle as reals.R.Rle.
+Register Rplus as reals.R.Rplus.
+Register Ropp as reals.R.Ropp.
+Register Rminus as reals.R.Rminus.
+Register Rmult as reals.R.Rmult.
+Register Rinv as reals.R.Rinv.
+Register Rdiv as reals.R.Rdiv.
+Register IZR as reals.R.IZR.
+Register Rabs as reals.R.Rabs.
+Register sqrt as reals.R.sqrt.
+Register powerRZ as reals.R.powerRZ.


### PR DESCRIPTION
I just realised that this change in 8.11 was not done in master as yet.

@silene has some objections against a similar change in Flocq (exporting commonly used symbols for plugins) but I would think that exporting stuff like R, 0, 1, +, -, *, / is less controversial and there is no good reason why every plugin should register these on its own.

Also from a software maintainability point of view I think it makes sense to register such interfaces so that if things change this is immediately visible and not only when dependent plugins fail in CI.

**Kind:** feature
