### PR TITLE
[gramlib] Remove legacy located exception wrapper in favor of standard infrastructure.

### DIFF
--- a/gramlib/ploc.ml
+++ b/gramlib/ploc.ml
@@ -16,10 +16,3 @@ let dummy =
 
 let sub loc sh len = {loc with bp = loc.bp + sh; ep = loc.bp + sh + len}
 let after loc sh len = {loc with bp = loc.ep + sh; ep = loc.ep + sh + len}
-
-exception Exc of Loc.t * exn
-
-let raise loc exc =
-  match exc with
-    Exc (_, _) -> raise exc
-  | _ -> raise (Exc (loc, exc))

--- a/gramlib/ploc.mli
+++ b/gramlib/ploc.mli
@@ -2,20 +2,6 @@
 (* ploc.mli,v *)
 (* Copyright (c) INRIA 2007-2017 *)
 
-(* located exceptions *)
-
-exception Exc of Loc.t * exn
-   (** [Ploc.Exc loc e] is an encapsulation of the exception [e] with
-       the input location [loc]. To be used to specify a location
-       for an error. This exception must not be raised by [raise] but
-       rather by [Ploc.raise] (see below), to prevent the risk of several
-       encapsulations of [Ploc.Exc]. *)
-
-val raise : Loc.t -> exn -> 'a
-   (** [Ploc.raise loc e], if [e] is already the exception [Ploc.Exc],
-       re-raise it (ignoring the new location [loc]), else raise the
-       exception [Ploc.Exc loc e]. *)
-
 val make_unlined : int * int -> Loc.t
    (** [Ploc.make_unlined] is like [Ploc.make] except that the line number
        is not provided (to be used e.g. when the line number is unknown. *)

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -1124,8 +1124,7 @@ let tclDO n tac =
       let _, info = Exninfo.capture e in
       let e' = CErrors.UserError (l, prefix i ++ s) in
       Exninfo.iraise (e', info)
-    | Gramlib.Ploc.Exc(loc, CErrors.UserError (l, s))  ->
-      raise (Gramlib.Ploc.Exc(loc, CErrors.UserError (l, prefix i ++ s))) in
+  in
   let rec loop i gl =
     if i = n then tac_err_at i gl else
     (tclTHEN (tac_err_at i) (loop (i + 1))) gl in

--- a/plugins/ssr/ssrelim.ml
+++ b/plugins/ssr/ssrelim.ml
@@ -490,7 +490,6 @@ let equality_inj l b id c =
   let msg = ref "" in
   try Proofview.V82.of_tactic (Equality.inj None l b None c) gl
   with
-    | Gramlib.Ploc.Exc(_,CErrors.UserError (_,s))
     | CErrors.UserError (_,s)
   when msg := Pp.string_of_ppcmds s;
        !msg = "Not a projectable equality but a discriminable one." ||


### PR DESCRIPTION
The old wrapper was basically unused, this PR also fixes backtraces in
some class of bugs such as https://github.com/coq/coq/issues/12695
