### PR TITLE
Clean-up include module syntax.

### DIFF
--- a/test-suite/modules/include.v
+++ b/test-suite/modules/include.v
@@ -1,0 +1,48 @@
+Module Example1.
+
+Module Type foo. Parameter A : Prop. End foo.
+Module Type bar. Parameter B : Prop. End bar.
+
+Module foobar <: foo <: bar.
+Fail End foobar.
+Include foo <+ bar.
+End foobar.
+
+Fail Module barfoo <: foo <: bar := foo.
+Fail Module barfoo <: foo <: bar := bar.
+Module barfoo <: foo <: bar := bar <+ foo.
+
+Module foo' : foo := foo.
+
+End Example1.
+
+Module Example2.
+
+Module Import bar.
+Module foo.
+End foo.
+End bar.
+
+Module empty.
+End empty.
+
+Fail Fail Module foo := foo.
+Fail Fail Module foo := empty <+ foo.
+Fail Fail Module foo := foo <+ empty.
+(* This is in fact implemented as the following: *)
+Module foo.
+Include foo.
+End foo.
+
+End Example2.
+
+Module Example3.
+
+(* Check that an interactive module can refer to elements
+   already defined in it *)
+Module foo'.
+Definition a := 0.
+Definition b := foo'.a.
+End foo'.
+
+End Example3.

--- a/vernac/declaremods.mli
+++ b/vernac/declaremods.mli
@@ -40,20 +40,34 @@ type library_name = DirPath.t
 
 type library_objects
 
+type current_module_syntax_info = {
+  cur_syn_mp : ModPath.t;
+  cur_syn_sign : (Modintern.module_struct_expr * Names.ModPath.t * Modintern.module_kind * int option) module_signature;
+  cur_syn_params : (MBId.t list * (Modintern.module_struct_expr * Names.ModPath.t * Modintern.module_kind * int option)) list; (** parameters *)
+  cur_syn_mbids : MBId.t list;
+}
+
 module Synterp : sig
 
 val declare_module :
   Id.t ->
   module_params ->
+  (Constrexpr.module_ast * inline) -> current_module_syntax_info
+
+val define_module :
+  Id.t ->
+  module_params ->
   (Constrexpr.module_ast * inline) module_signature ->
   (Constrexpr.module_ast * inline) list ->
-  ModPath.t * module_params_expr * module_expr list * module_expr module_signature
+  current_module_syntax_info *
+  (Modintern.module_struct_expr * Names.ModPath.t *
+   Modintern.module_kind * int option) list
 
 val start_module :
   Lib.export -> Id.t ->
   module_params ->
   (Constrexpr.module_ast * inline) module_signature ->
-  ModPath.t * module_params_expr * module_expr module_signature
+  current_module_syntax_info
 
 val end_module : unit -> ModPath.t
 
@@ -66,13 +80,15 @@ val declare_modtype :
   module_params ->
   (Constrexpr.module_ast * inline) list ->
   (Constrexpr.module_ast * inline) list ->
-  ModPath.t * module_params_expr * module_expr list * module_expr list
+  current_module_syntax_info *
+  (Modintern.module_struct_expr * Names.ModPath.t *
+   Modintern.module_kind * int option) list
 
 val start_modtype :
   Id.t ->
   module_params ->
   (Constrexpr.module_ast * inline) list ->
-  ModPath.t * module_params_expr * module_expr list
+  current_module_syntax_info
 
 val end_modtype : unit -> ModPath.t
 
@@ -95,9 +111,19 @@ module Interp : sig
 val declare_module :
   Id.t ->
   module_params_expr ->
-  module_expr module_signature ->
-  module_expr list ->
+  Modintern.module_struct_expr * Names.ModPath.t *
+  Modintern.module_kind * Entries.inline ->
   ModPath.t
+
+val define_module :
+  Id.t ->
+  module_params_expr ->
+  (Modintern.module_struct_expr * Names.ModPath.t *
+   Modintern.module_kind * Entries.inline)
+    module_signature ->
+  (Modintern.module_struct_expr * Names.ModPath.t *
+   Modintern.module_kind * Entries.inline)
+    list -> ModPath.t
 
 val start_module :
   Lib.export -> Id.t ->
@@ -186,6 +212,12 @@ val process_module_binding :
 val import_module : Libobject.open_filter -> export:Lib.export_flag -> ModPath.t -> unit
 
 val declare_module :
+  Id.t ->
+  module_params ->
+  Constrexpr.module_ast * inline ->
+  ModPath.t
+
+val define_module :
   Id.t ->
   module_params ->
   (Constrexpr.module_ast * inline) module_signature ->

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -620,7 +620,7 @@ GRAMMAR EXTEND Gram
         body = module_body ->
           { VernacSynterp (VernacDeclareModuleType (id, bl, sign, body)) }
       | IDENT "Declare"; IDENT "Module"; export = export_token; id = identref;
