### PR TITLE
Experimenting a different check about existential variables produced by non-"e" tactics

### DIFF
--- a/tactics/tacticals.ml
+++ b/tactics/tacticals.ml
@@ -711,6 +711,9 @@ module New = struct
           None in
     let rest =
       Evd.fold_undefined (fun evk evi acc ->
+        match snd evi.evar_source with
+        | Evar_kinds.GoalEvar -> acc
+        | _ ->
         match is_undefined_up_to_restriction sigma evk with
         | Some (evk',evi) ->
            (* If [evk'] descends from [evk] which descends itself from
@@ -719,7 +722,7 @@ module New = struct
            if Evar.Set.mem evk (Lazy.force reachable) then acc
            else (evk',evi)::acc
         | _ -> acc)
-        extsigma []
+        sigma []
     in
     match rest with
     | [] -> ()

--- a/test-suite/bugs/closed/bug_2244.v
+++ b/test-suite/bugs/closed/bug_2244.v
@@ -13,7 +13,7 @@ Lemma test : forall
 Proof.
   intros. eapply EV. intros.
   (* worked in v8.2 but not in v8.3beta, fixed in r12898 *)
-  apply HS.
+  eapply HS.
 
   (* still not compatible with 8.2 because an evar can be solved in
      two different ways and is left open *)

--- a/test-suite/bugs/closed/bug_3531.v
+++ b/test-suite/bugs/closed/bug_3531.v
@@ -42,9 +42,9 @@ Goal forall b, (exists e1 e2 e3,
  Set Printing Universes.
  Show Universes.
  do 3 eapply ex_intro.
- eapply piff_trans; [ apply flatten_exists | apply piff_refl ]; intros.
- eapply piff_trans; [ apply flatten_exists | apply piff_refl ]; intros.
- eapply piff_trans; [ apply flatten_exists | apply piff_refl ]; intros.
+ eapply piff_trans; [ eapply flatten_exists | apply piff_refl ]; intros.
+ eapply piff_trans; [ eapply flatten_exists | apply piff_refl ]; intros.
+ eapply piff_trans; [ eapply flatten_exists | apply piff_refl ]; intros.
  assert (H : False) by (clear; admit); destruct H.
  Grab Existential Variables.
  admit.

--- a/test-suite/bugs/closed/bug_4202.v
+++ b/test-suite/bugs/closed/bug_4202.v
@@ -4,7 +4,7 @@ Lemma foo (H : True) : exists n, g n /\ g n.
 eexists.
 clear H.
 split.
-simple apply a.
+simple eapply a.
 (* goal is "g (S ?Goal0@ {H:=H})" while H has long ceased to exist *)
 simpl.
 Abort.

--- a/test-suite/bugs/closed/bug_7392.v
+++ b/test-suite/bugs/closed/bug_7392.v
@@ -5,6 +5,6 @@ Proof.
 intros H0 H1.
 eapply H0.
 clear H1.
-apply ER.
+eapply ER.
 simpl.
 Abort.

--- a/test-suite/output-coqtop/DependentEvars.v
+++ b/test-suite/output-coqtop/DependentEvars.v
@@ -19,6 +19,6 @@ Section eex.
   Lemma p14 : P4.
   Proof.
     eapply strange_imp_trans.
-          apply modpon.
+          eapply modpon.
   Abort.
 End eex.

--- a/test-suite/output-coqtop/DependentEvars2.v
+++ b/test-suite/output-coqtop/DependentEvars2.v
@@ -21,7 +21,7 @@ Section eex.
     idtac "Second proof:".
     eapply strange_imp_trans.
           {
-            apply modpon.
+            eapply modpon.
           }
   Abort.
 End eex.

--- a/test-suite/output/unification.v
+++ b/test-suite/output/unification.v
@@ -15,15 +15,15 @@ End A.
 
 Goal (forall x, S (S (S x)) = x) -> exists x, S x = 0.
 eexists.
-rewrite H.
+erewrite H.
 Show.
 Undo 2.
 eexists ?[x].
-rewrite H.
+erewrite H.
 Show.
 Undo 2.
 eexists ?[y].
-rewrite H.
+erewrite H.
 Show.
 reflexivity.
 Qed.

--- a/theories/Reals/RiemannInt_SF.v
+++ b/theories/Reals/RiemannInt_SF.v
@@ -1749,7 +1749,7 @@ Lemma StepFun_P37 :
     RiemannInt_SF f <= RiemannInt_SF g.
 Proof.
   intros; eapply StepFun_P36; try assumption.
-  eapply StepFun_P25; apply StepFun_P29.
+  eapply StepFun_P25; eapply StepFun_P29.
   eapply StepFun_P23; apply StepFun_P29.
 Qed.
 

--- a/theories/Sorting/Mergesort.v
+++ b/theories/Sorting/Mergesort.v
@@ -178,9 +178,9 @@ Proof.
     reflexivity.
     rewrite app_assoc.
     etransitivity.
-      apply Permutation_app_tail.
+      eapply Permutation_app_tail.
       etransitivity.
-        apply Permutation_app_comm.
+        eapply Permutation_app_comm.
       apply Permuted_merge.
     apply IHstack.
     reflexivity.
@@ -223,7 +223,7 @@ Proof.
     change (a::l) with ([a]++l).
     rewrite app_assoc.
     etransitivity.
-      apply Permutation_app_tail.
+      eapply Permutation_app_tail.
     etransitivity.
     apply Permutation_app_comm.
     apply Permuted_merge_list_to_stack.


### PR DESCRIPTION
**Kind:** experiment

The current status for non-"e" tactics is that they fail if some hole in the arguments of the tactic remains unresolved. This has the effect that `apply f` may succeed but `apply (f _)` may not (if the hole is non-dependent). This PR experiments a different criterion so that:
- failures are stable by addition of extra `_`
- failures are at the toplevel of a tactic: check for unresolved evars is at the end of `apply f, g` and not first at the end of `apply f`, then at the end of `apply g`
- if an existing evar is instantiated by a non-trivial term containing an evar, this is considered leaving an unresolved evar

TODO: in "existing evar == new evar" problems, I presume it should not be considered a creation.

- [X] Added / updated test-suite
