### PR TITLE
Adding ability to tell that a section variable has to be hidden by default at goal initialization

### DIFF
--- a/interp/decls.ml
+++ b/interp/decls.ml
@@ -62,6 +62,7 @@ type logical_kind =
 type variable_data = {
   opaque:bool;
   kind:logical_kind;
+  goal_visibility:bool;
 }
 
 let vartab =
@@ -72,6 +73,7 @@ let add_variable_data id o = vartab := Id.Map.add id (o,secpath()) !vartab
 
 let variable_opacity id = let {opaque},_ = Id.Map.find id !vartab in opaque
 let variable_kind id = let {kind},_ = Id.Map.find id !vartab in kind
+let variable_goal_visibility id = let {goal_visibility},_ = Id.Map.find id !vartab in goal_visibility
 
 let variable_secpath id =
   let _, dir = Id.Map.find id !vartab in

--- a/interp/decls.mli
+++ b/interp/decls.mli
@@ -63,6 +63,7 @@ type logical_kind =
 type variable_data = {
   opaque:bool;
   kind:logical_kind;
+  goal_visibility:bool;
 }
 
 val add_variable_data : variable -> variable_data -> unit
@@ -76,3 +77,6 @@ val variable_opacity : variable -> bool
 
 (* Used in declare, very dubious *)
 val variable_exists : variable -> bool
+
+(* Used in declare*)
+val variable_goal_visibility : variable -> bool

--- a/vernac/comAssumption.mli
+++ b/vernac/comAssumption.mli
@@ -26,6 +26,7 @@ val do_assumptions
 val declare_variable
   : coercion_flag
   -> kind:Decls.assumption_object_kind
+  -> ?goal_visibility:bool
   -> Constr.types
   -> Impargs.manual_implicits
   -> Glob_term.binding_kind

--- a/vernac/comCoercion.ml
+++ b/vernac/comCoercion.ml
@@ -356,7 +356,7 @@ let try_add_new_coercion_with_source ref ~local ~poly ~source =
 let add_coercion_hook poly { Declare.Hook.S.scope; dref; _ } =
   let open Locality in
   let local = match scope with
-  | Discharge -> assert false (* Local Coercion in section behaves like Local Definition *)
+  | Discharge _ -> assert false (* Local Coercion in section behaves like Local Definition *)
   | Global ImportNeedQualified -> true
   | Global ImportDefaultBehavior -> false
   in
@@ -369,7 +369,7 @@ let add_coercion_hook ~poly = Declare.Hook.make (add_coercion_hook poly)
 let add_subclass_hook ~poly { Declare.Hook.S.scope; dref; _ } =
   let open Locality in
   let stre = match scope with
-  | Discharge -> assert false (* Local Subclass in section behaves like Local Definition *)
+  | Discharge _ -> assert false (* Local Subclass in section behaves like Local Definition *)
   | Global ImportNeedQualified -> true
   | Global ImportDefaultBehavior -> false
   in

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -437,8 +437,8 @@ let declare_variable_core ~name ~kind ?(goal_visibility=true) d =
   Impargs.declare_var_implicits ~impl name;
   Notation.declare_ref_arguments_scope Evd.empty (GlobRef.VarRef name)
 
-let declare_variable ~name ~kind ~typ ~impl =
-  declare_variable_core ~name ~kind (SectionLocalAssum { typ; impl })
+let declare_variable ~name ~kind ?goal_visibility ~typ ~impl =
+  declare_variable_core ~name ~kind ?goal_visibility (SectionLocalAssum { typ; impl })
 
 (* Declaration messages *)
 
@@ -561,8 +561,8 @@ let declare_entry_core ~name ~scope ~kind ?hook ~obls ~impargs ~uctx entry =
   in
   let ubind = UState.universe_binders uctx in
   let dref = match scope with
-  | Locality.Discharge ->
-    let () = declare_variable_core ~name ~kind (SectionLocalDef entry) in
+  | Locality.Discharge goal_visibility ->
+    let () = declare_variable_core ~name ~kind ~goal_visibility (SectionLocalDef entry) in
     if should_suggest then Proof_using.suggest_variable (Global.env ()) name;
     Names.GlobRef.VarRef name
   | Locality.Global local ->
