### PR TITLE
Use maximal implicit arguments for List functions

### DIFF
--- a/dev/ci/user-overlays/13069-Zimmi48-maximal-implicit-length.sh
+++ b/dev/ci/user-overlays/13069-Zimmi48-maximal-implicit-length.sh
@@ -1,8 +1,2 @@
-if [ "$CI_PULL_REQUEST" = "13069" ] || [ "$CI_BRANCH" = "maximal-implicit-length" ]; then
-
-    paramcoq_CI_REF=overlay-13069
-    paramcoq_CI_GITURL=https://github.com/Zimmi48/paramcoq
-
-    tlc_CI_REF=overlay-13069
-    tlc_CI_GITURL=https://github.com/Zimmi48/tlc
-fi
+overlay paramcoq https://github.com/Zimmi48/paramcoq overlay-13069 13069
+overlay tlc https://github.com/Zimmi48/tlc overlay-13069 13069

--- a/dev/ci/user-overlays/13069-Zimmi48-maximal-implicit-length.sh
+++ b/dev/ci/user-overlays/13069-Zimmi48-maximal-implicit-length.sh
@@ -1,0 +1,8 @@
+if [ "$CI_PULL_REQUEST" = "13069" ] || [ "$CI_BRANCH" = "maximal-implicit-length" ]; then
+
+    paramcoq_CI_REF=overlay-13069
+    paramcoq_CI_GITURL=https://github.com/Zimmi48/paramcoq
+
+    tlc_CI_REF=overlay-13069
+    tlc_CI_GITURL=https://github.com/Zimmi48/tlc
+fi

--- a/dev/ci/user-overlays/13069-Zimmi48-maximal-implicit-length.sh
+++ b/dev/ci/user-overlays/13069-Zimmi48-maximal-implicit-length.sh
@@ -1,2 +1,2 @@
 overlay paramcoq https://github.com/Zimmi48/paramcoq overlay-13069 13069
-overlay tlc https://github.com/Zimmi48/tlc overlay-13069 13069
+overlay tlc https://github.com/anton-trunov/tlc overlay-13069 13069

--- a/test-suite/output/Search.out
+++ b/test-suite/output/Search.out
@@ -404,7 +404,7 @@ Nat.lxor: nat -> nat -> nat
 Nat.of_hex_uint: Hexadecimal.uint -> nat
 Nat.of_uint: Decimal.uint -> nat
 Nat.of_num_uint: Number.uint -> nat
-length: forall [A : Type], list A -> nat
+length: forall {A : Type}, list A -> nat
 plus_n_O: forall n : nat, n = n + 0
 plus_O_n: forall n : nat, 0 + n = n
 plus_n_Sm: forall n m : nat, S (n + m) = n + S m

--- a/test-suite/output/SearchPattern.out
+++ b/test-suite/output/SearchPattern.out
@@ -59,7 +59,7 @@ Nat.of_hex_uint_acc: Hexadecimal.uint -> nat -> nat
 Nat.of_uint_acc: Decimal.uint -> nat -> nat
 Nat.sqrt_iter: nat -> nat -> nat -> nat -> nat
 Nat.log2_iter: nat -> nat -> nat -> nat -> nat
-length: forall [A : Type], list A -> nat
+length: forall {A : Type}, list A -> nat
 Nat.bitwise: (bool -> bool -> bool) -> nat -> nat -> nat -> nat
 Nat.div2: nat -> nat
 Nat.sqrt: nat -> nat

--- a/theories/Init/Datatypes.v
+++ b/theories/Init/Datatypes.v
@@ -326,7 +326,7 @@ Register cons as core.list.cons.
 
 Local Open Scope list_scope.
 
-Definition length (A : Type) : list A -> nat :=
+Definition length {A : Type} : list A -> nat :=
   fix length l :=
   match l with
    | nil => O

--- a/theories/Init/Datatypes.v
+++ b/theories/Init/Datatypes.v
@@ -335,7 +335,7 @@ Definition length {A : Type} : list A -> nat :=
 
 (** Concatenation of two lists *)
 
