### PR TITLE
Adding a mention of the JSON extraction in the documentation.

### DIFF
--- a/doc/sphinx/addendum/extraction.rst
+++ b/doc/sphinx/addendum/extraction.rst
@@ -99,11 +99,14 @@ Extraction Options
 Setting the target language
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. cmd:: Extraction Language {| OCaml | Haskell | Scheme }
+.. cmd:: Extraction Language {| OCaml | Haskell | Scheme | JSON }
    :name: Extraction Language
 
    The ability to fix target language is the first and more important
    of the extraction options. Default is ``OCaml``.
+
+   The JSON output is mostly for development or debugging:
+   it contains the raw ML term produced as an intermediary target.
 
 
 Inlining and optimizations


### PR DESCRIPTION
**Kind**: documentation.

This is a split of PR #12835 containing only the documentation change.

Fixes #10902.