### PR TITLE
Aligning homogeneous map terminology in Context.mli to Smart terminology + heterogeneous map

### DIFF
--- a/engine/eConstr.ml
+++ b/engine/eConstr.ml
@@ -741,7 +741,7 @@ let lookup_named_val n e = cast_named_decl (sym unsafe_eq) (lookup_named_ctxt n 
 let map_rel_context_in_env f env sign =
   let rec aux env acc = function
     | d::sign ->
-        aux (push_rel d env) (Context.Rel.Declaration.map_constr (f env) d :: acc) sign
+        aux (push_rel d env) (Context.Rel.Declaration.Smart.map_constr (f env) d :: acc) sign
     | [] ->
         acc
   in

--- a/engine/evarutil.ml
+++ b/engine/evarutil.ml
@@ -81,10 +81,10 @@ let nf_evars_universes evm =
     (Evd.universe_subst evm)
 
 let nf_named_context_evar sigma ctx =
-  Context.Named.map (nf_evar0 sigma) ctx
+  Context.Named.Smart.map (nf_evar0 sigma) ctx
 
 let nf_rel_context_evar sigma ctx =
-  Context.Rel.map (nf_evar sigma) ctx
+  Context.Rel.Smart.map (nf_evar sigma) ctx
 
 let nf_env_evar sigma env =
   let nc' = nf_named_context_evar sigma (Environ.named_context env) in
@@ -328,7 +328,7 @@ let push_rel_decl_to_named_context
   let open EConstr in
   let open Vars in
   let map_decl f d =
-    NamedDecl.map_constr f d
+    NamedDecl.Smart.map_constr f d
   in
   let rec replace_var_named_declaration id0 id nc = match match_named_context_val nc with
   | None -> empty_named_context_val
@@ -608,7 +608,7 @@ let clear_hyps_in_evi_main env sigma hyps terms ids =
   let nhyps =
     let check_context decl =
       let err = OccurHypInSimpleClause (Some (NamedDecl.get_id decl)) in
-      NamedDecl.map_constr (check_and_clear_in_constr env evdref err ids global) decl
+      NamedDecl.Smart.map_constr (check_and_clear_in_constr env evdref err ids global) decl
     in
     let check_value vk = match force_lazy_val vk with
     | None -> vk

--- a/engine/evd.ml
+++ b/engine/evd.ml
@@ -253,7 +253,7 @@ let map_evar_body f = function
 let map_evar_info f evi =
   {evi with
     evar_body = map_evar_body f evi.evar_body;
-    evar_hyps = map_named_val (fun d -> NamedDecl.map_constr f d) evi.evar_hyps;
+    evar_hyps = map_named_val (fun d -> NamedDecl.Smart.map_constr f d) evi.evar_hyps;
     evar_concl = f evi.evar_concl;
     evar_candidates = Option.map (List.map f) evi.evar_candidates }
 
@@ -1534,7 +1534,7 @@ module MiniEConstr = struct
   let unsafe_to_named_decl d = d
   let of_rel_decl d = d
   let unsafe_to_rel_decl d = d
-  let to_rel_decl sigma d = Context.Rel.Declaration.map_constr (to_constr sigma) d
+  let to_rel_decl sigma d = Context.Rel.Declaration.Smart.map_constr (to_constr sigma) d
 
   let unsafe_to_case_invert x = x
   let of_case_invert x = x

--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -46,7 +46,7 @@ let compact el ({ solution } as pv) =
   let apply_subst_einfo _ ei =
     Evd.({ ei with
        evar_concl =  nf ei.evar_concl;
-       evar_hyps = Environ.map_named_val (fun d -> map_constr nf0 d) ei.evar_hyps;
+       evar_hyps = Environ.map_named_val (fun d -> Smart.map_constr nf0 d) ei.evar_hyps;
        evar_candidates = Option.map (List.map nf) ei.evar_candidates }) in
   let new_solution = Evd.raw_map_undefined apply_subst_einfo pruned_solution in
   let new_size = Evd.fold (fun _ _ i -> i+1) new_solution 0 in

--- a/engine/termops.ml
+++ b/engine/termops.ml
@@ -1302,7 +1302,7 @@ let assums_of_rel_context sign =
 let map_rel_context_in_env f env sign =
   let rec aux env acc = function
     | d::sign ->
-        aux (push_rel d env) (RelDecl.map_constr (f env) d :: acc) sign
+        aux (push_rel d env) (RelDecl.Smart.map_constr (f env) d :: acc) sign
     | [] ->
         acc
   in
@@ -1310,7 +1310,7 @@ let map_rel_context_in_env f env sign =
 
 let map_rel_context_with_binders f sign =
   let rec aux k = function
-    | d::sign -> RelDecl.map_constr (f k) d :: aux (k-1) sign
+    | d::sign -> RelDecl.Smart.map_constr (f k) d :: aux (k-1) sign
     | [] -> []
   in
   aux (Context.Rel.length sign) sign

--- a/kernel/context.ml
+++ b/kernel/context.ml
@@ -225,6 +225,9 @@ struct
   (** Check whether given two rel-contexts are equal. *)
   let equal eq l = List.equal (fun c -> Declaration.equal eq c) l
 
+  (** Map all terms in a given rel-context. See also [Smart.map]. *)
+  let map_het f = List.map (Declaration.map_constr_het f)
+
   (** Perform a given action on every declaration in a given rel-context. *)
   let iter f = List.iter (Declaration.iter_constr f)
 
@@ -450,6 +453,9 @@ struct
 
   (** Check whether given two named-contexts are equal. *)
   let equal eq l = List.equal (fun c -> Declaration.equal eq c) l
+
+  (** Map all terms in a given named-context. See also [Smart.app]. *)
+  let map_het f = List.map (Declaration.map_constr_het f)
 
   (** Perform a given action on every declaration in a given named-context. *)
   let iter f = List.iter (Declaration.iter_constr f)

--- a/kernel/context.mli
+++ b/kernel/context.mli
@@ -150,6 +150,10 @@ sig
       @raise Not_found if the designated de Bruijn index outside the range. *)
   val lookup : int -> ('c, 't) pt -> ('c, 't) Declaration.pt
 
