### PR TITLE
[micromega] Fix bug#12790

### DIFF
--- a/plugins/micromega/certificate.ml
+++ b/plugins/micromega/certificate.ml
@@ -1020,10 +1020,11 @@ let lia (can_enum : bool) (prfdepth : int) sys =
           p)
       sys
   end;
+  let bnd1 = bound_monomials sys in
   let sys = subst sys in
-  let bnd = bound_monomials sys in
+  let bnd2 = bound_monomials sys in
   (* To deal with non-linear monomials *)
-  let sys = bnd @ saturate_by_linear_equalities sys @ sys in
+  let sys = bnd1 @ bnd2 @ saturate_by_linear_equalities sys @ sys in
   let sys' = List.map (fun ((p, o), prf) -> (cstr_of_poly (p, o), prf)) sys in
   xlia (List.map fst sys) can_enum reduction_equations sys'
 

--- a/test-suite/micromega/bug_12790.v
+++ b/test-suite/micromega/bug_12790.v
@@ -1,0 +1,8 @@
+Require Import Lia.
+
+Goal forall (a b c d x: nat),
+S c = a - b -> x <= x + (S c) * d.
+Proof.
+intros a b c d x H.
+lia.
+Qed.


### PR DESCRIPTION
zify used to generate many syntactic positivity constraints when translating a goal
from nat to Z. For instance, to state that the product of 2 integers
is positive. Instead, lia performs an interval analysis that is more semantic.

The bug was that the interval analysis was performed after the
elimination of equations.  The current workaround is to perform
interval analysis before and after eliminating equations.

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:**  bug fix 


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes #12790


<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [x] Added / updated test-suite
