### PR TITLE
Adding highlighting of the target of a internal link in default coqdoc CSS

### DIFF
--- a/doc/changelog/08-tools/12091-master+coqdoc-css-target.rst
+++ b/doc/changelog/08-tools/12091-master+coqdoc-css-target.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  ``Coqdoc``: Highlighting of the exact position of the target of links
+  (`#12091 <https://github.com/coq/coq/pull/12091>`_,
+  by Hugo Herbelin).

--- a/tools/coqdoc/coqdoc.css
+++ b/tools/coqdoc/coqdoc.css
@@ -331,3 +331,8 @@ ul.doclist {
     margin-top: 0em;
     margin-bottom: 0em;
 }
+
+.code :target {
+    border: 2px solid #D4D4D4;
+    background-color: #e5eecc;
+}


### PR DESCRIPTION
**Kind:** enhancement

As indicated by @Lysxia, CSS allows to highlight the current target of a link. We add it to coqdoc, leading for instance to the following result after having clicked on `mysum`:
<img width="419" alt="coqdoc-target" src="https://user-images.githubusercontent.com/460771/79130838-e8627b00-7da7-11ea-9c0d-e444157fe4c8.png">

For the choice of exact form of highlighting, I just copied an example found on the web.

- [x] Entry added in the changelog (to do?)
