### PR TITLE
Fix #12442: Confusing error message when the intro pattern of "apply in" fails

### DIFF
--- a/test-suite/output/bug12442.out
+++ b/test-suite/output/bug12442.out
@@ -1,0 +1,6 @@
+The command has indeed failed with message:
+No product even after head-reduction.
+The command has indeed failed with message:
+Not an inductive product.
+The command has indeed failed with message:
+Not an inductive product.

--- a/test-suite/output/bug12442.v
+++ b/test-suite/output/bug12442.v
@@ -1,0 +1,10 @@
+Parameter A B : Prop.
+Axiom P : inhabited (A -> B).
+
+Goal A -> True.
+Proof.
+  Fail intros ?%P ?.
+  Fail intros []%P.
+  intro a.
+  Fail apply P in a as [].
+Abort.


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** bug fix


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #12442


<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [x] Added / updated test-suite
<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->

