### PR TITLE
Modify lia to work with -mangle-names

### DIFF
--- a/test-suite/bugs/closed/bug_12907.v
+++ b/test-suite/bugs/closed/bug_12907.v
@@ -1,0 +1,7 @@
+From Coq Require Export Lia.
+Set Mangle Names.
+Lemma test (n : nat) : n <= 10 -> n <= 20.
+Proof. lia. Qed.
+
+Lemma test2 : 0 < 1.
+Proof. lia. Qed.

--- a/theories/micromega/Lia.v
+++ b/theories/micromega/Lia.v
@@ -20,7 +20,10 @@ Require Coq.micromega.Tauto.
 Declare ML Module "micromega_plugin".
 
 Ltac zchecker :=
-  intros ?__wit ?__varmap ?__ff ;
+  let __wit := fresh "__wit" in
+  let __varmap := fresh "__varmap" in
+  let __ff := fresh "__ff" in
+  intros __wit __varmap __ff ;
   exact (ZTautoChecker_sound __ff __wit
                                 (@eq_refl bool true <: @eq bool (ZTautoChecker __ff __wit) true)
                                 (@find Z Z0 __varmap)).


### PR DESCRIPTION
We used to be refreshing the names for intros but not using the refreshed names. The same pattern of `intro_using` (which is what `intros ?name` effectively is) messing things up as in coq/coq#12881.

**Kind:** bug fix

Closes #12907

- [x] Added / updated test-suite