### PR TITLE
CoqIDE: Disable client-side decoration on Windows

### DIFF
--- a/doc/changelog/09-coqide/12060-ide-disable-csd.rst
+++ b/doc/changelog/09-coqide/12060-ide-disable-csd.rst
@@ -1,0 +1,6 @@
+- **Changed:**
+  CoqIDE now uses native window frames by default on Windows.
+  The GTK window frames can be restored by setting the `GTK_CSD` environment variable to `1`
+  (`#12060 <https://github.com/coq/coq/pull/12060>`_,
+  fixes `#11080 <https://github.com/coq/coq/issues/11080>`_,
+  by Attila Gáspár).

--- a/ide/coqide_WIN32.ml.in
+++ b/ide/coqide_WIN32.ml.in
@@ -44,6 +44,7 @@ let () =
   Coq.gio_channel_of_descr_socket := Glib.Io.channel_of_descr_socket;
   set_win32_path ();
   Coq.interrupter := win32_interrupt;
-  reroute_stdout_stderr ()
+  reroute_stdout_stderr ();
+  try ignore (Unix.getenv "GTK_CSD") with Not_found -> Unix.putenv "GTK_CSD" "0"
 
 let init () = ()


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** bug fix

Since GTK does not seem to provide an API, setting the `GTK_CSD` environment variable is the only way to disable CSD.

([Relevant GTK code](https://gitlab.gnome.org/GNOME/gtk/-/blob/f9decb0cd61f7102af6b5d1f70493bfe6dacb3d1/gtk/gtkwindow.c#L6099))

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #11080


<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [x] Entry added in the changelog
