### PR TITLE
Remove redundant data from VM case switch.

### DIFF
--- a/dev/vm_printers.ml
+++ b/dev/vm_printers.ml
@@ -1,6 +1,5 @@
 open Format
 open Term
-open Constr
 open Names
 open Cemitcodes
 open Vmvalues
@@ -8,9 +7,7 @@ open Vmvalues
 let ppripos (ri,pos) =
   (match ri with
   | Reloc_annot a ->
-      let sp,i = a.ci.ci_ind in
-      print_string
-        ("annot : MutInd("^(MutInd.to_string sp)^","^(string_of_int i)^")\n")
+      print_string "switch\n"
   | Reloc_const _ ->
       print_string "structured constant\n"
   | Reloc_getglobal kn ->

--- a/kernel/byterun/coq_interp.c
+++ b/kernel/byterun/coq_interp.c
@@ -1187,7 +1187,7 @@ value coq_interprete
             if (sz == 0) accu = Atom(0);
             else {
               Alloc_small(accu, sz, Default_tag);
-              if (Field(*sp, 2) == Val_true) {
+              if (Is_tailrec_switch(*sp)) {
                 for (i = 0; i < sz; i++) Field(accu, i) = sp[i+2];
               }else{
                 for (i = 0; i < sz; i++) Field(accu, i) = sp[i+5];

--- a/kernel/byterun/coq_values.h
+++ b/kernel/byterun/coq_values.h
@@ -32,6 +32,7 @@
 #define Is_accu(v) (Is_block(v) && (Tag_val(v) == Accu_tag))
 #define IS_EVALUATED_COFIX(v) (Is_accu(v) && Is_block(Field(v,1)) && (Tag_val(Field(v,1)) == ATOM_COFIXEVALUATED_TAG))
 #define Is_double(v) (Tag_val(v) == Double_tag)
+#define Is_tailrec_switch(v) (Field(v,1) == Val_true)
 
 /* coq array */
 #define Is_coq_array(v) (Is_block(v) && (Wosize_val(v) == 1))

--- a/kernel/cbytegen.ml
+++ b/kernel/cbytegen.ml
@@ -761,7 +761,7 @@ let rec compile_lam env cenv lam sz cont =
       done;
 
       let annot =
-        {ci = ci; rtbl = rtbl; tailcall = is_tailcall;
+        {rtbl = rtbl; tailcall = is_tailcall;
          max_stack_size = !max_stack_size - sz}
       in
 

--- a/kernel/cemitcodes.ml
+++ b/kernel/cemitcodes.ml
@@ -13,7 +13,6 @@
 (* Extension: Arnaud Spiwack (support for native arithmetic), May 2005 *)
 
 open Names
-open Constr
 open Vmvalues
 open Cbytecodes
 open Copcodes
@@ -424,12 +423,11 @@ let subst_strcst s sc =
   | Const_float _ -> sc
   | Const_ind ind -> let kn,i = ind in Const_ind (subst_mind s kn, i)
 
+let subst_annot _ (a : annot_switch) = a
+
 let subst_reloc s ri =
   match ri with
-  | Reloc_annot a ->
-      let (kn,i) = a.ci.ci_ind in
-      let ci = {a.ci with ci_ind = (subst_mind s kn,i)} in
-      Reloc_annot {a with ci = ci}
+  | Reloc_annot a -> Reloc_annot (subst_annot s a)
   | Reloc_const sc -> Reloc_const (subst_strcst s sc)
   | Reloc_getglobal kn -> Reloc_getglobal (subst_constant s kn)
   | Reloc_proj_name p -> Reloc_proj_name (subst_proj_repr s p)

--- a/kernel/vmvalues.mli
+++ b/kernel/vmvalues.mli
@@ -9,7 +9,6 @@
 (************************************************************************)
 
 open Names
-open Constr
 
 (** Values *)
 
@@ -52,7 +51,7 @@ val pp_struct_const : structured_constant -> Pp.t
 type reloc_table = (tag * int) array
 
 type annot_switch =
-   {ci : case_info; rtbl : reloc_table; tailcall : bool; max_stack_size : int}
+   { rtbl : reloc_table; tailcall : bool; max_stack_size : int }
 
 val eq_structured_constant : structured_constant -> structured_constant -> bool
 val hash_structured_constant : structured_constant -> int

--- a/test-suite/success/sprop.v
+++ b/test-suite/success/sprop.v
@@ -171,6 +171,10 @@ End sFix.
 
 Fail Definition fix_relevance : _ -> nat := fun _ : iUnit => 0.
 
+(* Check that VM/native properly keep the relevance of the predicate in the case info
+   (bad-relevance warning as error otherwise) *)
+Definition vm_rebuild_case := Eval vm_compute in eq_sind.
+
 Require Import ssreflect.
 
 Goal forall T : SProp, T -> True.


### PR DESCRIPTION
No need to store the case_info, all the data is reconstructible from the context. Furthermore, this reconstruction is performed in a context where we already access the environment, so performance is not at stake.

Hopefully this will also reduce the number of globally allocated VM values, since the switch representation now only depends on the shape of the inductive type.