### PR TITLE
Generically interleave hashconsing with hash computation

### DIFF
--- a/clib/cSet.mli
+++ b/clib/cSet.mli
@@ -20,14 +20,8 @@ module Make(M : OrderedType) : S
   with type elt = M.t
   and type t = Set.Make(M).t
 
-module type HashedType =
-sig
-  type t
-  val hash : t -> int
-end
-
-module Hashcons (M : OrderedType) (H : HashedType with type t = M.t) : Hashcons.S with
+module Hashcons (M : OrderedType) : Hashcons.S with
   type t = Set.Make(M).t
-  and type u = M.t -> M.t
+  and type u = M.t Hashcons.hfun
 (** Create hash-consing for sets. The hashing function provided must be
     compatible with the comparison function. *)

--- a/clib/cString.ml
+++ b/clib/cString.ml
@@ -28,7 +28,7 @@ sig
   module Set : Set.S with type elt = t
   module Map : CMap.ExtS with type key = t and module Set := Set
   module List : CList.MonoS with type elt = t
-  val hcons : string -> string
+  val hcons : string Hashcons.hfun
 end
 
 include String

--- a/clib/cString.mli
+++ b/clib/cString.mli
@@ -65,7 +65,7 @@ sig
   module List : CList.MonoS with type elt = t
   (** Association lists with [string] as keys *)
 
-  val hcons : string -> string
+  val hcons : string Hashcons.hfun
   (** Hashconsing on [string] *)
 
 end

--- a/clib/hashcons.mli
+++ b/clib/hashcons.mli
@@ -10,6 +10,10 @@
 
 (** Generic hash-consing. *)
 
+type 'a hfun = 'a -> 'a * int
+
+val hfun : 'a hfun -> 'a -> 'a
+
 (** {6 Hashconsing functorial interface} *)
 
 module type HashconsedType =
@@ -34,20 +38,23 @@ module type HashconsedType =
     (** Type of hashcons functions for the sub-structures contained in [t].
         Usually a tuple of functions. *)
 
-    val hashcons :  u -> t -> t
+    val hashcons :  u -> t hfun
     (** The actual hashconsing function, using its fist argument to recursively
-        hashcons substructures. It should be compatible with [eq], that is
-        [eq x (hashcons f x) = true]. *)
+        hashcons substructures. For efficiency over recursive types, this
+        function must also return the hash of the argument.
+
+        The returned value should be compatible with [eq], that is
+        [eq x (fst (hashcons f x)) = true].
+
+        Similarly the hash must be compatible with [eq], i.e. if [eq x y = true]
+        then [snd (hashcons f x) == (hashcons f y)].
+    *)
 
     val eq : t -> t -> bool
     (** A comparison function. It is allowed to use physical equality
         on the sub-terms hashconsed by the [hashcons] function, but it should be
         insensible to shallow copy of the compared object. *)
 
-    val hash : t -> int
-    (** A hash function passed to the underlying hashtable structure. [hash]
-        should be compatible with [eq], i.e. if [eq x y = true] then
-        [hash x = hash y]. *)
   end
 
 module type S =
@@ -64,8 +71,9 @@ module type S =
     val generate : u -> table
     (** This create a hashtable of the hashconsed objects. *)
 
-    val hcons : table -> t -> t
-    (** Perform the hashconsing of the given object within the table. *)
+    val hcons : table -> t hfun
+    (** Perform the hashconsing of the given object within the table and also
+        returns the hash. *)
 
     val stats : table -> Hashset.statistics
     (** Recover statistics of the hashconsing table. *)
@@ -79,20 +87,20 @@ module Make (X : HashconsedType) : (S with type t = X.t and type u = X.u)
 (** These are intended to be used together with instances of the [Make]
     functor. *)
 
