### PR TITLE
Specify int upper and lower bound

### DIFF
--- a/theories/Numbers/Cyclic/Int63/Int63.v
+++ b/theories/Numbers/Cyclic/Int63/Int63.v
@@ -93,6 +93,9 @@ Definition digits := 63.
 Definition max_int := Eval vm_compute in 0 - 1.
 Register Inline max_int.
 
+Axiom int_lower_bound : forall x, 0 <=? x = true.
+Axiom int_upper_bound : forall x, x <=? max_int = true.
+
 (** Access to the nth digits *)
 Definition get_digit x p := (0 <? (x land (1 << p))).
 


### PR DESCRIPTION
**Kind:** feature

When using the `int` type, I have found myself in situation where I missed a theorem which says that `x : int` is always positive, and never greater than `max_int`. This PR adds axioms to that end (I don’t think we can prove them using regular lemmas, but maybe I am wrong).

As of now, this PR is more of a proposal, if that’s okay with you and if you want me to, I can write a changelog entry.

- [ ] Added / updated test-suite
- [ ] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [ ] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
