### PR TITLE
[doc] add a link to v8.13

### DIFF
--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -221,7 +221,8 @@ html_context = {
     'versions': [
         ("dev", "https://coq.github.io/doc/master/refman/"),
         ("stable", "https://coq.inria.fr/distrib/current/refman/"),
-        ("v8.12", "https://coq.github.io/doc/v8.12/refman/"),
+        ("v8.13", "https://coq.github.io/doc/v8.13/refman/"),
+        ("8.12", "https://coq.inria.fr/distrib/V8.12.1/refman/"),
         ("8.11", "https://coq.inria.fr/distrib/V8.11.2/refman/"),
         ("8.10", "https://coq.inria.fr/distrib/V8.10.2/refman/"),
         ("8.9", "https://coq.inria.fr/distrib/V8.9.1/refman/"),


### PR DESCRIPTION
It seems the link for 8.12 changed format w.r.t. previous versions.
I did copy that one, you tell me if it makes sense.
Also, should this be backported?