### PR TITLE
deprecate prod_curry and prod_uncurry

### DIFF
--- a/doc/changelog/10-standard-library/12716-curry.rst
+++ b/doc/changelog/10-standard-library/12716-curry.rst
@@ -1,0 +1,4 @@
+- **Deprecated:**
+  ``prod_curry`` and ``prod_uncurry``, in favor of ``uncurry`` and ``curry``
+  (`#12716 <https://github.com/coq/coq/pull/12716>`_,
+  by Yishuai Li).

--- a/theories/Init/Datatypes.v
+++ b/theories/Init/Datatypes.v
@@ -272,11 +272,17 @@ Proof with auto.
   - destruct H; subst...
 Qed.
 
-Definition prod_uncurry (A B C:Type) (f:A * B -> C)
+Definition curry {A B C:Type} (f:A * B -> C)
   (x:A) (y:B) : C := f (x,y).
 
-Definition prod_curry (A B C:Type) (f:A -> B -> C)
+Definition uncurry {A B C:Type} (f:A -> B -> C)
   (p:A * B) : C := match p with (x, y) => f x y end.
+
+#[deprecated(since = "8.13", note = "Use curry instead.")]
+Definition prod_uncurry (A B C:Type) : (A * B -> C) -> A -> B -> C := curry.
+
+#[deprecated(since = "8.13", note = "Use uncurry instead.")]
+Definition prod_curry (A B C:Type) : (A -> B -> C) -> A * B -> C := uncurry.
 
 Import EqNotations.
 


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->
Per https://coq.zulipchat.com/#narrow/stream/237977-Coq-users/topic/prod_curry.2Funcurry.20seem.20named.20backward

<!-- Keep what applies -->
**Kind:** feature.

- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
