### PR TITLE
Fixes for compilation without native dynlink

### DIFF
--- a/plugins/ssrsearch/g_search.mlg
+++ b/plugins/ssrsearch/g_search.mlg
@@ -2,6 +2,8 @@
 
 (* Main prefilter *)
 
+DECLARE PLUGIN "ssrsearch_plugin"
+
 {
 
 module CoqConstr = Constr

--- a/user-contrib/Ltac2/g_ltac2.mlg
+++ b/user-contrib/Ltac2/g_ltac2.mlg
@@ -8,6 +8,8 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
+DECLARE PLUGIN "ltac2_plugin"
+
 {
 
 open Pp

--- a/vernac/mltop.ml
+++ b/vernac/mltop.ml
@@ -309,6 +309,9 @@ type ml_module_object = {
 }
 
 let add_module_digest m =
+  if not has_dynlink then
+    m, NoDigest
+  else
   try
     let file = file_of_name m in
     let path, file = System.where_in_path ~warn:false !coq_mlpath_copy file in


### PR DESCRIPTION
**Kind:** bug fix

I fell on problems when compiling without native dynlink and this PR fixes them:
- `DECLARE PLUGIN` missing for `ltac2_plugin` (note that this impacts also 8.11)
- `DECLARE PLUGIN` missing for `ssrsearch_plugin`
- making fetching digests aware of the possibility of no native dynlink

Incidentally, @coq/ci-maintainers, how easy would it be to add a regression test for configuration with `-natdynlink no`?

- [ ] Entry added in the changelog (not needed?)