### PR TITLE
[ci] Run bignums' tests

### DIFF
--- a/dev/ci/ci-bignums.sh
+++ b/dev/ci/ci-bignums.sh
@@ -5,4 +5,4 @@ ci_dir="$(dirname "$0")"
 
 git_download bignums
 
-( cd "${CI_BUILD_DIR}/bignums" && make && make install)
+( cd "${CI_BUILD_DIR}/bignums" && make && make install && cd tests && make)


### PR DESCRIPTION
Since https://github.com/coq/bignums/pull/38 bignums has a Makefile for its tests. We probably want to run them in the CI.
