### PR TITLE
Fix #12228 negative integers not accepted in ltac integer_list

### DIFF
--- a/doc/changelog/05-tactic-language/12541-fix12228.rst
+++ b/doc/changelog/05-tactic-language/12541-fix12228.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  Excluding occurrences was causing an anomaly in tactics
+  (e.g., :g:`pattern _ at L` where :g:`L` is :g:`-2`).
+  (`#12541 <https://github.com/coq/coq/pull/12541>`_,
+  fixes `#12228 <https://github.com/coq/coq/issues/12228>`_,
+  by Pierre Roux).

--- a/tactics/redexpr.ml
+++ b/tactics/redexpr.ml
@@ -188,8 +188,18 @@ let out_arg = function
   | Locus.ArgVar _ -> anomaly (Pp.str "Unevaluated or_var variable.")
   | Locus.ArgArg x -> x
 
+let out_occurrences occs =
+  let occs = Locusops.occurrences_map (List.map out_arg) occs in
+  match occs with
+  | Locus.OnlyOccurrences (n::_ as nl) when n < 0 ->
+     Locus.AllOccurrencesBut (List.map abs nl)
+  | Locus.OnlyOccurrences nl when List.exists (fun n -> n < 0) nl ->
+     CErrors.user_err Pp.(str "Illegal negative occurrence number.")
+  | Locus.OnlyOccurrences _ | Locus.AllOccurrencesBut _ | Locus.NoOccurrences
+  | Locus.AllOccurrences | Locus.AtLeastOneOccurrence -> occs
+
 let out_with_occurrences (occs,c) =
-  (Locusops.occurrences_map (List.map out_arg) occs, c)
+  (out_occurrences occs, c)
 
 let e_red f env evm c = evm, f env evm c
 
@@ -199,7 +209,7 @@ let head_style = false (* Turn to true to have a semantics where simpl
 
 let contextualize f g = function
   | Some (occs,c) ->
-      let l = Locusops.occurrences_map (List.map out_arg) occs in
+      let l = out_occurrences occs in
       let b,c,h = match c with
         | Inl r -> true,PRef (global_of_evaluable_reference r),f
         | Inr c -> false,c,f in

--- a/test-suite/bugs/closed/bug_12228.v
+++ b/test-suite/bugs/closed/bug_12228.v
@@ -1,0 +1,4 @@
+Tactic Notation "mark" constr(P) "at" integer_list(L) := pattern P at L.
+Goal 0 = 0.
+mark 0 at -2.
+Abort.


### PR DESCRIPTION
**Kind:** bug fix

Fixes #12228 

- [x] Added / updated test-suite
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
