### PR TITLE
[ci] [performance-tests] Use a lighter target.

### DIFF
--- a/dev/ci/ci-coq_performance_tests.sh
+++ b/dev/ci/ci-coq_performance_tests.sh
@@ -5,4 +5,4 @@ ci_dir="$(dirname "$0")"
 
 git_download coq_performance_tests
 
-( cd "${CI_BUILD_DIR}/coq_performance_tests" && make coq perf && make validate && make install )
+( cd "${CI_BUILD_DIR}/coq_performance_tests" && make coq perf-Sanity && make validate && make install )


### PR DESCRIPTION
The current `perf` CI target is quite heavy, failing from out of
memory sometimes. We use the target suggested by Jason Gross (<- thanks)
in https://github.com/coq/coq/pull/12577#issuecomment-651970064
