### PR TITLE
[declare] Do `to_constr` and `univs_of_constr` in one pass.

### DIFF
--- a/engine/eConstr.mli
+++ b/engine/eConstr.mli
@@ -77,8 +77,13 @@ val to_constr : ?abort_on_undefined_evars:bool -> Evd.evar_map -> t -> Constr.t
     For getting the evar-normal form of a term with evars see
    {!Evarutil.nf_evar}. *)
 
+val to_constr_and_univs : ?abort_on_undefined_evars:bool -> Evd.evar_map -> t -> Univ.LSet.t * Constr.t
+
 val to_constr_opt : Evd.evar_map -> t -> Constr.t option
 (** Same as [to_constr], but returns [None] if some unresolved evars remain *)
+
+val to_constr_opt_and_univs : Evd.evar_map -> t -> (Univ.LSet.t * Constr.t) option
+(** Same as [to_constr_opt], but returns used universes too *)
 
 type kind_of_type =
   | SortType   of ESorts.t

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -38,8 +38,7 @@ let finalize ?abort_on_undefined_evars sigma f =
   let sigma = minimize_universes sigma in
   let uvars = ref Univ.LSet.empty in
   let v = f (fun c ->
-      let varsc = EConstr.universes_of_constr sigma c in
-      let c = EConstr.to_constr ?abort_on_undefined_evars sigma c in
+      let varsc, c = EConstr.to_constr_and_univs ?abort_on_undefined_evars sigma c in
       uvars := Univ.LSet.union !uvars varsc;
       c)
   in

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -747,7 +747,9 @@ module MiniEConstr : sig
   val of_constr_array : Constr.t array -> t array
 
   val to_constr : ?abort_on_undefined_evars:bool -> evar_map -> t -> Constr.t
+  val to_constr_and_univs : ?abort_on_undefined_evars:bool -> evar_map -> t -> Univ.LSet.t * Constr.t
   val to_constr_opt : evar_map -> t -> Constr.t option
+  val to_constr_opt_and_univs : evar_map -> t -> (Univ.LSet.t * Constr.t) option
 
   val unsafe_to_constr : t -> Constr.t
   val unsafe_to_constr_array : t array -> Constr.t array

--- a/engine/univSubst.mli
+++ b/engine/univSubst.mli
@@ -48,6 +48,10 @@ val normalize_opt_subst : universe_opt_subst -> universe_opt_subst
 val nf_evars_and_universes_opt_subst : (existential -> constr option) ->
   universe_opt_subst -> constr -> constr
 
+val nf_evars_and_universes_opt_subst_and_univs : (existential -> constr option) ->
+  (Evar.t -> constr) ->
+  universe_opt_subst -> constr -> LSet.t * constr
+
 (** Pretty-printing *)
 
 val pr_universe_opt_subst : universe_opt_subst -> Pp.t

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -1582,9 +1582,9 @@ let prepare_proof ~unsafe_typ { proof } =
   let eff = Evd.eval_side_effects evd in
   let evd = Evd.minimize_universes evd in
   let to_constr_body c =
-    match EConstr.to_constr_opt evd c with
+    match EConstr.to_constr_opt_and_univs evd c with
     | Some p ->
-      Vars.universes_of_constr p, p
+      p
     | None ->
       CErrors.user_err Pp.(str "Some unresolved existential variables remain")
   in


### PR DESCRIPTION
This makes sense as to avoid traversing large terms twice on proof
save.

Efficiency gains are pending bench https://ci.inria.fr/coq/job/benchmark-part-of-the-branch/897