### PR TITLE
Remove a positivity check when Positivity Checking is off

### DIFF
--- a/doc/changelog/01-kernel/11811-uncheck_positivity_bug.rst
+++ b/doc/changelog/01-kernel/11811-uncheck_positivity_bug.rst
@@ -1,0 +1,4 @@
+- **Fixed:**
+  Allow more inductive types in `Unset Positivity Checking` mode
+  (`#11811 <https://github.com/coq/coq/pull/11811>`_,
+  by SimonBoulier).

--- a/kernel/indtypes.ml
+++ b/kernel/indtypes.ml
@@ -102,7 +102,7 @@ let failwith_non_pos_list n ntypes l =
 
 (* Check the inductive type is called with the expected parameters *)
 (* [n] is the index of the last inductive type in [env] *)
-let check_correct_par (env,n,ntypes,_) paramdecls ind_index args =
+let check_correct_par ~chkpos (env,n,ntypes,_) paramdecls ind_index args =
   let nparams = Context.Rel.nhyps paramdecls in
   let args = Array.of_list args in
   if Array.length args < nparams then
@@ -123,7 +123,7 @@ let check_correct_par (env,n,ntypes,_) paramdecls ind_index args =
               LocalNonPar (param_index+1, paramdecl_index_in_env, ind_index) in
             raise (IllFormedInd err)
   in check (nparams-1) (n-nparamdecls) paramdecls;
-  if not (Array.for_all (noccur_between n ntypes) realargs) then
+  if chkpos && not (Array.for_all (noccur_between n ntypes) realargs) then
     failwith_non_pos_vect n ntypes realargs
 
 (* Computes the maximum number of recursive parameters:
@@ -325,7 +325,7 @@ let check_positivity_one ~chkpos recursive (env,_,ntypes,_ as ienv) paramsctxt (
               if check_head then
                 begin match hd with
                 | Rel j when Int.equal j (n + ntypes - i - 1) ->
-                  check_correct_par ienv paramsctxt (ntypes - i) largs
+                  check_correct_par ~chkpos ienv paramsctxt (ntypes - i) largs
                 | _ -> raise (IllFormedInd (LocalNotConstructor(paramsctxt,nnonrecargs)))
                 end
               else

--- a/test-suite/bugs/closed/bug_11811.v
+++ b/test-suite/bugs/closed/bug_11811.v
@@ -1,0 +1,13 @@
+
+Unset Positivity Checking.
+
+Inductive foo : Type -> Type :=
+| bar : foo (foo unit)
+| baz : foo nat.
+
+Definition toto : forall A, foo A -> {A = foo unit} + {A = nat}.
+Proof.
+  intros A x. destruct x; intuition.
+Defined.
+
+Check (eq_refl : toto _ baz = right eq_refl).


### PR DESCRIPTION
**Kind:**  bug fix

Fixes : https://github.com/SimonBoulier/TypingFlags/issues/5

The positivity checker was not totally disabled when it was supposed to be. Now we can do:
```
Unset Positivity Checking.
Inductive foo : Type -> Type :=
| bar : foo (foo unit).
```
while before it failed with `Error: Non strictly positive occurrence of "foo" in "foo (foo unit)".`.

I don't know what we can do with those types but apparently it is useful for some people (https://github.com/SimonBoulier/TypingFlags/issues/5).

- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
