### PR TITLE
Fix documentation of Print Libraries following #10476.

### DIFF
--- a/doc/sphinx/proof-engine/vernacular-commands.rst
+++ b/doc/sphinx/proof-engine/vernacular-commands.rst
@@ -668,9 +668,7 @@ file is a particular case of module called *library file*.
 .. cmd:: Print Libraries
 
    This command displays the list of library files loaded in the
-   current |Coq| session. For each of these libraries, it also tells if it
-   is imported.
-
+   current |Coq| session.
 
 .. cmd:: Declare ML Module {+ @string }
 


### PR DESCRIPTION
Up to 8.10, the output was:

```
Loaded and imported library files: 
  Coq.Init.Notations
  Coq.Init.Logic
  Coq.Init.Logic_Type
  Coq.Init.Datatypes
  Coq.Init.Specif
  Coq.Init.Peano
  Coq.Init.Wf
  Coq.Init.Tactics
  Coq.Init.Tauto
  Coq.Init.Prelude

Loaded and not imported library files: 
  Coq.Init.Decimal
  Coq.Init.Nat
  Coq.Init.Byte
```

Since 8.11, the output is:
```
Loaded library files: 
  Coq.Init.Notations
  Coq.Init.Logic
  Coq.Init.Datatypes
  Coq.Init.Logic_Type
  Coq.Init.Specif
  Coq.Init.Decimal
  Coq.Init.Nat
  Coq.Init.Byte
  Coq.Init.Peano
  Coq.Init.Wf
  Coq.Init.Tactics
  Coq.Init.Tauto
  Coq.Init.Prelude
```