### PR TITLE
Remove strong reduction wrappers

### DIFF
--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -1264,9 +1264,9 @@ let plain_instance sigma s c = match s with
 
 let instance env sigma s c =
   (* if s = [] then c else *)
-  let rec strongrec env t =
-    map_constr_with_full_binders env sigma push_rel strongrec env (whd_betaiota env sigma t) in
-  strongrec env (plain_instance sigma s c)
+  (* No need to compute contexts under binders as whd_betaiota is local *)
+  let rec strongrec t = EConstr.map sigma strongrec (whd_betaiota env sigma t) in
+  strongrec (plain_instance sigma s c)
 
 (* pseudo-reduction rule:
  * [hnf_prod_app env s (Prod(_,B)) N --> B[N]

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -468,18 +468,6 @@ let safe_meta_value sigma ev =
   try Some (Evd.meta_value sigma ev)
   with Not_found -> None
 
-let strong_with_flags whdfun flags env sigma t =
-  let push_rel_check_zeta d env =
-    let open CClosure.RedFlags in
-    let d = match d with
-      | LocalDef (na,c,t) when not (red_set flags fZETA) -> LocalAssum (na,t)
-      | d -> d in
-    push_rel d env in
-  let rec strongrec env t =
-    map_constr_with_full_binders env sigma
-      push_rel_check_zeta strongrec env (whdfun flags env sigma t) in
-  strongrec env t
-
 let strong whdfun env sigma t =
   let rec strongrec env t =
     map_constr_with_full_binders env sigma push_rel strongrec env (whdfun env sigma t) in

--- a/pretyping/reductionops.ml
+++ b/pretyping/reductionops.ml
@@ -468,11 +468,6 @@ let safe_meta_value sigma ev =
   try Some (Evd.meta_value sigma ev)
   with Not_found -> None
 
-let strong whdfun env sigma t =
-  let rec strongrec env t =
-    map_constr_with_full_binders env sigma push_rel strongrec env (whdfun env sigma t) in
-  strongrec env t
-
 (*************************************)
 (*** Reduction using bindingss ***)
 (*************************************)
@@ -1269,7 +1264,9 @@ let plain_instance sigma s c = match s with
 
 let instance env sigma s c =
   (* if s = [] then c else *)
-  strong whd_betaiota env sigma (plain_instance sigma s c)
+  let rec strongrec env t =
+    map_constr_with_full_binders env sigma push_rel strongrec env (whd_betaiota env sigma t) in
+  strongrec env (plain_instance sigma s c)
 
 (* pseudo-reduction rule:
  * [hnf_prod_app env s (Prod(_,B)) N --> B[N]

--- a/pretyping/reductionops.mli
+++ b/pretyping/reductionops.mli
@@ -145,9 +145,6 @@ type stack_reduction_function =
 
 (** {6 Reduction Function Operators } *)
 
-val strong_with_flags :
-  (CClosure.RedFlags.reds -> reduction_function) ->
-  (CClosure.RedFlags.reds -> reduction_function)
 val strong : reduction_function -> reduction_function
 
 (** {6 Generic Optimized Reduction Function using Closures } *)

--- a/pretyping/reductionops.mli
+++ b/pretyping/reductionops.mli
@@ -143,10 +143,6 @@ type e_reduction_function = env -> evar_map -> constr -> evar_map * constr
 type stack_reduction_function =
     env -> evar_map -> constr -> constr * constr list
 
-(** {6 Reduction Function Operators } *)
-
-val strong : reduction_function -> reduction_function
-
 (** {6 Generic Optimized Reduction Function using Closures } *)
 
 val clos_norm_flags : CClosure.RedFlags.reds -> reduction_function

--- a/pretyping/tacred.ml
+++ b/pretyping/tacred.ml
@@ -1040,7 +1040,10 @@ let hnf_constr env sigma c = whd_simpl_orelse_delta_but_fix env sigma (c, [])
 let whd_simpl env sigma c =
   applist (whd_simpl_stack env sigma (c, []))
 
-let simpl env sigma c = strong whd_simpl env sigma c
+let simpl env sigma c =
+  let rec strongrec env t =
+    map_constr_with_full_binders env sigma push_rel strongrec env (whd_simpl env sigma t) in
+  strongrec env c
 
 (* Reduction at specific subterms *)
 

--- a/tactics/cbn.ml
+++ b/tactics/cbn.ml
@@ -820,3 +820,15 @@ let whd_cbn flags env sigma t =
     (whd_state_gen ~refold:true ~tactic_mode:true flags env sigma (t, Stack.empty))
   in
   Stack.zip ~refold:true sigma state
+
+let norm_cbn flags env sigma t =
+  let push_rel_check_zeta d env =
+    let open CClosure.RedFlags in
+    let d = match d with
+      | LocalDef (na,c,t) when not (red_set flags fZETA) -> LocalAssum (na,t)
+      | d -> d in
+    push_rel d env in
+  let rec strongrec env t =
+    map_constr_with_full_binders env sigma
+      push_rel_check_zeta strongrec env (whd_cbn flags env sigma t) in
+  strongrec env t

--- a/tactics/cbn.mli
+++ b/tactics/cbn.mli
@@ -8,6 +8,13 @@
 (*         *     (see LICENSE file for the text of the license)         *)
 (************************************************************************)
 
+(** Weak-head cbn reduction. Despite the name, the cbn reduction is a complex
+    reduction distinct from call-by-name or call-by-need. *)
 val whd_cbn :
+  CClosure.RedFlags.reds ->
+  Environ.env -> Evd.evar_map -> EConstr.constr -> EConstr.constr
+
+(** Strong variant of cbn reduction. *)
+val norm_cbn :
   CClosure.RedFlags.reds ->
   Environ.env -> Evd.evar_map -> EConstr.constr -> EConstr.constr

--- a/tactics/redexpr.ml
+++ b/tactics/redexpr.ml
@@ -46,9 +46,6 @@ let cbv_native env sigma c =
 
 let whd_cbn = Cbn.whd_cbn
 
-let strong_cbn flags =
-  strong_with_flags whd_cbn flags
-
 let simplIsCbn =
   Goptions.declare_bool_option_and_ref ~depr:false ~key:["SimplIsCbn"] ~value:false
 
@@ -248,11 +245,11 @@ let reduction_of_red_expr_val = function
   | Hnf -> (e_red hnf_constr,DEFAULTcast)
   | Simpl (f,o) ->
      let whd_am = if simplIsCbn () then whd_cbn f else whd_simpl in
-     let am = if simplIsCbn () then strong_cbn f else simpl in
+     let am = if simplIsCbn () then Cbn.norm_cbn f else simpl in
      (contextualize (if head_style then whd_am else am) am o,DEFAULTcast)
   | Cbv f -> (e_red (cbv_norm_flags f),DEFAULTcast)
   | Cbn f ->
-     (e_red (strong_cbn f), DEFAULTcast)
+     (e_red (Cbn.norm_cbn f), DEFAULTcast)
   | Lazy f -> (e_red (clos_norm_flags f),DEFAULTcast)
   | Unfold ubinds -> (e_red (unfoldn (List.map out_with_occurrences ubinds)),DEFAULTcast)
   | Fold cl -> (e_red (fold_commands cl),DEFAULTcast)

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -1244,8 +1244,6 @@ let force_destruction_arg with_evars env sigma c =
 (* tactic "cut" (actually modus ponens) *)
 (****************************************)
 
-let normalize_cut = false
-
 let cut c =
   Proofview.Goal.enter begin fun gl ->
     let env = Proofview.Goal.env gl in
@@ -1260,8 +1258,6 @@ let cut c =
     | sigma, s ->
       let r = Sorts.relevance_of_sort s in
       let id = next_name_away_with_default "H" Anonymous (Tacmach.New.pf_ids_set_of_hyps gl) in
-      (* Backward compat: normalize [c]. *)
-      let c = if normalize_cut then strong whd_betaiota env sigma c else c in
       Proofview.tclTHEN (Proofview.Unsafe.tclEVARS sigma)
         (Refine.refine ~typecheck:false begin fun h ->
             let (h, f) = Evarutil.new_evar ~principal:true env h (mkArrow c r (Vars.lift 1 concl)) in


### PR DESCRIPTION
They were only used in very specific cases that would better take advantage of deeper knowledge about the underlying reduction function. We inline them and specialize one case.