### PR TITLE
"auto using *" now poses its arguments

### DIFF
--- a/tactics/auto.ml
+++ b/tactics/auto.ml
@@ -350,28 +350,30 @@ and trivial_resolve env sigma dbg db_list local_db secvars cl =
     "nocore" amongst the databases. *)
 
 let trivial ?(debug=Off) lems dbnames =
+  let d = mk_trivial_dbg debug in
   Hints.wrap_hint_warning @@
+  tclTRY_dbg d (
+  pose_local_lemmas lems <*>
   Proofview.Goal.enter begin fun gl ->
   let env = Proofview.Goal.env gl in
   let sigma = Tacmach.project gl in
   let db_list = make_db_list dbnames in
-  let d = mk_trivial_dbg debug in
-  let hints = make_local_hint_db env sigma false lems in
-  tclTRY_dbg d
-    (trivial_fail_db d db_list hints)
-  end
+  let hints = make_local_hint_db env sigma false in
+  trivial_fail_db d db_list hints
+  end)
 
 let full_trivial ?(debug=Off) lems =
+  let d = mk_trivial_dbg debug in
   Hints.wrap_hint_warning @@
+  tclTRY_dbg d (
+  pose_local_lemmas lems <*>
   Proofview.Goal.enter begin fun gl ->
   let env = Proofview.Goal.env gl in
   let sigma = Tacmach.project gl in
   let db_list = current_pure_db () in
-  let d = mk_trivial_dbg debug in
-  let hints = make_local_hint_db env sigma false lems in
-  tclTRY_dbg d
-    (trivial_fail_db d db_list hints)
-  end
+  let hints = make_local_hint_db env sigma false in
+  trivial_fail_db d db_list hints
+  end)
 
 let gen_trivial ?(debug=Off) lems = function
   | None -> full_trivial ~debug lems
@@ -440,32 +442,32 @@ let search d n db_list local_db =
 let default_search_depth = ref 5
 
 let delta_auto debug n lems dbnames =
+  let d = mk_auto_dbg debug in
   Hints.wrap_hint_warning @@
+  tclTRY_dbg d (pose_local_lemmas lems <*>
   Proofview.Goal.enter begin fun gl ->
   let env = Proofview.Goal.env gl in
   let sigma = Tacmach.project gl in
   let db_list = make_db_list dbnames in
-  let d = mk_auto_dbg debug in
-  let hints = make_local_hint_db env sigma false lems in
-  tclTRY_dbg d
-    (search d n db_list hints)
-  end
+  let hints = make_local_hint_db env sigma false in
+  search d n db_list hints
+  end)
 
 let auto ?(debug=Off) n = delta_auto debug n
 
 let default_auto = auto !default_search_depth [] []
 
 let delta_full_auto ?(debug=Off) n lems =
+  let d = mk_auto_dbg debug in
   Hints.wrap_hint_warning @@
+  tclTRY_dbg d (pose_local_lemmas lems <*>
   Proofview.Goal.enter begin fun gl ->
   let env = Proofview.Goal.env gl in
   let sigma = Tacmach.project gl in
   let db_list = current_pure_db () in
-  let d = mk_auto_dbg debug in
-  let hints = make_local_hint_db env sigma false lems in
-  tclTRY_dbg d
-    (search d n db_list hints)
-  end
+  let hints = make_local_hint_db env sigma false in
+  search d n db_list hints
+  end)
 
 let full_auto ?(debug=Off) n = delta_full_auto ~debug n
 

--- a/tactics/hints.mli
+++ b/tactics/hints.mli
@@ -13,7 +13,6 @@ open Names
 open EConstr
 open Environ
 open Evd
-open Tactypes
 open Typeclasses
 
 (** {6 General functions. } *)
@@ -220,7 +219,7 @@ val push_resolve_hyp :
    Useful to take the current goal hypotheses as hints;
    Boolean tells if lemmas with evars are allowed *)
 
-val make_local_hint_db : env -> evar_map -> ?ts:TransparentState.t -> bool -> delayed_open_constr list -> hint_db
+val make_local_hint_db : env -> evar_map -> ?ts:TransparentState.t -> bool -> hint_db
 
 val make_db_list : hint_db_name list -> hint_db list
 
@@ -237,6 +236,8 @@ val fresh_hint : env -> evar_map -> hint -> evar_map * constr
 
 val hint_res_pf : ?with_evars:bool -> ?with_classes:bool ->
   ?flags:Unification.unify_flags -> hint -> unit Proofview.tactic
+
+val pose_local_lemmas : Tactypes.delayed_open_constr list -> unit Proofview.tactic
 
 (** Printing  hints *)
 


### PR DESCRIPTION
This is in line with the documentation, which only mentions qualified identifiers. The interpretation of terms is actually much trickier than it seems since it also involves resolution of implicit arguments and typeclasses. The code can be ported in a backwards compatible way by pose-ing the corresponding "using" clauses before invoking auto.

Let's see how the CI fares.

- [ ] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
