### PR TITLE
Introduce a ADT for warning categories.

### DIFF
--- a/dev/ci/user-overlays/12347-Zimmi48-category-type.sh
+++ b/dev/ci/user-overlays/12347-Zimmi48-category-type.sh
@@ -1,0 +1,3 @@
+overlay elpi https://github.com/Zimmi48/coq-elpi category-type 12347
+
+overlay quickchick https://github.com/Zimmi48/QuickChick category-type 12347

--- a/doc/plugin_tutorial/tuto0/src/g_tuto0.mlg
+++ b/doc/plugin_tutorial/tuto0/src/g_tuto0.mlg
@@ -5,7 +5,7 @@ DECLARE PLUGIN "tuto0_plugin"
 open Pp
 open Ltac_plugin
 
-let tuto_warn = CWarnings.create ~name:"name" ~category:"category"
+let tuto_warn = CWarnings.(create ~name:"name" ~category:Debug)
                             (fun _ -> strbrk Tuto0_main.message)
 
 }

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -326,7 +326,7 @@ let mkGLambda ?loc (na,bk,t) body = DAst.make ?loc @@ GLambda (na, bk, t, body)
 (* Utilities for binders                                              *)
 
 let warn_shadowed_implicit_name =
-  CWarnings.create ~name:"shadowed-implicit-name" ~category:"syntax"
+  CWarnings.(create ~name:"shadowed-implicit-name" ~category:Syntax)
     Pp.(fun na -> str "Making shadowed name of implicit argument accessible by position.")
 
 let exists_name na l =
@@ -497,7 +497,7 @@ let restore_binders_impargs env l =
   List.fold_right pure_push_name_env l env
 
 let warn_ignoring_unexpected_implicit_binder_declaration =
-  CWarnings.create ~name:"unexpected-implicit-declaration" ~category:"syntax"
+  CWarnings.(create ~name:"unexpected-implicit-declaration" ~category:Syntax)
     Pp.(fun () -> str "Ignoring implicit binder declaration in unexpected position.")
 
 let check_implicit_meaningful ?loc k env =
@@ -1282,7 +1282,7 @@ let intern_qualid_for_pattern test_global intern_not qid pats =
     | None -> raise Not_found
 
 let warn_nonprimitive_projection =
-  CWarnings.create ~name:"nonprimitive-projection-syntax" ~category:"syntax" ~default:CWarnings.Disabled
+  CWarnings.(create ~name:"nonprimitive-projection-syntax" ~category:Syntax ~default:Disabled)
     Pp.(fun f -> pr_qualid f ++ str " used as a primitive projection but is not one.")
 
 let error_nonprojection_syntax ?loc qid =

--- a/interp/deprecation.ml
+++ b/interp/deprecation.ml
@@ -14,7 +14,7 @@ let make ?since ?note () = { since ; note }
 
 let create_warning ~object_name ~warning_name name_printer =
   let open Pp in
