### PR TITLE
Remove deprecated Extraction Language command value "Ocaml"

### DIFF
--- a/doc/changelog/07-commands-and-options/13016-remove-Ocaml-value.rst
+++ b/doc/changelog/07-commands-and-options/13016-remove-Ocaml-value.rst
@@ -1,0 +1,4 @@
+- **Removed:**
+  In the :cmd:`Extraction Language` command, remove `Ocaml` as a valid value.
+  Use `OCaml` instead.  This was deprecated in Coq 8.8, `#6261 <https://github.com/coq/coq/pull/6261>`_
+  (`#13016 <https://github.com/coq/coq/pull/13016>`_, by Jim Fehrle).

--- a/plugins/extraction/g_extraction.mlg
+++ b/plugins/extraction/g_extraction.mlg
@@ -60,16 +60,10 @@ let pr_language = function
   | Scheme -> str "Scheme"
   | JSON -> str "JSON"
 
-let warn_deprecated_ocaml_spelling =
-  CWarnings.create ~name:"deprecated-ocaml-spelling" ~category:"deprecated"
-    (fun () ->
-      strbrk ("The spelling \"OCaml\" should be used instead of \"Ocaml\"."))
-
 }
 
 VERNAC ARGUMENT EXTEND language
 PRINTED BY { pr_language }
-| [ "Ocaml" ] -> { let _ = warn_deprecated_ocaml_spelling () in Ocaml }
 | [ "OCaml" ] -> { Ocaml }
 | [ "Haskell" ] -> { Haskell }
 | [ "Scheme" ] -> { Scheme }


### PR DESCRIPTION
Use "OCaml" instead.

- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).

(FWIW, I believe the file referenced above is actually in doc/changelog/README.md.)