### PR TITLE
[stdlib] [list] Symmetry in conclusions of map_eq_cons and map_eq_app

### DIFF
--- a/theories/Lists/List.v
+++ b/theories/Lists/List.v
@@ -1141,7 +1141,7 @@ Section Map.
   Qed.
 
   Lemma map_eq_cons : forall l l' b,
-    map l = b :: l' -> exists a tl, l = a :: tl /\ b = f a /\ l' = map tl.
+    map l = b :: l' -> exists a tl, l = a :: tl /\ f a = b /\ map tl = l'.
   Proof.
     intros l l' b Heq.
     destruct l; inversion_clear Heq.
@@ -1149,7 +1149,7 @@ Section Map.
   Qed.
 
   Lemma map_eq_app  : forall l l1 l2,
-    map l = l1 ++ l2 -> exists l1' l2', l = l1' ++ l2' /\ l1 = map l1' /\ l2 = map l2'.
+    map l = l1 ++ l2 -> exists l1' l2', l = l1' ++ l2' /\ map l1' = l1 /\ map l2' = l2.
   Proof.
     induction l; simpl; intros l1 l2 Heq.
     - symmetry in Heq; apply app_eq_nil in Heq; destruct Heq; subst.

--- a/theories/Sorting/CPermutation.v
+++ b/theories/Sorting/CPermutation.v
@@ -235,9 +235,8 @@ induction m as [| b m]; intros l HC.
   apply CPermutation_nil in HC; inversion HC.
 - symmetry in HC.
   destruct (CPermutation_vs_cons_inv HC) as [m1 [m2 [-> Heq]]].
-  apply map_eq_app in Heq as [l1 [l1' [-> [-> Heq]]]].
-  symmetry in Heq.
-  apply map_eq_cons in Heq as [a [l1'' [-> [-> ->]]]].
+  apply map_eq_app in Heq as [l1 [l1' [-> [<- Heq]]]].
+  apply map_eq_cons in Heq as [a [l1'' [-> [<- <-]]]].
   exists (a :: l1'' ++ l1); split.
   + now simpl; rewrite map_app.
   + now rewrite app_comm_cons.

--- a/theories/Sorting/Permutation.v
+++ b/theories/Sorting/Permutation.v
@@ -552,7 +552,6 @@ Proof.
   - symmetry in HP.
     destruct (Permutation_vs_cons_inv HP) as [l3 [l4 Heq]].
     destruct (map_eq_app _ _ _ _ Heq) as [l1' [l2' [Heq1 [Heq2 Heq3]]]]; subst.
-    symmetry in Heq3.
     destruct (map_eq_cons _ _ Heq3) as [b [l1'' [Heq1' [Heq2' Heq3']]]]; subst.
     rewrite map_app in HP; simpl in HP.
     symmetry in HP.


### PR DESCRIPTION
Modify the conclusion of lemmas `map_eq_cons` and `map_eq_app` to make iterated applications easier like in `map f l = l1 ++ l2 ++ a :: l3`.

<!-- Keep what applies -->
**Kind:** feature.
