### PR TITLE
[bench] Also upload the raw timing files, etc

### DIFF
--- a/dev/bench/gitlab-bench.yml
+++ b/dev/bench/gitlab-bench.yml
@@ -28,7 +28,10 @@ bench:
     paths:
       - _bench/html/**/*.v.html
       - _bench/logs
-      - _bench/opam.NEW
-      - _bench/opam.OLD
+      - _bench/files.listing
+      - _bench/opam.NEW/**/*.log
+      - _bench/opam.NEW/**/*.timing
+      - _bench/opam.OLD/**/*.log
+      - _bench/opam.OLD/**/*.timing
     when: always
     expire_in: 1 year

--- a/dev/bench/gitlab-bench.yml
+++ b/dev/bench/gitlab-bench.yml
@@ -28,5 +28,7 @@ bench:
     paths:
       - _bench/html/**/*.v.html
       - _bench/logs
+      - _bench/opam.NEW
+      - _bench/opam.OLD
     when: always
     expire_in: 1 year

--- a/dev/bench/gitlab.sh
+++ b/dev/bench/gitlab.sh
@@ -114,6 +114,15 @@ else
     exit 1
 fi
 
+if which du > /dev/null; then
+    :
+else
+    echo > /dev/stderr
+    echo "ERROR: \"du\" program is not available." > /dev/stderr
+    echo > /dev/stderr
+    exit 1
+fi
+
 if [ ! -e "$working_dir" ]; then
     echo > /dev/stderr
     echo "ERROR: \"$working_dir\" does not exist." > /dev/stderr
@@ -429,6 +438,11 @@ for coq_opam_package in $sorted_coq_opam_packages; do
         fi
     done
 done
+
+# Since we do not upload all files, store a list of the files
+# available so that if we at some point want to tweak which files we
+# upload, we'll know which ones are available for upload
+du -ha "$working_dir" > "$working_dir/files.listing"
 
 # The following directories in $working_dir are no longer used:
 #


### PR DESCRIPTION
**Kind:** infrastructure

This allows us to access the raw timing logs, etc.  It might be too much data, so maybe we only want, say, `**/*.timing`, `**/*.log`, and `**/*.csv` (the last two for the perf repos)?

This will, e.g., give @ppedrot the ability to get better per-file timing info from `coq-performance-tests` and `coq-engine-bench` and `coq-rewriter-perf-SuperFast`.