### PR TITLE
[ci] Use lite target for Perennial

### DIFF
--- a/dev/ci/ci-perennial.sh
+++ b/dev/ci/ci-perennial.sh
@@ -6,7 +6,4 @@ ci_dir="$(dirname "$0")"
 FORCE_GIT=1
 git_download perennial
 
-# required by Perennial's coqc.py build wrapper
-export LC_ALL=C.UTF-8
-
-( cd "${CI_BUILD_DIR}/perennial" && git submodule update --init --recursive && make TIMED=false )
+( cd "${CI_BUILD_DIR}/perennial" && git submodule update --init --recursive && make TIMED=false lite )


### PR DESCRIPTION
<!-- Keep what applies -->
**Kind:** infrastructure.

Perennial has started taking a lot of time and memory to compile, more than we should be using as part of Coq's CI. This PR switches to a new `lite` target of the Perennial Makefile, decoupling what Perennial's default target builds vs what Coq builds.

For now this target just builds a couple examples and some unit tests rather than our whole large program verification case study. On my machine this took 30 user minutes. If we want to shorten this I could build less by changing [LiteBuild.v](https://github.com/mit-pdos/perennial/blob/master/src/LiteBuild.v) in Perennial and we would still be covering the core infrastructure, just not as much of the program proofs.