### PR TITLE
Locating identifiers in tactics (including ltac2, ssr)

### DIFF
--- a/interp/stdarg.ml
+++ b/interp/stdarg.ml
@@ -40,6 +40,9 @@ let wit_int_or_var =
 let wit_ident =
   make0 "ident"
 
+let wit_identref =
+  make0 "identref"
+
 let wit_hyp =
   make0 ~dyn:(val_tag (topwit wit_ident)) "hyp"
 

--- a/interp/stdarg.mli
+++ b/interp/stdarg.mli
@@ -37,6 +37,8 @@ val wit_int_or_var : (int or_var, int or_var, int) genarg_type
 
 val wit_ident : Id.t uniform_genarg_type
 
+val wit_identref : lident uniform_genarg_type
+
 val wit_hyp : (lident, lident, Id.t) genarg_type
 
 val wit_var : (lident, lident, Id.t) genarg_type

--- a/parsing/pcoq.ml
+++ b/parsing/pcoq.ml
@@ -507,6 +507,7 @@ let () =
   Grammar.register0 wit_int (Prim.integer);
   Grammar.register0 wit_string (Prim.string);
   Grammar.register0 wit_pre_ident (Prim.preident);
+  Grammar.register0 wit_identref (Prim.identref);
   Grammar.register0 wit_ident (Prim.ident);
   Grammar.register0 wit_hyp (Prim.hyp);
   Grammar.register0 wit_ref (Prim.reference);

--- a/plugins/funind/functional_principles_proofs.ml
+++ b/plugins/funind/functional_principles_proofs.ml
@@ -87,6 +87,7 @@ let is_incompatible_eq env sigma t =
   if res then observe (str "is_incompatible_eq " ++ pr_leconstr_env env sigma t);
   res
 
+
 let pf_get_new_id id env =
   next_ident_away id (Id.Set.of_list (Termops.ids_of_named_context env))
 
@@ -101,7 +102,7 @@ let change_hyp_with_using msg hyp_id t tac =
             [ (* observe_tac "change_hyp_with_using thin" *)
               Tactics.clear [hyp_id]
             ; (* observe_tac "change_hyp_with_using rename " *)
-              rename_hyp [(prov_id, hyp_id)] ] ])
+              rename_hyp [(CAst.make prov_id, CAst.make hyp_id)] ] ])
 
 exception TOREMOVE
 
@@ -558,7 +559,7 @@ let instantiate_hyps_with_args (do_prove : Id.t list -> unit Proofview.tactic)
                tclTHENLIST
                  [ pose_proof (Name prov_hid) c
                  ; thin [hid]
-                 ; rename_hyp [(prov_hid, hid)] ])))
+                 ; rename_hyp [(CAst.make prov_hid, CAst.make hid)] ])))
       (*
           if not then we are in a mutual function block
           and this hyp is a recursive hyp on an other function.

--- a/plugins/funind/functional_principles_proofs.ml
+++ b/plugins/funind/functional_principles_proofs.ml
@@ -1145,9 +1145,9 @@ let prove_princ_for_struct (evd : Evd.evar_map ref) interactive_proof fun_num
             else
               Indfun_common.New.observe_tac ~header:(str "observation")
                 (fun _ _ -> str "h_fix " ++ int (this_fix_info.idx + 1))
-                (fix this_fix_info.name (this_fix_info.idx + 1))
+                (fix (CAst.make this_fix_info.name) (this_fix_info.idx + 1))
           else
-            Tactics.mutual_fix this_fix_info.name (this_fix_info.idx + 1)
+            Tactics.mutual_fix (CAst.make this_fix_info.name) (this_fix_info.idx + 1)
               other_fix_infos 0
       in
       let first_tac : unit Proofview.tactic =
@@ -1543,7 +1543,7 @@ let prove_principle_for_gen (f_ref, functional_ref, eq_ref) tcc_lemma_ref is_mes
                , [|input_type; relation; mkVar rec_arg_id|] ))
             prove_rec_arg_acc
         ; revert (List.rev (acc_rec_arg_id :: args_ids))
-        ; fix fix_id (List.length args_ids + 1)
+        ; fix (CAst.make fix_id) (List.length args_ids + 1)
         ; h_intros (List.rev (acc_rec_arg_id :: args_ids))
         ; Equality.rewriteLR (mkConst eq_ref)
         ; Proofview.Goal.enter (fun gl' ->

--- a/plugins/funind/invfun.ml
+++ b/plugins/funind/invfun.ml
@@ -101,7 +101,7 @@ let functional_inversion kn hid fconst f_correct =
               [applist (f_correct, Array.to_list f_args @ [res; mkVar hid])]
           ; clear [hid]
           ; Simple.intro hid
-          ; Inv.inv Inv.FullInversion None (Tactypes.NamedHyp hid)
+          ; Inv.inv Inv.FullInversion None (Tactypes.NamedHyp (CAst.make hid))
           ; Proofview.Goal.enter (fun gl ->
                 let new_ids =
                   List.filter

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -1264,7 +1264,7 @@ let termination_proof_header is_mes input_type ids args_id relation rec_arg_num
                    (onNLastHypsId (nargs + 1)
                       (tclMAP (fun id ->
                            tclTHEN (Tactics.generalize [mkVar id]) (clear [id]))))
-               ; New.observe_tac (fun _ _ -> str "fix") (fix hrec (nargs + 1))
+               ; New.observe_tac (fun _ _ -> str "fix") (fix (CAst.make hrec) (nargs + 1))
                ; h_intros args_id
                ; Simple.intro wf_rec_arg
                ; New.observe_tac

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -977,8 +977,8 @@ let rec make_rewrite_list expr_info max = function
                    (* dep proofs also: *) true
                    ( mkVar hp
                    , ExplicitBindings
-                       [ CAst.make @@ (NamedHyp def, expr_info.f_constr)
-                       ; CAst.make @@ (NamedHyp k, f_S max) ] )
+                       [ CAst.make @@ (NamedHyp (CAst.make def), expr_info.f_constr)
+                       ; CAst.make @@ (NamedHyp (CAst.make k), f_S max) ] )
                    false)))
          [ make_rewrite_list expr_info max l
          ; New.observe_tclTHENLIST
@@ -1012,8 +1012,8 @@ let make_rewrite expr_info l hp max =
                     (* dep proofs also: *) true
                     ( mkVar hp
                     , ExplicitBindings
-                        [ CAst.make @@ (NamedHyp def, expr_info.f_constr)
-                        ; CAst.make @@ (NamedHyp k, f_S (f_S max)) ] )
+                        [ CAst.make @@ (NamedHyp (CAst.make def), expr_info.f_constr)
+                        ; CAst.make @@ (NamedHyp (CAst.make k), f_S (f_S max)) ] )
                     false)))
           [ New.observe_tac
               (fun _ _ -> str "make_rewrite finalize")

--- a/plugins/ltac/coretactics.mlg
+++ b/plugins/ltac/coretactics.mlg
@@ -275,13 +275,13 @@ END
 (* Fix *)
 
 TACTIC EXTEND fix
-| [ "fix" ident(id) natural(n) ] -> { Tactics.fix id n }
+| [ "fix" identref(id) natural(n) ] -> { Tactics.fix id n }
 END
 
 (* Cofix *)
 
 TACTIC EXTEND cofix
-| [ "cofix" ident(id) ] -> { Tactics.cofix id }
+| [ "cofix" identref(id) ] -> { Tactics.cofix id }
 END
 
 (* Clear *)

--- a/plugins/ltac/coretactics.mlg
+++ b/plugins/ltac/coretactics.mlg
@@ -201,11 +201,11 @@ END
 
 TACTIC EXTEND intro
 | [ "intro" ] -> { Tactics.intro_move None MoveLast }
-| [ "intro" ident(id) ] -> { Tactics.intro_move (Some id) MoveLast }
-| [ "intro" ident(id) "at" "top" ] -> { Tactics.intro_move (Some id) MoveFirst }
-| [ "intro" ident(id) "at" "bottom" ] -> { Tactics.intro_move (Some id) MoveLast }
-| [ "intro" ident(id) "after" hyp(h) ] -> { Tactics.intro_move (Some id) (MoveAfter h) }
-| [ "intro" ident(id) "before" hyp(h) ] -> { Tactics.intro_move (Some id) (MoveBefore h) }
+| [ "intro" identref(id) ] -> { Tactics.intro_move (Some id) MoveLast }
+| [ "intro" identref(id) "at" "top" ] -> { Tactics.intro_move (Some id) MoveFirst }
+| [ "intro" identref(id) "at" "bottom" ] -> { Tactics.intro_move (Some id) MoveLast }
+| [ "intro" identref(id) "after" hyp(h) ] -> { Tactics.intro_move (Some id) (MoveAfter h) }
+| [ "intro" identref(id) "before" hyp(h) ] -> { Tactics.intro_move (Some id) (MoveBefore h) }
 | [ "intro" "at" "top" ] -> { Tactics.intro_move None MoveFirst }
 | [ "intro" "at" "bottom" ] -> { Tactics.intro_move None MoveLast }
 | [ "intro" "after" hyp(h) ] -> { Tactics.intro_move None (MoveAfter h) }

--- a/plugins/ltac/evar_tactics.ml
+++ b/plugins/ltac/evar_tactics.ml
@@ -76,12 +76,12 @@ let instantiate_tac n c ido =
   instantiate_evar evk c
   end
 
-let instantiate_tac_by_name id c =
+let instantiate_tac_by_name CAst.{v=id;loc} c =
   Proofview.Goal.enter begin fun gl ->
   let sigma = Proofview.Goal.sigma gl in
   let evk =
     try Evd.evar_key id sigma
-    with Not_found -> user_err Pp.(str "Unknown existential variable.") in
+    with Not_found -> user_err ?loc Pp.(str "Unknown existential variable.") in
   instantiate_evar evk c
   end
 

--- a/plugins/ltac/evar_tactics.mli
+++ b/plugins/ltac/evar_tactics.mli
@@ -15,7 +15,7 @@ open Locus
 val instantiate_tac : int -> Tacinterp.interp_sign * Glob_term.glob_constr ->
   (Id.t * hyp_location_flag, unit) location -> unit Proofview.tactic
 
-val instantiate_tac_by_name : Id.t ->
+val instantiate_tac_by_name : lident ->
   Tacinterp.interp_sign * Glob_term.glob_constr -> unit Proofview.tactic
 
 val let_evar : Name.t -> EConstr.types -> unit Proofview.tactic

--- a/plugins/ltac/extraargs.mlg
+++ b/plugins/ltac/extraargs.mlg
@@ -283,14 +283,14 @@ ARGUMENT EXTEND hloc
 
 {
 
-let pr_rename _ _ _ (n, m) = Id.print n ++ str " into " ++ Id.print m
+let pr_rename _ _ _ (n, m) = Pputils.pr_lident n ++ str " into " ++ Pputils.pr_lident m
 
 }
 
 ARGUMENT EXTEND rename
-  TYPED AS (ident * ident)
+  TYPED AS (identref * identref)
   PRINTED BY { pr_rename }
-| [ ident(n) "into" ident(m) ] -> { (n, m) }
+| [ identref(n) "into" identref(m) ] -> { (n, m) }
 END
 
 (* Julien: Mise en commun des differentes version de replace with in by *)

--- a/plugins/ltac/extraargs.mlg
+++ b/plugins/ltac/extraargs.mlg
@@ -266,18 +266,18 @@ ARGUMENT EXTEND hloc
     { ConclLocation () }
   |  [ "in" "|-" "*" ] ->
     { ConclLocation () }
-| [ "in" ident(id) ] ->
-    { HypLocation ((CAst.make id),InHyp) }
-| [ "in" "(" "Type" "of" ident(id) ")" ] ->
-    { warn_deprecated_instantiate_syntax ("Type","type",id);
-      HypLocation ((CAst.make id),InHypTypeOnly) }
-| [ "in" "(" "Value" "of" ident(id) ")" ] ->
-    { warn_deprecated_instantiate_syntax ("Value","value",id);
-      HypLocation ((CAst.make id),InHypValueOnly) }
-| [ "in" "(" "type" "of" ident(id) ")" ] ->
-    { HypLocation ((CAst.make id),InHypTypeOnly) }
-| [ "in" "(" "value" "of" ident(id) ")" ] ->
-    { HypLocation ((CAst.make id),InHypValueOnly) }
+| [ "in" identref(id) ] ->
+    { HypLocation (id,InHyp) }
+| [ "in" "(" "Type" "of" identref(id) ")" ] ->
+    { warn_deprecated_instantiate_syntax ~loc ("Type","type",id.CAst.v);
+      HypLocation (id,InHypTypeOnly) }
+| [ "in" "(" "Value" "of" identref(id) ")" ] ->
+    { warn_deprecated_instantiate_syntax ~loc ("Value","value",id.CAst.v);
+      HypLocation (id,InHypValueOnly) }
+| [ "in" "(" "type" "of" identref(id) ")" ] ->
+    { HypLocation (id,InHypTypeOnly) }
+| [ "in" "(" "value" "of" identref(id) ")" ] ->
+    { HypLocation (id,InHypValueOnly) }
 
  END
 

--- a/plugins/ltac/extraargs.mli
+++ b/plugins/ltac/extraargs.mli
@@ -18,7 +18,7 @@ val wit_orient : bool Genarg.uniform_genarg_type
 val orient : bool Pcoq.Entry.t
 val pr_orient : bool -> Pp.t
 
-val wit_rename : (Id.t * Id.t) Genarg.uniform_genarg_type
+val wit_rename : (lident * lident) Genarg.uniform_genarg_type
 
 val occurrences : (int list Locus.or_var) Pcoq.Entry.t
 val wit_occurrences : (int list Locus.or_var, int list Locus.or_var, int list) Genarg.genarg_type

--- a/plugins/ltac/extratactics.mlg
+++ b/plugins/ltac/extratactics.mlg
@@ -478,7 +478,7 @@ open Evar_tactics
 (* TODO: add support for some test similar to g_constr.name_colon so that
    expressions like "evar (list A)" do not raise a syntax error *)
 TACTIC EXTEND evar
-| [ "evar" test_lpar_id_colon "(" ident(id) ":" lconstr(typ) ")" ] -> { let_evar (Name.Name id) typ }
+| [ "evar" test_lpar_id_colon "(" identref(id) ":" lconstr(typ) ")" ] -> { let_evar (Name.Name id.CAst.v) typ }
 | [ "evar" constr(typ) ] -> { let_evar Name.Anonymous typ }
 END
 
@@ -689,8 +689,8 @@ let hResolve_auto id c t =
 }
 
 TACTIC EXTEND hresolve_core
