### PR TITLE
[coqargs] use the standard option injection system for -w

### DIFF
--- a/stm/stm.ml
+++ b/stm/stm.ml
@@ -2305,7 +2305,10 @@ end (* }}} *)
 
 (** STM initialization options: *)
 
-type option_command = OptionSet of string option | OptionUnset
+type option_command =
+  | OptionSet of string option
+  | OptionAppend of string
+  | OptionUnset
 
 type injection_command =
   | OptionInjection of (Goptions.option_name * option_command)
@@ -2404,7 +2407,8 @@ let new_doc { doc_type ; ml_load_path; vo_load_path; injections; stm_options } =
   let set_option = let open Goptions in function
       | opt, OptionUnset -> unset_option_value_gen ~locality:OptLocal opt
       | opt, OptionSet None -> set_bool_option_value_gen ~locality:OptLocal opt true
-      | opt, OptionSet (Some v) -> set_option_value ~locality:OptLocal (interp_set_option opt) opt v in
+      | opt, OptionSet (Some v) -> set_option_value ~locality:OptLocal (interp_set_option opt) opt v
+      | opt, OptionAppend v -> set_string_option_append_value_gen ~locality:OptLocal opt v in
 
   let handle_injection = function
     | RequireInjection r -> require_file r

--- a/stm/stm.mli
+++ b/stm/stm.mli
@@ -52,7 +52,10 @@ type stm_doc_type =
   | VioDoc      of string       (* file path *)
   | Interactive of interactive_top    (* module path *)
 
-type option_command = OptionSet of string option | OptionUnset
+type option_command =
+  | OptionSet of string option
+  | OptionAppend of string
+  | OptionUnset
 
 type injection_command =
   | OptionInjection of (Goptions.option_name * option_command)

--- a/toplevel/coqargs.ml
+++ b/toplevel/coqargs.ml
@@ -464,12 +464,8 @@ let parse_args ~help ~init arglist : t * string list =
 
     |"-w" | "-W" ->
       let w = next () in
-      if w = "none" then
-        (CWarnings.set_flags w; oval)
-      else
-        let w = CWarnings.get_flags () ^ "," ^ w in
-        CWarnings.set_flags (CWarnings.normalize_flags_string w);
-        oval
+      if w = "none" then add_set_option oval ["Warnings"] (Stm.OptionSet(Some w))
+      else add_set_option oval ["Warnings"] (Stm.OptionAppend w)
 
     |"-bytecode-compiler" ->
       { oval with config = { oval.config with enable_VM = get_bool opt (next ()) }}


### PR DESCRIPTION
Here the separate PR about the warning system, to allow for a cleaner review.

About the doc, @SkySkimmer I don't really think this is necessary.
The `current` keyword is used internally, since the current semantics is that `Set Warning...` "adds" to the current set of warnings.
If we decide to change that, or to provide another command which really sets all warnings, then `current` may become user visible (CC @Zimmi48) and require doc.