### PR TITLE
Small improvement in naming dependent goals

### DIFF
--- a/test-suite/output/unification.out
+++ b/test-suite/output/unification.out
@@ -33,3 +33,10 @@ The term "id" has type "ID" while it is expected to have type
   H : forall x : nat, S x = x
   ============================
   ?y = 0
+1 focused goal
+(shelved: 3)
+  
+  T : Prop
+  H : forall Q R S : Prop, (Q /\ R) /\ S -> T
+  ============================
+  (?Q /\ ?R) /\ ?S

--- a/test-suite/output/unification.v
+++ b/test-suite/output/unification.v
@@ -1,3 +1,5 @@
+(* coq-prog-args: ("-async-proofs" "off") *)
+
 (* Unification error tests *)
 
 Module A.
@@ -36,3 +38,13 @@ rewrite H.
 Show.
 reflexivity.
 Qed.
+
+(* Use names also when instantiating an existing evar *)
+
+Lemma L (T : Prop) (H : forall Q R S : Prop, (Q /\ R) /\ S -> T) :
+  exists P:Prop, (P -> T) /\ P.
+Proof.
+eexists ?[P]. split.
+- apply H.
+- Show.
+Abort.


### PR DESCRIPTION
**Kind:** enhancement

This uses the corresponding variable name instead of `?Goal` in the following kind of cases:
```
Lemma L (Q : Prop) (H : forall P, P /\ P -> Q) : exists P:Prop, (P -> Q) /\ P.
eexists ?[P]. split.
- apply H. (* gives "?P /\ ?P" instead of "?Goal0 /\ ?Goal0" *)
```

Note: there is another kind of unsatisfactory situation:
```
Goal Prop.
refine (_ _).
```
gives `?Goal0 -> Prop` and `?Goal0` while e.g. `?T -> Prop` and `?T` would be better.

This would require to reorganize a bit the evar kinds though, separating at least the `VarInstance` and `GoalEvar` kinds which have a semantic role in proofs from instances which are purely informative.

- [X] Added / updated test-suite
