### PR TITLE
In non-strict mode, accept any variable as a tactic reference.

### DIFF
--- a/doc/changelog/05-tactic-language/12254-wit-ref-dyn.rst
+++ b/doc/changelog/05-tactic-language/12254-wit-ref-dyn.rst
@@ -1,0 +1,5 @@
+- **Changed:**
+  The "reference" tactic generic argument now accepts arbitrary
+  variables of the goal context
+  (`#12254 <https://github.com/coq/coq/pull/12254>`_,
+  by Pierre-Marie Pédrot).

--- a/test-suite/success/tac_wit_ref.v
+++ b/test-suite/success/tac_wit_ref.v
@@ -1,0 +1,8 @@
+Tactic Notation "foo" reference(n) := idtac n.
+
+Goal forall n : nat, n = 0.
+Proof.
+intros n.
+foo nat.
+foo n.
+Abort.


### PR DESCRIPTION
Part of the plan of #11840.

- [X] Added / updated test-suite
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
