### PR TITLE
Fixes #13298: Search applied to primitive projections needs a correct typing environment 

### DIFF
--- a/doc/changelog/07-commands-and-options/13301-master+fix13298-bad-env-search-primitive-projections.rst
+++ b/doc/changelog/07-commands-and-options/13301-master+fix13298-bad-env-search-primitive-projections.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  Failures of :cmd:`Search` in the presence of primitive projections
+  (`#13301 <https://github.com/coq/coq/pull/13301>`_,
+  fixes `#13298 <https://github.com/coq/coq/issues/13298>`_,
+  by Hugo Herbelin).

--- a/test-suite/output/Search_bug13298.out
+++ b/test-suite/output/Search_bug13298.out
@@ -1,0 +1,1 @@
+snd: forall c : c, fst c = 0

--- a/test-suite/output/Search_bug13298.v
+++ b/test-suite/output/Search_bug13298.v
@@ -1,0 +1,3 @@
+Set Primitive Projections.
+Record c : Type := { fst : nat; snd : fst = 0 }.
+Search concl:fst.


### PR DESCRIPTION
**Kind:** bug fix

Fixes / closes #13298

- [X] Added / updated test-suite
- [x] Entry added in the changelog