### PR TITLE
Switch opam file to make

### DIFF
--- a/coq.opam.docker
+++ b/coq.opam.docker
@@ -1,0 +1,38 @@
+synopsis: "The Coq Proof Assistant"
+description: """
+Coq is a formal proof management system. It provides
+a formal language to write mathematical definitions, executable
+algorithms and theorems together with an environment for
+semi-interactive development of machine-checked proofs. Typical
+applications include the certification of properties of programming
+languages (e.g. the CompCert compiler certification project, or the
+Bedrock verified low-level programming library), the formalization of
+mathematics (e.g. the full formalization of the Feit-Thompson theorem
+or homotopy type theory) and teaching.
+"""
+opam-version: "2.0"
+maintainer: "The Coq development team <coqdev@inria.fr>"
+authors: "The Coq development team, INRIA, CNRS, and contributors."
+homepage: "https://coq.inria.fr/"
+bug-reports: "https://github.com/coq/coq/issues"
+dev-repo: "git+https://github.com/coq/coq.git"
+license: "LGPL-2.1"
+
+version: "dev"
+
+depends: [
+  "ocaml"     { >= "4.05.0" }
+  "ocamlfind" { build }
+  "num"
+  "conf-findutils" {build}
+]
+
+build: [
+  [ "./configure" "-prefix" prefix "-coqide" "no" ]
+  [make "-j%{jobs}%"]
+  [make "-j%{jobs}%" "byte"]
+]
+install: [
+  [make "install"]
+  [make "install-byte"]
+]


### PR DESCRIPTION
In accordance with @ejgallego in coq/bignums#38 we'd like to switch the Opam file from dune to make compilation in order for the docker image coqorg/coq:dev to be built with the native compute files, enabling the CI to work on bignums.

This could of course be reverted to dune as soon as dune supports native compilation.

cc @erikmd who maintains docker images
