### PR TITLE
Fast path in tclPROGRESS.

### DIFF
--- a/clib/cList.ml
+++ b/clib/cList.ml
@@ -23,6 +23,7 @@ sig
   val for_all_i : (int -> 'a -> bool) -> int -> 'a list -> bool
   val for_all2eq : ('a -> 'b -> bool) -> 'a list -> 'b list -> bool
   val prefix_of : 'a eq -> 'a list -> 'a list -> bool
+  val same_length : 'a list -> 'b list -> bool
   val interval : int -> int -> int list
   val make : int -> 'a -> 'a list
   val addn : int -> 'a -> 'a list -> 'a list
@@ -153,6 +154,11 @@ external cast : 'a cell -> 'a list = "%identity"
 (** Extensions and redefinitions of OCaml Stdlib *)
 
 (** {6 Equality, testing} *)
+
+let rec same_length l1 l2 = match l1, l2 with
+| [], [] -> true
+| _ :: l1, _ :: l2 -> same_length l1 l2
+| ([], _ :: _) | (_ :: _, []) -> false
 
 let rec compare cmp l1 l2 =
   if l1 == l2 then 0 else

--- a/clib/cList.mli
+++ b/clib/cList.mli
@@ -42,6 +42,9 @@ sig
   (** [prefix_of eq l1 l2] returns [true] if [l1] is a prefix of [l2], [false]
       otherwise. It uses [eq] to compare elements *)
 
+  val same_length : 'a list -> 'b list -> bool
+  (** A more efficient variant of [for_all2eq (fun _ _ -> true)] *)
+
   (** {6 Creating lists} *)
 
   val interval : int -> int -> int list

--- a/engine/proofview.ml
+++ b/engine/proofview.ml
@@ -909,10 +909,11 @@ let tclPROGRESS t =
   in
   let test =
     quick_test ||
+    (CList.same_length initial.comb final.comb &&
     Util.List.for_all2eq begin fun i f ->
       Progress.goal_equal ~evd:initial.solution
         ~extended_evd:final.solution (drop_state i) (drop_state f)
-    end initial.comb final.comb
+    end initial.comb final.comb)
   in
   if not test then
     tclUNIT res


### PR DESCRIPTION
We first check that the list of goals have the same length before trying to engage into potentially costly equality checks.
