### PR TITLE
coqdoc: Report location of mismatched '[['

### DIFF
--- a/doc/changelog/08-tools/12037-coqdoc-preformatted.rst
+++ b/doc/changelog/08-tools/12037-coqdoc-preformatted.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  ``coqdoc`` now reports the location of a mismatched opening ``[[`` instead of
+  throwing an uninformative exception.
+  (`#12037 <https://github.com/coq/coq/pull/12037>`_,
+  fixes `#9670 <https://github.com/coq/coq/issues/9670>`_,
+  by Lysxia).


### PR DESCRIPTION
**Kind:** bug fix

Fixes #9670 

<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [ ] Added / updated test-suite
<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [ ] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).

I think we can also allow `]] *)` so that case would no longer be an error, but I have to think more about what `body` really does.