### PR TITLE
[exn] [tactics] improve backtraces on monadic errors

### DIFF
--- a/clib/exninfo.ml
+++ b/clib/exninfo.ml
@@ -117,3 +117,10 @@ let capture e =
     e, add info backtrace_info bt
   else
     e, info e
+
+let reify () =
+  if !is_recording then
+    let bt = Printexc.get_callstack 50 in
+    add null backtrace_info bt
+  else
+    null

--- a/clib/exninfo.mli
+++ b/clib/exninfo.mli
@@ -79,3 +79,5 @@ val capture : exn -> iexn
 
 val iraise : iexn -> 'a
 (** Raise the given enriched exception. *)
+
+val reify : unit -> info

--- a/doc/changelog/12-misc/11755-exn+tclfail.rst
+++ b/doc/changelog/12-misc/11755-exn+tclfail.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  Backtrace information for tactics has been improved
+  (`#11755 <https://github.com/coq/coq/pull/11755>`_,
+  by Emilio Jesus Gallego Arias).

--- a/plugins/ltac/g_class.mlg
+++ b/plugins/ltac/g_class.mlg
@@ -142,7 +142,9 @@ let progress_evars t =
         let sigma = Tacmach.New.project gl' in
         let newconcl = Proofview.Goal.concl gl' in
         if eq_constr_mod_evars sigma concl newconcl
-        then Tacticals.New.tclFAIL 0 (Pp.str"No progress made (modulo evars)")
+        then
+          let info = Exninfo.reify () in
+          Tacticals.New.tclFAIL ~info 0 (Pp.str"No progress made (modulo evars)")
         else Proofview.tclUNIT ()
       end
     in t <*> check

--- a/plugins/omega/coq_omega.ml
+++ b/plugins/omega/coq_omega.ml
@@ -1475,7 +1475,9 @@ let coq_omega =
       let path = simplify_strong (new_id,new_var_num,display_var) system in
       if !display_action_flag then display_action display_var path;
       tclTHEN prelude (replay_history tactic_normalisation path)
-    with NO_CONTRADICTION -> tclZEROMSG (Pp.str"Omega can't solve this system")
+    with NO_CONTRADICTION as e ->
+      let _, info = Exninfo.capture e in
+      tclZEROMSG ~info (Pp.str"Omega can't solve this system")
   end
   end
 
@@ -1890,7 +1892,9 @@ let destructure_goal =
                                          end)
                 intro
             with Undecidable -> Tactics.elim_type (Lazy.force coq_False)
-            | e when Proofview.V82.catchable_exception e -> Proofview.tclZERO e
+            | e when Proofview.V82.catchable_exception e ->
+              let e, info = Exninfo.capture e in
+              Proofview.tclZERO ~info e
           in
           tclTHEN goal_tac destructure_hyps
     in

--- a/plugins/ssr/ssrview.ml
+++ b/plugins/ssr/ssrview.ml
@@ -194,9 +194,11 @@ let interp_glob ist glob = Goal.enter_one ~__LOC__ begin fun goal ->
       Pp.(str"interp-out: " ++ Printer.pr_econstr_env env sigma term));
     tclUNIT (env,sigma,term)
   with e ->
+    (* XXX this is another catch all! *)
+    let e, info = Exninfo.capture e in
     Ssrprinters.ppdebug (lazy
     Pp.(str"interp-err: " ++ Printer.pr_glob_constr_env env glob));
-     tclZERO e
+    tclZERO ~info e
 end
 
 (* Commits the term to the monad *)

--- a/proofs/clenvtac.ml
+++ b/proofs/clenvtac.ml
@@ -129,5 +129,7 @@ let unify ?(flags=fail_quick_unif_flags) m =
     try
       let evd' = w_unify env evd CONV ~flags m n in
         Proofview.Unsafe.tclEVARSADVANCE evd'
-    with e when CErrors.noncritical e -> Proofview.tclZERO e
+    with e when CErrors.noncritical e ->
+      let info = Exninfo.reify () in
+      Proofview.tclZERO ~info e
   end

--- a/proofs/proof.ml
+++ b/proofs/proof.ml
@@ -525,7 +525,10 @@ let solve ?with_end_tac gi info_lvl tac pr =
       | None -> tac
       | Some _ -> Proofview.Trace.record_info_trace tac
     in
-    let nosuchgoal = Proofview.tclZERO (SuggestNoSuchGoals (1,pr)) in
+    let nosuchgoal =
+      let info = Exninfo.reify () in
+      Proofview.tclZERO ~info (SuggestNoSuchGoals (1,pr))
+    in
     let tac = let open Goal_select in match gi with
       | SelectAlreadyFocused ->
         let open Proofview.Notations in
