### PR TITLE
Locating identifiers in a few plugin commands

### DIFF
--- a/interp/stdarg.ml
+++ b/interp/stdarg.ml
@@ -43,6 +43,9 @@ let wit_nat_or_var =
 let wit_ident =
   make0 "ident"
 
+let wit_identref =
+  make0 "identref"
+
 let wit_hyp =
   make0 ~dyn:(val_tag (topwit wit_ident)) "hyp"
 

--- a/interp/stdarg.mli
+++ b/interp/stdarg.mli
@@ -39,6 +39,8 @@ val wit_nat_or_var : (int or_var, int or_var, int) genarg_type
 
 val wit_ident : Id.t uniform_genarg_type
 
+val wit_identref : (lident, lident, Id.t) genarg_type
+
 val wit_hyp : (lident, lident, Id.t) genarg_type
 
 val wit_var : (lident, lident, Id.t) genarg_type

--- a/parsing/pcoq.ml
+++ b/parsing/pcoq.ml
@@ -506,6 +506,7 @@ let () =
   Grammar.register0 wit_int (Prim.integer);
   Grammar.register0 wit_string (Prim.string);
   Grammar.register0 wit_pre_ident (Prim.preident);
+  Grammar.register0 wit_identref (Prim.identref);
   Grammar.register0 wit_ident (Prim.ident);
   Grammar.register0 wit_hyp (Prim.hyp);
   Grammar.register0 wit_ref (Prim.reference);

--- a/plugins/derive/g_derive.mlg
+++ b/plugins/derive/g_derive.mlg
@@ -23,6 +23,6 @@ let classify_derive_command _ = Vernacextend.(VtStartProof (Doesn'tGuaranteeOpac
 }
 
 VERNAC COMMAND EXTEND Derive CLASSIFIED BY { classify_derive_command } STATE open_proof
-| [ "Derive" ident(f) "SuchThat" constr(suchthat) "As" ident(lemma) ] ->
-  { Derive.start_deriving f suchthat lemma }
+| [ "Derive" identref(f) "SuchThat" constr(suchthat) "As" identref(lemma) ] ->
+  { Derive.start_deriving f.CAst.v suchthat lemma.CAst.v }
 END

--- a/plugins/extraction/extract_env.ml
+++ b/plugins/extraction/extract_env.ml
@@ -643,11 +643,11 @@ let simple_extraction r =
 (*s (Recursive) Extraction of a library. The vernacular command is
   \verb!(Recursive) Extraction Library! [M]. *)
 
-let extraction_library is_rec m =
+let extraction_library is_rec CAst.{loc;v=m} =
   init true true;
   let dir_m =
     let q = qualid_of_ident m in
-    try Nametab.full_name_module q with Not_found -> error_unknown_module q
+    try Nametab.full_name_module q with Not_found -> error_unknown_module ?loc q
   in
   Visit.add_mp_all (MPfile dir_m);
   let env = Global.env () in

--- a/plugins/extraction/extract_env.mli
+++ b/plugins/extraction/extract_env.mli
@@ -16,7 +16,7 @@ open Libnames
 val simple_extraction : qualid -> unit
 val full_extraction : string option -> qualid list -> unit
 val separate_extraction : qualid list -> unit
-val extraction_library : bool -> Id.t -> unit
+val extraction_library : bool -> lident -> unit
 
 (* For the test-suite : extraction to a temporary file + ocamlc on it *)
 

--- a/plugins/extraction/g_extraction.mlg
+++ b/plugins/extraction/g_extraction.mlg
@@ -94,12 +94,12 @@ END
 
 (* Modular extraction (one Coq library = one ML module) *)
 VERNAC COMMAND EXTEND ExtractionLibrary CLASSIFIED AS QUERY
-| [ "Extraction" "Library" ident(m) ]
+| [ "Extraction" "Library" identref(m) ]
   -> { extraction_library false m }
 END
 
 VERNAC COMMAND EXTEND RecursiveExtractionLibrary CLASSIFIED AS QUERY
-| [ "Recursive" "Extraction" "Library" ident(m) ]
+| [ "Recursive" "Extraction" "Library" identref(m) ]
   -> { extraction_library true m }
 END
 
@@ -138,7 +138,7 @@ END
 
 VERNAC COMMAND EXTEND ExtractionBlacklist CLASSIFIED AS SIDEFF
 (* Force Extraction to not use some filenames *)
-| [ "Extraction" "Blacklist" ne_ident_list(l) ]
+| [ "Extraction" "Blacklist" ne_preident_list(l) ]
   -> { extraction_blacklist l }
 END
 

--- a/plugins/extraction/table.ml
+++ b/plugins/extraction/table.ml
@@ -761,7 +761,7 @@ let blacklist_extraction : string list -> obj =
 (* Grammar entries. *)
 
 let extraction_blacklist l =
-  let l = List.rev_map Id.to_string l in
+  let l = List.rev l in
   Lib.add_anonymous_leaf (blacklist_extraction l)
 
 (* Printing part *)

--- a/plugins/extraction/table.ml
+++ b/plugins/extraction/table.ml
@@ -300,7 +300,7 @@ let pr_long_global ref = pr_path (Nametab.path_of_global ref)
 
 (*S Warning and Error messages. *)
 
-let err s = user_err ~hdr:"Extraction" s
+let err ?loc s = user_err ?loc ~hdr:"Extraction" s
 
 let warn_extraction_axiom_to_realize =
   CWarnings.create ~name:"extraction-axiom-to-realize" ~category:"extraction"
@@ -361,8 +361,8 @@ let warning_ambiguous_name =
                        strbrk "First choice is assumed, for the second one please use " ++
                        strbrk "fully qualified name." ++ fnl ())
 
