### PR TITLE
Towards better grammar entry names: renaming "identref" into "lident"?

### DIFF
--- a/dev/doc/changes.md
+++ b/dev/doc/changes.md
@@ -4,6 +4,11 @@
   comes from a notation. Use `None` if not and `Some foo` to tell to
   print such TacGeneric surrounded with `foo:( )`.
 
+### Grammar entries
+
+- `Prim.pattern_ident` now takes a location; it becomes a synonymous of
+  `Prim.pattern_identref` which is removed.
+
 ## Changes between Coq 8.11 and Coq 8.12
 
 ### Code formatting

--- a/dev/doc/changes.md
+++ b/dev/doc/changes.md
@@ -9,6 +9,8 @@
 - `Prim.pattern_ident` now takes a location; it becomes a synonymous of
   `Prim.pattern_identref` which is removed.
 
+- `Prim.identref` was a synonymous of `Prim.lident`; it is removed.
+
 ## Changes between Coq 8.11 and Coq 8.12
 
 ### Code formatting

--- a/interp/constrexpr.ml
+++ b/interp/constrexpr.ml
@@ -108,7 +108,7 @@ and constr_expr_r =
          * constr_expr * constr_expr
   | CHole   of Evar_kinds.t option * Namegen.intro_pattern_naming_expr * Genarg.raw_generic_argument option
   | CPatVar of Pattern.patvar
-  | CEvar   of Glob_term.existential_name * (Id.t * constr_expr) list
+  | CEvar   of Glob_term.existential_name * (lident * constr_expr) list
   | CSort   of Glob_term.glob_sort
   | CCast   of constr_expr * constr_expr Glob_term.cast_type
   | CNotation of notation_with_optional_scope option * notation * constr_notation_substitution

--- a/interp/constrexpr.ml
+++ b/interp/constrexpr.ml
@@ -108,7 +108,7 @@ and constr_expr_r =
          * constr_expr * constr_expr
   | CHole   of Evar_kinds.t option * Namegen.intro_pattern_naming_expr * Genarg.raw_generic_argument option
   | CPatVar of Pattern.patvar
-  | CEvar   of Glob_term.existential_name * (lident * constr_expr) list
+  | CEvar   of Glob_term.existential_name CAst.t * (lident * constr_expr) list
   | CSort   of Glob_term.glob_sort
   | CCast   of constr_expr * constr_expr Glob_term.cast_type
   | CNotation of notation_with_optional_scope option * notation * constr_notation_substitution

--- a/interp/constrexpr_ops.ml
+++ b/interp/constrexpr_ops.ml
@@ -235,7 +235,7 @@ and constr_notation_substitution_eq (e1, el1, b1, bl1) (e2, el2, b2, bl2) =
   List.equal (List.equal local_binder_eq) bl1 bl2
 
 and instance_eq (x1,c1) (x2,c2) =
-  Id.equal x1 x2 && constr_expr_eq c1 c2
+  Id.equal x1.CAst.v x2.CAst.v && constr_expr_eq c1 c2
 
 and cast_expr_eq c1 c2 = match c1, c2 with
 | CastConv t1, CastConv t2

--- a/interp/constrexpr_ops.ml
+++ b/interp/constrexpr_ops.ml
@@ -156,7 +156,7 @@ let rec constr_expr_eq e1 e2 =
     | CPatVar i1, CPatVar i2 ->
       Id.equal i1 i2
     | CEvar (id1, c1), CEvar (id2, c2) ->
-      Id.equal id1 id2 && List.equal instance_eq c1 c2
+      Id.equal id1.CAst.v id2.CAst.v && List.equal instance_eq c1 c2
     | CSort s1, CSort s2 ->
       Glob_ops.glob_sort_eq s1 s2
     | CCast(t1,c1), CCast(t2,c2) ->

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -1391,7 +1391,7 @@ let rec glob_of_pat avoid env sigma pat = DAst.make @@ match pat with
       | None -> Id.of_string "__"
       | Some id -> id
       in
-      GEvar (id,List.map (on_snd (glob_of_pat avoid env sigma)) l)
+      GEvar (id,List.map (fun (id,c) -> (CAst.make id, glob_of_pat avoid env sigma c)) l)
   | PRel n ->
       let id = try match lookup_name_of_rel n env with
         | Name id   -> id

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -978,7 +978,7 @@ let rec extern inctx ?impargs scopes vars r =
       if !print_meta_as_hole then CHole (None, IntroAnonymous, None) else
        (match kind with
          | Evar_kinds.SecondOrderPatVar n -> CPatVar n
-         | Evar_kinds.FirstOrderPatVar n -> CEvar (n,[]))
+         | Evar_kinds.FirstOrderPatVar n -> CEvar (CAst.make n,[]))
 
   | GApp (f,args) ->
       (match DAst.get f with
@@ -1391,7 +1391,7 @@ let rec glob_of_pat avoid env sigma pat = DAst.make @@ match pat with
       | None -> Id.of_string "__"
       | Some id -> id
       in
-      GEvar (id,List.map (fun (id,c) -> (CAst.make id, glob_of_pat avoid env sigma c)) l)
+      GEvar (CAst.make id,List.map (fun (id,c) -> (CAst.make id, glob_of_pat avoid env sigma c)) l)
   | PRel n ->
       let id = try match lookup_name_of_rel n env with
         | Name id   -> id

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -2188,7 +2188,7 @@ let internalize globalenv env pattern_mode (_, ntnvars as lvar) c =
         GPatVar (Evar_kinds.SecondOrderPatVar n)
     | CEvar (n, []) when pattern_mode ->
         DAst.make ?loc @@
-        GPatVar (Evar_kinds.FirstOrderPatVar n)
+        GPatVar (Evar_kinds.FirstOrderPatVar n.CAst.v)
     (* end *)
     (* Parsing existential variables *)
     | CEvar (n, l) ->

--- a/interp/stdarg.ml
+++ b/interp/stdarg.ml
@@ -40,6 +40,9 @@ let wit_int_or_var =
 let wit_ident =
   make0 "ident"
 
+let wit_lident =
+  make0 ~dyn:(val_tag (topwit wit_ident)) "lident"
+
 let wit_var =
   make0 ~dyn:(val_tag (topwit wit_ident)) "var"
 

--- a/interp/stdarg.mli
+++ b/interp/stdarg.mli
@@ -37,6 +37,8 @@ val wit_int_or_var : (int or_var, int or_var, int) genarg_type
 
 val wit_ident : Id.t uniform_genarg_type
 
+val wit_lident : (lident, lident, Id.t) genarg_type
+
 val wit_var : (lident, lident, Id.t) genarg_type
 
 val wit_ref : (qualid, GlobRef.t located or_var, GlobRef.t) genarg_type

--- a/parsing/g_constr.mlg
+++ b/parsing/g_constr.mlg
@@ -154,7 +154,7 @@ GRAMMAR EXTEND Gram
     | "10" LEFTA
       [ f = operconstr; args = LIST1 appl_arg -> { CAst.make ~loc @@ CApp((None,f),args) }
       | "@"; f = global; i = univ_instance; args = LIST0 NEXT -> { CAst.make ~loc @@ CAppExpl((None,f,i),args) }
-      | "@"; lid = pattern_identref; args = LIST1 identref ->
+      | "@"; lid = pattern_identref; args = LIST1 lident ->
         { let { CAst.loc = locid; v = id } = lid in
           let args = List.map (fun x -> CAst.make @@ CRef (qualid_of_ident ?loc:x.CAst.loc x.CAst.v, None), None) args in
           CAst.make ~loc @@ CApp((None, CAst.make ?loc:locid @@ CPatVar id),args) } ]
@@ -286,21 +286,21 @@ GRAMMAR EXTEND Gram
   ;
   fix_decls:
     [ [ dcl = fix_decl -> { let (id,_,_,_,_) = dcl.CAst.v in (id,[dcl.CAst.v]) }
-      | dcl = fix_decl; "with"; dcls = LIST1 fix_decl SEP "with"; "for"; id = identref ->
+      | dcl = fix_decl; "with"; dcls = LIST1 fix_decl SEP "with"; "for"; id = lident ->
         { (id,List.map (fun x -> x.CAst.v) (dcl::dcls)) } ] ]
   ;
   cofix_decls:
     [ [ dcl = cofix_decl -> { let (id,_,_,_) = dcl.CAst.v in (id,[dcl.CAst.v]) }
-      | dcl = cofix_decl; "with"; dcls = LIST1 cofix_decl SEP "with"; "for"; id = identref ->
+      | dcl = cofix_decl; "with"; dcls = LIST1 cofix_decl SEP "with"; "for"; id = lident ->
         { (id,List.map (fun x -> x.CAst.v) (dcl::dcls)) } ] ]
   ;
   fix_decl:
-    [ [ id = identref; bl = binders_fixannot; ty = type_cstr; ":=";
+    [ [ id = lident; bl = binders_fixannot; ty = type_cstr; ":=";
         c = operconstr LEVEL "200" ->
         { CAst.make ~loc (id,snd bl,fst bl,ty,c) } ] ]
   ;
   cofix_decl:
-    [ [ id = identref; bl = binders; ty = type_cstr; ":=";
+    [ [ id = lident; bl = binders; ty = type_cstr; ":=";
         c = operconstr LEVEL "200" ->
         { CAst.make ~loc (id,bl,ty,c) } ] ]
   ;
@@ -374,9 +374,9 @@ GRAMMAR EXTEND Gram
       | s = string -> { CAst.make ~loc @@ CPatPrim (String s) } ] ]
   ;
   fixannot:
-    [ [ "{"; IDENT "struct"; id = identref; "}" -> { CAst.make ~loc @@ CStructRec id }
-      | "{"; IDENT "wf"; rel = constr; id = identref; "}" -> { CAst.make ~loc @@ CWfRec(id,rel) }
-      | "{"; IDENT "measure"; m = constr; id = OPT identref; rel = OPT constr; "}" ->
+    [ [ "{"; IDENT "struct"; id = lident; "}" -> { CAst.make ~loc @@ CStructRec id }
+      | "{"; IDENT "wf"; rel = constr; id = lident; "}" -> { CAst.make ~loc @@ CWfRec(id,rel) }
+      | "{"; IDENT "measure"; m = constr; id = OPT lident; rel = OPT constr; "}" ->
         { CAst.make ~loc @@ CMeasureRec (id,m,rel) } ] ]
   ;
   binders_fixannot:

--- a/parsing/g_constr.mlg
+++ b/parsing/g_constr.mlg
@@ -252,7 +252,7 @@ GRAMMAR EXTEND Gram
       | "cofix"; c = cofix_decls -> { let (id,dcls) = c in CAst.make ~loc @@ CCoFix (id,dcls) } ] ]
   ;
   appl_arg:
-    [ [ test_lpar_id_coloneq; "("; id = ident; ":="; c = lconstr; ")" -> { (c,Some (CAst.make ~loc @@ ExplByName id)) }
+    [ [ test_lpar_id_coloneq; "("; id = lident; ":="; c = lconstr; ")" -> { (c,Some (CAst.make ?loc:id.CAst.loc @@ ExplByName id.CAst.v)) }
       | c=operconstr LEVEL "9" -> { (c,None) } ] ]
   ;
   atomic_constr:
@@ -261,12 +261,12 @@ GRAMMAR EXTEND Gram
       | n = NUMBER-> { CAst.make ~loc @@ CPrim (Numeral (NumTok.SPlus,n)) }
       | s = string -> { CAst.make ~loc @@ CPrim (String s) }
       | "_"      -> { CAst.make ~loc @@ CHole (None, IntroAnonymous, None) }
-      | "?"; "["; id = ident; "]"  -> { CAst.make ~loc @@  CHole (None, IntroIdentifier id, None) }
+      | "?"; "["; id = lident; "]"  -> { CAst.make ~loc @@  CHole (None, IntroIdentifier id.CAst.v, None) }
       | "?"; "["; id = pattern_ident; "]"  -> { CAst.make ~loc @@  CHole (None, IntroFresh id, None) }
       | id = pattern_ident; inst = evar_instance -> { CAst.make ~loc @@ CEvar(id,inst) } ] ]
   ;
   inst:
-    [ [ id = ident; ":="; c = lconstr -> { (id,c) } ] ]
+    [ [ id = lident; ":="; c = lconstr -> { (id,c) } ] ]
   ;
   evar_instance:
     [ [ "@{"; l = LIST1 inst SEP ";"; "}" -> { l }

--- a/parsing/g_constr.mlg
+++ b/parsing/g_constr.mlg
@@ -154,7 +154,7 @@ GRAMMAR EXTEND Gram
     | "10" LEFTA
       [ f = operconstr; args = LIST1 appl_arg -> { CAst.make ~loc @@ CApp((None,f),args) }
       | "@"; f = global; i = univ_instance; args = LIST0 NEXT -> { CAst.make ~loc @@ CAppExpl((None,f,i),args) }
-      | "@"; lid = pattern_identref; args = LIST1 lident ->
+      | "@"; lid = pattern_ident; args = LIST1 lident ->
         { let { CAst.loc = locid; v = id } = lid in
           let args = List.map (fun x -> CAst.make @@ CRef (qualid_of_ident ?loc:x.CAst.loc x.CAst.v, None), None) args in
           CAst.make ~loc @@ CApp((None, CAst.make ?loc:locid @@ CPatVar id),args) } ]
@@ -262,7 +262,7 @@ GRAMMAR EXTEND Gram
       | s = string -> { CAst.make ~loc @@ CPrim (String s) }
       | "_"      -> { CAst.make ~loc @@ CHole (None, IntroAnonymous, None) }
       | "?"; "["; id = lident; "]"  -> { CAst.make ~loc @@  CHole (None, IntroIdentifier id.CAst.v, None) }
-      | "?"; "["; id = pattern_ident; "]"  -> { CAst.make ~loc @@  CHole (None, IntroFresh id, None) }
+      | "?"; "["; id = pattern_ident; "]"  -> { CAst.make ~loc @@  CHole (None, IntroFresh id.CAst.v, None) }
       | id = pattern_ident; inst = evar_instance -> { CAst.make ~loc @@ CEvar(id,inst) } ] ]
   ;
   inst:

--- a/parsing/g_constr.mlg
+++ b/parsing/g_constr.mlg
@@ -82,12 +82,9 @@ let test_array_closing =
 GRAMMAR EXTEND Gram
   GLOBAL: binder_constr lconstr constr operconstr
   universe_level universe_name sort sort_family
-  global constr_pattern lconstr_pattern Constr.ident
+  global constr_pattern lconstr_pattern
   closed_binder open_binders binder binders binders_fixannot
   record_declaration typeclass_constraint pattern appl_arg type_cstr;
-  Constr.ident:
-    [ [ id = Prim.ident -> { id } ] ]
-  ;
   Prim.name:
     [ [ "_" -> { CAst.make ~loc Anonymous } ] ]
   ;

--- a/parsing/g_prim.mlg
+++ b/parsing/g_prim.mlg
@@ -45,7 +45,7 @@ let test_minus_nat =
 
 GRAMMAR EXTEND Gram
   GLOBAL:
-    bignat bigint natural integer identref name ident var preident
+    bignat bigint natural integer identref name ident lident var preident
     fullyqualid qualid reference dirpath ne_lstring
     ne_string string lstring pattern_ident pattern_identref by_notation
     smart_global bar_cbrace strategy_level;
@@ -64,8 +64,11 @@ GRAMMAR EXTEND Gram
   var: (* as identref, but interpret as a term identifier in ltac *)
     [ [ id = ident -> { CAst.make ~loc id } ] ]
   ;
-  identref:
+  lident:
     [ [ id = ident -> { CAst.make ~loc id } ] ]
+  ;
+  identref:
+    [ [ id = lident -> { id } ] ]
   ;
   field:
     [ [ s = FIELD -> { Id.of_string s } ] ]

--- a/parsing/g_prim.mlg
+++ b/parsing/g_prim.mlg
@@ -47,7 +47,7 @@ GRAMMAR EXTEND Gram
   GLOBAL:
     bignat bigint natural integer identref name ident lident var preident
     fullyqualid qualid reference dirpath ne_lstring
-    ne_string string lstring pattern_ident pattern_identref by_notation
+    ne_string string lstring pattern_ident by_notation
     smart_global bar_cbrace strategy_level;
   preident:
     [ [ s = IDENT -> { s } ] ]
@@ -56,10 +56,7 @@ GRAMMAR EXTEND Gram
     [ [ s = IDENT -> { Id.of_string s } ] ]
   ;
   pattern_ident:
-    [ [ LEFTQMARK; id = ident -> { id } ] ]
-  ;
-  pattern_identref:
-    [ [ id = pattern_ident -> { CAst.make ~loc id } ] ]
+    [ [ LEFTQMARK; id = ident -> { CAst.make ~loc id } ] ]
   ;
   var: (* as identref, but interpret as a term identifier in ltac *)
     [ [ id = ident -> { CAst.make ~loc id } ] ]

--- a/parsing/g_prim.mlg
+++ b/parsing/g_prim.mlg
@@ -45,7 +45,7 @@ let test_minus_nat =
 
 GRAMMAR EXTEND Gram
   GLOBAL:
-    bignat bigint natural integer identref name ident lident var preident
+    bignat bigint natural integer name ident lident var preident
     fullyqualid qualid reference dirpath ne_lstring
     ne_string string lstring pattern_ident by_notation
     smart_global bar_cbrace strategy_level;
@@ -55,16 +55,13 @@ GRAMMAR EXTEND Gram
   ident:
     [ [ s = IDENT -> { Id.of_string s } ] ]
   ;
-  pattern_ident:
-    [ [ LEFTQMARK; id = ident -> { CAst.make ~loc id } ] ]
-  ;
-  var: (* as identref, but interpret as a term identifier in ltac *)
-    [ [ id = ident -> { CAst.make ~loc id } ] ]
-  ;
   lident:
     [ [ id = ident -> { CAst.make ~loc id } ] ]
   ;
-  identref:
+  pattern_ident:
+    [ [ LEFTQMARK; id = ident -> { CAst.make ~loc id } ] ]
+  ;
+  var: (* as lident, but interpret as a term identifier in ltac *)
     [ [ id = lident -> { id } ] ]
   ;
   field:

--- a/parsing/pcoq.ml
+++ b/parsing/pcoq.ml
@@ -283,7 +283,6 @@ module Prim =
 
     let name = Entry.create "Prim.name"
     let lident = Entry.create "Prim.lident"
-    let identref = Entry.create "Prim.identref"
     let univ_decl = Entry.create "Prim.univ_decl"
     let ident_decl = Entry.create "Prim.ident_decl"
     let pattern_ident = Entry.create "pattern_ident"

--- a/parsing/pcoq.ml
+++ b/parsing/pcoq.ml
@@ -312,7 +312,6 @@ module Constr =
     let constr_eoi = eoi_entry constr
     let lconstr = gec_constr "lconstr"
     let binder_constr = gec_constr "binder_constr"
-    let ident = make_gen_entry uconstr "ident"
     let global = make_gen_entry uconstr "global"
     let universe_name = make_gen_entry uconstr "universe_name"
     let universe_level = make_gen_entry uconstr "universe_level"

--- a/parsing/pcoq.ml
+++ b/parsing/pcoq.ml
@@ -287,7 +287,6 @@ module Prim =
     let univ_decl = Entry.create "Prim.univ_decl"
     let ident_decl = Entry.create "Prim.ident_decl"
     let pattern_ident = Entry.create "pattern_ident"
-    let pattern_identref = Entry.create "pattern_identref"
 
     (* A synonym of ident - maybe ident will be located one day *)
     let base_ident = Entry.create "Prim.base_ident"

--- a/parsing/pcoq.ml
+++ b/parsing/pcoq.ml
@@ -505,6 +505,7 @@ let () =
   Grammar.register0 wit_int (Prim.integer);
   Grammar.register0 wit_string (Prim.string);
   Grammar.register0 wit_pre_ident (Prim.preident);
+  Grammar.register0 wit_lident (Prim.lident);
   Grammar.register0 wit_ident (Prim.ident);
   Grammar.register0 wit_var (Prim.var);
   Grammar.register0 wit_ref (Prim.reference);

--- a/parsing/pcoq.ml
+++ b/parsing/pcoq.ml
@@ -282,6 +282,7 @@ module Prim =
     let var = gec_gen "var"
 
     let name = Entry.create "Prim.name"
+    let lident = Entry.create "Prim.lident"
     let identref = Entry.create "Prim.identref"
     let univ_decl = Entry.create "Prim.univ_decl"
     let ident_decl = Entry.create "Prim.ident_decl"

--- a/parsing/pcoq.mli
+++ b/parsing/pcoq.mli
@@ -148,7 +148,8 @@ module Prim :
     val preident : string Entry.t
     val ident : Id.t Entry.t
     val name : lname Entry.t
-    val identref : lident Entry.t
+    val lident : lident Entry.t
+    val identref : lident Entry.t (* Synonymous of lident *)
     val univ_decl : universe_decl_expr Entry.t
     val ident_decl : ident_decl Entry.t
     val pattern_ident : Id.t Entry.t

--- a/parsing/pcoq.mli
+++ b/parsing/pcoq.mli
@@ -149,7 +149,6 @@ module Prim :
     val ident : Id.t Entry.t
     val name : lname Entry.t
     val lident : lident Entry.t
-    val identref : lident Entry.t (* Synonymous of lident *)
     val univ_decl : universe_decl_expr Entry.t
     val ident_decl : ident_decl Entry.t
     val pattern_ident : lident Entry.t

--- a/parsing/pcoq.mli
+++ b/parsing/pcoq.mli
@@ -152,8 +152,7 @@ module Prim :
     val identref : lident Entry.t (* Synonymous of lident *)
     val univ_decl : universe_decl_expr Entry.t
     val ident_decl : ident_decl Entry.t
-    val pattern_ident : Id.t Entry.t
-    val pattern_identref : lident Entry.t
+    val pattern_ident : lident Entry.t
     val base_ident : Id.t Entry.t
     val bignat : string Entry.t
     val natural : int Entry.t

--- a/parsing/pcoq.mli
+++ b/parsing/pcoq.mli
@@ -180,7 +180,6 @@ module Constr :
     val lconstr : constr_expr Entry.t
     val binder_constr : constr_expr Entry.t
     val operconstr : constr_expr Entry.t
-    val ident : Id.t Entry.t
     val global : qualid Entry.t
     val universe_name : Glob_term.glob_sort_name Entry.t
     val universe_level : Glob_term.glob_level Entry.t

--- a/plugins/derive/g_derive.mlg
+++ b/plugins/derive/g_derive.mlg
@@ -23,6 +23,6 @@ let classify_derive_command _ = Vernacextend.(VtStartProof (Doesn'tGuaranteeOpac
 }
 
 VERNAC COMMAND EXTEND Derive CLASSIFIED BY { classify_derive_command } STATE open_proof
-| [ "Derive" ident(f) "SuchThat" constr(suchthat) "As" ident(lemma) ] ->
-  { Derive.start_deriving f suchthat lemma }
+| [ "Derive" lident(f) "SuchThat" constr(suchthat) "As" lident(lemma) ] ->
+  { Derive.start_deriving f.CAst.v suchthat lemma.CAst.v }
 END

--- a/plugins/extraction/extract_env.ml
+++ b/plugins/extraction/extract_env.ml
@@ -643,10 +643,10 @@ let simple_extraction r =
 (*s (Recursive) Extraction of a library. The vernacular command is
   \verb!(Recursive) Extraction Library! [M]. *)
 
-let extraction_library is_rec m =
+let extraction_library is_rec CAst.{loc;v=m} =
   init true true;
   let dir_m =
-    let q = qualid_of_ident m in
+    let q = qualid_of_ident ?loc m in
     try Nametab.full_name_module q with Not_found -> error_unknown_module q
   in
   Visit.add_mp_all (MPfile dir_m);

--- a/plugins/extraction/extract_env.mli
+++ b/plugins/extraction/extract_env.mli
@@ -16,7 +16,7 @@ open Libnames
 val simple_extraction : qualid -> unit
 val full_extraction : string option -> qualid list -> unit
 val separate_extraction : qualid list -> unit
-val extraction_library : bool -> Id.t -> unit
+val extraction_library : bool -> lident -> unit
 
 (* For the test-suite : extraction to a temporary file + ocamlc on it *)
 

--- a/plugins/extraction/g_extraction.mlg
+++ b/plugins/extraction/g_extraction.mlg
@@ -94,12 +94,12 @@ END
 
 (* Modular extraction (one Coq library = one ML module) *)
 VERNAC COMMAND EXTEND ExtractionLibrary CLASSIFIED AS QUERY
-| [ "Extraction" "Library" ident(m) ]
+| [ "Extraction" "Library" lident(m) ]
   -> { extraction_library false m }
 END
 
 VERNAC COMMAND EXTEND RecursiveExtractionLibrary CLASSIFIED AS QUERY
-| [ "Recursive" "Extraction" "Library" ident(m) ]
+| [ "Recursive" "Extraction" "Library" lident(m) ]
   -> { extraction_library true m }
 END
 
@@ -138,7 +138,7 @@ END
 
 VERNAC COMMAND EXTEND ExtractionBlacklist CLASSIFIED AS SIDEFF
 (* Force Extraction to not use some filenames *)
-| [ "Extraction" "Blacklist" ne_ident_list(l) ]
+| [ "Extraction" "Blacklist" ne_preident_list(l) ]
   -> { extraction_blacklist l }
 END
 

--- a/plugins/extraction/table.ml
+++ b/plugins/extraction/table.ml
@@ -761,7 +761,7 @@ let blacklist_extraction : string list -> obj =
 (* Grammar entries. *)
 
 let extraction_blacklist l =
-  let l = List.rev_map Id.to_string l in
+  let l = List.rev l in
   Lib.add_anonymous_leaf (blacklist_extraction l)
 
 (* Printing part *)

--- a/plugins/extraction/table.mli
+++ b/plugins/extraction/table.mli
@@ -208,7 +208,7 @@ val extraction_implicit : qualid -> int_or_id list -> unit
 
 (*s Table of blacklisted filenames *)
 
-val extraction_blacklist : Id.t list -> unit
+val extraction_blacklist : string list -> unit
 val reset_extraction_blacklist : unit -> unit
 val print_extraction_blacklist : unit -> Pp.t
 

--- a/plugins/funind/g_indfun.mlg
+++ b/plugins/funind/g_indfun.mlg
@@ -218,7 +218,7 @@ let pr_fun_scheme_arg (princ_name,fun_name,s) =
 
 VERNAC ARGUMENT EXTEND fun_scheme_arg
 PRINTED BY { pr_fun_scheme_arg }
-| [ ident(princ_name) ":=" "Induction" "for" reference(fun_name) "Sort" sort_family(s) ] -> { (princ_name,fun_name,s) }
+| [ lident(princ_name) ":=" "Induction" "for" reference(fun_name) "Sort" sort_family(s) ] -> { (princ_name.CAst.v,fun_name,s) }
 END
 
 {

--- a/plugins/funind/invfun.ml
+++ b/plugins/funind/invfun.ml
@@ -100,7 +100,7 @@ let functional_inversion kn hid fconst f_correct =
               [applist (f_correct, Array.to_list f_args @ [res; mkVar hid])]
           ; clear [hid]
           ; Simple.intro hid
-          ; Inv.inv Inv.FullInversion None (Tactypes.NamedHyp hid)
+          ; Inv.inv Inv.FullInversion None (Tactypes.NamedHyp (CAst.make hid))
           ; Proofview.Goal.enter (fun gl ->
                 let new_ids =
                   List.filter

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -999,8 +999,8 @@ let rec make_rewrite_list expr_info max = function
                    (* dep proofs also: *) true
                    ( mkVar hp
                    , ExplicitBindings
-                       [ CAst.make @@ (NamedHyp def, expr_info.f_constr)
-                       ; CAst.make @@ (NamedHyp k, f_S max) ] )
+                       [ CAst.make @@ (NamedHyp (CAst.make def), expr_info.f_constr)
+                       ; CAst.make @@ (NamedHyp (CAst.make k), f_S max) ] )
                    false)
                 g))
          [ make_rewrite_list expr_info max l
@@ -1035,8 +1035,8 @@ let make_rewrite expr_info l hp max =
                     (* dep proofs also: *) true
                     ( mkVar hp
                     , ExplicitBindings
-                        [ CAst.make @@ (NamedHyp def, expr_info.f_constr)
-                        ; CAst.make @@ (NamedHyp k, f_S (f_S max)) ] )
+                        [ CAst.make @@ (NamedHyp (CAst.make def), expr_info.f_constr)
+                        ; CAst.make @@ (NamedHyp (CAst.make k), f_S (f_S max)) ] )
                     false))
               g)
           [ observe_tac

--- a/plugins/ltac/extraargs.mlg
+++ b/plugins/ltac/extraargs.mlg
@@ -33,7 +33,7 @@ let () = create_generic_quotation "string" Pcoq.Prim.string Stdarg.wit_string
 
 let () = create_generic_quotation "smart_global" Pcoq.Prim.smart_global Stdarg.wit_smart_global
 
-let () = create_generic_quotation "ident" Pcoq.Prim.ident Stdarg.wit_ident
+let () = create_generic_quotation "ident" Pcoq.Prim.lident Stdarg.wit_lident
 let () = create_generic_quotation "reference" Pcoq.Prim.reference Stdarg.wit_ref
 let () = create_generic_quotation "uconstr" Pcoq.Constr.lconstr Stdarg.wit_uconstr
 let () = create_generic_quotation "constr" Pcoq.Constr.lconstr Stdarg.wit_constr
@@ -266,31 +266,34 @@ ARGUMENT EXTEND hloc
     { ConclLocation () }
   |  [ "in" "|-" "*" ] ->
     { ConclLocation () }
-| [ "in" ident(id) ] ->
-    { HypLocation ((CAst.make id),InHyp) }
-| [ "in" "(" "Type" "of" ident(id) ")" ] ->
-    { warn_deprecated_instantiate_syntax ("Type","type",id);
-      HypLocation ((CAst.make id),InHypTypeOnly) }
-| [ "in" "(" "Value" "of" ident(id) ")" ] ->
-    { warn_deprecated_instantiate_syntax ("Value","value",id);
-      HypLocation ((CAst.make id),InHypValueOnly) }
-| [ "in" "(" "type" "of" ident(id) ")" ] ->
-    { HypLocation ((CAst.make id),InHypTypeOnly) }
-| [ "in" "(" "value" "of" ident(id) ")" ] ->
-    { HypLocation ((CAst.make id),InHypValueOnly) }
+| [ "in" lident(id) ] ->
+    { HypLocation (id,InHyp) }
+| [ "in" "(" "Type" "of" lident(id) ")" ] ->
+    { warn_deprecated_instantiate_syntax ~loc ("Type","type",id.CAst.v);
+      HypLocation (id,InHypTypeOnly) }
+| [ "in" "(" "Value" "of" lident(id) ")" ] ->
+    { warn_deprecated_instantiate_syntax ~loc ("Value","value",id.CAst.v);
+      HypLocation (id,InHypValueOnly) }
+| [ "in" "(" "type" "of" lident(id) ")" ] ->
+    { HypLocation (id,InHypTypeOnly) }
+| [ "in" "(" "value" "of" lident(id) ")" ] ->
+    { HypLocation (id,InHypValueOnly) }
 
  END
 
 {
 
 let pr_rename _ _ _ (n, m) = Id.print n ++ str " into " ++ Id.print m
+let pr_loc_rename a b c (n, m) = pr_rename a b c (n.CAst.v, m.CAst.v)
 
 }
 
 ARGUMENT EXTEND rename
-  TYPED AS (ident * ident)
+  TYPED AS (lident * lident)
   PRINTED BY { pr_rename }
-| [ ident(n) "into" ident(m) ] -> { (n, m) }
+  RAW_PRINTED BY { pr_loc_rename }
+  GLOB_PRINTED BY { pr_loc_rename }
+| [ lident(n) "into" lident(m) ] -> { (n, m) }
 END
 
 (* Julien: Mise en commun des differentes version de replace with in by *)

--- a/plugins/ltac/extraargs.mlg
+++ b/plugins/ltac/extraargs.mlg
@@ -397,5 +397,5 @@ ARGUMENT EXTEND strategy_level_or_var
     RAW_PRINTED BY { pr_loc_strategy }
     GLOB_PRINTED BY { pr_loc_strategy }
 | [ strategy_level(n) ] -> { ArgArg n }
-| [ identref(id) ] -> { ArgVar id }
+| [ lident(id) ] -> { ArgVar id }
 END

--- a/plugins/ltac/extraargs.mli
+++ b/plugins/ltac/extraargs.mli
@@ -18,7 +18,7 @@ val wit_orient : bool Genarg.uniform_genarg_type
 val orient : bool Pcoq.Entry.t
 val pr_orient : bool -> Pp.t
 
-val wit_rename : (Id.t * Id.t) Genarg.uniform_genarg_type
+val wit_rename : (lident * lident, lident * lident, Id.t * Id.t) Genarg.genarg_type
 
 val occurrences : (int list Locus.or_var) Pcoq.Entry.t
 val wit_occurrences : (int list Locus.or_var, int list Locus.or_var, int list) Genarg.genarg_type

--- a/plugins/ltac/extratactics.mlg
+++ b/plugins/ltac/extratactics.mlg
@@ -90,7 +90,7 @@ END
 
 let induction_arg_of_quantified_hyp = function
   | AnonHyp n -> None,ElimOnAnonHyp n
-  | NamedHyp id -> None,ElimOnIdent (CAst.make id)
+  | NamedHyp id -> None,ElimOnIdent id
 
 (* Versions *_main must come first!! so that "1" is interpreted as a
    ElimOnAnonHyp and not as a "constr", and "id" is interpreted as a
@@ -766,7 +766,7 @@ let case_eq_intros_rewrite x =
   end
 
 let rec find_a_destructable_match sigma t =
-  let cl = induction_arg_of_quantified_hyp (NamedHyp (Id.of_string "x")) in
+  let cl = induction_arg_of_quantified_hyp (NamedHyp (CAst.make (Id.of_string "x"))) in
   let cl = [cl, (None, None), None], None in
   let dest = TacAtom (CAst.make @@ TacInductionDestruct(false, false, cl)) in
   match EConstr.kind sigma t with

--- a/plugins/ltac/extratactics.mlg
+++ b/plugins/ltac/extratactics.mlg
@@ -400,7 +400,10 @@ END
 open Inv
 open Leminv
 
-let seff id = VtSideff ([id], VtLater)
+let seff id = VtSideff ([id.CAst.v], VtLater)
+
+let add_inversion_lemma_exn ~poly na com comsort bool tac =
+  add_inversion_lemma_exn ~poly na.CAst.v com comsort bool tac
 
 }
 
@@ -411,36 +414,36 @@ let seff id = VtSideff ([id], VtLater)
 END*)
 
 VERNAC COMMAND EXTEND DeriveInversionClear
