### PR TITLE
Locating a few tactic datatypes referring to identifiers

### DIFF
--- a/plugins/funind/invfun.ml
+++ b/plugins/funind/invfun.ml
@@ -101,7 +101,7 @@ let functional_inversion kn hid fconst f_correct =
               [applist (f_correct, Array.to_list f_args @ [res; mkVar hid])]
           ; clear [hid]
           ; Simple.intro hid
-          ; Inv.inv Inv.FullInversion None (Tactypes.NamedHyp hid)
+          ; Inv.inv Inv.FullInversion None (Tactypes.NamedHyp (CAst.make hid))
           ; Proofview.Goal.enter (fun gl ->
                 let new_ids =
                   List.filter

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -977,8 +977,8 @@ let rec make_rewrite_list expr_info max = function
                    (* dep proofs also: *) true
                    ( mkVar hp
                    , ExplicitBindings
-                       [ CAst.make @@ (NamedHyp def, expr_info.f_constr)
-                       ; CAst.make @@ (NamedHyp k, f_S max) ] )
+                       [ CAst.make @@ (NamedHyp (CAst.make def), expr_info.f_constr)
+                       ; CAst.make @@ (NamedHyp (CAst.make k), f_S max) ] )
                    false)))
          [ make_rewrite_list expr_info max l
          ; New.observe_tclTHENLIST
@@ -1012,8 +1012,8 @@ let make_rewrite expr_info l hp max =
                     (* dep proofs also: *) true
                     ( mkVar hp
                     , ExplicitBindings
-                        [ CAst.make @@ (NamedHyp def, expr_info.f_constr)
-                        ; CAst.make @@ (NamedHyp k, f_S (f_S max)) ] )
+                        [ CAst.make @@ (NamedHyp (CAst.make def), expr_info.f_constr)
+                        ; CAst.make @@ (NamedHyp (CAst.make k), f_S (f_S max)) ] )
                     false)))
           [ New.observe_tac
               (fun _ _ -> str "make_rewrite finalize")

--- a/plugins/ltac/extratactics.mlg
+++ b/plugins/ltac/extratactics.mlg
@@ -88,7 +88,7 @@ END
 
 let induction_arg_of_quantified_hyp = function
   | AnonHyp n -> None,ElimOnAnonHyp n
-  | NamedHyp id -> None,ElimOnIdent (CAst.make id)
+  | NamedHyp id -> None,ElimOnIdent id
 
 (* Versions *_main must come first!! so that "1" is interpreted as a
    ElimOnAnonHyp and not as a "constr", and "id" is interpreted as a
@@ -764,7 +764,7 @@ let case_eq_intros_rewrite x =
   end
 
 let rec find_a_destructable_match sigma t =
-  let cl = induction_arg_of_quantified_hyp (NamedHyp (Id.of_string "x")) in
+  let cl = induction_arg_of_quantified_hyp (NamedHyp (CAst.make (Id.of_string "x"))) in
   let cl = [cl, (None, None), None], None in
   let dest = TacAtom (CAst.make @@ TacInductionDestruct(false, false, cl)) in
   match EConstr.kind sigma t with

--- a/plugins/ltac/g_ltac.mlg
+++ b/plugins/ltac/g_ltac.mlg
@@ -122,7 +122,7 @@ GRAMMAR EXTEND Gram
       | IDENT "infoH"; ta = ltac_expr -> { TacShowHyps ta }
 (*To do: put Abstract in Refiner*)
       | IDENT "abstract"; tc = NEXT -> { TacAbstract (tc,None) }
-      | IDENT "abstract"; tc = NEXT; "using";  s = ident ->
+      | IDENT "abstract"; tc = NEXT; "using";  s = identref ->
         { TacAbstract (tc,Some s) }
       | IDENT "only"; sel = selector; ":"; ta = ltac_expr -> { TacSelect (sel, ta) } ]
 (*End of To do*)

--- a/plugins/ltac/g_ltac.mlg
+++ b/plugins/ltac/g_ltac.mlg
@@ -231,7 +231,7 @@ GRAMMAR EXTEND Gram
          { (CAst.map (fun id -> Name id) idr, arg_of_expr (TacFun(args,te))) } ] ]
   ;
   match_pattern:
