### PR TITLE
Deprecate the omega tactic

### DIFF
--- a/doc/changelog/04-tactics/11976-deprecate-omega.rst
+++ b/doc/changelog/04-tactics/11976-deprecate-omega.rst
@@ -1,0 +1,5 @@
+- **Deprecated:**
+  The :tacn:`omega` tactic is deprecated;
+  use :tacn:`lia` from the :ref:`Micromega <micromega>` plugin instead
+  (`#11976 <https://github.com/coq/coq/pull/11976>`_,
+  by Vincent Laporte).

--- a/doc/sphinx/addendum/micromega.rst
+++ b/doc/sphinx/addendum/micromega.rst
@@ -1,4 +1,4 @@
-.. _ micromega:
+.. _micromega:
 
 Micromega: tactics for solving arithmetic goals over ordered rings
 ==================================================================

--- a/doc/sphinx/addendum/omega.rst
+++ b/doc/sphinx/addendum/omega.rst
@@ -7,20 +7,18 @@ Omega: a solver for quantifier-free problems in Presburger Arithmetic
 
 .. warning::
 
-   The :tacn:`omega` tactic is about to be deprecated in favor of the
-   :tacn:`lia` tactic.  The goal is to consolidate the arithmetic
-   solving capabilities of Coq into a single engine; moreover,
-   :tacn:`lia` is in general more powerful than :tacn:`omega` (it is a
-   complete Presburger arithmetic solver while :tacn:`omega` was known
-   to be incomplete).
+   The :tacn:`omega` tactic is deprecated in favor of the :tacn:`lia`
+   tactic.  The goal is to consolidate the arithmetic solving
+   capabilities of Coq into a single engine; moreover, :tacn:`lia` is
+   in general more powerful than :tacn:`omega` (it is a complete
+   Presburger arithmetic solver while :tacn:`omega` was known to be
+   incomplete).
 
-   Work is in progress to make sure that there are no regressions
-   (including no performance regression) when switching from
-   :tacn:`omega` to :tacn:`lia` in existing projects.  However, we
-   already recommend using :tacn:`lia` in new or refactored proof
-   scripts.  We also ask that you report (in our `bug tracker
-   <https://github.com/coq/coq/issues>`_) any issue you encounter,
-   especially if the issue was not present in :tacn:`omega`.
+   It is recommended to switch from :tacn:`omega` to :tacn:`lia` in existing
+   projects.  We also ask that you report (in our `bug tracker
+   <https://github.com/coq/coq/issues>`_) any issue you encounter, especially
+   if the issue was not present in :tacn:`omega`.  If no new issues are
+   reported, :tacn:`omega` will be removed soon.
 
    Note that replacing :tacn:`omega` with :tacn:`lia` can break
    non-robust proof scripts which rely on incompleteness bugs of
@@ -30,6 +28,10 @@ Description of ``omega``
 ------------------------
 
 .. tacn:: omega
+
+   .. deprecated:: 8.12
+
+      Use :tacn:`lia` instead.
 
    :tacn:`omega` is a tactic for solving goals in Presburger arithmetic,
    i.e. for proving formulas made of equations and inequalities over the
@@ -118,7 +120,7 @@ loaded by
 
 .. example::
 
-  .. coqtop:: all
+  .. coqtop:: all warn
 
      Require Import Omega.
 

--- a/doc/sphinx/proof-engine/detailed-tactic-examples.rst
+++ b/doc/sphinx/proof-engine/detailed-tactic-examples.rst
@@ -353,7 +353,7 @@ the optional tactic of the ``Hint Rewrite`` command.
 
    .. coqtop:: in reset
 
-      Require Import Omega.
+      Require Import Lia.
 
    .. coqtop:: in
 
@@ -367,7 +367,7 @@ the optional tactic of the ``Hint Rewrite`` command.
 
    .. coqtop:: in
 
-      Hint Rewrite g0 g1 g2 using omega : base1.
+      Hint Rewrite g0 g1 g2 using lia : base1.
 
    .. coqtop:: in
 

--- a/doc/sphinx/proof-engine/ltac.rst
+++ b/doc/sphinx/proof-engine/ltac.rst
@@ -1715,6 +1715,7 @@ performance issue.
 
 .. coqtop:: reset in
 
+   Set Warnings "-omega-is-deprecated".
    Require Import Coq.omega.Omega.
 
    Ltac mytauto := tauto.

--- a/doc/sphinx/proof-engine/ssreflect-proof-language.rst
+++ b/doc/sphinx/proof-engine/ssreflect-proof-language.rst
@@ -2607,7 +2607,7 @@ After the :token:`i_pattern`, a list of binders is allowed.
   .. coqtop:: reset none
 
      From Coq Require Import ssreflect.
-     From Coq Require Import Omega.
+     From Coq Require Import ZArith Lia.
      Set Implicit Arguments.
      Unset Strict Implicit.
      Unset Printing Implicit Defensive.
@@ -2615,7 +2615,7 @@ After the :token:`i_pattern`, a list of binders is allowed.
   .. coqtop:: all
 
      Lemma test : True.