-let error_axiom_scheme r i =
-  err (str "The type scheme axiom " ++ spc () ++
+let error_axiom_scheme ?loc r i =
+  err ?loc (str "The type scheme axiom " ++ spc () ++
        safe_pr_global r ++ spc () ++ str "needs " ++ int i ++
        str " type variable(s).")
 
@@ -391,11 +391,11 @@ let warn_extraction_reserved_identifier =
 
 let warning_id s = warn_extraction_reserved_identifier s
 
-let error_constant r =
-  err (safe_pr_global r ++ str " is not a constant.")
+let error_constant ?loc r =
+  err ?loc (safe_pr_global r ++ str " is not a constant.")
 
-let error_inductive r =
-  err (safe_pr_global r ++ spc () ++ str "is not an inductive type.")
+let error_inductive ?loc r =
+  err ?loc (safe_pr_global r ++ spc () ++ str "is not an inductive type.")
 
 let error_nb_cons () =
   err (str "Not the right number of constructors.")
@@ -426,8 +426,8 @@ let error_singleton_become_prop id og =
        str "Instead, use a sort-monomorphic type such as (True /\\ True)\n" ++
        str "or extract to Haskell.")
 
-let error_unknown_module m =
-  err (str "Module" ++ spc () ++ pr_qualid m ++ spc () ++ str "not found.")
+let error_unknown_module ?loc m =
+  err ?loc (str "Module" ++ spc () ++ pr_qualid m ++ spc () ++ str "not found.")
 
 let error_scheme () =
   err (str "No Scheme modular extraction available yet.")
@@ -840,11 +840,11 @@ let extract_constant_inline inline r ids s =
         if Reduction.is_arity env typ
           then begin
             let nargs = Hook.get use_type_scheme_nb_args env typ in
-            if not (Int.equal (List.length ids) nargs) then error_axiom_scheme g nargs
+            if not (Int.equal (List.length ids) nargs) then error_axiom_scheme ?loc:r.CAst.loc g nargs
           end;
         Lib.add_anonymous_leaf (inline_extraction (inline,[g]));
         Lib.add_anonymous_leaf (in_customs (g,ids,s))
