### PR TITLE
[ocamformat] Update to 0.13.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ stages:
 variables:
   # Format: $IMAGE-V$DATE [Cache is not used as of today but kept here
   # for reference]
-  CACHEKEY: "bionic_coq-V2020-03-19-V93"
+  CACHEKEY: "bionic_coq-V2020-03-19-V29"
   IMAGE: "$CI_REGISTRY_IMAGE:$CACHEKEY"
   # By default, jobs run in the base switch; override to select another switch
   OPAM_SWITCH: "base"

--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,3 +1,4 @@
+version=0.13.0
 profile=ocamlformat
 module-item-spacing=compact
 sequence-style=terminator

--- a/Makefile.dune
+++ b/Makefile.dune
@@ -102,7 +102,7 @@ release: voboot
 	dune build $(DUNEOPT) -p coq
 
 fmt: voboot
-	dune build @fmt
+	dune build @fmt --auto-promote
 
 ocheck: voboot
 	dune build $(DUNEOPT) @install --workspace=dev/dune-workspace.all

--- a/dev/ci/docker/bionic_coq/Dockerfile
+++ b/dev/ci/docker/bionic_coq/Dockerfile
@@ -1,4 +1,4 @@
-# CACHEKEY: "bionic_coq-V2020-03-19-V93"
+# CACHEKEY: "bionic_coq-V2020-03-19-V29"
 # ^^ Update when modifying this file.
 
 FROM ubuntu:bionic
@@ -57,7 +57,7 @@ RUN opam switch create "${COMPILER}+32bit" && eval $(opam env) && \
 
 # EDGE switch
 ENV COMPILER_EDGE="4.09.1" \
-    BASE_OPAM_EDGE="dune-release.1.3.3 ocamlformat.0.12"
+    BASE_OPAM_EDGE="dune-release.1.3.3 ocamlformat.0.13.0"
 
 # EDGE+flambda switch, we install CI_OPAM as to be able to use
 # `ci-template-flambda` with everything.

--- a/dev/doc/changes.md
+++ b/dev/doc/changes.md
@@ -1,19 +1,19 @@
 ## Changes between Coq 8.11 and Coq 8.12
 
-### ML API
+### Code formatting
 
-Refiner.catchable_exception is deprecated, use instead
-CErrors.noncritical in try-with block. Note that nothing is needed in
-tclORELSE block since the exceptions there are supposed to be
-non-critical by construction.
-
-### ML API
-
-Types `precedence`, `parenRelation`, `tolerability` in
-`notgram_ops.ml` have been reworked. See `entry_level` and
-`entry_relative_level` in `constrexpr.ml`.
+- The automatic code formatting tool `ocamlformat` is enabled now for
+  the micromega codebase. Version 0.13.0 is required. See
+  `ocalmformat`'s documentation for more details on integration with
+  your editor.
 
 ### ML API
+
+Notations:
+
+- Types `precedence`, `parenRelation`, `tolerability` in
+  `notgram_ops.ml` have been reworked. See `entry_level` and
+  `entry_relative_level` in `constrexpr.ml`.
 
 Exception handling:
 
@@ -27,6 +27,11 @@ Exception handling:
 
   + printers are of type `exn -> Pp.t option` [`None` == not handled]
   + it is forbidden for exception printers to raise.
+
+- Refiner.catchable_exception is deprecated, use instead
+  CErrors.noncritical in try-with block. Note that nothing is needed in
+  tclORELSE block since the exceptions there are supposed to be
+  non-critical by construction.
 
 Printers:
 


### PR DESCRIPTION
We include the `version=0.13.0` field that should help users not to
use the wrong version. `disable=true` still seems a noop with `dune`.

There are some minor changes in the way comments are formatted; I'm
unsure if this is due to the `wrap-comments` option; as always; tweaks
to the config are most welcome.