### PR TITLE
Coqide: Apply style scheme and language settings to the three sourceview buffers.

### DIFF
--- a/doc/changelog/09-coqide/12106-master+coqide-style-apply-all-windows.rst
+++ b/doc/changelog/09-coqide/12106-master+coqide-style-apply-all-windows.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  Highlighting style and language settings consistently apply to all three buffers of CoqIDE
+  (`#12106 <https://github.com/coq/coq/pull/12106>`_,
+  by Hugo Herbelin; fixes
+  `#11506 <https://github.com/coq/coq/pull/11506>`_).

--- a/doc/sphinx/practical-tools/coqide.rst
+++ b/doc/sphinx/practical-tools/coqide.rst
@@ -1,3 +1,5 @@
+.. |GtkSourceView| replace:: :smallcaps:`GtkSourceView`
+
 .. _coqintegrateddevelopmentenvironment:
 
 |Coq| Integrated Development Environment
@@ -158,7 +160,18 @@ presented as a notebook.
 The first section is for selecting the text font used for scripts,
 goal and message windows.
 
-The second and third sections are for controlling colors and style.
+The second and third sections are for controlling colors and style of
+the three main buffers. A predefined |Coq| highlighting style as well
+as standard |GtkSourceView| styles are available. Other styles can be
+added e.g. in ``$HOME/.local/share/gtksourceview-3.0/styles/`` (see
+the general documentation about |GtkSourceView| for the various
+possibilities). Note that the style of the rest of graphical part of
+Coqide is not under the control of |GtkSourceView| but of GTK+ and
+governed by files such as ``settings.ini`` and ``gtk.css`` in
+``$XDG_CONFIG_HOME/gtk-3.0`` or files in
+``$HOME/.themes/NameOfTheme/gtk-3.0``, as well as the environment
+variable ``GTK_THEME`` (search on internet for the various
+possibilities).
 
 The fourth section is for customizing the editor. It includes in
 particular the ability to activate an Emacs mode named

--- a/ide/coqide.ml
+++ b/ide/coqide.ml
@@ -1293,12 +1293,18 @@ let build_ui () =
   (* Initializing hooks *)
   let refresh_style style =
     let style = style_manager#style_scheme style in
-    let iter_session v = v.script#source_buffer#set_style_scheme style in
+    let iter_session v =
+      v.script#source_buffer#set_style_scheme style;
+      v.proof#source_buffer#set_style_scheme style;
+      v.messages#default_route#source_buffer#set_style_scheme style in
     List.iter iter_session notebook#pages
   in
   let refresh_language lang =
     let lang = lang_manager#language lang in
-    let iter_session v = v.script#source_buffer#set_language lang in
+    let iter_session v =
+      v.script#source_buffer#set_language lang;
+      v.proof#source_buffer#set_language lang;
+      v.messages#default_route#source_buffer#set_language lang in
     List.iter iter_session notebook#pages
   in
   let refresh_toolbar b =

--- a/ide/wg_MessageView.ml
+++ b/ide/wg_MessageView.ml
@@ -28,6 +28,7 @@ end
 class type message_view =
   object
     inherit GObj.widget
+    method source_buffer : GSourceView3.source_buffer
     method connect : message_view_signals
     method clear : unit
     method add : Pp.t -> unit
@@ -44,7 +45,9 @@ class type message_view =
 let message_view () : message_view =
   let buffer = GSourceView3.source_buffer
     ~highlight_matching_brackets:true
-    ~tag_table:Tags.Message.table ()
+    ~tag_table:Tags.Message.table
+    ?language:(lang_manager#language source_language#get)
+    ?style_scheme:(style_manager#style_scheme source_style#get) ()
   in
   let mark = buffer#create_mark ~left_gravity:false buffer#start_iter in
   let box = GPack.vbox () in
@@ -87,6 +90,8 @@ let message_view () : message_view =
     val mutable msgs = []
 
     val push = new GUtil.signal ()
+
+    method source_buffer = buffer
 
     method connect =
       new message_view_signals_impl box#as_widget push

--- a/ide/wg_MessageView.mli
+++ b/ide/wg_MessageView.mli
@@ -18,6 +18,7 @@ end
 class type message_view =
   object
     inherit GObj.widget
+    method source_buffer : GSourceView3.source_buffer
     method connect : message_view_signals
     method clear : unit
     method add : Pp.t -> unit

--- a/ide/wg_ProofView.ml
+++ b/ide/wg_ProofView.ml
@@ -15,6 +15,7 @@ open Ideutils
 class type proof_view =
   object
     inherit GObj.widget
+    method source_buffer : GSourceView3.source_buffer
     method buffer : GText.buffer
     method refresh : force:bool -> unit
     method clear : unit -> unit
@@ -195,7 +196,9 @@ let display mode (view : #GText.view_skel) goals hints evars =
 let proof_view () =
   let buffer = GSourceView3.source_buffer
     ~highlight_matching_brackets:true
-    ~tag_table:Tags.Proof.table ()
+    ~tag_table:Tags.Proof.table
+    ?language:(lang_manager#language source_language#get)
+    ?style_scheme:(style_manager#style_scheme source_style#get) ()
   in
   let text_buffer = new GText.buffer buffer#as_buffer in
   let view = GSourceView3.source_view
@@ -216,6 +219,8 @@ let proof_view () =
     val mutable goals = None
     val mutable evars = None
     val mutable last_width = -1
+
+    method source_buffer = buffer
 
     method buffer = text_buffer
 

--- a/ide/wg_ProofView.mli
+++ b/ide/wg_ProofView.mli
@@ -11,6 +11,7 @@
 class type proof_view =
   object
     inherit GObj.widget
+    method source_buffer : GSourceView3.source_buffer
     method buffer : GText.buffer
     method refresh : force:bool -> unit
     method clear : unit -> unit


### PR DESCRIPTION
**Kind:** bug fix / enhancement

It was previously only applied to the script buffer.

Fixes #11506.

See #11558 for changing the theme of the rest of CoqIDE (toolbar, frame, menus, ...).

- [x] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).

Added note: the errors and jobs pages are not under control of gtksourceview. Their background and foreground colors are controlled by the GTK theme and then not impacted by a style scheme selection (*). There could be in principle a way to change their background and foreground based on what the gtksourceview style scheme says, but lablgtk is missing the class `GtkSourceStyle` that collects these information, and, a fortiori, the function `gtk_source_style_scheme_get_style` that allows to extract these informations from the xml style scheme file.


(*) The theme itself can be set either by adding a file `~/.config/gtk-3.0/settings.ini` indicating a theme name to be found in `~/.themes/ThemeName/gtk-3.0/gtk.css` (if light) or `~/.themes/ThemeName/gtk-3.0/gtk-dark.css` (if dark), or by adding the same `gtk.css` or `gtk-dark.css` files directly in `~/.config/gtk-3.0`, among other possibilities. More details my searching on the web.