### PR TITLE
Fixes #13165: implicit arguments in defined fields of record types not taken into account

### DIFF
--- a/dev/ci/user-overlays/13166-herbelin-master+fixes13165-missing-impargs-defined-fields.sh
+++ b/dev/ci/user-overlays/13166-herbelin-master+fixes13165-missing-impargs-defined-fields.sh
@@ -1,0 +1,6 @@
+if [ "$CI_PULL_REQUEST" = "13166" ] || [ "$CI_BRANCH" = "master+fixes13165-missing-impargs-defined-fields" ]; then
+
+    elpi_CI_REF=coq-master+adapt-coq-pr13166-impargs-record-fields
+    elpi_CI_GITURL=https://github.com/herbelin/coq-elpi
+
+fi

--- a/doc/changelog/02-specification-language/13166-master+fixes13165-missing-impargs-defined-fields.rst
+++ b/doc/changelog/02-specification-language/13166-master+fixes13165-missing-impargs-defined-fields.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  Implicit arguments taken into account in defined fields of a record type declaration
+  (`#13166 <https://github.com/coq/coq/pull/13166>`_,
+  fixes `#13165 <https://github.com/coq/coq/issues/13165>`_,
+  by Hugo Herbelin).

--- a/stm/vernac_classifier.ml
+++ b/stm/vernac_classifier.ml
@@ -128,7 +128,7 @@ let classify_vernac e =
         | Constructors l -> List.map (fun (_,({v=id},_)) -> id) l
         | RecordDecl (oid,l) -> (match oid with Some {v=x} -> [x] | _ -> []) @
            CList.map_filter (function
-            | AssumExpr({v=Names.Name n},_), _ -> Some n
+            | AssumExpr({v=Names.Name n},_,_), _ -> Some n
             | _ -> None) l) l in
         VtSideff (List.flatten ids, VtLater)
     | VernacScheme l ->

