### PR TITLE
Fix #11738 : Funind using deprecated Coqlib API.

### DIFF
--- a/plugins/funind/indfun_common.ml
+++ b/plugins/funind/indfun_common.ml
@@ -92,18 +92,14 @@ let list_union_eq eq_fun l1 l2 =
 let list_add_set_eq eq_fun x l =
   if List.exists (eq_fun x) l then l else x::l
 
-[@@@ocaml.warning "-3"]
-let coq_constant s =
-  UnivGen.constr_of_monomorphic_global @@
-  Coqlib.gen_reference_in_modules "RecursiveDefinition"
-    Coqlib.init_modules s;;
+let coq_constant s = UnivGen.constr_of_monomorphic_global @@ Coqlib.lib_ref s;;
 
 let find_reference sl s =
   let dp = Names.DirPath.make (List.rev_map Id.of_string sl) in
   Nametab.locate (make_qualid dp (Id.of_string s))
 
-let eq = lazy(EConstr.of_constr (coq_constant "eq"))
-let refl_equal = lazy(EConstr.of_constr (coq_constant "eq_refl"))
+let eq = lazy(EConstr.of_constr (coq_constant "core.eq.type"))
+let refl_equal = lazy(EConstr.of_constr (coq_constant "core.eq.refl"))
 
 let with_full_print f a =
   let old_implicit_args = Impargs.is_implicit_args ()
@@ -369,10 +365,10 @@ let do_observe_tac s tac g =
     ignore(Stack.pop debug_queue);
     v
   with reraise ->
-    let reraise = CErrors.push reraise in
+    let reraise = Exninfo.capture reraise in
     if not (Stack.is_empty debug_queue)
     then print_debug_queue true (fst reraise);
-    Util.iraise reraise
+    Exninfo.iraise reraise
 
 let observe_tac s tac g =
   if do_observe ()
@@ -447,14 +443,11 @@ let h_intros l =
 
 let h_id = Id.of_string "h"
 let hrec_id = Id.of_string "hrec"
-let well_founded = function () -> EConstr.of_constr (coq_constant "well_founded")
-let acc_rel = function () -> EConstr.of_constr (coq_constant "Acc")
-let acc_inv_id = function () -> EConstr.of_constr (coq_constant "Acc_inv")
+let well_founded = function () -> EConstr.of_constr (coq_constant "core.wf.well_founded")
+let acc_rel = function () -> EConstr.of_constr (coq_constant "core.wf.acc")
+let acc_inv_id = function () -> EConstr.of_constr (coq_constant "core.wf.acc_inv")
 
-[@@@ocaml.warning "-3"]
-let well_founded_ltof () = EConstr.of_constr @@ UnivGen.constr_of_monomorphic_global @@
-    Coqlib.find_reference "IndFun" ["Coq"; "Arith";"Wf_nat"] "well_founded_ltof"
-[@@@ocaml.warning "+3"]
+let well_founded_ltof () = EConstr.of_constr (coq_constant "num.nat.well_founded_ltof")
 
 let ltof_ref = function  () -> (find_reference ["Coq";"Arith";"Wf_nat"] "ltof")
 

--- a/theories/Arith/Lt.v
+++ b/theories/Arith/Lt.v
@@ -41,10 +41,14 @@ Proof.
  apply Nat.lt_succ_r.
 Qed.
 
+Register lt_n_Sm_le as num.nat.lt_n_Sm_le.
+
 Theorem le_lt_n_Sm n m : n <= m -> n < S m.
 Proof.
  apply Nat.lt_succ_r.
 Qed.
+
+Register le_lt_n_Sm as num.nat.le_lt_n_Sm.
 
 Hint Immediate lt_le_S: arith.
 Hint Immediate lt_n_Sm_le: arith.
@@ -99,6 +103,8 @@ Proof.
  apply Nat.succ_lt_mono.
 Qed.
 
+Register lt_S_n as num.nat.lt_S_n.
+
 Hint Resolve lt_n_Sn lt_S lt_n_S : arith.
 Hint Immediate lt_S_n : arith.
 
@@ -132,6 +138,8 @@ Hint Resolve lt_pred_n_n: arith.
 Notation lt_trans := Nat.lt_trans (only parsing).
 Notation lt_le_trans := Nat.lt_le_trans (only parsing).
 Notation le_lt_trans := Nat.le_lt_trans (only parsing).
+
+Register le_lt_trans as num.nat.le_lt_trans.
 
 Hint Resolve lt_trans lt_le_trans le_lt_trans: arith.
 

--- a/theories/Arith/PeanoNat.v
+++ b/theories/Arith/PeanoNat.v
@@ -764,6 +764,9 @@ Infix "mod" := Nat.modulo (at level 40, no associativity) : nat_scope.
 Hint Unfold Nat.le : core.
 Hint Unfold Nat.lt : core.
 
+Register Nat.le_trans as num.nat.le_trans.
+Register Nat.nlt_0_r as num.nat.nlt_0_r.
+
 (** [Nat] contains an [order] tactic for natural numbers *)
 
 (** Note that [Nat.order] is domain-agnostic: it will not prove

--- a/theories/Arith/Wf_nat.v
+++ b/theories/Arith/Wf_nat.v
@@ -34,6 +34,8 @@ Proof.
   intros a. apply (H (S (f a))). auto with arith.
 Defined.
 
+Register well_founded_ltof as num.nat.well_founded_ltof.
+
 Theorem well_founded_gtof : well_founded gtof.
 Proof.
   exact well_founded_ltof.

--- a/theories/Init/Peano.v
+++ b/theories/Init/Peano.v
@@ -159,6 +159,8 @@ Inductive le (n:nat) : nat -> Prop :=
 
 where "n <= m" := (le n m) : nat_scope.
 
+Register le_n as num.nat.le_n.
+
 Hint Constructors le: core.
 (*i equivalent to : "Hints Resolve le_n le_S : core." i*)
 

--- a/theories/Init/Wf.v
+++ b/theories/Init/Wf.v
@@ -32,11 +32,14 @@ Section Well_founded.
  Inductive Acc (x: A) : Prop :=
      Acc_intro : (forall y:A, R y x -> Acc y) -> Acc x.
 
+ Register Acc as core.wf.acc.
+
  Lemma Acc_inv : forall x:A, Acc x -> forall y:A, R y x -> Acc y.
   destruct 1; trivial.
  Defined.
 
  Global Arguments Acc_inv [x] _ [y] _, [x] _ y _.
+ Register Acc_inv as core.wf.acc_inv.
 
  (** A relation is well-founded if every element is accessible *)
 


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** bug fix


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #11738 : Funind using deprecated Coqlib API


