### PR TITLE
Deprecate intro_using 

### DIFF
--- a/plugins/funind/functional_principles_proofs.ml
+++ b/plugins/funind/functional_principles_proofs.ml
@@ -483,7 +483,10 @@ let treat_new_case ptes_infos nb_prod continue_tac term dyn_infos g =
         (Proofview.V82.of_tactic
            (intro_avoiding (Id.Set.of_list dyn_infos.rec_hyps)))
     ; (* Then the equation itself *)
-      Proofview.V82.of_tactic (intro_using heq_id)
+      Proofview.V82.of_tactic
+        (intro_using_then heq_id
+           (* we get the fresh name with onLastHypId *)
+           (fun _ -> Proofview.tclUNIT ()))
     ; onLastHypId (fun heq_id ->
           tclTHENLIST
             [ (* Then the new hypothesis *)
@@ -1113,16 +1116,18 @@ let prove_princ_for_struct (evd : Evd.evar_map ref) interactive_proof fun_num
   in
   let first_tac : tactic =
     (* every operations until fix creations *)
+    (* names are already refreshed *)
     tclTHENLIST
       [ observe_tac "introducing params"
           (Proofview.V82.of_tactic
-             (intros_using (List.rev_map id_of_decl princ_info.params)))
+             (intros_mustbe_force (List.rev_map id_of_decl princ_info.params)))
       ; observe_tac "introducing predictes"
           (Proofview.V82.of_tactic
-             (intros_using (List.rev_map id_of_decl princ_info.predicates)))
+             (intros_mustbe_force
+                (List.rev_map id_of_decl princ_info.predicates)))
       ; observe_tac "introducing branches"
           (Proofview.V82.of_tactic
-             (intros_using (List.rev_map id_of_decl princ_info.branches)))
+             (intros_mustbe_force (List.rev_map id_of_decl princ_info.branches)))
       ; observe_tac "building fixes" mk_fixes ]
   in
   let intros_after_fixes : tactic =

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -414,7 +414,8 @@ let treat_case forbid_new_ids to_intros finalize_tac nb_lam e infos : tactic =
   observe_tclTHENLIST
     (fun _ _ -> str "treat_case1")
     [ h_intros (List.rev rev_ids)
-    ; Proofview.V82.of_tactic (intro_using teq_id)
+    ; Proofview.V82.of_tactic
+        (intro_using_then teq_id (fun _ -> Proofview.tclUNIT ()))
     ; onLastHypId (fun heq ->
           observe_tclTHENLIST
             (fun _ _ -> str "treat_case2")
@@ -601,7 +602,11 @@ let rec destruct_bounds_aux infos (bound, hyple, rechyps) lbounds g =
                        (Proofview.V82.of_tactic (simplest_case (mkVar id)))
                        [ observe_tclTHENLIST
                            (fun _ _ -> str "")
-                           [ Proofview.V82.of_tactic (intro_using h_id)
+                           [ Proofview.V82.of_tactic
+                               (intro_using_then h_id
+                                  (* We don't care about the refreshed name,
+                                     accessed only through auto? *)
+                                  (fun _ -> Proofview.tclUNIT ()))
                            ; Proofview.V82.of_tactic
                                (simplest_elim
                                   (mkApp (delayed_force lt_n_O, [|s_max|])))
@@ -865,7 +870,10 @@ let terminate_app_rec (f, args) expr_info continuation_tac _ g =
             (simplest_elim (mkApp (mkVar expr_info.ih, Array.of_list args))))
          [ observe_tclTHENLIST
              (fun _ _ -> str "terminate_app_rec2")
-             [ Proofview.V82.of_tactic (intro_using rec_res_id)
+             [ Proofview.V82.of_tactic
+                 (intro_using_then rec_res_id
+                    (* refreshed name gotten from onNthHypId *)
+                    (fun _ -> Proofview.tclUNIT ()))
              ; Proofview.V82.of_tactic intro
              ; onNthHypId 1 (fun v_bound ->
                    onNthHypId 2 (fun v ->

--- a/tactics/elim.ml
+++ b/tactics/elim.ml
@@ -82,10 +82,10 @@ let general_decompose recognizer c =
   Proofview.Goal.enter begin fun gl ->
   let typc = pf_get_type_of gl c in
   tclTHENS (cut typc)
-    [ tclTHEN (intro_using tmphyp_name)
-         (onLastHypId
-            (ifOnHyp recognizer (general_decompose_aux recognizer)
-              (fun id -> clear [id])));
+    [ intro_using_then tmphyp_name (fun id ->
+          ifOnHyp recognizer (general_decompose_aux recognizer)
+            (fun id -> clear [id])
+            id);
        exact_no_check c ]
   end
 

--- a/tactics/eqdecide.ml
+++ b/tactics/eqdecide.ml
@@ -150,12 +150,12 @@ let injHyp id =
 let diseqCase hyps eqonleft =
   let diseq  = Id.of_string "diseq" in
   let absurd = Id.of_string "absurd" in
-  (tclTHEN (intro_using diseq)
-  (tclTHEN (choose_noteq eqonleft)
+  (intro_using_then diseq (fun diseq ->
+  tclTHEN (choose_noteq eqonleft)
   (tclTHEN (rewrite_and_clear (List.rev hyps))
   (tclTHEN  (red_in_concl)
-  (tclTHEN  (intro_using absurd)
-  (tclTHEN  (Simple.apply (mkVar diseq))
+  (intro_using_then absurd (fun absurd ->
+  tclTHEN  (Simple.apply (mkVar diseq))
   (tclTHEN  (injHyp absurd)
             (full_trivial []))))))))
 

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -1068,6 +1068,10 @@ let rec intros_using = function
   | []     -> Proofview.tclUNIT()
   | str::l -> Tacticals.New.tclTHEN (intro_using str) (intros_using l)
 
+let rec intros_mustbe_force = function
+  | []     -> Proofview.tclUNIT()
+  | str::l -> Tacticals.New.tclTHEN (intro_mustbe_force str) (intros_mustbe_force l)
+
 let rec intros_using_then_helper tac acc = function
   | []     -> tac (List.rev acc)
   | str::l -> intro_using_then str (fun str' -> intros_using_then_helper tac (str'::acc) l)

--- a/tactics/tactics.mli
+++ b/tactics/tactics.mli
@@ -65,10 +65,13 @@ val intro_avoiding       : Id.Set.t -> unit Proofview.tactic
 
 val intro_replacing      : Id.t -> unit Proofview.tactic
 val intro_using          : Id.t -> unit Proofview.tactic
+[@@ocaml.deprecated "Prefer [intro_using_then] to avoid renaming issues."]
 val intro_using_then     : Id.t -> (Id.t -> unit Proofview.tactic) -> unit Proofview.tactic
 val intro_mustbe_force   : Id.t -> unit Proofview.tactic
+val intros_mustbe_force  : Id.t list -> unit Proofview.tactic
 val intro_then           : (Id.t -> unit Proofview.tactic) -> unit Proofview.tactic
 val intros_using         : Id.t list -> unit Proofview.tactic
+[@@ocaml.deprecated "Prefer [intros_using_then] to avoid renaming issues."]
 val intros_using_then    : Id.t list -> (Id.t list -> unit Proofview.tactic) -> unit Proofview.tactic
 val intros_replacing     : Id.t list -> unit Proofview.tactic
 val intros_possibly_replacing : Id.t list -> unit Proofview.tactic

--- a/test-suite/bugs/closed/bug_12676.v
+++ b/test-suite/bugs/closed/bug_12676.v
@@ -1,0 +1,13 @@
+
+
+Definition nat_eq_dec(i j:nat) : {i=j}+{i<>j}.
+Proof.
+  pose (diseq := false).
+  decide equality.
+Defined.
+
+Set Mangle Names.
+Definition nat_eq_dec_mangle (i j:nat) : {i=j}+{i<>j}.
+Proof.
+  decide equality. (*Error: Anomaly "variable diseq unbound." ...*)
+Defined.


### PR DESCRIPTION
intro_using is a footgun as it can refresh the name. Callers can still ignore
the generated name by doing `intro_using_then id (fun _ -> tclUNIT())`.

Makes decide equality compatible with Mangle Names (Fix #12676)
Makes omega compatible with Mangle Names (tested with test-suite/success/Omega.v)

***Note from 8.12 RM:** Backported in 8.12.1 without the deprecation.*