### PR TITLE
Adding a Declare ML Module in empty file Ltac.v

### DIFF
--- a/dev/ci/user-overlays/12023-herbelin-master+fixing-empty-Ltac-v-file.sh
+++ b/dev/ci/user-overlays/12023-herbelin-master+fixing-empty-Ltac-v-file.sh
@@ -1,0 +1,15 @@
+if [ "$CI_PULL_REQUEST" = "12023" ] || [ "$CI_BRANCH" = "master+fixing-empty-Ltac-v-file" ]; then
+
+    fiat_crypto_CI_REF=master+fix12023-atomic-tactic-now-qualified-in-ltac-file
+    fiat_crypto_CI_GITURL=https://github.com/herbelin/fiat-crypto
+
+    mtac2_CI_REF=master+fix12023-atomic-tactic-now-qualified-in-ltac-file
+    mtac2_CI_GITURL=https://github.com/herbelin/Mtac2
+
+    metacoq_CI_REF=master+fix12023-atomic-tactic-now-qualified-in-ltac-file
+    metacoq_CI_GITURL=https://github.com/herbelin/template-coq
+
+    unimath_CI_REF=master+fix12023-atomic-tactic-now-qualified-in-ltac-file
+    unimath_CI_GITURL=https://github.com/herbelin/UniMath
+
+fi

--- a/dev/ci/user-overlays/12023-herbelin-master+fixing-empty-Ltac-v-file.sh
+++ b/dev/ci/user-overlays/12023-herbelin-master+fixing-empty-Ltac-v-file.sh
@@ -1,15 +1,15 @@
 if [ "$CI_PULL_REQUEST" = "12023" ] || [ "$CI_BRANCH" = "master+fixing-empty-Ltac-v-file" ]; then
 
-    fiat_crypto_CI_REF=master+fix12023-atomic-tactic-now-qualified-in-ltac-file
+    fiat_crypto_CI_REF=master+pr12023-atomic-tactic-now-qualified-in-ltac-file
     fiat_crypto_CI_GITURL=https://github.com/herbelin/fiat-crypto
 
-    mtac2_CI_REF=master+fix12023-atomic-tactic-now-qualified-in-ltac-file
+    mtac2_CI_REF=master+pr12023-atomic-tactic-now-qualified-in-ltac-file
     mtac2_CI_GITURL=https://github.com/herbelin/Mtac2
 
-    metacoq_CI_REF=master+fix12023-atomic-tactic-now-qualified-in-ltac-file
+    metacoq_CI_REF=master+pr12023-atomic-tactic-now-qualified-in-ltac-file
     metacoq_CI_GITURL=https://github.com/herbelin/template-coq
 
-    unimath_CI_REF=master+fix12023-atomic-tactic-now-qualified-in-ltac-file
+    unimath_CI_REF=master+pr12023-atomic-tactic-now-qualified-in-ltac-file
     unimath_CI_GITURL=https://github.com/herbelin/UniMath
 
 fi

--- a/doc/changelog/04-tactics/12023-master+fixing-empty-Ltac-v-file.rst
+++ b/doc/changelog/04-tactics/12023-master+fixing-empty-Ltac-v-file.rst
@@ -1,0 +1,6 @@
+- **Changed:**
+  Tactics with qualified name of the form ``Coq.Init.Notations`` are
+  now qualified with prefix ``Coq.Init.Ltac``; users of the -noinit
+  option should now import Coq.Init.Ltac if they want to use Ltac
+  (`#12023 <https://github.com/coq/coq/pull/12023>`_,
+  by Hugo Herbelin; minor source of incompatibilities).

--- a/doc/stdlib/index-list.html.template
+++ b/doc/stdlib/index-list.html.template
@@ -13,6 +13,7 @@ through the <tt>Require Import</tt> command.</p>
     The core library (automatically loaded when starting Coq)
   </dt>
   <dd>
+    theories/Init/Ltac.v
     theories/Init/Notations.v
     theories/Init/Datatypes.v
     theories/Init/Logic.v

