### PR TITLE
[ci] Switch to testing the maintenance branch for Flocq 3.

### DIFF
--- a/dev/ci/ci-basic-overlay.sh
+++ b/dev/ci/ci-basic-overlay.sh
@@ -101,7 +101,7 @@ project geocoq "https://github.com/GeoCoq/GeoCoq" "master"
 ########################################################################
 # Flocq
 ########################################################################
-project flocq "https://gitlab.inria.fr/flocq/flocq" "master"
+project flocq "https://gitlab.inria.fr/flocq/flocq" "flocq-3"
 
 ########################################################################
 # coq-performance-tests


### PR DESCRIPTION
This is the version that CompCert will be compatible with for the time being.

**Kind:** infrastructure.

Should fix the currently failing CompCert and VST jobs.
See: https://coq.zulipchat.com/#narrow/stream/237656-Coq-devs.20.26.20plugin.20devs/topic/CI/near/221194201