### PR TITLE
Merge duplicates in .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -115,11 +115,13 @@ Russell O'Connor <roconnor@blockstream.io>         roconnor-blockstream <roconno
 Christine Paulin <cpaulin@gforge>                  cpaulin <cpaulin@85f007b7-540e-0410-9357-904b9bb8a0f7>
 Christine Paulin <cpaulin@gforge>                  mohring <mohring@85f007b7-540e-0410-9357-904b9bb8a0f7>
 Pierre-Marie Pédrot <pierre-marie.pedrot@inria.fr> ppedrot <ppedrot@85f007b7-540e-0410-9357-904b9bb8a0f7>
+Pierre-Marie Pédrot <pierre-marie.pedrot@inria.fr> Pierre-Marie Pédrot <pierre-marie.pedrot@irif.fr>
 Frederic Peschanski <frederic.peschanski@lip6.fr>  fredokun <frederic.peschanski@lip6.fr>
 Clément Pit-Claudel <clement.pitclaudel@live.com>  Clément Pit--Claudel <clement.pitclaudel@live.com>
 Clément Pit-Claudel <clement.pitclaudel@live.com>  Clément Pit-Claudel <cpitclaudel@users.noreply.github.com>
 Loïc Pottier <pottier@gforge>                      pottier <pottier@85f007b7-540e-0410-9357-904b9bb8a0f7>
 Matthias Puech <puech@gforge>                      puech <puech@85f007b7-540e-0410-9357-904b9bb8a0f7>
+Robert Rand <rnrand@gmail.com>                     Robert Rand <rxtreme@gmail.com>
 Lars Rasmusson <lars.rasmusson@sics.se>            larsr <Lars.Rasmusson@sics.se>
 Lars Rasmusson <lars.rasmusson@sics.se>            larsr <Lars.Rasmusson@gmail.com>
 Daniel de Rauglaudre <daniel.de_rauglaudre@inria.fr> ddr <ddr@85f007b7-540e-0410-9357-904b9bb8a0f7>


### PR DESCRIPTION
I gave preference to the email address with the larger number of
commits.

To find duplicates, I used the script
```bash
for i in $(git shortlog -nse  | sed s'/^\s*[0-9]*\s*//g' | grep -o '^[^<]*' | sed s'/\s*$//g' | sed s'/ /,/g'); do if [ $(git shortlog -nse | sed s'/ /,/g' | grep -c "$i") -gt 1 ]; then git shortlog -nse | grep "$(echo "$i" | sed s'/,/ /g')"; fi; done
```

**Kind:** infrastructure
