### PR TITLE
Tactics inversion and replace work with eq in type

### DIFF
--- a/doc/changelog/04-tactics/12847-master+inversion-works-with-eq-in-type.rst
+++ b/doc/changelog/04-tactics/12847-master+inversion-works-with-eq-in-type.rst
@@ -1,0 +1,6 @@
+- **Added:**
+  :tacn:`replace` and :tacn:`inversion` support registration of a
+  :g:`core.identity`-like equality in :g:`Type`, such as HoTT's :g:`path`
+  (`#12847 <https://github.com/coq/coq/pull/12847>`_,
+  partially fixes `#12846 <https://github.com/coq/coq/issues/12846>`_,
+  by Hugo Herbelin).

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -659,8 +659,12 @@ let replace_using_leibniz clause c1 c2 l2r unsafe try_prove_eq_opt =
   | None ->
     tclFAIL 0 (str"Terms do not have convertible types")
   | Some evd ->
-    let e = lib_ref "core.eq.type" in
-    let sym = lib_ref "core.eq.sym" in
+    let e,sym =
+      try lib_ref "core.eq.type", lib_ref "core.eq.sym"
+      with UserError _ ->
+      try lib_ref "core.identity.type", lib_ref "core.identity.sym"
+      with UserError _ ->
+        user_err (strbrk "Need a registration for either core.eq.type and core.eq.sym or core.identity.type and core.identity.sym.") in
     Tacticals.New.pf_constr_of_global sym >>= fun sym ->
     Tacticals.New.pf_constr_of_global e >>= fun e ->
     let eq = applist (e, [t1;c1;c2]) in

--- a/test-suite/success/eqtacticsnois.v
+++ b/test-suite/success/eqtacticsnois.v
@@ -1,0 +1,15 @@
+(* coq-prog-args: ("-nois") *)
+
+Inductive eq {A : Type} (x : A) : forall a:A, Prop :=  eq_refl : eq x x.
+
+Axiom sym : forall A (x y : A) (_ : eq x y), eq y x.
+Require Import Ltac.
+
+Register eq as core.eq.type.
+Register sym as core.eq.sym.
+
+Goal forall A (x y:A) (_ : forall z, eq y z), eq x x.
+intros * H. replace x with y.
+- reflexivity.
+- apply H.
+Qed.


### PR DESCRIPTION
**Kind:** enhancement / fix

We do "minimal" changes so that `replace with` and `inversion` works with HoTT (on the side of HoTT, support for `discriminate` should also be provided, see HoTT/HoTT#1382).

This is a partial fix of #12846.

- [X] Added / updated test-suite (for `replace`)
- [ ] Corresponding documentation (that would be good that the role of each registerable constant is documented, but this goes beyond the scope of this PR)
- [X] Entry added in the changelog
