### PR TITLE
Adding support for printing goal names in CoqIDE

### DIFF
--- a/doc/changelog/09-coqide/13145-master+coqide-printing-goal-names-support.rst
+++ b/doc/changelog/09-coqide/13145-master+coqide-printing-goal-names-support.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  Support for flag :flag:`Printing Goal Names` in View menu
+  (`#13145 <https://github.com/coq/coq/pull/13145>`_,
+  by Hugo Herbelin).

--- a/ide/coqide/coq.ml
+++ b/ide/coqide/coq.ml
@@ -550,6 +550,7 @@ struct
   let existential = BoolOpt ["Printing"; "Existential"; "Instances"]
   let universes = BoolOpt ["Printing"; "Universes"]
   let unfocused = BoolOpt ["Printing"; "Unfocused"]
+  let goal_names = BoolOpt ["Printing"; "Goal"; "Names"]
   let diff = StringOpt ["Diffs"]
 
   type 'a descr = { opts : 'a t list; init : 'a; label : string }
@@ -568,7 +569,8 @@ struct
     { opts = [universes]; init = false; label = "Display _universe levels" };
     { opts = [all_basic;existential;universes]; init = false;
       label = "Display all _low-level contents" };
-    { opts = [unfocused]; init = false; label = "Display _unfocused goals" }
+    { opts = [unfocused]; init = false; label = "Display _unfocused goals" };
+    { opts = [goal_names]; init = false; label = "Display _goal names" }
   ]
 
   let diff_item = { opts = [diff]; init = "off"; label = "Display _proof diffs" }

--- a/ide/coqide/coqide_ui.ml
+++ b/ide/coqide/coqide_ui.ml
@@ -85,6 +85,7 @@ let init () =
 \n    <menuitem action='Display universe levels' />\
 \n    <menuitem action='Display all low-level contents' />\
 \n    <menuitem action='Display unfocused goals' />\
+\n    <menuitem action='Display goal names' />\
 \n    <separator/>\
 \n    <menuitem action='Unset diff' />\
 \n    <menuitem action='Set diff' />\

--- a/ide/coqide/idetop.ml
+++ b/ide/coqide/idetop.ml
@@ -195,7 +195,7 @@ let concl_next_tac =
 let process_goal sigma g =
   let env = Goal.V82.env sigma g in
   let min_env = Environ.reset_context env in
-  let id = Goal.uid g in
+  let id = if Printer.print_goal_names () then Names.Id.to_string (Termops.evar_suggested_name g sigma) else "" in
   let ccl =
     pr_letype_env ~goal_concl_style:true env sigma (Goal.V82.concl sigma g)
   in
@@ -206,7 +206,7 @@ let process_goal sigma g =
   let (_env, hyps) =
     Context.Compacted.fold process_hyp
       (Termops.compact_named_context (Environ.named_context env)) ~init:(min_env,[]) in
-  { Interface.goal_hyp = List.rev hyps; Interface.goal_ccl = ccl; Interface.goal_id = id; }
+  { Interface.goal_hyp = List.rev hyps; Interface.goal_ccl = ccl; Interface.goal_id = id }
 
 let process_goal_diffs diff_goal_map oldp nsigma ng =
   let open Evd in

--- a/printing/printer.ml
+++ b/printing/printer.ml
@@ -45,6 +45,8 @@ let should_gname =
     ~key:["Printing";"Goal";"Names"]
     ~value:false
 
+let print_goal_names = should_gname (* for export *)
+
 (**********************************************************************)
 (** Terms                                                             *)
 

--- a/printing/printer.mli
+++ b/printing/printer.mli
@@ -264,3 +264,6 @@ val pr_goal_by_id : proof:Proof.t -> Id.t -> Pp.t
 val pr_goal_emacs : proof:Proof.t option -> int -> int -> Pp.t
 
 val pr_typing_flags : Declarations.typing_flags -> Pp.t
+
+(** Tells if flag "Printing Goal Names" is activated *)
+val print_goal_names : unit -> bool


### PR DESCRIPTION
**Kind:** documentation / bug fix

Depends on #13140 (merged) for the correctness of the reference manual check.

This adds support for printing goal names in CoqIDE.

Incidentally, this invites to concoct names more informative than `?Goal`, `?Goal0` ...

Note: The `Printing Goal Names` flag is tested on the `idetop` side while the `Printing Unfocused` flag was tested on the coqide side. It is a bit inconsistent but I don't know precisely what would be the most relevant to do.

- [X] Entry added in the changelog