### PR TITLE
[obligation] Properly handle no obligations on `Next Obligation`

### DIFF
--- a/test-suite/output/bug_13320.out
+++ b/test-suite/output/bug_13320.out
@@ -1,0 +1,2 @@
+The command has indeed failed with message:
+No obligations remaining

--- a/test-suite/output/bug_13320.v
+++ b/test-suite/output/bug_13320.v
@@ -1,0 +1,2 @@
+(* Next Obligation should fail normally, not with an anomaly. *)
+Fail Next Obligation.

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -2499,7 +2499,12 @@ let admit_obligations ~pm n =
 
 let next_obligation ~pm n tac =
   let prg = match n with
-    | None -> State.first_pending pm |> Option.get
+    | None ->
+      begin match State.first_pending pm with
+        | Some prg -> prg
+        | None ->
+          Error.no_obligations None
+      end
     | Some _ -> get_unique_prog ~pm n
   in
   let {obls; remaining} = Internal.get_obligations prg in


### PR DESCRIPTION
Fixes #13320 .

Trivial programming error, actually this is handled better in a
further refactoring branch not submitted due to the long time the
whole rework took.
