### PR TITLE
[lib] make canonical_path_name always absolute (fix #13031)

### DIFF
--- a/clib/cUnix.ml
+++ b/clib/cUnix.ml
@@ -69,7 +69,7 @@ let canonical_path_name p =
     p'
   with Sys_error _ ->
     (* We give up to find a canonical name and just simplify it... *)
-    strip_path p
+    current ^ dirsep ^ strip_path p
 
 let make_suffix name suffix =
   if Filename.check_suffix name suffix then name else (name ^ suffix)

--- a/test-suite/misc/coq_makefile_destination_of.sh
+++ b/test-suite/misc/coq_makefile_destination_of.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+export COQBIN=$BIN
+export PATH=$COQBIN:$PATH
+
+TMP=`mktemp -d`
+cd $TMP
+
+function assert_eq() {
+  if [ "$1" != "$2" ]; then
+    echo "coq_makefile generates destination" $1 "!=" $2
+    cd /
+    rm -rf $TMP
+    exit 1
+  fi
+}
+
+assert_eq `coq_makefile -destination-of src/Y/Z/Test.v -Q src X` "X//Y/Z"
+mkdir src
+assert_eq `coq_makefile -destination-of src/Y/Z/Test.v -Q src X` "X//Y/Z"
+mkdir -p src/Y/Z
+touch src/Y/Z/Test.v
+assert_eq `coq_makefile -destination-of src/Y/Z/Test.v -Q src X` "X//Y/Z"
+cd /
+rm -rf $TMP
+exit 0


### PR DESCRIPTION
Fix #13031 