### PR TITLE
Add -q flag to Ltac2 dune file

### DIFF
--- a/user-contrib/Ltac2/dune
+++ b/user-contrib/Ltac2/dune
@@ -2,6 +2,7 @@
  (name Ltac2)
  (package coq)
  (synopsis "Ltac2 tactic language")
+ (flags -q)
  (libraries coq.plugins.ltac2))
 
 (library


### PR DESCRIPTION
This is useful for people who have something in their `coqrc` until the dune version containing ocaml/dune/pull/3931 is in wide use.

<!-- Keep what applies -->
**Kind:** bug fix