### PR TITLE
Tentatively enhance the behaviour of the dot after Ltac statements.

### DIFF
--- a/proofs/proof.ml
+++ b/proofs/proof.ml
@@ -557,6 +557,7 @@ let solve ?with_end_tac gi info_lvl tac pr =
       | SelectId id -> Proofview.tclFOCUSID ~nosuchgoal id tac
       | SelectAll -> tac
     in
+    let tac = Proofview.tclONCE tac in
     let tac =
       if use_unification_heuristics () then
         Proofview.tclTHEN tac Refine.solve_constraints


### PR DESCRIPTION
This first patch wraps the toplevel tatic into a once block so that it prevents backtrack that could be generated by a failing wrapper tactic.
