### PR TITLE
Fixes #13266: Avoiding encapsulating exceptions w/o a handler in NotFoundInstance

### DIFF
--- a/doc/changelog/02-specification-language/13376-master+minifix-NotFoundInstance.rst
+++ b/doc/changelog/02-specification-language/13376-master+minifix-NotFoundInstance.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  A case of unification raising an anomaly IllTypedInstance
+  (`#13376 <https://github.com/coq/coq/pull/13376>`_,
+  fixes `#13266 <https://github.com/coq/coq/issues/13266>`_,
+  by Hugo Herbelin).

--- a/test-suite/output/bug_13266.out
+++ b/test-suite/output/bug_13266.out
@@ -1,0 +1,12 @@
+The command has indeed failed with message:
+Abstracting over the terms "S", "p" and "u" leads to a term
+fun (S0 : Type) (p0 : proc S0) (_ : S0) => p0 = Tick -> True
+which is ill-typed.
+Reason is: Illegal application: 
+The term "@eq" of type "forall A : Type, A -> A -> Prop"
+cannot be applied to the terms
+ "proc S0" : "Prop"
+ "p0" : "proc S0"
+ "Tick" : "proc unit"
+The 3rd term has type "proc unit" which should be coercible to 
+"proc S0".

--- a/test-suite/output/bug_13266.v
+++ b/test-suite/output/bug_13266.v
@@ -1,0 +1,18 @@
+Inductive proc : Type -> Type :=
+| Tick : proc unit
+.
+
+Inductive exec :
+  forall T, proc T -> T -> Prop :=
+| ExecTick :
+    exec _ (Tick) tt
+.
+
+Lemma foo :
+  exec _ Tick tt ->
+  True.
+Proof.
+  intros H. 
+  remember Tick as p.
+  Fail induction H.
+Abort.


### PR DESCRIPTION
**Kind:** bug fix

This extends #12675, see discussion there.

Fixes / closes #13266

- [X] Added / updated test-suite
- [x] Entry added in the changelog
