### PR TITLE
Fixes for LaTeX/html export of standard library in coqdoc

### DIFF
--- a/doc/stdlib/Library.tex
+++ b/doc/stdlib/Library.tex
@@ -5,6 +5,7 @@
 \usepackage[T1]{fontenc}
 \usepackage{fullpage}
 \usepackage{amsfonts}
+\usepackage{amssymb}
 \usepackage{url}
 \usepackage[color]{../../coqdoc}
 

--- a/theories/extraction/ExtrOCamlFloats.v
+++ b/theories/extraction/ExtrOCamlFloats.v
@@ -14,10 +14,10 @@ Note: the extraction of primitive floats relies on Coq's internal file
 kernel/float64.ml, so make sure the corresponding binary is available
 when linking the extracted OCaml code.
 
-For example, if you build a (_CoqProject + coq_makefile)-based project
+For example, if you build a ("_CoqProject" + coq_makefile)-based project
 and if you created an empty subfolder "extracted" and a file "test.v"
 containing [Cd "extracted". Separate Extraction function_to_extract.],
-you will just need to add in the _CoqProject: [test.v], [-I extracted]
+you will just need to add in the "_CoqProject" file: [test.v], [-I extracted]
 and the list of [extracted/*.ml] and [extracted/*.mli] files, then add
 [CAMLFLAGS += -w -33] in the Makefile.local file.  *)
 

--- a/tools/coqdoc/cpretty.mll
+++ b/tools/coqdoc/cpretty.mll
@@ -284,7 +284,7 @@ let identifier =
 (* This misses unicode stuff, and it adds "[" and "]".  It's only an
    approximation of idents - used for detecting whether an underscore
    is part of an identifier or meant to indicate emphasis *)
-let nonidentchar = [^ 'A'-'Z' 'a'-'z' '_' '[' ']' '\'' '0'-'9' '@' ]
+let nonidentchar = [^ 'A'-'Z' 'a'-'z' '_' '[' ']' '\'' '0'-'9' '@' '\"' '\'' '`']
 
 let printing_token = [^ ' ' '\t']*
 


### PR DESCRIPTION
**Kind:** bug fix

This partially fixes the compilation of the stdlib in pdf format:
- we slightly constrain the rule for emphasis in coqdoc: a `_` following a `"`, `'` or `` ` `` is not considered to be starting emphasis
- this allows to support e.g. `"_CoqProject"` in a comment (as it happened in `ExtrOCamlFloats.v`)
- we add package `amssymb` in the LaTeX prelude to support the new notation for apartness ≶ in `Reals`

There remain problems: some files use Unicode subscript which are told to be turned into `$_...$` in LaTeX. But doing this would require to write a translation for all possible unicode subscripts, which may require some time.

- [ ] Added / updated test-suite
- [X] Corresponding documentation was added / updated
- [ ] Entry added in the changelog (to do?)

Putting 8.12 because the small change for detecting emphasis in coqdoc is maybe too much.

@Zimmi48: I added a label for `coqdoc` as it seems enough specific. I hope it is ok (or will it break too much the usage?).