### PR TITLE
Postpone evar <= sort and sort <= evar

### DIFF
--- a/test-suite/bugs/closed/bug_11039.v
+++ b/test-suite/bugs/closed/bug_11039.v
@@ -11,12 +11,13 @@ Fail #[universes(template)]
 Fail #[universes(template)]
  Record foo@{i}  (T:=Type@{i}:Type@{i+1}) (A:Type@{i}) : Type@{i+1} := bar { X:T }.
 
+Universe u.
 
 (* no implicit template poly, no explicit universe annotations *)
-Inductive foo (A:Type) := bar X : foo X -> foo A | nonempty.
+Inductive foo (A:Type) := bar (X:Type@{u}) : foo X -> foo A | nonempty.
 Arguments nonempty {_}.
 
-Fail Check foo nat : Type@{foo.u0}.
+Fail Check foo nat : Type@{foo.u}.
 (* template poly didn't activate *)
 
 Definition U := Type.

--- a/test-suite/bugs/closed/bug_5208.v
+++ b/test-suite/bugs/closed/bug_5208.v
@@ -66,9 +66,9 @@ Section poly.
 
   Fixpoint get_member (val : Type@{U}) p {struct p}
   : forall m, fields_get p m = @Some Type@{U} val -> member val m :=
-    match p as p return forall m, fields_get p m = @Some Type@{U} val -> member@{U} val m with
+    match p as p return forall m, fields_get p m = @Some Type@{U} val -> member val m with
       | xH => fun m =>
-        match m as m return fields_get xH m = @Some Type@{U} val -> member@{U} val m with
+        match m as m return fields_get xH m = @Some Type@{U} val -> member val m with
         | pm_Leaf => fun pf : None = @Some Type@{U} _ =>
                        match pf in _ = Z return match Z with
                                                 | Some _ => _
@@ -86,19 +86,19 @@ Section poly.
                                   | eq_refl => tt
                                   end
         | pm_Branch _ (Some x) _ => fun pf : @Some Type@{U} x = @Some Type@{U} val =>
-                                      match eq_sym pf in _ = Z return member@{U} val (pm_Branch _ Z _) with
+                                      match eq_sym pf in _ = Z return member val (pm_Branch _ Z _) with
                                       | eq_refl => pmm_H
                                       end
         end
       | xO p' => fun m =>
-        match m as m return fields_get (xO p') m = @Some Type@{U} val -> member@{U} val m with
+        match m as m return fields_get (xO p') m = @Some Type@{U} val -> member val m with
         | pm_Leaf => fun pf : fields_get p' pm_Leaf = @Some Type@{U} val =>
                        @get_member _ p' pm_Leaf pf
         | pm_Branch l _ _ => fun pf : fields_get p' l = @Some Type@{U} val =>
                        @pmm_L _ _ _ _ (@get_member _ p' l pf)
         end
       | xI p' => fun m =>
-        match m as m return fields_get (xI p') m = @Some Type@{U} val -> member@{U} val m with
+        match m as m return fields_get (xI p') m = @Some Type@{U} val -> member val m with
         | pm_Leaf => fun pf : fields_get p' pm_Leaf = @Some Type@{U} val =>
                        @get_member _ p' pm_Leaf pf
         | pm_Branch l _ r => fun pf : fields_get p' r = @Some Type@{U} val =>

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -515,16 +515,6 @@ let interp_lemma ~program_mode ~flags ~scope env0 evd thms =
     evd thms
 
 (* Checks done in start_lemma_com *)
-let post_check_evd ~udecl ~poly evd =
-  let () =
-    if not UState.(udecl.univdecl_extensible_instance &&
-                   udecl.univdecl_extensible_constraints) then
-      ignore (Evd.check_univ_decl ~poly evd udecl)
-  in
-  if poly then evd
-  else (* We fix the variables to ensure they won't be lowered to Set *)
-    Evd.fix_undefined_variables evd
-
 let start_lemma_com ~program_mode ~poly ~scope ~kind ?hook thms =
   let env0 = Global.env () in
   let flags = Pretyping.{ all_no_fail_flags with program_mode } in
@@ -536,12 +526,10 @@ let start_lemma_com ~program_mode ~poly ~scope ~kind ?hook thms =
   match mut_analysis with
   | RecLemmas.NonMutual thm ->
     let thm = Declare.CInfo.to_constr evd thm in
-    let evd = post_check_evd ~udecl ~poly evd in
     let info = Declare.Info.make ?hook ~poly ~scope ~kind ~udecl () in
     Declare.Proof.start_with_initialization ~info ~cinfo:thm evd
   | RecLemmas.Mutual { mutual_info; cinfo ; possible_guards } ->
     let cinfo = List.map (Declare.CInfo.to_constr evd) cinfo in
-    let evd = post_check_evd ~udecl ~poly evd in
     let info = Declare.Info.make ?hook ~poly ~scope ~kind ~udecl () in
     Declare.Proof.start_mutual_with_initialization ~info ~cinfo evd ~mutual_info (Some possible_guards)
 


### PR DESCRIPTION
**Kind:** experiment

 We do it by introducing a universe variable `u`, but only for `Set` and `Type(l)` because:
 - `?x` <= `SProp` has anyway only one solution
 - `?x` <= `Prop` has only one solution (in the absence of `SProp` <= `Prop`)
 - `Prop` <= `Type(u)` is not designed to minimize `u` to `Prop`

That would be simple if we had universe variables instantiable by `Prop`, and of course simpler also with `SProp` <= `Prop`.

The change allows to have more natural results, such as more symmetry:

1. `Definition f A (P:Type -> Type -> Prop) := P A A.` and `Definition f (A : Type) (P:Type -> Type -> Prop) := P A A.` would work the same producing both `fun (A : Type@{u}) (P : Type@{u0} -> Type@{u1} -> Prop` with `u <= u0, u <= u1` while master currently returns `fun (A : Type@{u}) (P : Type@{u} -> Type@{u1} -> Prop` with `u <= u1` for the former.

2. `Check nat = Type` would succeed the same as `Check Type = nat` and `Check if true then nat else Type` would also succeed the same as `Check if true then Type else nat`.

In the test-suite, the change has the "nice" (?) effect to give a better generalization of universe polymorphism in the test for #5208 (see also #13286) but also in some lemmas of the stdlib. For instance, the `success/unification.v` test shows that `CMorphisms.trans_co_eq_inv_arrow_morphism` has now 5 instead of 7 universes.

This has also the effect to change the flexibility of variables who don't have a type:
```
Inductive any_list {A} :=
| nil : @any_list A
| cons : forall X, A -> @any_list X -> @any_list A.
Set Printing Universes.
Print any_list.
```
now behaves like
```
Inductive any_list {A:Type} :=
| nil : @any_list A
| cons : forall X:Type, A -> @any_list X -> @any_list A.
Set Printing Universes.
Print any_list.
```
i.e. it generates two universes `u` and `v` related with `v <= u` while 8.12 forces `u = v`. This happens in test files `bug_10504.v` and `bug_11309.v`.
