### PR TITLE
Clean future goals

### DIFF
--- a/clib/option.ml
+++ b/clib/option.ml
@@ -55,6 +55,8 @@ let make x = Some x
 (** [bind x f] is [f y] if [x] is [Some y] and [None] otherwise *)
 let bind x f = match x with Some y -> f y | None -> None
 
+let filter f x = bind x (fun v -> if f v then x else None)
+
 (** [init b x] returns [Some x] if [b] is [true] and [None] otherwise. *)
 let init b x =
   if b then

--- a/clib/option.mli
+++ b/clib/option.mli
@@ -46,6 +46,9 @@ val make : 'a -> 'a option
 (** [bind x f] is [f y] if [x] is [Some y] and [None] otherwise *)
 val bind : 'a option -> ('a -> 'b option) -> 'b option
 
+(** [filter f x] is [x] if [x] [Some y] and [f y] is true, [None] otherwise *)
+val filter : ('a -> bool) -> 'a option -> 'a option
+
 (** [init b x] returns [Some x] if [b] is [true] and [None] otherwise. *)
 val init : bool -> 'a -> 'a option
 

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -522,7 +522,7 @@ let restrict_evar evd evk filter ?src candidates =
      let evd, evk' = Evd.restrict evk filter ?candidates ?src evd in
      (* Mark new evar as future goal, removing previous one,
         circumventing Proofview.advance but making Proof.run_tactic catch these. *)
-     let evd = Evd.filter_future_goals (fun evk' -> not (Evar.equal evk evk')) evd in
+     let evd = Evd.remove_future_goal evd evk in
      (Evd.declare_future_goal evk' evd, evk')
 
 let rec check_and_clear_in_constr env evdref err ids global c =

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -522,9 +522,7 @@ let restrict_evar evd evk filter ?src candidates =
      let evd, evk' = Evd.restrict evk filter ?candidates ?src evd in
      (* Mark new evar as future goal, removing previous one,
         circumventing Proofview.advance but making Proof.run_tactic catch these. *)
-     let future_goals = Evd.save_future_goals evd in
-     let future_goals = Evd.filter_future_goals (fun evk' -> not (Evar.equal evk evk')) future_goals in
-     let evd = Evd.restore_future_goals evd future_goals in
+     let evd = Evd.filter_future_goals (fun evk' -> not (Evar.equal evk evk')) evd in
      (Evd.declare_future_goal evk' evd, evk')
 
 let rec check_and_clear_in_constr env evdref err ids global c =

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -347,13 +347,11 @@ val drop_side_effects : evar_map -> evar_map
 
 (** {5 Future goals} *)
 
-type goal_kind = ToShelve
-
-val declare_future_goal : ?tag:goal_kind -> Evar.t -> evar_map -> evar_map
+val declare_future_goal : ?shelve:bool -> Evar.t -> evar_map -> evar_map
 (** Adds an existential variable to the list of future goals. For
     internal uses only. *)
 
-val declare_principal_goal : ?tag:goal_kind -> Evar.t -> evar_map -> evar_map
+val declare_principal_goal : ?shelve:bool -> Evar.t -> evar_map -> evar_map
 (** Adds an existential variable to the list of future goals and make
     it principal. Only one existential variable can be made principal, an
     error is raised otherwise. For internal uses only. *)
@@ -366,29 +364,30 @@ val principal_future_goal : evar_map -> Evar.t option
 (** Retrieves the name of the principal existential variable if there
     is one. Used by the [refine] primitive of the tactic engine. *)
 
-type future_goals
+type future_goals = {
+  future_comb : Evar.t list;
+  future_shelf : Evar.t list;
+  future_principal : Evar.t option; (** if [Some e], [e] must be
+                                        contained in
+                                        [future_comb]. The evar
+                                        [e] will inherit
+                                        properties (now: the
+                                        name) of the evar which
+                                        will be instantiated with
+                                        a term containing [e]. *)
+}
 
-val save_future_goals : evar_map -> future_goals
-(** Retrieves the list of future goals including the principal future
-    goal. Used by the [refine] primitive of the tactic engine. *)
+val push_future_goals : evar_map -> evar_map
 