-Definition app (A : Type) : list A -> list A -> list A :=
+Definition app {A : Type} : list A -> list A -> list A :=
   fix app l m :=
   match l with
    | nil => m

--- a/theories/Lists/ListSet.v
+++ b/theories/Lists/ListSet.v
@@ -483,11 +483,11 @@ End first_definitions.
 
 Section other_definitions.
 
-  Definition set_prod : forall {A B:Type}, set A -> set B -> set (A * B) :=
+  Definition set_prod {A B : Type} : set A -> set B -> set (A * B) :=
     list_prod.
 
   (** [B^A], set of applications from [A] to [B] *)
-  Definition set_power : forall {A B:Type}, set A -> set B -> set (set (A * B)) :=
+  Definition set_power {A B : Type} : set A -> set B -> set (set (A * B)) :=
     list_power.
 
   Definition set_fold_left {A B:Type} : (B -> A -> B) -> set A -> B -> B :=


### PR DESCRIPTION
**Kind:** enhancement.

Prompted by @roglo who complained about not being able to do `List.map length`. For now, I'm mostly opening the PR to assess the compatibility impact. If it is limited, a question would be then: what else should change like this?

Looks like we need these functions to have their type parameters maximally-inserted:
- [x] `length : forall {A : Type}, seq A -> nat`
- [x] `app : forall {A : Type}, seq A -> seq A -> seq A`
- [ ] `rev': forall {A : Type}, list A -> list A`
- [ ] `last: forall {A : Type}, list A -> A -> A`
- [ ] `rev: forall {A : Type}, list A -> list A`
- [ ] `hd: forall {A : Type}, A -> list A -> A`
- [ ] `removelast: forall {A : Type}, list A -> list A`
- [ ] `tl: forall {A : Type}, list A -> list A`
- [ ] `concat: forall {A : Type}, list (list A) -> list A`
- [ ] `repeat: forall {A : Type}, A -> nat -> list A`
- [ ] `hd_error: forall {A : Type}, list A -> option A`
- [ ] `rev_append: forall {A : Type}, list A -> list A -> list A`
- [ ] `nth: forall {A : Type}, nat -> list A -> A -> A`
- [ ] `existsb: forall {A : Type}, (A -> bool) -> list A -> bool`
- [ ] `skipn: forall {A : Type}, nat -> list A -> list A`
- [ ] `firstn: forall {A : Type}, nat -> list A -> list A`
- [ ] `forallb: forall {A : Type}, (A -> bool) -> list A -> bool`
- [ ] `nth_default: forall {A : Type}, A -> list A -> nat -> A`
- [ ] `map: forall {A B : Type}, (A -> B) -> list A -> list B`
- [ ] `filter: forall {A : Type}, (A -> bool) -> list A -> list A`
- [ ] `nth_error: forall {A : Type}, list A -> nat -> option A`
- [ ] `flat_map: forall {A B : Type}, (A -> list B) -> list A -> list B`
- [ ] `fold_left: forall {A B : Type}, (A -> B -> A) -> list B -> A -> A`
- [ ] `nth_ok: forall {A : Type}, nat -> list A -> A -> bool`
- [ ] `fold_right: forall {A B : Type}, (B -> A -> A) -> A -> list B -> A`
- [ ] `find: forall {A : Type}, (A -> bool) -> list A -> option A`
- [ ] `list_prod: forall {A B : Type}, list A -> list B -> list (A * B)`
- [ ] `combine: forall {A B : Type}, list A -> list B -> list (A * B)`
- [ ] `split: forall {A B : Type}, list (A * B) -> list A * list B`
- [ ] `list_power: forall {A B : Type}, list A -> list B -> list (list (A * B))`
- [ ] `partition: forall {A : Type}, (A -> bool) -> list A -> list A * list A`

Overlays:
- [x] https://github.com/charguer/tlc/pull/6

<!-- (Otherwise, remove this line.) -->
- [x] Added / updated test-suite
<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [ ] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [ ] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
