### PR TITLE
Enable canonical `fun _ => _` projections.

### DIFF
--- a/doc/sphinx/language/extensions/canonical.rst
+++ b/doc/sphinx/language/extensions/canonical.rst
@@ -45,8 +45,8 @@ in :ref:`canonicalstructures`; here only a simple example is given.
    structure :g:`struct` of which the fields are :n:`x__1, …, x__n`.
    Then, each time an equation of the form :n:`(x__i _)` |eq_beta_delta_iota_zeta| :n:`c__i` has to be
    solved during the type checking process, :token:`qualid` is used as a solution.
-   Otherwise said, :token:`qualid` is canonically used to extend the field :n:`c__i`
-   into a complete structure built on :n:`c__i`.
+   Otherwise said, :token:`qualid` is canonically used to extend the field :n:`x__i`
+   into a complete structure built on :n:`c__i` when :n:`c__i` unifies with :n:`(x__i _)`.
 
    The following kinds of terms are supported for the fields :n:`c__i` of :token:`qualid`:
 

--- a/doc/sphinx/language/extensions/canonical.rst
+++ b/doc/sphinx/language/extensions/canonical.rst
@@ -53,7 +53,7 @@ in :ref:`canonicalstructures`; here only a simple example is given.
    * Constants (defined through :cmd:`Definition`, :cmd:`Inductive` and constructors thereof,
      :cmd:`Record` and fields thereof, etc.) and section variables of an active section,
      applied to zero or more arguments.
-   * Any :token:`@sort`.
+   * Any :token:`sort`.
    * Literal functions:  `fun … => …`.
    * Literal, non-dependent function types, i.e. implications: `… -> …`.
    * Variables bound in :token:`qualid`.

--- a/doc/sphinx/language/extensions/canonical.rst
+++ b/doc/sphinx/language/extensions/canonical.rst
@@ -41,9 +41,9 @@ in :ref:`canonicalstructures`; here only a simple example is given.
    This command supports the :attr:`local` attribute.  When used, the
    structure is canonical only within the :cmd:`Section` containing it.
 
-   Assume that :token:`qualid` denotes an object ``(Build_struct`` :n:`c__1` … :n:`c__n` ``)`` in the
-   structure :g:`struct` of which the fields are :n:`x__1`, …, :n:`x__n`.
-   Then, each time an equation of the form ``(``\ :n:`x__i` ``_)`` |eq_beta_delta_iota_zeta| :n:`c__i` has to be
+   Assume that :token:`qualid` denotes an object :n:`(Build_struct c__1 … c__n)` in the
+   structure :g:`struct` of which the fields are :n:`x__1, …, x__n`.
+   Then, each time an equation of the form :n:`(x__i _)` |eq_beta_delta_iota_zeta| :n:`c__i` has to be
    solved during the type checking process, :token:`qualid` is used as a solution.
    Otherwise said, :token:`qualid` is canonically used to extend the field :n:`c__i`
    into a complete structure built on :n:`c__i`.

--- a/doc/sphinx/language/extensions/canonical.rst
+++ b/doc/sphinx/language/extensions/canonical.rst
@@ -48,6 +48,50 @@ in :ref:`canonicalstructures`; here only a simple example is given.
    Otherwise said, :token:`qualid` is canonically used to extend the field |c_i|
    into a complete structure built on |c_i|.
 
