### PR TITLE
[configure] Remove `-std=c99` from default C flags

### DIFF
--- a/configure.ml
+++ b/configure.ml
@@ -923,7 +923,11 @@ let datadir,datadirsuffix = let (_,_,d,s) = select "DATADIR" in d,s
 
 (** * CC runtime flags *)
 
-let cflags_dflt = "-Wall -Wno-unused -g -O2 -std=c99 -fasm"
+(* Note that Coq's VM requires at least C99-compliant floating-point
+   arithmetic; this should be ensured by OCaml's own C flags, which
+   set a minimum of [--std=gnu99] ; modern compilers by default assume
+   C11 or later, so no explicit [--std=] flags are added by OCaml *)
+let cflags_dflt = "-Wall -Wno-unused -g -O2"
 
 let cflags_sse2 = "-msse2 -mfpmath=sse"
 


### PR DESCRIPTION
Recent OCaml don't allow to build the VM with `--std=c99` anymore due
to changes in header files. `gnu99` is required, but it turns out this
is already enforced by OCaml, so we just remove the flag altogether.

See the discussion in #11432

Fixes #11940 , restores compatibility with OCaml 4.11