### PR TITLE
[exn] Add missing info to tclZEROMSG / tclFAIL

### DIFF
--- a/plugins/btauto/refl_btauto.ml
+++ b/plugins/btauto/refl_btauto.ml
@@ -207,7 +207,8 @@ module Btauto = struct
         str "Not a tautology:" ++ spc () ++ l
       with e when CErrors.noncritical e -> (str "Not a tautology")
     in
-    Tacticals.tclFAIL 0 msg
+    let info = Exninfo.reify () in
+    Tacticals.tclFAIL ~info 0 msg
   end
 
   let try_unification env =
@@ -223,7 +224,8 @@ module Btauto = struct
           tac
       | _ ->
           let msg = str "Btauto: Internal error" in
-          Tacticals.tclFAIL 0 msg
+          let info = Exninfo.reify () in
+          Tacticals.tclFAIL ~info 0 msg
     end
 
   let tac =
@@ -253,7 +255,8 @@ module Btauto = struct
           ]
       | _ ->
           let msg = str "Cannot recognize a boolean equality" in
-          Tacticals.tclFAIL 0 msg
+          let info = Exninfo.reify () in
+          Tacticals.tclFAIL ~info 0 msg
     end
 
 end

--- a/plugins/cc/cctac.ml
+++ b/plugins/cc/cctac.ml
@@ -356,7 +356,8 @@ let rec proof_tac p : unit Proofview.tactic =
              Tacticals.tclFIRST
                [Tacticals.tclTHEN lemma2 (proof_tac p2);
                 reflexivity;
-                Tacticals.tclZEROMSG
+                let info = Exninfo.reify () in
+                Tacticals.tclZEROMSG ~info
                     (Pp.str
                        "I don't know how to handle dependent equality")]])))
   | Inject (prf,cstr,nargs,argind) ->
@@ -451,7 +452,9 @@ let cc_tactic depth additional_terms b =
     let _ = debug_congruence (fun () -> Pp.str "Computation completed.") in
     let uf=forest state in
     match sol with
-      None -> Tacticals.tclFAIL 0 (str (if b then "simple congruence failed" else "congruence failed"))
+      None ->
+      let info = Exninfo.reify () in
+      Tacticals.tclFAIL ~info 0 (str (if b then "simple congruence failed" else "congruence failed"))
     | Some reason ->
       debug_congruence (fun () -> Pp.str "Goal solved, generating proof ...");
       match reason with
@@ -482,7 +485,8 @@ let cc_tactic depth additional_terms b =
                         end ++
                       fnl() ++ str "  replacing metavariables by arbitrary terms")
         in
