### PR TITLE
[ci] bump elpi to 1.11

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ stages:
 variables:
   # Format: $IMAGE-V$DATE [Cache is not used as of today but kept here
   # for reference]
-  CACHEKEY: "bionic_coq-V2020-03-13-V69"
+  CACHEKEY: "bionic_coq-V2020-05-06-V70"
   IMAGE: "$CI_REGISTRY_IMAGE:$CACHEKEY"
   # By default, jobs run in the base switch; override to select another switch
   OPAM_SWITCH: "base"

--- a/dev/ci/docker/bionic_coq/Dockerfile
+++ b/dev/ci/docker/bionic_coq/Dockerfile
@@ -1,4 +1,4 @@
-# CACHEKEY: "bionic_coq-V2020-03-13-V69"
+# CACHEKEY: "bionic_coq-V2020-05-06-V70"
 # ^^ Update when modifying this file.
 
 FROM ubuntu:bionic
@@ -39,7 +39,7 @@ ENV COMPILER="4.05.0"
 # with the compiler version.
 ENV BASE_OPAM="num ocamlfind.1.8.1 ounit.2.2.2 odoc.1.5.0" \
     CI_OPAM="menhir.20190626 ocamlgraph.1.8.8" \
-    BASE_ONLY_OPAM="elpi.1.10.2"
+    BASE_ONLY_OPAM="elpi.1.11.0"
 
 # BASE switch; CI_OPAM contains Coq's CI dependencies.
 ENV COQIDE_OPAM="cairo2.0.6.1 lablgtk3-sourceview3.3.1.0"

--- a/dev/ci/user-overlays/12267-gares-elpi-1.11.sh
+++ b/dev/ci/user-overlays/12267-gares-elpi-1.11.sh
@@ -1,0 +1,6 @@
+if [ "$CI_PULL_REQUEST" = "12267" ] || [ "$CI_BRANCH" = "elpi-1.11" ]; then
+
+    elpi_CI_REF="coq-master+elpi-1.11"
+    elpi_hb_CI_REF="coq-master+elpi.11"
+
+fi


### PR DESCRIPTION
This updates elpi to 1.11, which is a version that compiles fine on windows, cfr #12032 