### PR TITLE
Notations for numerals are treated natively and do not modify the constr parser

### DIFF
--- a/doc/tools/docgram/common.edit_mlg
+++ b/doc/tools/docgram/common.edit_mlg
@@ -322,7 +322,6 @@ qualid_annotated: [
 
 atomic_constr: [
 | qualid_annotated
-| MOVETO primitive_notations NUMBER
 | MOVETO primitive_notations string
 | MOVETO term_evar "_"
 | REPLACE "?" "[" identref "]"
@@ -417,6 +416,7 @@ term0: [
 | DELETE "{" binder_constr "}"
 | REPLACE "{|" record_declaration bar_cbrace
 | WITH "{|" LIST0 field_def SEP ";" OPT ";" bar_cbrace
+| MOVETO primitive_notations NUMBER
 | MOVETO term_record "{|" LIST0 field_def SEP ";" OPT ";" bar_cbrace
 | MOVETO term_generalizing "`{" term200 "}"
 | MOVETO term_generalizing "`(" term200 ")"

--- a/doc/tools/docgram/fullGrammar
+++ b/doc/tools/docgram/fullGrammar
@@ -114,6 +114,7 @@ term0: [
 | term_match
 | ident Prim.fields univ_annot
 | ident univ_annot
+| NUMBER
 | "(" term200 ")"
 | "{|" record_declaration bar_cbrace
 | "{" binder_constr "}"
@@ -168,7 +169,6 @@ arg: [
 
 atomic_constr: [
 | sort
-| NUMBER
 | string
 | "_"
 | "?" "[" identref "]"

--- a/parsing/cLexer.ml
+++ b/parsing/cLexer.ml
@@ -737,9 +737,11 @@ let rec next_token ~diff_mode loc s =
         IDENT id, set_loc_pos loc bp ep end
   | Some ('0'..'9') ->
       let n = NumTok.Unsigned.parse s in
-      let ep = Stream.count s in
       comment_stop bp;
-      (NUMBER n, set_loc_pos loc bp ep)
+      begin try find_keyword loc (NumTok.Unsigned.sprint n) bp s
+      with Not_found ->
+        let ep = Stream.count s in
+        NUMBER n, set_loc_pos loc bp ep end
   | Some '\"' ->
       Stream.junk s;
       let (loc, len) =

--- a/parsing/g_constr.mlg
+++ b/parsing/g_constr.mlg
@@ -179,6 +179,7 @@ GRAMMAR EXTEND Gram
         { let (l,id') = f in CAst.make ~loc @@ CRef (make_qualid ~loc (DirPath.make (l@[id])) id', i) }
       | id = ident; i = univ_annot ->
         { CAst.make ~loc @@ CRef (qualid_of_ident ~loc id, i) }
+      | n = NUMBER-> { CAst.make ~loc @@ CPrim (Number (NumTok.SPlus,n)) }
       | "("; c = term LEVEL "200"; ")" ->
         { (* Preserve parentheses around numbers so that constrintern does not
              collapse -(3) into the number -3. *)
@@ -264,7 +265,6 @@ GRAMMAR EXTEND Gram
   ;
   atomic_constr:
     [ [ s = sort   -> { CAst.make ~loc @@ CSort s }
-      | n = NUMBER-> { CAst.make ~loc @@ CPrim (Number (NumTok.SPlus,n)) }
       | s = string -> { CAst.make ~loc @@ CPrim (String s) }
       | "_"      -> { CAst.make ~loc @@ CHole (None, IntroAnonymous, None) }
       | "?"; "["; id = identref; "]"  -> { CAst.make ~loc @@  CHole (None, IntroIdentifier id.CAst.v, None) }

--- a/parsing/tok.ml
+++ b/parsing/tok.ml
@@ -70,18 +70,18 @@ let equal_p (type a b) (t1 : a p) (t2 : b p) : (a, b) Util.eq option =
   | _ -> None
 
 let equal t1 t2 = match t1, t2 with
-| IDENT s1, KEYWORD s2 -> string_equal s1 s2
-| KEYWORD s1, KEYWORD s2 -> string_equal s1 s2
-| PATTERNIDENT s1, PATTERNIDENT s2 -> string_equal s1 s2
-| IDENT s1, IDENT s2 -> string_equal s1 s2
-| FIELD s1, FIELD s2 -> string_equal s1 s2
-| NUMBER n1, NUMBER n2 -> NumTok.Unsigned.equal n1 n2
-| STRING s1, STRING s2 -> string_equal s1 s2
-| LEFTQMARK, LEFTQMARK -> true
-| BULLET s1, BULLET s2 -> string_equal s1 s2
-| EOI, EOI -> true
-| QUOTATION(s1,t1), QUOTATION(s2,t2) -> string_equal s1 s2 && string_equal t1 t2
-| _ -> false
+  | IDENT s1, KEYWORD s2 -> string_equal s1 s2
+  | KEYWORD s1, KEYWORD s2 -> string_equal s1 s2
+  | PATTERNIDENT s1, PATTERNIDENT s2 -> string_equal s1 s2
+  | IDENT s1, IDENT s2 -> string_equal s1 s2
+  | FIELD s1, FIELD s2 -> string_equal s1 s2
+  | NUMBER n1, NUMBER n2 -> NumTok.Unsigned.equal n1 n2
+  | STRING s1, STRING s2 -> string_equal s1 s2
+  | LEFTQMARK, LEFTQMARK -> true
+  | BULLET s1, BULLET s2 -> string_equal s1 s2
+  | EOI, EOI -> true
+  | QUOTATION(s1,t1), QUOTATION(s2,t2) -> string_equal s1 s2 && string_equal t1 t2
+  | _ -> false
 
 let token_text : type c. c p -> string = function
   | PKEYWORD t -> "'" ^ t ^ "'"

--- a/test-suite/output/NotationSyntax.out
+++ b/test-suite/output/NotationSyntax.out
@@ -1,12 +1,16 @@
-File "./output/NotationSyntax.v", line 2, characters 19-29:
-Warning: Notations for numbers are primitive; skipping this modifier.
-[primitive-token-modifier,parsing]
 The command has indeed failed with message:
 "only parsing" is given more than once.
 The command has indeed failed with message:
 A notation cannot be both "only printing" and "only parsing".
 The command has indeed failed with message:
 "only printing" is given more than once.
-File "./output/NotationSyntax.v", line 6, characters 33-43:
+File "./output/NotationSyntax.v", line 5, characters 33-43:
 Warning: The format modifier is irrelevant for only-parsing rules.
 [irrelevant-format-only-parsing,parsing]
+File "./output/NotationSyntax.v", line 8, characters 20-30:
+Warning: Notations for numbers are primitive; skipping this modifier.
+[primitive-token-modifier,parsing]
+1%nat
+     : nat
+The command has indeed failed with message:
+Notations for numbers are primitive and need not be reserved.

--- a/test-suite/output/NotationSyntax.v
+++ b/test-suite/output/NotationSyntax.v
@@ -1,6 +1,10 @@
 (* Various meaningless notations *)
-Notation "1" := 0 (at level 3).
 Fail Notation "#" := 0 (only parsing, only parsing).
 Fail Notation "#" := 0 (only parsing, only printing).
 Fail Notation "#" := 0 (only printing, only printing).
 Notation "#" := 0 (only parsing, format "#").
+
+(* Alerting about primitive syntax *)
+Notation "1" := tt (at level 3).
+Check 1%nat.
+Fail Reserved Notation "1".

--- a/test-suite/output/Notations4.out
+++ b/test-suite/output/Notations4.out
@@ -219,3 +219,9 @@ where
      : option ?A
 where
 ?A : [ |- Type]
+0+
+     : option ?A
+where
+?A : [ |- Type]
+0
+     : nat

--- a/test-suite/output/Notations4.out
+++ b/test-suite/output/Notations4.out
@@ -215,3 +215,7 @@ Some MyNone+
      : option (option ?A)
 where
 ?A : [ |- Type]
+0+
+     : option ?A
+where
+?A : [ |- Type]

--- a/test-suite/output/Notations4.v
+++ b/test-suite/output/Notations4.v
@@ -483,3 +483,10 @@ Check MyNone+.
 Check Some MyNone+.
 
 End LeadingIdent.
+
+Module SymbolsStartingWithNumbers.
+
+Notation "0+" := None.
+Check 0+.
+
+End SymbolsStartingWithNumbers.

--- a/test-suite/output/Notations4.v
+++ b/test-suite/output/Notations4.v
@@ -490,3 +490,11 @@ Notation "0+" := None.
 Check 0+.
 
 End SymbolsStartingWithNumbers.
+
+Module LeadingNumber.
+
+Notation "0 +" := None (format "0 +").
+Check 0+.
+Check 0.
+
+End LeadingNumber.

--- a/test-suite/output/PrintGrammarConstr.out
+++ b/test-suite/output/PrintGrammarConstr.out
@@ -1,0 +1,67 @@
+Entry constr is
+[ LEFTA
+  [ "@"; global; univ_annot
+  | term LEVEL "8" ] ]
+and lconstr is
+[ LEFTA
+  [ term LEVEL "200" ] ]
+where binder_constr is
+[ LEFTA
+  [ "forall"; open_binders; ","; term LEVEL "200"
+  | "fun"; open_binders; "=>"; term LEVEL "200"
+  | "let"; "fix"; fix_decl; "in"; term LEVEL "200"
+  | "let"; "cofix"; cofix_body; "in"; term LEVEL "200"
+  | "let"; "'"; pattern LEVEL "200"; ":="; term LEVEL "200"; "in"; term LEVEL
+    "200"
+  | "let"; "'"; pattern LEVEL "200"; ":="; term LEVEL "200"; case_type; "in";
+    term LEVEL "200"
+  | "let"; "'"; pattern LEVEL "200"; "in"; pattern LEVEL "200"; ":="; term
+    LEVEL "200"; case_type; "in"; term LEVEL "200"
+  | "let"; name; binders; let_type_cstr; ":="; term LEVEL "200"; "in"; term
+    LEVEL "200"
+  | "let"; [ "("; LIST0 name SEP ","; ")" | "()" ]; as_return_type; ":=";
+    term LEVEL "200"; "in"; term LEVEL "200"
+  | "if"; term LEVEL "200"; as_return_type; "then"; term LEVEL "200"; "else";
+    term LEVEL "200"
+  | "fix"; fix_decls
+  | "cofix"; cofix_decls ] ]
+and term is
+[ "200" RIGHTA
+  [ binder_constr ]
+| "100" RIGHTA
+  [ SELF; "<:"; term LEVEL "200"
+  | SELF; "<<:"; term LEVEL "200"
+  | SELF; ":"; term LEVEL "200" ]
+| "99" RIGHTA
+  [  ]
+| "90" RIGHTA
+  [  ]
+| "10" LEFTA
+  [ SELF; LIST1 arg
+  | "@"; global; univ_annot; LIST0 NEXT
+  | "@"; pattern_ident; LIST1 identref ]
+| "9" LEFTA
+  [ ".."; term LEVEL "0"; ".." ]
+| "8" LEFTA
+  [  ]
+| "1" LEFTA
+  [ SELF; ".("; "@"; global; LIST0 (term LEVEL "9"); ")"
+  | SELF; ".("; global; LIST0 arg; ")"
+  | SELF; "%"; IDENT ]
+| "0" LEFTA
+  [ "["; term LEVEL "10"; "+"; "+"; "*"; LIST1 (term LEVEL "10") SEP ["+";
+    "+"; "*"]; "|"; term LEVEL "200"; "]"
+  | "["; term LEVEL "10"; "|"; term LEVEL "200"; "]"
+  | "("; term LEVEL "200"; ")"
+  | "{|"; record_declaration; '|}'
+  | "{"; binder_constr; "}"
+  | "`{"; term LEVEL "200"; "}"
+  | "`("; term LEVEL "200"; ")"
+  | NUMBER
+  | atomic_constr
+  | term_match
+  | ident; fields; univ_annot
+  | ident; univ_annot
+  | test_array_opening; "["; "|"; array_elems; "|"; lconstr; type_cstr;
+    test_array_closing; "|"; "]"; univ_annot ] ]
+

--- a/test-suite/output/PrintGrammarConstr.v
+++ b/test-suite/output/PrintGrammarConstr.v
@@ -1,0 +1,4 @@
+(* coq-prog-args: ("-nois") *)
+
+Notation "[ a + + * .. + + * c | d ]" := (forall _ : a, .. (forall _ : c, d) ..) (a at level 10).
+Print Grammar constr.

--- a/vernac/egramcoq.ml
+++ b/vernac/egramcoq.ml
@@ -329,7 +329,10 @@ let is_binder_level custom (custom',from) e = match e with
 | _ -> false
 
 let make_pattern (keyword,s) =
-   TPattern (if keyword then Tok.PKEYWORD s else Tok.PIDENT (Some s))
+   if keyword then TPattern (Tok.PKEYWORD s) else
+     match NumTok.Unsigned.parse_string s with
+     | Some n -> TPattern (Tok.PNUMBER (Some n))
+     | None -> TPattern (Tok.PIDENT (Some s))
 
 let make_sep_rules tkl =
   Pcoq.Symbol.tokens (List.map make_pattern tkl)

--- a/vernac/metasyntax.ml
+++ b/vernac/metasyntax.ml
@@ -658,11 +658,17 @@ let prod_entry_type = function
 let keyword_needed need s =
   (* Ensure that IDENT articulation terminal symbols are keywords *)
   match CLexer.terminal s with
-    | Tok.PIDENT (Some k) ->
-      if need then
-        Flags.if_verbose Feedback.msg_info (str "Identifier '" ++ str k ++ str "' now a keyword");
-      need
-    | _ -> true
+  | Tok.PIDENT (Some k) ->
+    if need then
+      Flags.if_verbose Feedback.msg_info (str "Identifier '" ++ str k ++ str "' now a keyword");
+    need
+  | _ ->
+  match NumTok.Unsigned.parse_string s with
+  | Some n ->
+    if need then
+      Flags.if_verbose Feedback.msg_info (str "Number '" ++ NumTok.Unsigned.print n ++ str "' now a keyword");
+    need
+  | _ -> true
 
 let make_production (_,lev,_) etyps symbols =
   let rec aux need = function


### PR DESCRIPTION
**Kind:** enhancement

Depends on #14070 (merged) and #14071 (merged). Edit: depends on #14562 (merged).

This PR was originally in #13353 but it happens to be a significant change enough to grow as itself and be in its own PR.

For instance:
```coq
Notation "0" := tt (at level 3).
Check 0%nat.
```
should not return `tt`.

So we simply forbid notations to numerals to modify the parser. It is currently implemented as a warning telling that the modifiers are discarded but it could also be an error. The warning seems better since it would let developments that rely on it to be changed at their own pace.

Note that numerals can still be used in notations but no new rule is added for them in the parser.

Further additions (25/6/21):

```
Notation "0 +" := None (format "0 +").
Check 0. (* was blocked by the "0 +" notation before *)
```

```
Notation "0+" := None.
Check 0+. (* was working before for printing but not for parsing *)
```

- [X] Added / updated test-suite
- [ ] Entry added in the changelog (is it worth or too technical?)
