### PR TITLE
[v8.12] Revert Coq-Elpi to 1.5.1.

### DIFF
--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -271,8 +271,8 @@
 ########################################################################
 # Elpi + Hierarchy Builder
 ########################################################################
-# Released on 2020-08-21 and compatible with Coq 8.12.
-: "${elpi_CI_REF:=v1.6.0}"
+# Released on 2020-07-29 and compatible with Coq 8.12 and HB 0.10.
+: "${elpi_CI_REF:=v1.5.1}"
 : "${elpi_CI_GITURL:=https://github.com/LPCIC/coq-elpi}"
 : "${elpi_CI_ARCHIVEURL:=${elpi_CI_GITURL}/archive}"
 


### PR DESCRIPTION
For compatibility with HB 0.10.
See discussion at #13200.