### PR TITLE
[micromega] Add numerical compatibility layer.

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -570,8 +570,8 @@ bin/votour.byte: $(VOTOURCMO) $(LIBCOQRUN)
 ###########################################################################
 
 CSDPCERTCMO:=clib/clib.cma $(addprefix plugins/micromega/, \
-  micromega.cmo mutils.cmo 	 \
-  sos_types.cmo sos_lib.cmo sos.cmo 	csdpcert.cmo )
+  micromega.cmo numCompat.cmo mutils.cmo \
+  sos_types.cmo sos_lib.cmo sos.cmo csdpcert.cmo )
 
 $(CSDPCERT): $(call bestobj, $(CSDPCERTCMO))
 	$(SHOW)'OCAMLBEST -o $@'

--- a/plugins/micromega/coq_micromega.ml
+++ b/plugins/micromega/coq_micromega.ml
@@ -518,7 +518,7 @@ module M = struct
     | Mc.Zneg p -> EConstr.mkApp (Lazy.force coq_NEG, [|dump_positive p|])
 
   let pp_z o x =
-    Printf.fprintf o "%s" (Big_int.string_of_big_int (CoqToCaml.z_big_int x))
+    Printf.fprintf o "%s" (NumCompat.Z.to_string (CoqToCaml.z_big_int x))
 
   let dump_q q =
     EConstr.mkApp
@@ -636,14 +636,14 @@ module M = struct
     in
     pp_pol o e
 
