### PR TITLE
Add a type of format strings to Ltac2.

### DIFF
--- a/doc/changelog/05-tactic-language/13236-ltac2-printf.rst
+++ b/doc/changelog/05-tactic-language/13236-ltac2-printf.rst
@@ -1,0 +1,7 @@
+- **Added:**
+  Added a ``printf`` macro to Ltac2. It can be made accessible by
+  importing the ``Ltac2.Printf`` module. See the documentation
+  there for more information
+  (`#13236 <https://github.com/coq/coq/pull/13236>`_,
+  fixes `#10108 <https://github.com/coq/coq/issues/10108>`_,
+  by Pierre-Marie Pédrot).

--- a/doc/stdlib/index-list.html.template
+++ b/doc/stdlib/index-list.html.template
@@ -691,6 +691,7 @@ through the <tt>Require Import</tt> command.</p>
     user-contrib/Ltac2/Notations.v
     user-contrib/Ltac2/Option.v
     user-contrib/Ltac2/Pattern.v
+    user-contrib/Ltac2/Printf.v
     user-contrib/Ltac2/Std.v
     user-contrib/Ltac2/String.v
   </dd>

--- a/test-suite/ltac2/printf.v
+++ b/test-suite/ltac2/printf.v
@@ -1,0 +1,31 @@
+Require Import Ltac2.Ltac2.
+Require Import Ltac2.Printf.
+
+(* Check that the arguments have type unit *)
+Ltac2 ignore (x : unit) := ().
+
+Ltac2 dummy (_ : unit) (_ : int) := Message.of_string "dummy".
+
+(** Simple test for all specifications *)
+
+Ltac2 Eval ignore (printf "%i" 42).
+Ltac2 Eval ignore (printf "%s" "abc").
+Ltac2 Eval ignore (printf "%I" @Foo).
+Ltac2 Eval ignore (printf "%t" '(1 + 1 = 0)).
+Ltac2 Eval ignore (printf "%%").
+Ltac2 Eval ignore (printf "%a" dummy 18).
+
+(** More complex tests *)
+
+Ltac2 Eval ignore (printf "%I foo%a bar %s" @ok dummy 18 "yes").
+
+Ltac2 Eval Message.print (fprintf "%I foo%a bar %s" @ok dummy 18 "yes").
+
+(** Failure tests *)
+
+Fail Ltac2 Eval printf "%i" "foo".
+Fail Ltac2 Eval printf "%s" 0.
+Fail Ltac2 Eval printf "%I" "foo".
+Fail Ltac2 Eval printf "%t" "foo".
+Fail Ltac2 Eval printf "%a" (fun _ _ => ()).
+Fail Ltac2 Eval printf "%a" (fun _ i => Message.of_int i) "foo".

--- a/user-contrib/Ltac2/Init.v
+++ b/user-contrib/Ltac2/Init.v
@@ -35,6 +35,7 @@ Ltac2 Type preterm.
 Ltac2 Type binder.
 
 Ltac2 Type message.
+Ltac2 Type ('a, 'b, 'c, 'd) format.
 Ltac2 Type exn := [ .. ].
 Ltac2 Type 'a array.
 

--- a/user-contrib/Ltac2/Ltac2.v
+++ b/user-contrib/Ltac2/Ltac2.v
@@ -22,5 +22,6 @@ Require Ltac2.Fresh.
 Require Ltac2.Pattern.
 Require Ltac2.Std.
 Require Ltac2.Env.
+Require Ltac2.Printf.
 Require Ltac2.Ltac1.
 Require Export Ltac2.Notations.

--- a/user-contrib/Ltac2/Message.v
+++ b/user-contrib/Ltac2/Message.v
@@ -25,3 +25,32 @@ Ltac2 @ external of_exn : exn -> message := "ltac2" "message_of_exn".
 (** Panics if there is more than one goal under focus. *)
 
 Ltac2 @ external concat : message -> message -> message := "ltac2" "message_concat".
+
+Module Format.
+
+(** Only for internal use. *)
+
+Ltac2 @ external stop : unit -> ('a, 'b, 'c, 'a) format := "ltac2" "format_stop".
+
+Ltac2 @ external string : ('a, 'b, 'c, 'd) format ->
+  (string -> 'a, 'b, 'c, 'd) format := "ltac2" "format_string".
+
+Ltac2 @ external int : ('a, 'b, 'c, 'd) format ->
+  (int -> 'a, 'b, 'c, 'd) format := "ltac2" "format_int".
+
+Ltac2 @ external constr : ('a, 'b, 'c, 'd) format ->
+  (constr -> 'a, 'b, 'c, 'd) format := "ltac2" "format_constr".
+
+Ltac2 @ external ident : ('a, 'b, 'c, 'd) format ->
+  (ident -> 'a, 'b, 'c, 'd) format := "ltac2" "format_ident".
+
+Ltac2 @ external literal : string -> ('a, 'b, 'c, 'd) format ->
+  ('a, 'b, 'c, 'd) format := "ltac2" "format_literal".
+
+Ltac2 @ external alpha : ('a, 'b, 'c, 'd) format ->
+  (('b -> 'r -> 'c) -> 'r -> 'a, 'b, 'c, 'd) format := "ltac2" "format_alpha".
+
+Ltac2 @ external kfprintf : (message -> 'r) -> ('a, unit, message, 'r) format -> 'a :=
+  "ltac2" "format_kfprintf".
+
+End Format.

--- a/user-contrib/Ltac2/Printf.v
+++ b/user-contrib/Ltac2/Printf.v
@@ -1,0 +1,56 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+Require Import Ltac2.Message.
+
+(** This file defines a printf notation for easiness of writing messages *)
+
+(**
+
+  The built-in "format" notation scope can be used to create well-typed variadic
+  printing commands following a printf-like syntax. The "format" scope parses
+  quoted strings which contain either raw string data or printing
+  specifications. Raw strings will be output verbatim as if they were passed
+  to Ltac2.Message.of_string.
+
+  Printing specifications are of the form
+
+  << '%' type >>
+
+  where the type value defines which kind of arguments will be accepted and
+  how they will be printed. They can take the following values.
+
+  - << i >>: takes an argument of type int and behaves as Message.of_int
+  - << I >>: takes an argument of type ident and behaves as Message.of_ident
+  - << s >>: takes an argument of type string and behaves as Message.of_string
+  - << t >>: takes an argument of type constr and behaves as Message.of_constr
+  - << a >>: takes two arguments << f >> of type << (unit -> 'a -> message) >>
+             and << x >> of type << 'a >> and behaves as << f () x >>
+  - << % >>: outputs << % >> verbatim
+
+  TODO: add printing modifiers.
+
+*)
+
+Ltac2 printf fmt := Format.kfprintf print fmt.
+Ltac2 fprintf fmt := Format.kfprintf (fun x => x) fmt.
+
+(** The two following notations are made available when this module is imported.
+
+    - printf will parse a format and generate a function taking the
+      corresponding arguments ant printing the resulting message as per
+      Message.print. In particular when fully applied it has type unit.
+    - fprintf behaves similarly but return the message as a value instead of
+      printing it.
+
+*)
+
+Ltac2 Notation "printf" fmt(format) := printf fmt.
+Ltac2 Notation "fprintf" fmt(format) := fprintf fmt.

--- a/user-contrib/Ltac2/tac2print.ml
+++ b/user-contrib/Ltac2/tac2print.ml
@@ -489,3 +489,51 @@ let () =
   | _ -> assert false
   in
   register_val_printer kn { val_printer }
+
+(** {5 Ltac2 primitive} *)
+
+type format =
+| FmtString
+| FmtInt
+| FmtConstr
+| FmtIdent
+| FmtLiteral of string
+| FmtAlpha
+
+let val_format = Tac2dyn.Val.create "format"
+
+exception InvalidFormat
+
+let parse_format (s : string) : format list =
+  let len = String.length s in
+  let buf = Buffer.create len in
+  let rec parse i accu =
+    if len <= i then accu
+    else match s.[i] with
+    | '%' -> parse_argument (i + 1) accu
+    | _ ->
+      let i' = parse_literal i in
+      if Int.equal i i' then parse i' accu
+      else
+        let lit = Buffer.contents buf in
+        let () = Buffer.clear buf in
+        parse i' (FmtLiteral lit :: accu)
+  and parse_literal i =
+    if len <= i then i
+    else match s.[i] with
+    | '%' -> i
+    | c ->
+      let () = Buffer.add_char buf c in
+      parse_literal (i + 1)
+  and parse_argument i accu =
+    if len <= i then raise InvalidFormat
+    else match s.[i] with
+    | '%' -> parse (i + 1) (FmtLiteral "%" :: accu)
+    | 's' -> parse (i + 1) (FmtString :: accu)
+    | 'i' -> parse (i + 1) (FmtInt :: accu)
+    | 'I' -> parse (i + 1) (FmtIdent :: accu)
+    | 't' -> parse (i + 1) (FmtConstr :: accu)
+    | 'a' -> parse (i + 1) (FmtAlpha :: accu)
+    | _ -> raise InvalidFormat
+  in
+  parse 0 []

--- a/user-contrib/Ltac2/tac2print.mli
+++ b/user-contrib/Ltac2/tac2print.mli
@@ -46,3 +46,19 @@ val pr_valexpr : Environ.env -> Evd.evar_map -> valexpr -> 'a glb_typexpr -> Pp.
 val int_name : unit -> (int -> string)
 (** Create a function that give names to integers. The names are generated on
     the fly, in the order they are encountered. *)
+
+(** {5 Ltac2 primitives}*)
+
+type format =
+| FmtString
+| FmtInt
+| FmtConstr
+| FmtIdent
+| FmtLiteral of string
+| FmtAlpha
+
+val val_format : format list Tac2dyn.Val.tag
+
+exception InvalidFormat
+
+val parse_format : string -> format list

--- a/user-contrib/Ltac2/tac2quote.mli
+++ b/user-contrib/Ltac2/tac2quote.mli
@@ -85,6 +85,8 @@ val of_constr_matching : constr_matching -> raw_tacexpr
 
 val of_goal_matching : goal_matching -> raw_tacexpr
 
+val of_format : lstring -> raw_tacexpr
+
 (** {5 Generic arguments} *)
 
 val wit_pattern : (Constrexpr.constr_expr, Pattern.constr_pattern) Arg.tag


### PR DESCRIPTION
It provides an abstract type of well-typed format strings, a scope to parse them and a minimal printf-like API.

Fixes / closes #10108

- [x] Added / updated test-suite
- [x] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
