### PR TITLE
Do not call unification heuristics before resolving TC

### DIFF
--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -1107,11 +1107,6 @@ let initial_select_evars filter =
     Typeclasses.is_class_evar evd evi
 
 let resolve_typeclass_evars debug depth unique env evd filter split fail =
-  let evd =
-    try Evarconv.solve_unif_constraints_with_heuristics
-      ~flags:(Evarconv.default_flags_of (Typeclasses.classes_transparent_state ())) env evd
-    with e when CErrors.noncritical e -> evd
-  in
     resolve_all_evars debug depth unique env
                       (initial_select_evars filter) evd split fail
 


### PR DESCRIPTION
Trying to understand what kind of failures we get if we remove these heuristics.