### PR TITLE
Adding debugging printer for stacks on EConstr

### DIFF
--- a/dev/top_printers.dbg
+++ b/dev/top_printers.dbg
@@ -46,6 +46,7 @@ install_printer Top_printers.pp_idpred
 install_printer Top_printers.pp_cpred
 install_printer Top_printers.pp_transparent_state
 install_printer Top_printers.pp_stack_t
+install_printer Top_printers.pp_estack_t
 install_printer Top_printers.pp_state_t
 install_printer Top_printers.ppmetas
 install_printer Top_printers.ppevm

--- a/dev/top_printers.ml
+++ b/dev/top_printers.ml
@@ -165,6 +165,7 @@ let pp_idpred s = pp (pr_idpred s)
 let pp_cpred s = pp (pr_cpred s)
 let pp_transparent_state s = pp (pr_transparent_state s)
 let pp_stack_t n = pp (Reductionops.Stack.pr (EConstr.of_constr %> pr_econstr) n)
+let pp_estack_t n = pp (Reductionops.Stack.pr pr_econstr n)
 let pp_state_t n = pp (Reductionops.pr_state Global.(env()) Evd.empty n)
 
 (* proof printers *)

--- a/dev/top_printers.mli
+++ b/dev/top_printers.mli
@@ -108,6 +108,7 @@ val pp_cpred : Names.Cpred.t -> unit
 val pp_transparent_state : TransparentState.t -> unit
 
 val pp_stack_t : Constr.t Reductionops.Stack.t -> unit
+val pp_estack_t : EConstr.t Reductionops.Stack.t -> unit
 val pp_state_t : Reductionops.state -> unit
 
 val ppmetas : Evd.Metaset.t -> unit


### PR DESCRIPTION
**Kind:** debugging printer

Originally extracted from #13138 and #13440.