### PR TITLE
[ssr] notation to seed names at inductive declaration time

### DIFF
--- a/test-suite/ssr/ssr_elim_names.v
+++ b/test-suite/ssr/ssr_elim_names.v
@@ -1,0 +1,26 @@
+From Coq Require Import ssreflect.
+Open Scope ssrelim_scope.
+
+Inductive t := K (a : t).
+
+Axiom q : t -> Prop.
+
+Inductive p : t -> Prop :=
+| Rule_1 y : p y
+| Rule_for_K x t :
+                  q x   # q_x
+                  p t   # p_t__IHt
+                (* ----*)
+                  p (K t).
+
+Lemma test x (H : p x) : q x.
+Proof.
+elim: H => [^~ 1].
+  Check y1 : t.
+  admit.
+Check x1 : t.
+Check t1 : t.
+Check q_x1 : q x1.
+Check p_t1 : p t1.
+Check IHt1 : q t1.
+Admitted.

--- a/theories/ssr/ssreflect.v
+++ b/theories/ssr/ssreflect.v
@@ -654,3 +654,26 @@ End Exports.
 
 End NonPropType.
 Export NonPropType.Exports.
+
+(*****************************************************************************)
+
+(** Helper notation for giving names to induction principles. Example
+
+     Inductive p : t -> Prop :=
+      | Rule_for_K x t :
+                        q x    # q_x
+                        p t    # p_t__IHt
+                      (* ----*)
+                        p (K t)
+
+    This inductive seeds the elim tactic with names (for the Rule_for_K
+    branch): x t q_x p_t IHt. Elim interprets __ as a separator, so that
+    one can seed names for inductive hypotheses.
+
+    In order to enable this notation one has to Open Scope ssrelim_scope.
+
+*)
+
+Declare Scope ssrelim_scope.
+Notation "S # H T" := (forall H : S, T)
+  (H ident, T at level 200, at level 99, only parsing) : ssrelim_scope.


### PR DESCRIPTION
Using `=>[^ seed]` with eliminators is boring because the only way to attach names to all
hypotheses is to spell out explicitly the type of the eliminator, and update it every time you
update the inductive. Moreover this eliminator type is bizarre, since non dependent arguments
have to be quantified with a forall, rather than an arrow, just to give their name seed.

This PR adds a notation to let one annotate non dependent arguments of inductive types
with one or more names (more names are necessary if the argument is recursive, hence it
will come with an induction hypothesis).

Example: when block introduction is used after an elimination of an inductive with 
a constructor annotated as follows, one gets in the context of the corresponding goal
hypotheses names after the seeds:  `e u v pu tu mu tv tu' tv' p eu ev cap_u trm_u trm_v typ` and `IHp`, see the `__` separator to give two seeds in the last premise.

```coq
  | TyOutput (e : environment fv) u v pu tu mu tv tu' tv' p :

      e u = (Chan mu pu tu)                              # eu
      e v = tv                                           # ev
      {pu = Up} + {pu = UpDown}                          # cap_u
      type_remove (Chan mu pu tu) (Chan mu Up tu) tu'    # trm_u
      type_remove tv tu tv'                              # trm_v
      typechecks (update v tv' (update u tu' e)) p       # typ__IHp
      (*-----------------------------------------------*)
      typechecks e (Output u v p)
```
Note that, in each line `# name` plays the role of `->` (but also carrier name seeds).

Feedback on the notation is particularly welcome, I picked `#` because it reminds me of a
comment, but I'm open to other options, eg `,#` may be better at avoid conflicts.

**Kind:** feature
- [x] Added / updated test-suite
- [ ] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [ ] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).