### PR TITLE
Fix ltac2 type parameters

### DIFF
--- a/doc/changelog/05-tactic-language/12594-fix-ltac2-type-params.rst
+++ b/doc/changelog/05-tactic-language/12594-fix-ltac2-type-params.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  Fix the parsing of multi-parameters Ltac2 types
+  (`#12594 <https://github.com/coq/coq/pull/12594>`_,
+  fixes `#12595 <https://github.com/coq/coq/issues/12595>`_,
+  by Pierre-Marie Pédrot).

--- a/test-suite/ltac2/syntax.v
+++ b/test-suite/ltac2/syntax.v
@@ -1,0 +1,12 @@
+Require Import Ltac2.Ltac2.
+
+Ltac2 Type ('a, 'b, 'c) t.
+Ltac2 Type ('a) u.
+Ltac2 Type 'a v.
+
+Ltac2 foo
+  (f : ('a, 'b, 'c) t -> ('a -> 'a, 'b -> 'c, 'c * 'c) t)
+  (x : ('a, 'b, 'c) t) :=
+  f x.
+
+Ltac2 bar (x : 'a u) (y : ('b) v) := x.

--- a/user-contrib/Ltac2/g_ltac2.mlg
+++ b/user-contrib/Ltac2/g_ltac2.mlg
@@ -262,12 +262,16 @@ GRAMMAR EXTEND Gram
     | "1" LEFTA
       [ t = SELF; qid = Prim.qualid -> { CAst.make ~loc @@ CTypRef (RelId qid, [t]) } ]
     | "0"
-      [ "("; t = tac2type LEVEL "5"; ")"  -> { t }
+      [ "(";  p = LIST1 tac2type LEVEL "5" SEP ","; ")"; qid = OPT Prim.qualid ->
+        { match p, qid with
+          | [t], None -> t
+          | _, None -> CErrors.user_err ~loc (Pp.str "Syntax error")
+          | ts, Some qid -> CAst.make ~loc @@ CTypRef (RelId qid, p)
+        }
       | id = typ_param -> { CAst.make ~loc @@ CTypVar (Name id) }
       | "_" -> { CAst.make ~loc @@ CTypVar Anonymous }
       | qid = Prim.qualid -> { CAst.make ~loc @@ CTypRef (RelId qid, []) }
-      | "("; p = LIST1 tac2type LEVEL "5" SEP ","; ")"; qid = Prim.qualid ->
-        { CAst.make ~loc @@ CTypRef (RelId qid, p) } ]
+      ]
     ];
   locident:
     [ [ id = Prim.ident -> { CAst.make ~loc id } ] ]


### PR DESCRIPTION
It seems that nobody tried to write a parameterized type with more than one parameter since this was causing a syntax error. LL(1) being great, we work around the issue by factorizing the syntax with the generic parentheses and decide the validity after parsing.

Fixes #12595

- [X] Added / updated test-suite
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
