### PR TITLE
[obligations] Don't allocate libobjects for obligation info.

### DIFF
--- a/vernac/declareObl.mli
+++ b/vernac/declareObl.mli
@@ -139,6 +139,9 @@ val update_obls :
 
 (** { 2 Util }  *)
 
+(** Check obligations are properly solved before closing a section *)
+val check_can_close : Id.t -> unit
+
 val get_prg_info_map : unit -> ProgramDecl.t CEphemeron.key ProgMap.t
 
 val program_tcc_summary_tag :

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -983,7 +983,7 @@ let vernac_begin_section ~poly ({v=id} as lid) =
      to its current value ie noop. *)
   set_bool_option_value_gen ~locality:OptLocal ["Universe"; "Polymorphism"] poly
 
-let vernac_end_section {CAst.loc} =
+let vernac_end_section {CAst.loc; v} =
   Dumpglob.dump_reference ?loc
     (DirPath.to_string (Lib.current_dirpath true)) "<>" "sec";
   Lib.close_section ()
@@ -993,6 +993,7 @@ let vernac_name_sec_hyp {v=id} set = Proof_using.name_set id set
 (* Dispatcher of the "End" command *)
 
 let vernac_end_segment ({v=id} as lid) =
+  DeclareObl.check_can_close lid.v;
   match Lib.find_opening_node id with
   | Lib.OpenedModule (false,export,_,_) -> vernac_end_module export lid
   | Lib.OpenedModule (true,_,_,_) -> vernac_end_modtype lid


### PR DESCRIPTION
Obligations/Program currently allocates a libobject object just to
check that there are no obligations pending at the end of a section.

I think this is not the right use case for libobject, thus we turn the
check into an explicit one at the vernac level.