### PR TITLE
[test-suite] async-proofs off in tests with Fail Timeout

### DIFF
--- a/test-suite/success/Typeclasses.v
+++ b/test-suite/success/Typeclasses.v
@@ -1,3 +1,4 @@
+(* coq-prog-args: ("-async-proofs" "off") *)
 Module applydestruct.
   Class Foo (A : Type) :=
     { bar : nat -> A;

--- a/test-suite/success/auto.v
+++ b/test-suite/success/auto.v
@@ -1,3 +1,4 @@
+(* coq-prog-args: ("-async-proofs" "off") *)
 (* Wish #2154 by E. van der Weegen *)
 
 (* auto was not using f_equal-style lemmas with metavariables occurring

--- a/test-suite/success/bteauto.v
+++ b/test-suite/success/bteauto.v
@@ -1,3 +1,4 @@
+(* coq-prog-args: ("-async-proofs" "off") *)
 Require Import Program.Tactics.
 Module Backtracking.
   Class A := { foo : nat }.


### PR DESCRIPTION
Apparently the `Timeout` exception is raised by a signal handler, and
that can happen when the running thread is a worker manager, rather than
the main thread (the one that should be interrupted).

Given that the point of these tests is to test *auto and not the STM,
we disable async proofs forcibly.

Thanks @Coqbot !