### PR TITLE
Ltac helper functions API

### DIFF
--- a/plugins/ltac/tacentries.mli
+++ b/plugins/ltac/tacentries.mli
@@ -69,6 +69,25 @@ val print_ltacs : unit -> unit
 val print_located_tactic : Libnames.qualid -> unit
 (** Display the absolute name of a tactic. *)
 
+(** {5 Low-level registering of tactics} *)
+
+type (_, 'a) ml_ty_sig =
+| MLTyNil : ('a, 'a) ml_ty_sig
+| MLTyArg : ('r, 'a) ml_ty_sig -> (Geninterp.Val.t -> 'r, 'a) ml_ty_sig
+
+val ml_tactic_extend : plugin:string -> name:string -> local:locality_flag ->
+  ?deprecation:Deprecation.t -> ('r, unit Proofview.tactic) ml_ty_sig -> 'r -> unit
+(** Helper function to define directly an Ltac function in OCaml without any
+    associated parsing rule nor further shenanigans. The Ltac function will be
+    defined as [name] in the Coq file that loads the ML plugin where this
+    function is called. It will have the arity given by the [ml_ty_sig]
+    argument. *)
+
+val ml_val_tactic_extend : plugin:string -> name:string -> local:locality_flag ->
+  ?deprecation:Deprecation.t -> ('r, Geninterp.Val.t Ftactic.t) ml_ty_sig -> 'r -> unit
+(** Same as {!ml_tactic_extend} but the function can return an argument
+    instead. *)
+
 (** {5 TACTIC EXTEND} *)
 
 type _ ty_sig =

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -1895,8 +1895,7 @@ module Value = struct
     let closure = VFun (UnnamedAppl,extract_trace ist, ist.lfun, [], tac) in
     of_tacvalue closure
 
-  (** Apply toplevel tactic values *)
-  let apply (f : value) (args: value list) =
+  let apply_expr f args =
     let fold arg (i, vars, lfun) =
       let id = Id.of_string ("x" ^ string_of_int i) in
       let x = Reference (ArgVar CAst.(make id)) in
@@ -1905,8 +1904,17 @@ module Value = struct
     let (_, args, lfun) = List.fold_right fold args (0, [], Id.Map.empty) in
     let lfun = Id.Map.add (Id.of_string "F") f lfun in
     let ist = { (default_ist ()) with lfun = lfun; } in
-    let tac = TacArg(CAst.make @@ TacCall (CAst.make (ArgVar CAst.(make @@ Id.of_string "F"),args))) in
+    ist, TacArg(CAst.make @@ TacCall (CAst.make (ArgVar CAst.(make @@ Id.of_string "F"),args)))
+
+
+  (** Apply toplevel tactic values *)
+  let apply (f : value) (args: value list) =
+    let ist, tac = apply_expr f args in
     eval_tactic_ist ist tac
+
+  let apply_val (f : value) (args: value list) =
+    let ist, tac = apply_expr f args in
+    val_interp ist tac
 
 end
 

--- a/plugins/ltac/tacinterp.mli
+++ b/plugins/ltac/tacinterp.mli
@@ -29,6 +29,7 @@ sig
   val of_closure : Geninterp.interp_sign -> glob_tactic_expr -> t
   val cast : 'a typed_abstract_argument_type -> Geninterp.Val.t -> 'a
   val apply : t -> t list -> unit Proofview.tactic
+  val apply_val : t -> t list -> t Ftactic.t
 end
 
 (** Values for interpretation *)


### PR DESCRIPTION
This PR introduces helper functions to work around the intricacies of the Ltac runtime. I wrote it some time ago while trying to clean up the `ring` tactic, and realized it could be of general help since everybody keeps reinventing the wheel. In particular, a [Discourse post](https://coq.discourse.group/t/how-can-an-ocaml-tactic-return-something-else-than-unit/812) convinced me I should submit this PR.

The two functions are:
- `Tacentries.ml_tactic_extend`: define a Coq-facing Ltac definition that calls arbitrary ML code. This one is pretty straightforward if you know the API, it's just cobbling stuff together.
- `Tacentries.ml_val_tactic_extend`: same as above, but allows to return values (*wow!*). This is a generalization of the hack introduced in my [string-to-ident plugin](https://github.com/ppedrot/coq-string-ident). I don't want to enter the details but Ltac doesn't let you return values from ML, and it's impossible to fix properly due to the way Ltac makes a distinction between "values" and "tactics". Instead, we piggy-back on the `ARGUMENT EXTEND` node which *is* designed to return values. We create a new argument which stores a closure to an ML function, and wrap this into a fancy API.

