### PR TITLE
Sorting: Swap the names of Sorted_sort and LocallySorted_sort

### DIFF
--- a/doc/changelog/10-standard-library/1185-sort.rst
+++ b/doc/changelog/10-standard-library/1185-sort.rst
@@ -1,0 +1,5 @@
+- **Changed:**
+  The names of ``Sorted_sort`` and ``LocallySorted_sort`` in ``Coq.Sorting.MergeSort``
+  have been swapped to appropriately reflect their meanings
+  (`#1185 <https://github.com/coq/coq/pull/1185>`_,
+  by Lysxia).

--- a/theories/Sorting/Mergesort.v
+++ b/theories/Sorting/Mergesort.v
@@ -230,13 +230,13 @@ Proof.
     apply IHl.
 Qed.
 
-Theorem Sorted_sort : forall l, Sorted (sort l).
+Theorem LocallySorted_sort : forall l, Sorted (sort l).
 Proof.
 intro; apply Sorted_iter_merge. constructor.
 Qed.
 
-Corollary LocallySorted_sort : forall l, Sorted.Sorted leb (sort l).
-Proof. intro; eapply Sorted_LocallySorted_iff, Sorted_sort; auto. Qed.
+Corollary Sorted_sort : forall l, Sorted.Sorted leb (sort l).
+Proof. intro; eapply Sorted_LocallySorted_iff, LocallySorted_sort; auto. Qed.
 
 Theorem Permuted_sort : forall l, Permutation l (sort l).
 Proof.
@@ -245,7 +245,7 @@ Qed.
 
 Corollary StronglySorted_sort : forall l,
   Transitive leb -> StronglySorted leb (sort l).
-Proof. auto using Sorted_StronglySorted, LocallySorted_sort. Qed.
+Proof. auto using Sorted_StronglySorted, Sorted_sort. Qed.
 
 End Sort.
 


### PR DESCRIPTION
**Kind:** bug fix.

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #11884

It's a breaking change, so I don't know if it's worth it, but here's the patch anyway.

<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
<!-- - [ ] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified). -->
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
