### PR TITLE
Remove parallel building of Sphinx documentation.

### DIFF
--- a/doc/dune
+++ b/doc/dune
@@ -14,7 +14,7 @@
   unreleased.rst
   (env_var SPHINXWARNOPT))
  (action
-  (run env COQLIB=%{project_root} sphinx-build -j4 %{env:SPHINXWARNOPT=-W} -b html -d sphinx_build/doctrees sphinx sphinx_build/html)))
+  (run env COQLIB=%{project_root} sphinx-build %{env:SPHINXWARNOPT=-W} -b html -d sphinx_build/doctrees sphinx sphinx_build/html)))
 
 (alias
  (name refman-html)


### PR DESCRIPTION
Since version 1.0.0 of the sphinxcontrib-bibtex extension, parallel building of the Sphinx documentation emits a warning (and thus makes our warning-free build fail).

This change was already done in Makefile.doc as part of #11732.

**Kind:** infrastructure / fix.