### PR TITLE
[notation] force type_scope on P in sigT (fun x => P)

### DIFF
--- a/test-suite/success/Notations2.v
+++ b/test-suite/success/Notations2.v
@@ -202,3 +202,9 @@ Notation "#" := (@id nat).
 Check # = (fun a:nat => a). (* # should inherit its maximal implicit argument *)
 
 End InheritanceMaximalImplicitPureNotation.
+
+Module sigT_type_scope.
+
+Check { T & T * nat }.
+
+End sigT_type_scope

--- a/theories/Init/Specif.v
+++ b/theories/Init/Specif.v
@@ -63,9 +63,9 @@ Notation "{ x  |  P  & Q }" := (sig2 (fun x => P) (fun x => Q)) : type_scope.
 Notation "{ x : A  |  P }" := (sig (A:=A) (fun x => P)) : type_scope.
 Notation "{ x : A  |  P  & Q }" := (sig2 (A:=A) (fun x => P) (fun x => Q)) :
   type_scope.
-Notation "{ x  &  P }" := (sigT (fun x => P)) : type_scope.
-Notation "{ x : A  & P }" := (sigT (A:=A) (fun x => P)) : type_scope.
-Notation "{ x : A  & P  & Q }" := (sigT2 (A:=A) (fun x => P) (fun x => Q)) :
+Notation "{ x  &  P }" := (sigT (fun x => (P)%type)) : type_scope.
+Notation "{ x : A  & P }" := (sigT (A:=A) (fun x => (P)%type)) : type_scope.
+Notation "{ x : A  & P  & Q }" := (sigT2 (A:=A) (fun x => (P)%type) (fun x => (Q)%type)) :
   type_scope.
 
 Notation "{ ' pat  |  P }" := (sig (fun pat => P)) : type_scope.


### PR DESCRIPTION
Apparently sigT tries hard to put its argument in type scope, but not hard enough.