### PR TITLE
Better interleaving of evar resolution and constr interpretation

### DIFF
--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -2530,12 +2530,12 @@ let intern_context env impl_env binders =
               binder_block_names = Some (Some AbsPi,ids)}, []) binders in
   (lenv.impls, List.map glob_local_binder_of_extended bl)
 
-let interp_glob_context_evars ?(program_mode=false) env sigma k bl =
+let interp_glob_context_evars ?(program_mode=false) env sigma bl =
   let open EConstr in
   let flags = { Pretyping.all_no_fail_flags with program_mode } in
-  let env, sigma, par, _, impls =
+  let env, sigma, par, impls =
     List.fold_left
-      (fun (env,sigma,params,n,impls) (na, k, b, t) ->
+      (fun (env,sigma,params,impls) (na, k, b, t) ->
        let t' =
          if Option.is_empty b then locate_if_hole ?loc:(loc_of_glob_constr t) na t
          else t
@@ -2551,16 +2551,17 @@ let interp_glob_context_evars ?(program_mode=false) env sigma k bl =
                 | MaxImplicit -> CAst.make (Some (na,true)) :: impls
                 | Explicit -> CAst.make None :: impls
               in
-                (push_rel d env, sigma, d::params, succ n, impls)
+                (push_rel d env, sigma, d::params, impls)
           | Some b ->
               let sigma, c = understand_tcc ~flags env sigma ~expected_type:(OfType t) b in
               let r = Retyping.relevance_of_type env sigma t in
               let d = LocalDef (make_annot na r, c, t) in
-                (push_rel d env, sigma, d::params, n, impls))
-      (env,sigma,[],k+1,[]) (List.rev bl)
-  in sigma, ((env, par), List.rev impls)
+                (push_rel d env, sigma, d::params, impls))
+      (env,sigma,[],[]) (List.rev bl)
+  in
+  sigma, ((env, par), List.rev impls)
 
-let interp_context_evars ?program_mode ?(impl_env=empty_internalization_env) ?(shift=0) env sigma params =
+let interp_context_evars ?program_mode ?(impl_env=empty_internalization_env) env sigma params =
   let int_env,bl = intern_context env impl_env params in
-  let sigma, x = interp_glob_context_evars ?program_mode env sigma shift bl in
+  let sigma, x = interp_glob_context_evars ?program_mode env sigma bl in
   sigma, (int_env, x)

--- a/interp/constrintern.mli
+++ b/interp/constrintern.mli
@@ -111,6 +111,9 @@ val interp_open_constr : ?expected_type:typing_constraint -> env -> evar_map -> 
 
 (** Accepting unresolved evars *)
 
+val interp_constr_evars_gen : flags:inference_flags -> env -> evar_map ->
+  ?impls:internalization_env -> typing_constraint -> constr_expr -> evar_map * constr
+
 val interp_constr_evars : ?program_mode:bool -> env -> evar_map ->
   ?impls:internalization_env -> constr_expr -> evar_map * constr
 
@@ -122,6 +125,11 @@ val interp_type_evars : ?program_mode:bool -> env -> evar_map ->
 
 (** Accepting unresolved evars and giving back the manual implicit arguments *)
 
+val interp_constr_evars_impls_gen : flags:inference_flags ->
+  env -> evar_map -> ?impls:internalization_env ->
+  typing_constraint -> constr_expr ->
+  evar_map * (constr * Impargs.manual_implicits)
+
 val interp_constr_evars_impls : ?program_mode:bool -> env -> evar_map ->
   ?impls:internalization_env -> constr_expr ->
   evar_map * (constr * Impargs.manual_implicits)
@@ -130,7 +138,7 @@ val interp_casted_constr_evars_impls : ?program_mode:bool -> env -> evar_map ->
   ?impls:internalization_env -> constr_expr -> types ->
   evar_map * (constr * Impargs.manual_implicits)
 
