### PR TITLE
Fixes #12428: extraction was dropping Extract Inlined constants from the implementation when required in the signature

### DIFF
--- a/doc/changelog/12-misc/12429-master+fix12428-extraction-inlined-signature-check.rst
+++ b/doc/changelog/12-misc/12429-master+fix12428-extraction-inlined-signature-check.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  extraction of inlined constants in modules does not any longer drop
+  the definition when the signature expects the constant to be declared
+  (`#12429 <https://github.com/coq/coq/pull/12429>`_, by Hugo Herbelin,
+  fixes `#12428 <https://github.com/coq/coq/pull/12428>`_).

--- a/plugins/extraction/haskell.ml
+++ b/plugins/extraction/haskell.ml
@@ -382,7 +382,7 @@ let rec pp_structure_elem = function
       (* for the moment we simply discard module type *)
 
 and pp_module_expr = function
-  | MEstruct (mp,sel) -> prlist_strict pp_structure_elem sel
+  | MEstruct (mp,_,sel) -> prlist_strict pp_structure_elem sel
   | MEfunctor _ -> mt ()
       (* for the moment we simply discard unapplied functors *)
   | MEident _ | MEapply _ -> assert false

--- a/plugins/extraction/json.ml
+++ b/plugins/extraction/json.ml
@@ -256,7 +256,7 @@ let rec pp_structure_elem = function
       (* for the moment we simply discard module type *)
 
 and pp_module_expr = function
-  | MEstruct (mp,sel) -> List.concat (List.map pp_structure_elem sel)
+  | MEstruct (mp,_,sel) -> List.concat (List.map pp_structure_elem sel)
   | MEfunctor _ -> []
       (* for the moment we simply discard unapplied functors *)
   | MEident _ | MEapply _ -> assert false

--- a/plugins/extraction/miniml.ml
+++ b/plugins/extraction/miniml.ml
@@ -175,7 +175,7 @@ type ml_structure_elem =
 and ml_module_expr =
   | MEident of ModPath.t
   | MEfunctor of MBId.t * ml_module_type * ml_module_expr
-  | MEstruct of ModPath.t * ml_module_structure
+  | MEstruct of ModPath.t * bool * ml_module_structure
   | MEapply of ml_module_expr * ml_module_expr
 
 and ml_module_structure = (Label.t * ml_structure_elem) list

--- a/plugins/extraction/miniml.mli
+++ b/plugins/extraction/miniml.mli
@@ -175,7 +175,7 @@ type ml_structure_elem =
 and ml_module_expr =
   | MEident of ModPath.t
   | MEfunctor of MBId.t * ml_module_type * ml_module_expr
-  | MEstruct of ModPath.t * ml_module_structure
+  | MEstruct of ModPath.t * bool * ml_module_structure
   | MEapply of ml_module_expr * ml_module_expr
 
 and ml_module_structure = (Label.t * ml_structure_elem) list

--- a/plugins/extraction/modutil.ml
+++ b/plugins/extraction/modutil.ml
@@ -64,7 +64,7 @@ let se_iter do_decl do_spec do_mp =
     | MEident mp -> do_mp mp
     | MEfunctor (_,mt,me) -> me_iter me; mt_iter mt
     | MEapply (me,me') -> me_iter me; me_iter me'
-    | MEstruct (msid, sel) -> List.iter se_iter sel
+    | MEstruct (msid, _, sel) -> List.iter se_iter sel
   in
   se_iter
 
@@ -206,7 +206,7 @@ let signature_of_structure s =
 
 let rec mtyp_of_mexpr = function
   | MEfunctor (id,ty,e) -> MTfunsig (id,ty, mtyp_of_mexpr e)
-  | MEstruct (mp,str) -> MTsig (mp, msig_of_ms str)
+  | MEstruct (mp,_,str) -> MTsig (mp, msig_of_ms str)
   | _ -> assert false
 
 
@@ -234,11 +234,10 @@ let get_decl_in_structure r struc =
             | SEmodtype m -> assert false
             | SEmodule m ->
                 let rec aux = function
-                  | MEstruct (_,sel) -> go ll sel
+                  | MEstruct (_,_,sel) -> go ll sel
                   | MEfunctor (_,_,sel) -> aux sel
                   | MEident _ | MEapply _ -> error_not_visible r
                 in aux m.ml_mod_expr
-
     in go ll sel
   with Not_found ->
     anomaly (Pp.str "reference not found in extracted structure.")
@@ -301,7 +300,7 @@ let rec optim_se top to_appear s = function
   | se :: lse -> se :: (optim_se top to_appear s lse)
 
 and optim_me to_appear s = function
-  | MEstruct (msid, lse) -> MEstruct (msid, optim_se false to_appear s lse)
+  | MEstruct (msid, all, lse) -> MEstruct (msid, all, optim_se false to_appear s lse)
   | MEident mp as me -> me
   | MEapply (me, me') ->
       MEapply (optim_me to_appear s me, optim_me to_appear s me')

--- a/plugins/extraction/scheme.ml
+++ b/plugins/extraction/scheme.ml
@@ -213,7 +213,7 @@ let rec pp_structure_elem = function
       (* for the moment we simply discard module type *)
 
 and pp_module_expr = function
-  | MEstruct (mp,sel) -> prlist_strict pp_structure_elem sel
+  | MEstruct (mp,_,sel) -> prlist_strict pp_structure_elem sel
   | MEfunctor _ -> mt ()
       (* for the moment we simply discard unapplied functors *)
   | MEident _ | MEapply _ -> assert false

--- a/test-suite/output/ExtractInlined.out
+++ b/test-suite/output/ExtractInlined.out
@@ -1,0 +1,24 @@
+
+type nat =
+| O
+| S of nat
+
+module type T =
+ sig
+  val p : nat
+
+  val n : nat
+ end
+
+module M =
+ struct
+  (** val p : nat **)
+
+  let p =
+    O
+
+  (** val n : nat **)
+
+  let n = 1
+ end
+

--- a/test-suite/output/ExtractInlined.v
+++ b/test-suite/output/ExtractInlined.v
@@ -1,0 +1,12 @@
+(* Check that inlining does not drop definition needed in signature *)
+Require Import Extraction.
+Module Type T.
+Axiom p : nat.
+Axiom n : nat.
+End T.
+Module M : T.
+Definition p := 0.
+Definition n := 1.
+End M.
+Extract Inlined Constant M.n => "1".
+Extraction M.


### PR DESCRIPTION
**Kind:** bug fix

We fix it by adding a boolean telling if an implementation is explicitly sealed behind a signature in which case we don't omit printing also the inlined constants of the implementation.

Fixes / closes #12428

Note a remaining "bug": it is not possible to inline a constant which is not visible in the interface. This is normal from the typing point of view but not from the extraction point of view.

- [X] Added / updated test-suite
- [x] Entry added in the changelog
