### PR TITLE
Checking validity of coqdoc file name (fixes #12265)

### DIFF
--- a/doc/tools/coqrst/coqdoc/main.py
+++ b/doc/tools/coqrst/coqdoc/main.py
@@ -36,7 +36,7 @@ COQDOC_HEADER = "".join("(** remove printing {} *)".format(s) for s in COQDOC_SY
 def coqdoc(coq_code, coqdoc_bin=None):
     """Get the output of coqdoc on coq_code."""
     coqdoc_bin = coqdoc_bin or os.path.join(os.getenv("COQBIN", ""), "coqdoc")
-    fd, filename = mkstemp(prefix="coqdoc-", suffix=".v")
+    fd, filename = mkstemp(prefix="coqdoc_", suffix=".v")
     if platform.system().startswith("CYGWIN"):
         # coqdoc currently doesn't accept cygwin style paths in the form "/cygdrive/c/..."
         filename = check_output(["cygpath", "-w", filename]).decode("utf-8").strip()

--- a/tools/coqdoc/dune
+++ b/tools/coqdoc/dune
@@ -9,6 +9,6 @@
  (name main)
  (public_name coqdoc)
  (package coq)
- (libraries str coq.config))
+ (libraries str coq.config coq.clib))
 
 (ocamllex cpretty)

--- a/tools/coqdoc/main.ml
+++ b/tools/coqdoc/main.ml
@@ -127,6 +127,9 @@ let rec name_of_path p name dirname suffix =
 let coq_module filename =
   let bfname = Filename.chop_extension filename in
   let dirname, fname = normalize_filename bfname in
+  let _ = match Unicode.ident_refutation fname with
+    | Some err -> eprintf "\ncoqdoc: not a valid filename %s.v\n" fname; exit 1
+    | None -> () in
   let rec change_prefix = function
     (* Follow coqc: if in scope of -R, substitute logical name *)
     (* otherwise, keep only base name *)


### PR DESCRIPTION
In particular, this fixes #12265 (javascript injection vulnerability in file name).

**Kind:** bug fix

Fixes / closes #12265 (it fixes at least the reported vulnerability; there may be others).

- [ ] Entry added in the changelog