-val interp_type_evars_impls : ?flags:inference_flags -> env -> evar_map ->
+val interp_type_evars_impls : flags:inference_flags -> env -> evar_map ->
   ?impls:internalization_env -> constr_expr ->
   evar_map * (types * Impargs.manual_implicits)
 
@@ -146,17 +154,10 @@ val intern_reference : qualid -> GlobRef.t
 (** Expands abbreviations (syndef); raise an error if not existing *)
 val interp_reference : ltac_sign -> qualid -> glob_constr
 
-(** Interpret binders *)
-
-val interp_binder  : env -> evar_map -> Name.t -> constr_expr ->
-  types Evd.in_evar_universe_context
-
-val interp_binder_evars : env -> evar_map -> Name.t -> constr_expr -> evar_map * types
-
 (** Interpret contexts: returns extended env and context *)
 
 val interp_context_evars :
-  ?program_mode:bool -> ?impl_env:internalization_env ->
+  flags:inference_flags -> ?impl_env:internalization_env ->
   env -> evar_map -> local_binder_expr list ->
   evar_map * (internalization_env * ((env * rel_context) * Impargs.manual_implicits))
 

--- a/interp/constrintern.mli
+++ b/interp/constrintern.mli
@@ -156,7 +156,7 @@ val interp_binder_evars : env -> evar_map -> Name.t -> constr_expr -> evar_map *
 (** Interpret contexts: returns extended env and context *)
 
 val interp_context_evars :
-  ?program_mode:bool -> ?impl_env:internalization_env -> ?shift:int ->
+  ?program_mode:bool -> ?impl_env:internalization_env ->
   env -> evar_map -> local_binder_expr list ->
   evar_map * (internalization_env * ((env * rel_context) * Impargs.manual_implicits))
 

