### PR TITLE
Clarifying the logic of levels in custom and constr entry rules

### DIFF
--- a/dev/ci/user-overlays/13025-master+fix-printing-custom-no-level.sh
+++ b/dev/ci/user-overlays/13025-master+fix-printing-custom-no-level.sh
@@ -1,0 +1,6 @@
+if [ "$CI_PULL_REQUEST" = "13025" ] || [ "$CI_BRANCH" = "master+fix-printing-custom-no-level" ]; then
+
+    elpi_CI_REF=coq-master+adapt-coq-pr13025-fix-custom-entry-no-level-printing
+    elpi_CI_GITURL=https://github.com/herbelin/coq-elpi
+
+fi

--- a/dev/doc/changes.md
+++ b/dev/doc/changes.md
@@ -104,6 +104,15 @@ deprecation warning tells what to do.
   defined level with the provided rules. Note that this differs from FIRST,
   which creates a new level and prepends it to the list of levels of the entry.
 
+### Notations:
+
+- The type `notation_entry_level` has been split into two: the name
+  `notation_entry_level` still exists and is used to characterize the
+  level and custom entry name (if any) where a grammar rule lives; the
+  new `notation_subentry_level` is to characterize the level (possibly
+  none) and custom entry name associated to the variables (=
+  non-terminal subentries) of the grammar rule.
+
 ## Changes between Coq 8.12 and Coq 8.13
 
 ### Code formatting

--- a/interp/constrexpr.ml
+++ b/interp/constrexpr.ml
@@ -42,21 +42,13 @@ type entry_level = int
 type entry_relative_level = LevelLt of entry_level | LevelLe of entry_level | LevelSome
 
 (* The entry in which a notation is declared *)
-type notation_entry =
-  | InConstrEntry
-  | InCustomEntry of string
+type notation_entry = InConstrEntry | InCustomEntry of string
 
 (* A notation entry with the level where the notation lives *)
-(* Note: the level is hard-wired in the printer for constr *)
-type notation_entry_level =
-  | InConstrEntrySomeLevel
-  | InCustomEntryLevel of string * entry_level
+type notation_entry_level = notation_entry * entry_level
 
 (* Notation subentries, to be associated to the variables of the notation *)
-(* Note: the level is hard-wired in the printer for constr *)
-type notation_entry_relative_level =
-  | InConstrEntrySomeRelativeLevel
-  | InCustomEntryRelativeLevel of string * (entry_relative_level * side option)
+type notation_entry_relative_level = notation_entry * (entry_relative_level * side option)
 
 type notation_key = string
 

--- a/interp/constrexpr.ml
+++ b/interp/constrexpr.ml
@@ -54,9 +54,9 @@ type notation_entry_level =
 
 (* Notation subentries, to be associated to the variables of the notation *)
 (* Note: the level is hard-wired in the printer for constr *)
-type notation_subentry_level =
-  | InConstrSubentrySomeLevel
-  | InCustomSubentryLevel of string * (entry_relative_level * side option)
+type notation_entry_relative_level =
+  | InConstrEntrySomeRelativeLevel
+  | InCustomEntryRelativeLevel of string * (entry_relative_level * side option)
 
 type notation_key = string
 

--- a/interp/constrexpr.ml
+++ b/interp/constrexpr.ml
@@ -37,11 +37,27 @@ type name_decl = lname * universe_decl_expr option
 
 type notation_with_optional_scope = LastLonelyNotation | NotationInScope of string
 
+type side = Left | Right
 type entry_level = int
 type entry_relative_level = LevelLt of entry_level | LevelLe of entry_level | LevelSome
 
-type notation_entry = InConstrEntry | InCustomEntry of string
-type notation_entry_level = InConstrEntrySomeLevel | InCustomEntryLevel of string * entry_level
+(* The entry in which a notation is declared *)
+type notation_entry =
+  | InConstrEntry
+  | InCustomEntry of string
+
+(* A notation entry with the level where the notation lives *)
+(* Note: the level is hard-wired in the printer for constr *)
+type notation_entry_level =
+  | InConstrEntrySomeLevel
+  | InCustomEntryLevel of string * entry_level
+
+(* Notation subentries, to be associated to the variables of the notation *)
+(* Note: the level is hard-wired in the printer for constr *)
+type notation_subentry_level =
+  | InConstrSubentrySomeLevel
+  | InCustomSubentryLevel of string * (entry_relative_level * side option)
+
 type notation_key = string
 
 (* A notation associated to a given parsing rule *)

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -347,10 +347,10 @@ let rec fill_arg_scopes args subscopes (entry,(_,scopes) as all) =
 
 let update_with_subscope (entry,(scopt,scl)) scopes =
   let entry = match entry with
-  | InConstrSubentrySomeLevel -> InConstrSubentrySomeLevel
-  | InCustomSubentryLevel (custom,(lev,side)) ->
+  | InConstrEntrySomeRelativeLevel -> InConstrEntrySomeRelativeLevel
+  | InCustomEntryRelativeLevel (custom,(lev,side)) ->
      let lev = if !print_parentheses && side <> None then LevelLe 0 (* min level *) else lev in
-     InCustomSubentryLevel (custom,(lev,side)) in
+     InCustomEntryRelativeLevel (custom,(lev,side)) in
   entry,(scopt,scl@scopes)
 
 (**********************************************************************)
@@ -489,7 +489,7 @@ let rec extern_cases_pattern_in_scope (custom,scopes as allscopes) vars pat =
     match availability_of_entry_coercion custom InConstrEntrySomeLevel with
     | None -> raise No_match
     | Some coercion ->
-      let allscopes = (InConstrSubentrySomeLevel,scopes) in
+      let allscopes = (InConstrEntrySomeRelativeLevel,scopes) in
       let pat = match pat with
         | PatVar (Name id) -> CAst.make ?loc (CPatAtom (Some (qualid_of_ident ?loc id)))
         | PatVar (Anonymous) -> CAst.make ?loc (CPatAtom None)
@@ -626,7 +626,7 @@ let extern_ind_pattern_in_scope (custom,scopes as allscopes) vars ind args =
            |None           -> CAst.make @@ CPatCstr (c, Some args, [])
 
 let extern_cases_pattern vars p =
-  extern_cases_pattern_in_scope (InConstrSubentrySomeLevel,(None,[])) vars p
+  extern_cases_pattern_in_scope (InConstrEntrySomeRelativeLevel,(None,[])) vars p
 
 (**********************************************************************)
 (* Externalising applications *)
@@ -1014,7 +1014,7 @@ let rec extern inctx ?impargs scopes vars r =
   | None -> raise No_match
   | Some coercion ->
 
-  let scopes = (InConstrSubentrySomeLevel, snd scopes) in
+  let scopes = (InConstrEntrySomeRelativeLevel, snd scopes) in
   let c = match c with
 
   (* The remaining cases are only for the constr entry *)
@@ -1418,10 +1418,10 @@ and extern_applied_proj inctx scopes vars (cst,us) params c extraargs =
   extern_projection inctx (f,us) nparams args imps
 
 let extern_glob_constr vars c =
-  extern false (InConstrSubentrySomeLevel,(None,[])) vars c
+  extern false (InConstrEntrySomeRelativeLevel,(None,[])) vars c
 
 let extern_glob_type ?impargs vars c =
-  extern_typ ?impargs (InConstrSubentrySomeLevel,(None,[])) vars c
+  extern_typ ?impargs (InConstrEntrySomeRelativeLevel,(None,[])) vars c
 
 (******************************************************************)
 (* Main translation function from constr -> constr_expr *)
@@ -1429,7 +1429,7 @@ let extern_glob_type ?impargs vars c =
 let extern_constr ?lax ?(inctx=false) ?scope env sigma t =
   let r = Detyping.detype Detyping.Later ?lax false Id.Set.empty env sigma t in
   let vars = extern_env env sigma in
-  extern inctx (InConstrSubentrySomeLevel,(scope,[])) vars r
+  extern inctx (InConstrEntrySomeRelativeLevel,(scope,[])) vars r
 
 let extern_constr_in_scope ?lax ?inctx scope env sigma t =
   extern_constr ?lax ?inctx ~scope env sigma t
@@ -1454,7 +1454,7 @@ let extern_closed_glob ?lax ?(goal_concl_style=false) ?(inctx=false) ?scope env 
     Detyping.detype_closed_glob ?lax goal_concl_style avoid env sigma t
   in
   let vars = extern_env env sigma in
-  extern inctx (InConstrSubentrySomeLevel,(scope,[])) vars r
+  extern inctx (InConstrEntrySomeRelativeLevel,(scope,[])) vars r
 
 (******************************************************************)
 (* Main translation function from pattern -> constr_expr *)
@@ -1593,7 +1593,7 @@ and glob_of_pat_under_context avoid env sigma (nas, pat) =
   (Array.rev_of_list nas, pat)
 
 let extern_constr_pattern env sigma pat =
-  extern true (InConstrSubentrySomeLevel,(None,[]))
+  extern true (InConstrEntrySomeRelativeLevel,(None,[]))
     (* XXX no vars? *)
     (Id.Set.empty, Evd.universe_binders sigma)
     (glob_of_pat Id.Set.empty env sigma pat)
@@ -1602,4 +1602,4 @@ let extern_rel_context where env sigma sign =
   let a = detype_rel_context Detyping.Later where Id.Set.empty (names_of_rel_context env,env) sigma sign in
   let vars = extern_env env sigma in
   let a = List.map (extended_glob_local_binder_of_decl) a in
-  pi3 (extern_local_binder (InConstrSubentrySomeLevel,(None,[])) vars a)
+  pi3 (extern_local_binder (InConstrEntrySomeRelativeLevel,(None,[])) vars a)

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -345,13 +345,9 @@ let rec fill_arg_scopes args subscopes (entry,(_,scopes) as all) =
   | a :: args, [] ->
     (a, (entry, (None, scopes))) :: fill_arg_scopes args [] all
 
-let update_with_subscope (entry,(scopt,scl)) scopes =
-  let entry = match entry with
-  | InConstrEntrySomeRelativeLevel -> InConstrEntrySomeRelativeLevel
-  | InCustomEntryRelativeLevel (custom,(lev,side)) ->
-     let lev = if !print_parentheses && side <> None then LevelLe 0 (* min level *) else lev in
-     InCustomEntryRelativeLevel (custom,(lev,side)) in
-  entry,(scopt,scl@scopes)
+let update_with_subscope ((entry,(lev,side)),(scopt,scl)) scopes =
+  let lev = if !print_parentheses && side <> None then LevelLe 0 (* min level *) else lev in
+  ((entry,(lev,side)),(scopt,scl@scopes))
 
 (**********************************************************************)
 (* mapping patterns to cases_pattern_expr                                *)
@@ -469,7 +465,7 @@ let rec extern_cases_pattern_in_scope (custom,scopes as allscopes) vars pat =
   try
     if !Flags.in_debugger || !Flags.raw_print || !print_raw_literal then raise No_match;
     let (na,p,key) = uninterp_prim_token_cases_pattern pat scopes in
-    match availability_of_entry_coercion custom InConstrEntrySomeLevel with
+    match availability_of_entry_coercion custom (InConstrEntry,0) with
       | None -> raise No_match
       | Some coercion ->
         let loc = cases_pattern_loc pat in
@@ -486,10 +482,10 @@ let rec extern_cases_pattern_in_scope (custom,scopes as allscopes) vars pat =
     | PatVar (Name id) when entry_has_global custom || entry_has_ident custom ->
       CAst.make ?loc (CPatAtom (Some (qualid_of_ident ?loc id)))
     | pat ->
-    match availability_of_entry_coercion custom InConstrEntrySomeLevel with
+    match availability_of_entry_coercion custom (InConstrEntry,0) with
     | None -> raise No_match
     | Some coercion ->
