### PR TITLE
Protect caml_process_pending_actions_exn with caml_something_to_do.

### DIFF
--- a/kernel/byterun/coq_interp.c
+++ b/kernel/byterun/coq_interp.c
@@ -551,7 +551,7 @@ value coq_interprete
       CHECK_STACK(0);
       /* We also check for signals */
 #if OCAML_VERSION >= 41000
-      {
+      if (caml_something_to_do) {
         value res = caml_process_pending_actions_exn();
         if (Is_exception_result(res)) {
           /* If there is an asynchronous exception, we reset the vm */


### PR DESCRIPTION
When using OCaml >= 4.10, function `caml_process_pending_actions_exn` is called whenever the bytecode interpreter tries to apply a term. This function exits immediately when `caml_something_to_do` is not set. But since term application happens every few opcodes, even exiting immediately still accounts between 5% and 10% of the whole interpreter. So, this commit makes sure the function is not called unless `caml_something_to_do` is already set (i.e., when the user presses Ctrl+C). This means that this conditional branch is perfectly predicted by the processor.

On the following benchmark, this commit makes the VM 13% faster.

```coq
Time Eval vm_compute in Pos.iter (fun x => x) tt 100000000.
```

Note that, before OCaml 4.10, the VM code was checking the value of `caml_signals_are_pending` before calling `caml_process_pending_signals`. So, this commit actually fixes a regression.