### PR TITLE
CReal: changed epsilon for modulus of convergence from 1/n to 1/2^n

### DIFF
--- a/doc/changelog/10-standard-library/12186-creal-new-modulus.rst
+++ b/doc/changelog/10-standard-library/12186-creal-new-modulus.rst
@@ -1,0 +1,5 @@
+- **Changed:**
+  In the reals theory changed the epsilon in the definition of the modulus of convergence for CReal from 1/n (n in positive) to 2^z (z in Z)
+  so that a precision coarser than one is possible. Also added an upper bound to CReal to enable more efficient computations.
+  (`#12186 <https://github.com/coq/coq/pull/12186>`_,
+  by Michael Soegtrop).

--- a/doc/stdlib/hidden-files
+++ b/doc/stdlib/hidden-files
@@ -92,3 +92,6 @@ theories/setoid_ring/ZArithRing.v
 theories/ssr/ssrunder.v
 theories/ssr/ssrsetoid.v
 theories/ssrsearch/ssrsearch.vo
+theories/Reals/Cauchy/ConstructiveExtra.v
+theories/Reals/Cauchy/PosExtra.v
+theories/Reals/Cauchy/QExtra.v

--- a/test-suite/output/MExtraction.v
+++ b/test-suite/output/MExtraction.v
@@ -58,7 +58,7 @@ Recursive Extraction
            Tauto.abst_form
            ZMicromega.cnfZ  ZMicromega.Zeval_const QMicromega.cnfQ
            List.map simpl_cone (*map_cone  indexes*)
-           denorm Qpower vm_add
+           denorm QArith_base.Qpower vm_add
    normZ normQ normQ n_of_Z N.of_nat ZTautoChecker ZWeakChecker QTautoChecker RTautoChecker find.
 
 (* Local Variables: *)

--- a/theories/Reals/Cauchy/ConstructiveExtra.v
+++ b/theories/Reals/Cauchy/ConstructiveExtra.v
@@ -1,0 +1,76 @@
+Require Import ZArith.
+Require Import ConstructiveEpsilon.
+
+Definition Z_inj_nat (z : Z) : nat :=
+  match z with
+  | Z0 => 0
+  | Zpos p => Pos.to_nat (p~0)
+  | Zneg p => Pos.to_nat (Pos.pred_double p)
+  end.
+
+Definition Z_inj_nat_rev (n : nat) : Z :=
+  match n with
+  | O => 0
+  | S n' => match Pos.of_nat n with
+            | xH =>   Zneg xH
+            | xO p => Zpos p
+            | xI p => Zneg (Pos.succ p)
+            end
+  end.
+
+Lemma Pos_pred_double_inj: forall (p q : positive),
+    Pos.pred_double p = Pos.pred_double q -> p = q.
+Proof.
+  intros p q H.
+  apply (f_equal Pos.succ) in H.
+  do 2 rewrite Pos.succ_pred_double in H.
+  inversion H; reflexivity.
+Qed.
+
+Lemma Z_inj_nat_id: forall (z : Z),
+  Z_inj_nat_rev (Z_inj_nat z) = z.
+Proof.
+  intros z.
+  unfold Z_inj_nat, Z_inj_nat_rev.
+  destruct z eqn:Hdz.
+  - reflexivity.
+  - rewrite Pos2Nat.id.
+    destruct (Pos.to_nat p~0) eqn:Hd.
+    + pose proof Pos2Nat.is_pos p~0 as H.
+      rewrite <- Nat.neq_0_lt_0 in H.
+      exfalso; apply H, Hd.
+    + reflexivity.
+  - rewrite Pos2Nat.id.
+    destruct (Pos.to_nat (Pos.pred_double p)) eqn: Hd.
+    + pose proof Pos2Nat.is_pos (Pos.pred_double p) as H.
+      rewrite <- Nat.neq_0_lt_0 in H.
+      exfalso; apply H, Hd.
+    + destruct (Pos.pred_double p) eqn:Hd2.
+      * rewrite <- Pos.pred_double_succ in Hd2.
+        apply Pos_pred_double_inj in Hd2.
+        rewrite Hd2; reflexivity.
+      * apply (f_equal Pos.succ) in Hd2.
+        rewrite Pos.succ_pred_double in Hd2.
+        rewrite <- Pos.xI_succ_xO in Hd2.
+        inversion Hd2.
+      * change xH with (Pos.pred_double xH) in Hd2.
+        apply Pos_pred_double_inj in Hd2.
+        rewrite Hd2; reflexivity.
+Qed.
+
+Lemma Z_inj_nat_inj: forall (x y : Z),
+    Z_inj_nat x = Z_inj_nat y -> x = y.
+Proof.
+  intros x y H.
+  apply (f_equal Z_inj_nat_rev) in H.
+  do 2 rewrite Z_inj_nat_id in H.
+  assumption.
+Qed.
+
+Lemma constructive_indefinite_ground_description_Z:
+  forall P : Z -> Prop,
+  (forall z : Z, {P z} + {~ P z}) ->
+  (exists z : Z, P z) -> {z : Z | P z}.
+Proof.
+  apply (constructive_indefinite_ground_description Z Z_inj_nat Z_inj_nat_rev Z_inj_nat_id).
+Qed.

--- a/theories/Reals/Cauchy/ConstructiveRcomplete.v
+++ b/theories/Reals/Cauchy/ConstructiveRcomplete.v
@@ -15,6 +15,12 @@ Require Import ConstructiveReals.
 Require Import ConstructiveCauchyRealsMult.
 Require Import Logic.ConstructiveEpsilon.
 Require Import ConstructiveCauchyAbs.
