### PR TITLE
Turn ssr proxy notation for supporting second-order/contextual pattern abbreviations to only parsing

### DIFF
--- a/theories/ssrmatching/ssrmatching.v
+++ b/theories/ssrmatching/ssrmatching.v
@@ -25,7 +25,7 @@ Declare Scope ssrpatternscope.
 Delimit Scope ssrpatternscope with pattern.
 
 (* Notation to define shortcuts for the "X in t" part of a pattern.           *)
-Notation "( X 'in' t )" := (_ : fun X => t) : ssrpatternscope.
+Notation "( X 'in' t )" := (_ : fun X => t) (only parsing) : ssrpatternscope.
 
 (* Some shortcuts for recurrent "X in t" parts.                               *)
 Notation RHS := (X in _ = X)%pattern.


### PR DESCRIPTION
**Kind:** compromise

The notation`"( X 'in' t )" := (_ : fun X => t)` is the only notation to date which experimentally breaks the heuristics of preferring the more precise notations for printing (see #12986). As far as I can judge, this notation is only used to provide abbreviations (namely `LHS`, `RHS`, `BIG_F` and `BIG_P`) towards the proxy encoding second-order/contextual patterns as terms, for the purpose of tactics supporting such patterns (e.g. `set`). In particular, being used only to define new abbreviations (since, as far as I understood, individual tactics have otherwise their one parser for such patterns), the printing rule seems in practice useless (e.g. `Print RHS` returns `RHS` and `About RHS` returns `Notation RHS := (_ : (fun X => _ = X))`. Thus, it seems acceptable to turn this notation into an only parsing which allows at the same time to limit the interferences with the notation system, such as reported in this comment of [#12986](https://github.com/coq/coq/pull/12986#issuecomment-722251397).

@ggonthier, @cohencyril, @gares: are you ok with this change?

Incidentally, did you think at extensions of the support for second-order expressions? Like e.g. binding `RHS`/`LHS` to a type class? Or to equip the `in` clause with such patterns? Or to extend it into a more general languages of patterns, e.g. based on Ltac's `context` and an `as` clause?
