### PR TITLE
Cleanup of metasyntax.ml

### DIFF
--- a/dev/ci/user-overlays/13353-herbelin-master+metasyntax-cleaning.sh
+++ b/dev/ci/user-overlays/13353-herbelin-master+metasyntax-cleaning.sh
@@ -1,0 +1,1 @@
+overlay equations https://github.com/herbelin/Coq-Equations master+adapt13353-where-clause-notation-factoring 13353

--- a/interp/dumpglob.ml
+++ b/interp/dumpglob.ml
@@ -273,7 +273,7 @@ let dump_moddef ?loc mp ty =
   let mp = Names.DirPath.to_string (Names.DirPath.make l) in
   dump_def ?loc ty "<>" mp
 
-let dump_notation (loc,(df,_)) sc sec = Option.iter (fun loc ->
+let dump_notation {CAst.loc;v=df} sc sec = Option.iter (fun loc ->
   (* We dump the location of the opening '"' *)
   let i = fst (Loc.unloc loc) in
   let location = (Loc.make_loc (i, i+1)) in

--- a/interp/dumpglob.mli
+++ b/interp/dumpglob.mli
@@ -46,7 +46,7 @@ val dump_notation_location : (int * int) list -> Constrexpr.notation ->
   (Notation.notation_location * Notation_term.scope_name option) -> unit
 val dump_binding : ?loc:Loc.t -> string -> unit
 val dump_notation :
-  (Constrexpr.notation * Notation.notation_location) Loc.located ->
+  Constrexpr.notation CAst.t ->
   Notation_term.scope_name option -> bool -> unit
 
 val dump_constraint : Names.lname -> bool -> string -> unit

--- a/interp/notation.ml
+++ b/interp/notation.ml
@@ -2208,6 +2208,12 @@ let rec raw_analyze_anonymous_notation_tokens = function
 
 (* Interpret notations with a recursive component *)
 
+type notation_symbols = {
+  recvars : (Id.t * Id.t) list; (* pairs (x,y) as in [ x ; .. ; y ] *)
+  mainvars : Id.t list; (* variables non involved in a recursive pattern *)
+  symbols : symbol list; (* the decomposition of the notation into terminals and nonterminals *)
+}
+
 let out_nt = function NonTerminal x -> x | _ -> assert false
 
 let msg_expected_form_of_recursive_notation =
@@ -2256,10 +2262,10 @@ let get_notation_vars l =
 
 let decompose_raw_notation ntn =
   let l = split_notation_string ntn in
-  let l = raw_analyze_notation_tokens l in
-  let recvars,l = interp_list_parser [] l in
-  let vars = get_notation_vars l in
-  recvars, vars, l
+  let symbols = raw_analyze_notation_tokens l in
+  let recvars, symbols = interp_list_parser [] symbols in
+  let mainvars = get_notation_vars symbols in
+  {recvars; mainvars; symbols}
 
 let interpret_notation_string ntn =
   (* We collect the possible interpretations of a notation string depending on whether it is

--- a/interp/notation.mli
+++ b/interp/notation.mli
@@ -334,10 +334,16 @@ val symbol_eq : symbol -> symbol -> bool
 val make_notation_key : notation_entry -> symbol list -> notation
 val decompose_notation_key : notation -> notation_entry * symbol list
 
+type notation_symbols = {
+  recvars : (Id.t * Id.t) list; (* pairs (x,y) as in [ x ; .. ; y ] *)
+  mainvars : Id.t list; (* variables non involved in a recursive pattern *)
+  symbols : symbol list; (* the decomposition of the notation into terminals and nonterminals *)
+}
+
 (** Decompose a notation of the form "a 'U' b" together with the lists
     of pairs of recursive variables and the list of all variables
     binding in the notation *)
-val decompose_raw_notation : string -> (Id.t * Id.t) list * Id.t list * symbol list
+val decompose_raw_notation : string -> notation_symbols
 
 (** Prints scopes (expects a pure aconstr printer) *)
 val pr_scope_class : scope_class -> Pp.t

--- a/parsing/ppextend.ml
+++ b/parsing/ppextend.ml
@@ -47,7 +47,7 @@ type unparsing =
   | UnpBox of ppbox * unparsing Loc.located list
   | UnpCut of ppcut
 
-type unparsing_rule = unparsing list * entry_level
+type unparsing_rule = unparsing list
 type extra_unparsing_rules = (string * string) list
 
 let rec unparsing_eq unp1 unp2 = match (unp1,unp2) with
@@ -63,16 +63,27 @@ let rec unparsing_eq unp1 unp2 = match (unp1,unp2) with
 
 (* Register generic and specific printing rules *)
 
+type notation_printing_rules = {
+  notation_printing_unparsing : unparsing_rule;
+  notation_printing_level : entry_level;
+  notation_printing_extra : extra_unparsing_rules;
+}
+
+type generic_notation_printing_rules = {
+  notation_printing_reserved : bool;
+  notation_printing_rules : notation_printing_rules;
+}
+
 let generic_notation_printing_rules =
-  Summary.ref ~name:"generic-notation-printing-rules" (NotationMap.empty : (unparsing_rule * bool * extra_unparsing_rules) NotationMap.t)
+  Summary.ref ~name:"generic-notation-printing-rules" (NotationMap.empty : generic_notation_printing_rules NotationMap.t)
 
 let specific_notation_printing_rules =
-  Summary.ref ~name:"specific-notation-printing-rules" (SpecificNotationMap.empty : (unparsing_rule * extra_unparsing_rules) SpecificNotationMap.t)
+  Summary.ref ~name:"specific-notation-printing-rules" (SpecificNotationMap.empty : notation_printing_rules SpecificNotationMap.t)
 
-let declare_generic_notation_printing_rules ntn ~reserved ~extra unpl =
-  generic_notation_printing_rules := NotationMap.add ntn (unpl,reserved,extra) !generic_notation_printing_rules
-let declare_specific_notation_printing_rules specific_ntn ~extra unpl =
-  specific_notation_printing_rules := SpecificNotationMap.add specific_ntn (unpl,extra) !specific_notation_printing_rules
+let declare_generic_notation_printing_rules ntn rules =
+  generic_notation_printing_rules := NotationMap.add ntn rules !generic_notation_printing_rules
+let declare_specific_notation_printing_rules specific_ntn rules =
+  specific_notation_printing_rules := SpecificNotationMap.add specific_ntn rules !specific_notation_printing_rules
 
 let has_generic_notation_printing_rule ntn =
   NotationMap.mem ntn !generic_notation_printing_rules
@@ -86,20 +97,27 @@ let find_specific_notation_printing_rule specific_ntn =
 let find_notation_printing_rule which ntn =
   try match which with
   | None -> raise Not_found (* Normally not the case *)
-  | Some which -> fst (find_specific_notation_printing_rule (which,ntn))
-  with Not_found -> pi1 (find_generic_notation_printing_rule ntn)
+  | Some which -> (find_specific_notation_printing_rule (which,ntn))
+  with Not_found -> (find_generic_notation_printing_rule ntn).notation_printing_rules
 
 let find_notation_extra_printing_rules which ntn =
   try match which with
   | None -> raise Not_found
-  | Some which -> snd (find_specific_notation_printing_rule (which,ntn))
-  with Not_found -> pi3 (find_generic_notation_printing_rule ntn)
+  | Some which -> (find_specific_notation_printing_rule (which,ntn)).notation_printing_extra
+  with Not_found -> (find_generic_notation_printing_rule ntn).notation_printing_rules.notation_printing_extra
 
 let add_notation_extra_printing_rule ntn k v =
   try
     generic_notation_printing_rules :=
-      let p, b, pp = NotationMap.find ntn !generic_notation_printing_rules in
-      NotationMap.add ntn (p, b, (k,v) :: pp) !generic_notation_printing_rules
+      let { notation_printing_reserved; notation_printing_rules } = NotationMap.find ntn !generic_notation_printing_rules in
+      let rules = {
+          notation_printing_reserved;
+          notation_printing_rules = {
+              notation_printing_rules with
+              notation_printing_extra = (k,v) :: notation_printing_rules.notation_printing_extra
+            }
+        } in
+      NotationMap.add ntn rules !generic_notation_printing_rules
   with Not_found ->
     user_err ~hdr:"add_notation_extra_printing_rule"
       (str "No such Notation.")

--- a/parsing/ppextend.ml
+++ b/parsing/ppextend.ml
@@ -86,7 +86,8 @@ let declare_specific_notation_printing_rules specific_ntn rules =
   specific_notation_printing_rules := SpecificNotationMap.add specific_ntn rules !specific_notation_printing_rules
 
 let has_generic_notation_printing_rule ntn =
-  NotationMap.mem ntn !generic_notation_printing_rules
+  try (NotationMap.find ntn !generic_notation_printing_rules).notation_printing_reserved
+  with Not_found -> false
 
 let find_generic_notation_printing_rule ntn =
   NotationMap.find ntn !generic_notation_printing_rules

--- a/parsing/ppextend.mli
+++ b/parsing/ppextend.mli
@@ -40,16 +40,27 @@ type unparsing =
   | UnpBox of ppbox * unparsing Loc.located list
   | UnpCut of ppcut
 
-type unparsing_rule = unparsing list * entry_level
+type unparsing_rule = unparsing list
 type extra_unparsing_rules = (string * string) list
 
 val unparsing_eq : unparsing -> unparsing -> bool
 
-val declare_generic_notation_printing_rules : notation -> reserved:bool -> extra:extra_unparsing_rules -> unparsing_rule -> unit
-val declare_specific_notation_printing_rules : specific_notation -> extra:extra_unparsing_rules -> unparsing_rule -> unit
+type notation_printing_rules = {
+  notation_printing_unparsing : unparsing_rule;
+  notation_printing_level : entry_level;
+  notation_printing_extra : extra_unparsing_rules;
+}
+
+type generic_notation_printing_rules = {
+  notation_printing_reserved : bool;
+  notation_printing_rules : notation_printing_rules;
+}
+
+val declare_generic_notation_printing_rules : notation -> generic_notation_printing_rules -> unit
+val declare_specific_notation_printing_rules : specific_notation -> notation_printing_rules -> unit
 val has_generic_notation_printing_rule : notation -> bool
-val find_generic_notation_printing_rule : notation -> unparsing_rule * bool * extra_unparsing_rules
-val find_specific_notation_printing_rule : specific_notation -> unparsing_rule * extra_unparsing_rules
-val find_notation_printing_rule : notation_with_optional_scope option -> notation -> unparsing_rule
+val find_generic_notation_printing_rule : notation -> generic_notation_printing_rules
+val find_specific_notation_printing_rule : specific_notation -> notation_printing_rules
+val find_notation_printing_rule : notation_with_optional_scope option -> notation -> notation_printing_rules
 val find_notation_extra_printing_rules : notation_with_optional_scope option -> notation -> extra_unparsing_rules
 val add_notation_extra_printing_rule : notation -> string -> string -> unit

--- a/printing/ppconstr.ml
+++ b/printing/ppconstr.ml
@@ -129,7 +129,7 @@ let tag_var = tag Tag.variable
     aux unps
 
   let pr_notation pr pr_patt pr_binders which s env =
-    let unpl, level = find_notation_printing_rule which s in
+    let { notation_printing_unparsing = unpl; notation_printing_level = level } = find_notation_printing_rule which s in
     print_hunks level pr pr_patt pr_binders env unpl, level
 
   let pr_delimiters key strm =

--- a/test-suite/output/NotationSyntax.out
+++ b/test-suite/output/NotationSyntax.out
@@ -1,0 +1,12 @@
+File "./output/NotationSyntax.v", line 2, characters 19-29:
+Warning: Notations for numbers are primitive; skipping this modifier.
+[primitive-token-modifier,parsing]
+The command has indeed failed with message:
+"only parsing" is given more than once.
+The command has indeed failed with message:
+A notation cannot be both "only printing" and "only parsing".
+The command has indeed failed with message:
+"only printing" is given more than once.
+File "./output/NotationSyntax.v", line 6, characters 33-43:
+Warning: The format modifier is irrelevant for only-parsing rules.
+[irrelevant-format-only-parsing,parsing]

--- a/test-suite/output/NotationSyntax.v
+++ b/test-suite/output/NotationSyntax.v
@@ -1,0 +1,6 @@
+(* Various meaningless notations *)
+Notation "1" := 0 (at level 3).
+Fail Notation "#" := 0 (only parsing, only parsing).
+Fail Notation "#" := 0 (only parsing, only printing).
+Fail Notation "#" := 0 (only printing, only printing).
+Notation "#" := 0 (only parsing, format "#").

--- a/test-suite/output/Notations4.out
+++ b/test-suite/output/Notations4.out
@@ -99,10 +99,10 @@ format. [notation-incompatible-format,parsing]
      : nat
 3   %%   4
      : nat
-File "./output/Notations4.v", line 235, characters 0-61:
-Warning: The format modifier is irrelevant for only parsing rules.
+File "./output/Notations4.v", line 235, characters 47-59:
+Warning: The format modifier is irrelevant for only-parsing rules.
 [irrelevant-format-only-parsing,parsing]
-File "./output/Notations4.v", line 239, characters 0-63:
+File "./output/Notations4.v", line 239, characters 36-48:
 Warning: The only parsing modifier has no effect in Reserved Notation.
 [irrelevant-reserved-notation-only-parsing,parsing]
 fun x : nat => U (S x)

--- a/test-suite/output/Notations4.out
+++ b/test-suite/output/Notations4.out
@@ -203,3 +203,5 @@ Unexpected type constraint in notation already providing a type constraint.
      : Prop
 fun f : ## a (a = 0) => f 1 eq_refl
      : ## a (a = 0) -> 1 = 0
+[MyNotation 0]
+     : nat

--- a/test-suite/output/Notations4.v
+++ b/test-suite/output/Notations4.v
@@ -465,3 +465,12 @@ Check ## '((x,y):nat*nat) (x=0).
 Check fun (f : ## {a} (a=0)) => f (a:=1) eq_refl.
 
 End SingleBinder.
+
+Module GenericFormatPrecedence.
+(* Check that if a generic format exists, we use it preferably to no
+   explicit generic format *)
+Notation "[ 'MyNotation' G ]" := (S G) (at level 0, format "[ 'MyNotation'  G ]") : nat_scope.
+Notation "[ 'MyNotation' G ]" := (G+0) (at level 0, only parsing) : bool_scope.
+Notation "[ 'MyNotation' G ]" := (G*0).
+Check 0*0.
+End GenericFormatPrecedence.

--- a/test-suite/output/allBytes.out
+++ b/test-suite/output/allBytes.out
@@ -1,1 +1,4 @@
-!"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~
+File "./output/allBytes.v", line 21, characters 0-44:
+Warning: Lonely notation "" was already defined with a different format.
+[notation-incompatible-format,parsing]
+ !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~ 

--- a/test-suite/output/notation_principal_scope.out
+++ b/test-suite/output/notation_principal_scope.out
@@ -4,7 +4,7 @@ used in the empty scope stack. Scope function_scope will be used at parsing
 time unless you override it by annotating the argument with an explicit scope
 of choice. [inconsistent-scopes,syntax]
 The command has indeed failed with message:
-Simple notations don't support only printing
+Abbreviations don't support only printing
 The command has indeed failed with message:
 The reference nonexisting was not found in the current environment.
 The command has indeed failed with message:

--- a/vernac/comInductive.ml
+++ b/vernac/comInductive.ml
@@ -633,6 +633,7 @@ type uniform_inductive_flag =
 
 let do_mutual_inductive ~template udecl indl ~cumulative ~poly ?typing_flags ~private_ind ~uniform finite =
   let (params,indl),coes,ntns = extract_mutual_inductive_declaration_components indl in
+  let ntns = List.map Metasyntax.prepare_where_notation ntns in
   (* Interpret the types *)
   let indl = match params with
     | uparams, Some params -> (uparams, params, indl)
@@ -646,7 +647,7 @@ let do_mutual_inductive ~template udecl indl ~cumulative ~poly ?typing_flags ~pr
   (* Declare the mutual inductive block with its associated schemes *)
   ignore (DeclareInd.declare_mutual_inductive_with_eliminations ?typing_flags mie pl impls);
   (* Declare the possible notations of inductive types *)
-  List.iter (Metasyntax.add_notation_interpretation (Global.env ())) ntns;
+  List.iter (Metasyntax.add_notation_interpretation ~local:false (Global.env ())) ntns;
   (* Declare the coercions *)
   List.iter (fun qid -> ComCoercion.try_add_new_coercion (Nametab.locate qid) ~local:false ~poly) coes
 

--- a/vernac/comProgramFixpoint.ml
+++ b/vernac/comProgramFixpoint.ml
@@ -332,7 +332,7 @@ let do_program_recursive ~pm ~scope ~poly ?typing_flags ?using fixkind fixl =
   | Declare.Obls.IsFixpoint _ -> Decls.(IsDefinition Fixpoint)
   | Declare.Obls.IsCoFixpoint -> Decls.(IsDefinition CoFixpoint)
   in
-  let ntns = List.map_append (fun { Vernacexpr.notations } -> notations ) fixl in
+  let ntns = List.map_append (fun { Vernacexpr.notations } -> List.map Metasyntax.prepare_where_notation notations ) fixl in
   let info = Declare.Info.make ~poly ~scope ~kind ~udecl ?typing_flags () in
   Declare.Obls.add_mutual_definitions ~pm defs ~info ~uctx ~ntns fixkind
 

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -622,7 +622,7 @@ let declare_mutually_recursive_core ~info ~cinfo ~opaque ~ntns ~uctx ~rec_declar
   let isfix = Option.has_some possible_indexes in
   let fixnames = List.map (fun { CInfo.name } -> name) cinfo in
   recursive_message isfix indexes fixnames;
-  List.iter (Metasyntax.add_notation_interpretation (Global.env())) ntns;
+  List.iter (Metasyntax.add_notation_interpretation ~local:(scope=Locality.Discharge) (Global.env())) ntns;
   csts
 
 let declare_mutually_recursive = declare_mutually_recursive_core ~restrict_ucontext:true ()
@@ -748,7 +748,7 @@ module ProgramDecl = struct
     ; prg_obligations : obligations
     ; prg_deps : Id.t list
     ; prg_fixkind : fixpoint_kind option
-    ; prg_notations : Vernacexpr.decl_notation list
+    ; prg_notations : Metasyntax.where_decl_notation list
     ; prg_reduce : constr -> constr
     }
 

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -143,7 +143,7 @@ val declare_mutually_recursive
   : info:Info.t
   -> cinfo: Constr.t CInfo.t list
   -> opaque:bool
-  -> ntns:Vernacexpr.decl_notation list
+  -> ntns:Metasyntax.where_decl_notation list
   -> uctx:UState.t
   -> rec_declaration:Constr.rec_declaration
   -> possible_indexes:lemma_possible_guards option
@@ -515,7 +515,7 @@ val add_mutual_definitions :
   -> ?tactic:unit Proofview.tactic
   -> ?reduce:(Constr.t -> Constr.t)
   -> ?opaque:bool
-  -> ntns:Vernacexpr.decl_notation list
+  -> ntns:Metasyntax.where_decl_notation list
   -> fixpoint_kind
   -> OblState.t
 

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -1222,8 +1222,8 @@ GRAMMAR EXTEND Gram
       | IDENT "format"; s1 = [s = STRING -> { CAst.make ~loc s } ];
                         s2 = OPT [s = STRING -> { CAst.make ~loc s } ] ->
           { begin match s1, s2 with
-          | { CAst.v = k }, Some s -> SetFormat(k,s)
-          | s, None -> SetFormat ("text",s) end }
+          | { CAst.v = k }, Some s -> SetFormat (ExtraFormat (k,s))
+          | s, None -> SetFormat (TextFormat s) end }
       | x = IDENT; ","; l = LIST1 IDENT SEP ","; v =
           [ "at"; lev = level -> { fun x l -> SetItemLevel (x::l,None,lev) }
           | "in"; IDENT "scope"; k = IDENT -> { fun x l -> SetItemScope(x::l,k) } ] -> { v x l }
@@ -1235,7 +1235,7 @@ GRAMMAR EXTEND Gram
     ] ]
   ;
   syntax_modifiers:
