### PR TITLE
Fixing use of argument scopes in patterns + a further cleanup of constrintern.ml

### DIFF
--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -1759,17 +1759,12 @@ let drop_notations_pattern (test_kind_top,test_kind_inner) genv env pat =
           | None -> Loc.raise ?loc (InternalizationError (NotAConstructor head))
       end
     | CPatCstr (qid, Some expl_pl, pl) ->
-      let g =
-        try Nametab.locate qid
-        with Not_found as exn ->
-          let _, info = Exninfo.capture exn in
-          let info = Option.cata (Loc.add_loc info) info loc in
-          Exninfo.iraise (InternalizationError (NotAConstructor qid), info)
-      in
-      (* Convention: (@r expl_pl) deactivates implicit arguments in expl_pl and in pl *)
-      (* but not scopes in expl_pl *)
-      let (argscs1,_) = find_remaining_scopes expl_pl pl g in
-      DAst.make ?loc @@ RCPatCstr (g, List.map2 (in_pat_sc scopes) argscs1 expl_pl @ List.map (in_pat test_kind_inner scopes) pl, [])
+      begin
+        match drop_syndef test_kind scopes qid expl_pl with
+        | None -> Loc.raise ?loc (InternalizationError (NotAConstructor qid))
+        | Some (g,syndef_pl,extra_expl_pl) ->
+          DAst.make ?loc @@ RCPatCstr (g, syndef_pl @ extra_expl_pl @ List.map (in_pat test_kind_inner scopes) pl, [])
+      end
     | CPatNotation (_,(InConstrEntry,"- _"),([a],[]),[]) when is_non_zero_pat a ->
       let p = match a.CAst.v with CPatPrim (Number (_, p)) -> p | _ -> assert false in
       let pat, _df = Notation.interp_prim_token_cases_pattern_expr ?loc (ensure_kind test_kind_inner) (Number (SMinus,p)) scopes in

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -1822,8 +1822,8 @@ let drop_notations_pattern (test_kind_top,test_kind_inner) genv env pat =
       DAst.make ?loc @@ RCPatCstr (g, [], List.map2 (in_pat_sc scopes) argscs args)
     | NApp (NRef g,pl) ->
       ensure_kind test_kind ?loc g;
-      let (argscs1,argscs2) = find_remaining_scopes pl args g in
-      let pl = List.map2 (fun x -> in_not test_kind_inner loc (x,snd scopes) fullsubst []) argscs1 pl in
+      let (_,argscs2) = find_remaining_scopes pl args g in
+      let pl = List.map (in_not test_kind_inner loc scopes fullsubst []) pl in
       let pl = add_local_defs_and_check_length loc genv g pl args in
       let args = List.map2 (fun x -> in_pat test_kind_inner (x,snd scopes)) argscs2 args in
       let pat =

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -1426,8 +1426,8 @@ let check_has_letin ?loc g expanded nargs nimps tags =
   else if nargs = expected_ndecls then true else
     let env = Global.env() in
     match g with
