### PR TITLE
Rename "reference" nonterminal to "smart_global" in documentation

### DIFF
--- a/doc/sphinx/addendum/implicit-coercions.rst
+++ b/doc/sphinx/addendum/implicit-coercions.rst
@@ -44,7 +44,7 @@ Formally, the syntax of classes is defined as:
    .. prodn::
       class ::= Funclass
       | Sortclass
-      | @reference
+      | @smart_global
 
 
 

--- a/doc/sphinx/language/extensions/arguments-command.rst
+++ b/doc/sphinx/language/extensions/arguments-command.rst
@@ -3,7 +3,7 @@
 Setting properties of a function's arguments
 ++++++++++++++++++++++++++++++++++++++++++++
 
-.. cmd:: Arguments @reference {* @arg_specs } {* , {* @implicits_alt } } {? : {+, @args_modifier } }
+.. cmd:: Arguments @smart_global {* @arg_specs } {* , {* @implicits_alt } } {? : {+, @args_modifier } }
    :name: Arguments
 
    .. insertprodn argument_spec args_modifier
@@ -37,7 +37,7 @@ Setting properties of a function's arguments
    extensions into the core language used by the kernel).  The command's effects include:
 
    * Making arguments implicit. Afterward, implicit arguments
-     must be omitted in any expression that applies :token:`reference`.
+     must be omitted in any expression that applies :token:`smart_global`.
    * Declaring that some arguments of a given function should
      be interpreted in a given scope.
    * Affecting when the :tacn:`simpl` and :tacn:`cbn` tactics unfold the function.
@@ -82,7 +82,7 @@ Setting properties of a function's arguments
          evaulate to constructors.  See :ref:`Args_effect_on_unfolding`.
 
       :n:`@name {? % @scope }`
