### PR TITLE
Fix #11572: check_evars_are_solved returns a modified evar map

### DIFF
--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -306,7 +306,8 @@ let check_evars env ?initial sigma c =
 let check_evars_are_solved ~program_mode env sigma frozen =
   let sigma = check_typeclasses_instances_are_solved ~program_mode env sigma frozen in
   check_problems_are_solved env sigma;
-  check_extra_evars_are_solved env sigma frozen
+  check_extra_evars_are_solved env sigma frozen;
+  sigma
 
 (* Try typeclasses, hooks, unification heuristics ... *)
 
@@ -326,8 +327,8 @@ let solve_remaining_evars ?hook flags env ?initial sigma =
     then apply_heuristics env sigma false
     else sigma
   in
-  if flags.fail_evar then check_evars_are_solved ~program_mode env sigma frozen;
-  sigma
+  if flags.fail_evar then check_evars_are_solved ~program_mode env sigma frozen
+  else sigma
 
 let check_evars_are_solved ~program_mode env ?initial current_sigma =
   let frozen = frozen_and_pending_holes (initial, current_sigma) in

--- a/pretyping/pretyping.mli
+++ b/pretyping/pretyping.mli
@@ -125,10 +125,10 @@ val solve_remaining_evars : ?hook:inference_hook -> inference_flags ->
   env -> ?initial:evar_map -> (* current map *) evar_map -> evar_map
 
 (** Checking evars and pending conversion problems are all solved,
-    reporting an appropriate error message *)
+    reporting an appropriate error message. This call TC inference. *)
 
 val check_evars_are_solved :
-  program_mode:bool -> env -> ?initial:evar_map -> (* current map: *) evar_map -> unit
+  program_mode:bool -> env -> ?initial:evar_map -> (* current map: *) evar_map -> evar_map
 
 (** [check_evars env ?initial sigma c] fails if some unresolved evar
    remains in [c] which isn't in [initial] (any unresolved evar if

--- a/test-suite/bugs/closed/bug_11572.v
+++ b/test-suite/bugs/closed/bug_11572.v
@@ -1,0 +1,3 @@
+Class Foo := foo : True.
+Instance: Foo := I.
+Definition bar (v:=_) (H : @foo v = @foo v) : True := I.

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -490,7 +490,7 @@ let do_instance env env' sigma ?hook ~global ~poly cty k u ctx ctx' pri decl imp
     interp_props ~program_mode:false env' cty k u ctx ctx' subst sigma props
   in
   let termtype, sigma = do_instance_resolve_TC termtype sigma env in
-  Pretyping.check_evars_are_solved ~program_mode:false env sigma;
+  let sigma = Pretyping.check_evars_are_solved ~program_mode:false env sigma in
   declare_instance_constant pri global imps ?hook id decl poly sigma term termtype
 
 let do_instance_program ~pm env env' sigma ?hook ~global ~poly cty k u ctx ctx' pri decl imps subst id opt_props =

--- a/vernac/comFixpoint.ml
+++ b/vernac/comFixpoint.ml
@@ -235,7 +235,7 @@ let check_recursive isfix env evd (fixnames,_,fixdefs,_) =
   end
 
 let ground_fixpoint env evd (fixnames,fixrs,fixdefs,fixtypes) =
-  Pretyping.check_evars_are_solved ~program_mode:false env evd;
+  let evd = Pretyping.check_evars_are_solved ~program_mode:false env evd in
   let fixdefs = List.map (fun c -> Option.map EConstr.(to_constr evd) c) fixdefs in
   let fixtypes = List.map EConstr.(to_constr evd) fixtypes in
   Evd.evar_universe_context evd, (fixnames,fixrs,fixdefs,fixtypes)

--- a/vernac/comPrimitive.ml
+++ b/vernac/comPrimitive.ml
@@ -44,7 +44,7 @@ let do_primitive id udecl prim typopt =
         Exninfo.iraise (Pretype_errors.(
             PretypeError (env,evd,CannotUnify (typ,expected_typ,Some e)),info))
     in
-    Pretyping.check_evars_are_solved ~program_mode:false env evd;
+    let evd = Pretyping.check_evars_are_solved ~program_mode:false env evd in
     let evd = Evd.minimize_universes evd in
     let uvars = EConstr.universes_of_constr evd typ in
     let evd = Evd.restrict_universe_context evd uvars in

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -699,7 +699,7 @@ let prepare_obligation ~name ~types ~body sigma =
 
 let prepare_parameter ~poly ~udecl ~types sigma =
   let env = Global.env () in
-  Pretyping.check_evars_are_solved ~program_mode:false env sigma;
+  let sigma = Pretyping.check_evars_are_solved ~program_mode:false env sigma in
   let sigma, typ = Evarutil.finalize ~abort_on_undefined_evars:true
       sigma (fun nf -> nf types)
   in


### PR DESCRIPTION
Even then it's still possible to have unsolved evars after calling it
because of some implicit argument feature I don't understand.

Fixes #11572