### PR TITLE
[coqide] fix procedure to parse arguments

### DIFF
--- a/stm/asyncTaskQueue.ml
+++ b/stm/asyncTaskQueue.ml
@@ -125,7 +125,7 @@ module Make(T : Task) () = struct
                  "-async-proofs-worker-priority";
                  CoqworkmgrApi.(string_of_priority priority)]
         (* Options to discard: 0 arguments *)
-        | "-emacs"::tl ->
+        | ("-emacs" | "--xml_format=Ppcmds" | "-batch") :: tl  ->
           set_slave_opt tl
         (* Options to discard: 1 argument *)
         | ( "-async-proofs" | "-vio2vo" | "-o"

--- a/toplevel/workerLoop.ml
+++ b/toplevel/workerLoop.ml
@@ -8,13 +8,8 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
-let rec parse = function
-  | "--xml_format=Ppcmds" :: rest -> parse rest
-  | x :: rest -> x :: parse rest
-  | [] -> []
-
 let worker_parse_extra ~opts extra_args =
-  (), parse extra_args
+  (), extra_args
 
 let worker_init init () ~opts =
   Flags.quiet := true;


### PR DESCRIPTION
coqide calls coqidetop -batch, if you are in -async-proof on then
coqidetop spawns a worker and passes -batch to it. At some point,
I could not find the commit, this made the worker die.