### PR TITLE
Do not rely on higher-order interfaces for patterns in dnets.

### DIFF
--- a/tactics/btermdn.ml
+++ b/tactics/btermdn.ml
@@ -151,23 +151,15 @@ struct
 
  type t = Dn.t
 
+  type pattern = Dn.pattern
+
+  let pattern st pat = match st with
+  | None -> Dn.pattern bounded_constr_pat_discr (pat, !dnet_depth)
+  | Some st -> Dn.pattern (bounded_constr_pat_discr_st st) (pat, !dnet_depth)
+
   let empty = Dn.empty
-
-  let add = function
-    | None ->
-        (fun dn (c,v) ->
-           Dn.add dn bounded_constr_pat_discr ((c,!dnet_depth),v))
-    | Some st ->
-        (fun dn (c,v) ->
-           Dn.add dn (bounded_constr_pat_discr_st st) ((c,!dnet_depth),v))
-
-  let rmv = function
-    | None ->
-        (fun dn (c,v) ->
-           Dn.rmv dn bounded_constr_pat_discr ((c,!dnet_depth),v))
-    | Some st ->
-        (fun dn (c,v) ->
-         Dn.rmv dn (bounded_constr_pat_discr_st st) ((c,!dnet_depth),v))
+  let add = Dn.add
+  let rmv = Dn.rmv
 
   let lookup sigma = function
     | None ->

--- a/tactics/btermdn.mli
+++ b/tactics/btermdn.mli
@@ -28,10 +28,14 @@ module Make :
 sig
   type t
 
+  type pattern
+
+  val pattern : TransparentState.t option -> constr_pattern -> pattern
+
   val empty : t
 
-  val add : TransparentState.t option -> t -> (constr_pattern * Z.t) -> t
-  val rmv : TransparentState.t option -> t -> (constr_pattern * Z.t) -> t
+  val add : t -> pattern -> Z.t -> t
+  val rmv : t -> pattern -> Z.t -> t
 
   val lookup : Evd.evar_map -> TransparentState.t option -> t -> EConstr.constr -> Z.t list
   val app : (Z.t -> unit) -> t -> unit

--- a/tactics/dn.ml
+++ b/tactics/dn.ml
@@ -38,6 +38,8 @@ struct
 
   type  t = Trie.t
 
+  type pattern = (Y.t * int) option list
+
   let empty = Trie.empty
 
 (* [path_of dna pat] returns the list of nodes of the pattern [pat] read in
@@ -89,11 +91,13 @@ prefix ordering, [dna] is the function returning the main node of a pattern *)
     in
     List.flatten (List.map (fun (tm,b) -> ZSet.elements (Trie.get tm)) (lookrec t tm))
 
-  let add tm dna (pat,inf) =
-    let p = path_of dna pat in Trie.add p (ZSet.singleton inf) tm
+  let pattern dna pat = path_of dna pat
 
-  let rmv tm dna (pat,inf) =
-    let p = path_of dna pat in Trie.remove p (ZSet.singleton inf) tm
+  let add tm p inf =
+    Trie.add p (ZSet.singleton inf) tm
+
+  let rmv tm p inf =
+    Trie.remove p (ZSet.singleton inf) tm
 
   let app f tm = Trie.iter (fun _ p -> ZSet.iter f p) tm
 

--- a/tactics/dn.mli
+++ b/tactics/dn.mli
@@ -18,9 +18,13 @@ sig
      must decompose any tree into a label characterizing its root node and
      the list of its subtree *)
 
-  val add : t -> 'a decompose_fun -> 'a * Z.t -> t
+  type pattern
 
-  val rmv : t -> 'a decompose_fun -> 'a * Z.t -> t
+  val pattern : 'a decompose_fun -> 'a -> pattern
+
+  val add : t -> pattern -> Z.t -> t
+
+  val rmv : t -> pattern -> Z.t -> t
 
   type 'tree lookup_fun = 'tree -> (Y.t * 'tree list) lookup_res
 


### PR DESCRIPTION
The old API was taking a function to decompose constr patterns into dnet patterns, but it was applying it in an eager way. So there is not point in exposing such a complex interface. Instead, we make explicit the dnet pattern type, export a function that turns a constr pattern into a dnet pattern, and make the add and remove dnet functions take a dnet pattern instead.

This only affects pattern-consuming functions. The lookup function, which operates on kernel terms instead of constr patterns, is still relying on HO primitives.