### PR TITLE
Non-global terms declared as hints now generate a proxy constant.

### DIFF
--- a/doc/changelog/07-commands-and-options/12493-declare-constr-hint.rst
+++ b/doc/changelog/07-commands-and-options/12493-declare-constr-hint.rst
@@ -1,0 +1,7 @@
+- **Changed:**
+  Declaring a hint which is not a global reference now generates
+  a constant on the fly. This behaviour can be tweaked by
+  unsetting the deprecated :flag:`Declare Hint Proxy` flag
+  (`#12493 <https://github.com/coq/coq/pull/12493>`_,
+  fixes `#11970 <https://github.com/coq/coq/issues/11970>`_,
+  by Pierre-Marie Pédrot).

--- a/doc/sphinx/proofs/automatic-tactics/auto.rst
+++ b/doc/sphinx/proofs/automatic-tactics/auto.rst
@@ -412,7 +412,9 @@ Creating Hints
 
       :n:`@one_term`
         Permits declaring a hint without declaring a new
-        constant first, but this is not recommended.
+        constant first, but this is not recommended. The command first declares
+        the term as a local definition and then performs the above with the resulting
+        global reference.
 
          .. warn:: Declaring arbitrary terms as hints is fragile; it is recommended to declare a toplevel constant instead
             :undocumented:
@@ -630,6 +632,13 @@ Creating Hints
 
    This command displays all hints from database :n:`@ident`.
 
+.. flag:: Declare Hint Proxy
+
+   .. deprecated:: 8.15
+
+   When unset, the :cmd:`Hint Resolve` and :cmd:`Hint Immediate` commands will not
+   declare a local definition if given terms that are not qualified
+   identifiers as arguments.
 
 Hint databases defined in the Coq standard library
 --------------------------------------------------

--- a/test-suite/ssr/absevarprop.v
+++ b/test-suite/ssr/absevarprop.v
@@ -85,12 +85,14 @@ Definition R1 := fun (x : nat) (p : P x) m (q : P (x+1)) (r : Q x p) => m > 0.
 Inductive myEx1 : Type :=
   ExI1 : forall n (pn : P n) pn' (q : Q n pn), R1 n pn n pn' q -> myEx1.
 
-Hint Resolve (Q1 P1) : SSR.
+Definition my_hint := Q1 P1.
+
+Hint Resolve my_hint : SSR.
 
 (* tests that goals in prop are solved in the right order, propagating instantiations,
    thus the goal Q 1 ?p1 is faced by trivial after ?p1, and is thus evar free *)
 Lemma testmE14 : myEx1.
 Proof.
 apply: ExI1 1 _ _ _ _.
-match goal with |- is_true (R1 1 P1 1 P11 (Q1 P1)) => done | _ => fail end.
+match goal with |- is_true (R1 1 P1 1 P11 my_hint) => done | _ => fail end.
 Qed.

--- a/theories/Compat/Coq814.v
+++ b/theories/Compat/Coq814.v
@@ -11,3 +11,6 @@
 (** Compatibility file for making Coq act similar to Coq v8.14 *)
 
 Require Export Coq.Compat.Coq815.
+
+Set Warnings "-deprecated-option".
+Unset Declare Hint Proxy.


### PR DESCRIPTION
This can be tweaked via the Declare Hint Proxy option, which is deprecated.

Fixes #11970.

- [x] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