-| #[ polymorphic; ] [ "Derive" "Inversion_clear" ident(na) "with" constr(c) "Sort" sort_family(s) ]
+| #[ polymorphic; ] [ "Derive" "Inversion_clear" lident(na) "with" constr(c) "Sort" sort_family(s) ]
   => { seff na }
   -> {
       add_inversion_lemma_exn ~poly:polymorphic na c s false inv_clear_tac }
 
-| #[ polymorphic; ] [ "Derive" "Inversion_clear" ident(na) "with" constr(c) ] => { seff na }
+| #[ polymorphic; ] [ "Derive" "Inversion_clear" lident(na) "with" constr(c) ] => { seff na }
   -> {
       add_inversion_lemma_exn ~poly:polymorphic na c Sorts.InProp false inv_clear_tac }
 END
 
 VERNAC COMMAND EXTEND DeriveInversion
-| #[ polymorphic; ] [ "Derive" "Inversion" ident(na) "with" constr(c) "Sort" sort_family(s) ]
+| #[ polymorphic; ] [ "Derive" "Inversion" lident(na) "with" constr(c) "Sort" sort_family(s) ]
   => { seff na }
   -> {
       add_inversion_lemma_exn ~poly:polymorphic na c s false inv_tac }
 
-| #[ polymorphic; ] [ "Derive" "Inversion" ident(na) "with" constr(c) ] => { seff na }
+| #[ polymorphic; ] [ "Derive" "Inversion" lident(na) "with" constr(c) ] => { seff na }
   -> {
       add_inversion_lemma_exn ~poly:polymorphic na c Sorts.InProp false inv_tac }
 END
 
 VERNAC COMMAND EXTEND DeriveDependentInversion
-| #[ polymorphic; ] [ "Derive" "Dependent" "Inversion" ident(na) "with" constr(c) "Sort" sort_family(s) ]
+| #[ polymorphic; ] [ "Derive" "Dependent" "Inversion" lident(na) "with" constr(c) "Sort" sort_family(s) ]
   => { seff na }
   -> {
       add_inversion_lemma_exn ~poly:polymorphic na c s true dinv_tac }
 END
 
 VERNAC COMMAND EXTEND DeriveDependentInversionClear
-| #[ polymorphic; ] [ "Derive" "Dependent" "Inversion_clear" ident(na) "with" constr(c) "Sort" sort_family(s) ]
+| #[ polymorphic; ] [ "Derive" "Dependent" "Inversion_clear" lident(na) "with" constr(c) "Sort" sort_family(s) ]
   => { seff na }
   -> {
       add_inversion_lemma_exn ~poly:polymorphic na c s true dinv_clear_tac }
@@ -477,12 +480,12 @@ open Evar_tactics
 (* TODO: add support for some test similar to g_constr.name_colon so that
    expressions like "evar (list A)" do not raise a syntax error *)
 TACTIC EXTEND evar
-| [ "evar" test_lpar_id_colon "(" ident(id) ":" lconstr(typ) ")" ] -> { let_evar (Name.Name id) typ }
+| [ "evar" test_lpar_id_colon "(" lident(id) ":" lconstr(typ) ")" ] -> { let_evar (Name.Name id) typ }
 | [ "evar" constr(typ) ] -> { let_evar Name.Anonymous typ }
 END
 
 TACTIC EXTEND instantiate
-| [ "instantiate" "(" ident(id) ":=" lglob(c) ")" ] ->
+| [ "instantiate" "(" lident(id) ":=" lglob(c) ")" ] ->
     { Tacticals.New.tclTHEN (instantiate_tac_by_name id c) Proofview.V82.nf_evar_goals }
 | [ "instantiate" "(" integer(i) ":=" lglob(c) ")" hloc(hl) ] ->
     { Tacticals.New.tclTHEN (instantiate_tac i c hl) Proofview.V82.nf_evar_goals }
@@ -688,8 +691,8 @@ let hResolve_auto id c t =
 }
 
 TACTIC EXTEND hresolve_core
