### PR TITLE
Add build dependency of conf-python-3 to coq-doc

### DIFF
--- a/coq-doc.opam
+++ b/coq-doc.opam
@@ -17,6 +17,7 @@ doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/coq/issues"
 depends: [
   "dune" {build & >= "2.5.0"}
+  "conf-python-3" {build}
   "coq" {build & = version}
 ]
 build: [

--- a/dune-project
+++ b/dune-project
@@ -75,6 +75,7 @@ development of interactive proofs."))
  (license "OPL-1.0")
  (depends
   (dune (and :build (>= 2.5.0)))
+  (conf-python-3 :build)
   (coq (and :build (= :version))))
  (synopsis "The Coq Proof Assistant --- Reference Manual")
  (description "Coq is a formal proof management system. It provides


### PR DESCRIPTION
The build of `coq-doc` needs python. Might as well add `conf-python-3` to the dependencies. Ideally, there would also be dependencies on the specific python packages listed here: https://github.com/coq/coq/tree/master/doc#html-documentation However, there is currently no generic way to check for any python package using some kind of opam conf technology. And at this point I'm not willing to create individual conf packages for them :-)

<!-- Keep what applies -->
**Kind:** bug fix