### PR TITLE
[proof] Split vio and regular proof close paths.

### DIFF
--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -1664,11 +1664,9 @@ end = struct (* {{{ *)
         let _proof = PG_compat.return_partial_proof () in
         `OK_ADMITTED
       else begin
-      let opaque = Declare.Opaque in
 
       (* The original terminator, a hook, has not been saved in the .vio*)
-      let proof, _info =
-        PG_compat.close_proof ~opaque ~keep_body_ucst_separate:true in
+      let proof, _info = PG_compat.close_vio_proof () in
 
       let info = Lemmas.Info.make () in
 
@@ -1683,7 +1681,7 @@ end = struct (* {{{ *)
        *)
       (* STATE We use the state resulting from reaching start. *)
       let st = Vernacstate.freeze_interp_state ~marshallable:false in
-      ignore(stm_qed_delay_proof ~id:stop ~st ~proof ~info ~loc ~control:[] (Proved (opaque,None)));
+      ignore(stm_qed_delay_proof ~id:stop ~st ~proof ~info ~loc ~control:[] (Proved (Declare.Opaque,None)));
       (* Is this name the same than the one in scope? *)
       let name = Declare.get_po_name proof in
       `OK name
@@ -2524,7 +2522,7 @@ let known_state ~doc ?(redefine_qed=false) ~cache id =
                       | VtKeepOpaque -> Opaque | VtKeepDefined -> Transparent
                       | VtKeepAxiom -> assert false
                     in
-                    try Some (PG_compat.close_proof ~opaque ~keep_body_ucst_separate:false)
+                    try Some (PG_compat.close_proof ~opaque)
                     with exn ->
                       let iexn = Exninfo.capture exn in
                       Exninfo.iraise (State.exn_on id ~valid:eop iexn)

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -112,7 +112,8 @@ type proof_object
 (** Used by the STM only to store info, should go away *)
 val get_po_name : proof_object -> Id.t
 
-val close_proof : opaque:opacity_flag -> keep_body_ucst_separate:bool -> Proof.t -> proof_object
+val close_proof : opaque:opacity_flag -> Proof.t -> proof_object
+val close_vio_proof : Proof.t -> proof_object
 
 (** Declaration of local constructions (Variable/Hypothesis/Local) *)
 

--- a/vernac/vernacstate.ml
+++ b/vernac/vernacstate.ml
@@ -171,8 +171,12 @@ module Declare = struct
     cc_lemma (fun pt -> pf_fold (fun st -> close_future_proof ~feedback_id st pf) pt,
                         Lemmas.Internal.get_info pt)
 
-  let close_proof ~opaque ~keep_body_ucst_separate =
-    cc_lemma (fun pt -> pf_fold ((close_proof ~opaque ~keep_body_ucst_separate)) pt,
+  let close_proof ~opaque =
+    cc_lemma (fun pt -> pf_fold (close_proof ~opaque) pt,
+                        Lemmas.Internal.get_info pt)
+
+  let close_vio_proof () =
+    cc_lemma (fun pt -> pf_fold close_vio_proof pt,
                         Lemmas.Internal.get_info pt)
 
   let discard_all () = s_lemmas := None

--- a/vernac/vernacstate.mli
+++ b/vernac/vernacstate.mli
@@ -74,7 +74,8 @@ module Declare : sig
     feedback_id:Stateid.t ->
     Declare.closed_proof_output Future.computation -> closed_proof
 
-  val close_proof : opaque:Declare.opacity_flag -> keep_body_ucst_separate:bool -> closed_proof
+  val close_proof : opaque:Declare.opacity_flag -> closed_proof
+  val close_vio_proof : unit -> closed_proof
 
   val discard_all : unit -> unit
   val update_global_env : unit -> unit


### PR DESCRIPTION
The paths don't have the same type, in particular the opaque argument
cannot be set to `Transparent` for `close_vio_proof`.

We could add an assert, but it seems easier just to do change the type.

This depends on #12130 and it is a continuation of #11915 and #11916 ; the code here originally was part of #11916 and included much more refactoring of common parts which fully mitigated the duplication introduced here. I will push these changes once the depending PR has been merged as the removal of `Proof_global` made the rebase impossible.