### PR TITLE
CoqIDE: Fix CC reference in makefile

### DIFF
--- a/Makefile.ide
+++ b/Makefile.ide
@@ -298,7 +298,7 @@ $(COQIDEAPP):$(COQIDEAPP)/Contents/Resources
 ###########################################################################
 
 # This is either x86_64-w64-mingw32 or i686-w64-mingw32
-TARGET_ARCH=$(shell $CC -dumpmachine)
+TARGET_ARCH=$(shell $(CC) -dumpmachine)
 
 %.o: %.rc
 	$(SHOW)'WINDRES    $<'


### PR DESCRIPTION
**Kind:** infrastructure.

This fixes an issue generating a warning in CoqIDE make. Actually I am not sure why it does work without this fix - I guess the .rc file is not really created, so thatthe rule using TARGET_ARCH is not used.