### PR TITLE
Improve error messages for Set and Unset commands.

### DIFF
--- a/test-suite/output/BadOptionValueType.out
+++ b/test-suite/output/BadOptionValueType.out
@@ -1,8 +1,14 @@
 The command has indeed failed with message:
 Bad type of value for this option: expected int, got string.
 The command has indeed failed with message:
-Bad type of value for this option: expected bool, got string.
+This is an option. A value must be provided.
 The command has indeed failed with message:
-Bad type of value for this option: expected bool, got int.
+Bad type of value for this option: expected string, got int.
 The command has indeed failed with message:
-Bad type of value for this option: expected bool, got int.
+This is an option. A value must be provided.
+The command has indeed failed with message:
+This is a flag. It does not take a value.
+The command has indeed failed with message:
+This is a flag. It does not take a value.
+The command has indeed failed with message:
+This option does not support the "Unset" command.

--- a/test-suite/output/BadOptionValueType.v
+++ b/test-suite/output/BadOptionValueType.v
@@ -1,4 +1,7 @@
 Fail Set Default Timeout "2".
+Fail Set Default Timeout.
+Fail Set Bullet Behavior 2.
+Fail Set Bullet Behavior.
 Fail Set Debug Eauto "yes".
 Fail Set Debug Eauto 1.
-Fail Set Implicit Arguments 1.
+Fail Unset Warnings.


### PR DESCRIPTION
In particular, the error messages do not mention anymore the notion of bool-valued options, since these are documented as flags and work quite differently from the rest of options.

I initially did this patch on top of #11997 but it turns out that this does not conflict with it, so I'm submitting it separately so that it can be backported.

Not updating the documentation now because it will be done as part of #11961.