### PR TITLE
[ltac] Avoid magic numbers

### DIFF
--- a/clib/cString.ml
+++ b/clib/cString.ml
@@ -25,6 +25,7 @@ sig
   val ordinal : int -> string
   val is_sub : string -> string -> int -> bool
   val is_prefix : string -> string -> bool
+  val is_suffix : string -> string -> bool
   module Set : Set.S with type elt = t
   module Map : CMap.ExtS with type key = t and module Set := Set
   module List : CList.MonoS with type elt = t
@@ -104,6 +105,9 @@ let is_sub p s off =
 
 let is_prefix p s =
   is_sub p s 0
+
+let is_suffix p s =
+  is_sub p s (String.length s - String.length p)
 
 let plural n s = if n<>1 then s^"s" else s
 

--- a/clib/cString.mli
+++ b/clib/cString.mli
@@ -54,6 +54,9 @@ sig
   val is_prefix : string -> string -> bool
   (** [is_prefix p s] tests whether [p] is a prefix of [s]. *)
 
+  val is_suffix : string -> string -> bool
+  (** [is_suffix suf s] tests whether [suf] is a suffix of [s]. *)
+
   (** {6 Generic operations} **)
 
   module Set : Set.S with type elt = t


### PR DESCRIPTION
I think it's much easier to see that this is correct.

Separately, I notice that there are almost 1000 uses of `Int.equal`.  Would be nice to replace all of them with a simple `=`.  But not today :-(.