### PR TITLE
No implicit shelving

### DIFF
--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -1203,8 +1203,14 @@ let pop_shelf evd =
   | hd :: tl ->
     hd, { evd with shelf = tl }
 
-let modify_shelf evd f =
-  { evd with shelf = f evd.shelf }
+let filter_shelf f evd =
+  { evd with shelf = List.map (List.filter f) evd.shelf }
+
+let shelve evd l =
+  match evd.shelf with
+  | [] -> anomaly Pp.(str"shelf stack should not be empty")
+  | hd :: tl ->
+    { evd with shelf = (hd@l) :: tl }
 
 let unshelve evd l =
   { evd with shelf = List.map (List.filter (fun ev -> not (CList.mem_f Evar.equal ev l))) evd.shelf }
@@ -1213,7 +1219,10 @@ let given_up evd = evd.given_up
 
 let shelf evd = List.flatten evd.shelf
 
-let shelf_stack evd = evd.shelf
+let pr_shelf evd =
+  let open Pp in
+  if List.is_empty evd.shelf then str"(empty stack)"
+  else prlist_with_sep (fun () -> str"||") (prlist_with_sep spc Evar.print) evd.shelf
 
 (**********************************************************)
 (* Accessing metas *)

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -397,9 +397,11 @@ val push_shelf : evar_map -> evar_map
 
 val pop_shelf : evar_map -> Evar.t list * evar_map
 
+val filter_shelf : (Evar.t -> bool) -> evar_map -> evar_map
+
 val give_up : Evar.t -> evar_map -> evar_map
 
-val modify_shelf : evar_map -> (Evar.t list list -> Evar.t list list) -> evar_map
+val shelve : evar_map -> Evar.t list -> evar_map
 
 val unshelve : evar_map -> Evar.t list -> evar_map
 
@@ -407,7 +409,7 @@ val given_up : evar_map -> Evar.Set.t
 
 val shelf : evar_map -> Evar.t list
 
