### PR TITLE
Cleanup formatting in .. coqtop:: directives

### DIFF
--- a/doc/tools/coqrst/coqdoc/main.py
+++ b/doc/tools/coqrst/coqdoc/main.py
@@ -48,28 +48,16 @@ def coqdoc(coq_code, coqdoc_bin=None):
     finally:
         os.remove(filename)
 
-def is_whitespace_string(elem):
-    return isinstance(elem, NavigableString) and elem.strip() == ""
-
-def strip_soup(soup, pred):
-    """Strip elements matching pred from front and tail of soup."""
-    while soup.contents and pred(soup.contents[-1]):
-        soup.contents.pop()
-
-    skip = 0
-    for elem in soup.contents:
-        if not pred(elem):
-            break
-        skip += 1
-
-    soup.contents[:] = soup.contents[skip:]
-
 def lex(source):
     """Convert source into a stream of (css_classes, token_string)."""
     coqdoc_output = coqdoc(source)
     soup = BeautifulSoup(coqdoc_output, "html.parser")
     root = soup.find(class_='code')
-    strip_soup(root, is_whitespace_string)
+    if root.children:
+        # strip the leading '\n'
+        first = next(root.children)
+        if isinstance(first, NavigableString) and first.string[0] == '\n':
+            first.string.replace_with(first.string[1:])
     for elem in root.children:
         if isinstance(elem, NavigableString):
             yield [], elem

--- a/doc/tools/coqrst/coqdoc/main.py
+++ b/doc/tools/coqrst/coqdoc/main.py
@@ -48,16 +48,22 @@ def coqdoc(coq_code, coqdoc_bin=None):
     finally:
         os.remove(filename)
 
+def first_string_node(node):
+    """Return the first string node, or None if does not exist"""
+    while node.children:
+        node = next(node.children)
+        if isinstance(node, NavigableString):
+            return node
+
 def lex(source):
     """Convert source into a stream of (css_classes, token_string)."""
     coqdoc_output = coqdoc(source)
     soup = BeautifulSoup(coqdoc_output, "html.parser")
     root = soup.find(class_='code')
-    if root.children:
-        # strip the leading '\n'
-        first = next(root.children)
-        if isinstance(first, NavigableString) and first.string[0] == '\n':
-            first.string.replace_with(first.string[1:])
+    # strip the leading '\n'
+    first = first_string_node(root)
+    if first and first.string[0] == '\n':
+        first.string.replace_with(first.string[1:])
     for elem in root.children:
         if isinstance(elem, NavigableString):
             yield [], elem

--- a/doc/tools/coqrst/coqdomain.py
+++ b/doc/tools/coqrst/coqdomain.py
@@ -905,17 +905,13 @@ class CoqtopBlocksTransform(Transform):
         return isinstance(node, nodes.Element) and 'coqtop_options' in node
 
     @staticmethod
-    def split_sentences(node):
-        """Split Coq sentences in source. Could be improved."""
-        lines = map(lambda s: s.rstrip(), node.rawsource.splitlines())
-        out = [""]
-        for l in lines:
-            out[-1] = out[-1] + l + "\n"
-            if l.endswith("."):
-                out.append("")
-        if out[-1] == "":
-            out.pop()
-        return out
+    def split_lines(source):
+        """Split Coq input in chunks
+
+        A chunk is a minimal sequence of consecutive lines of the input that
+        ends with a '.'
+        """
+        return re.split(r"(?<=(?<!\.)\.)\s+\n", source)
 
     @staticmethod
     def parse_options(node):
@@ -994,7 +990,7 @@ class CoqtopBlocksTransform(Transform):
             repl.sendone('Unset Coqtop Exit On Error.')
         if options['warn']:
             repl.sendone('Set Warnings "default".')
-        for sentence in self.split_sentences(node):
+        for sentence in self.split_lines(node.rawsource):
             pairs.append((sentence, repl.sendone(sentence)))
         if options['abort']:
             repl.sendone('Abort All.')

--- a/doc/tools/coqrst/coqdomain.py
+++ b/doc/tools/coqrst/coqdomain.py
@@ -905,9 +905,17 @@ class CoqtopBlocksTransform(Transform):
         return isinstance(node, nodes.Element) and 'coqtop_options' in node
 
     @staticmethod
-    def split_sentences(source):
+    def split_sentences(node):
         """Split Coq sentences in source. Could be improved."""
-        return re.split(r"(?<=(?<!\.)\.)\s+", source)
+        lines = map(lambda s: s.rstrip(), node.rawsource.splitlines())
+        out = [""]
+        for l in lines:
+            out[-1] = out[-1] + l + "\n"
+            if l.endswith("."):
+                out.append("")
+        if out[-1] == "":
+            out.pop()
+        return out
 
     @staticmethod
     def parse_options(node):
@@ -986,7 +994,7 @@ class CoqtopBlocksTransform(Transform):
             repl.sendone('Unset Coqtop Exit On Error.')
         if options['warn']:
             repl.sendone('Set Warnings "default".')
-        for sentence in self.split_sentences(node.rawsource):
+        for sentence in self.split_sentences(node):
             pairs.append((sentence, repl.sendone(sentence)))
         if options['abort']:
             repl.sendone('Abort All.')


### PR DESCRIPTION
**Kind:** documentation

The formatting of `.. coqtop::` directives was pretty ugly. This PR attempts to fix that.
There are two main changes:
  1. Try to respect the line structure in coqtop directives
  2. Do not drop the whitespaces out of coqdoc's output to preserve the indentation of the rst file

This might have caused some unintended changes (less output than before), but the fixes should be easy.