-val reset_future_goals : evar_map -> evar_map
-(** Clears the list of future goals (as well as the principal future
-    goal). Used by the [refine] primitive of the tactic engine. *)
-
-val restore_future_goals : evar_map -> future_goals -> evar_map
-(** Sets the future goals (including the principal future goal) to a
-    previous value. Intended to be used after a local list of future
-    goals has been consumed. Used by the [refine] primitive of the
-    tactic engine. *)
+val pop_future_goals : evar_map -> future_goals * evar_map
 
 val fold_future_goals : (evar_map -> Evar.t -> evar_map) -> evar_map -> evar_map
 (** Fold future goals *)
 
-val map_filter_future_goals : (Evar.t -> Evar.t option) -> evar_map -> evar_map
+val map_filter_future_goals : (Evar.t -> Evar.t option) -> future_goals -> future_goals
 (** Applies a function on the future goals *)
 
-val filter_future_goals : (Evar.t -> bool) -> evar_map -> evar_map
+val filter_future_goals : (Evar.t -> bool) -> future_goals -> future_goals
 (** Applies a filter on the future goals *)
 
 val dispatch_future_goals : evar_map -> Evar.t list * Evar.t list * Evar.t option
@@ -397,6 +396,8 @@ val dispatch_future_goals : evar_map -> Evar.t list * Evar.t list * Evar.t optio
 
 val shelve_on_future_goals : Evar.t list -> evar_map -> evar_map
 (** Push goals on the shelve of future goals *)
+
+val remove_future_goal : evar_map -> Evar.t -> evar_map
 
 val give_up : Evar.t -> evar_map -> evar_map
 

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -167,6 +167,10 @@ val has_undefined : evar_map -> bool
 (** [has_undefined sigma] is [true] if and only if
     there are uninstantiated evars in [sigma]. *)
 
+val has_given_up : evar_map -> bool
+(** [has_given_up sigma] is [true] if and only if
+    there are given up evars in [sigma]. *)
+
 val new_evar : evar_map ->
   ?name:Id.t -> ?typeclass_candidate:bool -> evar_info -> evar_map * Evar.t
 (** Creates a fresh evar mapping to the given information. *)
@@ -343,7 +347,7 @@ val drop_side_effects : evar_map -> evar_map
 
 (** {5 Future goals} *)
 
