### PR TITLE
[proof using] Remove duplicate code, refactor.

### DIFF
--- a/vernac/comFixpoint.ml
+++ b/vernac/comFixpoint.ml
@@ -259,13 +259,10 @@ let build_recthms ~indexes ?using fixnames fixtypes fiximps =
   in
   let thms =
     List.map3 (fun name typ (ctx,impargs,_) ->
-        let using = using |> Option.map (fun expr ->
-          let terms = [EConstr.of_constr typ] in
-          let env = Global.env() in
-          let sigma = Evd.from_env env in
-          let l = Proof_using.process_expr env sigma expr terms in
-          Names.Id.Set.(List.fold_right add l empty))
-        in
+        let env = Global.env() in
+        let evd = Evd.from_env env in
+        let terms = [EConstr.of_constr typ] in
+        let using = Option.map (fun using -> Proof_using.definition_using env evd ~using ~terms) using in
         let args = List.map Context.Rel.Declaration.get_name ctx in
         Declare.CInfo.make ~name ~typ ~args ~impargs ?using ()
       ) fixnames fixtypes fiximps

--- a/vernac/comProgramFixpoint.ml
+++ b/vernac/comProgramFixpoint.ml
@@ -259,10 +259,9 @@ let build_wellfounded pm (recname,pl,bl,arityc,body) poly ?typing_flags ?using r
   let evars, _, evars_def, evars_typ =
     RetrieveObl.retrieve_obligations env recname sigma 0 def typ
   in
-  let using = using |> Option.map (fun expr ->
+  let using =
     let terms = List.map EConstr.of_constr [evars_def; evars_typ] in
-    let l = Proof_using.process_expr env sigma expr terms in
-    Names.Id.Set.(List.fold_right add l empty))
+    Option.map (fun using -> Proof_using.definition_using env sigma ~using ~terms) using
   in
   let uctx = Evd.evar_universe_context sigma in
   let cinfo = Declare.CInfo.make ~name:recname ~typ:evars_typ ?using () in
@@ -294,11 +293,8 @@ let do_program_recursive ~pm ~scope ~poly ?typing_flags ?using fixkind fixl =
   let evd = nf_evar_map_undefined evd in
   let collect_evars name def typ impargs =
     (* Generalize by the recursive prototypes  *)
-    let using = using |> Option.map (fun expr ->
-      let terms = [def; typ] in
-      let l = Proof_using.process_expr env evd expr terms in
-      Names.Id.Set.(List.fold_right add l empty))
-    in
+    let terms = [def; typ] in
+    let using = Option.map (fun using -> Proof_using.definition_using env evd ~using ~terms) using in
     let def = nf_evar evd (Termops.it_mkNamedLambda_or_LetIn def rec_sign) in
     let typ = nf_evar evd (Termops.it_mkNamedProd_or_LetIn typ rec_sign) in
     let evm = collect_evars_of_term evd def typ in

--- a/vernac/declare.ml
+++ b/vernac/declare.ml
@@ -57,7 +57,7 @@ module CInfo = struct
     (** Names to pre-introduce  *)
     ; impargs : Impargs.manual_implicits
     (** Explicitily declared implicit arguments  *)
-    ; using : Names.Id.Set.t option
+    ; using : Proof_using.t option
     (** Explicit declaration of section variables used by the constant *)
     }
 
@@ -1478,11 +1478,10 @@ let start_mutual_with_initialization ~info ~cinfo ~mutual_info sigma snl =
 let get_used_variables pf = pf.using
 let get_universe_decl pf = pf.pinfo.Proof_info.info.Info.udecl
 
-let set_used_variables ps l =
+let set_used_variables ps ~using =
   let open Context.Named.Declaration in
   let env = Global.env () in
-  let ids = List.fold_right Id.Set.add l Id.Set.empty in
-  let ctx = Environ.keep_hyps env ids in
+  let ctx = Environ.keep_hyps env using in
   let ctx_set =
     List.fold_right Id.Set.add (List.map NamedDecl.get_id ctx) Id.Set.empty in
   let vars_of = Environ.global_vars_set in

--- a/vernac/declare.mli
+++ b/vernac/declare.mli
@@ -79,7 +79,7 @@ module CInfo : sig
     -> typ:'constr
     -> ?args:Name.t list
     -> ?impargs:Impargs.manual_implicits
-    -> ?using:Names.Id.Set.t
+    -> ?using:Proof_using.t
     -> unit
     -> 'constr t
 
@@ -244,7 +244,7 @@ module Proof : sig
 
   (** Sets the section variables assumed by the proof, returns its closure
    * (w.r.t. type dependencies and let-ins covered by it) *)
-  val set_used_variables : t -> Names.Id.t list -> Constr.named_context * t
+  val set_used_variables : t -> using:Proof_using.t -> Constr.named_context * t
 
   (** Gets the set of variables declared to be used by the proof. None means
       no "Proof using" or #[using] was given *)

--- a/vernac/proof_using.ml
+++ b/vernac/proof_using.ml
@@ -64,6 +64,12 @@ let process_expr env sigma e ty =
   let s = Id.Set.union v_ty (process_expr env sigma e v_ty) in
   Id.Set.elements s
 
+type t = Names.Id.Set.t
+
+let definition_using env evd ~using ~terms =
+  let l = process_expr env evd using terms in
+  Names.Id.Set.(List.fold_right add l empty)
+
 let name_set id expr = known_names := (id,expr) :: !known_names
 
 let minimize_hyps env ids =

--- a/vernac/proof_using.mli
+++ b/vernac/proof_using.mli
@@ -10,10 +10,17 @@
 
 (** Utility code for section variables handling in Proof using... *)
 
-val process_expr :
-  Environ.env -> Evd.evar_map ->
-  Vernacexpr.section_subset_expr -> EConstr.types list ->
-    Names.Id.t list
+(** At some point it would be good to make this abstract *)
+type t = Names.Id.Set.t
+
+(** Process a [using] expression in definitions to provide the list of
+    used terms *)
+val definition_using
+  : Environ.env
+  -> Evd.evar_map
+  -> using:Vernacexpr.section_subset_expr
+  -> terms:EConstr.constr list
+  -> t
 
 val name_set : Names.Id.t -> Vernacexpr.section_subset_expr -> unit
 


### PR DESCRIPTION
PR #13183 introduced quite a bit of duplicate code, we refactor it and
expose less internals on the way. That should make the API more
robust.

@gares, this was in my typing flags tree, as you should be the assignee I'll let you set the milestone [seems trivial enough IMO]