-| [ "hresolve_core" "(" ident(id) ":=" constr(c) ")" "at" int_or_var(occ) "in" constr(t) ] -> { hResolve id c occ t }
-| [ "hresolve_core" "(" ident(id) ":=" constr(c) ")" "in" constr(t) ] -> { hResolve_auto id c t }
+| [ "hresolve_core" "(" lident(id) ":=" constr(c) ")" "at" int_or_var(occ) "in" constr(t) ] -> { hResolve id c occ t }
+| [ "hresolve_core" "(" lident(id) ":=" constr(c) ")" "in" constr(t) ] -> { hResolve_auto id c t }
 END
 
 (**
@@ -811,7 +814,7 @@ END
 TACTIC EXTEND transparent_abstract
 | [ "transparent_abstract" tactic3(t) ] -> { Proofview.Goal.enter begin fun gl ->
     Abstract.tclABSTRACT ~opaque:false None (Tacinterp.tactic_of_value ist t) end; }
-| [ "transparent_abstract" tactic3(t) "using" ident(id) ] -> { Proofview.Goal.enter begin fun gl ->
+| [ "transparent_abstract" tactic3(t) "using" lident(id) ] -> { Proofview.Goal.enter begin fun gl ->
     Abstract.tclABSTRACT ~opaque:false (Some id) (Tacinterp.tactic_of_value ist t) end; }
 END
 

--- a/plugins/ltac/g_ltac.mlg
+++ b/plugins/ltac/g_ltac.mlg
@@ -231,7 +231,7 @@ GRAMMAR EXTEND Gram
          { (CAst.map (fun id -> Name id) idr, arg_of_expr (TacFun(args,te))) } ] ]
   ;
   match_pattern:
-    [ [ IDENT "context";  oid = OPT Constr.ident;
+    [ [ IDENT "context";  oid = OPT lident;
           "["; pc = Constr.lconstr_pattern; "]" ->
         { Subterm (oid, pc) }
       | pc = Constr.lconstr_pattern -> { Term pc } ] ]

--- a/plugins/ltac/g_ltac.mlg
+++ b/plugins/ltac/g_ltac.mlg
@@ -220,7 +220,7 @@ GRAMMAR EXTEND Gram
   ;
   input_fun:
     [ [ "_" -> { Name.Anonymous }
-      | l = ident -> { Name.Name l } ] ]
+      | l = lident -> { Name.Name l.CAst.v } ] ]
   ;
   let_clause:
     [ [ idr = lident; ":="; te = tactic_expr ->
@@ -316,7 +316,7 @@ GRAMMAR EXTEND Gram
   ;
   selector_body:
   [ [ l = range_selector_or_nth -> { l }
-    | test_bracket_ident; "["; id = ident; "]" -> { Goal_select.SelectId id } ] ]
+    | test_bracket_ident; "["; id = lident; "]" -> { Goal_select.SelectId id.CAst.v } ] ]
   ;
   selector:
     [ [ IDENT "only"; sel = selector_body; ":" -> { sel } ] ]
@@ -471,10 +471,10 @@ let pr_ltac_production_item = function
 
 VERNAC ARGUMENT EXTEND ltac_production_item PRINTED BY { pr_ltac_production_item }
 | [ string(s) ] -> { Tacentries.TacTerm s }
-| [ ident(nt) "(" ident(p) ltac_production_sep_opt(sep) ")" ] ->
-  { Tacentries.TacNonTerm (Loc.tag ~loc ((Id.to_string nt, sep), Some p)) }
-| [ ident(nt) ] ->
-  { Tacentries.TacNonTerm (Loc.tag ~loc ((Id.to_string nt, None), None)) }
+| [ preident(nt) "(" lident(p) ltac_production_sep_opt(sep) ")" ] ->
+  { Tacentries.TacNonTerm (Loc.tag ~loc ((nt, sep), Some p.CAst.v)) }
+| [ preident(nt) ] ->
+  { Tacentries.TacNonTerm (Loc.tag ~loc ((nt, None), None)) }
 END
 
 VERNAC COMMAND EXTEND VernacTacticNotation

--- a/plugins/ltac/g_ltac.mlg
+++ b/plugins/ltac/g_ltac.mlg
@@ -199,7 +199,7 @@ GRAMMAR EXTEND Gram
   constr_eval:
     [ [ IDENT "eval"; rtc = red_expr; "in"; c = Constr.constr ->
           { ConstrEval (rtc,c) }
-      | IDENT "context"; id = identref; "["; c = Constr.lconstr; "]" ->
+      | IDENT "context"; id = lident; "["; c = Constr.lconstr; "]" ->
           { ConstrContext (id,c) }
       | IDENT "type"; IDENT "of"; c = Constr.constr ->
           { ConstrTypeOf c } ] ]
@@ -223,11 +223,11 @@ GRAMMAR EXTEND Gram
       | l = ident -> { Name.Name l } ] ]
   ;
   let_clause:
-    [ [ idr = identref; ":="; te = tactic_expr ->
+    [ [ idr = lident; ":="; te = tactic_expr ->
          { (CAst.map (fun id -> Name id) idr, arg_of_expr te) }
       | na = ["_" -> { CAst.make ~loc Anonymous } ]; ":="; te = tactic_expr ->
          { (na, arg_of_expr te) }
-      | idr = identref; args = LIST1 input_fun; ":="; te = tactic_expr ->
+      | idr = lident; args = LIST1 input_fun; ":="; te = tactic_expr ->
          { (CAst.map (fun id -> Name id) idr, arg_of_expr (TacFun(args,te))) } ] ]
   ;
   match_pattern:
@@ -269,7 +269,7 @@ GRAMMAR EXTEND Gram
       | "|"; mrl = LIST1 match_rule SEP "|" -> { mrl } ] ]
   ;
   message_token:
-    [ [ id = identref -> { MsgIdent id }
+    [ [ id = lident -> { MsgIdent id }
       | s = STRING -> { MsgString s }
       | n = natural -> { MsgInt n } ] ]
   ;

--- a/plugins/ltac/g_ltac.mlg
+++ b/plugins/ltac/g_ltac.mlg
@@ -122,7 +122,7 @@ GRAMMAR EXTEND Gram
       | IDENT "infoH"; ta = tactic_expr -> { TacShowHyps ta }
 (*To do: put Abstract in Refiner*)
       | IDENT "abstract"; tc = NEXT -> { TacAbstract (tc,None) }
-      | IDENT "abstract"; tc = NEXT; "using";  s = ident ->
+      | IDENT "abstract"; tc = NEXT; "using";  s = lident ->
         { TacAbstract (tc,Some s) }
       | sel = selector; ta = tactic_expr -> { TacSelect (sel, ta) } ]
 (*End of To do*)

--- a/plugins/ltac/g_obligations.mlg
+++ b/plugins/ltac/g_obligations.mlg
@@ -88,29 +88,29 @@ let classify_obbl _ = Vernacextend.(VtStartProof (Doesn'tGuaranteeOpacity,[]))
 }
 
 VERNAC COMMAND EXTEND Obligations CLASSIFIED BY { classify_obbl } STATE declare_program
-| [ "Obligation" natural(num) "of" ident(name) ":" lglob(t) withtac(tac) ] ->
-    { obligation (num, Some name, Some t) tac }
-| [ "Obligation" natural(num) "of" ident(name) withtac(tac) ] ->
-    { obligation (num, Some name, None) tac }
+| [ "Obligation" natural(num) "of" lident(name) ":" lglob(t) withtac(tac) ] ->
+    { obligation (num, Some name.CAst.v, Some t) tac }
+| [ "Obligation" natural(num) "of" lident(name) withtac(tac) ] ->
+    { obligation (num, Some name.CAst.v, None) tac }
 | [ "Obligation" natural(num) ":" lglob(t) withtac(tac) ] ->
     { obligation (num, None, Some t) tac }
 | [ "Obligation" natural(num) withtac(tac) ] ->
     { obligation (num, None, None) tac }
-| [ "Next" "Obligation" "of" ident(name) withtac(tac) ] ->
-    { next_obligation (Some name) tac }
+| [ "Next" "Obligation" "of" lident(name) withtac(tac) ] ->
+    { next_obligation (Some name.CAst.v) tac }
 | [ "Next" "Obligation" withtac(tac) ] -> { next_obligation None tac }
 END
 
 VERNAC COMMAND EXTEND Solve_Obligation CLASSIFIED AS SIDEFF STATE program
-| [ "Solve" "Obligation" natural(num) "of" ident(name) "with" tactic(t) ] ->
-    { try_solve_obligation num (Some name) (Some (Tacinterp.interp t)) }
+| [ "Solve" "Obligation" natural(num) "of" lident(name) "with" tactic(t) ] ->
+    { try_solve_obligation num (Some name.CAst.v) (Some (Tacinterp.interp t)) }
 | [ "Solve" "Obligation" natural(num) "with" tactic(t) ] ->
     { try_solve_obligation num None (Some (Tacinterp.interp t)) }
 END
 
 VERNAC COMMAND EXTEND Solve_Obligations CLASSIFIED AS SIDEFF STATE program
-| [ "Solve" "Obligations" "of" ident(name) "with" tactic(t) ] ->
-    { try_solve_obligations (Some name) (Some (Tacinterp.interp t)) }
+| [ "Solve" "Obligations" "of" lident(name) "with" tactic(t) ] ->
+    { try_solve_obligations (Some name.CAst.v) (Some (Tacinterp.interp t)) }
 | [ "Solve" "Obligations" "with" tactic(t) ] ->
     { try_solve_obligations None (Some (Tacinterp.interp t)) }
 | [ "Solve" "Obligations" ] ->
@@ -125,7 +125,7 @@ VERNAC COMMAND EXTEND Solve_All_Obligations CLASSIFIED AS SIDEFF STATE program
 END
 
 VERNAC COMMAND EXTEND Admit_Obligations CLASSIFIED AS SIDEFF STATE program
-| [ "Admit" "Obligations" "of" ident(name) ] -> { admit_obligations (Some name) }
+| [ "Admit" "Obligations" "of" lident(name) ] -> { admit_obligations (Some name.CAst.v) }
 | [ "Admit" "Obligations" ] -> { admit_obligations None }
 END
 
@@ -149,12 +149,12 @@ VERNAC COMMAND EXTEND Show_Solver CLASSIFIED AS QUERY
 END
 
 VERNAC COMMAND EXTEND Show_Obligations CLASSIFIED AS QUERY STATE read_program
-| [ "Obligations" "of" ident(name) ] -> { show_obligations (Some name) }
+| [ "Obligations" "of" lident(name) ] -> { show_obligations (Some name.CAst.v) }
 | [ "Obligations" ] -> { show_obligations None }
 END
 
 VERNAC COMMAND EXTEND Show_Preterm CLASSIFIED AS QUERY STATE read_program
-| [ "Preterm" "of" ident(name) ] -> { fun ~pm -> Feedback.msg_notice (show_term ~pm (Some name)) }
+| [ "Preterm" "of" lident(name) ] -> { fun ~pm -> Feedback.msg_notice (show_term ~pm (Some name.CAst.v)) }
 | [ "Preterm" ] -> { fun ~pm -> Feedback.msg_notice (show_term ~pm None) }
 END
 

--- a/plugins/ltac/g_rewrite.mlg
+++ b/plugins/ltac/g_rewrite.mlg
@@ -179,36 +179,43 @@ TACTIC EXTEND setoid_rewrite
       { cl_rewrite_clause c o (occurrences_of occ) (Some id) }
 END
 
+{
+
+let declare_relation atts a ?binders aeq n refl symm trans =
+  declare_relation atts a ?binders aeq n.CAst.v refl symm trans
+
+}
+
 VERNAC COMMAND EXTEND AddRelation CLASSIFIED AS SIDEFF
   | #[ atts = rewrite_attributes; ] [ "Add" "Relation" constr(a) constr(aeq) "reflexivity" "proved" "by" constr(lemma1)
-        "symmetry" "proved" "by" constr(lemma2) "as" ident(n) ] ->
+        "symmetry" "proved" "by" constr(lemma2) "as" lident(n) ] ->
       { declare_relation atts a aeq n (Some lemma1) (Some lemma2) None }
 
   | #[ atts = rewrite_attributes; ] [ "Add" "Relation" constr(a) constr(aeq) "reflexivity" "proved" "by" constr(lemma1)
-        "as" ident(n) ] ->
+        "as" lident(n) ] ->
       { declare_relation atts a aeq n (Some lemma1) None None }
-  | #[ atts = rewrite_attributes; ] [ "Add" "Relation" constr(a) constr(aeq)  "as" ident(n) ] ->
+  | #[ atts = rewrite_attributes; ] [ "Add" "Relation" constr(a) constr(aeq)  "as" lident(n) ] ->
       { declare_relation atts a aeq n None None None }
 END
 
 VERNAC COMMAND EXTEND AddRelation2 CLASSIFIED AS SIDEFF
   | #[ atts = rewrite_attributes; ] [ "Add" "Relation" constr(a) constr(aeq) "symmetry" "proved" "by" constr(lemma2)
-      "as" ident(n) ] ->
+      "as" lident(n) ] ->
       { declare_relation atts a aeq n None (Some lemma2) None }
-  | #[ atts = rewrite_attributes; ] [ "Add" "Relation" constr(a) constr(aeq) "symmetry" "proved" "by" constr(lemma2) "transitivity" "proved" "by" constr(lemma3)  "as" ident(n) ] ->
+  | #[ atts = rewrite_attributes; ] [ "Add" "Relation" constr(a) constr(aeq) "symmetry" "proved" "by" constr(lemma2) "transitivity" "proved" "by" constr(lemma3)  "as" lident(n) ] ->
       { declare_relation atts a aeq n None (Some lemma2) (Some lemma3) }
 END
 
 VERNAC COMMAND EXTEND AddRelation3 CLASSIFIED AS SIDEFF
   | #[ atts = rewrite_attributes; ] [ "Add" "Relation" constr(a) constr(aeq) "reflexivity" "proved" "by" constr(lemma1)
-      "transitivity" "proved" "by" constr(lemma3) "as" ident(n) ] ->
+      "transitivity" "proved" "by" constr(lemma3) "as" lident(n) ] ->
       { declare_relation atts a aeq n (Some lemma1) None (Some lemma3) }
   | #[ atts = rewrite_attributes; ] [ "Add" "Relation" constr(a) constr(aeq) "reflexivity" "proved" "by" constr(lemma1)
       "symmetry" "proved" "by" constr(lemma2) "transitivity" "proved" "by" constr(lemma3)
-      "as" ident(n) ] ->
+      "as" lident(n) ] ->
       { declare_relation atts a aeq n (Some lemma1) (Some lemma2) (Some lemma3) }
   | #[ atts = rewrite_attributes; ] [ "Add" "Relation" constr(a) constr(aeq) "transitivity" "proved" "by" constr(lemma3)
-        "as" ident(n) ] ->
+        "as" lident(n) ] ->
       { declare_relation atts a aeq n None None (Some lemma3) }
 END
 
@@ -236,61 +243,68 @@ END
 VERNAC COMMAND EXTEND AddParametricRelation CLASSIFIED AS SIDEFF
   | #[ atts = rewrite_attributes; ] [ "Add" "Parametric" "Relation" binders(b) ":" constr(a) constr(aeq)
         "reflexivity" "proved" "by" constr(lemma1)
-        "symmetry" "proved" "by" constr(lemma2) "as" ident(n) ] ->
+        "symmetry" "proved" "by" constr(lemma2) "as" lident(n) ] ->
       { declare_relation atts ~binders:b a aeq n (Some lemma1) (Some lemma2) None }
   | #[ atts = rewrite_attributes; ] [ "Add" "Parametric" "Relation" binders(b) ":" constr(a) constr(aeq)
         "reflexivity" "proved" "by" constr(lemma1)
-        "as" ident(n) ] ->
+        "as" lident(n) ] ->
       { declare_relation atts ~binders:b a aeq n (Some lemma1) None None }
-  | #[ atts = rewrite_attributes; ] [ "Add" "Parametric" "Relation" binders(b) ":" constr(a) constr(aeq)  "as" ident(n) ] ->
+  | #[ atts = rewrite_attributes; ] [ "Add" "Parametric" "Relation" binders(b) ":" constr(a) constr(aeq)  "as" lident(n) ] ->
       { declare_relation atts ~binders:b a aeq n None None None }
 END
 
 VERNAC COMMAND EXTEND AddParametricRelation2 CLASSIFIED AS SIDEFF
   | #[ atts = rewrite_attributes; ] [ "Add" "Parametric" "Relation" binders(b) ":" constr(a) constr(aeq) "symmetry" "proved" "by" constr(lemma2)
-      "as" ident(n) ] ->
+      "as" lident(n) ] ->
       { declare_relation atts ~binders:b a aeq n None (Some lemma2) None }
-  | #[ atts = rewrite_attributes; ] [ "Add" "Parametric" "Relation" binders(b) ":" constr(a) constr(aeq) "symmetry" "proved" "by" constr(lemma2) "transitivity" "proved" "by" constr(lemma3)  "as" ident(n) ] ->
+  | #[ atts = rewrite_attributes; ] [ "Add" "Parametric" "Relation" binders(b) ":" constr(a) constr(aeq) "symmetry" "proved" "by" constr(lemma2) "transitivity" "proved" "by" constr(lemma3)  "as" lident(n) ] ->
       { declare_relation atts ~binders:b a aeq n None (Some lemma2) (Some lemma3) }
 END
 
 VERNAC COMMAND EXTEND AddParametricRelation3 CLASSIFIED AS SIDEFF
   | #[ atts = rewrite_attributes; ] [ "Add" "Parametric" "Relation" binders(b) ":" constr(a) constr(aeq) "reflexivity" "proved" "by" constr(lemma1)
-      "transitivity" "proved" "by" constr(lemma3) "as" ident(n) ] ->
+      "transitivity" "proved" "by" constr(lemma3) "as" lident(n) ] ->
       { declare_relation atts ~binders:b a aeq n (Some lemma1) None (Some lemma3) }
   | #[ atts = rewrite_attributes; ] [ "Add" "Parametric" "Relation" binders(b) ":" constr(a) constr(aeq) "reflexivity" "proved" "by" constr(lemma1)
       "symmetry" "proved" "by" constr(lemma2) "transitivity" "proved" "by" constr(lemma3)
-      "as" ident(n) ] ->
+      "as" lident(n) ] ->
       { declare_relation atts ~binders:b a aeq n (Some lemma1) (Some lemma2) (Some lemma3) }
   | #[ atts = rewrite_attributes; ] [ "Add" "Parametric" "Relation" binders(b) ":" constr(a) constr(aeq) "transitivity" "proved" "by" constr(lemma3)
-        "as" ident(n) ] ->
+        "as" lident(n) ] ->
       { declare_relation atts ~binders:b a aeq n None None (Some lemma3) }
 END
 
+{
+
+let add_setoid atts binders a aeq t n =
+  add_setoid atts binders a aeq t n.CAst.v
+
+}
+
 VERNAC COMMAND EXTEND AddSetoid1 CLASSIFIED AS SIDEFF
-  | #[ atts = rewrite_attributes; ] [ "Add" "Setoid" constr(a) constr(aeq) constr(t) "as" ident(n) ] ->
+  | #[ atts = rewrite_attributes; ] [ "Add" "Setoid" constr(a) constr(aeq) constr(t) "as" lident(n) ] ->
      {
          add_setoid atts [] a aeq t n
      }
-  | #[ atts = rewrite_attributes; ] [ "Add" "Parametric" "Setoid" binders(binders) ":" constr(a) constr(aeq) constr(t) "as" ident(n) ] ->
+  | #[ atts = rewrite_attributes; ] [ "Add" "Parametric" "Setoid" binders(binders) ":" constr(a) constr(aeq) constr(t) "as" lident(n) ] ->
      {
          add_setoid atts binders a aeq t n
      }
