### PR TITLE
Define terminology "function" using the Sphinx glossary directive.

### DIFF
--- a/doc/sphinx/language/gallina-specification-language.rst
+++ b/doc/sphinx/language/gallina-specification-language.rst
@@ -755,13 +755,28 @@ A definition can be seen as a way to give a meaning to a name or as a
 way to abbreviate a term. In any case, the name can later be replaced at
 any time by its definition.
 
-The operation of unfolding a name into its definition is called
-:math:`\delta`-conversion (see Section :ref:`delta-reduction`). A
-definition is accepted by the system if and only if the defined term is
-well-typed in the current context of the definition and if the name is
-not already used. The name defined by the definition is called a
-*constant* and the term it refers to is its *body*. A definition has a
-type which is the type of its body.
+.. glossary::
+
+   constant
+
+     The name associated to a term through a command like
+     :cmd:`Definition`.
+
+   body
+
+     The term associated to a name through a command like
+     :cmd:`Definition`.
+
+   unfolding
+
+     Replacing a constant by its body.  This reduction operation is
+     more formally denoted as :math:`\delta`\-conversion (see Section
+     :ref:`delta-reduction`).
+
+A definition is accepted by the system if and only if the defined term
+is well-typed in the current context of the definition and if the name
+is not already used.  A definition has a type which is the type of its
+body.
 
 A formal presentation of constants and environments is given in
 Section :ref:`typing-rules`.

--- a/doc/sphinx/language/gallina-specification-language.rst
+++ b/doc/sphinx/language/gallina-specification-language.rst
@@ -349,6 +349,8 @@ Section :ref:`let-in`).
 
 .. index:: forall
 
+.. _product:
+
 Products: forall
 ----------------
 
@@ -373,7 +375,17 @@ the propositional implication and function types.
 Applications
 ------------
 
-:n:`@term__fun @term` denotes applying the function :n:`@term__fun` to :token:`term`.
+:n:`@term__fun @term` denotes applying the :term:`function`
+:n:`@term__fun` to :token:`term`.
+
+.. glossary::
+
+   function
+
+     Any Coq object whose type is a :ref:`product <product>`.
+
+     In particular, a non-dependent function has a non-dependent
+     product type :n:`@type -> @type`.
 
 :n:`@term__fun {+ @term__i }` denotes applying
 :n:`@term__fun` to the arguments :n:`@term__i`.  It is


### PR DESCRIPTION
**Kind:** documentation

Following discussions with @jfehrle, this is a first use of the Sphinx `glossary` directive (https://sublime-and-sphinx-guide.readthedocs.io/en/latest/glossary.html).

There are two ways to approach the creation of a glossary: either create one glossary on a single page where you explain everything there is to define. Or sprinkle the `glossary` directive throughout the manual. I prefer the second approach because it will avoid having to repeat some explanations. Furthermore, it works closer to the way grammar non-terminals are defined in many places of the manual and can be referred to from anywhere. If there's a way to have a glossary index, it would be great, but even if not, I still prefer this approach.

WDYT @cpitclaudel and @jfehrle?