### PR TITLE
Activating contravariant subtyping of dependent function types

### DIFF
--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -41,6 +41,7 @@ let stats = ref false
 (* Profiling *)
 let beta = ref 0
 let delta = ref 0
+let eta = ref 0
 let zeta = ref 0
 let evar = ref 0
 let nb_match = ref 0
@@ -54,7 +55,7 @@ let reset () =
 
 let stop() =
   Feedback.msg_debug (str "[Reds: beta=" ++ int !beta ++ str" delta=" ++ int !delta ++
-         str" zeta=" ++ int !zeta ++ str" evar=" ++
+         str " eta=" ++ int !eta ++ str" zeta=" ++ int !zeta ++ str" evar=" ++
          int !evar ++ str" match=" ++ int !nb_match ++ str" fix=" ++ int !fix ++
          str " cofix=" ++ int !cofix ++ str" prune=" ++ int !prune ++
          str"]")
@@ -82,6 +83,7 @@ module type RedFlagsSig = sig
   type red_kind
   val fBETA : red_kind
   val fDELTA : red_kind
+  val fETA : red_kind
   val fMATCH : red_kind
   val fFIX : red_kind
   val fCOFIX : red_kind
@@ -110,17 +112,19 @@ module RedFlags : RedFlagsSig = struct
   type reds = {
     r_beta : bool;
     r_delta : bool;
+    r_eta : bool;
     r_const : TransparentState.t;
     r_zeta : bool;
     r_match : bool;
     r_fix : bool;
     r_cofix : bool }
 
-  type red_kind = BETA | DELTA | MATCH | FIX
+  type red_kind = BETA | DELTA | ETA | MATCH | FIX
               | COFIX | ZETA
               | CONST of Constant.t | VAR of Id.t
   let fBETA = BETA
   let fDELTA = DELTA
+  let fETA = ETA
   let fMATCH = MATCH
   let fFIX = FIX
   let fCOFIX = COFIX
@@ -130,6 +134,7 @@ module RedFlags : RedFlagsSig = struct
   let no_red = {
     r_beta = false;
     r_delta = false;
+    r_eta = false;
     r_const = all_opaque;
     r_zeta = false;
     r_match = false;
@@ -138,6 +143,7 @@ module RedFlags : RedFlagsSig = struct
 
   let red_add red = function
     | BETA -> { red with r_beta = true }
+    | ETA -> { red with r_eta = true }
     | DELTA -> { red with r_delta = true }
     | CONST kn ->
       let r = red.r_const in
@@ -152,6 +158,7 @@ module RedFlags : RedFlagsSig = struct
 
   let red_sub red = function
     | BETA -> { red with r_beta = false }
+    | ETA -> { red with r_eta = false }
     | DELTA -> { red with r_delta = false }
     | CONST kn ->
       let r = red.r_const in
@@ -175,6 +182,7 @@ module RedFlags : RedFlagsSig = struct
 
   let red_set red = function
     | BETA -> incr_cnt red.r_beta beta
+    | ETA -> incr_cnt red.r_eta eta
     | CONST kn ->
       let c = is_transparent_constant red.r_const kn in
         incr_cnt c delta

--- a/kernel/cClosure.mli
+++ b/kernel/cClosure.mli
@@ -34,6 +34,8 @@ module RedFlags : sig
 
   val fBETA : red_kind
   val fDELTA : red_kind
+  val fETA : red_kind
+  (** The fETA flag is never used by the kernel reduction but pretyping does *)
   val fMATCH : red_kind
   val fFIX : red_kind
   val fCOFIX : red_kind

--- a/kernel/nativeconv.ml
+++ b/kernel/nativeconv.ml
@@ -119,7 +119,7 @@ and conv_atom env pb lvl a1 a2 cu =
           if not (Int.equal (Array.length f1) (Array.length f2)) then raise NotConvertible
           else conv_fix env lvl t1 f1 t2 f2 cu
     | Aprod(_,d1,_c1), Aprod(_,d2,_c2) ->
-       let cu = conv_val env CONV lvl d1 d2 cu in
+       let cu = conv_val env CUMUL lvl d2 d1 cu in
        let v = mk_rel_accu lvl in
        conv_val env pb (lvl + 1) (d1 v) (d2 v) cu
     | Aproj((ind1, i1), ac1), Aproj((ind2, i2), ac2) ->

--- a/kernel/reduction.ml
+++ b/kernel/reduction.ml
@@ -500,11 +500,11 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
            we throw them away *)
         if not (is_empty_stack v1 && is_empty_stack v2) then
           anomaly (Pp.str "conversion was given ill-typed terms (FLambda).");
