### PR TITLE
Centralize the call to `tclEFFECTS` in scheme declaration

### DIFF
--- a/tactics/ind_tables.mli
+++ b/tactics/ind_tables.mli
@@ -59,7 +59,7 @@ val define_mutual_scheme : mutual scheme_kind -> internal_flag (** internal *) -
   (int * Id.t) list -> MutInd.t -> unit
 
 (** Main function to retrieve a scheme in the cache or to generate it *)
-val find_scheme : ?mode:internal_flag -> 'a scheme_kind -> inductive -> Constant.t * Evd.side_effects
+val find_scheme : ?mode:internal_flag -> 'a scheme_kind -> inductive -> Constant.t Proofview.tactic
 
 (** Like [find_scheme] but does not generate a constant on the fly *)
 val lookup_scheme : 'a scheme_kind -> inductive -> Constant.t option


### PR DESCRIPTION
We move all the calls to `tclEFFECTS` into `find_scheme` whose type is turned into a tactic. This prevents having subtle low-level functions all over the place. Furthermore it makes explicit that there is a hack to work around a desynchronization between the imperative scheme table and the tactic state.

(Next PR in line enforces a strict state-passing discipline in side-effects, but I am submitting this one separately since it is self-contained.)