### PR TITLE
Addresses #13216: use of type classes in the return clause of a match.

### DIFF
--- a/doc/changelog/02-specification-language/13217-master+fix13216-typeclass-for-match-return-clause.rst
+++ b/doc/changelog/02-specification-language/13217-master+fix13216-typeclass-for-match-return-clause.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  Allow use of type classes inference for the return predicate of a :n:`match`
+  (was deactivated in versions 8.10 to 8.12, `#13217 <https://github.com/coq/coq/pull/13217>`_,
+  fixes `#13216 <https://github.com/coq/coq/issues/13216>`_,
+  by Hugo Herbelin).

--- a/pretyping/cases.ml
+++ b/pretyping/cases.ml
@@ -298,7 +298,7 @@ let inductive_template env sigma tmloc ind =
             let ty = EConstr.of_constr ty in
             let ty' = substl subst ty in
             let sigma, e =
-              Evarutil.new_evar env ~src:(hole_source n) ~typeclass_candidate:false sigma ty'
+              Evarutil.new_evar env ~src:(hole_source n) sigma ty'
             in
             (sigma, e::subst,e::evarl,n+1)
         | LocalDef (na,b,ty) ->

--- a/test-suite/bugs/closed/bug_13216.v
+++ b/test-suite/bugs/closed/bug_13216.v
@@ -1,0 +1,4 @@
+Class A.
+Declare Instance a:A.
+Inductive T `(A) := C.
+Definition f x := match x with C _ => 0 end.


### PR DESCRIPTION
**Kind:** bug fix

This was deactivated in fb1c2a017e, probably without strong will to do so, but it seems useful (e.g. in contribs containers).

Fixes / closes #13216

- [X] Added / updated test-suite
- [x] Entry added in the changelog