### PR TITLE
Put cyclic numbers in sort Set instead of Type

### DIFF
--- a/dev/ci/user-overlays/12801-VincentSe-CyclicSet.sh
+++ b/dev/ci/user-overlays/12801-VincentSe-CyclicSet.sh
@@ -1,0 +1,8 @@
+if [ "$CI_PULL_REQUEST" = "12801" ] || [ "$CI_BRANCH" = "CyclicSet" ]; then
+
+    bignums_CI_REF=CyclicSet
+    bignums_CI_GITURL=https://github.com/VincentSe/bignums
+
+    coqprime_CI_REF=CyclicSet
+    coqprime_CI_GITURL=https://github.com/VincentSe/coqprime
+fi

--- a/doc/changelog/10-standard-library/12801-cyclic-set.rst
+++ b/doc/changelog/10-standard-library/12801-cyclic-set.rst
@@ -1,0 +1,5 @@
+- **Changed:**
+  Change the sort of cyclic numbers from Type to Set. For backward compatibility, a dynamic sort was defined in the 3 packages bignums, coqprime and color.
+  See for example commit 6f62bda in bignums.
+  (`#12801 <https://github.com/coq/coq/pull/12801>`_,
+  by Vincent Semeria).

--- a/theories/Numbers/Cyclic/Abstract/CyclicAxioms.v
+++ b/theories/Numbers/Cyclic/Abstract/CyclicAxioms.v
@@ -99,7 +99,7 @@ Module ZnZ.
     lxor        : t -> t -> t }.
  
  Section Specs.
- Context {t : Type}{ops : Ops t}.
+ Context {t : Set}{ops : Ops t}.
 
  Notation "[| x |]" := (to_Z x)  (at level 0, x at level 99).
 
@@ -221,7 +221,7 @@ Module ZnZ.
 
  Section WW.
 
- Context {t : Type}{ops : Ops t}{specs : Specs ops}.
+ Context {t : Set}{ops : Ops t}{specs : Specs ops}.
 
  Let wB := base digits.
 
@@ -284,7 +284,7 @@ Module ZnZ.
 
  Section Of_Z.
 
- Context {t : Type}{ops : Ops t}{specs : Specs ops}.
+ Context {t : Set}{ops : Ops t}{specs : Specs ops}.
 
  Notation "[| x |]" := (to_Z x)  (at level 0, x at level 99).
 
@@ -325,7 +325,7 @@ End ZnZ.
 (** A modular specification grouping the earlier records. *)
 
 Module Type CyclicType.
- Parameter t : Type.
+ Parameter t : Set.
  Declare Instance ops : ZnZ.Ops t.
  Declare Instance specs : ZnZ.Specs ops.
 End CyclicType.

--- a/theories/Numbers/Cyclic/Abstract/DoubleType.v
+++ b/theories/Numbers/Cyclic/Abstract/DoubleType.v
@@ -54,7 +54,7 @@ Arguments W0 {znz}.
     (if depth = n).
 *)
 
-Fixpoint word (w:Type) (n:nat) : Type :=
+Fixpoint word (w:Set) (n:nat) : Set :=
  match n with
  | O => w
  | S n => zn2z (word w n)


### PR DESCRIPTION
**Kind:** Performance.

Numbers are in Set, there is no need to send them into higher universes.

Overlays PRs:
- [x] https://github.com/coq/bignums/pull/47
- [x] https://github.com/fblanqui/color/pull/30
- [x] https://github.com/thery/coqprime/pull/25