### PR TITLE
Temporarily disable Windows job on Azure.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,37 +6,37 @@ variables:
   NJOBS: "2"
 
 jobs:
-- job: Windows
-  pool:
-    vmImage: 'vs2017-win2016'
+#- job: Windows
+#  pool:
+#    vmImage: 'vs2017-win2016'
 
-  steps:
-  - checkout: self
-    fetchDepth: 10
+#  steps:
+#  - checkout: self
+#    fetchDepth: 10
 
   # cygwin package list not checked for minimality
-  - script: |
-      powershell -Command "(New-Object Net.WebClient).DownloadFile('http://www.cygwin.com/setup-x86_64.exe', 'setup-x86_64.exe')"
-      SET CYGROOT=C:\cygwin64
-      SET CYGCACHE=%CYGROOT%\var\cache\setup
-      setup-x86_64.exe -qnNdO -R %CYGROOT% -l %CYGCACHE% -s %CYGMIRROR% -P rsync -P patch -P diffutils -P make -P unzip -P m4 -P findutils -P time -P wget -P curl -P git -P mingw64-x86_64-binutils,mingw64-x86_64-gcc-core,mingw64-x86_64-gcc-g++,mingw64-x86_64-pkg-config,mingw64-x86_64-windows_default_manifest -P mingw64-x86_64-headers,mingw64-x86_64-runtime,mingw64-x86_64-pthreads,mingw64-x86_64-zlib -P python3
+#  - script: |
+#      powershell -Command "(New-Object Net.WebClient).DownloadFile('http://www.cygwin.com/setup-x86_64.exe', 'setup-x86_64.exe')"
+#      SET CYGROOT=C:\cygwin64
+#      SET CYGCACHE=%CYGROOT%\var\cache\setup
+#      setup-x86_64.exe -qnNdO -R %CYGROOT% -l %CYGCACHE% -s %CYGMIRROR% -P rsync -P patch -P diffutils -P make -P unzip -P m4 -P findutils -P time -P wget -P curl -P git -P mingw64-x86_64-binutils,mingw64-x86_64-gcc-core,mingw64-x86_64-gcc-g++,mingw64-x86_64-pkg-config,mingw64-x86_64-windows_default_manifest -P mingw64-x86_64-headers,mingw64-x86_64-runtime,mingw64-x86_64-pthreads,mingw64-x86_64-zlib -P python3
 
-      SET TARGET_ARCH=x86_64-w64-mingw32
-      SET CD_MFMT=%cd:\=/%
-      SET RESULT_INSTALLDIR_CFMT=%CD_MFMT:C:/=/cygdrive/c/%
-      C:\cygwin64\bin\bash -l %cd%\dev\build\windows\configure_profile.sh
-    displayName: 'Install cygwin'
-    env:
-      CYGMIRROR: "http://mirror.easyname.at/cygwin"
+#      SET TARGET_ARCH=x86_64-w64-mingw32
+#      SET CD_MFMT=%cd:\=/%
+#      SET RESULT_INSTALLDIR_CFMT=%CD_MFMT:C:/=/cygdrive/c/%
+#      C:\cygwin64\bin\bash -l %cd%\dev\build\windows\configure_profile.sh
+#    displayName: 'Install cygwin'
+#    env:
+#      CYGMIRROR: "http://mirror.easyname.at/cygwin"
 
-  - script: C:\cygwin64\bin\bash -l %cd%\dev\ci\azure-opam.sh
-    displayName: 'Install opam'
+#  - script: C:\cygwin64\bin\bash -l %cd%\dev\ci\azure-opam.sh
+#    displayName: 'Install opam'
 
-  - script: C:\cygwin64\bin\bash -l %cd%\dev\ci\azure-build.sh
-    displayName: 'Build Coq'
+#  - script: C:\cygwin64\bin\bash -l %cd%\dev\ci\azure-build.sh
+#    displayName: 'Build Coq'
 
-  - script: C:\cygwin64\bin\bash -l %cd%\dev\ci\azure-test.sh
-    displayName: 'Test Coq'
+#  - script: C:\cygwin64\bin\bash -l %cd%\dev\ci\azure-test.sh
+#    displayName: 'Test Coq'
 
 - job: macOS
   pool:


### PR DESCRIPTION
This job is currently broken because of Dune 2.5 not being available yet on the mingw-opam-repository (cf. #11539).

Before this, it was already red most of the time because of two issues:

- Cygwin cannot be downloaded

- `Error on dynamically loaded library: .\kernel/byterun\dllbyterun_stubs.dll: The specified module could not be found" bug.`

We don't know exactly when the latter appeared.  It was missed because of the former.

The goal is to reenable Windows testing based on standard opam with no cygwin.  Hopefully, this is achievable in the next few weeks.