### PR TITLE
Deprecate omega plugin/tactic and its options

### DIFF
--- a/doc/changelog/04-tactics/13745-deprecate_omega.rst
+++ b/doc/changelog/04-tactics/13745-deprecate_omega.rst
@@ -1,0 +1,6 @@
+- **Deprecated:**
+  Added deprecation warnings for :tacn:`omega`,
+  4 `* Omehttp://caml.inria.fr/mantis/view.php?id=5325ga *` flags and `Require Import Omega`.
+  Use :tacn:`lia` instead.
+  (`#13745 <https://github.com/coq/coq/pull/13745>`_,
+  by Jim Fehrle).

--- a/doc/sphinx/addendum/omega.rst
+++ b/doc/sphinx/addendum/omega.rst
@@ -116,6 +116,7 @@ loaded by
 
 .. coqtop:: in
 
+   Set Warnings "-deprecated-omega-plugin".
    Require Import Omega.
 
 .. example::

--- a/doc/sphinx/proof-engine/ltac.rst
+++ b/doc/sphinx/proof-engine/ltac.rst
@@ -1666,7 +1666,7 @@ Proving a subgoal as a separate lemma: abstract
    is chosen to get a fresh name.  If the proof is closed with :cmd:`Qed`, the auxiliary lemma
    is inlined in the final proof term.
 
-   This is useful with tactics such as :tacn:`omega` or
+   This is useful with tactics such as :tacn:`lia` or
    :tacn:`discriminate` that generate huge proof terms with many intermediate
    goals.  It can significantly reduce peak memory use.  In most cases it doesn't
    have a significant impact on run time.  One case in which it can reduce run time
@@ -2317,11 +2317,10 @@ performance issue.
 
 .. coqtop:: reset in
 
-   Set Warnings "-omega-is-deprecated".
-   Require Import Coq.omega.Omega.
+   Require Import Lia.
 
    Ltac mytauto := tauto.
-   Ltac tac := intros; repeat split; omega || mytauto.
+   Ltac tac := intros; repeat split; lia || mytauto.
 
    Notation max x y := (x + (y - x)) (only parsing).
 
@@ -2340,7 +2339,7 @@ performance issue.
    Set Ltac Profiling.
    tac.
    Show Ltac Profile.
-   Show Ltac Profile "omega".
+   Show Ltac Profile "lia".
 
 .. coqtop:: in
 

--- a/plugins/omega/coq_omega.ml
+++ b/plugins/omega/coq_omega.ml
@@ -80,21 +80,21 @@ open Goptions
 
 let () =
   declare_bool_option
-    { optdepr  = false;
+    { optdepr  = true;
       optkey   = ["Omega";"System"];
       optread  = read display_system_flag;
       optwrite = write display_system_flag }
 
 let () =
   declare_bool_option
-    { optdepr  = false;
+    { optdepr  = true;
       optkey   = ["Omega";"Action"];
       optread  = read display_action_flag;
       optwrite = write display_action_flag }
 
 let () =
   declare_bool_option
-    { optdepr  = false;
+    { optdepr  = true;
       optkey   = ["Omega";"OldStyle"];
       optread  = read old_style_flag;
       optwrite = write old_style_flag }
@@ -108,7 +108,7 @@ let () =
 
 let () =
   declare_bool_option
-    { optdepr  = false;
+    { optdepr  = true;
       optkey   = ["Omega";"UseLocalDefs"];
       optread  = read letin_flag;
       optwrite = write letin_flag }

--- a/plugins/omega/g_omega.mlg
+++ b/plugins/omega/g_omega.mlg
@@ -24,6 +24,6 @@ open Ltac_plugin
 
 }
 
-TACTIC EXTEND omega
+TACTIC EXTEND omega DEPRECATED { Deprecation.make ~since:"8.12" ~note:"Use lia instead." () }
 |  [ "omega" ] -> { Coq_omega.omega_solver }
 END

--- a/theories/ZArith/ZArith.v
+++ b/theories/ZArith/ZArith.v
@@ -18,6 +18,7 @@ Require Export Zpow_def.
 
 (** Extra modules using [Omega] or [Ring]. *)
 
+Set Warnings "-deprecated-omega-plugin".
 Require Export Omega.
 Require Export Zcomplements.
 Require Export Zpower.

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -535,6 +535,16 @@ let warn_deprecated_as_ident_kind =
   CWarnings.create ~name:"deprecated-as-ident-kind" ~category:"deprecated"
          (fun () -> strbrk "grammar kind \"as ident\" no longer accepts \"_\"; use \"as name\" instead to accept \"_\", too, or silence the warning if you actually intended to accept only identifiers.")
 
+let warn_omega_plugin_deprecated = CWarnings.create ~name:"deprecated-omega-plugin" ~category:"deprecated"
+  (fun () -> Pp.str "The Omega plugin is deprecated.  Please use Lia instead.")
+
+let check_for_omega qids =
+  List.iter (fun qid ->
+      let s = Libnames.string_of_qualid qid in
+      if s = "Omega" || s = "Coq.omega.Omega" then
+        warn_omega_plugin_deprecated ()
+    ) qids
+
 }
 
 (* Modules and Sections *)
@@ -566,7 +576,7 @@ GRAMMAR EXTEND Gram
 
       (* Requiring an already compiled module *)
       | IDENT "Require"; export = export_token; qidl = LIST1 global ->
-          { VernacRequire (None, export, qidl) }
+          { check_for_omega qidl; VernacRequire (None, export, qidl) }
       | IDENT "From" ; ns = global ; IDENT "Require"; export = export_token
         ; qidl = LIST1 global ->
         { VernacRequire (Some ns, export, qidl) }


### PR DESCRIPTION
While the documentation says that `omega` is deprecated since 8.12, there was no deprecation warning.  This adds one so we can consider removal in 8.15 (e.g. by #13741)

