### PR TITLE
Tentative fix of #9107: too weak occur check

### DIFF
--- a/pretyping/evarsolve.ml
+++ b/pretyping/evarsolve.ml
@@ -1469,19 +1469,15 @@ let solve_candidates unify flags env evd (evk,argsv) rhs =
       | l, [] -> evd
 
 let occur_evar_upto_types sigma n c =
-  let c = EConstr.Unsafe.to_constr c in
   let seen = ref Evar.Set.empty in
-  (* FIXME: Is that supposed to be evar-insensitive? *)
-  let rec occur_rec c = match Constr.kind c with
+  let rec occur_rec c = match EConstr.kind sigma c with
     | Evar (sp,_) when Evar.equal sp n -> raise Occur
     | Evar (sp,args as e) ->
-       if Evar.Set.mem sp !seen then
-         List.iter occur_rec args
-       else (
-         seen := Evar.Set.add sp !seen;
-         Option.iter occur_rec (existential_opt_value0 sigma e);
-         occur_rec (Evd.existential_type0 sigma e))
-    | _ -> Constr.iter occur_rec c
+       List.iter occur_rec args;
+       if not (Evar.Set.mem sp !seen) then
+         (seen := Evar.Set.add sp !seen;
+         occur_rec (Evd.existential_type sigma e))
+    | _ -> EConstr.iter sigma occur_rec c
   in
   try occur_rec c; false with Occur -> true
 

--- a/test-suite/bugs/closed/bug_9107.v
+++ b/test-suite/bugs/closed/bug_9107.v
@@ -1,0 +1,5 @@
+(* Occur-check issue *)
+Set Primitive Projections.
+Class A (x : unit) := { T : Set; x : T }.
+Unset Primitive Projections.
+Record B {a : A tt} := { P u := unit; _ : P x -> x = x }.


### PR DESCRIPTION
**Kind:** bug fix

I don't understand well the use case for the code, but it looks wrong that the occur-check is done in the arguments of the later occurrence of an evar but not in its first occurrence.

The case here is of an instantiation `?T := A _ ?x@{... ?T ...} `where the occur-check was done in the type of `?x` but not in the arguments of `?x`.

Note that the occur-check in the arguments is too restrictive in general. For instance, it would be also ok above to drop the
dependency of ?x in ?T. We cannot afford a loop but postponing could be better (maybe worth experimenting...).

Fixes / closes #9107

Indirectly fixes #5694 by forbidding the cyclic evar to be defined but a better fix would be to restrict the evar??

- [X] Added / updated test-suite
- [ ] Entry added in the changelog