-val shelf_stack : evar_map -> Evar.t list list
+val pr_shelf : evar_map -> Pp.t
 
 (** {5 Sort variables}
 

--- a/engine/evd.mli
+++ b/engine/evd.mli
@@ -171,6 +171,10 @@ val has_given_up : evar_map -> bool
 (** [has_given_up sigma] is [true] if and only if
     there are given up evars in [sigma]. *)
 
+val has_shelved : evar_map -> bool
+(** [has_shelved sigma] is [true] if and only if
+    there are shelved evars in [sigma]. *)
+
 val new_evar : evar_map ->
   ?name:Id.t -> ?typeclass_candidate:bool -> evar_info -> evar_map * Evar.t
 (** Creates a fresh evar mapping to the given information. *)
@@ -347,11 +351,11 @@ val drop_side_effects : evar_map -> evar_map
 
 (** {5 Future goals} *)
 
-val declare_future_goal : ?shelve:bool -> Evar.t -> evar_map -> evar_map
+val declare_future_goal : Evar.t -> evar_map -> evar_map
 (** Adds an existential variable to the list of future goals. For
     internal uses only. *)
 
-val declare_principal_goal : ?shelve:bool -> Evar.t -> evar_map -> evar_map
+val declare_principal_goal : Evar.t -> evar_map -> evar_map
 (** Adds an existential variable to the list of future goals and make
     it principal. Only one existential variable can be made principal, an
     error is raised otherwise. For internal uses only. *)
@@ -360,7 +364,6 @@ module FutureGoals : sig
 
   type t = private {
     comb : Evar.t list;
-    shelf : Evar.t list;
     principal : Evar.t option; (** if [Some e], [e] must be
                                    contained in
                                    [future_comb]. The evar
@@ -385,18 +388,26 @@ val pop_future_goals : evar_map -> FutureGoals.t * evar_map
 
 val fold_future_goals : (evar_map -> Evar.t -> evar_map) -> evar_map -> evar_map
 
-(** Fold future goals *)
-
-val shelve_on_future_goals : Evar.t list -> evar_map -> evar_map
-(** Push goals on the shelve of future goals *)
 
 val remove_future_goal : evar_map -> Evar.t -> evar_map
 
 val pr_future_goals_stack : evar_map -> Pp.t
 
+val push_shelf : evar_map -> evar_map
+
+val pop_shelf : evar_map -> Evar.t list * evar_map
+
 val give_up : Evar.t -> evar_map -> evar_map
 
+val modify_shelf : evar_map -> (Evar.t list list -> Evar.t list list) -> evar_map
+
+val unshelve : evar_map -> Evar.t list -> evar_map
+
 val given_up : evar_map -> Evar.Set.t
+
+val shelf : evar_map -> Evar.t list
+
+val shelf_stack : evar_map -> Evar.t list list
 
 (** {5 Sort variables}
 

--- a/engine/proofview.mli
+++ b/engine/proofview.mli
@@ -162,7 +162,7 @@ val apply
   -> 'a tactic
   -> proofview
   -> 'a * proofview
-       * (bool*Evar.t list)
+       * bool
        * Proofview_monad.Info.tree
 
 (** {7 Monadic primitives} *)
@@ -331,9 +331,6 @@ val unifiable : Evd.evar_map -> Evar.t -> Evar.t list -> bool
     considered). *)
 val shelve_unifiable : unit tactic
 
-(** Idem but also returns the list of shelved variables *)
-val shelve_unifiable_informative : Evar.t list tactic
-
 (** [guard_no_unifiable] returns the list of unifiable goals if some
     goals are unifiable (see {!shelve_unifiable}) in the current focus. *)
 val guard_no_unifiable : Names.Name.t list option tactic
@@ -341,6 +338,10 @@ val guard_no_unifiable : Names.Name.t list option tactic
 (** [unshelve l p] adds all the goals in [l] at the end of the focused
     goals of p *)
 val unshelve : Evar.t list -> proofview -> proofview
+
+val modify_global_shelf : (Evar.t list list -> Evar.t list list) -> proofview -> proofview
+
+val global_unshelve : Evar.t list -> proofview -> proofview
 
 (** [depends_on g1 g2 sigma] checks if g1 occurs in the type/ctx of g2 *)
 val depends_on : Evd.evar_map -> Evar.t -> Evar.t -> bool
@@ -460,15 +461,6 @@ module Unsafe : sig
 
   (** [tclGETGOALS] returns the list of goals under focus. *)
   val tclGETGOALS : Proofview_monad.goal_with_state list tactic
-
-  (** [tclSETSHELF gls] sets goals [gls] as the current shelf. *)
-  val tclSETSHELF : Evar.t list -> unit tactic
-
-  (** [tclGETSHELF] returns the list of goals on the shelf. *)
-  val tclGETSHELF : Evar.t list tactic
-
-  (** [tclPUTSHELF] appends goals to the shelf. *)
-  val tclPUTSHELF : Evar.t list -> unit tactic
 
   (** Sets the evar universe context. *)
   val tclEVARUNIVCONTEXT : UState.t -> unit tactic

--- a/engine/proofview.mli
+++ b/engine/proofview.mli
@@ -335,13 +335,11 @@ val shelve_unifiable : unit tactic
     goals are unifiable (see {!shelve_unifiable}) in the current focus. *)
 val guard_no_unifiable : Names.Name.t list option tactic
 
-(** [unshelve l p] adds all the goals in [l] at the end of the focused
-    goals of p *)
+(** [unshelve l p] moves all the goals in [l] from the shelf and put them at
+    the end of the focused goals of p, if they are still undefined after [advance] *)
 val unshelve : Evar.t list -> proofview -> proofview
 
-val modify_global_shelf : (Evar.t list list -> Evar.t list list) -> proofview -> proofview
-
-val global_unshelve : Evar.t list -> proofview -> proofview
+val filter_shelf : (Evar.t -> bool) -> proofview -> proofview
 
 (** [depends_on g1 g2 sigma] checks if g1 occurs in the type/ctx of g2 *)
 val depends_on : Evd.evar_map -> Evar.t -> Evar.t -> bool
@@ -454,6 +452,10 @@ module Unsafe : sig
       being proved, appending them to the list of focused goals. If a
       goal is already solved, it is not added. *)
   val tclNEWGOALS : Proofview_monad.goal_with_state list -> unit tactic
