### PR TITLE
[RM] script to notify "platform" projects to tag

### DIFF
--- a/dev/doc/release-process.md
+++ b/dev/doc/release-process.md
@@ -80,6 +80,9 @@ in time.
   exists, a branch dedicated to compatibility with the corresponding
   Coq branch). You can use the `dev/tools/pin-ci.sh` script to do this
   semi-automatically.
+  - [ ] Notify upstream authors about the pinning, see
+    `dev/tools/notify-upstream-pins.sh`. As of today there is no automated
+    way to track these issues.
 - [ ] Remove all remaining unmerged feature PRs from the beta milestone.
 - [ ] Start a new project to track PR backporting. The project should
   have a "Request X.X+beta1 inclusion" column for the PRs that were

--- a/dev/tools/notify-upstream-pins.sh
+++ b/dev/tools/notify-upstream-pins.sh
@@ -1,0 +1,116 @@
+
+#!/usr/bin/env bash
+
+# Script to notify upstreams that we need a tag to put in a platform/installer
+
+VERSION="8.13"
+DATEBETA="December 7, 2020"
+DATEFINAL="January 7, 2020"
+CC="CC: https://github.com/coq/coq/issues/12334"
+#CC="\n@coqbot column:...."
+REASON="bundled in the Windows installer"
+#REASON="bundled in the Coq platform"
+
+git show master:dev/ci/ci-basic-overlay.sh > /tmp/master-ci-basic-overlay.sh
+git show v${VERSION}:dev/ci/ci-basic-overlay.sh > /tmp/branch-ci-basic-overlay.sh
+
+# caveats:
+# - dev/ci/gitlab.bat has \r (windows)
+# - aactactics, gappa, HB, extlib have different names in ci
+# - menhir is not pinned but figures as an addon
+# - unicoq is not an addon
+WINDOWS_ADDONS=$(grep addon= dev/ci/gitlab.bat \
+  | cut -d = -f 2 \
+  | cut -d ' ' -f 1 \
+  | tr -d '\r' \
+  | sed -e 's/^aactactics$/aac_tactics/' \
+        -e 's/^gappa$/gappa_plugin/' \
+        -e 's/^HB$/elpi_hb/' \
+        -e 's/^extlib$/ext_lib/' \
+        \
+        -e '/^menhir$/d' \
+  ) \
+WINDOWS_ADDONS="$WINDOWS_ADDONS unicoq"
+
+# reads a variable value from a ci-basic-overlay.sh file
+function read_from() {
+  ( . $1; varname="$2"; echo ${!varname} )
+}
+
+# https://gist.github.com/cdown/1163649
+function urlencode() {
+    # urlencode <string>
+
+    old_lc_collate=$LC_COLLATE
+    LC_COLLATE=C
+
+    local length="${#1}"
+    for (( i = 0; i < length; i++ )); do
+        local c="${1:$i:1}"
+        case $c in
+            [a-zA-Z0-9.~_-]) printf '%s' "$c" ;;
+            *) printf '%%%02X' "'$c" ;;
+        esac
+    done
+
+    LC_COLLATE=$old_lc_collate
+}
+
+function template {
+  TITLE="Please create a tag for the upcoming release of Coq $VERSION"
+  BODY="The Coq team is planning to release Coq $VERSION-beta1 on $DATEBETA,
+and Coq $VERSION.0 on $DATEFINAL.
+
+Your project is currently scheduled for being $REASON.
+
+We are currently testing commit $3
+on branch $1/tree/$2
+but we would like to ship a released version instead (a tag in git's slang).
+
+Could you please tag that commit, or communicate us any other tag
+that works with the Coq branch v$VERSION at the *latest* 15 days before the
+date of the final release?
+
+Thanks!
+$CC
+"
+  UUTITLE=$(urlencode "$TITLE")
+  UUBODY=$(urlencode "$BODY")
+
+  case $1 in
+  ( http*github.com* )
+    echo "$1/issues/new?title=$UUTITLE&body=$UUBODY"
+  ;;
+  ( http*gitlab* )
+    echo "$1/-/issues/new"
+    echo
+    echo -e "$TITLE"
+    echo
+    echo -e "$BODY"
+  ;;
+  ( * )
+    echo "$1"
+    echo
+    echo -e "$TITLE"
+    echo
+    echo -e "$BODY"
+
+  ;;
+  esac
+}
+
+for addon in $WINDOWS_ADDONS; do
+    URL=`read_from /tmp/master-ci-basic-overlay.sh "${addon}_CI_GITURL"`
+    REF=`read_from /tmp/master-ci-basic-overlay.sh "${addon}_CI_REF"`
+    PIN=`read_from /tmp/branch-ci-basic-overlay.sh "${addon}_CI_REF"`
+    if [ "${#PIN}" = "40" ]; then
+      echo -e "Addon $addon is pinned to a hash, to open an issue open the following url:\n"
+      template $URL $REF $PIN
+    elif [ "${#PIN}" = "0" ]; then
+      echo "Addon $addon has no pin!"
+      exit 1
+    else
+      echo "Addon $addon is already pinned to version $PIN"
+    fi
+    echo -e "\n----------------------------------------------"
+done


### PR DESCRIPTION
I prepared this script to "automate" the process to requesting upstreams to tag a version for the windows installer/platform.
I have not run it yet, but I plan to do so tomorrow.

Issues
- [x] windows installer names and ci names are not the same (see the `sed -e` lines). Issues opened #13452 #13451and put in 8.14 milestone
- [ ] ci stuff that is in the installer/platform should be listed somewhere else (not a .bat file, see the `tr -d \r`)
- [ ] parametrize the script (could read the current branch from git, the minor version from config, the date from the command line)
- [x] the URL does not work for gitlab, only github

@Zimmi48 it would be nice to have an easy way to tell coqbot to put these into a column (right now I CC the bug about the release).
CC @MSoegtropIMC FYI