### PR TITLE
Fixes #12139: tactic subst missing clear with section variables indirectly dependent in goal

### DIFF
--- a/doc/changelog/04-tactics/12145-master+fix12139-subst-missing-clear-section-variables.rst
+++ b/doc/changelog/04-tactics/12145-master+fix12139-subst-missing-clear-section-variables.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  Tactic `subst` over a section variable was failing if the section
+  variable was only indirectly dependent in the goal
+  (`#12145 <https://github.com/coq/coq/pull/12145>`_,
+  by Hugo Herbelin; fixes `#12139 <https://github.com/coq/coq/pull/12139>`_).

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -1741,7 +1741,7 @@ let subst_one dep_proof_ok x (hyp,rhs,dir) =
        (tclMAP (fun (dest,id) -> intro_move (Some id) dest) dephyps)]
       else
        [Proofview.tclUNIT ()]) @
-     [tclTRY (clear [x; hyp])])
+     [tclTRY (clear [hyp]); tclTRY (clear [x])])
   end
 
 (* Look for an hypothesis hyp of the form "x=rhs" or "rhs=x", rewrite

--- a/test-suite/bugs/closed/bug_12139.v
+++ b/test-suite/bugs/closed/bug_12139.v
@@ -1,0 +1,45 @@
+(* subst with section variables *)
+
+(* Version courte *)
+
+Section A.
+Variable a:nat.
+Definition b := a.
+Goal a=1 -> a=b.
+intros.
+subst a. (* was not clearing H *)
+Fail clear H.
+Admitted.
+
+End A.
+
+(* Version originale *)
+
+Module B.
+
+Axiom proc : Type.
+Axiom mkproc : nat -> nat -> proc.
+
+Section WithParams.
+  Context (input aggregatorIn : nat).
+
+  Definition MapReduceImpl : proc := mkproc input aggregatorIn.
+
+  Inductive R: proc -> proc -> Prop :=
+  | BuildR : forall pr1 pr2,
+      pr1 = MapReduceImpl ->
+      pr2 = MapReduceImpl ->
+      R pr1 pr2.
+
+  Goal forall pr1 pr2,
+      input = aggregatorIn ->
+      R pr1 pr2 /\ aggregatorIn = input.
+  Proof.
+    intros.
+    subst input. 
+    Fail clear H.
+  Admitted.
+
+End WithParams.
+
+End B.


### PR DESCRIPTION
**Kind:** bug fix
    
If the section variable cannot be cleared, try nevertheless to clear the equation.

This is a potential source of incompatibilites, but it also has to be fixed.

Fixes  #12139 

- [X] Added / updated test-suite
- [X] Entry added in the changelog 