### PR TITLE
Use only nats for occs_nums rather than ints

### DIFF
--- a/doc/changelog/04-tactics/13403-occs_nums_nat.rst
+++ b/doc/changelog/04-tactics/13403-occs_nums_nat.rst
@@ -1,0 +1,7 @@
+- **Removed:**
+  :n:`at @occs_nums` clauses in tactics such as tacn:`unfold`
+  no longer allow negative values.  A "-" before the
+  list (for set complement) is still supported.  Ex: "at -1 -2"
+  is no longer supported but "at -1 2" is.
+  (`#13403 <https://github.com/coq/coq/pull/13403>`_,
+  by Jim Fehrle).

--- a/doc/sphinx/proofs/writing-proofs/rewriting.rst
+++ b/doc/sphinx/proofs/writing-proofs/rewriting.rst
@@ -320,7 +320,7 @@ Performing computations
    ref_or_pattern_occ ::= @reference {? at @occs_nums }
    | @one_term {? at @occs_nums }
    occs_nums ::= {+ {| @natural | @ident } }
-   | - {| @natural | @ident } {* @int_or_var }
+   | - {+ {| @natural | @ident } }
    int_or_var ::= @integer
    | @ident
    unfold_occ ::= @reference {? at @occs_nums }

--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -1939,11 +1939,6 @@ tac2rec_fields: [
 | LIST1 tac2rec_field SEP ";" OPT ";" TAG Ltac2
 ]
 
-(* todo: weird productions, ints only after an initial "-"??:
-  occs_nums: [
-  | LIST1 [ natural | ident ]
-  | "-" [ natural | ident ] LIST0 int_or_var
-*)
 ltac2_occs_nums: [
 | DELETE LIST1 nat_or_anti      (* Ltac2 plugin *)
 | REPLACE "-" nat_or_anti LIST0 nat_or_anti      (* Ltac2 plugin *)

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -480,6 +480,7 @@ opt_hintbases: [
 command: [
 | "Goal" lconstr
 | "Proof"
+| "Proof" "using" G_vernac.section_subset_expr
 | "Proof" "Mode" string
 | "Proof" lconstr
 | "Abort"
@@ -604,7 +605,7 @@ command: [
 | "Typeclasses" "Opaque" LIST1 reference
 | "Typeclasses" "eauto" ":=" debug eauto_search_strategy OPT natural
 | "Proof" "with" Pltac.tactic OPT [ "using" G_vernac.section_subset_expr ]
-| "Proof" "using" G_vernac.section_subset_expr OPT [ "with" Pltac.tactic ]
+| "Proof" "using" G_vernac.section_subset_expr "with" Pltac.tactic
 | "Tactic" "Notation" OPT ltac_tactic_level LIST1 ltac_production_item ":=" tactic
 | "Print" "Ltac" reference
 | "Locate" "Ltac" reference
@@ -2327,7 +2328,7 @@ conversion: [
 
 occs_nums: [
 | LIST1 nat_or_var
-| "-" nat_or_var LIST0 int_or_var
+| "-" LIST1 nat_or_var
 ]
 
 occs: [
@@ -2537,6 +2538,7 @@ or_and_intropattern_loc: [
 
 as_or_and_ipat: [
 | "as" or_and_intropattern_loc
+| "as" equality_intropattern
 |
 ]
 

--- a/doc/tools/docgram/orderedGrammar
+++ b/doc/tools/docgram/orderedGrammar
@@ -648,7 +648,7 @@ ref_or_pattern_occ: [
 
 occs_nums: [
 | LIST1 [ natural | ident ]
-| "-" [ natural | ident ] LIST0 int_or_var
+| "-" LIST1 [ natural | ident ]
 ]
 
 int_or_var: [
@@ -944,6 +944,7 @@ command: [
 | "Extract" "Inductive" qualid "=>" [ ident | string ] "[" LIST0 [ ident | string ] "]" OPT string      (* extraction plugin *)
 | "Show" "Extraction"      (* extraction plugin *)
 | "Proof"
+| "Proof" "using" section_var_expr
 | "Proof" "Mode" string
 | "Proof" term
 | "Abort" OPT [ "All" | ident ]
@@ -1024,7 +1025,7 @@ command: [
 | "Typeclasses" "Opaque" LIST1 qualid
 | "Typeclasses" "eauto" ":=" OPT "debug" OPT ( "(" [ "bfs" | "dfs" ] ")" ) OPT natural
 | "Proof" "with" ltac_expr OPT [ "using" section_var_expr ]
-| "Proof" "using" section_var_expr OPT [ "with" ltac_expr ]
+| "Proof" "using" section_var_expr "with" ltac_expr
 | "Tactic" "Notation" OPT ( "(" "at" "level" natural ")" ) LIST1 ltac_production_item ":=" ltac_expr
 | "Print" "Rewrite" "HintDb" ident
 | "Print" "Ltac" qualid
@@ -1960,6 +1961,7 @@ or_and_intropattern_loc: [
 
 as_or_and_ipat: [
 | "as" or_and_intropattern_loc
+| "as" equality_intropattern
 ]
 
 eqn_ipat: [

--- a/plugins/ltac/g_tactic.mlg
+++ b/plugins/ltac/g_tactic.mlg
@@ -234,9 +234,7 @@ GRAMMAR EXTEND Gram
   ;
   occs_nums:
     [ [ nl = LIST1 nat_or_var -> { OnlyOccurrences nl }
-      | "-"; n = nat_or_var; nl = LIST0 int_or_var ->
-          (* have used int_or_var instead of nat_or_var for compatibility *)
-         { AllOccurrencesBut (List.map (Locusops.or_var_map abs) (n::nl)) } ] ]
+      | "-"; nl = LIST1 nat_or_var -> { AllOccurrencesBut nl } ] ]
   ;
   occs:
     [ [ "at"; occs = occs_nums -> { occs } | -> { AllOccurrences } ] ]


### PR DESCRIPTION
In https://github.com/coq/coq/pull/13343#discussion_r524341931, @Zimmi48 noticed that `change a with b in * at -1 -2` is accepted, or `... at -1 2` but `... at 1 -2` is not.  That's because of the way that the `occs_nums` productions are written:

```
occs_nums: [
| LIST1 nat_or_var
| "-" nat_or_var LIST0 int_or_var
]
```

This change replaces the `int_or_var`.  The line taking the absolute value of the ints is from 2008 by one @herbelin.  Perhaps after 12 years we can remove this?  OTOH there hasn't been a deprecation message.

Please advise whether I should add a deprecation message first.  Also whether this should have a change log entry.
