### PR TITLE
Do not print constructor and inductive types as terms when asked to be printed as themselves

### DIFF
--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -257,11 +257,12 @@ let pr_puniverses f env sigma (c,u) =
   then f env c ++ pr_universe_instance sigma u
   else f env c
 
-let pr_constant env cst = pr_global_env (Termops.vars_of_env env) (GlobRef.ConstRef cst)
 let pr_existential_key = Termops.pr_existential_key
 let pr_existential env sigma ev = pr_lconstr_env env sigma (mkEvar ev)
-let pr_inductive env ind = pr_lconstr_env env (Evd.from_env env) (mkInd ind)
-let pr_constructor env cstr = pr_lconstr_env env (Evd.from_env env) (mkConstruct cstr)
+
+let pr_constant env cst = pr_global_env (Termops.vars_of_env env) (GlobRef.ConstRef cst)
+let pr_inductive env ind = pr_global_env (Termops.vars_of_env env) (GlobRef.IndRef ind)
+let pr_constructor env cstr = pr_global_env (Termops.vars_of_env env) (GlobRef.ConstructRef cstr)
 
 let pr_pconstant = pr_puniverses pr_constant
 let pr_pinductive = pr_puniverses pr_inductive

--- a/test-suite/output/PrintAssumptions.out
+++ b/test-suite/output/PrintAssumptions.out
@@ -7,7 +7,7 @@ bli : Type
 Axioms:
 bli : Type
 Axioms:
-@seq relies on definitional UIP.
+seq relies on definitional UIP.
 Axioms:
 extensionality
   : forall (P Q : Type) (f g : P -> Q), (forall x : P, f x = g x) -> f = g


### PR DESCRIPTION
**Kind:** enhancement, user messages

This was already the case for constant, but not for constructors and inductive types. Treating them as terms implies that there are prefixed by a `@`, or that a notation for the reference is used, but I'm unsure we want that, even more that notations are in general for the applied form.

For instance, I don't think that in the message `The constructor @cons (in type list) is expected to ...` we want a `@` to be printed. (Alternatively, we may want to write `"::"` or `_ :: _`, but I don't see how to justify writing `@cons`.)

I wonder what others think.

- [x] Added / updated test-suite (will be used and tested in #12100 if ever merged, so probably not needed)
- [ ] Entry added in the changelog (needed?)