### PR TITLE
CI: change ext-lib url, it is at coq-community now

### DIFF
--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -242,7 +242,7 @@
 # ext-lib
 ########################################################################
 : "${ext_lib_CI_REF:=master}"
-: "${ext_lib_CI_GITURL:=https://github.com/coq-ext-lib/coq-ext-lib}"
+: "${ext_lib_CI_GITURL:=https://github.com/coq-community/coq-ext-lib}"
 : "${ext_lib_CI_ARCHIVEURL:=${ext_lib_CI_GITURL}/archive}"
 
 ########################################################################

--- a/dev/ci/nix/default.nix
+++ b/dev/ci/nix/default.nix
@@ -22,7 +22,7 @@ let ssreflect = coqPackages.ssreflect.overrideAttrs (o: {
   }); in
 
 let coq-ext-lib = coqPackages.coq-ext-lib.overrideAttrs (o: {
-    src = fetchTarball "https://github.com/coq-ext-lib/coq-ext-lib/tarball/master";
+    src = fetchTarball "https://github.com/coq-community/coq-ext-lib/tarball/master";
   }); in
 
 let simple-io =


### PR DESCRIPTION

**Kind:** infrastructure.

It's working now only because there's a redirect.  That's a little confusing.
