### PR TITLE
Propagate in-context information for explicitation of extra arguments of notations

### DIFF
--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -1000,7 +1000,7 @@ let rec extern inctx ?impargs scopes vars r =
              mkFlattenedCApp (head,args))
 
   | GLetIn (na,b,t,c) ->
-      CLetIn (make ?loc na,sub_extern false scopes vars b,
+      CLetIn (make ?loc na,sub_extern (Option.has_some t) scopes vars b,
               Option.map (extern_typ scopes vars) t,
               extern inctx ?impargs scopes (add_vname vars na) c)
 

--- a/test-suite/output/Implicit.out
+++ b/test-suite/output/Implicit.out
@@ -17,3 +17,7 @@ fix f (x : nat) : option nat := match x with
                                 | S _ => x
                                 end
      : nat -> option nat
+fun x : False => let y := False_rect (A:=bool) x in y
+     : False -> bool
+fun x : False => let y : True := False_rect x in y
+     : False -> True

--- a/test-suite/output/Implicit.v
+++ b/test-suite/output/Implicit.v
@@ -61,3 +61,13 @@ Coercion some_nat := @Some nat.
 Check fix f x := match x with 0 => None | n => some_nat n end.
 
 End MatchBranchesInContext.
+
+Module LetInContext.
+
+Set Implicit Arguments.
+Set Contextual Implicit.
+Axiom False_rect : forall A:Type, False -> A.
+Check fun x:False => let y:= False_rect (A:=bool) x in y. (* will not be in context: explicitation *)
+Check fun x:False => let y:= False_rect (A:=True) x in y. (* will be in context: no explicitation *)
+
+End LetInContext.

--- a/test-suite/output/Notations5.out
+++ b/test-suite/output/Notations5.out
@@ -146,8 +146,10 @@ v
      : forall (B : Type) (b : B), 0 = 0 /\ b = b
 @v 0
      : forall (B : Type) (b : B), 0 = 0 /\ b = b
-v 0 (B:=bool)
+v 0
      : forall b : bool, 0 = 0 /\ b = b
+     = ?n@{x:=v 0 (B:=bool)}
+     : nat
 v
      : forall (a2 : nat) (B : Type) (b : B), 0 = a2 /\ b = b
 v 0
@@ -166,8 +168,10 @@ v
      : forall (B : Type) (b : B), 0 = 0 /\ b = b
 @v 0
      : forall (B : Type) (b : B), 0 = 0 /\ b = b
-v 0 (B:=bool)
+v 0
      : forall b : bool, 0 = 0 /\ b = b
+     = ?n@{x:=v 0 (B:=bool)}
+     : nat
 ##
      : forall (a1 a2 : ?A) (B : Type) (b : B), a1 = a2 /\ b = b
 where
@@ -192,10 +196,12 @@ where
      : 0 = 0 /\ true = true
 ## 0 0 true
      : 0 = 0 /\ true = true
-## 0 0 (B:=bool)
+## 0 0
      : forall b : bool, 0 = 0 /\ b = b
-## 0 0 (B:=bool)
+## 0 0
      : forall b : bool, 0 = 0 /\ b = b
+     = ?n@{x:=## 0 0 (B:=bool)}
+     : nat
 ## ?A
      : forall (a1 a2 : ?A) (B : Type) (b : B), a1 = a2 /\ b = b
 where
@@ -230,10 +236,12 @@ where
      : forall b : ?B, 0 = 0 /\ b = b
 where
 ?B : [ |- Type]
-## 0 0 (B:=bool)
+## 0 0
      : forall b : bool, 0 = 0 /\ b = b
-## 0 0 (B:=bool)
+## 0 0
      : forall b : bool, 0 = 0 /\ b = b
+     = ?n@{x:=## 0 0 (B:=bool)}
+     : nat
 ## 0 0 true
      : 0 = 0 /\ true = true
 ## 0 0 true
@@ -246,10 +254,12 @@ where
      : forall b : ?B, 0 = 0 /\ b = b
 where
 ?B : [ |- Type]
-## 0 0 (B:=bool)
+## 0 0
      : forall b : bool, 0 = 0 /\ b = b
-## 0 0 (B:=bool)
+## 0 0
      : forall b : bool, 0 = 0 /\ b = b
+     = ?n@{x:=## 0 0 (B:=bool)}
+     : nat
 ## 0 0 true
      : 0 = 0 /\ true = true
 ## 0 0 true

--- a/test-suite/output/Notations5.v
+++ b/test-suite/output/Notations5.v
@@ -189,7 +189,9 @@ Module AppliedTermsPrinting.
   Check @v 0.
   (* @v 0 *)
   Check @p nat 0 0 bool.
-  (* v 0 (B:=bool) *)
+  (* v 0 *)
+  Eval simpl in (fun x => _:nat) (@p nat 0 0 bool).
+  (* ?n@{x:=v 0 (B:=bool)} *)
 
   End AtAbbreviationForPartialApplication.
 
@@ -217,7 +219,9 @@ Module AppliedTermsPrinting.
   Check @v 0.
   (* @v 0 *)
   Check @p nat 0 0 bool.
-  (* v 0 (B:=bool) *)
+  (* v 0 *)
+  Eval simpl in (fun x => _:nat) (@p nat 0 0 bool).
+  (* ?n@{x:=v 0 (B:=bool)} *)
 
   End AbbreviationForPartialApplication.
 
@@ -247,9 +251,11 @@ Module AppliedTermsPrinting.
   Check ## 0 0 true.
   (* ## 0 0 true *)
   Check p 0 0 (B:=bool).
-  (* ## 0 0 (B:=bool) *)
+  (* ## 0 0 *)
   Check ## 0 0 (B:=bool).
-  (* ## 0 0 (B:=bool) *)
+  (* ## 0 0 *)
+  Eval simpl in (fun x => _:nat) (@p nat 0 0 bool).
+  (* ?n@{x:=## 0 0 (B:=bool)} *)
 
   End NotationForHeadApplication.
 
@@ -301,9 +307,11 @@ Module AppliedTermsPrinting.
   Check ## 0 0.
   (* ## 0 0 *)
   Check p 0 0 (B:=bool).
-  (* ## 0 0 (B:=bool) *)
+  (* ## 0 0 *)
   Check ## 0 0 (B:=bool).
-  (* ## 0 0 (B:=bool) *)
+  (* ## 0 0 *)
+  Eval simpl in (fun x => _:nat) (## 0 0 (B:=bool)).
+  (* ?n@{## 0 0 (B:=bool)} *)
   Check p 0 0 true.
   (* ## 0 0 true *)
   Check ## 0 0 true.
@@ -327,9 +335,11 @@ Module AppliedTermsPrinting.
   Check ## 0 0.
   (* ## 0 0 *)
   Check p 0 0 (B:=bool).
-  (* ## 0 0 (B:=bool) *)
+  (* ## 0 0 *)
   Check ## 0 0 (B:=bool).
-  (* ## 0 0 (B:=bool) *)
+  (* ## 0 0 *)
+  Eval simpl in (fun x => _:nat) (## 0 0 (B:=bool)).
+  (* ?n@{## 0 0 (B:=bool)} *)
   Check p 0 0 true.
   (* ## 0 0 true *)
   Check ## 0 0 true.


### PR DESCRIPTION
**Kind:** enhancement

There is a strategy to make explicit some implicit arguments known to be non inferable (when these arguments were set implicit automatically). The information of being a subterm (= "in context") was used to deactivate explicitation in some cases but not for applied notations.

This PR propagates the "in context" information also for notations. (In practice, very few situations are not "in context". One of the few is as argument of an evar, or the main term of a `match`.)

Incidentally, we also tell that the body of a `let` with an explicit type is "in context".

Note: this is derived from #11272.

- [X] Added / updated test-suite