### PR TITLE
Add -no-update command line option to doc_grammar for Dune

### DIFF
--- a/Makefile.doc
+++ b/Makefile.doc
@@ -246,16 +246,16 @@ $(DOC_GRAM): $(DOC_GRAMCMO) coqpp/coqpp_parser.mli coqpp/coqpp_parser.ml doc/too
 # user-contrib/*/*.mlg omitted for now (e.g. ltac2)
 PLUGIN_MLGS := $(wildcard plugins/*/*.mlg)
 OMITTED_PLUGIN_MLGS := plugins/ssr/ssrparser.mlg plugins/ssr/ssrvernac.mlg plugins/ssrmatching/g_ssrmatching.mlg
-DOC_MLGS := */*.mlg $(sort $(filter-out $(OMITTED_PLUGIN_MLGS), $(PLUGIN_MLGS)))
-DOC_EDIT_MLGS := doc/tools/docgram/*.edit_mlg
-DOC_RSTS := doc/sphinx/*/*.rst
+DOC_MLGS := $(wildcard */*.mlg) $(sort $(filter-out $(OMITTED_PLUGIN_MLGS), $(PLUGIN_MLGS)))
+DOC_EDIT_MLGS := $(wildcard doc/tools/docgram/*.edit_mlg)
+DOC_RSTS := $(wildcard doc/sphinx/*/*.rst)
 
 doc/tools/docgram/fullGrammar: $(DOC_GRAM) $(DOC_MLGS)
 	$(SHOW)'DOC_GRAM'
 	$(HIDE)$(DOC_GRAM) -short -no-warn $(DOC_MLGS)
 
 #todo: add a dependency of sphinx on updated_rsts when we're ready
-doc/tools/docgram/orderedGrammar doc/tools/docgram/updated_rsts: $(DOC_GRAM) $(DOC_EDIT_MLGS)
+doc/tools/docgram/orderedGrammar doc/tools/docgram/updated_rsts: doc/tools/docgram/fullGrammar $(DOC_GRAM) $(DOC_EDIT_MLGS)
 	$(SHOW)'DOC_GRAM_RSTS'
 	$(HIDE)$(DOC_GRAM) -check-cmds $(DOC_MLGS) $(DOC_RSTS)
 

--- a/doc/tools/docgram/README.md
+++ b/doc/tools/docgram/README.md
@@ -110,6 +110,9 @@ Other command line arguments:
 
 * `-no-warn` suppresses printing of some warning messages
 
+* `-no-update` puts updates to `fullGrammar` and `orderedGrammar` into new files named
+  `*.new`, leaving the originals unmodified.  For use in Dune.
+
 * `-short` limits processing to updating/verifying only the `fullGrammar` file
 
 * `-verbose` prints more messages about the grammar


### PR DESCRIPTION
If specified, updates to `fullGrammar` and `orderedGrammar` are written to `*.new` and the originals are not changed.

Note: removing the line with `(* always update rsts in place for now *)` will give the same behavior for the rst files.

Also fixed some makefile glitches

See https://github.com/coq/coq/pull/11938#issuecomment-605635008