### PR TITLE
Fixes #11808: support for test-suite in -byte-only mode

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -269,10 +269,6 @@ OPT:=
 BESTOBJ:=.cmo
 BESTLIB:=.cma
 BESTDYN:=.cma
-
-# needed while booting if non -local
-CAML_LD_LIBRARY_PATH := $(PWD)/kernel/byterun:$(CAML_LD_LIBRARY_PATH)
-export CAML_LD_LIBRARY_PATH
 endif
 
 define bestobj

--- a/configure.ml
+++ b/configure.ml
@@ -983,7 +983,7 @@ let config_runtime () =
     ["-dllib";"-lcoqrun";"-dllpath";("\"" ^ coqtop ^ "/kernel/byterun\"")]
   | _ ->
     let ld="CAML_LD_LIBRARY_PATH" in
-    build_loadpath := sprintf "export %s:='%s/kernel/byterun':$(%s)" ld coqtop ld;
+    build_loadpath := sprintf "export %s:=%s/kernel/byterun:$(%s)" ld coqtop ld;
     ["-dllib";"-lcoqrun";"-dllpath";coqlib/"kernel/byterun"]
 
 let vmbyteflags = config_runtime ()

--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -62,6 +62,10 @@ coqtopbyte := $(BIN)coqtop.byte -q
 coqc_interactive := $(coqc) -test-mode -async-proofs-cache force
 coqdep := $(BIN)coqdep
 
+# This is the convention for coq_makefile
+OPT=-$(BEST)
+export OPT
+
 VERBOSE?=
 SHOW := $(if $(VERBOSE),@true,@echo)
 HIDE := $(if $(VERBOSE),,@)


### PR DESCRIPTION
**Kind:** bug fix

We fix the export of `CAML_LD_LIBRARY_PATH` in `configure.ml` which was actually broken for bad reasons.

We translate the `BEST` flag into an `OPT` flag for the purpose of tests using Makefile built by `coq_makefile`.

Fixes / closes #11808

- [ ] Entry added in the changelog (not sure it is of general purpose enough)