### PR TITLE
Define quotation productions with mlgs rather than OCaml

### DIFF
--- a/doc/sphinx/proof-engine/ltac.rst
+++ b/doc/sphinx/proof-engine/ltac.rst
@@ -156,61 +156,19 @@ Syntactic values
 .. insertprodn syn_value syn_value
 
 .. prodn::
-   syn_value ::= @ident : ( @nonterminal )
+   syn_value ::= ident : ( @ident )
+   | integer : ( @integer )
+   | string : ( @string )
+   | reference : ( @qualid )
+   | smart_global : ( @reference )
+   | uconstr : ( @term )
+   | constr : ( @term )
+   | ipattern : ( @simple_intropattern )
+   | open_constr : ( @term )
+   | ltac : ( @ltac_expr )
 
 Provides a way to use the syntax and semantics of a grammar nonterminal as a
-value in an :token:`ltac_expr`.  The table below describes the most useful of
-these.  You can see the others by running ":cmd:`Print Grammar` `tactic`" and
-examining the part at the end under "Entry tactic:tactic_arg".
-
-   :token:`ident`
-      name of a grammar nonterminal listed in the table
-
-   :production:`nonterminal`
-      represents syntax described by :token:`nonterminal`.
-
-   .. list-table::
-      :header-rows: 1
-
-      * -  Specified :token:`ident`
-        - Parsed as
-        - Interpreted as
-        - as in tactic
-
-      * - ``ident``
-        - :token:`ident`
-        - a user-specified name
-        - :tacn:`intro`
-
-      * - ``string``
-        - :token:`string`
-        - a string
-        -
-
-      * - ``integer``
-        - :token:`integer`
-        - an integer
-        -
-
-      * - ``reference``
-        - :token:`qualid`
-        - a qualified identifier
-        -
-
-      * - ``uconstr``
-        - :token:`term`
-        - an untyped term
-        - :tacn:`refine`
-
-      * - ``constr``
-        - :token:`term`
-        - a term
-        - :tacn:`exact`
-
-      * - ``ltac``
-        - :token:`ltac_expr`
-        - a tactic
-        -
+value in an :token:`ltac_expr`.
 
 :n:`ltac:(@ltac_expr)` can be used to indicate that the parenthesized item
 should be interpreted as a tactic and not as a term.  The constructs can also

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -1876,10 +1876,16 @@ tactic_notation_tactics: [
 | "ring_simplify" OPT ( "[" LIST1 operconstr200 "]" ) LIST1 operconstr200 OPT ( "in" ident )  (* todo: ident was "hyp", worth keeping? *)
 ]
 
-(* defined in OCaml outside of mlgs *)
+syn_value: [
+]
+
 tactic_arg: [
-| "uconstr" ":" "(" operconstr200 ")"
-| MOVEALLBUT simple_tactic
+| MOVETO simple_tactic constr_eval
+| MOVETO simple_tactic "fresh" LIST0 fresh_id
+| MOVETO simple_tactic "type_term" uconstr
+| MOVETO simple_tactic "numgoals"
+| DELETE simple_tactic
+| MOVEALLBUT syn_value
 ]
 
 nonterminal: [ ]
