### PR TITLE
[ci] [build] Rebuild Coq's stdlib in documentation job.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -485,6 +485,15 @@ doc:stdlib:dune:
   extends: .dune-ci-template
   variables:
     DUNE_TARGET: stdlib-html
+  script:
+    # Warning: will rebuild Coq, need to fix Dune to know about glob files.
+    # c.f. https://github.com/coq/coq/issues/12699
+    - rm -rf _build
+    - set -e
+    - echo 'start:coq.test'
+    - make -f Makefile.dune "$DUNE_TARGET"
+    - echo 'end:coq.test'
+    - set +e
   artifacts:
     paths:
       - _build/log


### PR DESCRIPTION
This is an ugly but quick workaround for
https://github.com/coq/coq/issues/12699

Ideally we'd like to fix Dune to know about `.glob` files and flags.

Another alternative would be to deploy from the regular make-based doc
job, but I'm not familiar with it.
