### PR TITLE
[test-suite] Fix dependencies of modules/ files

### DIFF
--- a/doc/changelog/11-infrastructure-and-dependencies/12583-fix-remake.rst
+++ b/doc/changelog/11-infrastructure-and-dependencies/12583-fix-remake.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  Running ``make`` in ``test-suite/`` twice (or more) in a row will no longer
+  rebuild the ``modules/`` tests on subsequent runs, if they have not been
+  modified in the meantime (`#12583 <https://github.com/coq/coq/pull/12583>`_,
+  fixes `#12582 <https://github.com/coq/coq/issues/12582>`_, by Jason Gross).

--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -629,7 +629,14 @@ $(addsuffix .log,$(wildcard ideal-features/*.v)): %.v.log: %.v $(PREREQUISITELOG
 	} > "$@"
 
 # Additional dependencies for module tests
-$(addsuffix .log,$(wildcard modules/*.v)): %.v.log: modules/Nat.vo modules/plik.vo
+COMMON_MODULE_DEPENDENCIES := modules/plik.v modules/Nat.v
+# We exclude Nat.v.log and plik.v.log because these log files do not
+# depend on having the corresponding .vo files built first, and we end
+# up with pseudo-cyclic build rules if we don't exclude them (See
+# COQBUG(https://github.com/coq/coq/issues/12582)). Additionally, we
+# impose order-only dependencies to ensure that we won't rebuild the
+# .vo files in the .log target after we've already built them.
+$(addsuffix .log,$(filter-out $(COMMON_MODULE_DEPENDENCIES),$(wildcard modules/*.v))): %.v.log: $(COMMON_MODULE_DEPENDENCIES:.v=.vo) | $(COMMON_MODULE_DEPENDENCIES:.v=.v.log)
 modules/%.vo: modules/%.v
 	$(HIDE)$(coqc) -R modules Mods $<
 


### PR DESCRIPTION
The previous code said that `Nat.v.log` (and therefore `Nat.vo`) should
be rebuilt anytime `Nat.v.log` is older than `plik.v.vo`, and also says
that `plik.v.log` (and therefore `plik.vo`) should be rebuilt anytime
`plik.v.log` is older than `Nat.vo`.  This is circular, and results in
`make` considering all of the `modules/` tests out-of-date on any fresh
run.

**Kind:** bug fix / infrastructure.

Fixes #12582

- [x] Added / updated test-suite (though I haven't added a test for this particular failure, since it's a failure of configuration in the test-suite itself.....)
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
