### PR TITLE
Small coq_makefile improvement.

### DIFF
--- a/doc/changelog/08-tools/12389-coq_makefile.rst
+++ b/doc/changelog/08-tools/12389-coq_makefile.rst
@@ -1,0 +1,5 @@
+- **Changed:**
+  Adding the possibility in coq_makefile to directly set the installation folders,
+  through the :n:`COQLIBINSTALL` and :n:`COQDOCINSTALL` variables.
+  See :ref:`coqmakefilelocal`.
+  (`#12389 <https://github.com/coq/coq/pull/12389>`_, by Martin Bodin, review of Enrico Tassi).

--- a/doc/sphinx/practical-tools/utilities.rst
+++ b/doc/sphinx/practical-tools/utilities.rst
@@ -170,6 +170,10 @@ Here we describe only few of them.
    override the flags passed to ``coqdoc``. By default ``-interpolate -utf8``.
 :COQDOCEXTRAFLAGS:
    extend the flags passed to ``coqdoc``
+:COQLIBINSTALL, COQDOCINSTALL:
+   specify where the Coq libraries and documentation will be installed.
+   By default a combination of ``$(DESTDIR)`` (if defined) with
+   ``$(COQLIB)/user-contrib`` and ``$(DOCDIR)/user-contrib``.
 
 **Rule extension**
 

--- a/tools/CoqMakefile.in
+++ b/tools/CoqMakefile.in
@@ -153,7 +153,8 @@ endif
 
 # Substitution of the path by appending $(DESTDIR) if needed.
 # The variable $(COQMF_WINDRIVE) can be needed for Cygwin environments.
-destination_path = $(if $(DESTDIR),$(DESTDIR)/$(if $(COQMF_WINDRIVE),$(subst $(COQMF_WINDRIVE),/,$(1)),$(1)),$(1))
+windrive_path = $(if $(COQMF_WINDRIVE),$(subst $(COQMF_WINDRIVE),/,$(1)),$(1))
+destination_path = $(if $(DESTDIR),$(DESTDIR)/$(call windrive_path,$(1)),$(1))
 
 # Installation paths of libraries and documentation.
 COQLIBINSTALL ?= $(call destination_path,$(COQLIB)/user-contrib)

--- a/tools/CoqMakefile.in
+++ b/tools/CoqMakefile.in
@@ -146,6 +146,20 @@ TIME_OF_PRETTY_BUILD_EXTRA_FILES ?= - # also output to the command line
 
 TGTS ?=
 
+# Retro compatibility (DESTDIR is standard on Unix, DSTROOT is not)
+ifdef DSTROOT
+DESTDIR := $(DSTROOT)
+endif
+
+# Substitution of the path by appending $(DESTDIR) if needed.
+# The variable $(COQMF_WINDRIVE) can be needed for Cygwin environments.
+destination_path = $(if $(DESTDIR),$(DESTDIR)/$(if $(COQMF_WINDRIVE),$(subst $(COQMF_WINDRIVE),/,$(1)),$(1)),$(1))
+
+# Installation paths of libraries and documentation.
+COQLIBINSTALL ?= $(call destination_path,$(COQLIB)/user-contrib)
+COQDOCINSTALL ?= $(call destination_path,$(DOCDIR)/user-contrib)
+COQTOPINSTALL ?= $(call destination_path,$(COQLIB)/toploop) # FIXME: Unused variable?
+
 ########## End of parameters ##################################################
 # What follows may be relevant to you only if you need to
 # extend this Makefile.  If so, look for 'Extension point' here and
@@ -226,17 +240,6 @@ endif
 else
 TIMING_ARG=
 endif
-
-# Retro compatibility (DESTDIR is standard on Unix, DSTROOT is not)
-ifdef DSTROOT
-DESTDIR := $(DSTROOT)
-endif
-
-concat_path = $(if $(1),$(1)/$(if $(COQMF_WINDRIVE),$(subst $(COQMF_WINDRIVE),/,$(2)),$(2)),$(2))
-
-COQLIBINSTALL = $(call concat_path,$(DESTDIR),$(COQLIB)/user-contrib)
-COQDOCINSTALL = $(call concat_path,$(DESTDIR),$(DOCDIR)/user-contrib)
-COQTOPINSTALL = $(call concat_path,$(DESTDIR),$(COQLIB)/toploop)
 
 # Files #######################################################################
 #
@@ -577,7 +580,7 @@ uninstall::
 	 instf="$(COQLIBINSTALL)/$$df/`basename $$f`" &&\
 	 rm -f "$$instf" &&\
 	 echo RM "$$instf" &&\
-	 (rmdir "$(call concat_path,,$(COQLIBINSTALL)/$$df/)" 2>/dev/null || true); \
+	 (rmdir "$(COQLIBINSTALL)/$$df/" 2>/dev/null || true); \
 	done
 .PHONY: uninstall
 


### PR DESCRIPTION
**Kind:** feature.

Relates to #7740 and #7722.

- [ ] Updated test-suite
- [x] Corresponding documentation was added.
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).

The behaviour of coq_makefile regarding `DESTDIR` is somehow confusing (as seen in the related bug reports above). The “usual” set-up in Linux seems to be:
- set `DESTDIR` to the wanted place.
- set `COQMF_WINDRIVE` to `COQLIB` to “cancel” the default place.
- coq_makefile will add a `user-contrib` at the end.

The `COQMF_WINDRIVE` parts feels like a hack and is currently undocumented. This PR provides an alternative way (without breaking the previous way):
- set `COQLIBINSTALL`, `COQDOCINSTALL`, and `COQTOPINSTALL` to whatever the user needs.

Being able to set up the installation directory is especially important when using programs like `esy`, in which different Coq installation can be shared among repositories: `esy` installs Coq libraries into their own directory, relying on the `COQPATH` mechanism to link everything back together. By forcing the installation to `${COQLIB}/user-contrib`, coq_makefile is installing files in a shared folder, which breaks `esy`’s invariants required for replication.