### PR TITLE
[ci] [gitlab] Move VST to `allow_failure`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -697,6 +697,7 @@ library:ci-verdi-raft:
 
 library:ci-vst:
   extends: .ci-template-flambda
+  allow_failure: true
 
 # Plugins are by definition the projects that depend on Coq's ML API
 


### PR DESCRIPTION
VST has been broken for a few days, moving to allow failure.