### PR TITLE
Use dev version for opam git pinning in .gitlab-ci.yml.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -366,12 +366,11 @@ pkg:opam:
   dependencies: []
   script:
     - set -e
-    - opam pin add --kind=path coq.$COQ_VERSION .
-    - opam pin add --kind=path coqide-server.$COQ_VERSION .
-    - opam pin add --kind=path coqide.$COQ_VERSION .
+    - opam pin add --kind=path coq.dev .
+    - opam pin add --kind=path coqide-server.dev .
+    - opam pin add --kind=path coqide.dev .
     - set +e
   variables:
-    COQ_VERSION: "8.13"
     OPAM_SWITCH: "edge"
     OPAM_VARIANT: "+flambda"
   only: *full-ci


### PR DESCRIPTION
The main reason for this change is to reduce the number of places where the Coq version is hardcoded.

But moreover, I don't see why that wouldn't work since `dev` is precisely the version that is defined in the opam files.