### PR TITLE
Report a useful error for dependent destruction

### DIFF
--- a/test-suite/output/DependentInductionErrors.out
+++ b/test-suite/output/DependentInductionErrors.out
@@ -1,0 +1,4 @@
+The command has indeed failed with message:
+Tactic failure: To use dependent destruction, first [Require Import Coq.Program.Equality.].
+The command has indeed failed with message:
+Tactic failure: To use dependent induction, first [Require Import Coq.Program.Equality.].

--- a/test-suite/output/DependentInductionErrors.v
+++ b/test-suite/output/DependentInductionErrors.v
@@ -1,0 +1,17 @@
+Theorem foo (b:bool) : b = true \/ b = false.
+Proof.
+  Fail dependent destruction b.
+  Fail dependent induction b.
+Abort.
+
+From Coq Require Import Program.Equality.
+
+Theorem foo_with_destruction (b:bool) : b = true \/ b = false.
+Proof.
+  dependent destruction b; auto.
+Qed.
+
+Theorem foo_with_induction (b:bool) : b = true \/ b = false.
+Proof.
+  dependent induction b; auto.
+Qed.

--- a/theories/Init/Tactics.v
+++ b/theories/Init/Tactics.v
@@ -245,12 +245,15 @@ Tactic Notation "clear" "dependent" hyp(h) :=
 Tactic Notation "revert" "dependent" hyp(h) :=
  generalize dependent h.
 
-(** Provide an error message for dependent induction that reports an import is
-required to use it. Importing Coq.Program.Equality will shadow this notation
-with the actual [dependent induction] tactic. *)
+(** Provide an error message for dependent induction/dependent destruction that
+    reports an import is required to use it. Importing Coq.Program.Equality will
+    shadow this notation with the actual tactics. *)
 
 Tactic Notation "dependent" "induction" ident(H) :=
   fail "To use dependent induction, first [Require Import Coq.Program.Equality.]".
+
+Tactic Notation "dependent" "destruction" ident(H) :=
+  fail "To use dependent destruction, first [Require Import Coq.Program.Equality.]".
 
 (** *** [inversion_sigma] *)
 (** The built-in [inversion] will frequently leave equalities of


### PR DESCRIPTION
Similar to `dependent induction`, report an error message for `dependent
destruction` saying that importing `Coq.Program.Equality` is required,
rather than failing at parsing time.

This is a small extension of #605 to cover dependent destruction as
well. Here I also put in some tests.

If I should add this to the changelog let me know, I've never written something in the new changelog so I'd have to first learn how to do that.

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** feature.


<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [x] Added / updated test-suite
<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [ ] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [ ] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
