### PR TITLE
Windows build: use architecture dependent version of windres

### DIFF
--- a/Makefile.ide
+++ b/Makefile.ide
@@ -296,10 +296,12 @@ $(COQIDEAPP):$(COQIDEAPP)/Contents/Resources
 # CoqIde for Windows special targets
 ###########################################################################
 
+# This is either x86_64-w64-mingw32 or i686-w64-mingw32
+TARGET_ARCH=$(shell $CC -dumpmachine)
+
 %.o: %.rc
 	$(SHOW)'WINDRES    $<'
-	$(HIDE)i686-w64-mingw32-windres -i $< -o $@
-
+	$(HIDE)$(TARGET_ARCH)-windres -i $< -o $@
 
 # For emacs:
 # Local Variables:

--- a/dev/build/windows/makecoq_mingw.sh
+++ b/dev/build/windows/makecoq_mingw.sh
@@ -1401,10 +1401,6 @@ function make_coq {
       logn configure ./configure -with-doc no -prefix "$PREFIXCOQ"
     fi
 
-    # The windows resource compiler binary name is hard coded
-    sed -i "s/i686-w64-mingw32-windres/$TARGET_ARCH-windres/" Makefile.build
-    sed -i "s/i686-w64-mingw32-windres/$TARGET_ARCH-windres/" Makefile.ide || true
-
     # 8.4x doesn't support parallel make
     if [[ $COQ_VERSION == 8.4* ]] ; then
       log1 make


### PR DESCRIPTION
This PR fixes the long standing issue that Makefile.ide always uses the 32 bit resource compiler.
My windows build script patch this.

**Kind:** infrastructure.

@Zimmi48 : I would like to have this in 8.12 - otherwise I need to patch it in the platform build as well.