### PR TITLE
Fix #12513: coq no longer reports mismatched version numbers.

### DIFF
--- a/doc/changelog/07-commands-and-options/12677-require-v811-error-compat.rst
+++ b/doc/changelog/07-commands-and-options/12677-require-v811-error-compat.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  Properly report the mismatched magic number of vo files
+  (`#12677 <https://github.com/coq/coq/pull/12677>`_,
+  fixes `#12513 <https://github.com/coq/coq/issues/12513>`_,
+  by Pierre-Marie Pédrot).

--- a/lib/objFile.ml
+++ b/lib/objFile.ml
@@ -182,7 +182,7 @@ let open_in ~file =
     let version = input_int32 ch in
     let () =
       if not (Int32.equal magic magic_number) then
-        let e = { filename = file; actual = version; expected = magic_number } in
+        let e = { filename = file; actual = magic; expected = magic_number } in
         raise (Bad_magic_number e)
     in
     let () =

--- a/lib/system.ml
+++ b/lib/system.ml
@@ -239,9 +239,12 @@ let intern_state magic filename =
 let with_magic_number_check f a =
   try f a
   with
-  | Bad_magic_number {filename=fname; _} ->
+  | Bad_magic_number {filename=fname; actual; expected} ->
     CErrors.user_err ~hdr:"with_magic_number_check"
-    (str"File " ++ str fname ++ strbrk" is corrupted.")
+    (str"File " ++ str fname ++ strbrk" has bad magic number " ++
+    (str @@ Int32.to_string actual) ++ str" (expected " ++ (str @@ Int32.to_string expected) ++ str")." ++
+    spc () ++
+    strbrk "It is corrupted or was compiled with another version of Coq.")
   | Bad_version_number {filename=fname;actual=actual;expected=expected} ->
     CErrors.user_err ~hdr:"with_magic_number_check"
     (str"File " ++ str fname ++ strbrk" has bad version number " ++


### PR DESCRIPTION
Fixes #12513.

- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
