### PR TITLE
[zify] add support for Nat.le, Nat.lt and Nat.eq

### DIFF
--- a/doc/changelog/04-tactics/12213-zify-Nat.rst
+++ b/doc/changelog/04-tactics/12213-zify-Nat.rst
@@ -1,0 +1,3 @@
+- **Added:**
+  The :tacn:`zify` tactic is now aware of `Nat.le`, `Nat.lt` and `Nat.eq`
+  (`#12213 <https://github.com/coq/coq/pull/12213>`_, by Frédéric Besson; fixes `#12210 <https://github.com/coq/coq/issues/12210>`_).

--- a/test-suite/micromega/bug_12210.v
+++ b/test-suite/micromega/bug_12210.v
@@ -1,0 +1,19 @@
+Require Import PeanoNat Lia.
+
+Goal forall x, Nat.le x x.
+Proof.
+intros.
+lia.
+Qed.
+
+Goal forall x, Nat.lt x x -> False.
+Proof.
+intros.
+lia.
+Qed.
+
+Goal forall x, Nat.eq x x.
+Proof.
+intros.
+lia.
+Qed.

--- a/theories/micromega/ZifyInst.v
+++ b/theories/micromega/ZifyInst.v
@@ -42,6 +42,9 @@ Instance Op_lt : BinRel lt :=
   {| TR := Z.lt; TRInj := Nat2Z.inj_lt |}.
 Add BinRel Op_lt.
 
+Instance Op_Nat_lt : BinRel Nat.lt := Op_lt.
+Add BinRel Op_Nat_lt.
+
 Instance Op_gt : BinRel gt :=
   {| TR := Z.gt; TRInj := Nat2Z.inj_gt |}.
 Add BinRel Op_gt.
@@ -50,9 +53,15 @@ Instance Op_le : BinRel le :=
   {| TR := Z.le; TRInj := Nat2Z.inj_le |}.
 Add BinRel Op_le.
 
+Instance Op_Nat_le : BinRel Nat.le := Op_le.
+Add BinRel Op_Nat_le.
+
 Instance Op_eq_nat : BinRel (@eq nat) :=
   {| TR := @eq Z ; TRInj := fun x y : nat => iff_sym (Nat2Z.inj_iff x y) |}.
 Add BinRel Op_eq_nat.
+
+Instance Op_Nat_eq : BinRel (Nat.eq) := Op_eq_nat.
+Add BinRel Op_Nat_eq.
 
 (* zify_nat_op *)
 Instance Op_plus : BinOp Nat.add :=


### PR DESCRIPTION
Nat.le, Nat.lt and Nat.eq are aliased to le, lt and @eq nat.
The required declarations are now added in ZifyInst.

**Kind:**bug fix 
Fixes #12210 

- [x] Added test-suite

- [ ] Entry added in the changelog 
