### PR TITLE
Avoid exposing an internal name when "intros _ H" fails because of _ being dependent in H

### DIFF
--- a/doc/changelog/04-tactics/13337-master+improve-error-dependent-intro-wildcard.rst
+++ b/doc/changelog/04-tactics/13337-master+improve-error-dependent-intro-wildcard.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  Avoiding exposing an internal name of the form :n:`_tmp` when applying the
+  :n:`_` introduction pattern would break a dependency
+  (`#13337 <https://github.com/coq/coq/pull/13337>`_,
+  fixes `#13336 <https://github.com/coq/coq/issues/13336>`_,
+  by Hugo Herbelin).

--- a/test-suite/output/Tactics.out
+++ b/test-suite/output/Tactics.out
@@ -7,3 +7,5 @@ H is already used.
 The command has indeed failed with message:
 H is already used.
 a
+The command has indeed failed with message:
+This variable is used in hypothesis H.

--- a/test-suite/output/Tactics.v
+++ b/test-suite/output/Tactics.v
@@ -30,3 +30,11 @@ Goal True.
   assert_succeeds should_not_loop.
   assert_succeeds (idtac "a" + idtac "b"). (* should only output "a" *)
 Abort.
+
+Module IntroWildcard.
+
+Theorem foo : { p:nat*nat & p = (0,0) } -> True.
+Fail intros ((n,_),H).
+Abort.
+
+End IntroWildcard.


### PR DESCRIPTION
**Kind:** enhancement

Fixes / closes #13336. 

The new proposed error message is of the form "The variable is used in hypothesis id" (together with highlighting of the `_`).

- [X] Added / updated test-suite
- [x] Entry added in the changelog
