### PR TITLE
[ci] [coq-performance-tests] Errors at end of log

### DIFF
--- a/dev/ci/ci-coq_performance_tests.sh
+++ b/dev/ci/ci-coq_performance_tests.sh
@@ -5,4 +5,9 @@ ci_dir="$(dirname "$0")"
 
 git_download coq_performance_tests
 
-( cd "${CI_BUILD_DIR}/coq_performance_tests" && make coq perf-Sanity && make validate && make install )
+# run make -k; make again if make fails so that the failing file comes last, so that it's easier to find the error messages in the CI log
+function make_full() {
+    if ! make -k "$@"; then make -k "$@"; exit 1; fi
+}
+
+( cd "${CI_BUILD_DIR}/coq_performance_tests" && make_full coq perf-Sanity && make validate && make install )


### PR DESCRIPTION
By running `make -k; make` whenever `make` initially fails, we can get
error messages to occur at the end of the log.  This way they'll show up
on the GitHub Actions preview/summary, rather than me having to go
digging for them in the GitLab logs.

**Kind:** infrastructure.

