### PR TITLE
Use cbn instead of simpl in a proof of HexadecimalNat.

### DIFF
--- a/theories/Numbers/HexadecimalNat.v
+++ b/theories/Numbers/HexadecimalNat.v
@@ -230,7 +230,7 @@ Proof.
   simpl_of_lu;
   rewrite ?Nat.add_succ_l, Nat.add_0_l, ?to_lu_succ, to_of_lu_sixteenfold
    by assumption;
-  unfold lnorm; simpl; now destruct nztail.
+  unfold lnorm; cbn; now destruct nztail.
 Qed.
 
 (** Second bijection result *)


### PR DESCRIPTION
This reduces the tactic invocation time from 10s to 0.25s on my machine. I was growing tired of having to wait for that file while compiling the stdlib.
