### PR TITLE
Change the precedence of implicit coercions to respect `Import` invariant

### DIFF
--- a/pretyping/coercionops.ml
+++ b/pretyping/coercionops.ml
@@ -353,7 +353,12 @@ let add_coercion_in_graph env sigma (ic,source,target) =
         if not (List.exists (fun c -> List.exists (coe_info_typ_equal c) q) p ||
                 compare_path env sigma i p q) then
           ambig_paths := (ij,p,q)::!ambig_paths;
-        false
+        if List.length p <= List.length q then begin
+          (* If the new coercion path is non-strictly shorter than the valid
+             one, we overwrite it with the new one. See #10825. *)
+          add_new_path ij p; true
+        end else
+          false
       | exception Not_found -> (add_new_path ij p; true)
     else
       false

--- a/test-suite/output/relaxed_ambiguous_paths.out
+++ b/test-suite/output/relaxed_ambiguous_paths.out
@@ -3,7 +3,7 @@ Warning:
 New coercion path [ac; cd] : A >-> D is ambiguous with existing 
 [ab; bd] : A >-> D. [ambiguous-paths,typechecker]
 [ab] : A >-> B
-[ab; bd] : A >-> D
+[ac; cd] : A >-> D
 [ac] : A >-> C
 [bd] : B >-> D
 [cd] : C >-> D
@@ -27,7 +27,7 @@ New coercion path [ab; bc] : A >-> C is ambiguous with existing
 [B_A'; A'_A] : B >-> A
 [C_A'] : C >-> A'
 [C_A'; A'_A] : C >-> A
-[D_B; B_A'] : D >-> A'
+[D_C; C_A'] : D >-> A'
 [D_A] : D >-> A
 [D_B] : D >-> B
 [D_C] : D >-> C
@@ -40,7 +40,7 @@ New coercion path [D_C; C_A'] : D >-> A' is ambiguous with existing
 [B_A'; A'_A] : B >-> A
 [C_A'] : C >-> A'
 [C_A'; A'_A] : C >-> A
-[D_B; B_A'] : D >-> A'
+[D_C; C_A'] : D >-> A'
 [D_A] : D >-> A
 [D_B] : D >-> B
 [D_C] : D >-> C


### PR DESCRIPTION
We give the precedence to a newer coercion path when it is non-strictly shorter than existing ones. cc: @herbelin 

**Kind:** bug fix.

This PR partially fixes issue #10825.

<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [ ] Added / updated test-suite
<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [ ] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [ ] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
