### PR TITLE
Fix linter: incorrect commit was picked in CI

### DIFF
--- a/dev/lint-repository.sh
+++ b/dev/lint-repository.sh
@@ -9,10 +9,10 @@
 
 CODE=0
 
-if [[ $(git log -n 1 --pretty='format:%s') == "Bot merge"* ]]; then
-    # The FIRST parent of bot merges is from the PR, the second is
+if [[ $(git log -n 1 --pretty='format:%s') == "[CI merge]"* ]]; then
+    # The second parent of bot merges is from the PR, the first is
     # current master
-    head=$(git rev-parse HEAD~)
+    head=$(git rev-parse HEAD^2)
 else
     head=$(git rev-parse HEAD)
 fi


### PR DESCRIPTION
The bot merge was changed some time ago.
