### PR TITLE
[default.nix] Propagate dependency on num following #12604.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
     hostname
     python3 time # coq-makefile timing tools
   ]
-  ++ (with ocamlPackages; [ ocaml findlib num ])
+  ++ (with ocamlPackages; [ ocaml findlib ])
   ++ optionals buildIde [
     ocamlPackages.lablgtk3-sourceview3
     glib gnome3.defaultIconTheme wrapGAppsHook
@@ -68,6 +68,12 @@ stdenv.mkDerivation rec {
     ++ [ graphviz ] # Useful for STM debugging
     ++ [ dune_2 ] # Maybe the next build system
   );
+
+  # Since #12604, ocamlfind looks for num when building plugins
+  # This follows a similar change in the nixpkgs repo (cf. NixOS/nixpkgs#94230)
+  propagatedBuildInputs = [
+    ocamlPackages.num
+  ];
 
   src =
     if shell then null


### PR DESCRIPTION
Since #12604, `ocamlfind` looks for `num` when building plugins.
To avoid requiring all plugins to add a new, irrelevant, dependency, we propagate it.
This solution imitates what was decided for nixpkgs in NixOS/nixpkgs#94230.

Fix coq-community/aac-tactics#61 (we will be able to remove the irrelevant dependency on `num` from its `default.nix` after this PR).

**Kind:** fix / infrastructure.