### PR TITLE
Fix: `@tactic` is not a tactic, so can't begin a .. tacn::

### DIFF
--- a/doc/sphinx/proofs/writing-proofs/rewriting.rst
+++ b/doc/sphinx/proofs/writing-proofs/rewriting.rst
@@ -890,10 +890,8 @@ the conversion in hypotheses :n:`{+ @ident}`.
 Conversion tactics applied to hypotheses
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. tacn:: @tactic in {+, @ident}
-
-   Applies :token:`tactic` (any of the conversion tactics listed in this
-   section) to the hypotheses :n:`{+ @ident}`.
+   The form :n:`@tactic in {+, @ident }` applies :token:`tactic` (any of the
+   conversion tactics listed in this section) to the hypotheses :n:`{+ @ident}`.
 
    If :token:`ident` is a local definition, then :token:`ident` can be replaced by
    :n:`type of @ident` to address not the body but the type of the local


### PR DESCRIPTION
This was causing `make doc_gram_rsts` to fail because `@tactic ...` is not a concrete tactic from the (edited) grammar.  Just a bandaid fix until #13707 updates the rest of `rewriting.rst`.