### PR TITLE
Update sigma instead of erasing it in `update_global_env`

### DIFF
--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -1032,6 +1032,9 @@ module Unsafe = struct
   let mark_as_unresolvables p evs =
     { p with solution = mark_in_evm ~goal:false p.solution evs }
 
+  let update_sigma_env pv env =
+    { pv with solution = Evd.update_sigma_env pv.solution env }
+
 end
 
 module UnsafeRepr = Proof.Unsafe

--- a/engine/proofview.mli
+++ b/engine/proofview.mli
@@ -503,6 +503,9 @@ module Unsafe : sig
   val undefined : Evd.evar_map -> Proofview_monad.goal_with_state list ->
     Proofview_monad.goal_with_state list
 
+  (** [update_sigma_env] lifts [Evd.update_sigma_env] to the proofview *)
+  val update_sigma_env : proofview -> Environ.env -> proofview
+
 end
 
 (** This module gives access to the innards of the monad. Its use is

--- a/proofs/proof.ml
+++ b/proofs/proof.ml
@@ -356,6 +356,10 @@ let compact p =
   let entry, proofview = Proofview.compact p.entry p.proofview in
   { p with proofview; entry }
 
+let update_sigma_env p env =
+  let proofview = Proofview.Unsafe.update_sigma_env p.proofview env in
+  { p with proofview }
+
 (*** Function manipulation proof extra informations ***)
 
 (*** Tactics ***)

--- a/proofs/proof.mli
+++ b/proofs/proof.mli
@@ -78,6 +78,9 @@ val partial_proof : t -> EConstr.constr list
 
 val compact : t -> t
 
+(** [update_sigma_env] lifts [Evd.update_sigma_env] to the proof *)
+val update_sigma_env : t -> Environ.env -> t
+
 (* Returns the proofs (with their type) of the initial goals.
     Raises [UnfinishedProof] is some goals remain to be considered.
     Raises [HasShelvedGoals] if some goals are left on the shelf.

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -1735,11 +1735,7 @@ let return_proof ps =
   List.map (fun (((_ub, body),eff),_) -> (body,eff)) p, uctx
 
 let update_global_env =
-  map ~f:(fun p ->
-      let { Proof.sigma } = Proof.data p in
-      let tac = Proofview.Unsafe.tclEVARS (Evd.update_sigma_env sigma (Global.env ())) in
-      let p, (status,info), _ = Proof.run_tactic (Global.env ()) tac p in
-      p)
+  map ~f:(fun p -> Proof.update_sigma_env p (Global.env ()))
 
 let next = let n = ref 0 in fun () -> incr n; !n
 


### PR DESCRIPTION
The current implementation of `update_global_env` breaks `run_tactic` when we move more data to the evar_map (shelf, goals).

We simply make it update the evar_map instead of erasing it with the global one, so that only relevant components are touched.

@ppedrot can you confirm it looks ok?