### PR TITLE
Document change of behavior of Fail in 8.11.

### DIFF
--- a/doc/sphinx/changes.rst
+++ b/doc/sphinx/changes.rst
@@ -383,6 +383,10 @@ Changes in 8.11+beta1
   <https://github.com/coq/coq/issues/3890>`_ and `#4638
   <https://github.com/coq/coq/issues/4638>`_
   by Maxime Dénès, review by Gaëtan Gilbert).
+- **Changed:**
+  :cmd:`Fail` does not catch critical errors (including "stack overflow")
+  anymore (`#10173 <https://github.com/coq/coq/pull/10173>`_,
+  by Gaëtan Gilbert).
 - **Removed:**
   Undocumented :n:`Instance : !@type` syntax
   (`#10185 <https://github.com/coq/coq/pull/10185>`_, by Gaëtan Gilbert).

--- a/doc/sphinx/proof-engine/vernacular-commands.rst
+++ b/doc/sphinx/proof-engine/vernacular-commands.rst
@@ -929,16 +929,17 @@ Quitting and debugging
 
 .. cmd:: Fail @command
 
-   For debugging scripts, sometimes it is desirable to know
-   whether a command or a tactic fails. If the given :n:`@command`
-   fails, the ``Fail`` statement succeeds, without changing the proof
-   state, and in interactive mode, the system
-   prints a message confirming the failure.
-   If the given :n:`@command` succeeds, the statement is an error, and
-   it prints a message indicating that the failure did not occur.
+   For debugging scripts, sometimes it is desirable to know whether a
+   command or a tactic fails. If the given :n:`@command` fails, then
+   :n:`Fail @command` succeeds (excepts in the case of
+   critical errors, like a "stack overflow"), without changing the
+   proof state, and in interactive mode, the system prints a message
+   confirming the failure.
 
    .. exn:: The command has not failed!
-      :undocumented:
+
+      If the given :n:`@command` succeeds, then :n:`Fail @command`
+      fails with this error message.
 
 
 .. _controlling-display:


### PR DESCRIPTION
**Kind:** documentation

Fixes / closes #10793.

Since the change of behavior of `Fail` wrt "stack overflow" has been reported twice already, this seems like an important change, that shouldn't have gone in without documentation and a changelog entry. This PR fixes this.