### PR TITLE
Adding heterogeneous map on named contexts.

### DIFF
--- a/kernel/context.ml
+++ b/kernel/context.ml
@@ -365,6 +365,15 @@ struct
           let ty' = f ty in
           if v == v' && ty == ty' then decl else LocalDef (id, v', ty')
 
+    let map_constr_het f = function
+      | LocalAssum (id, ty) ->
+          let ty' = f ty in
+          LocalAssum (id, ty')
+      | LocalDef (id, v, ty) ->
+          let v' = f v in
+          let ty' = f ty in
+          LocalDef (id, v', ty')
+
     (** Perform a given action on all terms in a given declaration. *)
     let iter_constr f = function
       | LocalAssum (_, ty) -> f ty

--- a/kernel/context.mli
+++ b/kernel/context.mli
@@ -231,6 +231,9 @@ sig
     (** Map all terms in a given declaration. *)
     val map_constr : ('c -> 'c) -> ('c, 'c) pt -> ('c, 'c) pt
 
+    (** Map all terms, with an heterogeneous function. *)
+    val map_constr_het : ('a -> 'b) -> ('a, 'a) pt -> ('b, 'b) pt
+
     (** Perform a given action on all terms in a given declaration. *)
     val iter_constr : ('c -> unit) -> ('c, 'c) pt -> unit
 


### PR DESCRIPTION
Kind: completing the API about typing context

`map_constr_het` existed for `rel_context` and the `named_context` version was shown useful, e.g. for #12409. We complete the API.


