### PR TITLE
[doc] [sphinx] Run in silent mode by default

### DIFF
--- a/doc/dune
+++ b/doc/dune
@@ -32,7 +32,7 @@
   unreleased.rst
   (env_var SPHINXWARNOPT))
  (action
-  (run env COQLIB=%{project_root} sphinx-build %{env:SPHINXWARNOPT=-W} -b html sphinx %{targets})))
+  (run env COQLIB=%{project_root} sphinx-build -q %{env:SPHINXWARNOPT=-W} -b html sphinx %{targets})))
 
 (rule
  (targets refman-pdf)
@@ -48,7 +48,7 @@
   (env_var SPHINXWARNOPT))
  (action
   (progn
-   (run env COQLIB=%{project_root} sphinx-build %{env:SPHINXWARNOPT=-W} -b latex sphinx %{targets})
+   (run env COQLIB=%{project_root} sphinx-build -q %{env:SPHINXWARNOPT=-W} -b latex sphinx %{targets})
    (chdir %{targets} (run make)))))
 
 ; Installable directories are not yet fully supported by Dune.  See

--- a/doc/dune
+++ b/doc/dune
@@ -49,7 +49,7 @@
  (action
   (progn
    (run env COQLIB=%{project_root} sphinx-build -q %{env:SPHINXWARNOPT=-W} -b latex sphinx %{targets})
-   (chdir %{targets} (run make)))))
+   (chdir %{targets} (run make LATEXMKOPTS=-silent)))))
 
 ; Installable directories are not yet fully supported by Dune.  See
 ; ocaml/dune#1868.  Yet, this makes coq-doc.install a valid target to


### PR DESCRIPTION
The convention in the dune build is to be silent except for warnings
and errors, so they don't go unnoticed.

We could have this controlled by a variable if needed (likely would
require some support from Dune?)

Solves part of #12194