### PR TITLE
Fixes #10812 and #12139: tactic subst issues with section variables indirectly dependent in goal

### DIFF
--- a/doc/changelog/04-tactics/12143-master+fix10812-12139-subst-section-variables.rst
+++ b/doc/changelog/04-tactics/12143-master+fix10812-12139-subst-section-variables.rst
@@ -1,0 +1,11 @@
+- **Fixed:**
+  Tactic `subst` over a section variable was failing if the section
+  variable was only indirectly dependent in the goal
+  (`#12143 <https://github.com/coq/coq/pull/12143>`_,
+  by Hugo Herbelin; fixes `#12139 <https://github.com/coq/coq/pull/12139>`_).
+
+- **Fixed:**
+  Tactic `subst` over a section variable was not clearing the rewritten equality
+  if the section variable was indirectly dependent in the goal
+  (`#12143 <https://github.com/coq/coq/pull/12143>`_,
+  by Hugo Herbelin; fixes `#10812 <https://github.com/coq/coq/pull/10812>`_).

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -1732,7 +1732,9 @@ let subst_one dep_proof_ok x (hyp,rhs,dir) =
       hyps
       (MoveBefore x,[x],[]))) in (* In practice, no dep hyps before x, so MoveBefore x is good enough *)
   (* Decides if x appears in conclusion *)
-  let depconcl = occur_var env sigma x concl in
+  let depconcl =
+    (* Do not consider section variables occurring indirectly *)
+    local_occur_var sigma x concl in
   let need_rewrite = not (List.is_empty dephyps) || depconcl in
   tclTHENLIST
     ((if need_rewrite then
@@ -1741,7 +1743,7 @@ let subst_one dep_proof_ok x (hyp,rhs,dir) =
        (tclMAP (fun (dest,id) -> intro_move (Some id) dest) dephyps)]
       else
        [Proofview.tclUNIT ()]) @
-     [tclTRY (clear [x; hyp])])
+     [tclTRY (clear [hyp]); tclTRY (clear [x])])
   end
 
 (* Look for an hypothesis hyp of the form "x=rhs" or "rhs=x", rewrite

--- a/test-suite/bugs/closed/bug_10812.v
+++ b/test-suite/bugs/closed/bug_10812.v
@@ -1,0 +1,10 @@
+(* subst with section variables *)                                                                                     
+Section A.
+Variable a:nat.
+Definition b := a.
+Goal a=1 -> b=1.
+intros.
+subst a. (* Was failing *)
+Admitted.
+
+End A.

--- a/test-suite/bugs/closed/bug_12139.v
+++ b/test-suite/bugs/closed/bug_12139.v
@@ -1,0 +1,43 @@
+(* subst with section variables *)
+
+(* Version courte *)
+
+Section A.
+Variable a:nat.
+Definition b := a.
+Goal a=1 -> a=b.
+intros.
+subst a. (* was not clearing H *)
+Fail clear H.
+Admitted.
+
+End A.
+
+(* Version originale *)
+
+Module B.
+
+Axiom proc : Type.
+Axiom mkproc : nat -> nat -> proc.
+
+Section WithParams.
+  Context (input aggregatorIn : nat).
+
+  Definition MapReduceImpl : proc := mkproc input aggregatorIn.
+
+  Inductive R: proc -> proc -> Prop :=
+  | BuildR : forall pr1 pr2,
+      pr1 = MapReduceImpl ->
+      pr2 = MapReduceImpl ->
+      R pr1 pr2.
+
+  Goal forall pr1 pr2,
+      input = aggregatorIn ->
+      R pr1 pr2 /\ aggregatorIn = input.
+  Proof.
+    intros.
+    subst input. 
+    Fail clear H.
+  Admitted.
+
+End B.


### PR DESCRIPTION
**Kind:** bug fix

- For #10812: To decide if rewriting is needed, don't consider implicitly depending section variables as occurring since there are invisible from unification (i.e. use `local_occur_var`)
    
- For #12139:  If the section variable cannot be cleared, try nevertheless to clear the equation.

This is a potential source of incompatibilites, but it also has to be fixed.

Fixes #10812
Fixes  #12139 

- [X] Added / updated test-suite
- [X] Entry added in the changelog 