### PR TITLE
Cache meta instances in Clenv

### DIFF
--- a/pretyping/reductionops.mli
+++ b/pretyping/reductionops.mli
@@ -273,7 +273,11 @@ val whd_betaiota_deltazeta_for_iota_state :
   TransparentState.t -> Environ.env -> Evd.evar_map -> state -> state
 
 (** {6 Meta-related reduction functions } *)
-val meta_instance : env -> evar_map -> constr freelisted -> constr
+type meta_instance_subst
+
+val create_meta_instance_subst : Evd.evar_map -> meta_instance_subst
+
+val meta_instance : env -> meta_instance_subst -> constr freelisted -> constr
 val nf_meta       : env -> evar_map -> constr -> constr
 
 exception AnomalyInConversion of exn

--- a/pretyping/typing.ml
+++ b/pretyping/typing.ml
@@ -33,7 +33,7 @@ let meta_type env evd mv =
   let ty =
     try Evd.meta_ftype evd mv
     with Not_found -> anomaly (str "unknown meta ?" ++ str (Nameops.string_of_meta mv) ++ str ".") in
-  meta_instance env evd ty
+  meta_instance env (create_meta_instance_subst evd) ty
 
 let inductive_type_knowing_parameters env sigma (ind,u) jl =
   let u = Unsafe.to_instance u in

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -39,6 +39,13 @@ type clausenv = {
   templval : constr freelisted;
   templtyp : constr freelisted }
 
+let mk_clausenv env evd templval templtyp = {
+  env; evd; templval; templtyp;
+}
+
+let update_clenv_evd clenv evd =
+  mk_clausenv clenv.env evd clenv.templval clenv.templtyp
+
 let cl_env ce = ce.env
 let cl_sigma ce =  ce.evd
 

--- a/proofs/clenv.ml
+++ b/proofs/clenv.ml
@@ -42,10 +42,10 @@ type clausenv = {
 let cl_env ce = ce.env
 let cl_sigma ce =  ce.evd
 
-let clenv_term clenv c = meta_instance clenv.env clenv.evd c
+let clenv_term clenv c = meta_instance clenv.env (create_meta_instance_subst clenv.evd) c
 let clenv_meta_type clenv mv = Typing.meta_type clenv.env clenv.evd mv
-let clenv_value clenv = meta_instance clenv.env clenv.evd clenv.templval
-let clenv_type clenv = meta_instance clenv.env clenv.evd clenv.templtyp
+let clenv_value clenv = meta_instance clenv.env (create_meta_instance_subst clenv.evd) clenv.templval
+let clenv_type clenv = meta_instance clenv.env (create_meta_instance_subst clenv.evd) clenv.templtyp
 
 let clenv_hnf_constr ce t = hnf_constr (cl_env ce) (cl_sigma ce) t
 
@@ -203,7 +203,7 @@ let clenv_assign mv rhs clenv =
 *)
 
 let clenv_metas_in_type_of_meta env evd mv =
-  (mk_freelisted (meta_instance env evd (meta_ftype evd mv))).freemetas
+  (mk_freelisted (meta_instance env (create_meta_instance_subst evd) (meta_ftype evd mv))).freemetas
 
 let dependent_in_type_of_metas clenv mvs =
   List.fold_right

--- a/proofs/clenv.mli
+++ b/proofs/clenv.mli
@@ -28,7 +28,9 @@ type clausenv = private {
                            types and values *)
   templval : constr freelisted; (** the template which we are trying to fill
                                     out *)
-  templtyp : constr freelisted (** its type *)}
+  templtyp : constr freelisted; (** its type *)
+  cache : Reductionops.meta_instance_subst; (* Reductionops.create_meta_instance_subst evd) *)
+}
 
 val mk_clausenv : env -> evar_map -> constr freelisted -> types freelisted -> clausenv
 val update_clenv_evd : clausenv -> evar_map -> clausenv

--- a/proofs/clenv.mli
+++ b/proofs/clenv.mli
@@ -22,7 +22,7 @@ open Tactypes
 
 (** {6 The Type of Constructions clausale environments.} *)
 
-type clausenv = {
+type clausenv = private {
   env      : env; (** the typing context *)
   evd      : evar_map; (** the mapping from metavar and evar numbers to their
                            types and values *)
@@ -30,6 +30,8 @@ type clausenv = {
                                     out *)
   templtyp : constr freelisted (** its type *)}
 
+val mk_clausenv : env -> evar_map -> constr freelisted -> types freelisted -> clausenv
+val update_clenv_evd : clausenv -> evar_map -> clausenv
 
 (** subject of clenv (instantiated) *)
 val clenv_value     : clausenv -> constr

--- a/tactics/equality.ml
+++ b/tactics/equality.ml
@@ -154,7 +154,8 @@ let instantiate_lemma_all frzevars gl c ty l l2r concl =
   let c1 = args.(arglen - 2) in
   let c2 = args.(arglen - 1) in
   let try_occ (evd', c') =
-    Clenv.clenv_pose_dependent_evars ~with_evars:true {eqclause with evd = evd'}
+    let clenv = Clenv.update_clenv_evd eqclause evd' in
+    Clenv.clenv_pose_dependent_evars ~with_evars:true clenv
   in
   let flags = make_flags frzevars (Tacmach.New.project gl) rewrite_unif_flags eqclause in
   let occs =

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -1362,20 +1362,18 @@ let do_replace id = function
 
 let clenv_refine_in ?err with_evars targetid id sigma0 clenv tac =
   let clenv = Clenv.clenv_pose_dependent_evars ~with_evars clenv in
-  let clenv =
-      { clenv with evd = Typeclasses.resolve_typeclasses
-          ~fail:(not with_evars) clenv.env clenv.evd }
-  in
+  let evd = Typeclasses.resolve_typeclasses ~fail:(not with_evars) clenv.env clenv.evd in
+  let clenv = Clenv.update_clenv_evd clenv evd in
   let new_hyp_typ = clenv_type clenv in
   if not with_evars then check_unresolved_evars_of_metas sigma0 clenv;
-  if not with_evars && occur_meta clenv.evd new_hyp_typ then
+  if not with_evars && occur_meta evd new_hyp_typ then
     error_uninstantiated_metas new_hyp_typ clenv;
   let new_hyp_prf = clenv_value clenv in
   let exact_tac = Logic.refiner ~check:false EConstr.Unsafe.(to_constr new_hyp_prf) in
   let naming = NamingMustBe (CAst.make targetid) in
   let with_clear = do_replace (Some id) naming in
   Tacticals.New.tclTHEN
-    (Proofview.Unsafe.tclEVARS (clear_metas clenv.evd))
+    (Proofview.Unsafe.tclEVARS (clear_metas evd))
     (Tacticals.New.tclTHENLAST
       (assert_after_then_gen ?err with_clear naming new_hyp_typ tac) exact_tac)
 


### PR DESCRIPTION
We cache the expansion of metas repeatedly computed by `meta_instance` inside the `clenv` type itself. A variation on previously tried patch.

https://gitlab.com/coq/coq/-/jobs/907415242