### PR TITLE
[engine] Remove kernel-level side effects push in refine.

### DIFF
--- a/proofs/refine.ml
+++ b/proofs/refine.ml
@@ -57,9 +57,6 @@ let generic_refine ~typecheck f gl =
   f >>= fun (v, c) ->
   Proofview.tclEVARMAP >>= fun sigma' ->
   Proofview.V82.wrap_exceptions begin fun () ->
-  (* Redo the effects in sigma in the monad's env *)
-  let privates_csts = Evd.eval_side_effects sigma' in
-  let env = Safe_typing.push_private_constants env privates_csts.Evd.seff_private in
   (* Check that the introduced evars are well-typed *)
   let fold accu ev = typecheck_evar ev env accu in
   let sigma = if typecheck then Evd.fold_future_goals fold sigma' else sigma' in


### PR DESCRIPTION
This was noted by Gaëtan after some investigations, and indeed it
makes sense refine should have no business messing with this.

The functions creating the side-effects should be the ones that ensure
that the env is consistent.

I'm not fully sure how this is working yet tho, this part of the proof
engine is hard to follow.

Co-authored-by: Gaëtan Gilbert <gaetan.gilbert@skyskimmer.net>
