### PR TITLE
Add Ltac2.Constr.Case.{make,nparameters,inductive}

### DIFF
--- a/user-contrib/Ltac2/Constr.v
+++ b/user-contrib/Ltac2/Constr.v
@@ -20,6 +20,7 @@ Module Unsafe.
 
 (** Low-level access to kernel terms. Use with care! *)
 
+(** XXX TODO PR Should this be moved to [Constr.case]? *)
 Ltac2 Type case.
 
 Ltac2 Type kind := [
@@ -61,7 +62,8 @@ Ltac2 @ external closenl : ident list -> int -> constr -> constr := "ltac2" "con
 (** [closenl [x₁;...;xₙ] k c] abstracts over variables [x₁;...;xₙ] and replaces them with
     [Rel(k); ...; Rel(k+n-1)] in [c]. If two names are identical, the one of least index is kept. *)
 
-Ltac2 @ external case : inductive -> case := "ltac2" "constr_case".
+(* XXX TODO: Deprecate this.  We can't do #[deprecated(since="8.12",note="Use Constr.Case.make instead.")] because of COQBUG(https://github.com/coq/coq/issues/12317) *)
+Ltac2 @ external case : inductive -> case := "ltac2" "constr_case_make".
 (** Generate the case information for a given inductive type. *)
 
 Ltac2 @ external constructor : inductive -> int -> constructor := "ltac2" "constr_constructor".
@@ -82,6 +84,19 @@ Ltac2 @ external type : binder -> constr := "ltac2" "constr_binder_type".
 (** Retrieve the type of a binder. *)
 
 End Binder.
+
+Module Case.
+
+Ltac2 @ external make : inductive -> Unsafe.case := "ltac2" "constr_case_make".
+(** Generate the case information for a given inductive type. *)
+
+Ltac2 @ external inductive : Unsafe.case -> inductive := "ltac2" "constr_case_inductive".
+(** Retrieve the inductive of a case. *)
+
+Ltac2 @ external nparameters : Unsafe.case -> int := "ltac2" "constr_case_nparameters".
+(** Retrieve the number of parameters of the inductive in a case. *)
+
+End Case.
 
 Ltac2 @ external in_context : ident -> constr -> (unit -> unit) -> constr := "ltac2" "constr_in_context".
 (** On a focused goal [Γ ⊢ A], [in_context id c tac] evaluates [tac] in a

--- a/user-contrib/Ltac2/tac2core.ml
+++ b/user-contrib/Ltac2/tac2core.ml
@@ -413,7 +413,7 @@ let () = define1 "constr_kind" constr begin fun c ->
     |]
   | Ind (ind, u) ->
     v_blk 11 [|
-      Value.of_ext Value.val_inductive ind;
+      Value.of_inductive ind;
       of_instance u;
     |]
   | Construct (cstr, u) ->
@@ -423,7 +423,7 @@ let () = define1 "constr_kind" constr begin fun c ->
     |]
   | Case (ci, c, t, bl) ->
     v_blk 13 [|
-      Value.of_ext Value.val_case ci;
+      Value.of_case ci;
       Value.of_constr c;
       Value.of_constr t;
       Value.of_array Value.of_constr bl;
@@ -500,7 +500,7 @@ let () = define1 "constr_make" valexpr begin fun knd ->
     let u = to_instance u in
     EConstr.mkConstU (cst, u)
   | (11, [|ind; u|]) ->
-    let ind = Value.to_ext Value.val_inductive ind in
+    let ind = Value.to_inductive ind in
     let u = to_instance u in
     EConstr.mkIndU (ind, u)
   | (12, [|cstr; u|]) ->
@@ -508,7 +508,7 @@ let () = define1 "constr_make" valexpr begin fun knd ->
     let u = to_instance u in
     EConstr.mkConstructU (cstr, u)
   | (13, [|ci; c; t; bl|]) ->
-    let ci = Value.to_ext Value.val_case ci in
+    let ci = Value.to_case ci in
     let c = Value.to_constr c in
     let t = Value.to_constr t in
     let bl = Value.to_array Value.to_constr bl in
@@ -557,15 +557,6 @@ end
 let () = define3 "constr_closenl" (list ident) int constr begin fun ids k c ->
   let ans = EConstr.Vars.substn_vars k ids c in
   return (Value.of_constr ans)
-end
-
-let () = define1 "constr_case" (repr_ext val_inductive) begin fun ind ->
-  Proofview.tclENV >>= fun env ->
-  try
-    let ans = Inductiveops.make_case_info env ind Sorts.Relevant Constr.RegularStyle in
-    return (Value.of_ext Value.val_case ans)
-  with e when CErrors.noncritical e ->
-    throw err_notfound
 end
 
 let () = define2 "constr_constructor" (repr_ext val_inductive) int begin fun (ind, i) k ->
@@ -650,6 +641,25 @@ end
 
 let () = define1 "constr_binder_type" (repr_ext val_binder) begin fun (bnd, ty) ->
   return (of_constr ty)
+end
+
+let () = define1 "constr_case_make" (repr_ext val_inductive) begin fun ind ->
+  Proofview.tclENV >>= fun env ->
+  try
+    let ans = Inductiveops.make_case_info env ind Sorts.Relevant Constr.RegularStyle in
+    return (Value.of_case ans)
+  with e when CErrors.noncritical e ->
+    throw err_notfound
+end
+
+let () = define1 "constr_case_inductive" (repr_ext val_case) begin fun ci ->
+  let open Constr in
+  return (Value.of_inductive ci.ci_ind)
+end
+
+let () = define1 "constr_case_nparameters" (repr_ext val_case) begin fun ci ->
+  let open Constr in
+  return (Value.of_int ci.ci_npar)
 end
 
 (** Patterns *)

--- a/user-contrib/Ltac2/tac2ffi.ml
+++ b/user-contrib/Ltac2/tac2ffi.ml
@@ -220,6 +220,10 @@ let repr_ext tag = {
   r_id = false;
 }
 
+let of_case c = of_ext val_case c
+let to_case c = to_ext val_case c
+let case = repr_ext val_case
+
 let of_constr c = of_ext val_constr c
 let to_constr c = to_ext val_constr c
 let constr = repr_ext val_constr
@@ -227,6 +231,10 @@ let constr = repr_ext val_constr
 let of_ident c = of_ext val_ident c
 let to_ident c = to_ext val_ident c
 let ident = repr_ext val_ident
+
+let of_inductive c = of_ext val_inductive c
+let to_inductive c = to_ext val_inductive c
+let inductive = repr_ext val_inductive
 
 let of_pattern c = of_ext val_pattern c
 let to_pattern c = to_ext val_pattern c
@@ -354,13 +362,13 @@ let constant = repr_ext val_constant
 let of_reference = let open GlobRef in function
 | VarRef id -> ValBlk (0, [| of_ident id |])
 | ConstRef cst -> ValBlk (1, [| of_constant cst |])
-| IndRef ind -> ValBlk (2, [| of_ext val_inductive ind |])
+| IndRef ind -> ValBlk (2, [| of_inductive ind |])
 | ConstructRef cstr -> ValBlk (3, [| of_ext val_constructor cstr |])
 
 let to_reference = let open GlobRef in function
 | ValBlk (0, [| id |]) -> VarRef (to_ident id)
 | ValBlk (1, [| cst |]) -> ConstRef (to_constant cst)
-| ValBlk (2, [| ind |]) -> IndRef (to_ext val_inductive ind)
+| ValBlk (2, [| ind |]) -> IndRef (to_inductive ind)
 | ValBlk (3, [| cstr |]) -> ConstructRef (to_ext val_constructor cstr)
 | _ -> assert false
 

--- a/user-contrib/Ltac2/tac2ffi.mli
+++ b/user-contrib/Ltac2/tac2ffi.mli
@@ -78,6 +78,10 @@ val of_bool : bool -> valexpr
 val to_bool : valexpr -> bool
 val bool : bool repr
 
+val of_case : Constr.case_info -> valexpr
+val to_case : valexpr -> Constr.case_info
+val case : Constr.case_info repr
+
 val of_char : char -> valexpr
 val to_char : valexpr -> char
 val char : char repr
@@ -101,6 +105,10 @@ val exn : Exninfo.iexn repr
 val of_ident : Id.t -> valexpr
 val to_ident : valexpr -> Id.t
 val ident : Id.t repr
+
+val of_inductive : Names.inductive -> valexpr
+val to_inductive : valexpr -> Names.inductive
+val inductive : Names.inductive repr
 
 val of_closure : closure -> valexpr
 val to_closure : valexpr -> closure


### PR DESCRIPTION
**Kind:** bug fix / feature

Fixes / closes #10940

- [ ] Added / updated test-suite (still TODO)
- [ ] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified). (I don't think there's any documentation?)
- [ ] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details). (not yet)

cc @coq/ltac2-maintainers please help with how to deprecate `Constr.Unsafe.case`, and suggest what should be done about the type `Constr.Unsafe.case` (should it become `Constr.case`?).  Also, what's the rule on which things in the ffi get convenience aliases for `of_ext` and `to_ext`?
