### PR TITLE
Preserve sharing in evar instances

### DIFF
--- a/engine/eConstr.ml
+++ b/engine/eConstr.ml
@@ -733,6 +733,11 @@ let map_rel_context_in_env f env sign =
   in
   aux env [] (List.rev sign)
 
+let match_named_context_val :
+  named_context_val -> (named_declaration * lazy_val * named_context_val) option =
+  match unsafe_eq with
+  | Refl -> match_named_context_val
+
 let fresh_global ?loc ?rigid ?names env sigma reference =
   let (evd,t) = Evd.fresh_global ?loc ?rigid ?names env sigma reference in
   evd, t

--- a/engine/eConstr.mli
+++ b/engine/eConstr.mli
@@ -322,6 +322,9 @@ val lookup_named_val : variable -> named_context_val -> named_declaration
 val map_rel_context_in_env :
   (env -> constr -> constr) -> env -> rel_context -> rel_context
 
+val match_named_context_val :
+  named_context_val -> (named_declaration * lazy_val * named_context_val) option
+
 (* XXX Missing Sigma proxy *)
 val fresh_global :
   ?loc:Loc.t -> ?rigid:Evd.rigid -> ?names:Univ.Instance.t -> Environ.env ->

--- a/engine/evarutil.mli
+++ b/engine/evarutil.mli
@@ -268,7 +268,7 @@ val empty_csubst : csubst
 val csubst_subst : csubst -> constr -> constr
 
 type ext_named_context =
-  csubst * Id.Set.t * named_context
+  csubst * Id.Set.t * named_context_val
 
 val push_rel_decl_to_named_context : ?hypnaming:naming_mode ->
   evar_map -> rel_declaration -> ext_named_context -> ext_named_context

--- a/engine/univSubst.ml
+++ b/engine/univSubst.ml
@@ -131,9 +131,9 @@ let nf_evars_and_universes_opt_subst f subst =
   let rec aux c =
     match kind c with
     | Evar (evk, args) ->