+   The following kinds of terms are supported for the fields |c_i| of :token:`qualid`:
+
+   * Constants (defined through :cmd:`Definition`, :cmd:`Inductive` and constructors thereof,
+     :cmd:`Record` and fields thereof, etc.) and section variables of an active section,
+     applied to zero or more arguments.
+   * Any :token:`@sort`.
+   * Literal functions:  `fun … => …`.
+   * Literal function types without type dependencies, i.e. implications: `… -> …`.
+   * Variables bound in :token:`qualid`.
+
+   When searching for a canonical extension of a field |x_i|, only the head symbol of
+   any existing instance's field |c_i| is considered.
+   We call this head symbol the *key* and we say ":token:`qualid` keys field |x_i| to |k|" when |c_i|'s
+   head symbol is key |k|.
+   Keys are the only piece of information that is used for canonical extension.
+   The keys corresponding to the kinds of terms listed above are:
+
+   * For constants and section variables, potentially applied to arguments:
+     the constant or variable itself, disregarding any arguments.
+   * For sorts: the sort itself.
+   * For literal functions: a disembodied function key denoted `fun _ => _`, disregarding both its domain
+     and body.
+   * For literal functions types: a disembodied implication key denoted `_ -> _`, disregarding both its
+     domain and co-domain.
+   * For variables bound in :token:`qualid`: a catch-all key denoted `_`.
+
+   This means that, for example, `fun (x : nat) => x+1` and `fun (x : bool) => true` do not constitute
+   distinct keys, and neither do `some_constant x1` and `some_constant (other_constant y1 y2) x2`.
+
+   Variables bound in :token:`qualid` are considered to match any term for the purpose of canonical
+   extension.
+   This has two major consequences for a field |c_i| keyed to a variable of :token:`qualid`:
+   1. Unless another key—and, thus, instance—matches |c_i|, the instance will always be considered by
+      unification.
+   2. |c_i| will be considered overlapping with (i.e. not distinct from) any other canonical instance
+      that keys |x_i| to one of its respective variables.
+
+   A record's field |x_i| can only be keyed once to each key.
+   Coq will print a warning when :token:`qualid` keys |x_i| to a term
+   whose head symbol is already keyed to by an existing canonical instance.
+   In this case, Coq will not register that particular field :token:`qualid` as a canonical
+   extension.
+   (The remaining fields of the instance can still be used for canonical extension.)
+
    Canonical structures are particularly useful when mixed with coercions
    and strict implicit arguments.
 

--- a/doc/sphinx/language/extensions/canonical.rst
+++ b/doc/sphinx/language/extensions/canonical.rst
@@ -58,8 +58,8 @@ in :ref:`canonicalstructures`; here only a simple example is given.
    * Literal, non-dependent function types, i.e. implications: `… -> …`.
    * Variables bound in :token:`qualid`.
 
-   When searching for a canonical extension of a field |x_i|, only the head symbol of
-   any existing instance's field |c_i| is considered.
+   When searching for a canonical extension, only the head symbol of any existing instance's field |c_i|
+   is considered.
    We call this head symbol the *key* and we say ":token:`qualid` keys field |x_i| to |k|" when |c_i|'s
    head symbol is key |k|.
    Keys are the only piece of information that is used for canonical extension.
@@ -74,8 +74,8 @@ in :ref:`canonicalstructures`; here only a simple example is given.
      domain and co-domain.
    * For variables bound in :token:`qualid`: a catch-all key denoted `_`.
 
-   This means that, for example, `fun (x : nat) => x+1` and `fun (x : bool) => true` do not constitute
-   distinct keys, and neither do `some_constant x1` and `some_constant (other_constant y1 y2) x2`.
+   This means that, for example, `(fun (x : nat) => x+1)` and `(fun (x : bool) => true)` do not constitute
+   distinct keys, and neither do `(some_constant x1)` and `(some_constant (other_constant y1 y2) x2)`.
 
    Variables bound in :token:`qualid` are considered to match any term for the purpose of canonical
    extension.
@@ -83,7 +83,7 @@ in :ref:`canonicalstructures`; here only a simple example is given.
    1. Unless another key—and, thus, instance—matches |c_i|, the instance will always be considered by
       unification.
    2. |c_i| will be considered overlapping with (i.e. not distinct from) any other canonical instance
-      that keys |x_i| to one of its respective variables.
+      that keys |x_i| to one of its own respective variables.
 
    A record's field |x_i| can only be keyed once to each key.
    Coq will print a warning when :token:`qualid` keys |x_i| to a term

--- a/doc/sphinx/language/extensions/canonical.rst
+++ b/doc/sphinx/language/extensions/canonical.rst
@@ -41,14 +41,14 @@ in :ref:`canonicalstructures`; here only a simple example is given.
    This command supports the :attr:`local` attribute.  When used, the
    structure is canonical only within the :cmd:`Section` containing it.
 
