### PR TITLE
Document Number Notation for primitive integers

### DIFF
--- a/doc/sphinx/user-extensions/syntax-extensions.rst
+++ b/doc/sphinx/user-extensions/syntax-extensions.rst
@@ -1707,6 +1707,8 @@ Number notations
             * :n:`Number.uint -> option @qualid__type`
             * :n:`Z -> @qualid__type`
             * :n:`Z -> option @qualid__type`
+            * :n:`Int63.int -> @qualid__type`
+            * :n:`Int63.int -> option @qualid__type`
             * :n:`Number.number -> @qualid__type`
             * :n:`Number.number -> option @qualid__type`
 
@@ -1719,6 +1721,8 @@ Number notations
             * :n:`@qualid__type -> option Number.uint`
             * :n:`@qualid__type -> Z`
             * :n:`@qualid__type -> option Z`
+            * :n:`@qualid__type -> Int63.int`
+            * :n:`@qualid__type -> option Int63.int`
             * :n:`@qualid__type -> Number.number`
             * :n:`@qualid__type -> option Number.number`
 
@@ -1823,6 +1827,13 @@ Number notations
      only for integers or non-negative integers, and the given number
      has a fractional or exponent part or is negative.
 
+   .. exn:: int63 are only non-negative numbers.
+
+      :n:`Int63.int` are unsigned integers.
+
+   .. exn:: overflow in int63 literal @bigint
+
+      The constant is too big to fit into an unsigned 63-bit integer :n:`Int63.int`.
 
    .. exn:: @qualid__parse should go from Number.int to @type or (option @type). Instead of Number.int, the types Number.uint or Z or Int63.int or Number.number could be used (you may need to require BinNums or Number or Int63 first).
 


### PR DESCRIPTION
This feature is there since the beginning of primitive integers ( coq/coq#6914 ) but was undocumented.
