### PR TITLE
Removing deprecated destruct/remember syntax _eqn.

### DIFF
--- a/doc/changelog/04-tactics/11877-master+deprecated-_eqn.rst
+++ b/doc/changelog/04-tactics/11877-master+deprecated-_eqn.rst
@@ -1,0 +1,5 @@
+- **Removed:**
+  Deprecated syntax `_eqn` for :tacn:`destruct` and :tacn:`remember`.
+  Use `eqn:` syntax instead
+  (`#11877 <https://github.com/coq/coq/pull/11877>`_,
+  by Hugo Herbelin).

--- a/doc/sphinx/language/gallina-specification-language.rst
+++ b/doc/sphinx/language/gallina-specification-language.rst
@@ -117,7 +117,7 @@ Other tokens
 
     ! #[ % & ' ( () (bfs) (dfs) ) * ** + , - ->
     . .( .. ... / : ::= := :> :>> ; < <+ <- <:
-    <<: <= = => > >-> >= ? @ @{ [ [= ] _ _eqn
+    <<: <= = => > >-> >= ? @ @{ [ [= ] _
     `( `{ { {| | |- || }
 
   When multiple tokens match the beginning of a sequence of characters,

--- a/plugins/ltac/g_tactic.mlg
+++ b/plugins/ltac/g_tactic.mlg
@@ -185,10 +185,6 @@ let merge_occurrences loc cl = function
     in
     (Some p, ans)
 
-let warn_deprecated_eqn_syntax =
-  CWarnings.create ~name:"deprecated-eqn-syntax" ~category:"deprecated"
-         (fun arg -> strbrk (Printf.sprintf "Syntax \"_eqn:%s\" is deprecated. Please use \"eqn:%s\" instead." arg arg))
-
 (* Auxiliary grammar rules *)
 
 open Pvernac.Vernac_
@@ -461,10 +457,6 @@ GRAMMAR EXTEND Gram
   ;
   eqn_ipat:
     [ [ IDENT "eqn"; ":"; pat = naming_intropattern -> { Some (CAst.make ~loc pat) }
-      | IDENT "_eqn"; ":"; pat = naming_intropattern ->
-         { warn_deprecated_eqn_syntax ~loc "H"; Some (CAst.make ~loc pat) }
-      | IDENT "_eqn" ->
-         { warn_deprecated_eqn_syntax ~loc "?"; Some (CAst.make ~loc IntroAnonymous) }
       | -> { None } ] ]
   ;
   as_name:


### PR DESCRIPTION
**Kind:** removal of deprecated syntax

The `_eqn` syntax was deprecated since 2012, so I guess there is no scrupuls to have. Don't know if the change log is really worth.

- [X] Entry added in the changelog