### PR TITLE
[declare] [obligations] Restrict context on mutual obligation declaration

### DIFF
--- a/test-suite/bugs/closed/bug_11766.v
+++ b/test-suite/bugs/closed/bug_11766.v
@@ -1,0 +1,16 @@
+Require Import Program.Tactics.
+
+Set Universe Polymorphism.
+(* needed because we don't enforce universe declarations on
+   obligations, in univ poly mode however the universes must be
+   redeclared for the main definition so we do see the error *)
+
+Program Definition bla@{} : nat := _.
+Next Obligation.
+  let x := constr:(Type) in exact 0.
+Defined. (* unbound univ *)
+
+Program Fixpoint blo@{} (s : bool) : nat := _.
+Next Obligation.
+  let x := constr:(Type) in exact 0.
+Defined. (* unbound univ *)

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -1395,6 +1395,11 @@ let obligation_terminator ~pm ~entry ~uctx ~oinfo:{name; num; auto; check_final}
   let obl = {obl with obl_status = (false, status)} in
   let poly = prg.prg_info.Info.poly in
   let uctx = if poly then uctx else UState.union prg.prg_uctx uctx in
+  (* XXX: use the combined to_constr_and_evars form when merged *)
+  let vars = Vars.universes_of_constr body in
+  let vars = Option.cata
+      (fun ty -> Univ.Level.Set.union (Vars.universes_of_constr ty) vars) vars ty in
+  let uctx = UState.restrict uctx vars in
   let defined, obl, cst = declare_obligation prg obl ~body ~types:ty ~uctx in
   let prg_ctx = obligation_uctx_terminator prg uctx ~poly ~defined in
   let pm =


### PR DESCRIPTION
We were not doing this in the code, but it seems like a bug that arose
in the past due to bad API.

Will fix #11988 when fixed.