### PR TITLE
Change Dumpglob.pause and Dumpglob.continue into push and pop

### DIFF
--- a/dev/doc/changes.md
+++ b/dev/doc/changes.md
@@ -30,6 +30,13 @@ Generic arguments:
 
 - Generic arguments: `wit_var` is deprecated, use `wit_hyp`.
 
+Dumpglob:
+
+- The function `Dumpglob.pause` and `Dumpglob.continue` are replaced
+  by `Dumpglob.push_output` and `Dumpglob.pop_output`. This allows
+  plugins to temporarily change/pause the output of Dumpglob, and then
+  restore it to the original setting.
+
 ## Changes between Coq 8.11 and Coq 8.12
 
 ### Code formatting

--- a/interp/dumpglob.mli
+++ b/interp/dumpglob.mli
@@ -19,11 +19,19 @@ type glob_output =
   | MultFiles                   (* one glob file per .v file *)
   | File of string              (* Single file for all coqc arguments *)
 
-(* Default "NoGlob" *)
-val set_glob_output : glob_output -> unit
+(** [push_output o] temporarily overrides the output location to [o].
+    The original output can be restored using [pop_output] *)
+val push_output : glob_output -> unit
 
+(** Restores the original output that was overridden by [push_output] *)
+val pop_output : unit -> unit
+
+(** Alias for [push_output NoGlob] *)
 val pause : unit -> unit
+
+(** Deprecated alias for [pop_output] *)
 val continue : unit -> unit
+[@@ocaml.deprecated "Use pop_output"]
 
 val add_glob : ?loc:Loc.t -> Names.GlobRef.t -> unit
 val add_glob_kn : ?loc:Loc.t -> Names.KerName.t -> unit

--- a/plugins/funind/indfun_common.ml
+++ b/plugins/funind/indfun_common.ml
@@ -108,7 +108,7 @@ let with_full_print f a =
     Constrextern.print_universes := old_printuniverses;
     Goptions.set_bool_option_value Detyping.print_allow_match_default_opt_name
       old_printallowmatchdefaultclause;
-    Dumpglob.continue ();
+    Dumpglob.pop_output ();
     res
   with reraise ->
     Impargs.make_implicit_args old_implicit_args;
@@ -118,7 +118,7 @@ let with_full_print f a =
     Constrextern.print_universes := old_printuniverses;
     Goptions.set_bool_option_value Detyping.print_allow_match_default_opt_name
       old_printallowmatchdefaultclause;
-    Dumpglob.continue ();
+    Dumpglob.pop_output ();
     raise reraise
 
 (**********************)

--- a/toplevel/ccompile.ml
+++ b/toplevel/ccompile.ml
@@ -139,7 +139,7 @@ let compile opts copts ~echo ~f_in ~f_out =
         ~aux_file:(aux_file_name_for long_f_dot_out)
         ~v_file:long_f_dot_in);
 
-      Dumpglob.set_glob_output copts.glob_out;
+      Dumpglob.push_output copts.glob_out;
       Dumpglob.start_dump_glob ~vfile:long_f_dot_in ~vofile:long_f_dot_out;
       Dumpglob.dump_string ("F" ^ Names.DirPath.to_string ldir ^ "\n");
 


### PR DESCRIPTION
When you want to temporarily pause `Dumpglob` in a plugin, there is no way to later restore it, because you don't know what the original output location was. Therefore, I propose to modify `Dumpglob`, such that the output modification happens on a stack. Then `modify_output` pushes to the stack and `restore_output` takes from the stack. The output location is determined by the top of the stack.

A simpler, more ad-hoc way of solving this problem is to allow a plugin to query the current output location. But this seems more principled to me.

If this modification is acceptable, please let me know what kind of documentation I should write.

<!-- Keep what applies -->
**Kind:** feature.

<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [ ] Added / updated test-suite
<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [ ] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [ ] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
