### PR TITLE
Improve error handling with make when _CoqProject incorrect

### DIFF
--- a/doc/changelog/08-cli-tools/13541-fix9319.rst
+++ b/doc/changelog/08-cli-tools/13541-fix9319.rst
@@ -1,0 +1,5 @@
+- **Fixed:**
+  ``coq_makefile`` has improved logic when dealing with incorrect ``_CoqProject`` files
+  (`#13541 <https://github.com/coq/coq/pull/13541>`_,
+  fixes `#9319 <https://github.com/coq/coq/issues/9319>`_,
+  by Fabian Kunze).

--- a/test-suite/coq-makefile/gen-v-during-make/run.sh
+++ b/test-suite/coq-makefile/gen-v-during-make/run.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+. ../template/init.sh
+
+cat > _CoqProject <<EOF
+-R ./theories/ ""
+theories/use.v
+theories/generatedInPreAll.v
+EOF
+
+cat > theories/use.v <<EOF
+Require generatedInPreAll.
+EOF
+
+printf 'theories/generatedInPreAll.v:\n\ttouch theories/generatedInPreAll.v\n' > Makefile.local
+
+coq_makefile -f _CoqProject -o Makefile
+make

--- a/test-suite/coq-makefile/missing-included/run.sh
+++ b/test-suite/coq-makefile/missing-included/run.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+. ../template/init.sh
+
+cat > _CoqProject <<EOF
+-R ./theories/ ""
+theories/b.v
+theories/a.v
+theories/noSuchFile.v
+EOF
+touch theories/a.v
+cat > theories/b.v <<EOF
+Require a.
+EOF
+
+coq_makefile -f _CoqProject -o Makefile
+
+if make 2> stdErr.log; then exit 1; fi
+
+# on osx it says "No rule to make target `.Makefile.d', needed by `theories/b.vo'.  Stop."
+#grep -q noSuchFile stdErr.log

--- a/test-suite/coq-makefile/missing-required/run.sh
+++ b/test-suite/coq-makefile/missing-required/run.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+. ../template/init.sh
+
+cat > _CoqProject <<EOF
+-R ./theories/ "Lib"
+theories/a.v
+EOF
+cat > theories/a.v <<EOF
+Require noSuchFile.
+EOF
+
+coq_makefile -f _CoqProject -o Makefile
+
+if make 2> stdErr.log; then exit 1; fi
+
+grep -q noSuchFile stdErr.log

--- a/tools/CoqMakefile.in
+++ b/tools/CoqMakefile.in
@@ -759,7 +759,7 @@ else
 TIMING_EXTRA =
 endif
 
-$(VOFILES): %.vo: %.v
+$(VOFILES): %.vo: %.v | $(VDFILE)
 	$(SHOW)COQC $<
 	$(HIDE)$(TIMER) $(COQC) $(COQDEBUG) $(TIMING_ARG) $(COQFLAGS) $(COQLIBS) $< $(TIMING_EXTRA)
 ifeq ($(COQDONATIVE), "yes")


### PR DESCRIPTION
fix #9319 by always calling coqdep, even if a vfile does not exist
-also added tests that `make` with missing files produces errors mentioning the missing files and not something unrelated

The behaviour before was that since the VDFILE depended on all VFILES mentioned in the _CoqProject-file, the VDFILE simply did not get made when a .v-file did not exist.



<!-- Keep what applies -->
**Kind:** bug fix


<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes  #9319


<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [x] Added / updated test-suite

