### PR TITLE
In recursive notations, accept partial application over the recursive pattern

### DIFF
--- a/doc/changelog/03-notations/12765-master+partial-app-in-recursive-notation.rst
+++ b/doc/changelog/03-notations/12765-master+partial-app-in-recursive-notation.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  Added support for encoding notations of the form :g:`x ⪯ y ⪯ .. ⪯ z ⪯ t`
+  (`#12765 <https://github.com/coq/coq/pull/12765>`_,
+  by Hugo Herbelin).

--- a/doc/sphinx/user-extensions/syntax-extensions.rst
+++ b/doc/sphinx/user-extensions/syntax-extensions.rst
@@ -787,20 +787,39 @@ nested iterating pattern, the second placeholder is finally filled with the
 terminating expression.
 
 In the example above, the iterator :math:`φ([~]_E , [~]_I)` is :math:`cons [~]_E\, [~]_I`
-and the terminating expression is ``nil``. Here are other examples:
+and the terminating expression is ``nil``.
+
+Here is another example with the pattern associating on the left:
 
 .. coqtop:: in
 
    Notation "( x , y , .. , z )" := (pair .. (pair x y) .. z) (at level 0).
+
+Here is an example with more involved recursive patterns:
+
+.. coqtop:: in
 
    Notation "[| t * ( x , y , .. , z ) ; ( a , b , .. , c )  * u |]" :=
      (pair (pair .. (pair (pair t x) (pair t y)) .. (pair t z))
            (pair .. (pair (pair a u) (pair b u)) .. (pair c u)))
      (t at level 39).
 
-Notations with recursive patterns can be reserved like standard
-notations, they can also be declared within
-:ref:`notation scopes <Scopes>`.
+To give a flavor of the extent and limits of the mechanism, here is an
+example showing a notation for a chain of equalities. It relies on an
+artificial expansion of the intended denotation so as to expose a
+``φ(x, .. φ(y,t) ..)`` structure, with the drawback that if ever the
+beta-redexes are contracted, the notations stops to be used for
+printing.
+
+.. coqtop:: in
+
+   Notation "x  ⪯ y  ⪯ ..  ⪯ z  ⪯ t" :=
+     ((fun b A a => a <= b /\ A b) y .. ((fun b A a => a <= b /\ A b) z (fun b => b <= t)) .. x)
+     (at level 70, y at next level, z at next level, t at next level).
+
+Note finally that notations with recursive patterns can be reserved like
+standard notations, they can also be declared within :ref:`notation
+scopes <Scopes>`.
 
 .. _RecursiveNotationsWithBinders:
 

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -391,6 +391,10 @@ let notation_constr_key = function (* Rem: NApp(NRef ref,[]) stands for @ref *)
   | NBinderList (_,_,NApp (NRef ref,args),_,_) ->
       RefKey (canonical_gr ref), AppBoundedNotation (List.length args)
   | NRef ref -> RefKey(canonical_gr ref), NotAppNotation
+  | NApp (NList (_,_,NApp (NRef ref,args),_,_), args') ->
+      RefKey (canonical_gr ref), AppBoundedNotation (List.length args + List.length args')
+  | NApp (NList (_,_,NApp (_,args),_,_), args') ->
+      Oth, AppBoundedNotation (List.length args + List.length args')
   | NApp (_,args) -> Oth, AppBoundedNotation (List.length args)
   | NList (_,_,NApp (NVar x,_),_,_) when x = Notation_ops.ldots_var -> Oth, AppUnboundedNotation
   | _ -> Oth, NotAppNotation

--- a/test-suite/output/Notations3.out
+++ b/test-suite/output/Notations3.out
@@ -249,3 +249,5 @@ myfoo01 tt
      : nat
 myfoo01 tt
      : nat
+1 ⪯ 2 ⪯ 3 ⪯ 4
+     : Prop

--- a/test-suite/output/Notations3.v
+++ b/test-suite/output/Notations3.v
@@ -410,3 +410,13 @@ Check myfoo0 1 tt. (* was printing [myfoo0 1 HI], but should print [myfoo01 HI] 
 Check myfoo01 tt. (* was printing [myfoo0 1 HI], but should print [myfoo01 HI]  *)
 
 End Issue8126.
+
+Module RecursiveNotationPartialApp.
+
+(* Discussed on Coq Club, 28 July 2020 *)
+Notation "x  ⪯ y  ⪯ ..  ⪯ z  ⪯ t" :=
+  ((fun b A a => a <= b /\ A b) y .. ((fun b A a => a <= b /\ A b) z (fun b => b <= t)) .. x)
+  (at level 70, y at next level, z at next level, t at next level).
+Check 1 ⪯ 2 ⪯ 3 ⪯ 4.
+
+End RecursiveNotationPartialApp.


### PR DESCRIPTION
**Kind:** enhancement

Includes #12764 (now merged) which should be merged beforehand.

This allows e.g. to support a notation of the form `x ⪯ y ⪯ z ⪯ t` standing for `x <= y /\ y <= z /\ z <= t` as follows:
```
Notation "x  ⪯ y  ⪯ ..  ⪯ z  ⪯ t" :=
  ((fun b A a => a <= b /\ A b) y .. ((fun b A a => a <= b /\ A b) z (fun b => b <= t)) .. x)
  (at level 70, y at next level, z at next level, t at next level).
Check 1 ⪯ 2 ⪯ 3 ⪯ 4.
(* 1 ⪯ 2 ⪯ 3 ⪯ 4 *)
Eval simpl in 1 ⪯ 2 ⪯ 3 ⪯ 4.
(* reducing the beta-redexes: 1 <= 2 /\ 2 <= 3 <= 4 *)
```

The extension is natural as it adds support for matching prefixes of an n-ary application and I have no doubt that it is an enhancement.

On the other side, as a way to provide the notation `1 ⪯ 2 ⪯ 3 ⪯ 4` for `1 <= 2 /\ 2 <= 3 /\ 3 <= 4` discussed 29 July 2020 on Coq Club, this is a second best as the right-hand side is a bit hackish: we use beta-expansions to support the non-linearity and this obfuscates the expression. One day, we should think at a direct support but it is not clear to me how to phrase the notation. An temptative idea is to provide `Notation "x ⪯ ..  ⪯ z" := (x <= y /\ .. y <= y' /\ y' <= z ..) (connecting with y and y'))`. Currently, a notation recursive in `x1` and `xn` should have a rhs of the form `iter(x1, .. iter(xn,c) ..)` for `c` a fixed term, but here, it would have to be of a form `iter(phi(x1,x2), .. iter(phi(x_{n-2}),x_{n-1}),phi(x_{n-1},x_{n})) ..)` whose generality needs to be investigated further.

- [X] Added / updated test-suite
- [ ] Corresponding documentation was added / updated (isn't the notation a bit too far from what we reasonably expect to be worth to be shown as an example?)
- [x] Entry added in the changelog (idem)
