### PR TITLE
Fixes a freshness issue with destruct/induction (see comment in #12944).

### DIFF
--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -3317,7 +3317,7 @@ let induct_discharge with_evars dests avoid' tac (avoid,ra) names =
         Proofview.Goal.enter begin fun gl ->
         let (recpat,names) = match names with
           | [{CAst.loc;v=IntroNaming (IntroIdentifier id)} as pat] ->
-              let id' = next_ident_away (add_prefix "IH" id) avoid in
+              let id' = new_fresh_id avoid (add_prefix "IH" id) gl in
               (pat, [CAst.make @@ IntroNaming (IntroIdentifier id')])
           | _ -> consume_pattern avoid (Name recvarname) deprec gl names in
         let dest = get_recarg_dest dests in

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -3248,13 +3248,10 @@ let rec consume_pattern avoid na isdep gl = let open CAst in function
   | {loc;v=IntroForthcoming true}::names when not isdep ->
       consume_pattern avoid na isdep gl names
   | {loc;v=IntroForthcoming _}::names as fullpat ->
-      let avoid = Id.Set.union avoid (explicit_intro_names names) in
       (CAst.make ?loc @@ intropattern_of_name gl avoid na, fullpat)
   | {loc;v=IntroNaming IntroAnonymous}::names ->
-      let avoid = Id.Set.union avoid (explicit_intro_names names) in
       (CAst.make ?loc @@ intropattern_of_name gl avoid na, names)
   | {loc;v=IntroNaming (IntroFresh id')}::names ->
-      let avoid = Id.Set.union avoid (explicit_intro_names names) in
       (CAst.make ?loc @@ IntroNaming (IntroIdentifier (new_fresh_id avoid id' gl)), names)
   | pat::names -> (pat,names)
 
@@ -3312,7 +3309,7 @@ let get_recarg_dest (recargdests,tophyp) =
 *)
 
 let induct_discharge with_evars dests avoid' tac (avoid,ra) names =
-  let avoid = Id.Set.union avoid avoid' in
+  let avoid = Id.Set.union avoid' (Id.Set.union avoid (explicit_intro_names names)) in
   let rec peel_tac ra dests names thin =
     match ra with
     | (RecArg,_,deprec,recvarname) ::

--- a/test-suite/bugs/closed/bug_12944.v
+++ b/test-suite/bugs/closed/bug_12944.v
@@ -1,0 +1,12 @@
+
+Inductive vector A : nat -> Type :=
+  |nil : vector A 0
+  |cons : forall (h:A) (n:nat), vector A n -> vector A (S n).
+
+Global Set Mangle Names.
+
+Lemma vlookup_middle {A n} (v : vector A n) : True.
+Proof.
+  induction v as [|?? IHv].
+  all:exact I.
+Qed.

--- a/test-suite/success/induct.v
+++ b/test-suite/success/induct.v
@@ -196,3 +196,13 @@ Goal forall m n:nat, n=m.
 double induction m n.
 Abort.
 
+(* Mentioned as part of bug #12944 *)
+
+Inductive test : Set := cons : forall (IHv : nat) (v : test), test.
+
+Goal test -> test.
+induction 1 as [? IHv].
+Undo.
+destruct 1 as [? IHv].
+exact IHv. (* Check that the name is granted *)
+Qed.


### PR DESCRIPTION
**Kind:** bug fix 

Fixes issue mentioned in [#12944](https://github.com/coq/coq/issues/12944#issuecomment-683341373).

The names computed in `consume_pattern` were lost when calling `intros_pattern_core`. Moreover, the computation of names to avoid was done several time. We compute it once for all.

This should be backward-compatible, as long as the failure returned by `destruct`/`induction` (before the fix) is not caught by a `try`.

- [X] Added / updated test-suite