### PR TITLE
Use the kernel machine in whd_betaiota_deltazeta_for_iota_state

### DIFF
--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -678,6 +678,8 @@ let rec zip m stk =
 
 let fapp_stack (m,stk) = zip m stk
 
+let term_of_process c stk = term_of_fconstr (zip c stk)
+
 (*********************************************************************)
 
 (* The assertions in the functions below are granted because they are

--- a/kernel/cClosure.mli
+++ b/kernel/cClosure.mli
@@ -227,6 +227,10 @@ val kni: clos_infos -> clos_tab -> fconstr -> stack -> fconstr * stack
 val knr: clos_infos -> clos_tab -> fconstr -> stack -> fconstr * stack
 val kl : clos_infos -> clos_tab -> fconstr -> constr
 
+val zip : fconstr -> stack -> fconstr
+
+val term_of_process : fconstr -> stack -> constr
+
 val to_constr : lift -> fconstr -> constr
 
 (** End of cbn debug section i*)

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -1746,29 +1746,43 @@ let is_sort env sigma t =
 let whd_betaiota_deltazeta_for_iota_state ts env sigma s =
   let refold = false in
   let tactic_mode = false in
-  let all = CClosure.RedFlags.red_add_transparent CClosure.all ts in
+  let all' = CClosure.RedFlags.red_add_transparent CClosure.all ts in
   (* Unset the sharing flag to get a call-by-name reduction. This matters for
      the shape of the generated term. *)
   let env' = Environ.set_typing_flags { (Environ.typing_flags env) with Declarations.share_reduction = false } env in
-  let whd c =
-    let r = clos_whd_flags all env' sigma (Stack.zip sigma c) in
-    let (r, args) = Termops.decompose_app_vect sigma r in
-    r, Stack.append_app args []
+  let whd_opt c =
+    let open CClosure in
+    let evars ev = safe_evar_value sigma ev in
+    let infos = create_clos_infos ~evars all' env' in
+    let tab = create_tab () in
+    let c = inject (EConstr.Unsafe.to_constr (Stack.zip sigma c)) in
+    let (c, stk) = whd_stack infos tab c [] in
+    match fterm_of c with
+    | (FConstruct _ | FCoFix _) ->
+      (* Non-neutral normal, can trigger reduction below *)
+      let c = EConstr.of_constr (term_of_process c stk) in
+      Some (decompose_app_vect sigma c)
+    | _ -> None
   in
   let rec whrec s =
     let (t, stack as s), _ = whd_state_gen ~refold ~tactic_mode CClosure.betaiota env sigma s in
     match Stack.strip_app stack with
       |args, (Stack.Case _ :: _ as stack') ->
-        let (t_o, stack_o) = whd (t, args) in
-        if reducible_mind_case sigma t_o then whrec (t_o, stack_o@stack') else s
+        begin match whd_opt (t, args) with
+        | Some (t_o, args) when reducible_mind_case sigma t_o -> whrec (t_o, Stack.append_app args stack')
+        | (Some _ | None) -> s
+        end
       |args, (Stack.Fix _ :: _ as stack') ->
-        let (t_o, stack_o) = whd (t, args) in
-        if isConstruct sigma t_o then whrec (t_o, stack_o@stack') else s
+        begin match whd_opt (t, args) with
+        | Some (t_o, args) when isConstruct sigma t_o -> whrec (t_o, Stack.append_app args stack')
+        | (Some _ | None) -> s
+        end
       |args, (Stack.Proj (p,_) :: stack'') ->
-        let (t_o, stack_o) = whd (t, args) in
-        if isConstruct sigma t_o then
-          whrec (Stack.nth stack_o (Projection.npars p + Projection.arg p), stack'')
-        else s
+        begin match whd_opt (t, args) with
+        | Some (t_o, args) when isConstruct sigma t_o ->
+          whrec (args.(Projection.npars p + Projection.arg p), stack'')
+        | (Some _ | None) -> s
+        end
       |_, ((Stack.App _|Stack.Cst _|Stack.Primitive _) :: _|[]) -> s
   in
   whrec s

--- a/test-suite/bugs/closed/bug_4544.v
+++ b/test-suite/bugs/closed/bug_4544.v
@@ -1003,7 +1003,8 @@ Proof.
           = loops_functor (group_loops_functor
                                  (pmap_compose psi phi)) g).
   rewrite <- p.
-  Fail Timeout 1 Time rewrite !loops_functor_group.
+  Timeout 1 Time rewrite !loops_functor_group.
+  Undo.
   (* 0.004 s in 8.5rc1, 8.677 s in 8.5 *)
   Timeout 1 do 3 rewrite loops_functor_group.
 Abort.


### PR DESCRIPTION
There is no point in using the exaggerately inefficient Reductionops machine. We need to be call-by-name to preserve the shape of the reduced terms, as call-by-need would introduce sharing and thus at-distance effects in term refolding. Yet, the Reductionops machine is worse than that, since it performs substitutions eagerly, leading to a catastrophical performance profile.

Instead, we use the kernel reduction in by-name mode to replace the Reductionops machine in whd_betaiota_deltazeta_for_iota_state with all flags on. Since the kernel is using explicit substitutions, this is algorithmically more efficient. Apart from minor differences, this should produce the same normal form.

As showed by the benchmarks, this is a critical change for the odd-order proofs. Ideally, we should use delayed substitutions in the Reductionops machine as well for great profit, but due to code entanglement this is a much less self-contained change.
