### PR TITLE
Merging is now possible with coqbot.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -791,10 +791,12 @@ organization, because of a limitation of GitHub).
 
 #### Additional notes for pull request reviewers and assignees ####
 
-- NEVER USE GITHUB'S MERGE BUTTON.  Instead, we provide a script
-  [`dev/tools/merge-pr.sh`][merge-pr] which you should use to merge a
-  PR (requires having configured gpg with git).  In the future, we
-  will also support merging through a command to **@coqbot**.
+- NEVER USE GITHUB'S MERGE BUTTON.  Instead, you should either:
+  - run the [`dev/tools/merge-pr.sh`][merge-pr] script (requires
+    having configured gpg with git);
+  - or post a comment containing "@coqbot: merge now" (this is
+    especially convenient for developers who do not have a GPG key and
+    for when you do not have access to a console).
 
 - PR authors or co-authors cannot review, self-assign, or merge the PR
   they contributed to.  However, reviewers may push small fixes to the


### PR DESCRIPTION
This is proposed as an alternative to the merge script, in particular for maintainers without a GPG key.

**Kind:** documentation / change to the contributing process.

Once this is approved by @coq/contributing-process-maintainers, I will ping `@coq/pushers` so that they are made aware of this new feature.

FTR, calling this command will verify:
- that the base branch is master
- that the PR is approved and has no change request
- that there is a kind label, no needs label, and a milestone
- that the caller is among the assignees, part of `@coq/pushers` and not the PR author.

However, we do not verify the CI results given how frequently maintainers need to bypass them anyway, and because we expect that the maintainer requesting a merge from the GitHub interface checked the CI results first.