### PR TITLE
Clean the constr-as-hint API

### DIFF
--- a/dev/ci/user-overlays/13139-ppedrot-clean-hint-constr.sh
+++ b/dev/ci/user-overlays/13139-ppedrot-clean-hint-constr.sh
@@ -1,0 +1,9 @@
+if [ "$CI_PULL_REQUEST" = "13139" ] || [ "$CI_BRANCH" = "clean-hint-constr" ]; then
+
+    equations_CI_REF=clean-hint-constr
+    equations_CI_GITURL=https://github.com/ppedrot/Coq-Equations
+
+    fiat_parsers_CI_REF=clean-hint-constr
+    fiat_parsers_CI_GITURL=https://github.com/ppedrot/fiat
+
+fi

--- a/doc/changelog/07-commands-and-options/13139-clean-hint-constr.rst
+++ b/doc/changelog/07-commands-and-options/13139-clean-hint-constr.rst
@@ -1,0 +1,6 @@
+- **Changed:**
+  When declaring arbitrary terms as hints, unsolved
+  evars are not abstracted implicitly anymore and instead
+  raise an error
+  (`#13139 <https://github.com/coq/coq/pull/13139>`_,
+  by Pierre-Marie Pédrot).

--- a/engine/eConstr.ml
+++ b/engine/eConstr.ml
@@ -628,6 +628,9 @@ let subst_var subst c = of_constr (Vars.subst_var subst (to_constr c))
 let subst_univs_level_constr subst c =
   of_constr (Vars.subst_univs_level_constr subst (to_constr c))
 
+let subst_univs_constr subst c =
+  of_constr (UnivSubst.subst_univs_constr subst (to_constr c))
+
 (** Operations that dot NOT commute with evar-normalization *)
 let noccurn sigma n term =
   let rec occur_rec n c = match kind sigma c with

--- a/engine/eConstr.mli
+++ b/engine/eConstr.mli
@@ -295,6 +295,7 @@ val closedn : Evd.evar_map -> int -> t -> bool
 val closed0 : Evd.evar_map -> t -> bool
 
 val subst_univs_level_constr : Univ.universe_level_subst -> t -> t
+val subst_univs_constr : Univ.universe_subst -> t -> t
 val subst_of_rel_context_instance : rel_context -> t list -> t list
 
 

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -482,8 +482,7 @@ let make_resolve_hyp env sigma st only_classes pri decl =
   let keep = not only_classes || is_class in
     if keep then
       let id = GlobRef.VarRef id in
-      let name = PathHints [id] in
-        (make_resolves env sigma pri ~name ~check:false (IsGlobRef id))
+      make_resolves env sigma pri id
     else []
 
 let make_hints g (modes,st) only_classes sign =

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -1347,6 +1347,8 @@ let add_hints ~locality dbnames h =
   | HintsExternEntry (info, tacexp) ->
       add_externs info tacexp ~local ~superglobal dbnames
 
+let hint_globref gr = IsGlobRef gr
+
 let hint_constr env sigma ~poly c =
   let c, diff = prepare_hint true env sigma c in
   let diff, uctx =

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -1365,8 +1365,9 @@ let constructor_hints env sigma eapply lems =
   List.map_append (fun lem ->
       make_resolves env sigma (eapply, true) empty_hint_info ~check:true lem) lems
 
-let make_resolves env sigma info ~check ?name hint =
-  make_resolves env sigma (true, false) info ~check ?name hint
+let make_resolves env sigma info hint =
+  let name = PathHints [hint] in
+  make_resolves env sigma (true, false) info ~check:false ~name (IsGlobRef hint)
 
 let make_local_hint_db env sigma ts eapply lems =
   let map c = c env sigma in

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -1349,13 +1349,7 @@ let add_hints ~locality dbnames h =
 
 let hint_globref gr = IsGlobRef gr
 
