### PR TITLE
Fixes #12233: printing environment corrupted with eta-expansion of "match" branches

### DIFF
--- a/doc/changelog/07-commands-and-options/12295-master+fix12234-show-proof.rst
+++ b/doc/changelog/07-commands-and-options/12295-master+fix12234-show-proof.rst
@@ -1,0 +1,4 @@
+- **Fixed:**
+  A printing bug in the presence of elimination principles with local definitions
+  (`#12295 <https://github.com/coq/coq/pull/12295>`_,
+  by Hugo Herbelin; fixes `#12233 <https://github.com/coq/coq/pull/12233>`_).

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -370,6 +370,11 @@ let ehole_var = EConstr.mkVar (Id.of_string "_")
 let pr_econstr_pat env sigma c0 =
   let rec wipe_evar c = let open EConstr in
     if isEvar sigma c then ehole_var else map sigma wipe_evar c in
+  let dummy_decl =
+    let dummy_prod = mkProd (make_annot Anonymous Sorts.Relevant,mkProp,mkProp) in
+    let na = make_annot (EConstr.destVar sigma ehole_var) Sorts.Relevant in
+    Context.Named.Declaration.(LocalAssum (na, dummy_prod)) in
+  let env = Environ.push_named dummy_decl env in
   pr_econstr_env env sigma (wipe_evar c0)
 
 (* Turn (new) evars into metas *)

--- a/test-suite/bugs/closed/bug_12233.v
+++ b/test-suite/bugs/closed/bug_12233.v
@@ -1,0 +1,5 @@
+Theorem thm (A:Prop) (H:exists m:nat, True) : True.
+destruct H as ([|],?).
+assert A.
+Show Proof. (* was raising Not_found since 8.7 *)
+Abort.


### PR DESCRIPTION
**Kind:** bug fix

The main fix is in `Detyping.decomp_branch` which needs a declaration to push to the environment even in the eta-expansion cases.

In the process, we preserve binder annotations in detyping (maybe not so useful, but morally better, for instance for funind).

Note: we left an horrible hack in the case of LetIn expansion. This is supposed to disappear with #9710.

Fixes / closes #12233

- [X] Added / updated test-suite
- [x] Entry added in the changelog
