### PR TITLE
Sphinx warnings for duplicate objects

### DIFF
--- a/doc/tools/coqrst/coqdomain.py
+++ b/doc/tools/coqrst/coqdomain.py
@@ -158,8 +158,8 @@ class CoqObject(ObjectDescription):
     def _warn_if_duplicate_name(self, objects, name):
         """Check that two objects in the same domain don't have the same name."""
         if name in objects:
-            MSG = 'Duplicate object: {}; other is at {}'
-            msg = MSG.format(name, self.env.doc2path(objects[name][0]))
+            MSG = 'Duplicate {}: {}; other is at: {}'
+            msg = MSG.format(self.subdomain, name, objects[name][0])
             self.state_machine.reporter.warning(msg, line=self.lineno)
 
     def _record_name(self, name, target_id):
@@ -183,6 +183,10 @@ class CoqObject(ObjectDescription):
             signode['first'] = (not self.names)
             self.state.document.note_explicit_target(signode)
             self._record_name(name, targetid)
+        else:
+            names_in_subdomain = self.subdomain_data()
+            self._warn_if_duplicate_name(names_in_subdomain, name) # 2
+
         return targetid
 
     def _add_index_entry(self, name, target):

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -85,6 +85,7 @@ DELETE: [
 | test_ssrslashnum10
 | test_ssrslashnum11
 | test_ident_no_do
+| test_hash_ident
 | ssrdoarg  (* todo: this and the next one should be removed from the grammar? *)
 | ssrseqdir
 *)
@@ -1488,8 +1489,6 @@ scope_delimiter: [
 (* Don't show these details *)
 DELETE: [
 | register_token
-| register_prim_token
-| register_type_token
 ]
 
 

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -798,58 +798,7 @@ gallina: [
 ]
 
 register_token: [
-| register_prim_token
-| register_type_token
-]
-
-register_type_token: [
-| "#int63_type"
-| "#float64_type"
-]
-
-register_prim_token: [
-| "#int63_head0"
-| "#int63_tail0"
-| "#int63_add"
-| "#int63_sub"
-| "#int63_mul"
-| "#int63_div"
-| "#int63_mod"
-| "#int63_lsr"
-| "#int63_lsl"
-| "#int63_land"
-| "#int63_lor"
-| "#int63_lxor"
-| "#int63_addc"
-| "#int63_subc"
-| "#int63_addcarryc"
-| "#int63_subcarryc"
-| "#int63_mulc"
-| "#int63_diveucl"
-| "#int63_div21"
-| "#int63_addmuldiv"
-| "#int63_eq"
-| "#int63_lt"
-| "#int63_le"
-| "#int63_compare"
-| "#float64_opp"
-| "#float64_abs"
-| "#float64_eq"
-| "#float64_lt"
-| "#float64_le"
-| "#float64_compare"
-| "#float64_classify"
-| "#float64_add"
-| "#float64_sub"
-| "#float64_mul"
-| "#float64_div"
-| "#float64_sqrt"
-| "#float64_of_int63"
-| "#float64_normfr_mantissa"
-| "#float64_frshiftexp"
-| "#float64_ldshiftexp"
-| "#float64_next_up"
-| "#float64_next_down"
+| test_hash_ident "#" IDENT
 ]
 
 thm_token: [


### PR DESCRIPTION
Report duplicates for named objects (cmdv and tacv are named only if they have `:name:`).