-let hint_constr env sigma ~poly c =
-  let c, diff = prepare_hint true env sigma c in
-  let diff, uctx =
-    if poly then Some diff, Univ.ContextSet.empty
-    else None, diff
-  in
-  IsConstr (c, diff), uctx
+let hint_constr (c, diff) = IsConstr (c, diff)
 
 let expand_constructor_hints env sigma lems =
   List.map_append (fun (evd,lem) ->

--- a/tactics/hints.ml
+++ b/tactics/hints.ml
@@ -1347,6 +1347,14 @@ let add_hints ~locality dbnames h =
   | HintsExternEntry (info, tacexp) ->
       add_externs info tacexp ~local ~superglobal dbnames
 
+let hint_constr env sigma ~poly c =
+  let c, diff = prepare_hint true env sigma c in
+  let diff, uctx =
+    if poly then Some diff, Univ.ContextSet.empty
+    else None, diff
+  in
+  IsConstr (c, diff), uctx
+
 let expand_constructor_hints env sigma lems =
   List.map_append (fun (evd,lem) ->
     match EConstr.kind sigma lem with

--- a/tactics/hints.mli
+++ b/tactics/hints.mli
@@ -210,8 +210,7 @@ val prepare_hint : bool (* Check no remaining evars *) ->
          has missing arguments. *)
 
 val make_resolves :
-  env -> evar_map -> hint_info -> check:bool -> ?name:hints_path_atom ->
-  hint_term -> hint_entry list
+  env -> evar_map -> hint_info -> GlobRef.t -> hint_entry list
 
 (** [make_resolve_hyp hname htyp].
    used to add an hypothesis to the local hint database;

--- a/tactics/hints.mli
+++ b/tactics/hints.mli
@@ -167,9 +167,7 @@ type hint_db = Hint_db.t
 
 type hnf = bool
 
-type hint_term =
-  | IsGlobRef of GlobRef.t
-  | IsConstr of constr * Univ.ContextSet.t option [@ocaml.deprecated "Declare a hint constant instead"]
+type hint_term
 
 type hints_entry =
   | HintsResolveEntry of (hint_info * hnf * hints_path_atom * hint_term) list
@@ -198,6 +196,8 @@ val current_db_names : unit -> String.Set.t
 val current_pure_db : unit -> hint_db list
 
 val add_hints : locality:Goptions.option_locality -> hint_db_name list -> hints_entry -> unit
+
+val hint_globref : GlobRef.t -> hint_term
 
 val hint_constr :
   env -> evar_map -> poly:bool -> evar_map * constr -> hint_term * Univ.ContextSet.t

--- a/tactics/hints.mli
+++ b/tactics/hints.mli
@@ -199,8 +199,9 @@ val current_pure_db : unit -> hint_db list
 
 val add_hints : locality:Goptions.option_locality -> hint_db_name list -> hints_entry -> unit
 
-val prepare_hint : bool (* Check no remaining evars *) ->
-  env -> evar_map -> evar_map * constr -> (constr * Univ.ContextSet.t)
+val hint_constr :
+  env -> evar_map -> poly:bool -> evar_map * constr -> hint_term * Univ.ContextSet.t
+  [@ocaml.deprecated "Declare a hint constant instead"]
 
 (** A constr which is Hint'ed will be:
    - (1) used as an Exact, if it does not start with a product

--- a/tactics/hints.mli
+++ b/tactics/hints.mli
@@ -199,9 +199,8 @@ val add_hints : locality:Goptions.option_locality -> hint_db_name list -> hints_
 
 val hint_globref : GlobRef.t -> hint_term
 
-val hint_constr :
-  env -> evar_map -> poly:bool -> evar_map * constr -> hint_term * Univ.ContextSet.t
-  [@ocaml.deprecated "Declare a hint constant instead"]
+val hint_constr : constr * Univ.ContextSet.t option -> hint_term
+[@ocaml.deprecated "Declare a hint constant instead"]
 
 (** A constr which is Hint'ed will be:
    - (1) used as an Exact, if it does not start with a product

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -57,7 +57,7 @@ let is_local_for_hint i =
 
 let add_instance_base inst =
   let locality = if is_local_for_hint inst then Goptions.OptLocal else Goptions.OptGlobal in
-  add_instance_hint (Hints.IsGlobRef inst.is_impl) [inst.is_impl] ~locality
+  add_instance_hint (Hints.hint_globref inst.is_impl) [inst.is_impl] ~locality
     inst.is_info
 
 let mk_instance cl info glob impl =

--- a/vernac/comHints.ml
+++ b/vernac/comHints.ml
@@ -85,14 +85,12 @@ let interp_hints ~poly h =
   let env = Global.env () in
   let sigma = Evd.from_env env in
   let f poly c =
-    let evd, c = Constrintern.interp_open_constr env sigma c in
     let env = Global.env () in
     let sigma = Evd.from_env env in
-    let c, diff = Hints.prepare_hint true env sigma (evd, c) in
-    if poly then (Hints.IsConstr (c, Some diff) [@ocaml.warning "-3"])
-    else
-      let () = DeclareUctx.declare_universe_context ~poly:false diff in
-      (Hints.IsConstr (c, None) [@ocaml.warning "-3"])
+    let evd, c = Constrintern.interp_open_constr env sigma c in
+    let h, diff = Hints.hint_constr env sigma ~poly (evd, c) in
+    let () = DeclareUctx.declare_universe_context ~poly:false diff [@ocaml.warning "-3"] in
+    h
   in
   let fref r =
     let gr = Smartlocate.global_with_alias r in

--- a/vernac/comHints.ml
+++ b/vernac/comHints.ml
@@ -101,13 +101,10 @@ let interp_hints ~poly h =
       let () = warn_deprecated_hint_constr () in
       let env = Global.env () in
       let sigma = Evd.from_env env in
-      let sigma, c = Constrintern.interp_open_constr env sigma c in
-      let sigma = Typeclasses.resolve_typeclasses ~fail:false env sigma in
-      let sigma, _ = Evd.nf_univ_variables sigma in
-      let c = Evarutil.nf_evar sigma c in
-      let c = Termops.drop_extra_implicit_args sigma c in
-      let () = Pretyping.check_evars env sigma c in
-      let diff = Evd.universe_context_set sigma in
+      let c, uctx = Constrintern.interp_constr env sigma c in
+      let subst, uctx = UState.normalize_variables uctx in
+      let c = EConstr.Vars.subst_univs_constr subst c in
+      let diff = UState.context_set uctx in
       let c =
         if poly then (c, Some diff)
         else


### PR DESCRIPTION
This PR hides internal details of the API allowing to declare arbitrary terms as hints. Furthermore, in order to reduce the underspecified behaviours exposed to the end-user, this changes the semantics of open terms added as hints. Before the PR, it would implicitly quantify over the dangling evars in a fragile way (amongst others sensitive to the evar naming), now it simply errors out and one needs to explicitly quantify over the remaining holes. Note that I've only found one place where this (undocumented) feature was used in the whole CI, namely [in fiat-crypto](https://github.com/mit-plv/fiat-crypto/pull/882).

Overlays:
- https://github.com/mattam82/Coq-Equations/pull/330
- https://github.com/mit-plv/fiat/pull/45