-| [ "hresolve_core" "(" ident(id) ":=" constr(c) ")" "at" int_or_var(occ) "in" constr(t) ] -> { hResolve id c occ t }
-| [ "hresolve_core" "(" ident(id) ":=" constr(c) ")" "in" constr(t) ] -> { hResolve_auto id c t }
+| [ "hresolve_core" "(" identref(id) ":=" constr(c) ")" "at" int_or_var(occ) "in" constr(t) ] -> { hResolve id.CAst.v c occ t }
+| [ "hresolve_core" "(" identref(id) ":=" constr(c) ")" "in" constr(t) ] -> { hResolve_auto id.CAst.v c t }
 END
 
 (**
@@ -812,8 +812,8 @@ END
 TACTIC EXTEND transparent_abstract
 | [ "transparent_abstract" tactic3(t) ] -> { Proofview.Goal.enter begin fun gl ->
     Abstract.tclABSTRACT ~opaque:false None (Tacinterp.tactic_of_value ist t) end; }
-| [ "transparent_abstract" tactic3(t) "using" ident(id) ] -> { Proofview.Goal.enter begin fun gl ->
-    Abstract.tclABSTRACT ~opaque:false (Some id) (Tacinterp.tactic_of_value ist t) end; }
+| [ "transparent_abstract" tactic3(t) "using" identref(id) ] -> { Proofview.Goal.enter begin fun gl ->
+    Abstract.tclABSTRACT ~opaque:false (Some id.CAst.v) (Tacinterp.tactic_of_value ist t) end; }
 END
 
 (* ********************************************************************* *)

--- a/plugins/ltac/extratactics.mlg
+++ b/plugins/ltac/extratactics.mlg
@@ -398,7 +398,10 @@ END
 open Inv
 open Leminv
 
-let seff id = VtSideff ([id], VtLater)
+let seff id = VtSideff ([id.CAst.v], VtLater)
+
+let add_inversion_lemma_exn ~poly na com comsort bool tac =
+  add_inversion_lemma_exn ~poly na.CAst.v com comsort bool tac
 
 }
 
@@ -409,36 +412,36 @@ let seff id = VtSideff ([id], VtLater)
 END*)
 
 VERNAC COMMAND EXTEND DeriveInversionClear
-| #[ polymorphic; ] [ "Derive" "Inversion_clear" ident(na) "with" constr(c) "Sort" sort_family(s) ]
+| #[ polymorphic; ] [ "Derive" "Inversion_clear" identref(na) "with" constr(c) "Sort" sort_family(s) ]
   => { seff na }
   -> {
       add_inversion_lemma_exn ~poly:polymorphic na c s false inv_clear_tac }
 
-| #[ polymorphic; ] [ "Derive" "Inversion_clear" ident(na) "with" constr(c) ] => { seff na }
+| #[ polymorphic; ] [ "Derive" "Inversion_clear" identref(na) "with" constr(c) ] => { seff na }
   -> {
       add_inversion_lemma_exn ~poly:polymorphic na c Sorts.InProp false inv_clear_tac }
 END
 
 VERNAC COMMAND EXTEND DeriveInversion
-| #[ polymorphic; ] [ "Derive" "Inversion" ident(na) "with" constr(c) "Sort" sort_family(s) ]
+| #[ polymorphic; ] [ "Derive" "Inversion" identref(na) "with" constr(c) "Sort" sort_family(s) ]
   => { seff na }
   -> {
       add_inversion_lemma_exn ~poly:polymorphic na c s false inv_tac }
 
-| #[ polymorphic; ] [ "Derive" "Inversion" ident(na) "with" constr(c) ] => { seff na }
+| #[ polymorphic; ] [ "Derive" "Inversion" identref(na) "with" constr(c) ] => { seff na }
   -> {
       add_inversion_lemma_exn ~poly:polymorphic na c Sorts.InProp false inv_tac }
 END
 
 VERNAC COMMAND EXTEND DeriveDependentInversion
-| #[ polymorphic; ] [ "Derive" "Dependent" "Inversion" ident(na) "with" constr(c) "Sort" sort_family(s) ]
+| #[ polymorphic; ] [ "Derive" "Dependent" "Inversion" identref(na) "with" constr(c) "Sort" sort_family(s) ]
   => { seff na }
   -> {
       add_inversion_lemma_exn ~poly:polymorphic na c s true dinv_tac }
 END
 
 VERNAC COMMAND EXTEND DeriveDependentInversionClear
-| #[ polymorphic; ] [ "Derive" "Dependent" "Inversion_clear" ident(na) "with" constr(c) "Sort" sort_family(s) ]
+| #[ polymorphic; ] [ "Derive" "Dependent" "Inversion_clear" identref(na) "with" constr(c) "Sort" sort_family(s) ]
   => { seff na }
   -> {
       add_inversion_lemma_exn ~poly:polymorphic na c s true dinv_clear_tac }

--- a/plugins/ltac/extratactics.mlg
+++ b/plugins/ltac/extratactics.mlg
@@ -88,7 +88,7 @@ END
 
 let induction_arg_of_quantified_hyp = function
   | AnonHyp n -> None,ElimOnAnonHyp n
