### PR TITLE
WIP: check that records use the correct syntax at parsing time.

### DIFF
--- a/plugins/funind/glob_term_to_relation.ml
+++ b/plugins/funind/glob_term_to_relation.ml
@@ -1531,7 +1531,7 @@ let do_build_inductive evd (funconstants : pconstant list)
     let repacked_rel_inds =
       List.map
         (fun ((a, b, c, l), ntn) ->
-          (((false, (a, None)), b, c, Vernacexpr.Constructors l), ntn))
+          (((false, (a, None)), b, c), Vernacexpr.Constructors l, ntn))
         rel_inds
     in
     let msg =
@@ -1554,7 +1554,7 @@ let do_build_inductive evd (funconstants : pconstant list)
     let repacked_rel_inds =
       List.map
         (fun ((a, b, c, l), ntn) ->
-          (((false, (a, None)), b, c, Vernacexpr.Constructors l), ntn))
+          (((false, (a, None)), b, c), Vernacexpr.Constructors l, ntn))
         rel_inds
     in
     let msg =

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -229,8 +229,12 @@ GRAMMAR EXTEND Gram
       | IDENT "Let"; id = ident_decl; b = def_body ->
           { VernacDefinition ((DoDischarge, Let), name_of_ident_decl id, b) }
       (* Gallina inductive declarations *)
-      | f = finite_token; ind = inductive_definition ->
-          { VernacInductive (f, [ind]) }
+      | IDENT "Variant"; variant = inductive_definition ->
+          { VernacInductive (Variant, [variant]) }
+      | IDENT "Class"; cl = class_definition ->
+          { VernacInductive (Class true, [cl]) }
+      | r = record_token; record = record_definition ->
+          { VernacInductive (r, [record]) }
       | f = inductive_token; indl = LIST1 inductive_definition SEP "with" ->
           { VernacInductive (f, indl) }
       | "Fixpoint"; recs = LIST1 fix_definition SEP "with" ->
@@ -350,11 +354,9 @@ GRAMMAR EXTEND Gram
     [ [ IDENT "Inductive" -> { Inductive_kw }
       | IDENT "CoInductive" -> { CoInductive } ] ]
   ;
-  finite_token:
-    [ [ IDENT "Variant" -> { Variant }
-      | IDENT "Record" -> { Record }
-      | IDENT "Structure" -> { Structure }
-      | IDENT "Class" -> { Class true } ] ]
+  record_token:
+    [ [ IDENT "Record" -> { Record }
+      | IDENT "Structure" -> { Structure } ] ]
   ;
   (* Simple definitions *)
   def_body:
@@ -389,15 +391,12 @@ GRAMMAR EXTEND Gram
   ;
   (* Inductives and records *)
   opt_constructors_or_fields:
-    [ [ ":="; lc = constructors_or_record -> { lc }
-      | -> { RecordDecl (None, [], None) } ] ]
+    [ [ ":="; lc = constructors_or_record -> { lc } ] ]
   ;
   inductive_definition:
-    [ [ oc = opt_coercion; id = cumul_ident_decl; indpar = binders;
-        extrapar = OPT [ "|"; p = binders -> { p } ];
-        c = OPT [ ":"; c = lconstr -> { c } ];
-        lc=opt_constructors_or_fields; ntn = decl_notations ->
-           { (((oc,id),(indpar,extrapar),c,lc),ntn) } ] ]
+    [ [ header = inductive_header;
+        lc = opt_constructors_or_fields; ntn = decl_notations ->
+           { (header,lc,ntn) } ] ]
   ;
   constructors_or_record:
     [ [ "|"; l = LIST1 constructor SEP "|" -> { Constructors l }
@@ -406,12 +405,41 @@ GRAMMAR EXTEND Gram
       | id = identref ; c = constructor_type -> { Constructors [ c id ] }
       | cstr = identref; "{"; fs = record_fields; "}"; id = default_inhabitant_ident ->
           { RecordDecl (Some cstr,fs,id) }
-      | "{";fs = record_fields; "}"; id = default_inhabitant_ident -> { RecordDecl (None,fs,id) }
+      | "{"; fs = record_fields; "}"; id = default_inhabitant_ident -> { RecordDecl (None,fs,id) }
       |  -> { Constructors [] } ] ]
   ;
   default_inhabitant_ident:
     [ [ "as"; id = identref -> { Some id }
       | -> { None } ] ]
