### PR TITLE
In -noinit mode, add support for Proof using, using is not a keyword.

### DIFF
--- a/doc/changelog/07-commands-and-options/13339-proof-using-noinit.rst
+++ b/doc/changelog/07-commands-and-options/13339-proof-using-noinit.rst
@@ -1,0 +1,5 @@
+- **Added:**
+  The :cmd:`Proof using` command can now be used without loading the
+  Ltac plugin (`-noinit` mode)
+  (`#13339 <https://github.com/coq/coq/pull/13339>`_,
+  by Théo Zimmermann).

--- a/plugins/ltac/g_ltac.mlg
+++ b/plugins/ltac/g_ltac.mlg
@@ -332,8 +332,8 @@ GRAMMAR EXTEND Gram
         l = OPT [ "using"; l = G_vernac.section_subset_expr -> { l } ] ->
           { Vernacexpr.VernacProof (Some (in_tac ta), l) }
       | IDENT "Proof"; "using"; l = G_vernac.section_subset_expr;
-        ta = OPT [ "with"; ta = Pltac.tactic -> { in_tac ta } ] ->
-          { Vernacexpr.VernacProof (ta,Some l) } ] ]
+        "with"; ta = Pltac.tactic ->
+          { Vernacexpr.VernacProof (Some (in_tac ta),Some l) } ] ]
   ;
   hint:
     [ [ IDENT "Extern"; n = natural; c = OPT Constr.constr_pattern ; "=>";

--- a/plugins/ltac/g_ltac.mlg
+++ b/plugins/ltac/g_ltac.mlg
@@ -329,9 +329,9 @@ GRAMMAR EXTEND Gram
   ;
   command:
     [ [ IDENT "Proof"; "with"; ta = Pltac.tactic;
-        l = OPT [ "using"; l = G_vernac.section_subset_expr -> { l } ] ->
+        l = OPT [ IDENT "using"; l = G_vernac.section_subset_expr -> { l } ] ->
           { Vernacexpr.VernacProof (Some (in_tac ta), l) }
-      | IDENT "Proof"; "using"; l = G_vernac.section_subset_expr;
+      | IDENT "Proof"; IDENT "using"; l = G_vernac.section_subset_expr;
         "with"; ta = Pltac.tactic ->
           { Vernacexpr.VernacProof (Some (in_tac ta),Some l) } ] ]
   ;

--- a/test-suite/success/proof_using_noinit.v
+++ b/test-suite/success/proof_using_noinit.v
@@ -1,0 +1,9 @@
+(* -*- coq-prog-args: ("-noinit"); -*- *)
+
+Section A.
+Variable A : Prop.
+Hypothesis a : A.
+Lemma b : A.
+Proof using a.
+Admitted.
+End A.

--- a/vernac/g_proofs.mlg
+++ b/vernac/g_proofs.mlg
@@ -56,6 +56,8 @@ GRAMMAR EXTEND Gram
     [ [ IDENT "Goal"; c = lconstr ->
         { VernacDefinition (Decls.(NoDischarge, Definition), ((CAst.make ~loc Names.Anonymous), None), ProveBody ([], c)) }
       | IDENT "Proof" -> { VernacProof (None,None) }
+      | IDENT "Proof"; "using"; l = G_vernac.section_subset_expr ->
+          { VernacProof (None,Some l) }
       | IDENT "Proof" ; IDENT "Mode" ; mn = string -> { VernacProofMode mn }
       | IDENT "Proof"; c = lconstr -> { VernacExactProof c }
       | IDENT "Abort" -> { VernacAbort None }

--- a/vernac/g_proofs.mlg
+++ b/vernac/g_proofs.mlg
@@ -56,7 +56,7 @@ GRAMMAR EXTEND Gram
     [ [ IDENT "Goal"; c = lconstr ->
         { VernacDefinition (Decls.(NoDischarge, Definition), ((CAst.make ~loc Names.Anonymous), None), ProveBody ([], c)) }
       | IDENT "Proof" -> { VernacProof (None,None) }
-      | IDENT "Proof"; "using"; l = G_vernac.section_subset_expr ->
+      | IDENT "Proof"; IDENT "using"; l = G_vernac.section_subset_expr ->
           { VernacProof (None,Some l) }
       | IDENT "Proof" ; IDENT "Mode" ; mn = string -> { VernacProofMode mn }
       | IDENT "Proof"; c = lconstr -> { VernacExactProof c }

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -114,7 +114,8 @@ GRAMMAR EXTEND Gram
   ;
   attribute:
     [ [ k = ident ; v = attr_value -> { Names.Id.to_string k, v }
-      | "using" ; v = attr_value -> { "using", v } ]
+      (* Required because "ident" is declared a keyword when loading Ltac. *)
+      | IDENT "using" ; v = attr_value -> { "using", v } ]
     ]
   ;
   attr_value:


### PR DESCRIPTION
**Kind:** fix / enhancement.

#13183 had to treat the `using` attribute specially because it is declared as a keyword in the Ltac plugin. Following this, we discovered that `Proof using` is not available in `-noinit` mode. This PR is two commits doing the following changes:
- make the `Proof using` syntax available to users of the `-noinit` mode (there is no reason why it shouldn't be the case)
- go back to `using` not being a keyword until you load Ltac (by adding two `IDENT`).

I'm open to dropping the second commit, or to extend it to also make `using` not a keyword in the Ltac plugin (although I don't know if that would work with the tactics that have a `using` clause).
If the second commit was dropped, then the documentation should be fixed instead (it has been incorrect regarding the status of `using` since #13183).

- [x] Added / updated test-suite
- [ ] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