@@ -537,7 +540,8 @@ let solve ?with_end_tac gi info_lvl tac pr =
                Pp.(str "Expected a single focused goal but " ++
                    int n ++ str " goals are focused."))
           in
-          Proofview.tclZERO e
+          let info = Exninfo.reify () in
+          Proofview.tclZERO ~info e
 
       | SelectNth i -> Proofview.tclFOCUS ~nosuchgoal i i tac
       | SelectList l -> Proofview.tclFOCUSLIST ~nosuchgoal l tac

--- a/proofs/refine.ml
+++ b/proofs/refine.ml
@@ -132,4 +132,7 @@ let solve_constraints =
   tclENV >>= fun env -> tclEVARMAP >>= fun sigma ->
    try let sigma = Evarconv.solve_unif_constraints_with_heuristics env sigma in
        Unsafe.tclEVARSADVANCE sigma
-   with e -> tclZERO e
+   with e ->
+     (* XXX this is absorbing anomalies? *)
+     let info = Exninfo.reify () in
+     tclZERO ~info e

--- a/tactics/autorewrite.ml
+++ b/tactics/autorewrite.ml
@@ -154,7 +154,8 @@ let gen_auto_multi_rewrite conds tac_main lbas cl =
   if not (Locusops.is_all_occurrences cl.concl_occs) &&
      cl.concl_occs != NoOccurrences
   then
-    Tacticals.New.tclZEROMSG (str"The \"at\" syntax isn't available yet for the autorewrite tactic.")
+    let info = Exninfo.reify () in
+    Tacticals.New.tclZEROMSG ~info (str"The \"at\" syntax isn't available yet for the autorewrite tactic.")
   else
     let compose_tac t1 t2 =
       match cl.onhyps with
@@ -185,7 +186,9 @@ let auto_multi_rewrite_with ?(conds=Naive) tac_main lbas cl =
         *)
         Proofview.V82.wrap_exceptions (fun () -> gen_auto_multi_rewrite conds tac_main lbas cl)
     | _ ->
-        Tacticals.New.tclZEROMSG (strbrk "autorewrite .. in .. using can only be used either with a unique hypothesis or on the conclusion.")
+      let info = Exninfo.reify () in
+      Tacticals.New.tclZEROMSG ~info
+        (strbrk "autorewrite .. in .. using can only be used either with a unique hypothesis or on the conclusion.")
 
 (* Functions necessary to the library object declaration *)
 let cache_hintrewrite (_,(rbase,lrl)) =

