### PR TITLE
Remove warning on SSR Search having moved.

### DIFF
--- a/plugins/ssr/ssrvernac.mlg
+++ b/plugins/ssr/ssrvernac.mlg
@@ -304,21 +304,6 @@ END
 
 {
 
-  let warn_search_moved_enabled = ref true
-  let warn_search_moved = CWarnings.create ~name:"ssr-search-moved"
-      ~category:"deprecated" ~default:CWarnings.Enabled
-      (fun () ->
-         (Pp.strbrk
-            "In previous versions of Coq, loading SSReflect had the effect of \
-             replacing the built-in 'Search' command with an SSReflect version \
-             of that command. \
-             Coq's own search feature was still available via 'SearchAbout' \
-             (but that alias is deprecated). \
-             This replacement no longer happens; now 'Search' calls Coq's own search \
-             feature even when SSReflect is loaded. \
-             If you want to use SSReflect's deprecated Search command \
-             instead of the built-in one, please Require the ssrsearch module."))
-
 open G_vernac
 }
 
@@ -328,7 +313,6 @@ GRAMMAR EXTEND Gram
   query_command:
     [ [ IDENT "Search"; s = search_query; l = search_queries; "." ->
           { let (sl,m) = l in
-            if !warn_search_moved_enabled then warn_search_moved ();
             fun g ->
               Vernacexpr.VernacSearch (Vernacexpr.Search (s::sl),g, m) }
       ] ]

--- a/plugins/ssr/ssrvernac.mli
+++ b/plugins/ssr/ssrvernac.mli
@@ -9,5 +9,3 @@
 (************************************************************************)
 
 (* This file is (C) Copyright 2006-2015 Microsoft Corporation and Inria. *)
-
-val warn_search_moved_enabled : bool ref

--- a/plugins/ssrsearch/g_search.mlg
+++ b/plugins/ssrsearch/g_search.mlg
@@ -301,10 +301,6 @@ let ssrdisplaysearch gr env t =
   let pr_res = pr_global gr ++ str ":" ++ spc () ++ pr_lconstr_env env Evd.empty t in
   Feedback.msg_notice (hov 2 pr_res ++ fnl ())
 
-(* Remove the warning entirely when this plugin is loaded. *)
-let _ =
-  Ssreflect_plugin.Ssrvernac.warn_search_moved_enabled := false
-
 let deprecated_search =
   CWarnings.create
     ~name:"deprecated-ssr-search"


### PR DESCRIPTION
This warning was added in 8.12 to make sure SSR users would be aware of the move. However, it is annoying since SSR users cannot avoid a warning (unless they disable it) whether they use normal `Search` or SSR `Search`. Furthermore, it is confusing because of the "deprecated" category (but the command that raises the warning is not deprecated). IMHO one major version with that warning is enough and the warning should be removed as soon as 8.13.