@@ -1888,10 +1894,6 @@ value_tactic: [ ]
 
 RENAME: [
 | tactic_arg tactic_value
-]
-
-syn_value: [
-| IDENT; ":" "(" nonterminal ")"
 ]
 
 tactic_value: [

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -1740,11 +1740,11 @@ simple_tactic: [
 | "zify_elim_let"      (* micromega plugin *)
 | "nsatz_compute" constr      (* nsatz plugin *)
 | "omega"      (* omega plugin *)
-| "rtauto"
 | "protect_fv" string "in" ident      (* ring plugin *)
 | "protect_fv" string      (* ring plugin *)
 | "ring_lookup" tactic0 "[" LIST0 constr "]" LIST1 constr      (* ring plugin *)
 | "field_lookup" tactic "[" LIST0 constr "]" LIST1 constr      (* ring plugin *)
+| "rtauto"
 ]
 
 mlname: [
@@ -2020,6 +2020,16 @@ tactic_arg: [
 | "fresh" LIST0 fresh_id
 | "type_term" uconstr
 | "numgoals"
+| "integer" ":" "(" integer ")"
+| "string" ":" "(" string ")"
+| "smart_global" ":" "(" smart_global ")"
+| "ident" ":" "(" ident ")"
+| "reference" ":" "(" reference ")"
+| "uconstr" ":" "(" lconstr ")"
+| "constr" ":" "(" lconstr ")"
+| "ipattern" ":" "(" simple_intropattern ")"
+| "open_constr" ":" "(" lconstr ")"
+| "ltac" ":" "(" tactic_expr5 ")"
 ]
 
 fresh_id: [

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -1434,7 +1434,6 @@ simple_tactic: [
 | "fresh" LIST0 [ string | qualid ]
 | "type_term" one_term
 | "numgoals"
-| "uconstr" ":" "(" term ")"
 | "fun" LIST1 name "=>" ltac_expr
 | "let" OPT "rec" let_clause LIST0 ( "with" let_clause ) "in" ltac_expr
 | ltac_expr3 ";" [ ltac_expr3 | binder_tactic ]
@@ -2255,7 +2254,16 @@ value_tactic: [
 ]
 
 syn_value: [
-| ident ":" "(" nonterminal ")"
+| "ident" ":" "(" ident ")"
+| "integer" ":" "(" integer ")"
+| "string" ":" "(" string ")"
+| "reference" ":" "(" qualid ")"
+| "smart_global" ":" "(" reference ")"
+| "uconstr" ":" "(" term ")"
+| "constr" ":" "(" term ")"
+| "ipattern" ":" "(" simple_intropattern ")"
+| "open_constr" ":" "(" term ")"
+| "ltac" ":" "(" ltac_expr ")"
 ]
 
 ltac_expr: [

--- a/plugins/ltac/extraargs.mlg
+++ b/plugins/ltac/extraargs.mlg
@@ -22,27 +22,6 @@ open Taccoerce
 open Tacinterp
 open Locus
 
-(** Adding scopes for generic arguments not defined through ARGUMENT EXTEND *)
-
-let create_generic_quotation name e wit =
-  let inject (loc, v) = Tacexpr.TacGeneric (Some name, Genarg.in_gen (Genarg.rawwit wit) v) in
-  Tacentries.create_ltac_quotation name inject (e, None)
-
-let () = create_generic_quotation "integer" Pcoq.Prim.integer Stdarg.wit_int
-let () = create_generic_quotation "string" Pcoq.Prim.string Stdarg.wit_string
-
-let () = create_generic_quotation "smart_global" Pcoq.Prim.smart_global Stdarg.wit_smart_global
-
-let () = create_generic_quotation "ident" Pcoq.Prim.ident Stdarg.wit_ident
-let () = create_generic_quotation "reference" Pcoq.Prim.reference Stdarg.wit_ref
-let () = create_generic_quotation "uconstr" Pcoq.Constr.lconstr Stdarg.wit_uconstr
-let () = create_generic_quotation "constr" Pcoq.Constr.lconstr Stdarg.wit_constr
-let () = create_generic_quotation "ipattern" Pltac.simple_intropattern wit_simple_intropattern
-let () = create_generic_quotation "open_constr" Pcoq.Constr.lconstr Stdarg.wit_open_constr
-let () =
-  let inject (loc, v) = Tacexpr.Tacexp v in
-  Tacentries.create_ltac_quotation "ltac" inject (Pltac.tactic_expr, Some 5)
-
 (** Backward-compatible tactic notation entry names *)
 
 let () =

--- a/plugins/ltac/g_ltac.mlg
+++ b/plugins/ltac/g_ltac.mlg
@@ -54,6 +54,9 @@ let new_entry name =
   let e = Entry.create name in
   e
 
+let generate_quotation name wit v =
+  Tacexpr.TacGeneric (Some name, Genarg.in_gen (Genarg.rawwit wit) v)
+
 let toplevel_selector = new_entry "toplevel_selector"
 let tacdef_body = new_entry "tacdef_body"
 
@@ -187,7 +190,28 @@ GRAMMAR EXTEND Gram
     [ [ c = constr_eval -> { ConstrMayEval c }
       | IDENT "fresh"; l = LIST0 fresh_id -> { TacFreshId l }
       | IDENT "type_term"; c=uconstr -> { TacPretype c }
-      | IDENT "numgoals" -> { TacNumgoals } ] ]
+      | IDENT "numgoals" -> { TacNumgoals }
+
+      | IDENT "integer"; ":"; "("; v = integer; ")" ->
+        { generate_quotation "integer" Stdarg.wit_int v }
+      | IDENT "string"; ":"; "("; v = string; ")" ->
+        { generate_quotation "string" Stdarg.wit_string v }
+      | IDENT "smart_global"; ":"; "("; v = smart_global; ")" ->
+        { generate_quotation "smart_global" Stdarg.wit_smart_global v }
+      | IDENT "ident"; ":"; "("; v = ident; ")" ->
+        { generate_quotation "ident" Stdarg.wit_ident v }
+      | IDENT "reference"; ":"; "("; v = reference; ")" ->
+        { generate_quotation "reference" Stdarg.wit_ref v }
+      | IDENT "uconstr"; ":"; "("; v = lconstr; ")" ->
+        { generate_quotation "uconstr" Stdarg.wit_uconstr v }
+      | IDENT "constr"; ":"; "("; v = lconstr; ")" ->
+        { generate_quotation "uconstr" Stdarg.wit_constr v }
+      | IDENT "ipattern"; ":"; "("; v = simple_intropattern; ")" ->
+        { generate_quotation "ipattern" Tacarg.wit_simple_intropattern v }
+      | IDENT "open_constr"; ":"; "("; v = lconstr; ")" ->
+        { generate_quotation "open_constr" Stdarg.wit_open_constr v }
+      | IDENT "ltac"; ":"; "("; v = tactic_expr LEVEL "5"; ")" ->
+        { Tacexpr.Tacexp v } ] ]
   ;
   (* If a qualid is given, use its short name. TODO: have the shortest
      non ambiguous name where dots are replaced by "_"? Probably too


### PR DESCRIPTION
When possible, it's better to define productions using the standard mechanism, mlgs, rather than OCaml code.  Using fewer mechanisms is easier to maintain.  If productions are in OCaml code, they may be easily missed (see #13149) and require extra manual work to discover then and show them in the documented grammar.