### PR TITLE
Add missing print registration for wit_nat_or_var

### DIFF
--- a/plugins/ltac/pptactic.ml
+++ b/plugins/ltac/pptactic.ml
@@ -1317,6 +1317,7 @@ let () =
   let pr_unit _ = str "()" in
   let open Genprint in
   register_basic_print0 wit_int_or_var (pr_or_var int) (pr_or_var int) int;
+  register_basic_print0 wit_nat_or_var (pr_or_var int) (pr_or_var int) int;
   register_basic_print0 wit_ref
     pr_qualid (pr_or_var (pr_located pr_global)) pr_global;
   register_basic_print0 wit_smart_global


### PR DESCRIPTION
This fixes an oversight in #13417.  The print routine is not registered, so `Ltac x := constructor 1.  Print x.` currently shows `Ltac x := constructor <genarg:nat_or_var>`

@gares Can we get this fix into 8.13 beta of 8.13.0?

@herbelin, could you take this one?