### PR TITLE
[notation] option to fine tune printing of literals

### DIFF
--- a/doc/changelog/03-notations/13840-print-prim.rst
+++ b/doc/changelog/03-notations/13840-print-prim.rst
@@ -1,0 +1,11 @@
+- **Changed:**
+  Flag :flag:`Printing Notations` no longer controls
+  whether strings and numbers are printed raw
+  (`#13840 <https://github.com/coq/coq/pull/13840>`_,
+  by Enrico Tassi).
+
+- **Added:**
+  Flag :flag:`Printing Raw Literals` to control whether
+  strings and numbers are printed raw.
+  (`#13840 <https://github.com/coq/coq/pull/13840>`_,
+  by Enrico Tassi).

--- a/doc/sphinx/user-extensions/syntax-extensions.rst
+++ b/doc/sphinx/user-extensions/syntax-extensions.rst
@@ -442,6 +442,12 @@ Displaying information about notations
    Controls whether to use notations for printing terms wherever possible.
    Default is on.
 
+.. flag:: Printing Raw Literals
+
+   Controls whether to use string and number notations for printing terms
+   wherever possible (see :ref:`string-notations`).
+   Default is off.
+
 .. flag:: Printing Parentheses
 
    If on, parentheses are printed even if implied by associativity and precedence

--- a/interp/constrextern.mli
+++ b/interp/constrextern.mli
@@ -60,6 +60,7 @@ val print_parentheses : bool ref
 val print_universes : bool ref
 val print_no_symbol : bool ref
 val print_projections : bool ref
+val print_raw_literal : bool ref
 
 (** Customization of the global_reference printer *)
 val set_extern_reference :

--- a/test-suite/output/Notations3.out
+++ b/test-suite/output/Notations3.out
@@ -6,7 +6,7 @@
      : nat * nat * (nat * nat)
 (0, 2, (2, 2))
      : nat * nat * (nat * nat)
-pair (pair O (S (S O))) (pair (S (S O)) O)
+pair (pair 0 2) (pair 2 0)
      : prod (prod nat nat) (prod nat nat)
 << 0, 2, 4 >>
      : nat * nat * nat * (nat * (nat * nat))
@@ -16,8 +16,7 @@ pair (pair O (S (S O))) (pair (S (S O)) O)
      : nat * nat * nat * (nat * (nat * nat))
 (0, 2, 4, (0, (2, 4)))
      : nat * nat * nat * (nat * (nat * nat))
-pair (pair (pair O (S (S O))) (S (S (S (S O)))))
-  (pair (S (S (S (S O)))) (pair (S (S O)) O))
+pair (pair (pair 0 2) 4) (pair 4 (pair 2 0))
      : prod (prod (prod nat nat) nat) (prod nat (prod nat nat))
 ETA x y : nat, Nat.add
      : nat -> nat -> nat
@@ -174,9 +173,8 @@ forall_non_null x y z t : nat , x = y /\ z = t
      : nat * (nat * nat) * (nat * nat * nat) * (nat * (nat * nat)) *
        (nat * nat * nat)
 pair
-  (pair
-     (pair (pair (S (S O)) (pair (S O) O)) (pair (pair O (S (S O))) (S O)))
-     (pair (S O) (pair (S (S O)) O))) (pair (pair O (S O)) (S (S O)))
+  (pair (pair (pair 2 (pair 1 0)) (pair (pair 0 2) 1)) (pair 1 (pair 2 0)))
+  (pair (pair 0 1) 2)
      : prod
          (prod (prod (prod nat (prod nat nat)) (prod (prod nat nat) nat))
             (prod nat (prod nat nat))) (prod (prod nat nat) nat)

