### PR TITLE
Remove the native symbol registering from the safe environment.

### DIFF
--- a/checker/values.ml
+++ b/checker/values.ml
@@ -374,7 +374,7 @@ and v_modtype =
 let v_vodigest = Sum ("module_impl",0, [| [|String|]; [|String;String|] |])
 let v_deps = Array (v_tuple "dep" [|v_dp;v_vodigest|])
 let v_compiled_lib =
-  v_tuple "compiled" [|v_dp;v_module;v_context_set;v_deps;v_engagement;Any|]
+  v_tuple "compiled" [|v_dp;v_module;v_context_set;v_deps;v_engagement|]
 
 (** Library objects *)
 

--- a/kernel/environ.ml
+++ b/kernel/environ.ml
@@ -104,7 +104,6 @@ type env = {
   env_typing_flags  : typing_flags;
   retroknowledge : Retroknowledge.retroknowledge;
   indirect_pterms : Opaqueproof.opaquetab;
-  native_symbols : Nativevalues.symbols DPmap.t;
 }
 
 let empty_named_context_val = {
@@ -136,7 +135,6 @@ let empty_env = {
   env_typing_flags = Declareops.safe_flags Conv_oracle.empty;
   retroknowledge = Retroknowledge.empty;
   indirect_pterms = Opaqueproof.empty_opaquetab;
-  native_symbols = DPmap.empty;
 }
 
 
@@ -828,10 +826,6 @@ let is_type_in_type env r =
   | ConstructRef cstr -> type_in_type_ind (inductive_of_constructor cstr) env
 
 let set_retroknowledge env r = { env with retroknowledge = r }
-
-let set_native_symbols env native_symbols = { env with native_symbols }
-let add_native_symbols dir syms env =
-  { env with native_symbols = DPmap.add dir syms env.native_symbols }
 
 module type QNameS =
 sig

--- a/kernel/environ.mli
+++ b/kernel/environ.mli
@@ -90,7 +90,6 @@ type env = private {
   env_typing_flags  : typing_flags;
   retroknowledge : Retroknowledge.retroknowledge;
   indirect_pterms : Opaqueproof.opaquetab;
-  native_symbols : Nativevalues.symbols DPmap.t;
 }
 
 val oracle : env -> Conv_oracle.oracle
@@ -414,6 +413,3 @@ val no_link_info : link_info
 
 (** Primitives *)
 val set_retroknowledge : env -> Retroknowledge.retroknowledge -> env
-
-val set_native_symbols : env -> Nativevalues.symbols DPmap.t -> env
-val add_native_symbols : DirPath.t -> Nativevalues.symbols -> env -> env

--- a/kernel/nativecode.ml
+++ b/kernel/nativecode.ml
@@ -2192,11 +2192,9 @@ let mk_norm_code env sigma prefix t =
       [|MLglobal (Ginternal "()")|])) in
   header::gl, (mind_updates, const_updates)
 
-let mk_library_header dir =
-  let libname = Format.sprintf "(str_decode \"%s\")" (str_encode dir) in
-  [Glet(Ginternal "symbols_tbl",
-    MLapp (MLglobal (Ginternal "get_library_native_symbols"),
-    [|MLglobal (Ginternal libname)|]))]
+let mk_library_header (symbols : Nativevalues.symbols) =
+  let symbols = Format.sprintf "(str_decode \"%s\")" (str_encode symbols) in
+  [Glet(Ginternal "symbols_tbl", MLglobal (Ginternal symbols))]
 
 let update_location (r,v) = r := v
 

--- a/kernel/nativecode.mli
+++ b/kernel/nativecode.mli
@@ -69,7 +69,7 @@ val compile_mind_field : ModPath.t -> Label.t ->
 val mk_conv_code : env -> evars -> string -> constr -> constr -> linkable_code
 val mk_norm_code : env -> evars -> string -> constr -> linkable_code
 
-val mk_library_header : DirPath.t -> global list
+val mk_library_header : Nativevalues.symbols -> global list
 
 val mod_uid_of_dirpath : DirPath.t -> string
 

--- a/kernel/nativeconv.ml
+++ b/kernel/nativeconv.ml
@@ -161,7 +161,7 @@ let native_conv_gen pb sigma env univs t1 t2 =
   let fn = compile ml_filename code ~profile:false in
   if !Flags.debug then Feedback.msg_debug (Pp.str "Running test...");
   let t0 = Sys.time () in
-  call_linker env ~fatal:true ~prefix fn (Some upds);
+  call_linker ~fatal:true ~prefix fn (Some upds);
   let t1 = Sys.time () in
   let time_info = Format.sprintf "Evaluation done in %.5f@." (t1 -. t0) in
   if !Flags.debug then Feedback.msg_debug (Pp.str time_info);

--- a/kernel/nativelib.mli
+++ b/kernel/nativelib.mli
@@ -27,27 +27,24 @@ val get_ml_filename : unit -> string * string
    whether are in byte mode or not; file is expected to be .ml file *)
 val compile : string -> global list -> profile:bool -> string
 
