### PR TITLE
More precise information when unification fails because of incompatible candidates

### DIFF
--- a/pretyping/pretype_errors.ml
+++ b/pretyping/pretype_errors.ml
@@ -20,6 +20,7 @@ type unification_error =
   | NotSameHead
   | NoCanonicalStructure
   | ConversionFailed of env * constr * constr (* Non convertible closed terms *)
+  | IncompatibleInstances of env * existential * constr * constr
   | MetaOccurInBody of Evar.t
   | InstanceNotSameType of Evar.t * env * types * types
   | UnifUnivInconsistency of Univ.univ_inconsistency

--- a/pretyping/pretype_errors.mli
+++ b/pretyping/pretype_errors.mli
@@ -23,6 +23,7 @@ type unification_error =
   | NotSameHead
   | NoCanonicalStructure
   | ConversionFailed of env * constr * constr
+  | IncompatibleInstances of env * existential * constr * constr
   | MetaOccurInBody of Evar.t
   | InstanceNotSameType of Evar.t * env * types * types
   | UnifUnivInconsistency of Univ.univ_inconsistency


### PR DESCRIPTION
**Kind:** Enhancement

In the following example:
```coq
Record C (m : nat) := { f (Hn' : 0 <= m) : Type }.

Fixpoint F (m : nat) : C ?[X] :=
 match m with
  | O => {| f (H: 0 <= 0) := bool |}
  | S m' =>
    {| f (H : 0 <= S m') :=
     match H return C (S m') with
     | le_n _ => (F m').(@f ?[N]) H
     | le_S _ _ _ => unit
     end |}
  end.
```
Coq returns:
```
In environment
F : forall m : nat, C ?n@{m:=m; m1:=m}
m : nat
m' : nat
H : 0 <= S m
The term "H" has type "0 <= S m'" while it is expected to have type
 "0 <= ?n@{m:=m'; m1:=m'}" (cannot unify "?n@{m:=m'; m1:=m'}" and 
"S m'").
```
which is a bit surprising since two easy solutions are `?n[m,m1] := S m` and `?n[m,m1] := S m1`.

It happens that the error is caused by an incompatible candidate expecting `?n[m,m1] := m1`.

This PR provides more precise information to this problem by saying:
```
In environment
F : forall m : nat, C ?n@{m:=m; m1:=m}
m : nat
m' : nat
H : 0 <= S m
The term "H" has type "0 <= S m'" while it is expected to have type
 "0 <= ?n@{m:=m'; m1:=m'}" ("?n@{m:=m'; m1:=m'}" has elsewhere to unify with
"m'" which is incompatible with "S m'").
```
This is not perfect. For instance, we could:
- avoid the repetition of the instance which is long and redundant;
- explains what is the "elsewhere".

That would need more time though.

