### PR TITLE
Do not refresh the names of implicit arguments.

### DIFF
--- a/dev/ci/user-overlays/12756-jashug-dont-refresh-argument-names.sh
+++ b/dev/ci/user-overlays/12756-jashug-dont-refresh-argument-names.sh
@@ -1,0 +1,9 @@
+if [ "$CI_PULL_REQUEST" = "12756" ] || [ "$CI_BRANCH" = "dont-refresh-argument-names" ]; then
+
+    mathcomp_CI_REF=dont-refresh-argument-names-overlay
+    mathcomp_CI_GITURL=https://github.com/jashug/math-comp
+
+    oddorder_CI_REF=dont-refresh-argument-names-overlay
+    oddorder_CI_GITURL=https://github.com/jashug/odd-order
+
+fi

--- a/doc/changelog/02-specification-language/12756-dont-refresh-argument-names.rst
+++ b/doc/changelog/02-specification-language/12756-dont-refresh-argument-names.rst
@@ -1,0 +1,9 @@
+- **Changed:**
+  Tweaked the algorithm giving default names to arguments.
+  Should reduce the frequency that argument names get an
+  unexpected suffix.
+  Also makes :flag:`Mangle Names` not mess up argument names.
+  (`#12756 <https://github.com/coq/coq/pull/12756>`_,
+  fixes `#12001 <https://github.com/coq/coq/issues/12001>`_
+  and `#6785 <https://github.com/coq/coq/issues/6785>`_,
+  by Jasper Hugunin).

--- a/test-suite/bugs/closed/bug_12001.v
+++ b/test-suite/bugs/closed/bug_12001.v
@@ -1,0 +1,24 @@
+(* Argument names don't get mangled *)
+Set Mangle Names.
+Lemma leibniz_equiv_iff {A : Type} (x y : A) : True.
+Proof. tauto. Qed.
+Check leibniz_equiv_iff (A := nat) 2 3 : True.
+Unset Mangle Names.
+
+(* Coq doesn't make up names for arguments *)
+Definition bar (a a : nat) : nat := 3.
+Arguments bar _ _ : assert.
+Fail Arguments bar a a0 : assert.
+
+(* This definition caused an anomaly in a version of this PR
+without the change to prepare_implicits *)
+Set Implicit Arguments.
+Definition foo (_ : nat) (_ : @eq nat ltac:(assumption) 2) : True := I.
+Fail Check foo (H := 2).
+
+Definition baz (a b : nat) := b.
+Arguments baz a {b}.
+Set Mangle Names.
+Definition baz2 (a b : nat) := b.
+Arguments baz2 a {b}.
+Unset Mangle Names.

--- a/test-suite/output/Arguments_renaming.out
+++ b/test-suite/output/Arguments_renaming.out
@@ -84,8 +84,6 @@ Argument lists should agree on the names they provide.
 The command has indeed failed with message:
 Sequences of implicit arguments must be of different lengths.
 The command has indeed failed with message:
-Some argument names are duplicated: F
-The command has indeed failed with message:
 Argument number 3 is a trailing implicit, so it can't be declared non
 maximal. Please use { } instead of [ ].
 The command has indeed failed with message:

--- a/test-suite/output/Arguments_renaming.v
+++ b/test-suite/output/Arguments_renaming.v
@@ -48,7 +48,6 @@ Check @myplus.
 
 Fail Arguments eq_refl {F g}, [H] k.
 Fail Arguments eq_refl {F}, [F] : rename.
-Fail Arguments eq_refl {F F}, [F] F : rename.
 Fail Arguments eq {A} x [z] : rename.
 Fail Arguments eq {F} x z y.
 Fail Arguments eq {R} s t.

--- a/test-suite/output/Implicit.out
+++ b/test-suite/output/Implicit.out
@@ -5,7 +5,7 @@ ex_intro (P:=fun _ : nat => True) (x:=0) I
 d2 = fun x : nat => d1 (y:=x)
      : forall x x0 : nat, x0 = x -> x0 = x
 
-Arguments d2 [x x0]%nat_scope
+Arguments d2 [x x]%nat_scope
 map id (1 :: nil)
      : list nat
 map id' (1 :: nil)

--- a/test-suite/success/Typeclasses.v
+++ b/test-suite/success/Typeclasses.v
@@ -190,7 +190,7 @@ Record Monad {m : Type -> Type} := {
 
 Print Visibility.
 Print unit.
-Arguments unit {m m0 α}.
+Arguments unit {m _ α}.
 Arguments Monad : clear implicits.
 Notation "'return' t" := (unit t).
 

--- a/vernac/comArguments.ml
+++ b/vernac/comArguments.ml
@@ -213,14 +213,6 @@ let vernac_arguments ~section_local reference args more_implicits flags =
     in CErrors.user_err ~hdr:"vernac_declare_arguments" msg
   end;
 
-  let duplicate_names =
-    List.duplicates Name.equal (List.filter ((!=) Anonymous) names)
-  in
-  if not (List.is_empty duplicate_names) then begin
-    CErrors.user_err Pp.(strbrk "Some argument names are duplicated: " ++
-                         prlist_with_sep pr_comma Name.print duplicate_names)
-  end;
-
   let implicits =
     List.map (fun { name; implicit_status = i } -> (name,i)) args
   in


### PR DESCRIPTION
Try just going with the user-given names, and not worrying about what happens with repeated names or anonymous implicits.
(Support for anonymous implicits is due to herbelin in coq/coq#11098.)

This avoids unnecessarily refreshing the default name to `name0` in several cases in the CI.

This is another step towards checking the standard library with `-mangle-names`.
Closes coq/coq#6785
Closes coq/coq#12001
Unblocks coq/stdlib#50

This PR should not change behaviour in the absence of repeated names.
Since repeated names are already a poorly handled corner case, I would recommend changing binder names to avoid overlap in the case of a change in behavior.

The most common case caught by the CI was that a name like `eq0` now becomes `eq`, and that causes `Arguments` to complain about renaming. The fix is simply to add the `rename` flag or change to use the un-suffixed name.

Since anonymous implicits and implicits with repeated names can already happen, I think this is unlikely to cause too many new problems, though it might exacerbate existing ones. However, I already had to fix one newly possible anomaly, so I can't be too confident.

<!-- Keep what applies -->
**Kind:** bug fix?
I'm not really sure. It closes one issue by someone other than myself, so probably reasonable to call it a bug fix.

- [x] Added / updated test-suite
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).

Overlays:
- [x] [color](https://github.com/fblanqui/color/pull/29)
- [x] [math-comp](https://github.com/math-comp/math-comp/pull/550)
- [x] [odd-order](https://github.com/math-comp/odd-order/pull/25)