### PR TITLE
Fix handling for SELF, NEXT in doc_grammar

### DIFF
--- a/doc/sphinx/language/core/records.rst
+++ b/doc/sphinx/language/core/records.rst
@@ -170,8 +170,8 @@ available:
   .. insertprodn term_projection term_projection
 
   .. prodn::
-     term_projection ::= @term0 .( @qualid {* @arg } )
-     | @term0 .( @ @qualid {* @term1 } )
+     term_projection ::= @term .( @qualid {* @arg } )
+     | @term .( @ @qualid {* @term1 } )
 
   Syntax of Record projections
 

--- a/doc/sphinx/language/gallina-specification-language.rst
+++ b/doc/sphinx/language/gallina-specification-language.rst
@@ -204,7 +204,7 @@ Applications
 .. insertprodn term_application arg
 
 .. prodn::
-   term_application ::= @term1 {+ @arg }
+   term_application ::= @term {+ @arg }
    | @ @qualid_annotated {+ @term1 }
    arg ::= ( @ident := @term )
    | @term1
@@ -231,10 +231,10 @@ Type cast
 .. insertprodn term_cast term_cast
 
 .. prodn::
-   term_cast ::= @term10 <: @term
-   | @term10 <<: @term
-   | @term10 : @term
-   | @term10 :>
+   term_cast ::= @term <: @term
+   | @term <<: @term
+   | @term : @term
+   | @term :>
 
 The expression :n:`@term : @type` is a type cast expression. It enforces
 the type of :n:`@term` to be :n:`@type`.
@@ -287,12 +287,12 @@ Definition by cases: match
    term_match ::= match {+, @case_item } {? return @term100 } with {? %| } {*| @eqn } end
    case_item ::= @term100 {? as @name } {? in @pattern }
    eqn ::= {+| {+, @pattern } } => @term
-   pattern ::= @pattern10 : @term
+   pattern ::= @pattern : @term
    | @pattern10
-   pattern10 ::= @pattern1 as @name
-   | @pattern1 {* @pattern1 }
+   pattern10 ::= @pattern as @name
+   | @pattern {* @pattern1 }
    | @ @qualid {* @pattern1 }
-   pattern1 ::= @pattern0 % @scope_key
+   pattern1 ::= @pattern % @scope_key
    | @pattern0
    pattern0 ::= @qualid
    | %{%| {* @qualid := @pattern } %|%}

--- a/doc/sphinx/user-extensions/syntax-extensions.rst
+++ b/doc/sphinx/user-extensions/syntax-extensions.rst
@@ -1089,7 +1089,7 @@ Opening a notation scope locally
 .. insertprodn term_scope term_scope
 
 .. prodn::
