### PR TITLE
Fixes reduction effect printing in the presence of non purely applicative stacks

### DIFF
--- a/pretyping/cbv.ml
+++ b/pretyping/cbv.ml
@@ -397,6 +397,10 @@ and apply_env env t =
   | _ ->
     map_with_binders subs_lift apply_env env t
 
+let rec strip_app = function
+  | APP (args,st) -> APP (args,strip_app st)
+  | s -> TOP
+
 (* The main recursive functions
  *
  * Go under applications and cases/projections (pushed in the stack),
@@ -442,7 +446,7 @@ let rec norm_head info env t stack =
 
   | Const sp ->
     Reductionops.reduction_effect_hook info.env info.sigma
-      (fst sp) (lazy (reify_stack t stack));
+      (fst sp) (lazy (reify_stack t (strip_app stack)));
     norm_head_ref 0 info env stack (ConstKey sp) t
 
   | LetIn (_, b, _, c) ->

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -757,7 +757,7 @@ let rec whd_state_gen flags env sigma =
       | None -> fold ())
     | Const (c,u as const) ->
       reduction_effect_hook env sigma c
-         (lazy (EConstr.to_constr sigma (Stack.zip sigma (x,stack))));
+         (lazy (EConstr.to_constr sigma (Stack.zip sigma (x,fst (Stack.strip_app stack)))));
       if CClosure.RedFlags.red_set flags (CClosure.RedFlags.fCONST c) then
        let u' = EInstance.kind sigma u in
        match constant_value_in env (c, u') with

--- a/tactics/cbn.ml
+++ b/tactics/cbn.ml
@@ -571,7 +571,7 @@ let rec whd_state_gen ?csts ~refold ~tactic_mode flags env sigma =
       | None -> fold ())
     | Const (c,u as const) ->
       Reductionops.reduction_effect_hook env sigma c
-         (lazy (EConstr.to_constr sigma (Stack.zip sigma (x,stack))));
+         (lazy (EConstr.to_constr sigma (Stack.zip sigma (x,fst (Stack.strip_app stack)))));
       if CClosure.RedFlags.red_set flags (CClosure.RedFlags.fCONST c) then
        let u' = EInstance.kind sigma u in
        match constant_value_in env (c, u') with


### PR DESCRIPTION
**Kind:** bug fix

Fixes / closes  coq-community/reduction-effects#10.

The reduction effect plugin was expecting an applicative term of the form `print_id c`, so we drop any `match` or fixpoint, or  projection context from the stack.

An alternative would be to change the plugin. The question is whether we intend to communicate the applicative stack or the full stack. As it is, the intent is to communicate the applicative stack. Don't know if there would be a use for passing the whole stack.

- [ ] Entry added in the changelog
