### PR TITLE
dune: Don't echo "$(pwd)" when creating the shims

### DIFF
--- a/dev/shim/dune
+++ b/dev/shim/dune
@@ -7,7 +7,7 @@
   (with-stdout-to coqtop-prelude
    (progn
     (echo "#!/usr/bin/env bash\n")
-    (bash "echo \"$(pwd)/%{bin:coqtop} -coqlib $(pwd)/%{project_root}\" \\$@")
+    (bash "echo '$(dirname $0)/%{bin:coqtop} -coqlib $(dirname $0)/%{project_root}' \\$@")
     (run chmod +x %{targets})))))
 
 (rule
@@ -19,7 +19,7 @@
   (with-stdout-to coqc-prelude
    (progn
     (echo "#!/usr/bin/env bash\n")
-    (bash "echo \"$(pwd)/%{bin:coqc} -coqlib $(pwd)/%{project_root}\" \\$@")
+    (bash "echo '$(dirname $0)/%{bin:coqc} -coqlib $(dirname $0)/%{project_root}' \\$@")
     (run chmod +x %{targets})))))
 
 (rule
@@ -32,7 +32,7 @@
   (with-stdout-to %{targets}
    (progn
     (echo "#!/usr/bin/env bash\n")
-    (bash "echo \"$(pwd)/%{bin:coqtop.byte} -coqlib $(pwd)/%{project_root}\" \\$@")
+    (bash "echo '$(dirname $0)/%{bin:coqtop.byte} -coqlib $(dirname $0)/%{project_root}' \\$@")
     (run chmod +x %{targets})))))
 
 (rule
@@ -48,5 +48,5 @@
   (with-stdout-to coqide-prelude
    (progn
     (echo "#!/usr/bin/env bash\n")
-    (bash "echo \"$(pwd)/%{bin:coqide} -coqlib $(pwd)/%{project_root}\" \\$@")
+    (bash "echo '$(dirname $0)/%{bin:coqide} -coqlib $(dirname $0)/%{project_root}' \\$@")
     (run chmod +x %{targets})))))


### PR DESCRIPTION
AFAICT `echo "$(pwd)"` is unsound for the dune cache when called from
different paths (typically different git worktrees).