### PR TITLE
CoqIDE: Revert overzealous application of language-based highlighting from #12169

### DIFF
--- a/doc/changelog/09-coqide/12106-master+coqide-style-apply-all-windows.rst
+++ b/doc/changelog/09-coqide/12106-master+coqide-style-apply-all-windows.rst
@@ -1,5 +1,5 @@
 - **Fixed:**
-  Highlighting style and language settings consistently apply to all three buffers of CoqIDE
+  Highlighting style consistently applied to all three buffers of CoqIDE
   (`#12106 <https://github.com/coq/coq/pull/12106>`_,
   by Hugo Herbelin; fixes
   `#11506 <https://github.com/coq/coq/pull/11506>`_).

--- a/ide/coqide.ml
+++ b/ide/coqide.ml
@@ -1301,10 +1301,7 @@ let build_ui () =
   in
   let refresh_language lang =
     let lang = lang_manager#language lang in
-    let iter_session v =
-      v.script#source_buffer#set_language lang;
-      v.proof#source_buffer#set_language lang;
-      v.messages#default_route#source_buffer#set_language lang in
+    let iter_session v = v.script#source_buffer#set_language lang in
     List.iter iter_session notebook#pages
   in
   let refresh_toolbar b =

--- a/ide/wg_MessageView.ml
+++ b/ide/wg_MessageView.ml
@@ -46,7 +46,6 @@ let message_view () : message_view =
   let buffer = GSourceView3.source_buffer
     ~highlight_matching_brackets:true
     ~tag_table:Tags.Message.table
-    ?language:(lang_manager#language source_language#get)
     ?style_scheme:(style_manager#style_scheme source_style#get) ()
   in
   let mark = buffer#create_mark ~left_gravity:false buffer#start_iter in

--- a/ide/wg_ProofView.ml
+++ b/ide/wg_ProofView.ml
@@ -197,7 +197,6 @@ let proof_view () =
   let buffer = GSourceView3.source_buffer
     ~highlight_matching_brackets:true
     ~tag_table:Tags.Proof.table
-    ?language:(lang_manager#language source_language#get)
     ?style_scheme:(style_manager#style_scheme source_style#get) ()
   in
   let text_buffer = new GText.buffer buffer#as_buffer in


### PR DESCRIPTION
The parsing rules defining classes of lexemes in language configuration expect a Coq document and are not relevant in the message and proof window. Thus backtracking on this part of #12169. Keeping the highlighting style though. Sorry for the confusion.

**Kind:**  bug fix refinement

Fixes / closes #12169 

- [X] Entry updated in the changelog 