### PR TITLE
[exn] Remove some uses of print

### DIFF
--- a/pretyping/pretype_errors.ml
+++ b/pretyping/pretype_errors.ml
@@ -66,6 +66,7 @@ exception PretypeError of env * Evd.evar_map * pretype_error
 
 let precatchable_exception = function
   | CErrors.UserError _ | TypeError _ | PretypeError _
+  | Reductionops.AnomalyInConversion _
   | Nametab.GlobalizationError _ -> true
   | _ -> false
 

--- a/pretyping/pretyping.mllib
+++ b/pretyping/pretyping.mllib
@@ -1,8 +1,8 @@
 Geninterp
 Locus
 Locusops
-Pretype_errors
 Reductionops
+Pretype_errors
 Inductiveops
 Arguments_renaming
 Retyping

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -1097,12 +1097,17 @@ let pb_equal = function
   | Reduction.CUMUL -> Reduction.CONV
   | Reduction.CONV -> Reduction.CONV
 
+exception AnomalyInConversion of exn
+
+let _ = CErrors.register_handler (function
+    | AnomalyInConversion e ->
+      Some Pp.(str "Conversion test raised an anomaly:" ++
+               spc () ++ CErrors.print e)
+    | _ -> None)
+
 let report_anomaly (e, info) =
   let e =
-    if is_anomaly e then
-      let msg = Pp.(str "Conversion test raised an anomaly:" ++
-                    spc () ++ CErrors.print e) in
-      UserError (None, msg)
+    if is_anomaly e then AnomalyInConversion e
     else e
   in
   Exninfo.iraise (e, info)

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -1097,6 +1097,14 @@ let pb_equal = function
   | Reduction.CUMUL -> Reduction.CONV
   | Reduction.CONV -> Reduction.CONV
 
+(* NOTE: We absorb anomalies happening in the conversion tactic, which
+   is a bit ugly. This is mostly due to efficiency both in tactics and
+   in the conversion machinery itself. It is not uncommon for a tactic
+   to send some ill-typed term to the engine.
+
+   We would usually say that a tactic that converts ill-typed terms is
+   buggy, but fixing the tactic could have a very large runtime cost
+   *)
 exception AnomalyInConversion of exn
 
 let _ = CErrors.register_handler (function

--- a/pretyping/reductionops.mli
+++ b/pretyping/reductionops.mli
@@ -293,3 +293,5 @@ val whd_betaiota_deltazeta_for_iota_state :
 (** {6 Meta-related reduction functions } *)
 val meta_instance : env -> evar_map -> constr freelisted -> constr
 val nf_meta       : env -> evar_map -> constr -> constr
+
+exception AnomalyInConversion of exn

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -236,7 +236,7 @@ let with_prods nprods h f =
             f gl (h, diff)
       with e when CErrors.noncritical e ->
         let e, info = Exninfo.capture e in
-        Tacticals.New.tclZEROMSG ~info (CErrors.print e) end
+        Proofview.tclZERO ~info e end
   else Proofview.Goal.enter
          begin fun gl ->
          if Int.equal nprods 0 then f gl (h, None)

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -1331,10 +1331,8 @@ let pr_vernac_attributes =
   | flags ->  str "#[" ++ pr_vernac_flags flags ++ str "]" ++ cut ()
 
 let pr_vernac ({v = {control; attrs; expr}} as v) =
-  try
-    tag_vernac v
-      (pr_vernac_control control ++
-       pr_vernac_attributes attrs ++
-       pr_vernac_expr expr ++
-       sep_end expr)
-  with e -> CErrors.print e
+  tag_vernac v
+    (pr_vernac_control control ++
+     pr_vernac_attributes attrs ++
+     pr_vernac_expr expr ++
+     sep_end expr)


### PR DESCRIPTION
Exceptions should not printed except for the top-level.

There is the weird anomaly-absorbing code in `Reductionops`, I wonder
how frequent that case is, but as the exception is absorbed printing
there could have a real impact.
