### PR TITLE
Documentation of coq_makefile: fix name of installation dir + help on using option -f

### DIFF
--- a/doc/sphinx/practical-tools/utilities.rst
+++ b/doc/sphinx/practical-tools/utilities.rst
@@ -89,10 +89,11 @@ invoking ``coq_makefile`` is the following one:
 Such command generates the following files:
 
 CoqMakefile
-  is a generic makefile for ``GNU Make`` that provides
-  targets to build the project (both ``.v`` and ``.ml*`` files), to install it
-  system-wide in the ``coq-contrib`` directory (i.e. where |Coq| is installed)
-  as well as to invoke coqdoc to generate HTML documentation.
+  is a makefile for ``GNU Make`` with targets to build the project
+  (e.g. generate .vo or .html files from .v or compile .ml* files)
+  and install it in the ``user-contrib`` directory where the |Coq|
+  library is installed. Run ``make`` with the ``-f CoqMakefile``
+  option to use ``CoqMakefile``.
 
 CoqMakefile.conf
   contains make variables assignments that reflect


### PR DESCRIPTION
**Kind:** documentation

Hi, don't know if this is already known. Looking at the documentation of `coq_makefile`, I see that it was mentioning `coq-contrib` to mean `user-contrib`, so I'm just proposing this PR to fix it. While at it, I added the information that `CoqMakefile` needs `-f` to be used. Not so many people know about it, so I hope it could help. So do I hope that the PR is then useful.

- [X] Corresponding documentation was updated