### PR TITLE
[warnings] Be silent about the `set_tag` warning.

### DIFF
--- a/kernel/nativevalues.ml
+++ b/kernel/nativevalues.ml
@@ -96,14 +96,14 @@ let mk_accu (a : atom) : t =
     else
       let data = { data with acc_arg = x :: data.acc_arg } in
       let ans = Obj.repr (accumulate data) in
-      let () = Obj.set_tag ans accumulate_tag [@ocaml.alert "--deprecated"] in
+      let () = Obj.set_tag ans accumulate_tag [@ocaml.warning "-3"] in
       ans
   in
   let acc = { acc_atm = a; acc_arg = [] } in
   let ans = Obj.repr (accumulate acc) in
   (** FIXME: use another representation for accumulators, this causes naked
       pointers. *)
-  let () = Obj.set_tag ans accumulate_tag [@ocaml.alert "--deprecated"] in
+  let () = Obj.set_tag ans accumulate_tag [@ocaml.warning "-3"] in
   (Obj.obj ans : t)
 
 let get_accu (k : accumulator) =


### PR DESCRIPTION
This is a critical warning in terms of future compatibility but it
makes no sense to be verbose about it every build.
