### PR TITLE
Add support for instantiating non-implicit arguments by name or index

### DIFF
--- a/dev/ci/user-overlays/13443-herbelin-master+instantiate-non-implicit-arguments-by-name-or-index.sh
+++ b/dev/ci/user-overlays/13443-herbelin-master+instantiate-non-implicit-arguments-by-name-or-index.sh
@@ -1,0 +1,2 @@
+overlay elpi https://github.com/herbelin/coq-elpi coq-master+adapt-coq-pr13443-non-implicit-args-by-name 13443
+overlay equations https://github.com/herbelin/Coq-Equations master+adapt-coq-pr13443-non-implicit-args-by-name 13443

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -674,7 +674,7 @@ let adjust_implicit_arguments inctx n args impl =
           (!print_implicits && !print_implicits_explicit_args) ||
           (is_needed_for_correct_partial_application tail imp) ||
           (!print_implicits_defensive &&
-           (not (is_inferable_implicit inctx n imp) || !Flags.beautify) &&
+           (not (is_inferable_implicit inctx (List.length args) imp) || !Flags.beautify) &&
            is_significant_implicit (Lazy.force a))
         in
         if visible then

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -1429,7 +1429,7 @@ let rec adjust_to_down l l' default =
   match l, l' with
   | [], l -> []
   | true::l, l' -> adjust_to_down l l' default
