### PR TITLE
Ensure eintros allows creating evars

### DIFF
--- a/user-contrib/Ltac2/Notations.v
+++ b/user-contrib/Ltac2/Notations.v
@@ -146,7 +146,7 @@ match ev with
 end.
 
 Ltac2 intros0 ev p :=
-  Control.enter (fun () => Std.intros false p).
+  Control.enter (fun () => Std.intros ev p).
 
 Ltac2 Notation "intros" p(intropatterns) := intros0 false p.
 Ltac2 Notation intros := intros.


### PR DESCRIPTION
Thread the `ev` (an `evar_flag`) appropriately through `intros0`.
Discussed on https://gitter.im/coq/coq?at=5eacace7f0377f16316083b8.
It'd be good to test that this works.

<!-- Keep what applies -->
**Kind:** bug fix.

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #????


<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
- [ ] Added / updated test-suite
- [ ] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [ ] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
