### PR TITLE
add_trusted_constant API

### DIFF
--- a/kernel/safe_typing.mli
+++ b/kernel/safe_typing.mli
@@ -95,6 +95,15 @@ val export_private_constants :
 val add_constant :
   Label.t -> global_declaration -> Constant.t safe_transformer
 
+(** Unsafe: does no typechecking. The body must have universes pre-abstracted. *)
+val add_trusted_constant
+  : Label.t ->
+  opaque:bool ->
+  universes:Declarations.universes ->
+  typ:Constr.types ->
+  body:Constr.constr ->
+  Constant.t safe_transformer
+
 (** Similar to add_constant but also returns a certificate *)
 val add_private_constant :
   Label.t -> side_effect_declaration -> (Constant.t * private_constants) safe_transformer

--- a/library/global.ml
+++ b/library/global.ml
@@ -106,6 +106,8 @@ let set_allow_sprop b = globalize0 (Safe_typing.set_allow_sprop b)
 let sprop_allowed () = Environ.sprop_allowed (env())
 let export_private_constants cd = globalize (Safe_typing.export_private_constants cd)
 let add_constant id d = globalize (Safe_typing.add_constant (i2l id) d)
+let add_trusted_constant id ~opaque ~universes ~typ ~body =
+  globalize (Safe_typing.add_trusted_constant (i2l id) ~opaque ~universes ~typ ~body)
 let add_private_constant id d = globalize (Safe_typing.add_private_constant (i2l id) d)
 let add_mind id mie = globalize (Safe_typing.add_mind (i2l id) mie)
 let add_modtype id me inl = globalize (Safe_typing.add_modtype (i2l id) me inl)

--- a/library/global.mli
+++ b/library/global.mli
@@ -53,8 +53,18 @@ val export_private_constants :
 
 val add_constant :
   Id.t -> Safe_typing.global_declaration -> Constant.t
+
+val add_trusted_constant
+  : Id.t ->
+  opaque:bool ->
+  universes:Declarations.universes ->
+  typ:Constr.types ->
+  body:Constr.constr ->
+  Constant.t
+
 val add_private_constant :
   Id.t -> Safe_typing.side_effect_declaration -> Constant.t * Safe_typing.private_constants
+
 val add_mind :
   Id.t -> Entries.mutual_inductive_entry -> MutInd.t
 


### PR DESCRIPTION
We discussed adding this in a Coq call a while back.
TODO add something so Print Assumptions can report these constants.