### PR TITLE
CI: pass -silent to coqchk in compcert job

### DIFF
--- a/dev/ci/ci-compcert.sh
+++ b/dev/ci/ci-compcert.sh
@@ -6,4 +6,6 @@ ci_dir="$(dirname "$0")"
 git_download compcert
 
 ( cd "${CI_BUILD_DIR}/compcert" && \
-  ./configure -ignore-coq-version x86_32-linux && make && make check-proof )
+      ./configure -ignore-coq-version x86_32-linux && \
+      make && \
+      make check-proof COQCHK='"$(COQBIN)coqchk" -silent -o $(COQINCLUDES)')


### PR DESCRIPTION
Otherwise gitlab stops logging somewhere in the middle.

Also pass -o because we can.
