### PR TITLE
Remove the Hide Obligations flag (deprecated in 8.12)

### DIFF
--- a/doc/changelog/07-vernac-commands-and-options/13758-remove_hide_obligations.rst
+++ b/doc/changelog/07-vernac-commands-and-options/13758-remove_hide_obligations.rst
@@ -1,0 +1,4 @@
+- **Removed:**
+  The Hide Obligations flag, deprecated in 8.12
+  (`#13758 <https://github.com/coq/coq/pull/13758>`_,
+  by Jim Fehrle).

--- a/doc/sphinx/addendum/program.rst
+++ b/doc/sphinx/addendum/program.rst
@@ -320,14 +320,6 @@ optional tactic is replaced by the default one if not specified.
    (the default), or if the system should infer which obligations can be
    declared opaque.
 
-.. flag:: Hide Obligations
-
-   .. deprecated:: 8.12
-
-   Controls whether obligations appearing in the
-   term should be hidden as implicit arguments of the special
-   constant ``Program.Tactics.obligation``.
-
 The module :g:`Coq.Program.Tactics` defines the default tactic for solving
 obligations called :g:`program_simpl`. Importing :g:`Coq.Program.Program` also
 adds some useful notations, as documented in the file itself.

--- a/doc/sphinx/changes.rst
+++ b/doc/sphinx/changes.rst
@@ -1230,7 +1230,7 @@ Flags, options and attributes
   :attr:`universes(template)` and ``universes(notemplate)`` instead
   (`#11663 <https://github.com/coq/coq/pull/11663>`_, by Théo Zimmermann).
 - **Deprecated:**
-  :flag:`Hide Obligations` flag
+  `Hide Obligations` flag
   (`#11828 <https://github.com/coq/coq/pull/11828>`_,
   by Emilio Jesus Gallego Arias).
 - **Added:** Handle the :attr:`local` attribute in :cmd:`Canonical

--- a/theories/Program/Tactics.v
+++ b/theories/Program/Tactics.v
@@ -319,7 +319,3 @@ Create HintDb program discriminated.
 Ltac program_simpl := program_simplify ; try typeclasses eauto 10 with program ; try program_solve_wf.
 
 Obligation Tactic := program_simpl.
-
-Definition obligation (A : Type) {a : A} := a.
-
-Register obligation as program.tactics.obligation.


### PR DESCRIPTION
I assumed that we want to keep the code for the default value (false).  Right?

List of 8.14 deprecation removals is in #13538.