### PR TITLE
[ci] Use a tested branch of Perennial

### DIFF
--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -349,7 +349,7 @@
 ########################################################################
 # perennial
 ########################################################################
-: "${perennial_CI_REF:=master}"
+: "${perennial_CI_REF:=coq/tested}"
 : "${perennial_CI_GITURL:=https://github.com/mit-pdos/perennial}"
 : "${perennial_CI_ARCHIVEURL:=${perennial_CI_GITURL}/archive}"
 


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

Perennial is being tested as part of Coq's CI, which is great but puts some pressure on us to keep things working at all times. In order to decouple Coq CI from Perennial, this switches Coq to testing a branch `coq/tested`, which we fast-forward only after our own CI passes (against Coq nightly) and which has GitHub branch protection on top of that.

This is mostly mimicking the process bedrock2 is using.

<!-- Keep what applies -->
**Kind:** infrastructure.
