### PR TITLE
extracting API for comparing universes of constants/inductives/constructors

### DIFF
--- a/pretyping/evarconv.mli
+++ b/pretyping/evarconv.mli
@@ -84,6 +84,12 @@ val check_conv_record : env -> evar_map ->
     (constr Stack.t * constr Stack.t) * constr *
     (int option * constr)
 
+(** Compares two constants/inductives/constructors unifying their universes.
+   It required the number of arguments applied to the c/i/c in order to decided
+   the kind of check it must perform. *)
+val compare_heads : env -> evar_map ->
+  nargs:int -> EConstr.t -> EConstr.t -> Evarsolve.unification_result
+
 (** Try to solve problems of the form ?x[args] = c by second-order
     matching, using typing to select occurrences *)
 


### PR DESCRIPTION
This is just extracting a function to be usable from other plugins (e.g., Unicoq), in order to avoid code duplication. One function was exported as part of the Evarconv module. It is commented (in the code), although no modification was done to the changlog (and it probably won't be needed).

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** infrastructure.

<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [x] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).