-    | _ -> error_constant g
+    | _ -> error_constant ?loc:r.CAst.loc g
 
 
 let extract_inductive r s l optstr =
@@ -865,7 +865,7 @@ let extract_inductive r s l optstr =
              let g = GlobRef.ConstructRef (ip,succ j) in
              Lib.add_anonymous_leaf (inline_extraction (true,[g]));
              Lib.add_anonymous_leaf (in_customs (g,[],s))) l
-    | _ -> error_inductive g
+    | _ -> error_inductive ?loc:r.CAst.loc g
 
 
 

--- a/plugins/extraction/table.mli
+++ b/plugins/extraction/table.mli
@@ -208,7 +208,7 @@ val extraction_implicit : qualid -> int_or_id list -> unit
 
 (*s Table of blacklisted filenames *)
 
-val extraction_blacklist : Id.t list -> unit
+val extraction_blacklist : string list -> unit
 val reset_extraction_blacklist : unit -> unit
 val print_extraction_blacklist : unit -> Pp.t
 

--- a/plugins/extraction/table.mli
+++ b/plugins/extraction/table.mli
@@ -24,14 +24,14 @@ val warning_axioms : unit -> unit
 val warning_opaques : bool -> unit
 val warning_ambiguous_name : ?loc:Loc.t -> qualid * ModPath.t * GlobRef.t -> unit
 val warning_id : string -> unit
-val error_axiom_scheme : GlobRef.t -> int -> 'a
-val error_constant : GlobRef.t -> 'a
-val error_inductive : GlobRef.t -> 'a
+val error_axiom_scheme : ?loc:Loc.t -> GlobRef.t -> int -> 'a
+val error_constant : ?loc:Loc.t -> GlobRef.t -> 'a
+val error_inductive : ?loc:Loc.t -> GlobRef.t -> 'a
 val error_nb_cons : unit -> 'a
 val error_module_clash : ModPath.t -> ModPath.t -> 'a
 val error_no_module_expr : ModPath.t -> 'a
 val error_singleton_become_prop : Id.t -> GlobRef.t option -> 'a
-val error_unknown_module : qualid -> 'a
+val error_unknown_module : ?loc:Loc.t -> qualid -> 'a
 val error_scheme : unit -> 'a
 val error_not_visible : GlobRef.t -> 'a
 val error_MPfile_as_mod : ModPath.t -> bool -> 'a

--- a/plugins/funind/g_indfun.mlg
+++ b/plugins/funind/g_indfun.mlg
@@ -231,7 +231,7 @@ let pr_fun_scheme_arg (princ_name,fun_name,s) =
 
 VERNAC ARGUMENT EXTEND fun_scheme_arg
 PRINTED BY { pr_fun_scheme_arg }
