### PR TITLE
[ci] Add mit-plv/engine-bench

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -699,6 +699,9 @@ library:ci-coquelicot:
 library:ci-cross_crypto:
   extends: .ci-template
 
+library:ci-engine_bench:
+  extends: .ci-template
+
 library:ci-fcsl_pcm:
   extends: .ci-template
 

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -23,6 +23,7 @@ CI_TARGETS= \
     ci-coq_tools \
     ci-coqprime \
     ci-elpi \
+    ci-engine_bench \
     ci-ext_lib \
     ci-equations \
     ci-fcsl_pcm \

--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -239,6 +239,13 @@
 : "${elpi_hb_CI_ARCHIVEURL:=${elpi_hb_CI_GITURL}/archive}"
 
 ########################################################################
+# Engine-Bench
+########################################################################
+: "${engine_bench_CI_REF:=master}"
+: "${engine_bench_CI_GITURL:=https://github.com/mit-plv/engine-bench}"
+: "${engine_bench_CI_ARCHIVEURL:=${engine_bench_CI_GITURL}/archive}"
+
+########################################################################
 # fcsl-pcm
 ########################################################################
 : "${fcsl_pcm_CI_REF:=master}"

--- a/dev/ci/ci-engine_bench.sh
+++ b/dev/ci/ci-engine_bench.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+ci_dir="$(dirname "$0")"
+. "${ci_dir}/ci-common.sh"
+
+git_download engine_bench
+
+( cd "${CI_BUILD_DIR}/engine_bench" && make coq && make coq-perf-Sanity )


### PR DESCRIPTION
This is a new development where I'm aggregating a specific set of
benchmarks.  It's intended to be relatively lightweight, taking only a
handful of minutes (I can make the CI target much, much lighter if
desired).  It's probably one of the few developments currently testing
Ltac2.

**Kind:** infrastructure