### PR TITLE
[changelog] Indicate a replacement for deprecated syntax of debug / info_eauto.

### DIFF
--- a/doc/changelog/04-tactics/13381-bfs_eauto.rst
+++ b/doc/changelog/04-tactics/13381-bfs_eauto.rst
@@ -1,6 +1,6 @@
 - **Deprecated:**
   Undocumented :n:`eauto @int_or_var @int_or_var` syntax in favor of new ``bfs eauto``.
-  Also deprecated 2-integer syntax for ``debug eauto`` and ``info_eauto``;
-  replacement TBD.
+  Also deprecated 2-integer syntax for ``debug eauto`` and ``info_eauto``.
+  (Use ``bfs eauto`` with the :flag:`Info Eauto` or :flag:`Debug Eauto` flags instead.)
   (`#13381 <https://github.com/coq/coq/pull/13381>`_,
   by Jim Fehrle).


### PR DESCRIPTION
**Kind:** documentation

@jfehrle I realized that there already is an acceptable replacement for `debug eauto @int_or_var @int_or_var` and `info_eauto @int_or_var @int_or_var` since the `Debug Eauto` and `Info Eauto` flags activate the same logging as the `debug` and `info_` prefixes.