### PR TITLE
Allow empty expressions in `coqpp` rules.

### DIFF
--- a/coqpp/coqpp_parse.mly
+++ b/coqpp/coqpp_parse.mly
@@ -59,6 +59,8 @@ let parse_user_entry s sep =
 
 let no_code = { code = ""; loc = { loc_start=Lexing.dummy_pos; loc_end=Lexing.dummy_pos} }
 
+let noop_code = { code = "()"; loc = { loc_start=Lexing.dummy_pos; loc_end=Lexing.dummy_pos} }
+
 %}
 
 %token <Coqpp_ast.code> CODE
@@ -385,6 +387,8 @@ rules:
 rule:
 | symbols_opt ARROW CODE
   { { gprod_symbs = $1; gprod_body = $3; } }
+| symbols
+  { { gprod_symbs = $1; gprod_body = noop_code; } }
 ;
 
 symbols_opt:


### PR DESCRIPTION
**Kind:** feature

`coqpp` is based on `camlp5`, but there is a distinction. Unlike `camlp5`, `coqpp` does not allow rules without associated expressions. That is, `meow: [ [ "meow" ] ];` seems to be legal as per `camlp5` docs, but `coqpp` gives parser error and requires me to write the more verbose `meow: [ [ "meow" -> { [ ] } ] ];` with an explicit expression.

It would seem a pointless change, but I will shortly present a fix for #4446 and other similar changes that would altogether be cleaner with this feature.

I tried my best, but I am new to Coq and Ocaml, so I hope someone with more familiarity with the code base would be available to help me bring this effort to fruition.