-| [ ident(princ_name) ":=" "Induction" "for" reference(fun_name) "Sort" sort_family(s) ] -> { (princ_name,fun_name,s) }
+| [ identref(princ_name) ":=" "Induction" "for" reference(fun_name) "Sort" sort_family(s) ] -> { (princ_name.CAst.v,fun_name,s) }
 END
 
 {

--- a/plugins/ltac/g_obligations.mlg
+++ b/plugins/ltac/g_obligations.mlg
@@ -88,31 +88,31 @@ let classify_obbl _ = Vernacextend.(VtStartProof (Doesn'tGuaranteeOpacity,[]))
 }
 
 VERNAC COMMAND EXTEND Obligations CLASSIFIED BY { classify_obbl } STATE declare_program
-| [ "Obligation" natural(num) "of" ident(name) ":" lglob(t) withtac(tac) ] ->
-    { obligation (num, Some name, Some t) tac }
-| [ "Obligation" natural(num) "of" ident(name) withtac(tac) ] ->
-    { obligation (num, Some name, None) tac }
+| [ "Obligation" natural(num) "of" identref(name) ":" lglob(t) withtac(tac) ] ->
+    { obligation (num, Some name.CAst.v, Some t) tac }
+| [ "Obligation" natural(num) "of" identref(name) withtac(tac) ] ->
+    { obligation (num, Some name.CAst.v, None) tac }
 | [ "Obligation" natural(num) ":" lglob(t) withtac(tac) ] ->
     { obligation (num, None, Some t) tac }
 | [ "Obligation" natural(num) withtac(tac) ] ->
     { obligation (num, None, None) tac }
-| [ "Next" "Obligation" "of" ident(name) withtac(tac) ] ->
-    { next_obligation (Some name) tac }
+| [ "Next" "Obligation" "of" identref(name) withtac(tac) ] ->
+    { next_obligation (Some name.CAst.v) tac }
 | [ "Next" "Obligation" withtac(tac) ] -> { next_obligation None tac }
 END
 
 VERNAC COMMAND EXTEND Solve_Obligation CLASSIFIED AS SIDEFF STATE program
-| [ "Solve" "Obligation" natural(num) "of" ident(name) "with" tactic(t) ] ->
-    { try_solve_obligation num (Some name) (Some (Tacinterp.interp t)) }
+| [ "Solve" "Obligation" natural(num) "of" identref(name) "with" tactic(t) ] ->
+    { try_solve_obligation num (Some name.CAst.v) (Some (Tacinterp.interp t)) }
 | [ "Solve" "Obligation" natural(num) "with" tactic(t) ] ->
     { try_solve_obligation num None (Some (Tacinterp.interp t)) }
 END
 
 VERNAC COMMAND EXTEND Solve_Obligations CLASSIFIED AS SIDEFF STATE program
-| [ "Solve" "Obligations" "of" ident(name) "with" tactic(t) ] ->
-    { try_solve_obligations (Some name) (Some (Tacinterp.interp t)) }
-| [ "Solve" "Obligations" "of" ident(name) ] ->
-    { try_solve_obligations (Some name) None }
+| [ "Solve" "Obligations" "of" identref(name) "with" tactic(t) ] ->
+    { try_solve_obligations (Some name.CAst.v) (Some (Tacinterp.interp t)) }
+| [ "Solve" "Obligations" "of" identref(name) ] ->
+    { try_solve_obligations (Some name.CAst.v) None }
 | [ "Solve" "Obligations" "with" tactic(t) ] ->
     { try_solve_obligations None (Some (Tacinterp.interp t)) }
 | [ "Solve" "Obligations" ] ->
@@ -127,7 +127,7 @@ VERNAC COMMAND EXTEND Solve_All_Obligations CLASSIFIED AS SIDEFF STATE program
 END
 
 VERNAC COMMAND EXTEND Admit_Obligations CLASSIFIED AS SIDEFF STATE program
-| [ "Admit" "Obligations" "of" ident(name) ] -> { admit_obligations (Some name) }
+| [ "Admit" "Obligations" "of" identref(name) ] -> { admit_obligations (Some name.CAst.v) }
 | [ "Admit" "Obligations" ] -> { admit_obligations None }
 END
 
@@ -151,12 +151,12 @@ VERNAC COMMAND EXTEND Show_Solver CLASSIFIED AS QUERY
 END
 
 VERNAC COMMAND EXTEND Show_Obligations CLASSIFIED AS QUERY STATE read_program
-| [ "Obligations" "of" ident(name) ] -> { fun ~stack:_ -> show_obligations (Some name) }
+| [ "Obligations" "of" identref(name) ] -> { fun ~stack:_ -> show_obligations (Some name.CAst.v) }
 | [ "Obligations" ] -> { fun ~stack:_ -> show_obligations None }
 END
 
 VERNAC COMMAND EXTEND Show_Preterm CLASSIFIED AS QUERY STATE read_program
-| [ "Preterm" "of" ident(name) ] -> { fun ~stack:_ ~pm -> Feedback.msg_notice (show_term ~pm (Some name)) }
+| [ "Preterm" "of" identref(name) ] -> { fun ~stack:_ ~pm -> Feedback.msg_notice (show_term ~pm (Some name.CAst.v)) }
 | [ "Preterm" ] -> { fun ~stack:_ ~pm -> Feedback.msg_notice (show_term ~pm None) }
 END
 

--- a/plugins/ltac/g_rewrite.mlg
+++ b/plugins/ltac/g_rewrite.mlg
@@ -174,36 +174,43 @@ TACTIC EXTEND setoid_rewrite
       { cl_rewrite_clause c o (occurrences_of occ) (Some id) }
 END
 
+{
+
+let declare_relation atts a ?binders aeq n refl symm trans =
+  declare_relation atts a ?binders aeq n.CAst.v refl symm trans
+
+}
+
 VERNAC COMMAND EXTEND AddRelation CLASSIFIED AS SIDEFF
   | #[ atts = rewrite_attributes; ] [ "Add" "Relation" constr(a) constr(aeq) "reflexivity" "proved" "by" constr(lemma1)
-        "symmetry" "proved" "by" constr(lemma2) "as" ident(n) ] ->
+        "symmetry" "proved" "by" constr(lemma2) "as" identref(n) ] ->
       { declare_relation atts a aeq n (Some lemma1) (Some lemma2) None }
 
   | #[ atts = rewrite_attributes; ] [ "Add" "Relation" constr(a) constr(aeq) "reflexivity" "proved" "by" constr(lemma1)
