### PR TITLE
Remove Chapter command.

### DIFF
--- a/doc/changelog/07-commands-and-options/11746-remove-chapter.rst
+++ b/doc/changelog/07-commands-and-options/11746-remove-chapter.rst
@@ -1,0 +1,3 @@
+- **Removed:** undocumented ``Chapter`` command.  Use :cmd:`Section`
+  instead (`#11746 <https://github.com/coq/coq/pull/11746>`_, by Théo
+  Zimmermann).

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -552,7 +552,6 @@ GRAMMAR EXTEND Gram
           { VernacDeclareModule (export, id, bl, mty) }
       (* Section beginning *)
       | IDENT "Section"; id = identref -> { VernacBeginSection id }
-      | IDENT "Chapter"; id = identref -> { VernacBeginSection id }
 
       (* This end a Section a Module or a Module Type *)
       | IDENT "End"; id = identref -> { VernacEndSegment id }


### PR DESCRIPTION
This was an undocumented equivalent of the Section command (that existed since forever, i.e. at least 1999).

The intent of the PR is mostly to test if this command was used in tested projects. It also raises the question: is there a use case for having two synonym commands to start a section (and in this case we should document `Chapter`) or should we remove this undocumented (and unknown) variant?

- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
