### PR TITLE
Add `depopts: coq-native` in coq.opam.docker

### DIFF
--- a/coq.opam.docker
+++ b/coq.opam.docker
@@ -27,8 +27,14 @@ depends: [
   "conf-findutils" {build}
 ]
 
+depopts: [
+  "coq-native"
+]
+
 build: [
-  [ "./configure" "-prefix" prefix "-coqide" "no" ]
+  [ "./configure" "-prefix" prefix "-coqide" "no"
+    "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
+  ]
   [make "-j%{jobs}%"]
   [make "-j%{jobs}%" "byte"]
 ]


### PR DESCRIPTION
**Kind:** infrastructure.

To be merged after https://github.com/ocaml/opam-repository/pull/17690

Related to item 1 of https://github.com/coq/ceps/pull/48, so if we decide to enable native_compute within the `coqorg/coq:dev` Docker image, we'll just need to install the `coq-native` virtual package.