-         a *formal parameter* of the function :n:`@reference` (i.e.
+         a *formal parameter* of the function :n:`@smart_global` (i.e.
          the parameter name used in the function definition).  Unless `rename` is specified,
          the list of :n:`@name`\s must be a prefix of the formal parameters, including all implicit
          arguments.  `_` can be used to skip over a formal parameter.
@@ -103,15 +103,15 @@ Setting properties of a function's arguments
             :undocumented:
 
       `clear scopes`
-         clears argument scopes of :n:`@reference`
+         clears argument scopes of :n:`@smart_global`
       `extra scopes`
          defines extra argument scopes, to be used in case of coercion to ``Funclass``
          (see :ref:`coercions`) or with a computed type.
       `simpl nomatch`
-         prevents performing a simplification step for :n:`@reference`
+         prevents performing a simplification step for :n:`@smart_global`
          that would expose a match construct in the head position.  See :ref:`Args_effect_on_unfolding`.
       `simpl never`
-         prevents performing a simplification step for :n:`@reference`.  See :ref:`Args_effect_on_unfolding`.
+         prevents performing a simplification step for :n:`@smart_global`.  See :ref:`Args_effect_on_unfolding`.
 
       `clear bidirectionality hint`
          removes the bidirectionality hint, the `&`
@@ -130,7 +130,7 @@ Setting properties of a function's arguments
          .. todo the above feature seems a bit unnatural and doesn't play well with partial
             application.  See https://github.com/coq/coq/pull/11718#discussion_r408841762
 
-   Use :cmd:`About` to view the current implicit arguments setting for a :token:`reference`.
+   Use :cmd:`About` to view the current implicit arguments setting for a :token:`smart_global`.
 
    Or use the :cmd:`Print Implicit` command to see the implicit arguments
    of an object (see :ref:`displaying-implicit-args`).
@@ -268,13 +268,13 @@ Binding arguments to a scope
 
          Arguments plus_fct (f1 f2)%F x%R.
 
-   When interpreting a term, if some of the arguments of :token:`reference` are built
+   When interpreting a term, if some of the arguments of :token:`smart_global` are built
    from a notation, then this notation is interpreted in the scope stack
-   extended by the scope bound (if any) to this argument. The effect of
+   extended by the scope (if any) that is bound to this argument. The effect of
    the scope is limited to the argument itself. It does not propagate to
    subterms but the subterms that, after interpretation of the notation,
-   turn to be themselves arguments of a reference are interpreted
-   accordingly to the argument scopes bound to this reference.
+   turn to be themselves arguments of a global reference are interpreted
+   accordingly to the argument scopes bound to the global reference.
 
 .. note::
 

--- a/doc/sphinx/language/extensions/canonical.rst
+++ b/doc/sphinx/language/extensions/canonical.rst
@@ -27,11 +27,11 @@ applied to an unknown structure instance (an implicit argument) and a
 value. The complete documentation of canonical structures can be found
 in :ref:`canonicalstructures`; here only a simple example is given.
 
-.. cmd:: Canonical {? Structure } @reference
+.. cmd:: Canonical {? Structure } @smart_global
          Canonical {? Structure } @ident_decl @def_body
    :name: Canonical Structure; _
 
-   The first form of this command declares an existing :n:`@reference` as a
+   The first form of this command declares an existing :n:`@smart_global` as a
    canonical instance of a structure (a record).
 
    The second form defines a new constant as if the :cmd:`Definition` command
@@ -111,7 +111,7 @@ in :ref:`canonicalstructures`; here only a simple example is given.
    It is equivalent to having a :cmd:`Canonical Structure` declaration just
    after the command.
 
-.. cmd:: Print Canonical Projections {* @reference }
+.. cmd:: Print Canonical Projections {* @smart_global }
 
    This displays the list of global names that are components of some
    canonical structure. For each of them, the canonical structure of

--- a/doc/sphinx/language/extensions/implicit-arguments.rst
+++ b/doc/sphinx/language/extensions/implicit-arguments.rst
@@ -373,7 +373,7 @@ the hiding of implicit arguments for a single function application using the
 Displaying implicit arguments
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. cmd:: Print Implicit @reference
+.. cmd:: Print Implicit @smart_global
 
    Displays the implicit arguments associated with an object,
    identifying which arguments are applied maximally or not.

--- a/doc/sphinx/proof-engine/tactics.rst
+++ b/doc/sphinx/proof-engine/tactics.rst
@@ -2996,7 +2996,7 @@ Performing computations
    | fold {+ @one_term }
    | pattern {+, @pattern_occ }
    | @ident
-   delta_flag ::= {? - } [ {+ @reference } ]
+   delta_flag ::= {? - } [ {+ @smart_global } ]
    strategy_flag ::= {+ @red_flags }
    | @delta_flag
    red_flags ::= beta
@@ -3006,13 +3006,13 @@ Performing computations
    | cofix
    | zeta
    | delta {? @delta_flag }
-   ref_or_pattern_occ ::= @reference {? at @occs_nums }
+   ref_or_pattern_occ ::= @smart_global {? at @occs_nums }
    | @one_term {? at @occs_nums }
    occs_nums ::= {+ {| @num | @ident } }
    | - {| @num | @ident } {* @int_or_var }
    int_or_var ::= @int
    | @ident
-   unfold_occ ::= @reference {? at @occs_nums }
+   unfold_occ ::= @smart_global {? at @occs_nums }
    pattern_occ ::= @one_term {? at @occs_nums }
 
 This set of tactics implements different specialized usages of the
@@ -3421,7 +3421,7 @@ the conversion in hypotheses :n:`{+ @ident}`.
 
    This is the most general syntax that combines the different variants.
 
-.. tacn:: with_strategy @strategy_level_or_var [ {+ @reference } ] @ltac_expr3
+.. tacn:: with_strategy @strategy_level_or_var [ {+ @smart_global } ] @ltac_expr3
    :name: with_strategy
 
    Executes :token:`ltac_expr3`, applying the alternate unfolding

--- a/doc/sphinx/proof-engine/vernacular-commands.rst
+++ b/doc/sphinx/proof-engine/vernacular-commands.rst
@@ -11,14 +11,14 @@ Displaying
 
 .. _Print:
 
-.. cmd:: Print {? Term } @reference {? @univ_name_list }
+.. cmd:: Print {? Term } @smart_global {? @univ_name_list }
 
    .. insertprodn univ_name_list univ_name_list
 
    .. prodn::
       univ_name_list ::= @%{ {* @name } %}
 
-   Displays definitions of terms, including opaque terms, for the object :n:`@reference`.
+   Displays definitions of terms, including opaque terms, for the object :n:`@smart_global`.
 
    * :n:`Term` - a syntactic marker to allow printing a term
      that is the same as one of the various :n:`Print` commands.  For example,
@@ -26,7 +26,7 @@ Displaying
      information on the object whose name is ":n:`All`".
 
    * :n:`@univ_name_list` - locally renames the
-     polymorphic universes of :n:`@reference`.
+     polymorphic universes of :n:`@smart_global`.
      The name `_` means the usual name is printed.
 
    .. exn:: @qualid not a defined object.
@@ -65,14 +65,14 @@ If no selector is provided,
 the command applies to the current goal.  If no proof is open, then the command only applies
 to accessible objects.  (see Section :ref:`invocation-of-tactics`).
 
-.. cmd:: About @reference {? @univ_name_list }
+.. cmd:: About @smart_global {? @univ_name_list }
 
-   Displays information about the :n:`@reference` object, which,
+   Displays information about the :n:`@smart_global` object, which,
    if a proof is open,  may be a hypothesis of the selected goal,
    or an accessible theorem, axiom, etc.:
    its kind (module, constant, assumption, inductive,
    constructor, abbreviation, …), long name, type, implicit arguments and
-   argument scopes (as set in the definition of :token:`reference` or
+   argument scopes (as set in the definition of :token:`smart_global` or
    subsequently with the :cmd:`Arguments` command). It does not print the body of definitions or proofs.
 
 .. cmd:: Check @term
@@ -84,7 +84,7 @@ to accessible objects.  (see Section :ref:`invocation-of-tactics`).
 
    Performs the specified reduction on :n:`@term` and displays
    the resulting term with its type. If a proof is open, :n:`@term`
-   may reference hypotheses of the selected goal.
+   may refer to hypotheses of the selected goal.
 
    .. seealso:: Section :ref:`performingcomputations`.
 
@@ -157,7 +157,7 @@ to accessible objects.  (see Section :ref:`invocation-of-tactics`).
       - Otherwise, search for objects
         whose type contains the reference that this string,
         interpreted as a notation, is attached to (as described in
-        :n:`@reference`).  See :ref:`this example <search-by-notation>`.
+        :n:`@smart_global`).  See :ref:`this example <search-by-notation>`.
 
      .. note::
 
@@ -405,7 +405,7 @@ to accessible objects.  (see Section :ref:`invocation-of-tactics`).
 Requests to the environment
 -------------------------------
 
-.. cmd:: Print Assumptions @reference
+.. cmd:: Print Assumptions @smart_global
 
    Displays all the assumptions (axioms, parameters and
    variables) a theorem or definition depends on.
@@ -413,24 +413,24 @@ Requests to the environment
    The message "Closed under the global context" indicates that the theorem or
    definition has no dependencies.
 
-.. cmd:: Print Opaque Dependencies @reference
+.. cmd:: Print Opaque Dependencies @smart_global
 
-   Displays the assumptions and opaque constants that :n:`@reference` depends on.
+   Displays the assumptions and opaque constants that :n:`@smart_global` depends on.
 
-.. cmd:: Print Transparent Dependencies @reference
+.. cmd:: Print Transparent Dependencies @smart_global
 
-   Displays the assumptions and  transparent constants that :n:`@reference` depends on.
+   Displays the assumptions and  transparent constants that :n:`@smart_global` depends on.
 
-.. cmd:: Print All Dependencies @reference
+.. cmd:: Print All Dependencies @smart_global
 
-   Displays all the assumptions and constants :n:`@reference` depends on.
+   Displays all the assumptions and constants :n:`@smart_global` depends on.
 
-.. cmd:: Locate @reference
+.. cmd:: Locate @smart_global
 
-   .. insertprodn reference reference
+   .. insertprodn smart_global smart_global
 
    .. prodn::
-      reference ::= @qualid
+      smart_global ::= @qualid
       | @string {? % @scope_key }
 
    Displays the full name of objects from |Coq|'s various qualified namespaces such as terms,
@@ -450,7 +450,7 @@ Requests to the environment
 
    .. todo somewhere we should list all the qualified namespaces
 
-.. cmd:: Locate Term @reference
+.. cmd:: Locate Term @smart_global
 
    Like :cmd:`Locate`, but limits the search to terms
 
@@ -973,7 +973,7 @@ as numbers, and for reflection-based tactics. The commands to fine-
 tune the reduction strategies and the lazy conversion algorithm are
 described first.
 
-.. cmd:: Opaque {+ @reference }
+.. cmd:: Opaque {+ @smart_global }
 
    This command accepts the :attr:`global` attribute.  By default, the scope
    of :cmd:`Opaque` is limited to the current section or module.
@@ -982,7 +982,7 @@ described first.
    defined by :cmd:`Definition` or :cmd:`Let` (with an explicit body), or by a command
    assimilated to a definition such as :cmd:`Fixpoint`, :cmd:`Program Definition`, etc,
    or by a proof ended by :cmd:`Defined`. The command tells not to unfold the
-   constants in the :n:`@reference` sequence in tactics using δ-conversion (unfolding
+   constants in the :n:`@smart_global` sequence in tactics using δ-conversion (unfolding
    a constant is replacing it by its definition).
 
    :cmd:`Opaque` has also an effect on the conversion algorithm of |Coq|, telling
@@ -995,7 +995,7 @@ described first.
       Sections :ref:`performingcomputations`, :ref:`tactics-automating`,
       :ref:`proof-editing-mode`
 
-.. cmd:: Transparent {+ @reference }
+.. cmd:: Transparent {+ @smart_global }
 
    This command accepts the :attr:`global` attribute.  By default, the scope
    of :cmd:`Transparent` is limited to the current section or module.
@@ -1022,7 +1022,7 @@ described first.
 
 .. _vernac-strategy:
 
-.. cmd:: Strategy {+ @strategy_level [ {+ @reference } ] }
+.. cmd:: Strategy {+ @strategy_level [ {+ @smart_global } ] }
 
    .. insertprodn strategy_level strategy_level_or_var
 
@@ -1041,7 +1041,7 @@ described first.
    This command generalizes the behavior of the :cmd:`Opaque` and :cmd:`Transparent`
    commands. It is used to fine-tune the strategy for unfolding
    constants, both at the tactic level and at the kernel level. This
-   command associates a :n:`@strategy_level` with the qualified names in the :n:`@reference`
+   command associates a :n:`@strategy_level` with the qualified names in the :n:`@smart_global`
    sequence. Whenever two
    expressions with two distinct head constants are compared (for
    instance, this comparison can be triggered by a type cast), the one
@@ -1062,10 +1062,10 @@ described first.
       like −∞)
     + ``transparent`` : Equivalent to level 0
 
-.. cmd:: Print Strategy @reference
+.. cmd:: Print Strategy @smart_global
 
-   This command prints the strategy currently associated with :n:`@reference`. It
-   fails if :n:`@reference` is not an unfoldable reference, that is, neither a
+   This command prints the strategy currently associated with :n:`@smart_global`. It
+   fails if :n:`@smart_global` is not an unfoldable reference, that is, neither a
    variable nor a constant.
 
    .. exn:: The reference is not unfoldable.

--- a/doc/sphinx/user-extensions/syntax-extensions.rst
+++ b/doc/sphinx/user-extensions/syntax-extensions.rst
@@ -1789,7 +1789,7 @@ Tactic notations allow customizing the syntax of tactics.
         - :tacn:`unfold`
 
       * - ``smart_global``
-        - :token:`reference`
+        - :token:`smart_global`
         - a global reference of term
         - :tacn:`with_strategy`
 

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -2016,7 +2016,6 @@ RENAME: [
 | constructor_list_or_record_decl constructors_or_record
 | record_binder_body field_body
 | class_rawexpr class
-| smart_global reference
 (*
 | searchabout_query search_item
 *)

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -1,473 +1,6 @@
 (* Coq grammar generated from .mlg files.  Do not edit by hand.  Not compiled into Coq *)
 DOC_GRAMMAR
 
-Constr.ident: [
-| Prim.ident
-]
-
-Prim.name: [
-| "_"
-]
-
-global: [
-| Prim.reference
-]
-
-constr_pattern: [
-| constr
-]
-
-lconstr_pattern: [
-| lconstr
-]
-
-sort: [
-| "Set"
-| "Prop"
-| "SProp"
-| "Type"
-| "Type" "@{" "_" "}"
-| "Type" "@{" universe "}"
-]
-
-sort_family: [
-| "Set"
-| "Prop"
-| "SProp"
-| "Type"
-]
-
-universe_increment: [
-| "+" natural
-|
-]
-
-universe_name: [
-| global
-| "Set"
-| "Prop"
-]
-
-universe_expr: [
-| universe_name universe_increment
-]
-
-universe: [
-| "max" "(" LIST1 universe_expr SEP "," ")"
-| universe_expr
-]
-
-lconstr: [
-| operconstr200
-| l_constr
-]
-
-constr: [
-| operconstr8
-| "@" global univ_instance
-]
-
-operconstr200: [
-| binder_constr
-| operconstr100
-]
-
-operconstr100: [
-| operconstr99 "<:" operconstr200
-| operconstr99 "<<:" operconstr200
-| operconstr99 ":" operconstr200
-| operconstr99 ":>"
-| operconstr99
-]
-
-operconstr99: [
-| operconstr90
-]
-
-operconstr90: [
-| operconstr10
-]
-
-operconstr10: [
-| operconstr9 LIST1 appl_arg
-| "@" global univ_instance LIST0 operconstr9
-| "@" pattern_identref LIST1 identref
-| operconstr9
-]
-
-operconstr9: [
-| ".." operconstr0 ".."
-| operconstr8
-]
-
-operconstr8: [
-| operconstr1
-]
-
-operconstr1: [
-| operconstr0 ".(" global LIST0 appl_arg ")"
-| operconstr0 ".(" "@" global LIST0 ( operconstr9 ) ")"
-| operconstr0 "%" IDENT
-| operconstr0
-]
-
-operconstr0: [
-| atomic_constr
-| match_constr
-| "(" operconstr200 ")"
-| "{|" record_declaration bar_cbrace
-| "{" binder_constr "}"
-| "`{" operconstr200 "}"
-| "`(" operconstr200 ")"
-| "ltac" ":" "(" Pltac.tactic_expr ")"
-]
-
-record_declaration: [
-| fields_def
-]
-
-fields_def: [
-| field_def ";" fields_def
-| field_def
-|
-]
-
-field_def: [
-| global binders ":=" lconstr
-]
-
-binder_constr: [
-| "forall" open_binders "," operconstr200
-| "fun" open_binders "=>" operconstr200
-| "let" name binders let_type_cstr ":=" operconstr200 "in" operconstr200
-| "let" "fix" fix_decl "in" operconstr200
-| "let" "cofix" cofix_decl "in" operconstr200
-| "let" [ "(" LIST0 name SEP "," ")" | "()" ] return_type ":=" operconstr200 "in" operconstr200
-| "let" "'" pattern200 ":=" operconstr200 "in" operconstr200
-| "let" "'" pattern200 ":=" operconstr200 case_type "in" operconstr200
-| "let" "'" pattern200 "in" pattern200 ":=" operconstr200 case_type "in" operconstr200
-| "if" operconstr200 return_type "then" operconstr200 "else" operconstr200
-| "fix" fix_decls
-| "cofix" cofix_decls
-]
-
-appl_arg: [
-| test_lpar_id_coloneq "(" ident ":=" lconstr ")"
-| operconstr9
-]
-
-atomic_constr: [
-| global univ_instance
-| sort
-| NUMERAL
-| string
-| "_"
-| "?" "[" ident "]"
-| "?" "[" pattern_ident "]"
-| pattern_ident evar_instance
-]
-
-inst: [
-| ident ":=" lconstr
-]
-
-evar_instance: [
-| "@{" LIST1 inst SEP ";" "}"
-|
-]
-
-univ_instance: [
-| "@{" LIST0 universe_level "}"
-|
-]
-
-universe_level: [
-| "Set"
-| "Prop"
-| "Type"
-| "_"
-| global
-]
-
-fix_decls: [
-| fix_decl
-| fix_decl "with" LIST1 fix_decl SEP "with" "for" identref
-]
-
-cofix_decls: [
-| cofix_decl
-| cofix_decl "with" LIST1 cofix_decl SEP "with" "for" identref
-]
-
-fix_decl: [
-| identref binders_fixannot type_cstr ":=" operconstr200
-]
-
-cofix_decl: [
-| identref binders type_cstr ":=" operconstr200
-]
-
-match_constr: [
-| "match" LIST1 case_item SEP "," OPT case_type "with" branches "end"
-]
-
-case_item: [
-| operconstr100 OPT [ "as" name ] OPT [ "in" pattern200 ]
-]
-
-case_type: [
-| "return" operconstr100
-]
-
-return_type: [
-| OPT [ OPT [ "as" name ] case_type ]
-]
-
-branches: [
-| OPT "|" LIST0 eqn SEP "|"
-]
-
-mult_pattern: [
-| LIST1 pattern200 SEP ","
-]
-
-eqn: [
-| LIST1 mult_pattern SEP "|" "=>" lconstr
-]
-
-record_pattern: [
-| global ":=" pattern200
-]
-
-record_patterns: [
-| record_pattern ";" record_patterns
-| record_pattern
-|
-]
-
-pattern200: [
-| pattern100
-]
-
-pattern100: [
-| pattern99 ":" operconstr200
-| pattern99
-]
-
-pattern99: [
-| pattern90
-]
-
-pattern90: [
-| pattern10
-]
-
-pattern10: [
-| pattern1 "as" name
-| pattern1 LIST1 pattern1
-| "@" Prim.reference LIST0 pattern1
-| pattern1
-]
-
-pattern1: [
-| pattern0 "%" IDENT
-| pattern0
-]
-
-pattern0: [
-| Prim.reference
-| "{|" record_patterns bar_cbrace
-| "_"
-| "(" pattern200 ")"
-| "(" pattern200 "|" LIST1 pattern200 SEP "|" ")"
-| NUMERAL
-| string
-]
-
-fixannot: [
-| "{" "struct" identref "}"
-| "{" "wf" constr identref "}"
-| "{" "measure" constr OPT identref OPT constr "}"
-]
-
-binders_fixannot: [
-| ensure_fixannot fixannot
-| binder binders_fixannot
-|
-]
-
-open_binders: [
-| name LIST0 name ":" lconstr
-| name LIST0 name binders
-| name ".." name
-| closed_binder binders
-]
-
-binders: [
-| LIST0 binder
-| Pcoq.Constr.binders
-]
-
-binder: [
-| name
-| closed_binder
-]
-
-closed_binder: [
-| "(" name LIST1 name ":" lconstr ")"
-| "(" name ":" lconstr ")"
-| "(" name ":=" lconstr ")"
-| "(" name ":" lconstr ":=" lconstr ")"
-| "{" name "}"
-| "{" name LIST1 name ":" lconstr "}"
-| "{" name ":" lconstr "}"
-| "{" name LIST1 name "}"
-| "[" name "]"
-| "[" name LIST1 name ":" lconstr "]"
-| "[" name ":" lconstr "]"
-| "[" name LIST1 name "]"
-| "`(" LIST1 typeclass_constraint SEP "," ")"
-| "`{" LIST1 typeclass_constraint SEP "," "}"
-| "`[" LIST1 typeclass_constraint SEP "," "]"
-| "'" pattern0
-]
-
-typeclass_constraint: [
-| "!" operconstr200
-| "{" name "}" ":" [ "!" | ] operconstr200
-| test_name_colon name ":" [ "!" | ] operconstr200
-| operconstr200
-]
-
-type_cstr: [
-| ":" lconstr
-|
-]
-
-let_type_cstr: [
-| OPT [ ":" lconstr ]
-]
-
-preident: [
-| IDENT
-]
-
-ident: [
-| IDENT
-]
-
-pattern_ident: [
-| LEFTQMARK ident
-]
-
-pattern_identref: [
-| pattern_ident
-]
-
-var: [
-| ident
-]
-
-identref: [
-| ident
-]
-
-field: [
-| FIELD
-]
-
-fields: [
-| field fields
-| field
-]
-
-fullyqualid: [
-| ident fields
-| ident
-]
-
-name: [
-| "_"
-| ident
-]
-
-reference: [
-| ident fields
-| ident
-]
-
-qualid: [
-| reference
-]
-
-by_notation: [
-| ne_string OPT [ "%" IDENT ]
-]
-
-smart_global: [
-| reference
-| by_notation
-]
-
-ne_string: [
-| STRING
-]
-
-ne_lstring: [
-| ne_string
-]
-
-dirpath: [
-| ident LIST0 field
-]
-
-string: [
-| STRING
-]
-
-lstring: [
-| string
-]
-
-integer: [
-| bigint
-]
-
-natural: [
-| bignat
-| _natural
-]
-
-bigint: [
-| NUMERAL
-| test_minus_nat "-" NUMERAL
-]
-
-bignat: [
-| NUMERAL
-]
-
-bar_cbrace: [
-| test_pipe_closedcurly "|" "}"
-]
-
-strategy_level: [
-| "expand"
-| "opaque"
-| integer
-| "transparent"
-| strategy_level0
-]
-
-vernac_toplevel: [
-| "Drop" "."
-| "Quit" "."
-| "BackTo" natural "."
-| test_show_goal "Show" "Goal" natural "at" natural "."
-| "Show" "Proof" "Diffs" OPT "removed" "."
-| Pvernac.Vernac_.main_entry
-]
-
 opt_hintbases: [
 |
 | ":" LIST1 IDENT
@@ -655,6 +188,17 @@ command: [
 | "Show" "Ltac" "Profile" "CutOff" int
 | "Show" "Ltac" "Profile" string
 | "Show" "Lia" "Profile"      (* micromega plugin *)
+| "Add" "Zify" "InjTyp" constr      (* micromega plugin *)
+| "Add" "Zify" "BinOp" constr      (* micromega plugin *)
+| "Add" "Zify" "UnOp" constr      (* micromega plugin *)
+| "Add" "Zify" "CstOp" constr      (* micromega plugin *)
+| "Add" "Zify" "BinRel" constr      (* micromega plugin *)
+| "Add" "Zify" "PropOp" constr      (* micromega plugin *)
+| "Add" "Zify" "PropBinOp" constr      (* micromega plugin *)
+| "Add" "Zify" "PropUOp" constr      (* micromega plugin *)
+| "Add" "Zify" "BinOpSpec" constr      (* micromega plugin *)
+| "Add" "Zify" "UnOpSpec" constr      (* micromega plugin *)
+| "Add" "Zify" "Saturate" constr      (* micromega plugin *)
 | "Add" "InjTyp" constr      (* micromega plugin *)
 | "Add" "BinOp" constr      (* micromega plugin *)
 | "Add" "UnOp" constr      (* micromega plugin *)
@@ -663,7 +207,6 @@ command: [
 | "Add" "PropOp" constr      (* micromega plugin *)
 | "Add" "PropBinOp" constr      (* micromega plugin *)
 | "Add" "PropUOp" constr      (* micromega plugin *)
-| "Add" "Spec" constr      (* micromega plugin *)
 | "Add" "BinOpSpec" constr      (* micromega plugin *)
 | "Add" "UnOpSpec" constr      (* micromega plugin *)
 | "Add" "Saturate" constr      (* micromega plugin *)
@@ -672,6 +215,8 @@ command: [
 | "Show" "Zify" "UnOp"      (* micromega plugin *)
 | "Show" "Zify" "CstOp"      (* micromega plugin *)
 | "Show" "Zify" "BinRel"      (* micromega plugin *)
+| "Show" "Zify" "UnOpSpec"      (* micromega plugin *)
+| "Show" "Zify" "BinOpSpec"      (* micromega plugin *)
 | "Show" "Zify" "Spec"      (* micromega plugin *)
 | "Add" "Ring" ident ":" constr OPT ring_mods      (* setoid_ring plugin *)
 | "Print" "Rings"      (* setoid_ring plugin *)
@@ -1413,6 +958,473 @@ constr_as_binder_kind: [
 | "as" "strict" "pattern"
 ]
 
+vernac_toplevel: [
+| "Drop" "."
+| "Quit" "."
+| "BackTo" natural "."
+| test_show_goal "Show" "Goal" natural "at" natural "."
+| "Show" "Proof" "Diffs" OPT "removed" "."
+| Pvernac.Vernac_.main_entry
+]
+
+Constr.ident: [
+| Prim.ident
+]
+
+Prim.name: [
+| "_"
+]
+
+global: [
+| Prim.reference
+]
+
+constr_pattern: [
+| constr
+]
+
+lconstr_pattern: [
+| lconstr
+]
+
+sort: [
+| "Set"
+| "Prop"
+| "SProp"
+| "Type"
+| "Type" "@{" "_" "}"
+| "Type" "@{" universe "}"
+]
+
+sort_family: [
+| "Set"
+| "Prop"
+| "SProp"
+| "Type"
+]
+
+universe_increment: [
+| "+" natural
+|
+]
+
+universe_name: [
+| global
+| "Set"
+| "Prop"
+]
+
+universe_expr: [
+| universe_name universe_increment
+]
+
+universe: [
+| "max" "(" LIST1 universe_expr SEP "," ")"
+| universe_expr
+]
+
+lconstr: [
+| operconstr200
+| l_constr
+]
+
+constr: [
+| operconstr8
+| "@" global univ_instance
+]
+
+operconstr200: [
+| binder_constr
+| operconstr100
+]
+
+operconstr100: [
+| operconstr99 "<:" operconstr200
+| operconstr99 "<<:" operconstr200
+| operconstr99 ":" operconstr200
+| operconstr99 ":>"
+| operconstr99
+]
+
+operconstr99: [
+| operconstr90
+]
+
+operconstr90: [
+| operconstr10
+]
+
+operconstr10: [
+| operconstr9 LIST1 appl_arg
+| "@" global univ_instance LIST0 operconstr9
+| "@" pattern_identref LIST1 identref
+| operconstr9
+]
+
+operconstr9: [
+| ".." operconstr0 ".."
+| operconstr8
+]
+
+operconstr8: [
+| operconstr1
+]
+
+operconstr1: [
+| operconstr0 ".(" global LIST0 appl_arg ")"
+| operconstr0 ".(" "@" global LIST0 ( operconstr9 ) ")"
+| operconstr0 "%" IDENT
+| operconstr0
+]
+
+operconstr0: [
+| atomic_constr
+| match_constr
+| "(" operconstr200 ")"
+| "{|" record_declaration bar_cbrace
+| "{" binder_constr "}"
+| "`{" operconstr200 "}"
+| "`(" operconstr200 ")"
+| "ltac" ":" "(" Pltac.tactic_expr ")"
+]
+
+record_declaration: [
+| fields_def
+]
+
+fields_def: [
+| field_def ";" fields_def
+| field_def
+|
+]
+
+field_def: [
+| global binders ":=" lconstr
+]
+
+binder_constr: [
+| "forall" open_binders "," operconstr200
+| "fun" open_binders "=>" operconstr200
+| "let" name binders let_type_cstr ":=" operconstr200 "in" operconstr200
+| "let" "fix" fix_decl "in" operconstr200
+| "let" "cofix" cofix_decl "in" operconstr200
+| "let" [ "(" LIST0 name SEP "," ")" | "()" ] return_type ":=" operconstr200 "in" operconstr200
+| "let" "'" pattern200 ":=" operconstr200 "in" operconstr200
+| "let" "'" pattern200 ":=" operconstr200 case_type "in" operconstr200
+| "let" "'" pattern200 "in" pattern200 ":=" operconstr200 case_type "in" operconstr200
+| "if" operconstr200 return_type "then" operconstr200 "else" operconstr200
+| "fix" fix_decls
+| "cofix" cofix_decls
+]
+
+appl_arg: [
+| test_lpar_id_coloneq "(" ident ":=" lconstr ")"
+| operconstr9
+]
+
+atomic_constr: [
+| global univ_instance
+| sort
+| NUMERAL
+| string
+| "_"
+| "?" "[" ident "]"
+| "?" "[" pattern_ident "]"
+| pattern_ident evar_instance
+]
+
+inst: [
+| ident ":=" lconstr
+]
+
+evar_instance: [
+| "@{" LIST1 inst SEP ";" "}"
+|
+]
+
+univ_instance: [
+| "@{" LIST0 universe_level "}"
+|
+]
+
+universe_level: [
+| "Set"
+| "Prop"
+| "Type"
+| "_"
+| global
+]
+
+fix_decls: [
+| fix_decl
+| fix_decl "with" LIST1 fix_decl SEP "with" "for" identref
+]
+
+cofix_decls: [
+| cofix_decl
+| cofix_decl "with" LIST1 cofix_decl SEP "with" "for" identref
+]
+
+fix_decl: [
+| identref binders_fixannot type_cstr ":=" operconstr200
+]
+
+cofix_decl: [
+| identref binders type_cstr ":=" operconstr200
+]
+
+match_constr: [
+| "match" LIST1 case_item SEP "," OPT case_type "with" branches "end"
+]
+
+case_item: [
+| operconstr100 OPT [ "as" name ] OPT [ "in" pattern200 ]
+]
+
+case_type: [
+| "return" operconstr100
+]
+
+return_type: [
+| OPT [ OPT [ "as" name ] case_type ]
+]
+
+branches: [
+| OPT "|" LIST0 eqn SEP "|"
+]
+
+mult_pattern: [
+| LIST1 pattern200 SEP ","
+]
+
+eqn: [
+| LIST1 mult_pattern SEP "|" "=>" lconstr
+]
+
+record_pattern: [
+| global ":=" pattern200
+]
+
+record_patterns: [
+| record_pattern ";" record_patterns
+| record_pattern
+|
+]
+
+pattern200: [
+| pattern100
+]
+
+pattern100: [
+| pattern99 ":" operconstr200
+| pattern99
+]
+
+pattern99: [
+| pattern90
+]
+
+pattern90: [
+| pattern10
+]
+
+pattern10: [
+| pattern1 "as" name
+| pattern1 LIST1 pattern1
+| "@" Prim.reference LIST0 pattern1
+| pattern1
+]
+
+pattern1: [
+| pattern0 "%" IDENT
+| pattern0
+]
+
+pattern0: [
+| Prim.reference
+| "{|" record_patterns bar_cbrace
+| "_"
+| "(" pattern200 ")"
+| "(" pattern200 "|" LIST1 pattern200 SEP "|" ")"
+| NUMERAL
+| string
+]
+
+fixannot: [
+| "{" "struct" identref "}"
+| "{" "wf" constr identref "}"
+| "{" "measure" constr OPT identref OPT constr "}"
+]
+
+binders_fixannot: [
+| ensure_fixannot fixannot
+| binder binders_fixannot
+|
+]
+
+open_binders: [
+| name LIST0 name ":" lconstr
+| name LIST0 name binders
+| name ".." name
+| closed_binder binders
+]
+
+binders: [
+| LIST0 binder
+| Pcoq.Constr.binders
+]
+
+binder: [
+| name
+| closed_binder
+]
+
+closed_binder: [
+| "(" name LIST1 name ":" lconstr ")"
+| "(" name ":" lconstr ")"
+| "(" name ":=" lconstr ")"
+| "(" name ":" lconstr ":=" lconstr ")"
+| "{" name "}"
+| "{" name LIST1 name ":" lconstr "}"
+| "{" name ":" lconstr "}"
+| "{" name LIST1 name "}"
+| "[" name "]"
+| "[" name LIST1 name ":" lconstr "]"
+| "[" name ":" lconstr "]"
+| "[" name LIST1 name "]"
+| "`(" LIST1 typeclass_constraint SEP "," ")"
+| "`{" LIST1 typeclass_constraint SEP "," "}"
+| "`[" LIST1 typeclass_constraint SEP "," "]"
+| "'" pattern0
+]
+
+typeclass_constraint: [
+| "!" operconstr200
+| "{" name "}" ":" [ "!" | ] operconstr200
+| test_name_colon name ":" [ "!" | ] operconstr200
+| operconstr200
+]
+
+type_cstr: [
+| ":" lconstr
+|
+]
+
+let_type_cstr: [
+| OPT [ ":" lconstr ]
+]
+
+preident: [
+| IDENT
+]
+
+ident: [
+| IDENT
+]
+
+pattern_ident: [
+| LEFTQMARK ident
+]
+
+pattern_identref: [
+| pattern_ident
+]
+
+var: [
+| ident
+]
+
+identref: [
+| ident
+]
+
+field: [
+| FIELD
+]
+
+fields: [
+| field fields
+| field
+]
+
+fullyqualid: [
+| ident fields
+| ident
+]
+
+name: [
+| "_"
+| ident
+]
+
+reference: [
+| ident fields
+| ident
+]
+
+qualid: [
+| reference
+]
+
+by_notation: [
+| ne_string OPT [ "%" IDENT ]
+]
+
+smart_global: [
+| reference
+| by_notation
+]
+
+ne_string: [
+| STRING
+]
+
+ne_lstring: [
+| ne_string
+]
+
+dirpath: [
+| ident LIST0 field
+]
+
+string: [
+| STRING
+]
+
+lstring: [
+| string
+]
+
+integer: [
+| bigint
+]
+
+natural: [
+| bignat
+| _natural
+]
+
+bigint: [
+| NUMERAL
+| test_minus_nat "-" NUMERAL
+]
+
+bignat: [
+| NUMERAL
+]
+
+bar_cbrace: [
+| test_pipe_closedcurly "|" "}"
+]
+
+strategy_level: [
+| "expand"
+| "opaque"
+| integer
+| "transparent"
+| strategy_level0
+]
+
 simple_tactic: [
 | "btauto"
 | "congruence"
@@ -1985,7 +1997,6 @@ failkw: [
 binder_tactic: [
 | "fun" LIST1 input_fun "=>" tactic_expr5
 | "let" [ "rec" | ] LIST1 let_clause SEP "with" "in" tactic_expr5
-| "info" tactic_expr5
 ]
 
 tactic_arg_compat: [

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -458,7 +458,7 @@ red_expr: [
 ]
 
 delta_flag: [
-| OPT "-" "[" LIST1 reference "]"
+| OPT "-" "[" LIST1 smart_global "]"
 ]
 
 strategy_flag: [
@@ -477,7 +477,7 @@ red_flags: [
 ]
 
 ref_or_pattern_occ: [
-| reference OPT ( "at" occs_nums )
+| smart_global OPT ( "at" occs_nums )
 | one_term OPT ( "at" occs_nums )
 ]
 
@@ -492,7 +492,7 @@ int_or_var: [
 ]
 
 unfold_occ: [
-| reference OPT ( "at" occs_nums )
+| smart_global OPT ( "at" occs_nums )
 ]
 
 pattern_occ: [
@@ -547,11 +547,11 @@ cofix_definition: [
 ]
 
 scheme_kind: [
-| "Induction" "for" reference "Sort" sort_family
-| "Minimality" "for" reference "Sort" sort_family
-| "Elimination" "for" reference "Sort" sort_family
-| "Case" "for" reference "Sort" sort_family
-| "Equality" "for" reference
+| "Induction" "for" smart_global "Sort" sort_family
+| "Minimality" "for" smart_global "Sort" sort_family
+| "Elimination" "for" smart_global "Sort" sort_family
+| "Case" "for" smart_global "Sort" sort_family
+| "Equality" "for" smart_global
 ]
 
 sort_family: [
@@ -606,7 +606,7 @@ module_expr_inl: [
 | LIST1 module_expr_atom OPT functor_app_annot
 ]
 
-reference: [
+smart_global: [
 | qualid
 | string OPT [ "%" scope_key ]
 ]
@@ -684,8 +684,8 @@ command: [
 | "Cd" OPT string
 | "Load" OPT "Verbose" [ string | ident ]
 | "Declare" "ML" "Module" LIST1 string
-| "Locate" reference
-| "Locate" "Term" reference
+| "Locate" smart_global
+| "Locate" "Term" smart_global
 | "Locate" "Module" qualid
 | "Info" num ltac_expr
 | "Locate" "Ltac" qualid
@@ -708,30 +708,30 @@ command: [
 | "Print" "Graph"
 | "Print" "Classes"
 | "Print" "TypeClasses"
-| "Print" "Instances" reference
+| "Print" "Instances" smart_global
 | "Print" "Coercions"
 | "Print" "Coercion" "Paths" class class
-| "Print" "Canonical" "Projections" LIST0 reference
+| "Print" "Canonical" "Projections" LIST0 smart_global
 | "Print" "Typing" "Flags"
 | "Print" "Tables"
 | "Print" "Options"
 | "Print" "Hint"
-| "Print" "Hint" reference
+| "Print" "Hint" smart_global
 | "Print" "Hint" "*"
 | "Print" "HintDb" ident
 | "Print" "Scopes"
 | "Print" "Scope" scope_name
 | "Print" "Visibility" OPT scope_name
-| "Print" "Implicit" reference
+| "Print" "Implicit" smart_global
 | "Print" OPT "Sorted" "Universes" OPT ( "Subgraph" "(" LIST0 qualid ")" ) OPT string
-| "Print" "Assumptions" reference
-| "Print" "Opaque" "Dependencies" reference
-| "Print" "Transparent" "Dependencies" reference
-| "Print" "All" "Dependencies" reference
-| "Print" "Strategy" reference
+| "Print" "Assumptions" smart_global
+| "Print" "Opaque" "Dependencies" smart_global
+| "Print" "Transparent" "Dependencies" smart_global
+| "Print" "All" "Dependencies" smart_global
+| "Print" "Strategy" smart_global
 | "Print" "Strategies"
 | "Print" "Registered"
-| "Print" OPT "Term" reference OPT univ_name_list
+| "Print" OPT "Term" smart_global OPT univ_name_list
 | "Print" "Module" "Type" qualid
 | "Print" "Module" qualid
 | "Print" "Namespace" dirpath
@@ -807,6 +807,17 @@ command: [
 | "Reset" "Ltac" "Profile"
 | "Show" "Ltac" "Profile" OPT [ "CutOff" int | string ]
 | "Show" "Lia" "Profile"      (* micromega plugin *)
+| "Add" "Zify" "InjTyp" one_term      (* micromega plugin *)
+| "Add" "Zify" "BinOp" one_term      (* micromega plugin *)
+| "Add" "Zify" "UnOp" one_term      (* micromega plugin *)
+| "Add" "Zify" "CstOp" one_term      (* micromega plugin *)
+| "Add" "Zify" "BinRel" one_term      (* micromega plugin *)
+| "Add" "Zify" "PropOp" one_term      (* micromega plugin *)
+| "Add" "Zify" "PropBinOp" one_term      (* micromega plugin *)
+| "Add" "Zify" "PropUOp" one_term      (* micromega plugin *)
+| "Add" "Zify" "BinOpSpec" one_term      (* micromega plugin *)
+| "Add" "Zify" "UnOpSpec" one_term      (* micromega plugin *)
+| "Add" "Zify" "Saturate" one_term      (* micromega plugin *)
 | "Add" "InjTyp" one_term      (* micromega plugin *)
 | "Add" "BinOp" one_term      (* micromega plugin *)
 | "Add" "UnOp" one_term      (* micromega plugin *)
@@ -815,7 +826,6 @@ command: [
 | "Add" "PropOp" one_term      (* micromega plugin *)
 | "Add" "PropBinOp" one_term      (* micromega plugin *)
 | "Add" "PropUOp" one_term      (* micromega plugin *)
-| "Add" "Spec" one_term      (* micromega plugin *)
 | "Add" "BinOpSpec" one_term      (* micromega plugin *)
 | "Add" "UnOpSpec" one_term      (* micromega plugin *)
 | "Add" "Saturate" one_term      (* micromega plugin *)
@@ -824,6 +834,8 @@ command: [
 | "Show" "Zify" "UnOp"      (* micromega plugin *)
 | "Show" "Zify" "CstOp"      (* micromega plugin *)
 | "Show" "Zify" "BinRel"      (* micromega plugin *)
+| "Show" "Zify" "UnOpSpec"      (* micromega plugin *)
+| "Show" "Zify" "BinOpSpec"      (* micromega plugin *)
 | "Show" "Zify" "Spec"      (* micromega plugin *)
 | "Add" "Ring" ident ":" one_term OPT ( "(" LIST1 ring_mod SEP "," ")" )      (* setoid_ring plugin *)
 | "Hint" "Cut" "[" hints_path "]" OPT ( ":" LIST1 ident )
@@ -909,20 +921,20 @@ command: [
 | "Export" LIST1 filtered_import
 | "Include" module_type_inl LIST0 ( "<+" module_expr_inl )
 | "Include" "Type" LIST1 module_type_inl SEP "<+"
-| "Transparent" LIST1 reference
-| "Opaque" LIST1 reference
-| "Strategy" LIST1 [ strategy_level "[" LIST1 reference "]" ]
+| "Transparent" LIST1 smart_global
+| "Opaque" LIST1 smart_global
+| "Strategy" LIST1 [ strategy_level "[" LIST1 smart_global "]" ]
 | "Canonical" OPT "Structure" ident_decl def_body
-| "Canonical" OPT "Structure" reference
+| "Canonical" OPT "Structure" smart_global
 | "Coercion" qualid OPT univ_decl def_body
 | "Identity" "Coercion" ident ":" class ">->" class
-| "Coercion" reference ":" class ">->" class
+| "Coercion" smart_global ":" class ">->" class
 | "Context" LIST1 binder
 | "Instance" OPT ( ident_decl LIST0 binder ) ":" term OPT hint_info OPT [ ":=" "{" LIST0 field_def "}" | ":=" term ]
 | "Existing" "Instance" qualid OPT hint_info
 | "Existing" "Instances" LIST1 qualid OPT [ "|" num ]
 | "Existing" "Class" qualid
-| "Arguments" reference LIST0 arg_specs LIST0 [ "," LIST0 implicits_alt ] OPT [ ":" LIST1 args_modifier SEP "," ]
+| "Arguments" smart_global LIST0 arg_specs LIST0 [ "," LIST0 implicits_alt ] OPT [ ":" LIST1 args_modifier SEP "," ]
 | "Implicit" [ "Type" | "Types" ] reserv_list
 | "Generalizable" [ [ "Variable" | "Variables" ] LIST1 ident | "All" "Variables" | "No" "Variables" ]
 | "Set" setting_name OPT [ int | string ]
@@ -941,7 +953,7 @@ command: [
 | "Eval" red_expr "in" term
 | "Compute" term
 | "Check" term
-| "About" reference OPT univ_name_list
+| "About" smart_global OPT univ_name_list
 | "SearchHead" one_term OPT ( [ "inside" | "outside" ] LIST1 qualid )
 | "SearchPattern" one_term OPT ( [ "inside" | "outside" ] LIST1 qualid )
 | "SearchRewrite" one_term OPT ( [ "inside" | "outside" ] LIST1 qualid )
@@ -1105,7 +1117,7 @@ eauto_search_strategy_name: [
 class: [
 | "Funclass"
 | "Sortclass"
-| reference
+| smart_global
 ]
 
 syntax_modifier: [
@@ -1219,7 +1231,6 @@ simple_tactic: [
 | "uconstr" ":" "(" term ")"
 | "fun" LIST1 name "=>" ltac_expr
 | "let" OPT "rec" let_clause LIST0 ( "with" let_clause ) "in" ltac_expr
-| "info" ltac_expr
 | ltac_expr3 ";" [ ltac_expr3 | binder_tactic ]
 | ltac_expr3 ";" "[" for_each_goal "]"
 | ltac_expr1 "+" [ ltac_expr2 | binder_tactic ]
@@ -1287,7 +1298,7 @@ simple_tactic: [
 | "guard" int_or_var comparison int_or_var
 | "decompose" "[" LIST1 one_term "]" one_term
 | "optimize_heap"
-| "with_strategy" strategy_level_or_var "[" LIST1 reference "]" ltac_expr3
+| "with_strategy" strategy_level_or_var "[" LIST1 smart_global "]" ltac_expr3
 | "start" "ltac" "profiling"
 | "stop" "ltac" "profiling"
 | "reset" "ltac" "profile"


### PR DESCRIPTION
I wonder if `smart_qualid` might be better.  Just seeing the name, it gives a better idea of the syntax.  Does it really only refer to global entities?