### PR TITLE
Generalize exp_ineq1 and add exp_ineq1_le, which holds forall Reals.

### DIFF
--- a/doc/changelog/10-standard-library/13582-exp_ineq.rst
+++ b/doc/changelog/10-standard-library/13582-exp_ineq.rst
@@ -1,0 +1,9 @@
+- **Changed:**
+  Minor Changes to Rpower:
+  Generalizes exp_ineq1 to hold for all non-zero numbers.
+  Adds exp_ineq1_le, which holds for all reals (but is a <= instead of a <).
+
+  (`#13582 <https://github.com/coq/coq/pull/13582>`_,
+  by Avi Shinnar and Barry Trager, with help from Laurent Théry
+
+).


### PR DESCRIPTION
Adds exp_ineq2, the negative counterpart to exp_ineq1.
Adds exp_ineq, which holds for all reals (but is a <= instead of a <).

<!-- Thank you for your contribution.
     Make sure you read the contributing guide and fill this template. -->

Rpower currently defines exp_ineq1 : forall x:R, 0 < x -> 1 + x < exp x.
This PR adds the corresponding lemma for negative R: exp_ineq2 : forall x:R, 0 > x -> 1 + x < exp x
and the (slightly weaker) version for all R: exp_ineq : forall x:R, 1 + x <= exp x
These minor additions are nice to add for completeness, and are useful for users.

This proof was mostly done by Barry Trager (@bmtrager), and is being submitted with his permission (and at his request).

<!-- Keep what applies -->
**Kind:** documentation / bug fix / feature / performance / infrastructure.
library addition / minor feature 

<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes / closes #????


<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [ ] Added / updated test-suite
<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [ ] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
