### PR TITLE
Ltac2: added lazy boolean operators and if then else notations

### DIFF
--- a/test-suite/ltac2/bool_lib.v
+++ b/test-suite/ltac2/bool_lib.v
@@ -1,0 +1,125 @@
+Require Import Ltac2.Ltac2.
+Require Import Ltac2.Bool.
+
+
+(** * Lazy eval tests *)
+
+Require Import Ltac2.Notations.
+
+Example lazy_and_false : exists n, n=0.
+Proof.
+  exists ltac2:(let val:= if_bool (lazy_and false (Control.throw_invalid_argument "bad")) then '1 else '0 in exact $val).
+  reflexivity.
+Qed.
+
+Example lazy_and_true_false : exists n, n=0.
+Proof.
+  exists ltac2:(let val:= if_bool (lazy_and true false) then '1 else '0 in exact $val).
+  reflexivity.
+Qed.
+
+Example lazy_and_true_true : exists n, n=1.
+Proof.
+  exists ltac2:(let val:= if_bool (lazy_and true true) then '1 else '0 in exact $val).
+  reflexivity.
+Qed.
+
+Example lazy_or_true : exists n, n=1.
+Proof.
+  exists ltac2:(let val:= if_bool (lazy_or true (Control.throw_invalid_argument "bad")) then '1 else '0 in exact $val).
+  reflexivity.
+Qed.
+
+Example lazy_or_false_true : exists n, n=1.
+Proof.
+  exists ltac2:(let val:= if_bool (lazy_or false true) then '1 else '0 in exact $val).
+  reflexivity.
+Qed.
+
+Example lazy_or_false_false : exists n, n=0.
+Proof.
+  exists ltac2:(let val:= if_bool (lazy_or false false) then '1 else '0 in exact $val).
+  reflexivity.
+Qed.
+
+Example lazy_impl_false : exists n, n=1.
+Proof.
+  exists ltac2:(let val:= if_bool (lazy_impl false (Control.throw_invalid_argument "bad")) then '1 else '0 in exact $val).
+  reflexivity.
+Qed.
+
+Example lazy_impl_true_false : exists n, n=0.
+Proof.
+  exists ltac2:(let val:= if_bool (lazy_impl true false) then '1 else '0 in exact $val).
+  reflexivity.
+Qed.
+
+Example lazy_impl_true_true : exists n, n=1.
+Proof.
+  exists ltac2:(let val:= if_bool (lazy_impl true true) then '1 else '0 in exact $val).
+  reflexivity.
+Qed.
+
+(** * if then else tests *)
+
+Example if_then_else_true : exists n, n=1.
+Proof.
+  exists ltac2:(let val:=if_bool true then '1 else '0 in exact $val).
+  reflexivity.
+Qed.
+
+Example if_then_else_false : exists n, n=0.
+Proof.
+  exists ltac2:(let val:=if_bool false then '1 else '0 in exact $val).
+  reflexivity.
+Qed.
+
+(** Notes: parenthesis are mandatory for nested ifs - this is by design) *)
+
+Example if_then_else_nested_true : exists n, n=2.
+Proof.
+  exists ltac2:(let val:=if_bool true then (if_bool true then '2 else '1) else '0 in exact $val).
+  reflexivity.
+Qed.
+
+Example if_then_else_nested_false : exists n, n=0.
+Proof.
+  exists ltac2:(let val:=if_bool false then '2 else (if_bool false then '1 else '0) in exact $val).
+  reflexivity.
+Qed.
+
+Example if_then_else_match_cond : exists n, n=0.
+Proof.
+  exists ltac2:(let val:=if_bool match true with true => false | false => true end then '1 else '0 in exact $val).
+  reflexivity.
+Qed.
+
+Example if_then_else_match_true : exists n, n=2.
+Proof.
+  exists ltac2:(let val:=if_bool true then match true with true => '2 | false => '1 end else '0 in exact $val).
+  reflexivity.
+Qed.
+
+Example if_then_else_match_false : exists n, n=0.
+Proof.
+  exists ltac2:(let val:=if_bool false then '2 else match false with true => '1 | false => '0 end in exact $val).
+  reflexivity.
+Qed.
+
+(** * if then tests *)
+
+Example if_then_true : 0=0.
+Proof.
+  if_bool true then reflexivity.
+Qed.
+
+Example if_then_false : 0=0.
+Proof.
+  if_bool false then reflexivity.
+  reflexivity.
+Qed.
+
+Example if_then_sequence : 0=0.
+Proof.
+  (); if_bool false then reflexivity; reflexivity.
+Qed.

--- a/user-contrib/Ltac2/Bool.v
+++ b/user-contrib/Ltac2/Bool.v
@@ -10,6 +10,8 @@
 
 Require Import Ltac2.Init.
 
+(** * Boolean operators *)
+
 Ltac2 and x y :=
   match x with
   | true => y
@@ -61,3 +63,44 @@ Ltac2 eq x y :=
        | false => true
        end
   end.
+
+(** * Boolean operators with lazy evaluation of the second argument *)
+
+Ltac2 Notation "lazy_and" x(tactic(0)) y(thunk(tactic(0))) : 1 :=
+  match x with
+  | true => y ()
+  | false => false
+  end.
+
+Ltac2 Notation "lazy_or" x(tactic(0)) y(thunk(tactic(0))) : 1 :=
+  match x with
+  | true => true
+  | false => y ()
+  end.
+
+Ltac2 Notation "lazy_impl" x(tactic(0)) y(thunk(tactic(0))) : 1 :=
+  match x with
+  | true => y ()
+  | false => true
+  end.
+
+(** * Notations for if constructs *)
+
+(** if then - this only works for tactics returning a unit since false returns unit *)
+
+(** Note: the arguments are tactic(5) = matches and lets,
+    The if term itself is tactic(6) = semicolon tactic sequences *)
+
+Ltac2 Notation "if_bool" cond(tactic(5)) "then" true_tac(thunk(tactic(5))) : 6 :=
+  match cond with
+  | true => true_tac ()
+  | false => ()
+end.
+
+(** if then else - the then and else branch can return arbitrary types *)
+
+Ltac2 Notation "if_bool" cond(tactic(5)) "then" true_tac(thunk(tactic(5))) "else" false_tac(thunk(tactic(5))) : 6 :=
+  match cond with
+  | true => true_tac ()
+  | false => false_tac ()
+end.


### PR DESCRIPTION
This PR adds a few lazy boolean operators (as notations) and notations for boolean ifs.

What I am not exactly happy with is that while the argument parsing for the if constructs accept atoms and matches and things in between, they don't accept the lazy boolean operators defined as notations, although I think they should.

**Kind:** feature

- [x] Added / updated test-suite
- [ ] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
