### PR TITLE
Intern application arguments in left-to-right order

### DIFF
--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -2405,8 +2405,9 @@ let internalize globalenv env pattern_mode (_, ntnvars as lvar) c =
   and intern_args env subscopes = function
     | [] -> []
     | a::args ->
-        let (enva,subscopes) = apply_scope_env env subscopes in
-        (intern_no_implicit enva a) :: (intern_args env subscopes args)
+      let (enva,subscopes) = apply_scope_env env subscopes in
+      let a = intern_no_implicit enva a in
+      a :: (intern_args env subscopes args)
 
   in
   intern env c

--- a/test-suite/output/UnboundRef.out
+++ b/test-suite/output/UnboundRef.out
@@ -1,0 +1,3 @@
+File "stdin", line 1, characters 11-12:
+Error: The reference a was not found in the current environment.
+

--- a/test-suite/output/UnboundRef.v
+++ b/test-suite/output/UnboundRef.v
@@ -1,0 +1,2 @@
+Check Prop a b.
+(* Prop is because we need a real head for the application *)


### PR DESCRIPTION
This makes it so that we have an application `h a b` with both `a` and
`b` unbound, `a` is the one that is reported (parent commit with my current
compiler setup reports `b` first, and the code does not define which
it should be).

Ideally we would report both but that requires more code.
