### PR TITLE
Remove the compare_graph field from the conversion API.

### DIFF
--- a/kernel/mod_typing.ml
+++ b/kernel/mod_typing.ml
@@ -80,12 +80,11 @@ let rec check_with_def env struc (idl,(c,ctx)) mp equiv =
               let j = Typeops.infer env' c in
               assert (j.uj_val == c); (* relevances should already be correct here *)
               let typ = cb.const_type in
-              let cst' = Reduction.infer_conv_leq env' (Environ.universes env')
-                  j.uj_type typ in
+              let cst' = Reduction.infer_conv_leq env' j.uj_type typ in
               j.uj_val, cst'
             | Def cs ->
               let c' = Mod_subst.force_constr cs in
-              c, Reduction.infer_conv env' (Environ.universes env') c c'
+              c, Reduction.infer_conv env' c c'
             | Primitive _ ->
               error_incorrect_with_constraint lab
           in
@@ -103,12 +102,11 @@ let rec check_with_def env struc (idl,(c,ctx)) mp equiv =
               let j = Typeops.infer env' c in
               assert (j.uj_val == c); (* relevances should already be correct here *)
               let typ = cb.const_type in
-              let cst' = Reduction.infer_conv_leq env' (Environ.universes env')
-                  j.uj_type typ in
+              let cst' = Reduction.infer_conv_leq env' j.uj_type typ in
               cst'
             | Def cs ->
               let c' = Mod_subst.force_constr cs in
-              let cst' = Reduction.infer_conv env' (Environ.universes env') c c' in
+              let cst' = Reduction.infer_conv env' c c' in
               cst'
             | Primitive _ ->
               error_incorrect_with_constraint lab

--- a/kernel/nativeconv.ml
+++ b/kernel/nativeconv.ml
@@ -150,10 +150,10 @@ let warn_no_native_compiler =
          (fun () -> strbrk "Native compiler is disabled," ++
                       strbrk " falling back to VM conversion test.")
 
-let native_conv_gen pb sigma env univs t1 t2 =
+let native_conv_gen pb sigma env graph univs t1 t2 =
   if not (typing_flags env).Declarations.enable_native_compiler then begin
     warn_no_native_compiler ();
-    Vconv.vm_conv_gen pb env univs t1 t2
+    Vconv.vm_conv_gen pb env graph univs t1 t2
   end
   else
   let ml_filename, prefix = get_ml_filename () in
@@ -176,7 +176,7 @@ let native_conv cv_pb sigma env t1 t2 =
     else Constr.eq_constr_univs univs t1 t2
   in
   if not b then
-    let univs = (univs, checked_universes) in
+    let state = (univs, checked_universes) in
     let t1 = Term.it_mkLambda_or_LetIn t1 (Environ.rel_context env) in
     let t2 = Term.it_mkLambda_or_LetIn t2 (Environ.rel_context env) in
-    let _ = native_conv_gen cv_pb sigma env univs t1 t2 in ()
+    let _ = native_conv_gen cv_pb sigma env univs state t1 t2 in ()

--- a/kernel/nativeconv.ml
+++ b/kernel/nativeconv.ml
@@ -150,10 +150,10 @@ let warn_no_native_compiler =
          (fun () -> strbrk "Native compiler is disabled," ++
                       strbrk " falling back to VM conversion test.")
 
-let native_conv_gen pb sigma env graph univs t1 t2 =
+let native_conv_gen pb sigma env univs t1 t2 =
   if not (typing_flags env).Declarations.enable_native_compiler then begin
     warn_no_native_compiler ();
-    Vconv.vm_conv_gen pb env graph univs t1 t2
+    Vconv.vm_conv_gen pb env univs t1 t2
   end
   else
   let ml_filename, prefix = get_ml_filename () in
@@ -179,4 +179,4 @@ let native_conv cv_pb sigma env t1 t2 =
     let state = (univs, checked_universes) in
     let t1 = Term.it_mkLambda_or_LetIn t1 (Environ.rel_context env) in
     let t2 = Term.it_mkLambda_or_LetIn t2 (Environ.rel_context env) in
-    let _ = native_conv_gen cv_pb sigma env univs state t1 t2 in ()
+    let _ = native_conv_gen cv_pb sigma env state t1 t2 in ()

--- a/kernel/reduction.ml
+++ b/kernel/reduction.ml
@@ -189,7 +189,7 @@ type 'a kernel_conversion_function = env -> 'a -> 'a -> unit
 (* functions of this type can be called from outside the kernel *)
 type 'a extended_conversion_function =
   ?l2r:bool -> ?reds:TransparentState.t -> env ->
-  ?evars:((existential->constr option) * UGraph.t) ->
+  ?evars:(existential->constr option) ->
   'a -> 'a -> unit
 
 exception NotConvertible
@@ -888,8 +888,8 @@ let gen_conv cv_pb l2r reds env evars univs t1 t2 =
         ()
 
 (* Profiling *)
-let gen_conv cv_pb ?(l2r=false) ?(reds=TransparentState.full) env ?(evars=(fun _->None), universes env) =
-  let evars, univs = evars in
+let gen_conv cv_pb ?(l2r=false) ?(reds=TransparentState.full) env ?(evars=(fun _->None)) =
+  let univs = Environ.universes env in
   if Flags.profile then
     let fconv_universes_key = CProfile.declare_profile "trans_fconv_universes" in
       CProfile.profile8 fconv_universes_key gen_conv cv_pb l2r reds env evars univs

--- a/kernel/reduction.mli
+++ b/kernel/reduction.mli
@@ -31,7 +31,7 @@ exception NotConvertible
 type 'a kernel_conversion_function = env -> 'a -> 'a -> unit
 type 'a extended_conversion_function =
   ?l2r:bool -> ?reds:TransparentState.t -> env ->
-  ?evars:((existential->constr option) * UGraph.t) ->
+  ?evars:(existential->constr option) ->
   'a -> 'a -> unit
 
 type conv_pb = CONV | CUMUL

--- a/kernel/reduction.mli
+++ b/kernel/reduction.mli
@@ -37,8 +37,6 @@ type 'a extended_conversion_function =
 type conv_pb = CONV | CUMUL
 
 type 'a universe_compare = {
-  compare_graph : 'a -> UGraph.t; (* used for case inversion in reduction *)
-
   (* Might raise NotConvertible *)
   compare_sorts : env -> conv_pb -> Sorts.t -> Sorts.t -> 'a -> 'a;
   compare_instances: flex:bool -> Univ.Instance.t -> Univ.Instance.t -> 'a -> 'a;
@@ -48,7 +46,7 @@ type 'a universe_compare = {
 
 type 'a universe_state = 'a * 'a universe_compare
 
-type ('a,'b) generic_conversion_function = env -> 'b universe_state -> 'a -> 'a -> 'b
+type ('a,'b) generic_conversion_function = env -> UGraph.t -> 'b universe_state -> 'a -> 'a -> 'b
 
 type 'a infer_conversion_function = env -> UGraph.t -> 'a -> 'a -> Univ.Constraint.t
 

--- a/kernel/reduction.mli
+++ b/kernel/reduction.mli
@@ -46,9 +46,9 @@ type 'a universe_compare = {
 
 type 'a universe_state = 'a * 'a universe_compare
 
-type ('a,'b) generic_conversion_function = env -> UGraph.t -> 'b universe_state -> 'a -> 'a -> 'b
+type ('a,'b) generic_conversion_function = env -> 'b universe_state -> 'a -> 'a -> 'b
 
-type 'a infer_conversion_function = env -> UGraph.t -> 'a -> 'a -> Univ.Constraint.t
+type 'a infer_conversion_function = env -> 'a -> 'a -> Univ.Constraint.t
 
 val get_cumulativity_constraints : conv_pb -> Univ.Variance.t array ->
   Univ.Instance.t -> Univ.Instance.t -> Univ.Constraint.t

--- a/kernel/subtyping.ml
+++ b/kernel/subtyping.ml
@@ -85,7 +85,7 @@ let make_labmap mp list =
 
 let check_conv_error error why cst poly f env a1 a2 =
   try
-    let cst' = f env (Environ.universes env) a1 a2 in
+    let cst' = f env a1 a2 in
       if poly then
         if Constraint.is_empty cst' then cst
         else error (IncompatiblePolymorphism (env, a1, a2))

--- a/kernel/typeops.mli
+++ b/kernel/typeops.mli
@@ -111,7 +111,7 @@ val type_of_global_in_context : env -> GlobRef.t -> types * Univ.AUContext.t
 (** {6 Miscellaneous. } *)
 
 (** Check that hyps are included in env and fails with error otherwise *)
-val check_hyps_inclusion : env -> ?evars:((existential->constr option) * UGraph.t) ->
+val check_hyps_inclusion : env -> ?evars:(existential->constr option) ->
   GlobRef.t -> Constr.named_context -> unit
 
 (** Types for primitives *)

--- a/kernel/vconv.ml
+++ b/kernel/vconv.ml
@@ -190,10 +190,10 @@ let warn_bytecode_compiler_failed =
          (fun () -> strbrk "Bytecode compiler failed, " ++
                       strbrk "falling back to standard conversion")
 
-let vm_conv_gen cv_pb env graph univs t1 t2 =
+let vm_conv_gen cv_pb env univs t1 t2 =
   if not (typing_flags env).Declarations.enable_VM then
     Reduction.generic_conv cv_pb ~l2r:false (fun _ -> None)
-      TransparentState.full env graph univs t1 t2
+      TransparentState.full env univs t1 t2
   else
   try
     let v1 = val_of_constr env t1 in
@@ -202,7 +202,7 @@ let vm_conv_gen cv_pb env graph univs t1 t2 =
   with Not_found | Invalid_argument _ ->
     warn_bytecode_compiler_failed ();
     Reduction.generic_conv cv_pb ~l2r:false (fun _ -> None)
-      TransparentState.full env graph univs t1 t2
+      TransparentState.full env univs t1 t2
 
 let vm_conv cv_pb env t1 t2 =
   let univs = Environ.universes env in
@@ -212,4 +212,4 @@ let vm_conv cv_pb env t1 t2 =
   in
   if not b then
     let state = (univs, checked_universes) in
-    let _ = vm_conv_gen cv_pb env univs state t1 t2 in ()
+    let _ = vm_conv_gen cv_pb env state t1 t2 in ()

--- a/kernel/vconv.ml
+++ b/kernel/vconv.ml
@@ -190,10 +190,10 @@ let warn_bytecode_compiler_failed =
          (fun () -> strbrk "Bytecode compiler failed, " ++
                       strbrk "falling back to standard conversion")
 
-let vm_conv_gen cv_pb env univs t1 t2 =
+let vm_conv_gen cv_pb env graph univs t1 t2 =
   if not (typing_flags env).Declarations.enable_VM then
     Reduction.generic_conv cv_pb ~l2r:false (fun _ -> None)
-      TransparentState.full env univs t1 t2
+      TransparentState.full env graph univs t1 t2
   else
   try
     let v1 = val_of_constr env t1 in
@@ -202,7 +202,7 @@ let vm_conv_gen cv_pb env univs t1 t2 =
   with Not_found | Invalid_argument _ ->
     warn_bytecode_compiler_failed ();
     Reduction.generic_conv cv_pb ~l2r:false (fun _ -> None)
-      TransparentState.full env univs t1 t2
+      TransparentState.full env graph univs t1 t2
 
 let vm_conv cv_pb env t1 t2 =
   let univs = Environ.universes env in
@@ -211,5 +211,5 @@ let vm_conv cv_pb env t1 t2 =
     else Constr.eq_constr_univs univs t1 t2
   in
   if not b then
-    let univs = (univs, checked_universes) in
-    let _ = vm_conv_gen cv_pb env univs t1 t2 in ()
+    let state = (univs, checked_universes) in
+    let _ = vm_conv_gen cv_pb env univs state t1 t2 in ()

--- a/plugins/ssrmatching/ssrmatching.ml
+++ b/plugins/ssrmatching/ssrmatching.ml
@@ -204,7 +204,8 @@ exception NoProgress
 (*      comparison can be much faster than the HO one.          *)
 
 let unif_EQ env sigma p c =
-  let evars = existential_opt_value0 sigma, Evd.universes sigma in
+  let env = Environ.set_universes (Evd.universes sigma) env in
+  let evars = existential_opt_value0 sigma in
   try let _ = Reduction.conv env p ~evars c in true with _ -> false
 
 let unif_EQ_args env sigma pa a =

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -1163,10 +1163,10 @@ let infer_conv_gen conv_fun ?(catch_incon=true) ?(pb=Reduction.CUMUL)
       | None ->
         let x = EConstr.Unsafe.to_constr x in
         let y = EConstr.Unsafe.to_constr y in
-        let graph = Evd.universes sigma in
+        let env = Environ.set_universes (Evd.universes sigma) env in
         let sigma' =
           conv_fun pb ~l2r:false sigma ts
-            env graph (sigma, sigma_univ_state) x y in
+            env (sigma, sigma_univ_state) x y in
         Some sigma'
   with
   | Reduction.NotConvertible -> None

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -1138,8 +1138,7 @@ let sigma_check_inductive_instances cv_pb variance u1 u2 sigma =
 
 let sigma_univ_state =
   let open Reduction in
-  { compare_graph = Evd.universes;
-    compare_sorts = sigma_compare_sorts;
+  { compare_sorts = sigma_compare_sorts;
     compare_instances = sigma_compare_instances;
     compare_cumul_instances = sigma_check_inductive_instances; }
 
@@ -1164,9 +1163,10 @@ let infer_conv_gen conv_fun ?(catch_incon=true) ?(pb=Reduction.CUMUL)
       | None ->
         let x = EConstr.Unsafe.to_constr x in
         let y = EConstr.Unsafe.to_constr y in
+        let graph = Evd.universes sigma in
         let sigma' =
           conv_fun pb ~l2r:false sigma ts
-            env (sigma, sigma_univ_state) x y in
+            env graph (sigma, sigma_univ_state) x y in
         Some sigma'
   with
   | Reduction.NotConvertible -> None

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -1094,7 +1094,8 @@ let f_conv_leq ?l2r ?reds env ?evars x y =
 let test_trans_conversion (f: constr Reduction.extended_conversion_function) reds env sigma x y =
   try
     let evars ev = safe_evar_value sigma ev in
-    let _ = f ~reds env ~evars:(evars, Evd.universes sigma) x y in
+    let env = Environ.set_universes (Evd.universes sigma) env in
+    let _ = f ~reds env ~evars x y in
     true
   with Reduction.NotConvertible -> false
     | e ->
@@ -1112,7 +1113,8 @@ let check_conv ?(pb=Reduction.CUMUL) ?(ts=TransparentState.full) env sigma x y =
     | Reduction.CONV -> f_conv
     | Reduction.CUMUL -> f_conv_leq
   in
-    try f ~reds:ts env ~evars:(safe_evar_value sigma, Evd.universes sigma) x y; true
+    let env = Environ.set_universes (Evd.universes sigma) env in
+    try f ~reds:ts env ~evars:(safe_evar_value sigma) x y; true
     with Reduction.NotConvertible -> false
     | Univ.UniverseInconsistency _ -> false
     | e ->

--- a/pretyping/typing.ml
+++ b/pretyping/typing.ml
@@ -296,7 +296,8 @@ let judge_of_letin env name defj typj j =
     uj_type = subst1 defj.uj_val j.uj_type }
 
 let check_hyps_inclusion env sigma x hyps =
-  let evars = Evarutil.safe_evar_value sigma, Evd.universes sigma in
+  let env = Environ.set_universes (Evd.universes sigma) env in
+  let evars = Evarutil.safe_evar_value sigma in
   Typeops.check_hyps_inclusion env ~evars x hyps
 
 let type_of_constant env sigma (c,u) =


### PR DESCRIPTION
We know statically that the first thing the conversion algorithm is going to do is to get it from the provided function, so we simply explicitly pass it around.

@SkySkimmer as discussed some time ago, I could also do in one step the removal of this additional argument and simply take it from the environment.