### PR TITLE
Improve type-checking of case predicates

### DIFF
--- a/kernel/inductive.mli
+++ b/kernel/inductive.mli
@@ -87,8 +87,8 @@ val inductive_params : mind_specif -> int
    the universe constraints generated.
  *)
 val type_case_branches :
-  env -> pinductive * constr list -> unsafe_judgment -> constr
-    -> types array * types
+  env -> pinductive * constr list -> unsafe_judgment -> unsafe_judgment ->
+    types array * types
 
 val build_branches_type :
   pinductive -> mutual_inductive_body * one_inductive_body ->

--- a/kernel/reduction.ml
+++ b/kernel/reduction.ml
@@ -255,7 +255,7 @@ let convert_inductives_gen cmp_instances cmp_cumul cv_pb (mind,ind) nargs u1 u2 
     else
       cmp_cumul cv_pb variances u1 u2 s
 
-let convert_inductives cv_pb ind nargs u1 u2 (s, check) =
+let convert_inductives cv_pb ind ~nargs u1 u2 (s, check) =
   convert_inductives_gen (check.compare_instances ~flex:false) check.compare_cumul_instances
     cv_pb ind nargs u1 u2 s, check
 
@@ -585,7 +585,7 @@ and eqappr cv_pb l2r infos (lft1,st1) (lft2,st2) cuniv =
         else
           let mind = Environ.lookup_mind (fst ind1) (info_env infos.cnv_inf) in
           let nargs = same_args_size v1 v2 in
-          match convert_inductives cv_pb (mind, snd ind1) nargs u1 u2 cuniv with
+          match convert_inductives cv_pb (mind, snd ind1) ~nargs u1 u2 cuniv with
           | cuniv -> convert_stacks l2r infos lft1 lft2 v1 v2 cuniv
           | exception MustExpand ->
             let env = info_env infos.cnv_inf in

--- a/kernel/reduction.mli
+++ b/kernel/reduction.mli
@@ -64,6 +64,9 @@ constructors. *)
 val convert_instances : flex:bool -> Univ.Instance.t -> Univ.Instance.t ->
   'a * 'a universe_compare -> 'a * 'a universe_compare
 
+val convert_inductives : conv_pb -> Declarations.mutual_inductive_body * int -> nargs:int -> Univ.Instance.t -> Univ.Instance.t ->
+  'a * 'a universe_compare -> 'a * 'a universe_compare
+
 (** These two never raise UnivInconsistency, inferred_universes
     just gathers the constraints. *)
 val checked_universes : UGraph.t universe_compare

--- a/kernel/typeops.ml
+++ b/kernel/typeops.ml
@@ -403,7 +403,7 @@ let type_of_case env ci p pt iv c ct _lf lft =
     then error_bad_invert env
   in
   let (bty,rslty) =
-    type_case_branches env indspec (make_judge p pt) c in
+    type_case_branches env indspec (make_judge p pt) (make_judge c ct) in
   let () = check_branch_types env pind c ct lft bty in
   ci, rslty
 


### PR DESCRIPTION
We now verify independently that the match predicate and branches are correct
w.r.t the scrutinees inductive type declaration and effective parameters,
i.e. the predicate is of the form (indices ,, x : Ind@{u} params indices)
for some universe instance u. Only in a second phase we ensure that the
match can be applied to the scrutinee, which just means testing
cumulativity between its type (Ind@{u'}) and the type expected by the
predicate (Ind@{u}). The previous strategy using cumulativity was a tad
too permissive and we couldn't prove completeness for it in MetaCoq in
particular.

Taking a step back, the root of this problem is that we
were taking the discriminee's type as determining the shape of the
predicate/branches types while this type can change during reduction
or by cumulativity. Here we instead take the view that the "eliminator"
is defined independently of its application to the object to eliminate.
Again the change of representation of cases to make the information
currently implicitely present in the predicate and branches would make
this mistake less easy to make (and the implementation simpler as well).

This adapts both the kernel and Pretyping.typing.
Nothing needs to change for Pretyping as the user cannot
specify different params/universes for a match than the ones inferred in
the scrutinee's type. As a result this change should also be entirely
transparent to the user.

Also improve the error message about wrong elimination in Typing.typing,
reusing the same routine as kernel typing.

<!-- Keep what applies -->
**Kind:** bug fix

This is kind of a bug fix for PR #13501, but hard to reproduce. It allowed kernel to type weird cases like the following:

```
Polymorphic Cumulative Inductive Wrap@{u} : Type@{u} -> Type@{u+1}  := C T : Wrap T.
Definition WrapSet : Wrap@{Set} bool := C bool.
Polymorphic Definition elim@{u} : unit :=
  match WrapSet with
  | C T => tt
  end.
```
Now the predicate in the match would be `fun (S : Set) (w : Wrap@{Set} S) => unit`. With PR #13501 the kernel would also accept `P := fun (S : Set) (w : Wrap@{u} S) => unit` (checked with MetaCoq, which btw is a great debug printer :). Now the kernel typechecks the branch at type `forall (T : Type@{u}), P T (C@{u} T)` however now `T` is in `Type@{u}` and should not instantiate an argument in `Set` in general. The predicate is always fully applied so by reduction we get back a well-typed term, but this is messy, as the kernel now can temporarily handle ill-typed terms. We couldn't find a way to make a really problematic definition out of it though (together with @jakobbotsch). The current fix disallows this situation by looking at the instance of the inductive (here @{u}) in the predicate and forces previous binders to be well-typed with respect to it (up-to conversion).

If the patch is ok, I'd like to also document the type-checking rules for Case in detail in the refman. We're confident it can be shown sound and complete w.r.t. the spec in MetaCoq/PCUIC, which still did not have to change.

- [ ] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [ ] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
