### PR TITLE
Fix #13566: Add checks for invalid occurrences in several tactics. 

### DIFF
--- a/doc/changelog/04-tactics/13568-master+fix13566-check-invalid-occurrences-especially-rewrite.rst
+++ b/doc/changelog/04-tactics/13568-master+fix13566-check-invalid-occurrences-especially-rewrite.rst
@@ -1,0 +1,6 @@
+- **Changed:**
+  More systematic checks that occurrences of an :n:`at` clause are
+  valid in tactics such as :tacn:`rewrite` or :tacn:`pattern`
+  (`#13568 <https://github.com/coq/coq/pull/13568>`_,
+  fixes `#13566 <https://github.com/coq/coq/issues/13566>`_,
+  by Hugo Herbelin).

--- a/plugins/ltac/extratactics.mlg
+++ b/plugins/ltac/extratactics.mlg
@@ -608,7 +608,7 @@ END
 {
 
 let subst_var_with_hole occ tid t =
-  let occref = if occ > 0 then ref occ else Find_subterm.error_invalid_occurrence [occ] in
+  let occref = if occ > 0 then ref occ else Locusops.error_invalid_occurrence [occ] in
   let locref = ref 0 in
   let rec substrec x = match DAst.get x with
     | GVar id ->
@@ -628,7 +628,7 @@ let subst_var_with_hole occ tid t =
     | _ -> map_glob_constr_left_to_right substrec x in
   let t' = substrec t
   in
-  if !occref > 0 then Find_subterm.error_invalid_occurrence [occ] else t'
+  if !occref > 0 then Locusops.error_invalid_occurrence [occ] else t'
 
 let subst_hole_with_term occ tc t =
   let locref = ref 0 in

--- a/pretyping/find_subterm.ml
+++ b/pretyping/find_subterm.ml
@@ -21,42 +21,15 @@ module NamedDecl = Context.Named.Declaration
 
 (** Processing occurrences *)
 
-type occurrence_error =
-  | InvalidOccurrence of int list
-  | IncorrectInValueOccurrence of Id.t
-
-let explain_invalid_occurrence l =
-  let l = List.sort_uniquize Int.compare l in
-  str ("Invalid occurrence " ^ String.plural (List.length l) "number" ^": ")
-  ++ prlist_with_sep spc int l ++ str "."
-
 let explain_incorrect_in_value_occurrence id =
   Id.print id ++ str " has no value."
-
-let explain_occurrence_error = function
-  | InvalidOccurrence l -> explain_invalid_occurrence l
-  | IncorrectInValueOccurrence id -> explain_incorrect_in_value_occurrence id
-
-let error_occurrences_error e =
-  user_err  (explain_occurrence_error e)
-
-let error_invalid_occurrence occ =
-  error_occurrences_error (InvalidOccurrence occ)
-
-let check_used_occurrences nbocc (nowhere_except_in,locs) =
-  let rest = List.filter (fun o -> o >= nbocc) locs in
-  match rest with
-  | [] -> ()
-  | _ -> error_occurrences_error (InvalidOccurrence rest)
 
 let proceed_with_occurrences f occs x =
   match occs with
   | NoOccurrences -> x
   | occs ->
-    let plocs = Locusops.convert_occs occs in
-    assert (List.for_all (fun x -> x >= 0) (snd plocs));
-    let (nbocc,x) = f 1 x in
-    check_used_occurrences nbocc plocs;
+    let (occs,x) = f (Locusops.initialize_occurrence_counter occs) x in
+    Locusops.check_used_occurrences occs;
     x
 
 (** Applying a function over a named_declaration with an hypothesis
@@ -70,7 +43,7 @@ let map_named_declaration_with_hyploc f hyploc acc decl =
   in
   match decl,hyploc with
   | LocalAssum (id,_), InHypValueOnly ->
-      error_occurrences_error (IncorrectInValueOccurrence id.Context.binder_name)
+      user_err (explain_incorrect_in_value_occurrence id.Context.binder_name)
   | LocalAssum (id,typ), _ ->
       let acc,typ = f acc typ in acc, LocalAssum (id,typ)
   | LocalDef (id,body,typ), InHypTypeOnly ->
@@ -101,43 +74,43 @@ type 'a testing_function = {
    means all occurrences except the ones in l *)
 
 let replace_term_occ_gen_modulo sigma occs like_first test bywhat cl occ t =
-  let (nowhere_except_in,locs) = Locusops.convert_occs occs in
-  let maxocc = List.fold_right max locs 0 in
-  let pos = ref occ in
+  let count = ref (Locusops.initialize_occurrence_counter occs) in
   let nested = ref false in
-  let add_subst t subst =
+  let add_subst pos t subst =
     try
       test.testing_state <- test.merge_fun subst test.testing_state;
-      test.last_found <- Some ((cl,!pos),t)
+      test.last_found <- Some ((cl,pos),t)
     with NotUnifiable e when not like_first ->
       let lastpos = Option.get test.last_found in
-     raise (SubtermUnificationError (!nested,((cl,!pos),t),lastpos,e)) in
+     raise (SubtermUnificationError (!nested,((cl,pos),t),lastpos,e)) in
   let rec substrec k t =
-    if nowhere_except_in && !pos > maxocc then t else
+    if Locusops.occurrences_done !count then t else
     try
       let subst = test.match_fun test.testing_state t in
-      if Locusops.is_selected !pos occs then
+      let selected, count' = Locusops.update_occurrence_counter !count in count := count';
+      if selected then
+        let pos = Locusops.current_occurrence !count in
         (if !nested then begin
           (* in case it is nested but not later detected as unconvertible,
              as when matching "id _" in "id (id 0)" *)
           let lastpos = Option.get test.last_found in
-          raise (SubtermUnificationError (!nested,((cl,!pos),t),lastpos,None))
+          raise (SubtermUnificationError (!nested,((cl,pos),t),lastpos,None))
          end;
-         add_subst t subst; incr pos;
+         add_subst pos t subst;
          (* Check nested matching subterms *)
-         if not (Locusops.is_all_occurrences occs) && occs != Locus.NoOccurrences then
+         if Locusops.more_specific_occurrences !count then
            begin nested := true; ignore (subst_below k t); nested := false end;
          (* Do the effective substitution *)
          Vars.lift k (bywhat ()))
       else
-        (incr pos; subst_below k t)
+        subst_below k t
     with NotUnifiable _ ->
       subst_below k t
   and subst_below k t =
     map_constr_with_binders_left_to_right sigma (fun d k -> k+1) substrec k t
   in
   let t' = substrec 0 t in
-  (!pos, t')
+  (!count, t')
 
 let replace_term_occ_modulo evd occs test bywhat t =
   let occs',like_first =

--- a/pretyping/find_subterm.mli
+++ b/pretyping/find_subterm.mli
@@ -65,6 +65,3 @@ val subst_closed_term_occ : env -> evar_map -> occurrences or_like_first ->
 val subst_closed_term_occ_decl : env -> evar_map ->
   (occurrences * hyp_location_flag) or_like_first ->
   constr -> named_declaration -> named_declaration * evar_map
-
-(** Miscellaneous *)
-val error_invalid_occurrence : int list -> 'a

--- a/pretyping/locusops.mli
+++ b/pretyping/locusops.mli
@@ -20,12 +20,43 @@ val or_var_map : ('a -> 'b) -> 'a or_var -> 'b or_var
 val occurrences_map :
   ('a list -> 'b list) -> 'a occurrences_gen -> 'b occurrences_gen
 
-(** From occurrences to a list of positions (or complement of positions) *)
-val convert_occs : occurrences -> bool * int list
+(** {6 Counting occurrences} *)
+
+type occurrences_count
+  (** A counter of occurrences associated to a list of occurrences *)
+
+(** Three basic functions to initialize, count, and conclude a loop
+    browsing over subterms *)
+
+val initialize_occurrence_counter : occurrences -> occurrences_count
+  (** Initialize an occurrence_counter *)
+
+val update_occurrence_counter : occurrences_count -> bool * occurrences_count
+  (** Increase the occurrence counter by one and tell if the current occurrence is selected *)
+
+val check_used_occurrences : occurrences_count -> unit
+  (** Increase the occurrence counter and tell if the current occurrence is selected *)
+
+(** Auxiliary functions about occurrence counters *)
+
+val current_occurrence : occurrences_count -> int
+  (** Tell the value of the current occurrence *)
+
+val occurrences_done : occurrences_count -> bool
+  (** Tell if there are no more occurrences to select and if the loop
+      can be shortcut *)
+
+val more_specific_occurrences : occurrences_count -> bool
+  (** Tell if there are no more occurrences to select (or unselect)
+      and if an inner loop can be shortcut *)
+
+(** {6 Miscellaneous} *)
 
 val is_selected : int -> occurrences -> bool
 
 val is_all_occurrences : 'a occurrences_gen -> bool
+
+val error_invalid_occurrence : int list -> 'a
 
 (** Usual clauses *)
 

--- a/test-suite/success/rewrite_in.v
+++ b/test-suite/success/rewrite_in.v
@@ -5,4 +5,10 @@ Goal forall (P Q : Prop) (f:P->Prop) (p:P), (P<->Q) -> f p -> True.
   rewrite H in p || trivial.
 Qed.
 
-
+Goal 1 = 0 -> 0 = 1.
+  intro H.
+  Fail rewrite H at 1 2 3. (* bug #13566 *)
+  Fail rewrite H at 0.
+  rewrite H at 1.
+  reflexivity.
+Qed.


### PR DESCRIPTION
**Kind:** bug fix

We basically copy what was done in `tacred.ml`. We seize the opportunity to also check that occurrence 0 is invalid.

Fixes / closes #13566

Note: I did not follow whether bug fixes should still be in 8.13 beta or in 8.13.0. I put 8.13.0 (cc @gares).

- [X] Added / updated test-suite
- [x] Entry added in the changelog
