### PR TITLE
Restore the List.Smart.map original implementation.

### DIFF
--- a/clib/cList.ml
+++ b/clib/cList.ml
@@ -1019,20 +1019,12 @@ let rec factorize_left cmp = function
 module Smart =
 struct
 
-  let rec map_loop f p = function
-    | [] -> ()
-    | x :: l' as l ->
-      let x' = f x in
-      map_loop f p l';
-      if x' == x && !p == l' then p := l else p := x' :: !p
-
-  let map f = function
-    | [] -> []
-    | x :: l' as l ->
-      let p = ref [] in
-      let x' = f x in
-      map_loop f p l';
-      if x' == x && !p == l' then l else x' :: !p
+  let rec map f l = match l with
+  | [] -> l
+  | h :: tl ->
+    let h' = f h in
+    let tl' = map f tl in
+    if h' == h && tl' == tl then l else h' :: tl'
 
 end
 


### PR DESCRIPTION
Commit 56ff0c9 mangled the code claiming to make it tail-rec, but this is not the case. In addition to make the code convoluted it also over-allocates for nothing and breaks the write barrier for fun.

We simply rollback to the (slightly cleaned-up) previous code, that was simpler, likely faster, and as much tail-rec as the one introduced in 56ff0c9.
