### PR TITLE
Fix issue #13065 - Windows CI broken

### DIFF
--- a/dev/build/windows/patches_coq/ocaml-4.08.1.patch
+++ b/dev/build/windows/patches_coq/ocaml-4.08.1.patch
@@ -1,0 +1,25 @@
+diff --git a/runtime/caml/misc.h b/runtime/caml/misc.h
+index 6aa98516b..8184c2797 100644
+--- a/runtime/caml/misc.h
++++ b/runtime/caml/misc.h
+@@ -327,7 +327,6 @@ extern void caml_set_fields (intnat v, uintnat, uintnat);
+ 
+ #if defined(_WIN32) && !defined(_UCRT)
+ extern int caml_snprintf(char * buf, size_t size, const char * format, ...);
+-#define snprintf caml_snprintf
+ #endif
+ 
+ #ifdef CAML_INSTR
+@@ -336,6 +335,12 @@ extern int caml_snprintf(char * buf, size_t size, const char * format, ...);
+ #include <time.h>
+ #include <stdio.h>
+ 
++/* snprintf emulation for Win32 - do define after stdio.h, in case snprintf is defined */
++
++#if defined(_WIN32) && !defined(_UCRT)
++#define snprintf caml_snprintf
++#endif
++
+ extern intnat caml_stat_minor_collections;
+ extern intnat caml_instr_starttime, caml_instr_stoptime;
+ 


### PR DESCRIPTION
Fix the build issues of OCaml after the update of header files in Cygwin.

The root cause is that a function which was not defined and is emulated in OCaml is now defined so the compilation of the emulation function fails.

The fix is not terribly elegant - it would be better to use configure scripts to detect the availability of the function - the current fix keeps the emulation function.

**Kind:** bug fix

Fixes / closes part of #13065 
