### PR TITLE
Let solve_simple_eqn be aware of the possibility to recover from an occur-check error by reasoning up to eta

### DIFF
--- a/pretyping/evarsolve.mli
+++ b/pretyping/evarsolve.mli
@@ -134,6 +134,11 @@ val instantiate_evar : unifier -> unify_flags -> env -> evar_map ->
 val evar_define : unifier -> unify_flags -> ?choose:bool -> ?imitate_defs:bool ->
   env -> evar_map -> bool option -> existential -> constr -> evar_map
 
+val has_eta_constructor : env -> Names.constructor -> bool
+val eta_lambda : unifier -> unify_flags -> env -> evar_map -> bool ->
+  constr -> Names.Name.t Context.binder_annot -> types -> constr -> unification_result
+val eta_constructor : unifier -> unify_flags -> env -> evar_map -> bool ->
+  constr -> Names.constructor -> constr list -> unification_result
 
 val refresh_universes :
   ?status:Evd.rigid ->

--- a/pretyping/evarsolve.mli
+++ b/pretyping/evarsolve.mli
@@ -63,6 +63,24 @@ type unification_result =
 
 val is_success : unification_result -> bool
 
+(* Try in sequence unification functions until one works; returns a Failure if none work *)
+val ise_try : evar_map -> (evar_map -> unification_result) list -> unification_result
+
+(* All unification functions should unify; returns a Failure if some fails *)
+val ise_and : evar_map -> (evar_map -> unification_result) list -> unification_result
+
+(* Returns a success if the unification function returns Some and a success *)
+val ise_exact : ('a -> 'b -> 'c option * unification_result) ->
+  'a -> 'b -> unification_result
+
+(* The unification function should succeed on all pairs; returns a Failure if some fails or if not same size *)
+val ise_array2 : evar_map -> (evar_map -> 'a -> 'b -> unification_result) ->
+  'a array -> 'b array -> unification_result
+
+(* The unification function should succeed on all pairs; returns a Failure if some fails or if not same size *)
+val ise_list2 : evar_map -> (evar_map -> 'a -> 'b -> unification_result) ->
+  'a list -> 'b list -> unification_result
+
 val is_evar_allowed : unify_flags -> Evar.t -> bool
 
 (** Replace the vars and rels that are aliases to other vars and rels by


### PR DESCRIPTION
**Kind:** cleanup

This PR does two organizational cleanups:
- attach to the `ise` family of combinators (`ise_and`, `ise_try`, ...) an explicitly documented API (now in `evarsolve.ml`)
- move the code of `eta` for functions and for non-empty finite negative records in `evarsolve.ml`

and a semantic cleanup:
- remove the hack (3fdfb3ccb79) that bypassed the `OccurCheck` error returned by `solve_simple_eqn` for the purpose of allowing eta (formerly provided only by `evar_conv_x`) as fallback; instead, we treat `eta` directly in `solve_simple_eqn` so that when it returns an `OccurCheck`, it is really a fatal one

The latter issue has been revealed by #13126 and this PR should hopefully allow #13126 to be strictly CI-compatible.
