### PR TITLE
More improvements in locating tactic errors

### DIFF
--- a/plugins/ltac/taccoerce.ml
+++ b/plugins/ltac/taccoerce.ml
@@ -394,7 +394,7 @@ type appl =
 
 (* Values for interpretation *)
 type tacvalue =
-  | VFun of appl*Tacexpr.ltac_trace * Val.t Id.Map.t *
+  | VFun of appl * Tacexpr.ltac_trace * Loc.t option * Val.t Id.Map.t *
       Name.t list * Tacexpr.glob_tactic_expr
   | VRec of Val.t Id.Map.t ref * Tacexpr.glob_tactic_expr
 

--- a/plugins/ltac/taccoerce.mli
+++ b/plugins/ltac/taccoerce.mli
@@ -104,7 +104,7 @@ type appl =
        (** For calls to global constants, some may alias other. *)
 
 type tacvalue =
-  | VFun of appl*Tacexpr.ltac_trace * Val.t Id.Map.t *
+  | VFun of appl *Tacexpr.ltac_trace * Loc.t option * Val.t Id.Map.t *
       Name.t list * Tacexpr.glob_tactic_expr
   | VRec of Val.t Id.Map.t ref * Tacexpr.glob_tactic_expr
 

--- a/test-suite/output/ErrorLocation_ltac_1.out
+++ b/test-suite/output/ErrorLocation_ltac_1.out
@@ -1,0 +1,3 @@
+File "stdin", line 2, characters 7-11:
+Error: Tactic failure: Cannot solve this goal.
+

--- a/test-suite/output/ErrorLocation_ltac_1.v
+++ b/test-suite/output/ErrorLocation_ltac_1.v
@@ -1,0 +1,3 @@
+Goal False.
+idtac; easy.
+Abort.

--- a/test-suite/output/ErrorLocation_ltac_2.out
+++ b/test-suite/output/ErrorLocation_ltac_2.out
@@ -1,0 +1,3 @@
+File "stdin", line 3, characters 7-8:
+Error: Tactic failure.
+

--- a/test-suite/output/ErrorLocation_ltac_2.v
+++ b/test-suite/output/ErrorLocation_ltac_2.v
@@ -1,0 +1,4 @@
+Ltac f := fail.
+Goal False.
+idtac; f.
+Abort.

--- a/test-suite/output/ErrorLocation_ltac_3.out
+++ b/test-suite/output/ErrorLocation_ltac_3.out
@@ -1,0 +1,3 @@
+File "stdin", line 3, characters 7-10:
+Error: Not a negated primitive equality.
+

--- a/test-suite/output/ErrorLocation_ltac_3.v
+++ b/test-suite/output/ErrorLocation_ltac_3.v
@@ -1,0 +1,4 @@
+Ltac inj := injection.
+Goal False.
+idtac; inj.
+Abort.

--- a/test-suite/output/ErrorLocation_ltac_4.out
+++ b/test-suite/output/ErrorLocation_ltac_4.out
@@ -1,0 +1,3 @@
+File "stdin", line 2, characters 22-23:
+Error: Tactic failure.
+

--- a/test-suite/output/ErrorLocation_ltac_4.v
+++ b/test-suite/output/ErrorLocation_ltac_4.v
@@ -1,0 +1,3 @@
+Goal False.
+let x := fail in x || x.
+Abort.


### PR DESCRIPTION
**Kind:** bug fix

This is one more iteration about preserving locations after the trace mechanism is deactivated by default.

We finally pass the location in the "ist", and keep it in the "VFun" which is associated to expanded Ltac constants. This fixes a few more regressions, as shown in the examples.

This is a follow-up of #12223, #12773/#12992, #12774.

- [X] Added / updated test-suite