-   term_scope ::= @term0 % @scope_key
+   term_scope ::= @term % @scope_key
 
 The notation scope stack can be locally extended within
 a :token:`term` with the syntax

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -242,10 +242,10 @@ scope: [
 ]
 
 operconstr100: [
-| MOVETO term_cast operconstr99 "<:" operconstr200
-| MOVETO term_cast operconstr99 "<<:" operconstr200
-| MOVETO term_cast operconstr99 ":" operconstr200
-| MOVETO term_cast operconstr99 ":>"
+| MOVETO term_cast operconstr200 "<:" operconstr200
+| MOVETO term_cast operconstr200 "<<:" operconstr200
+| MOVETO term_cast operconstr200 ":" operconstr200
+| MOVETO term_cast operconstr200 ":>"
 ]
 
 constr: [
@@ -261,7 +261,7 @@ operconstr10: [
 | WITH "@" qualid_annotated LIST1 operconstr9
 | REPLACE operconstr9
 | WITH constr
-| MOVETO term_application operconstr9 LIST1 appl_arg
+| MOVETO term_application operconstr200 LIST1 appl_arg
 | MOVETO term_application "@" qualid_annotated LIST1 operconstr9
 (* fixme: add in as a prodn somewhere *)
 | MOVETO dangling_pattern_extension_rule "@" pattern_identref LIST1 identref
@@ -274,13 +274,13 @@ operconstr9: [
 ]
 
 operconstr1: [
-| REPLACE operconstr0 ".(" global LIST0 appl_arg ")"
-| WITH    operconstr0 ".(" global LIST0 appl_arg ")" (* huh? *)
-| REPLACE operconstr0 "%" IDENT
-| WITH operconstr0 "%" scope_key
-| MOVETO term_scope operconstr0 "%" scope_key
-| MOVETO term_projection operconstr0 ".(" global LIST0 appl_arg ")"
-| MOVETO term_projection operconstr0 ".(" "@" global LIST0 ( operconstr9 ) ")"
+| REPLACE operconstr200 ".(" global LIST0 appl_arg ")"
+| WITH    operconstr200 ".(" global LIST0 appl_arg ")" (* huh? *)
+| REPLACE operconstr200 "%" IDENT
+| WITH operconstr200 "%" scope_key
+| MOVETO term_scope operconstr200 "%" scope_key
+| MOVETO term_projection operconstr200 ".(" global LIST0 appl_arg ")"
+| MOVETO term_projection operconstr200 ".(" "@" global LIST0 ( operconstr9 ) ")"
 ]
 
 operconstr0: [
@@ -401,14 +401,14 @@ DELETE: [
 ]
 
 pattern10: [
-| REPLACE pattern1 LIST1 pattern1
-| WITH pattern1 LIST0 pattern1
+| REPLACE pattern200 LIST1 pattern1
+| WITH pattern200 LIST0 pattern1
 | DELETE pattern1
 ]
 
 pattern1: [
-| REPLACE pattern0 "%" IDENT
-| WITH pattern0 "%" scope_key
+| REPLACE pattern200 "%" IDENT
+| WITH pattern200 "%" scope_key
 ]
 
 pattern0: [
@@ -686,8 +686,8 @@ DELETE: [
 ]
 
 tactic_expr4: [
-| REPLACE tactic_expr3 ";" tactic_then_gen "]"
-| WITH tactic_expr3 ";" "[" tactic_then_gen "]"
+| REPLACE tactic_expr5 ";" tactic_then_gen "]"
+| WITH tactic_expr5 ";" "[" tactic_then_gen "]"
 | tactic_expr3 ";" "[" ">" tactic_then_gen "]"
 ]
 

--- a/doc/tools/docgram/doc_grammar.ml
+++ b/doc/tools/docgram/doc_grammar.ml
@@ -417,21 +417,46 @@ let add_symdef nt file symdef_map =
   in
   symdef_map := StringMap.add nt (Filename.basename file::ent) !symdef_map
 
-let rec edit_SELF nt cur_level next_level right_assoc prod =
+let rec edit_SELF nt cur_level next_level right_assoc inner prod =
+  let subedit sym = List.hd (edit_SELF nt cur_level next_level right_assoc true [sym]) in
   let len = List.length prod in
   List.mapi (fun i sym ->
     match sym with
-    | Snterm s -> begin match s with
-      | s when s = nt || s = "SELF" ->
-        if i = 0 then Snterm next_level
-        else if i+1 < len then sym
-        else if right_assoc then Snterm cur_level else Snterm next_level
-      | "NEXT" -> Snterm next_level
-      | _ -> sym
-    end
-    | Slist1 sym -> Slist1 (List.hd (edit_SELF nt cur_level next_level right_assoc [sym]))
-    | Slist0 sym -> Slist0 (List.hd (edit_SELF nt cur_level next_level right_assoc [sym]))
-    | x -> x)
+    | Sterm _ -> sym
+    | Snterm s ->
+      begin match s with
+        | s when s = "SELF" || s = nt ->
+          (* See https://camlp5.github.io/doc/pdf/camlp5-7.00.pdf version 7.00,
+            June 26, 2017 section 8.6.2:
+
+            This seems correct:
+            "When a SELF or the current entry name is encountered in the middle of the rule
+             (i.e. if it is not the last symbol), there is a call to the "start" function
+             of the First level of the current entry."
+
+            but this is incorrect, contradicting the first statement:
+            "The left "SELF"s of the two levels "minus" and "power" correspond to a call to the next level."
+
+            Examples:
+            once idtac + (once idtac).  ACCEPTED -> lhs goes to top
+            idtac + once idtac.  PARSE ERROR -> rhs is not to top level, sb at current level
+          *)
+          if not inner && i+1 = len then
+            (if right_assoc then Snterm cur_level else Snterm next_level)
+          else
+            Snterm nt
+        | "NEXT" -> Snterm next_level
+        | _ -> sym
+      end
+    | Slist1 sym -> Slist1 (subedit sym)
+    | Slist0 sym -> Slist0 (subedit sym)
+    | Slist1sep (sym, sep) -> Slist1sep ((subedit sym), (subedit sep))
+    | Slist0sep (sym, sep) -> Slist0sep ((subedit sym), (subedit sep))
+    | Sopt sym -> Sopt (subedit sym)
+    | Sparen syms -> Sparen (List.map (fun sym -> subedit sym) syms)
+    | Sprod prods -> Sprod (List.map (fun prod -> edit_SELF nt cur_level next_level right_assoc true prod) prods)
+    | Sedit _ -> sym
+    | Sedit2 _ -> sym)
   prod
 
 
@@ -501,6 +526,7 @@ in
 let has_match p prods = List.exists (fun p2 -> ematch p p2) prods
 
 let plugin_regex = Str.regexp "^plugins/\\([a-zA-Z0-9_]+\\)/"
+let level_regex = Str.regexp "[a-zA-Z0-9_]*$"
 
 let read_mlg is_edit ast file level_renames symdef_map =
   let res = ref [] in
@@ -541,6 +567,10 @@ let read_mlg is_edit ast file level_renames symdef_map =
                   -> lev
                 (* Looks like FIRST/LAST can be ignored for documenting the current grammar *)
                 | _ -> "" in
+              if len > 1 && level = "" then
+                error "Missing level string for `%s`\n" nt
+              else if not (Str.string_match level_regex level 0) then
+                error "Invalid level string `%s` for `%s`\n" level nt;
               let cur_level = nt ^ level in
               let next_level = nt ^
                   if i+1 < len then (get_label (List.nth ent.gentry_rules (i+1)).grule_label) else "" in
@@ -552,7 +582,7 @@ let read_mlg is_edit ast file level_renames symdef_map =
               let cvted = List.map cvt_gram_prod rule.grule_prods in
               (* edit names for levels *)
               (* See https://camlp5.github.io/doc/html/grammars.html#b:Associativity *)
-              let edited = List.map (edit_SELF nt cur_level next_level right_assoc) cvted in
+              let edited = List.map (edit_SELF nt cur_level next_level right_assoc false) cvted in
               let prods_to_add =
                 if cur_level <> nt && i+1 < len then
                   edited @ [[Snterm next_level]]

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -73,10 +73,10 @@ operconstr200: [
 ]
 
 operconstr100: [
-| operconstr99 "<:" operconstr200
-| operconstr99 "<<:" operconstr200
-| operconstr99 ":" operconstr200
-| operconstr99 ":>"
+| operconstr200 "<:" operconstr200
+| operconstr200 "<<:" operconstr200
+| operconstr200 ":" operconstr200
+| operconstr200 ":>"
 | operconstr99
 ]
 
@@ -89,7 +89,7 @@ operconstr90: [
 ]
 
 operconstr10: [
-| operconstr9 LIST1 appl_arg
+| operconstr200 LIST1 appl_arg
 | "@" global univ_instance LIST0 operconstr9
 | "@" pattern_identref LIST1 identref
 | operconstr9
@@ -105,9 +105,9 @@ operconstr8: [
 ]
 
 operconstr1: [
-| operconstr0 ".(" global LIST0 appl_arg ")"
-| operconstr0 ".(" "@" global LIST0 ( operconstr9 ) ")"
-| operconstr0 "%" IDENT
+| operconstr200 ".(" global LIST0 appl_arg ")"
+| operconstr200 ".(" "@" global LIST0 ( operconstr9 ) ")"
+| operconstr200 "%" IDENT
 | operconstr0
 ]
 
@@ -250,7 +250,7 @@ pattern200: [
 ]
 
 pattern100: [
-| pattern99 ":" operconstr200
+| pattern200 ":" operconstr200
 | pattern99
 ]
 
@@ -263,14 +263,14 @@ pattern90: [
 ]
 
 pattern10: [
-| pattern1 "as" name
-| pattern1 LIST1 pattern1
+| pattern200 "as" name
+| pattern200 LIST1 pattern1
 | "@" Prim.reference LIST0 pattern1
 | pattern1
 ]
 
 pattern1: [
-| pattern0 "%" IDENT
+| pattern200 "%" IDENT
 | pattern0
 ]
 
@@ -1163,8 +1163,8 @@ ssexpr35: [
 ]
 
 ssexpr50: [
-| ssexpr0 "-" ssexpr0
-| ssexpr0 "+" ssexpr0
+| ssexpr35 "-" ssexpr0
+| ssexpr35 "+" ssexpr0
 | ssexpr0
 ]
 
@@ -1933,9 +1933,9 @@ tactic_expr5: [
 ]
 
 tactic_expr4: [
-| tactic_expr3 ";" binder_tactic
-| tactic_expr3 ";" tactic_expr3
-| tactic_expr3 ";" tactic_then_locality tactic_then_gen "]"
+| tactic_expr5 ";" binder_tactic
+| tactic_expr5 ";" tactic_expr3
+| tactic_expr5 ";" tactic_then_locality tactic_then_gen "]"
 | tactic_expr3
 ]
 
@@ -1956,11 +1956,11 @@ tactic_expr3: [
 ]
 
 tactic_expr2: [
-| tactic_expr1 "+" binder_tactic
-| tactic_expr1 "+" tactic_expr2
+| tactic_expr5 "+" binder_tactic
+| tactic_expr5 "+" tactic_expr2
 | "tryif" tactic_expr5 "then" tactic_expr5 "else" tactic_expr2
-| tactic_expr1 "||" binder_tactic
-| tactic_expr1 "||" tactic_expr2
+| tactic_expr5 "||" binder_tactic
+| tactic_expr5 "||" tactic_expr2
 | tactic_expr1
 ]
 

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -65,12 +65,12 @@ term_ltac: [
 ]
 
 term_projection: [
-| term0 ".(" qualid LIST0 arg ")"
-| term0 ".(" "@" qualid LIST0 ( term1 ) ")"
+| term ".(" qualid LIST0 arg ")"
+| term ".(" "@" qualid LIST0 ( term1 ) ")"
 ]
 
 term_scope: [
-| term0 "%" scope_key
+| term "%" scope_key
 ]
 
 term_evar: [
@@ -85,7 +85,7 @@ dangling_pattern_extension_rule: [
 ]
 
 term_application: [
-| term1 LIST1 arg
+| term LIST1 arg
 | "@" qualid_annotated LIST1 term1
 ]
 
@@ -345,10 +345,10 @@ term_generalizing: [
 ]
 
 term_cast: [
-| term10 "<:" term
-| term10 "<<:" term
-| term10 ":" term
-| term10 ":>"
+| term "<:" term
+| term "<<:" term
+| term ":" term
+| term ":>"
 ]
 
 term_match: [
@@ -364,18 +364,18 @@ eqn: [
 ]
 
 pattern: [
-| pattern10 ":" term
+| pattern ":" term
 | pattern10
 ]
 
 pattern10: [
-| pattern1 "as" name
-| pattern1 LIST0 pattern1
+| pattern "as" name
+| pattern LIST0 pattern1
 | "@" qualid LIST0 pattern1
 ]
 
 pattern1: [
-| pattern0 "%" scope_key
+| pattern "%" scope_key
 | pattern0
 ]
 
@@ -957,8 +957,8 @@ ssexpr: [
 ]
 
 ssexpr50: [
-| ssexpr0 "-" ssexpr0
-| ssexpr0 "+" ssexpr0
+| ssexpr "-" ssexpr0
+| ssexpr "+" ssexpr0
 | ssexpr0
 ]
 
@@ -1666,9 +1666,9 @@ let_clause: [
 ]
 
 ltac_expr4: [
-| ltac_expr3 ";" binder_tactic
-| ltac_expr3 ";" ltac_expr3
-| ltac_expr3 ";" "[" OPT multi_goal_tactics "]"
+| ltac_expr ";" binder_tactic
+| ltac_expr ";" ltac_expr3
+| ltac_expr ";" "[" OPT multi_goal_tactics "]"
 | ltac_expr3
 | ltac_expr3 ";" "[" ">" OPT multi_goal_tactics "]"
 ]
@@ -1721,11 +1721,11 @@ range_selector: [
 ]
 
 ltac_expr2: [
-| ltac_expr1 "+" binder_tactic
-| ltac_expr1 "+" ltac_expr2
+| ltac_expr "+" binder_tactic
+| ltac_expr "+" ltac_expr2
 | "tryif" ltac_expr "then" ltac_expr "else" ltac_expr2
-| ltac_expr1 "||" binder_tactic
-| ltac_expr1 "||" ltac_expr2
+| ltac_expr "||" binder_tactic
+| ltac_expr "||" ltac_expr2
 | ltac_expr1
 ]
 


### PR DESCRIPTION
The camlp5 documentation for SELF is inconsistent, which contributed to errors in how doc_grammar translated the construct.  I've checked representative examples in Coq to verify that it's correct now.

See https://camlp5.github.io/doc/pdf/camlp5-7.00.pdf version 7.00, June 26, 2017 section 8.6.2:

This seems correct but wasn't fully followed in the code: "When a SELF or the current entry name is encountered in the middle of the rule (i.e. if it is not the last symbol), there is a call to the "start" function of the First level of the current entry."

But this is incorrect, contradicting the first statement and leading to some confusion: "The left "SELF"s of the two levels "minus" and "power" correspond to a call to the next level."

Examples:
once idtac + (once idtac).  ACCEPTED -> lhs is top level
idtac + once idtac.  PARSE ERROR -> rhs is not top level, should be current level

`g_ltac.mlg` includes the following productions.  

```
  tactic_expr:
    | "3" RIGHTA [
      | IDENT "once"; ta = tactic_expr -> { TacOnce ta }
    | "2" RIGHTA
      | ta0 = tactic_expr; "+"; ta1 = tactic_expr -> { TacOr (ta0,ta1) }
```

You can see the fix for the example in `fullGrammar` at "tactic_expr2:".

