### PR TITLE
Windows CI: changed cygwin repo server

### DIFF
--- a/dev/build/windows/MakeCoq_MinGW.bat
+++ b/dev/build/windows/MakeCoq_MinGW.bat
@@ -55,7 +55,7 @@ IF DEFINED HTTP_PROXY (
 )
 
 REM see -cygrepo in ReadMe.txt
-SET CYGWIN_REPOSITORY=http://mirror.easyname.at/cygwin
+SET CYGWIN_REPOSITORY=https://mirrors.kernel.org/sourceware/cygwin
 
 REM see -cygcache in ReadMe.txt
 SET CYGWIN_LOCAL_CACHE_WFMT=%BATCHDIR%cygwin_cache


### PR DESCRIPTION
The cygwin repo server we are using since a while has become slow .. unresponsive since about 2 weeks.

It seems to be time to change it.

I changed it to "https://mirror.checkdomain.de/cygwin". There are not that many mirrors in western Europe (close to our Windows CI servers) which are not from universities (I don't want to take their bandwidth). Maybe it is time to setup our own server.

@Zimmi48 : you might want to take this in 8.12 - I have the impression that this costs 30 minutes extra on each CI run, especially for the release builds which pull the source packages.