### PR TITLE
Distinguishing entry "ident" from entry "name" in term notations.

### DIFF
--- a/doc/changelog/03-notations/11841-master+distinguishing-ident-name-in-grammar-entries.rst
+++ b/doc/changelog/03-notations/11841-master+distinguishing-ident-name-in-grammar-entries.rst
@@ -1,0 +1,13 @@
+- **Changed:**
+  In notations (except in custom entries), the misleading :n:`@syntax_modifier`
+  :n:`@ident ident` (which accepted either an identifier or
+  a :g:`_`) is deprecated and should be replaced by :n:`@ident name`. If
+  the intent was really to only parse identifiers, this will
+  eventually become possible, but only as of Coq 8.15.
+  In custom entries, the meaning of :n:`@ident ident` is silently changed
+  from parsing identifiers or :g:`_` to parsing only identifiers
+  without warning, but this presumably affects only rare, recent and
+  relatively experimental code
+  (`#11841 <https://github.com/coq/coq/pull/11841>`_,
+  fixes `#9514 <https://github.com/coq/coq/pull/9514>`_,
+  by Hugo Herbelin).

--- a/doc/sphinx/language/extensions/canonical.rst
+++ b/doc/sphinx/language/extensions/canonical.rst
@@ -490,10 +490,10 @@ We need some infrastructure for that.
     Definition id {T} {t : T} (x : phantom t) := x.
 
     Notation "[find v | t1 ~ t2 ] p" := (fun v (_ : unify t1 t2 None) => p)
-      (at level 50, v ident, only parsing).
+      (at level 50, v name, only parsing).
 
     Notation "[find v | t1 ~ t2 | s ] p" := (fun v (_ : unify t1 t2 (Some s)) => p)
