### PR TITLE
[pp] Add a string formatter helper.

### DIFF
--- a/lib/pp.ml
+++ b/lib/pp.ml
@@ -108,6 +108,8 @@ let fnl  ()   = Ppcmd_force_newline
 let ws n      = Ppcmd_print_break (n,0)
 let comment l = Ppcmd_comment l
 
+let strf fmt = Printf.ksprintf str fmt
+
 (* derived commands *)
 let mt    () = Ppcmd_empty
 let spc   () = Ppcmd_print_break (1,0)

--- a/lib/pp.mli
+++ b/lib/pp.mli
@@ -65,6 +65,7 @@ val unrepr : doc_view -> t
 (** {6 Formatting commands} *)
 
 val str   : string -> t
+val strf : ('a, unit, string, t) format4 -> 'a
 val brk   : int * int -> t
 val fnl   : unit -> t
 val ws    : int -> t

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -1346,11 +1346,11 @@ let explain_prim_token_notation_error kind env sigma = function
   | Notation.UnexpectedTerm c ->
     (strbrk "Unexpected term " ++
      pr_constr_env env sigma c ++
-     strbrk (" while parsing a "^kind^" notation."))
+     strf " while parsing a %s notation." kind)
   | Notation.UnexpectedNonOptionTerm c ->
     (strbrk "Unexpected non-option term " ++
      pr_constr_env env sigma c ++
-     strbrk (" while parsing a "^kind^" notation."))
+     strf " while parsing a %s notation." kind)
 
 (** Registration of generic errors
     Nota: explain_exn does NOT end with a newline anymore!


### PR DESCRIPTION
The idea is copied from Dune's `Stdune.Pp.textf` function, and IMO it
can be quite useful to build some error messages.
