### PR TITLE
Fixes #13657: vscoq needs goal uid.

### DIFF
--- a/ide/coqide/idetop.ml
+++ b/ide/coqide/idetop.ml
@@ -195,7 +195,7 @@ let concl_next_tac =
 let process_goal sigma g =
   let env = Goal.V82.env sigma g in
   let min_env = Environ.reset_context env in
-  let id = if Printer.print_goal_names () then Names.Id.to_string (Termops.evar_suggested_name g sigma) else "" in
+  let id = if Printer.print_goal_names () then Names.Id.to_string (Termops.evar_suggested_name g sigma) else Goal.uid g in
   let ccl =
     pr_letype_env ~goal_concl_style:true env sigma (Goal.V82.concl sigma g)
   in

--- a/ide/coqide/wg_ProofView.ml
+++ b/ide/coqide/wg_ProofView.ml
@@ -70,7 +70,7 @@ let mode_tactic sel_cb (proof : #GText.view_skel) goals ~unfoc_goals hints = mat
       in
       let goal_str ?(shownum=false) index total id =
         let annot =
-          if CString.is_empty id then if shownum then Printf.sprintf "(%d/%d)" index total else ""
+          if Option.has_some (int_of_string_opt id) (* some uid *) then if shownum then Printf.sprintf "(%d/%d)" index total else ""
           else Printf.sprintf "(?%s)" id in
         Printf.sprintf "______________________________________%s\n" annot
       in
@@ -180,7 +180,7 @@ let display mode (view : #GText.view_skel) goals hints evars =
       let total = List.length bg in
       let goal_str index id =
         let annot =
-          if CString.is_empty id then Printf.sprintf "(%d/%d)" index total
+          if Option.has_some (int_of_string_opt id) (* some uid *) then Printf.sprintf "(%d/%d)" index total
           else Printf.sprintf "(?%s)" id in
         Printf.sprintf
                "______________________________________%s\n" annot


### PR DESCRIPTION
**Kind:** bug fix 

Fixes #13657 (alternative to full revert in #13661).

PR #13145 was reusing the `goal_id` of the `coqidetop` protocol to carry the `?Goal`-style name of a goal, for the purpose of `coqide` goal printing. This field was however used in vscoq. We restore the unique identifier.

The fix is not fully compatible with vscoq when `Set Printing Goal Names` is on. Formerly, this option was doing nothing. Now, it will a priori confuse the diff mode in vscoq. So, correct working of vscoq expects `Set Printing Goal Names` to be off.  How acceptable is it?

I'm preparing also another patch for 8.14 which is compatible with the option `Set Printing Goal Names`.