### PR TITLE
Disable Set Program Cases by default (fix #12245)

### DIFF
--- a/pretyping/program.ml
+++ b/pretyping/program.ml
@@ -63,7 +63,7 @@ let mk_coq_and sigma l =
 
 (* true = transparent by default, false = opaque if possible *)
 let proofs_transparency = ref true
-let program_cases = ref true
+let program_cases = ref false
 let program_generalized_coercion = ref true
 
 let set_proofs_transparency = (:=) proofs_transparency

--- a/test-suite/bugs/closed/bug_10757.v
+++ b/test-suite/bugs/closed/bug_10757.v
@@ -1,4 +1,6 @@
 Require Import Program Extraction ExtrOcamlBasic.
+Set Program Cases.
+
 Print sig.
 Section FIXPOINT.
 

--- a/test-suite/bugs/closed/bug_1411.v
+++ b/test-suite/bugs/closed/bug_1411.v
@@ -1,5 +1,6 @@
 Require Import List.
 Require Import Program.
+Set Program Cases.
 
 Inductive Tree : Set :=
 | Br : Tree -> Tree -> Tree

--- a/test-suite/bugs/closed/bug_2729.v
+++ b/test-suite/bugs/closed/bug_2729.v
@@ -1,5 +1,6 @@
 (* This bug report actually revealed two bugs in the reconstruction of
    a term with "match" in the vm *)
+Set Program Cases.
 
 (* A simplified form of the first problem *)
 

--- a/test-suite/bugs/closed/bug_4725.v
+++ b/test-suite/bugs/closed/bug_4725.v
@@ -2,6 +2,7 @@ Require Import EquivDec Equivalence List Program.
 Require Import Relation_Definitions.
 Import ListNotations.
 Generalizable All Variables.
+Set Program Cases.
 
 Fixpoint removeV `{eqDecV : @EqDec V eqV equivV}`(x : V) (l : list V) : list V
 :=

--- a/test-suite/bugs/closed/bug_5066.v
+++ b/test-suite/bugs/closed/bug_5066.v
@@ -1,4 +1,5 @@
 Require Import Vector.
+Set Program Cases.
 
 Fail Program Fixpoint vector_rev {A : Type} {n1 n2 : nat} (v1 : Vector.t A n1) (v2 : Vector.t A n2) : Vector.t A (n1+n2) :=
   match v1 with

--- a/test-suite/bugs/closed/bug_5066_a.v
+++ b/test-suite/bugs/closed/bug_5066_a.v
@@ -1,0 +1,7 @@
+Require Import Vector.
+
+Program Fixpoint vector_rev {A : Type} {n1 n2 : nat} (v1 : Vector.t A n1) (v2 : Vector.t A n2) : Vector.t A (n1+n2) :=
+  match v1 with
+  | nil _          => v2
+  | cons _ e n' sv => vector_rev sv (cons A e n2 v2)
+  end.

--- a/test-suite/success/ProgramWf.v
+++ b/test-suite/success/ProgramWf.v
@@ -8,6 +8,7 @@ Require Import Arith Program.
 Require Import ZArith Zwf.
 
 Set Implicit Arguments.
+Set Program Cases.
 (* Set Printing All. *)
 Print sigT_rect.
 Obligation Tactic := program_simplify ; auto with *.

--- a/theories/Classes/EquivDec.v
+++ b/theories/Classes/EquivDec.v
@@ -141,8 +141,3 @@ Program Instance list_eqdec `(eqa : EqDec A eq) : EqDec (list A) eq :=
           else in_right
       | _, _ => in_right
     end }.
-
-  Next Obligation. destruct y ; unfold not in *; eauto. Defined.
-
-  Solve Obligations with unfold equiv, complement in * ; 
-    program_simpl ; intuition (discriminate || eauto).


### PR DESCRIPTION
Disable `Set Program Cases` by default, due to the caused code size blowup, as discussed in #12245.
**Kind:** bug fix / enhancement.
Fixes #12245, fixes #12219.


<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [ ] Added / updated test-suite (WIP)
<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [ ] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [ ] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
