### PR TITLE
Extrude pattern ground check

### DIFF
--- a/pretyping/unification.mli
+++ b/pretyping/unification.mli
@@ -116,13 +116,3 @@ val unify_0 :            Environ.env ->
            types ->
            types ->
            subst0
-
-val unify_0_with_initial_metas :
-           subst0 ->
-           bool ->
-           Environ.env ->
-           Evd.conv_pb ->
-           core_unify_flags ->
-           types ->
-           types ->
-           subst0


### PR DESCRIPTION
We factorize the check that a term is ground in some unification functions used by subterm algorithms. This allows to prevent checking repeatedly for pattern groundness when crawling big terms, which can end up being very costly. As witnessed by the bench some tactic invocations pass their whole time doing that.