### PR TITLE
Require in Section: warning is now about fragility not deprecation.

### DIFF
--- a/doc/changelog/07-commands-and-options/11972-fix-require-in-section.rst
+++ b/doc/changelog/07-commands-and-options/11972-fix-require-in-section.rst
@@ -1,0 +1,5 @@
+- **Changed:** The warning when using :cmd:`Require` inside a section
+  moved from the ``deprecated`` category to the ``fragile`` category,
+  because there is no plan to remove the functionality at this time.
+  (`#11972 <https://github.com/coq/coq/pull/11972>`_, by Gaëtan
+  Gilbert).

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1081,10 +1081,9 @@ let vernac_end_segment ({v=id} as lid) =
 (* Libraries *)
 
 let warn_require_in_section =
-  let name = "require-in-section" in
-  let category = "deprecated" in
-  CWarnings.create ~name ~category
-    (fun () -> strbrk "Use of “Require” inside a section is deprecated.")
+  CWarnings.create ~name:"require-in-section" ~category:"fragile"
+    (fun () -> strbrk "Use of “Require” inside a section is fragile." ++ spc() ++
+               strbrk "It is not recommended to use this functionality in finished proof scripts.")
 
 let vernac_require from import qidl =
   if Global.sections_are_opened () then warn_require_in_section ();


### PR DESCRIPTION
Depends on https://github.com/coq/coq/pull/11972