### PR TITLE
[coqchk] Look inside inner modules as well

### DIFF
--- a/doc/changelog/08-tools/12862-more-mod-checking.rst
+++ b/doc/changelog/08-tools/12862-more-mod-checking.rst
@@ -1,0 +1,4 @@
+- **Fixed:**
+  ``coqchk`` no longer reports names from inner modules of opaque modules as
+  axioms (`#12862 <https://github.com/coq/coq/pull/12862>`_, fixes `#12845
+  <https://github.com/coq/coq/issues/12845>`_, by Jason Gross).

--- a/test-suite/output-coqchk/bug_12845.out
+++ b/test-suite/output-coqchk/bug_12845.out
@@ -1,0 +1,14 @@
+
+CONTEXT SUMMARY
+===============
+
+* Theory: Set is predicative
+  
+* Axioms: <none>
+  
+* Constants/Inductives relying on type-in-type: <none>
+  
+* Constants/Inductives relying on unsafe (co)fixpoints: <none>
+  
+* Inductives whose positivity is assumed: <none>
+  

--- a/test-suite/output-coqchk/bug_12845.v
+++ b/test-suite/output-coqchk/bug_12845.v
@@ -1,0 +1,13 @@
+Module Type A.
+  Module B.
+    Axiom t : Set.
+  End B.
+End A.
+
+Module a : A.
+  Module B.
+    Definition t : Set := unit.
+  End B.
+End a.
+
+Check a.B.t.


### PR DESCRIPTION
I don't fully understand the code here, so I can't speak as to its
correctness, but it should be simple enough that reviewers can
understand what it's doing and whether or not it's correct.

This is useful for me in making progress towards
https://github.com/mit-plv/fiat-crypto/issues/736

**Kind:** bug fix

Fixes #12845 (coqchk reports names from inner modules of opaque modules as axioms)

- [x] Added / updated test-suite
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
