### PR TITLE
Enable Async proofs using `Set Default Proof` annotations

### DIFF
--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -2157,22 +2157,23 @@ let collect_proof keep cur hd brkind id =
  let has_default_proof_using = Option.has_some (Proof_using.get_default_proof_using ()) in
  let proof_using_ast = function
    | VernacProof(_,Some _) -> true
+   | VernacProof(_,None) -> has_default_proof_using
    | _ -> false
  in
  let proof_using_ast = function
    | Some (_, v) when proof_using_ast v.expr.CAst.v.expr
                       && (not (Vernacprop.has_Fail v.expr)) -> Some v
    | _ -> None in
- let has_proof_using x = has_default_proof_using || (proof_using_ast x <> None) in
+ let has_proof_using x = proof_using_ast x <> None in
  let proof_no_using = function
-   | VernacProof(t,None) -> t
+   | VernacProof(t,None) -> if has_default_proof_using then None else t
    | _ -> assert false
  in
  let proof_no_using = function
    | Some (_, v) -> proof_no_using v.expr.CAst.v.expr, v
    | _ -> assert false in
  let has_proof_no_using = function
-   | VernacProof(_,None) -> true
+   | VernacProof(_,None) -> not has_default_proof_using
    | _ -> false
  in
  let has_proof_no_using = function

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -2154,6 +2154,7 @@ let collect_proof keep cur hd brkind id =
  let is_defined = function
    | _, { expr = e } -> is_defined_expr e.CAst.v.expr
                         && (not (Vernacprop.has_Fail e)) in
+ let has_default_proof_using = Option.has_some (Proof_using.get_default_proof_using ()) in
  let proof_using_ast = function
    | VernacProof(_,Some _) -> true
    | _ -> false
@@ -2162,7 +2163,7 @@ let collect_proof keep cur hd brkind id =
    | Some (_, v) when proof_using_ast v.expr.CAst.v.expr
                       && (not (Vernacprop.has_Fail v.expr)) -> Some v
    | _ -> None in
- let has_proof_using x = proof_using_ast x <> None in
+ let has_proof_using x = has_default_proof_using || (proof_using_ast x <> None) in
  let proof_no_using = function
    | VernacProof(t,None) -> t
    | _ -> assert false

--- a/test-suite/bugs/closed/bug_11342.v
+++ b/test-suite/bugs/closed/bug_11342.v
@@ -1,0 +1,29 @@
+(* -*- mode: coq; coq-prog-args: ("-vos") -*- *)
+
+Section foo.
+  Context {H:True}.
+  Theorem test1 : True.
+  Proof.
+    (* this gets printed with -vos because there's no annotation *)
+    idtac "without using".
+    exact I.
+  Qed.
+End foo.
+
+Section foo.
+  Context {H:True}.
+  Set Default Proof Using "Type".
+  Theorem test2 : True.
+  Proof.
+    (* BUG: this gets printed when compiling with -vos *)
+    fail "proof with default using".
+    exact I.
+  Qed.
+
+  Theorem test3 : True.
+  Proof using Type.
+    (* this isn't printed with -vos *)
+    fail "using".
+    exact I.
+  Qed.
+End foo.

--- a/test-suite/bugs/closed/bug_11608.v
+++ b/test-suite/bugs/closed/bug_11608.v
@@ -1,0 +1,13 @@
+(* -*- mode: coq; coq-prog-args: ("-vos") -*- *)
+
+Set Default Proof Using "Type".
+
+Section foo.
+  Context (A:Type).
+  Definition x : option A.
+    (* this can get printed with -vos since without "Proof." there's no Proof
+    using, even with a default annotation. *)
+    idtac "creating x".
+    exact None.
+  Qed.
+End foo.


### PR DESCRIPTION
**Kind:** backport

Backport pull requests #11564 and #11609: they make the new `make vos` actually useful on codebases using sections. For instance, `make vos` becomes twice as fast on `coq-iris`.

I've been using these pull requests, backported on an earlier snapshot of 8.11, for quite a while. (EDIT: And now, also this particular backport).

I understand this is not a "proper" backport using the established workflow, but I don't think I can fix that :-|.