-    | GlobRef.ConstructRef cstr -> error_wrong_numarg_constructor ?loc env cstr expanded nargs expected_nassums expected_ndecls
-    | GlobRef.IndRef ind -> error_wrong_numarg_inductive ?loc env ind expanded nargs expected_nassums expected_ndecls
+    | GlobRef.ConstructRef cstr -> error_wrong_numarg_constructor ?loc env ~cstr ~expanded ~nargs ~expected_nassums ~expected_ndecls
+    | GlobRef.IndRef ind -> error_wrong_numarg_inductive ?loc env ~ind ~expanded ~nargs ~expected_nassums ~expected_ndecls
     | _ -> assert false
 
 (** Do not raise NotEnoughArguments thanks to preconditions*)

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -265,9 +265,9 @@ type pattern_intern_env = {
 (* Remembering the parsing scope of variables in notations            *)
 
 let make_current_scope tmp scopes = match tmp, scopes with
-| Some tmp_scope, (sc :: _) when String.equal sc tmp_scope -> scopes
-| Some tmp_scope, scopes -> tmp_scope :: scopes
-| None, scopes -> scopes
+  | Some tmp_scope, (sc :: _) when String.equal sc tmp_scope -> scopes
+  | Some tmp_scope, scopes -> tmp_scope :: scopes
+  | None, scopes -> scopes
 
 let pr_scope_stack = function
   | [] -> str "the empty scope stack"
@@ -724,9 +724,9 @@ let set_type ty1 ty2 =
     user_err ?loc:t2.CAst.loc Pp.(str "Unexpected type constraint in notation already providing a type constraint.")
 
 let traverse_binder intern_pat ntnvars (terms,_,binders,_ as subst) avoid (renaming,env) na ty =
- match na with
- | Anonymous -> (renaming,env), None, Anonymous, Explicit, set_type ty None
- | Name id ->
+  match na with
+  | Anonymous -> (renaming,env), None, Anonymous, Explicit, set_type ty None
+  | Name id ->
   let store,get = set_temporary_memory () in
   let test_kind = test_kind_tolerant in
   try
@@ -766,10 +766,10 @@ let traverse_binder intern_pat ntnvars (terms,_,binders,_ as subst) avoid (renam
     (renaming',env), None, Name id', Explicit, set_type ty None
 
 type binder_action =
-| AddLetIn of lname * constr_expr * constr_expr option
-| AddTermIter of (constr_expr * subscopes) Names.Id.Map.t
-| AddPreBinderIter of Id.t * local_binder_expr (* A binder to be internalized *)
-| AddBinderIter of Id.t * extended_glob_local_binder (* A binder already internalized - used for generalized binders *)
+  | AddLetIn of lname * constr_expr * constr_expr option
+  | AddTermIter of (constr_expr * subscopes) Names.Id.Map.t
+  | AddPreBinderIter of Id.t * local_binder_expr (* A binder to be internalized *)
+  | AddBinderIter of Id.t * extended_glob_local_binder (* A binder already internalized - used for generalized binders *)
 
 let dmap_with_loc f n =
   CAst.map_with_loc (fun ?loc c -> f ?loc (DAst.get_thunk c)) n
@@ -1051,10 +1051,10 @@ let string_of_ty = function
   | Variable -> "var"
 
 let gvar (loc, id) us = match us with
-| None | Some [] -> DAst.make ?loc @@ GVar id
-| Some _ ->
-  user_err ?loc  (str "Variable " ++ Id.print id ++
-    str " cannot have a universe instance")
+  | None | Some [] -> DAst.make ?loc @@ GVar id
+  | Some _ ->
+    user_err ?loc  (str "Variable " ++ Id.print id ++
+      str " cannot have a universe instance")
 
 let intern_var env (ltacvars,ntnvars) namedctx loc id us =
   (* Is [id] a notation variable *)
@@ -1300,32 +1300,31 @@ let intern_applied_reference ~isproj intern env namedctx (_, ntnvars as lvar) us
   let loc = qid.CAst.loc in
   let us = intern_instance ~local_univs:env.local_univs us in
   if qualid_is_ident qid then
-      try
-        let res = intern_var env lvar namedctx loc (qualid_basename qid) us in
-        check_applied_projection isproj None qid;
-        res, args
-      with Not_found ->
-      try
-        let r, realref, args2 = intern_qualid ~no_secvar:true qid intern env ntnvars us args in
-        check_applied_projection isproj realref qid;
-        r, args2
-      with Not_found as exn ->
-        (* Extra allowance for non globalizing functions *)
-        if !interning_grammar || env.unb then
-          (* check_applied_projection ?? *)
-          gvar (loc,qualid_basename qid) us, args
-        else
-          let _, info = Exninfo.capture exn in
-          Nametab.error_global_not_found ~info qid
-  else
-    let r,realref,args2 =
-      try intern_qualid qid intern env ntnvars us args
-      with Not_found as exn ->
+    try
+      let res = intern_var env lvar namedctx loc (qualid_basename qid) us in
+      check_applied_projection isproj None qid;
+      res, args
+    with Not_found ->
+    try
+      let res, realref, args2 = intern_qualid ~no_secvar:true qid intern env ntnvars us args in
+      check_applied_projection isproj realref qid;
+      res, args2
+    with Not_found as exn ->
+      (* Extra allowance for non globalizing functions *)
+      if !interning_grammar || env.unb then
+        (* check_applied_projection ?? *)
+        gvar (loc,qualid_basename qid) us, args
+      else
         let _, info = Exninfo.capture exn in
         Nametab.error_global_not_found ~info qid
-    in
-    check_applied_projection isproj realref qid;
-    r, args2
+  else
+    try
+      let res, realref, args2 = intern_qualid qid intern env ntnvars us args in
+      check_applied_projection isproj realref qid;
+      res, args2
+    with Not_found as exn ->
+        let _, info = Exninfo.capture exn in
+        Nametab.error_global_not_found ~info qid
 
 let interp_reference vars r =
   let r,_ =
@@ -1562,8 +1561,8 @@ let merge_aliases aliases {loc;v=na} =
   { alias_ids; alias_map; }
 
 let alias_of als = match als.alias_ids with
-| [] -> Anonymous
-| {v=id} :: _ -> Name id
+  | [] -> Anonymous
+  | {v=id} :: _ -> Name id
 
 (** {6 Expanding notations }
 
@@ -1595,12 +1594,12 @@ let rec subst_pat_iterator y t = DAst.(map (function
   | RCPatOr pl -> RCPatOr (List.map (subst_pat_iterator y t) pl)))
 
 let is_non_zero c = match c with
-| { CAst.v = CPrim (Number p) } -> not (NumTok.Signed.is_zero p)
-| _ -> false
+  | { CAst.v = CPrim (Number p) } -> not (NumTok.Signed.is_zero p)
+  | _ -> false
 
 let is_non_zero_pat c = match c with
-| { CAst.v = CPatPrim (Number p) } -> not (NumTok.Signed.is_zero p)
-| _ -> false
+  | { CAst.v = CPatPrim (Number p) } -> not (NumTok.Signed.is_zero p)
+  | _ -> false
 
 let get_asymmetric_patterns = Goptions.declare_bool_option_and_ref
     ~depr:false

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -1766,14 +1766,10 @@ let drop_notations_pattern (test_kind_top,test_kind_inner) genv env pat =
           let info = Option.cata (Loc.add_loc info) info loc in
           Exninfo.iraise (InternalizationError (NotAConstructor qid), info)
       in
-      if expl_pl == [] then
-        (* Convention: (@r) deactivates all further implicit arguments and scopes *)
-        DAst.make ?loc @@ RCPatCstr (g, List.map (in_pat test_kind_inner scopes) pl, [])
-      else
-        (* Convention: (@r expl_pl) deactivates implicit arguments in expl_pl and in pl *)
-        (* but not scopes in expl_pl *)
-        let (argscs1,_) = find_remaining_scopes expl_pl pl g in
-        DAst.make ?loc @@ RCPatCstr (g, List.map2 (in_pat_sc scopes) argscs1 expl_pl @ List.map (in_pat test_kind_inner scopes) pl, [])
+      (* Convention: (@r expl_pl) deactivates implicit arguments in expl_pl and in pl *)
+      (* but not scopes in expl_pl *)
+      let (argscs1,_) = find_remaining_scopes expl_pl pl g in
+      DAst.make ?loc @@ RCPatCstr (g, List.map2 (in_pat_sc scopes) argscs1 expl_pl @ List.map (in_pat test_kind_inner scopes) pl, [])
     | CPatNotation (_,(InConstrEntry,"- _"),([a],[]),[]) when is_non_zero_pat a ->
       let p = match a.CAst.v with CPatPrim (Number (_, p)) -> p | _ -> assert false in
       let pat, _df = Notation.interp_prim_token_cases_pattern_expr ?loc (ensure_kind test_kind_inner) (Number (SMinus,p)) scopes in

--- a/pretyping/cases.mli
+++ b/pretyping/cases.mli
@@ -23,17 +23,17 @@ open Evardefine
 type pattern_matching_error =
   | BadPattern of constructor * constr
   | BadConstructor of constructor * inductive
-  | WrongNumargConstructor of constructor * int
-  | WrongNumargInductive of inductive * int
+  | WrongNumargConstructor of constructor * bool * int * int * int
+  | WrongNumargInductive of inductive * bool * int * int * int
   | UnusedClause of cases_pattern list
   | NonExhaustive of cases_pattern list
   | CannotInferPredicate of (constr * types) array
 
 exception PatternMatchingError of env * evar_map * pattern_matching_error
 
-val error_wrong_numarg_constructor : ?loc:Loc.t -> env -> constructor -> int -> 'a
+val error_wrong_numarg_constructor : ?loc:Loc.t -> env -> constructor -> bool -> int -> int -> int -> 'a
 
-val error_wrong_numarg_inductive   : ?loc:Loc.t -> env -> inductive -> int -> 'a
+val error_wrong_numarg_inductive   : ?loc:Loc.t -> env -> inductive -> bool -> int -> int -> int -> 'a
 
 val irrefutable : env -> cases_pattern -> bool
 

--- a/pretyping/cases.mli
+++ b/pretyping/cases.mli
@@ -23,17 +23,21 @@ open Evardefine
 type pattern_matching_error =
   | BadPattern of constructor * constr
   | BadConstructor of constructor * inductive
-  | WrongNumargConstructor of constructor * bool * int * int * int
-  | WrongNumargInductive of inductive * bool * int * int * int
+  | WrongNumargConstructor of
+      {cstr:constructor; expanded:bool; nargs:int; expected_nassums:int; expected_ndecls:int}
+  | WrongNumargInductive of
+      {ind:inductive; expanded:bool; nargs:int; expected_nassums:int; expected_ndecls:int}
   | UnusedClause of cases_pattern list
   | NonExhaustive of cases_pattern list
   | CannotInferPredicate of (constr * types) array
 
 exception PatternMatchingError of env * evar_map * pattern_matching_error
 
-val error_wrong_numarg_constructor : ?loc:Loc.t -> env -> constructor -> bool -> int -> int -> int -> 'a
+val error_wrong_numarg_constructor :
+  ?loc:Loc.t -> env -> cstr:constructor -> expanded:bool -> nargs:int -> expected_nassums:int -> expected_ndecls:int -> 'a
 
-val error_wrong_numarg_inductive   : ?loc:Loc.t -> env -> inductive -> bool -> int -> int -> int -> 'a
+val error_wrong_numarg_inductive :
+  ?loc:Loc.t -> env -> ind:inductive -> expanded:bool -> nargs:int -> expected_nassums:int -> expected_ndecls:int -> 'a
 
 val irrefutable : env -> cases_pattern -> bool
 

--- a/pretyping/inductiveops.ml
+++ b/pretyping/inductiveops.ml
@@ -245,6 +245,14 @@ let inductive_alldecls env (ind,u) =
 let inductive_alldecls_env env (ind,u) = inductive_alldecls env (ind,u)
 [@@ocaml.deprecated "Alias for Inductiveops.inductive_alldecls"]
 
+let inductive_alltags env ind =
+  let (mib,mip) = Inductive.lookup_mind_specif env ind in
+  Context.Rel.to_tags mip.mind_arity_ctxt
+
+let constructor_alltags env (ind,j) =
+  let (mib,mip) = Inductive.lookup_mind_specif env ind in
+  Context.Rel.to_tags (fst mip.mind_nf_lc.(j-1))
+
 let constructor_has_local_defs env (indsp,j) =
   let (mib,mip) = Inductive.lookup_mind_specif env indsp in
   let l1 = mip.mind_consnrealdecls.(j-1) + Context.Rel.length (mib.mind_params_ctxt) in

--- a/pretyping/inductiveops.mli
+++ b/pretyping/inductiveops.mli
@@ -138,6 +138,10 @@ val constructor_nrealdecls : env -> constructor -> int
 val constructor_nrealdecls_env : env -> constructor -> int
 [@@ocaml.deprecated "Alias for Inductiveops.constructor_nrealdecls"]
 
+(** @return tags of all decls: true = assumption, false = letin *)
+val inductive_alltags : env -> inductive -> bool list
+val constructor_alltags : env -> constructor -> bool list
+
 (** Is there local defs in params or args ? *)
 val constructor_has_local_defs : env -> constructor -> bool
 val inductive_has_local_defs : env -> inductive -> bool

--- a/test-suite/output/Cases.out
+++ b/test-suite/output/Cases.out
@@ -74,7 +74,9 @@ fun '{{n, m, p}} => n + m + p
 fun '(D n m p q) => n + m + p + q
      : J -> nat
 The command has indeed failed with message:
-The constructor D (in type J) expects 3 arguments.
+Once notations are expanded, the resulting constructor D (in type J) is
+expected to be applied to no arguments while it is actually applied to
+1 argument.
 lem1 = 
 fun dd : nat * nat => let (bb, cc) as aa return (aa = aa) := dd in eq_refl
      : forall k : nat * nat, k = k
@@ -181,3 +183,51 @@ end
 File "stdin", line 253, characters 4-5:
 Warning: Unused variable B catches more than one case.
 [unused-pattern-matching-variable,pattern-matching]
+The command has indeed failed with message:
+Application of arguments to a recursive notation not supported in patterns.
+The command has indeed failed with message:
+The constructor cons (in type list) is expected to be applied to 2 arguments
+while it is actually applied to 3 arguments.
+The command has indeed failed with message:
+The constructor cons (in type list) is expected to be applied to 2 arguments
+while it is actually applied to 1 argument.
+The command has indeed failed with message:
+The constructor D' (in type J') is expected to be applied to 4 arguments (or
+6 arguments when including variables for local definitions) while it is
+actually applied to 5 arguments.
+fun x : J' bool (true, true) =>
+match x with
+| D' _ _ _ m _ e => existT (fun x0 : nat => x0 = x0) m e
+end
+     : J' bool (true, true) -> {x0 : nat & x0 = x0}
+fun x : J' bool (true, true) =>
+match x with
+| @D' _ _ _ _ n _ p _ => n + p
+end
+     : J' bool (true, true) -> nat
+The command has indeed failed with message:
+Application of arguments to a recursive notation not supported in patterns.
+The command has indeed failed with message:
+The constructor cons (in type list) is expected to be applied to 2 arguments
+while it is actually applied to 3 arguments.
+The command has indeed failed with message:
+The constructor cons (in type list) is expected to be applied to 2 arguments
+while it is actually applied to 1 argument.
+The command has indeed failed with message:
+The constructor D' (in type J') is expected to be applied to 3 arguments (or
+4 arguments when including variables for local definitions) while it is
+actually applied to 2 arguments.
+The command has indeed failed with message:
+The constructor D' (in type J') is expected to be applied to 3 arguments (or
+4 arguments when including variables for local definitions) while it is
+actually applied to 5 arguments.
+fun x : J' bool (true, true) =>
+match x with
+| @D' _ _ _ _ _ m _ e => existT (fun x0 : nat => x0 = x0) m e
+end
+     : J' bool (true, true) -> {x0 : nat & x0 = x0}
+fun x : J' bool (true, true) =>
+match x with
+| @D' _ _ _ _ n _ p _ => (n, p)
+end
+     : J' bool (true, true) -> nat * nat

--- a/test-suite/output/Cases.v
+++ b/test-suite/output/Cases.v
@@ -254,3 +254,33 @@ Definition bar (f : foo) :=
   end.
 
 End Wish12762.
+
+Module ConstructorArgumentsNumber.
+
+Arguments cons {A} _ _.
+
+Inductive J' A {B} (C:=(A*B)%type) (c:C) := D' : forall n {m}, let p := n+m in m=m -> J' A c.
+
+Unset Asymmetric Patterns.
+
+Fail Check fun x => match x with (y,z) w => y+z+w end.
+Fail Check fun x => match x with cons y z w => 0 | nil => 0 end.
+Fail Check fun x => match x with cons y => 0 | nil => 0 end.
+
+(* Missing a let-in to be in let-in mode *)
+Fail Check fun x => match x with D' _ _ n p e => 0 end.
+Check fun x : J' bool (true,true) => match x with D' _ _ n e => existT (fun x => eq x x) _ e end.
+Check fun x : J' bool (true,true) => match x with D' _ _ _ n p e => n+p end.
+
+Set Asymmetric Patterns.
+
+Fail Check fun x => match x with (y,z) w => y+z+w end.
+Fail Check fun x => match x with cons y z w => 0 | nil => 0 end.
+Fail Check fun x => match x with cons y => 0 | nil => 0 end.
+
+Fail Check fun x => match x with D' n _ => 0 end.
+Fail Check fun x => match x with D' n m p e _ => 0 end.
+Check fun x : J' bool (true,true) => match x with D' n m e => existT (fun x => eq x x) m e end.
+Check fun x : J' bool (true,true) => match x with D' n m p e => (n,p) end.
+
+End ConstructorArgumentsNumber.

--- a/test-suite/output/RecordFieldErrors.out
+++ b/test-suite/output/RecordFieldErrors.out
@@ -11,4 +11,4 @@ This record defines several times the field foo.
 The command has indeed failed with message:
 This record defines several times the field unit.
 The command has indeed failed with message:
-unit: Not a projection of inductive t.
+unit: Not a projection.

--- a/test-suite/output/RecordFieldErrors.v
+++ b/test-suite/output/RecordFieldErrors.v
@@ -35,4 +35,4 @@ acceptable and seems an unlikely mistake. *)
 
 Fail Check {| foo := tt;
               unit := tt |}.