--- a/tactics/eauto.ml
+++ b/tactics/eauto.ml
@@ -526,5 +526,7 @@ let autounfold_one db cl =
       match cl with
       | Some hyp -> change_in_hyp ~check:true None (make_change_arg c') hyp
       | None -> convert_concl ~check:false c' DEFAULTcast
-    else Tacticals.New.tclFAIL 0 (str "Nothing to unfold")
+    else
+      let info = Exninfo.reify () in
+      Tacticals.New.tclFAIL ~info 0 (str "Nothing to unfold")
   end

--- a/tactics/elim.ml
+++ b/tactics/elim.ml
@@ -160,7 +160,8 @@ let double_ind h1 h2 =
   let abs =
     if abs_i < abs_j then Proofview.tclUNIT (abs_i,abs_j) else
     if abs_i > abs_j then  Proofview.tclUNIT (abs_j,abs_i) else
-      tclZEROMSG (Pp.str "Both hypotheses are the same.") in
+      let info = Exninfo.reify () in
+      tclZEROMSG ~info (Pp.str "Both hypotheses are the same.") in
   abs >>= fun (abs_i,abs_j) ->
   (tclTHEN (tclDO abs_i intro)
      (onLastHypId

--- a/tactics/eqdecide.ml
+++ b/tactics/eqdecide.ml
@@ -182,7 +182,9 @@ let match_eqdec env sigma c =
       let neq = mkApp (noteq,[|mkApp (eq2,[|t;x;y|])|]) in
       if eqonleft then mkApp (op,[|eq;neq|]) else mkApp (op,[|neq;eq|]) in
     Proofview.tclUNIT (eqonleft,mk,c1,c2,ty)
-  with PatternMatchingFailure -> Proofview.tclZERO PatternMatchingFailure
+  with PatternMatchingFailure as exn ->
+    let _, info = Exninfo.capture exn in
+    Proofview.tclZERO ~info PatternMatchingFailure
 
 (* /spiwack *)
 

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -1570,6 +1570,8 @@ let run_hint tac k = match warn_hint () with
   else Proofview.tclTHEN (log_hint tac) (k tac.obj)
 | HintStrict ->
   if is_imported tac then k tac.obj
-  else Proofview.tclZERO (UserError (None, (str "Tactic failure.")))
+  else
+    let info = Exninfo.reify () in
+    Proofview.tclZERO ~info (UserError (None, (str "Tactic failure.")))
 
 let repr_hint h = h.obj

--- a/tactics/tacticals.mli
+++ b/tactics/tacticals.mli
@@ -151,9 +151,9 @@ module New : sig
   (* [tclFAIL n msg] fails with [msg] as an error message at level [n]
      (meaning that it will jump over [n] error catching tacticals FROM
      THIS MODULE. *)
-  val tclFAIL : int -> Pp.t -> 'a tactic
+  val tclFAIL : ?info:Exninfo.info -> int -> Pp.t -> 'a tactic
 
-  val tclZEROMSG : ?loc:Loc.t -> Pp.t -> 'a tactic
+  val tclZEROMSG : ?info:Exninfo.info -> ?loc:Loc.t -> Pp.t -> 'a tactic
   (** Fail with a [User_Error] containing the given message. *)
 
   val tclOR : unit tactic -> unit tactic -> unit tactic

--- a/user-contrib/Ltac2/tac2match.ml
+++ b/user-contrib/Ltac2/tac2match.ml
@@ -131,7 +131,9 @@ module PatternMatching (E:StaticEnvironment) = struct
     { stream = fun k ctx -> m.stream (fun () ctx -> y.stream k ctx) ctx }
 
   (** Failure of the pattern-matching monad: no success. *)
-  let fail (type a) : a m = { stream = fun _ _ -> Proofview.tclZERO matching_error }
+  let fail (type a) : a m = { stream = fun _ _ ->
+      let info = Exninfo.reify () in
+      Proofview.tclZERO ~info matching_error }
 
   let run (m : 'a m) =
     let ctx = {
@@ -150,7 +152,11 @@ module PatternMatching (E:StaticEnvironment) = struct
 
   let put_subst subst : unit m =
     let s = { subst } in
-    { stream = fun k ctx -> match merge s ctx with None -> Proofview.tclZERO matching_error | Some s -> k () s }
+    { stream = fun k ctx -> match merge s ctx with
+          | None ->
+            let info = Exninfo.reify () in
+            Proofview.tclZERO ~info matching_error
+          | Some s -> k () s }
 
   (** {6 Pattern-matching} *)
 


### PR DESCRIPTION
Current backtraces for tactics leave a bit to desire, for example
given the program:

```coq
Lemma u n : n + 0 = n.
rewrite plus_O_n.
```

the backtrace stops at:

```
Found no subterm matching "0 + ?M160" in the current goal.
Called from file "proofs/proof.ml", line 381, characters 4-42
Called from file "tactics/pfedit.ml", line 102, characters 31-58
Called from file "plugins/ltac/g_ltac.mlg", line 378, characters 8-84
```

Backtrace information `?info` is as of today optional in some tactics,
such as `tclZERO`, it doesn't cost a lot  however to reify backtrace
information indeed in `tclZERO` and provide backtraces for all tactic
errors. The cost should be small if we are not in debug mode.

The backtrace for the failed rewrite is now:

```
Found no subterm matching "0 + ?M160" in the current goal.
Raised at file "pretyping/unification.ml", line 1827, characters 14-73
Called from file "pretyping/unification.ml", line 1929, characters 17-53
Called from file "pretyping/unification.ml", line 1948, characters 22-72
Called from file "pretyping/unification.ml", line 2020, characters 14-56
Re-raised at file "pretyping/unification.ml", line 2021, characters 66-73
Called from file "proofs/clenv.ml", line 254, characters 12-58
Called from file "proofs/clenvtac.ml", line 95, characters 16-53
Called from file "engine/proofview.ml", line 1110, characters 40-46
Called from file "engine/proofview.ml", line 1115, characters 10-34
Re-raised at file "clib/exninfo.ml", line 82, characters 4-38
Called from file "proofs/proof.ml", line 381, characters 4-42
Called from file "tactics/pfedit.ml", line 102, characters 31-58
Called from file "plugins/ltac/g_ltac.mlg", line 378, characters 8-84
```

which IMO is much better.

**Kind:** debugging

Fixes / closes #????

- [x] Entry added in the changelog