### PR TITLE
Fix spelling in warning entry

### DIFF
--- a/doc/changelog/07-commands-and-options/13556-master.rst
+++ b/doc/changelog/07-commands-and-options/13556-master.rst
@@ -1,0 +1,4 @@
+- **Changed:**
+  The warning `custom-entry-overriden` has been renamed to `custom-entry-overridden` (with two d's).
+  (`#13556 <https://github.com/coq/coq/pull/13556>`_,
+  by Simon Friis Vindum).

--- a/doc/sphinx/user-extensions/syntax-extensions.rst
+++ b/doc/sphinx/user-extensions/syntax-extensions.rst
@@ -309,7 +309,7 @@ at the time of use of the notation.
    a notation should only be used for printing.
 
    If a notation to be used both for parsing and printing is
-   overriden, both the parsing and printing are invalided, even if the
+   overridden, both the parsing and printing are invalided, even if the
    overriding rule is only parsing.
 
    If a given notation string occurs only in ``only printing`` rules,

--- a/test-suite/output/bug_12908.v
+++ b/test-suite/output/bug_12908.v
@@ -7,7 +7,7 @@ Check forall m n, mult' m n = Nat.mul (Nat.mul 2 m) n.
 End A.
 
 Module B.
-(* Test that an overriden scoped notation is deactivated *)
+(* Test that an overridden scoped notation is deactivated *)
 Infix "*" := mult' : nat_scope.
 Check forall m n, mult' m n = Nat.mul (Nat.mul 2 m) n.
 End B.

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -1822,9 +1822,9 @@ let add_syntactic_definition ~local deprecation env ident (vars,c) { onlyparsing
 (* Declaration of custom entry                                        *)
 
 let warn_custom_entry =
-  CWarnings.create ~name:"custom-entry-overriden" ~category:"parsing"
+  CWarnings.create ~name:"custom-entry-overridden" ~category:"parsing"
          (fun s ->
-          strbrk "Custom entry " ++ str s ++ strbrk " has been overriden.")
+          strbrk "Custom entry " ++ str s ++ strbrk " has been overridden.")
 
 let load_custom_entry _ _ = ()
 


### PR DESCRIPTION
The warning entry `custom-entry-overriden` is misspelled and is inconsistent with the correctly spelled `notation-overridden`.

This PR renames the warning entry accordingly and fixes two other occurrences of the same spelling mistake.