### PR TITLE
Re-implementing the disjunctive-conjunctive introduction pattern on top of "destruct" rather than "case"

### DIFF
--- a/dev/ci/user-overlays/13513-herbelin-master+disjunctive-intro-pattern-on-top-of-destruct.sh
+++ b/dev/ci/user-overlays/13513-herbelin-master+disjunctive-intro-pattern-on-top-of-destruct.sh
@@ -1,0 +1,7 @@
+if [ "$CI_PULL_REQUEST" = "13513" ] || [ "$CI_BRANCH" = "master+disjunctive-intro-pattern-on-top-of-destruct" ]; then
+
+    overlay flocq git@gitlab.inria.fr:herbelin/flocq.git master+adapt-coq-pr13513-disjunctive-intro-pattern-is-destruct
+    overlay hott https://github.com/herbelin/HoTT master+adapt-coq-pr13513-disjunctive-intro-pattern-is-destruct
+    overlay unimath https://github.com/herbelin/UniMath master+adapt-coq-pr13513-disjunctive-intro-pattern-is-destruct
+
+fi

--- a/dev/ci/user-overlays/13521-herbelin-master+disjunctive-intro-pattern-on-top-of-destruct
+++ b/dev/ci/user-overlays/13521-herbelin-master+disjunctive-intro-pattern-on-top-of-destruct
@@ -1,0 +1,11 @@
+if [ "$CI_PULL_REQUEST" = "13415" ] || [ "$CI_BRANCH" = "intern-univs" ]; then
+
+    overlay argosy https://github.com/herbelin/argosy master+adapt-coq-pr13521-edestruct-clear-variables-like-destruct
+    overlay cross-crypto https://github.com/herbelin/cross-crypto master+adapt-coq-pr13521-edestruct-clear-variables-like-destruct
+    overlay stdpp https://github.com/herbelin/stdpp master+adapt-coq-pr13521-edestruct-clear-variables-like-destruct
+    overlay sf https://github.com/herbelin/sf master+adapt-coq-pr13521-edestruct-clear-variables-like-destruct
+    overlay fiat-parsers https://github.com/herbelin/fiat-parsers master+adapt-coq-pr13521-edestruct-clear-variables-like-destruct
+    overlay metacoq https://github.com/herbelin/metacoq master+adapt-coq-pr13521-edestruct-clear-variables-like-destruct
+    overlay quickchick https://github.com/herbelin/QuickChick master+adapt-coq-pr13521-edestruct-clear-variables-like-destruct
+
+fi

--- a/test-suite/bugs/closed/bug_3045.v
+++ b/test-suite/bugs/closed/bug_3045.v
@@ -31,5 +31,5 @@ refine match m with
 (* This fails with an error rather than an anomaly, but morally
    it should work, if destruct were able to do the good generalization
    in advance, before doing the "intros []". *)
-Fail destruct (@ReifiedMorphismSimplifyWithProof T s1 d0 d0' m1) as [ [] ? ].
+destruct (@ReifiedMorphismSimplifyWithProof T s1 d0 d0' m1) as [ [] ? ].
 Abort.

--- a/test-suite/bugs/closed/bug_7972.v
+++ b/test-suite/bugs/closed/bug_7972.v
@@ -1,0 +1,6 @@
+Inductive foo : Set -> Type := Foo : foo unit.
+
+Lemma bar U (pf : unit = U) : forall (x : foo U), x = eq_rect unit foo Foo U pf.
+Proof.
+  intros [].
+Abort.


### PR DESCRIPTION
**Kind:** feature

Depends on #13509 (merged) and #13512  (merged).

First attempt at using `destruct` rather than `case` in disjunctive introduction patterns. 

It is surprisingly backward-compatible in the standard library and test-suite. It is probably a bit slower though since it looks for occurrences in the whole context. If significant, some fine-tuning may be needed.

This is also a step in the direction of a better compatibility with #9710 (compact representation of pattern-matching).

In particular, closes #7972 and answer a [comment](https://github.com/coq/coq/issues/3045#issuecomment-337514632) of #3045.

- [X] Added / updated test-suite
- [ ] Corresponding documentation was added / updated
- [ ] Entry added in the changelog
