### PR TITLE
We give to the binders grammar entry a status of reusable extra argument

### DIFF
--- a/interp/stdarg.ml
+++ b/interp/stdarg.ml
@@ -61,8 +61,11 @@ let wit_uconstr = make0 "uconstr"
 
 let wit_open_constr = make0 ~dyn:(val_tag (topwit wit_constr)) "open_constr"
 
-let wit_clause_dft_concl  =
+let wit_clause_dft_concl =
   make0 "clause_dft_concl"
+
+let wit_binders =
+  make0 "binders"
 
 (** Aliases for compatibility *)
 

--- a/interp/stdarg.mli
+++ b/interp/stdarg.mli
@@ -59,6 +59,8 @@ val wit_open_constr :
 
 val wit_clause_dft_concl :  (lident Locus.clause_expr, lident Locus.clause_expr, Names.Id.t Locus.clause_expr) genarg_type
 
+val wit_binders : (local_binder_expr list, Util.Empty.t, Util.Empty.t) genarg_type
+
 (** Aliases for compatibility *)
 
 val wit_natural : int uniform_genarg_type

--- a/plugins/ltac/g_rewrite.mlg
+++ b/plugins/ltac/g_rewrite.mlg
@@ -207,27 +207,6 @@ VERNAC COMMAND EXTEND AddRelation3 CLASSIFIED AS SIDEFF
       { declare_relation atts a aeq n None None (Some lemma3) }
 END
 
-{
-
-type binders_argtype = local_binder_expr list
-
-let wit_binders =
- (Genarg.create_arg "binders" : binders_argtype Genarg.uniform_genarg_type)
-
-let binders = Pcoq.create_generic_entry2 "binders" (Genarg.rawwit wit_binders)
-
-let () =
-  let raw_printer env sigma _ _ _ l = Pp.pr_non_empty_arg (Ppconstr.pr_binders env sigma) l in
-  Pptactic.declare_extra_vernac_genarg_pprule wit_binders raw_printer
-
-}
-
-GRAMMAR EXTEND Gram
-  GLOBAL: binders;
-    binders:
-    [ [ b = Pcoq.Constr.binders -> { b } ] ];
-END
-
 VERNAC COMMAND EXTEND AddParametricRelation CLASSIFIED AS SIDEFF
   | #[ atts = rewrite_attributes; ] [ "Add" "Parametric" "Relation" binders(b) ":" constr(a) constr(aeq)
         "reflexivity" "proved" "by" constr(lemma1)

--- a/plugins/ltac/g_rewrite.mlg
+++ b/plugins/ltac/g_rewrite.mlg
@@ -81,7 +81,7 @@ let pr_raw_strategy env sigma prc prlc _ (s : raw_strategy) =
   Rewrite.pr_strategy (prc env sigma) prr s
 let pr_glob_strategy env sigma prc prlc _ (s : glob_strategy) =
   let prpat env sigma (_,c,_) = prc env sigma c in
-  let prcst = Pputils.pr_or_var Pptactic.(pr_and_short_name (pr_evaluable_reference_env env)) in
+  let prcst = Pputils.pr_or_var Pptactic.(pr_and_short_name (Ppred.pr_evaluable_reference_env env)) in
   let prr = Pptactic.pr_red_expr env sigma (prc, prlc, prcst, prpat) in
   Rewrite.pr_strategy (prc env sigma) prr s
 

--- a/plugins/ltac/pltac.ml
+++ b/plugins/ltac/pltac.ml
@@ -66,4 +66,5 @@ let () =
   register_grammar wit_ltac (tactic);
   register_grammar wit_clause_dft_concl (clause_dft_concl);
   register_grammar wit_destruction_arg (destruction_arg);
+  register_grammar Stdarg.wit_binders (Pcoq.Constr.binders);
   ()

--- a/plugins/ltac/pltac.ml
+++ b/plugins/ltac/pltac.ml
@@ -66,5 +66,6 @@ let () =
   register_grammar wit_ltac (tactic);
   register_grammar wit_clause_dft_concl (clause_dft_concl);
   register_grammar wit_destruction_arg (destruction_arg);
+  register_grammar Genredexpr.wit_red_expr (Pvernac.Vernac_.red_expr);
   register_grammar Stdarg.wit_binders (Pcoq.Constr.binders);
   ()

--- a/plugins/ltac/pptactic.ml
+++ b/plugins/ltac/pptactic.ml
@@ -190,10 +190,6 @@ let string_of_genarg_arg (ArgumentType arg) =
 
   let pr_and_short_name pr (c,_) = pr c
 
-  let pr_evaluable_reference = function
-    | Tacred.EvalVarRef id -> pr_id id
-    | Tacred.EvalConstRef sp -> pr_global (GlobRef.ConstRef sp)
-
   let pr_quantified_hypothesis = function
     | AnonHyp n -> int n
     | NamedHyp id -> pr_id id
@@ -379,11 +375,6 @@ let string_of_genarg_arg (ArgumentType arg) =
            pr_qualid (Tacenv.shortest_qualid_of_tactic kn)
       with Not_found -> (* local tactic not accessible anymore *)
         str "<" ++ KerName.print kn ++ str ">"
-
-  let pr_evaluable_reference_env env = function
-    | Tacred.EvalVarRef id -> pr_id id
-    | Tacred.EvalConstRef sp ->
-      Nametab.pr_global_env (Termops.vars_of_env env) (GlobRef.ConstRef sp)
 
   let pr_as_disjunctive_ipat prc ipatl =
     keyword "as" ++ spc () ++
