### PR TITLE
Omit voluminous Latex warnings

### DIFF
--- a/Makefile.doc
+++ b/Makefile.doc
@@ -76,7 +76,7 @@ COQREFMAN_FILES := $(wildcard $(SPHINXBUILDDIR)/latex/CoqRefMan*)
 LATEX_REMOVE_FILES := $(filter-out $(SPHINXBUILDDIR)/latex/CoqRefMan.tex, $(COQREFMAN_FILES))
 refman-pdf: refman-latex
 	rm -f $(LATEX_REMOVE_FILES)
-	+$(MAKE) -C $(SPHINXBUILDDIR)/latex
+	+$(MAKE) -C $(SPHINXBUILDDIR)/latex LATEXMKOPTS=-silent
 
 refman: $(SPHINX_DEPS)
 	+$(MAKE) refman-html


### PR DESCRIPTION
Similar to https://github.com/coq/coq/pull/12195.  The `-q` of that PR didn't make much difference and hid some messages useful for local work.