-val simple_hcons : ('u -> 'tab) -> ('tab -> 't -> 't) -> 'u -> 't -> 't
+val simple_hcons : ('u -> 'tab) -> ('tab -> 't hfun) -> 'u -> 't hfun
 (** [simple_hcons f sub obj] creates a new table each time it is applied to any
     sub-hash function [sub]. *)
 
-val recursive_hcons : (('t -> 't) * 'u -> 'tab) -> ('tab -> 't -> 't) -> ('u -> 't -> 't)
+val recursive_hcons : ('t hfun * 'u -> 'tab) -> ('tab -> 't hfun) -> ('u -> 't hfun)
 (** As [simple_hcons] but intended to be used with well-founded data structures. *)
 
 (** {6 Hashconsing of usual structures} *)
 
-module type HashedType = sig type t val hash : t -> int end
+module type PType = sig type t end
 
 module Hstring : (S with type t = string and type u = unit)
 (** Hashconsing of strings.  *)
 
-module Hlist (D:HashedType) :
-  (S with type t = D.t list and type u = (D.t list -> D.t list)*(D.t->D.t))
+module Hlist (D:PType) :
+  (S with type t = D.t list and type u = (D.t list -> D.t list * int)*(D.t->D.t * int))
 (** Hashconsing of lists.  *)

--- a/kernel/constr.ml
+++ b/kernel/constr.ml
@@ -1392,8 +1392,6 @@ let hashcons (sh_sort,sh_ci,sh_construct,sh_ind,sh_con,sh_na,sh_id) =
 
   and sh_rec t =
     let (y, h) = hash_term t in
-    (* [h] must be positive. *)
-    let h = h land 0x3FFFFFFF in
     (HashsetTerm.repr h y term_table, h)
 
   (* Note : During hash-cons of arrays, we modify them *in place* *)
@@ -1405,8 +1403,7 @@ let hashcons (sh_sort,sh_ci,sh_construct,sh_ind,sh_con,sh_na,sh_id) =
       accu := combine !accu h;
       Array.unsafe_set t i x
     done;
-    (* [h] must be positive. *)
-    let h = !accu land 0x3FFFFFFF in
+    let h = !accu in
     (HashsetTermArray.repr h t term_array_table, h)
 
   and hash_list_array l =
@@ -1415,7 +1412,7 @@ let hashcons (sh_sort,sh_ci,sh_construct,sh_ind,sh_con,sh_na,sh_id) =
       (combine accu h, c)
     in
     let h, l = List.fold_left_map fold 0 l in
-    (l, h land 0x3FFFFFFF)
+    (l, h)
 
   and hash_name_array lna =
     let h = ref 0 in

--- a/kernel/context.ml
+++ b/kernel/context.ml
@@ -39,6 +39,11 @@ let eq_annot eq {binder_name=na1;binder_relevance=r1} {binder_name=na2;binder_re
 let hash_annot h {binder_name=n;binder_relevance=r} =
   Hashset.Combine.combinesmall (Sorts.relevance_hash r) (h n)
 
+let hcons_annot f {binder_name= n ; binder_relevance = r} =
+  let n, hn = f n in
+  let ans = { binder_name = n; binder_relevance = r } in
+  ans, Hashset.Combine.combinesmall (Sorts.relevance_hash r) hn
+
 let map_annot f {binder_name=na;binder_relevance} =
   {binder_name=f na;binder_relevance}
 

--- a/kernel/context.mli
+++ b/kernel/context.mli
@@ -28,6 +28,7 @@ type 'a binder_annot = { binder_name : 'a; binder_relevance : Sorts.relevance }
 val eq_annot : ('a -> 'a -> bool) -> 'a binder_annot -> 'a binder_annot -> bool
 
 val hash_annot : ('a -> int) -> 'a binder_annot -> int
+val hcons_annot : 'a Hashcons.hfun -> 'a binder_annot Hashcons.hfun
 
 val map_annot : ('a -> 'b) -> 'a binder_annot -> 'b binder_annot
 

--- a/kernel/declareops.ml
+++ b/kernel/declareops.ml
@@ -48,11 +48,11 @@ let map_decl_arity f g = function
   | TemplateArity a -> TemplateArity (g a)
 
 let hcons_template_arity ar =
-  { template_level = Univ.hcons_univ ar.template_level; }
+  { template_level = Hashcons.hfun Univ.hcons_univ ar.template_level; }
 
 let hcons_template_universe ar =
   { template_param_levels = ar.template_param_levels;
-    template_context = Univ.hcons_universe_context_set ar.template_context }
+    template_context = Hashcons.hfun Univ.hcons_universe_context_set ar.template_context }
 
 let universes_context = function
   | Monomorphic _ -> Univ.AUContext.empty
@@ -129,7 +129,7 @@ let subst_const_body sub cb =
     themselves. But would it really bring substantial gains ? *)
 
 let hcons_rel_decl =
-  RelDecl.map_name Names.Name.hcons %> RelDecl.map_value Constr.hcons %> RelDecl.map_type Constr.hcons
+  RelDecl.map_name (Hashcons.hfun Names.Name.hcons) %> RelDecl.map_value Constr.hcons %> RelDecl.map_type Constr.hcons
 
 let hcons_rel_context l = List.Smart.map hcons_rel_decl l
 
@@ -144,9 +144,9 @@ let hcons_const_def = function
 let hcons_universes cbu =
   match cbu with
   | Monomorphic ctx ->
-    Monomorphic (Univ.hcons_universe_context_set ctx)
+    Monomorphic (Hashcons.hfun Univ.hcons_universe_context_set ctx)
   | Polymorphic ctx ->
-    Polymorphic (Univ.hcons_abstract_universe_context ctx)
+    Polymorphic (Hashcons.hfun Univ.hcons_abstract_universe_context ctx)
 
 let hcons_const_body cb =
   { cb with
@@ -328,7 +328,7 @@ let relevance_of_projection_repr mib p =
 
 let hcons_regular_ind_arity a =
   { mind_user_arity = Constr.hcons a.mind_user_arity;
-    mind_sort = Sorts.hcons a.mind_sort }
+    mind_sort = Hashcons.hfun Sorts.hcons a.mind_sort }
 
 (** Just as for constants, this hash-consing is quite partial *)
 
@@ -342,10 +342,10 @@ let hcons_mind_packet oib =
   let map (ctx, c) = Context.Rel.map Constr.hcons ctx, Constr.hcons c in
   let nf = Array.Smart.map map oib.mind_nf_lc in
   { oib with
-    mind_typename = Names.Id.hcons oib.mind_typename;
+    mind_typename = Hashcons.hfun Names.Id.hcons oib.mind_typename;
     mind_arity_ctxt = hcons_rel_context oib.mind_arity_ctxt;
     mind_arity = hcons_ind_arity oib.mind_arity;
-    mind_consnames = Array.Smart.map Names.Id.hcons oib.mind_consnames;
+    mind_consnames = Array.Smart.map (Hashcons.hfun Names.Id.hcons) oib.mind_consnames;
     mind_user_lc = user;
     mind_nf_lc = nf }
 
@@ -389,7 +389,7 @@ let rec hcons_structure_field_body sb = match sb with
 and hcons_structure_body sb =
   (** FIXME *)
   let map (l, sfb as fb) =
-    let l' = Names.Label.hcons l in
+    let l' = Hashcons.hfun Names.Label.hcons l in
     let sfb' = hcons_structure_field_body sfb in
     if l == l' && sfb == sfb' then fb else (l', sfb')
   in

--- a/kernel/names.mli
+++ b/kernel/names.mli
@@ -71,7 +71,7 @@ sig
   module List : List.MonoS with type elt = t
   (** Operations over lists of identifiers. *)
 
-  val hcons : t -> t
+  val hcons : t Hashcons.hfun
   (** Hashconsing of identifiers. *)
 
 end
@@ -101,7 +101,7 @@ sig
   val hash : t -> int
   (** Hash over names. *)
 
-  val hcons : t -> t
+  val hcons : t Hashcons.hfun
   (** Hashconsing over names. *)
 
   val print : t -> Pp.t
@@ -152,7 +152,7 @@ sig
   val initial : t
   (** Initial "seed" of the unique identifier generator *)
 
-  val hcons : t -> t
+  val hcons : t Hashcons.hfun
   (** Hashconsing of directory paths. *)
 
   val to_string : t -> string
@@ -198,7 +198,7 @@ sig
   module Set : Set.S with type elt = t
   module Map : Map.ExtS with type key = t and module Set := Set
 
-  val hcons : t -> t
+  val hcons : t Hashcons.hfun
 
 end
 
@@ -521,10 +521,10 @@ val constructor_syntactic_hash : constructor -> int
 
 (** {6 Hash-consing } *)
 
-val hcons_con : Constant.t -> Constant.t
-val hcons_mind : MutInd.t -> MutInd.t
-val hcons_ind : inductive -> inductive
-val hcons_construct : constructor -> constructor
+val hcons_con : Constant.t Hashcons.hfun
+val hcons_mind : MutInd.t Hashcons.hfun
+val hcons_ind : inductive Hashcons.hfun
+val hcons_construct : constructor Hashcons.hfun
 
 (******)
 
@@ -624,7 +624,7 @@ module Projection : sig
 
   val equal : t -> t -> bool
   val hash : t -> int
-  val hcons : t -> t
+  val hcons : t Hashcons.hfun
   (** Hashconsing of projections. *)
 
   val repr_equal : t -> t -> bool

--- a/kernel/opaqueproof.ml
+++ b/kernel/opaqueproof.ml
@@ -60,8 +60,8 @@ let create dp cu tab =
   let hcons (c, u) =
     let c = Constr.hcons c in
     let u = match u with
-    | PrivateMonomorphic u -> PrivateMonomorphic (Univ.hcons_universe_context_set u)
-    | PrivatePolymorphic (n, u) -> PrivatePolymorphic (n, Univ.hcons_universe_context_set u)
+    | PrivateMonomorphic u -> PrivateMonomorphic (Hashcons.hfun Univ.hcons_universe_context_set u)
+    | PrivatePolymorphic (n, u) -> PrivatePolymorphic (n, Hashcons.hfun Univ.hcons_universe_context_set u)
     in
     (c, u)
   in

--- a/kernel/sorts.ml
+++ b/kernel/sorts.ml
@@ -110,19 +110,17 @@ module Hsorts =
     struct
       type _t = t
       type t = _t
-      type u = Universe.t -> Universe.t
+      type u = Universe.t Hashcons.hfun
 
       let hashcons huniv = function
-        | Type u as c ->
-          let u' = huniv u in
-            if u' == u then c else Type u'
-        | s -> s
+        | Type u ->
+          let u', hu = huniv u in
+          Type u', combinesmall 2 hu
+        | (SProp | Prop | Set) as s -> s, hash s
       let eq s1 s2 = match (s1,s2) with
         | Prop, Prop | Set, Set -> true
         | (Type u1, Type u2) -> u1 == u2
         |_ -> false
-
-      let hash = hash
     end)
 
 let hcons = Hashcons.simple_hcons Hsorts.generate Hsorts.hcons hcons_univ

