### PR TITLE
Pin lablgtk to an earlier version.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -79,12 +79,13 @@ jobs:
       opam switch set ocaml-base-compiler.$COMPILER
       eval $(opam env)
       opam update
-      opam install -j "$NJOBS" num ocamlfind${FINDLIB_VER} ounit lablgtk3-sourceview3
+      opam install -j "$NJOBS" num ocamlfind${FINDLIB_VER} ounit lablgtk3-sourceview3${LABLGTK_VER}
       opam list
     displayName: 'Install OCaml dependencies'
     env:
       COMPILER: "4.10.0"
       FINDLIB_VER: ".1.8.1"
+      LABLGTK_VER: ".3.0.beta8"
       OPAMYES: "true"
 
   - script: |


### PR DESCRIPTION
Tentative compatibility fix for macOS 10.11.1.

Since the installers for 8.11.1 and `v8.12` do not work on @herbelin's machine, it might be an issue with the latest lablgtk release (3.1.0) since this is the only thing that wasn't pinned in our macOS packaging job.

This PR attempts to pin lablgtk to an earlier version to see if this fixes the problem.

This is not a long-term solution: the actual source of the issue should be identified and worked around, but this should be good enough (if it works) for 8.12+beta1.