### PR TITLE
[Pretyping] Trigger CS search during pretyping of lambdas and applications

### DIFF
--- a/pretyping/coercion.ml
+++ b/pretyping/coercion.ml
@@ -456,7 +456,54 @@ let inh_app_fun_core ~program_mode env sigma j =
     | Evar ev ->
         let (sigma,t) = Evardefine.define_evar_as_product env sigma ev in
           (sigma,{ uj_val = j.uj_val; uj_type = t },IdCoe)
+    | Proj (proj, arg) when isEvar sigma arg ->
+      begin
+        try
+          (* Quick check to see if this can succeed at all, avoiding a costly unification call if possible. *)
+          let _ = Structures.CanonicalSolution.find env sigma (Names.GlobRef.ConstRef (Projection.constant proj), Structures.ValuePattern.Prod_cs) in
+          let sigma, (domain_hole, _) = Evarutil.new_type_evar env sigma Evd.univ_flexible in
+          let sigma, (codomain_hole, _) = Evarutil.new_type_evar env sigma Evd.univ_flexible in
+          let cs_type = mkProd (Context.anonR, domain_hole, codomain_hole) in
+
+          let sigma = Evarconv.unify
+              env
+              sigma
+              Reduction.CUMUL
+              t
+              cs_type
+          in
+          (sigma, { uj_val = j.uj_val; uj_type = cs_type }, IdCoe)
+
+        with
+        | Not_found | PretypeError _ -> (sigma,j,IdCoe)
+      end
     | _ ->
