### PR TITLE
[experiment] [evd] Make evar counter per evar_map

### DIFF
--- a/clib/int.ml
+++ b/clib/int.ml
@@ -14,6 +14,7 @@ external equal : int -> int -> bool = "%eq"
 
 external compare : int -> int -> int = "caml_int_compare"
 
+let max (x : t) (y : t) : t= if x >= y then x else y
 let hash i = i land 0x3FFFFFFF
 
 module Self =

--- a/clib/int.mli
+++ b/clib/int.mli
@@ -16,6 +16,8 @@ external equal : t -> t -> bool = "%eq"
 
 external compare : t -> t -> int = "caml_int_compare"
 
+val max : t -> t -> t
+
 val hash : t -> int
 
 module Set : Set.S with type elt = t

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -675,12 +675,6 @@ type open_constr = evar_map * econstr (* Special case when before is empty *)
 type unsolvability_explanation = SeveralInstancesFound of int
 (** Failure explanation. *)
 
-(** {5 Summary names} *)
-
-(* This stuff is internal and should not be used. Currently a hack in
-   the STM relies on it. *)
-val evar_counter_summary_tag : int Summary.Dyn.tag
-
 (** {5 Deprecated functions} *)
 val create_evar_defs : evar_map -> evar_map
 (* XXX: This is supposed to be deprecated by used by ssrmatching, what

--- a/vernac/vernacstate.ml
+++ b/vernac/vernacstate.ml
@@ -237,7 +237,6 @@ module Stm = struct
   type nonrec pstate =
     LemmaStack.t option *
     int *                                   (* Evarutil.meta_counter_summary_tag *)
-    int *                                   (* Evd.evar_counter_summary_tag *)
     Declare.Obls.State.t
 
   (* Parts of the system state that are morally part of the proof state *)
@@ -245,10 +244,9 @@ module Stm = struct
     let st = System.Stm.summary system in
     lemmas,
     Summary.project_from_summary st Evarutil.meta_counter_summary_tag,
-    Summary.project_from_summary st Evd.evar_counter_summary_tag,
     Summary.project_from_summary st Declare.Obls.State.prg_tag
 
-  let set_pstate ({ lemmas; system } as s) (pstate,c1,c2,c3) =
+  let set_pstate ({ lemmas; system } as s) (pstate,meta,obls) =
     { s with
       lemmas =
         Declare_.copy_terminators ~src:s.lemmas ~tgt:pstate
@@ -256,9 +254,8 @@ module Stm = struct
         System.Stm.replace_summary s.system
           begin
             let st = System.Stm.summary s.system in
-            let st = Summary.modify_summary st Evarutil.meta_counter_summary_tag c1 in
-            let st = Summary.modify_summary st Evd.evar_counter_summary_tag c2 in
-            let st = Summary.modify_summary st Declare.Obls.State.prg_tag c3 in
+            let st = Summary.modify_summary st Evarutil.meta_counter_summary_tag meta in
+            let st = Summary.modify_summary st Declare.Obls.State.prg_tag obls in
             st
           end
       }
@@ -266,7 +263,6 @@ module Stm = struct
   let non_pstate { system } =
     let st = System.Stm.summary system in
     let st = Summary.remove_from_summary st Evarutil.meta_counter_summary_tag in
-    let st = Summary.remove_from_summary st Evd.evar_counter_summary_tag in
     let st = Summary.remove_from_summary st Declare.Obls.State.prg_tag in
     st, System.Stm.lib system
 


### PR DESCRIPTION
Experiment motivated by the discussion on https://github.com/coq/coq/pull/12620, I've tried to make the evar counter per evar_map.

This is a bit less of imperative state, and it seems more logical that
evars are scoped to their evar_map instead of to the global backtrack
state.

However, as expected, this doesn't work. There are a couple of culprits, in `ssrbool` and `ring`. I'd say one point where the evar manipulation is weird is in `ssrcommon:abs_evars` , another weird spot is in `class_tactics:make_autogoal_hints`. Both are not surprising. You need #12630 to get a proper backtrace.

I wonder if the whole attempt here makes sense, indeed it seems to me that there are some questions about the semantics of evar_maps that we should discuss [are they a heap, etc...]