-(* unit: Not a projection of inductive t. *)
+(* unit: Not a projection. *)

--- a/test-suite/success/Case22.v
+++ b/test-suite/success/Case22.v
@@ -89,3 +89,16 @@ Check fun x:Ind bool nat =>
   match x in Ind _ X Y Z return Z with
   | y => (true,0)
   end.
+
+(* A check that multi-implicit arguments work *)
+
+Check fun x : {True}+{False} => match x with left _ _ => 0 | right _ _ => 1 end.
+Check fun x : {True}+{False} => match x with left _ => 0 | right _ => 1 end.
+
+(* Check that Asymmetric Patterns does not apply to the in clause *)
+
+Inductive expr {A} : A -> Type := intro : forall {n:nat} (a:A), n=n -> expr a.
+Check fun (x:expr true) => match x in expr n return n=n with intro _ _ => eq_refl end.
+Set Asymmetric Patterns.
+Check fun (x:expr true) => match x in expr n return n=n with intro _ a _ => eq_refl a end.
+Unset Asymmetric Patterns.

--- a/vernac/himsg.ml
+++ b/vernac/himsg.ml
@@ -1371,10 +1371,10 @@ let explain_pattern_matching_error env sigma = function
       explain_bad_pattern env sigma c t
   | BadConstructor (c,ind) ->
       explain_bad_constructor env c ind
