### PR TITLE
More robust display of goal names in graphical user interfaces.

### DIFF
--- a/ide/coqide/idetop.ml
+++ b/ide/coqide/idetop.ml
@@ -172,7 +172,7 @@ let concl_next_tac =
 let process_goal sigma g =
   let env = Goal.V82.env sigma g in
   let min_env = Environ.reset_context env in
-  let id = if Printer.print_goal_names () then Names.Id.to_string (Termops.evar_suggested_name g sigma) else Goal.uid g in
+  let name = if Printer.print_goal_names () then Some (Names.Id.to_string (Termops.evar_suggested_name g sigma)) else None in
   let ccl =
     pr_letype_env ~goal_concl_style:true env sigma (Goal.V82.concl sigma g)
   in
@@ -183,10 +183,11 @@ let process_goal sigma g =
   let (_env, hyps) =
     Context.Compacted.fold process_hyp
       (Termops.compact_named_context (Environ.named_context env)) ~init:(min_env,[]) in
-  { Interface.goal_hyp = List.rev hyps; Interface.goal_ccl = ccl; Interface.goal_id = id }
+  { Interface.goal_hyp = List.rev hyps; Interface.goal_ccl = ccl; Interface.goal_id = Goal.uid g; Interface.goal_name = name }
 
 let process_goal_diffs diff_goal_map oldp nsigma ng =
   let open Evd in
+  let name = if Printer.print_goal_names () then Some (Names.Id.to_string (Termops.evar_suggested_name ng nsigma)) else None in
   let og_s = match oldp with
     | Some oldp ->
       let Proof.{ sigma=osigma } = Proof.data oldp in
@@ -195,7 +196,7 @@ let process_goal_diffs diff_goal_map oldp nsigma ng =
     | None -> None
   in
   let (hyps_pp_list, concl_pp) = Proof_diffs.diff_goal_ide og_s ng nsigma in
-  { Interface.goal_hyp = hyps_pp_list; Interface.goal_ccl = concl_pp; Interface.goal_id = Goal.uid ng }
+  { Interface.goal_hyp = hyps_pp_list; Interface.goal_ccl = concl_pp; Interface.goal_id = Goal.uid ng; Interface.goal_name = name }
 
 let export_pre_goals Proof.{ sigma; goals; stack } process =
   let process = List.map (process sigma) in

--- a/ide/coqide/protocol/interface.ml
+++ b/ide/coqide/protocol/interface.ml
@@ -19,6 +19,8 @@ type verbose = bool
 type goal = {
   goal_id : string;
   (** Unique goal identifier *)
+  goal_name : string option;
+  (** User-level goal name *)
   goal_hyp : Pp.t list;
   (** List of hypotheses *)
   goal_ccl : Pp.t;

--- a/ide/coqide/protocol/xmlprotocol.ml
+++ b/ide/coqide/protocol/xmlprotocol.ml
@@ -9,7 +9,7 @@
 (************************************************************************)
 
 (** Protocol version of this file. This is the date of the last modification. *)
-let protocol_version = "20210409"
+let protocol_version = "20210506"
 
 (** WARNING: TO BE UPDATED WHEN MODIFIED! *)
 
@@ -208,13 +208,15 @@ let of_goal g =
   let hyp = of_list of_pp g.goal_hyp in
   let ccl = of_pp g.goal_ccl in
   let id = of_string g.goal_id in
-  Element ("goal", [], [id; hyp; ccl])
+  let name = of_option of_string g.goal_name in
+  Element ("goal", [], [id; name; hyp; ccl])
 let to_goal = function
-  | Element ("goal", [], [id; hyp; ccl]) ->
+  | Element ("goal", [], [id; name; hyp; ccl]) ->
     let hyp = to_list to_pp hyp in
     let ccl = to_pp ccl         in
     let id  = to_string id      in
-    { goal_hyp = hyp; goal_ccl = ccl; goal_id = id; }
+    let name  = to_option to_string name in
+    { goal_hyp = hyp; goal_ccl = ccl; goal_id = id; goal_name = name; }
   | x -> raise (Marshal_error("goal",x))
 
 let of_goals g =

--- a/ide/coqide/wg_ProofView.ml
+++ b/ide/coqide/wg_ProofView.ml
@@ -52,7 +52,7 @@ let hook_tag_cb tag menu_content sel_cb hover_cb =
 
 let mode_tactic sel_cb (proof : #GText.view_skel) goals ~unfoc_goals hints = match goals with
   | [] -> assert false
-  | { Interface.goal_hyp = hyps; Interface.goal_ccl = cur_goal; Interface.goal_id = cur_id } :: rem_goals ->
+  | { Interface.goal_hyp = hyps; Interface.goal_ccl = cur_goal; Interface.goal_name = cur_name } :: rem_goals ->
       let on_hover sel_start sel_stop =
         proof#buffer#remove_tag
           ~start:proof#buffer#start_iter
@@ -68,10 +68,11 @@ let mode_tactic sel_cb (proof : #GText.view_skel) goals ~unfoc_goals hints = mat
       let head_str = Printf.sprintf
         "%d goal%s\n" goals_cnt (if 1 < goals_cnt then "s" else "")
       in
-      let goal_str ?(shownum=false) index total id =
+      let goal_str ?(shownum=false) index total name =
         let annot =
-          if Option.has_some (int_of_string_opt id) (* some uid *) then if shownum then Printf.sprintf "(%d/%d)" index total else ""
-          else Printf.sprintf "(?%s)" id in
+          match name with
+          | Some id -> Printf.sprintf "(?%s)" id
+          | None -> if shownum then Printf.sprintf "(%d/%d)" index total else "" in
         Printf.sprintf "______________________________________%s\n" annot
       in
       (* Insert current goal and its hypotheses *)
@@ -103,13 +104,13 @@ let mode_tactic sel_cb (proof : #GText.view_skel) goals ~unfoc_goals hints = mat
           [tag]
           else []
         in
-        proof#buffer#insert (goal_str ~shownum:true 1 goals_cnt cur_id);
+        proof#buffer#insert (goal_str ~shownum:true 1 goals_cnt cur_name);
         insert_xml ~tags:[Tags.Proof.goal] proof#buffer (Richpp.richpp_of_pp width cur_goal);
         proof#buffer#insert "\n"
       in
       (* Insert remaining goals (no hypotheses) *)
-      let fold_goal ?(shownum=false) i _ { Interface.goal_ccl = g; Interface.goal_id = id } =
-        proof#buffer#insert (goal_str ~shownum i goals_cnt id);
+      let fold_goal ?(shownum=false) i _ { Interface.goal_ccl = g; Interface.goal_name = name } =
+        proof#buffer#insert (goal_str ~shownum i goals_cnt name);
         insert_xml proof#buffer (Richpp.richpp_of_pp width g);
         proof#buffer#insert "\n"
       in


### PR DESCRIPTION
**Kind:** bug fix 

This extends the `Interface.goal` component of the xml protocol instead of hacking the `goal_id` field.

In particular `Set Printing Goal Names` works in diff mode too. This fixes a limitation of #13145.

The drawback is that XML clients of the protocol (a priori) need to be adapted (e.g. vscoq, and who else?) to comply with the extra argument `name` of element `"goal"` in second position (as long as I understand correctly how the protocol is used).
