### PR TITLE
CI: Use hash of dockerfile in CACHEKEY

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,9 +17,9 @@ stages:
 
 # some default values
 variables:
-  # Format: $IMAGE-V$DATE [Cache is not used as of today but kept here
-  # for reference]
-  CACHEKEY: "bionic_coq-V2020-11-26-V92"
+  # Format: $IMAGE-V$DATE-$hash
+  # The $hash is the first 10 characters of the md5 of the dockerfile
+  CACHEKEY: "bionic_coq-V2020-11-26-db194d584e"
   IMAGE: "$CI_REGISTRY_IMAGE:$CACHEKEY"
   # By default, jobs run in the base switch; override to select another switch
   OPAM_SWITCH: "base"
@@ -59,6 +59,7 @@ before_script:
   - eval $(opam env)
   - opam list
   - opam config list
+  - dev/tools/check-cachekey.sh
 
 ################ GITLAB CACHING ######################
 # - use artifacts between jobs                       #

--- a/dev/ci/README-developers.md
+++ b/dev/ci/README-developers.md
@@ -171,7 +171,7 @@ loaded by subsequent jobs.
 
 **IMPORTANT**: When updating Coq's CI docker image, you must modify
 the `CACHEKEY` variable in [`.gitlab-ci.yml`](../../.gitlab-ci.yml)
-and [`Dockerfile`](docker/bionic_coq/Dockerfile)
+(see comment near it for details).
 
 The Docker building job reuses the uploaded image if it is available,
 but if you wish to save more time you can skip the job by setting

--- a/dev/ci/docker/bionic_coq/Dockerfile
+++ b/dev/ci/docker/bionic_coq/Dockerfile
@@ -1,5 +1,4 @@
-# CACHEKEY: "bionic_coq-V2020-11-26-V92"
-# ^^ Update when modifying this file.
+# Update CACHEKEY in the .gitlab-ci.yml when modifying this file.
 
 FROM ubuntu:bionic
 LABEL maintainer="e@x80.org"

--- a/dev/lint-repository.sh
+++ b/dev/lint-repository.sh
@@ -32,4 +32,7 @@ find . "(" -path ./.git -prune ")" -o -type f -print0 |
 echo Checking overlays
 dev/tools/check-overlays.sh || CODE=1
 
+echo Checking CACHEKEY
+dev/tools/check-cachekey.sh || CODE=1
+
 exit $CODE

--- a/dev/tools/check-cachekey.sh
+++ b/dev/tools/check-cachekey.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+hash=$(md5sum dev/ci/docker/bionic_coq/Dockerfile | head -c 10)
+key=$(grep CACHEKEY: .gitlab-ci.yml)
+keyhash=${key%\"}
+keyhash=${keyhash##*-}
+if ! [ "$hash" = "$keyhash" ]; then
+    echo "Bad CACHEKEY: expected '$hash' but got '$keyhash'"
+    exit 1
+fi


### PR DESCRIPTION
Checked by the linter so we don't forget to update it.

Also checked by before_script so we don't run jobs for nothing.
