### PR TITLE
[nix] CI script wrapper now requires Python

### DIFF
--- a/dev/ci/nix/default.nix
+++ b/dev/ci/nix/default.nix
@@ -131,7 +131,8 @@ stdenv.mkDerivation {
   name = "shell-for-${project}-in-${branch}";
 
   buildInputs =
-    optional withCoq coq
+    [ python ]
+  ++  optional withCoq coq
   ++ (prj.buildInputs or [])
   ++ optionals withCoq (prj.coqBuildInputs or [])
   ;


### PR DESCRIPTION
See https://github.com/coq/coq/blob/9c2228ff011dc6188b70084fa1e1a5158affcf24/dev/ci/ci-wrapper.sh#L19