-   Assume that :token:`qualid` denotes an object ``(Build_struct`` |c_1| … |c_n| ``)`` in the
-   structure :g:`struct` of which the fields are |x_1|, …, |x_n|.
-   Then, each time an equation of the form ``(``\ |x_i| ``_)`` |eq_beta_delta_iota_zeta| |c_i| has to be
+   Assume that :token:`qualid` denotes an object ``(Build_struct`` :n:`c__1` … :n:`c__n` ``)`` in the
+   structure :g:`struct` of which the fields are :n:`x__1`, …, :n:`x__n`.
+   Then, each time an equation of the form ``(``\ :n:`x__i` ``_)`` |eq_beta_delta_iota_zeta| :n:`c__i` has to be
    solved during the type checking process, :token:`qualid` is used as a solution.
-   Otherwise said, :token:`qualid` is canonically used to extend the field |c_i|
-   into a complete structure built on |c_i|.
+   Otherwise said, :token:`qualid` is canonically used to extend the field :n:`c__i`
+   into a complete structure built on :n:`c__i`.
 
-   The following kinds of terms are supported for the fields |c_i| of :token:`qualid`:
+   The following kinds of terms are supported for the fields :n:`c__i` of :token:`qualid`:
 
    * Constants (defined through :cmd:`Definition`, :cmd:`Inductive` and constructors thereof,
      :cmd:`Record` and fields thereof, etc.) and section variables of an active section,
@@ -58,10 +58,10 @@ in :ref:`canonicalstructures`; here only a simple example is given.
    * Literal, non-dependent function types, i.e. implications: `… -> …`.
    * Variables bound in :token:`qualid`.
 
-   When searching for a canonical extension, only the head symbol of any existing instance's field |c_i|
+   When searching for a canonical extension, only the head symbol of any existing instance's field :n:`c__i`
    is considered.
-   We call this head symbol the *key* and we say ":token:`qualid` keys field |x_i| to |k|" when |c_i|'s
-   head symbol is key |k|.
+   We call this head symbol the *key* and we say ":token:`qualid` keys field :n:`x__i` to :n:`k`" when :n:`c__i`'s
+   head symbol is key :n:`k`.
    Keys are the only piece of information that is used for canonical extension.
    The keys corresponding to the kinds of terms listed above are:
 
@@ -79,14 +79,15 @@ in :ref:`canonicalstructures`; here only a simple example is given.
 
    Variables bound in :token:`qualid` are considered to match any term for the purpose of canonical
    extension.
-   This has two major consequences for a field |c_i| keyed to a variable of :token:`qualid`:
-   1. Unless another key—and, thus, instance—matches |c_i|, the instance will always be considered by
-      unification.
-   2. |c_i| will be considered overlapping with (i.e. not distinct from) any other canonical instance
-      that keys |x_i| to one of its own respective variables.
+   This has two major consequences for a field :n:`c__i` keyed to a variable of :token:`qualid`:
 
-   A record's field |x_i| can only be keyed once to each key.
-   Coq will print a warning when :token:`qualid` keys |x_i| to a term
+   1. Unless another key—and, thus, instance—matches :n:`c__i`, the instance will always be considered by
+      unification.
+   2. :n:`c__i` will be considered overlapping with (i.e. not distinct from) any other canonical instance
+      that keys :n:`x__i` to one of its own respective variables.
+
+   A record's field :n:`x__i` can only be keyed once to each key.
+   Coq will print a warning when :token:`qualid` keys :n:`x__i` to a term
    whose head symbol is already keyed to by an existing canonical instance.
    In this case, Coq will not register that particular field :token:`qualid` as a canonical
    extension.

--- a/doc/sphinx/language/extensions/canonical.rst
+++ b/doc/sphinx/language/extensions/canonical.rst
@@ -55,7 +55,7 @@ in :ref:`canonicalstructures`; here only a simple example is given.
      applied to zero or more arguments.
    * Any :token:`@sort`.
    * Literal functions:  `fun … => …`.
