### PR TITLE
Revert removal of eoi_entry in #13447

### DIFF
--- a/parsing/pcoq.mli
+++ b/parsing/pcoq.mli
@@ -120,6 +120,7 @@ end
 (** Parse a string *)
 
 val parse_string : 'a Entry.t -> ?loc:Loc.t -> string -> 'a
+val eoi_entry : 'a Entry.t -> 'a Entry.t
 
 type gram_universe [@@deprecated "Deprecated in 8.13"]
 [@@@ocaml.warning "-3"]
@@ -180,6 +181,7 @@ module Prim :
 module Constr :
   sig
     val constr : constr_expr Entry.t
+    val constr_eoi : constr_expr Entry.t
     val lconstr : constr_expr Entry.t
     val binder_constr : constr_expr Entry.t
     val term : constr_expr Entry.t

--- a/plugins/ltac/pltac.ml
+++ b/plugins/ltac/pltac.ml
@@ -47,6 +47,8 @@ let binder_tactic = Entry.create "binder_tactic"
 let tactic = Entry.create "tactic"
 
 (* Main entry for quotations *)
+let tactic_eoi = eoi_entry tactic
+
 let () =
   let open Stdarg in
   let open Tacarg in

--- a/plugins/ltac/pltac.mli
+++ b/plugins/ltac/pltac.mli
@@ -40,3 +40,4 @@ val tactic_expr : raw_tactic_expr Entry.t
   [@@deprecated "Deprecated in 8.13; use 'ltac_expr' instead"]
 val binder_tactic : raw_tactic_expr Entry.t
 val tactic : raw_tactic_expr Entry.t
+val tactic_eoi : raw_tactic_expr Entry.t


### PR DESCRIPTION
While not used in the Coq source tree, `eoi_entry` is used in at least one plugin.  See discussion starting [here](https://github.com/coq/coq/pull/13447#issuecomment-735307396).

I didn't re-add `map_entry`.

@herbelin Perhaps you could take this one?

@gares We'd like to get this into 8.13.  The reversion may be pointless if it's not.