+Require Import Lia.
+Require Import Lqa.
+Require Import Qpower.
+Require Import QExtra.
+Require Import PosExtra.
+Require Import ConstructiveExtra.
 
 (** Proof that Cauchy reals are Cauchy-complete.
 
@@ -71,59 +77,7 @@ Proof.
     rewrite Qinv_plus_distr. reflexivity.
 Defined.
 
-
-(* A point in an archimedean field is the limit of a
-   sequence of rational numbers (n maps to the q between
-   a and a+1/n). This will yield a maximum
-   archimedean field, which is the field of real numbers. *)
-Definition FQ_dense (a b : CReal)
-  : a < b -> { q : Q & a < inject_Q q < b }.
-Proof.
-  intros H. assert (0 < b - a) as epsPos.
-  { apply (CReal_plus_lt_compat_l (-a)) in H.
-    rewrite CReal_plus_opp_l, CReal_plus_comm in H.
-    apply H. }
-  pose proof (Rup_pos ((/(b-a)) (inr epsPos)))
-    as [n maj].
-  destruct (Rfloor (inject_Q (2 * Z.pos n # 1) * b)) as [p maj2].
-  exists (p # (2*n))%Q. split.
-  - apply (CReal_lt_trans a (b - inject_Q (1 # n))).
-    apply (CReal_plus_lt_reg_r (inject_Q (1#n))).
-    unfold CReal_minus. rewrite CReal_plus_assoc. rewrite CReal_plus_opp_l.
-    rewrite CReal_plus_0_r. apply (CReal_plus_lt_reg_l (-a)).
-    rewrite <- CReal_plus_assoc, CReal_plus_opp_l, CReal_plus_0_l.
-    rewrite CReal_plus_comm.
-    apply (CReal_mult_lt_reg_l (inject_Q (Z.pos n # 1))).
-    apply inject_Q_lt. reflexivity. rewrite <- inject_Q_mult.
-    setoid_replace ((Z.pos n # 1) * (1 # n))%Q with 1%Q.
-    apply (CReal_mult_lt_compat_l (b-a)) in maj.
-    rewrite CReal_inv_r, CReal_mult_comm in maj. exact maj.
-    exact epsPos. unfold Qeq; simpl. do 2 rewrite Pos.mul_1_r. reflexivity.
-    apply (CReal_plus_lt_reg_r (inject_Q (1 # n))).
-    unfold CReal_minus. rewrite CReal_plus_assoc, CReal_plus_opp_l.
-    rewrite CReal_plus_0_r. rewrite <- inject_Q_plus.
-    destruct maj2 as [_ maj2].
-    setoid_replace ((p # 2 * n) + (1 # n))%Q
-      with ((p + 2 # 2 * n))%Q.
-    apply (CReal_mult_lt_reg_r (inject_Q (Z.pos (2 * n) # 1))).
-    apply inject_Q_lt. reflexivity. rewrite <- inject_Q_mult.
-    setoid_replace ((p + 2 # 2 * n) * (Z.pos (2 * n) # 1))%Q
-      with ((p#1) + 2)%Q.
-    rewrite inject_Q_plus. rewrite Pos2Z.inj_mul.
-    rewrite CReal_mult_comm. exact maj2.
-    unfold Qeq; simpl. rewrite Pos.mul_1_r, Z.mul_1_r. ring.
-    setoid_replace (1#n)%Q with (2#2*n)%Q. 2: reflexivity.
-    apply Qinv_plus_distr.
-  - destruct maj2 as [maj2 _].
-    apply (CReal_mult_lt_reg_r (inject_Q (Z.pos (2 * n) # 1))).
-    apply inject_Q_lt. reflexivity.
-    rewrite <- inject_Q_mult.
-    setoid_replace ((p # 2 * n) * (Z.pos (2 * n) # 1))%Q
-      with ((p#1))%Q.
-    rewrite CReal_mult_comm. exact maj2.
-    unfold Qeq; simpl. rewrite Pos.mul_1_r, Z.mul_1_r. reflexivity.
-Qed.
-
+(* ToDo: Move to ConstructiveCauchyAbs.v *)
 Lemma Qabs_Rabs : forall q : Q,
     inject_Q (Qabs q) == CReal_abs (inject_Q q).
 Proof.
@@ -134,40 +88,122 @@ Proof.
     apply inject_Q_le, H.
 Qed.
 
+Lemma Qlt_trans_swap_hyp: forall x y z : Q,
+  (y < z)%Q -> (x < y)%Q -> (x < z)%Q.
+Proof.
+  intros x y z H1 H2.
+  apply (Qlt_trans x y z); assumption.
+Qed.
 
-(* For instance the rational sequence 1/n converges to 0. *)
+Lemma Qle_trans_swap_hyp: forall x y z : Q,
+  (y <= z)%Q -> (x <= y)%Q -> (x <= z)%Q.
+Proof.
+  intros x y z H1 H2.
+  apply (Qle_trans x y z); assumption.
+Qed.
+
+(** This inequality is tight since it is equal for n=1 and n=2 *)
+
+Lemma Qpower_2powneg_le_inv: forall (n : positive),
+    (2 * 2 ^ Z.neg n <= 1 # n)%Q.
+Proof.
+  intros n.
+  induction n using Pos.peano_ind.
+  - cbn. lra.
+  - rewrite <- Pos2Z.opp_pos, Pos2Z.inj_succ, Z.opp_succ, Pos2Z.opp_pos, <- Z.sub_1_r.
+    rewrite Qpower_minus_pos.
+    ring_simplify.
+    apply (Qmult_le_l _ _ (1#2)) in IHn.
+      2: lra.
+    ring_simplify in IHn.
+    apply (Qle_trans _ _ _ IHn).
+    unfold Qle, Qmult, Qnum, Qden.
+    ring_simplify; rewrite Pos2Z.inj_succ, <- Z.add_1_l.
+    clear IHn; induction n using Pos.peano_ind.
+    + reflexivity.
+    + rewrite Pos2Z.inj_succ, <- Z.add_1_l.
+      (* ToDo: does this lemma really need to be named like this and have this statement? *)
+      rewrite <- POrderedType.Positive_as_OT.add_1_l.
+      rewrite POrderedType.Positive_as_OT.mul_add_distr_l.
+      rewrite Pos2Z.inj_add.
+      apply Z.add_le_mono.
+      * lia.
+      * exact IHn.
+Qed.
+
+Lemma Pospow_lin_le_2pow: forall (n : positive),
+    (2 * n <= 2 ^ n)%positive.
+Proof.
+  intros n.
+  induction n using Pos.peano_ind.
+  - cbn. lia.
+  - rewrite Pos.mul_succ_r, Pos.pow_succ_r.
+    lia.
+Qed.
+
 Lemma CReal_cv_self : forall (x : CReal) (n : positive),
-    CReal_abs (x - inject_Q (proj1_sig x n)) <= inject_Q (1#n).
+    CReal_abs (x - inject_Q (seq x (Z.neg n))) <= inject_Q (1#n).
+Proof.
+  intros x n.
+  (* ToDo: CRealLt_asym should be names CRealLt_Le_weak and asym should be x<y /\ y<x -> False *)
+  apply CRealLt_asym.
+  apply (CRealLt_RQ_from_single_dist _ _ (Z.neg n - 1)%Z).
+  unfold CReal_abs, CReal_abs_seq, CReal_abs_scale.
+  unfold CReal_minus, CReal_plus, CReal_plus_seq, CReal_abs_scale.
+  unfold CReal_opp, CReal_opp_seq, CReal_opp_scale.
+  unfold inject_Q.
+  do 4 rewrite CReal_red_seq; rewrite Qred_correct.
+  ring_simplify (Z.neg n - 1 - 1)%Z.
+  pose proof cauchy x (Z.neg n) (Z.neg n - 2)%Z (Z.neg n) ltac:(lia) ltac:(lia) as Hxbnd.
+  apply Qround.Qopp_lt_compat in Hxbnd.
+  apply (Qplus_lt_r _ _ (1#n)) in Hxbnd.
+  apply (Qlt_trans_swap_hyp _ _ _ Hxbnd); clear Hxbnd x.
+  rewrite Qpower_minus_pos.
+  apply (Qplus_lt_r _ _ (2 ^ Z.neg n)%Q); ring_simplify.
+  pose proof Qpower_2powneg_le_inv n as Hpowinv.
+  pose proof Qpower_pos_lt 2 (Z.neg n) ltac:(lra) as Hpowpos.
+  lra.
+Qed.
+
+Lemma CReal_cv_self' : forall (x : CReal) (n : Z),
+    CReal_abs (x - inject_Q (seq x n)) <= inject_Q (2^n).
 Proof.
   intros x n [k kmaj].
-  destruct x as [xn cau].
-  unfold CReal_abs, CReal_minus, CReal_plus, CReal_opp, inject_Q, proj1_sig in kmaj.
+  unfold CReal_abs, CReal_abs_seq, CReal_abs_scale in kmaj.
+  unfold CReal_minus, CReal_plus, CReal_plus_seq, CReal_abs_scale in kmaj.
+  unfold CReal_opp, CReal_opp_seq, CReal_opp_scale in kmaj.
+  unfold inject_Q in kmaj.
+  do 4 rewrite CReal_red_seq in kmaj; rewrite Qred_correct in kmaj.
   apply (Qlt_not_le _ _ kmaj). clear kmaj.
-  unfold QCauchySeq in cau.
-  rewrite <- (Qplus_le_l _ _ (1#n)). ring_simplify. unfold id in cau.
-  destruct (Pos.lt_total (2*k) n). 2: destruct H.
-  - specialize (cau k (2*k)%positive n).
-    assert (k <= 2 * k)%positive.
-    { apply (Pos.le_trans _ (1*k)). apply Pos.le_refl.
-      apply Pos.mul_le_mono_r. discriminate. }
-    apply (Qle_trans _ (1#k)). rewrite Qred_correct. apply Qlt_le_weak, cau.
-    exact H0. apply (Pos.le_trans _ _ _ H0). apply Pos.lt_le_incl, H.
-    rewrite <- (Qinv_plus_distr 1 1).
-    apply (Qplus_le_l _ _ (-(1#k))). ring_simplify. discriminate.
-  - subst n. rewrite Qplus_opp_r. discriminate.
-  - specialize (cau n (2*k)%positive n).
-    apply (Qle_trans _ (1#n)). rewrite Qred_correct. apply Qlt_le_weak, cau.
-    apply Pos.lt_le_incl, H. apply Pos.le_refl.
-    apply (Qplus_le_l _ _ (-(1#n))). ring_simplify. discriminate.
+  rewrite CReal_red_seq.
+  apply (Qplus_le_l _ _ (2^n)%Q); ring_simplify.
+  pose proof cauchy x (Z.max (k-1)%Z n) (k-1)%Z n ltac:(lia) ltac:(lia) as Hxbnd.
+  apply Qlt_le_weak in Hxbnd.
+  apply (Qle_trans _ _ _ Hxbnd); clear Hxbnd.
+  apply Z.max_case.
+  - rewrite <- Qplus_0_l; apply Qplus_le_compat.
+    + apply Qpower_pos; lra.
+    + rewrite Qpower_minus_pos.
+      pose proof (Qpower_pos_lt 2 k)%Q; lra.
+  - rewrite <- Qplus_0_r; apply Qplus_le_compat.
+    + lra.
+    + pose proof (Qpower_pos_lt 2 k)%Q; lra.
 Qed.
+
+Definition QCauchySeqLin (un : positive -> Q)
+  : Prop
+  := forall (k : positive) (p q : positive),
+      Pos.le k p
+      -> Pos.le k q
+      -> Qlt (Qabs (un p - un q)) (1 # k).
 
 (* We can probably reduce the factor 4. *)
 Lemma Rcauchy_limit : forall (xn : nat -> CReal) (xcau : Un_cauchy_mod xn),
-    QCauchySeq
+    QCauchySeqLin
       (fun n : positive =>
-         let (p, _) := xcau (4 * n)%positive in proj1_sig (xn p) (4 * n)%positive).
+         let (p, _) := xcau (4 * n)%positive in seq (xn p) (4 * Z.neg n)%Z).
 Proof.
-  intros xn xcau n p q H0 H1.
+  intros xn xcau n p q Hp Hq.
   destruct (xcau (4 * p)%positive) as [i imaj],
   (xcau (4 * q)%positive) as [j jmaj].
   assert (CReal_abs (xn i - xn j) <= inject_Q (1 # 4 * n)).
@@ -175,23 +211,23 @@ Proof.
     apply (CReal_le_trans _ _ _ (imaj i j (le_refl _) l)).
     apply inject_Q_le. unfold Qle, Qnum, Qden.
     rewrite Z.mul_1_l, Z.mul_1_l. apply Pos2Z.pos_le_pos.
-    apply Pos.mul_le_mono_l, H0. apply le_S, le_S_n in l.
+    apply Pos.mul_le_mono_l, Hp. apply le_S, le_S_n in l.
     apply (CReal_le_trans _ _ _ (jmaj i j l (le_refl _))).
     apply inject_Q_le. unfold Qle, Qnum, Qden.
     rewrite Z.mul_1_l, Z.mul_1_l. apply Pos2Z.pos_le_pos.
-    apply Pos.mul_le_mono_l, H1. }
+    apply Pos.mul_le_mono_l, Hq. }
   clear jmaj imaj.
   setoid_replace (1#n)%Q with ((1#(3*n)) + ((1#(3*n)) + (1#(3*n))))%Q.
   2: rewrite Qinv_plus_distr, Qinv_plus_distr; reflexivity.
   apply lt_inject_Q. rewrite inject_Q_plus.
   rewrite Qabs_Rabs.
-  apply (CReal_le_lt_trans _ (CReal_abs (inject_Q (proj1_sig (xn i) (4 * p)%positive) - xn i) + CReal_abs (xn i - inject_Q(proj1_sig (xn j) (4 * q)%positive)))).
+  apply (CReal_le_lt_trans _ (CReal_abs (inject_Q (seq (xn i) (4 * Z.neg p)%Z) - xn i) + CReal_abs (xn i - inject_Q(seq (xn j) (4 * Z.neg q)%Z)))).
   unfold Qminus.
   rewrite inject_Q_plus, opp_inject_Q.
-  setoid_replace (inject_Q (proj1_sig (xn i) (4 * p)%positive) +
-                  - inject_Q (proj1_sig (xn j) (4 * q)%positive))
-    with (inject_Q (proj1_sig (xn i) (4 * p)%positive) - xn i
-          + (xn i - inject_Q (proj1_sig (xn j) (4 * q)%positive))).
+  setoid_replace (inject_Q (seq (xn i) (4 * Z.neg p)%Z) +
+                  - inject_Q (seq (xn j) (4 * Z.neg q)%Z))
+    with (inject_Q (seq (xn i) (4 * Z.neg p)%Z) - xn i
+          + (xn i - inject_Q (seq (xn j) (4 * Z.neg q)%Z))).
   2: ring.
   apply CReal_abs_triang. apply CReal_plus_le_lt_compat.
   rewrite CReal_abs_minus_sym. apply (CReal_le_trans _ (inject_Q (1# 4*p))).
@@ -199,9 +235,9 @@ Proof.
   rewrite Z.mul_1_l, Z.mul_1_l.
   apply Pos2Z.pos_le_pos. apply (Pos.le_trans _ (4*n)).
   apply Pos.mul_le_mono_r. discriminate.
-  apply Pos.mul_le_mono_l. exact H0.
+  apply Pos.mul_le_mono_l. exact Hp.
   apply (CReal_le_lt_trans
-           _ (CReal_abs (xn i - xn j + (xn j - inject_Q (proj1_sig (xn j) (4 * q)%positive))))).
+           _ (CReal_abs (xn i - xn j + (xn j - inject_Q (seq (xn j) (4 * Z.neg q)%Z))))).
   apply CReal_abs_morph. ring.
   apply (CReal_le_lt_trans _ _ _ (CReal_abs_triang _ _)).
   rewrite inject_Q_plus. apply CReal_plus_le_lt_compat.
@@ -213,61 +249,405 @@ Proof.
   rewrite Z.mul_1_l, Z.mul_1_l.
   apply Pos2Z.pos_lt_pos. apply (Pos.lt_le_trans _ (4*n)).
   apply Pos.mul_lt_mono_r. reflexivity.
-  apply Pos.mul_le_mono_l. exact H1.
+  apply Pos.mul_le_mono_l. exact Hq.
 Qed.
+
+Definition CReal_from_cauchy_cm (n : Z) : positive :=
+  match n with
+    | Z0
+    | Zpos _ => 1%positive
+    | Zneg p => p
+    end.
+
+Lemma CReal_from_cauchy_cm_mono : forall (n p : Z),
+    (p <= n)%Z
+ -> (CReal_from_cauchy_cm n <= CReal_from_cauchy_cm p)%positive.
+Proof.
+  intros n p Hpn.
+  unfold CReal_from_cauchy_cm; destruct n; destruct p; lia.
+Qed.
+
+Definition CReal_from_cauchy_seq (xn : nat -> CReal) (xcau : Un_cauchy_mod xn) (n : Z) : Q :=
+  let p := CReal_from_cauchy_cm n in
+  let (q, _) := xcau (4 * 2^p)%positive in
+  seq (xn q) (Z.neg p - 2)%Z.
+
+Lemma CReal_from_cauchy_cauchy : forall (xn : nat -> CReal) (xcau : Un_cauchy_mod xn),
+    QCauchySeq (CReal_from_cauchy_seq xn xcau).
+Proof.
+  intros xn xcau n p q Hp Hq.
+  remember (CReal_from_cauchy_cm n) as n'.
+  remember (CReal_from_cauchy_cm p) as p'.
+  remember (CReal_from_cauchy_cm q) as q'.
+  unfold CReal_from_cauchy_seq.
+  rewrite <- Heqp', <- Heqq'.
+  destruct (xcau (4 * 2^p')%positive) as [i imaj].
+  destruct (xcau (4 * 2^q')%positive) as [j jmaj].
+  assert (CReal_abs (xn i - xn j) <= inject_Q (1 # 4 * 2^n')).
+  {
+    destruct (le_lt_dec i j).
+    apply (CReal_le_trans _ _ _ (imaj i j (le_refl _) l)).
+    apply inject_Q_le. unfold Qle, Qnum, Qden.
+    rewrite Z.mul_1_l, Z.mul_1_l. apply Pos2Z.pos_le_pos.
+    subst; apply Pos.mul_le_mono_l, Pos_pow_le_mono_r, CReal_from_cauchy_cm_mono, Hp.
+    apply le_S, le_S_n in l.
+    apply (CReal_le_trans _ _ _ (jmaj i j l (le_refl _))).
+    apply inject_Q_le. unfold Qle, Qnum, Qden.
+    rewrite Z.mul_1_l, Z.mul_1_l. apply Pos2Z.pos_le_pos.
+    subst; apply Pos.mul_le_mono_l, Pos_pow_le_mono_r, CReal_from_cauchy_cm_mono, Hq.
+  }
+  clear jmaj imaj.
+  setoid_replace (2^n)%Q with ((1#3)*2^n + ((1#3)*2^n + (1#3)*2^n))%Q by ring.
+  apply lt_inject_Q. rewrite inject_Q_plus.
+  rewrite Qabs_Rabs.
+  apply (CReal_le_lt_trans _ (CReal_abs (inject_Q (seq (xn i) (Z.neg p' - 2)%Z) - xn i) + CReal_abs (xn i - inject_Q(seq (xn j) (Z.neg q' - 2)%Z)))).
+  {
+    unfold Qminus.
+    rewrite inject_Q_plus, opp_inject_Q.
+    setoid_replace (inject_Q (seq (xn i) (Z.neg p' - 2)%Z) +
+                    - inject_Q (seq (xn j) (Z.neg q' -  2)%Z))
+      with (inject_Q (seq (xn i) (Z.neg p' - 2)%Z) - xn i
+            + (xn i - inject_Q (seq (xn j) (Z.neg q' - 2)%Z))).
+    2: ring.
+    apply CReal_abs_triang.
+  }
+  apply CReal_plus_le_lt_compat.
+  {
+    rewrite CReal_abs_minus_sym.
+    apply (CReal_le_trans _ (inject_Q ((1#4)*2^(Z.neg p')))).
+    - change (1#4)%Q with ((1#2)^2)%Q.
+      rewrite Qmult_comm, <- Qpower_minus_pos.
+      apply CReal_cv_self'.
+    - apply inject_Q_le.
+      apply Qmult_le_compat_nonneg.
+      + lra.
+      + { split.
+          - apply Qpower_pos; lra.
+          - apply Qpower_le_compat.
+            + subst; unfold CReal_from_cauchy_cm; destruct p; lia.
+            + lra. }
+  }
+  apply (CReal_le_lt_trans
+           _ (CReal_abs (xn i - xn j + (xn j - inject_Q (seq (xn j) (Z.neg q' - 2)%Z))))).
+    1: apply CReal_abs_morph; ring.
+  apply (CReal_le_lt_trans _ _ _ (CReal_abs_triang _ _)).
+  rewrite inject_Q_plus.
+  apply CReal_plus_le_lt_compat.
+  {
+    apply (CReal_le_trans _ _ _ H). apply inject_Q_le.
+    rewrite Q_factorDenom.
+    rewrite <- (Z.pow_1_l (Z.pos n')) at 2 by lia.
+    rewrite <- (Qpower_decomp').
+    change (1#2)%Q with (/2)%Q; rewrite Qinv_power, <- Qpower_opp.
+    apply Qmult_le_compat_nonneg.
+    - lra.
+    - { split.
+        - apply Qpower_pos; lra.
+        - apply Qpower_le_compat.
+          + subst; unfold CReal_from_cauchy_cm; destruct n; lia.
+          + lra. }
+  }
+  apply (CReal_le_lt_trans _ (inject_Q ((1#4)*2^(Z.neg q')))).
+  {
+    change (1#4)%Q with ((1#2)^2)%Q.
+    rewrite Qmult_comm, <- Qpower_minus_pos.
+    apply CReal_cv_self'.
+  }
+  apply inject_Q_lt.
+  setoid_rewrite Qmult_comm at 1 2.
+  apply Qmult_lt_le_compat_nonneg.
+  + { split.
+      - apply Qpower_pos_lt; lra.
+      - apply Qpower_le_compat.
+        + subst; unfold CReal_from_cauchy_cm. destruct q; lia.
+        + lra. }
+  + lra.
+Qed.
+
+Lemma Rup_pos (x : CReal)
+  : { n : positive  &  x < inject_Q (Z.pos n # 1) }.
+Proof.
+  intros. destruct (CRealArchimedean x) as [p [maj _]].
+  destruct p.
+  - exists 1%positive. apply (CReal_lt_trans _ 0 _ maj). apply CRealLt_0_1.
+  - exists p. exact maj.
+  - exists 1%positive. apply (CReal_lt_trans _ (inject_Q (Z.neg p # 1)) _ maj).
+    apply (CReal_lt_trans _ 0). apply inject_Q_lt. reflexivity.
+    apply CRealLt_0_1.
+Qed.
+
+Lemma CReal_abs_upper_bound (x : CReal)
+  : { n : positive  &  CReal_abs x < inject_Q (Z.pos n # 1) }.
+Proof.
+  intros.
+  destruct (Rup_pos x) as [np Hnp].
+  destruct (Rup_pos (-x)) as [nn Hnn].
+  exists (Pos.max np nn).
+  apply Rabs_def1.
+  - apply (CReal_lt_le_trans _ _ _ Hnp), inject_Q_le.
+    unfold Qle, Qnum, Qden; ring_simplify. lia.
+  - apply (CReal_lt_le_trans _ _ _ Hnn), inject_Q_le.
+    unfold Qle, Qnum, Qden; ring_simplify. lia.
+Qed.
+
+Require Import Qminmax.
+
+Lemma CRealLt_QR_from_single_dist : forall (q : Q) (r : CReal) (n :Z),
+    (2^n < seq r n - q)%Q
+ -> inject_Q q < r .
+Proof.
+  intros q r n Hapart.
+  pose proof Qpower_pos_lt 2 n ltac:(lra) as H2npos.
+  destruct (QarchimedeanLowExp2_Z (seq r n - q - 2^n) ltac:(lra)) as [k Hk].
+  unfold CRealLt; exists (Z.min n (k-1))%Z.
+  unfold inject_Q; rewrite CReal_red_seq.
+  pose proof cauchy r n n (Z.min n (k-1))%Z ltac:(lia) ltac:(lia) as Hrbnd.
+  pose proof Qpower_le_compat 2 (Z.min n (k - 1))%Z (k-1)%Z ltac:(lia) ltac:(lra).
+  apply (Qmult_le_l _ _ 2 ltac:(lra)) in H.
+  apply (Qle_lt_trans _ _ _ H); clear H.
+  rewrite Qpower_minus_pos.
+  ring_simplify.
+  apply Qabs_Qlt_condition in Hrbnd.
+  lra.
+Qed.
+
+Lemma CReal_abs_Qabs: forall (x : CReal) (q : Q) (n : Z),
+    CReal_abs x <= inject_Q q
+ -> (Qabs (seq x n) <= q + 2^n)%Q.
+Proof.
+  intros x q n Hr.
+  unfold CRealLe in Hr.
+  apply Qnot_lt_le; intros Hq; apply Hr; clear Hr.
+  apply (CRealLt_QR_from_single_dist _ _ n%Z).
+  unfold CReal_abs, CReal_abs_seq; rewrite CReal_red_seq.
+  lra.
+Qed.
+
+Lemma CReal_abs_Qabs_seq: forall (x : CReal) (n : Z),
+    (seq (CReal_abs x) n == Qabs (seq x n))%Q.
+Proof.
+  intros x n.
+  unfold CReal_abs, CReal_abs_seq; rewrite CReal_red_seq.
+  reflexivity.
+Qed.
+
+Lemma CReal_abs_Qabs_diff: forall (x y : CReal) (q : Q) (n : Z),
+    CReal_abs (x - y) <= inject_Q q
+ -> (Qabs (seq x n - seq y n) <= q + 2*2^n)%Q.
+Proof.
+  intros x y q n Hr.
+  unfold CRealLe in Hr.
+  apply Qnot_lt_le; intros Hq; apply Hr; clear Hr.
+  apply (CRealLt_QR_from_single_dist _ _ (n+1)%Z).
+  unfold CReal_abs, CReal_abs_seq; rewrite CReal_red_seq.
+  unfold CReal_minus, CReal_plus, CReal_plus_seq; rewrite CReal_red_seq, Qred_correct.
+  unfold CReal_opp, CReal_opp_seq; rewrite CReal_red_seq.
+  ring_simplify (n + 1 - 1)%Z.
+  rewrite Qpower_plus by lra.
+  ring_simplify; change (seq x n + - seq y n)%Q with (seq x n - seq y n)%Q.
+  lra.
+Qed.
+
+(** Note: the <= in the conclusion is likely tight *)
+
+Lemma CRealLt_QR_to_single_dist : forall (q : Q) (x : CReal) (n : Z),
+    inject_Q q < x -> (-(2^n) <= seq x n - q)%Q.
+Proof.
+  intros q x n Hqltx.
+  destruct (Qlt_le_dec (seq x n - q) (-(2^n))  ) as [Hdec|Hdec].
+  - exfalso.
+    pose proof CRealLt_RQ_from_single_dist x q n ltac:(lra) as contra.
+    apply CRealLt_asym in contra. apply contra, Hqltx.
+  - apply Hdec.
+Qed.
+
+Lemma CRealLt_RQ_to_single_dist : forall (x : CReal) (q : Q) (n : Z),
+    x < inject_Q q -> (-(2^n) <= q - seq x n)%Q.
+Proof.
+  intros x q n Hxltq.
+  destruct (Qlt_le_dec (q - seq x n) (-(2^n))  ) as [Hdec|Hdec].
+  - exfalso.
+    pose proof CRealLt_QR_from_single_dist q x n ltac:(lra) as contra.
+    apply CRealLt_asym in contra. apply contra, Hxltq.
+  - apply Hdec.
+Qed.
+
+Lemma Pos2Z_pos_is_pos : forall (p : positive),
+    (1 <= Z.pos p)%Z.
+Proof.
+  intros p.
+  lia.
+Qed.
+
+Lemma Pos_log2floor_plus1_spec_Qpower : forall (p : positive),
+    (2 ^ Z.pos (Pos_log2floor_plus1 p) <= 2 * (Z.pos p#1) < 2 * 2 ^ Z.pos (Pos_log2floor_plus1 p))%Q.
+Proof.
+  intros p; split.
+  -  rewrite Qpower_decomp', Pos_pow_1_r.
+     unfold Qle, Qmult, Qnum, Qden.
+     rewrite Pos.mul_1_r; ring_simplify.
+     pose proof Pos_log2floor_plus1_spec p as Hpos.
+     lia.
+  -  rewrite Qpower_decomp', Pos_pow_1_r.
+     unfold Qlt, Qmult, Qnum, Qden.
+     rewrite Pos.mul_1_r; ring_simplify.
+     pose proof Pos_log2floor_plus1_spec p as Hpos.
+     lia.
+Qed.
+
+Lemma Qabs_Qgt_condition: forall x y : Q,
+  (x < Qabs y)%Q <-> (x < y \/ x < -y)%Q.
+Proof.
+ intros x y.
+ apply Qabs_case; lra.
+Qed.
+
+Lemma CReal_from_cauchy_seq_bound :
+  forall (xn : nat -> CReal) (xcau : Un_cauchy_mod xn) (i j : Z),
+    (Qabs (CReal_from_cauchy_seq xn xcau i - CReal_from_cauchy_seq xn xcau j) <= 1)%Q.
+Proof.
+  intros xn xcau i j.
+  unfold CReal_from_cauchy_seq.
+  destruct (xcau (4 * 2 ^ CReal_from_cauchy_cm i)%positive) as [i' imaj].
+  destruct (xcau (4 * 2 ^ CReal_from_cauchy_cm j)%positive) as [j' jmaj].
+
+  assert (CReal_abs (xn i' - xn j') <= inject_Q (1#4)) as Hxij.
+    {
+    destruct (le_lt_dec i' j').
+    - apply (CReal_le_trans _ _ _ (imaj i' j' (le_refl _) l)).
+      apply inject_Q_le; unfold Qle, Qnum, Qden; ring_simplify.
+      apply Pos2Z_pos_is_pos.
+    - apply le_S, le_S_n in l.
+      apply (CReal_le_trans _ _ _ (jmaj i' j' l (le_refl _))).
+      apply inject_Q_le; unfold Qle, Qnum, Qden; ring_simplify.
+      apply Pos2Z_pos_is_pos.
+    }
+  clear imaj jmaj.
+  unfold CReal_abs, CReal_abs_seq in Hxij.
+  unfold CRealLe, CRealLt in Hxij.
+  rewrite CReal_red_seq in Hxij.
+  apply Qnot_lt_le; intros Hxij'; apply Hxij; clear Hxij.
+  exists (-2)%Z.
+  unfold inject_Q; rewrite CReal_red_seq.
+  unfold CReal_minus, CReal_plus, CReal_plus_seq; rewrite CReal_red_seq, Qred_correct.
+  unfold CReal_opp, CReal_opp_seq; rewrite CReal_red_seq.
+  change (2 * 2 ^ (-2))%Q with (2#4)%Q.
+  pose proof cauchy (xn i') (-3)%Z (-3)%Z (Z.neg (CReal_from_cauchy_cm i) - 2)%Z
+    ltac:(lia) ltac:(unfold CReal_from_cauchy_cm; destruct i; lia) as Hxibnd.
+  pose proof cauchy (xn j') (-3)%Z (-3)%Z (Z.neg (CReal_from_cauchy_cm j) - 2)%Z
+    ltac:(lia) ltac:(unfold CReal_from_cauchy_cm; destruct j; lia) as Hxjbnd.
+  apply (Qplus_lt_l _ _ (1 # 4)%Q); ring_simplify.
+  (* ToDo: ring_simplify should return reduced fractions *)
+  setoid_replace (12#16)%Q with (3#4)%Q by ring.
+  change (2^(-3))%Q with (1#8)%Q in Hxibnd, Hxjbnd.
+  change (-2-1)%Z with (-3)%Z.
+  apply Qabs_Qlt_condition in Hxibnd.
+  apply Qabs_Qlt_condition in Hxjbnd.
+  apply Qabs_Qgt_condition.
+  apply Qabs_Qgt_condition in Hxij'.
+  lra.
+Qed.
+
+Definition CReal_from_cauchy_scale (xn : nat -> CReal) (xcau : Un_cauchy_mod xn) : Z :=
+  Qbound_lt_ZExp2 (Qabs (CReal_from_cauchy_seq xn xcau (-1)) + 2)%Q.
+
+Lemma CReal_from_cauchy_bound : forall (xn : nat -> CReal) (xcau : Un_cauchy_mod xn),
+  QBound (CReal_from_cauchy_seq xn xcau) (CReal_from_cauchy_scale xn xcau).
+Proof.
+  intros xn xcau n.
+  unfold CReal_from_cauchy_scale.
+
+  (* Use the spec of Qbound_lt_ZExp2 to linearize the RHS *)
+  apply (Qlt_trans_swap_hyp _ _ _ (Qbound_lt_ZExp2_spec _)).
+
+  (* Massage the goal so that CReal_from_cauchy_seq_bound can be applied *)
+  apply (Qplus_lt_l _ _ (-Qabs (CReal_from_cauchy_seq xn xcau (-1)))%Q); ring_simplify.
+  assert(forall x y : Q, (x + -1*y == x-y)%Q) as Aux
+    by (intros x y; lra); rewrite Aux; clear Aux.
+  apply (Qle_lt_trans _ _ _ (Qabs_triangle_reverse _ _)).
+  apply (Qle_lt_trans _ 1%Q _).
+    2: lra.
+  apply CReal_from_cauchy_seq_bound.
+Qed.
+
+Definition CReal_from_cauchy (xn : nat -> CReal) (xcau : Un_cauchy_mod xn) : CReal :=
+{|
+  seq := CReal_from_cauchy_seq xn xcau;
+  scale := CReal_from_cauchy_scale xn xcau;
+  cauchy := CReal_from_cauchy_cauchy xn xcau;
+  bound := CReal_from_cauchy_bound xn xcau
+|}.
 
 Lemma Rcauchy_complete : forall (xn : nat -> CReal),
     Un_cauchy_mod xn
     -> { l : CReal  &  seq_cv xn l }.
 Proof.
   intros xn cau.
-  exists (exist _ (fun n : positive =>
-                let (p, _) := cau (4 * n)%positive in
-                proj1_sig (xn p) (4 * n)%positive)
-           (Rcauchy_limit xn cau)).
+  exists (CReal_from_cauchy xn cau).
+
   intro p.
-  pose proof (CReal_cv_self (exist _ (fun n : positive =>
-                let (p, _) := cau (4 * n)%positive in
-                proj1_sig (xn p) (4 * n)%positive)
-           (Rcauchy_limit xn cau)) (2*p)) as H.
-  unfold proj1_sig in H.
+  pose proof (CReal_cv_self' (CReal_from_cauchy xn cau) (Z.neg p - 1)%Z) as H.
+
   pose proof (cau (2*p)%positive) as [k cv].
-  destruct (cau (4 * (2 * p))%positive) as [i imaj].
-  (* The convergence modulus does not matter here, because a converging Cauchy
-     sequence always converges to its limit with twice the Cauchy modulus. *)
+
+  rewrite CReal_abs_minus_sym in H.
+  unfold CReal_from_cauchy at 1 in H.
+  rewrite CReal_red_seq in H.
+  unfold CReal_from_cauchy_seq in H.
+  remember (CReal_from_cauchy_cm (Z.neg p - 1))%positive as i'.
+  destruct (cau (4 * 2 ^ i')%positive) as [i imaj].
   exists (max k i).
+
   intros j H0.
-  setoid_replace (xn j -
-     exist (fun x : positive -> Q => QCauchySeq x)
-       (fun n : positive =>
-        let (p0, _) := cau (4 * n)%positive in proj1_sig (xn p0) (4 * n)%positive)
-       (Rcauchy_limit xn cau))
-    with (xn j - inject_Q (proj1_sig (xn i) (p~0~0~0)%positive)
-          + (inject_Q (proj1_sig (xn i) (p~0~0~0)%positive) -
-     exist (fun x : positive -> Q => QCauchySeq x)
-       (fun n : positive =>
-        let (p0, _) := cau (4 * n)%positive in proj1_sig (xn p0) (4 * n)%positive)
-       (Rcauchy_limit xn cau))).
-  2: ring. apply (CReal_le_trans _ _ _ (CReal_abs_triang _ _)).
+  setoid_replace (xn j - CReal_from_cauchy xn cau)
+  with (xn j -  inject_Q (seq (xn i) (Z.neg i' - 2)%Z)
+     + (inject_Q (seq (xn i) (Z.neg i' - 2)%Z) - CReal_from_cauchy xn cau)).
+  2: ring.
+  apply (CReal_le_trans _ _ _ (CReal_abs_triang _ _)).
   apply (CReal_le_trans _ (inject_Q (1#2*p) + inject_Q (1#2*p))).
-  apply CReal_plus_le_compat. unfold proj1_sig in H.
-  2: rewrite CReal_abs_minus_sym; exact H.
+  apply CReal_plus_le_compat.
+  2: { apply (CReal_le_trans _ _ _ H). apply inject_Q_le.
+       rewrite Qpower_minus_pos.
+       assert(forall (n:Z) (p q : positive), n#(p*q) == (n#p) * (1#q))%Q as Aux
+         by ( intros; unfold Qeq, Qmult, Qnum, Qden; ring ); rewrite Aux; clear Aux.
+       rewrite Qmult_comm; apply Qmult_le_l; [lra|].
+       pose proof Qpower_2powneg_le_inv p.
+       pose proof Qpower_pos_lt 2 (Z.neg p)%Z; lra. }
+
+  (* Use imaj to relate xn i and xn j *)
   specialize (imaj j i (le_trans _ _ _ (Nat.le_max_r _ _) H0) (le_refl _)).
-  apply (CReal_le_trans _ (inject_Q (1 # 4 * p) + inject_Q (1 # 4 * p))).
-  setoid_replace (xn j - inject_Q (proj1_sig (xn i) (p~0~0~0)%positive))
-    with (xn j - xn i
-          + (xn i - inject_Q (proj1_sig (xn i) (p~0~0~0)%positive))).
-  2: ring. apply (CReal_le_trans _ _ _ (CReal_abs_triang _ _)).
-  apply CReal_plus_le_compat. apply (CReal_le_trans _ _ _ imaj).
-  apply inject_Q_le. unfold Qle, Qnum, Qden.
-  rewrite Z.mul_1_l, Z.mul_1_l.
-  apply Pos2Z.pos_le_pos.
-  apply (Pos.mul_le_mono_r p 4 8). discriminate.
-  apply (CReal_le_trans _ _ _ (CReal_cv_self (xn i) (8*p))).
-  apply inject_Q_le. unfold Qle, Qnum, Qden.
-  rewrite Z.mul_1_l, Z.mul_1_l.
-  apply Pos2Z.pos_le_pos.
-  apply (Pos.mul_le_mono_r p 4 8). discriminate.
+    apply (CReal_le_trans _ (inject_Q (1 # 4 * p) + inject_Q (1 # 4 * p))).
+    setoid_replace (xn j - inject_Q (seq (xn i) (Z.neg i' - 2)))
+    with (xn j - xn i + (xn i - inject_Q (seq (xn i) (Z.neg i' - 2)))).
+      2: ring.
+    apply (CReal_le_trans _ _ _ (CReal_abs_triang _ _)).
+    apply CReal_plus_le_compat. apply (CReal_le_trans _ _ _ imaj).
+    rewrite Heqi'. change (Z.neg p - 1)%Z with (Z.neg (p + 1))%Z.
+    unfold CReal_from_cauchy_cm.
+    apply inject_Q_le.
+    unfold Qle, Qnum, Qden.
+    rewrite Z.mul_1_l, Z.mul_1_l.
+    apply Pos2Z.pos_le_pos, Pos.mul_le_mono_l.
+    pose proof Pospow_lin_le_2pow p.
+    rewrite Pos.add_1_r, Pos.pow_succ_r.
+    lia.
+    clear imaj.
+
+  (* Use CReal_cv_self' to relate xn i and seq (xn i) (...) *)
+  pose proof CReal_cv_self' (xn i) (Z.neg i' - 2).
+    apply (CReal_le_trans _ _ _ H1).
+    apply inject_Q_le.
+    rewrite Heqi'. change (Z.neg p - 1)%Z with (Z.neg (p + 1))%Z.
+    unfold CReal_from_cauchy_cm.
+    change (Z.neg (p + 1))%Z with (Z.neg p - 1)%Z.
+    ring_simplify (Z.neg p - 1 - 2)%Z.
+    rewrite Qpower_minus_pos.
+    assert(forall (n:Z) (p q : positive), n#(p*q) == (n#p) * (1#q))%Q as Aux
+      by ( intros; unfold Qeq, Qmult, Qnum, Qden; ring ); rewrite Aux; clear Aux.
+    pose proof Qpower_2powneg_le_inv p.
+    pose proof Qpower_pos_lt 2 (Z.neg p)%Z; lra.
+
+  (* Solve remaining aux goals *)
   rewrite <- inject_Q_plus. rewrite (inject_Q_morph _ (1#2*p)).
   apply CRealLe_refl. rewrite Qinv_plus_distr; reflexivity.
   rewrite <- inject_Q_plus. rewrite (inject_Q_morph _ (1#p)).
@@ -309,6 +689,65 @@ Proof.
   exists l. intros p. destruct (cv p).
   exists x. exact c.
 Defined.
+
+(* ToDO: Belongs into sumbool.v *)
+Section connectives.
+
+  Variables A B : Prop.
+
+  Hypothesis H1 : {A} + {~A}.
+  Hypothesis H2 : {B} + {~B}.
+
+  Definition sumbool_or_not_or : {A \/ B} + {~(A \/ B)}.
+    case H1; case H2; tauto.
+  Defined.
+
+End connectives.
+
+Lemma Qnot_le_iff_lt: forall x y : Q,
+  ~ (x <= y)%Q <-> (y < x)%Q.
+Proof.
+  intros x y; split.
+  - apply Qnot_le_lt.
+  - apply Qlt_not_le.
+Qed.
+
+Lemma Qnot_lt_iff_le: forall x y : Q,
+  ~ (x < y)%Q <-> (y <= x)%Q.
+Proof.
+  intros x y; split.
+  - apply Qnot_lt_le.
+  - apply Qle_not_lt.
+Qed.
+
+Lemma CRealLtDisjunctEpsilon : forall a b c d : CReal,
+    (CRealLtProp a b \/ CRealLtProp c d) -> CRealLt a b  +  CRealLt c d.
+Proof.
+  intros.
+  (* Combine both existentials into one *)
+  assert (exists n : Z, 2*2^n < seq b n - seq a n \/ 2*2^n < seq d n - seq c n)%Q.
+  { destruct H.
+    - destruct H as [n maj]. exists n. left. apply maj.
+    - destruct H as [n maj]. exists n. right. apply maj. }
+  apply constructive_indefinite_ground_description_Z in H0.
+  - destruct H0 as [n maj].
+    destruct (Qlt_le_dec (2 * 2^n) (seq b n - seq a n)).
+    + left. exists n. apply q.
+    + assert (2 * 2^n < seq d n - seq c n)%Q.
+      { destruct maj. exfalso.
+        apply (Qlt_not_le (2 * 2^n) (seq b n - seq a n)); assumption.
+        assumption. }
+      clear maj. right. exists n.
+      apply H0.
+  - clear H0 H. intro n.
+    apply sumbool_or_not_or.
+    + destruct (Qlt_le_dec (2 * 2 ^ n)%Q (seq b n - seq a n)%Q).
+      * left; assumption.
+      * right; apply Qle_not_lt; assumption.
+    + destruct (Qlt_le_dec (2 * 2 ^ n)%Q (seq d n - seq c n)%Q).
+      * left; assumption.
+      * right; apply Qle_not_lt; assumption.
+Qed.
 
 Definition CRealConstructive : ConstructiveReals
   := Build_ConstructiveReals

--- a/theories/Reals/Cauchy/PosExtra.v
+++ b/theories/Reals/Cauchy/PosExtra.v
@@ -1,0 +1,32 @@
+Require Import PArith.
+Require Import ZArith.
+Require Import Lia.
+
+Lemma Pos_pow_1_r: forall p : positive,
+  (1^p = 1)%positive.
+Proof.
+  intros p.
+  assert (forall q:positive, Pos.iter id 1 q = 1)%positive as H1.
+  { intros q; apply Pos.iter_invariant; tauto. }
+  induction p.
+  - cbn; rewrite IHp, H1; reflexivity.
+  - cbn; rewrite IHp, H1; reflexivity.
+  - reflexivity.
+Qed.
+
+Lemma Pos_le_multiple : forall n p : positive, (n <= p * n)%positive.
+Proof.
+  intros n p.
+  rewrite <- (Pos.mul_1_l n) at 1.
+  apply Pos.mul_le_mono_r.
+  destruct p; discriminate.
+Qed.
+
+Lemma Pos_pow_le_mono_r : forall a b c : positive,
+    (b <= c)%positive
+ -> (a ^ b <= a ^ c)%positive.
+Proof.
+  intros a b c.
+  pose proof Z.pow_le_mono_r (Z.pos a) (Z.pos b) (Z.pos c).
+  lia.
+Qed.

--- a/theories/Reals/Cauchy/QExtra.v
+++ b/theories/Reals/Cauchy/QExtra.v
@@ -1,0 +1,637 @@
+Require Import QArith.
+Require Import Qpower.
+Require Import Qabs.
+Require Import Qround.
+Require Import Lia.
+Require Import Lqa. (* This is only used in a few places and could be avoided *)
+Require Import PosExtra.
+
+(** * Lemmas on Q numerator denominator operations *)
+
+Lemma Q_factorDenom : forall (a:Z) (b d:positive), (a # (d * b)) == (1#d) * (a#b).
+Proof.
+  intros. unfold Qeq. simpl. destruct a; reflexivity.
+Qed.
+
+Lemma Q_factorNum_l : forall (a b : Z) (c : positive),
+  (a*b # c == (a # 1) * (b # c))%Q.
+Proof.
+  intros a b c.
+  unfold Qeq; cbn; lia.
+Qed.
+
+Lemma Q_factorNum : forall (a : Z) (b : positive),
+  (a # b == (a # 1) * (1 # b))%Q.
+Proof.
+  intros a b.
+  unfold Qeq; cbn; lia.
+Qed.
+
+Lemma Q_reduce_fl : forall (a b : positive),
+  (Z.pos a # a * b == (1 # b))%Q.
+Proof.
+  intros a b.
+  unfold Qeq; cbn; lia.
+Qed.
+
+(** * Lemmas on Q comparison *)
+
+Lemma Qle_neq: forall p q : Q, p < q <-> p <= q /\ ~ (p == q).
+Proof.
+  intros p q; split; intros H.
+  - rewrite Qlt_alt in H; rewrite Qle_alt, Qeq_alt.
+    rewrite H; split; intros H1; inversion H1.
+  - rewrite Qlt_alt; rewrite Qle_alt, Qeq_alt in H.
+    destruct (p ?= q); tauto.
+Qed.
+
+Lemma Qplus_lt_compat : forall x y z t : Q,
+  (x < y)%Q -> (z < t)%Q -> (x + z < y + t)%Q.
+Proof.
+  intros x y z t H1 H2.
+  apply Qplus_lt_le_compat.
+  - assumption.
+  - apply Qle_lteq; left; assumption.
+Qed.
+
+(* Qgt is just a notation, but one might now know this and search for this lemma *)
+
+Lemma Qgt_lt: forall p q : Q, p > q -> q < p.
+Proof.
+  intros p q H; assumption.
+Qed.
+
+Lemma Qlt_gt: forall p q : Q, p < q -> q > p.
+Proof.
+  intros p q H; assumption.
+Qed.
+
+Notation "x <= y < z" := (x<=y/\y<z) : Q_scope.
+Notation "x < y <= z" := (x<y/\y<=z) : Q_scope.
+Notation "x < y < z" := (x<y/\y<z) : Q_scope.
+
+(** * Lemmas on Qmult *)
+
+Lemma Qmult_lt_0_compat : forall a b : Q,
+    0 < a
+ -> 0 < b
+ -> 0 < a * b.
+Proof.
+  intros a b Ha Hb.
+  destruct a,b. unfold Qlt, Qmult, QArith_base.Qnum, QArith_base.Qden in *.
+  rewrite Pos2Z.inj_mul.
+  rewrite Z.mul_0_l, Z.mul_1_r in *.
+  apply Z.mul_pos_pos; assumption.
+Qed.
+
+Lemma Qmult_lt_1_compat:
+  forall a b : Q, (1 < a)%Q -> (1 < b)%Q -> (1 < a * b)%Q.
+Proof.
+  intros a b Ha Hb.
+  pose proof Qmult_lt_0_compat (a-1) (b-1) ltac:(lra) ltac:(lra).
+  lra.
+Qed.
+
+Lemma Qmult_le_1_compat:
+  forall a b : Q, (1 <= a)%Q -> (1 <= b)%Q -> (1 <= a * b)%Q.
+Proof.
+  intros a b Ha Hb.
+  pose proof Qmult_le_0_compat (a-1) (b-1) ltac:(lra) ltac:(lra).
+  lra.
+Qed.
+
+Lemma Qmult_lt_compat_nonneg: forall x y z t : Q,
+  (0 <= x < y)%Q -> (0 <= z < t)%Q -> (x * z < y * t)%Q.
+Proof.
+  intros [xn xd] [yn yd] [zn zd] [tn td] [H0lex Hxlty] [H0lez Hzltt].
+  (* ToDo: why do I need path qualification to Qnum? It is exported by QArith *)
+  unfold Qmult, Qlt, Qle, QArith_base.Qnum, QArith_base.Qden in *.
+  do 2 rewrite Pos2Z.inj_mul.
+  setoid_replace (xn * zn * (Z.pos yd * Z.pos td))%Z with ((xn * Z.pos yd) * (zn * Z.pos td))%Z by ring.
+  setoid_replace (yn * tn * (Z.pos xd * Z.pos zd))%Z with ((yn * Z.pos xd) * (tn * Z.pos zd))%Z by ring.
+  apply Z.mul_lt_mono_nonneg.
+  - rewrite <- (Z.mul_0_l 0); apply Z.mul_le_mono_nonneg; lia.
+  - exact Hxlty.
+  - rewrite <- (Z.mul_0_l 0); apply Z.mul_le_mono_nonneg; lia.
+  - exact Hzltt.
+Qed.
+
+Lemma Qmult_lt_le_compat_nonneg: forall x y z t : Q,
+  (0 < x <= y)%Q -> (0 < z < t)%Q -> (x * z < y * t)%Q.
+Proof.
+  intros [xn xd] [yn yd] [zn zd] [tn td] [H0lex Hxlty] [H0lez Hzltt].
+  (* ToDo: why do I need path qualification to Qnum? It is exported by QArith *)
+  unfold Qmult, Qlt, Qle, QArith_base.Qnum, QArith_base.Qden in *.
+  do 2 rewrite Pos2Z.inj_mul.
+  setoid_replace (xn * zn * (Z.pos yd * Z.pos td))%Z with ((xn * Z.pos yd) * (zn * Z.pos td))%Z by ring.
+  setoid_replace (yn * tn * (Z.pos xd * Z.pos zd))%Z with ((yn * Z.pos xd) * (tn * Z.pos zd))%Z by ring.
+  apply Zmult_lt_compat2; split.
+  - rewrite <- (Z.mul_0_l 0). apply Z.mul_lt_mono_nonneg; lia.
+  - exact Hxlty.
+  - rewrite <- (Z.mul_0_l 0). apply Z.mul_lt_mono_nonneg; lia.
+  - exact Hzltt.
+Qed.
+
+Lemma Qmult_le_compat_nonneg: forall x y z t : Q,
+  (0 <= x <= y)%Q -> (0 <= z <= t)%Q -> (x * z <= y * t)%Q.
+Proof.
+  intros [xn xd] [yn yd] [zn zd] [tn td] [H0lex Hxlty] [H0lez Hzltt].
+  (* ToDo: why do I need path qualification to Qnum? It is exported by QArith *)
+  unfold Qmult, Qlt, Qle, QArith_base.Qnum, QArith_base.Qden in *.
+  do 2 rewrite Pos2Z.inj_mul.
+  setoid_replace (xn * zn * (Z.pos yd * Z.pos td))%Z with ((xn * Z.pos yd) * (zn * Z.pos td))%Z by ring.
+  setoid_replace (yn * tn * (Z.pos xd * Z.pos zd))%Z with ((yn * Z.pos xd) * (tn * Z.pos zd))%Z by ring.
+  apply Z.mul_le_mono_nonneg.
+  - rewrite <- (Z.mul_0_l 0); apply Z.mul_le_mono_nonneg; lia.
+  - exact Hxlty.
+  - rewrite <- (Z.mul_0_l 0); apply Z.mul_le_mono_nonneg; lia.
+  - exact Hzltt.
+Qed.
+
+(** * Lemmas on Qinv *)
+
+Lemma Qinv_swap_pos: forall (a b : positive),
+  Z.pos a # b == / (Z.pos b # a).
+Proof.
+  intros a b.
+  reflexivity.
+Qed.
+
+Lemma Qinv_swap_neg: forall (a b : positive),
+  Z.neg a # b == / (Z.neg b # a).
+Proof.
+  intros a b.
+  reflexivity.
+Qed.
+
+(** * Lemmas on Qabs *)
+
+Lemma Qabs_Qlt_condition: forall x y : Q,
+  Qabs x < y <-> -y < x < y.
+Proof.
+ split.
+  split.
+   rewrite <- (Qopp_opp x).
+   apply Qopp_lt_compat.
+   apply Qle_lt_trans with (Qabs (-x)).
+   apply Qle_Qabs.
+   now rewrite Qabs_opp.
+  apply Qle_lt_trans with (Qabs x); auto using Qle_Qabs.
+ intros (H,H').
+ apply Qabs_case; trivial.
+ intros. rewrite <- (Qopp_opp y). now apply Qopp_lt_compat.
+Qed.
+
+Lemma Qabs_gt: forall r s : Q,
+    (r < s)%Q -> (r < Qabs s)%Q.
+Proof.
+  intros r s Hrlts.
+  apply Qabs_case; intros; lra.
+Qed.
+
+(** * Lemmas on Qpower *)
+
+Lemma Qpower_0_r: forall q:Q,
+  q^0 == 1.
+Proof.
+  intros q.
+  reflexivity.
+Qed.
+
+Lemma Qpower_1_r: forall q:Q,
+  q^1 == q.
+Proof.
+  intros q.
+  reflexivity.
+Qed.
+
+Lemma Qpower_not_0: forall (a : Q) (z : Z),
+  ~ a == 0 -> ~ Qpower a z == 0.
+Proof.
+  intros a z H; destruct z.
+  - discriminate.
+  - apply Qpower_not_0_positive; assumption.
+  - cbn. intros H1.
+    pose proof Qmult_inv_r (Qpower_positive a p) as H2.
+    specialize (H2 (Qpower_not_0_positive _ _ H)).
+    rewrite H1, Qmult_0_r in H2.
+    discriminate H2.
+Qed.
+
+(* Actually Qpower_pos should be named Qpower_nonneg *)
+
+Lemma Qpower_pos_lt: forall (a : Q) (z : Z),
+  a > 0 -> Qpower a z > 0.
+Proof.
+  intros q z Hpos.
+  pose proof Qpower_pos q z (Qlt_le_weak 0 q Hpos) as H1.
+  pose proof Qpower_not_0 q z as H2.
+  pose proof Qlt_not_eq 0 q Hpos as H3.
+  specialize (H2 (Qnot_eq_sym _ _ H3)); clear H3.
+  apply Qnot_eq_sym in H2.
+  apply Qle_neq; split; assumption.
+Qed.
+
+Lemma Qpower_minus: forall (a : Q) (n m : Z),
+  ~ a == 0 -> a ^ (n - m) == a ^ n / a ^ m.
+Proof.
+  intros a n m Hnz.
+  rewrite <- Z.add_opp_r.
+  rewrite Qpower_plus by assumption.
+  rewrite Qpower_opp.
+  field.
+  apply Qpower_not_0; assumption.
+Qed.
+
+Lemma Qpower_minus_pos: forall (a b : positive) (n m : Z),
+  (Z.pos a#b) ^ (n - m) == (Z.pos a#b) ^ n * (Z.pos b#a) ^ m.
+Proof.
+  intros a b n m.
+  rewrite Qpower_minus by discriminate.
+  rewrite (Qinv_swap_pos b a), Qinv_power.
+  reflexivity.
+Qed.
+
+Lemma Qpower_minus_neg: forall (a b : positive) (n m : Z),
+  (Z.neg a#b) ^ (n - m) == (Z.neg a#b) ^ n * (Z.neg b#a) ^ m.
+Proof.
+  intros a b n m.
+  rewrite Qpower_minus by discriminate.
+  rewrite (Qinv_swap_neg b a), Qinv_power.
+  reflexivity.
+Qed.
+
+Lemma Qpower_lt_1_increasing:
+  forall (q : Q) (n : positive), (1<q)%Q -> (1 < q ^ (Z.pos n))%Q.
+Proof.
+  intros q n Hq.
+  induction n.
+  - cbn in *.
+    apply Qmult_lt_1_compat. assumption.
+    apply Qmult_lt_1_compat; assumption.
+  - cbn in *.
+    apply Qmult_lt_1_compat; assumption.
+  - cbn; assumption.
+Qed.
+
+Lemma Qpower_lt_1_increasing':
+  forall (q : Q) (n : Z), (1<q)%Q -> (0<n)%Z -> (1 < q ^ n)%Q.
+Proof.
+  intros q n Hq Hn.
+  destruct n.
+  - inversion Hn.
+  - apply Qpower_lt_1_increasing; assumption.
+  - lia.
+Qed.
+
+Lemma Qzero_eq: forall (d : positive),
+  (0#d == 0)%Q.
+Proof.
+  intros d.
+  unfold Qeq, Qnum, Qden; reflexivity.
+Qed.
+
+Lemma Qpower_le_1_increasing:
+  forall (q : Q) (n : positive), (1<=q)%Q -> (1 <= q ^ (Z.pos n))%Q.
+Proof.
+  intros q n Hq.
+  induction n.
+  - cbn in *.
+    apply Qmult_le_1_compat. assumption.
+    apply Qmult_le_1_compat; assumption.
+  - cbn in *.
+    apply Qmult_le_1_compat; assumption.
+  - cbn; assumption.
+Qed.
+
+Lemma Qpower_le_1_increasing':
+  forall (q : Q) (n : Z), (1<=q)%Q -> (0<=n)%Z -> (1 <= q ^ n)%Q.
+Proof.
+  intros q n Hq Hn.
+  destruct n.
+  - apply Qle_refl.
+  - apply Qpower_le_1_increasing; assumption.
+  - lia.
+Qed.
+
+(* ToDo: check if name compat_r is more appropriate *)
+
+Lemma Qpower_lt_compat:
+  forall (q : Q) (n m : Z), (n < m)%Z -> (1<q)%Q -> (q ^ n < q ^ m)%Q.
+Proof.
+  intros q n m Hnm Hq.
+  replace m with (n+(m-n))%Z by ring.
+  rewrite Qpower_plus, <- Qmult_1_r, <- Qmult_assoc.
+    2: lra.
+  rewrite Qmult_lt_l, Qmult_1_l.
+    2: apply Qpower_pos_lt; lra.
+  remember (m-n)%Z as k.
+  apply Qpower_lt_1_increasing'.
+  - exact Hq.
+  - lia.
+Qed.
+
+Lemma Qpower_le_compat:
+  forall (q : Q) (n m : Z), (n <= m)%Z -> (1<=q)%Q -> (q ^ n <= q ^ m)%Q.
+Proof.
+  intros q n m Hnm Hq.
+  replace m with (n+(m-n))%Z by ring.
+  rewrite Qpower_plus, <- Qmult_1_r, <- Qmult_assoc.
+    2: lra.
+  rewrite Qmult_le_l, Qmult_1_l.
+    2: apply Qpower_pos_lt; lra.
+  remember (m-n)%Z as k.
+  apply Qpower_le_1_increasing'.
+  - exact Hq.
+  - lia.
+Qed.
+
+Lemma Qpower_lt_compat_inv:
+  forall (q : Q) (n m : Z), (q ^ n < q ^ m)%Q -> (1<q)%Q -> (n < m)%Z.
+Proof.
+  intros q n m Hnm Hq.
+  destruct (Z_lt_le_dec n m) as [Hd|Hd].
+  - assumption.
+  - pose proof Qpower_le_compat q m n Hd ltac:(lra).
+  lra.
+Qed.
+
+Lemma Qpower_le_compat_inv:
+  forall (q : Q) (n m : Z), (q ^ n <= q ^ m)%Q -> (1<q)%Q -> (n <= m)%Z.
+Proof.
+  intros q n m Hnm Hq.
+  destruct (Z_lt_le_dec m n) as [Hd|Hd].
+  - pose proof Qpower_lt_compat q m n Hd Hq.
+    lra.
+  - assumption.
+Qed.
+
+Lemma Qpower_decomp': forall (p : positive) (a : Z) (b : positive),
+  (a # b) ^ (Z.pos p) == a ^ (Z.pos p) # (b ^ p)%positive.
+Proof.
+  intros p a b.
+  pose proof Qpower_decomp p a b.
+  cbn; rewrite H; reflexivity.
+Qed.
+
+
+(** * Power of 2 open and closed upper and lower bounds for [q : Q] *)
+
+Lemma QarchimedeanExp2_Pos : forall q : Q,
+  {p : positive | (q < Z.pos (2^p) # 1)%Q}.
+Proof.
+  intros q.
+  destruct (Qarchimedean q) as [pexp Hpexp].
+  exists (Pos.size pexp).
+  pose proof Pos.size_gt pexp as H1.
+  unfold Qlt in *. cbn in *; Zify.zify.
+  apply (Z.mul_lt_mono_pos_r (QDen q)) in H1; [|assumption].
+  apply (Z.lt_trans _ _ _ Hpexp H1).
+Qed.
+
+Fixpoint Pos_log2floor_plus1 (p : positive) : positive :=
+  match p with
+  | (p'~1)%positive => Pos.succ (Pos_log2floor_plus1 p')
+  | (p'~0)%positive => Pos.succ (Pos_log2floor_plus1 p')
+  | 1%positive      => 1
+  end.
+
+Lemma Pos_log2floor_plus1_spec : forall (p : positive),
+  (Pos.pow 2 (Pos_log2floor_plus1 p) <= 2 * p < 2 * Pos.pow 2 (Pos_log2floor_plus1 p))%positive.
+Proof.
+  intros p.
+  split.
+  - induction p.
+    + cbn. rewrite Pos.pow_succ_r. lia.
+    + cbn. rewrite Pos.pow_succ_r. lia.
+    + cbn. lia.
+  - induction p.
+    + cbn. rewrite Pos.pow_succ_r. lia.
+    + cbn. rewrite Pos.pow_succ_r. lia.
+    + cbn. lia.
+Qed.
+
+Fixpoint Pos_log2ceil_plus1 (p : positive) : positive :=
+  match p with
+  | (p'~1)%positive => Pos.succ (Pos.succ (Pos_log2floor_plus1 p'))
+  | (p'~0)%positive => Pos.succ (Pos_log2ceil_plus1 p')
+  | 1%positive      => 1
+  end.
+
+Lemma Pos_log2ceil_plus1_spec : forall (p : positive),
+  (Pos.pow 2 (Pos_log2ceil_plus1 p) < 4 * p <= 2 * Pos.pow 2 (Pos_log2ceil_plus1 p))%positive.
+Proof.
+  intros p.
+  split.
+  - induction p.
+    + cbn. do 2 rewrite Pos.pow_succ_r.
+      pose proof Pos_log2floor_plus1_spec p. lia.
+    + cbn. rewrite Pos.pow_succ_r. lia.
+    + cbn. lia.
+  - induction p.
+    + cbn. do 2 rewrite Pos.pow_succ_r.
+      pose proof Pos_log2floor_plus1_spec p. lia.
+    + cbn. rewrite Pos.pow_succ_r. lia.
+    + cbn. lia.
+Qed.
+
+Fixpoint Pos_is_pow2 (p : positive) : bool :=
+  match p with
+  | (p'~1)%positive => false
+  | (p'~0)%positive => Pos_is_pow2 p'
+  | 1%positive      => true
+  end.
+
+(** ** Power of two closed upper bound [q <= 2^z] *)
+
+Definition Qbound_le_ZExp2 (q : Q) : Z :=
+  match Qnum q with
+  (* The -1000 is a compromise between a tight Archimedian and avoiding too large numbers *)
+  | Z0 => -1000
+  | Zneg p => 0
+  | Zpos p => (Z.pos (Pos_log2ceil_plus1 p) - Z.pos (Pos_log2floor_plus1 (Qden q)))%Z
+  end.
+
+Lemma Qbound_le_ZExp2_spec : forall (q : Q),
+  (q <= 2^(Qbound_le_ZExp2 q))%Q.
+Proof.
+  intros q.
+  destruct q as [num den]; unfold Qbound_le_ZExp2, Qnum; destruct num.
+  - intros contra; inversion contra.
+  - rewrite Qpower_minus by lra.
+    apply Qle_shift_div_l.
+      apply Qpower_pos_lt; lra.
+    do 2 rewrite Qpower_decomp', Pos_pow_1_r.
+    unfold Qle, Qmult, Qnum, Qden.
+    rewrite Pos.mul_1_r, Z.mul_1_r.
+    pose proof Pos_log2ceil_plus1_spec p as Hnom.
+    pose proof Pos_log2floor_plus1_spec den as Hden.
+
+    apply (Zmult_le_reg_r _ _ 2).
+        lia.
+    replace (Z.pos p * 2 ^ Z.pos (Pos_log2floor_plus1 den) * 2)%Z
+      with ((Z.pos p * 2) * 2 ^ Z.pos (Pos_log2floor_plus1 den))%Z by ring.
+    replace (2 ^ Z.pos (Pos_log2ceil_plus1 p) * Z.pos den * 2)%Z
+      with (2 ^ Z.pos (Pos_log2ceil_plus1 p) * (Z.pos den * 2))%Z by ring.
+    apply Z.mul_le_mono_nonneg; lia.
+  - intros contra; inversion contra.
+Qed.
+
+Definition Qbound_leabs_ZExp2 (q : Q) : Z := Qbound_le_ZExp2 (Qabs q).
+
+Lemma Qbound_leabs_ZExp2_spec : forall (q : Q),
+  (Qabs q <= 2^(Qbound_leabs_ZExp2 q))%Q.
+Proof.
+  intros q.
+  unfold Qbound_leabs_ZExp2; apply Qabs_case; intros.
+  1,2: apply Qbound_le_ZExp2_spec.
+Qed.
+
+(** ** Power of two open upper bound [q < 2^z] and [Qabs q < 2^z] *)
+
+(** Compute a z such that q<2^z.
+    z shall be close to as small as possible, but we need a compromise between
+    the tighness of the bound and the computation speed and proof complexity.
+    Looking just at the log2 of the numerator and denominator, this is a tight bound
+    except when the numerator is a power of 2 and the denomintor is not.
+    E.g. this return 4/5 < 2^1 instead of 4/5< 2^0.
+    If q==0, we return -1000, because as binary integer this has just 10 bits but
+    2^-1000 should be smaller than almost any number in practice.
+    If numbers are much smaller, computations might be inefficient. *)
+
+Definition Qbound_lt_ZExp2 (q : Q) : Z :=
+  match Qnum q with
+  (* The -1000 is a compromise between a tight Archimedian and avoiding too large numbers *)
+  | Z0 => -1000
+  | Zneg p => 0
+  | Zpos p => Z.pos_sub (Pos.succ (Pos_log2floor_plus1 p)) (Pos_log2floor_plus1 (Qden q))
+  end.
+
+Remark Qbound_lt_ZExp2_test_1 : Qbound_lt_ZExp2 (4#4) = 1%Z. reflexivity. Qed.
+Remark Qbound_lt_ZExp2_test_2 : Qbound_lt_ZExp2 (5#4) = 1%Z. reflexivity. Qed.
+Remark Qbound_lt_ZExp2_test_3 : Qbound_lt_ZExp2 (4#5) = 1%Z. reflexivity. Qed.
+Remark Qbound_lt_ZExp2_test_4 : Qbound_lt_ZExp2 (7#5) = 1%Z. reflexivity. Qed.
+
+Lemma Qbound_lt_ZExp2_spec : forall (q : Q),
+  (q < 2^(Qbound_lt_ZExp2 q))%Q.
+Proof.
+  intros q.
+  destruct q as [num den]; unfold Qbound_lt_ZExp2, Qnum; destruct num.
+  - reflexivity.
+  - (* Todo: A lemma like Pos2Z.add_neg_pos for minus would be nice *)
+    change
+      (Z.pos_sub (Pos.succ (Pos_log2floor_plus1 p)) (Pos_log2floor_plus1 (Qden (Z.pos p # den))))%Z
+    with
+      ((Z.pos (Pos.succ (Pos_log2floor_plus1 p)) - Z.pos (Pos_log2floor_plus1 (Qden (Z.pos p # den)))))%Z.
+    rewrite Qpower_minus by lra.
+    apply Qlt_shift_div_l.
+      apply Qpower_pos_lt; lra.
+    do 2 rewrite Qpower_decomp', Pos_pow_1_r.
+    unfold Qlt, Qmult, Qnum, Qden.
+    rewrite Pos.mul_1_r, Z.mul_1_r.
+    pose proof Pos_log2floor_plus1_spec p as Hnom.
+    pose proof Pos_log2floor_plus1_spec den as Hden.
+    apply (Zmult_lt_reg_r _ _ 2).
+      lia.
+    rewrite Pos2Z.inj_succ, <- Z.add_1_r.
+    rewrite Z.pow_add_r by lia.
+
+    replace (Z.pos p * 2 ^ Z.pos (Pos_log2floor_plus1 den) * 2)%Z
+      with (2 ^ Z.pos (Pos_log2floor_plus1 den) * (Z.pos p * 2))%Z by ring.
+    replace (2 ^ Z.pos (Pos_log2floor_plus1 p) * 2 ^ 1 * Z.pos den * 2)%Z
+      with ((Z.pos den * 2) * (2 * 2 ^ Z.pos (Pos_log2floor_plus1 p)))%Z by ring.
+
+    (* ToDo: this is weaker than neccessary: Z.mul_lt_mono_nonneg. *)
+    apply Zmult_lt_compat2; lia.
+  - cbn.
+    (* ToDo: lra could know that negative fractions are negative *)
+    assert (Z.neg p # den < 0) as Hnegfrac by (unfold Qlt, Qnum, Qden; lia).
+    lra.
+Qed.
+
+Definition Qbound_ltabs_ZExp2 (q : Q) : Z := Qbound_lt_ZExp2 (Qabs q).
+
+Lemma Qbound_ltabs_ZExp2_spec : forall (q : Q),
+  (Qabs q < 2^(Qbound_ltabs_ZExp2 q))%Q.
+Proof.
+  intros q.
+  unfold Qbound_ltabs_ZExp2; apply Qabs_case; intros.
+  1,2: apply Qbound_lt_ZExp2_spec.
+Qed.
+
+(** ** Power of 2 open lower bounds for [2^z < q] and [2^z < Qabs q] *)
+
+(** Note: the -2 is required cause of the Qlt limit.
+    In case q is a power of two, the lower and upper bound must be a factor of 4 apart *)
+Definition Qlowbound_ltabs_ZExp2 (q : Q) : Z := -2 + Qbound_ltabs_ZExp2 q.
+
+Lemma Qlowbound_ltabs_ZExp2_inv: forall q : Q,
+    q > 0
+ -> Qlowbound_ltabs_ZExp2 q = (- Qbound_ltabs_ZExp2 (/q))%Z.
+Proof.
+  intros q Hqgt0.
+  destruct q as [n d].
+  unfold Qlowbound_ltabs_ZExp2, Qbound_ltabs_ZExp2, Qbound_lt_ZExp2, Qnum.
+  destruct n.
+  - inversion Hqgt0.
+  - unfold Qabs, Z.abs, Qinv, Qnum, Qden.
+    rewrite -> Z.pos_sub_opp.
+    do 2 rewrite <- Pos2Z.add_pos_neg.
+    lia.
+  - inversion Hqgt0.
+Qed.
+
+Lemma Qlowbound_ltabs_ZExp2_opp: forall q : Q,
+  (Qlowbound_ltabs_ZExp2 q = Qlowbound_ltabs_ZExp2 (-q))%Z.
+Proof.
+  intros q.
+  destruct q as [[|n|n] d]; reflexivity.
+Qed.
+
+Lemma Qlowbound_lt_ZExp2_spec : forall (q : Q) (Hqgt0 : q > 0),
+  (2^(Qlowbound_ltabs_ZExp2 q) < q)%Q.
+Proof.
+  intros q Hqgt0.
+  pose proof Qbound_ltabs_ZExp2_spec (/q) as Hspecub.
+  rewrite Qlowbound_ltabs_ZExp2_inv by exact Hqgt0.
+  rewrite Qpower_opp.
+  setoid_rewrite <- (Qinv_involutive q) at 2.
+  apply -> Qinv_lt_contravar.
+  - rewrite Qabs_pos in Hspecub.
+    + exact Hspecub.
+    + apply Qlt_le_weak, Qinv_lt_0_compat, Hqgt0.
+  - apply Qpower_pos_lt; lra.
+  - apply Qinv_lt_0_compat, Hqgt0.
+Qed.
+
+Lemma Qlowbound_ltabs_ZExp2_spec : forall (q : Q) (Hqgt0 : ~ q == 0),
+  (2^(Qlowbound_ltabs_ZExp2 q) < Qabs q)%Q.
+Proof.
+  intros q Hqgt0.
+  destruct (Q_dec 0 q) as [[H|H]|H].
+  - rewrite Qabs_pos by lra.
+    apply Qlowbound_lt_ZExp2_spec, H.
+  - rewrite Qabs_neg by lra.
+    rewrite Qlowbound_ltabs_ZExp2_opp.
+    apply Qlowbound_lt_ZExp2_spec.
+    lra.
+  - lra.
+Qed.
+
+(** ** Existential formulations of power of 2 lower and upper bounds *)
+
+Definition QarchimedeanExp2_Z (q : Q)
+  :  {z : Z | (q < 2^z)%Q}
+  := exist _ (Qbound_lt_ZExp2 q) (Qbound_lt_ZExp2_spec q).
+
+Definition QarchimedeanAbsExp2_Z (q : Q)
+  :  {z : Z | (Qabs q < 2^z)%Q}
+  := exist _ (Qbound_ltabs_ZExp2 q) (Qbound_ltabs_ZExp2_spec q).
+
+Definition QarchimedeanLowExp2_Z (q : Q) (Hqgt0 : q > 0)
+  :  {z : Z | (2^z < q)%Q}
+  := exist _ (Qlowbound_ltabs_ZExp2 q) (Qlowbound_lt_ZExp2_spec q Hqgt0).
+
+Definition QarchimedeanLowAbsExp2_Z (q : Q) (Hqgt0 : ~ q == 0)
+  :  {z : Z | (2^z < Qabs q)%Q}
+  := exist _ (Qlowbound_ltabs_ZExp2 q) (Qlowbound_ltabs_ZExp2_spec q Hqgt0).

--- a/theories/Reals/ClassicalConstructiveReals.v
+++ b/theories/Reals/ClassicalConstructiveReals.v
@@ -219,7 +219,7 @@ Qed.
 Lemma Rarchimedean : forall x y : R, x < y -> {q : Q & ((x < IQR q) * (IQR q < y))%type}.
 Proof.
   intros. rewrite Rlt_def in H. apply CRealLtEpsilon in H.
-  apply FQ_dense in H. destruct H as [q [H2 H3]].
+  apply CRealQ_dense in H. destruct H as [q [H2 H3]].
   exists q. split. rewrite Rlt_def. apply CRealLtForget.
   unfold IQR. rewrite Rquot2. exact H2.
   rewrite Rlt_def. apply CRealLtForget.

--- a/theories/Reals/ClassicalDedekindReals.v
+++ b/theories/Reals/ClassicalDedekindReals.v
@@ -15,6 +15,83 @@ Require Import QArith.
 Require Import Qabs.
 Require Import ConstructiveCauchyReals.
 Require Import ConstructiveRcomplete.
+Require Import Lia.
+Require Import Lqa.
+Require Import Qpower.
+Require Import QExtra.
+Require CMorphisms.
+
+(*****************************************************************************)
+(** * Q Auxiliary Lemmas                                                     *)
+(*****************************************************************************)
+
+(*
+Fixpoint PosPow2_nat (n : nat) : positive :=
+  match n with
+  | O => 1
+  | S n' => 2 * (PosPow2_nat n')
+  end.
+
+Local Lemma Qpower_2_neg_eq_pospow_inv : forall n : nat,
+    (2 ^ (- Z.of_nat n) == 1#(PosPow2_nat n)%positive)%Q.
+Proof.
+  intros n; induction n.
+  - reflexivity.
+  - change (PosPow2_nat (S n)) with (2*(PosPow2_nat n))%positive.
+    rewrite Q_factorDenom.
+    rewrite Nat2Z.inj_succ, Z.opp_succ, <- Z.sub_1_r.
+    rewrite Qpower_minus_pos.
+    change ((1 # 2) ^ 1)%Q with (1 # 2)%Q.
+    rewrite Qmult_comm, IHn; reflexivity.
+Qed.
+*)
+
+Local Lemma Qpower_2_neg_eq_natpow_inv : forall n : nat,
+    (2 ^ (- Z.of_nat n) == 1#(Pos.of_nat (2^n)%nat))%Q.
+Proof.
+  intros n; induction n.
+  - reflexivity.
+  - rewrite Nat.pow_succ_r'.
+    rewrite Nat2Pos.inj_mul.
+    3: apply Nat.pow_nonzero; intros contra; inversion contra.
+    2: intros contra; inversion contra.
+    change (Pos.of_nat 2)%nat with 2%positive.
+    rewrite Q_factorDenom.
+    rewrite Nat2Z.inj_succ, Z.opp_succ, <- Z.sub_1_r.
+    rewrite Qpower_minus_pos.
+    change ((1 # 2) ^ 1)%Q with (1 # 2)%Q.
+    rewrite Qmult_comm, IHn; reflexivity.
+Qed.
+
+
+Local Lemma Qpower_2_invneg_le_pow : forall n : Z,
+    (1 # Pos.of_nat (2 ^ Z.to_nat (- n)) <= 2 ^ n)%Q.
+Proof.
+  intros n; destruct n.
+  - intros contra; inversion contra.
+  - (* ToDo: find out why this works - somehow 1#(...) seems to be coereced to 1 *)
+    apply (Qpower_le_1_increasing 2 p ltac:(lra)).
+  - rewrite <- Qpower_2_neg_eq_natpow_inv.
+    rewrite Z2Nat.id by lia.
+    rewrite Z.opp_involutive.
+    apply Qle_refl.
+Qed.
+
+Local Lemma Qpower_2_neg_le_one : forall n : nat,
+    (2 ^ (- Z.of_nat n) <= 1)%Q.
+Proof.
+  intros n; induction n.
+  - intros contra; inversion contra.
+  - rewrite Nat2Z.inj_succ, Z.opp_succ, <- Z.sub_1_r.
+    rewrite Qpower_minus_pos.
+    lra.
+Qed.
+
+(*****************************************************************************)
+(** * Dedekind cuts                                                          *)
+(*****************************************************************************)
+
+(** ** Definition *)
 
 (**
    Classical Dedekind reals. With the 3 logical axioms funext,
@@ -43,6 +120,8 @@ Definition isLowerCut (f : Q -> bool) : Prop
      (* openness, the cut contains rational numbers
         strictly lower than a real number. *)
      /\ (forall q:Q, f q = true -> ~(forall r:Q, Qle r q \/ f r = false)).
+
+(** ** Properties *)
 
 Lemma isLowerCut_hprop : forall (f : Q -> bool),
     IsHProp (isLowerCut f).
@@ -96,8 +175,34 @@ Proof.
     rewrite positive_nat_Z. apply Qlt_le_weak, pmaj. apply e.
 Qed.
 
+Lemma lowerUpper : forall (f : Q -> bool) (q r : Q),
+    isLowerCut f -> Qle q r -> f q = false -> f r = false.
+Proof.
+  intros. destruct H. specialize (H q r H0). destruct (f r) eqn:desR.
+  2: reflexivity. exfalso. specialize (H (eq_refl _)).
+  rewrite H in H1. discriminate.
+Qed.
+
+Lemma UpperAboveLower : forall (f : Q -> bool) (q r : Q),
+    isLowerCut f
+    -> f q = true
+    -> f r = false
+    -> Qlt q r.
+Proof.
+  intros. destruct H. apply Qnot_le_lt. intro abs.
+  rewrite (H r q abs) in H1. discriminate. exact H0.
+Qed.
+
+(*****************************************************************************)
+(** * Classical Dedekind reals                                               *)
+(*****************************************************************************)
+
+(** ** Definition *)
+
 Definition DReal : Set
   := { f : Q -> bool | isLowerCut f }.
+
+(** ** Induction principle *)
 
 Fixpoint DRealQlim_rec (f : Q -> bool) (low : isLowerCut f) (n p : nat) { struct p }
   : f (proj1_sig (lowerCutBelow f low) + (Z.of_nat p # Pos.of_nat (S n)))%Q = false
@@ -124,6 +229,84 @@ Proof.
       exists q. exact qmaj.
 Qed.
 
+(** ** Conversion to and from constructive Cauchy real CReal *)
+
+(** *** Conversion from CReal to DReal *)
+
+Definition DRealAbstr : CReal -> DReal.
+Proof.
+  intro x.
+  assert (forall (q : Q) (n : nat),
+   {(fun n0 : nat => (seq x (-Z.of_nat n0) <= q + (2^-Z.of_nat n0))%Q) n} +
+   {~ (fun n0 : nat => (seq x (-Z.of_nat n0) <= q + (2^-Z.of_nat n0))%Q) n}).
+  { intros. destruct (Qlt_le_dec (q + (2^-Z.of_nat n)) (seq x (-Z.of_nat n))).
+    right. apply (Qlt_not_le _ _ q0). left. exact q0. }
+
+  exists (fun q:Q => if sig_forall_dec (fun n:nat => Qle (seq x (-Z.of_nat n)) (q + (2^-Z.of_nat n))) (H q)
+             then true else false).
+  repeat split.
+  - intros.
+    destruct (sig_forall_dec (fun n : nat => (seq x (-Z.of_nat n) <= q + (2^-Z.of_nat n))%Q)
+                             (H q)).
+    reflexivity. exfalso.
+    destruct (sig_forall_dec (fun n : nat => (seq x (-Z.of_nat n) <= r + (2^-Z.of_nat n))%Q)
+                             (H r)).
+    destruct s. apply n.
+    apply (Qle_trans _ _ _ (q0 x0)).
+    apply Qplus_le_l. exact H0. discriminate.
+  - intro abs. destruct (Rfloor x) as [z [_ zmaj]].
+    specialize (abs (z+3 # 1)%Q).
+    destruct (sig_forall_dec (fun n : nat => (seq x (-Z.of_nat n) <= (z+3 # 1) + (2^-Z.of_nat n))%Q)
+                             (H (z+3 # 1)%Q)).
+    2: exfalso; discriminate. clear abs. destruct s as [n nmaj]. apply nmaj.
+    rewrite <- (inject_Q_plus (z#1) 2) in zmaj.
+    apply CRealLt_asym in zmaj. rewrite <- CRealLe_not_lt in zmaj.
+    specialize (zmaj (-Z.of_nat n)%Z).
+    unfold inject_Q in zmaj; rewrite CReal_red_seq in zmaj.
+    destruct x as [xn xcau]; rewrite CReal_red_seq in H, nmaj, zmaj |- *.
+    rewrite Qinv_plus_distr in zmaj.
+    apply (Qplus_le_l _ _ (-(z + 2 # 1))). apply (Qle_trans _ _ _ zmaj).
+    apply (Qplus_le_l _ _ (-(2^-Z.of_nat n))). apply (Qle_trans _ 1).
+    + ring_simplify. apply Qpower_2_neg_le_one.
+    + ring_simplify. rewrite <- (Qinv_plus_distr z 3 1), <- (Qinv_plus_distr z 2 1). lra.
+  - intro abs. destruct (Rfloor x) as [z [zmaj _]].
+    specialize (abs (z-4 # 1)%Q).
+    destruct (sig_forall_dec (fun n : nat => (seq x (-Z.of_nat n) <= (z-4 # 1) + (2^-Z.of_nat n))%Q)
+                             (H (z-4 # 1)%Q)).
+    exfalso; discriminate. clear abs.
+    apply CRealLt_asym in zmaj. apply zmaj. clear zmaj.
+    exists 0%Z. unfold inject_Q; rewrite CReal_red_seq.
+    specialize (q O).
+    destruct x as [xn xcau].
+    rewrite CReal_red_seq in H, q |- *.
+    unfold Z.of_nat in q.
+    change (2 ^ (- 0))%Q with 1%Q in q. change (-0)%Z with 0%Z in q.
+    rewrite <- Qinv_minus_distr in q.
+    change (2^0)%Q with 1%Q.
+    lra.
+  - intros q H0 abs.
+    destruct (sig_forall_dec (fun n : nat => (seq x (-Z.of_nat n) <= q + (2^-Z.of_nat n))%Q) (H q)).
+    2: exfalso; discriminate. clear H0.
+    destruct s as [n nmaj].
+    (* We have that q < x as real numbers. The middle
+       (q + xSn - 1/Sn)/2 is also lower than x, witnessed by the same index n. *)
+    specialize (abs ((q + seq x (-Z.of_nat n) - (2^-Z.of_nat n)%Q)/2)%Q).
+    destruct abs.
+    + apply (Qmult_le_r _ _ 2) in H0. field_simplify in H0.
+      apply (Qplus_le_r _ _ ((2^-Z.of_nat n) - q)) in H0.
+      ring_simplify in H0. apply nmaj. rewrite Qplus_comm. exact H0. reflexivity.
+    + destruct (sig_forall_dec
+           (fun n0 : nat =>
+            (seq x (-Z.of_nat n0) <= (q + seq x (-Z.of_nat n) - (2^-Z.of_nat n)) / 2 + (2^-Z.of_nat n0))%Q)
+           (H ((q + seq x (-Z.of_nat n) - (2^-Z.of_nat n)) / 2)%Q)).
+      discriminate. clear H0. specialize (q0 n).
+      apply (Qmult_le_l _ _ 2) in q0. field_simplify in q0.
+      apply (Qplus_le_l _ _ (-seq x (-Z.of_nat n))) in q0. ring_simplify in q0.
+      contradiction. reflexivity.
+Defined.
+
+(** *** Conversion from DReal to CReal *)
+
 Definition DRealQlim (x : DReal) (n : nat)
   : { q : Q | proj1_sig x q = true /\ proj1_sig x (q + (1# Pos.of_nat (S n)))%Q = false }.
 Proof.
@@ -145,113 +328,102 @@ Proof.
   apply Pos.succ_of_nat. discriminate.
 Qed.
 
-Definition DRealAbstr : CReal -> DReal.
+Definition DRealQlimExp2 (x : DReal) (n : nat)
+  : { q : Q | proj1_sig x q = true /\ proj1_sig x (q + (1#(Pos.of_nat (2^n)%nat)))%Q = false }.
 Proof.
-  intro x.
-  assert (forall (q : Q) (n : nat),
-   {(fun n0 : nat => (proj1_sig x (Pos.of_nat (S n0)) <= q + (1 # Pos.of_nat (S n0)))%Q) n} +
-   {~ (fun n0 : nat => (proj1_sig x (Pos.of_nat (S n0)) <= q + (1 # Pos.of_nat (S n0)))%Q) n}).
-  { intros. destruct (Qlt_le_dec (q + (1 # Pos.of_nat (S n))) (proj1_sig x (Pos.of_nat (S n)))).
-    right. apply (Qlt_not_le _ _ q0). left. exact q0. }
-
-  exists (fun q:Q => if sig_forall_dec (fun n:nat => Qle (proj1_sig x (Pos.of_nat (S n))) (q + (1#Pos.of_nat (S n)))) (H q)
-             then true else false).
-  repeat split.
-  - intros.
-    destruct (sig_forall_dec (fun n : nat => (proj1_sig x (Pos.of_nat (S n)) <= q + (1 # Pos.of_nat (S n)))%Q)
-                             (H q)).
-    reflexivity. exfalso.
-    destruct (sig_forall_dec (fun n : nat => (proj1_sig x (Pos.of_nat (S n)) <= r + (1 # Pos.of_nat (S n)))%Q)
-                             (H r)).
-    destruct s. apply n.
-    apply (Qle_trans _ _ _ (q0 x0)).
-    apply Qplus_le_l. exact H0. discriminate.
-  - intro abs. destruct (Rfloor x) as [z [_ zmaj]].
-    specialize (abs (z+3 # 1)%Q).
-    destruct (sig_forall_dec (fun n : nat => (proj1_sig x (Pos.of_nat (S n)) <= (z+3 # 1) + (1 # Pos.of_nat (S n)))%Q)
-                             (H (z+3 # 1)%Q)).
-    2: exfalso; discriminate. clear abs. destruct s as [n nmaj]. apply nmaj.
-    rewrite <- (inject_Q_plus (z#1) 2) in zmaj.
-    apply CRealLt_asym in zmaj. rewrite <- CRealLe_not_lt in zmaj.
-    specialize (zmaj (Pos.of_nat (S n))). unfold inject_Q, proj1_sig in zmaj.
-    destruct x as [xn xcau]; unfold proj1_sig.
-    rewrite Qinv_plus_distr in zmaj.
-    apply (Qplus_le_l _ _ (-(z + 2 # 1))). apply (Qle_trans _ _ _ zmaj).
-    apply (Qplus_le_l _ _ (-(1 # Pos.of_nat (S n)))). apply (Qle_trans _ 1).
-    unfold Qopp, Qnum, Qden. rewrite Qinv_plus_distr.
-    unfold Qle, Qnum, Qden. apply Z2Nat.inj_le. discriminate. discriminate.
-    do 2 rewrite Z.mul_1_l. unfold Z.to_nat. rewrite Nat2Pos.id. 2: discriminate.
-    apply le_n_S, le_0_n. setoid_replace (- (z + 2 # 1))%Q with (-(z+2) #1)%Q.
-    2: reflexivity. ring_simplify. rewrite Qinv_plus_distr.
-    replace (z + 3 + - (z + 2))%Z with 1%Z. apply Qle_refl. ring.
-  - intro abs. destruct (Rfloor x) as [z [zmaj _]].
-    specialize (abs (z-4 # 1)%Q).
-    destruct (sig_forall_dec (fun n : nat => (proj1_sig x (Pos.of_nat (S n)) <= (z-4 # 1) + (1 # Pos.of_nat (S n)))%Q)
-                             (H (z-4 # 1)%Q)).
-    exfalso; discriminate. clear abs.
-    apply CRealLt_asym in zmaj. apply zmaj. clear zmaj.
-    exists 1%positive. unfold inject_Q, proj1_sig.
-    specialize (q O).
-    destruct x as [xn xcau]; unfold proj1_sig; unfold proj1_sig in q.
-    unfold Pos.of_nat in q. rewrite Qinv_plus_distr in q.
-    apply (Qplus_lt_l _ _ (xn 1%positive - 2)).
-    ring_simplify. rewrite Qinv_plus_distr.
-    apply (Qle_lt_trans _ _ _ q). apply Qlt_minus_iff.
-    unfold Qopp, Qnum, Qden. rewrite Qinv_plus_distr.
-    replace (z + -2 + - (z - 4 + 1))%Z with 1%Z. 2: ring. reflexivity.
-  - intros q H0 abs.
-    destruct (sig_forall_dec (fun n : nat => (proj1_sig x (Pos.of_nat (S n)) <= q + (1 # Pos.of_nat (S n)))%Q) (H q)).
-    2: exfalso; discriminate. clear H0.
-    destruct x as [xn xcau]; unfold proj1_sig in abs, s.
-    destruct s as [n nmaj].
-    (* We have that q < x as real numbers. The middle
-       (q + xSn - 1/Sn)/2 is also lower than x, witnessed by the same index n. *)
-    specialize (abs ((q + xn (Pos.of_nat (S n)) - (1 # Pos.of_nat (S n))%Q)/2)%Q).
-    destruct abs.
-    + apply (Qmult_le_r _ _ 2) in H0. field_simplify in H0.
-      apply (Qplus_le_r _ _ ((1 # Pos.of_nat (S n)) - q)) in H0.
-      ring_simplify in H0. apply nmaj. rewrite Qplus_comm. exact H0. reflexivity.
-    + destruct (sig_forall_dec
-           (fun n0 : nat =>
-            (xn (Pos.of_nat (S n0)) <= (q + xn (Pos.of_nat (S n)) - (1 # Pos.of_nat (S n))) / 2 + (1 # Pos.of_nat (S n0)))%Q)
-           (H ((q + xn (Pos.of_nat (S n)) - (1 # Pos.of_nat (S n))) / 2)%Q)).
-      discriminate. clear H0. specialize (q0 n).
-      apply (Qmult_le_l _ _ 2) in q0. field_simplify in q0.
-      apply (Qplus_le_l _ _ (-xn (Pos.of_nat (S n)))) in q0. ring_simplify in q0.
-      contradiction. reflexivity.
-Defined.
-
-Lemma UpperAboveLower : forall (f : Q -> bool) (q r : Q),
-    isLowerCut f
-    -> f q = true
-    -> f r = false
-    -> Qlt q r.
-Proof.
-  intros. destruct H. apply Qnot_le_lt. intro abs.
-  rewrite (H r q abs) in H1. discriminate. exact H0.
+  destruct (DRealQlim x (pred (2^n))%nat) as [q qmaj].
+  exists q.
+  rewrite Nat.succ_pred_pos in qmaj.
+    2: apply neq_0_lt, not_eq_sym, Nat.pow_nonzero; intros contra; inversion contra.
+  exact qmaj.
 Qed.
 
-Definition DRealRepr : DReal -> CReal.
+Definition CReal_of_DReal_seq (x : DReal) (n : Z) :=
+    proj1_sig (DRealQlimExp2 x (Z.to_nat (-n))).
+
+Lemma CReal_of_DReal_cauchy (x : DReal) :
+    QCauchySeq (CReal_of_DReal_seq x).
 Proof.
-  intro x. exists (fun n:positive => proj1_sig (DRealQlim x (Pos.to_nat n))).
-  intros n p q H H0.
-  destruct (DRealQlim x (Pos.to_nat p)), (DRealQlim x (Pos.to_nat q))
-  ; unfold proj1_sig.
-  destruct x as [f low]; unfold proj1_sig in a0, a.
+  unfold QCauchySeq, CReal_of_DReal_seq.
+  intros n k l Hk Hl.
+  destruct (DRealQlimExp2 x (Z.to_nat (-k))) as [q Hq].
+  destruct (DRealQlimExp2 x (Z.to_nat (-l))) as [r Hr].
+  destruct x as [f Hflc].
+  unfold proj1_sig in *.
   apply Qabs_case.
-  - intros. apply (Qlt_le_trans _ (1 # Pos.of_nat (S (Pos.to_nat q)))).
-    apply (Qplus_lt_l _ _ x1). ring_simplify. apply (UpperAboveLower f).
-    exact low. apply a. apply a0. unfold Qle, Qnum, Qden.
-    do 2 rewrite Z.mul_1_l. apply Pos2Z.pos_le_pos.
-    apply Pos2Nat.inj_le. rewrite Nat2Pos.id.
-    apply le_S, Pos2Nat.inj_le, H0. discriminate.
-  - intros. apply (Qlt_le_trans _ (1 # Pos.of_nat (S (Pos.to_nat p)))).
-    apply (Qplus_lt_l _ _ x0). ring_simplify. apply (UpperAboveLower f).
-    exact low. apply a0. apply a. unfold Qle, Qnum, Qden.
-    do 2 rewrite Z.mul_1_l. apply Pos2Z.pos_le_pos.
-    apply Pos2Nat.inj_le. rewrite Nat2Pos.id.
-    apply le_S, Pos2Nat.inj_le, H. discriminate.
-Defined.
+  - intros. apply (Qlt_le_trans _ (1 # Pos.of_nat (2 ^ Z.to_nat (-l)))).
+    + apply (Qplus_lt_l _ _ r); ring_simplify.
+      apply (UpperAboveLower f).
+        exact Hflc. apply Hq. apply Hr.
+    + apply (Qle_trans _ _ _ (Qpower_2_invneg_le_pow _)).
+      apply Qpower_le_compat; [lia|lra].
+  - intros. apply (Qlt_le_trans _ (1 # Pos.of_nat (2 ^ Z.to_nat (-k)))).
+    + apply (Qplus_lt_l _ _ q); ring_simplify.
+      apply (UpperAboveLower f).
+        exact Hflc. apply Hr. apply Hq.
+    + apply (Qle_trans _ _ _ (Qpower_2_invneg_le_pow _)).
+      apply Qpower_le_compat; [lia|lra].
+Qed.
+
+Lemma CReal_of_DReal_seq_max_prec_1 : forall (x : DReal) (n : Z),
+   (n>=0)%Z -> CReal_of_DReal_seq x n = CReal_of_DReal_seq x 0.
+Proof.
+  intros x n Hngt0.
+  unfold CReal_of_DReal_seq.
+  destruct n.
+  - reflexivity.
+  - reflexivity.
+  - lia.
+Qed.
+
+Lemma CReal_of_DReal_seq_bound :
+  forall (x : DReal) (i j : Z),
+    (Qabs (CReal_of_DReal_seq x i - CReal_of_DReal_seq x j) <= 1)%Q.
+Proof.
+  intros x i j.
+  pose proof CReal_of_DReal_cauchy x 0%Z as Hcau.
+  apply Qlt_le_weak; change (2^0)%Q with 1%Q in Hcau.
+  (* Either i, j are >= 0 in which case we can rewrite with CReal_of_DReal_seq_max_prec_1,
+     or they are <0, in which case Hcau can be used immediately *)
+  destruct (Z_gt_le_dec i 0) as [Hi|Hi];
+  destruct (Z_gt_le_dec j 0) as [Hj|Hj].
+  all: try rewrite (CReal_of_DReal_seq_max_prec_1 x i) by lia;
+       try rewrite (CReal_of_DReal_seq_max_prec_1 x j) by lia;
+       apply Hcau; lia.
+  (* ToDo: check if for CReal_from_cauchy_seq_bound a similar simple proof is possible *)
+Qed.
+
+Definition CReal_of_DReal_scale (x : DReal) : Z :=
+  Qbound_lt_ZExp2 (Qabs (CReal_of_DReal_seq x (-1)) + 2)%Q.
+
+Lemma CReal_of_DReal_bound : forall (x : DReal),
+  QBound (CReal_of_DReal_seq x) (CReal_of_DReal_scale x).
+Proof.
+  intros x n.
+  unfold CReal_of_DReal_scale.
+
+  (* Use the spec of Qbound_lt_ZExp2 to linearize the RHS *)
+  apply (Qlt_trans_swap_hyp _ _ _ (Qbound_lt_ZExp2_spec _)).
+
+  (* Massage the goal so that CReal_of_DReal_seq_bound can be applied *)
+  apply (Qplus_lt_l _ _ (-Qabs (CReal_of_DReal_seq x (-1)))%Q); ring_simplify.
+  assert(forall r s : Q, (r + -1*s == r-s)%Q) as Aux
+    by (intros; lra); rewrite Aux; clear Aux.
+  apply (Qle_lt_trans _ _ _ (Qabs_triangle_reverse _ _)).
+  apply (Qle_lt_trans _ 1%Q _).
+    2: lra.
+  apply CReal_of_DReal_seq_bound.
+Qed.
+
+Definition DRealRepr (x : DReal) : CReal :=
+{|
+  seq := CReal_of_DReal_seq x;
+  scale := CReal_of_DReal_scale x;
+  cauchy := CReal_of_DReal_cauchy x;
+  bound := CReal_of_DReal_bound x
+|}.
+
+(** ** Order for DReal *)
 
 Definition Rle (x y : DReal)
   := forall q:Q, proj1_sig x q = true -> proj1_sig y q = true.
@@ -271,14 +443,6 @@ Proof.
     reflexivity. }
   subst g. replace cg with cf. reflexivity.
   apply isLowerCut_hprop.
-Qed.
-
-Lemma lowerUpper : forall (f : Q -> bool) (q r : Q),
-    isLowerCut f -> Qle q r -> f q = false -> f r = false.
-Proof.
-  intros. destruct H. specialize (H q r H0). destruct (f r) eqn:desR.
-  2: reflexivity. exfalso. specialize (H (eq_refl _)).
-  rewrite H in H1. discriminate.
 Qed.
 
 Lemma DRealOpen : forall (x : DReal) (q : Q),
@@ -325,40 +489,27 @@ Lemma DRealReprQ : forall (x : DReal) (q : Q),
     proj1_sig x q = true
     -> CRealLt (inject_Q q) (DRealRepr x).
 Proof.
-  intros.
+  intros x q H.
+
+  (* expand and simplify goal and hypothesis *)
   destruct (DRealOpen x q H) as [r rmaj].
-  destruct (Qarchimedean (4/(r - q))) as [p pmaj].
-  exists p.
-  destruct x as [f low]; unfold DRealRepr, inject_Q, proj1_sig.
-  destruct (DRealQlim (exist _ f low) (Pos.to_nat p)) as [s smaj].
-  unfold proj1_sig in smaj, rmaj.
-  apply (Qplus_lt_l _ _ (q+ (1 # Pos.of_nat (S (Pos.to_nat p))))).
-  ring_simplify. rewrite <- (Qplus_comm s).
-  apply (UpperAboveLower f _ _ low). 2: apply smaj.
-  destruct low. apply (e _ r). 2: apply rmaj.
-  rewrite <- (Qplus_comm q).
-  apply (Qle_trans _ (q + (4#p))).
-  - rewrite <- Qplus_assoc. apply Qplus_le_r.
-    apply (Qle_trans _ ((2#p) + (1#p))).
-    apply Qplus_le_r.
-    unfold Qle, Qnum, Qden. do 2 rewrite Z.mul_1_l.
-    apply Pos2Z.pos_le_pos. apply Pos2Nat.inj_le.
-    rewrite Nat2Pos.id. apply le_S, le_refl. discriminate.
-    rewrite Qinv_plus_distr. unfold Qle, Qnum, Qden.
-    apply Z.mul_le_mono_nonneg_r. discriminate. discriminate.
-  - apply (Qle_trans _ (q + (r-q))). 2: ring_simplify; apply Qle_refl.
-    apply Qplus_le_r.
-    apply (Qmult_le_l _ _ ( (Z.pos p # 1) / (r-q))).
-    rewrite <- (Qmult_0_r (Z.pos p #1)). apply Qmult_lt_l.
-    reflexivity. apply Qinv_lt_0_compat.
-    unfold Qminus. rewrite <- Qlt_minus_iff. apply rmaj.
-    unfold Qdiv. rewrite Qmult_comm, <- Qmult_assoc.
-    rewrite (Qmult_comm (/(r-q))), Qmult_inv_r, Qmult_assoc.
-    setoid_replace ((4 # p) * (Z.pos p # 1))%Q with 4%Q.
-    2: reflexivity. rewrite Qmult_1_r.
-    apply Qlt_le_weak, pmaj. intro abs. destruct rmaj.
-    apply Qlt_minus_iff in H0.
-    rewrite abs in H0. apply (Qlt_not_le _ _ H0), Qle_refl.
+  destruct (QarchimedeanLowExp2_Z ((1#4)*(r - q))) as [p pmaj].
+    1: lra.
+  exists (p)%Z.
+  destruct x as [f low]; unfold DRealRepr, CReal_of_DReal_seq, inject_Q; do 2 rewrite CReal_red_seq.
+  destruct (DRealQlimExp2 (exist _ f low) (Z.to_nat (-p))) as [s smaj].
+  unfold proj1_sig in smaj, rmaj, H |- * .
+  rewrite <- (Qmult_lt_l _ _ 4%Q) in pmaj by lra.
+  setoid_replace (4 * ((1 # 4) * (r - q)))%Q with (r-q)%Q in pmaj by ring.
+  apply proj2 in rmaj.
+  apply proj2 in smaj.
+
+  (* Use the fact that s+eps is above the cut and r is below the cut.
+     This limits the distance between s and r. *)
+  pose proof UpperAboveLower f _ _ low rmaj smaj as Hrltse; clear rmaj smaj.
+  pose proof Qpower_2_invneg_le_pow p as Hpowcut.
+  pose proof Qpower_pos_lt 2 p ltac:(lra) as Hpowpos.
+  lra.
 Qed.
 
 Lemma DRealReprQup : forall (x : DReal) (q : Q),
@@ -366,13 +517,18 @@ Lemma DRealReprQup : forall (x : DReal) (q : Q),
     -> CRealLe (DRealRepr x) (inject_Q q).
 Proof.
   intros x q H [p pmaj].
-  unfold inject_Q, DRealRepr, proj1_sig in pmaj.
-  destruct (DRealQlim x (Pos.to_nat p)) as [r rmaj], rmaj.
-  clear H1. destruct x as [f low], low; unfold proj1_sig in H, H0.
-  apply (Qplus_lt_l _ _ q) in pmaj. ring_simplify in pmaj.
-  rewrite (e _ r) in H. discriminate. 2: exact H0.
-  apply Qlt_le_weak. apply (Qlt_trans _ ((2#p)+q)). 2: exact pmaj.
-  apply (Qplus_lt_l _ _ (-q)). ring_simplify. reflexivity.
+
+  (* expand and simplify goal and hypothesis *)
+  unfold inject_Q, DRealRepr, CReal_of_DReal_seq in pmaj. do 2 rewrite CReal_red_seq in pmaj.
+  destruct (DRealQlimExp2 x (Z.to_nat (- p))) as [r rmaj].
+  destruct x as [f low].
+  unfold proj1_sig in pmaj, rmaj, H.
+  apply proj1 in rmaj.
+
+  (* Use the fact that q is above the cut and r is below the cut. *)
+  pose proof UpperAboveLower f _ _ low rmaj H as Hrltse.
+  pose proof Qpower_pos_lt 2 p ltac:(lra) as Hpowpos.
+  lra.
 Qed.
 
 Lemma DRealQuot1 : forall x y:DReal, CRealEq (DRealRepr x) (DRealRepr y) -> x = y.
@@ -390,79 +546,106 @@ Qed.
 
 Lemma DRealAbstrFalse : forall (x : CReal) (q : Q) (n : nat),
     proj1_sig (DRealAbstr x) q = false
-    -> (proj1_sig x (Pos.of_nat (S n)) <= q + (1 # Pos.of_nat (S n)))%Q.
+    -> (seq x (- Z.of_nat n) <= q + 2 ^ (- Z.of_nat n))%Q.
 Proof.
-  intros. destruct x as [xn xcau].
+  intros x q n H.
   unfold DRealAbstr, proj1_sig in H.
-  destruct (
-        sig_forall_dec (fun n : nat => (xn (Pos.of_nat (S n)) <= q + (1 # Pos.of_nat (S n)))%Q)
-          (fun n : nat =>
-           match Qlt_le_dec (q + (1 # Pos.of_nat (S n))) (xn (Pos.of_nat (S n))) with
-           | left q0 => right (Qlt_not_le (q + (1 # Pos.of_nat (S n))) (xn (Pos.of_nat (S n))) q0)
-           | right q0 => left q0
-           end)).
-  discriminate. apply q0.
+  match type of H with context [ if ?a then _ else _ ] => destruct a as [H'|H']end.
+  - discriminate.
+  - apply H'.
+Qed.
+
+(** For arbitrary n:Z, we need to relaxe the bound *)
+
+Lemma DRealAbstrFalse' : forall (x : CReal) (q : Q) (n : Z),
+    proj1_sig (DRealAbstr x) q = false
+    -> (seq x n <= q + 2*2^n)%Q.
+Proof.
+  intros x q n H.
+  unfold DRealAbstr, proj1_sig in H.
+  match type of H with context [ if ?a then _ else _ ] => destruct a as [H'|H']end.
+  - discriminate.
+  - destruct (Z_le_gt_dec n 0) as [Hdec|Hdec].
+    + specialize (H' (Z.to_nat (-n) )).
+      rewrite (Z2Nat.id (-n)%Z ltac:(lia)), Z.opp_involutive in H'.
+      pose proof Qpower_pos_lt 2 n; lra.
+    + specialize (H' (Z.to_nat (0) )). cbn in H'.
+      pose proof cauchy x n%Z 0%Z n ltac:(lia) ltac:(lia) as Hxbnd.
+      apply Qabs_Qlt_condition in Hxbnd.
+      pose proof Qpower_le_1_increasing' 2 n ltac:(lra) ltac:(lia).
+      lra.
+Qed.
+
+Lemma DRealAbstrFalse'' : forall (x : CReal) (q : Q) (n : Z),
+    proj1_sig (DRealAbstr x) q = false
+    -> (seq x n <= q + 2^n + 1)%Q.
+Proof.
+  intros x q n H.
+  unfold DRealAbstr, proj1_sig in H.
+  match type of H with context [ if ?a then _ else _ ] => destruct a as [H'|H']end.
+  - discriminate.
+  - destruct (Z_le_gt_dec n 0) as [Hdec|Hdec].
+    + specialize (H' (Z.to_nat (-n) )).
+      rewrite (Z2Nat.id (-n)%Z ltac:(lia)), Z.opp_involutive in H'.
+      pose proof Qpower_pos_lt 2 n; lra.
+    + specialize (H' (Z.to_nat (0) )). cbn in H'.
+      pose proof cauchy x n%Z 0%Z n ltac:(lia) ltac:(lia) as Hxbnd.
+      apply Qabs_Qlt_condition in Hxbnd.
+      lra.
 Qed.
 
 Lemma DRealQuot2 : forall x:CReal, CRealEq (DRealRepr (DRealAbstr x)) x.
 Proof.
   split.
-  - intros [p pmaj]. unfold DRealRepr, proj1_sig in pmaj.
-    destruct x as [xn xcau].
-    destruct (DRealQlim (DRealAbstr (exist _ xn xcau)) (Pos.to_nat p))
-      as [q [_ qmaj]].
-    (* By pmaj, q + 1/p < x as real numbers.
-       But by qmaj x <= q + 1/(p+1), contradiction. *)
-    apply (DRealAbstrFalse _ _ (pred (Pos.to_nat p))) in qmaj.
-    unfold proj1_sig in qmaj.
-    rewrite Nat.succ_pred in qmaj.
-    apply (Qlt_not_le _ _ pmaj), (Qplus_le_l _ _ q).
-    ring_simplify. rewrite Pos2Nat.id in qmaj.
-    apply (Qle_trans _ _ _ qmaj).
-    rewrite <- Qplus_assoc. apply Qplus_le_r.
-    apply (Qle_trans _ ((1#p)+(1#p))).
-    apply Qplus_le_l. unfold Qle, Qnum, Qden.
-    do 2 rewrite Z.mul_1_l.
-    apply Pos2Z.pos_le_pos. apply Pos2Nat.inj_le.
-    rewrite Nat2Pos.id. apply le_S, le_refl. discriminate.
-    rewrite Qinv_plus_distr. apply Qle_refl.
-    intro abs. pose proof (Pos2Nat.is_pos p).
-    rewrite abs in H. inversion H.
-  - intros [p pmaj]. unfold DRealRepr, proj1_sig in pmaj.
-    destruct x as [xn xcau].
-    destruct (DRealQlim (DRealAbstr (exist _ xn xcau)) (Pos.to_nat p))
-      as [q [qmaj _]].
-    (* By pmaj, x < q - 1/p *)
-    unfold DRealAbstr, proj1_sig in qmaj.
-    destruct (
-           sig_forall_dec (fun n : nat => (xn (Pos.of_nat (S n)) <= q + (1 # Pos.of_nat (S n)))%Q)
-             (fun n : nat =>
-              match Qlt_le_dec (q + (1 # Pos.of_nat (S n))) (xn (Pos.of_nat (S n))) with
-              | left q0 =>
-                  right (Qlt_not_le (q + (1 # Pos.of_nat (S n))) (xn (Pos.of_nat (S n))) q0)
-              | right q0 => left q0
-              end)).
-    2: discriminate. clear qmaj.
-    destruct s as [n nmaj]. apply nmaj.
-    apply (Qplus_lt_l _ _ (xn p + (1#Pos.of_nat (S n)))) in pmaj.
-    ring_simplify in pmaj. apply Qlt_le_weak. rewrite Qplus_comm.
-    apply (Qlt_trans _ ((2 # p) + xn p + (1 # Pos.of_nat (S n)))).
-    2: exact pmaj.
-    apply (Qplus_lt_l _ _ (-xn p)).
+  - intros [p pmaj].
+    unfold DRealRepr in pmaj.
+    rewrite CReal_red_seq in pmaj.
+    destruct (Z_ge_lt_dec 0 p) as [Hdec|Hdec].
+    + (* The usual case that p<=0 and 2^p is small *)
+      (* In this case the conversion of Z to nat and back is id *)
+      unfold CReal_of_DReal_seq in pmaj.
+      destruct (DRealQlimExp2 (DRealAbstr x) (Z.to_nat (- p))) as [q [Hql Hqr]].
+      unfold proj1_sig in pmaj.
+      pose proof (DRealAbstrFalse x _ (Z.to_nat (- p)) Hqr) as Hq; clear Hql Hqr.
+      rewrite <- Qpower_2_neg_eq_natpow_inv in Hq.
+      rewrite Z2Nat.id, Z.opp_involutive in Hq by lia; clear Hdec.
+      lra.
+    + (* The case that p>0 and 2^p is large *)
+      (* In this case we use CReal_of_DReal_seq_max_prec_1 to rewrite the index to 0 *)
+      rewrite CReal_of_DReal_seq_max_prec_1 in pmaj by lia.
+      unfold CReal_of_DReal_seq in pmaj.
+      change (Z.to_nat (-0))%Z with 0%nat in pmaj.
+      destruct (DRealQlimExp2 (DRealAbstr x) 0) as [q [Hql Hqr]].
+      unfold proj1_sig in pmaj.
+      pose proof (DRealAbstrFalse'' x _ p%nat Hqr) as Hq; clear Hql Hqr.
+      rewrite <- Qpower_2_neg_eq_natpow_inv in Hq.
+      change (- Z.of_nat 0)%Z with 0%Z in Hq.
+      pose proof (Qpower_le_compat 2 1 p ltac:(lia) ltac:(lra)) as Hpowle.
+      change (2^1)%Q with 2%Q in Hpowle.
+      lra.
+  - intros [p pmaj].
+    unfold DRealRepr in pmaj.
+    rewrite CReal_red_seq in pmaj.
+    unfold CReal_of_DReal_seq in pmaj.
+    destruct (DRealQlimExp2 (DRealAbstr x) (Z.to_nat (- p))) as [q [Hql Hqr]].
+    unfold proj1_sig in pmaj.
+    unfold DRealAbstr, proj1_sig in Hql.
+    match type of Hql with context [ if ?a then _ else _ ] => destruct a as [H'|H']end.
+      2: discriminate. clear Hql Hqr.
+    destruct H' as [n nmaj]. apply nmaj; clear nmaj.
+    apply (Qplus_lt_l _ _ (seq x p + 2 ^ (- Z.of_nat n))) in pmaj.
+   ring_simplify in pmaj. apply Qlt_le_weak. rewrite Qplus_comm.
+    apply (Qlt_trans _ ((2 * 2^p) + seq x p + (2 ^ (- Z.of_nat n)))).
+    2: exact pmaj. clear pmaj.
+    apply (Qplus_lt_l _ _ (-seq x p)).
     apply (Qle_lt_trans _ _ _ (Qle_Qabs _)).
-    destruct (le_lt_dec (S n) (Pos.to_nat p)).
-    + specialize (xcau (Pos.of_nat (S n)) (Pos.of_nat (S n)) p).
-      apply (Qlt_trans _ (1# Pos.of_nat (S n))). apply xcau.
-      apply Pos.le_refl. unfold id. apply Pos2Nat.inj_le.
-      rewrite Nat2Pos.id. exact l. discriminate.
-      apply (Qplus_lt_l _ _ (-(1#Pos.of_nat (S n)))).
-      ring_simplify. reflexivity.
-    + apply (Qlt_trans _ (1#p)). apply xcau.
-      apply le_S_n in l. unfold id. apply Pos2Nat.inj_le.
-      rewrite Nat2Pos.id.
-      apply le_S, l. discriminate. apply Pos.le_refl.
-      ring_simplify. apply (Qlt_trans _ (2#p)).
-      unfold Qlt, Qnum, Qden.
-      apply Z.mul_lt_mono_pos_r. reflexivity. reflexivity.
-      apply (Qplus_lt_l _ _ (-(2#p))). ring_simplify. reflexivity.
+    destruct (Z_le_gt_dec p (- Z.of_nat n)).
+    + apply (Qlt_trans _ (2 ^ (- Z.of_nat n))). apply (cauchy x).
+        1, 2: lia.
+      pose proof Qpower_pos_lt 2 p; lra.
+    + apply (Qlt_trans _ (2^p)). apply (cauchy x).
+        1, 2: lia.
+      pose proof Qpower_pos_lt 2 (- Z.of_nat n).
+      pose proof Qpower_pos_lt 2 p.
+      lra.
 Qed.

--- a/theories/Reals/Raxioms.v
+++ b/theories/Reals/Raxioms.v
@@ -370,7 +370,7 @@ Proof.
     + destruct (total_order_T (IZR (Z.pred n) - r) 1). destruct s.
       left. exact r1. right. exact e.
       exfalso. destruct nmaj as [_ nmaj].
-      pose proof Rrepr_IZR as iz. unfold inject_Z in iz.
+      pose proof Rrepr_IZR as iz.
       rewrite <- iz in nmaj.
       apply (Rlt_asym (IZR n) (r + 2)).
       rewrite RbaseSymbolsImpl.Rlt_def. rewrite Rrepr_plus. rewrite (Rrepr_plus 1 1).

--- a/theories/Reals/Rdefinitions.v
+++ b/theories/Reals/Rdefinitions.v
@@ -18,6 +18,7 @@ Require Export ZArith_base.
 Require Import QArith_base.
 Require Import ConstructiveCauchyReals.
 Require Import ConstructiveCauchyRealsMult.
+Require Import ConstructiveRcomplete.
 Require Import ClassicalDedekindReals.
 
 


### PR DESCRIPTION
This PR changes the epsilon in the definition of the modulus of convergence for CReal from 1/n to 1/2^n. This avoids the issue that in practical high precision computations, even as binary integer n would be quite large (say 2^1000000), although quadratically convergent algorithms might need only a few 10 iterations to reach such a precision.

This is work in progress (right now I just did the main file ConstructiveCauchyReals.v).

@VincentSe : some things I think I should change:

- as far as I can tell the major issue for the many lengthy manual arithmetic proofs is the use of variables in Qmake (a#b). As far as I can tell ring, field and lra don't understand that # and / is more or less the same thing. They can compute with literal numbers like 1#2 * 2#3 = 1#3, but they don't work for say 1#n. One should write 1/n instead and use # only for literal rational numbers (ground terms). This would be a major change, though, but I think expressions like 1#n are not intended and we should not do this in the standard library.

- In general I am not happy with the proof style, since proofs generally look more complicated than they actually are, but this might improve a lot with the point above and maybe a few little preprocessing tactics and reordering.

- When switching to an abstracted computational structure this might get much more messy so some upfront cleanup would help.

- The addition function should be fully split into computational part and proof

- [ ] Added / updated test-suite.  (N/A - no new functionality)
- [ ] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified). (N/A - CReal documentation is extracted from code)
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
