### PR TITLE
Fix PrintAssumptions in -vok compilation, now ignored (solving #13589)

### DIFF
--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -2668,7 +2668,7 @@ let process_transaction ~doc ?(newtip=Stateid.fresh ())
       | VtQuery ->
           let id = VCS.new_node ~id:newtip proof_mode () in
           let queue =
-            if VCS.is_vio_doc () &&
+            if (VCS.is_vio_doc () || !Flags.load_vos_libraries) &&
                VCS.((get_branch head).kind = `Master) &&
                may_pierce_opaque x.expr.CAst.v.expr
             then `SkipQueue

--- a/test-suite/vos/A.v
+++ b/test-suite/vos/A.v
@@ -2,3 +2,5 @@ Definition x := 3.
 
 Lemma xeq : x = x.
 Proof. auto. Qed.
+
+Axiom AxiomA : False.

--- a/test-suite/vos/C.v
+++ b/test-suite/vos/C.v
@@ -11,3 +11,6 @@ Proof. apply yeq'. Admitted.
 Module M. Include B.M. End M.
 Module T. Include B.T. End T.
 Module F. Include B.F. End F.
+
+
+Axiom AxiomC : False.

--- a/test-suite/vos/PrintAssumptions.v
+++ b/test-suite/vos/PrintAssumptions.v
@@ -1,0 +1,34 @@
+
+(** Print Assumption: not available when loading vos files *)
+
+Axiom foo : nat.
+
+Module Type T.
+ Parameter bar : nat.
+End T.
+
+Module M : T.
+  Module Hide. (* An entire sub-module could be hidden *)
+  Definition x := foo.
+  End Hide.
+  Definition bar := Hide.x.
+End M.
+
+Module N (X:T) : T.
+  Definition y := X.bar. (* A non-exported field *)
+  Definition bar := y.
+End N.
+
+Module P := N M.
+
+Print Assumptions M.bar. (* Should answer: print assumptions not available *)
+
+
+Require Import A C.
+
+Lemma R : False /\ False.
+Proof.
+  split. apply AxiomA. apply AxiomC.
+Qed.
+
+Print Assumptions R. (* Should answer: print assumptions not available *)

--- a/test-suite/vos/run.sh
+++ b/test-suite/vos/run.sh
@@ -1,13 +1,21 @@
 #!/bin/bash
 set -e
 set -o pipefail
+# export COQBIN=../../bin
 export PATH="$COQBIN:$PATH"
 
-# Clean
-rm -f *.vo *.vos *.vok *.glob *.aux Makefile
+# requires "make coqlight coqbinaries tools"
+# can be interrupted after compilation of the prelude
 
-# Test building all vos, then all vok
-coq_makefile -R . TEST -o Makefile *.v
+checker() { # give as argument the name of the output and expected output
+  diff -q -a -u --strip-trailing-cr $1 $2 >&1 || exit 1
+}
+
+# Clean before start
+rm -f *.vo *.vos *.vok *.glob *.aux Makefile Makefile.conf *.out.real
+
+# Test building all vos, then all vok, for A and B and C files.
+coq_makefile -R . TEST -o Makefile A.v B.v C.v
 make vos
 make vok
 
@@ -21,3 +29,16 @@ coqc -vos B.v
 coqc -vos C.v
 coqc -vok B.v
 coqc -vok C.v
+
+# Test whether Print Assumption is correctly disabled in -vos and -vok
+# ../../bin/coqc -vok PrintAssumptions.v &> PrintAssumptions.out.real
+
+coqc -vos PrintAssumptions.v
+coqc -vok PrintAssumptions.v &> PrintAssumptions.out.real
+checker PrintAssumptions.out PrintAssumptions.out.real
+
+# Test Print Assumptions in plain compilation
+# coqc A.v
+# coqc B.v
+# coqc C.v
+# coqc PrintAssumptions.v

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -437,6 +437,7 @@ let dump_global r =
     let gr = Smartlocate.smart_global r in
     Dumpglob.add_glob ?loc:r.loc gr
   with e when CErrors.noncritical e -> ()
+
 (**********)
 (* Syntax *)
 


### PR DESCRIPTION
Bug Fix for #13589.

Previously, `Print Assumptions` would raise an error if compiling a file using `-vok` and executing `Print Assumptions` and if the corresponding traversal needs to visit other files.

Now, it raises a warning saying that `Print Assumptions` commands are ignored in `-vok` mode.

If you find the fix is appropriate, let me know and I'll add a note in the changelog.
