### PR TITLE
Cleanup and documentation of the interpretation of evaluable references (for unfold)

### DIFF
--- a/doc/changelog/04-tactics/11840-master+cleanup-unfold-interpretation.rst
+++ b/doc/changelog/04-tactics/11840-master+cleanup-unfold-interpretation.rst
@@ -1,0 +1,7 @@
+- **Added:**
+  New tactic argument type `evaluable_ref` capturing the kind of
+  argument supported by :tacn:`unfold` or by the `delta` flag;
+  moreover, tactic :tacn:`unfold` now accepts opaque definitions and
+  axioms when used in Ltac definitions
+  (`#11840 <https://github.com/coq/coq/pull/11840>`_,
+  by Hugo Herbelin, fixes `#11727 <https://github.com/coq/coq/issues/11727>`_).

--- a/doc/sphinx/user-extensions/syntax-extensions.rst
+++ b/doc/sphinx/user-extensions/syntax-extensions.rst
@@ -1778,7 +1778,12 @@ Tactic notations allow to customize the syntax of tactics. They have the followi
 
       * - ``reference``
         - qualified identifier
-        - a global reference of term
+        - a global reference or a variable
+        -
+
+      * - ``evaluable_ref``
+        - smart qualified identifier
+        - an unfoldable global reference
         - unfold
 
       * - ``constr``
@@ -1833,6 +1838,18 @@ Tactic notations allow to customize the syntax of tactics. They have the followi
              primitive tactics or in other notations at places where a list of the
              underlying entry can be used: entry is either ``constr``, ``hyp``, ``integer``
              or ``int_or_var``.
+
+   .. note:: A *smart* qualified identifier is:
+
+             - either a qualified identifier (possibly with empty qualification)
+             - or some :n:`@string` denoting either the discriminating
+               symbol of a notation (e.g. "+") or an expression defining
+               a notation (e.g. `"_ + _"`), and this notation denotes an
+               application whose head symbol is a constant
+             - or some :n:`@string%ident` where :n:`@string` gets its
+               interpretation from the scope bound to the delimiting
+               key :token:`ident` instead of its default
+               interpretation
 
 .. cmdv:: Local Tactic Notation
 

--- a/interp/smartlocate.ml
+++ b/interp/smartlocate.ml
@@ -74,3 +74,12 @@ let smart_global_inductive = let open Constrexpr in CAst.with_loc_val (fun ?loc 
   | ByNotation (ntn,sc) ->
     destIndRef
       (Notation.interp_notation_as_global_reference ?loc isIndRef ntn sc))
+
+let smart_evaluable_global = let open Constrexpr in CAst.with_loc_val (fun ?loc -> function
+  | AN r ->
+    (try Tacred.evaluable_of_global_reference_lax (locate_global_with_alias ~head:true r)
+     with Not_found -> Nametab.error_global_not_found r)
+  | ByNotation (ntn,sc) ->
+    Tacred.evaluable_of_global_reference_lax
+      (Notation.interp_notation_as_global_reference ?loc
+        Names.GlobRef.(function ConstRef _ | VarRef _ -> true | _ -> false) ntn sc))

--- a/interp/smartlocate.mli
+++ b/interp/smartlocate.mli
@@ -36,3 +36,6 @@ val smart_global : ?head:bool -> qualid Constrexpr.or_by_notation -> GlobRef.t
 
 (** The same for inductive types *)
 val smart_global_inductive : qualid Constrexpr.or_by_notation -> inductive
+
+(** The same for evaluable references *)
+val smart_evaluable_global : qualid Constrexpr.or_by_notation -> evaluable_global_reference

--- a/interp/stdarg.ml
+++ b/interp/stdarg.ml
@@ -42,6 +42,8 @@ let wit_var =
 
 let wit_ref = make0 "ref"
 
+let wit_evaluable_ref = make0 "evaluable_ref"
+
 let wit_sort_family = make0 "sort_family"
 
 let wit_constr =

--- a/interp/stdarg.mli
+++ b/interp/stdarg.mli
@@ -40,6 +40,11 @@ val wit_var : (lident, lident, Id.t) genarg_type
 
 val wit_ref : (qualid, GlobRef.t located or_var, GlobRef.t) genarg_type
 
