### PR TITLE
Testing {in _, _} and {pred _} from ssrbool

### DIFF
--- a/doc/changelog/06-ssreflect/13473-test_pred.rst
+++ b/doc/changelog/06-ssreflect/13473-test_pred.rst
@@ -1,0 +1,4 @@
+- **Added:**
+  Adding a test that the notations `{in _, _}` and `{pred _}` from `ssrbool.v` are displayed correctly.
+  (`#13473 <https://github.com/coq/coq/pull/13473>`_,
+  by Cyril Cohen).

--- a/test-suite/output/ssr_pred.out
+++ b/test-suite/output/ssr_pred.out
@@ -1,0 +1,3 @@
+in1W
+     : forall (T1 : predArgType) (D1 : {pred T1}) (P1 : T1 -> Prop),
+       (forall x : T1, P1 x) -> {in D1, forall x : T1, P1 x}

--- a/test-suite/output/ssr_pred.v
+++ b/test-suite/output/ssr_pred.v
@@ -1,0 +1,3 @@
+Require Import ssreflect ssrfun ssrbool.
+
+Check @in1W.


### PR DESCRIPTION
<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** test.

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->

This tests that the notations `{in _, _}` and `{pred _}` from `ssrbool.v` are displayed correctly.
This display is broken in Coq 8.12 and 8.12.1 and has been fix for the upcoming release, cf https://github.com/math-comp/math-comp/pull/674#issuecomment-733657891 and #13436

<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [x] Added / updated test-suite
<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).