### PR TITLE
CI: Use bundled compcert for VST

### DIFF
--- a/dev/ci/ci-vst.sh
+++ b/dev/ci/ci-vst.sh
@@ -5,4 +5,6 @@ ci_dir="$(dirname "$0")"
 
 git_download vst
 
+export COMPCERT=bundled
+
 ( cd "${CI_BUILD_DIR}/vst" && make IGNORECOQVERSION=true )


### PR DESCRIPTION
The compcert configure looks complicated, and this should get CI working again until someone looks deeply into it.