### PR TITLE
Split long lines in errors and warning index

### DIFF
--- a/doc/sphinx/_static/notations.css
+++ b/doc/sphinx/_static/notations.css
@@ -266,3 +266,13 @@ code span.error {
 .rst-content tt.literal, .rst-content tt.literal, .rst-content code.literal {
     color: inherit !important;
 }
+
+/* make the error message index readable */
+.indextable code {
+    white-space: inherit;  /* break long lines */
+}
+
+.indextable tr td + td {
+    padding-left: 2em; /* indent 2nd & subsequent lines */
+    text-indent: -2em;
+}


### PR DESCRIPTION
Wraps long index entries so they don't go off the right hand margin, in particular in the errors and warnings index, which was a mess.

Fixes: #13504

@gares: would like to get doc-only fix into 8.13