### PR TITLE
python3 script does not need to import from the future

### DIFF
--- a/dev/tools/update-compat.py
+++ b/dev/tools/update-compat.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python3
-from __future__ import with_statement
-from __future__ import print_function
 import os, re, sys, subprocess
 from io import open
 


### PR DESCRIPTION
<!-- Keep what applies -->
**Kind:**  infrastructure.

This is a minor issue.

Note however that there are some python scripts which do not even have a #!/usr/bin/env python-whatever line. Since I do not know how to test them I cannot be sure wheter it is safe to label them
as python3. These are at least:
* doc/tools/coqrst/checkdeps.py
* tools/TimeFileMaker.py
