### PR TITLE
[dune] [opam] Disable dune subst in opam files until the upstream fix is propagated

### DIFF
--- a/coq-doc.opam
+++ b/coq-doc.opam
@@ -20,7 +20,8 @@ depends: [
   "coq" {build & = version}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+# Disabled until Dune 2.8 is available
+# ["dune" "subst"] {pinned}
   [
     "dune"
     "build"

--- a/coq.opam
+++ b/coq.opam
@@ -26,7 +26,8 @@ depends: [
   "zarith" {>= "1.10"}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+# Disabled until Dune 2.8 is available
+# ["dune" "subst"] {pinned}
   [
     "dune"
     "build"

--- a/coqide-server.opam
+++ b/coqide-server.opam
@@ -23,7 +23,8 @@ depends: [
   "coq" {= version}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+# Disabled until Dune 2.8 is available
+# ["dune" "subst"] {pinned}
   [
     "dune"
     "build"

--- a/coqide.opam
+++ b/coqide.opam
@@ -21,7 +21,8 @@ depends: [
   "coqide-server" {= version}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+# Disabled until Dune 2.8 is available
+# ["dune" "subst"] {pinned}
   [
     "dune"
     "build"

--- a/dune-project
+++ b/dune-project
@@ -5,7 +5,10 @@
 (formatting
  (enabled_for ocaml))
 
-(generate_opam_files true)
+; Pending on dune 2.8 as to avoid bug with dune subst
+; see https://github.com/ocaml/dune/pull/3879 and
+; https://github.com/ocaml/dune/pull/3879
+; (generate_opam_files true)
 
 (license LGPL-2.1-only)
 (maintainers "The Coq development team <coqdev@inria.fr>")


### PR DESCRIPTION
`dune subst` is broken on unicode files, see
https://github.com/ocaml/dune/pull/3879 and
https://github.com/ocaml/dune/pull/3879

This is a frequent problem, introduced by
https://github.com/coq/coq/pull/13374 , so disabling pending on dune
2.8 being released.
