### PR TITLE
Improve `make approve-output`

### DIFF
--- a/doc/changelog/11-infrastructure-and-dependencies/12864-fix-approve-output.rst
+++ b/doc/changelog/11-infrastructure-and-dependencies/12864-fix-approve-output.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  ``make approve-output`` in the test-suite now correctly handles
+  ``output-coqtop`` and ``output-coqchk`` tests (`#12864
+  <https://github.com/coq/coq/pull/12864>`_, fixes `#12863
+  <https://github.com/coq/coq/issues/12863>`_, by Jason Gross).

--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -501,8 +501,8 @@ $(addsuffix .log,$(wildcard output-coqchk/*.v)): %.v.log: %.v %.out $(PREREQUISI
 	} > "$(shell dirname $<)/$(shell basename $< .v).chk.log"; fi
 
 .PHONY: approve-output
-approve-output: output output-coqtop
-	$(HIDE)for f in output/*.out.real; do \
+approve-output: output output-coqtop output-coqchk
+	$(HIDE)for f in $(wildcard $(addsuffix /*.out.real,$^)); do \
 	  mv "$$f" "$${f%.real}"; \
 	  echo "Updated $${f%.real}!"; \
 	done


### PR DESCRIPTION
It now silently does nothing rather than erroring with `mv: cannot stat
'output/*.out.real': No such file or directory` if there is no output to
approve, and also correctly handles `output-coqtop` and `output-coqchk`
rather than ignoring these directories.

**Kind:** bug fix / infrastructure.

Fixes #12863

- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