-type goal_kind = ToShelve | ToGiveUp
+type goal_kind = ToShelve
 
 val declare_future_goal : ?tag:goal_kind -> Evar.t -> evar_map -> evar_map
 (** Adds an existential variable to the list of future goals. For
@@ -387,15 +391,16 @@ val map_filter_future_goals : (Evar.t -> Evar.t option) -> evar_map -> evar_map
 val filter_future_goals : (Evar.t -> bool) -> evar_map -> evar_map
 (** Applies a filter on the future goals *)
 
-val dispatch_future_goals : evar_map -> Evar.t list * Evar.t list * Evar.t list * Evar.t option
+val dispatch_future_goals : evar_map -> Evar.t list * Evar.t list * Evar.t option
 (** Returns the future_goals dispatched into regular, shelved, given_up
    goals; last argument is the goal tagged as principal if any *)
 
-val extract_given_up_future_goals : evar_map -> Evar.t list * Evar.t list
-(** An ad hoc variant for Proof.proof; not for general use *)
-
 val shelve_on_future_goals : Evar.t list -> evar_map -> evar_map
 (** Push goals on the shelve of future goals *)
+
+val give_up : Evar.t -> evar_map -> evar_map
+
+val given_up : evar_map -> Evar.Set.t
 
 (** {5 Sort variables}
 

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -356,43 +356,36 @@ val declare_principal_goal : ?shelve:bool -> Evar.t -> evar_map -> evar_map
     it principal. Only one existential variable can be made principal, an
     error is raised otherwise. For internal uses only. *)
 
-val future_goals : evar_map -> Evar.t list
-(** Retrieves the list of future goals. Used by the [refine] primitive
-    of the tactic engine. *)
+module FutureGoals : sig
 
-val principal_future_goal : evar_map -> Evar.t option
-(** Retrieves the name of the principal existential variable if there
-    is one. Used by the [refine] primitive of the tactic engine. *)
+  type t = private {
+    comb : Evar.t list;
+    shelf : Evar.t list;
+    principal : Evar.t option; (** if [Some e], [e] must be
+                                   contained in
+                                   [future_comb]. The evar
+                                   [e] will inherit
+                                   properties (now: the
+                                   name) of the evar which
+                                   will be instantiated with
+                                   a term containing [e]. *)
+  }
 
-type future_goals = {
-  future_comb : Evar.t list;
-  future_shelf : Evar.t list;
-  future_principal : Evar.t option; (** if [Some e], [e] must be
-                                        contained in
-                                        [future_comb]. The evar
-                                        [e] will inherit
-                                        properties (now: the
-                                        name) of the evar which
-                                        will be instantiated with
-                                        a term containing [e]. *)
-}
+  val map_filter : (Evar.t -> Evar.t option) -> t -> t
+  (** Applies a function on the future goals *)
+
+  val filter : (Evar.t -> bool) -> t -> t
+  (** Applies a filter on the future goals *)
+
+end
 
 val push_future_goals : evar_map -> evar_map
 
-val pop_future_goals : evar_map -> future_goals * evar_map
+val pop_future_goals : evar_map -> FutureGoals.t * evar_map
 
 val fold_future_goals : (evar_map -> Evar.t -> evar_map) -> evar_map -> evar_map
+
 (** Fold future goals *)
-
-val map_filter_future_goals : (Evar.t -> Evar.t option) -> future_goals -> future_goals
-(** Applies a function on the future goals *)
-
-val filter_future_goals : (Evar.t -> bool) -> future_goals -> future_goals
-(** Applies a filter on the future goals *)
-
-val dispatch_future_goals : evar_map -> Evar.t list * Evar.t list * Evar.t option
-(** Returns the future_goals dispatched into regular, shelved, given_up
-   goals; last argument is the goal tagged as principal if any *)
 
 val shelve_on_future_goals : Evar.t list -> evar_map -> evar_map
 (** Push goals on the shelve of future goals *)

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -378,23 +378,23 @@ val restore_future_goals : evar_map -> future_goals -> evar_map
     goals has been consumed. Used by the [refine] primitive of the
     tactic engine. *)
 
-val fold_future_goals : (evar_map -> Evar.t -> evar_map) -> evar_map -> future_goals -> evar_map
+val fold_future_goals : (evar_map -> Evar.t -> evar_map) -> evar_map -> evar_map
 (** Fold future goals *)
 
-val map_filter_future_goals : (Evar.t -> Evar.t option) -> future_goals -> future_goals
+val map_filter_future_goals : (Evar.t -> Evar.t option) -> evar_map -> evar_map
 (** Applies a function on the future goals *)
 
-val filter_future_goals : (Evar.t -> bool) -> future_goals -> future_goals
+val filter_future_goals : (Evar.t -> bool) -> evar_map -> evar_map
 (** Applies a filter on the future goals *)
 
-val dispatch_future_goals : future_goals -> Evar.t list * Evar.t list * Evar.t list * Evar.t option
+val dispatch_future_goals : evar_map -> Evar.t list * Evar.t list * Evar.t list * Evar.t option
 (** Returns the future_goals dispatched into regular, shelved, given_up
    goals; last argument is the goal tagged as principal if any *)
 
-val extract_given_up_future_goals : future_goals -> Evar.t list * Evar.t list
+val extract_given_up_future_goals : evar_map -> Evar.t list * Evar.t list
 (** An ad hoc variant for Proof.proof; not for general use *)
 
