### PR TITLE
Avoid running configure when plugins/ modified

### DIFF
--- a/config/dune
+++ b/config/dune
@@ -2,7 +2,13 @@
  (name config)
  (synopsis "Coq Configuration Variables")
  (public_name coq.config)
+ (modules :standard \ list_plugins)
  (wrapped false))
+
+(executable (name list_plugins) (modules list_plugins))
+(rule (targets plugin_list)
+  (deps (source_tree %{project_root}/plugins))
+  (action (with-stdout-to %{targets} (chdir %{project_root} (run config/list_plugins.exe)))))
 
 ; Dune doesn't use configure's output, but it is still necessary for
 ; some Coq files to work; will be fixed in the future.
@@ -13,7 +19,7 @@
    %{project_root}/configure.ml
    %{project_root}/dev/ocamldebug-coq.run
    %{project_root}/dev/header.c
-  ; Needed to generate include lists for coq_makefile
-  (source_tree %{project_root}/plugins)
+   ; Needed to generate include lists for coq_makefile
+   plugin_list
   (env_var COQ_CONFIGURE_PREFIX))
  (action (chdir %{project_root} (run %{ocaml} configure.ml -no-ask -native-compiler no))))

--- a/config/list_plugins.ml
+++ b/config/list_plugins.ml
@@ -1,0 +1,10 @@
+let plugins =
+  try Sys.readdir "plugins"
+  with _ -> [||]
+
+let () = Array.sort compare plugins
+
+let () =Array.iter (fun f ->
+    let f' = "plugins/"^f in
+    if Sys.is_directory f' && f.[0] <> '.' then print_endline f)
+    plugins


### PR DESCRIPTION
We use an indirection, producing the sorted list of subdirectories of
plugins/, so that dune can recognize it hasn't changed and doesn't
rerun configure. Since configure regenerates a timestamp this avoids
recompiling the stdlib.

Fix #12750.
