### PR TITLE
Mini-fix in test suite: arithmetic directory does no longer exist

### DIFF
--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -198,7 +198,6 @@ summary:
 	  $(call summary_dir, "Coqdoc tests", coqdoc); \
 	  $(call summary_dir, "tools/ tests", tools); \
 	  $(call summary_dir, "Unit tests", unit-tests); \
-	  $(call summary_dir, "Machine arithmetic tests", arithmetic); \
 	  $(call summary_dir, "Ltac2 tests", ltac2); \
 	  nb_success=`find . -name '*.log' -exec tail -n2 '{}' \; | grep -e $(log_success) | wc -l`; \
 	  nb_failure=`find . -name '*.log' -exec tail -n2 '{}' \; | grep -e $(log_failure) | wc -l`; \


### PR DESCRIPTION
**Kind:**  bug fix / infrastructure.

This is a straightforward PR: The directory test-suite/arithmetic is obsolete since 7461fe4f and we delete it (this was noticed thanks to `find` issuing a warning in `make report`).

