### PR TITLE
[proof] Split delayed and regular proof closing functions

### DIFF
--- a/plugins/funind/gen_principle.ml
+++ b/plugins/funind/gen_principle.ml
@@ -199,7 +199,7 @@ let build_functional_principle ?(opaque=Proof_global.Transparent) (evd:Evd.evar_
   (*    end; *)
 
   let open Proof_global in
-  let { entries } = Lemmas.pf_fold (close_proof ~opaque ~keep_body_ucst_separate:false (fun x -> x)) lemma in
+  let { entries } = Lemmas.pf_fold (close_proof ~opaque ~keep_body_ucst_separate:false) lemma in
   match entries with
   | [entry] ->
     entry, hook

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -1501,7 +1501,7 @@ end = struct (* {{{ *)
       let wall_clock2 = Unix.gettimeofday () in
       Aux_file.record_in_aux_at ?loc "proof_build_time"
         (Printf.sprintf "%.3f" (wall_clock2 -. wall_clock1));
-      let p = PG_compat.return_proof ~allow_partial:drop_pt () in
+      let p = if drop_pt then PG_compat.return_partial_proof () else PG_compat.return_proof () in
       if drop_pt then feedback ~id Complete;
       p)
 
@@ -1661,7 +1661,7 @@ end = struct (* {{{ *)
     try
       Reach.known_state ~doc:dummy_doc (* XXX should be document *) ~cache:false stop;
       if drop then
-        let _proof = PG_compat.return_proof ~allow_partial:true () in
+        let _proof = PG_compat.return_partial_proof () in
         `OK_ADMITTED
       else begin
       let opaque = Proof_global.Opaque in

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -1668,7 +1668,7 @@ end = struct (* {{{ *)
 
       (* The original terminator, a hook, has not been saved in the .vio*)
       let proof, _info =
-        PG_compat.close_proof ~opaque ~keep_body_ucst_separate:true (fun x -> x) in
+        PG_compat.close_proof ~opaque ~keep_body_ucst_separate:true in
 
       let info = Lemmas.Info.make () in
 
@@ -2518,9 +2518,11 @@ let known_state ~doc ?(redefine_qed=false) ~cache id =
                       | VtKeepOpaque -> Opaque | VtKeepDefined -> Transparent
                       | VtKeepAxiom -> assert false
                     in
-                      Some(PG_compat.close_proof ~opaque
-                                ~keep_body_ucst_separate:false
-                                (State.exn_on id ~valid:eop)) in
+                    try Some (PG_compat.close_proof ~opaque ~keep_body_ucst_separate:false)
+                    with exn ->
+                      let iexn = Exninfo.capture exn in
+                      Exninfo.iraise (State.exn_on id ~valid:eop iexn)
+                in
                 if keep <> VtKeep VtKeepAxiom then
                   reach view.next;
                 let wall_clock2 = Unix.gettimeofday () in

--- a/tactics/declare.ml
+++ b/tactics/declare.ml
@@ -187,14 +187,14 @@ let record_aux env s_ty s_bo =
 
 let default_univ_entry = Monomorphic_entry Univ.ContextSet.empty
 
-let definition_entry ?fix_exn ?(opaque=false) ?(inline=false) ?types
-    ?(univs=default_univ_entry) ?(eff=Evd.empty_side_effects) body =
-  { proof_entry_body = Future.from_val ?fix_exn ((body,Univ.ContextSet.empty), eff);
-    proof_entry_secctx = None;
+let definition_entry ?fix_exn ?(opaque=false) ?(inline=false) ?feedback_id ?section_vars ?types
+    ?(univs=default_univ_entry) ?(eff=Evd.empty_side_effects) ?(univc=Univ.ContextSet.empty) body =
+  { proof_entry_body = Future.from_val ?fix_exn ((body,univc), eff);
+    proof_entry_secctx = section_vars;
     proof_entry_type = types;
     proof_entry_universes = univs;
     proof_entry_opaque = opaque;
-    proof_entry_feedback = None;
+    proof_entry_feedback = feedback_id;
     proof_entry_inline_code = inline}
 
 let pure_definition_entry ?fix_exn ?(opaque=false) ?(inline=false) ?types

--- a/tactics/declare.ml
+++ b/tactics/declare.ml
@@ -188,8 +188,8 @@ let record_aux env s_ty s_bo =
 let default_univ_entry = Monomorphic_entry Univ.ContextSet.empty
 
 let definition_entry ?fix_exn ?(opaque=false) ?(inline=false) ?feedback_id ?section_vars ?types
-    ?(univs=default_univ_entry) ?(eff=Evd.empty_side_effects) ?(univc=Univ.ContextSet.empty) body =
-  { proof_entry_body = Future.from_val ?fix_exn ((body,univc), eff);
+    ?(univs=default_univ_entry) ?(eff=Evd.empty_side_effects) ?(univsbody=Univ.ContextSet.empty) body =
+  { proof_entry_body = Future.from_val ?fix_exn ((body,univsbody), eff);
     proof_entry_secctx = section_vars;
     proof_entry_type = types;
     proof_entry_universes = univs;

--- a/tactics/declare.mli
+++ b/tactics/declare.mli
@@ -59,9 +59,14 @@ val definition_entry
   : ?fix_exn:Future.fix_exn
   -> ?opaque:bool
   -> ?inline:bool
+  -> ?feedback_id:Stateid.t
+  -> ?section_vars:Id.Set.t
   -> ?types:types
   -> ?univs:Entries.universes_entry
   -> ?eff:Evd.side_effects
+  -> ?univc:Univ.ContextSet.t
+  (** Universe-constraints attached to the body-only, used in vio /
+     vio-delayed opaque constants *)
   -> constr
   -> Evd.side_effects proof_entry
 

--- a/tactics/declare.mli
+++ b/tactics/declare.mli
@@ -64,9 +64,9 @@ val definition_entry
   -> ?types:types
   -> ?univs:Entries.universes_entry
   -> ?eff:Evd.side_effects
-  -> ?univc:Univ.ContextSet.t
-  (** Universe-constraints attached to the body-only, used in vio /
-     vio-delayed opaque constants *)
+  -> ?univsbody:Univ.ContextSet.t
+  (** Universe-constraints attached to the body-only, used in
+     vio-delayed opaque constants and private poly universes *)
   -> constr
   -> Evd.side_effects proof_entry
 

--- a/tactics/pfedit.ml
+++ b/tactics/pfedit.ml
@@ -122,7 +122,7 @@ let build_constant_by_tactic ~name ?(opaque=Proof_global.Transparent) ~uctx ~sig
   let pf = Proof_global.start_proof ~name ~poly ~udecl:UState.default_univ_decl evd goals in
   let pf, status = by tac pf in
   let open Proof_global in
-  let { entries; uctx } = close_proof ~opaque ~keep_body_ucst_separate:false (fun x -> x) pf in
+  let { entries; uctx } = close_proof ~opaque ~keep_body_ucst_separate:false pf in
   match entries with
   | [entry] ->
     entry, status, uctx

--- a/tactics/proof_global.ml
+++ b/tactics/proof_global.ml
@@ -118,8 +118,7 @@ let set_used_variables ps l =
     Environ.fold_named_context aux env ~init:(ctx,ctx_set) in
   if not (Option.is_empty ps.section_vars) then
     CErrors.user_err Pp.(str "Used section variables can be declared only once");
-  (* EJGA: This is always empty thus we should modify the type *)
-  (ctx, []), { ps with section_vars = Some (Context.Named.to_vars ctx) }
+  ctx, { ps with section_vars = Some (Context.Named.to_vars ctx) }
 
 let get_open_goals ps =
   let Proof.{ goals; stack; shelf } = Proof.data ps.proof in

--- a/tactics/proof_global.ml
+++ b/tactics/proof_global.ml
@@ -221,7 +221,7 @@ let close_proof ~opaque ~keep_body_ucst_separate ps =
         let utyp = UState.check_univ_decl ~poly ctx udecl in
         utyp, Univ.ContextSet.empty
     in
-    Declare.definition_entry ~opaque ?section_vars ~univs:utyp ~univc:ubody ~types:typ ~eff body
+    Declare.definition_entry ~opaque ?section_vars ~univs:utyp ~univsbody:ubody ~types:typ ~eff body
   in
   let entries = CList.map2 make_entry elist (Proofview.initial_goals entry) in
   { name; entries; uctx }

--- a/tactics/proof_global.ml
+++ b/tactics/proof_global.ml
@@ -226,8 +226,7 @@ let close_proof ~opaque ~keep_body_ucst_separate ps =
   let entries = CList.map2 make_entry elist (Proofview.initial_goals entry) in
   { name; entries; uctx }
 
-let close_proof_delayed ~opaque ~keep_body_ucst_separate ?feedback_id
-                (fpl : closed_proof_output Future.computation) ps =
+let close_proof_delayed ~opaque ?feedback_id (fpl : closed_proof_output Future.computation) ps =
   let { section_vars; proof; udecl; initial_euctx } = ps in
   let { Proof.name; poly; entry; sigma } = Proof.data proof in
 
@@ -278,7 +277,7 @@ let return_partial_proof { proof } =
  proofs, Evd.evar_universe_context evd
 
 let close_future_proof ~opaque ~feedback_id ps proof =
-  close_proof_delayed ~opaque ~keep_body_ucst_separate:true ~feedback_id proof ps
+  close_proof_delayed ~opaque ~feedback_id proof ps
 
 let update_global_env =
   map_proof (fun p ->

--- a/tactics/proof_global.mli
+++ b/tactics/proof_global.mli
@@ -75,9 +75,12 @@ val close_proof : opaque:opacity_flag -> keep_body_ucst_separate:bool -> t -> pr
 
 type closed_proof_output
 
-(* If allow_partial is set (default no) then an incomplete proof
- * is allowed (no error), and a warn is given if the proof is complete. *)
-val return_proof : ?allow_partial:bool -> t -> closed_proof_output
+(** Requires a complete proof. *)
+val return_proof : t -> closed_proof_output
+
+(** An incomplete proof is allowed (no error), and a warn is given if
+   the proof is complete. *)
+val return_partial_proof : t -> closed_proof_output
 val close_future_proof : opaque:opacity_flag -> feedback_id:Stateid.t -> t ->
   closed_proof_output Future.computation -> proof_object
 

--- a/tactics/proof_global.mli
+++ b/tactics/proof_global.mli
@@ -67,7 +67,7 @@ val update_global_env : t -> t
 
 (* Takes a function to add to the exceptions data relative to the
    state in which the proof was built *)
-val close_proof : opaque:opacity_flag -> keep_body_ucst_separate:bool -> Future.fix_exn -> t -> proof_object
+val close_proof : opaque:opacity_flag -> keep_body_ucst_separate:bool -> t -> proof_object
 
 (* Intermediate step necessary to delegate the future.
  * Both access the current proof state. The former is supposed to be

--- a/tactics/proof_global.mli
+++ b/tactics/proof_global.mli
@@ -81,8 +81,7 @@ val return_proof : t -> closed_proof_output
 (** An incomplete proof is allowed (no error), and a warn is given if
    the proof is complete. *)
 val return_partial_proof : t -> closed_proof_output
-val close_future_proof : opaque:opacity_flag -> feedback_id:Stateid.t -> t ->
-  closed_proof_output Future.computation -> proof_object
+val close_future_proof : feedback_id:Stateid.t -> t -> closed_proof_output Future.computation -> proof_object
 
 val get_open_goals : t -> int
 

--- a/tactics/proof_global.mli
+++ b/tactics/proof_global.mli
@@ -94,7 +94,6 @@ val map_fold_proof_endline : (unit Proofview.tactic -> Proof.t -> Proof.t * 'a) 
 val set_endline_tactic : Genarg.glob_generic_argument -> t -> t
 
 (** Sets the section variables assumed by the proof, returns its closure
- * (w.r.t. type dependencies and let-ins covered by it) + a list of
- * ids to be cleared *)
+ * (w.r.t. type dependencies and let-ins covered by it) *)
 val set_used_variables : t ->
-  Names.Id.t list -> (Constr.named_context * Names.lident list) * t
+  Names.Id.t list -> Constr.named_context * t

--- a/vernac/lemmas.ml
+++ b/vernac/lemmas.ml
@@ -403,7 +403,7 @@ let process_idopt_for_save ~idopt info =
 
 let save_lemma_proved ~lemma ~opaque ~idopt =
   (* Env and sigma are just used for error printing in save_remaining_recthms *)
-  let proof_obj = Proof_global.close_proof ~opaque ~keep_body_ucst_separate:false (fun x -> x) lemma.proof in
+  let proof_obj = Proof_global.close_proof ~opaque ~keep_body_ucst_separate:false lemma.proof in
   let proof_info = process_idopt_for_save ~idopt lemma.info in
   finalize_proof proof_obj proof_info
 

--- a/vernac/vernacstate.ml
+++ b/vernac/vernacstate.ml
@@ -164,7 +164,8 @@ module Proof_global = struct
   type closed_proof = Proof_global.proof_object * Lemmas.Info.t
 
 
-  let return_proof ?allow_partial () = cc (return_proof ?allow_partial)
+  let return_proof () = cc return_proof
+  let return_partial_proof () = cc return_partial_proof
 
   let close_future_proof ~opaque ~feedback_id pf =
     cc_lemma (fun pt -> pf_fold (fun st -> close_future_proof ~opaque ~feedback_id st pf) pt,

--- a/vernac/vernacstate.ml
+++ b/vernac/vernacstate.ml
@@ -170,8 +170,8 @@ module Proof_global = struct
     cc_lemma (fun pt -> pf_fold (fun st -> close_future_proof ~opaque ~feedback_id st pf) pt,
                         Internal.get_info pt)
 
-  let close_proof ~opaque ~keep_body_ucst_separate f =
-    cc_lemma (fun pt -> pf_fold ((close_proof ~opaque ~keep_body_ucst_separate f)) pt,
+  let close_proof ~opaque ~keep_body_ucst_separate =
+    cc_lemma (fun pt -> pf_fold ((close_proof ~opaque ~keep_body_ucst_separate)) pt,
                         Internal.get_info pt)
 
   let discard_all () = s_lemmas := None

--- a/vernac/vernacstate.ml
+++ b/vernac/vernacstate.ml
@@ -167,8 +167,8 @@ module Proof_global = struct
   let return_proof () = cc return_proof
   let return_partial_proof () = cc return_partial_proof
 
-  let close_future_proof ~opaque ~feedback_id pf =
-    cc_lemma (fun pt -> pf_fold (fun st -> close_future_proof ~opaque ~feedback_id st pf) pt,
+  let close_future_proof ~feedback_id pf =
+    cc_lemma (fun pt -> pf_fold (fun st -> close_future_proof ~feedback_id st pf) pt,
                         Internal.get_info pt)
 
   let close_proof ~opaque ~keep_body_ucst_separate =

--- a/vernac/vernacstate.mli
+++ b/vernac/vernacstate.mli
@@ -74,7 +74,7 @@ module Proof_global : sig
     feedback_id:Stateid.t ->
     Proof_global.closed_proof_output Future.computation -> closed_proof
 
-  val close_proof : opaque:Proof_global.opacity_flag -> keep_body_ucst_separate:bool -> Future.fix_exn -> closed_proof
+  val close_proof : opaque:Proof_global.opacity_flag -> keep_body_ucst_separate:bool -> closed_proof
 
   val discard_all : unit -> unit
   val update_global_env : unit -> unit

--- a/vernac/vernacstate.mli
+++ b/vernac/vernacstate.mli
@@ -65,7 +65,8 @@ module Proof_global : sig
   val with_current_proof :
       (unit Proofview.tactic -> Proof.t -> Proof.t * 'a) -> 'a
 
-  val return_proof : ?allow_partial:bool -> unit -> Proof_global.closed_proof_output
+  val return_proof : unit -> Proof_global.closed_proof_output
+  val return_partial_proof : unit -> Proof_global.closed_proof_output
 
   type closed_proof = Proof_global.proof_object * Lemmas.Info.t
 

--- a/vernac/vernacstate.mli
+++ b/vernac/vernacstate.mli
@@ -71,7 +71,6 @@ module Proof_global : sig
   type closed_proof = Proof_global.proof_object * Lemmas.Info.t
 
   val close_future_proof :
-    opaque:Proof_global.opacity_flag ->
     feedback_id:Stateid.t ->
     Proof_global.closed_proof_output Future.computation -> closed_proof
 


### PR DESCRIPTION
We make the types of the delayed / non-delayed declaration path
different, as the latter is just creating futures that are forced
right away.

TTBOMK the new code should behave identically w.r.t. old one, modulo
the equation `Future.(force (from_val x)) = x`.

There are some questions as what the code is doing, but in this PR
I've opted to keep the code 100% faithful to the original one, unless
I did a mistake.