+val wit_evaluable_ref :
+  (qualid Constrexpr.or_by_notation,
+   (evaluable_global_reference or_dynamic_name) or_var,
+   evaluable_global_reference) genarg_type
+
 val wit_sort_family : (Sorts.family, unit, unit) genarg_type
 
 val wit_constr : (constr_expr, glob_constr_and_expr, constr) genarg_type

--- a/interp/stdarg.mli
+++ b/interp/stdarg.mli
@@ -17,6 +17,7 @@ open Libnames
 open Constrexpr
 open Genarg
 open Genintern
+open Geninterp
 open Locus
 
 val wit_unit : unit uniform_genarg_type

--- a/parsing/pcoq.ml
+++ b/parsing/pcoq.ml
@@ -699,6 +699,7 @@ let () =
   Grammar.register0 wit_ident (Prim.ident);
   Grammar.register0 wit_var (Prim.var);
   Grammar.register0 wit_ref (Prim.reference);
+  Grammar.register0 wit_evaluable_ref (Prim.smart_global);
   Grammar.register0 wit_sort_family (Constr.sort_family);
   Grammar.register0 wit_constr (Constr.constr);
   ()

--- a/plugins/ltac/pptactic.ml
+++ b/plugins/ltac/pptactic.ml
@@ -188,7 +188,9 @@ let string_of_genarg_arg (ArgumentType arg) =
 
   let pr_arg pr x = spc () ++ pr x
 
-  let pr_and_short_name pr (c,_) = pr c
+  let pr_and_short_name pr = function
+    | StaticRef c -> pr c
+    | DynamicRef id -> pr_id id.CAst.v
 
   let pr_evaluable_reference = function
     | EvalVarRef id -> pr_id id

--- a/plugins/ltac/pptactic.ml
+++ b/plugins/ltac/pptactic.ml
@@ -1304,6 +1304,7 @@ let make_constr_printer f c =
 let lift f a = Genprint.PrinterBasic (fun env sigma -> f a)
 let lift_env f a = Genprint.PrinterBasic (fun env sigma -> f env sigma a)
 let lift_top f a = Genprint.TopPrinterBasic (fun () -> f a)
+let lift_context f a = Genprint.TopPrinterNeedsContext (fun env sigma -> f env sigma a)
 
 let register_basic_print0 wit f g h =
   Genprint.register_print0 wit (lift f) (lift g) (lift_top h)
@@ -1327,6 +1328,10 @@ let () =
   register_basic_print0 wit_int_or_var (pr_or_var int) (pr_or_var int) int;
   register_basic_print0 wit_ref
     pr_qualid (pr_or_var (pr_located pr_global)) pr_global;
+  register_print0 wit_evaluable_ref
+    (lift (pr_or_by_notation pr_qualid))
+    (lift_env (fun env sigma -> pr_or_var (pr_or_dynamic_name (pr_evaluable_reference_env env))))
+    (lift_context (fun env sigma -> pr_evaluable_reference_env env));
   register_basic_print0 wit_ident pr_id pr_id pr_id;
   register_basic_print0 wit_var pr_lident pr_lident pr_id;
   register_print0 wit_intropattern pr_raw_intro_pattern pr_glob_intro_pattern pr_intro_pattern_env [@warning "-3"];

--- a/plugins/ltac/pptactic.ml
+++ b/plugins/ltac/pptactic.ml
@@ -188,9 +188,9 @@ let string_of_genarg_arg (ArgumentType arg) =
 
   let pr_arg pr x = spc () ++ pr x
 
-  let pr_and_short_name pr = function
-    | StaticRef c -> pr c
-    | DynamicRef id -> pr_id id.CAst.v
+  let pr_or_dynamic_name pr = function
+    | Static c -> pr c
+    | Dynamic id -> pr_id id.CAst.v
 
   let pr_evaluable_reference = function
     | EvalVarRef id -> pr_id id
@@ -1143,7 +1143,7 @@ let pr_goal_selector ~toplevel s =
         pr_lconstr = (fun env sigma -> pr_and_constr_expr (pr_lglob_constr_env env));
         pr_pattern = (fun env sigma -> pr_pat_and_constr_expr (pr_glob_constr_env env));
         pr_lpattern = (fun env sigma -> pr_pat_and_constr_expr (pr_lglob_constr_env env));
