### PR TITLE
[refman] Fix error names.

### DIFF
--- a/doc/sphinx/language/core/assumptions.rst
+++ b/doc/sphinx/language/core/assumptions.rst
@@ -170,7 +170,7 @@ has type :n:`@type`.
        Axiom R_S_inv : forall x y, R x y <-> S y x.
 
 .. exn:: @ident already exists.
-   :name: @ident already exists. (Axiom)
+   :name: ‘ident’ already exists. (Axiom)
    :undocumented:
 
 .. warn:: @ident is declared as a local axiom

--- a/doc/sphinx/language/core/definitions.rst
+++ b/doc/sphinx/language/core/definitions.rst
@@ -109,7 +109,7 @@ Section :ref:`typing-rules`.
    .. seealso:: :cmd:`Opaque`, :cmd:`Transparent`, :tacn:`unfold`.
 
    .. exn:: @ident already exists.
-      :name: @ident already exists. (Definition)
+      :name: ‘ident’ already exists. (Definition)
       :undocumented:
 
    .. exn:: The term @term has type @type while it is expected to have type @type'.
@@ -170,7 +170,7 @@ Chapter :ref:`Tactics`. The basic assertion command is:
       :undocumented:
 
    .. exn:: @ident already exists.
-      :name: @ident already exists. (Theorem)
+      :name: ‘ident’ already exists. (Theorem)
 
       The name you provided is already defined. You have then to choose
       another name.


### PR DESCRIPTION
The @ syntax is not supported in the name, so we transform it manually as it would have been if no name had been provided.

**Kind:** documentation fix
