### PR TITLE
Remove double induction tactic

### DIFF
--- a/doc/changelog/04-tactics/13762-remove_double_induction.rst
+++ b/doc/changelog/04-tactics/13762-remove_double_induction.rst
@@ -1,0 +1,9 @@
+- **Removed:**
+  double induction tactic.  Replace :n:`double induction @ident @ident`
+  with :n:`induction @ident; induction @ident` (or
+  :n:`induction @ident ; destruct @ident` depending on the exact needs).
+  Replace :n:`double induction @natural__1 @natural__2` with
+  :n:`induction @natural__1; induction natural__3` where :n:`natural__3` is the result
+  of :n:`natural__2 - natural__1`
+  (`#13762 <https://github.com/coq/coq/pull/13762>`_,
+  by Jim Fehrle).

--- a/doc/sphinx/proof-engine/tactics.rst
+++ b/doc/sphinx/proof-engine/tactics.rst
@@ -2067,19 +2067,6 @@ analysis on inductive or co-inductive objects (see :ref:`inductive-definitions`)
    is the name given by :n:`intros until @natural` to the :n:`@natural`-th non-dependent
    premise of the goal.
 
-.. tacn:: double induction @ident @ident
-   :name: double induction
-
-   This tactic is deprecated and should be replaced by
-   :n:`induction @ident; induction @ident` (or
-   :n:`induction @ident ; destruct @ident` depending on the exact needs).
-
-.. tacv:: double induction @natural__1 @natural__2
-
-   This tactic is deprecated and should be replaced by
-   :n:`induction num1; induction num3` where :n:`num3` is the result
-   of :n:`num2 - num1`
-
 .. tacn:: dependent induction @ident
    :name: dependent induction
 

--- a/plugins/ltac/coretactics.mlg
+++ b/plugins/ltac/coretactics.mlg
@@ -259,13 +259,6 @@ TACTIC EXTEND simple_destruct
 | [ "simple" "destruct" quantified_hypothesis(h) ] -> { simple_destruct h }
 END
 
-(** Double induction *)
-
-TACTIC EXTEND double_induction DEPRECATED { Deprecation.make () }
-| [ "double" "induction" quantified_hypothesis(h1) quantified_hypothesis(h2) ] ->
-  { Elim.h_double_induction h1 h2 }
-END
-
 (* Admit *)
 
 TACTIC EXTEND admit

--- a/tactics/elim.mli
+++ b/tactics/elim.mli
@@ -21,4 +21,3 @@ val case_tac : bool -> or_and_intro_pattern option ->
 val h_decompose       : inductive list -> constr -> unit Proofview.tactic
 val h_decompose_or    : constr -> unit Proofview.tactic
 val h_decompose_and   : constr -> unit Proofview.tactic
-val h_double_induction : quantified_hypothesis -> quantified_hypothesis-> unit Proofview.tactic

--- a/tactics/tactics.mli
+++ b/tactics/tactics.mli
@@ -81,11 +81,6 @@ val auto_intros_tac : Names.Name.t list -> unit Proofview.tactic
 
 val intros               : unit Proofview.tactic
 
-(** [depth_of_quantified_hypothesis b h g] returns the index of [h] in
-   the conclusion of goal [g], up to head-reduction if [b] is [true] *)
-val depth_of_quantified_hypothesis :
-  bool -> quantified_hypothesis -> Proofview.Goal.t -> int
-
 val intros_until         : quantified_hypothesis -> unit Proofview.tactic
 
 val intros_clearing      : bool list -> unit Proofview.tactic

--- a/test-suite/success/induct.v
+++ b/test-suite/success/induct.v
@@ -154,50 +154,6 @@ induction H.
 change (0 = z -> True) in IHrepr''.
 Abort.
 
-(* Test double induction *)
-
-(* This was failing in 8.5 and before because of a bug in the order of
-   hypotheses *)
-
-Set Warnings "-deprecated".
-
-Inductive I2 : Type :=
-  C2 : forall x:nat, x=x -> I2.
-Goal forall a b:I2, a = b.
-double induction a b.
-Abort.
-
-(* This was leaving useless hypotheses in 8.5 and before because of
-   the same bug. This is a change of compatibility. *)
-
-Inductive I3 : Prop :=
-  C3 : forall x:nat, x=x -> I3.
-Goal forall a b:I3, a = b.
-double induction a b.
-Fail clear H. (* H should have been erased *)
-Abort.
-
-(* This one had quantification in reverse order in 8.5 and before *)
-(* This is a change of compatibility. *)
-
-Goal forall m n, le m n -> le n m -> n=m.
-intros m n. double induction 1 2.
-3:destruct 1. (* Should be "S m0 <= m0" *)
-Abort.
-
-(* Idem *)
-
-Goal forall m n p q, le m n -> le p q -> n+p=m+q.
-intros *. double induction 1 2.
-3:clear H2. (* H2 should have been erased *)
-Abort.
-
-(* This is unchanged *)
-
-Goal forall m n:nat, n=m.
-double induction m n.
-Abort.
-
 (* Mentioned as part of bug #12944 *)
 
 Inductive test : Set := cons : forall (IHv : nat) (v : test), test.


### PR DESCRIPTION
List of 8.14 deprecation removals is in #13538.