### PR TITLE
[micromega] Fixes #13794

### DIFF
--- a/plugins/micromega/polynomial.mli
+++ b/plugins/micromega/polynomial.mli
@@ -393,6 +393,10 @@ module WithProof : sig
 
   val subst : t list -> t list
 
+  (** [subst_constant b sys] performs the equivalent of the 'subst' tactic of Coq
+      only if there is an equation a.x = c for a,c a constant and a divides c if b= true*)
+  val subst_constant : bool -> t list -> t list
+
   (** [subst1 sys] performs a single substitution *)
   val subst1 : t list -> t list
 

--- a/test-suite/micromega/bug_13794.v
+++ b/test-suite/micromega/bug_13794.v
@@ -1,0 +1,39 @@
+From Coq Require Import Lia ZArith.ZArith NArith.NArith.
+Unset Nia Cache.
+
+Open Scope N_scope.
+
+
+Lemma over (n0 n1 n2 n3 n4 n5 n6 : N)
+  (e0 : 1 + 8 * n0 = n1 * n1 + n2)
+  (e1 : n1 - 1 = 2 * n3 + n4)
+  (e2 : n3 * (1 + n3) = 2 * n5)
+  (e3 : n2 + 2 * n4 * n1 - n4 = 8 * n6)
+  (o0 : n4 = 0 \/ n4 = 1) :
+  n6 = n0 - n5.
+Proof.
+  Time nia.
+Qed.
+
+Lemma over2 (n0 n1 n2 n3 n4 n5 n6 : N)
+  (e0 : 1 + 8 * n0 = n1 * n1 + n2)
+  (e1 : n1 + 1 = 2 * n3 + n4)
+  (e2 : n3 * (1 + n3) = 2 * n5)
+  (e3 : n2 + 2 * n4 * n1 + n4 = 8 * n6)
+  (o0 : n4 = 0) :
+  n6 = n0 + n5.
+Proof.
+  Fail nia.
+Abort.
+
+Open Scope Z_scope.
+
+Lemma over3 (n1 n2 n3 n4 n5 : Z)
+  (e : 0 <= n1 /\ 0 <= n2 /\ 0 <= n3 /\ 0 <= n4
+   /\ 0 <= n5)
+  (e1 : n1 + 1 = 20 * n3 + n4)
+  (e3 : n2 + 2 * n4 * n1 + n4 = 8 * n5) :
+  n5 = 0.
+Proof.
+Time Fail nia.
+Abort.


### PR DESCRIPTION
This PR solves a Stack Overflow in `nia` (see #13794).
* Proof sharing is factorised -- this avoids proofs of exponential size.
* It also improves pre-processing and substitute equations of the form c+a.x = 0 when c divides a
 
<!-- If this is a bug fix, make sure the bug was reported beforehand. -->
Fixes #13794 


<!-- If there is a user-visible change in coqc/coqtop/coqchk/coq_makefile behavior and testing is not prohibitively expensive: -->
<!-- (Otherwise, remove this line.) -->
- [x ] Added  test-suite