--- a/kernel/sorts.mli
+++ b/kernel/sorts.mli
@@ -35,7 +35,7 @@ val is_prop : t -> bool
 val is_small : t -> bool
 val family : t -> family
 
-val hcons : t -> t
+val hcons : t Hashcons.hfun
 
 val family_compare : family -> family -> int
 val family_equal : family -> family -> bool

--- a/kernel/univ.mli
+++ b/kernel/univ.mli
@@ -293,14 +293,11 @@ sig
   val length : t -> int
   (** Instance length *)
 
-  val hcons : t -> t
+  val hcons : t Hashcons.hfun
   (** Hash-consing. *)
 
   val hash : t -> int
   (** Hash value *)
-
-  val share : t -> t * int
-  (** Simultaneous hash-consing and hash-value computation *)
 
   val subst_fn : universe_level_subst_fn -> t -> t
   (** Substitution by a level-to-level function. *)
@@ -493,9 +490,9 @@ val pr_universe_subst : universe_subst -> Pp.t
 
 (** {6 Hash-consing } *)
 
-val hcons_univ : Universe.t -> Universe.t
-val hcons_constraints : Constraint.t -> Constraint.t
-val hcons_universe_set : LSet.t -> LSet.t
-val hcons_universe_context : UContext.t -> UContext.t
-val hcons_abstract_universe_context : AUContext.t -> AUContext.t
-val hcons_universe_context_set : ContextSet.t -> ContextSet.t
+val hcons_univ : Universe.t Hashcons.hfun
+val hcons_constraints : Constraint.t Hashcons.hfun
+val hcons_universe_set : LSet.t Hashcons.hfun
+val hcons_universe_context : UContext.t Hashcons.hfun
+val hcons_abstract_universe_context : AUContext.t Hashcons.hfun
+val hcons_universe_context_set : ContextSet.t Hashcons.hfun

