### PR TITLE
Removing non relevant argument binding_kind of GLocalDef.

### DIFF
--- a/dev/doc/changes.md
+++ b/dev/doc/changes.md
@@ -37,6 +37,11 @@ Dumpglob:
   plugins to temporarily change/pause the output of Dumpglob, and then
   restore it to the original setting.
 
+Glob_term:
+
+- Removing useless `binding_kind` argument of `GLocalDef` in
+  `extended_glob_local_binder`.
+
 ## Changes between Coq 8.11 and Coq 8.12
 
 ### Code formatting

--- a/interp/constrextern.ml
+++ b/interp/constrextern.ml
@@ -886,9 +886,10 @@ let extern_prim_token_delimiter_if_required n key_n scope_n scopes =
 let extended_glob_local_binder_of_decl loc = function
   | (p,bk,None,t) -> GLocalAssum (p,bk,t)
   | (p,bk,Some x, t) ->
+    assert (bk = Explicit);
     match DAst.get t with
-    | GHole (_, IntroAnonymous, None) -> GLocalDef (p,bk,x,None)
-    | _ -> GLocalDef (p,bk,x,Some t)
+    | GHole (_, IntroAnonymous, None) -> GLocalDef (p,x,None)
+    | _ -> GLocalDef (p,x,Some t)
 
 let extended_glob_local_binder_of_decl ?loc u = DAst.make ?loc (extended_glob_local_binder_of_decl loc u)
 
@@ -1217,7 +1218,7 @@ and extern_local_binder scopes vars = function
     [] -> ([],[],[])
   | b :: l ->
     match DAst.get b with
-    | GLocalDef (na,bk,bd,ty) ->
+    | GLocalDef (na,bd,ty) ->
       let (assums,ids,l) =
         extern_local_binder scopes (on_fst (Name.fold_right Id.Set.add na) vars) l in
       (assums,na::ids,

--- a/pretyping/glob_term.ml
+++ b/pretyping/glob_term.ml
@@ -137,7 +137,7 @@ type cases_pattern_disjunction = [ `any ] cases_pattern_disjunction_g
 
 type 'a extended_glob_local_binder_r =
   | GLocalAssum   of Name.t * binding_kind * 'a glob_constr_g
-  | GLocalDef     of Name.t * binding_kind * 'a glob_constr_g * 'a glob_constr_g option
+  | GLocalDef     of Name.t * 'a glob_constr_g * 'a glob_constr_g option
   | GLocalPattern of ('a cases_pattern_disjunction_g * Id.t list) * Id.t * binding_kind * 'a glob_constr_g
 and 'a extended_glob_local_binder_g = ('a extended_glob_local_binder_r, 'a) DAst.t
 


### PR DESCRIPTION
**Kind:**  cleanup

This is an easy self-contained simplification commit taken out of #13445 so as to simplify the review of the latter.