### PR TITLE
Fixes #12752: applying symbol escaping in coqdoc index

### DIFF
--- a/doc/changelog/08-tools/12754-master+fix-coqdoc-index-escaping.rst
+++ b/doc/changelog/08-tools/12754-master+fix-coqdoc-index-escaping.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  Special symbols now escaped in the index produced by coqdoc,
+  avoiding collision with the syntax of the output format
+  (`#12754 <https://github.com/coq/coq/pull/12754>`_,
+  fixes `#12752 <https://github.com/coq/coq/issues/12752>`_,
+  by Hugo Herbelin).

--- a/tools/coqdoc/output.ml
+++ b/tools/coqdoc/output.ml
@@ -838,7 +838,7 @@ module Html = struct
       printf "<a id=\"%s_%c\"></a><h2>%s %s</h2>\n" idx c (display_letter c) cat;
       List.iter
         (fun (id,(text,link,t)) ->
-           let id' = prepare_entry id t in
+           let id' = escaped (prepare_entry id t) in
            printf "<a href=\"%s\">%s</a> %s<br/>\n" link id' text) l;
       printf "<br/><br/>"
     end


### PR DESCRIPTION
This is to avoid collision with the syntax of the host output language.

**Kind:**  bug fix 

Fixes / closes #12752

- [ ] Added / updated test-suite (waiting rather for a CI-based testing)
- [X] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