+  ;
+  inductive_header:
+    [ [ oc = opt_coercion; id = cumul_ident_decl; indpar = binders;
+        extrapar = OPT [ "|"; p = binders -> { p } ];
+        c = OPT [ ":"; c = lconstr -> { c } ] -> { ((oc,id),(indpar,extrapar),c) } ] ]
+  ;
+  record_definition_body:
+    [ [ cstr = OPT [ cstr = identref -> { cstr } ]; "{"; fs = record_fields; "}";
+    id = default_inhabitant_ident ->
+          { RecordDecl (cstr,fs,id) } ] ]
+  ;
+  class_definition_body:
+    [ [ cstr = identref; "{"; fs = record_fields; "}"; id = default_inhabitant_ident ->
+          { RecordDecl (Some cstr,fs,id) }
+      | "{"; fs = record_fields; "}"; id = default_inhabitant_ident -> { RecordDecl (None,fs,id) }
+      | id = identref; c = constructor_type -> { Constructors [c id] } ] ]
+  ;
+  class_definition:
+    [ [ header = inductive_header; ":="; cl = class_definition_body; ntn = decl_notations ->
+          { (header,cl,ntn) }
+      | header = inductive_header; ntn = decl_notations ->
+          { (header, RecordDecl (None, [], None), ntn) } ] ]
+  ;
+  record_definition:
+    [ [ header = inductive_header; ":=" ; record = record_definition_body; ntn = decl_notations ->
+          { (header,record,ntn) }
+      | header = inductive_header; ntn = decl_notations ->
+          { (header, RecordDecl (None, [], None), ntn) }
+ ] ]
   ;
 (*
   csort:

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -234,7 +234,7 @@ GRAMMAR EXTEND Gram
       | IDENT "Class"; cl = class_definition ->
           { VernacInductive (Class true, [cl]) }
       | r = record_token; record = record_definition ->
-          { VernacInductive (r, [record]) }
+          { VernacRecord (r, record) }
       | f = inductive_token; indl = LIST1 inductive_definition SEP "with" ->
           { VernacInductive (f, indl) }
       | "Fixpoint"; recs = LIST1 fix_definition SEP "with" ->
@@ -419,8 +419,7 @@ GRAMMAR EXTEND Gram
   ;
   record_definition_body:
     [ [ cstr = OPT [ cstr = identref -> { cstr } ]; "{"; fs = record_fields; "}";
-    id = default_inhabitant_ident ->
-          { RecordDecl (cstr,fs,id) } ] ]
+    id = default_inhabitant_ident -> { (cstr,fs,id) } ] ]
   ;
   class_definition_body:
     [ [ cstr = identref; "{"; fs = record_fields; "}"; id = default_inhabitant_ident ->
@@ -438,8 +437,7 @@ GRAMMAR EXTEND Gram
     [ [ header = inductive_header; ":=" ; record = record_definition_body; ntn = decl_notations ->
           { (header,record,ntn) }
       | header = inductive_header; ntn = decl_notations ->
-          { (header, RecordDecl (None, [], None), ntn) }
- ] ]
+          { (header, (None, [], None), ntn) } ] ]
   ;
 (*
   csort:

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -849,7 +849,7 @@ let pr_vernac_expr v =
       | RecordDecl (c,fs,obinder) ->
         pr_record_decl c fs obinder
     in
-    let pr_oneind key (((coe,iddecl),(indupar,indpar),s,lc),ntn) =
+    let pr_oneind key (((coe,iddecl),(indupar,indpar),s),lc,ntn) =
       hov 0 (
         str key ++ spc() ++
         (if coe then str"> " else str"") ++ pr_cumul_ident_decl iddecl ++

--- a/vernac/pvernac.mli
+++ b/vernac/pvernac.mli
@@ -21,7 +21,7 @@ module Vernac_ :
     val command : vernac_expr Entry.t
     val syntax : vernac_expr Entry.t
     val vernac_control : vernac_control Entry.t
-    val inductive_definition : (inductive_expr * decl_notation list) Entry.t
+    val inductive_definition : inductive_expr Entry.t
     val fix_definition : fixpoint_expr Entry.t
     val noedit_mode : vernac_expr Entry.t
     val command_entry : vernac_expr Entry.t

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -40,6 +40,8 @@ let typeclasses_unique =
     ~key:["Typeclasses";"Unique";"Instances"]
     ~value:false
 
+type structure_kind = ClassStructure of bool | RegularStructure
+
 let interp_fields_evars env sigma ~ninds ~nparams impls_env nots l =
   let _, sigma, impls, newfs, _ =
     List.fold_left2
@@ -835,7 +837,7 @@ let check_unique_names records =
   | id :: _ -> user_err (str "Two objects have the same name" ++ spc () ++ quote (Id.print id) ++ str ".")
 
 let check_priorities kind records =
-  let isnot_class = match kind with Class false -> false | _ -> true in
+  let isnot_class = match kind with ClassStructure false -> false | _ -> true in
   let has_priority { Ast.cfs; _ } =
     List.exists (fun (_, { rf_priority }) -> not (Option.is_empty rf_priority)) cfs
   in
@@ -919,14 +921,14 @@ let definition_structure udecl kind ~template ~cumulative ~poly ~primitive_proj
        is messing state beyond that.
     *)
     Vernacstate.System.protect (fun () ->
-        typecheck_params_and_fields (kind = Class true) poly udecl ps data) ()
+        typecheck_params_and_fields (kind = ClassStructure true) poly udecl ps data) ()
   in
   let template = template, auto_template in
   match kind with
