### PR TITLE
Fix #13169: vm_compute has existential crisis.

### DIFF
--- a/pretyping/vnorm.ml
+++ b/pretyping/vnorm.ml
@@ -218,7 +218,8 @@ and nf_evar env sigma evk stk =
     let t = List.fold_left fold concl hyps in
     let t, args = nf_args env sigma args t in
     let inst, args = Array.chop (List.length hyps) args in
-    let inst = Array.to_list inst in
+    (* Evar instances are reversed w.r.t. argument order *)
+    let inst = Array.rev_to_list inst in
     let c = mkApp (mkEvar (evk, inst), args) in
     nf_stk env sigma c t stk
   | _ ->

--- a/test-suite/bugs/closed/bug_13169.v
+++ b/test-suite/bugs/closed/bug_13169.v
@@ -1,0 +1,14 @@
+Goal False.
+Proof.
+  set (H1:=I).
+  set (x:=true).
+  assert (H2: x = true) by reflexivity.
+  set (y:=false).
+  assert (H3: y = false) by reflexivity.
+  clearbody H1 x y.
+  eenough (H4: _ = false).
+  vm_compute in H4.
+  (* H4 now has "x:=y" in the evar context. *)
+  2: exact H3.
+  match type of H4 with y = false => idtac end.
+Abort.


### PR DESCRIPTION
We simply use evars instance in the right order while reading back VM values.
