### PR TITLE
[sphinx] Fix regexp used in coqdomain.CoqtopBlocksTransform.split_lines

### DIFF
--- a/doc/tools/coqrst/coqdomain.py
+++ b/doc/tools/coqrst/coqdomain.py
@@ -923,12 +923,32 @@ class CoqtopBlocksTransform(Transform):
 
     @staticmethod
     def split_lines(source):
-        """Split Coq input in chunks
+        r"""Split Coq input in chunks
 
         A chunk is a minimal sequence of consecutive lines of the input that
         ends with a '.'
+
+        >>> split_lines('A.\nB.''')
+        ['A.', 'B.']
+
+        >>> split_lines('A.\n\nB.''')
+        ['A.', '\nB.']
+
+        >>> split_lines('A.\n\nB.\n''')
+        ['A.', '\nB.']
+
+        >>> split_lines("SearchPattern (_ + _ = _ + _).\n"
+        ...             "SearchPattern (nat -> bool).\n"
+        ...             "SearchPattern (forall l : list _, _ l l).")
+        ... # doctest: +NORMALIZE_WHITESPACE
+        ['SearchPattern (_ + _ = _ + _).',
+         'SearchPattern (nat -> bool).',
+         'SearchPattern (forall l : list _, _ l l).']
+
+        >>> split_lines('SearchHead le.\nSearchHead (@eq bool).')
+        ['SearchHead le.', 'SearchHead (@eq bool).']
         """
-        return re.split(r"(?<=(?<!\.)\.)\s+\n", source)
+        return re.split(r"(?<=(?<!\.)\.)\n", source.strip())
 
     @staticmethod
     def parse_options(node):


### PR DESCRIPTION
**Kind:** bug fix / infrastructure.

Fixes / closes #12305 

This is the code I posted in #12305 ; @Zimmi48, you wrote:

> I tested the regexp proposed by @cpitclaudel but it doesn't seem to fix the issue of consecutive lines not being split.

Can you point to specific examples?  I think I'm missing something.