### PR TITLE
[stdlib] update sigma-type notations

### DIFF
--- a/doc/changelog/10-standard-library/11957-signotations.rst
+++ b/doc/changelog/10-standard-library/11957-signotations.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  notations for sigma types: ``{ x & P & Q }``, ``{ ' pat & P }``, ``{ ' pat & P & Q }``
+  (`#11957 <https://github.com/coq/coq/pull/11957>`_,
+  by Olivier Laurent).

--- a/test-suite/output/NotationsSigma.out
+++ b/test-suite/output/NotationsSigma.out
@@ -1,0 +1,40 @@
+{0 = 0} + {0 < 1}
+     : Set
+(0 = 0) + {0 < 1}
+     : Set
+{x : nat | x = 1}
+     : Set
+{x : nat | x = 1 & 0 < x}
+     : Set
+{x : nat | x = 1}
+     : Set
+{x : nat | x = 1 & 0 < x}
+     : Set
+{x : nat & x = 1}
+     : Set
+{x : nat & x = 1 & 0 < x}
+     : Set
+{x : nat & x = 1}
+     : Set
+{x : nat & x = 1 & 0 < x}
+     : Set
+{'(x, _) : nat * ?T | x = 1}
+     : Type
+where
+?T : [pat : nat * ?T |- Type] (pat cannot be used)
+{'(x, y) : nat * nat | x = 1 & y = 0}
+     : Set
+{'(x, _) : nat * nat | x = 1}
+     : Set
+{'(x, y) : nat * nat | x = 1 & y = 0}
+     : Set
+{'(x, _) : nat * ?T & x = 1}
+     : Type
+where
+?T : [pat : nat * ?T |- Type] (pat cannot be used)
+{'(x, y) : nat * nat & x = 1 & y = 0}
+     : Type
+{'(x, _) : nat * nat & x = 1}
+     : Type
+{'(x, y) : nat * nat & x = 1 & y = 0}
+     : Type

--- a/test-suite/output/NotationsSigma.v
+++ b/test-suite/output/NotationsSigma.v
@@ -1,0 +1,22 @@
+(* Check notations for sigma types *)
+
+Check { 0 = 0 } + { 0 < 1 }.
+Check (0 = 0) + { 0 < 1 }.
+
+Check { x | x = 1 }.
+Check { x | x = 1 & 0 < x }.
+Check { x : nat | x = 1 }.
+Check { x : nat | x = 1 & 0 < x }.
+Check { x & x = 1 }.
+Check { x & x = 1 & 0 < x }.
+Check { x : nat & x = 1 }.
+Check { x : nat & x = 1 & 0 < x }.
+
+Check {'(x,y) | x = 1 }.
+Check {'(x,y) | x = 1 & y = 0 }.
+Check {'(x,y) : nat * nat | x = 1 }.
+Check {'(x,y) : nat * nat | x = 1 & y = 0 }.
+Check {'(x,y) & x = 1 }.
+Check {'(x,y) & x = 1 & y = 0 }.
+Check {'(x,y) : nat * nat & x = 1 }.
+Check {'(x,y) : nat * nat & x = 1 & y = 0 }.

--- a/theories/Init/Notations.v
+++ b/theories/Init/Notations.v
@@ -68,33 +68,40 @@ Reserved Notation "{ x }" (at level 0, x at level 99).
 
 (** Notations for sigma-types or subsets *)
 
-Reserved Notation "{ A }  + { B }" (at level 50, left associativity).
-Reserved Notation "A + { B }" (at level 50, left associativity).
+Reserved Notation "{ A }  +  { B }" (at level 50, left associativity).
+Reserved Notation "A  +  { B }" (at level 50, left associativity).
 
-Reserved Notation "{ x  |  P }" (at level 0, x at level 99).
-Reserved Notation "{ x  |  P  & Q }" (at level 0, x at level 99).
+Reserved Notation "{ x | P }" (at level 0, x at level 99).
+Reserved Notation "{ x | P & Q }" (at level 0, x at level 99).
 
-Reserved Notation "{ x : A  |  P }" (at level 0, x at level 99).
-Reserved Notation "{ x : A  |  P  & Q }" (at level 0, x at level 99).
+Reserved Notation "{ x : A | P }" (at level 0, x at level 99).
+Reserved Notation "{ x : A | P & Q }" (at level 0, x at level 99).
 
-Reserved Notation "{ x  &  P }" (at level 0, x at level 99).
-Reserved Notation "{ x : A  & P }" (at level 0, x at level 99).
-Reserved Notation "{ x : A  & P  & Q }" (at level 0, x at level 99).
+Reserved Notation "{ x & P }" (at level 0, x at level 99).
+Reserved Notation "{ x & P & Q }" (at level 0, x at level 99).
+
+Reserved Notation "{ x : A & P }" (at level 0, x at level 99).
+Reserved Notation "{ x : A & P & Q }" (at level 0, x at level 99).
 
 Reserved Notation "{ ' pat | P }"
-  (at level 0, pat strict pattern, format "{ ' pat  |  P  }").
+  (at level 0, pat strict pattern, format "{ ' pat  |  P }").
 Reserved Notation "{ ' pat | P & Q }"
-  (at level 0, pat strict pattern, format "{ ' pat  |  P  & Q }").
+  (at level 0, pat strict pattern, format "{ ' pat  |  P  &  Q }").
 
 Reserved Notation "{ ' pat : A | P }"
   (at level 0, pat strict pattern, format "{ ' pat  :  A  |  P }").
 Reserved Notation "{ ' pat : A | P & Q }"
-  (at level 0, pat strict pattern, format "{ ' pat  :  A  |  P  & Q }").
+  (at level 0, pat strict pattern, format "{ ' pat  :  A  |  P  &  Q }").
+
+Reserved Notation "{ ' pat & P }"
+  (at level 0, pat strict pattern, format "{ ' pat  &  P }").
+Reserved Notation "{ ' pat & P & Q }"
+  (at level 0, pat strict pattern, format "{ ' pat  &  P  &  Q }").
 
 Reserved Notation "{ ' pat : A & P }"
-  (at level 0, pat strict pattern, format "{ ' pat  :  A  & P }").
+  (at level 0, pat strict pattern, format "{ ' pat  :  A  &  P }").
 Reserved Notation "{ ' pat : A & P & Q }"
-  (at level 0, pat strict pattern, format "{ ' pat  :  A  & P  & Q }").
+  (at level 0, pat strict pattern, format "{ ' pat  :  A  &  P  &  Q }").
 
 (** Support for Gonthier-Ssreflect's "if c is pat then u else v" *)
 

--- a/theories/Init/Specif.v
+++ b/theories/Init/Specif.v
@@ -58,23 +58,26 @@ Arguments sig2 (A P Q)%type.
 Arguments sigT (A P)%type.
 Arguments sigT2 (A P Q)%type.
 
-Notation "{ x  |  P }" := (sig (fun x => P)) : type_scope.
-Notation "{ x  |  P  & Q }" := (sig2 (fun x => P) (fun x => Q)) : type_scope.
-Notation "{ x : A  |  P }" := (sig (A:=A) (fun x => P)) : type_scope.
-Notation "{ x : A  |  P  & Q }" := (sig2 (A:=A) (fun x => P) (fun x => Q)) :
+Notation "{ x | P }" := (sig (fun x => P)) : type_scope.
+Notation "{ x | P & Q }" := (sig2 (fun x => P) (fun x => Q)) : type_scope.
+Notation "{ x : A | P }" := (sig (A:=A) (fun x => P)) : type_scope.
+Notation "{ x : A | P & Q }" := (sig2 (A:=A) (fun x => P) (fun x => Q)) :
   type_scope.
-Notation "{ x  &  P }" := (sigT (fun x => P)) : type_scope.
-Notation "{ x : A  & P }" := (sigT (A:=A) (fun x => P)) : type_scope.
-Notation "{ x : A  & P  & Q }" := (sigT2 (A:=A) (fun x => P) (fun x => Q)) :
+Notation "{ x & P }" := (sigT (fun x => P)) : type_scope.
+Notation "{ x & P & Q }" := (sigT2 (fun x => P) (fun x => Q)) : type_scope.
+Notation "{ x : A & P }" := (sigT (A:=A) (fun x => P)) : type_scope.
+Notation "{ x : A & P & Q }" := (sigT2 (A:=A) (fun x => P) (fun x => Q)) :
   type_scope.
 
-Notation "{ ' pat  |  P }" := (sig (fun pat => P)) : type_scope.
-Notation "{ ' pat  |  P  & Q }" := (sig2 (fun pat => P) (fun pat => Q)) : type_scope.
-Notation "{ ' pat : A  |  P }" := (sig (A:=A) (fun pat => P)) : type_scope.
-Notation "{ ' pat : A  |  P  & Q }" := (sig2 (A:=A) (fun pat => P) (fun pat => Q)) :
+Notation "{ ' pat | P }" := (sig (fun pat => P)) : type_scope.
+Notation "{ ' pat | P & Q }" := (sig2 (fun pat => P) (fun pat => Q)) : type_scope.
+Notation "{ ' pat : A | P }" := (sig (A:=A) (fun pat => P)) : type_scope.
+Notation "{ ' pat : A | P & Q }" := (sig2 (A:=A) (fun pat => P) (fun pat => Q)) :
   type_scope.
-Notation "{ ' pat : A  & P }" := (sigT (A:=A) (fun pat => P)) : type_scope.
-Notation "{ ' pat : A  & P  & Q }" := (sigT2 (A:=A) (fun pat => P) (fun pat => Q)) :
+Notation "{ ' pat & P }" := (sigT (fun pat => P)) : type_scope.
+Notation "{ ' pat & P & Q }" := (sigT2 (fun pat => P) (fun pat => Q)) : type_scope.
+Notation "{ ' pat : A & P }" := (sigT (A:=A) (fun pat => P)) : type_scope.
+Notation "{ ' pat : A & P & Q }" := (sigT2 (A:=A) (fun pat => P) (fun pat => Q)) :
   type_scope.
 
 Add Printing Let sig.


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

Some spaces were missing in sigma-type notations.
Some missing notations are also added.
Summary:
```
Check { 0 = 0 } + { 0 < 1 }.
Check (0 = 0) + { 0 < 1 }.

Check { x | x = 1 }.
Check { x | x = 1 & 0 < x }.
Check { x : nat | x = 1 }.
Check { x : nat | x = 1 & 0 < x }.
Check { x & x = 1 }.
Check { x & x = 1 & 0 < x }.                 (* new *)
Check { x : nat & x = 1 }.
Check { x : nat & x = 1 & 0 < x }.

Check {'(x,y) | x = 1 }.
Check {'(x,y) | x = 1 & y = 0 }.             (* add space after & *)
Check {'(x,y) : nat * nat | x = 1 }.
Check {'(x,y) : nat * nat | x = 1 & y = 0 }. (* add space after & *)
Check {'(x,y) & x = 1 }.                     (* new *)
Check {'(x,y) & x = 1 & y = 0 }.             (* new *)
Check {'(x,y) : nat * nat & x = 1 }.         (* add space after & *)
Check {'(x,y) : nat * nat & x = 1 & y = 0 }. (* add space after both & *)
```

<!-- Keep what applies -->
**Kind:** feature.

<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [x] Added / updated test-suite
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
