### PR TITLE
Extraction: preventing possible conflicts with OCaml's primitive type names

### DIFF
--- a/doc/changelog/08-tools/13460-master+fix-ocaml-int-extraction-clash.rst
+++ b/doc/changelog/08-tools/13460-master+fix-ocaml-int-extraction-clash.rst
@@ -1,0 +1,9 @@
+- **Fixed:**
+  Coq name :n:`int` can be used in extraction without conflicting with
+  OCaml's :n:`int` type; additionally, to avoid possible conflicts in
+  :cmd:`Extract Constant` or :cmd:`Extract Inductive`, the alias
+  `__ocaml_int` can be used to refer to OCaml's :n:`int`
+  (`#13460 <https://github.com/coq/coq/pull/13460>`_,
+  fixes `#7017 <https://github.com/coq/coq/issues/7017>`_
+  and `#13288 <https://github.com/coq/coq/issues/13288>`_,
+  by Hugo Herbelin).

--- a/doc/changelog/08-tools/13460-master+fix-ocaml-int-extraction-clash.rst
+++ b/doc/changelog/08-tools/13460-master+fix-ocaml-int-extraction-clash.rst
@@ -1,8 +1,8 @@
 - **Fixed:**
-  Coq name :n:`int` can be used in extraction without conflicting with
-  OCaml's :n:`int` type; additionally, to avoid possible conflicts in
-  :cmd:`Extract Constant` or :cmd:`Extract Inductive`, the alias
-  `__ocaml_int` can be used to refer to OCaml's :n:`int`
+  Type :n:`int` in files :n:`Number.v`, :n:`Decimal.v` and
+  :n:`Hexadecimal.v` have been renamed to :n:`signed_int` (together
+  with a compatibility alias :n:`int`) so that they can be used in
+  extraction without conflicting with OCaml's :n:`int` type
   (`#13460 <https://github.com/coq/coq/pull/13460>`_,
   fixes `#7017 <https://github.com/coq/coq/issues/7017>`_
   and `#13288 <https://github.com/coq/coq/issues/13288>`_,

--- a/test-suite/bugs/closed/bug_7017.v
+++ b/test-suite/bugs/closed/bug_7017.v
@@ -1,0 +1,32 @@
+Require Import Extraction BinPos.
+Require Import ExtrOcamlNatInt.
+
+Require Import Extraction BinPos.
+
+Definition test (a:Decimal.int) n m (H:m>0) :=
+ let (q,r,_,_) := Euclid.eucl_dev m H n in
+ (Decimal.norm a, Nat.compare n (q*m+r)).
+
+Extraction TestCompile test.
+
+(* Test combination of Decimal.int with ExtrOcamlInt63 *)
+
+Require Import ExtrOCamlInt63.
+
+Definition f n p := (CompOpp n, Decimal.norm p).
+
+Extraction TestCompile f.
+
+(* Test combination of Decimal.int with ExtrOcamlIntConv *)
+
+Require Import ExtrOcamlIntConv.
+
+Definition g n p := (n_of_int n, Decimal.norm p).
+
+Extraction TestCompile g.
+
+(* Test combination of Decimal.int with ExtrOcamlZInt *)
+
+Require Import ExtrOcamlZInt ZArith.
+
+Extraction TestCompile Z.add.

--- a/test-suite/output/Search.out
+++ b/test-suite/output/Search.out
@@ -38,12 +38,13 @@ Number.uint_beq: Number.uint -> Number.uint -> bool
 Decimal.uint_beq: Decimal.uint -> Decimal.uint -> bool
 Hexadecimal.hexadecimal_beq:
   Hexadecimal.hexadecimal -> Hexadecimal.hexadecimal -> bool
-Number.int_beq: Number.int -> Number.int -> bool
+Number.signed_int_beq: Number.signed_int -> Number.signed_int -> bool
 Hexadecimal.uint_beq: Hexadecimal.uint -> Hexadecimal.uint -> bool
 Nat.ltb: nat -> nat -> bool
 Nat.leb: nat -> nat -> bool
-Hexadecimal.int_beq: Hexadecimal.int -> Hexadecimal.int -> bool
-Decimal.int_beq: Decimal.int -> Decimal.int -> bool
+Hexadecimal.signed_int_beq:
+  Hexadecimal.signed_int -> Hexadecimal.signed_int -> bool
+Decimal.signed_int_beq: Decimal.signed_int -> Decimal.signed_int -> bool
 Nat.bitwise: (bool -> bool -> bool) -> nat -> nat -> nat -> nat
 eq_true_rec_r:
   forall (P : bool -> Set) [b : bool], P b -> eq_true b -> P true
@@ -69,27 +70,29 @@ Number.internal_uint_dec_bl1:
 Hexadecimal.internal_hexadecimal_dec_lb:
   forall x y : Hexadecimal.hexadecimal,
   x = y -> Hexadecimal.hexadecimal_beq x y = true
-Hexadecimal.internal_int_dec_lb0:
-  forall x y : Hexadecimal.int, x = y -> Hexadecimal.int_beq x y = true
+Hexadecimal.internal_signed_int_dec_lb0:
+  forall x y : Hexadecimal.signed_int,
+  x = y -> Hexadecimal.signed_int_beq x y = true
 Number.internal_number_dec_lb:
   forall x y : Number.number, x = y -> Number.number_beq x y = true
 Decimal.internal_decimal_dec_lb:
   forall x y : Decimal.decimal, x = y -> Decimal.decimal_beq x y = true
-Hexadecimal.internal_int_dec_bl0:
-  forall x y : Hexadecimal.int, Hexadecimal.int_beq x y = true -> x = y
-Number.internal_int_dec_lb1:
-  forall x y : Number.int, x = y -> Number.int_beq x y = true
-Number.internal_int_dec_bl1:
-  forall x y : Number.int, Number.int_beq x y = true -> x = y
+Hexadecimal.internal_signed_int_dec_bl0:
+  forall x y : Hexadecimal.signed_int,
+  Hexadecimal.signed_int_beq x y = true -> x = y
+Number.internal_signed_int_dec_lb1:
+  forall x y : Number.signed_int, x = y -> Number.signed_int_beq x y = true
+Number.internal_signed_int_dec_bl1:
+  forall x y : Number.signed_int, Number.signed_int_beq x y = true -> x = y
 Hexadecimal.internal_hexadecimal_dec_bl:
   forall x y : Hexadecimal.hexadecimal,
   Hexadecimal.hexadecimal_beq x y = true -> x = y
 Number.internal_uint_dec_lb1:
   forall x y : Number.uint, x = y -> Number.uint_beq x y = true
-Decimal.internal_int_dec_bl:
-  forall x y : Decimal.int, Decimal.int_beq x y = true -> x = y
-Decimal.internal_int_dec_lb:
-  forall x y : Decimal.int, x = y -> Decimal.int_beq x y = true
+Decimal.internal_signed_int_dec_bl:
+  forall x y : Decimal.signed_int, Decimal.signed_int_beq x y = true -> x = y
+Decimal.internal_signed_int_dec_lb:
+  forall x y : Decimal.signed_int, x = y -> Decimal.signed_int_beq x y = true
 Number.internal_number_dec_bl:
   forall x y : Number.number, Number.number_beq x y = true -> x = y
 Byte.of_bits:
@@ -162,15 +165,15 @@ f_equal2_nat:
   x1 = y1 -> x2 = y2 -> f x1 x2 = f y1 y2
 Number.internal_number_dec_lb:
   forall x y : Number.number, x = y -> Number.number_beq x y = true
-Number.internal_int_dec_lb1:
-  forall x y : Number.int, x = y -> Number.int_beq x y = true
+Number.internal_signed_int_dec_lb1:
+  forall x y : Number.signed_int, x = y -> Number.signed_int_beq x y = true
 Number.internal_number_dec_bl:
   forall x y : Number.number, Number.number_beq x y = true -> x = y
 Hexadecimal.internal_hexadecimal_dec_lb:
   forall x y : Hexadecimal.hexadecimal,
   x = y -> Hexadecimal.hexadecimal_beq x y = true
-Number.internal_int_dec_bl1:
-  forall x y : Number.int, Number.int_beq x y = true -> x = y
+Number.internal_signed_int_dec_bl1:
+  forall x y : Number.signed_int, Number.signed_int_beq x y = true -> x = y
 Number.internal_uint_dec_lb1:
   forall x y : Number.uint, x = y -> Number.uint_beq x y = true
 Number.internal_uint_dec_bl1:
@@ -180,16 +183,18 @@ Decimal.internal_decimal_dec_lb:
 Hexadecimal.internal_hexadecimal_dec_bl:
   forall x y : Hexadecimal.hexadecimal,
   Hexadecimal.hexadecimal_beq x y = true -> x = y
-Hexadecimal.internal_int_dec_lb0:
-  forall x y : Hexadecimal.int, x = y -> Hexadecimal.int_beq x y = true
-Hexadecimal.internal_int_dec_bl0:
-  forall x y : Hexadecimal.int, Hexadecimal.int_beq x y = true -> x = y
-Decimal.internal_int_dec_lb:
-  forall x y : Decimal.int, x = y -> Decimal.int_beq x y = true
+Hexadecimal.internal_signed_int_dec_lb0:
+  forall x y : Hexadecimal.signed_int,
+  x = y -> Hexadecimal.signed_int_beq x y = true
+Hexadecimal.internal_signed_int_dec_bl0:
+  forall x y : Hexadecimal.signed_int,
+  Hexadecimal.signed_int_beq x y = true -> x = y
+Decimal.internal_signed_int_dec_lb:
+  forall x y : Decimal.signed_int, x = y -> Decimal.signed_int_beq x y = true
 Decimal.internal_decimal_dec_bl:
   forall x y : Decimal.decimal, Decimal.decimal_beq x y = true -> x = y
-Decimal.internal_int_dec_bl:
-  forall x y : Decimal.int, Decimal.int_beq x y = true -> x = y
+Decimal.internal_signed_int_dec_bl:
+  forall x y : Decimal.signed_int, Decimal.signed_int_beq x y = true -> x = y
 Decimal.internal_uint_dec_bl:
   forall x : Decimal.uint,
   (fun x0 : Decimal.uint =>
@@ -217,10 +222,10 @@ Number.internal_number_dec_lb:
   forall x y : Number.number, x = y -> Number.number_beq x y = true
 Number.internal_number_dec_bl:
   forall x y : Number.number, Number.number_beq x y = true -> x = y
-Number.internal_int_dec_lb1:
-  forall x y : Number.int, x = y -> Number.int_beq x y = true
-Number.internal_int_dec_bl1:
-  forall x y : Number.int, Number.int_beq x y = true -> x = y
+Number.internal_signed_int_dec_lb1:
+  forall x y : Number.signed_int, x = y -> Number.signed_int_beq x y = true
+Number.internal_signed_int_dec_bl1:
+  forall x y : Number.signed_int, Number.signed_int_beq x y = true -> x = y
 Number.internal_uint_dec_lb1:
   forall x y : Number.uint, x = y -> Number.uint_beq x y = true
 Number.internal_uint_dec_bl1:
@@ -231,18 +236,20 @@ Hexadecimal.internal_hexadecimal_dec_lb:
 Hexadecimal.internal_hexadecimal_dec_bl:
   forall x y : Hexadecimal.hexadecimal,
   Hexadecimal.hexadecimal_beq x y = true -> x = y
-Hexadecimal.internal_int_dec_lb0:
-  forall x y : Hexadecimal.int, x = y -> Hexadecimal.int_beq x y = true
-Hexadecimal.internal_int_dec_bl0:
-  forall x y : Hexadecimal.int, Hexadecimal.int_beq x y = true -> x = y
+Hexadecimal.internal_signed_int_dec_lb0:
+  forall x y : Hexadecimal.signed_int,
+  x = y -> Hexadecimal.signed_int_beq x y = true
+Hexadecimal.internal_signed_int_dec_bl0:
+  forall x y : Hexadecimal.signed_int,
+  Hexadecimal.signed_int_beq x y = true -> x = y
 Decimal.internal_decimal_dec_lb:
   forall x y : Decimal.decimal, x = y -> Decimal.decimal_beq x y = true
 Decimal.internal_decimal_dec_bl:
   forall x y : Decimal.decimal, Decimal.decimal_beq x y = true -> x = y
-Decimal.internal_int_dec_lb:
-  forall x y : Decimal.int, x = y -> Decimal.int_beq x y = true
-Decimal.internal_int_dec_bl:
-  forall x y : Decimal.int, Decimal.int_beq x y = true -> x = y
+Decimal.internal_signed_int_dec_lb:
+  forall x y : Decimal.signed_int, x = y -> Decimal.signed_int_beq x y = true
+Decimal.internal_signed_int_dec_bl:
+  forall x y : Decimal.signed_int, Decimal.signed_int_beq x y = true -> x = y
 Hexadecimal.internal_uint_dec_bl0:
   forall x : Hexadecimal.uint,
   (fun x0 : Hexadecimal.uint =>
@@ -308,19 +315,20 @@ nat_rect_plus:
 Nat.bitwise: (bool -> bool -> bool) -> nat -> nat -> nat -> nat
 Number.internal_number_dec_bl:
   forall x y : Number.number, Number.number_beq x y = true -> x = y
-Number.internal_int_dec_bl1:
-  forall x y : Number.int, Number.int_beq x y = true -> x = y
+Number.internal_signed_int_dec_bl1:
+  forall x y : Number.signed_int, Number.signed_int_beq x y = true -> x = y
 Number.internal_uint_dec_bl1:
   forall x y : Number.uint, Number.uint_beq x y = true -> x = y
 Hexadecimal.internal_hexadecimal_dec_bl:
   forall x y : Hexadecimal.hexadecimal,
   Hexadecimal.hexadecimal_beq x y = true -> x = y
-Hexadecimal.internal_int_dec_bl0:
-  forall x y : Hexadecimal.int, Hexadecimal.int_beq x y = true -> x = y
+Hexadecimal.internal_signed_int_dec_bl0:
+  forall x y : Hexadecimal.signed_int,
+  Hexadecimal.signed_int_beq x y = true -> x = y
 Decimal.internal_decimal_dec_bl:
   forall x y : Decimal.decimal, Decimal.decimal_beq x y = true -> x = y
-Decimal.internal_int_dec_bl:
-  forall x y : Decimal.int, Decimal.int_beq x y = true -> x = y
+Decimal.internal_signed_int_dec_bl:
+  forall x y : Decimal.signed_int, Decimal.signed_int_beq x y = true -> x = y
 Byte.of_bits:
   bool * (bool * (bool * (bool * (bool * (bool * (bool * bool)))))) ->
   Byte.byte
@@ -332,15 +340,16 @@ Number.internal_number_dec_lb:
   forall x y : Number.number, x = y -> Number.number_beq x y = true
 Number.internal_uint_dec_lb1:
   forall x y : Number.uint, x = y -> Number.uint_beq x y = true
-Number.internal_int_dec_lb1:
-  forall x y : Number.int, x = y -> Number.int_beq x y = true
-Decimal.internal_int_dec_lb:
-  forall x y : Decimal.int, x = y -> Decimal.int_beq x y = true
+Number.internal_signed_int_dec_lb1:
+  forall x y : Number.signed_int, x = y -> Number.signed_int_beq x y = true
+Decimal.internal_signed_int_dec_lb:
+  forall x y : Decimal.signed_int, x = y -> Decimal.signed_int_beq x y = true
 Hexadecimal.internal_hexadecimal_dec_lb:
   forall x y : Hexadecimal.hexadecimal,
   x = y -> Hexadecimal.hexadecimal_beq x y = true
-Hexadecimal.internal_int_dec_lb0:
-  forall x y : Hexadecimal.int, x = y -> Hexadecimal.int_beq x y = true
+Hexadecimal.internal_signed_int_dec_lb0:
+  forall x y : Hexadecimal.signed_int,
+  x = y -> Hexadecimal.signed_int_beq x y = true
 Decimal.internal_decimal_dec_lb:
   forall x y : Decimal.decimal, x = y -> Decimal.decimal_beq x y = true
 Byte.to_bits:

--- a/test-suite/output/SearchPattern.out
+++ b/test-suite/output/SearchPattern.out
@@ -15,11 +15,12 @@ Hexadecimal.hexadecimal_beq:
 Nat.ltb: nat -> nat -> bool
 Nat.leb: nat -> nat -> bool
 Number.number_beq: Number.number -> Number.number -> bool
-Number.int_beq: Number.int -> Number.int -> bool
-Hexadecimal.int_beq: Hexadecimal.int -> Hexadecimal.int -> bool
+Number.signed_int_beq: Number.signed_int -> Number.signed_int -> bool
+Hexadecimal.signed_int_beq:
+  Hexadecimal.signed_int -> Hexadecimal.signed_int -> bool
 Hexadecimal.uint_beq: Hexadecimal.uint -> Hexadecimal.uint -> bool
 Decimal.decimal_beq: Decimal.decimal -> Decimal.decimal -> bool
-Decimal.int_beq: Decimal.int -> Decimal.int -> bool
+Decimal.signed_int_beq: Decimal.signed_int -> Decimal.signed_int -> bool
 Decimal.uint_beq: Decimal.uint -> Decimal.uint -> bool
 Nat.two: nat
 Nat.zero: nat

--- a/test-suite/output/Search_headconcl.out
+++ b/test-suite/output/Search_headconcl.out
@@ -21,11 +21,12 @@ Hexadecimal.hexadecimal_beq:
 Nat.ltb: nat -> nat -> bool
 Nat.leb: nat -> nat -> bool
 Number.number_beq: Number.number -> Number.number -> bool
-Number.int_beq: Number.int -> Number.int -> bool
-Hexadecimal.int_beq: Hexadecimal.int -> Hexadecimal.int -> bool
+Number.signed_int_beq: Number.signed_int -> Number.signed_int -> bool
+Hexadecimal.signed_int_beq:
+  Hexadecimal.signed_int -> Hexadecimal.signed_int -> bool
 Hexadecimal.uint_beq: Hexadecimal.uint -> Hexadecimal.uint -> bool
 Decimal.decimal_beq: Decimal.decimal -> Decimal.decimal -> bool
-Decimal.int_beq: Decimal.int -> Decimal.int -> bool
+Decimal.signed_int_beq: Decimal.signed_int -> Decimal.signed_int -> bool
 Decimal.uint_beq: Decimal.uint -> Decimal.uint -> bool
 mult_n_O: forall n : nat, 0 = n * 0
 plus_O_n: forall n : nat, 0 + n = n

--- a/theories/Init/Decimal.v
+++ b/theories/Init/Decimal.v
@@ -59,6 +59,8 @@ Scheme Equality for int.
 Scheme Equality for decimal.
 Notation int_eq_dec := signed_int_eq_dec.
 Notation int_beq := signed_int_beq.
+Notation internal_int_dec_lb := internal_signed_int_dec_lb.
+Notation internal_int_dec_bl := internal_signed_int_dec_bl.
 
 Declare Scope dec_uint_scope.
 Delimit Scope dec_uint_scope with uint.

--- a/theories/Init/Decimal.v
+++ b/theories/Init/Decimal.v
@@ -42,7 +42,8 @@ Notation zero := (D0 Nil).
 
 (** For signed integers, we use two constructors [Pos] and [Neg]. *)
 
-Variant int := Pos (d:uint) | Neg (d:uint).
+Variant signed_int := Pos (d:uint) | Neg (d:uint).
+Notation int := signed_int.
 
 (** For decimal numbers, we use two constructors [Decimal] and
     [DecimalExp], depending on whether or not they are given with an
@@ -56,6 +57,8 @@ Variant decimal :=
 Scheme Equality for uint.
 Scheme Equality for int.
 Scheme Equality for decimal.
+Notation int_eq_dec := signed_int_eq_dec.
+Notation int_beq := signed_int_beq.
 
 Declare Scope dec_uint_scope.
 Delimit Scope dec_uint_scope with uint.

--- a/theories/Init/Hexadecimal.v
+++ b/theories/Init/Hexadecimal.v
@@ -65,6 +65,8 @@ Scheme Equality for int.
 Scheme Equality for hexadecimal.
 Notation int_eq_dec := signed_int_eq_dec.
 Notation int_beq := signed_int_beq.
+Notation internal_int_dec_lb := internal_signed_int_dec_lb.
+Notation internal_int_dec_bl := internal_signed_int_dec_bl.
 
 Declare Scope hex_uint_scope.
 Delimit Scope hex_uint_scope with huint.

--- a/theories/Init/Hexadecimal.v
+++ b/theories/Init/Hexadecimal.v
@@ -48,7 +48,8 @@ Notation zero := (D0 Nil).
 
 (** For signed integers, we use two constructors [Pos] and [Neg]. *)
 
-Variant int := Pos (d:uint) | Neg (d:uint).
+Variant signed_int := Pos (d:uint) | Neg (d:uint).
+Notation int := signed_int.
 
 (** For decimal numbers, we use two constructors [Hexadecimal] and
     [HexadecimalExp], depending on whether or not they are given with an
@@ -62,6 +63,8 @@ Variant hexadecimal :=
 Scheme Equality for uint.
 Scheme Equality for int.
 Scheme Equality for hexadecimal.
+Notation int_eq_dec := signed_int_eq_dec.
+Notation int_beq := signed_int_beq.
 
 Declare Scope hex_uint_scope.
 Delimit Scope hex_uint_scope with huint.

--- a/theories/Init/Number.v
+++ b/theories/Init/Number.v
@@ -14,13 +14,16 @@ Require Import Decimal Hexadecimal.
 
 Variant uint := UIntDecimal (u:Decimal.uint) | UIntHexadecimal (u:Hexadecimal.uint).
 
-Variant int := IntDecimal (i:Decimal.int) | IntHexadecimal (i:Hexadecimal.int).
+Variant signed_int := IntDecimal (i:Decimal.int) | IntHexadecimal (i:Hexadecimal.int).
+Notation int := signed_int.
 
 Variant number := Decimal (d:Decimal.decimal) | Hexadecimal (h:Hexadecimal.hexadecimal).
 
 Scheme Equality for uint.
 Scheme Equality for int.
 Scheme Equality for number.
+Notation int_eq_dec := signed_int_eq_dec.
+Notation int_beq := signed_int_beq.
 
 Register uint as num.num_uint.type.
 Register int as num.num_int.type.

--- a/theories/Init/Number.v
+++ b/theories/Init/Number.v
@@ -24,6 +24,8 @@ Scheme Equality for int.
 Scheme Equality for number.
 Notation int_eq_dec := signed_int_eq_dec.
 Notation int_beq := signed_int_beq.
+Notation internal_int_dec_lb := internal_signed_int_dec_lb.
+Notation internal_int_dec_bl := internal_signed_int_dec_bl.
 
 Register uint as num.num_uint.type.
 Register int as num.num_int.type.


### PR DESCRIPTION
**Kind:** bug fix

Fixes #7017 
Fixes #13288
Fixes QuickChick/QuickChick#193

Note: does not fix #10936

- [X] Added / updated test-suite
- [x] Entry added in the changelog
