### PR TITLE
Add cardinal_Add_In to FMapFacts

### DIFF
--- a/doc/changelog/11-standard-library/12096-FMapFacts_cardinal_3.rst
+++ b/doc/changelog/11-standard-library/12096-FMapFacts_cardinal_3.rst
@@ -1,0 +1,6 @@
+- **Added:**
+  Lemma `cardinal_Add_In` says that inserting an existing key with a new
+  value doesn't change the size of a map, lemma `Add_transpose_neqkey` says
+  that unequal keys can be inserted into a map in any order
+  (`#12096 <https://github.com/coq/coq/pull/12096>`_,
+  by Isaac van Bakel and Jean-Christophe Léchenet).

--- a/theories/FSets/FMapFacts.v
+++ b/theories/FSets/FMapFacts.v
@@ -764,34 +764,19 @@ Module WProperties_fun (E:DecidableType)(M:WSfun E).
   intros.
   exists (add k2 e2 m1).
   split.
+
   easy.
+
   unfold Add; intros.
-  rewrite -> H1.
+  rewrite H1.
   destruct (E.eq_dec k1 y).
-
-  assert (~ E.eq k2 y).
-  contradict H.
-  apply E.eq_trans with (y:=y).
-  assumption. apply E.eq_sym. assumption.
-  rewrite add_neq_o by assumption.
-  rewrite add_eq_o by assumption.
-  rewrite -> H0.
-  rewrite add_eq_o by assumption.
-  reflexivity.
-
-  destruct (E.eq_dec k2 y).
-
-  rewrite add_eq_o by assumption.
-  rewrite add_neq_o by assumption.
-  rewrite add_eq_o by assumption.
-  reflexivity.
-
-  rewrite add_neq_o by assumption.
-  rewrite H0.
-  rewrite add_neq_o by assumption.
-  rewrite add_neq_o by assumption.
-  rewrite add_neq_o by assumption.
-  reflexivity.
+  - assert (~ E.eq k2 y).
+     contradict H.
+     apply E.eq_trans with (y:=y); auto.
+    now rewrite add_neq_o, add_eq_o, H0, add_eq_o by assumption.
+  - destruct (E.eq_dec k2 y).
+    + now rewrite add_eq_o, add_neq_o, add_eq_o by assumption.
+    + now rewrite add_neq_o, H0, add_neq_o, add_neq_o, add_neq_o by assumption.
   Qed.
 
   Notation eqke := (@eq_key_elt elt).
@@ -1277,81 +1262,64 @@ Module WProperties_fun (E:DecidableType)(M:WSfun E).
   apply fold_Add with (eqA:=eq); compute; auto.
   Qed.
 
-  Lemma cardinal_3 :
+  Lemma cardinal_Add_In:
     forall m m' x e, In x m -> Add x e m m' -> cardinal m' = cardinal m.
   Proof.
   intros m.
   induction m using map_induction.
+  - intros.
+    contradict H0.
+    intros [ e' He' ].
+    now apply H in He'.
 