@@ -1135,7 +1126,7 @@ let pr_goal_selector ~toplevel s =
         pr_dconstr = (fun env sigma -> pr_and_constr_expr (pr_glob_constr_env env sigma));
         pr_lconstr = (fun env sigma -> pr_and_constr_expr (pr_lglob_constr_env env sigma));
         pr_pattern = (fun env sigma -> pr_pat_and_constr_expr (pr_glob_constr_env env sigma));
-        pr_constant = pr_or_var (pr_and_short_name (pr_evaluable_reference_env env));
+        pr_constant = pr_or_var (pr_and_short_name (Ppred.pr_evaluable_reference_env env));
         pr_lpattern = (fun env sigma -> pr_pat_and_constr_expr (pr_lglob_constr_env env sigma));
         pr_reference = pr_ltac_or_var (pr_located pr_ltac_constant);
         pr_name = pr_lident;
@@ -1171,7 +1162,7 @@ let pr_goal_selector ~toplevel s =
         pr_lconstr = pr_leconstr_env;
         pr_pattern = pr_constr_pattern_env;
         pr_lpattern = pr_lconstr_pattern_env;
-        pr_constant = pr_evaluable_reference_env env;
+        pr_constant = Ppred.pr_evaluable_reference_env env;
         pr_reference = pr_located pr_ltac_constant;
         pr_name = pr_id;
         (* Those are not used by the atomic printer *)
@@ -1270,8 +1261,8 @@ let pr_intro_pattern_env p = Genprint.TopPrinterNeedsContext (fun env sigma ->
   Miscprint.pr_intro_pattern print_constr p)
 
 let pr_red_expr_env r = Genprint.TopPrinterNeedsContext (fun env sigma ->
-  pr_red_expr env sigma ((fun e -> pr_econstr_env e), (fun e -> pr_leconstr_env e),
-                         pr_evaluable_reference_env env, pr_constr_pattern_env) r)
+  Ppred.pr_red_expr_env env sigma ((fun e -> pr_econstr_env e), (fun e -> pr_leconstr_env e),
+                         Ppred.pr_evaluable_reference_env env, pr_constr_pattern_env) Pp.str r)
 
 let pr_bindings_env bl = Genprint.TopPrinterNeedsContext (fun env sigma ->
   let sigma, bl = bl env sigma in

--- a/plugins/ltac/pptactic.ml
+++ b/plugins/ltac/pptactic.ml
@@ -1260,6 +1260,9 @@ let declare_extra_vernac_genarg_pprule wit f =
   let f x = Genprint.PrinterBasic (fun env sigma -> f env sigma pr_constr_expr pr_lconstr_expr pr_raw_tactic_level x) in
   Genprint.register_vernac_print0 wit f
 
+let () =
+  declare_extra_vernac_genarg_pprule Stdarg.wit_binders (fun env sigma _ _ _ -> Ppconstr.pr_binders env sigma)
+
 (** Registering *)
 
 let pr_intro_pattern_env p = Genprint.TopPrinterNeedsContext (fun env sigma ->

--- a/plugins/ltac/pptactic.mli
+++ b/plugins/ltac/pptactic.mli
@@ -106,8 +106,6 @@ val pr_may_eval :
 
 val pr_and_short_name : ('a -> Pp.t) -> 'a Genredexpr.and_short_name -> Pp.t
 
-val pr_evaluable_reference_env : env -> Tacred.evaluable_global_reference -> Pp.t
-
 val pr_quantified_hypothesis : quantified_hypothesis -> Pp.t
 
 val pr_in_clause :

--- a/tactics/ppred.ml
+++ b/tactics/ppred.ml
@@ -1,8 +1,29 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
 open Util
 open Pp
 open Locus
 open Genredexpr
 open Pputils
+open Names
+open Tacred
+
+let pr_evaluable_reference = function
+  | EvalVarRef id -> Id.print id
+  | EvalConstRef sp -> Printer.pr_global (GlobRef.ConstRef sp)
+
+let pr_evaluable_reference_env env = function
+  | EvalVarRef id -> Id.print id
+  | EvalConstRef sp ->
+    Nametab.pr_global_env (Termops.vars_of_env env) (GlobRef.ConstRef sp)
 
 let pr_with_occurrences pr keyword (occs,c) =
   match occs with

--- a/tactics/ppred.mli
+++ b/tactics/ppred.mli
@@ -1,4 +1,18 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
 open Genredexpr
+
+val pr_evaluable_reference : Tacred.evaluable_global_reference -> Pp.t
+
+val pr_evaluable_reference_env : Environ.env -> Tacred.evaluable_global_reference -> Pp.t
 
 val pr_with_occurrences :
   ('a -> Pp.t) -> (string -> Pp.t) -> 'a Locus.with_occurrences -> Pp.t

--- a/vernac/pvernac.ml
+++ b/vernac/pvernac.ml
@@ -79,6 +79,3 @@ end
 let main_entry proof_mode =
   Unsafe.set_tactic_entry proof_mode;
   Vernac_.main_entry
-
-let () =
-  register_grammar Genredexpr.wit_red_expr (Vernac_.red_expr);


### PR DESCRIPTION
This was shown interesting for the purpose of parametric rings (#12409) and was previously hidden in the file of `g_rewrite.mlg`.

**Kind:** code organization
