### PR TITLE
Use a compact case representation for patterns

### DIFF
--- a/pretyping/constr_matching.ml
+++ b/pretyping/constr_matching.ml
@@ -352,10 +352,9 @@ let matches_core env sigma allow_bound_rels
             (add_binders na1 na2 binding_vars (sorec ctx env subst c1 c2)) d1 d2
 
       | PIf (a1,b1,b1'), Case (ci, u2, pms2, p2, iv, a2, ([|b2;b2'|] as br2)) ->
-          let (ci2, p2, _, a2, br2) = EConstr.expand_case env sigma (ci, u2, pms2, p2, iv, a2, br2) in
-          let b2, b2' = match br2 with [|b2; b2'|] -> b2, b2' | _ -> assert false in
-          let ctx_b2,b2 = decompose_lam_n_decls sigma ci.ci_cstr_ndecls.(0) b2 in
-          let ctx_b2',b2' = decompose_lam_n_decls sigma ci.ci_cstr_ndecls.(1) b2' in
+          let (_, _, _, p2, _, _, br2) = EConstr.annotate_case env sigma (ci, u2, pms2, p2, iv, a2, br2) in
+          let ctx_b2,b2 = br2.(0) in
+          let ctx_b2',b2' = br2.(1) in
           let n = Context.Rel.length ctx_b2 in
           let n' = Context.Rel.length ctx_b2' in
           if Vars.noccur_between sigma 1 n b2 && Vars.noccur_between sigma 1 n' b2' then

--- a/pretyping/detyping.ml
+++ b/pretyping/detyping.ml
@@ -1160,18 +1160,3 @@ let rec subst_glob_constr env subst = DAst.map (function
           GArray(u,t',def',ty')
 
   )
-
-(* Utilities to transform kernel cases to simple pattern-matching problem *)
-
-let simple_cases_matrix_of_branches ind brs =
-  List.map (fun (i,n,b) ->
-      let nal,c = it_destRLambda_or_LetIn_names n b in
-      let mkPatVar na = DAst.make @@ PatVar na in
-      let p = DAst.make @@ PatCstr ((ind,i+1),List.map mkPatVar nal,Anonymous) in
-      let ids = List.map_filter Nameops.Name.to_option nal in
-      CAst.make @@ (ids,[p],c))
-    brs
-
-let return_type_of_predicate ind nrealargs_tags pred =
-  let nal,p = it_destRLambda_or_LetIn_names (nrealargs_tags@[false]) pred in
-  (List.hd nal, Some (CAst.make (ind, List.tl nal))), Some p

--- a/pretyping/detyping.mli
+++ b/pretyping/detyping.mli
@@ -72,14 +72,6 @@ val lookup_index_as_renamed : env -> evar_map -> constr -> int -> int option
 val force_wildcard : unit -> bool
 val synthetize_type : unit -> bool
 
-(** Utilities to transform kernel cases to simple pattern-matching problem *)
-
-val it_destRLambda_or_LetIn_names : bool list -> glob_constr -> Name.t list * glob_constr
-val simple_cases_matrix_of_branches :
-  inductive -> (int * bool list * glob_constr) list -> cases_clauses
-val return_type_of_predicate :
-  inductive -> bool list -> glob_constr -> predicate_pattern * glob_constr option
-
 val subst_genarg_hook :
   (substitution -> Genarg.glob_generic_argument -> Genarg.glob_generic_argument) Hook.t
 

--- a/pretyping/pattern.ml
+++ b/pretyping/pattern.ml
@@ -18,7 +18,6 @@ type patvar = Id.t
 type case_info_pattern =
     { cip_style : Constr.case_style;
       cip_ind : inductive option;
-      cip_ind_tags : bool list option; (** indicates LetIn/Lambda in arity *)
       cip_extensible : bool (** does this match end with _ => _ ? *) }
 
 type constr_pattern =
@@ -35,8 +34,8 @@ type constr_pattern =
   | PSort of Sorts.family
   | PMeta of patvar option
   | PIf of constr_pattern * constr_pattern * constr_pattern
-  | PCase of case_info_pattern * constr_pattern * constr_pattern *
-      (int * bool list * constr_pattern) list (** index of constructor, nb of args *)
+  | PCase of case_info_pattern * (Name.t array * constr_pattern) option * constr_pattern *
+      (int * Name.t array * constr_pattern) list (** index of constructor, nb of args *)
   | PFix of (int array * int) * (Name.t array * constr_pattern array * constr_pattern array)
   | PCoFix of int * (Name.t array * constr_pattern array * constr_pattern array)
   | PInt of Uint63.t


### PR DESCRIPTION
Follow-up of #13563. We use a case representation similar to kernel terms for patterns used by e.g. tactics.