### PR TITLE
Adding an "elaboration"/interpretation function for named_context

### DIFF
--- a/interp/constrintern.mli
+++ b/interp/constrintern.mli
@@ -172,6 +172,13 @@ val interp_context_evars :
   env -> evar_map -> local_binder_expr list ->
   evar_map * (internalization_env * ((env * rel_context) * Impargs.manual_implicits))
 
+(** Interpret named contexts: returns context *)
+
+val interp_named_context_evars :
+  ?program_mode:bool -> ?impl_env:internalization_env ->
+  env -> evar_map -> local_binder_expr list ->
+  evar_map * (internalization_env * ((env * named_context) * Impargs.manual_implicits))
+
 (** Locating references of constructions, possibly via a syntactic definition
    (these functions do not modify the glob file) *)
 


### PR DESCRIPTION
**Kind:** constrintern.ml API 

There was a function to "interpret" `rel_context`, we add one for interpreting `named_context`. This is a priori of general interest and was at least useful for #12409.