-val shelve_on_future_goals : Evar.t list -> future_goals -> future_goals
+val shelve_on_future_goals : Evar.t list -> evar_map -> evar_map
 (** Push goals on the shelve of future goals *)
 
 (** {5 Sort variables}

--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -759,7 +759,7 @@ let with_shelf tac =
   (* and thus considered as to shelve, as in Proof.run_tactic *)
   let fgl, sigma = Evd.pop_future_goals sigma in
   (* Ensure we mark and return only unsolved goals *)
-  let gls' = CList.rev_append fgl.Evd.future_shelf (CList.rev_append fgl.Evd.future_comb gls) in
+  let gls' = CList.rev_append fgl.Evd.FutureGoals.shelf (CList.rev_append fgl.Evd.FutureGoals.comb gls) in
   let gls' = undefined_evars sigma gls' in
   let sigma = mark_in_evm ~goal:false sigma gls' in
   let npv = { npv with shelf; solution = sigma } in

--- a/engine/proofview.mli
+++ b/engine/proofview.mli
@@ -162,7 +162,7 @@ val apply
   -> 'a tactic
   -> proofview
   -> 'a * proofview
-       * (bool*Evar.t list*Evar.t list)
+       * (bool*Evar.t list)
        * Proofview_monad.Info.tree
 
 (** {7 Monadic primitives} *)
@@ -469,9 +469,6 @@ module Unsafe : sig
 
   (** [tclPUTSHELF] appends goals to the shelf. *)
   val tclPUTSHELF : Evar.t list -> unit tactic
-
-  (** [tclPUTGIVENUP] add an given up goal. *)
-  val tclPUTGIVENUP : Evar.t list -> unit tactic
 
   (** Sets the evar universe context. *)
   val tclEVARUNIVCONTEXT : UState.t -> unit tactic

--- a/engine/proofview.mli
+++ b/engine/proofview.mli
@@ -474,7 +474,7 @@ module Unsafe : sig
   val tclEVARUNIVCONTEXT : UState.t -> unit tactic
 
   (** Clears the future goals store in the proof view. *)
-  val reset_future_goals : proofview -> proofview
+  val push_future_goals : proofview -> proofview
 
   (** Give the evars the status of a goal (changes their source location
       and makes them unresolvable for type classes. *)

--- a/engine/proofview_monad.ml
+++ b/engine/proofview_monad.ml
@@ -180,10 +180,10 @@ module P = struct
   type e = { trace: bool; name : Names.Id.t; poly : bool }
 
   (** Status (safe/unsafe) * shelved goals * given up *)
-  type w = bool * goal list
+  type w = bool
 
-  let wunit = true , []
-  let wprod (b1, g1) (b2, g2) = b1 && b2 , g1@g2
+  let wunit = true
+  let wprod b1 b2 = b1 && b2
 
   type u = Info.state
 
@@ -235,7 +235,7 @@ module Env : State with type t := Environ.env = struct
 end
 
 module Status : Writer with type t := bool = struct
-  let put s = Logical.put (s, [])
+  let put s = Logical.put s
 end
 
 module Shelf : State with type t = goal list = struct
@@ -244,12 +244,6 @@ module Shelf : State with type t = goal list = struct
   let get = Logical.map (fun {shelf} -> shelf) Pv.get
   let set c = Pv.modify (fun pv -> { pv with shelf = c })
   let modify f = Pv.modify (fun pv -> { pv with shelf = f pv.shelf })
-end
-
-module Giveup : Writer with type t = goal list = struct
-    (* spiwack: I don't know why I cannot substitute ([:=]) [t] with a type expression. *)
-  type t = goal list
-  let put gs = Logical.put (true, gs)
 end
 
 (** Lens and utilities pertaining to the info trace *)

--- a/engine/proofview_monad.mli
+++ b/engine/proofview_monad.mli
@@ -92,7 +92,7 @@ module P : sig
   type s = proofview * Environ.env
 
   (** Status (safe/unsafe) * given up *)
-  type w = bool * goal list
+  type w = bool
 
   val wunit : w
   val wprod : w -> w -> w
@@ -140,10 +140,6 @@ module Status : Writer with type t := bool
 (** Lens to the list of goals which have been shelved during the
     execution of the tactic. *)
 module Shelf : State with type t = goal list
-
-(** Lens to the list of goals which were given up during the execution
-    of the tactic. *)
-module Giveup : Writer with type t = goal list
 
 (** Lens and utilities pertaining to the info trace *)
 module InfoL : sig

--- a/ide/coqide/idetop.ml
+++ b/ide/coqide/idetop.ml
@@ -220,12 +220,12 @@ let process_goal_diffs diff_goal_map oldp nsigma ng =
   let (hyps_pp_list, concl_pp) = Proof_diffs.diff_goal_ide og_s ng nsigma in
   { Interface.goal_hyp = hyps_pp_list; Interface.goal_ccl = concl_pp; Interface.goal_id = Goal.uid ng }
 
-let export_pre_goals Proof.{ sigma; goals; stack; shelf; given_up } process =
+let export_pre_goals Proof.{ sigma; goals; stack; shelf } process =
   let process = List.map (process sigma) in
   { Interface.fg_goals       = process goals
   ; Interface.bg_goals       = List.(map (fun (lg,rg) -> process lg, process rg)) stack
   ; Interface.shelved_goals  = process shelf
-  ; Interface.given_up_goals = process given_up
+  ; Interface.given_up_goals = process (Evar.Set.elements @@ Evd.given_up sigma)
   }
 
 let goals () =

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -780,17 +780,18 @@ let pr_open_subgoals_diff ?(quiet=false) ?(diffs=false) ?oproof proof =
      straightforward, but seriously, [Proof.proof] should return
      [evar_info]-s instead. *)
   let p = proof in
-  let Proof.{goals; stack; shelf; given_up; sigma} = Proof.data p in
+  let Proof.{goals; stack; shelf; sigma} = Proof.data p in
+  let given_up = Evd.given_up sigma in
   let stack = List.map (fun (l,r) -> List.length l + List.length r) stack in
   let seeds = Proof.V82.top_evars p in
   begin match goals with
   | [] -> let { Evd.it = bgoals ; sigma = bsigma } = Proof.V82.background_subgoals p in
           begin match bgoals,shelf,given_up with
-          | [] , [] , [] -> pr_subgoals None sigma ~seeds ~shelf ~stack ~unfocused:[] ~goals
+          | [] , [] , g when Evar.Set.is_empty g -> pr_subgoals None sigma ~seeds ~shelf ~stack ~unfocused:[] ~goals
           | [] , [] , _ ->
              Feedback.msg_info (str "No more subgoals, but there are some goals you gave up:");
              fnl ()
-            ++ pr_subgoals ~pr_first:false None bsigma ~seeds ~shelf:[] ~stack:[] ~unfocused:[] ~goals:given_up
+            ++ pr_subgoals ~pr_first:false None bsigma ~seeds ~shelf:[] ~stack:[] ~unfocused:[] ~goals:(Evar.Set.elements given_up)
             ++ fnl () ++ str "You need to go back and solve them."
           | [] , _ , _ ->
             Feedback.msg_info (str "All the remaining goals are on the shelf.");

--- a/proofs/goal.ml
+++ b/proofs/goal.ml
@@ -56,18 +56,12 @@ module V82 = struct
        be shelved. It must not appear as a future_goal, so the future
        goals are restored to their initial value after the evar is
        created. *)
+    let evars = Evd.push_future_goals evars in
     let inst = EConstr.identity_subst_val hyps in
-    let evi = { Evd.evar_hyps = hyps;
-                Evd.evar_concl = concl;
-                Evd.evar_filter = Evd.Filter.identity;
-                Evd.evar_abstract_arguments = Evd.Abstraction.identity;
-                Evd.evar_body = Evd.Evar_empty;
-                Evd.evar_source = (Loc.tag Evar_kinds.GoalEvar);
-                Evd.evar_candidates = None;
-                Evd.evar_identity = Evd.Identity.make inst;
-              }
+    let (evars,evk) =
+      Evarutil.new_pure_evar ~src:(Loc.tag Evar_kinds.GoalEvar) ~typeclass_candidate:false ~identity:inst hyps evars concl
     in
-    let (evars, evk) = Evd.new_evar evars ~typeclass_candidate:false evi in
+    let _, evars = Evd.pop_future_goals evars in
     let ev = EConstr.mkEvar (evk,inst) in
     (evk, ev, evars)
 

--- a/proofs/goal.ml
+++ b/proofs/goal.ml
@@ -56,12 +56,18 @@ module V82 = struct
        be shelved. It must not appear as a future_goal, so the future
        goals are restored to their initial value after the evar is
        created. *)
