### PR TITLE
Replacing physical equalities by structural equalities in places where physical equalities isn’t justified.

### DIFF
--- a/plugins/extraction/common.ml
+++ b/plugins/extraction/common.ml
@@ -21,7 +21,7 @@ open Mlutil
 let ascii_of_id id =
   let s = Id.to_string id in
   for i = 0 to String.length s - 2 do
-    if s.[i] == '_' && s.[i+1] == '_' then warning_id s
+    if s.[i] = '_' && s.[i+1] = '_' then warning_id s
   done;
   Unicode.ascii_of_ident s
 
@@ -87,7 +87,7 @@ let begins_with s prefix =
 
 let begins_with_CoqXX s =
   let n = String.length s in
-  n >= 4 && s.[0] == 'C' && s.[1] == 'o' && s.[2] == 'q' &&
+  n >= 4 && s.[0] = 'C' && s.[1] = 'o' && s.[2] = 'q' &&
   let i = ref 3 in
   try while !i < n do
     match s.[!i] with
@@ -98,8 +98,8 @@ let begins_with_CoqXX s =
   with Not_found -> false
 
 let unquote s =
-  if lang () != Scheme then s
-  else String.map (fun c -> if c == '\'' then '~' else c) s
+  if lang () <> Scheme then s
+  else String.map (fun c -> if c = '\'' then '~' else c) s
 
 let rec qualify delim = function
   | [] -> assert false
@@ -119,7 +119,7 @@ let lowercase_id id = Id.of_string (String.uncapitalize_ascii (ascii_of_id id))
 let uppercase_id id =
   let s = ascii_of_id id in
   assert (not (String.is_empty s));
-  if s.[0] == '_' then Id.of_string ("Coq_"^s)
+  if s.[0] = '_' then Id.of_string ("Coq_"^s)
   else Id.of_string (String.capitalize_ascii s)
 
 type kind = Term | Type | Cons | Mod
@@ -136,7 +136,7 @@ end
 module KMap = Map.Make(KOrd)
 
 let upperkind = function
-  | Type -> lang () == Haskell
+  | Type -> lang () = Haskell
   | Term -> false
   | Cons | Mod -> true
 
@@ -287,7 +287,7 @@ let pop_visible, push_visible, get_visible =
       | v :: vl ->
           vis := vl;
           (* we save the 1st-level-content of MPfile for later use *)
-          if get_phase () == Impl && modular () && is_modfile v.mp
+          if get_phase () = Impl && modular () && is_modfile v.mp
           then add_mpfiles_content v.mp v.content
   and push mp mps =
     vis := { mp = mp; params = mps; content = KMap.empty } :: !vis
@@ -328,7 +328,7 @@ type reset_kind = AllButExternal | Everything
 
 let reset_renaming_tables flag =
   do_cleanup ();
-  if flag == Everything then clear_mpfiles_content ()
+  if flag = Everything then clear_mpfiles_content ()
 
 (*S Renaming functions *)
 
@@ -355,7 +355,7 @@ let modfstlev_rename =
     try
       let n = get_index id in
       add_index id (n+1);
-      let s = if n == 0 then "" else string_of_int (n-1) in
+      let s = if n = 0 then "" else string_of_int (n-1) in
       "Coq"^s^"_"^(ascii_of_id id)
     with Not_found ->
       let s = ascii_of_id id in
@@ -381,7 +381,7 @@ let rec mp_renaming_fun mp = match mp with
       else let i,_,_ = MBId.repr mbid in [s^"__"^string_of_int i]
   | MPfile _ ->
       assert (modular ()); (* see [at_toplevel] above *)
-      assert (get_phase () == Pre);
+      assert (get_phase () = Pre);
       let current_mpfile = (List.last (get_visible ())).mp in
       if not (ModPath.equal mp current_mpfile) then mpfiles_add mp;
       [string_of_modfile mp]
@@ -400,7 +400,7 @@ and mp_renaming =
 let ref_renaming_fun (k,r) =
   let mp = modpath_of_r r in
   let l = mp_renaming mp in
