### PR TITLE
Remove domains comparison in conversion test of lambdas

### DIFF
--- a/kernel/reduction.ml
+++ b/kernel/reduction.ml
@@ -463,11 +463,11 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
            we throw them away *)
         if not (is_empty_stack v1 && is_empty_stack v2) then
           anomaly (Pp.str "conversion was given ill-typed terms (FLambda).");
-        let (x1,ty1,bd1) = destFLambda mk_clos hd1 in
-        let (_,ty2,bd2) = destFLambda mk_clos hd2 in
+        let (x1,_,bd1) = destFLambda mk_clos hd1 in
+        let (_,_,bd2) = destFLambda mk_clos hd2 in
         let el1 = el_stack lft1 v1 in
         let el2 = el_stack lft2 v2 in
-        let cuniv = ccnv CONV l2r infos el1 el2 ty1 ty2 cuniv in
+        (* Domains do not need to be convertible in a PTS with eta-conversion *)
         ccnv CONV l2r (push_relevance infos x1) (el_lift el1) (el_lift el2) bd1 bd2 cuniv
 
     | (FProd (x1, c1, c2, e), FProd (_, c'1, c'2, e')) ->

--- a/test-suite/bugs/opened/bug_3395.v
+++ b/test-suite/bugs/opened/bug_3395.v
@@ -215,11 +215,8 @@ Proof.
   unfold yoneda.
   Time let t := (type of CYE) in
   let t' := (eval simpl in t) in pose proof ((fun (x : t) => (x : t')) CYE) as CYE'. (* Finished transaction in 0. secs (0.216013u,0.004s) *)
-  Fail Timeout 1 let t := match goal with |- ?G => constr:(G) end in
-  let t' := (eval simpl in t) in exact ((fun (x : t') => (x : t)) CYE').
   Time let t := match goal with |- ?G => constr:(G) end in
   let t' := (eval simpl in t) in exact ((fun (x : t') => (x : t)) CYE'). (* Finished transaction in 0. secs (0.248016u,0.s) *)
-Fail Timeout 2 Defined.
 Time Defined. (* Finished transaction in 1. secs (0.432027u,0.s) *)
 
 Definition yoneda_embedding `(A : @PreCategory objA) : @IsFullyFaithful _ _ _ _ (@yoneda _ A).
@@ -227,6 +224,5 @@ Proof.
   intros a b.
   pose proof (coyoneda_embedding A^op a b) as CYE.
   unfold yoneda; simpl in *.
-  Fail Timeout 1 exact CYE.
   Time exact CYE. (* Finished transaction in 0. secs (0.012001u,0.s) *)
 Abort.


### PR DESCRIPTION
I recently realized that in PTS with eta-conversion, the domains of lambdas are irrelevant. For instance in Geuvers thesis we can read:
![Capture d’écran de 2020-04-10 11-01-16](https://user-images.githubusercontent.com/1425905/80385606-8ecd7680-88a6-11ea-8748-fce4a8ec0713.png)

This is due to the fact that we have:
```
λx:A. t  ≡  λfresh:B. (λx:A.t) fresh  ≡  λfresh:B. t{x:=fresh}  ==  λx:B. t
```
(an η-expansion followed by a β-reduction).

So let's try to remove conversion of domains in conversion/cumulativity test!
It's only one line in [reduction.ml](https://github.com/coq/coq/blob/master/kernel/reduction.ml#L470).

Ho... test-suite is still compiling!
And it speedup some operations by a factor 6-7 in `test-suite/bugs/opened/bug_3395.v`!
(of course, it seems to be much less spectacular on more regular files).

Did I miss an application of this line?