### PR TITLE
Fixes #13363: in pose_all_metas_as_evars, use the context of the definition of the metas

### DIFF
--- a/doc/changelog/04-tactics/13373-master+fix13363-metas-posed-to-evars-in-wrong-env.rst
+++ b/doc/changelog/04-tactics/13373-master+fix13363-metas-posed-to-evars-in-wrong-env.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  The case of tactics, such as :tacn:`eapply`, producing existential variables
+  under binders with an ill-formed instance
+  (`#13373 <https://github.com/coq/coq/pull/13373>`_,
+  fixes `#13363 <https://github.com/coq/coq/issues/13363>`_,
+  by Hugo Herbelin).

--- a/pretyping/unification.mli
+++ b/pretyping/unification.mli
@@ -105,7 +105,7 @@ type metabinding = (metavariable * constr * (instance_constraint * instance_typi
 type subst0 =
   (evar_map *
     metabinding list *
-      (Environ.env * existential * t) list)
+      ((Environ.env * int) * existential * t) list)
 
 val w_merge : env -> bool -> core_unify_flags -> subst0 -> evar_map
 

--- a/test-suite/bugs/closed/bug_13363.v
+++ b/test-suite/bugs/closed/bug_13363.v
@@ -1,0 +1,17 @@
+Axiom X : Type.       
+Axiom P : (X -> unit) -> Prop.
+
+Axiom F: unit -> unit.
+Axiom G : unit -> unit.
+
+Lemma Hyp ss':
+    P (fun y : X => ss') ->
+    P (fun y : X => G (F ss')).
+Admitted.
+
+Lemma bug : exists x, P x.
+Proof.
+intros.
+eexists (fun y : X => G _).
+eapply Hyp. cbn beta.
+Abort.


### PR DESCRIPTION
**Kind:** bug fix

In `Evar` := `C[Meta]` problems of unification.ml, and `C[ ]` contains binders, `Meta`s were wrongly considered by `Unification.pose_all_metas_as_evars` as (possibly) under these binders (while the defining environment of a `Meta` is always the initial context of the unification problem).

Fixes / closes #13363 

- [X] Added / updated test-suite
- [x] Entry added in the changelog