+
+  (** [tclNEWSHELVED gls] adds the goals [gls] to the shelf. If a
+      goal is already solved, it is not added. *)
+  val tclNEWSHELVED : Evar.t list -> unit tactic
 
   (** [tclSETGOALS gls] sets goals [gls] as the goals being under focus. If a
       goal is already solved, it is not set. *)

--- a/engine/proofview_monad.ml
+++ b/engine/proofview_monad.ml
@@ -166,7 +166,6 @@ let map_goal_with_state f (g, s) = (f g, s)
 type proofview = {
   solution : Evd.evar_map;
   comb : goal_with_state list;
-  shelf : goal list;
 }
 
 (** {6 Instantiation of the logic monad} *)
@@ -236,14 +235,6 @@ end
 
 module Status : Writer with type t := bool = struct
   let put s = Logical.put s
-end
-
-module Shelf : State with type t = goal list = struct
-    (* spiwack: I don't know why I cannot substitute ([:=]) [t] with a type expression. *)
-  type t = goal list
-  let get = Logical.map (fun {shelf} -> shelf) Pv.get
-  let set c = Pv.modify (fun pv -> { pv with shelf = c })
-  let modify f = Pv.modify (fun pv -> { pv with shelf = f pv.shelf })
 end
 
 (** Lens and utilities pertaining to the info trace *)

--- a/engine/proofview_monad.mli
+++ b/engine/proofview_monad.mli
@@ -83,7 +83,6 @@ val map_goal_with_state : (goal -> goal) -> goal_with_state -> goal_with_state
 type proofview = {
   solution : Evd.evar_map;
   comb : goal_with_state list;
-  shelf : goal list;
 }
 
 (** {6 Instantiation of the logic monad} *)
@@ -136,10 +135,6 @@ module Env : State with type t := Environ.env
 
 (** Lens to the tactic status ([true] if safe, [false] if unsafe) *)
 module Status : Writer with type t := bool
-
-(** Lens to the list of goals which have been shelved during the
-    execution of the tactic. *)
-module Shelf : State with type t = goal list
 
 (** Lens and utilities pertaining to the info trace *)
 module InfoL : sig

--- a/engine/termops.ml
+++ b/engine/termops.ml
@@ -301,10 +301,12 @@ let pr_evar_map_gen with_univs pr_evars env sigma =
     if List.is_empty (Evd.meta_list sigma) then mt ()
     else
       str "METAS:" ++ brk (0, 1) ++ pr_meta_map env sigma
+  and shelf =
+    str "SHELF:" ++ brk (0, 1) ++ Evd.pr_shelf sigma ++ fnl ()
   and future_goals =
     str "FUTURE GOALS STACK:" ++ brk (0, 1) ++ Evd.pr_future_goals_stack sigma ++ fnl ()
   in
-  evs ++ svs ++ cstrs ++ typeclasses ++ obligations ++ metas ++ future_goals
+  evs ++ svs ++ cstrs ++ typeclasses ++ obligations ++ metas ++ shelf ++ future_goals
 
 let pr_evar_list env sigma l =
   let open Evd in

--- a/ide/coqide/idetop.ml
+++ b/ide/coqide/idetop.ml
@@ -220,11 +220,11 @@ let process_goal_diffs diff_goal_map oldp nsigma ng =
   let (hyps_pp_list, concl_pp) = Proof_diffs.diff_goal_ide og_s ng nsigma in
   { Interface.goal_hyp = hyps_pp_list; Interface.goal_ccl = concl_pp; Interface.goal_id = Goal.uid ng }
 
-let export_pre_goals Proof.{ sigma; goals; stack; shelf } process =
+let export_pre_goals Proof.{ sigma; goals; stack } process =
   let process = List.map (process sigma) in
   { Interface.fg_goals       = process goals
   ; Interface.bg_goals       = List.(map (fun (lg,rg) -> process lg, process rg)) stack
-  ; Interface.shelved_goals  = process shelf
+  ; Interface.shelved_goals  = process @@ Evd.shelf sigma
   ; Interface.given_up_goals = process (Evar.Set.elements @@ Evd.given_up sigma)
   }
 

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -780,7 +780,8 @@ let pr_open_subgoals_diff ?(quiet=false) ?(diffs=false) ?oproof proof =
      straightforward, but seriously, [Proof.proof] should return
      [evar_info]-s instead. *)
   let p = proof in
