### PR TITLE
Process command line load vernaculars before command line Goptions

### DIFF
--- a/doc/changelog/08-tools/11851-coqc-flags-fix.rst
+++ b/doc/changelog/08-tools/11851-coqc-flags-fix.rst
@@ -1,0 +1,6 @@
+- **Changed:**
+  The order in which the require/load flags `-l`, `-ri`, `-re`, `-rfrom`, etc.
+  and the option set flags `-set`, `-unset` are processed have been reversed.
+  In the new behavior, require/load flags are processed before option flags.
+  (`#11851 <https://github.com/coq/coq/pull/11851>`_,
+  by Lasse Blaauwbroek).

--- a/doc/sphinx/practical-tools/coq-commands.rst
+++ b/doc/sphinx/practical-tools/coq-commands.rst
@@ -227,7 +227,10 @@ and ``coqtop``, unless stated otherwise:
    type of the option. For flags ``Option Name`` is equivalent to
    ``Option Name=true``. For instance ``-set "Universe Polymorphism"``
    will enable :flag:`Universe Polymorphism`. Note that the quotes are
-   shell syntax, Coq does not see them.
+   shell syntax, Coq does not see them. Flags are processed after initialization
+   of the document. This includes the `Prelude` if loaded and any libraries loaded
+   through the `-l`, `-lv`, `-r`, `-re`, `-ri`, `rfrom`, `-refrom` and `-rifrom`
+   options.
 :-unset *string*: As ``-set`` but used to disable options and flags.
 :-compat *version*: Attempt to maintain some backward-compatibility
   with a previous version.

--- a/toplevel/ccompile.mli
+++ b/toplevel/ccompile.mli
@@ -17,3 +17,5 @@ val compile_files : Coqargs.t -> Coqcargs.t -> unit
 
 (** [do_vio opts] process [.vio] files in [opts] *)
 val do_vio : Coqargs.t -> Coqcargs.t -> unit
+
+val set_options : (Goptions.option_name * Coqargs.option_command) list -> unit

--- a/toplevel/usage.ml
+++ b/toplevel/usage.ml
@@ -41,7 +41,7 @@ let print_usage_common co command =
 \n  -l f                   (idem)\
 \n  -load-vernac-source-verbose f  load Coq file f.v (Load Verbose \"f\".)\
 \n  -lv f	           (idem)\
-\n  -load-vernac-object lib, -r lib\
+\n  -load-vernac-object lib\
 \n                         load Coq library lib (Require lib)\
 \n  -rfrom root lib        load Coq library lib (From root Require lib.)\
 \n  -require-import lib, -ri lib\


### PR DESCRIPTION
This pull request changes the order in which the command line options like `-load-vernac-object` and `-set` are processed. Currently, command-line load vernaculars are processed before command-line options. This is a problem when a load vernacular loads a new plugin that defines new options.

Example:
Load.v
```coq
Declare ML Module "my_options_plugin".
```
Now, if I use the following command, a warning is issued that the option `My Option` does not exist.
```bash
coqtop --load-vernac-object Load -set "My Option = 8"
```
This pull request fixes this. While I'm at it, I also added the `-r` alias of `--load-vernac-object` that was already documented in `coqtop -h` but was not working.

I'm not exactly sure what the impact of this change may be. The delayed setting of options may change some behavior. For example, an object loaded through `--load-vernac-object` may behave differently now that the options are set after it. As such, this is not a pull request that I expect to be merged, but rather have a discussion about. I would think that the ideal solution would be to set recognized options before processing the command-line load vernaculars and then add the unrecognized options as soon as they are available. I'm not sure how to achieve this, though.
<!-- Keep what applies -->
**Kind:** bug fix.


<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [ ] Added / updated test-suite
<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [x] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