-  | Class def ->
+  | ClassStructure def ->
     class_structure ~template ~impargs ~cumulative ~params ~univs ~variances ~primitive_proj
       def records data
-  | Inductive_kw | CoInductive | Variant | Record | Structure ->
+  | RegularStructure ->
     regular_structure ~cumulative ~template ~impargs ~univs ~variances ~params ~finite ~primitive_proj
       records data
 

--- a/vernac/record.mli
+++ b/vernac/record.mli
@@ -25,9 +25,11 @@ module Ast : sig
     }
 end
 
+type structure_kind = ClassStructure of bool | RegularStructure
+
 val definition_structure
   :  cumul_univ_decl_expr option
-  -> inductive_kind
+  -> structure_kind
   -> template:bool option
   -> cumulative:bool
   -> poly:bool

--- a/vernac/vernac_classifier.ml
+++ b/vernac/vernac_classifier.ml
@@ -122,7 +122,7 @@ let classify_vernac e =
         VtSideff ([id.CAst.v], VtLater)
     | VernacDefinition (_,({v=id},_),DefineBody _) -> VtSideff (idents_of_name id, VtLater)
     | VernacInductive (_,l) ->
-        let ids = List.map (fun (((_,({v=id},_)),_,_,cl),_) -> id :: match cl with
+        let ids = List.map (fun (((_,({v=id},_)),_,_),cl,_) -> id :: match cl with
         | Constructors l -> List.map (fun (_,({v=id},_)) -> id) l
         | RecordDecl (oid,l,obinder) -> (match oid with Some {v=x} -> [x] | _ -> []) @
            (match obinder with Some {v=x} -> [x] | _ -> []) @

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -175,7 +175,8 @@ type local_decl_expr =
   | AssumExpr of lname * local_binder_expr list * constr_expr
   | DefExpr of lname * local_binder_expr list * constr_expr * constr_expr option
 
-type inductive_kind = Inductive_kw | CoInductive | Variant | Record | Structure | Class of bool (* true = definitional, false = inductive *)
+type inductive_kind = Inductive_kw | CoInductive | Variant | Class of bool (* true = definitional, false = inductive *)
+type record_kind = Record | Structure
 type simple_binder = lident list  * constr_expr
 type class_binder = lident * constr_expr list
 type 'a with_coercion = coercion_flag * 'a
@@ -187,14 +188,18 @@ type record_field_attr = {
   rf_canonical: bool; (* use this projection in the search for canonical instances *)
   }
 type constructor_expr = (lident * constr_expr) with_coercion
+type record_decl = lident option * (local_decl_expr * record_field_attr) list * lident option
 type constructor_list_or_record_decl_expr =
   | Constructors of constructor_expr list
-  | RecordDecl of lident option * (local_decl_expr * record_field_attr) list * lident option
+  | RecordDecl of record_decl
 type inductive_params_expr = local_binder_expr list * local_binder_expr list option
 (** If the option is nonempty the "|" marker was used *)
 
 type inductive_header =
   cumul_ident_decl with_coercion * inductive_params_expr * constr_expr option
+
+type record_expr =
+  inductive_header * record_decl * decl_notation list
 
 type inductive_expr =
   inductive_header * constructor_list_or_record_decl_expr * decl_notation list
@@ -352,6 +357,7 @@ type nonrec vernac_expr =
   | VernacAssumption of (discharge * Decls.assumption_object_kind) *
       Declaremods.inline * (ident_decl list * constr_expr) with_coercion list
   | VernacInductive of inductive_kind * inductive_expr list
+  | VernacRecord of record_kind * record_expr
   | VernacFixpoint of discharge * fixpoint_expr list
   | VernacCoFixpoint of discharge * cofixpoint_expr list
   | VernacScheme of (lident option * scheme) list

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -193,10 +193,11 @@ type constructor_list_or_record_decl_expr =
 type inductive_params_expr = local_binder_expr list * local_binder_expr list option
 (** If the option is nonempty the "|" marker was used *)
 
+type inductive_header =
+  cumul_ident_decl with_coercion * inductive_params_expr * constr_expr option
+
 type inductive_expr =
-  cumul_ident_decl with_coercion
-  * inductive_params_expr * constr_expr option
-  * constructor_list_or_record_decl_expr
+  inductive_header * constructor_list_or_record_decl_expr * decl_notation list
 
 type one_inductive_expr =
   lident * inductive_params_expr * constr_expr option * constructor_expr list
@@ -350,7 +351,7 @@ type nonrec vernac_expr =
   | VernacExactProof of constr_expr
   | VernacAssumption of (discharge * Decls.assumption_object_kind) *
       Declaremods.inline * (ident_decl list * constr_expr) with_coercion list
-  | VernacInductive of inductive_kind * (inductive_expr * decl_notation list) list
+  | VernacInductive of inductive_kind * inductive_expr list
   | VernacFixpoint of discharge * fixpoint_expr list
   | VernacCoFixpoint of discharge * cofixpoint_expr list
   | VernacScheme of (lident option * scheme) list


### PR DESCRIPTION
This is a super-preliminary refactoring of the parsing of `Inductive` / `Record` following a suggestion of @jfehrle. In practice, the parser is not able to reject the combination of `Record` / `Structure` + the constructor syntax, does not know that the `@binders | @binders` syntax for uniform parameters  is not supported either, does not know that `Variant` does not support the record syntax. `Class` piggies-back on the constructor syntax for definitional classes, but rejects definitions with multiple constructors and it rejects mutual definitions. Finally, `Record` / `Structure` do support the `with` construct but I'm not sure with what use case since any properly (co-)recursive record must be constructed with (Co)Inductive.

Note that once there is more separation at parsing time, this could be reflected in the datatypes in `vernacexpr.ml` and eventually trickle down, leading to removal of some error paths. For instance, currently, at parsing time we could distinguish between definitional and non-definitional classes, but we don't do it. We give a dummy value to the constructor `Class` and we fix this value later, in `vernacentries.ml`.

Note that even this PR turns out to lead nowhere or does not raise consensus, I still think that we must do this kind of refactoring in the grammar that we document.