### PR TITLE
[refman] Fix caching, which was broken by the addition of coq_config

### DIFF
--- a/doc/sphinx/changes.rst
+++ b/doc/sphinx/changes.rst
@@ -4,7 +4,7 @@
 Recent changes
 --------------
 
-.. ifconfig:: not coq_config.is_a_released_version
+.. ifconfig:: not is_a_released_version
 
    .. include:: ../unreleased.rst
 

--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -100,7 +100,7 @@ def copy_formatspecific_files(app):
 
 def setup(app):
     app.connect('builder-inited', copy_formatspecific_files)
-    app.add_config_value('coq_config', coq_config, 'env')
+    app.add_config_value('is_a_released_version', coq_config.is_a_released_version, 'env')
 
 # The master toctree document.
 # We create this file in `copy_master_doc` above.


### PR DESCRIPTION
**Kind:** bug fix / infrastructure.

Reported as part of #11855.  My understanding is that the addition of coq_config confused the caching engine.  All config parameters are stored along with the on-disk build cache, and that cache is invalidated if the parameters change.  But the newly added `coq_config` parameter was a full Python module (hence not serializable), and as a result the cache was invalidated at every build. 