### PR TITLE
Fix ring/field in sections

### DIFF
--- a/interp/decls.ml
+++ b/interp/decls.ml
@@ -62,6 +62,7 @@ type logical_kind =
 type variable_data = {
   opaque:bool;
   kind:logical_kind;
+  goal_visibility:bool;
 }
 
 let vartab =
@@ -72,6 +73,7 @@ let add_variable_data id o = vartab := Id.Map.add id (o,secpath()) !vartab
 
 let variable_opacity id = let {opaque},_ = Id.Map.find id !vartab in opaque
 let variable_kind id = let {kind},_ = Id.Map.find id !vartab in kind
+let variable_goal_visibility id = let {goal_visibility},_ = Id.Map.find id !vartab in goal_visibility
 
 let variable_secpath id =
   let _, dir = Id.Map.find id !vartab in

--- a/interp/decls.mli
+++ b/interp/decls.mli
@@ -63,6 +63,7 @@ type logical_kind =
 type variable_data = {
   opaque:bool;
   kind:logical_kind;
+  goal_visibility:bool;
 }
 
 val add_variable_data : variable -> variable_data -> unit
@@ -76,3 +77,6 @@ val variable_opacity : variable -> bool
 
 (* Used in declare, very dubious *)
 val variable_exists : variable -> bool
+
+(* Used in declare*)
+val variable_goal_visibility : variable -> bool

--- a/plugins/setoid_ring/newring.ml
+++ b/plugins/setoid_ring/newring.ml
@@ -146,14 +146,14 @@ let ic_unsafe c = (*FIXME remove *)
   let sigma = Evd.from_env env in
   fst (Constrintern.interp_constr env sigma c)
 
-let decl_constant na univs c =
+let decl_constant name univs c =
   let open Constr in
   let vars = CVars.universes_of_constr c in
   let univs = UState.restrict_universe_context ~lbound:(Global.universes_lbound ()) univs vars in
   let () = DeclareUctx.declare_universe_context ~poly:false univs in
   let types = (Typeops.infer (Global.env ()) c).uj_type in
   let univs = Monomorphic_entry Univ.ContextSet.empty in