-        "as" ident(n) ] ->
+        "as" identref(n) ] ->
       { declare_relation atts a aeq n (Some lemma1) None None }
-  | #[ atts = rewrite_attributes; ] [ "Add" "Relation" constr(a) constr(aeq)  "as" ident(n) ] ->
+  | #[ atts = rewrite_attributes; ] [ "Add" "Relation" constr(a) constr(aeq)  "as" identref(n) ] ->
       { declare_relation atts a aeq n None None None }
 END
 
 VERNAC COMMAND EXTEND AddRelation2 CLASSIFIED AS SIDEFF
   | #[ atts = rewrite_attributes; ] [ "Add" "Relation" constr(a) constr(aeq) "symmetry" "proved" "by" constr(lemma2)
-      "as" ident(n) ] ->
+      "as" identref(n) ] ->
       { declare_relation atts a aeq n None (Some lemma2) None }
-  | #[ atts = rewrite_attributes; ] [ "Add" "Relation" constr(a) constr(aeq) "symmetry" "proved" "by" constr(lemma2) "transitivity" "proved" "by" constr(lemma3)  "as" ident(n) ] ->
+  | #[ atts = rewrite_attributes; ] [ "Add" "Relation" constr(a) constr(aeq) "symmetry" "proved" "by" constr(lemma2) "transitivity" "proved" "by" constr(lemma3)  "as" identref(n) ] ->
       { declare_relation atts a aeq n None (Some lemma2) (Some lemma3) }
 END
 
 VERNAC COMMAND EXTEND AddRelation3 CLASSIFIED AS SIDEFF
   | #[ atts = rewrite_attributes; ] [ "Add" "Relation" constr(a) constr(aeq) "reflexivity" "proved" "by" constr(lemma1)
-      "transitivity" "proved" "by" constr(lemma3) "as" ident(n) ] ->
+      "transitivity" "proved" "by" constr(lemma3) "as" identref(n) ] ->
       { declare_relation atts a aeq n (Some lemma1) None (Some lemma3) }
   | #[ atts = rewrite_attributes; ] [ "Add" "Relation" constr(a) constr(aeq) "reflexivity" "proved" "by" constr(lemma1)
       "symmetry" "proved" "by" constr(lemma2) "transitivity" "proved" "by" constr(lemma3)