--- a/test-suite/bugs/closed/HoTT_coq_107.v
+++ b/test-suite/bugs/closed/HoTT_coq_107.v
@@ -2,6 +2,7 @@
 (* File reduced by coq-bug-finder from 4897 lines to 2605 lines, then from 2297 lines to 236 lines, then from 239 lines to 137 lines, then from 118 lines to 67 lines, then from 520 lines to 76 lines. *)
 (** Note: The bug here is the same as the #113, that is, HoTT_coq_113.v *)
 Require Import Coq.Init.Logic.
+Require Import Coq.Init.Ltac.
 Global Set Universe Polymorphism.
 Global Set Asymmetric Patterns.
 Set Implicit Arguments.

--- a/test-suite/bugs/closed/bug_3881.v
+++ b/test-suite/bugs/closed/bug_3881.v
@@ -4,6 +4,7 @@
    coqtop version cagnode15:/afs/csail.mit.edu/u/j/jgross/coq-trunk,trunk (90ed6636dea41486ddf2cc0daead83f9f0788163) *)
 Generalizable All Variables.
 Require Import Coq.Init.Notations.
+Require Import Coq.Init.Ltac.
 Reserved Notation "x -> y" (at level 99, right associativity, y at level 200).
 Notation "A -> B" := (forall (_ : A), B) : type_scope.
 Axiom admit : forall {T}, T.

--- a/test-suite/bugs/closed/bug_4527.v
+++ b/test-suite/bugs/closed/bug_4527.v
@@ -5,7 +5,7 @@ then from 269 lines to 255 lines *)
 (* coqc version 8.5 (January 2016) compiled on Jan 23 2016 16:15:22 with OCaml
 4.01.0
    coqtop version 8.5 (January 2016) *)
-Declare ML Module "ltac_plugin".
+Require Import Coq.Init.Ltac.
 Inductive False := .
 Axiom proof_admitted : False.
 Tactic Notation "admit" := case proof_admitted.

--- a/test-suite/bugs/closed/bug_4533.v
+++ b/test-suite/bugs/closed/bug_4533.v
@@ -5,7 +5,7 @@ then from 285 lines to 271 lines *)
 (* coqc version 8.5 (January 2016) compiled on Jan 23 2016 16:15:22 with OCaml
 4.01.0
    coqtop version 8.5 (January 2016) *)
-Declare ML Module "ltac_plugin".
+Require Import Coq.Init.Ltac.
 Inductive False := .
 Axiom proof_admitted : False.
 Tactic Notation "admit" := case proof_admitted.

--- a/test-suite/bugs/closed/bug_4544.v
+++ b/test-suite/bugs/closed/bug_4544.v
@@ -2,7 +2,7 @@
 (* File reduced by coq-bug-finder from original input, then from 2553 lines to 1932 lines, then from 1946 lines to 1932 lines, then from 2467 lines to 1002 lines, then from 1016 lines to 1002 lines *)
 (* coqc version 8.5 (January 2016) compiled on Jan 23 2016 16:15:22 with OCaml 4.01.0
    coqtop version 8.5 (January 2016) *)
-Declare ML Module "ltac_plugin".
+Require Import Coq.Init.Ltac.
 Inductive False := .
 Axiom proof_admitted : False.
 Tactic Notation "admit" := case proof_admitted.

--- a/test-suite/bugs/closed/bug_6661.v
+++ b/test-suite/bugs/closed/bug_6661.v
@@ -7,6 +7,7 @@
 
 
 Require Export Coq.Init.Notations.
+Require Export Coq.Init.Ltac.
 Notation "'∏'  x .. y , P" := (forall x, .. (forall y, P) ..)
   (at level 200, x binder, y binder, right associativity) : type_scope.
 Notation "'λ' x .. y , t" := (fun x => .. (fun y => t) ..)

--- a/theories/Init/Byte.v
+++ b/theories/Init/Byte.v
@@ -10,6 +10,7 @@
 
 (** * Bytes *)
 
+Require Import Coq.Init.Ltac.
 Require Import Coq.Init.Datatypes.
 Require Import Coq.Init.Logic.
 Require Import Coq.Init.Specif.

--- a/theories/Init/Datatypes.v
+++ b/theories/Init/Datatypes.v
@@ -11,6 +11,7 @@
 Set Implicit Arguments.
 
 Require Import Notations.
