### PR TITLE
coq_makefile: Make .merlin PHONY

### DIFF
--- a/doc/changelog/08-tools/12212-fix-merlin.rst
+++ b/doc/changelog/08-tools/12212-fix-merlin.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  The ``.merlin`` target of ``coq_makefile``\-made makefiles is now
+  properly ``PHONY``, meaning that it will be rebuilt every time you
+  call ``make .merlin``, rather than only when the file did not exist
+  (`#PRNUM <https://github.com/coq/coq/pull/12212>`_, by Jason Gross).

--- a/tools/CoqMakefile.in
+++ b/tools/CoqMakefile.in
@@ -845,7 +845,7 @@ printenv::
 	$(HIDE)$(foreach d,$(SRC_SUBDIRS), echo 'B $(d)' >> .merlin;)
 	$(HIDE)$(foreach d,$(SRC_SUBDIRS), echo 'S $(d)' >> .merlin;)
 	$(HIDE)$(MAKE) merlin-hook -f "$(SELF)"
-.PHONY: merlin
+.PHONY: .merlin
 
 merlin-hook::
 	@# Extension point


### PR DESCRIPTION
I presume making the non-existent merlin target PHONY was just a typo.

**Kind:** bug fix

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #???? (do I really need to report this as a bug?)

- [ ] Added / updated test-suite (does this really need a test-suite case?)
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
