### PR TITLE
Create a tactic to display proof state statistics?

### DIFF
--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -358,7 +358,7 @@ module EvMap = Evar.Map
 module EvNames :
 sig
 
-type t
+type t = Id.t EvMap.t * Evar.t Id.Map.t
 
 val empty : t
 val add_name_undefined : Id.t option -> Evar.t -> evar_info -> t -> t
@@ -462,6 +462,26 @@ type evar_map = {
   future_goals_status : goal_kind EvMap.t;
   extras : Store.t;
 }
+
+let evar_map_info map =
+  let p name size =
+    if size > 0 then
+      Printf.printf "%s size = %d\n" name size in
+  p "defn_evars" (EvMap.cardinal map.defn_evars);
+  p "undf_evars" (EvMap.cardinal map.undf_evars);
+  let (m1, m2) = map.evar_names in
+  p "evar_names1" (EvMap.cardinal m1);
+  p "evar_names2" (Id.Map.cardinal m2);
+  (* skip ustate *)
+  p "conv_pbs" (List.length map.conv_pbs);
+  p "last_mods" (Evar.Set.cardinal map.last_mods);
+  p "metas" (Metamap.cardinal map.metas);
+  (* skip evar_flags *)
+  (* skip side_effects *)
+  p "future_goals" (List.length map.future_goals);
+  (* skip principal_future_goal *)
+  p "future_goals_status" (EvMap.cardinal map.future_goals_status)
+  (* skip extras *)
 
 let get_is_maybe_typeclass, (is_maybe_typeclass_hook : (evar_map -> constr -> bool) Hook.t) = Hook.make ~default:(fun evd c -> false) ()
 

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -137,6 +137,9 @@ type evar_map
 (** Type of unification state. Essentially a bunch of state-passing data needed
     to handle incremental term construction. *)
 
+val evar_map_info : evar_map -> unit
+(** print info about the evar map *)
+
 val empty : evar_map
 (** The empty evar map. *)
 

--- a/engine/proofview.mli
+++ b/engine/proofview.mli
@@ -583,6 +583,8 @@ end
     failures). *)
 module NonLogical : module type of Logic_monad.NonLogical
 
+module Logical : module type of Logic_monad.Logical
+
 (** [tclLIFT c] is a tactic which behaves exactly as [c]. *)
 val tclLIFT : 'a NonLogical.t -> 'a tactic
 

--- a/plugins/ltac/extratactics.mlg
+++ b/plugins/ltac/extratactics.mlg
@@ -1112,8 +1112,21 @@ END
 {
 
 let tclOPTIMIZE_HEAP =
-  Proofview.tclLIFT (Proofview.NonLogical.make (fun () -> Gc.compact ()))
-
+  Proofview.tclLIFT (Proofview.NonLogical.make (fun () ->
+      try
+        let min = int_of_string (Sys.getenv("ENABLE_ATEXIT2")) in
+        Printf.printf "\n\n";
+        Gc.print_stat stdout;
+        Gc.compact ();
+        Gc.print_stat stdout;
+        let stats = Gc.quick_stat () in
+        if stats.compactions = 1 then begin
+(*          CObj.dump ();  print file info*)
+(*          Gc.find_root "" 0 min;  print stack info*)
+          Printexc.print_raw_backtrace stdout (Printexc.get_callstack 5000);
+          flush stdout
+        end
+      with Not_found -> ()))
 }
 
 TACTIC EXTEND optimize_heap


### PR DESCRIPTION
For #12487, I wanted to create a tactic that would display info on the proof state that's being passed along the stack to help figure out where the memory leak is.  I couldn't figure out how to get the proof state for a `NonLogical` monad such as `optimize_heap`.  I tried printing info in `Proofview apply` which worked for my tiny test case but I couldn't get it to trigger for fiat-crypto.

@ppedrot Does this make sense/seem useful?  If so, how can I do this?