### PR TITLE
Recordops: unify struc_typ summary record and libobject entry struc_tuple

### DIFF
--- a/dev/ci/user-overlays/12650-SkySkimmer-rebuild-record.sh
+++ b/dev/ci/user-overlays/12650-SkySkimmer-rebuild-record.sh
@@ -1,0 +1,6 @@
+if [ "$CI_PULL_REQUEST" = "12650" ] || [ "$CI_BRANCH" = "rebuild-record" ]; then
+
+    elpi_CI_REF=rebuild-record
+    elpi_CI_GITURL=https://github.com/SkySkimmer/coq-elpi
+
+fi

--- a/pretyping/recordops.mli
+++ b/pretyping/recordops.mli
@@ -27,13 +27,12 @@ type struc_typ = {
   s_CONST : constructor;
   s_EXPECTEDPARAM : int;
   s_PROJKIND : proj_kind list;
-  s_PROJ : Constant.t option list }
+  s_PROJ : Constant.t option list;
+}
 
-type struc_tuple =
-    constructor * proj_kind list * Constant.t option list
-
-val register_structure : Environ.env -> struc_tuple -> unit
-val subst_structure : Mod_subst.substitution -> struc_tuple -> struc_tuple
+val register_structure : struc_typ -> unit
+val subst_structure : Mod_subst.substitution -> struc_typ -> struc_typ
+val rebuild_structure : Environ.env -> struc_typ -> struc_typ
 
 (** [lookup_structure isp] returns the struc_typ associated to the
    inductive path [isp] if it corresponds to a structure, otherwise

--- a/test-suite/bugs/closed/bug_12649.v
+++ b/test-suite/bugs/closed/bug_12649.v
@@ -1,0 +1,11 @@
+
+
+Module Type A.
+
+  Record baz : Prop := B { }. (* any sort would do *)
+
+End A.
+
+Print A.
+Module Type UseA (c: A). End UseA.
+Print UseA. (* ANOMALY! Int.Map.get's assert false *)

--- a/vernac/record.mli
+++ b/vernac/record.mli
@@ -29,8 +29,6 @@ val declare_projections :
   Constr.rel_context ->
     Recordops.proj_kind list * Constant.t option list
 
-val declare_structure_entry : Recordops.struc_tuple -> unit
-
 val definition_structure
   :  universe_decl_expr option
   -> inductive_kind
@@ -46,3 +44,6 @@ val definition_structure
   -> GlobRef.t list
 
 val declare_existing_class : GlobRef.t -> unit
+
+(** Used by elpi *)
+val declare_structure_entry : Recordops.struc_typ -> unit


### PR DESCRIPTION
This requires updating the parameter count at section end, I felt it
was easier to do with rebuild_function but it could be done in
discharge if needed.

Incidentally fixes #12649.

Overlays: https://github.com/LPCIC/coq-elpi/pull/154
