### PR TITLE
Use local persistent data structures for VM global tables

### DIFF
--- a/dev/vm_printers.ml
+++ b/dev/vm_printers.ml
@@ -13,7 +13,7 @@ let ppripos (ri,pos) =
   | Reloc_getglobal kn ->
     print_string ("getglob "^(Constant.to_string kn)^"\n")
   | Reloc_caml_prim op ->
-    print_string ("caml primitive "^CPrimitives.to_string op)
+    print_string ("caml primitive "^ CPrimitives.to_string @@ Vmbytecodes.caml_prim_to_prim op)
   );
    print_flush ()
 

--- a/kernel/byterun/coq_interp.c
+++ b/kernel/byterun/coq_interp.c
@@ -1970,7 +1970,3 @@ value  coq_interprete_ml(value tcode, value a, value t, value g, value e, value 
 value coq_interprete_byte(value* argv, int argn){
   return coq_interprete_ml(argv[0], argv[1], argv[2], argv[3], argv[4], argv[5]);
 }
-
-value coq_eval_tcode (value tcode, value t, value g, value e) {
-  return coq_interprete_ml(tcode, Val_unit, t, g, e, 0);
-}

--- a/kernel/byterun/coq_interp.h
+++ b/kernel/byterun/coq_interp.h
@@ -22,5 +22,3 @@ value coq_interprete_byte(value* argv, int argn);
 
 value coq_interprete
     (code_t coq_pc, value coq_accu, value coq_atom_tbl, value coq_global_data, value coq_env, long coq_extra_args);
-
-value coq_eval_tcode (value tcode, value t, value g, value e);

--- a/kernel/vm.ml
+++ b/kernel/vm.ml
@@ -38,13 +38,7 @@ external push_val : values -> unit = "coq_push_val"
 external push_arguments : arguments -> unit = "coq_push_arguments"
 external push_vstack : vstack -> int -> unit = "coq_push_vstack"
 
-
-(* interpreteur *)
-external coq_interprete : tcode -> values -> atom array -> vm_global -> vm_env -> int -> values =
-  "coq_interprete_byte" "coq_interprete_ml"
-
-let interprete code v env k =
-  coq_interprete code v (get_atom_rel ()) (Vmsymtable.get_global_data ()) env k
+let interprete = Vmsymtable.vm_interp
 
 (* Functions over arguments *)
 

--- a/kernel/vmbytecodes.ml
+++ b/kernel/vmbytecodes.ml
@@ -27,6 +27,14 @@ module Label =
     let reset_label_counter () = counter := no
   end
 
+type caml_prim =
+| CAML_Arraymake
+| CAML_Arrayget
+| CAML_Arraydefault
+| CAML_Arrayset
+| CAML_Arraycopy
+| CAML_Arraylength
+
 type instruction =
   | Klabel of Label.t
   | Kacc of int
@@ -61,7 +69,7 @@ type instruction =
   | Kensurestackcapacity of int
   | Kbranch of Label.t                  (* jump to label *)
   | Kprim of CPrimitives.t * pconstant
-  | Kcamlprim of CPrimitives.t * Label.t
+  | Kcamlprim of caml_prim * Label.t
 
 and bytecodes = instruction list
 
@@ -76,6 +84,14 @@ type fv = fv_elem array
 (* --- Pretty print *)
 open Pp
 open Util
+
+let caml_prim_to_prim = function
+| CAML_Arraymake -> CPrimitives.Arraymake
+| CAML_Arrayget -> CPrimitives.Arrayget
+| CAML_Arraydefault -> CPrimitives.Arraydefault
+| CAML_Arrayset -> CPrimitives.Arrayset
+| CAML_Arraycopy -> CPrimitives.Arraycopy
+| CAML_Arraylength -> CPrimitives.Arraylength
 
 let pp_lbl lbl = str "L" ++ int lbl
 
@@ -148,7 +164,7 @@ let rec pp_instr i =
         (Constant.print (fst id))
 
   | Kcamlprim (op, lbl) ->
-    str "camlcall " ++ str (CPrimitives.to_string op) ++ str ", branch " ++
+    str "camlcall " ++ str (CPrimitives.to_string (caml_prim_to_prim op)) ++ str ", branch " ++
     pp_lbl lbl ++ str " on accu"
 
 and pp_bytecodes c =

--- a/kernel/vmbytecodes.mli
+++ b/kernel/vmbytecodes.mli
@@ -22,6 +22,14 @@ module Label :
     val reset_label_counter : unit -> unit
   end
 
+type caml_prim =
+| CAML_Arraymake
+| CAML_Arrayget
+| CAML_Arraydefault
+| CAML_Arrayset
+| CAML_Arraycopy
+| CAML_Arraylength
+
 type instruction =
   | Klabel of Label.t
   | Kacc of int                         (** accu = sp[n] *)
@@ -60,7 +68,7 @@ type instruction =
 
   | Kbranch of Label.t                  (** jump to label, is it needed ? *)
   | Kprim of CPrimitives.t * pconstant
-  | Kcamlprim of CPrimitives.t * Label.t
+  | Kcamlprim of caml_prim * Label.t
 
 and bytecodes = instruction list
 
@@ -75,3 +83,5 @@ type fv_elem =
 type fv = fv_elem array
 
 val pp_fv_elem : fv_elem -> Pp.t
+
+val caml_prim_to_prim : caml_prim -> CPrimitives.t

--- a/kernel/vmbytegen.ml
+++ b/kernel/vmbytegen.ml
@@ -878,7 +878,8 @@ let compile ~fail_on_error ?universes:(universes=0) env sigma c =
     let fv = List.rev (!(cenv.in_env).fv_rev) in
     (if !dump_bytecode then
       Feedback.msg_debug (dump_bytecodes init_code !fun_code fv)) ;
-    Some (init_code,!fun_code, Array.of_list fv)
+    let res = init_code @ !fun_code in
+    Some (to_memory res, Array.of_list fv)
   with TooLargeInductive msg as exn ->
     let _, info = Exninfo.capture exn in
     let fn = if fail_on_error then
@@ -899,7 +900,7 @@ let compile_constant_body ~fail_on_error env univs = function
         | _ ->
             let sigma _ = assert false in
             let res = compile ~fail_on_error ~universes:instance_size env sigma body in
-              Option.map (fun x -> BCdefined (to_memory x)) res
+            Option.map (fun (code, fv) -> BCdefined (code, fv)) res
 
 (* Shortcut of the previous function used during module strengthening *)
 

--- a/kernel/vmbytegen.mli
+++ b/kernel/vmbytegen.mli
@@ -18,7 +18,7 @@ open Environ
 val compile :
   fail_on_error:bool -> ?universes:int ->
   env -> (existential -> constr option) -> constr ->
-  (bytecodes * bytecodes * fv) option
+  (to_patch * fv) option
 (** init, fun, fv *)
 
 val compile_constant_body : fail_on_error:bool ->

--- a/kernel/vmemitcodes.ml
+++ b/kernel/vmemitcodes.ml
@@ -80,14 +80,14 @@ let patch_int buff reloc =
   let () = CArray.iter iter reloc in
   buff
 
-let patch (buff, pl) f accu =
-  let fold accu (r, pos) =
-    let accu, r = f r accu in
-    accu, (r, pos)
+let patch (buff, pl) f =
+  let map (r, pos) =
+    let r = f r in
+    (r, pos)
   in
-  let accu, reloc = CArray.fold_left_map fold accu pl.reloc_infos in
+  let reloc = CArray.map_left map pl.reloc_infos in
   let buff = patch_int buff reloc in
-  accu, tcode_of_code buff
+  tcode_of_code buff
 
 (* Buffering of bytecode *)
 

--- a/kernel/vmemitcodes.ml
+++ b/kernel/vmemitcodes.ml
@@ -83,11 +83,14 @@ let patch_int buff reloc =
   let () = CArray.iter iter reloc in
   buff
 
-let patch (buff, pl) f =
-  (** Order seems important here? *)
-  let reloc = CArray.map (fun (r, pos) -> (f r, pos)) pl.reloc_infos in
+let patch (buff, pl) f accu =
+  let fold accu (r, pos) =
+    let accu, r = f r accu in
+    accu, (r, pos)
+  in
+  let accu, reloc = CArray.fold_left_map fold accu pl.reloc_infos in
   let buff = patch_int buff reloc in
-  tcode_of_code buff
+  accu, tcode_of_code buff
 
 (* Buffering of bytecode *)
 

--- a/kernel/vmemitcodes.mli
+++ b/kernel/vmemitcodes.mli
@@ -19,7 +19,7 @@ type reloc_info =
 
 type to_patch
 
-val patch : to_patch -> (reloc_info -> int) -> Vmvalues.tcode
+val patch : to_patch -> (reloc_info -> 'a -> 'a * int) -> 'a -> 'a * Vmvalues.tcode
 
 type body_code =
   | BCdefined of to_patch * fv

--- a/kernel/vmemitcodes.mli
+++ b/kernel/vmemitcodes.mli
@@ -17,20 +17,16 @@ type reloc_info =
   | Reloc_getglobal of Constant.t
   | Reloc_caml_prim of caml_prim
 
-type patches
-type emitcodes
+type to_patch
 
-val patch : emitcodes -> patches -> (reloc_info -> int) -> Vmvalues.tcode
-
-type to_patch = emitcodes * patches * fv
+val patch : to_patch -> (reloc_info -> int) -> Vmvalues.tcode
 
 type body_code =
-  | BCdefined of to_patch
+  | BCdefined of to_patch * fv
   | BCalias of Constant.t
   | BCconstant
 
 
 val subst_body_code : Mod_subst.substitution -> body_code -> body_code
 
-val to_memory : bytecodes * bytecodes * fv -> to_patch
-               (** init code, fun code, fv *)
+val to_memory : bytecodes -> to_patch

--- a/kernel/vmemitcodes.mli
+++ b/kernel/vmemitcodes.mli
@@ -19,7 +19,7 @@ type reloc_info =
 
 type to_patch
 
-val patch : to_patch -> (reloc_info -> 'a -> 'a * int) -> 'a -> 'a * Vmvalues.tcode
+val patch : to_patch -> (reloc_info -> int) -> Vmvalues.tcode
 
 type body_code =
   | BCdefined of to_patch * fv

--- a/kernel/vmemitcodes.mli
+++ b/kernel/vmemitcodes.mli
@@ -15,7 +15,7 @@ type reloc_info =
   | Reloc_annot of annot_switch
   | Reloc_const of structured_constant
   | Reloc_getglobal of Constant.t
-  | Reloc_caml_prim of CPrimitives.t
+  | Reloc_caml_prim of caml_prim
 
 type patches
 type emitcodes

--- a/kernel/vmsymtable.ml
+++ b/kernel/vmsymtable.ml
@@ -237,9 +237,9 @@ let rec slot_for_getglobal env sigma kn =
       match cb.const_body_code with
       | None -> set_global (val_of_constant kn)
       | Some code ->
-         match code with
-         | BCdefined(code,pl,fv) ->
-           let v = eval_to_patch env sigma (code,pl,fv) in
+        match code with
+        | BCdefined (code, fv) ->
+           let v = eval_to_patch env sigma (code, fv) in
            set_global v
          | BCalias kn' -> slot_for_getglobal env sigma kn'
          | BCconstant -> set_global (val_of_constant kn)
@@ -278,14 +278,14 @@ and slot_for_fv env sigma fv =
   | FVuniv_var _idu ->
     assert false
 
-and eval_to_patch env sigma (buff,pl,fv) =
+and eval_to_patch env sigma (code, fv) =
   let slots = function
     | Reloc_annot a -> slot_for_annot a
     | Reloc_const sc -> slot_for_str_cst sc
     | Reloc_getglobal kn -> slot_for_getglobal env sigma kn
     | Reloc_caml_prim op -> slot_for_caml_prim op
   in
-  let tc = patch buff pl slots in
+  let tc = patch code slots in
   let vm_env =
     (* Environment should look like a closure, so free variables start at slot 2. *)
     let a = Array.make (Array.length fv + 2) crazy_val in
@@ -297,7 +297,7 @@ and eval_to_patch env sigma (buff,pl,fv) =
 
 and val_of_constr env sigma c =
   match compile ~fail_on_error:true env sigma c with
-  | Some v -> eval_to_patch env sigma (to_memory v)
+  | Some v -> eval_to_patch env sigma v
   | None -> assert false
 
 let set_transparent_const _kn = () (* !?! *)

--- a/kernel/vmsymtable.ml
+++ b/kernel/vmsymtable.ml
@@ -28,11 +28,11 @@ module RelDecl = Context.Rel.Declaration
 
 type vm_global = values array
 
-(* interpreteur *)
+(* interpreter *)
 external coq_interprete : tcode -> values -> atom array -> vm_global -> Vmvalues.vm_env -> int -> values =
   "coq_interprete_byte" "coq_interprete_ml"
 
-(* table pour les structured_constant et les annotations des switchs *)
+(* table for structured constants and switch annotations *)
 
 module HashMap (M : Hashtbl.HashedType) :
 sig
@@ -149,11 +149,11 @@ struct
 end
 
 
-(*******************)
-(* Linkage du code *)
-(*******************)
+(****************)
+(* Code linking *)
+(****************)
 
-(* Table des globaux *)
+(* Global Table *)
 
 (** [global_table] contains values of global constants, switch annotations,
     and structured constants. *)

--- a/kernel/vmsymtable.ml
+++ b/kernel/vmsymtable.ml
@@ -123,15 +123,13 @@ let slot_for_annot key =
     AnnotTable.add annot_tbl key n;
     n
 
-let slot_for_caml_prim =
-  let open CPrimitives in function
-  | Arraymake -> parray_make
-  | Arrayget -> parray_get
-  | Arraydefault -> parray_get_default
-  | Arrayset -> parray_set
-  | Arraycopy -> parray_copy
-  | Arraylength -> parray_length
-  | _ -> assert false
+let slot_for_caml_prim = function
+  | CAML_Arraymake -> parray_make
+  | CAML_Arrayget -> parray_get
+  | CAML_Arraydefault -> parray_get_default
+  | CAML_Arrayset -> parray_set
+  | CAML_Arraycopy -> parray_copy
+  | CAML_Arraylength -> parray_length
 
 let rec slot_for_getglobal env sigma kn =
   let (cb,(_,rk)) = lookup_constant_key kn env in

--- a/kernel/vmsymtable.ml
+++ b/kernel/vmsymtable.ml
@@ -300,8 +300,5 @@ and val_of_constr env sigma c =
   | Some v -> eval_to_patch env sigma v
   | None -> assert false
 
-let set_transparent_const _kn = () (* !?! *)
-let set_opaque_const _kn = () (* !?! *)
-
 let vm_interp code v env k =
   coq_interprete code v (get_atom_rel ()) (get_global_data ()) env k

--- a/kernel/vmsymtable.mli
+++ b/kernel/vmsymtable.mli
@@ -10,14 +10,10 @@
 
 (* $Id$ *)
 
-open Names
 open Constr
 open Environ
 open Vmvalues
 
 val val_of_constr : env -> (existential -> constr option) -> constr -> Vmvalues.values
-
-val set_opaque_const      : Constant.t -> unit
-val set_transparent_const : Constant.t -> unit
 
 val vm_interp : tcode -> values -> vm_env -> int -> values

--- a/kernel/vmsymtable.mli
+++ b/kernel/vmsymtable.mli
@@ -13,10 +13,11 @@
 open Names
 open Constr
 open Environ
+open Vmvalues
 
 val val_of_constr : env -> (existential -> constr option) -> constr -> Vmvalues.values
 
 val set_opaque_const      : Constant.t -> unit
 val set_transparent_const : Constant.t -> unit
 
-val get_global_data : unit -> Vmvalues.vm_global
+val vm_interp : tcode -> values -> vm_env -> int -> values

--- a/kernel/vmvalues.ml
+++ b/kernel/vmvalues.ml
@@ -162,15 +162,13 @@ let fix_val v = (Obj.magic v : values)
 let cofix_upd_val v = (Obj.magic v : values)
 
 type vm_env
-type vm_global
+let inj_env v = (Obj.magic v : vm_env)
 let fun_env v = (Obj.magic v : vm_env)
 let cofix_env v = (Obj.magic v : vm_env)
 let cofix_upd_env v = (Obj.magic v : vm_env)
 type vstack = values array
 
 let fun_of_val v = (Obj.magic v : vfun)
-
-let vm_global (v : values array) = (Obj.magic v : vm_global)
 
 (*******************************************)
 (* Machine code *** ************************)

--- a/kernel/vmvalues.mli
+++ b/kernel/vmvalues.mli
@@ -15,7 +15,6 @@ open Names
 type values
 type structured_values
 type vm_env
-type vm_global
 type vprod
 type vfun
 type vfix
@@ -61,12 +60,11 @@ val fun_val : vfun -> values
 val fix_val : vfix -> values
 val cofix_upd_val : to_update -> values
 
+val inj_env : values array -> vm_env
 val fun_env : vfun -> vm_env
 val fix_env : vfix -> vm_env
 val cofix_env : vcofix -> vm_env
 val cofix_upd_env : to_update -> vm_env
-
-val vm_global : values array -> vm_global
 
 (** Cast a value known to be a function, unsafe in general *)
 val fun_of_val : values -> vfun


### PR DESCRIPTION
This is a PR I had lying on my drive, which is a first step towards being able to dynamically change the opacity of constants in the VM (#4476, #5660). In a nutshell, this removes the use of global mutable data structures used in the VM in favour of local persistent ones.

There is still a main global entry point to the table, but eventually it should be stored immutably in the kernel environment.