### PR TITLE
Move bench job definition to its own file

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,6 +27,9 @@ variables:
   OPAM_VARIANT: ""
   GIT_DEPTH: "10"
 
+include:
+  - local: '/dev/bench/gitlab-bench.yml'
+
 docker-boot:
   stage: docker
   image: docker:stable
@@ -921,35 +924,3 @@ plugin:ci-rewriter:
     name: "$CI_JOB_NAME"
     paths:
       - _build_ci
-
-bench:
-  stage: stage-1
-  when: manual
-  before_script:
-    - printenv -0 | sort -z | tr '\0' '\n'
-  script:
-    - . ~/.opam/opam-init/init.sh
-    - ./dev/bench/gitlab.sh
-  tags:
-    - timing
-  variables:
-    GIT_DEPTH: ""
-    coq_pr_number: ""
-    coq_pr_comment_id: ""
-    new_ocaml_switch: "ocaml-base-compiler.4.07.1"
-    old_ocaml_switch: "ocaml-base-compiler.4.07.1"
-    new_coq_repository: "https://gitlab.com/coq/coq.git"
-    old_coq_repository: "https://gitlab.com/coq/coq.git"
-    new_coq_opam_archive_git_uri: "https://github.com/coq/opam-coq-archive.git"
-    old_coq_opam_archive_git_uri: "https://github.com/coq/opam-coq-archive.git"
-    new_coq_opam_archive_git_branch: "master"
-    old_coq_opam_archive_git_branch: "master"
-    num_of_iterations: 1
-    coq_opam_packages: "coq-performance-tests coq-engine-bench coq-hott coq-bignums coq-mathcomp-ssreflect coq-mathcomp-fingroup coq-mathcomp-algebra coq-mathcomp-solvable coq-mathcomp-field coq-mathcomp-character coq-mathcomp-odd-order coq-math-classes coq-corn coq-flocq coq-compcert coq-geocoq coq-color coq-coqprime coq-coqutil coq-bedrock2 coq-rewriter coq-fiat-core coq-fiat-parsers coq-fiat-crypto coq-unimath coq-sf-plf coq-coquelicot coq-lambda-rust coq-verdi coq-verdi-raft coq-fourcolor coq-rewriter-perf-SuperFast"
-  artifacts:
-    name: "$CI_JOB_NAME"
-    paths:
-      - _bench/html/**/*.v.html
-      - _bench/logs
-    when: always
-    expire_in: 1 year

--- a/dev/bench/gitlab-bench.yml
+++ b/dev/bench/gitlab-bench.yml
@@ -1,0 +1,32 @@
+
+bench:
+  stage: stage-1
+  when: manual
+  before_script:
+    - printenv -0 | sort -z | tr '\0' '\n'
+  script:
+    - . ~/.opam/opam-init/init.sh
+    - ./dev/bench/gitlab.sh
+  tags:
+    - timing
+  variables:
+    GIT_DEPTH: ""
+    coq_pr_number: ""
+    coq_pr_comment_id: ""
+    new_ocaml_switch: "ocaml-base-compiler.4.07.1"
+    old_ocaml_switch: "ocaml-base-compiler.4.07.1"
+    new_coq_repository: "https://gitlab.com/coq/coq.git"
+    old_coq_repository: "https://gitlab.com/coq/coq.git"
+    new_coq_opam_archive_git_uri: "https://github.com/coq/opam-coq-archive.git"
+    old_coq_opam_archive_git_uri: "https://github.com/coq/opam-coq-archive.git"
+    new_coq_opam_archive_git_branch: "master"
+    old_coq_opam_archive_git_branch: "master"
+    num_of_iterations: 1
+    coq_opam_packages: "coq-performance-tests coq-engine-bench coq-hott coq-bignums coq-mathcomp-ssreflect coq-mathcomp-fingroup coq-mathcomp-algebra coq-mathcomp-solvable coq-mathcomp-field coq-mathcomp-character coq-mathcomp-odd-order coq-math-classes coq-corn coq-flocq coq-compcert coq-geocoq coq-color coq-coqprime coq-coqutil coq-bedrock2 coq-rewriter coq-fiat-core coq-fiat-parsers coq-fiat-crypto coq-unimath coq-sf-plf coq-coquelicot coq-lambda-rust coq-verdi coq-verdi-raft coq-fourcolor coq-rewriter-perf-SuperFast"
+  artifacts:
+    name: "$CI_JOB_NAME"
+    paths:
+      - _bench/html/**/*.v.html
+      - _bench/logs
+    when: always
+    expire_in: 1 year


### PR DESCRIPTION
This focuses review requests to bench-maintainers instead of sharing
with ci-maintainers
