### PR TITLE
Mark OCaml's predefined types as keywords, for the sake of extraction

### DIFF
--- a/plugins/extraction/ocaml.ml
+++ b/plugins/extraction/ocaml.ml
@@ -46,14 +46,21 @@ let pp_letin pat def body =
 
 let keywords =
   List.fold_right (fun s -> Id.Set.add (Id.of_string s))
-  [ "and"; "as"; "assert"; "begin"; "class"; "constraint"; "do";
+  [ (* parsing/lexer.mll *)
+    "and"; "as"; "assert"; "begin"; "class"; "constraint"; "do";
     "done"; "downto"; "else"; "end"; "exception"; "external"; "false";
     "for"; "fun"; "function"; "functor"; "if"; "in"; "include";
     "inherit"; "initializer"; "lazy"; "let"; "match"; "method";
-    "module"; "mutable"; "new"; "object"; "of"; "open"; "or";
+    "module"; "mutable"; "new"; "nonrec"; "object"; "of"; "open"; "or";
     "parser"; "private"; "rec"; "sig"; "struct"; "then"; "to"; "true";
-    "try"; "type"; "val"; "virtual"; "when"; "while"; "with"; "mod";
-    "land"; "lor"; "lxor"; "lsl"; "lsr"; "asr" ; "unit" ; "_" ; "__" ]
+    "try"; "type"; "val"; "virtual"; "when"; "while"; "with";
+    "lor"; "lxor"; "mod"; "land"; "lsl"; "lsr"; "asr";
+    (* typing/predef.ml *)
+    "int"; "char"; "bytes"; "float"; "bool"; "unit"; "exn"; "array";
+    "list"; "option"; "nativeint"; "int32"; "int64"; "lazy_t"; "string";
+    "extension_constructor"; "floatarray";
+    (* miscellaneous *)
+    "_"; "__"; ]
   Id.Set.empty
 
 (* Note: do not shorten [str "foo" ++ fnl ()] into [str "foo\n"],

--- a/theories/extraction/ExtrOCamlFloats.v
+++ b/theories/extraction/ExtrOCamlFloats.v
@@ -38,8 +38,6 @@ Extract Inductive PrimFloat.float_comparison =>
 (** Primitive types and operators. *)
 
 Extract Constant PrimFloat.float => "Float64.t".
-Extraction Inline PrimFloat.float.
-(* Otherwise, the name conflicts with the primitive OCaml type [float] *)
 
 Extract Constant PrimFloat.classify => "Float64.classify".
 Extract Constant PrimFloat.abs => "Float64.abs".

--- a/theories/extraction/ExtrOCamlInt63.v
+++ b/theories/extraction/ExtrOCamlInt63.v
@@ -21,8 +21,6 @@ Extract Inductive DoubleType.carry => "Uint63.carry" [ "Uint63.C0" "Uint63.C1" ]
 
 (** Primitive types and operators. *)
 Extract Constant Int63.int => "Uint63.t".
-Extraction Inline Int63.int.
-(* Otherwise, the name conflicts with the primitive OCaml type [int] *)
 
 Extract Constant Int63.lsl => "Uint63.l_sl".
 Extract Constant Int63.lsr => "Uint63.l_sr".

--- a/theories/extraction/ExtrOCamlPArray.v
+++ b/theories/extraction/ExtrOCamlPArray.v
@@ -14,8 +14,6 @@ From Coq Require PArray Extraction.
 
 (** Primitive types and operators. *)
 Extract Constant PArray.array "'a" => "'a Parray.t".
-Extraction Inline PArray.array.
-(* Otherwise, the name conflicts with the primitive OCaml type [array] *)
 
 Extract Constant PArray.make => "Parray.make".
 Extract Constant PArray.get => "Parray.get".


### PR DESCRIPTION
Fixes / closes #13575 