### PR TITLE
[RFC] [attributes] conditional compilation

### DIFF
--- a/test-suite/success/conditional_comp.v
+++ b/test-suite/success/conditional_comp.v
@@ -1,0 +1,6 @@
+#[if(SHELL)] Goal True.
+Proof.
+idtac.
+#[if(USER = " me ")] exact 1.
+#[if(not(USER = " you "))] exact I.
+Qed.

--- a/vernac/attributes.mli
+++ b/vernac/attributes.mli
@@ -137,3 +137,11 @@ val vernac_monomorphic_flag : vernac_flag
 (** For internal use. *)
 val universe_polymorphism_option_name : string list
 val is_universe_polymorphism : unit -> bool
+
+type boolean_condition =
+  | Var of { name : string; value : string option }
+  | Not of boolean_condition
+  | And of boolean_condition * boolean_condition
+  | Or of boolean_condition * boolean_condition
+
+val if_condition : boolean_condition option attribute

--- a/vernac/g_vernac.mlg
+++ b/vernac/g_vernac.mlg
@@ -114,6 +114,7 @@ GRAMMAR EXTEND Gram
   ;
   attribute:
     [ [ k = ident ; v = attr_value -> { Names.Id.to_string k, v }
+      | "if" ; v = attr_value -> { "if", v }
       (* Required because "ident" is declared a keyword when loading Ltac. *)
       | IDENT "using" ; v = attr_value -> { "using", v } ]
     ]


### PR DESCRIPTION
This lets you write
```coq
#[if(FOO)] command.
```
and have `command` executed only if `FOO` is set, or more in general if the condition holds.
This can help for retro compatibility code.

TODO:
- [ ] COQ_VERSION variable
- [ ] version comparison operator
- [ ] think about "parsing" the command only if the condition holds, eg `##[comment_if(EXPR)]` and `##[end_comment]` floating attributes (floating means not parsed attached to a command), like ocaml's `[@@@foobar]`.