### PR TITLE
tactics.rst: fix typo — readd `cbv` to title of its section

### DIFF
--- a/doc/sphinx/proof-engine/tactics.rst
+++ b/doc/sphinx/proof-engine/tactics.rst
@@ -3045,7 +3045,7 @@ following:
 For backward compatibility, the notation :n:`in {+ @ident}` performs
 the conversion in hypotheses :n:`{+ @ident}`.
 
-.. tacn:: {? @strategy_flag }
+.. tacn:: cbv {? @strategy_flag }
           lazy {? @strategy_flag }
    :name: cbv; lazy
 


### PR DESCRIPTION
The word `cbv` was missing from the output in both 8.12 and master:
https://coq.github.io/doc/v8.12/refman/proof-engine/tactics.html#coq:tacn.cbv
https://coq.github.io/doc/master/refman/proof-engine/tactics.html#coq:tacn.cbv

Hope this is enough, also looking at
https://github.com/coq/coq/commit/4c9ba141f8f7e067f274cb5a02293e8e52f89487#diff-a907eea979c6d310cb6208180b556d6d. Let's see the output.

**Kind:** documentation

- [x] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).

(Noticed in https://coq.zulipchat.com/#narrow/stream/237656-Coq-devs.20.26.20plugin.20devs/topic/Reference.20manual).