-    let prev_future_goals = Evd.save_future_goals evars in
     let inst = EConstr.identity_subst_val hyps in
-    let (evars, evk) =
-      Evarutil.new_pure_evar ~src:(Loc.tag Evar_kinds.GoalEvar) ~typeclass_candidate:false ~identity:inst hyps evars concl
+    let evi = { Evd.evar_hyps = hyps;
+                Evd.evar_concl = concl;
+                Evd.evar_filter = Evd.Filter.identity;
+                Evd.evar_abstract_arguments = Evd.Abstraction.identity;
+                Evd.evar_body = Evd.Evar_empty;
+                Evd.evar_source = (Loc.tag Evar_kinds.GoalEvar);
+                Evd.evar_candidates = None;
+                Evd.evar_identity = Evd.Identity.make inst;
+              }
     in
-    let evars = Evd.restore_future_goals evars prev_future_goals in
+    let (evars, evk) = Evd.new_evar evars ~typeclass_candidate:false evi in
     let ev = EConstr.mkEvar (evk,inst) in
     (evk, ev, evars)
 

--- a/proofs/goal.mli
+++ b/proofs/goal.mli
@@ -65,4 +65,4 @@ module V82 : sig
 
 end
 
-module Set : sig include Set.S with type elt = goal end
+module Set = Evar.Set

