### PR TITLE
Remove convert_concl_no_check (deprecated in 8.11)

### DIFF
--- a/doc/changelog/04-tactics/13761-remove_convert_concl_nc.rst
+++ b/doc/changelog/04-tactics/13761-remove_convert_concl_nc.rst
@@ -1,0 +1,4 @@
+- **Removed:**
+  convert_concl_no_check.  Use :tacn:`change_no_check` instead
+  (`#13761 <https://github.com/coq/coq/pull/13761>`_,
+  by Jim Fehrle).

--- a/doc/sphinx/changes.rst
+++ b/doc/sphinx/changes.rst
@@ -3191,7 +3191,7 @@ Other changes in 8.10+beta1
     by Maxime Dénès, review by Pierre-Marie Pédrot).
 
   - New variant :tacn:`change_no_check` of :tacn:`change`, usable as a
-    documented replacement of :tacn:`convert_concl_no_check`
+    documented replacement of `convert_concl_no_check`
     (`#10012 <https://github.com/coq/coq/pull/10012>`_,
     `#10017 <https://github.com/coq/coq/pull/10017>`_,
     `#10053 <https://github.com/coq/coq/pull/10053>`_, and

--- a/doc/sphinx/proofs/writing-proofs/rewriting.rst
+++ b/doc/sphinx/proofs/writing-proofs/rewriting.rst
@@ -338,13 +338,6 @@ Rewriting with definitional equality
            exact H.
          Qed.
 
-   .. tacn:: convert_concl_no_check @one_term
-
-      .. deprecated:: 8.11
-
-      Deprecated old name for :tacn:`change_no_check`. Does not support any of its
-      variants.
-
 .. _performingcomputations:
 
 Performing computations

--- a/plugins/ltac/g_auto.mlg
+++ b/plugins/ltac/g_auto.mlg
@@ -11,7 +11,6 @@
 {
 
 open Pp
-open Constr
 open Stdarg
 open Pcoq.Prim
 open Pcoq.Constr
@@ -195,20 +194,6 @@ TACTIC EXTEND unify
     | Some t ->
       let state = Hints.Hint_db.transparent_state t in
       Tactics.unify ~state x y
-  }
-END
-
-{
-let deprecated_convert_concl_no_check =
-  CWarnings.create
-    ~name:"convert_concl_no_check" ~category:"deprecated"
-    (fun () -> Pp.str "The syntax [convert_concl_no_check] is deprecated. Use [change_no_check] instead.")
-}
-
-TACTIC EXTEND convert_concl_no_check
-| ["convert_concl_no_check" constr(x) ] -> {
-    deprecated_convert_concl_no_check ();
-    Tactics.convert_concl ~check:false x DEFAULTcast
   }
 END
 

--- a/tactics/tactics.ml
+++ b/tactics/tactics.ml
@@ -156,9 +156,6 @@ let convert_hyp ~check ~reorder d =
     end
   end
 
-let convert_concl_no_check = convert_concl ~check:false
-let convert_hyp_no_check = convert_hyp ~check:false ~reorder:false
-
 let convert_gen pb x y =
   Proofview.Goal.enter begin fun gl ->
     match Tacmach.New.pf_apply (Reductionops.infer_conv ~pb) gl x y with

--- a/tactics/tactics.mli
+++ b/tactics/tactics.mli
@@ -35,10 +35,6 @@ val is_quantified_hypothesis : Id.t -> Proofview.Goal.t -> bool
 val introduction    : Id.t -> unit Proofview.tactic
 val convert_concl   : check:bool -> types -> cast_kind -> unit Proofview.tactic
 val convert_hyp     : check:bool -> reorder:bool -> named_declaration -> unit Proofview.tactic
-val convert_concl_no_check : types -> cast_kind -> unit Proofview.tactic
-[@@ocaml.deprecated "use [Tactics.convert_concl]"]
-val convert_hyp_no_check : named_declaration -> unit Proofview.tactic
-[@@ocaml.deprecated "use [Tactics.convert_hyp]"]
 val mutual_fix      :
   Id.t -> int -> (Id.t * int * constr) list -> int -> unit Proofview.tactic
 val fix             : Id.t -> int -> unit Proofview.tactic


### PR DESCRIPTION
Note this includes removing 2 functions defined in tactics.ml.

List of 8.14 deprecation removals is in #13538.