-      let allscopes = (InConstrEntrySomeRelativeLevel,scopes) in
+      let allscopes = ((InConstrEntry,(LevelSome,None)),scopes) in
       let pat = match pat with
         | PatVar (Name id) -> CAst.make ?loc (CPatAtom (Some (qualid_of_ident ?loc id)))
         | PatVar (Anonymous) -> CAst.make ?loc (CPatAtom None)
@@ -519,10 +515,7 @@ and apply_notation_to_pattern ?loc gr ((subst,substlist),(no_implicit,nb_to_drop
   match rule with
     | NotationRule (_,ntn as specific_ntn) ->
       begin
-        let entry = match fst ntn with
-          | InConstrEntry -> InConstrEntrySomeLevel
-          | InCustomEntry s -> InCustomEntryLevel (s, pi2 (Notation.level_of_notation ntn))
-        in
+        let entry = (fst ntn, pi2 (Notation.level_of_notation ntn)) in
         match availability_of_entry_coercion custom entry with
         | None -> raise No_match
         | Some coercion ->
@@ -558,7 +551,7 @@ and apply_notation_to_pattern ?loc gr ((subst,substlist),(no_implicit,nb_to_drop
                  (make_pat_notation ?loc specific_ntn (l,ll) l2') key)
       end
     | SynDefRule kn ->
-      match availability_of_entry_coercion custom InConstrEntrySomeLevel with
+      match availability_of_entry_coercion custom (InConstrEntry, 0) with
       | None -> raise No_match
       | Some coercion ->
       let qid = Nametab.shortest_qualid_of_syndef ?loc vars kn in
@@ -626,7 +619,7 @@ let extern_ind_pattern_in_scope (custom,scopes as allscopes) vars ind args =
            |None           -> CAst.make @@ CPatCstr (c, Some args, [])
 
 let extern_cases_pattern vars p =
-  extern_cases_pattern_in_scope (InConstrEntrySomeRelativeLevel,(None,[])) vars p
+  extern_cases_pattern_in_scope ((InConstrEntry,(LevelSome (*??*),None)),(None,[])) vars p
 
 (**********************************************************************)
 (* Externalising applications *)
@@ -882,7 +875,7 @@ let same_binder_type ty nal c =
 let extern_possible_prim_token (custom,scopes) r =
    if !print_raw_literal then raise No_match;
    let (n,key) = uninterp_prim_token r scopes in
-   match availability_of_entry_coercion custom InConstrEntrySomeLevel with
+   match availability_of_entry_coercion custom (InConstrEntry,0) with
    | None -> raise No_match
    | Some coercion ->
       insert_entry_coercion coercion (insert_delimiters (CAst.make ?loc:(loc_of_glob_constr r) @@ CPrim n) key)
@@ -1010,11 +1003,11 @@ let rec extern inctx ?impargs scopes vars r =
 
   | c ->
 
-  match availability_of_entry_coercion (fst scopes) InConstrEntrySomeLevel with
+  match availability_of_entry_coercion (fst scopes) (InConstrEntry,0) with
   | None -> raise No_match
   | Some coercion ->
 
-  let scopes = (InConstrEntrySomeRelativeLevel, snd scopes) in
+  let scopes = ((InConstrEntry,(LevelSome (*??*),None)), snd scopes) in
   let c = match c with
 
   (* The remaining cases are only for the constr entry *)
@@ -1341,13 +1334,8 @@ and extern_notation inctx (custom,scopes as allscopes) vars t rules =
         (* Try availability of interpretation ... *)
         match keyrule with
           | NotationRule (_,ntn as specific_ntn) ->
-            let notation_entry_level = match (fst ntn) with
-              | InConstrEntry -> InConstrEntrySomeLevel
-              | InCustomEntry s ->
-                let (_,level,_) = Notation.level_of_notation ntn in
-                InCustomEntryLevel (s, level)
-             in
-             (match availability_of_entry_coercion custom notation_entry_level with
+            let entry = (fst ntn, pi2 (Notation.level_of_notation ntn)) in
+             (match availability_of_entry_coercion custom entry with
              | None -> raise No_match
              | Some coercion ->
                match availability_of_notation specific_ntn scopes with
@@ -1399,7 +1387,7 @@ and extern_notation inctx (custom,scopes as allscopes) vars t rules =
               let args = extern_args (extern true) (vars,uvars) args in
               let c = CAst.make ?loc @@ extern_applied_syntactic_definition inctx nallargs argsimpls (a,cf) l args in
               if isCRef_no_univ c.CAst.v && entry_has_global custom then c
-             else match availability_of_entry_coercion custom InConstrEntrySomeLevel with
+             else match availability_of_entry_coercion custom (InConstrEntry,0) with
              | None -> raise No_match
              | Some coercion -> insert_entry_coercion coercion c
       with
@@ -1418,10 +1406,10 @@ and extern_applied_proj inctx scopes vars (cst,us) params c extraargs =
   extern_projection inctx (f,us) nparams args imps
 
 let extern_glob_constr vars c =
-  extern false (InConstrEntrySomeRelativeLevel,(None,[])) vars c
+  extern false ((InConstrEntry,(LevelSome,None)),(None,[])) vars c
 
 let extern_glob_type ?impargs vars c =
-  extern_typ ?impargs (InConstrEntrySomeRelativeLevel,(None,[])) vars c
+  extern_typ ?impargs ((InConstrEntry,(LevelSome,None)),(None,[])) vars c
 
 (******************************************************************)
 (* Main translation function from constr -> constr_expr *)
@@ -1429,7 +1417,7 @@ let extern_glob_type ?impargs vars c =
 let extern_constr ?lax ?(inctx=false) ?scope env sigma t =
   let r = Detyping.detype Detyping.Later ?lax false Id.Set.empty env sigma t in
   let vars = extern_env env sigma in
-  extern inctx (InConstrEntrySomeRelativeLevel,(scope,[])) vars r
+  extern inctx ((InConstrEntry,(LevelSome,None)),(scope,[])) vars r
 
 let extern_constr_in_scope ?lax ?inctx scope env sigma t =
   extern_constr ?lax ?inctx ~scope env sigma t
@@ -1454,7 +1442,7 @@ let extern_closed_glob ?lax ?(goal_concl_style=false) ?(inctx=false) ?scope env 
     Detyping.detype_closed_glob ?lax goal_concl_style avoid env sigma t
   in
   let vars = extern_env env sigma in
-  extern inctx (InConstrEntrySomeRelativeLevel,(scope,[])) vars r
+  extern inctx ((InConstrEntry,(LevelSome,None)),(scope,[])) vars r
 
 (******************************************************************)
 (* Main translation function from pattern -> constr_expr *)
@@ -1593,7 +1581,7 @@ and glob_of_pat_under_context avoid env sigma (nas, pat) =
   (Array.rev_of_list nas, pat)
 
 let extern_constr_pattern env sigma pat =
-  extern true (InConstrEntrySomeRelativeLevel,(None,[]))
+  extern true ((InConstrEntry,(LevelSome,None)),(None,[]))
     (* XXX no vars? *)
     (Id.Set.empty, Evd.universe_binders sigma)
     (glob_of_pat Id.Set.empty env sigma pat)
@@ -1602,4 +1590,4 @@ let extern_rel_context where env sigma sign =
   let a = detype_rel_context Detyping.Later where Id.Set.empty (names_of_rel_context env,env) sigma sign in
   let vars = extern_env env sigma in
   let a = List.map (extended_glob_local_binder_of_decl) a in
-  pi3 (extern_local_binder (InConstrEntrySomeRelativeLevel,(None,[])) vars a)
+  pi3 (extern_local_binder ((InConstrEntry,(LevelSome,None)),(None,[])) vars a)

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -345,6 +345,14 @@ let rec fill_arg_scopes args subscopes (entry,(_,scopes) as all) =
   | a :: args, [] ->
     (a, (entry, (None, scopes))) :: fill_arg_scopes args [] all
 
+let update_with_subscope (entry,(scopt,scl)) scopes =
+  let entry = match entry with
+  | InConstrSubentrySomeLevel -> InConstrSubentrySomeLevel
+  | InCustomSubentryLevel (custom,(lev,side)) ->
+     let lev = if !print_parentheses && side <> None then LevelLe 0 (* min level *) else lev in
+     InCustomSubentryLevel (custom,(lev,side)) in
+  entry,(scopt,scl@scopes)
+
 (**********************************************************************)
 (* mapping patterns to cases_pattern_expr                                *)
 
@@ -481,7 +489,7 @@ let rec extern_cases_pattern_in_scope (custom,scopes as allscopes) vars pat =
     match availability_of_entry_coercion custom InConstrEntrySomeLevel with
     | None -> raise No_match
     | Some coercion ->
-      let allscopes = (InConstrEntrySomeLevel,scopes) in
+      let allscopes = (InConstrSubentrySomeLevel,scopes) in
       let pat = match pat with
         | PatVar (Name id) -> CAst.make ?loc (CPatAtom (Some (qualid_of_ident ?loc id)))
         | PatVar (Anonymous) -> CAst.make ?loc (CPatAtom None)
@@ -507,17 +515,15 @@ let rec extern_cases_pattern_in_scope (custom,scopes as allscopes) vars pat =
       insert_pat_coercion coercion pat
 
 and apply_notation_to_pattern ?loc gr ((subst,substlist),(no_implicit,nb_to_drop,more_args))
-    (custom, (tmp_scope, scopes) as allscopes) vars =
-  function
+    (custom, (tmp_scope, scopes) as allscopes) vars rule =
+  match rule with
     | NotationRule (_,ntn as specific_ntn) ->
       begin
-        let notation_entry_level = match (fst ntn) with
+        let entry = match fst ntn with
           | InConstrEntry -> InConstrEntrySomeLevel
-          | InCustomEntry s ->
-            let (_,level,_) = Notation.level_of_notation ntn in
-            InCustomEntryLevel (s, level)
+          | InCustomEntry s -> InCustomEntryLevel (s, pi2 (Notation.level_of_notation ntn))
         in
-        match availability_of_entry_coercion custom notation_entry_level with
+        match availability_of_entry_coercion custom entry with
         | None -> raise No_match
         | Some coercion ->
         match availability_of_notation specific_ntn (tmp_scope,scopes) with
@@ -527,13 +533,14 @@ and apply_notation_to_pattern ?loc gr ((subst,substlist),(no_implicit,nb_to_drop
           | Some (scopt,key) ->
             let scopes' = Option.List.cons scopt scopes in
             let l =
-              List.map (fun (c,(subentry,(scopt,scl))) ->
-                extern_cases_pattern_in_scope (subentry,(scopt,scl@scopes')) vars c)
+              List.map (fun (c,subscope) ->
+                let scopes = update_with_subscope subscope scopes' in
+                extern_cases_pattern_in_scope scopes vars c)
                 subst in
             let ll =
-              List.map (fun (c,(subentry,(scopt,scl))) ->
-                let subscope = (subentry,(scopt,scl@scopes')) in
-                List.map (extern_cases_pattern_in_scope subscope vars) c)
+              List.map (fun (c,subscope) ->
+                let scopes = update_with_subscope subscope scopes' in
+                List.map (extern_cases_pattern_in_scope scopes vars) c)
                 substlist in
             let subscopes = find_arguments_scope gr in
             let more_args_scopes = try List.skipn nb_to_drop subscopes with Failure _ -> [] in
@@ -619,7 +626,7 @@ let extern_ind_pattern_in_scope (custom,scopes as allscopes) vars ind args =
            |None           -> CAst.make @@ CPatCstr (c, Some args, [])
 
 let extern_cases_pattern vars p =
-  extern_cases_pattern_in_scope (InConstrEntrySomeLevel,(None,[])) vars p
+  extern_cases_pattern_in_scope (InConstrSubentrySomeLevel,(None,[])) vars p
 
 (**********************************************************************)
 (* Externalising applications *)
@@ -1007,7 +1014,7 @@ let rec extern inctx ?impargs scopes vars r =
   | None -> raise No_match
   | Some coercion ->
 
-  let scopes = (InConstrEntrySomeLevel, snd scopes) in
+  let scopes = (InConstrSubentrySomeLevel, snd scopes) in
   let c = match c with
 
   (* The remaining cases are only for the constr entry *)
@@ -1350,28 +1357,29 @@ and extern_notation inctx (custom,scopes as allscopes) vars t rules =
               | Some (scopt,key) ->
                   let scopes' = Option.List.cons scopt (snd scopes) in
                   let l =
-                    List.map (fun ((vars,c),(subentry,(scopt,scl))) ->
-                      extern (* assuming no overloading: *) true
-                        (subentry,(scopt,scl@scopes')) (vars,uvars) c)
+                    List.map (fun ((vars,c),subscope) ->
+                      let scopes = update_with_subscope subscope scopes' in
+                      extern (* assuming no overloading: *) true scopes (vars,uvars) c)
                       terms
                   in
                   let ll =
-                    List.map (fun ((vars,l),(subentry,(scopt,scl))) ->
-                      List.map (extern true (subentry,(scopt,scl@scopes')) (vars,uvars)) l)
+                    List.map (fun ((vars,l),subscope) ->
+                      let scopes = update_with_subscope subscope scopes' in
+                      List.map (extern true scopes (vars,uvars)) l)
                       termlists
                   in
                   let bl =
-                    List.map (fun ((vars,bl),(subentry,(scopt,scl))) ->
+                    List.map (fun ((vars,bl),subscope) ->
+                      let scopes = update_with_subscope subscope scopes' in
                         (mkCPatOr (List.map
-                                     (extern_cases_pattern_in_scope
-                                        (subentry,(scopt,scl@scopes')) vars)
-                                     bl)),
+                                     (extern_cases_pattern_in_scope scopes vars) bl)),
                         Explicit)
                       binders
                   in
                   let bll =
-                    List.map (fun ((vars,bl),(subentry,(scopt,scl))) ->
-                      pi3 (extern_local_binder (subentry,(scopt,scl@scopes')) (vars,uvars) bl))
+                    List.map (fun ((vars,bl),subscope) ->
+                      let scopes = update_with_subscope subscope scopes' in
+                      pi3 (extern_local_binder scopes (vars,uvars) bl))
                       binderlists
                   in
                   let c = make_notation loc specific_ntn (l,ll,bl,bll) in
@@ -1410,10 +1418,10 @@ and extern_applied_proj inctx scopes vars (cst,us) params c extraargs =
   extern_projection inctx (f,us) nparams args imps
 
 let extern_glob_constr vars c =
-  extern false (InConstrEntrySomeLevel,(None,[])) vars c
+  extern false (InConstrSubentrySomeLevel,(None,[])) vars c
 
 let extern_glob_type ?impargs vars c =
-  extern_typ ?impargs (InConstrEntrySomeLevel,(None,[])) vars c
+  extern_typ ?impargs (InConstrSubentrySomeLevel,(None,[])) vars c
 
 (******************************************************************)
 (* Main translation function from constr -> constr_expr *)
@@ -1421,7 +1429,7 @@ let extern_glob_type ?impargs vars c =
 let extern_constr ?lax ?(inctx=false) ?scope env sigma t =
   let r = Detyping.detype Detyping.Later ?lax false Id.Set.empty env sigma t in
   let vars = extern_env env sigma in
-  extern inctx (InConstrEntrySomeLevel,(scope,[])) vars r
+  extern inctx (InConstrSubentrySomeLevel,(scope,[])) vars r
 
 let extern_constr_in_scope ?lax ?inctx scope env sigma t =
   extern_constr ?lax ?inctx ~scope env sigma t
@@ -1446,7 +1454,7 @@ let extern_closed_glob ?lax ?(goal_concl_style=false) ?(inctx=false) ?scope env 
     Detyping.detype_closed_glob ?lax goal_concl_style avoid env sigma t
   in
   let vars = extern_env env sigma in
-  extern inctx (InConstrEntrySomeLevel,(scope,[])) vars r
+  extern inctx (InConstrSubentrySomeLevel,(scope,[])) vars r
 
 (******************************************************************)
 (* Main translation function from pattern -> constr_expr *)
@@ -1585,7 +1593,7 @@ and glob_of_pat_under_context avoid env sigma (nas, pat) =
   (Array.rev_of_list nas, pat)
 
 let extern_constr_pattern env sigma pat =
-  extern true (InConstrEntrySomeLevel,(None,[]))
+  extern true (InConstrSubentrySomeLevel,(None,[]))
     (* XXX no vars? *)
     (Id.Set.empty, Evd.universe_binders sigma)
     (glob_of_pat Id.Set.empty env sigma pat)
@@ -1594,4 +1602,4 @@ let extern_rel_context where env sigma sign =
   let a = detype_rel_context Detyping.Later where Id.Set.empty (names_of_rel_context env,env) sigma sign in
   let vars = extern_env env sigma in
   let a = List.map (extended_glob_local_binder_of_decl) a in
-  pi3 (extern_local_binder (InConstrEntrySomeLevel,(None,[])) vars a)
+  pi3 (extern_local_binder (InConstrSubentrySomeLevel,(None,[])) vars a)

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -50,6 +50,11 @@ let notation_entry_level_eq s1 s2 = match (s1,s2) with
 | InCustomEntryLevel (s1,n1), InCustomEntryLevel (s2,n2) -> String.equal s1 s2 && n1 = n2
 | (InConstrEntrySomeLevel | InCustomEntryLevel _), _ -> false
 
+let notation_subentry_level_eq s1 s2 = match (s1,s2) with
+| InConstrSubentrySomeLevel, InConstrSubentrySomeLevel -> true
+| InCustomSubentryLevel (s1,n1), InCustomSubentryLevel (s2,n2) -> String.equal s1 s2 && n1 = n2
+| (InConstrSubentrySomeLevel | InCustomSubentryLevel _), _ -> false
+
 let notation_with_optional_scope_eq inscope1 inscope2 = match (inscope1,inscope2) with
  | LastLonelyNotation, LastLonelyNotation -> true
  | NotationInScope s1, NotationInScope s2 -> String.equal s1 s2
@@ -76,7 +81,7 @@ let ntpe_eq t1 t2 = match t1, t2 with
 | (NtnTypeConstr | NtnTypeBinder _ | NtnTypeConstrList | NtnTypeBinderList), _ -> false
 
 let var_attributes_eq (_, ((entry1, sc1), tp1)) (_, ((entry2, sc2), tp2)) =
-  notation_entry_level_eq entry1 entry2 &&
+  notation_subentry_level_eq entry1 entry2 &&
   pair_eq (Option.equal String.equal) (List.equal String.equal) sc1 sc2 &&
   ntpe_eq tp1 tp2
 
@@ -416,6 +421,15 @@ let notation_constr_key = function (* Rem: NApp(NRef ref,[]) stands for @ref *)
 
 type level = notation_entry * entry_level * entry_relative_level list
   (* first argument is InCustomEntry s for custom entries *)
+
+let entry_relative_level_le child parent =
+  match child with
+  | None -> true
+  | Some child ->
+  match parent with
+  | LevelLt parent -> child < parent
+  | LevelLe parent -> child <= parent
+  | LevelSome -> true
 
 let entry_relative_level_eq t1 t2 = match t1, t2 with
 | LevelLt n1, LevelLt n2 -> Int.equal n1 n2
@@ -1713,7 +1727,7 @@ module EntryCoercionOrd =
 
 module EntryCoercionMap = Map.Make(EntryCoercionOrd)
 
-let entry_coercion_map : (((entry_level option * entry_level option) * entry_coercion) list EntryCoercionMap.t) ref =
+let entry_coercion_map : (((entry_level option * entry_relative_level) * entry_coercion) list EntryCoercionMap.t) ref =
   ref EntryCoercionMap.empty
 
 let level_ord lev lev' =
@@ -1722,10 +1736,30 @@ let level_ord lev lev' =
   | _, None -> true
   | Some n, Some n' -> n <= n'
 
+let sublevel_ord lev lev' =
+  match lev, lev' with
+  | _, LevelSome -> true
+  | LevelSome, _ -> false
+  | LevelLt n, LevelLt n' | LevelLe n, LevelLe n' -> n <= n'
+  | LevelLt n, LevelLe n' -> n < n'
+  | LevelLe n, LevelLt n' -> n <= n'-1
+
+let notation_subentry_entry_level_lt s1 s2 = match (s1,s2) with
+| InConstrSubentrySomeLevel, InConstrEntrySomeLevel -> true
+| InCustomSubentryLevel (s1,(n1,_)), InCustomEntryLevel (s2,n2) ->
+  String.equal s1 s2 && not (entry_relative_level_le (Some n2) n1)
+| (InConstrSubentrySomeLevel | InCustomSubentryLevel _), _ -> false
+
+let notation_entry_subentry_level_le s1 s2 = match (s1,s2) with
+| InConstrEntrySomeLevel, InConstrSubentrySomeLevel -> true
+| InCustomEntryLevel (s1,n1), InCustomSubentryLevel (s2,(n2,_)) ->
+  String.equal s1 s2 && entry_relative_level_le (Some n1) n2
+| (InConstrEntrySomeLevel | InCustomEntryLevel _), _ -> false
+
 let rec search nfrom nto = function
   | [] -> raise Not_found
   | ((pfrom,pto),coe)::l ->
-    if level_ord pfrom nfrom && level_ord nto pto then coe else search nfrom nto l
+    if entry_relative_level_le pfrom nfrom && entry_relative_level_le nto pto then coe else search nfrom nto l
 
 let make_notation_entry_level entry level =
   match entry with
@@ -1736,17 +1770,21 @@ let decompose_notation_entry_level = function
   | InConstrEntrySomeLevel -> InConstrEntry, None
   | InCustomEntryLevel (s,n) -> InCustomEntry s, Some n
 
-let availability_of_entry_coercion entry entry' =
-  let entry, lev = decompose_notation_entry_level entry in
-  let entry', lev' = decompose_notation_entry_level entry' in
-  if notation_entry_eq entry entry' && level_ord lev' lev then Some []
+let decompose_notation_subentry_level = function
+  | InConstrSubentrySomeLevel -> InConstrEntry, LevelSome
+  | InCustomSubentryLevel (s,(n,_)) -> InCustomEntry s, n
+
+let availability_of_entry_coercion subentry entry' =
+  if notation_entry_subentry_level_le entry' subentry then Some []
   else
-    try Some (search lev lev' (EntryCoercionMap.find (entry,entry') !entry_coercion_map))
+    let entry, sublev = decompose_notation_subentry_level subentry in
+    let entry', lev = decompose_notation_entry_level entry' in
+    try Some (search sublev lev (EntryCoercionMap.find (entry,entry') !entry_coercion_map))
     with Not_found -> None
 
-let better_path ((lev1,lev2),path) ((lev1',lev2'),path') =
+let better_path ((lev1,sublev2),path) ((lev1',sublev2'),path') =
   (* better = shorter and lower source and higher target *)
-  level_ord lev1 lev1' && level_ord lev2' lev2 && List.length path <= List.length path'
+  level_ord lev1 lev1' && sublevel_ord sublev2' sublev2 && List.length path <= List.length path'
 
 let shorter_path (_,path) (_,path') =
   List.length path <= List.length path'
@@ -1760,27 +1798,28 @@ let rec insert_coercion_path path = function
       else if shorter_path path path' then path::allpaths
       else path'::insert_coercion_path path paths
 
-let declare_entry_coercion (scope,(entry,key)) lev entry' =
-  let entry', lev' = decompose_notation_entry_level entry' in
+let declare_entry_coercion ntn entry subentry =
+  let entry, lev = decompose_notation_entry_level entry in
+  let entry', sublev = decompose_notation_subentry_level subentry in
   (* Transitive closure *)
   let toaddleft =
     EntryCoercionMap.fold (fun (entry'',entry''') paths l ->
-        List.fold_right (fun ((lev'',lev'''),path) l ->
-        if notation_entry_eq entry entry''' && level_ord lev lev''' &&
+        List.fold_right (fun ((lev'',sublev'''),path) l ->
+        if notation_entry_eq entry entry''' && entry_relative_level_le lev sublev''' &&
            not (notation_entry_eq entry' entry'')
-        then ((entry'',entry'),((lev'',lev'),path@[(scope,(entry,key))]))::l else l) paths l)
+        then ((entry'',entry'),((lev'',sublev),path@[ntn]))::l else l) paths l)
       !entry_coercion_map [] in
   let toaddright =
     EntryCoercionMap.fold (fun (entry'',entry''') paths l ->
-        List.fold_right (fun ((lev'',lev'''),path) l ->
-        if entry' = entry'' && level_ord lev'' lev' && entry <> entry'''
-        then ((entry,entry'''),((lev,lev'''),path@[(scope,(entry,key))]))::l else l) paths l)
+        List.fold_right (fun ((lev'',sublev'''),path) l ->
+        if entry' = entry'' && entry_relative_level_le lev'' sublev && entry <> entry'''
+        then ((entry,entry'''),((lev,sublev'''),path@[ntn]))::l else l) paths l)
       !entry_coercion_map [] in
   entry_coercion_map :=
     List.fold_right (fun (pair,path) ->
         let olds = try EntryCoercionMap.find pair !entry_coercion_map with Not_found -> [] in
         EntryCoercionMap.add pair (insert_coercion_path path olds))
-      (((entry,entry'),((lev,lev'),[(scope,(entry,key))]))::toaddright@toaddleft)
+      (((entry,entry'),((lev,sublev),[ntn]))::toaddright@toaddleft)
       !entry_coercion_map
 
 let entry_has_global_map = ref String.Map.empty
@@ -1794,9 +1833,9 @@ let declare_custom_entry_has_global s n =
     entry_has_global_map := String.Map.add s n !entry_has_global_map
 
 let entry_has_global = function
-  | InConstrEntrySomeLevel -> true
-  | InCustomEntryLevel (s,n) ->
-     try String.Map.find s !entry_has_global_map <= n with Not_found -> false
+  | InConstrSubentrySomeLevel -> true
+  | InCustomSubentryLevel (s,(n,_)) ->
+     try entry_relative_level_le (Some (String.Map.find s !entry_has_global_map)) n with Not_found -> false
 
 let entry_has_ident_map = ref String.Map.empty
 
@@ -1809,12 +1848,12 @@ let declare_custom_entry_has_ident s n =
     entry_has_ident_map := String.Map.add s n !entry_has_ident_map
 
 let entry_has_ident = function
-  | InConstrEntrySomeLevel -> true
-  | InCustomEntryLevel (s,n) ->
-     try String.Map.find s !entry_has_ident_map <= n with Not_found -> false
+  | InConstrSubentrySomeLevel -> true
+  | InCustomSubentryLevel (s,(n,_)) ->
+     try entry_relative_level_le (Some (String.Map.find s !entry_has_ident_map)) n with Not_found -> false
 
 type entry_coercion_kind =
-  | IsEntryCoercion of notation_entry_level
+  | IsEntryCoercion of notation_entry_level * notation_subentry_level
   | IsEntryGlobal of string * int
   | IsEntryIdent of string * int
 
@@ -1843,13 +1882,7 @@ let declare_notation (scopt,ntn) pat df ~use ~also_in_cases_pattern coe deprecat
   end;
   (* Declare a possible coercion *)
   begin match coe with
-   | Some (IsEntryCoercion entry) ->
-     let (_,level,_) = level_of_notation ntn in
-     let level = match fst ntn with
-       | InConstrEntry -> None
-       | InCustomEntry _ -> Some level
-     in
-     declare_entry_coercion (scopt,ntn) level entry
+   | Some (IsEntryCoercion (entry,subentry)) -> declare_entry_coercion (scopt,ntn) entry subentry
    | Some (IsEntryGlobal (entry,n)) -> declare_custom_entry_has_global entry n
    | Some (IsEntryIdent (entry,n)) -> declare_custom_entry_has_ident entry n
    | None -> ()

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -1744,11 +1744,13 @@ let sublevel_ord lev lev' =
   | LevelLt n, LevelLe n' -> n < n'
   | LevelLe n, LevelLt n' -> n <= n'-1
 
-let notation_entry_relative_entry_level_lt s1 s2 = match (s1,s2) with
-| InConstrEntrySomeRelativeLevel, InConstrEntrySomeLevel -> true
-| InCustomEntryRelativeLevel (s1,(n1,_)), InCustomEntryLevel (s2,n2) ->
-  String.equal s1 s2 && not (entry_relative_level_le (Some n2) n1)
-| (InConstrEntrySomeRelativeLevel | InCustomEntryRelativeLevel _), _ -> false
+let is_coercion s1 s2 = match (s1,s2) with
+| InConstrEntrySomeLevel, InConstrEntrySomeRelativeLevel -> false (* only hard-wired coercions in constr *)
+|  InCustomEntryLevel (s1,n1), InCustomEntryRelativeLevel (s2,(n2,_)) when String.equal s1 s2 ->
+  (match n2 with
+  | LevelLt n2 | LevelLe n2 -> n1 < n2
+  | LevelSome -> true (* unless n2 is the entry top level but we shall know it only dynamically *))
+| (InConstrEntrySomeLevel | InCustomEntryLevel _), _ -> true
 
 let notation_entry_entry_relative_level_le s1 s2 = match (s1,s2) with
 | InConstrEntrySomeLevel, InConstrEntrySomeRelativeLevel -> true

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -1744,13 +1744,13 @@ let sublevel_ord lev lev' =
   | LevelLt n, LevelLe n' -> n < n'
   | LevelLe n, LevelLt n' -> n <= n'-1
 
-let notation_subentry_entry_level_lt s1 s2 = match (s1,s2) with
+let notation_entry_relative_entry_level_lt s1 s2 = match (s1,s2) with
 | InConstrEntrySomeRelativeLevel, InConstrEntrySomeLevel -> true
 | InCustomEntryRelativeLevel (s1,(n1,_)), InCustomEntryLevel (s2,n2) ->
   String.equal s1 s2 && not (entry_relative_level_le (Some n2) n1)
 | (InConstrEntrySomeRelativeLevel | InCustomEntryRelativeLevel _), _ -> false
 
-let notation_entry_subentry_level_le s1 s2 = match (s1,s2) with
+let notation_entry_entry_relative_level_le s1 s2 = match (s1,s2) with
 | InConstrEntrySomeLevel, InConstrEntrySomeRelativeLevel -> true
 | InCustomEntryLevel (s1,n1), InCustomEntryRelativeLevel (s2,(n2,_)) ->
   String.equal s1 s2 && entry_relative_level_le (Some n1) n2
@@ -1774,10 +1774,10 @@ let decompose_notation_entry_relative_level = function
   | InConstrEntrySomeRelativeLevel -> InConstrEntry, LevelSome
   | InCustomEntryRelativeLevel (s,(n,_)) -> InCustomEntry s, n
 
-let availability_of_entry_coercion subentry entry' =
-  if notation_entry_subentry_level_le entry' subentry then Some []
+let availability_of_entry_coercion relative_entry entry' =
+  if notation_entry_entry_relative_level_le entry' relative_entry then Some []
   else
-    let entry, sublev = decompose_notation_entry_relative_level subentry in
+    let entry, sublev = decompose_notation_entry_relative_level relative_entry in
     let entry', lev = decompose_notation_entry_level entry' in
     try Some (search sublev lev (EntryCoercionMap.find (entry,entry') !entry_coercion_map))
     with Not_found -> None
@@ -1798,9 +1798,9 @@ let rec insert_coercion_path path = function
       else if shorter_path path path' then path::allpaths
       else path'::insert_coercion_path path paths
 
-let declare_entry_coercion ntn entry subentry =
+let declare_entry_coercion ntn entry relative_entry =
   let entry, lev = decompose_notation_entry_level entry in
-  let entry', sublev = decompose_notation_entry_relative_level subentry in
+  let entry', sublev = decompose_notation_entry_relative_level relative_entry in
   (* Transitive closure *)
   let toaddleft =
     EntryCoercionMap.fold (fun (entry'',entry''') paths l ->

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -40,25 +40,27 @@ open NumTok
     expression, set this scope to be the current scope
 *)
 
+let entry_relative_level_eq t1 t2 = match t1, t2 with
+  | LevelLt n1, LevelLt n2 -> Int.equal n1 n2
+  | LevelLe n1, LevelLe n2 -> Int.equal n1 n2
+  | LevelSome, LevelSome -> true
+  | (LevelLt _ | LevelLe _ | LevelSome), _ -> false
+
 let notation_entry_eq s1 s2 = match (s1,s2) with
-| InConstrEntry, InConstrEntry -> true
-| InCustomEntry s1, InCustomEntry s2 -> String.equal s1 s2
-| (InConstrEntry | InCustomEntry _), _ -> false
+  | InConstrEntry, InConstrEntry -> true
+  | InCustomEntry s1, InCustomEntry s2 -> String.equal s1 s2
+  | (InConstrEntry | InCustomEntry _), _ -> false
 
-let notation_entry_level_eq s1 s2 = match (s1,s2) with
-| InConstrEntrySomeLevel, InConstrEntrySomeLevel -> true
-| InCustomEntryLevel (s1,n1), InCustomEntryLevel (s2,n2) -> String.equal s1 s2 && n1 = n2
-| (InConstrEntrySomeLevel | InCustomEntryLevel _), _ -> false
+let notation_entry_level_eq (e1,n1) (e2,n2) =
+  notation_entry_eq e1 e2 && Int.equal n1 n2
 
-let notation_entry_relative_level_eq s1 s2 = match (s1,s2) with
-| InConstrEntrySomeRelativeLevel, InConstrEntrySomeRelativeLevel -> true
-| InCustomEntryRelativeLevel (s1,n1), InCustomEntryRelativeLevel (s2,n2) -> String.equal s1 s2 && n1 = n2
-| (InConstrEntrySomeRelativeLevel | InCustomEntryRelativeLevel _), _ -> false
+let notation_entry_relative_level_eq (e1,(n1,s1)) (e2,(n2,s2)) =
+  notation_entry_eq e1 e2 && entry_relative_level_eq n1 n2 && s1 = s2
 
 let notation_with_optional_scope_eq inscope1 inscope2 = match (inscope1,inscope2) with
- | LastLonelyNotation, LastLonelyNotation -> true
- | NotationInScope s1, NotationInScope s2 -> String.equal s1 s2
- | (LastLonelyNotation | NotationInScope _), _ -> false
+  | LastLonelyNotation, LastLonelyNotation -> true
+  | NotationInScope s1, NotationInScope s2 -> String.equal s1 s2
+  | (LastLonelyNotation | NotationInScope _), _ -> false
 
 let notation_eq (from1,ntn1) (from2,ntn2) =
   notation_entry_eq from1 from2 && String.equal ntn1 ntn2
@@ -422,20 +424,10 @@ let notation_constr_key = function (* Rem: NApp(NRef ref,[]) stands for @ref *)
 type level = notation_entry * entry_level * entry_relative_level list
   (* first argument is InCustomEntry s for custom entries *)
 
-let entry_relative_level_le child parent =
-  match child with
-  | None -> true
-  | Some child ->
-  match parent with
+let entry_relative_level_le child = function
   | LevelLt parent -> child < parent
   | LevelLe parent -> child <= parent
   | LevelSome -> true
-
-let entry_relative_level_eq t1 t2 = match t1, t2 with
-| LevelLt n1, LevelLt n2 -> Int.equal n1 n2
-| LevelLe n1, LevelLe n2 -> Int.equal n1 n2
-| LevelSome, LevelSome -> true
-| (LevelLt _ | LevelLe _ | LevelSome), _ -> false
 
 let level_eq (s1, l1, t1) (s2, l2, t2) =
   notation_entry_eq s1 s2 && Int.equal l1 l2 && List.equal entry_relative_level_eq t1 t2
@@ -448,10 +440,6 @@ let declare_notation_level ntn level =
     anomaly (str "Notation " ++ pr_notation ntn ++ str " is already assigned a level.")
   with Not_found ->
   notation_level_map := NotationMap.add ntn level !notation_level_map
-
-let level_of_notation ntn =
-  NotationMap.find ntn !notation_level_map
-
 
 (**********************************************************************)
 (* Interpreting numbers (not in summary because functional objects)   *)
@@ -1727,14 +1715,9 @@ module EntryCoercionOrd =
 
 module EntryCoercionMap = Map.Make(EntryCoercionOrd)
 
-let entry_coercion_map : (((entry_level option * entry_relative_level) * entry_coercion) list EntryCoercionMap.t) ref =
+(* We index coercions by pairs of entry names to avoid a full linear search *)
+let entry_coercion_map : (((entry_level * entry_relative_level) * entry_coercion) list EntryCoercionMap.t) ref =
   ref EntryCoercionMap.empty
-
-let level_ord lev lev' =
-  match lev, lev' with
-  | None, _ -> true
-  | _, None -> true
-  | Some n, Some n' -> n <= n'
 
 let sublevel_ord lev lev' =
   match lev, lev' with
@@ -1744,52 +1727,31 @@ let sublevel_ord lev lev' =
   | LevelLt n, LevelLe n' -> n < n'
   | LevelLe n, LevelLt n' -> n <= n'-1
 
-let is_coercion s1 s2 = match (s1,s2) with
-| InConstrEntrySomeLevel, InConstrEntrySomeRelativeLevel -> false (* only hard-wired coercions in constr *)
-|  InCustomEntryLevel (s1,n1), InCustomEntryRelativeLevel (s2,(n2,_)) when String.equal s1 s2 ->
-  (match n2 with
+let is_coercion (e1,n1) (e2,(n2,_)) =
+  not (notation_entry_eq e1 e2) ||
+  match n2 with
   | LevelLt n2 | LevelLe n2 -> n1 < n2
-  | LevelSome -> true (* unless n2 is the entry top level but we shall know it only dynamically *))
-| (InConstrEntrySomeLevel | InCustomEntryLevel _), _ -> true
+  | LevelSome -> true (* unless n2 is the entry top level but we shall know it only dynamically *)
 
-let notation_entry_entry_relative_level_le s1 s2 = match (s1,s2) with
-| InConstrEntrySomeLevel, InConstrEntrySomeRelativeLevel -> true
-| InCustomEntryLevel (s1,n1), InCustomEntryRelativeLevel (s2,(n2,_)) ->
-  String.equal s1 s2 && entry_relative_level_le (Some n1) n2
-| (InConstrEntrySomeLevel | InCustomEntryLevel _), _ -> false
+let included (e1,n1) (e2,(n2,_)) =
+  notation_entry_eq e1 e2 && entry_relative_level_le n1 n2
 
 let rec search nfrom nto = function
   | [] -> raise Not_found
   | ((pfrom,pto),coe)::l ->
     if entry_relative_level_le pfrom nfrom && entry_relative_level_le nto pto then coe else search nfrom nto l
 
-let make_notation_entry_level entry level =
-  match entry with
-  | InConstrEntry -> InConstrEntrySomeLevel
-  | InCustomEntry s -> InCustomEntryLevel (s,level)
-
-let decompose_notation_entry_level = function
-  | InConstrEntrySomeLevel -> InConstrEntry, None
-  | InCustomEntryLevel (s,n) -> InCustomEntry s, Some n
-
-let decompose_notation_entry_relative_level = function
-  | InConstrEntrySomeRelativeLevel -> InConstrEntry, LevelSome
-  | InCustomEntryRelativeLevel (s,(n,_)) -> InCustomEntry s, n
-
-let availability_of_entry_coercion relative_entry entry' =
-  if notation_entry_entry_relative_level_le entry' relative_entry then Some []
+let availability_of_entry_coercion (entry,(sublev,_) as entry_sublev) (entry',lev' as entry_lev) =
+  if included entry_lev entry_sublev then
+    (* [entry] is by default included in [relative_entry] *)
+    Some []
   else
-    let entry, sublev = decompose_notation_entry_relative_level relative_entry in
-    let entry', lev = decompose_notation_entry_level entry' in
-    try Some (search sublev lev (EntryCoercionMap.find (entry,entry') !entry_coercion_map))
+    try Some (search sublev lev' (EntryCoercionMap.find (entry,entry') !entry_coercion_map))
     with Not_found -> None
 
 let better_path ((lev1,sublev2),path) ((lev1',sublev2'),path') =
   (* better = shorter and lower source and higher target *)
-  level_ord lev1 lev1' && sublevel_ord sublev2' sublev2 && List.length path <= List.length path'
-
-let shorter_path (_,path) (_,path') =
-  List.length path <= List.length path'
+  lev1 <= lev1' && sublevel_ord sublev2' sublev2 && List.length path <= List.length path'
 
 let rec insert_coercion_path path = function
   | [] -> [path]
@@ -1797,32 +1759,35 @@ let rec insert_coercion_path path = function
       (* If better or equal we keep the more recent one *)
       if better_path path path' then path::paths
       else if better_path path' path then allpaths
-      else if shorter_path path path' then path::allpaths
       else path'::insert_coercion_path path paths
 
-let declare_entry_coercion ntn entry relative_entry =
-  let entry, lev = decompose_notation_entry_level entry in
-  let entry', sublev = decompose_notation_entry_relative_level relative_entry in
+let declare_entry_coercion ntn entry_level entry_relative_level' =
+  let entry, lev = entry_level in
+  let entry', (sublev',_) = entry_relative_level' in
   (* Transitive closure *)
   let toaddleft =
     EntryCoercionMap.fold (fun (entry'',entry''') paths l ->
         List.fold_right (fun ((lev'',sublev'''),path) l ->
-        if notation_entry_eq entry entry''' && entry_relative_level_le lev sublev''' &&
-           not (notation_entry_eq entry' entry'')
-        then ((entry'',entry'),((lev'',sublev),path@[ntn]))::l else l) paths l)
+        if included entry_level (entry''',(sublev''',None)) &&
+           not (included (entry'',lev'') entry_relative_level')
+        then ((entry'',entry'),((lev'',sublev'),path@[ntn]))::l else l) paths l)
       !entry_coercion_map [] in
   let toaddright =
     EntryCoercionMap.fold (fun (entry'',entry''') paths l ->
         List.fold_right (fun ((lev'',sublev'''),path) l ->
-        if entry' = entry'' && entry_relative_level_le lev'' sublev && entry <> entry'''
+        if included (entry'',lev'') entry_relative_level' &&
+           not (included entry_level (entry''',(sublev''',None)))
         then ((entry,entry'''),((lev,sublev'''),path@[ntn]))::l else l) paths l)
       !entry_coercion_map [] in
   entry_coercion_map :=
     List.fold_right (fun (pair,path) ->
         let olds = try EntryCoercionMap.find pair !entry_coercion_map with Not_found -> [] in
         EntryCoercionMap.add pair (insert_coercion_path path olds))
-      (((entry,entry'),((lev,sublev),[ntn]))::toaddright@toaddleft)
+      (((entry,entry'),((lev,sublev'),[ntn]))::toaddright@toaddleft)
       !entry_coercion_map
+
+(* Hard-wired coercion in constr corresponding to "( x )" *)
+let _ = entry_coercion_map := (EntryCoercionMap.add (InConstrEntry,InConstrEntry) [(0,LevelSome),[]] !entry_coercion_map)
 
 let entry_has_global_map = ref String.Map.empty
 
@@ -1835,9 +1800,9 @@ let declare_custom_entry_has_global s n =
     entry_has_global_map := String.Map.add s n !entry_has_global_map
 
 let entry_has_global = function
-  | InConstrEntrySomeRelativeLevel -> true
-  | InCustomEntryRelativeLevel (s,(n,_)) ->
-     try entry_relative_level_le (Some (String.Map.find s !entry_has_global_map)) n with Not_found -> false
+  | InConstrEntry, _ -> true
+  | InCustomEntry s, (n,_) ->
+     try entry_relative_level_le (String.Map.find s !entry_has_global_map) n with Not_found -> false
 
 let entry_has_ident_map = ref String.Map.empty
 
@@ -1850,9 +1815,9 @@ let declare_custom_entry_has_ident s n =
     entry_has_ident_map := String.Map.add s n !entry_has_ident_map
 
 let entry_has_ident = function
-  | InConstrEntrySomeRelativeLevel -> true
-  | InCustomEntryRelativeLevel (s,(n,_)) ->
-     try entry_relative_level_le (Some (String.Map.find s !entry_has_ident_map)) n with Not_found -> false
+  | InConstrEntry, _ -> true
+  | InCustomEntry s, (n,_) ->
+     try entry_relative_level_le (String.Map.find s !entry_has_ident_map) n with Not_found -> false
 
 type entry_coercion_kind =
   | IsEntryCoercion of notation_entry_level * notation_entry_relative_level
@@ -2200,6 +2165,20 @@ let decompose_notation_key (from,s) =
     decomp_ntn (tok::dirs) (pos+1)
   in
     from, decomp_ntn [] 0
+
+let is_numeral_in_constr (entry,symbs) =
+  match entry, List.filter (function Break _ -> false | _ -> true) symbs with
+  | InConstrEntry, ([Terminal "-"; Terminal x] | [Terminal x]) ->
+      NumTok.Unsigned.parse_string x <> None
+  | _ ->
+      false
+
+let level_of_notation ntn =
+  if is_numeral_in_constr (decompose_notation_key ntn) then
+    (* A primitive notation *)
+    (fst ntn, 0, []) (* TODO: string notations*)
+  else
+    NotationMap.find ntn !notation_level_map
 
 (************)
 (* Printing *)

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -2579,9 +2579,9 @@ let freeze ~marshallable =
   !delimiters_map, !notations_key_table, !scope_class_map,
   !prim_token_interp_infos, !prim_token_uninterp_infos,
   !entry_coercion_map, !entry_has_global_map,
-  !entry_has_ident_map)
+  !entry_has_ident_map, !notation_level_map)
 
-let unfreeze (scm,scs,asc,dlm,fkm,clsc,ptii,ptui,coe,globs,ids) =
+let unfreeze (scm,scs,asc,dlm,fkm,clsc,ptii,ptui,coe,globs,ids,levs) =
   scope_map := scm;
   scope_stack := scs;
   delimiters_map := dlm;
@@ -2592,7 +2592,8 @@ let unfreeze (scm,scs,asc,dlm,fkm,clsc,ptii,ptui,coe,globs,ids) =
   prim_token_uninterp_infos := ptui;
   entry_coercion_map := coe;
   entry_has_global_map := globs;
-  entry_has_ident_map := ids
+  entry_has_ident_map := ids;
+  notation_level_map := levs
 
 let init () =
   init_scope_map ();
@@ -2600,7 +2601,8 @@ let init () =
   notations_key_table := KeyMap.empty;
   scope_class_map := initial_scope_class_map;
   prim_token_interp_infos := String.Map.empty;
-  prim_token_uninterp_infos := GlobRef.Map.empty
+  prim_token_uninterp_infos := GlobRef.Map.empty;
+  notation_level_map := NotationMap.empty
 
 let _ =
   Summary.declare_summary "symbols"

--- a/interp/notation.mli
+++ b/interp/notation.mli
@@ -255,7 +255,7 @@ type notation_use =
 val declare_uninterpretation : ?also_in_cases_pattern:bool -> interp_rule -> interpretation -> unit
 
 type entry_coercion_kind =
-  | IsEntryCoercion of notation_entry_level * notation_subentry_level
+  | IsEntryCoercion of notation_entry_level * notation_entry_relative_level
   | IsEntryGlobal of string * int
   | IsEntryIdent of string * int
 
@@ -358,14 +358,14 @@ val pr_visibility: (glob_constr -> Pp.t) -> scope_name option -> Pp.t
 val make_notation_entry_level : notation_entry -> entry_level -> notation_entry_level
 
 type entry_coercion = (notation_with_optional_scope * notation) list
-val declare_entry_coercion : specific_notation -> notation_entry_level -> notation_subentry_level -> unit
-val availability_of_entry_coercion : notation_subentry_level -> notation_entry_level -> entry_coercion option
+val declare_entry_coercion : specific_notation -> notation_entry_level -> notation_entry_relative_level -> unit
+val availability_of_entry_coercion : notation_entry_relative_level -> notation_entry_level -> entry_coercion option
 
 val declare_custom_entry_has_global : string -> int -> unit
 val declare_custom_entry_has_ident : string -> int -> unit
 
-val entry_has_global : notation_subentry_level -> bool
-val entry_has_ident : notation_subentry_level -> bool
+val entry_has_global : notation_entry_relative_level -> bool
+val entry_has_ident : notation_entry_relative_level -> bool
 
 (** Dealing with precedences *)
 
@@ -375,7 +375,7 @@ type level = notation_entry * entry_level * entry_relative_level list
 val level_eq : level -> level -> bool
 val entry_relative_level_eq : entry_relative_level -> entry_relative_level -> bool
 
-val notation_subentry_entry_level_lt : notation_subentry_level -> notation_entry_level -> bool
+val notation_subentry_entry_level_lt : notation_entry_relative_level -> notation_entry_level -> bool
 
 (** {6 Declare and test the level of a (possibly uninterpreted) notation } *)
 

--- a/interp/notation.mli
+++ b/interp/notation.mli
@@ -357,9 +357,21 @@ val pr_visibility: (glob_constr -> Pp.t) -> scope_name option -> Pp.t
 
 val make_notation_entry_level : notation_entry -> entry_level -> notation_entry_level
 
-type entry_coercion = (notation_with_optional_scope * notation) list
+(** Coercions between entries *)
+
+val is_coercion : notation_entry_level -> notation_entry_relative_level -> bool
+  (** For a rule of the form
+      "Notation string := x (in some-entry, x at some-relative-entry)",
+      tell if going from some-entry to some-relative-entry is coercing *)
+
 val declare_entry_coercion : specific_notation -> notation_entry_level -> notation_entry_relative_level -> unit
+  (** Add a coercion from some-entry to some-relative-entry *)
+
+type entry_coercion = (notation_with_optional_scope * notation) list
 val availability_of_entry_coercion : notation_entry_relative_level -> notation_entry_level -> entry_coercion option
+  (** Return a coercion path from some-relative-entry to some-entry if there is one *)
+
+(** Special properties of entries *)
 
 val declare_custom_entry_has_global : string -> int -> unit
 val declare_custom_entry_has_ident : string -> int -> unit
@@ -374,8 +386,6 @@ type level = notation_entry * entry_level * entry_relative_level list
 
 val level_eq : level -> level -> bool
 val entry_relative_level_eq : entry_relative_level -> entry_relative_level -> bool
-
-val notation_entry_relative_entry_level_lt : notation_entry_relative_level -> notation_entry_level -> bool
 
 (** {6 Declare and test the level of a (possibly uninterpreted) notation } *)
 

--- a/interp/notation.mli
+++ b/interp/notation.mli
@@ -355,8 +355,6 @@ val locate_notation : (glob_constr -> Pp.t) -> notation_key ->
 
 val pr_visibility: (glob_constr -> Pp.t) -> scope_name option -> Pp.t
 
-val make_notation_entry_level : notation_entry -> entry_level -> notation_entry_level
-
 (** Coercions between entries *)
 
 val is_coercion : notation_entry_level -> notation_entry_relative_level -> bool

--- a/interp/notation.mli
+++ b/interp/notation.mli
@@ -375,7 +375,7 @@ type level = notation_entry * entry_level * entry_relative_level list
 val level_eq : level -> level -> bool
 val entry_relative_level_eq : entry_relative_level -> entry_relative_level -> bool
 
-val notation_subentry_entry_level_lt : notation_entry_relative_level -> notation_entry_level -> bool
+val notation_entry_relative_entry_level_lt : notation_entry_relative_level -> notation_entry_level -> bool
 
 (** {6 Declare and test the level of a (possibly uninterpreted) notation } *)
 

--- a/interp/notation.mli
+++ b/interp/notation.mli
@@ -255,7 +255,7 @@ type notation_use =
 val declare_uninterpretation : ?also_in_cases_pattern:bool -> interp_rule -> interpretation -> unit
 
 type entry_coercion_kind =
-  | IsEntryCoercion of notation_entry_level
+  | IsEntryCoercion of notation_entry_level * notation_subentry_level
   | IsEntryGlobal of string * int
   | IsEntryIdent of string * int
 
@@ -358,14 +358,14 @@ val pr_visibility: (glob_constr -> Pp.t) -> scope_name option -> Pp.t
 val make_notation_entry_level : notation_entry -> entry_level -> notation_entry_level
 
 type entry_coercion = (notation_with_optional_scope * notation) list
-val declare_entry_coercion : specific_notation -> entry_level option -> notation_entry_level -> unit
-val availability_of_entry_coercion : notation_entry_level -> notation_entry_level -> entry_coercion option
+val declare_entry_coercion : specific_notation -> notation_entry_level -> notation_subentry_level -> unit
+val availability_of_entry_coercion : notation_subentry_level -> notation_entry_level -> entry_coercion option
 
 val declare_custom_entry_has_global : string -> int -> unit
 val declare_custom_entry_has_ident : string -> int -> unit
 
-val entry_has_global : notation_entry_level -> bool
-val entry_has_ident : notation_entry_level -> bool
+val entry_has_global : notation_subentry_level -> bool
+val entry_has_ident : notation_subentry_level -> bool
 
 (** Dealing with precedences *)
 
@@ -374,6 +374,8 @@ type level = notation_entry * entry_level * entry_relative_level list
 
 val level_eq : level -> level -> bool
 val entry_relative_level_eq : entry_relative_level -> entry_relative_level -> bool
+
+val notation_subentry_entry_level_lt : notation_subentry_level -> notation_entry_level -> bool
 
 (** {6 Declare and test the level of a (possibly uninterpreted) notation } *)
 

--- a/interp/notation_ops.ml
+++ b/interp/notation_ops.ml
@@ -1249,9 +1249,9 @@ let remove_sigma x (terms,termlists,binders,binderlists) =
 let remove_bindinglist_sigma x (terms,termlists,binders,binderlists) =
   (terms,termlists,binders,Id.List.remove_assoc x binderlists)
 
-let add_ldots_var metas = (ldots_var,((Constrexpr.InConstrSubentrySomeLevel,(None,[])),NtnTypeConstr))::metas
+let add_ldots_var metas = (ldots_var,((Constrexpr.InConstrEntrySomeRelativeLevel,(None,[])),NtnTypeConstr))::metas
 
-let add_meta_bindinglist x metas = (x,((Constrexpr.InConstrSubentrySomeLevel,(None,[])),NtnTypeBinderList))::metas
+let add_meta_bindinglist x metas = (x,((Constrexpr.InConstrEntrySomeRelativeLevel,(None,[])),NtnTypeBinderList))::metas
 
 (* This tells if letins in the middle of binders should be included in
    the sequence of binders *)
@@ -1296,7 +1296,7 @@ let match_binderlist match_fun alp metas sigma rest x y iter termin revert =
   let alp,sigma = bind_bindinglist_env alp sigma x bl in
   match_fun alp metas sigma rest termin
 
-let add_meta_term x metas = (x,((Constrexpr.InConstrSubentrySomeLevel,(None,[])),NtnTypeConstr))::metas (* Should reuse the scope of the partner of x! *)
+let add_meta_term x metas = (x,((Constrexpr.InConstrEntrySomeRelativeLevel,(None,[])),NtnTypeConstr))::metas (* Should reuse the scope of the partner of x! *)
 
 let match_termlist match_fun alp metas sigma rest x y iter termin revert =
   let rec aux alp sigma acc rest =

--- a/interp/notation_ops.ml
+++ b/interp/notation_ops.ml
@@ -1249,9 +1249,9 @@ let remove_sigma x (terms,termlists,binders,binderlists) =
 let remove_bindinglist_sigma x (terms,termlists,binders,binderlists) =
   (terms,termlists,binders,Id.List.remove_assoc x binderlists)
 
-let add_ldots_var metas = (ldots_var,((Constrexpr.InConstrEntrySomeLevel,(None,[])),NtnTypeConstr))::metas
+let add_ldots_var metas = (ldots_var,((Constrexpr.InConstrSubentrySomeLevel,(None,[])),NtnTypeConstr))::metas
 
-let add_meta_bindinglist x metas = (x,((Constrexpr.InConstrEntrySomeLevel,(None,[])),NtnTypeBinderList))::metas
+let add_meta_bindinglist x metas = (x,((Constrexpr.InConstrSubentrySomeLevel,(None,[])),NtnTypeBinderList))::metas
 
 (* This tells if letins in the middle of binders should be included in
    the sequence of binders *)
@@ -1296,7 +1296,7 @@ let match_binderlist match_fun alp metas sigma rest x y iter termin revert =
   let alp,sigma = bind_bindinglist_env alp sigma x bl in
   match_fun alp metas sigma rest termin
 
-let add_meta_term x metas = (x,((Constrexpr.InConstrEntrySomeLevel,(None,[])),NtnTypeConstr))::metas (* Should reuse the scope of the partner of x! *)
+let add_meta_term x metas = (x,((Constrexpr.InConstrSubentrySomeLevel,(None,[])),NtnTypeConstr))::metas (* Should reuse the scope of the partner of x! *)
 
 let match_termlist match_fun alp metas sigma rest x y iter termin revert =
   let rec aux alp sigma acc rest =

--- a/interp/notation_ops.ml
+++ b/interp/notation_ops.ml
@@ -1249,9 +1249,11 @@ let remove_sigma x (terms,termlists,binders,binderlists) =
 let remove_bindinglist_sigma x (terms,termlists,binders,binderlists) =
   (terms,termlists,binders,Id.List.remove_assoc x binderlists)
 
-let add_ldots_var metas = (ldots_var,((Constrexpr.InConstrEntrySomeRelativeLevel,(None,[])),NtnTypeConstr))::metas
+let default_constr_entry_relative_level = Constrexpr.(InConstrEntry,(LevelSome,None))
 
-let add_meta_bindinglist x metas = (x,((Constrexpr.InConstrEntrySomeRelativeLevel,(None,[])),NtnTypeBinderList))::metas
+let add_ldots_var metas = (ldots_var,((default_constr_entry_relative_level,(None,[])),NtnTypeConstr))::metas
+
+let add_meta_bindinglist x metas = (x,((default_constr_entry_relative_level,(None,[])),NtnTypeBinderList))::metas
 
 (* This tells if letins in the middle of binders should be included in
    the sequence of binders *)
@@ -1296,7 +1298,7 @@ let match_binderlist match_fun alp metas sigma rest x y iter termin revert =
   let alp,sigma = bind_bindinglist_env alp sigma x bl in
   match_fun alp metas sigma rest termin
 
-let add_meta_term x metas = (x,((Constrexpr.InConstrEntrySomeRelativeLevel,(None,[])),NtnTypeConstr))::metas (* Should reuse the scope of the partner of x! *)
+let add_meta_term x metas = (x,((default_constr_entry_relative_level,(None,[])),NtnTypeConstr))::metas (* Should reuse the scope of the partner of x! *)
 
 let match_termlist match_fun alp metas sigma rest x y iter termin revert =
   let rec aux alp sigma acc rest =

--- a/interp/notation_ops.mli
+++ b/interp/notation_ops.mli
@@ -83,6 +83,3 @@ val match_notation_constr_ind_pattern :
   inductive -> 'a cases_pattern_g list -> interpretation ->
   (('a cases_pattern_g * extended_subscopes) list * ('a cases_pattern_g list * extended_subscopes) list) *
     (bool * int * 'a cases_pattern_g list)
-
-(** {5 Matching a notation pattern against a [glob_constr]} *)
-

--- a/interp/notation_term.ml
+++ b/interp/notation_term.ml
@@ -61,7 +61,7 @@ type tmp_scope_name = scope_name
 
 type subscopes = tmp_scope_name option * scope_name list
 
-type extended_subscopes = Constrexpr.notation_entry_level * subscopes
+type extended_subscopes = Constrexpr.notation_subentry_level * subscopes
 
 (** Type of the meta-variables of an notation_constr: in a recursive pattern x..y,
     x carries the sequence of objects bound to the list x..y  *)

--- a/interp/notation_term.ml
+++ b/interp/notation_term.ml
@@ -61,7 +61,7 @@ type tmp_scope_name = scope_name
 
 type subscopes = tmp_scope_name option * scope_name list
 
-type extended_subscopes = Constrexpr.notation_subentry_level * subscopes
+type extended_subscopes = Constrexpr.notation_entry_relative_level * subscopes
 
 (** Type of the meta-variables of an notation_constr: in a recursive pattern x..y,
     x carries the sequence of objects bound to the list x..y  *)

--- a/parsing/extend.ml
+++ b/parsing/extend.ml
@@ -10,10 +10,8 @@
 
 (** Entry keys for constr notations *)
 
-type side = Left | Right
-
 type production_position =
-  | BorderProd of side * Gramlib.Gramext.g_assoc option
+  | BorderProd of Constrexpr.side * Gramlib.Gramext.g_assoc option
   | InternalProd
 
 type production_level =

--- a/parsing/extend.ml
+++ b/parsing/extend.ml
@@ -59,9 +59,9 @@ type constr_prod_entry_key =
   | ETProdReference       (* Parsed as a global reference *)
   | ETProdBigint          (* Parsed as an (unbounded) integer *)
   | ETProdOneBinder of bool (* Parsed as name, or name:type or 'pattern, possibly in closed form *)
-  | ETProdConstr of Constrexpr.notation_entry * (production_level * production_position) (* Parsed as constr or pattern, or a subentry of those *)
+  | ETProdConstr of Constrexpr.notation_entry * (production_level * production_position) (* Parsed as constr or custom when extending a constr or custom entry; parsed as pattern or custom pattern when extending a pattern or custom pattern entry *)
   | ETProdPattern of int  (* Parsed as pattern as a binder (as subpart of a constr) *)
-  | ETProdConstrList of Constrexpr.notation_entry * (production_level * production_position) * (bool * string) list (* Parsed as non-empty list of constr, or subentries of those *)
+  | ETProdConstrList of Constrexpr.notation_entry * (production_level * production_position) * (bool * string) list (* Parsed as a non-empty list of constr or custom entry *)
   | ETProdBinderList of binder_entry_kind  (* Parsed as non-empty list of local binders *)
 
 (** {5 AST for user-provided entries} *)

--- a/parsing/extend.mli
+++ b/parsing/extend.mli
@@ -10,10 +10,8 @@
 
 (** Entry keys for constr notations *)
 
-type side = Left | Right
-
 type production_position =
-  | BorderProd of side * Gramlib.Gramext.g_assoc option
+  | BorderProd of Constrexpr.side * Gramlib.Gramext.g_assoc option
   | InternalProd
 
 type production_level =

--- a/parsing/notgram_ops.ml
+++ b/parsing/notgram_ops.ml
@@ -28,17 +28,17 @@ let declare_notation_grammar ntn rule =
 let grammar_of_notation ntn =
   NotationMap.find ntn !notation_grammar_map
 
-let notation_subentries_map = Summary.ref ~name:"notation_subentries_map" NotationMap.empty
+let notation_non_terminals_map = Summary.ref ~name:"notation_non_terminals_map" NotationMap.empty
 
-let declare_notation_subentries ntn entries =
+let declare_notation_non_terminals ntn entries =
   try
     let _ = NotationMap.find ntn !notation_grammar_map in
     anomaly (str "Notation " ++ pr_notation ntn ++ str " is already assigned a grammar.")
   with Not_found ->
-  notation_subentries_map := NotationMap.add ntn entries !notation_subentries_map
+  notation_non_terminals_map := NotationMap.add ntn entries !notation_non_terminals_map
 
-let subentries_of_notation ntn =
-  NotationMap.find ntn !notation_subentries_map
+let non_terminals_of_notation ntn =
+  NotationMap.find ntn !notation_non_terminals_map
 
 let get_defined_notations () =
   NotationSet.elements @@ NotationMap.domain !notation_grammar_map

--- a/parsing/notgram_ops.mli
+++ b/parsing/notgram_ops.mli
@@ -18,8 +18,8 @@ val declare_notation_grammar : notation -> notation_grammar -> unit
 val grammar_of_notation : notation -> notation_grammar
   (** raise [Not_found] if not declared *)
 
-val declare_notation_subentries : notation -> Extend.constr_entry_key list -> unit
-val subentries_of_notation : notation -> Extend.constr_entry_key list
+val declare_notation_non_terminals : notation -> Extend.constr_entry_key list -> unit
+val non_terminals_of_notation : notation -> Extend.constr_entry_key list
 
 (** Returns notations with defined parsing/printing rules *)
 val get_defined_notations : unit -> notation list

--- a/printing/ppextend.ml
+++ b/printing/ppextend.ml
@@ -39,9 +39,9 @@ let ppcmd_of_cut = function
 type pattern_quote_style = QuotedPattern | NotQuotedPattern
 
 type unparsing =
-  | UnpMetaVar of entry_relative_level * Extend.side option
+  | UnpMetaVar of entry_relative_level * side option
   | UnpBinderMetaVar of entry_relative_level * pattern_quote_style
-  | UnpListMetaVar of entry_relative_level * unparsing list * Extend.side option
+  | UnpListMetaVar of entry_relative_level * unparsing list * side option
   | UnpBinderListMetaVar of bool * unparsing list
   | UnpTerminal of string
   | UnpBox of ppbox * unparsing Loc.located list

--- a/printing/ppextend.mli
+++ b/printing/ppextend.mli
@@ -32,9 +32,9 @@ type pattern_quote_style = QuotedPattern | NotQuotedPattern
 
 (** Declare and look for the printing rule for symbolic notations *)
 type unparsing =
-  | UnpMetaVar of entry_relative_level * Extend.side option
+  | UnpMetaVar of entry_relative_level * side option
   | UnpBinderMetaVar of entry_relative_level * pattern_quote_style
-  | UnpListMetaVar of entry_relative_level * unparsing list * Extend.side option
+  | UnpListMetaVar of entry_relative_level * unparsing list * side option
   | UnpBinderListMetaVar of bool * unparsing list
   | UnpTerminal of string
   | UnpBox of ppbox * unparsing Loc.located list

--- a/test-suite/output/Notations4.out
+++ b/test-suite/output/Notations4.out
@@ -18,10 +18,7 @@ Entry custom:myconstr is
      : nat
 fun a : nat => [a + a]
      : nat -> nat
-File "./output/Notations4.v", line 35, characters 0-52:
-Warning: This notation will not be used for printing as it is bound to a
-single variable. [notation-bound-to-variable,parsing]
-File "./output/Notations4.v", line 36, characters 0-88:
+File "./output/Notations4.v", line 38, characters 0-88:
 Warning: This notation will not be used for printing as it is bound to a
 single variable. [notation-bound-to-variable,parsing]
 [1 {f 1}]
@@ -85,18 +82,18 @@ fun x : nat => [x]
      : nat -> nat
 ∀ x : nat, x = x
      : Prop
-File "./output/Notations4.v", line 193, characters 0-160:
+File "./output/Notations4.v", line 195, characters 0-160:
 Warning: Notation "∀ _ .. _ , _" was already defined with a different format
 in scope type_scope. [notation-incompatible-format,parsing]
 ∀x : nat,x = x
      : Prop
-File "./output/Notations4.v", line 206, characters 0-60:
+File "./output/Notations4.v", line 208, characters 0-60:
 Warning: Notation "_ %%% _" was already defined with a different format.
 [notation-incompatible-format,parsing]
-File "./output/Notations4.v", line 210, characters 0-64:
+File "./output/Notations4.v", line 212, characters 0-64:
 Warning: Notation "_ %%% _" was already defined with a different format.
 [notation-incompatible-format,parsing]
-File "./output/Notations4.v", line 215, characters 0-62:
+File "./output/Notations4.v", line 217, characters 0-62:
 Warning: Lonely notation "_ %%%% _" was already defined with a different
 format. [notation-incompatible-format,parsing]
 3  %%  4
@@ -105,10 +102,10 @@ format. [notation-incompatible-format,parsing]
      : nat
 3   %%   4
      : nat
-File "./output/Notations4.v", line 243, characters 47-59:
+File "./output/Notations4.v", line 245, characters 47-59:
 Warning: The format modifier is irrelevant for only-parsing rules.
 [irrelevant-format-only-parsing,parsing]
-File "./output/Notations4.v", line 247, characters 36-48:
+File "./output/Notations4.v", line 249, characters 36-48:
 Warning: The only parsing modifier has no effect in Reserved Notation.
 [irrelevant-reserved-notation-only-parsing,parsing]
 fun x : nat => U (S x)
@@ -119,7 +116,7 @@ fun x : nat => V x
      : forall x : nat, nat * (?T -> ?T)
 where
 ?T : [x : nat  x0 : ?T |- Type] (x0 cannot be used)
-File "./output/Notations4.v", line 264, characters 0-30:
+File "./output/Notations4.v", line 266, characters 0-30:
 Warning: Notation "_ :=: _" was already used. [notation-overridden,parsing]
 0 :=: 0
      : Prop

--- a/test-suite/output/Notations4.out
+++ b/test-suite/output/Notations4.out
@@ -18,6 +18,12 @@ Entry custom:myconstr is
      : nat
 fun a : nat => [a + a]
      : nat -> nat
+File "./output/Notations4.v", line 35, characters 0-52:
+Warning: This notation will not be used for printing as it is bound to a
+single variable. [notation-bound-to-variable,parsing]
+File "./output/Notations4.v", line 36, characters 0-88:
+Warning: This notation will not be used for printing as it is bound to a
+single variable. [notation-bound-to-variable,parsing]
 [1 {f 1}]
      : Expr
 fun (x : nat) (y z : Expr) => [1 + y z + {f x}]
@@ -79,18 +85,18 @@ fun x : nat => [x]
      : nat -> nat
 ∀ x : nat, x = x
      : Prop
-File "./output/Notations4.v", line 185, characters 0-160:
+File "./output/Notations4.v", line 193, characters 0-160:
 Warning: Notation "∀ _ .. _ , _" was already defined with a different format
 in scope type_scope. [notation-incompatible-format,parsing]
 ∀x : nat,x = x
      : Prop
-File "./output/Notations4.v", line 198, characters 0-60:
+File "./output/Notations4.v", line 206, characters 0-60:
 Warning: Notation "_ %%% _" was already defined with a different format.
 [notation-incompatible-format,parsing]
-File "./output/Notations4.v", line 202, characters 0-64:
+File "./output/Notations4.v", line 210, characters 0-64:
 Warning: Notation "_ %%% _" was already defined with a different format.
 [notation-incompatible-format,parsing]
-File "./output/Notations4.v", line 207, characters 0-62:
+File "./output/Notations4.v", line 215, characters 0-62:
 Warning: Lonely notation "_ %%%% _" was already defined with a different
 format. [notation-incompatible-format,parsing]
 3  %%  4
@@ -99,10 +105,10 @@ format. [notation-incompatible-format,parsing]
      : nat
 3   %%   4
      : nat
-File "./output/Notations4.v", line 235, characters 47-59:
+File "./output/Notations4.v", line 243, characters 47-59:
 Warning: The format modifier is irrelevant for only-parsing rules.
 [irrelevant-format-only-parsing,parsing]
-File "./output/Notations4.v", line 239, characters 36-48:
+File "./output/Notations4.v", line 247, characters 36-48:
 Warning: The only parsing modifier has no effect in Reserved Notation.
 [irrelevant-reserved-notation-only-parsing,parsing]
 fun x : nat => U (S x)
@@ -113,7 +119,7 @@ fun x : nat => V x
      : forall x : nat, nat * (?T -> ?T)
 where
 ?T : [x : nat  x0 : ?T |- Type] (x0 cannot be used)
-File "./output/Notations4.v", line 256, characters 0-30:
+File "./output/Notations4.v", line 264, characters 0-30:
 Warning: Notation "_ :=: _" was already used. [notation-overridden,parsing]
 0 :=: 0
      : Prop

--- a/test-suite/output/Notations4.v
+++ b/test-suite/output/Notations4.v
@@ -29,6 +29,14 @@ Notation "x" := x (in custom myconstr at level 0, x global).
 Check [ b + c ].
 Check fun a => [ a + a ].
 
+Module NonCoercions.
+
+(* Check invalid coercions (thus not used for printing) *)
+Notation "[[ x ]]" := x (at level 0, x at level 42).
+Notation "[[[ x ]]]" := x (in custom myconstr at level 5, x custom myconstr at level 5).
+
+End NonCoercions.
+
 End A.
 
 Module B.

--- a/test-suite/output/Notations4.v
+++ b/test-suite/output/Notations4.v
@@ -31,8 +31,10 @@ Check fun a => [ a + a ].
 
 Module NonCoercions.
 
-(* Check invalid coercions (thus not used for printing) *)
+(* Should we forbid extra coercions in constr (knowing the "( x )" is hard-wiree)? *)
 Notation "[[ x ]]" := x (at level 0, x at level 42).
+
+(* Check invalid coercions (thus not used for printing) *)
 Notation "[[[ x ]]]" := x (in custom myconstr at level 5, x custom myconstr at level 5).
 
 End NonCoercions.
@@ -458,7 +460,7 @@ End MorePrecise3.
 
 Module TypedPattern.
 
-Notation "## x P" := (forall x:nat*nat, P) (x pattern, at level 0).
+Notation "## x P" := (forall x:nat*nat, P) (x pattern, at level 1).
 Check ## (x,y) (x=0).
 Fail Check ## ((x,y):bool*bool) (x=y).
 
@@ -466,7 +468,7 @@ End TypedPattern.
 
 Module SingleBinder.
 
-Notation "## x P" := (forall x, x = x -> P) (x binder, at level 0).
+Notation "## x P" := (forall x, x = x -> P) (x binder, at level 1).
 Check ## '(x,y) (x+y=0).
 Check ## (x:nat) (x=0).
 Check ## '((x,y):nat*nat) (x=0).

--- a/test-suite/output/PrintingParentheses.out
+++ b/test-suite/output/PrintingParentheses.out
@@ -35,3 +35,7 @@ Arguments mult_n_Sm (n m)%nat_scope
      : list nat
 {0 = 1} + {2 <= (4 + 5)}
      : Set
+forall x y z : nat, [(x + y) + z] = [x + y + z]
+     : Prop
+forall x y z : nat, [(x + y) + z] = [x + (y + z)]
+     : Prop

--- a/test-suite/output/PrintingParentheses.v
+++ b/test-suite/output/PrintingParentheses.v
@@ -1,10 +1,39 @@
+Module Test1.
+
 Set Printing Parentheses.
 
 Check (1+2*3,4,5).
 Print mult_n_Sm.
 
+End Test1.
+
 Require Import List.
+
+Module Test2.
+
+Set Printing Parentheses.
+
 Import ListNotations.
 Check [1;2;3;4].
 
 Check {0=1}+{2<=4+5}.
+
+End Test2.
+
+(* A test with custom entries *)
+
+Module CustomEntry.
+
+Declare Custom Entry myconstr.
+
+Notation "[ x ]" := x (x custom myconstr at level 6).
+Notation "x + y" := (Nat.add x y) (in custom myconstr at level 5, right associativity).
+Notation "( x )" := x (in custom myconstr at level 0).
+Notation "x" := x (in custom myconstr at level 0, x ident).
+
+Unset Printing Parentheses.
+Check forall x y z : nat, [ (x + y) + z ] = [ x + (y + z) ].
+Set Printing Parentheses.
+Check forall x y z : nat, [ (x + y) + z ] = [ x + (y + z) ].
+
+End CustomEntry.

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -1180,7 +1180,7 @@ let is_coercion level typs =
      | ETConstr _, _ ->
          let entry = make_notation_entry_level custom n in
          let entry_relative = entry_relative_level_of_constr_prod_entry (custom,n) e in
-         if notation_subentry_entry_level_lt entry_relative entry then None
+         if notation_entry_relative_entry_level_lt entry_relative entry then None
          else Some (IsEntryCoercion (entry,entry_relative))
      | ETGlobal, InCustomEntry s -> Some (IsEntryGlobal (s,n))
      | ETIdent, InCustomEntry s -> Some (IsEntryIdent (s,n))

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -278,7 +278,7 @@ let precedence_of_position_and_level from_level = function
   | NextLevel, _ -> LevelLt from_level, None
   | DefaultLevel, _ -> LevelSome, None
 
-(** Computing precedences of subentries for parsing *)
+(** Computing precedences of non-terminals for parsing *)
 let precedence_of_entry_type (from_custom,from_level) = function
   | ETConstr (custom,_,x) when notation_entry_eq custom from_custom ->
     fst (precedence_of_position_and_level from_level x)
@@ -812,7 +812,7 @@ let check_and_extend_constr_grammar ntn rule =
         Some (Notgram_ops.grammar_of_notation ntn_for_grammar)
       with Not_found -> None
     in
-    let oldtyps = Notgram_ops.subentries_of_notation ntn_for_grammar in
+    let oldtyps = Notgram_ops.non_terminals_of_notation ntn_for_grammar in
     if not (Notation.level_eq prec oldprec) && oldparsing <> None then
       error_parsing_incompatible_level ntn ntn_for_grammar oldprec oldtyps prec typs;
     if oldparsing = None then raise Not_found
@@ -830,14 +830,14 @@ let cache_one_syntax_extension (ntn,synext) =
           Some (Notgram_ops.grammar_of_notation ntn)
         with Not_found -> None
       in
-      let oldtyps = Notgram_ops.subentries_of_notation ntn in
+      let oldtyps = Notgram_ops.non_terminals_of_notation ntn in
       if not (Notation.level_eq prec oldprec) && (oldparsing <> None || synext.synext_notgram = None) then
         error_incompatible_level ntn oldprec oldtyps prec synext.synext_nottyps;
       oldparsing
     with Not_found ->
       (* Declare the level and the precomputed parsing rule *)
       let () = Notation.declare_notation_level ntn prec in
-      let () = Notgram_ops.declare_notation_subentries ntn synext.synext_nottyps in
+      let () = Notgram_ops.declare_notation_non_terminals ntn synext.synext_nottyps in
       let () = Option.iter (Notgram_ops.declare_notation_grammar ntn) synext.synext_notgram in
       None in
   (* Declare the parsing rule *)
@@ -1470,7 +1470,7 @@ exception NoSyntaxRule
 let recover_notation_syntax ntn =
   try
     let prec = Notation.level_of_notation ntn in
-    let pa_typs = Notgram_ops.subentries_of_notation ntn in
+    let pa_typs = Notgram_ops.non_terminals_of_notation ntn in
     let pa_rule = try Some (Notgram_ops.grammar_of_notation ntn) with Not_found -> None in
     let pp_rule = try Some (find_generic_notation_printing_rule ntn) with Not_found -> None in
     {

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -1180,8 +1180,10 @@ let is_coercion level typs =
      | ETConstr _, _ ->
          let entry = make_notation_entry_level custom n in
          let entry_relative = entry_relative_level_of_constr_prod_entry (custom,n) e in
-         if notation_entry_relative_entry_level_lt entry_relative entry then None
-         else Some (IsEntryCoercion (entry,entry_relative))
+         if is_coercion entry entry_relative then
+           Some (IsEntryCoercion (entry,entry_relative))
+         else
+           None
      | ETGlobal, InCustomEntry s -> Some (IsEntryGlobal (s,n))
      | ETIdent, InCustomEntry s -> Some (IsEntryIdent (s,n))
      | _ -> None)

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -1119,7 +1119,7 @@ let make_interpretation_type isrec isonlybinding default_if_binding = function
      if isrec then NtnTypeBinderList
      else NtnTypeBinder NtnParsedAsBinder
 
-let subentry_of_constr_prod_entry from_level = function
+let entry_relative_level_of_constr_prod_entry from_level = function
   | ETConstr (InCustomEntry s,_,(_,y)) as x ->
      let side = match y with BorderProd (side,_) -> Some side | _ -> None in
      InCustomEntryRelativeLevel (s,(precedence_of_entry_type from_level x,side))
@@ -1146,7 +1146,7 @@ let make_interpretation_vars
     Id.Map.filter (fun x _ -> not (Id.List.mem x useless_recvars)) allvars in
   Id.Map.mapi (fun x (isonlybinding, sc) ->
     let typ = Id.List.assoc x typs in
-    ((subentry_of_constr_prod_entry (from,level) typ,sc),
+    ((entry_relative_level_of_constr_prod_entry (from,level) typ,sc),
      make_interpretation_type (Id.List.mem_assoc x recvars) isonlybinding default_if_binding typ)) mainvars
 
 let check_rule_productivity l =
@@ -1179,9 +1179,9 @@ let is_coercion level typs =
      (match e, custom with
      | ETConstr _, _ ->
          let entry = make_notation_entry_level custom n in
-         let subentry = subentry_of_constr_prod_entry (custom,n) e in
-         if notation_subentry_entry_level_lt subentry entry then None
-         else Some (IsEntryCoercion (entry,subentry))
+         let entry_relative = entry_relative_level_of_constr_prod_entry (custom,n) e in
+         if notation_subentry_entry_level_lt entry_relative entry then None
+         else Some (IsEntryCoercion (entry,entry_relative))
      | ETGlobal, InCustomEntry s -> Some (IsEntryGlobal (s,n))
      | ETIdent, InCustomEntry s -> Some (IsEntryIdent (s,n))
      | _ -> None)

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -1122,11 +1122,11 @@ let make_interpretation_type isrec isonlybinding default_if_binding = function
 let subentry_of_constr_prod_entry from_level = function
   | ETConstr (InCustomEntry s,_,(_,y)) as x ->
      let side = match y with BorderProd (side,_) -> Some side | _ -> None in
-     InCustomSubentryLevel (s,(precedence_of_entry_type from_level x,side))
+     InCustomEntryRelativeLevel (s,(precedence_of_entry_type from_level x,side))
   (* level and use of parentheses for coercion is hard-wired for "constr";
      we don't remember the level *)
-  | ETConstr (InConstrEntry,_,_) -> InConstrSubentrySomeLevel
-  | _ -> InConstrSubentrySomeLevel
+  | ETConstr (InConstrEntry,_,_) -> InConstrEntrySomeRelativeLevel
+  | _ -> InConstrEntrySomeRelativeLevel
 
 let make_interpretation_vars
   (* For binders, default is to parse only as an ident *) ?(default_if_binding=AsName)


### PR DESCRIPTION
**Kind:** cleanup + small enhancements

Note: This PR was originally to fix #13018 and #12775 but those were finally fixed by #13073. This PR is thus now about small enhancements and a more principled code. The header has been updated.

Synchronous overlay for elpi at LPCIC/coq-elpi#184

- We introduce a type `notation_subentry_level` to preserve more informations about the subentries: we remember whether we are at any level, at the next level or at the self level. 
- We take into account option `Printing Parentheses` in custom entries
- We provide a more principled fix to #13018 and #12775 which subsumes the quicker fix done in #13073 (the loss of the `any level` information was the cause of the bug; #13073 hackily fixed it by using `max_int` as the default possible highest level in a custom entry)
- We warn about coercions not used for printing

- [X] Added / updated test-suite
- [X] Documented API change
