### PR TITLE
Adopt the same format for "Print Ltac foo" and "Print foo" when "foo" is an Ltac

### DIFF
--- a/plugins/ltac/g_ltac.mlg
+++ b/plugins/ltac/g_ltac.mlg
@@ -466,7 +466,7 @@ END
 
 VERNAC COMMAND EXTEND VernacPrintLtac CLASSIFIED AS QUERY
 | [ "Print" "Ltac" reference(r) ] ->
-  { Feedback.msg_notice (Tacintern.print_ltac r) }
+  { Feedback.msg_notice (Tacentries.print_ltac r) }
 END
 
 VERNAC COMMAND EXTEND VernacLocateLtac CLASSIFIED AS QUERY

--- a/plugins/ltac/tacentries.mli
+++ b/plugins/ltac/tacentries.mli
@@ -69,6 +69,9 @@ val print_ltacs : unit -> unit
 val print_located_tactic : Libnames.qualid -> unit
 (** Display the absolute name of a tactic. *)
 
+val print_ltac : Libnames.qualid -> Pp.t
+(** Display the definition of a tactic. *)
+
 (** {5 Low-level registering of tactics} *)
 
 type (_, 'a) ml_ty_sig =

--- a/plugins/ltac/tacintern.ml
+++ b/plugins/ltac/tacintern.ml
@@ -769,38 +769,6 @@ let glob_tactic_env l env x =
   (intern_pure_tactic { (Genintern.empty_glob_sign env) with ltacvars })
     x
 
-let split_ltac_fun = function
-  | TacFun (l,t) -> (l,t)
-  | t -> ([],t)
-
-let pr_ltac_fun_arg n = spc () ++ Name.print n
-
-let print_ltac id =
- try
-  let kn = Tacenv.locate_tactic id in
-  let entries = Tacenv.ltac_entries () in
-  let tac = KNmap.find kn entries in
-  let filter mp =
-    try Some (Nametab.shortest_qualid_of_module mp)
-    with Not_found -> None
-  in
-  let mods = List.map_filter filter tac.Tacenv.tac_redef in
-  let redefined = match mods with
-  | [] -> mt ()
-  | mods ->
-    let redef = prlist_with_sep fnl pr_qualid mods in
-    fnl () ++ str "Redefined by:" ++ fnl () ++ redef
-  in
-  let l,t = split_ltac_fun tac.Tacenv.tac_body in
-  hv 2 (
-    hov 2 (str "Ltac" ++ spc() ++ pr_qualid id ++
-           prlist pr_ltac_fun_arg l ++ spc () ++ str ":=")
-    ++ spc() ++ Pptactic.pr_glob_tactic (Global.env ()) t) ++ redefined
- with
-  Not_found ->
-   user_err ~hdr:"print_ltac"
-    (pr_qualid id ++ spc() ++ str "is not a user defined tactic.")
-
 (** Registering *)
 
 let lift intern = (); fun ist x -> (ist, intern ist x)

--- a/plugins/ltac/tacintern.mli
+++ b/plugins/ltac/tacintern.mli
@@ -55,9 +55,6 @@ val intern_hyp : glob_sign -> lident -> lident
 
 val intern_genarg : glob_sign -> raw_generic_argument -> glob_generic_argument
 
-(** printing *)
-val print_ltac : Libnames.qualid -> Pp.t
-
 (** Reduction expressions *)
 
 val intern_red_expr : glob_sign -> raw_red_expr -> glob_red_expr

--- a/test-suite/output/bug_13004.out
+++ b/test-suite/output/bug_13004.out
@@ -1,2 +1,2 @@
-Ltac bug_13004.t := ltac2:(print (of_string "hi"))
-Ltac bug_13004.u := ident:(H)
+Ltac t := ltac2:(print (of_string "hi"))
+Ltac u := ident:(H)

--- a/test-suite/output/bug_13238.out
+++ b/test-suite/output/bug_13238.out
@@ -1,4 +1,4 @@
-Ltac bug_13238.t1 x := replace (x x) with (x x)
-Ltac bug_13238.t2 x := case : x 
-Ltac bug_13238.t3 := by move ->
-Ltac bug_13238.t4 := congr True 
+Ltac t1 x := replace (x x) with (x x)
+Ltac t2 x := case : x 
+Ltac t3 := by move ->
+Ltac t4 := congr True 


### PR DESCRIPTION
**Kind:** subjective uniformization

Adopting the same format means printing `Ltac foo := ...` in both cases, as it is now for `Print Ltac`, and not the fully qualified name of `foo` in the `Print foo` case. I don't know if printing the full name was intended or not though.

Before:
```
Print exfalso.
(* Ltac Coq.Init.Tactics.exfalso := elimtype False *)
Print Ltac exfalso.
(* Ltac exfalso := elimtype False *)
```
With the PR:
```
Print exfalso.
(* Ltac exfalso := elimtype False *)
Print Ltac exfalso.
(* Ltac exfalso := elimtype False *)
```

Related to #13238.