### PR TITLE
[stdlib][List] add inductive definition for list inclusion

### DIFF
--- a/theories/Lists/List.v
+++ b/theories/Lists/List.v
@@ -3154,15 +3154,14 @@ Section SetIncl.
       Incl l m \/ Incl l n -> Incl l (m ++ n).
   Proof.
     intros * []; apply Forall_forall; intros;
-    apply in_or_app; [left|right]; apply In_Incl with l; auto.
+    apply in_or_app; eauto using In_Incl.
   Qed.
 
   Lemma Incl_app : forall l m n,
       Incl l n -> Incl m n -> Incl (l ++ m) n.
   Proof.
-    intros; apply Forall_forall; intros * Hin.
-    destruct (in_app_or _ _ _ Hin) as [];
-      [apply In_Incl with l|apply In_Incl with m]; auto.
+    intros; apply Forall_forall; intros.
+    edestruct in_app_or as []; eauto using In_Incl.
   Qed.
 
   Lemma Incl_app_inv : forall l m n,

--- a/theories/Lists/List.v
+++ b/theories/Lists/List.v
@@ -1910,7 +1910,7 @@ Hint Resolve lel_refl lel_cons_cons lel_cons lel_nil lel_nil nil_cons:
 (** ** Set inclusion on list  *)
 (******************************)
 
-Section SetIncl.
+Section Setincl.
 
   Variable A : Type.
 
@@ -2016,11 +2016,87 @@ Section SetIncl.
     apply in_in_remove; intuition.
   Qed.
 
-End SetIncl.
+End Setincl.
 
 Hint Resolve incl_refl incl_tl incl_tran incl_appl incl_appr incl_cons
   incl_app: datatypes.
 
+ Section SetIncl.
+
+   Variable A : Type.
+
+   Inductive Incl : list A -> list A -> Prop :=
+   | Incl_nil : forall l, Incl nil l
+   | Incl_cons : forall x l l', In x l' -> Incl l l' -> Incl (x :: l) l'.
+   Hint Constructors Incl : core.
+
+   Lemma In_Incl : forall a l m,
+       Incl l m -> In a l -> In a m.
+   Proof.
+     intros * H Ha.
+     induction H.
+     - inversion Ha.
+     - inversion Ha as [->|?]; auto.
+   Qed.
+
+   Lemma Incl_iff_incl : forall l m,
+       Incl l m <-> incl l m.
+   Proof.
+     intros; split; intro H.
+     - intros ? ?; apply In_Incl with l; auto.
+     - induction l.
+       + auto.
+       + destruct (incl_cons_inv H) as [].
+         constructor; auto.
+   Qed.
+
+   Lemma Incl_trans : forall l m n,
+       Incl l m -> Incl m n -> Incl l n.
+   Proof.
+     intros * Hlm ?.
+     induction Hlm as [| ? ? m ].
+     - auto.
+     - constructor.
+       + now apply In_Incl with m.
+       + auto.
+   Qed.
+
+   Lemma Incl_tl : forall a l m,
+       Incl l m -> Incl l (a :: m).
+   Proof.
+     intros * H.
+     induction H.
+     - auto.
+     - constructor; [simpl|]; auto.
+   Qed.
+
+   Lemma Incl_refl : forall l,
+       Incl l l.
+   Proof.
+     induction l.
+     - auto.
+     - constructor.
+       + simpl; auto.
+       + now apply Incl_tl.
+   Qed.
+
+   Lemma Incl_or_app : forall l m n,
+       Incl l m \/ Incl l n -> Incl l (m ++ n).
+   Proof.
+     intros * [H | H];
+       (induction H; [|constructor; [apply in_or_app|]]; auto).
+   Qed.
+
+   Lemma app_Incl : forall l m n,
+       Incl l n -> Incl m n -> Incl (l ++ m) n.
+   Proof.
+     intros l * Hln Hmn.
+     induction Hln.
+     - auto.
+     - rewrite <- app_comm_cons; constructor; auto.
+   Qed.
+
+End SetIncl.
 
 (**************************************)
 (** * Cutting a list at some position *)

--- a/theories/Lists/List.v
+++ b/theories/Lists/List.v
@@ -3157,12 +3157,32 @@ Section SetIncl.
     apply in_or_app; [left|right]; apply In_Incl with l; auto.
   Qed.
 