-     have H x (y : nat) : 2 * x + y = x + x + y by omega.
+     have H x (y : nat) : 2 * x + y = x + x + y by lia.
 
 A proof term provided after ``:=`` can mention these bound variables
 (that are automatically introduced with the given names).
@@ -2625,7 +2625,7 @@ with parentheses even if no type is specified:
 
 .. coqtop:: all restart
 
-   have (x) : 2 * x = x + x by omega.
+   have (x) : 2 * x = x + x by lia.
 
 The :token:`i_item` and :token:`s_item` can be used to interpret the asserted
 hypothesis with views (see section :ref:`views_and_reflection_ssr`) or simplify the resulting
@@ -2668,9 +2668,9 @@ context entry name.
      Arguments Sub {_} _ _.
 
      Lemma test n m (H : m + 1 < n) : True.
-     have @i : 'I_n by apply: (Sub m); omega.
+     have @i : 'I_n by apply: (Sub m); lia.
 
-Note that the subterm produced by :tacn:`omega` is in general huge and
+Note that the subterm produced by :tacn:`lia` is in general huge and
 uninteresting, and hence one may want to hide it.
 For this purpose the ``[: name ]`` intro pattern and the tactic
 ``abstract`` (see :ref:`abstract_ssr`) are provided.
@@ -2680,7 +2680,7 @@ For this purpose the ``[: name ]`` intro pattern and the tactic
   .. coqtop:: all abort
 
      Lemma test n m (H : m + 1 < n) : True.
-     have [:pm] @i : 'I_n by apply: (Sub m); abstract: pm; omega.
+     have [:pm] @i : 'I_n by apply: (Sub m); abstract: pm; lia.
 
   The type of ``pm`` can be cleaned up by its annotation ``(*1*)`` by just
   simplifying it. The annotations are there for technical reasons only.
@@ -2694,7 +2694,7 @@ with have and an explicit term, they must be used as follows:
 
      Lemma test n m (H : m + 1 < n) : True.
      have [:pm] @i : 'I_n := Sub m pm.
-       by omega.
+       by lia.
 
 In this case the abstract constant ``pm`` is assigned by using it in
 the term that follows ``:=`` and its corresponding goal is left to be
@@ -2712,7 +2712,7 @@ makes use of it).
   .. coqtop:: all abort
 
      Lemma test n m (H : m + 1 < n) : True.
-     have [:pm] @i k : 'I_(n+k) by apply: (Sub m); abstract: pm k; omega.
+     have [:pm] @i k : 'I_(n+k) by apply: (Sub m); abstract: pm k; lia.
 
 Last, notice that the use of intro patterns for abstract constants is
 orthogonal to the transparent flag ``@`` for have.
@@ -2963,7 +2963,7 @@ illustrated in the following example.
 
   .. coqtop:: reset none
 
-     From Coq Require Import ssreflect Omega.
+     From Coq Require Import ssreflect Lia.
      Set Implicit Arguments.
      Unset Strict Implicit.
      Unset Printing Implicit Defensive.

--- a/doc/stdlib/hidden-files
+++ b/doc/stdlib/hidden-files
@@ -44,6 +44,7 @@ theories/micromega/Refl.v
 theories/micromega/RingMicromega.v
 theories/micromega/Tauto.v
 theories/micromega/VarMap.v
+theories/micromega/ZArith_hints.v
 theories/micromega/ZCoeff.v
 theories/micromega/ZMicromega.v
 theories/micromega/ZifyInst.v

--- a/plugins/omega/coq_omega.ml
+++ b/plugins/omega/coq_omega.ml
@@ -1899,8 +1899,15 @@ let destructure_goal =
 
 let destructure_goal = destructure_goal
 
+let warn_omega_is_deprecated =
+  let name = "omega-is-deprecated" in
+  let category = "deprecated" in
+  CWarnings.create ~name ~category (fun () ->
+    Pp.str "omega is deprecated since 8.12; use “lia” instead.")
+
 let omega_solver =
   Proofview.tclUNIT () >>= fun () -> (* delay for [check_required_library] *)
+  warn_omega_is_deprecated ();
   Coqlib.check_required_library ["Coq";"omega";"Omega"];
   reset_all ();
   destructure_goal

--- a/test-suite/bugs/closed/bug_1912.v
+++ b/test-suite/bugs/closed/bug_1912.v
@@ -1,4 +1,4 @@
-Require Import ZArith.
+Require Import Omega.
 
 Goal forall x, Z.succ (Z.pred x) = x.
 intros x.

--- a/theories/Logic/WKL.v
+++ b/theories/Logic/WKL.v
@@ -25,7 +25,7 @@
 Require Import WeakFan List.
 Import ListNotations.
 
-Require Import Omega.
+Require Import Arith.
 
 (** [is_path_from P n l] means that there exists a path of length [n]
     from [l] on which [P] does not hold *)