@@ -628,7 +628,7 @@ let warn_let_as_axiom =
 
 let declare_assumption ~name ~scope ~hook ~impargs ~uctx pe =
   let local = match scope with
-    | Locality.Discharge -> warn_let_as_axiom name; Locality.ImportNeedQualified
+    | Locality.Discharge _ -> warn_let_as_axiom name; Locality.ImportNeedQualified
     | Locality.Global local -> local
   in
   let kind = Decls.(IsAssumption Conjectural) in

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -357,6 +357,7 @@ val declare_entry
 val declare_variable
   :  name:variable
   -> kind:Decls.logical_kind
+  -> ?goal_visibility:bool
   -> typ:Constr.types
   -> impl:Glob_term.binding_kind
   -> unit

--- a/vernac/locality.ml
+++ b/vernac/locality.ml
@@ -11,7 +11,8 @@
 (** * Managing locality *)
 
 type import_status = ImportDefaultBehavior | ImportNeedQualified
-type locality = Discharge | Global of import_status
+type goal_visibility = bool
+type locality = Discharge of goal_visibility | Global of import_status
 
 let importability_of_bool = function
   | true -> ImportNeedQualified
@@ -45,7 +46,7 @@ let enforce_locality_exp locality_flag discharge =
      (* If a Let/Variable is defined outside a section, then we consider it as a local definition *)
      warn_local_declaration ();
      Global ImportNeedQualified
-  | None, DoDischarge -> Discharge
+  | None, DoDischarge -> Discharge true
   | Some true, DoDischarge -> CErrors.user_err Pp.(str "Local not allowed in this case")
   | Some false, DoDischarge -> CErrors.user_err Pp.(str "Global not allowed in this case")
 

--- a/vernac/locality.mli
+++ b/vernac/locality.mli
@@ -11,7 +11,8 @@
 (** * Managing locality *)
 
 type import_status = ImportDefaultBehavior | ImportNeedQualified
-type locality = Discharge | Global of import_status
+type goal_visibility = bool
+type locality = Discharge of goal_visibility | Global of import_status
 
 (** * Positioning locality for commands supporting discharging and export
     outside of modules *)

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -463,10 +463,12 @@ let vernac_custom_entry ~module_local s =
 (***********)
 (* Gallina *)
 
+let is_not_discharge = function Locality.Discharge _ -> false | _ -> true
+
 let check_name_freshness locality {CAst.loc;v=id} : unit =
   (* We check existence here: it's a bit late at Qed time *)
   if Nametab.exists_cci (Lib.make_path id) || Termops.is_section_variable id ||
-     locality <> Locality.Discharge && Nametab.exists_cci (Lib.make_path_except_section id)
+     is_not_discharge locality && Nametab.exists_cci (Lib.make_path_except_section id)
   then
     user_err ?loc  (Id.print id ++ str " already exists.")
 
@@ -565,7 +567,7 @@ let vernac_definition_name lid local =
     | { v = Name.Name n; loc } -> CAst.make ?loc n in
   let () =
     match local with
-    | Discharge -> Dumpglob.dump_definition lid true "var"
+    | Discharge _ -> Dumpglob.dump_definition lid true "var"
     | Global _ -> Dumpglob.dump_definition lid false "def"
   in
   lid
@@ -632,7 +634,7 @@ let vernac_assumption ~atts discharge kind l nl =
       List.iter (fun (lid, _) ->
           match scope with
             | Global _ -> Dumpglob.dump_definition lid false "ax"
-            | Discharge -> Dumpglob.dump_definition lid true "var") idl) l;
+            | Discharge _ -> Dumpglob.dump_definition lid true "var") idl) l;
   ComAssumption.do_assumptions ~poly:atts.polymorphic ~program_mode:atts.program ~scope ~kind nl l
 
 let is_polymorphic_inductive_cumulativity =


### PR DESCRIPTION
**Kind:** developer-side feature 

This is in preparation of #12432, in relation to this [comment](https://github.com/coq/coq/pull/12432#issuecomment-664005730) and comments before and after.

The PR is at the current stage to get feedback on the "proof of concept" (starting with @ejgallego, specialist of `declare.ml` and @ppedrot, who expressed a related need).