### PR TITLE
Compatibility of make-change-log with MacOS X whose "sed" does not support the "\+" operator of regular expressions

### DIFF
--- a/dev/tools/make-changelog.sh
+++ b/dev/tools/make-changelog.sh
@@ -28,7 +28,7 @@ esac
 printf "Fixes? (space separated list of bug numbers)\n"
 read -r fixes_list
 
-fixes_string="$(echo $fixes_list | sed 's/ /~  and /g; s,\([0-9]\+\),`#\1 <https://github.com/coq/coq/issues/\1>`_,g' | tr '~' '\n')"
+fixes_string="$(echo $fixes_list | sed 's/ /~  and /g; s,\([0-9][0-9]*\),`#\1 <https://github.com/coq/coq/issues/\1>`_,g' | tr '~' '\n')"
 if [ ! -z "$fixes_string" ]; then fixes_string="$(printf '\n  fixes %s,' "$fixes_string")"; fi
 
 # shellcheck disable=SC2016


### PR DESCRIPTION
**Kind:** operating systems compatibility

We make it compatible by expanding `[0-9]\+` into `[0-9][0-9]*`. Sorry for these sempiternal BSD `sed` incompatibilities.