-        let (x1,ty1,bd1) = destFLambda mk_clos hd1 in
-        let (_,ty2,bd2) = destFLambda mk_clos hd2 in
+        (* We assume terms well-typed in the same supertype, so we don't compare the domains *)
+        let (x1,_ty1,bd1) = destFLambda mk_clos hd1 in
+        let (_,_ty2,bd2) = destFLambda mk_clos hd2 in
         let el1 = el_stack lft1 v1 in
         let el2 = el_stack lft2 v2 in
-        let cuniv = ccnv CONV l2r infos el1 el2 ty1 ty2 cuniv in
         ccnv CONV l2r (push_relevance infos x1) (el_lift el1) (el_lift el2) bd1 bd2 cuniv
 
     | (FProd (x1, c1, c2, e), FProd (_, c'1, c'2, e')) ->

--- a/kernel/reduction.ml
+++ b/kernel/reduction.ml
@@ -507,15 +507,15 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
         let el2 = el_stack lft2 v2 in
         ccnv CONV l2r (push_relevance infos x1) (el_lift el1) (el_lift el2) bd1 bd2 cuniv
 
-    | (FProd (x1, c1, c2, e), FProd (_, c'1, c'2, e')) ->
+    | (FProd (x1, t1, t1', e1), FProd (_, t2, t2', e2)) ->
         if not (is_empty_stack v1 && is_empty_stack v2) then
           (* May happen because we convert application right to left *)
           raise NotConvertible;
-        (* Luo's system *)
+        (* contravariant subtyping *)
         let el1 = el_stack lft1 v1 in
         let el2 = el_stack lft2 v2 in
-        let cuniv = ccnv CONV l2r infos el1 el2 c1 c'1 cuniv in
-        ccnv cv_pb l2r (push_relevance infos x1) (el_lift el1) (el_lift el2) (mk_clos (subs_lift e) c2) (mk_clos (subs_lift e') c'2) cuniv
+        let cuniv = ccnv CUMUL (not l2r) infos el2 el1 t2 t1 cuniv in
+        ccnv cv_pb l2r (push_relevance infos x1) (el_lift el1) (el_lift el2) (mk_clos (subs_lift e1) t1') (mk_clos (subs_lift e2) t2') cuniv
 
     (* Eta-expansion on the fly *)
     | (FLambda _, _) ->

--- a/kernel/vconv.ml
+++ b/kernel/vconv.ml
@@ -48,7 +48,7 @@ and conv_whd env pb k whd1 whd2 cu =
      **)
     assert false
   | Vprod p1, Vprod p2 ->
-      let cu = conv_val env CONV k (dom p1) (dom p2) cu in
+      let cu = conv_val env CUMUL k (dom p2) (dom p1) cu in
       conv_fun env pb k (codom p1) (codom p2) cu
   | Vfun f1, Vfun f2 -> conv_fun env CONV k f1 f2 cu
   | Vfix (f1,None), Vfix (f2,None) -> conv_fix env k f1 f2 cu

--- a/plugins/funind/recdef.ml
+++ b/plugins/funind/recdef.ml
@@ -165,6 +165,7 @@ let simpl_iter clause =
   reduce
     (Lazy
        { rBeta = true
+       ; rEta = true
        ; rMatch = true
        ; rFix = true
        ; rCofix = true

--- a/plugins/ltac/g_tactic.mlg
+++ b/plugins/ltac/g_tactic.mlg
@@ -327,6 +327,7 @@ GRAMMAR EXTEND Gram
   ;
   red_flag:
     [ [ IDENT "beta" -> { [FBeta] }
+      | IDENT "eta" -> { [FEta] }
       | IDENT "iota" -> { [FMatch;FFix;FCofix] }
       | IDENT "match" -> { [FMatch] }
       | IDENT "fix" -> { [FFix] }

--- a/plugins/ltac2/tac2qexpr.mli
+++ b/plugins/ltac2/tac2qexpr.mli
@@ -119,6 +119,7 @@ type dispatch = dispatch_r CAst.t
 
 type red_flag_r =
 | QBeta
+| QEta
 | QIota
 | QMatch
 | QFix

--- a/plugins/ltac2/tac2quote.ml
+++ b/plugins/ltac2/tac2quote.ml
@@ -349,6 +349,7 @@ let make_red_flag l =
   | {v=flag} :: lf ->
     let red = match flag with
     | QBeta -> { red with rBeta = true }
+    | QEta -> { red with rEta = true }
     | QMatch -> { red with rMatch = true }
     | QFix -> { red with rFix = true }
     | QCofix -> { red with rCofix = true }
@@ -369,7 +370,7 @@ let make_red_flag l =
     add_flag red lf
   in
   add_flag
-    {rBeta = false; rMatch = false; rFix = false; rCofix = false;
+    {rBeta = false; rEta = false; rMatch = false; rFix = false; rCofix = false;
      rZeta = false; rDelta = false; rConst = []}
     l
 

--- a/plugins/ltac2/tac2stdlib.ml
+++ b/plugins/ltac2/tac2stdlib.ml
@@ -62,9 +62,10 @@ let to_clause v = match Value.to_tuple v with
 let clause = make_to_repr to_clause
 
 let to_red_flag v = match Value.to_tuple v with
-| [| beta; iota; fix; cofix; zeta; delta; const |] ->
+| [| beta; eta; iota; fix; cofix; zeta; delta; const |] ->
   {
     rBeta = Value.to_bool beta;
+    rEta = Value.to_bool eta;
     rMatch = Value.to_bool iota;
     rFix = Value.to_bool fix;
     rCofix = Value.to_bool cofix;

--- a/plugins/ssr/ssrcommon.ml
+++ b/plugins/ssr/ssrcommon.ml
@@ -1185,7 +1185,7 @@ let rec decompose_assum env sigma orig_goal =
 let tclFULL_BETAIOTA = Goal.enter begin fun gl ->
   let r, _ = Redexpr.reduction_of_red_expr (Goal.env gl)
     Genredexpr.(Lazy {
-      rBeta=true; rMatch=true; rFix=true; rCofix=true;
+      rBeta=true; rEta=true; rMatch=true; rFix=true; rCofix=true;
       rZeta=false; rDelta=false; rConst=[]}) in
   Tactics.e_reduct_in_concl ~cast:false ~check:false (r,Constr.DEFAULTcast)
 end

--- a/pretyping/evarconv.ml
+++ b/pretyping/evarconv.ml
@@ -1047,13 +1047,13 @@ and evar_eqappr_x ?(rhs_is_already_stuck = false) flags env evd pbty
                UnifFailure (evd,UnifUnivInconsistency p)
              | e when CErrors.noncritical e -> UnifFailure (evd,NotSameHead))
 
-        | Prod (n1,c1,c'1), Prod (n2,c2,c'2) when app_empty ->
+        | Prod (na1,t1,t1'), Prod (na2,t2,t2') when app_empty ->
             ise_and evd
-              [(fun i -> evar_conv_x flags env i CONV c1 c2);
+              [(fun i -> evar_conv_x flags env i CUMUL t2 t1);
                (fun i ->
-                 let c = nf_evar i c1 in
-                 let na = Nameops.Name.pick_annot n1 n2 in
-                 evar_conv_x flags (push_rel (RelDecl.LocalAssum (na,c)) env) i pbty c'1 c'2)]
+                 let t = nf_evar i t1 in
+                 let na = Nameops.Name.pick_annot na1 na2 in
+                 evar_conv_x flags (push_rel (RelDecl.LocalAssum (na,t)) env) i pbty t1' t2')]
 
         | Rel x1, Rel x2 ->
             if Int.equal x1 x2 then

--- a/tactics/genredexpr.ml
+++ b/tactics/genredexpr.ml
@@ -14,6 +14,7 @@
 
 type 'a red_atom =
   | FBeta
+  | FEta
   | FMatch
   | FFix
   | FCofix
@@ -25,6 +26,7 @@ type 'a red_atom =
 
 type 'a glob_red_flag = {
   rBeta : bool;
+  rEta : bool;
   rMatch : bool;
   rFix : bool;
   rCofix : bool;

--- a/tactics/redexpr.ml
+++ b/tactics/redexpr.ml
@@ -133,6 +133,7 @@ let make_flag_constant = function
 let make_flag env f =
   let red = no_red in
   let red = if f.rBeta then red_add red fBETA else red in
+  let red = if f.rEta then red_add red fETA else red in
   let red = if f.rMatch then red_add red fMATCH else red in
   let red = if f.rFix then red_add red fFIX else red in
   let red = if f.rCofix then red_add red fCOFIX else red in

--- a/tactics/redops.ml
+++ b/tactics/redops.ml
@@ -16,6 +16,7 @@ let make_red_flag l =
   let rec add_flag red = function
     | [] -> red
     | FBeta :: lf -> add_flag { red with rBeta = true } lf
+    | FEta :: lf -> add_flag { red with rEta = true } lf
     | FMatch :: lf -> add_flag { red with rMatch = true } lf
     | FFix :: lf -> add_flag { red with rFix = true } lf
     | FCofix :: lf -> add_flag { red with rCofix = true } lf
@@ -34,13 +35,13 @@ let make_red_flag l =
           lf
   in
   add_flag
-    {rBeta = false; rMatch = false; rFix = false; rCofix = false;
+    {rBeta = false; rEta = false; rMatch = false; rFix = false; rCofix = false;
      rZeta = false; rDelta = false; rConst = []}
     l
 
 
 let all_flags =
-  {rBeta = true; rMatch = true; rFix = true; rCofix = true;
+  {rBeta = true; rEta = true; rMatch = true; rFix = true; rCofix = true;
    rZeta = true; rDelta = true; rConst = []}
 
 (** Mapping [red_expr_gen] *)

--- a/test-suite/bugs/bug_3777.v
+++ b/test-suite/bugs/bug_3777.v
@@ -14,5 +14,7 @@ Module WithPoly.
   Set Universe Polymorphism.
   Definition foo (A : Type@{i}) (B : Type@{i}) := A -> B.
   Set Printing Universes.
-  Fail Check ((@foo : Set -> _ -> _) : _ -> Type -> _).
+  (* With contravariant subtyping, we can instantiate foo on Type,
+     and have in Set -> Type -> Type *)
+  Check ((@foo : Set -> _ -> _) : _ -> Type -> _).
 End WithPoly.

--- a/test-suite/success/cbn.v
+++ b/test-suite/success/cbn.v
@@ -16,3 +16,10 @@ Goal forall n, foo (S n) = g n.
     |- g _ = g _ => reflexivity
   end.
 Qed.
+
+(* Support for eta *)
+
+Theorem g (f:nat->nat) : f = fun a => f a.
+cbn eta.
+match goal with |- f = f => idtac end.
+Abort.

--- a/test-suite/success/cbv.v
+++ b/test-suite/success/cbv.v
@@ -1,0 +1,6 @@
+(* Support for eta *)
+
+Theorem g (f:nat->nat) : f = fun a => f a.
+cbv eta.
+match goal with |- f = f => idtac end.
+Abort.

--- a/test-suite/success/subtyping.v
+++ b/test-suite/success/subtyping.v
@@ -1,0 +1,10 @@
+(* Testing comparison of terms inside their type in the presence of
+   contravariant subtyping *)
+
+Axiom E : (Set -> Set) -> Set.
+Axiom C : forall X, E X.
+
+(* Here, (fun X:Type => True) should be the same as (fun X:Set => True)
+   when seen as inhabitants of (Set->Set) *)
+
+Check C (fun X : Type => True) : E (fun X : Set => True).


### PR DESCRIPTION
**Kind:** feature

A first prototype in relation with coq/ceps#47.

- [ ] Add support of eta for `lazy`
- [ ] Optimize support of eta for `cbn` and `cbv`
- [ ] Address the lambda-domain conversion issue in `vm`, `native_compute`, `unification`
- [ ] Address the [performance issue](https://github.com/coq/coq/wiki/Performance-experiments#skipping-conversion-of-parameters-of-constructors-and-of-the-domain-of-lambdas-failed) in not converting the domains of lambdas
- [ ] Added / updated test-suite
- [ ] Corresponding documentation was added / updated
- [ ] Entry added in the changelog
