### PR TITLE
Support nested timeouts

### DIFF
--- a/doc/changelog/12-misc/13586-nested-timeout.rst
+++ b/doc/changelog/12-misc/13586-nested-timeout.rst
@@ -1,0 +1,7 @@
+- **Fixed:**
+  Fix the timeout facility on Unix to allow for nested timeouts.
+  Previous behavior on nested timeouts was that an "inner" timeout would replace an "outer"
+  timeout, so that the outer timeout would no longer fire. With the new behavior, Unix and Windows
+  implementations should be (approximately) equivalent.
+  (`#13586 <https://github.com/coq/coq/pull/13586>`_,
+  by Lasse Blaauwbroek).

--- a/test-suite/bugs/closed/bug_13586.v
+++ b/test-suite/bugs/closed/bug_13586.v
@@ -1,0 +1,6 @@
+Goal True.
+Fail timeout 2 ((timeout 1 repeat cut True) || (repeat cut True)).
+Fail Timeout 2 ((timeout 1 repeat cut True) || (repeat cut True)).
+Fail timeout 1 ((timeout 2 repeat cut True) || idtac "fail").
+auto.
+Qed.


### PR DESCRIPTION
Fixes the Unix timeout function to allow nested timeouts (for Windows nesting already seems to be supported).

This depends on #13378

<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [x] Added / updated test-suite
<!-- If this is a feature pull request / breaks compatibility: -->
<!-- (Otherwise, remove these lines.) -->
- [ ] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [x] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
