### PR TITLE
Propagating scope information in indirect application to a reference.

### DIFF
--- a/doc/changelog/03-notations/12685-master+propagate-scope-in-indirect-applied-ref.rst
+++ b/doc/changelog/03-notations/12685-master+propagate-scope-in-indirect-applied-ref.rst
@@ -1,0 +1,6 @@
+- **Changed:**
+  Scope information is propagated in indirect applications to a
+  reference prefixed with :g:`@@`; this covers for instance the case
+  :g:`r.(@@p) t` where scope information from :g:`p` is now taken into
+  account for interpreting :g:`t` (`#12685
+  <https://github.com/coq/coq/pull/12685>`_, by Hugo Herbelin).

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -2092,9 +2092,13 @@ let internalize globalenv env pattern_mode (_, ntnvars as lvar) c =
           assert (Option.is_empty isproj);
           let c = intern_notation intern env ntnvars loc ntn ntnargs in
           find_appl_head_data c, args
-        | _ -> assert (Option.is_empty isproj); (intern_no_implicit env f,[],[]), args in
-      apply_impargs c env impargs args_scopes
-        args loc
+        | _ ->
+           assert (Option.is_empty isproj);
+           let f = intern_no_implicit env f in
+           let f, _, args_scopes = find_appl_head_data f in
+           (f,[],args_scopes), args
+      in
+      apply_impargs c env impargs args_scopes args loc
 
     | CRecord fs ->
        let st = Evar_kinds.Define (not (Program.get_proofs_transparency ())) in

--- a/test-suite/success/Notations2.v
+++ b/test-suite/success/Notations2.v
@@ -51,8 +51,8 @@ Check fun A (x : prod' bool A) => match x with (@pair' _ 0) _ y 0%bool => 2 | _ 
 Notation c3 x := ((@pair') _ x).
 Check (@pair') _ 0%bool _ 0%bool 0%bool : prod' bool bool. (* @ is blocking implicit and scopes *)
 Check ((@pair') _ 0%bool) _ 0%bool 0%bool : prod' bool bool. (* parentheses and @ are blocking implicit and scopes *)
-Check c3 0 0 0 : prod' nat bool. (* First scope is blocked but not the last two scopes *)
-Check fun A (x :prod' nat A) => match x with c3 0 y 0 => 2 | _ => 1 end.
+Check c3 0 0 0 : prod' bool bool.
+Check fun A (x :prod' bool A) => match x with c3 0 y 0 => 2 | _ => 1 end.
 
 (* 4. Abbreviations do not stop implicit arguments to be inserted and scopes to be used *)
 (* unless an atomic @ is given *)

--- a/test-suite/success/Scopes.v
+++ b/test-suite/success/Scopes.v
@@ -26,3 +26,15 @@ Definition c := ε : U.
 Goal True.
 assert (nat * nat).
 Abort.
+
+(* Check propagation of scopes in indirect applications to references *)
+
+Module PropagateIndirect.
+Notation "0" := true : bool_scope.
+
+Axiom f : bool -> bool -> nat.
+Check (@f 0) 0.
+
+Record R := { p : bool -> nat }.
+Check fun r => r.(@p) 0.
+End PropagateIndirect.


### PR DESCRIPTION
**Kind:** enhancement

The following shows two situations where known scopes of a reference are not propagated while it could:
```coq
Notation "0" := true : bool_scope.
Axiom f : bool -> bool -> nat.
Check (@f 0) 0.
(* The term "0" has type "nat" while it is expected to have type "bool". *)
Record R := { p : bool -> nat }.
Check fun r => r.(@p) 0.
(* The term "0" has type "nat" while it is expected to have type "bool". *)
```
The PR makes that this works.

- [X] Added / updated test-suite
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