-  | false::l, [] -> default :: adjust_to_down l [] default
+  | false::l, [] -> default :: adjust_to_down l l' default
   | false::l, y::l' -> y :: adjust_to_down l l' default
 
 (* @return the first variable that occurs twice in a pattern

--- a/interp/constrintern.ml
+++ b/interp/constrintern.ml
@@ -1972,27 +1972,6 @@ let set_hole_implicit i b c =
   | _ -> anomaly (Pp.str "Only refs have implicits.") in
   Loc.tag ?loc (Evar_kinds.ImplicitArg (r,i,b),IntroAnonymous,None)
 
-let is_named_argument id =
-  List.exists (fun imp -> is_status_implicit imp && Id.equal id (name_of_argument imp))
-
-let print_allowed_named_implicit imps =
-  let l = List.map_filter (function ((Name id,_,_),Some _) -> Some id | _ -> None) imps in
-  match l with
-  | [] -> mt ()
-  | l ->
-    let n = List.length l in
-    str " (possible " ++ str (String.plural n "name") ++ str ":" ++ spc () ++
-    pr_sequence Id.print l ++ str ")"
-
-let print_allowed_nondep_implicit imps =
-  let l = List.map_filter (function ((_,_,Some n),Some _) -> Some n | _ -> None) imps in
-  match l with
-  | [] -> mt ()
-  | l ->
-    let n = List.length l in
-    str " (possible " ++ str (String.plural n "position") ++ str ":" ++ spc () ++
-    pr_sequence Pp.int l ++ str ")"
-
 let extract_explicit_arg imps args =
   let rec aux = function
   | [] -> [], []

--- a/interp/impargs.ml
+++ b/interp/impargs.ml
@@ -346,14 +346,14 @@ let binding_kind_of_status = function
   | _, Some (_, true, _) -> MaxImplicit
   | _, None -> Explicit
 
-let name_of_argument = function
+let name_of_argument i = function
   | ((Name id,_,_),_) -> id
-  | ((Anonymous,k,_),_) -> name_of_pos k
+  | ((Anonymous,_,_),_) -> name_of_pos i
 
-let match_argument imp pos = match imp, pos with
+let match_argument i imp pos = match imp, pos with
   | ((Name id,_,_),_), ExplByName id' -> Id.equal id id'
   | ((_,_,Some n),_), ExplByPos n' -> Int.equal n n'
-  | ((_,n,_),_), ExplByName id -> Id.equal id (name_of_pos n)
+  | ((_,_,_),_), ExplByName id -> Id.equal id (name_of_pos i)
   | _ -> false
 
 let maximal_insertion_of = function
@@ -364,14 +364,14 @@ let force_inference_of = function
   | _, Some (_, _, b) -> b
   | _, None -> anomaly (Pp.str "Not an implicit argument.")
 
-let is_named_argument id =
-  List.exists (fun imp -> is_status_implicit imp && Id.equal id (name_of_argument imp))
+let is_named_argument id imps =
+  List.exists_i (fun i imp -> Id.equal id (name_of_argument i imp)) 1 imps
 
 let is_nondep_argument p imps =
-  List.exists (function ((_,_,Some p'),Some _) -> Int.equal p p' | _ -> false) imps
+  List.exists (function ((_,_,Some p'),_) -> Int.equal p p' | _ -> false) imps
 
 let print_allowed_named_implicit imps =
-  let l = List.map_filter (function ((Name id,_,_),Some _) -> Some id | _ -> None) imps in
+  let l = List.map_filter (function ((Name id,_,_),_) -> Some id | _ -> None) imps in
   match l with
   | [] -> mt ()
   | l ->
@@ -380,7 +380,7 @@ let print_allowed_named_implicit imps =
     pr_sequence Id.print l ++ str ")"
 
 let print_allowed_nondep_implicit imps =
-  let l = List.map_filter (function ((_,_,Some n),Some _) -> Some n | _ -> None) imps in
+  let l = List.map_filter (function ((_,_,Some n),_) -> Some n | _ -> None) imps in
   match l with
   | [] -> mt ()
   | l ->

--- a/interp/impargs.ml
+++ b/interp/impargs.ml
@@ -364,8 +364,29 @@ let force_inference_of = function
   | _, Some (_, _, b) -> b
   | _, None -> anomaly (Pp.str "Not an implicit argument.")
 
+let is_named_argument id =
+  List.exists (fun imp -> is_status_implicit imp && Id.equal id (name_of_argument imp))
+
 let is_nondep_argument p imps =
   List.exists (function ((_,_,Some p'),Some _) -> Int.equal p p' | _ -> false) imps
+
+let print_allowed_named_implicit imps =
+  let l = List.map_filter (function ((Name id,_,_),Some _) -> Some id | _ -> None) imps in
+  match l with
+  | [] -> mt ()
+  | l ->
+    let n = List.length l in
+    str " (possible " ++ str (String.plural n "name") ++ str ":" ++ spc () ++
+    pr_sequence Id.print l ++ str ")"
+
+let print_allowed_nondep_implicit imps =
+  let l = List.map_filter (function ((_,_,Some n),Some _) -> Some n | _ -> None) imps in
+  match l with
+  | [] -> mt ()
+  | l ->
+    let n = List.length l in
+    str " (possible " ++ str (String.plural n "position") ++ str ":" ++ spc () ++
+    pr_sequence Pp.int l ++ str ")"
 
 (* [in_ctx] means we know the expected type, [n] is the number of extra arguments *)
 let is_inferable_implicit in_ctx n (pos,x) =

--- a/interp/impargs.mli
+++ b/interp/impargs.mli
@@ -86,8 +86,8 @@ type implicits_list = implicit_side_condition * implicit_status list
 val is_status_implicit : implicit_status -> bool
 val binding_kind_of_status : implicit_status -> Glob_term.binding_kind
 val is_inferable_implicit : bool -> int -> implicit_status -> bool
-val name_of_argument : implicit_status -> Id.t
-val match_argument : implicit_status -> Constrexpr.explicitation -> bool
+val name_of_argument : int -> implicit_status -> Id.t
+val match_argument : int -> implicit_status -> Constrexpr.explicitation -> bool
 val maximal_insertion_of : implicit_status -> bool
 val force_inference_of : implicit_status -> bool
 val is_named_argument : Id.t -> implicit_status list -> bool

--- a/interp/impargs.mli
+++ b/interp/impargs.mli
@@ -90,8 +90,12 @@ val name_of_argument : implicit_status -> Id.t
 val match_argument : implicit_status -> Constrexpr.explicitation -> bool
 val maximal_insertion_of : implicit_status -> bool
 val force_inference_of : implicit_status -> bool
+val is_named_argument : Id.t -> implicit_status list -> bool
 val is_nondep_argument : int -> implicit_status list -> bool
 val explicitation : implicit_status -> Constrexpr.explicitation
+
+val print_allowed_named_implicit : implicit_status list -> Pp.t
+val print_allowed_nondep_implicit : implicit_status list -> Pp.t
 
 val positions_of_implicits : implicits_list -> int list
 

--- a/interp/impargs.mli
+++ b/interp/impargs.mli
@@ -70,9 +70,14 @@ type force_inference = bool (** true = always infer, never turn into evar/subgoa
 
 type implicit_position = Name.t * int * int option
 
-type implicit_status = (implicit_position * implicit_explanation *
-                          (maximal_insertion * force_inference)) option
+type implicit_proper_status
+
+type implicit_status = implicit_position * implicit_proper_status option
+
     (** [None] = Not implicit *)
+val default_implicit : maximal:bool -> force:bool -> implicit_proper_status
+  (** maximal:true = maximal contextual insertion
+      force:true = always infer, never turn into evar/subgoal *)
 
 type implicit_side_condition
 
@@ -81,11 +86,11 @@ type implicits_list = implicit_side_condition * implicit_status list
 val is_status_implicit : implicit_status -> bool
 val binding_kind_of_status : implicit_status -> Glob_term.binding_kind
 val is_inferable_implicit : bool -> int -> implicit_status -> bool
-val name_of_implicit : implicit_status -> Id.t
-val match_implicit : implicit_status -> Constrexpr.explicitation -> bool
+val name_of_argument : implicit_status -> Id.t
+val match_argument : implicit_status -> Constrexpr.explicitation -> bool
 val maximal_insertion_of : implicit_status -> bool
 val force_inference_of : implicit_status -> bool
-val is_nondep_implicit : int -> implicit_status list -> bool
+val is_nondep_argument : int -> implicit_status list -> bool
 val explicitation : implicit_status -> Constrexpr.explicitation
 
 val positions_of_implicits : implicits_list -> int list

--- a/parsing/g_constr.mlg
+++ b/parsing/g_constr.mlg
@@ -233,7 +233,8 @@ GRAMMAR EXTEND Gram
         { let ty,c1 = match ty, c1 with
           | (_,None), { CAst.v = CCast(c, DEFAULTcast, t) } -> (Loc.tag ?loc:(constr_loc t) @@ Some t), c (* Tolerance, see G_vernac.def_body *)
           | _, _ -> ty, c1 in
-          CAst.make ~loc @@ CLetIn(id,mkLambdaCN ?loc:(constr_loc c1) bl c1,
+          let body_loc = Loc.merge_opt (constr_loc c1) (local_binders_loc bl) in
+          CAst.make ~loc @@ CLetIn(id,mkLambdaCN ?loc:body_loc bl c1,
                  Option.map (mkProdCN ?loc:(fst ty) bl) (snd ty), c2) }
       | "let"; "fix"; fx = fix_decl; "in"; c = term LEVEL "200" ->
         { let {CAst.loc=locf;CAst.v=({CAst.loc=li;CAst.v=id} as lid,_,_,_,_ as dcl)} = fx in

--- a/plugins/syntax/number.ml
+++ b/plugins/syntax/number.ml
@@ -337,8 +337,8 @@ let elaborate_to_post_via env sigma ty_name ty_ind l =
        match modulo [ind2ty] *)
     let rm_impls impls (l, t) =
       let rec aux impls l = match impls, l with
-        | Some _ :: impls, _ :: b -> aux impls b
-        | None :: impls, (n, a) :: b -> (n, a) :: aux impls b
+        | (_, Some _) :: impls, _ :: b -> aux impls b
+        | (_, None) :: impls, (n, a) :: b -> (n, a) :: aux impls b
         | _ -> l in
       aux impls l, t in
     let replace m (l, t) =
@@ -362,7 +362,7 @@ let elaborate_to_post_via env sigma ty_name ty_ind l =
   (* Finally elaborate [to_post] *)
   let to_post =
     let rec map_prod impls tindc = match impls with
-      | Some _ :: impls -> ToPostHole :: map_prod impls tindc
+      | (_, Some _) :: impls -> ToPostHole :: map_prod impls tindc
       | _ ->
          match tindc with
          | [] -> []

--- a/test-suite/success/implicit.v
+++ b/test-suite/success/implicit.v
@@ -187,3 +187,18 @@ Arguments bar {A} {x} _ {B} {y}.
 Check bar (1:=true) 0 (3:=false).
 
 End TestUnnamedImplicit.
+
+Module AnyArgumentsInAnyOrder.
+
+Unset Implicit Arguments.
+
+Definition p {A} (x:A) (y:A) := (x,y).
+Check p (y:=0) (x:=1).
+Fail Check p (y:=0).
+
+Definition p2 {A} B (x:A) (y:B) := (x,y).
+About p2.
+Check p2 (y:=1) (1:=0) nat.
+Fail Check p2 (y:=1) (1:=0).
+
+End AnyArgumentsInAnyOrder.

--- a/vernac/comProgramFixpoint.ml
+++ b/vernac/comProgramFixpoint.ml
@@ -199,7 +199,7 @@ let build_wellfounded pm (recname,pl,bl,arityc,body) poly ?typing_flags ?using r
     in
     let newimpls = Id.Map.singleton recname
         (Constrintern.extend_internalization_data interning_data
-           (Some ((Name (Id.of_string "recproof"),1,None), Impargs.Manual, (true, false)))
+           ((Name (Id.of_string "recproof"),1,None), Some (Impargs.default_implicit ~maximal:true ~force:false))
            None) in
     interp_casted_constr_evars ~program_mode:true (push_rel_context ctx env) sigma
       ~impls:newimpls body (lift 1 top_arity)

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -100,14 +100,13 @@ let print_ref reduce ref udecl =
 (********************************)
 (** Printing implicit arguments *)
 
-let pr_impl_name imp = Id.print (name_of_argument imp)
-
 let print_impargs_by_name max = function
   | []  -> []
   | impls ->
      let n = List.length impls in
+     let names = List.map_i name_of_argument 1 impls in
      [hov 0 (str (String.plural n "Argument") ++ spc() ++
-      prlist_with_sep pr_comma pr_impl_name impls ++ spc() ++
+      prlist_with_sep pr_comma Id.print names ++ spc() ++
       str (String.conjugate_verb_to_be n) ++ str" implicit" ++
       (if max then strbrk " and maximally inserted" else mt()))]
 

--- a/vernac/prettyp.ml
+++ b/vernac/prettyp.ml
@@ -100,7 +100,7 @@ let print_ref reduce ref udecl =
 (********************************)
 (** Printing implicit arguments *)
 
-let pr_impl_name imp = Id.print (name_of_implicit imp)
+let pr_impl_name imp = Id.print (name_of_argument imp)
 
 let print_impargs_by_name max = function
   | []  -> []
@@ -253,8 +253,8 @@ let needs_extra_scopes ref scopes =
   aux env ty scopes
 
 let implicit_kind_of_status = function
-  | None -> Anonymous, Glob_term.Explicit
-  | Some ((na,_,_),_,(maximal,_)) -> na, if maximal then Glob_term.MaxImplicit else Glob_term.NonMaxImplicit
+  | ((na,_,_),None) -> Anonymous, Glob_term.Explicit
+  | ((na,_,_),_ as imp) -> na, if maximal_insertion_of imp then Glob_term.MaxImplicit else Glob_term.NonMaxImplicit
 
 let extra_implicit_kind_of_status imp =
   let _,imp = implicit_kind_of_status imp in
@@ -281,9 +281,9 @@ let rec main_implicits i renames recargs scopes impls =
     in
     let (name, implicit_status) =
       match renames, impls with
-      | _, (Some _ as i) :: _ -> implicit_kind_of_status i
+      | _, (_,Some _ as i) :: _ -> implicit_kind_of_status i
       | name::_, _ -> (name,Glob_term.Explicit)
-      | [], (None::_ | []) -> (Anonymous, Glob_term.Explicit)
+      | [], ((_,None)::_ | []) -> (Anonymous, Glob_term.Explicit)
     in
     let notation_scope = match scopes with
       | scope :: _ -> Option.map CAst.make scope


### PR DESCRIPTION
**Kind:** feature

Depends on #11099  (support for instantiating non-dependent implicit arguments by index) (merged).

See CEP [#49](http://github.com/coq/ceps/pull/49).

The current state of the PR is that arguments denoted by name or index can be given in any order. Other arguments are used to fill in order the remaining non implicit arguments that are not yet instantiated. No hole should remain at the end of the instantiation.

For instance:
```
Definition p {A} (x:A) (y:A) := (x,y).
Check p (y:=0) (x:=1).
Fail Check p (y:=0). (* x is missing *)

Definition p2 {A} B (x:A) (y:B) := (x,y).
About p2.
Check p2 (y:=1) (1:=0) nat. (* nat instantiates B *)
Fail Check p2 (y:=1) (1:=0). (* B is missing *)
```

- [X] Added / updated test-suite
- [ ] Corresponding documentation was added / updated
- [ ] Entry added in the changelog
