### PR TITLE
[ci/gitlab/cachix] Avoid running in trouble when calling git fetch --unshallow

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -451,6 +451,8 @@ pkg:nix:deploy:channel:
     - pkg:nix:deploy
   script:
     - echo "$CACHIX_DEPLOYMENT_KEY" | tr -d '\r' | ssh-add - > /dev/null
+    # Remove all pr branches because they could be missing when we run git fetch --unshallow
+    - git branch --list 'pr-*' | xargs -r git branch -d
     - git fetch --unshallow
     - git branch -v
     - git push git@github.com:coq/coq-on-cachix "${CI_COMMIT_SHA}":"refs/heads/${CI_COMMIT_REF_NAME}"


### PR DESCRIPTION
**Kind:** infrastructure.

This is worth backporting.