### PR TITLE
Fast path in clenv_dependent

### DIFF
--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -303,17 +303,13 @@ let clenv_unify ?(flags=default_unify_flags ()) cv_pb t1 t2 clenv =
 let clenv_unify_meta_types ?(flags=default_unify_flags ()) clenv =
   { clenv with evd = w_unify_meta_types ~flags:flags clenv.env clenv.evd }
 
-let clenv_unique_resolver_gen ?(flags=default_unify_flags ()) clenv concl =
+let clenv_unique_resolver ~flags clenv concl =
   if isMeta clenv.evd (fst (decompose_app_vect clenv.evd (whd_nored clenv.env clenv.evd clenv.templtyp.rebus))) then
     clenv_unify CUMUL ~flags (clenv_type clenv) concl
       (clenv_unify_meta_types ~flags clenv)
   else
     clenv_unify CUMUL ~flags
       (meta_reducible_instance clenv.env clenv.evd clenv.templtyp) concl clenv
-
-let clenv_unique_resolver ?flags clenv gl =
-  let concl = Proofview.Goal.concl gl in
-  clenv_unique_resolver_gen ?flags clenv concl
 
 let adjust_meta_source evd mv = function
   | loc,Evar_kinds.VarInstance id ->
@@ -626,8 +622,12 @@ let clenv_pose_dependent_evars ?(with_evars=false) clenv =
       (RefinerError (env, sigma, UnresolvedBindings (List.map (meta_name clenv.evd) dep_mvs)));
   clenv_pose_metas_as_evars clenv dep_mvs
 
-let clenv_refine ?(with_evars=false) ?(with_classes=true) clenv =
+let dft = default_unify_flags
+
+let res_pf ?(with_evars=false) ?(with_classes=true) ?(flags=dft ()) clenv =
   Proofview.Goal.enter begin fun gl ->
+  let concl = Proofview.Goal.concl gl in
+  let clenv = clenv_unique_resolver ~flags clenv concl in
   let clenv = clenv_pose_dependent_evars ~with_evars clenv in
   let evd' =
     if with_classes then
@@ -647,14 +647,6 @@ let clenv_refine ?(with_evars=false) ?(with_classes=true) clenv =
   end
 
 open Unification
-
-let dft = default_unify_flags
-
-let res_pf ?with_evars ?(with_classes=true) ?(flags=dft ()) clenv =
-  Proofview.Goal.enter begin fun gl ->
-    let clenv = clenv_unique_resolver ~flags clenv gl in
-    clenv_refine ?with_evars ~with_classes clenv
-  end
 
 (* [unifyTerms] et [unify] ne semble pas gérer les Meta, en
    particulier ne semblent pas vérifier que des instances différentes

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -221,18 +221,20 @@ let dependent_closure clenv mvs =
 
 let clenv_dependent_gen hyps_only ?(iter=true) clenv =
   let all_undefined = undefined_metas clenv.evd in
-  let deps_in_concl = (mk_freelisted (clenv_type clenv)).freemetas in
-  let deps_in_hyps = dependent_in_type_of_metas clenv all_undefined in
-  let deps_in_concl =
-    if hyps_only && iter then dependent_closure clenv deps_in_concl
-    else deps_in_concl in
-  List.filter
-    (fun mv ->
-      if hyps_only then
-        Metaset.mem mv deps_in_hyps && not (Metaset.mem mv deps_in_concl)
-      else
-        Metaset.mem mv deps_in_hyps || Metaset.mem mv deps_in_concl)
-    all_undefined
+  if List.is_empty all_undefined then []
+  else
+    let deps_in_concl = (mk_freelisted (clenv_type clenv)).freemetas in
+    let deps_in_hyps = dependent_in_type_of_metas clenv all_undefined in
+    let deps_in_concl =
+      if hyps_only && iter then dependent_closure clenv deps_in_concl
+      else deps_in_concl in
+    List.filter
+      (fun mv ->
+        if hyps_only then
+          Metaset.mem mv deps_in_hyps && not (Metaset.mem mv deps_in_concl)
+        else
+          Metaset.mem mv deps_in_hyps || Metaset.mem mv deps_in_concl)
+      all_undefined
 
 let clenv_missing ce = clenv_dependent_gen true ce
 let clenv_dependent ce = clenv_dependent_gen false ce


### PR DESCRIPTION
When there are no free metas there is no point in trying to compute the set of dependent metas in potentially big terms.