### PR TITLE
Support the Ltac debugger in CoqIDE

### DIFF
--- a/dev/doc/xml-protocol.md
+++ b/dev/doc/xml-protocol.md
@@ -30,6 +30,7 @@ Changes to the XML protocol are documented as part of [`dev/doc/changes.md`](/de
   - [StopWorker](#command-stopworker)
   - [PrintAst](#command-printast)
   - [Annotate](#command-annotate)
+  - [Db_cmd](#command-db_cmd)
 * [Feedback messages](#feedback)
   - [Added Axiom](#feedback-addedaxiom)
   - [Processing](#feedback-processing)
@@ -44,6 +45,7 @@ Changes to the XML protocol are documented as part of [`dev/doc/changes.md`](/de
   - [File Loaded](#feedback-fileloaded)
   - [Message](#feedback-message)
   - [Custom](#feedback-custom)
+* [Ltac-debug messages](ltac_debug)
 * [Highlighting Text](#highlighting)
 
 Sentences: each command sent to Coqtop is a "sentence"; they are typically terminated by ".\s" (followed by whitespace or EOF).
@@ -629,6 +631,20 @@ take `<call val="Annotate"><string>Theorem plus_0_r : forall n : nat, n + 0 = n.
 
 -------------------------------
 
+
+
+### <a name="command-db_cmd">**Db_cmd(user_input: string)**</a>
+```html
+<call val="Db_cmd"><string>${user_input}</string></call>
+```
+#### *Returns*
+*
+
+`<call val="Db_cmd"><string>h</string></call>` passes the command "h" to the debugger.
+It returns unit.
+
+-------------------------------
+
 ## <a name="feedback">Feedback messages</a>
 
 Feedback messages are issued out-of-band,
@@ -752,6 +768,33 @@ Ex: `status = "Idle"` or `status = "proof: myLemmaName"` or `status = "Dead"`
   </feedback_content>
 </feedback>
 ```
+
+-------------------------------
+
+## <a name="ltac-debug">Ltac-debug messages</a>
+
+Ltac-debug messages are issued out-of-band, similar to Feedback messages.
+The response contains an identifying tag and a `<ppdoc>`.
+Currently these tags are used:
+
+* **output** - ordinary output for display in the Messages panel
+* **goal** - the current goal for the debugger, for display in the Messages panel
+  or elsewhere
+* **prompt** - output for display in the Messages panel prompting the user to
+  enter a debug command, allowing CoqIDE to display it without
+  appending a newline.  It also signals that coqidetop is waiting to receive
+  a debugger-specific message such as [Db_cmd](#command-db_cmd).
+
+```xml
+<ltac_debug>
+prompt
+  <ppdoc val="tag">
+        :
+  </ppdoc>
+</ltac_debug>
+```
+
+-------------------------------
 
 ## <a name="highlighting">Highlighting Text</a>
 

--- a/doc/changelog/09-coqide/13783-debugger_coqide.rst
+++ b/doc/changelog/09-coqide/13783-debugger_coqide.rst
@@ -1,0 +1,5 @@
+- **Added:**
+  Ltac debugger support in CoqIDE (see :flag:`Ltac Debug`).
+  Debugger output and prompts appear in the Messages panel
+  (`#13783 <https://github.com/coq/coq/pull/13783>`_,
+  by Jim Fehrle and Emilio J. Gallego Arias).

--- a/ide/coqide/coq.ml
+++ b/ide/coqide/coq.ml
@@ -200,7 +200,8 @@ type handle = {
   proc : CoqTop.process;
   xml_oc : Xml_printer.t;
   mutable alive : bool;
-  mutable waiting_for : ccb option; (* last call + callback *)
+  mutable waiting_for : ccb option; (* last non-debug call + callback *)
+  mutable db_waiting_for : ccb option; (* last debug call + callback *)
 }
 
 (** Coqtop process status :
@@ -208,11 +209,12 @@ type handle = {
              It will reject tasks given via [try_grab].
   - Ready  : no current task, accepts new tasks via [try_grab].
   - Busy   : has accepted a task via [init_coqtop] or [try_grab],
-             It will reject other tasks for the moment
+             Non-debug tasks will be rejected for the moment
+  - DbBusy : is processing a debug task
   - Closed : the coqide buffer has been closed, we discard any further task.
 *)
 
-type status = New | Ready | Busy | Closed
+type status = New | Ready | Busy | DbBusy | Closed
 
 type 'a task = handle -> ('a -> void) -> void
 
@@ -225,6 +227,8 @@ type coqtop = {
   mutable reset_handler : unit task;
   (* called whenever coqtop sends a feedback message *)
   mutable feedback_handler : Feedback.feedback -> unit;
+  (* called when the Ltac debugger sends an input prompt message *)
+  mutable debug_prompt_handler : tag:string -> Pp.t -> unit;
   (* actual coqtop process and its status *)
   mutable handle : handle;
   mutable status : status;
@@ -289,12 +293,16 @@ let handle_feedback feedback_processor xml =
   let feedback = Xmlprotocol.to_feedback xml in
   feedback_processor feedback
 
+let handle_ltac_debug ltac_debug_processor xml =
+  let tag, msg = Xmlprotocol.to_ltac_debug_answer xml in
+  ltac_debug_processor ~tag msg
+
 let handle_final_answer handle xml =
   let () = Minilib.log "Handling coqtop answer" in
-  let ccb = match handle.waiting_for with
-    | None -> raise (AnswerWithoutRequest (Xml_printer.to_string_fmt xml))
-    | Some c -> c in
-  let () = handle.waiting_for <- None in
+  let ccb = match handle.db_waiting_for, handle.waiting_for with
+  | None, None -> raise (AnswerWithoutRequest (Xml_printer.to_string_fmt xml))
+  | Some c, _ -> handle.db_waiting_for <- None; c
+  | None, Some c -> handle.waiting_for <- None; c in
   with_ccb ccb { bind_ccb = fun (c, f) -> f (Xmlprotocol.to_answer c xml) }
 
 type input_state = {
@@ -302,7 +310,7 @@ type input_state = {
   mutable lexerror : int option;
 }
 
-let unsafe_handle_input handle feedback_processor state conds ~read_all =
+let unsafe_handle_input handle (feedback_processor, ltac_debug_processor) state conds ~read_all =
   check_errors conds;
   let s = read_all () in
   if String.length s = 0 then raise (TubeError "EMPTY");
@@ -315,13 +323,17 @@ let unsafe_handle_input handle feedback_processor state conds ~read_all =
     let l_end = Lexing.lexeme_end lex in
     state.fragment <- String.sub s l_end (String.length s - l_end);
     state.lexerror <- None;
-    if Xmlprotocol.is_feedback xml then begin
+    match Xmlprotocol.msg_kind xml with
+    | Xmlprotocol.Feedback ->
       handle_feedback feedback_processor xml;
       loop ()
-    end else
-      begin
-        ignore (handle_final_answer handle xml)
-      end
+    | Xmlprotocol.LtacDebugInfo ->
+      handle_ltac_debug ltac_debug_processor xml;
+      loop ()
+    | Xmlprotocol.Other ->
+      ignore (handle_final_answer handle xml);
+      if handle.waiting_for <> None then (* i.e., just finished a db request *)
+        loop ()
   in
   try loop ()
   with Xml_parser.Error _ as e ->
@@ -340,13 +352,13 @@ let print_exception = function
         ^ Xml_printer.to_string actual
   | e -> Printexc.to_string e
 
-let input_watch handle respawner feedback_processor =
+let input_watch handle respawner processors =
   let state = { fragment = ""; lexerror = None; } in
   (fun conds ~read_all ->
     let h = handle () in
     if not h.alive then false
     else
-      try unsafe_handle_input h feedback_processor state conds ~read_all; true
+      try unsafe_handle_input h processors state conds ~read_all; true
       with e ->
         Minilib.log ("Coqtop reader failed, resetting: "^print_exception e);
         respawner ();
@@ -359,7 +371,7 @@ let bind_self_as f =
   Option.get !me
 
 (** This launches a fresh handle from its command line arguments. *)
-let spawn_handle args respawner feedback_processor =
+let spawn_handle args respawner processors =
   let prog = coqtop_path () in
   let async_default =
     (* disable async processing by default in Windows *)
@@ -385,12 +397,13 @@ let spawn_handle args respawner feedback_processor =
       with Not_found -> None end in
   bind_self_as (fun handle ->
   let proc, oc =
-    CoqTop.spawn ?env prog args (input_watch handle respawner feedback_processor) in
+    CoqTop.spawn ?env prog args (input_watch handle respawner processors) in
   {
     proc;
     xml_oc = Xml_printer.make (Xml_printer.TChannel oc);
     alive = true;
     waiting_for = None;
+    db_waiting_for = None;
   })
 
 (** This clears any potentially remaining open garbage. *)
@@ -403,7 +416,7 @@ let clear_handle h =
   end
 
 let mkready coqtop =
-  fun () -> coqtop.status <- Ready; Void
+  fun () -> coqtop.status <- if coqtop.status = DbBusy then Busy else Ready; Void
 
 let save_all = ref (fun () -> assert false)
 
@@ -420,11 +433,12 @@ let rec respawn_coqtop ?(why=Unexpected) coqtop =
   in
   clear_handle coqtop.handle;
   ignore_error (fun () ->
+     let processors = (coqtop.feedback_handler, coqtop.debug_prompt_handler) in
      coqtop.handle <-
        spawn_handle
          coqtop.sup_args
          (fun () -> respawn_coqtop coqtop)
-         coqtop.feedback_handler) ();
+         processors) ();
   (* Normally, the handle is now a fresh one.
      If not, there isn't much we can do ... *)
   assert (coqtop.handle.alive = true);
@@ -432,19 +446,26 @@ let rec respawn_coqtop ?(why=Unexpected) coqtop =
   ignore (coqtop.reset_handler coqtop.handle (mkready coqtop))
 
 let spawn_coqtop sup_args =
-  bind_self_as (fun this -> {
+  bind_self_as (fun this ->
+      let processors =
+        (fun msg -> (this ()).feedback_handler msg)
+      , (fun ~tag msg -> (this ()).debug_prompt_handler ~tag msg)
+      in
+  {
     handle = spawn_handle sup_args
                (fun () -> respawn_coqtop (this ()))
-               (fun msg -> (this ()).feedback_handler msg);
+               processors;
     sup_args = sup_args;
     reset_handler = (fun _ k -> k ());
     feedback_handler = (fun _ -> ());
+    debug_prompt_handler = (fun ~tag:_ _ -> ());
     status = New;
   })
 
 let set_reset_handler coqtop hook = coqtop.reset_handler <- hook
 
 let set_feedback_handler coqtop hook = coqtop.feedback_handler <- hook
+let set_debug_prompt_handler coqtop hook = coqtop.debug_prompt_handler <- hook
 
 let is_computing coqtop = (coqtop.status = Busy)
 
@@ -465,19 +486,20 @@ let set_arguments coqtop args =
   coqtop.sup_args <- args;
   reset_coqtop coqtop
 
-let process_task coqtop task =
-  assert (coqtop.status = Ready || coqtop.status = New);
-  coqtop.status <- Busy;
+let process_task ?(db=false) coqtop task =
+  assert (coqtop.status = Ready || coqtop.status = New || (db && coqtop.status = Busy));
+  coqtop.status <- if db then DbBusy else Busy;
   try ignore (task coqtop.handle (mkready coqtop))
   with e ->
     Minilib.log ("Coqtop writer failed, resetting: " ^ Printexc.to_string e);
     if coqtop.status <> Closed then respawn_coqtop coqtop
 
-let try_grab coqtop task abort =
+let try_grab ?(db=false) coqtop task abort =
   match coqtop.status with
-    |Closed -> ()
-    |Busy|New -> abort ()
-    |Ready -> process_task coqtop task
+    | Closed -> ()
+    | Busy when db -> process_task ~db coqtop task
+    | Busy | DbBusy | New -> abort ()
+    | Ready -> process_task coqtop task
 
 let init_coqtop coqtop task =
   assert (coqtop.status = New);
@@ -489,13 +511,19 @@ let init_coqtop coqtop task =
 
 type 'a query = 'a Interface.value task
 
-let eval_call call handle k =
+let eval_call ?(db=false) call handle k =
   (* Send messages to coqtop and prepare the decoding of the answer *)
-  Minilib.log ("Start eval_call " ^ Xmlprotocol.pr_call call);
-  assert (handle.alive && handle.waiting_for = None);
-  handle.waiting_for <- Some (mk_ccb (call,k));
+  let in_db = if db then "db " else "" in
+  Minilib.log ("Start " ^ in_db ^ "eval_call " ^ Xmlprotocol.pr_call call);
+  if db then begin
+    assert (handle.alive && handle.db_waiting_for = None);
+    handle.db_waiting_for <- Some (mk_ccb (call,k))
+  end else begin
+    assert (handle.alive && handle.waiting_for = None);
+    handle.waiting_for <- Some (mk_ccb (call,k))
+  end;
   Xml_printer.print handle.xml_oc (Xmlprotocol.of_call call);
-  Minilib.log "End eval_call";
+  Minilib.log ("End " ^ in_db ^ "eval_call");
   Void
 
 let add x = eval_call (Xmlprotocol.add x)
@@ -508,6 +536,7 @@ let search flags = eval_call (Xmlprotocol.search flags)
 let init x = eval_call (Xmlprotocol.init x)
 let stop_worker x = eval_call (Xmlprotocol.stop_worker x)
 let proof_diff x = eval_call (Xmlprotocol.proof_diff x)
+let db_cmd x = eval_call ~db:true (Xmlprotocol.db_cmd x)
 
 let break_coqtop coqtop workers =
   if coqtop.status = Busy then

--- a/ide/coqide/coq.mli
+++ b/ide/coqide/coq.mli
@@ -68,6 +68,9 @@ val set_reset_handler : coqtop -> unit task -> unit
 val set_feedback_handler : coqtop -> (Feedback.feedback -> unit) -> unit
 (** Register a handler called when coqtop sends a feedback message *)
 
+val set_debug_prompt_handler : coqtop -> (tag:string -> Pp.t -> unit) -> unit
+(** Register a handler called when the Ltac debugger sends a feedback message *)
+
 val init_coqtop : coqtop -> unit task -> unit
 (** Finish initializing a freshly spawned coqtop, by running a first task on it.
     The task should run its inner continuation at the end. *)
@@ -93,7 +96,7 @@ val gio_channel_of_descr_socket : (Unix.file_descr -> Glib.Io.channel) ref
 
 (** {5 Task processing} *)
 
-val try_grab : coqtop -> unit task -> (unit -> unit) -> unit
+val try_grab : ?db:bool -> coqtop -> unit task -> (unit -> unit) -> unit
 (** Try to schedule a task on a coqtop. If coqtop is available, the task
     callback is run (asynchronously), otherwise the [(unit->unit)] callback
     is triggered.
@@ -128,6 +131,7 @@ val mkcases    : Interface.mkcases_sty    -> Interface.mkcases_rty query
 val search     : Interface.search_sty     -> Interface.search_rty query
 val init       : Interface.init_sty       -> Interface.init_rty query
 val proof_diff : Interface.proof_diff_sty -> Interface.proof_diff_rty query
+val db_cmd     : Interface.db_cmd_sty     -> Interface.db_cmd_rty query
 
 val stop_worker: Interface.stop_worker_sty-> Interface.stop_worker_rty query
 

--- a/ide/coqide/coqOps.mli
+++ b/ide/coqide/coqOps.mli
@@ -16,6 +16,8 @@ object
   method go_to_insert : unit task
   method go_to_mark : GText.mark -> unit task
   method process_next_phrase : unit task
+  method process_db_cmd : string ->
+    next:(Interface.db_cmd_rty Interface.value -> unit task) -> unit task
   method process_until_end_or_error : unit task
   method handle_reset_initial : unit task
   method raw_coq_query :

--- a/ide/coqide/coqide.ml
+++ b/ide/coqide/coqide.ml
@@ -765,6 +765,15 @@ let show_proof_diff where sn =
 
 let show_proof_diffs _ = cb_on_current_term (show_proof_diff `INSERT) ()
 
+let db_cmd cmd sn =  (* todo: still good? *)
+  Coq.try_grab ~db:true sn.coqtop (sn.coqops#process_db_cmd cmd
+    ~next:(function | _ -> Coq.return ()))
+  ignore
+
+let send_db_cmd cmd = cb_on_current_term (db_cmd cmd) ()
+
+let _ = Wg_MessageView.forward_send_db_cmd := send_db_cmd
+
 let about _ =
   let dialog = GWindow.about_dialog () in
   let _ = dialog#connect#response ~callback:(fun _ -> dialog#destroy ()) in

--- a/ide/coqide/fake_ide.ml
+++ b/ide/coqide/fake_ide.ml
@@ -30,9 +30,12 @@ let base_eval_call ?(print=true) ?(fail=true) call coqtop =
   Xml_printer.print coqtop.xml_printer xml_query;
   let rec loop () =
     let xml = Xml_parser.parse coqtop.xml_parser in
-    if Xmlprotocol.is_feedback xml then
+    match Xmlprotocol.msg_kind xml with
+    | Xmlprotocol.Feedback
+    | Xmlprotocol.LtacDebugInfo ->
       loop ()
-    else Xmlprotocol.to_answer call xml
+    | Xmlprotocol.Other ->
+      Xmlprotocol.to_answer call xml
   in
   let res = loop () in
   if print then prerr_endline (Xmlprotocol.pr_full_value call res);

--- a/ide/coqide/minilib.ml
+++ b/ide/coqide/minilib.ml
@@ -17,6 +17,7 @@ type level = [
   | `DEBUG
   | `INFO
   | `NOTICE
+  | `PROMPT
   | `WARNING
   | `ERROR
   | `FATAL ]
@@ -37,6 +38,7 @@ let log_pp ?(level = `DEBUG) msg =
   | `DEBUG -> "DEBUG"
   | `INFO -> "INFO"
   | `NOTICE -> "NOTICE"
+  | `PROMPT -> "PROMPT"
   | `WARNING -> "WARNING"
   | `ERROR -> "ERROR"
   | `FATAL -> "FATAL"

--- a/ide/coqide/minilib.mli
+++ b/ide/coqide/minilib.mli
@@ -17,6 +17,7 @@ type level = [
   | `DEBUG
   | `INFO
   | `NOTICE
+  | `PROMPT
   | `WARNING
   | `ERROR
   | `FATAL ]

--- a/ide/coqide/preferences.ml
+++ b/ide/coqide/preferences.ml
@@ -506,6 +506,7 @@ let () =
     ("message.debug", make_tag ());
     ("message.error", make_tag ());
     ("message.warning", make_tag ());
+    ("message.prompt", make_tag ~fg:"green" ());
     ("module.definition", make_tag ~fg:"orange red" ~bold:true ());
     ("module.keyword", make_tag ());
     ("tactic.keyword", make_tag ());

--- a/ide/coqide/protocol/interface.ml
+++ b/ide/coqide/protocol/interface.ml
@@ -191,6 +191,10 @@ type search_rty = string coq_object list
 type proof_diff_sty = string * Stateid.t
 type proof_diff_rty = Pp.t
 
+(** A debugger command *)
+type db_cmd_sty = string
+type db_cmd_rty = unit
+
 (** Retrieve the list of options of the current toplevel *)
 type get_options_sty = unit
 type get_options_rty = (option_name * option_state) list
@@ -257,6 +261,7 @@ type handler = {
   print_ast   : print_ast_sty   -> print_ast_rty;
   annotate    : annotate_sty    -> annotate_rty;
   proof_diff  : proof_diff_sty  -> proof_diff_rty;
+  db_cmd      : db_cmd_sty      -> db_cmd_rty;
   handle_exn  : handle_exn_sty  -> handle_exn_rty;
   init        : init_sty        -> init_rty;
   quit        : quit_sty        -> quit_rty;

--- a/ide/coqide/protocol/xmlprotocol.ml
+++ b/ide/coqide/protocol/xmlprotocol.ml
@@ -9,10 +9,11 @@
 (************************************************************************)
 
 (** Protocol version of this file. This is the date of the last modification. *)
+let protocol_version = "20210409"
 
 (** WARNING: TO BE UPDATED WHEN MODIFIED! *)
 
-let protocol_version = "20200911"
+(** See xml-protocol.md for a description of the protocol. *)
 
 type msg_format = Richpp of int | Ppcmds
 let msg_format = ref (Richpp 72)
@@ -550,6 +551,7 @@ let stop_worker_sty_t : stop_worker_sty val_t = string_t
 let print_ast_sty_t : print_ast_sty val_t = state_id_t
 let annotate_sty_t : annotate_sty val_t = string_t
 let proof_diff_sty_t : proof_diff_sty val_t = pair_t string_t state_id_t
+let db_cmd_sty_t : db_cmd_sty val_t = string_t
 
 let add_rty_t : add_rty val_t =
   pair_t state_id_t (pair_t (union_t unit_t state_id_t) string_t)
@@ -576,6 +578,7 @@ let stop_worker_rty_t : stop_worker_rty val_t = unit_t
 let print_ast_rty_t : print_ast_rty val_t = xml_t
 let annotate_rty_t : annotate_rty val_t = xml_t
 let proof_diff_rty_t : proof_diff_rty val_t = pp_t
+let db_cmd_rty_t : db_cmd_rty val_t = unit_t
 
 let ($) x = erase x
 let calls = [|
@@ -599,6 +602,7 @@ let calls = [|
   "PrintAst",   ($)print_ast_sty_t,   ($)print_ast_rty_t;
   "Annotate",   ($)annotate_sty_t,    ($)annotate_rty_t;
   "PDiff",      ($)proof_diff_sty_t,  ($)proof_diff_rty_t;
+  "Db_cmd",     ($)db_cmd_sty_t,      ($)db_cmd_rty_t;
 |]
 
 type 'a call =
@@ -624,6 +628,7 @@ type 'a call =
   | PrintAst   : print_ast_sty -> print_ast_rty call
   | Annotate   : annotate_sty -> annotate_rty call
   | PDiff      : proof_diff_sty -> proof_diff_rty call
+  | Db_cmd     : db_cmd_sty -> db_cmd_rty call
 
 (* the order of the entries must match the order in "calls" above *)
 let id_of_call : type a. a call -> int = function
@@ -646,7 +651,8 @@ let id_of_call : type a. a call -> int = function
   | StopWorker _ -> 16
   | PrintAst _   -> 17
   | Annotate _   -> 18
-  | PDiff _     -> 19
+  | PDiff _      -> 19
+  | Db_cmd _     -> 20
 
 let str_of_call c = pi1 calls.(id_of_call c)
 
@@ -672,6 +678,7 @@ let stop_worker x : stop_worker_rty call = StopWorker x
 let print_ast x   : print_ast_rty call   = PrintAst x
 let annotate x    : annotate_rty call    = Annotate x
 let proof_diff x  : proof_diff_rty call  = PDiff x
+let db_cmd x      : db_cmd_rty call      = Db_cmd x
 
 let abstract_eval_call : type a. _ -> a call -> a value = fun handler c ->
   let mkGood : type a. a -> a value = fun x -> Good x in
@@ -697,6 +704,7 @@ let abstract_eval_call : type a. _ -> a call -> a value = fun handler c ->
     | PrintAst x   -> mkGood (handler.print_ast x)
     | Annotate x   -> mkGood (handler.annotate x)
     | PDiff x      -> mkGood (handler.proof_diff x)
+    | Db_cmd x     -> mkGood (handler.db_cmd x)
   with any ->
     let any = Exninfo.capture any in
     Fail (handler.handle_exn any)
@@ -723,6 +731,7 @@ let of_answer : type a. a call -> a value -> xml = function
   | PrintAst _   -> of_value (of_value_type print_ast_rty_t  )
   | Annotate _   -> of_value (of_value_type annotate_rty_t   )
   | PDiff _      -> of_value (of_value_type proof_diff_rty_t )
+  | Db_cmd _     -> of_value (of_value_type db_cmd_rty_t     )
 
 let of_answer msg_fmt =
   msg_format := msg_fmt; of_answer
@@ -748,6 +757,7 @@ let to_answer : type a. a call -> xml -> a value = function
   | PrintAst _   -> to_value (to_value_type print_ast_rty_t  )
   | Annotate _   -> to_value (to_value_type annotate_rty_t   )
   | PDiff _      -> to_value (to_value_type proof_diff_rty_t )
+  | Db_cmd _     -> to_value (to_value_type db_cmd_rty_t     )
 
 let of_call : type a. a call -> xml = fun q ->
   let mkCall x = constructor "call" (str_of_call q) [x] in
@@ -772,6 +782,7 @@ let of_call : type a. a call -> xml = fun q ->
   | PrintAst x   -> mkCall (of_value_type print_ast_sty_t   x)
   | Annotate x   -> mkCall (of_value_type annotate_sty_t    x)
   | PDiff x      -> mkCall (of_value_type proof_diff_sty_t  x)
+  | Db_cmd x     -> mkCall (of_value_type db_cmd_sty_t      x)
 
 let to_call : xml -> unknown_call =
   do_match "call" (fun s a ->
@@ -797,6 +808,7 @@ let to_call : xml -> unknown_call =
     | "PrintAst"   -> Unknown (PrintAst   (mkCallArg print_ast_sty_t   a))
     | "Annotate"   -> Unknown (Annotate   (mkCallArg annotate_sty_t    a))
     | "PDiff"      -> Unknown (PDiff      (mkCallArg proof_diff_sty_t  a))
+    | "Db_cmd"     -> Unknown (Db_cmd     (mkCallArg db_cmd_sty_t      a))
     | x -> raise (Marshal_error("call",PCData x)))
 
 (** Debug printing *)
@@ -829,6 +841,7 @@ let pr_full_value : type a. a call -> a value -> string = fun call value -> matc
   | PrintAst _   -> pr_value_gen (print print_ast_rty_t  ) value
   | Annotate _   -> pr_value_gen (print annotate_rty_t   ) value
   | PDiff _      -> pr_value_gen (print proof_diff_rty_t ) value
+  | Db_cmd _     -> pr_value_gen (print db_cmd_rty_t     ) value
 let pr_call : type a. a call -> string = fun call ->
   let return what x = str_of_call call ^ " " ^ print what x in
   match call with
@@ -852,6 +865,7 @@ let pr_call : type a. a call -> string = fun call ->
     | PrintAst x   -> return print_ast_sty_t x
     | Annotate x   -> return annotate_sty_t x
     | PDiff x      -> return proof_diff_sty_t x
+    | Db_cmd x     -> return db_cmd_sty_t x
 
 let document to_string_fmt =
   Printf.printf "=== Available calls ===\n\n";
@@ -979,9 +993,23 @@ let to_feedback xml = match xml with
       contents = to_feedback_content content }
   | x -> raise (Marshal_error("feedback",x))
 
-let is_feedback = function
-  | Element ("feedback", _, _) -> true
-  | _ -> false
+let of_ltac_debug_answer ~tag msg =
+  let wrap s = Element ("ltac_debug", [], s) in
+  wrap [PCData tag; of_pp msg]
+
+let to_ltac_debug_answer xml =
+  match xml with
+  | Element ("ltac_debug", [], [PCData tag; pp]) ->
+    let msg = to_pp pp in
+    tag, msg
+  | x -> raise (Marshal_error("ltac_debug_answer",x))
+
+type msg_type = Feedback | LtacDebugInfo | Other
+
+let msg_kind = function
+  | Element ("feedback", _, _) -> Feedback
+  | Element ("ltac_debug", _, _) -> LtacDebugInfo
+  | _ -> Other
 
 (* vim: set foldmethod=marker: *)
 

--- a/ide/coqide/protocol/xmlprotocol.mli
+++ b/ide/coqide/protocol/xmlprotocol.mli
@@ -38,6 +38,7 @@ val interp      : interp_sty      -> interp_rty call
 val print_ast   : print_ast_sty   -> print_ast_rty call
 val annotate    : annotate_sty    -> annotate_rty call
 val proof_diff  : proof_diff_sty  -> proof_diff_rty call
+val db_cmd      : db_cmd_sty      -> db_cmd_rty call
 
 val abstract_eval_call : handler -> 'a call -> 'a value
 
@@ -67,8 +68,16 @@ val pr_call : 'a call -> string
 val pr_value : 'a value -> string
 val pr_full_value : 'a call -> 'a value -> string
 
-(** * Serializaiton of feedback  *)
+(** Classification of messages handled by different mechanisms *)
+type msg_type = Feedback | LtacDebugInfo | Other
+
+(* EJGA: We could even include the decoding info here *)
+val msg_kind : xml -> msg_type
+
+(** * Serialization of feedback  *)
 val of_feedback : msg_format -> Feedback.feedback -> xml
 val to_feedback : xml -> Feedback.feedback
 
-val is_feedback : xml -> bool
+(** * Serialization of debugger output *)
+val of_ltac_debug_answer : tag:string -> Pp.t -> xml
+val to_ltac_debug_answer : xml -> string * Pp.t

--- a/ide/coqide/session.ml
+++ b/ide/coqide/session.ml
@@ -65,6 +65,7 @@ let create_buffer () =
 let create_script coqtop source_buffer =
   let script = Wg_ScriptView.script_view coqtop ~source_buffer
     ~show_line_numbers:true ~wrap_mode:`NONE ()
+    (* todo: line numbers don't appear *)
   in
   let _ = script#misc#set_name "ScriptWindow"
   in
@@ -490,6 +491,7 @@ let build_layout (sn:session) =
       if message_frame#all_children = [] then message_frame#misc#hide ();
       w#misc#set_size_request  ~width:500 ~height:400 ());
     detachable#connect#attached ~callback:(fun _ ->
+      w#misc#set_size_request  ~width:1 ~height:1 (); (* force resize *)
       ignore(message_frame#insert_page ~pos
         ~tab_label:label#coerce detachable#coerce);
       message_frame#misc#show ();

--- a/ide/coqide/wg_MessageView.ml
+++ b/ide/coqide/wg_MessageView.ml
@@ -38,9 +38,20 @@ class type message_view =
     method push : Ideutils.logger
       (** same as [add], but with an explicit level instead of [Notice] *)
 
+    (** Callback for the Ltac debugger *)
+    method debug_prompt : Pp.t -> unit
+
     method has_selection : bool
     method get_selected_text : string
   end
+
+let forward_send_db_cmd = ref ((fun x -> failwith "forward_send_db_cmd")
+    : string -> unit)
+
+(* The buffer can contain prompt or feedback messages *)
+type message_entry_kind =
+  | Fb of Feedback.level * Pp.t
+  | Prompt of Pp.t
 
 let message_view () : message_view =
   let buffer = GSourceView3.source_buffer
@@ -49,6 +60,7 @@ let message_view () : message_view =
     ?style_scheme:(style_manager#style_scheme source_style#get) ()
   in
   let mark = buffer#create_mark ~left_gravity:false buffer#start_iter in
+  let _ = buffer#create_mark ~name:"end_of_output" buffer#end_iter in
   let box = GPack.vbox () in
   let scroll = GBin.scrolled_window
     ~vpolicy:`AUTOMATIC ~hpolicy:`AUTOMATIC ~packing:(box#pack ~expand:true) () in
@@ -69,7 +81,7 @@ let message_view () : message_view =
   stick text_font view cb;
 
   (* Inserts at point, advances the mark *)
-  let insert_msg (level, msg) =
+  let insert_fb_msg (level, msg) =
     let tags = match level with
       | Feedback.Error   -> [Tags.Message.error]
       | Feedback.Warning -> [Tags.Message.warning]
@@ -78,15 +90,82 @@ let message_view () : message_view =
     let mark = `MARK mark in
     let width = Ideutils.textview_width view in
     Ideutils.insert_xml ~mark buffer ~tags (Richpp.richpp_of_pp width msg);
-    buffer#insert ~iter:(buffer#get_iter_at_mark mark) "\n"
+    buffer#insert ~iter:(buffer#get_iter_at_mark mark) "\n";
+    buffer#move_mark (`NAME "end_of_output") ~where:buffer#end_iter;
   in
+
+  (* Insert a prompt and make the buffer editable. *)
+  let insert_ltac_debug_prompt msg =
+    let tags = [] in
+    let mark = `MARK mark in
+    let width = Ideutils.textview_width view in
+    Ideutils.insert_xml ~mark buffer ~tags (Richpp.richpp_of_pp width msg);
+    buffer#move_mark (`NAME "end_of_output") ~where:buffer#end_iter;
+    view#set_editable true;
+    view#set_cursor_visible true;
+    view#scroll_to_mark (`NAME "end_of_output"); (* scroll to end *)
+    buffer#move_mark `INSERT ~where:buffer#end_iter;
+    let ins = buffer#get_iter_at_mark `INSERT in
+    buffer#select_range ins ins;  (* avoid highlighting *)
+  in
+
+  let insert_msg = function
+    | Fb (lvl,msg) -> insert_fb_msg (lvl,msg)
+    | Prompt msg -> insert_ltac_debug_prompt msg
+
+  in
+  let msgs : message_entry_kind list ref = ref [] in
+  let (return, _) = GtkData.AccelGroup.parse "Return" in
+  let (backspace, _) = GtkData.AccelGroup.parse "BackSpace" in
+  let (delete, _) = GtkData.AccelGroup.parse "Delete" in
+
+  (* Keypress handler *)
+  let keypress_cb ev =
+    let ev_key = GdkEvent.Key.keyval ev in
+    let ins = buffer#get_iter_at_mark `INSERT in
+    let eoo = buffer#get_iter_at_mark (`NAME "end_of_output") in
+    let delta = ins#offset - eoo#offset in
+    if not view#editable then
+      false
+    else if ev_key = delete && delta < 0 then
+      true (* ignore DELETE before end of output *)
+    else if ev_key = backspace && delta <= 0 then
+      true (* ignore BACKSPACE before eoo *)
+    else begin
+      if delta < 0 then
+        buffer#move_mark `INSERT ~where:buffer#end_iter;
+      if (ev_key >= Char.code ' ' && ev_key <= Char.code '~') then begin
+        buffer#insert (String.make 1 (Char.chr ev_key));
+        view#scroll_to_mark `INSERT; (* scroll to insertion point *)
+        let ins = buffer#get_iter_at_mark `INSERT in
+        buffer#select_range ins ins;  (* avoid highlighting *)
+        true (* consume the event *)
+      end else if ev_key = return then begin
+        let ins = buffer#get_iter_at_mark `INSERT in
+        let cmd = buffer#get_text ~start:eoo ~stop:ins () in
+        msgs := Fb (Feedback.Notice, Pp.str cmd) :: !msgs;
+        buffer#insert "\n";
+        buffer#move_mark `INSERT ~where:buffer#end_iter;
+        view#scroll_to_mark `INSERT; (* scroll to insertion point *)
+        let ins = buffer#get_iter_at_mark `INSERT in
+        buffer#select_range ins ins;  (* avoid highlighting *)
+        buffer#move_mark (`NAME "end_of_output") ~where:buffer#end_iter;
+        view#set_editable false;
+        view#set_cursor_visible false;
+
+        !forward_send_db_cmd cmd;
+        true
+      end else
+        false
+      end
+  in
+  let _ = view#event#connect#key_press ~callback:keypress_cb in
 
   let mv = object (self)
     inherit GObj.widget box#as_widget
 
     (* List of displayed messages *)
     val mutable last_width = -1
-    val mutable msgs = []
 
     val push = new GUtil.signal ()
 
@@ -108,16 +187,20 @@ let message_view () : message_view =
         last_width <- width;
         buffer#set_text "";
         buffer#move_mark (`MARK mark) ~where:buffer#start_iter;
-        List.(iter insert_msg (rev msgs))
+        List.(iter insert_msg (rev !msgs))
       end
 
     method clear =
-      msgs <- []; self#refresh true
+      msgs := []; self#refresh true
 
     method push level msg =
-      msgs <- (level, msg) :: msgs;
-      insert_msg (level, msg);
+      msgs := Fb (level, msg) :: !msgs;
+      insert_fb_msg (level, msg);
       push#call (level, msg)
+
+    method debug_prompt msg =
+      msgs := Prompt msg :: !msgs;
+      insert_ltac_debug_prompt msg
 
     method add msg = self#push Feedback.Notice msg
 

--- a/ide/coqide/wg_MessageView.mli
+++ b/ide/coqide/wg_MessageView.mli
@@ -28,8 +28,13 @@ class type message_view =
     method push : Ideutils.logger
       (** same as [add], but with an explicit level instead of [Notice] *)
 
+    (** In use by the ltac debugger *)
+    method debug_prompt : Pp.t -> unit
+
     method has_selection : bool
     method get_selected_text : string
   end
 
 val message_view : unit -> message_view
+
+val forward_send_db_cmd : (string -> unit) ref

--- a/test-suite/ide/debug_ltac.fake
+++ b/test-suite/ide/debug_ltac.fake
@@ -1,3 +1,1 @@
-ADD { Comments "fakeide doesn't support fail as the first sentence". }
-FAILADD { Debug On. }
 ADD { Set Debug On. }

--- a/toplevel/coqc.ml
+++ b/toplevel/coqc.ml
@@ -17,6 +17,10 @@ let coqc_init ((_,color_mode),_) injections ~opts =
   Flags.quiet := true;
   System.trust_file_cache := true;
   Coqtop.init_color (if opts.Coqargs.config.Coqargs.print_emacs then `EMACS else color_mode);
+  DebugHook.Intf.(set
+    { read_cmd = Coqtop.ltac_debug_parse
+    ; submit_answer = Coqtop.ltac_debug_answer
+    });
   injections
 
 let coqc_specific_usage = Usage.{

--- a/toplevel/coqtop.mli
+++ b/toplevel/coqtop.mli
@@ -51,3 +51,7 @@ type toplevel_options = {
 }
 
 val coqtop_toplevel : (toplevel_options * Stm.AsyncOpts.stm_opt,Vernac.State.t) custom_toplevel
+
+val ltac_debug_answer : DebugHook.Answer.t -> unit
+
+val ltac_debug_parse : unit -> DebugHook.Action.t

--- a/vernac/debugHook.ml
+++ b/vernac/debugHook.ml
@@ -1,0 +1,79 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+(** Ltac debugger interface; clients should register hooks to interact
+   with their provided interface. *)
+module Action = struct
+  type t =
+    | Step
+    (** Step one tactic *)
+    | Skip
+    (** Skip one tactic *)
+    | Exit
+    | Help
+    | RunCnt of int
+    | RunBreakpoint of string
+    | Failed
+
+  (* XXX: Could we move this to the CString utility library? *)
+  let possibly_unquote s =
+    if String.length s >= 2 && s.[0] == '"' && s.[String.length s - 1] == '"' then
+      String.sub s 1 (String.length s - 2)
+    else
+      s
+
+  let parse_complex inst : (t, string) result =
+    if 'r' = String.get inst 0 then
+      let arg = String.(trim (sub inst 1 (length inst - 1))) in
+      if arg <> "" then
+        match int_of_string_opt arg with
+        | Some num ->
+          if num < 0 then
+            Error "number must be positive"
+          else
+            Ok (RunCnt num)
+        | None ->
+          Ok (RunBreakpoint (possibly_unquote arg))
+      else
+        Error ("invalid input: " ^ inst)
+    else
+      Error ("invalid input: " ^ inst)
+
+  (* XXX: Should be moved to the clients *)
+  let parse inst : (t, string) result =
+    match inst with
+    | ""  -> Ok Step
+    | "s" -> Ok Skip
+    | "x" -> Ok Exit
+    | "h"| "?" -> Ok Help
+    | _ -> parse_complex inst
+end
+
+module Answer = struct
+  type t =
+    | Prompt of Pp.t
+    | Goal of Pp.t
+    | Output of Pp.t
+end
+
+module Intf = struct
+
+  type t =
+    { read_cmd : unit -> Action.t
+    (** request a debugger command from the client *)
+    ; submit_answer : Answer.t -> unit
+    (** receive a debugger answer from Ltac *)
+    }
+
+  let ltac_debug_ref : t option ref = ref None
+  let set hooks = ltac_debug_ref := Some hooks
+  let get () = !ltac_debug_ref
+
+end

--- a/vernac/debugHook.mli
+++ b/vernac/debugHook.mli
@@ -1,0 +1,46 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *         Copyright INRIA, CNRS and contributors             *)
+(* <O___,, * (see version control and CREDITS file for authors & dates) *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+(** Ltac debugger interface; clients should register hooks to interact
+   with their provided interface. *)
+module Action : sig
+  type t =
+    | Step
+    (** Step one tactic *)
+    | Skip
+    (** Skip one tactic *)
+    | Exit
+    | Help
+    | RunCnt of int
+    | RunBreakpoint of string
+    | Failed
+
+  (* XXX: Should be moved to the clients *)
+  val parse : string -> (t, string) result
+end
+
+module Answer : sig
+  type t =
+    | Prompt of Pp.t
+    | Goal of Pp.t
+    | Output of Pp.t
+end
+
+module Intf : sig
+  type t =
+    { read_cmd : unit -> Action.t
+    (** request a debugger command from the client *)
+    ; submit_answer : Answer.t -> unit
+    (** receive a debugger answer from Ltac *)
+    }
+
+  val set : t -> unit
+  val get : unit -> t option
+end

--- a/vernac/topfmt.ml
+++ b/vernac/topfmt.ml
@@ -109,7 +109,7 @@ module Tag = struct
 
 end
 
-let msgnl_with ?pre_hdr fmt strm =
+let msgnl_with fmt strm =
   pp_with fmt (strm ++ fnl ());
   Format.pp_print_flush fmt ()
 
@@ -168,6 +168,7 @@ let default_tag_map () = let open Terminal in [
     "message.error"    , make ~bold:true ~fg_color:`WHITE ~bg_color:`RED ()
   ; "message.warning"  , make ~bold:true ~fg_color:`WHITE ~bg_color:`YELLOW ()
   ; "message.debug"    , make ~bold:true ~fg_color:`WHITE ~bg_color:`MAGENTA ()
+  ; "message.prompt"   , make ~fg_color:`GREEN ()
   (* Coming from the printer *)
   ; "constr.evar"      , make            ~fg_color:`LIGHT_BLUE ()
   ; "constr.keyword"   , make ~bold:true ()


### PR DESCRIPTION
~~This is a prototype for evaluation (first by @gares) of the XML protocol changes for supporting the debugger in Coq.  It works but there are still lots of GUI details to address.~~

**UI**: The Messages panel is used as a terminal, showing the debugger output and letting the user enter debugger commands at the bottom of the panel, like this:

![image](https://user-images.githubusercontent.com/1253341/105624201-ae151800-5dd4-11eb-9513-c66c4a93c1b8.png)


**Current implementation:** coqidetop is single threaded.  It has a message read-eval-print loop, used to accept the usual Coq tactics and commands.  In coqtop, the debugger has a separate read-eval-print loop that accepts a handful of debugger-specific commands.  You must exit the debugger to enter more Coq tactics and commands.  An unusual feature of the Coq debugger is that control of the debugger and execution are in the same thread--it is more common to have these be separate threads or processes.  That makes it very synchronous in behavior.

**Protocol Requirements:** A debugging protocol should support structured data.  For example, a request to fetch the call stack with filename and location data should be returned as structured data--such as in XML or JSON or whatever LSP/VsCoq uses.  We'll want to allow different GUIs to use different packaging, but each GUI should only have to use one packaging mechanism.  For CoqIDE we'll stick with XML.

**The approach taken in this PR is:**
- Create a single-message read-eval-print routine that is called by both the coqidetop loop and by the debugger when it needs a command.  Given the synchronous and modal (regular messages vs debug) nature of the communication, it's easy to ensure that the messages are read at the appropriate point in the code (top loop vs debugger).
- Modify some of the CoqIDE logic to permit sending and receiving debug requests while a proof-modifying operation in still in progress.  In effect, debug requests are nested inside of proof requests, e.g. this sequence of operations:
1. "Forward command" request -> server
2. Client <- debugger prompt
2. Debugger request -> server
3. Client <- debug reply and output (repeat 2-4 as many times as needed)
4. Client <- forward command reply
- Under the current protocol, coqidetop can send "feedback" (really just output) messages at any time.  We can use this without change for debugger output.
- Messages are sent through a single connection.  A second connection isn't needed to handle asynchrony.
- Multiple protocols for different GUIs can be supported by making the read-eval-print loop pluggable.

The protocol code is in the final commit.  Let me know your thoughts and questions.

cc: @gares