-  CWarnings.create ~name:warning_name ~category:"deprecated"
+  CWarnings.(create ~name:warning_name ~category:Deprecated)
     (fun (qid,depr) -> str object_name ++ spc () ++ name_printer qid ++
       strbrk " is deprecated" ++
       pr_opt (fun since -> str "since " ++ str since) depr.since ++

--- a/interp/implicit_quantifiers.ml
+++ b/interp/implicit_quantifiers.ml
@@ -203,7 +203,7 @@ let implicit_application env ty =
     CAst.make ?loc @@ CAppExpl ((None, id, inst), args), avoid
 
 let warn_ignoring_implicit_status =
-  CWarnings.create ~name:"ignoring_implicit_status" ~category:"implicits"
+  CWarnings.(create ~name:"ignoring_implicit_status" ~category:Implicits)
     (fun na ->
        strbrk "Ignoring implicit status of product binder " ++
        Name.print na ++ strbrk " and following binders")

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -155,7 +155,7 @@ let init_scope_map () =
 (* Operations on scopes *)
 
 let warn_undeclared_scope =
-  CWarnings.create ~name:"undeclared-scope" ~category:"deprecated"
+  CWarnings.(create ~name:"undeclared-scope" ~category:Deprecated)
                    (fun (scope) ->
                     strbrk "Declaring a scope implicitly is deprecated; use in advance an explicit "
                     ++ str "\"Declare Scope " ++ str scope ++ str ".\".")
@@ -802,7 +802,7 @@ module Numbers = struct
 open PrimTokenNotation
 
 let warn_large_num =
-  CWarnings.create ~name:"large-number" ~category:"numbers"
+  CWarnings.(create ~name:"large-number" ~category:Numbers)
     (fun ty ->
       strbrk "Stack overflow or segmentation fault happens when " ++
       strbrk "working with large numbers in " ++ pr_qualid ty ++
@@ -810,7 +810,7 @@ let warn_large_num =
       strbrk " on your system limits and on the command executed).")
 
 let warn_abstract_large_num =
-  CWarnings.create ~name:"abstract-large-number" ~category:"numbers"
+  CWarnings.(create ~name:"abstract-large-number" ~category:Numbers)
     (fun (ty,f) ->
       strbrk "To avoid stack overflow, large numbers in " ++
       pr_qualid ty ++ strbrk " are interpreted as applications of " ++
@@ -1406,13 +1406,13 @@ let pr_optional_scope = function
   | NotationInScope scope -> spc () ++ strbrk "in scope" ++ spc () ++ str scope
 
 let warn_notation_overridden =
-  CWarnings.create ~name:"notation-overridden" ~category:"parsing"
+  CWarnings.(create ~name:"notation-overridden" ~category:Parsing)
                    (fun (scope,ntn) ->
                     str "Notation" ++ spc () ++ pr_notation ntn ++ spc ()
                     ++ strbrk "was already used" ++ pr_optional_scope scope ++ str ".")
 
 let warn_deprecation_overridden =
-  CWarnings.create ~name:"notation-overridden" ~category:"parsing"
+  CWarnings.(create ~name:"notation-overridden" ~category:Parsing)
                  (fun ((scope,ntn),old,now) ->
                   match old, now with
                   | None, None -> assert false

--- a/kernel/nativeconv.ml
+++ b/kernel/nativeconv.ml
@@ -146,7 +146,7 @@ and conv_fix env lvl t1 f1 t2 f2 cu =
 
 let warn_no_native_compiler =
   let open Pp in
-  CWarnings.create ~name:"native-compiler-disabled" ~category:"native-compiler"
+  CWarnings.(create ~name:"native-compiler-disabled" ~category:Native_compiler)
          (fun () -> strbrk "Native compiler is disabled," ++
                       strbrk " falling back to VM conversion test.")
 

--- a/kernel/typeops.ml
+++ b/kernel/typeops.ml
@@ -60,7 +60,7 @@ let infer_assumption env t ty =
 
 let warn_bad_relevance_name = "bad-relevance"
 let warn_bad_relevance =
-  CWarnings.create ~name:warn_bad_relevance_name ~category:"debug" ~default:CWarnings.Disabled
+  CWarnings.(create ~name:warn_bad_relevance_name ~category:Debug ~default:Disabled)
     Pp.(function
         | None ->  str "Bad relevance in case annotation."
         | Some x -> str "Bad relevance for binder " ++ Name.print x.binder_name ++ str ".")

--- a/kernel/vconv.ml
+++ b/kernel/vconv.ml
@@ -186,7 +186,7 @@ and conv_arguments env ?from:(from=0) k args1 args2 cu =
 
 let warn_bytecode_compiler_failed =
   let open Pp in
-  CWarnings.create ~name:"bytecode-compiler-failed" ~category:"bytecode-compiler"
+  CWarnings.(create ~name:"bytecode-compiler-failed" ~category:Bytecode_compiler)
          (fun () -> strbrk "Bytecode compiler failed, " ++
                       strbrk "falling back to standard conversion")
 

--- a/lib/cWarnings.ml
+++ b/lib/cWarnings.ml
@@ -152,10 +152,79 @@ let parse_flags s =
 let set_flags s =
   reset_default_warnings (); let s = parse_flags s in flags := s
 
+type category =
+  | Automation
+  | Bytecode_compiler
+  | Debug
+  | Deprecated
+  | Dev
+  | Extraction
+  | Filesystem
+  | Fixpoints
+  | Fragile
+  | Funind
+  | Implicits
+  | Loadpath
+  | Ltac
+  | Native_compiler
+  | Non_interactive
+  | Notation
+  | Numbers
+  | Option
+  | Parsing
+  | Pattern_matching
+  | Pedantic
+  | Records
+  | Require
+  | Schemes
+  | Scope
+  | Ssr
+  | Syntax
+  | Tactics
+  | Typechecker
+  | Typeclasses
+  | Vernacular
+  | Other of string
+
+let category_to_string = function
+  | Automation -> "automation"
+  | Bytecode_compiler -> "bytecode_compiler"
+  | Debug -> "debug"
+  | Deprecated -> "deprecated"
+  | Dev -> "dev"
+  | Extraction -> "extraction"
+  | Filesystem -> "filesystem"
+  | Fixpoints -> "fixpoints"
+  | Fragile -> "fragile"
+  | Funind -> "funind"
+  | Implicits -> "implicits"
+  | Loadpath -> "loadpath"
+  | Ltac -> "ltac"
+  | Native_compiler -> "native-compiler"
+  | Non_interactive -> "non-interactive"
+  | Notation -> "notation"
+  | Numbers -> "numbers"
+  | Option -> "option"
+  | Parsing -> "parsing"
+  | Pattern_matching -> "pattern-matching"
+  | Pedantic -> "pedantic"
+  | Records -> "records"
+  | Require -> "require"
+  | Schemes -> "schemes"
+  | Scope -> "scope"
+  | Ssr -> "ssr"
+  | Syntax -> "syntax"
+  | Tactics -> "tactics"
+  | Typechecker -> "typechecker"
+  | Typeclasses -> "typeclasses"
+  | Vernacular -> "vernacular"
+  | Other string -> string
+
 (* Adds a warning to the [warnings] and [category] tables. We then reparse the
    warning flags string, because the warning being created might have been set
    already. *)
 let create ~name ~category ?(default=Enabled) pp =
+  let category = category_to_string category in
   let pp x = let open Pp in
     pp x ++ spc () ++ str "[" ++ str name ++ str "," ++
     str category ++ str "]"

--- a/lib/cWarnings.mli
+++ b/lib/cWarnings.mli
@@ -10,7 +10,44 @@
 
 type status = Disabled | Enabled | AsError
 
-val create : name:string -> category:string -> ?default:status ->
+(** The list of warnings categories that are used in the code of Coq.
+    The Other category may be used by external plugin authors who do
+    not wish to be limited to this list.  *)
+type category =
+  | Automation
+  | Bytecode_compiler
+  | Debug
+  | Deprecated
+  | Dev
+  | Extraction
+  | Filesystem
+  | Fixpoints
+  | Fragile
+  | Funind
+  | Implicits
+  | Loadpath
+  | Ltac
+  | Native_compiler
+  | Non_interactive
+  | Notation
+  | Numbers
+  | Option
+  | Parsing
+  | Pattern_matching
+  | Pedantic
+  | Records
+  | Require
+  | Schemes
+  | Scope
+  | Ssr
+  | Syntax
+  | Tactics
+  | Typechecker
+  | Typeclasses
+  | Vernacular
+  | Other of string
+
+val create : name:string -> category:category -> ?default:status ->
              ('a -> Pp.t) -> ?loc:Loc.t -> 'a -> unit
 
 val get_flags : unit -> string

--- a/lib/system.ml
+++ b/lib/system.ml
@@ -19,7 +19,7 @@ include Minisys
     warns if [root] does not exist *)
 
 let warn_cannot_open_dir =
-  CWarnings.create ~name:"cannot-open-dir" ~category:"filesystem"
+  CWarnings.(create ~name:"cannot-open-dir" ~category:Filesystem)
   (fun dir -> str ("Cannot open directory " ^ dir))
 
 let all_subdirs ~unix_path:root =
@@ -92,7 +92,7 @@ let rec search paths test =
   | lpe :: rem -> test lpe @ search rem test
 
 let warn_ambiguous_file_name =
-  CWarnings.create ~name:"ambiguous-file-name" ~category:"filesystem"
+  CWarnings.(create ~name:"ambiguous-file-name" ~category:Filesystem)
     (fun (filename,l,f) -> str filename ++ str " has been found in" ++ spc () ++
                 hov 0 (str "[ " ++
                          hv 0 (prlist_with_sep (fun () -> str " " ++ pr_semicolon())
@@ -140,7 +140,7 @@ let is_in_path lpath filename =
   with Not_found -> false
 
 let warn_path_not_found =
-  CWarnings.create ~name:"path-not-found" ~category:"filesystem"
+  CWarnings.(create ~name:"path-not-found" ~category:Filesystem)
   (fun () -> str "system variable PATH not found")
 
 let is_in_system_path filename =
@@ -157,7 +157,7 @@ let open_trapping_failure name =
     CErrors.user_err ~hdr:"System.open" (str "Can't open " ++ str name)
 
 let warn_cannot_remove_file =
-  CWarnings.create ~name:"cannot-remove-file" ~category:"filesystem"
+  CWarnings.(create ~name:"cannot-remove-file" ~category:Filesystem)
   (fun filename -> str"Could not remove file " ++ str filename ++ str" which is corrupted!")
 
 let try_remove filename =

--- a/library/goptions.ml
+++ b/library/goptions.ml
@@ -248,7 +248,7 @@ with Not_found ->
 open Libobject
 
 let warn_deprecated_option =
-  CWarnings.create ~name:"deprecated-option" ~category:"deprecated"
+  CWarnings.(create ~name:"deprecated-option" ~category:Deprecated)
          (fun key -> str "Option" ++ spc () ++ str (nickname key) ++
                        strbrk " is deprecated")
 
@@ -413,8 +413,7 @@ let declare_interpreted_string_option_and_ref ~depr ~key ~(value:'a) from_string
 (* Setting values of options *)
 
 let warn_unknown_option =
-  CWarnings.create
-    ~name:"unknown-option" ~category:"option"
+  CWarnings.(create ~name:"unknown-option" ~category:Option)
     (fun key -> strbrk "There is no flag or option with this name: \"" ++
                   str (nickname key) ++ str "\".")
 

--- a/library/nametab.ml
+++ b/library/nametab.ml
@@ -117,7 +117,7 @@ struct
      The argument X of the functor F is masked by the inner module X.
    *)
   let warn_masking_absolute =
-    CWarnings.create ~name:"masking-absolute-name" ~category:"deprecated"
+    CWarnings.(create ~name:"masking-absolute-name" ~category:Deprecated)
       (fun n -> str ("Trying to mask the absolute name \"" ^ U.to_string n ^ "\"!"))
 
   type user_name = U.t

--- a/library/summary.ml
+++ b/library/summary.ml
@@ -69,9 +69,7 @@ let freeze_summaries ~marshallable : frozen =
 
 let warn_summary_out_of_scope =
   let name = "summary-out-of-scope" in
-  let category = "dev" in
-  let default = CWarnings.Disabled in
-  CWarnings.create ~name ~category ~default (fun name ->
+  CWarnings.(create ~name ~category:Dev ~default:Disabled) (fun name ->
     Pp.str (Printf.sprintf
       "A Coq plugin was loaded inside a local scope (such as a Section). It is recommended to load plugins at the start of the file. Summary entry: %s"
       name)

--- a/parsing/cLexer.ml
+++ b/parsing/cLexer.ml
@@ -299,7 +299,7 @@ let get_buff len = Bytes.sub_string !buff 0 len
 (* The classical lexer: idents, numbers, quoted strings, comments *)
 
 let warn_unrecognized_unicode =
-  CWarnings.create ~name:"unrecognized-unicode" ~category:"parsing"
+  CWarnings.(create ~name:"unrecognized-unicode" ~category:Parsing)
          (fun (u,id) ->
           strbrk (Printf.sprintf "Not considering unicode character \"%s\" of unknown \
                                   lexical status as part of identifier \"%s\"." u id))
@@ -319,7 +319,7 @@ let rec ident_tail loc len s = match Stream.peek s with
       | _ -> len
 
 let warn_comment_terminator_in_string =
-  CWarnings.create ~name:"comment-terminator-in-string" ~category:"parsing"
+  CWarnings.(create ~name:"comment-terminator-in-string" ~category:Parsing)
          (fun () ->
           (strbrk
              "Not interpreting \"*)\" as the end of current \

--- a/parsing/pcoq.ml
+++ b/parsing/pcoq.ml
@@ -227,8 +227,7 @@ end
 module Grammar = Register(GrammarObj)
 
 let warn_deprecated_intropattern =
-  let open CWarnings in
-  create ~name:"deprecated-intropattern-entry" ~category:"deprecated"
+  CWarnings.(create ~name:"deprecated-intropattern-entry" ~category:Deprecated)
   (fun () -> Pp.strbrk "Entry name intropattern has been renamed in order \
   to be consistent with the documented grammar of tactics. Use \
   \"simple_intropattern\" instead.")

--- a/plugins/extraction/table.ml
+++ b/plugins/extraction/table.ml
@@ -303,7 +303,7 @@ let pr_long_global ref = pr_path (Nametab.path_of_global ref)
 let err s = user_err ~hdr:"Extraction" s
 
 let warn_extraction_axiom_to_realize =
-  CWarnings.create ~name:"extraction-axiom-to-realize" ~category:"extraction"
+  CWarnings.(create ~name:"extraction-axiom-to-realize" ~category:Extraction)
          (fun axioms ->
           let s = if Int.equal (List.length axioms) 1 then "axiom" else "axioms" in
           strbrk ("The following "^s^" must be realized in the extracted code:")
@@ -311,7 +311,7 @@ let warn_extraction_axiom_to_realize =
                    ++ str "." ++ fnl ())
 
 let warn_extraction_logical_axiom =
-  CWarnings.create ~name:"extraction-logical-axiom" ~category:"extraction"
+  CWarnings.(create ~name:"extraction-logical-axiom" ~category:Extraction)
          (fun axioms ->
           let s =
             if Int.equal (List.length axioms) 1 then "axiom was" else "axioms were"
@@ -331,13 +331,13 @@ let warning_axioms () =
     warn_extraction_logical_axiom log_axioms
 
 let warn_extraction_opaque_accessed =
-  CWarnings.create ~name:"extraction-opaque-accessed" ~category:"extraction"
+  CWarnings.(create ~name:"extraction-opaque-accessed" ~category:Extraction)
     (fun lst -> strbrk "The extraction is currently set to bypass opacity, " ++
                   strbrk "the following opaque constant bodies have been accessed :" ++
                   lst ++ str "." ++ fnl ())
 
 let warn_extraction_opaque_as_axiom =
-  CWarnings.create ~name:"extraction-opaque-as-axiom" ~category:"extraction"
+  CWarnings.(create ~name:"extraction-opaque-as-axiom" ~category:Extraction)
     (fun lst -> strbrk "The extraction now honors the opacity constraints by default, " ++
          strbrk "the following opaque constants have been extracted as axioms :" ++
          lst ++ str "." ++ fnl () ++
@@ -352,7 +352,7 @@ let warning_opaques accessed =
     else warn_extraction_opaque_as_axiom lst
 
 let warning_ambiguous_name =
-  CWarnings.create ~name:"extraction-ambiguous-name" ~category:"extraction"
+  CWarnings.(create ~name:"extraction-ambiguous-name" ~category:Extraction)
     (fun (q,mp,r) -> strbrk "The name " ++ pr_qualid q ++ strbrk " is ambiguous, " ++
                        strbrk "do you mean module " ++
                        pr_long_mp mp ++
@@ -367,7 +367,7 @@ let error_axiom_scheme r i =
        str " type variable(s).")
 
 let warn_extraction_inside_module =
-  CWarnings.create ~name:"extraction-inside-module" ~category:"extraction"
+  CWarnings.(create ~name:"extraction-inside-module" ~category:Extraction)
       (fun () -> strbrk "Extraction inside an opened module is experimental." ++
        strbrk "In case of problem, close it first.")
 
@@ -385,7 +385,7 @@ let check_inside_section () =
          str "Close it and try again.")
 
 let warn_extraction_reserved_identifier =
-  CWarnings.create ~name:"extraction-reserved-identifier" ~category:"extraction"
+  CWarnings.(create ~name:"extraction-reserved-identifier" ~category:Extraction)
     (fun s -> strbrk ("The identifier "^s^
                 " contains __ which is reserved for the extraction"))
 
@@ -469,7 +469,7 @@ let error_remaining_implicit k =
        fnl() ++ str "the extraction of unsafe code and review it manually.")
 
 let warn_extraction_remaining_implicit =
-  CWarnings.create ~name:"extraction-remaining-implicit" ~category:"extraction"
+  CWarnings.(create ~name:"extraction-remaining-implicit" ~category:Extraction)
     (fun s -> strbrk ("At least an implicit occurs after extraction : "^s^".") ++ fnl () ++
      strbrk "Extraction SafeImplicits is unset, extracting nonetheless,"
      ++ strbrk "but this code is potentially unsafe, please review it manually.")

--- a/plugins/funind/gen_principle.ml
+++ b/plugins/funind/gen_principle.ml
@@ -1600,7 +1600,7 @@ let derive_correctness (funs : Constr.pconstant list) (graphs : inductive list)
     ()
 
 let warn_funind_cannot_build_inversion =
-  CWarnings.create ~name:"funind-cannot-build-inversion" ~category:"funind"
+  CWarnings.(create ~name:"funind-cannot-build-inversion" ~category:Funind)
     Pp.(
       fun e' ->
         strbrk "Cannot build inversion information"
@@ -1858,12 +1858,12 @@ let do_generate_principle_aux pconstants on_error register_built
   lemma
 
 let warn_cannot_define_graph =
-  CWarnings.create ~name:"funind-cannot-define-graph" ~category:"funind"
+  CWarnings.(create ~name:"funind-cannot-define-graph" ~category:Funind)
     (fun (names, error) ->
       Pp.(strbrk "Cannot define graph(s) for " ++ hv 1 names ++ error))
 
 let warn_cannot_define_principle =
-  CWarnings.create ~name:"funind-cannot-define-principle" ~category:"funind"
+  CWarnings.(create ~name:"funind-cannot-define-principle" ~category:Funind)
     (fun (names, error) ->
       Pp.(
         strbrk "Cannot define induction principle(s) for " ++ hv 1 names ++ error))

--- a/plugins/ltac/extraargs.mlg
+++ b/plugins/ltac/extraargs.mlg
@@ -246,7 +246,7 @@ let interp_place ist gl p =
 let subst_place subst pl = pl
 
 let warn_deprecated_instantiate_syntax =
-  CWarnings.create ~name:"deprecated-instantiate-syntax" ~category:"deprecated"
+  CWarnings.(create ~name:"deprecated-instantiate-syntax" ~category:Deprecated)
          (fun (v,v',id) ->
            let s = Id.to_string id in
            Pp.strbrk

--- a/plugins/ltac/g_auto.mlg
+++ b/plugins/ltac/g_auto.mlg
@@ -117,13 +117,11 @@ let make_depth n = snd (Eauto.make_dimension n None)
 
 (* deprecated in 8.13; the second int_or_var will be removed *)
 let deprecated_eauto_bfs =
-  CWarnings.create
-    ~name:"eauto_bfs" ~category:"deprecated"
+  CWarnings.(create ~name:"eauto_bfs" ~category:Deprecated)
     (fun () -> Pp.str "The syntax [eauto @int_or_var @int_or_var] is deprecated. Use [bfs eauto] instead.")
 
 let deprecated_bfs tacname =
-  CWarnings.create
-    ~name:"eauto_bfs" ~category:"deprecated"
+  CWarnings.(create ~name:"eauto_bfs" ~category:Deprecated)
     (fun () -> Pp.str "The syntax [" ++ Pp.str tacname ++ Pp.str "@int_or_var @int_or_var] is deprecated. No replacement yet.")
 
 }

--- a/plugins/ltac/g_class.mlg
+++ b/plugins/ltac/g_class.mlg
@@ -110,8 +110,7 @@ END
 
 {
 let deprecated_autoapply_using =
-  CWarnings.create
-    ~name:"autoapply-using" ~category:"deprecated"
+  CWarnings.(create ~name:"autoapply-using" ~category:Deprecated)
     (fun () -> Pp.str "The syntax [autoapply ... using] is deprecated. Use [autoapply ... with] instead.")
 }
 

--- a/plugins/ltac/g_tactic.mlg
+++ b/plugins/ltac/g_tactic.mlg
@@ -183,8 +183,7 @@ let merge_occurrences loc cl = function
     (Some p, ans)
 
 let deprecated_conversion_at_with =
-  CWarnings.create
-    ~name:"conversion_at_with" ~category:"deprecated"
+  CWarnings.(create ~name:"conversion_at_with" ~category:Deprecated)
     (fun () -> Pp.str "The syntax [at ... with ...] is deprecated. Use [with ... at ...] instead.")
 
 (* Auxiliary grammar rules *)

--- a/plugins/ltac/profile_ltac.ml
+++ b/plugins/ltac/profile_ltac.ml
@@ -28,7 +28,7 @@ let get_profiling () = !is_profiling
 let encountered_invalid_stack_no_self = ref false
 
 let warn_invalid_stack_no_self =
-  CWarnings.create ~name:"profile-invalid-stack-no-self" ~category:"ltac"
+  CWarnings.(create ~name:"profile-invalid-stack-no-self" ~category:Ltac)
     (fun () -> strbrk
         "Ltac Profiler encountered an invalid stack (no self \
          node). This can happen if you reset the profile during \

--- a/plugins/ltac/tacentries.ml
+++ b/plugins/ltac/tacentries.ml
@@ -433,7 +433,7 @@ let is_defined_tac kn =
   try ignore (Tacenv.interp_ltac kn); true with Not_found -> false
 
 let warn_unusable_identifier =
-  CWarnings.create ~name:"unusable-identifier" ~category:"parsing"
+  CWarnings.(create ~name:"unusable-identifier" ~category:Parsing)
       (fun id -> strbrk "The Ltac name" ++ spc () ++ Id.print id ++ spc () ++
         strbrk "may be unusable because of a conflict with a notation.")
 

--- a/plugins/micromega/g_zify.mlg
+++ b/plugins/micromega/g_zify.mlg
@@ -15,7 +15,7 @@ open Stdarg
 open Tacarg
 
 let warn_deprecated_Spec =
-  CWarnings.create ~name:"deprecated-Zify-Spec" ~category:"deprecated"
+  CWarnings.(create ~name:"deprecated-Zify-Spec" ~category:Deprecated)
     (fun () ->
       Pp.strbrk ("Show Zify Spec is deprecated. Use either \"Show Zify BinOpSpec\" or \"Show Zify UnOpSpec\"."))
 

--- a/plugins/omega/coq_omega.ml
+++ b/plugins/omega/coq_omega.ml
@@ -1927,8 +1927,7 @@ let destructure_goal = destructure_goal
 
 let warn_omega_is_deprecated =
   let name = "omega-is-deprecated" in
-  let category = "deprecated" in
-  CWarnings.create ~name ~category (fun () ->
+  CWarnings.(create ~name ~category:Deprecated) (fun () ->
     Pp.str "omega is deprecated since 8.12; use “lia” instead.")
 
 let omega_solver =

--- a/plugins/ssr/ssrelim.ml
+++ b/plugins/ssr/ssrelim.ml
@@ -491,7 +491,7 @@ let revtoptac n0 =
   end
 
 let nothing_to_inject =
-   CWarnings.create ~name:"spurious-ssr-injection" ~category:"ssr"
+   CWarnings.(create ~name:"spurious-ssr-injection" ~category:Ssr)
      (fun (sigma, env, ty) ->
          Pp.(str "SSReflect: cannot obtain new equations out of" ++ fnl() ++
              str"  " ++ Printer.pr_econstr_env env sigma ty ++ fnl() ++

--- a/plugins/ssr/ssripats.ml
+++ b/plugins/ssr/ssripats.ml
@@ -437,7 +437,7 @@ let tclLOG p t =
 let notTAC = tclUNIT false
 
 let duplicate_clear =
-  CWarnings.create ~name:"duplicate-clear" ~category:"ssr"
+  CWarnings.(create ~name:"duplicate-clear" ~category:Ssr)
     (fun id -> Pp.(str "Duplicate clear of " ++ Id.print id))
 
 (* returns true if it was a tactic (eg /ltac:tactic) *)

--- a/plugins/ssrsearch/g_search.mlg
+++ b/plugins/ssrsearch/g_search.mlg
@@ -302,9 +302,7 @@ let ssrdisplaysearch gr env t =
   Feedback.msg_notice (hov 2 pr_res ++ fnl ())
 
 let deprecated_search =
-  CWarnings.create
-    ~name:"deprecated-ssr-search"
-    ~category:"deprecated"
+  CWarnings.(create ~name:"deprecated-ssr-search" ~category:Deprecated)
     (fun () -> Pp.(str"SSReflect's Search command is deprecated."))
 
 }

--- a/plugins/syntax/float_syntax.ml
+++ b/plugins/syntax/float_syntax.ml
@@ -23,7 +23,7 @@ let make_path dir id = Libnames.make_path (make_dir dir) (Id.of_string id)
 (*** Parsing for float in digital notation ***)
 
 let warn_inexact_float =
-  CWarnings.create ~name:"inexact-float" ~category:"parsing"
+  CWarnings.(create ~name:"inexact-float" ~category:Parsing)
     (fun (sn, f) ->
       Pp.strbrk
         (Printf.sprintf

--- a/plugins/syntax/g_number_string.mlg
+++ b/plugins/syntax/g_number_string.mlg
@@ -28,7 +28,7 @@ let pr_number_after = function
 let pr_deprecated_number_modifier m = str "(" ++ pr_number_after m ++ str ")"
 
 let warn_deprecated_numeral_notation =
-  CWarnings.create ~name:"numeral-notation" ~category:"deprecated"
+  CWarnings.(create ~name:"numeral-notation" ~category:Deprecated)
     (fun () ->
       strbrk "Numeral Notation is deprecated, please use Number Notation instead.")
 

--- a/plugins/syntax/number.ml
+++ b/plugins/syntax/number.ml
@@ -27,7 +27,7 @@ type number_option =
   | Via of number_string_via
 
 let warn_abstract_large_num_no_op =
-  CWarnings.create ~name:"abstract-large-number-no-op" ~category:"numbers"
+  CWarnings.(create ~name:"abstract-large-number-no-op" ~category:Numbers)
     (fun f ->
       strbrk "The 'abstract after' directive has no effect when " ++
       strbrk "the parsing function (" ++
@@ -130,7 +130,7 @@ let type_error_of g ty =
      str "Instead of Number.int, the types Number.uint or Z or Int63.int or Number.number could be used (you may need to require BinNums or Number or Int63 first).")
 
 let warn_deprecated_decimal =
-  CWarnings.create ~name:"decimal-numeral-notation" ~category:"deprecated"
+  CWarnings.(create ~name:"decimal-numeral-notation" ~category:Deprecated)
     (fun () ->
       strbrk "Deprecated Number Notation for Decimal.uint, \
               Decimal.int or Decimal.decimal. Use Number.uint, \
@@ -157,7 +157,7 @@ let pr_constr env sigma c =
   Ppconstr.pr_constr_expr env sigma c
 
 let warn_via_remapping =
-  CWarnings.create ~name:"via-type-remapping" ~category:"numbers"
+  CWarnings.(create ~name:"via-type-remapping" ~category:Numbers)
     (fun (env, sigma, ty, ty', ty'') ->
       let constr = pr_constr env sigma in
       constr ty ++ str " was already mapped to" ++ spc () ++ constr ty'
@@ -165,7 +165,7 @@ let warn_via_remapping =
       ++ str " might yield ill typed terms when using the notation.")
 
 let warn_via_type_mismatch =
-  CWarnings.create ~name:"via-type-mismatch" ~category:"numbers"
+  CWarnings.(create ~name:"via-type-mismatch" ~category:Numbers)
     (fun (env, sigma, g, g', exp, actual) ->
       let constr = pr_constr env sigma in
       str "Type of" ++ spc() ++ Printer.pr_global g

--- a/pretyping/cases.ml
+++ b/pretyping/cases.ml
@@ -559,7 +559,7 @@ let set_pattern_catch_all_var ?loc eqn = function
   | _ -> ()
 
 let warn_named_multi_catch_all =
-  CWarnings.create ~name:"unused-pattern-matching-variable" ~category:"pattern-matching"
+  CWarnings.(create ~name:"unused-pattern-matching-variable" ~category:Pattern_matching)
          (fun id ->
           strbrk "Unused variable " ++ Id.print id ++ strbrk " catches more than one case.")
 

--- a/pretyping/coercionops.ml
+++ b/pretyping/coercionops.ml
@@ -310,7 +310,7 @@ let install_path_comparator f = path_comparator := f
 let compare_path p q = !path_comparator p q
 
 let warn_ambiguous_path =
-  CWarnings.create ~name:"ambiguous-paths" ~category:"typechecker"
+  CWarnings.(create ~name:"ambiguous-paths" ~category:Typechecker)
     (fun l -> prlist_with_sep fnl (fun (c,p,q) ->
          str"New coercion path " ++ print_path (c,p) ++
          if List.is_empty q then

--- a/pretyping/constr_matching.ml
+++ b/pretyping/constr_matching.ml
@@ -52,7 +52,7 @@ type bound_ident_map = Id.t Id.Map.t
 exception PatternMatchingFailure
 
 let warn_meta_collision =
-  CWarnings.create ~name:"meta-collision" ~category:"ltac"
+  CWarnings.(create ~name:"meta-collision" ~category:Ltac)
          (fun name ->
           strbrk "Collision between bound variable " ++ Id.print name ++
             strbrk " and a metavariable of same name.")

--- a/pretyping/glob_ops.ml
+++ b/pretyping/glob_ops.ml
@@ -356,7 +356,7 @@ let glob_visible_short_qualid c =
 
 let warn_variable_collision =
   let open Pp in
-  CWarnings.create ~name:"variable-collision" ~category:"ltac"
+  CWarnings.(create ~name:"variable-collision" ~category:Ltac)
          (fun name ->
           strbrk "Collision between bound variables of name " ++ Id.print name)
 

--- a/pretyping/patternops.ml
+++ b/pretyping/patternops.ml
@@ -412,7 +412,7 @@ let it_mkPLambda_or_LetIn = List.fold_left (fun c d -> mkPLambda_or_LetIn d c)
 let err ?loc pp = user_err ?loc ~hdr:"pattern_of_glob_constr" pp
 
 let warn_cast_in_pattern =
-  CWarnings.create ~name:"cast-in-pattern" ~category:"automation"
+  CWarnings.(create ~name:"cast-in-pattern" ~category:Automation)
     (fun () -> Pp.strbrk "Casts are ignored in patterns")
 
 let rec pat_of_raw metas vars = DAst.with_loc_val (fun ?loc -> function

--- a/pretyping/recordops.ml
+++ b/pretyping/recordops.ml
@@ -186,7 +186,7 @@ let rec cs_pattern_of_constr env t =
   | _ -> Const_cs (fst @@ destRef t) , None, []
 
 let warn_projection_no_head_constant =
-  CWarnings.create ~name:"projection-no-head-constant" ~category:"typechecker"
+  CWarnings.(create ~name:"projection-no-head-constant" ~category:Typechecker)
          (fun (sign,env,t,ref,proji_sp) ->
           let env = Termops.push_rels_assum sign env in
           let con_pp = Nametab.pr_global_env Id.Set.empty ref in
@@ -243,7 +243,7 @@ let pr_cs_pattern = function
   | Sort_cs s -> Sorts.pr_sort_family s
 
 let warn_redundant_canonical_projection =
-  CWarnings.create ~name:"redundant-canonical-projection" ~category:"typechecker"
+  CWarnings.(create ~name:"redundant-canonical-projection" ~category:Typechecker)
          (fun (hd_val,prj,new_can_s,old_can_s) ->
           strbrk "Ignoring canonical projection to " ++ hd_val
           ++ strbrk " by " ++ prj ++ strbrk " in "

--- a/proofs/proof.ml
+++ b/proofs/proof.ml
@@ -325,11 +325,11 @@ let _ = CErrors.register_handler begin function
   end
 
 let warn_remaining_shelved_goals =
-  CWarnings.create ~name:"remaining-shelved-goals" ~category:"tactics"
+  CWarnings.(create ~name:"remaining-shelved-goals" ~category:Tactics)
     (fun () -> Pp.str"The proof has remaining shelved goals")
 
 let warn_remaining_unresolved_evars =
-  CWarnings.create ~name:"remaining-unresolved-evars" ~category:"tactics"
+  CWarnings.(create ~name:"remaining-unresolved-evars" ~category:Tactics)
     (fun () -> Pp.str"The proof has unresolved variables")
 
 let return ?pid (p : t) =
@@ -413,7 +413,7 @@ module V82 = struct
     Proofview.V82.top_evars p.entry p.proofview
 
   let warn_deprecated_grab_existentials =
-    CWarnings.create ~name:"deprecated-grab-existentials" ~category:"deprecated"
+    CWarnings.(create ~name:"deprecated-grab-existentials" ~category:Deprecated)
        Pp.(fun () -> str "The Grab Existential Variables command is " ++
          str"deprecated. Please use the Unshelve command or the unshelve tactical " ++
          str"instead.")
@@ -426,7 +426,7 @@ module V82 = struct
       { p with proofview = Proofview.V82.grab p.proofview }
 
   let warn_deprecated_existential =
-    CWarnings.create ~name:"deprecated-existential" ~category:"deprecated"
+    CWarnings.(create ~name:"deprecated-existential" ~category:Deprecated)
        Pp.(fun () -> str "The Existential command is " ++
          str"deprecated. Please use the Unshelve command or the unshelve " ++
          str"tactical, and the instantiate tactic instead.")

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -1100,7 +1100,7 @@ end = struct (* {{{ *)
         | `Cont acc -> next acc
 
   let undo_costly_in_batch_mode =
-    CWarnings.create ~name:"undo-batch-mode" ~category:"non-interactive" Pp.(fun v ->
+    CWarnings.(create ~name:"undo-batch-mode" ~category:Non_interactive) Pp.(fun v ->
         str "Command " ++ Ppvernac.pr_vernac v ++
         str (" is not recommended in batch mode. In particular, going back in the document" ^
              " is not efficient in batch mode due to Coq not caching previous states for memory optimization reasons." ^

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -1657,7 +1657,7 @@ let cutSubstClause l2r eqn cls =
     | Some id -> cutSubstInHyp l2r eqn id
 
 let warn_deprecated_cutrewrite =
-  CWarnings.create ~name:"deprecated-cutrewrite" ~category:"deprecated"
+  CWarnings.(create ~name:"deprecated-cutrewrite" ~category:Deprecated)
     (fun () -> strbrk"\"cutrewrite\" is deprecated. Use \"replace\" instead.")
 
 let cutRewriteClause l2r eqn cls =
@@ -1835,7 +1835,7 @@ let default_subst_tactic_flags =
   { only_leibniz = false; rewrite_dependent_proof = true }
 
 let warn_deprecated_simple_subst =
-  CWarnings.create ~name:"deprecated-simple-subst" ~category:"deprecated"
+  CWarnings.(create ~name:"deprecated-simple-subst" ~category:Deprecated)
     (fun () -> strbrk"\"simple subst\" is deprecated")
 
 let subst_all ?(flags=default_subst_tactic_flags) () =

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -1188,7 +1188,7 @@ let create_hint_db l n st b =
   Lib.add_anonymous_leaf (inAutoHint hint)
 
 let warn_deprecated_hint_without_locality =
-  CWarnings.create ~name:"deprecated-hint-without-locality" ~category:"deprecated"
+  CWarnings.(create ~name:"deprecated-hint-without-locality" ~category:Deprecated)
     (fun () -> strbrk "The default value for hint locality is currently \
     \"local\" in a section and \"global\" otherwise, but is scheduled to change \
     in a future release. For the time being, adding hints outside of sections \
@@ -1581,7 +1581,7 @@ let log_hint h =
     Proofview.Unsafe.tclEVARS (set_extra_data store sigma)
 
 let warn_non_imported_hint =
-  CWarnings.create ~name:"non-imported-hint" ~category:"automation"
+  CWarnings.(create ~name:"non-imported-hint" ~category:Automation)
          (fun (hint,mp) ->
           strbrk "Hint used but not imported: " ++ hint ++ print_mp mp)
 

--- a/tactics/redexpr.ml
+++ b/tactics/redexpr.ml
@@ -32,7 +32,7 @@ let cbv_vm env sigma c =
     compute env sigma c
 
 let warn_native_compute_disabled =
-  CWarnings.create ~name:"native-compute-disabled" ~category:"native-compiler"
+  CWarnings.(create ~name:"native-compute-disabled" ~category:Native_compiler)
   (fun () ->
    strbrk "native_compute disabled at configure time; falling back to vm_compute.")
 
@@ -217,7 +217,7 @@ let contextualize f g = function
   | None -> e_red g
 
 let warn_simpl_unfolding_modifiers =
-  CWarnings.create ~name:"simpl-unfolding-modifiers" ~category:"tactics"
+  CWarnings.(create ~name:"simpl-unfolding-modifiers" ~category:Tactics)
          (fun () ->
           Pp.strbrk "The legacy simpl ignores constant unfolding modifiers.")
 

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -1111,7 +1111,7 @@ let msg_quantified_hypothesis = function
       str " non dependent hypothesis"
 
 let warn_deprecated_intros_until_0 =
-  CWarnings.create ~name:"deprecated-intros-until-0" ~category:"tactics"
+  CWarnings.(create ~name:"deprecated-intros-until-0" ~category:Tactics)
     (fun () ->
        strbrk"\"intros until 0\" is deprecated, use \"intros *\"; instead of \"induction 0\" and \"destruct 0\" use explicitly a name.\"")
 
@@ -3082,7 +3082,7 @@ let unfold_body x =
   end
 
 let warn_cannot_remove_as_expected =
-  CWarnings.create ~name:"cannot-remove-as-expected" ~category:"tactics"
+  CWarnings.(create ~name:"cannot-remove-as-expected" ~category:Tactics)
          (fun (id,inglobal) ->
            let pp = match inglobal with
              | None -> mt ()
@@ -3135,7 +3135,7 @@ let expand_hyp id =
  *)
 
 let warn_unused_intro_pattern env sigma =
-  CWarnings.create ~name:"unused-intro-pattern" ~category:"tactics"
+  CWarnings.(create ~name:"unused-intro-pattern" ~category:Tactics)
     (fun names ->
        strbrk"Unused introduction " ++ str (String.plural (List.length names) "pattern") ++
        str": " ++ prlist_with_sep spc

--- a/toplevel/ccompile.ml
+++ b/toplevel/ccompile.ml
@@ -50,7 +50,7 @@ let load_init_vernaculars opts ~state =
 (* File Compilation                                                           *)
 (******************************************************************************)
 let warn_file_no_extension =
-  CWarnings.create ~name:"file-no-extension" ~category:"filesystem"
+  CWarnings.(create ~name:"file-no-extension" ~category:Filesystem)
          (fun (f,ext) ->
           str "File \"" ++ str f ++
             strbrk "\" has been implicitly expanded to \"" ++

--- a/toplevel/coqargs.ml
+++ b/toplevel/coqargs.ml
@@ -190,11 +190,11 @@ let set_query opts q =
   }
 
 let warn_deprecated_sprop_cumul =
-  CWarnings.create ~name:"deprecated-spropcumul" ~category:"deprecated"
+  CWarnings.(create ~name:"deprecated-spropcumul" ~category:Deprecated)
          (fun () -> Pp.strbrk "Use the \"Cumulative StrictProp\" flag instead.")
 
 let warn_deprecated_inputstate =
-  CWarnings.create ~name:"deprecated-inputstate" ~category:"deprecated"
+  CWarnings.(create ~name:"deprecated-inputstate" ~category:Deprecated)
          (fun () -> Pp.strbrk "The inputstate option is deprecated and discouraged.")
 
 let set_inputstate opts s =
@@ -283,7 +283,7 @@ let parse_option_set opt =
     to_opt_key (String.sub opt 0 eqi), Some v
 
 let warn_no_native_compiler =
-  CWarnings.create ~name:"native-compiler-disabled" ~category:"native-compiler"
+  CWarnings.(create ~name:"native-compiler-disabled" ~category:Native_compiler)
     Pp.(fun s -> strbrk "Native compiler is disabled," ++
                    strbrk " -native-compiler " ++ strbrk s ++
                    strbrk " option ignored.")

--- a/toplevel/coqcargs.ml
+++ b/toplevel/coqcargs.ml
@@ -122,12 +122,12 @@ let rec add_vio_args peek next oval =
   else oval
 
 let warn_deprecated_outputstate =
-  CWarnings.create ~name:"deprecated-outputstate" ~category:"deprecated"
+  CWarnings.(create ~name:"deprecated-outputstate" ~category:Deprecated)
          (fun () ->
           Pp.strbrk "The outputstate option is deprecated and discouraged.")
 
 let warn_deprecated_quick =
-  CWarnings.create ~name:"deprecated-quick" ~category:"deprecated"
+  CWarnings.(create ~name:"deprecated-quick" ~category:Deprecated)
          (fun () ->
           Pp.strbrk "The -quick option is renamed -vio. Please consider using the -vos feature instead.")
 

--- a/user-contrib/Ltac2/tac2intern.ml
+++ b/user-contrib/Ltac2/tac2intern.ml
@@ -466,11 +466,11 @@ let polymorphic ((n, t) : type_scheme) : mix_type_scheme =
   (n, subst_type subst t)
 
 let warn_not_unit =
-  CWarnings.create ~name:"not-unit" ~category:"ltac"
+  CWarnings.(create ~name:"not-unit" ~category:Ltac)
     (fun () -> strbrk "The following expression should have type unit.")
 
 let warn_redundant_clause =
-  CWarnings.create ~name:"redundant-clause" ~category:"ltac"
+  CWarnings.(create ~name:"redundant-clause" ~category:Ltac)
     (fun () -> strbrk "The following clause is redundant.")
 
 let check_elt_unit loc env t =

--- a/vernac/attributes.ml
+++ b/vernac/attributes.ml
@@ -35,7 +35,7 @@ and pr_vernac_flag (s, arguments) =
   str s ++ (pr_vernac_flag_value arguments)
 
 let warn_unsupported_attributes =
-  CWarnings.create ~name:"unsupported-attributes" ~category:"parsing" ~default:CWarnings.AsError
+  CWarnings.(create ~name:"unsupported-attributes" ~category:Parsing ~default:AsError)
     (fun atts ->
        let keys = List.map fst atts in
        let keys = List.sort_uniq String.compare keys in
@@ -162,10 +162,10 @@ let legacy_bool_attribute ~name ~on ~off : bool option attribute =
 
 (* important note: we use on as the default for the new bool_attribute ! *)
 let deprecated_bool_attribute_warning =
-  CWarnings.create
+  CWarnings.(create
     ~name:"deprecated-attribute-syntax"
-    ~category:"parsing"
-    ~default:CWarnings.Enabled
+    ~category:Parsing
+    ~default:Enabled)
     (fun name ->
        Pp.(str "Syntax for switching off boolean attributes has been updated, use " ++ str name ++ str "=no instead."))
 

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -121,8 +121,7 @@ let add_instance i =
 
 let warning_not_a_class =
   let name = "not-a-class" in
-  let category = "typeclasses" in
-  CWarnings.create ~name ~category (fun (n, ty) ->
+  CWarnings.(create ~name ~category:Typeclasses) (fun (n, ty) ->
       let env = Global.env () in
       let evd = Evd.from_env env in
       Pp.(str "Ignored instance declaration for “"

--- a/vernac/comArguments.ml
+++ b/vernac/comArguments.ml
@@ -49,7 +49,7 @@ let inBidiHints =
 
 
 let warn_arguments_assert =
-  CWarnings.create ~name:"arguments-assert" ~category:"vernacular"
+  CWarnings.(create ~name:"arguments-assert" ~category:Vernacular)
     Pp.(fun sr ->
         strbrk "This command is just asserting the names of arguments of " ++
         Printer.pr_global sr ++ strbrk". If this is what you want, add " ++

--- a/vernac/comCoercion.ml
+++ b/vernac/comCoercion.ml
@@ -291,7 +291,7 @@ lorque source est None alors target est None aussi.
 *)
 
 let warn_uniform_inheritance =
-  CWarnings.create ~name:"uniform-inheritance" ~category:"typechecker"
+  CWarnings.(create ~name:"uniform-inheritance" ~category:Typechecker)
          (fun g ->
           Printer.pr_global g ++
             strbrk" does not respect the uniform inheritance condition")

--- a/vernac/comDefinition.ml
+++ b/vernac/comDefinition.ml
@@ -22,7 +22,7 @@ let red_constant_body red_opt env sigma body = match red_opt with
     red env sigma body
 
 let warn_implicits_in_term =
-  CWarnings.create ~name:"implicits-in-term" ~category:"implicits"
+  CWarnings.(create ~name:"implicits-in-term" ~category:Implicits)
          (fun () ->
           strbrk "Implicit arguments declaration relies on type." ++ spc () ++
             strbrk "Discarding incompatible declaration in term.")

--- a/vernac/comFixpoint.ml
+++ b/vernac/comFixpoint.ml
@@ -78,12 +78,12 @@ let non_full_mutual_message x xge y yge isfix rest =
   str "(" ++ e ++ str ")." ++ fnl () ++ w
 
 let warn_non_full_mutual =
-  CWarnings.create ~name:"non-full-mutual" ~category:"fixpoints"
+  CWarnings.(create ~name:"non-full-mutual" ~category:Fixpoints)
          (fun (x,xge,y,yge,isfix,rest) ->
           non_full_mutual_message x xge y yge isfix rest)
 
 let warn_non_recursive =
-  CWarnings.create ~name:"non-recursive" ~category:"fixpoints"
+  CWarnings.(create ~name:"non-recursive" ~category:Fixpoints)
          (fun (x,isfix) ->
           let k = if isfix then "fixpoint" else "cofixpoint" in
           strbrk "Not a truly recursive " ++ str k ++ str ".")

--- a/vernac/comHints.ml
+++ b/vernac/comHints.ml
@@ -65,7 +65,7 @@ let project_hint ~poly pri l2r r =
   (info, true, Hints.PathAny, Hints.hint_globref (GlobRef.ConstRef c))
 
 let warn_deprecated_hint_constr =
-  CWarnings.create ~name:"fragile-hint-constr" ~category:"automation"
+  CWarnings.(create ~name:"fragile-hint-constr" ~category:Automation)
     (fun () ->
       Pp.strbrk
         "Declaring arbitrary terms as hints is fragile; it is recommended to \

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -29,7 +29,7 @@ module RelDecl = Context.Rel.Declaration
 (* 3b| Mutual inductive definitions *)
 
 let warn_auto_template =
-  CWarnings.create ~name:"auto-template" ~category:"vernacular" ~default:CWarnings.Disabled
+  CWarnings.(create ~name:"auto-template" ~category:Vernacular ~default:Disabled)
     (fun id ->
        Pp.(strbrk "Automatically declaring " ++ Id.print id ++
            strbrk " as template polymorphic. Use attributes or " ++

--- a/vernac/comSearch.ml
+++ b/vernac/comSearch.ml
@@ -106,9 +106,7 @@ let () =
       optwrite = (:=) search_output_name_only }
 
 let deprecated_searchhead =
-  CWarnings.create
-    ~name:"deprecated-searchhead"
-    ~category:"deprecated"
+  CWarnings.(create ~name:"deprecated-searchhead" ~category:Deprecated)
     (fun () -> Pp.str("SearchHead is deprecated. Use the headconcl: clause of Search instead."))
 
 let interp_search env sigma s r =

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -628,7 +628,7 @@ let declare_mutually_recursive_core ~info ~cinfo ~opaque ~ntns ~uctx ~rec_declar
 let declare_mutually_recursive = declare_mutually_recursive_core ~restrict_ucontext:true ()
 
 let warn_let_as_axiom =
-  CWarnings.create ~name:"let-as-axiom" ~category:"vernacular"
+  CWarnings.(create ~name:"let-as-axiom" ~category:Vernacular)
     Pp.(fun id -> strbrk "Let definition" ++ spc () ++ Names.Id.print id ++
                   spc () ++ strbrk "declared as an axiom.")
 
@@ -2147,7 +2147,7 @@ let kind_of_obligation o =
 
 (* Solve an obligation using tactics, return the corresponding proof term *)
 let warn_solve_errored =
-  CWarnings.create ~name:"solve_obligation_error" ~category:"tactics"
+  CWarnings.(create ~name:"solve_obligation_error" ~category:Tactics)
     (fun err ->
       Pp.seq
         [ str "Solve Obligations tactic returned error: "

--- a/vernac/declareInd.ml
+++ b/vernac/declareInd.ml
@@ -139,7 +139,7 @@ let is_recursive mie =
   | _ -> false
 
 let warn_non_primitive_record =
-  CWarnings.create ~name:"non-primitive-record" ~category:"record"
+  CWarnings.(create ~name:"non-primitive-record" ~category:Records)
     (fun indsp ->
        Pp.(hov 0 (str "The record " ++ Nametab.pr_global_env Id.Set.empty (GlobRef.IndRef indsp) ++
                   strbrk" could not be defined as a primitive record")))

--- a/vernac/egramcoq.ml
+++ b/vernac/egramcoq.ml
@@ -595,7 +595,7 @@ let warn_disj_pattern_notation =
   let open Pp in
   let pp ng = str "Use of " ++ Notation.pr_notation ng.notgram_notation ++
               str " Notation is deprecated as it is inconsistent with pattern syntax." in
-  CWarnings.create ~name:"disj-pattern-notation" ~category:"notation" ~default:CWarnings.Disabled pp
+  CWarnings.(create ~name:"disj-pattern-notation" ~category:Notation ~default:Disabled) pp
 
 let extend_constr_notation ng state =
   let levels = match GramState.get state constr_levels with

--- a/vernac/g_proofs.mlg
+++ b/vernac/g_proofs.mlg
@@ -25,21 +25,21 @@ let thm_token = G_vernac.thm_token
 let hint = Entry.create "hint"
 
 let warn_deprecated_focus =
-  CWarnings.create ~name:"deprecated-focus" ~category:"deprecated"
+  CWarnings.(create ~name:"deprecated-focus" ~category:Deprecated)
          (fun () ->
            Pp.strbrk
              "The Focus command is deprecated; use bullets or focusing brackets instead"
          )
 
 let warn_deprecated_focus_n n =
-  CWarnings.create ~name:"deprecated-focus" ~category:"deprecated"
+  CWarnings.(create ~name:"deprecated-focus" ~category:Deprecated)
          (fun () ->
            Pp.(str "The Focus command is deprecated;" ++ spc ()
                ++ str "use '" ++ int n ++ str ": {' instead")
          )
 
 let warn_deprecated_unfocus =
-  CWarnings.create ~name:"deprecated-unfocus" ~category:"deprecated"
+  CWarnings.(create ~name:"deprecated-unfocus" ~category:Deprecated)
          (fun () -> Pp.strbrk "The Unfocus command is deprecated")
 
 }

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -176,7 +176,7 @@ END
 {
 
 let warn_plural_command =
-  CWarnings.create ~name:"plural-command" ~category:"pedantic" ~default:CWarnings.Disabled
+  CWarnings.(create ~name:"plural-command" ~category:Pedantic ~default:Disabled)
          (fun kwd -> strbrk (Printf.sprintf "Command \"%s\" expects more than one assumption." kwd))
 
 let test_plural_form loc kwd = function
@@ -528,11 +528,11 @@ let starredidentreflist_to_expr l =
   | x :: xs -> List.fold_right (fun i acc -> SsUnion(i,acc)) xs x
 
 let warn_deprecated_include_type =
-  CWarnings.create ~name:"deprecated-include-type" ~category:"deprecated"
+  CWarnings.(create ~name:"deprecated-include-type" ~category:Deprecated)
          (fun () -> strbrk "Include Type is deprecated; use Include instead")
 
 let warn_deprecated_as_ident_kind =
-  CWarnings.create ~name:"deprecated-as-ident-kind" ~category:"deprecated"
+  CWarnings.(create ~name:"deprecated-as-ident-kind" ~category:Deprecated)
          (fun () -> strbrk "grammar kind \"as ident\" no longer accepts \"_\"; use \"as name\" instead to accept \"_\", too, or silence the warning if you actually intended to accept only identifiers.")
 
 }

--- a/vernac/indschemes.ml
+++ b/vernac/indschemes.ml
@@ -291,7 +291,7 @@ let declare_rewriting_schemes ind =
   end
 
 let warn_cannot_build_congruence =
-  CWarnings.create ~name:"cannot-build-congruence" ~category:"schemes"
+  CWarnings.(create ~name:"cannot-build-congruence" ~category:Schemes)
          (fun () ->
           strbrk "Cannot build congruence scheme because eq is not found")
 

--- a/vernac/library.ml
+++ b/vernac/library.ml
@@ -369,7 +369,7 @@ let in_require : require_obj -> obj =
    if [export = Some true] *)
 
 let warn_require_in_module =
-  CWarnings.create ~name:"require-in-module" ~category:"deprecated"
+  CWarnings.(create ~name:"require-in-module" ~category:Deprecated)
                    (fun () -> strbrk "Require inside a module is" ++
                               strbrk " deprecated and strongly discouraged. " ++
                               strbrk "You can Require a module at toplevel " ++

--- a/vernac/loadpath.ml
+++ b/vernac/loadpath.ml
@@ -48,7 +48,7 @@ let remove_load_path dir =
   load_paths := List.filter filter !load_paths
 
 let warn_overriding_logical_loadpath =
-  CWarnings.create ~name:"overriding-logical-loadpath" ~category:"loadpath"
+  CWarnings.(create ~name:"overriding-logical-loadpath" ~category:Loadpath)
     (fun (phys_path, old_path, coq_path) ->
        Pp.(seq [str phys_path; strbrk " was previously bound to "
                ; DP.print old_path; strbrk "; it is remapped to "
@@ -121,7 +121,7 @@ type locate_error = LibUnmappedDir | LibNotFound
 type 'a locate_result = ('a, locate_error) result
 
 let warn_several_object_files =
-  CWarnings.create ~name:"several-object-files" ~category:"require"
+  CWarnings.(create ~name:"several-object-files" ~category:Require)
     Pp.(fun (vi, vo) ->
         seq [ str "Loading"; spc (); str vi
             ; strbrk " instead of "; str vo
@@ -232,11 +232,11 @@ type vo_path =
   }
 
 let warn_cannot_open_path =
-  CWarnings.create ~name:"cannot-open-path" ~category:"filesystem"
+  CWarnings.(create ~name:"cannot-open-path" ~category:Filesystem)
     (fun unix_path -> Pp.(str "Cannot open " ++ str unix_path))
 
 let warn_cannot_use_directory =
-  CWarnings.create ~name:"cannot-use-directory" ~category:"filesystem"
+  CWarnings.(create ~name:"cannot-use-directory" ~category:Filesystem)
     (fun d ->
        Pp.(str "Directory " ++ str d ++
            strbrk " cannot be used as a Coq identifier (skipped)"))

--- a/vernac/locality.ml
+++ b/vernac/locality.ml
@@ -29,7 +29,7 @@ let make_non_locality = function Some false -> false | _ -> true
 let make_locality = function Some true -> true | _ -> false
 
 let warn_local_declaration =
-  CWarnings.create ~name:"local-declaration" ~category:"scope"
+  CWarnings.(create ~name:"local-declaration" ~category:Scope)
     Pp.(fun () ->
         Pp.strbrk "Interpreting this declaration as if " ++
         strbrk "a global declaration prefixed by \"Local\", " ++

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -435,7 +435,7 @@ let make_hunks etyps symbols from_level =
 let error_format ?loc () = user_err ?loc Pp.(str "The format does not match the notation.")
 
 let warn_format_break =
-  CWarnings.create ~name:"notation-both-format-and-spaces" ~category:"parsing"
+  CWarnings.(create ~name:"notation-both-format-and-spaces" ~category:Parsing)
          (fun () ->
           strbrk "Discarding format implicitly indicated by multiple spaces in notation because an explicit format modifier is given.")
 
@@ -721,7 +721,7 @@ let error_parsing_incompatible_level ntn ntn' oldprec oldtyps prec typs =
     pr_level ntn prec typs ++ str ".")
 
 let warn_incompatible_format =
-  CWarnings.create ~name:"notation-incompatible-format" ~category:"parsing"
+  CWarnings.(create ~name:"notation-incompatible-format" ~category:Parsing)
     (fun (specific,ntn) ->
        let head,scope = match specific with
        | None -> str "Notation", mt ()
@@ -894,7 +894,7 @@ end
 
 (* To be turned into a fatal warning in 8.14 *)
 let warn_deprecated_ident_entry =
-  CWarnings.create ~name:"deprecated-ident-entry" ~category:"deprecated"
+  CWarnings.(create ~name:"deprecated-ident-entry" ~category:Deprecated)
          (fun () -> strbrk "grammar entry \"ident\" permitted \"_\" in addition to proper identifiers; this use is deprecated and its meaning will change in the future; use \"name\" instead.")
 
 let interp_modifiers modl = let open NotationMods in
@@ -1104,12 +1104,12 @@ let check_rule_productivity l =
     user_err Pp.(str "A recursive notation must start with at least one symbol.")
 
 let warn_notation_bound_to_variable =
-  CWarnings.create ~name:"notation-bound-to-variable" ~category:"parsing"
+  CWarnings.(create ~name:"notation-bound-to-variable" ~category:Parsing)
          (fun () ->
           strbrk "This notation will not be used for printing as it is bound to a single variable.")
 
 let warn_non_reversible_notation =
-  CWarnings.create ~name:"non-reversible-notation" ~category:"parsing"
+  CWarnings.(create ~name:"non-reversible-notation" ~category:Parsing)
          (function
           | APrioriReversible -> assert false
           | HasLtac ->
@@ -1349,7 +1349,7 @@ let compute_syntax_data ~local deprecation df modifiers =
   }
 
 let warn_only_parsing_reserved_notation =
-  CWarnings.create ~name:"irrelevant-reserved-notation-only-parsing" ~category:"parsing"
+  CWarnings.(create ~name:"irrelevant-reserved-notation-only-parsing" ~category:Parsing)
     (fun () -> strbrk "The only parsing modifier has no effect in Reserved Notation.")
 
 let compute_pure_syntax_data ~local df mods =
@@ -1522,7 +1522,7 @@ let make_parsing_rules (sd : SynData.syn_data) = let open SynData in
   }
 
 let warn_irrelevant_format =
-  CWarnings.create ~name:"irrelevant-format-only-parsing" ~category:"parsing"
+  CWarnings.(create ~name:"irrelevant-format-only-parsing" ~category:Parsing)
     (fun () -> str "The format modifier is irrelevant for only parsing rules.")
 
 let make_printing_rules reserved (sd : SynData.syn_data) = let open SynData in
@@ -1539,7 +1539,7 @@ let make_printing_rules reserved (sd : SynData.syn_data) = let open SynData in
   }
 
 let warn_unused_interpretation =
-  CWarnings.create ~name:"unused-notation" ~category:"parsing"
+  CWarnings.(create ~name:"unused-notation" ~category:Parsing)
          (fun b ->
           strbrk "interpretation is used neither for printing nor for parsing, " ++
           (if b then strbrk "the declaration could be replaced by \"Reserved Notation\"."
@@ -1816,7 +1816,7 @@ let add_syntactic_definition ~local deprecation env ident (vars,c) { onlyparsing
 (* Declaration of custom entry                                        *)
 
 let warn_custom_entry =
-  CWarnings.create ~name:"custom-entry-overridden" ~category:"parsing"
+  CWarnings.(create ~name:"custom-entry-overridden" ~category:Parsing)
          (fun s ->
           strbrk "Custom entry " ++ str s ++ strbrk " has been overridden.")
 

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -264,7 +264,7 @@ type record_error =
   | BadTypedProj of Id.t * env * Type_errors.type_error
 
 let warn_cannot_define_projection =
-  CWarnings.create ~name:"cannot-define-projection" ~category:"records"
+  CWarnings.(create ~name:"cannot-define-projection" ~category:Records)
          (fun msg -> hov 0 msg)
 
 (* If a projection is not definable, we throw an error if the user
@@ -767,7 +767,7 @@ let add_inductive_class env sigma ind =
   Classes.add_class env sigma k
 
 let warn_already_existing_class =
-  CWarnings.create ~name:"already-existing-class" ~category:"automation" Pp.(fun g ->
+  CWarnings.(create ~name:"already-existing-class" ~category:Automation) Pp.(fun g ->
       Printer.pr_global g ++ str " is already declared as a typeclass.")
 
 let declare_existing_class g =

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1228,7 +1228,7 @@ let vernac_end_segment ~pm ({v=id} as lid) =
 (* Libraries *)
 
 let warn_require_in_section =
-  CWarnings.create ~name:"require-in-section" ~category:"fragile"
+  CWarnings.(create ~name:"require-in-section" ~category:Fragile)
     (fun () -> strbrk "Use of “Require” inside a section is fragile." ++ spc() ++
                strbrk "It is not recommended to use this functionality in finished proof scripts.")
 
@@ -1397,7 +1397,7 @@ let vernac_create_hintdb ~module_local id b =
   Hints.create_hint_db module_local id TransparentState.full b
 
 let warn_implicit_core_hint_db =
-  CWarnings.create ~name:"implicit-core-hint-db" ~category:"deprecated"
+  CWarnings.(create ~name:"implicit-core-hint-db" ~category:Deprecated)
          (fun () -> strbrk "Adding and removing hints in the core database implicitly is deprecated. "
              ++ strbrk"Please specify a hint database.")
 

--- a/vernac/vernacextend.ml
+++ b/vernac/vernacextend.ml
@@ -88,8 +88,7 @@ let vinterp_map s =
       (str"Cannot find vernac command " ++ str (fst s) ++ str".")
 
 let warn_deprecated_command =
-  let open CWarnings in
-  create ~name:"deprecated-command" ~category:"deprecated"
+  CWarnings.(create ~name:"deprecated-command" ~category:Deprecated)
          (fun pr -> str "Deprecated vernacular command: " ++ pr)
 
 (* Interpretation of a vernac command *)


### PR DESCRIPTION
The goal is to avoid:
- uncontrolled category inflation;
- typos in category names accidentally leading to more categories.

We still provide a way for external plugin authors to define their own category through the Other constructor, but this constructor should not be used within the Coq code base (including internal plugins) since a specific constructor can be added to the ADT instead.

**Kind:** internal / API.

- [x] there are a couple of PRs (#12341, #11974) that target 8.12 that should be merged before this one. Then, this one will have to be rebased on top and fixed.