### PR TITLE
Add sphinx-clean option to force full sphinx rebuild

### DIFF
--- a/Makefile.doc
+++ b/Makefile.doc
@@ -100,6 +100,9 @@ doc-stdlib: \
 full-stdlib: \
   doc/stdlib/html/index.html doc/stdlib/FullLibrary.ps doc/stdlib/FullLibrary.pdf
 
+sphinx-clean:
+	rm -rf $(SPHINXBUILDDIR)
+
 .PHONY: plugin-tutorial
 plugin-tutorial: states tools
 	+$(MAKE) COQBIN=$(PWD)/bin/ -C $(PLUGINTUTO)


### PR DESCRIPTION
Sphinx caches information between runs imperfectly.  `make sphinx-clean` clears the cache so you can do another full Sphinx build without a `make clean` and unnecessarily recompiling all the source code.