-  mkConst(declare_constant ~name:(Id.of_string na)
+  mkConst(declare_constant ~name
             ~kind:Decls.(IsProof Lemma)
             (DefinitionEntry (definition_entry ~opaque:true ~types ~univs c)))
 
@@ -581,9 +581,9 @@ let add_theory0 name (sigma, rth) eqth morphth cst_tac (pre,post) power sign div
   let lemma2 = params.(4) in
 
   let lemma1 =
-    decl_constant (Id.to_string name^"_ring_lemma1") ctx lemma1 in
+    decl_constant (Nameops.add_suffix name "_ring_lemma1") ctx lemma1 in
   let lemma2 =
-    decl_constant (Id.to_string name^"_ring_lemma2") ctx lemma2 in
+    decl_constant (Nameops.add_suffix name "_ring_lemma2") ctx lemma2 in
   let cst_tac =
     interp_cst_tac env sigma morphth kind (zero,one,add,mul,opp) cst_tac in
   let pretac =
@@ -898,15 +898,15 @@ let add_field_theory0 name fth eqth morphth cst_tac inj (pre,post) power sign od
     match inj with
       | Some thm -> mkApp(params.(8),[|EConstr.to_constr sigma thm|])
       | None -> params.(7) in
-  let lemma1 = decl_constant (Id.to_string name^"_field_lemma1")
+  let lemma1 = decl_constant (Nameops.add_suffix name "_field_lemma1")
     ctx lemma1 in
-  let lemma2 = decl_constant (Id.to_string name^"_field_lemma2")
+  let lemma2 = decl_constant (Nameops.add_suffix name"_field_lemma2")
     ctx lemma2 in
-  let lemma3 = decl_constant (Id.to_string name^"_field_lemma3")
+  let lemma3 = decl_constant (Nameops.add_suffix name "_field_lemma3")
     ctx lemma3 in
-  let lemma4 = decl_constant (Id.to_string name^"_field_lemma4")
+  let lemma4 = decl_constant (Nameops.add_suffix name "_field_lemma4")
     ctx lemma4 in
-  let cond_lemma = decl_constant (Id.to_string name^"_lemma5")
+  let cond_lemma = decl_constant (Nameops.add_suffix name "_lemma5")
     ctx cond_lemma in
   let cst_tac =
     interp_cst_tac env sigma morphth kind (zero,one,add,mul,opp) cst_tac in

--- a/test-suite/success/setoid_ring_module.v
+++ b/test-suite/success/setoid_ring_module.v
@@ -38,3 +38,15 @@ Theorem check_setoid_ring_modules :
 intros.
 ring.
 Qed.
+
+(* Check that an Add Ring definition in a section is really local *)
+
+Module Ring_in_section.
+
+Section S.
+Add Ring CoefRing1 : cRth.
+End S.
+
+Add Ring CoefRing1 : cRth.
+
+End Ring_in_section.

--- a/vernac/comAssumption.mli
+++ b/vernac/comAssumption.mli
@@ -26,6 +26,7 @@ val do_assumptions
 val declare_variable
   : coercion_flag
   -> kind:Decls.assumption_object_kind
+  -> ?goal_visibility:bool
   -> Constr.types
   -> Impargs.manual_implicits
   -> Glob_term.binding_kind

--- a/vernac/comCoercion.ml
+++ b/vernac/comCoercion.ml
@@ -356,7 +356,7 @@ let try_add_new_coercion_with_source ref ~local ~poly ~source =
 let add_coercion_hook poly { Declare.Hook.S.scope; dref; _ } =
   let open Locality in
   let local = match scope with
-  | Discharge -> assert false (* Local Coercion in section behaves like Local Definition *)
+  | Discharge _ -> assert false (* Local Coercion in section behaves like Local Definition *)
   | Global ImportNeedQualified -> true
   | Global ImportDefaultBehavior -> false
   in
@@ -369,7 +369,7 @@ let add_coercion_hook ~poly = Declare.Hook.make (add_coercion_hook poly)
 let add_subclass_hook ~poly { Declare.Hook.S.scope; dref; _ } =
   let open Locality in
   let stre = match scope with
-  | Discharge -> assert false (* Local Subclass in section behaves like Local Definition *)
+  | Discharge _ -> assert false (* Local Subclass in section behaves like Local Definition *)
   | Global ImportNeedQualified -> true
   | Global ImportDefaultBehavior -> false
   in

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -437,8 +437,8 @@ let declare_variable_core ~name ~kind ?(goal_visibility=true) d =
   Impargs.declare_var_implicits ~impl name;
   Notation.declare_ref_arguments_scope Evd.empty (GlobRef.VarRef name)
 
-let declare_variable ~name ~kind ~typ ~impl =
-  declare_variable_core ~name ~kind (SectionLocalAssum { typ; impl })
+let declare_variable ~name ~kind ?goal_visibility ~typ ~impl =
+  declare_variable_core ~name ~kind ?goal_visibility (SectionLocalAssum { typ; impl })
 
 (* Declaration messages *)
 
@@ -561,8 +561,8 @@ let declare_entry_core ~name ~scope ~kind ?hook ~obls ~impargs ~uctx entry =
   in
   let ubind = UState.universe_binders uctx in
   let dref = match scope with
-  | Locality.Discharge ->
-    let () = declare_variable_core ~name ~kind (SectionLocalDef entry) in
+  | Locality.Discharge goal_visibility ->
+    let () = declare_variable_core ~name ~kind ~goal_visibility (SectionLocalDef entry) in
     if should_suggest then Proof_using.suggest_variable (Global.env ()) name;
     Names.GlobRef.VarRef name
   | Locality.Global local ->
@@ -628,7 +628,7 @@ let warn_let_as_axiom =
 
 let declare_assumption ~name ~scope ~hook ~impargs ~uctx pe =
   let local = match scope with
-    | Locality.Discharge -> warn_let_as_axiom name; Locality.ImportNeedQualified
+    | Locality.Discharge _ -> warn_let_as_axiom name; Locality.ImportNeedQualified
     | Locality.Global local -> local
   in
   let kind = Decls.(IsAssumption Conjectural) in

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -357,6 +357,7 @@ val declare_entry
 val declare_variable
   :  name:variable
   -> kind:Decls.logical_kind
+  -> ?goal_visibility:bool
   -> typ:Constr.types
   -> impl:Glob_term.binding_kind
   -> unit

--- a/vernac/locality.ml
+++ b/vernac/locality.ml
@@ -11,7 +11,8 @@
 (** * Managing locality *)
 
 type import_status = ImportDefaultBehavior | ImportNeedQualified
-type locality = Discharge | Global of import_status
+type goal_visibility = bool
+type locality = Discharge of goal_visibility | Global of import_status
 
 let importability_of_bool = function
   | true -> ImportNeedQualified
@@ -45,7 +46,7 @@ let enforce_locality_exp locality_flag discharge =
      (* If a Let/Variable is defined outside a section, then we consider it as a local definition *)
      warn_local_declaration ();
      Global ImportNeedQualified
-  | None, DoDischarge -> Discharge
+  | None, DoDischarge -> Discharge true
   | Some true, DoDischarge -> CErrors.user_err Pp.(str "Local not allowed in this case")
   | Some false, DoDischarge -> CErrors.user_err Pp.(str "Global not allowed in this case")
 

--- a/vernac/locality.mli
+++ b/vernac/locality.mli
@@ -11,7 +11,8 @@
 (** * Managing locality *)
 
 type import_status = ImportDefaultBehavior | ImportNeedQualified
-type locality = Discharge | Global of import_status
+type goal_visibility = bool
+type locality = Discharge of goal_visibility | Global of import_status
 
 (** * Positioning locality for commands supporting discharging and export
     outside of modules *)

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -463,10 +463,12 @@ let vernac_custom_entry ~module_local s =
 (***********)
 (* Gallina *)
 
+let is_not_discharge = function Locality.Discharge _ -> false | _ -> true
+
 let check_name_freshness locality {CAst.loc;v=id} : unit =
   (* We check existence here: it's a bit late at Qed time *)
   if Nametab.exists_cci (Lib.make_path id) || Termops.is_section_variable id ||
-     locality <> Locality.Discharge && Nametab.exists_cci (Lib.make_path_except_section id)
+     is_not_discharge locality && Nametab.exists_cci (Lib.make_path_except_section id)
   then
     user_err ?loc  (Id.print id ++ str " already exists.")
 
@@ -565,7 +567,7 @@ let vernac_definition_name lid local =
     | { v = Name.Name n; loc } -> CAst.make ?loc n in
   let () =
     match local with
-    | Discharge -> Dumpglob.dump_definition lid true "var"
+    | Discharge _ -> Dumpglob.dump_definition lid true "var"
     | Global _ -> Dumpglob.dump_definition lid false "def"
   in
   lid
@@ -632,7 +634,7 @@ let vernac_assumption ~atts discharge kind l nl =
       List.iter (fun (lid, _) ->
           match scope with
             | Global _ -> Dumpglob.dump_definition lid false "ax"
-            | Discharge -> Dumpglob.dump_definition lid true "var") idl) l;
+            | Discharge _ -> Dumpglob.dump_definition lid true "var") idl) l;
   ComAssumption.do_assumptions ~poly:atts.polymorphic ~program_mode:atts.program ~scope ~kind nl l
 
 let is_polymorphic_inductive_cumulativity =


### PR DESCRIPTION
**Kind:** bug fix

This fixes the bug reported by @VincentSe at [#12409](https://github.com/coq/coq/pull/12409#issuecomment-633700593): `ring` not cleaning its auxiliary lemmas at the end of a section.

There is a drawback to the fix: it turns the auxiliary lemmas as local definitions. Thus, they appear in the local context of goals...

Has anyone another fix to propose? We could e.g. add an information to local definitions of a section telling that they should not be visible in the goal (when non dependent)?

- [X] Added / updated test-suite
- [ ] Entry added in the changelog