-      "as" ident(n) ] ->
+      "as" identref(n) ] ->
       { declare_relation atts a aeq n (Some lemma1) (Some lemma2) (Some lemma3) }
   | #[ atts = rewrite_attributes; ] [ "Add" "Relation" constr(a) constr(aeq) "transitivity" "proved" "by" constr(lemma3)
-        "as" ident(n) ] ->
+        "as" identref(n) ] ->
       { declare_relation atts a aeq n None None (Some lemma3) }
 END
 
@@ -231,61 +238,68 @@ END
 VERNAC COMMAND EXTEND AddParametricRelation CLASSIFIED AS SIDEFF
   | #[ atts = rewrite_attributes; ] [ "Add" "Parametric" "Relation" binders(b) ":" constr(a) constr(aeq)
         "reflexivity" "proved" "by" constr(lemma1)
-        "symmetry" "proved" "by" constr(lemma2) "as" ident(n) ] ->
+        "symmetry" "proved" "by" constr(lemma2) "as" identref(n) ] ->
       { declare_relation atts ~binders:b a aeq n (Some lemma1) (Some lemma2) None }
   | #[ atts = rewrite_attributes; ] [ "Add" "Parametric" "Relation" binders(b) ":" constr(a) constr(aeq)
         "reflexivity" "proved" "by" constr(lemma1)
-        "as" ident(n) ] ->
+        "as" identref(n) ] ->
       { declare_relation atts ~binders:b a aeq n (Some lemma1) None None }
-  | #[ atts = rewrite_attributes; ] [ "Add" "Parametric" "Relation" binders(b) ":" constr(a) constr(aeq)  "as" ident(n) ] ->
+  | #[ atts = rewrite_attributes; ] [ "Add" "Parametric" "Relation" binders(b) ":" constr(a) constr(aeq)  "as" identref(n) ] ->
       { declare_relation atts ~binders:b a aeq n None None None }
 END
 
 VERNAC COMMAND EXTEND AddParametricRelation2 CLASSIFIED AS SIDEFF
   | #[ atts = rewrite_attributes; ] [ "Add" "Parametric" "Relation" binders(b) ":" constr(a) constr(aeq) "symmetry" "proved" "by" constr(lemma2)
-      "as" ident(n) ] ->
+      "as" identref(n) ] ->
       { declare_relation atts ~binders:b a aeq n None (Some lemma2) None }
-  | #[ atts = rewrite_attributes; ] [ "Add" "Parametric" "Relation" binders(b) ":" constr(a) constr(aeq) "symmetry" "proved" "by" constr(lemma2) "transitivity" "proved" "by" constr(lemma3)  "as" ident(n) ] ->
+  | #[ atts = rewrite_attributes; ] [ "Add" "Parametric" "Relation" binders(b) ":" constr(a) constr(aeq) "symmetry" "proved" "by" constr(lemma2) "transitivity" "proved" "by" constr(lemma3)  "as" identref(n) ] ->
       { declare_relation atts ~binders:b a aeq n None (Some lemma2) (Some lemma3) }
 END
 
 VERNAC COMMAND EXTEND AddParametricRelation3 CLASSIFIED AS SIDEFF
   | #[ atts = rewrite_attributes; ] [ "Add" "Parametric" "Relation" binders(b) ":" constr(a) constr(aeq) "reflexivity" "proved" "by" constr(lemma1)
-      "transitivity" "proved" "by" constr(lemma3) "as" ident(n) ] ->
+      "transitivity" "proved" "by" constr(lemma3) "as" identref(n) ] ->
       { declare_relation atts ~binders:b a aeq n (Some lemma1) None (Some lemma3) }
   | #[ atts = rewrite_attributes; ] [ "Add" "Parametric" "Relation" binders(b) ":" constr(a) constr(aeq) "reflexivity" "proved" "by" constr(lemma1)
       "symmetry" "proved" "by" constr(lemma2) "transitivity" "proved" "by" constr(lemma3)
