### PR TITLE
Doc: extend example for induction a bit

### DIFF
--- a/doc/sphinx/proof-engine/tactics.rst
+++ b/doc/sphinx/proof-engine/tactics.rst
@@ -1875,6 +1875,7 @@ analysis on inductive or co-inductive objects (see :ref:`inductive-definitions`)
       Lemma induction_test : forall n:nat, n = n -> n <= n.
       intros n H.
       induction n.
+      exact (le_n 0).
 
 .. exn:: Not an inductive product.
    :undocumented:


### PR DESCRIPTION
This makes it show the shape of the induction hypothesis in the second
goal instead of just saying "subgoal 2 is S n <= S n".
