### PR TITLE
Fix configure usage in .opam

### DIFF
--- a/coq.opam
+++ b/coq.opam
@@ -28,6 +28,6 @@ depends: [
 ]
 
 build: [
-  [ "./configure" "-prefix" prefix ]
+  [ "./configure" "-prefix" prefix "-native-compiler" "no" ]
   [ "dune" "build" "-p" name "-j" jobs ]
 ]


### PR DESCRIPTION
coq.opam forgot to disable native compile. Instead of calling configure in the opam I changed it to use our env variable for the prefix (as already done for coq-doc.opam).

Fix coq/coq-bench#87 (see eg https://ci.inria.fr/coq/view/benchmarking/job/benchmark-part-of-the-branch/959/console)
