### PR TITLE
Fixes #9569: in notations with binders, prevent collisions between variable and non-qualified global references

### DIFF
--- a/doc/changelog/03-notations/12965-master+fix9569-propagage-binding-vars-notations.rst
+++ b/doc/changelog/03-notations/12965-master+fix9569-propagage-binding-vars-notations.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  Occasional unexpected capture of the name of global references by
+  binders in the presence of notations for binders
+  (`#12965 <https://github.com/coq/coq/pull/12965>`_,
+  fixes `#9569 <https://github.com/coq/coq/issues/9569>`_,
+  by Hugo Herbelin).

--- a/doc/changelog/03-notations/12965-master+fix9569-propagage-binding-vars-notations.rst
+++ b/doc/changelog/03-notations/12965-master+fix9569-propagage-binding-vars-notations.rst
@@ -1,5 +1,5 @@
 - **Fixed:**
-  Occasional unexpected capture of the name of global references by
+  Capture of the name of global references by
   binders in the presence of notations for binders
   (`#12965 <https://github.com/coq/coq/pull/12965>`_,
   fixes `#9569 <https://github.com/coq/coq/issues/9569>`_,

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -85,7 +85,7 @@ let is_reserved_type na t =
   | Name id ->
     try
       let pat = Reserve.find_reserved_type id in
-      let _ = match_notation_constr false t ([],pat) in
+      let _ = match_notation_constr false t Id.Set.empty ([],pat) in
       true
     with Not_found | No_match -> false
 
@@ -1273,7 +1273,7 @@ and extern_notation inctx (custom,scopes as allscopes) vars t rules =
           | AppBoundedNotation _ -> raise No_match in
         (* Try matching ... *)
         let terms,termlists,binders,binderlists =
-          match_notation_constr !print_universes t pat in
+          match_notation_constr !print_universes t vars pat in
         (* Try availability of interpretation ... *)
         match keyrule with
           | NotationRule (_,ntn as specific_ntn) ->
@@ -1293,20 +1293,20 @@ and extern_notation inctx (custom,scopes as allscopes) vars t rules =
               | Some (scopt,key) ->
                   let scopes' = Option.List.cons scopt (snd scopes) in
                   let l =
-                    List.map (fun (c,(subentry,(scopt,scl))) ->
+                    List.map (fun ((vars,c),(subentry,(scopt,scl))) ->
                       extern (* assuming no overloading: *) true
                         (subentry,(scopt,scl@scopes')) vars c)
                       terms in
                   let ll =
-                    List.map (fun (c,(subentry,(scopt,scl))) ->
-                      List.map (extern true (subentry,(scopt,scl@scopes')) vars) c)
+                    List.map (fun ((vars,l),(subentry,(scopt,scl))) ->
+                      List.map (extern true (subentry,(scopt,scl@scopes')) vars) l)
                       termlists in
                   let bl =
-                    List.map (fun (bl,(subentry,(scopt,scl))) ->
+                    List.map (fun ((vars,bl),(subentry,(scopt,scl))) ->
                       mkCPatOr (List.map (extern_cases_pattern_in_scope (subentry,(scopt,scl@scopes')) vars) bl))
                       binders in
                   let bll =
-                    List.map (fun (bl,(subentry,(scopt,scl))) ->
+                    List.map (fun ((vars,bl),(subentry,(scopt,scl))) ->
                       pi3 (extern_local_binder (subentry,(scopt,scl@scopes')) vars bl))
                       binderlists in
                   let c = make_notation loc specific_ntn (l,ll,bl,bll) in
@@ -1316,7 +1316,7 @@ and extern_notation inctx (custom,scopes as allscopes) vars t rules =
                   CAst.make ?loc @@ extern_applied_notation inctx nallargs argsimpls c args)
           | SynDefRule kn ->
               let l =
-                List.map (fun (c,(subentry,(scopt,scl))) ->
+                List.map (fun ((vars,c),(subentry,(scopt,scl))) ->
                   extern true (subentry,(scopt,scl@snd scopes)) vars c)
                   terms in
               let cf = Nametab.shortest_qualid_of_syndef ?loc vars kn in

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -85,7 +85,7 @@ let is_reserved_type na t =
   | Name id ->
     try
       let pat = Reserve.find_reserved_type id in
-      let _ = match_notation_constr false t Id.Set.empty ([],pat) in
+      let _ = match_notation_constr ~print_univ:false t ~vars:Id.Set.empty ([],pat) in
       true
     with Not_found | No_match -> false
 
@@ -1273,7 +1273,7 @@ and extern_notation inctx (custom,scopes as allscopes) vars t rules =
           | AppBoundedNotation _ -> raise No_match in
         (* Try matching ... *)
         let terms,termlists,binders,binderlists =
-          match_notation_constr !print_universes t vars pat in
+          match_notation_constr ~print_univ:(!print_universes) t ~vars pat in
         (* Try availability of interpretation ... *)
         match keyrule with
           | NotationRule (_,ntn as specific_ntn) ->

--- a/interp/notation_ops.ml
+++ b/interp/notation_ops.ml
@@ -1380,9 +1380,9 @@ and match_disjunctive_equations u alp metas sigma {CAst.v=(ids,disjpatl1,rhs1)} 
       (alp,sigma) disjpatl1 disjpatl2 in
   match_in u alp metas sigma rhs1 rhs2
 
-let match_notation_constr u c vars (metas,pat) =
+let match_notation_constr ~print_univ c ~vars (metas,pat) =
   let terms,termlists,binders,binderlists =
-    match_ false u (vars,([],[])) metas ([],[],[],[]) c pat in
+    match_ false print_univ (vars,([],[])) metas ([],[],[],[]) c pat in
   (* Turning substitution based on binding/constr distinction into a
      substitution based on entry productions *)
   List.fold_right (fun (x,(scl,typ)) (terms',termlists',binders',binderlists') ->

--- a/interp/notation_ops.mli
+++ b/interp/notation_ops.mli
@@ -63,10 +63,11 @@ exception No_match
 
 val print_parentheses : bool ref
 
-val match_notation_constr : bool -> 'a glob_constr_g -> interpretation ->
-      ('a glob_constr_g * extended_subscopes) list * ('a glob_constr_g list * extended_subscopes) list *
-      ('a cases_pattern_disjunction_g * extended_subscopes) list *
-      ('a extended_glob_local_binder_g list * extended_subscopes) list
+val match_notation_constr : bool -> 'a glob_constr_g -> Id.Set.t -> interpretation ->
+      ((Id.Set.t * 'a glob_constr_g) * extended_subscopes) list *
+      ((Id.Set.t * 'a glob_constr_g list) * extended_subscopes) list *
+      ((Id.Set.t * 'a cases_pattern_disjunction_g) * extended_subscopes) list *
+      ((Id.Set.t * 'a extended_glob_local_binder_g list) * extended_subscopes) list
 
 val match_notation_constr_cases_pattern :
   'a cases_pattern_g -> interpretation ->

--- a/interp/notation_ops.mli
+++ b/interp/notation_ops.mli
@@ -63,7 +63,7 @@ exception No_match
 
 val print_parentheses : bool ref
 
-val match_notation_constr : bool -> 'a glob_constr_g -> Id.Set.t -> interpretation ->
+val match_notation_constr : print_univ:bool -> 'a glob_constr_g -> vars:Id.Set.t -> interpretation ->
       ((Id.Set.t * 'a glob_constr_g) * extended_subscopes) list *
       ((Id.Set.t * 'a glob_constr_g list) * extended_subscopes) list *
       ((Id.Set.t * 'a cases_pattern_disjunction_g) * extended_subscopes) list *

--- a/interp/reserve.ml
+++ b/interp/reserve.ml
@@ -119,7 +119,7 @@ let revert_reserved_type t =
         then I've introduced a bug... *)
     let filter _ pat =
       try
-        let _ = match_notation_constr false t ([], pat) in
+        let _ = match_notation_constr false t Id.Set.empty ([], pat) in
         true
       with No_match -> false
     in

--- a/interp/reserve.ml
+++ b/interp/reserve.ml
@@ -119,7 +119,7 @@ let revert_reserved_type t =
         then I've introduced a bug... *)
     let filter _ pat =
       try
-        let _ = match_notation_constr false t Id.Set.empty ([], pat) in
+        let _ = match_notation_constr ~print_univ:false t ~vars:Id.Set.empty ([], pat) in
         true
       with No_match -> false
     in

--- a/test-suite/output/bug_9569.out
+++ b/test-suite/output/bug_9569.out
@@ -1,0 +1,16 @@
+1 subgoal
+  
+  ============================
+  exists I : True, I = Logic.I
+1 subgoal
+  
+  ============================
+  f True False True False (Logic.True /\ Logic.False)
+1 subgoal
+  
+  ============================
+  [I | I = Logic.I; I = Logic.I] = [I | I = Logic.I; I = Logic.I]
+1 subgoal
+  
+  ============================
+  [I & I = Logic.I | I = Logic.I; Logic.I = I]

--- a/test-suite/output/bug_9569.v
+++ b/test-suite/output/bug_9569.v
@@ -1,0 +1,18 @@
+Goal exists I, I = Logic.I.
+Show.
+Abort.
+
+Notation f x y p q r := ((forall x, p /\ r) /\ forall y, q /\ r).
+Goal f True False True False (Logic.True /\ Logic.False).
+Show.
+Abort.
+
+Notation "[ x | y ; z ; .. ; t ]" := (pair .. (pair (forall x, y) (forall x, z)) .. (forall x, t)).
+Goal [ I | I = Logic.I ; I = Logic.I ] = [ I | I = Logic.I ; I = Logic.I ].
+Show.
+Abort.
+
+Notation "[ x & p | y ; .. ; z ; t ]" := (forall x, p -> y -> .. (forall x, p -> z -> forall x, p -> t) ..).
+Goal [ I & I = Logic.I | I = Logic.I ; Logic.I = I ].
+Show.
+Abort.


### PR DESCRIPTION
**Kind:** bug fix 

Collecting the spine of variables of a term at printing time was not yet done when traversing notations. This PR repairs it.

Fixes #9569

- [X] Added / updated test-suite
- [x] Entry added in the changelog
