### PR TITLE
Allow split compilation for native compute files

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -98,7 +98,7 @@ states: $(VO_OUT_DIR)theories/Init/Prelude.$(VO)
 
 .PHONY: coqbinaries tools
 
-coqbinaries: $(TOPBINOPT) $(COQC) $(COQTOPEXE) $(CHICKEN) $(CSDPCERT) $(FAKEIDE)
+coqbinaries: $(TOPBINOPT) $(COQC) $(COQTOPEXE) $(CHICKEN) $(CSDPCERT) $(FAKEIDE) $(COQNATIVE)
 tools: $(TOOLS) $(OCAMLLIBDEP) $(COQDEP) $(DOC_GRAM)
 
 ###########################################################################
@@ -217,11 +217,14 @@ DUNEPLUGININCLUDES=$(addprefix -I _build/default/, $(wildcard plugins/*))
 NATIVEINCLUDES=$(addprefix -nI _build/default/, kernel/.kernel.objs/byte)
 USERCONTRIBINCLUDES=$(addprefix -I _build/default/user-contrib/,$(USERCONTRIBDIRS))
 
-COQOPTS=$(NATIVECOMPUTE) $(COQWARNERROR) $(COQUSERFLAGS)
+ifdef NATIVECOMPUTE
+  COQOPTS += -native-compiler ondemand
+endif
+COQOPTS += $(COQWARNERROR) $(COQUSERFLAGS)
 # Beware this depends on the makefile being in a particular dir, we
 # should pass an absolute path here but windows is tricky
 # c.f. https://github.com/coq/coq/pull/9560
-BOOTCOQC=$(TIMER) $(COQC) -coqlib $(VO_OUT_DIR) -q $(COQOPTS) $(DUNEPLUGININCLUDES) $(NATIVEINCLUDES) $(USERCONTRIBINCLUDES)
+BOOTCOQC=$(TIMER) $(COQC) -coqlib $(VO_OUT_DIR) -q $(COQOPTS) $(DUNEPLUGININCLUDES) $(USERCONTRIBINCLUDES)
 
 ###########################################################################
 # Infrastructure for the rest of the Makefile
@@ -231,6 +234,10 @@ VO_TOOLS_DEP = $(COQC)
 
 ifeq ($(BEST),byte)
   VO_TOOLS_DEP += $(CONTEXT)/lib/stublibs/dllbyterun_stubs.so
+endif
+
+ifdef NATIVECOMPUTE
+  VO_TOOLS_DEP += $(COQNATIVE)
 endif
 
 ifdef VALIDATE
@@ -324,6 +331,10 @@ $(VO_OUT_DIR)theories/Init/%.vo $(VO_OUT_DIR)theories/Init/%.glob: $(VO_OUT_DIR)
 	$(HIDE)rm -f $(VO_OUT_DIR)theories/Init/$*.glob
 	$(HIDE)mkdir -p $(shell dirname $<)
 	$(HIDE)$(BOOTCOQC) $< -o $@ -noinit -R $(VO_OUT_DIR)theories Coq $(TIMING_ARG) $(TIMING_EXTRA)
+ifdef NATIVECOMPUTE
+	$(SHOW)'COQNATIVE $*.vo'
+	$(HIDE)$(COQNATIVE) $(NATIVEINCLUDES) -coqlib . -R $(VO_OUT_DIR)theories Coq $(VO_OUT_DIR)theories/Init/$*.vo
+endif
 
 $(VO_OUT_DIR)theories/Init/%.vio: theories/Init/%.v $(VO_TOOLS_DEP) | $(VO_OUT_DIR)
 	$(SHOW)'COQC -quick -noinit $<'
@@ -337,6 +348,10 @@ $(VO_OUT_DIR)%.vo $(VO_OUT_DIR)%.glob: $(VO_OUT_DIR)%.v $(VO_OUT_DIR)theories/In
 	$(HIDE)rm -f $*.glob
 	$(HIDE)mkdir -p $(shell dirname $<)
 	$(HIDE)$(BOOTCOQC) $< -o $@ $(TIMING_ARG) $(TIMING_EXTRA)
+ifdef NATIVECOMPUTE
+	$(SHOW)'COQNATIVE $*.vo'
+	$(HIDE)$(COQNATIVE) $(NATIVEINCLUDES) -coqlib . -R $(VO_OUT_DIR)theories Coq $(VO_OUT_DIR)$*.vo
+endif
 ifdef VALIDATE
 	$(SHOW)'COQCHK    $(call vo_to_mod,$@)'
 	$(HIDE)$(CHICKEN) $(VALIDOPTS) -norec $(call vo_to_mod,$@) \

--- a/Makefile.common
+++ b/Makefile.common
@@ -68,6 +68,7 @@ COQMAKEFILEIN:=$(BCONTEXT)/tools/CoqMakefile.in
 COQTEX:=$(CBIN)/coq-tex$(EXE)
 COQWC:=$(CBIN)/coqwc$(EXE)
 COQDOC:=$(CBIN)/coqdoc$(EXE)
+COQNATIVE:=$(CBIN)/coqnative$(EXE)
 COQDOCSTY:=$(CONTEXT)/lib/coq-core/tools/coqdoc/coqdoc.sty
 COQDOCCSS:=$(CONTEXT)/lib/coq-core/tools/coqdoc/coqdoc.css
 COQWORKMGR:=$(CBIN)/coqworkmgr$(EXE)
@@ -80,7 +81,7 @@ OCAMLLIBDEP:=$(CBIN)/ocamllibdep$(EXE)
 FAKEIDE:=$(CBIN)/fake_ide$(EXE)
 USERCONTRIBDIRS:=Ltac2
 CHICKEN:=$(CBIN)/coqchk$(EXE)
-TOOLS:=$(VOTOUR) $(COQDOC) $(COQDOCSTY) $(COQDOCCSS) $(COQWC) $(COQMAKEFILE) $(COQMAKEFILEIN)
+TOOLS:=$(VOTOUR) $(COQDOC) $(COQDOCSTY) $(COQDOCCSS) $(COQWC) $(COQMAKEFILE) $(COQMAKEFILEIN) $(COQNATIVE)
 CSDPCERT:=$(CBIN)/csdpcert$(EXE)
 
 ifeq ($(origin COQ_SRC_DIR),undefined)

--- a/doc/changelog/08-cli-tools/13287-native-vo-to-cmxs-compiler.rst
+++ b/doc/changelog/08-cli-tools/13287-native-vo-to-cmxs-compiler.rst
@@ -1,0 +1,7 @@
+- **Added:**
+  A standalone `coqnative` binary that performs native compilation
+  out of `vo` files, allowing to split library compilation from
+  native compilation. See :ref:`coqnative`. The hybrid build
+  system was adapted to perform a split compilation on the stdlib
+  (`#13287 <https://github.com/coq/coq/pull/13287>`_,
+  by Pierre-Marie Pédrot).

--- a/doc/sphinx/practical-tools/utilities.rst
+++ b/doc/sphinx/practical-tools/utilities.rst
@@ -667,6 +667,38 @@ See the man page of ``coqdep`` for more details and options.
 Both Dune and ``coq_makefile`` use ``coqdep`` to compute the
 dependencies among the files part of a Coq project.
 
+.. _coqnative:
+
+Split compilation of native computation files
+---------------------------------------------
+
+Coq features a :tacn:`native_compute` tactic to provide fast computation in the
+kernel. This process performs compilation of Coq terms to OCaml programs using
+the OCaml compiler, which may cause an important overhead. Hence native
+compilation is an opt-in configure flag.
+
+When native compilation is activated, Coq generates the compiled files upfront,
+i.e. during the ``coqc`` invocation on the corresponding ``.v`` file. This is
+impractical because it means one must chose in advance whether they will use
+a native-capable Coq installation. In particular, activating native compilation
+forces the recompilation of the whole Coq installation. See
+:ref:`command line options <command-line-options>` for more details.
+
+Starting from Coq 8.14, a new binary ``coqnative`` is available. It allows
+performing split native compilation by generating the native compute files out
+of the compiled ``.vo`` file rather than out of the source ``.v`` file.
+
+The ``coqnative`` command takes a name *file.vo* as argument and tries to
+perform native compilation on it. It assumes that the Coq libraries on which
+*file.vo* depends have been first compiled to their native files, and will fail
+otherwise. It accepts the ``-R``, ``-Q``, ``-I`` and ``-nI`` arguments with the
+same semantics as if the native compilation process had been performed through
+``coqc``. In particular, it means that:
+
++ ``-R`` and ``-Q`` are equivalent
+
++ ``-I`` is a no-op that is accepted only for scripting convenience
+
 Embedded Coq phrases inside |Latex| documents
 -----------------------------------------------
 

--- a/topbin/coqnative_bin.ml
+++ b/topbin/coqnative_bin.ml
@@ -1,0 +1,328 @@
+(* Coq native compiler *)
+open CErrors
+open Util
+open Names
+open Pp
+
+let fatal_error info anomaly =
+  flush_all (); Format.eprintf "@[Fatal Error: @[%a@]@]@\n%!" Pp.pp_with info; flush_all ();
+  exit (if anomaly then 129 else 1)
+
+module Loadpath :
+sig
+  val add_load_path : string * DirPath.t -> unit
+  val default_root_prefix : DirPath.t
+  val dirpath_of_string : string -> DirPath.t
+  val locate_absolute_library : DirPath.t -> string
+end =
+struct
+
+let pr_dirpath dp = str (DirPath.to_string dp)
+let default_root_prefix = DirPath.empty
+let split_dirpath d =
+  let l = DirPath.repr d in (DirPath.make (List.tl l), List.hd l)
+
+type logical_path = DirPath.t
+
+let load_paths = ref ([],[] : CUnix.physical_path list * logical_path list)
+
+let remove_load_path dir =
+  let physical, logical = !load_paths in
+  load_paths := List.filter2 (fun p d -> p <> dir) physical logical
+
+let add_load_path (phys_path,coq_path) =
+  if CDebug.(get_flag misc) then
+    Feedback.msg_notice (str "path: " ++ pr_dirpath coq_path ++ str " ->" ++ spc() ++
+           str phys_path);
+  let phys_path = CUnix.canonical_path_name phys_path in
+  let physical, logical = !load_paths in
+    match List.filter2 (fun p d -> p = phys_path) physical logical with
+      | _,[dir] ->
+          if coq_path <> dir
+            (* If this is not the default -I . to coqtop *)
+            && not
+            (phys_path = CUnix.canonical_path_name Filename.current_dir_name
+                && coq_path = default_root_prefix)
+          then
+            begin
+              (* Assume the user is concerned by library naming *)
+              if dir <> default_root_prefix then
+                Feedback.msg_warning
+                  (str phys_path ++ strbrk " was previously bound to " ++
+                   pr_dirpath dir ++ strbrk "; it is remapped to " ++
+                   pr_dirpath coq_path);
+              remove_load_path phys_path;
+              load_paths := (phys_path::fst !load_paths, coq_path::snd !load_paths)
+            end
+      | _,[] ->
+          load_paths := (phys_path :: fst !load_paths, coq_path :: snd !load_paths)
+      | _ -> anomaly (Pp.str ("Two logical paths are associated to "^phys_path^"."))
+
+let load_paths_of_dir_path dir =
+  let physical, logical = !load_paths in
+  fst (List.filter2 (fun p d -> d = dir) physical logical)
+
+let locate_absolute_library dir =
+  (* Search in loadpath *)
+  let pref, base = split_dirpath dir in
+  let loadpath = load_paths_of_dir_path pref in
+  if loadpath = [] then CErrors.user_err (str "No loadpath for " ++ DirPath.print pref);
+  let name = Id.to_string base^".vo" in
+  try
+    let _, file = System.where_in_path ~warn:false loadpath name in
+    file
+  with Not_found ->
+    CErrors.user_err (str "File " ++ str name ++ str " not found in loadpath")
+
+let dirpath_of_string s = match String.split_on_char '.' s with
+| [] -> default_root_prefix
+| dir -> DirPath.make (List.rev_map Id.of_string dir)
+
+end
+
+module Library =
+struct
+
+type library_objects
+
+type compilation_unit_name = DirPath.t
+
+(* The [*_disk] types below must be kept in sync with the vo representation. *)
+
+type library_disk = {
+  md_compiled : Safe_typing.compiled_library;
+  md_objects : library_objects;
+}
+
+type summary_disk = {
+  md_name : compilation_unit_name;
+  md_deps : (compilation_unit_name * Safe_typing.vodigest) array;
+  md_ocaml : string;
+}
+
+type library_t = {
+  library_name : compilation_unit_name;
+  library_file : string;
+  library_data : Safe_typing.compiled_library;
+  library_deps : (compilation_unit_name * Safe_typing.vodigest) array;
+  library_digests : Safe_typing.vodigest;
+  library_extra_univs : Univ.ContextSet.t;
+}
+
+let libraries_table : string DPmap.t ref = ref DPmap.empty
+
+let register_loaded_library senv libname file =
+  let () = assert (not @@ DPmap.mem libname !libraries_table) in
+  let () = libraries_table := DPmap.add libname file !libraries_table in
+  let dirname = Filename.dirname file in
+  let () = Nativelib.enable_library dirname libname in
+  let () = Nativelib.link_libraries () in
+  senv
+
+let mk_library sd f md digests univs =
+  {
+    library_name     = sd.md_name;
+    library_file     = f;
+    library_data     = md;
+    library_deps     = sd.md_deps;
+    library_digests  = digests;
+    library_extra_univs = univs;
+  }
+
+let intern_from_file f =
+  let ch = System.with_magic_number_check (fun file -> ObjFile.open_in ~file) f in
+  let (lsd : summary_disk), digest_lsd = ObjFile.marshal_in_segment ch ~segment:"summary" in
+  let ((lmd : library_disk), digest_lmd) = ObjFile.marshal_in_segment ch ~segment:"library" in
+  let (univs : (Univ.ContextSet.t * bool) option), digest_u = ObjFile.marshal_in_segment ch ~segment:"universes" in
+  ObjFile.close_in ch;
+  System.check_caml_version ~caml:lsd.md_ocaml ~file:f;
+  let open Safe_typing in
+  match univs with
+  | None -> mk_library lsd f lmd.md_compiled (Dvo_or_vi digest_lmd) Univ.ContextSet.empty
+  | Some (uall,true) ->
+      mk_library lsd f lmd.md_compiled (Dvivo (digest_lmd,digest_u)) uall
+  | Some (_,false) ->
+      mk_library lsd f lmd.md_compiled (Dvo_or_vi digest_lmd) Univ.ContextSet.empty
+
+let rec intern_library (needed, contents) dir =
+  (* Look if already listed and consequently its dependencies too *)
+  match DPmap.find dir contents with
+  | lib -> lib.library_digests, (needed, contents)
+  | exception Not_found ->
+  let f = Loadpath.locate_absolute_library dir in
+  let m = intern_from_file f in
+  if not (DirPath.equal dir m.library_name) then
+    user_err ~hdr:"load_physical_library"
+      (str "The file " ++ str f ++ str " contains library" ++ spc () ++
+       DirPath.print m.library_name ++ spc () ++ str "and not library" ++
+       spc() ++ DirPath.print dir);
+  let (needed, contents) = intern_library_deps (needed, contents) dir m f in
+  m.library_digests, (dir :: needed, DPmap.add dir m contents)
+
+and intern_library_deps libs dir m from =
+  Array.fold_left (intern_mandatory_library dir from) libs m.library_deps
+
+and intern_mandatory_library caller from libs (dir,d) =
+  let digest, libs = intern_library libs dir in
+  if not (Safe_typing.digest_match ~actual:digest ~required:d) then
+    user_err (str "Compiled library " ++ DirPath.print caller ++
+    str " (in file " ++ str from ++ str ") makes inconsistent assumptions \
+    over library " ++ DirPath.print dir);
+  libs
+
+let register_library senv m =
+  let mp = MPfile m.library_name in
+  let mp', senv = Safe_typing.import m.library_data m.library_extra_univs m.library_digests senv in
+  let () =
+    if not (ModPath.equal mp mp') then
+      anomaly (Pp.str "Unexpected disk module name.")
+  in
+  register_loaded_library senv m.library_name m.library_file
+
+let save_library_to env dir f lib =
+  let mp = MPfile dir in
+  let ast = Nativelibrary.dump_library mp env lib in
+  let fn = Filename.dirname f ^"/"^ Nativecode.mod_uid_of_dirpath dir in
+  Nativelib.compile_library ast fn
+
+let get_used_load_paths () =
+  String.Set.elements
+    (DPmap.fold (fun m f acc -> String.Set.add
+      (Filename.dirname f) acc)
+       !libraries_table String.Set.empty)
+
+let _ = Nativelib.get_load_paths := get_used_load_paths
+end
+
+let add_path ~unix_path:dir ~coq_root:coq_dirpath =
+  let open System in
+  if exists_dir dir then
+    begin
+      Loadpath.add_load_path (dir,coq_dirpath)
+    end
+  else
+    Feedback.msg_warning (str "Cannot open " ++ str dir)
+
+let convert_string d =
+  try Id.of_string d
+  with CErrors.UserError _ ->
+    Flags.if_verbose Feedback.msg_warning
+      (str "Directory " ++ str d ++ str " cannot be used as a Coq identifier (skipped)");
+    raise Exit
+
+let coq_root = Id.of_string "Coq"
+
+let add_rec_path ~unix_path ~coq_root =
+  let open System in
+  if exists_dir unix_path then
+    let dirs = all_subdirs ~unix_path in
+    let prefix = DirPath.repr coq_root in
+    let convert_dirs (lp, cp) =
+      try
+        let path = List.rev_map convert_string cp @ prefix in
+        Some (lp, Names.DirPath.make path)
+      with Exit -> None
+    in
+    let dirs = List.map_filter convert_dirs dirs in
+    List.iter Loadpath.add_load_path dirs;
+    Loadpath.add_load_path (unix_path, coq_root)
+  else
+    Feedback.msg_warning (str "Cannot open " ++ str unix_path)
+
+let init_load_path includes =
+  let () = Envars.set_coqlib ~fail:(fun x -> CErrors.user_err Pp.(str x)) in
+  let ( / ) = Filename.concat in
+  let coqlib = Envars.coqlib () in
+  let user_contrib = coqlib/"user-contrib" in
+  let xdg_dirs = Envars.xdg_dirs in
+  let coqpath = Envars.coqpath in
+  let plugins = coqlib/"plugins" in
+  (* NOTE: These directories are searched from last to first *)
+  (* first standard library *)
+  add_rec_path ~unix_path:(coqlib/"theories") ~coq_root:(Names.DirPath.make[coq_root]);
+  (* then plugins *)
+  add_rec_path ~unix_path:plugins ~coq_root:(Names.DirPath.make [coq_root]);
+  (* then user-contrib *)
+  if Sys.file_exists user_contrib then
+    add_rec_path ~unix_path:user_contrib ~coq_root:Loadpath.default_root_prefix;
+  (* then directories in XDG_DATA_DIRS and XDG_DATA_HOME *)
+  List.iter (fun s -> add_rec_path ~unix_path:s ~coq_root:Loadpath.default_root_prefix)
+    (xdg_dirs ~warn:(fun x -> Feedback.msg_warning (str x)));
+  (* then directories in COQPATH *)
+  List.iter (fun s -> add_rec_path ~unix_path:s ~coq_root:Loadpath.default_root_prefix) coqpath;
+  (* then current directory *)
+  add_path ~unix_path:"." ~coq_root:Loadpath.default_root_prefix;
+  (* additional loadpath, given with -R/-Q options *)
+  List.iter
+    (fun (unix_path, coq_root) -> add_rec_path ~unix_path ~coq_root)
+    (List.rev includes)
+
+let fb_handler = function
+  | Feedback.{ contents; _ } ->
+    match contents with
+    | Feedback.Message(_lvl,_loc,msg)->
+      Format.printf "%s@\n%!" Pp.(string_of_ppcmds msg)
+    | _ -> ()
+
+let init_coq () =
+  let senv = Safe_typing.empty_environment in
+  let senv = Safe_typing.set_engagement Declarations.PredicativeSet senv in
+  let () = Flags.set_native_compiler true in
+  let senv = Safe_typing.set_native_compiler true senv in
+  let () = Safe_typing.allow_delayed_constants := false in
+  let dummy = Names.DirPath.make [Names.Id.of_string_soft "@native"] in
+  let _, senv = Safe_typing.start_library dummy senv in
+  senv
+
+let compile senv ~in_file =
+  let lib = Library.intern_from_file in_file in
+  let dir = lib.Library.library_name in
+  (* Require the dependencies **only once** *)
+  let deps, contents = Library.intern_library_deps ([], DPmap.empty) dir lib in_file in
+  let fold senv dep = Library.register_library senv (DPmap.find dep contents) in
+  let senv = List.fold_left fold senv (List.rev deps) in
+  (* Extract the native code and compile it *)
+  let modl = (Safe_typing.module_of_library lib.Library.library_data).Declarations.mod_type in
+  let out_vo = Filename.(remove_extension in_file) ^ ".vo" in
+  Library.save_library_to (Safe_typing.env_of_safe_env senv) dir out_vo modl
+
+type opts = {
+  vo_path : (string * DirPath.t) list;
+  ml_path : string list;
+}
+
+let rec parse_args (args : string list) accu =
+  match args with
+  | [] -> CErrors.user_err (Pp.str "parse args error: missing argument")
+  | ("-Q" | "-R") :: d :: p :: rem ->
+    let p = Loadpath.dirpath_of_string p in
+    let accu = { accu with vo_path = (d, p) :: accu.vo_path } in
+    parse_args rem accu
+  | "-I" :: _d :: rem ->
+    (* Ignore *)
+    parse_args rem accu
+  | "-nI" :: dir :: rem ->
+    let accu =  { accu with ml_path = dir :: accu.ml_path } in
+    parse_args rem accu
+  | "-coqlib" :: s :: rem ->
+    if not (Minisys.exists_dir s) then
+      fatal_error (str "Directory '" ++ str s ++ str "' does not exist") false;
+    Envars.set_user_coqlib s;
+    parse_args rem accu
+  | [file] ->
+    accu, file
+  | args ->
+    let args_msg = String.concat " " args in
+    CErrors.user_err Pp.(str "parse args error, too many arguments: " ++ str args_msg)
+
+let () =
+  let _ = Feedback.add_feeder fb_handler in
+  try
+    let opts = { vo_path = []; ml_path = [] } in
+    let opts, in_file = parse_args (List.tl @@ Array.to_list Sys.argv) opts in
+    let () = init_load_path (List.rev opts.vo_path) in
+    let () = Nativelib.include_dirs := List.rev opts.ml_path in
+    let senv = init_coq () in
+    compile senv ~in_file
+  with exn ->
+    Format.eprintf "Error: @[%a@]@\n%!" Pp.pp_with (CErrors.print exn)

--- a/topbin/dune
+++ b/topbin/dune
@@ -36,12 +36,20 @@
  (package coq-core)
  (files (coqc_bin.bc as coqc.byte)))
 
+(executable
+ (name coqnative_bin)
+ (public_name coqnative)
+ (package coq-core)
+ (modules coqnative_bin)
+ (libraries coq-core.toplevel)
+ (link_flags -linkall))
+
 ; Workers
 (executables
  (names coqqueryworker_bin coqtacticworker_bin coqproofworker_bin)
  (public_names coqqueryworker.opt coqtacticworker.opt coqproofworker.opt)
  (package coq-core)
- (modules :standard \ coqtop_byte_bin coqtop_bin coqc_bin)
+ (modules :standard \ coqtop_byte_bin coqtop_bin coqc_bin coqnative_bin)
  (libraries coq-core.toplevel)
  (link_flags -linkall))
 


### PR DESCRIPTION
~~This is a experiment for people to discuss about.~~ This is now deemed ready.

See https://github.com/coq/ceps/pull/48 for the bigger picture.

1. This PR introduces a new `coqnative` program that converts `vo` files to their `cmxs` native library.
2. The hybrid Makefile build was adapted: if `-native-compiler` **configure** option is set to `yes`, it will shortcut the native library generation of `coqc` by passing to it the `-native-compiler ondemand` **runtime** option and call instead `coqnative` on the generated `vo` file
3. ~~`coq_makefile` does the same basing its decision on `COQMF_COQ_NATIVE_COMPILER_DEFAULT`, which is set to the configure value by default.~~ This is deferred to a subsequent PR.

- [x] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
