### PR TITLE
Make the level of ≡ in Int63 consistent with =

### DIFF
--- a/doc/changelog/10-standard-library/11909-fix-≡-level.rst
+++ b/doc/changelog/10-standard-library/11909-fix-≡-level.rst
@@ -1,0 +1,5 @@
+- **Changed:**
+  The level of :g:`≡` in ``Coq.Numbers.Cyclic.Int63.Int63`` is now 70,
+  no associativity, in line with :g:`=` (fixes `#11905
+  <https://github.com/coq/coq/issues/11905>`_, `#11909
+  <https://github.com/coq/coq/pull/11909>`_, by Jason Gross).

--- a/doc/changelog/10-standard-library/11909-fix-≡-level.rst
+++ b/doc/changelog/10-standard-library/11909-fix-≡-level.rst
@@ -1,5 +1,7 @@
 - **Changed:**
   The level of :g:`≡` in ``Coq.Numbers.Cyclic.Int63.Int63`` is now 70,
-  no associativity, in line with :g:`=` (fixes `#11905
+  no associativity, in line with :g:`=`.  Note that this is a minor
+  incompatibility with developments that declare their own :g:`≡`
+  notation and import ``Int63`` (fixes `#11905
   <https://github.com/coq/coq/issues/11905>`_, `#11909
   <https://github.com/coq/coq/pull/11909>`_, by Jason Gross).

--- a/theories/Numbers/Cyclic/Int63/Int63.v
+++ b/theories/Numbers/Cyclic/Int63/Int63.v
@@ -690,7 +690,7 @@ Proof. now intros h; rewrite (to_Z_inj _ 0 h). Qed.
 Lemma tail00_spec x : φ  x = 0 -> φ (tail0 x) = φ digits.
 Proof. now intros h; rewrite (to_Z_inj _ 0 h). Qed.
 
-Infix "≡" := (eqm wB) (at level 80) : int63_scope.
+Infix "≡" := (eqm wB) (at level 70, no associativity) : int63_scope.
 
 Lemma eqm_mod x y : x mod wB ≡ y mod wB → x ≡ y.
 Proof.


### PR DESCRIPTION
**Kind:** bug fix

Fixes #11905

- Added / updated test-suite (seems not really worth it...)
- Corresponding documentation was added / updated (including any warning and error messages added / removed / modified). (no doc to update)
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details). (let's see how well the tools handle files with Unicode in their file names)  (Also, should I mention in the changelog that this is a minor incompatibility with developments that declare their own `≡` notation and import Int63?)