-  let Proof.{goals; stack; shelf; sigma} = Proof.data p in
+  let Proof.{goals; stack; sigma} = Proof.data p in
+  let shelf = Evd.shelf sigma in
   let given_up = Evd.given_up sigma in
   let stack = List.map (fun (l,r) -> List.length l + List.length r) stack in
   let seeds = Proof.V82.top_evars p in

--- a/proofs/proof.ml
+++ b/proofs/proof.ml
@@ -367,9 +367,11 @@ let run_tactic env tac pr =
     let retrieved = Evd.FutureGoals.filter (Evd.is_undefined sigma) retrieved in
     let retrieved = List.rev retrieved.Evd.FutureGoals.comb in
     let sigma = Proofview.Unsafe.mark_as_goals sigma retrieved in
+    let retrieved = CList.map Proofview_monad.with_empty_state retrieved in
     let to_shelve, sigma = Evd.pop_shelf sigma in
     Proofview.Unsafe.tclEVARS sigma >>= fun () ->
-    Proofview.Unsafe.tclNEWSHELVED (retrieved@to_shelve) <*>
+    Proofview.Unsafe.tclNEWGOALS retrieved <*>
+    Proofview.Unsafe.tclNEWSHELVED to_shelve <*>
     Proofview.tclUNIT (result,retrieved,to_shelve)
   in
   let { name; poly; proofview } = pr in

--- a/proofs/proof.mli
+++ b/proofs/proof.mli
@@ -43,8 +43,6 @@ type data =
   (** Entry for the proofview *)
   ; stack : (Evar.t list * Evar.t list) list
   (** A representation of the focus stack *)
-  ; shelf : Evar.t list
-  (** A representation of the shelf  *)
   ; name : Names.Id.t
   (** The name of the theorem whose proof is being constructed *)
   ; poly : bool;

--- a/proofs/refine.ml
+++ b/proofs/refine.ml
@@ -92,9 +92,6 @@ let generic_refine ~typecheck f gl =
   in
   (* Mark goals *)
   let sigma = Proofview.Unsafe.mark_as_goals sigma future_goals.Evd.FutureGoals.comb in
-  (* FIXME
-  let sigma = Proofview.Unsafe.mark_unresolvables sigma future_goals.Evd.FutureGoals.shelf in
-*)
   let comb = CList.rev_map (fun x -> Proofview.goal_with_state x state) future_goals.Evd.FutureGoals.comb in
   let trace env sigma = Pp.(hov 2 (str"simple refine"++spc()++
                                    Termops.Internal.print_constr_env env sigma c)) in

--- a/proofs/refine.ml
+++ b/proofs/refine.ml
@@ -92,7 +92,9 @@ let generic_refine ~typecheck f gl =
   in
   (* Mark goals *)
   let sigma = Proofview.Unsafe.mark_as_goals sigma future_goals.Evd.FutureGoals.comb in
+  (* FIXME
   let sigma = Proofview.Unsafe.mark_unresolvables sigma future_goals.Evd.FutureGoals.shelf in
+*)
   let comb = CList.rev_map (fun x -> Proofview.goal_with_state x state) future_goals.Evd.FutureGoals.comb in
   let trace env sigma = Pp.(hov 2 (str"simple refine"++spc()++
                                    Termops.Internal.print_constr_env env sigma c)) in
@@ -100,7 +102,6 @@ let generic_refine ~typecheck f gl =
   Proofview.Unsafe.tclSETENV (Environ.reset_context env) <*>
   Proofview.Unsafe.tclEVARS sigma <*>
   Proofview.Unsafe.tclSETGOALS comb <*>
-  Proofview.Unsafe.tclPUTSHELF @@ List.rev future_goals.Evd.FutureGoals.shelf <*>
   Proofview.tclUNIT v
   end
 

