### PR TITLE
Partial revert of #11817.

### DIFF
--- a/ide/wg_Completion.ml
+++ b/ide/wg_Completion.ml
@@ -8,7 +8,17 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-module Proposals = CString.Set
+module StringOrd =
+struct
+  type t = string
+  let compare s1 s2 =
+    (* we use first size, then usual comparison *)
+    let d = String.length s1 - String.length s2 in
+    if d <> 0 then d
+    else compare s1 s2
+end
+
+module Proposals = Set.Make(StringOrd)
 
 (** Retrieve completion proposals in the buffer *)
 let get_syntactic_completion (buffer : GText.buffer) pattern accu =


### PR DESCRIPTION
The completion proposals need to be ordered by length first for usability. I aknowledge that it's too easy to mess up when refactoring, but here there was a clear comment that this change should not have been performed.