+      try
+        (* We could still be looking at a reduced non-primitive projection *)
+        let (proj, inst, evar, params) = Structures.CanonicalSolution.decompose_reduced_canonical_projection sigma t in
+
+        (* Quick check to see if this can succeed at all, avoiding a costly unification call if possible. *)
+        let _ = Structures.CanonicalSolution.find env sigma (Names.GlobRef.ConstRef proj, Structures.ValuePattern.Prod_cs) in
+
+        let sigma, (domain_hole, _) = Evarutil.new_type_evar env sigma Evd.univ_flexible in
+        let sigma, (codomain_hole, _) = Evarutil.new_type_evar env sigma Evd.univ_flexible in
+        let cs_type = mkProd (Context.anonR, domain_hole, codomain_hole) in
+
+        (* We can't use [t] here since it's the reduced projection.
+           So we'll reconstruct the unreduced projection. *)
+        let args = params in
+        let args = Array.append args [|evar|] in
+
+        let sigma = Evarconv.unify
+            env
+            sigma
+            Reduction.CUMUL
+            (mkApp (mkConstU (proj, inst), args))
+            cs_type
+        in
+        (sigma, { uj_val = j.uj_val; uj_type = cs_type }, IdCoe)
+      with
+      | Not_found | PretypeError _ ->
         try let t,p =
           lookup_path_to_fun_from env sigma j.uj_type in
             apply_coercion env sigma p j t

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -942,7 +942,7 @@ struct
               let cs_type = mkProd (binder, domain_hole, codomain_hole) in
 
               let sigma = Evarconv.unify
-                  (GlobEnv.env env)
+                  !!env
                   sigma
                   Reduction.CUMUL
                   ty
@@ -954,7 +954,7 @@ struct
             end
         | _ ->
           try
-            let (proj, inst, evar, params) = CanonicalSolution.decompose_reduced_canonical_projection sigma ty in
+            let (proj, app) = CanonicalSolution.decompose_reduced_canonical_projection sigma ty in
 
             (* Quick check to see if this can succeed at all, avoiding a costly unification call if possible. *)
             let _ =
@@ -967,16 +967,11 @@ struct
             let binder = Context.anonR in
             let cs_type = mkProd (binder, domain_hole, codomain_hole) in
 
-            (* We can't use [t] here since it's the reduced projection.
-               So we'll reconstruct the unreduced projection. *)
-            let args = params in
-            let args = Array.append args [|evar|] in
-
             let sigma = Evarconv.unify
-                (GlobEnv.env env)
+                !!env
                 sigma
                 Reduction.CUMUL
-                (mkApp (mkConstU (proj, inst), args))
+                app
                 cs_type
             in
             sigma,Context.binder_name binder, Some domain_hole, Some codomain_hole

--- a/pretyping/structures.ml
+++ b/pretyping/structures.ml
@@ -408,12 +408,12 @@ let decompose_reduced_canonical_projection sigma c =
   match EConstr.kind sigma c with
   | Case (ci, inst, params, _, _, head, [|branch|]) ->
     begin
+      let bound_args = ci.ci_cstr_ndecls.(0) in
       (* is the head of the actual branch body a projection? *)
-      let n_args = ci.ci_cstr_nargs.(0) in
       let i =
         try
           let i = EConstr.destRel sigma (snd branch) in
-          if i <= n_args then n_args - i
+          if i <= bound_args then bound_args - i
           else raise Not_found
         with DestKO -> raise Not_found
       in

--- a/pretyping/structures.mli
+++ b/pretyping/structures.mli
@@ -131,7 +131,7 @@ val is_open_canonical_projection :
 
 
 val decompose_reduced_canonical_projection :
-  Evd.evar_map -> EConstr.t -> Names.Constant.t * EConstr.EInstance.t * EConstr.t * EConstr.t array
+  Evd.evar_map -> EConstr.t -> Names.Constant.t * EConstr.t
 
 end
 

--- a/pretyping/structures.mli
+++ b/pretyping/structures.mli
@@ -129,6 +129,10 @@ val find :
 val is_open_canonical_projection :
   Environ.env -> Evd.evar_map -> EConstr.t -> bool
 
+
+val decompose_reduced_canonical_projection :
+  Evd.evar_map -> EConstr.t -> Names.Constant.t * EConstr.EInstance.t * EConstr.t * EConstr.t array
+
 end
 
 (** Low level access to the Canonical Structure database *)

--- a/test-suite/bugs/closed/bug_11189.v
+++ b/test-suite/bugs/closed/bug_11189.v
@@ -1,0 +1,10 @@
+Structure trivial_cs := { key : Type }.
+
+Canonical Structure base : trivial_cs := {|key := unit|}.
+Canonical Structure step {A : Type} (t : trivial_cs) : trivial_cs := {| key := A -> key t |}.
+
+Definition test := fun (t : trivial_cs) (k : key t) => tt.
+
+Check test (_) (fun x : unit => tt).
+
+Check (fun (x : key _) => x tt).

--- a/test-suite/success/CanonicalStructure.v
+++ b/test-suite/success/CanonicalStructure.v
@@ -116,3 +116,19 @@ Section DepProd.
       let h := _ in fun f : hello_key h => (f : forall x : list _, _ = _) (@nil nat).
   End VariableTypes.
 End DepProd.
+
+Section NoCasts.
+  Section A.
+    Structure bla (useless_param: bool) := { #[canonical(false)]bla_pre : unit; bla_key : Type; #[canonical(false)]bla_post: nat; }.
+    Canonical Structure bla_func b : bla b := {| bla_pre:= tt; bla_key := nat -> nat; bla_post:= 0|}.
+    Example ex_bla1 p := let b := _ in fun f : @bla_key p b => f 1.
+    Example ex_bla2 p := let b := _ in (fun x => x) : @bla_key p b.
+  End A.
+  Section B.
+    Local Set Primitive Projections.
+    Structure pbla (useless_param: bool) := { #[canonical(false)]pbla_pre : unit; pbla_key : Type; #[canonical(false)]pbla_post: nat; }.
+    Canonical Structure pbla_func b : pbla b := {| pbla_pre:= tt; pbla_key := nat -> nat; pbla_post:= 0|}.
+    Example ex_pbla1 p := let b := _ in fun f : @pbla_key p b => f 1.
+    Example ex_pbla2 p := let b := _ in (fun x => x) : @pbla_key p b.
+  End B.
+End NoCasts.

--- a/test-suite/success/CanonicalStructure.v
+++ b/test-suite/success/CanonicalStructure.v
@@ -33,7 +33,7 @@ Check (fun x : b => x != x).
 Inductive four := x0 | x1 | x2 | x3.
 Structure local := MKL { l : four }.
 
-Section X.
+Module X.
   Definition s0 := MKL x0.
   #[local] Canonical Structure s0.
   Check (refl_equal _ : l _ = x0).
@@ -48,11 +48,11 @@ End X.
 Fail Check (refl_equal _ : l _ = x0).
 Fail Check (refl_equal _ : l _ = x1).
 Fail Check (refl_equal _ : l _ = x2).
-Check s0.
-Check s1.
-Check s2.
+Check X.s0.
+Check X.s1.
+Check X.s2.
 
-Section Y.
+Module Y.
   Let s3 := MKL x3.
   Canonical Structure s3.
   Check (refl_equal _ : l _ = x3).
@@ -60,57 +60,59 @@ End Y.
 Fail Check (refl_equal _ : l _ = x3).
 Fail Check s3.
 
-Section V.
+Module V.
   #[canonical] Let s3 := MKL x3.
   Check (refl_equal _ : l _ = x3).
 End V.
 
-Section W.
+Module W.
   #[canonical, local] Definition s2' := MKL x2.
   Check (refl_equal _ : l _ = x2).
 End W.
 Fail Check (refl_equal _ : l _ = x2).
 
 (* Lambda keys *)
-Section L1.
+Module LambdaKeys.
   Structure cs_lambda := { cs_lambda_key : nat -> nat }.
-  #[local] Canonical Structure cs_lambda_func :=
-    {| cs_lambda_key := fun x => x + 1 |}.
-  Check (refl_equal _ : cs_lambda_key _ = fun _ => _ + _).
-End L1.
+  Module L1.
+    #[local] Canonical Structure cs_lambda_func :=
+      {| cs_lambda_key := fun x => x + 1 |}.
+    Check (refl_equal _ : cs_lambda_key _ = fun _ => _ + _).
+  End L1.
 
-Section L2.
-  #[local] Canonical Structure cs_lambda_func2 :=
-    {| cs_lambda_key := fun x => 1 + x |}.
-  Check (refl_equal _ : cs_lambda_key _ = fun x => 1 + x).
-End L2.
+  Module L2.
+    #[local] Canonical Structure cs_lambda_func2 :=
+      {| cs_lambda_key := fun x => 1 + x |}.
+    Check (refl_equal _ : cs_lambda_key _ = fun x => 1 + x).
+  End L2.
 
-Section L3.
-  #[local] Canonical Structure cs_lambda_func3 :=
-    {| cs_lambda_key := fun x => 1 + x |}.
-  Check (refl_equal _ : cs_lambda_key _ = Nat.add 1).
-End L3.
+  Module L3.
+    #[local] Canonical Structure cs_lambda_func3 :=
+      {| cs_lambda_key := fun x => 1 + x |}.
+    Check (refl_equal _ : cs_lambda_key _ = Nat.add 1).
+  End L3.
 
-Section L4.
-  #[local] Canonical Structure cs_lambda_func4 :=
-    {| cs_lambda_key := Nat.add 1 |}.
-  Check (refl_equal _ : cs_lambda_key _ = Nat.add 1).
-End L4.
+  Module L4.
+    #[local] Canonical Structure cs_lambda_func4 :=
+      {| cs_lambda_key := Nat.add 1 |}.
+    Check (refl_equal _ : cs_lambda_key _ = Nat.add 1).
+  End L4.
 
-Section L5.
-  #[local] Canonical Structure cs_lambda_func5 :=
-    {| cs_lambda_key := Nat.add 1 |}.
-  Check (refl_equal _ : cs_lambda_key _ = fun x => 1 + x).
-End L5.
+  Module L5.
+    #[local] Canonical Structure cs_lambda_func5 :=
+      {| cs_lambda_key := Nat.add 1 |}.
+    Check (refl_equal _ : cs_lambda_key _ = fun x => 1 + x).
+  End L5.
+End LambdaKeys.
 
-Section DepProd.
+Module DepProd.
   Structure hello := { hello_key : Type }.
-  Section FixedTypes.
+  Module FixedTypes.
     Local Canonical Structure hello_dep1 := {| hello_key := forall x : nat, x = x |}.
     Example ex_hello2 := let h := _ in fun f : hello_key h => (f : forall x : nat, x = x) 1.
   End FixedTypes.
 
-  Section VariableTypes.
+  Module VariableTypes.
     Local Canonical Structure hello_dep2 v1 v2 := {| hello_key := forall x : list v1, x = v2 |}.
     Example ex_hello1 : _ -> _ = nil :=
       let h := _ in fun f : hello_key h => (f : forall x : list _, _ = _) (@nil nat).
@@ -125,8 +127,8 @@ End DepProd.
    1. [f x : _] when [f : proj _]
    2. [(fun x => _) : proj _].
  *)
-Section NoCasts.
-  Section Basic.
+Module NoCasts.
+  Module Basic.
     Structure r1 (useless_param: bool) :=
       { #[canonical=no]  r1_pre : unit
       ; #[canonical=yes] r1_key : Type
@@ -137,7 +139,7 @@ Section NoCasts.
     Example ex_r1_2 p := let b := _ in (fun x => x) : @r1_key p b.
   End Basic.
 
-  Section Primitive.
+  Module Primitive.
     Local Set Primitive Projections.
     Structure r2 (useless_param: bool) :=
       { #[canonical=no]  r2_pre : unit
@@ -148,7 +150,7 @@ Section NoCasts.
     Example ex_r2_2 p := let b := _ in (fun x => x) : @r2_key p b.
   End Primitive.
 
-  Section UsedParameters.
+  Module UsedParameters.
     Structure r3 (useless_param: bool) (T : Type) :=
       { #[canonical=no]  r3_pre : unit
       ; #[canonical=yes] r3_key : Type
@@ -159,7 +161,7 @@ Section NoCasts.
     Example ex_r3_2 p := let b := _ in (fun x => x) : @r3_key p _ b.
   End UsedParameters.
 
-  Section LetBoundProjections.
+  Module LetBoundProjections.
     Structure r4 (useless_param: bool) :=
       { #[canonical=no]  r4_pre : unit
       ; #[canonical=no]  r4_let := true

--- a/test-suite/success/CanonicalStructure.v
+++ b/test-suite/success/CanonicalStructure.v
@@ -117,18 +117,58 @@ Section DepProd.
   End VariableTypes.
 End DepProd.
 
+
+(* Testing that canonical projections equipped with function type instances
+   ([forall _, _]) or default instances ([_]) can be used in places where
+   functions/function types are expected.
+   This feature triggers CS search in two typing cases:
+   1. [f x : _] when [f : proj _]
+   2. [(fun x => _) : proj _].
+ *)
 Section NoCasts.
-  Section A.
-    Structure bla (useless_param: bool) := { #[canonical=no]bla_pre : unit; bla_key : Type; #[canonical=no]bla_post: nat; }.
-    Canonical Structure bla_func b : bla b := {| bla_pre:= tt; bla_key := nat -> nat; bla_post:= 0|}.
-    Example ex_bla1 p := let b := _ in fun f : @bla_key p b => f 1.
-    Example ex_bla2 p := let b := _ in (fun x => x) : @bla_key p b.
-  End A.
-  Section B.
+  Section Basic.
+    Structure r1 (useless_param: bool) :=
+      { #[canonical=no]  r1_pre : unit
+      ; #[canonical=yes] r1_key : Type
+      ; #[canonical=no]  r1_post: nat
+      }.
+    Canonical Structure r1_func b : r1 b := {| r1_pre:= tt; r1_key := nat -> nat; r1_post:= 0|}.
+    Example ex_r1_1 p := let b := _ in fun f : @r1_key p b => f 1.
+    Example ex_r1_2 p := let b := _ in (fun x => x) : @r1_key p b.
+  End Basic.
+
+  Section Primitive.
     Local Set Primitive Projections.
-    Structure pbla (useless_param: bool) := { #[canonical=no]pbla_pre : unit; pbla_key : Type; #[canonical=no]pbla_post: nat; }.
-    Canonical Structure pbla_func b : pbla b := {| pbla_pre:= tt; pbla_key := nat -> nat; pbla_post:= 0|}.
-    Example ex_pbla1 p := let b := _ in fun f : @pbla_key p b => f 1.
-    Example ex_pbla2 p := let b := _ in (fun x => x) : @pbla_key p b.
-  End B.
+    Structure r2 (useless_param: bool) :=
+      { #[canonical=no]  r2_pre : unit
+      ; #[canonical=yes] r2_key : Type
+      ; #[canonical=no]  r2_post: nat; }.
+    Canonical Structure r2_func b : r2 b := {| r2_pre:= tt; r2_key := nat -> nat; r2_post:= 0|}.
+    Example ex_r2_1 p := let b := _ in fun f : @r2_key p b => f 1.
+    Example ex_r2_2 p := let b := _ in (fun x => x) : @r2_key p b.
+  End Primitive.
+
+  Section UsedParameters.
+    Structure r3 (useless_param: bool) (T : Type) :=
+      { #[canonical=no]  r3_pre : unit
+      ; #[canonical=yes] r3_key : Type
+      ; #[canonical=no]  r3_post: T
+      }.
+    Canonical Structure r3_func b : r3 b nat := {| r3_pre:= tt; r3_key := nat -> nat; r3_post:= 0|}.
+    Example ex_r3_1 p := let b := _ in fun f : @r3_key p _ b => f 1.
+    Example ex_r3_2 p := let b := _ in (fun x => x) : @r3_key p _ b.
+  End UsedParameters.
+
+  Section LetBoundProjections.
+    Structure r4 (useless_param: bool) :=
+      { #[canonical=no]  r4_pre : unit
+      ; #[canonical=no]  r4_let := true
+      ; #[canonical=yes] r4_key : Type
+      ; #[canonical=no]  r4_post: nat;
+      }.
+    Canonical Structure r4_func b : r4 b := {| r4_pre:= tt; r4_key := nat -> nat; r4_post:= 0|}.
+    Example ex_r4_1 p := let b := _ in fun f : @r4_key p b => f 1.
+    Example ex_r4_2 p := let b := _ in (fun x => x) : @r4_key p b.
+  End LetBoundProjections.
+
 End NoCasts.

--- a/test-suite/success/CanonicalStructure.v
+++ b/test-suite/success/CanonicalStructure.v
@@ -119,14 +119,14 @@ End DepProd.
 
 Section NoCasts.
   Section A.
-    Structure bla (useless_param: bool) := { #[canonical(false)]bla_pre : unit; bla_key : Type; #[canonical(false)]bla_post: nat; }.
+    Structure bla (useless_param: bool) := { #[canonical=no]bla_pre : unit; bla_key : Type; #[canonical=no]bla_post: nat; }.
     Canonical Structure bla_func b : bla b := {| bla_pre:= tt; bla_key := nat -> nat; bla_post:= 0|}.
     Example ex_bla1 p := let b := _ in fun f : @bla_key p b => f 1.
     Example ex_bla2 p := let b := _ in (fun x => x) : @bla_key p b.
   End A.
   Section B.
     Local Set Primitive Projections.
-    Structure pbla (useless_param: bool) := { #[canonical(false)]pbla_pre : unit; pbla_key : Type; #[canonical(false)]pbla_post: nat; }.
+    Structure pbla (useless_param: bool) := { #[canonical=no]pbla_pre : unit; pbla_key : Type; #[canonical=no]pbla_post: nat; }.
     Canonical Structure pbla_func b : pbla b := {| pbla_pre:= tt; pbla_key := nat -> nat; pbla_post:= 0|}.
     Example ex_pbla1 p := let b := _ in fun f : @pbla_key p b => f 1.
     Example ex_pbla2 p := let b := _ in (fun x => x) : @pbla_key p b.

--- a/test-suite/success/CanonicalStructure.v
+++ b/test-suite/success/CanonicalStructure.v
@@ -161,7 +161,7 @@ Module NoCasts.
     Example ex_r3_2 p := let b := _ in (fun x => x) : @r3_key p _ b.
   End UsedParameters.
 
-  Module LetBoundProjections.
+  Module LetBoundFieldBefore.
     Structure r4 (useless_param: bool) :=
       { #[canonical=no]  r4_pre : unit
       ; #[canonical=no]  r4_let := true
@@ -171,6 +171,18 @@ Module NoCasts.
     Canonical Structure r4_func b : r4 b := {| r4_pre:= tt; r4_key := nat -> nat; r4_post:= 0|}.
     Example ex_r4_1 p := let b := _ in fun f : @r4_key p b => f 1.
     Example ex_r4_2 p := let b := _ in (fun x => x) : @r4_key p b.
-  End LetBoundProjections.
+  End LetBoundFieldBefore.
+
+  Module LetBoundFieldAfter.
+    Structure r4 (useless_param: bool) :=
+      { #[canonical=no]  r4_pre : unit
+      ; #[canonical=yes] r4_key : Type
+      ; #[canonical=no]  r4_let := true
+      ; #[canonical=no]  r4_post: nat;
+      }.
+    Canonical Structure r4_func b : r4 b := {| r4_pre:= tt; r4_key := nat -> nat; r4_post:= 0|}.
+    Example ex_r4_1 p := let b := _ in fun f : @r4_key p b => f 1.
+    Example ex_r4_2 p := let b := _ in (fun x => x) : @r4_key p b.
+  End LetBoundFieldAfter.
 
 End NoCasts.


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

This PR allows the pretyper to look for suitable canonical instances to make the following typing problems succeed (which I consider to be dual to each other):
```
f : key ?c ⊢ f x : _
```
and

```
(fun _ : _ => _) : key ?c
```


I am actually calling unification to trigger the search because I couldn't figure out how to use the result of `lookup_canonical_projection`. There will surely be a cost to this. However, I did put in a check to see if there is a `Prod_cs` instance for `key`. If there isn't, unification is never called. This should limit the impact.

Unfortunately, there is also an unnecessary call to `whd_all` in `pretype_lambda`. This could be removed with some refactoring of `split_tycon`, where the same reduction is already performed. (One could also imagine that `split_tycon` would actually be a better place to trigger the CS search but that seemed wrong to me.)

I am marking this a draft because a) the code needs cleaning up, b) I am not convinced that unification is the best way to trigger CS here, and c) there might be metatheoretical implications to this change that I am not aware of.

**Depends on**: #12349 (because I didn't know how to create the evars for `_ -> _`, i.e. how to make sure the 2nd `_` doesn't depend on the first.)

<!-- Keep what applies -->
**Kind:** bug fix & feature.


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #11189


<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [X] Added / updated test-suite
<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [ ] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [ ] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