-    [ [ IDENT "context";  oid = OPT Constr.ident;
+    [ [ IDENT "context";  oid = OPT identref;
           "["; pc = Constr.cpattern; "]" ->
         { Subterm (oid, pc) }
       | pc = Constr.cpattern -> { Term pc } ] ]

--- a/plugins/ltac/g_tactic.mlg
+++ b/plugins/ltac/g_tactic.mlg
@@ -130,7 +130,7 @@ let mkTacCase with_evar = function
   (* Reinterpret numbers as a notation for terms *)
   | [(clear,ElimOnAnonHyp n),(None,None),None],None ->
       TacCase (with_evar,
-        (clear,(CAst.make @@ CPrim (mkNumber n),
+        (clear,(CAst.make @@ CPrim (mkNumber n.CAst.v),
          NoBindings)))
   (* Reinterpret ident as notations for variables in the context *)
   (* because we don't know if they are quantified or not *)
@@ -212,7 +212,7 @@ GRAMMAR EXTEND Gram
     [ [ c = constr -> { c } ] ]
   ;
   destruction_arg:
-    [ [ n = natural -> { (None,ElimOnAnonHyp n) }
+    [ [ n = lnatural -> { (None,ElimOnAnonHyp n) }
       | test_lpar_id_rpar; c = constr_with_bindings ->
         { (Some false,destruction_arg_of_constr c) }
       | c = constr_with_bindings_arg -> { on_snd destruction_arg_of_constr c }
@@ -223,8 +223,8 @@ GRAMMAR EXTEND Gram
       | c = constr_with_bindings -> { (None,c) } ] ]
   ;
   quantified_hypothesis:
-    [ [ id = ident -> { NamedHyp id }
-      | n = natural -> { AnonHyp n } ] ]
+    [ [ id = identref -> { NamedHyp id }
+      | n = lnatural -> { AnonHyp n } ] ]
   ;
   conversion:
     [ [ c = constr -> { (None, c) }
@@ -305,9 +305,12 @@ GRAMMAR EXTEND Gram
       | "_" -> { CAst.make ~loc @@ IntroAction IntroWildcard }
       | pat = naming_intropattern -> { CAst.make ~loc @@ IntroNaming pat } ] ]
   ;
+  lnatural:
+    [ [ n = natural -> { CAst.make ~loc n } ] ]
+  ;
   simple_binding:
-    [ [ "("; id = ident; ":="; c = lconstr; ")" -> { CAst.make ~loc (NamedHyp id, c) }
-      | "("; n = natural; ":="; c = lconstr; ")" -> { CAst.make ~loc (AnonHyp n, c) } ] ]
+    [ [ "("; id = identref; ":="; c = lconstr; ")" -> { CAst.make ~loc (NamedHyp id, c) }
+      | "("; n = lnatural; ":="; c = lconstr; ")" -> { CAst.make ~loc (AnonHyp n, c) } ] ]
   ;
   bindings:
     [ [ test_lpar_idnum_coloneq; bl = LIST1 simple_binding ->

--- a/plugins/ltac/pptactic.ml
+++ b/plugins/ltac/pptactic.ml
@@ -538,7 +538,7 @@ let pr_goal_selector ~toplevel s =
     | Subterm (None,a) ->
       keyword "context" ++ str" [ " ++ pr_pat a ++ str " ]"
     | Subterm (Some id,a) ->
-      keyword "context" ++ spc () ++ pr_id id ++ str "[ " ++ pr_pat a ++ str " ]"
+      keyword "context" ++ spc () ++ pr_lident id ++ str "[ " ++ pr_pat a ++ str " ]"
 
   let pr_match_hyps pr_pat = function
     | Hyp (nal,mp) ->

--- a/plugins/ltac/pptactic.ml
+++ b/plugins/ltac/pptactic.ml
@@ -195,8 +195,8 @@ let string_of_genarg_arg (ArgumentType arg) =
     | EvalConstRef sp -> pr_global (GlobRef.ConstRef sp)
 
   let pr_quantified_hypothesis = function
-    | AnonHyp n -> int n
-    | NamedHyp id -> pr_id id
+    | AnonHyp n -> int n.CAst.v
+    | NamedHyp id -> pr_lident id
 
   let pr_clear_flag clear_flag pp x =
     match clear_flag with
@@ -504,7 +504,7 @@ let string_of_genarg_arg (ArgumentType arg) =
   let pr_core_destruction_arg prc prlc = function
     | ElimOnConstr c -> pr_with_bindings prc prlc c
     | ElimOnIdent {CAst.loc;v=id} -> pr_with_comments ?loc (pr_id id)
-    | ElimOnAnonHyp n -> int n
+    | ElimOnAnonHyp {CAst.loc;v=n} -> pr_with_comments ?loc (int n)
 
   let pr_destruction_arg prc prlc (clear_flag,h) =
     pr_clear_flag clear_flag (pr_core_destruction_arg prc prlc) h

--- a/plugins/ltac/pptactic.ml
+++ b/plugins/ltac/pptactic.ml
@@ -896,7 +896,7 @@ let pr_goal_selector ~toplevel s =
               hov 0 (
                 keyword "abstract"
                 ++ str" (" ++ pr_tac (LevelLt labstract) t ++ str")" ++ spc ()
-                ++ keyword "using" ++ spc () ++ pr_id s),
+                ++ keyword "using" ++ spc () ++ pr_lident s),
               labstract
             | TacLetIn (recflag,llc,u) ->
               let llc = List.map (fun (id,t) -> (id,extract_binders t)) llc in

--- a/plugins/ltac/taccoerce.ml
+++ b/plugins/ltac/taccoerce.ml
@@ -357,23 +357,23 @@ let coerce_to_reference sigma v =
 (* (as in Inversion) *)
 let coerce_to_quantified_hypothesis sigma v =
   match is_intro_pattern v with
-  | Some (IntroNaming (IntroIdentifier id)) -> NamedHyp id
+  | Some (IntroNaming (IntroIdentifier id)) -> NamedHyp (CAst.make id)
   | Some _ -> raise (CannotCoerceTo "a quantified hypothesis")
   | None ->
   if has_type v (topwit wit_hyp) then
     let id = out_gen (topwit wit_hyp) v in
-    NamedHyp id
+    NamedHyp (CAst.make id)
   else if has_type v (topwit wit_int) then
-    AnonHyp (out_gen (topwit wit_int) v)
+    AnonHyp (CAst.make (out_gen (topwit wit_int) v))
   else match Value.to_constr v with
-  | Some c when isVar sigma c -> NamedHyp (destVar sigma c)
+  | Some c when isVar sigma c -> NamedHyp (CAst.make (destVar sigma c))
   | _ -> raise (CannotCoerceTo "a quantified hypothesis")
 
 (* Quantified named or numbered hypothesis or hypothesis in context *)
 (* (as in Inversion) *)
 let coerce_to_decl_or_quant_hyp sigma v =
   if has_type v (topwit wit_int) then
-    AnonHyp (out_gen (topwit wit_int) v)
+    AnonHyp (CAst.make (out_gen (topwit wit_int) v))
   else
     try coerce_to_quantified_hypothesis sigma v
     with CannotCoerceTo _ ->

--- a/plugins/ltac/tacexpr.ml
+++ b/plugins/ltac/tacexpr.ml
@@ -65,7 +65,7 @@ type 'a with_bindings_arg = clear_flag * 'a with_bindings
 (* Type of patterns *)
 type 'a match_pattern =
   | Term of 'a
-  | Subterm of Id.t option * 'a
+  | Subterm of lident option * 'a
 
 (* Type of hypotheses for a Match Context rule *)
 type 'a match_context_hyps =

--- a/plugins/ltac/tacexpr.ml
+++ b/plugins/ltac/tacexpr.ml
@@ -222,7 +222,7 @@ and 'a gen_tactic_expr =
   | TacProgress of 'a gen_tactic_expr
   | TacShowHyps of 'a gen_tactic_expr
   | TacAbstract of
-      'a gen_tactic_expr * Id.t option
+      'a gen_tactic_expr * 'n option
   | TacId of 'n message_token list
   | TacFail of global_flag * int or_var * 'n message_token list
   | TacLetIn of rec_flag *

--- a/plugins/ltac/tacexpr.mli
+++ b/plugins/ltac/tacexpr.mli
@@ -221,7 +221,7 @@ and 'a gen_tactic_expr =
   | TacProgress of 'a gen_tactic_expr
   | TacShowHyps of 'a gen_tactic_expr
   | TacAbstract of
-      'a gen_tactic_expr * Id.t option
+      'a gen_tactic_expr * 'n option
   | TacId of 'n message_token list
   | TacFail of global_flag * int or_var * 'n message_token list
   | TacLetIn of rec_flag *

--- a/plugins/ltac/tacexpr.mli
+++ b/plugins/ltac/tacexpr.mli
@@ -65,7 +65,7 @@ type 'a with_bindings_arg = clear_flag * 'a with_bindings
 (* Type of patterns *)
 type 'a match_pattern =
   | Term of 'a
-  | Subterm of Id.t option * 'a
+  | Subterm of lident option * 'a
 
 (* Type of hypotheses for a Match Context rule *)
 type 'a match_context_hyps =

--- a/plugins/ltac/tacintern.ml
+++ b/plugins/ltac/tacintern.ml
@@ -486,7 +486,7 @@ let name_cons accu = function
 
 let opt_cons accu = function
 | None -> accu
-| Some id -> Id.Set.add id accu
+| Some {CAst.v=id} -> Id.Set.add id accu
 
 (* Reads the hypotheses of a "match goal" rule *)
 let rec intern_match_goal_hyps ist ?(as_type=false) lfun = function

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -898,14 +898,14 @@ let interp_binding_name ist env sigma = function
       (* If a name is bound, it has to be a quantified hypothesis *)
       (* user has to use other names for variables if these ones clash with *)
       (* a name intended to be used as a (non-variable) identifier *)
-      try try_interp_ltac_var (coerce_to_quantified_hypothesis sigma) ist (Some (env,sigma)) (make id)
+      try try_interp_ltac_var (coerce_to_quantified_hypothesis sigma) ist (Some (env,sigma)) id
       with Not_found -> NamedHyp id
 
 let interp_declared_or_quantified_hypothesis ist env sigma = function
   | AnonHyp n -> AnonHyp n
   | NamedHyp id ->
       try try_interp_ltac_var
-            (coerce_to_decl_or_quant_hyp sigma) ist (Some (env,sigma)) (make id)
+            (coerce_to_decl_or_quant_hyp sigma) ist (Some (env,sigma)) id
       with Not_found -> NamedHyp id
 
 let interp_binding ist env sigma {loc;v=(b,c)} =
@@ -951,20 +951,20 @@ let interp_destruction_arg ist gl arg =
         interp_open_constr_with_bindings ist env sigma c
       end
   | keep,ElimOnAnonHyp n as x -> x
-  | keep,ElimOnIdent {loc;v=id} ->
+  | keep,ElimOnIdent ({loc;v=id} as lid) ->
       let error () = user_err ?loc
        (strbrk "Cannot coerce " ++ Id.print id ++
         strbrk " neither to a quantified hypothesis nor to a term.")
       in
-      let try_cast_id id' =
-        if Tactics.is_quantified_hypothesis id' gl
-        then keep,ElimOnIdent (make ?loc id')
+      let try_cast_id lid =
+        if Tactics.is_quantified_hypothesis lid gl
+        then keep,ElimOnIdent lid
         else
           (keep, ElimOnConstr begin fun env sigma ->
-          try (sigma, (constr_of_id env id', NoBindings))
+          try (sigma, (constr_of_id env lid.CAst.v, NoBindings))
           with Not_found ->
             user_err ?loc  ~hdr:"interp_destruction_arg" (
-            Id.print id ++ strbrk " binds to " ++ Id.print id' ++ strbrk " which is neither a declared nor a quantified hypothesis.")
+            Id.print id ++ strbrk " binds to " ++ Id.print lid.CAst.v ++ strbrk " which is neither a declared nor a quantified hypothesis.")
           end)
       in
       try
@@ -973,20 +973,20 @@ let interp_destruction_arg ist gl arg =
         if has_type v (topwit wit_intro_pattern) then
           let v = out_gen (topwit wit_intro_pattern) v in
           match v with
-          | {v=IntroNaming (IntroIdentifier id)} -> try_cast_id id
+          | {loc;v=IntroNaming (IntroIdentifier id)} -> try_cast_id (CAst.make ?loc id)
           | _ -> error ()
         else if has_type v (topwit wit_hyp) then
           let id = out_gen (topwit wit_hyp) v in
-          try_cast_id id
+          try_cast_id (CAst.make id)
         else if has_type v (topwit wit_int) then
-          keep,ElimOnAnonHyp (out_gen (topwit wit_int) v)
+          keep,ElimOnAnonHyp (CAst.make (out_gen (topwit wit_int) v))
         else match Value.to_constr v with
         | None -> error ()
         | Some c -> keep,ElimOnConstr (fun env sigma -> (sigma, (c,NoBindings)))
       with Not_found ->
         (* We were in non strict (interactive) mode *)
-        if Tactics.is_quantified_hypothesis id gl then
-          keep,ElimOnIdent (make ?loc id)
+        if Tactics.is_quantified_hypothesis lid gl then
+          keep,ElimOnIdent lid
         else
           let c = (DAst.make ?loc @@ GVar id,Some (make @@ CRef (qualid_of_ident ?loc id,None))) in
           let f env sigma =

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -356,6 +356,9 @@ let interp_ident ist env sigma id =
   try try_interp_ltac_var (coerce_var_to_ident false env sigma) ist (Some (env,sigma)) (make id)
   with Not_found -> id
 
+let interp_lident ist env sigma id =
+  interp_ident ist env sigma id.CAst.v
+
 (* Interprets an optional identifier, bound or fresh *)
 let interp_name ist env sigma = function
   | Anonymous -> Anonymous
@@ -1144,7 +1147,7 @@ and eval_tactic_ist ist tac : unit Proofview.tactic = match tac with
       Profile_ltac.do_profile "eval_tactic:TacAbstract" trace
         (catch_error_tac trace begin
       Proofview.Goal.enter begin fun gl -> Abstract.tclABSTRACT
-        (Option.map (interp_ident ist (pf_env gl) (project gl)) ido) (interp_tactic ist t)
+        (Option.map (interp_lident ist (pf_env gl) (project gl)) ido) (interp_tactic ist t)
       end end)
   | TacThen (t1,t) ->
       Tacticals.New.tclTHEN (interp_tactic ist t1) (interp_tactic ist t)

--- a/plugins/ltac/tactic_matching.ml
+++ b/plugins/ltac/tactic_matching.ml
@@ -47,7 +47,7 @@ let adjust : Constr_matching.bound_ident_map * Ltac_pretype.patvar_map ->
 (** Adds a binding to a {!Id.Map.t} if the identifier is [Some id] *)
 let id_map_try_add id x m =
   match id with
-  | Some id -> Id.Map.add id (Lazy.force x) m
+  | Some {CAst.v=id} -> Id.Map.add id (Lazy.force x) m
   | None -> m
 
 (** Adds a binding to a {!Id.Map.t} if the name is [Name id] *)

--- a/proofs/miscprint.ml
+++ b/proofs/miscprint.ml
@@ -45,8 +45,8 @@ and pr_or_and_intro_pattern prc = function
 
 (** Printing of bindings *)
 let pr_binding prc = let open CAst in function
-  | {loc;v=(NamedHyp id, c)} -> hov 1 (Names.Id.print id ++ str " := " ++ cut () ++ prc c)
-  | {loc;v=(AnonHyp n, c)} -> hov 1 (int n ++ str " := " ++ cut () ++ prc c)
+  | {loc;v=(NamedHyp CAst.{v=id}, c)} -> hov 1 (Id.print id ++ str " := " ++ cut () ++ prc c)
+  | {loc;v=(AnonHyp CAst.{v=n}, c)} -> hov 1 (int n ++ str " := " ++ cut () ++ prc c)
 
 let pr_bindings prc prlc = function
   | ImplicitBindings l ->

--- a/proofs/tactypes.ml
+++ b/proofs/tactypes.ml
@@ -32,7 +32,7 @@ and 'constr or_and_intro_pattern_expr =
 
 (** Bindings *)
 
-type quantified_hypothesis = AnonHyp of int | NamedHyp of Id.t
+type quantified_hypothesis = AnonHyp of int CAst.t | NamedHyp of lident
 
 type 'a explicit_bindings = (quantified_hypothesis * 'a) CAst.t list
 

--- a/tactics/inv.ml
+++ b/tactics/inv.ml
@@ -529,13 +529,13 @@ let inv_gen thin status names =
 
 let inv k = inv_gen k NoDep
 
-let inv_tac id       = inv FullInversion None (NamedHyp id)
-let inv_clear_tac id = inv FullInversionClear None (NamedHyp id)
+let inv_tac id       = inv FullInversion None (NamedHyp (CAst.make id))
+let inv_clear_tac id = inv FullInversionClear None (NamedHyp (CAst.make id))
 
 let dinv k c = inv_gen k (Dep c)
 
-let dinv_tac id       = dinv FullInversion None None (NamedHyp id)
-let dinv_clear_tac id = dinv FullInversionClear None None (NamedHyp id)
+let dinv_tac id       = dinv FullInversion None None (NamedHyp (CAst.make id))
+let dinv_clear_tac id = dinv FullInversionClear None None (NamedHyp (CAst.make id))
 
 (* InvIn will bring the specified clauses into the conclusion, and then
  * perform inversion on the named hypothesis.  After, it will intro them

--- a/tactics/tactics.mli
+++ b/tactics/tactics.mli
@@ -28,7 +28,7 @@ open Ltac_pretype
 
 (** {6 General functions. } *)
 
-val is_quantified_hypothesis : Id.t -> Proofview.Goal.t -> bool
+val is_quantified_hypothesis : lident -> Proofview.Goal.t -> bool
 
 (** {6 Primitive tactics. } *)
 
@@ -110,7 +110,7 @@ type clear_flag = bool option (* true = clear hyp, false = keep hyp, None = use 
 type 'a core_destruction_arg =
   | ElimOnConstr of 'a
   | ElimOnIdent of lident
-  | ElimOnAnonHyp of int
+  | ElimOnAnonHyp of int CAst.t
 
 type 'a destruction_arg =
   clear_flag * 'a core_destruction_arg

--- a/user-contrib/Ltac2/tac2extffi.ml
+++ b/user-contrib/Ltac2/tac2extffi.ml
@@ -19,8 +19,8 @@ let make_to_repr f = Tac2ffi.make_repr (fun _ -> assert false) f
 (** More ML representations *)
 
 let to_qhyp v = match Value.to_block v with
-| (0, [| i |]) -> AnonHyp (Value.to_int i)
-| (1, [| id |]) -> NamedHyp (Value.to_ident id)
+| (0, [| i |]) -> AnonHyp (CAst.make (Value.to_int i))
+| (1, [| id |]) -> NamedHyp (CAst.make (Value.to_ident id))
 | _ -> assert false
 
 let qhyp = make_to_repr to_qhyp

--- a/user-contrib/Ltac2/tac2stdlib.ml
+++ b/user-contrib/Ltac2/tac2stdlib.ml
@@ -124,8 +124,8 @@ let to_destruction_arg v = match Value.to_block v with
 | (0, [| c |]) ->
   let c = uthaw constr_with_bindings c in
   ElimOnConstr c
-| (1, [| id |]) -> ElimOnIdent (Value.to_ident id)
-| (2, [| n |]) -> ElimOnAnonHyp (Value.to_int n)
+| (1, [| id |]) -> ElimOnIdent (CAst.make (Value.to_ident id))
+| (2, [| n |]) -> ElimOnAnonHyp (CAst.make (Value.to_int n))
 | _ -> assert false
 
 let destruction_arg = make_to_repr to_destruction_arg

--- a/user-contrib/Ltac2/tac2tactics.ml
+++ b/user-contrib/Ltac2/tac2tactics.ml
@@ -112,7 +112,7 @@ let mk_destruction_arg = function
 | ElimOnConstr c ->
   let c = c >>= fun c -> return (mk_with_bindings c) in
   Tactics.ElimOnConstr (delayed_of_tactic c)
-| ElimOnIdent id -> Tactics.ElimOnIdent CAst.(make id)
+| ElimOnIdent id -> Tactics.ElimOnIdent id
 | ElimOnAnonHyp n -> Tactics.ElimOnAnonHyp n
 
 let mk_induction_clause (arg, eqn, as_, occ) =
@@ -347,7 +347,7 @@ let on_destruction_arg tac ev arg =
       let flags = tactic_infer_flags ev in
       let (sigma', c) = Unification.finish_evar_resolution ~flags env sigma' (sigma, c) in
       Proofview.tclUNIT (Some sigma', Tactics.ElimOnConstr (c, lbind))
-    | ElimOnIdent id -> Proofview.tclUNIT (None, Tactics.ElimOnIdent CAst.(make id))
+    | ElimOnIdent id -> Proofview.tclUNIT (None, Tactics.ElimOnIdent id)
     | ElimOnAnonHyp n -> Proofview.tclUNIT (None, Tactics.ElimOnAnonHyp n)
     in
     arg >>= fun (sigma', arg) ->
@@ -433,13 +433,13 @@ let inversion knd arg pat ids =
     | None -> assert false
     | Some (_, Tactics.ElimOnAnonHyp n) ->
       Inv.inv_clause knd pat ids (AnonHyp n)
-    | Some (_, Tactics.ElimOnIdent {CAst.v=id}) ->
+    | Some (_, Tactics.ElimOnIdent id) ->
       Inv.inv_clause knd pat ids (NamedHyp id)
     | Some (_, Tactics.ElimOnConstr c) ->
       let open Tactypes in
       let anon = CAst.make @@ IntroNaming Namegen.IntroAnonymous in
       Tactics.specialize c (Some anon) >>= fun () ->
-      Tacticals.New.onLastHypId (fun id -> Inv.inv_clause knd pat ids (NamedHyp id))
+      Tacticals.New.onLastHypId (fun id -> Inv.inv_clause knd pat ids (NamedHyp (CAst.make id)))
     end
   in
   on_destruction_arg inversion true (Some (None, arg))

--- a/user-contrib/Ltac2/tac2types.mli
+++ b/user-contrib/Ltac2/tac2types.mli
@@ -20,8 +20,8 @@ type advanced_flag = bool
 type 'a thunk = (unit, 'a) Tac2ffi.fun1
 
 type quantified_hypothesis = Tactypes.quantified_hypothesis =
-| AnonHyp of int
-| NamedHyp of Id.t
+| AnonHyp of int CAst.t
+| NamedHyp of Id.t CAst.t
 
 type explicit_bindings = (quantified_hypothesis * EConstr.t) list
 
@@ -34,8 +34,8 @@ type constr_with_bindings = EConstr.constr * bindings
 
 type core_destruction_arg =
 | ElimOnConstr of constr_with_bindings tactic
-| ElimOnIdent of Id.t
-| ElimOnAnonHyp of int
+| ElimOnIdent of Id.t CAst.t
+| ElimOnAnonHyp of int CAst.t
 
 type destruction_arg = core_destruction_arg
 


### PR DESCRIPTION
**Kind:** enhancement

This is part of the project started in [#11842](https://github.com/coq/coq/pull/11842#issuecomment-699600005).

This should eventually give more precise error locations but there are apparently still some issues with the grain of tactic error reporting. At the current time, this is mostly a step towards #11842.