-  | NamedHyp id -> None,ElimOnIdent (CAst.make id)
+  | NamedHyp id -> None,ElimOnIdent id
 
 (* Versions *_main must come first!! so that "1" is interpreted as a
    ElimOnAnonHyp and not as a "constr", and "id" is interpreted as a
@@ -767,7 +767,7 @@ let case_eq_intros_rewrite x =
   end
 
 let rec find_a_destructable_match sigma t =
-  let cl = induction_arg_of_quantified_hyp (NamedHyp (Id.of_string "x")) in
+  let cl = induction_arg_of_quantified_hyp (NamedHyp (CAst.make @@ Id.of_string "x")) in
   let cl = [cl, (None, None), None], None in
   let dest = TacAtom (CAst.make @@ TacInductionDestruct(false, false, cl)) in
   match EConstr.kind sigma t with

--- a/plugins/ltac/extratactics.mlg
+++ b/plugins/ltac/extratactics.mlg
@@ -483,7 +483,7 @@ TACTIC EXTEND evar
 END
 
 TACTIC EXTEND instantiate
-| [ "instantiate" "(" ident(id) ":=" lglob(c) ")" ] ->
+| [ "instantiate" "(" identref(id) ":=" lglob(c) ")" ] ->
     { Tacticals.New.tclTHEN (instantiate_tac_by_name id c) Proofview.V82.nf_evar_goals }
 | [ "instantiate" "(" integer(i) ":=" lglob(c) ")" hloc(hl) ] ->
     { Tacticals.New.tclTHEN (instantiate_tac i c hl) Proofview.V82.nf_evar_goals }

--- a/plugins/ltac/g_ltac.mlg
+++ b/plugins/ltac/g_ltac.mlg
@@ -220,7 +220,7 @@ GRAMMAR EXTEND Gram
   ;
   input_fun:
     [ [ "_" -> { Name.Anonymous }
-      | l = ident -> { Name.Name l } ] ]
+      | l = identref -> { Name.Name l.CAst.v } ] ]
   ;
   let_clause:
     [ [ idr = identref; ":="; te = ltac_expr ->
@@ -316,7 +316,7 @@ GRAMMAR EXTEND Gram
   ;
   selector:
   [ [ l = range_selector_or_nth -> { l }
-    | test_bracket_ident; "["; id = ident; "]" -> { Goal_select.SelectId id } ] ]
+    | test_bracket_ident; "["; id = identref; "]" -> { Goal_select.SelectId id.CAst.v } ] ]
   ;
   toplevel_selector:
     [ [ sel = selector; ":" -> { sel }
@@ -448,10 +448,10 @@ let pr_ltac_production_item = function
 
 VERNAC ARGUMENT EXTEND ltac_production_item PRINTED BY { pr_ltac_production_item }
 | [ string(s) ] -> { Tacentries.TacTerm s }
-| [ ident(nt) "(" ident(p) ltac_production_sep_opt(sep) ")" ] ->
-  { Tacentries.TacNonTerm (Loc.tag ~loc ((Id.to_string nt, sep), Some p)) }
-| [ ident(nt) ] ->
-  { Tacentries.TacNonTerm (Loc.tag ~loc ((Id.to_string nt, None), None)) }
+| [ preident(nt) "(" identref(p) ltac_production_sep_opt(sep) ")" ] ->
+  { Tacentries.TacNonTerm (Loc.tag ~loc ((nt, sep), Some p.CAst.v)) }
+| [ preident(nt) ] ->
+  { Tacentries.TacNonTerm (Loc.tag ~loc ((nt, None), None)) }
 END
 
 VERNAC COMMAND EXTEND VernacTacticNotation

--- a/plugins/ltac/g_tactic.mlg
+++ b/plugins/ltac/g_tactic.mlg
@@ -128,14 +128,14 @@ let mkTacCase with_evar = function
   | [(clear,ElimOnConstr cl),(None,None),None],None ->
       TacCase (with_evar,(clear,cl))
   (* Reinterpret numbers as a notation for terms *)
-  | [(clear,ElimOnAnonHyp n),(None,None),None],None ->
+  | [(clear,ElimOnAnonHyp {CAst.v=n;loc}),(None,None),None],None ->
       TacCase (with_evar,
-        (clear,(CAst.make @@ CPrim (mkNumeral n),
+        (clear,(CAst.make ?loc @@ CPrim (mkNumeral n),
          NoBindings)))
   (* Reinterpret ident as notations for variables in the context *)
   (* because we don't know if they are quantified or not *)
   | [(clear,ElimOnIdent id),(None,None),None],None ->
-      TacCase (with_evar,(clear,(CAst.make @@ CRef (qualid_of_ident ?loc:id.CAst.loc id.CAst.v,None),NoBindings)))
+      TacCase (with_evar,(clear,(CAst.make ?loc:id.CAst.loc @@ CRef (qualid_of_ident ?loc:id.CAst.loc id.CAst.v,None),NoBindings)))
   | ic ->
       if List.exists (function ((_, ElimOnAnonHyp _),_,_) -> true | _ -> false) (fst ic)
       then
@@ -212,7 +212,7 @@ GRAMMAR EXTEND Gram
     [ [ c = constr -> { c } ] ]
   ;
   destruction_arg:
-    [ [ n = natural -> { (None,ElimOnAnonHyp n) }
+    [ [ n = natural -> { (None,ElimOnAnonHyp (CAst.make n)) }
       | test_lpar_id_rpar; c = constr_with_bindings ->
         { (Some false,destruction_arg_of_constr c) }
       | c = constr_with_bindings_arg -> { on_snd destruction_arg_of_constr c }
@@ -223,8 +223,8 @@ GRAMMAR EXTEND Gram
       | c = constr_with_bindings -> { (None,c) } ] ]
   ;
   quantified_hypothesis:
-    [ [ id = ident -> { NamedHyp id }
-      | n = natural -> { AnonHyp n } ] ]
+    [ [ id = identref -> { NamedHyp id }
+      | n = natural -> { AnonHyp (CAst.make ~loc n) } ] ]
   ;
   conversion:
     [ [ c = constr -> { (None, c) }
@@ -306,8 +306,8 @@ GRAMMAR EXTEND Gram
       | pat = naming_intropattern -> { CAst.make ~loc @@ IntroNaming pat } ] ]
   ;
   simple_binding:
-    [ [ "("; id = ident; ":="; c = lconstr; ")" -> { CAst.make ~loc (NamedHyp id, c) }
-      | "("; n = natural; ":="; c = lconstr; ")" -> { CAst.make ~loc (AnonHyp n, c) } ] ]
+    [ [ "("; id = identref; ":="; c = lconstr; ")" -> { CAst.make ~loc (NamedHyp id, c) }
+      | "("; n = natural; ":="; c = lconstr; ")" -> { CAst.make ~loc (AnonHyp (CAst.make ~loc n), c) } ] ]
   ;
   bindings:
     [ [ test_lpar_idnum_coloneq; bl = LIST1 simple_binding ->

--- a/plugins/ltac/g_tactic.mlg
+++ b/plugins/ltac/g_tactic.mlg
@@ -516,9 +516,9 @@ GRAMMAR EXTEND Gram
           { TacAtom (CAst.make ~loc @@ TacElim (true,cl,el)) }
       | IDENT "case"; icl = induction_clause_list -> { TacAtom (CAst.make ~loc @@ mkTacCase false icl) }
       | IDENT "ecase"; icl = induction_clause_list -> { TacAtom (CAst.make ~loc @@ mkTacCase true icl) }
-      | "fix"; id = ident; n = natural; "with"; fd = LIST1 fixdecl ->
+      | "fix"; id = identref; n = natural; "with"; fd = LIST1 fixdecl ->
           { TacAtom (CAst.make ~loc @@ TacMutualFix (id,n,List.map mk_fix_tac fd)) }
-      | "cofix"; id = ident; "with"; fd = LIST1 cofixdecl ->
+      | "cofix"; id = identref; "with"; fd = LIST1 cofixdecl ->
           { TacAtom (CAst.make ~loc @@ TacMutualCofix (id,List.map mk_cofix_tac fd)) }
 
       | IDENT "pose"; bl = bindings_with_parameters ->

--- a/plugins/ltac/g_tactic.mlg
+++ b/plugins/ltac/g_tactic.mlg
@@ -282,7 +282,7 @@ GRAMMAR EXTEND Gram
   naming_intropattern:
     [ [ prefix = pattern_ident -> { IntroFresh prefix.CAst.v }
       | "?" -> { IntroAnonymous }
-      | id = ident -> { IntroIdentifier id } ] ]
+      | id = identref -> { IntroIdentifier id.CAst.v } ] ]
   ;
   intropattern:
     [ [ l = simple_intropattern -> { l }
@@ -422,20 +422,20 @@ GRAMMAR EXTEND Gram
     ] ]
   ;
   fixdecl:
-    [ [ "("; id = ident; bl=LIST0 simple_binder; ann=struct_annot;
-        ":"; ty=lconstr; ")" -> { (loc, id, bl, ann, ty) } ] ]
+    [ [ "("; id = identref; bl=LIST0 simple_binder; ann=struct_annot;
+        ":"; ty=lconstr; ")" -> { (loc, id.CAst.v, bl, ann, ty) } ] ]
   ;
   struct_annot:
     [ [ "{"; IDENT "struct"; id=name; "}" -> { Some id }
       | -> { None } ] ]
   ;
   cofixdecl:
-    [ [ "("; id = ident; bl=LIST0 simple_binder; ":"; ty=lconstr; ")" ->
-        { (loc, id, bl, None, ty) } ] ]
+    [ [ "("; id = identref; bl=LIST0 simple_binder; ":"; ty=lconstr; ")" ->
+        { (loc, id.CAst.v, bl, None, ty) } ] ]
   ;
   bindings_with_parameters:
-    [ [ check_for_coloneq; "(";  id = ident; bl = LIST0 simple_binder;
-        ":="; c = lconstr; ")" -> { (id, mkCLambdaN_simple bl c) } ] ]
+    [ [ check_for_coloneq; "(";  id = identref; bl = LIST0 simple_binder;
+        ":="; c = lconstr; ")" -> { (id.CAst.v, mkCLambdaN_simple bl c) } ] ]
   ;
   eliminator:
     [ [ "using"; el = constr_with_bindings -> { el } ] ]
@@ -457,7 +457,7 @@ GRAMMAR EXTEND Gram
       | -> { None } ] ]
   ;
   as_name:
-    [ [ "as"; id = ident -> { Names.Name.Name id } | -> { Names.Name.Anonymous } ] ]
+    [ [ "as"; id = identref -> { Names.Name.Name id.CAst.v } | -> { Names.Name.Anonymous } ] ]
   ;
   by_tactic:
     [ [ "by"; tac = ltac_expr LEVEL "3" -> { Some tac }

--- a/plugins/ltac/pptactic.ml
+++ b/plugins/ltac/pptactic.ml
@@ -195,8 +195,8 @@ let string_of_genarg_arg (ArgumentType arg) =
     | EvalConstRef sp -> pr_global (GlobRef.ConstRef sp)
 
   let pr_quantified_hypothesis = function
-    | AnonHyp n -> int n
-    | NamedHyp id -> pr_id id
+    | AnonHyp n -> int n.CAst.v
+    | NamedHyp id -> pr_id id.CAst.v
 
   let pr_clear_flag clear_flag pp x =
     match clear_flag with
@@ -504,7 +504,7 @@ let string_of_genarg_arg (ArgumentType arg) =
   let pr_core_destruction_arg prc prlc = function
     | ElimOnConstr c -> pr_with_bindings prc prlc c
     | ElimOnIdent {CAst.loc;v=id} -> pr_with_comments ?loc (pr_id id)
-    | ElimOnAnonHyp n -> int n
+    | ElimOnAnonHyp {CAst.loc;v=n} -> int n
 
   let pr_destruction_arg prc prlc (clear_flag,h) =
     pr_clear_flag clear_flag (pr_core_destruction_arg prc prlc) h

--- a/plugins/ltac/pptactic.ml
+++ b/plugins/ltac/pptactic.ml
@@ -1323,6 +1323,7 @@ let () =
   register_basic_print0 wit_smart_global
     (pr_or_by_notation pr_qualid) (pr_or_var (pr_located pr_global)) pr_global;
   register_basic_print0 wit_ident pr_id pr_id pr_id;
+  register_basic_print0 wit_identref pr_lident pr_lident pr_lident;
   register_basic_print0 wit_hyp pr_lident pr_lident pr_id;
   register_print0 wit_intropattern pr_raw_intro_pattern pr_glob_intro_pattern pr_intro_pattern_env [@warning "-3"];
   register_print0 wit_simple_intropattern pr_raw_intro_pattern pr_glob_intro_pattern pr_intro_pattern_env;

--- a/plugins/ltac/pptactic.ml
+++ b/plugins/ltac/pptactic.ml
@@ -767,11 +767,11 @@ let pr_goal_selector ~toplevel s =
           hov 1 (primitive (with_evars ev "case") ++ spc () ++ pr_with_bindings_arg cb)
         | TacMutualFix (id,n,l) ->
           hov 1 (
-            primitive "fix" ++ spc () ++ pr_id id ++ pr_intarg n ++ spc()
+            primitive "fix" ++ spc () ++ pr_lident id ++ pr_intarg n ++ spc()
             ++ keyword "with" ++ spc () ++ prlist_with_sep spc pr_fix_tac l)
         | TacMutualCofix (id,l) ->
           hov 1 (
-            primitive "cofix" ++ spc () ++ pr_id id ++ spc()
+            primitive "cofix" ++ spc () ++ pr_lident id ++ spc()
             ++ keyword "with" ++ spc () ++ prlist_with_sep spc pr_cofix_tac l
           )
         | TacAssert (ev,b,Some tac,ipat,c) ->

--- a/plugins/ltac/taccoerce.ml
+++ b/plugins/ltac/taccoerce.ml
@@ -357,23 +357,23 @@ let coerce_to_reference sigma v =
 (* (as in Inversion) *)
 let coerce_to_quantified_hypothesis sigma v =
   match is_intro_pattern v with
-  | Some (IntroNaming (IntroIdentifier id)) -> NamedHyp id
+  | Some (IntroNaming (IntroIdentifier id)) -> NamedHyp (CAst.make id)
   | Some _ -> raise (CannotCoerceTo "a quantified hypothesis")
   | None ->
   if has_type v (topwit wit_hyp) then
     let id = out_gen (topwit wit_hyp) v in
-    NamedHyp id
+    NamedHyp (CAst.make id)
   else if has_type v (topwit wit_int) then
-    AnonHyp (out_gen (topwit wit_int) v)
+    AnonHyp (CAst.make @@ out_gen (topwit wit_int) v)
   else match Value.to_constr v with
-  | Some c when isVar sigma c -> NamedHyp (destVar sigma c)
+  | Some c when isVar sigma c -> NamedHyp (CAst.make @@ destVar sigma c)
   | _ -> raise (CannotCoerceTo "a quantified hypothesis")
 
 (* Quantified named or numbered hypothesis or hypothesis in context *)
 (* (as in Inversion) *)
 let coerce_to_decl_or_quant_hyp sigma v =
   if has_type v (topwit wit_int) then
-    AnonHyp (out_gen (topwit wit_int) v)
+    AnonHyp (CAst.make @@ out_gen (topwit wit_int) v)
   else
     try coerce_to_quantified_hypothesis sigma v
     with CannotCoerceTo _ ->

--- a/plugins/ltac/tacexpr.ml
+++ b/plugins/ltac/tacexpr.ml
@@ -111,8 +111,8 @@ type 'a gen_atomic_tactic_expr =
       ('nam * 'dtrm intro_pattern_expr CAst.t option) option
   | TacElim of evars_flag * 'trm with_bindings_arg * 'trm with_bindings option
   | TacCase of evars_flag * 'trm with_bindings_arg
-  | TacMutualFix of Id.t * int * (Id.t * int * 'trm) list
-  | TacMutualCofix of Id.t * (Id.t * 'trm) list
+  | TacMutualFix of lident * int * (Id.t * int * 'trm) list
+  | TacMutualCofix of lident * (Id.t * 'trm) list
   | TacAssert of
       evars_flag * bool * 'tacexpr option option *
       'dtrm intro_pattern_expr CAst.t option * 'trm

--- a/plugins/ltac/tacexpr.mli
+++ b/plugins/ltac/tacexpr.mli
@@ -110,8 +110,8 @@ type 'a gen_atomic_tactic_expr =
       ('nam * 'dtrm intro_pattern_expr CAst.t option) option
   | TacElim of evars_flag * 'trm with_bindings_arg * 'trm with_bindings option
   | TacCase of evars_flag * 'trm with_bindings_arg
-  | TacMutualFix of Id.t * int * (Id.t * int * 'trm) list
-  | TacMutualCofix of Id.t * (Id.t * 'trm) list
+  | TacMutualFix of lident * int * (Id.t * int * 'trm) list
+  | TacMutualCofix of lident * (Id.t * 'trm) list
   | TacAssert of
       evars_flag * bool * 'tacexpr option option *
       'dtrm intro_pattern_expr CAst.t option * 'trm

--- a/plugins/ltac/tacintern.ml
+++ b/plugins/ltac/tacintern.ml
@@ -826,6 +826,10 @@ let intern_ident' ist id =
   let lf = ref Id.Set.empty in
   (ist, intern_ident lf ist id)
 
+let intern_lident ist CAst.{loc;v=id} =
+  let lf = ref Id.Set.empty in
+  (ist, CAst.make ?loc @@ intern_ident lf ist id)
+
 let intern_ltac ist tac =
   Flags.with_option strict_check (fun () -> intern_pure_tactic ist tac) ()
 
@@ -835,6 +839,7 @@ let () =
   Genintern.register_intern0 wit_ref (lift intern_global_reference);
   Genintern.register_intern0 wit_pre_ident (fun ist c -> (ist,c));
   Genintern.register_intern0 wit_ident intern_ident';
+  Genintern.register_intern0 wit_identref intern_lident;
   Genintern.register_intern0 wit_hyp (lift intern_hyp);
   Genintern.register_intern0 wit_tactic (lift intern_tactic_or_tacarg);
   Genintern.register_intern0 wit_ltac (lift intern_ltac);

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -1705,7 +1705,7 @@ and interp_atomic ist tac : unit Proofview.tactic =
           Evd.MonadR.List.map_right (fun c sigma -> f sigma c) l (project gl)
         in
         Tacticals.New.tclTHEN (Proofview.Unsafe.tclEVARS sigma)
-        (Tactics.mutual_fix (interp_ident ist env sigma id) n l_interp 0)
+        (Tactics.mutual_fix (interp_lident ist env sigma id) n l_interp 0)
       end
       end
   | TacMutualCofix (id,l) ->
@@ -1720,7 +1720,7 @@ and interp_atomic ist tac : unit Proofview.tactic =
           Evd.MonadR.List.map_right (fun c sigma -> f sigma c) l (project gl)
         in
         Tacticals.New.tclTHEN (Proofview.Unsafe.tclEVARS sigma)
-        (Tactics.mutual_cofix (interp_ident ist env sigma id) l_interp 0)
+        (Tactics.mutual_cofix (interp_lident ist env sigma id) l_interp 0)
       end
       end
   | TacAssert (ev,b,t,ipat,c) ->

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -352,6 +352,9 @@ let interp_ident ist env sigma id =
   try try_interp_ltac_var (coerce_var_to_ident false env sigma) ist (Some (env,sigma)) (make id)
   with Not_found -> id
 
+let interp_lident ist env sigma id =
+  CAst.map (interp_ident ist env sigma) id
+
 (* Interprets an optional identifier, bound or fresh *)
 let interp_name ist env sigma = function
   | Anonymous -> Anonymous
@@ -2096,6 +2099,7 @@ let () =
   register_interp0 wit_ref (lift interp_reference);
   register_interp0 wit_pre_ident (lift interp_pre_ident);
   register_interp0 wit_ident (lift interp_ident);
+  register_interp0 wit_identref (lift interp_lident);
   register_interp0 wit_hyp (lift interp_hyp);
   register_interp0 wit_intropattern (lifts interp_intro_pattern) [@warning "-3"];
   register_interp0 wit_simple_intropattern (lifts interp_intro_pattern);

--- a/plugins/ltac/tacinterp.ml
+++ b/plugins/ltac/tacinterp.ml
@@ -897,14 +897,14 @@ let interp_binding_name ist env sigma = function
       (* If a name is bound, it has to be a quantified hypothesis *)
       (* user has to use other names for variables if these ones clash with *)
       (* a name intended to be used as a (non-variable) identifier *)
-      try try_interp_ltac_var (coerce_to_quantified_hypothesis sigma) ist (Some (env,sigma)) (make id)
+      try try_interp_ltac_var (coerce_to_quantified_hypothesis sigma) ist (Some (env,sigma)) id
       with Not_found -> NamedHyp id
 
 let interp_declared_or_quantified_hypothesis ist env sigma = function
   | AnonHyp n -> AnonHyp n
   | NamedHyp id ->
       try try_interp_ltac_var
-            (coerce_to_decl_or_quant_hyp sigma) ist (Some (env,sigma)) (make id)
+            (coerce_to_decl_or_quant_hyp sigma) ist (Some (env,sigma)) id
       with Not_found -> NamedHyp id
 
 let interp_binding ist env sigma {loc;v=(b,c)} =
@@ -978,7 +978,7 @@ let interp_destruction_arg ist gl arg =
           let id = out_gen (topwit wit_hyp) v in
           try_cast_id id
         else if has_type v (topwit wit_int) then
-          keep,ElimOnAnonHyp (out_gen (topwit wit_int) v)
+          keep,ElimOnAnonHyp (CAst.make @@ out_gen (topwit wit_int) v)
         else match Value.to_constr v with
         | None -> error ()
         | Some c -> keep,ElimOnConstr (fun env sigma -> (sigma, (c,NoBindings)))

--- a/plugins/ltac/tacsubst.ml
+++ b/plugins/ltac/tacsubst.ml
@@ -282,6 +282,7 @@ let () =
   Genintern.register_subst0 wit_smart_global subst_global_reference;
   Genintern.register_subst0 wit_pre_ident (fun _ v -> v);
   Genintern.register_subst0 wit_ident (fun _ v -> v);
+  Genintern.register_subst0 wit_identref (fun _ v -> v);
   Genintern.register_subst0 wit_hyp (fun _ v -> v);
   Genintern.register_subst0 wit_intropattern subst_intro_pattern [@warning "-3"];
   Genintern.register_subst0 wit_simple_intropattern subst_intro_pattern;

--- a/plugins/micromega/zify.ml
+++ b/plugins/micromega/zify.ml
@@ -1288,7 +1288,7 @@ let trans_hyp h t0 prfp =
           tclTHEN
             (Tactics.pose_proof (Name.Name h') prf)
             (tclTRY
-               (tclTHEN (Tactics.clear [h]) (Tactics.rename_hyp [(h', h)])))))
+               (tclTHEN (Tactics.clear [h]) (Tactics.rename_hyp [(CAst.make h', CAst.make h)])))))
 
 let trans_concl prfp =
   if debug then

--- a/plugins/ssr/ssripats.ml
+++ b/plugins/ssr/ssripats.ml
@@ -290,7 +290,7 @@ let intro_clear ids =
     let _, clear_ids, ren =
       List.fold_left (fun (used_ids, clear_ids, ren) id ->
             let new_id = Ssrcommon.mk_anon_id (Id.to_string id) used_ids in
-            (new_id :: used_ids, new_id :: clear_ids, (id, new_id) :: ren))
+            (new_id :: used_ids, new_id :: clear_ids, (CAst.make id, CAst.make new_id) :: ren))
                      (Tacmach.New.pf_ids_of_hyps gl, [], []) ids
     in
     Tactics.rename_hyp ren <*>

--- a/plugins/ssr/ssrparser.mlg
+++ b/plugins/ssr/ssrparser.mlg
@@ -166,7 +166,7 @@ open Pcoq.Prim
 ARGUMENT EXTEND ssrhyp TYPED AS ssrhyprep PRINTED BY { pr_ssrhyp }
                        INTERPRETED BY { interp_hyp }
                        GLOBALIZED BY { intern_hyp }
-  | [ ident(id) ] -> { SsrHyp (Loc.tag ~loc id) }
+  | [ identref(id) ] -> { SsrHyp (Loc.tag ~loc id.CAst.v) }
 END
 
 {
@@ -178,27 +178,27 @@ let wit_ssrhoirep = add_genarg "ssrhoirep" (fun env sigma -> pr_hoi)
 
 let intern_ssrhoi ist = function
   | Hyp h -> Hyp (intern_hyp ist h)
-  | Id (SsrHyp (_, id)) as hyp ->
-    let _ = Tacintern.intern_genarg ist (in_gen (rawwit wit_ident) id) in
+  | Id (SsrHyp (loc, id)) as hyp ->
+    let _ = Tacintern.intern_genarg ist (in_gen (rawwit wit_identref) (CAst.make ?loc id)) in
     hyp
 
 let interp_ssrhoi ist gl = function
   | Hyp h -> let s, h' = interp_hyp ist gl h in s, Hyp h'
   | Id (SsrHyp (loc, id)) ->
-    let s, id' = interp_wit wit_ident ist gl id in
-    s, Id (SsrHyp (loc, id'))
+    let s, id' = interp_wit wit_identref ist gl (CAst.make ?loc id) in
+    s, Id (SsrHyp (loc, id'.CAst.v))
 
 }
 
 ARGUMENT EXTEND ssrhoi_hyp TYPED AS ssrhoirep PRINTED BY { pr_ssrhoi }
                        INTERPRETED BY { interp_ssrhoi }
                        GLOBALIZED BY { intern_ssrhoi }
-  | [ ident(id) ] -> { Hyp (SsrHyp(Loc.tag ~loc id)) }
+  | [ identref(id) ] -> { Hyp (SsrHyp(Loc.tag ~loc id.CAst.v)) }
 END
 ARGUMENT EXTEND ssrhoi_id TYPED AS ssrhoirep PRINTED BY { pr_ssrhoi }
                        INTERPRETED BY { interp_ssrhoi }
                        GLOBALIZED BY { intern_ssrhoi }
-  | [ ident(id) ] -> { Id (SsrHyp(Loc.tag ~loc id)) }
+  | [ identref(id) ] -> { Id (SsrHyp(Loc.tag ~loc id.CAst.v)) }
 END
 
 (** Rewriting direction *)
@@ -781,8 +781,8 @@ ARGUMENT EXTEND ssripat TYPED AS ssripatrep list PRINTED BY { pr_ssripats }
   | [ "-/" integer(n) "/" integer (m) "=" ] ->
       { [IPatNoop;IPatSimpl(SimplCut(n,m))] }
   | [ ssrfwdview(v) ] -> { [IPatView v] }
-  | [ "[" ":" ident_list(idl) "]" ] -> { [IPatAbstractVars idl] }
-  | [ "[:" ident_list(idl) "]" ] -> { [IPatAbstractVars idl] }
+  | [ "[" ":" identref_list(idl) "]" ] -> { [IPatAbstractVars (List.map (fun {CAst.v=id} -> id) idl)] }
+  | [ "[:" identref_list(idl) "]" ] -> { [IPatAbstractVars (List.map (fun {CAst.v=id} -> id) idl)] }
 END
 
 ARGUMENT EXTEND ssripats TYPED AS ssripat PRINTED BY { pr_ssripats }
@@ -836,10 +836,10 @@ END
 GRAMMAR EXTEND Gram
   GLOBAL: ssrcpat;
   hat: [
-  [ "^"; id = ident -> { Prefix id }
-  | "^"; "~"; id = ident -> { SuffixId id }
+  [ "^"; id = identref -> { Prefix id.CAst.v }
+  | "^"; "~"; id = identref -> { SuffixId id.CAst.v }
   | "^"; "~"; n = natural -> { SuffixNum n }
-  | "^~"; id = ident -> { SuffixId id }
+  | "^~"; id = identref -> { SuffixId id.CAst.v }
   | "^~"; n = natural -> { SuffixNum n }
   ]];
   ssrcpat: [
@@ -973,13 +973,13 @@ end
 (** Defined identifier *)
 let pr_ssrfwdid id = pr_spc () ++ pr_id id
 
-let pr_ssrfwdidx _ _ _ = pr_ssrfwdid
+let pr_ssrfwdidx _ _ _ id = pr_ssrfwdid id.CAst.v
 
 }
 
 (* We use a primitive parser for the head identifier of forward *)
 (* tactis to avoid syntactic conflicts with basic Coq tactics. *)
-ARGUMENT EXTEND ssrfwdid TYPED AS ident PRINTED BY { pr_ssrfwdidx }
+ARGUMENT EXTEND ssrfwdid TYPED AS identref PRINTED BY { pr_ssrfwdidx }
 END
 
 {
@@ -994,7 +994,7 @@ let test_ssrfwdid =
 
 GRAMMAR EXTEND Gram
   GLOBAL: ssrfwdid;
-  ssrfwdid: [[ test_ssrfwdid; id = Prim.ident -> { id } ]];
+  ssrfwdid: [[ test_ssrfwdid; id = identref -> { id } ]];
   END
 
 
@@ -1295,7 +1295,7 @@ let pr_ssrbvar env sigma prc _ _ v = prc env sigma v
 }
 
 ARGUMENT EXTEND ssrbvar TYPED AS constr PRINTED BY { pr_ssrbvar env sigma }
-| [ ident(id) ] -> { mkCVar ~loc id }
+| [ identref(id) ] -> { mkCVar ~loc id.CAst.v }
 | [ "_" ] -> { mkCHole (Some loc) }
 END
 
@@ -1379,7 +1379,8 @@ let pr_ssrstruct _ _ _ = function
 
 }
 
-ARGUMENT EXTEND ssrstruct TYPED AS ident option PRINTED BY { pr_ssrstruct }
+ARGUMENT EXTEND ssrstruct TYPED AS ident option
+PRINTED BY { pr_ssrstruct }
 | [ "{" "struct" ident(id) "}" ] -> { Some id }
 | [ ] -> { None }
 END
@@ -1590,7 +1591,7 @@ let ssrorelse = Entry.create "ssrorelse"
 GRAMMAR EXTEND Gram
   GLOBAL: ssrorelse ssrseqarg;
   ssrseqidx: [
-    [ test_ssrseqvar; id = Prim.ident -> { ArgVar (CAst.make ~loc id) }
+    [ test_ssrseqvar; id = identref -> { ArgVar id }
     | n = Prim.natural -> { ArgArg (check_index ~loc n) }
     ] ];
   ssrswap: [[ IDENT "first" -> { loc, true } | IDENT "last" -> { loc, false } ]];
@@ -1646,15 +1647,15 @@ let ssr_id_of_string loc s =
     else Feedback.msg_warning (str (
      "The name " ^ s ^ " fits the _xxx_ format used for anonymous variables.\n"
   ^ "Scripts with explicit references to anonymous variables are fragile."))
-    end; Id.of_string s
+    end; CAst.make ~loc (Id.of_string s)
 
 let ssr_null_entry = Pcoq.Entry.of_parser "ssr_null" (fun _ _ -> ())
 
 }
 
 GRAMMAR EXTEND Gram
-  GLOBAL: Prim.ident;
-  Prim.ident: [[ s = IDENT; ssr_null_entry -> { ssr_id_of_string loc s } ]];
+  GLOBAL: Prim.identref;
+  Prim.identref: [[ s = IDENT; ssr_null_entry -> { ssr_id_of_string loc s } ]];
 END
 
 {
@@ -1965,7 +1966,7 @@ let test_ssreqid =
 GRAMMAR EXTEND Gram
   GLOBAL: ssreqid;
   ssreqpat: [
-    [ id = Prim.ident -> { IPatId id }
+    [ id = Prim.identref -> { IPatId id.CAst.v }
     | "_" -> { IPatAnon Drop }
     | "?" -> { IPatAnon (One None) }
     | "+" -> { IPatAnon Temporary }
@@ -2427,7 +2428,7 @@ END
 TACTIC EXTEND ssrpose
 | [ "pose" ssrfixfwd(ffwd) ] -> { ssrposetac ffwd }
 | [ "pose" ssrcofixfwd(ffwd) ] -> { ssrposetac ffwd }
-| [ "pose" ssrfwdid(id) ssrposefwd(fwd) ] -> { ssrposetac (id, fwd) }
+| [ "pose" ssrfwdid(id) ssrposefwd(fwd) ] -> { ssrposetac (id.CAst.v, fwd) }
 END
 
 (** The "set" tactic *)
@@ -2436,7 +2437,7 @@ END
 
 TACTIC EXTEND ssrset
 | [ "set" ssrfwdid(id) ssrsetfwd(fwd) ssrclauses(clauses) ] ->
-  { tclCLAUSES (ssrsettac id fwd) clauses }
+  { tclCLAUSES (ssrsettac id.CAst.v fwd) clauses }
 END
 
 (** The "have" tactic *)

--- a/plugins/ssr/ssrparser.mli
+++ b/plugins/ssr/ssrparser.mli
@@ -65,7 +65,7 @@ val wit_ssrhintarg :
 
 val wit_ssrexactarg : ssrapplyarg Genarg.uniform_genarg_type
 val wit_ssrcongrarg : ((int * ssrterm) * cpattern ssragens) Genarg.uniform_genarg_type
-val wit_ssrfwdid : Names.Id.t Genarg.uniform_genarg_type
+val wit_ssrfwdid : Names.lident Genarg.uniform_genarg_type
 
 val wit_ssrsetfwd :
   ((ssrfwdfmt * (cpattern * ast_closure_term option)) * ssrdocc) Genarg.uniform_genarg_type

--- a/plugins/ssr/ssrvernac.mlg
+++ b/plugins/ssr/ssrvernac.mlg
@@ -366,10 +366,10 @@ END
 GRAMMAR EXTEND Gram
   GLOBAL: hloc;
 hloc: [
-  [ "in"; "("; "Type"; "of"; id = ident; ")" ->
-    { Tacexpr.HypLocation (CAst.make id, Locus.InHypTypeOnly) }
-  | "in"; "("; IDENT "Value"; "of"; id = ident; ")" ->
-    { Tacexpr.HypLocation (CAst.make id, Locus.InHypValueOnly) }
+  [ "in"; "("; "Type"; "of"; id = identref; ")" ->
+    { Tacexpr.HypLocation (id, Locus.InHypTypeOnly) }
+  | "in"; "("; IDENT "Value"; "of"; id = identref; ")" ->
+    { Tacexpr.HypLocation (id, Locus.InHypValueOnly) }
   ] ];
 END
 

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -447,19 +447,19 @@ let clenv_independent clenv =
   List.filter (fun mv -> not (Metaset.mem mv deps)) mvs
 
 let qhyp_eq h1 h2 = match h1, h2 with
-| NamedHyp n1, NamedHyp n2 -> Id.equal n1 n2
-| AnonHyp i1, AnonHyp i2 -> Int.equal i1 i2
+| NamedHyp n1, NamedHyp n2 -> Id.equal n1.CAst.v n2.CAst.v
+| AnonHyp i1, AnonHyp i2 -> Int.equal i1.CAst.v i2.CAst.v
 | _ -> false
 
 let check_bindings bl =
   match List.duplicates qhyp_eq (List.map (fun {CAst.v=x} -> fst x) bl) with
     | NamedHyp s :: _ ->
         user_err
-          (str "The variable " ++ Id.print s ++
+          (str "The variable " ++ Id.print s.CAst.v ++
            str " occurs more than once in binding list.");
     | AnonHyp n :: _ ->
         user_err
-          (str "The position " ++ int n ++
+          (str "The position " ++ int n.CAst.v ++
            str " occurs more than once in binding list.")
     | [] -> ()
 
@@ -480,7 +480,7 @@ let explain_no_such_bound_variable evd id =
          str (if List.length mvl == 1 then " is: " else "s are: ") ++
          pr_enum Id.print mvl ++ str").")))
 
-let meta_with_name evd id =
+let meta_with_name evd {CAst.v=id;loc} =
   let na = Name id in
   let fold (l1, l2 as l) (n, clb) =
     let (na',def) = match clb with
@@ -497,25 +497,25 @@ let meta_with_name evd id =
     | ([n],_|_,[n]) ->
         n
     | _  ->
-        user_err ~hdr:"Evd.meta_with_name"
+        user_err ?loc ~hdr:"Evd.meta_with_name"
           (str "Binder name \"" ++ Id.print id ++
            strbrk "\" occurs more than once in clause.")
 
 let meta_of_binder clause loc mvs = function
   | NamedHyp s -> meta_with_name clause.evd s
-  | AnonHyp n ->
+  | AnonHyp {CAst.v=n;loc} ->
       try List.nth mvs (n-1)
       with (Failure _|Invalid_argument _) ->
-        user_err  (str "No such binder.")
+        user_err ?loc (str "No such binder.")
 
 let error_already_defined b =
   match b with
-    | NamedHyp id ->
-        user_err
+    | NamedHyp {CAst.v=id;loc} ->
+        user_err ?loc
           (str "Binder name \"" ++ Id.print id ++
            str"\" already defined with incompatible value.")
-    | AnonHyp n ->
-        anomaly
+    | AnonHyp {CAst.v=n;loc} ->
+        anomaly ?loc
           (str "Position " ++ int n ++ str" already defined.")
 
 let clenv_unify_binding_type clenv c t u =
@@ -795,7 +795,7 @@ let explain_no_such_bound_variable holes id =
   in
   user_err  (str "No such bound variable " ++ Id.print id ++ expl)
 
-let evar_with_name holes id =
+let evar_with_name holes {CAst.v=id;loc} =
   let map h = match h.hole_name with
   | Anonymous -> None
   | Name id' -> if Id.equal id id' then Some h else None
@@ -805,19 +805,19 @@ let evar_with_name holes id =
   | [] -> explain_no_such_bound_variable holes id
   | [h] -> h.hole_evar
   | _ ->
-    user_err
+    user_err ?loc
       (str "Binder name \"" ++ Id.print id ++
         str "\" occurs more than once in clause.")
 
 let evar_of_binder holes = function
 | NamedHyp s -> evar_with_name holes s
-| AnonHyp n ->
+| AnonHyp {CAst.v=n;loc} ->
   try
     let nondeps = List.filter (fun hole -> not hole.hole_deps) holes in
     let h = List.nth nondeps (pred n) in
     h.hole_evar
   with e when CErrors.noncritical e ->
-    user_err  (str "No such binder.")
+    user_err ?loc (str "No such binder.")
 
 let define_with_type sigma env ev c =
   let open EConstr in

--- a/proofs/miscprint.ml
+++ b/proofs/miscprint.ml
@@ -45,8 +45,8 @@ and pr_or_and_intro_pattern prc = function
 
 (** Printing of bindings *)
 let pr_binding prc = let open CAst in function
-  | {loc;v=(NamedHyp id, c)} -> hov 1 (Names.Id.print id ++ str " := " ++ cut () ++ prc c)
-  | {loc;v=(AnonHyp n, c)} -> hov 1 (int n ++ str " := " ++ cut () ++ prc c)
+  | {loc;v=(NamedHyp id, c)} -> hov 1 (Names.Id.print id.CAst.v ++ str " := " ++ cut () ++ prc c)
+  | {loc;v=(AnonHyp n, c)} -> hov 1 (int n.CAst.v ++ str " := " ++ cut () ++ prc c)
 
 let pr_bindings prc prlc = function
   | ImplicitBindings l ->

--- a/proofs/tactypes.ml
+++ b/proofs/tactypes.ml
@@ -32,7 +32,7 @@ and 'constr or_and_intro_pattern_expr =
 
 (** Bindings *)
 
-type quantified_hypothesis = AnonHyp of int | NamedHyp of Id.t
+type quantified_hypothesis = AnonHyp of int CAst.t | NamedHyp of Id.t CAst.t
 
 type 'a explicit_bindings = (quantified_hypothesis * 'a) CAst.t list
 

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -1775,7 +1775,7 @@ let subst_one dep_proof_ok x (hyp,rhs,dir) =
     ((if need_rewrite then
       [revert (List.map snd dephyps);
        general_rewrite dir AtLeastOneOccurrence true dep_proof_ok (mkVar hyp);
-       (tclMAP (fun (dest,id) -> intro_move (Some id) dest) dephyps)]
+       (tclMAP (fun (dest,id) -> intro_move (Some (CAst.make id)) dest) dephyps)]
       else
        [Proofview.tclUNIT ()]) @
      [tclTRY (clear [x; hyp])])

--- a/tactics/inv.ml
+++ b/tactics/inv.ml
@@ -529,13 +529,13 @@ let inv_gen thin status names =
 
 let inv k = inv_gen k NoDep
 
-let inv_tac id       = inv FullInversion None (NamedHyp id)
-let inv_clear_tac id = inv FullInversionClear None (NamedHyp id)
+let inv_tac id       = inv FullInversion None (NamedHyp (CAst.make id))
+let inv_clear_tac id = inv FullInversionClear None (NamedHyp (CAst.make id))
 
 let dinv k c = inv_gen k (Dep c)
 
-let dinv_tac id       = dinv FullInversion None None (NamedHyp id)
-let dinv_clear_tac id = dinv FullInversionClear None None (NamedHyp id)
+let dinv_tac id       = dinv FullInversion None None (NamedHyp (CAst.make id))
+let dinv_clear_tac id = dinv FullInversionClear None None (NamedHyp (CAst.make id))
 
 (* InvIn will bring the specified clauses into the conclusion, and then
  * perform inversion on the named hypothesis.  After, it will intro them

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -141,7 +141,7 @@ let introduction id =
     | _ -> raise (RefinerError (env, sigma, IntroNeedsProduct))
   end
 
-let error msg = CErrors.user_err Pp.(str msg)
+let error ?loc msg = CErrors.user_err ?loc Pp.(str msg)
 
 let convert_concl ~check ty k =
   Proofview.Goal.enter begin fun gl ->
@@ -538,7 +538,7 @@ let rec check_mutind env sigma k cl = match EConstr.kind sigma (strip_outer_cast
 | _ -> error "Not enough products."
 
 (* Refine as a fixpoint *)
-let mutual_fix f n rest j = Proofview.Goal.enter begin fun gl ->
+let mutual_fix {CAst.v=f;loc} n rest j = Proofview.Goal.enter begin fun gl ->
   let env = Proofview.Goal.env gl in
   let sigma = Tacmach.New.project gl in
   let concl = Proofview.Goal.concl gl in
@@ -553,7 +553,7 @@ let mutual_fix f n rest j = Proofview.Goal.enter begin fun gl ->
     if not (QMutInd.equal env sp sp') then
       error "Fixpoints should be on the same mutual inductive declaration.";
     if mem_named_context_val f sign then
-      user_err ~hdr:"Logic.prim_refiner"
+      user_err ?loc ~hdr:"Logic.prim_refiner"
         (str "Name " ++ Id.print f ++ str " already used in the environment");
     mk_sign (push_named_context_val (LocalAssum (make_annot f Sorts.Relevant, ar)) sign) oth
   in
@@ -587,7 +587,7 @@ let rec check_is_mutcoind env sigma cl =
       error "All methods must construct elements in coinductive types."
 
 (* Refine as a cofixpoint *)
-let mutual_cofix f others j = Proofview.Goal.enter begin fun gl ->
+let mutual_cofix {CAst.v=f;loc} others j = Proofview.Goal.enter begin fun gl ->
   let env = Proofview.Goal.env gl in
   let sigma = Tacmach.New.project gl in
   let concl = Proofview.Goal.concl gl in
@@ -599,7 +599,7 @@ let mutual_cofix f others j = Proofview.Goal.enter begin fun gl ->
   | (f, ar) :: oth ->
     let open Context.Named.Declaration in
     if mem_named_context_val f sign then
-      error "Name already used in the environment.";
+      error ?loc "Name already used in the environment.";
     mk_sign (push_named_context_val (LocalAssum (make_annot f Sorts.Relevant, ar)) sign) oth
   in
   let nenv = reset_with_named_context (mk_sign (named_context_val env) all) env in

--- a/tactics/tactics.mli
+++ b/tactics/tactics.mli
@@ -202,7 +202,7 @@ val apply_clear_request : clear_flag -> bool -> constr -> unit Proofview.tactic
 val specialize    : constr with_bindings -> intro_pattern option -> unit Proofview.tactic
 
 val move_hyp      : Id.t -> Id.t Logic.move_location -> unit Proofview.tactic
-val rename_hyp    : (Id.t * Id.t) list -> unit Proofview.tactic
+val rename_hyp    : (lident * lident) list -> unit Proofview.tactic
 
 val revert        : Id.t list -> unit Proofview.tactic
 

--- a/tactics/tactics.mli
+++ b/tactics/tactics.mli
@@ -40,10 +40,10 @@ val convert_concl_no_check : types -> cast_kind -> unit Proofview.tactic
 val convert_hyp_no_check : named_declaration -> unit Proofview.tactic
 [@@ocaml.deprecated "use [Tactics.convert_hyp]"]
 val mutual_fix      :
-  Id.t -> int -> (Id.t * int * constr) list -> int -> unit Proofview.tactic
-val fix             : Id.t -> int -> unit Proofview.tactic
-val mutual_cofix    : Id.t -> (Id.t * constr) list -> int -> unit Proofview.tactic
-val cofix           : Id.t -> unit Proofview.tactic
+  lident -> int -> (Id.t * int * constr) list -> int -> unit Proofview.tactic
+val fix             : lident -> int -> unit Proofview.tactic
+val mutual_cofix    : lident -> (Id.t * constr) list -> int -> unit Proofview.tactic
+val cofix           : lident -> unit Proofview.tactic
 
 val convert         : constr -> constr -> unit Proofview.tactic
 val convert_leq     : constr -> constr -> unit Proofview.tactic

--- a/tactics/tactics.mli
+++ b/tactics/tactics.mli
@@ -110,7 +110,7 @@ type clear_flag = bool option (* true = clear hyp, false = keep hyp, None = use 
 type 'a core_destruction_arg =
   | ElimOnConstr of 'a
   | ElimOnIdent of lident
-  | ElimOnAnonHyp of int
+  | ElimOnAnonHyp of int CAst.t
 
 type 'a destruction_arg =
   clear_flag * 'a core_destruction_arg

--- a/tactics/tactics.mli
+++ b/tactics/tactics.mli
@@ -56,8 +56,8 @@ val find_intro_names : rel_context -> Goal.goal sigma -> Id.t list
 
 val intro                : unit Proofview.tactic
 val introf               : unit Proofview.tactic
-val intro_move        : Id.t option -> Id.t Logic.move_location -> unit Proofview.tactic
-val intro_move_avoid  : Id.t option -> Id.Set.t -> Id.t Logic.move_location -> unit Proofview.tactic
+val intro_move        : lident option -> Id.t Logic.move_location -> unit Proofview.tactic
+val intro_move_avoid  : lident option -> Id.Set.t -> Id.t Logic.move_location -> unit Proofview.tactic
 
   (** [intro_avoiding idl] acts as intro but prevents the new Id.t
      to belong to [idl] *)

--- a/test-suite/output/ErrorLocation_12152_2.out
+++ b/test-suite/output/ErrorLocation_12152_2.out
@@ -1,3 +1,3 @@
-File "stdin", line 3, characters 0-8:
+File "stdin", line 3, characters 7-8:
 Error: No product even after head-reduction.
 

--- a/test-suite/output/Errors.out
+++ b/test-suite/output/Errors.out
@@ -6,7 +6,7 @@ The command has indeed failed with message:
 In nested Ltac calls to "f" and "apply x", last call failed.
 Unable to unify "nat" with "True".
 The command has indeed failed with message:
-Ltac call to "instantiate ( (ident) := (lglob) )" failed.
+Ltac call to "instantiate ( (identref) := (lglob) )" failed.
 Instance is not well-typed in the environment of ?x.
 The command has indeed failed with message:
 Cannot infer ?T in the partial instance "?T -> nat" found for the type of f.

--- a/user-contrib/Ltac2/g_ltac2.mlg
+++ b/user-contrib/Ltac2/g_ltac2.mlg
@@ -195,7 +195,7 @@ GRAMMAR EXTEND Gram
       | -> { false } ] ]
   ;
   ltac2_typevar:
-    [ [ "'"; id = Prim.ident -> { id } ] ]
+    [ [ "'"; id = Prim.identref -> { id.CAst.v } ] ]
   ;
   tactic_atom:
     [ [ n = Prim.integer -> { CAst.make ~loc @@ CTacAtm (AtmInt n) }
@@ -205,7 +205,7 @@ GRAMMAR EXTEND Gram
           CAst.make ~loc @@ CTacCst (RelId qid)
         else
           CAst.make ~loc @@ CTacRef (RelId qid) }
-      | "@"; id = Prim.ident -> { Tac2quote.of_ident (CAst.make ~loc id) }
+      | "@"; id = lident -> { Tac2quote.of_ident (CAst.make ~loc id.CAst.v) }
       | "&"; id = lident -> { Tac2quote.of_hyp ~loc id }
       | "'"; c = Constr.constr -> { inj_open_constr loc c }
       | IDENT "constr"; ":"; "("; c = Constr.lconstr; ")" -> { Tac2quote.of_constr c }
@@ -218,12 +218,12 @@ GRAMMAR EXTEND Gram
     ] ]
   ;
   ltac1_expr_in_env:
-    [ [ test_ltac1_env; ids = LIST0 locident; "|-"; e = ltac_expr -> { ids, e }
+    [ [ test_ltac1_env; ids = LIST0 lident; "|-"; e = ltac_expr -> { ids, e }
       | e = ltac_expr -> { [], e }
     ] ]
   ;
   tac2expr_in_env :
-    [ [ test_ltac1_env; ids = LIST0 locident; "|-"; e = ltac2_expr ->
+    [ [ test_ltac1_env; ids = LIST0 lident; "|-"; e = ltac2_expr ->
       { let check { CAst.v = id; CAst.loc = loc } =
           if Tac2env.is_constructor (Libnames.qualid_of_ident ?loc id) then
             CErrors.user_err ?loc Pp.(str "Invalid bound Ltac2 identifier " ++ Id.print id)
@@ -274,12 +274,11 @@ GRAMMAR EXTEND Gram
       | qid = Prim.qualid -> { CAst.make ~loc @@ CTypRef (RelId qid, []) }
       ]
     ];
-  locident:
-    [ [ id = Prim.ident -> { CAst.make ~loc id } ] ]
+  lident:
+    [ [ id = Prim.identref -> { id } ] ]
   ;
   binder:
-    [ [ "_" -> { CAst.make ~loc Anonymous }
-      | l = Prim.ident -> { CAst.make ~loc (Name l) } ] ]
+    [ [ na = Prim.name -> { na } ] ]
   ;
   input_fun:
     [ [ b = tac2pat LEVEL "0" -> { b } ] ]
@@ -296,7 +295,7 @@ GRAMMAR EXTEND Gram
     ] ]
   ;
   tac2def_mut:
-    [ [ "Set"; qid = Prim.qualid; old = OPT [ "as"; id = locident -> { id } ]; ":="; e = ltac2_expr -> { StrMut (qid, old, e) } ] ]
+    [ [ "Set"; qid = Prim.qualid; old = OPT [ "as"; id = lident -> { id } ]; ":="; e = ltac2_expr -> { StrMut (qid, old, e) } ] ]
   ;
   tac2typ_knd:
     [ [ t = ltac2_type -> { CTydDef (Some t) }
@@ -309,8 +308,8 @@ GRAMMAR EXTEND Gram
       | cs = LIST0 tac2alg_constructor SEP "|" -> { cs } ] ]
   ;
   tac2alg_constructor:
-    [ [ c = Prim.ident -> { (c, []) }
-      | c = Prim.ident; "("; args = LIST0 ltac2_type SEP ","; ")"-> { (c, args) } ] ]
+    [ [ c = Prim.identref -> { (c.CAst.v, []) }
+      | c = Prim.identref; "("; args = LIST0 ltac2_type SEP ","; ")"-> { (c.CAst.v, args) } ] ]
   ;
   tac2rec_fields:
     [ [ f = tac2rec_field; ";"; l = tac2rec_fields -> { f :: l }
@@ -319,7 +318,7 @@ GRAMMAR EXTEND Gram
       | -> { [] } ] ]
   ;
   tac2rec_field:
-    [ [ mut = mut_flag; id = Prim.ident; ":"; t = ltac2_type -> { (id, mut, t) } ] ]
+    [ [ mut = mut_flag; id = Prim.identref; ":"; t = ltac2_type -> { (id.CAst.v, mut, t) } ] ]
   ;
   tac2rec_fieldexprs:
     [ [ f = tac2rec_fieldexpr; ";"; l = tac2rec_fieldexprs -> { f :: l }
@@ -351,7 +350,7 @@ GRAMMAR EXTEND Gram
     ] ]
   ;
   tac2def_ext:
-    [ [ "@"; IDENT "external"; id = locident; ":"; t = ltac2_type LEVEL "5"; ":=";
+    [ [ "@"; IDENT "external"; id = lident; ":"; t = ltac2_type LEVEL "5"; ":=";
         plugin = Prim.string; name = Prim.string ->
       { let ml = { mltac_plugin = plugin; mltac_tactic = name } in
         StrPrm (id, t, ml) }
@@ -359,7 +358,7 @@ GRAMMAR EXTEND Gram
   ;
   syn_node:
     [ [ "_" -> { CAst.make ~loc None }
-      | id = Prim.ident -> { CAst.make ~loc (Some id) }
+      | id = Prim.identref -> { CAst.make ~loc (Some id.CAst.v) }
     ] ]
   ;
   ltac2_scope:
@@ -382,10 +381,10 @@ GRAMMAR EXTEND Gram
     ] ]
   ;
   lident:
-    [ [ id = Prim.ident -> { CAst.make ~loc id } ] ]
+    [ [ id = Prim.identref -> { id } ] ]
   ;
   globref:
-    [ [ "&"; id = Prim.ident -> { CAst.make ~loc (QHypothesis id) }
+    [ [ "&"; id = Prim.identref -> { CAst.make ~loc (QHypothesis id.CAst.v) }
       | qid = Prim.qualid -> { CAst.make ~loc @@ QReference qid }
     ] ]
   ;
@@ -407,15 +406,15 @@ GRAMMAR EXTEND Gram
           q_destruction_arg q_reference q_with_bindings q_constr_matching
           q_goal_matching q_hintdb q_move_location q_pose q_assert;
   anti:
-    [ [ "$"; id = Prim.ident -> { QAnti (CAst.make ~loc id) } ] ]
+    [ [ "$"; id = Prim.identref -> { QAnti (CAst.make ~loc id.CAst.v) } ] ]
   ;
   ident_or_anti:
     [ [ id = lident -> { QExpr id }
-      | "$"; id = Prim.ident -> { QAnti (CAst.make ~loc id) }
+      | "$"; id = Prim.identref -> { QAnti (CAst.make ~loc id.CAst.v) }
     ] ]
   ;
   lident:
-    [ [ id = Prim.ident -> { CAst.make ~loc id } ] ]
+    [ [ id = Prim.identref -> { id } ] ]
   ;
   lnatural:
     [ [ n = Prim.natural -> { CAst.make ~loc n } ] ]
@@ -522,7 +521,7 @@ GRAMMAR EXTEND Gram
   ;
   nat_or_anti:
     [ [ n = lnatural -> { QExpr n }
-      | "$"; id = Prim.ident -> { QAnti (CAst.make ~loc id) }
+      | "$"; id = Prim.identref -> { QAnti (CAst.make ~loc id.CAst.v) }
     ] ]
   ;
   eqn_ipat:
@@ -685,9 +684,9 @@ GRAMMAR EXTEND Gram
     ] ]
   ;
   refglobal:
-    [ [ "&"; id = Prim.ident -> { QExpr (CAst.make ~loc @@ QHypothesis id) }
+    [ [ "&"; id = Prim.identref -> { QExpr (CAst.make ~loc @@ QHypothesis id.CAst.v) }
       | qid = Prim.qualid -> { QExpr (CAst.make ~loc @@ QReference qid) }
-      | "$"; id = Prim.ident -> { QAnti (CAst.make ~loc id) }
+      | "$"; id = Prim.identref -> { QAnti (CAst.make ~loc id.CAst.v) }
     ] ]
   ;
   q_reference:
@@ -721,8 +720,8 @@ GRAMMAR EXTEND Gram
     [ [ db = hintdb -> { db } ] ]
   ;
   match_pattern:
-    [ [ IDENT "context";  id = OPT Prim.ident;
-          "["; pat = Constr.cpattern; "]" -> { CAst.make ~loc @@ QConstrMatchContext (id, pat) }
+    [ [ IDENT "context";  id = OPT Prim.identref;
+          "["; pat = Constr.cpattern; "]" -> { CAst.make ~loc @@ QConstrMatchContext (Option.map (fun {CAst.v=id} -> id) id, pat) }
       | pat = Constr.cpattern -> { CAst.make ~loc @@ QConstrMatchPattern pat } ] ]
   ;
   match_rule:
@@ -817,12 +816,12 @@ GRAMMAR EXTEND Gram
     [ [ IDENT "ltac2"; ":"; "("; tac = ltac2_expr; ")" ->
       { let arg = Genarg.in_gen (Genarg.rawwit Tac2env.wit_ltac2_constr) tac in
         CAst.make ~loc (CHole (None, Namegen.IntroAnonymous, Some arg)) }
-      | test_ampersand_ident; "&"; id = Prim.ident ->
-      { let tac = Tac2quote.of_exact_hyp ~loc (CAst.make ~loc id) in
+      | test_ampersand_ident; "&"; id = Prim.identref ->
+      { let tac = Tac2quote.of_exact_hyp ~loc (CAst.make ~loc id.CAst.v) in
         let arg = Genarg.in_gen (Genarg.rawwit Tac2env.wit_ltac2_constr) tac in
         CAst.make ~loc (CHole (None, Namegen.IntroAnonymous, Some arg)) }
-      | test_dollar_ident; "$"; id = Prim.ident ->
-      { let id = Loc.tag ~loc id in
+      | test_dollar_ident; "$"; id = Prim.identref ->
+      { let id = Loc.tag ~loc id.CAst.v in
         let arg = Genarg.in_gen (Genarg.rawwit Tac2env.wit_ltac2_quotation) id in
         CAst.make ~loc (CHole (None, Namegen.IntroAnonymous, Some arg)) }
     ] ]
@@ -838,9 +837,9 @@ let (++) r s = Pcoq.Rule.next r s in
 let rules = [
   Pcoq.(
     Production.make
-      (Rule.stop ++ Symbol.nterm test_dollar_ident ++ Symbol.token (PKEYWORD "$") ++ Symbol.nterm Prim.ident)
+      (Rule.stop ++ Symbol.nterm test_dollar_ident ++ Symbol.token (PKEYWORD "$") ++ Symbol.nterm Prim.identref)
     begin fun id _ _ loc ->
-      let id = Loc.tag ~loc id in
+      let id = Loc.tag ~loc id.CAst.v in
       let arg = Genarg.in_gen (Genarg.rawwit Tac2env.wit_ltac2_quotation) id in
       CAst.make ~loc (CHole (None, Namegen.IntroAnonymous, Some arg))
     end
@@ -848,9 +847,9 @@ let rules = [
 
   Pcoq.(
     Production.make
-      (Rule.stop ++ Symbol.nterm test_ampersand_ident ++ Symbol.token (PKEYWORD "&") ++ Symbol.nterm Prim.ident)
+      (Rule.stop ++ Symbol.nterm test_ampersand_ident ++ Symbol.token (PKEYWORD "&") ++ Symbol.nterm Prim.identref)
     begin fun id _ _ loc ->
-      let tac = Tac2quote.of_exact_hyp ~loc (CAst.make ~loc id) in
+      let tac = Tac2quote.of_exact_hyp ~loc (CAst.make ~loc id.CAst.v) in
       let arg = Genarg.in_gen (Genarg.rawwit Tac2env.wit_ltac2_constr) tac in
       CAst.make ~loc (CHole (None, Namegen.IntroAnonymous, Some arg))
     end

--- a/user-contrib/Ltac2/tac2extffi.ml
+++ b/user-contrib/Ltac2/tac2extffi.ml
@@ -19,8 +19,8 @@ let make_to_repr f = Tac2ffi.make_repr (fun _ -> assert false) f
 (** More ML representations *)
 
 let to_qhyp v = match Value.to_block v with
-| (0, [| i |]) -> AnonHyp (Value.to_int i)
-| (1, [| id |]) -> NamedHyp (Value.to_ident id)
+| (0, [| i |]) -> AnonHyp (CAst.make @@ Value.to_int i)
+| (1, [| id |]) -> NamedHyp (CAst.make @@ Value.to_ident id)
 | _ -> assert false
 
 let qhyp = make_to_repr to_qhyp

--- a/user-contrib/Ltac2/tac2stdlib.ml
+++ b/user-contrib/Ltac2/tac2stdlib.ml
@@ -494,7 +494,7 @@ let () = define_prim2 "tac_split" bool bindings begin fun ev bnd ->
 end
 
 let () = define_prim1 "tac_rename" (list (pair ident ident)) begin fun ids ->
-  Tactics.rename_hyp ids
+  Tactics.rename_hyp (List.map (fun (src,dst) -> (CAst.make src,CAst.make dst)) ids)
 end
 
 let () = define_prim1 "tac_revert" (list ident) begin fun ids ->

--- a/user-contrib/Ltac2/tac2stdlib.ml
+++ b/user-contrib/Ltac2/tac2stdlib.ml
@@ -427,7 +427,7 @@ end
 
 let () = define_prim2 "tac_intro" (option ident) (option move_location) begin fun id mv ->
   let mv = Option.default Logic.MoveLast mv in
-  Tactics.intro_move id mv
+  Tactics.intro_move (Option.map CAst.make id) mv
 end
 
 (*

--- a/user-contrib/Ltac2/tac2stdlib.ml
+++ b/user-contrib/Ltac2/tac2stdlib.ml
@@ -504,11 +504,11 @@ end
 let () = define_prim0 "tac_admit" Proofview.give_up
 
 let () = define_prim2 "tac_fix" ident int begin fun ident n ->
-  Tactics.fix ident n
+  Tactics.fix (CAst.make ident) n
 end
 
 let () = define_prim1 "tac_cofix" ident begin fun ident ->
-  Tactics.cofix ident
+  Tactics.cofix (CAst.make ident)
 end
 
 let () = define_prim1 "tac_clear" (list ident) begin fun ids ->

--- a/user-contrib/Ltac2/tac2tactics.ml
+++ b/user-contrib/Ltac2/tac2tactics.ml
@@ -113,7 +113,7 @@ let mk_destruction_arg = function
   let c = c >>= fun c -> return (mk_with_bindings c) in
   Tactics.ElimOnConstr (delayed_of_tactic c)
 | ElimOnIdent id -> Tactics.ElimOnIdent CAst.(make id)
-| ElimOnAnonHyp n -> Tactics.ElimOnAnonHyp n
+| ElimOnAnonHyp n -> Tactics.ElimOnAnonHyp CAst.(make n)
 
 let mk_induction_clause (arg, eqn, as_, occ) =
   let eqn = Option.map (fun ipat -> CAst.make @@ mk_intro_pattern_naming ipat) eqn in
@@ -348,7 +348,7 @@ let on_destruction_arg tac ev arg =
       let (sigma', c) = Unification.finish_evar_resolution ~flags env sigma' (sigma, c) in
       Proofview.tclUNIT (Some sigma', Tactics.ElimOnConstr (c, lbind))
     | ElimOnIdent id -> Proofview.tclUNIT (None, Tactics.ElimOnIdent CAst.(make id))
-    | ElimOnAnonHyp n -> Proofview.tclUNIT (None, Tactics.ElimOnAnonHyp n)
+    | ElimOnAnonHyp n -> Proofview.tclUNIT (None, Tactics.ElimOnAnonHyp CAst.(make n))
     in
     arg >>= fun (sigma', arg) ->
     let arg = Some (clear, arg) in
@@ -434,12 +434,12 @@ let inversion knd arg pat ids =
     | Some (_, Tactics.ElimOnAnonHyp n) ->
       Inv.inv_clause knd pat ids (AnonHyp n)
     | Some (_, Tactics.ElimOnIdent {CAst.v=id}) ->
-      Inv.inv_clause knd pat ids (NamedHyp id)
+      Inv.inv_clause knd pat ids (NamedHyp CAst.(make id))
     | Some (_, Tactics.ElimOnConstr c) ->
       let open Tactypes in
       let anon = CAst.make @@ IntroNaming Namegen.IntroAnonymous in
       Tactics.specialize c (Some anon) >>= fun () ->
-      Tacticals.New.onLastHypId (fun id -> Inv.inv_clause knd pat ids (NamedHyp id))
+      Tacticals.New.onLastHypId (fun id -> Inv.inv_clause knd pat ids (NamedHyp CAst.(make id)))
     end
   in
   on_destruction_arg inversion true (Some (None, arg))

--- a/user-contrib/Ltac2/tac2types.mli
+++ b/user-contrib/Ltac2/tac2types.mli
@@ -20,8 +20,8 @@ type advanced_flag = bool
 type 'a thunk = (unit, 'a) Tac2ffi.fun1
 
 type quantified_hypothesis = Tactypes.quantified_hypothesis =
-| AnonHyp of int
-| NamedHyp of Id.t
+| AnonHyp of int CAst.t
+| NamedHyp of Id.t CAst.t
 
 type explicit_bindings = (quantified_hypothesis * EConstr.t) list
 

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -1474,7 +1474,7 @@ let start_equations ~name ~info ~hook ~types sigma goals =
 let rec_tac_initializer finite guard thms snl =
   if finite then
     match List.map (fun { CInfo.name; typ } -> name, (EConstr.of_constr typ)) thms with
-    | (id,_)::l -> Tactics.mutual_cofix id l 0
+    | (id,_)::l -> Tactics.mutual_cofix (CAst.make id) l 0
     | _ -> assert false
   else
     (* nl is dummy: it will be recomputed at Qed-time *)
@@ -1482,7 +1482,7 @@ let rec_tac_initializer finite guard thms snl =
      | None -> List.map succ (List.map List.last guard)
      | Some nl -> nl
     in match List.map2 (fun { CInfo.name; typ } n -> (name, n, (EConstr.of_constr typ))) thms nl with
-       | (id,n,_)::l -> Tactics.mutual_fix id n l 0
+       | (id,n,_)::l -> Tactics.mutual_fix (CAst.make id) n l 0
        | _ -> assert false
 
 let start_with_initialization ~info ~cinfo sigma =


### PR DESCRIPTION
**Kind:** "cleanup"

This is part of the project started in [#11842](https://github.com/coq/coq/pull/11842#issuecomment-699600005).

We use located identifiers in tactics in anticipation of identifying `Prim.identref` and `Prim.ident`, with the latter eventually taking a location by default and the former being eventually deprecated.

Tactics `intro_move`, `rename_hyp`, `instantiate_by_name`, `fix`/`cofix`, `destruct`, ... now take a located identifier. This is a compromise in the sense that internal calls to these tactics need to add a dummy loc just to comply to the extended API. On the other side, having the location at hand in error messages is desirable when the call directly comes from the user (for instance, `intros H` may now hightlight `H`, though there are still some issues, as indicated in #13100, which make that `intro H` does not highlight errors on `H`).

The first commit is shared with #13102 (it does not matter which PR comes first). 

The four next commits are about tactics but do not concern interpretation, thus, in some sense, they could have been alternatively in #13100 (for `HypLocation`) or #13102 (for `Derive Inversion` or Ltac definitions).

The last six commits (7th to 12th) rely on the support for located identifiers in `ARGUMENT EXTEND` and `TACTIC EXTEND`, which is provided by the 6th commit.

In `ssrparser`, some harmonization could be done, e.g. using `Id.t CAst.t` in some places rather than `Id.t Loc.located` (e.g. in `SsrHyp`). I can do it if there is a will to, or the work can also be shared, if this is what is preferred.

In Ltac2, I did not change the parsing rules so that they possibly pass located identifiers to tactics. I may try to do it, if there is a demand.