### PR TITLE
Fix broken links in prodn:: in doc

### DIFF
--- a/doc/tools/coqrst/coqdomain.py
+++ b/doc/tools/coqrst/coqdomain.py
@@ -519,7 +519,7 @@ class ProductionObject(CoqObject):
             row = nodes.inline(classes=['prodn-row'])
             entry = nodes.inline(classes=['prodn-cell-nonterminal'])
             if lhs != "":
-                target_name = 'grammar-token-' + lhs
+                target_name = 'grammar-token-' + nodes.make_id(lhs)
                 target = nodes.target('', '', ids=[target_name], names=[target_name])
                 # putting prodn-target on the target node won't appear in the tex file
                 inline = nodes.inline(classes=['prodn-target'])


### PR DESCRIPTION
Hyperlinks for grammar nonterminals containing underscores were broken, presumably due to a change in nodes.make_id() in docutils.  The id in the target had underscores but the references (created in _target_id()) had dashes.  Now they will be consistent.
