### PR TITLE
Reduce options passed to workers

### DIFF
--- a/stm/asyncTaskQueue.ml
+++ b/stm/asyncTaskQueue.ml
@@ -130,7 +130,6 @@ module Make(T : Task) () = struct
         (* Options to discard: 1 argument *)
         | ( "-async-proofs" | "-vio2vo" | "-o"
           | "-load-vernac-source" | "-l" | "-load-vernac-source-verbose" | "-lv"
-          | "-compile" | "-compile-verbose"
           | "-async-proofs-cache" | "-async-proofs-j" | "-async-proofs-tac-j"
           | "-async-proofs-private-flags" | "-async-proofs-tactic-error-resilience"
           | "-async-proofs-command-error-resilience" | "-async-proofs-delegation-threshold"

--- a/stm/asyncTaskQueue.ml
+++ b/stm/asyncTaskQueue.ml
@@ -130,18 +130,23 @@ module Make(T : Task) () = struct
         (* Options to discard: 1 argument *)
         | ( "-async-proofs" | "-vio2vo" | "-o"
           | "-load-vernac-source" | "-l" | "-load-vernac-source-verbose" | "-lv"
+          | "-require-import" | "-require-export" | "-ri" | "-re"
+          | "-load-vernac-object"
+          | "-set" | "-unset" | "-compat" | "-mangle-names" | "-diffs" | "-w"
           | "-async-proofs-cache" | "-async-proofs-j" | "-async-proofs-tac-j"
           | "-async-proofs-private-flags" | "-async-proofs-tactic-error-resilience"
           | "-async-proofs-command-error-resilience" | "-async-proofs-delegation-threshold"
           | "-async-proofs-worker-priority" | "-worker-id") :: _ :: tl ->
           set_slave_opt tl
+        (* Options to discard: 2 arguments *)
+        | ( "-rifrom" | "-refrom" | "-rfrom"
+          | "-require-import-from" | "-require-export-from") :: _ :: _ :: tl ->
+           set_slave_opt tl
         (* We need to pass some options with one argument *)
-        | ( "-I" | "-include" | "-top" | "-topfile" | "-coqlib" | "-exclude-dir" | "-compat"
-          | "-require-import" | "-require-export" | "-require-import-from" | "-require-export-from"
-          | "-ri" | "-re" | "-rifrom" | "-refrom" | "-load-vernac-object"
-          | "-w" | "-color" | "-init-file"
-          | "-profile-ltac-cutoff" | "-main-channel" | "-control-channel" | "-mangle-names" | "-set" | "-unset"
-          | "-diffs" | "-mangle-name" | "-dump-glob" | "-bytecode-compiler" | "-native-compiler" as x) :: a :: tl ->
+        | ( "-I" | "-include" | "-top" | "-topfile" | "-coqlib" | "-exclude-dir"
+          | "-color" | "-init-file"
+          | "-profile-ltac-cutoff" | "-main-channel" | "-control-channel"
+          | "-dump-glob" | "-bytecode-compiler" | "-native-compiler" as x) :: a :: tl ->
           x :: a :: set_slave_opt tl
         (* We need to pass some options with two arguments *)
         | ( "-R" | "-Q" as x) :: a1 :: a2 :: tl ->

--- a/toplevel/usage.ml
+++ b/toplevel/usage.ml
@@ -50,10 +50,10 @@ let print_usage_common co command =
 \n  -require-export lib, -re lib\
 \n                         load and transitively import Coq library lib\
 \n                         (equivalent to Require Export lib.)\
-\n  -require-import-from root lib, -rifrom lib\
+\n  -require-import-from root lib, -rifrom root lib\
 \n                         load and import Coq library lib\
 \n                         (equivalent to From root Require Import lib.)\
-\n  -require-export-from root lib, -refrom lib\
+\n  -require-export-from root lib, -refrom root lib\
 \n                         load and transitively import Coq library lib\
 \n                         (equivalent to From root Require Export lib.)\
 \n\


### PR DESCRIPTION
**Kind:** fix.

If I understood @gares correctly on Zulip, the `-ri` and variants and the `-set` and variants do not need to be passed to the workers because they have been applied in the initial state that is passed to the workers. If this is correct, this should fix the failing `interleave_options_bad_order` test with async.