-(** [compile_library lib code file] is similar to [compile file code]
+type native_library = Nativecode.global list * Nativevalues.symbols
+
+(** [compile_library (code, _) file] is similar to [compile file code]
    but will perform some extra tweaks to handle [code] as a Coq lib. *)
-val compile_library : Names.DirPath.t -> global list -> string -> unit
+val compile_library : native_library -> string -> unit
 
 val call_linker
   : ?fatal:bool
-  -> Environ.env
   -> prefix:string
   -> string
   -> code_location_updates option
   -> unit
 
 val link_library
-  : Environ.env
-  -> prefix:string
+  : prefix:string
   -> dirname:string
   -> basename:string
   -> unit
 
 val rt1 : Nativevalues.t ref
 val rt2 : Nativevalues.t ref
-
-val get_library_native_symbols : Names.DirPath.t -> Nativevalues.symbols
-(** Strictly for usage by code produced by native compute. *)

--- a/kernel/safe_typing.mli
+++ b/kernel/safe_typing.mli
@@ -191,8 +191,6 @@ val current_dirpath : safe_environment -> DirPath.t
 
 type compiled_library
 
-type native_library = Nativecode.global list
-
 val module_of_library : compiled_library -> Declarations.module_body
 val univs_of_library : compiled_library -> Univ.ContextSet.t
 
@@ -201,7 +199,7 @@ val start_library : DirPath.t -> ModPath.t safe_transformer
 val export :
   ?except:Future.UUIDSet.t -> output_native_objects:bool ->
   safe_environment -> DirPath.t ->
-    ModPath.t * compiled_library * native_library
+    ModPath.t * compiled_library * Nativelib.native_library
 
 (* Constraints are non empty iff the file is a vi2vo *)
 val import : compiled_library -> Univ.ContextSet.t -> vodigest ->

--- a/library/global.mli
+++ b/library/global.mli
@@ -134,7 +134,7 @@ val body_of_constant_body : Opaqueproof.indirect_accessor ->
 
 val start_library : DirPath.t -> ModPath.t
 val export : ?except:Future.UUIDSet.t -> output_native_objects:bool -> DirPath.t ->
-  ModPath.t * Safe_typing.compiled_library * Safe_typing.native_library
+  ModPath.t * Safe_typing.compiled_library * Nativelib.native_library
 val import :
   Safe_typing.compiled_library -> Univ.ContextSet.t -> Safe_typing.vodigest ->
   ModPath.t

--- a/pretyping/nativenorm.ml
+++ b/pretyping/nativenorm.ml
@@ -525,7 +525,7 @@ let native_norm env sigma c ty =
     if print_timing then Feedback.msg_info (Pp.str time_info);
     let profiler_pid = if profile then start_profiler () else None in
     let t0 = Unix.gettimeofday () in
-    Nativelib.call_linker ~fatal:true env ~prefix fn (Some upd);
+    Nativelib.call_linker ~fatal:true ~prefix fn (Some upd);
     let t1 = Unix.gettimeofday () in
     if profile then stop_profiler profiler_pid;
     let time_info = Format.sprintf "native_compute: Evaluation done in %.5f" (t1 -. t0) in

--- a/vernac/declaremods.mli
+++ b/vernac/declaremods.mli
@@ -86,7 +86,7 @@ val start_library : library_name -> unit
 
 val end_library :
   ?except:Future.UUIDSet.t -> output_native_objects:bool -> library_name ->
-    Safe_typing.compiled_library * library_objects * Safe_typing.native_library
+    Safe_typing.compiled_library * library_objects * Nativelib.native_library
 
 (** append a function to be executed at end_library *)
 val append_end_library_hook : (unit -> unit) -> unit

--- a/vernac/library.ml
+++ b/vernac/library.ml
@@ -160,7 +160,7 @@ let register_loaded_library m =
     let prefix = Nativecode.mod_uid_of_dirpath libname ^ "." in
     let f = prefix ^ "cmo" in
     let f = Dynlink.adapt_filename f in
-    Nativelib.link_library (Global.env()) ~prefix ~dirname ~basename:f
+    Nativelib.link_library ~prefix ~dirname ~basename:f
   in
   let rec aux = function
     | [] ->
@@ -502,7 +502,7 @@ let save_library_to todo_proofs ~output_native_objects dir f otab =
   (* Writing native code files *)
   if output_native_objects then
     let fn = Filename.dirname f ^"/"^ Nativecode.mod_uid_of_dirpath dir in
-    Nativelib.compile_library dir ast fn
+    Nativelib.compile_library ast fn
 
 let save_library_raw f sum lib univs proofs =
   save_library_base f sum lib (Some univs) None proofs


### PR DESCRIPTION
Instead we store that data in the native code that was generated in adapt the compilation scheme accordingly. Less indirections and less imperative tinkering makes the code safer.

The global symbol table was originally introduced in #10359 as a way not to depend on the Global module in the generated code. By storing all the native-related information in the cmxs file itself, this PR also makes other changes easier, such as e.g. #13287.
