### PR TITLE
Git commit hook doesn't fix whitespace issues in a rebase

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,7 +184,7 @@ stream][Zulip-dev] of our Zulip chat.
 
 Finally, we strongly encourage authors of plugins to submit their
 plugins to join Coq's continuous integration (CI) early on.  Indeed,
-the Coq API gets continously reworked, so this is the best way of
+the Coq API gets continuously reworked, so this is the best way of
 ensuring your plugin stays compatible with new Coq versions, as this
 means Coq developers will fix your plugin for you.  Learn more about
 this in the [CI README (user part)][CI-README-users].

--- a/doc/sphinx/proof-engine/tactics.rst
+++ b/doc/sphinx/proof-engine/tactics.rst
@@ -3432,6 +3432,7 @@ the conversion in hypotheses :n:`{+ @ident}`.
    ensure that unfolding does not fail.
 
 Change #1
+Change #2:
    .. example::
    Change #3   
 

--- a/doc/sphinx/proof-engine/tactics.rst
+++ b/doc/sphinx/proof-engine/tactics.rst
@@ -3431,7 +3431,9 @@ the conversion in hypotheses :n:`{+ @ident}`.
    never unfolded by tactics like :tacn:`simpl` and :tacn:`cbn` or to
    ensure that unfolding does not fail.
 
+Change #1
    .. example::
+   Change #3   
 
       .. coqtop:: all reset abort
 


### PR DESCRIPTION
See #12578

I created two commits with two "git commit"s, which removed whitespace at the end of lines that I modified.  Then I did "rebase -i HEAD~2" and introduced the "Change 3" line, which still has extra space on the end of the line.