### PR TITLE
Forbid Prop-living inductive types to be template.

### DIFF
--- a/kernel/indTyping.ml
+++ b/kernel/indTyping.ml
@@ -218,8 +218,7 @@ let template_polymorphic_univs ~ctor_levels uctx paramsctxt concl =
     | LocalDef _ -> acc
   in
   let params = List.fold_left fold [] paramsctxt in
-  if Universe.is_type0m concl then Some (univs, params)
-  else if not @@ Univ.LSet.is_empty univs then Some (univs, params)
+  if not @@ Univ.LSet.is_empty univs then Some (univs, params)
   else None
 
 let get_param_levels ctx params arity splayed_lc =

--- a/theories/ssr/ssrbool.v
+++ b/theories/ssr/ssrbool.v
@@ -1562,7 +1562,6 @@ Notation "[ 'qualify' 'an' x : T | P ]" :=
 Section KeyPred.
 
 Variable T : Type.
-#[universes(template)]
 Variant pred_key (p : {pred T}) := DefaultPredKey.
 
 Variable p : {pred T}.

--- a/theories/ssr/ssreflect.v
+++ b/theories/ssr/ssreflect.v
@@ -237,7 +237,6 @@ Inductive external_view : Type := tactic_view of Type.
 
 Module TheCanonical.
 
-#[universes(template)]
 Variant put vT sT (v1 v2 : vT) (s : sT) := Put.
 
 Definition get vT sT v s (p : @put vT sT v v s) := let: Put _ _ _ := p in s.
@@ -331,11 +330,9 @@ Notation "{ 'type' 'of' c 'for' s }" := (dependentReturnType c s) : type_scope.
    We also define a simpler version ("phant" / "Phant") of phantom for the
  common case where p_type is Type.                                           **)
 
-#[universes(template)]
 Variant phantom T (p : T) := Phantom.
 Arguments phantom : clear implicits.
 Arguments Phantom : clear implicits.
-#[universes(template)]
 Variant phant (p : Type) := Phant.
 
 (**  Internal tagging used by the implementation of the ssreflect elim.  **)

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -375,7 +375,9 @@ let interp_mutual_inductive_constr ~sigma ~template ~udecl ~ctx_params ~indnames
       indnames arities arityconcl constructors
   in
   let template = List.map4 (fun indname (templatearity, _) concl (_, ctypes) ->
-      let template_candidate () =
+      let template_candidate () = match concl with
+      | Some (Prop | Set | SProp) -> false
+      | None | Some (Type _) ->
         templatearity ||
         let ctor_levels =
           let add_levels c levels = Univ.LSet.union levels (Vars.universes_of_constr c) in


### PR DESCRIPTION
This does not bring anything, because they have the same typing rules in template and non-template mode.