### PR TITLE
Build and install refman with Dune.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -425,7 +425,16 @@ doc:refman:dune:
   artifacts:
     paths:
       - _build/log
-      - _build/default/doc/sphinx_build/html
+      - _build/default/doc/refman-html
+
+doc:refman-pdf:dune:
+  extends: .dune-ci-template
+  variables:
+    DUNE_TARGET: refman-pdf
+  artifacts:
+    paths:
+      - _build/log
+      - _build/default/doc/refman-pdf
 
 doc:stdlib:dune:
   extends: .dune-ci-template

--- a/Makefile.dune
+++ b/Makefile.dune
@@ -4,7 +4,7 @@
 .PHONY: help voboot states world watch check          # Main developer targets
 .PHONY: coq coqide coqide-server                      # Package targets
 .PHONY: quickbyte quickopt quickide                   # Partial / quick developer targets
-.PHONY: refman-html stdlib-html apidoc                # Documentation targets
+.PHONY: refman-html refman-pdf stdlib-html apidoc     # Documentation targets
 .PHONY: test-suite release                            # Accessory targets
 .PHONY: fmt ocheck ireport clean                      # Maintenance targets
 
@@ -32,6 +32,7 @@ help:
 	@echo ""
 	@echo "  - test-suite:  run Coq's test suite"
 	@echo "  - refman-html: build Coq's reference manual [HTML version]"
+	@echo "  - refman-pdf:  build Coq's reference manual [PDF version]"
 	@echo "  - stdlib-html: build Coq's Stdlib documentation [HTML version]"
 	@echo "  - apidoc:      build ML API documentation"
 	@echo "  - release:     build Coq in release mode"
@@ -91,6 +92,9 @@ test-suite: voboot
 
 refman-html: voboot
 	dune build @refman-html
+
+refman-pdf: voboot
+	dune build @refman-pdf
 
 stdlib-html: voboot
 	dune build @stdlib-html

--- a/coq-doc.opam
+++ b/coq-doc.opam
@@ -27,7 +27,7 @@ build-env: [
 ]
 
 build: [
-  [ "dune" "build" "@refman" "-j" jobs ]
+  [ "dune" "build" "-p" name "-j" jobs ]
 ]
 
 # Would be better to have a *-conf package?

--- a/doc/dune
+++ b/doc/dune
@@ -1,5 +1,10 @@
 (rule
- (targets sphinx_build)
+ (targets unreleased.rst)
+ (deps (source_tree changelog))
+ (action (with-stdout-to %{targets} (bash "cat changelog/00-title.rst changelog/*/*.rst"))))
+
+(alias
+ (name refman-deps)
  (deps
   ; We could use finer dependencies here so the build is faster:
   ;
@@ -10,23 +15,34 @@
   ;   + tools/coqdoc/coqdoc.css
   (package coq)
   (source_tree sphinx)
-  (source_tree tools)
+  (source_tree tools/coqrst)
   unreleased.rst
-  (env_var SPHINXWARNOPT))
- (action
-  (run env COQLIB=%{project_root} sphinx-build %{env:SPHINXWARNOPT=-W} -b html -d sphinx_build/doctrees sphinx sphinx_build/html)))
-
-(alias
- (name refman-html)
- (deps sphinx_build))
+  (env_var SPHINXWARNOPT)))
 
 (rule
- (targets unreleased.rst)
- (deps (source_tree changelog))
- (action (with-stdout-to %{targets} (bash "cat changelog/00-title.rst changelog/*/*.rst"))))
+ (targets refman-html)
+ (alias refman-html)
+ (package coq-doc)
+ (deps (alias refman-deps))
+ (action
+  (run env COQLIB=%{project_root} sphinx-build %{env:SPHINXWARNOPT=-W} -b html sphinx %{targets})))
 
-; The install target still needs more work.
-; (install
-;  (section doc)
-;  (package coq-refman)
-;  (files sphinx_build))
+(rule
+ (targets refman-pdf)
+ (alias refman-pdf)
+ (package coq-doc)
+ (deps (alias refman-deps))
+ (action
+  (progn
+   (run env COQLIB=%{project_root} sphinx-build %{env:SPHINXWARNOPT=-W} -b latex sphinx %{targets})
+   (chdir %{targets} (run make)))))
+
+; Installable directories are not yet fully supported by Dune.  See
+; ocaml/dune#1868.  Yet, this makes coq-doc.install a valid target to
+; generate the whole Coq documentation.  And the result under
+; _build/install/default/doc/coq-doc looks just right!
+
+(install
+ (files (refman-html as html/refman) (refman-pdf as pdf/refman))
+ (section doc)
+ (package coq-doc))

--- a/doc/stdlib/dune
+++ b/doc/stdlib/dune
@@ -13,6 +13,8 @@
 
 (rule
   (targets html)
+  (alias stdlib-html)
+  (package coq-doc)
   (deps
    ; This will be replaced soon by `theories/**/*.v` soon, thanks to rgrinberg
    (source_tree %{project_root}/theories)
@@ -31,6 +33,12 @@
     (progn (cat %{header}) (cat index-list.html) (cat %{footer})))
    (run cp _index.html html/index.html))))
 
-(alias
- (name stdlib-html)
- (deps html))
+; Installable directories are not yet fully supported by Dune.  See
+; ocaml/dune#1868.  Yet, this makes coq-doc.install a valid target to
+; generate the whole Coq documentation.  And the result under
+; _build/install/default/doc/coq-doc looks just right!
+
+(install
+ (files (html as html/stdlib))
+ (section doc)
+ (package coq-doc))


### PR DESCRIPTION
**Kind:** infrastructure.

FTR `make -f Makefile.dune voboot && dune build coq-doc.install` works but `dune install coq-doc` gives an error:

```
Installing /tmp/lib/coq-doc/META
Installing /tmp/lib/coq-doc/dune-package
Installing /tmp/lib/coq-doc/opam
Installing /tmp/doc/coq-doc/LICENSE
Installing /tmp/doc/coq-doc/README.md
Installing /tmp/doc/coq-doc/html/refman
Error: exception Sys_error("Is a directory")
Backtrace:
Raised by primitive operation at file "stdlib.ml", line 408, characters 7-32
Called from file "src/dune/artifact_substitution.ml", line 378, characters 8-27
Called from file "src/fiber/fiber.ml", line 114, characters 10-15
Re-raised at file "src/stdune/exn.ml" (inlined), line 37, characters 27-56
Called from file "src/stdune/exn_with_backtrace.ml", line 13, characters 33-71
Called from file "src/fiber/fiber.ml", line 102, characters 8-15

I must not segfault.  Uncertainty is the mind-killer.  Exceptions are
the little-death that brings total obliteration.  I will fully express
my cases.  Execution will pass over me and through me.  And when it
has gone past, I will unwind the stack along its path.  Where the
cases are handled there will be nothing.  Only I will remain.
```

Probably a bug to report upstream. @ejgallego WDYT?

In any case, I'd like this PR to be merged without waiting too long. If you want, I can comment out the `install` stanza.