### PR TITLE
adjust Search deprecation warning

### DIFF
--- a/plugins/ssr/ssrvernac.mlg
+++ b/plugins/ssr/ssrvernac.mlg
@@ -309,9 +309,15 @@ END
       ~category:"deprecated" ~default:CWarnings.Enabled
       (fun () ->
          (Pp.strbrk
-            "SSReflect's Search command has been moved to the \
-             ssrsearch module; please Require that module if you \
-             still want to use SSReflect's Search command"))
+            "In previous versions of Coq, loading SSReflect had the effect of \
+             replacing the built-in 'Search' command with an SSReflect version \
+             of that command. \
+             Coq's own search feature was still available via 'SearchAbout' \
+             (but that alias is deprecated). \
+             This replacement no longer happens; now 'Search' calls Coq's own search \
+             feature even when SSReflect is loaded. \
+             If you want to use SSReflect's deprecated Search command \
+             instead of the built-in one, please Require the ssrsearch module."))
 
 open G_vernac
 }


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->
This is a strawman proposal to improve the warning about `Search` to hopefully confuse fewer people.

<!-- Keep what applies -->
**Kind:** documentation / bug fix (not sure).



<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [ ] Added / updated test-suite
<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [ ] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [ ] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