-        pr_constant = pr_or_var (pr_and_short_name (pr_evaluable_reference_env env));
+        pr_constant = pr_or_var (pr_or_dynamic_name (pr_evaluable_reference_env env));
         pr_reference = pr_ltac_or_var (pr_located pr_ltac_constant);
         pr_name = pr_lident;
         pr_generic = Pputils.pr_glb_generic;
@@ -1361,7 +1361,7 @@ let () =
     (lift_env (fun env sigma -> pr_red_expr env sigma
                   ((fun env sigma -> pr_and_constr_expr @@ pr_glob_constr_pptac env sigma),
                    (fun env sigma -> pr_and_constr_expr @@ pr_lglob_constr_pptac env sigma),
-                   pr_or_var (pr_and_short_name pr_evaluable_reference),
+                   pr_or_var (pr_or_dynamic_name pr_evaluable_reference),
                    (fun env sigma -> pr_pat_and_constr_expr @@ pr_glob_constr_pptac env sigma))))
     pr_red_expr_env
   ;

--- a/plugins/ltac/pptactic.mli
+++ b/plugins/ltac/pptactic.mli
@@ -104,7 +104,7 @@ val pr_may_eval :
   (env -> Evd.evar_map -> 'a -> Pp.t) -> (env -> Evd.evar_map -> 'a -> Pp.t) -> ('b -> Pp.t) ->
   (env -> Evd.evar_map -> 'c -> Pp.t) -> ('a,'b,'c) Genredexpr.may_eval -> Pp.t
 
-val pr_and_short_name : ('a -> Pp.t) -> 'a Genredexpr.and_short_name -> Pp.t
+val pr_or_dynamic_name : ('a -> Pp.t) -> 'a or_dynamic_name -> Pp.t
 
 val pr_evaluable_reference_env : env -> evaluable_global_reference -> Pp.t
 

--- a/plugins/ltac/taccoerce.ml
+++ b/plugins/ltac/taccoerce.ml
@@ -278,7 +278,9 @@ let coerce_to_closed_constr env v =
 let coerce_to_evaluable_ref env sigma v =
   let fail () = raise (CannotCoerceTo "an evaluable reference") in
   let ev =
-  match is_intro_pattern v with
+  if has_type v (topwit wit_evaluable_ref) then
+    out_gen (topwit wit_evaluable_ref) v
+  else match is_intro_pattern v with
   | Some (IntroNaming (IntroIdentifier id)) when is_variable env id -> EvalVarRef id
   | Some _ -> fail ()
   | None ->

--- a/plugins/ltac/tacexpr.ml
+++ b/plugins/ltac/tacexpr.ml
@@ -16,6 +16,7 @@ open Genredexpr
 open Genarg
 open Pattern
 open Tactypes
+open Geninterp
 open Locus
 
 type ltac_constant = KerName.t
@@ -271,7 +272,7 @@ constraint 'a = <
 
 type g_trm = Genintern.glob_constr_and_expr
 type g_pat = Genintern.glob_constr_pattern_and_expr
-type g_cst = evaluable_global_reference Genredexpr.and_short_name or_var
+type g_cst = evaluable_global_reference or_dynamic_name or_var
 type g_ref = ltac_constant located or_var
 type g_nam = lident
 

--- a/plugins/ltac/tacexpr.mli
+++ b/plugins/ltac/tacexpr.mli
@@ -15,6 +15,7 @@ open Libnames
 open Genredexpr
 open Genarg
 open Pattern
+open Geninterp
 open Locus
 open Tactypes
 
@@ -270,7 +271,7 @@ constraint 'a = <
 
 type g_trm = Genintern.glob_constr_and_expr
 type g_pat = Genintern.glob_constr_pattern_and_expr
-type g_cst = evaluable_global_reference Genredexpr.and_short_name or_var
+type g_cst = evaluable_global_reference or_dynamic_name or_var
 type g_ref = ltac_constant located or_var
 type g_nam = lident
 

--- a/plugins/ltac/tacintern.ml
+++ b/plugins/ltac/tacintern.ml
@@ -28,6 +28,7 @@ open Tacarg
 open Namegen
 open Tactypes
 open Tactics
+open Geninterp
 open Locus
 
 (** Globalization of tactic expressions :
@@ -296,10 +297,10 @@ let intern_evaluable ist r =
   | {v=AN qid} when qualid_is_ident qid && not !strict_check ->
     (* Possibly an hypothesis: we postpone the interpretation of the name *)
     let id = qualid_basename qid in
-    ArgArg (DynamicRef (make ?loc:qid.CAst.loc id))
+    ArgArg (Dynamic (make ?loc:qid.CAst.loc id))
   | _ ->
     (* Ensured not to refer to an hypothesis *)
-    ArgArg (StaticRef (smart_evaluable_global r))
+    ArgArg (Static (smart_evaluable_global r))
 
 let intern_unfold ist (l,qid) = (l,intern_evaluable ist qid)
 
@@ -361,10 +362,10 @@ let intern_typed_pattern_or_ref_with_occurrences ist (l,p) =
       let c = Constrintern.interp_reference sign r in
       match DAst.get c with
       | GRef (r,None) ->
-          Inl (ArgArg (StaticRef (evaluable_of_global_reference ist.genv r)))
+          Inl (ArgArg (Static (evaluable_of_global_reference ist.genv r)))
       | GVar id ->
           let r = evaluable_of_global_reference ist.genv (GlobRef.VarRef id) in
-          Inl (ArgArg (StaticRef r))
+          Inl (ArgArg (Static r))
       | _ ->
           let bound_names = Glob_ops.bound_glob_vars c in
           Inr (bound_names,(c,None),dummy_pat) in

--- a/plugins/ltac/tacintern.ml
+++ b/plugins/ltac/tacintern.ml
@@ -296,10 +296,10 @@ let intern_evaluable ist r =
   | {v=AN qid} when qualid_is_ident qid && not !strict_check ->
     (* Possibly an hypothesis: we postpone the interpretation of the name *)
     let id = qualid_basename qid in
-    ArgArg (EvalVarRef id, Some (make ?loc:qid.CAst.loc id))
+    ArgArg (DynamicRef (make ?loc:qid.CAst.loc id))
   | _ ->
     (* Ensured not to refer to an hypothesis *)
-    ArgArg (smart_evaluable_global r, None)
+    ArgArg (StaticRef (smart_evaluable_global r))
 
 let intern_unfold ist (l,qid) = (l,intern_evaluable ist qid)
 
@@ -361,10 +361,10 @@ let intern_typed_pattern_or_ref_with_occurrences ist (l,p) =
       let c = Constrintern.interp_reference sign r in
       match DAst.get c with
       | GRef (r,None) ->
-          Inl (ArgArg (evaluable_of_global_reference ist.genv r,None))
+          Inl (ArgArg (StaticRef (evaluable_of_global_reference ist.genv r)))
       | GVar id ->
           let r = evaluable_of_global_reference ist.genv (GlobRef.VarRef id) in
-          Inl (ArgArg (r,None))
+          Inl (ArgArg (StaticRef r))
       | _ ->
           let bound_names = Glob_ops.bound_glob_vars c in
           Inr (bound_names,(c,None),dummy_pat) in

--- a/plugins/ltac/tacintern.ml
+++ b/plugins/ltac/tacintern.ml
@@ -795,6 +795,7 @@ let intern_ltac ist tac =
 
 let () =
   Genintern.register_intern0 wit_int_or_var (lift intern_int_or_var);
+  Genintern.register_intern0 wit_evaluable_ref (lift intern_evaluable);
   Genintern.register_intern0 wit_ref (lift intern_global_reference);
   Genintern.register_intern0 wit_pre_ident (fun ist c -> (ist,c));
   Genintern.register_intern0 wit_ident intern_ident';

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -378,13 +378,11 @@ let try_interp_evaluable env (loc, id) =
 
 let interp_evaluable ist env sigma = function
   | ArgArg (r,Some {loc;v=id}) ->
-    (* Maybe [id] has been introduced by Intro-like tactics *)
+    (* Dynamic interpretation: maybe [id] has been introduced by Intro-like tactics *)
     begin
       try try_interp_evaluable env (loc, id)
       with Not_found ->
-        match r with
-        | EvalConstRef _ -> r
-        | _ -> Nametab.error_global_not_found (qualid_of_ident ?loc id)
+        Smartlocate.smart_evaluable_global (CAst.make ?loc (AN (qualid_of_ident ?loc id)))
     end
   | ArgArg (r,None) -> r
   | ArgVar {loc;v=id} ->

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -377,14 +377,14 @@ let try_interp_evaluable env (loc, id) =
   | _ -> error_not_evaluable (GlobRef.VarRef id)
 
 let interp_evaluable ist env sigma = function
-  | ArgArg (r,Some {loc;v=id}) ->
+  | ArgArg (DynamicRef {loc;v=id}) ->
     (* Dynamic interpretation: maybe [id] has been introduced by Intro-like tactics *)
     begin
       try try_interp_evaluable env (loc, id)
       with Not_found ->
         Smartlocate.smart_evaluable_global (CAst.make ?loc (AN (qualid_of_ident ?loc id)))
     end
-  | ArgArg (r,None) -> r
+  | ArgArg (StaticRef r) -> r
   | ArgVar {loc;v=id} ->
     try try_interp_ltac_var (coerce_to_evaluable_ref env sigma) ist (Some (env,sigma)) (make ?loc id)
     with Not_found ->

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -2013,6 +2013,7 @@ let interp_pre_ident ist env sigma s =
 let () =
   register_interp0 wit_int_or_var (fun ist n -> Ftactic.return (interp_int_or_var ist n));
   register_interp0 wit_ref (lift interp_reference);
+  register_interp0 wit_evaluable_ref (lift interp_evaluable);
   register_interp0 wit_pre_ident (lift interp_pre_ident);
   register_interp0 wit_ident (lift interp_ident);
   register_interp0 wit_var (lift interp_hyp);

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -377,14 +377,14 @@ let try_interp_evaluable env (loc, id) =
   | _ -> error_not_evaluable (GlobRef.VarRef id)
 
 let interp_evaluable ist env sigma = function
-  | ArgArg (DynamicRef {loc;v=id}) ->
+  | ArgArg (Dynamic {loc;v=id}) ->
     (* Dynamic interpretation: maybe [id] has been introduced by Intro-like tactics *)
     begin
       try try_interp_evaluable env (loc, id)
       with Not_found ->
         Smartlocate.smart_evaluable_global (CAst.make ?loc (AN (qualid_of_ident ?loc id)))
     end
-  | ArgArg (StaticRef r) -> r
+  | ArgArg (Static r) -> r
   | ArgVar {loc;v=id} ->
     try try_interp_ltac_var (coerce_to_evaluable_ref env sigma) ist (Some (env,sigma)) (make ?loc id)
     with Not_found ->

--- a/plugins/ltac/tacsubst.ml
+++ b/plugins/ltac/tacsubst.ml
@@ -72,9 +72,9 @@ let subst_destruction_arg subst = function
   | clear,ElimOnAnonHyp n as x -> x
   | clear,ElimOnIdent id as x -> x
 
-let subst_and_short_name f (c,n) =
-(*  assert (n=None); *)(* since tacdef are strictly globalized *)
-  (f c,None)
+let subst_and_short_name f = function
+  | StaticRef c -> StaticRef (f c)
+  | DynamicRef _ -> assert false (* since tacdef are strictly globalized *)
 
 let subst_located f = Loc.map f
 

--- a/plugins/ltac/tacsubst.ml
+++ b/plugins/ltac/tacsubst.ml
@@ -19,6 +19,7 @@ open Tactics
 open Globnames
 open Genredexpr
 open Patternops
+open Geninterp
 
 (** Substitution of tactics at module closing time *)
 
@@ -72,9 +73,9 @@ let subst_destruction_arg subst = function
   | clear,ElimOnAnonHyp n as x -> x
   | clear,ElimOnIdent id as x -> x
 
-let subst_and_short_name f = function
-  | StaticRef c -> StaticRef (f c)
-  | DynamicRef _ -> assert false (* since tacdef are strictly globalized *)
+let subst_or_dynamic_name f = function
+  | Static c -> Static (f c)
+  | Dynamic _ -> assert false (* since tacdef are strictly globalized *)
 
 let subst_located f = Loc.map f
 
@@ -90,7 +91,7 @@ let subst_global_reference subst =
 
 let subst_evaluable subst =
   let subst_eval_ref = subst_evaluable_reference subst in
-    Locusops.or_var_map (subst_and_short_name subst_eval_ref)
+    Locusops.or_var_map (subst_or_dynamic_name subst_eval_ref)
 
 let subst_constr_with_occurrences subst (l,c) = (l,subst_glob_constr subst c)
 

--- a/plugins/ltac/tauto.ml
+++ b/plugins/ltac/tauto.ml
@@ -196,7 +196,7 @@ let evalglobref_of_globref =
 
 let make_unfold name =
   let const = evalglobref_of_globref (Coqlib.lib_ref name) in
-  Locus.(AllOccurrences, ArgArg (const, None))
+  Locus.(AllOccurrences, ArgArg (Genredexpr.StaticRef const))
 
 let reduction_not_iff _ ist =
   let make_reduce c = TacAtom (CAst.make @@ TacReduce (Genredexpr.Unfold c, Locusops.allHypsAndConcl)) in

--- a/plugins/ltac/tauto.ml
+++ b/plugins/ltac/tauto.ml
@@ -196,7 +196,7 @@ let evalglobref_of_globref =
 
 let make_unfold name =
   let const = evalglobref_of_globref (Coqlib.lib_ref name) in
-  Locus.(AllOccurrences, ArgArg (Genredexpr.StaticRef const))
+  Locus.(AllOccurrences, ArgArg (Static const))
 
 let reduction_not_iff _ ist =
   let make_reduce c = TacAtom (CAst.make @@ TacReduce (Genredexpr.Unfold c, Locusops.allHypsAndConcl)) in

--- a/pretyping/geninterp.ml
+++ b/pretyping/geninterp.ml
@@ -101,3 +101,9 @@ module Interp = Register(InterpObj)
 let interp = Interp.obj
 
 let register_interp0 = Interp.register0
+
+(** {6 Basic interpretation types *)
+
+type 'a or_dynamic_name =
+  | Static of 'a
+  | Dynamic of Names.lident

--- a/pretyping/geninterp.mli
+++ b/pretyping/geninterp.mli
@@ -73,3 +73,10 @@ val interp : ('raw, 'glb, 'top) genarg_type -> ('glb, Val.t) interp_fun
 
 val register_interp0 :
   ('raw, 'glb, 'top) genarg_type -> ('glb, Val.t) interp_fun -> unit
+
+(** {6 Basic interpretation types *)
+
+type 'a or_dynamic_name =
+  | Static of 'a
+  | Dynamic of Names.lident
+(** Tell if an interpreted value or an ident to be interpreted at runtime *)

--- a/pretyping/tacred.ml
+++ b/pretyping/tacred.ml
@@ -71,6 +71,11 @@ let evaluable_of_global_reference env = function
   | GlobRef.VarRef id when is_evaluable_var env id -> EvalVarRef id
   | r -> error_not_evaluable r
 
+let evaluable_of_global_reference_lax = function
+  | GlobRef.ConstRef cst -> EvalConstRef cst
+  | GlobRef.VarRef id -> EvalVarRef id
+  | r -> raise Not_found
+
 let global_of_evaluable_reference = function
   | EvalConstRef cst -> GlobRef.ConstRef cst
   | EvalVarRef id -> GlobRef.VarRef id

--- a/pretyping/tacred.mli
+++ b/pretyping/tacred.mli
@@ -34,6 +34,10 @@ val error_not_evaluable : GlobRef.t -> 'a
 val evaluable_of_global_reference :
   Environ.env -> GlobRef.t -> evaluable_global_reference
 
+val evaluable_of_global_reference_lax :
+  GlobRef.t -> evaluable_global_reference
+  (** syntactic translation; raise Not_found if not a constant or variable *)
+
 val global_of_evaluable_reference :
   evaluable_global_reference -> GlobRef.t
 

--- a/tactics/genredexpr.ml
+++ b/tactics/genredexpr.ml
@@ -69,7 +69,9 @@ let make0 ?dyn name =
   let () = Geninterp.register_val0 wit dyn in
   wit
 
-type 'a and_short_name = 'a * Names.lident option
+type 'a and_short_name =
+ | StaticRef of 'a
+ | DynamicRef of Names.lident
 
 let wit_red_expr :
   ((constr_expr,qualid or_by_notation,constr_expr) red_expr_gen,

--- a/tactics/genredexpr.ml
+++ b/tactics/genredexpr.ml
@@ -69,13 +69,9 @@ let make0 ?dyn name =
   let () = Geninterp.register_val0 wit dyn in
   wit
 
-type 'a and_short_name =
- | StaticRef of 'a
- | DynamicRef of Names.lident
-
 let wit_red_expr :
   ((constr_expr,qualid or_by_notation,constr_expr) red_expr_gen,
-   (Genintern.glob_constr_and_expr,Names.evaluable_global_reference and_short_name Locus.or_var,Genintern.glob_constr_pattern_and_expr) red_expr_gen,
+   (Genintern.glob_constr_and_expr,Names.evaluable_global_reference Geninterp.or_dynamic_name Locus.or_var,Genintern.glob_constr_pattern_and_expr) red_expr_gen,
    (EConstr.t,Names.evaluable_global_reference,Pattern.constr_pattern) red_expr_gen)
     Genarg.genarg_type =
   make0 "redexpr"

--- a/test-suite/success/unfold.v
+++ b/test-suite/success/unfold.v
@@ -95,3 +95,18 @@ match goal with |- 0 = Datatypes.fst (0,0) => idtac end.
 Abort.
 
 End D.
+
+Module E.
+
+(* This is #11727: provide an entry which works like unfold *)
+
+Tactic Notation "myunfold" evaluable_ref(x) := unfold x.
+Notation idnat := (@id nat).
+Goal let n := 0 in idnat n = 0.
+Proof.
+  intro n.
+  myunfold idnat.
+  myunfold n.
+Abort.
+
+End E.

--- a/test-suite/success/unfold.v
+++ b/test-suite/success/unfold.v
@@ -15,6 +15,7 @@ Goal EQ nat 0 0.
 Hint Unfold EQ.
 auto.
 Qed.
+End toto.
 
 (* Check regular failure when statically existing ref does not exist
    any longer at run time *)
@@ -23,4 +24,74 @@ Goal let x := 0 in True.
 intro x.
 Fail (clear x; unfold x).
 Abort.
-End toto.
+
+(* Static analysis of unfold *)
+
+Module A.
+
+(* New 8.12: statically accept to refer to id, since it can become transparent later *)
+Opaque id.
+Ltac f := unfold id.
+Goal id 0 = 0.
+Fail f.
+Transparent id.
+f.
+Abort.
+
+End A.
+
+Module B.
+
+(* New 8.12: statically accept to refer to id, since it can be instantiated later *)
+
+Module Type T. Axiom n : nat. End T.
+
+Module F(X:T).
+Ltac f := unfold X.n.
+End F.
+
+Module M. Definition n := 0. End M.
+Module N := F M.
+Goal match M.n with 0 => 0 | S _ => 1 end = 0.
+N.f.
+match goal with |- 0=0 => idtac end.
+Abort.
+
+End B.
+
+Module C.
+
+(* We reject inductive types and constructors *)
+
+Fail Ltac g := unfold nat.
+Fail Ltac g := unfold S.
+
+End C.
+
+Module D.
+
+(* In interactive mode, we delay the interpretation of short names *)
+
+Notation x := Nat.add.
+
+Goal let x := 0 in x = 0+0.
+unfold x.
+match goal with |- 0 = 0 => idtac end.
+Abort.
+
+Goal let x := 0 in x = 0+0.
+intro; unfold x. (* dynamic binding (but is it really the most natural?) *)
+match goal with |- 0 = 0+0 => idtac end.
+Abort.
+
+Goal let fst := 0 in fst = Datatypes.fst (0,0).
+unfold fst.
+match goal with |- 0 = 0 => idtac end.
+Abort.
+
+Goal let fst := 0 in fst = Datatypes.fst (0,0).
+intro; unfold fst. (* dynamic binding *)
+match goal with |- 0 = Datatypes.fst (0,0) => idtac end.
+Abort.
+
+End D.


### PR DESCRIPTION
**Kind:** documentation / cleanup

We clarify the two possible interpretation strategies for evaluable references, such as used in `unfold` or the `delta` flag of `cbv`/`cbn`/`lazy`:
- new type `or_dynamic_binding` to characterize the result of `interning` depending on whether the interpretation is done in an `Ltac` or in a toplevel call to `unfold`;
- relaxed static semantics for this argument: we don't fail statically if it is an axiom or an opaque term, since this status can change at runtime (by functor instantiation or transparent setting, respectively) (see related discussion wrt Ltac2 at #11727);
- new tactic argument `evaluable_ref` precisely matching what `unfold` does, addressing the lying documentation issue #11727.

Fixes / closes #11727

@ejgallego: I put `or_dynamic_binding` in `genarg.mli`. Does it look ok to you?

- [X] Added / updated test-suite
- [X] Corresponding documentation was added / updated
- [X] Entry added in the changelog
