### PR TITLE
A fix and two enhancements of trailing pattern factorization in recursive notations

### DIFF
--- a/parsing/extend.mli
+++ b/parsing/extend.mli
@@ -21,12 +21,7 @@ type production_level =
   | NumLevel of int
   | DefaultLevel (** Interpreted differently at the border or inside a rule *)
 
-let production_level_eq lev1 lev2 =
-  match lev1, lev2 with
-  | NextLevel, NextLevel -> true
-  | NumLevel n1, NumLevel n2 -> Int.equal n1 n2
-  | DefaultLevel, DefaultLevel -> true
-  | (NextLevel | NumLevel _| DefaultLevel), _ -> false
+val production_level_eq : production_level -> production_level -> bool
 
 (** User-level types used to tell how to parse or interpret of the non-terminal *)
 

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -665,13 +665,6 @@ let expand_list_rule s typ tkl x n p ll =
        aux (i+1) (main :: tks @ hds) ll in
   aux 0 [] ll
 
-let production_level_eq lev1 lev2 =
-  match lev1, lev2 with
-  | NextLevel, NextLevel -> true
-  | NumLevel n1, NumLevel n2 -> Int.equal n1 n2
-  | DefaultLevel, DefaultLevel -> true
-  | (NextLevel | NumLevel _| DefaultLevel), _ -> false
-
 let is_constr_typ (s,lev) x etyps =
   match List.assoc x etyps with
   (* TODO: factorize these rules with the ones computing the effective


### PR DESCRIPTION
**Kind:** bug fix + enhancements

The fix is a missing check of equality of custom entry names. The enhancements are:
- not to bother about printing breaking hints while checking if a factorization is possible,
- not to care about the border or internal position when the level is made explicit (see `is_constr_typ`).

Ideally, one could also improve the treatment of `DefaultLevel`. It may be done later on as part of a reworking of the computation of associativity.

There will be an example in the test-suite exploiting the enhancement as part of #12765.