### PR TITLE
Micro-optimization in Control.check_for_interrupt.

### DIFF
--- a/lib/control.ml
+++ b/lib/control.ml
@@ -18,10 +18,12 @@ let enable_thread_delay = ref false
 
 let check_for_interrupt () =
   if !interrupt then begin interrupt := false; raise Sys.Break end;
-  incr steps;
-  if !enable_thread_delay && !steps = 1000 then begin
-    Thread.delay 0.001;
-    steps := 0;
+  if !enable_thread_delay then begin
+    incr steps;
+    if !steps = 1000 then begin
+      Thread.delay 0.001;
+      steps := 0;
+    end
   end
 
 (** This function does not work on windows, sigh... *)


### PR DESCRIPTION
We do not have to increase the step counter when out of the threaded mode since this counter is only relevant when in that mode.
