### PR TITLE
Fix CoRN & Flocq CI scripts.

### DIFF
--- a/dev/ci/ci-corn.sh
+++ b/dev/ci/ci-corn.sh
@@ -5,4 +5,4 @@ ci_dir="$(dirname "$0")"
 
 git_download Corn
 
-( cd "${CI_BUILD_DIR}/Corn" && make && make install )
+( cd "${CI_BUILD_DIR}/Corn" && ./configure.sh && make && make install )

--- a/dev/ci/ci-flocq.sh
+++ b/dev/ci/ci-flocq.sh
@@ -5,4 +5,4 @@ ci_dir="$(dirname "$0")"
 
 git_download Flocq
 
-( cd "${CI_BUILD_DIR}/Flocq" && ./autogen.sh && ./configure && ./remake "-j${NJOBS}" )
+( cd "${CI_BUILD_DIR}/Flocq" && autoconf && ./configure && ./remake "-j${NJOBS}" )


### PR DESCRIPTION
Auto-generated files like the Makefile have recently been removed from the sources (cf. coq-community/corn#88).  Calling ./configure.sh is now required.

**Kind:** infrastructure.

Could be backported, but not absolutely required since the version tested in v8.11 is pinned.