-  (*  let pp_clause pp_c o (f: 'cst clause) =
-    List.iter (fun ((p,_),(t,_)) -> Printf.fprintf o "(%a @%a)" (pp_pol pp_c)  p Tag.pp t) f *)
+  (* let pp_clause pp_c o (f: 'cst clause) =
+     List.iter (fun ((p,_),(t,_)) -> Printf.fprintf o "(%a @%a)" (pp_pol pp_c)  p Tag.pp t) f *)
 
   let pp_clause_tag o (f : 'cst clause) =
     List.iter (fun ((p, _), (t, _)) -> Printf.fprintf o "(_ @%a)" Tag.pp t) f
 
-  (*  let pp_cnf pp_c o (f:'cst cnf) =
-    List.iter (fun l -> Printf.fprintf o "[%a]" (pp_clause pp_c) l) f *)
+  (* let pp_cnf pp_c o (f:'cst cnf) =
+     List.iter (fun l -> Printf.fprintf o "[%a]" (pp_clause pp_c) l) f *)
 
   let pp_cnf_tag o (f : 'cst cnf) =
     List.iter (fun l -> Printf.fprintf o "[%a]" pp_clause_tag l) f
@@ -819,16 +819,16 @@ module M = struct
 
     let elements env = env.vars
 
-    (*   let string_of_env gl env =
-     let rec string_of_env i env acc =
-       match env with
-       | [] -> acc
-       | e::env -> string_of_env (i+1) env
-                     (IMap.add i
-                             (Pp.string_of_ppcmds
-                                   (Printer.pr_econstr_env gl.env gl.sigma e)) acc) in
-     string_of_env 1 env IMap.empty
- *)
+    (* let string_of_env gl env =
+       let rec string_of_env i env acc =
+         match env with
+         | [] -> acc
+         | e::env -> string_of_env (i+1) env
+                       (IMap.add i
+                               (Pp.string_of_ppcmds
+                                     (Printer.pr_econstr_env gl.env gl.sigma e)) acc) in
+       string_of_env 1 env IMap.empty
+    *)
     let pp gl env =
       let ppl =
         List.mapi
@@ -951,7 +951,7 @@ module M = struct
   (* NB: R is a different story.
      Because it is axiomatised, reducing would not be effective.
      Therefore, there is a specific parser for constant over R
-   *)
+  *)
 
   let rconst_assoc =
     [ (coq_Rplus, fun x y -> Mc.CPlus (x, y))
@@ -1613,14 +1613,14 @@ let compact_proofs (cnf_ff : 'cst cnf) res (cnf_ff' : 'cst cnf) =
       in
       List.assoc formula new_cl
     in
-    (*    if debug then
-      begin
-        Printf.printf "\ncompact_proof : %a %a %a"
-          (pp_ml_list prover.pp_f) (List.map fst old_cl)
-          prover.pp_prf prf
-          (pp_ml_list prover.pp_f) (List.map fst new_cl)   ;
-          flush stdout
-      end ; *)
+    (* if debug then
+       begin
+         Printf.printf "\ncompact_proof : %a %a %a"
+           (pp_ml_list prover.pp_f) (List.map fst old_cl)
+           prover.pp_prf prf
+           (pp_ml_list prover.pp_f) (List.map fst new_cl)   ;
+           flush stdout
+       end ; *)
     let res =
       try prover.compact prf remap
       with x when CErrors.noncritical x -> (
@@ -1790,14 +1790,14 @@ let micromega_tauto pre_process cnf spec prover env
       flush stdout
     end;
     (* Even if it does not work, this does not mean it is not provable
-  -- the prover is REALLY incomplete *)
+       -- the prover is REALLY incomplete *)
     (* if debug then
-      begin
-        (* recompute the proofs *)
-        match witness_list_tags prover  cnf_ff' with
-          | None -> failwith "abstraction is wrong"
-          | Some res -> ()
-      end ; *)
+       begin
+         (* recompute the proofs *)
+         match witness_list_tags prover  cnf_ff' with
+           | None -> failwith "abstraction is wrong"
+           | Some res -> ()
+       end ; *)
     let res' = compact_proofs cnf_ff res cnf_ff' in
     let ff', res', ids = (ff', res', Mc.ids_of_formula ff') in
     let res' = dump_list spec.proof_typ spec.dump_proof res' in
@@ -2009,7 +2009,7 @@ let micromega_genr prover tac =
           let goal_vars = List.map (fun (_, i) -> List.nth env (i - 1)) vars in
           let arith_args = goal_props @ goal_vars in
           let kill_arith = Tacticals.New.tclTHEN tac_arith tac in
-          (*  Tacticals.New.tclTHEN
+          (* Tacticals.New.tclTHEN
              (Tactics.keep [])
              (Tactics.tclABSTRACT  None*)
           Tacticals.New.tclTHENS

--- a/plugins/micromega/csdpcert.ml
+++ b/plugins/micromega/csdpcert.ml
@@ -14,7 +14,7 @@
 (*                                                                      *)
 (************************************************************************)
 
-open Num
+open NumCompat
 open Sos
 open Sos_types
 open Sos_lib
@@ -96,7 +96,7 @@ let real_nonlinear_prover d l =
                 | Axiom_lt i -> poly_mul p y
                 | Axiom_eq i -> poly_mul (poly_pow p 2) y
                 | _ -> failwith "monoids")
-              m (poly_const (Int 1))
+              m (poly_const Q.one)
           , List.map snd m ))
         (sets_of_list neq)
     in
@@ -127,7 +127,7 @@ let real_nonlinear_prover d l =
         match
           List.map (function Axiom_eq i -> i | _ -> failwith "error") neq
         with
-        | [] -> Rational_lt (Int 1)
+        | [] -> Rational_lt Q.one
         | l -> Monoid l
       in
       List.fold_right (fun x y -> Product (x, y)) lt sq
@@ -146,7 +146,7 @@ let real_nonlinear_prover d l =
 let pure_sos l =
   let l = List.map (fun (e, o) -> (Mc.denorm e, o)) l in
   (* If there is no strict inequality,
-    I should nonetheless be able to try something - over Z  > is equivalent to -1  >= *)
+     I should nonetheless be able to try something - over Z  > is equivalent to -1  >= *)
   try
     let l = List.combine l (CList.interval 0 (List.length l - 1)) in
     let lt, i =
@@ -162,11 +162,11 @@ let pure_sos l =
         , List.fold_right
             (fun (c, p) rst ->
               Sum (Product (Rational_lt c, Square (term_of_poly p)), rst))
-            polys (Rational_lt (Int 0)) )
+            polys (Rational_lt Q.zero) )
     in
     let proof = Sum (Axiom_lt i, pos) in
-    (*  let s,proof' = scale_certificate proof in
-  let cert  = snd (cert_of_pos proof') in *)
+    (* let s,proof' = scale_certificate proof in
+       let cert  = snd (cert_of_pos proof') in *)
     S (Some proof)
   with (*   | Sos.CsdpNotFound -> F "Sos.CsdpNotFound" *)
   | any ->
@@ -184,8 +184,8 @@ let main () =
   try
     let (prover, poly) = (input_value stdin : provername * micromega_polys) in
     let cert = run_prover prover poly in
-    (*      Printf.fprintf chan "%a -> %a" print_list_term poly output_csdp_certificate cert ;
-      close_out chan ;   *)
+    (* Printf.fprintf chan "%a -> %a" print_list_term poly output_csdp_certificate cert ;
+       close_out chan ; *)
     output_value stdout (cert : csdp_certificate);
     flush stdout;
     Marshal.to_channel chan (cert : csdp_certificate) [];

--- a/plugins/micromega/itv.ml
+++ b/plugins/micromega/itv.ml
@@ -8,12 +8,13 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
+open NumCompat
+open Q.Notations
+
 (** Intervals (extracted from mfourier.ml) *)
 
-open Num
-
 (** The type of intervals is *)
-type interval = num option * num option
+type interval = Q.t option * Q.t option
 (** None models the absence of bound i.e. infinity
           As a result,
           - None , None   -> \]-oo,+oo\[
@@ -26,11 +27,11 @@ type interval = num option * num option
 let pp o (n1, n2) =
   ( match n1 with
   | None -> output_string o "]-oo"
-  | Some n -> Printf.fprintf o "[%s" (string_of_num n) );
+  | Some n -> Printf.fprintf o "[%s" (Q.to_string n) );
   output_string o ",";
   match n2 with
   | None -> output_string o "+oo["
-  | Some n -> Printf.fprintf o "%s]" (string_of_num n)
+  | Some n -> Printf.fprintf o "%s]" (Q.to_string n)
 
 (** if then interval [itv] is empty, [norm_itv itv] returns [None]
       otherwise, it returns [Some itv] *)
@@ -51,11 +52,11 @@ let inter i1 i2 =
     | None, Some _ -> o2
     | Some n1, Some n2 -> Some (f n1 n2)
   in
-  norm_itv (inter max_num l1 l2, inter min_num r1 r2)
+  norm_itv (inter Q.max l1 l2, inter Q.min r1 r2)
 
 let range = function
   | None, _ | _, None -> None
-  | Some i, Some j -> Some (floor_num j -/ ceiling_num i +/ Int 1)
+  | Some i, Some j -> Some (Q.floor j -/ Q.ceiling i +/ Q.one)
 
 let smaller_itv i1 i2 =
   match (range i1, range i2) with

--- a/plugins/micromega/itv.mli
+++ b/plugins/micromega/itv.mli
@@ -7,13 +7,13 @@
 (*         *     GNU Lesser General Public License Version 2.1          *)
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
-open Num
+open NumCompat
 
-type interval = num option * num option
+type interval = Q.t option * Q.t option
 
 val pp : out_channel -> interval -> unit
 val inter : interval -> interval -> interval option
-val range : interval -> num option
+val range : interval -> Q.t option
 val smaller_itv : interval -> interval -> bool
-val in_bound : interval -> num -> bool
+val in_bound : interval -> Q.t -> bool
 val norm_itv : interval -> interval option

--- a/plugins/micromega/micromega_plugin.mlpack
+++ b/plugins/micromega/micromega_plugin.mlpack
@@ -1,4 +1,5 @@
 Micromega
+NumCompat
 Mutils
 Itv
 Vect

--- a/plugins/micromega/mutils.mli
+++ b/plugins/micromega/mutils.mli
@@ -8,6 +8,8 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
+open NumCompat
+
 module Int : sig
   type t = int
 
@@ -27,9 +29,6 @@ module IMap : sig
   val from : key -> 'elt t -> 'elt t
   (** [from k  m] returns the submap of [m] with keys greater or equal k *)
 end
-
-val numerator : Num.num -> Big_int.big_int
-val denominator : Num.num -> Big_int.big_int
 
 module Cmp : sig
   val compare_list : ('a -> 'b -> int) -> 'a list -> 'b list -> int
@@ -53,19 +52,19 @@ val pp_list :
 
 module CamlToCoq : sig
   val positive : int -> Micromega.positive
-  val bigint : Big_int.big_int -> Micromega.z
+  val bigint : Z.t -> Micromega.z
   val n : int -> Micromega.n
   val nat : int -> Micromega.nat
-  val q : Num.num -> Micromega.q
+  val q : Q.t -> Micromega.q
   val index : int -> Micromega.positive
   val z : int -> Micromega.z
-  val positive_big_int : Big_int.big_int -> Micromega.positive
+  val positive_big_int : Z.t -> Micromega.positive
 end
 
 module CoqToCaml : sig
-  val z_big_int : Micromega.z -> Big_int.big_int
+  val z_big_int : Micromega.z -> Z.t
   val z : Micromega.z -> int
-  val q_to_num : Micromega.q -> Num.num
+  val q_to_num : Micromega.q -> Q.t
   val positive : Micromega.positive -> int
   val n : Micromega.n -> int
   val nat : Micromega.nat -> int
@@ -96,7 +95,6 @@ module Hash : sig
   val hash_elt : ('a -> int) -> int -> 'a -> int
 end
 
-val ppcm : Big_int.big_int -> Big_int.big_int -> Big_int.big_int
 val all_pairs : ('a -> 'a -> 'b) -> 'a list -> 'b list
 val try_any : (('a -> 'b option) * 'c) list -> 'a -> 'b option
 val is_sublist : ('a -> 'b -> bool) -> 'a list -> 'b list -> bool

--- a/plugins/micromega/numCompat.ml
+++ b/plugins/micromega/numCompat.ml
@@ -1,0 +1,174 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *   INRIA, CNRS and contributors - Copyright 1999-2019       *)
+(* <O___,, *       (see CREDITS file for the list of authors)           *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+module type ZArith = sig
+  type t
+
+  val zero : t
+  val one : t
+  val two : t
+  val add : t -> t -> t
+  val sub : t -> t -> t
+  val mul : t -> t -> t
+  val div : t -> t -> t
+  val neg : t -> t
+  val sign : t -> int
+  val equal : t -> t -> bool
+  val compare : t -> t -> int
+  val power_int : t -> int -> t
+  val quomod : t -> t -> t * t
+  val ppcm : t -> t -> t
+  val gcd : t -> t -> t
+  val lcm : t -> t -> t
+  val to_string : t -> string
+end
+
+module Z = struct
+  type t = Big_int.big_int
+
+  open Big_int
+
+  let zero = zero_big_int
+  let one = unit_big_int
+  let two = big_int_of_int 2
+  let add = Big_int.add_big_int
+  let sub = Big_int.sub_big_int
+  let mul = Big_int.mult_big_int
+  let div = Big_int.div_big_int
+  let neg = Big_int.minus_big_int
+  let sign = Big_int.sign_big_int
+  let equal = eq_big_int
+  let compare = compare_big_int
+  let power_int = power_big_int_positive_int
+  let quomod = quomod_big_int
+
+  let ppcm x y =
+    let g = gcd_big_int x y in
+    let x' = div_big_int x g in
+    let y' = div_big_int y g in
+    mult_big_int g (mult_big_int x' y')
+
+  let gcd = gcd_big_int
+
+  let lcm x y =
+    if eq_big_int x zero && eq_big_int y zero then zero
+    else abs_big_int (div_big_int (mult_big_int x y) (gcd x y))
+
+  let to_string = string_of_big_int
+end
+
+module type QArith = sig
+  module Z : ZArith
+
+  type t
+
+  val of_int : int -> t
+  val zero : t
+  val one : t
+  val two : t
+  val ten : t
+  val neg_one : t
+
+  module Notations : sig
+    val ( // ) : t -> t -> t
+    val ( +/ ) : t -> t -> t
+    val ( -/ ) : t -> t -> t
+    val ( */ ) : t -> t -> t
+    val ( =/ ) : t -> t -> bool
+    val ( <>/ ) : t -> t -> bool
+    val ( >/ ) : t -> t -> bool
+    val ( >=/ ) : t -> t -> bool
+    val ( </ ) : t -> t -> bool
+    val ( <=/ ) : t -> t -> bool
+  end
+
+  val compare : t -> t -> int
+  val make : Z.t -> Z.t -> t
+  val den : t -> Z.t
+  val num : t -> Z.t
+  val of_bigint : Z.t -> t
+  val to_bigint : t -> Z.t
+  val neg : t -> t
+
+  (* val inv : t -> t *)
+  val max : t -> t -> t
+  val min : t -> t -> t
+  val sign : t -> int
+  val abs : t -> t
+  val mod_ : t -> t -> t
+  val floor : t -> t
+
+  (* val floorZ : t -> Z.t *)
+  val ceiling : t -> t
+  val round : t -> t
+  val pow2 : int -> t
+  val pow10 : int -> t
+  val power : int -> t -> t
+  val to_string : t -> string
+  val of_string : string -> t
+  val to_float : t -> float
+end
+
+module Q : QArith with module Z = Z = struct
+  module Z = Z
+
+  type t = Num.num
+
+  open Num
+
+  let of_int x = Int x
+  let zero = Int 0
+  let one = Int 1
+  let two = Int 2
+  let ten = Int 10
+  let neg_one = Int (-1)
+
+  module Notations = struct
+    let ( // ) = div_num
+    let ( +/ ) = add_num
+    let ( -/ ) = sub_num
+    let ( */ ) = mult_num
+    let ( =/ ) = eq_num
+    let ( <>/ ) = ( <>/ )
+    let ( >/ ) = ( >/ )
+    let ( >=/ ) = ( >=/ )
+    let ( </ ) = ( </ )
+    let ( <=/ ) = ( <=/ )
+  end
+
+  let compare = compare_num
+  let make x y = Big_int x // Big_int y
+
+  let numdom r =
+    let r' = Ratio.normalize_ratio (ratio_of_num r) in
+    (Ratio.numerator_ratio r', Ratio.denominator_ratio r')
+
+  let num x = numdom x |> fst
+  let den x = numdom x |> snd
+  let of_bigint x = Big_int x
+  let to_bigint = big_int_of_num
+  let neg = minus_num
+
+  (* let inv =  *)
+  let max = max_num
+  let min = min_num
+  let sign = sign_num
+  let abs = abs_num
+  let mod_ = mod_num
+  let floor = floor_num
+  let ceiling = ceiling_num
+  let round = round_num
+  let pow2 n = power_num two (Int n)
+  let pow10 n = power_num ten (Int n)
+  let power x = power_num (Int x)
+  let to_string = string_of_num
+  let of_string = num_of_string
+  let to_float = float_of_num
+end

--- a/plugins/micromega/numCompat.mli
+++ b/plugins/micromega/numCompat.mli
@@ -1,0 +1,85 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *   INRIA, CNRS and contributors - Copyright 1999-2019       *)
+(* <O___,, *       (see CREDITS file for the list of authors)           *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+module type ZArith = sig
+  type t
+
+  val zero : t
+  val one : t
+  val two : t
+  val add : t -> t -> t
+  val sub : t -> t -> t
+  val mul : t -> t -> t
+  val div : t -> t -> t
+  val neg : t -> t
+  val sign : t -> int
+  val equal : t -> t -> bool
+  val compare : t -> t -> int
+  val power_int : t -> int -> t
+  val quomod : t -> t -> t * t
+  val ppcm : t -> t -> t
+  val gcd : t -> t -> t
+  val lcm : t -> t -> t
+  val to_string : t -> string
+end
+
+module type QArith = sig
+  module Z : ZArith
+
+  type t
+
+  val of_int : int -> t
+  val zero : t
+  val one : t
+  val two : t
+  val ten : t
+  val neg_one : t
+
+  module Notations : sig
+    val ( // ) : t -> t -> t
+    val ( +/ ) : t -> t -> t
+    val ( -/ ) : t -> t -> t
+    val ( */ ) : t -> t -> t
+    val ( =/ ) : t -> t -> bool
+    val ( <>/ ) : t -> t -> bool
+    val ( >/ ) : t -> t -> bool
+    val ( >=/ ) : t -> t -> bool
+    val ( </ ) : t -> t -> bool
+    val ( <=/ ) : t -> t -> bool
+  end
+
+  val compare : t -> t -> int
+  val make : Z.t -> Z.t -> t
+  val den : t -> Z.t
+  val num : t -> Z.t
+  val of_bigint : Z.t -> t
+  val to_bigint : t -> Z.t
+  val neg : t -> t
+
+  (* val inv : t -> t *)
+
+  val max : t -> t -> t
+  val min : t -> t -> t
+  val sign : t -> int
+  val abs : t -> t
+  val mod_ : t -> t -> t
+  val floor : t -> t
+  val ceiling : t -> t
+  val round : t -> t
+  val pow2 : int -> t
+  val pow10 : int -> t
+  val power : int -> t -> t
+  val to_string : t -> string
+  val of_string : string -> t
+  val to_float : t -> float
+end
+
+module Z : ZArith
+module Q : QArith with module Z = Z

--- a/plugins/micromega/persistent_cache.ml
+++ b/plugins/micromega/persistent_cache.ml
@@ -82,9 +82,9 @@ module PHashtable (Key : HashedType) : PHashtable with type key = Key.t = struct
     with Unix.Unix_error (_, _, _) ->
       ()
       (* Here, this is really bad news --
-       there is a pending lock which could cause a deadlock.
-       Should it be an anomaly or produce a warning ?
-    *);
+         there is a pending lock which could cause a deadlock.
+         Should it be an anomaly or produce a warning ?
+      *);
       ignore (lseek fd pos SEEK_SET)
 
   (* We make the assumption that an acquired lock can always be released *)

--- a/plugins/micromega/polynomial.mli
+++ b/plugins/micromega/polynomial.mli
@@ -9,6 +9,7 @@
 (************************************************************************)
 
 open Mutils
+open NumCompat
 module Mc = Micromega
 
 val max_nb_cstr : int ref
@@ -81,7 +82,7 @@ module Poly : sig
 
   type t
 
-  val constant : Num.num -> t
+  val constant : Q.t -> t
   (** [constant c]
       @return the constant polynomial c *)
 
@@ -101,24 +102,24 @@ module Poly : sig
   (** [uminus p]
       @return the polynomial -p i.e product by -1 *)
 
-  val get : Monomial.t -> t -> Num.num
+  val get : Monomial.t -> t -> Q.t
   (** [get mi p]
       @return the coefficient ai of the  monomial mi. *)
 
-  val fold : (Monomial.t -> Num.num -> 'a -> 'a) -> t -> 'a -> 'a
+  val fold : (Monomial.t -> Q.t -> 'a -> 'a) -> t -> 'a -> 'a
   (** [fold f p a] folds f over the monomials of p with non-zero coefficient *)
 
-  val add : Monomial.t -> Num.num -> t -> t
+  val add : Monomial.t -> Q.t -> t -> t
   (** [add m n p]
       @return the polynomial n*m + p *)
 end
 
-type cstr = {coeffs : Vect.t; op : op; cst : Num.num}
+type cstr = {coeffs : Vect.t; op : op; cst : Q.t}
 
 (* Representation of linear constraints *)
 and op = Eq | Ge | Gt
 
-val eval_op : op -> Num.num -> Num.num -> bool
+val eval_op : op -> Q.t -> Q.t -> bool
 
 (*val opMult : op -> op -> op*)
 
@@ -172,7 +173,7 @@ module LinPoly : sig
       @return 1.y where y is the variable index of the monomial x^1.
    *)
 
-  val coq_poly_of_linpol : (Num.num -> 'a) -> t -> 'a Mc.pExpr
+  val coq_poly_of_linpol : (Q.t -> 'a) -> t -> 'a Mc.pExpr
   (** [coq_poly_of_linpol c p]
       @param p is a multi-variate polynomial.
       @param c maps a rational to a Coq polynomial coefficient.
@@ -206,7 +207,7 @@ module LinPoly : sig
       @return true if the polynomial is linear in x
       i.e can be written c*x+r where c is a constant and r is independent from x *)
 
-  val constant : Num.num -> t
+  val constant : Q.t -> t
   (** [constant c]
       @return the constant polynomial c
    *)
@@ -216,9 +217,9 @@ module LinPoly : sig
       p is linear in x i.e x does not occur in b and
       a is a constant such that [pred a] *)
 
-  val search_linear : (Num.num -> bool) -> t -> var option
+  val search_linear : (Q.t -> bool) -> t -> var option
 
-  val search_all_linear : (Num.num -> bool) -> t -> var list
+  val search_all_linear : (Q.t -> bool) -> t -> var list
   (** [search_all_linear pred p]
       @return all the variables x such p = a.x + b such that
       p is linear in x i.e x does not occur in b and
@@ -270,11 +271,11 @@ module ProofFormat : sig
     | Annot of string * prf_rule
     | Hyp of int
     | Def of int
-    | Cst of Num.num
+    | Cst of Q.t
     | Zero
     | Square of Vect.t
     | MulC of Vect.t * prf_rule
-    | Gcd of Big_int.big_int * prf_rule
+    | Gcd of Z.t * prf_rule
     | MulPrf of prf_rule * prf_rule
     | AddPrf of prf_rule * prf_rule
     | CutPrf of prf_rule
@@ -287,20 +288,20 @@ module ProofFormat : sig
 
   (* x = z - t, z >= 0, t >= 0 *)
 
-  val pr_size : prf_rule -> Num.num
+  val pr_size : prf_rule -> Q.t
   val pr_rule_max_id : prf_rule -> int
   val proof_max_id : proof -> int
   val normalise_proof : int -> proof -> int * proof
   val output_prf_rule : out_channel -> prf_rule -> unit
   val output_proof : out_channel -> proof -> unit
   val add_proof : prf_rule -> prf_rule -> prf_rule
-  val mul_cst_proof : Num.num -> prf_rule -> prf_rule
+  val mul_cst_proof : Q.t -> prf_rule -> prf_rule
   val mul_proof : prf_rule -> prf_rule -> prf_rule
   val compile_proof : int list -> proof -> Micromega.zArithProof
 
   val cmpl_prf_rule :
        ('a Micromega.pExpr -> 'a Micromega.pol)
-    -> (Num.num -> 'a)
+    -> (Q.t -> 'a)
     -> int list
     -> prf_rule
     -> 'a Micromega.psatz
@@ -332,7 +333,7 @@ module WithProof : sig
   val zero : t
   (** [zero] represents the tautology (0=0) *)
 
-  val const : Num.num -> t
+  val const : Q.t -> t
   (** [const n] represents the tautology (n>=0) *)
 
   val product : t -> t -> t

--- a/plugins/micromega/simplex.mli
+++ b/plugins/micromega/simplex.mli
@@ -7,6 +7,8 @@
 (*         *     GNU Lesser General Public License Version 2.1          *)
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
+
+open NumCompat
 open Polynomial
 
 (** Profiling *)
@@ -23,7 +25,7 @@ val get_profile_info : unit -> profile_info
 
 (** Simplex interface *)
 
-val optimise : Vect.t -> cstr list -> (Num.num option * Num.num option) option
+val optimise : Vect.t -> cstr list -> (Q.t option * Q.t option) option
 val find_point : cstr list -> Vect.t option
 val find_unsat_certificate : cstr list -> Vect.t option
 

--- a/plugins/micromega/sos.mli
+++ b/plugins/micromega/sos.mli
@@ -8,6 +8,7 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
+open NumCompat
 open Sos_types
 
 type poly
@@ -16,13 +17,10 @@ val poly_isconst : poly -> bool
 val poly_neg : poly -> poly
 val poly_mul : poly -> poly -> poly
 val poly_pow : poly -> int -> poly
-val poly_const : Num.num -> poly
+val poly_const : Q.t -> poly
 val poly_of_term : term -> poly
 val term_of_poly : poly -> term
-
-val term_of_sos :
-  positivstellensatz * (Num.num * poly) list -> positivstellensatz
-
+val term_of_sos : positivstellensatz * (Q.t * poly) list -> positivstellensatz
 val string_of_poly : poly -> string
 
 val real_positivnullstellensatz_general :
@@ -31,6 +29,6 @@ val real_positivnullstellensatz_general :
   -> poly list
   -> (poly * positivstellensatz) list
   -> poly
-  -> poly list * (positivstellensatz * (Num.num * poly) list) list
+  -> poly list * (positivstellensatz * (Q.t * poly) list) list
 
-val sumofsquares : poly -> Num.num * (Num.num * poly) list
+val sumofsquares : poly -> Q.t * (Q.t * poly) list

--- a/plugins/micromega/sos_lib.ml
+++ b/plugins/micromega/sos_lib.ml
@@ -7,8 +7,6 @@
 (* - Frédéric Besson (fbesson@irisa.fr) is using it to feed  micromega       *)
 (* ========================================================================= *)
 
-open Num
-
 (* ------------------------------------------------------------------------- *)
 (* Comparisons that are reflexive on NaN and also short-circuiting.          *)
 (* ------------------------------------------------------------------------- *)
@@ -26,32 +24,6 @@ let ( >? ) x y = cmp x y > 0
 (* ------------------------------------------------------------------------- *)
 
 let o f g x = f (g x)
-
-(* ------------------------------------------------------------------------- *)
-(* Some useful functions on "num" type.                                      *)
-(* ------------------------------------------------------------------------- *)
-
-let num_0 = Int 0
-and num_1 = Int 1
-and num_2 = Int 2
-and num_10 = Int 10
-
-let pow2 n = power_num num_2 (Int n)
-let pow10 n = power_num num_10 (Int n)
-
-let numdom r =
-  let r' = Ratio.normalize_ratio (ratio_of_num r) in
-  ( num_of_big_int (Ratio.numerator_ratio r')
-  , num_of_big_int (Ratio.denominator_ratio r') )
-
-let numerator = o fst numdom
-and denominator = o snd numdom
-
-let gcd_num n1 n2 =
-  num_of_big_int (Big_int.gcd_big_int (big_int_of_num n1) (big_int_of_num n2))
-
-let lcm_num x y =
-  if x =/ num_0 && y =/ num_0 then num_0 else abs_num (x */ y // gcd_num x y)
 
 (* ------------------------------------------------------------------------- *)
 (* Various versions of list iteration.                                       *)
@@ -518,8 +490,8 @@ let deepen_until limit f n =
     let rec d_until f n =
       try
         (* if !debugging
-          then (print_string "Searching with depth limit ";
-                print_int n; print_newline()) ;*)
+           then (print_string "Searching with depth limit ";
+                 print_int n; print_newline()) ;*)
         f n
       with Failure x ->
         (*if !debugging then (Printf.printf "solver error : %s\n" x) ; *)

--- a/plugins/micromega/sos_lib.mli
+++ b/plugins/micromega/sos_lib.mli
@@ -9,9 +9,6 @@
 (************************************************************************)
 
 val o : ('a -> 'b) -> ('c -> 'a) -> 'c -> 'b
-val num_1 : Num.num
-val pow10 : int -> Num.num
-val pow2 : int -> Num.num
 val implode : string list -> string
 val explode : string -> string list
 val funpow : int -> ('a -> 'a) -> 'a -> 'a
@@ -50,10 +47,6 @@ val sort : ('a -> 'a -> bool) -> 'a list -> 'a list
 val setify : 'a list -> 'a list
 val increasing : ('a -> 'b) -> 'a -> 'a -> bool
 val allpairs : ('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
-val gcd_num : Num.num -> Num.num -> Num.num
-val lcm_num : Num.num -> Num.num -> Num.num
-val numerator : Num.num -> Num.num
-val denominator : Num.num -> Num.num
 val end_itlist : ('a -> 'a -> 'a) -> 'a list -> 'a
 val ( >> ) : ('a -> 'b * 'c) -> ('b -> 'd) -> 'a -> 'd * 'c
 val ( ++ ) : ('a -> 'b * 'c) -> ('c -> 'd * 'e) -> 'a -> ('b * 'd) * 'e

--- a/plugins/micromega/sos_types.ml
+++ b/plugins/micromega/sos_types.ml
@@ -9,13 +9,13 @@
 (************************************************************************)
 
 (* The type of positivstellensatz -- used to communicate with sos *)
-open Num
-
 type vname = string
+
+open NumCompat
 
 type term =
   | Zero
-  | Const of Num.num
+  | Const of Q.t
   | Var of vname
   | Opp of term
   | Add of (term * term)
@@ -26,7 +26,7 @@ type term =
 let rec output_term o t =
   match t with
   | Zero -> output_string o "0"
-  | Const n -> output_string o (string_of_num n)
+  | Const n -> output_string o (Q.to_string n)
   | Var n -> Printf.fprintf o "v%s" n
   | Opp t -> Printf.fprintf o "- (%a)" output_term t
   | Add (t1, t2) -> Printf.fprintf o "(%a)+(%a)" output_term t1 output_term t2
@@ -42,9 +42,9 @@ type positivstellensatz =
   | Axiom_eq of int
   | Axiom_le of int
   | Axiom_lt of int
-  | Rational_eq of num
-  | Rational_le of num
-  | Rational_lt of num
+  | Rational_eq of Q.t
+  | Rational_le of Q.t
+  | Rational_lt of Q.t
   | Square of term
   | Monoid of int list
   | Eqmul of term * positivstellensatz
@@ -55,9 +55,9 @@ let rec output_psatz o = function
   | Axiom_eq i -> Printf.fprintf o "Aeq(%i)" i
   | Axiom_le i -> Printf.fprintf o "Ale(%i)" i
   | Axiom_lt i -> Printf.fprintf o "Alt(%i)" i
-  | Rational_eq n -> Printf.fprintf o "eq(%s)" (string_of_num n)
-  | Rational_le n -> Printf.fprintf o "le(%s)" (string_of_num n)
-  | Rational_lt n -> Printf.fprintf o "lt(%s)" (string_of_num n)
+  | Rational_eq n -> Printf.fprintf o "eq(%s)" (Q.to_string n)
+  | Rational_le n -> Printf.fprintf o "le(%s)" (Q.to_string n)
+  | Rational_lt n -> Printf.fprintf o "lt(%s)" (Q.to_string n)
   | Square t -> Printf.fprintf o "(%a)^2" output_term t
   | Monoid l -> Printf.fprintf o "monoid"
   | Eqmul (t, ps) -> Printf.fprintf o "%a * %a" output_term t output_psatz ps

--- a/plugins/micromega/sos_types.mli
+++ b/plugins/micromega/sos_types.mli
@@ -8,13 +8,15 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
+open NumCompat
+
 (* The type of positivstellensatz -- used to communicate with sos *)
 
 type vname = string
 
 type term =
   | Zero
-  | Const of Num.num
+  | Const of Q.t
   | Var of vname
   | Opp of term
   | Add of (term * term)
@@ -28,9 +30,9 @@ type positivstellensatz =
   | Axiom_eq of int
   | Axiom_le of int
   | Axiom_lt of int
-  | Rational_eq of Num.num
-  | Rational_le of Num.num
-  | Rational_lt of Num.num
+  | Rational_eq of Q.t
+  | Rational_le of Q.t
+  | Rational_lt of Q.t
   | Square of term
   | Monoid of int list
   | Eqmul of term * positivstellensatz

--- a/plugins/micromega/vect.mli
+++ b/plugins/micromega/vect.mli
@@ -8,7 +8,7 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-open Num
+open NumCompat
 open Mutils
 
 type var = int
@@ -50,18 +50,18 @@ val pp_smt : out_channel -> t -> unit
 val variables : t -> ISet.t
 (** [variables v] returns the set of variables with non-zero coefficients *)
 
-val get_cst : t -> num
+val get_cst : t -> Q.t
 (** [get_cst v] returns c i.e. the coefficient of the variable zero *)
 
-val decomp_cst : t -> num * t
+val decomp_cst : t -> Q.t * t
 (** [decomp_cst v] returns the pair (c,a1.x1+...+an.xn) *)
 
-val decomp_at : int -> t -> num * t
+val decomp_at : int -> t -> Q.t * t
 (** [decomp_cst v] returns the pair (ai, ai+1.xi+...+an.xn) *)
 
-val decomp_fst : t -> (var * num) * t
+val decomp_fst : t -> (var * Q.t) * t
 
-val cst : num -> t
+val cst : Q.t -> t
 (** [cst c] returns the vector v=c+0.x1+...+0.xn *)
 
 val is_constant : t -> bool
@@ -74,33 +74,33 @@ val null : t
 val is_null : t -> bool
 (** [is_null v] returns whether [v] is the [null] vector i.e [equal v  null] *)
 
-val get : var -> t -> num
+val get : var -> t -> Q.t
 (** [get xi v] returns the coefficient ai of the variable [xi].
     [get] is also defined for the variable 0 *)
 
-val set : var -> num -> t -> t
+val set : var -> Q.t -> t -> t
 (** [set xi ai' v] returns the vector c+a1.x1+...ai'.xi+...+an.xn
     i.e. the coefficient of the variable xi is set to ai' *)
 
 val mkvar : var -> t
 (** [mkvar xi] returns 1.xi *)
 
-val update : var -> (num -> num) -> t -> t
+val update : var -> (Q.t -> Q.t) -> t -> t
 (** [update xi f v] returns c+a1.x1+...+f(ai).xi+...+an.xn *)
 
 val fresh : t -> int
 (** [fresh v] return the fresh variable with index 1+ max (variables v) *)
 
-val choose : t -> (var * num * t) option
+val choose : t -> (var * Q.t * t) option
 (** [choose v] decomposes a vector [v] depending on whether it is [null] or not.
     @return None if v is [null]
     @return Some(x,n,r) where v = r + n.x  x is the smallest variable with non-zero coefficient n <> 0.
  *)
 
-val from_list : num list -> t
+val from_list : Q.t list -> t
 (** [from_list l] returns the vector c+a1.x1...an.xn from the list of coefficient [l=c;a1;...;an] *)
 
-val to_list : t -> num list
+val to_list : t -> Q.t list
 (** [to_list v] returns the list of all coefficient of the vector v i.e. [c;a1;...;an]
     The list representation is (obviously) not sparsed
     and therefore certain ai may be 0 *)
@@ -114,7 +114,7 @@ val incr_var : int -> t -> t
 (** [incr_var i v] increments the variables of the vector [v] by the amount [i].
  *)
 
-val gcd : t -> Big_int.big_int
+val gcd : t -> Z.t
 (** [gcd v] returns gcd(num(c),num(a1),...,num(an)) where num extracts
    the numerator of a rational value. *)
 
@@ -130,17 +130,17 @@ val add : t -> t -> t
     @return c1+c1'+ (a1+a1').x1 + ... + (an+an').xn
  *)
 
-val mul : num -> t -> t
+val mul : Q.t -> t -> t
 (** [mul a v] is vector multiplication of vector [v] by a scalar [a].
     @return a.v = a.c+a.a1.x1+...+a.an.xn *)
 
-val mul_add : num -> t -> num -> t -> t
+val mul_add : Q.t -> t -> Q.t -> t -> t
 (** [mul_add c1 v1 c2 v2] returns the linear combination c1.v1+c2.v2 *)
 
 val subst : int -> t -> t -> t
 (** [subst x v v'] replaces x by v in vector v' *)
 
-val div : num -> t -> t
+val div : Q.t -> t -> t
 (** [div c1 v1] returns the mutiplication by the inverse of c1 i.e (1/c1).v1 *)
 
 val uminus : t -> t
@@ -148,36 +148,36 @@ val uminus : t -> t
 
 (** {1 Iterators} *)
 
-val fold : ('acc -> var -> num -> 'acc) -> 'acc -> t -> 'acc
+val fold : ('acc -> var -> Q.t -> 'acc) -> 'acc -> t -> 'acc
 (** [fold f acc v] returns f (f (f acc 0 c ) x1 a1 ) ... xn an *)
 
-val fold_error : ('acc -> var -> num -> 'acc option) -> 'acc -> t -> 'acc option
+val fold_error : ('acc -> var -> Q.t -> 'acc option) -> 'acc -> t -> 'acc option
 (** [fold_error f acc v] is the same as
     [fold (fun acc x i -> match acc with None -> None | Some acc' -> f acc' x i) (Some acc) v]
     but with early exit...
  *)
 
-val find : (var -> num -> 'c option) -> t -> 'c option
+val find : (var -> Q.t -> 'c option) -> t -> 'c option
 (** [find f v] returns the first [f xi ai] such that [f xi ai <> None].
     If no such xi ai exists, it returns None *)
 
-val for_all : (var -> num -> bool) -> t -> bool
+val for_all : (var -> Q.t -> bool) -> t -> bool
 (** [for_all p v] returns /\_{i>=0} (f xi ai) *)
 
-val exists2 : (num -> num -> bool) -> t -> t -> (var * num * num) option
+val exists2 : (Q.t -> Q.t -> bool) -> t -> t -> (var * Q.t * Q.t) option
 (** [exists2 p v v'] returns Some(xi,ai,ai')
     if p(xi,ai,ai') holds and ai,ai' <> 0.
     It returns None if no such pair of coefficient exists. *)
 
-val dotproduct : t -> t -> num
+val dotproduct : t -> t -> Q.t
 (** [dotproduct v1 v2] is the dot product of v1 and v2. *)
 
-val map : (var -> num -> 'a) -> t -> 'a list
-val abs_min_elt : t -> (var * num) option
-val partition : (var -> num -> bool) -> t -> t * t
+val map : (var -> Q.t -> 'a) -> t -> 'a list
+val abs_min_elt : t -> (var * Q.t) option
+val partition : (var -> Q.t -> bool) -> t -> t * t
 
 module Bound : sig
-  type t = {cst : num; var : var; coeff : num}
+  type t = {cst : Q.t; var : var; coeff : Q.t}
   (** represents a0 + ai.xi  *)
 
   val of_vect : vector -> t option

--- a/plugins/micromega/zify.ml
+++ b/plugins/micromega/zify.ml
@@ -147,7 +147,7 @@ type classify_op =
   | OpConv (* e.g. Pos.ge     == \x.y. Z.ge (Z.pos x) (Z.pos y)
                      \x.y. Z.pos (Pos.add x y) == \x.y. Z.add (Z.pos x) (Z.pos y)
                      Z.succ              == (\x.x + 1)
-                   *)
+           *)
   | OpOther
 
 (*let pp_classify_op = function
@@ -1043,8 +1043,8 @@ let rec trans_expr env evd e =
       app_binop evd e binop a.(n - 2) prf1 a.(n - 1) prf2
     | d -> mkvar evd inj e
   with Not_found ->
-    (*    Feedback.msg_debug
-      Pp.(str "Not found " ++ Termops.Internal.debug_print_constr e); *)
+    (* Feedback.msg_debug
+       Pp.(str "Not found " ++ Termops.Internal.debug_print_constr e); *)
     mkvar evd inj e
 
 let trans_expr env evd e =


### PR DESCRIPTION
Only significant change is in gcd / lcm which now are typed in `Z.t`

The chosen interface is almost isomorphic to the one in `zarith`, so this will help porting.