--- a/test-suite/success/Record.v
+++ b/test-suite/success/Record.v
@@ -93,3 +93,18 @@ Record R : Type := {
 (* This is used in a couple of development such as UniMatch *)
 
 Record S {A:Type} := { a : A; b : forall A:Type, A }.
+
+(* Bug #13165 on implicit arguments in defined fields *)
+Record T := {
+ f {n:nat} (p:n=n) := nat;
+ g := f (eq_refl 0)
+}.
+
+(* Slight improvement in when SProp relevance is detected *)
+Inductive True : SProp := I.
+Inductive eqI : True -> SProp := reflI : eqI I.
+
+Record U (c:True) := {
+ u := c;
+ v := reflI : eqI u;
+ }.

--- a/vernac/comAssumption.ml
+++ b/vernac/comAssumption.ml
@@ -71,7 +71,8 @@ let declare_axiom is_coe ~poly ~local ~kind typ (univs, pl) imps nl {CAst.v=name
 let interp_assumption ~program_mode env sigma impl_env bl c =
   let flags = { Pretyping.all_no_fail_flags with program_mode } in
   let sigma, (impls, ((env_bl, ctx), impls1)) = interp_context_evars ~program_mode ~impl_env env sigma bl in
-  let sigma, (ty, impls2) = interp_type_evars_impls ~flags env sigma ~impls c in
+  let sigma, (ty, impls2) = interp_type_evars_impls ~flags env_bl sigma ~impls c in
+  let ty = EConstr.it_mkProd_or_LetIn ty ctx in
   sigma, ty, impls1@impls2
 
 (* When monomorphic the universe constraints and universe names are

--- a/vernac/comAssumption.mli
+++ b/vernac/comAssumption.mli
@@ -14,6 +14,15 @@ open Constrexpr
 
 (** {6 Parameters/Assumptions} *)
 
+val interp_assumption
+  : program_mode:bool
+  -> Environ.env
+  -> Evd.evar_map
+  -> Constrintern.internalization_env
+  -> Constrexpr.local_binder_expr list
+  -> constr_expr
+  -> Evd.evar_map * EConstr.t * Impargs.manual_implicits
+
 val do_assumptions
   :  program_mode:bool
   -> poly:bool

--- a/vernac/comDefinition.mli
+++ b/vernac/comDefinition.mli
@@ -14,6 +14,17 @@ open Constrexpr
 
 (** {6 Definitions/Let} *)
 
+val interp_definition
+  :  program_mode:bool
+  -> Environ.env
+  -> Evd.evar_map
+  -> Constrintern.internalization_env
+  -> Constrexpr.local_binder_expr list
+  -> red_expr option
+  -> constr_expr
+  -> constr_expr option
+  -> Evd.evar_map * (EConstr.t * EConstr.t option) * Impargs.manual_implicits
+
 val do_definition
   :  ?hook:Declare.Hook.t
   -> name:Id.t

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -429,19 +429,19 @@ GRAMMAR EXTEND Gram
   ;
   record_binder_body:
     [ [ l = binders; oc = of_type_with_opt_coercion;
-         t = lconstr -> { fun id -> (oc,AssumExpr (id,mkProdCN ~loc l t)) }
+         t = lconstr -> { fun id -> (oc,AssumExpr (id,l,t)) }
       | l = binders; oc = of_type_with_opt_coercion;
          t = lconstr; ":="; b = lconstr -> { fun id ->
-           (oc,DefExpr (id,mkLambdaCN ~loc l b,Some (mkProdCN ~loc l t))) }
+           (oc,DefExpr (id,l,b,Some t)) }
       | l = binders; ":="; b = lconstr -> { fun id ->
          match b.CAst.v with
          | CCast(b', (CastConv t|CastVM t|CastNative t)) ->
-             (NoInstance,DefExpr(id,mkLambdaCN ~loc l b',Some (mkProdCN ~loc l t)))
+             (NoInstance,DefExpr(id,l,b',Some t))
          | _ ->
-             (NoInstance,DefExpr(id,mkLambdaCN ~loc l b,None)) } ] ]
+             (NoInstance,DefExpr(id,l,b,None)) } ] ]
   ;
   record_binder:
-    [ [ id = name -> { (NoInstance,AssumExpr(id, CAst.make ~loc @@ CHole (None, IntroAnonymous, None))) }
+    [ [ id = name -> { (NoInstance,AssumExpr(id, [], CAst.make ~loc @@ CHole (None, IntroAnonymous, None))) }
       | id = name; f = record_binder_body -> { f id } ] ]
   ;
   assum_list:

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -508,13 +508,15 @@ let pr_oc = function
 
 let pr_record_field (x, { rf_subclass = oc ; rf_priority = pri ; rf_notation = ntn }) =
   let prx = match x with
-    | AssumExpr (id,t) ->
+    | AssumExpr (id,binders,t) ->
       hov 1 (pr_lname id ++
+             pr_binders_arg binders ++ spc() ++
              pr_oc oc ++ spc() ++
              pr_lconstr_expr t)
-    | DefExpr(id,b,opt) -> (match opt with
+    | DefExpr(id,binders,b,opt) -> (match opt with
         | Some t ->
           hov 1 (pr_lname id ++
+                 pr_binders_arg binders ++ spc() ++
                  pr_oc oc ++ spc() ++
                  pr_lconstr_expr t ++ str" :=" ++ pr_lconstr b)
         | None ->

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -700,7 +700,7 @@ let vernac_record ~template udecl ~cumulative k ~poly finite records =
       if Dumpglob.dump () then
         let () = Dumpglob.dump_definition id false "rec" in
         let iter (x, _) = match x with
-        | Vernacexpr.AssumExpr ({loc;v=Name id}, _) ->
+        | Vernacexpr.(AssumExpr ({loc;v=Name id}, _, _) | DefExpr ({loc;v=Name id}, _, _, _)) ->
           Dumpglob.dump_definition (make ?loc id) false "proj"
         | _ -> ()
         in
@@ -777,7 +777,7 @@ let vernac_inductive ~atts kind indl =
     in
     let (coe, (lid, ce)) = l in
     let coe' = if coe then BackInstance else NoInstance in
-    let f = AssumExpr ((make ?loc:lid.loc @@ Name lid.v), ce),
+    let f = AssumExpr ((make ?loc:lid.loc @@ Name lid.v), [], ce),
             { rf_subclass = coe' ; rf_priority = None ; rf_notation = [] ; rf_canonical = true } in
     vernac_record ~template udecl ~cumulative (Class true) ~poly finite [id, bl, c, None, [f]]
   else if List.for_all is_record indl then

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -167,8 +167,8 @@ type fixpoint_expr = recursion_order_expr option fix_expr_gen
 type cofixpoint_expr = unit fix_expr_gen
 
 type local_decl_expr =
-  | AssumExpr of lname * constr_expr
-  | DefExpr of lname * constr_expr * constr_expr option
+  | AssumExpr of lname * local_binder_expr list * constr_expr
+  | DefExpr of lname * local_binder_expr list * constr_expr * constr_expr option
 
 type inductive_kind = Inductive_kw | CoInductive | Variant | Record | Structure | Class of bool (* true = definitional, false = inductive *)
 type simple_binder = lident list  * constr_expr


### PR DESCRIPTION
**Kind:** bug fix

Synchronous overlay for ELPI [#191](https://github.com/LPCIC/coq-elpi/pull/191)

We fix it by relying on more "central" code: `interp_definition` from `comDefinition` and `interp_assumption` from `comAssumption`.

@ejgallego: I wonder whether it would make sense to move `interp_definition` and `interp_assumption` to `constrintern.ml`? (And even to eventually make a file `constrinterp.ml` out of `constrintern.ml`?)

Fixes / closes #13165

- [X] Added / updated test-suite
- [X] Entry added in the changelog
