### PR TITLE
[micromega] Add missing support for `implb`

### DIFF
--- a/doc/changelog/04-tactics/13715-lia_implb.rst
+++ b/doc/changelog/04-tactics/13715-lia_implb.rst
@@ -1,0 +1,2 @@
+- **Added:**
+  :tacn:`lia` supports the boolean operator `Bool.implb` (`#13715 <https://github.com/coq/coq/pull/13715>`_, by Frédéric Besson).

--- a/test-suite/micromega/reify_bool.v
+++ b/test-suite/micromega/reify_bool.v
@@ -1,0 +1,18 @@
+Require Import ZArith.
+Require Import Lia.
+Import Z.
+Unset Lia Cache.
+
+Goal forall (x y : Z),
+   implb (Z.eqb x y) (Z.eqb y x) = true.
+Proof.
+  intros.
+  lia.
+Qed.
+
+Goal forall (x y :Z), implb (Z.eqb x 0) (Z.eqb y 0) = true <->
+                      orb (negb (Z.eqb x 0))(Z.eqb y 0) = true.
+Proof.
+  intro.
+  lia.
+Qed.


### PR DESCRIPTION
This PR adds `implb` to the boolean operators recognised by `lia`.

**Kind:** bugfix

- [x]  updated test-suite