--- a/stm/proofBlockDelimiter.ml
+++ b/stm/proofBlockDelimiter.ml
@@ -51,8 +51,8 @@ let is_focused_goal_simple ~doc id =
   | `Valid (Some { Vernacstate.lemmas }) ->
     Option.cata (Vernacstate.LemmaStack.with_top ~f:(fun proof ->
         let proof = Declare.Proof.get proof in
-        let Proof.{ goals=focused; stack=r1; shelf=r2; sigma } = Proof.data proof in
-        let rest = List.(flatten (map (fun (x,y) -> x @ y) r1)) @ r2 @ (Evar.Set.elements @@ Evd.given_up sigma) in
+        let Proof.{ goals=focused; stack=r1; sigma } = Proof.data proof in
+        let rest = List.(flatten (map (fun (x,y) -> x @ y) r1)) @ (Evd.shelf sigma) @ (Evar.Set.elements @@ Evd.given_up sigma) in
         if List.for_all (fun x -> simple_goal sigma x rest) focused
         then `Simple focused
         else `Not)) `Not lemmas

--- a/toplevel/coqloop.ml
+++ b/toplevel/coqloop.ml
@@ -324,11 +324,11 @@ let loop_flush_all () =
 let pequal cmp1 cmp2 (a1,a2) (b1,b2) = cmp1 a1 b1 && cmp2 a2 b2
 let evleq e1 e2 = CList.equal Evar.equal e1 e2
 let cproof p1 p2 =
-  let Proof.{goals=a1;stack=a2;shelf=a3;sigma=sigma1} = Proof.data p1 in
-  let Proof.{goals=b1;stack=b2;shelf=b3;sigma=sigma2} = Proof.data p2 in
+  let Proof.{goals=a1;stack=a2;sigma=sigma1} = Proof.data p1 in
+  let Proof.{goals=b1;stack=b2;sigma=sigma2} = Proof.data p2 in
   evleq a1 b1 &&
   CList.equal (pequal evleq evleq) a2 b2 &&
-  CList.equal Evar.equal a3 b3 &&
+  CList.equal Evar.equal (Evd.shelf sigma1) (Evd.shelf sigma2) &&
   Evar.Set.equal (Evd.given_up sigma1) (Evd.given_up sigma2)
 
 let drop_last_doc = ref None

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -359,7 +359,7 @@ let declare_instance_open sigma ?hook ~tac ~global ~poly id pri impargs udecl id
      consequence, we use the low-level primitives to code
      the refinement manually.*)
   let future_goals, sigma = Evd.pop_future_goals sigma in
-  let gls = List.rev_append future_goals.Evd.FutureGoals.shelf (List.rev future_goals.Evd.FutureGoals.comb) in
+  let gls = List.rev future_goals.Evd.FutureGoals.comb in
   let sigma = Evd.push_future_goals sigma in
   let kind = Decls.(IsDefinition Instance) in
   let hook = Declare.Hook.(make (fun { S.dref ; _ } -> instance_hook pri global ?hook dref)) in

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -1553,11 +1553,11 @@ let set_used_variables ps l =
   ctx, { ps with section_vars = Some (Context.Named.to_vars ctx) }
 
 let get_open_goals ps =
-  let Proof.{ goals; stack; shelf } = Proof.data ps.proof in
+  let Proof.{ goals; stack; sigma } = Proof.data ps.proof in
   List.length goals +
   List.fold_left (+) 0
     (List.map (fun (l1,l2) -> List.length l1 + List.length l2) stack) +
-  List.length shelf
+  List.length (Evd.shelf sigma)
 
 type proof_object =
   { name : Names.Id.t

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -112,7 +112,8 @@ let show_proof ~pstate =
 
 let show_top_evars ~proof =
   (* spiwack: new as of Feb. 2010: shows goal evars in addition to non-goal evars. *)
-  let Proof.{goals;shelf;sigma} = Proof.data proof in
+  let Proof.{goals; sigma} = Proof.data proof in
+  let shelf = Evd.shelf sigma in
   let given_up = Evar.Set.elements @@ Evd.given_up sigma in
   pr_evars_int sigma ~shelf ~given_up 1 (Evd.undefined_map sigma)
 


### PR DESCRIPTION
This is an experiment following a comment by @mattam82. This PR is on top of #12872, to view the real change, look at the last commit.

I realized that for #7825, we need to know the future, which is not easy. Indeed, we need to know whether `future_goals` are going to be shelved or not by the caller. Of course, I could blindly propagate the information, but I'd rather understand first why we need this implicit shelving (as opposed to making `future_goals`... future goals).

The first failures I saw in the test suite were all due to a `Grab Existential Variables` that was used to unshelve the implicitly shelved goals, which makes me wonder if it is a feature or a bug.