### PR TITLE
Deprecate `Grab Existential Variables` and `Existential` commands

### DIFF
--- a/doc/changelog/07-commands-and-options/12516-deprecate-grab-existentials.rst
+++ b/doc/changelog/07-commands-and-options/12516-deprecate-grab-existentials.rst
@@ -1,0 +1,4 @@
+- **Deprecated:**
+  :cmd:`Grab Existential Variables` and :cmd:`Existential` commands
+  (`#12516 <https://github.com/coq/coq/pull/12516>`_,
+  by Maxime Dénès).

--- a/doc/sphinx/proofs/writing-proofs/proof-mode.rst
+++ b/doc/sphinx/proofs/writing-proofs/proof-mode.rst
@@ -288,11 +288,17 @@ Name a set of section hypotheses for ``Proof using``
    existential variables remain. To instantiate existential variables
    during proof edition, you should use the tactic :tacn:`instantiate`.
 
+   .. deprecated:: 8.13
+
 .. cmd:: Grab Existential Variables
 
    This command can be run when a proof has no more goal to be solved but
    has remaining uninstantiated existential variables. It takes every
    uninstantiated existential variable and turns it into a goal.
+
+   .. deprecated:: 8.13
+
+      Use :cmd:`Unshelve` instead.
 
 Proof modes
 ```````````

--- a/proofs/proof.ml
+++ b/proofs/proof.ml
@@ -409,14 +409,28 @@ module V82 = struct
   let top_evars p =
     Proofview.V82.top_evars p.entry p.proofview
 
+  let warn_deprecated_grab_existentials =
+    CWarnings.create ~name:"deprecated-grab-existentials" ~category:"deprecated"
+       Pp.(fun () -> str "The Grab Existential Variables command is " ++
+         str"deprecated. Please use the Unshelve command or the unshelve tactical " ++
+         str"instead.")
+
   let grab_evars p =
+    warn_deprecated_grab_existentials ();
     if not (is_done p) then
       raise (OpenProof(None, UnfinishedProof))
     else
       { p with proofview = Proofview.V82.grab p.proofview }
 
+  let warn_deprecated_existential =
+    CWarnings.create ~name:"deprecated-existential" ~category:"deprecated"
+       Pp.(fun () -> str "The Existential command is " ++
+         str"deprecated. Please use the Unshelve command or the unshelve " ++
+         str"tactical, and the instantiate tactic instead.")
+
   (* Main component of vernac command Existential *)
   let instantiate_evar env n intern pr =
+    warn_deprecated_existential ();
     let tac =
       Proofview.tclBIND Proofview.tclEVARMAP begin fun sigma ->
       let (evk, evi) =


### PR DESCRIPTION
I thought this was done a long time ago, but it seems that these commands were never actually deprecated.

I'll update the changelog and documentation if the PR is approved.

Related: https://github.com/coq/coq/issues/9545, https://github.com/coq/coq/issues/9171

<!-- Keep what applies -->
**Kind:** documentation / bug fix / feature / performance / infrastructure.


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #????


<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [ ] Added / updated test-suite
<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [x] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
