### PR TITLE
Docgram use new no update option

### DIFF
--- a/doc/tools/docgram/dune
+++ b/doc/tools/docgram/dune
@@ -43,9 +43,6 @@
   orderedGrammar)
  (action
   (progn
-   (bash "for f in fullGrammar orderedGrammar; do cp ${f} ${f}.old; done")
-   (chdir %{project_root} (run doc_grammar -check-cmds %{input}))
-   (bash "for f in fullGrammar orderedGrammar; do cp ${f} ${f}.new; done")
-   (bash "for f in fullGrammar orderedGrammar; do cp ${f}.old ${f}; done")
+   (chdir %{project_root} (run doc_grammar -check-cmds -no-update %{input}))
    (diff? fullGrammar fullGrammar.new)
    (diff? orderedGrammar orderedGrammar.new))))


### PR DESCRIPTION
This draft PR demonstrates the simplification to the Dune build rules resulting from the new `-no-update` option added to `doc_grammar` in #11958.