### PR TITLE
Support in-line glossary definitions and references with an index

### DIFF
--- a/doc/sphinx/README.rst
+++ b/doc/sphinx/README.rst
@@ -358,6 +358,13 @@ In addition to the objects and directives above, the ``coqrst`` Sphinx plugin de
     <http://www.sphinx-doc.org/en/stable/markup/para.html#directive-productionlist>`_
     and reference its tokens using ``:token:`…```.
 
+``:gdef:`` Marks the definition of a glossary term inline in the text.  Matching :term:`XXX`
+    constructs will link to it.  The term will also appear in the Glossary Index.
+
+    Example::
+
+       A :gdef:`prime` number is divisible only by itself and 1.
+
 Common mistakes
 ===============
 

--- a/doc/sphinx/_static/notations.css
+++ b/doc/sphinx/_static/notations.css
@@ -215,6 +215,14 @@
     margin-bottom: 0.28em;
 }
 
+.term-defn {
+    font-style: italic;
+}
+
+.std-term {
+    color: #2980B9;  /* override if :visited */
+}
+
 /* We can't display nested blocks otherwise */
 code, .rst-content tt, .rst-content code {
     background: transparent !important;

--- a/doc/sphinx/appendix/indexes/index.rst
+++ b/doc/sphinx/appendix/indexes/index.rst
@@ -17,6 +17,7 @@ find what you are looking for.
    ../../coq-optindex
    ../../coq-exnindex
    ../../coq-attrindex
+   ../../std-glossindex
 
 For reference, here are direct links to the documentation of:
 

--- a/doc/sphinx/std-glossindex.rst
+++ b/doc/sphinx/std-glossindex.rst
@@ -1,0 +1,7 @@
+:orphan:
+
+.. hack to get index in TOC
+
+--------------
+Glossary index
+--------------


### PR DESCRIPTION
Here's an alternate implementation of a glossary.  This has inline definitions (`:gdef:`) showing in italic and references (`:gref:`) and a `Glossary Page` index.  An alternative to #12114.  Look at the beginning of the implicit arguments section of the Gallina extensions chapter.  And the new index.

What do you think?