### PR TITLE
Setting default value for Display Parentheses off in CoqIDE

### DIFF
--- a/doc/changelog/03-notations/13067-master+fix-display-parentheses-default-coqide.rst
+++ b/doc/changelog/03-notations/13067-master+fix-display-parentheses-default-coqide.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  Repairing option :g:`Display parentheses` in CoqIDE
+  (`#12794 <https://github.com/coq/coq/pull/12794>`_ and `#13067 <https://github.com/coq/coq/pull/13067>`_,
+  fixes `#12793 <https://github.com/coq/coq/issues/12793>`_,
+  by Jean-Christophe Léchenet and Hugo Herbelin).

--- a/ide/coqide/coq.ml
+++ b/ide/coqide/coq.ml
@@ -559,7 +559,7 @@ struct
     { opts = [raw_matching]; init = true;
       label = "Display raw _matching expressions" };
     { opts = [notations]; init = true; label = "Display _notations" };
-    { opts = [parentheses]; init = true; label = "Display _parentheses" };
+    { opts = [parentheses]; init = false; label = "Display _parentheses" };
     { opts = [all_basic]; init = false;
       label = "Display _all basic low-level contents" };
     { opts = [existential]; init = false;


### PR DESCRIPTION
**Kind:** bug fix

Continuing #11650 and #12794: it seems more expected to set the default value for `Printing Parentheses` to off (as in `coqtop`).

- [x] Entry added in the changelog (standing for #12794 too).