--- a/proofs/proof.ml
+++ b/proofs/proof.ml
@@ -370,8 +370,8 @@ let run_tactic env tac pr =
     (* Already solved goals are not to be counted as shelved. Nor are
       they to be marked as unresolvable. *)
     let retrieved, sigma = Evd.pop_future_goals sigma in
-    let retrieved = Evd.filter_future_goals (Evd.is_undefined sigma) retrieved in
-    let retrieved = List.rev_append retrieved.Evd.future_shelf (List.rev retrieved.Evd.future_comb) in
+    let retrieved = Evd.FutureGoals.filter (Evd.is_undefined sigma) retrieved in
+    let retrieved = List.rev_append retrieved.Evd.FutureGoals.shelf (List.rev retrieved.Evd.FutureGoals.comb) in
     let sigma = Proofview.Unsafe.mark_as_goals sigma retrieved in
     Proofview.Unsafe.tclEVARS sigma >>= fun () ->
     Proofview.tclUNIT (result,retrieved)

--- a/proofs/proof.ml
+++ b/proofs/proof.ml
@@ -373,7 +373,7 @@ let run_tactic env tac pr =
     Proofview.tclEVARMAP >>= fun sigma ->
     (* Already solved goals are not to be counted as shelved. Nor are
       they to be marked as unresolvable. *)
-    let retrieved = Evd.filter_future_goals (Evd.is_undefined sigma) (Evd.save_future_goals sigma) in
+    let retrieved = Evd.filter_future_goals (Evd.is_undefined sigma) sigma in
     let retrieved,retrieved_given_up = Evd.extract_given_up_future_goals retrieved in
     (* Check that retrieved given up is empty *)
     if not (List.is_empty retrieved_given_up) then

--- a/proofs/proof.mli
+++ b/proofs/proof.mli
@@ -45,8 +45,6 @@ type data =
   (** A representation of the focus stack *)
   ; shelf : Evar.t list
   (** A representation of the shelf  *)
-  ; given_up : Evar.t list
-  (** A representation of the given up goals  *)
   ; name : Names.Id.t
   (** The name of the theorem whose proof is being constructed *)
   ; poly : bool;

--- a/proofs/refine.ml
+++ b/proofs/refine.ml
@@ -75,7 +75,7 @@ let generic_refine ~typecheck f gl =
   let sigma = Evd.restore_future_goals sigma prev_future_goals in
   (* Select the goals *)
   let evs = Evd.map_filter_future_goals (Proofview.Unsafe.advance sigma) sigma' in
-  let comb,shelf,given_up,evkmain = Evd.dispatch_future_goals evs in
+  let comb,shelf,evkmain = Evd.dispatch_future_goals evs in
   (* Proceed to the refinement *)
   let sigma = match Proofview.Unsafe.advance sigma self with
   | None ->
