### PR TITLE
CoqIDE: accept to open files with invalid names

### DIFF
--- a/doc/changelog/09-coqide/12562-coqide-lax-filename.rst
+++ b/doc/changelog/09-coqide/12562-coqide-lax-filename.rst
@@ -1,0 +1,4 @@
+- **Fixed:** CoqIDE no longer exits when trying to open a file whose name is not a valid identifier
+  (`#12562 <https://github.com/coq/coq/pull/12562>`_,
+  fixes `#10988 <https://github.com/coq/coq/issues/10988>`_,
+  by Vincent Laporte).

--- a/ide/coqide/coqide.ml
+++ b/ide/coqide/coqide.ml
@@ -114,8 +114,10 @@ let make_coqtop_args fname =
         (* We basically copy the code of Names.check_valid since it is not exported *)
         (* to coqide. This is to prevent a possible failure of parsing  "-topfile"  *)
         (* at initialization of coqtop (see #10286) *)
+        (* If the file name is a valid identifier, use it as toplevel name; *)
+        (* otherwise the default “Top” will be used. *)
         match Unicode.ident_refutation (Filename.chop_extension (Filename.basename fname)) with
-        | Some (_,x) -> output_string stderr (x^"\n"); exit 1
+        | Some _ -> args
         | None -> "-topfile"::fname::args
   in
   proj, args


### PR DESCRIPTION
How to close CoqIDE? Use the “File → Open” menu and select a file name which is not a valid identifier.

This PR fixes this unexpected behavior by removing a call to “exit”.

Fixes: #10988.

TODO:
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
