### PR TITLE
Tests for bugs #9583 (fixed by #11613) and #9679.

### DIFF
--- a/test-suite/bugs/closed/bug_9583.v
+++ b/test-suite/bugs/closed/bug_9583.v
@@ -1,0 +1,7 @@
+(* Was causing a stack overflow before #11613 *)
+Declare Custom Entry bla.
+Notation "[ t ]" := (t) (at level 0, t custom bla at level 0).
+Notation "] t [" := (t) (in custom bla at level 0, t custom bla at level 0).
+Notation "t" := (t) (in custom bla at level 0, t constr at level 9).
+Notation "0" := (0) (in custom bla at level 0).
+Check fun x => [ ] x [ ].

--- a/test-suite/bugs/closed/bug_9679.v
+++ b/test-suite/bugs/closed/bug_9679.v
@@ -1,0 +1,6 @@
+(* Was raising an anomaly *)
+Notation "'[#' ] f '|' x .. z '=n>' b" :=
+  (fun x => .. (fun z => f b) ..)
+    (at level 201, x binder, z binder,
+     format "'[  ' [# ] '[' f  | ']'  x  ..  z  =n>  '[' b ']' ']'"
+    ).


### PR DESCRIPTION
**Kind:** tests

This adds tests for  #9583 and #9679, as suggested by @ejgallego on the correspondings pages of the issues.

- [X] Added / updated test-suite
