### PR TITLE
Fix #12280: do not use xindy to avoid build failures on some machines.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ stages:
 variables:
   # Format: $IMAGE-V$DATE [Cache is not used as of today but kept here
   # for reference]
-  CACHEKEY: "bionic_coq-V2020-05-19-V33"
+  CACHEKEY: "bionic_coq-V2020-05-24-V1"
   IMAGE: "$CI_REGISTRY_IMAGE:$CACHEKEY"
   # By default, jobs run in the base switch; override to select another switch
   OPAM_SWITCH: "base"

--- a/dev/ci/docker/bionic_coq/Dockerfile
+++ b/dev/ci/docker/bionic_coq/Dockerfile
@@ -1,4 +1,4 @@
-# CACHEKEY: "bionic_coq-V2020-05-19-V33"
+# CACHEKEY: "bionic_coq-V2020-05-24-V1"
 # ^^ Update when modifying this file.
 
 FROM ubuntu:bionic
@@ -13,8 +13,7 @@ RUN apt-get update -qq && apt-get install --no-install-recommends -y -qq \
         libgtksourceview-3.0-dev \
         # Dependencies of stdlib and sphinx doc
         texlive-latex-extra texlive-fonts-recommended texlive-xetex latexmk \
-        xindy python3-pip python3-setuptools python3-pexpect python3-bs4 \
-        fonts-freefont-otf \
+        python3-pip python3-setuptools python3-pexpect python3-bs4 fonts-freefont-otf \
         # Dependencies of source-doc and coq-makefile
         texlive-science tipa
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -58,7 +58,6 @@ additional tools are required:
   - makeindex
   - xelatex
   - latexmk
-  - xindy
 
 All of them are part of the TexLive distribution. E.g. on Debian / Ubuntu,
 install them with:
@@ -68,7 +67,7 @@ install them with:
 Or if you want to use less disk space:
 
     apt install texlive-latex-extra texlive-fonts-recommended texlive-xetex \
-                latexmk xindy fonts-freefont-otf
+                latexmk fonts-freefont-otf
 
 Compilation
 -----------

--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -356,6 +356,9 @@ latex_elements = {
 
 latex_engine = "xelatex"
 
+# Cf. https://github.com/sphinx-doc/sphinx/issues/7015
+latex_use_xindy = False
+
 ########
 # done #
 ########


### PR DESCRIPTION
**Kind:** documentation infrastructure.

Fixes / closes #12280.

- [x] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).

The build still goes through and the index still looks fine. Since the manual is entirely written in English, I think there is no issue with using `makeindex` instead.