### PR TITLE
Add a rudimentary script to generate release changelog.

### DIFF
--- a/dev/tools/generate-release-changelog.sh
+++ b/dev/tools/generate-release-changelog.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+if [ $# != 1 ]; then
+    echo "Usage: $0 BRANCH"
+    exit
+fi
+
+branch=$1
+
+git checkout $branch
+git pull
+changelog_entries_with_title=$(ls doc/changelog/*/*.rst)
+changelog_entries_no_title=$(echo "$changelog_entries_with_title" | grep -v "00000-title.rst")
+git checkout master
+git pull
+for f in $changelog_entries_with_title; do
+    if [ -f "$f" ]; then
+        cat "$f" >> released.rst
+    else
+        echo "Warning: $f is missing in master branch."
+    fi
+done
+for f in $changelog_entries_no_title; do
+    if [ -f "$f" ]; then
+        git rm "$f"
+    fi
+done
+echo "Changelog written in released.rst. Move its content to a new section in doc/sphinx/changes.rst."

--- a/dev/tools/generate-release-changelog.sh
+++ b/dev/tools/generate-release-changelog.sh
@@ -1,4 +1,7 @@
-#!/bin/sh
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
 
 if [ $# != 1 ]; then
     echo "Usage: $0 BRANCH"
@@ -7,12 +10,73 @@ fi
 
 branch=$1
 
-git checkout $branch
-git pull
+# Set SLOW_CONF to have the confirmation output wait for a newline
+# Emacs doesn't send characters until the RET so we can't quick_conf
+if [ -z ${SLOW_CONF+x} ] || [ -n "$INSIDE_EMACS" ]; then
+    quick_conf="-n 1"
+else
+    quick_conf=""
+fi
+
+ask_confirmation() {
+    read -p "Continue anyway? [y/N] " $quick_conf -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        exit 1
+    fi
+}
+
+if ! git diff --quiet; then
+    echo "Warning: current tree is dirty."
+    ask_confirmation
+fi
+
+remote=$(git config --get "branch.${branch}.remote")
+
+if [ -z "$remote" ]; then
+    echo "Warning: branch $branch has no associated remote."
+    ask_confirmation
+else
+
+    if [ "$remote" != $(git config --get "branch.master.remote") ]; then
+        echo "Warning: branch master and branch $branch do not have the same remote."
+        ask_confirmation
+    fi
+
+    official_remote_git_url="git@github.com:coq/coq"
+    official_remote_https_url="github.com/coq/coq"
+    remote_url=$(git remote get-url "$remote" --all)
+
+    if [ "$remote_url" != "${official_remote_git_url}" ] && \
+           [ "$remote_url" != "${official_remote_git_url}.git" ] && \
+           [ "$remote_url" != "https://${official_remote_https_url}" ] && \
+           [ "$remote_url" != "https://${official_remote_https_url}.git" ] && \
+           [[ "$remote_url" != "https://"*"@${official_remote_https_url}" ]] && \
+           [[ "$remote_url" != "https://"*"@${official_remote_https_url}.git" ]] ; then
+        echo "Warning: remote $remote does not point to the official Coq repo,"
+        echo "that is $official_remote_git_url"
+        echo "It points to $remote_url instead."
+        ask_confirmation
+    fi
+
+    git fetch "$remote"
+
+    if [ $(git rev-parse master) != $(git rev-parse "${remote}/master") ]; then
+        echo "Warning: branch master is not up-to-date with ${remote}/master."
+        ask_confirmation
+    fi
+
+    if [ $(git rev-parse "$branch") != $(git rev-parse "${remote}/${branch}") ]; then
+        echo "Warning: branch ${branch} is not up-to-date with ${remote}/${branch}."
+        ask_confirmation
+    fi
+
+fi
+
+git checkout $branch --detach
 changelog_entries_with_title=$(ls doc/changelog/*/*.rst)
 changelog_entries_no_title=$(echo "$changelog_entries_with_title" | grep -v "00000-title.rst")
 git checkout master
-git pull
 for f in $changelog_entries_with_title; do
     if [ -f "$f" ]; then
         cat "$f" >> released.rst


### PR DESCRIPTION
The idea is very simple: use the list in the release branch to know which changelog entries to include, but do the work of removing these entries and consolidating the released changelog in the master branch (so that it is applied both to the master branch and to the release branch following the backporting process).

The script could be refined further, e.g. to not include the section titles without any content.

cc @ppedrot 

I created the script, then realized I couldn't yet apply it to v8.11 because not all the PRs that contain a changelog and are targeting this release have been backported, so I guess I'll leave you the task of calling the script once this is done.