### PR TITLE
Tweak #11306 for the 8.11 branch.

### DIFF
--- a/lib/flags.ml
+++ b/lib/flags.ml
@@ -109,10 +109,7 @@ let get_inline_level () = !inline_level
 let profile_ltac = ref false
 let profile_ltac_cutoff = ref 2.0
 
-let native_compiler = ref None
-let get_native_compiler () = match !native_compiler with
-| None -> assert false
-| Some b -> b
+let native_compiler = ref false
+let get_native_compiler () = !native_compiler
 let set_native_compiler b =
-  let () = assert (!native_compiler == None) in
-  native_compiler := Some b
+  native_compiler := b


### PR DESCRIPTION
We set a default value instead of failing when the option is unset to preserve backwards runtime compatibility.