-        Tacticals.tclFAIL 0 msg
+        let info = Exninfo.reify () in
+        Tacticals.tclFAIL ~info 0 msg
       | Contradiction dis ->
         let env = Proofview.Goal.env gl in
         let p=build_proof env sigma uf (`Prove (dis.lhs,dis.rhs)) in

--- a/plugins/firstorder/ground.ml
+++ b/plugins/firstorder/ground.ml
@@ -55,7 +55,8 @@ let ground_tac solver startseq =
                       | Rforall->
                           let backtrack1=
                             if !qflag then
-                              tclFAIL 0 (Pp.str "reversible in 1st order mode")
+                              let info = Exninfo.reify () in
+                              tclFAIL ~info 0 (Pp.str "reversible in 1st order mode")
                             else
                               backtrack in
                             forall_tac backtrack1 continue (re_add seq1)

--- a/plugins/firstorder/instances.ml
+++ b/plugins/firstorder/instances.ml
@@ -133,7 +133,8 @@ let left_instance_tac (inst,id) continue seq=
   match inst with
       Phantom dom->
         if lookup env sigma (id,None) seq then
-          tclFAIL 0 (Pp.str "already done")
+          let info = Exninfo.reify () in
+          tclFAIL ~info 0 (Pp.str "already done")
         else
           tclTHENS (cut dom)
             [tclTHENLIST
@@ -150,7 +151,8 @@ let left_instance_tac (inst,id) continue seq=
     | Real((m,t),_)->
         let c = (m, EConstr.to_constr ~abort_on_undefined_evars:false sigma t) in
         if lookup env sigma (id,Some c) seq then
-          tclFAIL 0 (Pp.str "already done")
+          let info = Exninfo.reify () in
+          tclFAIL ~info 0 (Pp.str "already done")
         else
           let special_generalize=
             if m>0 then
@@ -195,7 +197,8 @@ let right_instance_tac inst continue seq=
         (tclTHEN (split (Tactypes.ImplicitBindings [t]))
            (tclSOLVE [wrap 0 true continue (deepen seq)]))
     | Real ((m,t),_) ->
-        tclFAIL 0 (Pp.str "not implemented ... yet")
+      let info = Exninfo.reify () in
+      tclFAIL ~info 0 (Pp.str "not implemented ... yet")
   end
 
 let instance_tac inst=

--- a/plugins/firstorder/rules.ml
+++ b/plugins/firstorder/rules.ml
@@ -65,7 +65,9 @@ let axiom_tac t seq =
   try
     pf_constr_of_global (find_left (project gl) t seq) >>= fun c ->
     exact_no_check c
-  with Not_found -> tclFAIL 0 (Pp.str "No axiom link")
+  with Not_found as exn ->
+    let _, info = Exninfo.capture exn in
+    tclFAIL ~info 0 (Pp.str "No axiom link")
   end
 
 let ll_atom_tac a backtrack id continue seq =
@@ -75,7 +77,9 @@ let ll_atom_tac a backtrack id continue seq =
         [(Proofview.tclEVARMAP >>= fun sigma ->
           let gr =
             try Proofview.tclUNIT (find_left sigma a seq)
-            with Not_found -> tclFAIL 0 (Pp.str "No link")
+            with Not_found as exn ->
+              let _, info = Exninfo.capture exn in
+              tclFAIL ~info 0 (Pp.str "No link")
           in
           gr >>= fun gr ->
           pf_constr_of_global gr >>= fun left ->
@@ -190,7 +194,8 @@ let forall_tac backtrack continue seq=
           (tclTHEN introf (tclCOMPLETE (wrap 0 true continue seq)))
           backtrack))
     (if !qflag then
-       tclFAIL 0 (Pp.str "reversible in 1st order mode")
+       let info = Exninfo.reify () in
+       tclFAIL ~info 0 (Pp.str "reversible in 1st order mode")
      else
        backtrack)
 

--- a/plugins/funind/indfun_common.ml
+++ b/plugins/funind/indfun_common.ml
@@ -415,7 +415,8 @@ let list_rewrite (rev : bool) (eqs : (EConstr.constr * bool) list) =
             ((if b then Equality.rewriteLR else Equality.rewriteRL) eq)
             i)
         (if rev then List.rev eqs else eqs)
-        (tclFAIL 0 (mt ()))) [@ocaml.warning "-3"])
+        (let info = Exninfo.reify () in
+         tclFAIL ~info 0 (mt ()))) [@ocaml.warning "-3"])
 
 let decompose_lam_n sigma n =
   if n < 0 then

--- a/plugins/funind/invfun.ml
+++ b/plugins/funind/invfun.ml
@@ -93,7 +93,12 @@ let functional_inversion kn hid fconst f_correct =
             ((fun hid -> intros_symmetry (Locusops.onHyp hid)), f_args, args.(2))
           | _, App (f, f_args) when EConstr.eq_constr sigma f fconst ->
             ((fun hid -> tclIDTAC), f_args, args.(1))
-          | _ -> ((fun hid -> tclFAIL 1 Pp.(mt ())), [||], args.(2))
+          | _ ->
+            ( (fun hid ->
+                let info = Exninfo.reify () in
+                tclFAIL ~info 1 Pp.(mt ()))
+            , [||]
+            , args.(2) )
         in
         tclTHENLIST
           [ pre_tac hid
@@ -109,7 +114,9 @@ let functional_inversion kn hid fconst f_correct =
                     (pf_ids_of_hyps gl)
                 in
                 tclMAP (revert_graph kn pre_tac) (hid :: new_ids)) ]
-      | _ -> tclFAIL 1 Pp.(mt ()))
+      | _ ->
+        let info = Exninfo.reify () in
+        tclFAIL ~info 1 Pp.(mt ()))
 
 let invfun qhyp f =
   let f =

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -946,7 +946,9 @@ let rec prove_le () =
                 ; New.observe_tac
                     (fun _ _ -> str "prove_le (rec)")
                     (prove_le ()) ]
-            with Not_found -> Tacticals.tclFAIL 0 (mt ())
+            with Not_found as exn ->
+              let _, info = Exninfo.capture exn in
+              Tacticals.tclFAIL ~info 0 (mt ())
           end ])
 
 let rec make_rewrite_list expr_info max = function

--- a/plugins/ltac/coretactics.mlg
+++ b/plugins/ltac/coretactics.mlg
@@ -337,7 +337,9 @@ let register_list_tactical name f =
   let tac args ist = match args with
   | [v] ->
     begin match Tacinterp.Value.to_list v with
-    | None -> Tacticals.tclZEROMSG (Pp.str "Expected a list")
+    | None ->
+      let info = Exninfo.reify () in
+      Tacticals.tclZEROMSG ~info (Pp.str "Expected a list")
     | Some tacs ->
       let tacs = List.map (fun tac -> Tacinterp.tactic_of_value ist tac) tacs in
       f tacs

--- a/plugins/ltac/extratactics.mlg
+++ b/plugins/ltac/extratactics.mlg
@@ -522,7 +522,11 @@ END
 TACTIC EXTEND constr_eq_nounivs
 | [ "constr_eq_nounivs" constr(x) constr(y) ] -> {
     Proofview.tclEVARMAP >>= fun sigma ->
-    if EConstr.eq_constr_nounivs sigma x y then Proofview.tclUNIT () else Tacticals.tclFAIL 0 (str "Not equal") }
+    if EConstr.eq_constr_nounivs sigma x y
+    then Proofview.tclUNIT ()
+    else
+      let info = Exninfo.reify () in
+      Tacticals.tclFAIL ~info 0 (str "Not equal") }
 END
 
 TACTIC EXTEND is_evar
@@ -680,8 +684,9 @@ let guard tst =
   if run_test tst then
     Proofview.tclUNIT ()
   else
+    let info = Exninfo.reify () in
     let msg = Pp.(str"Condition not satisfied:"++ws 1++(pr_itest tst)) in
-    Tacticals.tclZEROMSG msg
+    Tacticals.tclZEROMSG ~info msg
 
 }
 

--- a/plugins/ltac/g_auto.mlg
+++ b/plugins/ltac/g_auto.mlg
@@ -182,7 +182,8 @@ TACTIC EXTEND unify
     match table with
     | None ->
       let msg = str "Hint table " ++ str base ++ str " not found" in
-      Tacticals.tclZEROMSG msg
+      let info = Exninfo.reify () in
+      Tacticals.tclZEROMSG ~info msg
     | Some t ->
       let state = Hints.Hint_db.transparent_state t in
       Tactics.unify ~state x y

--- a/plugins/ltac/internals.ml
+++ b/plugins/ltac/internals.ml
@@ -273,8 +273,10 @@ let rec find_a_destructable_match sigma t =
 
 let destauto0 t =
   Proofview.tclEVARMAP >>= fun sigma ->
-  try find_a_destructable_match sigma t;
-    Tacticals.tclZEROMSG (Pp.str "No destructable match found")
+  try
+    find_a_destructable_match sigma t;
+    let info = Exninfo.reify () in
+    Tacticals.tclZEROMSG ~info (Pp.str "No destructable match found")
   with Found tac -> tac
 
 let destauto =
@@ -294,55 +296,73 @@ let is_evar x =
   Proofview.tclEVARMAP >>= fun sigma ->
   match EConstr.kind sigma x with
     | Evar _ -> Proofview.tclUNIT ()
-    | _ -> Tacticals.tclFAIL 0 (Pp.str "Not an evar")
+    | _ ->
+      let info = Exninfo.reify () in
+      Tacticals.tclFAIL ~info 0 (Pp.str "Not an evar")
 
 let has_evar x =
   Proofview.tclEVARMAP >>= fun sigma ->
   if Evarutil.has_undefined_evars sigma x
   then Proofview.tclUNIT ()
-  else Tacticals.tclFAIL 0 (Pp.str "No evars")
+  else
+    let info = Exninfo.reify () in
+    Tacticals.tclFAIL ~info 0 (Pp.str "No evars")
 
 let is_var x =
   Proofview.tclEVARMAP >>= fun sigma ->
   match EConstr.kind sigma x with
     | Var _ ->  Proofview.tclUNIT ()
-    | _ -> Tacticals.tclFAIL 0 (Pp.str "Not a variable or hypothesis")
+    | _ ->
+      let info = Exninfo.reify () in
+      Tacticals.tclFAIL ~info 0 (Pp.str "Not a variable or hypothesis")
 
 let is_fix x =
   Proofview.tclEVARMAP >>= fun sigma ->
   match EConstr.kind sigma x with
     | Fix _ -> Proofview.tclUNIT ()
-    | _ -> Tacticals.tclFAIL 0 (Pp.str "not a fix definition")
+    | _ ->
+      let info = Exninfo.reify () in
+      Tacticals.tclFAIL ~info 0 (Pp.str "not a fix definition")
 
 let is_cofix x =
   Proofview.tclEVARMAP >>= fun sigma ->
   match EConstr.kind sigma x with
     | CoFix _ -> Proofview.tclUNIT ()
-    | _ -> Tacticals.tclFAIL 0 (Pp.str "not a cofix definition")
+    | _ ->
+      let info = Exninfo.reify () in
+      Tacticals.tclFAIL ~info 0 (Pp.str "not a cofix definition")
 
 let is_ind x =
   Proofview.tclEVARMAP >>= fun sigma ->
   match EConstr.kind sigma x with
     | Ind _ -> Proofview.tclUNIT ()
-    | _ -> Tacticals.tclFAIL 0 (Pp.str "not an (co)inductive datatype")
+    | _ ->
+      let info = Exninfo.reify () in
+      Tacticals.tclFAIL ~info 0 (Pp.str "not an (co)inductive datatype")
 
 let is_constructor x =
   Proofview.tclEVARMAP >>= fun sigma ->
   match EConstr.kind sigma x with
     | Construct _ -> Proofview.tclUNIT ()
-    | _ -> Tacticals.tclFAIL 0 (Pp.str "not a constructor")
+    | _ ->
+      let info = Exninfo.reify () in
+      Tacticals.tclFAIL ~info 0 (Pp.str "not a constructor")
 
 let is_proj x =
   Proofview.tclEVARMAP >>= fun sigma ->
   match EConstr.kind sigma x with
     | Proj _ -> Proofview.tclUNIT ()
-    | _ -> Tacticals.tclFAIL 0 (Pp.str "not a primitive projection")
+    | _ ->
+      let info = Exninfo.reify () in
+      Tacticals.tclFAIL ~info 0 (Pp.str "not a primitive projection")
 
 let is_const x =
   Proofview.tclEVARMAP >>= fun sigma ->
   match EConstr.kind sigma x with
     | Const _ -> Proofview.tclUNIT ()
-    | _ -> Tacticals.tclFAIL 0 (Pp.str "not a constant")
+    | _ ->
+      let info = Exninfo.reify () in
+      Tacticals.tclFAIL ~info 0 (Pp.str "not a constant")
 
 let unshelve ist t =
   Proofview.with_shelf (Tacinterp.tactic_of_value ist t) >>= fun (gls, ()) ->

--- a/plugins/ltac2/tac2core.ml
+++ b/plugins/ltac2/tac2core.ml
@@ -695,7 +695,8 @@ let () = define3 "constr_in_context" ident constr closure begin fun id t c ->
       with Not_found -> false
     in
     if has_var then
-      Tacticals.tclZEROMSG (str "Variable already exists")
+      let info = Exninfo.reify () in
+      Tacticals.tclZEROMSG ~info (str "Variable already exists")
     else
       let open Context.Named.Declaration in
       let nenv = EConstr.push_named (LocalAssum (Context.make_annot id Sorts.Relevant, t)) env in
@@ -953,8 +954,10 @@ let () = define1 "hyp" ident begin fun id ->
   pf_apply begin fun env _ ->
     let mem = try ignore (Environ.lookup_named id env); true with Not_found -> false in
     if mem then return (Value.of_constr (EConstr.mkVar id))
-    else Tacticals.tclZEROMSG
-      (str "Hypothesis " ++ quote (Id.print id) ++ str " not found") (* FIXME: Do something more sensible *)
+    else
+      let info = Exninfo.reify () in
+      Tacticals.tclZEROMSG ~info
+        (str "Hypothesis " ++ quote (Id.print id) ++ str " not found") (* FIXME: Do something more sensible *)
   end
 end
 

--- a/plugins/ltac2/tac2stdlib.ml
+++ b/plugins/ltac2/tac2stdlib.ml
@@ -290,7 +290,8 @@ let () = define_prim5 "tac_remember" bool name (thunk constr) (option intro_patt
     thaw constr c >>= fun c ->
     Tac2tactics.letin_pat_tac ev (Some (true, eqpat)) na (sigma, c) cl
   | _ ->
-    Tacticals.tclZEROMSG (Pp.str "Invalid pattern for remember")
+    let info = Exninfo.reify () in
+    Tacticals.tclZEROMSG ~info (Pp.str "Invalid pattern for remember")
 end
 
 let () = define_prim3 "tac_destruct" bool (list induction_clause) (option constr_with_bindings) begin fun ev ic using ->

--- a/plugins/ltac2/tac2tactics.ml
+++ b/plugins/ltac2/tac2tactics.ml
@@ -217,9 +217,11 @@ let get_evaluable_reference = function
 | GlobRef.VarRef id -> Proofview.tclUNIT (Tacred.EvalVarRef id)
 | GlobRef.ConstRef cst -> Proofview.tclUNIT (Tacred.EvalConstRef cst)
 | r ->
-  Tacticals.tclZEROMSG (str "Cannot coerce" ++ spc () ++
-    Nametab.pr_global_env Id.Set.empty r ++ spc () ++
-    str "to an evaluable reference.")
+  let info = Exninfo.reify () in
+  Tacticals.tclZEROMSG ~info
+    (str "Cannot coerce" ++ spc () ++
+     Nametab.pr_global_env Id.Set.empty r ++ spc () ++
+     str "to an evaluable reference.")
 
 let reduce r cl =
   let cl = mk_clause cl in
@@ -419,7 +421,8 @@ let inversion knd arg pat ids =
   | Some (IntroAction (IntroOrAndPattern p)) ->
     Proofview.tclUNIT (Some (CAst.make @@ mk_or_and_intro_pattern p))
   | Some _ ->
-    Tacticals.tclZEROMSG (str "Inversion only accept disjunctive patterns")
+    let info = Exninfo.reify () in
+    Tacticals.tclZEROMSG ~info (str "Inversion only accept disjunctive patterns")
   end >>= fun pat ->
   let inversion _ arg =
     begin match arg with

--- a/plugins/micromega/coq_micromega.ml
+++ b/plugins/micromega/coq_micromega.ml
@@ -1858,9 +1858,11 @@ let micromega_gen parse_arith pre_process cnf spec dumpexpr prover tac =
         with
         | Unknown ->
           flush stdout;
-          Tacticals.tclFAIL 0 (Pp.str " Cannot find witness")
+          let info = Exninfo.reify () in
+          Tacticals.tclFAIL ~info 0 (Pp.str " Cannot find witness")
         | Model (m, e) ->
-          Tacticals.tclFAIL 0 (Pp.str " Cannot find witness")
+          let info = Exninfo.reify () in
+          Tacticals.tclFAIL ~info 0 (Pp.str " Cannot find witness")
         | Prf (ids, ff', res') ->
           let arith_goal, props, vars, ff_arith =
             make_goal_of_formula (genv, sigma) dumpexpr ff'
@@ -1906,10 +1908,13 @@ Tacticals.tclTHEN
                   ( EConstr.mkVar goal_name
                   , arith_args @ List.map EConstr.mkVar ids )))
       with
-      | Mfourier.TimeOut -> Tacticals.tclFAIL 0 (Pp.str "Timeout")
+      | Mfourier.TimeOut ->
+        let info = Exninfo.reify () in
+        Tacticals.tclFAIL ~info 0 (Pp.str "Timeout")
       | CsdpNotFound ->
         flush stdout;
-        Tacticals.tclFAIL 0
+        let info = Exninfo.reify () in
+        Tacticals.tclFAIL ~info 0
           (Pp.str
              ( " Skipping what remains of this tactic: the complexity of the \
                 goal requires "
@@ -1921,7 +1926,8 @@ Tacticals.tclTHEN
                 https://projects.coin-or.org/Csdp" ))
       | x ->
         if debug then
-          Tacticals.tclFAIL 0 (Pp.str (Printexc.get_backtrace ()))
+          let info = Exninfo.reify () in
+          Tacticals.tclFAIL ~info 0 (Pp.str (Printexc.get_backtrace ()))
         else raise x)
 
 let micromega_order_changer cert env ff =
@@ -1995,7 +2001,8 @@ let micromega_genr prover tac =
         with
         | Unknown | Model _ ->
           flush stdout;
-          Tacticals.tclFAIL 0 (Pp.str " Cannot find witness")
+          let info = Exninfo.reify () in
+          Tacticals.tclFAIL ~info 0 (Pp.str " Cannot find witness")
         | Prf (ids, ff', res') ->
           let ff, ids =
             formula_hyps_concl
@@ -2045,10 +2052,13 @@ let micromega_genr prover tac =
                 ; Tactics.exact_check
                     (EConstr.applist (EConstr.mkVar goal_name, arith_args)) ] ]
       with
-      | Mfourier.TimeOut -> Tacticals.tclFAIL 0 (Pp.str "Timeout")
+      | Mfourier.TimeOut ->
+        let info = Exninfo.reify () in
+        Tacticals.tclFAIL ~info 0 (Pp.str "Timeout")
       | CsdpNotFound ->
         flush stdout;
-        Tacticals.tclFAIL 0
+        let info = Exninfo.reify () in
+        Tacticals.tclFAIL ~info 0
           (Pp.str
              ( " Skipping what remains of this tactic: the complexity of the \
                 goal requires "

--- a/plugins/micromega/zify.ml
+++ b/plugins/micromega/zify.ml
@@ -1393,8 +1393,9 @@ let assert_inj t =
       try
         ignore (get_injection env evd t);
         Tacticals.tclIDTAC
-      with Not_found ->
-        Tacticals.tclFAIL 0 (Pp.str " InjTyp does not exist"))
+      with Not_found as exn ->
+        let _, info = Exninfo.capture exn in
+        Tacticals.tclFAIL ~info 0 (Pp.str " InjTyp does not exist"))
 
 let elim_binding x t ty =
   Proofview.Goal.enter (fun gl ->

--- a/plugins/ring/ring.ml
+++ b/plugins/ring/ring.ml
@@ -108,7 +108,11 @@ let closed_term args _ = match args with
   let l = List.map (fun c -> Value.cast (Genarg.topwit Stdarg.wit_ref) c) (Option.get (Value.to_list l)) in
   Proofview.tclEVARMAP >>= fun sigma ->
   let cs = List.fold_right GlobRef.Set_env.add l GlobRef.Set_env.empty in
-  if closed_under sigma cs t then Proofview.tclUNIT () else Tacticals.tclFAIL 0 (mt())
+  if closed_under sigma cs t
+  then Proofview.tclUNIT ()
+  else
+    let info = Exninfo.reify () in
+    Tacticals.tclFAIL ~info 0 (mt())
 | _ -> assert false
 
 let closed_term_ast =

--- a/plugins/ssr/ssrequality.ml
+++ b/plugins/ssr/ssrequality.ml
@@ -168,7 +168,9 @@ let newssrcongrtac arg ist =
       Tacticals.tclTHENLIST [ pf_typecheck a
                   ; Tactics.apply a
                   ; congrtac (arg, mkRType) ist ])
-    (fun _ -> Tacticals.tclZEROMSG Pp.(str"Conclusion is not an equality nor an arrow"))
+    (fun () ->
+       let info = Exninfo.reify () in
+       Tacticals.tclZEROMSG ~info Pp.(str"Conclusion is not an equality nor an arrow"))
     with e -> Proofview.tclZERO e (* FIXME *)
     ))
     gl
@@ -486,13 +488,13 @@ let rwcltac ?under ?map_redex cl rdx dir sr =
   in
   let cvtac' =
     Proofview.tclORELSE cvtac begin function
-    | (PRtype_error e, _) ->
+    | (PRtype_error e, info) ->
       let error = Option.cata (fun (env, sigma, te) ->
           Pp.(fnl () ++ str "Type error was: " ++ Himsg.explain_pretype_error env sigma te))
           (Pp.mt ()) e in
       if occur_existential sigma0 (Tacmach.pf_concl gl)
-      then Tacticals.tclZEROMSG Pp.(str "Rewriting impacts evars" ++ error)
-      else Tacticals.tclZEROMSG Pp.(str "Dependent type error in rewrite of "
+      then Tacticals.tclZEROMSG ~info Pp.(str "Rewriting impacts evars" ++ error)
+      else Tacticals.tclZEROMSG ~info Pp.(str "Dependent type error in rewrite of "
         ++ pr_econstr_env env sigma0
           (EConstr.mkNamedLambda (make_annot pattern_id Sorts.Relevant) rdxt cl)
         ++ error)

--- a/plugins/ssr/ssrview.ml
+++ b/plugins/ssr/ssrview.ml
@@ -248,9 +248,12 @@ let pad_to_inductive ist glob = Goal.enter_one ~__LOC__ begin fun goal ->
   let rel_ctx =
     List.map (fun (a,b) -> Context.Rel.Declaration.LocalAssum(a,b)) ctx in
   if not (Ssrcommon.isAppInd (EConstr.push_rel_context rel_ctx env) sigma i)
-  then Tacticals.tclZEROMSG Pp.(str"not an inductive")
-  else tclUNIT (mkGApp glob (mkGHoles (List.length ctx)))
-       >>= tclADD_CLEAR_IF_ID ot
+  then
+    let info = Exninfo.reify () in
+    Tacticals.tclZEROMSG ~info Pp.(str"not an inductive")
+  else
+    tclUNIT (mkGApp glob (mkGHoles (List.length ctx)))
+    >>= tclADD_CLEAR_IF_ID ot
 end
 
 (* There are two ways of "applying" a view to term:            *)

--- a/tactics/eauto.ml
+++ b/tactics/eauto.ml
@@ -415,7 +415,9 @@ let autounfold db cls =
       | OnHyp (id, _, where) -> tac (Some (id, where))
       | OnConcl _ -> tac None) cls
     end
-  | exception UnknownDatabase dbname -> Tacticals.tclZEROMSG (str "Unknown database " ++ str dbname)
+  | exception (UnknownDatabase dbname as exn) ->
+    let _, info = Exninfo.capture exn in
+    Tacticals.tclZEROMSG ~info (str "Unknown database " ++ str dbname)
 
 let autounfold_tac db cls =
   Proofview.tclUNIT () >>= fun () ->

--- a/tactics/eqdecide.ml
+++ b/tactics/eqdecide.ml
@@ -224,7 +224,8 @@ let solveEqBranch rectype =
       end
     end
     begin function (e, info) -> match e with
-      | PatternMatchingFailure -> Tacticals.tclZEROMSG (Pp.str"Unexpected conclusion!")
+      | PatternMatchingFailure ->
+        Tacticals.tclZEROMSG ~info (Pp.str"Unexpected conclusion!")
       | e -> Proofview.tclZERO ~info e
     end
 
@@ -245,7 +246,9 @@ let decideGralEquality =
         let headtyp = hd_app sigma (pf_compute gl typ) in
         begin match EConstr.kind sigma headtyp with
         | Ind (mi,_) -> Proofview.tclUNIT mi
-        | _ -> tclZEROMSG (Pp.str"This decision procedure only works for inductive objects.")
+        | _ ->
+          let info = Exninfo.reify () in
+          tclZEROMSG ~info (Pp.str"This decision procedure only works for inductive objects.")
         end >>= fun rectype ->
           (tclTHEN
              (mkBranches data)
@@ -254,7 +257,7 @@ let decideGralEquality =
     end
     begin function (e, info) -> match e with
       | PatternMatchingFailure ->
-          Tacticals.tclZEROMSG (Pp.str"The goal must be of the form {x<>y}+{x=y} or {x=y}+{x<>y}.")
+        Tacticals.tclZEROMSG ~info (Pp.str"The goal must be of the form {x<>y}+{x=y} or {x=y}+{x<>y}.")
       | e -> Proofview.tclZERO ~info e
     end
 

--- a/tactics/inv.ml
+++ b/tactics/inv.ml
@@ -299,7 +299,8 @@ let error_too_many_names pats =
   let loc = Loc.merge_opt (List.hd pats).CAst.loc (List.last pats).CAst.loc in
   Proofview.tclENV >>= fun env ->
   Proofview.tclEVARMAP >>= fun sigma ->
-  tclZEROMSG ?loc (
+  let info = Exninfo.reify () in
+  tclZEROMSG ~info ?loc (
     str "Unexpected " ++
     str (String.plural (List.length pats) "introduction pattern") ++
     str ": " ++ pr_enum (Miscprint.pr_intro_pattern
@@ -509,7 +510,8 @@ let wrap_inv_error id = function (e, info) -> match e with
       (_, Indrec.NotAllowedCaseAnalysis (_,(Type _ | Set as k),i)) ->
       Proofview.tclENV >>= fun env ->
       Proofview.tclEVARMAP >>= fun sigma ->
-      tclZEROMSG (
+      let info = Exninfo.reify () in
+      tclZEROMSG ~info (
         (strbrk "Inversion would require case analysis on sort " ++
         pr_sort sigma k ++
         strbrk " which is not allowed for inductive definition " ++

--- a/tactics/tacticals.mli
+++ b/tactics/tacticals.mli
@@ -127,9 +127,9 @@ val tclTHEN : unit tactic -> unit tactic -> unit tactic
 (* [tclFAIL n msg] fails with [msg] as an error message at level [n]
     (meaning that it will jump over [n] error catching tacticals FROM
     THIS MODULE. *)
-val tclFAIL : ?info:Exninfo.info -> int -> Pp.t -> 'a tactic
+val tclFAIL : info:Exninfo.info -> int -> Pp.t -> 'a tactic
 
-val tclZEROMSG : ?info:Exninfo.info -> ?loc:Loc.t -> Pp.t -> 'a tactic
+val tclZEROMSG : info:Exninfo.info -> ?loc:Loc.t -> Pp.t -> 'a tactic
 (** Fail with a [User_Error] containing the given message. *)
 
 val tclOR : unit tactic -> unit tactic -> unit tactic

--- a/vernac/auto_ind_decl.ml
+++ b/vernac/auto_ind_decl.ml
@@ -533,30 +533,44 @@ let do_replace_bl handle (ind,u as indu) aavoid narg lft rgt =
         )
         end
     | ([],[]) -> Proofview.tclUNIT ()
-    | _ -> Tacticals.tclZEROMSG (str "Both side of the equality must have the same arity.")
+    | _ ->
+      let info = Exninfo.reify () in
+      Tacticals.tclZEROMSG ~info (str "Both side of the equality must have the same arity.")
   in
   Proofview.tclEVARMAP >>= fun sigma ->
   begin try Proofview.tclUNIT (destApp sigma lft)
-    with DestKO -> Tacticals.tclZEROMSG (str "replace failed.")
+    with DestKO ->
+      let info = Exninfo.reify () in
+      Tacticals.tclZEROMSG ~info (str "replace failed.")
   end >>= fun (ind1,ca1) ->
   begin try Proofview.tclUNIT (destApp sigma rgt)
-    with DestKO -> Tacticals.tclZEROMSG (str "replace failed.")
+    with DestKO ->
+      let info = Exninfo.reify () in
+      Tacticals.tclZEROMSG ~info (str "replace failed.")
   end >>= fun (ind2,ca2) ->
-  begin try Proofview.tclUNIT (fst (destInd sigma ind1))
+  begin
+    try Proofview.tclUNIT (fst (destInd sigma ind1))
     with DestKO ->
       begin try Proofview.tclUNIT (fst (fst (destConstruct sigma ind1)))
-        with DestKO -> Tacticals.tclZEROMSG (str "The expected type is an inductive one.")
+        with DestKO ->
+          let info = Exninfo.reify () in
+          Tacticals.tclZEROMSG ~info (str "The expected type is an inductive one.")
       end
   end >>= fun (sp1,i1) ->
-  begin try Proofview.tclUNIT (fst (destInd sigma ind2))
+  begin
+    try Proofview.tclUNIT (fst (destInd sigma ind2))
     with DestKO ->
       begin try Proofview.tclUNIT (fst (fst (destConstruct sigma ind2)))
-        with DestKO -> Tacticals.tclZEROMSG (str "The expected type is an inductive one.")
+        with DestKO ->
+          let info = Exninfo.reify () in
+          Tacticals.tclZEROMSG ~info (str "The expected type is an inductive one.")
       end
   end >>= fun (sp2,i2) ->
   Proofview.tclENV >>= fun env ->
   if not (Environ.QMutInd.equal env sp1 sp2) || not (Int.equal i1 i2)
-  then Tacticals.tclZEROMSG (str "Eq should be on the same type")
+  then
+    let info = Exninfo.reify () in
+    Tacticals.tclZEROMSG ~info (str "Eq should be on the same type")
   else aux (Array.to_list ca1) (Array.to_list ca2)
 
 (*
@@ -683,12 +697,16 @@ repeat ( apply andb_prop in z;let z1:= fresh "Z" in destruct z as [z1 z]).
                             (ca.(1)))
                          Auto.default_auto
                      else
-                       Tacticals.tclZEROMSG (str "Failure while solving Boolean->Leibniz.")
-                  | _ -> Tacticals.tclZEROMSG (str" Failure while solving Boolean->Leibniz.")
+                       let info = Exninfo.reify () in
+                       Tacticals.tclZEROMSG ~info (str "Failure while solving Boolean->Leibniz.")
+                  | _ ->
+                    let info = Exninfo.reify () in
+                    Tacticals.tclZEROMSG ~info (str" Failure while solving Boolean->Leibniz.")
                 )
-                | _ -> Tacticals.tclZEROMSG (str "Failure while solving Boolean->Leibniz.")
+                | _ ->
+                  let info = Exninfo.reify () in
+                  Tacticals.tclZEROMSG ~info (str "Failure while solving Boolean->Leibniz.")
                 end
-
             ]
           end
       ]
@@ -808,10 +826,12 @@ let compute_lb_tact handle ind lnamesparrec nparrec =
                                      nparrec
                                      ca'.(n-2) ca'.(n-1)
                                 | _ ->
-                                   Tacticals.tclZEROMSG (str "Failure while solving Leibniz->Boolean.")
+                                  let info = Exninfo.reify () in
+                                   Tacticals.tclZEROMSG ~info (str "Failure while solving Leibniz->Boolean.")
                                )
                 | _ ->
-                   Tacticals.tclZEROMSG (str "Failure while solving Leibniz->Boolean.")
+                  let info = Exninfo.reify () in
+                  Tacticals.tclZEROMSG ~info (str "Failure while solving Leibniz->Boolean.")
                 end
             ]
           end


### PR DESCRIPTION
When debugging some problems with evar modification (in #12629) I found some
missing backtraces originating from tactic code, so it seems useful to
require the two missing primitives to carry backtrace information.

AFAICT there are no more cases of missing backtrace information on
tactic code, so we should be finally done with this.
