### PR TITLE
Add support for "typeclasses eauto bfs <int_or_var_opt>"

### DIFF
--- a/plugins/ltac/g_class.mlg
+++ b/plugins/ltac/g_class.mlg
@@ -87,11 +87,13 @@ END
 (** Compatibility: typeclasses eauto has 8.5 and 8.6 modes *)
 TACTIC EXTEND typeclasses_eauto
  | [ "typeclasses" "eauto" "bfs" int_or_var_opt(d) "with" ne_preident_list(l) ] ->
-    { typeclasses_eauto ~strategy:Bfs ~depth:d l }
+    { typeclasses_eauto ~depth:d ~strategy:Bfs l }
  | [ "typeclasses" "eauto" int_or_var_opt(d) "with" ne_preident_list(l) ] ->
     { typeclasses_eauto ~depth:d l }
+ | [ "typeclasses" "eauto" "bfs" int_or_var_opt(d) ] -> {
+     typeclasses_eauto ~depth:d ~strategy:Bfs ~only_classes:true [Class_tactics.typeclasses_db] }
  | [ "typeclasses" "eauto" int_or_var_opt(d) ] -> {
-     typeclasses_eauto ~only_classes:true ~depth:d [Class_tactics.typeclasses_db] }
+     typeclasses_eauto ~depth:d ~only_classes:true [Class_tactics.typeclasses_db] }
 END
 
 TACTIC EXTEND head_of_constr


### PR DESCRIPTION
This combination of options was not supported.  That looks like an oversight.

My analysis is superficial; I haven't tested the new combination.

Not sure if this should have a log entry--it seems so trivial.