### PR TITLE
[osx] macpack also coqidetop (for libgmp)

### DIFF
--- a/Makefile.ide
+++ b/Makefile.ide
@@ -233,7 +233,6 @@ install-ide-info:
 .PHONY: $(COQIDEAPP)/Contents
 
 $(COQIDEAPP)/Contents:
-	rm -rdf $@
 	$(MKDIR) $@
 	sed -e "s/VERSION/$(VERSION4MACOS)/g" ide/coqide/MacOS/Info.plist.template > $@/Info.plist
 	$(MKDIR) "$@/MacOS"
@@ -282,6 +281,10 @@ $(COQIDEAPP)/Contents/Resources/etc: $(COQIDEAPP)/Contents/Resources/lib
 $(COQIDEAPP)/Contents/Resources/lib: $(COQIDEAPP)/Contents/Resources/immodules $(COQIDEAPP)/Contents/Resources/loaders $(COQIDEAPP)/Contents $(COQIDEINAPP)
 	$(MKDIR) $@
 	macpack -d ../Resources/lib $(COQIDEINAPP)
+	for i in $@/../bin/*; \
+	do \
+	  macpack -d ../lib $$i; \
+	done
 	for i in $@/../loaders/*.so $@/../immodules/*.{dylib,so}; \
 	do \
 	  macpack -d ../lib $$i; \

--- a/dev/build/osx/make-macos-dmg.sh
+++ b/dev/build/osx/make-macos-dmg.sh
@@ -8,11 +8,11 @@ DMGDIR=$PWD/_dmg
 VERSION=$(sed -n -e '/^let coq_version/ s/^[^"]*"\([^"]*\)"$/\1/p' configure.ml)
 APP=bin/CoqIDE_${VERSION}.app
 
-# Create a .app file with CoqIDE, without signing it
-make PRIVATEBINARIES="$APP" -j "$NJOBS" -l2 "$APP"
-
-# Add Coq to the .app file
+# Install Coq into the .app file
 make OLDROOT="$OUTDIR" COQINSTALLPREFIX="$APP/Contents/Resources" install-coq install-ide-toploop
+
+# Fill .app file with metadata and other .app specific stuff (like non-system .so)
+make PRIVATEBINARIES="$APP" -j 1 -l2 "$APP" VERBOSE=1
 
 # Create the dmg bundle
 mkdir -p "$DMGDIR"


### PR DESCRIPTION
This PR fixes the build of the OSX .app by calling macpak on *all* binaries, not just `coqide`, since `coqc` can depend on external libs as well (eg libgmp coming from zarith I guess).