### PR TITLE
Take into account the existing delta-resolver when starting a new interactive module or module type

### DIFF
--- a/doc/changelog/01-kernel/12537-master+module-starting-extends-delta-resolver.rst
+++ b/doc/changelog/01-kernel/12537-master+module-starting-extends-delta-resolver.rst
@@ -1,0 +1,8 @@
+- **Fixed:**
+  A loss of definitional equality for declarations obtained through
+  :cmd:`Include` when entering the scope of a :cmd:`Module` or
+  :cmd:`Module Type` was causing :cmd:`Search` not to see the included
+  declarations
+  (`#12537 <https://github.com/coq/coq/pull/12537>`_, fixes `#12525
+  <https://github.com/coq/coq/pull/12525>`_ and `#12647
+  <https://github.com/coq/coq/pull/12647>`_, by Hugo Herbelin).

--- a/kernel/safe_typing.ml
+++ b/kernel/safe_typing.ml
@@ -1023,6 +1023,8 @@ let start_module l senv =
   mp,
   { empty_environment with
     env = senv.env;
+    modresolver = senv.modresolver;
+    paramresolver = senv.paramresolver;
     modpath = mp;
     modvariant = STRUCT ([],senv);
     required = senv.required }
@@ -1034,6 +1036,8 @@ let start_modtype l senv =
   mp,
   { empty_environment with
     env = senv.env;
+    modresolver = senv.modresolver;
+    paramresolver = senv.paramresolver;
     modpath = mp;
     modvariant = SIG ([], senv);
     required = senv.required }

--- a/test-suite/output/Search.out
+++ b/test-suite/output/Search.out
@@ -455,3 +455,6 @@ PreOrder_Reflexive:
 reflexive_eq_dom_reflexive:
   forall {A B : Type} {R' : Relation_Definitions.relation B},
   Reflexive R' -> Reflexive (eq ==> R')%signature
+B.b: B.a
+A.b: A.a
+F.L: F.P 0

--- a/test-suite/output/Search.v
+++ b/test-suite/output/Search.v
@@ -66,3 +66,26 @@ Reset Initial.
 Require Import Morphisms.
 
 Search is:Instance [ Reflexive | Symmetric ].
+
+Module Bug12525.
+  (* This was revealing a kernel bug with delta-resolution *)
+  Module A. Axiom a:Prop. Axiom b:a. End A.
+  Module B. Include A. End B.
+  Module M.
+    Search B.a.
+  End M.
+End Bug12525.
+
+From Coq Require Lia.
+
+Module Bug12647.
+  (* Similar to #12525 *)
+  Module Type Foo.
+  Axiom P : nat -> Prop.
+  Axiom L : P 0.
+  End Foo.
+
+  Module Bar (F : Foo).
+  Search F.P.
+  End Bar.
+End Bug12647.


### PR DESCRIPTION
**Kind:** bug fix

The default value of the delta-resolver for name aliasing was reinitialized to the empty substitution at `Module` and `Module Type` starting time. The existing resolver was saved but the saved resolver was not used in `Safe_typing.constant_of_delta_kn_senv` and `Safe_typing.mind_of_delta_kn_senv`.

A possible fix could have been to take the saved resolver into account in `Safe_typing.constant_of_delta_kn_senv` and `Safe_typing.mind_of_delta_kn_senv`. We instead try to just not reset it.

This incidentally fixes #12525 (`Search` unable to see through an `Include` when inside an interactive `Module`).

The issue apparently comes from the beginning of modules aliases (2008, 0d0d1ba857).

I suspect this only loses some delta equalities and is otherwise w/o bad consequences.

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes #12525, fixes #12647 (indirectly).

- [X] Added / updated test-suite
- [x] Entry added in the changelog