+  (** Map all terms in a given named-context.
+      If domain and codomain are the same, use [Smart.map]. *)
+  val map_het : ('c -> 'd) -> ('c, 'c) pt -> ('d, 'd) pt
+
   (** Perform a given action on every declaration in a given rel-context. *)
   val iter : ('c -> unit) -> ('c, 'c) pt -> unit
 
@@ -298,6 +302,10 @@ sig
 
   (** Check whether given two named-contexts are equal. *)
   val equal : ('c -> 'c -> bool) -> ('c, 'c) pt -> ('c, 'c) pt -> bool
+
+  (** Map all terms in a given named-context.
+      If domain and codomain are the same, use [Smart.map]. *)
+  val map_het : ('c -> 'd) -> ('c, 'c) pt -> ('d, 'd) pt
 
   (** Perform a given action on every declaration in a given named-context. *)
   val iter : ('c -> unit) -> ('c, 'c) pt -> unit

--- a/kernel/context.mli
+++ b/kernel/context.mli
@@ -100,10 +100,8 @@ sig
     (** Map the type of the name bound by a given declaration. *)
     val map_type : ('t -> 't) -> ('c, 't) pt -> ('c, 't) pt
 
-    (** Map all terms in a given declaration. *)
-    val map_constr : ('c -> 'c) -> ('c, 'c) pt -> ('c, 'c) pt
-
-    (** Map all terms, with an heterogeneous function. *)
+    (** Map all terms, with an heterogeneous function.
+        If domain and codomain are the same, use [Smart.map_constr]. *)
     val map_constr_het : ('a -> 'b) -> ('a, 'a) pt -> ('b, 'b) pt
 
     (** Perform a given action on all terms in a given declaration. *)
@@ -116,6 +114,16 @@ sig
 
     (** Turn [LocalDef] into [LocalAssum], identity otherwise. *)
     val drop_body : ('c, 't) pt -> ('c, 't) pt
+
+    module Smart :
+    sig
+      (** Map all terms in a given declaration. *)
+      val map_constr : ('c -> 'c) -> ('c, 'c) pt -> ('c, 'c) pt
+    end
+
+    (** Map all terms in a given declaration. *)
+    val map_constr : ('c -> 'c) -> ('c, 'c) pt -> ('c, 'c) pt
+    [@@ocaml.deprecated "Use Smart.map_constr"]
   end
 
   (** Rel-context is represented as a list of declarations.
@@ -141,9 +149,6 @@ sig
   (** Return a declaration designated by a given de Bruijn index.
       @raise Not_found if the designated de Bruijn index outside the range. *)
   val lookup : int -> ('c, 't) pt -> ('c, 't) Declaration.pt
-
-  (** Map all terms in a given rel-context. *)
-  val map : ('c -> 'c) -> ('c, 'c) pt -> ('c, 'c) pt
 
   (** Perform a given action on every declaration in a given rel-context. *)
   val iter : ('c -> unit) -> ('c, 'c) pt -> unit
@@ -171,6 +176,16 @@ sig
 
   (** [extended_vect n Γ] does the same, returning instead an array. *)
   val to_extended_vect : (int -> 'r) -> int -> ('c, 't) pt -> 'r array
+
+  module Smart :
+  sig
+    (** Map all terms in a given rel-context. *)
+    val map : ('c -> 'c) -> ('c, 'c) pt -> ('c, 'c) pt
+  end
+
+  (** Map all terms in a given rel-context. *)
+  val map : ('c -> 'c) -> ('c, 'c) pt -> ('c, 'c) pt
+  [@@ocaml.deprecated "Use Smart.map"]
 end
 
 (** This module represents contexts that can capture non-anonymous variables.
@@ -228,10 +243,8 @@ sig
     (** Map the type of the name bound by a given declaration. *)
     val map_type : ('t -> 't) -> ('c, 't) pt -> ('c, 't) pt
 
-    (** Map all terms in a given declaration. *)
-    val map_constr : ('c -> 'c) -> ('c, 'c) pt -> ('c, 'c) pt
-
-    (** Map all terms, with an heterogeneous function. *)
+    (** Map all terms, with an heterogeneous function.
+        If domain and codomain are the same, use [Smart.map_constr]. *)
     val map_constr_het : ('a -> 'b) -> ('a, 'a) pt -> ('b, 'b) pt
 
     (** Perform a given action on all terms in a given declaration. *)
@@ -253,6 +266,16 @@ sig
     (** Convert [Named.Declaration.t] value to the corresponding [Rel.Declaration.t] value. *)
     (* TODO: Move this function to [Rel.Declaration] module and rename it to [of_named]. *)
     val to_rel_decl : ('c, 't) pt -> ('c, 't) Rel.Declaration.pt
+
+    module Smart :
+    sig
+      (** Map all terms in a given declaration. *)
+      val map_constr : ('c -> 'c) -> ('c, 'c) pt -> ('c, 'c) pt
+    end
+
+    (** Map all terms in a given declaration. *)
+    val map_constr : ('c -> 'c) -> ('c, 'c) pt -> ('c, 'c) pt
+    [@@ocaml.deprecated "Use Smart.map_constr"]
   end
 
   (** Named-context is represented as a list of declarations.
@@ -276,9 +299,6 @@ sig
   (** Check whether given two named-contexts are equal. *)
   val equal : ('c -> 'c -> bool) -> ('c, 'c) pt -> ('c, 'c) pt -> bool
 
-  (** Map all terms in a given named-context. *)
-  val map : ('c -> 'c) -> ('c, 'c) pt -> ('c, 'c) pt
-
   (** Perform a given action on every declaration in a given named-context. *)
   val iter : ('c -> unit) -> ('c, 'c) pt -> unit
 
@@ -301,6 +321,16 @@ sig
       definitions of [Ω] skipped. Example: for [id1:T,id2:=c,id3:U], it
       gives [Var id1, Var id3]. All [idj] are supposed distinct. *)
   val to_instance : (Id.t -> 'r) -> ('c, 't) pt -> 'r list
+
+  module Smart :
+  sig
+    (** Map all terms in a given named-context. *)
+    val map : ('c -> 'c) -> ('c, 'c) pt -> ('c, 'c) pt
+  end
+
+  (** Map all terms in a given named-context. *)
+  val map : ('c -> 'c) -> ('c, 'c) pt -> ('c, 'c) pt
+  [@@ocaml.deprecated "Use Smart.map"]
 end
 
 module Compacted :
@@ -311,12 +341,21 @@ sig
       | LocalAssum of Id.t binder_annot list * 'types
       | LocalDef of Id.t binder_annot list * 'constr * 'types
 
-    val map_constr : ('c -> 'c) -> ('c, 'c) pt -> ('c, 'c) pt
     val of_named_decl : ('c, 't) Named.Declaration.pt -> ('c, 't) pt
     val to_named_context : ('c, 't) pt -> ('c, 't) Named.pt
+
+    module Smart :
+    sig
+      (** Map all terms in a given declaration. *)
+      val map_constr : ('c -> 'c) -> ('c, 'c) pt -> ('c, 'c) pt
+    end
+
+    val map_constr : ('c -> 'c) -> ('c, 'c) pt -> ('c, 'c) pt
+    [@@ocaml.deprecated "Use Smart.map_constr"]
   end
 
   type ('constr, 'types) pt = ('constr, 'types) Declaration.pt list
 
   val fold : (('c, 't) Declaration.pt -> 'a -> 'a) -> ('c, 't) pt -> init:'a -> 'a
+
 end

--- a/kernel/cooking.ml
+++ b/kernel/cooking.ml
@@ -223,7 +223,7 @@ let cook_constr { Opaqueproof.modlist ; abstract } (c, priv) =
     usubst, Opaqueproof.PrivatePolymorphic (univs, ctx)
   in
   let expmod = expmod_constr_subst cache modlist usubst in
-  let hyps = Context.Named.map expmod abstract in
+  let hyps = Context.Named.Smart.map expmod abstract in
   let hyps = abstract_context hyps in
   let c = abstract_as_body (expmod c) hyps in
   (c, priv)
@@ -238,7 +238,7 @@ let cook_constant { from = cb; info } =
   let abstract, usubst, abs_ctx = abstract in
   let usubst, univs = lift_univs usubst abs_ctx cb.const_universes in
   let expmod = expmod_constr_subst cache modlist usubst in
-  let hyps0 = Context.Named.map expmod abstract in
+  let hyps0 = Context.Named.Smart.map expmod abstract in
   let hyps = abstract_context hyps0 in
   let map c = abstract_as_body (expmod c) hyps in
   let body = match cb.const_body with
@@ -312,7 +312,7 @@ let cook_one_ind ~ntypes
       TemplateArity {template_level}
   in
   let mind_arity_ctxt =
-    let ctx = Context.Rel.map expmod mip.mind_arity_ctxt in
+    let ctx = Context.Rel.Smart.map expmod mip.mind_arity_ctxt in
     abstract_rel_ctx hyps ctx
   in
   let mind_user_lc =
@@ -348,12 +348,12 @@ let cook_inductive { Opaqueproof.modlist; abstract } mib =
   let subst, mind_universes = lift_univs subst abs_uctx mib.mind_universes in
   let cache = RefTable.create 13 in
   let expmod = expmod_constr_subst cache modlist subst in
-  let section_decls = Context.Named.map expmod section_decls in
+  let section_decls = Context.Named.Smart.map expmod section_decls in
   let removed_vars = Context.Named.to_vars section_decls in
   let section_decls, _ as hyps = abstract_context section_decls in
   let nnewparams = Context.Rel.nhyps section_decls in
   let mind_params_ctxt =
-    let ctx = Context.Rel.map expmod mib.mind_params_ctxt in
+    let ctx = Context.Rel.Smart.map expmod mib.mind_params_ctxt in
     abstract_rel_ctx hyps ctx
   in
   let ntypes = mib.mind_ntypes in

--- a/kernel/declareops.ml
+++ b/kernel/declareops.ml
@@ -88,7 +88,7 @@ let is_opaque cb = match cb.const_body with
 (** {7 Constant substitutions } *)
 
 let subst_rel_declaration sub =
-  RelDecl.map_constr (subst_mps sub)
+  RelDecl.Smart.map_constr (subst_mps sub)
 
 let subst_rel_context sub = List.Smart.map (subst_rel_declaration sub)
 
@@ -240,7 +240,7 @@ let subst_mind_packet sub mbp =
     mind_consnrealdecls = mbp.mind_consnrealdecls;
     mind_consnrealargs = mbp.mind_consnrealargs;
     mind_typename = mbp.mind_typename;
-    mind_nf_lc = Array.Smart.map (fun (ctx, c) -> Context.Rel.map (subst_mps sub) ctx, subst_mps sub c) mbp.mind_nf_lc;
+    mind_nf_lc = Array.Smart.map (fun (ctx, c) -> Context.Rel.Smart.map (subst_mps sub) ctx, subst_mps sub c) mbp.mind_nf_lc;
     mind_arity_ctxt = subst_rel_context sub mbp.mind_arity_ctxt;
     mind_arity = subst_ind_arity sub mbp.mind_arity;
     mind_user_lc = Array.Smart.map (subst_mps sub) mbp.mind_user_lc;
@@ -273,7 +273,7 @@ let subst_mind_body sub mib =
     mind_nparams = mib.mind_nparams;
     mind_nparams_rec = mib.mind_nparams_rec;
     mind_params_ctxt =
-      Context.Rel.map (subst_mps sub) mib.mind_params_ctxt;
+      Context.Rel.Smart.map (subst_mps sub) mib.mind_params_ctxt;
     mind_packets = Array.Smart.map (subst_mind_packet sub) mib.mind_packets ;
     mind_universes = mib.mind_universes;
     mind_template = mib.mind_template;
@@ -339,7 +339,7 @@ let hcons_ind_arity =
 
 let hcons_mind_packet oib =
   let user = Array.Smart.map Constr.hcons oib.mind_user_lc in
-  let map (ctx, c) = Context.Rel.map Constr.hcons ctx, Constr.hcons c in
+  let map (ctx, c) = Context.Rel.Smart.map Constr.hcons ctx, Constr.hcons c in
   let nf = Array.Smart.map map oib.mind_nf_lc in
   { oib with
     mind_typename = Names.Id.hcons oib.mind_typename;

--- a/kernel/vars.ml
+++ b/kernel/vars.ml
@@ -152,9 +152,9 @@ let substnl laml n c = substn_many (make_subst laml) n c
 let substl laml c = substn_many (make_subst laml) 0 c
 let subst1 lam c = substn_many [|make_substituend lam|] 0 c
 
-let substnl_decl laml k r = RelDecl.map_constr (fun c -> substnl laml k c) r
-let substl_decl laml r = RelDecl.map_constr (fun c -> substnl laml 0 c) r
-let subst1_decl lam r = RelDecl.map_constr (fun c -> subst1 lam c) r
+let substnl_decl laml k r = RelDecl.Smart.map_constr (fun c -> substnl laml k c) r
+let substl_decl laml r = RelDecl.Smart.map_constr (fun c -> substnl laml 0 c) r
+let subst1_decl lam r = RelDecl.Smart.map_constr (fun c -> subst1 lam c) r
 
 (* Build a substitution from an instance, inserting missing let-ins *)
 
@@ -274,7 +274,7 @@ let subst_univs_level_constr subst c =
       if !changed then c' else c
 
 let subst_univs_level_context s =
-  Context.Rel.map (subst_univs_level_constr s)
+  Context.Rel.Smart.map (subst_univs_level_constr s)
 
 let subst_instance_constr subst c =
   if Univ.Instance.is_empty subst then c
@@ -332,7 +332,7 @@ let univ_instantiate_constr u c =
 
 let subst_instance_context s ctx =
   if Univ.Instance.is_empty s then ctx
-  else Context.Rel.map (fun x -> subst_instance_constr s x) ctx
+  else Context.Rel.Smart.map (fun x -> subst_instance_constr s x) ctx
 
 let universes_of_constr c =
   let open Univ in

--- a/plugins/ssr/ssrtacticals.ml
+++ b/plugins/ssr/ssrtacticals.ml
@@ -113,7 +113,7 @@ let endclausestac id_map clseq gl_id cl0 =
   | _ -> EConstr.map (project gl) unmark c in
   let utac hyp =
     Proofview.V82.of_tactic
-     (Tactics.convert_hyp ~check:false ~reorder:false (NamedDecl.map_constr unmark hyp)) in
+     (Tactics.convert_hyp ~check:false ~reorder:false (NamedDecl.Smart.map_constr unmark hyp)) in
   let utacs = List.map utac (pf_hyps gl) in
   let ugtac gl' =
     Proofview.V82.of_tactic

--- a/pretyping/evardefine.ml
+++ b/pretyping/evardefine.ml
@@ -28,12 +28,12 @@ module RelDecl = Context.Rel.Declaration
 let env_nf_evar sigma env =
   let nf_evar c = nf_evar sigma c in
   process_rel_context
-    (fun d e -> push_rel (RelDecl.map_constr nf_evar d) e) env
+    (fun d e -> push_rel (RelDecl.Smart.map_constr nf_evar d) e) env
 
 let env_nf_betaiotaevar sigma env =
   process_rel_context
     (fun d env ->
-      push_rel (RelDecl.map_constr (fun c -> Reductionops.nf_betaiota env sigma c) d) env) env
+      push_rel (RelDecl.Smart.map_constr (fun c -> Reductionops.nf_betaiota env sigma c) d) env) env
 
 (****************************************)
 (* Operations on value/type constraints *)

--- a/pretyping/evarsolve.ml
+++ b/pretyping/evarsolve.ml
@@ -650,7 +650,7 @@ let solve_pattern_eqn env sigma l c =
       (* Rem: if [a] links to a let-in, do as if it were an assumption *)
       | RelAlias n ->
           let open Context.Rel.Declaration in
-          let d = map_constr (lift n) (lookup_rel n env) in
+          let d = Smart.map_constr (lift n) (lookup_rel n env) in
           mkLambda_or_LetIn d c'
       | VarAlias id ->
           let d = lookup_named id env in mkNamedLambda_or_LetIn d c'

--- a/pretyping/pretyping.ml
+++ b/pretyping/pretyping.ml
@@ -1036,7 +1036,7 @@ struct
           | [], [] -> []
           | _ -> assert false
         in aux 1 1 (List.rev nal) cs.cs_args, true in
-    let fsign = Context.Rel.map (whd_betaiota !!env sigma) fsign in
+    let fsign = Context.Rel.Smart.map (whd_betaiota !!env sigma) fsign in
     let hypnaming = if program_mode then ProgramNaming else KeepUserNameAndRenameExistingButSectionNames in
     let fsign,env_f = push_rel_context ~hypnaming sigma fsign env in
     let obj indt rci p v f =
@@ -1145,7 +1145,7 @@ struct
         let pi = lift n pred in (* liftn n 2 pred ? *)
         let pi = beta_applist sigma (pi, [EConstr.of_constr (build_dependent_constructor cs)]) in
         let cs_args = List.map (fun d -> map_rel_decl EConstr.of_constr d) cs.cs_args in
-        let cs_args = Context.Rel.map (whd_betaiota !!env sigma) cs_args in
+        let cs_args = Context.Rel.Smart.map (whd_betaiota !!env sigma) cs_args in
         let csgn =
           List.map (set_name Anonymous) cs_args
         in

--- a/pretyping/typeclasses.ml
+++ b/pretyping/typeclasses.ml
@@ -96,7 +96,7 @@ let instances : instances ref = Summary.ref GlobRef.Map.empty ~name:"instances"
 
 let typeclass_univ_instance (cl, u) =
   assert (Univ.AUContext.size cl.cl_univs == Univ.Instance.length u);
-  let subst_ctx c = Context.Rel.map (subst_instance_constr u) c in
+  let subst_ctx c = Context.Rel.Smart.map (subst_instance_constr u) c in
     { cl with cl_context = subst_ctx cl.cl_context;
       cl_props = subst_ctx cl.cl_props}
 

--- a/tactics/auto.ml
+++ b/tactics/auto.ml
@@ -291,7 +291,7 @@ let rec trivial_fail_db dbg mod_delta db_list local_db =
           let env = Proofview.Goal.env gl in
           let nf c = Evarutil.nf_evar sigma c in
           let decl = Tacmach.New.pf_last_hyp gl in
-          let hyp = Context.Named.Declaration.map_constr nf decl in
+          let hyp = Context.Named.Declaration.Smart.map_constr nf decl in
           let hintl = make_resolve_hyp env sigma hyp
           in trivial_fail_db dbg mod_delta db_list
                (Hint_db.add_list env sigma hintl local_db)

--- a/tactics/eqschemes.ml
+++ b/tactics/eqschemes.ml
@@ -659,9 +659,9 @@ let fix_r2l_forward_rew_scheme (c, ctx') =
   | hp :: p :: ind :: indargs ->
      let c' =
       my_it_mkLambda_or_LetIn indargs
-        (mkLambda_or_LetIn (RelDecl.map_constr (liftn (-1) 1) p)
-          (mkLambda_or_LetIn (RelDecl.map_constr (liftn (-1) 2) hp)
-            (mkLambda_or_LetIn (RelDecl.map_constr (lift 2) ind)
+        (mkLambda_or_LetIn (RelDecl.Smart.map_constr (liftn (-1) 1) p)
+          (mkLambda_or_LetIn (RelDecl.Smart.map_constr (liftn (-1) 2) hp)
+            (mkLambda_or_LetIn (RelDecl.Smart.map_constr (lift 2) ind)
               (EConstr.Unsafe.to_constr (Reductionops.whd_beta env sigma
                 (EConstr.of_constr (applist (c,
                   Context.Rel.to_extended_list mkRel 3 indargs @ [mkRel 1;mkRel 3;mkRel 2]))))))))

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -335,7 +335,7 @@ let rename_hyp repl =
       let subst c = Vars.replace_vars subst c in
       let map decl =
         decl |> NamedDecl.map_id (fun id -> try List.assoc_f Id.equal id repl with Not_found -> id)
-             |> NamedDecl.map_constr subst
+             |> NamedDecl.Smart.map_constr subst
       in
       let nhyps = List.map map hyps in
       let nconcl = subst concl in
@@ -3106,11 +3106,11 @@ let specialize (c,lbind) ipat =
            (* thie arg was solved, we update thing accordingly *)
            (* we replace in lprod the arg by rel 1 *)
            let substlp' = (* rel 1 must be lifted along the context *)
-             map_rel_context_lift (fun i x -> map_constr (replace_term sigma (mkRel i) t) x)
+             map_rel_context_lift (fun i x -> Smart.map_constr (replace_term sigma (mkRel i) t) x)
                env 1 lp' in
            (* Then we lift every rel above the just removed arg *)
            let updatedlp' =
-             map_rel_context_lift (fun i x -> map_constr (liftn (-1) i) x) env 1 substlp' in
+             map_rel_context_lift (fun i x -> Smart.map_constr (liftn (-1) i) x) env 1 substlp' in
            (* We replace also the term in the conclusion, its rel index is the
               length of the list lprd (remaining products before concl) *)
            let concl'' = replace_term sigma (mkRel (List.length lprd)) t concl in

--- a/vernac/classes.ml
+++ b/vernac/classes.ml
@@ -151,7 +151,7 @@ let subst_class (subst,cl) =
   let do_subst_con c = Mod_subst.subst_constant subst c
   and do_subst c = Mod_subst.subst_mps subst c
   and do_subst_gr gr = fst (subst_global subst gr) in
-  let do_subst_ctx = List.Smart.map (RelDecl.map_constr do_subst) in
+  let do_subst_ctx = List.Smart.map (RelDecl.Smart.map_constr do_subst) in
   let do_subst_meth m =
     let c = Option.Smart.map do_subst_con m.meth_const in
     if c == m.meth_const then m
@@ -176,14 +176,14 @@ let discharge_class (_,cl) =
   let repl = Lib.replacement_context () in
   let rel_of_variable_context ctx = List.fold_right
     ( fun decl (ctx', subst) ->
-        let decl' = decl |> NamedDecl.map_constr (substn_vars 1 subst) |> NamedDecl.to_rel_decl in
+        let decl' = decl |> NamedDecl.Smart.map_constr (substn_vars 1 subst) |> NamedDecl.to_rel_decl in
         (decl' :: ctx', NamedDecl.get_id decl :: subst)
     ) ctx ([], []) in
   let discharge_rel_context (subst, usubst) n rel =
-    let rel = Context.Rel.map (Cooking.expmod_constr repl) rel in
+    let rel = Context.Rel.Smart.map (Cooking.expmod_constr repl) rel in
     let fold decl (ctx, k) =
       let map c = subst_univs_level_constr usubst (substn_vars k subst c) in
-      RelDecl.map_constr map decl :: ctx, succ k
+      RelDecl.Smart.map_constr map decl :: ctx, succ k
     in
     let ctx, _ = List.fold_right fold rel ([], n) in
     ctx

--- a/vernac/comProgramFixpoint.ml
+++ b/vernac/comProgramFixpoint.ml
@@ -107,7 +107,7 @@ let telescope env sigma l =
   telescope sigma l
 
 let nf_evar_context sigma ctx =
-  List.map (map_constr (fun c -> Evarutil.nf_evar sigma c)) ctx
+  List.map (Smart.map_constr (fun c -> Evarutil.nf_evar sigma c)) ctx
 
 let build_wellfounded pm (recname,pl,bl,arityc,body) poly ?using r measure notation =
   let open EConstr in

--- a/vernac/record.ml
+++ b/vernac/record.ml
@@ -705,8 +705,8 @@ let declare_class def ~cumulative ~ubind ~univs ~variances id idbuild paramimpls
       let usubst, auctx = Univ.abstract_universes nas univs in
       let usubst = Univ.make_instance_subst usubst in
       let map c = Vars.subst_univs_level_constr usubst c in
-      let fields = Context.Rel.map map fields in
-      let params = Context.Rel.map map params in
+      let fields = Context.Rel.Smart.map map fields in
+      let params = Context.Rel.Smart.map map params in
       auctx, params, fields
     | Monomorphic_entry _ ->
       Univ.AUContext.empty, params, fields


### PR DESCRIPTION
**Kind:** cleanup

Following a [comment](https://github.com/coq/coq/pull/9317#pullrequestreview-199553442) of @ppedrot, we align the terminology for homogeneous map functions in `Context` to the `Smart` terminology already present in `List`, `Option`, ...

We also add `map_het` on contexts (to be used in #13445).

Not using `Smart` is deprecated. In a next step, the `_het` suffix of heteregeneous version could be to dropped.

This is at the limit of being overzealous though: the risk is that thinking to use the `Smart` versions whenever possible becomes less obvious from the moment the hetero- and homogeneous versions have the same name. We compensate this by recommending looking at the `Smart` versions in the documentation of the heterogeneous ones.