-      let args = List.map aux args in
-      (match try f (evk, args) with Not_found -> None with
-      | None -> mkEvar (evk, args)
+      let args' = List.Smart.map aux args in
+      (match try f (evk, args') with Not_found -> None with
+      | None -> if args == args' then c else mkEvar (evk, args')
       | Some c -> aux c)
     | Const pu ->
       let pu' = subst_univs_fn_puniverses lsubst pu in

--- a/kernel/environ.mli
+++ b/kernel/environ.mli
@@ -176,6 +176,8 @@ val named_body : variable -> env -> constr option
 val fold_named_context :
   (env -> Constr.named_declaration -> 'a -> 'a) -> env -> init:'a -> 'a
 
+val match_named_context_val : named_context_val -> (named_declaration * lazy_val * named_context_val) option
+
 (** Recurrence on [named_context] starting from younger decl *)
 val fold_named_context_reverse :
   ('a -> Constr.named_declaration -> 'a) -> init:'a -> env -> 'a

--- a/pretyping/globEnv.ml
+++ b/pretyping/globEnv.ml
@@ -33,6 +33,8 @@ type t = {
   (** For locating indices *)
   renamed_env : env;
   (** For name management *)
+  renamed_vars : EConstr.t list Lazy.t;
+  (** Identity instance of named_context of renamed_env, to maximize sharing *)
   extra : ext_named_context Lazy.t;
   (** Delay the computation of the evar extended environment *)
   lvar : ltac_var_map;
@@ -43,9 +45,11 @@ let make ~hypnaming env sigma lvar =
     let avoid = Environ.ids_of_named_context_val (Environ.named_context_val env) in
     Context.Rel.fold_outside (fun d acc -> push_rel_decl_to_named_context ~hypnaming sigma d acc)
       (rel_context env) ~init:(empty_csubst, avoid, named_context_val env) in
+  let open Context.Named.Declaration in
   {
     static_env = env;
     renamed_env = env;
+    renamed_vars = lazy (List.map (get_id %> mkVar) (named_context env));
     extra = lazy (get_extra env sigma);
     lvar = lvar;
   }
@@ -67,10 +71,12 @@ let ltac_interp_id { ltac_idents ; ltac_genargs } id =
 let ltac_interp_name lvar = Nameops.Name.map (ltac_interp_id lvar)
 
 let push_rel ~hypnaming sigma d env =
-  let d' = Context.Rel.Declaration.map_name (ltac_interp_name env.lvar) d in
+  let open Context.Rel.Declaration in
+  let d' = map_name (ltac_interp_name env.lvar) d in
   let env = {
     static_env = push_rel d env.static_env;
     renamed_env = push_rel d' env.renamed_env;
+    renamed_vars = env.renamed_vars;
     extra = lazy (push_rel_decl_to_named_context ~hypnaming:hypnaming sigma d' (Lazy.force env.extra));
     lvar = env.lvar;
     } in
@@ -83,6 +89,7 @@ let push_rel_context ~hypnaming ?(force_names=false) sigma ctx env =
   let env = {
     static_env = push_rel_context ctx env.static_env;
     renamed_env = push_rel_context ctx' env.renamed_env;
+    renamed_vars = env.renamed_vars;
     extra = lazy (List.fold_right (fun d acc -> push_rel_decl_to_named_context ~hypnaming:hypnaming sigma d acc) ctx' (Lazy.force env.extra));
     lvar = env.lvar;
     } in
@@ -95,12 +102,14 @@ let push_rec_types ~hypnaming sigma (lna,typarray) env =
   Array.map get_annot ctx, env
 
 let new_evar env sigma ?src ?naming typ =
-  let open Context.Named.Declaration in
-  let inst_vars = List.map (get_id %> mkVar) (named_context env.renamed_env) in
-  let inst_rels = List.rev (rel_list 0 (nb_rel env.renamed_env)) in
+  let lazy inst_vars = env.renamed_vars in
+  let rec rel_list n accu =
+    if n <= 0 then accu
+    else rel_list (n - 1) (mkRel n :: accu)
+  in
+  let instance = rel_list (nb_rel env.renamed_env) inst_vars in
   let (subst, _, sign) = Lazy.force env.extra in
   let typ' = csubst_subst subst typ in
-  let instance = inst_rels @ inst_vars in
   new_evar_instance sign sigma typ' ?src ?naming instance
 
 let new_type_evar env sigma ~src =

--- a/pretyping/globEnv.ml
+++ b/pretyping/globEnv.ml
@@ -42,7 +42,7 @@ let make ~hypnaming env sigma lvar =
   let get_extra env sigma =
     let avoid = Environ.ids_of_named_context_val (Environ.named_context_val env) in
     Context.Rel.fold_outside (fun d acc -> push_rel_decl_to_named_context ~hypnaming sigma d acc)
-      (rel_context env) ~init:(empty_csubst, avoid, named_context env) in
+      (rel_context env) ~init:(empty_csubst, avoid, named_context_val env) in
   {
     static_env = env;
     renamed_env = env;
@@ -98,10 +98,9 @@ let new_evar env sigma ?src ?naming typ =
   let open Context.Named.Declaration in
   let inst_vars = List.map (get_id %> mkVar) (named_context env.renamed_env) in
   let inst_rels = List.rev (rel_list 0 (nb_rel env.renamed_env)) in
-  let (subst, _, nc) = Lazy.force env.extra in
+  let (subst, _, sign) = Lazy.force env.extra in
   let typ' = csubst_subst subst typ in
   let instance = inst_rels @ inst_vars in
-  let sign = val_of_named_context nc in
   new_evar_instance sign sigma typ' ?src ?naming instance
 
 let new_type_evar env sigma ~src =


### PR DESCRIPTION
This PR tries to share evar instances as much as possible, especially for identity instances. This has remarkable effects on #12487, where it cut downs the used memory by more than 2.
