### PR TITLE
Fix #11934 equality on constrexpr ignores instances of explicit applications

### DIFF
--- a/interp/constrexpr_ops.ml
+++ b/interp/constrexpr_ops.ml
@@ -121,9 +121,10 @@ let rec constr_expr_eq e1 e2 =
       constr_expr_eq a1 a2 &&
       Option.equal constr_expr_eq t1 t2 &&
       constr_expr_eq b1 b2
-    | CAppExpl((proj1,r1,_),al1), CAppExpl((proj2,r2,_),al2) ->
+    | CAppExpl((proj1,r1,u1),al1), CAppExpl((proj2,r2,u2),al2) ->
       Option.equal Int.equal proj1 proj2 &&
       qualid_eq r1 r2 &&
+      eq_universes u1 u2 &&
       List.equal constr_expr_eq al1 al2
     | CApp((proj1,e1),al1), CApp((proj2,e2),al2) ->
       Option.equal Int.equal proj1 proj2 &&
@@ -158,8 +159,8 @@ let rec constr_expr_eq e1 e2 =
       Id.equal id1 id2 && List.equal instance_eq c1 c2
     | CSort s1, CSort s2 ->
       Glob_ops.glob_sort_eq s1 s2
-  | CCast(t1,c1), CCast(t2,c2) ->
-    constr_expr_eq t1 t2 && cast_expr_eq c1 c2
+    | CCast(t1,c1), CCast(t2,c2) ->
+      constr_expr_eq t1 t2 && cast_expr_eq c1 c2
     | CNotation(inscope1, n1, s1), CNotation(inscope2, n2, s2) ->
       Option.equal notation_with_optional_scope_eq inscope1 inscope2 &&
       notation_eq n1 n2 &&

--- a/pretyping/glob_ops.mli
+++ b/pretyping/glob_ops.mli
@@ -15,6 +15,8 @@ open Glob_term
 
 val glob_sort_eq : Glob_term.glob_sort -> Glob_term.glob_sort -> bool
 
+val glob_level_eq : Glob_term.glob_level -> Glob_term.glob_level -> bool
+
 val cases_pattern_eq : 'a cases_pattern_g -> 'a cases_pattern_g -> bool
 
 (** Expect a Prop/SProp/Set/Type universe; raise [ComplexSort] if

--- a/test-suite/output/bug_11934.out
+++ b/test-suite/output/bug_11934.out
@@ -1,0 +1,13 @@
+thing = forall x y : foo, bla x y
+     : Prop
+thing = 
+forall (x : foo@{thing.u0}) (y : foo@{thing.u1}), bla x y
+     : Prop
+(* {thing.u1 thing.u0} |= bla.u0 = thing.u0
+                          bla.u1 = thing.u1 *)
+thing = 
+forall (x : @foo@{thing.u0} True) (y : @foo@{thing.u1} True),
+@bla True True x y
+     : Prop
+(* {thing.u1 thing.u0} |= bla.u0 = thing.u0
+                          bla.u1 = thing.u1 *)

--- a/test-suite/output/bug_11934.v
+++ b/test-suite/output/bug_11934.v
@@ -1,0 +1,13 @@
+Polymorphic Axiom foo@{u} : Prop -> Prop.
+Arguments foo {_}.
+
+Axiom bla : forall {A B}, @foo A -> @foo B -> Prop.
+Definition thing := forall (x:@foo@{Type} True) (y:@foo@{Type} True), bla x y.
+
+Print thing. (* forall x y : foo, bla x y *)
+
+Set Printing Universes.
+Print thing. (* forall (x : foo@{thing.u0}) (y : foo@{thing.u1}), bla x y *)
+
+Set Printing Implicit.
+Print thing. (* BAD: forall x y : @foo@{thing.u0} True, @bla True True x y *)


### PR DESCRIPTION
While we're at it also compare instances in glob_constr although I
don't know if that changes any behaviour.

Fixes #11934 
