### PR TITLE
[vernac] Check that no proofs do remain open at section/module closing time

### DIFF
--- a/plugins/ltac/g_obligations.mlg
+++ b/plugins/ltac/g_obligations.mlg
@@ -151,13 +151,13 @@ VERNAC COMMAND EXTEND Show_Solver CLASSIFIED AS QUERY
 END
 
 VERNAC COMMAND EXTEND Show_Obligations CLASSIFIED AS QUERY STATE read_program
-| [ "Obligations" "of" ident(name) ] -> { show_obligations (Some name) }
-| [ "Obligations" ] -> { show_obligations None }
+| [ "Obligations" "of" ident(name) ] -> { fun ~stack:_ -> show_obligations (Some name) }
+| [ "Obligations" ] -> { fun ~stack:_ -> show_obligations None }
 END
 
 VERNAC COMMAND EXTEND Show_Preterm CLASSIFIED AS QUERY STATE read_program
-| [ "Preterm" "of" ident(name) ] -> { fun ~pm -> Feedback.msg_notice (show_term ~pm (Some name)) }
-| [ "Preterm" ] -> { fun ~pm -> Feedback.msg_notice (show_term ~pm None) }
+| [ "Preterm" "of" ident(name) ] -> { fun ~stack:_ ~pm -> Feedback.msg_notice (show_term ~pm (Some name)) }
+| [ "Preterm" ] -> { fun ~stack:_ ~pm -> Feedback.msg_notice (show_term ~pm None) }
 END
 
 {

--- a/test-suite/bugs/closed/bug_13755.v
+++ b/test-suite/bugs/closed/bug_13755.v
@@ -1,0 +1,5 @@
+Module M1.
+Lemma t1 : True.
+Fail End M1.
+Proof. exact I. Qed.
+End M1.

--- a/vernac/vernacextend.ml
+++ b/vernac/vernacextend.ml
@@ -59,7 +59,7 @@ type typed_vernac =
   | VtModifyProof of (pstate:Declare.Proof.t -> Declare.Proof.t)
   | VtReadProofOpt of (pstate:Declare.Proof.t option -> unit)
   | VtReadProof of (pstate:Declare.Proof.t -> unit)
-  | VtReadProgram of (pm:Declare.OblState.t -> unit)
+  | VtReadProgram of (stack:Vernacstate.LemmaStack.t option -> pm:Declare.OblState.t -> unit)
   | VtModifyProgram of (pm:Declare.OblState.t -> Declare.OblState.t)
   | VtDeclareProgram of (pm:Declare.OblState.t -> Declare.Proof.t)
   | VtOpenProofProgram of (pm:Declare.OblState.t -> Declare.OblState.t * Declare.Proof.t)

--- a/vernac/vernacextend.mli
+++ b/vernac/vernacextend.mli
@@ -77,7 +77,7 @@ type typed_vernac =
   | VtModifyProof of (pstate:Declare.Proof.t -> Declare.Proof.t)
   | VtReadProofOpt of (pstate:Declare.Proof.t option -> unit)
   | VtReadProof of (pstate:Declare.Proof.t -> unit)
-  | VtReadProgram of (pm:Declare.OblState.t -> unit)
+  | VtReadProgram of (stack:Vernacstate.LemmaStack.t option -> pm:Declare.OblState.t -> unit)
   | VtModifyProgram of (pm:Declare.OblState.t -> Declare.OblState.t)
   | VtDeclareProgram of (pm:Declare.OblState.t -> Declare.Proof.t)
   | VtOpenProofProgram of (pm:Declare.OblState.t -> Declare.OblState.t * Declare.Proof.t)

--- a/vernac/vernacinterp.ml
+++ b/vernac/vernacinterp.ml
@@ -48,7 +48,7 @@ let interp_typed_vernac c ~pm ~stack =
     vernac_require_open_lemma ~stack
       (Vernacstate.LemmaStack.with_top ~f:(fun pstate -> f ~pstate));
     stack, pm
-  | VtReadProgram f -> f ~pm; stack, pm
+  | VtReadProgram f -> f ~stack ~pm; stack, pm
   | VtModifyProgram f ->
     let pm = f ~pm in stack, pm
   | VtDeclareProgram f ->


### PR DESCRIPTION
Fixes #13755 .

I dunno if there is a better way to do this @SkySkimmer , `VtReadProgram` is actually seldom used, so we could even specialize these in 8.14 as to actually provide section/module structure [`VtOpenSection` etc...]