@@ -102,7 +102,6 @@ let generic_refine ~typecheck f gl =
   Proofview.Unsafe.tclEVARS sigma <*>
   Proofview.Unsafe.tclSETGOALS comb <*>
   Proofview.Unsafe.tclPUTSHELF shelf <*>
-  Proofview.Unsafe.tclPUTGIVENUP given_up <*>
   Proofview.tclUNIT v
   end
 

--- a/stm/proofBlockDelimiter.ml
+++ b/stm/proofBlockDelimiter.ml
@@ -51,8 +51,8 @@ let is_focused_goal_simple ~doc id =
   | `Valid (Some { Vernacstate.lemmas }) ->
     Option.cata (Vernacstate.LemmaStack.with_top ~f:(fun proof ->
         let proof = Declare.Proof.get proof in
-        let Proof.{ goals=focused; stack=r1; shelf=r2; given_up=r3; sigma } = Proof.data proof in
-        let rest = List.(flatten (map (fun (x,y) -> x @ y) r1)) @ r2 @ r3 in
+        let Proof.{ goals=focused; stack=r1; shelf=r2; sigma } = Proof.data proof in
+        let rest = List.(flatten (map (fun (x,y) -> x @ y) r1)) @ r2 @ (Evar.Set.elements @@ Evd.given_up sigma) in
         if List.for_all (fun x -> simple_goal sigma x rest) focused
         then `Simple focused
         else `Not)) `Not lemmas

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -934,7 +934,6 @@ module Search = struct
        let tac = tac <*> Proofview.Unsafe.tclGETGOALS >>=
          fun stuck -> Proofview.shelve_goals (List.map Proofview_monad.drop_state stuck) in
        let evm = Evd.set_typeclass_evars evm Evar.Set.empty in
-       let fgoals = Evd.save_future_goals evm in
        let _, pv = Proofview.init evm [] in
        let pv = Proofview.unshelve goalsl pv in
        try
@@ -956,7 +955,8 @@ module Search = struct
                          (str "leaking evar " ++ int (Evar.repr ev) ++
                             spc () ++ pr_ev evm' ev);
                      acc && okev) evm' true);
-           let fgoals = Evd.shelve_on_future_goals shelved fgoals in
+           let evm = Evd.shelve_on_future_goals shelved evm in
+           let fgoals = Evd.save_future_goals evm in
            let evm' = Evd.restore_future_goals evm' fgoals in
            let nongoals' =
              Evar.Set.fold (fun ev acc -> match Evarutil.advance evm' ev with

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -967,9 +967,7 @@ module Search = struct
            let evm' = Evd.set_typeclass_evars evm' nongoals' in
              Some evm'
         in
-        let (), pv', (unsafe, shelved, gaveup), _ = Proofview.apply ~name ~poly env tac pv in
-        if not (List.is_empty gaveup) then
-          CErrors.anomaly (Pp.str "run_on_evars not assumed to apply tactics generating given up goals.");
+        let (), pv', (unsafe, shelved), _ = Proofview.apply ~name ~poly env tac pv in
         if Proofview.finished pv' then finish pv' shelved
         else raise Not_found
        with Logic_monad.TacticFailure _ -> raise Not_found

--- a/test-suite/bugs/closed/bug_10939.v
+++ b/test-suite/bugs/closed/bug_10939.v
@@ -1,0 +1,5 @@
+Goal False.
+Proof.
+  epose proof ltac:(shelve). (* works *)
+  epose proof ltac:(admit). (* anomaly *)
+Abort.

--- a/test-suite/bugs/closed/bug_4095.v
+++ b/test-suite/bugs/closed/bug_4095.v
@@ -71,18 +71,9 @@ Goal forall (T : Type) (O0 : T -> OPred) (O1 : T -> PointedOPred)
     refine (P _ _)
   end.
   Undo.
-  Fail lazymatch goal with
+  lazymatch goal with
   | |- ?R (?f ?a ?b) (?f ?a' ?b') =>
     let P := constr:(fun H H' => Morphisms.proper_prf a a' H b b' H') in
     set(p:=P)
-  end. (* Toplevel input, characters 15-182:
-Error: Cannot infer an instance of type
-"PointedOPred" for the variable p in environment:
-T : Type
-O0 : T -> OPred
-O1 : T -> PointedOPred
-tr : T -> T
-O2 : PointedOPred
-x0 : T
-H : forall x0 : T, catOP (O0 x0) (O1 (tr x0)) |-- O1 x0 *)
+  end.
 Abort.

--- a/toplevel/coqloop.ml
+++ b/toplevel/coqloop.ml
@@ -324,12 +324,12 @@ let loop_flush_all () =
 let pequal cmp1 cmp2 (a1,a2) (b1,b2) = cmp1 a1 b1 && cmp2 a2 b2
 let evleq e1 e2 = CList.equal Evar.equal e1 e2
 let cproof p1 p2 =
-  let Proof.{goals=a1;stack=a2;shelf=a3;given_up=a4} = Proof.data p1 in
-  let Proof.{goals=b1;stack=b2;shelf=b3;given_up=b4} = Proof.data p2 in
+  let Proof.{goals=a1;stack=a2;shelf=a3;sigma=sigma1} = Proof.data p1 in
+  let Proof.{goals=b1;stack=b2;shelf=b3;sigma=sigma2} = Proof.data p2 in
   evleq a1 b1 &&
   CList.equal (pequal evleq evleq) a2 b2 &&
   CList.equal Evar.equal a3 b3 &&
-  CList.equal Evar.equal a4 b4
+  Evar.Set.equal (Evd.given_up sigma1) (Evd.given_up sigma2)
 
 let drop_last_doc = ref None
 

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -358,8 +358,9 @@ let declare_instance_open sigma ?hook ~tac ~global ~poly id pri impargs udecl id
      the pretyping after the proof has opened. As a
      consequence, we use the low-level primitives to code
      the refinement manually.*)
