### PR TITLE
[kernel]Use ~l2r:true to restore previous order of unfolding 

### DIFF
--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -331,6 +331,9 @@ let check_allowed_sort ksort specif =
     raise (LocalArity (Some(elim_sort specif, ksort,s,error_elim_explain ksort s)))
 
 let check_correct_arity env c pj ind specif params =
+  (* We use l2r:true for compat with old versions which used CONV
+     instead of CUMUL called with arguments flipped. It is relevant
+     for performance eg in bedrock / Kami. *)
   let arsign,_ = get_instantiated_arity ind specif params in
   let rec srec env ar pt =
     let pt' = whd_all env pt in

--- a/kernel/inductive.ml
+++ b/kernel/inductive.ml
@@ -337,7 +337,7 @@ let check_correct_arity env c pj ind specif params =
     match ar, kind pt' with
     | (LocalAssum (_,a1))::ar', Prod (na1,a1',t) ->
       let () =
-        try conv_leq env a1 a1'
+        try conv_leq ~l2r:true env a1 a1'
         with NotConvertible -> raise (LocalArity None) in
       srec (push_rel (LocalAssum (na1,a1)) env) ar' t
     (* The last Prod domain is the type of the scrutinee *)
@@ -351,7 +351,7 @@ let check_correct_arity env c pj ind specif params =
       let () =
         (* This ensures that the type of the scrutinee is <= the
            inductive type declared in the predicate. *)
-        try conv_leq env dep_ind a1'
+        try conv_leq ~l2r:true env dep_ind a1'
         with NotConvertible -> raise (LocalArity None)
       in
       let () = check_allowed_sort ksort specif in


### PR DESCRIPTION
When typing predicates of cases. Apparently Kami is sensitive to that.

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->


<!-- Keep what applies -->
**Kind:** performance


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes: comment in #13501


<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [ ] Added / updated test-suite
<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [ ] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [ ] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
