### PR TITLE
[v8.12] Use tag v2.6 for VST, like in the platform.

### DIFF
--- a/dev/build/windows/makecoq_mingw.sh
+++ b/dev/build/windows/makecoq_mingw.sh
@@ -1839,7 +1839,7 @@ function make_addon_vst {
   installer_addon_dependency_beg vst
   make_addon_compcert
   installer_addon_dependency_end
-  if build_prep_overlay vst_platform vst; then
+  if build_prep_overlay vst; then
     installer_addon_section vst "VST" "ATTENTION: SOME INCLUDED COMPCERT PARTS ARE NOT OPEN SOURCE! Verified Software Toolchain for verifying C code" "off"
     # log1 coq_set_timeouts_1000
     # The usage of the shell variable ARCH in VST collides with the usage in this shellscript

--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -179,19 +179,9 @@
 ########################################################################
 # VST
 ########################################################################
-# This commit sets the version number to 2.6
-# M.Soegtrop discussed with A.Appel via email to use this commit for 8.12.beta
-: "${vst_CI_REF:=766971b60f705e7e8b890e533518bdc79a9a60b5}"
+: "${vst_CI_REF:=v2.6}"
 : "${vst_CI_GITURL:=https://github.com/PrincetonUniversity/VST}"
 : "${vst_CI_ARCHIVEURL:=${vst_CI_GITURL}/archive}"
-
-# This is a platform friendly variant using platform supplied compcert and Flocq
-# This is used by the Windows Installer (and the Coq platform)
-# This includes one extra commit relative to the above:
-# 45239bb5 MSoegtrop Changed build and CI system to use opam / coq-platform supplied CompCert
-: "${vst_platform_CI_REF:=release-v2.6}"
-: "${vst_platform_CI_GITURL:=https://github.com/PrincetonUniversity/VST}"
-: "${vst_platform_CI_ARCHIVEURL:=${vst_platform_CI_GITURL}/archive}"
 
 ########################################################################
 # cross-crypto

--- a/dev/ci/ci-vst.sh
+++ b/dev/ci/ci-vst.sh
@@ -5,4 +5,6 @@ ci_dir="$(dirname "$0")"
 
 git_download vst
 
+export COMPCERT=bundled
+
 ( cd "${CI_BUILD_DIR}/vst" && make IGNORECOQVERSION=true )


### PR DESCRIPTION
**Kind:**  infrastructure.

@MSoegtropIMC What are the other things to change in `ci-basic-overlays.sh`? CompCert?