### PR TITLE
Fix two bugs in conversion of primitive values

### DIFF
--- a/kernel/cClosure.ml
+++ b/kernel/cClosure.ml
@@ -1165,7 +1165,7 @@ module FNativeEntries =
 
     let mkFloat env f =
       check_float env;
-      { mark = mark Norm KnownR; term = FFloat f }
+      { mark = mark Cstr KnownR; term = FFloat f }
 
     let mkBool env b =
       check_bool env;

--- a/test-suite/bugs/closed/bug_13276.v
+++ b/test-suite/bugs/closed/bug_13276.v
@@ -1,0 +1,9 @@
+From Coq Require Import Floats.
+Open Scope float_scope.
+
+Lemma foo :
+  let n := opp 0 in sub n 0 = n.
+Proof.
+cbv.
+apply eq_refl.
+Qed.


### PR DESCRIPTION
The conversion algorithm relies on marks that allow to quickly check whether a term is neutral. The addition of int63 and float introduced two bugs where terms were misclassified as neutral when they were merely normal. As explained in #13258 the CClosure nomenclature is quite confusing because `Norm` stands for neutral, when `Cstr` is normal, which might explain the second bug. The first bug looks like an oversight though.

These bugs were discovered while tweaking the conversion heuristics in #13258.

I don't think we can get a soundness issue out of this, just an incompleteness of the conversion. Still, this is quite serious stuff.

Fixes #13276
