### PR TITLE
Fix output tests for location errors when running in async mode.

### DIFF
--- a/test-suite/output/ErrorLocation_12152_1.v
+++ b/test-suite/output/ErrorLocation_12152_1.v
@@ -1,3 +1,4 @@
 (* Reported in #12152 *)
 Goal True.
 intro H; auto.
+Abort.

--- a/test-suite/output/ErrorLocation_12152_2.v
+++ b/test-suite/output/ErrorLocation_12152_2.v
@@ -1,3 +1,4 @@
 (* Reported in #12152 *)
 Goal True.
 intros H; auto.
+Abort.

--- a/test-suite/output/ErrorLocation_12255.v
+++ b/test-suite/output/ErrorLocation_12255.v
@@ -2,3 +2,4 @@ Ltac can_unfold x := let b := eval cbv delta [x] in x in idtac.
 Definition i := O.
 Goal False.
 can_unfold (i>0).
+Abort.


### PR DESCRIPTION
In this mode, an additional error was emitted, which made the test fail:
`Error: There are pending proofs: Unnamed_thm.`

**Kind:** fix