### PR TITLE
Closes #13142: more standardized pretty-printing of Coq records

### DIFF
--- a/printing/ppconstr.mli
+++ b/printing/ppconstr.mli
@@ -41,7 +41,8 @@ val pr_guard_annot
   -> recursion_order_expr option
   -> Pp.t
 
-val pr_record_body : (qualid * constr_expr) list -> Pp.t
+val pr_record : string -> string -> ('a -> Pp.t) -> 'a list -> Pp.t
+val pr_record_body : string -> string -> ('a -> Pp.t) -> (Libnames.qualid * 'a) list -> Pp.t
 val pr_binders : Environ.env -> Evd.evar_map -> local_binder_expr list -> Pp.t
 val pr_constr_pattern_expr : Environ.env -> Evd.evar_map -> constr_pattern_expr -> Pp.t
 val pr_lconstr_pattern_expr : Environ.env -> Evd.evar_map -> constr_pattern_expr -> Pp.t

--- a/test-suite/output/Record.out
+++ b/test-suite/output/Record.out
@@ -30,3 +30,43 @@ fun '{| U := T; a := a; q := p |} => (T, p, a)
      : M -> Type * True * nat
 fun '{| U := T; a := a; q := p |} => (T, p, a)
      : M -> Type * True * nat
+{| a := 0; b := 0 |}
+     : T
+fun '{| |} => 0
+     : LongModuleName.test -> nat
+     = {|
+         a :=
+           {|
+             LongModuleName.long_field_name0 := 0;
+             LongModuleName.long_field_name1 := 1;
+             LongModuleName.long_field_name2 := 2;
+             LongModuleName.long_field_name3 := 3
+           |};
+         b :=
+           fun
+             '{|
+                LongModuleName.long_field_name0 := a;
+                LongModuleName.long_field_name1 := b;
+                LongModuleName.long_field_name2 := c;
+                LongModuleName.long_field_name3 := d
+              |} => (a, b, c, d)
+       |}
+     : T
+     = {|
+         a :=
+           {|
+             long_field_name0 := 0;
+             long_field_name1 := 1;
+             long_field_name2 := 2;
+             long_field_name3 := 3
+           |};
+         b :=
+           fun
+             '{|
+                long_field_name0 := a;
+                long_field_name1 := b;
+                long_field_name2 := c;
+                long_field_name3 := d
+              |} => (a, b, c, d)
+       |}
+     : T

--- a/test-suite/output/Record.v
+++ b/test-suite/output/Record.v
@@ -33,3 +33,34 @@ Check fun x:M => let 'D T _ p := x in T.
 Check fun x:M => let 'D T p := x in (T,p).
 Check fun x:M => let 'D T a p := x in (T,p,a).
 Check fun x:M => let '{|U:=T;a:=a;q:=p|} := x in (T,p,a).
+
+Module FormattingIssue13142.
+
+Record T {A B} := {a:A;b:B}.
+
+Module LongModuleName.
+  Record test := { long_field_name0 : nat;
+                  long_field_name1 : nat;
+                  long_field_name2 : nat;
+                  long_field_name3 : nat }.
+End LongModuleName.
+
+Definition c :=
+      {| LongModuleName.long_field_name0 := 0;
+         LongModuleName.long_field_name1 := 1;
+         LongModuleName.long_field_name2 := 2;
+         LongModuleName.long_field_name3 := 3 |}.
+
+Definition d :=
+ fun '{| LongModuleName.long_field_name0 := a;
+         LongModuleName.long_field_name1 := b;
+         LongModuleName.long_field_name2 := c;
+         LongModuleName.long_field_name3 := d |} => (a,b,c,d).
+
+Check {|a:=0;b:=0|}.
+Check fun '{| LongModuleName.long_field_name0:=_ |} => 0.
+Eval compute in {|a:=c;b:=d|}.
+Import LongModuleName.
+Eval compute in {|a:=c;b:=d|}.
+
+End FormattingIssue13142.

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -524,8 +524,7 @@ let pr_record_field (x, { rf_subclass = oc ; rf_priority = pri ; rf_notation = n
   prx ++ prpri ++ prlist (pr_decl_notation @@ pr_constr) ntn
 
 let pr_record_decl c fs =
-  pr_opt pr_lident c ++ (if c = None then str"{" else str" {") ++
-  hv 0 (prlist_with_sep pr_semicolon pr_record_field fs ++ str"}")
+  pr_opt pr_lident c ++ pr_record "{" "}" pr_record_field fs
 
 let pr_printable = function
   | PrintFullContext ->
@@ -966,7 +965,7 @@ let pr_vernac_expr v =
         str":" ++ spc () ++
         pr_constr cl ++ pr_hint_info pr_constr_pattern_expr info ++
         (match props with
-         | Some (true, { v = CRecord l}) -> spc () ++ str":=" ++ spc () ++ str"{" ++ pr_record_body l ++ str "}"
+         | Some (true, { v = CRecord l}) -> spc () ++ str":=" ++ spc () ++ pr_record_body "{" "}" pr_lconstr l
          | Some (true,_) -> assert false
          | Some (false,p) -> spc () ++ str":=" ++ spc () ++ pr_constr p
          | None -> mt()))


### PR DESCRIPTION
**Kind:** enhancement

Fixes / closes #13142

We adopt the following formatting and make it consistently available for printing instances, inductive records, record tuples, record patterns:
```
{|
  a := t;
  b := u;
|}
```
We added a comment in `ppconstr.ml` telling how to implement the other variants, if ever wished.

- [X] Added / updated test-suite
- [ ] Entry added in the changelog
