### PR TITLE
Tests make bytecode

### DIFF
--- a/test-suite/coq-makefile/camldep/run.sh
+++ b/test-suite/coq-makefile/camldep/run.sh
@@ -13,5 +13,9 @@ mkdir src
 echo '{ let foo = () }' > src/file1.mlg
 echo 'let bar = File1.foo' > src/file2.ml
 coq_makefile -f _CoqProject -o Makefile
-make src/file2.cmx
-[ -f src/file2.cmx ]
+if which ocamlopt >/dev/null 2>&1; then
+    make src/file2.cmx
+    [ -f src/file2.cmx ]
+fi
+make src/file2.cmo
+[ -f src/file2.cmo ]

--- a/test-suite/coq-makefile/findlib-package-unpacked/run.sh
+++ b/test-suite/coq-makefile/findlib-package-unpacked/run.sh
@@ -16,5 +16,7 @@ coq_makefile -f _CoqProject -o Makefile
 cat Makefile.conf
 cat Makefile.local
 make -C findlib/foo
-make
+if which ocamlopt >/dev/null 2>&1; then
+    make
+fi
 make byte


### PR DESCRIPTION
**Kind:**infrastructure.



- Updated test-suite

Fix two test cases so that they also work on bytecode-only architectures
