### PR TITLE
Correct doc using :>>

### DIFF
--- a/doc/sphinx/changes.rst
+++ b/doc/sphinx/changes.rst
@@ -1463,8 +1463,8 @@ Changes in 8.11+beta1
   A simplification of parsing rules could cause a slight change of
   parsing precedences for the very rare users who defined notations
   with `constr` at level strictly between 100 and 200 and used these
-  notations on the right-hand side of a cast operator (`:`, `:>`,
-  `:>>`) (`#10963 <https://github.com/coq/coq/pull/10963>`_, by Théo
+  notations on the right-hand side of a cast operator (`:`, `<:`,
+  `<<:`) (`#10963 <https://github.com/coq/coq/pull/10963>`_, by Théo
   Zimmermann, simplification initially noticed by Jim Fehrle).
 
 **Tactics**

--- a/doc/sphinx/language/core/basic.rst
+++ b/doc/sphinx/language/core/basic.rst
@@ -172,7 +172,7 @@ Other tokens
   (even when starting |Coq| with the `-noinit` command-line flag)::
 
     ! #[ % & ' ( () ) * + , - ->
-    . .( .. ... / : ::= := :> :>> ; < <+ <- <:
+    . .( .. ... / : ::= := :> ; < <+ <- <:
     <<: <= = => > >-> >= ? @ @{ [ ] _
     `( `{ { {| | }
 


### PR DESCRIPTION
The cast keywords are <: and <<:, not :>/:>>

:>> stopped being a keyword in #13106