### PR TITLE
[micromega] Deprecate hopefully useless options and flags

### DIFF
--- a/doc/changelog/04-tactics/13781-deprecate_micromega_options.rst
+++ b/doc/changelog/04-tactics/13781-deprecate_micromega_options.rst
@@ -1,0 +1,3 @@
+- **Deprecated:**
+  The micromega option :flag:`Simplex` is deprecated. It is already set by default and will be removed.
+  (`#13781 <https://github.com/coq/coq/pull/13781>`_, by Frédéric Besson).

--- a/doc/changelog/04-tactics/13781-deprecate_micromega_options.rst
+++ b/doc/changelog/04-tactics/13781-deprecate_micromega_options.rst
@@ -1,3 +1,3 @@
 - **Deprecated:**
-  The micromega option :flag:`Simplex` is deprecated. It is already set by default and will be removed.
+  The micromega option :flag:`Simplex`, which is currently set by default
   (`#13781 <https://github.com/coq/coq/pull/13781>`_, by Frédéric Besson).

--- a/doc/sphinx/addendum/micromega.rst
+++ b/doc/sphinx/addendum/micromega.rst
@@ -34,8 +34,8 @@ tactics for solving arithmetic goals over :math:`\mathbb{Q}`,
    .. deprecated:: 8.14
 
    This flag (set by default) instructs the decision procedures to
-   use the Simplex method for solving linear goals.
-   If it is not set, the decision procedures are using the *deprecated* Fourier elimination.
+   use the Simplex method for solving linear goals instead of the
+   deprecated Fourier elimination.
 
 .. opt:: Dump Arith
 

--- a/doc/sphinx/addendum/micromega.rst
+++ b/doc/sphinx/addendum/micromega.rst
@@ -31,9 +31,11 @@ tactics for solving arithmetic goals over :math:`\mathbb{Q}`,
 
 .. flag:: Simplex
 
+   .. deprecated:: 8.14
+
    This flag (set by default) instructs the decision procedures to
-   use the Simplex method for solving linear goals. If it is not set,
-   the decision procedures are using Fourier elimination.
+   use the Simplex method for solving linear goals.
+   If it is not set, the decision procedures are using the *deprecated* Fourier elimination.
 
 .. opt:: Dump Arith
 

--- a/plugins/micromega/certificate.ml
+++ b/plugins/micromega/certificate.ml
@@ -28,7 +28,7 @@ open Q.Notations
 open Mutils
 
 let use_simplex =
-  Goptions.declare_bool_option_and_ref ~depr:false ~key:["Simplex"] ~value:true
+  Goptions.declare_bool_option_and_ref ~depr:true ~key:["Simplex"] ~value:true
 
 (* If set to some [file], arithmetic goals are dumped in [file].v *)
 

--- a/plugins/micromega/coq_micromega.ml
+++ b/plugins/micromega/coq_micromega.ml
@@ -38,14 +38,14 @@ let max_depth = max_int
 
 (* Search limit for provers over Q R *)
 let lra_proof_depth =
-  declare_int_option_and_ref ~depr:false ~key:["Lra"; "Depth"] ~value:max_depth
+  declare_int_option_and_ref ~depr:true ~key:["Lra"; "Depth"] ~value:max_depth
 
 (* Search limit for provers over Z *)
 let lia_enum =
-  declare_bool_option_and_ref ~depr:false ~key:["Lia"; "Enum"] ~value:true
+  declare_bool_option_and_ref ~depr:true ~key:["Lia"; "Enum"] ~value:true
 
 let lia_proof_depth =
-  declare_int_option_and_ref ~depr:false ~key:["Lia"; "Depth"] ~value:max_depth
+  declare_int_option_and_ref ~depr:true ~key:["Lia"; "Depth"] ~value:max_depth
 
 let get_lia_option () =
   (Certificate.use_simplex (), lia_enum (), lia_proof_depth ())


### PR DESCRIPTION
The goal is to eventually only use the Simplex solver and
remove all the code needed for fourier elimination.

- [x] Corresponding documentation was added 
- [x] Entry added in the changelog