-   * Literal function types without type dependencies, i.e. implications: `… -> …`.
+   * Literal, non-dependent function types, i.e. implications: `… -> …`.
    * Variables bound in :token:`qualid`.
 
    When searching for a canonical extension of a field |x_i|, only the head symbol of

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -244,7 +244,10 @@ let check_conv_record env sigma (t1,sk1) (t2,sk2) =
   let canon_s,sk2_effective =
     try
       match EConstr.kind sigma t2 with
-        Prod (_,a,b) -> (* assert (l2=[]); *)
+      | Lambda (_,_,_) -> (* assert (l2=[]); *)
+        lookup_canonical_conversion (proji, Lambda_cs),
+        (Stack.append_app [|t2|] Stack.empty)
+      | Prod (_,a,b) -> (* assert (l2=[]); *)
           let _, a, b = destProd sigma t2 in
           if noccurn sigma 1 b then
             lookup_canonical_conversion (proji, Prod_cs),

--- a/pretyping/recordops.ml
+++ b/pretyping/recordops.ml
@@ -149,6 +149,7 @@ type obj_typ = {
 
 type cs_pattern =
     Const_cs of GlobRef.t
+  | Lambda_cs
   | Prod_cs
   | Sort_cs of Sorts.family
   | Default_cs
@@ -156,6 +157,7 @@ type cs_pattern =
 let eq_cs_pattern p1 p2 = match p1, p2 with
 | Const_cs gr1, Const_cs gr2 -> GlobRef.equal gr1 gr2
 | Prod_cs, Prod_cs -> true
+| Lambda_cs, Lambda_cs -> true
 | Sort_cs s1, Sort_cs s2 -> Sorts.family_equal s1 s2
 | Default_cs, Default_cs -> true
 | _ -> false
@@ -183,6 +185,7 @@ let rec cs_pattern_of_constr env t =
     let patt, n, args = cs_pattern_of_constr env f in
     patt, n, args @ Array.to_list vargs
   | Rel n -> Default_cs, Some n, []
+  | Lambda (_, _, _) -> Lambda_cs, None, [t]
   | Prod (_,a,b) when Vars.noccurn 1 b -> Prod_cs, None, [a; Vars.lift (-1) b]
   | Proj (p, c) ->
     let { Environ.uj_type = ty } = Typeops.infer env c in
@@ -243,6 +246,7 @@ let compute_canonical_projections env ~warn (gref,ind) =
 
 let pr_cs_pattern = function
     Const_cs c -> Nametab.pr_global_env Id.Set.empty c
+  | Lambda_cs -> str "fun _ => _"
   | Prod_cs -> str "_ -> _"
   | Default_cs -> str "_"
   | Sort_cs s -> Sorts.pr_sort_family s

--- a/pretyping/recordops.mli
+++ b/pretyping/recordops.mli
@@ -68,6 +68,7 @@ val find_primitive_projection : Constant.t -> Projection.Repr.t option
 (** A cs_pattern characterizes the form of a component of canonical structure *)
 type cs_pattern =
     Const_cs of GlobRef.t
+  | Lambda_cs
   | Prod_cs
   | Sort_cs of Sorts.family
   | Default_cs

--- a/test-suite/success/CanonicalStructure.v
+++ b/test-suite/success/CanonicalStructure.v
@@ -70,3 +70,11 @@ Section W.
   Check (refl_equal _ : l _ = x2).
 End W.
 Fail Check (refl_equal _ : l _ = x2).
+
+(* Lambda keys *)
+Section L.
+  Structure cs_lambda := { cs_lambda_key : nat -> nat }.
+  Canonical Structure cs_lambda_func := {| cs_lambda_key := fun x => x+1 |}.
+  (* [Check] is too lenient. We need a [Definition]/[Example] to force Coq to infer the canonical structure. *)
+  Example cs_lambda_ex0 := (refl_equal _ : (cs_lambda_key _) = (fun _ => _)).
+End L.


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

This PR enables canonical projections of the shape `fun _ => _`. It also adds a simple test case.

I don't think the different kinds of canonical projections are documented anywhere so maybe there isn't any documentation to change? It might need a changelog entry, though.

<!-- Keep what applies -->
**Kind:** feature


<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [X] Added / updated test-suite
<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [ ] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [ ] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
