### PR TITLE
Fixes #13413: freshness failure in apply-in introduction pattern

### DIFF
--- a/dev/ci/user-overlays/13512-herbelin-master+fix13413-apply-on-intro-pattern-fresh-names.sh
+++ b/dev/ci/user-overlays/13512-herbelin-master+fix13413-apply-on-intro-pattern-fresh-names.sh
@@ -1,0 +1,5 @@
+if [ "$CI_PULL_REQUEST" = "13415" ] || [ "$CI_BRANCH" = "intern-univs" ]; then
+
+    overlay perennial https://github.com/herbelin/perennial master+adapt13512-fresness-names-apply-in-introduction-pattern
+
+fi

--- a/doc/changelog/04-tactics/13512-master+fix13413-apply-on-intro-pattern-fresh-names.rst
+++ b/doc/changelog/04-tactics/13512-master+fix13413-apply-on-intro-pattern-fresh-names.rst
@@ -1,0 +1,6 @@
+- **Fixed:**
+  Possible collision between a user-level name and an internal name when
+  using the :n:`%` introduction pattern
+  (`#13512 <https://github.com/coq/coq/pull/13512>`_,
+  fixes `#13413 <https://github.com/coq/coq/issues/13413>`_,
+  by Hugo Herbelin).

--- a/test-suite/bugs/closed/bug_13413.v
+++ b/test-suite/bugs/closed/bug_13413.v
@@ -1,0 +1,20 @@
+Goal forall (A B : Prop) (H : A -> B), A -> A -> B.
+intros A B H ?%H H0.
+exact H1.
+Qed.
+
+Goal forall (A B : Prop) (H : A -> B), A -> A -> B.
+intros A B H ?H%H H0.
+exact H1.
+Qed.
+
+Goal forall (A B : Prop) (H : A -> B), A -> A -> B.
+intros A B H J%H H0.
+exact J.
+Qed.
+
+Set Mangle Names.
+Goal forall (A B : Prop) (H : A -> B), A -> A -> B.
+intros A B H ?%H _0.
+assumption.
+Qed.

--- a/test-suite/success/forward.v
+++ b/test-suite/success/forward.v
@@ -27,3 +27,7 @@ Fail match goal with |- (?f ?a) => idtac end. (* should be beta-iota reduced *)
 2:match goal with _: (?f ?a) |- _ => idtac end. (* should not be beta-iota reduced *)
 Abort.
 
+Goal nat.
+assert nat as J%S by exact 0.
+exact J.
+Qed.

--- a/test-suite/success/intros.v
+++ b/test-suite/success/intros.v
@@ -152,3 +152,15 @@ Definition d := ltac:(intro x; exact (x*x)).
 Definition d' : nat -> _ := ltac:(intros;exact 0).
 
 End Evar.
+
+Module Wildcard.
+
+(* We check that the wildcard internal name does not interfere with
+   user fresh names (currently the prefix is "_H") *)
+
+Goal nat -> bool -> nat -> bool.
+intros _ ?_H ?_H.
+exact _H.
+Qed.
+
+End Wildcard.


### PR DESCRIPTION
**Kind:** bug fix

The fix mostly computes the internal name for an `%` introduction pattern by looking earlier than before at the end of the chain of `%` (i.e. in `make_naming` instead of `prepare_naming`), so that, if this end is some `?` or `?H`, the names to avoid in the rest of patterns to introduce is known.

Also, we prevent internal names to interact with user names prefix, as in:
```
Goal nat -> nat -> nat.
intros _ ?_tmp.
```
which was using `_tmp0` as a internal side effect instead of `_tmp`.

We do some reworking at the same time.

Fixes / closes #13413

- [X] Added / updated test-suite
- [x] Entry added in the changelog
