### PR TITLE
dune: pass -bin-annot to configure

### DIFF
--- a/config/dune
+++ b/config/dune
@@ -22,4 +22,4 @@
    ; Needed to generate include lists for coq_makefile
    plugin_list
   (env_var COQ_CONFIGURE_PREFIX))
- (action (chdir %{project_root} (run %{ocaml} configure.ml -no-ask -native-compiler no))))
+ (action (chdir %{project_root} (run %{ocaml} configure.ml -no-ask -native-compiler no -bin-annot))))


### PR DESCRIPTION
This ends up in coq_makefile's CAMLFLAGS so we need it to make merlin
work properly.
