### PR TITLE
Fixes #12322: anomaly when printing "fun" binders with implicit types

### DIFF
--- a/doc/changelog/02-specification-language/12323-master+fix12322-anomaly-implicit-binder-factorization.rst
+++ b/doc/changelog/02-specification-language/12323-master+fix12322-anomaly-implicit-binder-factorization.rst
@@ -1,0 +1,4 @@
+- **Fixed:**
+  Anomaly possibly raised when printing binders with implicit types
+  (`#12323 <https://github.com/coq/coq/pull/12323>`_,
+  by Hugo Herbelin; fixes `#12322 <https://github.com/coq/coq/pull/12322>`_).

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -836,7 +836,7 @@ let rec flatten_application c = match DAst.get c with
 
 let same_binder_type ty nal c =
   match nal, DAst.get c with
-  | _::_, GProd (_,_,ty',_) -> glob_constr_eq ty ty'
+  | _::_, (GProd (_,_,ty',_) | GLambda (_,_,ty',_)) -> glob_constr_eq ty ty'
   | [], _ -> true
   | _ -> assert false
 

--- a/test-suite/output/ImplicitTypes.out
+++ b/test-suite/output/ImplicitTypes.out
@@ -14,6 +14,12 @@ forall b1 b2, b1 = b2
      : Prop
 fun b => b = b
      : bool -> Prop
+fun b c : bool => b = c
+     : bool -> bool -> Prop
+fun c b : bool => b = c
+     : bool -> bool -> Prop
+fun b1 b2 => b1 = b2
+     : bool -> bool -> Prop
 fix f b (n : nat) {struct n} : bool :=
   match n with
   | 0 => b

--- a/test-suite/output/ImplicitTypes.v
+++ b/test-suite/output/ImplicitTypes.v
@@ -23,6 +23,9 @@ Check forall b1 b2, b1 = b2.
 
 (* Check in "fun" *)
 Check fun b => b = b.
+Check fun b c => b = c.
+Check fun c b => b = c.
+Check fun b1 b2 => b1 = b2.
 
 (* Check in binders *)
 Check fix f b n := match n with 0 => b | S p => f b p end.


### PR DESCRIPTION
**Kind:** bug fix

Anomaly was introduced in #11261: a pattern-matching clause was missing.

The anomaly triggered in configurations like `fun (x:T) y =>` (even in the absence of `Implicit Types`).

Fixes / closes #12322

- [X] Added / updated test-suite
- [X] Entry added in the changelog