-      "as" ident(n) ] ->
+      "as" identref(n) ] ->
       { declare_relation atts ~binders:b a aeq n (Some lemma1) (Some lemma2) (Some lemma3) }
   | #[ atts = rewrite_attributes; ] [ "Add" "Parametric" "Relation" binders(b) ":" constr(a) constr(aeq) "transitivity" "proved" "by" constr(lemma3)
-        "as" ident(n) ] ->
+        "as" identref(n) ] ->
       { declare_relation atts ~binders:b a aeq n None None (Some lemma3) }
 END
 
+{
+
+let add_setoid atts binders a aeq t n =
+  add_setoid atts binders a aeq t n.CAst.v
+
+}
+
 VERNAC COMMAND EXTEND AddSetoid1 CLASSIFIED AS SIDEFF
-  | #[ atts = rewrite_attributes; ] [ "Add" "Setoid" constr(a) constr(aeq) constr(t) "as" ident(n) ] ->
+  | #[ atts = rewrite_attributes; ] [ "Add" "Setoid" constr(a) constr(aeq) constr(t) "as" identref(n) ] ->
      {
          add_setoid atts [] a aeq t n
      }
-  | #[ atts = rewrite_attributes; ] [ "Add" "Parametric" "Setoid" binders(binders) ":" constr(a) constr(aeq) constr(t) "as" ident(n) ] ->
+  | #[ atts = rewrite_attributes; ] [ "Add" "Parametric" "Setoid" binders(binders) ":" constr(a) constr(aeq) constr(t) "as" identref(n) ] ->
      {
          add_setoid atts binders a aeq t n
      }
-  | #[ atts = rewrite_attributes; ] ![ open_proof ] [ "Add" "Morphism" constr(m) ":" ident(n) ]
-    => { VtStartProof(GuaranteesOpacity, [n]) }
+  | #[ atts = rewrite_attributes; ] ![ open_proof ] [ "Add" "Morphism" constr(m) ":" identref(n) ]
+    => { VtStartProof(GuaranteesOpacity, [n.CAst.v]) }
     -> { if Lib.is_modtype () then
            CErrors.user_err Pp.(str "Add Morphism cannot be used in a module type. Use Parameter Morphism instead.");
-         add_morphism_interactive atts m n }
-  | #[ atts = rewrite_attributes; ] [ "Declare" "Morphism" constr(m) ":" ident(n) ]
-    => { VtSideff([n], VtLater) }
-    -> { add_morphism_as_parameter atts m n }
-  | #[ atts = rewrite_attributes; ] ![ open_proof ] [ "Add" "Morphism" constr(m) "with" "signature" lconstr(s) "as" ident(n) ]
-    => { VtStartProof(GuaranteesOpacity,[n]) }
-    -> { add_morphism atts [] m s n }
+         add_morphism_interactive atts m n.CAst.v }
+  | #[ atts = rewrite_attributes; ] [ "Declare" "Morphism" constr(m) ":" identref(n) ]
+    => { VtSideff([n.CAst.v], VtLater) }
+    -> { add_morphism_as_parameter atts m n.CAst.v }
+  | #[ atts = rewrite_attributes; ] ![ open_proof ] [ "Add" "Morphism" constr(m) "with" "signature" lconstr(s) "as" identref(n) ]
+    => { VtStartProof(GuaranteesOpacity,[n.CAst.v]) }
+    -> { add_morphism atts [] m s n.CAst.v }
   | #[ atts = rewrite_attributes; ] ![ open_proof ] [ "Add" "Parametric" "Morphism" binders(binders) ":" constr(m)
-        "with" "signature" lconstr(s) "as" ident(n) ]
-    => { VtStartProof(GuaranteesOpacity,[n]) }
-    -> { add_morphism atts binders m s n }
+        "with" "signature" lconstr(s) "as" identref(n) ]
+    => { VtStartProof(GuaranteesOpacity,[n.CAst.v]) }
+    -> { add_morphism atts binders m s n.CAst.v }
 END
 
 TACTIC EXTEND setoid_symmetry