-        bl = LIST0 module_binder; ":"; mty = module_type_inl ->
+        bl = LIST0 module_binder; ":"; mty = module_expr_inl ->
           { VernacSynterp (VernacDeclareModule (export, id, bl, mty)) }
       (* Section beginning *)
       | IDENT "Section"; id = identref -> { VernacSynterp (VernacBeginSection id) }
@@ -648,9 +648,9 @@ GRAMMAR EXTEND Gram
         { VernacSynterp (VernacImport ((Import,cats),qidl)) }
       | IDENT "Export"; cats = OPT import_categories; qidl = LIST1 filtered_import ->
         { VernacSynterp (VernacImport ((Export,cats),qidl)) }
-      | IDENT "Include"; l = LIST1 module_type_inl SEP "<+" ->
+      | IDENT "Include"; l = LIST1 module_expr_inl SEP "<+" ->
           { VernacSynterp (VernacInclude l) }
-      | IDENT "Include"; "Type"; l = LIST1 module_type_inl SEP "<+" ->
+      | IDENT "Include"; "Type"; l = LIST1 module_expr_inl SEP "<+" ->
           { warn_deprecated_include_type ~loc ();
             VernacSynterp (VernacInclude l) } ] ]
   ;
@@ -673,17 +673,17 @@ GRAMMAR EXTEND Gram
       |  -> { None } ] ]
   ;
   check_module_type:
-    [ [ "<:"; mty = module_type_inl -> { mty } ] ]
+    [ [ "<:"; mty = module_expr_inl -> { mty } ] ]
   ;
   check_module_types:
     [ [ mtys = LIST0 check_module_type -> { mtys } ] ]
   ;
   of_module_type:
-    [ [ ":"; mty = module_type_inl -> { Enforce mty }
+    [ [ ":"; mty = module_expr_inl -> { Enforce mty }
       | mtys = check_module_types -> { Check mtys } ] ]
   ;
   module_body:
-    [ [ ":="; l = LIST1 module_type_inl SEP "<+" -> { l }
+    [ [ ":="; l = LIST1 module_expr_inl SEP "<+" -> { l }
       | -> { [] } ] ]
   ;
   functor_app_annot:
@@ -693,19 +693,21 @@ GRAMMAR EXTEND Gram
       | -> { DefaultInline }
       ] ]
   ;
-  module_type_inl:
-    [ [ "!"; me = module_type -> { (me,NoInline) }
-      | me = module_type; a = functor_app_annot -> { (me,a) } ] ]
+  module_expr_inl:
+    [ [ "!"; me = module_expr -> { (me,NoInline) }
+      | me = module_expr; a = functor_app_annot -> { (me,a) } ] ]
   ;
   (* Module binder  *)
   module_binder:
     [ [ "("; export = export_token; idl = LIST1 identref; ":";
-         mty = module_type_inl; ")" -> { (export,idl,mty) } ] ]
+         mty = module_expr_inl; ")" -> { (export,idl,mty) } ] ]
   ;
   (* Module expressions *)
   module_expr:
     [ [ me = module_expr_atom -> { CAst.make ~loc @@ CMident me }
       | me1 = module_expr; me2 = module_expr_atom -> { CAst.make ~loc @@ CMapply (me1,me2) }
+      | me = module_expr; "with"; decl = with_declaration ->
+          { CAst.make ~loc @@ CMwith (me,decl) }
       ] ]
   ;
   module_expr_atom:
@@ -716,15 +718,6 @@ GRAMMAR EXTEND Gram
           { CWith_Definition (fqid,udecl,c) }
       | IDENT "Module"; fqid = fullyqualid; ":="; qid = qualid ->
           { CWith_Module (fqid,qid) }