--- a/plugins/funind/gen_principle.ml
+++ b/plugins/funind/gen_principle.ml
@@ -43,7 +43,8 @@ let build_newrecursive lnameargsardef =
         let arity, _ctx = Constrintern.interp_type env0 sigma arityc in
         let evd = Evd.from_env env0 in
         let evd, (_, (_, impls')) =
-          Constrintern.interp_context_evars ~program_mode:false env evd binders
+          Constrintern.interp_context_evars ~flags:Pretyping.all_no_fail_flags
+            env evd binders
         in
         let impl =
           Constrintern.compute_internalization_data env0 evd recname

--- a/plugins/ltac/leminv.ml
+++ b/plugins/ltac/leminv.ml
@@ -244,7 +244,8 @@ let add_inversion_lemma ~poly name env sigma t sort dep inv_op =
 let add_inversion_lemma_exn ~poly na com comsort bool tac =
   let env = Global.env () in
   let sigma = Evd.from_env env in
-  let sigma, c = Constrintern.interp_type_evars ~program_mode:false env sigma com in
+  let c, uctx = Constrintern.interp_type env sigma com in
+  let sigma = Evd.from_ctx uctx in
   let sigma, sort = Evd.fresh_sort_in_family ~rigid:univ_rigid sigma comsort in
   try
     add_inversion_lemma ~poly na env sigma c sort bool tac

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -198,6 +198,8 @@ type inference_flags = {
   expand_evars : bool;
   program_mode : bool;
   polymorphic : bool;
+  (* [polymorphic] is only used by Tacinterp.interp_constr_gen and
+     type_uconstr, we need a better way to pass it around. *)
 }
 
 (* Compute the set of still-undefined initial evars up to restriction
@@ -1345,6 +1347,15 @@ let ise_pretype_gen flags env sigma lvar kind c =
       sigma, tj.utj_val, mkSort tj.utj_type
   in
   process_inference_flags flags !!env sigma (sigma',c',c'_ty)
+
+let partial_flags = {
+  use_typeclasses = UseTCForConv;
+  solve_unification_constraints = false;
+  fail_evar = false;
+  expand_evars = true; (* questionable, TODO bench *)
+  program_mode = false;
+  polymorphic = false;
+}
 
 let default_inference_flags fail = {
   use_typeclasses = UseTC;

--- a/pretyping/pretyping.mli
+++ b/pretyping/pretyping.mli
@@ -62,6 +62,12 @@ type inference_flags = {
   polymorphic : bool;
 }
 
+(** For typechecking multiple terms separately, avoid calling
+    typeclasses/heuristics until all are done.
+    Using these flags means you must use [solve_remaining_evars] afterwards.
+*)
+val partial_flags : inference_flags
+
 val default_inference_flags : bool -> inference_flags
 
 val no_classes_no_fail_inference_flags : inference_flags

--- a/test-suite/bugs/closed/bug_11576.v
+++ b/test-suite/bugs/closed/bug_11576.v
@@ -1,0 +1,43 @@
+Module Reduced.
+  Class Foo := foo : True.
+  Instance: Foo := I.
+  (* Definition bar (v:=_) (H : @foo v = @foo v) : True := I. *)
+End Reduced.
+
+Global Set Asymmetric Patterns.
+Inductive type := base | arrow (s d : type).
+Fixpoint for_each_lhs_of_arrow (f : Type) (t : type) : Type
+  := match t with
+     | base => unit
+     | arrow s d => f * @for_each_lhs_of_arrow f d
+     end.
+Inductive expr {var : Type} : type -> Type :=
+| Var {t} (v : var) : expr t
+| Abs {s d} (f : var -> expr d) : expr (arrow s d)
+.
+Class parameters := {}.
+Record rep {p : parameters} := {}.
+Axiom listZ_local : forall {p}, @rep p.
+Axiom p : parameters.
+Existing Instance p.
+Axiom cmd : forall {p : parameters}, Type.
+Axiom ltype : forall {p : parameters} {listZ : @rep p}, Type.
+Axiom translate_cmd
+  : forall {p : parameters}
+           (e : expr (var:=@ltype p (@listZ_local p)) base),
+    cmd.
+Axiom admit : forall {T}, T.
+Existing Class rep.
+Fixpoint translate_func' (pv:=_) {t} (e : @expr ltype t)
+  : for_each_lhs_of_arrow ltype t -> @cmd pv :=
+  match e with
+  | Abs base d f =>
+    fun (args : _ * for_each_lhs_of_arrow _ d) =>
+      translate_func' (f (fst args)) (snd args)
+  | Var base v =>
+    fun _ => translate_cmd (Var v)
+  | _ => fun _ => admit
+  end.
+(* File "./bug_01.v", line 30, characters 30-31:
+Error: Cannot infer this placeholder of type "parameters" (no type class
+instance found).*)

--- a/test-suite/bugs/closed/bug_12910.v
+++ b/test-suite/bugs/closed/bug_12910.v
@@ -1,0 +1,8 @@
+Class Foo := foo : True.
+Instance i : Foo. Proof. exact I. Qed.
+Definition j : Foo. Proof. exact I. Qed.
+
+Inductive bla : Foo -> Prop := .
+
+Definition xx : bla _ -> _ := fun x : bla j => x.
+(* Error: Found type "bla j" where "bla i" was expected. *)

--- a/test-suite/bugs/closed/bug_12917.v
+++ b/test-suite/bugs/closed/bug_12917.v
@@ -1,0 +1,1 @@
+Fail Derive Inversion bla with (le _ _).

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -518,7 +518,8 @@ let interp_instance_context ~program_mode env ctx ~generalize pl tclass =
     if generalize then CAst.make @@ CGeneralization (Glob_term.MaxImplicit, Some AbsPi, tclass)
     else tclass
   in
-  let sigma, (impls, ((env', ctx), imps)) = interp_context_evars ~program_mode env sigma ctx in
+  let flags = Pretyping.{all_no_fail_flags with program_mode} in
+  let sigma, (impls, ((env', ctx), imps)) = interp_context_evars ~flags env sigma ctx in
   let flags = Pretyping.{ all_no_fail_flags with program_mode } in
   let sigma, (c', imps') = interp_type_evars_impls ~flags ~impls env' sigma tclass in
   let imps = imps @ imps' in

--- a/vernac/comAssumption.ml
+++ b/vernac/comAssumption.ml
@@ -254,7 +254,10 @@ let context_nosection sigma ~poly ctx =
 let context ~poly l =
   let env = Global.env() in
   let sigma = Evd.from_env env in
-  let sigma, (_, ((_env, ctx), impls)) = interp_context_evars ~program_mode:false env sigma l in
+  let sigma, (_, ((_env, ctx), impls)) =
+    interp_context_evars ~flags:Pretyping.partial_flags env sigma l
+  in
+  let sigma = Pretyping.solve_remaining_evars Pretyping.all_and_fail_flags env sigma in
   (* Note, we must use the normalized evar from now on! *)
   let sigma = Evd.minimize_universes sigma in
   let ce t = Pretyping.check_evars env sigma t in

--- a/vernac/comDefinition.ml
+++ b/vernac/comDefinition.ml
@@ -94,6 +94,9 @@ let interp_definition ~program_mode pl bl ~poly red_option c ctypopt =
       (interp_type_evars_impls ~flags ~impls env_bl)
       evd ctypopt
   in
+  (* solve typeclasses / heuristics before checking the body *)
+  let solve_flags = Pretyping.{all_no_fail_flags with program_mode} in
+  let evd = Pretyping.solve_remaining_evars solve_flags env evd in
   (* Build the body, and merge implicits from parameters and from type/body *)
   let evd, c, imps, tyopt =
     match tyopt with

--- a/vernac/comFixpoint.ml
+++ b/vernac/comFixpoint.ml
@@ -110,7 +110,7 @@ let interp_fix_context ~program_mode ~cofix env sigma fix =
     else [], fix.Vernacexpr.binders in
   let sigma, (impl_env, ((env', ctx), imps)) = interp_context_evars ~program_mode env sigma before in
   let sigma, (impl_env', ((env'', ctx'), imps')) =
-    interp_context_evars ~program_mode ~impl_env ~shift:(Context.Rel.nhyps ctx) env' sigma after
+    interp_context_evars ~program_mode ~impl_env env' sigma after
   in
   let annot = Option.map (fun _ -> List.length (Termops.assums_of_rel_context ctx)) fix.Vernacexpr.rec_order in
   sigma, ((env'', ctx' @ ctx), (impl_env',imps @ imps'), annot)

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -438,9 +438,9 @@ let interp_mutual_inductive_constr ~sigma ~template ~udecl ~ctx_params ~indnames
 let interp_params env udecl uparamsl paramsl =
   let sigma, udecl = interp_univ_decl_opt env udecl in
   let sigma, (uimpls, ((env_uparams, ctx_uparams), useruimpls)) =
-    interp_context_evars ~program_mode:false env sigma uparamsl in
+    interp_context_evars ~flags:Pretyping.partial_flags env sigma uparamsl in
   let sigma, (impls, ((env_params, ctx_params), userimpls)) =
-    interp_context_evars ~program_mode:false ~impl_env:uimpls env_uparams sigma paramsl
+    interp_context_evars ~flags:Pretyping.partial_flags ~impl_env:uimpls env_uparams sigma paramsl
   in
   (* Names of parameters as arguments of the inductive type (defs removed) *)
   let assums = List.filter is_local_assum ctx_params in


### PR DESCRIPTION
Instead of using all_no_fail_flags we use partial_flags where we will
interp more constrs with the same evar map. Then we use
solve_remaining_evars.

partial_flags is a new set of inference flags with UseTCForConv and
unification heuristics off.

Fixes #12910
Fixes #11576
Fixes #11572

After this there is still some questionable use of
all_no_fail_flags (implicitly) in classes.ml.
It's also used in funind, derive and the plugin tutorial but I didn't
look closely at them.

Pretyping.check_evars_are_solved is now used only in
Declare.prepare_parameter, probably this should be changed to checking
only the evars in the term (callers are calling solve_remaining_evars
possibly with fail_evar).
(Technically it's also used internally to pretyping in
solve_remaining_evars to provide the errors when fail_evar.)
