### PR TITLE
Dune build rules for doc_grammar and fullGrammar.

### DIFF
--- a/coqpp/dune
+++ b/coqpp/dune
@@ -1,9 +1,15 @@
 (ocamllex coqpp_lex)
 (ocamlyacc coqpp_parse)
 
+(library
+ (name coqpp)
+ (wrapped false)
+ (modules coqpp_ast coqpp_lex coqpp_parse coqpp_parser)
+ (modules_without_implementation coqpp_ast))
+
 (executable
  (name coqpp_main)
  (public_name coqpp)
  (package coq)
- (modules coqpp_ast coqpp_lex coqpp_parse coqpp_parser coqpp_main)
- (modules_without_implementation coqpp_ast))
+ (libraries coqpp)
+ (modules coqpp_main))

--- a/doc/tools/docgram/README.md
+++ b/doc/tools/docgram/README.md
@@ -1,12 +1,13 @@
 # Grammar extraction tool for documentation
 
-`doc_grammar` extracts Coq's grammar from `.mlg` files, edits it and inserts it in
-chunks into `.rst` files.  The tool currently inserts Sphinx
-`productionlist` constructs.  It also generates a file with `prodn` constructs
-for the entire grammar, but updates to `tacn` and `cmd` constructs must be done
-manually since the grammar doesn't have names for them as it does for
-nonterminals.  There is an option to report which `tacn` and `cmd` were not
-found in the `.rst` files.  `tacv` and `cmdv` constructs are not processed at all.
+`doc_grammar` extracts Coq's grammar from `.mlg` files, edits it and
+inserts it in chunks into `.rst` files.  The tool currently inserts
+Sphinx `productionlist` and `prodn` constructs (`productionlist` are
+gradually being replaced by `prodn` in the manual).  Updates to `tacn`
+and `cmd` constructs must be done manually since the grammar doesn't
+have names for them as it does for nonterminals.  There is an option
+to report which `tacn` and `cmd` were not found in the `.rst` files.
+`tacv` and `cmdv` constructs are not processed at all.
 
 The mlg grammars present several challenges to generating an accurate grammar
 for documentation purposes:

--- a/doc/tools/docgram/dune
+++ b/doc/tools/docgram/dune
@@ -1,0 +1,30 @@
+(executable
+ (name doc_grammar)
+ (libraries coq.clib coqpp))
+
+(env (_ (binaries doc_grammar.exe)))
+
+(rule
+ (targets fullGrammar)
+ (deps
+  ; Main grammar
+  (glob_files %{project_root}/parsing/*.mlg)
+  (glob_files %{project_root}/toplevel/*.mlg)
+  (glob_files %{project_root}/vernac/*.mlg)
+  ; All plugins except SSReflect for now (mimicking what is done in Makefile.doc)
+  (glob_files %{project_root}/plugins/btauto/*.mlg)
+  (glob_files %{project_root}/plugins/cc/*.mlg)
+  (glob_files %{project_root}/plugins/derive/*.mlg)
+  (glob_files %{project_root}/plugins/extraction/*.mlg)
+  (glob_files %{project_root}/plugins/firstorder/*.mlg)
+  (glob_files %{project_root}/plugins/funind/*.mlg)
+  (glob_files %{project_root}/plugins/ltac/*.mlg)
+  (glob_files %{project_root}/plugins/micromega/*.mlg)
+  (glob_files %{project_root}/plugins/nsatz/*.mlg)
+  (glob_files %{project_root}/plugins/omega/*.mlg)
+  (glob_files %{project_root}/plugins/rtauto/*.mlg)
+  (glob_files %{project_root}/plugins/setoid_ring/*.mlg)
+  (glob_files %{project_root}/plugins/syntax/*.mlg))
+ (action
+  (chdir %{project_root} (run doc_grammar -short -no-warn %{deps})))
+ (mode promote))


### PR DESCRIPTION
**Kind:** infrastructure.

cc @jfehrle 

Notes:
- I cannot go further and have a rule update, e.g. `orderedGrammar` or the rst files because Dune won't accept a file being both a dependency and a target of a rule. We need to change the model this tool follows to be compatible with Dune. For the rst files, we could generate files containing grammar chunks only and include them (using the appropriate Sphinx directive) in the main rst files.
- We cannot have multiple rules generating the same target. It would be better if the tool was able to use `fullGrammar` as input for the next steps.
- I didn't find any better way of providing the dependencies than listing them all explicitly.