--- a/theories/micromega/ZArith_hints.v
+++ b/theories/micromega/ZArith_hints.v
@@ -1,0 +1,43 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+Require Import Lia.
+Import ZArith_base.
+
+Hint Resolve Z.le_refl Z.add_comm Z.add_assoc Z.mul_comm Z.mul_assoc Z.add_0_l
+  Z.add_0_r Z.mul_1_l Z.add_opp_diag_l Z.add_opp_diag_r Z.mul_add_distr_r
+  Z.mul_add_distr_l: zarith.
+
+Require Export Zhints.
+
+Hint Extern 10 (_ = _ :>nat) => abstract lia: zarith.
+Hint Extern 10 (_ <= _) => abstract lia: zarith.
+Hint Extern 10 (_ < _) => abstract lia: zarith.
+Hint Extern 10 (_ >= _) => abstract lia: zarith.
+Hint Extern 10 (_ > _) => abstract lia: zarith.
+
+Hint Extern 10 (_ <> _ :>nat) => abstract lia: zarith.
+Hint Extern 10 (~ _ <= _) => abstract lia: zarith.
+Hint Extern 10 (~ _ < _) => abstract lia: zarith.
+Hint Extern 10 (~ _ >= _) => abstract lia: zarith.
+Hint Extern 10 (~ _ > _) => abstract lia: zarith.
+
+Hint Extern 10 (_ = _ :>Z) => abstract lia: zarith.
+Hint Extern 10 (_ <= _)%Z => abstract lia: zarith.
+Hint Extern 10 (_ < _)%Z => abstract lia: zarith.
+Hint Extern 10 (_ >= _)%Z => abstract lia: zarith.
+Hint Extern 10 (_ > _)%Z => abstract lia: zarith.
+
+Hint Extern 10 (_ <> _ :>Z) => abstract lia: zarith.
+Hint Extern 10 (~ (_ <= _)%Z) => abstract lia: zarith.
+Hint Extern 10 (~ (_ < _)%Z) => abstract lia: zarith.
+Hint Extern 10 (~ (_ >= _)%Z) => abstract lia: zarith.
+Hint Extern 10 (~ (_ > _)%Z) => abstract lia: zarith.
+
+Hint Extern 10 False => abstract lia: zarith.

--- a/theories/omega/Omega.v
+++ b/theories/omega/Omega.v
@@ -19,38 +19,6 @@
 Require Export ZArith_base.
 Require Export OmegaLemmas.
 Require Export PreOmega.
-Require Import Lia.
+Require Export ZArith_hints.
 
 Declare ML Module "omega_plugin".
-
-Hint Resolve Z.le_refl Z.add_comm Z.add_assoc Z.mul_comm Z.mul_assoc Z.add_0_l
-  Z.add_0_r Z.mul_1_l Z.add_opp_diag_l Z.add_opp_diag_r Z.mul_add_distr_r
-  Z.mul_add_distr_l: zarith.
-
-Require Export Zhints.
-
-Hint Extern 10 (_ = _ :>nat) => abstract lia: zarith.
-Hint Extern 10 (_ <= _) => abstract lia: zarith.
-Hint Extern 10 (_ < _) => abstract lia: zarith.
-Hint Extern 10 (_ >= _) => abstract lia: zarith.
-Hint Extern 10 (_ > _) => abstract lia: zarith.
-
-Hint Extern 10 (_ <> _ :>nat) => abstract lia: zarith.
-Hint Extern 10 (~ _ <= _) => abstract lia: zarith.
-Hint Extern 10 (~ _ < _) => abstract lia: zarith.
-Hint Extern 10 (~ _ >= _) => abstract lia: zarith.
-Hint Extern 10 (~ _ > _) => abstract lia: zarith.
-
-Hint Extern 10 (_ = _ :>Z) => abstract lia: zarith.
-Hint Extern 10 (_ <= _)%Z => abstract lia: zarith.
-Hint Extern 10 (_ < _)%Z => abstract lia: zarith.
-Hint Extern 10 (_ >= _)%Z => abstract lia: zarith.
-Hint Extern 10 (_ > _)%Z => abstract lia: zarith.
-
-Hint Extern 10 (_ <> _ :>Z) => abstract lia: zarith.
-Hint Extern 10 (~ (_ <= _)%Z) => abstract lia: zarith.
-Hint Extern 10 (~ (_ < _)%Z) => abstract lia: zarith.
-Hint Extern 10 (~ (_ >= _)%Z) => abstract lia: zarith.
-Hint Extern 10 (~ (_ > _)%Z) => abstract lia: zarith.
-
-Hint Extern 10 False => abstract lia: zarith.

--- a/theories/setoid_ring/Rings_Z.v
+++ b/theories/setoid_ring/Rings_Z.v
@@ -11,7 +11,6 @@
 Require Export Cring.
 Require Export Integral_domain.
 Require Export Ncring_initial.
-Require Export Omega.
 
 Instance Zcri: (Cring (Rr:=Zr)).
 red. exact Z.mul_comm. Defined.


### PR DESCRIPTION
This deprecates the `omega` tactic. Tactics from the micromega plug-in can be used instead.

This adds a new file: what header/copyright/disclaimer/ascii-art logo should I put in it?