### PR TITLE
[8.12] Updated picks for CompCert and VST

### DIFF
--- a/dev/build/windows/makecoq_mingw.sh
+++ b/dev/build/windows/makecoq_mingw.sh
@@ -1835,43 +1835,16 @@ function make_addon_compcert {
 
 # Princeton VST
 
-function install_addon_vst {
-    VSTDEST="$PREFIXCOQ/lib/coq/user-contrib/VST"
-
-    # Install VST .v, .vo, .c and .h files
-    install_rec compcert '*.v' "$VSTDEST/compcert/"
-    install_rec compcert '*.vo' "$VSTDEST/compcert/"
-    install_glob "msl" '*.v' "$VSTDEST/msl/"
-    install_glob "msl" '*.vo' "$VSTDEST/msl/"
-    install_glob "sepcomp" '*.v' "$VSTDEST/sepcomp/"
-    install_glob "sepcomp" '*.vo' "$VSTDEST/sepcomp/"
-    install_glob "floyd" '*.v' "$VSTDEST/floyd/"
-    install_glob "floyd" '*.vo' "$VSTDEST/floyd/"
-    install_glob "progs" '*.v' "$VSTDEST/progs/"
-    install_glob "progs" '*.c' "$VSTDEST/progs/"
-    install_glob "progs" '*.h' "$VSTDEST/progs/"
-    install_glob "veric" '*.v' "$VSTDEST/veric/"
-    install_glob "veric" '*.vo' "$VSTDEST/veric/"
-
-    # Install VST documentation files
-    install_glob "." 'LICENSE' "$VSTDEST"
-    install_glob "." '*.md' "$VSTDEST"
-    install_glob "compcert" '*' "$VSTDEST/compcert"
-    install_glob "doc" '*.pdf' "$VSTDEST/doc"
-
-    # Install VST _CoqProject files
-    install_glob "." '_CoqProject*' "$VSTDEST"
-    install_glob "." '_CoqProject-export' "$VSTDEST/progs"
-}
-
 function make_addon_vst {
-  installer_addon_dependency vst
+  installer_addon_dependency_beg vst
+  make_addon_compcert
+  installer_addon_dependency_end
   if build_prep_overlay vst_platform vst; then
     installer_addon_section vst "VST" "ATTENTION: SOME INCLUDED COMPCERT PARTS ARE NOT OPEN SOURCE! Verified Software Toolchain for verifying C code" "off"
     # log1 coq_set_timeouts_1000
     # The usage of the shell variable ARCH in VST collides with the usage in this shellscript
     logn make env -u ARCH make IGNORECOQVERSION=true $MAKE_OPT
-    log1 install_addon_vst
+    logn install env -u ARCH make install
     build_post
   fi
 }

--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -144,6 +144,7 @@
 # This uses the platform supplied version of Flocq and Menhirlib as
 # published in http://coq.io/opam/coq-compcert.3.7~coq-platform.html
 # with a few additional patches for 8.12
+# This is used by the Windows Installer (and the Coq platform)
 # Author codes:
 # SN : Michael Soegtrop, new (not in the above opam release)
 # SO : Michael Soegtrop, opam (in the above opam release)
@@ -159,20 +160,19 @@
 # cea50ef9 CO Dual-license aarch64/{Archi.v,Cbuiltins.ml,extractionMachdep.v}
 # b7980c83 CO Install "compcert.config" file along the Coq development
 # 76a4ff8f    Updates for release 3.7
-: "${compcert_platform_CI_REF:=coq-platform-8.12.beta}"
+: "${compcert_platform_CI_REF:=coq-platform-8.12}"
 : "${compcert_platform_CI_GITURL:=https://github.com/MSoegtropIMC/CompCert}"
 : "${compcert_platform_CI_ARCHIVEURL:=${compcert_platform_CI_GITURL}/archive}"
 
 # As above, but does use bundled Flocq and Menhirlib rather than the
 # platform supplied version
-# This is used by the Windows Installer (and the Coq platform)
 # 10bafbaa CN Coq-MenhirLib: explicit import ListNotations (#354)
 # f494c983 CN Import ListNotations explicitly
 # 16878a61 CO Update the list of dual-licensed files
 # cea50ef9 CO Dual-license aarch64/{Archi.v,Cbuiltins.ml,extractionMachdep.v}
 # b7980c83 CO Install "compcert.config" file along the Coq development
 # 76a4ff8f    Updates for release 3.7
-: "${compcert_CI_REF:=coq-8.12.beta}"
+: "${compcert_CI_REF:=coq-8.12}"
 : "${compcert_CI_GITURL:=https://github.com/MSoegtropIMC/CompCert}"
 : "${compcert_CI_ARCHIVEURL:=${compcert_CI_GITURL}/archive}"
 
@@ -189,8 +189,8 @@
 # This is used by the Windows Installer (and the Coq platform)
 # This includes one extra commit relative to the above:
 # 45239bb5 MSoegtrop Changed build and CI system to use opam / coq-platform supplied CompCert
-: "${vst_platform_CI_REF:=coq-platform-8.12.beta}"
-: "${vst_platform_CI_GITURL:=https://github.com/MSoegtropIMC/VST}"
+: "${vst_platform_CI_REF:=release-v2.6}"
+: "${vst_platform_CI_GITURL:=https://github.com/PrincetonUniversity/VST}"
 : "${vst_platform_CI_ARCHIVEURL:=${vst_platform_CI_GITURL}/archive}"
 
 ########################################################################


### PR DESCRIPTION
Note: for CompCert just the branch name changed, not the content

@Zimmi48 : this didn't yet pass my local tests. But since the builds take some time I alredy created the PR so that CI can run.

One question: currently the windows installer and CI use different versions of CompCert and VST. There is no good reason for this any more but changing it likely requires some extra CI runs. I am unsure what to do here.

Closes #12360