### PR TITLE
[ltac] Remove compat tactic notation entry mechanism

### DIFF
--- a/plugins/ltac/extraargs.mlg
+++ b/plugins/ltac/extraargs.mlg
@@ -41,18 +41,7 @@ let () =
   let inject (loc, v) = Tacexpr.Tacexp v in
   Tacentries.create_ltac_quotation "ltac" inject (Pltac.tactic_expr, Some 5)
 
-(** Backward-compatible tactic notation entry names *)
-
-let () =
-  let register name entry = Tacentries.register_tactic_notation_entry name entry in
-  register "hyp" wit_var;
-  register "simple_intropattern" wit_simple_intropattern;
-  register "integer" wit_integer;
-  register "reference" wit_ref;
-  ()
-
 (* Rewriting orientation *)
-
 let _ =
   Mltop.declare_cache_obj
     (fun () -> Metasyntax.add_token_obj "<-";

--- a/plugins/ltac/tacentries.ml
+++ b/plugins/ltac/tacentries.ml
@@ -202,23 +202,13 @@ let extend_tactic_grammar kn ml ntn = extend_grammar_command tactic_grammar (kn,
 (**********************************************************************)
 (* Tactic Notation                                                    *)
 
-let entry_names = ref String.Map.empty
-
-let register_tactic_notation_entry name entry =
-  let entry = match entry with
-  | ExtraArg arg -> ArgT.Any arg
-  | _ -> assert false
-  in
-  entry_names := String.Map.add name entry !entry_names
-
 let interp_prod_item = function
   | TacTerm s -> TacTerm s
   | TacNonTerm (loc, ((nt, sep), ido)) ->
     let symbol = parse_user_entry ?loc nt sep in
     let interp s = function
     | None ->
-      if String.Map.mem s !entry_names then String.Map.find s !entry_names
-      else begin match ArgT.name s with
+      begin match ArgT.name s with
       | None -> user_err Pp.(str ("Unknown entry "^s^"."))
       | Some arg -> arg
       end

--- a/plugins/ltac/tacentries.mli
+++ b/plugins/ltac/tacentries.mli
@@ -41,13 +41,6 @@ val add_tactic_notation :
     environment at level [level] with locality [local] made of the grammar
     productions [prods] and returning the body [expr] *)
 
-val register_tactic_notation_entry : string -> ('a, 'b, 'c) Genarg.genarg_type -> unit
-(** Register an argument under a given entry name for tactic notations. When
-    translating [raw_argument] into [argument], atomic names will be first
-    looked up according to names registered through this function and fallback
-    to finding an argument by name (as in {!Genarg}) if there is none
-    matching. *)
-
 val add_ml_tactic_notation : ml_tactic_name -> level:int -> ?deprecation:Deprecation.t ->
   argument grammar_tactic_prod_item_expr list list -> unit
 (** A low-level variant of {!add_tactic_notation} used by the TACTIC EXTEND

--- a/theories/Classes/CRelationClasses.v
+++ b/theories/Classes/CRelationClasses.v
@@ -249,7 +249,7 @@ Ltac reduce_goal :=
     | _ => red ; intros ; try reduce_goal
   end.
 
-Tactic Notation "reduce" "in" hyp(Hid) := reduce_hyp Hid.
+Tactic Notation "reduce" "in" var(Hid) := reduce_hyp Hid.
 
 Ltac reduce := reduce_goal.
 

--- a/theories/Classes/RelationClasses.v
+++ b/theories/Classes/RelationClasses.v
@@ -248,7 +248,7 @@ Ltac reduce_goal :=
     | _ => red ; intros ; try reduce_goal
   end.
 
-Tactic Notation "reduce" "in" hyp(Hid) := reduce_hyp Hid.
+Tactic Notation "reduce" "in" var(Hid) := reduce_hyp Hid.
 
 Ltac reduce := reduce_goal.
 

--- a/theories/Classes/SetoidTactics.v
+++ b/theories/Classes/SetoidTactics.v
@@ -70,11 +70,11 @@ Tactic Notation "setoid_replace" constr(x) "with" constr(y)
   setoidreplaceat (default_relation x y) idtac o.
 
 Tactic Notation "setoid_replace" constr(x) "with" constr(y)
-  "in" hyp(id) :=
+  "in" var(id) :=
   setoidreplacein (default_relation x y) id idtac.
 
 Tactic Notation "setoid_replace" constr(x) "with" constr(y)
-  "in" hyp(id)
+  "in" var(id)
   "at" int_or_var_list(o) :=
   setoidreplaceinat (default_relation x y) id idtac o.
 
@@ -88,12 +88,12 @@ Tactic Notation "setoid_replace" constr(x) "with" constr(y)
   setoidreplaceat (default_relation x y) ltac:(t) o.
 
 Tactic Notation "setoid_replace" constr(x) "with" constr(y)
-  "in" hyp(id)
+  "in" var(id)
   "by" tactic3(t) :=
   setoidreplacein (default_relation x y) id ltac:(t).
 
 Tactic Notation "setoid_replace" constr(x) "with" constr(y)
-  "in" hyp(id)
+  "in" var(id)
   "at" int_or_var_list(o)
   "by" tactic3(t) :=
   setoidreplaceinat (default_relation x y) id ltac:(t) o.
@@ -120,24 +120,24 @@ Tactic Notation "setoid_replace" constr(x) "with" constr(y)
 
 Tactic Notation "setoid_replace" constr(x) "with" constr(y)
   "using" "relation" constr(rel)
-  "in" hyp(id) :=
+  "in" var(id) :=
   setoidreplacein (rel x y) id idtac.
 
 Tactic Notation "setoid_replace" constr(x) "with" constr(y)
   "using" "relation" constr(rel)
-  "in" hyp(id)
+  "in" var(id)
   "at" int_or_var_list(o) :=
   setoidreplaceinat (rel x y) id idtac o.
 
 Tactic Notation "setoid_replace" constr(x) "with" constr(y)
   "using" "relation" constr(rel)
-  "in" hyp(id)
+  "in" var(id)
   "by" tactic3(t) :=
   setoidreplacein (rel x y) id ltac:(t).
 
 Tactic Notation "setoid_replace" constr(x) "with" constr(y)
   "using" "relation" constr(rel)
-  "in" hyp(id)
+  "in" var(id)
   "at" int_or_var_list(o)
   "by" tactic3(t) :=
   setoidreplaceinat (rel x y) id ltac:(t) o.

--- a/theories/Init/Tactics.v
+++ b/theories/Init/Tactics.v
@@ -153,10 +153,10 @@ bapply lemma ltac:(fun H => destruct H as [H _]; apply H).
 Tactic Notation "apply" "<-" constr(lemma) :=
 bapply lemma ltac:(fun H => destruct H as [_ H]; apply H).
 
-Tactic Notation "apply" "->" constr(lemma) "in" hyp(J) :=
+Tactic Notation "apply" "->" constr(lemma) "in" var(J) :=
 bapply lemma ltac:(fun H => destruct H as [H _]; apply H in J).
 
-Tactic Notation "apply" "<-" constr(lemma) "in" hyp(J) :=
+Tactic Notation "apply" "<-" constr(lemma) "in" var(J) :=
 bapply lemma ltac:(fun H => destruct H as [_ H]; apply H in J).
 
 (** An experimental tactic simpler than auto that is useful for ending
@@ -228,7 +228,7 @@ Tactic Notation "decide" constr(lemma) "with" constr(H) :=
 
 (** Clear an hypothesis and its dependencies *)
 
-Tactic Notation "clear" "dependent" hyp(h) :=
+Tactic Notation "clear" "dependent" var(h) :=
  let rec depclear h :=
   clear h ||
   match goal with
@@ -240,7 +240,7 @@ Tactic Notation "clear" "dependent" hyp(h) :=
 (** Revert an hypothesis and its dependencies :
     this is actually generalize dependent... *)
 
-Tactic Notation "revert" "dependent" hyp(h) :=
+Tactic Notation "revert" "dependent" var(h) :=
  generalize dependent h.
 
 (** Provide an error message for dependent induction that reports an import is

--- a/theories/Logic/FunctionalExtensionality.v
+++ b/theories/Logic/FunctionalExtensionality.v
@@ -147,7 +147,7 @@ Tactic Notation "extensionality" ident(x) :=
 (* Note that you can write [Ltac extensionality_in_checker tac ::= tac tt.] to get a more informative error message. *)
 Ltac extensionality_in_checker tac :=
   first [ tac tt | fail 1 "Anomaly: Unexpected error in extensionality tactic.  Please report." ].
-Tactic Notation "extensionality" "in" hyp(H) :=
+Tactic Notation "extensionality" "in" var(H) :=
   let rec check_is_extensional_equality H :=
       lazymatch type of H with
       | _ = _ => constr:(Prop)

--- a/theories/Program/Equality.v
+++ b/theories/Program/Equality.v
@@ -382,7 +382,7 @@ Ltac is_introduced H :=
     | [ H' : _ |- _ ] => match H' with H => idtac end
   end.
 
-Tactic Notation "intro_block" hyp(H) :=
+Tactic Notation "intro_block" var(H) :=
   (is_introduced H ; block_goal ; revert_until H ; block_goal) ||
     (let H' := fresh H in intros until H' ; block_goal) || (intros ; block_goal).
 
@@ -442,10 +442,10 @@ Tactic Notation "dependent" "destruction" ident(H) "using" constr(c) :=
 
 (** This tactic also generalizes the goal by the given variables before the elimination. *)
 
-Tactic Notation "dependent" "destruction" ident(H) "generalizing" ne_hyp_list(l) := 
+Tactic Notation "dependent" "destruction" ident(H) "generalizing" ne_var_list(l) :=
   do_depelim' ltac:(fun hyp => revert l) ltac:(fun hyp => do_case hyp) H.
 
-Tactic Notation "dependent" "destruction" ident(H) "generalizing" ne_hyp_list(l) "using" constr(c) := 
+Tactic Notation "dependent" "destruction" ident(H) "generalizing" ne_var_list(l) "using" constr(c) :=
   do_depelim' ltac:(fun hyp => revert l) ltac:(fun hyp => destruct hyp using c) H.
 
 (** Then we have wrappers for usual calls to induction. One can customize the induction tactic by 
@@ -460,14 +460,14 @@ Tactic Notation "dependent" "induction" ident(H) "using" constr(c) :=
 
 (** This tactic also generalizes the goal by the given variables before the induction. *)
 
-Tactic Notation "dependent" "induction" ident(H) "generalizing" ne_hyp_list(l) := 
+Tactic Notation "dependent" "induction" ident(H) "generalizing" ne_var_list(l) :=
   do_depelim' ltac:(fun hyp => revert l) ltac:(fun hyp => do_ind hyp) H.
 
-Tactic Notation "dependent" "induction" ident(H) "generalizing" ne_hyp_list(l) "using" constr(c) := 
+Tactic Notation "dependent" "induction" ident(H) "generalizing" ne_var_list(l) "using" constr(c) :=
   do_depelim' ltac:(fun hyp => revert l) ltac:(fun hyp => induction hyp using c) H.
 
-Tactic Notation "dependent" "induction" ident(H) "in" ne_hyp_list(l) :=
+Tactic Notation "dependent" "induction" ident(H) "in" ne_var_list(l) :=
   do_depelim' ltac:(fun hyp => idtac) ltac:(fun hyp => induction hyp in l) H.
 
-Tactic Notation "dependent" "induction" ident(H) "in" ne_hyp_list(l) "using" constr(c) := 
+Tactic Notation "dependent" "induction" ident(H) "in" ne_var_list(l) "using" constr(c) :=
   do_depelim' ltac:(fun hyp => idtac) ltac:(fun hyp => induction hyp in l using c) H.

--- a/theories/Program/Tactics.v
+++ b/theories/Program/Tactics.v
@@ -215,10 +215,10 @@ Tactic Notation "destruct_call" constr(f) "as" simple_intropattern(l) :=
 
 (** Specify the hypothesis in which the call occurs as well. *)
 
-Tactic Notation "destruct_call" constr(f) "in" hyp(id) :=
+Tactic Notation "destruct_call" constr(f) "in" var(id) :=
   destruct_call_in f id.
 
-Tactic Notation "destruct_call" constr(f) "as" simple_intropattern(l) "in" hyp(id) :=
+Tactic Notation "destruct_call" constr(f) "as" simple_intropattern(l) "in" var(id) :=
   destruct_call_as_in f l id.
 
 (** A marker for prototypes to destruct. *)

--- a/theories/setoid_ring/Field_tac.v
+++ b/theories/setoid_ring/Field_tac.v
@@ -276,7 +276,7 @@ Tactic Notation (at level 0)
   let G := Get_goal in
   field_lookup (PackField Field_simplify) [lH] rl G.
 
-Tactic Notation "field_simplify" constr_list(rl) "in" hyp(H):=
+Tactic Notation "field_simplify" constr_list(rl) "in" var(H):=
   let G := Get_goal in
   let t := type of H in
   let g := fresh "goal" in
@@ -287,7 +287,7 @@ Tactic Notation "field_simplify" constr_list(rl) "in" hyp(H):=
   unfold g;clear g.
 
 Tactic Notation "field_simplify"
-    "["constr_list(lH) "]" constr_list(rl) "in" hyp(H):=
+    "["constr_list(lH) "]" constr_list(rl) "in" var(H):=
   let G := Get_goal in
   let t := type of H in
   let g := fresh "goal" in
@@ -302,12 +302,12 @@ Ltac Field_simplify_in hyp:=
    Field_simplify_gen ltac:(fun H => rewrite H in hyp).
 
 Tactic Notation (at level 0)
-  "field_simplify" constr_list(rl) "in" hyp(h) :=
+  "field_simplify" constr_list(rl) "in" var(h) :=
   let t := type of h in
   field_lookup (Field_simplify_in h) [] rl t.
 
 Tactic Notation (at level 0)
-  "field_simplify" "[" constr_list(lH) "]" constr_list(rl) "in" hyp(h) :=
+  "field_simplify" "[" constr_list(lH) "]" constr_list(rl) "in" var(h) :=
   let t := type of h in
   field_lookup (Field_simplify_in h) [lH] rl t.
 *)
@@ -412,7 +412,7 @@ Ltac FIELD_SIMPL_EQ FLD lH rl :=
   Field_simplify_eq Ring_tac.ring_subst_niter FLD lH;
   get_FldPost FLD ().
 
-Tactic Notation (at level 0) "field_simplify_eq" "in" hyp(H) :=
+Tactic Notation (at level 0) "field_simplify_eq" "in" var(H) :=
   let t := type of H in
   generalize H;
   field_lookup (PackField FIELD_SIMPL_EQ) [] t;
@@ -421,7 +421,7 @@ Tactic Notation (at level 0) "field_simplify_eq" "in" hyp(H) :=
 
 
 Tactic Notation (at level 0)
-  "field_simplify_eq" "[" constr_list(lH) "]"  "in" hyp(H) :=
+  "field_simplify_eq" "[" constr_list(lH) "]"  "in" var(H) :=
   let t := type of H in
   generalize H;
   field_lookup (PackField FIELD_SIMPL_EQ) [lH] t;

--- a/theories/setoid_ring/Ring_tac.v
+++ b/theories/setoid_ring/Ring_tac.v
@@ -431,7 +431,7 @@ Tactic Notation (at level 0)
   let G := Get_goal in
   ring_lookup (PackRing Ring_simplify) [lH] rl G.
 
-Tactic Notation "ring_simplify" constr_list(rl) "in" hyp(H):=
+Tactic Notation "ring_simplify" constr_list(rl) "in" var(H):=
   let G := Get_goal in
   let t := type of H in
   let g := fresh "goal" in
@@ -451,7 +451,7 @@ Tactic Notation "ring_simplify" constr_list(rl) "in" hyp(H):=
   clear H;rename H' into H;
   unfold g;clear g.
 
-Tactic Notation "ring_simplify" "["constr_list(lH)"]" constr_list(rl) "in" hyp(H):=
+Tactic Notation "ring_simplify" "["constr_list(lH)"]" constr_list(rl) "in" var(H):=
   let G := Get_goal in
   let t := type of H in
   let g := fresh "goal" in


### PR DESCRIPTION
This seems unnecessary as the same can be achieved in `Tacarg`.

It seems that going thru a deprecation phase could be convenient.

- [ ] Entry added in the changelog