### PR TITLE
Remove command Include Type, deprecated since Coq 8.3 and strictly equivalent to Include.

### DIFF
--- a/doc/changelog/07-commands-and-options/11876-remove-include-type.rst
+++ b/doc/changelog/07-commands-and-options/11876-remove-include-type.rst
@@ -1,0 +1,3 @@
+- **Removed:** Command ``Include Type`` which was deprecated since Coq
+  8.3 and a strict equivalent of :cmd:`Include` (`#11876
+  <https://github.com/coq/coq/pull/11876>`_, by Théo Zimmermann).

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -541,10 +541,6 @@ let starredidentreflist_to_expr l =
   | [] -> SsEmpty
   | x :: xs -> List.fold_right (fun i acc -> SsUnion(i,acc)) xs x
 
-let warn_deprecated_include_type =
-  CWarnings.create ~name:"deprecated-include-type" ~category:"deprecated"
-         (fun () -> strbrk "Include Type is deprecated; use Include instead")
-
 }
 
 (* Modules and Sections *)
@@ -584,10 +580,7 @@ GRAMMAR EXTEND Gram
       | IDENT "Import"; qidl = LIST1 global -> { VernacImport (false,qidl) }
       | IDENT "Export"; qidl = LIST1 global -> { VernacImport (true,qidl) }
       | IDENT "Include"; e = module_type_inl; l = LIST0 ext_module_expr ->
-          { VernacInclude(e::l) }
-      | IDENT "Include"; "Type"; e = module_type_inl; l = LIST0 ext_module_type ->
-         { warn_deprecated_include_type ~loc ();
-        VernacInclude(e::l) } ] ]
+          { VernacInclude(e::l) } ] ]
   ;
   export_token:
     [ [ IDENT "Import" -> { Some false }


### PR DESCRIPTION
**Kind:** clean-up.

The command was not documented. Does this need a changelog?

- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
