### PR TITLE
Fixes another instance of bug #7967 and #8076: restriction of universes in "Context"

### DIFF
--- a/test-suite/bugs/closed/bug_7967.v
+++ b/test-suite/bugs/closed/bug_7967.v
@@ -1,2 +1,6 @@
 Set Universe Polymorphism.
 Inductive A@{} : Set := B : ltac:(let y := constr:(Type) in exact nat) -> A.
+
+(* A similar bug *)
+Context (C := ltac:(let y := constr:(Type) in exact nat)).
+Check C@{}.


### PR DESCRIPTION
**Kind:** bug fix

This fixes another instance of bug #7967 and #8076 The patch is copied from PR #9317 which fixes #8076.

I'm unsure that this is the expected fix, compared to eventually calling the right function of `declare.ml` which does the restriction. In the meantime, this at least provide a regression test.

- [X] Added / updated test-suite
- [ ] Entry added in the changelog