-      ] ]
-  ;
-  module_type:
-    [ [ qid = qualid -> { CAst.make ~loc @@ CMident qid }
-      | "("; mt = module_type; ")" -> { mt }
-      | mty = module_type; me = module_expr_atom ->
-          { CAst.make ~loc @@ CMapply (mty,me) }
-      | mty = module_type; "with"; decl = with_declaration ->
-          { CAst.make ~loc @@ CMwith (mty,decl) }
       ] ]
   ;
   (* Proof using *)

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -613,11 +613,11 @@ GRAMMAR EXTEND Gram
     [ [ (* Interactive module declaration *)
         IDENT "Module"; export = export_token; id = identref;
         bl = LIST0 module_binder; sign = of_module_type;
-        body = is_module_expr ->
+        body = module_body ->
           { VernacSynterp (VernacDefineModule (export, id, bl, sign, body)) }
       | IDENT "Module"; "Type"; id = identref;
         bl = LIST0 module_binder; sign = check_module_types;
-        body = is_module_type ->
+        body = module_body ->
           { VernacSynterp (VernacDeclareModuleType (id, bl, sign, body)) }
       | IDENT "Declare"; IDENT "Module"; export = export_token; id = identref;
         bl = LIST0 module_binder; ":"; mty = module_type_inl ->
@@ -648,11 +648,11 @@ GRAMMAR EXTEND Gram
         { VernacSynterp (VernacImport ((Import,cats),qidl)) }
       | IDENT "Export"; cats = OPT import_categories; qidl = LIST1 filtered_import ->
         { VernacSynterp (VernacImport ((Export,cats),qidl)) }
-      | IDENT "Include"; e = module_type_inl; l = LIST0 ext_module_expr ->
-          { VernacSynterp (VernacInclude(e::l)) }
-      | IDENT "Include"; "Type"; e = module_type_inl; l = LIST0 ext_module_type ->
-         { warn_deprecated_include_type ~loc ();
-        VernacSynterp (VernacInclude(e::l)) } ] ]
+      | IDENT "Include"; l = LIST1 module_type_inl SEP "<+" ->
+          { VernacSynterp (VernacInclude l) }
+      | IDENT "Include"; "Type"; l = LIST1 module_type_inl SEP "<+" ->
+          { warn_deprecated_include_type ~loc ();
+            VernacSynterp (VernacInclude l) } ] ]
   ;
   import_categories:
   [ [ negative = OPT "-"; "("; cats = LIST1 qualid SEP ","; ")" ->
@@ -672,12 +672,6 @@ GRAMMAR EXTEND Gram
       | IDENT "Export"; cats = OPT import_categories -> { Some (Export,cats) }
       |  -> { None } ] ]
   ;
-  ext_module_type:
-    [ [ "<+"; mty = module_type_inl -> { mty } ] ]
-  ;
-  ext_module_expr:
-    [ [ "<+"; mexpr = module_expr_inl -> { mexpr } ] ]
-  ;
   check_module_type:
     [ [ "<:"; mty = module_type_inl -> { mty } ] ]
   ;
@@ -688,12 +682,8 @@ GRAMMAR EXTEND Gram
     [ [ ":"; mty = module_type_inl -> { Enforce mty }
       | mtys = check_module_types -> { Check mtys } ] ]
   ;
-  is_module_type:
-    [ [ ":="; mty = module_type_inl ; l = LIST0 ext_module_type -> { (mty::l) }
-      | -> { [] } ] ]
-  ;
-  is_module_expr:
-    [ [ ":="; mexpr = module_expr_inl; l = LIST0 ext_module_expr -> { (mexpr::l) }
+  module_body:
+    [ [ ":="; l = LIST1 module_type_inl SEP "<+" -> { l }
       | -> { [] } ] ]
   ;
   functor_app_annot:
@@ -702,10 +692,6 @@ GRAMMAR EXTEND Gram
       | "["; IDENT "no"; IDENT "inline"; "]" -> { NoInline }
       | -> { DefaultInline }
       ] ]
-  ;
-  module_expr_inl:
-    [ [ "!"; me = module_expr -> { (me,NoInline) }
-      | me = module_expr; a = functor_app_annot -> { (me,a) } ] ]
   ;
   module_type_inl:
     [ [ "!"; me = module_type -> { (me,NoInline) }

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1263,7 +1263,7 @@ let vernac_declare_module export {loc;v=id} binders_ast mty_ast =
      and what module information is supplied *)
   if Lib.sections_are_opened () then
     user_err Pp.(str "Modules and Module Types are not allowed inside sections.");
-  let mp = Declaremods.Interp.declare_module id binders_ast (Declaremods.Enforce mty_ast) [] in
+  let mp = Declaremods.Interp.declare_module id binders_ast mty_ast in
   Dumpglob.dump_moddef ?loc mp "mod";
   Flags.if_verbose Feedback.msg_info (str "Module " ++ Id.print id ++ str " is declared");
   Option.iter (fun export -> vernac_import export [CAst.make ?loc mp, ImportAll]) export
@@ -1284,8 +1284,7 @@ let vernac_define_module export {loc;v=id} binders_ast argsexport mty_ast_o mexp
          argsexport
     | _::_ ->
        let mp =
-         Declaremods.Interp.declare_module
-           id binders_ast mty_ast_o mexpr_ast_l
+         Declaremods.Interp.define_module id binders_ast mty_ast_o mexpr_ast_l
        in
        Dumpglob.dump_moddef ?loc mp "mod";
        Flags.if_verbose Feedback.msg_info


### PR DESCRIPTION
Make `Include` a true equivalent to `Include Type`.  Until now, it was interpreted exactly in the same way, but the syntax was purposelessly restricted.

Make `:=` in Module definition a true equivalent to the `Include` / `Include Type` commands.  This triggers a small clean-up in the interpretation of modules.

Merging this PR in 8.12 will allow merging #11876 (removal of `Include Type` command) in 8.13.

**Kind:** enhancement / clean-up.

- [x] Added / updated test-suite
- [ ] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [ ] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).

Documentation will be done after #11705 is merged.