### PR TITLE
Fix fiat_crypto(_ocaml) needs/dependencies

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -751,6 +751,7 @@ library:ci-fiat_crypto:
   dependencies:
   - build:edge+flambda
   - library:ci-coqprime
+  - plugin:ci-bignums
   - plugin:ci-rewriter
 
 library:ci-fiat_crypto_legacy:
@@ -765,9 +766,15 @@ library:ci-fiat_crypto_ocaml:
   stage: stage-5
   needs:
   - build:edge+flambda
+  - library:ci-coqprime
+  - plugin:ci-bignums
+  - plugin:ci-rewriter
   - library:ci-fiat_crypto
   dependencies:
   - build:edge+flambda
+  - library:ci-coqprime
+  - plugin:ci-bignums
+  - plugin:ci-rewriter
   - library:ci-fiat_crypto
 
 library:ci-flocq:


### PR DESCRIPTION
It seems gitlab has issues with missing transitive dependencies, for
instance in https://gitlab.com/coq/coq/-/pipelines/164834444 rewriter
failed (missing overlay), fiat_crypto was skipped and
fiat_crypto_ocaml was incorrectly started and so failed.

May also fix (intermittent?) issue where it doesn't download the
rewriter or bignum artifact and gets incompatible ocaml when compiling.
