### PR TITLE
[proof] consolidation of mutual definition declaration path

### DIFF
--- a/tactics/proof_global.ml
+++ b/tactics/proof_global.ml
@@ -8,14 +8,6 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(***********************************************************************)
-(*                                                                     *)
-(*      This module defines proof facilities relevant to the           *)
-(*      toplevel. In particular it defines the global proof            *)
-(*      environment.                                                   *)
-(*                                                                     *)
-(***********************************************************************)
-
 open Util
 open Names
 open Context

--- a/tactics/proof_global.mli
+++ b/tactics/proof_global.mli
@@ -8,9 +8,7 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-(** This module defines proof facilities relevant to the
-     toplevel. In particular it defines the global proof
-     environment. *)
+(** State for interactive proofs. *)
 
 type t
 

--- a/vernac/comFixpoint.ml
+++ b/vernac/comFixpoint.ml
@@ -279,12 +279,10 @@ let declare_fixpoint_generic ?indexes ~scope ~poly ((fixnames,fixrs,fixdefs,fixt
   let fiximps = List.map (fun (n,r,p) -> r) fiximps in
   let evd = Evd.from_ctx ctx in
   let evd = Evd.restrict_universe_context evd vars in
-  let ctx = Evd.check_univ_decl ~poly evd pl in
+  let univs = Evd.check_univ_decl ~poly evd pl in
   let ubind = Evd.universe_binders evd in
   let _ : GlobRef.t list =
-    List.map4 (fun name body types impargs ->
-        let ce = Declare.definition_entry ~opaque:false ~types ~univs:ctx body in
-        DeclareDef.declare_definition ~name ~scope ~kind:fix_kind ~ubind ~impargs ce)
+    DeclareDef.declare_mutually_recursive ~scope ~opaque:false ~univs ~kind:fix_kind ~ubind
       fixnames fixdecls fixtypes fiximps
   in
   Declare.recursive_message (not cofix) gidx fixnames;

--- a/vernac/comFixpoint.ml
+++ b/vernac/comFixpoint.ml
@@ -282,10 +282,9 @@ let declare_fixpoint_generic ?indexes ~scope ~poly ((fixnames,fixrs,fixdefs,fixt
   let univs = Evd.check_univ_decl ~poly evd pl in
   let ubind = Evd.universe_binders evd in
   let _ : GlobRef.t list =
-    DeclareDef.declare_mutually_recursive ~indexes ~cofix ~scope ~opaque:false ~univs ~kind:fix_kind ~ubind
+    DeclareDef.declare_mutually_recursive ~indexes ~cofix ~scope ~opaque:false ~univs ~kind:fix_kind ~ubind ~ntns
       fixnames fixdecls fixtypes fiximps
   in
-  List.iter (Metasyntax.add_notation_interpretation (Global.env())) ntns;
   ()
 
 let extract_decreasing_argument ~structonly { CAst.v = v; _ } =

--- a/vernac/comFixpoint.ml
+++ b/vernac/comFixpoint.ml
@@ -264,7 +264,7 @@ let declare_fixpoint_generic ?indexes ~scope ~poly ((fixnames,fixrs,fixdefs,fixt
   (* We shortcut the proof process *)
   let fixdefs = List.map Option.get fixdefs in
   let fixdecls = prepare_recursive_declaration fixnames fixrs fixtypes fixdefs in
-  let vars, fixdecls, gidx =
+  let vars, fixdecls, indexes =
     if not cofix then
       let env = Global.env() in
       let indexes = Pretyping.search_guard env indexes fixdecls in
@@ -282,10 +282,9 @@ let declare_fixpoint_generic ?indexes ~scope ~poly ((fixnames,fixrs,fixdefs,fixt
   let univs = Evd.check_univ_decl ~poly evd pl in
   let ubind = Evd.universe_binders evd in
   let _ : GlobRef.t list =
-    DeclareDef.declare_mutually_recursive ~scope ~opaque:false ~univs ~kind:fix_kind ~ubind
+    DeclareDef.declare_mutually_recursive ~indexes ~cofix ~scope ~opaque:false ~univs ~kind:fix_kind ~ubind
       fixnames fixdecls fixtypes fiximps
   in
-  Declare.recursive_message (not cofix) gidx fixnames;
   List.iter (Metasyntax.add_notation_interpretation (Global.env())) ntns;
   ()
 

--- a/vernac/comFixpoint.ml
+++ b/vernac/comFixpoint.ml
@@ -236,16 +236,22 @@ let interp_fixpoint ~cofix l =
   let uctx,fix = ground_fixpoint env evd fix in
   (fix,pl,uctx,info)
 
-let declare_fixpoint_interactive_generic ?indexes ~scope ~poly ((fixnames,_fixrs,fixdefs,fixtypes),udecl,ctx,fiximps) ntns =
-  let fix_kind, cofix, indexes = match indexes with
-    | Some indexes -> Decls.Fixpoint, false, indexes
-    | None -> Decls.CoFixpoint, true, []
+let build_recthms ~indexes fixnames fixtypes fiximps =
+  let fix_kind, cofix = match indexes with
+    | Some indexes -> Decls.Fixpoint, false
+    | None -> Decls.CoFixpoint, true
   in
   let thms =
     List.map3 (fun name typ (ctx,impargs,_) ->
-        { Lemmas.Recthm.name; typ
+        { DeclareDef.Recthm.name; typ
         ; args = List.map Context.Rel.Declaration.get_name ctx; impargs})
-      fixnames fixtypes fiximps in
+      fixnames fixtypes fiximps
+  in
+  fix_kind, cofix, thms
+
+let declare_fixpoint_interactive_generic ?indexes ~scope ~poly ((fixnames,_fixrs,fixdefs,fixtypes),udecl,ctx,fiximps) ntns =
+  let fix_kind, cofix, thms = build_recthms ~indexes fixnames fixtypes fiximps in
+  let indexes = Option.default [] indexes in
   let init_terms = Some fixdefs in
   let evd = Evd.from_ctx ctx in
   let lemma =
@@ -256,19 +262,15 @@ let declare_fixpoint_interactive_generic ?indexes ~scope ~poly ((fixnames,_fixrs
   lemma
 
 let declare_fixpoint_generic ?indexes ~scope ~poly ((fixnames,fixrs,fixdefs,fixtypes),udecl,uctx,fiximps) ntns =
-  let possible_indexes, fix_kind =
-    match indexes with
-    | Some indexes -> Some indexes, Decls.(IsDefinition Fixpoint)
-    | None -> None, Decls.(IsDefinition CoFixpoint)
-  in
   (* We shortcut the proof process *)
+  let fix_kind, cofix, fixitems = build_recthms ~indexes fixnames fixtypes fiximps in
   let fixdefs = List.map Option.get fixdefs in
   let rec_declaration = prepare_recursive_declaration fixnames fixrs fixtypes fixdefs in
-  let fiximps = List.map (fun (n,r,p) -> r) fiximps in
+  let fix_kind = Decls.IsDefinition fix_kind in
   let _ : GlobRef.t list =
     DeclareDef.declare_mutually_recursive ~scope ~opaque:false ~kind:fix_kind ~poly ~uctx
-      ~possible_indexes ~restrict_ucontext:true ~udecl ~ntns ~rec_declaration
-      fixnames fixtypes fiximps
+      ~possible_indexes:indexes ~restrict_ucontext:true ~udecl ~ntns ~rec_declaration
+      fixitems
   in
   ()
 

--- a/vernac/declareDef.ml
+++ b/vernac/declareDef.ml
@@ -69,6 +69,13 @@ let declare_definition ~name ~scope ~kind ?hook_data ~ubind ~impargs ce =
   end;
   dref
 
+let declare_mutually_recursive ~opaque ~univs ~scope ~kind ~ubind fixnames fixdecls fixtypes fiximps =
+  CList.map4
+    (fun name body types impargs ->
+       let ce = Declare.definition_entry ~opaque ~types ~univs body in
+       declare_definition ~name ~scope ~kind ~ubind ~impargs ce)
+    fixnames fixdecls fixtypes fiximps
+
 let warn_let_as_axiom =
   CWarnings.create ~name:"let-as-axiom" ~category:"vernacular"
     Pp.(fun id -> strbrk "Let definition" ++ spc () ++ Names.Id.print id ++

--- a/vernac/declareDef.ml
+++ b/vernac/declareDef.ml
@@ -69,12 +69,15 @@ let declare_definition ~name ~scope ~kind ?hook_data ~ubind ~impargs ce =
   end;
   dref
 
-let declare_mutually_recursive ~opaque ~univs ~scope ~kind ~ubind fixnames fixdecls fixtypes fiximps =
-  CList.map4
-    (fun name body types impargs ->
-       let ce = Declare.definition_entry ~opaque ~types ~univs body in
-       declare_definition ~name ~scope ~kind ~ubind ~impargs ce)
-    fixnames fixdecls fixtypes fiximps
+let declare_mutually_recursive ~cofix ~indexes ~opaque ~univs ~scope ~kind ~ubind fixnames fixdecls fixtypes fiximps =
+  let csts = CList.map4
+      (fun name body types impargs ->
+         let ce = Declare.definition_entry ~opaque ~types ~univs body in
+         declare_definition ~name ~scope ~kind ~ubind ~impargs ce)
+      fixnames fixdecls fixtypes fiximps
+  in
+  Declare.recursive_message (not cofix) indexes fixnames;
+  csts
 
 let warn_let_as_axiom =
   CWarnings.create ~name:"let-as-axiom" ~category:"vernacular"

--- a/vernac/declareDef.ml
+++ b/vernac/declareDef.ml
@@ -69,7 +69,7 @@ let declare_definition ~name ~scope ~kind ?hook_data ~ubind ~impargs ce =
   end;
   dref
 
-let declare_mutually_recursive ~cofix ~indexes ~opaque ~univs ~scope ~kind ~ubind fixnames fixdecls fixtypes fiximps =
+let declare_mutually_recursive ~cofix ~indexes ~opaque ~univs ~scope ~kind ~ubind ~ntns fixnames fixdecls fixtypes fiximps =
   let csts = CList.map4
       (fun name body types impargs ->
          let ce = Declare.definition_entry ~opaque ~types ~univs body in
@@ -77,6 +77,7 @@ let declare_mutually_recursive ~cofix ~indexes ~opaque ~univs ~scope ~kind ~ubin
       fixnames fixdecls fixtypes fiximps
   in
   Declare.recursive_message (not cofix) indexes fixnames;
+  List.iter (Metasyntax.add_notation_interpretation (Global.env())) ntns;
   csts
 
 let warn_let_as_axiom =

--- a/vernac/declareDef.ml
+++ b/vernac/declareDef.ml
@@ -95,11 +95,11 @@ module Recthm = struct
     }
 end
 
-let declare_mutually_recursive ~opaque ~scope ~kind ~poly ~uctx ~udecl ~ntns ~rec_declaration ~possible_indexes ~restrict_ucontext fixitems =
+let declare_mutually_recursive ~opaque ~scope ~kind ~poly ~uctx ~udecl ~ntns ~rec_declaration ~possible_indexes ?(restrict_ucontext=true) fixitems =
   let vars, fixdecls, indexes =
     mutual_make_bodies ~fixitems ~rec_declaration ~possible_indexes in
   let ubind, univs =
-    (* XXX: Note that obligations don't do this, is that a bug? *)
+    (* XXX: Obligations don't do this, this seems like a bug? *)
     if restrict_ucontext
     then
       let evd = Evd.from_ctx uctx in

--- a/vernac/declareDef.mli
+++ b/vernac/declareDef.mli
@@ -59,6 +59,18 @@ val declare_assumption
   -> Entries.parameter_entry
   -> GlobRef.t
 
+val declare_mutually_recursive
+  : opaque:bool
+  -> univs:Entries.universes_entry
+  -> scope:locality
+  -> kind:Decls.logical_kind
+  -> ubind:UnivNames.universe_binders
+  -> Names.variable list
+  -> Constr.constr list
+  -> Constr.types list
+  -> Impargs.manual_implicits list
+  -> Names.GlobRef.t list
+
 val prepare_definition
   :  allow_evars:bool
   -> ?opaque:bool

--- a/vernac/declareDef.mli
+++ b/vernac/declareDef.mli
@@ -59,6 +59,19 @@ val declare_assumption
   -> Entries.parameter_entry
   -> GlobRef.t
 
+module Recthm : sig
+  type t =
+    { name : Id.t
+    (** Name of theorem *)
+    ; typ : Constr.t
+    (** Type of theorem  *)
+    ; args : Name.t list
+    (** Names to pre-introduce  *)
+    ; impargs : Impargs.manual_implicits
+    (** Explicitily declared implicit arguments  *)
+    }
+end
+
 val declare_mutually_recursive
   : opaque:bool
   -> scope:locality
@@ -70,9 +83,7 @@ val declare_mutually_recursive
   -> rec_declaration:Constr.rec_declaration
   -> possible_indexes:int list list option
   -> restrict_ucontext:bool
-  -> Names.variable list
-  -> Constr.types list
-  -> Impargs.manual_implicits list
+  -> Recthm.t list
   -> Names.GlobRef.t list
 
 val prepare_definition

--- a/vernac/declareDef.mli
+++ b/vernac/declareDef.mli
@@ -60,7 +60,9 @@ val declare_assumption
   -> GlobRef.t
 
 val declare_mutually_recursive
-  : opaque:bool
+  : cofix:bool
+  -> indexes:int array option
+  -> opaque:bool
   -> univs:Entries.universes_entry
   -> scope:locality
   -> kind:Decls.logical_kind

--- a/vernac/declareDef.mli
+++ b/vernac/declareDef.mli
@@ -59,6 +59,14 @@ val declare_assumption
   -> Entries.parameter_entry
   -> GlobRef.t
 
+(* Returns [uvars, bodies, indexes], [possible_indexes] determines if
+   we are in a fix / cofix case *)
+val mutual_make_bodies
+  : fixnames:'a list
+  -> rec_declaration:Constr.rec_declaration
+  -> possible_indexes:int list list option
+  -> Univ.LSet.t * Constr.constr list * int array option
+
 val declare_mutually_recursive
   : cofix:bool
   -> indexes:int array option

--- a/vernac/declareDef.mli
+++ b/vernac/declareDef.mli
@@ -59,25 +59,18 @@ val declare_assumption
   -> Entries.parameter_entry
   -> GlobRef.t
 
-(* Returns [uvars, bodies, indexes], [possible_indexes] determines if
-   we are in a fix / cofix case *)
-val mutual_make_bodies
-  : fixnames:'a list
-  -> rec_declaration:Constr.rec_declaration
-  -> possible_indexes:int list list option
-  -> Univ.LSet.t * Constr.constr list * int array option
-
 val declare_mutually_recursive
-  : cofix:bool
-  -> indexes:int array option
-  -> opaque:bool
-  -> univs:Entries.universes_entry
+  : opaque:bool
   -> scope:locality
   -> kind:Decls.logical_kind
-  -> ubind:UnivNames.universe_binders
+  -> poly:bool
+  -> uctx:UState.t
+  -> udecl:UState.universe_decl
   -> ntns:Vernacexpr.decl_notation list
+  -> rec_declaration:Constr.rec_declaration
+  -> possible_indexes:int list list option
+  -> restrict_ucontext:bool
   -> Names.variable list
-  -> Constr.constr list
   -> Constr.types list
   -> Impargs.manual_implicits list
   -> Names.GlobRef.t list

--- a/vernac/declareDef.mli
+++ b/vernac/declareDef.mli
@@ -67,6 +67,7 @@ val declare_mutually_recursive
   -> scope:locality
   -> kind:Decls.logical_kind
   -> ubind:UnivNames.universe_binders
+  -> ntns:Vernacexpr.decl_notation list
   -> Names.variable list
   -> Constr.constr list
   -> Constr.types list

--- a/vernac/declareDef.mli
+++ b/vernac/declareDef.mli
@@ -82,7 +82,9 @@ val declare_mutually_recursive
   -> ntns:Vernacexpr.decl_notation list
   -> rec_declaration:Constr.rec_declaration
   -> possible_indexes:int list list option
-  -> restrict_ucontext:bool
+  -> ?restrict_ucontext:bool
+  (** XXX: restrict_ucontext should be always true, this seems like a
+     bug in obligations, so this parameter should go away *)
   -> Recthm.t list
   -> Names.GlobRef.t list
 

--- a/vernac/declareObl.ml
+++ b/vernac/declareObl.ml
@@ -467,14 +467,11 @@ let declare_mutual_definition l =
   let kind = Decls.IsDefinition (if fixkind != IsCoFixpoint then Decls.Fixpoint else Decls.CoFixpoint) in
   let ubind = UnivNames.empty_binders in
   let cofix = fixkind = IsCoFixpoint in
+  let ntns = first.prg_notations in
   let kns =
-    DeclareDef.declare_mutually_recursive ~cofix ~indexes ~scope ~opaque ~univs ~kind ~ubind
+    DeclareDef.declare_mutually_recursive ~cofix ~indexes ~scope ~opaque ~univs ~kind ~ubind ~ntns
       fixnames fixdecls fixtypes fiximps
   in
-  (* Declare notations *)
-  List.iter
-    (Metasyntax.add_notation_interpretation (Global.env ()))
-    first.prg_notations;
   (* Only for the first constant *)
   let dref = List.hd kns in
   DeclareDef.Hook.(call ?hook:first.prg_hook ~fix_exn { S.uctx = first.prg_ctx; obls; scope; dref });

--- a/vernac/declareObl.ml
+++ b/vernac/declareObl.ml
@@ -466,15 +466,15 @@ let declare_mutual_definition l =
   let fix_exn = Hook.get get_fix_exn () in
   let kind = Decls.IsDefinition (if fixkind != IsCoFixpoint then Decls.Fixpoint else Decls.CoFixpoint) in
   let ubind = UnivNames.empty_binders in
+  let cofix = fixkind = IsCoFixpoint in
   let kns =
-    DeclareDef.declare_mutually_recursive ~scope ~opaque ~univs ~kind ~ubind
+    DeclareDef.declare_mutually_recursive ~cofix ~indexes ~scope ~opaque ~univs ~kind ~ubind
       fixnames fixdecls fixtypes fiximps
   in
   (* Declare notations *)
   List.iter
     (Metasyntax.add_notation_interpretation (Global.env ()))
     first.prg_notations;
-  Declare.recursive_message (fixkind != IsCoFixpoint) indexes fixnames;
   (* Only for the first constant *)
   let dref = List.hd kns in
   DeclareDef.Hook.(call ?hook:first.prg_hook ~fix_exn { S.uctx = first.prg_ctx; obls; scope; dref });

--- a/vernac/declareObl.ml
+++ b/vernac/declareObl.ml
@@ -467,10 +467,7 @@ let declare_mutual_definition l =
   let kind = Decls.IsDefinition (if fixkind != IsCoFixpoint then Decls.Fixpoint else Decls.CoFixpoint) in
   let ubind = UnivNames.empty_binders in
   let kns =
-    List.map4
-      (fun name body types impargs ->
-         let ce = Declare.definition_entry ~opaque ~types ~univs body in
-         DeclareDef.declare_definition ~name ~scope ~kind ~ubind ~impargs ce)
+    DeclareDef.declare_mutually_recursive ~scope ~opaque ~univs ~kind ~ubind
       fixnames fixdecls fixtypes fiximps
   in
   (* Declare notations *)
@@ -478,6 +475,7 @@ let declare_mutual_definition l =
     (Metasyntax.add_notation_interpretation (Global.env ()))
     first.prg_notations;
   Declare.recursive_message (fixkind != IsCoFixpoint) indexes fixnames;
+  (* Only for the first constant *)
   let dref = List.hd kns in
   DeclareDef.Hook.(call ?hook:first.prg_hook ~fix_exn { S.uctx = first.prg_ctx; obls; scope; dref });
   List.iter progmap_remove l;

--- a/vernac/declareObl.ml
+++ b/vernac/declareObl.ml
@@ -450,15 +450,13 @@ let declare_mutual_definition l =
   in
   (* In the future we will pack all this in a proper record *)
   let poly, scope, ntns, opaque, fixnames = first.prg_poly, first.prg_scope, first.prg_notations, first.prg_opaque, first.prg_deps in
-  let kind, cofix = if fixkind != IsCoFixpoint then Decls.(IsDefinition Fixpoint, false) else Decls.(IsDefinition CoFixpoint, true) in
-  let univs = UState.univ_entry ~poly first.prg_ctx in
-  let ubind = UnivNames.empty_binders in
-  (* XXX: Note that obligations doesn't call restrict_universe_context *)
-  let _vars, fixdecls, indexes = DeclareDef.mutual_make_bodies ~fixnames ~rec_declaration ~possible_indexes in
+  let kind = if fixkind != IsCoFixpoint then Decls.(IsDefinition Fixpoint) else Decls.(IsDefinition CoFixpoint) in
   (* Declare the recursive definitions *)
+  let udecl = UState.default_univ_decl in
   let kns =
-    DeclareDef.declare_mutually_recursive ~cofix ~indexes ~scope ~opaque ~univs ~kind ~ubind ~ntns
-      fixnames fixdecls fixtypes fiximps
+    DeclareDef.declare_mutually_recursive ~scope ~opaque ~kind
+      ~udecl ~ntns ~uctx:first.prg_ctx ~rec_declaration ~possible_indexes
+      ~poly ~restrict_ucontext:false fixnames fixtypes fiximps
   in
   (* Only for the first constant *)
   let fix_exn = Hook.get get_fix_exn () in

--- a/vernac/lemmas.mli
+++ b/vernac/lemmas.mli
@@ -44,19 +44,6 @@ module Proof_ending : sig
 
 end
 
-module Recthm : sig
-  type t =
-    { name : Id.t
-    (** Name of theorem *)
-    ; typ : Constr.t
-    (** Type of theorem  *)
-    ; args : Name.t list
-    (** Names to pre-introduce  *)
-    ; impargs : Impargs.manual_implicits
-    (** Explicitily declared implicit arguments  *)
-    }
-end
-
 module Info : sig
 
   type t
@@ -104,7 +91,7 @@ val start_lemma_with_initialization
   -> udecl:UState.universe_decl
   -> Evd.evar_map
   -> (bool * lemma_possible_guards * Constr.t option list option) option
-  -> Recthm.t list
+  -> DeclareDef.Recthm.t list
   -> int list option
   -> t
 

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -501,7 +501,7 @@ let start_lemma_com ~program_mode ~poly ~scope ~kind ?hook thms =
   let recguard,thms,snl = RecLemmas.look_for_possibly_mutual_statements evd thms in
   let evd = Evd.minimize_universes evd in
   let thms = List.map (fun (name, (typ, (args, impargs))) ->
-      { Lemmas.Recthm.name; typ = EConstr.to_constr evd typ; args; impargs} ) thms in
+      { DeclareDef.Recthm.name; typ = EConstr.to_constr evd typ; args; impargs} ) thms in
   let () =
     let open UState in
     if not (udecl.univdecl_extensible_instance && udecl.univdecl_extensible_constraints) then


### PR DESCRIPTION
In the style of #11016 , we consolidate all the duplicated code for the declaration of mutually-recursive definitions.

This does enable finer control over certain invariants, however we cannot fully seal the type [as #11016 does for the interactive path] without actually removing the duplication in the save proof path of `Proof_global` and `Declare/DeclareDef`. On the other hand this PR makes this very close to happen so that would be great news.

Depends on #11016 and #11731 .