### PR TITLE
Address #13235: avoid passing degenerate in-hyps clauses

### DIFF
--- a/doc/changelog/04-tactics/13237-master+fix13235-no-degenerate-in-hyps-clause.rst
+++ b/doc/changelog/04-tactics/13237-master+fix13235-no-degenerate-in-hyps-clause.rst
@@ -1,0 +1,6 @@
+- **Changed:**
+  Giving an empty list of occurrences after :n:`in` in tactics is no
+  longer permitted. Omitting the :n:`in` gives the same behavior
+  (`#13237 <https://github.com/coq/coq/pull/13236>`_,
+  fixes `#13235 <https://github.com/coq/coq/issues/13235>`_,
+  by Hugo Herbelin).

--- a/doc/sphinx/proofs/writing-proofs/rewriting.rst
+++ b/doc/sphinx/proofs/writing-proofs/rewriting.rst
@@ -274,9 +274,13 @@ simply :g:`t=u` dropping the implicit type of :g:`t` and :g:`u`.
       .. exn:: Too few occurrences.
          :undocumented:
 
-   .. tacv:: change @term {? {? at {+ @natural}} with @term} in @ident
+   .. tacv:: change @term {? {? at {+ @natural}} with @term} in @goal_occurrences
 
-      This applies the :tacn:`change` tactic not to the goal but to the hypothesis :n:`@ident`.
+      In the presence of :n:`with`, this applies :tacn:`change` to the
+      occurrences specified by :n:`@goal_occurrences`. In the
+      absence of :n:`with`, :n:`@goal_occurrences` is expected to
+      only list hypotheses (and optionally the conclusion) without
+      specifying occurrences (i.e. no :n:`at` clause).
 
    .. tacv:: now_show @term
 

--- a/plugins/ltac/g_tactic.mlg
+++ b/plugins/ltac/g_tactic.mlg
@@ -379,9 +379,11 @@ GRAMMAR EXTEND Gram
           { {onhyps=None; concl_occs=occs} }
       | "*"; "|-"; occs=concl_occ ->
           { {onhyps=None; concl_occs=occs} }
-      | hl=LIST0 hypident_occ SEP","; "|-"; occs=concl_occ ->
+      | "|-"; occs=concl_occ ->
+          { {onhyps=Some []; concl_occs=occs} }
+      | hl = LIST1 hypident_occ SEP ","; "|-"; occs=concl_occ ->
           { {onhyps=Some hl; concl_occs=occs} }
-      | hl=LIST0 hypident_occ SEP"," ->
+      | hl = LIST1 hypident_occ SEP "," ->
           { {onhyps=Some hl; concl_occs=NoOccurrences} } ] ]
   ;
   clause_dft_concl:


### PR DESCRIPTION
**Kind:** enhancement

We do not accept a degenerate `in-hyps` clause, which is somehow fragile, as reported in #13235 

In passing, we update the documentation of `change` which was not mentioning the general form of `in-hyps` clause that `change` was actually supporting.

Closes #13235 

- [X] Corresponding documentation was added / updated
- [X] Entry added in the changelog

I did not put a test which would require being able to observe a parsing error (am I correct that we don't know how to do that?).
