### PR TITLE
Fix version switcher when building with Dune.

### DIFF
--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -214,11 +214,12 @@ html_context = {
     'conf_py_path': '/doc/sphinx/',
     # Versions and downloads listed in the versions menu (see _templates/versions.html)
     'versions': [
-        ("master", "https://coq.github.io/doc/master/refman/"),
+        ("dev", "https://coq.github.io/doc/master/refman/"),
         ("stable", "https://coq.inria.fr/distrib/current/refman/"),
-        ("v8.11", "https://coq.github.io/doc/v8.11/refman/"),
-        ("v8.10", "https://coq.github.io/doc/v8.10/refman/"),
-        ("v8.9", "https://coq.github.io/doc/v8.9/refman/"),
+        ("v8.12", "https://coq.github.io/doc/v8.12/refman/"),
+        ("8.11", "https://coq.inria.fr/distrib/V8.11.2/refman/"),
+        ("8.10", "https://coq.inria.fr/distrib/V8.10.2/refman/"),
+        ("8.9", "https://coq.inria.fr/distrib/V8.9.1/refman/"),
         ("8.8", "https://coq.inria.fr/distrib/V8.8.2/refman/"),
         ("8.7", "https://coq.inria.fr/distrib/V8.7.2/refman/"),
         ("8.6", "https://coq.inria.fr/distrib/V8.6.1/refman/"),

--- a/doc/sphinx/dune
+++ b/doc/sphinx/dune
@@ -1,4 +1,4 @@
-(dirs :standard _static)
+(dirs :standard _static _templates)
 
 (rule
  (targets README.gen.rst)


### PR DESCRIPTION
Closes #12395.

@ejgallego I don't understand why Dune ignored the sub-directory named `_templates`. I didn't find any doc of this being an expected behavior. Should I report a bug to Dune?