-    [ [ "("; l = LIST1 syntax_modifier SEP ","; ")" -> { l }
+    [ [ "("; l = LIST1 [ s = syntax_modifier -> { CAst.make ~loc s } ] SEP ","; ")" -> { l }
       | -> { [] }
     ] ]
   ;

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -1194,12 +1194,12 @@ GRAMMAR EXTEND Gram
      | IDENT "Reserved"; IDENT "Infix"; s = ne_lstring;
          l = syntax_modifiers ->
            { let s = CAst.map (fun s -> "x '"^s^"' y") s in
-           VernacSyntaxExtension (true,(s,l)) }
+           VernacReservedNotation (true,(s,l)) }
 
      | IDENT "Reserved"; IDENT "Notation";
          s = ne_lstring;
          l = syntax_modifiers
-         -> { VernacSyntaxExtension (false, (s,l)) }
+         -> { VernacReservedNotation (false, (s,l)) }
 
      (* "Print" "Grammar" and "Declare" "Scope" should be here but are in "command" entry in order
         to factorize with other "Print"-based or "Declare"-based vernac entries *)

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -1625,7 +1625,7 @@ let make_notation_interpretation ~local main_data notation_symbols ntn syntax_ru
 
 (* Notations without interpretation (Reserved Notation) *)
 
-let add_syntax_extension ~local ~infix ({CAst.loc;v=df},mods) =
+let add_reserved_notation ~local ~infix ({CAst.loc;v=df},mods) =
   let open SynData in
   let (main_data,mods) = interp_non_syntax_modifiers ~reserved:true ~infix ~syndef:false None mods in
   let mods = interp_modifiers main_data.entry mods in

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -1536,7 +1536,7 @@ let make_parsing_rules main_data (sd : SynData.syn_data) = let open SynData in
   in {
     synext_level    = sd.level;
     synext_notgram  = pa_rule;
-    synext_nottyps = sd.not_data.typs_for_grammar;
+    synext_nottyps = sd.subentries;
   }
 
 let make_printing_rules reserved main_data sd =

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -14,6 +14,7 @@ open Util
 open Names
 open Constrexpr
 open Constrexpr_ops
+open Vernacexpr
 open Notation_term
 open Notation_gram
 open Notation_ops
@@ -21,7 +22,6 @@ open Ppextend
 open Extend
 open Libobject
 open Constrintern
-open Vernacexpr
 open Libnames
 open Notation
 open Nameops
@@ -210,10 +210,10 @@ let is_numeral_in_constr entry symbs =
   | _ ->
       false
 
-let analyze_notation_tokens ~onlyprint df =
+let analyze_notation_tokens ~onlyprinting df =
   let (recvars,mainvars,symbols as res) = decompose_raw_notation df in
     (* don't check for nonlinearity if printing only, see Bug 5526 *)
-  (if not onlyprint then
+  (if not onlyprinting then
     match List.duplicates Id.equal (mainvars @ List.map snd recvars) with
     | id :: _ ->
         user_err ~hdr:"Metasyntax.get_notation_vars"
@@ -724,10 +724,9 @@ let warn_incompatible_format =
        strbrk " was already defined with a different format" ++ scope ++ str ".")
 
 type syntax_parsing_extension = {
-  synext_level : Notation.level;
-  synext_notation : notation;
+  synext_level : level;
   synext_notgram : notation_grammar option;
-  synext_nottyps : Extend.constr_entry_key list;
+  synext_nottyps : constr_entry_key list;
 }
 
 type syntax_printing_extension = {
@@ -765,7 +764,7 @@ let specific_format_to_declare (specific,ntn as specific_ntn)
   with Not_found -> true
 
 type syntax_extension_obj =
-  locality_flag * (syntax_parsing_extension * syntax_printing_extension option)
+  locality_flag * (notation * syntax_parsing_extension * syntax_printing_extension option)
 
 let check_and_extend_constr_grammar ntn rule =
   try
@@ -786,8 +785,7 @@ let check_and_extend_constr_grammar ntn rule =
   with Not_found ->
     Egramcoq.extend_constr_grammar rule
 
-let cache_one_syntax_extension (pa_se,pp_se) =
-  let ntn = pa_se.synext_notation in
+let cache_one_syntax_extension (ntn,pa_se,pp_se) =
   let prec = pa_se.synext_level in
   (* Check and ensure that the level and the precomputed parsing rule is declared *)
   let oldparsing =
@@ -830,9 +828,9 @@ let subst_parsing_rule subst x = x
 
 let subst_printing_rule subst x = x
 
-let subst_syntax_extension (subst, (local, (pa_sy,pp_sy))) =
-  (local, ({ pa_sy with
-    synext_notgram = Option.map (List.map (subst_parsing_rule subst)) pa_sy.synext_notgram },
+let subst_syntax_extension (subst, (local, (ntn,pa_sy,pp_sy))) =
+  (local, (ntn,
+    { pa_sy with synext_notgram = Option.map (List.map (subst_parsing_rule subst)) pa_sy.synext_notgram },
     Option.map (fun pp_sy -> {pp_sy with synext_unparsing = subst_printing_rule subst pp_sy.synext_unparsing}) pp_sy)
   )
 
@@ -856,51 +854,14 @@ let inSyntaxExtension : syntax_extension_obj -> obj =
 
 (* XXX: We could move this to the parser itself *)
 
-module SyndefMods = struct
-
-type t = {
-  only_parsing  : bool;
-  scopes : (Id.t * scope_name) list;
-}
-
-let default = {
-  only_parsing  = false;
-  scopes = [];
-}
-
-end
-
-let interp_syndef_modifiers modl = let open SyndefMods in
-  let rec interp skipped acc = function
-    | [] -> List.rev skipped, acc
-    | SetOnlyParsing :: l ->
-        interp skipped { acc with only_parsing = true; } l
-    | SetItemScope([],_) :: l ->
-        interp skipped acc l
-    | SetItemScope(s::ids,k) :: l ->
-        let scopes = acc.scopes in
-        let id = Id.of_string s in
-        if List.mem_assoc id scopes then
-          user_err (str "Notation scope for argument " ++ str s ++
-                    str " can be specified only once.");
-        interp skipped { acc with scopes = (id,k) :: scopes }
-          (SetItemScope(ids,s) :: l)
-    | x :: l ->
-        interp (x :: skipped) acc l
- in
-   interp [] default modl
-
 module NotationMods = struct
 
 type notation_modifier = {
   assoc         : Gramlib.Gramext.g_assoc option;
   level         : int option;
-  custom        : notation_entry;
   etyps         : (Id.t * simple_constr_prod_entry_key) list;
-  subtyps       : (Id.t * production_level) list;
 
   (* common to syn_data below *)
-  only_printing : bool;
   format        : lstring option;
   extra         : (string * string) list;
 }
@@ -908,10 +869,7 @@ type notation_modifier = {
 let default = {
   assoc         = None;
   level         = None;
-  custom        = InConstrEntry;
   etyps         = [];
-  subtyps       = [];
-  only_printing = false;
   format        = None;
   extra         = [];
 }
@@ -923,82 +881,61 @@ let warn_deprecated_ident_entry =
   CWarnings.create ~name:"deprecated-ident-entry" ~category:"deprecated"
          (fun () -> strbrk "grammar entry \"ident\" permitted \"_\" in addition to proper identifiers; this use is deprecated and its meaning will change in the future; use \"name\" instead.")
 
-let interp_modifiers modl = let open NotationMods in
+let interp_modifiers entry modl = let open NotationMods in
   let rec interp subtyps acc = function
-    | [] -> subtyps, acc
-    | SetEntryType (s,typ) :: l ->
+  | [] -> subtyps, acc
+  | CAst.{loc;v} :: l -> match v with
+    | SetEntryType (s,typ) ->
         let id = Id.of_string s in
         if Id.List.mem_assoc id acc.etyps then
-          user_err ~hdr:"Metasyntax.interp_modifiers"
+          user_err ?loc ~hdr:"Metasyntax.interp_modifiers"
             (str s ++ str " is already assigned to an entry or constr level.");
         interp subtyps { acc with etyps = (id,typ) :: acc.etyps; } l
-    | SetItemLevel ([],bko,n) :: l ->
+    | SetItemLevel ([],bko,n) ->
         interp subtyps acc l
-    | SetItemLevel (s::idl,bko,n) :: l ->
+    | SetItemLevel (s::idl,bko,n) ->
         let id = Id.of_string s in
         if Id.List.mem_assoc id acc.etyps then
-          user_err ~hdr:"Metasyntax.interp_modifiers"
+          user_err ?loc ~hdr:"Metasyntax.interp_modifiers"
             (str s ++ str " is already assigned to an entry or constr level.");
-        interp ((id,bko,n)::subtyps) acc (SetItemLevel (idl,bko,n)::l)
-    | SetLevel n :: l ->
-        (match acc.custom with
+        interp ((id,bko,n)::subtyps) acc ((CAst.make ?loc @@ SetItemLevel (idl,bko,n))::l)
+    | SetLevel n ->
+        (match entry with
         | InCustomEntry s ->
           if acc.level <> None then
-            user_err (str ("isolated \"at level " ^ string_of_int n ^ "\" unexpected."))
+            user_err ?loc (str ("isolated \"at level " ^ string_of_int n ^ "\" unexpected."))
           else
-            user_err (str ("use \"in custom " ^ s ^ " at level " ^ string_of_int n ^
+            user_err ?loc (str ("use \"in custom " ^ s ^ " at level " ^ string_of_int n ^
                          "\"") ++ spc () ++ str "rather than" ++ spc () ++
                          str ("\"at level " ^ string_of_int n ^ "\"") ++
                          spc () ++ str "isolated.")
         | InConstrEntry ->
           if acc.level <> None then
-            user_err (str "A level is already assigned.");
+            user_err ?loc (str "A level is already assigned.");
           interp subtyps { acc with level = Some n; } l)
-    | SetCustomEntry (s,n) :: l ->
+    | SetCustomEntry (s,Some n) ->
+        (* Note: name of entry already registered in interp_non_syntax_modifiers *)
         if acc.level <> None then
-          (if n = None then
-            user_err (str ("use \"in custom " ^ s ^ " at level " ^
-                         string_of_int (Option.get acc.level) ^
-                         "\"") ++ spc () ++ str "rather than" ++ spc () ++
-                         str ("\"at level " ^
-                         string_of_int (Option.get acc.level) ^ "\"") ++
-                         spc () ++ str "isolated.")
-          else
-            user_err (str ("isolated \"at level " ^ string_of_int (Option.get acc.level) ^ "\" unexpected.")));
-        if acc.custom <> InConstrEntry then
-           user_err (str "Entry is already assigned to custom " ++ str s ++ (match acc.level with None -> mt () | Some lev -> str " at level " ++ int lev) ++ str ".");
-        interp subtyps { acc with custom = InCustomEntry s; level = n } l
-    | SetAssoc a :: l ->
-        if not (Option.is_empty acc.assoc) then user_err Pp.(str "An associativity is given more than once.");
+          user_err ?loc (str ("isolated \"at level " ^ string_of_int (Option.get acc.level) ^ "\" unexpected."));
+        interp subtyps { acc with level = Some n } l
+    | SetAssoc a ->
+        if not (Option.is_empty acc.assoc) then user_err ?loc Pp.(str "An associativity is given more than once.");
         interp subtyps { acc with assoc = Some a; } l
-    | SetOnlyPrinting :: l ->
-        interp subtyps { acc with only_printing = true; } l
-    | SetFormat ("text",s) :: l ->
-        if not (Option.is_empty acc.format) then user_err Pp.(str "A format is given more than once.");
-        interp subtyps { acc with format = Some s; } l
-    | SetFormat (k,s) :: l ->
-        interp subtyps { acc with extra = (k,s.CAst.v)::acc.extra; } l
-    | (SetOnlyParsing | SetItemScope _) :: _ -> assert false
+    | SetOnlyParsing | SetOnlyPrinting | SetCustomEntry (_,None) | SetFormat _ | SetItemScope _ ->
+        (* interpreted in interp_non_syntax_modifiers *)
+        assert false
   in
-  let modl, syndef_mods = interp_syndef_modifiers modl in
   let subtyps, mods = interp [] default modl in
   (* interpret item levels wrt to main entry *)
-  let extra_etyps = List.map (fun (id,bko,n) -> (id,ETConstr (mods.custom,bko,n))) subtyps in
+  let extra_etyps = List.map (fun (id,bko,n) -> (id,ETConstr (entry,bko,n))) subtyps in
   (* Temporary hack: "ETName false" (i.e. "ident" in deprecation phase) means "ETIdent" for custom entries *)
   let mods =
     { mods with etyps = List.map (function
         | (id,ETName false) ->
-           if mods.custom = InConstrEntry then (warn_deprecated_ident_entry (); (id,ETName true))
+           if entry = InConstrEntry then (warn_deprecated_ident_entry (); (id,ETName true))
            else (id,ETIdent)
         | x -> x) mods.etyps } in
-  syndef_mods, { mods with etyps = extra_etyps@mods.etyps }
-
-let check_infix_modifiers modifiers =
-  let _, mods = interp_modifiers modifiers in
-  let t = mods.NotationMods.etyps in
-  let u = mods.NotationMods.subtyps in
-  if not (List.is_empty t) || not (List.is_empty u) then
-    user_err Pp.(str "Explicit entry level or type unexpected in infix notation.")
+  { mods with etyps = extra_etyps@mods.etyps }
 
 let check_useless_entry_types recvars mainvars etyps =
   let vars = let (l1,l2) = List.split recvars in l1@l2@mainvars in
@@ -1007,14 +944,90 @@ let check_useless_entry_types recvars mainvars etyps =
                   (Id.print x ++ str " is unbound in the notation.")
   | _ -> ()
 
-let interp_non_syntax_modifiers mods =
-  let set modif (only_parsing,only_printing,entry) = match modif with
-    | SetOnlyParsing -> Some (true,only_printing,entry)
-    | SetOnlyPrinting -> Some (only_parsing,true,entry)
-    | SetCustomEntry(entry,None) -> Some (only_parsing,only_printing,InCustomEntry entry)
-    | _ -> None
+type notation_main_data = {
+  onlyparsing  : bool;
+  onlyprinting : bool;
+  deprecation  : Deprecation.t option;
+  entry        : notation_entry;
+  format       : unparsing Loc.located list option;
+  extra        : (string * string) list;
+  itemscopes  : (Id.t * scope_name) list;
+}
+
+let warn_only_parsing_reserved_notation =
+  CWarnings.create ~name:"irrelevant-reserved-notation-only-parsing" ~category:"parsing"
+    (fun () -> strbrk "The only parsing modifier has no effect in Reserved Notation.")
+
+let warn_only_parsing_discarded_format =
+  CWarnings.create ~name:"discarded-format-only-parsing" ~category:"parsing"
+    (fun () -> strbrk "The format modifier has no effect for only-parsing notations.")
+
+let error_onlyparsing_onlyprinting ?loc =
+  user_err ?loc (str "A notation cannot be both \"only printing\" and \"only parsing\".")
+
+let set_onlyparsing ?loc ~reserved main_data =
+  if reserved then
+    (warn_only_parsing_reserved_notation ?loc ();
+     main_data)
+  else
+    (if main_data.onlyparsing then user_err ?loc (str "\"only parsing\" is given more than once.");
+     if main_data.onlyprinting then error_onlyparsing_onlyprinting ?loc;
+     { main_data with onlyparsing = true })
+
+let set_onlyprinting ?loc main_data =
+  if main_data.onlyprinting then user_err ?loc (str "\"only printing\" is given more than once.");
+  if main_data.onlyparsing then error_onlyparsing_onlyprinting ?loc;
+  { main_data with onlyprinting = true }
+
+let set_custom_entry ?loc main_data entry' =
+  match main_data.entry with
+  | InConstrEntry -> { main_data with entry = InCustomEntry entry' }
+  | _ -> user_err ?loc (str "\"in custom\" is given more than once.")
+
+let warn_irrelevant_format =
+  CWarnings.create ~name:"irrelevant-format-only-parsing" ~category:"parsing"
+    (fun () -> str "The format modifier is irrelevant for only-parsing rules.")
+
+let set_format ?loc main_data format =
+  if not (Option.is_empty main_data.format) then user_err ?loc Pp.(str "A format is given more than once.");
+  let format = if main_data.onlyparsing then (warn_irrelevant_format ?loc (); None) else Some (parse_format format) in
+  { main_data with format }
+
+let set_extra_format ?loc main_data (k,s) =
+  if List.mem_assoc k main_data.extra then user_err ?loc Pp.(str "A format for " ++ str k ++ str " is given more than once.");
+  let extra = if main_data.onlyparsing then (warn_irrelevant_format ?loc (); main_data.extra) else (k,s.CAst.v)::main_data.extra in
+  { main_data with extra }
+
+let set_item_scope ?loc main_data ids sc =
+  let itemscopes = List.map (fun id -> (Id.of_string id,sc)) ids @ main_data.itemscopes in
+  match List.duplicates (fun (id1,_) (id2,_) -> Id.equal id1 id2) itemscopes  with
+  | (id,_)::_ -> user_err ?loc (str "Notation scope for argument " ++ Id.print id ++ str " can be specified only once.")
+  | [] -> { main_data with itemscopes }
+
+let interp_non_syntax_modifiers ~reserved ~infix ~syndef deprecation mods =
+  let set (main_data,rest) = CAst.with_loc_val (fun ?loc -> function
+    | SetOnlyParsing ->
+       if not (Option.is_empty main_data.format && List.is_empty main_data.extra) then
+         (warn_only_parsing_discarded_format ?loc (); (main_data, rest))
+       else
+         (set_onlyparsing ?loc ~reserved main_data,rest)
+    | SetOnlyPrinting when not syndef -> (set_onlyprinting ?loc main_data,rest)
+    | SetCustomEntry (entry,None) when not syndef -> (set_custom_entry ?loc main_data entry,rest)
+    | SetCustomEntry (entry,Some _) as x when not syndef -> (set_custom_entry main_data entry,CAst.make ?loc x :: rest)
+    | SetEntryType _ when infix -> user_err ?loc Pp.(str "Unexpected entry type in infix notation.")
+    | SetItemLevel _ when infix -> user_err ?loc Pp.(str "Unexpected entry level in infix notation.")
+    | SetFormat (TextFormat s) when not syndef -> (set_format ?loc main_data s, rest)
+    | SetFormat (ExtraFormat (k,s)) when not syndef -> (set_extra_format ?loc main_data (k,s), rest)
+    | SetItemScope (ids,sc) -> (set_item_scope ?loc main_data ids sc, rest)
+    | modif -> (main_data,(CAst.make ?loc modif)::rest))
   in
-  List.fold_left (fun st modif -> Option.bind st @@ set modif) (Some (false,false,InConstrEntry)) mods
+  let main_data =
+    {
+      onlyparsing = false; onlyprinting = false; deprecation;
+      entry = InConstrEntry; format = None; extra = []; itemscopes = []
+    }
+  in
+  List.fold_left set (main_data,[]) mods
 
 (* Check if an interpretation can be used for printing a cases printing *)
 let has_no_binders_type =
@@ -1162,16 +1175,16 @@ let is_coercion level typs =
   | Some _, _ -> assert false
   | None, _ -> None
 
-let printability level typs onlyparse reversibility = function
+let printability level typs onlyparsing reversibility = function
 | NVar _ when reversibility = APrioriReversible ->
   let coe = is_coercion level typs in
-  if not onlyparse && coe = None then
+  if not onlyparsing && coe = None then
     warn_notation_bound_to_variable ();
   true, coe
 | _ ->
-   (if not onlyparse && reversibility <> APrioriReversible then
+   (if not onlyparsing && reversibility <> APrioriReversible then
      (warn_non_reversible_notation reversibility; true)
-    else onlyparse),None
+    else onlyparsing),None
 
 let find_precedence custom lev etyps symbols onlyprint =
   let first_symbol =
@@ -1257,6 +1270,16 @@ let remove_curly_brackets l =
   | x :: l -> x :: aux false l
   in aux true l
 
+(* Because of the special treatment for { }, the grammar rule sent
+   to the parser may be different than what the user sees; e.g. for
+   "{ A } + { B }", it is "A + B" which is sent to the parser *)
+type syn_pa_data = {
+    ntn_for_grammar : notation;
+    prec_for_grammar : level;
+    typs_for_grammar : constr_entry_key list;
+    need_squash : bool;
+  }
+
 module SynData = struct
 
   type subentry_types = (Id.t * constr_entry_key) list
@@ -1264,15 +1287,8 @@ module SynData = struct
   (* XXX: Document *)
   type syn_data = {
 
-    (* Notation name and location *)
-    info          : notation * notation_location;
-
-    (* Fields coming from the vernac-level modifiers *)
-    only_parsing  : bool;
-    only_printing : bool;
-    deprecation   : Deprecation.t option;
-    format        : lstring option;
-    extra         : (string * string) list;
+    (* Notation name *)
+    info          : notation;
 
     (* XXX: Callback to printing, must remove *)
     msgs          : (unit -> unit) list;
@@ -1287,10 +1303,7 @@ module SynData = struct
     subentries    : constr_entry_key list;
     pa_syntax_data : subentry_types * symbol list;
     pp_syntax_data : subentry_types * symbol list;
-    not_data      : notation *                   (* notation *)
-                    level *                      (* level, precedence *)
-                    constr_entry_key list *
-                    bool;                        (* needs_squash *)
+    not_data      : syn_pa_data;
   }
 
 end
@@ -1316,52 +1329,45 @@ let check_locality_compatibility local custom i_typs =
                     strbrk " which is local."))
       (List.uniquize allcustoms)
 
-let compute_syntax_data ~local deprecation df modifiers =
+let compute_syntax_data ~local main_data df mods =
   let open SynData in
-  let open SyndefMods in
   let open NotationMods in
-  let syndef_mods, mods = interp_modifiers modifiers in
-  let only_printing = mods.only_printing in
-  let only_parsing = syndef_mods.only_parsing in
-  if only_printing && only_parsing then user_err (str "A notation cannot be both 'only printing' and 'only parsing'.");
-  if syndef_mods.scopes <> [] then user_err (str "General notations don't support 'in scope'.");
+  let onlyprinting = main_data.onlyprinting in
+  if main_data.itemscopes <> [] then user_err (str "General notations don't support 'in scope'.");
   let assoc = Option.append mods.assoc (Some Gramlib.Gramext.NonA) in
-  let (recvars,mainvars,symbols) = analyze_notation_tokens ~onlyprint:only_printing df in
+  let (recvars,mainvars,symbols) = analyze_notation_tokens ~onlyprinting df in
   let _ = check_useless_entry_types recvars mainvars mods.etyps in
 
   (* Notations for interp and grammar  *)
-  let msgs,n = find_precedence mods.custom mods.level mods.etyps symbols only_printing in
-  let ntn_for_interp = make_notation_key mods.custom symbols in
+  let msgs,n = find_precedence main_data.entry mods.level mods.etyps symbols onlyprinting in
+  let ntn_for_interp = make_notation_key main_data.entry symbols in
   let symbols_for_grammar =
-    if mods.custom = InConstrEntry then remove_curly_brackets symbols else symbols in
+    if main_data.entry = InConstrEntry then remove_curly_brackets symbols else symbols in
   let need_squash = not (List.equal Notation.symbol_eq symbols symbols_for_grammar) in
-  let ntn_for_grammar = if need_squash then make_notation_key mods.custom symbols_for_grammar else ntn_for_interp in
-  if mods.custom = InConstrEntry && not only_printing then check_rule_productivity symbols_for_grammar;
+  let ntn_for_grammar = if need_squash then make_notation_key main_data.entry symbols_for_grammar else ntn_for_interp in
+  if main_data.entry = InConstrEntry && not onlyprinting then check_rule_productivity symbols_for_grammar;
   (* To globalize... *)
   let etyps = join_auxiliary_recursive_types recvars mods.etyps in
   let sy_typs, prec =
-    find_subentry_types mods.custom n assoc etyps symbols in
+    find_subentry_types main_data.entry n assoc etyps symbols in
   let sy_typs_for_grammar, prec_for_grammar =
     if need_squash then
-      find_subentry_types mods.custom n assoc etyps symbols_for_grammar
+      find_subentry_types main_data.entry n assoc etyps symbols_for_grammar
     else
       sy_typs, prec in
   let i_typs = set_internalization_type sy_typs in
-  check_locality_compatibility local mods.custom sy_typs;
+  check_locality_compatibility local main_data.entry sy_typs;
   let pa_sy_data = (sy_typs_for_grammar,symbols_for_grammar) in
   let pp_sy_data = (sy_typs,symbols) in
-  let sy_fulldata = (ntn_for_grammar,(mods.custom,n,prec_for_grammar),List.map snd sy_typs_for_grammar,need_squash) in
-  let df' = ((Lib.library_dp(),Lib.current_dirpath true),df) in
-  let i_data = ntn_for_interp, df' in
+  let sy_fulldata = {
+      ntn_for_grammar;
+      prec_for_grammar = (main_data.entry,n,prec_for_grammar);
+      typs_for_grammar = List.map snd sy_typs_for_grammar;
+      need_squash
+    } in
 
   (* Return relevant data for interpretation and for parsing/printing *)
-  { info = i_data;
-
-    only_parsing;
-    only_printing;
-    deprecation;
-    format        = mods.format;
-    extra         = mods.extra;
+  { info = ntn_for_interp;
 
     msgs;
 
@@ -1369,26 +1375,12 @@ let compute_syntax_data ~local deprecation df modifiers =
     mainvars;
     intern_typs = i_typs;
 
-    level  = (mods.custom,n,prec);
+    level  = (main_data.entry,n,prec);
     subentries = List.map snd sy_typs;
     pa_syntax_data = pa_sy_data;
     pp_syntax_data = pp_sy_data;
     not_data    = sy_fulldata;
   }
-
-let warn_only_parsing_reserved_notation =
-  CWarnings.create ~name:"irrelevant-reserved-notation-only-parsing" ~category:"parsing"
-    (fun () -> strbrk "The only parsing modifier has no effect in Reserved Notation.")
-
-let compute_pure_syntax_data ~local df mods =
-  let open SynData in
-  let sd = compute_syntax_data ~local None df mods in
-  if sd.only_parsing
-  then
-    let msgs = (fun () -> warn_only_parsing_reserved_notation ?loc:None ())::sd.msgs in
-    { sd with msgs; only_parsing = false }
-  else
-    sd
 
 (**********************************************************************)
 (* Registration of notations interpretation                            *)
@@ -1484,7 +1476,6 @@ let recover_notation_syntax ntn =
       let pa_typs = Notgram_ops.subentries_of_notation ntn in
       let pa_rule = try Some (Notgram_ops.grammar_of_notation ntn) with Not_found -> None in
       { synext_level = prec;
-        synext_notation = ntn;
         synext_notgram = pa_rule;
         synext_nottyps = pa_typs;
       }
@@ -1510,15 +1501,16 @@ let recover_squash_syntax sy =
 (**********************************************************************)
 (* Main entry point for building parsing and printing rules           *)
 
-let make_pa_rule level entries (typs,symbols) ntn need_squash =
+let make_pa_rule (typs,symbols) not_data =
+  let { ntn_for_grammar; prec_for_grammar; typs_for_grammar; need_squash } = not_data in
   let assoc = recompute_assoc typs in
   let prod = make_production typs symbols in
   let sy = {
-    notgram_level = level;
+    notgram_level = prec_for_grammar;
     notgram_assoc = assoc;
-    notgram_notation = ntn;
+    notgram_notation = ntn_for_grammar;
     notgram_prods = prod;
-    notgram_typs = entries;
+    notgram_typs = typs_for_grammar;
   } in
   (* By construction, the rule for "{ _ }" is declared, but we need to
      redeclare it because the file where it is declared needs not be open
@@ -1535,35 +1527,46 @@ let make_pp_rule level (typs,symbols) fmt =
        (* Optimization to work around what seems an ocaml Format bug (see Mantis #7804/#7807) *)
        List.map snd hunks (* drop locations which are dummy *)
   | Some fmt ->
-     hunks_of_format (level, List.split typs) (symbols, parse_format fmt)
+     hunks_of_format (level, List.split typs) (symbols, fmt)
 
-let make_parsing_rules (sd : SynData.syn_data) = let open SynData in
-  let ntn_for_grammar, prec_for_grammar, typs_for_grammar, need_squash = sd.not_data in
+let make_parsing_rules main_data (sd : SynData.syn_data) = let open SynData in
   let pa_rule =
-    if sd.only_printing then None
-    else Some (make_pa_rule prec_for_grammar typs_for_grammar sd.pa_syntax_data ntn_for_grammar need_squash)
+    if main_data.onlyprinting then None
+    else Some (make_pa_rule sd.pa_syntax_data sd.not_data)
   in {
     synext_level    = sd.level;
-    synext_notation = fst sd.info;
     synext_notgram  = pa_rule;
-    synext_nottyps = typs_for_grammar;
+    synext_nottyps = sd.not_data.typs_for_grammar;
   }
 
-let warn_irrelevant_format =
-  CWarnings.create ~name:"irrelevant-format-only-parsing" ~category:"parsing"
-    (fun () -> str "The format modifier is irrelevant for only parsing rules.")
-
-let make_printing_rules reserved (sd : SynData.syn_data) = let open SynData in
+let make_printing_rules reserved main_data sd =
+  let open SynData in
   let custom,level,_ = sd.level in
-  let format =
-    if sd.only_parsing && sd.format <> None then (warn_irrelevant_format (); None)
-    else sd.format in
-  let pp_rule = make_pp_rule level sd.pp_syntax_data format in
+  let pp_rule = make_pp_rule level sd.pp_syntax_data main_data.format in
   (* We produce a generic rule even if this precise notation is only parsing *)
   Some {
     synext_reserved = reserved;
     synext_unparsing = (pp_rule,level);
-    synext_extra  = sd.extra;
+    synext_extra  = main_data.extra;
+  }
+
+let merge_extra extra1 extra2 =
+  List.fold_left (fun extras (k,s) -> (k,s) :: List.remove_assoc k extras)
+    extra1 extra2
+
+let make_specific_printing_rules etyps symbols level pp_rule (format,new_extra) =
+  match level with
+  | None -> None
+  | Some (_,level,_) ->
+  let old_extra = match pp_rule with Some { synext_extra = old_extra } -> old_extra | None -> [] in
+  let pp_rule = match format, pp_rule with
+    | None, Some { synext_unparsing = (pp_rule,_) } -> pp_rule
+    | _ -> make_pp_rule level (etyps,symbols) format in
+  (* Should we warn if there is an incompatible reserved format? *)
+  Some {
+    synext_reserved = false;
+    synext_unparsing = (pp_rule,level);
+    synext_extra  = merge_extra old_extra new_extra;
   }
 
 let warn_unused_interpretation =
@@ -1587,17 +1590,16 @@ let to_map l =
   let fold accu (x, v) = Id.Map.add x v accu in
   List.fold_left fold Id.Map.empty l
 
-let add_notation_in_scope ~local deprecation df env c mods scope =
+let add_notation_in_scope ~local main_data df env c sd scope =
   let open SynData in
-  let sd = compute_syntax_data ~local deprecation df mods in
   (* Prepare the parsing and printing rules *)
-  let sy_pa_rules = make_parsing_rules sd in
+  let sy_pa_rules = make_parsing_rules main_data sd in
   let sy_pp_rules, gen_sy_pp_rules =
-    match sd.only_parsing, Ppextend.has_generic_notation_printing_rule (fst sd.info) with
+    match main_data.onlyparsing, Ppextend.has_generic_notation_printing_rule sd.info with
     | true, true -> None, None
     | onlyparse, has_generic ->
-      let rules = make_printing_rules false sd in
-      let _ = check_reserved_format (fst sd.info) rules in
+      let rules = make_printing_rules false main_data sd in
+      let _ = check_reserved_format sd.info rules in
       (if onlyparse then None else rules),
       (if has_generic then None else (* We use the format of this notation as the default *) rules) in
   (* Prepare the interpretation *)
@@ -1611,41 +1613,44 @@ let add_notation_in_scope ~local deprecation df env c mods scope =
   let map (x, _) = try Some (x, Id.Map.find x interp) with Not_found -> None in
   let vars = List.map_filter map i_vars in (* Order of elements is important here! *)
   let also_in_cases_pattern = has_no_binders_type vars in
-  let onlyparse,coe = printability (Some sd.level) sd.subentries sd.only_parsing reversibility ac in
-  let notation, location = sd.info in
-  let use = make_use true onlyparse sd.only_printing in
+  let onlyparsing,coe = printability (Some sd.level) sd.subentries main_data.onlyparsing reversibility ac in
+  let main_data = { main_data with onlyparsing } in
+  let use = make_use true onlyparsing main_data.onlyprinting in
+  let path = (Lib.library_dp(), Lib.current_dirpath true) in
+  let df' = sd.info, (path,df) in
   let notation = {
     notobj_local = local;
     notobj_scope = scope;
     notobj_use = use;
     notobj_interp = (vars, ac);
     notobj_coercion = coe;
-    notobj_deprecation = sd.deprecation;
-    notobj_notation = (notation, location);
+    notobj_deprecation = main_data.deprecation;
+    notobj_notation = df';
     notobj_specific_pp_rules = sy_pp_rules;
     notobj_also_in_cases_pattern = also_in_cases_pattern;
   } in
   (* Ready to change the global state *)
   List.iter (fun f -> f ()) sd.msgs;
-  Lib.add_anonymous_leaf (inSyntaxExtension (local, (sy_pa_rules,gen_sy_pp_rules)));
+  Lib.add_anonymous_leaf (inSyntaxExtension (local, (sd.info,sy_pa_rules,gen_sy_pp_rules)));
   Lib.add_anonymous_leaf (inNotation notation);
-  sd.info
+  df'
 
-let add_notation_interpretation_core ~local df env ?(impls=empty_internalization_env) entry c scope onlyparse onlyprint deprecation =
-  let (recvars,mainvars,symbs) = analyze_notation_tokens ~onlyprint df in
+let add_notation_interpretation_core ~local main_data df env ?(impls=empty_internalization_env) c scope =
+  let (recvars,mainvars,symbs) = analyze_notation_tokens ~onlyprinting:main_data.onlyprinting df in
   (* Recover types of variables and pa/pp rules; redeclare them if needed *)
-  let notation_key = make_notation_key entry symbs in
-  let level, i_typs, onlyprint, pp_sy = if not (is_numeral_in_constr entry symbs) then begin
-    let (pa_sy,pp_sy as sy) = recover_notation_syntax notation_key in
-    let () = Lib.add_anonymous_leaf (inSyntaxExtension (local,sy)) in
+  let notation_key = make_notation_key main_data.entry symbs in
+  let level, i_typs, main_data, sy_pp_rules = if not (is_numeral_in_constr main_data.entry symbs) then begin
+    let (pa_sy,pp_sy) = recover_notation_syntax notation_key in
+    let () = Lib.add_anonymous_leaf (inSyntaxExtension (local,(notation_key,pa_sy,pp_sy))) in
     (* If the only printing flag has been explicitly requested, put it back *)
-    let onlyprint = onlyprint || pa_sy.synext_notgram = None in
+    let main_data = { main_data with onlyprinting = main_data.onlyprinting || pa_sy.synext_notgram = None } in
     let typs = pa_sy.synext_nottyps in
-    Some pa_sy.synext_level, typs, onlyprint, pp_sy
-  end else None, [], false, None in
+    Some pa_sy.synext_level, typs, main_data, pp_sy
+  end else None, [], { main_data with onlyprinting = main_data.onlyprinting }, None in
   (* Declare interpretation *)
+  let sy_pp_rules = make_specific_printing_rules (List.combine mainvars i_typs) symbs level sy_pp_rules (main_data.format, main_data.extra) in
   let path = (Lib.library_dp(), Lib.current_dirpath true) in
-  let df'  = notation_key, (path,df) in
+  let df' = notation_key, (path,df) in
   let i_vars = make_internalization_vars recvars mainvars (List.map internalization_type_of_entry_type i_typs) in
   let nenv = {
     ninterp_var_type = to_map i_vars;
@@ -1657,17 +1662,18 @@ let add_notation_interpretation_core ~local df env ?(impls=empty_internalization
   let map (x, _) = try Some (x, Id.Map.find x interp) with Not_found -> None in
   let vars = List.map_filter map i_vars in (* Order of elements is important here! *)
   let also_in_cases_pattern = has_no_binders_type vars in
-  let onlyparse,coe = printability level i_typs onlyparse reversibility ac in
-  let use = make_use false onlyparse onlyprint in
+  let onlyparsing,coe = printability level i_typs main_data.onlyparsing reversibility ac in
+  let main_data = { main_data with onlyparsing } in
+  let use = make_use false onlyparsing main_data.onlyprinting in
   let notation = {
     notobj_local = local;
     notobj_scope = scope;
     notobj_use = use;
     notobj_interp = (vars, ac);
     notobj_coercion = coe;
-    notobj_deprecation = deprecation;
+    notobj_deprecation = main_data.deprecation;
     notobj_notation = df';
-    notobj_specific_pp_rules = pp_sy;
+    notobj_specific_pp_rules = sy_pp_rules;
     notobj_also_in_cases_pattern = also_in_cases_pattern;
   } in
   Lib.add_anonymous_leaf (inNotation notation);
@@ -1675,16 +1681,19 @@ let add_notation_interpretation_core ~local df env ?(impls=empty_internalization
 
 (* Notations without interpretation (Reserved Notation) *)
 
-let add_syntax_extension ~local ({CAst.loc;v=df},mods) = let open SynData in
-  let psd = {(compute_pure_syntax_data ~local df mods) with deprecation = None} in
-  let pa_rules = make_parsing_rules psd in
-  let pp_rules = make_printing_rules true psd in
-  List.iter (fun f -> f ()) psd.msgs;
-  Lib.add_anonymous_leaf (inSyntaxExtension(local,(pa_rules,pp_rules)))
+let add_syntax_extension ~local ~infix ({CAst.loc;v=df},mods) =
+  let open SynData in
+  let (main_data,mods) = interp_non_syntax_modifiers ~reserved:true ~infix ~syndef:false None mods in
+  let mods = interp_modifiers main_data.entry mods in
+  let sd = compute_syntax_data ~local main_data df mods in
+  let pa_rules = make_parsing_rules main_data sd in
+  let pp_rules = make_printing_rules true main_data sd in
+  List.iter (fun f -> f ()) sd.msgs;
+  Lib.add_anonymous_leaf (inSyntaxExtension(local,(sd.info,pa_rules,pp_rules)))
 
 (* Notations associated to a where clause *)
 
-type where_decl_notation = decl_notation * bool * notation_entry
+type where_decl_notation = decl_notation * notation_main_data
 
 let prepare_where_notation decl_ntn =
   let
@@ -1693,44 +1702,47 @@ let prepare_where_notation decl_ntn =
       decl_ntn_modifiers = modifiers;
       decl_ntn_scope = sc;
     } = decl_ntn in
-  match interp_non_syntax_modifiers modifiers with
-  | None | Some (_,true,_) ->
-    CErrors.user_err (str"Only modifiers not affecting parsing are supported here.")
-  | Some (only_parsing,false,entry) ->
-    (decl_ntn,only_parsing,entry)
+  let (main_data,mods) = interp_non_syntax_modifiers ~reserved:false ~infix:false ~syndef:false None modifiers in
+  match mods with
+  | _::_ -> CErrors.user_err (str"Only modifiers not affecting parsing are supported here.")
+  | [] -> (decl_ntn,main_data)
 
-let add_notation_interpretation ~local env (decl_ntn,only_parsing,entry) =
+let add_notation_interpretation ~local env (decl_ntn,main_data) =
   let { decl_ntn_string = { CAst.loc ; v = df }; decl_ntn_interp = c; decl_ntn_scope = sc } = decl_ntn in
-  let df' = add_notation_interpretation_core ~local df env entry c sc only_parsing false None in
+  let df' = add_notation_interpretation_core ~local main_data df env c sc in
   Dumpglob.dump_notation (loc,df') sc true
 
 (* interpreting a where clause *)
-let set_notation_for_interpretation env impls (decl_ntn,only_parsing,entry) =
+let set_notation_for_interpretation env impls (decl_ntn,main_data) =
   let { decl_ntn_string = { CAst.loc ; v = df }; decl_ntn_interp = c; decl_ntn_scope = sc } = decl_ntn in
-  let _ = add_notation_interpretation_core ~local:true df env ~impls entry c sc only_parsing false None in
+  let _ = add_notation_interpretation_core ~local:true main_data df env ~impls c sc in
   Option.iter (fun sc -> Notation.open_close_scope (false,true,sc)) sc
 
 (* Main entry point *)
 
 let add_notation ~local deprecation env c ({CAst.loc;v=df},modifiers) sc =
   let df' =
-   match interp_non_syntax_modifiers modifiers with
-   | Some (only_parsing,only_printing,entry) ->
+   let (main_data,modifiers') = interp_non_syntax_modifiers ~reserved:false ~infix:false ~syndef:false deprecation modifiers in
+   match modifiers' with
+   | [] ->
     (* No syntax data: try to rely on a previously declared rule *)
-    begin try add_notation_interpretation_core ~local df env entry c sc only_parsing only_printing deprecation
+    begin try add_notation_interpretation_core ~local main_data df env c sc
     with NoSyntaxRule ->
       (* Try to determine a default syntax rule *)
-      add_notation_in_scope ~local deprecation df env c modifiers sc
+      let sd = compute_syntax_data ~local main_data df NotationMods.default in
+      add_notation_in_scope ~local main_data df env c sd sc
     end
-   | None ->
+   | _ ->
     (* Declare both syntax and interpretation *)
-    add_notation_in_scope ~local deprecation df env c modifiers sc
+    let mods = interp_modifiers main_data.entry modifiers' in
+    let sd = compute_syntax_data ~local main_data df mods in
+    add_notation_in_scope ~local main_data df env c sd sc
   in
   Dumpglob.dump_notation (loc,df') sc true
 
 let add_notation_extra_printing_rule df k v =
   let notk =
-    let _,_, symbs = analyze_notation_tokens ~onlyprint:true df in
+    let _,_, symbs = analyze_notation_tokens ~onlyprinting:true df in
     make_notation_key InConstrEntry symbs in
   add_notation_extra_printing_rule notk k v
 
@@ -1739,7 +1751,6 @@ let add_notation_extra_printing_rule df k v =
 let inject_var x = CAst.make @@ CRef (qualid_of_ident x,None)
 
 let add_infix ~local deprecation env ({CAst.loc;v=inf},modifiers) pr sc =
-  check_infix_modifiers modifiers;
   (* check the precedence *)
   let vars = names_of_constr_expr pr in
   let x = Namegen.next_ident_away (Id.of_string "x") vars in
@@ -1818,15 +1829,21 @@ let remove_delimiters local scope =
 let add_class_scope local scope cl =
   Lib.add_anonymous_leaf (inScopeCommand(local,scope,ScopeClasses cl))
 
-let add_syntactic_definition ~local deprecation env ident (vars,c) modl =
-  let open SyndefMods in
-  let skipped, { only_parsing; scopes } = interp_syndef_modifiers modl in
+let interp_syndef_modifiers deprecation modl =
+  let mods, skipped = interp_non_syntax_modifiers ~reserved:false ~infix:false ~syndef:true deprecation modl in
   if skipped <> [] then
-    user_err (str "Simple notations don't support " ++ Ppvernac.pr_syntax_modifier (List.hd skipped));
+    (let modifier = List.hd skipped in
+    user_err ?loc:modifier.CAst.loc (str "Abbreviations don't support " ++ Ppvernac.pr_syntax_modifier modifier));
+  (mods.onlyparsing, mods.itemscopes)
+
+let add_syntactic_definition ~local deprecation env ident (vars,c) modl =
+  let (only_parsing, scopes) = interp_syndef_modifiers deprecation modl in
   let vars = List.map (fun v -> v, List.assoc_opt v scopes) vars in
   let acvars,pat,reversibility =
     match vars, intern_name_alias c with
     | [], Some(r,u) ->
+      (* Check if abbreviation to a name and avoid early insertion of
+         maximal implicit arguments *)
       Id.Map.empty, NRef(r, u), APrioriReversible
     | _ ->
       let fold accu (id,scope) = Id.Map.add id (NtnInternTypeAny scope) accu in

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -1677,7 +1677,7 @@ let set_notation_for_interpretation env impls (decl_ntn, main_data, notation_sym
   Lib.add_anonymous_leaf (inNotation notation);
   Option.iter (fun sc -> Notation.open_close_scope (false,true,sc)) sc
 
-(* Main entry point *)
+(* Main entry point for command Notation *)
 
 let add_notation ~local deprecation env c ({CAst.loc;v=df},modifiers) sc =
   (* Extract the modifiers not affecting the parsing rule *)
@@ -1710,6 +1710,8 @@ let add_notation ~local deprecation env c ({CAst.loc;v=df},modifiers) sc =
   Lib.add_anonymous_leaf (inNotation notation);
   (* Dump the location of the notation for coqdoc *)
   Dumpglob.dump_notation (CAst.make ?loc ntn) sc true
+
+(* Main entry point for Format Notation *)
 
 let add_notation_extra_printing_rule df k v =
   let notk =

--- a/vernac/metasyntax.mli
+++ b/vernac/metasyntax.mli
@@ -19,11 +19,11 @@ val add_token_obj : string -> unit
 
 (** Adding a (constr) notation in the environment*)
 
-val add_infix : local:bool -> Deprecation.t option -> env -> (lstring * syntax_modifier list) ->
+val add_infix : local:bool -> Deprecation.t option -> env -> (lstring * syntax_modifier CAst.t list) ->
   constr_expr -> scope_name option -> unit
 
 val add_notation : local:bool -> Deprecation.t option -> env -> constr_expr ->
-  (lstring * syntax_modifier list) -> scope_name option -> unit
+  (lstring * syntax_modifier CAst.t list) -> scope_name option -> unit
 
 val add_notation_extra_printing_rule : string -> string -> string -> unit
 
@@ -53,19 +53,17 @@ val set_notation_for_interpretation :
 (** Add only the parsing/printing rule of a notation *)
 
 val add_syntax_extension :
-  local:bool -> (lstring * syntax_modifier list) -> unit
+  local:bool -> infix:bool -> (lstring * syntax_modifier CAst.t list) -> unit
 
 (** Add a syntactic definition (as in "Notation f := ...") *)
 
 val add_syntactic_definition : local:bool -> Deprecation.t option -> env ->
-  Id.t -> Id.t list * constr_expr -> syntax_modifier list -> unit
+  Id.t -> Id.t list * constr_expr -> syntax_modifier CAst.t list -> unit
 
 (** Print the Camlp5 state of a grammar *)
 
 val pr_grammar : string -> Pp.t
 val pr_custom_grammar : string -> Pp.t
-
-val check_infix_modifiers : syntax_modifier list -> unit
 
 val with_syntax_protection : ('a -> 'b) -> 'a -> 'b
 

--- a/vernac/metasyntax.mli
+++ b/vernac/metasyntax.mli
@@ -52,7 +52,7 @@ val set_notation_for_interpretation :
 
 (** Add only the parsing/printing rule of a notation *)
 
-val add_syntax_extension :
+val add_reserved_notation :
   local:bool -> infix:bool -> (lstring * syntax_modifier CAst.t list) -> unit
 
 (** Add a syntactic definition (as in "Notation f := ...") *)

--- a/vernac/metasyntax.mli
+++ b/vernac/metasyntax.mli
@@ -34,15 +34,21 @@ val add_delimiters : locality_flag -> scope_name -> string -> unit
 val remove_delimiters : locality_flag -> scope_name -> unit
 val add_class_scope : locality_flag -> scope_name -> scope_class list -> unit
 
-(** Add only the interpretation of a notation that already has pa/pp rules *)
+(** Add a notation interpretation associated to a "where" clause (already has pa/pp rules) *)
+
+type where_decl_notation
+
+val prepare_where_notation :
+  decl_notation -> where_decl_notation
+  (** Interpret the modifiers of a where-notation *)
 
 val add_notation_interpretation :
-  env -> decl_notation -> unit
-
-(** Add a notation interpretation for supporting the "where" clause *)
+  local:bool -> env -> where_decl_notation -> unit
+  (** Declare the interpretation of the where-notation *)
 
 val set_notation_for_interpretation :
-  env -> Constrintern.internalization_env -> decl_notation -> unit
+  env -> Constrintern.internalization_env -> where_decl_notation -> unit
+  (** Set the interpretation of the where-notation for interpreting a mutual block *)
 
 (** Add only the parsing/printing rule of a notation *)
 

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -464,7 +464,7 @@ let pr_ne_params_list pr_c l =
 
 let pr_thm_token k = keyword (string_of_theorem_kind k)
 
-let pr_syntax_modifier = let open Gramlib.Gramext in function
+let pr_syntax_modifier = let open Gramlib.Gramext in CAst.with_val (function
     | SetItemLevel (l,bko,n) ->
       prlist_with_sep sep_v2 str l ++ spc () ++ pr_at_level n ++
       pr_opt pr_constr_as_binder_kind bko
@@ -478,8 +478,8 @@ let pr_syntax_modifier = let open Gramlib.Gramext in function
     | SetEntryType (x,typ) -> str x ++ spc() ++ pr_set_simple_entry_type typ
     | SetOnlyPrinting -> keyword "only printing"
     | SetOnlyParsing -> keyword "only parsing"
-    | SetFormat("text",s) -> keyword "format " ++ pr_ast qs s
-    | SetFormat(k,s) -> keyword "format " ++ qs k ++ spc() ++ pr_ast qs s
+    | SetFormat (TextFormat s) -> keyword "format " ++ pr_ast qs s
+    | SetFormat (ExtraFormat (k,s)) -> keyword "format " ++ qs k ++ spc() ++ pr_ast qs s)
 
 let pr_syntax_modifiers = function
   | [] -> mt()

--- a/vernac/ppvernac.ml
+++ b/vernac/ppvernac.ml
@@ -774,7 +774,7 @@ let pr_vernac_expr v =
               | None -> mt()
               | Some sc -> str" :" ++ spc() ++ str sc))
     )
-  | VernacSyntaxExtension (_, (s, l)) ->
+  | VernacReservedNotation (_, (s, l)) ->
     return (
       keyword "Reserved Notation" ++ spc() ++ pr_ast qs s ++
       pr_syntax_modifiers l

--- a/vernac/ppvernac.mli
+++ b/vernac/ppvernac.mli
@@ -13,7 +13,7 @@
 
 val pr_set_entry_type : ('a -> Pp.t) -> 'a Extend.constr_entry_key_gen -> Pp.t
 
-val pr_syntax_modifier : Vernacexpr.syntax_modifier -> Pp.t
+val pr_syntax_modifier : Vernacexpr.syntax_modifier CAst.t -> Pp.t
 
 (** Prints a fixpoint body *)
 val pr_rec_definition : Vernacexpr.fixpoint_expr -> Pp.t

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -127,7 +127,7 @@ module DataI = struct
     { name : Id.t
     ; arity : Constrexpr.constr_expr option
     (** declared sort for the record  *)
-    ; nots : Vernacexpr.decl_notation list list
+    ; nots : Metasyntax.where_decl_notation list list
     (** notations for fields *)
     ; fs : Vernacexpr.local_decl_expr list
     }
@@ -810,7 +810,7 @@ module Ast = struct
     let fs = List.map fst cfs in
     { DataI.name = name.CAst.v
     ; arity = sort
-    ; nots = List.map (fun (_, { rf_notation }) -> rf_notation) cfs
+    ; nots = List.map (fun (_, { rf_notation }) -> List.map Metasyntax.prepare_where_notation rf_notation) cfs
     ; fs
     }
 end

--- a/vernac/vernac_classifier.ml
+++ b/vernac/vernac_classifier.ml
@@ -170,7 +170,7 @@ let classify_vernac e =
     | VernacOpenCloseScope _ | VernacDeclareScope _
     | VernacDelimiters _ | VernacBindScope _
     | VernacInfix _ | VernacNotation _ | VernacNotationAddFormat _
-    | VernacSyntaxExtension _
+    | VernacReservedNotation _
     | VernacSyntacticDefinition _
     | VernacRequire _ | VernacImport _ | VernacInclude _
     | VernacDeclareMLModule _

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -504,8 +504,8 @@ let dump_global r =
 (**********)
 (* Syntax *)
 
-let vernac_syntax_extension ~module_local ~infix l =
-  Metasyntax.add_syntax_extension ~local:module_local ~infix l
+let vernac_reserved_notation ~module_local ~infix l =
+  Metasyntax.add_reserved_notation ~local:module_local ~infix l
 
 let vernac_declare_scope ~module_local sc =
   Metasyntax.declare_scope module_local sc
@@ -2089,8 +2089,8 @@ let translate_vernac ?loc ~atts v = let open Vernacextend in match v with
     anomaly (str "Load is not supported recursively")
 
   (* Syntax *)
-  | VernacSyntaxExtension (infix, sl) ->
-    VtDefault(fun () -> with_module_locality ~atts vernac_syntax_extension ~infix sl)
+  | VernacReservedNotation (infix, sl) ->
+    VtDefault(fun () -> with_module_locality ~atts vernac_reserved_notation ~infix sl)
   | VernacDeclareScope sc ->
     VtDefault(fun () -> with_module_locality ~atts vernac_declare_scope sc)
   | VernacDelimiters (sc,lr) ->

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -504,9 +504,8 @@ let dump_global r =
 (**********)
 (* Syntax *)
 
-let vernac_syntax_extension ~module_local infix l =
-  if infix then Metasyntax.check_infix_modifiers (snd l);
-  Metasyntax.add_syntax_extension ~local:module_local l
+let vernac_syntax_extension ~module_local ~infix l =
+  Metasyntax.add_syntax_extension ~local:module_local ~infix l
 
 let vernac_declare_scope ~module_local sc =
   Metasyntax.declare_scope module_local sc
@@ -2091,7 +2090,7 @@ let translate_vernac ?loc ~atts v = let open Vernacextend in match v with
 
   (* Syntax *)
   | VernacSyntaxExtension (infix, sl) ->
-    VtDefault(fun () -> with_module_locality ~atts vernac_syntax_extension infix sl)
+    VtDefault(fun () -> with_module_locality ~atts vernac_syntax_extension ~infix sl)
   | VernacDeclareScope sc ->
     VtDefault(fun () -> with_module_locality ~atts vernac_declare_scope sc)
   | VernacDelimiters (sc,lr) ->

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -313,7 +313,7 @@ type nonrec vernac_expr =
 
   | VernacLoad of verbose_flag * string
   (* Syntax *)
-  | VernacSyntaxExtension of bool * (lstring * syntax_modifier CAst.t list)
+  | VernacReservedNotation of bool * (lstring * syntax_modifier CAst.t list)
   | VernacOpenCloseScope of bool * scope_name
   | VernacDeclareScope of scope_name
   | VernacDelimiters of scope_name * string option

--- a/vernac/vernacexpr.ml
+++ b/vernac/vernacexpr.ml
@@ -129,6 +129,10 @@ type definition_expr =
   | DefineBody of local_binder_expr list * Genredexpr.raw_red_expr option * constr_expr
       * constr_expr option
 
+type notation_format =
+  | TextFormat of lstring
+  | ExtraFormat of string * lstring
+
 type syntax_modifier =
   | SetItemLevel of string list * Notation_term.constr_as_binder_kind option * Extend.production_level
   | SetItemScope of string list * scope_name
@@ -138,13 +142,13 @@ type syntax_modifier =
   | SetEntryType of string * Extend.simple_constr_prod_entry_key
   | SetOnlyParsing
   | SetOnlyPrinting
-  | SetFormat of string * lstring
+  | SetFormat of notation_format
 
 type decl_notation =
   { decl_ntn_string : lstring
   ; decl_ntn_interp : constr_expr
   ; decl_ntn_scope : scope_name option
-  ; decl_ntn_modifiers : syntax_modifier list
+  ; decl_ntn_modifiers : syntax_modifier CAst.t list
   }
 
 type 'a fix_expr_gen =
@@ -309,15 +313,15 @@ type nonrec vernac_expr =
 
   | VernacLoad of verbose_flag * string
   (* Syntax *)
-  | VernacSyntaxExtension of bool * (lstring * syntax_modifier list)
+  | VernacSyntaxExtension of bool * (lstring * syntax_modifier CAst.t list)
   | VernacOpenCloseScope of bool * scope_name
   | VernacDeclareScope of scope_name
   | VernacDelimiters of scope_name * string option
   | VernacBindScope of scope_name * class_rawexpr list
-  | VernacInfix of (lstring * syntax_modifier list) *
+  | VernacInfix of (lstring * syntax_modifier CAst.t list) *
       constr_expr * scope_name option
   | VernacNotation of
-      constr_expr * (lstring * syntax_modifier list) *
+      constr_expr * (lstring * syntax_modifier CAst.t list) *
       scope_name option
   | VernacNotationAddFormat of string * string * string
   | VernacDeclareCustomEntry of string
@@ -408,7 +412,7 @@ type nonrec vernac_expr =
   | VernacRemoveHints of string list * qualid list
   | VernacHints of string list * hints_expr
   | VernacSyntacticDefinition of
-      lident * (Id.t list * constr_expr) * syntax_modifier list
+      lident * (Id.t list * constr_expr) * syntax_modifier CAst.t list
   | VernacArguments of
       qualid or_by_notation *
       vernac_argument_status list (* Main arguments status list *) *


### PR DESCRIPTION
**Kind:** cleanup

This is mostly a reorganization of `metasyntax.ml` in the hope of making it easier to follow. It is now organized around 4 phases (see `Metasyntax.add_notation`):
1. interpret the modifiers referring to the interpretation (only parsing, only printing, custom entry, but also format since specific formats can be attached to an interpretation)
2. analyze the string on the left-hand side and build the notation key identifying uniquely a right-hand side
3. determine the syntax rules (parsing and generic printing):
   - in the absence of other modifiers:
     - look if a notation or reserved notation with same notation key exists
     - if none, try to infer the grammar rules (e.g. by using level 0 for bracketed notations)
   - in the presence of other modifiers: use them and override an existing rule if there is one
4. compute the interpretation
5. register the syntax and interpretation

Incidentally:
1. this removes the redundancy between `add_notation_in_scope` and `add_notation_interpretation_core` (the former disappears)
2. we continue to try to use records when possible, but organized differently
3. we locate errors when interpreting the modifiers and adds some stronger check of consistency of the modifiers (we also centralize those checks)
4. `format` is allowed in the `where` clause
5. for simplicity, in corner situations like `Notation "#" := 0 (at level 10). Notation "#" := 0 (format "  #  ").` the second call (where no strictly parsing data is given ) inherits the level of the first call instead of setting the level at 0 as if an overriding.

If I'm not mistaken, and bugs apart, points 3., 4., 5. in the last enumeration are the only observational changes.

- [X] Added / updated test-suite

## Overlays:
- https://github.com/mattam82/Coq-Equations/pull/411