### PR TITLE
Fixes #13244: support for coercions in Search

### DIFF
--- a/doc/changelog/07-commands-and-options/13255-master+fix13244-use-coercions-in-search.rst
+++ b/doc/changelog/07-commands-and-options/13255-master+fix13244-use-coercions-in-search.rst
@@ -1,0 +1,7 @@
+- **Added:**
+  Added support for automatic insertion of coercions in :cmd:`Search`
+  patterns. Additionally, head patterns are now automatically
+  interpreted as types
+  (`#13255 <https://github.com/coq/coq/pull/13255>`_,
+  fixes `#13244 <https://github.com/coq/coq/issues/13244>`_,
+  by Hugo Herbelin).

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -2471,6 +2471,15 @@ let intern_constr_pattern env sigma ?(as_type=false) ?(ltacvars=empty_ltac_sign)
             ~pattern_mode:true ~ltacvars env sigma c in
   pattern_of_glob_constr c
 
+let interp_constr_pattern env sigma ?(expected_type=WithoutTypeConstraint) c =
+  let kind_for_intern = match expected_type with OfType _ -> WithoutTypeConstraint | _ -> expected_type in
+  let c = intern_gen kind_for_intern ~pattern_mode:true env sigma c in
+  let flags = { Pretyping.no_classes_no_fail_inference_flags with expand_evars = false } in
+  let sigma, c = understand_tcc ~flags env sigma ~expected_type c in
+  (* FIXME: it is necessary to be unsafe here because of the way we handle
+     evars in the pretyper. Sometimes they get solved eagerly. *)
+  pattern_of_constr env sigma (EConstr.Unsafe.to_constr c)
+
 let intern_core kind env sigma ?(pattern_mode=false) ?(ltacvars=empty_ltac_sign)
       { Genintern.intern_ids = ids; Genintern.notation_variable_status = vl } c =
   let tmp_scope = scope_of_type_kind env sigma kind in

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -2472,8 +2472,7 @@ let intern_constr_pattern env sigma ?(as_type=false) ?(ltacvars=empty_ltac_sign)
   pattern_of_glob_constr c
 
 let interp_constr_pattern env sigma ?(expected_type=WithoutTypeConstraint) c =
-  let kind_for_intern = match expected_type with OfType _ -> WithoutTypeConstraint | _ -> expected_type in
-  let c = intern_gen kind_for_intern ~pattern_mode:true env sigma c in
+  let c = intern_gen expected_type ~pattern_mode:true env sigma c in
   let flags = { Pretyping.no_classes_no_fail_inference_flags with expand_evars = false } in
   let sigma, c = understand_tcc ~flags env sigma ~expected_type c in
   (* FIXME: it is necessary to be unsafe here because of the way we handle

--- a/interp/constrintern.mli
+++ b/interp/constrintern.mli
@@ -136,9 +136,15 @@ val interp_type_evars_impls : ?flags:inference_flags -> env -> evar_map ->
 
 (** Interprets constr patterns *)
 
+(** Without typing *)
 val intern_constr_pattern :
   env -> evar_map -> ?as_type:bool -> ?ltacvars:ltac_sign ->
     constr_pattern_expr -> patvar list * constr_pattern
+
+(** With typing *)
+val interp_constr_pattern :
+  env -> evar_map -> ?expected_type:typing_constraint ->
+    constr_pattern_expr -> constr_pattern
 
 (** Raise Not_found if syndef not bound to a name and error if unexisting ref *)
 val intern_reference : qualid -> GlobRef.t

--- a/test-suite/output/Search.out
+++ b/test-suite/output/Search.out
@@ -458,3 +458,7 @@ reflexive_eq_dom_reflexive:
 B.b: B.a
 A.b: A.a
 F.L: F.P 0
+inr: forall {A B : Type}, B -> A + B
+inl: forall {A B : Type}, A -> A + B
+(use "About" for full details on the implicit arguments of inl and inr)
+f: None = 0

--- a/test-suite/output/Search.v
+++ b/test-suite/output/Search.v
@@ -89,3 +89,10 @@ Module Bug12647.
   Search F.P.
   End Bar.
 End Bug12647.
+
+Module WithCoercions.
+  Search headconcl:(_ + _) inside Datatypes.
+  Coercion Some_nat := @Some nat.
+  Axiom f : None = 0.
+  Search (None = 0).
+End WithCoercions.

--- a/test-suite/output/bug_13244.out
+++ b/test-suite/output/bug_13244.out
@@ -1,0 +1,9 @@
+negbT: forall [b : bool], b = false -> ~~ b
+contra_notN: forall [P : Prop] [b : bool], (b -> P) -> ~ P -> ~~ b
+contraPN: forall [P : Prop] [b : bool], (b -> ~ P) -> P -> ~~ b
+contraNN: forall [c b : bool], (c -> b) -> ~~ b -> ~~ c
+contraL: forall [c b : bool], (c -> ~~ b) -> b -> ~~ c
+contraTN: forall [c b : bool], (c -> ~~ b) -> b -> ~~ c
+contra: forall [c b : bool], (c -> b) -> ~~ b -> ~~ c
+introN: forall [P : Prop] [b : bool], reflect P b -> ~ P -> ~~ b
+contraFN: forall [c b : bool], (c -> b) -> b = false -> ~~ c

--- a/test-suite/output/bug_13244.v
+++ b/test-suite/output/bug_13244.v
@@ -1,0 +1,3 @@
+Require Import ssr.ssrbool.
+Set Warnings "-ssr-search-moved".
+Search headconcl:(~~ _).


### PR DESCRIPTION
**Kind:** enhancement

Fixes / closes #13244

This PR introduces typing of `Search` patterns, and, as a consequence, coercions are inserted in the patterns whenever insertable. This includes support for coercion head patterns to types, as ssreflect `Search` was doing.

Notations in head patterns are also interpreted in `type_scope`, so that `Search head:(_ + _)` is now talking about the `sum` type.

Don't know if this is considered important for 8.12.1. Maybe not.

- [X] Added / updated test-suite
- [x] Entry added in the changelog