### PR TITLE
Rename lconstr -> term in mlgs and Tactic Notation

### DIFF
--- a/doc/sphinx/user-extensions/syntax-extensions.rst
+++ b/doc/sphinx/user-extensions/syntax-extensions.rst
@@ -1860,6 +1860,8 @@ Tactic notations allow customizing the syntax of tactics.
         we want to support all these?
         @JasonGross's opinion here: https://github.com/coq/coq/pull/11718#discussion_r415387421
 
+     .. todo "term" is now available, not sure it's worth documenting
+
    .. list-table::
       :header-rows: 1
 

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -13,10 +13,6 @@
 DOC_GRAMMAR
 
 (* first, fixup symbols duplicated across files *)
-lglob: [
-| lconstr
-| DELETE EXTRAARGS_lconstr
-]
 
 hint: [
 | "Extern" natural OPT constr_pattern "=>" tactic
@@ -98,9 +94,9 @@ RENAME: [
    Put other renames at the end *)
 RENAME: [
   (* map missing names for rhs *)
-| Constr.constr term
+| Constr.constr term200
 | Constr.global global
-| Constr.lconstr lconstr
+| Constr.term200 term200
 | Constr.cpattern cpattern
 | G_vernac.query_command query_command
 | G_vernac.section_subset_expr section_var_expr
@@ -257,7 +253,7 @@ dirpath: [
 ]
 
 let_type_cstr: [
-| DELETE OPT [ ":" lconstr ]
+| DELETE OPT [ ":" term200 ]
 | type_cstr
 ]
 
@@ -339,6 +335,10 @@ type: [
 | term200
 ]
 
+term: [
+| DELETE _term
+]
+
 term100: [
 | REPLACE term99 "<:" term200
 | WITH term99 "<:" type
@@ -396,8 +396,8 @@ term0: [
 | MOVETO term_generalizing "`{" term200 "}"
 | MOVETO term_generalizing "`(" term200 ")"
 | MOVETO term_ltac "ltac" ":" "(" ltac_expr5 ")"
-| REPLACE "[" "|" array_elems "|" lconstr type_cstr "|" "]" univ_annot
-| WITH "[|" array_elems "|" lconstr type_cstr "|]" univ_annot
+| REPLACE "[" "|" array_elems "|" term200 type_cstr "|" "]" univ_annot
+| WITH "[|" array_elems "|" term200 type_cstr "|]" univ_annot
 ]
 
 fix_decls: [
@@ -430,8 +430,8 @@ binder: [
 ]
 
 open_binders: [
-| REPLACE name LIST0 name ":" lconstr
-| WITH LIST1 name ":" lconstr
+| REPLACE name LIST0 name ":" term200
+| WITH LIST1 name ":" term200
 (* @Zimmi48: Special token .. is for use in the Notation command. (see bug_3304.v) *)
 | DELETE name ".." name
 | REPLACE name LIST0 name binders
@@ -442,33 +442,33 @@ open_binders: [
 closed_binder: [
 | name
 
-| REPLACE "(" name LIST1 name ":" lconstr ")"
+| REPLACE "(" name LIST1 name ":" term200 ")"
 | WITH "(" LIST1 name ":" type ")"
-| DELETE "(" name ":" lconstr ")"
+| DELETE "(" name ":" term200 ")"
 
-| DELETE "(" name ":=" lconstr ")"
+| DELETE "(" name ":=" term200 ")"
 
-| REPLACE "(" name ":" lconstr ":=" lconstr ")"
-| WITH "(" name type_cstr ":=" lconstr ")"
+| REPLACE "(" name ":" term200 ":=" term200 ")"
+| WITH "(" name type_cstr ":=" term200 ")"
 
 | DELETE "{" name "}"
 | DELETE "{" name LIST1 name "}"
 
-| REPLACE "{" name LIST1 name ":" lconstr "}"
+| REPLACE "{" name LIST1 name ":" term200 "}"
 | WITH "{" LIST1 name type_cstr "}"
-| DELETE "{" name ":" lconstr  "}"
+| DELETE "{" name ":" term200  "}"
 | MOVETO implicit_binders "{" LIST1 name type_cstr "}"
 
 | DELETE "[" name "]"
 | DELETE "[" name LIST1 name "]"
 
-| REPLACE "[" name LIST1 name ":" lconstr "]"
+| REPLACE "[" name LIST1 name ":" term200 "]"
 | WITH "[" LIST1 name type_cstr "]"
-| DELETE "[" name ":" lconstr  "]"
+| DELETE "[" name ":" term200  "]"
 | MOVETO implicit_binders "[" LIST1 name type_cstr "]"
 
-| REPLACE "(" Prim.name ":" lconstr "|" lconstr ")"
-| WITH "(" Prim.name ":" type "|" lconstr ")"
+| REPLACE "(" Prim.name ":" term200 "|" term200 ")"
+| WITH "(" Prim.name ":" type "|" term200 ")"
 
 | MOVETO generalizing_binder "`(" LIST1 typeclass_constraint SEP "," ")"
 | MOVETO generalizing_binder "`{" LIST1 typeclass_constraint SEP "," "}"
@@ -526,8 +526,8 @@ DELETE: [
 ]
 
 eqn: [
-| REPLACE LIST1 mult_pattern SEP "|" "=>" lconstr
-| WITH LIST1 [ LIST1 pattern100 SEP "," ] SEP "|" "=>" lconstr
+| REPLACE LIST1 mult_pattern SEP "|" "=>" term200
+| WITH LIST1 [ LIST1 pattern100 SEP "," ] SEP "|" "=>" term200
 ]
 
 universe_increment: [
@@ -555,7 +555,7 @@ variant_definition: [
 ]
 
 gallina: [
-| REPLACE thm_token ident_decl binders ":" lconstr LIST0 [ "with" ident_decl binders ":" lconstr ]
+| REPLACE thm_token ident_decl binders ":" term200 LIST0 [ "with" ident_decl binders ":" term200 ]
 | WITH thm_token ident_decl binders ":" type LIST0 [ "with" ident_decl binders ":" type ]
 | DELETE assumptions_token inline assum_list
 | REPLACE finite_token LIST1 inductive_definition SEP "with"
@@ -625,10 +625,10 @@ attr_value: [
 ]
 
 def_body: [
-| DELETE binders ":=" reduce lconstr
-| REPLACE binders ":" lconstr ":=" reduce lconstr
-| WITH LIST0 binder OPT (":" type) ":=" reduce lconstr
-| REPLACE binders ":" lconstr
+| DELETE binders ":=" reduce term200
+| REPLACE binders ":" term200 ":=" reduce term200
+| WITH LIST0 binder OPT (":" type) ":=" reduce term200
+| REPLACE binders ":" term200
 | WITH LIST0 binder ":" type
 ]
 
@@ -722,8 +722,8 @@ gallina_ext: [
 | WITH "Set" setting_name option_setting
 | REPLACE "Export" "Unset" setting_name
 | WITH "Unset" setting_name
-| REPLACE "Instance" instance_name ":" term200 hint_info [ ":=" "{" record_declaration "}" | ":=" lconstr | ]
-| WITH "Instance" instance_name ":" type hint_info OPT [ ":=" "{" record_declaration "}" | ":=" lconstr ]
+| REPLACE "Instance" instance_name ":" term200 hint_info [ ":=" "{" record_declaration "}" | ":=" term200 | ]
+| WITH "Instance" instance_name ":" type hint_info OPT [ ":=" "{" record_declaration "}" | ":=" term200 ]
 
 | REPLACE "From" global "Require" export_token LIST1 global
 | WITH "From" dirpath "Require" export_token LIST1 global
@@ -910,7 +910,7 @@ match_list: [
 ]
 
 match_rule: [
-(* redundant; match_pattern -> term -> _ *)
+(* redundant; match_pattern -> term200 -> _ *)
 | DELETE "_" "=>" ltac_expr5
 ]
 
@@ -1315,7 +1315,7 @@ command: [
 | DELETE "Show" "Zify" "BinOpSpec"      (* micromega plugin *)
 (* keep this one | "Show" "Zify" "Spec"      (* micromega plugin *)*)
 | "Show" "Zify" show_zify  TAG Micromega
-| REPLACE "Goal" lconstr
+| REPLACE "Goal" term200
 | WITH "Goal" type
 ]
 
@@ -1369,19 +1369,19 @@ binder_tactic: [
 ]
 
 field_body: [
-| REPLACE binders of_type lconstr
+| REPLACE binders of_type term200
 | WITH binders of_type
-| REPLACE binders of_type lconstr ":=" lconstr
-| WITH binders of_type ":=" lconstr
+| REPLACE binders of_type term200 ":=" term200
+| WITH binders of_type ":=" term200
 ]
 
 assumpt: [
-| REPLACE LIST1 ident_decl of_type lconstr
+| REPLACE LIST1 ident_decl of_type term200
 | WITH LIST1 ident_decl of_type
 ]
 
 constructor_type: [
-| REPLACE binders [ of_type lconstr | ]
+| REPLACE binders [ of_type term200 | ]
 | WITH binders OPT of_type
 ]
 
@@ -1427,24 +1427,24 @@ legacy_attr: [
 sentence: [ ]  (* productions defined below *)
 
 fix_definition: [
-| REPLACE ident_decl binders_fixannot type_cstr OPT [ ":=" lconstr ] decl_notations
-| WITH ident_decl binders_fixannot type_cstr OPT [ ":=" lconstr ] decl_notations
+| REPLACE ident_decl binders_fixannot type_cstr OPT [ ":=" term200 ] decl_notations
+| WITH ident_decl binders_fixannot type_cstr OPT [ ":=" term200 ] decl_notations
 ]
 
 cofix_definition: [
-| REPLACE ident_decl binders type_cstr OPT [ ":=" lconstr ] decl_notations
-| WITH ident_decl binders type_cstr OPT [ ":=" lconstr ] decl_notations
+| REPLACE ident_decl binders type_cstr OPT [ ":=" term200 ] decl_notations
+| WITH ident_decl binders type_cstr OPT [ ":=" term200 ] decl_notations
 ]
 
 type_cstr: [
-| REPLACE ":" lconstr
+| REPLACE ":" term200
 | WITH ":" type
 | OPTINREF
 ]
 
 inductive_definition: [
-| REPLACE opt_coercion ident_decl binders OPT [ "|" binders ] OPT [ ":" lconstr ] opt_constructors_or_fields decl_notations
-| WITH    opt_coercion ident_decl binders OPT [ "|" binders ] OPT [ ":" type ]    opt_constructors_or_fields decl_notations
+| REPLACE opt_coercion ident_decl binders OPT [ "|" binders ] OPT [ ":" term200 ] opt_constructors_or_fields decl_notations
+| WITH    opt_coercion ident_decl binders OPT [ "|" binders ] OPT [ ":" type ] opt_constructors_or_fields decl_notations
 ]
 
 (* note that constructor -> identref constructor_type *)
@@ -1469,12 +1469,12 @@ at_level_opt: [
 ]
 
 query_command: [
-| REPLACE "Eval" red_expr "in" lconstr "."
-| WITH "Eval" red_expr "in" lconstr
-| REPLACE "Compute" lconstr "."
-| WITH "Compute" lconstr
-| REPLACE "Check" lconstr "."
-| WITH "Check" lconstr
+| REPLACE "Eval" red_expr "in" term200 "."
+| WITH "Eval" red_expr "in" term200
+| REPLACE "Compute" term200 "."
+| WITH "Compute" term200
+| REPLACE "Check" term200 "."
+| WITH "Check" term200
 | REPLACE "About" smart_global OPT univ_name_list "."
 | WITH "About" smart_global OPT univ_name_list
 | REPLACE "SearchHead" constr_pattern in_or_out_modules "."
@@ -1665,9 +1665,9 @@ eauto_search_strategy: [
 
 
 constr_body: [
-| DELETE ":=" lconstr
-| REPLACE ":" lconstr ":=" lconstr
-| WITH OPT ( ":" type ) ":=" lconstr
+| DELETE ":=" term200
+| REPLACE ":" term200 ":=" term200
+| WITH OPT ( ":" type ) ":=" term200
 ]
 
 opt_hintbases: [
@@ -1689,7 +1689,7 @@ instance_name: [
 ]
 
 simple_reserv: [
-| REPLACE LIST1 identref ":" lconstr
+| REPLACE LIST1 identref ":" term200
 | WITH LIST1 identref ":" type
 ]
 
@@ -2210,8 +2210,8 @@ ltac2_quotations: [
 ]
 
 ltac2_tactic_atom: [
-| MOVETO ltac2_quotations "constr" ":" "(" lconstr ")"      (* Ltac2 plugin *)
-| MOVETO ltac2_quotations "open_constr" ":" "(" lconstr ")"      (* Ltac2 plugin *)
+| MOVETO ltac2_quotations "constr" ":" "(" term200 ")"      (* Ltac2 plugin *)
+| MOVETO ltac2_quotations "open_constr" ":" "(" term200 ")"      (* Ltac2 plugin *)
 | MOVETO ltac2_quotations "ident" ":" "(" lident ")"      (* Ltac2 plugin *)
 | MOVETO ltac2_quotations "pattern" ":" "(" cpattern ")"      (* Ltac2 plugin *)
 | MOVETO ltac2_quotations "reference" ":" "(" globref ")"      (* Ltac2 plugin *)
@@ -2259,9 +2259,9 @@ ssexpr35: [
 ]
 
 simple_binding: [
-| REPLACE "(" ident ":=" lconstr ")"
-| WITH "(" [ ident | natural ] ":=" lconstr ")"
-| DELETE "(" natural ":=" lconstr ")"
+| REPLACE "(" ident ":=" term200 ")"
+| WITH "(" [ ident | natural ] ":=" term200 ")"
+| DELETE "(" natural ":=" term200 ")"
 ]
 
 
@@ -2273,6 +2273,8 @@ subprf: [
 ltac2_expr: [
 | DELETE _ltac2_expr
 ]
+
+lconstr: [ | DELETENT ]
 
 SPLICE: [
 | clause
@@ -2307,7 +2309,6 @@ SPLICE: [
 | global
 | reference
 | bar_cbrace
-| lconstr
 
 (*
 | ast_closure_term

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -18,7 +18,7 @@ constr_pattern: [
 ]
 
 cpattern: [
-| lconstr
+| term200
 ]
 
 sort: [
@@ -117,12 +117,12 @@ term0: [
 | "{|" record_declaration bar_cbrace
 | "{" binder_constr "}"
 | "`{" term200 "}"
-| test_array_opening "[" "|" array_elems "|" lconstr type_cstr test_array_closing "|" "]" univ_annot
+| test_array_opening "[" "|" array_elems "|" term200 type_cstr test_array_closing "|" "]" univ_annot
 | "`(" term200 ")"
 ]
 
 array_elems: [
-| LIST0 lconstr SEP ";"
+| LIST0 term200 SEP ";"
 ]
 
 record_declaration: [
@@ -136,7 +136,7 @@ fields_def: [
 ]
 
 field_def: [
-| global binders ":=" lconstr
+| global binders ":=" term200
 ]
 
 binder_constr: [
@@ -155,7 +155,7 @@ binder_constr: [
 ]
 
 arg: [
-| test_lpar_id_coloneq "(" identref ":=" lconstr ")"
+| test_lpar_id_coloneq "(" identref ":=" term200 ")"
 | term9
 ]
 
@@ -171,7 +171,7 @@ atomic_constr: [
 ]
 
 inst: [
-| identref ":=" lconstr
+| identref ":=" term200
 ]
 
 evar_instance: [
@@ -235,7 +235,7 @@ mult_pattern: [
 ]
 
 eqn: [
-| LIST1 mult_pattern SEP "|" "=>" lconstr
+| LIST1 mult_pattern SEP "|" "=>" term200
 ]
 
 record_pattern: [
@@ -300,7 +300,7 @@ binders_fixannot: [
 ]
 
 open_binders: [
-| name LIST0 name ":" lconstr
+| name LIST0 name ":" term200
 | name LIST0 name binders
 | name ".." name
 | closed_binder binders
@@ -316,17 +316,17 @@ binder: [
 ]
 
 closed_binder: [
-| "(" name LIST1 name ":" lconstr ")"
-| "(" name ":" lconstr ")"
-| "(" name ":=" lconstr ")"
-| "(" name ":" lconstr ":=" lconstr ")"
+| "(" name LIST1 name ":" term200 ")"
+| "(" name ":" term200 ")"
+| "(" name ":=" term200 ")"
+| "(" name ":" term200 ":=" term200 ")"
 | "{" name "}"
-| "{" name LIST1 name ":" lconstr "}"
-| "{" name ":" lconstr "}"
+| "{" name LIST1 name ":" term200 "}"
+| "{" name ":" term200 "}"
 | "{" name LIST1 name "}"
 | "[" name "]"
-| "[" name LIST1 name ":" lconstr "]"
-| "[" name ":" lconstr "]"
+| "[" name LIST1 name ":" term200 "]"
+| "[" name ":" term200 "]"
 | "[" name LIST1 name "]"
 | "`(" LIST1 typeclass_constraint SEP "," ")"
 | "`{" LIST1 typeclass_constraint SEP "," "}"
@@ -342,12 +342,12 @@ typeclass_constraint: [
 ]
 
 type_cstr: [
-| ":" lconstr
+| ":" term200
 |
 ]
 
 let_type_cstr: [
-| OPT [ ":" lconstr ]
+| OPT [ ":" term200 ]
 ]
 
 preident: [
@@ -470,10 +470,10 @@ opt_hintbases: [
 ]
 
 command: [
-| "Goal" lconstr
+| "Goal" term200
 | "Proof"
 | "Proof" "Mode" string
-| "Proof" lconstr
+| "Proof" term200
 | "Abort"
 | "Abort" "All"
 | "Abort" identref
@@ -517,7 +517,7 @@ command: [
 | "Add" "LoadPath" ne_string "as" dirpath
 | "Add" "Rec" "LoadPath" ne_string "as" dirpath
 | "Remove" "LoadPath" ne_string
-| "Type" lconstr
+| "Type" term200
 | "Print" printable
 | "Print" smart_global OPT univ_name_list
 | "Print" "Module" "Type" global
@@ -644,8 +644,8 @@ command: [
 | "Add" "Parametric" "Setoid" G_REWRITE_binders ":" constr constr constr "as" ident
 | "Add" "Morphism" constr ":" ident
 | "Declare" "Morphism" constr ":" ident
-| "Add" "Morphism" constr "with" "signature" lconstr "as" ident
-| "Add" "Parametric" "Morphism" G_REWRITE_binders ":" constr "with" "signature" lconstr "as" ident
+| "Add" "Morphism" constr "with" "signature" term200 "as" ident
+| "Add" "Parametric" "Morphism" G_REWRITE_binders ":" constr "with" "signature" term200 "as" ident
 | "Print" "Rewrite" "HintDb" preident
 | "Reset" "Ltac" "Profile"
 | "Show" "Ltac" "Profile"
@@ -716,8 +716,8 @@ hint: [
 ]
 
 constr_body: [
-| ":=" lconstr
-| ":" lconstr ":=" lconstr
+| ":=" term200
+| ":" term200 ":=" term200
 ]
 
 mode: [
@@ -789,7 +789,7 @@ subprf: [
 ]
 
 gallina: [
-| thm_token ident_decl binders ":" lconstr LIST0 [ "with" ident_decl binders ":" lconstr ]
+| thm_token ident_decl binders ":" term200 LIST0 [ "with" ident_decl binders ":" term200 ]
 | assumption_token inline assum_list
 | assumptions_token inline assum_list
 | def_token ident_decl def_body
@@ -803,7 +803,7 @@ gallina: [
 | "Combined" "Scheme" identref "from" LIST1 identref SEP ","
 | "Register" global "as" qualid
 | "Register" "Inline" global
-| "Primitive" ident_decl OPT [ ":" lconstr ] ":=" register_token
+| "Primitive" ident_decl OPT [ ":" term200 ] ":=" register_token
 | "Universe" LIST1 identref
 | "Universes" LIST1 identref
 | "Constraint" LIST1 univ_constraint SEP ","
@@ -873,9 +873,9 @@ finite_token: [
 ]
 
 def_body: [
-| binders ":=" reduce lconstr
-| binders ":" lconstr ":=" reduce lconstr
-| binders ":" lconstr
+| binders ":=" reduce term200
+| binders ":" term200 ":=" reduce term200
+| binders ":" term200
 ]
 
 reduce: [
@@ -902,7 +902,7 @@ opt_constructors_or_fields: [
 ]
 
 inductive_definition: [
-| opt_coercion ident_decl binders OPT [ "|" binders ] OPT [ ":" lconstr ] opt_constructors_or_fields decl_notations
+| opt_coercion ident_decl binders OPT [ "|" binders ] OPT [ ":" term200 ] opt_constructors_or_fields decl_notations
 ]
 
 constructors_or_record: [
@@ -920,11 +920,11 @@ opt_coercion: [
 ]
 
 fix_definition: [
-| ident_decl binders_fixannot type_cstr OPT [ ":=" lconstr ] decl_notations
+| ident_decl binders_fixannot type_cstr OPT [ ":=" term200 ] decl_notations
 ]
 
 cofix_definition: [
-| ident_decl binders type_cstr OPT [ ":=" lconstr ] decl_notations
+| ident_decl binders type_cstr OPT [ ":=" term200 ] decl_notations
 ]
 
 scheme: [
@@ -951,9 +951,9 @@ record_fields: [
 ]
 
 field_body: [
-| binders of_type lconstr
-| binders of_type lconstr ":=" lconstr
-| binders ":=" lconstr
+| binders of_type term200
+| binders of_type term200 ":=" term200
+| binders ":=" term200
 ]
 
 record_binder: [
@@ -971,11 +971,11 @@ assum_coe: [
 ]
 
 assumpt: [
-| LIST1 ident_decl of_type lconstr
+| LIST1 ident_decl of_type term200
 ]
 
 constructor_type: [
-| binders [ of_type lconstr | ]
+| binders [ of_type term200 | ]
 ]
 
 constructor: [
@@ -1011,7 +1011,7 @@ gallina_ext: [
 | "Coercion" global ":" class_rawexpr ">->" class_rawexpr
 | "Coercion" by_notation ":" class_rawexpr ">->" class_rawexpr
 | "Context" LIST1 binder
-| "Instance" instance_name ":" term200 hint_info [ ":=" "{" record_declaration "}" | ":=" lconstr | ]
+| "Instance" instance_name ":" term200 hint_info [ ":=" "{" record_declaration "}" | ":=" term200 | ]
 | "Existing" "Instance" global hint_info
 | "Existing" "Instances" LIST1 global OPT [ "|" natural ]
 | "Existing" "Class" global
@@ -1100,7 +1100,7 @@ module_expr_atom: [
 ]
 
 with_declaration: [
-| "Definition" fullyqualid OPT univ_decl ":=" Constr.lconstr
+| "Definition" fullyqualid OPT univ_decl ":=" Constr.term
 | "Module" fullyqualid ":=" qualid
 ]
 
@@ -1199,13 +1199,13 @@ reserv_tuple: [
 ]
 
 simple_reserv: [
-| LIST1 identref ":" lconstr
+| LIST1 identref ":" term200
 ]
 
 query_command: [
-| "Eval" red_expr "in" lconstr "."
-| "Compute" lconstr "."
-| "Check" lconstr "."
+| "Eval" red_expr "in" term200 "."
+| "Compute" term200 "."
+| "Check" term200 "."
 | "About" smart_global OPT univ_name_list "."
 | "SearchHead" constr_pattern in_or_out_modules "."
 | "SearchPattern" constr_pattern in_or_out_modules "."
@@ -1439,7 +1439,7 @@ simple_tactic: [
 | "firstorder" OPT tactic firstorder_using "with" LIST1 preident
 | "gintuition" OPT tactic
 | "functional" "inversion" quantified_hypothesis OPT reference      (* funind plugin *)
-| "functional" "induction" lconstr fun_ind_using with_names      (* funind plugin *)
+| "functional" "induction" term200 fun_ind_using with_names      (* funind plugin *)
 | "soft" "functional" "induction" LIST1 constr fun_ind_using with_names      (* funind plugin *)
 | "reflexivity"
 | "exact" casted_constr
@@ -1551,7 +1551,7 @@ simple_tactic: [
 | "subst" LIST1 hyp
 | "subst"
 | "simple" "subst"
-| "evar" test_lpar_id_colon "(" ident ":" lconstr ")"
+| "evar" test_lpar_id_colon "(" ident ":" term200 ")"
 | "evar" constr
 | "instantiate" "(" ident ":=" lglob ")"
 | "instantiate" "(" integer ":=" lglob ")" hloc
@@ -1665,18 +1665,18 @@ simple_tactic: [
 | "eset" constr as_name clause_dft_concl
 | "remember" constr as_name eqn_ipat clause_dft_all
 | "eremember" constr as_name eqn_ipat clause_dft_all
-| "assert" test_lpar_id_coloneq "(" identref ":=" lconstr ")"
-| "eassert" test_lpar_id_coloneq "(" identref ":=" lconstr ")"
-| "assert" test_lpar_id_colon "(" identref ":" lconstr ")" by_tactic
-| "eassert" test_lpar_id_colon "(" identref ":" lconstr ")" by_tactic
-| "enough" test_lpar_id_colon "(" identref ":" lconstr ")" by_tactic
-| "eenough" test_lpar_id_colon "(" identref ":" lconstr ")" by_tactic
+| "assert" test_lpar_id_coloneq "(" identref ":=" term200 ")"
+| "eassert" test_lpar_id_coloneq "(" identref ":=" term200 ")"
+| "assert" test_lpar_id_colon "(" identref ":" term200 ")" by_tactic
+| "eassert" test_lpar_id_colon "(" identref ":" term200 ")" by_tactic
+| "enough" test_lpar_id_colon "(" identref ":" term200 ")" by_tactic
+| "eenough" test_lpar_id_colon "(" identref ":" term200 ")" by_tactic
 | "assert" constr as_ipat by_tactic
 | "eassert" constr as_ipat by_tactic
-| "pose" "proof" test_lpar_id_coloneq "(" identref ":=" lconstr ")"
-| "epose" "proof" test_lpar_id_coloneq "(" identref ":=" lconstr ")"
-| "pose" "proof" lconstr as_ipat
-| "epose" "proof" lconstr as_ipat
+| "pose" "proof" test_lpar_id_coloneq "(" identref ":=" term200 ")"
+| "epose" "proof" test_lpar_id_coloneq "(" identref ":=" term200 ")"
+| "pose" "proof" term200 as_ipat
+| "epose" "proof" term200 as_ipat
 | "enough" constr as_ipat by_tactic
 | "eenough" constr as_ipat by_tactic
 | "generalize" constr
@@ -1817,11 +1817,15 @@ glob: [
 ]
 
 EXTRAARGS_lconstr: [
-| l_constr
+| _term
+]
+
+term: [
+| _term
 ]
 
 lglob: [
-| EXTRAARGS_lconstr
+| term200
 ]
 
 casted_constr: [
@@ -2027,7 +2031,7 @@ fresh_id: [
 
 constr_eval: [
 | "eval" red_expr "in" Constr.constr
-| "context" identref "[" Constr.lconstr "]"
+| "context" identref "[" term200 "]"
 | "type" "of" Constr.constr
 ]
 
@@ -2184,7 +2188,7 @@ withtac: [
 ]
 
 Constr.closed_binder: [
-| "(" Prim.name ":" Constr.lconstr "|" Constr.lconstr ")"
+| "(" Prim.name ":" Constr.term "|" Constr.term ")"
 ]
 
 glob_constr_with_bindings: [
@@ -2334,8 +2338,8 @@ simple_intropattern_closed: [
 ]
 
 simple_binding: [
-| "(" ident ":=" lconstr ")"
-| "(" natural ":=" lconstr ")"
+| "(" ident ":=" term200 ")"
+| "(" natural ":=" term200 ")"
 ]
 
 bindings: [
@@ -2446,11 +2450,11 @@ orient_rw: [
 
 simple_binder: [
 | name
-| "(" LIST1 name ":" lconstr ")"
+| "(" LIST1 name ":" term200 ")"
 ]
 
 fixdecl: [
-| "(" ident LIST0 simple_binder struct_annot ":" lconstr ")"
+| "(" ident LIST0 simple_binder struct_annot ":" term200 ")"
 ]
 
 struct_annot: [
@@ -2459,11 +2463,11 @@ struct_annot: [
 ]
 
 cofixdecl: [
-| "(" ident LIST0 simple_binder ":" lconstr ")"
+| "(" ident LIST0 simple_binder ":" term200 ")"
 ]
 
 bindings_with_parameters: [
-| check_for_coloneq "(" ident LIST0 simple_binder ":=" lconstr ")"
+| check_for_coloneq "(" ident LIST0 simple_binder ":=" term200 ")"
 ]
 
 eliminator: [
@@ -2651,8 +2655,8 @@ G_LTAC2_tactic_atom: [
 | "@" Prim.ident      (* Ltac2 plugin *)
 | "&" lident      (* Ltac2 plugin *)
 | "'" Constr.constr      (* Ltac2 plugin *)
-| "constr" ":" "(" Constr.lconstr ")"      (* Ltac2 plugin *)
-| "open_constr" ":" "(" Constr.lconstr ")"      (* Ltac2 plugin *)
+| "constr" ":" "(" Constr.term ")"      (* Ltac2 plugin *)
+| "open_constr" ":" "(" Constr.term ")"      (* Ltac2 plugin *)
 | "ident" ":" "(" lident ")"      (* Ltac2 plugin *)
 | "pattern" ":" "(" Constr.cpattern ")"      (* Ltac2 plugin *)
 | "reference" ":" "(" globref ")"      (* Ltac2 plugin *)
@@ -2842,7 +2846,7 @@ qhyp: [
 ]
 
 G_LTAC2_simple_binding: [
-| "(" qhyp ":=" Constr.lconstr ")"      (* Ltac2 plugin *)
+| "(" qhyp ":=" Constr.term ")"      (* Ltac2 plugin *)
 ]
 
 G_LTAC2_bindings: [
@@ -3149,7 +3153,7 @@ G_LTAC2_as_name: [
 ]
 
 pose: [
-| test_lpar_id_coloneq "(" ident_or_anti ":=" Constr.lconstr ")"      (* Ltac2 plugin *)
+| test_lpar_id_coloneq "(" ident_or_anti ":=" Constr.term ")"      (* Ltac2 plugin *)
 | Constr.constr G_LTAC2_as_name      (* Ltac2 plugin *)
 ]
 
@@ -3168,8 +3172,8 @@ G_LTAC2_by_tactic: [
 ]
 
 assertion: [
-| test_lpar_id_coloneq "(" ident_or_anti ":=" Constr.lconstr ")"      (* Ltac2 plugin *)
-| test_lpar_id_colon "(" ident_or_anti ":" Constr.lconstr ")" G_LTAC2_by_tactic      (* Ltac2 plugin *)
+| test_lpar_id_coloneq "(" ident_or_anti ":=" Constr.term ")"      (* Ltac2 plugin *)
+| test_lpar_id_colon "(" ident_or_anti ":" Constr.term ")" G_LTAC2_by_tactic      (* Ltac2 plugin *)
 | Constr.constr G_LTAC2_as_ipat G_LTAC2_by_tactic      (* Ltac2 plugin *)
 ]
 

--- a/gramlib/grammar.ml
+++ b/gramlib/grammar.ml
@@ -1058,7 +1058,7 @@ let symb_failed entry prev_symb_result prev_symb symb =
 let level_number entry lab =
   let rec lookup levn =
     function
-      [] -> failwith ("unknown level " ^ lab)
+      [] -> failwith ("Unknown level " ^ lab ^ " for " ^ entry.ename)
     | lev :: levs ->
         if is_level_labelled lab lev then levn else lookup (succ levn) levs
   in

--- a/parsing/g_constr.mlg
+++ b/parsing/g_constr.mlg
@@ -77,6 +77,9 @@ let test_array_closing =
     lk_kw "|" >> lk_kw "]" >> check_no_space
   end
 
+[@@@ocaml.warning "-3"]
+let lconstr = Pcoq.Constr.lconstr
+[@@@ocaml.warning "+3"]
 }
 
 GRAMMAR EXTEND Gram
@@ -98,7 +101,7 @@ GRAMMAR EXTEND Gram
     [ [ c = constr -> { c } ] ]
   ;
   cpattern:
-    [ [ c = lconstr -> { c } ] ]
+    [ [ c = term LEVEL "200" -> { c } ] ]
   ;
   sort:
     [ [ "Set"  -> { UNamed [GSet,0] }
@@ -184,7 +187,7 @@ GRAMMAR EXTEND Gram
         { CAst.make ~loc @@ CNotation(None,(InConstrEntry,"{ _ }"),([c],[],[],[])) }
       | "`{"; c = term LEVEL "200"; "}" ->
         { CAst.make ~loc @@ CGeneralization (MaxImplicit, None, c) }
-      | test_array_opening; "["; "|"; ls = array_elems; "|"; def = lconstr; ty = type_cstr; test_array_closing; "|"; "]"; u = univ_annot ->
+      | test_array_opening; "["; "|"; ls = array_elems; "|"; def = term LEVEL "200"; ty = type_cstr; test_array_closing; "|"; "]"; u = univ_annot ->
         { let t = Array.make (List.length ls) def in
           List.iteri (fun i e -> t.(i) <- e) ls;
           CAst.make ~loc @@ CArray(u, t, def, ty)
@@ -193,7 +196,7 @@ GRAMMAR EXTEND Gram
         { CAst.make ~loc @@ CGeneralization (Explicit, None, c) } ] ]
   ;
   array_elems:
-    [ [ fs = LIST0 lconstr SEP ";" -> { fs } ]]
+    [ [ fs = LIST0 term LEVEL "200" SEP ";" -> { fs } ]]
   ;
   record_declaration:
     [ [ fs = fields_def -> { CAst.make ~loc @@ CRecord fs } ] ]
@@ -204,7 +207,7 @@ GRAMMAR EXTEND Gram
       | -> { [] } ] ]
   ;
   field_def:
-    [ [ id = global; bl = binders; ":="; c = lconstr ->
+    [ [ id = global; bl = binders; ":="; c = term LEVEL "200" ->
         { (id, mkLambdaCN ~loc bl c) } ] ]
   ;
   binder_constr:
@@ -252,7 +255,7 @@ GRAMMAR EXTEND Gram
       | "cofix"; c = cofix_decls -> { let (id,dcls) = c in CAst.make ~loc @@ CCoFix (id,dcls) } ] ]
   ;
   arg:
-    [ [ test_lpar_id_coloneq; "("; id = identref; ":="; c = lconstr; ")" -> { (c,Some (CAst.make ?loc:id.CAst.loc @@ ExplByName id.CAst.v)) }
+    [ [ test_lpar_id_coloneq; "("; id = identref; ":="; c = term LEVEL "200"; ")" -> { (c,Some (CAst.make ?loc:id.CAst.loc @@ ExplByName id.CAst.v)) }
       | c=term LEVEL "9" -> { (c,None) } ] ]
   ;
   atomic_constr:
@@ -266,7 +269,7 @@ GRAMMAR EXTEND Gram
       | id = pattern_ident; inst = evar_instance -> { CAst.make ~loc @@ CEvar(id,inst) } ] ]
   ;
   inst:
-    [ [ id = identref; ":="; c = lconstr -> { (id,c) } ] ]
+    [ [ id = identref; ":="; c = term LEVEL "200" -> { (id,c) } ] ]
   ;
   evar_instance:
     [ [ "@{"; l = LIST1 inst SEP ";"; "}" -> { l }
@@ -332,7 +335,7 @@ GRAMMAR EXTEND Gram
   ;
   eqn:
     [ [ pll = LIST1 mult_pattern SEP "|";
-        "=>"; rhs = lconstr -> { (CAst.make ~loc (pll,rhs)) } ] ]
+        "=>"; rhs = term LEVEL "200" -> { (CAst.make ~loc (pll,rhs)) } ] ]
   ;
   record_pattern:
     [ [ id = global; ":="; pat = pattern LEVEL "200" -> { (id, pat) } ] ]
@@ -387,7 +390,7 @@ GRAMMAR EXTEND Gram
   open_binders:
     (* Same as binders but parentheses around a closed binder are optional if
        the latter is unique *)
-    [ [ id = name; idl = LIST0 name; ":"; c = lconstr ->
+    [ [ id = name; idl = LIST0 name; ":"; c = term LEVEL "200" ->
         { [CLocalAssum (id::idl,Default Explicit,c)] }
         (* binders factorized with open binder *)
       | id = name; idl = LIST0 name; bl = binders ->
@@ -406,29 +409,29 @@ GRAMMAR EXTEND Gram
       | bl = closed_binder -> { bl } ] ]
   ;
   closed_binder:
-    [ [ "("; id = name; idl = LIST1 name; ":"; c = lconstr; ")" ->
+    [ [ "("; id = name; idl = LIST1 name; ":"; c = term LEVEL "200"; ")" ->
         { [CLocalAssum (id::idl,Default Explicit,c)] }
-      | "("; id = name; ":"; c = lconstr; ")" ->
+      | "("; id = name; ":"; c = term LEVEL "200"; ")" ->
         { [CLocalAssum ([id],Default Explicit,c)] }
-      | "("; id = name; ":="; c = lconstr; ")" ->
+      | "("; id = name; ":="; c = term LEVEL "200"; ")" ->
         { match c.CAst.v with
           | CCast(c, CastConv t) -> [CLocalDef (id,c,Some t)]
           | _ -> [CLocalDef (id,c,None)] }
-      | "("; id = name; ":"; t = lconstr; ":="; c = lconstr; ")" ->
+      | "("; id = name; ":"; t = term LEVEL "200"; ":="; c = term LEVEL "200"; ")" ->
         { [CLocalDef (id,c,Some t)] }
       | "{"; id = name; "}" ->
         { [CLocalAssum ([id],Default MaxImplicit, CAst.make ~loc @@ CHole (None, IntroAnonymous, None))] }
-      | "{"; id = name; idl = LIST1 name; ":"; c = lconstr; "}" ->
+      | "{"; id = name; idl = LIST1 name; ":"; c = term LEVEL "200"; "}" ->
         { [CLocalAssum (id::idl,Default MaxImplicit,c)] }
-      | "{"; id = name; ":"; c = lconstr; "}" ->
+      | "{"; id = name; ":"; c = term LEVEL "200"; "}" ->
         { [CLocalAssum ([id],Default MaxImplicit,c)] }
       | "{"; id = name; idl = LIST1 name; "}" ->
         { List.map (fun id -> CLocalAssum ([id],Default MaxImplicit, CAst.make ~loc @@ CHole (None, IntroAnonymous, None))) (id::idl) }
       | "["; id = name; "]" ->
         { [CLocalAssum ([id],Default NonMaxImplicit, CAst.make ~loc @@ CHole (None, IntroAnonymous, None))] }
-      | "["; id = name; idl = LIST1 name; ":"; c = lconstr; "]" ->
+      | "["; id = name; idl = LIST1 name; ":"; c = term LEVEL "200"; "]" ->
         { [CLocalAssum (id::idl,Default NonMaxImplicit,c)] }
-      | "["; id = name; ":"; c = lconstr; "]" ->
+      | "["; id = name; ":"; c = term LEVEL "200"; "]" ->
         { [CLocalAssum ([id],Default NonMaxImplicit,c)] }
       | "["; id = name; idl = LIST1 name; "]" ->
         { List.map (fun id -> CLocalAssum ([id],Default NonMaxImplicit, CAst.make ~loc @@ CHole (None, IntroAnonymous, None))) (id::idl) }
@@ -456,10 +459,10 @@ GRAMMAR EXTEND Gram
           { (CAst.make ~loc Anonymous), false, c } ] ]
   ;
   type_cstr:
-    [ [ ":"; c = lconstr -> { c }
+    [ [ ":"; c = term LEVEL "200" -> { c }
       | -> { CAst.make ~loc @@ CHole (None, IntroAnonymous, None) } ] ]
   ;
   let_type_cstr:
-    [ [ c = OPT [":"; c = lconstr -> { c } ] -> { Loc.tag ~loc c } ] ]
+    [ [ c = OPT [":"; c = term LEVEL "200" -> { c } ] -> { Loc.tag ~loc c } ] ]
   ;
   END

--- a/parsing/pcoq.mli
+++ b/parsing/pcoq.mli
@@ -184,6 +184,7 @@ module Constr :
     val constr : constr_expr Entry.t
     val constr_eoi : constr_expr Entry.t
     val lconstr : constr_expr Entry.t
+      [@@deprecated "Deprecated in 8.13; use 'term' instead"]
     val binder_constr : constr_expr Entry.t
     val term : constr_expr Entry.t
     val operconstr : constr_expr Entry.t

--- a/plugins/funind/g_indfun.mlg
+++ b/plugins/funind/g_indfun.mlg
@@ -97,7 +97,7 @@ let functional_induction b c x pat =
 }
 
 TACTIC EXTEND newfunind
-| ["functional" "induction" lconstr(c) fun_ind_using(princl) with_names(pat)] ->
+| ["functional" "induction" term(c) fun_ind_using(princl) with_names(pat)] ->
    {
      (Extratactics.onSomeWithHoles
           (fun x -> functional_induction true c x pat) princl)

--- a/plugins/ltac/extraargs.mlg
+++ b/plugins/ltac/extraargs.mlg
@@ -35,10 +35,10 @@ let () = create_generic_quotation "smart_global" Pcoq.Prim.smart_global Stdarg.w
 
 let () = create_generic_quotation "ident" Pcoq.Prim.ident Stdarg.wit_ident
 let () = create_generic_quotation "reference" Pcoq.Prim.reference Stdarg.wit_ref
-let () = create_generic_quotation "uconstr" Pcoq.Constr.lconstr Stdarg.wit_uconstr
-let () = create_generic_quotation "constr" Pcoq.Constr.lconstr Stdarg.wit_constr
+let () = create_generic_quotation "uconstr" Pcoq.Constr.term Stdarg.wit_uconstr
+let () = create_generic_quotation "constr" Pcoq.Constr.term Stdarg.wit_constr
 let () = create_generic_quotation "ipattern" Pltac.simple_intropattern wit_simple_intropattern
-let () = create_generic_quotation "open_constr" Pcoq.Constr.lconstr Stdarg.wit_open_constr
+let () = create_generic_quotation "open_constr" Pcoq.Constr.term Stdarg.wit_open_constr
 let () =
   let inject (loc, v) = Tacexpr.Tacexp v in
   Tacentries.create_ltac_quotation "ltac" inject (Pltac.ltac_expr, Some 5)
@@ -156,7 +156,7 @@ let interp_glob ist gl (t,_) = Tacmach.project gl , (ist,t)
 
 let glob_glob = Tacintern.intern_constr
 
-let pr_lconstr env sigma _ prc _ c = prc env sigma c
+let pr_term env sigma _ prc _ c = prc env sigma c
 
 let subst_glob = Tacsubst.subst_glob_constr_and_expr
 
@@ -176,14 +176,20 @@ END
 
 {
 
-let l_constr = Pcoq.Constr.lconstr
+let _term = Pcoq.Constr.term
 
 }
 
-ARGUMENT EXTEND lconstr
+ARGUMENT EXTEND lconstr (* remove in 8.14 *)
     TYPED AS constr
-    PRINTED BY { pr_lconstr env sigma }
-| [ l_constr(c) ] -> { c }
+    PRINTED BY { pr_term env sigma }
+| [ _term(c) ] -> { c }
+END
+
+ARGUMENT EXTEND term
+    TYPED AS constr
+    PRINTED BY { pr_term env sigma }
+| [ _term(c) ] -> { c }
 END
 
 ARGUMENT EXTEND lglob
@@ -196,7 +202,7 @@ ARGUMENT EXTEND lglob
 
      RAW_PRINTED BY { pr_gen env sigma }
      GLOB_PRINTED BY { pr_gen env sigma }
-| [ lconstr(c) ] -> { c }
+| [ term(c) ] -> { c }
 END
 
 {

--- a/plugins/ltac/extraargs.mli
+++ b/plugins/ltac/extraargs.mli
@@ -41,6 +41,12 @@ val wit_lconstr :
   (constr_expr,
   glob_constr_and_expr,
   EConstr.t) Genarg.genarg_type
+  [@@deprecated "Deprecated in 8.13; use 'term' instead"]
+
+val wit_term :
+  (constr_expr,
+  glob_constr_and_expr,
+  EConstr.t) Genarg.genarg_type
 
 val wit_casted_constr :
   (constr_expr,

--- a/plugins/ltac/extratactics.mlg
+++ b/plugins/ltac/extratactics.mlg
@@ -475,7 +475,7 @@ open Evar_tactics
 (* TODO: add support for some test similar to g_constr.name_colon so that
    expressions like "evar (list A)" do not raise a syntax error *)
 TACTIC EXTEND evar
-| [ "evar" test_lpar_id_colon "(" ident(id) ":" lconstr(typ) ")" ] -> { let_evar (Name.Name id) typ }
+| [ "evar" test_lpar_id_colon "(" ident(id) ":" term(typ) ")" ] -> { let_evar (Name.Name id) typ }
 | [ "evar" constr(typ) ] -> { let_evar Name.Anonymous typ }
 END
 

--- a/plugins/ltac/g_ltac.mlg
+++ b/plugins/ltac/g_ltac.mlg
@@ -199,7 +199,7 @@ GRAMMAR EXTEND Gram
   constr_eval:
     [ [ IDENT "eval"; rtc = red_expr; "in"; c = Constr.constr ->
           { ConstrEval (rtc,c) }
-      | IDENT "context"; id = identref; "["; c = Constr.lconstr; "]" ->
+      | IDENT "context"; id = identref; "["; c = term LEVEL "200"; "]" ->
           { ConstrContext (id,c) }
       | IDENT "type"; IDENT "of"; c = Constr.constr ->
           { ConstrTypeOf c } ] ]

--- a/plugins/ltac/g_obligations.mlg
+++ b/plugins/ltac/g_obligations.mlg
@@ -69,7 +69,7 @@ GRAMMAR EXTEND Gram
   ;
 
   Constr.closed_binder:
-    [[ "("; id=Prim.name; ":"; t=Constr.lconstr; "|"; c=Constr.lconstr; ")" -> {
+    [[ "("; id=Prim.name; ":"; t=Constr.term LEVEL "200"; "|"; c=Constr.term LEVEL "200"; ")" -> {
           let typ = mkAppC (sigref loc, [mkLambdaC ([id], default_binder_kind, t, c)]) in
           [CLocalAssum ([id], default_binder_kind, typ)] }
     ] ];

--- a/plugins/ltac/g_rewrite.mlg
+++ b/plugins/ltac/g_rewrite.mlg
@@ -282,11 +282,11 @@ VERNAC COMMAND EXTEND AddSetoid1 CLASSIFIED AS SIDEFF
   | #[ atts = rewrite_attributes; ] [ "Declare" "Morphism" constr(m) ":" ident(n) ]
     => { VtSideff([n], VtLater) }
     -> { add_morphism_as_parameter atts m n }
-  | #[ atts = rewrite_attributes; ] ![ open_proof ] [ "Add" "Morphism" constr(m) "with" "signature" lconstr(s) "as" ident(n) ]
+  | #[ atts = rewrite_attributes; ] ![ open_proof ] [ "Add" "Morphism" constr(m) "with" "signature" term(s) "as" ident(n) ]
     => { VtStartProof(GuaranteesOpacity,[n]) }
     -> { add_morphism atts [] m s n }
   | #[ atts = rewrite_attributes; ] ![ open_proof ] [ "Add" "Parametric" "Morphism" binders(binders) ":" constr(m)
-        "with" "signature" lconstr(s) "as" ident(n) ]
+        "with" "signature" term(s) "as" ident(n) ]
     => { VtStartProof(GuaranteesOpacity,[n]) }
     -> { add_morphism atts binders m s n }
 END

--- a/plugins/ltac/g_tactic.mlg
+++ b/plugins/ltac/g_tactic.mlg
@@ -306,8 +306,8 @@ GRAMMAR EXTEND Gram
       | pat = naming_intropattern -> { CAst.make ~loc @@ IntroNaming pat } ] ]
   ;
   simple_binding:
-    [ [ "("; id = ident; ":="; c = lconstr; ")" -> { CAst.make ~loc (NamedHyp id, c) }
-      | "("; n = natural; ":="; c = lconstr; ")" -> { CAst.make ~loc (AnonHyp n, c) } ] ]
+    [ [ "("; id = ident; ":="; c = term LEVEL "200"; ")" -> { CAst.make ~loc (NamedHyp id, c) }
+      | "("; n = natural; ":="; c = term LEVEL "200"; ")" -> { CAst.make ~loc (AnonHyp n, c) } ] ]
   ;
   bindings:
     [ [ test_lpar_idnum_coloneq; bl = LIST1 simple_binding ->
@@ -418,24 +418,24 @@ GRAMMAR EXTEND Gram
   simple_binder:
     [ [ na=name -> { ([na],Default Glob_term.Explicit, CAst.make ~loc @@
                     CHole (Some (Evar_kinds.BinderType na.CAst.v), IntroAnonymous, None)) }
-      | "("; nal=LIST1 name; ":"; c=lconstr; ")" -> { (nal,Default Glob_term.Explicit,c) }
+      | "("; nal=LIST1 name; ":"; c=term LEVEL "200"; ")" -> { (nal,Default Glob_term.Explicit,c) }
     ] ]
   ;
   fixdecl:
     [ [ "("; id = ident; bl=LIST0 simple_binder; ann=struct_annot;
-        ":"; ty=lconstr; ")" -> { (loc, id, bl, ann, ty) } ] ]
+        ":"; ty=term LEVEL "200"; ")" -> { (loc, id, bl, ann, ty) } ] ]
   ;
   struct_annot:
     [ [ "{"; IDENT "struct"; id=name; "}" -> { Some id }
       | -> { None } ] ]
   ;
   cofixdecl:
-    [ [ "("; id = ident; bl=LIST0 simple_binder; ":"; ty=lconstr; ")" ->
+    [ [ "("; id = ident; bl=LIST0 simple_binder; ":"; ty=term LEVEL "200"; ")" ->
         { (loc, id, bl, None, ty) } ] ]
   ;
   bindings_with_parameters:
     [ [ check_for_coloneq; "(";  id = ident; bl = LIST0 simple_binder;
-        ":="; c = lconstr; ")" -> { (id, mkCLambdaN_simple bl c) } ] ]
+        ":="; c = term LEVEL "200"; ")" -> { (id, mkCLambdaN_simple bl c) } ] ]
   ;
   eliminator:
     [ [ "using"; el = constr_with_bindings -> { el } ] ]
@@ -546,31 +546,31 @@ GRAMMAR EXTEND Gram
 
       (* Alternative syntax for "pose proof c as id" *)
       | IDENT "assert"; test_lpar_id_coloneq; "("; lid = identref; ":=";
-          c = lconstr; ")" ->
+          c = term LEVEL "200"; ")" ->
           { let { CAst.loc = loc; v = id } = lid in
           TacAtom (CAst.make ?loc @@ TacAssert (false,true,None,Some (CAst.make ?loc @@ IntroNaming (IntroIdentifier id)),c)) }
       | IDENT "eassert"; test_lpar_id_coloneq; "("; lid = identref; ":=";
-          c = lconstr; ")" ->
+          c = term LEVEL "200"; ")" ->
           { let { CAst.loc = loc; v = id } = lid in
           TacAtom (CAst.make ?loc @@ TacAssert (true,true,None,Some (CAst.make ?loc @@ IntroNaming (IntroIdentifier id)),c)) }
 
       (* Alternative syntax for "assert c as id by tac" *)
       | IDENT "assert"; test_lpar_id_colon; "("; lid = identref; ":";
-          c = lconstr; ")"; tac=by_tactic ->
+          c = term LEVEL "200"; ")"; tac=by_tactic ->
           { let { CAst.loc = loc; v = id } = lid in
           TacAtom (CAst.make ?loc @@ TacAssert (false,true,Some tac,Some (CAst.make ?loc @@ IntroNaming (IntroIdentifier id)),c)) }
       | IDENT "eassert"; test_lpar_id_colon; "("; lid = identref; ":";
-          c = lconstr; ")"; tac=by_tactic ->
+          c = term LEVEL "200"; ")"; tac=by_tactic ->
           { let { CAst.loc = loc; v = id } = lid in
           TacAtom (CAst.make ?loc @@ TacAssert (true,true,Some tac,Some (CAst.make ?loc @@ IntroNaming (IntroIdentifier id)),c)) }
 
       (* Alternative syntax for "enough c as id by tac" *)
       | IDENT "enough"; test_lpar_id_colon; "("; lid = identref; ":";
-          c = lconstr; ")"; tac=by_tactic ->
+          c = term LEVEL "200"; ")"; tac=by_tactic ->
           { let { CAst.loc = loc; v = id } = lid in
           TacAtom (CAst.make ?loc @@ TacAssert (false,false,Some tac,Some (CAst.make ?loc @@ IntroNaming (IntroIdentifier id)),c)) }
       | IDENT "eenough"; test_lpar_id_colon; "("; lid = identref; ":";
-          c = lconstr; ")"; tac=by_tactic ->
+          c = term LEVEL "200"; ")"; tac=by_tactic ->
           { let { CAst.loc = loc; v = id } = lid in
           TacAtom (CAst.make ?loc @@ TacAssert (true,false,Some tac,Some (CAst.make ?loc @@ IntroNaming (IntroIdentifier id)),c)) }
 
@@ -581,16 +581,16 @@ GRAMMAR EXTEND Gram
 
       (* Alternative syntax for "pose proof c as id by tac" *)
       | IDENT "pose"; IDENT "proof"; test_lpar_id_coloneq; "("; lid = identref; ":=";
-          c = lconstr; ")" ->
+          c = term LEVEL "200"; ")" ->
           { let { CAst.loc = loc; v = id } = lid in
           TacAtom (CAst.make ?loc @@ TacAssert (false,true,None,Some (CAst.make ?loc @@ IntroNaming (IntroIdentifier id)),c)) }
       | IDENT "epose"; IDENT "proof"; test_lpar_id_coloneq; "("; lid = identref; ":=";
-          c = lconstr; ")" ->
+          c = term LEVEL "200"; ")" ->
           { let { CAst.loc = loc; v = id } = lid in
           TacAtom (CAst.make ?loc @@ TacAssert (true,true,None,Some (CAst.make ?loc @@ IntroNaming (IntroIdentifier id)),c)) }
-      | IDENT "pose"; IDENT "proof"; c = lconstr; ipat = as_ipat ->
+      | IDENT "pose"; IDENT "proof"; c = term LEVEL "200"; ipat = as_ipat ->
           { TacAtom (CAst.make ~loc @@ TacAssert (false,true,None,ipat,c)) }
-      | IDENT "epose"; IDENT "proof"; c = lconstr; ipat = as_ipat ->
+      | IDENT "epose"; IDENT "proof"; c = term LEVEL "200"; ipat = as_ipat ->
           { TacAtom (CAst.make ~loc @@ TacAssert (true,true,None,ipat,c)) }
       | IDENT "enough"; c = constr; ipat = as_ipat; tac = by_tactic ->
           { TacAtom (CAst.make ~loc @@ TacAssert (false,false,Some tac,ipat,c)) }

--- a/plugins/ltac/tacentries.ml
+++ b/plugins/ltac/tacentries.ml
@@ -214,10 +214,12 @@ let interp_prod_item = function
     let symbol = parse_user_entry ?loc nt sep in
     let interp s = function
     | None ->
-      if String.Map.mem s !entry_names then String.Map.find s !entry_names
+      (* todo: how to make this a warning? *)
+      if s = "lconstr" then user_err Pp.(str ("'lconstr' is deprecated, please use 'term'.")) (* to remove in 8.14 *)
+      else if String.Map.mem s !entry_names then String.Map.find s !entry_names
       else begin match ArgT.name s with
       | None ->
-         if s = "var" then user_err Pp.(str ("var is deprecated, use hyp.")) (* to remove in 8.14 *)
+         if s = "var" then user_err Pp.(str ("'var` is deprecated, please use `hyp`.")) (* to remove in 8.14 *)
          else user_err Pp.(str ("Unknown entry "^s^"."))
       | Some arg -> arg
       end

--- a/plugins/ssr/ssrparser.mlg
+++ b/plugins/ssr/ssrparser.mlg
@@ -533,7 +533,7 @@ ARGUMENT EXTEND ast_closure_lterm
      SUBSTITUTED BY { subst_ast_closure_term }
      RAW_PRINTED BY { pp_ast_closure_term }
      GLOB_PRINTED BY { pp_ast_closure_term }
-  | [ term_annotation(a) lconstr(c) ] -> { mk_ast_closure_term a c }
+  | [ term_annotation(a) term(c) ] -> { mk_ast_closure_term a c }
 END
 
 (* Old Views *)
@@ -1319,18 +1319,18 @@ ARGUMENT EXTEND ssrbinder TYPED AS (ssrfwdfmt * constr) PRINTED BY { pr_ssrbinde
    { let { CAst.loc=xloc } as x = bvar_lname bv in
      (FwdPose, [BFvar]),
      CAst.make ~loc @@ CLambdaN ([CLocalAssum([x],Default Glob_term.Explicit,mkCHole xloc)],mkCHole (Some loc)) }
- | [ "(" ssrbvar(bv) ":" lconstr(t) ")" ] ->
+ | [ "(" ssrbvar(bv) ":" term(t) ")" ] ->
    { let x = bvar_lname bv in
      (FwdPose, [BFdecl 1]),
      CAst.make ~loc @@ CLambdaN ([CLocalAssum([x], Default Glob_term.Explicit, t)], mkCHole (Some loc)) }
- | [ "(" ssrbvar(bv) ne_ssrbvar_list(bvs) ":" lconstr(t) ")" ] ->
+ | [ "(" ssrbvar(bv) ne_ssrbvar_list(bvs) ":" term(t) ")" ] ->
    { let xs = List.map bvar_lname (bv :: bvs) in
      let n = List.length xs in
      (FwdPose, [BFdecl n]),
      CAst.make ~loc @@ CLambdaN ([CLocalAssum (xs, Default Glob_term.Explicit, t)], mkCHole (Some loc)) }
- | [ "(" ssrbvar(id) ":" lconstr(t) ":=" lconstr(v) ")" ] ->
+ | [ "(" ssrbvar(id) ":" term(t) ":=" term(v) ")" ] ->
    { (FwdPose,[BFdef]), CAst.make ~loc @@ CLetIn (bvar_lname id, v, Some t, mkCHole (Some loc)) }
- | [ "(" ssrbvar(id) ":=" lconstr(v) ")" ] ->
+ | [ "(" ssrbvar(id) ":=" term(v) ")" ] ->
    { (FwdPose,[BFdef]), CAst.make ~loc @@ CLetIn (bvar_lname id, v, None, mkCHole (Some loc)) }
      END
 
@@ -2186,7 +2186,7 @@ TACTIC EXTEND ssrexact
      tclBY (inner_ssrapplytac views gens_clr ist) }
 | [ "exact" ] -> {
      Tacticals.New.tclORELSE (donetac ~-1) (tclBY apply_top_tac) }
-| [ "exact" "<:" lconstr(pf) ] -> { vmexacttac pf }
+| [ "exact" "<:" term(pf) ] -> { vmexacttac pf }
 END
 
 (** The "congr" tactic *)

--- a/plugins/ssr/ssrvernac.mlg
+++ b/plugins/ssr/ssrvernac.mlg
@@ -92,9 +92,9 @@ GRAMMAR EXTEND Gram
     | mp = ssr_mpat; rt = ssr_rtype -> { mp, mk_cnotype mp, rt }
     | mp = ssr_mpat -> { mp, no_ct, no_rt }
   ] ];
-  ssr_dthen: [[ dp = ssr_dpat; "then"; c = lconstr -> { mk_dthen ~loc dp c } ]];
+  ssr_dthen: [[ dp = ssr_dpat; "then"; c = term -> { mk_dthen ~loc dp c } ]];
   ssr_elsepat: [[ "else" -> { [[CAst.make ~loc @@ CPatAtom None]] } ]];
-  ssr_else: [[ mp = ssr_elsepat; c = lconstr -> { CAst.make ~loc (mp, c) } ]];
+  ssr_else: [[ mp = ssr_elsepat; c = term -> { CAst.make ~loc (mp, c) } ]];
   binder_constr: [
     [ "if"; c = term LEVEL "200"; "is"; db1 = ssr_dthen; b2 = ssr_else ->
       { let b1, ct, rt = db1 in CAst.make ~loc @@ CCases (MatchStyle, rt, [mk_pat c ct], [b1; b2]) }
@@ -105,13 +105,13 @@ GRAMMAR EXTEND Gram
         (make ?loc:l1 (p1, r2), make ?loc:l2 (p2, r1))
       in
       CAst.make ~loc @@ CCases (MatchStyle, rt, [mk_pat c ct], [b1; b2]) }
-    | "let"; ":"; mp = ssr_mpat; ":="; c = lconstr; "in"; c1 = lconstr ->
+    | "let"; ":"; mp = ssr_mpat; ":="; c = term; "in"; c1 = term ->
       { mk_let ~loc no_rt [mk_pat c no_ct] mp c1 }
-    | "let"; ":"; mp = ssr_mpat; ":="; c = lconstr;
-      rt = ssr_rtype; "in"; c1 = lconstr ->
+    | "let"; ":"; mp = ssr_mpat; ":="; c = term;
+      rt = ssr_rtype; "in"; c1 = term ->
       { mk_let ~loc rt [mk_pat c (mk_cnotype mp)] mp c1 }
-    | "let"; ":"; mp = ssr_mpat; "in"; t = pattern; ":="; c = lconstr;
-      rt = ssr_rtype; "in"; c1 = lconstr ->
+    | "let"; ":"; mp = ssr_mpat; "in"; t = pattern; ":="; c = term;
+      rt = ssr_rtype; "in"; c1 = term ->
       { mk_let ~loc rt [mk_pat c (mk_ctype mp t)] mp c1 }
   ] ];
 END

--- a/plugins/ssrmatching/g_ssrmatching.mlg
+++ b/plugins/ssrmatching/g_ssrmatching.mlg
@@ -37,15 +37,15 @@ ARGUMENT EXTEND rpattern
   INTERPRETED BY { interp_rpattern }
   GLOBALIZED BY { glob_rpattern }
   SUBSTITUTED BY { subst_rpattern }
-  | [ lconstr(c) ] -> { mk_rpattern (T (mk_lterm c None)) }
-  | [ "in" lconstr(c) ] -> { mk_rpattern (In_T (mk_lterm c None)) }
-  | [ lconstr(x) "in" lconstr(c) ] ->
+  | [ term(c) ] -> { mk_rpattern (T (mk_lterm c None)) }
+  | [ "in" term(c) ] -> { mk_rpattern (In_T (mk_lterm c None)) }
+  | [ term(x) "in" term(c) ] ->
     { mk_rpattern (X_In_T (mk_lterm x None, mk_lterm c None)) }
-  | [ "in" lconstr(x) "in" lconstr(c) ] ->
+  | [ "in" term(x) "in" term(c) ] ->
     { mk_rpattern (In_X_In_T (mk_lterm x None, mk_lterm c None)) }
-  | [ lconstr(e) "in" lconstr(x) "in" lconstr(c) ] ->
+  | [ term(e) "in" term(x) "in" term(c) ] ->
     { mk_rpattern (E_In_X_In_T (mk_lterm e None, mk_lterm x None, mk_lterm c None)) }
-  | [ lconstr(e) "as" lconstr(x) "in" lconstr(c) ] ->
+  | [ term(e) "as" term(x) "in" term(c) ] ->
     { mk_rpattern (E_As_X_In_T (mk_lterm e None, mk_lterm x None, mk_lterm c None)) }
 END
 
@@ -90,12 +90,12 @@ ARGUMENT EXTEND lcpattern
      GLOBALIZED BY { glob_cpattern } SUBSTITUTED BY { subst_ssrterm }
      RAW_PRINTED BY { pr_ssrterm }
      GLOB_PRINTED BY { pr_ssrterm }
-| [ "Qed" lconstr(c) ] -> { mk_lterm c None }
+| [ "Qed" term(c) ] -> { mk_lterm c None }
 END
 
 GRAMMAR EXTEND Gram
   GLOBAL: lcpattern;
-  lcpattern: [[ k = ssrtermkind; c = lconstr -> {
+  lcpattern: [[ k = ssrtermkind; c = term LEVEL "200" -> {
     let pattern = mk_term k c None in
     if loc_of_cpattern pattern <> Some loc && k = '('
     then mk_term 'x' c None

--- a/printing/ppconstr.mli
+++ b/printing/ppconstr.mli
@@ -65,7 +65,7 @@ val default_term_pr : term_pr
   [modular_constr_pr pr s p t] prints the head of the term [t] and calls
   [pr] on its subterms.
   [s] is typically {!Pp.mt} and [p] is [lsimpleconstr] for "constr" printers
-  and [ltop] for "lconstr" printers (spiwack: we might need more
+  and [ltop] for "term" printers (spiwack: we might need more
   specification here).
   We can make a new modular constr printer by overriding certain branches,
   for instance if we want to build a printer which prints "Prop" as "Omega"

--- a/printing/printer.mli
+++ b/printing/printer.mli
@@ -25,7 +25,7 @@ val print_goal_tag_opt_name : string list
 
 (** Printers for terms.
 
-    The "lconstr" variant does not require parentheses to isolate the
+    The "term" variant does not require parentheses to isolate the
     expression from the surrounding context (for instance [3 + 4]
     will be written [3 + 4]). The "constr" variant (w/o "l")
     enforces parentheses whenever the term is not an atom (for

--- a/user-contrib/Ltac2/g_ltac2.mlg
+++ b/user-contrib/Ltac2/g_ltac2.mlg
@@ -208,8 +208,8 @@ GRAMMAR EXTEND Gram
       | "@"; id = Prim.ident -> { Tac2quote.of_ident (CAst.make ~loc id) }
       | "&"; id = lident -> { Tac2quote.of_hyp ~loc id }
       | "'"; c = Constr.constr -> { inj_open_constr loc c }
-      | IDENT "constr"; ":"; "("; c = Constr.lconstr; ")" -> { Tac2quote.of_constr c }
-      | IDENT "open_constr"; ":"; "("; c = Constr.lconstr; ")" -> { Tac2quote.of_open_constr c }
+      | IDENT "constr"; ":"; "("; c = Constr.term LEVEL "200"; ")" -> { Tac2quote.of_constr c }
+      | IDENT "open_constr"; ":"; "("; c = Constr.term LEVEL "200"; ")" -> { Tac2quote.of_open_constr c }
       | IDENT "ident"; ":"; "("; c = lident; ")" -> { Tac2quote.of_ident c }
       | IDENT "pattern"; ":"; "("; c = Constr.cpattern; ")" -> { inj_pattern loc c }
       | IDENT "reference"; ":"; "("; c = globref; ")" -> { inj_reference loc c }
@@ -430,7 +430,7 @@ GRAMMAR EXTEND Gram
     ] ]
   ;
   simple_binding:
-    [ [ "("; h = qhyp; ":="; c = Constr.lconstr; ")" ->
+    [ [ "("; h = qhyp; ":="; c = Constr.term LEVEL "200"; ")" ->
         { CAst.make ~loc (h, c) }
     ] ]
   ;
@@ -776,7 +776,7 @@ GRAMMAR EXTEND Gram
     ] ]
   ;
   pose:
-    [ [ test_lpar_id_coloneq; "("; id = ident_or_anti; ":="; c = Constr.lconstr; ")" ->
+    [ [ test_lpar_id_coloneq; "("; id = ident_or_anti; ":="; c = Constr.term LEVEL "200"; ")" ->
         { CAst.make ~loc (Some id, c) }
       | c = Constr.constr; na = as_name -> { CAst.make ~loc (na, c) }
     ] ]
@@ -795,9 +795,9 @@ GRAMMAR EXTEND Gram
     ] ]
   ;
   assertion:
-    [ [ test_lpar_id_coloneq; "("; id = ident_or_anti; ":="; c = Constr.lconstr; ")" ->
+    [ [ test_lpar_id_coloneq; "("; id = ident_or_anti; ":="; c = Constr.term LEVEL "200"; ")" ->
         { CAst.make ~loc (QAssertValue (id, c)) }
-      | test_lpar_id_colon; "("; id = ident_or_anti; ":"; c = Constr.lconstr; ")"; tac = by_tactic ->
+      | test_lpar_id_colon; "("; id = ident_or_anti; ":"; c = Constr.term LEVEL "200"; ")"; tac = by_tactic ->
       { let ipat = CAst.make ~loc @@ QIntroNaming (CAst.make ~loc @@ QIntroIdentifier id) in
         CAst.make ~loc (QAssertType (Some ipat, c, tac)) }
       | c = Constr.constr; ipat = as_ipat; tac = by_tactic ->

--- a/vernac/g_proofs.mlg
+++ b/vernac/g_proofs.mlg
@@ -53,11 +53,11 @@ GRAMMAR EXTEND Gram
     | ":"; l = LIST1 [id = IDENT -> { id } ] -> { l } ] ]
   ;
   command:
-    [ [ IDENT "Goal"; c = lconstr ->
+    [ [ IDENT "Goal"; c = term LEVEL "200" ->
         { VernacDefinition (Decls.(NoDischarge, Definition), ((CAst.make ~loc Names.Anonymous), None), ProveBody ([], c)) }
       | IDENT "Proof" -> { VernacProof (None,None) }
       | IDENT "Proof" ; IDENT "Mode" ; mn = string -> { VernacProofMode mn }
-      | IDENT "Proof"; c = lconstr -> { VernacExactProof c }
+      | IDENT "Proof"; c = term LEVEL "200" -> { VernacExactProof c }
       | IDENT "Abort" -> { VernacAbort None }
       | IDENT "Abort"; IDENT "All" -> { VernacAbortAll }
       | IDENT "Abort"; id = identref -> { VernacAbort (Some id) }
@@ -127,8 +127,8 @@ GRAMMAR EXTEND Gram
       | IDENT "Constructors"; lc = LIST1 global -> { HintsConstructors lc } ] ]
     ;
   constr_body:
-    [ [ ":="; c = lconstr -> { c }
-      | ":"; t = lconstr; ":="; c = lconstr -> { CAst.make ~loc @@ CCast(c,CastConv t) } ] ]
+    [ [ ":="; c = term LEVEL "200" -> { c }
+      | ":"; t = term LEVEL "200"; ":="; c = term LEVEL "200" -> { CAst.make ~loc @@ CCast(c,CastConv t) } ] ]
   ;
   mode:
     [ [ l = LIST1 [ "+" -> { ModeInput }

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -201,9 +201,9 @@ GRAMMAR EXTEND Gram
 
   gallina:
       (* Definition, Theorem, Variable, Axiom, ... *)
-    [ [ thm = thm_token; id = ident_decl; bl = binders; ":"; c = lconstr;
+    [ [ thm = thm_token; id = ident_decl; bl = binders; ":"; c = term LEVEL "200";
         l = LIST0
-          [ "with"; id = ident_decl; bl = binders; ":"; c = lconstr ->
+          [ "with"; id = ident_decl; bl = binders; ":"; c = term LEVEL "200" ->
           { (id,(bl,c)) } ] ->
           { VernacStartTheoremProof (thm, (id,(bl,c))::l) }
       | stre = assumption_token; nl = inline; bl = assum_list ->
@@ -234,7 +234,7 @@ GRAMMAR EXTEND Gram
           { VernacRegister(g, RegisterCoqlib quid) }
       | IDENT "Register"; IDENT "Inline"; g = global ->
           { VernacRegister(g, RegisterInline) }
-      | IDENT "Primitive"; id = ident_decl; typopt = OPT [ ":"; typ = lconstr -> { typ } ]; ":="; r = register_token ->
+      | IDENT "Primitive"; id = ident_decl; typopt = OPT [ ":"; typ = term LEVEL "200" -> { typ } ]; ":="; r = register_token ->
           { VernacPrimitive(id, r, typopt) }
       | IDENT "Universe"; l = LIST1 identref -> { VernacUniverse l }
       | IDENT "Universes"; l = LIST1 identref -> { VernacUniverse l }
@@ -308,13 +308,13 @@ GRAMMAR EXTEND Gram
   ;
   (* Simple definitions *)
   def_body:
-    [ [ bl = binders; ":="; red = reduce; c = lconstr ->
+    [ [ bl = binders; ":="; red = reduce; c = term LEVEL "200" ->
         { match c.CAst.v with
           | CCast(c, Glob_term.CastConv t) -> DefineBody (bl, red, c, Some t)
           | _ -> DefineBody (bl, red, c, None) }
-    | bl = binders; ":"; t = lconstr; ":="; red = reduce; c = lconstr ->
+    | bl = binders; ":"; t = term LEVEL "200"; ":="; red = reduce; c = term LEVEL "200" ->
         { DefineBody (bl, red, c, Some t) }
-    | bl = binders; ":"; t = lconstr ->
+    | bl = binders; ":"; t = term LEVEL "200" ->
         { ProveBody (bl, t) } ] ]
   ;
   reduce:
@@ -345,7 +345,7 @@ GRAMMAR EXTEND Gram
   inductive_definition:
     [ [ oc = opt_coercion; id = ident_decl; indpar = binders;
         extrapar = OPT [ "|"; p = binders -> { p } ];
-        c = OPT [ ":"; c = lconstr -> { c } ];
+        c = OPT [ ":"; c = term LEVEL "200" -> { c } ];
         lc=opt_constructors_or_fields; ntn = decl_notations ->
            { (((oc,id),(indpar,extrapar),c,lc),ntn) } ] ]
   ;
@@ -373,14 +373,14 @@ GRAMMAR EXTEND Gram
     [ [ id_decl = ident_decl;
         bl = binders_fixannot;
         rtype = type_cstr;
-        body_def = OPT [":="; def = lconstr -> { def } ]; notations = decl_notations ->
+        body_def = OPT [":="; def = term LEVEL "200" -> { def } ]; notations = decl_notations ->
           { let binders, rec_order = bl in
             {fname = fst id_decl; univs = snd id_decl; rec_order; binders; rtype; body_def; notations}
           } ] ]
   ;
   cofix_definition:
     [ [ id_decl = ident_decl; binders = binders; rtype = type_cstr;
-        body_def = OPT [":="; def = lconstr -> { def }]; notations = decl_notations ->
+        body_def = OPT [":="; def = term LEVEL "200" -> { def }]; notations = decl_notations ->
         { {fname = fst id_decl; univs = snd id_decl; rec_order = (); binders; rtype; body_def; notations}
         } ]]
   ;
@@ -429,11 +429,11 @@ GRAMMAR EXTEND Gram
   ;
   field_body:
     [ [ l = binders; oc = of_type;
-         t = lconstr -> { fun id -> (oc,AssumExpr (id,l,t)) }
+         t = term LEVEL "200" -> { fun id -> (oc,AssumExpr (id,l,t)) }
       | l = binders; oc = of_type;
-         t = lconstr; ":="; b = lconstr -> { fun id ->
+         t = term LEVEL "200"; ":="; b = term LEVEL "200" -> { fun id ->
            (oc,DefExpr (id,l,b,Some t)) }
-      | l = binders; ":="; b = lconstr -> { fun id ->
+      | l = binders; ":="; b = term LEVEL "200" -> { fun id ->
          match b.CAst.v with
          | CCast(b', (CastConv t|CastVM t|CastNative t)) ->
              (NoInstance,DefExpr(id,l,b',Some t))
@@ -451,13 +451,13 @@ GRAMMAR EXTEND Gram
     [ [ "("; a = assumpt; ")" -> { a } ] ]
   ;
   assumpt:
-    [ [ idl = LIST1 ident_decl; oc = of_type; c = lconstr ->
+    [ [ idl = LIST1 ident_decl; oc = of_type; c = term LEVEL "200" ->
         { (oc <> NoInstance,(idl,c)) } ] ]
   ;
 
   constructor_type:
     [[ l = binders;
-      t= [ coe = of_type; c = lconstr ->
+      t= [ coe = of_type; c = term LEVEL "200" ->
                     { fun l id -> (coe <> NoInstance,(id,mkProdCN ~loc l c)) }
             |  ->
                  { fun l id -> (false,(id,mkProdCN ~loc l (CAst.make ~loc @@ CHole (None, IntroAnonymous, None)))) } ]
@@ -601,7 +601,7 @@ GRAMMAR EXTEND Gram
     [ [ qid = qualid -> { CAst.make ~loc @@ CMident qid } | "("; me = module_expr; ")" -> { me } ] ]
   ;
   with_declaration:
-    [ [ "Definition"; fqid = fullyqualid; udecl = OPT univ_decl; ":="; c = Constr.lconstr ->
+    [ [ "Definition"; fqid = fullyqualid; udecl = OPT univ_decl; ":="; c = term LEVEL "200" ->
           { CWith_Definition (fqid,udecl,c) }
       | IDENT "Module"; fqid = fullyqualid; ":="; qid = qualid ->
           { CWith_Module (fqid,qid) }
@@ -690,7 +690,7 @@ GRAMMAR EXTEND Gram
          t = term LEVEL "200";
          info = hint_info ;
          props = [ ":="; "{"; r = record_declaration; "}" -> { Some (true,r) } |
-             ":="; c = lconstr -> { Some (false,c) } | -> { None } ] ->
+             ":="; c = term LEVEL "200" -> { Some (false,c) } | -> { None } ] ->
            { VernacInstance (fst namesup,snd namesup,t,props,info) }
 
       | IDENT "Existing"; IDENT "Instance"; id = global;
@@ -817,7 +817,7 @@ GRAMMAR EXTEND Gram
     [ [ "("; a = simple_reserv; ")" -> { a } ] ]
   ;
   simple_reserv:
-    [ [ idl = LIST1 identref; ":"; c = lconstr -> { (idl,c) } ] ]
+    [ [ idl = LIST1 identref; ":"; c = term LEVEL "200" -> { (idl,c) } ] ]
   ;
 
 END
@@ -868,7 +868,7 @@ GRAMMAR EXTEND Gram
           { VernacRemoveLoadPath dir }
 
       (* Type-Checking *)
-      | "Type"; c = lconstr -> { VernacGlobalCheck c }
+      | "Type"; c = term LEVEL "200" -> { VernacGlobalCheck c }
 
       (* Printing (careful factorization of entries) *)
       | IDENT "Print"; p = printable -> { VernacPrint p }
@@ -913,11 +913,11 @@ GRAMMAR EXTEND Gram
           { VernacRemoveOption ([table], v) } ]]
   ;
   query_command: (* TODO: rapprocher Eval et Check *)
-    [ [ IDENT "Eval"; r = red_expr; "in"; c = lconstr; "." ->
+    [ [ IDENT "Eval"; r = red_expr; "in"; c = term LEVEL "200"; "." ->
           { fun g -> VernacCheckMayEval (Some r, g, c) }
-      | IDENT "Compute"; c = lconstr; "." ->
+      | IDENT "Compute"; c = term LEVEL "200"; "." ->
           { fun g -> VernacCheckMayEval (Some (Genredexpr.CbvVm None), g, c) }
-      | IDENT "Check"; c = lconstr; "." ->
+      | IDENT "Check"; c = term LEVEL "200"; "." ->
          { fun g -> VernacCheckMayEval (None, g, c) }
       (* Searching the environment *)
       | IDENT "About"; qid = smart_global; l = OPT univ_name_list; "." ->

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -64,11 +64,9 @@ let pr_grammar = function
   | "constr" | "term" | "binder_constr" ->
       str "Entry constr is" ++ fnl () ++
       pr_entry Pcoq.Constr.constr ++
-      str "and lconstr is" ++ fnl () ++
-      pr_entry Pcoq.Constr.lconstr ++
-      str "where binder_constr is" ++ fnl () ++
+      str "Entry binder_constr is" ++ fnl () ++
       pr_entry Pcoq.Constr.binder_constr ++
-      str "and term is" ++ fnl () ++
+      str "Entry term is" ++ fnl () ++
       pr_entry Pcoq.Constr.term
   | "pattern" ->
       pr_entry Pcoq.Constr.pattern


### PR DESCRIPTION
Part of cleaning up nonterminal names to make them consistent with the names we used in the documentation.  Too many `*constr*` symbols is confusing.  I wanted to get some feedback on this one before doing others.

"lconstr" is deprecated for both mlgs and `Tactic Notation`.  For `Tactic Notation`, it's a hard error but at least it tells you how to fix it.  I would have made it a warning but I didn't know how to make that work both for coqtop (just print it) versus CoqIDE.  And there were no uses of `lconstr` in `Tactic Notation` in any of the .v files.

I didn't touch `lconstr` where it was just a variable name (not syntax related) in the .ml files.

Only functional changes: a slight change in `Print Grammar` output and an improved message for one parse error for developers.