### PR TITLE
Tweak ltac2 grammar to make doc_grammar happy

### DIFF
--- a/user-contrib/Ltac2/g_ltac2.mlg
+++ b/user-contrib/Ltac2/g_ltac2.mlg
@@ -145,10 +145,10 @@ GRAMMAR EXTEND Gram
         { CAst.make ~loc @@ CTacCse (e, bl) }
       ]
     | "4" LEFTA [ ]
-    | [ e0 = SELF; ","; el = LIST1 NEXT SEP "," ->
+    | "3" [ e0 = SELF; ","; el = LIST1 NEXT SEP "," ->
         { let el = e0 :: el in
           CAst.make ~loc @@ CTacApp (CAst.make ~loc @@ CTacCst (AbsKn (Tuple (List.length el))), el) } ]
-    | "::" RIGHTA
+    | "2" RIGHTA
       [ e1 = tac2expr; "::"; e2 = tac2expr ->
         { CAst.make ~loc @@ CTacApp (CAst.make ~loc @@ CTacCst (AbsKn (Other Tac2core.Core.c_cons)), [e1; e2]) }
       ]


### PR DESCRIPTION
For nonterminals that use levels in their definition, doc_grammar expects the "level" string is a) not empty and b) appending it to the non-terminal name gives a valid identifier for a non-terminal.

In this case, it seems cleaner and simpler to adjust the grammar than the tool.