### PR TITLE
Locate definitions, notations and references to tactics in coqdoc

### DIFF
--- a/interp/dumpglob.ml
+++ b/interp/dumpglob.ml
@@ -252,7 +252,7 @@ let add_glob_kn ?loc kn =
     let lib_dp = Lib.dp_of_mp (mp_of_kn kn) in
     add_glob_gen ?loc sp lib_dp "syndef"
 
-let add_tactic ?loc kn =
+let add_tactic ?loc ~isml kn =
   if dump () then
     let mp,id = Names.KerName.repr kn in
     let lib_dp, ids = Lib.split_modpath mp in
@@ -260,7 +260,7 @@ let add_tactic ?loc kn =
     let filepath = Names.DirPath.to_string lib_dp in
     let modpath = Names.DirPath.to_string mod_dp_trunc in
     let ident = Names.Label.to_string id in
-      dump_ref ?loc filepath modpath ident "tac"
+    dump_ref ?loc filepath modpath ident (if isml then "mltac" else "tac")
 
 let dump_def ?loc ty secpath id = Option.iter (fun loc ->
   if get_output () = Feedback then

--- a/interp/dumpglob.ml
+++ b/interp/dumpglob.ml
@@ -252,6 +252,16 @@ let add_glob_kn ?loc kn =
     let lib_dp = Lib.dp_of_mp (mp_of_kn kn) in
     add_glob_gen ?loc sp lib_dp "syndef"
 
+let add_tactic ?loc kn =
+  if dump () then
+    let mp,id = Names.KerName.repr kn in
+    let lib_dp, ids = Lib.split_modpath mp in
+    let mod_dp_trunc = Names.DirPath.make ids in
+    let filepath = Names.DirPath.to_string lib_dp in
+    let modpath = Names.DirPath.to_string mod_dp_trunc in
+    let ident = Names.Label.to_string id in
+      dump_ref ?loc filepath modpath ident "tac"
+
 let dump_def ?loc ty secpath id = Option.iter (fun loc ->
   if get_output () = Feedback then
     Feedback.feedback (Feedback.GlobDef (loc, id, secpath, ty))

--- a/interp/dumpglob.mli
+++ b/interp/dumpglob.mli
@@ -36,7 +36,7 @@ val continue : unit -> unit
 val add_glob : ?loc:Loc.t -> Names.GlobRef.t -> unit
 val add_glob_kn : ?loc:Loc.t -> Names.KerName.t -> unit
 
-val add_tactic : ?loc:Loc.t -> Names.KerName.t -> unit
+val add_tactic : ?loc:Loc.t -> isml:bool -> Names.KerName.t -> unit
   (* Add a name for tactic language [ml] *)
 
 val dump_definition : Names.lident -> bool -> string -> unit

--- a/interp/dumpglob.mli
+++ b/interp/dumpglob.mli
@@ -36,6 +36,9 @@ val continue : unit -> unit
 val add_glob : ?loc:Loc.t -> Names.GlobRef.t -> unit
 val add_glob_kn : ?loc:Loc.t -> Names.KerName.t -> unit
 
+val add_tactic : ?loc:Loc.t -> Names.KerName.t -> unit
+  (* Add a name for tactic language [ml] *)
+
 val dump_definition : Names.lident -> bool -> string -> unit
 val dump_moddef : ?loc:Loc.t -> Names.ModPath.t -> string -> unit
 val dump_modref  : ?loc:Loc.t -> Names.ModPath.t -> string -> unit

--- a/plugins/ltac/g_ltac.mlg
+++ b/plugins/ltac/g_ltac.mlg
@@ -440,10 +440,10 @@ END
 {
 
 let pr_ltac_production_item = function
-| Tacentries.TacTerm (_, s) -> quote (str s)
-| Tacentries.TacNonTerm (_, ((arg, None), None)) -> str arg
-| Tacentries.TacNonTerm (_, ((arg, Some _), None)) -> assert false
-| Tacentries.TacNonTerm (_, ((arg, sep), Some id)) ->
+| Tacentries.TacTerm {CAst.v = s} -> quote (str s)
+| Tacentries.TacNonTerm {CAst.v = ((arg, None), None)} -> str arg
+| Tacentries.TacNonTerm {CAst.v = ((arg, Some _), None)} -> assert false
+| Tacentries.TacNonTerm {CAst.v = ((arg, sep), Some id)} ->
   let sep = match sep with
   | None -> mt ()
   | Some sep -> str "," ++ spc () ++ quote (str sep)
@@ -456,11 +456,11 @@ let check_non_empty_string ?loc s =
 }
 
 VERNAC ARGUMENT EXTEND ltac_production_item PRINTED BY { pr_ltac_production_item }
-| [ string(s) ] -> { check_non_empty_string ~loc s; Tacentries.TacTerm (Some loc,s) }
+| [ string(s) ] -> { check_non_empty_string ~loc s; Tacentries.TacTerm (CAst.make ~loc s) }
 | [ ident(nt) "(" ident(p) ltac_production_sep_opt(sep) ")" ] ->
-  { Tacentries.TacNonTerm (Loc.tag ~loc ((Id.to_string nt, sep), Some p)) }
+  { Tacentries.TacNonTerm (CAst.make ~loc ((Id.to_string nt, sep), Some p)) }
 | [ ident(nt) ] ->
-  { Tacentries.TacNonTerm (Loc.tag ~loc ((Id.to_string nt, None), None)) }
+  { Tacentries.TacNonTerm (CAst.make ~loc ((Id.to_string nt, None), None)) }
 END
 
 VERNAC COMMAND EXTEND VernacTacticNotation

--- a/plugins/ltac/g_ltac.mlg
+++ b/plugins/ltac/g_ltac.mlg
@@ -440,7 +440,7 @@ END
 {
 
 let pr_ltac_production_item = function
-| Tacentries.TacTerm s -> quote (str s)
+| Tacentries.TacTerm (_, s) -> quote (str s)
 | Tacentries.TacNonTerm (_, ((arg, None), None)) -> str arg
 | Tacentries.TacNonTerm (_, ((arg, Some _), None)) -> assert false
 | Tacentries.TacNonTerm (_, ((arg, sep), Some id)) ->
@@ -456,7 +456,7 @@ let check_non_empty_string ?loc s =
 }
 
 VERNAC ARGUMENT EXTEND ltac_production_item PRINTED BY { pr_ltac_production_item }
-| [ string(s) ] -> { check_non_empty_string ~loc s; Tacentries.TacTerm s }
+| [ string(s) ] -> { check_non_empty_string ~loc s; Tacentries.TacTerm (Some loc,s) }
 | [ ident(nt) "(" ident(p) ltac_production_sep_opt(sep) ")" ] ->
   { Tacentries.TacNonTerm (Loc.tag ~loc ((Id.to_string nt, sep), Some p)) }
 | [ ident(nt) ] ->

--- a/plugins/ltac/pptactic.ml
+++ b/plugins/ltac/pptactic.ml
@@ -1063,7 +1063,7 @@ let pr_goal_selector ~toplevel s =
               pr_tacarg a, latom
             | TacML (s,l) ->
               pr_with_comments ?loc (pr.pr_extend 1 s l), lcall
-            | TacAlias (kn,l) ->
+            | TacAlias (kn,_,l) ->
               pr_with_comments ?loc (pr.pr_alias (level_of inherited) kn l), latom
           )
           in

--- a/plugins/ltac/pptactic.ml
+++ b/plugins/ltac/pptactic.ml
@@ -52,7 +52,7 @@ let tag_atomic_tactic_expr      = do_not_tag
 let pr_global x = Nametab.pr_global_env Id.Set.empty x
 
 type 'a grammar_tactic_prod_item_expr =
-| TacTerm of string
+| TacTerm of string Loc.located
 | TacNonTerm of ('a * Names.Id.t option) Loc.located
 
 type grammar_terminals = Genarg.ArgT.any Extend.user_symbol grammar_tactic_prod_item_expr list
@@ -226,13 +226,13 @@ let string_of_genarg_arg (ArgumentType arg) =
 
   let rec tacarg_using_rule_token pr_gen = function
     | [] -> []
-    | TacTerm s :: l -> keyword s :: tacarg_using_rule_token pr_gen l
+    | TacTerm (_, s) :: l -> keyword s :: tacarg_using_rule_token pr_gen l
     | TacNonTerm (_, ((symb, arg), _)) :: l  ->
       pr_gen symb arg :: tacarg_using_rule_token pr_gen l
 
   let pr_tacarg_using_rule pr_gen l =
     let l = match l with
-    | TacTerm s :: l ->
+    | TacTerm (_, s) :: l ->
       (* First terminal token should be considered as the name of the tactic,
          so we tag it differently than the other terminal tokens. *)
       primitive s :: tacarg_using_rule_token pr_gen l
@@ -266,7 +266,7 @@ let string_of_genarg_arg (ArgumentType arg) =
     try
       let prods = (KNmap.find key !prnotation_tab).pptac_prods in
       let pr = function
-      | TacTerm s -> primitive s
+      | TacTerm (_, s) -> primitive s
       | TacNonTerm (_, (symb, _)) -> str (Printf.sprintf "(%s)" (pr_user_symbol symb))
       in
       pr_sequence pr prods

--- a/plugins/ltac/pptactic.mli
+++ b/plugins/ltac/pptactic.mli
@@ -21,7 +21,7 @@ open Tacexpr
 open Tactypes
 
 type 'a grammar_tactic_prod_item_expr =
-| TacTerm of string
+| TacTerm of string Loc.located
 | TacNonTerm of ('a * Names.Id.t option) Loc.located
 
 type 'a raw_extra_genarg_printer =

--- a/plugins/ltac/pptactic.mli
+++ b/plugins/ltac/pptactic.mli
@@ -21,8 +21,8 @@ open Tacexpr
 open Tactypes
 
 type 'a grammar_tactic_prod_item_expr =
-| TacTerm of string Loc.located
-| TacNonTerm of ('a * Names.Id.t option) Loc.located
+| TacTerm of string CAst.t
+| TacNonTerm of ('a * Names.Id.t option) CAst.t
 
 type 'a raw_extra_genarg_printer =
   Environ.env -> Evd.evar_map ->

--- a/plugins/ltac/tacentries.ml
+++ b/plugins/ltac/tacentries.ml
@@ -324,6 +324,9 @@ let add_glob_tactic_notation local ~level ?deprecation prods forml ids tac =
     tacobj_body = { alias_args = ids; alias_body = tac; alias_deprecation = deprecation };
     tacobj_forml = forml;
   } in
+  if not forml then
+    (let id = CAst.make ?loc (Label.to_id (KerName.label key)) in
+     Dumpglob.dump_definition id false "tac");
   Lib.add_anonymous_leaf (inTacticGrammar tacobj)
 
 let add_tactic_notation local n ?deprecation prods e =
@@ -495,9 +498,11 @@ let register_ltac local ?deprecation tacl =
   let iter (loc, def, tac) = match def with
   | NewTac id ->
     Tacenv.register_ltac false local id tac ?deprecation;
+    Dumpglob.dump_definition (CAst.make ?loc id) false "tac";
     Flags.if_verbose Feedback.msg_info (Id.print id ++ str " is defined")
   | UpdateTac kn ->
     Tacenv.redefine_ltac local kn tac ?deprecation;
+    (* TODO: unique coqdoc link for redefinitions *)
     let name = Tacenv.shortest_qualid_of_tactic kn in
     Flags.if_verbose Feedback.msg_info (Libnames.pr_qualid name ++ str " is redefined")
   in

--- a/plugins/ltac/tacentries.ml
+++ b/plugins/ltac/tacentries.ml
@@ -366,7 +366,7 @@ let extend_atomic_tactic name entries =
     let args = List.map (fun a -> Tacexp a) args in
     let entry = { mltac_name = name; mltac_index = i } in
     let body = CAst.make (TacML (entry, args)) in
-    Tacenv.register_ltac false false (Names.Id.of_string id) body
+    Tacenv.register_ltac true false (Names.Id.of_string id) body
   in
   List.iteri add_atomic entries
 

--- a/plugins/ltac/tacentries.ml
+++ b/plugins/ltac/tacentries.ml
@@ -174,7 +174,7 @@ let add_tactic_entry (kn, ml, tg) state =
         TacGeneric (None, arg)
     in
     let l = List.map map l in
-    (CAst.make ~loc (TacAlias (kn,l)):raw_tactic_expr)
+    (CAst.make ~loc (TacAlias (kn,ml,l)):raw_tactic_expr)
   in
   let () =
     if Int.equal tg.tacgram_level 0 && not (head_is_ident tg) then

--- a/plugins/ltac/tacentries.mli
+++ b/plugins/ltac/tacentries.mli
@@ -22,8 +22,8 @@ val register_ltac : locality_flag -> ?deprecation:Deprecation.t ->
 (** {5 Tactic Notations} *)
 
 type 'a grammar_tactic_prod_item_expr = 'a Pptactic.grammar_tactic_prod_item_expr =
-| TacTerm of string Loc.located
-| TacNonTerm of ('a * Names.Id.t option) Loc.located
+| TacTerm of string CAst.t
+| TacNonTerm of ('a * Names.Id.t option) CAst.t
 
 type raw_argument = string * string option
 (** An argument type as provided in Tactic notations, i.e. a string like

--- a/plugins/ltac/tacentries.mli
+++ b/plugins/ltac/tacentries.mli
@@ -22,7 +22,7 @@ val register_ltac : locality_flag -> ?deprecation:Deprecation.t ->
 (** {5 Tactic Notations} *)
 
 type 'a grammar_tactic_prod_item_expr = 'a Pptactic.grammar_tactic_prod_item_expr =
-| TacTerm of string
+| TacTerm of string Loc.located
 | TacNonTerm of ('a * Names.Id.t option) Loc.located
 
 type raw_argument = string * string option

--- a/plugins/ltac/tacexpr.ml
+++ b/plugins/ltac/tacexpr.ml
@@ -239,7 +239,7 @@ and 'a gen_tactic_expr_r =
   (* For ML extensions *)
   | TacML of ml_tactic_entry * 'a gen_tactic_arg list
   (* For syntax extensions *)
-  | TacAlias of KerName.t * 'a gen_tactic_arg list
+  | TacAlias of KerName.t * bool * 'a gen_tactic_arg list
 
 constraint 'a = <
     term:'t;

--- a/plugins/ltac/tacexpr.mli
+++ b/plugins/ltac/tacexpr.mli
@@ -238,7 +238,7 @@ and 'a gen_tactic_expr_r =
   (* For ML extensions *)
   | TacML of ml_tactic_entry * 'a gen_tactic_arg list
   (* For syntax extensions *)
-  | TacAlias of KerName.t * 'a gen_tactic_arg list
+  | TacAlias of KerName.t * bool * 'a gen_tactic_arg list
 
 constraint 'a = <
     term:'t;

--- a/plugins/ltac/tacintern.ml
+++ b/plugins/ltac/tacintern.ml
@@ -677,11 +677,11 @@ and intern_tactic_seq onlytac ist tac =
       ist.ltacvars, CAst.make ?loc (TacSelect (sel, intern_pure_tactic ist tac))
 
   (* For extensions *)
-  | TacAlias (s,l) ->
+  | TacAlias (s,isml,l) ->
       let alias = Tacenv.interp_alias s in
       Option.iter (fun o -> warn_deprecated_alias ?loc (s,o)) @@ alias.Tacenv.alias_deprecation;
       let l = List.map (intern_tacarg !strict_check false ist) l in
-      ist.ltacvars, CAst.make ?loc (TacAlias (s,l))
+      ist.ltacvars, CAst.make ?loc (TacAlias (s,isml,l))
   | TacML (opn,l) ->
       let _ignore = Tacenv.interp_ml_tactic opn in
       ist.ltacvars, CAst.make ?loc (TacML (opn,List.map (intern_tacarg !strict_check false ist) l))

--- a/plugins/ltac/tacintern.ml
+++ b/plugins/ltac/tacintern.ml
@@ -139,10 +139,12 @@ let warn_deprecated_alias =
     Pptactic.pr_alias_key
 
 let dump_tactic_reference ?loc kn =
-  try if not (Tacenv.is_ltac_for_ml_tactic kn) then Dumpglob.add_tactic ?loc kn
-  with Not_found ->
-    (* This is a not-yet registered Ltac recursive definition *)
-    Dumpglob.add_tactic ?loc kn
+  let isml =
+    try Tacenv.is_ltac_for_ml_tactic kn
+    with Not_found ->
+      (* This is a not-yet registered Ltac recursive definition *)
+      false in
+  Dumpglob.add_tactic ?loc ~isml kn
 
 let intern_isolated_global_tactic_reference qid =
   let loc = qid.CAst.loc in
@@ -689,7 +691,7 @@ and intern_tactic_seq onlytac ist tac =
   (* For extensions *)
   | TacAlias (s,isml,l) ->
       let alias = Tacenv.interp_alias s in
-      if not forml then Dumpglob.add_tactic ?loc s;
+      Dumpglob.add_tactic ?loc ~isml s;
       Option.iter (fun o -> warn_deprecated_alias ?loc (s,o)) @@ alias.Tacenv.alias_deprecation;
       let l = List.map (intern_tacarg !strict_check false ist) l in
       ist.ltacvars, CAst.make ?loc (TacAlias (s,isml,l))

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -1203,7 +1203,7 @@ and eval_tactic_ist ist tac : unit Proofview.tactic =
   | TacArg _ -> Ftactic.run (val_interp (ensure_loc loc ist) tac) (fun v -> tactic_of_value ist v)
   | TacSelect (sel, tac) -> Goal_select.tclSELECT sel (interp_tactic ist tac)
   (* For extensions *)
-  | TacAlias (s,l) ->
+  | TacAlias (s,_,l) ->
       let alias = Tacenv.interp_alias s in
       Proofview.tclProofInfo [@ocaml.warning "-3"] >>= fun (_name, poly) ->
       let (>>=) = Ftactic.bind in

--- a/plugins/ltac/tacsubst.ml
+++ b/plugins/ltac/tacsubst.ml
@@ -222,9 +222,9 @@ and subst_tactic subst = CAst.map (function
   | TacSelect (s, tac) -> TacSelect (s, subst_tactic subst tac)
 
   (* For extensions *)
-  | TacAlias (s,l) ->
+  | TacAlias (s,forml,l) ->
       let s = subst_kn subst s in
-      TacAlias (s,List.map (subst_tacarg subst) l)
+      TacAlias (s,forml,List.map (subst_tacarg subst) l)
   | TacML (opn,l) -> TacML (opn,List.map (subst_tacarg subst) l)
   )
 

--- a/plugins/ssr/ssrparser.mlg
+++ b/plugins/ssr/ssrparser.mlg
@@ -100,7 +100,7 @@ let register_ssrtac name f prods =
   let map id = Reference (Locus.ArgVar (CAst.make id)) in
   let get_id = function
     | TacTerm s -> None
-    | TacNonTerm (_, (_, ido)) -> ido in
+    | TacNonTerm {CAst.v = (_, ido)} -> ido in
   let ids = List.map_filter get_id prods in
   let tac = CAst.make (TacML (ssrtac_entry name, List.map map ids)) in
   let key = KerName.make path (Label.make ("ssrparser_" ^ name)) in
@@ -1696,11 +1696,11 @@ let _ = add_internal_name (is_tagged perm_tag)
 {
 
   let ssrtac_expr ?loc key args =
-    CAst.make ?loc (TacAlias (key, (List.map (fun x -> Tacexpr.TacGeneric (None, x)) args)))
+    CAst.make ?loc (TacAlias (key, true, (List.map (fun x -> Tacexpr.TacGeneric (None, x)) args)))
 
 let mk_non_term wit id =
   let open Pptactic in
-  TacNonTerm (None, (Extend.Uentry (Genarg.ArgT.Any (Genarg.get_arg_tag wit)), Some id))
+  TacNonTerm (CAst.make (Extend.Uentry (Genarg.ArgT.Any (Genarg.get_arg_tag wit)), Some id))
 
 let tclintroskey =
   let prods =
@@ -1801,7 +1801,7 @@ END
 
 let tcldokey =
   let open Pptactic in
-  let prods = [ TacTerm "do"; mk_non_term wit_ssrdoarg (Names.Id.of_string "arg") ] in
+  let prods = [ TacTerm (CAst.make "do"); mk_non_term wit_ssrdoarg (Names.Id.of_string "arg") ] in
   let tac = begin fun args ist -> match args with
     | [arg] ->
       let arg = cast_arg wit_ssrdoarg arg in

--- a/test-suite/Datatypes.ml
+++ b/test-suite/Datatypes.ml
@@ -1,0 +1,4 @@
+
+type nat =
+| O
+| S of nat

--- a/test-suite/Datatypes.mli
+++ b/test-suite/Datatypes.mli
@@ -1,0 +1,4 @@
+
+type nat =
+| O
+| S of nat

--- a/test-suite/coqdoc/bug5648.html.out
+++ b/test-suite/coqdoc/bug5648.html.out
@@ -19,9 +19,12 @@
 <h1 class="libtitle">Library Coqdoc.bug5648</h1>
 
 <div class="code">
-<span class="id" title="keyword">Lemma</span> <a id="a" class="idref" href="#a"><span class="id" title="lemma">a</span></a> : <a class="idref" href="http://coq.inria.fr/stdlib/Coq.Init.Logic.html#True"><span class="id" title="inductive">True</span></a>.<br/>
+<span class="id" title="keyword">Ltac</span> <a name="f"><span class="id" title="tactic">f</span></a> <span class="id" title="var">tac</span> := <span class="id" title="var">tac</span>.<br/>
+<span class="id" title="keyword">Lemma</span> <a name="a"><span class="id" title="lemma">a</span></a> : <a class="idref" href="http://coq.inria.fr/stdlib/Coq.Init.Logic.html#True"><span class="id" title="inductive">True</span></a> <a class="idref" href="http://coq.inria.fr/stdlib/Coq.Init.Logic.html#ba2b0e492d2b4675a0acf3ea92aabadd"><span class="id" title="notation">∧</span></a> <a class="idref" href="http://coq.inria.fr/stdlib/Coq.Init.Logic.html#True"><span class="id" title="inductive">True</span></a>.<br/>
 <span class="id" title="keyword">Proof</span>.<br/>
-<span class="id" title="tactic">auto</span>.<br/>
+<span class="id" title="tactic">split</span>.<br/>
+- <span class="id" title="tactic">auto</span>.<br/>
+- <a class="idref" href="Coqdoc.bug5648.html#f"><span class="id" title="tactic">f</span></a> <span class="id" title="tactic">auto</span>.<br/>
 <span class="id" title="keyword">Qed</span>.<br/>
 
 <br/>

--- a/test-suite/coqdoc/bug5648.tex.out
+++ b/test-suite/coqdoc/bug5648.tex.out
@@ -20,11 +20,17 @@
 
 \begin{coqdoccode}
 \coqdocnoindent
-\coqdockw{Lemma} \coqdef{Coqdoc.bug5648.a}{a}{\coqdoclemma{a}} : \coqexternalref{True}{http://coq.inria.fr/stdlib/Coq.Init.Logic}{\coqdocinductive{True}}.\coqdoceol
+\coqdockw{Ltac} \coqdef{Coqdoc.bug5648.f}{f}{\coqdoctactic{f}} \coqdocvar{tac} := \coqdocvar{tac}.\coqdoceol
+\coqdocnoindent
+\coqdockw{Lemma} \coqdef{Coqdoc.bug5648.a}{a}{\coqdoclemma{a}} : \coqexternalref{True}{http://coq.inria.fr/stdlib/Coq.Init.Logic}{\coqdocinductive{True}} \coqexternalref{::type scope:x '/x5C' x}{http://coq.inria.fr/stdlib/Coq.Init.Logic}{\coqdocnotation{\ensuremath{\land}}} \coqexternalref{True}{http://coq.inria.fr/stdlib/Coq.Init.Logic}{\coqdocinductive{True}}.\coqdoceol
 \coqdocnoindent
 \coqdockw{Proof}.\coqdoceol
 \coqdocnoindent
-\coqdoctac{auto}.\coqdoceol
+\coqdoctac{split}.\coqdoceol
+\coqdocnoindent
+- \coqdoctac{auto}.\coqdoceol
+\coqdocnoindent
+- \coqref{Coqdoc.bug5648.f}{\coqdoctactic{f}} \coqdoctac{auto}.\coqdoceol
 \coqdocnoindent
 \coqdockw{Qed}.\coqdoceol
 \coqdocemptyline

--- a/test-suite/coqdoc/bug5648.v
+++ b/test-suite/coqdoc/bug5648.v
@@ -1,6 +1,9 @@
-Lemma a : True.
+Ltac f tac := tac.
+Lemma a : True /\ True.
 Proof.
-auto.
+split.
+- auto.
+- f auto.
 Qed.
 
 Variant t :=

--- a/tools/coqdoc/coqdoc.css
+++ b/tools/coqdoc/coqdoc.css
@@ -199,6 +199,10 @@ tr.infrulemiddle hr {
     color: rgb(0%,40%,0%);
 }
 
+.id[title="tactic"] {
+    color: rgb(0%,40%,0%);
+}
+
 .id[title="inductive"] {
     color: rgb(0%,0%,80%);
 }

--- a/tools/coqdoc/coqdoc.sty
+++ b/tools/coqdoc/coqdoc.sty
@@ -85,6 +85,7 @@
 \newcommand{\coqdocsection}[1]{\coqdoccst{#1}}
 \newcommand{\coqdocaxiom}[1]{\coqdocax{#1}}
 \newcommand{\coqdocmodule}[1]{\coqdocmod{#1}}
+\newcommand{\coqdoctactic}[1]{\coqdoccst{#1}}
 
 % Environment encompassing code fragments
 % !!! CAUTION: This environment may have empty contents


### PR DESCRIPTION
**Kind:** feature 

`coqdoc` has already support for an index of tactics but `coqc` was not giving information about tactic in the `glob` file. This PR does the following:
- add locations for definitions, notations and references to tactics in coqdoc (I can do it for `Ltac2` too if @ppedrot ok)
- add up-to-now missing locations to global references in Ltac definitions
- add a "tactic" style in the default css file (I used the same light green like for definitions, any suggestions??)

Various further extensions could be imagined...

- [ ] Support for Ltac redefinitions (one would need to generate a unique link for each redefinitions...)
- [ ] Support for Ltac2
- [ ] Entry added in the changelog