### PR TITLE
Remove deprecated coqtop options

### DIFF
--- a/doc/changelog/08-tools/12005-remove-deprecated-coqtop-options.rst
+++ b/doc/changelog/08-tools/12005-remove-deprecated-coqtop-options.rst
@@ -1,5 +1,5 @@
 - **Removed:**
   Confusingly-named and deprecated since 8.11 `-require` option.
-  Use `-require-import` instead
+  Use the equivalent `-require-import` instead
   (`#12005 <https://github.com/coq/coq/pull/12005>`_,
   by Théo Zimmermann).

--- a/doc/changelog/08-tools/12005-remove-deprecated-coqtop-options.rst
+++ b/doc/changelog/08-tools/12005-remove-deprecated-coqtop-options.rst
@@ -1,0 +1,5 @@
+- **Removed:**
+  Confusingly-named and deprecated since 8.11 `-require` option.
+  Use `-require-import` instead
+  (`#12005 <https://github.com/coq/coq/pull/12005>`_,
+  by Théo Zimmermann).

--- a/doc/sphinx/practical-tools/coq-commands.rst
+++ b/doc/sphinx/practical-tools/coq-commands.rst
@@ -164,6 +164,8 @@ and ``coqtop``, unless stated otherwise:
   it is executed.
 :-load-vernac-object *qualid*: Load |Coq| compiled library :n:`@qualid`. This
   is equivalent to running :cmd:`Require` :n:`qualid`.
+:-rfrom *dirpath* *qualid*: Load |Coq| compiled library :n:`@qualid`.
+  This is equivalent to running :n:`From` :n:`@dirpath` :cmd:`Require Import` :n:`@qualid`.
 :-ri *qualid*, -require-import *qualid*: Load |Coq| compiled library :n:`@qualid` and import it.
   This is equivalent to running :cmd:`Require Import` :n:`@qualid`.
 :-re *qualid*, -require-export *qualid*: Load |Coq| compiled library :n:`@qualid` and transitively import it.

--- a/doc/sphinx/practical-tools/coq-commands.rst
+++ b/doc/sphinx/practical-tools/coq-commands.rst
@@ -172,7 +172,6 @@ and ``coqtop``, unless stated otherwise:
   This is equivalent to running :n:`From` :n:`@dirpath` :cmd:`Require Import` :n:`@qualid`.
 :-refrom *dirpath* *qualid*, -require-export-from *dirpath* *qualid*: Load |Coq| compiled library :n:`@qualid` and transitively import it.
   This is equivalent to running :n:`From` :n:`@dirpath` :cmd:`Require Export` :n:`@qualid`.
-:-require *qualid*: Deprecated; use ``-ri`` *qualid*.
 :-batch: Exit just after argument parsing. Available for ``coqtop`` only.
 :-compile *file.v*: Deprecated; use ``coqc`` instead. Compile file *file.v* into *file.vo*. This option
   implies -batch (exit just after argument parsing). It is available only

--- a/man/coqide.1
+++ b/man/coqide.1
@@ -69,7 +69,7 @@ Load Coq library
 (Require
 .IR path .).
 .TP
-.BI \-require\  path
+.BI \-require-import\  path
 Load Coq library
 .IR path
 and import it (Require Import

--- a/man/coqtop.1
+++ b/man/coqtop.1
@@ -79,7 +79,7 @@ load Coq library
 (Require path.)
 
 .TP
-.BI \-require \ path
+.BI \-require-import \ path
 load Coq library
 .I path
 and import it (Require Import path.)

--- a/stm/asyncTaskQueue.ml
+++ b/stm/asyncTaskQueue.ml
@@ -138,7 +138,9 @@ module Make(T : Task) () = struct
           set_slave_opt tl
         (* We need to pass some options with one argument *)
         | ( "-I" | "-include" | "-top" | "-topfile" | "-coqlib" | "-exclude-dir" | "-compat"
-          | "-require" | "-w" | "-color" | "-init-file"
+          | "-require-import" | "-require-export" | "-require-import-from" | "-require-export-from"
+          | "-ri" | "-re" | "-rifrom" | "-refrom" | "-load-vernac-object"
+          | "-w" | "-color" | "-init-file"
           | "-profile-ltac-cutoff" | "-main-channel" | "-control-channel" | "-mangle-names" | "-set" | "-unset"
           | "-diffs" | "-mangle-name" | "-dump-glob" | "-bytecode-compiler" | "-native-compiler" as x) :: a :: tl ->
           x :: a :: set_slave_opt tl

--- a/toplevel/coqargs.ml
+++ b/toplevel/coqargs.ml
@@ -203,10 +203,6 @@ let warn_deprecated_inputstate =
   CWarnings.create ~name:"deprecated-inputstate" ~category:"deprecated"
          (fun () -> Pp.strbrk "The inputstate option is deprecated and discouraged.")
 
-let warn_deprecated_simple_require =
-  CWarnings.create ~name:"deprecated-boot" ~category:"deprecated"
-         (fun () -> Pp.strbrk "The -require option is deprecated, please use -require-import instead.")
-
 let set_inputstate opts s =
   warn_deprecated_inputstate ();
   { opts with pre = { opts.pre with inputstate = Some s }}
@@ -421,10 +417,6 @@ let parse_args ~help ~init arglist : t * string list =
 
     |"-rfrom" ->
       let from = next () in add_vo_require oval (next ()) (Some from) None
-
-    |"-require" ->
-      warn_deprecated_simple_require ();
-      add_vo_require oval (next ()) None (Some false)
 
     |"-require-import" | "-ri" -> add_vo_require oval (next ()) None (Some false)
 


### PR DESCRIPTION
- [x] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).

The first commit removes `-require` that was deprecated in favor of `-require-import` / `-ri` in 8.11. The goal is to reintroduce it in 8.13 but this time as a better-named `-load-vernac-object` replacement. cc @herbelin (who introduced the deprecation in #10245)

~~The second commit removes the undocumented and deprecated since 8.5 `-inputstate`. cc @ppedrot (who introduced the deprecation in 6dd9e003c289a79b0656e7c6f2cc59935997370c).~~