### PR TITLE
[ci] [mathcomp] run the test suite

### DIFF
--- a/dev/ci/ci-mathcomp.sh
+++ b/dev/ci/ci-mathcomp.sh
@@ -6,7 +6,7 @@ ci_dir="$(dirname "$0")"
 
 git_download mathcomp
 
-( cd "${CI_BUILD_DIR}/mathcomp/mathcomp" && make && make install )
+( cd "${CI_BUILD_DIR}/mathcomp/mathcomp" && make && make test-suite && make install )
 
 git_download fourcolor
 


### PR DESCRIPTION
Hopefully soon the test suite of mathcomp will include a test for notations, see https://github.com/math-comp/math-comp/pull/433
This PR adds to the math-comp job a call to the test suite (it takes a few seconds to run)