--- a/kernel/vmemitcodes.ml
+++ b/kernel/vmemitcodes.ml
@@ -485,7 +485,7 @@ let to_memory (init_code, fun_code, fv) =
   emit env fun_code [];
   (** Later uses of this string are all purely functional *)
   let code = Bytes.sub_string env.out_buffer 0 env.out_position in
-  let code = CString.hcons code in
+  let code = Hashcons.hfun CString.hcons code in
   let fold reloc npos accu = (reloc, Array.of_list npos) :: accu in
   let reloc = RelocTable.fold fold env.reloc_info [] in
   let reloc = { reloc_infos = CArray.of_list reloc } in

--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -1695,7 +1695,7 @@ end = struct (* {{{ *)
         (* No need to delay the computation, the future has been forced by
            the call to [check_task_aux] above. *)
         let uc = Opaqueproof.force_constraints Library.indirect_accessor (Global.opaque_tables ()) o in
-        let uc = Univ.hcons_universe_context_set uc in
+        let uc = Hashcons.hfun Univ.hcons_universe_context_set uc in
         let (pr, priv, ctx) = Option.get (Global.body_of_constant_body Library.indirect_accessor c) in
         (* We only manipulate monomorphic terms here. *)
         let () = assert (Univ.AUContext.is_empty ctx) in


### PR DESCRIPTION
This allows to have a better algorithmic complexity for recursive datatypes.
