### PR TITLE
Remove irrelevant shift argument from interp_context_evars

### DIFF
--- a/interp/constrintern.mli
+++ b/interp/constrintern.mli
@@ -156,7 +156,7 @@ val interp_binder_evars : env -> evar_map -> Name.t -> constr_expr -> evar_map *
 (** Interpret contexts: returns extended env and context *)
 
 val interp_context_evars :
-  ?program_mode:bool -> ?impl_env:internalization_env -> ?shift:int ->
+  ?program_mode:bool -> ?impl_env:internalization_env ->
   env -> evar_map -> local_binder_expr list ->
   evar_map * (internalization_env * ((env * rel_context) * Impargs.manual_implicits))
 

--- a/vernac/comFixpoint.ml
+++ b/vernac/comFixpoint.ml
@@ -110,7 +110,7 @@ let interp_fix_context ~program_mode ~cofix env sigma fix =
     else [], fix.Vernacexpr.binders in
   let sigma, (impl_env, ((env', ctx), imps)) = interp_context_evars ~program_mode env sigma before in
   let sigma, (impl_env', ((env'', ctx'), imps')) =
-    interp_context_evars ~program_mode ~impl_env ~shift:(Context.Rel.nhyps ctx) env' sigma after
+    interp_context_evars ~program_mode ~impl_env env' sigma after
   in
   let annot = Option.map (fun _ -> List.length (Termops.assums_of_rel_context ctx)) fix.Vernacexpr.rec_order in
   sigma, ((env'', ctx' @ ctx), (impl_env',imps @ imps'), annot)


### PR DESCRIPTION
**Kind:** cleanup

`shift` appears to be entirely irrelevant, and was confusing me as I was reading the function.

Historically, it seems to have become irrelevant as part of #10231 ( @herbelin ), in particular, `shift` was only used in the returned description of which arguments are implicit, and this was simplified away in the referenced PR.