-  intros.
-  contradict H0. intros [ e' He' ]. apply H in He'. auto.
+  - intros.
+    destruct  (E.eq_dec x x0).
+    + enough (Add x0 e0 m1 m').
+       rewrite cardinal_2 with (m:=m1) (m':=m2) (x:=x) (e:=e) by assumption.
+       rewrite cardinal_2 with (m:=m1) (m':=m') (x:=x0) (e:=e0); try assumption.
+       reflexivity.
+       contradict H.
+       now apply (In_iff m1 e1).
 
-  intros.
-  destruct  (E.eq_dec x x0).
+      intro y.
+      destruct (E.eq_dec x0 y).
+      * rewrite H2.
+        now do 2 rewrite add_eq_o by assumption.
+      * rewrite H2.
+        do 2 rewrite add_neq_o by assumption.
+        rewrite H0.
+        assert (~E.eq x y).
+         contradict n.
+         now apply E.eq_trans with (y:= x).
+        now rewrite add_neq_o by assumption.
 
-  enough (Add x0 e0 m1 m').
-  rewrite cardinal_2 with (m:=m1) (m':=m2) (x:=x) (e:=e).
-  rewrite cardinal_2 with (m:=m1) (m':=m') (x:=x0) (e:=e0).
-  reflexivity.
-  contradict H.
-  apply (In_iff m1 e1).
-  assumption.
-  assumption.
-  assumption.
-  assumption.
+    + destruct (Add_transpose_neqkey) with (k1:=x) (k2:=x0) (e1:=e) (e2:=e0) (m1:=m1) (m2:=m2) (m3:=m')
+        as [ transposed [ Add_transposed_1 Add_transposed_2 ] ]; auto.
+      rewrite cardinal_2 with (x:=x) (e:=e) (m:=transposed); try assumption.
+      rewrite cardinal_2 with (x:=x) (e:=e) (m:=m1) (m':=m2) by assumption.
+      rewrite IHm1 with (x:=x0) (e:=e0).
+      reflexivity.
 
-  intro y.
-  destruct (E.eq_dec x0 y).
-  rewrite H2.
-  do 2 rewrite add_eq_o by assumption.
-  reflexivity.
+      destruct H1 as [ e' e'mapsto ].
+      exists e'.
+      apply M.add_3 with (x:=x) (e':=e).
+      assumption.
 
-  rewrite H2.
-  do 2 rewrite add_neq_o by assumption.
-  rewrite H0.
-  assert (~E.eq x y).
-  contradict n.
-  apply E.eq_trans with (y:= x). apply E.eq_sym. assumption. assumption.
-  rewrite add_neq_o by assumption.
-  reflexivity.
+      apply find_mapsto_iff.
+      rewrite <- H0 by assumption.
+      now apply find_mapsto_iff.
+      assumption.
 
-  destruct (Add_transpose_neqkey) with (k1:=x) (k2:=x0) (e1:=e) (e2:=e0) (m1:=m1) (m2:=m2) (m3:=m') as [ transposed [ Add_transposed_1 Add_transposed_2 ] ].
-  assumption.
-  assumption.
-  assumption.
-
-  rewrite cardinal_2 with (x:=x) (e:=e) (m:=transposed).
-  rewrite cardinal_2 with (x:=x) (e:=e) (m:=m1) (m':=m2).
-  rewrite IHm1 with (x:=x0) (e:=e0).
-  reflexivity.
-
-  destruct H1 as [ e' e'mapsto ].
-  exists e'.
-  apply M.add_3 with (x:=x) (e':=e).
-  assumption.
-  apply find_mapsto_iff.
-  rewrite <- H0.
-  apply find_mapsto_iff.
-  assumption.
-
-  assumption.
-  assumption.
-  assumption.
-
-  contradict n.
-  assert (In x (add x0 e0 m1)).
-  destruct n as [ e' e'mapsto ].
-  exists e'.
-  apply find_mapsto_iff.
-  rewrite <- Add_transposed_1.
-  apply find_mapsto_iff.
-  assumption.
-  apply add_in_iff in H3.
-  destruct H3.
-  apply E.eq_sym; assumption.
-  contradiction.
-
-  assumption.
+      contradict n.
+      assert (In x (add x0 e0 m1)).
+       destruct n as [ e' e'mapsto ].
+       exists e'.
+       apply find_mapsto_iff.
+       rewrite <- Add_transposed_1.
+       apply find_mapsto_iff.
+       assumption.
+      apply add_in_iff in H3.
+      now destruct H3.
   Qed.
 
   Lemma cardinal_inv_1 : forall m : t elt,

--- a/theories/FSets/FMapFacts.v
+++ b/theories/FSets/FMapFacts.v
@@ -1265,61 +1265,35 @@ Module WProperties_fun (E:DecidableType)(M:WSfun E).
   Lemma cardinal_Add_In:
     forall m m' x e, In x m -> Add x e m m' -> cardinal m' = cardinal m.
   Proof.
-  intros m.
-  induction m using map_induction.
-  - intros.
-    contradict H0.
-    intros [ e' He' ].
-    now apply H in He'.
-
-  - intros.
-    destruct  (E.eq_dec x x0).
-    + enough (Add x0 e0 m1 m').
-       rewrite cardinal_2 with (m:=m1) (m':=m2) (x:=x) (e:=e) by assumption.
-       rewrite cardinal_2 with (m:=m1) (m':=m') (x:=x0) (e:=e0); try assumption.
-       reflexivity.
-       contradict H.
-       now apply (In_iff m1 e1).
-
-      intro y.
-      destruct (E.eq_dec x0 y).
-      * rewrite H2.
-        now do 2 rewrite add_eq_o by assumption.
-      * rewrite H2.
-        do 2 rewrite add_neq_o by assumption.
-        rewrite H0.
-        assert (~E.eq x y).
-         contradict n.
-         now apply E.eq_trans with (y:= x).
-        now rewrite add_neq_o by assumption.
-
-    + destruct (Add_transpose_neqkey) with (k1:=x) (k2:=x0) (e1:=e) (e2:=e0) (m1:=m1) (m2:=m2) (m3:=m')
-        as [ transposed [ Add_transposed_1 Add_transposed_2 ] ]; auto.
-      rewrite cardinal_2 with (x:=x) (e:=e) (m:=transposed); try assumption.
-      rewrite cardinal_2 with (x:=x) (e:=e) (m:=m1) (m':=m2) by assumption.
-      rewrite IHm1 with (x:=x0) (e:=e0).
-      reflexivity.
-
-      destruct H1 as [ e' e'mapsto ].
-      exists e'.
-      apply M.add_3 with (x:=x) (e':=e).
-      assumption.
-
-      apply find_mapsto_iff.
-      rewrite <- H0 by assumption.
-      now apply find_mapsto_iff.
-      assumption.
-
-      contradict n.
-      assert (In x (add x0 e0 m1)).
-       destruct n as [ e' e'mapsto ].
-       exists e'.
-       apply find_mapsto_iff.
-       rewrite <- Add_transposed_1.
-       apply find_mapsto_iff.
-       assumption.
-      apply add_in_iff in H3.
-      now destruct H3.
+  assert (forall k e m, MapsTo k e m -> Add k e (remove k m) m) as remove_In_Add.
+  { intros. unfold Add.
+    intros.
+    rewrite F.add_o.
+    destruct (F.eq_dec k y).
+    - apply find_1. rewrite <-MapsTo_m; [exact H|assumption|reflexivity|reflexivity].
+    - rewrite F.remove_neq_o by assumption. reflexivity.
+  }
+  intros.
+  assert (Equal (remove x m) (remove x m')).
+  { intros y. rewrite 2!F.remove_o.
+    destruct (F.eq_dec x y). reflexivity.
+    unfold Add in H0. rewrite H0.
+    rewrite F.add_neq_o by assumption. reflexivity.
+  }
+  apply Equal_cardinal in H1.
+  rewrite 2!cardinal_fold.
+  destruct H as (e' & H).
+  rewrite fold_Add with (eqA:=eq) (m1:=remove x m) (m2:=m) (k:=x) (e:=e');
+  try now (compute; auto).
+  rewrite fold_Add with (eqA:=eq) (m1:=remove x m') (m2:=m') (k:=x) (e:=e);
+  try now (compute; auto).
+  rewrite <- 2!cardinal_fold. congruence.
+  apply remove_1. reflexivity.
+  apply remove_In_Add.
+  apply find_2. unfold Add in H0. rewrite H0.
+  rewrite F.add_eq_o; reflexivity.
+  apply remove_1. reflexivity.
+  apply remove_In_Add. assumption.
   Qed.
 
   Lemma cardinal_inv_1 : forall m : t elt,

--- a/theories/FSets/FMapFacts.v
+++ b/theories/FSets/FMapFacts.v
@@ -757,6 +757,43 @@ Module WProperties_fun (E:DecidableType)(M:WSfun E).
 
   Definition Add x (e:elt) m m' := forall y, find y m' = find y (add x e m).
 
+  Lemma Add_transpose_neqkey : forall k1 k2 e1 e2 m1 m2 m3,
+    ~ E.eq k1 k2 -> Add k1 e1 m1 m2 -> Add k2 e2 m2 m3 ->
+    { m | Add k2 e2 m1 m /\ Add k1 e1 m m3 }.
+  Proof.
+  intros.
+  exists (add k2 e2 m1).
+  split.
+  easy.
+  unfold Add; intros.
+  rewrite -> H1.
+  destruct (E.eq_dec k1 y).
+
+  assert (~ E.eq k2 y).
+  contradict H.
+  apply E.eq_trans with (y:=y).
+  assumption. apply E.eq_sym. assumption.
+  rewrite add_neq_o by assumption.
+  rewrite add_eq_o by assumption.
+  rewrite -> H0.
+  rewrite add_eq_o by assumption.
+  reflexivity.
+
+  destruct (E.eq_dec k2 y).
+
+  rewrite add_eq_o by assumption.
+  rewrite add_neq_o by assumption.
+  rewrite add_eq_o by assumption.
+  reflexivity.
+
+  rewrite add_neq_o by assumption.
+  rewrite H0.
+  rewrite add_neq_o by assumption.
+  rewrite add_neq_o by assumption.
+  rewrite add_neq_o by assumption.
+  reflexivity.
+  Qed.
+
   Notation eqke := (@eq_key_elt elt).
   Notation eqk := (@eq_key elt).
 
@@ -1238,6 +1275,83 @@ Module WProperties_fun (E:DecidableType)(M:WSfun E).
   intros; do 2 rewrite cardinal_fold.
   change S with ((fun _ _ => S) x e).
   apply fold_Add with (eqA:=eq); compute; auto.
+  Qed.
+
+  Lemma cardinal_3 :
+    forall m m' x e, In x m -> Add x e m m' -> cardinal m' = cardinal m.
+  Proof.
+  intros m.
+  induction m using map_induction.
+
+  intros.
+  contradict H0. intros [ e' He' ]. apply H in He'. auto.
+
+  intros.
+  destruct  (E.eq_dec x x0).
+
+  enough (Add x0 e0 m1 m').
+  rewrite cardinal_2 with (m:=m1) (m':=m2) (x:=x) (e:=e).
+  rewrite cardinal_2 with (m:=m1) (m':=m') (x:=x0) (e:=e0).
+  reflexivity.
+  contradict H.
+  apply (In_iff m1 e1).
+  assumption.
+  assumption.
+  assumption.
+  assumption.
+
+  intro y.
+  destruct (E.eq_dec x0 y).
+  rewrite H2.
+  do 2 rewrite add_eq_o by assumption.
+  reflexivity.
+
+  rewrite H2.
+  do 2 rewrite add_neq_o by assumption.
+  rewrite H0.
+  assert (~E.eq x y).
+  contradict n.
+  apply E.eq_trans with (y:= x). apply E.eq_sym. assumption. assumption.
+  rewrite add_neq_o by assumption.
+  reflexivity.
+
+  destruct (Add_transpose_neqkey) with (k1:=x) (k2:=x0) (e1:=e) (e2:=e0) (m1:=m1) (m2:=m2) (m3:=m') as [ transposed [ Add_transposed_1 Add_transposed_2 ] ].
+  assumption.
+  assumption.
+  assumption.
+
+  rewrite cardinal_2 with (x:=x) (e:=e) (m:=transposed).
+  rewrite cardinal_2 with (x:=x) (e:=e) (m:=m1) (m':=m2).
+  rewrite IHm1 with (x:=x0) (e:=e0).
+  reflexivity.
+
+  destruct H1 as [ e' e'mapsto ].
+  exists e'.
+  apply M.add_3 with (x:=x) (e':=e).
+  assumption.
+  apply find_mapsto_iff.
+  rewrite <- H0.
+  apply find_mapsto_iff.
+  assumption.
+
+  assumption.
+  assumption.
+  assumption.
+
+  contradict n.
+  assert (In x (add x0 e0 m1)).
+  destruct n as [ e' e'mapsto ].
+  exists e'.
+  apply find_mapsto_iff.
+  rewrite <- Add_transposed_1.
+  apply find_mapsto_iff.
+  assumption.
+  apply add_in_iff in H3.
+  destruct H3.
+  apply E.eq_sym; assumption.
+  contradiction.
+
+  assumption.
   Qed.
 
   Lemma cardinal_inv_1 : forall m : t elt,


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** feature.

- [ ] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).

cardinal_Add_In asserts that updating a key already present in a map does not change the number of keys in the map. This complements cardinal_2, which makes the similar statement for if the key is not present.

It uses a new lemma, Add_transpose_neqkey, which states that it is possible to transpose two map updates provided they are for different keys. Since of course `add x e (add y f m) <> add y f (add x e m)` necessarily, even if `x <> y`, this uses `Add` instead.

My proofs are very messy, because I am a relative Coq novice. I'll happily take advice or patches to improve them.