### PR TITLE
[zify] fix for bug#12791

### DIFF
--- a/plugins/micromega/zify.ml
+++ b/plugins/micromega/zify.ml
@@ -1324,9 +1324,14 @@ let do_let tac (h : Constr.named_declaration) =
         let env = Tacmach.New.pf_env gl in
         let evd = Tacmach.New.project gl in
         try
-          ignore (get_injection env evd (EConstr.of_constr ty));
-          tac id.Context.binder_name (EConstr.of_constr t)
-            (EConstr.of_constr ty)
+          let x = id.Context.binder_name in
+          ignore
+            (let eq = Lazy.force eq in
+             find_option
+               (match_operator env evd eq
+                  [|EConstr.of_constr ty; EConstr.mkVar x; EConstr.of_constr t|])
+               (HConstr.find_all eq !table_cache));
+          tac x (EConstr.of_constr t) (EConstr.of_constr ty)
         with Not_found -> Tacticals.New.tclIDTAC)
 
 let iter_let_aux tac =

--- a/test-suite/micromega/bug_12791.v
+++ b/test-suite/micromega/bug_12791.v
@@ -1,0 +1,9 @@
+Require Import Lia.
+
+Definition t := nat.
+
+Goal forall (a b: t), let c := a in b = a -> b = c.
+Proof.
+  intros a b c H.
+  lia.
+Qed.


### PR DESCRIPTION
The elimination of let bindings is performing a convertibility check in
order to deal with type aliases.

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** bug fix 


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes #12791 


<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [x] Added / updated test-suite