-      (at level 50, v ident, only parsing).
+      (at level 50, v name, only parsing).
 
     Notation "'Error : t : s" := (unify _ t (Some s))
       (at level 50, format "''Error' : t : s").

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -1420,6 +1420,7 @@ syntax_modifiers: [
 
 explicit_subentry: [
 | "ident"
+| "name"
 | "global"
 | "bigint"
 | "binder"
@@ -1440,6 +1441,7 @@ at_level_opt: [
 
 binder_interp: [
 | "as" "ident"
+| "as" "name"
 | "as" "pattern"
 | "as" "strict" "pattern"
 ]

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -1574,6 +1574,7 @@ syntax_modifier: [
 
 explicit_subentry: [
 | "ident"
+| "name"
 | "global"
 | "bigint"
 | "strict" "pattern" OPT ( "at" "level" natural )
@@ -1586,6 +1587,7 @@ explicit_subentry: [
 
 binder_interp: [
 | "as" "ident"
+| "as" "name"
 | "as" "pattern"
 | "as" "strict" "pattern"
 ]

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -62,10 +62,11 @@ let pair_eq f g (x1, y1) (x2, y2) = f x1 x2 && g y1 y2
 
 let notation_binder_source_eq s1 s2 = match s1, s2 with
 | NtnParsedAsIdent,  NtnParsedAsIdent -> true
+| NtnParsedAsName,  NtnParsedAsName -> true
 | NtnParsedAsPattern b1, NtnParsedAsPattern b2 -> b1 = b2
 | NtnBinderParsedAsConstr bk1, NtnBinderParsedAsConstr bk2 -> bk1 = bk2
 | NtnParsedAsBinder,  NtnParsedAsBinder -> true
-| (NtnParsedAsIdent | NtnParsedAsPattern _ | NtnBinderParsedAsConstr _ | NtnParsedAsBinder), _ -> false
+| (NtnParsedAsIdent | NtnParsedAsName | NtnParsedAsPattern _ | NtnBinderParsedAsConstr _ | NtnParsedAsBinder), _ -> false
 
 let ntpe_eq t1 t2 = match t1, t2 with
 | NtnTypeConstr, NtnTypeConstr -> true

--- a/interp/notation_ops.ml
+++ b/interp/notation_ops.ml
@@ -881,7 +881,7 @@ let is_onlybinding_meta id metas =
 let is_onlybinding_pattern_like_meta isvar id metas =
   try match Id.List.assoc id metas with
       | _,NtnTypeBinder (NtnBinderParsedAsConstr
-                           (AsIdentOrPattern | AsStrictPattern)) -> true
+                           (AsNameOrPattern | AsStrictPattern)) -> true
       | _,NtnTypeBinder (NtnParsedAsPattern strict) -> not (strict && isvar)
       | _,NtnTypeBinder NtnParsedAsBinder -> not isvar
       | _ -> false
@@ -1533,7 +1533,7 @@ let match_notation_constr ~print_univ c ~vars (metas,pat) =
           let v = glob_constr_of_cases_pattern (Global.env()) pat in
           (((vars,v),scl)::terms',termlists',binders',binderlists')
         | _ -> raise No_match)
-    | NtnTypeBinder (NtnParsedAsIdent | NtnParsedAsPattern _ | NtnParsedAsBinder) ->
+    | NtnTypeBinder (NtnParsedAsIdent | NtnParsedAsName | NtnParsedAsPattern _ | NtnParsedAsBinder) ->
        (terms',termlists',(Id.List.assoc x binders,scl)::binders',binderlists')
     | NtnTypeConstrList ->
        (terms',(Id.List.assoc x termlists,scl)::termlists',binders',binderlists')

--- a/interp/notation_term.ml
+++ b/interp/notation_term.ml
@@ -67,7 +67,8 @@ type extended_subscopes = Constrexpr.notation_entry_level * subscopes
 
 type constr_as_binder_kind =
   | AsIdent
-  | AsIdentOrPattern
+  | AsName
+  | AsNameOrPattern
   | AsStrictPattern
 
 type notation_binder_source =
@@ -76,6 +77,8 @@ type notation_binder_source =
   | NtnParsedAsPattern of bool
   (* This accepts only ident *)
   | NtnParsedAsIdent
+  (* This accepts only name *)
+  | NtnParsedAsName
   (* This accepts ident, or pattern, or both *)
   | NtnBinderParsedAsConstr of constr_as_binder_kind
   (* This accepts ident, _, and quoted pattern *)

--- a/parsing/extend.ml
+++ b/parsing/extend.ml
@@ -32,6 +32,7 @@ let production_level_eq lev1 lev2 =
 
 type 'a constr_entry_key_gen =
   | ETIdent
+  | ETName of bool (* Temporary: true = user told "name", false = user wrote "ident" *)
   | ETGlobal
   | ETBigint
   | ETBinder of bool  (* open list of binders if true, closed list of binders otherwise *)
@@ -55,6 +56,7 @@ type binder_entry_kind = ETBinderOpen | ETBinderClosed of string Tok.p list
 type binder_target = ForBinder | ForTerm
 
 type constr_prod_entry_key =
+  | ETProdIdent           (* Parsed as an ident *)
   | ETProdName            (* Parsed as a name (ident or _) *)
   | ETProdReference       (* Parsed as a global reference *)
   | ETProdBigint          (* Parsed as an (unbounded) integer *)

--- a/parsing/extend.mli
+++ b/parsing/extend.mli
@@ -27,6 +27,7 @@ val production_level_eq : production_level -> production_level -> bool
 
 type 'a constr_entry_key_gen =
   | ETIdent
+  | ETName of bool (* Temporary: true = user told "name", false = user wrote "ident" *)
   | ETGlobal
   | ETBigint
   | ETBinder of bool  (* open list of binders if true, closed list of binders otherwise *)
@@ -50,6 +51,7 @@ type binder_entry_kind = ETBinderOpen | ETBinderClosed of string Tok.p list
 type binder_target = ForBinder | ForTerm
 
 type constr_prod_entry_key =
+  | ETProdIdent           (* Parsed as an ident *)
   | ETProdName            (* Parsed as a name (ident or _) *)
   | ETProdReference       (* Parsed as a global reference *)
   | ETProdBigint          (* Parsed as an (unbounded) integer *)

--- a/test-suite/bugs/closed/bug_9517.v
+++ b/test-suite/bugs/closed/bug_9517.v
@@ -2,6 +2,7 @@ Declare Custom Entry expr.
 Declare Custom Entry stmt.
 Notation "x" := x (in custom stmt, x ident).
 Notation "x" := x (in custom expr, x ident).
+Notation "'_'" := _ (in custom expr).
 
 Notation "1" := 1 (in custom expr).
 

--- a/test-suite/output/Notations2.v
+++ b/test-suite/output/Notations2.v
@@ -62,7 +62,7 @@ Check `(∀ n p : A, n=p).
 
 Notation "'let'' f x .. y  :=  t 'in' u":=
   (let f := fun x => .. (fun y => t) .. in u)
-  (f ident, x closed binder, y closed binder, at level 200,
+  (f name, x closed binder, y closed binder, at level 200,
    right associativity).
 
 Check let' f x y (a:=0) z (b:bool) := x+y+z+1 in f 0 1 2.
@@ -93,7 +93,7 @@ End A.
 
 Notation "'mylet' f [ x ; .. ; y ]  :=  t 'in' u":=
   (let f := fun x => .. (fun y => t) .. in u)
-  (f ident, x closed binder, y closed binder, at level 200,
+  (f name, x closed binder, y closed binder, at level 200,
    right associativity).
 
 Check mylet f [x;y;z;(a:bool)] := x+y+z+1 in f 0 1 2.
@@ -104,7 +104,7 @@ Check mylet f [x;y;z;(a:bool)] := x+y+z+1 in f 0 1 2.
 (* Old request mentioned again on coq-club 20/1/2012 *)
 
 Notation "#  x : T => t" := (fun x : T => t)
-  (at level 0, t at level 200, x ident).
+  (at level 0, t at level 200, x name).
 
 Check # x : nat => x.
 Check # _ : nat => 2.
@@ -116,7 +116,7 @@ Parameters (A : Set) (x y : A) (Q : A -> A -> Prop) (conj : Q x y).
 Check (exist (Q x) y conj).
 
 (* Check bug #4854 *)
-Notation "% i" := (fun i : nat => i) (at level 0, i ident).
+Notation "% i" := (fun i : nat => i) (at level 0, i name).
 Check %i.
 Check %j.
 

--- a/test-suite/output/Notations3.v
+++ b/test-suite/output/Notations3.v
@@ -305,7 +305,7 @@ Module E.
 Inductive myex2 {A:Type} (P Q:A -> Prop) : Prop :=
   myex_intro2 : forall x:A, P x -> Q x -> myex2 P Q.
 Notation "'myexists2' x : A , p & q" := (myex2 (A:=A) (fun x => p) (fun x => q))
-  (at level 200, x ident, A at level 200, p at level 200, right associativity,
+  (at level 200, x name, A at level 200, p at level 200, right associativity,
     format "'[' 'myexists2'  '/  ' x  :  A ,  '/  ' '[' p  &  '/' q ']' ']'")
   : type_scope.
 Check myex2 (fun x => let '(y,z) := x in y>z) (fun x => let '(y,z) := x in z>y).

--- a/test-suite/output/Notations4.v
+++ b/test-suite/output/Notations4.v
@@ -327,6 +327,7 @@ Module P.
 
   Module NotationMixedTermBinderAsIdent.
 
+  Set Warnings "-deprecated-ident-entry". (* We do want ident! *)
   Notation "▢_ n P" := (pseudo_force n (fun n => P))
     (at level 0, n ident, P at level 9, format "▢_ n  P").
   Check exists p, ▢_p (p >= 1).

--- a/theories/Init/Logic.v
+++ b/theories/Init/Logic.v
@@ -309,9 +309,9 @@ Notation "'exists' x .. y , p" := (ex (fun x => .. (ex (fun y => p)) ..))
   : type_scope.
 
 Notation "'exists2' x , p & q" := (ex2 (fun x => p) (fun x => q))
-  (at level 200, x ident, p at level 200, right associativity) : type_scope.
+  (at level 200, x name, p at level 200, right associativity) : type_scope.
 Notation "'exists2' x : A , p & q" := (ex2 (A:=A) (fun x => p) (fun x => q))
-  (at level 200, x ident, A at level 200, p at level 200, right associativity,
+  (at level 200, x name, A at level 200, p at level 200, right associativity,
     format "'[' 'exists2'  '/  ' x  :  A ,  '/  ' '[' p  &  '/' q ']' ']'")
   : type_scope.
 
@@ -489,18 +489,18 @@ Module EqNotations.
     := (match H as p in (_ = y) return P with
         | eq_refl => H'
         end)
-         (at level 10, H' at level 10, y ident, p ident,
+         (at level 10, H' at level 10, y name, p name,
           format "'[' 'rew'  'dependent'  [ 'fun'  y  p  =>  P ]  '/    ' H  in  '/' H' ']'").
   Notation "'rew' 'dependent' -> [ 'fun' y p => P ] H 'in' H'"
     := (match H as p in (_ = y) return P with
         | eq_refl => H'
         end)
-         (at level 10, H' at level 10, y ident, p ident, only parsing).
+         (at level 10, H' at level 10, y name, p name, only parsing).
   Notation "'rew' 'dependent' <- [ 'fun' y p => P ] H 'in' H'"
     := (match eq_sym H as p in (_ = y) return P with
         | eq_refl => H'
         end)
-         (at level 10, H' at level 10, y ident, p ident,
+         (at level 10, H' at level 10, y name, p name,
           format "'[' 'rew'  'dependent'  <-  [ 'fun'  y  p  =>  P ]  '/    ' H  in  '/' H' ']'").
   Notation "'rew' 'dependent' [ P ] H 'in' H'"
     := (match H as p in (_ = y) return P y p with

--- a/theories/Logic/Hurkens.v
+++ b/theories/Logic/Hurkens.v
@@ -96,19 +96,19 @@ Module Generic.
 (* begin hide *)
 (* Notations used in the proof. Hidden in coqdoc. *)
 
-Reserved Notation "'∀₁' x : A , B" (at level 200, x ident, A at level 200,right associativity).
+Reserved Notation "'∀₁' x : A , B" (at level 200, x name, A at level 200,right associativity).
 Reserved Notation "A '⟶₁' B" (at level 99, right associativity, B at level 200).
-Reserved Notation "'λ₁' x , u" (at level 200, x ident, right associativity).
+Reserved Notation "'λ₁' x , u" (at level 200, x name, right associativity).
 Reserved Notation "f '·₁' x" (at level 5, left associativity).
-Reserved Notation "'∀₂' A , F" (at level 200, A ident, right associativity).
-Reserved Notation "'λ₂' x , u" (at level 200, x ident, right associativity).
+Reserved Notation "'∀₂' A , F" (at level 200, A name, right associativity).
+Reserved Notation "'λ₂' x , u" (at level 200, x name, right associativity).
 Reserved Notation "f '·₁' [ A ]" (at level 5, left associativity).
-Reserved Notation "'∀₀' x : A , B" (at level 200, x ident, A at level 200,right associativity).
+Reserved Notation "'∀₀' x : A , B" (at level 200, x name, A at level 200,right associativity).
 Reserved Notation "A '⟶₀' B" (at level 99, right associativity, B at level 200).
-Reserved Notation "'λ₀' x , u" (at level 200, x ident, right associativity).
+Reserved Notation "'λ₀' x , u" (at level 200, x name, right associativity).
 Reserved Notation "f '·₀' x" (at level 5, left associativity).
-Reserved Notation "'∀₀¹' A : U , F" (at level 200, A ident, right associativity).
-Reserved Notation "'λ₀¹' x , u" (at level 200, x ident, right associativity).
+Reserved Notation "'∀₀¹' A : U , F" (at level 200, A name, right associativity).
+Reserved Notation "'λ₀¹' x , u" (at level 200, x name, right associativity).
 Reserved Notation "f '·₀' [ A ]" (at level 5, left associativity).
 
 (* end hide *)

--- a/theories/Program/Utils.v
+++ b/theories/Program/Utils.v
@@ -18,7 +18,7 @@ Set Implicit Arguments.
 
 Notation "{ ( x , y )  :  A  |  P }" :=
   (sig (fun anonymous : A => let (x,y) := anonymous in P))
-  (x ident, y ident, at level 10) : type_scope.
+  (x name, y name, at level 10) : type_scope.
 
 Declare Scope program_scope.
 Delimit Scope program_scope with prg.

--- a/theories/ssr/ssrbool.v
+++ b/theories/ssr/ssrbool.v
@@ -335,19 +335,19 @@ Reserved Notation "[ 'predType' 'of' T ]" (at level 0,
 
 Reserved Notation "[ 'pred' : T | E ]" (at level 0,
   format "'[hv' [ 'pred' :  T  | '/ '  E ] ']'").
-Reserved Notation "[ 'pred' x | E ]" (at level 0, x ident,
+Reserved Notation "[ 'pred' x | E ]" (at level 0, x name,
   format "'[hv' [ 'pred'  x  | '/ '  E ] ']'").
-Reserved Notation "[ 'pred' x : T | E ]" (at level 0, x ident,
+Reserved Notation "[ 'pred' x : T | E ]" (at level 0, x name,
   format "'[hv' [ 'pred'  x  :  T  | '/ '  E ] ']'").
-Reserved Notation "[ 'pred' x | E1 & E2 ]" (at level 0, x ident,
+Reserved Notation "[ 'pred' x | E1 & E2 ]" (at level 0, x name,
   format "'[hv' [ 'pred'  x  | '/ '  E1  & '/ '  E2 ] ']'").
-Reserved Notation "[ 'pred' x : T | E1 & E2 ]" (at level 0, x ident,
+Reserved Notation "[ 'pred' x : T | E1 & E2 ]" (at level 0, x name,
   format "'[hv' [ 'pred'  x  :  T  | '/ '  E1  &  E2 ] ']'").
-Reserved Notation "[ 'pred' x 'in' A ]" (at level 0, x ident,
+Reserved Notation "[ 'pred' x 'in' A ]" (at level 0, x name,
   format "'[hv' [ 'pred'  x  'in'  A ] ']'").
-Reserved Notation "[ 'pred' x 'in' A | E ]" (at level 0, x ident,
+Reserved Notation "[ 'pred' x 'in' A | E ]" (at level 0, x name,
   format "'[hv' [ 'pred'  x  'in'  A  | '/ '  E ] ']'").
-Reserved Notation "[ 'pred' x 'in' A | E1 & E2 ]" (at level 0, x ident,
+Reserved Notation "[ 'pred' x 'in' A | E1 & E2 ]" (at level 0, x name,
   format "'[hv' [ 'pred'  x  'in'  A  | '/ '  E1  & '/ '  E2 ] ']'").
 
 Reserved Notation "[ 'qualify' x | P ]" (at level 0, x at level 99,
@@ -363,17 +363,17 @@ Reserved Notation "[ 'qualify' 'an' x | P ]" (at level 0, x at level 99,
 Reserved Notation "[ 'qualify' 'an' x : T | P ]" (at level 0, x at level 99,
   format "'[hv' [ 'qualify'  'an'  x  :  T  | '/ '  P ] ']'").
 
-Reserved Notation "[ 'rel' x y | E ]"  (at level 0, x ident, y ident,
+Reserved Notation "[ 'rel' x y | E ]"  (at level 0, x name, y name,
   format "'[hv' [ 'rel'  x  y  | '/ '  E ] ']'").
-Reserved Notation "[ 'rel' x y : T | E ]" (at level 0, x ident, y ident,
+Reserved Notation "[ 'rel' x y : T | E ]" (at level 0, x name, y name,
   format "'[hv' [ 'rel'  x  y  :  T  | '/ '  E ] ']'").
-Reserved Notation "[ 'rel' x y 'in' A & B | E ]" (at level 0, x ident, y ident,
+Reserved Notation "[ 'rel' x y 'in' A & B | E ]" (at level 0, x name, y name,
   format "'[hv' [ 'rel'  x  y  'in'  A  &  B  | '/ '  E ] ']'").
-Reserved Notation "[ 'rel' x y 'in' A & B ]" (at level 0, x ident, y ident,
+Reserved Notation "[ 'rel' x y 'in' A & B ]" (at level 0, x name, y name,
   format "'[hv' [ 'rel'  x  y  'in'  A  &  B ] ']'").
-Reserved Notation "[ 'rel' x y 'in' A | E ]" (at level 0, x ident, y ident,
+Reserved Notation "[ 'rel' x y 'in' A | E ]" (at level 0, x name, y name,
   format "'[hv' [ 'rel'  x  y  'in'  A  | '/ '  E ] ']'").
-Reserved Notation "[ 'rel' x y 'in' A ]" (at level 0, x ident, y ident,
+Reserved Notation "[ 'rel' x y 'in' A ]" (at level 0, x name, y name,
   format "'[hv' [ 'rel'  x  y  'in'  A ] ']'").
 
 Reserved Notation "[ 'mem' A ]" (at level 0, format "[ 'mem'  A ]").

--- a/theories/ssr/ssreflect.v
+++ b/theories/ssr/ssreflect.v
@@ -110,7 +110,7 @@ Reserved Notation "'if' c 'then' vT 'else' vF" (at level 200,
 Reserved Notation "'if' c 'return' R 'then' vT 'else' vF" (at level 200,
   c, R, vT, vF at level 200).
 Reserved Notation "'if' c 'as' x 'return' R 'then' vT 'else' vF" (at level 200,
-  c, R, vT, vF at level 200, x ident).
+  c, R, vT, vF at level 200, x name).
 
 Reserved Notation "x : T" (at level 100, right associativity,
   format "'[hv' x '/ '  :  T ']'").

--- a/theories/ssr/ssrfun.v
+++ b/theories/ssr/ssrfun.v
@@ -236,19 +236,19 @@ Reserved Notation "'fun' => E" (at level 200, format "'fun' =>  E").
 Reserved Notation "[ 'fun' : T => E ]" (at level 0,
   format "'[hv' [ 'fun' :  T  => '/ '  E ] ']'").
 Reserved Notation "[ 'fun' x => E ]" (at level 0,
-  x ident, format "'[hv' [ 'fun'  x  => '/ '  E ] ']'").
+  x name, format "'[hv' [ 'fun'  x  => '/ '  E ] ']'").
 Reserved Notation "[ 'fun' x : T => E ]" (at level 0,
-  x ident, format "'[hv' [ 'fun'  x  :  T  => '/ '  E ] ']'").
+  x name, format "'[hv' [ 'fun'  x  :  T  => '/ '  E ] ']'").
 Reserved Notation "[ 'fun' x y => E ]" (at level 0,
-  x ident, y ident, format "'[hv' [ 'fun'  x  y  => '/ '  E ] ']'").
+  x name, y name, format "'[hv' [ 'fun'  x  y  => '/ '  E ] ']'").
 Reserved Notation "[ 'fun' x y : T => E ]" (at level 0,
-  x ident, y ident, format "'[hv' [ 'fun'  x  y  :  T  => '/ '  E ] ']'").
+  x name, y name, format "'[hv' [ 'fun'  x  y  :  T  => '/ '  E ] ']'").
 Reserved Notation "[ 'fun' ( x : T ) y => E ]" (at level 0,
-  x ident, y ident, format "'[hv' [ 'fun'  ( x  :  T )  y  => '/ '  E ] ']'").
+  x name, y name, format "'[hv' [ 'fun'  ( x  :  T )  y  => '/ '  E ] ']'").
 Reserved Notation "[ 'fun' x ( y : T ) => E ]" (at level 0,
-  x ident, y ident, format "'[hv' [ 'fun'  x  ( y  :  T )  => '/ '  E ] ']'").
+  x name, y name, format "'[hv' [ 'fun'  x  ( y  :  T )  => '/ '  E ] ']'").
 Reserved Notation "[ 'fun' ( x : T ) ( y : U ) => E ]" (at level 0,
-  x ident, y ident, format "[ 'fun'  ( x  :  T )  ( y  :  U )  =>  E ]" ).
+  x name, y name, format "[ 'fun'  ( x  :  T )  ( y  :  U )  =>  E ]" ).
 
 Reserved Notation "f =1 g" (at level 70, no associativity).
 Reserved Notation "f =1 g :> A" (at level 70, g at next level, A at level 90).
@@ -259,33 +259,33 @@ Reserved Notation "f \; g" (at level 60, right associativity,
   format "f  \; '/ '  g").
 
 Reserved Notation "{ 'morph' f : x / a >-> r }" (at level 0, f at level 99,
-  x ident, format "{ 'morph'  f  :  x  /  a  >->  r }").
+  x name, format "{ 'morph'  f  :  x  /  a  >->  r }").
 Reserved Notation "{ 'morph' f : x / a }" (at level 0, f at level 99,
-  x ident, format "{ 'morph'  f  :  x  /  a }").
+  x name, format "{ 'morph'  f  :  x  /  a }").
 Reserved Notation "{ 'morph' f : x y / a >-> r }" (at level 0, f at level 99,
-  x ident, y ident, format "{ 'morph'  f  :  x  y  /  a  >->  r }").
+  x name, y name, format "{ 'morph'  f  :  x  y  /  a  >->  r }").
 Reserved Notation "{ 'morph' f : x y / a }" (at level 0, f at level 99,
-  x ident, y ident, format "{ 'morph'  f  :  x  y  /  a }").
+  x name, y name, format "{ 'morph'  f  :  x  y  /  a }").
 Reserved Notation "{ 'homo' f : x / a >-> r }" (at level 0, f at level 99,
-  x ident, format "{ 'homo'  f  :  x  /  a  >->  r }").
+  x name, format "{ 'homo'  f  :  x  /  a  >->  r }").
 Reserved Notation "{ 'homo' f : x / a }"  (at level 0, f at level 99,
-  x ident, format "{ 'homo'  f  :  x  /  a }").
+  x name, format "{ 'homo'  f  :  x  /  a }").
 Reserved Notation "{ 'homo' f : x y / a >-> r }" (at level 0, f at level 99,
-  x ident, y ident, format "{ 'homo'  f  :  x  y  /  a  >->  r }").
+  x name, y name, format "{ 'homo'  f  :  x  y  /  a  >->  r }").
 Reserved Notation "{ 'homo' f : x y / a }" (at level 0, f at level 99,
-  x ident, y ident, format "{ 'homo'  f  :  x  y  /  a }").
+  x name, y name, format "{ 'homo'  f  :  x  y  /  a }").
 Reserved Notation "{ 'homo' f : x y /~ a }" (at level 0, f at level 99,
-  x ident, y ident, format "{ 'homo'  f  :  x  y  /~  a }").
+  x name, y name, format "{ 'homo'  f  :  x  y  /~  a }").
 Reserved Notation "{ 'mono' f : x / a >-> r }" (at level 0, f at level 99,
-  x ident, format "{ 'mono'  f  :  x  /  a  >->  r }").
+  x name, format "{ 'mono'  f  :  x  /  a  >->  r }").
 Reserved Notation "{ 'mono' f : x / a }" (at level 0, f at level 99,
-  x ident, format "{ 'mono'  f  :  x  /  a }").
+  x name, format "{ 'mono'  f  :  x  /  a }").
 Reserved Notation "{ 'mono' f : x y / a >-> r }" (at level 0, f at level 99,
-  x ident, y ident, format "{ 'mono'  f  :  x  y  /  a  >->  r }").
+  x name, y name, format "{ 'mono'  f  :  x  y  /  a  >->  r }").
 Reserved Notation "{ 'mono' f : x y / a }" (at level 0, f at level 99,
-  x ident, y ident, format "{ 'mono'  f  :  x  y  /  a }").
+  x name, y name, format "{ 'mono'  f  :  x  y  /  a }").
 Reserved Notation "{ 'mono' f : x y /~ a }" (at level 0, f at level 99,
-  x ident, y ident, format "{ 'mono'  f  :  x  y  /~  a }").
+  x name, y name, format "{ 'mono'  f  :  x  y  /~  a }").
 
 Reserved Notation "@ 'id' T" (at level 10, T at level 8, format "@ 'id'  T").
 Reserved Notation "@ 'sval'" (at level 10, format "@ 'sval'").

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -531,6 +531,10 @@ let warn_deprecated_include_type =
   CWarnings.create ~name:"deprecated-include-type" ~category:"deprecated"
          (fun () -> strbrk "Include Type is deprecated; use Include instead")
 
+let warn_deprecated_as_ident_kind =
+  CWarnings.create ~name:"deprecated-as-ident-kind" ~category:"deprecated"
+         (fun () -> strbrk "grammar kind \"as ident\" no longer accepts \"_\"; use \"as name\" instead to accept \"_\", too, or silence the warning if you actually intended to accept only identifiers.")
+
 }
 
 (* Modules and Sections *)
@@ -1242,7 +1246,13 @@ GRAMMAR EXTEND Gram
     ] ]
   ;
   explicit_subentry:
-    [ [ IDENT "ident" -> { ETIdent } | IDENT "global" -> { ETGlobal }
+    [ [ (* Warning to be turn into an error at the end of deprecation phase (for 8.14) *)
+        IDENT "ident" -> { ETName false }
+        (* To be activated at the end of transitory phase (for 8.15)
+      | IDENT "ident" -> { ETIdent }
+        *)
+      | IDENT "name" -> { ETName true } (* Boolean to remove at the end of transitory phase *)
+      | IDENT "global" -> { ETGlobal }
       | IDENT "bigint" -> { ETBigint }
       | IDENT "binder" -> { ETBinder true }
       | IDENT "constr" -> { ETConstr (InConstrEntry,None,DefaultLevel) }
@@ -1261,8 +1271,9 @@ GRAMMAR EXTEND Gram
       | -> { DefaultLevel } ] ]
   ;
   binder_interp:
-    [ [ "as"; IDENT "ident" -> { Notation_term.AsIdent }
-      | "as"; IDENT "pattern" -> { Notation_term.AsIdentOrPattern }
+    [ [ "as"; IDENT "ident" -> { warn_deprecated_as_ident_kind (); Notation_term.AsIdent }
+      | "as"; IDENT "name" -> { Notation_term.AsName }
+      | "as"; IDENT "pattern" -> { Notation_term.AsNameOrPattern }
       | "as"; IDENT "strict"; IDENT "pattern" -> { Notation_term.AsStrictPattern } ] ]
   ;
 END

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -271,9 +271,9 @@ let pr_reference_or_constr pr_c = function
   | HintsConstr c -> pr_c c
 
 let pr_hint_mode = let open Hints in function
-    | ModeInput -> str"+"
-    | ModeNoHeadEvar -> str"!"
-    | ModeOutput -> str"-"
+  | ModeInput -> str"+"
+  | ModeNoHeadEvar -> str"!"
+  | ModeOutput -> str"-"
 
 let pr_hint_info pr_pat { Typeclasses.hint_priority = pri; hint_pattern = pat } =
   pr_opt (fun x -> str"|" ++ int x) pri ++

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -187,13 +187,16 @@ let level_of_pattern_level = function None -> DefaultLevel | Some n -> NumLevel 
 
 let pr_constr_as_binder_kind = let open Notation_term in function
     | AsIdent -> spc () ++ keyword "as ident"
-    | AsIdentOrPattern -> spc () ++ keyword "as pattern"
+    | AsName -> spc () ++ keyword "as name"
+    | AsNameOrPattern -> spc () ++ keyword "as pattern"
     | AsStrictPattern -> spc () ++ keyword "as strict pattern"
 
 let pr_strict b = if b then str "strict " else mt ()
 
 let pr_set_entry_type pr = function
   | ETIdent -> str"ident"
+  | ETName false -> str"ident" (* temporary *)
+  | ETName true -> str"name"
   | ETGlobal -> str"global"
   | ETPattern (b,n) -> pr_strict b ++ str"pattern" ++ pr_at_level (level_of_pattern_level n)
   | ETConstr (s,bko,lev) -> pr_notation_entry s ++ pr lev ++ pr_opt pr_constr_as_binder_kind bko


### PR DESCRIPTION
**Kind:** clarification

There is a confusion between `ident` in term notations (which includes the anonymous `_`) and `ident` in tactic notations (which does not include `_`). This PR proposes to unify the terminology and to document the corresponding behavior, as asked in #9514.

That would close #9514 when the documentation is done.

The PR adopts the following strategy:
- `ident` in custom entries is deprecated in favor of either `identifier` (no `_`) or `name` (includes `_`)
- in a latter step, `ident` is removed and `identifier` is renamed to `ident` (for consistency with what happens in tactic notations)

An alternative strategy could be to not add `identifier` and to wait for the end of deprecation of `ident` to change its meaning.

Any opinion, especially from @jfehrle or @Zimmi48?

- [x] Corresponding documentation was added / updated
- [x] Entry added in the changelog