--- a/test-suite/output/primitive_tokens.out
+++ b/test-suite/output/primitive_tokens.out
@@ -1,0 +1,29 @@
+"foo"
+     : string
+1234
+     : nat
+String (Ascii.Ascii false true true false false true true false)
+  (String (Ascii.Ascii true true true true false true true false)
+     (String (Ascii.Ascii true true true true false true true false)
+        EmptyString))
+     : string
+S
+  (S
+     (S
+        (S
+           (S
+              (S
+                 (S
+                    (S
+                       (S
+                          (S
+                             (S
+                                (S
+                                   (S
+                                      (S
+                                         (S
+                                            (S
+                                               (S
+                                                 (S
+                                                 (S (S (S (S (S (S ...)))))))))))))))))))))))
+     : nat

--- a/test-suite/output/primitive_tokens.out
+++ b/test-suite/output/primitive_tokens.out
@@ -2,6 +2,20 @@
      : string
 1234
      : nat
+Nat.add 1 2
+     : nat
+match "a" with
+| "a" => true
+| _ => false
+end
+     : bool
+match 1 with
+| 1 => true
+| _ => false
+end
+     : bool
+{| field := 7 |}
+     : test
 String (Ascii.Ascii false true true false false true true false)
   (String (Ascii.Ascii true true true true false true true false)
      (String (Ascii.Ascii true true true true false true true false)
@@ -27,3 +41,21 @@ S
                                                  (S
                                                  (S (S (S (S (S (S ...)))))))))))))))))))))))
      : nat
+Nat.add (S O) (S (S O))
+     : nat
+match
+  String (Ascii.Ascii true false false false false true true false)
+    EmptyString
+with
+| String (Ascii.Ascii true false false false false true true false)
+  EmptyString => true
+| _ => false
+end
+     : bool
+match S O with
+| S O => true
+| _ => false
+end
+     : bool
+{| field := S (S (S (S (S (S (S O)))))) |}
+     : test

--- a/test-suite/output/primitive_tokens.v
+++ b/test-suite/output/primitive_tokens.v
@@ -1,5 +1,7 @@
 Require Import String.
 
+Record test := { field : nat }.
+
 Open Scope string_scope.
 
 Unset Printing Notations.
@@ -7,9 +9,15 @@ Unset Printing Notations.
 Check "foo".
 Check 1234.
 Check 1 + 2.
+Check match "a" with "a" => true | _ => false end.
+Check match 1 with 1 => true | _ => false end.
+Check {| field := 7 |}.
 
-Unset Printing Primitive Tokens.
+Set Printing Raw Literals.
 
 Check "foo".
 Check 1234.
 Check 1 + 2.
+Check match "a" with "a" => true | _ => false end.
+Check match 1 with 1 => true | _ => false end.
+Check {| field := 7 |}.

--- a/test-suite/output/primitive_tokens.v
+++ b/test-suite/output/primitive_tokens.v
@@ -1,0 +1,15 @@
+Require Import String.
+
+Open Scope string_scope.
+
+Unset Printing Notations.
+
+Check "foo".
+Check 1234.
+Check 1 + 2.
+
+Unset Printing Primitive Tokens.
+
+Check "foo".
+Check 1234.
+Check 1 + 2.

--- a/vernac/vernacentries.ml
+++ b/vernac/vernacentries.ml
@@ -1568,6 +1568,13 @@ let () =
 let () =
   declare_bool_option
     { optdepr  = false;
+      optkey   = ["Printing";"Raw";"Literals"];
+      optread  = (fun () -> !Constrextern.print_raw_literal);
+      optwrite = (fun b ->  Constrextern.print_raw_literal := b) }
+
+let () =
+  declare_bool_option
+    { optdepr  = false;
       optkey   = ["Printing";"All"];
       optread  = (fun () -> !Flags.raw_print);
       optwrite = (fun b -> Flags.raw_print := b) }


### PR DESCRIPTION
My objective is to make it possible to disable notations but still be able to read terms containing numbers and strings.
Before this PR `Set Printing Notations` governs both regular notations and "string notations". With this PR, we have two distinct options.

overlay PR: https://gitlab.mpi-sws.org/iris/iris/-/merge_requests/635 (already merged)