### PR TITLE
Derive Inversion does not allow leftover evars

### DIFF
--- a/plugins/ltac/leminv.ml
+++ b/plugins/ltac/leminv.ml
@@ -245,7 +245,8 @@ let add_inversion_lemma ~poly name env sigma t sort dep inv_op =
 let add_inversion_lemma_exn ~poly na com comsort bool tac =
   let env = Global.env () in
   let sigma = Evd.from_env env in
-  let sigma, c = Constrintern.interp_type_evars ~program_mode:false env sigma com in
+  let c, uctx = Constrintern.interp_type env sigma com in
+  let sigma = Evd.from_ctx uctx in
   let sigma, sort = Evd.fresh_sort_in_family ~rigid:univ_rigid sigma comsort in
   add_inversion_lemma ~poly na env sigma c sort bool tac
 

--- a/test-suite/bugs/closed/bug_12917.v
+++ b/test-suite/bugs/closed/bug_12917.v
@@ -1,0 +1,1 @@
+Fail Derive Inversion bla with (le _ _).


### PR DESCRIPTION
Fix #12917
