### PR TITLE
RFC: Introduce the guard/unguard attributes for Fixpoint

### DIFF
--- a/vernac/attributes.ml
+++ b/vernac/attributes.ml
@@ -161,6 +161,8 @@ let () = let open Goptions in
 let program =
   enable_attribute ~key:"program" ~default:(fun () -> !program_mode)
 
+let guard_check = bool_attribute ~name:"Guard Checking" ~on:"guard" ~off:"unguard"
+
 let locality = bool_attribute ~name:"Locality" ~on:"local" ~off:"global"
 
 let option_locality =

--- a/vernac/attributes.mli
+++ b/vernac/attributes.mli
@@ -45,6 +45,7 @@ end
 
 val polymorphic : bool attribute
 val program : bool attribute
+val guard_check : bool option attribute
 val template : bool option attribute
 val locality : bool option attribute
 val option_locality : Goptions.option_locality attribute


### PR DESCRIPTION
I occasionally run into situation where I am okay with relying on the `Unset Guard Checking` recent feature of Coq (for utility functions, mostly), but I found the current way of using it cumbersome.

This patch adds new attributes to more easily control the feature.

It is a work in progress, in particular I believe the code can be refactor to be made more idiomatic wrt. the rest of the code base.

Overall, this is a RFC. Do you think we can move forward, from this draft to a complete PR?

And, finally, the obligatory snippet to demonstrate the feature.

```coq
(* Success *)
#[unguard]
Fixpoint tada (x : nat) : nat := tada (S x).

(* Fail *)
Unset Guard Checking.
#[guard]
Fixpoint tada (x : nat) : nat := tada (S x).
Set Guard Checking.
```