### PR TITLE
Fix #12575: GRAMMAR EXTEND in plugins not backtracking

### DIFF
--- a/parsing/pcoq.mli
+++ b/parsing/pcoq.mli
@@ -222,13 +222,6 @@ module Module :
 
 val epsilon_value : ('a -> 'self) -> ('self, _, 'a) Symbol.t -> 'self option
 
-(** {5 Extending the parser without synchronization} *)
-
-val grammar_extend : 'a Entry.t -> 'a extend_statement -> unit
-(** Extend the grammar of Coq, without synchronizing it with the backtracking
-    mechanism. This means that grammar extensions defined this way will survive
-    an undo. *)
-
 (** {5 Extending the parser with summary-synchronized commands} *)
 
 module GramState : Store.S
@@ -259,6 +252,9 @@ val create_grammar_command : string -> 'a grammar_extension -> 'a grammar_comman
 
 val extend_grammar_command : 'a grammar_command -> 'a -> unit
 (** Extend the grammar of Coq with the given data. *)
+
+val grammar_extend : 'a Entry.t -> 'a extend_statement -> unit
+(** A particular case for extending an existing entry *)
 
 (** {6 Extension with parsing entries} *)
 

--- a/test-suite/bugs/closed/bug_12575.v
+++ b/test-suite/bugs/closed/bug_12575.v
@@ -1,0 +1,3 @@
+From Ltac2 Require Ltac2.
+Back 1.
+Ltac2 Eval ().


### PR DESCRIPTION
**Kind:** bug fix

This PR plugs `GRAMMAR EXTEND` on the backtracking mechanism. This fixes #12575 but seems to go against the intention of `Pcoq.grammar_extend` as described in `pcoq.mli`. Is there something wrong at plugging it on the backtracking mechanism? (The code of `pcoq.ml` is rather intricate and it's difficult to see if something may go wrong. Eventually, I guess we should provide backtracking directly from gramlib rather than trying to accomodate the limitations of its backtracking API).

Fixes / closes #12575

- [X] Added / updated test-suite
- [ ] Entry added in the changelog