-  Lemma app_Incl : forall l m n,
+  Lemma Incl_app : forall l m n,
       Incl l n -> Incl m n -> Incl (l ++ m) n.
   Proof.
     intros; apply Forall_forall; intros * Hin.
     destruct (in_app_or _ _ _ Hin) as [];
       [apply In_Incl with l|apply In_Incl with m]; auto.
+  Qed.
+
+  Lemma Incl_app_inv : forall l m n,
+      Incl (l ++ m) n -> Incl l n /\ Incl m n.
+  Proof.
+    split;
+      (apply Incl_trans with (l ++ m);
+       [ apply Incl_or_app; auto using Incl_refl | auto ]).
+  Qed.
+
+  Lemma Incl_cons_inv : forall a l m,
+      Incl (a :: l) m -> In a m /\ Incl l m.
+  Proof.
+    intros * H. inversion H; auto.
+  Qed.
+
+  Lemma Incl_nil : forall l,
+      Incl l nil -> l = nil.
+  Proof.
+    intros * H. inversion H; [auto|contradiction].
   Qed.
 
 End SetIncl.

--- a/theories/Lists/List.v
+++ b/theories/Lists/List.v
@@ -2021,82 +2021,6 @@ End Setincl.
 Hint Resolve incl_refl incl_tl incl_tran incl_appl incl_appr incl_cons
   incl_app: datatypes.
 
- Section SetIncl.
-
-   Variable A : Type.
-
-   Inductive Incl : list A -> list A -> Prop :=
-   | Incl_nil : forall l, Incl nil l
-   | Incl_cons : forall x l l', In x l' -> Incl l l' -> Incl (x :: l) l'.
-   Hint Constructors Incl : core.
-
-   Lemma In_Incl : forall a l m,
-       Incl l m -> In a l -> In a m.
-   Proof.
-     intros * H Ha.
-     induction H.
-     - inversion Ha.
-     - inversion Ha as [->|?]; auto.
-   Qed.
-
-   Lemma Incl_iff_incl : forall l m,
-       Incl l m <-> incl l m.
-   Proof.
-     intros; split; intro H.
-     - intros ? ?; apply In_Incl with l; auto.
-     - induction l.
-       + auto.
-       + destruct (incl_cons_inv H) as [].
-         constructor; auto.
-   Qed.
-
-   Lemma Incl_trans : forall l m n,
-       Incl l m -> Incl m n -> Incl l n.
-   Proof.
-     intros * Hlm ?.
-     induction Hlm as [| ? ? m ].
-     - auto.
-     - constructor.
-       + now apply In_Incl with m.
-       + auto.
-   Qed.
-
-   Lemma Incl_tl : forall a l m,
-       Incl l m -> Incl l (a :: m).
-   Proof.
-     intros * H.
-     induction H.
-     - auto.
-     - constructor; [simpl|]; auto.
-   Qed.
-
-   Lemma Incl_refl : forall l,
-       Incl l l.
-   Proof.
-     induction l.
-     - auto.
-     - constructor.
-       + simpl; auto.
-       + now apply Incl_tl.
-   Qed.
-
-   Lemma Incl_or_app : forall l m n,
-       Incl l m \/ Incl l n -> Incl l (m ++ n).
-   Proof.
-     intros * [H | H];
-       (induction H; [|constructor; [apply in_or_app|]]; auto).
-   Qed.
-
-   Lemma app_Incl : forall l m n,
-       Incl l n -> Incl m n -> Incl (l ++ m) n.
-   Proof.
-     intros l * Hln Hmn.
-     induction Hln.
-     - auto.
-     - rewrite <- app_comm_cons; constructor; auto.
-   Qed.
-
-End SetIncl.
 
 (**************************************)
 (** * Cutting a list at some position *)
@@ -3178,6 +3102,70 @@ Section ForallPairs.
     destruct (ForallOrdPairs_In Hl _ _ Hx Hy); subst; intuition.
   Qed.
 End ForallPairs.
