### PR TITLE
Fix running unit tests with dune compiled coq

### DIFF
--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -36,7 +36,8 @@ include ../Makefile.common
 # Note that this will later need an eval in shell to interpret the quotes
 ROOT='$(shell cd ..; pwd)'
 
-ifneq ($(wildcard ../_build),)
+ifneq ($(wildcard ../_build/default/config/Makefile),)
+include ../_build/default/config/Makefile
 BIN:=$(ROOT)/_build/install/default/bin/
 # COQLIB is an env variable so no quotes
 COQLIB:=$(shell cd ..; pwd)/_build/install/default/lib/coq


### PR DESCRIPTION
(for runs outside dune, ie "make -C test-suite unit-tests" rather than
"dune build @runtest")

Fix #13333 