+Require Import Ltac.
 Require Import Logic.
 
 (********************************************************************)

--- a/theories/Init/Logic.v
+++ b/theories/Init/Logic.v
@@ -11,6 +11,7 @@
 Set Implicit Arguments.
 
 Require Export Notations.
+Require Import Ltac.
 
 Notation "A -> B" := (forall (_ : A), B) : type_scope.
 

--- a/theories/Init/Logic_Type.v
+++ b/theories/Init/Logic_Type.v
@@ -13,6 +13,7 @@
 
 Set Implicit Arguments.
 
+Require Import Ltac.
 Require Import Datatypes.
 Require Export Logic.
 

--- a/theories/Init/Ltac.v
+++ b/theories/Init/Ltac.v
@@ -1,0 +1,13 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+Declare ML Module "ltac_plugin".
+
+Export Set Default Proof Mode "Classic".

--- a/theories/Init/Notations.v
+++ b/theories/Init/Notations.v
@@ -132,6 +132,4 @@ Open Scope type_scope.
 
 (** ML Tactic Notations *)
 
-Declare ML Module "ltac_plugin".
-
-Global Set Default Proof Mode "Classic".
+Require Export Ltac.

--- a/theories/Init/Notations.v
+++ b/theories/Init/Notations.v
@@ -129,7 +129,3 @@ Bind Scope type_scope with Sortclass.
 Open Scope core_scope.
 Open Scope function_scope.
 Open Scope type_scope.
-
-(** ML Tactic Notations *)
-
-Require Export Ltac.

--- a/theories/Init/Peano.v
+++ b/theories/Init/Peano.v
@@ -26,6 +26,7 @@
  *)
 
 Require Import Notations.
+Require Import Ltac.
 Require Import Datatypes.
 Require Import Logic.
 Require Coq.Init.Nat.

--- a/theories/Init/Prelude.v
+++ b/theories/Init/Prelude.v
@@ -18,10 +18,11 @@ Require Coq.Init.Decimal.
 Require Coq.Init.Nat.
 Require Export Peano.
 Require Export Coq.Init.Wf.
+Require Export Coq.Init.Ltac.
 Require Export Coq.Init.Tactics.
 Require Export Coq.Init.Tauto.
 (* Some initially available plugins. See also:
-   - ltac_plugin (in Notations)
+   - ltac_plugin (in Ltac)
    - tauto_plugin (in Tauto).
 *)
 Declare ML Module "cc_plugin".

--- a/theories/Init/Specif.v
+++ b/theories/Init/Specif.v
@@ -14,6 +14,7 @@ Set Implicit Arguments.
 Set Reversible Pattern Implicit.
 
 Require Import Notations.
+Require Import Ltac.
 Require Import Datatypes.
 Require Import Logic.
 

--- a/theories/Init/Tactics.v
+++ b/theories/Init/Tactics.v
@@ -9,6 +9,7 @@
 (************************************************************************)
 
 Require Import Notations.
+Require Import Ltac.
 Require Import Logic.
 Require Import Specif.
 

--- a/theories/Init/Tauto.v
+++ b/theories/Init/Tauto.v
@@ -1,4 +1,17 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+(** * The tauto and intuition tactics *)
+
 Require Import Notations.
+Require Import Ltac.
 Require Import Datatypes.
 Require Import Logic.
 

--- a/theories/Init/Wf.v
+++ b/theories/Init/Wf.v
@@ -16,6 +16,7 @@
 Set Implicit Arguments.
 
 Require Import Notations.
+Require Import Ltac.
 Require Import Logic.
 Require Import Datatypes.
 


### PR DESCRIPTION
Indeed, it would be intuitive that `Require Import Ltac` is parallel to `Require Import Ltac2.Ltac2` for `Ltac`??

Also declaring the classic proof mode.

**Kind:** bug fix

Overlays: 
- mit-plv/fiat-crypto#759 (merged)
- Mtac2/Mtac2#263 (backwards-incompatible)
- MetaCoq/metacoq#402 (backwards-incompatible)
- UniMath/UniMath#1317 (backwards-incompatible)

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #10746

- [ ] Entry added in the changelog (not needed?)
