### PR TITLE
Read rcfile local to the current Coq installation

### DIFF
--- a/configure.ml
+++ b/configure.ml
@@ -842,9 +842,9 @@ let install = [
   "COQLIBINSTALL", "the Coq library", !prefs.libdir,
     Relative "lib", Relative "lib/coq", Relative "";
   "CONFIGDIR", "the Coqide configuration files", !prefs.configdir,
-    Relative "config", Absolute "/etc/xdg/coq", Relative "ide/coqide";
+    Relative "config", Absolute "/etc/coq", Relative "etc";
   "DATADIR", "the Coqide data files", !prefs.datadir,
-    Relative "share", Relative "share/coq", Relative "ide/coqide";
+    Relative "share", Relative "share/coq", Relative "share";
   "MANDIR", "the Coq man pages", !prefs.mandir,
     Relative "man", Relative "share/man", Relative "man";
   "DOCDIR", "the Coq documentation", !prefs.docdir,

--- a/toplevel/coqrc.ml
+++ b/toplevel/coqrc.ml
@@ -26,6 +26,9 @@ let load_rcfile ~rcfile ~state =
       | None ->
         try
           let warn x = Feedback.msg_warning (Pp.str x) in
+          let localrc = Envars.configdir () / rcdefaultname in
+          let state = if CUnix.file_readable_p localrc then
+            Vernac.load_vernac ~echo:false ~interactive:false ~check:true ~state localrc else state in
           let inferedrc = List.find CUnix.file_readable_p [
             Envars.xdg_config_home warn / rcdefaultname^"."^Coq_config.version;
             Envars.xdg_config_home warn / rcdefaultname;

--- a/toplevel/coqrc.ml
+++ b/toplevel/coqrc.ml
@@ -26,9 +26,13 @@ let load_rcfile ~rcfile ~state =
       | None ->
         try
           let warn x = Feedback.msg_warning (Pp.str x) in
-          let localrc = Envars.configdir () / rcdefaultname in
-          let state = if CUnix.file_readable_p localrc then
-            Vernac.load_vernac ~echo:false ~interactive:false ~check:true ~state localrc else state in
+          let localrcdir = Envars.configdir () / "coqrc.d" in
+          let localrcs = if not (Sys.file_exists localrcdir) || not (Sys.is_directory localrcdir) then [] else
+              List.sort String.compare @@ List.filter (fun f -> not (Sys.is_directory f)) @@
+              List.map (fun f -> localrcdir / f) @@
+              Array.to_list @@ Sys.readdir localrcdir in
+          let state = List.fold_left (fun state rcfile ->
+              Vernac.load_vernac ~echo:false ~interactive:false ~check:true ~state rcfile) state localrcs in
           let inferedrc = List.find CUnix.file_readable_p [
             Envars.xdg_config_home warn / rcdefaultname^"."^Coq_config.version;
             Envars.xdg_config_home warn / rcdefaultname;


### PR DESCRIPTION
Coq currently has a hierarchy of rcfiles it tries to load:
```
$XDG_CONFIG_HOME/coq/coqrc.coqversion
$XDG_CONFIG_HOME/coq/coqrc
~/coqrc.coqversion
~/coqrc
```
I'd like to propose to add a switch-local file to this hierarchy. Many people have multiple Opam switches with Coq installed, and at least for me, it would be useful to have a place to put startup scripts specific to that switch.

The code in this PR is just a first attempt. If people agree in principle that this is a good idea, there are a couple of considerations:
- Currently, this PR loads the switch-local rcfile in _addition_ to other rcfiles that might be loaded, for compatibility reasons. (I think it may make sense to do this for the other files as well)
- For now, I've specified the file to be in Coq's config directory. However, I think it would make more sense to look for it in `<opam-prefix>/etc/coq` (this is a directory recognized by Opam). For this, I would need to add this directory to `coq_config.ml` though. This would also mean that package managers would have to deal with configuring this directory location. I would propose to add this directory as an optional location that can be ignored by non-opam packagers.

<!-- Keep what applies -->
**Kind:** feature.

- [ ] Corresponding documentation was added / updated (including any warning and error messages added / removed / modified).
- [ ] Entry added in the changelog (see https://github.com/coq/coq/tree/master/doc/changelog#unreleased-changelog for details).
