### PR TITLE
Defined a specification for the mod operator that resembles the form usually used in mathematics.

### DIFF
--- a/theories/Arith/PeanoNat.v
+++ b/theories/Arith/PeanoNat.v
@@ -373,6 +373,28 @@ Proof.
  apply lt_succ_r, le_sub_l.
 Qed.
 
+Lemma mod_ex : forall x y z : nat, z <> 0 -> x = y mod z -> exists k : nat, k * z + x = y.
+Proof.
+  intros x y z.
+  destruct z.
+  + contradiction.
+  + intro Hz.
+    unfold modulo.
+    intro H.
+    apply (ex_intro (fun k => k * S z + x = y) (fst (divmod y z 0 z))).
+    set (H0 := (divmod_spec y z 0 z (le_refl z))).
+    rewrite (mul_0_r (S z)) in H0.
+    rewrite (add_0_r y) in H0.
+    rewrite (sub_diag z) in H0.
+    rewrite (add_0_r y) in H0.
+    rewrite (surjective_pairing (divmod y z 0 z)) in H0.
+    set (H1 := proj1 H0).
+    rewrite <- H in H1.
+    set (H2 := @eq_sym y (S z * fst (divmod y z 0 z) + x) H1).
+    rewrite (mul_comm (S z) (fst (divmod y z 0 z))) in H2.
+    assumption.
+Qed.
+
 (** ** Square root *)
 
 Lemma sqrt_iter_spec : forall k p q r,

--- a/theories/Arith/PeanoNat.v
+++ b/theories/Arith/PeanoNat.v
@@ -373,26 +373,12 @@ Proof.
  apply lt_succ_r, le_sub_l.
 Qed.
 
-Lemma mod_ex : forall x y z : nat, z <> 0 -> x = y mod z -> exists k : nat, k * z + x = y.
+Lemma mod_ex : forall x y z : nat, z <> 0 ->
+ x = y mod z -> exists k : nat, k * z + x = y.
 Proof.
-  intros x y z.
-  destruct z.
-  + contradiction.
-  + intro Hz.
-    unfold modulo.
-    intro H.
-    apply (ex_intro (fun k => k * S z + x = y) (fst (divmod y z 0 z))).
-    set (H0 := (divmod_spec y z 0 z (le_refl z))).
-    rewrite (mul_0_r (S z)) in H0.
-    rewrite (add_0_r y) in H0.
-    rewrite (sub_diag z) in H0.
-    rewrite (add_0_r y) in H0.
-    rewrite (surjective_pairing (divmod y z 0 z)) in H0.
-    set (H1 := proj1 H0).
-    rewrite <- H in H1.
-    set (H2 := @eq_sym y (S z * fst (divmod y z 0 z) + x) H1).
-    rewrite (mul_comm (S z) (fst (divmod y z 0 z))) in H2.
-    assumption.
+ intros x y z Hy%(div_mod y) ->.
+ exists (y / z); symmetry.
+ now rewrite mul_comm.
 Qed.
 
 (** ** Square root *)


### PR DESCRIPTION
The meaning of `x mod y == z`, where `==` denotes modular congruence,  is normally expressed as an existential statement - i.e. `exists k, z - x = k y`. The Standard Library currently contains a lemma that describes the recursive function used to compute the `divmod` function, `divmod_spec`, but lacks a lemma that follows the normal form. This commit provides a proof of an existential statement similar to that normally used in mathematics.

<!-- Keep what applies -->
**Kind:** feature