### PR TITLE
Fix #7812: autounfold's behavior depends on file names

### DIFF
--- a/doc/changelog/04-tactics/11883-fix-autounfold.rst
+++ b/doc/changelog/04-tactics/11883-fix-autounfold.rst
@@ -1,0 +1,13 @@
+- **Fixed:**
+  The behavior of :tacn:`autounfold` no longer depends on the names of terms and modules
+  (`#11883 <https://github.com/coq/coq/pull/11883>`_,
+  fixes `#7812 <https://github.com/coq/coq/issues/7812>`_,
+  by Attila Gáspár).
+- **Changed:**
+  `at` clauses can no longer be used with :tacn:`autounfold`. Since they had no effect, it is safe to remove them
+  (`#11883 <https://github.com/coq/coq/pull/11883>`_,
+  by Attila Gáspár).
+- **Changed:**
+  :tacn:`autounfold` no longer fails when the :cmd:`Opaque` command is used on constants in the hint databases
+  (`#11883 <https://github.com/coq/coq/pull/11883>`_,
+  by Attila Gáspár).

--- a/test-suite/bugs/closed/bug_7812.v
+++ b/test-suite/bugs/closed/bug_7812.v
@@ -1,0 +1,30 @@
+Module Foo.
+  Definition binary A := A -> A -> Prop.
+
+  Definition inter A (R1 R2 : binary A): binary A :=
+    fun (x y:A) => R1 x y /\ R2 x y.
+End Foo.
+
+Module Simple_sparse_proof.
+  Parameter node : Type.
+  Parameter graph : Type.
+  Parameter has_edge : graph -> node -> node -> Prop.
+  Implicit Types x y z : node.
+  Implicit Types G : graph.
+
+  Parameter mem : forall A, A -> list A -> Prop.
+  Hypothesis mem_nil : forall x, mem node x nil = False.
+
+  Definition notin (l: list node): node -> node -> Prop :=
+    fun x y => ~ mem node x l /\ ~ mem node y l.
+
+  Definition edge_notin G l : node -> node -> Prop :=
+    Foo.inter node (has_edge G) (notin l).
+
+  Hint Unfold Foo.inter notin edge_notin : rel_crush.
+
+  Lemma edge_notin_nil G : forall x y, edge_notin G nil x y <-> has_edge G x y.
+  Proof.
+    intros. autounfold with rel_crush. rewrite !mem_nil. tauto.
+  Qed.
+End Simple_sparse_proof.


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** bug fix

The following changes are made to `autounfold`:
- It is now idempotent
- Opaque hints are ignored instead of resulting in errors (this is consistent with `auto`)
- `at` clauses result in an error (they were silently ignored before)

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #7812

<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [x] Added / updated test-suite
<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).