### PR TITLE
Allow dependent products in canonical instances.

### DIFF
--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -244,12 +244,9 @@ let check_conv_record env sigma (t1,sk1) (t2,sk2) =
   let canon_s,sk2_effective =
     try
       match EConstr.kind sigma t2 with
-        Prod (_,a,b) -> (* assert (l2=[]); *)
-          let _, a, b = destProd sigma t2 in
-          if noccurn sigma 1 b then
+        Prod (_,_,_) -> (* assert (l2=[]); *)
             lookup_canonical_conversion (proji, Prod_cs),
-            (Stack.append_app [|a;pop b|] Stack.empty)
-          else raise Not_found
+            (Stack.append_app [|t2|] Stack.empty)
       | Sort s ->
         let s = ESorts.kind sigma s in
         lookup_canonical_conversion

--- a/pretyping/recordops.ml
+++ b/pretyping/recordops.ml
@@ -183,7 +183,7 @@ let rec cs_pattern_of_constr env t =
     let patt, n, args = cs_pattern_of_constr env f in
     patt, n, args @ Array.to_list vargs
   | Rel n -> Default_cs, Some n, []
-  | Prod (_,a,b) when Vars.noccurn 1 b -> Prod_cs, None, [a; Vars.lift (-1) b]
+  | Prod (_,_,_) -> Prod_cs, None, [t]
   | Proj (p, c) ->
     let { Environ.uj_type = ty } = Typeops.infer env c in
     let _, params = Inductive.find_rectype env ty in
@@ -243,7 +243,7 @@ let compute_canonical_projections env ~warn (gref,ind) =
 
 let pr_cs_pattern = function
     Const_cs c -> Nametab.pr_global_env Id.Set.empty c
-  | Prod_cs -> str "_ -> _"
+  | Prod_cs -> str "forall _, _"
   | Default_cs -> str "_"
   | Sort_cs s -> Sorts.pr_sort_family s
 

--- a/test-suite/success/CanonicalStructure.v
+++ b/test-suite/success/CanonicalStructure.v
@@ -76,7 +76,15 @@ Fail Check (refl_equal _ : l _ = x2).
 (* Dependent function fields *)
 Section DepProd.
   Structure hello := { hello_key : Type }.
-  Canonical Structure hello_dep := {| hello_key := forall x : nat, x = x |}.
+  Section FixedTypes.
+    Local Canonical Structure hello_dep1 := {| hello_key := forall x : nat, x = x |}.
+    Example ex_hello2 := let h := _ in fun f : hello_key h => (f : forall x : nat, x = x) 1.
+  End FixedTypes.
 
-  Example ex_hello := let h := _ in fun f : hello_key h => (f : forall x : nat, x = x) 1.
+  Section VariableTypes.
+    Local Canonical Structure hello_dep2 v1 v2 := {| hello_key := forall x : list v1, x = v2 |}.
+    Set Debug Unification.
+    Example ex_hello1 : _ -> _ = nil :=
+      let h := _ in fun f : hello_key h => (f : forall x : list _, _ = _) (@nil nat).
+  End VariableTypes.
 End DepProd.

--- a/test-suite/success/CanonicalStructure.v
+++ b/test-suite/success/CanonicalStructure.v
@@ -70,3 +70,13 @@ Section W.
   Check (refl_equal _ : l _ = x2).
 End W.
 Fail Check (refl_equal _ : l _ = x2).
+
+
+
+(* Dependent function fields *)
+Section DepProd.
+  Structure hello := { hello_key : Type }.
+  Canonical Structure hello_dep := {| hello_key := forall x : nat, x = x |}.
+
+  Example ex_hello := let h := _ in fun f : hello_key h => (f : forall x : nat, x = x) 1.
+End DepProd.


### PR DESCRIPTION
This removes the restriction to non-dependent products. Dependent and non-dependent products are handled the same way.

The code is arguably simpler than before and also more powerful. I have some use cases in mind but they would probably only work with Unicoq so I can't provide a very compelling example here. In any case, @gares and @mattam82 seemed to agree that this could be a worthwhile change, and, based on what @ggonthier's wrote in https://github.com/coq/coq/issues/11189#issuecomment-558673619, it seems that removing the dependency check could be the right thing to do even without any use cases where the function type actually is dependent (as opposed to just appearing dependent during unification).

This needs benchmarking since it might well be slower for non-dependent functions than the original code.

I'll add documentation after #12329 is merged since that PR contains new documentation for canonical structures.

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** feature.


<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [X] Added / updated test-suite
<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [ ] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [ ] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
