### PR TITLE
Some changes of representation in Tacred

### DIFF
--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -572,14 +572,6 @@ let reduce_and_refold_fix recfun env sigma fix sk =
     (fun _ (t,sk') -> recfun (t,sk'))
     [] sigma raw_answer sk
 
-let fix_recarg ((recindices,bodynum),_) stack =
-  assert (0 <= bodynum && bodynum < Array.length recindices);
-  let recargnum = Array.get recindices bodynum in
-  try
-    Some (recargnum, Stack.nth stack recargnum)
-  with Not_found ->
-    None
-
 open Primred
 
 module CNativeEntries =

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -436,15 +436,11 @@ type state = constr * constr Stack.t
 type reduction_function = env -> evar_map -> constr -> constr
 type e_reduction_function = env -> evar_map -> constr -> evar_map * constr
 
-type contextual_stack_reduction_function =
+type stack_reduction_function =
     env -> evar_map -> constr -> constr * constr list
-type stack_reduction_function = contextual_stack_reduction_function
-type local_stack_reduction_function =
-    evar_map -> constr -> constr * constr list
 
 type state_reduction_function =
     env -> evar_map -> state -> state
-type local_state_reduction_function = evar_map -> state -> state
 
 let pr_state env sigma (tm,sk) =
   let open Pp in

--- a/pretyping/reductionops.mli
+++ b/pretyping/reductionops.mli
@@ -111,15 +111,11 @@ type reduction_function = env -> evar_map -> constr -> constr
 
 type e_reduction_function = env -> evar_map -> constr -> evar_map * constr
 
-type contextual_stack_reduction_function =
+type stack_reduction_function =
     env -> evar_map -> constr -> constr * constr list
-type stack_reduction_function = contextual_stack_reduction_function
-type local_stack_reduction_function =
-    evar_map -> constr -> constr * constr list
 
 type state_reduction_function =
     env -> evar_map -> state -> state
-type local_state_reduction_function = evar_map -> state -> state
 
 val pr_state : env -> evar_map -> state -> Pp.t
 
@@ -129,11 +125,6 @@ val strong_with_flags :
   (CClosure.RedFlags.reds -> reduction_function) ->
   (CClosure.RedFlags.reds -> reduction_function)
 val strong : reduction_function -> reduction_function
-(*i
-val stack_reduction_of_reduction :
-  'a reduction_function -> 'a state_reduction_function
-i*)
-val stacklam : (state -> 'a) -> constr list -> evar_map -> constr -> constr Stack.t -> 'a
 
 val whd_state_gen :
   CClosure.RedFlags.reds -> Environ.env -> Evd.evar_map -> state -> state
@@ -166,13 +157,13 @@ val whd_allnolet :  reduction_function
 val whd_betalet : reduction_function
 
 (** Removes cast and put into applicative form *)
-val whd_nored_stack : contextual_stack_reduction_function
-val whd_beta_stack : contextual_stack_reduction_function
-val whd_betaiota_stack : contextual_stack_reduction_function
-val whd_betaiotazeta_stack : contextual_stack_reduction_function
-val whd_all_stack : contextual_stack_reduction_function
-val whd_allnolet_stack : contextual_stack_reduction_function
-val whd_betalet_stack : contextual_stack_reduction_function
+val whd_nored_stack : stack_reduction_function
+val whd_beta_stack : stack_reduction_function
+val whd_betaiota_stack : stack_reduction_function
+val whd_betaiotazeta_stack : stack_reduction_function
+val whd_all_stack : stack_reduction_function
+val whd_allnolet_stack : stack_reduction_function
+val whd_betalet_stack : stack_reduction_function
 
 val whd_nored_state : state_reduction_function
 val whd_beta_state : state_reduction_function

--- a/pretyping/reductionops.mli
+++ b/pretyping/reductionops.mli
@@ -241,7 +241,6 @@ val is_arity : env ->  evar_map -> constr -> bool
 val is_sort : env -> evar_map -> types -> bool
 
 val contract_fix : evar_map -> fixpoint -> constr
-val fix_recarg : ('a, 'a) pfixpoint -> 'b Stack.t -> (int * 'b) option
 
 (** {6 Querying the kernel conversion oracle: opaque/transparent constants } *)
 val is_transparent : Environ.env -> Constant.t tableKey -> bool

--- a/pretyping/tacred.ml
+++ b/pretyping/tacred.ml
@@ -867,10 +867,10 @@ let try_red_product env sigma c =
                  (match fix_recarg fix (Array.to_list l) with
                     | None -> raise Redelimination
                     | Some (recargnum,recarg) ->
-                        let stack = Stack.append_app l Stack.empty in
                         let recarg' = redrec env recarg in
-                        let stack' = Stack.assign stack recargnum recarg' in
-                        simpfun (Stack.zip sigma (f,stack')))
+                        let l = Array.copy l in
+                        let () = Array.set l recargnum recarg' in
+                        simpfun (mkApp (f, l)))
              | _ -> simpfun (mkApp (redrec env f, l)))
       | Cast (c,_,_) -> redrec env c
       | Prod (x,a,b) ->


### PR DESCRIPTION
This cleans up a bit the intertwining between Reductionops and Tacred. The essential points are the following:
- Stop converting back and forth between arrays and lists
- Inline higher-order functions that were used only in one instance
- Remove the dependency on Reductionops.Stack in Tacred