### PR TITLE
Fixes #12234: wrong environment for Show Proof

### DIFF
--- a/doc/changelog/07-commands-and-options/12296-master+fix12234-show-proof-proper.rst
+++ b/doc/changelog/07-commands-and-options/12296-master+fix12234-show-proof-proper.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  Anomalies with :cmd:`Show Proof`
+  (`#12296 <https://github.com/coq/coq/pull/12296>`_,
+  by Hugo Herbelin; fixes
+  `#12234 <https://github.com/coq/coq/pull/12234>`_).

--- a/test-suite/bugs/closed/bug_12234.v
+++ b/test-suite/bugs/closed/bug_12234.v
@@ -1,0 +1,9 @@
+(* Checking a Show Proof bug *)
+Section S.
+Variable A:Prop.
+Theorem thm (a:A) : True.
+assert (b:=a).
+clear A a b.
+Show Proof.
+Abort.
+End S.

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -95,8 +95,14 @@ let show_proof ~pstate =
   try
     let pstate = Option.get pstate in
     let p = Declare.Proof.get_proof pstate in
-    let sigma, env = Declare.get_current_context pstate in
+    let sigma, _ = Declare.get_current_context pstate in
     let pprf = Proof.partial_proof p in
+    (* In the absence of an environment explicitly attached to the
+       proof and on top of which side effects of the proof would be pushed, ,
+       we take the global environment which in practise should be a
+       superset of the initial environment in which the proof was
+       started *)
+    let env = Global.env() in
     Pp.prlist_with_sep Pp.fnl (Printer.pr_econstr_env env sigma) pprf
   (* We print nothing if there are no goals left *)
   with


### PR DESCRIPTION
We take the env of the current goal with the context replaced with section variables. In practice, this is the global env, but, maybe, one day, a goal state will have its own env.

**Kind:**  bug fix 

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #12234
Presumably fixed #10859 and #10860 too

- [X] Added / updated test-suite
- [ ] Entry added in the changelog