-  | WrongNumargConstructor (c,expanded,n,n1,n2) ->
-      explain_wrong_numarg_constructor env c expanded n n1 n2
-  | WrongNumargInductive (c,expanded,n,n1,n2) ->
-      explain_wrong_numarg_inductive env c expanded n n1 n2
+  | WrongNumargConstructor {cstr; expanded; nargs; expected_nassums; expected_ndecls} ->
+      explain_wrong_numarg_constructor env cstr expanded nargs expected_nassums expected_ndecls
+  | WrongNumargInductive {ind; expanded; nargs; expected_nassums; expected_ndecls} ->
+      explain_wrong_numarg_inductive env ind expanded nargs expected_nassums expected_ndecls
   | UnusedClause tms ->
       explain_unused_clause env tms
   | NonExhaustive tms ->


### PR DESCRIPTION
**Kind:** fix + cleanup

This PR contains a few bug fixes:
- fixing argument scopes and let-ins in cases patterns
- for `foo` an abbreviation, accepting `@foo` in cases pattern as it is already the case in terms

It contains also cleanings such as making the interpretation path for cases pattern more consistent with the one of terms, even if more could be done.

It depended on #12027 (merged), #12684 (merged) and #12685 (merged) but eventually should be pushed also on top of #8808 (merged) and #12099 (merged).

- [X] Added / updated test-suite
- [ ] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).

Added: happened to have fixed #13534.