### PR TITLE
Add zarith to the include path for ocamldebug-coq

### DIFF
--- a/dev/ocamldebug-coq.run
+++ b/dev/ocamldebug-coq.run
@@ -34,4 +34,5 @@ exec $OCAMLDEBUG \
     -I $COQTOP/plugins/subtac     -I $COQTOP/plugins/syntax \
     -I $COQTOP/plugins/xml        -I $COQTOP/plugins/ltac \
     -I $COQTOP/ide \
+    $(ocamlfind query -recursive -i-format zarith) \
     "$@"


### PR DESCRIPTION
**Kind:** bug fix / infrastructure

Closes #12945

Fix due to @SkySkimmer 