### PR TITLE
Fixes #13241: nested Ltac functions wrongly reporting error on the inner calls

### DIFF
--- a/doc/changelog/05-tactic-language/13247-master+fix13241-locating-nested-ltac-errors.rst
+++ b/doc/changelog/05-tactic-language/13247-master+fix13241-locating-nested-ltac-errors.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  Miscellaneous issues with locating tactic errors
+  (`#13247 <https://github.com/coq/coq/pull/13247>`_,
+  fixes `#12773 <https://github.com/coq/coq/issues/12773>`_
+  and `#12992 <https://github.com/coq/coq/issues/12992>`_,
+  by Hugo Herbelin).

--- a/plugins/ltac/taccoerce.ml
+++ b/plugins/ltac/taccoerce.ml
@@ -394,8 +394,13 @@ type appl =
 
 (* Values for interpretation *)
 type tacvalue =
-  | VFun of appl * Tacexpr.ltac_trace * Loc.t option * Val.t Id.Map.t *
-      Name.t list * Tacexpr.glob_tactic_expr
+  | VFun of
+      appl *
+      Tacexpr.ltac_trace *
+      Loc.t option * (* when executing a global Ltac function: the location where this function was called *)
+      Val.t Id.Map.t * (* closure *)
+      Name.t list * (* binders *)
+      Tacexpr.glob_tactic_expr (* body *)
   | VRec of Val.t Id.Map.t ref * Tacexpr.glob_tactic_expr
 
 let (wit_tacvalue : (Empty.t, tacvalue, tacvalue) Genarg.genarg_type) =

--- a/test-suite/output/ErrorLocation_13241_1.out
+++ b/test-suite/output/ErrorLocation_13241_1.out
@@ -1,0 +1,3 @@
+File "stdin", line 4, characters 0-1:
+Error: No product even after head-reduction.
+

--- a/test-suite/output/ErrorLocation_13241_1.v
+++ b/test-suite/output/ErrorLocation_13241_1.v
@@ -1,0 +1,4 @@
+Ltac a := intro.
+Ltac b := a.
+Goal True.
+b.

--- a/test-suite/output/ErrorLocation_13241_2.out
+++ b/test-suite/output/ErrorLocation_13241_2.out
@@ -1,0 +1,3 @@
+File "stdin", line 4, characters 0-1:
+Error: No product even after head-reduction.
+

--- a/test-suite/output/ErrorLocation_13241_2.v
+++ b/test-suite/output/ErrorLocation_13241_2.v
@@ -1,0 +1,4 @@
+Ltac a _ := intro.
+Ltac b := a ().
+Goal True.
+b.


### PR DESCRIPTION
This continues #12223, #12773, #12992, #12774, #12999.

**Kind:** bug fix 

Fixes / closes #13241

- [X] Added / updated test-suite
- [X] Entry added in the changelog (I referred there to #12773 and #12992 but not to #13241 since the latter was only in the dev branch).