-  let l = if lang () != Ocaml && not (modular ()) then [""] else l in
+  let l = if lang () <> Ocaml && not (modular ()) then [""] else l in
   let s =
     let idg = safe_basename_of_global r in
     match l with
@@ -509,7 +509,7 @@ let opened_libraries () =
 
 let pp_duplicate k' prefix mp rls olab =
   let rls', lbl =
-    if k' != Mod then
+    if k' <> Mod then
       (* Here rls=[s], the ref to print is <prefix>.<s>, and olab<>None *)
       rls, Option.get olab
     else
@@ -519,7 +519,7 @@ let pp_duplicate k' prefix mp rls olab =
   match get_duplicate prefix lbl with
   | Some ren -> dottify (ren :: rls')
   | None ->
-     assert (get_phase () == Pre); (* otherwise it's too late *)
+     assert (get_phase () = Pre); (* otherwise it's too late *)
      add_duplicate prefix lbl; dottify rls
 
 let fstlev_ks k = function
@@ -532,7 +532,7 @@ let fstlev_ks k = function
 
 let pp_ocaml_local k prefix mp rls olab =
   (* what is the largest prefix of [mp] that belongs to [visible]? *)
-  assert (k != Mod || not (ModPath.equal mp prefix)); (* mp as whole module isn't in itself *)
+  assert (k <> Mod || not (ModPath.equal mp prefix)); (* mp as whole module isn't in itself *)
   let rls' = List.skipn (mp_length prefix) rls in
   let k's = fstlev_ks k rls' in
   (* Reference r / module path mp is of the form [<prefix>.s.<...>]. *)
@@ -544,7 +544,7 @@ let pp_ocaml_local k prefix mp rls olab =
 
 let pp_ocaml_bound base rls =
   (* clash with a MPbound will be detected and fixed by renaming this MPbound *)
-  if get_phase () == Pre then ignore (visible_clash base (Mod,List.hd rls));
+  if get_phase () = Pre then ignore (visible_clash base (Mod,List.hd rls));
   dottify rls
 
 (* [pp_ocaml_extern] : [mp] isn't local, it is defined in another [MPfile]. *)

--- a/plugins/extraction/extract_env.ml
+++ b/plugins/extraction/extract_env.ml
@@ -144,7 +144,7 @@ let factor_fix env sg l cb msb =
          function
            | (l,SFBconst cb') ->
               let check' = check_fix env sg cb' (j+1) in
-              if not ((fst check : bool) == (fst check') &&
+              if not ((fst check = fst check') &&
                         prec_declaration_equal sg (snd check) (snd check'))
                then raise Impossible;
                labels.(j+1) <- l;
@@ -328,7 +328,7 @@ let rec extract_structure env mp reso ~all = function
 
 and extract_mexpr env mp = function
   | MEwith _ -> assert false (* no 'with' syntax for modules *)
-  | me when lang () != Ocaml || Table.is_extrcompute () ->
+  | me when lang () <> Ocaml || Table.is_extrcompute () ->
       (* In Haskell/Scheme, we expand everything.
          For now, we also extract everything, dead code will be removed later
          (see [Modutil.optimize_struct]. *)
@@ -429,7 +429,7 @@ let mono_filename f =
           else f
         in
         let id =
-          if lang () != Haskell then default_id
+          if lang () <> Haskell then default_id
           else
             try Id.of_string (Filename.basename f)
             with UserError _ ->
@@ -499,9 +499,9 @@ let print_structure_to_file (fn,si,mo) dry struc =
   let unsafe_needs = {
     mldummy = struct_ast_search Mlutil.isMLdummy struc;
     tdummy = struct_type_search Mlutil.isTdummy struc;
-    tunknown = struct_type_search ((==) Tunknown) struc;
+    tunknown = struct_type_search ((=) Tunknown) struc;
     magic =
-      if lang () != Haskell then false
+      if lang () <> Haskell then false
       else struct_ast_search (function MLmagic _ -> true | _ -> false) struc }
   in
   (* First, a dry run, for computing objects to rename or duplicate *)
@@ -563,7 +563,7 @@ let init ?(compute=false) ?(inner=false) modular library =
   set_library library;
   set_extrcompute compute;
   reset ();
-  if modular && lang () == Scheme then error_scheme ()
+  if modular && lang () = Scheme then error_scheme ()
 
 let warns () =
   warning_opaques (access_opaque ());
@@ -716,7 +716,7 @@ let remove f =
   if Sys.file_exists f then Sys.remove f
 
 let extract_and_compile l =
-  if lang () != Ocaml then
+  if lang () <> Ocaml then
     CErrors.user_err (Pp.str "This command only works with OCaml extraction");
   let f = Filename.temp_file "testextraction" ".ml" in
   let () = full_extraction (Some f) l in

--- a/plugins/extraction/haskell.ml
+++ b/plugins/extraction/haskell.ml
@@ -322,7 +322,7 @@ let rec pp_ind first kn i ind =
 (*s Pretty-printing of a declaration. *)
 
 let pp_decl = function
-  | Dind (kn,i) when i.ind_kind == Singleton ->
+  | Dind (kn,i) when i.ind_kind = Singleton ->
       pp_singleton kn i.ind_packets.(0) ++ fnl ()
   | Dind (kn,i) -> hov 0 (pp_ind true kn 0 i)
   | Dtype (r, l, t) ->
@@ -335,7 +335,7 @@ let pp_decl = function
             prlist (fun id -> str (id^" ")) ids ++ str "=" ++ spc () ++ str s
           with Not_found ->
             prlist (fun id -> Id.print id ++ str " ") l ++
-            if t == Taxiom then str "= () -- AXIOM TO BE REALIZED" ++ fnl ()
+            if t = Taxiom then str "= () -- AXIOM TO BE REALIZED" ++ fnl ()
             else str "=" ++ spc () ++ pp_type false l t
         in
         hov 2 (str "type " ++ pp_global Type r ++ spc () ++ st) ++ fnl2 ()

--- a/plugins/extraction/mlutil.ml
+++ b/plugins/extraction/mlutil.ml
@@ -62,7 +62,7 @@ let rec eq_ml_type t1 t2 = match t1, t2 with
 | Tvar i1, Tvar i2 -> Int.equal i1 i2
 | Tvar' i1, Tvar' i2 -> Int.equal i1 i2
 | Tmeta m1, Tmeta m2 -> eq_ml_meta m1 m2
-| Tdummy k1, Tdummy k2 -> k1 == k2
+| Tdummy k1, Tdummy k2 -> k1 == k2 (* FIXME: Why is the physical equality useful here? *)
 | Tunknown, Tunknown -> true
 | Taxiom, Taxiom -> true
 | (Tarr _ | Tglob _ | Tvar _ | Tvar' _ | Tmeta _ | Tdummy _ | Tunknown | Taxiom), _
@@ -129,7 +129,7 @@ let rec mgu = function
   | Taxiom, Taxiom -> ()
   | _ -> raise Impossible
 
-let skip_typing () = lang () == Scheme || is_extrcompute ()
+let skip_typing () = lang () = Scheme || is_extrcompute ()
 
 let needs_magic p =
   if skip_typing () then false
@@ -140,7 +140,7 @@ let put_magic_if b a = if b then MLmagic a else a
 let put_magic p a = if needs_magic p then MLmagic a else a
 
 let generalizable a =
-  lang () != Ocaml ||
+  lang () <> Ocaml ||
     match a with
       | MLapp _ -> false
       | _ -> true (* TODO, this is just an approximation for the moment *)
@@ -353,7 +353,7 @@ let type_expunge_from_sign env s t =
     | _ -> assert false
   in
   let t = expunge (sign_no_final_keeps s) t in
-  if lang () != Haskell && sign_kind s == UnsafeLogicalSig then
+  if lang () <> Haskell && sign_kind s = UnsafeLogicalSig then
     Tarr (Tdummy Kprop, t)
   else t
 
@@ -394,7 +394,7 @@ let rec eq_ml_ast t1 t2 = match t1, t2 with
 | MLfix (i1, id1, t1), MLfix (i2, id2, t2) ->
   Int.equal i1 i2 && Array.equal Id.equal id1 id2 && Array.equal eq_ml_ast t1 t2
 | MLexn e1, MLexn e2 -> String.equal e1 e2
-| MLdummy k1, MLdummy k2 -> k1 == k2
+| MLdummy k1, MLdummy k2 -> k1 == k2 (* FIXME: Why is the physical equality useful here? *)
 | MLaxiom, MLaxiom -> true
 | MLmagic t1, MLmagic t2 -> eq_ml_ast t1 t2
 | MLuint i1, MLuint i2 -> Uint63.equal i1 i2
@@ -959,7 +959,7 @@ let rec merge_ids ids ids' = match ids,ids' with
   | [],l -> l
   | l,[] -> l
   | i::ids, i'::ids' ->
-      (if i == Dummy then i' else i) :: (merge_ids ids ids')
+      (if i = Dummy then i' else i) :: (merge_ids ids ids')
 
 let is_exn = function MLexn _ -> true | _ -> false
 
@@ -1089,7 +1089,7 @@ let rec simpl o = function
   | MLmagic(MLcase(typ,e,br)) ->
      let br' = Array.map (fun (ids,p,c) -> (ids,p,MLmagic c)) br in
      simpl o (MLcase(typ,e,br'))
-  | MLmagic(MLdummy _ as e) when lang () == Haskell -> e
+  | MLmagic(MLdummy _ as e) when lang () = Haskell -> e
   | MLmagic(MLexn _ as e) -> e
   | MLlam _ as e ->
      (match atomic_eta_red e with
@@ -1146,7 +1146,7 @@ and simpl_case o typ br e =
       simpl o (named_lams ids (MLcase (typ, ast_lift n e, br)))
     else
       (* Can we merge several branches as the same constant or function ? *)
-      if lang() == Scheme || is_custom_match br
+      if lang() = Scheme || is_custom_match br
       then MLcase (typ, e, br)
       else match factor_branches o typ br with
         | Some (f,ints) when Int.equal (Int.Set.cardinal ints) (Array.length br) ->
@@ -1187,7 +1187,7 @@ let is_impl_kill = function Kill (Kimplicit _) -> true | _ -> false
 
 let kill_some_lams bl (ids,c) =
   let n = List.length bl in
-  let n' = List.fold_left (fun n b -> if b == Keep then (n+1) else n) 0 bl in
+  let n' = List.fold_left (fun n b -> if b = Keep then (n+1) else n) 0 bl in
   if Int.equal n n' then ids,c
   else if Int.equal n' 0 && not (List.exists is_impl_kill bl)
   then [],ast_lift (-n) c
@@ -1266,8 +1266,8 @@ let term_expunge s (ids,c) =
   if List.is_empty s then c
   else
     let ids,c = kill_some_lams (List.rev s) (ids,c) in
-    if List.is_empty ids && lang () != Haskell &&
-       sign_kind s == UnsafeLogicalSig
+    if List.is_empty ids && lang () <> Haskell &&
+       sign_kind s = UnsafeLogicalSig
     then MLlam (Dummy, ast_lift 1 c)
     else named_lams ids c
 
@@ -1563,7 +1563,7 @@ let inline r t =
   not (to_keep r) (* The user DOES want to keep it *)
   && not (is_inline_custom r)
   && (to_inline r (* The user DOES want to inline it *)
-     || (lang () != Haskell &&
+     || (lang () <> Haskell &&
          (is_projection r || is_recursor r ||
           manual_inline r || inline_test r t)))
 

--- a/plugins/extraction/modutil.ml
+++ b/plugins/extraction/modutil.ml
@@ -115,13 +115,13 @@ let ind_iter_references do_term do_cons do_type kn ind =
   let cons_iter cp l = do_cons (GlobRef.ConstructRef cp); List.iter type_iter l in
   let packet_iter ip p =
     do_type (GlobRef.IndRef ip);
-    if lang () == Ocaml then
+    if lang () = Ocaml then
       (match ind.ind_equiv with
          | Miniml.Equiv kne -> do_type (GlobRef.IndRef (MutInd.make1 kne, snd ip));
          | _ -> ());
     Array.iteri (fun j -> cons_iter (ip,j+1)) p.ip_types
   in
-  if lang () == Ocaml then record_iter_references do_term ind.ind_kind;
+  if lang () = Ocaml then record_iter_references do_term ind.ind_kind;
     Array.iteri (fun i -> packet_iter (kn,i)) ind.ind_packets
 
 let decl_iter_references do_term do_cons do_type =
@@ -218,7 +218,7 @@ let is_modular = function
 
 let rec search_structure l m = function
   | [] -> raise Not_found
-  | (lab,d)::_ when Label.equal lab l && (is_modular d : bool) == m -> d
+  | (lab,d)::_ when Label.equal lab l && (is_modular d = m) -> d
   | _::fields -> search_structure l m fields
 
 let get_decl_in_structure r struc =

--- a/plugins/extraction/ocaml.ml
+++ b/plugins/extraction/ocaml.ml
@@ -127,13 +127,13 @@ let is_infix r =
    let len = String.length s in
    len >= 3 &&
    (* parenthesized *)
-   (s.[0] == '(' && s.[len-1] == ')' &&
+   (s.[0] = '(' && s.[len-1] = ')' &&
       let inparens = String.trim (String.sub s 1 (len - 2)) in
       let inparens_len = String.length inparens in
       (* either, begins with infix symbol, any remainder is all operator chars *)
       (List.mem inparens.[0] infix_symbols && substring_all_opchars inparens 1 inparens_len) ||
       (* or, starts with #, at least one more char, all are operator chars *)
-      (inparens.[0] == '#' && inparens_len >= 2 && substring_all_opchars inparens 1 inparens_len) ||
+      (inparens.[0] = '#' && inparens_len >= 2 && substring_all_opchars inparens 1 inparens_len) ||
       (* or, is an OCaml built-in infix *)
       (List.mem inparens builtin_infixes)))
 
@@ -583,7 +583,7 @@ let pp_decl = function
             pp_string_parameters ids, str " =" ++ spc () ++ str s
           with Not_found ->
             pp_parameters l,
-            if t == Taxiom then str " (* AXIOM TO BE REALIZED *)"
+            if t = Taxiom then str " (* AXIOM TO BE REALIZED *)"
             else str " =" ++ spc () ++ pp_type false l t
         in
         hov 2 (str "type " ++ ids ++ name ++ def)
@@ -705,7 +705,7 @@ let rec pp_structure_elem = function
   | (l,SEmodule m) ->
       let typ =
         (* virtual printing of the type, in order to have a correct mli later*)
-        if Common.get_phase () == Pre then
+        if Common.get_phase () = Pre then
           str ": " ++ pp_module_type [] m.ml_mod_type
         else mt ()
       in

--- a/plugins/extraction/scheme.ml
+++ b/plugins/extraction/scheme.ml
@@ -42,7 +42,7 @@ let preamble _ comment _ usf =
   (if usf.mldummy then str "(define __ (lambda (_) __))\n\n" else mt ())
 
 let pr_id id =
-  str @@ String.map (fun c -> if c == '\'' then '~' else c) (Id.to_string id)
+  str @@ String.map (fun c -> if c = '\'' then '~' else c) (Id.to_string id)
 
 let paren = pp_par true
 

--- a/plugins/extraction/table.ml
+++ b/plugins/extraction/table.ml
@@ -156,7 +156,7 @@ let is_coinductive r =
     | IndRef (kn,_) -> kn
     | _ -> assert false
   in
-  try Mindmap_env.find kn !inductive_kinds == Coinductive
+  try Mindmap_env.find kn !inductive_kinds = Coinductive
   with Not_found -> false
 
 let is_coinductive_type = function


### PR DESCRIPTION
**Kind:** infrastructure (I guess?).
Closes #12818

The extraction plugin uses a lot of physical equalities in places where I don’t see any justifications for why. By reading the code, most of these usages are against flags (e.g. `type lang = Ocaml | Haskell | Scheme | JSON`): sure, for such structures, structural equality is basically the physical one… but why using the physical one then?

This commit should not change the behaviour of Coq in any way: I left the physical equality wherever I had a doubt.