--- a/plugins/ring/g_ring.mlg
+++ b/plugins/ring/g_ring.mlg
@@ -82,8 +82,8 @@ VERNAC ARGUMENT EXTEND ring_mods
 END
 
 VERNAC COMMAND EXTEND AddSetoidRing CLASSIFIED AS SIDEFF
-  | [ "Add" "Ring" ident(id) ":" constr(t) ring_mods_opt(l) ] ->
-    { add_theory id t (Option.default [] l) }
+  | [ "Add" "Ring" identref(id) ":" constr(t) ring_mods_opt(l) ] ->
+    { add_theory id.CAst.v t (Option.default [] l) }
   | [ "Print" "Rings" ] => { Vernacextend.classify_as_query } -> {
     print_rings ()
   }
@@ -120,8 +120,8 @@ VERNAC ARGUMENT EXTEND field_mods
 END
 
 VERNAC COMMAND EXTEND AddSetoidField CLASSIFIED AS SIDEFF
-| [ "Add" "Field" ident(id) ":" constr(t) field_mods_opt(l) ] ->
-  { let l = match l with None -> [] | Some l -> l in add_field_theory id t l }
+| [ "Add" "Field" identref(id) ":" constr(t) field_mods_opt(l) ] ->
+  { let l = match l with None -> [] | Some l -> l in add_field_theory id.CAst.v t l }
 | [ "Print" "Fields" ] => {Vernacextend.classify_as_query} -> {
     print_fields ()
   }

--- a/plugins/syntax/g_number_string.mlg
+++ b/plugins/syntax/g_number_string.mlg
@@ -16,7 +16,6 @@ open Notation
 open Number
 open String_notation
 open Pp
-open Names
 open Stdarg
 open Pcoq.Prim
 
@@ -93,18 +92,18 @@ END
 
 VERNAC COMMAND EXTEND NumberNotation CLASSIFIED AS SIDEFF
   | #[ locality = Attributes.locality; ] [ "Number" "Notation" reference(ty) reference(f) reference(g) number_options_opt(nl) ":"
-      ident(sc) ] ->
+      preident(sc) ] ->
 
-    { vernac_number_notation (Locality.make_module_locality locality) ty f g (Option.default [] nl) (Id.to_string sc) }
+    { vernac_number_notation (Locality.make_module_locality locality) ty f g (Option.default [] nl) sc }
   | #[ locality = Attributes.locality; ] [ "Numeral" "Notation" reference(ty) reference(f) reference(g) ":"
-      ident(sc) deprecated_number_modifier(o) ] ->
+      preident(sc) deprecated_number_modifier(o) ] ->
 
     { warn_deprecated_numeral_notation ();
-      vernac_number_notation (Locality.make_module_locality locality) ty f g [After o] (Id.to_string sc) }
+      vernac_number_notation (Locality.make_module_locality locality) ty f g [After o] sc }
 END
 
 VERNAC COMMAND EXTEND StringNotation CLASSIFIED AS SIDEFF
   | #[ locality = Attributes.locality; ] [ "String" "Notation" reference(ty) reference(f) reference(g) string_option_opt(o) ":"
-      ident(sc) ] ->
-    { vernac_string_notation (Locality.make_module_locality locality) ty f g o (Id.to_string sc) }
+      preident(sc) ] ->
+    { vernac_string_notation (Locality.make_module_locality locality) ty f g o sc }
 END


### PR DESCRIPTION
**Kind:** infrastructure.

This is part of the project started in [#11842](https://github.com/coq/coq/pull/11842#issuecomment-699600005).

We add locations to identifiers in a couple of grammars of plugins in anticipation of identifying `Prim.identref` and `Prim.ident`, with the latter eventually taking a location by default and the former being eventually deprecated.
