### PR TITLE
Add changelog for #12044

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -65,6 +65,7 @@ Huang Guan-Shieng <huang@gforge>                   huang <huang@85f007b7-540e-04
 Hugo Herbelin <Hugo.Herbelin@inria.fr>             herbelin <herbelin@85f007b7-540e-0410-9357-904b9bb8a0f7>
 Jasper Hugunin <jasperh@cs.washington.edu>         Jasper Hugunin <jasper@hashplex.com>
 Tom Hutchinson <thutchin@gforge>                   thutchin <thutchin@85f007b7-540e-0410-9357-904b9bb8a0f7>
+Ilya <ilya@localhost.localdomain>                  ilya <ilya@localhost.localdomain>
 Cezary Kaliszyk <cek@gforge>                       cek <cek@85f007b7-540e-0410-9357-904b9bb8a0f7>
 Florent Kirchner <fkirchne@gforge>                 fkirchne <fkirchne@85f007b7-540e-0410-9357-904b9bb8a0f7>
 Florent Kirchner <fkirchne@gforge>                 kirchner <kirchner@85f007b7-540e-0410-9357-904b9bb8a0f7>

--- a/doc/changelog/10-standard-library/12044-fix-string-as-ot.rst
+++ b/doc/changelog/10-standard-library/12044-fix-string-as-ot.rst
@@ -1,0 +1,10 @@
+- **Added:**
+  The library ``Coq.Structures.OrderedTypeEx`` now contains
+  :g:`Ascii_as_OT` demonstrating that the :g:`ascii` type is a
+  :g:`UsualOrderedType` (`#12044
+  <https://github.com/coq/coq/pull/12044>`_, by Ilya).
+- **Changed:**
+  The definition :g:`String_as_OT.compare` in
+  ``Coq.Structures.OrderedTypeEx`` now has better computational
+  behavior (fixes `#12015 <https://github.com/coq/coq/issues/12015>`_,
+  `#12044 <https://github.com/coq/coq/pull/12044>`_, by Ilya).


### PR DESCRIPTION
This adds a changelog entry for #12044.  I've also added the username from the commit to .mailmap; @formalize, let me know if you want to have your commits and contributions associated to any name other than `Ilya` (e.g., most people also include their last name), or to any email address other than `ilya@localhost.localdomain`.