-  | #[ atts = rewrite_attributes; ] ![ open_proof ] [ "Add" "Morphism" constr(m) ":" ident(n) ]
-    => { VtStartProof(GuaranteesOpacity, [n]) }
+  | #[ atts = rewrite_attributes; ] ![ open_proof ] [ "Add" "Morphism" constr(m) ":" lident(n) ]
+    => { VtStartProof(GuaranteesOpacity, [n.CAst.v]) }
     -> { if Lib.is_modtype () then
            CErrors.user_err Pp.(str "Add Morphism cannot be used in a module type. Use Parameter Morphism instead.");
-         add_morphism_interactive atts m n }
-  | #[ atts = rewrite_attributes; ] [ "Declare" "Morphism" constr(m) ":" ident(n) ]
-    => { VtSideff([n], VtLater) }
-    -> { add_morphism_as_parameter atts m n }
-  | #[ atts = rewrite_attributes; ] ![ open_proof ] [ "Add" "Morphism" constr(m) "with" "signature" lconstr(s) "as" ident(n) ]
-    => { VtStartProof(GuaranteesOpacity,[n]) }
-    -> { add_morphism atts [] m s n }
+         add_morphism_interactive atts m n.CAst.v }
+  | #[ atts = rewrite_attributes; ] [ "Declare" "Morphism" constr(m) ":" lident(n) ]
+    => { VtSideff([n.CAst.v], VtLater) }
+    -> { add_morphism_as_parameter atts m n.CAst.v }
+  | #[ atts = rewrite_attributes; ] ![ open_proof ] [ "Add" "Morphism" constr(m) "with" "signature" lconstr(s) "as" lident(n) ]
+    => { VtStartProof(GuaranteesOpacity,[n.CAst.v]) }
+    -> { add_morphism atts [] m s n.CAst.v }
   | #[ atts = rewrite_attributes; ] ![ open_proof ] [ "Add" "Parametric" "Morphism" binders(binders) ":" constr(m)
-        "with" "signature" lconstr(s) "as" ident(n) ]
-    => { VtStartProof(GuaranteesOpacity,[n]) }
-    -> { add_morphism atts binders m s n }
+        "with" "signature" lconstr(s) "as" lident(n) ]
+    => { VtStartProof(GuaranteesOpacity,[n.CAst.v]) }
+    -> { add_morphism atts binders m s n.CAst.v }
 END
 
 TACTIC EXTEND setoid_symmetry

--- a/plugins/ltac/g_tactic.mlg
+++ b/plugins/ltac/g_tactic.mlg
@@ -282,7 +282,7 @@ GRAMMAR EXTEND Gram
   naming_intropattern:
     [ [ prefix = pattern_ident -> { IntroFresh prefix.CAst.v }
       | "?" -> { IntroAnonymous }
-      | id = ident -> { IntroIdentifier id } ] ]
+      | id = lident -> { IntroIdentifier id.CAst.v } ] ]
   ;
   intropattern:
     [ [ l = simple_intropattern -> { l }
@@ -425,20 +425,20 @@ GRAMMAR EXTEND Gram
     ] ]
   ;
   fixdecl:
-    [ [ "("; id = ident; bl=LIST0 simple_binder; ann=struct_annot;
-        ":"; ty=lconstr; ")" -> { (loc, id, bl, ann, ty) } ] ]
+    [ [ "("; id = lident; bl=LIST0 simple_binder; ann=struct_annot;
+        ":"; ty=lconstr; ")" -> { (loc, id.CAst.v, bl, ann, ty) } ] ]
   ;
   struct_annot:
     [ [ "{"; IDENT "struct"; id=name; "}" -> { Some id }
       | -> { None } ] ]
   ;
   cofixdecl:
-    [ [ "("; id = ident; bl=LIST0 simple_binder; ":"; ty=lconstr; ")" ->
-        { (loc, id, bl, None, ty) } ] ]
+    [ [ "("; id = lident; bl=LIST0 simple_binder; ":"; ty=lconstr; ")" ->
+        { (loc, id.CAst.v, bl, None, ty) } ] ]
   ;
   bindings_with_parameters:
-    [ [ check_for_coloneq; "(";  id = ident; bl = LIST0 simple_binder;
-        ":="; c = lconstr; ")" -> { (id, mkCLambdaN_simple bl c) } ] ]
+    [ [ check_for_coloneq; "(";  id = lident; bl = LIST0 simple_binder;
+        ":="; c = lconstr; ")" -> { (id.CAst.v, mkCLambdaN_simple bl c) } ] ]
   ;
   eliminator:
     [ [ "using"; el = constr_with_bindings -> { el } ] ]
@@ -460,7 +460,7 @@ GRAMMAR EXTEND Gram
       | -> { None } ] ]
   ;
   as_name:
-    [ [ "as"; id = ident -> { Names.Name.Name id } | -> { Names.Name.Anonymous } ] ]
+    [ [ "as"; id = lident -> { Names.Name.Name id.CAst.v } | -> { Names.Name.Anonymous } ] ]
   ;
   by_tactic:
     [ [ "by"; tac = tactic_expr LEVEL "3" -> { Some tac }
@@ -519,10 +519,10 @@ GRAMMAR EXTEND Gram
           { TacAtom (CAst.make ~loc @@ TacElim (true,cl,el)) }
       | IDENT "case"; icl = induction_clause_list -> { TacAtom (CAst.make ~loc @@ mkTacCase false icl) }
       | IDENT "ecase"; icl = induction_clause_list -> { TacAtom (CAst.make ~loc @@ mkTacCase true icl) }
-      | "fix"; id = ident; n = natural; "with"; fd = LIST1 fixdecl ->
-          { TacAtom (CAst.make ~loc @@ TacMutualFix (id,n,List.map mk_fix_tac fd)) }
-      | "cofix"; id = ident; "with"; fd = LIST1 cofixdecl ->
-          { TacAtom (CAst.make ~loc @@ TacMutualCofix (id,List.map mk_cofix_tac fd)) }
+      | "fix"; id = lident; n = natural; "with"; fd = LIST1 fixdecl ->
+          { TacAtom (CAst.make ~loc @@ TacMutualFix (id.CAst.v,n,List.map mk_fix_tac fd)) }
+      | "cofix"; id = lident; "with"; fd = LIST1 cofixdecl ->
+          { TacAtom (CAst.make ~loc @@ TacMutualCofix (id.CAst.v,List.map mk_cofix_tac fd)) }
 
       | IDENT "pose"; bl = bindings_with_parameters ->
           { let (id,b) = bl in TacAtom (CAst.make ~loc @@ TacLetTac (false,Names.Name.Name id,b,Locusops.nowhere,true,None)) }

--- a/plugins/ltac/g_tactic.mlg
+++ b/plugins/ltac/g_tactic.mlg
@@ -280,7 +280,7 @@ GRAMMAR EXTEND Gram
       | "[="; tc = intropatterns; "]" -> { IntroInjection tc } ] ]
   ;
   naming_intropattern:
-    [ [ prefix = pattern_ident -> { IntroFresh prefix }
+    [ [ prefix = pattern_ident -> { IntroFresh prefix.CAst.v }
       | "?" -> { IntroAnonymous }
       | id = ident -> { IntroIdentifier id } ] ]
   ;

--- a/plugins/ltac/g_tactic.mlg
+++ b/plugins/ltac/g_tactic.mlg
@@ -130,7 +130,7 @@ let mkTacCase with_evar = function
   (* Reinterpret numbers as a notation for terms *)
   | [(clear,ElimOnAnonHyp n),(None,None),None],None ->
       TacCase (with_evar,
-        (clear,(CAst.make @@ CPrim (mkNumeral n),
+        (clear,(CAst.make @@ CPrim (mkNumeral n.CAst.v),
          NoBindings)))
   (* Reinterpret ident as notations for variables in the context *)
   (* because we don't know if they are quantified or not *)
@@ -212,7 +212,7 @@ GRAMMAR EXTEND Gram
     [ [ c = constr -> { c } ] ]
   ;
   destruction_arg:
-    [ [ n = natural -> { (None,ElimOnAnonHyp n) }
+    [ [ n = lnatural -> { (None,ElimOnAnonHyp n) }
       | test_lpar_id_rpar; c = constr_with_bindings ->
         { (Some false,destruction_arg_of_constr c) }
       | c = constr_with_bindings_arg -> { on_snd destruction_arg_of_constr c }
@@ -223,8 +223,8 @@ GRAMMAR EXTEND Gram
       | c = constr_with_bindings -> { (None,c) } ] ]
   ;
   quantified_hypothesis:
-    [ [ id = ident -> { NamedHyp id }
-      | n = natural -> { AnonHyp n } ] ]
+    [ [ id = lident -> { NamedHyp id }
+      | n = lnatural -> { AnonHyp n } ] ]
   ;
   conversion:
     [ [ c = constr -> { (None, c) }
@@ -305,9 +305,12 @@ GRAMMAR EXTEND Gram
       | "_" -> { CAst.make ~loc @@ IntroAction IntroWildcard }
       | pat = naming_intropattern -> { CAst.make ~loc @@ IntroNaming pat } ] ]
   ;
+  lnatural:
+    [ [ n = natural -> { CAst.make ~loc n } ] ]
+  ;
   simple_binding:
-    [ [ "("; id = ident; ":="; c = lconstr; ")" -> { CAst.make ~loc (NamedHyp id, c) }
-      | "("; n = natural; ":="; c = lconstr; ")" -> { CAst.make ~loc (AnonHyp n, c) } ] ]
+    [ [ "("; id = lident; ":="; c = lconstr; ")" -> { CAst.make ~loc (NamedHyp id, c) }
+      | "("; n = lnatural; ":="; c = lconstr; ")" -> { CAst.make ~loc (AnonHyp n, c) } ] ]
   ;
   bindings:
     [ [ test_lpar_idnum_coloneq; bl = LIST1 simple_binding ->

--- a/plugins/ltac/g_tactic.mlg
+++ b/plugins/ltac/g_tactic.mlg
@@ -195,15 +195,15 @@ GRAMMAR EXTEND Gram
 
   int_or_var:
     [ [ n = integer  -> { ArgArg n }
-      | id = identref -> { ArgVar id } ] ]
+      | id = lident -> { ArgVar id } ] ]
   ;
   nat_or_var:
     [ [ n = natural  -> { ArgArg n }
-      | id = identref -> { ArgVar id } ] ]
+      | id = lident -> { ArgVar id } ] ]
   ;
   (* An identifier or a quotation meta-variable *)
   id_or_meta:
-    [ [ id = identref -> { id } ] ]
+    [ [ id = lident -> { id } ] ]
   ;
   open_constr:
     [ [ c = constr -> { c } ] ]
@@ -446,7 +446,7 @@ GRAMMAR EXTEND Gram
   ;
   or_and_intropattern_loc:
     [ [ ipat = or_and_intropattern -> { ArgArg (CAst.make ~loc ipat) }
-      | locid = identref -> { ArgVar locid } ] ]
+      | locid = lident -> { ArgVar locid } ] ]
   ;
   as_or_and_ipat:
     [ [ "as"; ipat = or_and_intropattern_loc -> { Some ipat }
@@ -545,31 +545,31 @@ GRAMMAR EXTEND Gram
           { TacAtom (CAst.make ~loc @@ TacLetTac (true,na,c,p,false,e)) }
 
       (* Alternative syntax for "pose proof c as id" *)
-      | IDENT "assert"; test_lpar_id_coloneq; "("; lid = identref; ":=";
+      | IDENT "assert"; test_lpar_id_coloneq; "("; lid = lident; ":=";
           c = lconstr; ")" ->
           { let { CAst.loc = loc; v = id } = lid in
           TacAtom (CAst.make ?loc @@ TacAssert (false,true,None,Some (CAst.make ?loc @@ IntroNaming (IntroIdentifier id)),c)) }
-      | IDENT "eassert"; test_lpar_id_coloneq; "("; lid = identref; ":=";
+      | IDENT "eassert"; test_lpar_id_coloneq; "("; lid = lident; ":=";
           c = lconstr; ")" ->
           { let { CAst.loc = loc; v = id } = lid in
           TacAtom (CAst.make ?loc @@ TacAssert (true,true,None,Some (CAst.make ?loc @@ IntroNaming (IntroIdentifier id)),c)) }
 
       (* Alternative syntax for "assert c as id by tac" *)
-      | IDENT "assert"; test_lpar_id_colon; "("; lid = identref; ":";
+      | IDENT "assert"; test_lpar_id_colon; "("; lid = lident; ":";
           c = lconstr; ")"; tac=by_tactic ->
           { let { CAst.loc = loc; v = id } = lid in
           TacAtom (CAst.make ?loc @@ TacAssert (false,true,Some tac,Some (CAst.make ?loc @@ IntroNaming (IntroIdentifier id)),c)) }
-      | IDENT "eassert"; test_lpar_id_colon; "("; lid = identref; ":";
+      | IDENT "eassert"; test_lpar_id_colon; "("; lid = lident; ":";
           c = lconstr; ")"; tac=by_tactic ->
           { let { CAst.loc = loc; v = id } = lid in
           TacAtom (CAst.make ?loc @@ TacAssert (true,true,Some tac,Some (CAst.make ?loc @@ IntroNaming (IntroIdentifier id)),c)) }
 
       (* Alternative syntax for "enough c as id by tac" *)
-      | IDENT "enough"; test_lpar_id_colon; "("; lid = identref; ":";
+      | IDENT "enough"; test_lpar_id_colon; "("; lid = lident; ":";
           c = lconstr; ")"; tac=by_tactic ->
           { let { CAst.loc = loc; v = id } = lid in
           TacAtom (CAst.make ?loc @@ TacAssert (false,false,Some tac,Some (CAst.make ?loc @@ IntroNaming (IntroIdentifier id)),c)) }
-      | IDENT "eenough"; test_lpar_id_colon; "("; lid = identref; ":";
+      | IDENT "eenough"; test_lpar_id_colon; "("; lid = lident; ":";
           c = lconstr; ")"; tac=by_tactic ->
           { let { CAst.loc = loc; v = id } = lid in
           TacAtom (CAst.make ?loc @@ TacAssert (true,false,Some tac,Some (CAst.make ?loc @@ IntroNaming (IntroIdentifier id)),c)) }
@@ -580,11 +580,11 @@ GRAMMAR EXTEND Gram
           { TacAtom (CAst.make ~loc @@ TacAssert (true,true,Some tac,ipat,c)) }
 
       (* Alternative syntax for "pose proof c as id by tac" *)
-      | IDENT "pose"; IDENT "proof"; test_lpar_id_coloneq; "("; lid = identref; ":=";
+      | IDENT "pose"; IDENT "proof"; test_lpar_id_coloneq; "("; lid = lident; ":=";
           c = lconstr; ")" ->
           { let { CAst.loc = loc; v = id } = lid in
           TacAtom (CAst.make ?loc @@ TacAssert (false,true,None,Some (CAst.make ?loc @@ IntroNaming (IntroIdentifier id)),c)) }
-      | IDENT "epose"; IDENT "proof"; test_lpar_id_coloneq; "("; lid = identref; ":=";
+      | IDENT "epose"; IDENT "proof"; test_lpar_id_coloneq; "("; lid = lident; ":=";
           c = lconstr; ")" ->
           { let { CAst.loc = loc; v = id } = lid in
           TacAtom (CAst.make ?loc @@ TacAssert (true,true,None,Some (CAst.make ?loc @@ IntroNaming (IntroIdentifier id)),c)) }

--- a/plugins/ltac/pptactic.ml
+++ b/plugins/ltac/pptactic.ml
@@ -1323,6 +1323,7 @@ let () =
   register_basic_print0 wit_smart_global
     (pr_or_by_notation pr_qualid) (pr_or_var (pr_located pr_global)) pr_global;
   register_basic_print0 wit_ident pr_id pr_id pr_id;
+  register_basic_print0 wit_lident pr_lident pr_lident pr_id;
   register_basic_print0 wit_var pr_lident pr_lident pr_id;
   register_print0 wit_intropattern pr_raw_intro_pattern pr_glob_intro_pattern pr_intro_pattern_env [@warning "-3"];
   register_print0 wit_simple_intropattern pr_raw_intro_pattern pr_glob_intro_pattern pr_intro_pattern_env;

--- a/plugins/ltac/pptactic.ml
+++ b/plugins/ltac/pptactic.ml
@@ -538,7 +538,7 @@ let pr_goal_selector ~toplevel s =
     | Subterm (None,a) ->
       keyword "context" ++ str" [ " ++ pr_pat a ++ str " ]"
     | Subterm (Some id,a) ->
-      keyword "context" ++ spc () ++ pr_id id ++ str "[ " ++ pr_pat a ++ str " ]"
+      keyword "context" ++ spc () ++ pr_lident id ++ str "[ " ++ pr_pat a ++ str " ]"
 
   let pr_match_hyps pr_pat = function
     | Hyp (nal,mp) ->

--- a/plugins/ltac/pptactic.ml
+++ b/plugins/ltac/pptactic.ml
@@ -195,8 +195,8 @@ let string_of_genarg_arg (ArgumentType arg) =
     | EvalConstRef sp -> pr_global (GlobRef.ConstRef sp)
 
   let pr_quantified_hypothesis = function
-    | AnonHyp n -> int n
-    | NamedHyp id -> pr_id id
+    | AnonHyp n -> int n.CAst.v
+    | NamedHyp id -> pr_lident id
 
   let pr_clear_flag clear_flag pp x =
     match clear_flag with
@@ -504,7 +504,7 @@ let string_of_genarg_arg (ArgumentType arg) =
   let pr_core_destruction_arg prc prlc = function
     | ElimOnConstr c -> pr_with_bindings prc prlc c
     | ElimOnIdent {CAst.loc;v=id} -> pr_with_comments ?loc (pr_id id)
-    | ElimOnAnonHyp n -> int n
+    | ElimOnAnonHyp {CAst.loc;v=n} -> pr_with_comments ?loc (int n)
 
   let pr_destruction_arg prc prlc (clear_flag,h) =
     pr_clear_flag clear_flag (pr_core_destruction_arg prc prlc) h

--- a/plugins/ltac/pptactic.ml
+++ b/plugins/ltac/pptactic.ml
@@ -896,7 +896,7 @@ let pr_goal_selector ~toplevel s =
               hov 0 (
                 keyword "abstract"
                 ++ str" (" ++ pr_tac (LevelLt labstract) t ++ str")" ++ spc ()
-                ++ keyword "using" ++ spc () ++ pr_id s),
+                ++ keyword "using" ++ spc () ++ pr_lident s),
               labstract
             | TacLetIn (recflag,llc,u) ->
               let llc = List.map (fun (id,t) -> (id,extract_binders t)) llc in

--- a/plugins/ltac/taccoerce.ml
+++ b/plugins/ltac/taccoerce.ml
@@ -357,23 +357,23 @@ let coerce_to_reference sigma v =
 (* (as in Inversion) *)
 let coerce_to_quantified_hypothesis sigma v =
   match is_intro_pattern v with
-  | Some (IntroNaming (IntroIdentifier id)) -> NamedHyp id
+  | Some (IntroNaming (IntroIdentifier id)) -> NamedHyp (CAst.make id)
   | Some _ -> raise (CannotCoerceTo "a quantified hypothesis")
   | None ->
   if has_type v (topwit wit_var) then
     let id = out_gen (topwit wit_var) v in
-    NamedHyp id
+    NamedHyp (CAst.make id)
   else if has_type v (topwit wit_int) then
-    AnonHyp (out_gen (topwit wit_int) v)
+    AnonHyp (CAst.make (out_gen (topwit wit_int) v))
   else match Value.to_constr v with
-  | Some c when isVar sigma c -> NamedHyp (destVar sigma c)
+  | Some c when isVar sigma c -> NamedHyp (CAst.make (destVar sigma c))
   | _ -> raise (CannotCoerceTo "a quantified hypothesis")
 
 (* Quantified named or numbered hypothesis or hypothesis in context *)
 (* (as in Inversion) *)
 let coerce_to_decl_or_quant_hyp sigma v =
   if has_type v (topwit wit_int) then
-    AnonHyp (out_gen (topwit wit_int) v)
+    AnonHyp (CAst.make (out_gen (topwit wit_int) v))
   else
     try coerce_to_quantified_hypothesis sigma v
     with CannotCoerceTo _ ->

--- a/plugins/ltac/tacexpr.ml
+++ b/plugins/ltac/tacexpr.ml
@@ -65,7 +65,7 @@ type 'a with_bindings_arg = clear_flag * 'a with_bindings
 (* Type of patterns *)
 type 'a match_pattern =
   | Term of 'a
-  | Subterm of Id.t option * 'a
+  | Subterm of lident option * 'a
 
 (* Type of hypotheses for a Match Context rule *)
 type 'a match_context_hyps =

--- a/plugins/ltac/tacexpr.ml
+++ b/plugins/ltac/tacexpr.ml
@@ -222,7 +222,7 @@ and 'a gen_tactic_expr =
   | TacProgress of 'a gen_tactic_expr
   | TacShowHyps of 'a gen_tactic_expr
   | TacAbstract of
-      'a gen_tactic_expr * Id.t option
+      'a gen_tactic_expr * 'n option
   | TacId of 'n message_token list
   | TacFail of global_flag * int or_var * 'n message_token list
   | TacLetIn of rec_flag *

--- a/plugins/ltac/tacexpr.mli
+++ b/plugins/ltac/tacexpr.mli
@@ -221,7 +221,7 @@ and 'a gen_tactic_expr =
   | TacProgress of 'a gen_tactic_expr
   | TacShowHyps of 'a gen_tactic_expr
   | TacAbstract of
-      'a gen_tactic_expr * Id.t option
+      'a gen_tactic_expr * 'n option
   | TacId of 'n message_token list
   | TacFail of global_flag * int or_var * 'n message_token list
   | TacLetIn of rec_flag *

--- a/plugins/ltac/tacexpr.mli
+++ b/plugins/ltac/tacexpr.mli
@@ -65,7 +65,7 @@ type 'a with_bindings_arg = clear_flag * 'a with_bindings
 (* Type of patterns *)
 type 'a match_pattern =
   | Term of 'a
-  | Subterm of Id.t option * 'a
+  | Subterm of lident option * 'a
 
 (* Type of hypotheses for a Match Context rule *)
 type 'a match_context_hyps =

--- a/plugins/ltac/tacintern.ml
+++ b/plugins/ltac/tacintern.ml
@@ -486,7 +486,7 @@ let name_cons accu = function
 
 let opt_cons accu = function
 | None -> accu
-| Some id -> Id.Set.add id accu
+| Some {CAst.v=id} -> Id.Set.add id accu
 
 (* Reads the hypotheses of a "match goal" rule *)
 let rec intern_match_goal_hyps ist ?(as_type=false) lfun = function

--- a/plugins/ltac/tacintern.ml
+++ b/plugins/ltac/tacintern.ml
@@ -826,6 +826,10 @@ let intern_ident' ist id =
   let lf = ref Id.Set.empty in
   (ist, intern_ident lf ist id)
 
+let intern_lident ist CAst.{loc;v=id} =
+  let lf = ref Id.Set.empty in
+  (ist, CAst.make ?loc @@ intern_ident lf ist id)
+
 let intern_ltac ist tac =
   Flags.with_option strict_check (fun () -> intern_pure_tactic ist tac) ()
 
@@ -835,6 +839,7 @@ let () =
   Genintern.register_intern0 wit_ref (lift intern_global_reference);
   Genintern.register_intern0 wit_pre_ident (fun ist c -> (ist,c));
   Genintern.register_intern0 wit_ident intern_ident';
+  Genintern.register_intern0 wit_lident intern_lident;
   Genintern.register_intern0 wit_var (lift intern_hyp);
   Genintern.register_intern0 wit_tactic (lift intern_tactic_or_tacarg);
   Genintern.register_intern0 wit_ltac (lift intern_ltac);

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -352,6 +352,9 @@ let interp_ident ist env sigma id =
   try try_interp_ltac_var (coerce_var_to_ident false env sigma) ist (Some (env,sigma)) (make id)
   with Not_found -> id
 
+let interp_lident ist env sigma id =
+  interp_ident ist env sigma id.CAst.v
+
 (* Interprets an optional identifier, bound or fresh *)
 let interp_name ist env sigma = function
   | Anonymous -> Anonymous
@@ -2090,6 +2093,7 @@ let () =
   register_interp0 wit_ref (lift interp_reference);
   register_interp0 wit_pre_ident (lift interp_pre_ident);
   register_interp0 wit_ident (lift interp_ident);
+  register_interp0 wit_lident (lift interp_lident);
   register_interp0 wit_var (lift interp_hyp);
   register_interp0 wit_intropattern (lifts interp_intro_pattern) [@warning "-3"];
   register_interp0 wit_simple_intropattern (lifts interp_intro_pattern);

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -1143,7 +1143,7 @@ and eval_tactic_ist ist tac : unit Proofview.tactic = match tac with
       Profile_ltac.do_profile "eval_tactic:TacAbstract" trace
         (catch_error_tac trace begin
       Proofview.Goal.enter begin fun gl -> Abstract.tclABSTRACT
-        (Option.map (interp_ident ist (pf_env gl) (project gl)) ido) (interp_tactic ist t)
+        (Option.map (interp_lident ist (pf_env gl) (project gl)) ido) (interp_tactic ist t)
       end end)
   | TacThen (t1,t) ->
       Tacticals.New.tclTHEN (interp_tactic ist t1) (interp_tactic ist t)

--- a/plugins/ltac/tactic_matching.ml
+++ b/plugins/ltac/tactic_matching.ml
@@ -47,7 +47,7 @@ let adjust : Constr_matching.bound_ident_map * Ltac_pretype.patvar_map ->
 (** Adds a binding to a {!Id.Map.t} if the identifier is [Some id] *)
 let id_map_try_add id x m =
   match id with
-  | Some id -> Id.Map.add id (Lazy.force x) m
+  | Some {CAst.v=id} -> Id.Map.add id (Lazy.force x) m
   | None -> m
 
 (** Adds a binding to a {!Id.Map.t} if the name is [Name id] *)

--- a/plugins/setoid_ring/g_newring.mlg
+++ b/plugins/setoid_ring/g_newring.mlg
@@ -82,8 +82,8 @@ VERNAC ARGUMENT EXTEND ring_mods
 END
 
 VERNAC COMMAND EXTEND AddSetoidRing CLASSIFIED AS SIDEFF
-  | [ "Add" "Ring" ident(id) ":" constr(t) ring_mods_opt(l) ] ->
-    { add_theory id t (Option.default [] l) }
+  | [ "Add" "Ring" lident(id) ":" constr(t) ring_mods_opt(l) ] ->
+    { add_theory id.CAst.v t (Option.default [] l) }
   | [ "Print" "Rings" ] => { Vernacextend.classify_as_query } -> {
     print_rings ()
   }
@@ -120,8 +120,8 @@ VERNAC ARGUMENT EXTEND field_mods
 END
 
 VERNAC COMMAND EXTEND AddSetoidField CLASSIFIED AS SIDEFF
-| [ "Add" "Field" ident(id) ":" constr(t) field_mods_opt(l) ] ->
-  { let l = match l with None -> [] | Some l -> l in add_field_theory id t l }
+| [ "Add" "Field" lident(id) ":" constr(t) field_mods_opt(l) ] ->
+  { let l = match l with None -> [] | Some l -> l in add_field_theory id.CAst.v t l }
 | [ "Print" "Fields" ] => {Vernacextend.classify_as_query} -> {
     print_fields ()
   }

--- a/plugins/ssr/ssrparser.mlg
+++ b/plugins/ssr/ssrparser.mlg
@@ -166,7 +166,7 @@ open Pcoq.Prim
 ARGUMENT EXTEND ssrhyp TYPED AS ssrhyprep PRINTED BY { pr_ssrhyp }
                        INTERPRETED BY { interp_hyp }
                        GLOBALIZED BY { intern_hyp }
-  | [ ident(id) ] -> { SsrHyp (Loc.tag ~loc id) }
+  | [ lident(id) ] -> { SsrHyp (Loc.tag ~loc id.CAst.v) }
 END
 
 {
@@ -178,14 +178,14 @@ let wit_ssrhoirep = add_genarg "ssrhoirep" (fun env sigma -> pr_hoi)
 
 let intern_ssrhoi ist = function
   | Hyp h -> Hyp (intern_hyp ist h)
-  | Id (SsrHyp (_, id)) as hyp ->
-    let _ = Tacintern.intern_genarg ist (in_gen (rawwit wit_ident) id) in
+  | Id (SsrHyp (loc, id)) as hyp ->
+    let _ = Tacintern.intern_genarg ist (in_gen (rawwit wit_lident) (CAst.make ?loc id)) in
     hyp
 
 let interp_ssrhoi ist gl = function
   | Hyp h -> let s, h' = interp_hyp ist gl h in s, Hyp h'
   | Id (SsrHyp (loc, id)) ->
-    let s, id' = interp_wit wit_ident ist gl id in
+    let s, id' = interp_wit wit_lident ist gl (CAst.make ?loc id) in
     s, Id (SsrHyp (loc, id'))
 
 }
@@ -193,12 +193,12 @@ let interp_ssrhoi ist gl = function
 ARGUMENT EXTEND ssrhoi_hyp TYPED AS ssrhoirep PRINTED BY { pr_ssrhoi }
                        INTERPRETED BY { interp_ssrhoi }
                        GLOBALIZED BY { intern_ssrhoi }
-  | [ ident(id) ] -> { Hyp (SsrHyp(Loc.tag ~loc id)) }
+  | [ lident(id) ] -> { Hyp (SsrHyp(Loc.tag ~loc id.CAst.v)) }
 END
 ARGUMENT EXTEND ssrhoi_id TYPED AS ssrhoirep PRINTED BY { pr_ssrhoi }
                        INTERPRETED BY { interp_ssrhoi }
                        GLOBALIZED BY { intern_ssrhoi }
-  | [ ident(id) ] -> { Id (SsrHyp(Loc.tag ~loc id)) }
+  | [ lident(id) ] -> { Id (SsrHyp(Loc.tag ~loc id.CAst.v)) }
 END
 
 (** Rewriting direction *)
@@ -781,8 +781,8 @@ ARGUMENT EXTEND ssripat TYPED AS ssripatrep list PRINTED BY { pr_ssripats }
   | [ "-/" integer(n) "/" integer (m) "=" ] ->
       { [IPatNoop;IPatSimpl(SimplCut(n,m))] }
   | [ ssrfwdview(v) ] -> { [IPatView v] }
-  | [ "[" ":" ident_list(idl) "]" ] -> { [IPatAbstractVars idl] }
-  | [ "[:" ident_list(idl) "]" ] -> { [IPatAbstractVars idl] }
+  | [ "[" ":" lident_list(idl) "]" ] -> { [IPatAbstractVars (List.map (fun {CAst.v=id} -> id) idl)] }
+  | [ "[:" lident_list(idl) "]" ] -> { [IPatAbstractVars (List.map (fun {CAst.v=id} -> id) idl)] }
 END
 
 ARGUMENT EXTEND ssripats TYPED AS ssripat PRINTED BY { pr_ssripats }
@@ -836,10 +836,10 @@ END
 GRAMMAR EXTEND Gram
   GLOBAL: ssrcpat;
   hat: [
-  [ "^"; id = ident -> { Prefix id }
-  | "^"; "~"; id = ident -> { SuffixId id }
+  [ "^"; id = lident -> { Prefix id.CAst.v }
+  | "^"; "~"; id = lident -> { SuffixId id.CAst.v }
   | "^"; "~"; n = natural -> { SuffixNum n }
-  | "^~"; id = ident -> { SuffixId id }
+  | "^~"; id = lident -> { SuffixId id.CAst.v }
   | "^~"; n = natural -> { SuffixNum n }
   ]];
   ssrcpat: [
@@ -974,12 +974,16 @@ end
 let pr_ssrfwdid id = pr_spc () ++ pr_id id
 
 let pr_ssrfwdidx _ _ _ = pr_ssrfwdid
+let pr_ssrfwdidx_loc _ _ _ id = pr_ssrfwdid id.CAst.v
 
 }
 
 (* We use a primitive parser for the head identifier of forward *)
 (* tactis to avoid syntactic conflicts with basic Coq tactics. *)
-ARGUMENT EXTEND ssrfwdid TYPED AS ident PRINTED BY { pr_ssrfwdidx }
+ARGUMENT EXTEND ssrfwdid TYPED AS lident
+PRINTED BY { pr_ssrfwdidx }
+RAW_PRINTED BY { pr_ssrfwdidx_loc }
+GLOB_PRINTED BY { pr_ssrfwdidx_loc }
 END
 
 {
@@ -994,7 +998,7 @@ let test_ssrfwdid =
 
 GRAMMAR EXTEND Gram
   GLOBAL: ssrfwdid;
-  ssrfwdid: [[ test_ssrfwdid; id = Prim.ident -> { id } ]];
+  ssrfwdid: [[ test_ssrfwdid; id = lident -> { id } ]];
   END
 
 
@@ -1295,7 +1299,7 @@ let pr_ssrbvar env sigma prc _ _ v = prc env sigma v
 }
 
 ARGUMENT EXTEND ssrbvar TYPED AS constr PRINTED BY { pr_ssrbvar env sigma }
-| [ ident(id) ] -> { mkCVar ~loc id }
+| [ lident(id) ] -> { mkCVar ~loc id.CAst.v }
 | [ "_" ] -> { mkCHole (Some loc) }
 END
 
@@ -1379,7 +1383,8 @@ let pr_ssrstruct _ _ _ = function
 
 }
 
-ARGUMENT EXTEND ssrstruct TYPED AS ident option PRINTED BY { pr_ssrstruct }
+ARGUMENT EXTEND ssrstruct TYPED AS ident option
+PRINTED BY { pr_ssrstruct }
 | [ "{" "struct" ident(id) "}" ] -> { Some id }
 | [ ] -> { None }
 END

--- a/plugins/ssr/ssrparser.mli
+++ b/plugins/ssr/ssrparser.mli
@@ -65,7 +65,7 @@ val wit_ssrhintarg :
 
 val wit_ssrexactarg : ssrapplyarg Genarg.uniform_genarg_type
 val wit_ssrcongrarg : ((int * ssrterm) * cpattern ssragens) Genarg.uniform_genarg_type
-val wit_ssrfwdid : Names.Id.t Genarg.uniform_genarg_type
+val wit_ssrfwdid : (Names.lident, Names.lident, Names.Id.t) Genarg.genarg_type
 
 val wit_ssrsetfwd :
   ((ssrfwdfmt * (cpattern * ast_closure_term option)) * ssrdocc) Genarg.uniform_genarg_type

--- a/plugins/ssr/ssrvernac.mlg
+++ b/plugins/ssr/ssrvernac.mlg
@@ -352,8 +352,8 @@ open Pltac
 GRAMMAR EXTEND Gram
   GLOBAL: hypident;
   hypident: [
-  [ "("; IDENT "type"; "of"; id = Prim.identref; ")" -> { id, Locus.InHypTypeOnly }
-  | "("; IDENT "value"; "of"; id = Prim.identref; ")" -> { id, Locus.InHypValueOnly }
+  [ "("; IDENT "type"; "of"; id = Prim.lident; ")" -> { id, Locus.InHypTypeOnly }
+  | "("; IDENT "value"; "of"; id = Prim.lident; ")" -> { id, Locus.InHypValueOnly }
   ] ];
 END
 

--- a/plugins/ssr/ssrvernac.mlg
+++ b/plugins/ssr/ssrvernac.mlg
@@ -360,10 +360,10 @@ END
 GRAMMAR EXTEND Gram
   GLOBAL: hloc;
 hloc: [
-  [ "in"; "("; "Type"; "of"; id = ident; ")" ->
-    { Tacexpr.HypLocation (CAst.make id, Locus.InHypTypeOnly) }
-  | "in"; "("; IDENT "Value"; "of"; id = ident; ")" ->
-    { Tacexpr.HypLocation (CAst.make id, Locus.InHypValueOnly) }
+  [ "in"; "("; "Type"; "of"; id = lident; ")" ->
+    { Tacexpr.HypLocation (id, Locus.InHypTypeOnly) }
+  | "in"; "("; IDENT "Value"; "of"; id = lident; ")" ->
+    { Tacexpr.HypLocation (id, Locus.InHypValueOnly) }
   ] ];
 END
 

--- a/plugins/syntax/g_numeral.mlg
+++ b/plugins/syntax/g_numeral.mlg
@@ -15,7 +15,6 @@ DECLARE PLUGIN "numeral_notation_plugin"
 open Notation
 open Numeral
 open Pp
-open Names
 open Stdarg
 open Pcoq.Prim
 
@@ -40,12 +39,12 @@ END
 
 VERNAC COMMAND EXTEND NumeralNotation CLASSIFIED AS SIDEFF
   | #[ locality = Attributes.locality; ] [ "Number" "Notation" reference(ty) reference(f) reference(g) ":"
-      ident(sc) numnotoption(o) ] ->
+      preident(sc) numnotoption(o) ] ->
 
-    { vernac_numeral_notation (Locality.make_module_locality locality) ty f g (Id.to_string sc) o }
+    { vernac_numeral_notation (Locality.make_module_locality locality) ty f g sc o }
   | #[ locality = Attributes.locality; ] [ "Numeral" "Notation" reference(ty) reference(f) reference(g) ":"
-      ident(sc) numnotoption(o) ] ->
+      preident(sc) numnotoption(o) ] ->
 
     { warn_deprecated_numeral_notation ();
-      vernac_numeral_notation (Locality.make_module_locality locality) ty f g (Id.to_string sc) o }
+      vernac_numeral_notation (Locality.make_module_locality locality) ty f g sc o }
 END

--- a/plugins/syntax/g_string.mlg
+++ b/plugins/syntax/g_string.mlg
@@ -13,13 +13,12 @@ DECLARE PLUGIN "string_notation_plugin"
 {
 
 open String_notation
-open Names
 open Stdarg
 
 }
 
 VERNAC COMMAND EXTEND StringNotation CLASSIFIED AS SIDEFF
   | #[ locality = Attributes.locality; ] [ "String" "Notation" reference(ty) reference(f) reference(g) ":"
-      ident(sc) ] ->
-    { vernac_string_notation (Locality.make_module_locality locality) ty f g (Id.to_string sc) }
+      preident(sc) ] ->
+    { vernac_string_notation (Locality.make_module_locality locality) ty f g sc }
 END

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -715,9 +715,9 @@ and detype_r d flags avoid env sigma t =
         (* Meta in constr are not user-parsable and are mapped to Evar *)
         if n = Constr_matching.special_meta then
           (* Using a dash to be unparsable *)
-          GEvar (Id.of_string_soft "CONTEXT-HOLE", [])
+          GEvar (CAst.make @@ Id.of_string_soft "CONTEXT-HOLE", [])
         else
-          GEvar (Id.of_string_soft ("M" ^ string_of_int n), [])
+          GEvar (CAst.make @@ Id.of_string_soft ("M" ^ string_of_int n), [])
     | Var id ->
         (* Discriminate between section variable and non-section variable *)
         (try let _ = Global.lookup_named id in GRef (GlobRef.VarRef id, None)
@@ -793,7 +793,7 @@ and detype_r d flags avoid env sigma t =
           Id.of_string ("X" ^ string_of_int (Evar.repr evk)),
           (List.map (fun c -> (CAst.make @@ Id.of_string "__",c)) cl)
       in
-        GEvar (id,
+        GEvar (CAst.make id,
                List.map (on_snd (detype d flags avoid env sigma)) l)
     | Ind (ind_sp,u) ->
         GRef (GlobRef.IndRef ind_sp, detype_instance sigma u)

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -788,10 +788,10 @@ and detype_r d flags avoid env sigma t =
           let l = Evd.evar_instance_array bound_to_itself_or_letin (Evd.find sigma evk) cl in
           let fvs,rels = List.fold_left (fun (fvs,rels) (_,c) -> match EConstr.kind sigma c with Rel n -> (fvs,Int.Set.add n rels) | Var id -> (Id.Set.add id fvs,rels) | _ -> (fvs,rels)) (Id.Set.empty,Int.Set.empty) l in
           let l = Evd.evar_instance_array (fun d c -> not !print_evar_arguments && (bound_to_itself_or_letin d c && not (isRel sigma c && Int.Set.mem (destRel sigma c) rels || isVar sigma c && (Id.Set.mem (destVar sigma c) fvs)))) (Evd.find sigma evk) cl in
-          id,l
+          id,List.map (fun (id,c) -> (CAst.make id,c)) l
         with Not_found ->
           Id.of_string ("X" ^ string_of_int (Evar.repr evk)),
-          (List.map (fun c -> (Id.of_string "__",c)) cl)
+          (List.map (fun c -> (CAst.make @@ Id.of_string "__",c)) cl)
       in
         GEvar (id,
                List.map (on_snd (detype d flags avoid env sigma)) l)

--- a/pretyping/glob_ops.ml
+++ b/pretyping/glob_ops.ml
@@ -128,7 +128,7 @@ let fix_kind_eq k1 k2 = match k1, k2 with
   | (GFix _ | GCoFix _), _ -> false
 
 let instance_eq f (x1,c1) (x2,c2) =
-  Id.equal x1 x2 && f c1 c2
+  Id.equal x1.CAst.v x2.CAst.v && f c1 c2
 
 let mk_glob_constr_eq f c1 c2 = match DAst.get c1, DAst.get c2 with
   | GRef (gr1, u1), GRef (gr2, u2) ->

--- a/pretyping/glob_ops.ml
+++ b/pretyping/glob_ops.ml
@@ -136,7 +136,7 @@ let mk_glob_constr_eq f c1 c2 = match DAst.get c1, DAst.get c2 with
     Option.equal (List.equal glob_level_eq) u1 u2
   | GVar id1, GVar id2 -> Id.equal id1 id2
   | GEvar (id1, arg1), GEvar (id2, arg2) ->
-    Id.equal id1 id2 && List.equal (instance_eq f) arg1 arg2
+    Id.equal id1.CAst.v id2.CAst.v && List.equal (instance_eq f) arg1 arg2
   | GPatVar k1, GPatVar k2 -> matching_var_kind_eq k1 k2
   | GApp (f1, arg1), GApp (f2, arg2) ->
     f f1 f2 && List.equal f arg1 arg2

--- a/pretyping/glob_term.ml
+++ b/pretyping/glob_term.ml
@@ -75,7 +75,7 @@ type 'a glob_constr_r =
   | GVar of Id.t
       (** An identifier that cannot be regarded as "GRef".
           Bound variables are typically represented this way. *)
-  | GEvar   of existential_name * (Id.t * 'a glob_constr_g) list
+  | GEvar   of existential_name * (lident * 'a glob_constr_g) list
   | GPatVar of Evar_kinds.matching_var_kind (** Used for patterns only *)
   | GApp    of 'a glob_constr_g * 'a glob_constr_g list
   | GLambda of Name.t * binding_kind *  'a glob_constr_g * 'a glob_constr_g

--- a/pretyping/glob_term.ml
+++ b/pretyping/glob_term.ml
@@ -75,7 +75,7 @@ type 'a glob_constr_r =
   | GVar of Id.t
       (** An identifier that cannot be regarded as "GRef".
           Bound variables are typically represented this way. *)
-  | GEvar   of existential_name * (lident * 'a glob_constr_g) list
+  | GEvar   of existential_name CAst.t * (lident * 'a glob_constr_g) list
   | GPatVar of Evar_kinds.matching_var_kind (** Used for patterns only *)
   | GApp    of 'a glob_constr_g * 'a glob_constr_g list
   | GLambda of Name.t * binding_kind *  'a glob_constr_g * 'a glob_constr_g

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -365,9 +365,9 @@ let inh_conv_coerce_to_tycon ?loc ~program_mode resolve_tc env sigma j = functio
   | Some t ->
     Coercion.inh_conv_coerce_to ?loc ~program_mode resolve_tc !!env sigma j t
 
-let check_instance loc subst = function
+let check_instance subst = function
   | [] -> ()
-  | (id,_) :: _ ->
+  | (CAst.{loc;v=id},_) :: _ ->
       if List.mem_assoc id subst then
         user_err ?loc  (Id.print id ++ str "appears more than once.")
       else
@@ -493,7 +493,7 @@ type 'a pretype_fun = ?loc:Loc.t -> program_mode:bool -> poly:bool -> bool -> ty
 type pretyper = {
   pretype_ref : pretyper -> GlobRef.t * glob_level list option -> unsafe_judgment pretype_fun;
   pretype_var : pretyper -> Id.t -> unsafe_judgment pretype_fun;
-  pretype_evar : pretyper -> existential_name * (Id.t * glob_constr) list -> unsafe_judgment pretype_fun;
+  pretype_evar : pretyper -> existential_name * (lident * glob_constr) list -> unsafe_judgment pretype_fun;
   pretype_patvar : pretyper -> Evar_kinds.matching_var_kind -> unsafe_judgment pretype_fun;
   pretype_app : pretyper -> glob_constr * glob_constr list -> unsafe_judgment pretype_fun;
   pretype_lambda : pretyper -> Name.t * binding_kind * glob_constr * glob_constr -> unsafe_judgment pretype_fun;
@@ -587,10 +587,10 @@ let pretype_instance self ~program_mode ~poly resolve_tc env sigma loc hyps evk 
           strbrk " is not well-typed.") in
     let sigma, c, update =
       try
-        let c = List.assoc id update in
+        let c = snd (List.find (fun (CAst.{v=id'},c) -> Id.equal id id') update) in
         let sigma, c = eval_pretyper self ~program_mode ~poly resolve_tc (mk_tycon t) env sigma c in
         check_body sigma id (Some c.uj_val);
-        sigma, c.uj_val, List.remove_assoc id update
+        sigma, c.uj_val, List.remove_first (fun (CAst.{v=id'},_) -> Id.equal id id') update
       with Not_found ->
       try
         let (n,b',t') = lookup_rel_id id (rel_context !!env) in
@@ -609,7 +609,7 @@ let pretype_instance self ~program_mode ~poly resolve_tc env sigma loc hyps evk 
           str " in current context: no binding for " ++ Id.print id ++ str ".") in
     ((id,c)::subst, update, sigma) in
   let subst,inst,sigma = List.fold_right f hyps ([],update,sigma) in
-  check_instance loc subst inst;
+  check_instance subst inst;
   sigma, List.map snd subst
 
 module Default =

--- a/pretyping/pretyping.mli
+++ b/pretyping/pretyping.mli
@@ -148,7 +148,7 @@ type 'a pretype_fun = ?loc:Loc.t -> program_mode:bool -> poly:bool -> bool -> Ev
 type pretyper = {
   pretype_ref : pretyper -> GlobRef.t * glob_level list option -> unsafe_judgment pretype_fun;
   pretype_var : pretyper -> Id.t -> unsafe_judgment pretype_fun;
-  pretype_evar : pretyper -> existential_name * (Id.t * glob_constr) list -> unsafe_judgment pretype_fun;
+  pretype_evar : pretyper -> existential_name * (lident * glob_constr) list -> unsafe_judgment pretype_fun;
   pretype_patvar : pretyper -> Evar_kinds.matching_var_kind -> unsafe_judgment pretype_fun;
   pretype_app : pretyper -> glob_constr * glob_constr list -> unsafe_judgment pretype_fun;
   pretype_lambda : pretyper -> Name.t * binding_kind * glob_constr * glob_constr -> unsafe_judgment pretype_fun;

--- a/pretyping/pretyping.mli
+++ b/pretyping/pretyping.mli
@@ -148,7 +148,7 @@ type 'a pretype_fun = ?loc:Loc.t -> program_mode:bool -> poly:bool -> bool -> Ev
 type pretyper = {
   pretype_ref : pretyper -> GlobRef.t * glob_level list option -> unsafe_judgment pretype_fun;
   pretype_var : pretyper -> Id.t -> unsafe_judgment pretype_fun;
-  pretype_evar : pretyper -> existential_name * (lident * glob_constr) list -> unsafe_judgment pretype_fun;
+  pretype_evar : pretyper -> existential_name CAst.t * (lident * glob_constr) list -> unsafe_judgment pretype_fun;
   pretype_patvar : pretyper -> Evar_kinds.matching_var_kind -> unsafe_judgment pretype_fun;
   pretype_app : pretyper -> glob_constr * glob_constr list -> unsafe_judgment pretype_fun;
   pretype_lambda : pretyper -> Name.t * binding_kind * glob_constr * glob_constr -> unsafe_judgment pretype_fun;

--- a/printing/ppconstr.ml
+++ b/printing/ppconstr.ml
@@ -227,7 +227,7 @@ let tag_var = tag Tag.variable
 
   let pr_evar pr id l =
     hov 0 (
-      tag_evar (str "?" ++ pr_id id) ++
+      tag_evar (str "?" ++ pr_lident id) ++
         (match l with
           | [] -> mt()
           | l ->

--- a/printing/ppconstr.ml
+++ b/printing/ppconstr.ml
@@ -231,7 +231,7 @@ let tag_var = tag Tag.variable
         (match l with
           | [] -> mt()
           | l ->
-            let f (id,c) = pr_id id ++ str ":=" ++ pr ltop c in
+            let f (id,c) = pr_lident id ++ str ":=" ++ pr ltop c in
             str"@{" ++ hov 0 (prlist_with_sep pr_semicolon f (List.rev l)) ++ str"}"))
 
   let las = lapp

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -830,12 +830,12 @@ let pr_nth_open_subgoal ~proof n =
   let Proof.{goals;sigma} = Proof.data proof in
   pr_subgoal n sigma goals
 
-let pr_goal_by_id ~proof id =
+let pr_goal_by_id ~proof CAst.{loc;v=id} =
   try
     let { Proof.sigma } = Proof.data proof in
     let g = Evd.evar_key id sigma in
     pr_selected_subgoal (pr_id id) sigma g
-  with Not_found -> user_err Pp.(str "No such goal.")
+  with Not_found -> user_err ?loc Pp.(str "No such goal.")
 
 (** print a goal identified by the goal id as it appears in -emacs mode.
     sid should be the Stm state id corresponding to proof.  Used to support

--- a/printing/printer.mli
+++ b/printing/printer.mli
@@ -260,7 +260,7 @@ module ContextObjectMap : CMap.ExtS
 
 val pr_assumptionset : env -> evar_map -> types ContextObjectMap.t -> Pp.t
 
-val pr_goal_by_id : proof:Proof.t -> Id.t -> Pp.t
+val pr_goal_by_id : proof:Proof.t -> lident -> Pp.t
 val pr_goal_emacs : proof:Proof.t option -> int -> int -> Pp.t
 
 val pr_typing_flags : Declarations.typing_flags -> Pp.t

--- a/printing/proof_diffs.ml
+++ b/printing/proof_diffs.ml
@@ -511,12 +511,12 @@ let match_goals ot nt =
     | CHole (k,naming,solve), CHole (k2,naming2,solve2) -> ()
     | CPatVar _, CPatVar _ -> ()
     | CEvar (n,l), CEvar (n2,l2) ->
-      let oevar = if ogname = "" then Id.to_string n else ogname in
-      nevar_to_oevar := CString.Map.add (Id.to_string n2) oevar !nevar_to_oevar;
+      let oevar = if ogname = "" then Id.to_string n.CAst.v else ogname in
+      nevar_to_oevar := CString.Map.add (Id.to_string n2.CAst.v) oevar !nevar_to_oevar;
       iter2  (fun x x2 -> let (_, g) = x and (_, g2) = x2 in constr_expr ogname g g2)  l l2
     | CEvar (n,l), nt' ->
       (* pass down the old goal evar name *)
-      match_goals_r (Id.to_string n) nt' nt'
+      match_goals_r (Id.to_string n.CAst.v) nt' nt'
     | CSort s, CSort s2 -> ()
     | CCast (c,c'), CCast (c2,c'2) ->
       constr_expr ogname c c2;

--- a/proofs/miscprint.ml
+++ b/proofs/miscprint.ml
@@ -45,8 +45,8 @@ and pr_or_and_intro_pattern prc = function
 
 (** Printing of bindings *)
 let pr_binding prc = let open CAst in function
-  | {loc;v=(NamedHyp id, c)} -> hov 1 (Names.Id.print id ++ str " := " ++ cut () ++ prc c)
-  | {loc;v=(AnonHyp n, c)} -> hov 1 (int n ++ str " := " ++ cut () ++ prc c)
+  | {loc;v=(NamedHyp CAst.{v=id}, c)} -> hov 1 (Id.print id ++ str " := " ++ cut () ++ prc c)
+  | {loc;v=(AnonHyp CAst.{v=n}, c)} -> hov 1 (int n ++ str " := " ++ cut () ++ prc c)
 
 let pr_bindings prc prlc = function
   | ImplicitBindings l ->

--- a/proofs/tactypes.ml
+++ b/proofs/tactypes.ml
@@ -32,7 +32,7 @@ and 'constr or_and_intro_pattern_expr =
 
 (** Bindings *)
 
-type quantified_hypothesis = AnonHyp of int | NamedHyp of Id.t
+type quantified_hypothesis = AnonHyp of int CAst.t | NamedHyp of lident
 
 type 'a explicit_bindings = (quantified_hypothesis * 'a) CAst.t list
 

--- a/tactics/inv.ml
+++ b/tactics/inv.ml
@@ -529,13 +529,13 @@ let inv_gen thin status names =
 
 let inv k = inv_gen k NoDep
 
-let inv_tac id       = inv FullInversion None (NamedHyp id)
-let inv_clear_tac id = inv FullInversionClear None (NamedHyp id)
+let inv_tac id       = inv FullInversion None (NamedHyp (CAst.make id))
+let inv_clear_tac id = inv FullInversionClear None (NamedHyp (CAst.make id))
 
 let dinv k c = inv_gen k (Dep c)
 
-let dinv_tac id       = dinv FullInversion None None (NamedHyp id)
-let dinv_clear_tac id = dinv FullInversionClear None None (NamedHyp id)
+let dinv_tac id       = dinv FullInversion None None (NamedHyp (CAst.make id))
+let dinv_clear_tac id = dinv FullInversionClear None None (NamedHyp (CAst.make id))
 
 (* InvIn will bring the specified clauses into the conclusion, and then
  * perform inversion on the named hypothesis.  After, it will intro them

--- a/tactics/tactics.mli
+++ b/tactics/tactics.mli
@@ -28,7 +28,7 @@ open Ltac_pretype
 
 (** {6 General functions. } *)
 
-val is_quantified_hypothesis : Id.t -> Proofview.Goal.t -> bool
+val is_quantified_hypothesis : lident -> Proofview.Goal.t -> bool
 
 (** {6 Primitive tactics. } *)
 
@@ -110,7 +110,7 @@ type clear_flag = bool option (* true = clear hyp, false = keep hyp, None = use 
 type 'a core_destruction_arg =
   | ElimOnConstr of 'a
   | ElimOnIdent of lident
-  | ElimOnAnonHyp of int
+  | ElimOnAnonHyp of int CAst.t
 
 type 'a destruction_arg =
   clear_flag * 'a core_destruction_arg

--- a/user-contrib/Ltac2/g_ltac2.mlg
+++ b/user-contrib/Ltac2/g_ltac2.mlg
@@ -194,7 +194,7 @@ GRAMMAR EXTEND Gram
       | -> { false } ] ]
   ;
   typ_param:
-    [ [ "'"; id = Prim.ident -> { id } ] ]
+    [ [ "'"; id = lident -> { id.CAst.v } ] ]
   ;
   tactic_atom:
     [ [ n = Prim.integer -> { CAst.make ~loc @@ CTacAtm (AtmInt n) }
@@ -204,7 +204,7 @@ GRAMMAR EXTEND Gram
           CAst.make ~loc @@ CTacCst (RelId qid)
         else
           CAst.make ~loc @@ CTacRef (RelId qid) }
-      | "@"; id = Prim.ident -> { Tac2quote.of_ident (CAst.make ~loc id) }
+      | "@"; id = lident -> { Tac2quote.of_ident (CAst.make ~loc id.CAst.v) }
       | "&"; id = lident -> { Tac2quote.of_hyp ~loc id }
       | "'"; c = Constr.constr -> { inj_open_constr loc c }
       | IDENT "constr"; ":"; "("; c = Constr.lconstr; ")" -> { Tac2quote.of_constr c }
@@ -217,12 +217,12 @@ GRAMMAR EXTEND Gram
     ] ]
   ;
   ltac1_expr_in_env:
-    [ [ test_ltac1_env; ids = LIST0 locident; "|-"; e = ltac1_expr -> { ids, e }
+    [ [ test_ltac1_env; ids = LIST0 lident; "|-"; e = ltac1_expr -> { ids, e }
       | e = ltac1_expr -> { [], e }
     ] ]
   ;
   tac2expr_in_env :
-    [ [ test_ltac1_env; ids = LIST0 locident; "|-"; e = tac2expr ->
+    [ [ test_ltac1_env; ids = LIST0 lident; "|-"; e = tac2expr ->
       { let check { CAst.v = id; CAst.loc = loc } =
           if Tac2env.is_constructor (Libnames.qualid_of_ident ?loc id) then
             CErrors.user_err ?loc Pp.(str "Invalid bound Ltac2 identifier " ++ Id.print id)
@@ -273,12 +273,8 @@ GRAMMAR EXTEND Gram
       | qid = Prim.qualid -> { CAst.make ~loc @@ CTypRef (RelId qid, []) }
       ]
     ];
-  locident:
-    [ [ id = Prim.ident -> { CAst.make ~loc id } ] ]
-  ;
   binder:
-    [ [ "_" -> { CAst.make ~loc Anonymous }
-      | l = Prim.ident -> { CAst.make ~loc (Name l) } ] ]
+    [ [ na = Prim.name -> { na } ] ]
   ;
   input_fun:
     [ [ b = tac2pat LEVEL "0" -> { b } ] ]
@@ -295,7 +291,7 @@ GRAMMAR EXTEND Gram
     ] ]
   ;
   tac2def_mut:
-    [ [ "Set"; qid = Prim.qualid; old = OPT [ "as"; id = locident -> { id } ]; ":="; e = tac2expr -> { StrMut (qid, old, e) } ] ]
+    [ [ "Set"; qid = Prim.qualid; old = OPT [ "as"; id = lident -> { id } ]; ":="; e = tac2expr -> { StrMut (qid, old, e) } ] ]
   ;
   tac2typ_knd:
     [ [ t = tac2type -> { CTydDef (Some t) }
@@ -308,8 +304,8 @@ GRAMMAR EXTEND Gram
       | cs = LIST0 tac2alg_constructor SEP "|" -> { cs } ] ]
   ;
   tac2alg_constructor:
-    [ [ c = Prim.ident -> { (c, []) }
-      | c = Prim.ident; "("; args = LIST0 tac2type SEP ","; ")"-> { (c, args) } ] ]
+    [ [ c = lident -> { (c.CAst.v, []) }
+      | c = lident; "("; args = LIST0 tac2type SEP ","; ")"-> { (c.CAst.v, args) } ] ]
   ;
   tac2rec_fields:
     [ [ f = tac2rec_field; ";"; l = tac2rec_fields -> { f :: l }
@@ -318,7 +314,7 @@ GRAMMAR EXTEND Gram
       | -> { [] } ] ]
   ;
   tac2rec_field:
-    [ [ mut = mut_flag; id = Prim.ident; ":"; t = tac2type -> { (id, mut, t) } ] ]
+    [ [ mut = mut_flag; id = lident; ":"; t = tac2type -> { (id.CAst.v, mut, t) } ] ]
   ;
   tac2rec_fieldexprs:
     [ [ f = tac2rec_fieldexpr; ";"; l = tac2rec_fieldexprs -> { f :: l }
@@ -350,7 +346,7 @@ GRAMMAR EXTEND Gram
     ] ]
   ;
   tac2def_ext:
-    [ [ "@"; IDENT "external"; id = locident; ":"; t = tac2type LEVEL "5"; ":=";
+    [ [ "@"; IDENT "external"; id = lident; ":"; t = tac2type LEVEL "5"; ":=";
         plugin = Prim.string; name = Prim.string ->
       { let ml = { mltac_plugin = plugin; mltac_tactic = name } in
         StrPrm (id, t, ml) }
@@ -358,7 +354,7 @@ GRAMMAR EXTEND Gram
   ;
   syn_node:
     [ [ "_" -> { CAst.make ~loc None }
-      | id = Prim.ident -> { CAst.make ~loc (Some id) }
+      | id = lident -> { CAst.make ~loc (Some id.CAst.v) }
     ] ]
   ;
   sexpr:
@@ -381,10 +377,10 @@ GRAMMAR EXTEND Gram
     ] ]
   ;
   lident:
-    [ [ id = Prim.ident -> { CAst.make ~loc id } ] ]
+    [ [ id = Prim.lident -> { id } ] ]
   ;
   globref:
-    [ [ "&"; id = Prim.ident -> { CAst.make ~loc (QHypothesis id) }
+    [ [ "&"; id = lident -> { CAst.make ~loc (QHypothesis id.CAst.v) }
       | qid = Prim.qualid -> { CAst.make ~loc @@ QReference qid }
     ] ]
   ;
@@ -406,15 +402,15 @@ GRAMMAR EXTEND Gram
           q_destruction_arg q_reference q_with_bindings q_constr_matching
           q_goal_matching q_hintdb q_move_location q_pose q_assert;
   anti:
-    [ [ "$"; id = Prim.ident -> { QAnti (CAst.make ~loc id) } ] ]
+    [ [ "$"; id = Prim.lident -> { QAnti (CAst.make ~loc id.CAst.v) } ] ]
   ;
   ident_or_anti:
     [ [ id = lident -> { QExpr id }
-      | "$"; id = Prim.ident -> { QAnti (CAst.make ~loc id) }
+      | "$"; id = Prim.lident -> { QAnti (CAst.make ~loc id.CAst.v) }
     ] ]
   ;
   lident:
-    [ [ id = Prim.ident -> { CAst.make ~loc id } ] ]
+    [ [ id = Prim.lident -> { id } ] ]
   ;
   lnatural:
     [ [ n = Prim.natural -> { CAst.make ~loc n } ] ]
@@ -521,7 +517,7 @@ GRAMMAR EXTEND Gram
   ;
   nat_or_anti:
     [ [ n = lnatural -> { QExpr n }
-      | "$"; id = Prim.ident -> { QAnti (CAst.make ~loc id) }
+      | "$"; id = Prim.lident -> { QAnti (CAst.make ~loc id.CAst.v) }
     ] ]
   ;
   eqn_ipat:
@@ -684,9 +680,9 @@ GRAMMAR EXTEND Gram
     ] ]
   ;
   refglobal:
-    [ [ "&"; id = Prim.ident -> { QExpr (CAst.make ~loc @@ QHypothesis id) }
+    [ [ "&"; id = Prim.lident -> { QExpr (CAst.make ~loc @@ QHypothesis id.CAst.v) }
       | qid = Prim.qualid -> { QExpr (CAst.make ~loc @@ QReference qid) }
-      | "$"; id = Prim.ident -> { QAnti (CAst.make ~loc id) }
+      | "$"; id = Prim.lident -> { QAnti (CAst.make ~loc id.CAst.v) }
     ] ]
   ;
   q_reference:
@@ -720,8 +716,8 @@ GRAMMAR EXTEND Gram
     [ [ db = hintdb -> { db } ] ]
   ;
   match_pattern:
-    [ [ IDENT "context";  id = OPT Prim.ident;
-          "["; pat = Constr.lconstr_pattern; "]" -> { CAst.make ~loc @@ QConstrMatchContext (id, pat) }
+    [ [ IDENT "context";  id = OPT Prim.lident;
+          "["; pat = Constr.lconstr_pattern; "]" -> { CAst.make ~loc @@ QConstrMatchContext (Option.map (fun {CAst.v=id} -> id) id, pat) }
       | pat = Constr.lconstr_pattern -> { CAst.make ~loc @@ QConstrMatchPattern pat } ] ]
   ;
   match_rule:
@@ -816,12 +812,12 @@ GRAMMAR EXTEND Gram
     [ [ IDENT "ltac2"; ":"; "("; tac = tac2expr; ")" ->
       { let arg = Genarg.in_gen (Genarg.rawwit Tac2env.wit_ltac2_constr) tac in
         CAst.make ~loc (CHole (None, Namegen.IntroAnonymous, Some arg)) }
-      | test_ampersand_ident; "&"; id = Prim.ident ->
-      { let tac = Tac2quote.of_exact_hyp ~loc (CAst.make ~loc id) in
+      | test_ampersand_ident; "&"; id = Prim.lident ->
+      { let tac = Tac2quote.of_exact_hyp ~loc (CAst.make ~loc id.CAst.v) in
         let arg = Genarg.in_gen (Genarg.rawwit Tac2env.wit_ltac2_constr) tac in
         CAst.make ~loc (CHole (None, Namegen.IntroAnonymous, Some arg)) }
-      | test_dollar_ident; "$"; id = Prim.ident ->
-      { let id = Loc.tag ~loc id in
+      | test_dollar_ident; "$"; id = Prim.lident ->
+      { let id = Loc.tag ~loc id.CAst.v in
         let arg = Genarg.in_gen (Genarg.rawwit Tac2env.wit_ltac2_quotation) id in
         CAst.make ~loc (CHole (None, Namegen.IntroAnonymous, Some arg)) }
     ] ]
@@ -837,9 +833,9 @@ let (++) r s = Pcoq.Rule.next r s in
 let rules = [
   Pcoq.(
     Production.make
-      (Rule.stop ++ Symbol.nterm test_dollar_ident ++ Symbol.token (PKEYWORD "$") ++ Symbol.nterm Prim.ident)
+      (Rule.stop ++ Symbol.nterm test_dollar_ident ++ Symbol.token (PKEYWORD "$") ++ Symbol.nterm Prim.lident)
     begin fun id _ _ loc ->
-      let id = Loc.tag ~loc id in
+      let id = Loc.tag ~loc id.CAst.v in
       let arg = Genarg.in_gen (Genarg.rawwit Tac2env.wit_ltac2_quotation) id in
       CAst.make ~loc (CHole (None, Namegen.IntroAnonymous, Some arg))
     end
@@ -847,9 +843,9 @@ let rules = [
 
   Pcoq.(
     Production.make
-      (Rule.stop ++ Symbol.nterm test_ampersand_ident ++ Symbol.token (PKEYWORD "&") ++ Symbol.nterm Prim.ident)
+      (Rule.stop ++ Symbol.nterm test_ampersand_ident ++ Symbol.token (PKEYWORD "&") ++ Symbol.nterm Prim.lident)
     begin fun id _ _ loc ->
-      let tac = Tac2quote.of_exact_hyp ~loc (CAst.make ~loc id) in
+      let tac = Tac2quote.of_exact_hyp ~loc (CAst.make ~loc id.CAst.v) in
       let arg = Genarg.in_gen (Genarg.rawwit Tac2env.wit_ltac2_constr) tac in
       CAst.make ~loc (CHole (None, Namegen.IntroAnonymous, Some arg))
     end

--- a/user-contrib/Ltac2/tac2extffi.ml
+++ b/user-contrib/Ltac2/tac2extffi.ml
@@ -19,8 +19,8 @@ let make_to_repr f = Tac2ffi.make_repr (fun _ -> assert false) f
 (** More ML representations *)
 
 let to_qhyp v = match Value.to_block v with
-| (0, [| i |]) -> AnonHyp (Value.to_int i)
-| (1, [| id |]) -> NamedHyp (Value.to_ident id)
+| (0, [| i |]) -> AnonHyp (CAst.make (Value.to_int i))
+| (1, [| id |]) -> NamedHyp (CAst.make (Value.to_ident id))
 | _ -> assert false
 
 let qhyp = make_to_repr to_qhyp

--- a/user-contrib/Ltac2/tac2quote.ml
+++ b/user-contrib/Ltac2/tac2quote.ml
@@ -229,7 +229,7 @@ let check_pattern_id ?loc id =
 let pattern_vars pat =
   let rec aux () accu pat = match pat.CAst.v with
   | Constrexpr.CPatVar id
-  | Constrexpr.CEvar (id, []) ->
+  | Constrexpr.CEvar ({CAst.v=id}, []) ->
     let loc = pat.CAst.loc in
     let () = check_pattern_id ?loc id in
     Id.Map.add id loc accu

--- a/user-contrib/Ltac2/tac2stdlib.ml
+++ b/user-contrib/Ltac2/tac2stdlib.ml
@@ -124,8 +124,8 @@ let to_destruction_arg v = match Value.to_block v with
 | (0, [| c |]) ->
   let c = uthaw constr_with_bindings c in
   ElimOnConstr c
-| (1, [| id |]) -> ElimOnIdent (Value.to_ident id)
-| (2, [| n |]) -> ElimOnAnonHyp (Value.to_int n)
+| (1, [| id |]) -> ElimOnIdent (CAst.make (Value.to_ident id))
+| (2, [| n |]) -> ElimOnAnonHyp (CAst.make (Value.to_int n))
 | _ -> assert false
 
 let destruction_arg = make_to_repr to_destruction_arg

--- a/user-contrib/Ltac2/tac2tactics.ml
+++ b/user-contrib/Ltac2/tac2tactics.ml
@@ -112,7 +112,7 @@ let mk_destruction_arg = function
 | ElimOnConstr c ->
   let c = c >>= fun c -> return (mk_with_bindings c) in
   Tactics.ElimOnConstr (delayed_of_tactic c)
-| ElimOnIdent id -> Tactics.ElimOnIdent CAst.(make id)
+| ElimOnIdent id -> Tactics.ElimOnIdent id
 | ElimOnAnonHyp n -> Tactics.ElimOnAnonHyp n
 
 let mk_induction_clause (arg, eqn, as_, occ) =
@@ -347,7 +347,7 @@ let on_destruction_arg tac ev arg =
       let flags = tactic_infer_flags ev in
       let (sigma', c) = Unification.finish_evar_resolution ~flags env sigma' (sigma, c) in
       Proofview.tclUNIT (Some sigma', Tactics.ElimOnConstr (c, lbind))
-    | ElimOnIdent id -> Proofview.tclUNIT (None, Tactics.ElimOnIdent CAst.(make id))
+    | ElimOnIdent id -> Proofview.tclUNIT (None, Tactics.ElimOnIdent id)
     | ElimOnAnonHyp n -> Proofview.tclUNIT (None, Tactics.ElimOnAnonHyp n)
     in
     arg >>= fun (sigma', arg) ->
@@ -433,13 +433,13 @@ let inversion knd arg pat ids =
     | None -> assert false
     | Some (_, Tactics.ElimOnAnonHyp n) ->
       Inv.inv_clause knd pat ids (AnonHyp n)
-    | Some (_, Tactics.ElimOnIdent {CAst.v=id}) ->
+    | Some (_, Tactics.ElimOnIdent id) ->
       Inv.inv_clause knd pat ids (NamedHyp id)
     | Some (_, Tactics.ElimOnConstr c) ->
       let open Tactypes in
       let anon = CAst.make @@ IntroNaming Namegen.IntroAnonymous in
       Tactics.specialize c (Some anon) >>= fun () ->
-      Tacticals.New.onLastHypId (fun id -> Inv.inv_clause knd pat ids (NamedHyp id))
+      Tacticals.New.onLastHypId (fun id -> Inv.inv_clause knd pat ids (NamedHyp (CAst.make id)))
     end
   in
   on_destruction_arg inversion true (Some (None, arg))

--- a/user-contrib/Ltac2/tac2types.mli
+++ b/user-contrib/Ltac2/tac2types.mli
@@ -20,8 +20,8 @@ type advanced_flag = bool
 type 'a thunk = (unit, 'a) Tac2ffi.fun1
 
 type quantified_hypothesis = Tactypes.quantified_hypothesis =
-| AnonHyp of int
-| NamedHyp of Id.t
+| AnonHyp of int CAst.t
+| NamedHyp of Id.t CAst.t
 
 type explicit_bindings = (quantified_hypothesis * EConstr.t) list
 
@@ -34,8 +34,8 @@ type constr_with_bindings = EConstr.constr * bindings
 
 type core_destruction_arg =
 | ElimOnConstr of constr_with_bindings tactic
-| ElimOnIdent of Id.t
-| ElimOnAnonHyp of int
+| ElimOnIdent of Id.t CAst.t
+| ElimOnAnonHyp of int CAst.t
 
 type destruction_arg = core_destruction_arg
 

--- a/vernac/attributes.mli
+++ b/vernac/attributes.mli
@@ -10,7 +10,7 @@
 
 (** The type of parsing attribute data *)
 type vernac_flags = vernac_flag list
-and vernac_flag = string * vernac_flag_value
+and vernac_flag = Names.lstring * vernac_flag_value
 and vernac_flag_value =
   | VernacFlagEmpty
   | VernacFlagLeaf of string
@@ -70,7 +70,7 @@ val parse_with_extra : 'a attribute -> vernac_flags -> vernac_flags * 'a
 
 (** * Defining attributes. *)
 
-type 'a key_parser = 'a option -> vernac_flag_value -> 'a
+type 'a key_parser = ?loc:Loc.t -> 'a option -> vernac_flag_value -> 'a
 (** A parser for some key in an attribute. It is given a nonempty ['a
     option] when the attribute is multiply set for some command.
 
@@ -93,11 +93,11 @@ val qualify_attribute : string -> 'a attribute -> 'a attribute
 (** Combinators to help define your own parsers. See the
    implementation of [bool_attribute] for practical use. *)
 
-val assert_empty : string -> vernac_flag_value -> unit
+val assert_empty : ?loc:Loc.t -> string -> vernac_flag_value -> unit
 (** [assert_empty key v] errors if [v] is not empty. [key] is used in
    the error message as the name of the attribute. *)
 
-val assert_once : name:string -> 'a option -> unit
+val assert_once : ?loc:Loc.t -> name:string -> 'a option -> unit
 (** [assert_once ~name v] errors if [v] is not empty. [name] is used
    in the error message as the name of the attribute. Used to ensure
    that a given attribute is not reapeated. *)
@@ -112,8 +112,8 @@ val make_attribute : (vernac_flags -> vernac_flags * 'a) -> 'a attribute
    access to the full power of attributes. Unstable. *)
 
 (** Compatibility values for parsing [Polymorphic]. *)
-val vernac_polymorphic_flag : vernac_flag
-val vernac_monomorphic_flag : vernac_flag
+val vernac_polymorphic_flag : loc:Loc.t -> vernac_flag
+val vernac_monomorphic_flag : loc:Loc.t -> vernac_flag
 
 (** For internal use. *)
 val universe_polymorphism_option_name : string list

--- a/vernac/g_proofs.mlg
+++ b/vernac/g_proofs.mlg
@@ -60,15 +60,15 @@ GRAMMAR EXTEND Gram
       | IDENT "Proof"; c = lconstr -> { VernacExactProof c }
       | IDENT "Abort" -> { VernacAbort None }
       | IDENT "Abort"; IDENT "All" -> { VernacAbortAll }
-      | IDENT "Abort"; id = identref -> { VernacAbort (Some id) }
+      | IDENT "Abort"; id = lident -> { VernacAbort (Some id) }
       | IDENT "Existential"; n = natural; c = constr_body ->
           { VernacSolveExistential (n,c) }
       | IDENT "Admitted" -> { VernacEndProof Admitted }
       | IDENT "Qed" -> { VernacEndProof (Proved (Opaque,None)) }
-      | IDENT "Save"; id = identref ->
+      | IDENT "Save"; id = lident ->
           { VernacEndProof (Proved (Opaque, Some id)) }
       | IDENT "Defined" -> { VernacEndProof (Proved (Transparent,None)) }
-      |	IDENT "Defined"; id=identref ->
+      |	IDENT "Defined"; id = lident ->
           { VernacEndProof (Proved (Transparent,Some id)) }
       | IDENT "Restart" -> { VernacRestart }
       | IDENT "Undo" -> { VernacUndo 1 }

--- a/vernac/g_proofs.mlg
+++ b/vernac/g_proofs.mlg
@@ -86,7 +86,7 @@ GRAMMAR EXTEND Gram
       | IDENT "Unfocused" -> { VernacUnfocused }
       | IDENT "Show" -> { VernacShow (ShowGoal OpenSubgoals) }
       | IDENT "Show"; n = natural -> { VernacShow (ShowGoal (NthGoal n)) }
-      | IDENT "Show"; id = ident -> { VernacShow (ShowGoal (GoalId id)) }
+      | IDENT "Show"; id = lident -> { VernacShow (ShowGoal (GoalId id)) }
       | IDENT "Show"; IDENT "Existentials" -> { VernacShow ShowExistentials }
       | IDENT "Show"; IDENT "Universes" -> { VernacShow ShowUniverses }
       | IDENT "Show"; IDENT "Conjectures" -> { VernacShow ShowProofNames }

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -1144,9 +1144,9 @@ GRAMMAR EXTEND Gram
          sc = OPT [ ":"; sc = IDENT -> { sc } ] ->
          { VernacInfix ((op,modl),p,sc) }
      | IDENT "Notation"; id = lident;
-         idl = LIST0 ident; ":="; c = constr; b = only_parsing ->
+         idl = LIST0 lident; ":="; c = constr; b = only_parsing ->
            { VernacSyntacticDefinition
-             (id,(idl,c),{ onlyparsing = b }) }
+             (id,idl,c,{ onlyparsing = b }) }
      | IDENT "Notation"; s = lstring; ":=";
          c = constr;
          modl = syntax_modifiers;

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -228,16 +228,16 @@ GRAMMAR EXTEND Gram
       | IDENT "Let"; "CoFixpoint"; corecs = LIST1 corec_definition SEP "with" ->
           { VernacCoFixpoint (DoDischarge, corecs) }
       | IDENT "Scheme"; l = LIST1 scheme SEP "with" -> { VernacScheme l }
-      | IDENT "Combined"; IDENT "Scheme"; id = identref; IDENT "from";
-              l = LIST1 identref SEP "," -> { VernacCombinedScheme (id, l) }
+      | IDENT "Combined"; IDENT "Scheme"; id = lident; IDENT "from";
+              l = LIST1 lident SEP "," -> { VernacCombinedScheme (id, l) }
       | IDENT "Register"; g = global; "as"; quid = qualid ->
           { VernacRegister(g, RegisterCoqlib quid) }
       | IDENT "Register"; IDENT "Inline"; g = global ->
           { VernacRegister(g, RegisterInline) }
       | IDENT "Primitive"; id = ident_decl; typopt = OPT [ ":"; typ = lconstr -> { typ } ]; ":="; r = register_token ->
           { VernacPrimitive(id, r, typopt) }
-      | IDENT "Universe"; l = LIST1 identref -> { VernacUniverse l }
-      | IDENT "Universes"; l = LIST1 identref -> { VernacUniverse l }
+      | IDENT "Universe"; l = LIST1 lident -> { VernacUniverse l }
+      | IDENT "Universes"; l = LIST1 lident -> { VernacUniverse l }
       | IDENT "Constraint"; l = LIST1 univ_constraint SEP "," -> { VernacConstraint l }
   ] ]
   ;
@@ -282,7 +282,7 @@ GRAMMAR EXTEND Gram
         r = universe_name -> { (l, ord, r) } ] ]
   ;
   univ_decl :
-    [ [  "@{" ; l = LIST0 identref; ext = [ "+" -> { true } | -> { false } ];
+    [ [  "@{" ; l = LIST0 lident; ext = [ "+" -> { true } | -> { false } ];
          cs = [ "|"; l' = LIST0 univ_constraint SEP ",";
                 ext = [ "+" -> { true } | -> { false } ]; "}" -> { (l',ext) }
               | ext = [ "}" -> { true } | bar_cbrace -> { false } ] -> { ([], ext) } ]
@@ -295,7 +295,7 @@ GRAMMAR EXTEND Gram
     ] ]
   ;
   ident_decl:
-    [ [ i = identref; l = OPT univ_decl -> { (i, l) }
+    [ [ i = lident; l = OPT univ_decl -> { (i, l) }
   ] ]
   ;
   finite_token:
@@ -351,10 +351,10 @@ GRAMMAR EXTEND Gram
   ;
   constructor_list_or_record_decl:
     [ [ "|"; l = LIST1 constructor SEP "|" -> { Constructors l }
-      | id = identref ; c = constructor_type; "|"; l = LIST1 constructor SEP "|" ->
+      | id = lident ; c = constructor_type; "|"; l = LIST1 constructor SEP "|" ->
           { Constructors ((c id)::l) }
-      | id = identref ; c = constructor_type -> { Constructors [ c id ] }
-      | cstr = identref; "{"; fs = record_fields; "}" ->
+      | id = lident ; c = constructor_type -> { Constructors [ c id ] }
+      | cstr = lident; "{"; fs = record_fields; "}" ->
           { RecordDecl (Some cstr,fs) }
       | "{";fs = record_fields; "}" -> { RecordDecl (None,fs) }
       |  -> { Constructors [] } ] ]
@@ -387,7 +387,7 @@ GRAMMAR EXTEND Gram
   (* Inductive schemes *)
   scheme:
     [ [ kind = scheme_kind -> { (None,kind) }
-      | id = identref; ":="; kind = scheme_kind -> { (Some id,kind) } ] ]
+      | id = lident; ":="; kind = scheme_kind -> { (Some id,kind) } ] ]
   ;
   scheme_kind:
     [ [ IDENT "Induction"; "for"; ind = smart_global;
@@ -466,7 +466,7 @@ GRAMMAR EXTEND Gram
 ;
 
   constructor:
-    [ [ id = identref; c=constructor_type -> { c id } ] ]
+    [ [ id = lident; c=constructor_type -> { c id } ] ]
   ;
   of_type_with_opt_coercion:
     [ [ ":>>" -> { Some false }
@@ -480,13 +480,13 @@ END
 
 {
 
-let test_only_starredidentrefs =
+let test_only_starredlidents =
   let open Pcoq.Lookahead in
-  to_entry "test_only_starredidentrefs" begin
+  to_entry "test_only_starredlidents" begin
     lk_list (lk_ident <+> lk_kws ["Type"; "*"]) >> (lk_kws [".";")"])
   end
 
-let starredidentreflist_to_expr l =
+let starredlidentlist_to_expr l =
   match l with
   | [] -> SsEmpty
   | x :: xs -> List.fold_right (fun i acc -> SsUnion(i,acc)) xs x
@@ -503,25 +503,25 @@ GRAMMAR EXTEND Gram
 
   gallina_ext:
     [ [ (* Interactive module declaration *)
-        IDENT "Module"; export = export_token; id = identref;
+        IDENT "Module"; export = export_token; id = lident;
         bl = LIST0 module_binder; sign = of_module_type;
         body = is_module_expr ->
           { VernacDefineModule (export, id, bl, sign, body) }
-      | IDENT "Module"; "Type"; id = identref;
+      | IDENT "Module"; "Type"; id = lident;
         bl = LIST0 module_binder; sign = check_module_types;
         body = is_module_type ->
           { VernacDeclareModuleType (id, bl, sign, body) }
-      | IDENT "Declare"; IDENT "Module"; export = export_token; id = identref;
+      | IDENT "Declare"; IDENT "Module"; export = export_token; id = lident;
         bl = LIST0 module_binder; ":"; mty = module_type_inl ->
           { VernacDeclareModule (export, id, bl, mty) }
       (* Section beginning *)
-      | IDENT "Section"; id = identref -> { VernacBeginSection id }
+      | IDENT "Section"; id = lident -> { VernacBeginSection id }
 
       (* This end a Section a Module or a Module Type *)
-      | IDENT "End"; id = identref -> { VernacEndSegment id }
+      | IDENT "End"; id = lident -> { VernacEndSegment id }
 
       (* Naming a set of section hyps *)
-      | IDENT "Collection"; id = identref; ":="; expr = section_subset_expr ->
+      | IDENT "Collection"; id = lident; ":="; expr = section_subset_expr ->
           { VernacNameSectionHypSet (id, expr) }
 
       (* Requiring an already compiled module *)
@@ -591,7 +591,7 @@ GRAMMAR EXTEND Gram
   ;
   (* Module binder  *)
   module_binder:
-    [ [ "("; export = export_token; idl = LIST1 identref; ":";
+    [ [ "("; export = export_token; idl = LIST1 lident; ":";
          mty = module_type_inl; ")" -> { (export,idl,mty) } ] ]
   ;
   (* Module expressions *)
@@ -621,13 +621,13 @@ GRAMMAR EXTEND Gram
   ;
   (* Proof using *)
   section_subset_expr:
-    [ [ test_only_starredidentrefs; l = LIST0 starredidentref ->
-          { starredidentreflist_to_expr l }
+    [ [ test_only_starredlidents; l = LIST0 starredlident ->
+          { starredlidentlist_to_expr l }
       | e = ssexpr -> { e } ]]
   ;
-  starredidentref:
-    [ [ i = identref -> { SsSingl i }
-      | i = identref; "*" -> { SsFwdClose(SsSingl i) }
+  starredlident:
+    [ [ i = lident -> { SsSingl i }
+      | i = lident; "*" -> { SsFwdClose(SsSingl i) }
       | "Type" -> { SsType }
       | "Type"; "*" -> { SsFwdClose SsType } ]]
   ;
@@ -638,11 +638,11 @@ GRAMMAR EXTEND Gram
       [ e1 = ssexpr; "-"; e2 = ssexpr-> { SsSubstr(e1,e2) }
       | e1 = ssexpr; "+"; e2 = ssexpr-> { SsUnion(e1,e2) } ]
     | "0"
-      [ i = starredidentref -> { i }
-      | "("; test_only_starredidentrefs; l = LIST0 starredidentref; ")"->
-          { starredidentreflist_to_expr l }
-      | "("; test_only_starredidentrefs; l = LIST0 starredidentref; ")"; "*" ->
-          { SsFwdClose(starredidentreflist_to_expr l) }
+      [ i = starredlident -> { i }
+      | "("; test_only_starredlidents; l = LIST0 starredlident; ")"->
+          { starredlidentlist_to_expr l }
+      | "("; test_only_starredlidents; l = LIST0 starredlident; ")"; "*" ->
+          { SsFwdClose(starredlidentlist_to_expr l) }
       | "("; e = ssexpr; ")"-> { e }
       | "("; e = ssexpr; ")"; "*" -> { SsFwdClose e } ] ]
   ;
@@ -676,7 +676,7 @@ GRAMMAR EXTEND Gram
       | IDENT "Coercion"; qid = global; u = OPT univ_decl; d = def_body ->
           { let s = coerce_reference_to_id qid in
           VernacDefinition ((NoDischarge,Coercion),((CAst.make ?loc:qid.CAst.loc (Name s)),u),d) }
-      | IDENT "Identity"; IDENT "Coercion"; f = identref; ":";
+      | IDENT "Identity"; IDENT "Coercion"; f = lident; ":";
          s = class_rawexpr; ">->"; t = class_rawexpr ->
            { VernacIdentityCoercion (f, s, t) }
       | IDENT "Coercion"; qid = global; ":"; s = class_rawexpr; ">->";
@@ -732,7 +732,7 @@ GRAMMAR EXTEND Gram
            gen = [IDENT "All"; IDENT "Variables" -> { Some [] }
              | IDENT "No"; IDENT "Variables" -> { None }
              | ["Variable" -> { () } | IDENT "Variables" -> { () } ];
-                  idl = LIST1 identref -> { Some idl } ] ->
+                  idl = LIST1 lident -> { Some idl } ] ->
              { VernacGeneralizable gen } ] ]
   ;
   arguments_modifier:
@@ -820,7 +820,7 @@ GRAMMAR EXTEND Gram
     [ [ "("; a = simple_reserv; ")" -> { a } ] ]
   ;
   simple_reserv:
-    [ [ idl = LIST1 identref; ":"; c = lconstr -> { (idl,c) } ] ]
+    [ [ idl = LIST1 lident; ":"; c = lconstr -> { (idl,c) } ] ]
   ;
 
 END
@@ -1094,7 +1094,7 @@ GRAMMAR EXTEND Gram
 
 (* Resetting *)
       | IDENT "Reset"; IDENT "Initial" -> { VernacResetInitial }
-      | IDENT "Reset"; id = identref -> { VernacResetName id }
+      | IDENT "Reset"; id = lident -> { VernacResetName id }
       | IDENT "Back" -> { VernacBack 1 }
       | IDENT "Back"; n = natural -> { VernacBack n }
 
@@ -1143,7 +1143,7 @@ GRAMMAR EXTEND Gram
          modl = syntax_modifiers;
          sc = OPT [ ":"; sc = IDENT -> { sc } ] ->
          { VernacInfix ((op,modl),p,sc) }
-     | IDENT "Notation"; id = identref;
+     | IDENT "Notation"; id = lident;
          idl = LIST0 ident; ":="; c = constr; b = only_parsing ->
            { VernacSyntacticDefinition
              (id,(idl,c),{ onlyparsing = b }) }

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -113,7 +113,7 @@ GRAMMAR EXTEND Gram
     ]
   ;
   attribute:
-    [ [ k = ident ; v = attribute_value -> { Names.Id.to_string k, v } ]
+    [ [ k = lident ; v = attribute_value -> { CAst.(make ?loc:k.loc (Names.Id.to_string k.v)), v } ]
     ]
   ;
   attribute_value:
@@ -124,21 +124,21 @@ GRAMMAR EXTEND Gram
   ;
   legacy_attr:
     [ [ IDENT "Local" ->
-        { ("local", VernacFlagEmpty) }
+        { (CAst.make ~loc "local", VernacFlagEmpty) }
       | IDENT "Global" ->
-        { ("global", VernacFlagEmpty) }
+        { (CAst.make ~loc "global", VernacFlagEmpty) }
       | IDENT "Polymorphic" ->
-        { Attributes.vernac_polymorphic_flag }
+        { Attributes.vernac_polymorphic_flag ~loc }
       | IDENT "Monomorphic" ->
-        { Attributes.vernac_monomorphic_flag }
+        { Attributes.vernac_monomorphic_flag ~loc }
       | IDENT "Cumulative" ->
-        { ("universes", VernacFlagList ["cumulative", VernacFlagEmpty]) }
+        { (CAst.make "universes", VernacFlagList [CAst.make ~loc "cumulative", VernacFlagEmpty]) }
       | IDENT "NonCumulative" ->
-        { ("universes", VernacFlagList ["noncumulative", VernacFlagEmpty]) }
+        { (CAst.make "universes", VernacFlagList [CAst.make ~loc "noncumulative", VernacFlagEmpty]) }
       | IDENT "Private" ->
-        { ("private", VernacFlagList ["matching", VernacFlagEmpty]) }
+        { (CAst.make ~loc "private", VernacFlagList [CAst.make "matching", VernacFlagEmpty]) }
       | IDENT "Program" ->
-        { ("program", VernacFlagEmpty) }
+        { (CAst.make ~loc "program", VernacFlagEmpty) }
       ] ]
   ;
   vernac:

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -1842,11 +1842,11 @@ let try_interp_name_alias = function
   | [], { CAst.v = CRef (ref,_) } -> intern_reference ref
   | _ -> raise Not_found
 
-let add_syntactic_definition ~local deprecation env ident (vars,c) { onlyparsing } =
+let add_syntactic_definition ~local deprecation env ident vars c  { onlyparsing } =
   let acvars,pat,reversibility =
     try Id.Map.empty, NRef (try_interp_name_alias (vars,c)), APrioriReversible
     with Not_found ->
-      let fold accu id = Id.Map.add id NtnInternTypeAny accu in
+      let fold accu id = Id.Map.add id.CAst.v NtnInternTypeAny accu in
       let i_vars = List.fold_left fold Id.Map.empty vars in
       let nenv = {
         ninterp_var_type = i_vars;
@@ -1854,11 +1854,11 @@ let add_syntactic_definition ~local deprecation env ident (vars,c) { onlyparsing
       } in
       interp_notation_constr env nenv c
   in
-  let in_pat id = (id,ETConstr (Constrexpr.InConstrEntry,None,(NextLevel,InternalProd))) in
+  let in_pat id = (id.CAst.v,ETConstr (Constrexpr.InConstrEntry,None,(NextLevel,InternalProd))) in
   let interp = make_interpretation_vars ~default_if_binding:AsIdentOrPattern [] 0 acvars (List.map in_pat vars) in
-  let vars = List.map (fun x -> (x, Id.Map.find x interp)) vars in
+  let vars = List.map (fun {CAst.v=x} -> (x, Id.Map.find x interp)) vars in
   let onlyparsing = onlyparsing || fst (printability None [] false reversibility pat) in
-  Syntax_def.declare_syntactic_definition ~local deprecation ident ~onlyparsing (vars,pat)
+  Syntax_def.declare_syntactic_definition ~local deprecation ident.CAst.v ~onlyparsing (vars,pat)
 
 (**********************************************************************)
 (* Declaration of custom entry                                        *)

--- a/vernac/metasyntax.mli
+++ b/vernac/metasyntax.mli
@@ -52,7 +52,7 @@ val add_syntax_extension :
 (** Add a syntactic definition (as in "Notation f := ...") *)
 
 val add_syntactic_definition : local:bool -> Deprecation.t option -> env ->
-  Id.t -> Id.t list * constr_expr -> onlyparsing_flag -> unit
+  lident -> lident list -> constr_expr -> onlyparsing_flag -> unit
 
 (** Print the Camlp5 state of a grammar *)
 

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -1312,7 +1312,7 @@ let pr_control_flag (p : control_flag) =
 
 let pr_vernac_control flags = Pp.prlist pr_control_flag flags
 
-let rec pr_vernac_flag (k, v) =
+let rec pr_vernac_flag ({CAst.v=k}, v) =
   let k = keyword k in
   let open Attributes in
   match v with

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -1077,11 +1077,11 @@ let pr_vernac_expr v =
     )
   | VernacHints (dbnames,h) ->
     return (pr_hints dbnames h pr_constr pr_constr_pattern_expr)
-  | VernacSyntacticDefinition (id,(ids,c),{onlyparsing}) ->
+  | VernacSyntacticDefinition (id,ids,c,{onlyparsing}) ->
     return (
       hov 2
         (keyword "Notation" ++ spc () ++ pr_lident id ++ spc () ++
-         prlist_with_sep spc pr_id ids ++ str":=" ++ pr_constrarg c ++
+         prlist_with_sep spc pr_lident ids ++ str":=" ++ pr_constrarg c ++
          pr_only_parsing_clause onlyparsing)
     )
   | VernacArguments (q, args, more_implicits, mods) ->
@@ -1100,6 +1100,7 @@ let pr_vernac_expr v =
             | Glob_term.Explicit -> if force then str"(",str")" else mt(),mt()
           in
           left ++ x ++ right
+
         in
         let get_arguments_like s imp tl =
           if s = None && imp = Glob_term.Explicit then [], tl

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -682,7 +682,7 @@ let pr_vernac_expr v =
     let pr_goal_reference = function
       | OpenSubgoals -> mt ()
       | NthGoal n -> spc () ++ int n
-      | GoalId id -> spc () ++ pr_id id
+      | GoalId id -> spc () ++ pr_lident id
     in
     let pr_showable = function
       | ShowGoal n -> keyword "Show" ++ pr_goal_reference n

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1323,10 +1323,11 @@ let vernac_hints ~atts dbnames h =
   in
   Hints.add_hints ~locality dbnames (ComHints.interp_hints ~poly h)
 
-let vernac_syntactic_definition ~atts lid x only_parsing =
+let vernac_syntactic_definition ~atts lid vars c only_parsing =
   let module_local, deprecation = Attributes.(parse Notations.(module_locality ++ deprecation) atts) in
   Dumpglob.dump_definition lid false "syndef";
-  Metasyntax.add_syntactic_definition ~local:module_local deprecation (Global.env()) lid.v x only_parsing
+  List.iter (fun {loc;v} -> Dumpglob.dump_binding ?loc (Id.to_string v)) vars;
+  Metasyntax.add_syntactic_definition ~local:module_local deprecation (Global.env()) lid vars c only_parsing
 
 let default_env () = {
   Notation_term.ninterp_var_type = Id.Map.empty;
@@ -2169,8 +2170,8 @@ let translate_vernac ~atts v = let open Vernacextend in match v with
   | VernacHints (dbnames,hints) ->
     VtDefault(fun () ->
         vernac_hints ~atts dbnames hints)
-  | VernacSyntacticDefinition (id,c,b) ->
-     VtDefault(fun () -> vernac_syntactic_definition ~atts id c b)
+  | VernacSyntacticDefinition (id,vars,c,b) ->
+     VtDefault(fun () -> vernac_syntactic_definition ~atts id vars c b)
   | VernacArguments (qid, args, more_implicits, flags) ->
     VtDefault(fun () ->
         with_section_locality ~atts

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -2186,7 +2186,7 @@ let translate_vernac ~atts v = let open Vernacextend in match v with
   | VernacSetStrategy l ->
     VtDefault(fun () -> with_locality ~atts vernac_set_strategy l)
   | VernacSetOption (export,key,v) ->
-    let atts = if export then ("export", VernacFlagEmpty) :: atts else atts in
+    let atts = if export then (CAst.make "export", VernacFlagEmpty) :: atts else atts in
     VtDefault(fun () ->
         vernac_set_option ~locality:(parse option_locality atts) key v)
   | VernacRemoveOption (key,v) ->

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -414,8 +414,7 @@ type nonrec vernac_expr =
   | VernacRemoveHints of string list * qualid list
   | VernacHints of string list * hints_expr
   | VernacSyntacticDefinition of
-      lident * (Id.t list * constr_expr) *
-      onlyparsing_flag
+      lident * lident list * constr_expr * onlyparsing_flag
   | VernacArguments of
       qualid or_by_notation *
       vernac_argument_status list (* Main arguments status list *) *

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -21,7 +21,7 @@ type scope_name = string
 type goal_reference =
   | OpenSubgoals
   | NthGoal of int
-  | GoalId of Id.t
+  | GoalId of lident
 
 type printable =
   | PrintTypingFlags


### PR DESCRIPTION
**Kind:** tentative clarification

The parser has entries `name` and `ident`. Names carrying a location are parsed with `lname` but identifiers with a location are called `identref`. This PR renames `identref` into `lident`.

I would say that it is a slight improvement but maybe not so much. Why not to have locations always there when using `ident` and `name`? That would probably help to describe the grammar in the reference manual??

The `l` in `lname` and `lident` can also be confused with the `l` in `lconstr` which has nothing to do with locations (I don't know what the `l` means in `lconstr` though).

Any opinion, especially from @jfehrle or @zimmi48?