### PR TITLE
Add flag -open Gramlib so that merlin works in gramlib with make

### DIFF
--- a/gramlib/.merlin.in
+++ b/gramlib/.merlin.in
@@ -1,0 +1,3 @@
+FLG -open Gramlib
+
+REC


### PR DESCRIPTION
**Kind:** infrastructure.

Credits to @SkySkimmer on [Zulip](https://coq.zulipchat.com/#narrow/stream/237656-Coq-devs.20.26.20plugin.20devs/topic/merlin.20for.20gramlib)