### PR TITLE
Fix typo in new doc on `Program Mode`

### DIFF
--- a/doc/sphinx/addendum/program.rst
+++ b/doc/sphinx/addendum/program.rst
@@ -98,10 +98,10 @@ coercions.
 .. flag:: Program Mode
 
    Enables the program mode, in which 1) typechecking allows subset coercions and
-   2) the elaboration of pattern matching of :cmd:`Program Fixpoint` and
-   :cmd:`Program Definition` act
-   like Program Fixpoint/Definition, generating obligations if there are
-   unresolved holes after typechecking.
+   2) the elaboration of pattern matching of :cmd:`Fixpoint` and
+   :cmd:`Definition` act respectively like :cmd:`Program Fixpoint` and
+   :cmd:`Program Definition`, generating obligations if there are unresolved
+   holes after typechecking.
 
 .. _syntactic_control:
 


### PR DESCRIPTION
`master` has a more complete fix, but it is part of commit
2c785aaab9b54b3d3406e7e021de635247f6535c in #11665. Meanwhile, the current text
is too inaccurate.

**Kind:** documentation