### PR TITLE
Return the assigned KerName.t in Tacentries.add_tactic_notation

### DIFF
--- a/plugins/ltac/g_ltac.mlg
+++ b/plugins/ltac/g_ltac.mlg
@@ -460,7 +460,7 @@ VERNAC COMMAND EXTEND VernacTacticNotation
   { VtSideff ([], VtNow) } ->
   {
     let n = Option.default 0 n in
-    Tacentries.add_tactic_notation (Locality.make_module_locality locality) n ?deprecation r e;
+    ignore (Tacentries.add_tactic_notation (Locality.make_module_locality locality) n ?deprecation r e)
   }
 END
 

--- a/plugins/ltac/tacentries.ml
+++ b/plugins/ltac/tacentries.ml
@@ -314,14 +314,16 @@ let add_glob_tactic_notation local ~level ?deprecation prods forml ids tac =
     tacgram_prods = prods;
   } in
   let open Tacenv in
+  let key = make_fresh_key prods in
   let tacobj = {
-    tacobj_key = make_fresh_key prods;
+    tacobj_key = key;
     tacobj_local = local;
     tacobj_tacgram = parule;
     tacobj_body = { alias_args = ids; alias_body = tac; alias_deprecation = deprecation };
     tacobj_forml = forml;
   } in
-  Lib.add_anonymous_leaf (inTacticGrammar tacobj)
+  Lib.add_anonymous_leaf (inTacticGrammar tacobj);
+  key
 
 let add_tactic_notation local n ?deprecation prods e =
   let ids = List.map_filter cons_production_parameter prods in
@@ -379,7 +381,7 @@ let add_ml_tactic_notation name ~level ?deprecation prods =
     let entry = { mltac_name = name; mltac_index = len - i - 1 } in
     let map id = Reference (Locus.ArgVar (CAst.make id)) in
     let tac = TacML (CAst.make (entry, List.map map ids)) in
-    add_glob_tactic_notation false ~level ?deprecation prods true ids tac
+    ignore (add_glob_tactic_notation false ~level ?deprecation prods true ids tac)
   in
   List.iteri iter (List.rev prods);
   (* We call [extend_atomic_tactic] only for "basic tactics" (the ones

--- a/plugins/ltac/tacentries.mli
+++ b/plugins/ltac/tacentries.mli
@@ -36,7 +36,7 @@ type argument = Genarg.ArgT.any Extend.user_symbol
 
 val add_tactic_notation :
   locality_flag -> int -> ?deprecation:Deprecation.t -> raw_argument
-  grammar_tactic_prod_item_expr list -> raw_tactic_expr -> unit
+  grammar_tactic_prod_item_expr list -> raw_tactic_expr -> Names.KerName.t
 (** [add_tactic_notation local level prods expr] adds a tactic notation in the
     environment at level [level] with locality [local] made of the grammar
     productions [prods] and returning the body [expr] *)


### PR DESCRIPTION
For my plugin I am discharging tactic notations that have been declared inside a section. For that, I need to know the `Kername.t` that has been assigned to the notation. I'm currently using a horrible hack to reconstruct which `KerName.t` has been assigned to a notation. But it would be much easier if `Tacentries.add_tactic_notation` would just return it. This PR implements that.

<!-- Keep what applies -->
**Kind:** feature.

- [ ] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
