### PR TITLE
Fast freeze summary

### DIFF
--- a/clib/dyn.ml
+++ b/clib/dyn.ml
@@ -49,6 +49,13 @@ sig
 
   module Map(Value : ValueS) :
     MapS with type 'a key = 'a tag and type 'a value = 'a Value.t
+
+  module HMap (V1 : ValueS)(V2 : ValueS) :
+    sig
+      type map = { map : 'a. 'a tag -> 'a V1.t -> 'a V2.t }
+      val map : map -> Map(V1).t -> Map(V2).t
+    end
+
 end
 
 module type S =
@@ -132,6 +139,16 @@ module Self : PreS = struct
     let iter f m = Int.Map.iter (fun k v -> f (Any (k, v))) m
     let fold f m accu = Int.Map.fold (fun k v accu -> f (Any (k, v)) accu) m accu
   end
+
+  module HMap (V1 : ValueS) (V2 : ValueS) =
+  struct
+    type map = { map : 'a. 'a tag -> 'a V1.t -> 'a V2.t }
+
+    let map (f : map) (m : Map(V1).t) : Map(V2).t =
+      Int.Map.mapi f.map m
+
+  end
+
 end
 include Self
 

--- a/clib/dyn.mli
+++ b/clib/dyn.mli
@@ -75,6 +75,12 @@ sig
     MapS with type 'a key = 'a tag and type 'a value = 'a Value.t
   (** Map from type tags to values parameterized by the tag type *)
 
+  module HMap (V1 : ValueS)(V2 : ValueS) :
+    sig
+      type map = { map : 'a. 'a tag -> 'a V1.t -> 'a V2.t }
+      val map : map -> Map(V1).t -> Map(V2).t
+    end
+
   module Easy : sig
     (* To create a dynamic type on the fly *)
     val make_dyn_tag : string -> ('a -> t) * (t -> 'a) * 'a tag


### PR DESCRIPTION
This PR makes summary freezing faster by using a O(n) algorithm based on binary tree mapping instead of a O(n log n) one reconstructing the frozen map from scratch. As witnessed by the bench, it's actually quite observable on developments with a lot of small files.

Note that I am somewhat baffled by the number of times we freeze summaries in `coqc`. Quite a few files in the stdlib freeze summaries several thousands of times, starting with Coq.Init.Logic which does it about 1.2k times, more than the number of LOC of the file. I believe this is the symptom of a deeper problem, i.e. the STM doing way to much state handling when in batch mode, similarly to #12639. In an ideal world `coqc` should almost never rely on state handling when batch compiling, except maybe for `par:` commands. So this PR merely qualifies as a workaround.

cc @ejgallego 
