### PR TITLE
Fixes #13456: regression in tactic exists which started to check resolution of evars more incrementally

### DIFF
--- a/tactics/tacticals.mli
+++ b/tactics/tacticals.mli
@@ -209,6 +209,10 @@ module New : sig
   val tclSELECT : Goal_select.t -> 'a tactic -> 'a tactic
   val tclWITHHOLES : bool -> 'a tactic -> Evd.evar_map -> 'a tactic
   val tclDELAYEDWITHHOLES : bool -> 'a delayed_open -> ('a -> unit tactic) -> unit tactic
+  val tclMAPDELAYEDWITHHOLES : bool -> 'a delayed_open list -> ('a -> unit tactic) -> unit tactic
+  (* in [tclMAPDELAYEDWITHHOLES with_evars l tac] the delayed
+     argument of [l] are evaluated in the possibly-updated
+     environment and updated sigma of each new successive goals *)
 
   val tclTIMEOUT : int -> unit tactic -> unit tactic
   val tclTIME : string option -> 'a tactic -> 'a tactic

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -2282,10 +2282,9 @@ let left_with_bindings  with_evars = constructor_tac with_evars (Some 2) 1
 let right_with_bindings with_evars = constructor_tac with_evars (Some 2) 2
 let split_with_bindings with_evars l =
   Tacticals.New.tclMAP (constructor_tac with_evars (Some 1) 1) l
-let split_with_delayed_bindings with_evars =
-  Tacticals.New.tclMAP (fun bl ->
-    Tacticals.New.tclDELAYEDWITHHOLES with_evars bl
-    (constructor_tac with_evars (Some 1) 1))
+let split_with_delayed_bindings with_evars bl =
+  Tacticals.New.tclMAPDELAYEDWITHHOLES with_evars bl
+    (constructor_tac with_evars (Some 1) 1)
 
 let left           = left_with_bindings false
 let simplest_left  = left NoBindings

--- a/test-suite/bugs/closed/bug_13456.v
+++ b/test-suite/bugs/closed/bug_13456.v
@@ -1,0 +1,5 @@
+Lemma minbug (n : nat) (P : nat -> Prop) (pn : P n) : exists (m : nat) (p : P m), True.
+Proof.
+  exists _, pn.
+  exact I.
+Qed.


### PR DESCRIPTION
**Kind:**  bug fix 

The regression was due to #12365. We fix it by postponing the evar check after the calls to the underlying constructor tactic, while retaining from #12365 the ability to use information from the first instantiations to resolve the latter instantiations.

Fixes / closes #13456

- [X] Added / updated test-suite
- [ ] Entry added in the changelog