+
+Section SetIncl.
+
+  Variable A : Type.
+
+  Definition Incl l m := Forall (fun a => @In A a m) l.
+  Hint Unfold Incl : core.
+
+  Lemma In_Incl : forall a l m,
+      Incl l m -> In a l -> In a m.
+  Proof.
+    intros.
+    pattern a.
+    eapply Forall_forall with l; auto.
+  Qed.
+
+  Lemma Incl_iff_incl : forall l m,
+      Incl l m <-> incl l m.
+  Proof.
+    intros; split; intro.
+    - intros a ?. pattern a. eapply Forall_forall with l; auto.
+    - apply Forall_forall. auto.
+  Qed.
+
+  Lemma Incl_trans : forall l m n,
+      Incl l m -> Incl m n -> Incl l n.
+  Proof.
+    intros.
+    eapply Forall_impl with (fun x => In x m).
+    - apply Forall_forall; auto.
+    - auto.
+  Qed.
+
+  Lemma Incl_tl : forall a l m,
+      Incl l m -> Incl l (a :: m).
+  Proof.
+    intros.
+    eapply Forall_impl with (fun x => In x m).
+    - intros; simpl; auto.
+    - auto.
+  Qed.
+
+  Lemma Incl_refl : forall l,
+      Incl l l.
+  Proof.
+    intros. apply Forall_forall. auto.
+  Qed.
+
+  Lemma Incl_or_app : forall l m n,
+      Incl l m \/ Incl l n -> Incl l (m ++ n).
+  Proof.
+    intros * []; apply Forall_forall; intros;
+    apply in_or_app; [left|right]; apply In_Incl with l; auto.
+  Qed.
+
+  Lemma app_Incl : forall l m n,
+      Incl l n -> Incl m n -> Incl (l ++ m) n.
+  Proof.
+    intros; apply Forall_forall; intros * Hin.
+    destruct (in_app_or _ _ _ Hin) as [];
+      [apply In_Incl with l|apply In_Incl with m]; auto.
+  Qed.
+
+End SetIncl.
 
 Section Repeat.
 

--- a/theories/Lists/List.v
+++ b/theories/Lists/List.v
@@ -3138,9 +3138,7 @@ Section SetIncl.
   Lemma Incl_tl : forall a l m,
       Incl l m -> Incl l (a :: m).
   Proof.
-    intros. eapply Forall_impl with (fun x => In x m).
-    - intros; simpl; auto.
-    - auto.
+    intros. apply Forall_impl with (fun x => In x m); auto using in_cons.
   Qed.
 
   Lemma Incl_refl : forall l,

--- a/theories/Lists/List.v
+++ b/theories/Lists/List.v
@@ -3138,8 +3138,7 @@ Section SetIncl.
   Lemma Incl_tl : forall a l m,
       Incl l m -> Incl l (a :: m).
   Proof.
-    intros.
-    eapply Forall_impl with (fun x => In x m).
+    intros. eapply Forall_impl with (fun x => In x m).
     - intros; simpl; auto.
     - auto.
   Qed.
@@ -3153,15 +3152,15 @@ Section SetIncl.
   Lemma Incl_or_app : forall l m n,
       Incl l m \/ Incl l n -> Incl l (m ++ n).
   Proof.
-    intros * []; apply Forall_forall; intros;
-    apply in_or_app; eauto using In_Incl.
+    intros * []; apply Forall_forall;
+      intros; apply in_or_app; eauto using In_Incl.
   Qed.
 
   Lemma Incl_app : forall l m n,
       Incl l n -> Incl m n -> Incl (l ++ m) n.
   Proof.
-    intros; apply Forall_forall; intros.
-    edestruct in_app_or as []; eauto using In_Incl.
+    intros. apply Forall_forall.
+    intros. edestruct in_app_or as []; eauto using In_Incl.
   Qed.
 
   Lemma Incl_app_inv : forall l m n,
@@ -3182,6 +3181,26 @@ Section SetIncl.
       Incl l nil -> l = nil.
   Proof.
     intros * H. inversion H; [auto|contradiction].
+  Qed.
+
+  Lemma Incl_rev_l : forall l m,
+      Incl l m -> Incl (rev l) m.
+  Proof.
+    intros. apply Forall_rev. auto.
+  Qed.
+
+  Lemma Incl_rev_r : forall l m,
+      Incl l m -> Incl l (rev m).
+  Proof.
+    intros. apply Forall_forall.
+    intros. apply in_rev. rewrite rev_involutive. apply In_Incl with l; auto.
+  Qed.
+
+  Lemma Incl_Forall : forall P l m,
+      Incl l m -> Forall P m -> Forall P l.
+  Proof.
+    intros. apply Forall_forall.
+    intros. apply Forall_forall with m; eauto using In_Incl.
   Qed.
 
 End SetIncl.


### PR DESCRIPTION
Following discussion in #12237 this PR proposes an inductive definition for list inclusion, which is already present in `List` under the name `incl` with a different definition.

This is my first contribution to the project, do not hesitate if you have any suggestions to share.