-  let gls = List.rev (Evd.future_goals sigma) in
-  let sigma = Evd.reset_future_goals sigma in
+  let future_goals, sigma = Evd.pop_future_goals sigma in
+  let gls = List.rev_append future_goals.Evd.future_shelf (List.rev future_goals.Evd.future_comb) in
+  let sigma = Evd.push_future_goals sigma in
   let kind = Decls.(IsDefinition Instance) in
   let hook = Declare.Hook.(make (fun { S.dref ; _ } -> instance_hook pri global ?hook dref)) in
   let info = Declare.Info.make ~hook ~kind ~udecl ~poly () in

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -359,7 +359,7 @@ let declare_instance_open sigma ?hook ~tac ~global ~poly id pri impargs udecl id
      consequence, we use the low-level primitives to code
      the refinement manually.*)
   let future_goals, sigma = Evd.pop_future_goals sigma in
-  let gls = List.rev_append future_goals.Evd.future_shelf (List.rev future_goals.Evd.future_comb) in
+  let gls = List.rev_append future_goals.Evd.FutureGoals.shelf (List.rev future_goals.Evd.FutureGoals.comb) in
   let sigma = Evd.push_future_goals sigma in
   let kind = Decls.(IsDefinition Instance) in
   let hook = Declare.Hook.(make (fun { S.dref ; _ } -> instance_hook pri global ?hook dref)) in

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -112,7 +112,8 @@ let show_proof ~pstate =
 
 let show_top_evars ~proof =
   (* spiwack: new as of Feb. 2010: shows goal evars in addition to non-goal evars. *)
-  let Proof.{goals;shelf;given_up;sigma} = Proof.data proof in
+  let Proof.{goals;shelf;sigma} = Proof.data proof in
+  let given_up = Evar.Set.elements @@ Evd.given_up sigma in
   pr_evars_int sigma ~shelf ~given_up 1 (Evd.undefined_map sigma)
 
 let show_universes ~proof =


### PR DESCRIPTION
We make the `future_goals` stack explicit in the evarmap. This is a preliminary change before moving the shelf to the evarmap, which is necessary for #7825 and other changes where shelving info is needed by components which are not in the tactic monad.

We also move given up goals to the evarmap, which makes it possible to fix a long standing issue triggering an anomaly.

Fixes https://github.com/coq/coq/issues/10939