### PR TITLE
Fix .gitignore after the merge of #12849.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,7 +154,7 @@ plugins/ssr/ssrvernac.ml
 kernel/byterun/coq_instruct.h
 kernel/byterun/coq_jumptbl.h
 kernel/genOpcodeFiles.exe
-kernel/copcodes.ml
+kernel/vmopcodes.ml
 kernel/uint63.ml
 ide/coqide/default.bindings
 ide/coqide/default_bindings_src.exe


### PR DESCRIPTION
A stray generated file was forgotten.
