### PR TITLE
[stdlib] Add HasDecide and HasDecideSpec classes

### DIFF
--- a/theories/Classes/DecidableClass.v
+++ b/theories/Classes/DecidableClass.v
@@ -17,6 +17,23 @@ Class Decidable (P : Prop) := {
   Decidable_spec : Decidable_witness = true <-> P
 }.
 
+Class HasDecide (P : Prop) :=
+  decide : bool.
+
+Class HasDecideSpec P `{HasDecide P} :=
+  decide_spec : decide = true <-> P.
+
+Instance Decidable__HasDecideSpec P `{HasDecideSpec P} : Decidable P := {
+  Decidable_witness := decide;
+  Decidable_spec    := decide_spec
+}.
+
+Instance HasDecide__Decidable     P `{Decidable P} : HasDecide     P :=
+  Decidable_witness.
+
+Instance HasDecideSpec__Decidable P `{Decidable P} : HasDecideSpec P :=
+  Decidable_spec.
+
 (** Alternative ways of specifying the reflection property. *)
 
 Lemma Decidable_sound : forall P (H : Decidable P),
@@ -45,8 +62,6 @@ Qed.
 
 (** The generic function that should be used to program, together with some
   useful tactics. *)
-
-Definition decide P {H : Decidable P} := Decidable_witness (Decidable:=H).
 
 Ltac _decide_ P H :=
   let b := fresh "b" in


### PR DESCRIPTION
**Kind:** feature.

Breaking down `Decidable` class, as proposed in https://github.com/coq/stdlib/issues/46.

- [ ] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).