### PR TITLE
Match only a single line as the coqtop prompt in coqtop:: directive

### DIFF
--- a/doc/tools/coqrst/repl/coqtop.py
+++ b/doc/tools/coqrst/repl/coqtop.py
@@ -39,7 +39,7 @@ class CoqTop:
     confuse it).
     """
 
-    COQTOP_PROMPT = re.compile("\r\n[^< ]+ < ")
+    COQTOP_PROMPT = re.compile("\r\n[^< \r\n]+ < ")
 
     def __init__(self, coqtop_bin=None, color=False, args=None) -> str:
         """Configure a coqtop instance (but don't start it yet).


### PR DESCRIPTION
The previous expression was including some expected output.

For example, `idtac "x"; idtac "y".` generates this output in coqtop:

```
x
y

Unnamed_thm < 
```

but the regex match for the prompt incorrectly included the second line (`after` below):

```
expect =  'x'
after = '

y

Unnamed_thm < '
```

Fixes #12435
