### PR TITLE
Fixes #12348: de Bruijn indices bug in the imitation part of unification

### DIFF
--- a/doc/changelog/02-specification-language/13387-master+fix12348-debruijn-bug-imitation.rst
+++ b/doc/changelog/02-specification-language/13387-master+fix12348-debruijn-bug-imitation.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  A bug producing ill-typed instances of existential variables when let-ins
+  interleaved with assumptions
+  (`#13387 <https://github.com/coq/coq/pull/13387>`_,
+  fixes `#12348 <https://github.com/coq/coq/issues/13387>`_,
+  by Hugo Herbelin).

--- a/pretyping/evarsolve.ml
+++ b/pretyping/evarsolve.ml
@@ -810,7 +810,8 @@ let check_evar_instance unify flags env evd evk1 body =
   (* This happens in practice, cf MathClasses build failure on 2013-3-15 *)
   let ty =
     try Retyping.get_type_of ~lax:true evenv evd body
-    with Retyping.RetypeError _ -> user_err (Pp.(str "Ill-typed evar instance"))
+    with Retyping.RetypeError _ ->
+      let loc, _ = evi.evar_source in user_err ?loc (Pp.(str "Ill-typed evar instance"))
   in
   match unify flags TypeUnification evenv evd Reduction.CUMUL ty evi.evar_concl with
   | Success evd -> evd

--- a/pretyping/evarsolve.ml
+++ b/pretyping/evarsolve.ml
@@ -1576,7 +1576,7 @@ let rec invert_definition unify flags choose imitate_defs
     match EConstr.kind !evdref t with
     | Rel i when i>k ->
         let open Context.Rel.Declaration in
-        (match Environ.lookup_rel (i-k) env' with
+        (match Environ.lookup_rel i env' with
         | LocalAssum _ -> project_variable (RelAlias (i-k))
         | LocalDef (_,b,_) ->
           try project_variable (RelAlias (i-k))

--- a/test-suite/bugs/closed/bug_12348.v
+++ b/test-suite/bugs/closed/bug_12348.v
@@ -1,0 +1,11 @@
+(* Was raising an anomaly before 8.13 *)
+Check let 'tt := tt in
+      let X := nat in
+      let b : bool := _ in
+      (fun n : nat => 0 : X) : _.
+
+(* Was raising an ill-typed instance error before 8.13 *)
+Check let 'tt := tt in
+      let X := nat in
+      let b : bool := true in
+      (fun n : nat => 0 : X) : _.


### PR DESCRIPTION
**Kind:** bug fix

The bug was that an local assumption could be interpreted as a local definition and wrongly expanded.
    
It triggered rarely because it required a context mixing let-ins and local assumptions + an imitation under binders.

Fixes / closes #12348

- [X] Added / updated test-suite
- [x] Entry added in the changelog