### PR TITLE
Fixes #12682: printing bug with recursive notations for n-ary applications used with applied references

### DIFF
--- a/doc/changelog/03-notations/12683-master+fix12682-notation-printing-nary-application-ref.rst
+++ b/doc/changelog/03-notations/12683-master+fix12682-notation-printing-nary-application-ref.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  Printing bug with notations for n-ary applications used with applied references.
+  (`#12683 <https://github.com/coq/coq/pull/12683>`_,
+  fixes `#12682 <https://github.com/coq/coq/pull/12682>`_,
+  by Hugo Herbelin).

--- a/interp/notation.mli
+++ b/interp/notation.mli
@@ -239,7 +239,12 @@ val declare_uninterpretation : interp_rule -> interpretation -> unit
 val interp_notation : ?loc:Loc.t -> notation -> subscopes ->
       interpretation * (notation_location * scope_name option)
 
-type notation_rule = interp_rule * interpretation * int option
+type notation_applicative_status =
+  | AppBoundedNotation of int
+  | AppUnboundedNotation
+  | NotAppNotation
+
+type notation_rule = interp_rule * interpretation * notation_applicative_status
 
 (** Return the possible notations for a given term *)
 val uninterp_notations : 'a glob_constr_g -> notation_rule list

--- a/test-suite/output/Notations.out
+++ b/test-suite/output/Notations.out
@@ -80,6 +80,12 @@ NIL : list nat
      : Z * Z * (Z * Z) * (Z * Z) * (Z * bool * (Z * bool) * (Z * bool))
 fun f : Z -> Z -> Z -> Z => {|f; 0; 1; 2|} : Z
      : (Z -> Z -> Z -> Z) -> Z
+{|fun x : Z => x + x; 0|}
+     : Z
+{|op; 0; 1|}
+     : Z
+false = 0
+     : Prop
 Init.Nat.add
      : nat -> nat -> nat
 S

--- a/test-suite/output/Notations.v
+++ b/test-suite/output/Notations.v
@@ -216,12 +216,31 @@ Check [|0*(1,2,3);(4,5,6)*false|].
 
 (**********************************************************************)
 (* Test recursive notations involving applications                    *)
-(* Caveat: does not work for applied constant because constants are   *)
-(* classified as notations for the particular constant while this     *)
-(* generic application notation is classified as generic              *)
+
+Module Application.
 
 Notation "{| f ; x ; .. ; y |}" := ( .. (f x) .. y).
+
+(* Application to a variable *)
+
 Check fun f => {| f; 0; 1; 2 |} : Z.
+
+(* Application to a fun *)
+
+Check {| (fun x => x+x); 0 |}.
+
+(* Application to a reference *)
+
+Axiom op : Z -> Z -> Z.
+Check {| op; 0; 1 |}.
+
+(* Interaction with coercion *)
+
+Axiom c : Z -> bool.
+Coercion c : Z >-> bool.
+Check false = {| c; 0 |}.
+
+End Application.
 
 (**********************************************************************)
 (* Check printing of notations from other modules *)


### PR DESCRIPTION
**Kind:**  bug fix

We fix #12682 by introducing a special treatment for this special kind of notations.

Note that the problem was actually already identified (see corresponding comment in `output/Notations.v`).

Fixes / closes #12682

- [X] Added / updated test-suite
- [X] Entry added in the changelog

----
A side design question is: in the presence of coercions, should we consider such generic notation for applications as prioritary over dropping the coercion or not, i.e., in:
```
Notation "{| f ; x ; .. ; y |}" := ( .. (f x) .. y). 
Axiom c : nat -> bool.
Coercion c : nat >-> bool.
Check true = c 0.
```
should we see `true = 0` or `true = {| c; 0 |}`?

The PR decides that we want to see `true = 0` (as it was before, though, before, it was because the recursive notation was not working).

----
Milestone set at 8.12.0 (which would make Software Foundations happy) but maybe that's too short.