### PR TITLE
Move Elim-specific code

### DIFF
--- a/tactics/elim.ml
+++ b/tactics/elim.ml
@@ -30,10 +30,6 @@ type branch_args = {
                                true=assumption, false=let-in *)
   branchnames : Tactypes.intro_patterns}
 
-type branch_assumptions = {
-  ba        : branch_args;       (* the branch args *)
-  assums    : named_context}   (* the list of assumptions introduced *)
-
 module NamedDecl = Context.Named.Declaration
 
 (* Find the right elimination suffix corresponding to the sort of the goal *)
@@ -122,7 +118,7 @@ let make_elim_branch_assumptions ba hyps =
   let assums =
     try List.rev (List.firstn ba.nassums hyps)
     with Failure _ -> anomaly (Pp.str "make_elim_branch_assumptions.") in
-  { ba = ba; assums = assums }
+  assums
 
 let elim_on_ba tac ba =
   Proofview.Goal.enter begin fun gl ->
@@ -201,7 +197,7 @@ and general_decompose_aux recognizer id =
        (fun bas ->
           tclTHEN (clear [id])
             (tclMAP (general_decompose_on_hyp recognizer)
-               (ids_of_named_context bas.assums))))
+               (ids_of_named_context bas))))
     id
 
 (* We should add a COMPLETE to be sure that the created hypothesis
@@ -269,7 +265,7 @@ let induction_trailer abs_i abs_j bargs =
           let idty = pf_get_type_of gl (mkVar id) in
           let fvty = global_vars (pf_env gl) (project gl) idty in
           let possible_bring_hyps =
-            (List.tl (nLastDecls gl (abs_j - abs_i))) @ bargs.assums
+            (List.tl (nLastDecls gl (abs_j - abs_i))) @ bargs
           in
           let (hyps,_) =
             List.fold_left

--- a/tactics/elim.ml
+++ b/tactics/elim.ml
@@ -8,32 +8,165 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
+open CErrors
 open Util
 open Names
+open Constr
 open Termops
 open EConstr
 open Inductiveops
 open Hipattern
 open Tacmach.New
 open Tacticals.New
+open Clenv
 open Tactics
 open Proofview.Notations
 
+type branch_args = {
+  ity        : pinductive;   (* the type we were eliminating on *)
+  branchnum  : int;         (* the branch number *)
+  nassums    : int;         (* number of assumptions/letin to be introduced *)
+  branchsign : bool list;   (* the signature of the branch.
+                               true=assumption, false=let-in *)
+  branchnames : Tactypes.intro_patterns}
+
+type branch_assumptions = {
+  ba        : branch_args;       (* the branch args *)
+  assums    : named_context}   (* the list of assumptions introduced *)
+
 module NamedDecl = Context.Named.Declaration
+
+(* Find the right elimination suffix corresponding to the sort of the goal *)
+(* c should be of type A1->.. An->B with B an inductive definition *)
+let general_elim_then_using mk_elim
+    rec_flag allnames tac predicate ind (c, t) =
+  let open Pp in
+  Proofview.Goal.enter begin fun gl ->
+  let sigma, elim = mk_elim ind gl in
+  let ind = on_snd (fun u -> EInstance.kind sigma u) ind in
+  Proofview.tclTHEN (Proofview.Unsafe.tclEVARS sigma)
+  (Proofview.Goal.enter begin fun gl ->
+  let indclause = mk_clenv_from gl (c, t) in
+  (* applying elimination_scheme just a little modified *)
+  let elimclause = mk_clenv_from gl (elim,Tacmach.New.pf_get_type_of gl elim)  in
+  let indmv =
+    match EConstr.kind elimclause.evd (last_arg elimclause.evd elimclause.templval.Evd.rebus) with
+    | Meta mv -> mv
+    | _         -> anomaly (str"elimination.")
+  in
+  let pmv =
+    let p, _ = decompose_app elimclause.evd elimclause.templtyp.Evd.rebus in
+    match EConstr.kind elimclause.evd p with
+    | Meta p -> p
+    | _ ->
+        let name_elim =
+          match EConstr.kind sigma elim with
+          | Const _ | Var _ -> str " " ++ Printer.pr_econstr_env (pf_env gl) sigma elim
+          | _ -> mt ()
+        in
+        user_err ~hdr:"Tacticals.general_elim_then_using"
+          (str "The elimination combinator " ++ name_elim ++ str " is unknown.")
+  in
+  let elimclause' = clenv_fchain ~with_univs:false indmv elimclause indclause in
+  let branchsigns = Tacticals.compute_constructor_signatures ~rec_flag ind in
+  let brnames = Tacticals.compute_induction_names false branchsigns allnames in
+  let flags = Unification.elim_flags () in
+  let elimclause' =
+    match predicate with
+    | None   -> elimclause'
+    | Some p -> clenv_unify ~flags Reduction.CONV (mkMeta pmv) p elimclause'
+  in
+  let after_tac i =
+    let ba = { branchsign = branchsigns.(i);
+                branchnames = brnames.(i);
+                nassums = List.length branchsigns.(i);
+                branchnum = i+1;
+                ity = ind; }
+    in
+    tac ba
+  in
+  let branchtacs = List.init (Array.length branchsigns) after_tac in
+  Proofview.tclTHEN
+    (Clenv.res_pf ~flags elimclause')
+    (Proofview.tclEXTEND [] tclIDTAC branchtacs)
+  end) end
+
+(* computing the case/elim combinators *)
+
+let gl_make_elim ind = begin fun gl ->
+  let env = Proofview.Goal.env gl in
+  let gr = Indrec.lookup_eliminator env (fst ind) (elimination_sort_of_goal gl) in
+  let (sigma, c) = pf_apply Evd.fresh_global gl gr in
+  (sigma, c)
+end
+
+let gl_make_case_dep (ind, u) = begin fun gl ->
+  let sigma = project gl in
+  let u = EInstance.kind (project gl) u in
+  let (sigma, r) = Indrec.build_case_analysis_scheme (pf_env gl) sigma (ind, u) true
+    (elimination_sort_of_goal gl)
+  in
+  (sigma, EConstr.of_constr r)
+end
+
+let gl_make_case_nodep (ind, u) = begin fun gl ->
+  let sigma = project gl in
+  let u = EInstance.kind sigma u in
+  let (sigma, r) = Indrec.build_case_analysis_scheme (pf_env gl) sigma (ind, u) false
+    (elimination_sort_of_goal gl)
+  in
+  (sigma, EConstr.of_constr r)
+end
+
+let make_elim_branch_assumptions ba hyps =
+  let assums =
+    try List.rev (List.firstn ba.nassums hyps)
+    with Failure _ -> anomaly (Pp.str "make_elim_branch_assumptions.") in
+  { ba = ba; assums = assums }
+
+let elim_on_ba tac ba =
+  Proofview.Goal.enter begin fun gl ->
+  let branches = make_elim_branch_assumptions ba (Proofview.Goal.hyps gl) in
+  tac branches
+  end
+
+let case_on_ba tac ba =
+  Proofview.Goal.enter begin fun gl ->
+  let branches = make_elim_branch_assumptions ba (Proofview.Goal.hyps gl) in
+  tac branches
+  end
+
+let elimination_then tac c =
+  let open Declarations in
+  Proofview.Goal.enter begin fun gl ->
+  let (ind,t) = pf_reduce_to_quantified_ind gl (pf_get_type_of gl c) in
+  let isrec,mkelim =
+    match (Global.lookup_mind (fst (fst ind))).mind_record with
+    | NotRecord -> true,gl_make_elim
+    | FakeRecord | PrimRecord _ -> false,gl_make_case_dep
+  in
+  general_elim_then_using mkelim isrec None tac None ind (c, t)
+  end
+
+let case_then_using =
+  general_elim_then_using gl_make_case_dep false
+
+let case_nodep_then_using =
+  general_elim_then_using gl_make_case_nodep false
 
 (* Supposed to be called without as clause *)
 let introElimAssumsThen tac ba =
-  assert (ba.Tacticals.branchnames == []);
-  let introElimAssums = tclDO ba.Tacticals.nassums intro in
+  assert (ba.branchnames == []);
+  let introElimAssums = tclDO ba.nassums intro in
   (tclTHEN introElimAssums (elim_on_ba tac ba))
 
 (* Supposed to be called with a non-recursive scheme *)
 let introCaseAssumsThen with_evars tac ba =
-  let n1 = List.length ba.Tacticals.branchsign in
-  let n2 = List.length ba.Tacticals.branchnames in
+  let n1 = List.length ba.branchsign in
+  let n2 = List.length ba.branchnames in
   let (l1,l2),l3 =
-    if n1 < n2 then List.chop n1 ba.Tacticals.branchnames, []
-    else (ba.Tacticals.branchnames, []), List.make (n1-n2) false in
+    if n1 < n2 then List.chop n1 ba.branchnames, []
+    else (ba.branchnames, []), List.make (n1-n2) false in
   let introCaseAssums =
     tclTHEN (intro_patterns with_evars l1) (intros_clearing l3) in
   (tclTHEN introCaseAssums (case_on_ba (tac l2) ba))
@@ -68,7 +201,7 @@ and general_decompose_aux recognizer id =
        (fun bas ->
           tclTHEN (clear [id])
             (tclMAP (general_decompose_on_hyp recognizer)
-               (ids_of_named_context bas.Tacticals.assums))))
+               (ids_of_named_context bas.assums))))
     id
 
 (* We should add a COMPLETE to be sure that the created hypothesis
@@ -136,7 +269,7 @@ let induction_trailer abs_i abs_j bargs =
           let idty = pf_get_type_of gl (mkVar id) in
           let fvty = global_vars (pf_env gl) (project gl) idty in
           let possible_bring_hyps =
-            (List.tl (nLastDecls gl (abs_j - abs_i))) @ bargs.Tacticals.assums
+            (List.tl (nLastDecls gl (abs_j - abs_i))) @ bargs.assums
           in
           let (hyps,_) =
             List.fold_left

--- a/tactics/elim.ml
+++ b/tactics/elim.ml
@@ -8,7 +8,6 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-open CErrors
 open Util
 open Names
 open Constr
@@ -48,7 +47,7 @@ let general_elim_then_using mk_elim
   let indmv =
     match EConstr.kind elimclause.evd (last_arg elimclause.evd elimclause.templval.Evd.rebus) with
     | Meta mv -> mv
-    | _         -> anomaly (str"elimination.")
+    | _         -> CErrors.anomaly (str"elimination.")
   in
   let pmv =
     let p, _ = decompose_app elimclause.evd elimclause.templtyp.Evd.rebus in
@@ -60,7 +59,7 @@ let general_elim_then_using mk_elim
           | Const _ | Var _ -> str " " ++ Printer.pr_econstr_env (pf_env gl) sigma elim
           | _ -> mt ()
         in
-        user_err ~hdr:"Tacticals.general_elim_then_using"
+        CErrors.user_err ~hdr:"Tacticals.general_elim_then_using"
           (str "The elimination combinator " ++ name_elim ++ str " is unknown.")
   in
   let elimclause' = clenv_fchain ~with_univs:false indmv elimclause indclause in
@@ -108,7 +107,7 @@ end
 let make_elim_branch_assumptions ba hyps =
   let assums =
     try List.rev (List.firstn ba.nassums hyps)
-    with Failure _ -> anomaly (Pp.str "make_elim_branch_assumptions.") in
+    with Failure _ -> CErrors.anomaly (Pp.str "make_elim_branch_assumptions.") in
   assums
 
 let elim_on_ba tac ba =

--- a/tactics/elim.ml
+++ b/tactics/elim.ml
@@ -167,6 +167,10 @@ let introCaseAssumsThen with_evars tac ba =
     tclTHEN (intro_patterns with_evars l1) (intros_clearing l3) in
   (tclTHEN introCaseAssums (case_on_ba (tac l2) ba))
 
+let case_tac dep names tac elim ind c =
+  let case_tac = if dep then case_then_using else case_nodep_then_using in
+  case_tac names (introCaseAssumsThen false (* ApplyOn not supported by inversion *) tac) (Some elim) ind c
+
 (* The following tactic Decompose repeatedly applies the
    elimination(s) rule(s) of the types satisfying the predicate
    ``recognizer'' onto a certain hypothesis. For example :

--- a/tactics/elim.mli
+++ b/tactics/elim.mli
@@ -22,10 +22,6 @@ type branch_args = private {
                                 true=assumption, false=let-in *)
   branchnames : intro_patterns}
 
-type branch_assumptions = private {
-  ba        : branch_args;       (** the branch args *)
-  assums    : named_context}   (** the list of assumptions introduced *)
-
 val case_then_using :
   or_and_intro_pattern option -> (branch_args -> unit Proofview.tactic) ->
   constr option -> inductive * EInstance.t -> constr * types -> unit Proofview.tactic
@@ -35,7 +31,7 @@ val case_nodep_then_using :
   constr option -> inductive * EInstance.t -> constr * types -> unit Proofview.tactic
 
 val introCaseAssumsThen : Tactics.evars_flag ->
-  (intro_patterns -> branch_assumptions -> unit Proofview.tactic) ->
+  (intro_patterns -> named_context -> unit Proofview.tactic) ->
     branch_args -> unit Proofview.tactic
 
 val h_decompose       : inductive list -> constr -> unit Proofview.tactic

--- a/tactics/elim.mli
+++ b/tactics/elim.mli
@@ -10,10 +10,36 @@
 
 open Names
 open EConstr
-open Tacticals
 open Tactypes
 
 (** Eliminations tactics. *)
+
+type branch_args = private {
+  ity        : Constr.pinductive;  (** the type we were eliminating on *)
+  branchnum  : int;         (** the branch number *)
+  nassums    : int;         (** number of assumptions/letin to be introduced *)
+  branchsign : bool list;   (** the signature of the branch.
+                                true=assumption, false=let-in *)
+  branchnames : intro_patterns}
+
+type branch_assumptions = private {
+  ba        : branch_args;       (** the branch args *)
+  assums    : named_context}   (** the list of assumptions introduced *)
+
+val elimination_then :
+  (branch_args -> unit Proofview.tactic) ->
+  constr -> unit Proofview.tactic
+
+val case_then_using :
+  or_and_intro_pattern option -> (branch_args -> unit Proofview.tactic) ->
+  constr option -> inductive * EInstance.t -> constr * types -> unit Proofview.tactic
+
+val case_nodep_then_using :
+  or_and_intro_pattern option -> (branch_args -> unit Proofview.tactic) ->
+  constr option -> inductive * EInstance.t -> constr * types -> unit Proofview.tactic
+
+val elim_on_ba : (branch_assumptions -> unit Proofview.tactic) -> branch_args  -> unit Proofview.tactic
+val case_on_ba : (branch_assumptions -> unit Proofview.tactic) -> branch_args  -> unit Proofview.tactic
 
 val introCaseAssumsThen : Tactics.evars_flag ->
   (intro_patterns -> branch_assumptions -> unit Proofview.tactic) ->

--- a/tactics/elim.mli
+++ b/tactics/elim.mli
@@ -26,10 +26,6 @@ type branch_assumptions = private {
   ba        : branch_args;       (** the branch args *)
   assums    : named_context}   (** the list of assumptions introduced *)
 
-val elimination_then :
-  (branch_args -> unit Proofview.tactic) ->
-  constr -> unit Proofview.tactic
-
 val case_then_using :
   or_and_intro_pattern option -> (branch_args -> unit Proofview.tactic) ->
   constr option -> inductive * EInstance.t -> constr * types -> unit Proofview.tactic
@@ -37,9 +33,6 @@ val case_then_using :
 val case_nodep_then_using :
   or_and_intro_pattern option -> (branch_args -> unit Proofview.tactic) ->
   constr option -> inductive * EInstance.t -> constr * types -> unit Proofview.tactic
-
-val elim_on_ba : (branch_assumptions -> unit Proofview.tactic) -> branch_args  -> unit Proofview.tactic
-val case_on_ba : (branch_assumptions -> unit Proofview.tactic) -> branch_args  -> unit Proofview.tactic
 
 val introCaseAssumsThen : Tactics.evars_flag ->
   (intro_patterns -> branch_assumptions -> unit Proofview.tactic) ->

--- a/tactics/elim.mli
+++ b/tactics/elim.mli
@@ -14,19 +14,9 @@ open Tactypes
 
 (** Eliminations tactics. *)
 
-type branch_args
-
-val case_then_using :
-  or_and_intro_pattern option -> (branch_args -> unit Proofview.tactic) ->
-  constr option -> inductive * EInstance.t -> constr * types -> unit Proofview.tactic
-
-val case_nodep_then_using :
-  or_and_intro_pattern option -> (branch_args -> unit Proofview.tactic) ->
-  constr option -> inductive * EInstance.t -> constr * types -> unit Proofview.tactic
-
-val introCaseAssumsThen : Tactics.evars_flag ->
+val case_tac : bool -> or_and_intro_pattern option ->
   (intro_patterns -> named_context -> unit Proofview.tactic) ->
-    branch_args -> unit Proofview.tactic
+  constr -> inductive * EInstance.t -> constr * types -> unit Proofview.tactic
 
 val h_decompose       : inductive list -> constr -> unit Proofview.tactic
 val h_decompose_or    : constr -> unit Proofview.tactic

--- a/tactics/elim.mli
+++ b/tactics/elim.mli
@@ -14,13 +14,7 @@ open Tactypes
 
 (** Eliminations tactics. *)
 
-type branch_args = private {
-  ity        : Constr.pinductive;  (** the type we were eliminating on *)
-  branchnum  : int;         (** the branch number *)
-  nassums    : int;         (** number of assumptions/letin to be introduced *)
-  branchsign : bool list;   (** the signature of the branch.
-                                true=assumption, false=let-in *)
-  branchnames : intro_patterns}
+type branch_args
 
 val case_then_using :
   or_and_intro_pattern option -> (branch_args -> unit Proofview.tactic) ->

--- a/tactics/inv.ml
+++ b/tactics/inv.ml
@@ -409,7 +409,7 @@ let nLastDecls i tac =
 
 let rewrite_equations as_mode othin neqns names ba =
   Proofview.Goal.enter begin fun gl ->
-  let (depids,nodepids) = split_dep_and_nodep ba.Elim.assums gl in
+  let (depids,nodepids) = split_dep_and_nodep ba gl in
   let first_eq = ref Logic.MoveLast in
   let avoid = if as_mode then Id.Set.of_list (List.map NamedDecl.get_id nodepids) else Id.Set.empty in
   match othin with

--- a/tactics/inv.ml
+++ b/tactics/inv.ml
@@ -409,7 +409,7 @@ let nLastDecls i tac =
 
 let rewrite_equations as_mode othin neqns names ba =
   Proofview.Goal.enter begin fun gl ->
-  let (depids,nodepids) = split_dep_and_nodep ba.Tacticals.assums gl in
+  let (depids,nodepids) = split_dep_and_nodep ba.Elim.assums gl in
   let first_eq = ref Logic.MoveLast in
   let avoid = if as_mode then Id.Set.of_list (List.map NamedDecl.get_id nodepids) else Id.Set.empty in
   match othin with

--- a/tactics/tacticals.mli
+++ b/tactics/tacticals.mli
@@ -9,7 +9,6 @@
 (************************************************************************)
 
 open Names
-open Constr
 open EConstr
 open Evd
 open Locus
@@ -94,18 +93,6 @@ val onClauseLR : (Id.t option -> tactic) -> clause -> tactic
 
 (** {6 Elimination tacticals. } *)
 
-type branch_args = private {
-  ity        : pinductive;  (** the type we were eliminating on *)
-  branchnum  : int;         (** the branch number *)
-  nassums    : int;         (** number of assumptions/letin to be introduced *)
-  branchsign : bool list;   (** the signature of the branch.
-                                true=assumption, false=let-in *)
-  branchnames : intro_patterns}
-
-type branch_assumptions = private {
-  ba        : branch_args;       (** the branch args *)
-  assums    : named_context}   (** the list of assumptions introduced *)
-
 (** [get_and_check_or_and_pattern loc pats branchsign] returns an appropriate
    error message if |pats| <> |branchsign|; extends them if no pattern is given
    for let-ins in the case of a conjunctive pattern *)
@@ -122,7 +109,7 @@ val compute_constructor_signatures : rec_flag:bool -> inductive * 'a -> bool lis
 
 (** Useful for [as intro_pattern] modifier *)
 val compute_induction_names :
-  bool list array -> or_and_intro_pattern option -> intro_patterns array
+  bool -> bool list array -> or_and_intro_pattern option -> intro_patterns array
 
 val elimination_sort_of_goal : Goal.goal sigma -> Sorts.family
 val elimination_sort_of_hyp  : Id.t -> Goal.goal sigma -> Sorts.family
@@ -248,21 +235,6 @@ module New : sig
   val elimination_sort_of_goal : Proofview.Goal.t -> Sorts.family
   val elimination_sort_of_hyp  : Id.t -> Proofview.Goal.t -> Sorts.family
   val elimination_sort_of_clause : Id.t option -> Proofview.Goal.t -> Sorts.family
-
-  val elimination_then :
-    (branch_args -> unit Proofview.tactic) ->
-    constr -> unit Proofview.tactic
-
-  val case_then_using :
-    or_and_intro_pattern option -> (branch_args -> unit Proofview.tactic) ->
-    constr option -> inductive * EInstance.t -> constr * types -> unit Proofview.tactic
-
-  val case_nodep_then_using :
-    or_and_intro_pattern option -> (branch_args -> unit Proofview.tactic) ->
-    constr option -> inductive * EInstance.t -> constr * types -> unit Proofview.tactic
-
-  val elim_on_ba : (branch_assumptions -> unit Proofview.tactic) -> branch_args  -> unit Proofview.tactic
-  val case_on_ba : (branch_assumptions -> unit Proofview.tactic) -> branch_args  -> unit Proofview.tactic
 
   val pf_constr_of_global : GlobRef.t -> constr Proofview.tactic
 end

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -4397,7 +4397,7 @@ let apply_induction_in_context with_evars hyp0 inhyps elim indvars names induct_
     let branchletsigns =
       let f (_,is_not_let,_,_) = is_not_let in
       Array.map (fun (_,l) -> List.map f l) indsign in
-    let names = compute_induction_names branchletsigns names in
+    let names = compute_induction_names true branchletsigns names in
     Array.iter (check_name_unicity env toclear []) names;
     let tac =
     (if isrec then Tacticals.New.tclTHENFIRSTn else Tacticals.New.tclTHENLASTn)


### PR DESCRIPTION
Move elim-specific code from Tacticals to Elim, and cleanup the Elim API.