### PR TITLE
Fix #12406: fix Coq type error in dependent induction's Ltac

### DIFF
--- a/theories/Program/Equality.v
+++ b/theories/Program/Equality.v
@@ -264,7 +264,7 @@ Class DependentEliminationPackage (A : Type) :=
 
 Ltac elim_tac tac p :=
   let ty := type of p in
-  let eliminator := eval simpl in (@elim (_ : DependentEliminationPackage ty)) in
+  let eliminator := eval simpl in (@elim _ (_ : DependentEliminationPackage ty)) in
     tac p eliminator.
 
 (** Specialization to do case analysis or induction.


### PR DESCRIPTION
<!-- Keep what applies -->
**Kind:** bug fix.


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #12406


<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [ ] Added / updated test-suite
<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [ ] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).