### PR TITLE
added numeral_notation to META.coq.in

### DIFF
--- a/META.coq.in
+++ b/META.coq.in
@@ -521,7 +521,7 @@ package "plugins" (
     description = "Coq numeral notation plugin"
     version 	= "8.13"
 
-    requires    = ""
+    requires    = "coq.vernac"
     directory 	= "numeral_notation"
 
     archive(byte)    = "numeral_notation_plugin.cmo"

--- a/META.coq.in
+++ b/META.coq.in
@@ -507,7 +507,7 @@ package "plugins" (
     description = "Coq string_notation plugin"
     version     = "8.13"
 
-    requires    = ""
+    requires    = "coq.vernac"
     directory   = "syntax"
 
     archive(byte)    = "string_notation_plugin.cmo"

--- a/META.coq.in
+++ b/META.coq.in
@@ -517,6 +517,20 @@ package "plugins" (
     plugin(native)  = "string_notation_plugin.cmxs"
   )
 
+  package "numeral_notation" (
+    description = "Coq numeral notation plugin"
+    version 	= "8.13"
+
+    requires    = ""
+    directory 	= "numeral_notation"
+
+    archive(byte)    = "numeral_notation_plugin.cmo"
+    archive(native)  = "numeral_notation_plugin.cmx"
+
+    plugin(byte)    = "numeral_notation_plugin.cmo"
+    plugin(native)  = "numeral_notation_plugin.cmxs"
+  )
+
   package "derive" (
 
     description = "Coq derive plugin"


### PR DESCRIPTION
**Kind:** bug fix.

closes #12789 

This allows for dune to find the numeral_notation plugin which is a problem when `-noinit` is passed.